### PR TITLE
fix(desktop): fresh sweep on new tip — restraint consistency, bot primary, honest fade

### DIFF
--- a/apps/desktop/src/renderer/settings/bot-chat-settings-page.tsx
+++ b/apps/desktop/src/renderer/settings/bot-chat-settings-page.tsx
@@ -780,8 +780,9 @@ export function BotChatSettingsPage(props: {
             </>
           ) : support === 'runtime' && !selectedStatus?.running ? (
             <Button
+              // One primary per view: 测试并连接 is the form's completion
+              // action — the page previously had no primary at all.
               type="button"
-              variant="secondary"
               disabled={botActionBusy}
               onClick={testAndConnect}
             >

--- a/apps/desktop/src/renderer/styles/onboarding.css
+++ b/apps/desktop/src/renderer/styles/onboarding.css
@@ -229,7 +229,9 @@
   left: var(--border-width-hairline);
   right: var(--border-width-hairline);
   bottom: var(--border-width-hairline);
-  height: 28px;
+  /* 56px: tall enough to fully veil a half-clipped row's text — at 28px the
+     cut row stayed half-legible under the fade and still read as broken. */
+  height: 56px;
   border-radius: 0 0 var(--radius-surface) var(--radius-surface);
   background: linear-gradient(to bottom, oklch(from var(--background-elevated) l c h / 0), var(--background-elevated));
   pointer-events: none;

--- a/packages/ui/src/daily-review-panel.tsx
+++ b/packages/ui/src/daily-review-panel.tsx
@@ -57,7 +57,9 @@ const EMPTY_MODEL_OPTIONS: ReadonlyArray<readonly [string, string]> = [];
 // no_model = the run could not produce a report (destructive). no_data /
 // skipped are expected non-events and stay neutral (exception-only color).
 function dailyReviewArchiveChipTone(status: DailyReviewArchive['status']): ChipProps['variant'] {
-  if (status === 'ok') return 'success';
+  // Status-color restraint (#651 rule): 已生成 is the EXPECTED outcome —
+  // neutral ink, matching 健康 正常 and 权限 已授权. Color stays reserved
+  // for the failures that need attention.
   if (status === 'failed' || status === 'no_model') return 'destructive';
   return 'neutral';
 }


### PR DESCRIPTION
Discovery sweep over today's externally-merged tip (LiteLLM #707, Goal #625, FormatJson #658, tool-row rework #712/#717/#721 — all reviewed clean; the Goal kill-switch pill correctly absorbed the earlier maintainer-review blockers: visible, one-click stoppable, Target icon through the funnel, mode-pill recipe).

Three finds, all fixed and CDP-verified:
1. **每日回顾 已生成 chip was success-green** — expected outcomes are neutral per the #651 restraint rule (健康 正常 / 权限 已授权 precedents); failures keep destructive.
2. **机器人对话 had no primary anywhere** — 测试并连接, the form's completion action, promoted to default.
3. **first-run 28px bottom fade** left the clipped provider row half-legible (still read as broken); 56px fully veils it.

Process note: a JSX syntax error passed the 2309-test suite untouched — the suite never compiles renderer pages; only vite/typecheck catches it. Full `npm run typecheck` added to this round's gate (and worth wiring into CI later).

Desktop 2309/2309 + typecheck + dead-css clean.