### PR TITLE
fix(headless): make runtime A/B experiments fail closed

### DIFF
--- a/packages/headless/harbor/run-runtime-policy-ab.mjs
+++ b/packages/headless/harbor/run-runtime-policy-ab.mjs
@@ -1,0 +1,126 @@
+#!/usr/bin/env node
+
+import { createHash } from 'node:crypto';
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { homedir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { BENCHMARK_BASE_SYSTEM_PROMPT } from '@maka/headless';
+import { ensureAbRunManifest } from '#ab-manifest';
+import { discoverCachedHarborTasks, resolveFixedPromptRunRoot } from '#fixed-prompt-task-source';
+import { createHarborTaskRunner } from '#harbor-task-runner';
+import { runRuntimePolicyAbLifecycle } from '#runtime-policy-ab-lifecycle';
+import { parseRuntimePolicyAbExecutionProfile } from '#runtime-policy-ab-profile';
+import { buildRuntimePolicyAbRunManifest, renderRuntimePolicyAbComparisonMarkdown } from '#runtime-policy-ab-run';
+import { parseRuntimePolicyAbSpec } from '#runtime-policy-ab-spec';
+import { buildSubjectFingerprint, buildTaskSourceFingerprint, buildToolchainFingerprint } from './run-prompt-ab.mjs';
+
+function envPath(name, fallback) {
+  const raw = process.env[name] || fallback;
+  if (!raw) throw new Error(`${name} is required`);
+  return raw.startsWith('~') ? join(homedir(), raw.slice(1)) : resolve(raw);
+}
+
+function selectTasks(allTasks, taskIds, label) {
+  const byId = new Map(allTasks.map((task) => [task.id, task]));
+  const missing = taskIds.filter((id) => !byId.has(id));
+  if (missing.length > 0) throw new Error(`${label} contains unknown task id(s): ${missing.join(', ')}`);
+  return taskIds.map((id) => byId.get(id));
+}
+
+async function main() {
+  const repoRoot = resolve(fileURLToPath(new URL('../../..', import.meta.url)));
+  const makaRepoPath = process.env.MAKA_RUNTIME_AB_MAKA_REPO ? resolve(process.env.MAKA_RUNTIME_AB_MAKA_REPO) : repoRoot;
+  const outDir = envPath('MAKA_RUNTIME_AB_OUT_DIR');
+  const tasksRoot = envPath('MAKA_RUNTIME_AB_TASKS_ROOT', join(homedir(), '.cache/harbor/tasks'));
+  const specPath = envPath('MAKA_RUNTIME_AB_SPEC_PATH');
+  const profilePath = envPath('MAKA_RUNTIME_AB_PROFILE_PATH');
+  const runId = process.env.MAKA_RUNTIME_AB_RUN_ID || `runtime-policy-ab-${Date.now()}`;
+  const runRoot = resolveFixedPromptRunRoot(outDir, runId, 'MAKA_RUNTIME_AB_RUN_ID');
+  const spec = parseRuntimePolicyAbSpec(JSON.parse(await readFile(specPath, 'utf8')));
+  const executionProfile = parseRuntimePolicyAbExecutionProfile(JSON.parse(await readFile(profilePath, 'utf8')));
+  const allTasks = await discoverCachedHarborTasks(tasksRoot);
+  const pilotTasks = selectTasks(allTasks, spec.pilotTaskIds, 'pilotTaskIds');
+  const evaluationTasks = selectTasks(allTasks, spec.evaluationTaskIds, 'evaluationTaskIds');
+  const systemPrompt = `${BENCHMARK_BASE_SYSTEM_PROMPT}\n`;
+  const runManifest = buildRuntimePolicyAbRunManifest({
+    arms: spec.arms,
+    promptHash: `sha256:${createHash('sha256').update(JSON.stringify(systemPrompt)).digest('hex')}`,
+    executionProfile,
+    sharedAgentEnv: spec.sharedAgentEnv,
+    subjectFingerprint: await buildSubjectFingerprint(makaRepoPath, process.env.MAKA_RUNTIME_AB_EXPLICIT_SUBJECT_FINGERPRINT),
+    taskSourceFingerprint: await buildTaskSourceFingerprint(tasksRoot, [...pilotTasks, ...evaluationTasks]),
+    toolchainFingerprint: await buildToolchainFingerprint(process.env.MAKA_RUNTIME_AB_TOOLCHAIN_FINGERPRINT, undefined, makaRepoPath),
+    evaluationTaskIds: evaluationTasks.map((task) => task.id),
+    pilotTaskIds: pilotTasks.map((task) => task.id),
+    reps: spec.fullReps,
+    candidateLimit: null,
+    selectionMode: 'explicit',
+    candidateTaskIds: evaluationTasks.map((task) => task.id),
+    nonInferiorityMargin: spec.nonInferiorityMargin,
+  });
+  const manifestPath = join(runRoot, 'runtime-policy-ab-manifest.json');
+  await ensureAbRunManifest(manifestPath, runManifest);
+
+  if (process.env.MAKA_RUNTIME_AB_DRY_RUN === '1') {
+    console.log(`dry-run: executable manifest validated -> ${manifestPath}`);
+    return;
+  }
+
+  const keyFile = envPath('MAKA_RUNTIME_AB_KEY_FILE', join(repoRoot, '.local-secrets/deepseek-key'));
+  await readFile(keyFile, 'utf8');
+  const controllerDir = join(runRoot, 'controller');
+  const jobsDir = join(runRoot, 'jobs');
+  const promptsDir = join(runRoot, 'prompts');
+  await mkdir(controllerDir, { recursive: true });
+  await mkdir(jobsDir, { recursive: true });
+  await mkdir(promptsDir, { recursive: true });
+  const systemPromptPath = join(promptsDir, 'shared-system-prompt.md');
+  await writeFile(systemPromptPath, systemPrompt, 'utf8');
+  const config = {
+    id: `runtime-policy-ab-${spec.id}`,
+    backend: 'harbor',
+    llmConnectionSlug: executionProfile.llmConnectionSlug,
+    model: executionProfile.model,
+  };
+  const harborRunner = createHarborTaskRunner({
+    makaRepoPath,
+    jobsDir,
+    model: executionProfile.model,
+    provider: executionProfile.provider,
+    apiKeyFile: keyFile,
+    pricing: executionProfile.pricing,
+    agentEnv: {
+      DEEPSEEK_BASE_URL: executionProfile.baseUrl,
+      MAKA_CELL_TIMEOUT_SEC: String(executionProfile.taskBudgetSec),
+    },
+    harborTimeoutMs: executionProfile.harborTimeoutMs,
+  });
+  const state = await runRuntimePolicyAbLifecycle({
+    runId,
+    runRoot,
+    manifestFingerprint: runManifest.fingerprint,
+    config,
+    systemPromptPath,
+    resultsJsonlPath: join(controllerDir, 'results.jsonl'),
+    pilotTasks,
+    evaluationTasks,
+    fullReps: spec.fullReps,
+    arms: spec.arms,
+    executionProfile,
+    nonInferiorityMargin: spec.nonInferiorityMargin,
+    sharedAgentEnv: spec.sharedAgentEnv,
+    resumeFingerprint: runManifest.fingerprint,
+    harborRunner,
+  });
+  await writeFile(join(runRoot, 'runtime-policy-ab-result.json'), `${JSON.stringify({ runManifest, spec, state }, null, 2)}\n`, 'utf8');
+  if (state.full) await writeFile(join(runRoot, 'runtime-policy-ab-report.md'), renderRuntimePolicyAbComparisonMarkdown(state.full), 'utf8');
+  console.log(`status: ${state.status}${state.reason ? ` (${state.reason})` : ''}`);
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  main().catch((error) => {
+    console.error(error);
+    process.exitCode = 1;
+  });
+}

--- a/packages/headless/harbor/run-runtime-policy-ab.mjs
+++ b/packages/headless/harbor/run-runtime-policy-ab.mjs
@@ -115,7 +115,7 @@ async function main() {
   });
   await writeFile(join(runRoot, 'runtime-policy-ab-result.json'), `${JSON.stringify({ runManifest, spec, state }, null, 2)}\n`, 'utf8');
   if (state.full) await writeFile(join(runRoot, 'runtime-policy-ab-report.md'), renderRuntimePolicyAbComparisonMarkdown(state.full), 'utf8');
-  console.log(`status: ${state.status}${state.reason ? ` (${state.reason})` : ''}`);
+  console.log(`status: ${state.status}${state.reason ? ` (${state.reason})` : ''}${state.full ? `; decision: ${state.full.decision}` : ''}`);
 }
 
 if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {

--- a/packages/headless/harbor/runtime-policy-ab-profiles/deepseek-v4-flash.json
+++ b/packages/headless/harbor/runtime-policy-ab-profiles/deepseek-v4-flash.json
@@ -14,6 +14,6 @@
   },
   "taskBudgetSec": 1800,
   "harborTimeoutMs": 2100000,
-  "costCeilingUsd": 20,
-  "maxConcurrentAttempts": 4
+  "observedCostStopUsd": 20,
+  "maxConcurrentAttempts": 2
 }

--- a/packages/headless/harbor/runtime-policy-ab-profiles/deepseek-v4-flash.json
+++ b/packages/headless/harbor/runtime-policy-ab-profiles/deepseek-v4-flash.json
@@ -1,0 +1,19 @@
+{
+  "schemaVersion": 1,
+  "id": "deepseek-v4-flash",
+  "llmConnectionSlug": "deepseek",
+  "provider": "deepseek",
+  "baseUrl": "https://api.deepseek.com",
+  "model": "deepseek/deepseek-v4-flash",
+  "pricing": {
+    "inputUsdPer1M": 0.145,
+    "outputUsdPer1M": 0.29,
+    "cacheReadUsdPer1M": 0.0029,
+    "cacheWriteUsdPer1M": 0,
+    "source": "deepseek-v4-flash"
+  },
+  "taskBudgetSec": 1800,
+  "harborTimeoutMs": 2100000,
+  "costCeilingUsd": 20,
+  "maxConcurrentAttempts": 4
+}

--- a/packages/headless/package.json
+++ b/packages/headless/package.json
@@ -32,6 +32,10 @@
     "#prompt-ab-run": "./dist/prompt-ab-run.js",
     "#harbor-task-runner": "./dist/harbor-task-runner.js",
     "#harbor-cell": "./dist/harbor-cell.js",
+    "#runtime-policy-ab-profile": "./dist/runtime-policy-ab-profile.js",
+    "#runtime-policy-ab-spec": "./dist/runtime-policy-ab-spec.js",
+    "#runtime-policy-ab-run": "./dist/runtime-policy-ab-run.js",
+    "#runtime-policy-ab-lifecycle": "./dist/runtime-policy-ab-lifecycle.js",
     "#prompt-structural-smoke": "./dist/prompt-structural-smoke.js"
   },
   "bin": {

--- a/packages/headless/src/__tests__/ab-manifest.test.ts
+++ b/packages/headless/src/__tests__/ab-manifest.test.ts
@@ -1,6 +1,9 @@
 import assert from 'node:assert/strict';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { describe, test } from 'node:test';
-import { buildAbRunManifest } from '../ab-manifest.js';
+import { buildAbRunManifest, ensureAbRunManifest } from '../ab-manifest.js';
 import { sha256 } from './helpers/hash-fixture.js';
 
 describe('buildAbRunManifest', () => {
@@ -38,5 +41,33 @@ describe('buildAbRunManifest', () => {
       'tools:tools-on',
     ]);
     assert.match(manifest.fingerprint, /^sha256:[a-f0-9]{64}$/);
+  });
+
+  test('rejects a stored manifest whose body no longer matches its fingerprint', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'maka-ab-manifest-'));
+    try {
+      const manifest = buildAbRunManifest({
+        experimentKind: 'runtime',
+        arms: [
+          { id: 'off', kind: 'runtime', fingerprint: sha256('off') },
+          { id: 'on', kind: 'runtime', fingerprint: sha256('on') },
+        ],
+        taskBudgetSec: 1800,
+        harborTimeoutMs: 2_100_000,
+        subjectFingerprint: sha256('subject'),
+        taskSourceFingerprint: sha256('tasks'),
+        toolchainFingerprint: sha256('toolchain'),
+        evaluationTaskIds: ['task-a'],
+        reps: 1,
+        candidateLimit: null,
+        maxConcurrency: 1,
+      });
+      const path = join(dir, 'manifest.json');
+      await writeFile(path, `${JSON.stringify({ ...manifest, taskBudgetSec: 60 })}\n`, 'utf8');
+
+      await assert.rejects(ensureAbRunManifest(path, manifest), /stored A\/B run manifest fingerprint is invalid/);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
   });
 });

--- a/packages/headless/src/__tests__/ab-manifest.test.ts
+++ b/packages/headless/src/__tests__/ab-manifest.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, test } from 'node:test';
@@ -66,6 +66,43 @@ describe('buildAbRunManifest', () => {
       await writeFile(path, `${JSON.stringify({ ...manifest, taskBudgetSec: 60 })}\n`, 'utf8');
 
       await assert.rejects(ensureAbRunManifest(path, manifest), /stored A\/B run manifest fingerprint is invalid/);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  test('atomically chooses one canonical manifest when two processes create the same run', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'maka-ab-manifest-race-'));
+    try {
+      const base = {
+        experimentKind: 'runtime' as const,
+        arms: [
+          { id: 'off', kind: 'runtime' as const, fingerprint: sha256('off') },
+          { id: 'on', kind: 'runtime' as const, fingerprint: sha256('on') },
+        ] as const,
+        taskBudgetSec: 1800,
+        harborTimeoutMs: 2_100_000,
+        subjectFingerprint: sha256('subject'),
+        taskSourceFingerprint: sha256('tasks'),
+        toolchainFingerprint: sha256('toolchain'),
+        evaluationTaskIds: ['task-a'],
+        reps: 2,
+        candidateLimit: null,
+        maxConcurrency: 1,
+      };
+      const flash = buildAbRunManifest({ ...base, observedCostStopUsd: 20 });
+      const pro = buildAbRunManifest({ ...base, observedCostStopUsd: 30 });
+      const path = join(dir, 'manifest.json');
+
+      const results = await Promise.allSettled([
+        ensureAbRunManifest(path, flash),
+        ensureAbRunManifest(path, pro),
+      ]);
+
+      assert.equal(results.filter((result) => result.status === 'fulfilled').length, 1);
+      assert.equal(results.filter((result) => result.status === 'rejected').length, 1);
+      const stored = JSON.parse(await readFile(path, 'utf8'));
+      assert.equal(stored.fingerprint === flash.fingerprint || stored.fingerprint === pro.fingerprint, true);
     } finally {
       await rm(dir, { recursive: true, force: true });
     }

--- a/packages/headless/src/__tests__/ab-render.test.ts
+++ b/packages/headless/src/__tests__/ab-render.test.ts
@@ -27,7 +27,7 @@ describe('renderAbComparisonMarkdown', () => {
 
     const markdown = renderAbComparisonMarkdown(result);
 
-    assert.match(markdown, /Decision: B non-inferior \(non_inferiority_lower_bound_within_margin\)/);
+    assert.match(markdown, /Decision: not cleared \(non_inferiority_confidence_interval_crosses_margin\)/);
     assert.match(markdown, /Budget: 600s task budget/);
     assert.match(markdown, /Evaluation pass rate: A=1\/4 = 0.25, B=4\/4 = 1/);
     assert.match(markdown, /Task-level delta: mean=0.75/);

--- a/packages/headless/src/__tests__/ab-run-lock.test.ts
+++ b/packages/headless/src/__tests__/ab-run-lock.test.ts
@@ -1,0 +1,18 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { test } from 'node:test';
+import { withAbRunLock } from '../ab-run-lock.js';
+
+test('withAbRunLock excludes concurrent writers and releases after completion', async () => {
+  const dir = await mkdtemp(join(tmpdir(), 'maka-ab-lock-'));
+  try {
+    await withAbRunLock(dir, async () => {
+      await assert.rejects(withAbRunLock(dir, async () => undefined), /A\/B run is already active/);
+    });
+    await withAbRunLock(dir, async () => undefined);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});

--- a/packages/headless/src/__tests__/ab-run.test.ts
+++ b/packages/headless/src/__tests__/ab-run.test.ts
@@ -3,6 +3,7 @@ import { describe, test } from 'node:test';
 import { runAbComparison } from '../ab-run.js';
 import { completed } from './helpers/ab-run-fixtures.js';
 import { sha256 } from './helpers/hash-fixture.js';
+import type { FixedPromptTaskInfraFailedEvent } from '../fixed-prompt-controller.js';
 
 describe('runAbComparison', () => {
   test('rejects arm ids that collapse to the same round id suffix', async () => {
@@ -126,4 +127,47 @@ describe('runAbComparison', () => {
     assert.deepEqual(calls, ['ab-tools-off-r0-t1', 'ab-tools-on-r0-t1']);
     assert.equal(result.stopReason, 'cost_ceiling_reached');
   });
+
+  test('stops scheduling new pairs after a systemic provider failure', async () => {
+    const calls: string[] = [];
+    const result = await runAbComparison({
+      runId: 'ab-run',
+      arms: [
+        { id: 'off', kind: 'runtime', fingerprint: sha256('off') },
+        { id: 'on', kind: 'runtime', fingerprint: sha256('on') },
+      ],
+      evaluationTasks: [
+        { id: 't1', path: '/tasks/t1' },
+        { id: 't2', path: '/tasks/t2' },
+        { id: 't3', path: '/tasks/t3' },
+      ],
+      reps: 1,
+      maxConcurrency: 1,
+      runArm: async ({ roundId, task }) => {
+        calls.push(roundId);
+        return providerBilling(task.id);
+      },
+    });
+
+    assert.deepEqual(calls, ['ab-off-r0-t1', 'ab-on-r0-t1']);
+    assert.equal(result.stopReason, 'systemic_provider_failure');
+  });
 });
+
+function providerBilling(taskId: string): FixedPromptTaskInfraFailedEvent {
+  return {
+    schemaVersion: 1,
+    type: 'task_infra_failed',
+    id: `event-${taskId}`,
+    ts: 0,
+    runId: 'ab-run',
+    roundId: 'round',
+    taskId,
+    status: 'infra_failed',
+    passed: false,
+    scored: false,
+    eligible: false,
+    errorClass: 'provider_billing',
+    error: 'provider billing failure',
+  };
+}

--- a/packages/headless/src/__tests__/ab-run.test.ts
+++ b/packages/headless/src/__tests__/ab-run.test.ts
@@ -101,4 +101,29 @@ describe('runAbComparison', () => {
       'ab-tools-on-r0-t1',
     ]);
   });
+
+  test('stops scheduling pairs after the hard cost ceiling is reached', async () => {
+    const calls: string[] = [];
+    const result = await runAbComparison({
+      runId: 'ab-run',
+      arms: [
+        { id: 'tools-off', kind: 'tools', fingerprint: sha256('tools-off') },
+        { id: 'tools-on', kind: 'tools', fingerprint: sha256('tools-on') },
+      ],
+      evaluationTasks: [
+        { id: 't1', path: '/tasks/t1' },
+        { id: 't2', path: '/tasks/t2' },
+      ],
+      reps: 1,
+      maxConcurrency: 1,
+      costCeilingUsd: 0.02,
+      runArm: async ({ roundId, task }) => {
+        calls.push(roundId);
+        return completed(task.id, true);
+      },
+    });
+
+    assert.deepEqual(calls, ['ab-tools-off-r0-t1', 'ab-tools-on-r0-t1']);
+    assert.equal(result.stopReason, 'cost_ceiling_reached');
+  });
 });

--- a/packages/headless/src/__tests__/ab-run.test.ts
+++ b/packages/headless/src/__tests__/ab-run.test.ts
@@ -103,7 +103,7 @@ describe('runAbComparison', () => {
     ]);
   });
 
-  test('stops scheduling pairs after the hard cost ceiling is reached', async () => {
+  test('stops scheduling new pairs after the observed cost threshold is reached', async () => {
     const calls: string[] = [];
     const result = await runAbComparison({
       runId: 'ab-run',
@@ -117,7 +117,7 @@ describe('runAbComparison', () => {
       ],
       reps: 1,
       maxConcurrency: 1,
-      costCeilingUsd: 0.02,
+      observedCostStopUsd: 0.02,
       runArm: async ({ roundId, task }) => {
         calls.push(roundId);
         return completed(task.id, true);
@@ -125,7 +125,7 @@ describe('runAbComparison', () => {
     });
 
     assert.deepEqual(calls, ['ab-tools-off-r0-t1', 'ab-tools-on-r0-t1']);
-    assert.equal(result.stopReason, 'cost_ceiling_reached');
+    assert.equal(result.stopReason, 'observed_cost_stop_reached');
   });
 
   test('stops scheduling new pairs after a systemic provider failure', async () => {

--- a/packages/headless/src/__tests__/ab-summary.test.ts
+++ b/packages/headless/src/__tests__/ab-summary.test.ts
@@ -72,8 +72,8 @@ describe('summarizeAbComparison', () => {
       budgetMs: 600_000,
     });
 
-    assert.equal(result.decision, 'inferior');
-    assert.equal(result.reason, 'pass_rate_delta_below_non_inferiority_margin');
+    assert.equal(result.decision, 'invalid');
+    assert.equal(result.reason, 'asymmetric_budget_exhaustion');
     assert.equal(result.candidate.passRate, 0);
     assert.equal(result.candidate.budgetExhausted, 1);
     assert.equal(result.candidate.infraFailed, 0);
@@ -560,7 +560,7 @@ describe('summarizeAbComparison', () => {
     assert.equal(result.taskLevel.wins, 9);
     assert.equal(result.taskLevel.losses, 7);
     assert.equal(result.taskLevel.signTestPValue !== null && result.taskLevel.signTestPValue > 0.05, true);
-    assert.equal(result.decision, 'inconclusive');
+    assert.equal(result.decision, 'not_cleared');
     assert.equal(result.reason, 'non_inferiority_confidence_interval_crosses_margin');
     assert.equal(result.nonInferiority.lowerBound !== null && result.nonInferiority.lowerBound < -0.1, true);
   });
@@ -600,7 +600,7 @@ describe('summarizeAbComparison', () => {
     });
     assert.equal(underpoweredNinePointLoss.nonInferiorityMargin, 0.1);
     assert.equal(underpoweredNinePointLoss.passRateDelta, -0.09);
-    assert.equal(underpoweredNinePointLoss.decision, 'inconclusive');
+    assert.equal(underpoweredNinePointLoss.decision, 'not_cleared');
     assert.equal(underpoweredNinePointLoss.reason, 'non_inferiority_confidence_interval_crosses_margin');
     assert.equal(underpoweredNinePointLoss.nonInferiority.lowerBound !== null && underpoweredNinePointLoss.nonInferiority.lowerBound < -0.1, true);
     const poweredFivePointLoss = summarizeAbComparison({
@@ -644,7 +644,7 @@ describe('summarizeAbComparison', () => {
     assert.equal(onePairTie.passRateDelta, 0);
     assert.equal(onePairTie.nonInferiority.method, 'newcombe_wilson');
     assert.equal(onePairTie.nonInferiority.lowerBound !== null && onePairTie.nonInferiority.lowerBound < -0.1, true);
-    assert.equal(onePairTie.decision, 'inconclusive');
+    assert.equal(onePairTie.decision, 'not_cleared');
     assert.equal(onePairTie.reason, 'non_inferiority_confidence_interval_crosses_margin');
 
     const tieTaskIds = Array.from({ length: 10 }, (_, index) => `tie-${index}`);
@@ -660,7 +660,7 @@ describe('summarizeAbComparison', () => {
     assert.equal(allTieSmallSample.passRateDelta, 0);
     assert.equal(allTieSmallSample.nonInferiority.method, 'newcombe_wilson');
     assert.equal(allTieSmallSample.nonInferiority.lowerBound !== null && allTieSmallSample.nonInferiority.lowerBound < -0.1, true);
-    assert.equal(allTieSmallSample.decision, 'inconclusive');
+    assert.equal(allTieSmallSample.decision, 'not_cleared');
 
     const poweredTaskIds = Array.from({ length: 1000 }, (_, index) => `powered-${index}`);
     const powered = summarizeAbComparison({
@@ -694,7 +694,7 @@ describe('summarizeAbComparison', () => {
     assert.equal(underpowered.passRateDelta, -0.05);
     assert.equal(underpowered.nonInferiority.method, 'newcombe_wilson');
     assert.equal(underpowered.nonInferiority.lowerBound !== null && underpowered.nonInferiority.lowerBound < -0.1, true);
-    assert.equal(underpowered.decision, 'inconclusive');
+    assert.equal(underpowered.decision, 'not_cleared');
     assert.equal(underpowered.reason, 'non_inferiority_confidence_interval_crosses_margin');
 
     const inferiorTaskIds = Array.from({ length: 100 }, (_, index) => `inferior-${index}`);
@@ -728,8 +728,8 @@ describe('summarizeAbComparison', () => {
     assert.equal(result.candidate.passed, 1);
     assert.equal(result.pairedAttempts.wins, 1);
     assert.deepEqual(result.pairedAttempts.budgetDiscordantPairIds, ['t1#r0']);
-    assert.equal(result.decision, 'inconclusive');
-    assert.equal(result.reason, 'non_inferiority_confidence_interval_crosses_margin');
+    assert.equal(result.decision, 'invalid');
+    assert.equal(result.reason, 'asymmetric_budget_exhaustion');
   });
 
   test('counts baseline pass and candidate timeout as an effective B loss', () => {
@@ -747,11 +747,11 @@ describe('summarizeAbComparison', () => {
     assert.equal(result.candidate.budgetExhausted, 1);
     assert.equal(result.pairedAttempts.losses, 1);
     assert.deepEqual(result.pairedAttempts.budgetDiscordantPairIds, ['t1#r0']);
-    assert.equal(result.decision, 'inferior');
-    assert.equal(result.reason, 'pass_rate_delta_below_non_inferiority_margin');
+    assert.equal(result.decision, 'invalid');
+    assert.equal(result.reason, 'asymmetric_budget_exhaustion');
   });
 
-  test('reports budget-discordant refs without blocking a powered non-inferiority decision', () => {
+  test('reports budget-discordant refs and invalidates a powered non-inferiority decision', () => {
     const taskIds = Array.from({ length: 100 }, (_, index) => `t${index}`);
     const result = summarizeAbComparison({
       runId: 'ab-run',
@@ -765,7 +765,7 @@ describe('summarizeAbComparison', () => {
 
     assert.deepEqual(result.pairedAttempts.budgetDiscordantPairIds, ['t0#r0']);
     assert.equal(result.investigationRefs.budgetDiscordantPairs[0]?.pairId, 't0#r0');
-    assert.equal(result.decision, 'non_inferior');
-    assert.equal(result.reason, 'non_inferiority_lower_bound_within_margin');
+    assert.equal(result.decision, 'invalid');
+    assert.equal(result.reason, 'asymmetric_budget_exhaustion');
   });
 });

--- a/packages/headless/src/__tests__/ab-summary.test.ts
+++ b/packages/headless/src/__tests__/ab-summary.test.ts
@@ -30,8 +30,8 @@ describe('summarizeAbComparison', () => {
       budgetMs: 600_000,
     });
 
-    assert.equal(result.decision, 'non_inferior');
-    assert.equal(result.reason, 'non_inferiority_lower_bound_within_margin');
+    assert.equal(result.decision, 'not_cleared');
+    assert.equal(result.reason, 'non_inferiority_confidence_interval_crosses_margin');
     assert.equal(result.taskCount, 2);
     assert.equal(result.reps, 2);
     assert.equal(result.baseline.passRate, 0.25);
@@ -639,7 +639,7 @@ describe('summarizeAbComparison', () => {
     assert.equal(elevenPointLoss.reason, 'pass_rate_delta_below_non_inferiority_margin');
   });
 
-  test('uses Wilson/Newcombe lower bound for non-inferiority boundary cases', () => {
+  test('uses a 95% simultaneous paired Wilson lower bound for non-inferiority boundary cases', () => {
     const onePairTie = summarizeAbComparison({
       runId: 'ab-run',
       roundId: 'ab-summary',
@@ -650,7 +650,8 @@ describe('summarizeAbComparison', () => {
       candidateRuns: repeatedRuns([completed('single', true)]),
     });
     assert.equal(onePairTie.passRateDelta, 0);
-    assert.equal(onePairTie.nonInferiority.method, 'paired_newcombe_wilson');
+    assert.equal(onePairTie.nonInferiority.method, 'paired_bonferroni_wilson');
+    assert.equal(onePairTie.nonInferiority.lowerBound, -0.657619772493);
     assert.equal(onePairTie.nonInferiority.lowerBound !== null && onePairTie.nonInferiority.lowerBound < -0.1, true);
     assert.equal(onePairTie.decision, 'not_cleared');
     assert.equal(onePairTie.reason, 'non_inferiority_confidence_interval_crosses_margin');
@@ -666,7 +667,7 @@ describe('summarizeAbComparison', () => {
       candidateRuns: repeatedRuns(tieTaskIds.map((taskId) => completed(taskId, true))),
     });
     assert.equal(allTieSmallSample.passRateDelta, 0);
-    assert.equal(allTieSmallSample.nonInferiority.method, 'paired_newcombe_wilson');
+    assert.equal(allTieSmallSample.nonInferiority.method, 'paired_bonferroni_wilson');
     assert.equal(allTieSmallSample.nonInferiority.lowerBound !== null && allTieSmallSample.nonInferiority.lowerBound < -0.1, true);
     assert.equal(allTieSmallSample.decision, 'not_cleared');
 
@@ -684,7 +685,7 @@ describe('summarizeAbComparison', () => {
     assert.equal(powered.passRateDelta, -0.05);
     assert.equal(powered.pairedAttempts.losses, 100);
     assert.equal(powered.pairedAttempts.ties, 1900);
-    assert.equal(powered.nonInferiority.method, 'paired_newcombe_wilson');
+    assert.equal(powered.nonInferiority.method, 'paired_bonferroni_wilson');
     assert.equal(powered.nonInferiority.lowerBound !== null && powered.nonInferiority.lowerBound >= -0.1, true);
     assert.equal(powered.decision, 'non_inferior');
     assert.equal(powered.reason, 'non_inferiority_lower_bound_within_margin');
@@ -700,7 +701,7 @@ describe('summarizeAbComparison', () => {
       candidateRuns: repeatedRuns(smallTaskIds.map((taskId, index) => completed(taskId, index >= 9 && index < 19))),
     });
     assert.equal(underpowered.passRateDelta, -0.05);
-    assert.equal(underpowered.nonInferiority.method, 'paired_newcombe_wilson');
+    assert.equal(underpowered.nonInferiority.method, 'paired_bonferroni_wilson');
     assert.equal(underpowered.nonInferiority.lowerBound !== null && underpowered.nonInferiority.lowerBound < -0.1, true);
     assert.equal(underpowered.decision, 'not_cleared');
     assert.equal(underpowered.reason, 'non_inferiority_confidence_interval_crosses_margin');
@@ -716,7 +717,7 @@ describe('summarizeAbComparison', () => {
       candidateRuns: repeatedRuns(inferiorTaskIds.map((taskId, index) => completed(taskId, index >= 44 && index < 89))),
     });
     assert.equal(inferior.passRateDelta, -0.11);
-    assert.equal(inferior.nonInferiority.method, 'paired_newcombe_wilson');
+    assert.equal(inferior.nonInferiority.method, 'paired_bonferroni_wilson');
     assert.equal(inferior.decision, 'inferior');
     assert.equal(inferior.reason, 'pass_rate_delta_below_non_inferiority_margin');
   });

--- a/packages/headless/src/__tests__/ab-summary.test.ts
+++ b/packages/headless/src/__tests__/ab-summary.test.ts
@@ -54,7 +54,21 @@ describe('summarizeAbComparison', () => {
       candidateArmId: 'candidate',
       evaluationTaskIds: ['long-task'],
       baselineRuns: [[completed('long-task', true)]],
-      candidateRuns: [[budgetExhausted('long-task')]],
+      candidateRuns: [[{
+        ...budgetExhausted('long-task'),
+        tokenSummary: {
+          input: 100,
+          cachedInput: 0,
+          cacheHitInput: 0,
+          cacheMissInput: 100,
+          cacheWriteInput: 0,
+          output: 20,
+          reasoning: 0,
+          total: 120,
+          costUsd: 0.42,
+          pricingSource: 'runtime',
+        },
+      }]],
       budgetMs: 600_000,
     });
 
@@ -63,6 +77,8 @@ describe('summarizeAbComparison', () => {
     assert.equal(result.candidate.passRate, 0);
     assert.equal(result.candidate.budgetExhausted, 1);
     assert.equal(result.candidate.infraFailed, 0);
+    assert.equal(result.candidate.totalCostUsd, 0.42);
+    assert.equal(result.candidate.tokenCostSummary.total, 120);
     assert.equal(result.taskLevel.losses, 1);
   });
 

--- a/packages/headless/src/__tests__/ab-summary.test.ts
+++ b/packages/headless/src/__tests__/ab-summary.test.ts
@@ -296,7 +296,7 @@ describe('summarizeAbComparison', () => {
       ))],
     });
 
-    assert.equal(result.decision, 'non_inferior');
+    assert.equal(result.decision, 'diagnostic');
     assert.deepEqual(result.baseline.tokenCostSummary, {
       input: 100_000,
       cachedInput: 20_000,
@@ -549,12 +549,8 @@ describe('summarizeAbComparison', () => {
       baselineArmId: 'maka-baseline',
       candidateArmId: 'candidate',
       evaluationTaskIds: taskIds,
-      baselineRuns: [
-        taskIds.map((taskId, index) => completed(taskId, index >= 9)),
-      ],
-      candidateRuns: [
-        taskIds.map((taskId, index) => completed(taskId, index < 9)),
-      ],
+      baselineRuns: repeatedRuns(taskIds.map((taskId, index) => completed(taskId, index >= 9))),
+      candidateRuns: repeatedRuns(taskIds.map((taskId, index) => completed(taskId, index < 9))),
     });
 
     assert.equal(result.taskLevel.wins, 9);
@@ -573,12 +569,8 @@ describe('summarizeAbComparison', () => {
       baselineArmId: 'maka-baseline',
       candidateArmId: 'candidate',
       evaluationTaskIds: taskIds,
-      baselineRuns: [
-        taskIds.map((taskId, index) => completed(taskId, index >= 13)),
-      ],
-      candidateRuns: [
-        taskIds.map((taskId, index) => completed(taskId, index < 13)),
-      ],
+      baselineRuns: repeatedRuns(taskIds.map((taskId, index) => completed(taskId, index >= 13))),
+      candidateRuns: repeatedRuns(taskIds.map((taskId, index) => completed(taskId, index < 13))),
     });
 
     assert.equal(result.taskLevel.wins, 13);
@@ -588,6 +580,22 @@ describe('summarizeAbComparison', () => {
     assert.equal(result.reason, 'non_inferiority_lower_bound_within_margin');
   });
 
+  test('keeps every single-rep comparison diagnostic even when the sample is large', () => {
+    const taskIds = Array.from({ length: 1000 }, (_, index) => `diagnostic-${index}`);
+    const result = summarizeAbComparison({
+      runId: 'ab-run',
+      roundId: 'ab-summary',
+      baselineArmId: 'off',
+      candidateArmId: 'on',
+      evaluationTaskIds: taskIds,
+      baselineRuns: [taskIds.map((taskId) => completed(taskId, true))],
+      candidateRuns: [taskIds.map((taskId) => completed(taskId, true))],
+    });
+
+    assert.equal(result.decision, 'diagnostic');
+    assert.equal(result.reason, 'single_rep_diagnostic_only');
+  });
+
   test('requires a 10pp non-inferiority confidence bound for prune comparisons', () => {
     const underpoweredNinePointLoss = summarizeAbComparison({
       runId: 'ab-run',
@@ -595,8 +603,8 @@ describe('summarizeAbComparison', () => {
       baselineArmId: 'prune-off',
       candidateArmId: 'prune-on',
       evaluationTaskIds: Array.from({ length: 100 }, (_, index) => `t${index}`),
-      baselineRuns: [Array.from({ length: 100 }, (_, index) => completed(`t${index}`, index < 100))],
-      candidateRuns: [Array.from({ length: 100 }, (_, index) => completed(`t${index}`, index < 91))],
+      baselineRuns: repeatedRuns(Array.from({ length: 100 }, (_, index) => completed(`t${index}`, index < 100))),
+      candidateRuns: repeatedRuns(Array.from({ length: 100 }, (_, index) => completed(`t${index}`, index < 91))),
     });
     assert.equal(underpoweredNinePointLoss.nonInferiorityMargin, 0.1);
     assert.equal(underpoweredNinePointLoss.passRateDelta, -0.09);
@@ -609,8 +617,8 @@ describe('summarizeAbComparison', () => {
       baselineArmId: 'prune-off',
       candidateArmId: 'prune-on',
       evaluationTaskIds: Array.from({ length: 1000 }, (_, index) => `t${index}`),
-      baselineRuns: [Array.from({ length: 1000 }, (_, index) => completed(`t${index}`, index < 1000))],
-      candidateRuns: [Array.from({ length: 1000 }, (_, index) => completed(`t${index}`, index < 950))],
+      baselineRuns: repeatedRuns(Array.from({ length: 1000 }, (_, index) => completed(`t${index}`, index < 1000))),
+      candidateRuns: repeatedRuns(Array.from({ length: 1000 }, (_, index) => completed(`t${index}`, index < 950))),
     });
     assert.equal(poweredFivePointLoss.passRateDelta, -0.05);
     assert.equal(poweredFivePointLoss.nonInferiority.lowerBound !== null && poweredFivePointLoss.nonInferiority.lowerBound >= -0.1, true);
@@ -623,8 +631,8 @@ describe('summarizeAbComparison', () => {
       baselineArmId: 'prune-off',
       candidateArmId: 'prune-on',
       evaluationTaskIds: Array.from({ length: 100 }, (_, index) => `t${index}`),
-      baselineRuns: [Array.from({ length: 100 }, (_, index) => completed(`t${index}`, index < 100))],
-      candidateRuns: [Array.from({ length: 100 }, (_, index) => completed(`t${index}`, index < 89))],
+      baselineRuns: repeatedRuns(Array.from({ length: 100 }, (_, index) => completed(`t${index}`, index < 100))),
+      candidateRuns: repeatedRuns(Array.from({ length: 100 }, (_, index) => completed(`t${index}`, index < 89))),
     });
     assert.equal(elevenPointLoss.passRateDelta, -0.11);
     assert.equal(elevenPointLoss.decision, 'inferior');
@@ -638,8 +646,8 @@ describe('summarizeAbComparison', () => {
       baselineArmId: 'prune-off',
       candidateArmId: 'prune-on',
       evaluationTaskIds: ['single'],
-      baselineRuns: [[completed('single', true)]],
-      candidateRuns: [[completed('single', true)]],
+      baselineRuns: repeatedRuns([completed('single', true)]),
+      candidateRuns: repeatedRuns([completed('single', true)]),
     });
     assert.equal(onePairTie.passRateDelta, 0);
     assert.equal(onePairTie.nonInferiority.method, 'paired_newcombe_wilson');
@@ -654,8 +662,8 @@ describe('summarizeAbComparison', () => {
       baselineArmId: 'prune-off',
       candidateArmId: 'prune-on',
       evaluationTaskIds: tieTaskIds,
-      baselineRuns: [tieTaskIds.map((taskId) => completed(taskId, true))],
-      candidateRuns: [tieTaskIds.map((taskId) => completed(taskId, true))],
+      baselineRuns: repeatedRuns(tieTaskIds.map((taskId) => completed(taskId, true))),
+      candidateRuns: repeatedRuns(tieTaskIds.map((taskId) => completed(taskId, true))),
     });
     assert.equal(allTieSmallSample.passRateDelta, 0);
     assert.equal(allTieSmallSample.nonInferiority.method, 'paired_newcombe_wilson');
@@ -669,13 +677,13 @@ describe('summarizeAbComparison', () => {
       baselineArmId: 'prune-off',
       candidateArmId: 'prune-on',
       evaluationTaskIds: poweredTaskIds,
-      baselineRuns: [poweredTaskIds.map((taskId) => completed(taskId, true))],
-      candidateRuns: [poweredTaskIds.map((taskId, index) => completed(taskId, index < 950))],
+      baselineRuns: repeatedRuns(poweredTaskIds.map((taskId) => completed(taskId, true))),
+      candidateRuns: repeatedRuns(poweredTaskIds.map((taskId, index) => completed(taskId, index < 950))),
     });
 
     assert.equal(powered.passRateDelta, -0.05);
-    assert.equal(powered.pairedAttempts.losses, 50);
-    assert.equal(powered.pairedAttempts.ties, 950);
+    assert.equal(powered.pairedAttempts.losses, 100);
+    assert.equal(powered.pairedAttempts.ties, 1900);
     assert.equal(powered.nonInferiority.method, 'paired_newcombe_wilson');
     assert.equal(powered.nonInferiority.lowerBound !== null && powered.nonInferiority.lowerBound >= -0.1, true);
     assert.equal(powered.decision, 'non_inferior');
@@ -688,8 +696,8 @@ describe('summarizeAbComparison', () => {
       baselineArmId: 'prune-off',
       candidateArmId: 'prune-on',
       evaluationTaskIds: smallTaskIds,
-      baselineRuns: [smallTaskIds.map((taskId, index) => completed(taskId, index >= 9))],
-      candidateRuns: [smallTaskIds.map((taskId, index) => completed(taskId, index >= 9 && index < 19))],
+      baselineRuns: repeatedRuns(smallTaskIds.map((taskId, index) => completed(taskId, index >= 9))),
+      candidateRuns: repeatedRuns(smallTaskIds.map((taskId, index) => completed(taskId, index >= 9 && index < 19))),
     });
     assert.equal(underpowered.passRateDelta, -0.05);
     assert.equal(underpowered.nonInferiority.method, 'paired_newcombe_wilson');
@@ -704,8 +712,8 @@ describe('summarizeAbComparison', () => {
       baselineArmId: 'prune-off',
       candidateArmId: 'prune-on',
       evaluationTaskIds: inferiorTaskIds,
-      baselineRuns: [inferiorTaskIds.map((taskId, index) => completed(taskId, index >= 44))],
-      candidateRuns: [inferiorTaskIds.map((taskId, index) => completed(taskId, index >= 44 && index < 89))],
+      baselineRuns: repeatedRuns(inferiorTaskIds.map((taskId, index) => completed(taskId, index >= 44))),
+      candidateRuns: repeatedRuns(inferiorTaskIds.map((taskId, index) => completed(taskId, index >= 44 && index < 89))),
     });
     assert.equal(inferior.passRateDelta, -0.11);
     assert.equal(inferior.nonInferiority.method, 'paired_newcombe_wilson');
@@ -769,3 +777,7 @@ describe('summarizeAbComparison', () => {
     assert.equal(result.reason, 'asymmetric_budget_exhaustion');
   });
 });
+
+function repeatedRuns<T>(events: readonly T[]): readonly (readonly T[])[] {
+  return [events, events];
+}

--- a/packages/headless/src/__tests__/ab-summary.test.ts
+++ b/packages/headless/src/__tests__/ab-summary.test.ts
@@ -642,7 +642,7 @@ describe('summarizeAbComparison', () => {
       candidateRuns: [[completed('single', true)]],
     });
     assert.equal(onePairTie.passRateDelta, 0);
-    assert.equal(onePairTie.nonInferiority.method, 'newcombe_wilson');
+    assert.equal(onePairTie.nonInferiority.method, 'paired_newcombe_wilson');
     assert.equal(onePairTie.nonInferiority.lowerBound !== null && onePairTie.nonInferiority.lowerBound < -0.1, true);
     assert.equal(onePairTie.decision, 'not_cleared');
     assert.equal(onePairTie.reason, 'non_inferiority_confidence_interval_crosses_margin');
@@ -658,7 +658,7 @@ describe('summarizeAbComparison', () => {
       candidateRuns: [tieTaskIds.map((taskId) => completed(taskId, true))],
     });
     assert.equal(allTieSmallSample.passRateDelta, 0);
-    assert.equal(allTieSmallSample.nonInferiority.method, 'newcombe_wilson');
+    assert.equal(allTieSmallSample.nonInferiority.method, 'paired_newcombe_wilson');
     assert.equal(allTieSmallSample.nonInferiority.lowerBound !== null && allTieSmallSample.nonInferiority.lowerBound < -0.1, true);
     assert.equal(allTieSmallSample.decision, 'not_cleared');
 
@@ -676,7 +676,7 @@ describe('summarizeAbComparison', () => {
     assert.equal(powered.passRateDelta, -0.05);
     assert.equal(powered.pairedAttempts.losses, 50);
     assert.equal(powered.pairedAttempts.ties, 950);
-    assert.equal(powered.nonInferiority.method, 'newcombe_wilson');
+    assert.equal(powered.nonInferiority.method, 'paired_newcombe_wilson');
     assert.equal(powered.nonInferiority.lowerBound !== null && powered.nonInferiority.lowerBound >= -0.1, true);
     assert.equal(powered.decision, 'non_inferior');
     assert.equal(powered.reason, 'non_inferiority_lower_bound_within_margin');
@@ -692,7 +692,7 @@ describe('summarizeAbComparison', () => {
       candidateRuns: [smallTaskIds.map((taskId, index) => completed(taskId, index >= 9 && index < 19))],
     });
     assert.equal(underpowered.passRateDelta, -0.05);
-    assert.equal(underpowered.nonInferiority.method, 'newcombe_wilson');
+    assert.equal(underpowered.nonInferiority.method, 'paired_newcombe_wilson');
     assert.equal(underpowered.nonInferiority.lowerBound !== null && underpowered.nonInferiority.lowerBound < -0.1, true);
     assert.equal(underpowered.decision, 'not_cleared');
     assert.equal(underpowered.reason, 'non_inferiority_confidence_interval_crosses_margin');
@@ -708,7 +708,7 @@ describe('summarizeAbComparison', () => {
       candidateRuns: [inferiorTaskIds.map((taskId, index) => completed(taskId, index >= 44 && index < 89))],
     });
     assert.equal(inferior.passRateDelta, -0.11);
-    assert.equal(inferior.nonInferiority.method, 'newcombe_wilson');
+    assert.equal(inferior.nonInferiority.method, 'paired_newcombe_wilson');
     assert.equal(inferior.decision, 'inferior');
     assert.equal(inferior.reason, 'pass_rate_delta_below_non_inferiority_margin');
   });

--- a/packages/headless/src/__tests__/cell-output.test.ts
+++ b/packages/headless/src/__tests__/cell-output.test.ts
@@ -5,6 +5,7 @@ import type { InvocationResult } from '@maka/runtime';
 import {
   buildHarborCellOutput,
   validateHarborCellOutput,
+  type HarborCellOutput,
 } from '../cell-output.js';
 
 describe('Harbor cell output contract', () => {
@@ -105,6 +106,29 @@ describe('Harbor cell output contract', () => {
         runId: 'run-1',
         turnId: 'turn-1',
       },
+    });
+  });
+
+  test('preserves the actual execution identity reported by the cell', () => {
+    const output = buildHarborCellOutput({
+      invocation: invocationFixture(),
+      runtimeEventsPath: '/logs/agent/runtime-events.jsonl',
+    });
+    const validated = validateHarborCellOutput({
+      ...output,
+      executionIdentity: {
+        llmConnectionSlug: 'deepseek',
+        model: 'deepseek-v4-flash',
+        systemPromptHash: 'sha256:prompt-a',
+        pricingProfile: 'deepseek-v4-flash-tbench-v1',
+      },
+    }) as HarborCellOutput & { executionIdentity?: unknown };
+
+    assert.deepEqual(validated.executionIdentity, {
+      llmConnectionSlug: 'deepseek',
+      model: 'deepseek-v4-flash',
+      systemPromptHash: 'sha256:prompt-a',
+      pricingProfile: 'deepseek-v4-flash-tbench-v1',
     });
   });
 
@@ -351,5 +375,18 @@ function runtimeEvent(extra: Partial<RuntimeEvent>): RuntimeEvent {
     role: 'model',
     author: 'agent',
     ...extra,
+  };
+}
+
+function invocationFixture(): InvocationResult {
+  return {
+    invocationId: 'inv-1',
+    sessionId: 'session-1',
+    runId: 'run-1',
+    turnId: 'turn-1',
+    status: 'completed',
+    events: [],
+    startedAt: 100,
+    finishedAt: 250,
   };
 }

--- a/packages/headless/src/__tests__/fixed-prompt-controller.test.ts
+++ b/packages/headless/src/__tests__/fixed-prompt-controller.test.ts
@@ -676,6 +676,40 @@ describe('fixed prompt controller', () => {
     });
   });
 
+  test('stops immediately and leaves provider billing failures unscored', async () => {
+    await withDir(async (dir) => {
+      const systemPromptPath = join(dir, 'system_prompt.md');
+      await writeFile(systemPromptPath, 'fixed prompt\n', 'utf8');
+      const calls: string[] = [];
+
+      const result = await runFixedPromptController({
+        runId: 'run-1',
+        roundId: 'round-1',
+        config,
+        systemPromptPath,
+        resultsJsonlPath: join(dir, 'results.jsonl'),
+        resultsTsvPath: join(dir, 'results.tsv'),
+        tasks: [
+          { id: 'task-a', path: '/bench/task-a' },
+          { id: 'task-b', path: '/bench/task-b' },
+        ],
+        maxConcurrency: 1,
+        harborRunner: async ({ task }) => {
+          calls.push(task.id);
+          return harborOutput({ taskId: task.id, status: 'failed', errorClass: 'provider_billing' });
+        },
+        now: () => 100,
+        newId: idFactory(),
+      });
+
+      assert.deepEqual(calls, ['task-a']);
+      assert.equal(String(result.stopReason), 'systemic_provider_failure');
+      assert.equal(result.events[0]?.type, 'task_infra_failed');
+      assert.equal(String(result.events[0]?.errorClass), 'provider_billing');
+      assert.equal(result.events[0]?.scored, false);
+    });
+  });
+
   test('stops when cost exceeds the configured ceiling', async () => {
     await withDir(async (dir) => {
       const systemPromptPath = join(dir, 'system_prompt.md');
@@ -1261,13 +1295,14 @@ function harborOutput(input: {
   continuationSummary?: HarborTaskRunOutput['cell']['continuationSummary'];
   taskToolSummary?: HarborTaskRunOutput['cell']['taskToolSummary'];
   errorClass?: string;
+  status?: HarborTaskRunOutput['cell']['status'];
   executionIdentity?: HarborTaskRunOutput['cell']['executionIdentity'];
 }): HarborTaskRunOutput {
   return {
     harbor: { reward: input.reward ?? 1 },
     cell: {
       schemaVersion: 1,
-      status: 'completed',
+      status: input.status ?? 'completed',
       ...(input.errorClass ? { errorClass: input.errorClass } : {}),
       runtimeEventsPath: `/logs/${input.taskId}/runtime-events.jsonl`,
       traceEventsPath: `/logs/${input.taskId}/events.jsonl`,

--- a/packages/headless/src/__tests__/fixed-prompt-controller.test.ts
+++ b/packages/headless/src/__tests__/fixed-prompt-controller.test.ts
@@ -443,6 +443,36 @@ describe('fixed prompt controller', () => {
     });
   });
 
+  test('accounts for token cost retained by a timed-out cell', async () => {
+    await withDir(async (dir) => {
+      const systemPromptPath = join(dir, 'system_prompt.md');
+      await writeFile(systemPromptPath, 'fixed prompt\n', 'utf8');
+      const retainedUsage = tokenSummary({ input: 100, output: 20, reasoning: 0, total: 120, costUsd: 0.42 });
+
+      const result = await runFixedPromptController({
+        runId: 'run-1',
+        roundId: 'round-1',
+        config,
+        systemPromptPath,
+        resultsJsonlPath: join(dir, 'results.jsonl'),
+        resultsTsvPath: join(dir, 'results.tsv'),
+        tasks: [{ id: 'task-a', path: '/bench/task-a' }],
+        harborRunner: async () => {
+          throw new FixedPromptBudgetExhaustedError('agent timed out', undefined, {
+            tokenSummary: retainedUsage,
+          });
+        },
+        now: () => 100,
+        newId: idFactory(),
+      });
+
+      assert.equal(result.totalTokens, 120);
+      assert.equal(result.totalCostUsd, 0.42);
+      assert.equal(result.events[0]?.type, 'task_budget_exhausted');
+      assert.deepEqual('tokenSummary' in result.events[0]! ? result.events[0].tokenSummary : undefined, retainedUsage);
+    });
+  });
+
   test('reruns budget-exhausted WAL events instead of reusing a timeout', async () => {
     await withDir(async (dir) => {
       const systemPromptPath = join(dir, 'system_prompt.md');

--- a/packages/headless/src/__tests__/fixed-prompt-controller.test.ts
+++ b/packages/headless/src/__tests__/fixed-prompt-controller.test.ts
@@ -473,6 +473,41 @@ describe('fixed prompt controller', () => {
     });
   });
 
+  test('invalidates a timed-out cell whose execution identity is wrong', async () => {
+    await withDir(async (dir) => {
+      const systemPromptPath = join(dir, 'system_prompt.md');
+      await writeFile(systemPromptPath, 'fixed prompt\n', 'utf8');
+      const cell = harborOutput({
+        taskId: 'task-a',
+        executionIdentity: {
+          llmConnectionSlug: 'deepseek',
+          model: 'wrong-model',
+          systemPromptHash: hashSystemPrompt('fixed prompt\n'),
+          pricingProfile: 'test-profile',
+        },
+      }).cell;
+      const result = await runFixedPromptController({
+        runId: 'run-1',
+        roundId: 'round-1',
+        config,
+        systemPromptPath,
+        resultsJsonlPath: join(dir, 'results.jsonl'),
+        resultsTsvPath: join(dir, 'results.tsv'),
+        tasks: [{ id: 'task-a', path: '/bench/task-a' }],
+        requireExecutionIdentity: true,
+        expectedPricingProfile: 'test-profile',
+        harborRunner: async () => {
+          throw new FixedPromptBudgetExhaustedError('agent timed out', undefined, { cellOutput: cell });
+        },
+        now: () => 100,
+        newId: idFactory(),
+      });
+
+      assert.equal(result.events[0]?.type, 'task_plumbing_failed');
+      assert.equal(result.events[0]?.errorClass, 'execution_identity_mismatch');
+    });
+  });
+
   test('reruns budget-exhausted WAL events instead of reusing a timeout', async () => {
     await withDir(async (dir) => {
       const systemPromptPath = join(dir, 'system_prompt.md');

--- a/packages/headless/src/__tests__/fixed-prompt-controller.test.ts
+++ b/packages/headless/src/__tests__/fixed-prompt-controller.test.ts
@@ -1242,6 +1242,29 @@ describe('fixed prompt controller', () => {
     });
   });
 
+  test('requires execution identity when the experiment requests attestation', async () => {
+    await withDir(async (dir) => {
+      const systemPromptPath = join(dir, 'system_prompt.md');
+      await writeFile(systemPromptPath, 'fixed prompt\n', 'utf8');
+      const result = await runFixedPromptController({
+        runId: 'run-1',
+        roundId: 'round-1',
+        config,
+        systemPromptPath,
+        resultsJsonlPath: join(dir, 'results.jsonl'),
+        resultsTsvPath: join(dir, 'results.tsv'),
+        tasks: [{ id: 'task-a', path: '/bench/task-a' }],
+        requireExecutionIdentity: true,
+        harborRunner: async () => harborOutput({ taskId: 'task-a' }),
+        now: () => 100,
+        newId: idFactory(),
+      });
+
+      assert.equal(result.events[0]?.type, 'task_plumbing_failed');
+      assert.equal(result.events[0]?.errorClass, 'missing_execution_identity');
+    });
+  });
+
   test('records missing prompt hashes with tokens as plumbing failures', async () => {
     await withDir(async (dir) => {
       const systemPromptPath = join(dir, 'system_prompt.md');

--- a/packages/headless/src/__tests__/fixed-prompt-controller.test.ts
+++ b/packages/headless/src/__tests__/fixed-prompt-controller.test.ts
@@ -1147,6 +1147,37 @@ describe('fixed prompt controller', () => {
     });
   });
 
+  test('records execution model mismatches as plumbing failures', async () => {
+    await withDir(async (dir) => {
+      const systemPromptPath = join(dir, 'system_prompt.md');
+      await writeFile(systemPromptPath, 'fixed prompt\n', 'utf8');
+
+      const result = await runFixedPromptController({
+        runId: 'run-1',
+        roundId: 'round-1',
+        config,
+        systemPromptPath,
+        resultsJsonlPath: join(dir, 'results.jsonl'),
+        resultsTsvPath: join(dir, 'results.tsv'),
+        tasks: [{ id: 'task-a', path: '/bench/task-a' }],
+        harborRunner: async () => harborOutput({
+          taskId: 'task-a',
+          executionIdentity: {
+            llmConnectionSlug: 'fake',
+            model: 'wrong-model',
+            systemPromptHash: hashSystemPrompt('fixed prompt\n'),
+            pricingProfile: 'test-profile',
+          },
+        }),
+        now: () => 100,
+        newId: idFactory(),
+      });
+
+      assert.equal(result.events[0]?.type, 'task_plumbing_failed');
+      assert.equal(result.events[0]?.errorClass, 'execution_identity_mismatch');
+    });
+  });
+
   test('records missing prompt hashes with tokens as plumbing failures', async () => {
     await withDir(async (dir) => {
       const systemPromptPath = join(dir, 'system_prompt.md');
@@ -1230,6 +1261,7 @@ function harborOutput(input: {
   continuationSummary?: HarborTaskRunOutput['cell']['continuationSummary'];
   taskToolSummary?: HarborTaskRunOutput['cell']['taskToolSummary'];
   errorClass?: string;
+  executionIdentity?: HarborTaskRunOutput['cell']['executionIdentity'];
 }): HarborTaskRunOutput {
   return {
     harbor: { reward: input.reward ?? 1 },
@@ -1240,6 +1272,7 @@ function harborOutput(input: {
       runtimeEventsPath: `/logs/${input.taskId}/runtime-events.jsonl`,
       traceEventsPath: `/logs/${input.taskId}/events.jsonl`,
       ...(input.omitPromptHash ? {} : { promptHash: input.promptHash ?? hashSystemPrompt('fixed prompt\n') }),
+      ...(input.executionIdentity ? { executionIdentity: input.executionIdentity } : {}),
       tokenSummary: input.tokenSummary ?? tokenSummary({ input: 1, output: 2, reasoning: 0, total: 3, costUsd: 0.02 }),
       ...(input.contextBudgetPolicy ? { contextBudgetPolicy: input.contextBudgetPolicy } : {}),
       ...(input.contextBudgetSummary ? { contextBudgetSummary: input.contextBudgetSummary } : {}),

--- a/packages/headless/src/__tests__/fixed-prompt-controller.test.ts
+++ b/packages/headless/src/__tests__/fixed-prompt-controller.test.ts
@@ -443,6 +443,33 @@ describe('fixed prompt controller', () => {
     });
   });
 
+  test('fails closed when an attested experiment times out before cell output exists', async () => {
+    await withDir(async (dir) => {
+      const systemPromptPath = join(dir, 'system_prompt.md');
+      await writeFile(systemPromptPath, 'fixed prompt\n', 'utf8');
+      const result = await runFixedPromptController({
+        runId: 'run-1',
+        roundId: 'round-1',
+        config,
+        systemPromptPath,
+        resultsJsonlPath: join(dir, 'results.jsonl'),
+        resultsTsvPath: join(dir, 'results.tsv'),
+        tasks: [{ id: 'task-a', path: '/bench/task-a' }],
+        requireExecutionIdentity: true,
+        expectedPricingProfile: 'test-profile',
+        harborRunner: async () => {
+          throw new FixedPromptBudgetExhaustedError('timed out before cell output');
+        },
+        now: () => 100,
+        newId: idFactory(),
+      });
+
+      assert.equal(result.events[0]?.type, 'task_plumbing_failed');
+      assert.equal(result.events[0]?.errorClass, 'missing_execution_identity');
+      assert.equal('tokenSummary' in result.events[0]!, false);
+    });
+  });
+
   test('accounts for token cost retained by a timed-out cell', async () => {
     await withDir(async (dir) => {
       const systemPromptPath = join(dir, 'system_prompt.md');

--- a/packages/headless/src/__tests__/harbor-cell.test.ts
+++ b/packages/headless/src/__tests__/harbor-cell.test.ts
@@ -302,6 +302,7 @@ describe('runHarborCell', () => {
         cwd: workspaceDir,
         outputDir,
         storageRoot,
+        pricingProfile: 'deepseek-v4-flash-tbench-v1',
         registerBackends: registerCellBackend,
       });
 
@@ -310,6 +311,12 @@ describe('runHarborCell', () => {
       assert.equal(result.output.promptHash, 'sha256:cell-prompt');
       assert.equal(result.output.runtimeEventsPath, join(outputDir, HARBOR_CELL_RUNTIME_EVENTS_FILENAME));
       assert.equal(result.output.tokenSummary.costUsd, 0.0042);
+      assert.deepEqual(result.output.executionIdentity, {
+        llmConnectionSlug: 'fake',
+        model: 'fake-model',
+        systemPromptHash: `sha256:${createHash('sha256').update(JSON.stringify(config.systemPrompt)).digest('hex')}`,
+        pricingProfile: 'deepseek-v4-flash-tbench-v1',
+      });
 
       const outputJson = JSON.parse(await readFile(join(outputDir, HARBOR_CELL_OUTPUT_FILENAME), 'utf8'));
       assert.deepEqual(outputJson, result.output);

--- a/packages/headless/src/__tests__/harbor-task-runner.test.ts
+++ b/packages/headless/src/__tests__/harbor-task-runner.test.ts
@@ -479,6 +479,24 @@ describe('createHarborTaskRunner', () => {
 });
 
 describe('buildHarborJobConfig', () => {
+  test('rejects experiment identity overrides in extra agent env', () => {
+    assert.throws(
+      () => buildHarborJobConfig(runInput(), {
+        makaRepoPath: '/repo',
+        jobsDir: '/jobs/x',
+        jobName: 'trial',
+        model: 'deepseek/deepseek-v4-flash',
+        pricing: { inputUsdPer1M: 0.145, outputUsdPer1M: 0.29 },
+        agentEnv: {
+          MAKA_MODEL: 'deepseek-v4-pro',
+          MAKA_SYSTEM_PROMPT: 'wrong prompt',
+          MAKA_TRIAL_INPUT_USD_PER_1M: '9',
+        },
+      }),
+      /agentEnv must not override experiment identity: MAKA_MODEL, MAKA_SYSTEM_PROMPT, MAKA_TRIAL_INPUT_USD_PER_1M/,
+    );
+  });
+
   test('rejects provider secrets in extra agent env at config-build time', () => {
     assert.throws(
       () => buildHarborJobConfig(runInput(), {

--- a/packages/headless/src/__tests__/harbor-task-runner.test.ts
+++ b/packages/headless/src/__tests__/harbor-task-runner.test.ts
@@ -341,13 +341,21 @@ describe('createHarborTaskRunner', () => {
 
   test('treats Harbor agent timeout with verifier reward as budget exhausted', async () => {
     await withRun(async ({ jobsDir, repo }) => {
+      const timedCell = cellOutput({
+        executionIdentity: {
+          llmConnectionSlug: 'deepseek',
+          model: 'deepseek-v4-flash',
+          systemPromptHash: 'sha256:abc',
+          pricingProfile: 'test-profile',
+        },
+      });
       const runner = createHarborTaskRunner({
         makaRepoPath: repo,
         jobsDir,
         model: 'deepseek/deepseek-v4-flash',
         runHarbor: fakeRunner({
           reward: '0\n',
-          cell: cellOutput(),
+          cell: timedCell,
           trialResult: {
             exception_info: {
               exception_type: 'AgentTimeoutError',
@@ -358,7 +366,8 @@ describe('createHarborTaskRunner', () => {
       });
       await assert.rejects(runner(runInput()), (error: unknown) => {
         assert.ok(error instanceof FixedPromptBudgetExhaustedError);
-        assert.deepEqual(error.artifactRefs?.tokenSummary, cellOutput().tokenSummary);
+        assert.deepEqual(error.artifactRefs?.tokenSummary, timedCell.tokenSummary);
+        assert.deepEqual(error.artifactRefs?.cellOutput?.executionIdentity, timedCell.executionIdentity);
         return true;
       });
     });
@@ -640,6 +649,35 @@ describe('createHarborTaskRunner timeout', () => {
         }),
       });
       await assert.rejects(runner(runInput()), FixedPromptBudgetExhaustedError);
+    });
+  });
+
+  test('recovers cell usage and identity after the harbor process wall timeout', async () => {
+    await withRun(async ({ jobsDir, repo }) => {
+      const writeArtifacts = fakeRunner({ cell: cellOutput({
+        executionIdentity: {
+          llmConnectionSlug: 'deepseek',
+          model: 'deepseek-v4-flash',
+          systemPromptHash: 'sha256:abc',
+          pricingProfile: 'test-profile',
+        },
+      }) });
+      const runner = createHarborTaskRunner({
+        makaRepoPath: repo,
+        jobsDir,
+        model: 'deepseek/deepseek-v4-flash',
+        runHarbor: async (request) => {
+          await writeArtifacts(request);
+          return { exitCode: 1, stdout: '', stderr: 'timed out', timedOut: true, signal: 'SIGKILL' };
+        },
+      });
+
+      await assert.rejects(runner(runInput()), (error: unknown) => {
+        assert.ok(error instanceof FixedPromptBudgetExhaustedError);
+        assert.equal(error.artifactRefs?.tokenSummary?.total, 150);
+        assert.equal(error.artifactRefs?.cellOutput?.executionIdentity?.model, 'deepseek-v4-flash');
+        return true;
+      });
     });
   });
 });

--- a/packages/headless/src/__tests__/harbor-task-runner.test.ts
+++ b/packages/headless/src/__tests__/harbor-task-runner.test.ts
@@ -356,7 +356,11 @@ describe('createHarborTaskRunner', () => {
           },
         }),
       });
-      await assert.rejects(runner(runInput()), FixedPromptBudgetExhaustedError);
+      await assert.rejects(runner(runInput()), (error: unknown) => {
+        assert.ok(error instanceof FixedPromptBudgetExhaustedError);
+        assert.deepEqual(error.artifactRefs?.tokenSummary, cellOutput().tokenSummary);
+        return true;
+      });
     });
   });
 

--- a/packages/headless/src/__tests__/runtime-policy-ab-cli.test.ts
+++ b/packages/headless/src/__tests__/runtime-policy-ab-cli.test.ts
@@ -52,7 +52,7 @@ test('runtime policy A/B CLI dry-run builds one executable Flash manifest withou
     assert.match(stdout, /dry-run: executable manifest validated/);
     const manifest = JSON.parse(await readFile(join(outDir, 'dry-run', 'runtime-policy-ab-manifest.json'), 'utf8'));
     assert.equal(manifest.arms[0].metadata.executionProfile.model, 'deepseek/deepseek-v4-flash');
-    assert.equal(manifest.maxConcurrentAttempts, 4);
+    assert.equal(manifest.maxConcurrentAttempts, 2);
     assert.deepEqual(manifest.pilotTaskIds, ['pilot-task']);
   } finally {
     await rm(dir, { recursive: true, force: true });

--- a/packages/headless/src/__tests__/runtime-policy-ab-cli.test.ts
+++ b/packages/headless/src/__tests__/runtime-policy-ab-cli.test.ts
@@ -1,0 +1,60 @@
+import assert from 'node:assert/strict';
+import { execFile } from 'node:child_process';
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { promisify } from 'node:util';
+import { test } from 'node:test';
+
+const execFileAsync = promisify(execFile);
+
+test('runtime policy A/B CLI dry-run builds one executable Flash manifest without reading a key', async () => {
+  const dir = await mkdtemp(join(tmpdir(), 'maka-runtime-ab-cli-'));
+  try {
+    const tasksRoot = join(dir, 'tasks');
+    for (const id of ['pilot-task', 'full-task']) {
+      const taskDir = join(tasksRoot, `hash-${id}`, id);
+      await mkdir(taskDir, { recursive: true });
+      await writeFile(join(taskDir, 'task.toml'), '[metadata]\ndifficulty = "medium"\n', 'utf8');
+    }
+    const specPath = join(dir, 'spec.json');
+    await writeFile(specPath, JSON.stringify({
+      schemaVersion: 1,
+      id: 'stale-prune',
+      arms: [
+        { id: 'prune-off', contextEnv: { MAKA_CONTEXT_BUDGET: 'off' } },
+        { id: 'prune-on', contextEnv: { MAKA_CONTEXT_STALE_TOOL_RESULT_PRUNE: 'on' } },
+      ],
+      sharedAgentEnv: {},
+      pilotTaskIds: ['pilot-task'],
+      evaluationTaskIds: ['full-task'],
+      fullReps: 2,
+      nonInferiorityMargin: 0.1,
+    }), 'utf8');
+    const profilePath = new URL('../../harbor/runtime-policy-ab-profiles/deepseek-v4-flash.json', import.meta.url);
+    const scriptPath = new URL('../../harbor/run-runtime-policy-ab.mjs', import.meta.url);
+    const outDir = join(dir, 'out');
+    const { stdout } = await execFileAsync(process.execPath, [scriptPath.pathname], {
+      cwd: process.cwd(),
+      env: {
+        ...process.env,
+        MAKA_RUNTIME_AB_OUT_DIR: outDir,
+        MAKA_RUNTIME_AB_TASKS_ROOT: tasksRoot,
+        MAKA_RUNTIME_AB_SPEC_PATH: specPath,
+        MAKA_RUNTIME_AB_PROFILE_PATH: profilePath.pathname,
+        MAKA_RUNTIME_AB_RUN_ID: 'dry-run',
+        MAKA_RUNTIME_AB_DRY_RUN: '1',
+        MAKA_RUNTIME_AB_EXPLICIT_SUBJECT_FINGERPRINT: `sha256:${'a'.repeat(64)}`,
+        MAKA_RUNTIME_AB_TOOLCHAIN_FINGERPRINT: `sha256:${'b'.repeat(64)}`,
+      },
+    });
+
+    assert.match(stdout, /dry-run: executable manifest validated/);
+    const manifest = JSON.parse(await readFile(join(outDir, 'dry-run', 'runtime-policy-ab-manifest.json'), 'utf8'));
+    assert.equal(manifest.arms[0].metadata.executionProfile.model, 'deepseek/deepseek-v4-flash');
+    assert.equal(manifest.maxConcurrentAttempts, 4);
+    assert.deepEqual(manifest.pilotTaskIds, ['pilot-task']);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});

--- a/packages/headless/src/__tests__/runtime-policy-ab-lifecycle.test.ts
+++ b/packages/headless/src/__tests__/runtime-policy-ab-lifecycle.test.ts
@@ -101,6 +101,46 @@ test('pilot without candidate activation does not launch full execution', async 
   });
 });
 
+test('maps an invalid full summary to invalid lifecycle status', async () => {
+  await withDir(async (dir) => {
+    const promptPath = join(dir, 'prompt.md');
+    await writeFile(promptPath, 'shared prompt\n', 'utf8');
+    const state = await runRuntimePolicyAbLifecycle({
+      runId: 'run-1',
+      runRoot: dir,
+      manifestFingerprint: 'sha256:manifest',
+      config,
+      systemPromptPath: promptPath,
+      resultsJsonlPath: join(dir, 'results.jsonl'),
+      pilotTasks: [{ id: 'pilot', path: '/tasks/pilot' }],
+      evaluationTasks: [{ id: 'full', path: '/tasks/full' }],
+      fullReps: 2,
+      arms: [
+        { id: 'prune-off', contextEnv: { MAKA_CONTEXT_BUDGET: 'off' } },
+        { id: 'prune-on', contextEnv: { MAKA_CONTEXT_STALE_TOOL_RESULT_PRUNE: 'on' } },
+      ],
+      executionProfile,
+      harborRunner: async (runInput) => {
+        const result = output(runInput, runInput.agentEnv?.MAKA_CONTEXT_STALE_TOOL_RESULT_PRUNE === 'on');
+        if (runInput.roundId.startsWith('full-')) {
+          return {
+            ...result,
+            cell: {
+              ...result.cell,
+              executionIdentity: { ...result.cell.executionIdentity!, model: 'wrong-model' },
+            },
+          };
+        }
+        return result;
+      },
+    });
+
+    assert.equal(state.full?.decision, 'invalid');
+    assert.equal(state.status, 'invalid');
+    assert.equal(state.reason, 'plumbing_failure_observed');
+  });
+});
+
 function output(input: HarborTaskRunInput, activated: boolean): HarborTaskRunOutput {
   return {
     harbor: { reward: 1 },

--- a/packages/headless/src/__tests__/runtime-policy-ab-lifecycle.test.ts
+++ b/packages/headless/src/__tests__/runtime-policy-ab-lifecycle.test.ts
@@ -27,7 +27,7 @@ const executionProfile: RuntimePolicyAbExecutionProfile = {
   pricing: { inputUsdPer1M: 1, outputUsdPer1M: 1, cacheReadUsdPer1M: 0, cacheWriteUsdPer1M: 0, source: 'test-profile' },
   taskBudgetSec: 1800,
   harborTimeoutMs: 2_100_000,
-  costCeilingUsd: 20,
+  observedCostStopUsd: 20,
   maxConcurrentAttempts: 2,
 };
 

--- a/packages/headless/src/__tests__/runtime-policy-ab-lifecycle.test.ts
+++ b/packages/headless/src/__tests__/runtime-policy-ab-lifecycle.test.ts
@@ -1,0 +1,138 @@
+import assert from 'node:assert/strict';
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { test } from 'node:test';
+import type { Config } from '../contracts.js';
+import { hashSystemPrompt, type HarborTaskRunInput, type HarborTaskRunOutput } from '../fixed-prompt-controller.js';
+import { runRuntimePolicyAbLifecycle } from '../runtime-policy-ab-lifecycle.js';
+import { contextBudgetSummary } from './helpers/ab-summary-fixtures.js';
+import { tokenSummary } from './helpers/cell-output-fixtures.js';
+import type { RuntimePolicyAbExecutionProfile } from '../runtime-policy-ab-profile.js';
+
+const config: Config = {
+  id: 'runtime-ab',
+  backend: 'fake',
+  llmConnectionSlug: 'deepseek',
+  model: 'deepseek/deepseek-v4-flash',
+};
+
+const executionProfile: RuntimePolicyAbExecutionProfile = {
+  schemaVersion: 1,
+  id: 'test-profile',
+  llmConnectionSlug: 'deepseek',
+  provider: 'deepseek',
+  baseUrl: 'https://api.deepseek.com',
+  model: 'deepseek/deepseek-v4-flash',
+  pricing: { inputUsdPer1M: 1, outputUsdPer1M: 1, cacheReadUsdPer1M: 0, cacheWriteUsdPer1M: 0, source: 'test-profile' },
+  taskBudgetSec: 1800,
+  harborTimeoutMs: 2_100_000,
+  costCeilingUsd: 20,
+  maxConcurrentAttempts: 2,
+};
+
+test('same-run pilot checkpoint gates full execution and resumes completed state', async () => {
+  await withDir(async (dir) => {
+    const promptPath = join(dir, 'prompt.md');
+    await writeFile(promptPath, 'shared prompt\n', 'utf8');
+    const calls: string[] = [];
+    const input = {
+      runId: 'run-1',
+      runRoot: dir,
+      manifestFingerprint: 'sha256:manifest',
+      config,
+      systemPromptPath: promptPath,
+      resultsJsonlPath: join(dir, 'results.jsonl'),
+      pilotTasks: [{ id: 'pilot', path: '/tasks/pilot' }],
+      evaluationTasks: [{ id: 'full', path: '/tasks/full' }],
+      fullReps: 2,
+      arms: [
+        { id: 'prune-off', contextEnv: { MAKA_CONTEXT_BUDGET: 'off' } },
+        { id: 'prune-on', contextEnv: { MAKA_CONTEXT_STALE_TOOL_RESULT_PRUNE: 'on' } },
+      ] as const,
+      executionProfile,
+      harborRunner: async (runInput: HarborTaskRunInput) => {
+        calls.push(runInput.roundId);
+        return output(runInput, runInput.agentEnv?.MAKA_CONTEXT_STALE_TOOL_RESULT_PRUNE === 'on');
+      },
+    };
+
+    const first = await runRuntimePolicyAbLifecycle(input);
+    assert.equal(first.status, 'full_completed');
+    assert.equal(first.pilot?.candidate.contextBudget?.activatedAttempts, 1);
+    assert.equal(calls.length, 6);
+    assert.equal(calls.every((roundId) => roundId.startsWith('pilot-') || roundId.startsWith('full-')), true);
+
+    const resumed = await runRuntimePolicyAbLifecycle(input);
+    assert.equal(resumed.status, 'full_completed');
+    assert.equal(calls.length, 6);
+  });
+});
+
+test('pilot without candidate activation does not launch full execution', async () => {
+  await withDir(async (dir) => {
+    const promptPath = join(dir, 'prompt.md');
+    await writeFile(promptPath, 'shared prompt\n', 'utf8');
+    const calls: string[] = [];
+    const state = await runRuntimePolicyAbLifecycle({
+      runId: 'run-1',
+      runRoot: dir,
+      manifestFingerprint: 'sha256:manifest',
+      config,
+      systemPromptPath: promptPath,
+      resultsJsonlPath: join(dir, 'results.jsonl'),
+      pilotTasks: [{ id: 'pilot', path: '/tasks/pilot' }],
+      evaluationTasks: [{ id: 'full', path: '/tasks/full' }],
+      fullReps: 2,
+      arms: [
+        { id: 'prune-off', contextEnv: { MAKA_CONTEXT_BUDGET: 'off' } },
+        { id: 'prune-on', contextEnv: { MAKA_CONTEXT_STALE_TOOL_RESULT_PRUNE: 'on' } },
+      ],
+      executionProfile,
+      harborRunner: async (runInput) => {
+        calls.push(runInput.roundId);
+        return output(runInput, false);
+      },
+    });
+
+    assert.equal(state.status, 'pilot_not_cleared');
+    assert.equal(state.reason, 'pilot_candidate_not_activated');
+    assert.equal(calls.length, 2);
+  });
+});
+
+function output(input: HarborTaskRunInput, activated: boolean): HarborTaskRunOutput {
+  return {
+    harbor: { reward: 1 },
+    cell: {
+      schemaVersion: 1,
+      status: 'completed',
+      promptHash: hashSystemPrompt(input.systemPrompt),
+      executionIdentity: {
+        llmConnectionSlug: 'deepseek',
+        model: 'deepseek-v4-flash',
+        systemPromptHash: hashSystemPrompt(input.systemPrompt),
+        pricingProfile: 'test-profile',
+      },
+      tokenSummary: tokenSummary({ input: 4, output: 6, reasoning: 0, total: 10, costUsd: 0.01 }),
+      ...(activated ? { contextBudgetSummary: contextBudgetSummary({ activePrunedToolResults: 1 }) } : {}),
+      toolSummary: { providerVisibleToolCount: 0, actualToolCalls: 0, actualToolNames: [], actualToolCallCounts: {} },
+      steps: 1,
+      durationMs: 100,
+      startedAt: 0,
+      finishedAt: 100,
+      runtimeEventsPath: `/logs/${input.task.id}/runtime-events.jsonl`,
+      runtimeRefs: { invocationId: 'inv', sessionId: 'session', runId: 'run', turnId: 'turn' },
+    },
+  };
+}
+
+async function withDir(action: (dir: string) => Promise<void>): Promise<void> {
+  const dir = await mkdtemp(join(tmpdir(), 'maka-runtime-ab-lifecycle-'));
+  try {
+    await mkdir(dir, { recursive: true });
+    await action(dir);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+}

--- a/packages/headless/src/__tests__/runtime-policy-ab-profile.test.ts
+++ b/packages/headless/src/__tests__/runtime-policy-ab-profile.test.ts
@@ -9,8 +9,8 @@ test('checked-in runtime A/B profile pins DeepSeek Flash identity, pricing, and 
 
   assert.equal(profile.model, 'deepseek/deepseek-v4-flash');
   assert.equal(profile.pricing.source, 'deepseek-v4-flash');
-  assert.equal(profile.costCeilingUsd, 20);
-  assert.equal(profile.maxConcurrentAttempts, 4);
+  assert.equal(profile.observedCostStopUsd, 20);
+  assert.equal(profile.maxConcurrentAttempts, 2);
 });
 
 test('profile parser rejects the old ambiguous attempt concurrency', () => {
@@ -25,7 +25,7 @@ test('profile parser rejects the old ambiguous attempt concurrency', () => {
       pricing: { inputUsdPer1M: 1, outputUsdPer1M: 1, cacheReadUsdPer1M: 0, cacheWriteUsdPer1M: 0, source: 'bad' },
       taskBudgetSec: 1800,
       harborTimeoutMs: 2_100_000,
-      costCeilingUsd: 20,
+      observedCostStopUsd: 20,
       maxConcurrentAttempts: 3,
     }),
     /maxConcurrentAttempts must be an even integer of at least 2/,

--- a/packages/headless/src/__tests__/runtime-policy-ab-profile.test.ts
+++ b/packages/headless/src/__tests__/runtime-policy-ab-profile.test.ts
@@ -1,0 +1,33 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import { test } from 'node:test';
+import { parseRuntimePolicyAbExecutionProfile } from '../runtime-policy-ab-profile.js';
+
+test('checked-in runtime A/B profile pins DeepSeek Flash identity, pricing, and safety limits', async () => {
+  const path = new URL('../../harbor/runtime-policy-ab-profiles/deepseek-v4-flash.json', import.meta.url);
+  const profile = parseRuntimePolicyAbExecutionProfile(JSON.parse(await readFile(path, 'utf8')));
+
+  assert.equal(profile.model, 'deepseek/deepseek-v4-flash');
+  assert.equal(profile.pricing.source, 'deepseek-v4-flash');
+  assert.equal(profile.costCeilingUsd, 20);
+  assert.equal(profile.maxConcurrentAttempts, 4);
+});
+
+test('profile parser rejects the old ambiguous attempt concurrency', () => {
+  assert.throws(
+    () => parseRuntimePolicyAbExecutionProfile({
+      schemaVersion: 1,
+      id: 'bad',
+      llmConnectionSlug: 'deepseek',
+      provider: 'deepseek',
+      baseUrl: 'https://api.deepseek.com',
+      model: 'deepseek/deepseek-v4-flash',
+      pricing: { inputUsdPer1M: 1, outputUsdPer1M: 1, cacheReadUsdPer1M: 0, cacheWriteUsdPer1M: 0, source: 'bad' },
+      taskBudgetSec: 1800,
+      harborTimeoutMs: 2_100_000,
+      costCeilingUsd: 20,
+      maxConcurrentAttempts: 3,
+    }),
+    /maxConcurrentAttempts must be an even integer of at least 2/,
+  );
+});

--- a/packages/headless/src/__tests__/runtime-policy-ab-run.test.ts
+++ b/packages/headless/src/__tests__/runtime-policy-ab-run.test.ts
@@ -11,12 +11,27 @@ import {
 } from '../fixed-prompt-controller.js';
 import { buildRuntimePolicyAbRunManifest, runRuntimePolicyAbComparison } from '../runtime-policy-ab-run.js';
 import { tokenSummary } from './helpers/cell-output-fixtures.js';
+import type { RuntimePolicyAbExecutionProfile } from '../runtime-policy-ab-profile.js';
 
 const config: Config = {
   id: 'cfg-runtime-policy-ab',
   backend: 'fake',
   llmConnectionSlug: 'deepseek',
   model: 'deepseek/deepseek-v4-flash',
+};
+
+const executionProfile: RuntimePolicyAbExecutionProfile = {
+  schemaVersion: 1,
+  id: 'test-profile',
+  llmConnectionSlug: 'deepseek',
+  provider: 'deepseek',
+  baseUrl: 'https://api.deepseek.com',
+  model: 'deepseek/deepseek-v4-flash',
+  pricing: { inputUsdPer1M: 1, outputUsdPer1M: 1, cacheReadUsdPer1M: 0, cacheWriteUsdPer1M: 0, source: 'test-profile' },
+  taskBudgetSec: 1800,
+  harborTimeoutMs: 2_100_000,
+  costCeilingUsd: 20,
+  maxConcurrentAttempts: 2,
 };
 
 describe('runRuntimePolicyAbComparison', () => {
@@ -27,19 +42,13 @@ describe('runRuntimePolicyAbComparison', () => {
         { id: 'prune-on', contextEnv: { MAKA_CONTEXT_STALE_TOOL_RESULT_PRUNE: 'on' } },
       ],
       promptHash: sha256('p'),
-      provider: 'deepseek',
-      baseUrl: 'https://api.deepseek.com',
-      model: 'deepseek/deepseek-v4-flash',
-      taskBudgetSec: 1800,
-      harborTimeoutMs: 2_100_000,
+      executionProfile: { ...executionProfile, maxConcurrentAttempts: 4 },
       subjectFingerprint: sha256('s'),
       taskSourceFingerprint: sha256('t'),
       toolchainFingerprint: sha256('c'),
       evaluationTaskIds: ['t1', 't2'],
       reps: 3,
       candidateLimit: null,
-      maxConcurrentAttempts: 4,
-      costCeilingUsd: 20,
       nonInferiorityMargin: 0.1,
       sharedAgentEnv: {
         MAKA_HARBOR_CONTINUATION: 'on',
@@ -85,19 +94,13 @@ describe('runRuntimePolicyAbComparison', () => {
       const manifest = buildRuntimePolicyAbRunManifest({
         arms: [taskToolsOff, taskToolsOn],
         promptHash: sha256('p'),
-        provider: 'deepseek',
-        baseUrl: 'https://api.deepseek.com',
-        model: 'deepseek/deepseek-v4-flash',
-        taskBudgetSec: 1800,
-        harborTimeoutMs: 2_100_000,
+        executionProfile,
         subjectFingerprint: sha256('s'),
         taskSourceFingerprint: sha256('t'),
         toolchainFingerprint: sha256('c'),
         evaluationTaskIds: ['t1'],
         reps: 1,
         candidateLimit: null,
-        maxConcurrentAttempts: 2,
-        costCeilingUsd: 20,
       });
       const calls: string[] = [];
 
@@ -110,8 +113,7 @@ describe('runRuntimePolicyAbComparison', () => {
         evaluationTasks: [{ id: 't1', path: '/bench/t1' }],
         reps: 1,
         arms: [taskToolsOff, taskToolsOn],
-        costCeilingUsd: 20,
-        maxConcurrentAttempts: 2,
+        executionProfile,
         resumeFingerprint: 'caller-salt',
         harborRunner: async (input) => {
           calls.push(`${input.roundId}:${JSON.stringify(input.agentEnv ?? {})}`);
@@ -140,20 +142,14 @@ describe('runRuntimePolicyAbComparison', () => {
           { id: 'prune-off', contextEnv: { MAKA_CONTEXT_BUDGET: 'off' } },
           { id: 'prune-on', contextEnv: { MAKA_CONTEXT_STALE_TOOL_RESULT_PRUNE: 'on', MAKA_CONTEXT_FOO: '1' } as never },
         ],
-        costCeilingUsd: 20,
         promptHash: sha256('p'),
-        provider: 'deepseek',
-        baseUrl: 'https://api.deepseek.com',
-        model: 'deepseek/deepseek-v4-flash',
-        taskBudgetSec: 1800,
-        harborTimeoutMs: 2_100_000,
+        executionProfile,
         subjectFingerprint: sha256('s'),
         taskSourceFingerprint: sha256('t'),
         toolchainFingerprint: sha256('c'),
         evaluationTaskIds: ['t1'],
         reps: 1,
         candidateLimit: null,
-        maxConcurrentAttempts: 2,
       }),
       /unsupported Harbor context env key: MAKA_CONTEXT_FOO/,
     );
@@ -168,19 +164,13 @@ describe('runRuntimePolicyAbComparison', () => {
         ],
         sharedAgentEnv: { MAKA_CONTEXT_STALE_TOOL_RESULT_PRUNE: 'on' } as never,
         promptHash: sha256('p'),
-        provider: 'deepseek',
-        baseUrl: 'https://api.deepseek.com',
-        model: 'deepseek/deepseek-v4-flash',
-        taskBudgetSec: 1800,
-        harborTimeoutMs: 2_100_000,
+        executionProfile,
         subjectFingerprint: sha256('s'),
         taskSourceFingerprint: sha256('t'),
         toolchainFingerprint: sha256('c'),
         evaluationTaskIds: ['t1'],
         reps: 1,
         candidateLimit: null,
-        maxConcurrentAttempts: 2,
-        costCeilingUsd: 20,
       }),
       /unsupported runtime policy shared agent env key: MAKA_CONTEXT_STALE_TOOL_RESULT_PRUNE/,
     );
@@ -210,8 +200,7 @@ describe('runRuntimePolicyAbComparison', () => {
             },
           },
         ],
-        costCeilingUsd: 20,
-        maxConcurrentAttempts: 2,
+        executionProfile,
         harborRunner: async (input) => {
           calls.push(input);
           return harborOutput(input);
@@ -291,8 +280,7 @@ describe('runRuntimePolicyAbComparison', () => {
           evaluationTasks: [task],
           reps: 1,
           arms,
-          costCeilingUsd: 20,
-          maxConcurrentAttempts: 2,
+          executionProfile,
           sharedAgentEnv: { MAKA_HARBOR_CONTINUATION: 'on' },
           resumeFingerprint: 'caller-salt',
           harborRunner: async (input) => {
@@ -327,8 +315,7 @@ describe('runRuntimePolicyAbComparison', () => {
         evaluationTasks: [task],
         reps: 1,
         arms: [pruneOff, pruneOnChanged],
-        costCeilingUsd: 20,
-        maxConcurrentAttempts: 2,
+        executionProfile,
         sharedAgentEnv: {
           MAKA_HARBOR_CONTINUATION: 'on',
           MAKA_HARBOR_CONTINUATION_MAX_TURNS: '3',
@@ -358,6 +345,12 @@ function harborOutput(input: HarborTaskRunInput): HarborTaskRunOutput {
       schemaVersion: 1,
       status: 'completed',
       promptHash: hashSystemPrompt(input.systemPrompt),
+      executionIdentity: {
+        llmConnectionSlug: 'deepseek',
+        model: 'deepseek-v4-flash',
+        systemPromptHash: hashSystemPrompt(input.systemPrompt),
+        pricingProfile: 'test-profile',
+      },
       tokenSummary: tokenSummary({ input: 4, output: 6, reasoning: 0, total: 10, costUsd: 0.01 }),
       contextBudgetPolicy: pruneOn
         ? {

--- a/packages/headless/src/__tests__/runtime-policy-ab-run.test.ts
+++ b/packages/headless/src/__tests__/runtime-policy-ab-run.test.ts
@@ -38,7 +38,8 @@ describe('runRuntimePolicyAbComparison', () => {
       evaluationTaskIds: ['t1', 't2'],
       reps: 3,
       candidateLimit: null,
-      maxConcurrency: 4,
+      maxConcurrentAttempts: 4,
+      costCeilingUsd: 20,
       nonInferiorityMargin: 0.1,
       sharedAgentEnv: {
         MAKA_HARBOR_CONTINUATION: 'on',
@@ -48,6 +49,8 @@ describe('runRuntimePolicyAbComparison', () => {
     });
 
     assert.equal(manifest.experimentKind, 'runtime');
+    assert.equal(manifest.maxConcurrentAttempts, 4);
+    assert.equal(manifest.maxConcurrency, 2);
     assert.equal(manifest.toolchainFingerprint, sha256('c'));
     assert.deepEqual(manifest.evaluationTaskIds, ['t1', 't2']);
     assert.deepEqual(manifest.arms.map((arm) => arm.metadata?.promptHash), [sha256('p'), sha256('p')]);
@@ -93,18 +96,22 @@ describe('runRuntimePolicyAbComparison', () => {
         evaluationTaskIds: ['t1'],
         reps: 1,
         candidateLimit: null,
-        maxConcurrency: 1,
+        maxConcurrentAttempts: 2,
+        costCeilingUsd: 20,
       });
       const calls: string[] = [];
 
       await runRuntimePolicyAbComparison({
         runId: 'runtime-ab-run',
+        runRoot: dir,
         config,
         systemPromptPath,
         resultsJsonlPath,
         evaluationTasks: [{ id: 't1', path: '/bench/t1' }],
         reps: 1,
         arms: [taskToolsOff, taskToolsOn],
+        costCeilingUsd: 20,
+        maxConcurrentAttempts: 2,
         resumeFingerprint: 'caller-salt',
         harborRunner: async (input) => {
           calls.push(`${input.roundId}:${JSON.stringify(input.agentEnv ?? {})}`);
@@ -133,6 +140,7 @@ describe('runRuntimePolicyAbComparison', () => {
           { id: 'prune-off', contextEnv: { MAKA_CONTEXT_BUDGET: 'off' } },
           { id: 'prune-on', contextEnv: { MAKA_CONTEXT_STALE_TOOL_RESULT_PRUNE: 'on', MAKA_CONTEXT_FOO: '1' } as never },
         ],
+        costCeilingUsd: 20,
         promptHash: sha256('p'),
         provider: 'deepseek',
         baseUrl: 'https://api.deepseek.com',
@@ -145,7 +153,7 @@ describe('runRuntimePolicyAbComparison', () => {
         evaluationTaskIds: ['t1'],
         reps: 1,
         candidateLimit: null,
-        maxConcurrency: 1,
+        maxConcurrentAttempts: 2,
       }),
       /unsupported Harbor context env key: MAKA_CONTEXT_FOO/,
     );
@@ -171,7 +179,8 @@ describe('runRuntimePolicyAbComparison', () => {
         evaluationTaskIds: ['t1'],
         reps: 1,
         candidateLimit: null,
-        maxConcurrency: 1,
+        maxConcurrentAttempts: 2,
+        costCeilingUsd: 20,
       }),
       /unsupported runtime policy shared agent env key: MAKA_CONTEXT_STALE_TOOL_RESULT_PRUNE/,
     );
@@ -185,6 +194,7 @@ describe('runRuntimePolicyAbComparison', () => {
 
       const result = await runRuntimePolicyAbComparison({
         runId: 'runtime-ab-run',
+        runRoot: dir,
         config,
         systemPromptPath: promptPath,
         resultsJsonlPath: join(dir, 'results.jsonl'),
@@ -200,6 +210,8 @@ describe('runRuntimePolicyAbComparison', () => {
             },
           },
         ],
+        costCeilingUsd: 20,
+        maxConcurrentAttempts: 2,
         harborRunner: async (input) => {
           calls.push(input);
           return harborOutput(input);
@@ -272,12 +284,15 @@ describe('runRuntimePolicyAbComparison', () => {
       const run = async (arms: Parameters<typeof runRuntimePolicyAbComparison>[0]['arms']) => {
         await runRuntimePolicyAbComparison({
           runId: 'runtime-ab-run',
+          runRoot: dir,
           config,
           systemPromptPath: promptPath,
           resultsJsonlPath,
           evaluationTasks: [task],
           reps: 1,
           arms,
+          costCeilingUsd: 20,
+          maxConcurrentAttempts: 2,
           sharedAgentEnv: { MAKA_HARBOR_CONTINUATION: 'on' },
           resumeFingerprint: 'caller-salt',
           harborRunner: async (input) => {
@@ -305,12 +320,15 @@ describe('runRuntimePolicyAbComparison', () => {
       calls = [];
       await runRuntimePolicyAbComparison({
         runId: 'runtime-ab-run',
+        runRoot: dir,
         config,
         systemPromptPath: promptPath,
         resultsJsonlPath,
         evaluationTasks: [task],
         reps: 1,
         arms: [pruneOff, pruneOnChanged],
+        costCeilingUsd: 20,
+        maxConcurrentAttempts: 2,
         sharedAgentEnv: {
           MAKA_HARBOR_CONTINUATION: 'on',
           MAKA_HARBOR_CONTINUATION_MAX_TURNS: '3',

--- a/packages/headless/src/__tests__/runtime-policy-ab-run.test.ts
+++ b/packages/headless/src/__tests__/runtime-policy-ab-run.test.ts
@@ -30,7 +30,7 @@ const executionProfile: RuntimePolicyAbExecutionProfile = {
   pricing: { inputUsdPer1M: 1, outputUsdPer1M: 1, cacheReadUsdPer1M: 0, cacheWriteUsdPer1M: 0, source: 'test-profile' },
   taskBudgetSec: 1800,
   harborTimeoutMs: 2_100_000,
-  costCeilingUsd: 20,
+  observedCostStopUsd: 20,
   maxConcurrentAttempts: 2,
 };
 

--- a/packages/headless/src/__tests__/runtime-policy-ab-spec.test.ts
+++ b/packages/headless/src/__tests__/runtime-policy-ab-spec.test.ts
@@ -1,0 +1,23 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { parseRuntimePolicyAbSpec } from '../runtime-policy-ab-spec.js';
+
+test('runtime A/B spec requires a real pilot and repeated full evidence', () => {
+  const base = {
+    schemaVersion: 1,
+    id: 'stale-prune',
+    arms: [
+      { id: 'off', contextEnv: { MAKA_CONTEXT_BUDGET: 'off' } },
+      { id: 'on', contextEnv: { MAKA_CONTEXT_STALE_TOOL_RESULT_PRUNE: 'on' } },
+    ],
+    sharedAgentEnv: {},
+    pilotTaskIds: ['pilot'],
+    evaluationTaskIds: ['full'],
+    fullReps: 2,
+    nonInferiorityMargin: 0.1,
+  };
+
+  assert.equal(parseRuntimePolicyAbSpec(base).fullReps, 2);
+  assert.throws(() => parseRuntimePolicyAbSpec({ ...base, fullReps: 1 }), /fullReps must be an integer of at least 2/);
+  assert.throws(() => parseRuntimePolicyAbSpec({ ...base, pilotTaskIds: [] }), /pilotTaskIds must be a non-empty string array/);
+});

--- a/packages/headless/src/ab-manifest.ts
+++ b/packages/headless/src/ab-manifest.ts
@@ -26,7 +26,7 @@ export function buildAbRunManifest(input: AbRunManifestInput): AbRunManifest {
     candidateLimit: input.candidateLimit,
     maxConcurrency: input.maxConcurrency,
     maxConcurrentAttempts: input.maxConcurrentAttempts,
-    costCeilingUsd: input.costCeilingUsd,
+    observedCostStopUsd: input.observedCostStopUsd,
     selectionMode: input.selectionMode,
     candidateTaskIds: input.candidateTaskIds ? [...input.candidateTaskIds] : undefined,
     pilotTaskIds: input.pilotTaskIds ? [...input.pilotTaskIds] : undefined,

--- a/packages/headless/src/ab-manifest.ts
+++ b/packages/headless/src/ab-manifest.ts
@@ -29,6 +29,7 @@ export function buildAbRunManifest(input: AbRunManifestInput): AbRunManifest {
     costCeilingUsd: input.costCeilingUsd,
     selectionMode: input.selectionMode,
     candidateTaskIds: input.candidateTaskIds ? [...input.candidateTaskIds] : undefined,
+    pilotTaskIds: input.pilotTaskIds ? [...input.pilotTaskIds] : undefined,
     maxExpertTimeEstimateMin: input.maxExpertTimeEstimateMin,
     targetEvaluationTaskCount: input.targetEvaluationTaskCount,
     nonInferiorityMargin: input.nonInferiorityMargin,

--- a/packages/headless/src/ab-manifest.ts
+++ b/packages/headless/src/ab-manifest.ts
@@ -25,6 +25,8 @@ export function buildAbRunManifest(input: AbRunManifestInput): AbRunManifest {
     reps: input.reps,
     candidateLimit: input.candidateLimit,
     maxConcurrency: input.maxConcurrency,
+    maxConcurrentAttempts: input.maxConcurrentAttempts,
+    costCeilingUsd: input.costCeilingUsd,
     selectionMode: input.selectionMode,
     candidateTaskIds: input.candidateTaskIds ? [...input.candidateTaskIds] : undefined,
     maxExpertTimeEstimateMin: input.maxExpertTimeEstimateMin,
@@ -65,12 +67,27 @@ export async function ensureAbRunManifest<T extends { fingerprint: string }>(
     return manifest;
   }
   const existing = JSON.parse(raw) as T;
+  if (hasFullBodyFingerprint(existing)) {
+    const { fingerprint: existingFingerprint, ...existingBody } = existing;
+    const recomputedFingerprint = buildRunManifestFingerprint(existingBody);
+    if (existingFingerprint !== recomputedFingerprint) {
+      throw new Error(
+        `stored A/B run manifest fingerprint is invalid: stored ${existingFingerprint ?? 'missing'}, recomputed ${recomputedFingerprint}`,
+      );
+    }
+  }
   if (existing.fingerprint !== manifest.fingerprint) {
     throw new Error(
       `A/B run manifest does not match existing run id: existing ${existing.fingerprint ?? 'missing'}, current ${manifest.fingerprint}. Use a new run id or restore the original run config.`,
     );
   }
   return existing;
+}
+
+function hasFullBodyFingerprint(value: unknown): value is { schemaVersion: string; fingerprint: string } {
+  if (!value || typeof value !== 'object' || !('schemaVersion' in value)) return false;
+  const schemaVersion = (value as { schemaVersion?: unknown }).schemaVersion;
+  return schemaVersion === 'maka.ab.run_manifest.v1';
 }
 
 function canonicalJson(value: unknown): string {

--- a/packages/headless/src/ab-manifest.ts
+++ b/packages/headless/src/ab-manifest.ts
@@ -64,8 +64,13 @@ export async function ensureAbRunManifest<T extends { fingerprint: string }>(
   }
   if (raw === undefined) {
     await mkdir(dirname(path), { recursive: true });
-    await writeFile(path, `${JSON.stringify(manifest, null, 2)}\n`, 'utf8');
-    return manifest;
+    try {
+      await writeFile(path, `${JSON.stringify(manifest, null, 2)}\n`, { encoding: 'utf8', flag: 'wx' });
+      return manifest;
+    } catch (error) {
+      if (!isAlreadyExists(error)) throw error;
+      raw = await readConcurrentManifest(path);
+    }
   }
   const existing = JSON.parse(raw) as T;
   if (hasFullBodyFingerprint(existing)) {
@@ -111,4 +116,26 @@ function isNotFound(error: unknown): boolean {
     && error !== null
     && 'code' in error
     && (error as { code?: unknown }).code === 'ENOENT';
+}
+
+function isAlreadyExists(error: unknown): boolean {
+  return typeof error === 'object'
+    && error !== null
+    && 'code' in error
+    && (error as { code?: unknown }).code === 'EEXIST';
+}
+
+async function readConcurrentManifest(path: string): Promise<string> {
+  let lastError: unknown;
+  for (let attempt = 0; attempt < 10; attempt += 1) {
+    try {
+      const raw = await readFile(path, 'utf8');
+      JSON.parse(raw);
+      return raw;
+    } catch (error) {
+      lastError = error;
+      await new Promise<void>((resolve) => setImmediate(resolve));
+    }
+  }
+  throw lastError;
 }

--- a/packages/headless/src/ab-render.ts
+++ b/packages/headless/src/ab-render.ts
@@ -157,8 +157,12 @@ function decisionLabel(decision: AbDecision): string {
       return 'B non-inferior';
     case 'inferior':
       return 'B inferior';
-    case 'inconclusive':
-      return 'inconclusive';
+    case 'not_cleared':
+      return 'not cleared';
+    case 'diagnostic':
+      return 'diagnostic only';
+    case 'invalid':
+      return 'invalid';
   }
 }
 

--- a/packages/headless/src/ab-run-lock.ts
+++ b/packages/headless/src/ab-run-lock.ts
@@ -1,0 +1,70 @@
+import { mkdir, readFile, rename, rm, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+
+const LOCK_DIR_NAME = '.ab-run.lock';
+
+export async function withAbRunLock<T>(runRoot: string, action: () => Promise<T>): Promise<T> {
+  await mkdir(runRoot, { recursive: true });
+  const lockPath = join(runRoot, LOCK_DIR_NAME);
+  await acquireLock(lockPath);
+  try {
+    return await action();
+  } finally {
+    await rm(lockPath, { recursive: true, force: true });
+  }
+}
+
+async function acquireLock(lockPath: string): Promise<void> {
+  try {
+    await mkdir(lockPath);
+    await writeFile(join(lockPath, 'owner.json'), `${JSON.stringify({ pid: process.pid, startedAt: Date.now() })}\n`, 'utf8');
+    return;
+  } catch (error) {
+    if (!isAlreadyExists(error)) throw error;
+  }
+
+  const ownerPid = await readOwnerPid(lockPath);
+  if (ownerPid === undefined || isProcessAlive(ownerPid)) {
+    throw new Error(`A/B run is already active (lock: ${lockPath}${ownerPid ? `, pid: ${ownerPid}` : ''})`);
+  }
+
+  const stalePath = `${lockPath}.stale-${process.pid}-${Date.now()}`;
+  try {
+    await rename(lockPath, stalePath);
+  } catch {
+    throw new Error(`A/B run is already active (lock changed while checking: ${lockPath})`);
+  }
+  await rm(stalePath, { recursive: true, force: true });
+  await mkdir(lockPath);
+  await writeFile(join(lockPath, 'owner.json'), `${JSON.stringify({ pid: process.pid, startedAt: Date.now() })}\n`, 'utf8');
+}
+
+async function readOwnerPid(lockPath: string): Promise<number | undefined> {
+  try {
+    const value = JSON.parse(await readFile(join(lockPath, 'owner.json'), 'utf8')) as { pid?: unknown };
+    return Number.isInteger(value.pid) && Number(value.pid) > 0 ? Number(value.pid) : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return !isNoSuchProcess(error);
+  }
+}
+
+function isAlreadyExists(error: unknown): boolean {
+  return isNodeError(error, 'EEXIST');
+}
+
+function isNoSuchProcess(error: unknown): boolean {
+  return isNodeError(error, 'ESRCH');
+}
+
+function isNodeError(error: unknown, code: string): boolean {
+  return typeof error === 'object' && error !== null && 'code' in error && (error as { code?: unknown }).code === code;
+}

--- a/packages/headless/src/ab-run.ts
+++ b/packages/headless/src/ab-run.ts
@@ -7,7 +7,7 @@ import type {
   FixedPromptTask,
   FixedPromptTaskWalEvent,
 } from './fixed-prompt-controller.js';
-import { assertPositiveInt } from './numeric-guards.js';
+import { assertFinitePositive, assertPositiveInt } from './numeric-guards.js';
 import { summarizeAbComparison } from './ab-summary.js';
 
 export async function runAbComparison(input: RunAbComparisonInput): Promise<AbComparisonSummary> {
@@ -15,6 +15,7 @@ export async function runAbComparison(input: RunAbComparisonInput): Promise<AbCo
   const reps = input.reps ?? 3;
   assertPositiveInt('reps', reps);
   const maxConcurrency = input.maxConcurrency !== undefined ? assertPositiveInt('maxConcurrency', input.maxConcurrency) : 1;
+  if (input.costCeilingUsd !== undefined) assertFinitePositive('costCeilingUsd', input.costCeilingUsd);
   const baselineRuns: FixedPromptTaskWalEvent[][] = Array.from({ length: reps }, () => []);
   const candidateRuns: FixedPromptTaskWalEvent[][] = Array.from({ length: reps }, () => []);
   const pairs: { rep: number; taskIndex: number; task: FixedPromptTask }[] = [];
@@ -23,6 +24,8 @@ export async function runAbComparison(input: RunAbComparisonInput): Promise<AbCo
   }
 
   let nextPairIndex = 0;
+  let observedCostUsd = 0;
+  let stopReason: AbComparisonSummary['stopReason'];
   const active = new Map<number, Promise<{
     pairIndex: number;
     rep: number;
@@ -30,7 +33,7 @@ export async function runAbComparison(input: RunAbComparisonInput): Promise<AbCo
     candidate: FixedPromptTaskWalEvent;
   }>>();
   const launchReadyPairs = () => {
-    while (active.size < maxConcurrency && nextPairIndex < pairs.length) {
+    while (!stopReason && active.size < maxConcurrency && nextPairIndex < pairs.length) {
       const pairIndex = nextPairIndex;
       const pair = pairs[nextPairIndex++]!;
       active.set(pairIndex, runComparisonPair(input, pair).then((result) => ({ pairIndex, ...result })));
@@ -43,6 +46,10 @@ export async function runAbComparison(input: RunAbComparisonInput): Promise<AbCo
     active.delete(result.pairIndex);
     baselineRuns[result.rep]!.push(result.baseline);
     candidateRuns[result.rep]!.push(result.candidate);
+    observedCostUsd += eventCostUsd(result.baseline) + eventCostUsd(result.candidate);
+    if (input.costCeilingUsd !== undefined && observedCostUsd >= input.costCeilingUsd) {
+      stopReason = 'cost_ceiling_reached';
+    }
     launchReadyPairs();
   }
   const taskOrder = new Map(input.evaluationTasks.map((task, index) => [task.id, index]));
@@ -50,7 +57,7 @@ export async function runAbComparison(input: RunAbComparisonInput): Promise<AbCo
     run.sort((a, b) => (taskOrder.get(a.taskId) ?? 0) - (taskOrder.get(b.taskId) ?? 0));
   }
 
-  return summarizeAbComparison({
+  const summary = summarizeAbComparison({
     runId: input.runId,
     roundId: 'ab-summary',
     baselineArmId: input.arms[0].id,
@@ -61,6 +68,11 @@ export async function runAbComparison(input: RunAbComparisonInput): Promise<AbCo
     ...(input.budgetMs !== undefined ? { budgetMs: input.budgetMs } : {}),
     ...(input.nonInferiorityMargin !== undefined ? { nonInferiorityMargin: input.nonInferiorityMargin } : {}),
   });
+  return stopReason ? { ...summary, stopReason } : summary;
+}
+
+function eventCostUsd(event: FixedPromptTaskWalEvent): number {
+  return 'tokenSummary' in event ? event.tokenSummary?.costUsd ?? 0 : 0;
 }
 
 async function runComparisonPair(

--- a/packages/headless/src/ab-run.ts
+++ b/packages/headless/src/ab-run.ts
@@ -47,7 +47,9 @@ export async function runAbComparison(input: RunAbComparisonInput): Promise<AbCo
     baselineRuns[result.rep]!.push(result.baseline);
     candidateRuns[result.rep]!.push(result.candidate);
     observedCostUsd += eventCostUsd(result.baseline) + eventCostUsd(result.candidate);
-    if (input.costCeilingUsd !== undefined && observedCostUsd >= input.costCeilingUsd) {
+    if (isSystemicProviderFailure(result.baseline) || isSystemicProviderFailure(result.candidate)) {
+      stopReason = 'systemic_provider_failure';
+    } else if (input.costCeilingUsd !== undefined && observedCostUsd >= input.costCeilingUsd) {
       stopReason = 'cost_ceiling_reached';
     }
     launchReadyPairs();
@@ -73,6 +75,10 @@ export async function runAbComparison(input: RunAbComparisonInput): Promise<AbCo
 
 function eventCostUsd(event: FixedPromptTaskWalEvent): number {
   return 'tokenSummary' in event ? event.tokenSummary?.costUsd ?? 0 : 0;
+}
+
+function isSystemicProviderFailure(event: FixedPromptTaskWalEvent): boolean {
+  return event.type === 'task_infra_failed' && (event.errorClass === 'provider_billing' || event.errorClass === 'auth');
 }
 
 async function runComparisonPair(

--- a/packages/headless/src/ab-run.ts
+++ b/packages/headless/src/ab-run.ts
@@ -15,7 +15,7 @@ export async function runAbComparison(input: RunAbComparisonInput): Promise<AbCo
   const reps = input.reps ?? 3;
   assertPositiveInt('reps', reps);
   const maxConcurrency = input.maxConcurrency !== undefined ? assertPositiveInt('maxConcurrency', input.maxConcurrency) : 1;
-  if (input.costCeilingUsd !== undefined) assertFinitePositive('costCeilingUsd', input.costCeilingUsd);
+  if (input.observedCostStopUsd !== undefined) assertFinitePositive('observedCostStopUsd', input.observedCostStopUsd);
   const baselineRuns: FixedPromptTaskWalEvent[][] = Array.from({ length: reps }, () => []);
   const candidateRuns: FixedPromptTaskWalEvent[][] = Array.from({ length: reps }, () => []);
   const pairs: { rep: number; taskIndex: number; task: FixedPromptTask }[] = [];
@@ -49,8 +49,8 @@ export async function runAbComparison(input: RunAbComparisonInput): Promise<AbCo
     observedCostUsd += eventCostUsd(result.baseline) + eventCostUsd(result.candidate);
     if (isSystemicProviderFailure(result.baseline) || isSystemicProviderFailure(result.candidate)) {
       stopReason = 'systemic_provider_failure';
-    } else if (input.costCeilingUsd !== undefined && observedCostUsd >= input.costCeilingUsd) {
-      stopReason = 'cost_ceiling_reached';
+    } else if (input.observedCostStopUsd !== undefined && observedCostUsd >= input.observedCostStopUsd) {
+      stopReason = 'observed_cost_stop_reached';
     }
     launchReadyPairs();
   }

--- a/packages/headless/src/ab-run.ts
+++ b/packages/headless/src/ab-run.ts
@@ -98,7 +98,8 @@ async function runComparisonTaskArm(
   arm: AbArmSpec,
   pair: { rep: number; task: FixedPromptTask },
 ): Promise<FixedPromptTaskWalEvent> {
-  const roundId = `ab-${roundIdArmSuffix(arm.id)}-r${pair.rep}-${roundIdTaskSuffix(pair.task.id)}`;
+  const prefix = input.roundIdPrefix ? `${roundIdArmSuffix(input.roundIdPrefix)}-` : '';
+  const roundId = `${prefix}ab-${roundIdArmSuffix(arm.id)}-r${pair.rep}-${roundIdTaskSuffix(pair.task.id)}`;
   const event = await input.runArm({
     runId: input.runId,
     roundId,

--- a/packages/headless/src/ab-summary.ts
+++ b/packages/headless/src/ab-summary.ts
@@ -43,7 +43,7 @@ export function summarizeAbComparison(input: SummarizeAbComparisonInput): AbComp
   const passRateDelta = baseline.passRate !== null && candidate.passRate !== null
     ? roundRateDelta(candidate.passRate - baseline.passRate)
     : null;
-  const nonInferiority = summarizeNonInferiority(baseline, candidate, passRateDelta);
+  const nonInferiority = summarizeNonInferiority(pairedAttempts, passRateDelta);
   const { decision, reason } = decide(baseline, candidate, pairedAttempts, passRateDelta, nonInferiority, nonInferiorityMargin);
 
   return {
@@ -526,19 +526,18 @@ function decide(
 }
 
 function summarizeNonInferiority(
-  baseline: AbArmSummary,
-  candidate: AbArmSummary,
+  pairedAttempts: AbAttemptPairSummary,
   passRateDelta: number | null,
 ): AbNonInferioritySummary {
-  if (passRateDelta === null || baseline.passRate === null || candidate.passRate === null || baseline.valid === 0 || candidate.valid === 0) {
+  if (passRateDelta === null || pairedAttempts.observedPairs === 0) {
     return { method: 'unavailable', confidenceLevel: NON_INFERIORITY_CONFIDENCE_LEVEL, lowerBound: null };
   }
-  const baselineInterval = wilsonScoreInterval(baseline.passed, baseline.valid, ONE_SIDED_95_Z);
-  const candidateInterval = wilsonScoreInterval(candidate.passed, candidate.valid, ONE_SIDED_95_Z);
+  const winInterval = wilsonScoreInterval(pairedAttempts.wins, pairedAttempts.observedPairs, ONE_SIDED_95_Z);
+  const lossInterval = wilsonScoreInterval(pairedAttempts.losses, pairedAttempts.observedPairs, ONE_SIDED_95_Z);
   return {
-    method: 'newcombe_wilson',
+    method: 'paired_newcombe_wilson',
     confidenceLevel: NON_INFERIORITY_CONFIDENCE_LEVEL,
-    lowerBound: roundRateDelta(clampRateDelta(candidateInterval.lower - baselineInterval.upper)),
+    lowerBound: roundRateDelta(clampRateDelta(winInterval.lower - lossInterval.upper)),
   };
 }
 

--- a/packages/headless/src/ab-summary.ts
+++ b/packages/headless/src/ab-summary.ts
@@ -509,17 +509,20 @@ function decide(
   nonInferiorityMargin: number,
 ): { decision: AbDecision; reason: string } {
   const coverage = Math.min(baseline.coverageRate, candidate.coverageRate);
-  if (coverage < 0.9) return { decision: 'inconclusive', reason: 'low_effective_coverage' };
-  if (pairedAttempts.missingPairIds.length > 0) return { decision: 'inconclusive', reason: 'missing_attempt_pair' };
+  if (baseline.infraFailed + candidate.infraFailed > 0) return { decision: 'invalid', reason: 'infra_failure_observed' };
+  if (baseline.plumbingFailed + candidate.plumbingFailed > 0) return { decision: 'invalid', reason: 'plumbing_failure_observed' };
+  if (pairedAttempts.budgetDiscordantPairIds.length > 0) return { decision: 'invalid', reason: 'asymmetric_budget_exhaustion' };
+  if (coverage < 0.9) return { decision: 'not_cleared', reason: 'low_effective_coverage' };
+  if (pairedAttempts.missingPairIds.length > 0) return { decision: 'not_cleared', reason: 'missing_attempt_pair' };
   if (pairedAttempts.infraOrPlumbingDiscordantPairIds.length > 0) {
-    return { decision: 'inconclusive', reason: 'asymmetric_infra_or_plumbing' };
+    return { decision: 'invalid', reason: 'asymmetric_infra_or_plumbing' };
   }
-  if (passRateDelta === null) return { decision: 'inconclusive', reason: 'missing_pass_rate_delta' };
+  if (passRateDelta === null) return { decision: 'not_cleared', reason: 'missing_pass_rate_delta' };
   if (passRateDelta < -nonInferiorityMargin) return { decision: 'inferior', reason: 'pass_rate_delta_below_non_inferiority_margin' };
   if (nonInferiority.lowerBound !== null && nonInferiority.lowerBound >= -nonInferiorityMargin) {
     return { decision: 'non_inferior', reason: 'non_inferiority_lower_bound_within_margin' };
   }
-  return { decision: 'inconclusive', reason: 'non_inferiority_confidence_interval_crosses_margin' };
+  return { decision: 'not_cleared', reason: 'non_inferiority_confidence_interval_crosses_margin' };
 }
 
 function summarizeNonInferiority(

--- a/packages/headless/src/ab-summary.ts
+++ b/packages/headless/src/ab-summary.ts
@@ -1,4 +1,5 @@
 import { BUDGET_EXHAUSTED_RUNTIME_UNAVAILABLE_REASON, type FixedPromptTaskWalEvent } from './fixed-prompt-controller.js';
+import type { HarborCellTokenSummary } from './cell-output.js';
 import { assertRatio } from './numeric-guards.js';
 import type {
   AbArmSummary,
@@ -169,7 +170,7 @@ function pairTaskId(pairId: string): string {
 function summarizeTokenCost(
   events: readonly FixedPromptTaskWalEvent[],
 ): AbTokenCostSummary {
-  const withUsage = events.filter((event): event is FixedPromptTaskWalEvent & { tokenSummary: FixedPromptTaskCompletedEvent['tokenSummary'] } => 'tokenSummary' in event);
+  const withUsage = events.filter((event): event is FixedPromptTaskWalEvent & { tokenSummary: HarborCellTokenSummary } => 'tokenSummary' in event);
   const durations = events.flatMap((event) => 'durationMs' in event ? [event.durationMs] : []);
   return {
     input: sum(withUsage.map((event) => event.tokenSummary.input)),

--- a/packages/headless/src/ab-summary.ts
+++ b/packages/headless/src/ab-summary.ts
@@ -174,7 +174,7 @@ function summarizeTokenCost(
   events: readonly FixedPromptTaskWalEvent[],
 ): AbTokenCostSummary {
   const withUsage = events.filter((event): event is FixedPromptTaskWalEvent & { tokenSummary: HarborCellTokenSummary } => 'tokenSummary' in event);
-  const durations = events.flatMap((event) => 'durationMs' in event ? [event.durationMs] : []);
+  const durations = events.flatMap((event) => 'durationMs' in event && event.durationMs !== undefined ? [event.durationMs] : []);
   return {
     input: sum(withUsage.map((event) => event.tokenSummary.input)),
     cachedInput: sum(withUsage.map((event) => event.tokenSummary.cachedInput)),

--- a/packages/headless/src/ab-summary.ts
+++ b/packages/headless/src/ab-summary.ts
@@ -44,7 +44,10 @@ export function summarizeAbComparison(input: SummarizeAbComparisonInput): AbComp
     ? roundRateDelta(candidate.passRate - baseline.passRate)
     : null;
   const nonInferiority = summarizeNonInferiority(pairedAttempts, passRateDelta);
-  const { decision, reason } = decide(baseline, candidate, pairedAttempts, passRateDelta, nonInferiority, nonInferiorityMargin);
+  const formalDecision = decide(baseline, candidate, pairedAttempts, passRateDelta, nonInferiority, nonInferiorityMargin);
+  const { decision, reason } = reps === 1 && formalDecision.decision !== 'invalid'
+    ? { decision: 'diagnostic' as const, reason: 'single_rep_diagnostic_only' }
+    : formalDecision;
 
   return {
     runId: input.runId,

--- a/packages/headless/src/ab-summary.ts
+++ b/packages/headless/src/ab-summary.ts
@@ -93,7 +93,7 @@ function summarizeArm(
   const taskTools = summarizeTaskTools(observed);
   const activePruneSubset = summarizeActivePruneSubset(observedAttempts, activePrunePairIds);
   const contextBudgetPolicy = summarizeContextBudgetPolicy(observed);
-  const tokenCostSummary = summarizeTokenCost(budgetedRuns);
+  const tokenCostSummary = summarizeTokenCost(observed);
   return {
     attempts,
     observed: observed.length,
@@ -136,7 +136,7 @@ function summarizeActivePruneSubset(
   const budgetedRuns = valid.filter((event) => event.type !== 'task_budget_exhausted');
   const passed = valid.filter((event) => event.passed).length;
   const durations = budgetedRuns.map((event) => event.durationMs);
-  const tokenCostSummary = summarizeTokenCost(budgetedRuns);
+  const tokenCostSummary = summarizeTokenCost(observed);
   const contextBudget = summarizeContextBudget(sliceAttempts);
   return {
     taskCount: new Set([...activePrunePairIds].map(pairTaskId)).size,
@@ -167,19 +167,20 @@ function pairTaskId(pairId: string): string {
 }
 
 function summarizeTokenCost(
-  events: readonly Extract<FixedPromptTaskWalEvent, { type: 'task_completed' }>[],
+  events: readonly FixedPromptTaskWalEvent[],
 ): AbTokenCostSummary {
-  const durations = events.map((event) => event.durationMs);
+  const withUsage = events.filter((event): event is FixedPromptTaskWalEvent & { tokenSummary: FixedPromptTaskCompletedEvent['tokenSummary'] } => 'tokenSummary' in event);
+  const durations = events.flatMap((event) => 'durationMs' in event ? [event.durationMs] : []);
   return {
-    input: sum(events.map((event) => event.tokenSummary.input)),
-    cachedInput: sum(events.map((event) => event.tokenSummary.cachedInput)),
-    cacheHitInput: sum(events.map((event) => event.tokenSummary.cacheHitInput)),
-    cacheMissInput: sum(events.map((event) => event.tokenSummary.cacheMissInput)),
-    cacheWriteInput: sum(events.map((event) => event.tokenSummary.cacheWriteInput)),
-    output: sum(events.map((event) => event.tokenSummary.output)),
-    reasoning: sum(events.map((event) => event.tokenSummary.reasoning)),
-    total: sum(events.map((event) => event.tokenSummary.total)),
-    costUsd: sum(events.map((event) => event.tokenSummary.costUsd)),
+    input: sum(withUsage.map((event) => event.tokenSummary.input)),
+    cachedInput: sum(withUsage.map((event) => event.tokenSummary.cachedInput)),
+    cacheHitInput: sum(withUsage.map((event) => event.tokenSummary.cacheHitInput)),
+    cacheMissInput: sum(withUsage.map((event) => event.tokenSummary.cacheMissInput)),
+    cacheWriteInput: sum(withUsage.map((event) => event.tokenSummary.cacheWriteInput)),
+    output: sum(withUsage.map((event) => event.tokenSummary.output)),
+    reasoning: sum(withUsage.map((event) => event.tokenSummary.reasoning)),
+    total: sum(withUsage.map((event) => event.tokenSummary.total)),
+    costUsd: sum(withUsage.map((event) => event.tokenSummary.costUsd)),
     meanDurationMs: durations.length > 0 ? sum(durations) / durations.length : null,
   };
 }

--- a/packages/headless/src/ab-summary.ts
+++ b/packages/headless/src/ab-summary.ts
@@ -176,7 +176,7 @@ function pairTaskId(pairId: string): string {
 function summarizeTokenCost(
   events: readonly FixedPromptTaskWalEvent[],
 ): AbTokenCostSummary {
-  const withUsage = events.filter((event): event is FixedPromptTaskWalEvent & { tokenSummary: HarborCellTokenSummary } => 'tokenSummary' in event);
+  const withUsage = events.filter((event): event is FixedPromptTaskWalEvent & { tokenSummary: HarborCellTokenSummary } => 'tokenSummary' in event && event.tokenSummary !== undefined);
   const durations = events.flatMap((event) => 'durationMs' in event && event.durationMs !== undefined ? [event.durationMs] : []);
   return {
     input: sum(withUsage.map((event) => event.tokenSummary.input)),

--- a/packages/headless/src/ab-summary.ts
+++ b/packages/headless/src/ab-summary.ts
@@ -25,7 +25,10 @@ import type { HarborCellContextBudgetSummary, HarborCellTaskToolSummary } from '
 
 const DEFAULT_NON_INFERIORITY_MARGIN = 0.10;
 const NON_INFERIORITY_CONFIDENCE_LEVEL = 0.95;
-const ONE_SIDED_95_Z = 1.6448536269514722;
+// Two one-sided 97.5% score bounds give at least 95% simultaneous coverage by
+// Bonferroni; subtracting loss.upper from win.lower is therefore a valid paired
+// lower bound without pretending the multinomial cells are independent.
+const ONE_SIDED_97_5_Z = 1.959963984540054;
 
 export function summarizeAbComparison(input: SummarizeAbComparisonInput): AbComparisonSummary {
   assertSameRunCount(input.baselineRuns, input.candidateRuns);
@@ -535,10 +538,10 @@ function summarizeNonInferiority(
   if (passRateDelta === null || pairedAttempts.observedPairs === 0) {
     return { method: 'unavailable', confidenceLevel: NON_INFERIORITY_CONFIDENCE_LEVEL, lowerBound: null };
   }
-  const winInterval = wilsonScoreInterval(pairedAttempts.wins, pairedAttempts.observedPairs, ONE_SIDED_95_Z);
-  const lossInterval = wilsonScoreInterval(pairedAttempts.losses, pairedAttempts.observedPairs, ONE_SIDED_95_Z);
+  const winInterval = wilsonScoreInterval(pairedAttempts.wins, pairedAttempts.observedPairs, ONE_SIDED_97_5_Z);
+  const lossInterval = wilsonScoreInterval(pairedAttempts.losses, pairedAttempts.observedPairs, ONE_SIDED_97_5_Z);
   return {
-    method: 'paired_newcombe_wilson',
+    method: 'paired_bonferroni_wilson',
     confidenceLevel: NON_INFERIORITY_CONFIDENCE_LEVEL,
     lowerBound: roundRateDelta(clampRateDelta(winInterval.lower - lossInterval.upper)),
   };

--- a/packages/headless/src/ab-types.ts
+++ b/packages/headless/src/ab-types.ts
@@ -28,7 +28,7 @@ export interface RunAbComparisonInput {
   evaluationTasks: readonly FixedPromptTask[];
   reps?: number;
   maxConcurrency?: number;
-  costCeilingUsd?: number;
+  observedCostStopUsd?: number;
   roundIdPrefix?: string;
   budgetMs?: number;
   nonInferiorityMargin?: number;
@@ -247,7 +247,7 @@ export interface AbComparisonSummary {
   taskLevel: AbTaskLevelSummary;
   pairedAttempts: AbAttemptPairSummary;
   investigationRefs: AbInvestigationRefs;
-  stopReason?: 'cost_ceiling_reached' | 'systemic_provider_failure';
+  stopReason?: 'observed_cost_stop_reached' | 'systemic_provider_failure';
 }
 
 export interface AbRunManifestInput {
@@ -263,7 +263,7 @@ export interface AbRunManifestInput {
   candidateLimit: number | null;
   maxConcurrency: number;
   maxConcurrentAttempts?: number;
-  costCeilingUsd?: number;
+  observedCostStopUsd?: number;
   selectionMode?: 'explicit' | 'metadata';
   candidateTaskIds?: readonly string[];
   pilotTaskIds?: readonly string[];

--- a/packages/headless/src/ab-types.ts
+++ b/packages/headless/src/ab-types.ts
@@ -29,6 +29,7 @@ export interface RunAbComparisonInput {
   reps?: number;
   maxConcurrency?: number;
   costCeilingUsd?: number;
+  roundIdPrefix?: string;
   budgetMs?: number;
   nonInferiorityMargin?: number;
   runArm: AbArmRunner;
@@ -47,7 +48,9 @@ export type AbArmRunner = (input: AbArmRunInput) => Promise<FixedPromptTaskWalEv
 export type AbDecision =
   | 'non_inferior'
   | 'inferior'
-  | 'inconclusive';
+  | 'not_cleared'
+  | 'diagnostic'
+  | 'invalid';
 
 export interface AbArmSummary {
   attempts: number;
@@ -263,6 +266,7 @@ export interface AbRunManifestInput {
   costCeilingUsd?: number;
   selectionMode?: 'explicit' | 'metadata';
   candidateTaskIds?: readonly string[];
+  pilotTaskIds?: readonly string[];
   maxExpertTimeEstimateMin?: number | null;
   targetEvaluationTaskCount?: number | null;
   nonInferiorityMargin?: number;
@@ -274,4 +278,5 @@ export type AbRunManifest = AbRunManifestInput & {
   arms: [AbArmSpec, AbArmSpec];
   evaluationTaskIds: string[];
   candidateTaskIds?: string[];
+  pilotTaskIds?: string[];
 };

--- a/packages/headless/src/ab-types.ts
+++ b/packages/headless/src/ab-types.ts
@@ -28,6 +28,7 @@ export interface RunAbComparisonInput {
   evaluationTasks: readonly FixedPromptTask[];
   reps?: number;
   maxConcurrency?: number;
+  costCeilingUsd?: number;
   budgetMs?: number;
   nonInferiorityMargin?: number;
   runArm: AbArmRunner;
@@ -243,6 +244,7 @@ export interface AbComparisonSummary {
   taskLevel: AbTaskLevelSummary;
   pairedAttempts: AbAttemptPairSummary;
   investigationRefs: AbInvestigationRefs;
+  stopReason?: 'cost_ceiling_reached';
 }
 
 export interface AbRunManifestInput {
@@ -257,6 +259,8 @@ export interface AbRunManifestInput {
   reps: number;
   candidateLimit: number | null;
   maxConcurrency: number;
+  maxConcurrentAttempts?: number;
+  costCeilingUsd?: number;
   selectionMode?: 'explicit' | 'metadata';
   candidateTaskIds?: readonly string[];
   maxExpertTimeEstimateMin?: number | null;

--- a/packages/headless/src/ab-types.ts
+++ b/packages/headless/src/ab-types.ts
@@ -224,7 +224,7 @@ export interface AbInvestigationRefs {
 }
 
 export interface AbNonInferioritySummary {
-  method: 'paired_newcombe_wilson' | 'unavailable';
+  method: 'paired_bonferroni_wilson' | 'unavailable';
   confidenceLevel: number;
   lowerBound: number | null;
 }

--- a/packages/headless/src/ab-types.ts
+++ b/packages/headless/src/ab-types.ts
@@ -247,7 +247,7 @@ export interface AbComparisonSummary {
   taskLevel: AbTaskLevelSummary;
   pairedAttempts: AbAttemptPairSummary;
   investigationRefs: AbInvestigationRefs;
-  stopReason?: 'cost_ceiling_reached';
+  stopReason?: 'cost_ceiling_reached' | 'systemic_provider_failure';
 }
 
 export interface AbRunManifestInput {

--- a/packages/headless/src/ab-types.ts
+++ b/packages/headless/src/ab-types.ts
@@ -224,7 +224,7 @@ export interface AbInvestigationRefs {
 }
 
 export interface AbNonInferioritySummary {
-  method: 'newcombe_wilson' | 'unavailable';
+  method: 'paired_newcombe_wilson' | 'unavailable';
   confidenceLevel: number;
   lowerBound: number | null;
 }

--- a/packages/headless/src/cell-output.ts
+++ b/packages/headless/src/cell-output.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'node:crypto';
 import type { RuntimeEvent } from '@maka/core';
 import type { ContextBudgetPolicy, InvocationResult } from '@maka/runtime';
 
@@ -55,6 +56,13 @@ export interface HarborCellRuntimeRefs {
   turnId: string;
 }
 
+export interface HarborCellExecutionIdentity {
+  llmConnectionSlug: string;
+  model: string;
+  systemPromptHash: string;
+  pricingProfile: string;
+}
+
 export interface HarborCellContinuationSummary {
   enabled: boolean;
   maxTurns: number;
@@ -91,6 +99,7 @@ export interface HarborCellOutput {
   errorClass?: string;
   runtimeEventsPath: string;
   promptHash?: string;
+  executionIdentity?: HarborCellExecutionIdentity;
   tokenSummary: HarborCellTokenSummary;
   contextBudgetPolicy?: HarborCellContextBudgetPolicySnapshot;
   contextBudgetSummary?: HarborCellContextBudgetSummary;
@@ -107,6 +116,7 @@ export interface HarborCellOutput {
 export function buildHarborCellOutput(input: {
   invocation: InvocationResult;
   runtimeEventsPath: string;
+  executionIdentity?: HarborCellExecutionIdentity;
   contextBudgetPolicy?: HarborCellContextBudgetPolicySnapshot;
   continuationSummary?: HarborCellContinuationSummary;
   taskToolSummaryEnabled?: boolean;
@@ -118,6 +128,7 @@ export function buildHarborCellOutput(input: {
     ...(invocation.failure?.class ? { errorClass: invocation.failure.class } : {}),
     runtimeEventsPath: input.runtimeEventsPath,
     ...promptHashField(invocation.events),
+    ...(input.executionIdentity ? { executionIdentity: input.executionIdentity } : {}),
     tokenSummary: summarizeCellTokens(invocation.events),
     ...(input.contextBudgetPolicy ? { contextBudgetPolicy: input.contextBudgetPolicy } : {}),
     ...contextBudgetSummaryField(invocation.events),
@@ -137,6 +148,10 @@ export function buildHarborCellOutput(input: {
   };
 }
 
+export function hashHarborSystemPrompt(systemPrompt: string): string {
+  return `sha256:${createHash('sha256').update(JSON.stringify(systemPrompt)).digest('hex')}`;
+}
+
 export function validateHarborCellOutput(value: unknown): HarborCellOutput {
   if (!isRecord(value)) {
     throw new Error('Harbor cell output must be a JSON object');
@@ -149,6 +164,9 @@ export function validateHarborCellOutput(value: unknown): HarborCellOutput {
   const errorClass = 'errorClass' in value ? requireOptionalString(value.errorClass, 'errorClass') : undefined;
   const runtimeEventsPath = requireString(value.runtimeEventsPath, 'runtimeEventsPath');
   const promptHash = 'promptHash' in value ? requireOptionalString(value.promptHash, 'promptHash') : undefined;
+  const executionIdentity = 'executionIdentity' in value
+    ? validateExecutionIdentity(value.executionIdentity)
+    : undefined;
   const tokenSummary = validateTokenSummary(value.tokenSummary);
   const contextBudgetPolicy = 'contextBudgetPolicy' in value
     ? validateContextBudgetPolicySnapshot(value.contextBudgetPolicy)
@@ -174,6 +192,7 @@ export function validateHarborCellOutput(value: unknown): HarborCellOutput {
     ...(errorClass !== undefined ? { errorClass } : {}),
     runtimeEventsPath,
     ...(promptHash !== undefined ? { promptHash } : {}),
+    ...(executionIdentity !== undefined ? { executionIdentity } : {}),
     tokenSummary,
     ...(contextBudgetPolicy !== undefined ? { contextBudgetPolicy } : {}),
     ...(contextBudgetSummary !== undefined ? { contextBudgetSummary } : {}),
@@ -187,6 +206,16 @@ export function validateHarborCellOutput(value: unknown): HarborCellOutput {
     runtimeRefs,
   };
   return output;
+}
+
+function validateExecutionIdentity(value: unknown): HarborCellExecutionIdentity {
+  if (!isRecord(value)) throw new Error('executionIdentity must be a JSON object');
+  return {
+    llmConnectionSlug: requireString(value.llmConnectionSlug, 'executionIdentity.llmConnectionSlug'),
+    model: requireString(value.model, 'executionIdentity.model'),
+    systemPromptHash: requireString(value.systemPromptHash, 'executionIdentity.systemPromptHash'),
+    pricingProfile: requireString(value.pricingProfile, 'executionIdentity.pricingProfile'),
+  };
 }
 
 export function summarizeCellTaskTools(events: readonly RuntimeEvent[]): HarborCellTaskToolSummary {

--- a/packages/headless/src/fixed-prompt-controller.ts
+++ b/packages/headless/src/fixed-prompt-controller.ts
@@ -118,7 +118,7 @@ export interface FixedPromptTaskInfraFailedEvent {
   passed: false;
   scored: false;
   eligible: false;
-  errorClass: 'infra_error';
+  errorClass: 'infra_error' | 'provider_billing' | 'auth';
   error: string;
 }
 
@@ -295,6 +295,7 @@ export interface RunFixedPromptControllerInput {
 
 export type FixedPromptControllerStopReason =
   | 'infra_failure_rate_exceeded'
+  | 'systemic_provider_failure'
   | 'cost_ceiling_exceeded';
 
 export interface FixedPromptControllerResult {
@@ -581,7 +582,14 @@ function taskEventFromOutput(input: {
   roundId: string;
   id: string;
   ts: number;
-}): FixedPromptTaskCompletedEvent | FixedPromptTaskPlumbingFailedEvent {
+}): FixedPromptTaskCompletedEvent | FixedPromptTaskPlumbingFailedEvent | FixedPromptTaskInfraFailedEvent {
+  if (isSystemicProviderFailure(input.output.cell.errorClass)) {
+    return taskInfraFailedEvent({
+      ...input,
+      errorClass: input.output.cell.errorClass,
+      error: `Harbor cell failed with ${input.output.cell.errorClass}`,
+    });
+  }
   const plumbingFailure = classifyPlumbingFailure(input.output, input.expectedPromptHash, input.expectedConfig);
   if (plumbingFailure) {
     return taskPlumbingFailedEvent({
@@ -737,6 +745,7 @@ function classifyPlumbingFailure(output: HarborTaskRunOutput, expectedPromptHash
 
 function taskInfraFailedEvent(input: {
   error: unknown;
+  errorClass?: FixedPromptTaskInfraFailedEvent['errorClass'];
   taskId: string;
   runId: string;
   roundId: string;
@@ -757,7 +766,7 @@ function taskInfraFailedEvent(input: {
     passed: false,
     scored: false,
     eligible: false,
-    errorClass: 'infra_error',
+    errorClass: input.errorClass ?? 'infra_error',
     error: errorMessage(input.error),
   };
 }
@@ -881,6 +890,9 @@ function controllerStopReason(input: {
   maxInfraFailureRate?: number;
   costCeilingUsd?: number;
 }): FixedPromptControllerStopReason | undefined {
+  if (input.events.some((event) => event.type === 'task_infra_failed' && isSystemicProviderFailure(event.errorClass))) {
+    return 'systemic_provider_failure';
+  }
   if (
     input.maxInfraFailureRate !== undefined
     && infraFailureRate(input.events, input.taskCount) > input.maxInfraFailureRate
@@ -891,6 +903,10 @@ function controllerStopReason(input: {
     return 'cost_ceiling_exceeded';
   }
   return undefined;
+}
+
+function isSystemicProviderFailure(errorClass: string | undefined): errorClass is 'provider_billing' | 'auth' {
+  return errorClass === 'provider_billing' || errorClass === 'auth';
 }
 
 function infraFailureRate(events: readonly FixedPromptTaskWalEvent[], taskCount: number): number {

--- a/packages/headless/src/fixed-prompt-controller.ts
+++ b/packages/headless/src/fixed-prompt-controller.ts
@@ -1,8 +1,9 @@
-import { createHash, randomUUID } from 'node:crypto';
+import { randomUUID } from 'node:crypto';
 import { appendFile, mkdir, readFile, truncate, writeFile } from 'node:fs/promises';
 import { dirname } from 'node:path';
 import {
   validateHarborCellOutput,
+  hashHarborSystemPrompt,
   type HarborCellContextBudgetPolicySnapshot,
   type HarborCellContextBudgetSummary,
   type HarborCellContinuationSummary,
@@ -155,7 +156,7 @@ export interface FixedPromptTaskPlumbingFailedEvent {
   passed: false;
   scored: false;
   eligible: false;
-  errorClass: 'zero_cost_with_tokens' | 'prompt_hash_mismatch' | 'missing_prompt_hash';
+  errorClass: 'zero_cost_with_tokens' | 'prompt_hash_mismatch' | 'missing_prompt_hash' | 'execution_identity_mismatch';
   error: string;
   promptHash?: string;
   expectedPromptHash?: string;
@@ -559,6 +560,7 @@ async function runTaskAndBuildEvent(input: {
   }
   return taskEventFromOutput({
     output,
+    expectedConfig: input.config,
     expectedPromptHash: input.expectedPromptHash,
     resumeFingerprint: input.resumeFingerprint,
     taskId: input.task.id,
@@ -571,6 +573,7 @@ async function runTaskAndBuildEvent(input: {
 
 function taskEventFromOutput(input: {
   output: HarborTaskRunOutput;
+  expectedConfig: Config;
   expectedPromptHash: string;
   resumeFingerprint?: string;
   taskId: string;
@@ -579,7 +582,7 @@ function taskEventFromOutput(input: {
   id: string;
   ts: number;
 }): FixedPromptTaskCompletedEvent | FixedPromptTaskPlumbingFailedEvent {
-  const plumbingFailure = classifyPlumbingFailure(input.output, input.expectedPromptHash);
+  const plumbingFailure = classifyPlumbingFailure(input.output, input.expectedPromptHash, input.expectedConfig);
   if (plumbingFailure) {
     return taskPlumbingFailedEvent({
       ...input,
@@ -690,10 +693,27 @@ function taskPlumbingFailedEvent(input: {
   };
 }
 
-function classifyPlumbingFailure(output: HarborTaskRunOutput, expectedPromptHash: string): {
+function classifyPlumbingFailure(output: HarborTaskRunOutput, expectedPromptHash: string, expectedConfig: Config): {
   errorClass: FixedPromptTaskPlumbingFailedEvent['errorClass'];
   error: string;
 } | undefined {
+  const identity = output.cell.executionIdentity;
+  if (identity) {
+    const modelPrefix = `${expectedConfig.llmConnectionSlug}/`;
+    const expectedModel = expectedConfig.model?.startsWith(modelPrefix)
+      ? expectedConfig.model.slice(modelPrefix.length)
+      : expectedConfig.model;
+    if (
+      identity.llmConnectionSlug !== expectedConfig.llmConnectionSlug
+      || identity.model !== expectedModel
+      || identity.systemPromptHash !== expectedPromptHash
+    ) {
+      return {
+        errorClass: 'execution_identity_mismatch',
+        error: 'Harbor cell execution identity did not match the configured connection, model, and prompt',
+      };
+    }
+  }
   if (output.cell.status === 'completed' && output.cell.promptHash === undefined) {
     return {
       errorClass: 'missing_prompt_hash',
@@ -913,7 +933,7 @@ async function truncateTornWalTail(path: string): Promise<void> {
 }
 
 export function hashSystemPrompt(systemPrompt: string): string {
-  return `sha256:${createHash('sha256').update(JSON.stringify(systemPrompt)).digest('hex')}`;
+  return hashHarborSystemPrompt(systemPrompt);
 }
 
 async function readJsonObject(path: string): Promise<Record<string, unknown>> {

--- a/packages/headless/src/fixed-prompt-controller.ts
+++ b/packages/headless/src/fixed-prompt-controller.ts
@@ -158,7 +158,7 @@ export interface FixedPromptTaskPlumbingFailedEvent {
   passed: false;
   scored: false;
   eligible: false;
-  errorClass: 'zero_cost_with_tokens' | 'prompt_hash_mismatch' | 'missing_prompt_hash' | 'execution_identity_mismatch';
+  errorClass: 'zero_cost_with_tokens' | 'prompt_hash_mismatch' | 'missing_prompt_hash' | 'missing_execution_identity' | 'execution_identity_mismatch';
   error: string;
   promptHash?: string;
   expectedPromptHash?: string;
@@ -290,6 +290,8 @@ export interface RunFixedPromptControllerInput {
   costCeilingUsd?: number;
   maxConcurrency?: number;
   resumeFingerprint?: string;
+  requireExecutionIdentity?: boolean;
+  expectedPricingProfile?: string;
   harborRunner: HarborTaskRunner;
   now?: () => number;
   newId?: () => string;
@@ -369,6 +371,8 @@ export async function runFixedPromptController(
         config,
         systemPrompt,
         expectedPromptHash,
+        requireExecutionIdentity: input.requireExecutionIdentity,
+        expectedPricingProfile: input.expectedPricingProfile,
         resumeFingerprint: input.resumeFingerprint,
         id: newId(),
         ts: now(),
@@ -500,6 +504,8 @@ async function runTaskAndBuildEvent(input: {
   config: Config;
   systemPrompt: string;
   expectedPromptHash: string;
+  requireExecutionIdentity?: boolean;
+  expectedPricingProfile?: string;
   resumeFingerprint?: string;
   id: string;
   ts: number;
@@ -565,6 +571,8 @@ async function runTaskAndBuildEvent(input: {
     output,
     expectedConfig: input.config,
     expectedPromptHash: input.expectedPromptHash,
+    requireExecutionIdentity: input.requireExecutionIdentity,
+    expectedPricingProfile: input.expectedPricingProfile,
     resumeFingerprint: input.resumeFingerprint,
     taskId: input.task.id,
     runId: input.input.runId,
@@ -578,6 +586,8 @@ function taskEventFromOutput(input: {
   output: HarborTaskRunOutput;
   expectedConfig: Config;
   expectedPromptHash: string;
+  requireExecutionIdentity?: boolean;
+  expectedPricingProfile?: string;
   resumeFingerprint?: string;
   taskId: string;
   runId: string;
@@ -592,7 +602,13 @@ function taskEventFromOutput(input: {
       error: `Harbor cell failed with ${input.output.cell.errorClass}`,
     });
   }
-  const plumbingFailure = classifyPlumbingFailure(input.output, input.expectedPromptHash, input.expectedConfig);
+  const plumbingFailure = classifyPlumbingFailure(
+    input.output,
+    input.expectedPromptHash,
+    input.expectedConfig,
+    input.requireExecutionIdentity ?? false,
+    input.expectedPricingProfile,
+  );
   if (plumbingFailure) {
     return taskPlumbingFailedEvent({
       ...input,
@@ -703,11 +719,17 @@ function taskPlumbingFailedEvent(input: {
   };
 }
 
-function classifyPlumbingFailure(output: HarborTaskRunOutput, expectedPromptHash: string, expectedConfig: Config): {
+function classifyPlumbingFailure(output: HarborTaskRunOutput, expectedPromptHash: string, expectedConfig: Config, requireExecutionIdentity: boolean, expectedPricingProfile: string | undefined): {
   errorClass: FixedPromptTaskPlumbingFailedEvent['errorClass'];
   error: string;
 } | undefined {
   const identity = output.cell.executionIdentity;
+  if (requireExecutionIdentity && !identity) {
+    return {
+      errorClass: 'missing_execution_identity',
+      error: 'Harbor cell did not attest the connection, model, prompt, and pricing profile that executed',
+    };
+  }
   if (identity) {
     const modelPrefix = `${expectedConfig.llmConnectionSlug}/`;
     const expectedModel = expectedConfig.model?.startsWith(modelPrefix)
@@ -717,6 +739,7 @@ function classifyPlumbingFailure(output: HarborTaskRunOutput, expectedPromptHash
       identity.llmConnectionSlug !== expectedConfig.llmConnectionSlug
       || identity.model !== expectedModel
       || identity.systemPromptHash !== expectedPromptHash
+      || (expectedPricingProfile !== undefined && identity.pricingProfile !== expectedPricingProfile)
     ) {
       return {
         errorClass: 'execution_identity_mismatch',

--- a/packages/headless/src/fixed-prompt-controller.ts
+++ b/packages/headless/src/fixed-prompt-controller.ts
@@ -92,7 +92,7 @@ export interface FixedPromptTaskCompletedEvent {
   eligible: boolean;
   errorClass?: string;
   promptHash?: string;
-  tokenSummary?: HarborCellTokenSummary;
+  tokenSummary: HarborCellTokenSummary;
   contextBudgetPolicy?: HarborCellContextBudgetPolicySnapshot;
   contextBudgetSummary?: HarborCellContextBudgetSummary;
   continuationSummary?: HarborCellContinuationSummary;

--- a/packages/headless/src/fixed-prompt-controller.ts
+++ b/packages/headless/src/fixed-prompt-controller.ts
@@ -57,6 +57,7 @@ export interface FixedPromptBudgetExhaustedArtifactRefs {
   runtimeEventsPath?: string;
   traceEventsPath?: string;
   runtimeEventsUnavailableReason?: string;
+  tokenSummary?: HarborCellTokenSummary;
 }
 
 export class FixedPromptBudgetExhaustedError extends Error {
@@ -141,6 +142,7 @@ export interface FixedPromptTaskBudgetExhaustedEvent {
   runtimeEventsPath?: string;
   traceEventsPath?: string;
   runtimeEventsUnavailableReason?: string;
+  tokenSummary?: HarborCellTokenSummary;
 }
 
 export interface FixedPromptTaskPlumbingFailedEvent {
@@ -400,8 +402,8 @@ export async function runFixedPromptController(
   return {
     taskIds: resultEvents.map((event) => event.taskId),
     events: resultEvents,
-    totalTokens: sum(resultEvents.map((event) => eventHasRunArtifacts(event) ? event.tokenSummary.total : 0)),
-    totalCostUsd: sum(resultEvents.map((event) => eventHasRunArtifacts(event) ? event.tokenSummary.costUsd : 0)),
+    totalTokens: sum(resultEvents.map((event) => eventTokenSummary(event)?.total ?? 0)),
+    totalCostUsd: sum(resultEvents.map((event) => eventTokenSummary(event)?.costUsd ?? 0)),
     resultsTsvPath: input.resultsTsvPath,
     ...(stopReason ? { stopReason } : {}),
   };
@@ -483,10 +485,10 @@ export async function writeFixedPromptResultsTsv(
     String(event.scored),
     String(event.eligible),
     event.errorClass ?? '',
-    eventHasRunArtifacts(event) ? event.promptHash ?? '' : '',
-    String(eventHasRunArtifacts(event) ? event.tokenSummary.total : 0),
-    String(eventHasRunArtifacts(event) ? event.tokenSummary.costUsd : 0),
-    eventHasRunArtifacts(event) ? event.runtimeEventsPath : '',
+    'promptHash' in event ? event.promptHash ?? '' : '',
+    String(eventTokenSummary(event)?.total ?? 0),
+    String(eventTokenSummary(event)?.costUsd ?? 0),
+    'runtimeEventsPath' in event ? event.runtimeEventsPath ?? '' : '',
   ]);
   const body = [header, ...rows].map((row) => row.map(tsvCell).join('\t')).join('\n');
   await writeFile(path, `${body}\n`, 'utf8');
@@ -803,13 +805,14 @@ function taskBudgetExhaustedEvent(input: {
     ...(artifactRefs.runtimeEventsUnavailableReason
       ? { runtimeEventsUnavailableReason: artifactRefs.runtimeEventsUnavailableReason }
       : {}),
+    ...(artifactRefs.tokenSummary ? { tokenSummary: artifactRefs.tokenSummary } : {}),
   };
 }
 
 function budgetExhaustedArtifactRefs(error: unknown): FixedPromptBudgetExhaustedArtifactRefs {
   if (isBudgetExhaustedError(error)) {
     const refs = (error as { artifactRefs?: FixedPromptBudgetExhaustedArtifactRefs }).artifactRefs;
-    if (refs && (refs.runtimeEventsPath || refs.traceEventsPath || refs.runtimeEventsUnavailableReason)) return refs;
+    if (refs && (refs.runtimeEventsPath || refs.traceEventsPath || refs.runtimeEventsUnavailableReason || refs.tokenSummary)) return refs;
   }
   return { runtimeEventsUnavailableReason: BUDGET_EXHAUSTED_RUNTIME_UNAVAILABLE_REASON };
 }
@@ -915,13 +918,11 @@ function infraFailureRate(events: readonly FixedPromptTaskWalEvent[], taskCount:
 }
 
 function taskEventsCostUsd(events: readonly FixedPromptTaskWalEvent[]): number {
-  return sum(events.map((event) => eventHasRunArtifacts(event) ? event.tokenSummary.costUsd : 0));
+  return sum(events.map((event) => eventTokenSummary(event)?.costUsd ?? 0));
 }
 
-function eventHasRunArtifacts(
-  event: FixedPromptTaskWalEvent,
-): event is FixedPromptTaskCompletedEvent | FixedPromptTaskPlumbingFailedEvent {
-  return event.type === 'task_completed' || event.type === 'task_plumbing_failed';
+function eventTokenSummary(event: FixedPromptTaskWalEvent): HarborCellTokenSummary | undefined {
+  return 'tokenSummary' in event ? event.tokenSummary : undefined;
 }
 
 function isBudgetExhaustedError(error: unknown): boolean {

--- a/packages/headless/src/fixed-prompt-controller.ts
+++ b/packages/headless/src/fixed-prompt-controller.ts
@@ -92,7 +92,7 @@ export interface FixedPromptTaskCompletedEvent {
   eligible: boolean;
   errorClass?: string;
   promptHash?: string;
-  tokenSummary: HarborCellTokenSummary;
+  tokenSummary?: HarborCellTokenSummary;
   contextBudgetPolicy?: HarborCellContextBudgetPolicySnapshot;
   contextBudgetSummary?: HarborCellContextBudgetSummary;
   continuationSummary?: HarborCellContinuationSummary;
@@ -163,16 +163,16 @@ export interface FixedPromptTaskPlumbingFailedEvent {
   error: string;
   promptHash?: string;
   expectedPromptHash?: string;
-  tokenSummary: HarborCellTokenSummary;
+  tokenSummary?: HarborCellTokenSummary;
   contextBudgetPolicy?: HarborCellContextBudgetPolicySnapshot;
   contextBudgetSummary?: HarborCellContextBudgetSummary;
   continuationSummary?: HarborCellContinuationSummary;
   taskToolSummary?: HarborCellTaskToolSummary;
-  steps: number;
-  durationMs: number;
-  runtimeEventsPath: string;
+  steps?: number;
+  durationMs?: number;
+  runtimeEventsPath?: string;
   traceEventsPath?: string;
-  harbor: {
+  harbor?: {
     reward: number;
   };
 }
@@ -817,6 +817,28 @@ function taskBudgetExhaustedEvent(input: {
   ts: number;
 }): FixedPromptTaskBudgetExhaustedEvent | FixedPromptTaskPlumbingFailedEvent {
   const artifactRefs = budgetExhaustedArtifactRefs(input.error);
+  if (input.requireExecutionIdentity && !artifactRefs.cellOutput) {
+    return {
+      schemaVersion: FIXED_PROMPT_WAL_SCHEMA_VERSION,
+      type: 'task_plumbing_failed',
+      id: input.id,
+      ts: input.ts,
+      runId: input.runId,
+      roundId: input.roundId,
+      ...(input.resumeFingerprint ? { resumeFingerprint: input.resumeFingerprint } : {}),
+      taskId: input.taskId,
+      status: 'plumbing_failed',
+      passed: false,
+      scored: false,
+      eligible: false,
+      errorClass: 'missing_execution_identity',
+      error: 'Timed-out Harbor attempt did not produce execution identity attestation',
+      expectedPromptHash: input.expectedPromptHash,
+      ...(artifactRefs.tokenSummary ? { tokenSummary: artifactRefs.tokenSummary } : {}),
+      ...(artifactRefs.runtimeEventsPath ? { runtimeEventsPath: artifactRefs.runtimeEventsPath } : {}),
+      ...(artifactRefs.traceEventsPath ? { traceEventsPath: artifactRefs.traceEventsPath } : {}),
+    };
+  }
   if (artifactRefs.cellOutput) {
     const output = { harbor: { reward: 0 }, cell: artifactRefs.cellOutput };
     const plumbingFailure = classifyPlumbingFailure(

--- a/packages/headless/src/fixed-prompt-controller.ts
+++ b/packages/headless/src/fixed-prompt-controller.ts
@@ -58,6 +58,7 @@ export interface FixedPromptBudgetExhaustedArtifactRefs {
   traceEventsPath?: string;
   runtimeEventsUnavailableReason?: string;
   tokenSummary?: HarborCellTokenSummary;
+  cellOutput?: HarborTaskRunCellOutput;
 }
 
 export class FixedPromptBudgetExhaustedError extends Error {
@@ -528,6 +529,9 @@ async function runTaskAndBuildEvent(input: {
         runId: input.input.runId,
         roundId: input.input.roundId,
         expectedPromptHash: input.expectedPromptHash,
+        expectedConfig: input.config,
+        requireExecutionIdentity: input.requireExecutionIdentity,
+        expectedPricingProfile: input.expectedPricingProfile,
         resumeFingerprint: input.resumeFingerprint,
         id: input.id,
         ts: input.ts,
@@ -551,6 +555,9 @@ async function runTaskAndBuildEvent(input: {
           runId: input.input.runId,
           roundId: input.input.roundId,
           expectedPromptHash: input.expectedPromptHash,
+          expectedConfig: input.config,
+          requireExecutionIdentity: input.requireExecutionIdentity,
+          expectedPricingProfile: input.expectedPricingProfile,
           resumeFingerprint: input.resumeFingerprint,
           id: input.id,
           ts: input.ts,
@@ -802,11 +809,38 @@ function taskBudgetExhaustedEvent(input: {
   runId: string;
   roundId: string;
   expectedPromptHash: string;
+  expectedConfig: Config;
+  requireExecutionIdentity?: boolean;
+  expectedPricingProfile?: string;
   resumeFingerprint?: string;
   id: string;
   ts: number;
-}): FixedPromptTaskBudgetExhaustedEvent {
+}): FixedPromptTaskBudgetExhaustedEvent | FixedPromptTaskPlumbingFailedEvent {
   const artifactRefs = budgetExhaustedArtifactRefs(input.error);
+  if (artifactRefs.cellOutput) {
+    const output = { harbor: { reward: 0 }, cell: artifactRefs.cellOutput };
+    const plumbingFailure = classifyPlumbingFailure(
+      output,
+      input.expectedPromptHash,
+      input.expectedConfig,
+      input.requireExecutionIdentity ?? false,
+      input.expectedPricingProfile,
+    );
+    if (plumbingFailure) {
+      return taskPlumbingFailedEvent({
+        output,
+        expectedPromptHash: input.expectedPromptHash,
+        resumeFingerprint: input.resumeFingerprint,
+        taskId: input.taskId,
+        runId: input.runId,
+        roundId: input.roundId,
+        id: input.id,
+        ts: input.ts,
+        errorClass: plumbingFailure.errorClass,
+        error: plumbingFailure.error,
+      });
+    }
+  }
   return {
     schemaVersion: FIXED_PROMPT_WAL_SCHEMA_VERSION,
     type: 'task_budget_exhausted',
@@ -835,7 +869,7 @@ function taskBudgetExhaustedEvent(input: {
 function budgetExhaustedArtifactRefs(error: unknown): FixedPromptBudgetExhaustedArtifactRefs {
   if (isBudgetExhaustedError(error)) {
     const refs = (error as { artifactRefs?: FixedPromptBudgetExhaustedArtifactRefs }).artifactRefs;
-    if (refs && (refs.runtimeEventsPath || refs.traceEventsPath || refs.runtimeEventsUnavailableReason || refs.tokenSummary)) return refs;
+    if (refs && (refs.runtimeEventsPath || refs.traceEventsPath || refs.runtimeEventsUnavailableReason || refs.tokenSummary || refs.cellOutput)) return refs;
   }
   return { runtimeEventsUnavailableReason: BUDGET_EXHAUSTED_RUNTIME_UNAVAILABLE_REASON };
 }

--- a/packages/headless/src/harbor-cell.ts
+++ b/packages/headless/src/harbor-cell.ts
@@ -38,6 +38,7 @@ import {
 import { registerFakeBackend } from './backends.js';
 import {
   buildHarborCellOutput,
+  hashHarborSystemPrompt,
   validateHarborCellOutput,
   type HarborCellContextBudgetPolicySnapshot,
   type HarborCellOutput,
@@ -66,6 +67,7 @@ export interface RunHarborCellInput {
   cwd: string;
   outputDir: string;
   storageRoot: string;
+  pricingProfile?: string;
   registerBackends?: (
     registry: BackendRegistry,
     context: HeadlessBackendContext,
@@ -364,6 +366,7 @@ export async function runHarborCell(input: RunHarborCellInput): Promise<RunHarbo
     throw new Error('Harbor cell finished without a runtime invocation result');
   }
   const combinedInvocation = combineInvocations(invocations);
+  if (!config.model) throw new Error('Harbor cell config must include a model for execution identity');
   const continuationSummary = continuationPolicy.enabled
     ? buildContinuationSummary(continuationPolicy, invocations, stepCapHits)
     : undefined;
@@ -375,6 +378,12 @@ export async function runHarborCell(input: RunHarborCellInput): Promise<RunHarbo
   const output = validateHarborCellOutput(buildHarborCellOutput({
     invocation: combinedInvocation,
     runtimeEventsPath,
+    executionIdentity: {
+      llmConnectionSlug: config.llmConnectionSlug,
+      model: config.model,
+      systemPromptHash: hashHarborSystemPrompt(config.systemPrompt ?? ''),
+      pricingProfile: input.pricingProfile ?? 'unconfigured',
+    },
     ...(input.contextBudgetPolicy ? { contextBudgetPolicy: input.contextBudgetPolicy } : {}),
     ...(continuationSummary ? { continuationSummary } : {}),
     ...(input.taskToolSummaryEnabled !== undefined ? { taskToolSummaryEnabled: input.taskToolSummaryEnabled } : {}),
@@ -474,6 +483,7 @@ export async function runHarborCellFromEnv(
     cwd: resolvedEnv.MAKA_WORKDIR ?? process.cwd(),
     outputDir,
     storageRoot,
+    pricingProfile: resolvedEnv.MAKA_TRIAL_PRICING_SOURCE ?? 'unconfigured',
     ...(contextBudgetPolicy ? { contextBudgetPolicy } : {}),
     ...(continuationPolicy ? { continuationPolicy } : {}),
     ...(taskLedgerExperimentPolicy ? { taskToolSummaryEnabled: true } : {}),

--- a/packages/headless/src/harbor-task-runner.ts
+++ b/packages/headless/src/harbor-task-runner.ts
@@ -105,6 +105,18 @@ const PROVIDER_SECRET_ENV: Record<string, { key: string; file: string; baseUrl: 
   anthropic: { key: 'ANTHROPIC_API_KEY', file: 'ANTHROPIC_API_KEY_FILE', baseUrl: 'ANTHROPIC_BASE_URL' },
 };
 
+const EXPERIMENT_IDENTITY_ENV_KEYS = new Set([
+  'MAKA_BACKEND',
+  'MAKA_MODEL',
+  'MAKA_PROVIDER',
+  'MAKA_SYSTEM_PROMPT',
+  'MAKA_TRIAL_INPUT_USD_PER_1M',
+  'MAKA_TRIAL_OUTPUT_USD_PER_1M',
+  'MAKA_TRIAL_CACHE_READ_USD_PER_1M',
+  'MAKA_TRIAL_CACHE_WRITE_USD_PER_1M',
+  'MAKA_TRIAL_PRICING_SOURCE',
+]);
+
 export function createHarborTaskRunner(options: HarborTaskRunnerOptions): HarborTaskRunner {
   const runHarbor = options.runHarbor ?? defaultHarborProcessRunner;
   const harborBin = options.harborBin ?? 'harbor';
@@ -293,6 +305,7 @@ export function buildHarborJobConfig(
 ): Record<string, unknown> {
   const attemptAgentEnv = mergeAgentEnv(options.agentEnv, input.agentEnv);
   assertNoProviderSecretsInAgentEnv(attemptAgentEnv);
+  assertNoExperimentIdentityOverrides(attemptAgentEnv);
   const provider = options.provider ?? 'deepseek';
   const model = modelIdForProvider(options.model, provider);
   const mounts: Array<Record<string, unknown>> = [
@@ -395,6 +408,13 @@ function assertNoProviderSecretsInAgentEnv(agentEnv: Record<string, string> | un
   const forbidden = Object.keys(agentEnv ?? {}).filter((key) => /_API_KEY(_FILE)?$/.test(key));
   if (forbidden.length > 0) {
     throw new Error(`agentEnv must not contain provider secrets: ${forbidden.sort().join(', ')}`);
+  }
+}
+
+function assertNoExperimentIdentityOverrides(agentEnv: Record<string, string> | undefined): void {
+  const forbidden = Object.keys(agentEnv ?? {}).filter((key) => EXPERIMENT_IDENTITY_ENV_KEYS.has(key));
+  if (forbidden.length > 0) {
+    throw new Error(`agentEnv must not override experiment identity: ${forbidden.sort().join(', ')}`);
   }
 }
 

--- a/packages/headless/src/harbor-task-runner.ts
+++ b/packages/headless/src/harbor-task-runner.ts
@@ -174,9 +174,11 @@ export function createHarborTaskRunner(options: HarborTaskRunnerOptions): Harbor
       throw new HarborInfraError(`harbor run failed to launch for task ${input.task.id}`, errorText(error));
     }
     if (result.timedOut) {
+      const artifactRefs = await readTimedOutCellArtifacts(jobDir, basename(input.task.path), input.task.id);
       throw new FixedPromptBudgetExhaustedError(
         `harbor run timed out for task ${input.task.id}`,
         tail(result.stderr || result.stdout),
+        artifactRefs ?? undefined,
       );
     }
     if (result.exitCode !== 0) {
@@ -242,18 +244,30 @@ async function readOptionalCellOutput(cellOutputPath: string, taskId: string): P
 }
 
 function cellArtifactRefs(cell: HarborCellOutput, hostEventsPath: string, trialDir: string) {
+  const traceEventsPath = join(
+    trialDir,
+    TRIAL_TRACE_EVENTS_ROOT,
+    cell.runtimeRefs.sessionId,
+    'runs',
+    cell.runtimeRefs.runId,
+    'events.jsonl',
+  );
   return {
     runtimeEventsPath: hostEventsPath,
-    traceEventsPath: join(
-      trialDir,
-      TRIAL_TRACE_EVENTS_ROOT,
-      cell.runtimeRefs.sessionId,
-      'runs',
-      cell.runtimeRefs.runId,
-      'events.jsonl',
-    ),
+    traceEventsPath,
     tokenSummary: cell.tokenSummary,
+    cellOutput: { ...cell, runtimeEventsPath: hostEventsPath, traceEventsPath },
   };
+}
+
+async function readTimedOutCellArtifacts(jobDir: string, taskName: string, taskId: string) {
+  try {
+    const trialDir = await findTrialDir(jobDir, taskName);
+    const cell = await readOptionalCellOutput(join(trialDir, TRIAL_CELL_OUTPUT), taskId);
+    return cell ? cellArtifactRefs(cell, join(trialDir, TRIAL_RUNTIME_EVENTS), trialDir) : null;
+  } catch {
+    return null;
+  }
 }
 
 async function readOptionalText(path: string): Promise<string | null> {

--- a/packages/headless/src/harbor-task-runner.ts
+++ b/packages/headless/src/harbor-task-runner.ts
@@ -194,9 +194,11 @@ export function createHarborTaskRunner(options: HarborTaskRunnerOptions): Harbor
 
     const trialException = await readTrialException(resultPath);
     if (trialException && isBudgetExhaustedTrialException(trialException)) {
+      const cell = await readOptionalCellOutput(cellOutputPath, input.task.id);
       throw new FixedPromptBudgetExhaustedError(
         `agent budget exhausted for task ${input.task.id}`,
         trialException,
+        cell ? cellArtifactRefs(cell, hostEventsPath, trialDir) : undefined,
       );
     }
     const reward = await readReward(rewardPath, resultPath, input.task.id);
@@ -228,6 +230,29 @@ export function createHarborTaskRunner(options: HarborTaskRunnerOptions): Harbor
         ),
       },
     };
+  };
+}
+
+async function readOptionalCellOutput(cellOutputPath: string, taskId: string): Promise<HarborCellOutput | null> {
+  try {
+    return await readCellOutput(cellOutputPath, taskId);
+  } catch {
+    return null;
+  }
+}
+
+function cellArtifactRefs(cell: HarborCellOutput, hostEventsPath: string, trialDir: string) {
+  return {
+    runtimeEventsPath: hostEventsPath,
+    traceEventsPath: join(
+      trialDir,
+      TRIAL_TRACE_EVENTS_ROOT,
+      cell.runtimeRefs.sessionId,
+      'runs',
+      cell.runtimeRefs.runId,
+      'events.jsonl',
+    ),
+    tokenSummary: cell.tokenSummary,
   };
 }
 

--- a/packages/headless/src/prompt-optimization-replay-sweeps.ts
+++ b/packages/headless/src/prompt-optimization-replay-sweeps.ts
@@ -1,7 +1,5 @@
 import type {
   FixedPromptControllerResult,
-  FixedPromptTaskCompletedEvent,
-  FixedPromptTaskPlumbingFailedEvent,
   FixedPromptTaskWalEvent,
   FixedPromptWalEvent,
 } from './fixed-prompt-controller.js';
@@ -43,8 +41,8 @@ export function replayControllerSweep(input: {
   return {
     taskIds: [...input.taskIds],
     events: orderedEvents,
-    totalTokens: sum(orderedEvents.map((event) => eventHasRunArtifacts(event) ? event.tokenSummary.total : 0)),
-    totalCostUsd: sum(orderedEvents.map((event) => eventHasRunArtifacts(event) ? event.tokenSummary.costUsd : 0)),
+    totalTokens: sum(orderedEvents.map((event) => 'tokenSummary' in event ? event.tokenSummary?.total ?? 0 : 0)),
+    totalCostUsd: sum(orderedEvents.map((event) => 'tokenSummary' in event ? event.tokenSummary?.costUsd ?? 0 : 0)),
     resultsTsvPath: input.resultsTsvPath,
   };
 }
@@ -82,12 +80,6 @@ function mergeReplayedTaskEvent(
     return;
   }
   throw new Error(`RSI WAL replay duplicate task event for ${event.roundId}/${event.taskId}`);
-}
-
-function eventHasRunArtifacts(
-  event: FixedPromptTaskWalEvent,
-): event is FixedPromptTaskCompletedEvent | FixedPromptTaskPlumbingFailedEvent {
-  return event.type === 'task_completed' || event.type === 'task_plumbing_failed';
 }
 
 function sum(values: readonly number[]): number {

--- a/packages/headless/src/prompt-structural-smoke.ts
+++ b/packages/headless/src/prompt-structural-smoke.ts
@@ -70,7 +70,7 @@ export function promptStructuralSmokeReport(
     : [];
   const quarantineCount = decisionEvents.filter((event) => isQuarantineDecision(event)).length;
   const totalCostUsd = roundCost(sum(taskEvents.map((event) => (
-    event.type === 'task_completed' || event.type === 'task_plumbing_failed' ? event.tokenSummary.costUsd : 0
+    event.type === 'task_completed' || event.type === 'task_plumbing_failed' ? event.tokenSummary?.costUsd ?? 0 : 0
   ))));
   const failures: PromptStructuralSmokeFailure[] = [];
   if (observedRounds < minimumRounds) failures.push('minimum_rounds_not_met');

--- a/packages/headless/src/runtime-policy-ab-lifecycle.ts
+++ b/packages/headless/src/runtime-policy-ab-lifecycle.ts
@@ -61,9 +61,9 @@ export async function runRuntimePolicyAbLifecycle(
       return state;
     }
     const pilotCost = (state.pilot?.baseline.totalCostUsd ?? 0) + (state.pilot?.candidate.totalCostUsd ?? 0);
-    const remainingCostUsd = input.executionProfile.costCeilingUsd - pilotCost;
+    const remainingCostUsd = input.executionProfile.observedCostStopUsd - pilotCost;
     if (remainingCostUsd <= 0) {
-      state = { ...state, status: 'invalid', reason: 'cost_ceiling_reached_during_pilot' };
+      state = { ...state, status: 'invalid', reason: 'observed_cost_stop_reached_during_pilot' };
       await writeState(statePath, state);
       return state;
     }
@@ -72,7 +72,7 @@ export async function runRuntimePolicyAbLifecycle(
       evaluationTasks: input.evaluationTasks,
       reps: input.fullReps,
       roundIdPrefix: 'full',
-      executionProfile: { ...input.executionProfile, costCeilingUsd: remainingCostUsd },
+      executionProfile: { ...input.executionProfile, observedCostStopUsd: remainingCostUsd },
     });
     state = {
       ...state,

--- a/packages/headless/src/runtime-policy-ab-lifecycle.ts
+++ b/packages/headless/src/runtime-policy-ab-lifecycle.ts
@@ -70,10 +70,11 @@ export async function runRuntimePolicyAbLifecycle(
       roundIdPrefix: 'full',
       executionProfile: { ...input.executionProfile, observedCostStopUsd: remainingCostUsd },
     });
+    const invalidReason = full.stopReason ?? (full.decision === 'invalid' ? full.reason : undefined);
     state = {
       ...state,
-      status: full.stopReason ? 'invalid' : 'full_completed',
-      ...(full.stopReason ? { reason: full.stopReason } : {}),
+      status: invalidReason ? 'invalid' : 'full_completed',
+      ...(invalidReason ? { reason: invalidReason } : {}),
       full,
     };
     await writeState(statePath, state);

--- a/packages/headless/src/runtime-policy-ab-lifecycle.ts
+++ b/packages/headless/src/runtime-policy-ab-lifecycle.ts
@@ -38,11 +38,7 @@ export async function runRuntimePolicyAbLifecycle(
         reps: 1,
         roundIdPrefix: 'pilot',
       });
-      const pilot: RuntimePolicyAbComparisonSummary = {
-        ...pilotResult,
-        decision: 'diagnostic',
-        reason: 'single_rep_pilot_diagnostic',
-      };
+      const pilot: RuntimePolicyAbComparisonSummary = pilotResult;
       const clearanceFailure = pilotClearanceFailure(pilot);
       state = {
         schemaVersion: 'maka.runtime_policy_ab.lifecycle.v1',

--- a/packages/headless/src/runtime-policy-ab-lifecycle.ts
+++ b/packages/headless/src/runtime-policy-ab-lifecycle.ts
@@ -1,0 +1,122 @@
+import { readFile, rename, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { withAbRunLock } from './ab-run-lock.js';
+import {
+  runRuntimePolicyAbComparisonUnlocked,
+  type RunRuntimePolicyAbComparisonInput,
+  type RuntimePolicyAbComparisonSummary,
+} from './runtime-policy-ab-run.js';
+
+export interface RunRuntimePolicyAbLifecycleInput extends Omit<RunRuntimePolicyAbComparisonInput, 'evaluationTasks' | 'reps' | 'roundIdPrefix'> {
+  manifestFingerprint: string;
+  pilotTasks: RunRuntimePolicyAbComparisonInput['evaluationTasks'];
+  evaluationTasks: RunRuntimePolicyAbComparisonInput['evaluationTasks'];
+  fullReps: number;
+}
+
+export interface RuntimePolicyAbLifecycleState {
+  schemaVersion: 'maka.runtime_policy_ab.lifecycle.v1';
+  manifestFingerprint: string;
+  status: 'pilot_pending' | 'pilot_not_cleared' | 'pilot_cleared' | 'full_completed' | 'invalid';
+  reason?: string;
+  pilot?: RuntimePolicyAbComparisonSummary;
+  full?: RuntimePolicyAbComparisonSummary;
+}
+
+export async function runRuntimePolicyAbLifecycle(
+  input: RunRuntimePolicyAbLifecycleInput,
+): Promise<RuntimePolicyAbLifecycleState> {
+  return withAbRunLock(input.runRoot, async () => {
+    const statePath = join(input.runRoot, 'runtime-policy-ab-state.json');
+    let state = await readState(statePath, input.manifestFingerprint);
+    if (state.status === 'full_completed' || state.status === 'invalid' || state.status === 'pilot_not_cleared') return state;
+
+    if (state.status === 'pilot_pending') {
+      const pilotResult = await runRuntimePolicyAbComparisonUnlocked({
+        ...input,
+        evaluationTasks: input.pilotTasks,
+        reps: 1,
+        roundIdPrefix: 'pilot',
+      });
+      const pilot: RuntimePolicyAbComparisonSummary = {
+        ...pilotResult,
+        decision: 'diagnostic',
+        reason: 'single_rep_pilot_diagnostic',
+      };
+      const clearanceFailure = pilotClearanceFailure(pilot);
+      state = {
+        schemaVersion: 'maka.runtime_policy_ab.lifecycle.v1',
+        manifestFingerprint: input.manifestFingerprint,
+        status: clearanceFailure ? 'pilot_not_cleared' : 'pilot_cleared',
+        ...(clearanceFailure ? { reason: clearanceFailure } : {}),
+        pilot,
+      };
+      await writeState(statePath, state);
+      if (clearanceFailure) return state;
+    }
+
+    if (input.fullReps < 2 || !Number.isSafeInteger(input.fullReps)) {
+      state = { ...state, status: 'invalid', reason: 'full_reps_must_be_at_least_2' };
+      await writeState(statePath, state);
+      return state;
+    }
+    const pilotCost = (state.pilot?.baseline.totalCostUsd ?? 0) + (state.pilot?.candidate.totalCostUsd ?? 0);
+    const remainingCostUsd = input.executionProfile.costCeilingUsd - pilotCost;
+    if (remainingCostUsd <= 0) {
+      state = { ...state, status: 'invalid', reason: 'cost_ceiling_reached_during_pilot' };
+      await writeState(statePath, state);
+      return state;
+    }
+    const full = await runRuntimePolicyAbComparisonUnlocked({
+      ...input,
+      evaluationTasks: input.evaluationTasks,
+      reps: input.fullReps,
+      roundIdPrefix: 'full',
+      executionProfile: { ...input.executionProfile, costCeilingUsd: remainingCostUsd },
+    });
+    state = {
+      ...state,
+      status: full.stopReason ? 'invalid' : 'full_completed',
+      ...(full.stopReason ? { reason: full.stopReason } : {}),
+      full,
+    };
+    await writeState(statePath, state);
+    return state;
+  });
+}
+
+function pilotClearanceFailure(summary: RuntimePolicyAbComparisonSummary): string | undefined {
+  if (summary.stopReason) return summary.stopReason;
+  if (summary.pairedAttempts.budgetDiscordantPairIds.length > 0) return 'pilot_asymmetric_budget_exhaustion';
+  if (summary.baseline.coverageRate !== 1 || summary.candidate.coverageRate !== 1) return 'pilot_incomplete';
+  if (summary.baseline.infraFailed + summary.candidate.infraFailed > 0) return 'pilot_infra_failure';
+  if (summary.baseline.plumbingFailed + summary.candidate.plumbingFailed > 0) return 'pilot_plumbing_failure';
+  if ((summary.candidate.contextBudget?.activatedAttempts ?? 0) === 0) return 'pilot_candidate_not_activated';
+  return undefined;
+}
+
+async function readState(path: string, manifestFingerprint: string): Promise<RuntimePolicyAbLifecycleState> {
+  try {
+    const state = JSON.parse(await readFile(path, 'utf8')) as RuntimePolicyAbLifecycleState;
+    if (state.schemaVersion !== 'maka.runtime_policy_ab.lifecycle.v1') throw new Error('unsupported runtime policy A/B lifecycle state');
+    if (state.manifestFingerprint !== manifestFingerprint) throw new Error('runtime policy A/B lifecycle state does not match manifest');
+    return state;
+  } catch (error) {
+    if (!isNotFound(error)) throw error;
+    return {
+      schemaVersion: 'maka.runtime_policy_ab.lifecycle.v1',
+      manifestFingerprint,
+      status: 'pilot_pending',
+    };
+  }
+}
+
+async function writeState(path: string, state: RuntimePolicyAbLifecycleState): Promise<void> {
+  const temporaryPath = `${path}.tmp-${process.pid}`;
+  await writeFile(temporaryPath, `${JSON.stringify(state, null, 2)}\n`, 'utf8');
+  await rename(temporaryPath, path);
+}
+
+function isNotFound(error: unknown): boolean {
+  return typeof error === 'object' && error !== null && 'code' in error && (error as { code?: unknown }).code === 'ENOENT';
+}

--- a/packages/headless/src/runtime-policy-ab-profile.ts
+++ b/packages/headless/src/runtime-policy-ab-profile.ts
@@ -1,0 +1,47 @@
+import type { HarborTaskPricing } from './harbor-task-runner.js';
+
+export interface RuntimePolicyAbExecutionProfile {
+  schemaVersion: 1;
+  id: string;
+  llmConnectionSlug: string;
+  provider: string;
+  baseUrl: string;
+  model: string;
+  pricing: HarborTaskPricing & { source: string };
+  taskBudgetSec: number;
+  harborTimeoutMs: number;
+  costCeilingUsd: number;
+  maxConcurrentAttempts: number;
+}
+
+export function parseRuntimePolicyAbExecutionProfile(value: unknown): RuntimePolicyAbExecutionProfile {
+  if (!isRecord(value) || value.schemaVersion !== 1) throw new Error('runtime policy A/B execution profile schemaVersion must be 1');
+  for (const key of ['id', 'llmConnectionSlug', 'provider', 'baseUrl', 'model'] as const) {
+    if (typeof value[key] !== 'string' || value[key].trim().length === 0) throw new Error(`runtime policy A/B execution profile ${key} must be a non-empty string`);
+  }
+  if (!String(value.model).startsWith(`${String(value.provider)}/`)) {
+    throw new Error('runtime policy A/B execution profile model must be qualified by its provider');
+  }
+  if (!isRecord(value.pricing) || typeof value.pricing.source !== 'string' || value.pricing.source.length === 0) {
+    throw new Error('runtime policy A/B execution profile pricing.source must be a non-empty string');
+  }
+  if (value.pricing.source !== value.id) throw new Error('runtime policy A/B execution profile pricing.source must equal profile id');
+  for (const key of ['inputUsdPer1M', 'outputUsdPer1M', 'cacheReadUsdPer1M', 'cacheWriteUsdPer1M'] as const) {
+    const rate = value.pricing[key];
+    if (typeof rate !== 'number' || !Number.isFinite(rate) || rate < 0) throw new Error(`runtime policy A/B execution profile pricing.${key} must be a finite non-negative number`);
+  }
+  for (const key of ['taskBudgetSec', 'harborTimeoutMs'] as const) {
+    if (!Number.isSafeInteger(value[key]) || Number(value[key]) <= 0) throw new Error(`runtime policy A/B execution profile ${key} must be a positive integer`);
+  }
+  if (typeof value.costCeilingUsd !== 'number' || !Number.isFinite(value.costCeilingUsd) || value.costCeilingUsd <= 0) {
+    throw new Error('runtime policy A/B execution profile costCeilingUsd must be a finite positive number');
+  }
+  if (!Number.isSafeInteger(value.maxConcurrentAttempts) || Number(value.maxConcurrentAttempts) < 2 || Number(value.maxConcurrentAttempts) % 2 !== 0) {
+    throw new Error('runtime policy A/B execution profile maxConcurrentAttempts must be an even integer of at least 2');
+  }
+  return value as unknown as RuntimePolicyAbExecutionProfile;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}

--- a/packages/headless/src/runtime-policy-ab-profile.ts
+++ b/packages/headless/src/runtime-policy-ab-profile.ts
@@ -10,7 +10,7 @@ export interface RuntimePolicyAbExecutionProfile {
   pricing: HarborTaskPricing & { source: string };
   taskBudgetSec: number;
   harborTimeoutMs: number;
-  costCeilingUsd: number;
+  observedCostStopUsd: number;
   maxConcurrentAttempts: number;
 }
 
@@ -33,8 +33,8 @@ export function parseRuntimePolicyAbExecutionProfile(value: unknown): RuntimePol
   for (const key of ['taskBudgetSec', 'harborTimeoutMs'] as const) {
     if (!Number.isSafeInteger(value[key]) || Number(value[key]) <= 0) throw new Error(`runtime policy A/B execution profile ${key} must be a positive integer`);
   }
-  if (typeof value.costCeilingUsd !== 'number' || !Number.isFinite(value.costCeilingUsd) || value.costCeilingUsd <= 0) {
-    throw new Error('runtime policy A/B execution profile costCeilingUsd must be a finite positive number');
+  if (typeof value.observedCostStopUsd !== 'number' || !Number.isFinite(value.observedCostStopUsd) || value.observedCostStopUsd <= 0) {
+    throw new Error('runtime policy A/B execution profile observedCostStopUsd must be a finite positive number');
   }
   if (!Number.isSafeInteger(value.maxConcurrentAttempts) || Number(value.maxConcurrentAttempts) < 2 || Number(value.maxConcurrentAttempts) % 2 !== 0) {
     throw new Error('runtime policy A/B execution profile maxConcurrentAttempts must be an even integer of at least 2');

--- a/packages/headless/src/runtime-policy-ab-run.ts
+++ b/packages/headless/src/runtime-policy-ab-run.ts
@@ -10,6 +10,7 @@ import { runAbComparison } from './ab-run.js';
 import type { AbArmSpec, AbComparisonSummary, AbRunManifest, AbRunManifestInput } from './ab-types.js';
 import type { Config } from './contracts.js';
 import { withAbRunLock } from './ab-run-lock.js';
+import type { RuntimePolicyAbExecutionProfile } from './runtime-policy-ab-profile.js';
 import {
   HARBOR_CELL_CONTEXT_ENV_KEYS,
   normalizeHarborCellContextEnv,
@@ -41,8 +42,8 @@ export interface RunRuntimePolicyAbComparisonInput {
   evaluationTasks: readonly FixedPromptTask[];
   arms: readonly [RuntimePolicyAbArmInput, RuntimePolicyAbArmInput];
   reps?: number;
-  maxConcurrentAttempts: number;
-  costCeilingUsd: number;
+  executionProfile: RuntimePolicyAbExecutionProfile;
+  roundIdPrefix?: string;
   resumeFingerprint?: string;
   budgetMs?: number;
   nonInferiorityMargin?: number;
@@ -54,28 +55,34 @@ export interface RunRuntimePolicyAbComparisonInput {
 
 export type RuntimePolicyAbComparisonSummary = AbComparisonSummary;
 
-export interface RuntimePolicyAbRunManifestInput extends Omit<AbRunManifestInput, 'experimentKind' | 'arms' | 'maxConcurrency' | 'maxConcurrentAttempts'> {
+export interface RuntimePolicyAbRunManifestInput extends Omit<AbRunManifestInput, 'experimentKind' | 'arms' | 'taskBudgetSec' | 'harborTimeoutMs' | 'costCeilingUsd' | 'maxConcurrency' | 'maxConcurrentAttempts'> {
   arms: readonly [RuntimePolicyAbArmInput, RuntimePolicyAbArmInput];
   promptHash: string;
-  provider: string;
-  baseUrl: string;
-  model: string;
   sharedAgentEnv?: Partial<Record<RuntimePolicySharedAgentEnvKey, string>>;
-  costCeilingUsd: number;
-  maxConcurrentAttempts: number;
+  executionProfile: RuntimePolicyAbExecutionProfile;
 }
 
 export type RuntimePolicyAbRunManifest = AbRunManifest;
 
 export function buildRuntimePolicyAbRunManifest(input: RuntimePolicyAbRunManifestInput): RuntimePolicyAbRunManifest {
-  const { arms, promptHash, provider, baseUrl, model, sharedAgentEnv: rawSharedAgentEnv, ...abInput } = input;
-  const maxConcurrency = pairConcurrency(input.maxConcurrentAttempts);
+  const { arms, promptHash, executionProfile, sharedAgentEnv: rawSharedAgentEnv, ...abInput } = input;
+  const maxConcurrency = pairConcurrency(executionProfile.maxConcurrentAttempts);
   const sharedAgentEnv = sanitizeSharedAgentEnv(rawSharedAgentEnv ?? {});
-  const sharedMetadata = { promptHash, provider, baseUrl, model, sharedAgentEnv };
+  const sharedMetadata = {
+    promptHash,
+    provider: executionProfile.provider,
+    baseUrl: executionProfile.baseUrl,
+    model: executionProfile.model,
+    executionProfile,
+    sharedAgentEnv,
+  };
   return buildAbRunManifest({
     ...abInput,
+    taskBudgetSec: executionProfile.taskBudgetSec,
+    harborTimeoutMs: executionProfile.harborTimeoutMs,
+    costCeilingUsd: executionProfile.costCeilingUsd,
     maxConcurrency,
-    maxConcurrentAttempts: input.maxConcurrentAttempts,
+    maxConcurrentAttempts: executionProfile.maxConcurrentAttempts,
     experimentKind: 'runtime',
     arms: [
       runtimeArmSpec(arms[0], sharedMetadata),
@@ -90,10 +97,11 @@ export async function runRuntimePolicyAbComparison(
   return withAbRunLock(input.runRoot, () => runRuntimePolicyAbComparisonUnlocked(input));
 }
 
-async function runRuntimePolicyAbComparisonUnlocked(
+export async function runRuntimePolicyAbComparisonUnlocked(
   input: RunRuntimePolicyAbComparisonInput,
 ): Promise<RuntimePolicyAbComparisonSummary> {
-  const maxConcurrency = pairConcurrency(input.maxConcurrentAttempts);
+  assertProfileIdentity(input.executionProfile, input.config);
+  const maxConcurrency = pairConcurrency(input.executionProfile.maxConcurrentAttempts);
   const sharedConfigFingerprint = runtimePolicySharedConfigFingerprint(input.config);
   const sharedAgentEnv = sanitizeSharedAgentEnv(input.sharedAgentEnv ?? {});
   return runAbComparison({
@@ -102,7 +110,8 @@ async function runRuntimePolicyAbComparisonUnlocked(
     evaluationTasks: input.evaluationTasks,
     ...(input.reps !== undefined ? { reps: input.reps } : {}),
     maxConcurrency,
-    costCeilingUsd: input.costCeilingUsd,
+    costCeilingUsd: input.executionProfile.costCeilingUsd,
+    ...(input.roundIdPrefix ? { roundIdPrefix: input.roundIdPrefix } : {}),
     ...(input.budgetMs !== undefined ? { budgetMs: input.budgetMs } : {}),
     ...(input.nonInferiorityMargin !== undefined ? { nonInferiorityMargin: input.nonInferiorityMargin } : {}),
     runArm: async ({ roundId, arm, task }) => {
@@ -124,6 +133,8 @@ async function runRuntimePolicyAbComparisonUnlocked(
         resultsJsonlPath: input.resultsJsonlPath,
         resultsTsvPath: `${input.resultsJsonlPath}.${roundId}.tsv`,
         tasks: [task],
+        requireExecutionIdentity: true,
+        expectedPricingProfile: input.executionProfile.id,
         resumeFingerprint,
         harborRunner: (runnerInput) => input.harborRunner({ ...runnerInput, agentEnv }),
         ...(input.now ? { now: input.now } : {}),
@@ -141,6 +152,12 @@ function pairConcurrency(maxConcurrentAttempts: number): number {
     throw new Error('maxConcurrentAttempts must be an even integer of at least 2 so each A/B pair starts together');
   }
   return maxConcurrentAttempts / 2;
+}
+
+function assertProfileIdentity(profile: RuntimePolicyAbExecutionProfile, config: Pick<Config, 'llmConnectionSlug' | 'model'>): void {
+  if (config.llmConnectionSlug !== profile.llmConnectionSlug || config.model !== profile.model) {
+    throw new Error(`runtime policy A/B config must match execution profile ${profile.id}`);
+  }
 }
 
 export function renderRuntimePolicyAbComparisonMarkdown(summary: RuntimePolicyAbComparisonSummary): string {

--- a/packages/headless/src/runtime-policy-ab-run.ts
+++ b/packages/headless/src/runtime-policy-ab-run.ts
@@ -9,6 +9,7 @@ import { buildAbRunManifest } from './ab-manifest.js';
 import { runAbComparison } from './ab-run.js';
 import type { AbArmSpec, AbComparisonSummary, AbRunManifest, AbRunManifestInput } from './ab-types.js';
 import type { Config } from './contracts.js';
+import { withAbRunLock } from './ab-run-lock.js';
 import {
   HARBOR_CELL_CONTEXT_ENV_KEYS,
   normalizeHarborCellContextEnv,
@@ -33,13 +34,15 @@ export interface RuntimePolicyAbArmInput {
 
 export interface RunRuntimePolicyAbComparisonInput {
   runId: string;
+  runRoot: string;
   config: Config;
   systemPromptPath: string;
   resultsJsonlPath: string;
   evaluationTasks: readonly FixedPromptTask[];
   arms: readonly [RuntimePolicyAbArmInput, RuntimePolicyAbArmInput];
   reps?: number;
-  maxConcurrency?: number;
+  maxConcurrentAttempts: number;
+  costCeilingUsd: number;
   resumeFingerprint?: string;
   budgetMs?: number;
   nonInferiorityMargin?: number;
@@ -51,23 +54,28 @@ export interface RunRuntimePolicyAbComparisonInput {
 
 export type RuntimePolicyAbComparisonSummary = AbComparisonSummary;
 
-export interface RuntimePolicyAbRunManifestInput extends Omit<AbRunManifestInput, 'experimentKind' | 'arms'> {
+export interface RuntimePolicyAbRunManifestInput extends Omit<AbRunManifestInput, 'experimentKind' | 'arms' | 'maxConcurrency' | 'maxConcurrentAttempts'> {
   arms: readonly [RuntimePolicyAbArmInput, RuntimePolicyAbArmInput];
   promptHash: string;
   provider: string;
   baseUrl: string;
   model: string;
   sharedAgentEnv?: Partial<Record<RuntimePolicySharedAgentEnvKey, string>>;
+  costCeilingUsd: number;
+  maxConcurrentAttempts: number;
 }
 
 export type RuntimePolicyAbRunManifest = AbRunManifest;
 
 export function buildRuntimePolicyAbRunManifest(input: RuntimePolicyAbRunManifestInput): RuntimePolicyAbRunManifest {
   const { arms, promptHash, provider, baseUrl, model, sharedAgentEnv: rawSharedAgentEnv, ...abInput } = input;
+  const maxConcurrency = pairConcurrency(input.maxConcurrentAttempts);
   const sharedAgentEnv = sanitizeSharedAgentEnv(rawSharedAgentEnv ?? {});
   const sharedMetadata = { promptHash, provider, baseUrl, model, sharedAgentEnv };
   return buildAbRunManifest({
     ...abInput,
+    maxConcurrency,
+    maxConcurrentAttempts: input.maxConcurrentAttempts,
     experimentKind: 'runtime',
     arms: [
       runtimeArmSpec(arms[0], sharedMetadata),
@@ -79,6 +87,13 @@ export function buildRuntimePolicyAbRunManifest(input: RuntimePolicyAbRunManifes
 export async function runRuntimePolicyAbComparison(
   input: RunRuntimePolicyAbComparisonInput,
 ): Promise<RuntimePolicyAbComparisonSummary> {
+  return withAbRunLock(input.runRoot, () => runRuntimePolicyAbComparisonUnlocked(input));
+}
+
+async function runRuntimePolicyAbComparisonUnlocked(
+  input: RunRuntimePolicyAbComparisonInput,
+): Promise<RuntimePolicyAbComparisonSummary> {
+  const maxConcurrency = pairConcurrency(input.maxConcurrentAttempts);
   const sharedConfigFingerprint = runtimePolicySharedConfigFingerprint(input.config);
   const sharedAgentEnv = sanitizeSharedAgentEnv(input.sharedAgentEnv ?? {});
   return runAbComparison({
@@ -86,7 +101,8 @@ export async function runRuntimePolicyAbComparison(
     arms: [runtimeArmSpec(input.arms[0]), runtimeArmSpec(input.arms[1])],
     evaluationTasks: input.evaluationTasks,
     ...(input.reps !== undefined ? { reps: input.reps } : {}),
-    ...(input.maxConcurrency !== undefined ? { maxConcurrency: input.maxConcurrency } : {}),
+    maxConcurrency,
+    costCeilingUsd: input.costCeilingUsd,
     ...(input.budgetMs !== undefined ? { budgetMs: input.budgetMs } : {}),
     ...(input.nonInferiorityMargin !== undefined ? { nonInferiorityMargin: input.nonInferiorityMargin } : {}),
     runArm: async ({ roundId, arm, task }) => {
@@ -118,6 +134,13 @@ export async function runRuntimePolicyAbComparison(
       return event;
     },
   });
+}
+
+function pairConcurrency(maxConcurrentAttempts: number): number {
+  if (!Number.isSafeInteger(maxConcurrentAttempts) || maxConcurrentAttempts < 2 || maxConcurrentAttempts % 2 !== 0) {
+    throw new Error('maxConcurrentAttempts must be an even integer of at least 2 so each A/B pair starts together');
+  }
+  return maxConcurrentAttempts / 2;
 }
 
 export function renderRuntimePolicyAbComparisonMarkdown(summary: RuntimePolicyAbComparisonSummary): string {

--- a/packages/headless/src/runtime-policy-ab-run.ts
+++ b/packages/headless/src/runtime-policy-ab-run.ts
@@ -55,7 +55,7 @@ export interface RunRuntimePolicyAbComparisonInput {
 
 export type RuntimePolicyAbComparisonSummary = AbComparisonSummary;
 
-export interface RuntimePolicyAbRunManifestInput extends Omit<AbRunManifestInput, 'experimentKind' | 'arms' | 'taskBudgetSec' | 'harborTimeoutMs' | 'costCeilingUsd' | 'maxConcurrency' | 'maxConcurrentAttempts'> {
+export interface RuntimePolicyAbRunManifestInput extends Omit<AbRunManifestInput, 'experimentKind' | 'arms' | 'taskBudgetSec' | 'harborTimeoutMs' | 'observedCostStopUsd' | 'maxConcurrency' | 'maxConcurrentAttempts'> {
   arms: readonly [RuntimePolicyAbArmInput, RuntimePolicyAbArmInput];
   promptHash: string;
   sharedAgentEnv?: Partial<Record<RuntimePolicySharedAgentEnvKey, string>>;
@@ -80,7 +80,7 @@ export function buildRuntimePolicyAbRunManifest(input: RuntimePolicyAbRunManifes
     ...abInput,
     taskBudgetSec: executionProfile.taskBudgetSec,
     harborTimeoutMs: executionProfile.harborTimeoutMs,
-    costCeilingUsd: executionProfile.costCeilingUsd,
+    observedCostStopUsd: executionProfile.observedCostStopUsd,
     maxConcurrency,
     maxConcurrentAttempts: executionProfile.maxConcurrentAttempts,
     experimentKind: 'runtime',
@@ -110,7 +110,7 @@ export async function runRuntimePolicyAbComparisonUnlocked(
     evaluationTasks: input.evaluationTasks,
     ...(input.reps !== undefined ? { reps: input.reps } : {}),
     maxConcurrency,
-    costCeilingUsd: input.executionProfile.costCeilingUsd,
+    observedCostStopUsd: input.executionProfile.observedCostStopUsd,
     ...(input.roundIdPrefix ? { roundIdPrefix: input.roundIdPrefix } : {}),
     ...(input.budgetMs !== undefined ? { budgetMs: input.budgetMs } : {}),
     ...(input.nonInferiorityMargin !== undefined ? { nonInferiorityMargin: input.nonInferiorityMargin } : {}),

--- a/packages/headless/src/runtime-policy-ab-spec.ts
+++ b/packages/headless/src/runtime-policy-ab-spec.ts
@@ -1,0 +1,63 @@
+import {
+  RUNTIME_POLICY_CONTEXT_ENV_KEYS,
+  RUNTIME_POLICY_SHARED_AGENT_ENV_KEYS,
+  type RuntimePolicyAbArmInput,
+  type RuntimePolicySharedAgentEnvKey,
+} from './runtime-policy-ab-run.js';
+
+export interface RuntimePolicyAbSpec {
+  schemaVersion: 1;
+  id: string;
+  arms: readonly [RuntimePolicyAbArmInput, RuntimePolicyAbArmInput];
+  sharedAgentEnv: Partial<Record<RuntimePolicySharedAgentEnvKey, string>>;
+  pilotTaskIds: readonly string[];
+  evaluationTaskIds: readonly string[];
+  fullReps: number;
+  nonInferiorityMargin: number;
+}
+
+export function parseRuntimePolicyAbSpec(value: unknown): RuntimePolicyAbSpec {
+  if (!isRecord(value) || value.schemaVersion !== 1) throw new Error('runtime policy A/B spec schemaVersion must be 1');
+  nonEmptyString(value.id, 'runtime policy A/B spec id');
+  if (!Array.isArray(value.arms) || value.arms.length !== 2) throw new Error('runtime policy A/B spec must define exactly two arms');
+  const arms = value.arms.map((arm, index) => parseArm(arm, index));
+  if (arms[0]!.id === arms[1]!.id) throw new Error('runtime policy A/B spec arm ids must be distinct');
+  stringEnv(value.sharedAgentEnv, new Set(RUNTIME_POLICY_SHARED_AGENT_ENV_KEYS), 'runtime policy A/B spec sharedAgentEnv');
+  stringIds(value.pilotTaskIds, 'runtime policy A/B spec pilotTaskIds');
+  stringIds(value.evaluationTaskIds, 'runtime policy A/B spec evaluationTaskIds');
+  if (!Number.isSafeInteger(value.fullReps) || Number(value.fullReps) < 2) throw new Error('runtime policy A/B spec fullReps must be an integer of at least 2');
+  if (typeof value.nonInferiorityMargin !== 'number' || value.nonInferiorityMargin < 0 || value.nonInferiorityMargin > 1) {
+    throw new Error('runtime policy A/B spec nonInferiorityMargin must be a number in [0, 1]');
+  }
+  return value as unknown as RuntimePolicyAbSpec;
+}
+
+function parseArm(value: unknown, index: number): RuntimePolicyAbArmInput {
+  if (!isRecord(value)) throw new Error(`runtime policy A/B spec arm ${index} must be an object`);
+  nonEmptyString(value.id, `runtime policy A/B spec arm ${index} id`);
+  stringEnv(value.contextEnv, new Set(RUNTIME_POLICY_CONTEXT_ENV_KEYS), `runtime policy A/B spec arm ${index} contextEnv`);
+  return value as unknown as RuntimePolicyAbArmInput;
+}
+
+function stringEnv(value: unknown, allowed: ReadonlySet<string>, label: string): void {
+  if (!isRecord(value)) throw new Error(`${label} must be an object`);
+  for (const [key, entryValue] of Object.entries(value)) {
+    if (!allowed.has(key)) throw new Error(`${label} contains unsupported key: ${key}`);
+    if (typeof entryValue !== 'string') throw new Error(`${label} values must be strings`);
+  }
+}
+
+function stringIds(value: unknown, label: string): void {
+  if (!Array.isArray(value) || value.length === 0 || value.some((entry) => typeof entry !== 'string' || entry.length === 0)) {
+    throw new Error(`${label} must be a non-empty string array`);
+  }
+  if (new Set(value).size !== value.length) throw new Error(`${label} must not contain duplicates`);
+}
+
+function nonEmptyString(value: unknown, label: string): asserts value is string {
+  if (typeof value !== 'string' || value.trim().length === 0) throw new Error(`${label} must be a non-empty string`);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}

--- a/packages/runtime/src/__tests__/model-adapter.test.ts
+++ b/packages/runtime/src/__tests__/model-adapter.test.ts
@@ -171,6 +171,9 @@ describe('ModelAdapter stream and error normalization', () => {
     const adapter = newAdapter();
 
     assert.equal(adapter.classifyError(Object.assign(new Error('401 Authorization'), { code: 401 })), 'Auth');
+    const billingError = Object.assign(new Error('provider request failed'), { statusCode: 402 });
+    assert.equal(adapter.classifyError(billingError), 'ProviderBilling');
+    assert.equal(adapter.makeErrorEvent('turn-1', billingError).reason, 'provider_billing');
     assert.equal(adapter.makeErrorEvent('turn-1', new Error('Model stream idle timeout after 120000ms')).reason, 'timeout');
     assert.equal(adapter.mapFinishReason('stop'), 'end_turn');
     assert.equal(adapter.mapFinishReason('length'), 'max_tokens');

--- a/packages/runtime/src/tool-runtime.ts
+++ b/packages/runtime/src/tool-runtime.ts
@@ -759,10 +759,17 @@ export function formatSyntheticToolErrorText(error: unknown): string {
 export function classifyError(error: unknown): string {
   if (!(error instanceof Error)) return 'Other';
   const code = 'code' in error ? String((error as { code?: unknown }).code) : '';
-  const text = `${error.name} ${code} ${error.message}`.toLowerCase();
+  const statusCode = 'statusCode' in error
+    ? String((error as { statusCode?: unknown }).statusCode)
+    : 'status' in error
+      ? String((error as { status?: unknown }).status)
+      : '';
+  const text = `${error.name} ${code} ${statusCode} ${error.message}`.toLowerCase();
   if (text.includes('abort')) return 'Abort';
-  if (text.includes('rate') || code === '429') return 'RateLimit';
-  if (text.includes('auth') || code === '401' || code === '403') return 'Auth';
+  if (statusCode === '402' || code === '402') return 'ProviderBilling';
+  if (text.includes('rate') || statusCode === '429' || code === '429') return 'RateLimit';
+  if (text.includes('auth') || statusCode === '401' || statusCode === '403' || code === '401' || code === '403') return 'Auth';
+  if (/^5\d\d$/.test(statusCode) || /^5\d\d$/.test(code)) return 'ProviderUnavailable';
   if (text.includes('timeout')) return 'Timeout';
   if (text.includes('network') || text.includes('fetch')) return 'Network';
   return error.name || 'Other';
@@ -774,6 +781,10 @@ export function errorReasonFromClass(errorClass: string): string | undefined {
       return 'timeout';
     case 'Auth':
       return 'auth';
+    case 'ProviderBilling':
+      return 'provider_billing';
+    case 'ProviderUnavailable':
+      return 'provider_unavailable';
     case 'RateLimit':
       return 'rate_limit';
     case 'Network':


### PR DESCRIPTION
## Summary

Make runtime-policy A/B experiments fail closed when the intended execution identity, observed artifacts, or statistical evidence cannot be verified.

This adds one executable DeepSeek Flash profile, an atomic manifest, a resumable pilot-to-full lifecycle, and validity gates shared by the existing headless A/B harness.

## Why

The previous workflow could produce misleading comparisons when the executed model differed from the intended model, provider billing failed, timed-out attempts omitted cost, concurrent processes reused one run, or single-rep and budget-discordant evidence reached formal inference.

The experiment contract now enforces:

`intended configuration == executed identity == analyzed evidence`

## Scope

Changed:

- Require and attest connection, model, prompt hash, and pricing profile.
- Pin the canonical runtime A/B profile to `deepseek/deepseek-v4-flash`.
- Reject experiment identity overrides from per-attempt environment variables.
- Classify provider billing/auth failures as unscored infrastructure failures and stop scheduling new pairs.
- Recover token cost and execution identity from timed-out cell artifacts.
- Fail closed when an attested timeout has no cell output.
- Create manifests atomically and lock active runs.
- Expose actual attempt concurrency instead of ambiguous pair concurrency.
- Add an honest post-observation spend guard, with one pair maximum in flight.
- Require a same-run pilot checkpoint and observed candidate activation before full execution.
- Keep single-rep comparisons diagnostic.
- Invalidate infrastructure, plumbing, identity, and asymmetric timeout evidence.
- Use paired wins/losses with simultaneous Bonferroni-Wilson score bounds for formal non-inferiority.
- Persist resumable lifecycle state and surface invalid full runs explicitly.

Not included:

- No Harbor adapter fork.
- No database or parallel benchmark harness.
- No paid benchmark run.
- No stale-tool-prune product behavior changes.

## Verification

- `npm run -w @maka/headless test`
  - 764 tests passed
- `npm run typecheck`
  - all workspaces passed
- Runtime A/B CLI dry-run
  - executable manifest validated without reading a provider key
- Independent read-only review
  - no remaining P0-P2 findings
  - first-principles review passed
  - Occam's razor review passed

## User-facing impact

No desktop UI change, migration, or changelog entry.

Runtime-policy benchmark operators must now provide a validated execution profile and a spec containing pilot tasks, full evaluation tasks, and at least two full repetitions.

`costCeilingUsd` was intentionally replaced by `observedCostStopUsd`: the provider cannot guarantee an exact dollar cutoff for an already in-flight request, so the contract now states the enforceable behavior instead of claiming a hard ceiling.

## Reviewer notes

Review the validity chain in this order:

1. manifest and execution profile
2. cell execution attestation
3. timeout/provider failure classification
4. pilot checkpoint and resume state
5. paired decision boundary

The PR is intentionally one rollback unit because these gates only close the validity chain when shipped together.

## Checklist

- [x] Scope matches the PR title and excludes unrelated changes
- [x] Verification lists commands and results
- [x] User-facing impact and breaking operator contract are noted
- [x] Risk and review focus are called out
- [x] UI screenshots are not applicable