### PR TITLE
refactor(ui): EmptyState inline variant — last note strips converge (R5 tail)

### DIFF
--- a/apps/desktop/src/renderer/settings/permission-center-page.tsx
+++ b/apps/desktop/src/renderer/settings/permission-center-page.tsx
@@ -18,7 +18,7 @@ import type {
   PermissionSnapshot,
 } from '@maka/core';
 import { OS_PERMISSION_IDS } from '@maka/core';
-import { Button, Badge, RelativeTime, PageHeader, SectionHeader, StatTile, useToast } from '@maka/ui';
+import { Button, Badge, EmptyState, RelativeTime, PageHeader, SectionHeader, StatTile, useToast } from '@maka/ui';
 import { settingsActionErrorMessage } from './settings-error-copy';
 import { statusBadgeVariant } from './settings-status-badge';
 import { SettingsSkeletonStack } from './settings-skeleton';
@@ -478,7 +478,7 @@ function CapabilityRow(props: { capability: CapabilitySnapshot }) {
       */}
       <div className="settingsCapabilityAuditSlot" aria-hidden={capability.auditEvents.length === 0}>
         {capability.auditEvents.length === 0 ? (
-          <small>暂无审计记录。</small>
+          <EmptyState variant="inline" title="暂无审计记录" body="" />
         ) : (
           <ul aria-label={`${capability.label}审计记录列表`}>
             {capability.auditEvents.slice(-3).map((event, index) => (

--- a/packages/ui/src/daily-review-panel.tsx
+++ b/packages/ui/src/daily-review-panel.tsx
@@ -392,9 +392,12 @@ export function DailyReviewPanel(props: {
             </Alert>
           )}
           {archives.length === 0 && !archiveError ? (
-            <p className="maka-daily-review-archive-empty">
-              还没有生成报告。点击上方按钮后，报告会保存到本机并显示在这里。
-            </p>
+            <EmptyState
+              variant="inline"
+              extraClassName="maka-daily-review-archive-empty"
+              title="还没有生成报告"
+              body="点击上方按钮后，报告会保存到本机并显示在这里。"
+            />
           ) : (
             <div className="maka-daily-review-archive-layout">
               {/* PR-DAILYREVIEW-ARCHIVE-ROW-A11Y-0 (round 7/30):

--- a/packages/ui/src/empty-state.tsx
+++ b/packages/ui/src/empty-state.tsx
@@ -19,9 +19,14 @@ type EmptyStateIcon = typeof Search;
  * pile of "empty-state action variants".
  */
 interface EmptyStateProps {
-  Icon: EmptyStateIcon;
+  /** Required for the card variant; unused by inline. */
+  Icon?: EmptyStateIcon;
   title: string;
   body: ReactNode;
+  /** Convergence R5: `inline` renders a single quiet muted line (no icon,
+   *  no card) for in-flow "waiting/none yet" notes; `card` is the full
+   *  empty surface. */
+  variant?: 'card' | 'inline';
   cta?: { label: string; onClick: () => void; disabled?: boolean };
   secondaryCta?: { label: string; onClick: () => void; disabled?: boolean };
   /** Optional extra class on the container (e.g. `maka-plan-empty`). */
@@ -31,6 +36,21 @@ interface EmptyStateProps {
 }
 
 export function EmptyState(props: EmptyStateProps) {
+  if (props.variant === 'inline') {
+    return (
+      <p
+        className={cn(
+          'm-0 text-[length:var(--font-size-ui)] leading-normal text-[color:var(--muted-foreground)]',
+          props.extraClassName,
+        )}
+        data-slot="empty-state-inline"
+        data-empty-view={props.dataEmptyView}
+      >
+        {props.title}
+        {props.body != null && props.body !== '' ? <> · {props.body}</> : null}
+      </p>
+    );
+  }
   const className = cn(
     'maka-empty-state rounded-md border-border bg-card/70 p-8 text-card-foreground shadow-maka-panel',
     props.extraClassName,
@@ -39,7 +59,7 @@ export function EmptyState(props: EmptyStateProps) {
     <Empty className={className} data-empty-view={props.dataEmptyView}>
       <EmptyHeader>
         <EmptyMedia variant="icon" className="maka-empty-state-media">
-          <props.Icon className="maka-empty-state-icon size-6 text-muted-foreground" />
+          {props.Icon && <props.Icon className="maka-empty-state-icon size-6 text-muted-foreground" />}
         </EmptyMedia>
         <EmptyTitle className="maka-empty-state-title">{props.title}</EmptyTitle>
         <EmptyDescription className="maka-empty-state-body">{props.body}</EmptyDescription>

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -61,6 +61,7 @@ export * from './primitives/menu.js';
 export * from './primitives/dialog-header.js';
 export * from './primitives/stat-tile.js';
 export * from './primitives/section-header.js';
+export { EmptyState } from './empty-state.js';
 export * from './primitives/choice-card.js';
 export * from './primitives/settings-segmented.js';
 export * from './primitives/settings-select.js';


### PR DESCRIPTION
Completes round 5's remaining scope from the convergence map: `EmptyState` gains `variant='inline'` (single muted line, no icon/card) and the two live hand-rolled note strips migrate (daily-review archive-empty, permission 暂无审计记录). ActionRow assessment: `settingsActionRow` is already the shared implementation across 9 settings pages; the three module-page clusters carry distinct pinned layout (wrap/justify variants) where a primitive would add a hook without removing duplication — recorded on the map as intentionally closed. Desktop 2297/2297 + ui 46/46 + typecheck + dead-css clean.