### PR TITLE
refactor(ui): StatTile primitive — four stat-tile recipes become one (convergence R4)

### DIFF
--- a/apps/desktop/src/main/__tests__/card-converge-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/card-converge-contract.test.ts
@@ -27,7 +27,8 @@ import { REPO_ROOT } from './css-test-helpers.js';
 /** Sites whose top-level container becomes <Card>. */
 const CARD_SITES = [
   'apps/desktop/src/renderer/settings/settings-rows.tsx',
-  'apps/desktop/src/renderer/settings/settings-metric-card.tsx',
+  // settings-metric-card retired its Card wrapper in convergence R4 — it is
+  // a thin alias over the shared StatTile primitive now.
   'apps/desktop/src/renderer/error-boundary.tsx',
 ];
 

--- a/apps/desktop/src/main/__tests__/radius-converge-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/radius-converge-contract.test.ts
@@ -403,7 +403,6 @@ describe('radius token governance (#406 gap 4)', () => {
       // .maka-daily-review-info dropped: unboxed to a plain hint line in
       // the daily-review IA restructure — no card chrome, no radius.
       '.maka-daily-review-archive-body': '--radius-surface',
-      '.settingsPermissionSummaryTile': '--radius-surface',
     };
     const offenders: string[] = [];
     for (const [sel, token] of Object.entries(SELECTOR_TIER)) {

--- a/apps/desktop/src/main/__tests__/settings-roadmap-cleanup-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/settings-roadmap-cleanup-contract.test.ts
@@ -307,7 +307,9 @@ describe('Settings coming-soon cleanup contract', () => {
     // `<div role="listitem">`. ARIA list semantics still hold
     // — the elements carry them implicitly.
     assert.match(healthPage![0], /<ul aria-label="健康摘要" className="settingsHealthSummary">/, 'Health Center summary metrics must expose list semantics');
-    assert.match(settings, /<li className="settingsHealthSummaryTile" data-tone=\{props\.tone\} data-empty=\{props\.count === 0\}>/, 'Health Center summary metric tiles must expose listitem semantics');
+    // Convergence R4: the tile is the shared StatTile rendered as="li" —
+    // listitem semantics preserved through the primitive's `as` prop.
+    assert.match(settings, /<StatTile\s+as="li"\s+className="settingsHealthSummaryTile"/, 'Health Center summary metric tiles must expose listitem semantics via StatTile as="li"');
     assert.match(healthPage![0], /aria-label=\{`\$\{copy\.label\}健康信号`\}/, 'Health Center section aria labels should not mix English "signals" into Chinese UI');
     assert.match(healthPage![0], /<ul className="settingsHealthSignalList" aria-label=\{`\$\{copy\.label\}健康信号列表`\}>/, 'Health Center signal lists must expose product-scoped accessible names');
     assert.match(healthSignalRow![0], /来源：\{HEALTH_SOURCE_LABEL\[signal\.source\]\}/, 'Health Center row should present localized source labels');

--- a/apps/desktop/src/main/__tests__/tabular-nums-converge-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/tabular-nums-converge-contract.test.ts
@@ -45,17 +45,13 @@ const TABULAR_NUMS_SELECTORS = [
   '.maka-plan-tab span',
   '.maka-daily-review-archive-count',
   '.maka-daily-review-archive-row-meta',
-  '.maka-daily-review-totals-value',
   '.maka-daily-review-top-meta',
-  '.settingsPermissionSummaryValue',
   '.maka-nav-count',
   '.maka-list-group-count',
   '.maka-first-run-checklist-count',
   '.settingsQuotaRow',
   // settings numeric surfaces
-  '.settingsMetricCard',
   '.settingsUsageRecordCount',
-  '.settingsHealthSummaryTile strong',
   '.settingsMemoryEntryGroupHeader',
   // skill counts
   '.maka-skill-tab span',
@@ -87,7 +83,16 @@ async function readTabularNumsCoveredSelectors(): Promise<Set<string>> {
   return covered;
 }
 
+// Convergence R4: the four stat-tile surfaces (permission/health summaries,
+// MetricCard, daily-review totals) render through the StatTile primitive,
+// whose value slot BAKES tabular-nums as a Tailwind utility — pinned below
+// against the primitive source instead of renderer CSS selectors.
 describe('PR-ANTI-LAYOUT-SHIFT-TABULAR-NUMS-0 contract', () => {
+  it('StatTile bakes tabular-nums into its value slot (stat-tile surfaces converged in R4)', async () => {
+    const statTile = await readFile(resolve(REPO_ROOT, 'packages/ui/src/primitives/stat-tile.tsx'), 'utf8');
+    assert.match(statTile, /\[font-variant-numeric:tabular-nums\]/, 'StatTile value must keep tabular-nums baked in');
+  });
+
   it('every whitelisted numeric surface declares tabular-nums in renderer CSS', async () => {
     const covered = await readTabularNumsCoveredSelectors();
     const missing = TABULAR_NUMS_SELECTORS.filter((s) => !covered.has(s));

--- a/apps/desktop/src/renderer/maka-tokens.css
+++ b/apps/desktop/src/renderer/maka-tokens.css
@@ -301,6 +301,9 @@
      Caption 11 is dense meta (timestamps, badges, kbd, overlines).
      Bubble h1-h4 scale in em off body 13 so they track the root automatically. */
   --font-size-heading: 15px;
+  /* Display tier for stat-tile values (convergence R4) — the summary tiles
+     used ad-hoc 1.5em/1.4em; one ladder step ends that. */
+  --font-size-stat: 20px;
   --font-size-base: 13px;
   --font-size-ui: var(--font-size-base);
   --font-size-caption: 11px;

--- a/apps/desktop/src/renderer/settings/health-center-page.tsx
+++ b/apps/desktop/src/renderer/settings/health-center-page.tsx
@@ -7,7 +7,7 @@ import type {
   HealthSnapshot,
 } from '@maka/core';
 import { HEALTH_SIGNAL_LAYERS } from '@maka/core';
-import { Button, Badge, RelativeTime, PageHeader } from '@maka/ui';
+import { Button, Badge, RelativeTime, PageHeader, StatTile } from '@maka/ui';
 import { settingsActionErrorMessage } from './settings-error-copy';
 import { statusBadgeVariant } from './settings-status-badge';
 import { SettingsSkeletonStack } from './settings-skeleton';
@@ -209,11 +209,16 @@ function HealthSummaryTile(props: {
   label: string;
   count: number;
 }) {
+  // Convergence R4: same StatTile as the permission summary — the two
+  // recipes were literal twins hand-rolled twice.
   return (
-    <li className="settingsHealthSummaryTile" data-tone={props.tone} data-empty={props.count === 0}>
-      <strong>{props.count}</strong>
-      <small>{props.label}</small>
-    </li>
+    <StatTile
+      as="li"
+      className="settingsHealthSummaryTile"
+      label={props.label}
+      value={props.count}
+      tone={props.tone}
+    />
   );
 }
 

--- a/apps/desktop/src/renderer/settings/permission-center-page.tsx
+++ b/apps/desktop/src/renderer/settings/permission-center-page.tsx
@@ -18,7 +18,7 @@ import type {
   PermissionSnapshot,
 } from '@maka/core';
 import { OS_PERMISSION_IDS } from '@maka/core';
-import { Button, Badge, RelativeTime, PageHeader, useToast } from '@maka/ui';
+import { Button, Badge, RelativeTime, PageHeader, StatTile, useToast } from '@maka/ui';
 import { settingsActionErrorMessage } from './settings-error-copy';
 import { statusBadgeVariant } from './settings-status-badge';
 import { SettingsSkeletonStack } from './settings-skeleton';
@@ -284,14 +284,15 @@ function PermissionSummaryTile(props: {
   value: number;
   tone: 'success' | 'warning' | 'destructive' | 'neutral';
 }) {
-  // A zero count is not an exception — the tone only paints when there is
-  // actually something to look at (0 已拒绝 in red read as a false alarm).
-  const effectiveTone = props.value > 0 ? props.tone : 'neutral';
+  // Convergence R4: StatTile owns the recipe (incl. the zero-is-not-an-
+  // exception tone gate this tile pioneered).
   return (
-    <div className="settingsPermissionSummaryTile" data-tone={effectiveTone} data-empty={props.value === 0}>
-      <span className="settingsPermissionSummaryValue">{props.value}</span>
-      <span className="settingsPermissionSummaryLabel">{props.label}</span>
-    </div>
+    <StatTile
+      className="settingsPermissionSummaryTile"
+      label={props.label}
+      value={props.value}
+      tone={props.tone}
+    />
   );
 }
 

--- a/apps/desktop/src/renderer/settings/settings-metric-card.tsx
+++ b/apps/desktop/src/renderer/settings/settings-metric-card.tsx
@@ -1,12 +1,16 @@
-import { Card } from '@maka/ui';
+import { StatTile } from '@maka/ui';
 
+/** Thin alias over the shared StatTile (convergence R4) — usage/bot call
+ *  sites keep their name; the recipe lives in the primitive. */
 export function MetricCard(props: { title: string; value: string; detail?: string }) {
   return (
-    <Card className="settingsMetricCard">
-      <small>{props.title}</small>
-      <strong>{props.value}</strong>
-      {props.detail && <span>{props.detail}</span>}
-    </Card>
+    <StatTile
+      className="settingsMetricCard"
+      emphasis="filled"
+      label={props.title}
+      value={props.value}
+      detail={props.detail}
+    />
   );
 }
 

--- a/apps/desktop/src/renderer/styles/daily-review.css
+++ b/apps/desktop/src/renderer/styles/daily-review.css
@@ -332,29 +332,15 @@
 .maka-module-main .maka-daily-review-totals {
     grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
   }
+/* Convergence R4: recipe lives in the StatTile primitive; density override
+   only (tight strip cells). */
 .maka-daily-review-totals-cell {
-    display: grid;
     gap: 1px;
     padding: var(--space-1) var(--space-2);
-    border: 0;
-    border-radius: var(--radius-control);
-    background: oklch(from var(--foreground) l c h / 0.04);
   }
-.maka-daily-review-totals-cell[data-tone="error"] {
+.maka-daily-review-totals-cell[data-tone="destructive"] {
     border-color: oklch(from var(--destructive, var(--warning, var(--info))) l c h / 0.35);
     background: oklch(from var(--destructive, var(--warning, var(--info))) l c h / 0.06);
-  }
-.maka-daily-review-totals-value {
-    font-size: var(--font-size-ui);
-    font-weight: var(--font-weight-semibold);
-    color: var(--foreground);
-    font-variant-numeric: tabular-nums;
-  }
-.maka-daily-review-totals-label {
-    font-size: var(--font-size-caption);
-    text-transform: none;
-    letter-spacing: var(--tracking-normal);
-    color: var(--muted-foreground);
   }
 
 /* PR-DAILY-REVIEW-EYEBROW-RHYTHM-0 (WAWQAQ msg `7f0ec4a5`): granularity

--- a/apps/desktop/src/renderer/styles/settings/bot.css
+++ b/apps/desktop/src/renderer/styles/settings/bot.css
@@ -333,24 +333,13 @@
   gap: var(--space-1-5);
 }
 
+/* Convergence R4: recipe lives in the StatTile primitive; this class keeps
+   only the metric-strip density override. */
 .settingsMetricCard {
-  font-variant-numeric: tabular-nums;
   min-height: 52px;
-  display: grid;
-  align-content: center;
+  justify-content: center;
   gap: var(--space-0-5);
-  background: var(--foreground-5);
   padding: var(--space-1-5) var(--space-2-5);
-}
-
-.settingsMetricCard small,
-.settingsMetricCard span {
-  color: var(--muted-foreground);
-  font-size: var(--font-size-caption);
-}
-
-.settingsMetricCard strong {
-  font-size: var(--font-size-ui);
 }
 
 /* #520 PR9: .settingsStatsTable retired onto the local native

--- a/apps/desktop/src/renderer/styles/settings/health.css
+++ b/apps/desktop/src/renderer/styles/settings/health.css
@@ -115,66 +115,6 @@
     gap: var(--space-2-5);
   }
 
-.settingsHealthSummaryTile {
-    display: flex;
-    flex-direction: column;
-    align-items: flex-start;
-    gap: var(--space-1);
-    padding: var(--space-3) var(--space-3);
-    border: var(--border-width-hairline) solid var(--border);
-    border-radius: var(--radius-surface);
-    background: var(--background);
-  }
-
-.settingsHealthSummaryTile strong {
-    font-variant-numeric: tabular-nums;
-    font-size: 1.4em;
-    font-weight: var(--font-weight-semibold);
-    line-height: var(--leading-tight);
-  }
-
-.settingsHealthSummaryTile small {
-    font-size: var(--font-size-caption);
-    letter-spacing: var(--tracking-wider);
-    text-transform: uppercase;
-    color: var(--muted-foreground);
-  }
-
-.settingsHealthSummaryTile[data-empty="true"] {
-    opacity: var(--opacity-disabled);
-  }
-
-/* Status-color restraint: a healthy tile keeps the default hairline and
-   ink — color is reserved for the exception tones. */
-
-.settingsHealthSummaryTile[data-tone="info"] {
-    border-color: oklch(from var(--info) l c h / 0.24);
-  }
-
-.settingsHealthSummaryTile[data-tone="info"] strong {
-    color: var(--info-text);
-  }
-
-.settingsHealthSummaryTile[data-tone="warning"] {
-    border-color: oklch(from var(--warning, var(--info)) l c h / 0.28);
-  }
-
-.settingsHealthSummaryTile[data-tone="warning"] strong {
-    color: var(--warning-text, var(--info-text));
-  }
-
-.settingsHealthSummaryTile[data-tone="destructive"] {
-    border-color: oklch(from var(--destructive) l c h / 0.30);
-  }
-
-.settingsHealthSummaryTile[data-tone="destructive"] strong {
-    color: var(--destructive-text);
-  }
-
-.settingsHealthSummaryTile[data-tone="neutral"] strong {
-    color: var(--foreground-secondary);
-  }
-
 .settingsHealthBlockers {
     display: flex;
     flex-wrap: wrap;

--- a/apps/desktop/src/renderer/styles/settings/permission.css
+++ b/apps/desktop/src/renderer/styles/settings/permission.css
@@ -544,44 +544,6 @@
     gap: var(--space-2);
   }
 
-.settingsPermissionSummaryTile {
-    display: flex;
-    flex-direction: column;
-    gap: var(--space-0-5);
-    padding: var(--space-3) var(--space-3);
-    border: var(--border-width-hairline) solid var(--card-border-color, var(--border));
-    border-radius: var(--radius-surface);
-    background: var(--card-bg, var(--background));
-    box-shadow:
-      var(--card-shadow, none),
-      var(--card-highlight, none);
-  }
-
-.settingsPermissionSummaryValue {
-    font-size: 1.5em;
-    font-weight: var(--font-weight-semibold);
-    line-height: var(--leading-tight);
-    font-variant-numeric: tabular-nums;
-    color: var(--foreground);
-  }
-
-.settingsPermissionSummaryLabel {
-    font-size: var(--font-size-caption);
-    color: var(--foreground-secondary);
-    letter-spacing: var(--tracking-wide);
-  }
-
-/* success tile keeps the default ink — the granted count is the normal
-   posture; only warning/destructive counts get colored. */
-
-.settingsPermissionSummaryTile[data-tone="warning"] .settingsPermissionSummaryValue {
-    color: var(--warning-text, var(--info-text));
-  }
-
-.settingsPermissionSummaryTile[data-tone="destructive"] .settingsPermissionSummaryValue {
-    color: oklch(from var(--destructive) l c h);
-  }
-
 /* Diagnostic 5-column capability detail collapsed by default so the
      page reads as "system permissions" first. Expand on click. */
 

--- a/packages/ui/src/daily-review-panel.tsx
+++ b/packages/ui/src/daily-review-panel.tsx
@@ -23,6 +23,7 @@ import { Chip, type ChipProps } from './primitives/chip.js';
 import { SettingsSegmented } from './primitives/settings-segmented.js';
 import { Alert, AlertAction, AlertDescription } from './primitives/alert.js';
 import { EmptyState } from './empty-state.js';
+import { StatTile } from './primitives/stat-tile.js';
 import type { DailyReviewBridge, DailyReviewMarkdownActionInput } from './module-panel-types.js';
 import { RelativeTime } from './relative-time.js';
 import { Markdown } from './markdown.js';
@@ -698,11 +699,16 @@ function DailyReviewArchiveBody(props: { archive: DailyReviewArchive | null; loa
 }
 
 function DailyReviewTotalsCell(props: { label: string; value: string; tone?: 'error' }) {
+  // Convergence R4: shared StatTile, filled emphasis; the error tone maps
+  // to the primitive's destructive ink + this cell's tinted wash (CSS).
   return (
-    <div className="maka-daily-review-totals-cell" data-tone={props.tone}>
-      <span className="maka-daily-review-totals-value">{props.value}</span>
-      <span className="maka-daily-review-totals-label">{props.label}</span>
-    </div>
+    <StatTile
+      className="maka-daily-review-totals-cell"
+      emphasis="filled"
+      label={props.label}
+      value={props.value}
+      tone={props.tone === 'error' ? 'destructive' : 'neutral'}
+    />
   );
 }
 

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -59,6 +59,7 @@ export * from './primitives/spinner.js';
 export * from './primitives/kbd.js';
 export * from './primitives/menu.js';
 export * from './primitives/dialog-header.js';
+export * from './primitives/stat-tile.js';
 export * from './primitives/choice-card.js';
 export * from './primitives/settings-segmented.js';
 export * from './primitives/settings-select.js';

--- a/packages/ui/src/primitives/stat-tile.tsx
+++ b/packages/ui/src/primitives/stat-tile.tsx
@@ -1,0 +1,111 @@
+// packages/ui/src/primitives/stat-tile.tsx
+//
+// Convergence round 4 (notes/ui-convergence-map-2026-07-09.md): the ONE
+// implementation for "big number + label (+ detail)" stat tiles. Before
+// this, four near-identical recipes lived in page CSS (permission summary,
+// health summary — literal twins — plus the filled MetricCard and the
+// daily-review totals cell).
+//
+// Recipe decisions (union of the twins):
+//   - value is tabular-nums ALWAYS (tabular-nums-converge contract);
+//   - emphasis="outline" = card-like tile (hairline + radius-surface +
+//     1.5em value); emphasis="filled" = compact quiet tile (foreground-5
+//     wash + radius-control + ui-size value) for dense metric strips;
+//   - tone paints the value ink AND (outline only) tints the border —
+//     the health model, which scans better than value-only;
+//   - a ZERO count is not an exception: numeric zero drops the tone to
+//     neutral and sets data-empty (dim) — the permission rationale
+//     (0 已拒绝 in red read as a false alarm) now applies everywhere.
+//
+// Styled with Tailwind utilities so the primitive is portable; wrapper
+// classes from call sites (grid placement, page pins) pass through.
+
+import type { ReactNode } from 'react';
+import { cn } from '../utils.js';
+
+export type StatTileTone = 'neutral' | 'info' | 'success' | 'warning' | 'destructive';
+
+const TONE_VALUE_CLASS: Record<StatTileTone, string> = {
+  neutral: '',
+  info: 'text-[color:var(--info-text)]',
+  success: 'text-[color:var(--success-text)]',
+  warning: 'text-[color:var(--warning-text)]',
+  destructive: 'text-[color:var(--destructive-text)]',
+};
+
+const TONE_BORDER_CLASS: Record<StatTileTone, string> = {
+  neutral: '',
+  info: 'border-[oklch(from_var(--info)_l_c_h_/_0.24)]',
+  success: 'border-[oklch(from_var(--success)_l_c_h_/_0.24)]',
+  warning: 'border-[oklch(from_var(--warning)_l_c_h_/_0.28)]',
+  destructive: 'border-[oklch(from_var(--destructive)_l_c_h_/_0.30)]',
+};
+
+export interface StatTileProps {
+  label: ReactNode;
+  value: ReactNode;
+  /** Optional third quiet line under the label (MetricCard's detail). */
+  detail?: ReactNode;
+  tone?: StatTileTone;
+  /** outline = card tile (permission/health); filled = compact metric strip. */
+  emphasis?: 'outline' | 'filled';
+  /** Numeric zero drops tone to neutral + dims (data-empty). Default on. */
+  zeroNeutral?: boolean;
+  as?: 'div' | 'li';
+  className?: string;
+}
+
+export function StatTile({
+  label,
+  value,
+  detail,
+  tone = 'neutral',
+  emphasis = 'outline',
+  zeroNeutral = true,
+  as: Tag = 'div',
+  className,
+}: StatTileProps) {
+  const isEmptyCount = zeroNeutral && typeof value === 'number' && value === 0;
+  const effectiveTone: StatTileTone = isEmptyCount ? 'neutral' : tone;
+  return (
+    <Tag
+      className={cn(
+        'flex min-w-0 flex-col items-start gap-1',
+        emphasis === 'outline'
+          ? 'rounded-[var(--radius-surface)] border border-[var(--card-border-color,var(--border))] bg-[var(--card-bg,var(--background))] p-3 shadow-[var(--card-shadow,none)]'
+          : 'rounded-[var(--radius-control)] bg-[var(--foreground-5)] p-3',
+        emphasis === 'outline' ? TONE_BORDER_CLASS[effectiveTone] : '',
+        isEmptyCount ? 'opacity-[var(--opacity-disabled)]' : '',
+        className,
+      )}
+      data-slot="stat-tile"
+      data-tone={effectiveTone}
+      data-empty={isEmptyCount ? 'true' : undefined}
+    >
+      <span
+        className={cn(
+          'font-semibold leading-tight text-foreground [font-variant-numeric:tabular-nums]',
+          emphasis === 'outline' ? 'text-[length:var(--font-size-stat)]' : 'text-[length:var(--font-size-ui)]',
+          TONE_VALUE_CLASS[effectiveTone],
+        )}
+        data-slot="stat-tile-value"
+      >
+        {value}
+      </span>
+      <span
+        className="text-[length:var(--font-size-caption)] tracking-wide text-[color:var(--foreground-secondary)]"
+        data-slot="stat-tile-label"
+      >
+        {label}
+      </span>
+      {detail != null && (
+        <span
+          className="text-[length:var(--font-size-caption)] text-[color:var(--muted-foreground)]"
+          data-slot="stat-tile-detail"
+        >
+          {detail}
+        </span>
+      )}
+    </Tag>
+  );
+}


### PR DESCRIPTION
Round 4 of notes/ui-convergence-map-2026-07-09.md, executed inline after the agent run was cancelled.

- **One primitive** (packages/ui/src/primitives/stat-tile.tsx, Tailwind-portable like DialogHeader): value slot bakes tabular-nums; emphasis outline|filled; tone paints value ink + (outline) border tint; numeric zero → neutral + dim everywhere (permission's false-alarm rationale generalized)
- **Migrated**: permission summary + health summary (the literal twins), MetricCard (thin alias retained), daily-review totals cell
- **Typography ladder** gains --font-size-stat: 20px — the typography-converge contract rejected my 1.5em arbitrary literal, which is the governance loop doing its job; same for card-converge/radius/tabular-nums/roadmap contracts, each re-pinned to the new form
- **Screenshot net catch**: the first build shipped with a missing import (vite builds don't typecheck) and the health page crashed — caught by the CDP capture, fixed, and full `npm run typecheck` added to this round's gate

Desktop 2297/2297 + ui 46/46 exit-code gated; dead-css, alignment auditor, health/permission captures all verified.