### PR TITLE
fix(headless): enforce prompt acceptance safety gates

### DIFF
--- a/packages/headless/harbor/run-prompt-optimization.mjs
+++ b/packages/headless/harbor/run-prompt-optimization.mjs
@@ -181,6 +181,7 @@ async function main() {
   // validation this runner exists to perform.
   const rounds = envPosInt('MAKA_PROMPT_ROUNDS', promptProfile.rounds);
   const baselineRuns = envInt('MAKA_PROMPT_BASELINE_RUNS', promptProfile.baselineRuns);
+  const zScore = envNum('MAKA_PROMPT_Z_SCORE', 1.96);
   const heldInCount = envInt('MAKA_PROMPT_HELD_IN', promptProfile.heldInCount);
   const heldOutCount = envInt('MAKA_PROMPT_HELD_OUT', promptProfile.heldOutCount);
   const runId = process.env.MAKA_PROMPT_RUN_ID || `prompt-opt-${Date.now()}`;
@@ -314,6 +315,7 @@ async function main() {
       model,
       rounds,
       baselineRuns,
+      zScore,
       costCeilingUsd,
       maxConcurrency,
       maxInfraFailureRate,
@@ -369,6 +371,7 @@ async function main() {
     runId,
     rounds,
     baselineRuns,
+    zScore,
     gitCwdPath: promptRepoDir,
     agentCwdPath,
     programPath,

--- a/packages/headless/src/__tests__/harbor-adapter.test.ts
+++ b/packages/headless/src/__tests__/harbor-adapter.test.ts
@@ -217,6 +217,9 @@ describe('Harbor adapter contract', () => {
     assert.match(source, /const keyFile = envPath\('MAKA_PROMPT_KEY_FILE', join\(localEvalRoot, '\.local-secrets', 'deepseek-key'\)\);/);
     assert.match(source, /MAKA_PROMPT_INITIAL_SYSTEM_PROMPT_FILE/);
     assert.match(source, /const maxConcurrency = envPosInt\('MAKA_PROMPT_MAX_CONCURRENCY', defaultMaxConcurrency\(\)\);/);
+    assert.match(source, /const zScore = envNum\('MAKA_PROMPT_Z_SCORE', 1\.96\);/);
+    assert.match(source, /buildPromptOptimizationRunManifest\(\{[\s\S]*?\n      zScore,/);
+    assert.match(source, /runPromptOptimizationRun\(\{[\s\S]*?\n    zScore,/);
     // The secret travels as a file path only — never a raw key on argv/env here.
     assert.doesNotMatch(source, /DEEPSEEK_API_KEY[^_]/);
   });

--- a/packages/headless/src/__tests__/prompt-optimization-loop.test.ts
+++ b/packages/headless/src/__tests__/prompt-optimization-loop.test.ts
@@ -3,9 +3,32 @@ import { readFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { describe, test } from 'node:test';
 import { readFixedPromptWal } from '../fixed-prompt-controller.js';
+import { promptAcceptanceNoiseBand } from '../prompt-acceptance-policy.js';
 import { execFileAsync, evidenceRefsFor, makeTasks, runLoop, taskIndex, withHarness, type MetaAgentPromptInput } from './helpers/prompt-optimization-loop-harness.js';
 
 describe('runPromptOptimizationLoop', () => {
+  test('defaults the acceptance noise band to a 1.96 z-score', async () => {
+    await withHarness(async (harness) => {
+      const result = await runLoop(harness, {
+        heldInTasks: makeTasks('hin', 4),
+        heldOutTasks: makeTasks('hout', 2),
+        rewardFor: (_roundId, taskId) => taskIndex(taskId) % 2,
+        rounds: 1,
+        baselineRuns: 1,
+      });
+
+      assert.equal(
+        result.baseline.heldIn.noiseBand,
+        promptAcceptanceNoiseBand({
+          sampleSize: 4,
+          passRate: 0.5,
+          baselineRunCount: 1,
+          zScore: 1.96,
+        }),
+      );
+    });
+  });
+
   test('keeps an improving candidate, discards a regressing one, and reports a passing smoke', async () => {
     await withHarness(async (harness) => {
       const heldInTasks = makeTasks('hin', 20);

--- a/packages/headless/src/__tests__/prompt-optimization-manifest.test.ts
+++ b/packages/headless/src/__tests__/prompt-optimization-manifest.test.ts
@@ -180,6 +180,15 @@ describe('prompt optimization run manifest', () => {
     assert.notEqual(full.fingerprint, pilot.fingerprint);
   });
 
+  test('records the z-score in the resume fingerprint', () => {
+    const narrow = buildManifest('sha256:task-source', [], 'pilot', 1, 1);
+    const standard = buildManifest('sha256:task-source', [], 'pilot', 1, 1.96);
+
+    assert.equal('zScore' in narrow, true);
+    assert.equal('zScore' in standard, true);
+    assert.notEqual(standard.fingerprint, narrow.fingerprint);
+  });
+
   test('does not record an always-empty dropped held-in no-pattern field', () => {
     const manifest = buildManifest('sha256:task-source', []);
     assert.equal('droppedHeldInNoPatternTaskIds' in manifest, false);
@@ -191,6 +200,7 @@ function buildManifest(
   heldInTasks: FixedPromptTask[],
   profile: 'pilot' | 'full' = 'pilot',
   costCeilingUsd = 1,
+  zScore = 1.96,
 ) {
   return buildPromptOptimizationRunManifest({
     runId: 'rsi-test',
@@ -200,6 +210,7 @@ function buildManifest(
     model: 'deepseek/deepseek-v4-flash',
     rounds: 1,
     baselineRuns: 1,
+    zScore,
     costCeilingUsd,
     maxConcurrency: 1,
     maxInfraFailureRate: null,

--- a/packages/headless/src/__tests__/prompt-structural-smoke.test.ts
+++ b/packages/headless/src/__tests__/prompt-structural-smoke.test.ts
@@ -64,6 +64,7 @@ describe('prompt structural smoke report', () => {
       'minimum_rounds_not_met',
       'cost_ceiling_exceeded',
       'plumbing_failures_present',
+      'reward_hack_quarantine_present',
     ]);
     assert.equal(report.observedRounds, 9);
     assert.equal(report.totalCostUsd, 37);
@@ -227,7 +228,7 @@ describe('prompt structural smoke report', () => {
     assert.deepEqual(report.failures, []);
   });
 
-  test('reports reward-hack scan quarantine without failing smoke', () => {
+  test('fails when reward-hack scan quarantine is present', () => {
     const events: FixedPromptWalEvent[] = [];
     for (let index = 1; index <= 10; index += 1) {
       const roundId = `round-${index}`;
@@ -245,12 +246,12 @@ describe('prompt structural smoke report', () => {
       costCeilingUsd: 30,
     });
 
-    assert.equal(report.status, 'pass');
+    assert.equal(report.status, 'fail');
     assert.equal(report.quarantineCount, 10);
-    assert.deepEqual(report.failures, []);
+    assert.deepEqual(report.failures, ['reward_hack_quarantine_present']);
   });
 
-  test('reports unknown reward-hack scan decisions without failing smoke', () => {
+  test('fails closed on unknown reward-hack scan decisions', () => {
     const events: FixedPromptWalEvent[] = [];
     for (let index = 1; index <= 10; index += 1) {
       const roundId = `round-${index}`;
@@ -267,12 +268,12 @@ describe('prompt structural smoke report', () => {
       costCeilingUsd: 30,
     });
 
-    assert.equal(report.status, 'pass');
+    assert.equal(report.status, 'fail');
     assert.equal(report.quarantineCount, 10);
-    assert.deepEqual(report.failures, []);
+    assert.deepEqual(report.failures, ['reward_hack_quarantine_present']);
   });
 
-  test('reports null reward-hack scan evidence without failing smoke', () => {
+  test('fails closed on null reward-hack scan evidence', () => {
     const events: FixedPromptWalEvent[] = [];
     for (let index = 1; index <= 10; index += 1) {
       const roundId = `round-${index}`;
@@ -295,9 +296,9 @@ describe('prompt structural smoke report', () => {
       costCeilingUsd: 30,
     });
 
-    assert.equal(report.status, 'pass');
+    assert.equal(report.status, 'fail');
     assert.equal(report.quarantineCount, 10);
-    assert.deepEqual(report.failures, []);
+    assert.deepEqual(report.failures, ['reward_hack_quarantine_present']);
   });
 
   test('fails when task evidence is appended after decision rounds', () => {

--- a/packages/headless/src/prompt-optimization-loop.ts
+++ b/packages/headless/src/prompt-optimization-loop.ts
@@ -166,6 +166,7 @@ export async function runPromptOptimizationLoop(
   const now = input.now ?? Date.now;
   const newId = input.newId ?? randomUUID;
   const baselineRunCount = input.baselineRuns ?? 3;
+  const zScore = input.zScore ?? 1.96;
   // Fail loud on out-of-contract numbers. The CLI env parser guards env values,
   // but this public API is callable directly, so the invariants live here too: a
   // NaN/fraction/0 would otherwise slip past a `< 1` or `>= ceiling` comparison
@@ -174,7 +175,7 @@ export async function runPromptOptimizationLoop(
   // structural smoke (minimumRounds 0), and a NaN cost ceiling never trips.
   assertPositiveInt('rounds', input.rounds);
   assertPositiveInt('baselineRuns', baselineRunCount);
-  if (input.zScore !== undefined) assertFinitePositive('zScore', input.zScore);
+  assertFinitePositive('zScore', zScore);
   if (input.minStableHeldInTasks !== undefined) {
     assertPositiveInt('minStableHeldInTasks', input.minStableHeldInTasks);
   }
@@ -406,7 +407,7 @@ export async function runPromptOptimizationLoop(
     heldInTaskIds: stableHeldInTaskIds,
     heldOutTaskIds: stableHeldOutTaskIds,
     baselineRuns: baselineRunsData,
-    ...(input.zScore !== undefined ? { zScore: input.zScore } : {}),
+    zScore,
   });
 
   const originalHeldOutEvents = stableHeldOut(baselineRunsData[0]!.heldOutEvents);

--- a/packages/headless/src/prompt-optimization-manifest.ts
+++ b/packages/headless/src/prompt-optimization-manifest.ts
@@ -21,6 +21,7 @@ export interface PromptOptimizationRunManifest {
   model: string;
   rounds: number;
   baselineRuns: number;
+  zScore: number;
   costCeilingUsd: number | undefined;
   maxConcurrency: number | null;
   maxInfraFailureRate: number | null;
@@ -46,6 +47,7 @@ export interface PromptOptimizationRunManifestInput {
   model: string;
   rounds: number;
   baselineRuns: number;
+  zScore: number;
   costCeilingUsd?: number;
   maxConcurrency?: number;
   maxInfraFailureRate?: number | null;
@@ -81,6 +83,7 @@ export function buildPromptOptimizationRunManifest(
     model: input.model,
     rounds: input.rounds,
     baselineRuns: input.baselineRuns,
+    zScore: input.zScore,
     costCeilingUsd: input.costCeilingUsd,
     maxConcurrency: input.maxConcurrency ?? null,
     maxInfraFailureRate: input.maxInfraFailureRate ?? null,

--- a/packages/headless/src/prompt-structural-smoke.ts
+++ b/packages/headless/src/prompt-structural-smoke.ts
@@ -82,6 +82,7 @@ export function promptStructuralSmokeReport(
   if (taskEvents.some((event) => event.type === 'task_plumbing_failed')) {
     failures.push('plumbing_failures_present');
   }
+  if (quarantineCount > 0) failures.push('reward_hack_quarantine_present');
   if (roundsWithoutRsiAttribution.length > 0) failures.push('rsi_attribution_missing');
   if (roundsWithMalformedRsiAttribution.length > 0) failures.push('rsi_attribution_malformed');
   if (roundsWithOutOfScopeRsiAttribution.length > 0) failures.push('rsi_attribution_task_scope_invalid');


### PR DESCRIPTION
## Summary

- Wire a non-zero z-score through prompt-optimization acceptance configuration and resume-safe run metadata.
- Make structural smoke fail when reward-hack quarantine evidence is present.
- Add regression coverage for both safety gates.

## Why

Later RSI runs could silently use a zero noise band, while structural smoke could still pass runs containing reward-hack quarantines. Both paths made a successful run look more trustworthy than its evidence supported.

Refs #619

## Scope

Changed:

- Prompt-optimization z-score defaults, runner wiring, and manifest coverage.
- Structural smoke quarantine failure handling and focused tests.

Not included:

- Powered keep-profile design, addressability filtering, audit-schema changes, failure-signature clustering, or paid benchmark runs.

## Verification

- `npm run -w @maka/headless test`
- `npm run -w @maka/headless typecheck`

## User-facing impact

None. This tightens headless benchmark acceptance and smoke validation only.

## Reviewer notes

Review the default/override precedence for z-score and the resume-manifest compatibility boundary. No provider credentials or Harbor benchmark spend are required.

## Checklist

- [x] Scope matches the PR title and excludes unrelated changes
- [x] Verification lists commands/results
- [x] User-facing impact and breaking changes are marked none
- [x] Risk and review focus are called out
- [x] UI evidence is not applicable
