### PR TITLE
fix(desktop): prevent startup skeleton flash

### DIFF
--- a/apps/desktop/src/main/__tests__/window-reveal-after-first-commit-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/window-reveal-after-first-commit-contract.test.ts
@@ -249,8 +249,19 @@ describe('window reveal wiring (PR-SHOW-AFTER-FIRST-COMMIT)', () => {
       /setTimeout\([\s\S]*?revealGate\.markReady\(mainWindow\)[\s\S]*?SHOW_FALLBACK_TIMEOUT_MS\)/,
       'the fallback timer must reveal through the reveal gate',
     );
-    // Timer must not run for visual-smoke windows, and must clear on close.
-    assert.match(src, /if \(!keepHiddenForVisualSmoke\) \{\s*showFallbackTimer = setTimeout/);
+    // The countdown starts after the document load, otherwise a cold Vite
+    // transform can consume the timeout and reveal the preload skeleton.
+    const rendererLoadIndex = src.indexOf('await mainWindow.loadURL');
+    const fallbackTimerIndex = src.indexOf('showFallbackTimer = setTimeout');
+    assert.notEqual(rendererLoadIndex, -1);
+    assert.notEqual(fallbackTimerIndex, -1);
+    assert.ok(fallbackTimerIndex > rendererLoadIndex, 'fallback must start after renderer load');
+    // Timer must not run for visual-smoke or already-revealed windows, and
+    // must clear on close.
+    assert.match(
+      src,
+      /if \(!keepHiddenForVisualSmoke && !mainWindow\.isVisible\(\)\) \{\s*showFallbackTimer = setTimeout/,
+    );
     assert.match(
       src,
       /mainWindow\.on\('close', \(\) => \{\s*clearShowFallbackTimer\(\);/,
@@ -308,13 +319,17 @@ describe('window reveal wiring (PR-SHOW-AFTER-FIRST-COMMIT)', () => {
     );
   });
 
-  it('the renderer signals ready after the first commit, unconditionally', async () => {
+  it('the renderer signals ready only after the committed UI has painted', async () => {
     const src = await readRepoFile('apps/desktop/src/renderer/app.tsx');
-    // useLayoutEffect fires post-commit; the empty dep array makes it fire once.
-    // The guarded chain must not depend on the onboarding snapshot value.
+    // A layout effect is still before paint and can reveal the BrowserWindow
+    // while Chromium's last composited frame is the preload skeleton. A nested
+    // animation frame waits through one paint before notifying main.
+    assert.doesNotMatch(src, /useLayoutEffect/);
     assert.match(
       src,
-      /useLayoutEffect\(\(\) => \{\s*void window\.maka\?\.appWindow\?\.notifyRendererReady\?\.\(\);\s*\}, \[\]\)/,
+      /useEffect\(\(\) => \{[\s\S]*?requestAnimationFrame\(\(\) => \{[\s\S]*?requestAnimationFrame\(\(\) => \{[\s\S]*?notifyRendererReady\?\.\(\)/,
     );
+    assert.match(src, /cancelAnimationFrame\(firstFrame\)/);
+    assert.match(src, /cancelAnimationFrame\(secondFrame\)/);
   });
 });

--- a/apps/desktop/src/main/main-window.ts
+++ b/apps/desktop/src/main/main-window.ts
@@ -72,9 +72,11 @@ const MAIN_WINDOW_TRAFFIC_LIGHT_POSITION = { x: 14, y: 14 } as const;
 const HIDDEN_TRAFFIC_LIGHT_POSITION = { x: -100, y: -100 } as const;
 
 // PR-SHOW-AFTER-FIRST-COMMIT: fallback reveal delay for a renderer that never
-// signals its first commit (window:notifyRendererReady). main.tsx's onboarding
-// prefetch bails at 2500ms; the remainder is headroom for load + first paint,
-// so a wedged renderer can never leave the window invisible forever.
+// signals its first painted frame (window:notifyRendererReady). main.tsx's
+// onboarding prefetch bails at 2500ms; the remainder is headroom for React +
+// first paint. The timer is armed only after loadURL/loadFile resolves, so
+// Vite compilation and document loading do not consume this budget, while a
+// wedged renderer still cannot leave the window invisible forever.
 const SHOW_FALLBACK_TIMEOUT_MS = 4000;
 
 // PR-WINDOW-TITLEBAR-0: the Windows titleBarOverlay height matches the
@@ -345,22 +347,24 @@ export function createMainWindowController(deps: MainWindowControllerDeps): Main
       void writeSavedBounds(workspaceRoot, final);
     });
 
-    // PR-SHOW-AFTER-FIRST-COMMIT: reveal fallback. The window stays hidden
-    // until the renderer signals its first commit; if the renderer wedges and
-    // never signals, reveal it anyway after SHOW_FALLBACK_TIMEOUT_MS. Skipped
-    // for visual-smoke windows, which must stay hidden; cleared on
-    // renderer-ready (notifyRendererReady) and on close.
-    if (!keepHiddenForVisualSmoke) {
-      showFallbackTimer = setTimeout(() => {
-        showFallbackTimer = undefined;
-        revealGate.markReady(mainWindow);
-      }, SHOW_FALLBACK_TIMEOUT_MS);
-    }
-
     if (process.env.VITE_DEV_SERVER_URL) {
       await mainWindow.loadURL(process.env.VITE_DEV_SERVER_URL);
     } else {
       await mainWindow.loadFile(join(import.meta.dirname, '..', '..', 'dist-renderer', 'index.html'));
+    }
+
+    // PR-SHOW-AFTER-FIRST-COMMIT: reveal fallback. Start this budget only once
+    // the renderer document has loaded. Starting it before loadURL/loadFile
+    // let a cold Vite transform or slow disk consume the whole timeout and
+    // reveal index.html's preload skeleton before React had a chance to paint.
+    // If renderer-ready arrived while loadURL/loadFile was resolving, the
+    // window is already visible and no timer is needed. Visual-smoke windows
+    // remain hidden for their whole lifecycle.
+    if (!keepHiddenForVisualSmoke && !mainWindow.isVisible()) {
+      showFallbackTimer = setTimeout(() => {
+        showFallbackTimer = undefined;
+        revealGate.markReady(mainWindow);
+      }, SHOW_FALLBACK_TIMEOUT_MS);
     }
     if (process.env.MAKA_REAL_WINDOW_SMOKE === '1') {
       emitRealWindowSmokeDiagnostic('after-load');

--- a/apps/desktop/src/renderer/app.tsx
+++ b/apps/desktop/src/renderer/app.tsx
@@ -1,4 +1,4 @@
-import { StrictMode, useLayoutEffect } from 'react';
+import { StrictMode, useEffect } from 'react';
 import { ToastProvider } from '@maka/ui';
 import { AppShell } from './app-shell';
 import { ErrorBoundary } from './error-boundary';
@@ -12,15 +12,27 @@ export function App({
 }) {
   // PR-SHOW-AFTER-FIRST-COMMIT: the BrowserWindow is created hidden
   // (main-window.ts show: false) so the OS never flashes the index.html
-  // `.maka-preload` skeleton before React paints. Signal main after the first
-  // real commit — useLayoutEffect fires post-commit — unconditionally: even
-  // when the onboarding snapshot is null and AppShell mounts its fail-soft
-  // loading state, the window should still appear. A fallback timer in main
-  // reveals it if this signal never arrives. `window.maka` is undefined
-  // outside the Electron renderer (storybook), so guard the chain like
-  // theme.ts.
-  useLayoutEffect(() => {
-    void window.maka?.appWindow?.notifyRendererReady?.();
+  // `.maka-preload` skeleton before React paints. A layout effect is too early
+  // for this signal: it runs after the DOM commit but before Chromium paints,
+  // so the main process can show the BrowserWindow while its last composited
+  // frame is still the preload skeleton. Two animation frames put the signal
+  // after at least one paint of the committed AppShell. This remains
+  // unconditional: even when the onboarding snapshot is null and AppShell
+  // mounts its fail-soft loading state, the window should still appear. The
+  // main-process fallback handles a renderer that never reaches either frame.
+  // `window.maka` is undefined outside Electron (storybook), so guard it.
+  useEffect(() => {
+    let secondFrame = 0;
+    const firstFrame = requestAnimationFrame(() => {
+      secondFrame = requestAnimationFrame(() => {
+        void window.maka?.appWindow?.notifyRendererReady?.();
+      });
+    });
+
+    return () => {
+      cancelAnimationFrame(firstFrame);
+      if (secondFrame) cancelAnimationFrame(secondFrame);
+    };
   }, []);
   return (
     <StrictMode>


### PR DESCRIPTION
## Summary

- start the fallback reveal timeout only after `loadURL` / `loadFile` completes
- notify the main process after the committed React UI has painted, using two animation frames
- extend the startup reveal contract tests to cover both timing guarantees

## Root cause

The startup reveal flow had two races:

1. the four-second fallback timer started before renderer navigation, so a cold Vite transform or slow document load could consume the entire budget and reveal the inline preload skeleton
2. `useLayoutEffect` notified the main process after the React DOM commit but before Chromium painted it, allowing the window's last composited preload frame to become visible

## Impact

The main window now opens on a painted application surface instead of briefly showing the centered skeleton card. The existing recovery behavior remains intact: a renderer that fails to become ready is still revealed after a four-second timeout, measured from document load completion.

## Validation

- `npm --workspace @maka/desktop run typecheck`
- `npm --workspace @maka/desktop run build:renderer`
- `npm --workspace @maka/desktop run test:checks`
- startup reveal and loading-shell tests: 16 passed
