### PR TITLE
fix(headless): preserve timeout budget outcomes

### DIFF
--- a/packages/headless/src/__tests__/ab-run.test.ts
+++ b/packages/headless/src/__tests__/ab-run.test.ts
@@ -3,7 +3,7 @@ import { describe, test } from 'node:test';
 import { runAbComparison } from '../ab-run.js';
 import { completed } from './helpers/ab-run-fixtures.js';
 import { sha256 } from './helpers/hash-fixture.js';
-import type { FixedPromptTaskInfraFailedEvent } from '../fixed-prompt-controller.js';
+import type { FixedPromptTaskBudgetExhaustedEvent, FixedPromptTaskInfraFailedEvent } from '../fixed-prompt-controller.js';
 
 describe('runAbComparison', () => {
   test('rejects arm ids that collapse to the same round id suffix', async () => {
@@ -152,7 +152,53 @@ describe('runAbComparison', () => {
     assert.deepEqual(calls, ['ab-off-r0-t1', 'ab-on-r0-t1']);
     assert.equal(result.stopReason, 'systemic_provider_failure');
   });
+
+  test('stops scheduling new pairs after a timeout carries systemic provider evidence', async () => {
+    const calls: string[] = [];
+    const result = await runAbComparison({
+      runId: 'ab-run',
+      arms: [
+        { id: 'off', kind: 'runtime', fingerprint: sha256('off') },
+        { id: 'on', kind: 'runtime', fingerprint: sha256('on') },
+      ],
+      evaluationTasks: [
+        { id: 't1', path: '/tasks/t1' },
+        { id: 't2', path: '/tasks/t2' },
+        { id: 't3', path: '/tasks/t3' },
+      ],
+      reps: 1,
+      maxConcurrency: 1,
+      runArm: async ({ roundId, task }) => {
+        calls.push(roundId);
+        return providerAuthTimeout(task.id);
+      },
+    });
+
+    assert.deepEqual(calls, ['ab-off-r0-t1', 'ab-on-r0-t1']);
+    assert.equal(result.stopReason, 'systemic_provider_failure');
+  });
 });
+
+function providerAuthTimeout(taskId: string): FixedPromptTaskBudgetExhaustedEvent {
+  return {
+    schemaVersion: 1,
+    type: 'task_budget_exhausted',
+    id: `event-${taskId}`,
+    ts: 0,
+    runId: 'ab-run',
+    roundId: 'round',
+    taskId,
+    status: 'budget_exhausted',
+    passed: false,
+    scored: false,
+    eligible: false,
+    errorClass: 'budget_exhausted',
+    error: 'agent timed out',
+    evidenceErrorClass: 'auth',
+    evidenceError: 'provider auth failed',
+    expectedPromptHash: 'sha256:prompt',
+  };
+}
 
 function providerBilling(taskId: string): FixedPromptTaskInfraFailedEvent {
   return {

--- a/packages/headless/src/__tests__/ab-summary.test.ts
+++ b/packages/headless/src/__tests__/ab-summary.test.ts
@@ -86,7 +86,6 @@ describe('summarizeAbComparison', () => {
     const unverifiedTimeout = {
       ...budgetExhausted('long-task'),
       eligible: false,
-      evidenceStatus: 'unverified' as const,
       evidenceErrorClass: 'missing_execution_identity' as const,
     };
     const result = summarizeAbComparison({
@@ -105,6 +104,26 @@ describe('summarizeAbComparison', () => {
     assert.equal(result.baseline.coverageRate, 0);
     assert.equal(result.candidate.valid, 0);
     assert.equal(result.candidate.coverageRate, 0);
+  });
+
+  test('does not count ineligible completed attempts as valid A/B coverage', () => {
+    const ineligibleCompleted = { ...completed('task-a', false), eligible: false };
+    const result = summarizeAbComparison({
+      runId: 'ab-run',
+      roundId: 'ab-summary',
+      baselineArmId: 'maka-baseline',
+      candidateArmId: 'candidate',
+      evaluationTaskIds: ['task-a'],
+      baselineRuns: [[ineligibleCompleted]],
+      candidateRuns: [[ineligibleCompleted]],
+      budgetMs: 600_000,
+    });
+
+    assert.equal(result.baseline.valid, 0);
+    assert.equal(result.baseline.coverageRate, 0);
+    assert.equal(result.candidate.valid, 0);
+    assert.equal(result.candidate.coverageRate, 0);
+    assert.equal(result.pairedAttempts.observedPairs, 0);
   });
 
   test('summarizes context budget activation in the A/B report', () => {

--- a/packages/headless/src/__tests__/ab-summary.test.ts
+++ b/packages/headless/src/__tests__/ab-summary.test.ts
@@ -82,6 +82,31 @@ describe('summarizeAbComparison', () => {
     assert.equal(result.taskLevel.losses, 1);
   });
 
+  test('does not count an unverified budget exhaustion as valid A/B coverage', () => {
+    const unverifiedTimeout = {
+      ...budgetExhausted('long-task'),
+      eligible: false,
+      evidenceStatus: 'unverified' as const,
+      evidenceErrorClass: 'missing_execution_identity' as const,
+    };
+    const result = summarizeAbComparison({
+      runId: 'ab-run',
+      roundId: 'ab-summary',
+      baselineArmId: 'maka-baseline',
+      candidateArmId: 'candidate',
+      evaluationTaskIds: ['long-task'],
+      baselineRuns: [[unverifiedTimeout]],
+      candidateRuns: [[unverifiedTimeout]],
+      budgetMs: 600_000,
+    });
+
+    assert.equal(result.baseline.budgetExhausted, 1);
+    assert.equal(result.baseline.valid, 0);
+    assert.equal(result.baseline.coverageRate, 0);
+    assert.equal(result.candidate.valid, 0);
+    assert.equal(result.candidate.coverageRate, 0);
+  });
+
   test('summarizes context budget activation in the A/B report', () => {
     const baselineInactive = contextBudgetSummary({ prunedToolResults: 0 });
     const candidateActive = contextBudgetSummary({

--- a/packages/headless/src/__tests__/fixed-prompt-controller.test.ts
+++ b/packages/headless/src/__tests__/fixed-prompt-controller.test.ts
@@ -443,7 +443,7 @@ describe('fixed prompt controller', () => {
     });
   });
 
-  test('fails closed when an attested experiment times out before cell output exists', async () => {
+  test('keeps an unattested timeout as an ineligible budget exhaustion', async () => {
     await withDir(async (dir) => {
       const systemPromptPath = join(dir, 'system_prompt.md');
       await writeFile(systemPromptPath, 'fixed prompt\n', 'utf8');
@@ -464,8 +464,13 @@ describe('fixed prompt controller', () => {
         newId: idFactory(),
       });
 
-      assert.equal(result.events[0]?.type, 'task_plumbing_failed');
-      assert.equal(result.events[0]?.errorClass, 'missing_execution_identity');
+      const event = result.events[0];
+      assert.equal(event?.type, 'task_budget_exhausted');
+      if (event?.type !== 'task_budget_exhausted') assert.fail('expected budget exhaustion event');
+      assert.equal(event.status, 'budget_exhausted');
+      assert.equal(event.eligible, false);
+      assert.equal(event.evidenceStatus, 'unverified');
+      assert.equal(event.evidenceErrorClass, 'missing_execution_identity');
       assert.equal('tokenSummary' in result.events[0]!, false);
     });
   });
@@ -500,7 +505,7 @@ describe('fixed prompt controller', () => {
     });
   });
 
-  test('invalidates a timed-out cell whose execution identity is wrong', async () => {
+  test('keeps an identity-mismatched timeout as an ineligible budget exhaustion', async () => {
     await withDir(async (dir) => {
       const systemPromptPath = join(dir, 'system_prompt.md');
       await writeFile(systemPromptPath, 'fixed prompt\n', 'utf8');
@@ -530,8 +535,13 @@ describe('fixed prompt controller', () => {
         newId: idFactory(),
       });
 
-      assert.equal(result.events[0]?.type, 'task_plumbing_failed');
-      assert.equal(result.events[0]?.errorClass, 'execution_identity_mismatch');
+      const event = result.events[0];
+      assert.equal(event?.type, 'task_budget_exhausted');
+      if (event?.type !== 'task_budget_exhausted') assert.fail('expected budget exhaustion event');
+      assert.equal(event.status, 'budget_exhausted');
+      assert.equal(event.eligible, false);
+      assert.equal(event.evidenceStatus, 'unverified');
+      assert.equal(event.evidenceErrorClass, 'execution_identity_mismatch');
     });
   });
 

--- a/packages/headless/src/__tests__/fixed-prompt-controller.test.ts
+++ b/packages/headless/src/__tests__/fixed-prompt-controller.test.ts
@@ -196,6 +196,59 @@ describe('fixed prompt controller', () => {
     });
   });
 
+  test('projects an unambiguous legacy timeout plumbing event as budget exhausted on resume', async () => {
+    await withDir(async (dir) => {
+      const systemPromptPath = join(dir, 'system_prompt.md');
+      const resultsJsonlPath = join(dir, 'results.jsonl');
+      await writeFile(systemPromptPath, 'fixed prompt\n', 'utf8');
+      await writeFile(resultsJsonlPath, `${JSON.stringify({
+        schemaVersion: 1,
+        type: 'task_plumbing_failed',
+        id: 'legacy-timeout',
+        ts: 10,
+        runId: 'run-1',
+        roundId: 'round-1',
+        resumeFingerprint: 'fingerprint-same',
+        taskId: 'task-a',
+        status: 'plumbing_failed',
+        passed: false,
+        scored: false,
+        eligible: false,
+        errorClass: 'missing_execution_identity',
+        error: 'Timed-out Harbor attempt did not produce execution identity attestation',
+        expectedPromptHash: hashSystemPrompt('fixed prompt\n'),
+      })}\n`, 'utf8');
+      const originalWal = await readFile(resultsJsonlPath, 'utf8');
+      let calls = 0;
+
+      const result = await runFixedPromptController({
+        runId: 'run-1',
+        roundId: 'round-1',
+        config,
+        systemPromptPath,
+        resultsJsonlPath,
+        resultsTsvPath: join(dir, 'results.tsv'),
+        tasks: [{ id: 'task-a', path: '/bench/task-a' }],
+        resumeFingerprint: 'fingerprint-same',
+        requireExecutionIdentity: true,
+        harborRunner: async () => {
+          calls += 1;
+          return harborOutput({ taskId: 'task-a' });
+        },
+        now: () => 100,
+        newId: idFactory(),
+      });
+
+      assert.equal(calls, 0);
+      const event = result.events[0];
+      assert.equal(event?.type, 'task_budget_exhausted');
+      if (event?.type !== 'task_budget_exhausted') assert.fail('expected budget exhaustion event');
+      assert.equal(event.eligible, false);
+      assert.equal(event.evidenceErrorClass, 'missing_execution_identity');
+      assert.equal(await readFile(resultsJsonlPath, 'utf8'), originalWal);
+    });
+  });
+
   test('ignores a torn final WAL line when resuming', async () => {
     await withDir(async (dir) => {
       const systemPromptPath = join(dir, 'system_prompt.md');
@@ -469,7 +522,6 @@ describe('fixed prompt controller', () => {
       if (event?.type !== 'task_budget_exhausted') assert.fail('expected budget exhaustion event');
       assert.equal(event.status, 'budget_exhausted');
       assert.equal(event.eligible, false);
-      assert.equal(event.evidenceStatus, 'unverified');
       assert.equal(event.evidenceErrorClass, 'missing_execution_identity');
       assert.equal('tokenSummary' in result.events[0]!, false);
     });
@@ -540,7 +592,6 @@ describe('fixed prompt controller', () => {
       if (event?.type !== 'task_budget_exhausted') assert.fail('expected budget exhaustion event');
       assert.equal(event.status, 'budget_exhausted');
       assert.equal(event.eligible, false);
-      assert.equal(event.evidenceStatus, 'unverified');
       assert.equal(event.evidenceErrorClass, 'execution_identity_mismatch');
     });
   });
@@ -580,8 +631,52 @@ describe('fixed prompt controller', () => {
       if (event?.type !== 'task_budget_exhausted') assert.fail('expected budget exhaustion event');
       assert.equal(event.status, 'budget_exhausted');
       assert.equal(event.eligible, true);
-      assert.equal(event.evidenceStatus, 'verified');
       assert.equal(event.evidenceErrorClass, undefined);
+      assert.equal(event.tokenSummary?.total, 3);
+      assert.equal(event.tokenSummary?.costUsd, 0.02);
+      assert.equal(result.totalTokens, 3);
+      assert.equal(result.totalCostUsd, 0.02);
+    });
+  });
+
+  test('keeps a provider-error timeout ineligible and stops the controller', async () => {
+    await withDir(async (dir) => {
+      const systemPromptPath = join(dir, 'system_prompt.md');
+      await writeFile(systemPromptPath, 'fixed prompt\n', 'utf8');
+      const cell = harborOutput({
+        taskId: 'task-a',
+        status: 'failed',
+        errorClass: 'auth',
+        executionIdentity: {
+          llmConnectionSlug: 'fake',
+          model: 'fake-model',
+          systemPromptHash: hashSystemPrompt('fixed prompt\n'),
+          pricingProfile: 'test-profile',
+        },
+      }).cell;
+      const result = await runFixedPromptController({
+        runId: 'run-1',
+        roundId: 'round-1',
+        config,
+        systemPromptPath,
+        resultsJsonlPath: join(dir, 'results.jsonl'),
+        resultsTsvPath: join(dir, 'results.tsv'),
+        tasks: [{ id: 'task-a', path: '/bench/task-a' }],
+        requireExecutionIdentity: true,
+        expectedPricingProfile: 'test-profile',
+        harborRunner: async () => {
+          throw new FixedPromptBudgetExhaustedError('agent timed out', undefined, { cellOutput: cell });
+        },
+        now: () => 100,
+        newId: idFactory(),
+      });
+
+      const event = result.events[0];
+      assert.equal(event?.type, 'task_budget_exhausted');
+      if (event?.type !== 'task_budget_exhausted') assert.fail('expected budget exhaustion event');
+      assert.equal(event.eligible, false);
+      assert.equal(event.evidenceErrorClass, 'auth');
+      assert.equal(result.stopReason, 'systemic_provider_failure');
     });
   });
 

--- a/packages/headless/src/__tests__/fixed-prompt-controller.test.ts
+++ b/packages/headless/src/__tests__/fixed-prompt-controller.test.ts
@@ -8,6 +8,7 @@ import { tokenSummary } from './helpers/cell-output-fixtures.js';
 import {
   FixedPromptBudgetExhaustedError,
   hashSystemPrompt,
+  readFixedPromptWal,
   readHarborTaskRunOutput,
   runFixedPromptController,
   type FixedPromptWalEvent,
@@ -219,6 +220,8 @@ describe('fixed prompt controller', () => {
         expectedPromptHash: hashSystemPrompt('fixed prompt\n'),
       })}\n`, 'utf8');
       const originalWal = await readFile(resultsJsonlPath, 'utf8');
+      const projectedWal = await readFixedPromptWal(resultsJsonlPath);
+      assert.equal(projectedWal[0]?.type, 'task_budget_exhausted');
       let calls = 0;
 
       const result = await runFixedPromptController({

--- a/packages/headless/src/__tests__/fixed-prompt-controller.test.ts
+++ b/packages/headless/src/__tests__/fixed-prompt-controller.test.ts
@@ -545,6 +545,46 @@ describe('fixed prompt controller', () => {
     });
   });
 
+  test('keeps an identity-verified timeout eligible as a budget exhaustion', async () => {
+    await withDir(async (dir) => {
+      const systemPromptPath = join(dir, 'system_prompt.md');
+      await writeFile(systemPromptPath, 'fixed prompt\n', 'utf8');
+      const cell = harborOutput({
+        taskId: 'task-a',
+        executionIdentity: {
+          llmConnectionSlug: 'fake',
+          model: 'fake-model',
+          systemPromptHash: hashSystemPrompt('fixed prompt\n'),
+          pricingProfile: 'test-profile',
+        },
+      }).cell;
+      const result = await runFixedPromptController({
+        runId: 'run-1',
+        roundId: 'round-1',
+        config,
+        systemPromptPath,
+        resultsJsonlPath: join(dir, 'results.jsonl'),
+        resultsTsvPath: join(dir, 'results.tsv'),
+        tasks: [{ id: 'task-a', path: '/bench/task-a' }],
+        requireExecutionIdentity: true,
+        expectedPricingProfile: 'test-profile',
+        harborRunner: async () => {
+          throw new FixedPromptBudgetExhaustedError('agent timed out', undefined, { cellOutput: cell });
+        },
+        now: () => 100,
+        newId: idFactory(),
+      });
+
+      const event = result.events[0];
+      assert.equal(event?.type, 'task_budget_exhausted');
+      if (event?.type !== 'task_budget_exhausted') assert.fail('expected budget exhaustion event');
+      assert.equal(event.status, 'budget_exhausted');
+      assert.equal(event.eligible, true);
+      assert.equal(event.evidenceStatus, 'verified');
+      assert.equal(event.evidenceErrorClass, undefined);
+    });
+  });
+
   test('reruns budget-exhausted WAL events instead of reusing a timeout', async () => {
     await withDir(async (dir) => {
       const systemPromptPath = join(dir, 'system_prompt.md');

--- a/packages/headless/src/__tests__/fixed-prompt-controller.test.ts
+++ b/packages/headless/src/__tests__/fixed-prompt-controller.test.ts
@@ -683,6 +683,48 @@ describe('fixed prompt controller', () => {
     });
   });
 
+  for (const errorClass of ['infra_failed', 'setup_failed', 'verification_error'] as const) {
+    test(`keeps a timeout with ${errorClass} evidence ineligible`, async () => {
+      await withDir(async (dir) => {
+        const systemPromptPath = join(dir, 'system_prompt.md');
+        await writeFile(systemPromptPath, 'fixed prompt\n', 'utf8');
+        const cell = harborOutput({
+          taskId: 'task-a',
+          status: 'failed',
+          errorClass,
+          executionIdentity: {
+            llmConnectionSlug: 'fake',
+            model: 'fake-model',
+            systemPromptHash: hashSystemPrompt('fixed prompt\n'),
+            pricingProfile: 'test-profile',
+          },
+        }).cell;
+        const result = await runFixedPromptController({
+          runId: 'run-1',
+          roundId: 'round-1',
+          config,
+          systemPromptPath,
+          resultsJsonlPath: join(dir, 'results.jsonl'),
+          resultsTsvPath: join(dir, 'results.tsv'),
+          tasks: [{ id: 'task-a', path: '/bench/task-a' }],
+          requireExecutionIdentity: true,
+          expectedPricingProfile: 'test-profile',
+          harborRunner: async () => {
+            throw new FixedPromptBudgetExhaustedError('agent timed out', undefined, { cellOutput: cell });
+          },
+          now: () => 100,
+          newId: idFactory(),
+        });
+
+        const event = result.events[0];
+        assert.equal(event?.type, 'task_budget_exhausted');
+        if (event?.type !== 'task_budget_exhausted') assert.fail('expected budget exhaustion event');
+        assert.equal(event.eligible, false);
+        assert.equal(event.evidenceErrorClass, errorClass);
+      });
+    });
+  }
+
   test('reruns budget-exhausted WAL events instead of reusing a timeout', async () => {
     await withDir(async (dir) => {
       const systemPromptPath = join(dir, 'system_prompt.md');

--- a/packages/headless/src/__tests__/prompt-structural-smoke.test.ts
+++ b/packages/headless/src/__tests__/prompt-structural-smoke.test.ts
@@ -94,6 +94,18 @@ describe('prompt structural smoke report', () => {
     assert.deepEqual(report.failures, ['cost_ceiling_exceeded']);
   });
 
+  test('includes budget-exhausted task cost in the structural ceiling', () => {
+    const report = promptStructuralSmokeReport({
+      events: [budgetExhaustedEvent('round-1', 'task-1', 0.42)],
+      minimumRounds: 0,
+      costCeilingUsd: 0.4,
+    });
+
+    assert.equal(report.totalCostUsd, 0.42);
+    assert.equal(report.status, 'fail');
+    assert.deepEqual(report.failures, ['cost_ceiling_exceeded']);
+  });
+
   test('fails when decision rounds have no task evidence', () => {
     const events: FixedPromptWalEvent[] = [];
     for (let index = 1; index <= 10; index += 1) {
@@ -740,6 +752,26 @@ function completedEvent(
     durationMs: 10,
     runtimeEventsPath: `/logs/${roundId}/${taskId}.jsonl`,
     harbor: { reward: 0 },
+  };
+}
+
+function budgetExhaustedEvent(roundId: string, taskId: string, costUsd: number): FixedPromptWalEvent {
+  return {
+    schemaVersion: 1,
+    type: 'task_budget_exhausted',
+    id: `budget-${roundId}-${taskId}`,
+    ts: 1,
+    runId: 'run-1',
+    roundId,
+    taskId,
+    status: 'budget_exhausted',
+    passed: false,
+    scored: false,
+    eligible: true,
+    errorClass: 'budget_exhausted',
+    error: 'agent timed out',
+    expectedPromptHash: promptHashForRound(roundId),
+    tokenSummary: tokenSummary({ input: 1, output: 1, reasoning: 0, total: 2, costUsd }),
   };
 }
 

--- a/packages/headless/src/ab-run.ts
+++ b/packages/headless/src/ab-run.ts
@@ -78,7 +78,12 @@ function eventCostUsd(event: FixedPromptTaskWalEvent): number {
 }
 
 function isSystemicProviderFailure(event: FixedPromptTaskWalEvent): boolean {
-  return event.type === 'task_infra_failed' && (event.errorClass === 'provider_billing' || event.errorClass === 'auth');
+  const errorClass = event.type === 'task_infra_failed'
+    ? event.errorClass
+    : event.type === 'task_budget_exhausted'
+      ? event.evidenceErrorClass
+      : undefined;
+  return errorClass === 'provider_billing' || errorClass === 'auth';
 }
 
 async function runComparisonPair(

--- a/packages/headless/src/ab-summary.ts
+++ b/packages/headless/src/ab-summary.ts
@@ -562,7 +562,7 @@ function wilsonScoreInterval(passed: number, total: number, z: number): { lower:
 function isValidBudgetedOutcome(
   event: FixedPromptTaskWalEvent,
 ): event is Extract<FixedPromptTaskWalEvent, { type: 'task_completed' | 'task_budget_exhausted' }> {
-  return event.type === 'task_completed' || event.type === 'task_budget_exhausted';
+  return event.type === 'task_completed' || (event.type === 'task_budget_exhausted' && event.eligible);
 }
 
 function isBudgetExhaustedOutcome(event: FixedPromptTaskWalEvent): boolean {

--- a/packages/headless/src/ab-summary.ts
+++ b/packages/headless/src/ab-summary.ts
@@ -562,7 +562,7 @@ function wilsonScoreInterval(passed: number, total: number, z: number): { lower:
 function isValidBudgetedOutcome(
   event: FixedPromptTaskWalEvent,
 ): event is Extract<FixedPromptTaskWalEvent, { type: 'task_completed' | 'task_budget_exhausted' }> {
-  return event.type === 'task_completed' || (event.type === 'task_budget_exhausted' && event.eligible);
+  return event.eligible && (event.type === 'task_completed' || event.type === 'task_budget_exhausted');
 }
 
 function isBudgetExhaustedOutcome(event: FixedPromptTaskWalEvent): boolean {

--- a/packages/headless/src/fixed-prompt-controller.ts
+++ b/packages/headless/src/fixed-prompt-controller.ts
@@ -16,6 +16,7 @@ import { assertFinitePositive, assertPositiveInt, assertRatio } from './numeric-
 
 export const FIXED_PROMPT_WAL_SCHEMA_VERSION = 1;
 export const BUDGET_EXHAUSTED_RUNTIME_UNAVAILABLE_REASON = 'budget_exhausted_before_cell_output';
+const LEGACY_TIMEOUT_MISSING_EXECUTION_IDENTITY_ERROR = 'Timed-out Harbor attempt did not produce execution identity attestation';
 
 export interface FixedPromptTask {
   id: string;
@@ -139,8 +140,7 @@ export interface FixedPromptTaskBudgetExhaustedEvent {
   eligible: boolean;
   errorClass: 'budget_exhausted';
   error: string;
-  evidenceStatus?: 'not_required' | 'verified' | 'unverified';
-  evidenceErrorClass?: FixedPromptTaskPlumbingFailedEvent['errorClass'];
+  evidenceErrorClass?: FixedPromptTaskPlumbingFailedEvent['errorClass'] | 'provider_billing' | 'auth';
   evidenceError?: string;
   expectedPromptHash: string;
   runtimeEventsPath?: string;
@@ -329,7 +329,7 @@ export async function runFixedPromptController(
   const systemPrompt = await readFile(input.systemPromptPath, 'utf8');
   const expectedPromptHash = hashSystemPrompt(systemPrompt);
   const config = { ...input.config, systemPrompt };
-  const events = await readFixedPromptWal(input.resultsJsonlPath);
+  const events = (await readFixedPromptWal(input.resultsJsonlPath)).map(projectLegacyTimeoutOutcome);
   const completed = terminalTaskEvents(events, input.runId, input.roundId, expectedPromptHash, input.resumeFingerprint);
   const stopEvidence = roundTaskEvents(events, input.runId, input.roundId, expectedPromptHash, input.resumeFingerprint);
   let stopReason = controllerStopReason({
@@ -820,27 +820,31 @@ function taskBudgetExhaustedEvent(input: {
   ts: number;
 }): FixedPromptTaskBudgetExhaustedEvent {
   const artifactRefs = budgetExhaustedArtifactRefs(input.error);
-  let evidenceFailure: ReturnType<typeof classifyPlumbingFailure>;
+  let evidenceFailure: {
+    errorClass: NonNullable<FixedPromptTaskBudgetExhaustedEvent['evidenceErrorClass']>;
+    error: string;
+  } | undefined;
   if (artifactRefs.cellOutput) {
     const output = { harbor: { reward: 0 }, cell: artifactRefs.cellOutput };
-    evidenceFailure = classifyPlumbingFailure(
-      output,
-      input.expectedPromptHash,
-      input.expectedConfig,
-      input.requireExecutionIdentity ?? false,
-      input.expectedPricingProfile,
-    );
+    evidenceFailure = isSystemicProviderFailure(output.cell.errorClass)
+      ? {
+          errorClass: output.cell.errorClass,
+          error: `Harbor cell failed with ${output.cell.errorClass}`,
+        }
+      : classifyPlumbingFailure(
+          output,
+          input.expectedPromptHash,
+          input.expectedConfig,
+          input.requireExecutionIdentity ?? false,
+          input.expectedPricingProfile,
+        );
   } else if (input.requireExecutionIdentity) {
     evidenceFailure = {
       errorClass: 'missing_execution_identity',
-      error: 'Timed-out Harbor attempt did not produce execution identity attestation',
+      error: LEGACY_TIMEOUT_MISSING_EXECUTION_IDENTITY_ERROR,
     };
   }
-  const evidenceStatus = evidenceFailure
-    ? 'unverified'
-    : artifactRefs.cellOutput
-      ? 'verified'
-      : 'not_required';
+  const tokenSummary = artifactRefs.cellOutput?.tokenSummary ?? artifactRefs.tokenSummary;
   return {
     schemaVersion: FIXED_PROMPT_WAL_SCHEMA_VERSION,
     type: 'task_budget_exhausted',
@@ -856,7 +860,6 @@ function taskBudgetExhaustedEvent(input: {
     eligible: evidenceFailure === undefined,
     errorClass: 'budget_exhausted',
     error: errorMessage(input.error),
-    evidenceStatus,
     ...(evidenceFailure ? {
       evidenceErrorClass: evidenceFailure.errorClass,
       evidenceError: evidenceFailure.error,
@@ -867,7 +870,40 @@ function taskBudgetExhaustedEvent(input: {
     ...(artifactRefs.runtimeEventsUnavailableReason
       ? { runtimeEventsUnavailableReason: artifactRefs.runtimeEventsUnavailableReason }
       : {}),
-    ...(artifactRefs.tokenSummary ? { tokenSummary: artifactRefs.tokenSummary } : {}),
+    ...(tokenSummary ? { tokenSummary } : {}),
+  };
+}
+
+function projectLegacyTimeoutOutcome(event: FixedPromptWalEvent): FixedPromptWalEvent {
+  if (
+    event.type !== 'task_plumbing_failed'
+    || event.errorClass !== 'missing_execution_identity'
+    || event.error !== LEGACY_TIMEOUT_MISSING_EXECUTION_IDENTITY_ERROR
+    || event.expectedPromptHash === undefined
+  ) {
+    return event;
+  }
+  return {
+    schemaVersion: event.schemaVersion,
+    type: 'task_budget_exhausted',
+    id: event.id,
+    ts: event.ts,
+    runId: event.runId,
+    roundId: event.roundId,
+    ...(event.resumeFingerprint ? { resumeFingerprint: event.resumeFingerprint } : {}),
+    taskId: event.taskId,
+    status: 'budget_exhausted',
+    passed: false,
+    scored: false,
+    eligible: false,
+    errorClass: 'budget_exhausted',
+    error: 'Harbor attempt exhausted its configured time budget',
+    evidenceErrorClass: event.errorClass,
+    evidenceError: event.error,
+    expectedPromptHash: event.expectedPromptHash,
+    ...(event.tokenSummary ? { tokenSummary: event.tokenSummary } : {}),
+    ...(event.runtimeEventsPath ? { runtimeEventsPath: event.runtimeEventsPath } : {}),
+    ...(event.traceEventsPath ? { traceEventsPath: event.traceEventsPath } : {}),
   };
 }
 
@@ -955,7 +991,11 @@ function controllerStopReason(input: {
   maxInfraFailureRate?: number;
   costCeilingUsd?: number;
 }): FixedPromptControllerStopReason | undefined {
-  if (input.events.some((event) => event.type === 'task_infra_failed' && isSystemicProviderFailure(event.errorClass))) {
+  if (input.events.some((event) => (
+    event.type === 'task_infra_failed' && isSystemicProviderFailure(event.errorClass)
+  ) || (
+    event.type === 'task_budget_exhausted' && isSystemicProviderFailure(event.evidenceErrorClass)
+  ))) {
     return 'systemic_provider_failure';
   }
   if (

--- a/packages/headless/src/fixed-prompt-controller.ts
+++ b/packages/headless/src/fixed-prompt-controller.ts
@@ -329,7 +329,7 @@ export async function runFixedPromptController(
   const systemPrompt = await readFile(input.systemPromptPath, 'utf8');
   const expectedPromptHash = hashSystemPrompt(systemPrompt);
   const config = { ...input.config, systemPrompt };
-  const events = (await readFixedPromptWal(input.resultsJsonlPath)).map(projectLegacyTimeoutOutcome);
+  const events = await readFixedPromptWal(input.resultsJsonlPath);
   const completed = terminalTaskEvents(events, input.runId, input.roundId, expectedPromptHash, input.resumeFingerprint);
   const stopEvidence = roundTaskEvents(events, input.runId, input.roundId, expectedPromptHash, input.resumeFingerprint);
   let stopReason = controllerStopReason({
@@ -449,7 +449,7 @@ export async function readFixedPromptWal(path: string): Promise<FixedPromptWalEv
       throw error;
     }
   }
-  return events;
+  return events.map(projectLegacyTimeoutOutcome);
 }
 
 export async function readHarborTaskRunOutput(

--- a/packages/headless/src/fixed-prompt-controller.ts
+++ b/packages/headless/src/fixed-prompt-controller.ts
@@ -17,6 +17,7 @@ import { assertFinitePositive, assertPositiveInt, assertRatio } from './numeric-
 export const FIXED_PROMPT_WAL_SCHEMA_VERSION = 1;
 export const BUDGET_EXHAUSTED_RUNTIME_UNAVAILABLE_REASON = 'budget_exhausted_before_cell_output';
 const LEGACY_TIMEOUT_MISSING_EXECUTION_IDENTITY_ERROR = 'Timed-out Harbor attempt did not produce execution identity attestation';
+type UnscoredCellFailureClass = 'infra_failed' | 'setup_failed' | 'verification_error';
 
 export interface FixedPromptTask {
   id: string;
@@ -140,7 +141,7 @@ export interface FixedPromptTaskBudgetExhaustedEvent {
   eligible: boolean;
   errorClass: 'budget_exhausted';
   error: string;
-  evidenceErrorClass?: FixedPromptTaskPlumbingFailedEvent['errorClass'] | 'provider_billing' | 'auth';
+  evidenceErrorClass?: FixedPromptTaskPlumbingFailedEvent['errorClass'] | UnscoredCellFailureClass | 'provider_billing' | 'auth';
   evidenceError?: string;
   expectedPromptHash: string;
   runtimeEventsPath?: string;
@@ -673,7 +674,7 @@ function taskCompletedEvent(input: {
   };
 }
 
-function isUnscoredCellFailure(errorClass: string | undefined): boolean {
+function isUnscoredCellFailure(errorClass: string | undefined): errorClass is UnscoredCellFailureClass {
   return errorClass === 'infra_failed' || errorClass === 'setup_failed' || errorClass === 'verification_error';
 }
 
@@ -831,13 +832,18 @@ function taskBudgetExhaustedEvent(input: {
           errorClass: output.cell.errorClass,
           error: `Harbor cell failed with ${output.cell.errorClass}`,
         }
-      : classifyPlumbingFailure(
-          output,
-          input.expectedPromptHash,
-          input.expectedConfig,
-          input.requireExecutionIdentity ?? false,
-          input.expectedPricingProfile,
-        );
+      : isUnscoredCellFailure(output.cell.errorClass)
+        ? {
+            errorClass: output.cell.errorClass,
+            error: `Harbor cell failed with ${output.cell.errorClass}`,
+          }
+        : classifyPlumbingFailure(
+            output,
+            input.expectedPromptHash,
+            input.expectedConfig,
+            input.requireExecutionIdentity ?? false,
+            input.expectedPricingProfile,
+          );
   } else if (input.requireExecutionIdentity) {
     evidenceFailure = {
       errorClass: 'missing_execution_identity',

--- a/packages/headless/src/fixed-prompt-controller.ts
+++ b/packages/headless/src/fixed-prompt-controller.ts
@@ -136,9 +136,12 @@ export interface FixedPromptTaskBudgetExhaustedEvent {
   status: 'budget_exhausted';
   passed: false;
   scored: false;
-  eligible: true;
+  eligible: boolean;
   errorClass: 'budget_exhausted';
   error: string;
+  evidenceStatus?: 'not_required' | 'verified' | 'unverified';
+  evidenceErrorClass?: FixedPromptTaskPlumbingFailedEvent['errorClass'];
+  evidenceError?: string;
   expectedPromptHash: string;
   runtimeEventsPath?: string;
   traceEventsPath?: string;
@@ -815,54 +818,29 @@ function taskBudgetExhaustedEvent(input: {
   resumeFingerprint?: string;
   id: string;
   ts: number;
-}): FixedPromptTaskBudgetExhaustedEvent | FixedPromptTaskPlumbingFailedEvent {
+}): FixedPromptTaskBudgetExhaustedEvent {
   const artifactRefs = budgetExhaustedArtifactRefs(input.error);
-  if (input.requireExecutionIdentity && !artifactRefs.cellOutput) {
-    return {
-      schemaVersion: FIXED_PROMPT_WAL_SCHEMA_VERSION,
-      type: 'task_plumbing_failed',
-      id: input.id,
-      ts: input.ts,
-      runId: input.runId,
-      roundId: input.roundId,
-      ...(input.resumeFingerprint ? { resumeFingerprint: input.resumeFingerprint } : {}),
-      taskId: input.taskId,
-      status: 'plumbing_failed',
-      passed: false,
-      scored: false,
-      eligible: false,
-      errorClass: 'missing_execution_identity',
-      error: 'Timed-out Harbor attempt did not produce execution identity attestation',
-      expectedPromptHash: input.expectedPromptHash,
-      ...(artifactRefs.tokenSummary ? { tokenSummary: artifactRefs.tokenSummary } : {}),
-      ...(artifactRefs.runtimeEventsPath ? { runtimeEventsPath: artifactRefs.runtimeEventsPath } : {}),
-      ...(artifactRefs.traceEventsPath ? { traceEventsPath: artifactRefs.traceEventsPath } : {}),
-    };
-  }
+  let evidenceFailure: ReturnType<typeof classifyPlumbingFailure>;
   if (artifactRefs.cellOutput) {
     const output = { harbor: { reward: 0 }, cell: artifactRefs.cellOutput };
-    const plumbingFailure = classifyPlumbingFailure(
+    evidenceFailure = classifyPlumbingFailure(
       output,
       input.expectedPromptHash,
       input.expectedConfig,
       input.requireExecutionIdentity ?? false,
       input.expectedPricingProfile,
     );
-    if (plumbingFailure) {
-      return taskPlumbingFailedEvent({
-        output,
-        expectedPromptHash: input.expectedPromptHash,
-        resumeFingerprint: input.resumeFingerprint,
-        taskId: input.taskId,
-        runId: input.runId,
-        roundId: input.roundId,
-        id: input.id,
-        ts: input.ts,
-        errorClass: plumbingFailure.errorClass,
-        error: plumbingFailure.error,
-      });
-    }
+  } else if (input.requireExecutionIdentity) {
+    evidenceFailure = {
+      errorClass: 'missing_execution_identity',
+      error: 'Timed-out Harbor attempt did not produce execution identity attestation',
+    };
   }
+  const evidenceStatus = evidenceFailure
+    ? 'unverified'
+    : artifactRefs.cellOutput
+      ? 'verified'
+      : 'not_required';
   return {
     schemaVersion: FIXED_PROMPT_WAL_SCHEMA_VERSION,
     type: 'task_budget_exhausted',
@@ -875,9 +853,14 @@ function taskBudgetExhaustedEvent(input: {
     status: 'budget_exhausted',
     passed: false,
     scored: false,
-    eligible: true,
+    eligible: evidenceFailure === undefined,
     errorClass: 'budget_exhausted',
     error: errorMessage(input.error),
+    evidenceStatus,
+    ...(evidenceFailure ? {
+      evidenceErrorClass: evidenceFailure.errorClass,
+      evidenceError: evidenceFailure.error,
+    } : {}),
     expectedPromptHash: input.expectedPromptHash,
     ...(artifactRefs.runtimeEventsPath ? { runtimeEventsPath: artifactRefs.runtimeEventsPath } : {}),
     ...(artifactRefs.traceEventsPath ? { traceEventsPath: artifactRefs.traceEventsPath } : {}),

--- a/packages/headless/src/prompt-structural-smoke.ts
+++ b/packages/headless/src/prompt-structural-smoke.ts
@@ -70,7 +70,7 @@ export function promptStructuralSmokeReport(
     : [];
   const quarantineCount = decisionEvents.filter((event) => isQuarantineDecision(event)).length;
   const totalCostUsd = roundCost(sum(taskEvents.map((event) => (
-    event.type === 'task_completed' || event.type === 'task_plumbing_failed' ? event.tokenSummary?.costUsd ?? 0 : 0
+    'tokenSummary' in event ? event.tokenSummary?.costUsd ?? 0 : 0
   ))));
   const failures: PromptStructuralSmokeFailure[] = [];
   if (observedRounds < minimumRounds) failures.push('minimum_rounds_not_met');


### PR DESCRIPTION
## Summary

- Preserve Harbor timeouts as `task_budget_exhausted`, regardless of execution-evidence availability.
- Record evidence verification separately from the terminal outcome.
- Exclude unverified timeout attempts from valid A/B coverage while retaining their true budget outcome.

## Why

A Terminal-Bench task that reached its configured agent timeout was incorrectly rewritten as `task_plumbing_failed` when the final execution identity artifact was unavailable. Timeout outcome and evidence validity are separate facts and should be recorded independently.

## Scope

Changed:

- Fixed-prompt timeout WAL projection.
- A/B valid-coverage filtering.
- Regression coverage for missing, mismatched, and verified timeout evidence.

Not included:

- Changes to timeout duration.
- Historical WAL rewriting.
- Benchmark task reruns.

## Verification

- `npm run -w @maka/headless test`
  - 765 tests, 764 passed, 1 existing skip.
- `npm run typecheck`
- Targeted timeout and A/B coverage regression tests.

## User-facing impact

None. No UI, migration, documentation, or changelog changes.

## Reviewer notes

The review boundary is the separation between terminal outcome and evidence validity:

- Every timeout remains `task_budget_exhausted`.
- Missing or mismatched evidence sets `eligible: false`.
- Verified timeout evidence remains eligible.
- New evidence fields are optional for legacy WAL compatibility.

## Checklist

- [x] Scope matches the PR title and excludes unrelated changes
- [x] Verification lists commands and results
- [x] User-facing impact and migrations are marked none
- [x] Risk and review focus are documented
- [x] UI evidence is not applicable
