### PR TITLE
fix(desktop): guidance chips carry the bare action — location moves to the detail tooltip

### DIFF
--- a/apps/desktop/src/main/__tests__/account-auth-ui.test.ts
+++ b/apps/desktop/src/main/__tests__/account-auth-ui.test.ts
@@ -60,7 +60,9 @@ describe('Account auth UI contract mapping', () => {
           }
           assert.equal(action.kind, 'guidance');
           assert.equal(action.executable, false);
-          assert.match(action.label, /模型设置/);
+          // Location guarantee moved from the label to the detail tooltip:
+          // labels are the bare action, the detail must still say WHERE.
+          assert.match(action.detail, /设置 · 模型|模型设置/);
           assert.doesNotMatch(action.label, /Roadmap|路线图|即将|TODO/i);
           assert.doesNotMatch(action.detail, /Roadmap|路线图|即将|TODO/i);
         }
@@ -160,9 +162,13 @@ describe('Account settings credential probe UI', () => {
     assert.match(connectionStatus, /最近一次测试成功。修改模型密钥、服务地址或默认模型会清掉此状态；发送链路需独立验证/);
     assert.match(row, /正在读取本机凭据和账号登录状态/);
     assert.match(row, /读取本机凭据和账号登录状态失败/);
-    assert.match(authUi, /在模型设置中保存模型密钥/);
+    // Guidance chips carry the bare action; the 设置 · 模型 location lives in
+    // the detail tooltip — the 在模型设置中 prefix repeated across four sibling
+    // chips was pure noise once #645 gave guidance its own visual form.
+    assert.match(authUi, /label: '保存密钥',/);
+    assert.doesNotMatch(authUi, /在模型设置中/);
     assert.match(authUi, /账号页只展示状态；密钥输入仍在 设置 · 模型/);
-    assert.match(authUi, /当前页面不直接写入凭据存储/);
+    assert.match(authUi, /本页不直接写入凭据存储/);
     assert.match(authUi, /模型密钥管理/);
 
     for (const block of [page, row, authUi, connectionStatus, providerAuth]) {

--- a/apps/desktop/src/renderer/settings/account-auth-ui.ts
+++ b/apps/desktop/src/renderer/settings/account-auth-ui.ts
@@ -105,7 +105,7 @@ function availableAction(
         action,
         kind: 'guidance',
         executable: false,
-        label: '在模型设置中保存模型密钥',
+        label: '保存密钥',
         detail: '账号页只展示状态；密钥输入仍在 设置 · 模型。',
         tone: 'neutral',
       };
@@ -114,7 +114,7 @@ function availableAction(
         action,
         kind: 'guidance',
         executable: false,
-        label: contract.setupMode === 'none' ? '在模型设置中探测模型' : '在模型设置中拉取模型',
+        label: contract.setupMode === 'none' ? '探测模型' : '拉取模型',
         detail: '模型列表刷新由 设置 · 模型 的连接编辑器执行。',
         tone: 'neutral',
       };
@@ -123,8 +123,8 @@ function availableAction(
         action,
         kind: 'guidance',
         executable: false,
-        label: contract.setupMode === 'oauth' ? '在模型设置中退出登录' : '在模型设置中替换或移除凭据',
-        detail: '当前页面不直接写入凭据存储。',
+        label: contract.setupMode === 'oauth' ? '退出登录' : '替换或移除凭据',
+        detail: '凭据的替换与移除在 设置 · 模型 中执行；本页不直接写入凭据存储。',
         tone: 'neutral',
       };
     case 'start_oauth':
@@ -132,7 +132,7 @@ function availableAction(
         action,
         kind: 'guidance',
         executable: false,
-        label: '在模型设置中登录 OAuth',
+        label: '登录 OAuth',
         detail: 'OAuth 登录入口位于 设置 · 模型 · OAuth。',
         tone: 'neutral',
       };
@@ -141,7 +141,7 @@ function availableAction(
         action,
         kind: 'guidance',
         executable: false,
-        label: '在模型设置中刷新登录',
+        label: '刷新登录',
         detail: 'OAuth 账号状态刷新位于 设置 · 模型 · OAuth。',
         tone: 'neutral',
       };


### PR DESCRIPTION
Closes the last recorded copy-debt item: six account-page guidance chips all opened with 在模型设置中…, a prefix repeated across sibling chips that stopped earning its keep once #645 gave guidance chips their own visual form. Labels are now the bare action; the behavioral contract's location guarantee is re-pinned onto the detail tooltip (every guidance detail must state where the action lives), and the revoke detail — the only one without a location — gained one. Desktop 2294/2294 exit-code gated.