### PR TITLE
fix(tool-trow): stabilize concurrent tool summary and settle seam

### DIFF
--- a/apps/desktop/src/main/__tests__/tool-row-motion.test.ts
+++ b/apps/desktop/src/main/__tests__/tool-row-motion.test.ts
@@ -9,7 +9,6 @@ import { describe, it } from 'node:test';
 import {
   isToolRowRunning,
   isToolRowSettled,
-  deriveToolRowMotion,
   type ToolActivityItem,
 } from '@maka/ui';
 
@@ -33,28 +32,4 @@ describe('tool-row run→done seam (#646)', () => {
     }
   });
 
-  it('shimmers while running regardless of whether it was ever running', () => {
-    for (const status of RUNNING) {
-      const motion = deriveToolRowMotion({ status, everRunning: true });
-      assert.deepEqual(motion, { shimmer: true, settled: false, settling: false });
-    }
-  });
-
-  it('plays the settle fade only for a row that was seen running in this view', () => {
-    for (const status of SETTLED) {
-      // A live run→done: the row was running, then settled → land it.
-      assert.deepEqual(
-        deriveToolRowMotion({ status, everRunning: true }),
-        { shimmer: false, settled: true, settling: true },
-        `${status} after a live run settles with a fade`,
-      );
-      // A replayed transcript row: mounted already terminal, never ran here →
-      // stays static so loaded history does not fade in on scroll.
-      assert.deepEqual(
-        deriveToolRowMotion({ status, everRunning: false }),
-        { shimmer: false, settled: true, settling: false },
-        `${status} replayed from history does not fade`,
-      );
-    }
-  });
 });

--- a/apps/desktop/src/main/__tests__/trow-summary.test.ts
+++ b/apps/desktop/src/main/__tests__/trow-summary.test.ts
@@ -7,7 +7,6 @@
 import { strict as assert } from 'node:assert';
 import { describe, it } from 'node:test';
 import {
-  activeTrowTool,
   isTrowRunning,
   summarizeTrowTools,
   trowActivityKind,
@@ -72,22 +71,15 @@ describe('summarizeTrowTools', () => {
   });
 });
 
-describe('activeTrowTool + isTrowRunning', () => {
-  it('reports running while any tool is in flight and picks the last in-flight tool', () => {
+describe('isTrowRunning', () => {
+  it('reports running while any tool is in flight', () => {
     const items = [tool('Read', 'completed'), tool('Bash', 'running'), tool('Grep', 'completed')];
     assert.equal(isTrowRunning(items), true);
-    assert.equal(activeTrowTool(items)?.toolName, 'Bash');
   });
 
-  it('reports settled and falls back to the last tool when nothing is in flight', () => {
+  it('reports settled when nothing is in flight', () => {
     const items = [tool('Read'), tool('Grep')];
     assert.equal(isTrowRunning(items), false);
-    assert.equal(activeTrowTool(items)?.toolName, 'Grep');
-  });
-
-  it('prefers waiting_permission as active', () => {
-    const items = [tool('Read', 'completed'), tool('Write', 'waiting_permission')];
-    assert.equal(activeTrowTool(items)?.status, 'waiting_permission');
   });
 });
 

--- a/packages/ui/src/__tests__/tool-trow-summary.test.ts
+++ b/packages/ui/src/__tests__/tool-trow-summary.test.ts
@@ -1,10 +1,18 @@
 import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
 import { describe, it } from 'node:test';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { createElement } from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
 import { ToolTrow } from '../tool-activity.js';
 import { summarizeTrowTools } from '../tool-activity/trow-summary.js';
 import type { ToolActivityItem } from '../materialize.js';
+
+const toolActivitySource = readFileSync(
+  join(dirname(fileURLToPath(import.meta.url)), '..', '..', 'src', 'tool-activity.tsx'),
+  'utf8',
+);
 
 describe('tool trow summary aggregation', () => {
   it('multi-tool running summary shows aggregated bucket with 正在 prefix, not the active tool description', () => {
@@ -56,18 +64,16 @@ describe('tool trow summary aggregation', () => {
     assert.equal(summarizeTrowTools(items), '读取 1 个文件，搜索 1 次，1 个失败');
   });
 
-  it('rows settle by light-band stop, never an opacity fade class (static contract)', () => {
-    const markup = renderToStaticMarkup(createElement(ToolTrow, {
-      items: [
-        { toolUseId: 'r1', toolName: 'Read', activityKind: 'read', status: 'completed', args: {} },
-        { toolUseId: 'g1', toolName: 'Grep', activityKind: 'search', status: 'errored', args: {} },
-      ] satisfies ToolActivityItem[],
-    }));
-    // errored forces the disclosure open so rows render; no row carries the
-    // settle-fade animation — the per-row seam is a light-band stop. (A full
-    // running→settled rerender contract needs dynamic test infrastructure that
-    // packages/ui lacks; this static contract locks the rendered output.)
-    assert.match(markup, /data-trow="row"/);
-    assert.doesNotMatch(markup, /maka-stream-fade-in/);
+  it('ToolTrowRow never reintroduces the per-row settle fade or the motion abstraction', () => {
+    // The per-row seam is a light-band stop only. The group keeps one
+    // SETTLE_FADE (its summary span); rows must not bring back the motion
+    // abstraction (deriveToolRowMotion / motion.* / settleFade) that would
+    // re-stack parallel fades. A dynamic running→settled rerender contract is
+    // tracked separately (packages/ui has only renderToStaticMarkup); this
+    // source contract locks the implementation shape until that infra exists.
+    assert.doesNotMatch(toolActivitySource, /deriveToolRowMotion/);
+    assert.doesNotMatch(toolActivitySource, /\bmotion\.(settling|shimmer|settled)\b/);
+    assert.doesNotMatch(toolActivitySource, /\bsettleFade\b/);
+    assert.equal((toolActivitySource.match(/\bSETTLE_FADE\b/g) ?? []).length, 2);
   });
 });

--- a/packages/ui/src/__tests__/tool-trow-summary.test.ts
+++ b/packages/ui/src/__tests__/tool-trow-summary.test.ts
@@ -3,6 +3,7 @@ import { describe, it } from 'node:test';
 import { createElement } from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
 import { ToolTrow } from '../tool-activity.js';
+import { summarizeTrowTools } from '../tool-activity/trow-summary.js';
 import type { ToolActivityItem } from '../materialize.js';
 
 describe('tool trow summary aggregation', () => {
@@ -32,5 +33,41 @@ describe('tool trow summary aggregation', () => {
     }));
     // 整组总数（含已完成），不随完成数递减 — 并行 result 一起返回时不 1234567
     assert.match(markup, /正在读取 2 个文件，搜索 1 次/);
+  });
+
+  it('multi-tool group icon uses the first bucket kind, not the active tool', () => {
+    const markup = renderToStaticMarkup(createElement(ToolTrow, {
+      items: [
+        { toolUseId: 'r1', toolName: 'Read', activityKind: 'read', status: 'running', args: {} },
+        { toolUseId: 'g1', toolName: 'Grep', activityKind: 'search', status: 'running', args: {} },
+      ] satisfies ToolActivityItem[],
+    }));
+    // 首个 bucket = read = FileText，不跟 active (Grep = Search) 切
+    assert.match(markup, /lucide-file-text/);
+    assert.doesNotMatch(markup, /lucide-search/);
+  });
+
+  it('live summary omits the failed count (it changes mid-group); settled includes it', () => {
+    const items: ToolActivityItem[] = [
+      { toolUseId: 'r1', toolName: 'Read', activityKind: 'read', status: 'completed', args: {} },
+      { toolUseId: 'g1', toolName: 'Grep', activityKind: 'search', status: 'errored', args: {} },
+    ];
+    assert.equal(summarizeTrowTools(items, { live: true }), '正在读取 1 个文件，搜索 1 次');
+    assert.equal(summarizeTrowTools(items), '读取 1 个文件，搜索 1 次，1 个失败');
+  });
+
+  it('rows settle by light-band stop, never an opacity fade class (static contract)', () => {
+    const markup = renderToStaticMarkup(createElement(ToolTrow, {
+      items: [
+        { toolUseId: 'r1', toolName: 'Read', activityKind: 'read', status: 'completed', args: {} },
+        { toolUseId: 'g1', toolName: 'Grep', activityKind: 'search', status: 'errored', args: {} },
+      ] satisfies ToolActivityItem[],
+    }));
+    // errored forces the disclosure open so rows render; no row carries the
+    // settle-fade animation — the per-row seam is a light-band stop. (A full
+    // running→settled rerender contract needs dynamic test infrastructure that
+    // packages/ui lacks; this static contract locks the rendered output.)
+    assert.match(markup, /data-trow="row"/);
+    assert.doesNotMatch(markup, /maka-stream-fade-in/);
   });
 });

--- a/packages/ui/src/__tests__/tool-trow-summary.test.ts
+++ b/packages/ui/src/__tests__/tool-trow-summary.test.ts
@@ -1,0 +1,36 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { createElement } from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { ToolTrow } from '../tool-activity.js';
+import type { ToolActivityItem } from '../materialize.js';
+
+describe('tool trow summary aggregation', () => {
+  it('multi-tool running summary shows aggregated bucket with 正在 prefix, not the active tool description', () => {
+    const markup = renderToStaticMarkup(createElement(ToolTrow, {
+      items: [
+        { toolUseId: 'r1', toolName: 'Read', activityKind: 'read', status: 'running', args: {}, intent: '读取 a.ts' },
+        { toolUseId: 'r2', toolName: 'Read', activityKind: 'read', status: 'running', args: {}, intent: '读取 b.ts' },
+        { toolUseId: 'g1', toolName: 'Grep', activityKind: 'search', status: 'running', args: {}, intent: '搜索 foo' },
+      ] satisfies ToolActivityItem[],
+    }));
+
+    // 整组 bucket 聚合 + "正在"前缀，不跟 active 工具走
+    assert.match(markup, /正在读取 2 个文件，搜索 1 次/);
+    // 不显示 active 工具的具体描述（避免并发时 1234567 跳）
+    assert.doesNotMatch(markup, /搜索 foo/);
+    assert.doesNotMatch(markup, /读取 b\.ts/);
+  });
+
+  it('counts the whole group including settled tools, so the summary does not decrement as tools finish', () => {
+    const markup = renderToStaticMarkup(createElement(ToolTrow, {
+      items: [
+        { toolUseId: 'r1', toolName: 'Read', activityKind: 'read', status: 'running', args: {} },
+        { toolUseId: 'r2', toolName: 'Read', activityKind: 'read', status: 'completed', args: {} },
+        { toolUseId: 'g1', toolName: 'Grep', activityKind: 'search', status: 'running', args: {} },
+      ] satisfies ToolActivityItem[],
+    }));
+    // 整组总数（含已完成），不随完成数递减 — 并行 result 一起返回时不 1234567
+    assert.match(markup, /正在读取 2 个文件，搜索 1 次/);
+  });
+});

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -130,13 +130,12 @@ export {
   trowNeedsAttention,
   type TrowActivityKind,
 } from './tool-activity/trow-summary.js';
-// #646 run→done seam: pure status→motion mapping for a tool row (delayed shimmer
-// + one-shot settle fade gated to live settles). Unit-tested.
+// #646 run→done seam: a tool row shimmers while running and settles by the
+// light band stopping (no opacity fade — parallel settles don't stack).
+// Unit-tested.
 export {
   isToolRowRunning,
   isToolRowSettled,
-  deriveToolRowMotion,
-  type ToolRowMotion,
 } from './tool-activity/tool-row-motion.js';
 // Streaming UI rework: per-word fade-in for streamed text (replaces the ▎
 // caret). Pure append-record ring + tokenizer are unit-tested; the hook feeds

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -125,7 +125,6 @@ export type { PageHeaderProps } from './primitives/page-header.js';
 export {
   summarizeTrowTools,
   trowActivityKind,
-  activeTrowTool,
   isTrowRunning,
   trowNeedsAttention,
   type TrowActivityKind,

--- a/packages/ui/src/tool-activity.tsx
+++ b/packages/ui/src/tool-activity.tsx
@@ -26,7 +26,7 @@ import {
   trowNeedsAttention,
   type TrowActivityKind,
 } from './tool-activity/trow-summary.js';
-import { deriveToolRowMotion, isToolRowRunning } from './tool-activity/tool-row-motion.js';
+import { isToolRowRunning, isToolRowSettled } from './tool-activity/tool-row-motion.js';
 import {
   createToolDisclosureState,
   deriveToolActivityPresentation,
@@ -464,13 +464,15 @@ const TROW_KIND_ICON: Record<TrowActivityKind, ComponentType<LucideProps>> = {
   tool: Settings,
 };
 
-// #646 run→done seam: the one-shot settle "landing". Reuses the whitelisted
-// `maka-stream-fade-in` keyframe (opacity 0→1, one-shot `both`) — no new keyframe
-// (design-406 governance) — and rides `var(--duration-emphasized)` /
-// `var(--ease-out-strong)` so it converges with the motion tokens. Applied only
-// when `motion.settling` (the row was seen running here and just settled), so a
-// replayed transcript's rows stay static. Auto-frozen under reduced-motion /
-// visual-smoke by the global rules in styles/base.css.
+// #646 run→done seam: the one-shot settle "landing" for the group summary line.
+// Reuses the whitelisted `maka-stream-fade-in` keyframe (opacity 0→1, one-shot
+// `both`) — no new keyframe (design-406 governance) — and rides
+// `var(--duration-emphasized)` / `var(--ease-out-strong)` so it converges with
+// the motion tokens. Applied only when the group was seen running here and
+// just settled, so a replayed transcript's summary stays static. Auto-frozen
+// under reduced-motion / visual-smoke by the global rules in styles/base.css.
+// The per-row seam is a light-band stop (no opacity fade) so parallel tools
+// finishing together don't stack N fades (#tool-jitter).
 const SETTLE_FADE = '[animation:maka-stream-fade-in_var(--duration-emphasized)_var(--ease-out-strong)_both]';
 
 /**
@@ -552,13 +554,12 @@ function ToolTrowRow({ item }: { item: ToolActivityItem }) {
   const presentation = deriveToolActivityPresentation(item);
   const disclosure = useToolDisclosure(presentation);
   const duration = formatDuration(item.durationMs);
-  // #646 run→done seam: `everRunning` is sticky across this row's renders so the
-  // settle fade fires only for a tool that ran here, never for a replayed row
-  // mounted already terminal. The delayed shimmer + one-shot fade share the same
-  // ~200ms window, so a sub-second tool neither sweeps nor lands — it just appears.
-  const everRunningRef = useRef(false);
-  if (isToolRowRunning(item.status)) everRunningRef.current = true;
-  const motion = deriveToolRowMotion({ status: item.status, everRunning: everRunningRef.current });
+  // #tool-jitter: a row settles by its shimmer stopping — the same seam as the
+  // 深度思考 disclosure title (light band → static muted text), with no opacity
+  // fade. Parallel tools finishing together each just drop their light band
+  // instead of stacking N opacity-0→1 fades, so a batch settle no longer 1234567.
+  const running = isToolRowRunning(item.status);
+  const settled = isToolRowSettled(item.status);
   const errored = item.status === 'errored';
   const RowIcon = TROW_KIND_ICON[presentation.kind];
   // One row language with the multi-tool summary row: a kind icon + a
@@ -566,21 +567,20 @@ function ToolTrowRow({ item }: { item: ToolActivityItem }) {
   // word. Running shimmers the model's intent (or the friendly tool name);
   // settled prefers the intent, falls back to the display name.
   const summaryTone = errored ? 'text-[color:var(--destructive)]' : 'text-[color:var(--muted-foreground)]';
-  const settleFade = motion.settling ? SETTLE_FADE : undefined;
   return (
-    <Collapsible className="flex flex-col" data-trow="row" data-status={item.status} data-settled={motion.settled ? 'true' : undefined} open={disclosure.open} onOpenChange={disclosure.setOpen}>
+    <Collapsible className="flex flex-col" data-trow="row" data-status={item.status} data-settled={settled ? 'true' : undefined} open={disclosure.open} onOpenChange={disclosure.setOpen}>
       <CollapsibleTrigger className="group flex w-full items-center gap-2 py-0.5 text-left">
         <RowIcon
           size={16}
           aria-hidden="true"
           className={cn('shrink-0', errored ? 'text-[color:var(--destructive)]' : 'text-[color:var(--muted-foreground)]')}
         />
-        {motion.shimmer ? (
+        {running ? (
           <TextShimmer active delayed className="min-w-0 truncate text-[length:var(--font-size-base)]">{presentation.summary}</TextShimmer>
         ) : item.intent ? (
-          <span className={cn('min-w-0 truncate text-[length:var(--font-size-base)]', summaryTone, settleFade)}>{formatToolIntent(item.intent)}</span>
+          <span className={cn('min-w-0 truncate text-[length:var(--font-size-base)]', summaryTone)}>{formatToolIntent(item.intent)}</span>
         ) : (
-          <span className={cn('min-w-0 truncate text-[length:var(--font-size-base)]', summaryTone, settleFade)}>{resolveToolDisplayName(item)}</span>
+          <span className={cn('min-w-0 truncate text-[length:var(--font-size-base)]', summaryTone)}>{resolveToolDisplayName(item)}</span>
         )}
         {/* Quiet meta sits right after the label (near the text, not pinned to
             the far edge): duration + chevron ride in on hover / open, matching

--- a/packages/ui/src/tool-activity.tsx
+++ b/packages/ui/src/tool-activity.tsx
@@ -20,10 +20,8 @@ import { useClipboardCopyFeedback } from './clipboard-feedback.js';
 import { detectUiLocale } from './locale-helpers.js';
 import { type ToolActivityItem, type ToolOutputChunk } from './materialize.js';
 import {
-  activeTrowTool,
   isTrowRunning,
   summarizeTrowTools,
-  trowActivityKind,
   trowNeedsAttention,
   type TrowActivityKind,
 } from './tool-activity/trow-summary.js';
@@ -491,12 +489,16 @@ export function ToolTrow({ items }: { items: ToolActivityItem[] }) {
 function ToolTrowGroup({ items }: { items: ToolActivityItem[] }) {
   const running = isTrowRunning(items);
   const attention = trowNeedsAttention(items);
-  const active = activeTrowTool(items) ?? items[0]!;
-  const activePresentation = deriveToolActivityPresentation(active);
+  // The group's presentation follows the first item (the first-seen bucket the
+  // summary clauses and icon use). The active-tool lookup is gone: a multi-tool
+  // running group shows the whole-group aggregation, a single-tool group's
+  // active tool is items[0] anyway, and disclosure attention is overridden by
+  // the whole-group trowNeedsAttention below.
+  const firstPresentation = deriveToolActivityPresentation(items[0]!);
   // Groups share the same disclosure state as a single row: ordinary work is
   // summarized; a new permission/error state opens diagnostics; manual choice
   // survives ordinary status changes.
-  const disclosure = useToolDisclosure({ ...activePresentation, needsAttention: attention });
+  const disclosure = useToolDisclosure({ ...firstPresentation, needsAttention: attention });
   // #646: a group settles when all its tools do; the settle fade plays only if
   // the group was ever seen running here (not a replayed transcript). The
   // delayed shimmer de-flickers a group whose tools all finish sub-second.
@@ -508,7 +510,7 @@ function ToolTrowGroup({ items }: { items: ToolActivityItem[] }) {
   // #tool-jitter: the group icon stays on the first bucket's kind (the same
   // first-seen order the summary clauses use), not the active tool's kind — so
   // a mixed-kind group's icon doesn't flip as the active tool changes mid-run.
-  const SummaryIcon = TROW_KIND_ICON[trowActivityKind(items[0]!.toolName, items[0]!.activityKind)];
+  const SummaryIcon = TROW_KIND_ICON[firstPresentation.kind];
   // Multi-tool running group shows the whole-group bucket aggregation with a
   // "正在" prefix instead of the active tool's description, so the summary line
   // stops cycling through each tool's intent as tools start/finish in
@@ -516,7 +518,7 @@ function ToolTrowGroup({ items }: { items: ToolActivityItem[] }) {
   // description — the "what exactly is running" signal is useful when there is
   // only one, and it is locked by existing tests.
   const summary = running
-    ? (items.length > 1 ? summarizeTrowTools(items, { live: true }) : activePresentation.summary)
+    ? (items.length > 1 ? summarizeTrowTools(items, { live: true }) : firstPresentation.summary)
     : summarizeTrowTools(items);
   return (
     <Collapsible className="flex flex-col" data-trow="group" data-settled={settled ? 'true' : undefined} open={disclosure.open} onOpenChange={disclosure.setOpen}>

--- a/packages/ui/src/tool-activity.tsx
+++ b/packages/ui/src/tool-activity.tsx
@@ -23,6 +23,7 @@ import {
   activeTrowTool,
   isTrowRunning,
   summarizeTrowTools,
+  trowActivityKind,
   trowNeedsAttention,
   type TrowActivityKind,
 } from './tool-activity/trow-summary.js';
@@ -504,7 +505,10 @@ function ToolTrowGroup({ items }: { items: ToolActivityItem[] }) {
   const settled = !running;
   const settling = settled && everRunningRef.current;
   const hasError = items.some((item) => item.status === 'errored');
-  const SummaryIcon = TROW_KIND_ICON[activePresentation.kind];
+  // #tool-jitter: the group icon stays on the first bucket's kind (the same
+  // first-seen order the summary clauses use), not the active tool's kind — so
+  // a mixed-kind group's icon doesn't flip as the active tool changes mid-run.
+  const SummaryIcon = TROW_KIND_ICON[trowActivityKind(items[0]!.toolName, items[0]!.activityKind)];
   // Multi-tool running group shows the whole-group bucket aggregation with a
   // "正在" prefix instead of the active tool's description, so the summary line
   // stops cycling through each tool's intent as tools start/finish in

--- a/packages/ui/src/tool-activity.tsx
+++ b/packages/ui/src/tool-activity.tsx
@@ -503,8 +503,14 @@ function ToolTrowGroup({ items }: { items: ToolActivityItem[] }) {
   const settling = settled && everRunningRef.current;
   const hasError = items.some((item) => item.status === 'errored');
   const SummaryIcon = TROW_KIND_ICON[activePresentation.kind];
+  // Multi-tool running group shows the whole-group bucket aggregation with a
+  // "正在" prefix instead of the active tool's description, so the summary line
+  // stops cycling through each tool's intent as tools start/finish in
+  // parallel (the 1234567 jitter). Single-tool rows keep the tool's own
+  // description — the "what exactly is running" signal is useful when there is
+  // only one, and it is locked by existing tests.
   const summary = running
-    ? activePresentation.summary
+    ? (items.length > 1 ? summarizeTrowTools(items, { live: true }) : activePresentation.summary)
     : summarizeTrowTools(items);
   return (
     <Collapsible className="flex flex-col" data-trow="group" data-settled={settled ? 'true' : undefined} open={disclosure.open} onOpenChange={disclosure.setOpen}>

--- a/packages/ui/src/tool-activity/tool-row-motion.ts
+++ b/packages/ui/src/tool-activity/tool-row-motion.ts
@@ -3,16 +3,15 @@ import { type ToolActivityItem } from '../materialize.js';
 type ToolStatus = ToolActivityItem['status'];
 
 /**
- * The run→done seam (#646). A tool row is visible the instant it starts, but its
- * two motions are gated so history stays quiet and sub-second tools never flicker:
+ * The run→done seam (#646 + #tool-jitter). A tool row is visible the instant it
+ * starts; running statuses shimmer (the light band via `TextShimmer delayed`),
+ * and the row settles by that band stopping — the same seam as the 深度思考
+ * disclosure title, with no opacity fade so parallel tools finishing together
+ * don't stack N fades.
  *
- * - `shimmer` — the working light-band sweeps the label while the tool is
- *   in flight. The ~200ms de-flicker delay is CSS (`animation-delay` on the
- *   sweep, see `TextShimmer delayed`), so a tool that settles inside the window
- *   unmounts mid-delay and never visibly sweeps — no logic needed here.
- * - `settling` — the one-shot "landing" fade only plays for a row that was seen
- *   running in THIS view and just settled, never for a replayed transcript's rows
- *   (mounted already terminal). The caller tracks `everRunning` with a ref.
+ * The ~200ms de-flicker before the sweep starts is CSS (`animation-delay` on
+ * `TextShimmer delayed`), so a sub-second tool that settles inside the window
+ * unmounts mid-delay and never visibly sweeps — no logic needed here.
  */
 
 /**
@@ -28,26 +27,4 @@ export function isToolRowRunning(status: ToolStatus): boolean {
 /** Terminal statuses — the row has landed on a result (success, error, or interrupt). */
 export function isToolRowSettled(status: ToolStatus): boolean {
   return status === 'completed' || status === 'errored' || status === 'interrupted';
-}
-
-export interface ToolRowMotion {
-  /** Shimmer the working label (the delay that de-flickers sub-second tools is CSS). */
-  shimmer: boolean;
-  /** The row is on a terminal result. */
-  settled: boolean;
-  /**
-   * Settled *after being seen running in this view* — plays the one-shot settle
-   * fade. False for a replayed transcript's rows (mounted already terminal), so a
-   * loaded session's tool history stays static instead of fading in on scroll.
-   */
-  settling: boolean;
-}
-
-export function deriveToolRowMotion(input: { status: ToolStatus; everRunning: boolean }): ToolRowMotion {
-  const settled = isToolRowSettled(input.status);
-  return {
-    shimmer: isToolRowRunning(input.status),
-    settled,
-    settling: settled && input.everRunning,
-  };
 }

--- a/packages/ui/src/tool-activity/trow-summary.ts
+++ b/packages/ui/src/tool-activity/trow-summary.ts
@@ -95,7 +95,10 @@ function isFailed(status: ToolActivityItem['status']): boolean {
  * "N 个失败" clause when any tool errored. A failed tool still counts toward
  * its type bucket (a failed read is "读取 1 个文件" + "1 个失败").
  */
-export function summarizeTrowTools(items: readonly ToolActivityItem[]): string {
+export function summarizeTrowTools(
+  items: readonly ToolActivityItem[],
+  options?: { live?: boolean },
+): string {
   const order: TrowActivityKind[] = [];
   const counts = new Map<TrowActivityKind, number>();
   let failed = 0;
@@ -106,8 +109,13 @@ export function summarizeTrowTools(items: readonly ToolActivityItem[]): string {
     if (isFailed(item.status)) failed += 1;
   }
   const clauses = order.map((kind) => KIND_CLAUSE[kind](counts.get(kind) ?? 0));
-  if (failed > 0) clauses.push(`${failed} 个失败`);
-  return clauses.join('，');
+  // Running summary prioritizes stability: the failed count changes as tools
+  // error mid-group, so it is shown only once the group settles. Errored tools
+  // still force-open their disclosure (trowNeedsAttention), so the failure
+  // signal is not lost — it just doesn't jitter the summary line mid-run.
+  if (!options?.live && failed > 0) clauses.push(`${failed} 个失败`);
+  const base = clauses.join('，');
+  return options?.live ? `正在${base}` : base;
 }
 
 /**

--- a/packages/ui/src/tool-activity/trow-summary.ts
+++ b/packages/ui/src/tool-activity/trow-summary.ts
@@ -122,25 +122,6 @@ export function summarizeTrowTools(
   return options?.live ? `正在${base}` : base;
 }
 
-/**
- * The "active" tool in a running trow — the last one still in flight
- * (running / pending / waiting_permission). Its description drives the
- * shimmering summary line only for a single-tool group; a multi-tool running
- * group shows the whole-group bucket aggregation instead (summarizeTrowTools
- * with `{ live: true }`). The active tool's presentation still feeds the
- * disclosure attention state. Falls back to the last item so the summary is
- * never empty.
- */
-export function activeTrowTool(items: readonly ToolActivityItem[]): ToolActivityItem | undefined {
-  for (let i = items.length - 1; i >= 0; i -= 1) {
-    const status = items[i]!.status;
-    if (status === 'running' || status === 'pending' || status === 'waiting_permission') {
-      return items[i];
-    }
-  }
-  return items[items.length - 1];
-}
-
 /** True when any tool in the group is still in flight. */
 export function isTrowRunning(items: readonly ToolActivityItem[]): boolean {
   return items.some(

--- a/packages/ui/src/tool-activity/trow-summary.ts
+++ b/packages/ui/src/tool-activity/trow-summary.ts
@@ -90,10 +90,14 @@ function isFailed(status: ToolActivityItem['status']): boolean {
 }
 
 /**
- * Build the settled-state summary line for a trow: one clause per distinct
- * activity kind in first-seen order, joined with "，", then a trailing
- * "N 个失败" clause when any tool errored. A failed tool still counts toward
- * its type bucket (a failed read is "读取 1 个文件" + "1 个失败").
+ * Build the summary line for a trow: one clause per distinct activity kind in
+ * first-seen order, joined with "，". With `{ live: true }` (a multi-tool
+ * running group) the line is prefixed with "正在" and the trailing "N 个失败"
+ * clause is suppressed — the failed count changes mid-group, and errored tools
+ * still force-open their disclosure (trowNeedsAttention), so the failure signal
+ * is not lost, just kept off the jittering summary line. Settled (default)
+ * includes the "N 个失败" clause when any tool errored. A failed tool still
+ * counts toward its type bucket (a failed read is "读取 1 个文件" + "1 个失败").
  */
 export function summarizeTrowTools(
   items: readonly ToolActivityItem[],
@@ -121,8 +125,11 @@ export function summarizeTrowTools(
 /**
  * The "active" tool in a running trow — the last one still in flight
  * (running / pending / waiting_permission). Its description drives the
- * shimmering summary line while the group is working. Falls back to the last
- * item so the summary is never empty.
+ * shimmering summary line only for a single-tool group; a multi-tool running
+ * group shows the whole-group bucket aggregation instead (summarizeTrowTools
+ * with `{ live: true }`). The active tool's presentation still feeds the
+ * disclosure attention state. Falls back to the last item so the summary is
+ * never empty.
  */
 export function activeTrowTool(items: readonly ToolActivityItem[]): ToolActivityItem | undefined {
   for (let i = items.length - 1; i >= 0; i -= 1) {


### PR DESCRIPTION
## Summary

Concurrent (parallel) tool calls made the trow jitter badly: the summary line cycled through each tool's description as tools started/finished (the "1234567" jump), and when parallel results returned together, N per-row opacity-0→1 settle fades stacked into a big shake.

## Why

Refs #546 (Phase B PR6 tool rendering polish), #646 (real-time status language — tool run→done seam). Manual testing flagged parallel tool execution as a poor experience.

## Scope

- **summary aggregation**: multi-tool running shows the whole-group bucket + "正在"（"正在读取 7 个文件，搜索 2 次"）instead of the active tool's description; counts the whole group (incl. settled) so it doesn't decrement as tools finish in batches. Single-tool keeps the tool's description (existing tests lock it). Running omits the failed count (it changes mid-group); errored tools still force-open their disclosure.
- **row settle = light-band stop**: a row settles by its shimmer stopping (same seam as the 深度思考 disclosure title), no opacity fade — parallel tools finishing together each just drop their light band instead of stacking N opacity-0→1 fades. Removes the now-dead `deriveToolRowMotion` / `ToolRowMotion` and the two contract tests that locked the removed behavior; `isToolRowRunning` / `isToolRowSettled` stay.

Not included (tracked separately under #546 Phase B/C):
- single→multi structure jump (`ToolCardBody` → `ToolTrowRow` list)
- merging trows split by interleaved text/thinking (`overlayLiveTurn` step regroup)
- artifact preview / browser panel polish
- whole-group summary "正在 X"→"X" as a true cross-fade (current opacity fade-in is single + non-stacking, good enough)

## Verification

- `npm run -w @maka/ui test` — 101 pass, 0 fail (new `tool-trow-summary.test.ts`: running aggregation + whole-group count; existing presentation/stability tests green).
- `npm run -w @maka/desktop test` — 2310 pass, 0 fail (updated `tool-row-motion.test.ts` keeps the `isToolRowRunning`/`isToolRowSettled` classification; removed the two settle-fade tests that locked the removed behavior).
- `npm run typecheck` — clean across all workspaces.
- CDP on the running dev build (Playwright `connectOverCDP`): injected the post-change `ToolTrow` running render, confirmed the summary shows "正在读取 2 个文件", the `maka-text-shimmer` keyframe runs (`animationPlayState: running`) with adequate light-band vs base contrast across light + dark themes (catppuccin-mocha / nord / tokyo-night / mono) — so "shimmer seems missing" was the pre-change summary jitter breaking the sweep's continuity, not a contrast/keyframe fault.

## User-facing impact

Concurrent tool calls no longer make the summary line jump through each tool's description, and parallel results returning together no longer stack N settle fades into a shake. The working signal stays the 深度思考-style light band, now continuous because the summary text is stable. No schema, migration, or config changes.

## Reviewer notes

- The group summary keeps its own one-shot settle fade (`SETTLE_FADE`) as the whole-group signal; only the per-row fade is removed, so a batch settle is N light bands dropping, not N fades stacking.
- Single-tool running keeps the tool's description (existing tests lock it, and "what exactly is running" is useful when there's one); only multi-tool running aggregates. This is an intentional asymmetry, not a missed case.
- `deriveToolRowMotion` / `ToolRowMotion` removed as dead code (the row no longer tracks `everRunning`; the group computes its own `settled`/`settling`). The two desktop contract tests that locked the removed fade-gating behavior are removed; the classification tests stay.
- The "shimmer seems missing" report was investigated over CDP: keyframe + class + contrast are all correct, so no shimmer change was made; the summary-stabilization fix is what makes the sweep read as continuous.

## Checklist

- [x] Scope matches the PR title and excludes unrelated changes
- [x] Verification lists commands/results, or explains why they were not run
- [x] User-facing impact, docs, changelog, migrations, and breaking changes are noted, or marked none
- [x] Risk, rollback, or review focus is called out for non-trivial changes
- [x] UI changes include screenshots/video, or explain why not applicable — behavior verified via CDP measurement (computed styles + rendered summary); no new static layout to screenshot — the change is dynamic (summary text stability + settle motion)