### PR TITLE
fix(ui): normalize tool activity presentation

### DIFF
--- a/apps/desktop/src/main/__tests__/automation-result-preview-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/automation-result-preview-contract.test.ts
@@ -42,10 +42,10 @@ function renderAutomationResult(text: string): string {
   const item: ToolActivityItem = {
     toolUseId: 'tu-1',
     toolName: AUTOMATION_TOOL_NAME,
-    // 'running' keeps the collapsible card open by default so the static
-    // markup includes the body (a settled card collapses and Base UI unmounts
-    // closed panel content — nothing to assert on).
-    status: 'running',
+    // This test exercises the result parser, not disclosure defaults. Use an
+    // attention state so Base UI mounts the panel in static markup; ordinary
+    // running tools now stay collapsed until the user asks for diagnostics.
+    status: 'errored',
     args: { mode: 'create' },
     result: { kind: 'text', text },
   };

--- a/apps/desktop/src/main/__tests__/chat-status-cluster-layout-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/chat-status-cluster-layout-contract.test.ts
@@ -81,6 +81,13 @@ describe('chat status cluster layout contract', () => {
       /const showAssistantMessage = turn\.timeline\.length > 0 \|\| !!props\.liveStreaming;/,
       'the assistant Message must mount when the turn has timeline content OR is the live tail',
     );
+    // Terminal liveTurn is evidence-only (empty shell_run chunks). Footer must
+    // stay actionable — do not treat terminal projection as in-flight stream.
+    assert.match(
+      src,
+      /liveInFlight = !!\(props\.liveTurn && !props\.liveTurn\.terminal\)/,
+      'only non-terminal liveTurn blocks the footer as streaming',
+    );
   });
 
   it('uses an in-flow wrapping row instead of absolute positioning', async () => {

--- a/apps/desktop/src/main/__tests__/chat-status-cluster-layout-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/chat-status-cluster-layout-contract.test.ts
@@ -82,11 +82,17 @@ describe('chat status cluster layout contract', () => {
       'the assistant Message must mount when the turn has timeline content OR is the live tail',
     );
     // Terminal liveTurn is evidence-only (empty shell_run chunks). Footer must
-    // stay actionable — do not treat terminal projection as in-flight stream.
+    // stay actionable — do not treat terminal projection as in-flight stream,
+    // and do not let lagging wait indicators re-lock the footer over it.
     assert.match(
       src,
       /liveInFlight = !!\(props\.liveTurn && !props\.liveTurn\.terminal\)/,
       'only non-terminal liveTurn blocks the footer as streaming',
+    );
+    assert.match(
+      src,
+      /streamingActive = liveInFlight \|\| \(!props\.liveTurn\?\.terminal && waitIndicators\)/,
+      'terminal evidence outranks delayed processing/continuing indicators',
     );
   });
 

--- a/apps/desktop/src/main/__tests__/chat-stream-cascade-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/chat-stream-cascade-contract.test.ts
@@ -19,16 +19,20 @@ import { REPO_ROOT, TOKENS_FILE, readAllRendererCss, stripCssComments } from './
  * by before/after screenshots rather than the computed-style diff harness.
  */
 describe('chat tool-output stream migration contract (#332 PR3)', () => {
-  it('keeps the computed-style fixture aligned with production diagnostic flags', async () => {
+  it('keeps the computed-style fixture aligned with the quiet tool-output panel', async () => {
     const harness = await readFile(
       resolve(REPO_ROOT, 'scripts', 'check-chat-marker-computed-style.mjs'),
       'utf8',
     );
 
-    assert.match(harness, /sv\('flags'\)/);
-    assert.match(harness, /sv\('flag'\)/);
-    assert.doesNotMatch(harness, /sv\('counts?'\)/);
-    assert.doesNotMatch(harness, /stdout 1/);
+    // Stream variants are no longer the production tool body; the quiet panel is.
+    assert.match(harness, /TOOL_OUTPUT_PANEL_CLASS/);
+    assert.match(harness, /TOOL_OUTPUT_BODY_CLASS/);
+    assert.match(harness, /data-slot="tool-output"/);
+    // Live code must not still import/call streamVariants (comments may mention history).
+    assert.doesNotMatch(harness, /streamVariants\s*\(/);
+    assert.doesNotMatch(harness, /from\s+.*primitives\/chat.*streamVariants|streamVariants\s*\}/);
+    assert.doesNotMatch(harness, /toolOutputPanel[\s\S]*maka-tool-output-stream|sv\s*\(/);
   });
 
   it('keeps the computed-style fixture aligned with production disclosure defaults', async () => {

--- a/apps/desktop/src/main/__tests__/chat-stream-cascade-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/chat-stream-cascade-contract.test.ts
@@ -7,7 +7,7 @@ import { REPO_ROOT, TOKENS_FILE, readAllRendererCss, stripCssComments } from './
 /**
  * Zero-visual governance contract for issue #332 PR3 — the tool live-output
  * stream (`ToolOutputStream`) moved onto the `@maka/ui` chat substrate: the
- * panel/header/counts/body/chunk shell onto the `streamVariants` literalize
+ * panel/header/flags/body/chunk shell onto the `streamVariants` literalize
  * table, and the pulsing "live" dot onto the governed `LiveIndicator` primitive.
  *
  * The shell halves of "zero visual change" are locked the same way as PR2: the
@@ -19,6 +19,30 @@ import { REPO_ROOT, TOKENS_FILE, readAllRendererCss, stripCssComments } from './
  * by before/after screenshots rather than the computed-style diff harness.
  */
 describe('chat tool-output stream migration contract (#332 PR3)', () => {
+  it('keeps the computed-style fixture aligned with production diagnostic flags', async () => {
+    const harness = await readFile(
+      resolve(REPO_ROOT, 'scripts', 'check-chat-marker-computed-style.mjs'),
+      'utf8',
+    );
+
+    assert.match(harness, /sv\('flags'\)/);
+    assert.match(harness, /sv\('flag'\)/);
+    assert.doesNotMatch(harness, /sv\('counts?'\)/);
+    assert.doesNotMatch(harness, /stdout 1/);
+  });
+
+  it('keeps the computed-style fixture aligned with production disclosure defaults', async () => {
+    const harness = await readFile(
+      resolve(REPO_ROOT, 'scripts', 'check-chat-marker-computed-style.mjs'),
+      'utf8',
+    );
+
+    assert.match(
+      harness,
+      /const openByDefault = \(s\) => s === 'waiting_permission' \|\| s === 'errored';/,
+    );
+  });
+
   it('retires the bespoke stream shell selectors + the per-feature pulse keyframe', async () => {
     const css = stripCssComments(await readAllRendererCss());
     for (const selector of [
@@ -65,8 +89,8 @@ describe('chat tool-output stream migration contract (#332 PR3)', () => {
   });
 
   it('pins the live indicator dot — the one part the computed-style diff cannot cover', async () => {
-    // The stream SHELL (container/header/counts/body/chunk) is proven by the
-    // computed-style diff harness (38 rows, 0 delta), so this test does NOT
+    // The stream SHELL (container/header/flags/body/chunk) is proven by the
+    // computed-style diff harness (0 delta), so this test does NOT
     // re-assert those literals — that would just mirror the implementation. The
     // dot is the exception: an animation can't be a leaf-literal and
     // `getComputedStyle` reads a phase-dependent value, so the diff can't see it.

--- a/apps/desktop/src/main/__tests__/disclosure-collapsible-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/disclosure-collapsible-contract.test.ts
@@ -56,18 +56,11 @@ describe('PR-DISCLOSURE-COLLAPSIBLE-0 contract', () => {
     }
   });
 
-  it('tool-activity Collapsible is controlled (open follows item.status), not defaultOpen', async () => {
-    // A `defaultOpen` card decides open only on first render, so a card that
-    // defaults open while pending/running would NOT auto-collapse when it
-    // settles to completed/interrupted — the pre-Collapsible `<details
-    // open={isOpenByDefault(status)}>` re-evaluated open every render. The
-    // controlled form (open + onOpenChange, re-synced via useEffect on
-    // [item.status]) restores that: status change collapses/expands the card,
-    // the user can still toggle in between.
+  it('tool-activity Collapsible is controlled by the shared disclosure state, not defaultOpen', async () => {
     const src = await readFile(resolve(REPO_ROOT, 'packages/ui/src/tool-activity.tsx'), 'utf8');
-    assert.ok(!/defaultOpen=/.test(src), 'tool-activity must not use defaultOpen (a running card that defaults open would not auto-collapse when it settles); use controlled open that follows item.status');
+    assert.ok(!/defaultOpen=/.test(src), 'tool-activity must not use defaultOpen; shared disclosure state preserves manual choices and surfaces new attention states');
     assert.match(src, /\bonOpenChange\b/, 'tool-activity Collapsible must be controlled via onOpenChange');
-    assert.match(src, /useEffect\([^]*\[item\.status\]/, 'tool-activity must re-sync open when item.status changes (useEffect on [item.status])');
+    assert.match(src, /useToolDisclosure/, 'tool-activity must route open state through the shared disclosure controller');
   });
 });
 

--- a/apps/desktop/src/main/__tests__/materialize-turns.test.ts
+++ b/apps/desktop/src/main/__tests__/materialize-turns.test.ts
@@ -121,6 +121,33 @@ describe('materializeTurns', () => {
     assert.equal(turns[0]?.tools[0]?.status, 'interrupted');
   });
 
+  it('surfaces cancelled terminal results as interrupted instead of failed', () => {
+    const turns = materializeTurns([
+      userMsg('t1', 100, 'q'),
+      toolCallMsg('t1', 101, 'bash-cancel', 'Bash'),
+      {
+        type: 'tool_result',
+        id: 'r-bash-cancel',
+        turnId: 't1',
+        ts: 102,
+        toolUseId: 'bash-cancel',
+        isError: true,
+        content: {
+          kind: 'terminal',
+          cwd: '/repo',
+          cmd: 'sleep 99',
+          status: 'cancelled',
+          exitCode: 130,
+          stdout: '',
+          stderr: '',
+          stdoutTruncated: false,
+          stderrTruncated: false,
+        },
+      } as StoredMessage,
+    ]);
+    assert.equal(turns[0]?.tools[0]?.status, 'interrupted');
+  });
+
   it('surfaces canceled ExploreAgent results as interrupted instead of failed', () => {
     const turns = materializeTurns([
       userMsg('t1', 100, 'q'),

--- a/apps/desktop/src/main/__tests__/office-documents-capability.test.ts
+++ b/apps/desktop/src/main/__tests__/office-documents-capability.test.ts
@@ -171,13 +171,13 @@ describe('Office document capability contract', () => {
     assert.ok(officeBranch > 0, 'Office document branch must exist');
     assert.ok(jsonBranch > 0, 'JSON branch must exist');
     assert.ok(officeBranch < jsonBranch, 'Office document results must be intercepted before raw JSON rendering');
-    // #332 PR4: the office preview shell migrated onto the @maka/ui previewVariants
-    // literalize table; the bespoke selectors are retired and the render site wires
-    // the governed parts instead.
+    // Tool-output quiet panel: office structure nests inside the shared
+    // tool-output body classes (no second card chrome / retired CSS selectors).
     assert.doesNotMatch(styles, /\.maka-office-document-preview/, 'retired office preview selector must be gone post-migration');
     assert.doesNotMatch(styles, /\.maka-office-document-stream/, 'retired office stream selector must be gone post-migration');
-    assert.match(previewSource, /previewVariants\(\{ part: 'office' \}\)/, 'office preview must render the governed previewVariants office surface');
-    assert.match(previewSource, /previewVariants\(\{ part: 'office-stream' \}\)/, 'office stdout/stderr must render the governed previewVariants office-stream surface');
+    assert.match(previewSource, /data-kind="office_document"/, 'office preview must keep a stable data-kind hook');
+    assert.match(previewSource, /TOOL_OUTPUT_BODY_CLASS/, 'office stdout/stderr must use the shared tool-output body surface');
+    assert.match(previewSource, /TOOL_OUTPUT_COMMAND_CLASS/, 'officecli args must use the shared command surface');
   });
 
   it('summarizes Office document edits in the permission dialog before raw args', async () => {

--- a/apps/desktop/src/main/__tests__/text-swap-min-width-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/text-swap-min-width-contract.test.ts
@@ -108,13 +108,6 @@ const TEXT_SWAP_BUTTONS: Array<{ file: string; onClick: string; minW: string; no
   { file: 'apps/desktop/src/renderer/error-boundary.tsx', onClick: 'onClick={this.handleCopyReport}', minW: '5.5rem', note: '复制诊断信息 ↔ 复制中… ↔ 已复制 ↔ 复制失败' },
 ];
 
-// Chat stream-count variant lock: the min-w-[Nrem]
-// declaration lives in the variant definition (chat.tsx), not at the call
-// site, so we pin the literal declaration substrings.
-const CHAT_VARIANT_LOCKS: Array<{ file: string; substr: string; note: string }> = [
-  { file: 'packages/ui/src/primitives/chat.tsx', substr: 'min-w-[5rem] [font-variant-numeric:tabular-nums]', note: 'streamVariants count (stdout/stderr/已脱敏 N)' },
-];
-
 const BUTTON_OPEN_RE = /<(?:Ui)?Button\b/g;
 
 // --- Heuristic scan (DISCOVERY, scoped to PR3 files) ------------------------
@@ -168,24 +161,6 @@ describe('PR-ANTI-LAYOUT-SHIFT-TEXT-SWAP-0 contract', () => {
         assert.ok(
           clsMatch[1].includes(`min-w-[${minW}]`),
           `${file}: button for "${onClick}" className="${clsMatch[1]}" is missing min-w-[${minW}] (${note})`,
-        );
-      }
-    }
-  });
-
-  it('chat stream-count variants keep their min-w declarations', async () => {
-    const byFile = new Map<string, typeof CHAT_VARIANT_LOCKS>();
-    for (const l of CHAT_VARIANT_LOCKS) {
-      const arr = byFile.get(l.file) ?? [];
-      arr.push(l);
-      byFile.set(l.file, arr);
-    }
-    for (const [file, locks] of byFile) {
-      const src = await readFile(resolve(REPO_ROOT, file), 'utf8');
-      for (const { substr, note } of locks) {
-        assert.ok(
-          src.includes(substr),
-          `${file}: missing variant declaration "${substr}" (${note})`,
         );
       }
     }

--- a/apps/desktop/src/main/__tests__/text-swap-min-width-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/text-swap-min-width-contract.test.ts
@@ -41,9 +41,7 @@
  *    its onClick handler. The scan also requires every discovered button to
  *    be value-pinned here (or in EXCEPTIONS) so a too-small `min-w-[1rem]`
  *    can't bypass the value lock; the whitelist pins the exact value so a
- *    refactor can't shrink a real lock to the wrong value. Chat stream-count variant locks live in
- *    the variant definition, so they're pinned by their literal declaration
- *    substrings.
+ *    refactor can't shrink a real lock to the wrong value.
  */
 import { strict as assert } from 'node:assert';
 import { readFile } from 'node:fs/promises';

--- a/apps/desktop/src/main/__tests__/tool-activity-result-preview-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/tool-activity-result-preview-contract.test.ts
@@ -62,7 +62,7 @@ describe('ToolActivity result preview contract', () => {
           stdoutTruncated: false,
           stderrTruncated: false,
         },
-        expected: [/data-kind="terminal"/, /退出码 1/, /stdout 已隐藏 1 行/, /复制研读提示/],
+        expected: [/data-kind="terminal"/, /失败 · 退出码 1/, /stdout 已隐藏 1 行/, /输出已截断/],
       },
       {
         kind: 'office_document',

--- a/apps/desktop/src/main/__tests__/tool-activity-result-preview-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/tool-activity-result-preview-contract.test.ts
@@ -151,7 +151,9 @@ describe('ToolActivity result preview contract', () => {
 
     const json = renderPreview({ kind: 'json', value: { token: SECRET, ok: true } });
     assert.match(json, /data-kind="json"/);
-    assert.match(json, /&quot;ok&quot;: true/);
+    // Quiet panel: plain key:value lines, not pretty-printed JSON quotes.
+    assert.match(json, /ok:\s*true/);
+    assert.doesNotMatch(json, /&quot;ok&quot;:\s*true/);
     assert.doesNotMatch(json, new RegExp(SECRET));
 
     const fileWrite = renderPreview({ kind: 'file_write', path: 'out.txt', bytes: 12 });

--- a/apps/desktop/src/main/__tests__/tool-args-redaction-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/tool-args-redaction-contract.test.ts
@@ -17,16 +17,24 @@ describe('tool and permission args redaction', () => {
     assert.match(rendered, /command/);
   });
 
-  it('routes ToolActivity and PermissionDialog args through formatRedactedJson', async () => {
-    const [toolSource, permissionSource] = await Promise.all([
+  it('routes ToolActivity args through quiet formatters and PermissionDialog through formatRedactedJson', async () => {
+    const [toolSource, permissionSource, quietSource] = await Promise.all([
       readFile(join(process.cwd(), '../../packages/ui/src/tool-activity.tsx'), 'utf8'),
       readFile(join(process.cwd(), '../../packages/ui/src/permission-dialog.tsx'), 'utf8'),
+      readFile(join(process.cwd(), '../../packages/ui/src/tool-activity/builtin-preview.ts'), 'utf8'),
     ]);
     const toolActivity = toolSource.match(/export function ToolActivity[\s\S]*?function ToolOutputStream/)?.[0] ?? '';
     const permissionDialog = permissionSource.match(/export function PermissionDialog[\s\S]*?function renderPermissionSummary/)?.[0] ?? '';
 
-    assert.match(toolActivity, /\{formatRedactedJson\(item\.args\)\}/);
+    // Quiet panel: never stringify args; use formatToolInvocationLine / formatQuietJsonValue.
+    assert.match(toolActivity, /formatToolInvocationLine\(item\)/);
+    assert.match(toolActivity, /formatQuietJsonValue/);
     assert.doesNotMatch(toolActivity, /JSON\.stringify\(item\.args/);
+    assert.doesNotMatch(toolActivity, /formatRedactedJson\(item\.args\)/);
+    // Keys and full lines are redacted in the quiet key/value formatter.
+    assert.match(quietSource, /redactSecrets\(key\)/);
+    assert.match(quietSource, /push\(redactSecrets\(line\)\)|lines\.push\(redactSecrets\(line\)\)/);
+    // Permission dialog still uses formatRedactedJson for its summary dump.
     assert.match(permissionDialog, /\{formatRedactedJson\(props\.request\.args\)\}/);
     assert.doesNotMatch(permissionDialog, /JSON\.stringify\(props\.request\.args/);
   });

--- a/apps/desktop/src/main/__tests__/trow-summary.test.ts
+++ b/apps/desktop/src/main/__tests__/trow-summary.test.ts
@@ -33,6 +33,8 @@ describe('trowActivityKind', () => {
     assert.equal(trowActivityKind('Write'), 'edit');
     assert.equal(trowActivityKind('Edit'), 'edit');
     assert.equal(trowActivityKind('Bash'), 'command');
+    assert.equal(trowActivityKind('StopBackgroundTask'), 'command');
+    assert.equal(trowActivityKind('stop_background_task'), 'command');
     assert.equal(trowActivityKind('ExploreAgent'), 'explore');
     assert.equal(trowActivityKind('browser_click'), 'browser');
     assert.equal(trowActivityKind('OfficeDocument'), 'tool');

--- a/apps/desktop/src/main/__tests__/visible-copy-hygiene-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/visible-copy-hygiene-contract.test.ts
@@ -305,13 +305,23 @@ describe('terminal truncation handoff contract', () => {
     );
     assert.match(
       src,
-      /\{hiddenLines > 0 && \(/,
-      'The truncation note should only render when at least one terminal output stream is capped.',
+      /runtimeTruncated \|\| hiddenLines > 0/,
+      'The truncation note should honor runtime stream flags as well as UI line caps.',
     );
     assert.match(
       src,
-      /输出已截断 · 每路仅展示前 \{TOOL_LINE_CAP\} 行/,
+      /输出已截断 · 每路仅展示前 \$\{TOOL_LINE_CAP\} 行/,
       'The truncation note should state the line cap without a copy button.',
+    );
+    assert.match(
+      src,
+      /stdoutTruncated|stderrTruncated/,
+      'Terminal preview must receive runtime truncated flags from the result content.',
+    );
+    assert.match(
+      src,
+      /data-kind="shell_run"|ShellRunPreview/,
+      'Background shell_run results need a dedicated quiet presenter, not [shell_run].',
     );
     assert.doesNotMatch(
       src,

--- a/apps/desktop/src/main/__tests__/visible-copy-hygiene-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/visible-copy-hygiene-contract.test.ts
@@ -292,132 +292,53 @@ describe('visible-copy hygiene contract (PR-SIDEBAR-IA-0 Phase 3 P0 fixup v2)', 
 });
 
 describe('terminal truncation handoff contract', () => {
-  it('shows a deep-research handoff when terminal output is capped', async () => {
+  it('shows a quiet truncation note without a copy control on the tool output well', async () => {
+    // Tool-output presentation: one Codex-like panel, no always-on copy chrome.
+    // Truncation is a one-line caption note; users select text to copy.
     const terminalPreviewPath = resolve(process.cwd(), '..', '..', 'packages', 'ui', 'src', 'tool-activity', 'tool-result-preview.tsx');
     const src = await readFile(terminalPreviewPath, 'utf8');
 
     assert.match(
       src,
       /const hiddenLines = stdout\.capped \+ stderr\.capped;/,
-      'TerminalPreview should combine capped stdout/stderr counts into one visible handoff condition.',
+      'TerminalPreview should combine capped stdout/stderr counts into one visible note condition.',
     );
     assert.match(
       src,
       /\{hiddenLines > 0 && \(/,
-      'The handoff note should only render when at least one terminal output stream is capped.',
+      'The truncation note should only render when at least one terminal output stream is capped.',
     );
     assert.match(
       src,
-      /previewVariants\(\{ part: 'terminal-truncated-note' \}\)/,
-      'TerminalPreview should render the capped-output handoff through the governed previewVariants terminal-truncated-note part.',
-    );
-    assert.match(
-      src,
-      /前 \{TOOL_LINE_CAP\} 行/,
-      'The handoff note should reflect the actual terminal preview line cap instead of hard-coding a stale number.',
-    );
-    assert.match(
-      src,
-      /深度研究.*只读探索/,
-      'Long terminal output should point users toward the read-only deep-research workflow instead of ending at a dead truncated preview.',
-    );
-    assert.match(
-      src,
-      /const handoffText = \[/,
-      'TerminalPreview should build a copyable handoff prompt for capped terminal output.',
-    );
-    assert.match(
-      src,
-      /工作目录：\$\{safeCwd\}/,
-      'The capped-output handoff should include the redacted working directory.',
-    );
-    assert.match(
-      src,
-      /命令：\$\{safeCmd\}/,
-      'The capped-output handoff should include the redacted command.',
-    );
-    assert.match(
-      src,
-      /copyFeedback\.copy\('handoff', handoffText\)/,
-      'The capped-output handoff copy path must use the shared guarded clipboard feedback path.',
-    );
-    assert.match(
-      src,
-      /import \{ Button as UiButton[^}]*\} from '\.\.\/ui\.js';/,
-      'The capped-output handoff copy action should use the shared UiButton from ui.tsx.',
-    );
-    assert.match(
-      src,
-      /<UiButton[\s\S]*?variant="ghost"[\s\S]*?size="sm"[\s\S]*?className=\{previewVariants\(\{ part: 'terminal-copy' \}\)\}/,
-      'The capped-output handoff copy action should keep its ghost/sm affordance through UiButton props and the governed previewVariants terminal-copy part.',
+      /输出已截断 · 每路仅展示前 \{TOOL_LINE_CAP\} 行/,
+      'The truncation note should state the line cap without a copy button.',
     );
     assert.doesNotMatch(
       src,
-      /\bmaka-tool-terminal-copy\b/,
-      'The copy action must not reintroduce the retired bespoke maka-tool-terminal-copy class (it migrated onto previewVariants in #332 PR4).',
-    );
-    // PR-UI-LIB-EXTRACT-7 (round 8/10): the shared clipboard
-    // feedback hook moved from `components.tsx` into a sibling
-    // `clipboard-feedback.ts` leaf module. The behavioral
-    // contract is unchanged; we just read the hook from where
-    // it now lives.
-    const clipboardPath = resolve(process.cwd(), '..', '..', 'packages', 'ui', 'src', 'clipboard-feedback.ts');
-    const clipboardSrc = await readFile(clipboardPath, 'utf8');
-    assert.match(
-      clipboardSrc,
-      /export function useClipboardCopyFeedback/,
-      'Clipboard copy actions should share one pending/failure feedback boundary instead of silently firing raw writes.',
-    );
-    assert.match(
-      clipboardSrc,
-      /navigator\.clipboard\.writeText\(options\.redact === false \? text : redactSecrets\(text\)\)/,
-      'The shared clipboard feedback helper must redact by default and require an explicit raw-copy opt-out.',
-    );
-    assert.match(
-      src,
-      /handoffCopyPhase === 'pending'/,
-      'The capped-output handoff copy button should expose a pending state while the clipboard write is running.',
-    );
-    assert.match(
-      src,
-      /data-copy-error=\{handoffCopyPhase === 'failed'/,
-      'The capped-output handoff copy button should expose clipboard failures in-place instead of silently failing.',
-    );
-    assert.match(
-      src,
       /复制研读提示/,
-      'The truncation handoff should expose a visible copy action for the deep-research prompt.',
+      'Tool output wells must not show an always-on copy action.',
+    );
+    assert.doesNotMatch(
+      src,
+      /copyFeedback\.copy\('handoff'/,
+      'Terminal truncation must not reintroduce a handoff clipboard control on the quiet panel.',
+    );
+    assert.match(
+      src,
+      /data-slot="tool-output"/,
+      'Terminal preview must use the unified tool-output panel slot.',
+    );
+    assert.match(
+      src,
+      /失败 · 退出码/,
+      'Failed terminals should expose a one-line failure note with the exit code.',
     );
   });
 
-  it('styles the terminal truncation handoff distinctly from raw terminal output', async () => {
-    // #332 PR4: the handoff note + copy-state styling moved off bespoke CSS onto
-    // the `@maka/ui` `previewVariants` literalize table. The distinguishing
-    // declarations are now literal utilities in chat.tsx — assert them where they
-    // live (the diff harness proves they render identically).
+  it('keeps explore-agent copy feedback on non-tool-output surfaces', async () => {
+    // Explore agent still has explicit copy affordances; only tool mono wells dropped them.
     const chatPath = resolve(process.cwd(), '..', '..', 'packages', 'ui', 'src', 'primitives', 'chat.tsx');
     const chat = await readFile(chatPath, 'utf8');
-
-    assert.match(
-      chat,
-      /"terminal-truncated-note":\s*\n?\s*"[^"]*\[border-top:1px_solid_var\(--border\)\]/,
-      'The truncation handoff should be visually separated from terminal text (border-top).',
-    );
-    assert.match(
-      chat,
-      /"terminal-truncated-note":\s*\n?\s*"[^"]*bg-\[oklch\(from_var\(--warning\)/,
-      'The truncation handoff should use the warning token so it reads as a capped-output state.',
-    );
-    assert.match(
-      chat,
-      /"terminal-copy":\s*\n?\s*"\[flex:0_0_auto\]/,
-      'The copy action should keep a stable size inside the truncation handoff row.',
-    );
-    assert.match(
-      chat,
-      /"terminal-copy":[\s\S]*?data-\[copy-error=true\]:text-\[color:var\(--destructive\)\]/,
-      'The terminal handoff copy button should have a visible failed state.',
-    );
     assert.match(
       chat,
       /"agent-copy":[\s\S]*?data-\[pending=true\]:cursor-progress/,

--- a/packages/core/src/events.ts
+++ b/packages/core/src/events.ts
@@ -20,6 +20,18 @@ import type {
 
 export const TOOL_OUTPUT_STREAMS = ['stdout', 'stderr'] as const;
 export const TOOL_OUTPUT_DELTA_MAX_CHARS = 8192;
+export const TOOL_ACTIVITY_KINDS = [
+  'read',
+  'search',
+  'websearch',
+  'webfetch',
+  'edit',
+  'command',
+  'explore',
+  'browser',
+  'tool',
+] as const;
+export type ToolActivityKind = typeof TOOL_ACTIVITY_KINDS[number];
 type TerminalToolResultStatus = Exclude<ShellRunTerminalStatus, 'orphaned'>;
 
 // ============================================================================
@@ -99,6 +111,8 @@ export interface ToolStartEvent extends BaseEvent {
   type: 'tool_start';
   toolUseId: string;
   toolName: string;
+  /** Stable semantic category for presentation; absent on legacy events. */
+  activityKind?: ToolActivityKind;
   args: unknown;
   displayName?: string;
   intent?: string;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -40,6 +40,13 @@ export {
   TOOL_OUTPUT_STREAMS,
 } from './events.js';
 
+// tool-result-status.ts — settled tool activity status from tool_result
+export type { SettledToolActivityStatus } from './tool-result-status.js';
+export {
+  isCancelledToolResultContent,
+  toolResultActivityStatus,
+} from './tool-result-status.js';
+
 // runtime-event.ts — canonical Runtime v2 event contract.
 // Subpath `@maka/core/runtime-event` is the canonical import; these barrel
 // re-exports are for convenience.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -16,6 +16,7 @@ export type {
   ThinkingDeltaEvent,
   ThinkingCompleteEvent,
   ToolStartEvent,
+  ToolActivityKind,
   ToolOutputDeltaEvent,
   ToolOutputStream,
   ToolProgressEvent,
@@ -34,6 +35,7 @@ export type {
   AttachmentIngestItem,
 } from './events.js';
 export {
+  TOOL_ACTIVITY_KINDS,
   TOOL_OUTPUT_DELTA_MAX_CHARS,
   TOOL_OUTPUT_STREAMS,
 } from './events.js';

--- a/packages/core/src/session.ts
+++ b/packages/core/src/session.ts
@@ -9,7 +9,7 @@
  * documented in spec §5.2.
  */
 
-import type { AttachmentRef, ToolResultContent } from './events.js';
+import type { AttachmentRef, ToolActivityKind, ToolResultContent } from './events.js';
 import type { PermissionMode } from './permission.js';
 import type {
   CacheMissInputSource,
@@ -215,6 +215,8 @@ export interface ToolCallMessage {
   turnId: string;
   ts: number;
   toolName: string;
+  /** Stable semantic category for presentation; absent on legacy rows. */
+  activityKind?: ToolActivityKind;
   displayName?: string;
   intent?: string;
   args: unknown;

--- a/packages/core/src/tool-result-status.ts
+++ b/packages/core/src/tool-result-status.ts
@@ -1,0 +1,34 @@
+/**
+ * Map a tool_result onto the UI activity status used by cards/trows.
+ * Cancel / abort are user-or-system stops, not tool failures.
+ */
+import type { ToolResultContent } from './events.js';
+
+export type SettledToolActivityStatus = 'completed' | 'errored' | 'interrupted';
+
+/** Terminal / shell_run results whose runtime status is explicit cancel. */
+export function isCancelledToolResultContent(
+  content: ToolResultContent | undefined,
+): boolean {
+  if (!content) return false;
+  if (content.kind === 'terminal' || content.kind === 'shell_run') {
+    return content.status === 'cancelled';
+  }
+  return false;
+}
+
+/**
+ * Derive settled ToolActivityItem.status from tool_result flags + content.
+ * Cancelled shells and aborted explore agents land as `interrupted`.
+ */
+export function toolResultActivityStatus(
+  isError: boolean,
+  content: ToolResultContent | undefined,
+): SettledToolActivityStatus {
+  if (isCancelledToolResultContent(content)) return 'interrupted';
+  if (!isError) return 'completed';
+  if (content?.kind === 'explore_agent' && content.reason === 'aborted') {
+    return 'interrupted';
+  }
+  return 'errored';
+}

--- a/packages/core/src/tool-result-status.ts
+++ b/packages/core/src/tool-result-status.ts
@@ -19,14 +19,19 @@ export function isCancelledToolResultContent(
 
 /**
  * Derive settled ToolActivityItem.status from tool_result flags + content.
- * Cancelled shells and aborted explore agents land as `interrupted`.
+ *
+ * `isError` is the call-level contract: a successful observation of a
+ * cancelled background task (`StopBackgroundTask` → shell_run cancelled,
+ * isError:false) is `completed`, not interrupted. Only failed cancels and
+ * aborted explore agents map to `interrupted`.
  */
 export function toolResultActivityStatus(
   isError: boolean,
   content: ToolResultContent | undefined,
 ): SettledToolActivityStatus {
-  if (isCancelledToolResultContent(content)) return 'interrupted';
   if (!isError) return 'completed';
+  // Failed cancel (user stop / kill) — not a tool failure banner.
+  if (isCancelledToolResultContent(content)) return 'interrupted';
   if (content?.kind === 'explore_agent' && content.reason === 'aborted') {
     return 'interrupted';
   }

--- a/packages/runtime/src/__tests__/ai-sdk-flow.test.ts
+++ b/packages/runtime/src/__tests__/ai-sdk-flow.test.ts
@@ -624,6 +624,22 @@ describe('mapSessionEventToRuntimeEvent (pure)', () => {
     assert.equal(b.role, 'tool');
   });
 
+  test('tool_start maps its semantic activity kind into runtime state', () => {
+    const event = mapSessionEventToRuntimeEvent(
+      ev({
+        type: 'tool_start',
+        toolUseId: 'tu-kind',
+        toolName: 'CustomCommand',
+        activityKind: 'command',
+        args: {},
+      }),
+      ctx,
+      createSessionEventMapMemory(),
+    );
+
+    assert.equal(event.actions?.stateDelta?.activityKind, 'command');
+  });
+
   test('plan_submitted maps to an agent-authored state delta', () => {
     const a = mapSessionEventToRuntimeEvent(
       ev({ type: 'plan_submitted', planId: 'p1', title: 'T', markdownPath: '/p.md' }),

--- a/packages/runtime/src/__tests__/builtin-tools.test.ts
+++ b/packages/runtime/src/__tests__/builtin-tools.test.ts
@@ -12,6 +12,33 @@ import {
   type WorkspaceExecutorFacts,
 } from '../workspace-executor.js';
 
+describe('builtin tool activity kinds', () => {
+  test('declares stable semantic categories independently of tool names', () => {
+    const kinds = Object.fromEntries(buildBuiltinTools().map((tool) => [tool.name, tool.activityKind]));
+
+    expect(kinds).toEqual({
+      Bash: 'command',
+      Read: 'read',
+      Write: 'edit',
+      Edit: 'edit',
+      Glob: 'search',
+      Grep: 'search',
+    });
+  });
+
+  test('categorizes background task controls as command activity', () => {
+    const shellRuns = {
+      runBash: () => Promise.reject(new Error('not used')),
+      readResource: () => Promise.reject(new Error('not used')),
+      stopResource: () => Promise.reject(new Error('not used')),
+    } satisfies ShellRunToolController;
+    const kinds = Object.fromEntries(buildBuiltinTools({ shellRuns }).map((tool) => [tool.name, tool.activityKind]));
+
+    expect(kinds.Bash).toBe('command');
+    expect(kinds.StopBackgroundTask).toBe('command');
+  });
+});
+
 describe('builtin tool executor facts', () => {
   test('attaches executor facts to every built-in tool', () => {
     const facts: WorkspaceExecutorFacts = {

--- a/packages/runtime/src/__tests__/deferred-guard.test.ts
+++ b/packages/runtime/src/__tests__/deferred-guard.test.ts
@@ -92,6 +92,22 @@ function run(h: Harness, t: MakaTool) {
 }
 
 describe('tool-availability execute-boundary guard', () => {
+  test('projects a declared activity kind into persisted and live tool facts', async () => {
+    const h = makeHarness();
+    const implCalls: string[] = [];
+    const t = Object.assign(tool('CustomCommand', implCalls), {
+      activityKind: 'command' as const,
+      permissionRequired: false,
+    });
+
+    await run(h, t);
+
+    const call = h.appended.find((message) => message.type === 'tool_call') as unknown as { activityKind?: string };
+    const start = h.pushed.find((event) => event.type === 'tool_start') as unknown as { activityKind?: string };
+    assert.equal(call.activityKind, 'command');
+    assert.equal(start.activityKind, 'command');
+  });
+
   test('passes tool execution facts into permission evaluation', async () => {
     const h = makeHarness();
     const implCalls: string[] = [];

--- a/packages/runtime/src/__tests__/materializer.test.ts
+++ b/packages/runtime/src/__tests__/materializer.test.ts
@@ -142,6 +142,40 @@ describe('materializeSession', () => {
     expect(item.item.isError).toBe(true);
   });
 
+  test('cancelled terminal with isError=true → status interrupted', () => {
+    const cancelled: ToolResultMessage = {
+      type: 'tool_result',
+      id: 'r-cancel',
+      turnId,
+      ts: ts + 4,
+      toolUseId: 't-cancel',
+      isError: true,
+      content: {
+        kind: 'terminal',
+        cwd: '/repo',
+        cmd: 'sleep 99',
+        status: 'cancelled',
+        exitCode: 130,
+        stdout: '',
+        stderr: '',
+        stdoutTruncated: false,
+        stderrTruncated: false,
+      },
+    };
+    const vm = materializeSession([toolCall('t-cancel', 'Bash'), cancelled]);
+    const item = vm.items[0];
+    if (item?.kind !== 'tool') throw new Error('wrong kind');
+    expect(item.item.status).toBe('interrupted');
+
+    const live = applyAppendedMessage(
+      applyAppendedMessage([], toolCall('t-cancel', 'Bash')).items,
+      cancelled,
+    );
+    const liveItem = live.items[0];
+    if (liveItem?.kind !== 'tool') throw new Error('wrong kind');
+    expect(liveItem.item.status).toBe('interrupted');
+  });
+
   test('orphan tool_call (no matching result) → interrupted', () => {
     const vm = materializeSession([toolCall('t-orphan', 'Bash')]);
     expect(vm.items).toHaveLength(1);

--- a/packages/runtime/src/__tests__/materializer.test.ts
+++ b/packages/runtime/src/__tests__/materializer.test.ts
@@ -196,6 +196,18 @@ describe('materializeSession', () => {
 // ---------- applyAppendedMessage ----------
 
 describe('applyAppendedMessage', () => {
+  test('preserves a semantic activity kind during reload and live append', () => {
+    const call = { ...toolCall('t', 'custom_shell'), activityKind: 'command' as const };
+    const reloaded = materializeSession([call]);
+    const appended = applyAppendedMessage([], call);
+
+    const reloadedItem = reloaded.items[0];
+    const appendedItem = appended.items[0];
+    if (reloadedItem?.kind !== 'tool' || appendedItem?.kind !== 'tool') throw new Error('wrong kind');
+    expect(reloadedItem.item.activityKind).toBe('command');
+    expect(appendedItem.item.activityKind).toBe('command');
+  });
+
   test('append user → adds bubble', () => {
     const next = applyAppendedMessage([], user('u', 'hi'));
     expect(next.items).toHaveLength(1);

--- a/packages/runtime/src/__tests__/materializer.test.ts
+++ b/packages/runtime/src/__tests__/materializer.test.ts
@@ -176,6 +176,40 @@ describe('materializeSession', () => {
     expect(liveItem.item.status).toBe('interrupted');
   });
 
+  test('successful shell_run cancelled observation stays completed', () => {
+    // StopBackgroundTask returns isError:false + shell_run.status cancelled —
+    // the stop call succeeded; do not map to interrupted/error.
+    const observed: ToolResultMessage = {
+      type: 'tool_result',
+      id: 'r-stop',
+      turnId,
+      ts: ts + 4,
+      toolUseId: 't-stop',
+      isError: false,
+      content: {
+        kind: 'shell_run',
+        ref: 'maka://runtime/background-tasks/bg',
+        status: 'cancelled',
+        cwd: '/repo',
+        cmd: 'sleep 99',
+        startedAt: 1,
+        updatedAt: 2,
+        exitCode: 130,
+        stdout: '',
+        stderr: '',
+        stdoutTruncated: false,
+        stderrTruncated: false,
+      },
+    };
+    const vm = materializeSession([
+      toolCall('t-stop', 'StopBackgroundTask'),
+      observed,
+    ]);
+    const item = vm.items[0];
+    if (item?.kind !== 'tool') throw new Error('wrong kind');
+    expect(item.item.status).toBe('completed');
+  });
+
   test('orphan tool_call (no matching result) → interrupted', () => {
     const vm = materializeSession([toolCall('t-orphan', 'Bash')]);
     expect(vm.items).toHaveLength(1);

--- a/packages/runtime/src/__tests__/runtime-event-backfill.test.ts
+++ b/packages/runtime/src/__tests__/runtime-event-backfill.test.ts
@@ -65,6 +65,7 @@ describe('runtime event backfill', () => {
         turnId: 'turn-1',
         ts: 120,
         toolName: 'Read',
+        activityKind: 'read',
         displayName: 'Read file',
         intent: 'inspect',
         args: { path: 'README.md' },
@@ -144,6 +145,7 @@ describe('runtime event backfill', () => {
     expect(result.events[2]?.content).toEqual({ kind: 'thinking', text: 'reasoning', signature: 'sig-1' });
     expect(result.events[3]?.content).toEqual({ kind: 'function_call', id: 'tool-1', name: 'Read', args: { path: 'README.md' } });
     expect(result.events[3]?.actions?.stateDelta?.displayName).toBe('Read file');
+    expect(result.events[3]?.actions?.stateDelta?.activityKind).toBe('read');
     expect(result.events[3]?.actions?.stateDelta?.intent).toBe('inspect');
     expect(result.events[3]?.refs).toEqual({ storedMessageId: 'tool-1', toolCallId: 'tool-1', stepId: 'step-1' });
     expect(result.events[4]?.content).toEqual({ kind: 'function_response', id: 'tool-1', name: 'Read', result: { kind: 'text', text: 'file body' }, isError: false });

--- a/packages/runtime/src/__tests__/runtime-event-read-model.test.ts
+++ b/packages/runtime/src/__tests__/runtime-event-read-model.test.ts
@@ -666,6 +666,28 @@ describe('projectRuntimeEventsToStoredMessages', () => {
     expect(legacyCall).toMatchObject({ type: 'tool_call', id: 'tool-legacy' });
     expect(legacyCall && 'stepId' in legacyCall).toBe(false);
   });
+
+  test('projects tool_call activityKind from runtime state for replay', () => {
+    const out = projectRuntimeEventsToStoredMessages([ev({
+      id: 'evt-tool-kind',
+      role: 'model',
+      author: 'agent',
+      content: {
+        kind: 'function_call',
+        id: 'tool-kind',
+        name: 'CustomCommand',
+        args: {},
+      },
+      actions: { stateDelta: { activityKind: 'command' } },
+      refs: { toolCallId: 'tool-kind' },
+    })], { runHeaders: [header] });
+
+    expect(out.messages[0]).toMatchObject({
+      type: 'tool_call',
+      id: 'tool-kind',
+      activityKind: 'command',
+    });
+  });
 });
 
 describe('compareRuntimeReadModelMessages', () => {
@@ -730,6 +752,24 @@ describe('compareRuntimeReadModelMessages', () => {
 
     expect(result.compatible).toBe(true);
     expect(result.diagnostics).toEqual([]);
+  });
+
+  test('rejects a mismatched tool activity kind', () => {
+    const projected: StoredMessage[] = [{
+      type: 'tool_call',
+      id: 'tool-kind',
+      turnId,
+      ts,
+      toolName: 'CustomTool',
+      activityKind: 'read',
+      args: {},
+    }];
+    const legacy: StoredMessage[] = [{
+      ...projected[0] as Extract<StoredMessage, { type: 'tool_call' }>,
+      activityKind: 'command',
+    }];
+
+    expect(compareRuntimeReadModelMessages(projected, legacy).compatible).toBe(false);
   });
 
   test('rejects missing tool result and assistant text cases', () => {

--- a/packages/runtime/src/__tests__/shell-tools.test.ts
+++ b/packages/runtime/src/__tests__/shell-tools.test.ts
@@ -6,6 +6,11 @@ import type { ShellPlan } from '../shell-detect.js';
 const pwshPlan: ShellPlan = { kind: 'pwsh', displayName: 'PowerShell 7 (pwsh)', exe: 'C:\\pf\\pwsh.exe' };
 
 describe('Bash tool description declares the executing shell', () => {
+  test('foreground and background variants declare command activity', () => {
+    assert.equal(buildLocalForegroundBashTool().activityKind, 'command');
+    assert.equal(buildBackgroundBashTool(fakeShellRuns()).activityKind, 'command');
+  });
+
   test('foreground tool tells the model commands run under PowerShell 7', () => {
     const tool = buildLocalForegroundBashTool({ shell: pwshPlan });
     assert.match(tool.description, /PowerShell 7 \(pwsh\)/);

--- a/packages/runtime/src/ai-sdk-flow.ts
+++ b/packages/runtime/src/ai-sdk-flow.ts
@@ -200,8 +200,9 @@ export function mapSessionEventToRuntimeEvent(
           ...(event.stepId !== undefined ? { stepId: event.stepId } : {}),
         },
       };
-      if (event.displayName !== undefined || event.intent !== undefined) {
+      if (event.activityKind !== undefined || event.displayName !== undefined || event.intent !== undefined) {
         const stateDelta: Record<string, unknown> = {};
+        if (event.activityKind !== undefined) stateDelta.activityKind = event.activityKind;
         if (event.displayName !== undefined) stateDelta.displayName = event.displayName;
         if (event.intent !== undefined) stateDelta.intent = event.intent;
         ev.actions = { stateDelta };

--- a/packages/runtime/src/builtin-tools.ts
+++ b/packages/runtime/src/builtin-tools.ts
@@ -59,6 +59,7 @@ export function buildBuiltinTools(options: BuildBuiltinToolsOptions = {}): MakaT
     ...bashTools,
     {
       name: 'Read',
+      activityKind: 'read',
       description: readDescription,
       parameters: z.object({
         path: z.string(),
@@ -84,6 +85,7 @@ export function buildBuiltinTools(options: BuildBuiltinToolsOptions = {}): MakaT
     },
     {
       name: 'Write',
+      activityKind: 'edit',
       description: 'Write content to a file (creates or overwrites). Subject to permission policy.',
       parameters: z.object({ path: z.string(), content: z.string() }),
       permissionRequired: true,
@@ -98,6 +100,7 @@ export function buildBuiltinTools(options: BuildBuiltinToolsOptions = {}): MakaT
     },
     {
       name: 'Edit',
+      activityKind: 'edit',
       description:
         'Replace old_string with new_string in a file. Prefers an exact, unique match; '
         + 'if exact fails it tolerates limited whitespace/indentation/escape drift in old_string, '
@@ -131,6 +134,7 @@ export function buildBuiltinTools(options: BuildBuiltinToolsOptions = {}): MakaT
     },
     {
       name: 'Glob',
+      activityKind: 'search',
       description:
         'Find files matching a glob pattern (case-insensitive, capped at 200, sorted by walk order).',
       parameters: z.object({
@@ -151,6 +155,7 @@ export function buildBuiltinTools(options: BuildBuiltinToolsOptions = {}): MakaT
     },
     {
       name: 'Grep',
+      activityKind: 'search',
       description: 'Search file contents with a regex via ripgrep.',
       parameters: z.object({
         pattern: z.string(),
@@ -187,6 +192,7 @@ export function buildBuiltinTools(options: BuildBuiltinToolsOptions = {}): MakaT
 function buildExecutorBashTool(executor: WorkspaceExecutor, shell: ShellPlan): MakaTool {
   return {
     name: 'Bash',
+    activityKind: 'command',
     description: withShellGuidance('Run a shell command in the session cwd.', shell)
       + ' Subject to permission policy.',
     parameters: z.object({

--- a/packages/runtime/src/materializer.ts
+++ b/packages/runtime/src/materializer.ts
@@ -18,6 +18,7 @@ import type {
   PermissionDecisionMessage,
   TokenUsageMessage,
   SystemNoteMessage,
+  ToolActivityKind,
   ToolResultContent,
 } from '@maka/core';
 
@@ -28,6 +29,7 @@ import type {
 export interface ToolActivityItem {
   toolUseId: string;
   toolName: string;
+  activityKind?: ToolActivityKind;
   displayName?: string;
   intent?: string;
   status:
@@ -150,6 +152,7 @@ function toolActivityFromPair(
     return {
       toolUseId: call.id,
       toolName: call.toolName,
+      ...(call.activityKind !== undefined ? { activityKind: call.activityKind } : {}),
       ...(call.displayName !== undefined ? { displayName: call.displayName } : {}),
       ...(call.intent !== undefined ? { intent: call.intent } : {}),
       status: 'interrupted',
@@ -160,6 +163,7 @@ function toolActivityFromPair(
   return {
     toolUseId: call.id,
     toolName: call.toolName,
+    ...(call.activityKind !== undefined ? { activityKind: call.activityKind } : {}),
     ...(call.displayName !== undefined ? { displayName: call.displayName } : {}),
     ...(call.intent !== undefined ? { intent: call.intent } : {}),
     status: result.isError ? 'errored' : 'completed',
@@ -198,6 +202,7 @@ export function applyAppendedMessage(
       const item: ToolActivityItem = {
         toolUseId: message.id,
         toolName: message.toolName,
+        ...(message.activityKind !== undefined ? { activityKind: message.activityKind } : {}),
         ...(message.displayName !== undefined ? { displayName: message.displayName } : {}),
         ...(message.intent !== undefined ? { intent: message.intent } : {}),
         status: 'pending',

--- a/packages/runtime/src/materializer.ts
+++ b/packages/runtime/src/materializer.ts
@@ -21,6 +21,7 @@ import type {
   ToolActivityKind,
   ToolResultContent,
 } from '@maka/core';
+import { toolResultActivityStatus } from '@maka/core';
 
 // ============================================================================
 // View-model types (mirror packages/ui/src exports, lifted here for reuse)
@@ -140,7 +141,8 @@ export function materializeSession(messages: readonly StoredMessage[]): SessionV
 /**
  * Build a ToolActivityItem from a (ToolCallMessage, ToolResultMessage?) pair.
  *
- * - Missing result + isError-false-not-applicable → status 'interrupted' (orphan from crash)
+ * - Missing result → status 'interrupted' (orphan from crash)
+ * - Cancelled shell / aborted explore → 'interrupted' (not failure)
  * - Result with isError === true → 'errored' (includes permission deny/block)
  * - Result with isError === false → 'completed'
  */
@@ -166,7 +168,7 @@ function toolActivityFromPair(
     ...(call.activityKind !== undefined ? { activityKind: call.activityKind } : {}),
     ...(call.displayName !== undefined ? { displayName: call.displayName } : {}),
     ...(call.intent !== undefined ? { intent: call.intent } : {}),
-    status: result.isError ? 'errored' : 'completed',
+    status: toolResultActivityStatus(result.isError, result.content),
     args: call.args,
     result: result.content,
     isError: result.isError,
@@ -220,7 +222,7 @@ export function applyAppendedMessage(
           ...it,
           item: {
             ...it.item,
-            status: message.isError ? 'errored' as const : 'completed' as const,
+            status: toolResultActivityStatus(message.isError, message.content),
             result: message.content,
             isError: message.isError,
             ...(message.durationMs !== undefined ? { durationMs: message.durationMs } : {}),

--- a/packages/runtime/src/runtime-event-backfill.ts
+++ b/packages/runtime/src/runtime-event-backfill.ts
@@ -140,6 +140,7 @@ export function backfillRuntimeEventsFromStoredMessages(
           actions: {
             stateDelta: {
               ...recoveryState(now, message),
+              ...(message.activityKind !== undefined ? { activityKind: message.activityKind } : {}),
               ...(message.displayName !== undefined ? { displayName: message.displayName } : {}),
               ...(message.intent !== undefined ? { intent: message.intent } : {}),
             },

--- a/packages/runtime/src/runtime-event-read-model.ts
+++ b/packages/runtime/src/runtime-event-read-model.ts
@@ -4,10 +4,12 @@ import type {
   RuntimeEvent,
   RuntimeEventStatus,
   StoredMessage,
+  ToolActivityKind,
   ToolResultContent,
   TurnStatus,
 } from '@maka/core';
 import {
+  TOOL_ACTIVITY_KINDS,
   isPartialRuntimeEvent,
   isTerminalRuntimeEvent,
   isTerminalRuntimeEventStatus,
@@ -501,6 +503,9 @@ function projectFunctionCall(
     turnId: event.turnId,
     ts: event.ts,
     toolName: event.content.name,
+    ...(toolActivityKindStateDelta(event) !== undefined
+      ? { activityKind: toolActivityKindStateDelta(event) }
+      : {}),
     ...(stringStateDelta(event, 'displayName') !== undefined
       ? { displayName: stringStateDelta(event, 'displayName') }
       : {}),
@@ -814,6 +819,11 @@ function stringStateDelta(event: RuntimeEvent, key: string): string | undefined 
   return typeof value === 'string' ? value : undefined;
 }
 
+function toolActivityKindStateDelta(event: RuntimeEvent): ToolActivityKind | undefined {
+  const value = stringStateDelta(event, 'activityKind');
+  return TOOL_ACTIVITY_KINDS.find((kind) => kind === value);
+}
+
 function numberStateDelta(event: RuntimeEvent, key: string): number | undefined {
   const value = event.actions?.stateDelta?.[key];
   return typeof value === 'number' ? value : undefined;
@@ -940,6 +950,7 @@ function semanticMessage(message: StoredMessage): unknown {
         turnId: message.turnId,
         toolUseId: message.id,
         toolName: message.toolName,
+        activityKind: message.activityKind,
         displayName: message.displayName,
         intent: message.intent,
         args: message.args,

--- a/packages/runtime/src/shell-tools.ts
+++ b/packages/runtime/src/shell-tools.ts
@@ -58,6 +58,7 @@ export function buildForegroundBashTool(options: BuildForegroundBashToolOptions)
   const maxTimeoutMs = options.maxTimeoutMs ?? 600_000;
   return {
     name: 'Bash',
+    activityKind: 'command',
     description: options.description,
     parameters: z.object({
       command: z.string().describe('The shell command to execute'),
@@ -108,6 +109,7 @@ export function buildBackgroundBashTool(
   const shell = options.shell ?? defaultShellPlan();
   return {
     name: 'Bash',
+    activityKind: 'command',
     description:
       withShellGuidance('Run a shell command in the session cwd.', shell)
       + ' Commands that outlive yield_time_ms continue as runtime background tasks; use the returned ref with Read to inspect them. Subject to permission policy.',
@@ -142,6 +144,7 @@ export function withShellGuidance(lead: string, shell: ShellPlan): string {
 export function buildStopBackgroundTaskTool(shellRuns: ShellRunToolController): MakaTool {
   return {
     name: 'StopBackgroundTask',
+    activityKind: 'command',
     description:
       'Stop a background task by runtime ref. Currently supports background shell run refs returned by Bash and shown in the turn tail.',
     parameters: z.object({

--- a/packages/runtime/src/tool-runtime.ts
+++ b/packages/runtime/src/tool-runtime.ts
@@ -1,5 +1,6 @@
 import type {
   SessionEvent,
+  ToolActivityKind,
   ToolOutputStream,
   ToolResultContent,
   ToolResultEvent,
@@ -43,6 +44,8 @@ export interface MakaTool<P = any, R = unknown> {
   permissionRequired?: boolean;
   /** Optional UI display name. */
   displayName?: string;
+  /** Stable semantic category used by UI presentation; never carries styling. */
+  activityKind?: ToolActivityKind;
   /** Optional trusted category override for custom tools. */
   categoryHint?: ToolCategory;
   /** Optional trusted facts about the executor that runs this tool. */
@@ -251,6 +254,7 @@ export class ToolRuntime {
       turnId,
       ts: now,
       toolName: tool.name,
+      ...(tool.activityKind ? { activityKind: tool.activityKind } : {}),
       ...(tool.displayName ? { displayName: tool.displayName } : {}),
       ...(toolIntent ? { intent: toolIntent } : {}),
       args,
@@ -266,6 +270,7 @@ export class ToolRuntime {
       ts: now,
       toolUseId,
       toolName: tool.name,
+      ...(tool.activityKind ? { activityKind: tool.activityKind } : {}),
       args,
       ...(tool.displayName ? { displayName: tool.displayName } : {}),
       ...(toolIntent ? { intent: toolIntent } : {}),

--- a/packages/ui/src/__tests__/live-turn-projection.test.ts
+++ b/packages/ui/src/__tests__/live-turn-projection.test.ts
@@ -508,6 +508,64 @@ describe('reconcileTerminalLiveTurn', () => {
     assert.equal(reconcileTerminalLiveTurn(withOutput, toolCallOnly), withOutput);
   });
 
+  it('keeps live stream evidence when persisted shell_run streams are still empty', () => {
+    const withOutput: LiveTurnProjection = {
+      ...toolOnly,
+      steps: [{
+        ...toolOnly.steps[0]!,
+        tools: [{
+          ...toolOnly.steps[0]!.tools[0]!,
+          status: 'completed',
+          outputChunks: [
+            { seq: 0, stream: 'stdout', text: 'starting-live-output\n', redacted: true, createdAt: 1 },
+          ],
+          outputTruncated: true,
+        }],
+      }],
+    };
+    const emptyContent = {
+      kind: 'shell_run' as const,
+      ref: 'maka://runtime/background-tasks/bg',
+      status: 'running' as const,
+      cwd: '/repo',
+      cmd: 'npm test',
+      startedAt: 1,
+      updatedAt: 2,
+      stdout: '',
+      stderr: '',
+      stdoutTruncated: false,
+      stderrTruncated: false,
+    };
+    const emptyShellRun = [
+      { type: 'tool_call' as const, id: 'tool-1', turnId: 'turn-1', stepId: 'step-1', ts: 1, toolName: 'Bash', args: {} },
+      {
+        type: 'tool_result' as const,
+        id: 'result-1',
+        turnId: 'turn-1',
+        ts: 2,
+        toolUseId: 'tool-1',
+        isError: false,
+        content: emptyContent,
+      },
+    ];
+
+    assert.equal(reconcileTerminalLiveTurn(withOutput, emptyShellRun), withOutput);
+
+    const filled = [
+      emptyShellRun[0]!,
+      {
+        type: 'tool_result' as const,
+        id: 'result-1',
+        turnId: 'turn-1',
+        ts: 2,
+        toolUseId: 'tool-1',
+        isError: false,
+        content: { ...emptyContent, stdout: 'starting-live-output\n' },
+      },
+    ];
+    assert.equal(reconcileTerminalLiveTurn(withOutput, filled), undefined);
+  });
+
   it('leaves text steps to the smoother handoff', () => {
     const textTurn: LiveTurnProjection = {
       ...toolOnly,

--- a/packages/ui/src/__tests__/live-turn-projection.test.ts
+++ b/packages/ui/src/__tests__/live-turn-projection.test.ts
@@ -465,6 +465,53 @@ describe('settleLiveTurnStep', () => {
       { turnId: 'turn-1', phase: 'streamed', steps: [] },
     );
   });
+
+  it('keeps co-located tool stream evidence when text handoff settles', () => {
+    const projection: LiveTurnProjection = {
+      turnId: 'turn-1',
+      phase: 'streamed',
+      terminal: true,
+      steps: [{
+        stepId: 'step-1',
+        text: { text: 'done', truncated: false, complete: true },
+        tools: [{
+          toolUseId: 'tool-1',
+          toolName: 'Bash',
+          status: 'completed',
+          args: { command: 'npm test' },
+          outputChunks: [
+            { seq: 0, stream: 'stdout', text: 'starting-live-output\n', redacted: true, createdAt: 1 },
+          ],
+          outputTruncated: true,
+        }],
+      }],
+    };
+
+    const settled = settleLiveTurnStep(projection, 'step-1');
+    assert.ok(settled);
+    assert.equal(settled!.steps.length, 1);
+    assert.equal(settled!.steps[0]!.text, undefined);
+    assert.equal(settled!.steps[0]!.tools[0]!.outputChunks?.[0]?.text, 'starting-live-output\n');
+  });
+
+  it('still drops tools without live stream evidence on text settle', () => {
+    const projection: LiveTurnProjection = {
+      turnId: 'turn-1',
+      phase: 'streamed',
+      terminal: true,
+      steps: [{
+        stepId: 'step-1',
+        text: { text: 'done', truncated: false, complete: true },
+        tools: [{
+          toolUseId: 'tool-1',
+          toolName: 'Bash',
+          status: 'interrupted',
+          args: {},
+        }],
+      }],
+    };
+    assert.equal(settleLiveTurnStep(projection, 'step-1'), undefined);
+  });
 });
 
 describe('reconcileTerminalLiveTurn', () => {

--- a/packages/ui/src/__tests__/live-turn-projection.test.ts
+++ b/packages/ui/src/__tests__/live-turn-projection.test.ts
@@ -64,6 +64,7 @@ describe('applyLiveTurnEvent', () => {
       stepId: 'step-1',
       toolUseId: 'tool-1',
       toolName: 'Task List',
+      activityKind: 'command',
       args: {},
       ts: 101,
     });
@@ -72,6 +73,7 @@ describe('applyLiveTurnEvent', () => {
     assert.deepEqual(projection.steps[0]?.tools, [{
       toolUseId: 'tool-1',
       toolName: 'Task List',
+      activityKind: 'command',
       stepId: 'step-1',
       status: 'pending',
       args: {},

--- a/packages/ui/src/__tests__/live-turn-projection.test.ts
+++ b/packages/ui/src/__tests__/live-turn-projection.test.ts
@@ -191,6 +191,40 @@ describe('applyLiveTurnEvent', () => {
     });
   });
 
+  it('maps cancelled terminal tool_result to interrupted, not errored', () => {
+    const started = applyLiveTurnEvent(undefined, {
+      type: 'tool_start',
+      id: 'event-1',
+      turnId: 'turn-1',
+      stepId: 'step-1',
+      toolUseId: 'tool-1',
+      toolName: 'Bash',
+      args: { command: 'sleep 99' },
+      ts: 100,
+    });
+    const projection = applyLiveTurnEvent(started, {
+      type: 'tool_result',
+      id: 'event-2',
+      turnId: 'turn-1',
+      toolUseId: 'tool-1',
+      isError: true,
+      content: {
+        kind: 'terminal',
+        cwd: '/repo',
+        cmd: 'sleep 99',
+        status: 'cancelled',
+        exitCode: 130,
+        stdout: '',
+        stderr: '',
+        stdoutTruncated: false,
+        stderrTruncated: false,
+      },
+      ts: 101,
+    });
+
+    assert.equal(projection.steps[0]?.tools[0]?.status, 'interrupted');
+  });
+
   it('appends streamed tool output to the existing tool without changing its step', () => {
     const started = applyLiveTurnEvent(undefined, {
       type: 'tool_start',

--- a/packages/ui/src/__tests__/tool-activity-presentation.test.ts
+++ b/packages/ui/src/__tests__/tool-activity-presentation.test.ts
@@ -355,6 +355,12 @@ describe('tool activity presentation', () => {
       'token: short-secret',
       'Authorization: Bearer SENTINEL_TOKEN',
       'password: correct horse',
+      // Multi-word key names + bare auth= payloads
+      'api key: correct horse',
+      'private key: gamma delta',
+      'auth=correct horse',
+      'auth: short secret',
+      'access token: alpha beta',
     ]) {
       const markup = renderToStaticMarkup(createElement(ToolActivity, {
         items: [{
@@ -365,7 +371,10 @@ describe('tool activity presentation', () => {
           result: { kind: 'json', value: { ok: true } },
         } satisfies ToolActivityItem],
       }));
-      assert.doesNotMatch(markup, /correct-horse|short-secret|SENTINEL_TOKEN|\bhorse\b/);
+      assert.doesNotMatch(
+        markup,
+        /correct-horse|short-secret|SENTINEL_TOKEN|\bhorse\b|gamma|delta|alpha|beta/,
+      );
       assert.match(markup, /redacted/i);
     }
   });

--- a/packages/ui/src/__tests__/tool-activity-presentation.test.ts
+++ b/packages/ui/src/__tests__/tool-activity-presentation.test.ts
@@ -146,8 +146,71 @@ describe('tool activity presentation', () => {
 
     assert.doesNotMatch(markup, /stdout\s+2/i);
     assert.doesNotMatch(markup, /stderr\s+1/i);
-    assert.match(markup, /stderr/i);
+    // Body still carries the failed stream text; no transport counts.
+    assert.match(markup, /failed/);
     assert.match(markup, /已脱敏/);
-    assert.match(markup, /已截断/);
+    assert.match(markup, /已截断|输出已截断/);
+  });
+
+  it('renders expanded terminal output as one quiet panel without diagnostic chrome', () => {
+    const markup = renderToStaticMarkup(createElement(ToolActivity, {
+      items: [{
+        toolUseId: 'tool-terminal-panel',
+        toolName: 'Bash',
+        intent: '跑测试',
+        status: 'errored',
+        args: { command: 'npm run -w @maka/ui test' },
+        result: {
+          kind: 'terminal',
+          cwd: '/tmp/maka',
+          cmd: 'npm run -w @maka/ui test',
+          status: 'failed',
+          exitCode: 1,
+          stdout: 'packages/ui ok\n',
+          stderr: 'Error: boom\n',
+          stdoutTruncated: false,
+          stderrTruncated: false,
+        },
+      } satisfies ToolActivityItem],
+    }));
+
+    // Command without shell prompt; no cwd / success-style exit badge bar.
+    assert.match(markup, /npm run -w @maka\/ui test/);
+    assert.doesNotMatch(markup, /\$\s*npm run -w @maka\/ui test/);
+    assert.doesNotMatch(markup, /\/tmp\/maka/);
+    assert.doesNotMatch(markup, /实时输出/);
+    // Failure note, not a permanent exit-code chrome row for successes.
+    assert.match(markup, /失败 · 退出码 1|失败.*退出码 1/);
+    assert.match(markup, /Error: boom/);
+    // Unified panel surface (Codex-like well).
+    assert.match(markup, /bg-\[var\(--foreground-3\)\]|data-slot="tool-output"/);
+    // Tool output body uses base 13px, not caption 11px.
+    assert.match(markup, /font-size-base/);
+    // No always-on copy control on the output well (error banner may still copy).
+    assert.doesNotMatch(markup, /复制研读提示/);
+  });
+
+  it('keeps live tool output in the same quiet panel language when open', () => {
+    const markup = renderToStaticMarkup(createElement(ToolActivity, {
+      items: [{
+        toolUseId: 'tool-live-panel',
+        toolName: 'Bash',
+        intent: '检查结构',
+        status: 'waiting_permission',
+        args: { command: 'Get-ChildItem -Depth 1' },
+        outputChunks: [
+          { seq: 1, stream: 'stdout', text: 'packages\n', redacted: false, createdAt: 1 },
+        ],
+        outputTruncated: true,
+      } satisfies ToolActivityItem],
+    }));
+
+    assert.match(markup, /Get-ChildItem -Depth 1/);
+    assert.doesNotMatch(markup, /\$\s*Get-ChildItem/);
+    assert.doesNotMatch(markup, /实时输出/);
+    assert.match(markup, /packages/);
+    assert.match(markup, /已截断|输出已截断/);
+    assert.match(markup, /bg-\[var\(--foreground-3\)\]|data-slot="tool-output"/);
+    assert.match(markup, /max-h-64/);
   });
 });

--- a/packages/ui/src/__tests__/tool-activity-presentation.test.ts
+++ b/packages/ui/src/__tests__/tool-activity-presentation.test.ts
@@ -294,4 +294,42 @@ describe('tool activity presentation', () => {
     assert.doesNotMatch(markup, /\{\s*&quot;ok&quot;/);
     assert.doesNotMatch(markup, /line one\\nline two/);
   });
+
+  it('redacts credential-bearing property names in quiet key/value output', () => {
+    const secret = 'sk-1234567890abcdefghi';
+    const markup = renderToStaticMarkup(createElement(ToolActivity, {
+      items: [{
+        toolUseId: 'tool-secret-key',
+        toolName: 'CustomInspect',
+        status: 'waiting_permission',
+        args: { [`api_key=${secret}`]: true },
+        result: {
+          kind: 'json',
+          value: { nested: { [`token=${secret}`]: 'ok' } },
+        },
+      } satisfies ToolActivityItem],
+    }));
+
+    assert.doesNotMatch(markup, new RegExp(secret));
+    assert.match(markup, /redacted|api_key|&lt;redacted&gt;|ok/i);
+  });
+
+  it('keeps the Write path when args and result headlines match', () => {
+    const markup = renderToStaticMarkup(createElement(ToolActivity, {
+      items: [{
+        toolUseId: 'tool-write',
+        toolName: 'Write',
+        activityKind: 'edit',
+        status: 'waiting_permission',
+        args: { path: 'packages/ui/src/secret.ts', content: 'x' },
+        result: {
+          kind: 'json',
+          value: { ok: true, path: 'packages/ui/src/secret.ts', bytes: 1 },
+        },
+      } satisfies ToolActivityItem],
+    }));
+
+    assert.match(markup, /packages\/ui\/src\/secret\.ts/);
+    assert.match(markup, /已完成|1 B/);
+  });
 });

--- a/packages/ui/src/__tests__/tool-activity-presentation.test.ts
+++ b/packages/ui/src/__tests__/tool-activity-presentation.test.ts
@@ -314,6 +314,43 @@ describe('tool activity presentation', () => {
     assert.match(markup, /redacted|api_key|&lt;redacted&gt;|ok/i);
   });
 
+  it('redacts short secrets under sensitive keys like password', () => {
+    const markup = renderToStaticMarkup(createElement(ToolActivity, {
+      items: [{
+        toolUseId: 'tool-password',
+        toolName: 'CustomInspect',
+        status: 'waiting_permission',
+        args: { password: 'correct-horse' },
+        result: {
+          kind: 'json',
+          value: { token: 'short-secret', ok: true },
+        },
+      } satisfies ToolActivityItem],
+    }));
+
+    assert.doesNotMatch(markup, /correct-horse/);
+    assert.doesNotMatch(markup, /short-secret/);
+    assert.match(markup, /redacted|password|token/i);
+  });
+
+  it('keeps error diagnostics when a list field is also present', () => {
+    const markup = renderToStaticMarkup(createElement(ToolActivity, {
+      items: [{
+        toolUseId: 'tool-mixed',
+        toolName: 'CustomInspect',
+        status: 'errored',
+        args: {},
+        result: {
+          kind: 'json',
+          value: { results: [], error: 'permission denied', ok: false },
+        },
+      } satisfies ToolActivityItem],
+    }));
+
+    assert.match(markup, /permission denied/);
+    assert.match(markup, /ok:\s*false|未完成|false/);
+  });
+
   it('keeps the Write path when args and result headlines match', () => {
     const markup = renderToStaticMarkup(createElement(ToolActivity, {
       items: [{
@@ -331,5 +368,81 @@ describe('tool activity presentation', () => {
 
     assert.match(markup, /packages\/ui\/src\/secret\.ts/);
     assert.match(markup, /已完成|1 B/);
+  });
+
+  it('renders shell_run with command, status, and captured output', () => {
+    const markup = renderToStaticMarkup(createElement(ToolActivity, {
+      items: [{
+        toolUseId: 'tool-shell-run',
+        toolName: 'Bash',
+        activityKind: 'command',
+        status: 'waiting_permission',
+        args: { command: 'npm test' },
+        result: {
+          kind: 'shell_run',
+          ref: 'maka://runtime/background-tasks/bg-1',
+          status: 'running',
+          cwd: '/repo',
+          cmd: 'npm test',
+          startedAt: 1,
+          updatedAt: 2,
+          stdout: 'starting\n',
+          stderr: '',
+          stdoutTruncated: false,
+          stderrTruncated: false,
+        },
+      } satisfies ToolActivityItem],
+    }));
+
+    assert.match(markup, /npm test/);
+    assert.match(markup, /后台运行中|background-tasks/);
+    assert.match(markup, /starting/);
+    assert.doesNotMatch(markup, /\[shell_run\]/);
+  });
+
+  it('surfaces terminal cancel and runtime truncation flags', () => {
+    const cancelled = renderToStaticMarkup(createElement(ToolActivity, {
+      items: [{
+        toolUseId: 'tool-cancel',
+        toolName: 'Bash',
+        status: 'errored',
+        args: { command: 'sleep 99' },
+        result: {
+          kind: 'terminal',
+          cwd: '/repo',
+          cmd: 'sleep 99',
+          status: 'cancelled',
+          exitCode: 130,
+          stdout: '',
+          stderr: '',
+          stdoutTruncated: false,
+          stderrTruncated: false,
+        },
+      } satisfies ToolActivityItem],
+    }));
+    assert.match(cancelled, /已取消/);
+    assert.doesNotMatch(cancelled, /失败 · 退出码 130/);
+
+    const truncated = renderToStaticMarkup(createElement(ToolActivity, {
+      items: [{
+        toolUseId: 'tool-trunc',
+        toolName: 'Bash',
+        status: 'waiting_permission',
+        args: { command: 'run' },
+        result: {
+          kind: 'terminal',
+          cwd: '/repo',
+          cmd: 'run',
+          status: 'completed',
+          exitCode: 0,
+          stdout: 'tail only',
+          stderr: '',
+          stdoutTruncated: true,
+          stderrTruncated: false,
+        },
+      } satisfies ToolActivityItem],
+    }));
+    assert.match(truncated, /tail only/);
+    assert.match(truncated, /输出已截断/);
   });
 });

--- a/packages/ui/src/__tests__/tool-activity-presentation.test.ts
+++ b/packages/ui/src/__tests__/tool-activity-presentation.test.ts
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 import { createElement } from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
+import type { StoredMessage } from '@maka/core';
 import { ToolActivity, ToolTrow } from '../tool-activity.js';
 import {
   createToolDisclosureState,
@@ -9,13 +10,39 @@ import {
   setToolDisclosureOpen,
   syncToolDisclosureState,
 } from '../tool-activity/presentation.js';
-import type { ToolActivityItem } from '../materialize.js';
+import { materializeTools, type ToolActivityItem } from '../materialize.js';
 
 function renderTool(item: ToolActivityItem): string {
   return renderToStaticMarkup(createElement(ToolTrow, { items: [item] }));
 }
 
 describe('tool activity presentation', () => {
+  it('prefers a declared semantic kind over the legacy tool-name fallback', () => {
+    const item: ToolActivityItem = {
+      toolUseId: 'tool-kind',
+      toolName: 'Read',
+      activityKind: 'command',
+      status: 'running',
+      args: {},
+    };
+
+    assert.equal(deriveToolActivityPresentation(item).kind, 'command');
+  });
+
+  it('materializes a persisted activity kind for replay', () => {
+    const messages: StoredMessage[] = [{
+      type: 'tool_call',
+      id: 'tool-replay',
+      turnId: 'turn-replay',
+      ts: 1,
+      toolName: 'CustomPatch',
+      activityKind: 'edit',
+      args: {},
+    }];
+
+    assert.equal(materializeTools(messages)[0]?.activityKind, 'edit');
+  });
+
   it('keeps a running command detail collapsed by default', () => {
     const markup = renderTool({
       toolUseId: 'tool-running',

--- a/packages/ui/src/__tests__/tool-activity-presentation.test.ts
+++ b/packages/ui/src/__tests__/tool-activity-presentation.test.ts
@@ -478,6 +478,40 @@ describe('tool activity presentation', () => {
     assert.equal(panels.length, 1);
   });
 
+  it('keeps redacted/truncated meta when live chunks are empty bodies', () => {
+    const markup = renderToStaticMarkup(createElement(ToolActivity, {
+      items: [{
+        toolUseId: 'tool-shell-run-empty-meta',
+        toolName: 'Bash',
+        activityKind: 'command',
+        status: 'waiting_permission',
+        args: { command: 'npm test' },
+        outputChunks: [
+          { seq: 1, stream: 'stdout', text: '', redacted: true, createdAt: 1 },
+        ],
+        outputTruncated: true,
+        result: {
+          kind: 'shell_run',
+          ref: 'maka://runtime/background-tasks/bg-meta',
+          status: 'running',
+          cwd: '/repo',
+          cmd: 'npm test',
+          startedAt: 1,
+          updatedAt: 2,
+          stdout: '',
+          stderr: '',
+          stdoutTruncated: false,
+          stderrTruncated: false,
+        },
+      } satisfies ToolActivityItem],
+    }));
+
+    assert.match(markup, /已脱敏/);
+    assert.match(markup, /输出已截断/);
+    const panels = markup.match(/data-slot="tool-output"/g) ?? [];
+    assert.equal(panels.length, 1);
+  });
+
   it('does not wrap subagent preview in an outer quiet panel', () => {
     const markup = renderToStaticMarkup(createElement(ToolActivity, {
       items: [{

--- a/packages/ui/src/__tests__/tool-activity-presentation.test.ts
+++ b/packages/ui/src/__tests__/tool-activity-presentation.test.ts
@@ -349,7 +349,13 @@ describe('tool activity presentation', () => {
   });
 
   it('redacts secrets in keys that use colon or space separators', () => {
-    for (const key of ['password: correct-horse', 'password correct-horse', 'token: short-secret']) {
+    for (const key of [
+      'password: correct-horse',
+      'password correct-horse',
+      'token: short-secret',
+      'Authorization: Bearer SENTINEL_TOKEN',
+      'password: correct horse',
+    ]) {
       const markup = renderToStaticMarkup(createElement(ToolActivity, {
         items: [{
           toolUseId: `tool-key-${key}`,
@@ -359,7 +365,7 @@ describe('tool activity presentation', () => {
           result: { kind: 'json', value: { ok: true } },
         } satisfies ToolActivityItem],
       }));
-      assert.doesNotMatch(markup, /correct-horse|short-secret/);
+      assert.doesNotMatch(markup, /correct-horse|short-secret|SENTINEL_TOKEN|\bhorse\b/);
       assert.match(markup, /redacted/i);
     }
   });
@@ -445,8 +451,9 @@ describe('tool activity presentation', () => {
         status: 'waiting_permission',
         args: { command: 'npm test' },
         outputChunks: [
-          { seq: 1, stream: 'stdout', text: 'starting-live-output\n', redacted: false, createdAt: 1 },
+          { seq: 1, stream: 'stdout', text: 'starting-live-output\n', redacted: true, createdAt: 1 },
         ],
+        outputTruncated: true,
         result: {
           kind: 'shell_run',
           ref: 'maka://runtime/background-tasks/bg-empty',
@@ -464,9 +471,36 @@ describe('tool activity presentation', () => {
     }));
 
     assert.match(markup, /starting-live-output/);
+    assert.match(markup, /已脱敏/);
+    assert.match(markup, /输出已截断/);
     assert.doesNotMatch(markup, /尚无输出/);
     const panels = markup.match(/data-slot="tool-output"/g) ?? [];
     assert.equal(panels.length, 1);
+  });
+
+  it('does not wrap subagent preview in an outer quiet panel', () => {
+    const markup = renderToStaticMarkup(createElement(ToolActivity, {
+      items: [{
+        toolUseId: 'tool-subagent',
+        toolName: 'Subagent',
+        status: 'waiting_permission',
+        args: {},
+        result: {
+          kind: 'subagent',
+          agentName: 'Review Agent',
+          turnId: 'turn',
+          status: 'completed',
+          permissionMode: 'ask',
+          summary: 'done',
+          artifactIds: [],
+          startedAt: 1,
+          durationMs: 1,
+        },
+      } satisfies ToolActivityItem],
+    }));
+    assert.match(markup, /data-kind="subagent"/);
+    // Subagent owns its surface — no outer tool-output well wrapping it.
+    assert.equal((markup.match(/data-slot="tool-output"/g) ?? []).length, 0);
   });
 
   it('surfaces terminal cancel and runtime truncation flags', () => {

--- a/packages/ui/src/__tests__/tool-activity-presentation.test.ts
+++ b/packages/ui/src/__tests__/tool-activity-presentation.test.ts
@@ -1,0 +1,100 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { createElement } from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { ToolActivity, ToolTrow } from '../tool-activity.js';
+import {
+  createToolDisclosureState,
+  deriveToolActivityPresentation,
+  setToolDisclosureOpen,
+  syncToolDisclosureState,
+} from '../tool-activity/presentation.js';
+import type { ToolActivityItem } from '../materialize.js';
+
+function renderTool(item: ToolActivityItem): string {
+  return renderToStaticMarkup(createElement(ToolTrow, { items: [item] }));
+}
+
+describe('tool activity presentation', () => {
+  it('keeps a running command detail collapsed by default', () => {
+    const markup = renderTool({
+      toolUseId: 'tool-running',
+      toolName: 'Bash',
+      intent: '检查当前项目结构',
+      status: 'running',
+      args: { command: 'Get-ChildItem -Recurse -Depth 1' },
+      outputChunks: [
+        { seq: 1, stream: 'stdout', text: 'packages\n', redacted: false, createdAt: 1 },
+      ],
+    });
+
+    assert.doesNotMatch(markup, /Get-ChildItem/);
+    assert.doesNotMatch(markup, /实时输出/);
+    assert.match(markup, /检查当前项目结构/);
+  });
+
+  it('preserves a manual expansion across ordinary status changes', () => {
+    const running: ToolActivityItem = {
+      toolUseId: 'tool-manual',
+      toolName: 'Bash',
+      status: 'running',
+      args: { command: 'npm test' },
+    };
+    const completed: ToolActivityItem = {
+      ...running,
+      status: 'completed',
+    };
+    const initial = createToolDisclosureState(deriveToolActivityPresentation(running));
+    const expanded = setToolDisclosureOpen(initial, true);
+
+    assert.deepEqual(
+      syncToolDisclosureState(expanded, deriveToolActivityPresentation(completed)),
+      { open: true, manuallySet: true },
+    );
+  });
+
+  it('opens a newly errored tool even after an earlier manual collapse', () => {
+    const running: ToolActivityItem = {
+      toolUseId: 'tool-error',
+      toolName: 'Bash',
+      status: 'running',
+      args: { command: 'npm test' },
+    };
+    const errored: ToolActivityItem = {
+      ...running,
+      status: 'errored',
+    };
+    const collapsed = setToolDisclosureOpen(
+      createToolDisclosureState(deriveToolActivityPresentation(running)),
+      false,
+    );
+
+    assert.deepEqual(
+      syncToolDisclosureState(collapsed, deriveToolActivityPresentation(errored)),
+      { open: true, manuallySet: false },
+    );
+  });
+
+  it('shows diagnostic flags without exposing transport chunk counts', () => {
+    const markup = renderToStaticMarkup(createElement(ToolActivity, {
+      items: [{
+        toolUseId: 'tool-output',
+        toolName: 'Bash',
+        status: 'errored',
+        args: { command: 'npm test' },
+        outputChunks: [
+          { seq: 1, stream: 'stdout', text: 'one\n', redacted: false, createdAt: 1 },
+          { seq: 2, stream: 'stdout', text: 'two\n', redacted: true, createdAt: 2 },
+          { seq: 3, stream: 'stderr', text: 'failed\n', redacted: false, createdAt: 3 },
+        ],
+        outputTruncated: true,
+      } satisfies ToolActivityItem],
+    }));
+
+    assert.doesNotMatch(markup, /stdout\s+2/i);
+    assert.doesNotMatch(markup, /stderr\s+1/i);
+    assert.match(markup, /stderr/i);
+    assert.match(markup, /已脱敏/);
+    assert.match(markup, /已截断/);
+  });
+});

--- a/packages/ui/src/__tests__/tool-activity-presentation.test.ts
+++ b/packages/ui/src/__tests__/tool-activity-presentation.test.ts
@@ -213,4 +213,60 @@ describe('tool activity presentation', () => {
     assert.match(markup, /bg-\[var\(--foreground-3\)\]|data-slot="tool-output"/);
     assert.match(markup, /max-h-64/);
   });
+
+  it('renders Read as path + file text, not tool-call/result JSON', () => {
+    // waiting_permission opens the panel without the error banner (which would
+    // otherwise stringify the JSON result for copy).
+    const markup = renderToStaticMarkup(createElement(ToolActivity, {
+      items: [{
+        toolUseId: 'tool-read',
+        toolName: 'Read',
+        activityKind: 'read',
+        intent: '读取 tool-runtime',
+        status: 'waiting_permission',
+        args: { path: 'packages/runtime/src/tool-runtime.ts', limit: 100 },
+        result: {
+          kind: 'json',
+          value: {
+            content: 'import type {\n  SessionEvent,\n  ToolOutputStream,\n} from \'@maka/core/events\';\n',
+          },
+        },
+      } satisfies ToolActivityItem],
+    }));
+
+    assert.match(markup, /packages\/runtime\/src\/tool-runtime\.ts/);
+    assert.match(markup, /SessionEvent/);
+    assert.match(markup, /ToolOutputStream/);
+    assert.doesNotMatch(markup, /&quot;path&quot;\s*:|"path"\s*:/);
+    assert.doesNotMatch(markup, /&quot;limit&quot;\s*:|"limit"\s*:/);
+    assert.doesNotMatch(markup, /&quot;content&quot;\s*:|"content"\s*:/);
+    assert.doesNotMatch(markup, /import type \{\\n/);
+  });
+
+  it('renders Grep as pattern + match lines, not raw JSON', () => {
+    const markup = renderToStaticMarkup(createElement(ToolActivity, {
+      items: [{
+        toolUseId: 'tool-grep',
+        toolName: 'Grep',
+        activityKind: 'search',
+        intent: '搜索 ToolOutputStream',
+        status: 'waiting_permission',
+        args: { pattern: 'ToolOutputStream', path: 'packages/ui/src' },
+        result: {
+          kind: 'json',
+          value: {
+            matches: [
+              'packages/ui/src/tool-activity.tsx:10:function ToolOutputStream',
+              'packages/ui/src/tool-activity.tsx:20:  chunks',
+            ],
+          },
+        },
+      } satisfies ToolActivityItem],
+    }));
+
+    assert.match(markup, /ToolOutputStream/);
+    assert.match(markup, /packages\/ui\/src\/tool-activity\.tsx:10/);
+    assert.doesNotMatch(markup, /&quot;pattern&quot;\s*:|"pattern"\s*:/);
+    assert.doesNotMatch(markup, /&quot;matches&quot;\s*:|"matches"\s*:/);
+  });
 });

--- a/packages/ui/src/__tests__/tool-activity-presentation.test.ts
+++ b/packages/ui/src/__tests__/tool-activity-presentation.test.ts
@@ -80,6 +80,32 @@ describe('tool activity presentation', () => {
     );
   });
 
+  it('preserves a manual expansion through a permission attention cycle', () => {
+    const running: ToolActivityItem = {
+      toolUseId: 'tool-permission',
+      toolName: 'Bash',
+      status: 'running',
+      args: { command: 'npm test' },
+    };
+    const waiting: ToolActivityItem = {
+      ...running,
+      status: 'waiting_permission',
+    };
+    const expanded = setToolDisclosureOpen(
+      createToolDisclosureState(deriveToolActivityPresentation(running)),
+      true,
+    );
+    const duringPermission = syncToolDisclosureState(
+      expanded,
+      deriveToolActivityPresentation(waiting),
+    );
+
+    assert.deepEqual(
+      syncToolDisclosureState(duringPermission, deriveToolActivityPresentation(running)),
+      { open: true, manuallySet: true },
+    );
+  });
+
   it('opens a newly errored tool even after an earlier manual collapse', () => {
     const running: ToolActivityItem = {
       toolUseId: 'tool-error',

--- a/packages/ui/src/__tests__/tool-activity-presentation.test.ts
+++ b/packages/ui/src/__tests__/tool-activity-presentation.test.ts
@@ -348,6 +348,22 @@ describe('tool activity presentation', () => {
     assert.match(markup, /password=&lt;redacted&gt;|password=&lt;redacted&gt;|password=&lt;redacted&gt;|password=<redacted>|redacted/i);
   });
 
+  it('redacts secrets in keys that use colon or space separators', () => {
+    for (const key of ['password: correct-horse', 'password correct-horse', 'token: short-secret']) {
+      const markup = renderToStaticMarkup(createElement(ToolActivity, {
+        items: [{
+          toolUseId: `tool-key-${key}`,
+          toolName: 'CustomInspect',
+          status: 'waiting_permission',
+          args: { [key]: true },
+          result: { kind: 'json', value: { ok: true } },
+        } satisfies ToolActivityItem],
+      }));
+      assert.doesNotMatch(markup, /correct-horse|short-secret/);
+      assert.match(markup, /redacted/i);
+    }
+  });
+
   it('keeps error diagnostics when a list field is also present', () => {
     const markup = renderToStaticMarkup(createElement(ToolActivity, {
       items: [{
@@ -420,12 +436,45 @@ describe('tool activity presentation', () => {
     assert.equal(commands.length, 1);
   });
 
+  it('keeps pre-yield live output when shell_run lands with empty streams', () => {
+    const markup = renderToStaticMarkup(createElement(ToolActivity, {
+      items: [{
+        toolUseId: 'tool-shell-run-empty',
+        toolName: 'Bash',
+        activityKind: 'command',
+        status: 'waiting_permission',
+        args: { command: 'npm test' },
+        outputChunks: [
+          { seq: 1, stream: 'stdout', text: 'starting-live-output\n', redacted: false, createdAt: 1 },
+        ],
+        result: {
+          kind: 'shell_run',
+          ref: 'maka://runtime/background-tasks/bg-empty',
+          status: 'running',
+          cwd: '/repo',
+          cmd: 'npm test',
+          startedAt: 1,
+          updatedAt: 2,
+          stdout: '',
+          stderr: '',
+          stdoutTruncated: false,
+          stderrTruncated: false,
+        },
+      } satisfies ToolActivityItem],
+    }));
+
+    assert.match(markup, /starting-live-output/);
+    assert.doesNotMatch(markup, /尚无输出/);
+    const panels = markup.match(/data-slot="tool-output"/g) ?? [];
+    assert.equal(panels.length, 1);
+  });
+
   it('surfaces terminal cancel and runtime truncation flags', () => {
     const cancelled = renderToStaticMarkup(createElement(ToolActivity, {
       items: [{
         toolUseId: 'tool-cancel',
         toolName: 'Bash',
-        status: 'errored',
+        status: 'interrupted',
         args: { command: 'sleep 99' },
         result: {
           kind: 'terminal',
@@ -443,6 +492,31 @@ describe('tool activity presentation', () => {
     assert.match(cancelled, /已取消/);
     assert.doesNotMatch(cancelled, /失败 · 退出码 130/);
     assert.doesNotMatch(cancelled, /工具调用失败/);
+    // Outer status must not say 失败 either.
+    assert.doesNotMatch(cancelled, />失败</);
+
+    const cancelledTrow = renderToStaticMarkup(createElement(ToolTrow, {
+      items: [{
+        toolUseId: 'tool-cancel-trow',
+        toolName: 'Bash',
+        activityKind: 'command',
+        status: 'interrupted',
+        args: { command: 'sleep 99' },
+        result: {
+          kind: 'terminal',
+          cwd: '/repo',
+          cmd: 'sleep 99',
+          status: 'cancelled',
+          exitCode: 130,
+          stdout: '',
+          stderr: '',
+          stdoutTruncated: false,
+          stderrTruncated: false,
+        },
+      } satisfies ToolActivityItem],
+    }));
+    assert.match(cancelledTrow, /运行 1 条命令/);
+    assert.doesNotMatch(cancelledTrow, /1 个失败/);
 
     const truncated = renderToStaticMarkup(createElement(ToolActivity, {
       items: [{

--- a/packages/ui/src/__tests__/tool-activity-presentation.test.ts
+++ b/packages/ui/src/__tests__/tool-activity-presentation.test.ts
@@ -269,4 +269,29 @@ describe('tool activity presentation', () => {
     assert.doesNotMatch(markup, /&quot;pattern&quot;\s*:|"pattern"\s*:/);
     assert.doesNotMatch(markup, /&quot;matches&quot;\s*:|"matches"\s*:/);
   });
+
+  it('never dumps pretty JSON for an arbitrary tool result object', () => {
+    const markup = renderToStaticMarkup(createElement(ToolActivity, {
+      items: [{
+        toolUseId: 'tool-custom',
+        toolName: 'CustomInspect',
+        status: 'waiting_permission',
+        args: { target: 'packages/ui', depth: 2 },
+        result: {
+          kind: 'json',
+          value: {
+            ok: true,
+            notes: 'looks fine',
+            detail: 'line one\nline two',
+          },
+        },
+      } satisfies ToolActivityItem],
+    }));
+
+    assert.match(markup, /packages\/ui|target: packages\/ui/);
+    assert.match(markup, /looks fine|notes:/);
+    assert.match(markup, /line one/);
+    assert.doesNotMatch(markup, /\{\s*&quot;ok&quot;/);
+    assert.doesNotMatch(markup, /line one\\nline two/);
+  });
 });

--- a/packages/ui/src/__tests__/tool-activity-presentation.test.ts
+++ b/packages/ui/src/__tests__/tool-activity-presentation.test.ts
@@ -333,6 +333,21 @@ describe('tool activity presentation', () => {
     assert.match(markup, /redacted|password|token/i);
   });
 
+  it('redacts secrets embedded in property names', () => {
+    const markup = renderToStaticMarkup(createElement(ToolActivity, {
+      items: [{
+        toolUseId: 'tool-password-key',
+        toolName: 'CustomInspect',
+        status: 'waiting_permission',
+        args: { 'password=correct-horse': true },
+        result: { kind: 'json', value: { ok: true } },
+      } satisfies ToolActivityItem],
+    }));
+
+    assert.doesNotMatch(markup, /correct-horse/);
+    assert.match(markup, /password=&lt;redacted&gt;|password=&lt;redacted&gt;|password=&lt;redacted&gt;|password=<redacted>|redacted/i);
+  });
+
   it('keeps error diagnostics when a list field is also present', () => {
     const markup = renderToStaticMarkup(createElement(ToolActivity, {
       items: [{
@@ -398,6 +413,11 @@ describe('tool activity presentation', () => {
     assert.match(markup, /后台运行中|background-tasks/);
     assert.match(markup, /starting/);
     assert.doesNotMatch(markup, /\[shell_run\]/);
+    // One quiet well only — not nested shared + shell_run panels.
+    const panels = markup.match(/data-slot="tool-output"/g) ?? [];
+    assert.equal(panels.length, 1);
+    const commands = markup.match(/npm test/g) ?? [];
+    assert.equal(commands.length, 1);
   });
 
   it('surfaces terminal cancel and runtime truncation flags', () => {
@@ -422,6 +442,7 @@ describe('tool activity presentation', () => {
     }));
     assert.match(cancelled, /已取消/);
     assert.doesNotMatch(cancelled, /失败 · 退出码 130/);
+    assert.doesNotMatch(cancelled, /工具调用失败/);
 
     const truncated = renderToStaticMarkup(createElement(ToolActivity, {
       items: [{

--- a/packages/ui/src/chat-view.tsx
+++ b/packages/ui/src/chat-view.tsx
@@ -1668,7 +1668,7 @@ function DeepThinking(props: { text: string; live: boolean; truncated?: boolean 
           {props.live ? (
             <pre
               ref={bodyRef}
-              className="m-0 max-h-64 overflow-y-auto whitespace-pre-wrap [word-break:break-word] [font-family:inherit] text-[length:var(--font-size-caption)] leading-normal text-[color:var(--muted-foreground)] [scroll-behavior:auto]"
+              className="m-0 max-h-64 overflow-y-auto whitespace-pre-wrap [word-break:break-word] [font-family:inherit] text-[length:var(--font-size-base)] leading-normal text-[color:var(--muted-foreground)] [scroll-behavior:auto]"
             >
               <DeepThinkingBody text={displayed} streamFade={streamFade} />
             </pre>
@@ -1677,8 +1677,9 @@ function DeepThinking(props: { text: string; live: boolean; truncated?: boolean 
               {/* Same `max-h-64 overflow-y-auto` bound as the live `<pre>` above
                   so an expanded panel doesn't jump taller the frame thinking
                   settles (live→settled swaps this body in place). Long reasoning
-                  stays a compact scroll box in both states. */}
-              <div className="max-h-64 overflow-y-auto whitespace-pre-wrap [word-break:break-word] text-[length:var(--font-size-caption)] leading-normal text-[color:var(--muted-foreground)]">
+                  stays a compact scroll box in both states. Body uses base 13px
+                  so tool output and thinking share one reading size. */}
+              <div className="max-h-64 overflow-y-auto whitespace-pre-wrap [word-break:break-word] text-[length:var(--font-size-base)] leading-normal text-[color:var(--muted-foreground)]">
                 {props.text}
               </div>
               <div className="absolute right-0 top-0 opacity-0 [transition:opacity_var(--duration-quick)_var(--ease-out-strong)] group-hover/reasoning:opacity-100 focus-within:opacity-100">

--- a/packages/ui/src/chat-view.tsx
+++ b/packages/ui/src/chat-view.tsx
@@ -332,8 +332,15 @@ export function ChatView(props: {
   // the non-actionable placeholder and the indicator injects into the tail turn
   // (not the fallback section) — it is, by derivation, only ever true when text /
   // thinking / tools are all absent.
-  const streamingActive = !!(props.liveTurn || props.processingIndicator || props.continuingIndicator);
-  const tailTurnId = props.liveTurn?.turnId ?? (streamingActive ? turns[turns.length - 1]?.turnId : undefined);
+  //
+  // Terminal liveTurn is evidence overlay only (e.g. empty shell_run still needs
+  // pre-yield chunks). It must NOT block footer actions — keeping evidence and
+  // being in-flight are separate signals.
+  const liveInFlight = !!(props.liveTurn && !props.liveTurn.terminal);
+  const streamingActive = !!(liveInFlight || props.processingIndicator || props.continuingIndicator);
+  const tailTurnId = liveInFlight
+    ? props.liveTurn!.turnId
+    : (streamingActive ? turns[turns.length - 1]?.turnId : undefined);
   // One rail tick per turn that carries a user prompt (Codex-style prompt
   // navigation). Memoized so the rail's IntersectionObserver isn't rebuilt
   // on every render.

--- a/packages/ui/src/chat-view.tsx
+++ b/packages/ui/src/chat-view.tsx
@@ -335,9 +335,12 @@ export function ChatView(props: {
   //
   // Terminal liveTurn is evidence overlay only (e.g. empty shell_run still needs
   // pre-yield chunks). It must NOT block footer actions — keeping evidence and
-  // being in-flight are separate signals.
+  // being in-flight are separate signals. Wait indicators alone still mark
+  // streaming, but delayed flags can lag one frame past complete; terminal
+  // evidence must outrank them so copy/regenerate stay actionable.
   const liveInFlight = !!(props.liveTurn && !props.liveTurn.terminal);
-  const streamingActive = !!(liveInFlight || props.processingIndicator || props.continuingIndicator);
+  const waitIndicators = !!(props.processingIndicator || props.continuingIndicator);
+  const streamingActive = liveInFlight || (!props.liveTurn?.terminal && waitIndicators);
   const tailTurnId = liveInFlight
     ? props.liveTurn!.turnId
     : (streamingActive ? turns[turns.length - 1]?.turnId : undefined);

--- a/packages/ui/src/live-turn-projection.ts
+++ b/packages/ui/src/live-turn-projection.ts
@@ -170,6 +170,7 @@ export function applyLiveTurnEvent(
     const startedTool: ToolActivityItem = {
       toolUseId: event.toolUseId,
       toolName: event.toolName,
+      ...(event.activityKind !== undefined ? { activityKind: event.activityKind } : {}),
       ...(event.displayName !== undefined ? { displayName: event.displayName } : {}),
       ...(event.intent !== undefined ? { intent: event.intent } : {}),
       ...(event.stepId !== undefined ? { stepId: event.stepId } : {}),

--- a/packages/ui/src/live-turn-projection.ts
+++ b/packages/ui/src/live-turn-projection.ts
@@ -1,6 +1,7 @@
 import type { SessionEvent, StoredMessage } from '@maka/core';
 import { applyAssistantComplete, applyAssistantDelta } from './assistant-stream.js';
 import type { ToolActivityItem } from './materialize.js';
+import { toolResultActivityStatus } from './materialize.js';
 import { applyThinkingComplete, applyThinkingDelta } from './thinking-stream.js';
 import { applyToolOutputChunk } from './tool-output-stream.js';
 
@@ -219,7 +220,7 @@ export function applyLiveTurnEvent(
       : { toolUseId: event.toolUseId, toolName: 'Tool', status: 'pending', args: undefined };
     const tool: ToolActivityItem = {
       ...base,
-      status: event.isError ? 'errored' : 'completed',
+      status: toolResultActivityStatus(event.isError, event.content),
       result: event.content,
       ...(event.durationMs !== undefined ? { durationMs: event.durationMs } : {}),
     };

--- a/packages/ui/src/live-turn-projection.ts
+++ b/packages/ui/src/live-turn-projection.ts
@@ -1,7 +1,7 @@
 import type { SessionEvent, StoredMessage } from '@maka/core';
 import { applyAssistantComplete, applyAssistantDelta } from './assistant-stream.js';
+import { toolResultActivityStatus } from '@maka/core';
 import type { ToolActivityItem } from './materialize.js';
-import { toolResultActivityStatus } from './materialize.js';
 import { applyThinkingComplete, applyThinkingDelta } from './thinking-stream.js';
 import { applyToolOutputChunk } from './tool-output-stream.js';
 

--- a/packages/ui/src/live-turn-projection.ts
+++ b/packages/ui/src/live-turn-projection.ts
@@ -292,12 +292,32 @@ export function applyLiveTurnEvent(
   return { ...prior, phase: 'streamed', steps };
 }
 
+/**
+ * Text smoother handoff: drop the committed text/thinking slots for `stepId`.
+ * Tools that still carry live stream evidence (outputChunks) stay — empty
+ * shell_run durable results do not cover them, and co-located Bash+answer
+ * steps must not lose pre-yield output when the answer settles.
+ */
 export function settleLiveTurnStep(
   current: LiveTurnProjection,
   stepId: string,
 ): LiveTurnProjection | undefined {
-  const steps = current.steps.filter((step) => step.stepId !== stepId);
-  if (steps.length === current.steps.length) return current;
+  const stepIndex = current.steps.findIndex((step) => step.stepId === stepId);
+  if (stepIndex < 0) return current;
+  const step = current.steps[stepIndex]!;
+  const retainedTools = step.tools.filter((tool) => (tool.outputChunks?.length ?? 0) > 0);
+  const steps = retainedTools.length > 0
+    ? current.steps.map((candidate, index) => (
+      index === stepIndex
+        ? {
+            stepId: candidate.stepId,
+            tools: retainedTools,
+            contentOrder: ['tools' as const],
+          }
+        : candidate
+    ))
+    : current.steps.filter((candidate) => candidate.stepId !== stepId);
+  if (steps.length === current.steps.length && retainedTools.length === 0) return current;
   if (steps.length === 0 && current.terminal) return undefined;
   return { ...current, steps };
 }

--- a/packages/ui/src/live-turn-projection.ts
+++ b/packages/ui/src/live-turn-projection.ts
@@ -303,6 +303,31 @@ export function settleLiveTurnStep(
 }
 
 /**
+ * True when a persisted tool_result can replace live stream evidence for the
+ * same toolUseId. Empty shell_run/terminal bodies do not cover live chunks —
+ * background Bash yields an empty shell_run while live output is the only
+ * evidence the user already saw.
+ */
+function durableStreamEvidence(
+  messages: readonly StoredMessage[],
+  toolUseId: string,
+): boolean {
+  for (const message of messages) {
+    if (message.type !== 'tool_result' || message.toolUseId !== toolUseId) continue;
+    const content = message.content;
+    if (!content || typeof content !== 'object') return true;
+    if (content.kind === 'terminal' || content.kind === 'shell_run') {
+      return (content.stdout?.length ?? 0) > 0
+        || (content.stderr?.length ?? 0) > 0
+        || content.stdoutTruncated === true
+        || content.stderrTruncated === true;
+    }
+    return true;
+  }
+  return false;
+}
+
+/**
  * Removes terminal non-text steps only when the persisted transcript can
  * render the same durable evidence. Text steps remain owned by the smoother,
  * whose completion callback performs their handoff after the tail is visible.
@@ -321,8 +346,13 @@ export function reconcileTerminalLiveTurn(
     if (step.thinking && !assistantIds.has(step.stepId)) return true;
     const toolsCovered = step.tools.every((tool) => {
       if (!toolCallIds.has(tool.toolUseId)) return false;
-      if (tool.outputChunks?.length && !toolResultIds.has(tool.toolUseId)) return false;
-      return tool.status === 'interrupted' || toolResultIds.has(tool.toolUseId);
+      const hasResult = toolResultIds.has(tool.toolUseId);
+      // Live stream evidence only hands off when durable result has streams/meta.
+      if (tool.outputChunks?.length) {
+        if (!hasResult) return false;
+        if (!durableStreamEvidence(turnMessages, tool.toolUseId)) return false;
+      }
+      return tool.status === 'interrupted' || hasResult;
     });
     return !toolsCovered;
   });

--- a/packages/ui/src/materialize.ts
+++ b/packages/ui/src/materialize.ts
@@ -136,8 +136,31 @@ export function materializeTools(messages: StoredMessage[]): ToolActivityItem[] 
 function materializeToolResultStatus(
   result: Extract<StoredMessage, { type: 'tool_result' }>,
 ): ToolActivityItem['status'] {
-  if (!result.isError) return 'completed';
-  if (result.content.kind === 'explore_agent' && result.content.reason === 'aborted') {
+  return toolResultActivityStatus(result.isError, result.content);
+}
+
+/** Terminal / shell_run results whose runtime status is explicit cancel. */
+export function isCancelledToolResultContent(
+  content: ToolResultContent | undefined,
+): boolean {
+  if (!content) return false;
+  if (content.kind === 'terminal' || content.kind === 'shell_run') {
+    return content.status === 'cancelled';
+  }
+  return false;
+}
+
+/**
+ * Map a tool_result onto ToolActivityItem.status. Cancel is interrupted
+ * (user stop), not errored — so cards/trows never say "失败" for cancel.
+ */
+export function toolResultActivityStatus(
+  isError: boolean,
+  content: ToolResultContent | undefined,
+): ToolActivityItem['status'] {
+  if (isCancelledToolResultContent(content)) return 'interrupted';
+  if (!isError) return 'completed';
+  if (content?.kind === 'explore_agent' && content.reason === 'aborted') {
     return 'interrupted';
   }
   return 'errored';

--- a/packages/ui/src/materialize.ts
+++ b/packages/ui/src/materialize.ts
@@ -1,6 +1,8 @@
-import { deriveTurnRecords } from '@maka/core';
+import { deriveTurnRecords, toolResultActivityStatus } from '@maka/core';
 import type { AttachmentRef, StoredMessage, ToolActivityKind, ToolResultContent, TurnRecord, TurnStatus } from '@maka/core';
 import type { LiveTurnProjection } from './live-turn-projection.js';
+
+export { isCancelledToolResultContent, toolResultActivityStatus } from '@maka/core';
 
 export interface ChatItem {
   id: string;
@@ -137,33 +139,6 @@ function materializeToolResultStatus(
   result: Extract<StoredMessage, { type: 'tool_result' }>,
 ): ToolActivityItem['status'] {
   return toolResultActivityStatus(result.isError, result.content);
-}
-
-/** Terminal / shell_run results whose runtime status is explicit cancel. */
-export function isCancelledToolResultContent(
-  content: ToolResultContent | undefined,
-): boolean {
-  if (!content) return false;
-  if (content.kind === 'terminal' || content.kind === 'shell_run') {
-    return content.status === 'cancelled';
-  }
-  return false;
-}
-
-/**
- * Map a tool_result onto ToolActivityItem.status. Cancel is interrupted
- * (user stop), not errored — so cards/trows never say "失败" for cancel.
- */
-export function toolResultActivityStatus(
-  isError: boolean,
-  content: ToolResultContent | undefined,
-): ToolActivityItem['status'] {
-  if (isCancelledToolResultContent(content)) return 'interrupted';
-  if (!isError) return 'completed';
-  if (content?.kind === 'explore_agent' && content.reason === 'aborted') {
-    return 'interrupted';
-  }
-  return 'errored';
 }
 
 /**

--- a/packages/ui/src/materialize.ts
+++ b/packages/ui/src/materialize.ts
@@ -1,5 +1,5 @@
 import { deriveTurnRecords } from '@maka/core';
-import type { AttachmentRef, StoredMessage, ToolResultContent, TurnRecord, TurnStatus } from '@maka/core';
+import type { AttachmentRef, StoredMessage, ToolActivityKind, ToolResultContent, TurnRecord, TurnStatus } from '@maka/core';
 import type { LiveTurnProjection } from './live-turn-projection.js';
 
 export interface ChatItem {
@@ -32,6 +32,7 @@ export interface ToolOutputChunk {
 export interface ToolActivityItem {
   toolUseId: string;
   toolName: string;
+  activityKind?: ToolActivityKind;
   displayName?: string;
   intent?: string;
   /**
@@ -120,6 +121,7 @@ export function materializeTools(messages: StoredMessage[]): ToolActivityItem[] 
       return {
         toolUseId: call.id,
         toolName: call.toolName,
+        activityKind: call.activityKind,
         displayName: call.displayName,
         intent: call.intent,
         ...(call.stepId !== undefined ? { stepId: call.stepId } : {}),

--- a/packages/ui/src/primitives/chat.tsx
+++ b/packages/ui/src/primitives/chat.tsx
@@ -254,7 +254,7 @@ export function Marker({
  * Tool live-output stream shell (issue #332, PR3).
  *
  * Retires the bespoke `.maka-tool-output-stream-*` shell CSS (the panel,
- * header, counts row, scrolling body, and chunk/tag spans in
+ * header, diagnostic flags, scrolling body, and chunk/tag spans in
  * `styles/tool-stream.css`), moving each onto this Tailwind substrate. Every
  * value is a LITERAL arbitrary utility that compiles 1:1 to the declaration it
  * replaces, so the cva source string IS the computed-style proof (the cascade
@@ -286,16 +286,12 @@ const streamVariants = cva("", {
         "flex items-center justify-between gap-3 px-2.5 py-1.5 border-b border-[var(--border)] bg-[var(--foreground-3)] text-xs uppercase tracking-[0.06em] text-[color:var(--muted-foreground)]",
       // `.maka-tool-output-stream-label`
       label: "inline-flex items-center gap-1.5",
-      // `.maka-tool-output-stream-counts`
-      counts: "inline-flex items-center gap-2.5",
-      // `.maka-tool-output-stream-counts span` (tabular-nums on every count) plus
-      // the `[data-stream=stderr]` / `[data-redacted]` / `[data-truncated]`
-      // recolors. The `已截断` pill (`data-truncated`) gets the warning chrome the
-      // old `span[data-truncated="true"]` rule supplied; the inert
-      // `.maka-tool-output-stream-truncated-tag` class (no rule of its own) is
-      // dropped.
-      count:
-        "min-w-[5rem] [font-variant-numeric:tabular-nums]"
+      // Diagnostic flags replace transport chunk counts. A stream's internal
+      // delivery granularity is not user progress; only stderr, redaction, and
+      // truncation facts belong in this header.
+      flags: "inline-flex items-center gap-2.5",
+      flag:
+        "whitespace-nowrap"
         + " data-[stream=stderr]:text-[color:var(--destructive-text)]"
         + " data-[redacted=true]:text-[color:var(--warning-text,var(--info-text))]"
         + " data-[truncated=true]:rounded-[var(--radius-control)] data-[truncated=true]:border data-[truncated=true]:border-[oklch(from_var(--warning)_l_c_h_/_0.30)] data-[truncated=true]:bg-[oklch(from_var(--warning)_l_c_h_/_0.06)] data-[truncated=true]:px-1 data-[truncated=true]:text-[color:var(--warning-text,var(--info-text))] data-[truncated=true]:cursor-help",

--- a/packages/ui/src/tool-activity.tsx
+++ b/packages/ui/src/tool-activity.tsx
@@ -106,11 +106,11 @@ function AutomationResultPreview(props: { text: string }) {
       <div className={previewVariants({ part: 'load-tool' })} data-kind="automation_create">
         <p className={previewVariants({ part: 'load-tool-title' })}>
           <Icon size={14} aria-hidden="true" style={{ display: 'inline', verticalAlign: 'text-bottom', marginRight: 4 }} />
-          自动化任务已创建：{created[1]}
+          自动化任务已创建：{redactSecrets(created[1] ?? '')}
         </p>
-        {schedule && <p className={previewVariants({ part: 'load-tool-count' })}>{schedule}</p>}
-        {nextFire && nextFire !== 'N/A' && <p className={previewVariants({ part: 'load-tool-tools' })}>下次触发：{nextFire}</p>}
-        <p className={previewVariants({ part: 'load-tool-footer' })}>{created[2]}</p>
+        {schedule && <p className={previewVariants({ part: 'load-tool-count' })}>{redactSecrets(schedule)}</p>}
+        {nextFire && nextFire !== 'N/A' && <p className={previewVariants({ part: 'load-tool-tools' })}>下次触发：{redactSecrets(nextFire)}</p>}
+        <p className={previewVariants({ part: 'load-tool-footer' })}>{redactSecrets(created[2] ?? '')}</p>
       </div>
     );
   }
@@ -146,7 +146,7 @@ function AutomationResultPreview(props: { text: string }) {
           return (
             <p key={i} className={previewVariants({ part: 'load-tool-tools' })}>
               <BlockIcon size={12} aria-hidden="true" style={{ display: 'inline', verticalAlign: 'text-bottom', marginRight: 3 }} />
-              {head}
+              {redactSecrets(head)}
             </p>
           );
         })}

--- a/packages/ui/src/tool-activity.tsx
+++ b/packages/ui/src/tool-activity.tsx
@@ -205,6 +205,16 @@ function isPermissionDeniedToolResult(result: ToolActivityItem['result']): boole
   return result?.kind === 'text' && formatUserVisibleToolText(result.text).trim() === '用户已拒绝权限请求';
 }
 
+/** Result kinds that own their own quiet panel (do not nest in the shared well). */
+function resultOwnsOwnPanel(result: ToolActivityItem['result']): boolean {
+  return result?.kind === 'terminal' || result?.kind === 'shell_run';
+}
+
+function isCancelledToolResult(result: ToolActivityItem['result']): boolean {
+  if (!result || result.kind !== 'terminal') return false;
+  return result.status === 'cancelled';
+}
+
 export function ToolActivity(props: { items: ToolActivityItem[] }) {
   return (
     <section className={toolVariants({ part: 'container' })} aria-label="工具调用记录">
@@ -259,10 +269,14 @@ function ToolCardBody({ item }: { item: ToolActivityItem }) {
   const errored = item.status === 'errored';
   const permissionDenied = isPermissionDeniedToolResult(item.result);
   const running = item.status === 'running' || item.status === 'pending';
-  // Terminal result already includes the command line inside its quiet panel.
-  const resultIsTerminal = item.result?.kind === 'terminal';
+  // terminal / shell_run own a single quiet panel — never nest inside the shared well.
+  const ownsPanel = resultOwnsOwnPanel(item.result);
+  // Cancelled terminals still land as status=errored; skip the generic failure
+  // banner so the panel note ("已取消") is the only status story.
+  const showErrorBanner = errored && !isCancelledToolResult(item.result);
   // Every tool: human invocation line from args — never pretty-printed JSON.
-  const invocationLine = !permissionDenied && !resultIsTerminal
+  // Skip when the result panel already prints the command (terminal/shell_run).
+  const invocationLine = !permissionDenied && !ownsPanel
     ? formatToolInvocationLine(item)
     : undefined;
   // While running the live stream is the output; once a structured result
@@ -281,19 +295,20 @@ function ToolCardBody({ item }: { item: ToolActivityItem }) {
     && quietJson.headline !== invocationLine
     ? quietJson.headline
     : undefined;
-  // Terminal results own their own quiet panel (command + body + failure note).
-  // Other results share one panel with any in-flight command/args/live stream.
+  // Owned-panel kinds render alone. Everything else shares one quiet well.
   const hasSharedPanelContent =
-    showInvocation
-    || !!resultHeadline
-    || showLiveStream
-    || (showResult && !resultIsTerminal)
-    || (!!item.args && !permissionDenied && !resultIsTerminal && !invocationLine && !showResult && !showLiveStream);
+    !ownsPanel && (
+      showInvocation
+      || !!resultHeadline
+      || showLiveStream
+      || showResult
+      || (!!item.args && !permissionDenied && !invocationLine && !showResult && !showLiveStream)
+    );
 
   return (
     <div className="mt-1 flex flex-col gap-1.5">
-      {errored && <ToolErrorBanner result={item.result} />}
-      {showResult && resultIsTerminal && <ToolResultPreview content={item.result!} />}
+      {showErrorBanner && <ToolErrorBanner result={item.result} />}
+      {showResult && ownsPanel && <ToolResultPreview content={item.result!} />}
       {hasSharedPanelContent && (
         <div
           data-slot="tool-output"
@@ -306,7 +321,7 @@ function ToolCardBody({ item }: { item: ToolActivityItem }) {
             <code className={TOOL_OUTPUT_COMMAND_CLASS}>{resultHeadline}</code>
           )}
           {/* No formatRedactedJson dump — if invocation failed, quiet-format args. */}
-          {!showInvocation && !resultHeadline && item.args !== undefined && !permissionDenied && !resultIsTerminal && !showResult && (
+          {!showInvocation && !resultHeadline && item.args !== undefined && !permissionDenied && !showResult && (
             <pre className={cn(TOOL_OUTPUT_BODY_CLASS, 'max-h-40')}>
               {formatQuietJsonValue(item.args).body}
             </pre>
@@ -318,7 +333,7 @@ function ToolCardBody({ item }: { item: ToolActivityItem }) {
               truncated={item.outputTruncated === true}
             />
           )}
-          {showResult && !resultIsTerminal && (
+          {showResult && !ownsPanel && (
             isConnectorTool(item.toolName) && item.result!.kind === 'json' ? (
               <LoadToolResultPreview args={item.args} value={item.result!.value} />
             ) : isAutomationTool(item.toolName) && item.result!.kind === 'text' ? (

--- a/packages/ui/src/tool-activity.tsx
+++ b/packages/ui/src/tool-activity.tsx
@@ -256,36 +256,44 @@ function withLiveStreamFallback(
   chunks: ToolActivityItem['outputChunks'] | undefined,
   options?: { truncated?: boolean },
 ): NonNullable<ToolActivityItem['result']> {
-  if (!chunks?.length) return result;
   if (result.kind !== 'terminal' && result.kind !== 'shell_run') return result;
   if (resultHasCapturedStreams(result)) return result;
+
   let stdout = '';
   let stderr = '';
   let anyRedacted = false;
-  for (const chunk of chunks) {
+  for (const chunk of chunks ?? []) {
     if (chunk.redacted) anyRedacted = true;
     if (chunk.stream === 'stderr') stderr += chunk.text;
     else stdout += chunk.text;
   }
-  if (!stdout && !stderr) return result;
-  // Match live stream's "[已脱敏]" marker when a chunk was redacted.
+  const truncated = result.stdoutTruncated === true || options?.truncated === true;
+  // Empty redacted/truncated live buffer still carries diagnosis — do not
+  // early-return and drop "已脱敏" / "输出已截断".
+  if (!stdout && !stderr && !anyRedacted && !truncated) return result;
+
+  // Match live stream's "[已脱敏]" marker when a chunk was redacted
+  // (including empty bodies that only suppressed secrets).
   if (anyRedacted) {
     if (stdout.length > 0) stdout = `${stdout}${stdout.endsWith('\n') ? '' : '\n'}[已脱敏]`;
-    else stderr = `${stderr}${stderr.endsWith('\n') ? '' : '\n'}[已脱敏]`;
+    else if (stderr.length > 0) stderr = `${stderr}${stderr.endsWith('\n') ? '' : '\n'}[已脱敏]`;
+    else stdout = '[已脱敏]';
   }
   return {
     ...result,
     stdout,
     stderr,
-    stdoutTruncated: result.stdoutTruncated === true || options?.truncated === true,
+    stdoutTruncated: truncated,
   };
 }
 
 function toolStatusLabel(item: ToolActivityItem): string {
-  if (isCancelledToolResult(item.result)) return '已取消';
+  // Outer label follows call status. Panel notes still show task cancel state.
+  if (item.status === 'interrupted' && isCancelledToolResult(item.result)) return '已取消';
   if (
     (item.result?.kind === 'terminal' || item.result?.kind === 'shell_run')
     && item.result.status === 'timed_out'
+    && item.status !== 'completed'
   ) {
     return '已超时';
   }

--- a/packages/ui/src/tool-activity.tsx
+++ b/packages/ui/src/tool-activity.tsx
@@ -41,10 +41,10 @@ import { Collapsible, CollapsibleTrigger, CollapsiblePanel } from './primitives/
 import { previewVariants, TextShimmer, toolVariants } from './primitives/chat.js';
 import { redactSecrets } from './redact.js';
 import { Button as UiButton, cn } from './ui.js';
-import { describeLoadToolResult, formatRedactedJson, formatToolIntent } from './tool-format.js';
+import { describeLoadToolResult, formatToolIntent } from './tool-format.js';
 import { formatDuration, formatUserVisibleToolText } from './tool-activity/preview-utils.js';
 import {
-  formatBuiltinJsonResult,
+  formatQuietJsonValue,
   formatToolInvocationLine,
 } from './tool-activity/builtin-preview.js';
 import {
@@ -183,12 +183,11 @@ function extractErrorText(result: ToolActivityItem['result']): string {
   switch (result.kind) {
     case 'text':
       return result.text;
-    case 'json':
-      try {
-        return JSON.stringify(result.value, null, 2);
-      } catch {
-        return String(result.value);
-      }
+    case 'json': {
+      // Same quiet formatter as the panel — never dump escaped JSON braces.
+      const quiet = formatQuietJsonValue(result.value);
+      return quiet.headline ? `${quiet.headline}\n${quiet.body}` : quiet.body;
+    }
     case 'terminal':
       return result.stderr || result.stdout || `exit ${result.exitCode}`;
     case 'file_diff':
@@ -262,31 +261,34 @@ function ToolCardBody({ item }: { item: ToolActivityItem }) {
   const running = item.status === 'running' || item.status === 'pending';
   // Terminal result already includes the command line inside its quiet panel.
   const resultIsTerminal = item.result?.kind === 'terminal';
-  // Prefer a human invocation line (path / pattern / shell command) over a
-  // pretty-printed args object — Read/Grep were dumping raw tool-call JSON.
+  // Every tool: human invocation line from args — never pretty-printed JSON.
   const invocationLine = !permissionDenied && !resultIsTerminal
     ? formatToolInvocationLine(item)
     : undefined;
-  const showArgsFallback =
-    !permissionDenied
-    && !resultIsTerminal
-    && invocationLine === undefined
-    && item.args !== undefined;
   // While running the live stream is the output; once a structured result
   // preview exists it is the single quiet output block — never render both.
   const showLiveStream = !!item.outputChunks && item.outputChunks.length > 0 && (running || !item.result);
   const showResult = !!item.result && !permissionDenied;
-  const builtinJson =
+  const quietJson =
     showResult && item.result?.kind === 'json'
-      ? formatBuiltinJsonResult(item.toolName, item.result.value)
+      ? formatQuietJsonValue(item.result.value)
       : undefined;
-  // When the builtin result already carries a path headline (Write/Edit), skip
-  // duplicating the args invocation line.
-  const showInvocation = invocationLine !== undefined && !(builtinJson?.headline);
+  // Result headline (e.g. Write path) wins over args when both would restate path.
+  const showInvocation = invocationLine !== undefined
+    && !(quietJson?.headline && quietJson.headline === invocationLine);
+  // Prefer args headline when result has no headline of its own.
+  const resultHeadline = quietJson?.headline
+    && quietJson.headline !== invocationLine
+    ? quietJson.headline
+    : undefined;
   // Terminal results own their own quiet panel (command + body + failure note).
   // Other results share one panel with any in-flight command/args/live stream.
   const hasSharedPanelContent =
-    showInvocation || showArgsFallback || showLiveStream || (showResult && !resultIsTerminal);
+    showInvocation
+    || !!resultHeadline
+    || showLiveStream
+    || (showResult && !resultIsTerminal)
+    || (!!item.args && !permissionDenied && !resultIsTerminal && !invocationLine && !showResult && !showLiveStream);
 
   return (
     <div className="mt-1 flex flex-col gap-1.5">
@@ -300,11 +302,14 @@ function ToolCardBody({ item }: { item: ToolActivityItem }) {
           {showInvocation && (
             <code className={TOOL_OUTPUT_COMMAND_CLASS}>{invocationLine}</code>
           )}
-          {builtinJson?.headline && (
-            <code className={TOOL_OUTPUT_COMMAND_CLASS}>{builtinJson.headline}</code>
+          {resultHeadline && (
+            <code className={TOOL_OUTPUT_COMMAND_CLASS}>{resultHeadline}</code>
           )}
-          {showArgsFallback && (
-            <pre className={cn(TOOL_OUTPUT_BODY_CLASS, 'max-h-40')}>{formatRedactedJson(item.args)}</pre>
+          {/* No formatRedactedJson dump — if invocation failed, quiet-format args. */}
+          {!showInvocation && !resultHeadline && item.args !== undefined && !permissionDenied && !resultIsTerminal && !showResult && (
+            <pre className={cn(TOOL_OUTPUT_BODY_CLASS, 'max-h-40')}>
+              {formatQuietJsonValue(item.args).body}
+            </pre>
           )}
           {showLiveStream && (
             <ToolOutputStream
@@ -318,8 +323,8 @@ function ToolCardBody({ item }: { item: ToolActivityItem }) {
               <LoadToolResultPreview args={item.args} value={item.result!.value} />
             ) : isAutomationTool(item.toolName) && item.result!.kind === 'text' ? (
               <AutomationResultPreview text={(item.result as { text: string }).text} />
-            ) : builtinJson ? (
-              <pre className={TOOL_OUTPUT_BODY_CLASS}>{builtinJson.body}</pre>
+            ) : quietJson ? (
+              <pre className={TOOL_OUTPUT_BODY_CLASS}>{quietJson.body}</pre>
             ) : (
               <ToolResultPreview content={item.result!} />
             )

--- a/packages/ui/src/tool-activity.tsx
+++ b/packages/ui/src/tool-activity.tsx
@@ -38,12 +38,18 @@ import {
 } from './tool-activity/presentation.js';
 import { Alert, AlertAction, AlertDescription, AlertTitle } from './primitives/alert.js';
 import { Collapsible, CollapsibleTrigger, CollapsiblePanel } from './primitives/collapsible.js';
-import { LiveIndicator, previewVariants, streamVariants, TextShimmer, toolVariants } from './primitives/chat.js';
+import { previewVariants, TextShimmer, toolVariants } from './primitives/chat.js';
 import { redactSecrets } from './redact.js';
 import { Button as UiButton, cn } from './ui.js';
 import { describeLoadToolResult, formatRedactedJson, formatToolIntent } from './tool-format.js';
 import { formatDuration, formatUserVisibleToolText } from './tool-activity/preview-utils.js';
-import { ToolResultPreview } from './tool-activity/tool-result-preview.js';
+import {
+  TOOL_OUTPUT_BODY_CLASS,
+  TOOL_OUTPUT_COMMAND_CLASS,
+  TOOL_OUTPUT_NOTE_CLASS,
+  TOOL_OUTPUT_PANEL_CLASS,
+  ToolResultPreview,
+} from './tool-activity/tool-result-preview.js';
 
 /** Friendly card for a `load_tools` result; falls back to JSON on unexpected shapes. */
 function LoadToolResultPreview(props: { args: unknown; value: unknown }) {
@@ -255,11 +261,10 @@ function ToolActivityCard({ item }: { item: ToolActivityItem }) {
 }
 
 /**
- * The tool detail body — error banner, intent, args, live output stream, and
- * result preview — shared by the boxed `ToolActivityCard` and the flat trow
- * rows. Extracted so the trow can render the same details without the card
- * frame. Args/intent stay routed through `formatRedactedJson` /
- * `formatToolIntent` (tool-args-redaction-contract).
+ * The tool detail body — error banner + one Codex-like output well for
+ * command/args, live stream, and structured results. Shared by the boxed
+ * `ToolActivityCard` and flat trow rows. Args still route through
+ * `formatRedactedJson` (tool-args-redaction-contract).
  */
 function ToolCardBody({ item }: { item: ToolActivityItem }) {
   const errored = item.status === 'errored';
@@ -267,47 +272,52 @@ function ToolCardBody({ item }: { item: ToolActivityItem }) {
   const presentation = deriveToolActivityPresentation(item);
   const running = item.status === 'running' || item.status === 'pending';
   const command = presentation.kind === 'command' ? extractToolCommand(item.args) : undefined;
-  // A terminal result preview already prints `$ cmd` + cwd + exit in its head,
-  // so the invocation line only fills the in-flight gap (and any non-terminal
-  // result). The compact redacted-args fallback still routes through
-  // formatRedactedJson (tool-args-redaction-contract).
+  // Terminal result already includes the command line inside its quiet panel.
   const resultIsTerminal = item.result?.kind === 'terminal';
-  const showInvocation = !permissionDenied && !resultIsTerminal && (command !== undefined || item.args !== undefined);
+  const showCommand = !permissionDenied && !resultIsTerminal && command !== undefined;
+  const showArgsFallback =
+    !permissionDenied && !resultIsTerminal && command === undefined && item.args !== undefined;
   // While running the live stream is the output; once a structured result
-  // preview exists it is the single quiet output block — never render both
-  // (the old body double-printed stdout as stream + preview).
+  // preview exists it is the single quiet output block — never render both.
   const showLiveStream = !!item.outputChunks && item.outputChunks.length > 0 && (running || !item.result);
+  const showResult = !!item.result && !permissionDenied;
+  // Terminal results own their own quiet panel (command + body + failure note).
+  // Other results share one panel with any in-flight command/args/live stream.
+  const hasSharedPanelContent =
+    showCommand || showArgsFallback || showLiveStream || (showResult && !resultIsTerminal);
+
   return (
-    // Flat, left-border-indented detail area — one visual language with the
-    // 深度思考 disclosure body. No nested card frame, no per-row rounded boxes.
-    <div className="mt-1 ml-2 flex flex-col gap-1.5 border-l border-[var(--border)] pl-2.5 pb-1">
+    <div className="mt-1 flex flex-col gap-1.5">
       {errored && <ToolErrorBanner result={item.result} />}
-      {showInvocation && (
-        command !== undefined ? (
-          <code className="[font-family:var(--font-mono)] [font-variant-ligatures:none] text-[length:var(--font-size-caption)] text-[color:var(--foreground-secondary)] [white-space:pre-wrap] [word-break:break-word]">
-            <span className="select-none text-[color:var(--muted-foreground)]">$ </span>
-            {redactSecrets(command)}
-          </code>
-        ) : (
-          <pre className="m-0 max-h-40 overflow-auto [font-family:var(--font-mono)] [font-variant-ligatures:none] text-[length:var(--font-size-caption)] leading-normal text-[color:var(--foreground-secondary)] [white-space:pre-wrap] [word-break:break-word]">{formatRedactedJson(item.args)}</pre>
-        )
-      )}
-      {showLiveStream && (
-        <ToolOutputStream
-          chunks={item.outputChunks!}
-          live={running}
-          interrupted={item.status === 'interrupted'}
-          truncated={item.outputTruncated === true}
-        />
-      )}
-      {item.result && !permissionDenied && (
-        isConnectorTool(item.toolName) && item.result.kind === 'json' ? (
-          <LoadToolResultPreview args={item.args} value={item.result.value} />
-        ) : isAutomationTool(item.toolName) && item.result.kind === 'text' ? (
-          <AutomationResultPreview text={item.result.text} />
-        ) : (
-          <ToolResultPreview content={item.result} />
-        )
+      {showResult && resultIsTerminal && <ToolResultPreview content={item.result!} />}
+      {hasSharedPanelContent && (
+        <div
+          data-slot="tool-output"
+          className={cn(TOOL_OUTPUT_PANEL_CLASS, errored && 'border-[oklch(from_var(--destructive)_l_c_h_/_0.28)]')}
+        >
+          {showCommand && (
+            <code className={TOOL_OUTPUT_COMMAND_CLASS}>{redactSecrets(command!)}</code>
+          )}
+          {showArgsFallback && (
+            <pre className={cn(TOOL_OUTPUT_BODY_CLASS, 'max-h-40')}>{formatRedactedJson(item.args)}</pre>
+          )}
+          {showLiveStream && (
+            <ToolOutputStream
+              chunks={item.outputChunks!}
+              live={running}
+              truncated={item.outputTruncated === true}
+            />
+          )}
+          {showResult && !resultIsTerminal && (
+            isConnectorTool(item.toolName) && item.result!.kind === 'json' ? (
+              <LoadToolResultPreview args={item.args} value={item.result!.value} />
+            ) : isAutomationTool(item.toolName) && item.result!.kind === 'text' ? (
+              <AutomationResultPreview text={(item.result as { text: string }).text} />
+            ) : (
+              <ToolResultPreview content={item.result!} />
+            )
+          )}
+        </div>
       )}
     </div>
   );
@@ -460,34 +470,19 @@ function ToolTrowRow({ item }: { item: ToolActivityItem }) {
 }
 
 /**
- * PR-UI-12 — live stdout/stderr stream from PR-REAL-4 `tool_output_delta`.
+ * Live stdout/stderr body for the unified tool-output panel.
  *
- * Renders chunks in their original seq order (already sorted in main.tsx
- * before this component sees them) so interleaved stdout+stderr reads
- * the way a human would expect from a real terminal. Each chunk keeps
- * its stream tag so stderr can render in a destructive tone — a
- * single mono `<pre>` would lose that visual signal.
+ * No second card shell and no "实时输出" header — the parent panel is the
+ * only chrome. Chunks keep stream tags so stderr can tint destructive.
+ * Redacted chunks still surface an inline "[已脱敏]" hint. Truncation is a
+ * quiet footer note, not a flag row.
  *
- * `redacted: true` chunks render as a small inline hint "[已脱敏]"
- * instead of pretending the chunk arrived clean. Empty redacted
- * chunks (runtime suppressed everything) collapse to just the hint.
- *
- * `truncated: true` (PR-UI-12 fixup #2, @kenji A3 msg 365ff8b9) flips
- * a "已截断" pill in the header counts row. This means
- * `applyToolOutputChunk` dropped chunks (per-tool count or
- * total-char cap) or tail-truncated a single oversize chunk. Users
- * see explicitly that the displayed stream is bounded — they should
- * use Finder / external viewer if they need the full output.
- *
- * Auto-scroll: while `live` is true, we anchor to the bottom on every
- * chunk update so users see the latest output. Once the tool reaches
- * terminal (`tool_result`), auto-scroll stops so users can scroll up
- * to read history without being yanked back.
+ * Auto-scroll: while `live` is true, anchor to the bottom on every chunk
+ * update; stop once the tool settles so the user can scroll history.
  */
 function ToolOutputStream(props: {
   chunks: ToolOutputChunk[];
   live: boolean;
-  interrupted: boolean;
   truncated: boolean;
 }) {
   const preRef = useRef<HTMLPreElement>(null);
@@ -498,59 +493,33 @@ function ToolOutputStream(props: {
     el.scrollTop = el.scrollHeight;
   }, [props.chunks, props.live]);
 
-  const hasStderr = props.chunks.some((c) => c.stream === 'stderr');
-  const hasRedacted = props.chunks.some((c) => c.redacted);
-  const hasFlags = hasStderr || hasRedacted || props.truncated;
-
   return (
-    <div className={streamVariants({ part: 'container' })} data-live={props.live ? 'true' : undefined}>
-      <header className={streamVariants({ part: 'header' })}>
-        <span className={streamVariants({ part: 'label' })}>
-          {props.live ? (
-            <>
-              <LiveIndicator />
-              <span>实时输出</span>
-            </>
-          ) : props.interrupted ? (
-            <span>已中断 · 已收到的输出</span>
-          ) : (
-            <span>工具输出</span>
-          )}
-        </span>
-        {hasFlags && (
-          <span className={streamVariants({ part: 'flags' })}>
-            {hasStderr && <span className={streamVariants({ part: 'flag' })} data-stream="stderr">stderr</span>}
-            {hasRedacted && <span className={streamVariants({ part: 'flag' })} data-redacted="true">已脱敏</span>}
-            {props.truncated && (
-              <span
-                className={streamVariants({ part: 'flag' })}
-                data-truncated="true"
-                title="部分输出已截断；如需完整输出请查看对应工具结果或生成的 artifact"
-              >
-                已截断
-              </span>
-            )}
-          </span>
-        )}
-      </header>
-      <pre ref={preRef} className={streamVariants({ part: 'body' })}>
+    <>
+      <pre ref={preRef} className={TOOL_OUTPUT_BODY_CLASS} data-live={props.live ? 'true' : undefined}>
         {props.chunks.map((chunk) => (
           <span
             key={chunk.seq}
-            className={streamVariants({ part: 'chunk' })}
+            className={cn(
+              'contents',
+              chunk.stream === 'stderr' && 'text-[color:var(--destructive)]',
+              chunk.redacted && 'opacity-[0.65]',
+            )}
             data-stream={chunk.stream}
             data-redacted={chunk.redacted ? 'true' : undefined}
           >
             {chunk.text}
             {chunk.redacted && (
-              <span className={streamVariants({ part: 'redacted-tag' })} aria-label="已脱敏">
+              <span className="inline ml-0.5 text-[color:var(--warning-text,var(--info-text))]" aria-label="已脱敏">
                 {' '}[已脱敏]
               </span>
             )}
           </span>
         ))}
       </pre>
-    </div>
+      {props.truncated && (
+        <p className={TOOL_OUTPUT_NOTE_CLASS}>输出已截断</p>
+      )}
+    </>
   );
 }
 

--- a/packages/ui/src/tool-activity.tsx
+++ b/packages/ui/src/tool-activity.tsx
@@ -211,8 +211,51 @@ function resultOwnsOwnPanel(result: ToolActivityItem['result']): boolean {
 }
 
 function isCancelledToolResult(result: ToolActivityItem['result']): boolean {
-  if (!result || result.kind !== 'terminal') return false;
-  return result.status === 'cancelled';
+  if (!result) return false;
+  if (result.kind === 'terminal' || result.kind === 'shell_run') {
+    return result.status === 'cancelled';
+  }
+  return false;
+}
+
+function resultHasCapturedStreams(result: ToolActivityItem['result']): boolean {
+  if (!result) return false;
+  if (result.kind === 'terminal' || result.kind === 'shell_run') {
+    return (result.stdout?.length ?? 0) > 0 || (result.stderr?.length ?? 0) > 0;
+  }
+  return true;
+}
+
+/**
+ * Background Bash yields an empty shell_run body; keep the live chunks the
+ * user already saw by filling empty stdout/stderr from outputChunks.
+ */
+function withLiveStreamFallback(
+  result: NonNullable<ToolActivityItem['result']>,
+  chunks: ToolActivityItem['outputChunks'] | undefined,
+): NonNullable<ToolActivityItem['result']> {
+  if (!chunks?.length) return result;
+  if (result.kind !== 'terminal' && result.kind !== 'shell_run') return result;
+  if (resultHasCapturedStreams(result)) return result;
+  let stdout = '';
+  let stderr = '';
+  for (const chunk of chunks) {
+    if (chunk.stream === 'stderr') stderr += chunk.text;
+    else stdout += chunk.text;
+  }
+  if (!stdout && !stderr) return result;
+  return { ...result, stdout, stderr };
+}
+
+function toolStatusLabel(item: ToolActivityItem): string {
+  if (isCancelledToolResult(item.result)) return '已取消';
+  if (
+    (item.result?.kind === 'terminal' || item.result?.kind === 'shell_run')
+    && item.result.status === 'timed_out'
+  ) {
+    return '已超时';
+  }
+  return STATUS_LABEL[item.status];
 }
 
 export function ToolActivity(props: { items: ToolActivityItem[] }) {
@@ -249,7 +292,7 @@ function ToolActivityCard({ item }: { item: ToolActivityItem }) {
         <span className={toolVariants({ part: 'name' })}>{resolveToolDisplayName(item)}</span>
         <span className={toolVariants({ part: 'meta' })}>
           {duration && <span className={toolVariants({ part: 'duration' })}>{duration}</span>}
-          <span className={toolVariants({ part: 'status-label' })}>{STATUS_LABEL[item.status]}</span>
+          <span className={toolVariants({ part: 'status-label' })}>{toolStatusLabel(item)}</span>
         </span>
       </CollapsibleTrigger>
       <CollapsiblePanel>
@@ -266,14 +309,15 @@ function ToolActivityCard({ item }: { item: ToolActivityItem }) {
  * quiet formatters (tool-args-redaction-contract / quiet-panel contracts).
  */
 function ToolCardBody({ item }: { item: ToolActivityItem }) {
-  const errored = item.status === 'errored';
+  const cancelled = isCancelledToolResult(item.result);
+  // Cancel maps to interrupted at materialize/live-projection; keep defensive
+  // checks so a stale errored+cancelled item still does not look like failure.
+  const errored = item.status === 'errored' && !cancelled;
   const permissionDenied = isPermissionDeniedToolResult(item.result);
   const running = item.status === 'running' || item.status === 'pending';
   // terminal / shell_run own a single quiet panel — never nest inside the shared well.
   const ownsPanel = resultOwnsOwnPanel(item.result);
-  // Cancelled terminals still land as status=errored; skip the generic failure
-  // banner so the panel note ("已取消") is the only status story.
-  const showErrorBanner = errored && !isCancelledToolResult(item.result);
+  const showErrorBanner = errored;
   // Every tool: human invocation line from args — never pretty-printed JSON.
   // Skip when the result panel already prints the command (terminal/shell_run).
   const invocationLine = !permissionDenied && !ownsPanel
@@ -281,11 +325,19 @@ function ToolCardBody({ item }: { item: ToolActivityItem }) {
     : undefined;
   // While running the live stream is the output; once a structured result
   // preview exists it is the single quiet output block — never render both.
-  const showLiveStream = !!item.outputChunks && item.outputChunks.length > 0 && (running || !item.result);
+  // Owned terminal/shell_run panels absorb empty-body yield via
+  // withLiveStreamFallback (never a second live panel).
+  const showLiveStream = !!item.outputChunks
+    && item.outputChunks.length > 0
+    && !ownsPanel
+    && (running || !item.result);
   const showResult = !!item.result && !permissionDenied;
+  const displayResult = showResult && item.result
+    ? withLiveStreamFallback(item.result, item.outputChunks)
+    : undefined;
   const quietJson =
-    showResult && item.result?.kind === 'json'
-      ? formatQuietJsonValue(item.result.value)
+    displayResult?.kind === 'json'
+      ? formatQuietJsonValue(displayResult.value)
       : undefined;
   // Keep the invocation line whenever args yield one. Only add a result
   // headline when it says something different (avoids dropping Write/Edit paths
@@ -307,8 +359,8 @@ function ToolCardBody({ item }: { item: ToolActivityItem }) {
 
   return (
     <div className="mt-1 flex flex-col gap-1.5">
-      {showErrorBanner && <ToolErrorBanner result={item.result} />}
-      {showResult && ownsPanel && <ToolResultPreview content={item.result!} />}
+      {showErrorBanner && <ToolErrorBanner result={displayResult ?? item.result} />}
+      {showResult && ownsPanel && displayResult && <ToolResultPreview content={displayResult} />}
       {hasSharedPanelContent && (
         <div
           data-slot="tool-output"
@@ -333,15 +385,15 @@ function ToolCardBody({ item }: { item: ToolActivityItem }) {
               truncated={item.outputTruncated === true}
             />
           )}
-          {showResult && !ownsPanel && (
-            isConnectorTool(item.toolName) && item.result!.kind === 'json' ? (
-              <LoadToolResultPreview args={item.args} value={item.result!.value} />
-            ) : isAutomationTool(item.toolName) && item.result!.kind === 'text' ? (
-              <AutomationResultPreview text={(item.result as { text: string }).text} />
+          {showResult && !ownsPanel && displayResult && (
+            isConnectorTool(item.toolName) && displayResult.kind === 'json' ? (
+              <LoadToolResultPreview args={item.args} value={displayResult.value} />
+            ) : isAutomationTool(item.toolName) && displayResult.kind === 'text' ? (
+              <AutomationResultPreview text={displayResult.text} />
             ) : quietJson ? (
               <pre className={TOOL_OUTPUT_BODY_CLASS}>{quietJson.body}</pre>
             ) : (
-              <ToolResultPreview content={item.result!} />
+              <ToolResultPreview content={displayResult} />
             )
           )}
         </div>

--- a/packages/ui/src/tool-activity.tsx
+++ b/packages/ui/src/tool-activity.tsx
@@ -44,6 +44,10 @@ import { Button as UiButton, cn } from './ui.js';
 import { describeLoadToolResult, formatRedactedJson, formatToolIntent } from './tool-format.js';
 import { formatDuration, formatUserVisibleToolText } from './tool-activity/preview-utils.js';
 import {
+  formatBuiltinJsonResult,
+  formatToolInvocationLine,
+} from './tool-activity/builtin-preview.js';
+import {
   TOOL_OUTPUT_BODY_CLASS,
   TOOL_OUTPUT_COMMAND_CLASS,
   TOOL_OUTPUT_NOTE_CLASS,
@@ -202,20 +206,6 @@ function isPermissionDeniedToolResult(result: ToolActivityItem['result']): boole
   return result?.kind === 'text' && formatUserVisibleToolText(result.text).trim() === '用户已拒绝权限请求';
 }
 
-/**
- * Pull the shell command string out of a command-tool's args (bash / shell).
- * Used to render a single `$ <command>` invocation line while the tool is in
- * flight — the settled terminal result preview already prints the command in
- * its header, so this only fills the running gap. Returns undefined for a
- * non-command shape so the caller falls back to the compact redacted-args view.
- */
-function extractToolCommand(args: unknown): string | undefined {
-  if (!args || typeof args !== 'object') return undefined;
-  const record = args as Record<string, unknown>;
-  const raw = record.command ?? record.cmd ?? record.script;
-  return typeof raw === 'string' && raw.trim().length > 0 ? raw : undefined;
-}
-
 export function ToolActivity(props: { items: ToolActivityItem[] }) {
   return (
     <section className={toolVariants({ part: 'container' })} aria-label="工具调用记录">
@@ -269,22 +259,34 @@ function ToolActivityCard({ item }: { item: ToolActivityItem }) {
 function ToolCardBody({ item }: { item: ToolActivityItem }) {
   const errored = item.status === 'errored';
   const permissionDenied = isPermissionDeniedToolResult(item.result);
-  const presentation = deriveToolActivityPresentation(item);
   const running = item.status === 'running' || item.status === 'pending';
-  const command = presentation.kind === 'command' ? extractToolCommand(item.args) : undefined;
   // Terminal result already includes the command line inside its quiet panel.
   const resultIsTerminal = item.result?.kind === 'terminal';
-  const showCommand = !permissionDenied && !resultIsTerminal && command !== undefined;
+  // Prefer a human invocation line (path / pattern / shell command) over a
+  // pretty-printed args object — Read/Grep were dumping raw tool-call JSON.
+  const invocationLine = !permissionDenied && !resultIsTerminal
+    ? formatToolInvocationLine(item)
+    : undefined;
   const showArgsFallback =
-    !permissionDenied && !resultIsTerminal && command === undefined && item.args !== undefined;
+    !permissionDenied
+    && !resultIsTerminal
+    && invocationLine === undefined
+    && item.args !== undefined;
   // While running the live stream is the output; once a structured result
   // preview exists it is the single quiet output block — never render both.
   const showLiveStream = !!item.outputChunks && item.outputChunks.length > 0 && (running || !item.result);
   const showResult = !!item.result && !permissionDenied;
+  const builtinJson =
+    showResult && item.result?.kind === 'json'
+      ? formatBuiltinJsonResult(item.toolName, item.result.value)
+      : undefined;
+  // When the builtin result already carries a path headline (Write/Edit), skip
+  // duplicating the args invocation line.
+  const showInvocation = invocationLine !== undefined && !(builtinJson?.headline);
   // Terminal results own their own quiet panel (command + body + failure note).
   // Other results share one panel with any in-flight command/args/live stream.
   const hasSharedPanelContent =
-    showCommand || showArgsFallback || showLiveStream || (showResult && !resultIsTerminal);
+    showInvocation || showArgsFallback || showLiveStream || (showResult && !resultIsTerminal);
 
   return (
     <div className="mt-1 flex flex-col gap-1.5">
@@ -295,8 +297,11 @@ function ToolCardBody({ item }: { item: ToolActivityItem }) {
           data-slot="tool-output"
           className={cn(TOOL_OUTPUT_PANEL_CLASS, errored && 'border-[oklch(from_var(--destructive)_l_c_h_/_0.28)]')}
         >
-          {showCommand && (
-            <code className={TOOL_OUTPUT_COMMAND_CLASS}>{redactSecrets(command!)}</code>
+          {showInvocation && (
+            <code className={TOOL_OUTPUT_COMMAND_CLASS}>{invocationLine}</code>
+          )}
+          {builtinJson?.headline && (
+            <code className={TOOL_OUTPUT_COMMAND_CLASS}>{builtinJson.headline}</code>
           )}
           {showArgsFallback && (
             <pre className={cn(TOOL_OUTPUT_BODY_CLASS, 'max-h-40')}>{formatRedactedJson(item.args)}</pre>
@@ -313,6 +318,8 @@ function ToolCardBody({ item }: { item: ToolActivityItem }) {
               <LoadToolResultPreview args={item.args} value={item.result!.value} />
             ) : isAutomationTool(item.toolName) && item.result!.kind === 'text' ? (
               <AutomationResultPreview text={(item.result as { text: string }).text} />
+            ) : builtinJson ? (
+              <pre className={TOOL_OUTPUT_BODY_CLASS}>{builtinJson.body}</pre>
             ) : (
               <ToolResultPreview content={item.result!} />
             )

--- a/packages/ui/src/tool-activity.tsx
+++ b/packages/ui/src/tool-activity.tsx
@@ -252,8 +252,8 @@ function ToolActivityCard({ item }: { item: ToolActivityItem }) {
 /**
  * The tool detail body — error banner + one Codex-like output well for
  * command/args, live stream, and structured results. Shared by the boxed
- * `ToolActivityCard` and flat trow rows. Args still route through
- * `formatRedactedJson` (tool-args-redaction-contract).
+ * `ToolActivityCard` and flat trow rows. Args/results route through
+ * quiet formatters (tool-args-redaction-contract / quiet-panel contracts).
  */
 function ToolCardBody({ item }: { item: ToolActivityItem }) {
   const errored = item.status === 'errored';
@@ -273,10 +273,10 @@ function ToolCardBody({ item }: { item: ToolActivityItem }) {
     showResult && item.result?.kind === 'json'
       ? formatQuietJsonValue(item.result.value)
       : undefined;
-  // Result headline (e.g. Write path) wins over args when both would restate path.
-  const showInvocation = invocationLine !== undefined
-    && !(quietJson?.headline && quietJson.headline === invocationLine);
-  // Prefer args headline when result has no headline of its own.
+  // Keep the invocation line whenever args yield one. Only add a result
+  // headline when it says something different (avoids dropping Write/Edit paths
+  // when path === path).
+  const showInvocation = invocationLine !== undefined;
   const resultHeadline = quietJson?.headline
     && quietJson.headline !== invocationLine
     ? quietJson.headline

--- a/packages/ui/src/tool-activity.tsx
+++ b/packages/ui/src/tool-activity.tsx
@@ -23,39 +23,27 @@ import {
   activeTrowTool,
   isTrowRunning,
   summarizeTrowTools,
-  trowActivityKind,
   trowNeedsAttention,
   type TrowActivityKind,
 } from './tool-activity/trow-summary.js';
 import { deriveToolRowMotion, isToolRowRunning } from './tool-activity/tool-row-motion.js';
+import {
+  createToolDisclosureState,
+  deriveToolActivityPresentation,
+  isConnectorTool,
+  resolveToolDisplayName,
+  setToolDisclosureOpen,
+  syncToolDisclosureState,
+  type ToolActivityPresentation,
+} from './tool-activity/presentation.js';
 import { Alert, AlertAction, AlertDescription, AlertTitle } from './primitives/alert.js';
 import { Collapsible, CollapsibleTrigger, CollapsiblePanel } from './primitives/collapsible.js';
 import { LiveIndicator, previewVariants, streamVariants, TextShimmer, toolVariants } from './primitives/chat.js';
 import { redactSecrets } from './redact.js';
 import { Button as UiButton, cn } from './ui.js';
-import { describeLoadToolResult, formatRedactedJson, formatToolIntent, loadToolDisplayName } from './tool-format.js';
+import { describeLoadToolResult, formatRedactedJson, formatToolIntent } from './tool-format.js';
 import { formatDuration, formatUserVisibleToolText } from './tool-activity/preview-utils.js';
 import { ToolResultPreview } from './tool-activity/tool-result-preview.js';
-
-// Mirror of runtime's LOAD_TOOLS_NAME. @maka/ui must not depend on @maka/runtime,
-// so the always-on group-activation connector's name is duplicated here as the
-// single hook for its friendly, locale-aware presentation. The pre-unification
-// name `load_tool` (PR #30) is also matched — it shipped and returns the same
-// `{ loaded: [...] }` shape, so replayed old sessions still render friendly.
-// `connect_tool_source` (PR #34) is intentionally NOT here: it never shipped and
-// its `{ tools: [...] }` result shape this card does not render.
-const CONNECTOR_TOOL_NAMES: ReadonlySet<string> = new Set(['load_tools', 'load_tool']);
-
-function isConnectorTool(name: string): boolean {
-  return CONNECTOR_TOOL_NAMES.has(name);
-}
-
-/** Friendly tool name: an explicit displayName wins; the connector gets a localized name. */
-function resolveToolDisplayName(item: ToolActivityItem): string {
-  if (item.displayName) return item.displayName;
-  if (isConnectorTool(item.toolName)) return loadToolDisplayName(detectUiLocale());
-  return item.toolName;
-}
 
 /** Friendly card for a `load_tools` result; falls back to JSON on unexpected shapes. */
 function LoadToolResultPreview(props: { args: unknown; value: unknown }) {
@@ -169,16 +157,15 @@ const STATUS_LABEL: Record<ToolActivityItem['status'], string> = {
   interrupted: '已中断',
 };
 
-function isOpenByDefault(status: ToolActivityItem['status']): boolean {
-  // Show details inline while the call is in flight or blocking the user; also
-  // for errored calls so the failure is visible without an extra click. Settled
-  // success / interruption collapse so completed history doesn't drown the chat.
-  return (
-    status === 'pending' ||
-    status === 'waiting_permission' ||
-    status === 'running' ||
-    status === 'errored'
-  );
+function useToolDisclosure(presentation: ToolActivityPresentation) {
+  const [disclosure, setDisclosure] = useState(() => createToolDisclosureState(presentation));
+  useEffect(() => {
+    setDisclosure((current) => syncToolDisclosureState(current, presentation));
+  }, [presentation.needsAttention]);
+  return {
+    open: disclosure.open,
+    setOpen: (open: boolean) => setDisclosure((current) => setToolDisclosureOpen(current, open)),
+  };
 }
 
 function extractErrorText(result: ToolActivityItem['result']): string {
@@ -238,25 +225,19 @@ export function ToolActivity(props: { items: ToolActivityItem[] }) {
 }
 
 function ToolActivityCard({ item }: { item: ToolActivityItem }) {
-  // Controlled open that follows item.status: a card that defaults open while
-  // pending/running auto-collapses when it settles to completed/interrupted
-  // (restoring the pre-Collapsible native-disclosure behavior, where
-  // open={isOpenByDefault(status)} re-evaluated every render). The user can
-  // still toggle in between — onOpenChange updates local state, and the next
-  // status change re-syncs. See disclosure-collapsible-contract: defaultOpen
-  // is banned here.
-  const [open, setOpen] = useState(isOpenByDefault(item.status));
-  useEffect(() => {
-    setOpen(isOpenByDefault(item.status));
-  }, [item.status]);
+  // Ordinary work stays summarized. A new permission/error state opens the
+  // diagnostics, while an explicit user toggle survives later ordinary status
+  // changes. See disclosure-collapsible-contract: defaultOpen is banned here.
+  const presentation = deriveToolActivityPresentation(item);
+  const disclosure = useToolDisclosure(presentation);
   const duration = formatDuration(item.durationMs);
   return (
     <Collapsible
       data-slot="tool"
       className={toolVariants({ part: 'item' })}
       data-status={item.status}
-      open={open}
-      onOpenChange={setOpen}
+      open={disclosure.open}
+      onOpenChange={disclosure.setOpen}
     >
       <CollapsibleTrigger className={toolVariants({ part: 'header' })}>
         <span className={toolVariants({ part: 'dot' })} data-status={item.status} aria-hidden="true" />
@@ -283,8 +264,9 @@ function ToolActivityCard({ item }: { item: ToolActivityItem }) {
 function ToolCardBody({ item }: { item: ToolActivityItem }) {
   const errored = item.status === 'errored';
   const permissionDenied = isPermissionDeniedToolResult(item.result);
+  const presentation = deriveToolActivityPresentation(item);
   const running = item.status === 'running' || item.status === 'pending';
-  const command = trowActivityKind(item.toolName) === 'command' ? extractToolCommand(item.args) : undefined;
+  const command = presentation.kind === 'command' ? extractToolCommand(item.args) : undefined;
   // A terminal result preview already prints `$ cmd` + cwd + exit in its head,
   // so the invocation line only fills the in-flight gap (and any non-terminal
   // result). The compact redacted-args fallback still routes through
@@ -345,10 +327,6 @@ const TROW_KIND_ICON: Record<TrowActivityKind, ComponentType<LucideProps>> = {
   tool: Settings,
 };
 
-function trowKindIcon(toolName: string): ComponentType<LucideProps> {
-  return TROW_KIND_ICON[trowActivityKind(toolName)];
-}
-
 // #646 run→done seam: the one-shot settle "landing". Reuses the whitelisted
 // `maka-stream-fade-in` keyframe (opacity 0→1, one-shot `both`) — no new keyframe
 // (design-406 governance) — and rides `var(--duration-emphasized)` /
@@ -374,17 +352,11 @@ function ToolTrowGroup({ items }: { items: ToolActivityItem[] }) {
   const running = isTrowRunning(items);
   const attention = trowNeedsAttention(items);
   const active = activeTrowTool(items) ?? items[0]!;
-  // Controlled open: default collapsed, but a waiting_permission or errored
-  // tool forces the group open — a permission prompt must not hide behind the
-  // summary line, and an error banner must stay diagnosable (the old boxed
-  // cards kept errored tools expanded). The user's manual collapse sticks
-  // while `attention` stays true. No defaultOpen
-  // (disclosure-collapsible-contract) — controlled open re-syncs from status,
-  // like ToolActivityCard.
-  const [open, setOpen] = useState(attention);
-  useEffect(() => {
-    if (attention) setOpen(true);
-  }, [attention]);
+  const activePresentation = deriveToolActivityPresentation(active);
+  // Groups share the same disclosure state as a single row: ordinary work is
+  // summarized; a new permission/error state opens diagnostics; manual choice
+  // survives ordinary status changes.
+  const disclosure = useToolDisclosure({ ...activePresentation, needsAttention: attention });
   // #646: a group settles when all its tools do; the settle fade plays only if
   // the group was ever seen running here (not a replayed transcript). The
   // delayed shimmer de-flickers a group whose tools all finish sub-second.
@@ -393,12 +365,12 @@ function ToolTrowGroup({ items }: { items: ToolActivityItem[] }) {
   const settled = !running;
   const settling = settled && everRunningRef.current;
   const hasError = items.some((item) => item.status === 'errored');
-  const SummaryIcon = trowKindIcon(active.toolName);
+  const SummaryIcon = TROW_KIND_ICON[activePresentation.kind];
   const summary = running
-    ? formatUserVisibleToolText(active.intent ?? '') || resolveToolDisplayName(active)
+    ? activePresentation.summary
     : summarizeTrowTools(items);
   return (
-    <Collapsible className="flex flex-col" data-trow="group" data-settled={settled ? 'true' : undefined} open={open} onOpenChange={setOpen}>
+    <Collapsible className="flex flex-col" data-trow="group" data-settled={settled ? 'true' : undefined} open={disclosure.open} onOpenChange={disclosure.setOpen}>
       <CollapsibleTrigger className="group flex w-full items-center gap-2 py-0.5 text-left">
         <SummaryIcon size={16} aria-hidden="true" className={cn('shrink-0', hasError ? 'text-[color:var(--destructive)]' : 'text-[color:var(--muted-foreground)]')} />
         {running ? (
@@ -428,18 +400,14 @@ function ToolTrowGroup({ items }: { items: ToolActivityItem[] }) {
 }
 
 /**
- * A single flat, borderless tool row inside a multi-tool trow. Its header
- * expands to the shared `ToolCardBody`. Permission and error force it open;
- * normal running stays height-stable, and a user's manual choice survives
- * later status changes. No card frame (`toolVariants({item})`), per the flat
- * trow visual language.
+ * A single flat, borderless tool row inside a multi-tool trow. Ordinary work
+ * is collapsed; permission prompts and errors open for attention, and a user's
+ * manual choice survives later ordinary status changes. No card frame
+ * (`toolVariants({item})`), per the flat trow visual language.
  */
 function ToolTrowRow({ item }: { item: ToolActivityItem }) {
-  const attention = trowNeedsAttention([item]);
-  const [open, setOpen] = useState(attention);
-  useEffect(() => {
-    if (attention) setOpen(true);
-  }, [attention]);
+  const presentation = deriveToolActivityPresentation(item);
+  const disclosure = useToolDisclosure(presentation);
   const duration = formatDuration(item.durationMs);
   // #646 run→done seam: `everRunning` is sticky across this row's renders so the
   // settle fade fires only for a tool that ran here, never for a replayed row
@@ -449,16 +417,15 @@ function ToolTrowRow({ item }: { item: ToolActivityItem }) {
   if (isToolRowRunning(item.status)) everRunningRef.current = true;
   const motion = deriveToolRowMotion({ status: item.status, everRunning: everRunningRef.current });
   const errored = item.status === 'errored';
-  const RowIcon = trowKindIcon(item.toolName);
+  const RowIcon = TROW_KIND_ICON[presentation.kind];
   // One row language with the multi-tool summary row: a kind icon + a
   // user-language phrase, never the old status-dot + mono tool-name + status
   // word. Running shimmers the model's intent (or the friendly tool name);
   // settled prefers the intent, falls back to the display name.
-  const runningSummary = formatUserVisibleToolText(item.intent ?? '') || resolveToolDisplayName(item);
   const summaryTone = errored ? 'text-[color:var(--destructive)]' : 'text-[color:var(--muted-foreground)]';
   const settleFade = motion.settling ? SETTLE_FADE : undefined;
   return (
-    <Collapsible className="flex flex-col" data-trow="row" data-status={item.status} data-settled={motion.settled ? 'true' : undefined} open={open} onOpenChange={setOpen}>
+    <Collapsible className="flex flex-col" data-trow="row" data-status={item.status} data-settled={motion.settled ? 'true' : undefined} open={disclosure.open} onOpenChange={disclosure.setOpen}>
       <CollapsibleTrigger className="group flex w-full items-center gap-2 py-0.5 text-left">
         <RowIcon
           size={16}
@@ -466,7 +433,7 @@ function ToolTrowRow({ item }: { item: ToolActivityItem }) {
           className={cn('shrink-0', errored ? 'text-[color:var(--destructive)]' : 'text-[color:var(--muted-foreground)]')}
         />
         {motion.shimmer ? (
-          <TextShimmer active delayed className="min-w-0 truncate text-[length:var(--font-size-base)]">{runningSummary}</TextShimmer>
+          <TextShimmer active delayed className="min-w-0 truncate text-[length:var(--font-size-base)]">{presentation.summary}</TextShimmer>
         ) : item.intent ? (
           <span className={cn('min-w-0 truncate text-[length:var(--font-size-base)]', summaryTone, settleFade)}>{formatToolIntent(item.intent)}</span>
         ) : (
@@ -531,9 +498,9 @@ function ToolOutputStream(props: {
     el.scrollTop = el.scrollHeight;
   }, [props.chunks, props.live]);
 
-  const stdoutCount = props.chunks.filter((c) => c.stream === 'stdout').length;
-  const stderrCount = props.chunks.filter((c) => c.stream === 'stderr').length;
-  const redactedCount = props.chunks.filter((c) => c.redacted).length;
+  const hasStderr = props.chunks.some((c) => c.stream === 'stderr');
+  const hasRedacted = props.chunks.some((c) => c.redacted);
+  const hasFlags = hasStderr || hasRedacted || props.truncated;
 
   return (
     <div className={streamVariants({ part: 'container' })} data-live={props.live ? 'true' : undefined}>
@@ -550,20 +517,21 @@ function ToolOutputStream(props: {
             <span>工具输出</span>
           )}
         </span>
-        <span className={streamVariants({ part: 'counts' })}>
-          {stdoutCount > 0 && <span className={streamVariants({ part: 'count' })}>stdout {stdoutCount}</span>}
-          {stderrCount > 0 && <span className={streamVariants({ part: 'count' })} data-stream="stderr">stderr {stderrCount}</span>}
-          {redactedCount > 0 && <span className={streamVariants({ part: 'count' })} data-redacted="true">已脱敏 {redactedCount}</span>}
-          {props.truncated && (
-            <span
-              className={streamVariants({ part: 'count' })}
-              data-truncated="true"
-              title="部分输出已截断；如需完整输出请查看对应工具结果或生成的 artifact"
-            >
-              已截断
-            </span>
-          )}
-        </span>
+        {hasFlags && (
+          <span className={streamVariants({ part: 'flags' })}>
+            {hasStderr && <span className={streamVariants({ part: 'flag' })} data-stream="stderr">stderr</span>}
+            {hasRedacted && <span className={streamVariants({ part: 'flag' })} data-redacted="true">已脱敏</span>}
+            {props.truncated && (
+              <span
+                className={streamVariants({ part: 'flag' })}
+                data-truncated="true"
+                title="部分输出已截断；如需完整输出请查看对应工具结果或生成的 artifact"
+              >
+                已截断
+              </span>
+            )}
+          </span>
+        )}
       </header>
       <pre ref={preRef} className={streamVariants({ part: 'body' })}>
         {props.chunks.map((chunk) => (

--- a/packages/ui/src/tool-activity.tsx
+++ b/packages/ui/src/tool-activity.tsx
@@ -205,9 +205,29 @@ function isPermissionDeniedToolResult(result: ToolActivityItem['result']): boole
   return result?.kind === 'text' && formatUserVisibleToolText(result.text).trim() === '用户已拒绝权限请求';
 }
 
-/** Result kinds that own their own quiet panel (do not nest in the shared well). */
-function resultOwnsOwnPanel(result: ToolActivityItem['result']): boolean {
-  return result?.kind === 'terminal' || result?.kind === 'shell_run';
+/**
+ * Result kinds (or tool-specific cards) that already paint their own chrome —
+ * never nest them inside the shared quiet well.
+ */
+function resultOwnsOwnPanel(item: ToolActivityItem): boolean {
+  const result = item.result;
+  if (!result) return false;
+  if (isAutomationTool(item.toolName) && result.kind === 'text') return true;
+  if (isConnectorTool(item.toolName) && result.kind === 'json') return true;
+  switch (result.kind) {
+    case 'terminal':
+    case 'shell_run':
+    case 'subagent':
+    case 'explore_agent':
+    case 'web_search':
+    case 'web_search_error':
+    case 'file_diff':
+    case 'office_document':
+    case 'rive_workflow':
+      return true;
+    default:
+      return false;
+  }
 }
 
 function isCancelledToolResult(result: ToolActivityItem['result']): boolean {
@@ -228,23 +248,37 @@ function resultHasCapturedStreams(result: ToolActivityItem['result']): boolean {
 
 /**
  * Background Bash yields an empty shell_run body; keep the live chunks the
- * user already saw by filling empty stdout/stderr from outputChunks.
+ * user already saw by filling empty stdout/stderr from outputChunks. Also
+ * forward truncation / redaction hints so settled preview matches live.
  */
 function withLiveStreamFallback(
   result: NonNullable<ToolActivityItem['result']>,
   chunks: ToolActivityItem['outputChunks'] | undefined,
+  options?: { truncated?: boolean },
 ): NonNullable<ToolActivityItem['result']> {
   if (!chunks?.length) return result;
   if (result.kind !== 'terminal' && result.kind !== 'shell_run') return result;
   if (resultHasCapturedStreams(result)) return result;
   let stdout = '';
   let stderr = '';
+  let anyRedacted = false;
   for (const chunk of chunks) {
+    if (chunk.redacted) anyRedacted = true;
     if (chunk.stream === 'stderr') stderr += chunk.text;
     else stdout += chunk.text;
   }
   if (!stdout && !stderr) return result;
-  return { ...result, stdout, stderr };
+  // Match live stream's "[已脱敏]" marker when a chunk was redacted.
+  if (anyRedacted) {
+    if (stdout.length > 0) stdout = `${stdout}${stdout.endsWith('\n') ? '' : '\n'}[已脱敏]`;
+    else stderr = `${stderr}${stderr.endsWith('\n') ? '' : '\n'}[已脱敏]`;
+  }
+  return {
+    ...result,
+    stdout,
+    stderr,
+    stdoutTruncated: result.stdoutTruncated === true || options?.truncated === true,
+  };
 }
 
 function toolStatusLabel(item: ToolActivityItem): string {
@@ -315,8 +349,8 @@ function ToolCardBody({ item }: { item: ToolActivityItem }) {
   const errored = item.status === 'errored' && !cancelled;
   const permissionDenied = isPermissionDeniedToolResult(item.result);
   const running = item.status === 'running' || item.status === 'pending';
-  // terminal / shell_run own a single quiet panel — never nest inside the shared well.
-  const ownsPanel = resultOwnsOwnPanel(item.result);
+  // Rich kinds + tool-specific cards own their chrome — never nest in the shared well.
+  const ownsPanel = resultOwnsOwnPanel(item);
   const showErrorBanner = errored;
   // Every tool: human invocation line from args — never pretty-printed JSON.
   // Skip when the result panel already prints the command (terminal/shell_run).
@@ -333,7 +367,9 @@ function ToolCardBody({ item }: { item: ToolActivityItem }) {
     && (running || !item.result);
   const showResult = !!item.result && !permissionDenied;
   const displayResult = showResult && item.result
-    ? withLiveStreamFallback(item.result, item.outputChunks)
+    ? withLiveStreamFallback(item.result, item.outputChunks, {
+      truncated: item.outputTruncated === true,
+    })
     : undefined;
   const quietJson =
     displayResult?.kind === 'json'
@@ -360,7 +396,15 @@ function ToolCardBody({ item }: { item: ToolActivityItem }) {
   return (
     <div className="mt-1 flex flex-col gap-1.5">
       {showErrorBanner && <ToolErrorBanner result={displayResult ?? item.result} />}
-      {showResult && ownsPanel && displayResult && <ToolResultPreview content={displayResult} />}
+      {showResult && ownsPanel && displayResult && (
+        isConnectorTool(item.toolName) && displayResult.kind === 'json' ? (
+          <LoadToolResultPreview args={item.args} value={displayResult.value} />
+        ) : isAutomationTool(item.toolName) && displayResult.kind === 'text' ? (
+          <AutomationResultPreview text={displayResult.text} />
+        ) : (
+          <ToolResultPreview content={displayResult} />
+        )
+      )}
       {hasSharedPanelContent && (
         <div
           data-slot="tool-output"
@@ -386,11 +430,7 @@ function ToolCardBody({ item }: { item: ToolActivityItem }) {
             />
           )}
           {showResult && !ownsPanel && displayResult && (
-            isConnectorTool(item.toolName) && displayResult.kind === 'json' ? (
-              <LoadToolResultPreview args={item.args} value={displayResult.value} />
-            ) : isAutomationTool(item.toolName) && displayResult.kind === 'text' ? (
-              <AutomationResultPreview text={displayResult.text} />
-            ) : quietJson ? (
+            quietJson ? (
               <pre className={TOOL_OUTPUT_BODY_CLASS}>{quietJson.body}</pre>
             ) : (
               <ToolResultPreview content={displayResult} />

--- a/packages/ui/src/tool-activity/builtin-preview.ts
+++ b/packages/ui/src/tool-activity/builtin-preview.ts
@@ -86,8 +86,25 @@ function isSensitiveKey(key: string): boolean {
   return SENSITIVE_KEY_RE.test(key);
 }
 
+/**
+ * Keys may themselves embed secrets (`password=correct-horse`). Mask the
+ * assignment payload; never rely on redactSecrets alone for short passwords.
+ */
+function safeKeyLabel(key: string): string {
+  if (isSensitiveKey(key) || /(?:password|passwd|secret|token|api[_-]?key)\s*=/i.test(key)) {
+    if (key.includes('=')) {
+      const left = key.slice(0, key.indexOf('='));
+      return redactSecrets(`${left}=<redacted>`);
+    }
+    return redactSecrets(key);
+  }
+  return redactSecrets(key);
+}
+
 function maskSensitiveValue(key: string, value: unknown): unknown {
-  if (!isSensitiveKey(key)) return value;
+  if (!isSensitiveKey(key) && !/(?:password|passwd|secret|token|api[_-]?key)\s*=/i.test(key)) {
+    return value;
+  }
   if (value === undefined) return undefined;
   return '<redacted>';
 }
@@ -320,7 +337,7 @@ export function formatAsKeyValueLines(record: Record<string, unknown>, depth = 0
   };
   for (const [key, raw] of Object.entries(record)) {
     if (raw === undefined) continue;
-    const safeKey = redactSecrets(key);
+    const safeKey = safeKeyLabel(key);
     const value = maskSensitiveValue(key, raw);
     if (value === null) {
       push(`${indent}${safeKey}: null`);

--- a/packages/ui/src/tool-activity/builtin-preview.ts
+++ b/packages/ui/src/tool-activity/builtin-preview.ts
@@ -227,54 +227,64 @@ function formatArrayAsBody(values: unknown[]): string {
 
 /**
  * Plain `key: value` lines — never JSON braces or escaped `\n` sequences.
+ * Keys and whole lines pass through `redactSecrets` so dynamic property names
+ * carrying credentials (e.g. `api_key=sk-…`) cannot bypass value-only redaction.
  */
 export function formatAsKeyValueLines(record: Record<string, unknown>, depth = 0): string {
   if (depth > 3) return redactSecrets(String(record));
   const indent = '  '.repeat(depth);
   const lines: string[] = [];
+  const push = (line: string) => {
+    lines.push(redactSecrets(line));
+  };
   for (const [key, raw] of Object.entries(record)) {
     if (raw === undefined) continue;
+    const safeKey = redactSecrets(key);
     if (raw === null) {
-      lines.push(`${indent}${key}: null`);
+      push(`${indent}${safeKey}: null`);
       continue;
     }
     if (typeof raw === 'string') {
       // Multi-line strings get a block, not a quoted escape soup.
       if (raw.includes('\n')) {
-        lines.push(`${indent}${key}:`);
+        push(`${indent}${safeKey}:`);
         for (const line of redactSecrets(raw).split('\n')) {
-          lines.push(`${indent}  ${line}`);
+          push(`${indent}  ${line}`);
         }
       } else {
-        lines.push(`${indent}${key}: ${redactSecrets(raw)}`);
+        push(`${indent}${safeKey}: ${redactSecrets(raw)}`);
       }
       continue;
     }
     if (typeof raw === 'number' || typeof raw === 'boolean') {
-      lines.push(`${indent}${key}: ${raw}`);
+      push(`${indent}${safeKey}: ${raw}`);
       continue;
     }
     if (Array.isArray(raw)) {
       if (raw.length === 0) {
-        lines.push(`${indent}${key}: （空）`);
+        push(`${indent}${safeKey}: （空）`);
       } else if (raw.every((item) => typeof item === 'string' || typeof item === 'number' || typeof item === 'boolean')) {
-        lines.push(`${indent}${key}:`);
+        push(`${indent}${safeKey}:`);
         for (const item of raw) {
-          lines.push(`${indent}  - ${typeof item === 'string' ? redactSecrets(item) : String(item)}`);
+          push(`${indent}  - ${typeof item === 'string' ? redactSecrets(item) : String(item)}`);
         }
       } else {
-        lines.push(`${indent}${key}:`);
-        lines.push(formatArrayAsBody(raw).split('\n').map((line) => `${indent}  ${line}`).join('\n'));
+        push(`${indent}${safeKey}:`);
+        for (const line of formatArrayAsBody(raw).split('\n')) {
+          push(`${indent}  ${line}`);
+        }
       }
       continue;
     }
     if (typeof raw === 'object') {
-      lines.push(`${indent}${key}:`);
+      push(`${indent}${safeKey}:`);
       const nested = formatAsKeyValueLines(raw as Record<string, unknown>, depth + 1);
-      if (nested) lines.push(nested);
+      if (nested) {
+        for (const line of nested.split('\n')) push(line);
+      }
       continue;
     }
-    lines.push(`${indent}${key}: ${redactSecrets(String(raw))}`);
+    push(`${indent}${safeKey}: ${redactSecrets(String(raw))}`);
   }
   return lines.join('\n');
 }

--- a/packages/ui/src/tool-activity/builtin-preview.ts
+++ b/packages/ui/src/tool-activity/builtin-preview.ts
@@ -68,11 +68,12 @@ const SENSITIVE_KEY_RE =
   /(password|passwd|secret|token|api[_-]?key|access[_-]?token|authorization|^auth$|credential|private[_-]?key)/i;
 
 /**
- * Secret embedded in a key itself, e.g. `password=x`, `password: x`, `token x`.
- * Captures keyword + separator so only the payload is replaced with <redacted>.
+ * Secret embedded in a key itself, e.g. `password=x`, `password: x`,
+ * `Authorization: Bearer tok`. Captures keyword + separator; the remainder of
+ * the key (not just the first token) is replaced with <redacted>.
  */
 const SENSITIVE_KEY_PAYLOAD_RE =
-  /((?:password|passwd|secret|token|api[_-]?key|access[_-]?token|authorization|credential|private[_-]?key)[^\s=:]*)(\s*[=:]\s*|\s+)(\S+)/gi;
+  /((?:password|passwd|secret|token|api[_-]?key|access[_-]?token|authorization|credential|private[_-]?key)[^\s=:]*)(\s*[=:]\s*|\s+)(.+)$/gi;
 
 function asRecord(value: unknown): Record<string, unknown> | undefined {
   if (!value || typeof value !== 'object' || Array.isArray(value)) return undefined;

--- a/packages/ui/src/tool-activity/builtin-preview.ts
+++ b/packages/ui/src/tool-activity/builtin-preview.ts
@@ -3,7 +3,8 @@
  *
  * Built-in tools (Read/Grep/…) still persist as `kind: 'json'`. The quiet panel
  * must never dump pretty-printed JSON with escaped newlines — always plain
- * headline + body text, for every tool name.
+ * headline + body text. Primary fields win the main body, but remaining fields
+ * are always appended so diagnostics (error/ok/truncated) cannot disappear.
  */
 import { redactSecrets } from '../redact.js';
 import type { ToolActivityItem } from '../materialize.js';
@@ -48,6 +49,24 @@ const HEADLINE_KEYS = [
   'ref',
 ] as const;
 
+/** Diagnostic / meta fields shown after the primary body when still present. */
+const REMAINDER_PRIORITY = [
+  'error',
+  'reason',
+  'ok',
+  'truncated',
+  'status',
+  'code',
+  'message',
+] as const;
+
+/**
+ * Property names whose values must never be shown raw — structural redaction
+ * beyond the string-pattern safety net in redactSecrets.
+ */
+const SENSITIVE_KEY_RE =
+  /(password|passwd|secret|token|api[_-]?key|access[_-]?token|authorization|^auth$|credential|private[_-]?key)/i;
+
 function asRecord(value: unknown): Record<string, unknown> | undefined {
   if (!value || typeof value !== 'object' || Array.isArray(value)) return undefined;
   return value as Record<string, unknown>;
@@ -61,6 +80,16 @@ function stringField(record: Record<string, unknown> | undefined, key: string): 
 function numberField(record: Record<string, unknown> | undefined, key: string): number | undefined {
   const raw = record?.[key];
   return typeof raw === 'number' && Number.isFinite(raw) ? raw : undefined;
+}
+
+function isSensitiveKey(key: string): boolean {
+  return SENSITIVE_KEY_RE.test(key);
+}
+
+function maskSensitiveValue(key: string, value: unknown): unknown {
+  if (!isSensitiveKey(key)) return value;
+  if (value === undefined) return undefined;
+  return '<redacted>';
 }
 
 function formatRangeSuffix(args: Record<string, unknown>): string {
@@ -114,6 +143,7 @@ export function formatToolInvocationLine(
   if (query) return redactSecrets(query);
 
   for (const key of HEADLINE_KEYS) {
+    if (isSensitiveKey(key)) continue;
     const value = stringField(args, key);
     if (value) return redactSecrets(value);
   }
@@ -132,6 +162,9 @@ export interface QuietPreview {
  * Format any tool JSON/result payload for the quiet panel.
  * Always returns a body — never `undefined` for object values so callers
  * cannot fall back to `JSON.stringify`.
+ *
+ * Primary list/text fields become the main body; remaining fields (error, ok,
+ * truncated, …) are appended so diagnostics cannot vanish.
  */
 export function formatQuietJsonValue(value: unknown): QuietPreview {
   if (value === null || value === undefined) {
@@ -155,23 +188,35 @@ export function formatQuietJsonValue(value: unknown): QuietPreview {
   // Known list payloads (Grep/Glob/load_tools/…).
   for (const key of LIST_KEYS) {
     if (!Array.isArray(record[key])) continue;
-    const body = formatArrayAsBody(record[key] as unknown[]);
-    const headline = pickHeadline(record, new Set<string>([key]));
+    const consumed = new Set<string>([key]);
+    const primary = formatArrayAsBody(record[key] as unknown[]);
+    const headline = pickHeadline(record, consumed);
+    if (headline) consumed.add(headlineSourceKey(record, headline) ?? '');
+    const rest = formatRemainder(record, consumed);
+    const body = rest ? `${primary}\n${rest}` : primary;
     return headline ? { headline, body } : { body };
   }
 
   // Dominant text payload (Read content, messages, …).
   for (const key of BODY_KEYS) {
     if (typeof record[key] !== 'string') continue;
-    const body = redactSecrets(record[key] as string);
-    // Prefer path/title from sibling fields as headline; do not restate the body key.
-    const headline = pickHeadline(record, new Set<string>([key]));
+    if (isSensitiveKey(key)) continue;
+    const consumed = new Set<string>([key]);
+    const primary = redactSecrets(record[key] as string);
+    const headline = pickHeadline(record, consumed);
+    if (headline) {
+      const hk = headlineSourceKey(record, headline);
+      if (hk) consumed.add(hk);
+    }
+    const rest = formatRemainder(record, consumed);
+    const body = rest ? `${primary}\n${rest}` : primary;
     return headline ? { headline, body } : { body };
   }
 
   // Write / Edit style { ok, path, bytes, … }.
   const path = stringField(record, 'path');
-  if (path && (record.ok === true || numberField(record, 'bytes') !== undefined || numberField(record, 'replacements') !== undefined)) {
+  if (path && (record.ok === true || record.ok === false || numberField(record, 'bytes') !== undefined || numberField(record, 'replacements') !== undefined)) {
+    const consumed = new Set<string>(['path', 'ok', 'bytes', 'replacements', 'startLine', 'endLine', 'matchedVia']);
     const bytes = numberField(record, 'bytes');
     const replacements = numberField(record, 'replacements');
     const startLine = numberField(record, 'startLine');
@@ -182,9 +227,11 @@ export function formatQuietJsonValue(value: unknown): QuietPreview {
     if (bytes !== undefined) parts.push(`${bytes} B`);
     if (replacements !== undefined) parts.push(`${replacements} 处`);
     if (startLine !== undefined && endLine !== undefined) parts.push(`L${startLine}–${endLine}`);
+    const primary = parts.length > 0 ? parts.join(' · ') : '已写入';
+    const rest = formatRemainder(record, consumed);
     return {
       headline: redactSecrets(path),
-      body: parts.length > 0 ? parts.join(' · ') : '已写入',
+      body: rest ? `${primary}\n${rest}` : primary,
     };
   }
 
@@ -201,11 +248,45 @@ function pickHeadline(
   skip: ReadonlySet<string>,
 ): string | undefined {
   for (const key of HEADLINE_KEYS) {
-    if (skip.has(key)) continue;
+    if (skip.has(key) || isSensitiveKey(key)) continue;
     const value = stringField(record, key);
     if (value) return redactSecrets(value);
   }
   return undefined;
+}
+
+function headlineSourceKey(
+  record: Record<string, unknown>,
+  headline: string,
+): string | undefined {
+  for (const key of HEADLINE_KEYS) {
+    const value = stringField(record, key);
+    if (value && redactSecrets(value) === headline) return key;
+  }
+  return undefined;
+}
+
+/**
+ * Remaining fields after a primary body was chosen — always keep diagnostics.
+ * Order: REMAINDER_PRIORITY first, then the rest alphabetically stable via Object.entries.
+ */
+function formatRemainder(
+  record: Record<string, unknown>,
+  consumed: ReadonlySet<string>,
+): string {
+  const rest: Record<string, unknown> = {};
+  const prioritized: Record<string, unknown> = {};
+  for (const key of REMAINDER_PRIORITY) {
+    if (consumed.has(key) || record[key] === undefined) continue;
+    prioritized[key] = record[key];
+  }
+  for (const [key, value] of Object.entries(record)) {
+    if (consumed.has(key) || value === undefined) continue;
+    if (key in prioritized) continue;
+    rest[key] = value;
+  }
+  const ordered = { ...prioritized, ...rest };
+  return formatAsKeyValueLines(ordered);
 }
 
 function formatArrayAsBody(values: unknown[]): string {
@@ -227,8 +308,8 @@ function formatArrayAsBody(values: unknown[]): string {
 
 /**
  * Plain `key: value` lines — never JSON braces or escaped `\n` sequences.
- * Keys and whole lines pass through `redactSecrets` so dynamic property names
- * carrying credentials (e.g. `api_key=sk-…`) cannot bypass value-only redaction.
+ * Keys and whole lines pass through `redactSecrets`; sensitive key names force
+ * value masking even when the value itself is a short non-token secret.
  */
 export function formatAsKeyValueLines(record: Record<string, unknown>, depth = 0): string {
   if (depth > 3) return redactSecrets(String(record));
@@ -240,51 +321,51 @@ export function formatAsKeyValueLines(record: Record<string, unknown>, depth = 0
   for (const [key, raw] of Object.entries(record)) {
     if (raw === undefined) continue;
     const safeKey = redactSecrets(key);
-    if (raw === null) {
+    const value = maskSensitiveValue(key, raw);
+    if (value === null) {
       push(`${indent}${safeKey}: null`);
       continue;
     }
-    if (typeof raw === 'string') {
-      // Multi-line strings get a block, not a quoted escape soup.
-      if (raw.includes('\n')) {
+    if (typeof value === 'string') {
+      if (value.includes('\n') && value !== '<redacted>') {
         push(`${indent}${safeKey}:`);
-        for (const line of redactSecrets(raw).split('\n')) {
+        for (const line of redactSecrets(value).split('\n')) {
           push(`${indent}  ${line}`);
         }
       } else {
-        push(`${indent}${safeKey}: ${redactSecrets(raw)}`);
+        push(`${indent}${safeKey}: ${redactSecrets(value)}`);
       }
       continue;
     }
-    if (typeof raw === 'number' || typeof raw === 'boolean') {
-      push(`${indent}${safeKey}: ${raw}`);
+    if (typeof value === 'number' || typeof value === 'boolean') {
+      push(`${indent}${safeKey}: ${value}`);
       continue;
     }
-    if (Array.isArray(raw)) {
-      if (raw.length === 0) {
+    if (Array.isArray(value)) {
+      if (value.length === 0) {
         push(`${indent}${safeKey}: （空）`);
-      } else if (raw.every((item) => typeof item === 'string' || typeof item === 'number' || typeof item === 'boolean')) {
+      } else if (value.every((item) => typeof item === 'string' || typeof item === 'number' || typeof item === 'boolean')) {
         push(`${indent}${safeKey}:`);
-        for (const item of raw) {
+        for (const item of value) {
           push(`${indent}  - ${typeof item === 'string' ? redactSecrets(item) : String(item)}`);
         }
       } else {
         push(`${indent}${safeKey}:`);
-        for (const line of formatArrayAsBody(raw).split('\n')) {
+        for (const line of formatArrayAsBody(value).split('\n')) {
           push(`${indent}  ${line}`);
         }
       }
       continue;
     }
-    if (typeof raw === 'object') {
+    if (typeof value === 'object') {
       push(`${indent}${safeKey}:`);
-      const nested = formatAsKeyValueLines(raw as Record<string, unknown>, depth + 1);
+      const nested = formatAsKeyValueLines(value as Record<string, unknown>, depth + 1);
       if (nested) {
         for (const line of nested.split('\n')) push(line);
       }
       continue;
     }
-    push(`${indent}${safeKey}: ${redactSecrets(String(raw))}`);
+    push(`${indent}${safeKey}: ${redactSecrets(String(value))}`);
   }
   return lines.join('\n');
 }

--- a/packages/ui/src/tool-activity/builtin-preview.ts
+++ b/packages/ui/src/tool-activity/builtin-preview.ts
@@ -64,16 +64,18 @@ const REMAINDER_PRIORITY = [
  * Property names whose values must never be shown raw — structural redaction
  * beyond the string-pattern safety net in redactSecrets.
  */
+// Multi-word forms use [\s_-]* so "api key" / "private key" / "access token" match.
 const SENSITIVE_KEY_RE =
-  /(password|passwd|secret|token|api[_-]?key|access[_-]?token|authorization|^auth$|credential|private[_-]?key)/i;
+  /(password|passwd|secret|token|api[\s_-]*key|access[\s_-]*token|authorization|(?:^|[\s_-])auth(?:$|[\s_=:.-])|credential|private[\s_-]*key)/i;
 
 /**
  * Secret embedded in a key itself, e.g. `password=x`, `password: x`,
- * `Authorization: Bearer tok`. Captures keyword + separator; the remainder of
- * the key (not just the first token) is replaced with <redacted>.
+ * `api key: …`, `auth=…`, `Authorization: Bearer tok`. Captures keyword +
+ * separator; the remainder of the key (not just the first token) is replaced
+ * with <redacted>.
  */
 const SENSITIVE_KEY_PAYLOAD_RE =
-  /((?:password|passwd|secret|token|api[_-]?key|access[_-]?token|authorization|credential|private[_-]?key)[^\s=:]*)(\s*[=:]\s*|\s+)(.+)$/gi;
+  /((?:password|passwd|secret|token|api[\s_-]*key|access[\s_-]*token|authorization|\bauth\b|credential|private[\s_-]*key)[^\s=:]*)(\s*[=:]\s*|\s+)(.+)$/gi;
 
 function asRecord(value: unknown): Record<string, unknown> | undefined {
   if (!value || typeof value !== 'object' || Array.isArray(value)) return undefined;

--- a/packages/ui/src/tool-activity/builtin-preview.ts
+++ b/packages/ui/src/tool-activity/builtin-preview.ts
@@ -67,6 +67,13 @@ const REMAINDER_PRIORITY = [
 const SENSITIVE_KEY_RE =
   /(password|passwd|secret|token|api[_-]?key|access[_-]?token|authorization|^auth$|credential|private[_-]?key)/i;
 
+/**
+ * Secret embedded in a key itself, e.g. `password=x`, `password: x`, `token x`.
+ * Captures keyword + separator so only the payload is replaced with <redacted>.
+ */
+const SENSITIVE_KEY_PAYLOAD_RE =
+  /((?:password|passwd|secret|token|api[_-]?key|access[_-]?token|authorization|credential|private[_-]?key)[^\s=:]*)(\s*[=:]\s*|\s+)(\S+)/gi;
+
 function asRecord(value: unknown): Record<string, unknown> | undefined {
   if (!value || typeof value !== 'object' || Array.isArray(value)) return undefined;
   return value as Record<string, unknown>;
@@ -86,23 +93,25 @@ function isSensitiveKey(key: string): boolean {
   return SENSITIVE_KEY_RE.test(key);
 }
 
+function maskSensitiveKeyPayload(key: string): string {
+  SENSITIVE_KEY_PAYLOAD_RE.lastIndex = 0;
+  return key.replace(SENSITIVE_KEY_PAYLOAD_RE, '$1$2<redacted>');
+}
+
 /**
- * Keys may themselves embed secrets (`password=correct-horse`). Mask the
- * assignment payload; never rely on redactSecrets alone for short passwords.
+ * Keys may themselves embed secrets (`password=x`, `password: x`). Mask the
+ * assignment payload for = / : / whitespace separators — never rely on
+ * redactSecrets alone for short passwords.
  */
 function safeKeyLabel(key: string): string {
-  if (isSensitiveKey(key) || /(?:password|passwd|secret|token|api[_-]?key)\s*=/i.test(key)) {
-    if (key.includes('=')) {
-      const left = key.slice(0, key.indexOf('='));
-      return redactSecrets(`${left}=<redacted>`);
-    }
-    return redactSecrets(key);
-  }
+  const masked = maskSensitiveKeyPayload(key);
+  if (masked !== key) return redactSecrets(masked);
   return redactSecrets(key);
 }
 
 function maskSensitiveValue(key: string, value: unknown): unknown {
-  if (!isSensitiveKey(key) && !/(?:password|passwd|secret|token|api[_-]?key)\s*=/i.test(key)) {
+  const keyHasEmbeddedSecret = maskSensitiveKeyPayload(key) !== key;
+  if (!isSensitiveKey(key) && !keyHasEmbeddedSecret) {
     return value;
   }
   if (value === undefined) return undefined;

--- a/packages/ui/src/tool-activity/builtin-preview.ts
+++ b/packages/ui/src/tool-activity/builtin-preview.ts
@@ -1,0 +1,145 @@
+/**
+ * Quiet-panel presentation for built-in Read / Grep / Glob / Edit / Write
+ * tools that still persist as generic JSON. Pure helpers — no React.
+ */
+import { redactSecrets } from '../redact.js';
+import type { ToolActivityItem } from '../materialize.js';
+import { extractToolCommand } from './tool-command.js';
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return undefined;
+  return value as Record<string, unknown>;
+}
+
+function stringField(record: Record<string, unknown> | undefined, key: string): string | undefined {
+  const raw = record?.[key];
+  return typeof raw === 'string' && raw.length > 0 ? raw : undefined;
+}
+
+function numberField(record: Record<string, unknown> | undefined, key: string): number | undefined {
+  const raw = record?.[key];
+  return typeof raw === 'number' && Number.isFinite(raw) ? raw : undefined;
+}
+
+/**
+ * First-line invocation for the quiet panel: path / pattern / command text,
+ * never a pretty-printed args object.
+ */
+export function formatToolInvocationLine(item: Pick<ToolActivityItem, 'toolName' | 'args' | 'activityKind'>): string | undefined {
+  const args = asRecord(item.args);
+  if (!args) return undefined;
+
+  const command = extractToolCommand(item.args);
+  if (command) return redactSecrets(command);
+
+  const path = stringField(args, 'path');
+  const pattern = stringField(args, 'pattern');
+  const name = item.toolName;
+
+  if (name === 'Read' || name === 'Write' || name === 'Edit') {
+    if (!path) return undefined;
+    const offset = numberField(args, 'offset');
+    const limit = numberField(args, 'limit');
+    const range =
+      offset !== undefined || limit !== undefined
+        ? ` · L${offset ?? 0}${limit !== undefined ? `+${limit}` : ''}`
+        : '';
+    return redactSecrets(`${path}${range}`);
+  }
+
+  if (name === 'Grep') {
+    if (!pattern) return undefined;
+    const scope = path ? ` in ${path}` : '';
+    const glob = stringField(args, 'glob');
+    const globSuffix = glob ? ` (${glob})` : '';
+    return redactSecrets(`${pattern}${scope}${globSuffix}`);
+  }
+
+  if (name === 'Glob') {
+    if (!pattern) return undefined;
+    const cwd = stringField(args, 'cwd');
+    return redactSecrets(cwd ? `${pattern} in ${cwd}` : pattern);
+  }
+
+  // Unknown tools: prefer a single primary string field over JSON dump.
+  if (path) return redactSecrets(path);
+  if (pattern) return redactSecrets(pattern);
+  return undefined;
+}
+
+export interface BuiltinJsonPreview {
+  /** Preferred first line when the result already embeds the subject (e.g. write path). */
+  headline?: string;
+  body: string;
+}
+
+/**
+ * Turn built-in tool JSON results into plain text for the quiet panel.
+ * Returns undefined when the shape is not a known builtin result — caller
+ * falls back to generic JSON preview.
+ */
+export function formatBuiltinJsonResult(
+  toolName: string,
+  value: unknown,
+): BuiltinJsonPreview | undefined {
+  const record = asRecord(value);
+  if (!record) return undefined;
+
+  if (toolName === 'Read') {
+    const content = stringField(record, 'content');
+    if (content === undefined) return undefined;
+    return { body: redactSecrets(content) };
+  }
+
+  if (toolName === 'Grep') {
+    const matches = record.matches;
+    if (!Array.isArray(matches)) return undefined;
+    const lines = matches
+      .filter((line): line is string => typeof line === 'string')
+      .map((line) => redactSecrets(line));
+    return {
+      body: lines.length > 0 ? lines.join('\n') : '（无匹配）',
+    };
+  }
+
+  if (toolName === 'Glob') {
+    const files = record.files;
+    if (!Array.isArray(files)) return undefined;
+    const lines = files
+      .filter((line): line is string => typeof line === 'string')
+      .map((line) => redactSecrets(line));
+    return {
+      body: lines.length > 0 ? lines.join('\n') : '（无匹配文件）',
+    };
+  }
+
+  if (toolName === 'Write') {
+    const path = stringField(record, 'path');
+    const bytes = numberField(record, 'bytes');
+    if (!path) return undefined;
+    const size = bytes !== undefined ? ` · ${bytes} B` : '';
+    return {
+      headline: redactSecrets(path),
+      body: `已写入${size}`,
+    };
+  }
+
+  if (toolName === 'Edit') {
+    const path = stringField(record, 'path');
+    const replacements = numberField(record, 'replacements');
+    const startLine = numberField(record, 'startLine');
+    const endLine = numberField(record, 'endLine');
+    if (!path) return undefined;
+    const range =
+      startLine !== undefined && endLine !== undefined
+        ? ` · L${startLine}–${endLine}`
+        : '';
+    const count = replacements !== undefined ? ` · ${replacements} 处` : '';
+    return {
+      headline: redactSecrets(path),
+      body: `已替换${count}${range}`,
+    };
+  }
+
+  return undefined;
+}

--- a/packages/ui/src/tool-activity/builtin-preview.ts
+++ b/packages/ui/src/tool-activity/builtin-preview.ts
@@ -1,10 +1,52 @@
 /**
- * Quiet-panel presentation for built-in Read / Grep / Glob / Edit / Write
- * tools that still persist as generic JSON. Pure helpers — no React.
+ * Quiet-panel formatting for tool args + generic JSON results.
+ *
+ * Built-in tools (Read/Grep/…) still persist as `kind: 'json'`. The quiet panel
+ * must never dump pretty-printed JSON with escaped newlines — always plain
+ * headline + body text, for every tool name.
  */
 import { redactSecrets } from '../redact.js';
 import type { ToolActivityItem } from '../materialize.js';
 import { extractToolCommand } from './tool-command.js';
+
+const BODY_KEYS = [
+  'content',
+  'text',
+  'message',
+  'output',
+  'stdout',
+  'stderr',
+  'diff',
+  'summary',
+  'body',
+  'result',
+] as const;
+
+const LIST_KEYS = [
+  'matches',
+  'files',
+  'results',
+  'items',
+  'lines',
+  'rows',
+  'loaded',
+  'tools',
+  'paths',
+] as const;
+
+const HEADLINE_KEYS = [
+  'path',
+  'file',
+  'cmd',
+  'command',
+  'pattern',
+  'query',
+  'url',
+  'name',
+  'title',
+  'id',
+  'ref',
+] as const;
 
 function asRecord(value: unknown): Record<string, unknown> | undefined {
   if (!value || typeof value !== 'object' || Array.isArray(value)) return undefined;
@@ -21,125 +63,218 @@ function numberField(record: Record<string, unknown> | undefined, key: string): 
   return typeof raw === 'number' && Number.isFinite(raw) ? raw : undefined;
 }
 
+function formatRangeSuffix(args: Record<string, unknown>): string {
+  const offset = numberField(args, 'offset');
+  const limit = numberField(args, 'limit');
+  if (offset === undefined && limit === undefined) return '';
+  return ` · L${offset ?? 0}${limit !== undefined ? `+${limit}` : ''}`;
+}
+
 /**
- * First-line invocation for the quiet panel: path / pattern / command text,
- * never a pretty-printed args object.
+ * First-line invocation for the quiet panel from tool args — never a
+ * pretty-printed args object.
  */
-export function formatToolInvocationLine(item: Pick<ToolActivityItem, 'toolName' | 'args' | 'activityKind'>): string | undefined {
+export function formatToolInvocationLine(
+  item: Pick<ToolActivityItem, 'toolName' | 'args' | 'activityKind'>,
+): string | undefined {
   const args = asRecord(item.args);
-  if (!args) return undefined;
+  if (!args) {
+    if (typeof item.args === 'string' && item.args.trim()) return redactSecrets(item.args);
+    return undefined;
+  }
 
   const command = extractToolCommand(item.args);
   if (command) return redactSecrets(command);
 
-  const path = stringField(args, 'path');
+  const path = stringField(args, 'path') ?? stringField(args, 'file');
   const pattern = stringField(args, 'pattern');
+  const query = stringField(args, 'query');
   const name = item.toolName;
 
-  if (name === 'Read' || name === 'Write' || name === 'Edit') {
-    if (!path) return undefined;
-    const offset = numberField(args, 'offset');
-    const limit = numberField(args, 'limit');
-    const range =
-      offset !== undefined || limit !== undefined
-        ? ` · L${offset ?? 0}${limit !== undefined ? `+${limit}` : ''}`
-        : '';
-    return redactSecrets(`${path}${range}`);
+  if (name === 'Grep' || (pattern && (name === 'Glob' || path))) {
+    if (pattern) {
+      const scope = path ? ` in ${path}` : '';
+      const glob = stringField(args, 'glob');
+      const cwd = stringField(args, 'cwd');
+      const where = scope || (cwd ? ` in ${cwd}` : '');
+      const globSuffix = glob ? ` (${glob})` : '';
+      return redactSecrets(`${pattern}${where}${globSuffix}`);
+    }
   }
 
-  if (name === 'Grep') {
-    if (!pattern) return undefined;
-    const scope = path ? ` in ${path}` : '';
-    const glob = stringField(args, 'glob');
-    const globSuffix = glob ? ` (${glob})` : '';
-    return redactSecrets(`${pattern}${scope}${globSuffix}`);
+  if (path) {
+    return redactSecrets(`${path}${formatRangeSuffix(args)}`);
   }
 
-  if (name === 'Glob') {
-    if (!pattern) return undefined;
+  if (pattern) {
     const cwd = stringField(args, 'cwd');
     return redactSecrets(cwd ? `${pattern} in ${cwd}` : pattern);
   }
 
-  // Unknown tools: prefer a single primary string field over JSON dump.
-  if (path) return redactSecrets(path);
-  if (pattern) return redactSecrets(pattern);
-  return undefined;
+  if (query) return redactSecrets(query);
+
+  for (const key of HEADLINE_KEYS) {
+    const value = stringField(args, key);
+    if (value) return redactSecrets(value);
+  }
+
+  // Last resort: short key:value lines (still not JSON braces).
+  const lines = formatAsKeyValueLines(args);
+  return lines.length > 0 ? lines : undefined;
 }
 
-export interface BuiltinJsonPreview {
-  /** Preferred first line when the result already embeds the subject (e.g. write path). */
+export interface QuietPreview {
   headline?: string;
   body: string;
 }
 
 /**
- * Turn built-in tool JSON results into plain text for the quiet panel.
- * Returns undefined when the shape is not a known builtin result — caller
- * falls back to generic JSON preview.
+ * Format any tool JSON/result payload for the quiet panel.
+ * Always returns a body — never `undefined` for object values so callers
+ * cannot fall back to `JSON.stringify`.
  */
-export function formatBuiltinJsonResult(
-  toolName: string,
-  value: unknown,
-): BuiltinJsonPreview | undefined {
+export function formatQuietJsonValue(value: unknown): QuietPreview {
+  if (value === null || value === undefined) {
+    return { body: '（空）' };
+  }
+  if (typeof value === 'string') {
+    return { body: redactSecrets(value) || '（空）' };
+  }
+  if (typeof value === 'number' || typeof value === 'boolean') {
+    return { body: String(value) };
+  }
+  if (Array.isArray(value)) {
+    return { body: formatArrayAsBody(value) };
+  }
+
   const record = asRecord(value);
-  if (!record) return undefined;
-
-  if (toolName === 'Read') {
-    const content = stringField(record, 'content');
-    if (content === undefined) return undefined;
-    return { body: redactSecrets(content) };
+  if (!record) {
+    return { body: redactSecrets(String(value)) };
   }
 
-  if (toolName === 'Grep') {
-    const matches = record.matches;
-    if (!Array.isArray(matches)) return undefined;
-    const lines = matches
-      .filter((line): line is string => typeof line === 'string')
-      .map((line) => redactSecrets(line));
-    return {
-      body: lines.length > 0 ? lines.join('\n') : '（无匹配）',
-    };
+  // Known list payloads (Grep/Glob/load_tools/…).
+  for (const key of LIST_KEYS) {
+    if (!Array.isArray(record[key])) continue;
+    const body = formatArrayAsBody(record[key] as unknown[]);
+    const headline = pickHeadline(record, new Set<string>([key]));
+    return headline ? { headline, body } : { body };
   }
 
-  if (toolName === 'Glob') {
-    const files = record.files;
-    if (!Array.isArray(files)) return undefined;
-    const lines = files
-      .filter((line): line is string => typeof line === 'string')
-      .map((line) => redactSecrets(line));
-    return {
-      body: lines.length > 0 ? lines.join('\n') : '（无匹配文件）',
-    };
+  // Dominant text payload (Read content, messages, …).
+  for (const key of BODY_KEYS) {
+    if (typeof record[key] !== 'string') continue;
+    const body = redactSecrets(record[key] as string);
+    // Prefer path/title from sibling fields as headline; do not restate the body key.
+    const headline = pickHeadline(record, new Set<string>([key]));
+    return headline ? { headline, body } : { body };
   }
 
-  if (toolName === 'Write') {
-    const path = stringField(record, 'path');
+  // Write / Edit style { ok, path, bytes, … }.
+  const path = stringField(record, 'path');
+  if (path && (record.ok === true || numberField(record, 'bytes') !== undefined || numberField(record, 'replacements') !== undefined)) {
     const bytes = numberField(record, 'bytes');
-    if (!path) return undefined;
-    const size = bytes !== undefined ? ` · ${bytes} B` : '';
-    return {
-      headline: redactSecrets(path),
-      body: `已写入${size}`,
-    };
-  }
-
-  if (toolName === 'Edit') {
-    const path = stringField(record, 'path');
     const replacements = numberField(record, 'replacements');
     const startLine = numberField(record, 'startLine');
     const endLine = numberField(record, 'endLine');
-    if (!path) return undefined;
-    const range =
-      startLine !== undefined && endLine !== undefined
-        ? ` · L${startLine}–${endLine}`
-        : '';
-    const count = replacements !== undefined ? ` · ${replacements} 处` : '';
+    const parts: string[] = [];
+    if (record.ok === true) parts.push('已完成');
+    if (record.ok === false) parts.push('未完成');
+    if (bytes !== undefined) parts.push(`${bytes} B`);
+    if (replacements !== undefined) parts.push(`${replacements} 处`);
+    if (startLine !== undefined && endLine !== undefined) parts.push(`L${startLine}–${endLine}`);
     return {
       headline: redactSecrets(path),
-      body: `已替换${count}${range}`,
+      body: parts.length > 0 ? parts.join(' · ') : '已写入',
     };
   }
 
+  return { body: formatAsKeyValueLines(record) || '（空）' };
+}
+
+/** @deprecated Use formatQuietJsonValue — kept name for call-site clarity with toolName. */
+export function formatBuiltinJsonResult(_toolName: string, value: unknown): QuietPreview {
+  return formatQuietJsonValue(value);
+}
+
+function pickHeadline(
+  record: Record<string, unknown>,
+  skip: ReadonlySet<string>,
+): string | undefined {
+  for (const key of HEADLINE_KEYS) {
+    if (skip.has(key)) continue;
+    const value = stringField(record, key);
+    if (value) return redactSecrets(value);
+  }
   return undefined;
+}
+
+function formatArrayAsBody(values: unknown[]): string {
+  if (values.length === 0) return '（空）';
+  if (values.every((item) => typeof item === 'string')) {
+    return redactSecrets((values as string[]).join('\n'));
+  }
+  return values
+    .map((item) => {
+      if (typeof item === 'string') return redactSecrets(item);
+      if (item && typeof item === 'object' && !Array.isArray(item)) {
+        return formatAsKeyValueLines(item as Record<string, unknown>);
+      }
+      return redactSecrets(String(item));
+    })
+    .filter((line) => line.length > 0)
+    .join('\n');
+}
+
+/**
+ * Plain `key: value` lines — never JSON braces or escaped `\n` sequences.
+ */
+export function formatAsKeyValueLines(record: Record<string, unknown>, depth = 0): string {
+  if (depth > 3) return redactSecrets(String(record));
+  const indent = '  '.repeat(depth);
+  const lines: string[] = [];
+  for (const [key, raw] of Object.entries(record)) {
+    if (raw === undefined) continue;
+    if (raw === null) {
+      lines.push(`${indent}${key}: null`);
+      continue;
+    }
+    if (typeof raw === 'string') {
+      // Multi-line strings get a block, not a quoted escape soup.
+      if (raw.includes('\n')) {
+        lines.push(`${indent}${key}:`);
+        for (const line of redactSecrets(raw).split('\n')) {
+          lines.push(`${indent}  ${line}`);
+        }
+      } else {
+        lines.push(`${indent}${key}: ${redactSecrets(raw)}`);
+      }
+      continue;
+    }
+    if (typeof raw === 'number' || typeof raw === 'boolean') {
+      lines.push(`${indent}${key}: ${raw}`);
+      continue;
+    }
+    if (Array.isArray(raw)) {
+      if (raw.length === 0) {
+        lines.push(`${indent}${key}: （空）`);
+      } else if (raw.every((item) => typeof item === 'string' || typeof item === 'number' || typeof item === 'boolean')) {
+        lines.push(`${indent}${key}:`);
+        for (const item of raw) {
+          lines.push(`${indent}  - ${typeof item === 'string' ? redactSecrets(item) : String(item)}`);
+        }
+      } else {
+        lines.push(`${indent}${key}:`);
+        lines.push(formatArrayAsBody(raw).split('\n').map((line) => `${indent}  ${line}`).join('\n'));
+      }
+      continue;
+    }
+    if (typeof raw === 'object') {
+      lines.push(`${indent}${key}:`);
+      const nested = formatAsKeyValueLines(raw as Record<string, unknown>, depth + 1);
+      if (nested) lines.push(nested);
+      continue;
+    }
+    lines.push(`${indent}${key}: ${redactSecrets(String(raw))}`);
+  }
+  return lines.join('\n');
 }

--- a/packages/ui/src/tool-activity/presentation.ts
+++ b/packages/ui/src/tool-activity/presentation.ts
@@ -43,7 +43,9 @@ export function syncToolDisclosureState(
   current: ToolDisclosureState,
   presentation: ToolActivityPresentation,
 ): ToolDisclosureState {
-  if (presentation.needsAttention) return createToolDisclosureState(presentation);
+  if (presentation.needsAttention) {
+    return current.open ? current : createToolDisclosureState(presentation);
+  }
   if (current.manuallySet) return current;
   return createToolDisclosureState(presentation);
 }

--- a/packages/ui/src/tool-activity/presentation.ts
+++ b/packages/ui/src/tool-activity/presentation.ts
@@ -29,7 +29,7 @@ export function resolveToolDisplayName(item: ToolActivityItem): string {
 
 export function deriveToolActivityPresentation(item: ToolActivityItem): ToolActivityPresentation {
   return {
-    kind: trowActivityKind(item.toolName),
+    kind: trowActivityKind(item.toolName, item.activityKind),
     summary: formatUserVisibleToolText(item.intent ?? '') || resolveToolDisplayName(item),
     needsAttention: item.status === 'waiting_permission' || item.status === 'errored',
   };

--- a/packages/ui/src/tool-activity/presentation.ts
+++ b/packages/ui/src/tool-activity/presentation.ts
@@ -1,0 +1,56 @@
+import { detectUiLocale } from '../locale-helpers.js';
+import type { ToolActivityItem } from '../materialize.js';
+import { loadToolDisplayName } from '../tool-format.js';
+import { formatUserVisibleToolText } from './preview-utils.js';
+import { trowActivityKind, type TrowActivityKind } from './trow-summary.js';
+
+export interface ToolActivityPresentation {
+  kind: TrowActivityKind;
+  summary: string;
+  needsAttention: boolean;
+}
+
+export interface ToolDisclosureState {
+  open: boolean;
+  manuallySet: boolean;
+}
+
+const CONNECTOR_TOOL_NAMES: ReadonlySet<string> = new Set(['load_tools', 'load_tool']);
+
+export function isConnectorTool(name: string): boolean {
+  return CONNECTOR_TOOL_NAMES.has(name);
+}
+
+export function resolveToolDisplayName(item: ToolActivityItem): string {
+  if (item.displayName) return item.displayName;
+  if (isConnectorTool(item.toolName)) return loadToolDisplayName(detectUiLocale());
+  return item.toolName;
+}
+
+export function deriveToolActivityPresentation(item: ToolActivityItem): ToolActivityPresentation {
+  return {
+    kind: trowActivityKind(item.toolName),
+    summary: formatUserVisibleToolText(item.intent ?? '') || resolveToolDisplayName(item),
+    needsAttention: item.status === 'waiting_permission' || item.status === 'errored',
+  };
+}
+
+export function createToolDisclosureState(presentation: ToolActivityPresentation): ToolDisclosureState {
+  return { open: presentation.needsAttention, manuallySet: false };
+}
+
+export function syncToolDisclosureState(
+  current: ToolDisclosureState,
+  presentation: ToolActivityPresentation,
+): ToolDisclosureState {
+  if (presentation.needsAttention) return createToolDisclosureState(presentation);
+  if (current.manuallySet) return current;
+  return createToolDisclosureState(presentation);
+}
+
+export function setToolDisclosureOpen(
+  current: ToolDisclosureState,
+  open: boolean,
+): ToolDisclosureState {
+  return { ...current, open, manuallySet: true };
+}

--- a/packages/ui/src/tool-activity/tool-command.ts
+++ b/packages/ui/src/tool-activity/tool-command.ts
@@ -1,0 +1,11 @@
+/**
+ * Pull the shell command string out of a command-tool's args (bash / shell).
+ * Returns undefined for a non-command shape so callers fall back to path /
+ * pattern presentation or redacted JSON.
+ */
+export function extractToolCommand(args: unknown): string | undefined {
+  if (!args || typeof args !== 'object') return undefined;
+  const record = args as Record<string, unknown>;
+  const raw = record.command ?? record.cmd ?? record.script;
+  return typeof raw === 'string' && raw.trim().length > 0 ? raw : undefined;
+}

--- a/packages/ui/src/tool-activity/tool-result-preview.tsx
+++ b/packages/ui/src/tool-activity/tool-result-preview.tsx
@@ -183,8 +183,9 @@ function TerminalPreview(props: {
   stdoutTruncated?: boolean;
   stderrTruncated?: boolean;
 }) {
-  const succeeded = props.exitCode === 0 && !isCancelledStatus(props.status);
   const cancelled = isCancelledStatus(props.status);
+  const timedOut = props.status === 'timed_out';
+  const succeeded = props.exitCode === 0 && !cancelled && !timedOut;
   const hasOutput = props.stdout.length > 0 || props.stderr.length > 0;
   // Redact + cap stdout/stderr independently. `npm test` against a misconfigured
   // provider can dump megabytes of stderr; we keep the first TOOL_LINE_CAP
@@ -196,7 +197,7 @@ function TerminalPreview(props: {
   const safeCmd = redactSecrets(props.cmd);
   const hiddenLines = stdout.capped + stderr.capped;
   const runtimeTruncated = props.stdoutTruncated === true || props.stderrTruncated === true;
-  const attention = !succeeded || cancelled;
+  const attention = !succeeded || cancelled || timedOut;
 
   return (
     <div
@@ -230,7 +231,12 @@ function TerminalPreview(props: {
           已取消 · 退出码 {props.exitCode}
         </p>
       )}
-      {!succeeded && !cancelled && (
+      {timedOut && !cancelled && (
+        <p className={cn(TOOL_OUTPUT_NOTE_CLASS, 'text-[color:var(--destructive)]')}>
+          已超时 · 退出码 {props.exitCode}
+        </p>
+      )}
+      {!succeeded && !cancelled && !timedOut && (
         <p className={cn(TOOL_OUTPUT_NOTE_CLASS, 'text-[color:var(--destructive)]')}>
           失败 · 退出码 {props.exitCode}
         </p>
@@ -313,8 +319,7 @@ function ShellRunPreview(props: {
 }
 
 function isCancelledStatus(status: string | undefined): boolean {
-  if (!status) return false;
-  return status === 'cancelled' || status === 'canceled' || status === 'canceled_partial' || status === 'interrupted';
+  return status === 'cancelled';
 }
 
 function shellRunStatusLabel(status: string): string {

--- a/packages/ui/src/tool-activity/tool-result-preview.tsx
+++ b/packages/ui/src/tool-activity/tool-result-preview.tsx
@@ -1,11 +1,26 @@
 import { normalizeSearchUrl, type ToolResultContent } from '@maka/core';
-import { Check, Copy } from '../icons.js';
-import { useClipboardCopyFeedback } from '../clipboard-feedback.js';
 import { previewVariants } from '../primitives/chat.js';
 import { redactSecrets } from '../redact.js';
-import { Button as UiButton, cn } from '../ui.js';
+import { cn } from '../ui.js';
 import { ExploreAgentPreview, SubagentPreview } from './agent-preview.js';
 import { TOOL_LINE_CAP, capLines, formatUserVisibleToolText } from './preview-utils.js';
+
+/**
+ * Shared Codex-like tool output well — one surface for live and settled
+ * mono/command output. Tokens only: foreground-3 + border + radius-surface.
+ * Body type uses font-size-base (13px), not caption.
+ */
+export const TOOL_OUTPUT_PANEL_CLASS =
+  'mt-1 grid gap-2 rounded-[var(--radius-surface)] border border-[var(--border)] bg-[var(--foreground-3)] px-3 py-2.5';
+
+export const TOOL_OUTPUT_COMMAND_CLASS =
+  'block min-w-0 [font-family:var(--font-mono)] [font-variant-ligatures:none] text-[length:var(--font-size-base)] leading-normal text-[color:var(--foreground)] [white-space:pre-wrap] [word-break:break-word]';
+
+export const TOOL_OUTPUT_BODY_CLASS =
+  'm-0 max-h-64 overflow-y-auto whitespace-pre-wrap [word-break:break-word] [font-family:var(--font-mono)] [font-variant-ligatures:none] text-[length:var(--font-size-base)] leading-normal text-[color:var(--muted-foreground)] [scroll-behavior:auto]';
+
+export const TOOL_OUTPUT_NOTE_CLASS =
+  'm-0 text-[length:var(--font-size-base)] leading-normal text-[color:var(--muted-foreground)]';
 
 /** Routes persisted tool results to bounded, kind-specific preview cards. */
 export function ToolResultPreview(props: { content: ToolResultContent }) {
@@ -71,13 +86,14 @@ export function ToolResultPreview(props: { content: ToolResultContent }) {
     // JSON shouldn't contain secrets persisted by Maka (settings + telemetry
     // are sanitized at write-time), but apply the renderer redactor as a
     // second-layer defense in case a tool returned raw provider response.
-    return <pre className={previewVariants({ part: 'overlay' })} data-kind="json">{formatUserVisibleToolText(redactSecrets(body))}</pre>;
+    // Body-only: parent ToolCardBody owns the quiet panel shell.
+    return <pre className={TOOL_OUTPUT_BODY_CLASS} data-kind="json">{formatUserVisibleToolText(redactSecrets(body))}</pre>;
   }
 
   if (content.kind === 'text') {
     const { body, capped } = capLines(formatUserVisibleToolText(redactSecrets(content.text)));
     return (
-      <pre className={previewVariants({ part: 'overlay' })} data-kind="text">
+      <pre className={TOOL_OUTPUT_BODY_CLASS} data-kind="text">
         {body}
         {capped > 0 && `\n\n… 已隐藏 ${capped} 行`}
       </pre>
@@ -87,7 +103,7 @@ export function ToolResultPreview(props: { content: ToolResultContent }) {
   // file_write / image / summary / unknown — show a compact descriptor so the
   // user knows what kind landed without dumping binary or storage refs.
   return (
-    <pre className={previewVariants({ part: 'overlay' })} data-kind={content.kind}>
+    <pre className={TOOL_OUTPUT_BODY_CLASS} data-kind={content.kind}>
       [{content.kind}]
     </pre>
   );
@@ -106,16 +122,18 @@ function FileDiffPreview(props: { diff: string; paths: string[] }) {
   // 10k-line diff create 10k React elements.
   const { body, capped } = capLines(redactSecrets(props.diff));
   const lines = body.split('\n');
+  // Structure kept (paths + colored lines); no second card chrome — parent panel
+  // is the only surface when embedded in a tool row.
   return (
-    <div className={cn(previewVariants({ part: 'overlay' }), previewVariants({ part: 'diff' }))} data-kind="file_diff">
+    <div className="grid gap-1.5" data-kind="file_diff">
       {props.paths.length > 0 && (
-        <div className={previewVariants({ part: 'diff-paths' })}>
+        <div className="flex flex-wrap gap-1.5 [font-family:var(--font-mono)] text-[length:var(--font-size-base)] text-[color:var(--muted-foreground)]">
           {props.paths.map((path) => (
-            <code key={path}>{path}</code>
+            <code key={path} className="bg-transparent text-[color:var(--foreground-secondary)]">{path}</code>
           ))}
         </div>
       )}
-      <pre className={previewVariants({ part: 'diff-body' })}>
+      <pre className={cn(TOOL_OUTPUT_BODY_CLASS, '[white-space:pre] [word-break:normal]')}>
         {lines.map((line, index) => (
           <span
             key={`${index}:${line.slice(0, 16)}`}
@@ -145,11 +163,9 @@ function diffLineKind(line: string): 'add' | 'del' | 'hunk' | 'meta' | 'ctx' {
 }
 
 /**
- * Terminal output preview. Shows the command + working directory header,
- * an exit-code badge tinted by success/failure, then stdout and stderr
- * in separate blocks (stderr only rendered when non-empty, in destructive
- * tone). Empty output gets an explicit "(no output)" placeholder so a
- * silent successful command doesn't look like a render bug.
+ * Terminal output preview — quiet single well: command (no $) + stdout/stderr.
+ * No cwd bar, no exit-code badge chrome, no copy control. Failure and
+ * truncation are one-line notes. Empty output keeps an explicit placeholder.
  */
 function TerminalPreview(props: {
   cwd: string;
@@ -158,7 +174,6 @@ function TerminalPreview(props: {
   stdout: string;
   stderr: string;
 }) {
-  const copyFeedback = useClipboardCopyFeedback();
   const succeeded = props.exitCode === 0;
   const hasOutput = props.stdout.length > 0 || props.stderr.length > 0;
   // Redact + cap stdout/stderr independently. `npm test` against a misconfigured
@@ -169,83 +184,46 @@ function TerminalPreview(props: {
   // The cmd line is also user-runtime text — don't echo a `--api-key=...`
   // arg into the chat without masking it.
   const safeCmd = redactSecrets(props.cmd);
-  const safeCwd = redactSecrets(props.cwd);
   const hiddenLines = stdout.capped + stderr.capped;
-  const handoffText = [
-    '终端输出需要继续研读',
-    `工作目录：${safeCwd}`,
-    `命令：${safeCmd}`,
-    `退出码：${props.exitCode}`,
-    `截断：stdout 已隐藏 ${stdout.capped} 行，stderr 已隐藏 ${stderr.capped} 行`,
-    stdout.body.length > 0 ? `stdout 预览：\n${stdout.body}` : '',
-    stderr.body.length > 0 ? `stderr 预览：\n${stderr.body}` : '',
-    '请在深度研究 / 只读探索里结合相关路径确认完整输出影响和下一步。',
-  ].filter((line) => line.length > 0).join('\n\n');
 
-  const handoffCopyPhase = copyFeedback.phaseFor('handoff');
-  const handoffCopyLabel = handoffCopyPhase === 'pending'
-    ? '复制中…'
-    : handoffCopyPhase === 'copied'
-      ? '已复制'
-      : handoffCopyPhase === 'failed'
-        ? '复制失败'
-        : '复制研读提示';
-  const handoffCopyAria = handoffCopyPhase === 'pending'
-    ? '复制终端研读提示中'
-    : handoffCopyPhase === 'copied'
-      ? '已复制终端研读提示'
-      : handoffCopyPhase === 'failed'
-        ? '复制终端研读提示失败'
-        : '复制终端研读提示';
-
+  // Codex-like single well: command (no $) + body. No cwd / exit badge chrome,
+  // no always-on copy control. Failure and truncation are one quiet note each.
   return (
-    <div className={cn(previewVariants({ part: 'overlay' }), previewVariants({ part: 'terminal' }))} data-kind="terminal">
-      <header className={previewVariants({ part: 'terminal-head' })}>
-        <code className={previewVariants({ part: 'terminal-cwd' })}>{safeCwd}</code>
-        <code className={previewVariants({ part: 'terminal-cmd' })}>$ {safeCmd}</code>
-        <span
-          className={previewVariants({ part: 'terminal-exit' })}
-          data-ok={succeeded ? 'true' : 'false'}
-          aria-label={`退出码 ${props.exitCode}`}
-        >
-          退出码 {props.exitCode}
-        </span>
-      </header>
-      {!hasOutput && <p className={previewVariants({ part: 'terminal-empty' })}>（无输出）</p>}
+    <div
+      data-slot="tool-output"
+      data-kind="terminal"
+      className={cn(TOOL_OUTPUT_PANEL_CLASS, !succeeded && 'border-[oklch(from_var(--destructive)_l_c_h_/_0.28)]')}
+    >
+      {safeCmd.length > 0 && (
+        <code className={TOOL_OUTPUT_COMMAND_CLASS}>{safeCmd}</code>
+      )}
+      {!hasOutput && (
+        <p className={TOOL_OUTPUT_NOTE_CLASS}>（无输出）</p>
+      )}
       {props.stdout.length > 0 && (
-        <pre className={previewVariants({ part: 'terminal-stream' })} data-stream="stdout">
+        <pre className={TOOL_OUTPUT_BODY_CLASS} data-stream="stdout">
           {stdout.body}
           {stdout.capped > 0 && `\n\n… stdout 已隐藏 ${stdout.capped} 行`}
         </pre>
       )}
       {props.stderr.length > 0 && (
-        <pre className={previewVariants({ part: 'terminal-stream' })} data-stream="stderr">
+        <pre
+          className={cn(TOOL_OUTPUT_BODY_CLASS, 'text-[color:var(--destructive)]')}
+          data-stream="stderr"
+        >
           {stderr.body}
           {stderr.capped > 0 && `\n\n… stderr 已隐藏 ${stderr.capped} 行`}
         </pre>
       )}
+      {!succeeded && (
+        <p className={cn(TOOL_OUTPUT_NOTE_CLASS, 'text-[color:var(--destructive)]')}>
+          失败 · 退出码 {props.exitCode}
+        </p>
+      )}
       {hiddenLines > 0 && (
-        <div className={previewVariants({ part: 'terminal-truncated-note' })}>
-          <span>
-            输出较长，当前只展示每路输出的前 {TOOL_LINE_CAP} 行。需要继续研读时，可以切到深度研究并把命令、相关路径和想确认的问题交给只读探索。
-          </span>
-          <UiButton
-            type="button"
-            variant="ghost"
-            size="sm"
-            className={previewVariants({ part: 'terminal-copy' })}
-            onClick={() => void copyFeedback.copy('handoff', handoffText)}
-            disabled={handoffCopyPhase === 'pending'}
-            aria-label={handoffCopyAria}
-            aria-busy={handoffCopyPhase === 'pending' ? 'true' : undefined}
-            data-pending={handoffCopyPhase === 'pending' ? 'true' : undefined}
-            data-copied={handoffCopyPhase === 'copied' ? 'true' : 'false'}
-            data-copy-error={handoffCopyPhase === 'failed' ? 'true' : undefined}
-          >
-            {handoffCopyPhase === 'copied' ? <Check size={13} aria-hidden="true" /> : <Copy size={13} aria-hidden="true" />}
-            <span>{handoffCopyLabel}</span>
-          </UiButton>
-        </div>
+        <p className={TOOL_OUTPUT_NOTE_CLASS}>
+          输出已截断 · 每路仅展示前 {TOOL_LINE_CAP} 行
+        </p>
       )}
     </div>
   );
@@ -265,31 +243,31 @@ function OfficeDocumentPreview(props: {
   const hasOutput = stdout.body.length > 0 || stderr.body.length > 0;
 
   return (
-    <div className={cn(previewVariants({ part: 'overlay' }), previewVariants({ part: 'office' }))} data-kind="office_document" data-ok={result.ok ? 'true' : 'false'}>
-      <header className={previewVariants({ part: 'office-head' })}>
-        <strong>{title}</strong>
-        <small>
+    <div className="grid gap-1.5" data-kind="office_document" data-ok={result.ok ? 'true' : 'false'}>
+      <header className="grid gap-0.5">
+        <strong className="text-[length:var(--font-size-base)] text-[color:var(--foreground)]">{title}</strong>
+        <small className="text-[length:var(--font-size-base)] text-[color:var(--muted-foreground)]">
           {operation}
           {result.ok ? ' · 已完成' : ' · 未完成'}
           {result.truncated ? ' · 输出已截断' : ''}
         </small>
       </header>
-      {args && <code className={previewVariants({ part: 'office-args' })}>officecli {args}</code>}
+      {args && <code className={TOOL_OUTPUT_COMMAND_CLASS}>officecli {args}</code>}
       {!result.ok && (
-        <div className={previewVariants({ part: 'office-message' })} role="note">
+        <div className="grid gap-0.5 text-[length:var(--font-size-base)] text-[color:var(--destructive)]" role="note">
           <span>{message || 'Office 文档操作未完成。'}</span>
-          {reason && <small>诊断：{reason}</small>}
+          {reason && <small className="text-[color:var(--muted-foreground)]">诊断：{reason}</small>}
         </div>
       )}
-      {result.ok && !hasOutput && <p className={previewVariants({ part: 'office-empty' })}>（无输出）</p>}
+      {result.ok && !hasOutput && <p className={TOOL_OUTPUT_NOTE_CLASS}>（无输出）</p>}
       {stdout.body.length > 0 && (
-        <pre className={previewVariants({ part: 'office-stream' })} data-stream="stdout">
+        <pre className={TOOL_OUTPUT_BODY_CLASS} data-stream="stdout">
           {stdout.body}
           {stdout.capped > 0 && `\n\n… stdout 已隐藏 ${stdout.capped} 行`}
         </pre>
       )}
       {stderr.body.length > 0 && (
-        <pre className={previewVariants({ part: 'office-stream' })} data-stream="stderr">
+        <pre className={cn(TOOL_OUTPUT_BODY_CLASS, 'text-[color:var(--destructive)]')} data-stream="stderr">
           {stderr.body}
           {stderr.capped > 0 && `\n\n… stderr 已隐藏 ${stderr.capped} 行`}
         </pre>
@@ -372,7 +350,7 @@ function RiveWorkflowPreview(props: {
   ].join('\n');
   const cappedPreview = capLines(redactSecrets(body));
   return (
-    <pre className={previewVariants({ part: 'overlay' })} data-kind="rive_workflow">
+    <pre className={TOOL_OUTPUT_BODY_CLASS} data-kind="rive_workflow">
       {cappedPreview.body}
       {cappedPreview.capped > 0 && `\n\n… 已隐藏 ${cappedPreview.capped} 行`}
     </pre>
@@ -412,30 +390,35 @@ function WebSearchPreview(props: {
 
   if (rows.length === 0) {
     return (
-      <div className={cn(previewVariants({ part: 'overlay' }), previewVariants({ part: 'web-search' }))} data-kind="web_search">
-        <header>
-          <strong>{redactSecrets(props.query)}</strong>
-          <small>{props.provider} · 没有结果</small>
+      <div className="grid gap-1.5 [font-family:var(--font-sans)]" data-kind="web_search">
+        <header className="grid gap-0.5">
+          <strong className="text-[length:var(--font-size-base)] text-[color:var(--foreground)]">{redactSecrets(props.query)}</strong>
+          <small className="text-[length:var(--font-size-base)] text-[color:var(--muted-foreground)]">{props.provider} · 没有结果</small>
         </header>
       </div>
     );
   }
   return (
-    <div className={cn(previewVariants({ part: 'overlay' }), previewVariants({ part: 'web-search' }))} data-kind="web_search">
-      <header>
-        <strong>{redactSecrets(props.query)}</strong>
-        <small>
+    <div className="grid gap-2 [font-family:var(--font-sans)]" data-kind="web_search">
+      <header className="grid gap-0.5">
+        <strong className="text-[length:var(--font-size-base)] text-[color:var(--foreground)]">{redactSecrets(props.query)}</strong>
+        <small className="text-[length:var(--font-size-base)] text-[color:var(--muted-foreground)]">
           {props.provider} · {rows.length} 条结果
         </small>
       </header>
-      <ul>
+      <ul className="m-0 grid list-none gap-2 p-0">
         {rows.map((row, idx) => (
-          <li key={`${row.url}-${idx}`}>
-            <a href={row.url} target="_blank" rel="noreferrer noopener">
+          <li key={`${row.url}-${idx}`} className="grid gap-0.5">
+            <a
+              href={row.url}
+              target="_blank"
+              rel="noreferrer noopener"
+              className="text-[length:var(--font-size-base)] font-medium text-[color:var(--link)]"
+            >
               {redactSecrets(row.title)}
             </a>
-            <small>{redactSecrets(row.source)}</small>
-            <p>{redactSecrets(row.snippet)}</p>
+            <small className="text-[length:var(--font-size-base)] text-[color:var(--muted-foreground)]">{redactSecrets(row.source)}</small>
+            <p className="m-0 text-[length:var(--font-size-base)] leading-snug text-[color:var(--foreground-secondary)]">{redactSecrets(row.snippet)}</p>
           </li>
         ))}
       </ul>
@@ -473,13 +456,13 @@ function WebSearchErrorPreview(props: {
                 ? '隐私模式下不会发起联网搜索。'
                 : '请检查网络或稍后重试。';
   return (
-    <div className={cn(previewVariants({ part: 'overlay' }), previewVariants({ part: 'web-search' }), previewVariants({ part: 'web-search-error' }))} data-kind="web_search_error">
-      <header>
-        <strong>{redactSecrets(props.query ?? '联网搜索')}</strong>
-        <small>{redactSecrets(props.provider)} · 搜索失败 · {sourceCopy}</small>
+    <div className="grid gap-1.5 [font-family:var(--font-sans)]" data-kind="web_search_error">
+      <header className="grid gap-0.5">
+        <strong className="text-[length:var(--font-size-base)] text-[color:var(--foreground)]">{redactSecrets(props.query ?? '联网搜索')}</strong>
+        <small className="text-[length:var(--font-size-base)] text-[color:var(--muted-foreground)]">{redactSecrets(props.provider)} · 搜索失败 · {sourceCopy}</small>
       </header>
-      <p className={previewVariants({ part: 'web-search-error-message' })}>{redactSecrets(props.message)}</p>
-      <p className={previewVariants({ part: 'web-search-error-repair' })}>{repairCopy}</p>
+      <p className="m-0 text-[length:var(--font-size-base)] text-[color:var(--destructive)]">{redactSecrets(props.message)}</p>
+      <p className="m-0 text-[length:var(--font-size-base)] text-[color:var(--muted-foreground)]">{repairCopy}</p>
     </div>
   );
 }

--- a/packages/ui/src/tool-activity/tool-result-preview.tsx
+++ b/packages/ui/src/tool-activity/tool-result-preview.tsx
@@ -57,8 +57,15 @@ export function ToolResultPreview(props: { content: ToolResultContent }) {
         exitCode={content.exitCode}
         stdout={content.stdout}
         stderr={content.stderr}
+        status={content.status}
+        stdoutTruncated={content.stdoutTruncated}
+        stderrTruncated={content.stderrTruncated}
       />
     );
+  }
+
+  if (content.kind === 'shell_run') {
+    return <ShellRunPreview result={content} />;
   }
 
   if (content.kind === 'office_document') {
@@ -164,8 +171,7 @@ function diffLineKind(line: string): 'add' | 'del' | 'hunk' | 'meta' | 'ctx' {
 
 /**
  * Terminal output preview — quiet single well: command (no $) + stdout/stderr.
- * No cwd bar, no exit-code badge chrome, no copy control. Failure and
- * truncation are one-line notes. Empty output keeps an explicit placeholder.
+ * Honors runtime `status` and stream truncated flags (not only UI line caps).
  */
 function TerminalPreview(props: {
   cwd: string;
@@ -173,8 +179,12 @@ function TerminalPreview(props: {
   exitCode: number;
   stdout: string;
   stderr: string;
+  status?: string;
+  stdoutTruncated?: boolean;
+  stderrTruncated?: boolean;
 }) {
-  const succeeded = props.exitCode === 0;
+  const succeeded = props.exitCode === 0 && !isCancelledStatus(props.status);
+  const cancelled = isCancelledStatus(props.status);
   const hasOutput = props.stdout.length > 0 || props.stderr.length > 0;
   // Redact + cap stdout/stderr independently. `npm test` against a misconfigured
   // provider can dump megabytes of stderr; we keep the first TOOL_LINE_CAP
@@ -185,14 +195,14 @@ function TerminalPreview(props: {
   // arg into the chat without masking it.
   const safeCmd = redactSecrets(props.cmd);
   const hiddenLines = stdout.capped + stderr.capped;
+  const runtimeTruncated = props.stdoutTruncated === true || props.stderrTruncated === true;
+  const attention = !succeeded || cancelled;
 
-  // Codex-like single well: command (no $) + body. No cwd / exit badge chrome,
-  // no always-on copy control. Failure and truncation are one quiet note each.
   return (
     <div
       data-slot="tool-output"
       data-kind="terminal"
-      className={cn(TOOL_OUTPUT_PANEL_CLASS, !succeeded && 'border-[oklch(from_var(--destructive)_l_c_h_/_0.28)]')}
+      className={cn(TOOL_OUTPUT_PANEL_CLASS, attention && 'border-[oklch(from_var(--destructive)_l_c_h_/_0.28)]')}
     >
       {safeCmd.length > 0 && (
         <code className={TOOL_OUTPUT_COMMAND_CLASS}>{safeCmd}</code>
@@ -215,18 +225,115 @@ function TerminalPreview(props: {
           {stderr.capped > 0 && `\n\n… stderr 已隐藏 ${stderr.capped} 行`}
         </pre>
       )}
-      {!succeeded && (
+      {cancelled && (
+        <p className={cn(TOOL_OUTPUT_NOTE_CLASS, 'text-[color:var(--destructive)]')}>
+          已取消 · 退出码 {props.exitCode}
+        </p>
+      )}
+      {!succeeded && !cancelled && (
         <p className={cn(TOOL_OUTPUT_NOTE_CLASS, 'text-[color:var(--destructive)]')}>
           失败 · 退出码 {props.exitCode}
         </p>
       )}
-      {hiddenLines > 0 && (
+      {(runtimeTruncated || hiddenLines > 0) && (
         <p className={TOOL_OUTPUT_NOTE_CLASS}>
-          输出已截断 · 每路仅展示前 {TOOL_LINE_CAP} 行
+          {hiddenLines > 0
+            ? `输出已截断 · 每路仅展示前 ${TOOL_LINE_CAP} 行`
+            : '输出已截断'}
         </p>
       )}
     </div>
   );
+}
+
+/**
+ * Background shell-run result (desktop Bash after yield). Keep cmd, status,
+ * ref, and any captured streams — never collapse to `[shell_run]`.
+ */
+function ShellRunPreview(props: {
+  result: Extract<ToolResultContent, { kind: 'shell_run' }>;
+}) {
+  const { result } = props;
+  const safeCmd = redactSecrets(result.cmd);
+  const safeRef = redactSecrets(result.ref);
+  const stdout = capLines(redactSecrets(result.stdout ?? ''));
+  const stderr = capLines(redactSecrets(result.stderr ?? ''));
+  const hasOutput = (result.stdout?.length ?? 0) > 0 || (result.stderr?.length ?? 0) > 0;
+  const runtimeTruncated = result.stdoutTruncated === true || result.stderrTruncated === true;
+  const hiddenLines = stdout.capped + stderr.capped;
+  const statusLabel = shellRunStatusLabel(result.status);
+  const attention = result.status === 'failed' || result.status === 'orphaned' || (result.exitCode !== undefined && result.exitCode !== 0);
+
+  return (
+    <div
+      data-slot="tool-output"
+      data-kind="shell_run"
+      className={cn(TOOL_OUTPUT_PANEL_CLASS, attention && 'border-[oklch(from_var(--destructive)_l_c_h_/_0.28)]')}
+    >
+      {safeCmd.length > 0 && (
+        <code className={TOOL_OUTPUT_COMMAND_CLASS}>{safeCmd}</code>
+      )}
+      <p className={TOOL_OUTPUT_NOTE_CLASS}>
+        {statusLabel}
+        {result.exitCode !== undefined ? ` · 退出码 ${result.exitCode}` : ''}
+        {safeRef ? ` · ${safeRef}` : ''}
+      </p>
+      {result.failureMessage && (
+        <p className={cn(TOOL_OUTPUT_NOTE_CLASS, 'text-[color:var(--destructive)]')}>
+          {redactSecrets(result.failureMessage)}
+        </p>
+      )}
+      {!hasOutput && (
+        <p className={TOOL_OUTPUT_NOTE_CLASS}>（尚无输出）</p>
+      )}
+      {(result.stdout?.length ?? 0) > 0 && (
+        <pre className={TOOL_OUTPUT_BODY_CLASS} data-stream="stdout">
+          {stdout.body}
+          {stdout.capped > 0 && `\n\n… stdout 已隐藏 ${stdout.capped} 行`}
+        </pre>
+      )}
+      {(result.stderr?.length ?? 0) > 0 && (
+        <pre
+          className={cn(TOOL_OUTPUT_BODY_CLASS, 'text-[color:var(--destructive)]')}
+          data-stream="stderr"
+        >
+          {stderr.body}
+          {stderr.capped > 0 && `\n\n… stderr 已隐藏 ${stderr.capped} 行`}
+        </pre>
+      )}
+      {(runtimeTruncated || hiddenLines > 0) && (
+        <p className={TOOL_OUTPUT_NOTE_CLASS}>
+          {hiddenLines > 0
+            ? `输出已截断 · 每路仅展示前 ${TOOL_LINE_CAP} 行`
+            : '输出已截断'}
+        </p>
+      )}
+    </div>
+  );
+}
+
+function isCancelledStatus(status: string | undefined): boolean {
+  if (!status) return false;
+  return status === 'cancelled' || status === 'canceled' || status === 'canceled_partial' || status === 'interrupted';
+}
+
+function shellRunStatusLabel(status: string): string {
+  switch (status) {
+    case 'running':
+      return '后台运行中';
+    case 'completed':
+      return '后台已完成';
+    case 'failed':
+      return '后台失败';
+    case 'timed_out':
+      return '后台超时';
+    case 'cancelled':
+      return '后台已取消';
+    case 'orphaned':
+      return '后台任务已断开';
+    default:
+      return `后台 · ${status}`;
+  }
 }
 
 function OfficeDocumentPreview(props: {

--- a/packages/ui/src/tool-activity/tool-result-preview.tsx
+++ b/packages/ui/src/tool-activity/tool-result-preview.tsx
@@ -3,6 +3,7 @@ import { previewVariants } from '../primitives/chat.js';
 import { redactSecrets } from '../redact.js';
 import { cn } from '../ui.js';
 import { ExploreAgentPreview, SubagentPreview } from './agent-preview.js';
+import { formatQuietJsonValue } from './builtin-preview.js';
 import { TOOL_LINE_CAP, capLines, formatUserVisibleToolText } from './preview-utils.js';
 
 /**
@@ -77,17 +78,16 @@ export function ToolResultPreview(props: { content: ToolResultContent }) {
   }
 
   if (content.kind === 'json') {
-    let body: string;
-    try {
-      body = JSON.stringify(content.value, null, 2);
-    } catch {
-      body = String(content.value);
-    }
-    // JSON shouldn't contain secrets persisted by Maka (settings + telemetry
-    // are sanitized at write-time), but apply the renderer redactor as a
-    // second-layer defense in case a tool returned raw provider response.
-    // Body-only: parent ToolCardBody owns the quiet panel shell.
-    return <pre className={TOOL_OUTPUT_BODY_CLASS} data-kind="json">{formatUserVisibleToolText(redactSecrets(body))}</pre>;
+    // Never pretty-print JSON with escaped newlines — quiet plain text only.
+    const quiet = formatQuietJsonValue(content.value);
+    return (
+      <div className="grid gap-1.5" data-kind="json">
+        {quiet.headline ? (
+          <code className={TOOL_OUTPUT_COMMAND_CLASS}>{formatUserVisibleToolText(quiet.headline)}</code>
+        ) : null}
+        <pre className={TOOL_OUTPUT_BODY_CLASS}>{formatUserVisibleToolText(quiet.body)}</pre>
+      </div>
+    );
   }
 
   if (content.kind === 'text') {

--- a/packages/ui/src/tool-activity/trow-summary.ts
+++ b/packages/ui/src/tool-activity/trow-summary.ts
@@ -11,25 +11,20 @@
  * kind to an icon.
  */
 
+import type { ToolActivityKind } from '@maka/core';
 import type { ToolActivityItem } from '../materialize.js';
 
-export type TrowActivityKind =
-  | 'read'
-  | 'search'
-  | 'websearch'
-  | 'webfetch'
-  | 'edit'
-  | 'command'
-  | 'explore'
-  | 'browser'
-  | 'tool';
+export type TrowActivityKind = ToolActivityKind;
 
 /**
- * Bucket a maka tool by its canonical name (case-insensitive). `browser_*`
- * tools collapse to one `browser` bucket; anything unrecognized falls back to
- * the generic `tool` bucket so the summary always renders.
+ * Prefer a declared semantic category. Legacy rows fall back to the canonical
+ * tool name (case-insensitive); unknown names use the generic `tool` bucket.
  */
-export function trowActivityKind(toolName: string): TrowActivityKind {
+export function trowActivityKind(
+  toolName: string,
+  activityKind?: ToolActivityKind,
+): TrowActivityKind {
+  if (activityKind) return activityKind;
   const name = toolName.toLowerCase();
   if (name.startsWith('browser_')) return 'browser';
   switch (name) {
@@ -89,7 +84,7 @@ export function summarizeTrowTools(items: readonly ToolActivityItem[]): string {
   const counts = new Map<TrowActivityKind, number>();
   let failed = 0;
   for (const item of items) {
-    const kind = trowActivityKind(item.toolName);
+    const kind = trowActivityKind(item.toolName, item.activityKind);
     if (!counts.has(kind)) order.push(kind);
     counts.set(kind, (counts.get(kind) ?? 0) + 1);
     if (isFailed(item.status)) failed += 1;

--- a/packages/ui/src/tool-activity/trow-summary.ts
+++ b/packages/ui/src/tool-activity/trow-summary.ts
@@ -61,6 +61,8 @@ export function trowActivityKind(
       return 'edit';
     case 'bash':
     case 'shell':
+    case 'stopbackgroundtask':
+    case 'stop_background_task':
       return 'command';
     case 'exploreagent':
     case 'explore_agent':

--- a/packages/ui/src/tool-activity/trow-summary.ts
+++ b/packages/ui/src/tool-activity/trow-summary.ts
@@ -20,11 +20,25 @@ export type TrowActivityKind = ToolActivityKind;
  * Prefer a declared semantic category. Legacy rows fall back to the canonical
  * tool name (case-insensitive); unknown names use the generic `tool` bucket.
  */
+const KNOWN_ACTIVITY_KINDS: ReadonlySet<string> = new Set<TrowActivityKind>([
+  'read',
+  'search',
+  'websearch',
+  'webfetch',
+  'edit',
+  'command',
+  'explore',
+  'browser',
+  'tool',
+]);
+
 export function trowActivityKind(
   toolName: string,
   activityKind?: ToolActivityKind,
 ): TrowActivityKind {
-  if (activityKind) return activityKind;
+  // Trust only known kinds — corrupted/future persisted values must not crash
+  // KIND_CLAUSE[kind] during summarize.
+  if (activityKind && KNOWN_ACTIVITY_KINDS.has(activityKind)) return activityKind;
   const name = toolName.toLowerCase();
   if (name.startsWith('browser_')) return 'browser';
   switch (name) {

--- a/scripts/check-chat-marker-computed-style.mjs
+++ b/scripts/check-chat-marker-computed-style.mjs
@@ -82,7 +82,12 @@ import { fileURLToPath, pathToFileURL } from 'node:url';
 
 const REPO_ROOT = resolve(fileURLToPath(new URL('..', import.meta.url)));
 const { buttonVariants, cn } = await import(pathToFileURL(resolve(REPO_ROOT, 'packages/ui/dist/ui.js')).href);
-const { markerVariants, streamVariants, toolVariants } = await import(pathToFileURL(resolve(REPO_ROOT, 'packages/ui/dist/primitives/chat.js')).href);
+const { markerVariants, toolVariants } = await import(pathToFileURL(resolve(REPO_ROOT, 'packages/ui/dist/primitives/chat.js')).href);
+const {
+  TOOL_OUTPUT_PANEL_CLASS,
+  TOOL_OUTPUT_BODY_CLASS,
+  TOOL_OUTPUT_COMMAND_CLASS,
+} = await import(pathToFileURL(resolve(REPO_ROOT, 'packages/ui/dist/tool-activity/tool-result-preview.js')).href);
 const { Alert, AlertTitle, AlertDescription, AlertAction } = await import(pathToFileURL(resolve(REPO_ROOT, 'packages/ui/dist/primitives/alert.js')).href);
 
 const mainCssPath = process.argv[2] && resolve(process.argv[2]);
@@ -107,31 +112,13 @@ const pair = (m, h) => ({ main: m, head: h });
 const fa = (variant) => pair(cn(bv(variant, 'sm'), 'maka-turn-footer-action'), cn(bv('quiet', 'nav'), mv('footer-action')));
 const lb = pair(cn(bv('quiet', 'sm'), 'maka-turn-lineage-badge'), cn(bv('quiet', 'nav'), mv('lineage-badge')));
 
-// PR3 — the tool live-output stream shell. Resting, non-interactive, and
-// non-animated, so the computed-style diff covers it in full (the proof PR2's
-// shell got). The pulsing live DOT is the ONLY part NOT diffed here: its
-// `getComputedStyle` reads a phase-dependent animation value, so it is pinned by
-// the cascade contract's `@keyframes maka-pulse` frames + `LiveIndicator`
-// literals instead. `<el>` puts an empty class on the flag spans on `main`
-// (they were styled by the `.maka-tool-output-stream-counts span` DESCENDANT
-// rule, not their own class) and nests them inside the old counts element so that
-// rule resolves exactly as in production.
-const sv = (part) => streamVariants({ part });
-// `el` is the side-bound local builder from TREE — passed in so this lives at
-// module scope alongside the other shell helpers.
-const streamPanel = (el, id, attrs) =>
-  el('div', id, pair('maka-tool-output-stream', sv('container')), attrs,
-    el('header', `${id}-header`, pair('maka-tool-output-stream-header', sv('header')), '',
-      el('span', `${id}-label`, pair('maka-tool-output-stream-label', sv('label')), '', '<span>实时输出</span>')
-      + el('span', `${id}-flags`, pair('maka-tool-output-stream-counts', sv('flags')), '',
-          el('span', `${id}-flag-stderr`, pair('', sv('flag')), 'data-stream="stderr"', 'stderr')
-          + el('span', `${id}-flag-redacted`, pair('', sv('flag')), 'data-redacted="true"', '已脱敏')
-          + el('span', `${id}-flag-truncated`, pair('', sv('flag')), 'data-truncated="true"', '已截断')))
-    + el('pre', `${id}-body`, pair('maka-tool-output-stream-body', sv('body')), '',
-        el('span', `${id}-chunk`, pair('maka-tool-output-stream-chunk', sv('chunk')), '', 'out')
-        + el('span', `${id}-chunk-stderr`, pair('maka-tool-output-stream-chunk', sv('chunk')), 'data-stream="stderr"', 'err')
-        + el('span', `${id}-chunk-redacted`, pair('maka-tool-output-stream-chunk', sv('chunk')), 'data-redacted="true"',
-            'x' + el('span', `${id}-redacted-tag`, pair('maka-tool-output-stream-redacted-tag', sv('redacted-tag')), '', '[已脱敏]'))));
+// Quiet tool-output panel (production shell after streamVariants retirement).
+// Both sides use the same production classes — this pins layout invariants
+// (max-height, mono, panel surface) rather than a retired stream migration pair.
+const toolOutputPanel = (el, id) =>
+  el('div', id, pair(TOOL_OUTPUT_PANEL_CLASS, TOOL_OUTPUT_PANEL_CLASS), 'data-slot="tool-output"',
+    el('code', `${id}-cmd`, pair(TOOL_OUTPUT_COMMAND_CLASS, TOOL_OUTPUT_COMMAND_CLASS), '', 'npm test')
+    + el('pre', `${id}-body`, pair(TOOL_OUTPUT_BODY_CLASS, TOOL_OUTPUT_BODY_CLASS), '', 'out\nerr'));
 
 // PR3b — the `ToolActivity` card shell. The only part NOT diffed is the RUNNING
 // status dot (its `maka-tool-pulse` ring is animated → phase-dependent
@@ -254,10 +241,8 @@ const TREE = (side) => {
     el('div', 'aborted', pair('maka-turn-aborted-marker', mv('aborted')), '', '<span>x</span>'),
     el('div', 'failed-banner', pair('maka-turn-failed-banner', mv('failed-banner')), '',
       '<span>x</span>' + el('span', 'failed-recovery', pair('maka-turn-failed-recovery', mv('failed-recovery')), '', '<span>x</span>')),
-    // The live-output stream, resting and (separately) with `data-live="true"`
-    // so the accent border + inset ring are diffed too.
-    streamPanel(el, 'stream', ''),
-    streamPanel(el, 'stream-live', 'data-live="true"'),
+    // Quiet tool-output panel (command + body) used by ToolCardBody / TerminalPreview.
+    toolOutputPanel(el, 'tool-output'),
     // The PR3b tool-activity card shell.
     toolCardSection(el),
     // The PR3c tool-error banner (Alert primitive).
@@ -267,9 +252,8 @@ const TREE = (side) => {
 
 const PROPS = ['display', 'height', 'minHeight', 'width', 'maxWidth', 'maxHeight', 'minWidth', 'paddingTop', 'paddingRight', 'paddingBottom', 'paddingLeft', 'marginTop', 'marginRight', 'marginBottom', 'marginLeft', 'borderTopWidth', 'borderRightWidth', 'borderBottomWidth', 'borderLeftWidth', 'borderTopColor', 'borderBottomColor', 'borderTopStyle', 'borderTopLeftRadius', 'boxShadow', 'overflowX', 'overflowY', 'fontFamily', 'fontSize', 'fontWeight', 'fontStyle', 'letterSpacing', 'lineHeight', 'textTransform', 'gridTemplateColumns', 'columnGap', 'color', 'backgroundColor', 'opacity', 'transition', 'justifyContent', 'alignItems', 'flexWrap', 'flexDirection', 'fontVariantNumeric', 'whiteSpace', 'wordBreak', 'textOverflow', 'textAlign', 'cursor'];
 const IDS = ['footer', 'footer-rest', 'footer-pending', 'footer-copy-pending', 'footer-copied', 'footer-failed', 'lineage-row', 'lineage-fwd', 'lineage-row-reverse', 'lineage-rev', 'aborted', 'failed-banner', 'failed-recovery',
-  // PR3 stream shell (resting + live border ring). The pulse dot is excluded
-  // (animated → phase-dependent computed style).
-  'stream', 'stream-header', 'stream-label', 'stream-flags', 'stream-flag-stderr', 'stream-flag-redacted', 'stream-flag-truncated', 'stream-body', 'stream-chunk', 'stream-chunk-stderr', 'stream-chunk-redacted', 'stream-redacted-tag', 'stream-live',
+  // Quiet tool-output panel (panel + command + body).
+  'tool-output', 'tool-output-cmd', 'tool-output-body',
   // PR3b tool-card shell: section + count, all six `[data-status]` card
   // containers at their production default open/collapsed state, the summary header
   // grid, the static dot colors (running dot excluded — animated ring), the

--- a/scripts/check-chat-marker-computed-style.mjs
+++ b/scripts/check-chat-marker-computed-style.mjs
@@ -30,7 +30,7 @@
  *
  * What this renders + diffs `main` vs head: the resting box / typography /
  * color / transition style of all 9 marker families and the PR3 stream shell
- * (panel / header / counts + its data-variant pills / body / chunk, resting AND
+ * (panel / header / flags + their data-variant pills / body / chunk, resting AND
  * with `data-live="true"` for the accent border + inset ring), plus the footer
  * action across resting / pending / copy-pending / copied / failed —
  * including `main`'s old pending `secondary` variant vs the new always-
@@ -112,9 +112,9 @@ const lb = pair(cn(bv('quiet', 'sm'), 'maka-turn-lineage-badge'), cn(bv('quiet',
 // shell got). The pulsing live DOT is the ONLY part NOT diffed here: its
 // `getComputedStyle` reads a phase-dependent animation value, so it is pinned by
 // the cascade contract's `@keyframes maka-pulse` frames + `LiveIndicator`
-// literals instead. `<el>` puts an empty class on the count spans on `main`
+// literals instead. `<el>` puts an empty class on the flag spans on `main`
 // (they were styled by the `.maka-tool-output-stream-counts span` DESCENDANT
-// rule, not their own class) and nests them inside the counts element so that
+// rule, not their own class) and nests them inside the old counts element so that
 // rule resolves exactly as in production.
 const sv = (part) => streamVariants({ part });
 // `el` is the side-bound local builder from TREE — passed in so this lives at
@@ -123,11 +123,10 @@ const streamPanel = (el, id, attrs) =>
   el('div', id, pair('maka-tool-output-stream', sv('container')), attrs,
     el('header', `${id}-header`, pair('maka-tool-output-stream-header', sv('header')), '',
       el('span', `${id}-label`, pair('maka-tool-output-stream-label', sv('label')), '', '<span>实时输出</span>')
-      + el('span', `${id}-counts`, pair('maka-tool-output-stream-counts', sv('counts')), '',
-          el('span', `${id}-count`, pair('', sv('count')), '', 'stdout 1')
-          + el('span', `${id}-count-stderr`, pair('', sv('count')), 'data-stream="stderr"', 'stderr 1')
-          + el('span', `${id}-count-redacted`, pair('', sv('count')), 'data-redacted="true"', '已脱敏 1')
-          + el('span', `${id}-count-truncated`, pair('', sv('count')), 'data-truncated="true"', '已截断')))
+      + el('span', `${id}-flags`, pair('maka-tool-output-stream-counts', sv('flags')), '',
+          el('span', `${id}-flag-stderr`, pair('', sv('flag')), 'data-stream="stderr"', 'stderr')
+          + el('span', `${id}-flag-redacted`, pair('', sv('flag')), 'data-redacted="true"', '已脱敏')
+          + el('span', `${id}-flag-truncated`, pair('', sv('flag')), 'data-truncated="true"', '已截断')))
     + el('pre', `${id}-body`, pair('maka-tool-output-stream-body', sv('body')), '',
         el('span', `${id}-chunk`, pair('maka-tool-output-stream-chunk', sv('chunk')), '', 'out')
         + el('span', `${id}-chunk-stderr`, pair('maka-tool-output-stream-chunk', sv('chunk')), 'data-stream="stderr"', 'err')
@@ -143,25 +142,24 @@ const streamPanel = (el, id, attrs) =>
 // body / intent, and the args `<pre>` override over the shared `.maka-code` base
 // — is static and diffed in full.
 //
-// Each card carries its REAL `isOpenByDefault` state (components.tsx): pending /
-// waiting_permission / running / errored render OPEN, completed / interrupted
-// render COLLAPSED. That matters — the most common historical card is a settled,
-// collapsed `completed` tool, whose `[open]>summary` divider is absent. So the
-// rich inner parts ride the (open) `errored` card, and a COLLAPSED `completed`
-// card is diffed too. The non-vacuous collapsed signal is the summary's
+// Each card carries the production disclosure default: waiting_permission /
+// errored render OPEN; ordinary pending / running / completed / interrupted
+// states render COLLAPSED. The rich inner parts ride the open `errored` card,
+// and a collapsed `completed` card is diffed too. The non-vacuous collapsed
+// signal is the summary's
 // border-bottom: 1px on the open card, 0px on the collapsed one (the `[open]`
 // gate), so the rows genuinely exercise both states. (The body is hidden via
 // Chromium's `::details-content` pseudo, so its child `display` stays `block`
 // either way — the collapsed body row still diffs its box / typography parity.)
 const tv = (part) => toolVariants({ part });
-const openByDefault = (s) => s === 'pending' || s === 'waiting_permission' || s === 'running' || s === 'errored';
+const openByDefault = (s) => s === 'waiting_permission' || s === 'errored';
 // The SINGLE source of truth for the tool-card fixture: every production
 // `ToolActivityItem['status']` (the keys of components.tsx's STATUS_LABEL). The
 // cards, the header count, and the diffed IDS all derive from this one list, so
 // they can't drift apart; the cascade contract asserts it stays complete, so a
 // new status can't silently escape the zero-visual proof. `pending` has NO
 // `data-[status=pending]` branch in toolVariants, so it falls back to the base
-// card border + gray dot; it renders OPEN (isOpenByDefault).
+// card border + gray dot; it renders collapsed by default.
 const STAT = ['pending', 'waiting_permission', 'running', 'completed', 'errored', 'interrupted'];
 const toolCardSection = (el) => {
   const item = pair('maka-tool toolItem', tv('item'));
@@ -271,9 +269,9 @@ const PROPS = ['display', 'height', 'minHeight', 'width', 'maxWidth', 'maxHeight
 const IDS = ['footer', 'footer-rest', 'footer-pending', 'footer-copy-pending', 'footer-copied', 'footer-failed', 'lineage-row', 'lineage-fwd', 'lineage-row-reverse', 'lineage-rev', 'aborted', 'failed-banner', 'failed-recovery',
   // PR3 stream shell (resting + live border ring). The pulse dot is excluded
   // (animated → phase-dependent computed style).
-  'stream', 'stream-header', 'stream-label', 'stream-counts', 'stream-count', 'stream-count-stderr', 'stream-count-redacted', 'stream-count-truncated', 'stream-body', 'stream-chunk', 'stream-chunk-stderr', 'stream-chunk-redacted', 'stream-redacted-tag', 'stream-live',
+  'stream', 'stream-header', 'stream-label', 'stream-flags', 'stream-flag-stderr', 'stream-flag-redacted', 'stream-flag-truncated', 'stream-body', 'stream-chunk', 'stream-chunk-stderr', 'stream-chunk-redacted', 'stream-redacted-tag', 'stream-live',
   // PR3b tool-card shell: section + count, all six `[data-status]` card
-  // containers at their REAL default open/collapsed state, the summary header
+  // containers at their production default open/collapsed state, the summary header
   // grid, the static dot colors (running dot excluded — animated ring), the
   // status-invariant inner parts (on the open `errored` card), and the COLLAPSED
   // `completed` default — its summary (no `[open]` divider) + UA-hidden body.


### PR DESCRIPTION
## Summary

- Collapse ordinary tool diagnostics by default while keeping permission and error states visible.
- Preserve explicit user disclosure choices across normal tool lifecycle transitions.
- Replace transport chunk counts with user-relevant diagnostic flags.
- Carry an optional semantic `activityKind` from tool declarations through runtime events, persistence, replay, and live desktop state.

## Why

Tool activity rows exposed raw commands and transport details such as `STDOUT N`, while lifecycle changes also controlled whether details were open. Long PowerShell commands made this especially visible on Windows, but the underlying presentation-state coupling was platform-independent.

## Scope

Changed:

- Added a pure tool activity presentation and disclosure policy.
- Added the backward-compatible `ToolActivityKind` contract and legacy tool-name fallback.
- Classified built-in read, search, edit, and command tools.
- Added regression coverage across runtime, UI, replay, and desktop live events.

Not included:

- Tool execution behavior or shell command generation.
- OS-specific command rewriting.
- Changes to legacy session storage requirements.

## Verification

- `npm run -w @maka/runtime test` — 1134 passed, 2 environment-dependent skipped
- `npm run -w @maka/ui test` — 52 passed
- `npm run -w @maka/desktop test` — 2335 passed
- `npm run typecheck` — passed for all workspaces

## User-facing impact

Ordinary tool activity stays compact, permission requests and failures remain prominent, and internal stdout/stderr chunk counts are no longer shown. The optional persisted field is backward-compatible; no migration, documentation, or changelog change is required.

## Reviewer notes

The main review seams are `packages/ui/src/tool-activity/presentation.ts` and the `activityKind` projection path. Legacy rows and custom tools without a declared kind continue to use tool-name inference.

A Windows screenshot is not included because this workspace has no Windows renderer. The platform-independent disclosure and text behavior is covered by contract tests.

## Checklist

- [x] Scope matches the PR title and excludes unrelated changes
- [x] Verification lists commands and results
- [x] User-facing impact, docs, changelog, migrations, and breaking changes are noted
- [x] Risk, rollback, and review focus are called out
- [x] UI screenshot absence is explained
