### PR TITLE
feat(desktop): search funnel bridge — palette hands its query to the search modal

### DIFF
--- a/apps/desktop/src/main/__tests__/use-thread-search.test.ts
+++ b/apps/desktop/src/main/__tests__/use-thread-search.test.ts
@@ -629,3 +629,28 @@ describe('disabled flag on status tiles (xuan fd675604)', () => {
     assert.equal(closeCalled, 1);
   });
 });
+
+describe('search funnel bridge (palette → search modal)', () => {
+  const hit = { target: { kind: 'thread', sessionId: 's1', turnId: 't1' }, snippet: 'x' };
+  it('appends the 查看全部结果 bridge row after hits when the callback is wired', () => {
+    const opened: string[] = [];
+    const commands = buildContentSearchCommands(
+      { kind: 'results', query: 'deploy', hits: [hit] } as never,
+      () => undefined,
+      (query) => opened.push(query),
+    );
+    const bridge = commands.at(-1);
+    assert.equal(bridge?.id, 'thread-search:open-modal');
+    assert.match(bridge?.label ?? '', /查看全部结果/);
+    bridge?.run();
+    assert.deepEqual(opened, ['deploy']);
+  });
+
+  it('renders no bridge row without the callback (portable palette)', () => {
+    const commands = buildContentSearchCommands(
+      { kind: 'results', query: 'deploy', hits: [hit] } as never,
+      () => undefined,
+    );
+    assert.equal(commands.some((command) => command.id === 'thread-search:open-modal'), false);
+  });
+});

--- a/apps/desktop/src/renderer/app-shell-overlays.tsx
+++ b/apps/desktop/src/renderer/app-shell-overlays.tsx
@@ -54,12 +54,14 @@ export function AppShellOverlays(props: {
   helpOpen: boolean;
   closeHelp(): void;
   searchModalOpen: boolean;
+  searchModalInitialQuery: string;
   closeSearchModal: SearchModalProps['onClose'];
   searchModalDeps: SearchModalProps['deps'];
   searchModalOnNavigate: NonNullable<SearchModalProps['onNavigateToSession']>;
   paletteOpen: boolean;
   closePalette(): void;
   paletteOnSelectSession(sessionId: string, turnId?: string): void;
+  paletteOnOpenSearchModal(query: string): void;
   commandOptions: AppShellCommandListOptions;
 }) {
   const {
@@ -72,11 +74,13 @@ export function AppShellOverlays(props: {
     connections,
     defaultConnection,
     helpOpen,
+    paletteOnOpenSearchModal,
     paletteOnSelectSession,
     paletteOpen,
     refreshConnections,
     respondToPermission,
     searchModalDeps,
+    searchModalInitialQuery,
     searchModalOnNavigate,
     searchModalOpen,
     settingsOpen,
@@ -119,6 +123,7 @@ export function AppShellOverlays(props: {
         <SearchModal
           onClose={closeSearchModal}
           deps={searchModalDeps}
+          initialQuery={searchModalInitialQuery}
           onNavigateToSession={searchModalOnNavigate}
         />
       )}
@@ -126,6 +131,10 @@ export function AppShellOverlays(props: {
         <CommandPalette
           onClose={closePalette}
           onSelectSession={paletteOnSelectSession}
+          onOpenSearchModal={(query) => {
+            closePalette();
+            paletteOnOpenSearchModal(query);
+          }}
           commands={buildAppShellCommandList(commandOptions)}
         />
       )}

--- a/apps/desktop/src/renderer/app-shell.tsx
+++ b/apps/desktop/src/renderer/app-shell.tsx
@@ -276,6 +276,9 @@ export function AppShell({
   // modal; result selection below can also hand ChatView a turn anchor
   // so the hit is visible after session navigation.
   const [searchModalOpen, setSearchModalOpen] = useState(false);
+  // Funnel bridge: query handed from the palette's 查看全部结果 row into the
+  // search modal. Topbar opens reset it so a plain open starts blank.
+  const [searchModalInitialQuery, setSearchModalInitialQuery] = useState('');
   const [searchScrollTarget, setSearchScrollTarget] = useState<{
     sessionId: string;
     turnId: string;
@@ -659,6 +662,10 @@ export function AppShell({
   }, []);
   const paletteOnSelectSession = useCallback((sessionId: string, turnId?: string) => {
     openSessionInChatRef.current(sessionId, turnId);
+  }, []);
+  const paletteOnOpenSearchModal = useCallback((query: string) => {
+    setSearchModalInitialQuery(query);
+    setSearchModalOpen(true);
   }, []);
   const sessionListSelectSession = useCallback((sessionId: string) => {
     openSessionInChatRef.current(sessionId);
@@ -1369,7 +1376,10 @@ export function AppShell({
       >
         <AppShellTopbarActions
           sidebarCollapsed={sessionListCollapsed}
-          onOpenSearchModal={() => setSearchModalOpen(true)}
+          onOpenSearchModal={() => {
+            setSearchModalInitialQuery('');
+            setSearchModalOpen(true);
+          }}
           onCollapseSidebar={() => setSessionListCollapsed(true)}
           onExpandSidebar={() => setSessionListCollapsed(false)}
           onCreateSession={createSession}
@@ -1675,12 +1685,14 @@ export function AppShell({
         helpOpen={helpOpen}
         closeHelp={closeHelp}
         searchModalOpen={searchModalOpen}
+        searchModalInitialQuery={searchModalInitialQuery}
         closeSearchModal={closeSearchModal}
         searchModalDeps={searchModalDeps}
         searchModalOnNavigate={searchModalOnNavigate}
         paletteOpen={paletteOpen}
         closePalette={closePalette}
         paletteOnSelectSession={paletteOnSelectSession}
+        paletteOnOpenSearchModal={paletteOnOpenSearchModal}
         commandOptions={commandOptions}
       />
     </div>

--- a/apps/desktop/src/renderer/command-palette-content-search.ts
+++ b/apps/desktop/src/renderer/command-palette-content-search.ts
@@ -28,6 +28,7 @@ import type { NormalizedThreadHit, ThreadSearchState } from './use-thread-search
 export function buildContentSearchCommands(
   state: ThreadSearchState,
   onSelectSession?: (sessionId: string, turnId?: string) => void,
+  onOpenSearchModal?: (query: string) => void,
 ): Command[] {
   switch (state.kind) {
     case 'idle':
@@ -96,7 +97,25 @@ export function buildContentSearchCommands(
           },
         ];
       }
-      return state.hits.map((hit, index) => contentSearchHitCommand(hit, index, onSelectSession));
+      return [
+        ...state.hits.map((hit, index) => contentSearchHitCommand(hit, index, onSelectSession)),
+        // Funnel bridge: the palette shows quick-jump hits; the search modal
+        // is the browse surface (same window.maka.search.thread backend).
+        // A terminal row hands the query over so the two entry points read
+        // as one funnel, not two disconnected searches.
+        ...(onOpenSearchModal
+          ? [{
+              id: 'thread-search:open-modal',
+              kind: 'action' as const,
+              label: '在搜索面板中查看全部结果',
+              hint: `"${truncateForHint(state.query)}"`,
+              group: '内容搜索',
+              Icon: Search,
+              keywords: [],
+              run: () => onOpenSearchModal(state.query),
+            }]
+          : []),
+      ];
   }
 }
 

--- a/apps/desktop/src/renderer/command-palette.tsx
+++ b/apps/desktop/src/renderer/command-palette.tsx
@@ -582,6 +582,9 @@ export function CommandPalette(props: {
    * when the backend supplied one, scroll to the matched turn.
    */
   onSelectSession?: (sessionId: string, turnId?: string) => void;
+  /** Funnel bridge: hands the current query to the search modal (the
+   *  browse surface over the same thread-search backend). */
+  onOpenSearchModal?: (query: string) => void;
   threadSearchDeps?: UseThreadSearchDeps;
 }) {
   const inputRef = useRef<HTMLInputElement>(null);
@@ -624,8 +627,8 @@ export function CommandPalette(props: {
   // sessions first, then matched content. Single empty / blocked /
   // error tile per state.
   const contentCommands = useMemo(() => {
-    return buildContentSearchCommands(threadSearch.state, props.onSelectSession);
-  }, [threadSearch.state, props.onSelectSession]);
+    return buildContentSearchCommands(threadSearch.state, props.onSelectSession, props.onOpenSearchModal);
+  }, [threadSearch.state, props.onSelectSession, props.onOpenSearchModal]);
 
   // Combine. Filtered commands keep their existing order; content
   // commands always sit at the end so they don't disrupt muscle

--- a/packages/ui/src/search-modal.tsx
+++ b/packages/ui/src/search-modal.tsx
@@ -74,6 +74,9 @@ interface SearchModalCloseOptions {
 
 export function SearchModal(props: {
   onClose(options?: SearchModalCloseOptions): void;
+  /** Seed query for the funnel bridge (palette 查看全部结果 → modal).
+   *  Read once on mount; the modal owns the state afterwards. */
+  initialQuery?: string;
   /**
    * Navigate to a session (optionally scrolling to a specific turn).
    * Provided by the application shell so the modal stays portable —
@@ -107,7 +110,7 @@ export function SearchModal(props: {
   //   - `pending` reflects whether ANY IPC call is in flight. We do
   //     NOT show a spinner if the query is empty (avoids flashing
   //     loading state during typing).
-  const [query, setQuery] = useState('');
+  const [query, setQuery] = useState(props.initialQuery ?? '');
   const [results, setResults] = useState<SearchResult[]>([]);
   const [error, setError] = useState<{ reason: SearchErrorReason; message: string } | null>(null);
   const [pending, setPending] = useState(false);


### PR DESCRIPTION
Resolves the last recorded product-decision item (search modal vs command palette overlap) by first principles: both consume the same `window.maka.search.thread` backend — no duplicated implementation, just two interaction depths (quick-jump vs browse; the standard ⌘P/search-panel split). Keeping both, adding the missing funnel: the palette's content-search results end with a 在搜索面板中查看全部结果 row that closes the palette and opens the search modal seeded with the query. SearchModal gains `initialQuery` (read once on mount); topbar opens reset to blank; callbacks stable per the shell's identity rule. Behavioral tests pin the bridge row with and without wiring. Desktop 2296/2296 exit-code gated; dead-css clean.