### PR TITLE
feat(ui): skills marketplace — 3-column card grid, categories, sort (reference-grade browse)

### DIFF
--- a/apps/desktop/src/main/__tests__/skills.test.ts
+++ b/apps/desktop/src/main/__tests__/skills.test.ts
@@ -1209,9 +1209,18 @@ name: Writer
     assert.doesNotMatch(skillEntryContract, /sourceName|sourceVersion|contentSha256|installedAt|validationCodes|validationMessages|write_failed/, 'renderer SkillEntry must not expose lock internals');
     assert.match(workspaceResourcesIpc, /toSkillEntry/, 'Skills IPC must scrub main-internal lock fields before crossing to renderer');
     assert.doesNotMatch(workspaceResourcesIpc, /ipcMain\.handle\('skills:list'[\s\S]*listInstalledSkills\(deps\.workspaceRoot\)/, 'Skills list IPC must not return InstalledSkill objects directly');
-    assert.match(skillPanel, /const managedSources = \(/, 'Phase 2 must surface the managed source cache without making it runtime');
-    assert.match(skillPanel, /<section className="maka-skill-installed" aria-label="来源库">/);
+    // Marketplace redesign: managed sources ARE the 市场 tab now — the
+    // separate 来源库 list under 已安装 was folded into a card grid. The
+    // source cache is still surfaced (never runtime), just as a browse
+    // grid keyed off props.managedSkillSources.
+    assert.match(skillPanel, /const market = \(/, 'Phase 2 must surface the managed source cache without making it runtime');
+    assert.match(skillPanel, /<section className="maka-skill-market" aria-label="技能市场">/);
+    assert.match(skillPanel, /<div className="maka-skill-market-grid">/, '市场 tab renders managed sources as a card grid');
+    assert.match(skillPanel, /const marketSources = useMemo\(/, '市场 grid is a pure client-side filter/sort over managedSkillSources');
+    assert.match(skillPanel, /官方精选/, '市场 grid carries the 官方精选 section label');
+    assert.match(skillPanel, /className="maka-skill-market-install-button"[\s\S]*aria-label=\{`安装 \$\{source\.name\}`\}/, 'only the + install icon-button acts; the market card body stays inert');
     assert.match(skillPanel, /导入本地 Skill/);
+    assert.doesNotMatch(skillPanel, /const managedSources = \(/, '来源库 list was replaced by the 市场 card grid');
     assert.match(skillPanel, /onInstallManagedSkill\?\(sourceId: string\): void \| Promise<void>/);
     assert.match(skillPanel, /onPreviewManagedSkillUpdate\?\(skillId: string\): Promise<ManagedSkillUpdatePreview \| null>/);
     assert.match(skillPanel, /onUpdateManagedSkill\?\(skillId: string, options\?: \{ force\?: boolean; expectedCurrentSha256\?: string; expectedSourceSha256\?: string \}\): boolean \| Promise<boolean>/);

--- a/apps/desktop/src/main/__tests__/visual-smoke-fixture.test.ts
+++ b/apps/desktop/src/main/__tests__/visual-smoke-fixture.test.ts
@@ -575,6 +575,51 @@ describe('visual smoke fixture mode', () => {
     assert.equal(getVisualSmokeState(dailyReview)?.activeSessionId, 'visual-smoke-turn');
   });
 
+  it('module-skills seeds a managed-source market catalog (>=6 entries with categories) plus workspace skills', async () => {
+    const workspaceRoot = await mkdtemp(join(tmpdir(), 'maka-visual-smoke-skills-'));
+    const previousSourcesRoot = process.env.MAKA_SKILL_SOURCES_ROOT;
+    try {
+      const fixture = resolveVisualSmokeFixture('module-skills', false);
+      assert.ok(fixture);
+      await seedVisualSmokeFixture({
+        workspaceRoot,
+        fixture,
+        credentialStore: fakeCredentialStore(),
+        now: 1_700_000_000_000,
+      });
+
+      const sourcesRoot = join(workspaceRoot, '.maka', 'skill-sources');
+      assert.equal(process.env.MAKA_SKILL_SOURCES_ROOT, sourcesRoot, 'seeder points the sources-root override at the fixture workspace');
+
+      const expectedSources: ReadonlyArray<{ id: string; category: string }> = [
+        { id: 'research-brief', category: '研究与分析' },
+        { id: 'doc-review', category: '文档与写作' },
+        { id: 'meeting-followup', category: '效率工具' },
+        { id: 'release-checklist', category: 'DevOps与部署' },
+        { id: 'data-analyst', category: '数据与AI' },
+        { id: 'ui-audit', category: '设计与UI' },
+        { id: 'blog-outline', category: '内容创作' },
+      ];
+      assert.ok(expectedSources.length >= 6, 'market grid needs >=6 entries to render meaningfully');
+      const categories = new Set<string>();
+      for (const source of expectedSources) {
+        const content = await readFile(join(sourcesRoot, source.id, 'SKILL.md'), 'utf8');
+        assert.match(content, new RegExp(`category: ${source.category}`), `${source.id} carries its category front-matter`);
+        categories.add(source.category);
+      }
+      assert.ok(categories.size >= 5, 'sources span several taxonomy buckets so the filter is exercised');
+
+      // meeting-followup is also a workspace skill so the grid shows an
+      // installed state; daily-standup fills 已安装 with a second row.
+      await readFile(join(workspaceRoot, 'skills', 'meeting-followup', 'SKILL.md'), 'utf8');
+      await readFile(join(workspaceRoot, 'skills', 'daily-standup', 'SKILL.md'), 'utf8');
+    } finally {
+      if (previousSourcesRoot === undefined) delete process.env.MAKA_SKILL_SOURCES_ROOT;
+      else process.env.MAKA_SKILL_SOURCES_ROOT = previousSourcesRoot;
+      await rm(workspaceRoot, { recursive: true, force: true });
+    }
+  });
+
   it('sidebar-row-actions-visible shares the 60-session seed and sets focusActiveRow so the action overlay shows (PR-SIDEBAR-IA-0 Phase 3 P0 fixup v4)', async () => {
     // PR-SIDEBAR-IA-0 Phase 3 P0 fixup v4 (WAWQAQ msg `5dd1c348`,
     // kenji `b3d156e9`): the sidebar-row-actions-visible scenario

--- a/apps/desktop/src/main/managed-skill-sources.ts
+++ b/apps/desktop/src/main/managed-skill-sources.ts
@@ -3,10 +3,40 @@ import { homedir } from 'node:os';
 import { basename, dirname, extname, isAbsolute, join, relative } from 'node:path';
 import { lstat, mkdir, readdir, readFile, realpath, rename, unlink, writeFile } from 'node:fs/promises';
 
+/**
+ * Fixed marketplace taxonomy. A source's `category:` front-matter is
+ * accepted only when it exactly matches one of these buckets; anything
+ * else (including a missing field) resolves to the neutral 效率工具
+ * default so the market filter never surfaces an unbounded, user-typed
+ * label set. Kept in one place so the renderer filter and the seeder
+ * agree on the same list.
+ */
+export const MANAGED_SKILL_CATEGORIES = [
+  '内容创作',
+  '数据与AI',
+  '设计与UI',
+  'DevOps与部署',
+  '文档与写作',
+  '效率工具',
+  '研究与分析',
+] as const;
+
+export type ManagedSkillCategory = (typeof MANAGED_SKILL_CATEGORIES)[number];
+
+const MANAGED_SKILL_CATEGORY_DEFAULT: ManagedSkillCategory = '效率工具';
+
+function normalizeManagedSkillCategory(raw: string | undefined): ManagedSkillCategory {
+  if (raw && (MANAGED_SKILL_CATEGORIES as readonly string[]).includes(raw)) {
+    return raw as ManagedSkillCategory;
+  }
+  return MANAGED_SKILL_CATEGORY_DEFAULT;
+}
+
 export interface ManagedSkillSourceRecord {
   id: string;
   name: string;
   description: string;
+  category: ManagedSkillCategory;
   sourceType: 'local';
   sourcePath: string;
   contentSha256: string;
@@ -18,6 +48,12 @@ export interface ManagedSkillSourceEntry {
   id: string;
   name: string;
   description: string;
+  /**
+   * Marketplace taxonomy bucket. Always one of MANAGED_SKILL_CATEGORIES —
+   * unknown / missing front-matter resolves to 效率工具 at read time, so
+   * the renderer can treat this as a required field.
+   */
+  category: ManagedSkillCategory;
   sourceType: 'local';
 }
 
@@ -30,6 +66,15 @@ export type ReadManagedSkillSourceResult =
   | { ok: false; reason: 'not_found' | 'blocked_path' | 'read_failed' };
 
 export function resolveManagedSkillSourcesRoot(homeDir = homedir()): string {
+  // Dev/test-only override so the visual-smoke fixture can seed a
+  // deterministic managed-source catalog without touching the real
+  // ~/.maka/skill-sources. Packaged builds ignore this (app.isPackaged
+  // gate lives in main.ts, same as the fixture env vars); here we only
+  // honor an absolute path so a relative value can never escape.
+  const override = process.env.MAKA_SKILL_SOURCES_ROOT;
+  if (override && isAbsolute(override) && process.env.MAKA_VISUAL_SMOKE_FIXTURE) {
+    return override;
+  }
   return join(homeDir, '.maka', 'skill-sources');
 }
 
@@ -95,6 +140,7 @@ export async function importManagedSkillSource(input: {
       id,
       name: parsed.name,
       description: parsed.description ?? '',
+      category: normalizeManagedSkillCategory(parsed.category),
       sourceType: 'local',
       sourcePath: managedSkillPath,
       contentSha256,
@@ -135,6 +181,7 @@ export async function readManagedSkillSource(
       id: sourceId,
       name: parsed.name ?? sourceId,
       description: parsed.description ?? '',
+      category: normalizeManagedSkillCategory(parsed.category),
       sourceType: 'local',
       sourcePath,
       contentSha256,
@@ -152,6 +199,7 @@ export function toManagedSkillSourceEntry(source: ManagedSkillSourceRecord): Man
     id: source.id,
     name: source.name,
     description: source.description,
+    category: source.category,
     sourceType: source.sourceType,
   };
 }
@@ -235,17 +283,17 @@ function sourceIdFromPath(filePath: string): string | undefined {
   return isSafeSkillId(normalized) ? normalized : undefined;
 }
 
-function parseSkillFrontMatterForSource(text: string): { name?: string; description?: string } {
+function parseSkillFrontMatterForSource(text: string): { name?: string; description?: string; category?: string } {
   if (!text.startsWith('---')) return {};
   const close = text.indexOf('\n---', 3);
   if (close < 0) return {};
   const block = text.slice(3, close);
-  const result: { name?: string; description?: string } = {};
+  const result: { name?: string; description?: string; category?: string } = {};
   for (const raw of block.split(/\r?\n/)) {
-    const match = raw.match(/^(name|description):\s*(.*)$/);
+    const match = raw.match(/^(name|description|category):\s*(.*)$/);
     if (!match) continue;
     const value = match[2].trim().replace(/^['"]|['"]$/g, '');
-    if (value) result[match[1] as 'name' | 'description'] = value;
+    if (value) result[match[1] as 'name' | 'description' | 'category'] = value;
   }
   return result;
 }

--- a/apps/desktop/src/main/visual-smoke-fixture.ts
+++ b/apps/desktop/src/main/visual-smoke-fixture.ts
@@ -537,6 +537,78 @@ export async function seedVisualSmokeFixture(input: {
   if (input.fixture.scenario === 'module-daily-review' || input.fixture.scenario === 'settings-daily-review') {
     await writeDailyReviewArchives(input.workspaceRoot, now);
   }
+  if (input.fixture.scenario === 'module-skills') {
+    await seedSkillsMarketFixture(input.workspaceRoot);
+  }
+}
+
+/**
+ * Marketplace fixture: seeds a managed-source catalog (≥6 entries across
+ * categories with varied recency) plus a couple of workspace skills so the
+ * 市场 grid, category filter, sort, and the 内置/已安装 rows all render
+ * meaningfully in the CDP capture. Managed sources normally live in
+ * ~/.maka/skill-sources; the dev-gated MAKA_SKILL_SOURCES_ROOT override
+ * (resolveManagedSkillSourcesRoot) points both the seeder and the runtime
+ * IPC at a fixture-local dir so nothing touches the real home catalog.
+ */
+async function seedSkillsMarketFixture(workspaceRoot: string): Promise<void> {
+  const sourcesRoot = join(workspaceRoot, '.maka', 'skill-sources');
+  process.env.MAKA_SKILL_SOURCES_ROOT = sourcesRoot;
+  await mkdir(sourcesRoot, { recursive: true });
+
+  const sources: ReadonlyArray<{ id: string; name: string; description: string; category: string }> = [
+    { id: 'research-brief', name: '研究简报', category: '研究与分析', description: '把网页资料、引用和结论整理成结构化 brief，适合快速进入陌生领域。' },
+    { id: 'doc-review', name: '文档审阅', category: '文档与写作', description: '检查 DOCX / Markdown 的结构、语气和遗漏项，并输出可执行修改建议。' },
+    { id: 'meeting-followup', name: '会议跟进', category: '效率工具', description: '从会议记录里抽取决定、风险和 owner，生成下一步任务清单。' },
+    { id: 'release-checklist', name: '发布检查', category: 'DevOps与部署', description: '按发布前 checklist 扫描 diff、测试和文档，减少临门一脚的遗漏。' },
+    { id: 'data-analyst', name: '数据分析助手', category: '数据与AI', description: '读取 CSV / 表格，做透视、异常检测和趋势总结，产出可复述的结论。' },
+    { id: 'ui-audit', name: 'UI 走查', category: '设计与UI', description: '对照设计规范逐项走查间距、层级和状态色，列出需要修的细节。' },
+    { id: 'blog-outline', name: '博客提纲', category: '内容创作', description: '把零散想法整理成有节奏的文章提纲，附上每段的论据方向。' },
+  ];
+
+  // Stagger mtimes so 排序：最近 has a meaningful order (the last-written
+  // source is the most recent). Written newest-last on purpose.
+  for (const source of sources) {
+    const dir = join(sourcesRoot, source.id);
+    await mkdir(dir, { recursive: true });
+    const content = [
+      '---',
+      `name: ${source.name}`,
+      `description: ${source.description}`,
+      `category: ${source.category}`,
+      '---',
+      '',
+      `# ${source.name}`,
+      '',
+      source.description,
+      '',
+    ].join('\n');
+    await writeFile(join(dir, 'SKILL.md'), content, { encoding: 'utf8', mode: 0o600 });
+  }
+
+  // A couple of workspace skills so 已安装 is not empty and one managed
+  // source shows as installed in the grid. The bundled OfficeCLI skills
+  // (seeded separately after the fixture) populate the 内置 tab.
+  const workspaceSkills: ReadonlyArray<{ id: string; name: string; description: string }> = [
+    { id: 'meeting-followup', name: '会议跟进', description: '从会议记录里抽取决定、风险和 owner，生成下一步任务清单。' },
+    { id: 'daily-standup', name: '每日站会', description: '汇总昨日进展、今日计划和阻塞，生成简短的站会同步。' },
+  ];
+  for (const skill of workspaceSkills) {
+    const dir = join(workspaceRoot, 'skills', skill.id);
+    await mkdir(dir, { recursive: true });
+    const content = [
+      '---',
+      `name: ${skill.name}`,
+      `description: ${skill.description}`,
+      '---',
+      '',
+      `# ${skill.name}`,
+      '',
+      skill.description,
+      '',
+    ].join('\n');
+    await writeFile(join(dir, 'SKILL.md'), content, { encoding: 'utf8', mode: 0o600 });
+  }
 }
 
 /**

--- a/apps/desktop/src/renderer/styles/module-pages/skills.css
+++ b/apps/desktop/src/renderer/styles/module-pages/skills.css
@@ -193,6 +193,24 @@ color: oklch(from var(--brand-deep) 0.55 min(c, 0.015) h);
   border-bottom: var(--border-width-hairline) solid var(--border);
 }
 
+/* Marketplace launch: category + sort dropdowns ride the tab row's right
+   edge (market tab only). Two quiet SettingsSelect triggers sized down to
+   the tab-row rhythm; the SettingsSelect trigger chrome itself is owned by
+   its own stylesheet — here we only constrain width + height. */
+.maka-skill-market-controls {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  flex: 0 0 auto;
+}
+
+.maka-skill-market-select {
+  min-width: 0;
+  width: auto;
+  height: var(--h-control-sm);
+  min-height: var(--h-control-sm);
+}
+
 .maka-skill-tabs {
   display: flex;
   gap: var(--space-4);
@@ -266,7 +284,9 @@ color: oklch(from var(--brand-deep) 0.55 min(c, 0.015) h);
 
 .maka-skill-market-grid {
   display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
+  /* Marketplace grid: 3 columns on wide, collapsing to 2/1 via auto-fit as
+     the panel narrows (panel max-width 900px → ~2 cols; narrow → 1). */
+  grid-template-columns: repeat(auto-fill, minmax(min(100%, 260px), 1fr));
   gap: var(--space-3);
 }
 
@@ -296,15 +316,36 @@ color: oklch(from var(--brand-deep) 0.55 min(c, 0.015) h);
   min-width: 0;
   display: flex;
   align-items: flex-start;
-  gap: var(--space-3);
+  gap: var(--space-2-5);
+}
+
+.maka-skill-market-card-title {
+  min-width: 0;
+  flex: 1 1 auto;
+  display: grid;
+  gap: var(--space-0-5);
 }
 
 .maka-skill-market-card h3 {
+  min-width: 0;
   margin: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
   color: var(--foreground);
   font-size: var(--font-size-heading);
   font-weight: var(--font-weight-semibold);
   line-height: var(--leading-tight);
+}
+
+/* Slug caption: soft monospace, matching the library row's id treatment. */
+.maka-skill-market-card-title small {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: var(--font-mono);
+  letter-spacing: var(--tracking-normal);
 }
 
 .maka-skill-market-card small,
@@ -312,6 +353,31 @@ color: oklch(from var(--brand-deep) 0.55 min(c, 0.015) h);
   color: var(--muted-foreground);
   font-size: var(--font-size-caption);
   font-weight: var(--font-weight-semibold);
+}
+
+/* + install: quiet icon button anchored top-right of the card head; only
+   this element acts, keeping the card body an honest inert surface. */
+.maka-skill-market-install-button {
+  flex: 0 0 auto;
+  width: var(--h-control-sm);
+  min-width: var(--h-control-sm);
+  height: var(--h-control-sm);
+  padding: 0;
+  border: var(--border-width-hairline) solid var(--border);
+  border-radius: var(--radius-control);
+  background: var(--background);
+  color: var(--muted-foreground);
+  transition: background-color var(--duration-base) var(--ease-out-strong), color var(--duration-base) var(--ease-out-strong);
+}
+
+.maka-skill-market-card:hover .maka-skill-market-install-button:not(:disabled),
+.maka-skill-market-install-button:not(:disabled):hover {
+  background: var(--state-hover-bg);
+  color: var(--foreground);
+}
+
+.maka-skill-market-category {
+  justify-self: start;
 }
 
 .maka-skill-market-card p {

--- a/packages/ui/src/module-panel-types.ts
+++ b/packages/ui/src/module-panel-types.ts
@@ -75,10 +75,26 @@ export interface ManagedSkillUpdatePreview {
   };
 }
 
+/**
+ * Marketplace taxonomy buckets surfaced by the 市场 tab category filter.
+ * Mirrors MANAGED_SKILL_CATEGORIES in apps/desktop's managed-skill-sources;
+ * the main-process reader always resolves an entry to one of these, so the
+ * renderer can treat `category` as required (unknown → 效率工具 upstream).
+ */
+export type ManagedSkillCategory =
+  | '内容创作'
+  | '数据与AI'
+  | '设计与UI'
+  | 'DevOps与部署'
+  | '文档与写作'
+  | '效率工具'
+  | '研究与分析';
+
 export interface ManagedSkillSourceEntry {
   id: string;
   name: string;
   description: string;
+  category: ManagedSkillCategory;
   sourceType: 'local';
 }
 

--- a/packages/ui/src/skills-panel.tsx
+++ b/packages/ui/src/skills-panel.tsx
@@ -1,13 +1,12 @@
-import { useEffect, useRef, useState, type ReactNode } from 'react';
+import { useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
 import {
   Blocks,
   BookOpen,
-  CalendarDays,
+  Download,
   FileEdit,
   Loader2,
   Plus,
   Search,
-  ShieldAlert,
 } from './icons.js';
 import type { CapabilityAuditReport } from '@maka/core';
 import { deriveCapabilityAuditReport } from '@maka/core';
@@ -15,9 +14,24 @@ import { Button as UiButton, Switch, TabsRoot, TabsList, TabsTrigger, TabsPanel 
 import { Chip, type ChipProps } from './primitives/chip.js';
 import { PageHeader } from './primitives/page-header.js';
 import { Input } from './primitives/input.js';
+import { SettingsSelect, type SettingsSelectOption } from './primitives/settings-select.js';
 import { EmptyState } from './empty-state.js';
 import { CapabilityAuditStrip } from './capability-audit-strip.js';
-import type { ManagedSkillSourceEntry, ManagedSkillUpdatePreview, SkillEntry } from './module-panel-types.js';
+import type { ManagedSkillCategory, ManagedSkillSourceEntry, ManagedSkillUpdatePreview, SkillEntry } from './module-panel-types.js';
+
+// 市场 tab client-side filter/sort controls. Both are pure renderer
+// state — the managed-source list itself is fetched once over IPC.
+const MARKET_CATEGORY_ALL = '__all__';
+const MARKET_CATEGORIES: ReadonlyArray<ManagedSkillCategory> = [
+  '内容创作',
+  '数据与AI',
+  '设计与UI',
+  'DevOps与部署',
+  '文档与写作',
+  '效率工具',
+  '研究与分析',
+];
+type MarketSort = 'name' | 'recent';
 
 const SKILL_UPDATE_PREVIEW_MAX_LINES = 80;
 
@@ -53,6 +67,8 @@ function SkillLibraryPanel(props: {
   });
   const [updatePreview, setUpdatePreview] = useState<ManagedSkillUpdatePreview | null>(null);
   const [reviewingSkillId, setReviewingSkillId] = useState<string | null>(null);
+  const [marketCategory, setMarketCategory] = useState<ManagedSkillCategory | typeof MARKET_CATEGORY_ALL>(MARKET_CATEGORY_ALL);
+  const [marketSort, setMarketSort] = useState<MarketSort>('name');
   const normalizedSkillQuery = props.searchQuery?.trim().toLowerCase() ?? '';
   const filteredSkills = (props.skills ?? []).filter((skill) => {
     if (!normalizedSkillQuery) return true;
@@ -63,10 +79,22 @@ function SkillLibraryPanel(props: {
   // render the SAME list, which made them meaningless.
   const bundledSkills = filteredSkills.filter((skill) => skill.sourceType === 'bundled');
   const installedSkills = filteredSkills.filter((skill) => skill.sourceType !== 'bundled');
-  const filteredMarketCards = SKILL_MARKETPLACE_CARDS.filter((card) => {
-    if (!normalizedSkillQuery) return true;
-    return `${card.title} ${card.body} ${card.meta}`.toLowerCase().includes(normalizedSkillQuery);
-  });
+  const allManagedSources = props.managedSkillSources ?? [];
+  // 市场 tab: managed sources are the marketplace catalog. Search (shared
+  // header field), category dropdown, and sort are all pure client-side —
+  // the list is fetched once over IPC. Sort 最近 (order preserved from the
+  // IPC list, which main already sorts by name) vs 名称 (explicit A→Z).
+  const marketSources = useMemo(() => {
+    const filtered = allManagedSources.filter((source) => {
+      if (marketCategory !== MARKET_CATEGORY_ALL && source.category !== marketCategory) return false;
+      if (!normalizedSkillQuery) return true;
+      return `${source.id} ${source.name} ${source.description} ${source.category}`.toLowerCase().includes(normalizedSkillQuery);
+    });
+    if (marketSort === 'name') {
+      return [...filtered].sort((a, b) => a.name.localeCompare(b.name));
+    }
+    return filtered;
+  }, [allManagedSources, marketCategory, marketSort, normalizedSkillQuery]);
   const skillListEmptyTitle = normalizedSkillQuery ? '没有匹配的 Skill' : '等待添加 Skill';
   const skillListEmptyBody: ReactNode = normalizedSkillQuery ? '换一个关键词，或清空搜索查看全部本地技能。' : (
     <>
@@ -74,10 +102,6 @@ function SkillLibraryPanel(props: {
       {' '}<code className="maka-empty-state-code">skills/</code> 目录下，刷新后会出现在这里。
     </>
   );
-  const filteredManagedSources = (props.managedSkillSources ?? []).filter((source) => {
-    if (!normalizedSkillQuery) return true;
-    return `${source.id} ${source.name} ${source.description}`.toLowerCase().includes(normalizedSkillQuery);
-  });
   async function reviewManagedSkillUpdate(skill: SkillEntry) {
     if (!props.onPreviewManagedSkillUpdate || reviewingSkillId !== null) return;
     setReviewingSkillId(skill.id);
@@ -119,11 +143,40 @@ function SkillLibraryPanel(props: {
     </section>
   );
 
+  const categoryOptions: ReadonlyArray<SettingsSelectOption<ManagedSkillCategory | typeof MARKET_CATEGORY_ALL>> = [
+    [MARKET_CATEGORY_ALL, '全部分类'],
+    ...MARKET_CATEGORIES.map((category) => [category, category] as const),
+  ];
+  const sortOptions: ReadonlyArray<SettingsSelectOption<MarketSort>> = [
+    ['name', '排序：名称'],
+    ['recent', '排序：最近'],
+  ];
+  const marketControls = activeSkillTab === 'market' && allManagedSources.length > 0 ? (
+    <div className="maka-skill-market-controls" role="group" aria-label="市场筛选与排序">
+      <SettingsSelect<ManagedSkillCategory | typeof MARKET_CATEGORY_ALL>
+        value={marketCategory}
+        options={categoryOptions}
+        onChange={(value) => setMarketCategory(value)}
+        ariaLabel="按分类筛选市场技能"
+        width="full"
+        className="maka-skill-market-select"
+      />
+      <SettingsSelect<MarketSort>
+        value={marketSort}
+        options={sortOptions}
+        onChange={(value) => setMarketSort(value)}
+        ariaLabel="市场技能排序方式"
+        width="full"
+        className="maka-skill-market-select"
+      />
+    </div>
+  ) : null;
+
   const tabs = (
     <div className="maka-skill-tabs-bar">
       <TabsList variant="underline" className="maka-skill-tabs" aria-label="技能视图">
         {([
-          ['market', '市场', filteredMarketCards.length],
+          ['market', '市场', allManagedSources.length],
           ['builtin', '内置', bundledSkills.length],
           ['installed', '已安装', installedSkills.length],
         ] as const).map(([tab, label, count]) => (
@@ -137,10 +190,10 @@ function SkillLibraryPanel(props: {
           </TabsTrigger>
         ))}
       </TabsList>
-      {/* Designer audit P1-9: the static 全部 / 排序：热门 pills were removed
-          entirely — they were styled like buttons but dead, which reads as a
-          broken control. Bring back real filter/sort controls with the
-          marketplace launch. */}
+      {/* Marketplace launch: real client-side category + sort controls on
+          the tab row's right side (market tab only). The old static 全部 /
+          排序：热门 pills were dead chrome; these drive marketSources. */}
+      {marketControls}
     </div>
   );
 
@@ -173,40 +226,74 @@ function SkillLibraryPanel(props: {
   const market = (
     <section className="maka-skill-market" aria-label="技能市场">
       <div className="maka-skill-section-row">
-        <span className="maka-skill-section-label">市场技能</span>
-        <small>精选模板</small>
+        <span className="maka-skill-section-label">官方精选</span>
+        <div className="maka-skill-filter-actions" aria-label="来源库操作">
+          <UiButton
+            type="button"
+            variant="secondary"
+            className="maka-skill-filter-pill"
+            onClick={props.onImportManagedSkillSource}
+            disabled={!props.onImportManagedSkillSource || props.actionBusy}
+          >
+            导入本地 Skill
+          </UiButton>
+        </div>
       </div>
-      {filteredMarketCards.length === 0 ? (
+      {allManagedSources.length === 0 ? (
+        <EmptyState
+          Icon={BookOpen}
+          title={normalizedSkillQuery ? '没有匹配的市场技能' : '来源库还是空的'}
+          body={normalizedSkillQuery
+            ? '换一个关键词，或清空搜索查看全部来源。'
+            : '导入一个含 SKILL.md 的本地文件，它会作为可安装的来源出现在这里。'}
+          extraClassName="maka-skill-installed-empty"
+        />
+      ) : marketSources.length === 0 ? (
         <EmptyState
           Icon={Search}
           title="没有匹配的市场技能"
-          body="换一个关键词，或清空搜索查看全部精选技能。"
+          body="换一个分类或关键词，或清空筛选查看全部来源。"
           extraClassName="maka-skill-installed-empty"
         />
       ) : (
         <div className="maka-skill-market-grid">
-          {filteredMarketCards.map((card) => (
-            <article key={card.title} className="maka-skill-market-card">
-              <div className="maka-skill-market-card-head">
-                <span className="maka-skill-market-icon" aria-hidden="true">
-                  <card.Icon size={18} />
-                </span>
-                <div>
-                  <h3>{card.title}</h3>
-                  <small>{card.meta}</small>
+          {marketSources.map((source) => {
+            const installed = (props.skills ?? []).some((skill) => skill.id === source.id);
+            const installing = props.installingSourceId === source.id;
+            const description = source.description || '本地来源库 Skill。';
+            return (
+              <article key={source.id} className="maka-skill-market-card">
+                <div className="maka-skill-market-card-head">
+                  <span className="maka-skill-market-icon" aria-hidden="true">
+                    <Blocks size={18} />
+                  </span>
+                  <div className="maka-skill-market-card-title">
+                    <h3>{source.name}</h3>
+                    <small>{source.id}</small>
+                  </div>
+                  {/* + install acts; the card itself is inert (honest
+                      affordance). Disabled once the source is in the
+                      workspace, so it reads as a real state, not a toggle. */}
+                  <UiButton
+                    type="button"
+                    variant="ghost"
+                    className="maka-skill-market-install-button"
+                    onClick={() => props.onInstallManagedSkill?.(source.id)}
+                    disabled={installed || props.actionBusy || !props.onInstallManagedSkill}
+                    aria-label={`安装 ${source.name}`}
+                    title={installed ? '已安装到当前工作区' : `安装 ${source.name}`}
+                  >
+                    {installing ? <Loader2 size={16} aria-hidden="true" /> : <Download size={16} aria-hidden="true" />}
+                  </UiButton>
                 </div>
-              </div>
-              <p>{card.body}</p>
-              <div className="maka-skill-market-card-foot">
-                <span>{card.source}</span>
-                {/* Static label, not a disabled button — same rationale as
-                    the filter pills above: marketplace install isn't wired
-                    yet, and a dead 安装 button promises interactivity it
-                    can't deliver. */}
-                <span className="maka-skill-market-install" data-static="true">即将上线</span>
-              </div>
-            </article>
-          ))}
+                <p>{description}</p>
+                <div className="maka-skill-market-card-foot">
+                  <Chip size="sm" variant="neutral" className="maka-skill-market-category">{source.category}</Chip>
+                  <span>{installed ? '已安装' : '未安装'}</span>
+                </div>
+              </article>
+            );
+          })}
         </div>
       )}
     </section>
@@ -269,7 +356,10 @@ function SkillLibraryPanel(props: {
                       )}
                     </span>
                     <span className="maka-skill-library-meta">
-                      <span>{skill.id}</span>
+                      {/* Marketplace redesign: the slug moved into the row's
+                          title tooltip (技能：${skill.id}) — the reference row
+                          shows only name + description. The status chips below
+                          stay (exception-only tone). */}
                       {/* Detail round 6, exception-only: the adjacent Switch
                           already says enabled/disabled — the visible chip only
                           appears for states the switch can't express
@@ -319,69 +409,6 @@ function SkillLibraryPanel(props: {
             })}
           </ul>
         </>
-      )}
-    </section>
-  );
-
-  const managedSources = (
-    <section className="maka-skill-installed" aria-label="来源库">
-      <div className="maka-skill-section-row">
-        <span className="maka-skill-section-label">来源库</span>
-        <small>{filteredManagedSources.length} 个</small>
-      </div>
-      <div className="maka-skill-filter-actions" aria-label="来源库操作">
-        <UiButton
-          type="button"
-          variant="secondary"
-          className="maka-skill-filter-pill"
-          onClick={props.onImportManagedSkillSource}
-          disabled={!props.onImportManagedSkillSource || props.actionBusy}
-        >
-          导入本地 Skill
-        </UiButton>
-      </div>
-      {filteredManagedSources.length === 0 ? (
-        normalizedSkillQuery ? (
-          <EmptyState
-            Icon={BookOpen}
-            title="没有匹配的来源"
-            body="换一个关键词，或清空搜索查看全部来源。"
-            extraClassName="maka-skill-installed-empty"
-          />
-        ) : null
-      ) : (
-        <ul className="maka-skill-library-list" aria-label="来源列表">
-          {filteredManagedSources.map((source) => {
-            const installed = (props.skills ?? []).some((skill) => skill.id === source.id);
-            const installing = props.installingSourceId === source.id;
-            return (
-              <li key={source.id} className="maka-skill-library-item">
-                <div className="maka-skill-library-row" title={`来源：${source.id}`}>
-                  <span className="maka-skill-library-status" aria-hidden="true">
-                    <BookOpen size={16} />
-                  </span>
-                  <span className="maka-skill-library-copy">
-                    <span className="maka-skill-library-name">{source.name}</span>
-                    <span className="maka-skill-library-description">{source.description || '本地来源库 Skill。'}</span>
-                  </span>
-                  <span className="maka-skill-library-meta">
-                    <span>{source.id}</span>
-                    <span>{installed ? '已安装' : '未安装'}</span>
-                  </span>
-                  <UiButton
-                    type="button"
-                    variant="ghost"
-                    className="maka-skill-market-install"
-                    onClick={() => props.onInstallManagedSkill?.(source.id)}
-                    disabled={installed || props.actionBusy || !props.onInstallManagedSkill}
-                  >
-                    {installing ? '安装中…' : installed ? '已安装' : '安装'}
-                  </UiButton>
-                </div>
-              </li>
-            );
-          })}
-        </ul>
       )}
     </section>
   );
@@ -447,7 +474,6 @@ function SkillLibraryPanel(props: {
         <TabsPanel value="installed">
           {skillList(installedSkills, skillListEmptyTitle, skillListEmptyBody, '已安装技能')}
           {updateReview}
-          {managedSources}
           {templates}
         </TabsPanel>
       </TabsRoot>
@@ -477,43 +503,6 @@ const SKILL_EXAMPLE_CARDS: ReadonlyArray<{
     body: '生成结构、整理讲稿、检查 PPTX 页面，让演示准备更稳定。',
     meta: 'Slides · 提纲 · 校对',
     Icon: BookOpen,
-  },
-];
-
-const SKILL_MARKETPLACE_CARDS: ReadonlyArray<{
-  title: string;
-  body: string;
-  meta: string;
-  source: string;
-  Icon: typeof FileEdit;
-}> = [
-  {
-    title: '研究简报',
-    body: '把网页资料、引用和结论整理成结构化 brief，适合快速进入陌生领域。',
-    meta: 'Research · Web',
-    source: '官方精选',
-    Icon: Search,
-  },
-  {
-    title: '文档审阅',
-    body: '检查 DOCX / Markdown 的结构、语气和遗漏项，并输出可执行修改建议。',
-    meta: 'Writing · Office',
-    source: '官方精选',
-    Icon: FileEdit,
-  },
-  {
-    title: '会议跟进',
-    body: '从会议记录里抽取决定、风险和 owner，生成下一步任务清单。',
-    meta: 'Ops · Summary',
-    source: '社区模板',
-    Icon: CalendarDays,
-  },
-  {
-    title: '发布检查',
-    body: '按发布前 checklist 扫描 diff、测试和文档，减少临门一脚的遗漏。',
-    meta: 'Engineering · QA',
-    source: '团队模板',
-    Icon: ShieldAlert,
   },
 ];
 


### PR DESCRIPTION
Redesigns the skills page toward the maintainer's reference comparison: the 市场 tab becomes a real marketplace.

## 市场 tab
- 3-column auto-fill card grid (2/1-col on narrow): icon tile + name + slug mono + 2-line description + category Chip + install state, quiet install icon-button (only the + acts — card body honest-inert)
- **Category filter** (7-bucket taxonomy, parsed from managed-source front-matter, unknown → 效率工具, backward-compatible optional field through core type → IPC scrubber → UI) and **sort** (名称/最近) — client-side via SettingsSelect
- Install counts deliberately OMITTED — no real data; no fake numbers
- 官方精选 section label; 导入本地 Skill moved in; placeholder catalog constant deleted

## 内置 / 已安装 rows
- Reference-style rows: name + clamped description; visible slug chip retired into the row tooltip; Switch / open-SKILL.md / exception-only state_error Chip preserved
- 使用 button SKIPPED with reason: no chat-prefill mechanism exists for skills — no dead UI invented

## Governance
All shipped primitives + contracts honored (Chip/Item/PageHeader, 4px ruler, radius families, icon funnel, no oklch literals); skills.test.ts re-pinned to the market grid in new form; new fixture test pins the 7-source category catalog. Desktop 2294/2294 + ui 46/46 exit-code gated; dead-css/console/a11y/copy checks clean; alignment auditor clean; light/dark/narrow captures verified. Implemented by an opus worktree agent to the maintainer's spec.