### PR TITLE
fix(cli): keep background task cards truthful

### DIFF
--- a/packages/cli/src/__tests__/pi-transcript.test.ts
+++ b/packages/cli/src/__tests__/pi-transcript.test.ts
@@ -5,6 +5,7 @@ import type { SessionEvent, ToolResultContent } from '@maka/core/events';
 import type { StoredMessage } from '@maka/core/session';
 import {
   appendUserPrompt,
+  applyDetachedShellRunToTranscript,
   applyMakaSessionEventToTranscript,
   applyShellRunUpdateToTranscript,
   createMakaPiTranscriptState,
@@ -666,6 +667,23 @@ describe('Maka Pi TUI transcript', () => {
     const rendered = renderMakaPiTranscript(state, meta(), 100).map(stripAnsi).join('\n');
     assert.match(rendered, /running 12s/);
     assert.match(rendered, /Ask Maka to stop this task/);
+  });
+
+  test('describes a detached background Bash card by ownership, not lifecycle', () => {
+    const state = createMakaPiTranscriptState();
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_start', toolUseId: 'bash-bg', toolName: 'Bash',
+      args: { command: 'build' },
+    }));
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_result', toolUseId: 'bash-bg', isError: false,
+      content: shellRun({ stdout: '', stderr: '' }),
+    }));
+    applyDetachedShellRunToTranscript(state, 'bash-bg', shellRun({ stdout: '', stderr: '' }));
+
+    const rendered = renderMakaPiTranscript(state, meta(), 100).map(stripAnsi).join('\n');
+    assert.match(rendered, /owned by source session/);
+    assert.doesNotMatch(rendered, /continues in source session/);
   });
 
   test('folds a background-task Read result into its parent Bash card', () => {

--- a/packages/cli/src/__tests__/pi-transcript.test.ts
+++ b/packages/cli/src/__tests__/pi-transcript.test.ts
@@ -1765,6 +1765,26 @@ describe('transcript entry render memoization', () => {
     assert.match(after, /AAAA/);
     assert.doesNotMatch(after, /BBBB/);
   });
+
+  test('re-renders a ShellRun when equal-length output changes at the same timestamp', () => {
+    const state = createMakaPiTranscriptState();
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_start', toolUseId: 'bash-bg', toolName: 'Bash', args: { command: 'build' },
+    }));
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_result', toolUseId: 'bash-bg', isError: false,
+      content: shellRun({ stdout: 'AAAA', updatedAt: 3_000, latestOutputStream: 'stdout' }),
+    }));
+    const before = renderMakaPiTranscript(state, meta(), 100).map(stripAnsi).join('\n');
+    assert.match(before, /AAAA/);
+
+    applyShellRunUpdateToTranscript(state, 'bash-bg', shellRun({
+      stdout: 'BBBB', updatedAt: 3_000, latestOutputStream: 'stdout',
+    }));
+    const after = renderMakaPiTranscript(state, meta(), 100).map(stripAnsi).join('\n');
+    assert.match(after, /BBBB/);
+    assert.doesNotMatch(after, /AAAA/);
+  });
 });
 
 function meta() {

--- a/packages/cli/src/__tests__/pi-transcript.test.ts
+++ b/packages/cli/src/__tests__/pi-transcript.test.ts
@@ -1743,6 +1743,28 @@ describe('transcript entry render memoization', () => {
     assert.match(finalized, /BBBB/);
     assert.doesNotMatch(finalized, /AAAA/);
   });
+
+  test('re-renders a ShellRun when only the latest output stream changes', () => {
+    const state = createMakaPiTranscriptState();
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_start', toolUseId: 'bash-bg', toolName: 'Bash', args: { command: 'build' },
+    }));
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_result', toolUseId: 'bash-bg', isError: false,
+      content: shellRun({
+        stdout: 'AAAA', stderr: 'BBBB', updatedAt: 3_000, latestOutputStream: 'stderr',
+      }),
+    }));
+    const before = renderMakaPiTranscript(state, meta(), 100).map(stripAnsi).join('\n');
+    assert.match(before, /BBBB/);
+
+    applyShellRunUpdateToTranscript(state, 'bash-bg', shellRun({
+      stdout: 'AAAA', stderr: 'BBBB', updatedAt: 3_000, latestOutputStream: 'stdout',
+    }));
+    const after = renderMakaPiTranscript(state, meta(), 100).map(stripAnsi).join('\n');
+    assert.match(after, /AAAA/);
+    assert.doesNotMatch(after, /BBBB/);
+  });
 });
 
 function meta() {

--- a/packages/cli/src/__tests__/pi-transcript.test.ts
+++ b/packages/cli/src/__tests__/pi-transcript.test.ts
@@ -1,13 +1,15 @@
 import assert from 'node:assert/strict';
 import { describe, test } from 'node:test';
 import { visibleWidth } from '@earendil-works/pi-tui';
-import type { SessionEvent } from '@maka/core/events';
+import type { SessionEvent, ToolResultContent } from '@maka/core/events';
 import type { StoredMessage } from '@maka/core/session';
 import {
   appendUserPrompt,
   applyMakaSessionEventToTranscript,
+  applyShellRunUpdateToTranscript,
   createMakaPiTranscriptState,
   renderMakaPiTranscript,
+  refreshRunningShellRunElapsed,
   replaceTranscriptWithStoredMessages,
   submitCompactToTranscript,
   submitPromptToTranscript,
@@ -237,6 +239,56 @@ describe('Maka Pi TUI transcript', () => {
       'We decided to keep the TUI small.',
     );
     assert.equal(state.entries[3]?.kind === 'tool' ? state.entries[3].output : '', 'README contents');
+  });
+
+  test('folds stored background-task polling into its parent Bash card on resume', () => {
+    const state = createMakaPiTranscriptState();
+    const ref = 'maka://runtime/background-tasks/bg-1';
+
+    replaceTranscriptWithStoredMessages(state, [
+      {
+        type: 'tool_call', id: 'bash-bg', turnId: 'turn-1', ts: 1,
+        toolName: 'Bash', args: { command: 'npm test' },
+      },
+      {
+        type: 'tool_result', id: 'bash-result', turnId: 'turn-1', ts: 2,
+        toolUseId: 'bash-bg', isError: false,
+        content: shellRun({ ref, status: 'running', stdout: 'starting\n', updatedAt: 2_000 }),
+      },
+      {
+        type: 'tool_call', id: 'read-bg', turnId: 'turn-1', ts: 3,
+        toolName: 'Read', args: { path: ref },
+      },
+      {
+        type: 'tool_result', id: 'read-result', turnId: 'turn-1', ts: 4,
+        toolUseId: 'read-bg', isError: false,
+        content: shellRun({ ref, status: 'completed', stdout: 'starting\ndone\n', completedAt: 5_000, updatedAt: 5_000, exitCode: 0 }),
+      },
+    ] satisfies StoredMessage[]);
+
+    const tools = state.entries.filter((entry) => entry.kind === 'tool');
+    assert.equal(tools.length, 1);
+    assert.equal(tools[0]?.toolUseId, 'bash-bg');
+    assert.equal(tools[0]?.status, 'done');
+    assert.equal(tools[0]?.result?.kind === 'shell_run' ? tools[0].result.stdout : '', 'starting\ndone\n');
+  });
+
+  test('restores the total elapsed time of a settled background Bash card', () => {
+    const state = createMakaPiTranscriptState();
+    replaceTranscriptWithStoredMessages(state, [
+      {
+        type: 'tool_call', id: 'bash-bg', turnId: 'turn-1', ts: 1,
+        toolName: 'Bash', args: { command: 'npm test' },
+      },
+      {
+        type: 'tool_result', id: 'bash-result', turnId: 'turn-1', ts: 2,
+        toolUseId: 'bash-bg', isError: false,
+        content: shellRun({ status: 'completed', startedAt: 1_000, updatedAt: 6_000, completedAt: 6_000, exitCode: 0 }),
+      },
+    ] satisfies StoredMessage[]);
+
+    const rendered = renderMakaPiTranscript(state, meta(), 100).map(stripAnsi).join('\n');
+    assert.match(rendered, /Tool Bash \$ npm test done 5s/);
   });
 
   test('rebuilds automatic context compaction notes from stored session messages', () => {
@@ -572,6 +624,206 @@ describe('Maka Pi TUI transcript', () => {
     assert.match(compact, /Tool Bash \$ npm run build running/);
     assert.match(compact, /step two \(Ctrl\+O\)/);
     assert.doesNotMatch(compact, /step one/);
+  });
+
+  test('keeps a yielded background Bash card running until the process settles', () => {
+    const state = createMakaPiTranscriptState();
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_start', toolUseId: 'bash-bg', toolName: 'Bash',
+      args: { command: 'sleep 30' },
+    }));
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_result', toolUseId: 'bash-bg', isError: false,
+      content: {
+        kind: 'shell_run', ref: 'maka://runtime/background-tasks/bg-1',
+        status: 'running', cwd: '/repo', cmd: 'sleep 30',
+        startedAt: 1_000, updatedAt: 11_000,
+        stdout: '', stderr: '', stdoutTruncated: false, stderrTruncated: false,
+      },
+      durationMs: 10_000,
+    }));
+
+    const tool = state.entries.find((entry) => entry.kind === 'tool');
+    assert.equal(tool?.kind === 'tool' ? tool.status : undefined, 'running');
+    const rendered = renderMakaPiTranscript(state, meta(), 100).map(stripAnsi).join('\n');
+    assert.match(rendered, /Tool Bash \$ sleep 30 running/);
+    assert.doesNotMatch(rendered, /Tool Bash .* done/);
+    assert.equal(rendered.split('$ sleep 30').length - 1, 1);
+  });
+
+  test('shows live elapsed time and stop guidance on a running background Bash card', () => {
+    const state = createMakaPiTranscriptState();
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_start', toolUseId: 'bash-bg', toolName: 'Bash',
+      args: { command: 'sleep 30' },
+    }));
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_result', toolUseId: 'bash-bg', isError: false,
+      content: shellRun({ startedAt: 1_000, updatedAt: 2_000 }),
+    }));
+
+    assert.equal(refreshRunningShellRunElapsed(state, 13_500), true);
+    const rendered = renderMakaPiTranscript(state, meta(), 100).map(stripAnsi).join('\n');
+    assert.match(rendered, /running 12s/);
+    assert.match(rendered, /Ask Maka to stop this task/);
+  });
+
+  test('folds a background-task Read result into its parent Bash card', () => {
+    const state = createMakaPiTranscriptState();
+    const ref = 'maka://runtime/background-tasks/bg-1';
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_start', toolUseId: 'bash-bg', toolName: 'Bash',
+      args: { command: 'npm test' },
+    }));
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_result', toolUseId: 'bash-bg', isError: false,
+      content: shellRun({ ref, status: 'running', stdout: 'starting\n', updatedAt: 2_000 }),
+    }));
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_start', toolUseId: 'read-bg', toolName: 'Read', args: { path: ref },
+    }));
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_result', toolUseId: 'read-bg', isError: false,
+      content: shellRun({ ref, status: 'running', stdout: 'starting\nstill running\n', updatedAt: 5_000 }),
+    }));
+
+    const tools = state.entries.filter((entry) => entry.kind === 'tool');
+    assert.equal(tools.length, 1);
+    assert.equal(tools[0]?.toolUseId, 'bash-bg');
+    assert.equal(tools[0]?.result?.kind === 'shell_run' ? tools[0].result.stdout : '', 'starting\nstill running\n');
+    const rendered = renderMakaPiTranscript(state, meta(), 100).map(stripAnsi).join('\n');
+    assert.doesNotMatch(rendered, /Tool Read/);
+    assert.match(rendered, /still running/);
+  });
+
+  test('shows polled background output instead of the stale pre-yield live delta', () => {
+    const state = createMakaPiTranscriptState();
+    const ref = 'maka://runtime/background-tasks/bg-1';
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_start', toolUseId: 'bash-bg', toolName: 'Bash', args: { command: 'build' },
+    }));
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_output_delta', toolUseId: 'bash-bg', seq: 1,
+      stream: 'stdout', chunk: 'starting\n', redacted: false,
+    }));
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_result', toolUseId: 'bash-bg', isError: false,
+      content: shellRun({ ref, stdout: '', updatedAt: 2_000 }),
+    }));
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_start', toolUseId: 'read-bg', toolName: 'Read', args: { path: ref },
+    }));
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_result', toolUseId: 'read-bg', isError: false,
+      content: shellRun({ ref, stdout: 'starting\n50%\n', updatedAt: 3_000 }),
+    }));
+
+    const rendered = renderMakaPiTranscript(state, meta(), 100).map(stripAnsi).join('\n');
+    assert.match(rendered, /50%/);
+  });
+
+  test('re-renders a background Bash card when polling replaces output with the same length', () => {
+    const state = createMakaPiTranscriptState();
+    const ref = 'maka://runtime/background-tasks/bg-1';
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_start', toolUseId: 'bash-bg', toolName: 'Bash', args: { command: 'watch' },
+    }));
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_result', toolUseId: 'bash-bg', isError: false,
+      content: shellRun({ ref, stdout: 'aaaa\n', updatedAt: 2_000 }),
+    }));
+    const before = renderMakaPiTranscript(state, meta(), 100).map(stripAnsi).join('\n');
+    assert.match(before, /aaaa/);
+
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_start', toolUseId: 'read-bg', toolName: 'Read', args: { path: ref },
+    }));
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_result', toolUseId: 'read-bg', isError: false,
+      content: shellRun({ ref, stdout: 'bbbb\n', updatedAt: 3_000 }),
+    }));
+    const after = renderMakaPiTranscript(state, meta(), 100).map(stripAnsi).join('\n');
+    assert.match(after, /bbbb/);
+    assert.doesNotMatch(after, /aaaa/);
+  });
+
+  test('keeps background-task Read cards when their parent Bash card is missing', () => {
+    const state = createMakaPiTranscriptState();
+    const ref = 'maka://runtime/background-tasks/bg-1';
+    for (const [toolUseId, stdout] of [['read-1', 'first\n'], ['read-2', 'second\n']] as const) {
+      applyMakaSessionEventToTranscript(state, event({
+        type: 'tool_start', toolUseId, toolName: 'Read', args: { path: ref },
+      }));
+      applyMakaSessionEventToTranscript(state, event({
+        type: 'tool_result', toolUseId, isError: false,
+        content: shellRun({ ref, status: 'running', stdout }),
+      }));
+    }
+
+    const tools = state.entries.filter((entry) => entry.kind === 'tool');
+    assert.equal(tools.length, 2);
+    assert.deepEqual(tools.map((tool) => tool.toolUseId), ['read-1', 'read-2']);
+  });
+
+  test('folds StopBackgroundTask into its parent Bash card as aborted', () => {
+    const state = createMakaPiTranscriptState();
+    const ref = 'maka://runtime/background-tasks/bg-1';
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_start', toolUseId: 'bash-bg', toolName: 'Bash', args: { command: 'sleep 30' },
+    }));
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_result', toolUseId: 'bash-bg', isError: false,
+      content: shellRun({ ref, status: 'running' }),
+    }));
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_start', toolUseId: 'stop-bg', toolName: 'StopBackgroundTask', args: { ref },
+    }));
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_result', toolUseId: 'stop-bg', isError: false,
+      content: shellRun({ ref, status: 'cancelled', completedAt: 8_000, exitCode: 130 }),
+    }));
+
+    const tools = state.entries.filter((entry) => entry.kind === 'tool');
+    assert.equal(tools.length, 1);
+    assert.equal(tools[0]?.status, 'aborted');
+    const rendered = renderMakaPiTranscript(state, meta(), 100).map(stripAnsi).join('\n');
+    assert.match(rendered, /Tool Bash \$ sleep 30 aborted/);
+    assert.doesNotMatch(rendered, /Tool StopBackgroundTask/);
+  });
+
+  test('applies a runtime-published terminal update directly to its parent Bash card', () => {
+    const state = createMakaPiTranscriptState();
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_start', toolUseId: 'bash-bg', toolName: 'Bash', args: { command: 'build' },
+    }));
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_result', toolUseId: 'bash-bg', isError: false,
+      content: shellRun({ status: 'running', updatedAt: 2_000 }),
+    }));
+
+    const applied = applyShellRunUpdateToTranscript(state, 'bash-bg', shellRun({
+      status: 'completed', stdout: 'done\n', updatedAt: 5_000, completedAt: 5_000, exitCode: 0,
+    }));
+
+    assert.equal(applied, true);
+    const rendered = renderMakaPiTranscript(state, meta(), 100).map(stripAnsi).join('\n');
+    assert.match(rendered, /Tool Bash \$ build done 4s/);
+    assert.match(rendered, /done/);
+  });
+
+  test('does not erase a runtime-published output update with an equal-time handoff result', () => {
+    const state = createMakaPiTranscriptState();
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_start', toolUseId: 'bash-bg', toolName: 'Bash', args: { command: 'build' },
+    }));
+    applyShellRunUpdateToTranscript(state, 'bash-bg', shellRun({ stdout: 'starting\n', updatedAt: 2_000 }));
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_result', toolUseId: 'bash-bg', isError: false,
+      content: shellRun({ stdout: '', updatedAt: 2_000 }),
+    }));
+
+    const tool = state.entries.find((entry) => entry.kind === 'tool');
+    assert.equal(tool?.kind === 'tool' && tool.result?.kind === 'shell_run' ? tool.result.stdout : '', 'starting\n');
   });
 
   test('summarizes Read results as a line/byte count and never replays file content', () => {
@@ -1477,6 +1729,18 @@ function terminalResult(stdout: string, stderr = '') {
     stdoutTruncated: false,
     stderrTruncated: false,
   } as const;
+}
+
+function shellRun(
+  overrides: Partial<Extract<ToolResultContent, { kind: 'shell_run' }>> = {},
+): Extract<ToolResultContent, { kind: 'shell_run' }> {
+  return {
+    kind: 'shell_run', ref: 'maka://runtime/background-tasks/bg-1',
+    status: 'running', cwd: '/repo', cmd: 'npm test',
+    startedAt: 1_000, updatedAt: 1_000,
+    stdout: '', stderr: '', stdoutTruncated: false, stderrTruncated: false,
+    ...overrides,
+  };
 }
 
 class RecordingDriver {

--- a/packages/cli/src/__tests__/pi-transcript.test.ts
+++ b/packages/cli/src/__tests__/pi-transcript.test.ts
@@ -722,6 +722,26 @@ describe('Maka Pi TUI transcript', () => {
     assert.match(rendered, /50%/);
   });
 
+  test('shows stdout as latest when it arrives after stderr', () => {
+    const state = createMakaPiTranscriptState();
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_start', toolUseId: 'bash-bg', toolName: 'Bash',
+      args: { command: 'build' },
+    }));
+    const result = Object.assign(shellRun({
+      stdout: '99%\n',
+      stderr: 'warning\n',
+      updatedAt: 3_000,
+    }), { latestOutputStream: 'stdout' as const });
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_result', toolUseId: 'bash-bg', isError: false, content: result,
+    }));
+
+    const rendered = renderMakaPiTranscript(state, meta(), 100).map(stripAnsi).join('\n');
+    assert.match(rendered, /99%/);
+    assert.doesNotMatch(rendered, /  warning \(Ctrl\+O\)/);
+  });
+
   test('re-renders a background Bash card when polling replaces output with the same length', () => {
     const state = createMakaPiTranscriptState();
     const ref = 'maka://runtime/background-tasks/bg-1';

--- a/packages/cli/src/__tests__/pi-tui-runner.test.ts
+++ b/packages/cli/src/__tests__/pi-tui-runner.test.ts
@@ -5,6 +5,7 @@ import { setTimeout as delay } from 'node:timers/promises';
 import { describe, test } from 'node:test';
 import { visibleWidth } from '@earendil-works/pi-tui';
 import type { PermissionMode, PermissionResponse, SessionEvent, SessionSummary, StoredMessage, ThinkingLevel } from '@maka/core';
+import type { ShellRunUpdate } from '@maka/runtime';
 import type { MakaSessionDriver, MakaSessionRewindResult, MakaSessionSwitchResult, RewindTarget } from '../session-driver.js';
 import { runMakaPiTui } from '../pi-tui-runner.js';
 import { BUSY_SPINNER_FRAMES } from '../tui-attention.js';
@@ -268,6 +269,40 @@ describe('Maka Pi TUI runner', () => {
         throw new Error('TUI did not close during test cleanup');
       }),
     ]);
+  });
+
+  test('renders a background ShellRun terminal update after the agent turn ends', async () => {
+    const terminal = new FakeTerminal();
+    const driver = new BackgroundShellRunDriver();
+    let listener: ((update: ShellRunUpdate) => void) | undefined;
+    let unsubscribed = false;
+    const run = runMakaPiTui({
+      title: 'Maka', driver, cwd: '/repo', model: 'claude-sonnet-4-5',
+      connectionSlug: 'claude-subscription', permissionMode: 'ask', terminal,
+      subscribeShellRunUpdates: (next) => {
+        listener = next;
+        return () => { listener = undefined; unsubscribed = true; };
+      },
+    });
+
+    terminal.input('run');
+    terminal.input('\r');
+    await waitFor(() => plainTerminalOutput(terminal.screenOutput()).includes('running'));
+    assert.ok(listener);
+    listener({
+      sessionId: 'session-1', sourceToolCallId: 'tool-bg',
+      result: {
+        kind: 'shell_run', ref: 'maka://runtime/background-tasks/bg-1',
+        status: 'completed', cwd: '/repo', cmd: 'build',
+        startedAt: 1_000, updatedAt: 5_000, completedAt: 5_000, exitCode: 0,
+        stdout: 'done\n', stderr: '', stdoutTruncated: false, stderrTruncated: false,
+      },
+    });
+    await waitFor(() => plainTerminalOutput(terminal.screenOutput()).includes('done 4s'));
+
+    exitMaka(terminal);
+    await run;
+    assert.equal(unsubscribed, true);
   });
 
   test('keeps tool expansion when kitty protocol reports the Ctrl-O release', async () => {
@@ -2817,6 +2852,26 @@ class ToolOutputDriver implements MakaSessionDriver {
   startNewSession(): void {}
   getSessionId(): string {
     return 'session-1';
+  }
+}
+
+class BackgroundShellRunDriver extends ToolOutputDriver {
+  override async *sendPrompt(_prompt: string): AsyncIterable<SessionEvent> {
+    yield {
+      type: 'tool_start', id: 'event-tool-start', turnId: 'turn-1', ts: 1,
+      toolUseId: 'tool-bg', toolName: 'Bash', args: { command: 'build' },
+    };
+    yield {
+      type: 'tool_result', id: 'event-tool-result', turnId: 'turn-1', ts: 2,
+      toolUseId: 'tool-bg', isError: false,
+      content: {
+        kind: 'shell_run', ref: 'maka://runtime/background-tasks/bg-1',
+        status: 'running', cwd: '/repo', cmd: 'build',
+        startedAt: 1_000, updatedAt: 2_000,
+        stdout: '', stderr: '', stdoutTruncated: false, stderrTruncated: false,
+      },
+    };
+    yield { type: 'complete', id: 'event-complete', turnId: 'turn-1', ts: 3, stopReason: 'end_turn' };
   }
 }
 

--- a/packages/cli/src/__tests__/pi-tui-runner.test.ts
+++ b/packages/cli/src/__tests__/pi-tui-runner.test.ts
@@ -1566,6 +1566,53 @@ describe('Maka Pi TUI runner', () => {
     ]);
   });
 
+  test('hydrates a resumed background Bash card from durable shell-run state', async () => {
+    const terminal = new FakeTerminal();
+    const ref = 'maka://runtime/background-tasks/bg-1';
+    const driver = new SlashCommandDriver(
+      [fakeSessionSummary('session-2', '/repo')],
+      new Map([
+        ['session-2', [
+          {
+            type: 'tool_call', id: 'tool-bg', turnId: 'turn-1', ts: 1,
+            toolName: 'Bash', args: { command: 'build' },
+          },
+          {
+            type: 'tool_result', id: 'result-bg', turnId: 'turn-1', ts: 2,
+            toolUseId: 'tool-bg', isError: false,
+            content: {
+              kind: 'shell_run', ref, status: 'running', cwd: '/repo', cmd: 'build',
+              startedAt: 1_000, updatedAt: 2_000,
+              stdout: 'starting\n', stderr: '', stdoutTruncated: false, stderrTruncated: false,
+            },
+          },
+        ] satisfies StoredMessage[]],
+      ]),
+    );
+    const reads: Array<{ sessionId: string; ref: string }> = [];
+    const run = runMakaPiTui({
+      title: 'Maka', driver, cwd: '/repo', model: 'claude-sonnet-4-5',
+      connectionSlug: 'claude-subscription', permissionMode: 'ask', terminal,
+      readShellRun: async (sessionId, requestedRef) => {
+        reads.push({ sessionId, ref: requestedRef });
+        return {
+          kind: 'shell_run', ref, status: 'completed', cwd: '/repo', cmd: 'build',
+          startedAt: 1_000, updatedAt: 5_000, completedAt: 5_000, exitCode: 0,
+          stdout: 'starting\ndone\n', stderr: '', stdoutTruncated: false, stderrTruncated: false,
+        };
+      },
+    });
+
+    terminal.input('/session session-2');
+    terminal.input('\r');
+
+    await waitFor(() => plainTerminalOutput(terminal.screenOutput()).includes('done 4s'));
+    assert.deepEqual(reads, [{ sessionId: 'session-2', ref }]);
+
+    exitMaka(terminal);
+    await run;
+  });
+
   test('shows only current-cwd sessions in the session picker', async () => {
     const terminal = new FakeTerminal();
     const driver = new SlashCommandDriver([

--- a/packages/cli/src/__tests__/pi-tui-runner.test.ts
+++ b/packages/cli/src/__tests__/pi-tui-runner.test.ts
@@ -1596,9 +1596,12 @@ describe('Maka Pi TUI runner', () => {
       readShellRun: async (sessionId, requestedRef) => {
         reads.push({ sessionId, ref: requestedRef });
         return {
-          kind: 'shell_run', ref, status: 'completed', cwd: '/repo', cmd: 'build',
-          startedAt: 1_000, updatedAt: 5_000, completedAt: 5_000, exitCode: 0,
-          stdout: 'starting\ndone\n', stderr: '', stdoutTruncated: false, stderrTruncated: false,
+          ownerSessionId: sessionId,
+          result: {
+            kind: 'shell_run', ref, status: 'completed', cwd: '/repo', cmd: 'build',
+            startedAt: 1_000, updatedAt: 5_000, completedAt: 5_000, exitCode: 0,
+            stdout: 'starting\ndone\n', stderr: '', stdoutTruncated: false, stderrTruncated: false,
+          },
         };
       },
     });
@@ -1997,6 +2000,54 @@ describe('Maka Pi TUI runner', () => {
         throw new Error('TUI did not close during test cleanup');
       }),
     ]);
+  });
+
+  test('marks an inherited running Bash card detached after rewind', async () => {
+    const terminal = new FakeTerminal();
+    const ref = 'maka://runtime/background-tasks/bg-1';
+    const branchMessages = [
+      {
+        type: 'tool_call', id: 'tool-bg', turnId: 'turn-1', ts: 1,
+        toolName: 'Bash', args: { command: 'build' },
+      },
+      {
+        type: 'tool_result', id: 'result-bg', turnId: 'turn-1', ts: 2,
+        toolUseId: 'tool-bg', isError: false,
+        content: {
+          kind: 'shell_run', ref, status: 'running', cwd: '/repo', cmd: 'build',
+          startedAt: 1_000, updatedAt: 2_000,
+          stdout: 'still running\n', stderr: '', stdoutTruncated: false, stderrTruncated: false,
+        },
+      },
+    ] satisfies StoredMessage[];
+    const driver = new RewindDriver(
+      [{ turnId: 'turn-2', label: 'second question' }],
+      branchMessages,
+      { ...fakeSessionSummary('session-branch'), parentSessionId: 'session-1' },
+    );
+    const run = runMakaPiTui({
+      title: 'Maka', driver, cwd: '/repo', model: 'claude-sonnet-4-5',
+      connectionSlug: 'claude-subscription', permissionMode: 'ask', terminal,
+      readShellRun: async () => ({
+        ownerSessionId: 'session-1',
+        result: {
+          kind: 'shell_run', ref, status: 'running', cwd: '/repo', cmd: 'build',
+          startedAt: 1_000, updatedAt: 3_000,
+          stdout: 'still running\n', stderr: '', stdoutTruncated: false, stderrTruncated: false,
+        },
+      }),
+    });
+
+    terminal.input('/rewind');
+    terminal.input('\r');
+    await waitFor(() => plainTerminalOutput(terminal.output()).includes('回到选定轮次'));
+    terminal.input('\r');
+
+    await waitFor(() => plainTerminalOutput(terminal.screenOutput()).includes('detached'));
+    assert.equal(plainTerminalOutput(terminal.screenOutput()).includes('Ask Maka to stop this task'), false);
+
+    exitMaka(terminal);
+    await run;
   });
 
   test('reports when /rewind has no earlier turns', async () => {
@@ -2931,7 +2982,7 @@ class SlashCommandDriver implements MakaSessionDriver {
   readonly sessionIds: string[] = [];
   readonly renames: string[] = [];
   startNewSessionCalls = 0;
-  private sessionId = 'session-1';
+  protected sessionId = 'session-1';
 
   constructor(
     private readonly sessions: SessionSummary[] = [fakeSessionSummary('session-2', '/repo')],
@@ -3332,6 +3383,7 @@ class RewindDriver extends SlashCommandDriver {
   constructor(
     private readonly targets: RewindTarget[],
     private readonly branchMessages: readonly StoredMessage[] = [],
+    private readonly branchSummary: SessionSummary = fakeSessionSummary('session-branch'),
   ) {
     super();
   }
@@ -3342,8 +3394,9 @@ class RewindDriver extends SlashCommandDriver {
 
   override async rewindToTurn(turnId: string): Promise<MakaSessionRewindResult> {
     this.rewound.push(turnId);
+    this.sessionId = this.branchSummary.id;
     return {
-      ...switchResult(fakeSessionSummary('session-branch'), [...this.branchMessages]),
+      ...switchResult(this.branchSummary, [...this.branchMessages]),
       prompt: `refilled: ${turnId}`,
     };
   }

--- a/packages/cli/src/__tests__/runtime-bootstrap.test.ts
+++ b/packages/cli/src/__tests__/runtime-bootstrap.test.ts
@@ -212,6 +212,42 @@ describe('Maka CLI runtime bootstrap', () => {
     });
   });
 
+  test('hydrates terminal ShellRun state without marking it observed by the agent', async () => {
+    await withWorkspace(async (workspaceRoot) => {
+      const connectionStore = createConnectionStore(workspaceRoot);
+      await connectionStore.create({
+        slug: 'local', name: 'Local Ollama', providerType: 'ollama', defaultModel: 'llama3.2',
+      });
+      const context = await createMakaCliRuntimeContext({ workspaceRoot, cwd: workspaceRoot });
+      try {
+        const bash = context.tools.find((tool) => tool.name === 'Bash');
+        assert.ok(bash);
+        const command = `${JSON.stringify(process.execPath)} -e "setTimeout(() => {}, 500)"`;
+        const started = await bash.impl(
+          { command, yield_time_ms: 250 },
+          {
+            sessionId: 'session-1', runId: 'run-1', turnId: 'turn-1',
+            cwd: workspaceRoot, toolCallId: 'tool-1',
+            abortSignal: new AbortController().signal, emitOutput: () => {},
+          },
+        ) as { ref?: string; status?: string };
+        assert.equal(started.status, 'running');
+        assert.ok(started.ref);
+
+        await new Promise((resolve) => setTimeout(resolve, 650));
+        const hydrated = await context.readShellRun('session-1', started.ref);
+        assert.equal(hydrated.result.status, 'completed');
+        const stored = await createShellRunStore(workspaceRoot).readShellRun(
+          'session-1',
+          backgroundTaskId(started.ref),
+        );
+        assert.equal(stored.observedAt, undefined);
+      } finally {
+        await context.close();
+      }
+    });
+  });
+
   test('passes the default context budget policy to ai-sdk backends', async () => {
     await withCleanContextBudgetEnv(async () => {
       await withWorkspace(async (workspaceRoot) => {

--- a/packages/cli/src/__tests__/runtime-bootstrap.test.ts
+++ b/packages/cli/src/__tests__/runtime-bootstrap.test.ts
@@ -171,6 +171,47 @@ describe('Maka CLI runtime bootstrap', () => {
     });
   });
 
+  test('resolves an inherited ShellRun through branch session lineage', async () => {
+    await withWorkspace(async (workspaceRoot) => {
+      const connectionStore = createConnectionStore(workspaceRoot);
+      await connectionStore.create({
+        slug: 'local', name: 'Local Ollama', providerType: 'ollama', defaultModel: 'llama3.2',
+      });
+      const context = await createMakaCliRuntimeContext({ workspaceRoot, cwd: workspaceRoot });
+      try {
+        const parent = await context.runtime.createSession({
+          cwd: workspaceRoot, backend: 'ai-sdk', llmConnectionSlug: 'local',
+          model: 'llama3.2', permissionMode: 'bypass', name: 'parent',
+        });
+        const runtimeDeps = (context.runtime as unknown as RuntimeWithPrivateDeps).deps;
+        const branch = await runtimeDeps.store.create({
+          cwd: workspaceRoot, backend: 'ai-sdk', llmConnectionSlug: 'local',
+          model: 'llama3.2', permissionMode: 'bypass', name: 'branch',
+          parentSessionId: parent.id,
+        });
+        const bash = context.tools.find((tool) => tool.name === 'Bash');
+        assert.ok(bash);
+        const command = `${JSON.stringify(process.execPath)} -e "setTimeout(() => {}, 5000)"`;
+        const started = await bash.impl(
+          { command, yield_time_ms: 250 },
+          {
+            sessionId: parent.id, runId: 'run-1', turnId: 'turn-1',
+            cwd: workspaceRoot, toolCallId: 'tool-1',
+            abortSignal: new AbortController().signal, emitOutput: () => {},
+          },
+        ) as { kind?: string; ref?: string; status?: string };
+        assert.equal(started.status, 'running');
+        assert.ok(started.ref);
+
+        const inherited = await context.readShellRun(branch.id, started.ref);
+        assert.equal(inherited.ownerSessionId, parent.id);
+        assert.equal(inherited.result.status, 'running');
+      } finally {
+        await context.close();
+      }
+    });
+  });
+
   test('passes the default context budget policy to ai-sdk backends', async () => {
     await withCleanContextBudgetEnv(async () => {
       await withWorkspace(async (workspaceRoot) => {

--- a/packages/cli/src/__tests__/runtime-bootstrap.test.ts
+++ b/packages/cli/src/__tests__/runtime-bootstrap.test.ts
@@ -5,7 +5,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, test } from 'node:test';
 import { createConnectionStore, createFileCredentialStore, createShellRunStore } from '@maka/storage';
-import { BackendRegistry, type AiSdkBackendInput, type SessionStore } from '@maka/runtime';
+import { BackendRegistry, type AiSdkBackendInput, type SessionStore, type ShellRunUpdate } from '@maka/runtime';
 import {
   createMakaCliRuntimeContext,
   getOrCreateCliClaudeDeviceId,
@@ -121,14 +121,51 @@ describe('Maka CLI runtime bootstrap', () => {
             abortSignal: new AbortController().signal,
             emitOutput: () => {},
           },
-        ) as { content?: string };
-        assert.match(detail.content ?? '', /stdout:\nstart/);
+        ) as { kind?: string; status?: string; stdout?: string };
+        assert.equal(detail.kind, 'shell_run');
+        assert.equal(detail.status, 'running');
+        assert.equal(detail.stdout, 'start');
 
         await context.close();
         const record = await createShellRunStore(workspaceRoot).readShellRun('session-1', backgroundTaskId(result.ref));
         assert.equal(record.status, 'cancelled');
         assert.equal(record.exitCode, 130);
       } finally {
+        await context.close();
+      }
+    });
+  });
+
+  test('publishes yielded ShellRun completion without a model resource read', async () => {
+    await withWorkspace(async (workspaceRoot) => {
+      const connectionStore = createConnectionStore(workspaceRoot);
+      await connectionStore.create({
+        slug: 'local', name: 'Local Ollama', providerType: 'ollama', defaultModel: 'llama3.2',
+      });
+      const context = await createMakaCliRuntimeContext({ workspaceRoot, cwd: workspaceRoot });
+      const updates: ShellRunUpdate[] = [];
+      const unsubscribe = context.subscribeShellRunUpdates((update) => updates.push(update));
+      try {
+        const bash = context.tools.find((tool) => tool.name === 'Bash');
+        assert.ok(bash);
+        const command = `${JSON.stringify(process.execPath)} -e "process.stdout.write('start'); setTimeout(() => process.stdout.write('done'), 500)"`;
+        const result = await bash.impl(
+          { command, yield_time_ms: 250 },
+          {
+            sessionId: 'session-1', runId: 'run-1', turnId: 'turn-1',
+            cwd: workspaceRoot, toolCallId: 'tool-1',
+            abortSignal: new AbortController().signal, emitOutput: () => {},
+          },
+        ) as { kind?: string; status?: string };
+        assert.equal(result.kind, 'shell_run');
+        assert.equal(result.status, 'running');
+
+        await new Promise((resolve) => setTimeout(resolve, 650));
+        const terminal = updates.find((update) => update.result.status === 'completed');
+        assert.equal(terminal?.sourceToolCallId, 'tool-1');
+        assert.equal(terminal?.result.stdout, 'startdone');
+      } finally {
+        unsubscribe();
         await context.close();
       }
     });

--- a/packages/cli/src/__tests__/shell-run-elapsed-ticker.test.ts
+++ b/packages/cli/src/__tests__/shell-run-elapsed-ticker.test.ts
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict';
 import { test } from 'node:test';
 import type { SessionEvent, ToolResultContent } from '@maka/core/events';
 import {
+  applyDetachedShellRunToTranscript,
   applyMakaSessionEventToTranscript,
   createMakaPiTranscriptState,
 } from '../pi-transcript.js';
@@ -41,6 +42,11 @@ test('runs the elapsed ticker only while a background Bash card is running', () 
   const tool = state.entries.find((entry) => entry.kind === 'tool');
   assert.equal(tool?.kind === 'tool' ? tool.durationMs : undefined, 5_500);
   assert.equal(renders, 1);
+
+  applyDetachedShellRunToTranscript(state, 'bash-bg', shellRun({ updatedAt: 6_500 }));
+  ticker.sync();
+  assert.equal(tick, undefined);
+  assert.equal(cancelled, 1);
 
   applyMakaSessionEventToTranscript(state, event({
     type: 'tool_result', toolUseId: 'bash-bg', isError: false,

--- a/packages/cli/src/__tests__/shell-run-elapsed-ticker.test.ts
+++ b/packages/cli/src/__tests__/shell-run-elapsed-ticker.test.ts
@@ -1,0 +1,68 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import type { SessionEvent, ToolResultContent } from '@maka/core/events';
+import {
+  applyMakaSessionEventToTranscript,
+  createMakaPiTranscriptState,
+} from '../pi-transcript.js';
+import { createShellRunElapsedTicker } from '../shell-run-elapsed-ticker.js';
+
+test('runs the elapsed ticker only while a background Bash card is running', () => {
+  const state = createMakaPiTranscriptState();
+  let now = 1_000;
+  let tick: (() => void) | undefined;
+  let cancelled = 0;
+  let renders = 0;
+  const ticker = createShellRunElapsedTicker({
+    state,
+    now: () => now,
+    onTick: () => { renders += 1; },
+    schedule: (callback) => {
+      tick = callback;
+      return () => { cancelled += 1; tick = undefined; };
+    },
+  });
+
+  ticker.sync();
+  assert.equal(tick, undefined);
+
+  applyMakaSessionEventToTranscript(state, event({
+    type: 'tool_start', toolUseId: 'bash-bg', toolName: 'Bash', args: { command: 'sleep 30' },
+  }));
+  applyMakaSessionEventToTranscript(state, event({
+    type: 'tool_result', toolUseId: 'bash-bg', isError: false,
+    content: shellRun({ status: 'running' }),
+  }));
+  ticker.sync();
+  assert.ok(tick);
+
+  now = 6_500;
+  (tick as (() => void) | undefined)?.();
+  const tool = state.entries.find((entry) => entry.kind === 'tool');
+  assert.equal(tool?.kind === 'tool' ? tool.durationMs : undefined, 5_500);
+  assert.equal(renders, 1);
+
+  applyMakaSessionEventToTranscript(state, event({
+    type: 'tool_result', toolUseId: 'bash-bg', isError: false,
+    content: shellRun({ status: 'completed', completedAt: 6_500, updatedAt: 6_500, exitCode: 0 }),
+  }));
+  ticker.sync();
+  assert.equal(tick, undefined);
+  assert.equal(cancelled, 1);
+});
+
+function event(input: { type: SessionEvent['type'] } & Record<string, unknown>): SessionEvent {
+  return { id: `${input.type}-id`, turnId: 'turn-1', ts: 1, ...input } as SessionEvent;
+}
+
+function shellRun(
+  overrides: Partial<Extract<ToolResultContent, { kind: 'shell_run' }>>,
+): Extract<ToolResultContent, { kind: 'shell_run' }> {
+  return {
+    kind: 'shell_run', ref: 'maka://runtime/background-tasks/bg-1',
+    status: 'running', cwd: '/repo', cmd: 'sleep 30',
+    startedAt: 1_000, updatedAt: 1_000,
+    stdout: '', stderr: '', stdoutTruncated: false, stderrTruncated: false,
+    ...overrides,
+  };
+}

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -126,6 +126,7 @@ export async function runMakaCli(argv: string[] = process.argv.slice(2)): Promis
           providerType: context.target.connection.providerType,
           permissionMode: 'ask',
           subscribeShellRunUpdates: context.subscribeShellRunUpdates,
+          readShellRun: context.readShellRun,
           onProcessExit: handleMakaCliProcessExit,
         });
         return 0;

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -125,6 +125,7 @@ export async function runMakaCli(argv: string[] = process.argv.slice(2)): Promis
           connectionSlug: context.target.connection.slug,
           providerType: context.target.connection.providerType,
           permissionMode: 'ask',
+          subscribeShellRunUpdates: context.subscribeShellRunUpdates,
           onProcessExit: handleMakaCliProcessExit,
         });
         return 0;

--- a/packages/cli/src/pi-transcript-tools.ts
+++ b/packages/cli/src/pi-transcript-tools.ts
@@ -99,7 +99,9 @@ function compactToolSummary(entry: MakaPiToolEntry, width: number): CompactToolS
   const hasLiveOutput = entry.outputDeltas.length > 0 || entry.progress.length > 0;
   const result = entry.result;
   if (result?.kind === 'shell_run') {
-    const latest = lastNonEmptyLine([result.stdout, result.stderr].filter(Boolean).join('\n'));
+    const latest = result.latestOutputStream
+      ? lastNonEmptyLine(result[result.latestOutputStream])
+      : lastNonEmptyLine([result.stdout, result.stderr].filter(Boolean).join('\n'));
     if (latest) return { text: latest, expandable: true };
     return {
       text: entry.status === 'detached'

--- a/packages/cli/src/pi-transcript-tools.ts
+++ b/packages/cli/src/pi-transcript-tools.ts
@@ -20,10 +20,14 @@ export function renderToolBlock(entry: MakaPiToolEntry, width: number, expanded:
 function toolStatusText(entry: MakaPiToolEntry): string {
   const status = entry.status === 'running'
     ? ansi.yellow('running')
-    : entry.status === 'error'
-      ? ansi.red('error')
-      : ansi.green('done');
-  const duration = entry.durationMs === undefined ? '' : ansi.dim(` ${entry.durationMs}ms`);
+    : entry.status === 'done'
+      ? ansi.green('done')
+      : ansi.red(entry.status);
+  const duration = entry.durationMs === undefined
+    ? ''
+    : entry.result?.kind === 'shell_run'
+      ? ansi.dim(` ${Math.floor(entry.durationMs / 1_000)}s`)
+      : ansi.dim(` ${entry.durationMs}ms`);
   return `${status}${duration}`;
 }
 
@@ -43,6 +47,9 @@ function renderCompactToolBlock(entry: MakaPiToolEntry, width: number): string[]
   if (summary) {
     const hint = summary.expandable ? ansi.dim(' (Ctrl+O)') : '';
     lines.push(fitLine(`  ${collapseToSingleLine(summary.text)}${hint}`, width));
+  }
+  if (entry.status === 'running' && entry.result?.kind === 'shell_run') {
+    lines.push(fitLine(ansi.dim('  Ask Maka to stop this task'), width));
   }
   return lines;
 }
@@ -74,6 +81,9 @@ function renderExpandedToolBlock(entry: MakaPiToolEntry, width: number): string[
   if (entry.result || entry.output) {
     lines.push(...renderToolResult(entry, width));
   }
+  if (entry.status === 'running' && entry.result?.kind === 'shell_run') {
+    lines.push(...renderIndented(ansi.dim('Ask Maka to stop this task'), width, 2));
+  }
   return lines.map((line) => fitLine(line, width));
 }
 
@@ -85,12 +95,20 @@ interface CompactToolSummary {
 
 function compactToolSummary(entry: MakaPiToolEntry, width: number): CompactToolSummary | undefined {
   const hasLiveOutput = entry.outputDeltas.length > 0 || entry.progress.length > 0;
+  const result = entry.result;
+  if (result?.kind === 'shell_run') {
+    const latest = lastNonEmptyLine([result.stdout, result.stderr].filter(Boolean).join('\n'));
+    if (latest) return { text: latest, expandable: true };
+    return {
+      text: result.status === 'running' ? ansi.dim('(waiting for output)') : ansi.dim('(no output)'),
+      expandable: true,
+    };
+  }
   if (entry.status === 'running' && hasLiveOutput) {
     const live = latestLiveOutputLine(entry);
     if (live) return { text: live, expandable: true };
   }
 
-  const result = entry.result;
   if (result?.kind === 'terminal') return compactTerminalSummary(result, hasLiveOutput);
   if (result?.kind === 'file_diff') return compactDiffSummary(result);
   if (result?.kind === 'file_write') {

--- a/packages/cli/src/pi-transcript-tools.ts
+++ b/packages/cli/src/pi-transcript-tools.ts
@@ -105,7 +105,7 @@ function compactToolSummary(entry: MakaPiToolEntry, width: number): CompactToolS
     if (latest) return { text: latest, expandable: true };
     return {
       text: entry.status === 'detached'
-        ? ansi.dim('(continues in source session)')
+        ? ansi.dim('(owned by source session)')
         : result.status === 'running'
           ? ansi.dim('(waiting for output)')
           : ansi.dim('(no output)'),

--- a/packages/cli/src/pi-transcript-tools.ts
+++ b/packages/cli/src/pi-transcript-tools.ts
@@ -20,9 +20,11 @@ export function renderToolBlock(entry: MakaPiToolEntry, width: number, expanded:
 function toolStatusText(entry: MakaPiToolEntry): string {
   const status = entry.status === 'running'
     ? ansi.yellow('running')
-    : entry.status === 'done'
-      ? ansi.green('done')
-      : ansi.red(entry.status);
+    : entry.status === 'detached'
+      ? ansi.dim('detached')
+      : entry.status === 'done'
+        ? ansi.green('done')
+        : ansi.red(entry.status);
   const duration = entry.durationMs === undefined
     ? ''
     : entry.result?.kind === 'shell_run'
@@ -100,7 +102,11 @@ function compactToolSummary(entry: MakaPiToolEntry, width: number): CompactToolS
     const latest = lastNonEmptyLine([result.stdout, result.stderr].filter(Boolean).join('\n'));
     if (latest) return { text: latest, expandable: true };
     return {
-      text: result.status === 'running' ? ansi.dim('(waiting for output)') : ansi.dim('(no output)'),
+      text: entry.status === 'detached'
+        ? ansi.dim('(continues in source session)')
+        : result.status === 'running'
+          ? ansi.dim('(waiting for output)')
+          : ansi.dim('(no output)'),
       expandable: true,
     };
   }

--- a/packages/cli/src/pi-transcript.ts
+++ b/packages/cli/src/pi-transcript.ts
@@ -64,7 +64,7 @@ export type MakaPiTranscriptEntry =
       progress: BoundedChunkBuffer<string>;
       outputDeltas: BoundedChunkBuffer<MakaPiToolOutputDelta>;
       durationMs?: number;
-      status: 'running' | 'done' | 'error' | 'failed' | 'aborted';
+      status: 'running' | 'done' | 'error' | 'failed' | 'aborted' | 'detached';
     }
   | { kind: 'notice'; level: 'info' | 'error'; text: string };
 
@@ -99,7 +99,7 @@ export function refreshRunningShellRunElapsed(
 ): boolean {
   let found = false;
   for (const entry of state.entries) {
-    if (entry.kind !== 'tool' || entry.result?.kind !== 'shell_run' || entry.result.status !== 'running') continue;
+    if (entry.kind !== 'tool' || entry.status !== 'running' || entry.result?.kind !== 'shell_run') continue;
     entry.durationMs = Math.max(0, now - entry.result.startedAt);
     found = true;
   }
@@ -111,10 +111,27 @@ export function runningShellRunsInTranscript(
 ): Array<{ sourceToolCallId: string; ref: string }> {
   return state.entries.flatMap((entry) => entry.kind === 'tool'
     && entry.toolName === 'Bash'
+    && entry.status === 'running'
     && entry.result?.kind === 'shell_run'
     && entry.result.status === 'running'
     ? [{ sourceToolCallId: entry.toolUseId, ref: entry.result.ref }]
     : []);
+}
+
+export function applyDetachedShellRunToTranscript(
+  state: MakaPiTranscriptState,
+  sourceToolCallId: string,
+  update: Extract<ToolResultContent, { kind: 'shell_run' }>,
+): boolean {
+  const applied = applyShellRunUpdateToTranscript(state, sourceToolCallId, update);
+  const tool = findToolEntry(state, sourceToolCallId);
+  if (!tool
+    || tool.toolName !== 'Bash'
+    || tool.result?.kind !== 'shell_run'
+    || tool.result.ref !== update.ref
+    || tool.result.status !== 'running') return applied;
+  tool.status = 'detached';
+  return true;
 }
 
 export function applyShellRunUpdateToTranscript(

--- a/packages/cli/src/pi-transcript.ts
+++ b/packages/cli/src/pi-transcript.ts
@@ -64,7 +64,7 @@ export type MakaPiTranscriptEntry =
       progress: BoundedChunkBuffer<string>;
       outputDeltas: BoundedChunkBuffer<MakaPiToolOutputDelta>;
       durationMs?: number;
-      status: 'running' | 'done' | 'error';
+      status: 'running' | 'done' | 'error' | 'failed' | 'aborted';
     }
   | { kind: 'notice'; level: 'info' | 'error'; text: string };
 
@@ -93,12 +93,36 @@ export function appendUserPrompt(state: MakaPiTranscriptState, text: string): vo
   state.entries.push({ kind: 'user', text });
 }
 
+export function refreshRunningShellRunElapsed(
+  state: MakaPiTranscriptState,
+  now = Date.now(),
+): boolean {
+  let found = false;
+  for (const entry of state.entries) {
+    if (entry.kind !== 'tool' || entry.result?.kind !== 'shell_run' || entry.result.status !== 'running') continue;
+    entry.durationMs = Math.max(0, now - entry.result.startedAt);
+    found = true;
+  }
+  return found;
+}
+
+export function applyShellRunUpdateToTranscript(
+  state: MakaPiTranscriptState,
+  sourceToolCallId: string,
+  update: Extract<ToolResultContent, { kind: 'shell_run' }>,
+): boolean {
+  const tool = findToolEntry(state, sourceToolCallId);
+  if (!tool || tool.toolName !== 'Bash') return false;
+  if (tool.result?.kind === 'shell_run' && tool.result.ref !== update.ref) return false;
+  return applyShellRunResult(tool, update);
+}
+
 export function replaceTranscriptWithStoredMessages(
   state: MakaPiTranscriptState,
   messages: readonly StoredMessage[],
 ): void {
   const view = materializeSession(messages);
-  state.entries = view.items.flatMap(chatItemToTranscriptEntries);
+  state.entries = foldStoredShellRunChildren(view.items.flatMap(chatItemToTranscriptEntries));
   state.sawTextDeltaMessageIds = new Set(
     state.entries
       .filter((entry): entry is Extract<MakaPiTranscriptEntry, { kind: 'assistant' }> => entry.kind === 'assistant')
@@ -230,11 +254,24 @@ export function applyMakaSessionEventToTranscript(
 
     case 'tool_result': {
       const tool = findToolEntry(state, event.toolUseId);
+      const shellRun = event.content.kind === 'shell_run' ? event.content : undefined;
+      const parent = shellRun
+        ? findShellRunParent(state, shellRun.ref, event.toolUseId)
+        : undefined;
+      if (tool && parent && shellRun) {
+        applyShellRunResult(parent, shellRun);
+        state.entries.splice(state.entries.indexOf(tool), 1);
+        break;
+      }
       if (tool) {
-        tool.status = event.isError ? 'error' : 'done';
-        tool.result = event.content;
-        tool.output = formatToolResultContent(event.content);
-        tool.durationMs = event.durationMs;
+        if (shellRun) {
+          applyShellRunResult(tool, shellRun);
+        } else {
+          tool.status = event.isError ? 'error' : 'done';
+          tool.result = event.content;
+          tool.output = formatToolResultContent(event.content);
+          tool.durationMs = event.durationMs;
+        }
       } else {
         state.entries.push({
           kind: 'tool',
@@ -369,13 +406,13 @@ function chatItemToTranscriptEntries(item: ChatItem): MakaPiTranscriptEntry[] {
   }
 }
 
-function toolActivityToTranscriptEntry(item: ToolActivityItem): MakaPiTranscriptEntry {
+function toolActivityToTranscriptEntry(item: ToolActivityItem): MakaPiToolEntry {
   const output = item.result
     ? formatToolResultContent(item.result)
     : item.status === 'interrupted'
       ? 'Interrupted before the tool returned a result.'
       : undefined;
-  return {
+  const entry: MakaPiToolEntry = {
     kind: 'tool',
     toolUseId: item.toolUseId,
     toolName: item.toolName,
@@ -388,6 +425,29 @@ function toolActivityToTranscriptEntry(item: ToolActivityItem): MakaPiTranscript
     ...(item.durationMs !== undefined ? { durationMs: item.durationMs } : {}),
     status: transcriptToolStatus(item.status),
   };
+  if (item.result?.kind === 'shell_run') applyShellRunResult(entry, item.result);
+  return entry;
+}
+
+function foldStoredShellRunChildren(entries: MakaPiTranscriptEntry[]): MakaPiTranscriptEntry[] {
+  const folded: MakaPiTranscriptEntry[] = [];
+  for (const entry of entries) {
+    if (entry.kind === 'tool' && entry.result?.kind === 'shell_run') {
+      const shellRun = entry.result;
+      const parent = [...folded]
+        .reverse()
+        .find((candidate): candidate is MakaPiToolEntry => candidate.kind === 'tool'
+          && candidate.toolName === 'Bash'
+          && candidate.result?.kind === 'shell_run'
+          && candidate.result.ref === shellRun.ref);
+      if (parent) {
+        applyShellRunResult(parent, shellRun);
+        continue;
+      }
+    }
+    folded.push(entry);
+  }
+  return folded;
 }
 
 function transcriptToolStatus(status: ToolActivityItem['status']): MakaPiToolEntry['status'] {
@@ -402,6 +462,46 @@ function transcriptToolStatus(status: ToolActivityItem['status']): MakaPiToolEnt
     case 'running':
       return 'running';
   }
+}
+
+function shellRunTranscriptStatus(
+  status: Extract<ToolResultContent, { kind: 'shell_run' }>['status'],
+): MakaPiToolEntry['status'] {
+  switch (status) {
+    case 'running':
+      return 'running';
+    case 'completed':
+      return 'done';
+    case 'cancelled':
+      return 'aborted';
+    case 'failed':
+    case 'timed_out':
+    case 'orphaned':
+      return 'failed';
+  }
+}
+
+function applyShellRunResult(
+  entry: MakaPiToolEntry,
+  result: Extract<ToolResultContent, { kind: 'shell_run' }>,
+): boolean {
+  if (entry.result?.kind === 'shell_run' && shellRunUpdateIsStale(entry.result, result)) return false;
+  entry.status = shellRunTranscriptStatus(result.status);
+  entry.result = result;
+  entry.output = formatToolResultContent(result);
+  entry.durationMs = Math.max(0, (result.completedAt ?? result.updatedAt) - result.startedAt);
+  return true;
+}
+
+function shellRunUpdateIsStale(
+  current: Extract<ToolResultContent, { kind: 'shell_run' }>,
+  next: Extract<ToolResultContent, { kind: 'shell_run' }>,
+): boolean {
+  if (current.updatedAt !== next.updatedAt) return current.updatedAt > next.updatedAt;
+  if (current.status !== 'running' || next.status !== 'running') {
+    return current.status !== 'running' && next.status === 'running';
+  }
+  return current.stdout.length + current.stderr.length > next.stdout.length + next.stderr.length;
 }
 
 function systemNoteToTranscriptEntry(message: SystemNoteMessage): MakaPiTranscriptEntry | undefined {
@@ -593,6 +693,7 @@ function transcriptEntrySignature(
         entry.outputDeltas.version,
         entry.output?.length ?? '',
         entry.result ? entry.result.kind : '',
+        entry.result?.kind === 'shell_run' ? entry.result.updatedAt : '',
       ].join('|');
   }
 }
@@ -676,6 +777,20 @@ function createOutputBuffer(): BoundedChunkBuffer<MakaPiToolOutputDelta> {
     withText: (delta, chunk) => ({ ...delta, chunk }),
     sequence: (delta) => delta.seq,
   });
+}
+
+function findShellRunParent(
+  state: MakaPiTranscriptState,
+  ref: string,
+  childToolUseId: string,
+): MakaPiToolEntry | undefined {
+  return [...state.entries]
+    .reverse()
+    .find((entry): entry is MakaPiToolEntry => entry.kind === 'tool'
+      && entry.toolName === 'Bash'
+      && entry.toolUseId !== childToolUseId
+      && entry.result?.kind === 'shell_run'
+      && entry.result.ref === ref);
 }
 
 function renderTextBlock(

--- a/packages/cli/src/pi-transcript.ts
+++ b/packages/cli/src/pi-transcript.ts
@@ -61,6 +61,8 @@ export type MakaPiTranscriptEntry =
       result?: ToolResultContent;
       /** Flattened result text, kept as a fallback for text/json/unknown kinds. */
       output?: string;
+      /** In-memory revision for render-cache invalidation when a result is replaced. */
+      resultVersion: number;
       progress: BoundedChunkBuffer<string>;
       outputDeltas: BoundedChunkBuffer<MakaPiToolOutputDelta>;
       durationMs?: number;
@@ -274,6 +276,7 @@ export function applyMakaSessionEventToTranscript(
         toolName: event.toolName,
         ...(event.displayName ? { title: event.displayName } : {}),
         input: event.args,
+        resultVersion: 0,
         progress: createProgressBuffer(),
         outputDeltas: createOutputBuffer(),
         status: 'running',
@@ -299,6 +302,7 @@ export function applyMakaSessionEventToTranscript(
           tool.result = event.content;
           tool.output = formatToolResultContent(event.content);
           tool.durationMs = event.durationMs;
+          tool.resultVersion += 1;
         }
       } else {
         state.entries.push({
@@ -310,6 +314,7 @@ export function applyMakaSessionEventToTranscript(
           outputDeltas: createOutputBuffer(),
           result: event.content,
           output: formatToolResultContent(event.content),
+          resultVersion: 1,
           durationMs: event.durationMs,
           status: event.isError ? 'error' : 'done',
         });
@@ -450,6 +455,7 @@ function toolActivityToTranscriptEntry(item: ToolActivityItem): MakaPiToolEntry 
     outputDeltas: createOutputBuffer(),
     ...(item.result ? { result: item.result } : {}),
     ...(output ? { output } : {}),
+    resultVersion: item.result ? 1 : 0,
     ...(item.durationMs !== undefined ? { durationMs: item.durationMs } : {}),
     status: transcriptToolStatus(item.status),
   };
@@ -518,6 +524,7 @@ function applyShellRunResult(
   entry.result = result;
   entry.output = formatToolResultContent(result);
   entry.durationMs = Math.max(0, (result.completedAt ?? result.updatedAt) - result.startedAt);
+  entry.resultVersion += 1;
   return true;
 }
 
@@ -704,10 +711,10 @@ function transcriptEntrySignature(
     case 'notice':
       return `notice|${width}|${entry.level}|${entry.text.length}`;
     case 'tool':
-      // A tool entry mutates in place as it runs: status/duration flip on the
-      // result, progress/output deltas append, and background snapshots can
-      // replace the result without changing its timestamp or text lengths.
-      // Count the fields that change rendering. `input` and
+      // A tool entry mutates in place as it runs: status/duration flip,
+      // progress/output deltas append, and resultVersion advances whenever a
+      // result is accepted. Count those revisions instead of duplicating the
+      // result's rendering contract in this cache key. `input` and
       // `toolName` are omitted deliberately: both are set once at `tool_start`,
       // before the first render, and never change, so they can't go stale.
       return [
@@ -719,10 +726,7 @@ function transcriptEntrySignature(
         entry.title ?? entry.toolName,
         entry.progress.version,
         entry.outputDeltas.version,
-        entry.output?.length ?? '',
-        entry.result ? entry.result.kind : '',
-        entry.result?.kind === 'shell_run' ? entry.result.updatedAt : '',
-        entry.result?.kind === 'shell_run' ? entry.result.latestOutputStream ?? '' : '',
+        entry.resultVersion,
       ].join('|');
   }
 }

--- a/packages/cli/src/pi-transcript.ts
+++ b/packages/cli/src/pi-transcript.ts
@@ -106,6 +106,17 @@ export function refreshRunningShellRunElapsed(
   return found;
 }
 
+export function runningShellRunsInTranscript(
+  state: MakaPiTranscriptState,
+): Array<{ sourceToolCallId: string; ref: string }> {
+  return state.entries.flatMap((entry) => entry.kind === 'tool'
+    && entry.toolName === 'Bash'
+    && entry.result?.kind === 'shell_run'
+    && entry.result.status === 'running'
+    ? [{ sourceToolCallId: entry.toolUseId, ref: entry.result.ref }]
+    : []);
+}
+
 export function applyShellRunUpdateToTranscript(
   state: MakaPiTranscriptState,
   sourceToolCallId: string,

--- a/packages/cli/src/pi-transcript.ts
+++ b/packages/cli/src/pi-transcript.ts
@@ -705,9 +705,9 @@ function transcriptEntrySignature(
       return `notice|${width}|${entry.level}|${entry.text.length}`;
     case 'tool':
       // A tool entry mutates in place as it runs: status/duration flip on the
-      // result, and progress/output deltas append while running. Its result
-      // object is set once and never rewritten, so counting these fields is
-      // enough to detect every change to the rendered block. `input` and
+      // result, progress/output deltas append, and background snapshots can
+      // replace the result without changing its timestamp or text lengths.
+      // Count the fields that change rendering. `input` and
       // `toolName` are omitted deliberately: both are set once at `tool_start`,
       // before the first render, and never change, so they can't go stale.
       return [
@@ -722,6 +722,7 @@ function transcriptEntrySignature(
         entry.output?.length ?? '',
         entry.result ? entry.result.kind : '',
         entry.result?.kind === 'shell_run' ? entry.result.updatedAt : '',
+        entry.result?.kind === 'shell_run' ? entry.result.latestOutputStream ?? '' : '',
       ].join('|');
   }
 }

--- a/packages/cli/src/pi-tui-runner.ts
+++ b/packages/cli/src/pi-tui-runner.ts
@@ -15,6 +15,7 @@ import {
 import { PERMISSION_MODES, isPermissionMode, type PermissionMode } from '@maka/core/permission';
 import { isThinkingLevel, thinkingVariantsForModel, type ThinkingLevel } from '@maka/core/model-thinking';
 import type { ProviderType } from '@maka/core/llm-connections';
+import type { ToolResultContent } from '@maka/core/events';
 import type { ShellRunUpdate } from '@maka/runtime';
 import type { ModelChoice } from './connection-target.js';
 import type { MakaSessionDriver, MakaSessionSwitchResult } from './session-driver.js';
@@ -22,6 +23,7 @@ import {
   createMakaPiTranscriptState,
   applyShellRunUpdateToTranscript,
   replaceTranscriptWithStoredMessages,
+  runningShellRunsInTranscript,
   submitCompactToTranscript,
   submitPromptToTranscript,
   toggleAllThinkingExpansion,
@@ -79,6 +81,10 @@ export interface MakaPiTuiInput {
    */
   attentionLongTurnThresholdMs?: number;
   subscribeShellRunUpdates?: (listener: (update: ShellRunUpdate) => void) => () => void;
+  readShellRun?: (
+    sessionId: string,
+    ref: string,
+  ) => Promise<Extract<ToolResultContent, { kind: 'shell_run' }>>;
 }
 
 export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
@@ -394,13 +400,26 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
   // Adopt a switch/rewind result: the active session is now `summary` with
   // `messages`. Shared by switchSession and rewindToTurn so both land the same
   // runner state (model/connection/thinking/transcript/scroll).
-  const applySwitchResult = ({ summary, messages }: MakaSessionSwitchResult): void => {
+  const applySwitchResult = async ({ summary, messages }: MakaSessionSwitchResult): Promise<void> => {
     model = summary.model;
     connectionSlug = summary.llmConnectionSlug;
     permissionMode = summary.permissionMode;
     thinkingLevel = summary.thinkingLevel;
     thinkingLevels = providerType ? thinkingVariantsForModel(providerType, summary.model) : [];
     replaceTranscriptWithStoredMessages(state, messages);
+    if (input.readShellRun) {
+      const sessionId = summary.id;
+      await Promise.all(runningShellRunsInTranscript(state).map(async ({ sourceToolCallId, ref }) => {
+        try {
+          const result = await input.readShellRun?.(sessionId, ref);
+          if (!result || closed || input.driver.getSessionId() !== sessionId) return;
+          applyShellRunUpdateToTranscript(state, sourceToolCallId, result);
+        } catch {
+          // Missing legacy records must not make an otherwise valid session
+          // impossible to resume. Keep the stored card and let live updates win.
+        }
+      }));
+    }
     shellRunElapsedTicker.sync();
   };
 
@@ -409,7 +428,7 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
   // active session untouched and the next prompt still lands on the old one.
   const switchSession = async (sessionId: string) => {
     const result = await input.driver.switchSession(sessionId);
-    applySwitchResult(result);
+    await applySwitchResult(result);
     if (result.messages.length === 0) {
       state.entries.push({
         kind: 'notice',
@@ -426,7 +445,7 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
   // non-destructive and inherits the branch's resume guarantees.
   const rewindToTurn = async (turnId: string) => {
     const result = await input.driver.rewindToTurn(turnId);
-    applySwitchResult(result);
+    await applySwitchResult(result);
     // Refill the editor with the discarded turn's prompt so the user can edit
     // and resend it. The picker only arms when the editor is neutral (empty
     // draft, no autocomplete), so overwriting the text loses no in-progress work.

--- a/packages/cli/src/pi-tui-runner.ts
+++ b/packages/cli/src/pi-tui-runner.ts
@@ -15,10 +15,12 @@ import {
 import { PERMISSION_MODES, isPermissionMode, type PermissionMode } from '@maka/core/permission';
 import { isThinkingLevel, thinkingVariantsForModel, type ThinkingLevel } from '@maka/core/model-thinking';
 import type { ProviderType } from '@maka/core/llm-connections';
+import type { ShellRunUpdate } from '@maka/runtime';
 import type { ModelChoice } from './connection-target.js';
 import type { MakaSessionDriver, MakaSessionSwitchResult } from './session-driver.js';
 import {
   createMakaPiTranscriptState,
+  applyShellRunUpdateToTranscript,
   replaceTranscriptWithStoredMessages,
   submitCompactToTranscript,
   submitPromptToTranscript,
@@ -28,6 +30,7 @@ import {
 } from './pi-transcript.js';
 import { editorTheme, selectListTheme } from './tui-ansi.js';
 import { MakaAutocompleteAboveEditorComponent } from './tui-autocomplete-layout.js';
+import { createShellRunElapsedTicker } from './shell-run-elapsed-ticker.js';
 import {
   AttentionController,
   DISABLE_FOCUS_REPORTING,
@@ -75,6 +78,7 @@ export interface MakaPiTuiInput {
    * without waiting real seconds; defaults to the attention layer's own value.
    */
   attentionLongTurnThresholdMs?: number;
+  subscribeShellRunUpdates?: (listener: (update: ShellRunUpdate) => void) => () => void;
 }
 
 export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
@@ -137,6 +141,16 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
     transcript.invalidate();
     tui.requestRender();
   };
+  const shellRunElapsedTicker = createShellRunElapsedTicker({
+    state,
+    onTick: requestRender,
+  });
+  const unsubscribeShellRunUpdates = input.subscribeShellRunUpdates?.((update) => {
+    if (closed || input.driver.getSessionId() !== update.sessionId) return;
+    if (!applyShellRunUpdateToTranscript(state, update.sourceToolCallId, update.result)) return;
+    shellRunElapsedTicker.sync();
+    requestRender();
+  });
 
   const reportError = (error: unknown) => {
     state.entries.push({
@@ -184,6 +198,8 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
 
   const restoreTerminal = () => {
     removeProcessHandlers();
+    unsubscribeShellRunUpdates?.();
+    shellRunElapsedTicker.dispose();
     terminal.setProgress(false);
     // Drop the busy / attention title marker so the tab is not handed back to
     // the shell still marked busy when the session exits.
@@ -320,6 +336,7 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
         } else {
           permissionAlerted = false;
         }
+        shellRunElapsedTicker.sync();
         requestRender();
       },
     }).finally(() => {
@@ -384,6 +401,7 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
     thinkingLevel = summary.thinkingLevel;
     thinkingLevels = providerType ? thinkingVariantsForModel(providerType, summary.model) : [];
     replaceTranscriptWithStoredMessages(state, messages);
+    shellRunElapsedTicker.sync();
   };
 
   // Folder/connection safety is enforced inside driver.switchSession(),
@@ -535,6 +553,7 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
     // session, send a prompt to begin" cue. A notice here would make entries
     // non-empty and suppress it.
     replaceTranscriptWithStoredMessages(state, []);
+    shellRunElapsedTicker.sync();
     requestRender();
   };
 

--- a/packages/cli/src/pi-tui-runner.ts
+++ b/packages/cli/src/pi-tui-runner.ts
@@ -21,6 +21,7 @@ import type { ModelChoice } from './connection-target.js';
 import type { MakaSessionDriver, MakaSessionSwitchResult } from './session-driver.js';
 import {
   createMakaPiTranscriptState,
+  applyDetachedShellRunToTranscript,
   applyShellRunUpdateToTranscript,
   replaceTranscriptWithStoredMessages,
   runningShellRunsInTranscript,
@@ -84,7 +85,10 @@ export interface MakaPiTuiInput {
   readShellRun?: (
     sessionId: string,
     ref: string,
-  ) => Promise<Extract<ToolResultContent, { kind: 'shell_run' }>>;
+  ) => Promise<{
+    ownerSessionId: string;
+    result: Extract<ToolResultContent, { kind: 'shell_run' }>;
+  }>;
 }
 
 export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
@@ -411,9 +415,13 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
       const sessionId = summary.id;
       await Promise.all(runningShellRunsInTranscript(state).map(async ({ sourceToolCallId, ref }) => {
         try {
-          const result = await input.readShellRun?.(sessionId, ref);
-          if (!result || closed || input.driver.getSessionId() !== sessionId) return;
-          applyShellRunUpdateToTranscript(state, sourceToolCallId, result);
+          const read = await input.readShellRun?.(sessionId, ref);
+          if (!read || closed || input.driver.getSessionId() !== sessionId) return;
+          if (read.ownerSessionId !== sessionId && read.result.status === 'running') {
+            applyDetachedShellRunToTranscript(state, sourceToolCallId, read.result);
+          } else {
+            applyShellRunUpdateToTranscript(state, sourceToolCallId, read.result);
+          }
         } catch {
           // Missing legacy records must not make an otherwise valid session
           // impossible to resume. Keep the stored card and let live updates win.

--- a/packages/cli/src/runtime-bootstrap.ts
+++ b/packages/cli/src/runtime-bootstrap.ts
@@ -282,7 +282,7 @@ export async function createMakaCliRuntimeContext(
       try {
         return {
           ownerSessionId,
-          result: await shellRuns.readResource(ownerSessionId, ref),
+          result: await shellRuns.inspectResource(ownerSessionId, ref),
         };
       } catch (error) {
         if (!isNotFoundError(error)) throw error;

--- a/packages/cli/src/runtime-bootstrap.ts
+++ b/packages/cli/src/runtime-bootstrap.ts
@@ -49,7 +49,10 @@ export interface MakaCliRuntimeContext {
   automationManager: AutomationManager;
   automationScheduler: AutomationScheduler;
   subscribeShellRunUpdates(listener: (update: ShellRunUpdate) => void): () => void;
-  readShellRun(sessionId: string, ref: string): Promise<Extract<ToolResultContent, { kind: 'shell_run' }>>;
+  readShellRun(sessionId: string, ref: string): Promise<{
+    ownerSessionId: string;
+    result: Extract<ToolResultContent, { kind: 'shell_run' }>;
+  }>;
   close(): Promise<void>;
 }
 
@@ -271,6 +274,25 @@ export async function createMakaCliRuntimeContext(
 
   automationScheduler.start();
 
+  const readShellRun = async (sessionId: string, ref: string) => {
+    let ownerSessionId: string | undefined = sessionId;
+    const visited = new Set<string>();
+    while (ownerSessionId && !visited.has(ownerSessionId)) {
+      visited.add(ownerSessionId);
+      try {
+        return {
+          ownerSessionId,
+          result: await shellRuns.readResource(ownerSessionId, ref),
+        };
+      } catch (error) {
+        if (!isNotFoundError(error)) throw error;
+        ownerSessionId = (await store.readHeader(ownerSessionId)).parentSessionId;
+        if (!ownerSessionId) throw error;
+      }
+    }
+    throw new Error(`Cannot resolve ShellRun owner for session ${sessionId}`);
+  };
+
   return {
     workspaceRoot: input.workspaceRoot,
     cwd: input.cwd,
@@ -284,7 +306,7 @@ export async function createMakaCliRuntimeContext(
       shellRunListeners.add(listener);
       return () => shellRunListeners.delete(listener);
     },
-    readShellRun: (sessionId, ref) => shellRuns.readResource(sessionId, ref),
+    readShellRun,
     close: async () => {
       // Stop the automation scheduler's timer (else it keeps the process alive
       // and ticks into a stopped session), then terminate background shell runs.
@@ -335,6 +357,10 @@ function userOptedIntoSemanticCompact(env: Record<string, string | undefined>): 
   }
   const mode = env.MAKA_CONTEXT_SEMANTIC_COMPACT_MODE?.trim().toLowerCase();
   return mode === 'validate_only' || mode === 'prepare_step_dry_run' || mode === 'replace';
+}
+
+function isNotFoundError(error: unknown): error is NodeJS.ErrnoException {
+  return error instanceof Error && 'code' in error && error.code === 'ENOENT';
 }
 
 export async function getOrCreateCliClaudeDeviceId(

--- a/packages/cli/src/runtime-bootstrap.ts
+++ b/packages/cli/src/runtime-bootstrap.ts
@@ -33,6 +33,7 @@ import {
   createSettingsStore,
   createShellRunStore,
 } from '@maka/storage';
+import type { ToolResultContent } from '@maka/core/events';
 import type { ModelChoice, ReadySessionTarget } from './connection-target.js';
 import { listReadyModelChoices, resolveDefaultSessionTarget, resolveSessionTargetForSlug } from './connection-target.js';
 import { buildCliSystemPrompt, buildCliTurnTailPrompt } from './cli-system-prompt.js';
@@ -48,6 +49,7 @@ export interface MakaCliRuntimeContext {
   automationManager: AutomationManager;
   automationScheduler: AutomationScheduler;
   subscribeShellRunUpdates(listener: (update: ShellRunUpdate) => void): () => void;
+  readShellRun(sessionId: string, ref: string): Promise<Extract<ToolResultContent, { kind: 'shell_run' }>>;
   close(): Promise<void>;
 }
 
@@ -282,6 +284,7 @@ export async function createMakaCliRuntimeContext(
       shellRunListeners.add(listener);
       return () => shellRunListeners.delete(listener);
     },
+    readShellRun: (sessionId, ref) => shellRuns.readResource(sessionId, ref),
     close: async () => {
       // Stop the automation scheduler's timer (else it keeps the process alive
       // and ticks into a stopped session), then terminate background shell runs.

--- a/packages/cli/src/runtime-bootstrap.ts
+++ b/packages/cli/src/runtime-bootstrap.ts
@@ -20,6 +20,7 @@ import {
   loadHistoryCompactBlocksFromArtifacts,
   persistHistoryCompactBlocksToArtifacts,
   type AutomationDefinition,
+  type ShellRunUpdate,
 } from '@maka/runtime';
 import {
   createAgentRunStore,
@@ -46,6 +47,7 @@ export interface MakaCliRuntimeContext {
   tools: ReturnType<typeof buildBuiltinTools>;
   automationManager: AutomationManager;
   automationScheduler: AutomationScheduler;
+  subscribeShellRunUpdates(listener: (update: ShellRunUpdate) => void): () => void;
   close(): Promise<void>;
 }
 
@@ -91,10 +93,20 @@ export async function createMakaCliRuntimeContext(
   const modelChoices = await listReadyModelChoices({ connectionStore, credentialStore });
   const permissionEngine = new PermissionEngine({ newId: randomUUID, now: Date.now });
   const backends = new BackendRegistry();
+  const shellRunListeners = new Set<(update: ShellRunUpdate) => void>();
   const shellRuns = new ShellRunProcessManager({
     store: shellRunStore,
     newId: randomUUID,
     now: Date.now,
+    onShellRunUpdate: (update) => {
+      for (const listener of shellRunListeners) {
+        try {
+          listener(update);
+        } catch {
+          // One UI observer must not suppress updates for the rest.
+        }
+      }
+    },
   });
   const tools = buildBuiltinTools({ shellRuns });
   const automationManager = new AutomationManager({
@@ -266,11 +278,16 @@ export async function createMakaCliRuntimeContext(
     tools,
     automationManager,
     automationScheduler,
+    subscribeShellRunUpdates: (listener) => {
+      shellRunListeners.add(listener);
+      return () => shellRunListeners.delete(listener);
+    },
     close: async () => {
       // Stop the automation scheduler's timer (else it keeps the process alive
       // and ticks into a stopped session), then terminate background shell runs.
       automationScheduler.dispose();
       await shellRuns.terminateAll();
+      shellRunListeners.clear();
     },
   };
 }

--- a/packages/cli/src/shell-run-elapsed-ticker.ts
+++ b/packages/cli/src/shell-run-elapsed-ticker.ts
@@ -1,0 +1,50 @@
+import {
+  refreshRunningShellRunElapsed,
+  type MakaPiTranscriptState,
+} from './pi-transcript.js';
+
+type CancelInterval = () => void;
+type ScheduleInterval = (callback: () => void, intervalMs: number) => CancelInterval;
+
+export interface ShellRunElapsedTicker {
+  sync(): void;
+  dispose(): void;
+}
+
+export function createShellRunElapsedTicker(input: {
+  state: MakaPiTranscriptState;
+  onTick: () => void;
+  now?: () => number;
+  schedule?: ScheduleInterval;
+}): ShellRunElapsedTicker {
+  const now = input.now ?? Date.now;
+  const schedule = input.schedule ?? scheduleInterval;
+  let cancel: CancelInterval | undefined;
+
+  const stop = () => {
+    cancel?.();
+    cancel = undefined;
+  };
+  const tick = () => {
+    if (!refreshRunningShellRunElapsed(input.state, now())) {
+      stop();
+      return;
+    }
+    input.onTick();
+  };
+
+  return {
+    sync() {
+      const running = refreshRunningShellRunElapsed(input.state, now());
+      if (running && !cancel) cancel = schedule(tick, 1_000);
+      if (!running) stop();
+    },
+    dispose: stop,
+  };
+}
+
+function scheduleInterval(callback: () => void, intervalMs: number): CancelInterval {
+  const handle = setInterval(callback, intervalMs);
+  handle.unref();
+  return () => clearInterval(handle);
+}

--- a/packages/core/src/events.ts
+++ b/packages/core/src/events.ts
@@ -191,6 +191,7 @@ export type ToolResultContent =
       failureMessage?: string;
       stdout: string;
       stderr: string;
+      latestOutputStream?: 'stdout' | 'stderr';
       stdoutTruncated: boolean;
       stderrTruncated: boolean;
       timeoutMs?: number;

--- a/packages/core/src/shell-run.ts
+++ b/packages/core/src/shell-run.ts
@@ -36,6 +36,7 @@ export interface ShellRunRecord {
   timeoutMs?: number;
   stdoutTail: string;
   stderrTail: string;
+  latestOutputStream?: 'stdout' | 'stderr';
   stdoutTruncated: boolean;
   stderrTruncated: boolean;
   observedAt?: number;

--- a/packages/runtime/src/__tests__/builtin-tools.test.ts
+++ b/packages/runtime/src/__tests__/builtin-tools.test.ts
@@ -81,8 +81,8 @@ describe('builtin Bash streaming output', () => {
           stderrTruncated: false,
         };
       },
-      async readResource(sessionId: string, ref: string) {
-        return { content: `session=${sessionId} ref=${ref}` };
+      async readResource() {
+        throw new Error('not used');
       },
       async stopResource() {
         throw new Error('not used');
@@ -123,7 +123,12 @@ describe('builtin Bash streaming output', () => {
       },
       async readResource(sessionId: string, ref: string) {
         calls.push({ sessionId, ref });
-        return { content: 'background task detail' };
+        return {
+          kind: 'shell_run', ref, status: 'running', cwd: '/workspace',
+          cmd: 'sleep 60', startedAt: 1, updatedAt: 2,
+          stdout: 'background task detail', stderr: '',
+          stdoutTruncated: false, stderrTruncated: false,
+        };
       },
       async stopResource() {
         throw new Error('not used');
@@ -145,7 +150,12 @@ describe('builtin Bash streaming output', () => {
       },
     );
 
-    expect(result).toEqual({ content: 'background task detail' });
+    expect(result).toEqual({
+      kind: 'shell_run', ref: 'maka://runtime/background-tasks/shell-run-1',
+      status: 'running', cwd: '/workspace', cmd: 'sleep 60',
+      startedAt: 1, updatedAt: 2, stdout: 'background task detail', stderr: '',
+      stdoutTruncated: false, stderrTruncated: false,
+    });
     expect(calls).toEqual([{
       sessionId: 'session-1',
       ref: 'maka://runtime/background-tasks/shell-run-1',

--- a/packages/runtime/src/__tests__/shell-run-manager.test.ts
+++ b/packages/runtime/src/__tests__/shell-run-manager.test.ts
@@ -4,7 +4,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, test } from 'node:test';
 import type { ShellRunRecord, ShellRunStore } from '@maka/core';
-import { ShellRunProcessManager } from '../shell-run-manager.js';
+import { ShellRunProcessManager, type ShellRunUpdate } from '../shell-run-manager.js';
 import type { ShellPlan } from '../shell-detect.js';
 
 describe('ShellRunProcessManager', () => {
@@ -89,19 +89,61 @@ describe('ShellRunProcessManager', () => {
     if (!initial.ref) throw new Error('expected ShellRun resource ref');
 
     const detail = await manager.readResource('session-1', initial.ref);
-    assert.match(detail.content, /status: running/);
-    assert.match(detail.content, /stdout:\nstart/);
+    assert.equal(detail.kind, 'shell_run');
+    assert.equal(detail.status, 'running');
+    assert.equal(detail.stdout, 'start');
 
     const summary = await manager.buildContextSummary('session-1');
     assert.match(summary ?? '', /ref=maka:\/\/runtime\/background-tasks\/shell-run-1/);
 
     await sleep(600);
     const completed = await manager.readResource('session-1', initial.ref);
-    assert.match(completed.content, /status: completed/);
-    assert.match(completed.content, /stdout:\nstartdone/);
+    assert.equal(completed.kind, 'shell_run');
+    assert.equal(completed.status, 'completed');
+    assert.equal(completed.stdout, 'startdone');
     assert.equal(manager.liveCount(), 0);
 
     assert.equal(await manager.buildContextSummary('session-1'), undefined);
+  });
+
+  test('publishes the terminal state when a yielded ShellRun settles without a resource read', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'maka-shell-run-'));
+    const store = new MemoryShellRunStore();
+    const updates: ShellRunUpdate[] = [];
+    const manager = createManager(store, (update) => updates.push(update));
+
+    const initial = await manager.runBash(shellInput({
+      cwd,
+      command: 'printf "start"; sleep 0.5; printf "done"',
+      yieldTimeMs: 250,
+    }));
+    assert.equal(initial.kind, 'shell_run');
+    assert.equal(initial.status, 'running');
+
+    await sleep(600);
+    const terminal = updates.find((update) => update.result.status === 'completed');
+    assert.equal(terminal?.sessionId, 'session-1');
+    assert.equal(terminal?.sourceToolCallId, 'tool-1');
+    assert.equal(terminal?.result.stdout, 'startdone');
+    assert.equal(terminal?.result.exitCode, 0);
+  });
+
+  test('publishes retained output after a ShellRun yields', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'maka-shell-run-'));
+    const store = new MemoryShellRunStore();
+    const updates: ShellRunUpdate[] = [];
+    const manager = createManager(store, (update) => updates.push(update));
+
+    const initial = await manager.runBash(shellInput({
+      cwd,
+      command: 'printf "start"; sleep 5',
+      yieldTimeMs: 250,
+    }));
+    assert.equal(initial.kind, 'shell_run');
+    const running = updates.find((update) => update.result.status === 'running');
+    assert.equal(running?.result.stdout, 'start');
+
+    await manager.terminateAll();
   });
 
   test('stops running ShellRuns by runtime ref only after the process has exited', async () => {
@@ -139,8 +181,8 @@ describe('ShellRunProcessManager', () => {
     assert.equal(initial.ref, 'maka://runtime/background-tasks/shell-run-1');
 
     const detail = await manager.readResource('session-1', initial.ref);
-    assert.match(detail.content, /status: completed/);
-    assert.match(detail.content, /stdout:\nstartdone/);
+    assert.equal(detail.status, 'completed');
+    assert.equal(detail.stdout, 'startdone');
 
     const stored = await store.readShellRun('session-1', 'shell-run-1');
     assert.equal(stored.status, 'completed');
@@ -223,8 +265,8 @@ describe('ShellRunProcessManager', () => {
     assert.equal(recovered, 1);
 
     const detail = await manager.readResource('session-1', 'maka://runtime/background-tasks/orphan-1');
-    assert.match(detail.content, /status: orphaned/);
-    assert.match(detail.content, /orphanedReason: runtime restarted/);
+    assert.equal(detail.status, 'orphaned');
+    assert.match(detail.orphanedReason ?? '', /runtime restarted/);
   });
 
   test('context summary lists metadata without stdout or stderr tails', async () => {
@@ -260,8 +302,8 @@ describe('ShellRunProcessManager', () => {
     }));
 
     const detail = await manager.readResource('session-1', 'maka://runtime/background-tasks/done-1');
-    assert.match(detail.content, /status: completed/);
-    assert.ok(detail.content.length < largeStdout.length);
+    assert.equal(detail.status, 'completed');
+    assert.ok(detail.stdout.length < largeStdout.length);
 
     const stored = await store.readShellRun('session-1', 'done-1');
     assert.equal(stored.stdoutTail, largeStdout);
@@ -321,16 +363,21 @@ class MemoryShellRunStore implements ShellRunStore {
   }
 }
 
-function createManager(store: ShellRunStore): ShellRunProcessManager {
+function createManager(
+  store: ShellRunStore,
+  onShellRunUpdate?: (update: ShellRunUpdate) => void,
+): ShellRunProcessManager {
   let id = 0;
   let now = 1_000;
-  return new ShellRunProcessManager({
+  const input = {
     store,
     newId: () => `shell-run-${++id}`,
     now: () => ++now,
     flushIntervalMs: 10,
     killGraceMs: 50,
-  });
+    ...(onShellRunUpdate ? { onShellRunUpdate } : {}),
+  };
+  return new ShellRunProcessManager(input);
 }
 
 function shellInput(input: {

--- a/packages/runtime/src/__tests__/shell-run-manager.test.ts
+++ b/packages/runtime/src/__tests__/shell-run-manager.test.ts
@@ -128,6 +128,46 @@ describe('ShellRunProcessManager', () => {
     assert.equal(terminal?.result.exitCode, 0);
   });
 
+  test('persists stdout as the latest output stream when it follows stderr', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'maka-shell-run-'));
+    const store = new MemoryShellRunStore();
+    const updates: ShellRunUpdate[] = [];
+    const manager = createManager(store, (update) => updates.push(update));
+
+    const initial = await manager.runBash(shellInput({
+      cwd,
+      command: 'printf "warning\\n" >&2; sleep 0.5; printf "99%%\\n"',
+      yieldTimeMs: 250,
+    }));
+    assert.equal(initial.kind, 'shell_run');
+
+    await sleep(600);
+    const terminal = updates.find((update) => update.result.status === 'completed');
+    assert.equal(terminal?.result.latestOutputStream, 'stdout');
+    assert.equal(
+      (await store.readShellRun('session-1', 'shell-run-1')).latestOutputStream,
+      'stdout',
+    );
+  });
+
+  test('persists stderr as the latest output stream when it follows stdout', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'maka-shell-run-'));
+    const store = new MemoryShellRunStore();
+    const updates: ShellRunUpdate[] = [];
+    const manager = createManager(store, (update) => updates.push(update));
+
+    const initial = await manager.runBash(shellInput({
+      cwd,
+      command: 'printf "99%%\\n"; sleep 0.5; printf "warning\\n" >&2',
+      yieldTimeMs: 250,
+    }));
+    assert.equal(initial.kind, 'shell_run');
+
+    await sleep(600);
+    const terminal = updates.find((update) => update.result.status === 'completed');
+    assert.equal(terminal?.result.latestOutputStream, 'stderr');
+  });
+
   test('publishes retained output after a ShellRun yields', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'maka-shell-run-'));
     const store = new MemoryShellRunStore();

--- a/packages/runtime/src/__tests__/shell-run-manager.test.ts
+++ b/packages/runtime/src/__tests__/shell-run-manager.test.ts
@@ -128,6 +128,27 @@ describe('ShellRunProcessManager', () => {
     assert.equal(terminal?.result.exitCode, 0);
   });
 
+  test('keeps terminal updatedAt after queued running flushes', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'maka-shell-run-'));
+    const store = new MemoryShellRunStore({ updateDelayMs: 300 });
+    const updates: ShellRunUpdate[] = [];
+    const manager = createManager(store, (update) => updates.push(update));
+
+    const initial = await manager.runBash(shellInput({
+      cwd,
+      command: 'printf "start"; sleep 0.1; printf "middle"; sleep 0.1',
+      yieldTimeMs: 50,
+    }));
+    assert.equal(initial.kind, 'shell_run');
+
+    await sleep(750);
+    const latestRunning = updates.filter((update) => update.result.status === 'running').at(-1);
+    const terminal = updates.find((update) => update.result.status === 'completed');
+    assert.ok(latestRunning);
+    assert.ok(terminal);
+    assert.ok(terminal.result.updatedAt >= latestRunning.result.updatedAt);
+  });
+
   test('persists stdout as the latest output stream when it follows stderr', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'maka-shell-run-'));
     const store = new MemoryShellRunStore();

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -105,6 +105,7 @@ export {
 export type {
   ShellRunBashInput,
   ShellRunProcessManagerInput,
+  ShellRunUpdate,
 } from './shell-run-manager.js';
 export {
   LOCAL_WORKSPACE_EXECUTOR_FACTS,

--- a/packages/runtime/src/shell-run-manager.ts
+++ b/packages/runtime/src/shell-run-manager.ts
@@ -32,10 +32,17 @@ export const DEFAULT_SHELL_RUN_FLUSH_BYTES = 64 * 1024;
 export const SHELL_RUN_CONTEXT_SUMMARY_LIMIT = 8;
 export const SHELL_RUN_RESOURCE_PREFIX = 'maka://runtime/background-tasks';
 
+export interface ShellRunUpdate {
+  sessionId: string;
+  sourceToolCallId: string;
+  result: Extract<ToolResultContent, { kind: 'shell_run' }>;
+}
+
 export interface ShellRunProcessManagerInput {
   store: ShellRunStore;
   newId: () => string;
   now: () => number;
+  onShellRunUpdate?: (update: ShellRunUpdate) => void;
   maxLiveShellRuns?: number;
   flushIntervalMs?: number;
   flushBytes?: number;
@@ -185,11 +192,10 @@ export class ShellRunProcessManager {
     return lines.join('\n');
   }
 
-  async readResource(sessionId: string, ref: string): Promise<{ content: string }> {
+  async readResource(sessionId: string, ref: string): Promise<ShellRunToolResult> {
     const target = parseShellRunResourceRef(ref);
     if (!target) throw new Error(`Unsupported runtime resource ref: ${ref}`);
-    const content = await this.renderResourceDetail(sessionId, target.shellRunId);
-    return { content };
+    return this.resourceDetail(sessionId, target.shellRunId);
   }
 
   async stopResource(sessionId: string, ref: string): Promise<ShellRunToolResult> {
@@ -361,10 +367,11 @@ export class ShellRunProcessManager {
     const patch = this.tailPatch(live);
     live.flushChain = live.flushChain.then(async () => {
       await live.created;
-      await this.input.store.updateShellRun(live.sessionId, live.shellRunId, {
+      const updated = await this.input.store.updateShellRun(live.sessionId, live.shellRunId, {
         ...patch,
         updatedAt: this.input.now(),
       });
+      if (!live.forwardLive) this.notifyShellRunUpdate(updated);
     });
     await live.flushChain;
   }
@@ -395,6 +402,7 @@ export class ShellRunProcessManager {
           updatedAt: now,
           completedAt: now,
         });
+        if (!live.forwardLive) this.notifyShellRunUpdate(updated);
         live.finish(updated);
       });
       await live.flushChain;
@@ -417,6 +425,18 @@ export class ShellRunProcessManager {
       stdoutTruncated: live.stdoutChars > stdoutRawTail.length || live.stdoutBuf.hasDroppedUnsafe(),
       stderrTruncated: live.stderrChars > stderrRawTail.length || live.stderrBuf.hasDroppedUnsafe(),
     };
+  }
+
+  private notifyShellRunUpdate(record: ShellRunRecord): void {
+    try {
+      this.input.onShellRunUpdate?.({
+        sessionId: record.sessionId,
+        sourceToolCallId: record.sourceToolCallId,
+        result: shellRunContent(record),
+      });
+    } catch {
+      // UI observers are best-effort; durable process state is authoritative.
+    }
   }
 
   private beginTermination(live: LiveShellRun, reason: ShellRunTermination): void {
@@ -473,7 +493,7 @@ export class ShellRunProcessManager {
       .sort(compareActionableShellRuns);
   }
 
-  private async renderResourceDetail(sessionId: string, shellRunId: string): Promise<string> {
+  private async resourceDetail(sessionId: string, shellRunId: string): Promise<ShellRunToolResult> {
     let record = await this.input.store.readShellRun(sessionId, shellRunId);
     if (record.status === 'running') {
       const live = this.live.get(shellRunId);
@@ -491,7 +511,7 @@ export class ShellRunProcessManager {
     if (isTerminalShellRunStatus(record.status)) {
       record = await this.markObserved(record);
     }
-    return renderShellRunResource(record);
+    return shellRunContent(record);
   }
 }
 
@@ -649,32 +669,6 @@ function parseShellRunResourceRef(ref: string): ShellRunResourceTarget | null {
     }
   }
   return null;
-}
-
-function renderShellRunResource(record: ShellRunRecord): string {
-  const stdout = truncateToolOutput(record.stdoutTail, { direction: 'tail' });
-  const stderr = truncateToolOutput(record.stderrTail, { direction: 'tail' });
-  const lines = [
-    'Background task',
-    `ref: ${shellRunResourceRef(record.shellRunId)}`,
-    `status: ${record.status}`,
-    `cwd: ${record.cwd}`,
-    `command: ${record.command}`,
-    `startedAt: ${record.startedAt}`,
-    `updatedAt: ${record.updatedAt}`,
-    record.completedAt !== undefined ? `completedAt: ${record.completedAt}` : '',
-    record.exitCode !== undefined ? `exitCode: ${record.exitCode}` : '',
-    record.timeoutMs !== undefined ? `timeoutMs: ${record.timeoutMs}` : '',
-    record.failureMessage ? `failureMessage: ${record.failureMessage}` : '',
-    record.orphanedReason ? `orphanedReason: ${record.orphanedReason}` : '',
-    '',
-    `stdout${record.stdoutTruncated || stdout.truncated ? ' (truncated)' : ''}:`,
-    stdout.content,
-    '',
-    `stderr${record.stderrTruncated || stderr.truncated ? ' (truncated)' : ''}:`,
-    stderr.content,
-  ];
-  return lines.filter((line, index) => line.length > 0 || index > 0).join('\n');
 }
 
 function clampInt(value: number, min: number, max: number): number {

--- a/packages/runtime/src/shell-run-manager.ts
+++ b/packages/runtime/src/shell-run-manager.ts
@@ -397,11 +397,11 @@ export class ShellRunProcessManager {
 
     try {
       await live.created;
-      const now = this.input.now();
       const status = statusFromClose(code, signal, live.termination);
       const exitCode = exitCodeFromClose(code, signal, live.termination);
       const failureMessage = failureMessageFor(status, live.timeoutMs);
       live.flushChain = live.flushChain.then(async () => {
+        const now = this.input.now();
         const updated = await this.input.store.updateShellRun(live.sessionId, live.shellRunId, {
           ...this.tailPatch(live),
           status,

--- a/packages/runtime/src/shell-run-manager.ts
+++ b/packages/runtime/src/shell-run-manager.ts
@@ -195,7 +195,13 @@ export class ShellRunProcessManager {
   async readResource(sessionId: string, ref: string): Promise<ShellRunToolResult> {
     const target = parseShellRunResourceRef(ref);
     if (!target) throw new Error(`Unsupported runtime resource ref: ${ref}`);
-    return this.resourceDetail(sessionId, target.shellRunId);
+    return this.resourceDetail(sessionId, target.shellRunId, true);
+  }
+
+  async inspectResource(sessionId: string, ref: string): Promise<ShellRunToolResult> {
+    const target = parseShellRunResourceRef(ref);
+    if (!target) throw new Error(`Unsupported runtime resource ref: ${ref}`);
+    return this.resourceDetail(sessionId, target.shellRunId, false);
   }
 
   async stopResource(sessionId: string, ref: string): Promise<ShellRunToolResult> {
@@ -493,7 +499,11 @@ export class ShellRunProcessManager {
       .sort(compareActionableShellRuns);
   }
 
-  private async resourceDetail(sessionId: string, shellRunId: string): Promise<ShellRunToolResult> {
+  private async resourceDetail(
+    sessionId: string,
+    shellRunId: string,
+    markObserved: boolean,
+  ): Promise<ShellRunToolResult> {
     let record = await this.input.store.readShellRun(sessionId, shellRunId);
     if (record.status === 'running') {
       const live = this.live.get(shellRunId);
@@ -508,7 +518,7 @@ export class ShellRunProcessManager {
         record = await this.markOrphaned(record, 'missing live shell process handle during resource read');
       }
     }
-    if (isTerminalShellRunStatus(record.status)) {
+    if (markObserved && isTerminalShellRunStatus(record.status)) {
       record = await this.markObserved(record);
     }
     return shellRunContent(record);

--- a/packages/runtime/src/shell-run-manager.ts
+++ b/packages/runtime/src/shell-run-manager.ts
@@ -83,6 +83,7 @@ interface LiveShellRun {
   stderrBuf: BashTailBuffer;
   stdoutChars: number;
   stderrChars: number;
+  latestOutputStream?: 'stdout' | 'stderr';
   pendingFlushChars: number;
   flushTimer?: NodeJS.Timeout;
   flushChain: Promise<void>;
@@ -327,6 +328,7 @@ export class ShellRunProcessManager {
 
   private append(live: LiveShellRun, stream: 'stdout' | 'stderr', chunk: string): void {
     if (live.settled || chunk.length === 0) return;
+    if (chunk.trim()) live.latestOutputStream = stream;
     if (stream === 'stdout') {
       live.stdoutBuf.push(chunk);
       live.stdoutChars += chunk.length;
@@ -421,13 +423,14 @@ export class ShellRunProcessManager {
 
   private tailPatch(live: LiveShellRun): Pick<
     ShellRunRecord,
-    'stdoutTail' | 'stderrTail' | 'stdoutTruncated' | 'stderrTruncated'
+    'stdoutTail' | 'stderrTail' | 'latestOutputStream' | 'stdoutTruncated' | 'stderrTruncated'
   > {
     const stdoutRawTail = shellTailValueWithUnsafeDropMarker(live.stdoutBuf);
     const stderrRawTail = shellTailValueWithUnsafeDropMarker(live.stderrBuf);
     return {
       stdoutTail: redactSecrets(stdoutRawTail),
       stderrTail: redactSecrets(stderrRawTail),
+      ...(live.latestOutputStream ? { latestOutputStream: live.latestOutputStream } : {}),
       stdoutTruncated: live.stdoutChars > stdoutRawTail.length || live.stdoutBuf.hasDroppedUnsafe(),
       stderrTruncated: live.stderrChars > stderrRawTail.length || live.stderrBuf.hasDroppedUnsafe(),
     };
@@ -574,6 +577,7 @@ function shellRunContent(record: ShellRunRecord, cancelled?: boolean): ShellRunT
     ...(record.failureMessage !== undefined ? { failureMessage: record.failureMessage } : {}),
     stdout: stdout.content,
     stderr: stderr.content,
+    ...(record.latestOutputStream ? { latestOutputStream: record.latestOutputStream } : {}),
     stdoutTruncated: record.stdoutTruncated || stdout.truncated,
     stderrTruncated: record.stderrTruncated || stderr.truncated,
     ...(record.timeoutMs !== undefined ? { timeoutMs: record.timeoutMs } : {}),

--- a/packages/runtime/src/shell-tools.ts
+++ b/packages/runtime/src/shell-tools.ts
@@ -50,7 +50,7 @@ export interface ShellRunToolController {
   readResource(
     sessionId: string,
     ref: string,
-  ): Promise<{ content: string }>;
+  ): Promise<ShellRunToolResult>;
   stopResource(sessionId: string, ref: string): Promise<ShellRunToolResult>;
 }
 

--- a/packages/storage/src/__tests__/shell-run-store.test.ts
+++ b/packages/storage/src/__tests__/shell-run-store.test.ts
@@ -16,12 +16,14 @@ describe('ShellRunStore', () => {
         status: 'completed',
         exitCode: 0,
         stdoutTail: 'done',
+        latestOutputStream: 'stdout',
         completedAt: 10,
         updatedAt: 10,
       });
 
       assert.equal(updated.status, 'completed');
       assert.equal(updated.stdoutTail, 'done');
+      assert.equal(updated.latestOutputStream, 'stdout');
       assert.deepEqual((await store.listSessionShellRuns('session-1')).map((run) => run.shellRunId), ['shell-1', 'shell-2']);
       assert.equal((await store.readShellRun('session-1', 'shell-1')).completedAt, 10);
       assert.equal(

--- a/packages/storage/src/shell-run-store.ts
+++ b/packages/storage/src/shell-run-store.ts
@@ -163,6 +163,7 @@ function normalizeShellRunRecord(value: unknown, sessionId: string, shellRunId: 
     (record.exitCode === undefined || isFiniteNumber(record.exitCode)) &&
     (record.observedAt === undefined || isFiniteNumber(record.observedAt)) &&
     (record.pid === undefined || isFiniteNumber(record.pid)) &&
+    (record.latestOutputStream === undefined || record.latestOutputStream === 'stdout' || record.latestOutputStream === 'stderr') &&
     typeof record.stdoutTruncated === 'boolean' &&
     typeof record.stderrTruncated === 'boolean' &&
     optionalStrings.every((item) => item === undefined || typeof item === 'string');


### PR DESCRIPTION
## Summary

- Keep long-running background Bash cards visibly running until the process settles.
- Update the original Bash card with elapsed time, retained output, and the final done, failed, or aborted state.
- Fold matching Read and StopBackgroundTask results into that card, including session resume and rewind branches.

## Why

A yielded Bash command currently looks finished while its process is still running. Later polling also appears as separate internal tool cards, so the CLI presents implementation details instead of the real task state.

Refs #549

## Scope

Changed:

- Return structured shell-run results from runtime resource reads.
- Publish post-yield output and terminal updates to the active CLI session.
- Restore background-task state from durable storage when resuming a session.
- Keep UI resume hydration non-observing, so it cannot consume the agent's terminal-state notification.
- Persist the latest stdout/stderr stream and invalidate cached cards on every accepted result revision.
- Mark still-running tasks inherited by a rewind branch as detached, because the branch does not own them.

Not included:

- A direct `/stop` command.
- Status-line, onboarding, scrollback, or narrow-layout redesigns.

## Verification

- `npm run -w @maka/storage test` — 206 passed.
- `npm run -w @maka/runtime test` — 1137 passed, 2 skipped.
- `npm run -w packages/cli test` — 242 passed.
- `npm run typecheck` — passed for all workspaces.
- GitHub CI `typecheck`, `test`, and `e2e` — passed.

## User-facing impact

Background Bash work now stays in one truthful card from handoff through completion. Resumed sessions recover the durable task state, while rewind branches no longer claim control over tasks owned by their source session.

No docs, changelog, migration, dependency, or breaking changes.

## Reviewer notes

The main review boundary is state reconciliation across live observer updates, stored transcript data, and durable shell-run records. Updates are monotonic by `updatedAt`; terminal state wins over an equal-time running state. Matching is restricted to the exact session, source Bash tool call, and resource ref.

UI hydration uses a non-observing snapshot path. Mutable tool results carry an in-memory revision so render-cache invalidation does not duplicate the result rendering contract.

Screenshots are not included because deterministic transcript and TUI tests cover the behavior.

## Checklist

- [x] Scope matches the PR title and excludes unrelated changes.
- [x] Verification commands and results are listed.
- [x] User-facing impact and release-documentation impact are noted.
- [x] Review focus is called out.
- [x] UI behavior is covered by deterministic tests.