### PR TITLE
fix(desktop): usage/health first sweep — fixtures, edged 显示明细, 正常 goes neutral

### DIFF
--- a/apps/desktop/src/main/visual-smoke-fixture.ts
+++ b/apps/desktop/src/main/visual-smoke-fixture.ts
@@ -51,6 +51,8 @@ const VISUAL_SMOKE_SCENARIOS = new Set<VisualSmokeScenario>([
   'settings-voice',
   'settings-gateway',
   'settings-search',
+  'settings-usage',
+  'settings-health',
   'module-skills',
   'module-daily-review',
   // PR109b: workstation-statuses — seed one session per SessionStatus
@@ -369,6 +371,10 @@ export function getVisualSmokeState(fixture: VisualSmokeFixture | null): VisualS
       return { ...state, activeSessionId: TURN_SESSION_ID, openSettingsSection: 'open-gateway' };
     case 'settings-search':
       return { ...state, activeSessionId: TURN_SESSION_ID, openSettingsSection: 'search' };
+    case 'settings-usage':
+      return { ...state, activeSessionId: TURN_SESSION_ID, openSettingsSection: 'usage' };
+    case 'settings-health':
+      return { ...state, activeSessionId: TURN_SESSION_ID, openSettingsSection: 'health' };
     case 'module-skills':
       return { ...state, activeSessionId: TURN_SESSION_ID, sidebarSection: 'skills', sidebarCollapsed: false };
     case 'module-daily-review':

--- a/apps/desktop/src/renderer/settings/health-center-page.tsx
+++ b/apps/desktop/src/renderer/settings/health-center-page.tsx
@@ -39,7 +39,9 @@ const HEALTH_LAYER_COPY: Record<HealthSignalLayer, { label: string; description:
 };
 
 const HEALTH_STATUS_COPY: Record<HealthSignalStatus, { label: string; tone: 'neutral' | 'info' | 'success' | 'warning' | 'destructive' }> = {
-  ok: { label: '正常', tone: 'success' },
+  // Status-color restraint (#651 rule): 正常 is the EXPECTED state — neutral
+  // ink; color stays reserved for the signals that need attention.
+  ok: { label: '正常', tone: 'neutral' },
   info: { label: '提示', tone: 'info' },
   warning: { label: '警告', tone: 'warning' },
   error: { label: '错误', tone: 'destructive' },
@@ -153,7 +155,7 @@ export function HealthCenterPage() {
           drops its `role="listitem"` because the `<li>`
           wrapper already carries it. */}
       <ul aria-label="健康摘要" className="settingsHealthSummary">
-        <HealthSummaryTile tone="success" label="正常" count={snapshot.summary.ok} />
+        <HealthSummaryTile tone="neutral" label="正常" count={snapshot.summary.ok} />
         <HealthSummaryTile tone="info" label="提示" count={snapshot.summary.info} />
         <HealthSummaryTile tone="warning" label="警告" count={snapshot.summary.warning} />
         <HealthSummaryTile tone="destructive" label="错误" count={snapshot.summary.error} />

--- a/apps/desktop/src/renderer/settings/usage-settings-page.tsx
+++ b/apps/desktop/src/renderer/settings/usage-settings-page.tsx
@@ -200,7 +200,7 @@ export function UsageSettingsPage(props: {
         <div className="settingsNotice">
           当前仅显示汇总指标。打开详情记录后，可以查看逐条模型请求和工具调用，按模型、工具或状态筛选，并用于排查费用与失败请求。
           <div className="settingsActionRow settingsNoticeAction">
-            <Button type="button" variant="ghost" size="sm" onClick={() => void updateUsage({ showDetails: true })}>
+            <Button type="button" variant="outline" size="sm" onClick={() => void updateUsage({ showDetails: true })}>
               显示明细
             </Button>
           </div>

--- a/packages/core/src/visual-smoke.ts
+++ b/packages/core/src/visual-smoke.ts
@@ -36,6 +36,8 @@ export type VisualSmokeScenario =
   | 'settings-voice'
   | 'settings-gateway'
   | 'settings-search'
+  | 'settings-usage'
+  | 'settings-health'
   | 'module-skills'
   | 'module-daily-review'
   | 'workstation-statuses'


### PR DESCRIPTION
使用统计 and 健康 were the last settings pages without CDP fixtures. Added both, and their first sweep caught two rule violations:

1. **使用统计** — the amber notice's 显示明细 action rendered as a bare text ghost; now outline per the codified text-buttons-wear-edges rule (#659/#660/#665/#668 lineage).
2. **健康** — ok/正常 still wore success-green on signal chips and the summary tile while 权限's 已授权 went neutral under the same #651 restraint rule. On a triage dashboard the eye belongs on 警告/错误 — 正常 is the expected state and is neutral now; attention tones unchanged.

Desktop 2296/2296 exit-code gated; dead-css clean.