### PR TITLE
fix(chat): widen assistant prose to match composer width

### DIFF
--- a/apps/desktop/src/main/__tests__/markdown-prose-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/markdown-prose-contract.test.ts
@@ -13,7 +13,7 @@
  *    The shell keeps only container geometry (padding); element typography
  *    (margins, font-size, list style, link/border, code padding,
  *    blockquote/table chrome) and the load-bearing base typography
- *    (color / line-height / break-word / 72ch cap / edge trims — #618
+ *    (color / line-height / break-word / edge trims — #618
  *    item 2, locked by PROSE-SELF-CONTAINED in the polish contract below)
  *    live on .maka-prose.
  *
@@ -275,7 +275,8 @@ describe('PROSE-POLISH-13PX-0 contract (#546 Phase B)', () => {
     // depend on `.maka-bubble-assistant` for line-height (the
     // WCAG 1.4.12 floor — var(--leading-normal) = 1.5), word-wrap (no global
     // overflow-wrap fallback exists — long URLs/tokens overflow horizontally),
-    // color, the 72ch measure cap, or the first/last-child edge-margin trims.
+    // color, or the first/last-child edge-margin trims. (The reading
+    // measure is NOT set here — see the max-width assertion below.)
     // Moving them is behavior-neutral in chat: the assistant div carries both
     // classes, same specificity, same layer.
     const css = stripCssComments(await readFile(PROSE_CSS, 'utf8'));
@@ -287,7 +288,10 @@ describe('PROSE-POLISH-13PX-0 contract (#546 Phase B)', () => {
     assert.match(prose!.decls, /font-size:\s*var\(--font-size-base\)/, '.maka-prose must pin font-size to the body tier — the tool card item shell sets text-xs (11px caption), which inherits into the prose body and scales the whole em-based heading ladder down (codex review P2)');
     assert.match(prose!.decls, /line-height:\s*var\(--leading-normal\)/, '.maka-prose must pin line-height to var(--leading-normal): it is the WCAG 1.4.12 floor (1.5) — inherited UI line-heights can dip below it at 13px');
     assert.match(prose!.decls, /(?:word-wrap|overflow-wrap):\s*break-word/, '.maka-prose must carry break-word — no global overflow-wrap fallback exists, so a bare consumer gets horizontally overflowing URLs/tokens');
-    assert.match(prose!.decls, /max-width:\s*72ch/, '.maka-prose must cap the measure at 72ch — the readability cap is prose typography, not bubble geometry');
+    assert.ok(
+      !/max-width\s*:/.test(prose!.decls),
+      '.maka-prose must not set its own max-width — the reading measure is owned by .maka-message-row (var(--maka-chat-measure), the same cap the composer uses), so the assistant block matches the composer width instead of being narrowed by an inner readability cap',
+    );
     assert.match(
       css,
       /\.maka-prose\s*>\s*:first-child\s*\{[^}]*margin-top:\s*0/,

--- a/apps/desktop/src/renderer/styles/chat-message.css
+++ b/apps/desktop/src/renderer/styles/chat-message.css
@@ -29,10 +29,11 @@
    neutral `--chat-user-bg` token path; the shell utilities live in
    packages/ui/src/primitives/chat.tsx. */
 /* Assistant: no bubble — just text on background, like an editor. The
-   markdown typography (color, line-height, break-word, the 72ch measure cap,
-   edge-margin trims) lives on .maka-prose in prose.css — the assistant Bubble
-   variant carries both classes, so the shell keeps only container geometry
-   (#618 item 2). */
+   markdown typography (color, line-height, break-word, edge-margin trims)
+   lives on .maka-prose in prose.css — the assistant Bubble variant carries
+   both classes, so the shell keeps only container geometry (#618 item 2).
+   The reading measure (max-width) lives on .maka-message-row above, shared
+   with the composer, so the assistant block matches the composer width. */
 .maka-bubble-assistant {
   padding: var(--space-0-5) 0 0;
 }

--- a/apps/desktop/src/renderer/styles/prose.css
+++ b/apps/desktop/src/renderer/styles/prose.css
@@ -81,29 +81,31 @@
 /* The base rule is self-contained (#618 item 2): a bare .maka-prose consumer
    must not depend on the assistant bubble shell — or on whatever chrome
    surrounds it — for line-height (the WCAG 1.4.12 floor — --leading-normal =
-   1.5), break-word (no global overflow-wrap fallback exists), color, the
-   measure cap, or the font. font-family/font-size are pinned defensively:
-   a host that sets font-mono or a caption-size font (as the tool card item
-   shell does) would otherwise inherit into the prose body and scale the
-   whole em-based heading ladder off the wrong tier (codex review P2). */
+   1.5), break-word (no global overflow-wrap fallback exists), color, or the
+   font. font-family/font-size are pinned defensively: a host that sets
+   font-mono or a caption-size font (as the tool card item shell does) would
+   otherwise inherit into the prose body and scale the whole em-based heading
+   ladder off the wrong tier (codex review P2). The reading measure is
+   intentionally NOT set here — see the note below. */
 .maka-prose {
   color: var(--foreground);
   font-family: var(--font-sans);
   font-size: var(--font-size-base);
   line-height: var(--leading-normal);
   word-wrap: break-word;
-  /* PR-MESSAGE-BODY-MAX-WIDTH-0 (WAWQAQ msg `38055b9f`, skills round task
-     #116): cap prose at ~72ch per pbakaus impeccable (65–75ch) and
-     design-taste-frontend (max-w-[65ch]). On wide windows the text used to
-     stretch the full pane width and wrap into very long lines, hurting
-     eye-tracking. Applies to inline text only — pre / table / code blocks
-     re-expand to 100% of the capped box below. */
-  max-width: 72ch;
+  /* No max-width here: the reading measure is owned by .maka-message-row
+     (var(--maka-chat-measure), the same cap the composer uses), so the
+     assistant block matches the composer width. An inner 72ch cap used to
+     narrow the prose ~200px short of the composer; removing it lets the
+     answer fill the row. pre / table / code blocks still expand to the full
+     row via the rule below. */
 }
 .maka-prose pre,
 .maka-prose table,
 .maka-prose .maka-code-block {
-  /* Wide payloads bypass the prose cap. */
+  /* Block payloads (tables especially — display:table would otherwise
+     shrink-wrap to content width) fill the prose box instead of hugging
+     their intrinsic width. */
   max-width: 100%;
 }
 .maka-prose p {

--- a/packages/ui/src/primitives/chat.tsx
+++ b/packages/ui/src/primitives/chat.tsx
@@ -73,9 +73,11 @@ const bubbleVariants = cva("", {
       user: "max-w-[min(100%,640px)] whitespace-pre-wrap break-words rounded-[var(--radius-surface)] bg-[var(--chat-user-bg)] px-3 py-2.5 leading-normal text-[color:var(--chat-user-foreground,var(--foreground))]",
       // Assistant / system: open prose, no bubble. The shell stays
       // `.maka-bubble-assistant` (now just surface padding — typography,
-      // the 72ch measure cap, and edge-margin trims live on the prose layer,
-      // #618 item 2); the Markdown prose layer `.maka-prose` (p / h / ul /
-      // code / ... typography) rides alongside and stays reusable on its own.
+      // edge-margin trims, and line-height/break-word live on the prose
+      // layer, #618 item 2; the reading measure is owned by
+      // `.maka-message-row`, not the prose layer); the Markdown prose layer
+      // `.maka-prose` (p / h / ul / code / ... typography) rides alongside
+      // and stays reusable on its own.
       assistant: "maka-bubble-assistant maka-prose",
     },
   },


### PR DESCRIPTION
## Summary

Drop the inner `max-width: 72ch` on `.maka-prose` so the assistant reply fills the message row, which already equals the composer width (`--maka-chat-measure`).

## Why

The assistant body (`.maka-prose`) carried an inner `max-width: 72ch` (~480px at the 13px body font), while both the message row and the composer share `--maka-chat-measure: 680px`. The reply therefore stopped ~200px short of the composer's right edge, reading as wasted space.

Root cause is a duplicated measure invariant: the reading-column width was expressed twice with two conflicting values (680px on the row/composer, 72ch on the prose). Removing the redundant inner cap restores a single source of truth (`--maka-chat-measure`).

## Scope

Changed:
- `apps/desktop/src/renderer/styles/prose.css` — remove `.maka-prose { max-width: 72ch }`; the measure is now owned solely by `.maka-message-row`.
- `apps/desktop/src/main/__tests__/markdown-prose-contract.test.ts` — flip the locked invariant from "must cap at 72ch" to "must not set its own max-width"; fix surrounding comments.
- `apps/desktop/src/renderer/styles/chat-message.css` — correct a now-stale "72ch measure cap" comment.
- `packages/ui/src/primitives/chat.tsx` — correct a now-stale "72ch measure cap" comment.

Not included:
- The absolute value of `--maka-chat-measure` (680px) is untouched. If the whole column (composer + assistant) should later use more of the window, that is a one-token change affecting the composer too, and is a separate decision.

## Verification

- TDD: flipped the contract test to the new invariant first → red (CSS still capped at 72ch) → removed the cap → green.
- `markdown-prose-contract`: 14/14 pass.
- `markdown-prose` + `chat-primitive-cascade` + `renderer-style-layer-cascade` + `border-width-converge`: 34/34 pass.
- `npm run typecheck` (all workspaces): pass.
- Screenshot baselines unaffected: the default `npm test` does not run pixel diffing, and the three committed baseline scenarios (`artifact-errors`, `artifact-pane`, `first-run`) do not render assistant prose.
- Confirmed in a local dev run that the assistant body now left/right aligns with the composer.

## User-facing impact

Assistant replies are wider and align with the composer; the right-hand gap is gone. No `CHANGELOG.md`, docs, breaking changes, or migrations.

## Reviewer notes

- The functional change is a single CSS declaration (remove `max-width`). The other three files are the contract-test flip and stale-comment corrections.
- Trade-off: line length rises to ~95ch, above the 65–75ch reading-comfort range. This is the explicit cost of the requested "match composer width"; reverting is a one-line restore.

## Checklist

- [x] Scope matches the PR title and excludes unrelated changes
- [x] Verification lists commands/results, or explains why they were not run
- [x] User-facing impact, docs, changelog, migrations, and breaking changes are noted, or marked none
- [x] Risk, rollback, or review focus is called out for non-trivial changes
- [ ] UI changes include screenshots/video, or explain why not applicable
