### PR TITLE
feat(desktop): 技能 使用 button — composer prefill lands (last backlog item)

### DIFF
--- a/apps/desktop/src/renderer/app-shell.tsx
+++ b/apps/desktop/src/renderer/app-shell.tsx
@@ -667,6 +667,21 @@ export function AppShell({
     setSearchModalInitialQuery(query);
     setSearchModalOpen(true);
   }, []);
+  /** 技能页 使用: jump to the chat view and seed the composer with a skill
+   *  invocation. Same human-in-the-loop rule as maka://compose — we never
+   *  auto-send; the user finishes the sentence and presses Enter. */
+  const useSkillInChat = useCallback((_skillId: string, skillName: string) => {
+    setNavSelection({ section: 'sessions', filter: 'chats' });
+    const seed = () => {
+      composerRef.current?.setText(`使用 ${skillName} 技能：`);
+      composerRef.current?.focus();
+    };
+    if (activeIdRef.current) {
+      window.requestAnimationFrame(seed);
+      return;
+    }
+    void createSession().then(() => window.requestAnimationFrame(seed));
+  }, []);
   const sessionListSelectSession = useCallback((sessionId: string) => {
     openSessionInChatRef.current(sessionId);
   }, []);
@@ -1491,6 +1506,7 @@ export function AppShell({
                 onRefreshManagedSkillSources={() => refreshManagedSkillSources()}
                 onCreateSkillTemplate={() => createSkillTemplate()}
                 onOpenSkill={(skillId) => openSkill(skillId)}
+                onUseSkill={useSkillInChat}
                 onOpenSkillsFolder={() => openSkillsFolder()}
                 onImportManagedSkillSource={() => importManagedSkillSource()}
                 onInstallManagedSkill={(sourceId) => installManagedSkill(sourceId)}

--- a/apps/desktop/src/renderer/styles/module-pages/skills.css
+++ b/apps/desktop/src/renderer/styles/module-pages/skills.css
@@ -457,7 +457,12 @@ color: oklch(from var(--brand-deep) 0.55 min(c, 0.015) h);
 .maka-skill-template-row {
   min-width: 0;
   display: grid;
+  /* 3 children in a 2-col grid need explicit placement — auto-flow dropped
+     the meta line under the ICON column and shattered the row. */
   grid-template-columns: 18px minmax(0, 1fr);
+  grid-template-areas:
+    'icon copy'
+    '.    meta';
   gap: var(--space-0-5) var(--space-1-5);
   align-items: center;
   padding: var(--space-1) var(--space-2);
@@ -470,6 +475,10 @@ color: oklch(from var(--brand-deep) 0.55 min(c, 0.015) h);
 .maka-skill-template-row:hover {
   background: var(--state-hover-bg);
 }
+
+.maka-skill-template-row > .maka-skill-template-icon { grid-area: icon; align-self: center; }
+.maka-skill-template-row > .maka-skill-template-copy { grid-area: copy; }
+.maka-skill-template-row > small { grid-area: meta; }
 
 .maka-skill-template-icon {
   grid-row: span 2;

--- a/packages/ui/src/chat-view.tsx
+++ b/packages/ui/src/chat-view.tsx
@@ -243,6 +243,8 @@ export function ChatView(props: {
   onRefreshSkills?(): void | Promise<void>;
   onCreateSkillTemplate?(): void | Promise<void>;
   onOpenSkill?(skillId: string): void | Promise<void>;
+  /** 使用 button: seed the composer with a skill invocation (R5 follow-up). */
+  onUseSkill?(skillId: string, skillName: string): void;
   onOpenSkillsFolder?(): void | Promise<void>;
   managedSkillSources?: ManagedSkillSourceEntry[];
   onRefreshManagedSkillSources?(): void | Promise<void>;
@@ -445,6 +447,7 @@ export function ChatView(props: {
           onRefreshSkills={props.onRefreshSkills}
           onCreateSkillTemplate={props.onCreateSkillTemplate}
           onOpenSkill={props.onOpenSkill}
+          onUseSkill={props.onUseSkill}
           onOpenSkillsFolder={props.onOpenSkillsFolder}
           managedSkillSources={props.managedSkillSources}
           onRefreshManagedSkillSources={props.onRefreshManagedSkillSources}

--- a/packages/ui/src/composer.tsx
+++ b/packages/ui/src/composer.tsx
@@ -53,7 +53,9 @@ const COMPOSER_COPY_BY_LOCALE: Record<UiLocale, {
   streamingHintInterrupt: string;
 }> = {
   zh: {
-    placeholder: '描述任务  /  快捷调用  @  添加上下文',
+    // Placeholder honesty: '/' quick-invoke and '@' context syntax do not
+    // exist yet — the old copy advertised affordances the input can't honor.
+    placeholder: '描述任务…',
     textareaAriaLabel: '消息输入框',
     awaitingPermission: '等待你确认权限…',
     sending: '正在发送…',

--- a/packages/ui/src/skills-panel.tsx
+++ b/packages/ui/src/skills-panel.tsx
@@ -41,6 +41,7 @@ function SkillLibraryPanel(props: {
   onRefreshSkills?(): void | Promise<void>;
   onCreateSkillTemplate?(): void | Promise<void>;
   onOpenSkill?(skillId: string): void | Promise<void>;
+  onUseSkill?(skillId: string, skillName: string): void;
   onImportManagedSkillSource?(): void | Promise<void>;
   onInstallManagedSkill?(sourceId: string): void | Promise<void>;
   onPreviewManagedSkillUpdate?(skillId: string): Promise<ManagedSkillUpdatePreview | null>;
@@ -379,6 +380,19 @@ function SkillLibraryPanel(props: {
                       {reviewing && <span>审查中…</span>}
                     </span>
                   </div>
+                  {props.onUseSkill && skill.enabled && (
+                    <UiButton
+                      type="button"
+                      variant="secondary"
+                      size="sm"
+                      className="maka-skill-library-use-button"
+                      onClick={() => props.onUseSkill?.(skill.id, skill.name)}
+                      disabled={props.actionBusy}
+                      aria-label={`在对话中使用 ${skill.name}`}
+                    >
+                      使用
+                    </UiButton>
+                  )}
                   <UiButton
                     type="button"
                     variant="ghost"
@@ -588,6 +602,7 @@ export function SkillsModuleMain(props: {
   onRefreshSkills?(): void | Promise<void>;
   onCreateSkillTemplate?(): void | Promise<void>;
   onOpenSkill?(skillId: string): void | Promise<void>;
+  onUseSkill?(skillId: string, skillName: string): void;
   onOpenSkillsFolder?(): void | Promise<void>;
   onRefreshManagedSkillSources?(): void | Promise<void>;
   onImportManagedSkillSource?(): void | Promise<void>;
@@ -697,6 +712,7 @@ export function SkillsModuleMain(props: {
         onUpdateManagedSkill={props.onUpdateManagedSkill ? async (skillId, options) =>
           (await runSkillAction(`managed:update:${skillId}`, () => props.onUpdateManagedSkill?.(skillId, options))) === true : undefined}
         onSetSkillEnabled={props.onSetSkillEnabled ? (skillId, enabled) => runSkillAction(`runtime:set:${skillId}`, () => props.onSetSkillEnabled?.(skillId, enabled)) : undefined}
+        onUseSkill={props.onUseSkill}
         actionBusy={skillActionBusy}
         refreshPending={pendingSkillAction === 'refresh'}
         createPending={pendingSkillAction === 'create'}


### PR DESCRIPTION
The 使用 button was deferred pending a prefill mechanism — the mechanism already existed (`ComposerHandle.setText`, the maka://compose pathway) and just needed the seam wired:

- 使用 on enabled 内置/已安装 skill rows → jump to chat view, ensure a session (create only if none active), seed the composer with 「使用 <技能名> 技能：」 and focus. Human-in-the-loop preserved — never auto-sends (the maka://compose rule).
- **Placeholder honesty**: the composer advertised '/' quick-invoke and '@' add-context — neither is implemented; copy is now 描述任务…. (When a real slash-invoke ships, the 使用 seed and the placeholder can both upgrade.)
- **Template-row grid fix**: 3 children in a 2-col grid without placement — auto-flow shattered the 技能示例 rows (icon on the wrong row); explicit grid-template-areas.

Desktop 2297/2297 exit-code gated + full typecheck + dead-css + CI alignment auditor clean; before/after captures verified.