### PR TITLE
Feat/add litellm provider

### DIFF
--- a/apps/desktop/src/renderer/settings/provider-brand-marks.tsx
+++ b/apps/desktop/src/renderer/settings/provider-brand-marks.tsx
@@ -133,6 +133,7 @@ export function ProviderBrandMark({ type }: { type: ProviderType }): ReactElemen
       return <Claude />;
     case 'openai':
     case 'codex-subscription':
+    case 'litellm':
     case 'openai-compatible':
       return <OpenAI />;
     case 'google':

--- a/apps/desktop/src/renderer/settings/provider-display.tsx
+++ b/apps/desktop/src/renderer/settings/provider-display.tsx
@@ -38,6 +38,8 @@ export function providerDisplay(type: ProviderType): { name: string; description
       return { name: 'MiniMax', description: 'MiniMax · Anthropic 兼容', badge: 'API' };
     case 'MiniMax-cn':
       return { name: 'MiniMax 中国站', description: 'MiniMax 中国站 · Anthropic 兼容', badge: 'API' };
+    case 'litellm':
+      return { name: 'LiteLLM', description: 'AI gateway proxy for 100+ LLM providers.', badge: 'Gateway' };
     case 'ollama':
       return { name: 'Ollama', description: '本机运行 · 离线可用', badge: 'Local' };
     case 'openai-compatible':

--- a/packages/core/src/__tests__/llm-connections.test.ts
+++ b/packages/core/src/__tests__/llm-connections.test.ts
@@ -191,6 +191,19 @@ describe('provider URL defaults', () => {
     assert.equal(PROVIDER_DEFAULTS['codex-subscription'].description, 'ChatGPT/Codex account OAuth path for OpenAI Responses models.');
   });
 
+  it('defines LiteLLM as an OpenAI-protocol custom gateway with localhost default', () => {
+    const litellm = PROVIDER_DEFAULTS['litellm'];
+    assert.equal(litellm.label, 'LiteLLM');
+    assert.equal(litellm.protocol, 'openai');
+    assert.equal(litellm.category, 'custom');
+    assert.equal(litellm.baseUrl, 'http://localhost:4000/v1');
+    assert.equal(litellm.authKind, 'api_key');
+    assert.equal(litellm.backendKind, 'ai-sdk');
+    assert.equal(litellm.status, 'ready');
+    assert.equal(litellm.catalogBadge, 'Gateway');
+    assert.deepEqual(litellm.fallbackModels, []);
+  });
+
   it('keeps Kimi Coding Plan separate from Moonshot API key access', () => {
     assert.equal(PROVIDER_DEFAULTS['kimi-coding-plan'].baseUrl, 'https://api.kimi.com/coding/v1');
     assert.equal(PROVIDER_DEFAULTS['kimi-coding-plan'].signupUrl, 'https://www.kimi.com/code/console');
@@ -240,6 +253,19 @@ describe('persistedBaseUrl', () => {
     assert.equal(persistedBaseUrl('openai', custom), custom);
     assert.equal(persistedBaseUrl('openai', `  ${custom}  `), custom, 'whitespace is trimmed');
     assert.equal(persistedBaseUrl('google', 'https://my-gemini-proxy.example.com/v1beta'), 'https://my-gemini-proxy.example.com/v1beta');
+  });
+
+  it('collapses litellm default localhost URL to undefined (no override to persist)', () => {
+    assert.equal(
+      persistedBaseUrl('litellm', 'http://localhost:4000/v1'),
+      undefined,
+      'litellm default must not be persisted as an override',
+    );
+  });
+
+  it('persists a custom litellm proxy URL as a real override', () => {
+    const custom = 'https://litellm.company.internal/v1';
+    assert.equal(persistedBaseUrl('litellm', custom), custom);
   });
 
   it('persists a custom override for openai-compatible (whose default is the empty string)', () => {

--- a/packages/core/src/llm-connections.ts
+++ b/packages/core/src/llm-connections.ts
@@ -19,6 +19,7 @@ export type ProviderType =
   | 'zai-coding-plan'
   | 'MiniMax'
   | 'MiniMax-cn'
+  | 'litellm'
   | 'ollama'
   | 'openai-compatible'
   | 'claude-subscription'
@@ -236,6 +237,19 @@ export const PROVIDER_DEFAULTS: Record<ProviderType, ProviderDefaults> = {
     catalogBadge: 'API',
     signupUrl: 'https://platform.minimaxi.com/user-center/basic-information/interface-key',
   },
+  litellm: {
+    label: 'LiteLLM',
+    description: 'AI gateway proxy for 100+ LLM providers.',
+    baseUrl: 'http://localhost:4000/v1',
+    authKind: 'api_key',
+    backendKind: 'ai-sdk',
+    fallbackModels: [],
+    status: 'ready',
+    protocol: 'openai',
+    category: 'custom',
+    catalogBadge: 'Gateway',
+    signupUrl: 'https://docs.litellm.ai/',
+  },
   ollama: {
     label: 'Ollama',
     description: 'Local models from Ollama on localhost.',
@@ -327,6 +341,7 @@ export const CATALOG_PROVIDER_TYPES: ProviderType[] = [
   'openai',
   'google',
   'ollama',
+  'litellm',
   'openai-compatible',
 ];
 

--- a/packages/runtime/src/__tests__/model-factory-thinking.test.ts
+++ b/packages/runtime/src/__tests__/model-factory-thinking.test.ts
@@ -2,7 +2,7 @@ import assert from 'node:assert/strict';
 import { describe, test } from 'node:test';
 import type { LlmConnection } from '@maka/core';
 import { thinkingVariantsForModel, type ThinkingLevel } from '@maka/core';
-import { changesBackendConfig, buildProviderOptions } from '@maka/runtime';
+import { changesBackendConfig, buildProviderOptions, getAIModel } from '@maka/runtime';
 
 function conn(providerType: LlmConnection['providerType'], slug = 'test'): LlmConnection {
   return {
@@ -74,6 +74,48 @@ describe('buildProviderOptions: thinking level', () => {
   test('a level the model does not support is dropped (defensive)', () => {
     assert.deepEqual(buildProviderOptions(conn('openai'), 'gpt-4o', 'high'), { openai: {} });
     assert.deepEqual(buildProviderOptions(conn('anthropic'), 'claude-haiku-4-5', 'max'), { anthropic: {} });
+  });
+});
+
+describe('getAIModel: litellm provider', () => {
+  test('creates an OpenAI-compatible client with provider name "litellm" and correct modelId', () => {
+    const model = getAIModel({
+      connection: conn('litellm', 'litellm-gateway'),
+      apiKey: 'sk-test-key',
+      modelId: 'gpt-4o',
+    });
+    assert.equal(model.modelId, 'gpt-4o');
+    assert.equal(model.provider, 'litellm.chat');
+  });
+
+  test('uses the connection baseUrl override when provided', () => {
+    const model = getAIModel({
+      connection: { ...conn('litellm', 'litellm-custom'), baseUrl: 'https://litellm.company.internal/v1' },
+      apiKey: 'sk-test-key',
+      modelId: 'claude-sonnet-4-5-20250929',
+    });
+    assert.equal(model.modelId, 'claude-sonnet-4-5-20250929');
+    assert.equal(model.provider, 'litellm.chat');
+  });
+
+  test('falls back to localhost:4000 default when no baseUrl override is set', () => {
+    const model = getAIModel({
+      connection: conn('litellm', 'litellm-default'),
+      apiKey: 'sk-test-key',
+      modelId: 'gpt-4o-mini',
+    });
+    // The model is created successfully with default base URL
+    assert.equal(model.provider, 'litellm.chat');
+    assert.equal(model.modelId, 'gpt-4o-mini');
+  });
+});
+
+describe('buildProviderOptions: litellm falls through to default (empty options)', () => {
+  test('litellm returns empty options regardless of thinking level', () => {
+    assert.deepEqual(buildProviderOptions(conn('litellm'), 'gpt-4o'), {});
+    assert.deepEqual(buildProviderOptions(conn('litellm'), 'gpt-4o', 'high'), {});
+    assert.deepEqual(buildProviderOptions(conn('litellm'), 'gpt-4o', 'off'), {});
+    assert.deepEqual(buildProviderOptions(conn('litellm'), 'claude-sonnet-4-5-20250929'), {});
   });
 });
 

--- a/packages/runtime/src/model-factory.ts
+++ b/packages/runtime/src/model-factory.ts
@@ -100,6 +100,13 @@ export function getAIModel(input: ModelFactoryInput): LanguageModelV3 {
         baseURL: baseURL || 'https://api.z.ai/api/coding/paas/v4',
       }).chatModel(modelId);
 
+    case 'litellm':
+      return createOpenAICompatible({
+        name: 'litellm',
+        apiKey,
+        baseURL: baseURL || 'http://localhost:4000/v1',
+      }).chatModel(modelId);
+
     case 'ollama':
       return createOpenAICompatible({
         name: 'ollama',

--- a/packages/ui/src/chat-model-helpers.ts
+++ b/packages/ui/src/chat-model-helpers.ts
@@ -53,6 +53,7 @@ const PROVIDER_SHORT_LABEL = {
   google: 'Google',
   deepseek: 'DeepSeek',
   moonshot: 'Moonshot',
+  litellm: 'LiteLLM',
   ollama: 'Ollama',
   'kimi-coding-plan': 'Kimi',
   'zai-coding-plan': 'Z.AI',


### PR DESCRIPTION
## Summary

- Adds [LiteLLM](https://github.com/BerriAI/litellm) as a first-class provider in Maka, giving users access to 100+ LLM providers (AWS Bedrock, Azure, Vertex AI, Cohere, Replicate, etc.) through a single OpenAI-compatible proxy endpoint.
- Includes model factory integration, provider defaults, UI registration, and comprehensive tests.
- Additive only - no existing providers modified.


## Changes

**Core (`packages/core/src/llm-connections.ts`):**
- Added `'litellm'` to `ProviderType` union
- Added `PROVIDER_DEFAULTS` entry: protocol `'openai'`, category `'custom'`, base URL `http://localhost:4000/v1`, auth `'api_key'`, badge `'Gateway'`
- Added `'litellm'` to `CATALOG_PROVIDER_TYPES` array

**Runtime (`packages/runtime/src/model-factory.ts`):**
- Added `case 'litellm'` in `getAIModel()` using `createOpenAICompatible()` from `@ai-sdk/openai-compatible` with name `'litellm'`, apiKey, and baseURL fallback

**UI (`apps/desktop/src/renderer/settings/`):**
- `provider-brand-marks.tsx` - Added `'litellm'` to the OpenAI brand mark case
- `provider-display.tsx` - Added display name "LiteLLM" with description and "Gateway" badge

**UI (`packages/ui/src/chat-model-helpers.ts`):**
- Added `litellm: 'LiteLLM'` to exhaustive `PROVIDER_SHORT_LABEL` map

**Tests (`packages/core/src/__tests__/llm-connections.test.ts`, +26 lines):**
- `PROVIDER_DEFAULTS['litellm']` correctness: label, protocol, category, baseUrl, authKind, backendKind, status, catalogBadge, empty fallbackModels
- `persistedBaseUrl('litellm', ...)` collapses default URL to `undefined`, persists custom overrides

**Tests (`packages/runtime/src/__tests__/model-factory-thinking.test.ts`, +43 lines):**
- `getAIModel` with litellm: correct provider namespace `'litellm.chat'` and modelId, default and custom baseUrl
- `buildProviderOptions` with litellm: falls through to default case, returns empty `{}` for all thinking levels

## Tests

**1. All 2293 tests pass (446 suites):**
```
# tests 2293
# suites 446
# pass 2293
# fail 0
# duration_ms 9982
```

**2. TypeScript build:** clean across all 7 workspaces.

## Example usage

```typescript
import { type LlmConnection } from '@maka/core';
import { getAIModel } from '@maka/runtime';

// Create a LiteLLM connection
const connection: LlmConnection = {
  slug: 'my-litellm-proxy',
  name: 'LiteLLM Proxy',
  providerType: 'litellm',
  baseUrl: 'http://localhost:4000/v1',  // default, pre-filled in UI
  defaultModel: 'anthropic/claude-sonnet-4-6',
  enabled: true,
  createdAt: Date.now(),
  updatedAt: Date.now(),
};

// Get AI model - uses @ai-sdk/openai-compatible under the hood
const model = getAIModel({
  connection,
  apiKey: 'sk-your-litellm-key',
  modelId: 'anthropic/claude-sonnet-4-6',
});
```

## Risk / Compatibility

- **Additive only.** No existing provider types, model factory cases, or UI components modified.
- **No new dependencies.** LiteLLM proxy speaks the OpenAI protocol, so the existing `@ai-sdk/openai-compatible` package handles everything.
- **Protocol: `'openai'`.** Model discovery automatically uses the standard `/v1/models` endpoint.
- **Type-safe.** `satisfies Record<ProviderType, string>` compile-time check ensures the new provider is registered in every exhaustive map.
