### PR TITLE
fix(ui): 新任务 compose icon in both sidebar states + warning tone splits from info

### DIFF
--- a/apps/desktop/src/main/__tests__/icon-governance-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/icon-governance-contract.test.ts
@@ -13,7 +13,7 @@
  *      apps/desktop/src/renderer or packages/ui/src (brand-asset files
  *      excepted) — icons ride the single governed stroke instead.
  *   b) session-sidebar-nav.tsx imports exactly the decided semantic set
- *      (Plus / CalendarCheck / Blocks / Timer / Settings) from ./icons.js.
+ *      (SquarePen / CalendarCheck / Blocks / Timer / Settings) from ./icons.js.
  *   c) icons.tsx stays the ONLY packages/ui/src file importing lucide-react
  *      (funnel integrity).
  */
@@ -85,9 +85,10 @@ describe('icon + typography governance contract', () => {
       .map((name) => name.trim())
       .filter(Boolean)
       .sort();
-    // Decided semantic mapping: 新任务 → Plus, 每日回顾 → CalendarCheck,
+    // Decided semantic mapping (maintainer 2026-07-10: 新任务 matches the
+    // collapsed-topbar compose icon): 新任务 → SquarePen, 每日回顾 → CalendarCheck,
     // 技能 → Blocks, 定时任务 → Timer, 设置 → Settings.
-    const expected = ['Blocks', 'CalendarCheck', 'Plus', 'Settings', 'Timer'];
+    const expected = ['Blocks', 'CalendarCheck', 'Settings', 'SquarePen', 'Timer'];
     assert.deepEqual(
       imported,
       expected,

--- a/apps/desktop/src/renderer/maka-tokens.css
+++ b/apps/desktop/src/renderer/maka-tokens.css
@@ -136,8 +136,12 @@
   --success-text: color-mix(in oklab, var(--success) 50%, var(--foreground));
   --destructive-text: color-mix(in oklab, var(--destructive) 50%, var(--foreground));
   --info-text: color-mix(in oklab, var(--info) 50%, var(--foreground));
-  --warning: var(--info);
-  --warning-text: var(--info-text);
+  /* 警告 must be visually distinct from 提示 — they were literally the same
+     token, so the health page's info/warning tiers were indistinguishable.
+     Warning steps deeper + more orange than info's amber (l .75→.66,
+     h 70→55); still derived nowhere else, safe across palettes. */
+  --warning: oklch(0.66 0.18 55);
+  --warning-text: color-mix(in oklab, var(--warning) 50%, var(--foreground));
 
   /* === foreground solid mix scale ===
      foreground-N = N% of foreground interpolated INTO background.

--- a/packages/ui/src/session-sidebar-nav.tsx
+++ b/packages/ui/src/session-sidebar-nav.tsx
@@ -1,5 +1,5 @@
 import type { PlanReminder } from '@maka/core';
-import { Blocks, CalendarCheck, Plus, Settings, Timer } from './icons.js';
+import { Blocks, CalendarCheck, Settings, SquarePen, Timer } from './icons.js';
 import type { NavSelection } from './nav-selection.js';
 import { Button as UiButton, cn } from './ui.js';
 import { cva } from 'class-variance-authority';
@@ -69,7 +69,7 @@ export function SessionSidebarNav(props: {
         type="button"
         onClick={props.onNew}
       >
-        <Plus className="maka-nav-icon" aria-hidden="true" />
+        <SquarePen className="maka-nav-icon" aria-hidden="true" />
         <span>新任务</span>
         <kbd className="maka-nav-kbd" aria-hidden="true">⌘ N</kbd>
       </UiButton>


### PR DESCRIPTION
Two fixes:

1. **新任务 icon parity** (maintainer instruction): expanded sidebar row showed Plus (#662) while the collapsed topbar shows SquarePen — same action, two glyphs. Unified on SquarePen (the collapsed one). icon-governance contract re-pinned; CDP probe confirms `lucide-square-pen` on the row.
2. **警告 ≠ 提示**: `--warning` was literally `var(--info)` — the health page's info and warning tiers rendered the identical amber. Warning now steps deeper and more orange (oklch .66/.18/55 vs info's .75/.16/70) with its own --warning-text mix. Health capture confirms the tiers are finally distinguishable; all palettes inherit since none overrode --warning.

Desktop 2296/2296 exit-code gated.