### PR TITLE
fix(ci): portable electron launch for alignment auditor

### DIFF
--- a/scripts/audit-alignment.mjs
+++ b/scripts/audit-alignment.mjs
@@ -12,7 +12,26 @@ import { spawn } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 import { tmpdir } from 'node:os';
+
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+const DESKTOP_DIR = join(ROOT, 'apps', 'desktop');
+const FIXTURES = [
+  'module-skills',
+  'module-daily-review',
+  'plan-reminders',
+  'settings-general',
+  'fetched-empty',
+  'settings-data',
+  'settings-gateway',
+  'turn-narrative',
+  'settings-permissions',
+];
+const BOOT_TIMEOUT_MS = Number(process.env.AUDIT_BOOT_TIMEOUT_MS ?? 30_000);
+const SETTLE_MS = Number(process.env.AUDIT_SETTLE_MS ?? 2_500);
+let port = Number(process.env.AUDIT_PORT_BASE ?? 14_600);
+let totalIssues = 0;
+let fixtureErrors = 0;
+
 // Resolve via the electron package export so Linux CI gets
 // `electron/dist/electron` and macOS gets `Electron.app/.../Electron`.
 // Hardcoding the .app path is what broke the ubuntu-latest e2e job in #695.
@@ -27,12 +46,80 @@ async function resolveElectronBin() {
   console.error('[audit-alignment] electron resolved but exposed no binary path; run `npm install`.');
   process.exit(2);
 }
-const ELECTRON = await resolveElectronBin();
-const FIXTURES=['module-skills','module-daily-review','plan-reminders','settings-general','fetched-empty','settings-data','settings-gateway','turn-narrative','settings-permissions'];
-let port=Number(process.env.AUDIT_PORT_BASE ?? 14600);
-let totalIssues=0;
-let fixtureErrors=0;
-const EXPR=`(()=>{
+
+function launchArgs(debugPort, userDataDir) {
+  // Chromium/Electron switches must come before the app path. Mirror the
+  // capture-screenshots / Playwright e2e launch: cwd=apps/desktop, app='.'.
+  const args = [
+    `--remote-debugging-port=${debugPort}`,
+    `--user-data-dir=${userDataDir}`,
+  ];
+  // Headless Linux runners (GitHub Actions) need these; macOS/Windows e2e
+  // already pass without them. Playwright's chromium launcher adds the same
+  // set — raw electron spawn does not.
+  if (process.platform === 'linux') {
+    args.push('--no-sandbox', '--disable-gpu', '--disable-dev-shm-usage');
+  }
+  args.push('.');
+  return args;
+}
+
+function tail(buf, n = 600) {
+  const s = buf.toString();
+  return s.length <= n ? s : s.slice(-n);
+}
+
+/** Poll CDP until a page target appears, or the process exits / times out. */
+async function waitForPageTarget(debugPort, child, stderrBuf, stdoutBuf) {
+  const started = Date.now();
+  while (Date.now() - started < BOOT_TIMEOUT_MS) {
+    if (child.exitCode !== null || child.signalCode !== null) {
+      throw new Error(
+        `electron exited code=${child.exitCode} signal=${child.signalCode}` +
+          ` stderr=${JSON.stringify(tail(stderrBuf))}` +
+          ` stdout=${JSON.stringify(tail(stdoutBuf))}`,
+      );
+    }
+    try {
+      const list = await (await fetch(`http://127.0.0.1:${debugPort}/json/list`)).json();
+      const page = list.find((t) => t.type === 'page' && t.webSocketDebuggerUrl);
+      if (page) return page;
+    } catch {
+      // not listening yet
+    }
+    await new Promise((r) => setTimeout(r, 250));
+  }
+  throw new Error(
+    `CDP timeout after ${BOOT_TIMEOUT_MS}ms` +
+      ` stderr=${JSON.stringify(tail(stderrBuf))}` +
+      ` stdout=${JSON.stringify(tail(stdoutBuf))}`,
+  );
+}
+
+function cdpSend(ws) {
+  let id = 0;
+  return (method, params) =>
+    new Promise((res, rej) => {
+      const i = ++id;
+      const onMessage = (e) => {
+        let d;
+        try {
+          d = JSON.parse(e.data);
+        } catch (err) {
+          rej(err);
+          return;
+        }
+        if (d.id !== i) return;
+        ws.removeEventListener('message', onMessage);
+        if (d.error) rej(new Error(d.error.message ?? JSON.stringify(d.error)));
+        else res(d.result);
+      };
+      ws.addEventListener('message', onMessage);
+      ws.send(JSON.stringify({ id: i, method, params }));
+    });
+}
+
+const EXPR = `(()=>{
   const controls=[...document.querySelectorAll('button,[role=button],[role=switch],input,select,[role=combobox],[role=tab]')].filter(e=>{
     const r=e.getBoundingClientRect();
     const cs=getComputedStyle(e);
@@ -67,31 +154,62 @@ const EXPR=`(()=>{
   }
   return JSON.stringify(issues.slice(0,12));
 })()`;
-for(const fx of FIXTURES){
-  const P=port++;
-  const child=spawn(ELECTRON,[ROOT+'/apps/desktop','--remote-debugging-port='+P,'--user-data-dir='+join(tmpdir(),'maka-audit-'+P+'-'+process.pid)],{env:{...process.env,MAKA_VISUAL_SMOKE_FIXTURE:fx,MAKA_VISUAL_SMOKE_THEME:'light'},stdio:'ignore'});
+
+const ELECTRON = await resolveElectronBin();
+
+for (const fx of FIXTURES) {
+  const P = port++;
+  const userDataDir = join(tmpdir(), `maka-audit-${P}-${process.pid}`);
+  const stderrBuf = { s: '', toString() { return this.s; } };
+  const stdoutBuf = { s: '', toString() { return this.s; } };
+  const child = spawn(ELECTRON, launchArgs(P, userDataDir), {
+    cwd: DESKTOP_DIR,
+    env: {
+      ...process.env,
+      MAKA_VISUAL_SMOKE_FIXTURE: fx,
+      MAKA_VISUAL_SMOKE_THEME: 'light',
+    },
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  child.stderr?.on('data', (d) => {
+    stderrBuf.s += d;
+    if (stderrBuf.s.length > 8_000) stderrBuf.s = stderrBuf.s.slice(-4_000);
+  });
+  child.stdout?.on('data', (d) => {
+    stdoutBuf.s += d;
+    if (stdoutBuf.s.length > 8_000) stdoutBuf.s = stdoutBuf.s.slice(-4_000);
+  });
   // Surface spawn failures (ENOENT etc.) into the try/catch instead of an
   // unhandled 'error' event that crashes the process before fixtureErrors++.
-  const launchError=new Promise((_,rej)=>child.once('error',rej));
-  try{
-    await Promise.race([new Promise(r=>setTimeout(r,8500)),launchError]);
-    const list=await (await fetch(`http://127.0.0.1:${P}/json/list`)).json();
-    const page=list.find(t=>t.type==='page');
-    const ws=new WebSocket(page.webSocketDebuggerUrl);
-    await new Promise(r=>ws.onopen=r);
-    let id=0; const send=(m,p)=>new Promise(res=>{const i=++id;const h=e=>{const d=JSON.parse(e.data);if(d.id===i){ws.removeEventListener('message',h);res(d.result);}};ws.addEventListener('message',h);ws.send(JSON.stringify({id:i,method:m,params:p}));});
-    const r=await send('Runtime.evaluate',{expression:EXPR,returnByValue:true});
-    console.log('==',fx,'==');
-    const arr=JSON.parse(r.result.value);
-    for(const i of arr) console.log(JSON.stringify(i));
-    totalIssues+=arr.length;
-    if(!arr.length) console.log('(clean)');
-  }catch(e){console.log('==',fx,'== ERROR',e.message);fixtureErrors++;}
+  const launchError = new Promise((_, rej) => child.once('error', rej));
+  try {
+    const page = await Promise.race([waitForPageTarget(P, child, stderrBuf, stdoutBuf), launchError]);
+    // Fixture paint settles after the page target appears; fixed 8.5s was both
+    // slow on warm macOS and still insufficient when boot itself never finished.
+    await new Promise((r) => setTimeout(r, SETTLE_MS));
+    const ws = new WebSocket(page.webSocketDebuggerUrl);
+    await new Promise((r, j) => {
+      ws.addEventListener('open', r, { once: true });
+      ws.addEventListener('error', () => j(new Error('cdp websocket error')), { once: true });
+    });
+    const send = cdpSend(ws);
+    const r = await send('Runtime.evaluate', { expression: EXPR, returnByValue: true });
+    console.log('==', fx, '==');
+    const arr = JSON.parse(r.result.value);
+    for (const i of arr) console.log(JSON.stringify(i));
+    totalIssues += arr.length;
+    if (!arr.length) console.log('(clean)');
+    try { ws.close(); } catch { /* ignore */ }
+  } catch (e) {
+    console.log('==', fx, '== ERROR', e.message);
+    fixtureErrors++;
+  }
   child.kill('SIGKILL');
 }
+
 // CI semantics: alignment findings fail the run; fixture-level launch errors
 // fail too (a fixture that can't boot means the audit didn't actually cover it).
-if(totalIssues>0 || fixtureErrors>0){
+if (totalIssues > 0 || fixtureErrors > 0) {
   console.log(`FAIL: ${totalIssues} alignment issue(s), ${fixtureErrors} fixture error(s)`);
   process.exit(1);
 }

--- a/scripts/audit-alignment.mjs
+++ b/scripts/audit-alignment.mjs
@@ -13,7 +13,21 @@ import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 import { tmpdir } from 'node:os';
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
-const ELECTRON=ROOT+'/node_modules/electron/dist/Electron.app/Contents/MacOS/Electron';
+// Resolve via the electron package export so Linux CI gets
+// `electron/dist/electron` and macOS gets `Electron.app/.../Electron`.
+// Hardcoding the .app path is what broke the ubuntu-latest e2e job in #695.
+async function resolveElectronBin() {
+  try {
+    const bin = (await import('electron')).default;
+    if (typeof bin === 'string') return bin;
+  } catch (err) {
+    console.error('[audit-alignment] electron not resolvable (run `npm install`):', err);
+    process.exit(2);
+  }
+  console.error('[audit-alignment] electron resolved but exposed no binary path; run `npm install`.');
+  process.exit(2);
+}
+const ELECTRON = await resolveElectronBin();
 const FIXTURES=['module-skills','module-daily-review','plan-reminders','settings-general','fetched-empty','settings-data','settings-gateway','turn-narrative','settings-permissions'];
 let port=Number(process.env.AUDIT_PORT_BASE ?? 14600);
 let totalIssues=0;
@@ -56,8 +70,11 @@ const EXPR=`(()=>{
 for(const fx of FIXTURES){
   const P=port++;
   const child=spawn(ELECTRON,[ROOT+'/apps/desktop','--remote-debugging-port='+P,'--user-data-dir='+join(tmpdir(),'maka-audit-'+P+'-'+process.pid)],{env:{...process.env,MAKA_VISUAL_SMOKE_FIXTURE:fx,MAKA_VISUAL_SMOKE_THEME:'light'},stdio:'ignore'});
+  // Surface spawn failures (ENOENT etc.) into the try/catch instead of an
+  // unhandled 'error' event that crashes the process before fixtureErrors++.
+  const launchError=new Promise((_,rej)=>child.once('error',rej));
   try{
-    await new Promise(r=>setTimeout(r,8500));
+    await Promise.race([new Promise(r=>setTimeout(r,8500)),launchError]);
     const list=await (await fetch(`http://127.0.0.1:${P}/json/list`)).json();
     const page=list.find(t=>t.type==='page');
     const ws=new WebSocket(page.webSocketDebuggerUrl);


### PR DESCRIPTION
## Summary

Make the CDP alignment auditor actually boot on `ubuntu-latest`. #695 wired it into the e2e job as a CI gate but left a macOS-only Electron path and a launch shape that never opens DevTools on Linux, so main and open PRs (including #680) fail the Alignment audit step.

## Why

Refs #695 (CI gate introduction). Seen on #680 and #702.

On the runner the failure progressed as:

1. `ENOENT` on `Electron.app/Contents/MacOS/Electron` (hard-coded macOS binary).
2. After resolving the binary via `import('electron')`: all 9 fixtures `ERROR fetch failed` — process spawned, but `/json/list` never answered (no CDP), with `stdio: 'ignore'` hiding why.

Playwright e2e on the same job already launches Electron successfully; the auditor did not mirror that launch.

## Scope

Changed:

- `scripts/audit-alignment.mjs`
  - Resolve Electron via `import('electron')` (platform-correct binary).
  - Launch like capture-screenshots / e2e: `cwd=apps/desktop`, app path `'.'`, Chromium switches before the app path.
  - On Linux: `--no-sandbox`, `--disable-gpu`, `--disable-dev-shm-usage`.
  - Pipe stdout/stderr; poll CDP until a page target appears (default 30s) instead of a blind 8.5s sleep.
  - Surface spawn errors and process tails in per-fixture errors; keep fail-on-findings / fail-on-fixture-errors CI semantics.

Not included:

- No product UI or fixture content changes.
- No change to the set of audited fixtures or alignment thresholds.
- Not folding this into #680 (independent CI infrastructure fix).

## Verification

- Local macOS (main checkout with built renderer): fixed launch shape reaches CDP page target in ~400ms for `fetched-empty` (`--remote-debugging-port` + `cwd=apps/desktop` + `'.'`).
- `import('electron')` on macOS resolves to `.../Electron.app/Contents/MacOS/Electron` (package export, not a hand-built string).
- CI e2e job on this PR is the real Linux gate (path resolution + boot + audit).

## User-facing impact

None. CI-only script fix; no CHANGELOG, docs, migrations, or breaking changes.

## Reviewer notes

- Risk is low and localized to `scripts/audit-alignment.mjs`. Rollback restores the broken hard-coded path / launch.
- If CI still fails after this, fixture ERROR lines now include stderr/stdout tails and exit code so the next root cause is visible.
- Prefer landing on main quickly so open PRs can re-run without carrying this commit themselves.

## Checklist

- [x] Scope matches the PR title and excludes unrelated changes
- [x] Verification lists commands/results, or explains why they were not run
- [x] User-facing impact, docs, changelog, migrations, and breaking changes are noted, or marked none
- [x] Risk, rollback, or review focus is called out for non-trivial changes
- [x] UI changes include screenshots/video, or explain why not applicable — N/A, CI script only