### PR TITLE
fix(cli): bound live tool output buffers

### DIFF
--- a/packages/cli/src/__tests__/bounded-chunk-buffer.test.ts
+++ b/packages/cli/src/__tests__/bounded-chunk-buffer.test.ts
@@ -1,0 +1,56 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+import { BoundedChunkBuffer } from '../bounded-chunk-buffer.js';
+
+interface Chunk {
+  text: string;
+}
+
+describe('BoundedChunkBuffer', () => {
+  test('releases a discarded backing slot before delayed storage compaction', () => {
+    const buffer = new BoundedChunkBuffer<Chunk>({
+      maxChars: 3,
+      maxChunks: 512,
+      textOf: (chunk) => chunk.text,
+      withText: (chunk, text) => ({ ...chunk, text }),
+    });
+    const discarded = { text: 'old' };
+    buffer.append(discarded);
+    buffer.append({ text: 'new' });
+
+    const storage = buffer as unknown as { chunks: Array<Chunk | undefined>; head: number };
+    assert.equal(storage.head, 1);
+    assert.equal(storage.chunks[0], undefined);
+  });
+
+  test('ignores a replay of a sequence that was already discarded', () => {
+    const buffer = new BoundedChunkBuffer<Chunk & { seq: number }>({
+      maxChars: 1,
+      maxChunks: 512,
+      textOf: (chunk) => chunk.text,
+      withText: (chunk, text) => ({ ...chunk, text }),
+      sequence: (chunk) => chunk.seq,
+    });
+    buffer.append({ seq: 1, text: 'a' });
+    buffer.append({ seq: 2, text: 'b' });
+
+    assert.equal(buffer.append({ seq: 1, text: 'a' }), false);
+    assert.equal(buffer.droppedChars, 1);
+    assert.equal(buffer.version, 2);
+    assert.deepEqual(buffer.values(), [{ seq: 2, text: 'b' }]);
+  });
+
+  test('does not split a UTF-16 surrogate pair at the character boundary', () => {
+    const buffer = new BoundedChunkBuffer<string>({
+      maxChars: 2,
+      maxChunks: 512,
+      textOf: (chunk) => chunk,
+      withText: (_chunk, text) => text,
+    });
+
+    buffer.append('😀a');
+
+    assert.deepEqual(buffer.values(), ['a']);
+    assert.equal(buffer.droppedChars, 2);
+  });
+});

--- a/packages/cli/src/__tests__/pi-transcript.test.ts
+++ b/packages/cli/src/__tests__/pi-transcript.test.ts
@@ -1209,6 +1209,20 @@ describe('Maka Pi TUI transcript', () => {
     assert.match(rendered, /\[stderr\]/);
   });
 
+  test('renders the redaction marker for an empty redacted output delta', () => {
+    const state = createMakaPiTranscriptState();
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_start', toolUseId: 'redacted-empty', toolName: 'Bash', args: { command: 'secret' },
+    }));
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_output_delta', toolUseId: 'redacted-empty', seq: 1,
+      stream: 'stdout', chunk: '', redacted: true,
+    }));
+
+    const rendered = renderMakaPiTranscript(state, meta(), 100).map(stripAnsi).join('\n');
+    assert.match(rendered, /\[redacted\]/);
+  });
+
   test('caps a long live stream group in the expanded card', () => {
     const state = createMakaPiTranscriptState();
     applyMakaSessionEventToTranscript(state, event({
@@ -1273,6 +1287,28 @@ describe('Maka Pi TUI transcript', () => {
     assert.match(expanded, /chunk-512\b/);
   });
 
+  test('ignores empty output without displacing retained output', () => {
+    const state = createMakaPiTranscriptState();
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_start', toolUseId: 'output-empty', toolName: 'Bash', args: { command: 'verbose' },
+    }));
+    for (let i = 0; i < 512; i += 1) {
+      applyMakaSessionEventToTranscript(state, event({
+        type: 'tool_output_delta', toolUseId: 'output-empty', seq: i,
+        stream: i % 2 === 0 ? 'stdout' : 'stderr', chunk: `chunk-${i}\n`, redacted: false,
+      }));
+    }
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_output_delta', toolUseId: 'output-empty', seq: 512,
+      stream: 'stdout', chunk: '', redacted: false,
+    }));
+
+    assert.equal(toggleAllToolExpansion(state), true);
+    const expanded = renderMakaPiTranscript(state, meta(), 100).map(stripAnsi).join('\n');
+    assert.match(expanded, /chunk-0\b/);
+    assert.match(expanded, /chunk-511\b/);
+  });
+
   test('retains the newest progress when progress text exceeds its buffer limit', () => {
     const state = createMakaPiTranscriptState();
     applyMakaSessionEventToTranscript(state, event({
@@ -1311,6 +1347,26 @@ describe('Maka Pi TUI transcript', () => {
     const expanded = renderMakaPiTranscript(state, meta(), 100).map(stripAnsi).join('\n');
     assert.doesNotMatch(expanded, /progress-0\b/);
     assert.match(expanded, /progress-512\b/);
+  });
+
+  test('ignores empty progress without displacing retained progress', () => {
+    const state = createMakaPiTranscriptState();
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_start', toolUseId: 'progress-empty', toolName: 'Workflow', args: {},
+    }));
+    for (let i = 0; i < 512; i += 1) {
+      applyMakaSessionEventToTranscript(state, event({
+        type: 'tool_progress', toolUseId: 'progress-empty', chunk: `progress-${i}\n`,
+      }));
+    }
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_progress', toolUseId: 'progress-empty', chunk: '',
+    }));
+
+    assert.equal(toggleAllToolExpansion(state), true);
+    const expanded = renderMakaPiTranscript(state, meta(), 100).map(stripAnsi).join('\n');
+    assert.match(expanded, /progress-0\b/);
+    assert.match(expanded, /progress-511\b/);
   });
 });
 

--- a/packages/cli/src/__tests__/pi-transcript.test.ts
+++ b/packages/cli/src/__tests__/pi-transcript.test.ts
@@ -1230,6 +1230,88 @@ describe('Maka Pi TUI transcript', () => {
     assert.match(expanded, /lines hidden/);
     assert.doesNotMatch(expanded, /stream-line-5/); // a middle line the cap hides
   });
+
+  test('retains the newest live output when a stream exceeds its buffer limit', () => {
+    const state = createMakaPiTranscriptState();
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_start', toolUseId: 'bash-bounded', toolName: 'Bash', args: { command: 'verbose' },
+    }));
+    const chunks = Array.from(
+      { length: 9 },
+      (_, i) => `chunk-${i}-start\n${'x\n'.repeat(4_090)}chunk-${i}-end\n`,
+    );
+    for (const [i, chunk] of chunks.entries()) {
+      applyMakaSessionEventToTranscript(state, event({
+        type: 'tool_output_delta', toolUseId: 'bash-bounded', seq: i, stream: 'stdout',
+        chunk, redacted: false,
+      }));
+    }
+
+    assert.equal(toggleAllToolExpansion(state), true);
+    const expanded = renderMakaPiTranscript(state, meta(), 100).map(stripAnsi).join('\n');
+    assert.doesNotMatch(expanded, /chunk-0-start\b/);
+    assert.match(expanded, /chunk-8-end\b/);
+    const droppedChars = chunks.reduce((total, chunk) => total + chunk.length, 0) - 64 * 1024;
+    assert.match(expanded, new RegExp(`${droppedChars} earlier live-output chars truncated`));
+  });
+
+  test('drops the oldest live output when the chunk count reaches its limit', () => {
+    const state = createMakaPiTranscriptState();
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_start', toolUseId: 'bash-many-chunks', toolName: 'Bash', args: { command: 'verbose' },
+    }));
+    for (let i = 0; i < 513; i += 1) {
+      applyMakaSessionEventToTranscript(state, event({
+        type: 'tool_output_delta', toolUseId: 'bash-many-chunks', seq: i,
+        stream: i % 2 === 0 ? 'stdout' : 'stderr', chunk: `chunk-${i}\n`, redacted: false,
+      }));
+    }
+
+    assert.equal(toggleAllToolExpansion(state), true);
+    const expanded = renderMakaPiTranscript(state, meta(), 100).map(stripAnsi).join('\n');
+    assert.doesNotMatch(expanded, /chunk-0\b/);
+    assert.match(expanded, /chunk-512\b/);
+  });
+
+  test('retains the newest progress when progress text exceeds its buffer limit', () => {
+    const state = createMakaPiTranscriptState();
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_start', toolUseId: 'progress-bounded', toolName: 'Workflow', args: {},
+    }));
+    const chunks = Array.from(
+      { length: 9 },
+      (_, i) => `progress-${i}-start\n${'x\n'.repeat(4_090)}progress-${i}-end\n`,
+    );
+    for (const chunk of chunks) {
+      applyMakaSessionEventToTranscript(state, event({
+        type: 'tool_progress', toolUseId: 'progress-bounded', chunk,
+      }));
+    }
+
+    assert.equal(toggleAllToolExpansion(state), true);
+    const expanded = renderMakaPiTranscript(state, meta(), 100).map(stripAnsi).join('\n');
+    assert.doesNotMatch(expanded, /progress-0-start\b/);
+    assert.match(expanded, /progress-8-end\b/);
+    const droppedChars = chunks.reduce((total, chunk) => total + chunk.length, 0) - 64 * 1024;
+    assert.match(expanded, new RegExp(`${droppedChars} earlier progress chars truncated`));
+  });
+
+  test('drops the oldest progress when the chunk count reaches its limit', () => {
+    const state = createMakaPiTranscriptState();
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_start', toolUseId: 'progress-many-chunks', toolName: 'Workflow', args: {},
+    }));
+    for (let i = 0; i < 513; i += 1) {
+      applyMakaSessionEventToTranscript(state, event({
+        type: 'tool_progress', toolUseId: 'progress-many-chunks', chunk: `progress-${i}\n`,
+      }));
+    }
+
+    assert.equal(toggleAllToolExpansion(state), true);
+    const expanded = renderMakaPiTranscript(state, meta(), 100).map(stripAnsi).join('\n');
+    assert.doesNotMatch(expanded, /progress-0\b/);
+    assert.match(expanded, /progress-512\b/);
+  });
 });
 
 describe('transcript entry render memoization', () => {
@@ -1273,6 +1355,28 @@ describe('transcript entry render memoization', () => {
     const expanded = renderMakaPiTranscript(state, meta(), 100).map(stripAnsi).join('\n');
     assert.notEqual(expanded, collapsed);
     assert.match(expanded, /beta/);
+  });
+
+  test('re-renders live progress after the bounded buffer reaches a stable length', () => {
+    const state = createMakaPiTranscriptState();
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_start', toolUseId: 'progress-cache', toolName: 'Workflow', args: {},
+    }));
+    for (let i = 0; i < 512; i += 1) {
+      applyMakaSessionEventToTranscript(state, event({
+        type: 'tool_progress', toolUseId: 'progress-cache', chunk: `progress-${i}\n`,
+      }));
+    }
+    assert.equal(toggleAllToolExpansion(state), true);
+    const before = renderMakaPiTranscript(state, meta(), 100).map(stripAnsi).join('\n');
+    assert.match(before, /progress-511\b/);
+
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_progress', toolUseId: 'progress-cache', chunk: 'progress-512\n',
+    }));
+    const after = renderMakaPiTranscript(state, meta(), 100).map(stripAnsi).join('\n');
+    assert.match(after, /progress-512\b/);
+    assert.doesNotMatch(after, /progress-0\b/);
   });
 
   test('re-renders thinking when a same-length final replaces the streamed text', () => {

--- a/packages/cli/src/bounded-chunk-buffer.ts
+++ b/packages/cli/src/bounded-chunk-buffer.ts
@@ -3,16 +3,16 @@ export interface BoundedChunkBufferOptions<T> {
   maxChunks: number;
   textOf: (chunk: T) => string;
   withText: (chunk: T, text: string) => T;
-  compare?: (left: T, right: T) => number;
-  same?: (left: T, right: T) => boolean;
+  sequence?: (chunk: T) => number;
 }
 
 /** A tail buffer bounded by both retained text and retained chunk objects. */
 export class BoundedChunkBuffer<T> {
-  private chunks: T[] = [];
+  private chunks: Array<T | undefined> = [];
   private head = 0;
   private retainedChars = 0;
   private cachedValues: readonly T[] | undefined;
+  private discardedThroughSequence: number | undefined;
   private dropped = 0;
   private revision = 0;
 
@@ -31,16 +31,20 @@ export class BoundedChunkBuffer<T> {
   }
 
   values(): readonly T[] {
-    this.cachedValues ??= this.chunks.slice(this.head);
+    this.cachedValues ??= this.chunks.slice(this.head) as T[];
     return this.cachedValues;
   }
 
   append(chunk: T): boolean {
-    const same = this.options.same;
-    if (same) {
+    const sequenceOf = this.options.sequence;
+    if (sequenceOf) {
+      const sequence = sequenceOf(chunk);
+      if (this.discardedThroughSequence !== undefined && sequence <= this.discardedThroughSequence) {
+        return false;
+      }
       for (let index = this.head; index < this.chunks.length; index += 1) {
         const candidate = this.chunks[index];
-        if (candidate !== undefined && same(candidate, chunk)) return false;
+        if (candidate !== undefined && sequenceOf(candidate) === sequence) return false;
       }
     }
 
@@ -53,15 +57,17 @@ export class BoundedChunkBuffer<T> {
   }
 
   private insert(chunk: T): void {
-    const compare = this.options.compare;
+    const sequenceOf = this.options.sequence;
     const last = this.chunks[this.chunks.length - 1];
-    if (!compare || last === undefined || compare(last, chunk) <= 0) {
+    if (!sequenceOf || last === undefined || sequenceOf(last) <= sequenceOf(chunk)) {
       this.chunks.push(chunk);
       return;
     }
 
     this.compactStorage(true);
-    const index = this.chunks.findIndex((candidate) => compare(candidate, chunk) > 0);
+    const index = this.chunks.findIndex(
+      (candidate) => candidate !== undefined && sequenceOf(candidate) > sequenceOf(chunk),
+    );
     this.chunks.splice(index < 0 ? this.chunks.length : index, 0, chunk);
   }
 
@@ -72,23 +78,32 @@ export class BoundedChunkBuffer<T> {
       if (first === undefined) break;
       const text = this.options.textOf(first);
       if (text.length <= excess) {
-        this.dropFirst(text.length);
+        this.dropFirst(first, text.length);
         excess -= text.length;
         continue;
       }
-      this.chunks[this.head] = this.options.withText(first, text.slice(excess));
-      this.retainedChars -= excess;
-      this.dropped += excess;
+      const cut = unicodeSafePrefixLength(text, excess);
+      this.chunks[this.head] = this.options.withText(first, text.slice(cut));
+      this.retainedChars -= cut;
+      this.dropped += cut;
       excess = 0;
     }
     while (this.length > this.options.maxChunks) {
       const first = this.chunks[this.head];
-      this.dropFirst(first === undefined ? 0 : this.options.textOf(first).length);
+      if (first === undefined) break;
+      this.dropFirst(first, this.options.textOf(first).length);
     }
     this.compactStorage(false);
   }
 
-  private dropFirst(chars: number): void {
+  private dropFirst(chunk: T, chars: number): void {
+    const sequence = this.options.sequence?.(chunk);
+    if (sequence !== undefined && (
+      this.discardedThroughSequence === undefined || this.discardedThroughSequence < sequence
+    )) {
+      this.discardedThroughSequence = sequence;
+    }
+    this.chunks[this.head] = undefined;
     this.head += 1;
     this.retainedChars -= chars;
     this.dropped += chars;
@@ -100,4 +115,12 @@ export class BoundedChunkBuffer<T> {
     this.chunks.splice(0, this.head);
     this.head = 0;
   }
+}
+
+function unicodeSafePrefixLength(text: string, minimum: number): number {
+  const before = text.charCodeAt(minimum - 1);
+  const after = text.charCodeAt(minimum);
+  const splitsSurrogatePair = before >= 0xd800 && before <= 0xdbff
+    && after >= 0xdc00 && after <= 0xdfff;
+  return splitsSurrogatePair ? minimum + 1 : minimum;
 }

--- a/packages/cli/src/bounded-chunk-buffer.ts
+++ b/packages/cli/src/bounded-chunk-buffer.ts
@@ -1,0 +1,103 @@
+export interface BoundedChunkBufferOptions<T> {
+  maxChars: number;
+  maxChunks: number;
+  textOf: (chunk: T) => string;
+  withText: (chunk: T, text: string) => T;
+  compare?: (left: T, right: T) => number;
+  same?: (left: T, right: T) => boolean;
+}
+
+/** A tail buffer bounded by both retained text and retained chunk objects. */
+export class BoundedChunkBuffer<T> {
+  private chunks: T[] = [];
+  private head = 0;
+  private retainedChars = 0;
+  private cachedValues: readonly T[] | undefined;
+  private dropped = 0;
+  private revision = 0;
+
+  constructor(private readonly options: BoundedChunkBufferOptions<T>) {}
+
+  get length(): number {
+    return this.chunks.length - this.head;
+  }
+
+  get droppedChars(): number {
+    return this.dropped;
+  }
+
+  get version(): number {
+    return this.revision;
+  }
+
+  values(): readonly T[] {
+    this.cachedValues ??= this.chunks.slice(this.head);
+    return this.cachedValues;
+  }
+
+  append(chunk: T): boolean {
+    const same = this.options.same;
+    if (same) {
+      for (let index = this.head; index < this.chunks.length; index += 1) {
+        const candidate = this.chunks[index];
+        if (candidate !== undefined && same(candidate, chunk)) return false;
+      }
+    }
+
+    this.insert(chunk);
+    this.retainedChars += this.options.textOf(chunk).length;
+    this.trim();
+    this.revision += 1;
+    this.cachedValues = undefined;
+    return true;
+  }
+
+  private insert(chunk: T): void {
+    const compare = this.options.compare;
+    const last = this.chunks[this.chunks.length - 1];
+    if (!compare || last === undefined || compare(last, chunk) <= 0) {
+      this.chunks.push(chunk);
+      return;
+    }
+
+    this.compactStorage(true);
+    const index = this.chunks.findIndex((candidate) => compare(candidate, chunk) > 0);
+    this.chunks.splice(index < 0 ? this.chunks.length : index, 0, chunk);
+  }
+
+  private trim(): void {
+    let excess = this.retainedChars - this.options.maxChars;
+    while (excess > 0 && this.length > 0) {
+      const first = this.chunks[this.head];
+      if (first === undefined) break;
+      const text = this.options.textOf(first);
+      if (text.length <= excess) {
+        this.dropFirst(text.length);
+        excess -= text.length;
+        continue;
+      }
+      this.chunks[this.head] = this.options.withText(first, text.slice(excess));
+      this.retainedChars -= excess;
+      this.dropped += excess;
+      excess = 0;
+    }
+    while (this.length > this.options.maxChunks) {
+      const first = this.chunks[this.head];
+      this.dropFirst(first === undefined ? 0 : this.options.textOf(first).length);
+    }
+    this.compactStorage(false);
+  }
+
+  private dropFirst(chars: number): void {
+    this.head += 1;
+    this.retainedChars -= chars;
+    this.dropped += chars;
+  }
+
+  private compactStorage(force: boolean): void {
+    if (this.head === 0) return;
+    if (!force && (this.head < 64 || this.head * 2 < this.chunks.length)) return;
+    this.chunks.splice(0, this.head);
+    this.head = 0;
+  }
+}

--- a/packages/cli/src/pi-transcript-tools.ts
+++ b/packages/cli/src/pi-transcript-tools.ts
@@ -53,10 +53,24 @@ function renderExpandedToolBlock(entry: MakaPiToolEntry, width: number): string[
   ];
   const inputSummary = toolInputSummary(entry);
   if (inputSummary) lines.push(...renderIndented(inputSummary, width, 2).map(ansi.dim));
-  if (entry.progress.length > 0) {
-    lines.push(...renderToolText(entry.progress.join(''), width).map(ansi.dim));
+  if (entry.progress.droppedChars > 0) {
+    lines.push(...renderIndented(
+      ansi.dim(`⋯ ${entry.progress.droppedChars} earlier progress chars truncated ⋯`),
+      width,
+      2,
+    ));
   }
-  lines.push(...renderToolStreams(entry.outputDeltas, width));
+  if (entry.progress.length > 0) {
+    lines.push(...renderCappedResultText(entry.progress.values().join(''), width, ansi.dim));
+  }
+  if (entry.outputDeltas.droppedChars > 0) {
+    lines.push(...renderIndented(
+      ansi.dim(`⋯ ${entry.outputDeltas.droppedChars} earlier live-output chars truncated ⋯`),
+      width,
+      2,
+    ));
+  }
+  lines.push(...renderToolStreams(entry.outputDeltas.values(), width));
   if (entry.result || entry.output) {
     lines.push(...renderToolResult(entry, width));
   }
@@ -184,12 +198,12 @@ function jsonArrayCount(entry: MakaPiToolEntry, key: string): number | undefined
 
 /** Latest non-empty output line from live deltas (redaction-aware), else progress. */
 function latestLiveOutputLine(entry: MakaPiToolEntry): string {
-  const groups = groupOutputDeltas(entry.outputDeltas);
+  const groups = groupOutputDeltas(entry.outputDeltas.values());
   if (groups.length > 0) {
     const fromDeltas = lastNonEmptyLine(groups.map((group) => group.text).join('\n'));
     if (fromDeltas) return fromDeltas;
   }
-  return lastNonEmptyLine(entry.progress.join(''));
+  return lastNonEmptyLine(entry.progress.values().join(''));
 }
 
 function lastNonEmptyLine(text: string): string {

--- a/packages/cli/src/pi-transcript.ts
+++ b/packages/cli/src/pi-transcript.ts
@@ -255,16 +255,19 @@ export function applyMakaSessionEventToTranscript(
     case 'tool_progress': {
       const tool = findToolEntry(state, event.toolUseId);
       if (tool) {
-        tool.progress.append(
-          typeof event.chunk === 'string' ? event.chunk : `[${event.chunk.kind}] ${event.chunk.text}`,
-        );
+        const progress = typeof event.chunk === 'string'
+          ? event.chunk
+          : event.chunk.text
+            ? `[${event.chunk.kind}] ${event.chunk.text}`
+            : '';
+        if (progress) tool.progress.append(progress);
       }
       break;
     }
 
     case 'tool_output_delta': {
       const tool = findToolEntry(state, event.toolUseId);
-      if (tool) {
+      if (tool && (event.chunk || event.redacted)) {
         tool.outputDeltas.append({
           seq: event.seq,
           stream: event.stream,

--- a/packages/cli/src/pi-transcript.ts
+++ b/packages/cli/src/pi-transcript.ts
@@ -671,8 +671,7 @@ function createOutputBuffer(): BoundedChunkBuffer<MakaPiToolOutputDelta> {
     maxChunks: LIVE_TOOL_BUFFER_MAX_CHUNKS,
     textOf: (delta) => delta.chunk,
     withText: (delta, chunk) => ({ ...delta, chunk }),
-    compare: (left, right) => left.seq - right.seq,
-    same: (left, right) => left.seq === right.seq,
+    sequence: (delta) => delta.seq,
   });
 }
 

--- a/packages/cli/src/pi-transcript.ts
+++ b/packages/cli/src/pi-transcript.ts
@@ -10,6 +10,7 @@ import type { ContextBudgetDiagnostic } from '@maka/core/usage-stats/types';
 import type { ThinkingLevel } from '@maka/core/model-thinking';
 import { materializeSession, type ChatItem, type ToolActivityItem } from '@maka/runtime';
 import type { MakaSessionDriver } from './session-driver.js';
+import { BoundedChunkBuffer } from './bounded-chunk-buffer.js';
 import { ansi } from './tui-ansi.js';
 import {
   fitLine,
@@ -43,6 +44,9 @@ export interface MakaPiToolOutputDelta {
   redacted: boolean;
 }
 
+const LIVE_TOOL_BUFFER_MAX_CHARS = 64 * 1024;
+const LIVE_TOOL_BUFFER_MAX_CHUNKS = 512;
+
 export type MakaPiTranscriptEntry =
   | { kind: 'user'; text: string }
   | { kind: 'assistant'; messageId: string; text: string }
@@ -57,8 +61,8 @@ export type MakaPiTranscriptEntry =
       result?: ToolResultContent;
       /** Flattened result text, kept as a fallback for text/json/unknown kinds. */
       output?: string;
-      progress: string[];
-      outputDeltas: MakaPiToolOutputDelta[];
+      progress: BoundedChunkBuffer<string>;
+      outputDeltas: BoundedChunkBuffer<MakaPiToolOutputDelta>;
       durationMs?: number;
       status: 'running' | 'done' | 'error';
     }
@@ -218,8 +222,8 @@ export function applyMakaSessionEventToTranscript(
         toolName: event.toolName,
         ...(event.displayName ? { title: event.displayName } : {}),
         input: event.args,
-        progress: [],
-        outputDeltas: [],
+        progress: createProgressBuffer(),
+        outputDeltas: createOutputBuffer(),
         status: 'running',
       });
       break;
@@ -237,8 +241,8 @@ export function applyMakaSessionEventToTranscript(
           toolUseId: event.toolUseId,
           toolName: event.toolUseId,
           input: undefined,
-          progress: [],
-          outputDeltas: [],
+          progress: createProgressBuffer(),
+          outputDeltas: createOutputBuffer(),
           result: event.content,
           output: formatToolResultContent(event.content),
           durationMs: event.durationMs,
@@ -251,7 +255,9 @@ export function applyMakaSessionEventToTranscript(
     case 'tool_progress': {
       const tool = findToolEntry(state, event.toolUseId);
       if (tool) {
-        tool.progress.push(typeof event.chunk === 'string' ? event.chunk : `[${event.chunk.kind}] ${event.chunk.text}`);
+        tool.progress.append(
+          typeof event.chunk === 'string' ? event.chunk : `[${event.chunk.kind}] ${event.chunk.text}`,
+        );
       }
       break;
     }
@@ -259,7 +265,7 @@ export function applyMakaSessionEventToTranscript(
     case 'tool_output_delta': {
       const tool = findToolEntry(state, event.toolUseId);
       if (tool) {
-        tool.outputDeltas.push({
+        tool.outputDeltas.append({
           seq: event.seq,
           stream: event.stream,
           chunk: event.chunk,
@@ -372,8 +378,8 @@ function toolActivityToTranscriptEntry(item: ToolActivityItem): MakaPiTranscript
     toolName: item.toolName,
     ...(item.displayName ? { title: item.displayName } : {}),
     input: item.args,
-    progress: [],
-    outputDeltas: [],
+    progress: createProgressBuffer(),
+    outputDeltas: createOutputBuffer(),
     ...(item.result ? { result: item.result } : {}),
     ...(output ? { output } : {}),
     ...(item.durationMs !== undefined ? { durationMs: item.durationMs } : {}),
@@ -580,8 +586,8 @@ function transcriptEntrySignature(
         entry.status,
         entry.durationMs ?? '',
         entry.title ?? entry.toolName,
-        entry.progress.length,
-        entry.outputDeltas.length,
+        entry.progress.version,
+        entry.outputDeltas.version,
         entry.output?.length ?? '',
         entry.result ? entry.result.kind : '',
       ].join('|');
@@ -648,6 +654,26 @@ function findToolEntry(state: MakaPiTranscriptState, toolUseId: string): MakaPiT
   return [...state.entries]
     .reverse()
     .find((entry): entry is MakaPiToolEntry => entry.kind === 'tool' && entry.toolUseId === toolUseId);
+}
+
+function createProgressBuffer(): BoundedChunkBuffer<string> {
+  return new BoundedChunkBuffer({
+    maxChars: LIVE_TOOL_BUFFER_MAX_CHARS,
+    maxChunks: LIVE_TOOL_BUFFER_MAX_CHUNKS,
+    textOf: (chunk) => chunk,
+    withText: (_chunk, text) => text,
+  });
+}
+
+function createOutputBuffer(): BoundedChunkBuffer<MakaPiToolOutputDelta> {
+  return new BoundedChunkBuffer({
+    maxChars: LIVE_TOOL_BUFFER_MAX_CHARS,
+    maxChunks: LIVE_TOOL_BUFFER_MAX_CHUNKS,
+    textOf: (delta) => delta.chunk,
+    withText: (delta, chunk) => ({ ...delta, chunk }),
+    compare: (left, right) => left.seq - right.seq,
+    same: (left, right) => left.seq === right.seq,
+  });
 }
 
 function renderTextBlock(
@@ -719,4 +745,3 @@ function permissionRequestSummary(request: PermissionRequestEvent): string {
   }
   return limitText(formatUnknown(request.args), 600);
 }
-


### PR DESCRIPTION
## Summary

Bound the Maka TUI's transient tool progress and stdout/stderr buffers by both retained characters and retained chunks, while keeping the newest output visible.

## Why

Long-running tools could append `tool_progress` and `tool_output_delta` chunks without limit. The TUI then retained and reprocessed the entire live stream on every render, so memory use and refresh cost grew with command output.

Refs #549

## Scope

Changed:

- Add a CLI-local bounded tail buffer with 64 KiB and 512-chunk limits.
- Apply it independently to tool progress and stdout/stderr deltas.
- Preserve delta ordering and de-duplication by sequence number, including replays older than the retained tail.
- Release discarded backing references immediately and avoid splitting UTF-16 surrogate pairs at the trim boundary.
- Ignore empty progress and unredacted output events while preserving empty redacted markers.
- Show the exact number of truncated earlier characters in expanded tool output.
- Key transcript render memoization by buffer version so rendering continues after the retained chunk count stabilizes.
- Add regression coverage for character limits, chunk limits, newest-tail retention, truncation counts, sequence replay, Unicode boundaries, empty events, and render-cache invalidation.

Not included:

- Runtime event, persistence, model-context, or final `tool_result` changes.
- `NO_COLOR`, statusline, or non-interactive CLI work.

## Verification

- `npm run -w maka-agent test` — 220 tests passed.
- `npm run typecheck` — all workspaces passed.
- `npm run build` — all workspaces built successfully.
- `git diff --check main...HEAD` — passed.

## User-facing impact

Extremely verbose live tool output now retains the newest 64 KiB / 512 chunks per stream buffer. Expanded tool cards show when and how much earlier live output was truncated. Normal-sized output is unchanged.

No docs, changelog, migration, or breaking API changes are required.

## Reviewer notes

Please focus on:

- Tail-buffer character and chunk invariants.
- Out-of-order / duplicate `tool_output_delta` handling.
- Render-cache invalidation once buffer length remains constant.
- The boundary between transient TUI state and durable/final tool results.

Rollback is a single revert of this PR's squash commit.

Screenshots are not included because the new marker only appears after synthetic overflow; deterministic transcript tests cover the rendered contract.

## Checklist

- [x] Scope matches the PR title and excludes unrelated changes
- [x] Verification lists commands/results
- [x] User-facing impact and absence of docs, changelog, migrations, and breaking changes are noted
- [x] Risk, rollback, and review focus are documented
- [x] Screenshot omission is explained
