### PR TITLE
fix(ui): keep tool batch counts stable

### DIFF
--- a/apps/desktop/src/main/__tests__/streaming-handoff.test.ts
+++ b/apps/desktop/src/main/__tests__/streaming-handoff.test.ts
@@ -319,6 +319,51 @@ describe('single live-turn handoff', () => {
     assert.equal(liveTurns.get()['session-1'], undefined);
   });
 
+  it('reconciles persisted stream evidence while the next tool batch is running', () => {
+    const projection: LiveTurnProjection = {
+      turnId: 'turn-1',
+      phase: 'streamed',
+      steps: [
+        {
+          stepId: 'step-1',
+          tools: [{
+            toolUseId: 'old-tool', toolName: 'Bash', status: 'completed', args: {},
+            outputChunks: [{ seq: 0, stream: 'stdout', text: 'old\n', redacted: false, createdAt: 1 }],
+          }],
+          contentOrder: ['tools'],
+        },
+        {
+          stepId: 'step-2',
+          tools: [{ toolUseId: 'new-tool', toolName: 'Bash', status: 'running', args: {} }],
+          contentOrder: ['tools'],
+        },
+      ],
+    };
+    const liveTurns = createStateSetter<Record<string, LiveTurnProjection>>({ 'session-1': projection });
+    const ref = { current: liveTurns.get() };
+    const permissions = createStateSetter<PermissionQueues>({});
+    const handlers = createAppShellSessionEventHandlers({
+      activeIdRef: { current: 'session-1' },
+      liveTurnBySessionRef: ref,
+      refreshMessages: async () => true,
+      refreshSessions: async () => [],
+      setLiveTurnBySession: (updater) => {
+        liveTurns.set(updater);
+        ref.current = liveTurns.get();
+      },
+      setPermissionBySession: permissions.set,
+      showModelSetupToast: () => {},
+      toastApi: { error: () => {} },
+    });
+
+    handlers.reconcilePersistedMessages('session-1', [
+      { type: 'tool_call', id: 'old-tool', turnId: 'turn-1', stepId: 'step-1', ts: 1, toolName: 'Bash', args: {} },
+      { type: 'tool_result', id: 'old-result', turnId: 'turn-1', ts: 2, toolUseId: 'old-tool', isError: false, content: { kind: 'text', text: 'old\n' } },
+    ]);
+
+    assert.deepEqual(liveTurns.get()['session-1']?.steps, [projection.steps[1]]);
+  });
+
   it('settles a tool-only terminal projection after persisted history refreshes', async () => {
     const liveTurns = createStateSetter<Record<string, LiveTurnProjection>>({
       'session-1': {

--- a/apps/desktop/src/renderer/app-shell-session-events.ts
+++ b/apps/desktop/src/renderer/app-shell-session-events.ts
@@ -91,7 +91,7 @@ export function createAppShellSessionEventHandlers(options: {
   function reconcilePersistedMessages(sessionId: string, messages: readonly StoredMessage[]): void {
     setLiveTurnBySession((current) => {
       const projection = current[sessionId];
-      if (!projection?.terminal) return current;
+      if (!projection) return current;
       const reconciled = reconcileTerminalLiveTurn(projection, messages);
       if (reconciled === projection) return current;
       const next = { ...current };

--- a/apps/desktop/src/renderer/app-shell.tsx
+++ b/apps/desktop/src/renderer/app-shell.tsx
@@ -1039,10 +1039,10 @@ export function AppShell({
     },
   });
 
-  // A terminal tool/thinking projection may survive when its event-triggered
-  // refresh fails. Reconcile from durable evidence whenever either side
-  // changes, so a later poll, manual retry, or session refresh closes the
-  // handoff without deleting text that the smoother still owns.
+  // Tool/thinking evidence may survive its event-triggered refresh, including
+  // between steps of one running turn. Reconcile from durable evidence whenever
+  // either side changes, so old output stays on its original tool instead of
+  // joining the next batch, without deleting text that the smoother still owns.
   const reconcilePersistedMessagesEffect = useEffectEvent(reconcilePersistedMessages);
   useEffect(() => {
     if (!activeId) return;

--- a/packages/ui/src/__tests__/live-turn-projection.test.ts
+++ b/packages/ui/src/__tests__/live-turn-projection.test.ts
@@ -7,7 +7,7 @@ import {
   settleLiveTurnStep,
   type LiveTurnProjection,
 } from '../live-turn-projection.js';
-import { overlayLiveTurn } from '../materialize.js';
+import { overlayLiveTurn, type ToolActivityItem } from '../materialize.js';
 
 describe('applyLiveTurnEvent', () => {
   it('moves an armed turn from waiting to streamed on its first content event', () => {
@@ -643,5 +643,38 @@ describe('reconcileTerminalLiveTurn', () => {
     assert.equal(reconcileTerminalLiveTurn(thinkingOnly, [
       { type: 'assistant', id: 'step-1', turnId: 'turn-1', ts: 1, text: '', thinking: { text: 'reasoning' }, modelId: 'm' },
     ]), undefined);
+  });
+
+  it('drops persisted stream evidence before the next tool batch settles', () => {
+    const evidence = (toolUseId: string): ToolActivityItem => ({
+      toolUseId,
+      toolName: 'Bash',
+      status: 'completed',
+      args: {},
+      outputChunks: [{ seq: 0, stream: 'stdout', text: 'ok\n', redacted: false, createdAt: 1 }],
+    });
+    const current = (toolUseId: string): ToolActivityItem => ({
+      toolUseId,
+      toolName: 'Bash',
+      status: 'running',
+      args: {},
+    });
+    const projection: LiveTurnProjection = {
+      turnId: 'turn-1',
+      phase: 'streamed',
+      steps: [
+        { stepId: 'step-1', tools: ['old-1', 'old-2', 'old-3'].map(evidence), contentOrder: ['tools'] },
+        { stepId: 'step-2', tools: ['new-1', 'new-2', 'new-3', 'new-4'].map(current), contentOrder: ['tools'] },
+      ],
+    };
+    const persisted = ['old-1', 'old-2', 'old-3'].flatMap((toolUseId, index) => ([
+      { type: 'tool_call' as const, id: toolUseId, turnId: 'turn-1', stepId: 'step-1', ts: index * 2 + 1, toolName: 'Bash', args: {} },
+      { type: 'tool_result' as const, id: `result-${toolUseId}`, turnId: 'turn-1', ts: index * 2 + 2, toolUseId, isError: false, content: { kind: 'text' as const, text: 'ok\n' } },
+    ]));
+
+    assert.deepEqual(reconcileTerminalLiveTurn(projection, persisted), {
+      ...projection,
+      steps: [projection.steps[1]!],
+    });
   });
 });

--- a/packages/ui/src/live-turn-projection.ts
+++ b/packages/ui/src/live-turn-projection.ts
@@ -348,15 +348,15 @@ function durableStreamEvidence(
 }
 
 /**
- * Removes terminal non-text steps only when the persisted transcript can
- * render the same durable evidence. Text steps remain owned by the smoother,
- * whose completion callback performs their handoff after the tail is visible.
+ * Removes evidence-only steps once the persisted transcript can render the
+ * same durable output, including while a later step is still running. Text
+ * steps remain owned by the smoother, whose completion callback performs
+ * their handoff after the tail is visible.
  */
 export function reconcileTerminalLiveTurn(
   current: LiveTurnProjection,
   messages: readonly StoredMessage[],
 ): LiveTurnProjection | undefined {
-  if (!current.terminal) return current;
   const turnMessages = messages.filter((message) => message.turnId === current.turnId);
   const assistantIds = new Set(turnMessages.flatMap((message) => message.type === 'assistant' ? [message.id] : []));
   const toolCallIds = new Set(turnMessages.flatMap((message) => message.type === 'tool_call' ? [message.id] : []));


### PR DESCRIPTION
## Summary

- Reconcile persisted tool stream evidence during multi-step turns instead of waiting for the whole turn to finish.
- Keep completed Bash output attached to its original tool row without counting it again in the next batch.
- Add UI projection and desktop handoff regression coverage.

## Why

Completed tools with streamed output remained in the live projection until the turn became terminal. During a multi-step turn, those retained Bash rows were merged into later tool groups, so batch counts accumulated as `3, 7, 11, 14` even though the actual batches contained `3, 4, 4, 3` commands. The count snapped back only after persisted history replaced the stale live rows.

## Scope

Changed:

- Live-turn reconciliation now removes evidence-only steps as soon as persisted history contains equivalent durable output.
- Desktop reconciliation runs while a later step is still active.
- Regression tests cover both the UI projection and desktop event-handler boundary.

Not included:

- Tool execution or persistence format changes.
- Tool summary copy, styling, or layout changes.
- Changes to incomplete or empty `shell_run` evidence retention.

## Verification

- `npm run -w @maka/ui test` — 99 tests passed.
- `npm run -w @maka/desktop test` — 2,312 tests passed.
- Replayed the recorded four-batch session: counts remain `3, 4, 4, 3`, with no residual live evidence.

## User-facing impact

Tool counts remain stable before and after each call completes, while streamed output stays available on the original tool row. No docs, changelog, migrations, or breaking changes.

## Reviewer notes

The review focus is the expansion from terminal-only reconciliation to active multi-step turns. `durableStreamEvidence` still prevents handoff when persisted terminal or `shell_run` output is empty, so live-only output is not discarded.

No new screenshot is included because this is a timing/state reconciliation fix with no visual styling change; the original recorded symptom is locked by deterministic projection and handoff tests.

## Checklist

- [x] Scope matches the PR title and excludes unrelated changes
- [x] Verification lists commands/results
- [x] User-facing impact and absence of docs/changelog/migration/breaking changes are noted
- [x] Risk and review focus are called out
- [x] UI screenshot/video applicability is explained
