### PR TITLE
feat(desktop): OAuth 重新登录 lands in the connection detail — no more expiry dead-end

### DIFF
--- a/apps/desktop/src/main/__tests__/model-oauth-section-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/model-oauth-section-contract.test.ts
@@ -24,6 +24,14 @@ import { readMainProcessCombinedSource } from './main-process-contract-source-he
 
 const REPO_ROOT = resolve(process.cwd(), '..', '..');
 const PRELOAD_SOURCE = resolve(REPO_ROOT, 'apps', 'desktop', 'src', 'preload', 'preload.ts');
+// The browser-loopback login/logout controller was extracted out of
+// SubscriptionLoginModal into this shared hook so the model connection detail
+// sheet's 重新登录 button drives the identical flow. Its internals are pinned
+// here directly (it is not part of the provider settings combined source).
+const OAUTH_LOGIN_FLOW_HOOK_SOURCE = resolve(
+  REPO_ROOT,
+  'apps', 'desktop', 'src', 'renderer', 'settings', 'use-oauth-login-flow.ts',
+);
 
 describe('Model OAuth catalog contract (PR-MODEL-OAUTH-ALL-0 + PR-CLAUDE-CARD-MOVE-0)', () => {
   it('renders OAuth as a catalog tab peer, not a standalone section above the market', async () => {
@@ -1022,100 +1030,108 @@ describe('Model OAuth catalog contract (PR-MODEL-OAUTH-ALL-0 + PR-CLAUDE-CARD-MO
     assert.match(body, /case 'antigravity'[\s\S]*?window\.maka\.antigravitySubscription/);
   });
 
-  it('modal flow calls getAuthUrl → openAuthUrl → completeAuthorization on the bridge', async () => {
-    const src = await readProviderSettingsCombinedSource();
-    const fnMatch = src.match(/async function startLogin\(\)[\s\S]*?\n  \}/);
-    assert.ok(fnMatch, 'startLogin must exist on SubscriptionLoginModal');
+  it('shared login flow calls getAuthUrl → openAuthUrl → completeAuthorization on the bridge', async () => {
+    const hook = await readFile(OAUTH_LOGIN_FLOW_HOOK_SOURCE, 'utf8');
+    const fnMatch = hook.match(/async function startLogin\(\)[\s\S]*?\n  \}/);
+    assert.ok(fnMatch, 'startLogin must exist in the shared useOAuthLoginFlow hook');
     const body = fnMatch[0];
     assert.match(body, /bridge\.getAuthUrl\(\)/);
     assert.match(body, /bridge\.openAuthUrl\(payload\.authRequestId\)/);
     assert.match(body, /bridge\.completeAuthorization\(payload\.authRequestId\)/);
+    // Both the OAuth catalog modal and the connection detail sheet must drive
+    // this one flow rather than re-implementing the browser handoff.
+    const src = await readProviderSettingsCombinedSource();
+    assert.match(src, /const flow = useOAuthLoginFlow\(\{/, 'SubscriptionLoginModal must consume the shared login-flow hook');
   });
 
   it('OAuth login modals surface thrown IPC/service failures instead of leaving console-only rejections', async () => {
     const src = await readProviderSettingsCombinedSource();
-    const helper = src.match(/function subscriptionActionErrorMessage[\s\S]*?async function getSubscriptionSnapshot/)?.[0] ?? '';
+    // Localization helpers + the whole browser-loopback controller now live in
+    // the shared hook; the thin modal only renders from its return.
+    const hook = await readFile(OAUTH_LOGIN_FLOW_HOOK_SOURCE, 'utf8');
     const browserModal = src.match(/function SubscriptionLoginModal[\s\S]*?function ClaudeSubscriptionCard/)?.[0] ?? '';
     const claudeCard = src.match(/function ClaudeSubscriptionCard[\s\S]*?function presentSubscriptionState/)?.[0] ?? '';
 
-    assert.match(helper, /登录服务暂时不可用，请检查网络后重试。/, 'OAuth thrown-error fallback must be user-facing Chinese copy');
-    assert.match(helper, /redactSecrets\(message \?\? ''\)\.trim\(\)/, 'OAuth service messages must be redacted before reaching visible UI');
-    assert.match(helper, /generalizedErrorMessageChinese\(new Error\(raw\), ''\)/, 'OAuth service messages must pass through Chinese error classification');
-    assert.match(helper, /\/\[\\u4e00-\\u9fff\]\/\.test\(raw\)/, 'already-Chinese OAuth diagnostics may be preserved after redaction');
-    assert.match(browserModal, /async function refresh\(\)(?:: Promise<boolean>)?[\s\S]*catch \(error\) \{[\s\S]*toast\.error\('刷新登录状态失败', message\);[\s\S]*setErrorMessage\(message\);/, 'browser OAuth state refresh must surface thrown failures');
-    assert.match(browserModal, /catch \(error\) \{[\s\S]*toast\.error\('登录失败', message\);[\s\S]*setErrorMessage\(message\);/, 'browser OAuth login must toast thrown failures');
-    assert.match(browserModal, /catch \(error\) \{[\s\S]*toast\.error\('退出失败', subscriptionActionErrorMessage\(error\)\);/, 'browser OAuth logout must toast thrown failures');
-    assert.doesNotMatch(browserModal, /toast\.error\('[^']+', (?:payload|opened|result)\.message\)/, 'browser OAuth action envelopes must not toast raw service messages');
-    assert.doesNotMatch(browserModal, /setErrorMessage\((?:payload|opened|result)\.message\)/, 'browser OAuth action envelopes must not render raw service messages');
-    assert.match(browserModal, /subscriptionResultMessage\(payload\.message, '无法开始登录，请稍后再试。'\)/, 'browser OAuth getAuthUrl failures must be localized');
-    assert.match(browserModal, /subscriptionResultMessage\(opened\.message, '无法打开浏览器，请稍后重试。'\)/, 'browser OAuth openAuthUrl failures must be localized');
-    assert.match(browserModal, /subscriptionResultMessage\(result\.message, '登录未完成，请重新打开浏览器授权。'\)/, 'browser OAuth completion failures must be localized');
+    assert.match(hook, /登录服务暂时不可用，请检查网络后重试。/, 'OAuth thrown-error fallback must be user-facing Chinese copy');
+    assert.match(hook, /redactSecrets\(message \?\? ''\)\.trim\(\)/, 'OAuth service messages must be redacted before reaching visible UI');
+    assert.match(hook, /generalizedErrorMessageChinese\(new Error\(raw\), ''\)/, 'OAuth service messages must pass through Chinese error classification');
+    assert.match(hook, /\/\[\\u4e00-\\u9fff\]\/\.test\(raw\)/, 'already-Chinese OAuth diagnostics may be preserved after redaction');
+    assert.match(hook, /async function refresh\(\): Promise<boolean>[\s\S]*catch \(error\) \{[\s\S]*toast\.error\('刷新登录状态失败', message\);[\s\S]*setErrorMessage\(message\);/, 'shared OAuth state refresh must surface thrown failures');
+    assert.match(hook, /catch \(error\) \{[\s\S]*toast\.error\('登录失败', message\);[\s\S]*setErrorMessage\(message\);/, 'shared OAuth login must toast thrown failures');
+    assert.match(hook, /catch \(error\) \{[\s\S]*toast\.error\('退出失败', subscriptionActionErrorMessage\(error\)\);/, 'shared OAuth logout must toast thrown failures');
+    assert.doesNotMatch(hook, /toast\.error\('[^']+', (?:payload|opened|result)\.message\)/, 'shared OAuth action envelopes must not toast raw service messages');
+    assert.doesNotMatch(hook, /setErrorMessage\((?:payload|opened|result)\.message\)/, 'shared OAuth action envelopes must not render raw service messages');
+    assert.match(hook, /subscriptionResultMessage\(payload\.message, '无法开始登录，请稍后再试。'\)/, 'shared OAuth getAuthUrl failures must be localized');
+    assert.match(hook, /subscriptionResultMessage\(opened\.message, '无法打开浏览器，请稍后重试。'\)/, 'shared OAuth openAuthUrl failures must be localized');
+    assert.match(hook, /subscriptionResultMessage\(result\.message, '登录未完成，请重新打开浏览器授权。'\)/, 'shared OAuth completion failures must be localized');
     assert.match(
-      browserModal,
-      /const \[pendingAction, setPendingAction\] = useState<BrowserSubscriptionPendingAction \| null>\(null\)/,
-      'browser OAuth modal needs a named pending action, not a bare boolean',
+      hook,
+      /const \[pendingAction, setPendingAction\] = useState<OAuthLoginPendingAction \| null>\(null\)/,
+      'shared OAuth flow needs a named pending action, not a bare boolean',
     );
     assert.match(
-      browserModal,
-      /const pendingActionRef = useRef<BrowserSubscriptionPendingAction \| null>\(null\)/,
-      'browser OAuth modal must gate one-shot auth actions synchronously through a ref',
+      hook,
+      /const pendingGuard = useRef\(createOneShotActionGuard<OAuthLoginPendingAction>\(\)\)\.current/,
+      'shared OAuth flow must gate one-shot auth actions synchronously through a ref-held guard',
     );
     assert.match(
-      browserModal,
-      /const browserSubscriptionMountedRef = useRef\(false\)/,
-      'browser OAuth modal must own mounted state before writing async feedback',
+      hook,
+      /const oauthLoginFlowMountedRef = useRef\(false\)/,
+      'shared OAuth flow must own mounted state before writing async feedback',
     );
     assert.match(
-      browserModal,
+      hook,
       /const authRequestIdRef = useRef<string \| null>\(null\)/,
-      'browser OAuth modal must keep the pending authorization request in a ref for cleanup',
+      'shared OAuth flow must keep the pending authorization request in a ref for cleanup',
     );
     assert.match(
-      browserModal,
-      /async function refresh\(\): Promise<boolean> \{[\s\S]*const next = \(await bridge\.getAccountState\(\)\) as SubscriptionSnapshot;[\s\S]*if \(!browserSubscriptionMountedRef\.current\) return false;[\s\S]*setState\(next\);[\s\S]*catch \(error\) \{[\s\S]*if \(!browserSubscriptionMountedRef\.current\) return false;[\s\S]*toast\.error\('刷新登录状态失败', message\);[\s\S]*return true;/,
-      'browser OAuth refresh must drop late state/error writes after modal close',
+      hook,
+      /async function refresh\(\): Promise<boolean> \{[\s\S]*const next = \(await bridge\.getAccountState\(\)\) as SubscriptionSnapshot;[\s\S]*if \(!oauthLoginFlowMountedRef\.current\) return false;[\s\S]*setState\(next\);[\s\S]*catch \(error\) \{[\s\S]*if \(!oauthLoginFlowMountedRef\.current\) return false;[\s\S]*toast\.error\('刷新登录状态失败', message\);[\s\S]*return true;/,
+      'shared OAuth refresh must drop late state/error writes after unmount',
     );
     assert.match(
-      browserModal,
-      /useEffect\(\(\) => \{[\s\S]*browserSubscriptionMountedRef\.current = true;[\s\S]*void refresh\(\);[\s\S]*return \(\) => \{[\s\S]*browserSubscriptionMountedRef\.current = false;[\s\S]*pendingActionRef\.current = null;[\s\S]*const pendingAuthRequestId = authRequestIdRef\.current;[\s\S]*authRequestIdRef\.current = null;[\s\S]*if \(pendingAuthRequestId\) void bridge\.cancelAuthorization\(pendingAuthRequestId\);[\s\S]*\};[\s\S]*\}, \[\]\);/,
-      'browser OAuth modal cleanup must invalidate async feedback and cancel pending authorization',
+      hook,
+      /useEffect\(\(\) => \{[\s\S]*oauthLoginFlowMountedRef\.current = true;[\s\S]*void refresh\(\);[\s\S]*return \(\) => \{[\s\S]*oauthLoginFlowMountedRef\.current = false;[\s\S]*pendingGuard\.finish\(\);[\s\S]*teardownPendingAuthorization\(authRequestIdRef, \(id\) => void bridge\.cancelAuthorization\(id\)\);[\s\S]*\};[\s\S]*\}, \[\]\);/,
+      'shared OAuth flow cleanup must invalidate async feedback and cancel pending authorization',
     );
     assert.match(
-      browserModal,
-      /function finishPendingAction\(\) \{[\s\S]*pendingActionRef\.current = null;[\s\S]*if \(browserSubscriptionMountedRef\.current\) setPendingAction\(null\);[\s\S]*\}/,
-      'browser OAuth pending cleanup must not set state after unmount',
+      hook,
+      /function finishPendingAction\(\) \{[\s\S]*pendingGuard\.finish\(\);[\s\S]*if \(oauthLoginFlowMountedRef\.current\) setPendingAction\(null\);[\s\S]*\}/,
+      'shared OAuth pending cleanup must not set state after unmount',
     );
     assert.match(
-      browserModal,
-      /function beginPendingAction\(action: BrowserSubscriptionPendingAction\): boolean \{[\s\S]*if \(pendingActionRef\.current !== null\) return false;[\s\S]*pendingActionRef\.current = action;[\s\S]*setPendingAction\(action\);[\s\S]*return true;/,
-      'browser OAuth duplicate clicks must be rejected before React re-renders disabled buttons',
+      hook,
+      /function beginPendingAction\(action: OAuthLoginPendingAction\): boolean \{[\s\S]*if \(!pendingGuard\.begin\(action\)\) return false;[\s\S]*setPendingAction\(action\);[\s\S]*return true;/,
+      'shared OAuth duplicate clicks must be rejected before React re-renders disabled buttons',
     );
-    assert.match(browserModal, /if \(!beginPendingAction\('login'\)\) return;/, 'browser OAuth login must use the ref-backed action guard');
-    assert.match(browserModal, /if \(!beginPendingAction\('logout'\)\) return;/, 'browser OAuth logout must use the ref-backed action guard');
+    assert.match(hook, /if \(!beginPendingAction\('login'\)\) return;/, 'shared OAuth login must use the ref-backed action guard');
+    assert.match(hook, /if \(!beginPendingAction\('logout'\)\) return;/, 'shared OAuth logout must use the ref-backed action guard');
     assert.match(
-      browserModal,
-      /const payload = await bridge\.getAuthUrl\(\);[\s\S]*authRequestIdRef\.current = payload\.authRequestId;[\s\S]*if \(!browserSubscriptionMountedRef\.current\) \{[\s\S]*authRequestIdRef\.current = null;[\s\S]*void bridge\.cancelAuthorization\(payload\.authRequestId\);[\s\S]*return;[\s\S]*\}[\s\S]*const opened = await bridge\.openAuthUrl\(payload\.authRequestId\);[\s\S]*if \(!browserSubscriptionMountedRef\.current\) return;[\s\S]*const refreshed = await refresh\(\);[\s\S]*if \(!browserSubscriptionMountedRef\.current \|\| !refreshed\) return;[\s\S]*const result = await bridge\.completeAuthorization\(payload\.authRequestId\);[\s\S]*if \(!browserSubscriptionMountedRef\.current\) return;[\s\S]*authRequestIdRef\.current = null;/,
-      'browser OAuth login must stop each async continuation after modal close',
+      hook,
+      /const payload = await bridge\.getAuthUrl\(\);[\s\S]*authRequestIdRef\.current = payload\.authRequestId;[\s\S]*if \(!oauthLoginFlowMountedRef\.current\) \{[\s\S]*authRequestIdRef\.current = null;[\s\S]*void bridge\.cancelAuthorization\(payload\.authRequestId\);[\s\S]*return;[\s\S]*\}[\s\S]*const opened = await bridge\.openAuthUrl\(payload\.authRequestId\);[\s\S]*if \(!oauthLoginFlowMountedRef\.current\) return;[\s\S]*const refreshed = await refresh\(\);[\s\S]*if \(!oauthLoginFlowMountedRef\.current \|\| !refreshed\) return;[\s\S]*const result = await bridge\.completeAuthorization\(payload\.authRequestId\);[\s\S]*if \(!oauthLoginFlowMountedRef\.current\) return;[\s\S]*authRequestIdRef\.current = null;/,
+      'shared OAuth login must stop each async continuation after unmount',
     );
     assert.match(
-      browserModal,
+      hook,
       /if \(!opened\.ok\) \{[\s\S]*void bridge\.cancelAuthorization\(payload\.authRequestId\);[\s\S]*authRequestIdRef\.current = null;[\s\S]*setAuthRequestId\(null\);[\s\S]*setStateHint\(null\);/,
-      'browser OAuth open-browser failures must clear and cancel the pending authorization request',
+      'shared OAuth open-browser failures must clear and cancel the pending authorization request',
     );
     assert.match(
-      browserModal,
+      hook,
       /catch \(error\) \{[\s\S]*const pendingAuthRequestId = authRequestIdRef\.current;[\s\S]*authRequestIdRef\.current = null;[\s\S]*if \(pendingAuthRequestId\) void bridge\.cancelAuthorization\(pendingAuthRequestId\);[\s\S]*setAuthRequestId\(null\);[\s\S]*setStateHint\(null\);/,
-      'browser OAuth thrown login failures must clear and cancel the pending authorization request',
+      'shared OAuth thrown login failures must clear and cancel the pending authorization request',
     );
     assert.match(
-      browserModal,
-      /const result = await bridge\.logout\(\);[\s\S]*if \(!browserSubscriptionMountedRef\.current\) return;[\s\S]*catch \(error\) \{[\s\S]*if \(!browserSubscriptionMountedRef\.current\) return;[\s\S]*toast\.error\('退出失败', subscriptionActionErrorMessage\(error\)\);/,
-      'browser OAuth logout must not toast after modal close',
+      hook,
+      /const result = await bridge\.logout\(\);[\s\S]*if \(!oauthLoginFlowMountedRef\.current\) return;[\s\S]*catch \(error\) \{[\s\S]*if \(!oauthLoginFlowMountedRef\.current\) return;[\s\S]*toast\.error\('退出失败', subscriptionActionErrorMessage\(error\)\);/,
+      'shared OAuth logout must not toast after unmount',
     );
-    assert.match(browserModal, /const actionBusy = pendingAction !== null/, 'browser OAuth modal needs a shared busy flag derived from the named action');
-    assert.match(browserModal, /disabled=\{actionBusy\}/, 'browser OAuth action buttons must disable while another one-shot action is pending');
-    assert.match(browserModal, /pendingAction === 'login' \? '打开浏览器…' : `登录 \$\{display\.shortName\}`/, 'browser OAuth login start must expose specific pending copy');
-    assert.match(browserModal, /pendingAction === 'logout' \? '退出中…' : '退出登录'/, 'browser OAuth logout must expose local progress feedback');
+    assert.match(hook, /const actionBusy = pendingAction !== null/, 'shared OAuth flow needs a shared busy flag derived from the named action');
+    // The thin modal renders login/logout straight from the hook return.
+    assert.match(browserModal, /const flow = useOAuthLoginFlow\(\{/, 'SubscriptionLoginModal must consume the shared login-flow hook');
+    assert.match(browserModal, /disabled=\{flow\.actionBusy\}/, 'browser OAuth action buttons must disable while another one-shot action is pending');
+    assert.match(browserModal, /flow\.pendingAction === 'login' \? '打开浏览器…' : `登录 \$\{display\.shortName\}`/, 'browser OAuth login start must expose specific pending copy');
+    assert.match(browserModal, /flow\.pendingAction === 'logout' \? '退出中…' : '退出登录'/, 'browser OAuth logout must expose local progress feedback');
     assert.match(claudeCard, /const refresh = async \(\) => \{[\s\S]*catch \(error\) \{[\s\S]*toast\.error\('刷新登录状态失败', message\);[\s\S]*setPasteError\(message\);/, 'Claude OAuth state refresh must surface thrown failures');
     assert.match(claudeCard, /settingsErrorText" role="alert"\>\{pasteError\}/, 'Claude OAuth refresh failures must be visible in the modal body');
     assert.match(claudeCard, /catch \(error\) \{[\s\S]*toast\.error\('无法开始登录', message\);[\s\S]*setPasteError\(message\);/, 'Claude OAuth start must toast thrown failures');
@@ -1235,6 +1251,47 @@ describe('Model OAuth catalog contract (PR-MODEL-OAUTH-ALL-0 + PR-CLAUDE-CARD-MO
     );
     assert.match(claudeCard, /pendingAction === 'submit' \? '提交中…' : '提交授权码'/, 'authorization-code submit must expose local progress feedback');
     assert.match(claudeCard, /pendingAction === 'cancel' \? '取消中…' : '取消'/, 'authorization cancel must expose local progress feedback');
+  });
+
+  it('OAuth model connection detail offers an in-sheet 重新登录 action wired to the shared login flow', async () => {
+    const src = await readProviderSettingsCombinedSource();
+    const mapping = src.match(/function oauthLoginServiceFor\(providerType: ProviderType\): OAuthLoginService \| null \{[\s\S]*?\n\}/)?.[0] ?? '';
+    const notice = src.match(/function OAuthReloginNotice\([\s\S]*?\ntype ConnectionDetailSnapshot/)?.[0] ?? '';
+    const detail = src.match(/function ConnectionDetail[\s\S]*?function OAuthReloginNotice/)?.[0] ?? '';
+
+    // Loopback services (Codex, Antigravity) get a bridge; Claude's paste flow
+    // and plain API-key providers fall through to null so the notice renders
+    // prose, never a dead button.
+    assert.match(mapping, /case 'codex-subscription':[\s\S]*window\.maka\.codexSubscription as unknown as OAuthLoginFlowBridge/);
+    assert.match(mapping, /case 'gemini-cli':[\s\S]*window\.maka\.antigravitySubscription as unknown as OAuthLoginFlowBridge/);
+    assert.match(mapping, /default:\s*return null;/);
+    assert.doesNotMatch(mapping, /case 'claude-subscription'/, 'Claude uses a paste-code flow and must not be routed through the one-button loopback hook');
+
+    // The notice drives the shared hook; its onLoginSuccess re-probes the
+    // credential and reloads the connection.
+    assert.match(notice, /const flow = useOAuthLoginFlow\(\{[\s\S]*bridge: props\.service\.bridge,[\s\S]*onLoginSuccess: props\.onRelogin,/);
+    // The button shows in every credential state EXCEPT 'loading'. An expired
+    // token still reads hasSecret===true, so the action must NOT hide behind
+    // hasSecret===false.
+    assert.match(notice, /const loggedIn = hasSecret === true;/);
+    assert.match(notice, /\{!loading && \(/);
+    assert.match(notice, /<Button[\s\S]*size="sm"[\s\S]*disabled=\{flow\.actionBusy\}[\s\S]*onClick=\{\(\) => void flow\.startLogin\(\)\}/);
+    assert.match(notice, /flow\.pendingAction === 'login' \? '登录中…' : loggedIn \? '重新登录' : '登录'/);
+    // Honest logged-in banner: it points at the re-auth action instead of
+    // claiming there is nothing to do.
+    assert.match(notice, /若请求提示需要重新登录，点这里重新走一遍授权/);
+    assert.doesNotMatch(notice, /请到上方 OAuth 分类完成登录/, 'the mapped notice must drop the go-hunt-the-catalog prose');
+
+    // ConnectionDetail wires the notice for mapped OAuth types and keeps a
+    // buttonless prose fallback for unmapped ones.
+    assert.match(detail, /const oauthLoginService = needsOAuth \? oauthLoginServiceFor\(connection\.providerType\) : null/);
+    assert.match(detail, /oauthLoginService \? \(\s*<OAuthReloginNotice/);
+    assert.match(
+      detail,
+      /async function refreshAfterRelogin\(\) \{[\s\S]*await props\.bridge\.hasSecret\(connection\.slug\)[\s\S]*setHasSecret\(nextHasSecret\);[\s\S]*await props\.onChanged\(\);/,
+      'a successful in-sheet re-login must re-probe the credential (expired tokens read hasSecret===true) and reload the connection status',
+    );
+    assert.match(detail, /请到 OAuth 分类的登录卡片完成登录/, 'unmapped OAuth types keep an honest prose fallback');
   });
 
   it('preload exposes the three new subscription namespaces alongside claudeSubscription', async () => {

--- a/apps/desktop/src/main/__tests__/oauth-login-flow-guard.test.ts
+++ b/apps/desktop/src/main/__tests__/oauth-login-flow-guard.test.ts
@@ -1,0 +1,72 @@
+/**
+ * Behavioral coverage for the framework-free primitives behind
+ * useOAuthLoginFlow — the shared browser-loopback login controller that both
+ * the OAuth catalog modals and the model connection detail sheet's 重新登录
+ * button drive.
+ *
+ * The hook itself needs a DOM + React to render; these primitives are pulled
+ * out precisely so the two safety behaviors the task cares about — the
+ * pending-action guard (a second concurrent login/logout is rejected) and
+ * cancel-on-unmount (a still-open authorization request is cancelled and not
+ * re-cancelled) — are testable directly, without a renderer.
+ */
+
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'node:test';
+import {
+  createOneShotActionGuard,
+  teardownPendingAuthorization,
+} from '../../renderer/settings/oauth-login-flow-guard.js';
+
+describe('useOAuthLoginFlow pending-action guard', () => {
+  it('admits the first action and rejects a concurrent second one', () => {
+    const guard = createOneShotActionGuard<'login' | 'logout'>();
+    assert.equal(guard.current, null);
+    assert.equal(guard.begin('login'), true, 'first login must be admitted');
+    assert.equal(guard.current, 'login');
+    // A double-click / a logout racing the in-flight login must be rejected
+    // synchronously, before React re-renders the disabled button.
+    assert.equal(guard.begin('login'), false, 'a second login must be rejected while one is pending');
+    assert.equal(guard.begin('logout'), false, 'a racing logout must be rejected while login is pending');
+    assert.equal(guard.current, 'login', 'the rejected action must not overwrite the pending one');
+  });
+
+  it('re-admits an action only after the pending one finishes', () => {
+    const guard = createOneShotActionGuard<'login' | 'logout'>();
+    assert.equal(guard.begin('login'), true);
+    guard.finish();
+    assert.equal(guard.current, null, 'finish must clear the pending action');
+    assert.equal(guard.begin('logout'), true, 'a new action is admitted once the previous one finished');
+    assert.equal(guard.current, 'logout');
+  });
+});
+
+describe('useOAuthLoginFlow cancel-on-unmount', () => {
+  it('cancels a still-pending authorization request and clears the holder', () => {
+    const holder: { current: string | null } = { current: 'auth-req-123' };
+    const cancelled: string[] = [];
+    teardownPendingAuthorization(holder, (id) => cancelled.push(id));
+    assert.deepEqual(cancelled, ['auth-req-123'], 'the pending authorization request must be cancelled');
+    assert.equal(holder.current, null, 'the holder must be cleared so a late resolution cannot re-cancel');
+  });
+
+  it('does nothing when no authorization request is pending', () => {
+    const holder: { current: string | null } = { current: null };
+    let calls = 0;
+    teardownPendingAuthorization(holder, () => { calls += 1; });
+    assert.equal(calls, 0, 'no pending request means no cancellation call');
+    assert.equal(holder.current, null);
+  });
+
+  it('clears the holder before cancelling so re-entrancy cannot double-cancel', () => {
+    const holder: { current: string | null } = { current: 'auth-req-777' };
+    const cancelled: string[] = [];
+    teardownPendingAuthorization(holder, (id) => {
+      // If teardown cleared the holder AFTER calling cancel, a re-entrant
+      // teardown here would see the same id and cancel it twice.
+      cancelled.push(id);
+      teardownPendingAuthorization(holder, (again) => cancelled.push(again));
+    });
+    assert.deepEqual(cancelled, ['auth-req-777'], 'the request must be cancelled exactly once');
+  });
+});

--- a/apps/desktop/src/main/__tests__/settings-confirm-dialog-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/settings-confirm-dialog-contract.test.ts
@@ -32,18 +32,23 @@ describe('Settings destructive confirm contract', () => {
   });
 
   it('routes OAuth, provider, memory restore, and WeChat destructive actions through toast.confirm', async () => {
-    const [settings, providers] = await Promise.all([
+    const [settings, providers, loginFlowHook] = await Promise.all([
       readSettingsCombinedSource(),
       readProviderSettingsCombinedSource(),
+      // The browser-loopback logout confirm moved into the shared login-flow
+      // hook when SubscriptionLoginModal was thinned onto useOAuthLoginFlow.
+      readRepo('apps/desktop/src/renderer/settings/use-oauth-login-flow.ts'),
     ]);
+    const providerSources = `${providers}\n${loginFlowHook}`;
 
     for (const title of [
       '退出 ${display.name} 登录？',
       '删除供应商 ${connection.name}？',
       '退出 Claude Code 登录？',
     ]) {
-      assert.ok(providers.includes(`title: \`${title}\``) || providers.includes(`title: '${title}'`));
+      assert.ok(providerSources.includes(`title: \`${title}\``) || providerSources.includes(`title: '${title}'`));
     }
+    assert.match(loginFlowHook, /destructive:\s*true/, 'shared OAuth logout confirm must use destructive styling');
 
     for (const title of [
       '恢复上一版 MEMORY.md？',

--- a/apps/desktop/src/main/visual-smoke-fixture.ts
+++ b/apps/desktop/src/main/visual-smoke-fixture.ts
@@ -21,6 +21,10 @@ const VISUAL_SMOKE_SCENARIOS = new Set<VisualSmokeScenario>([
   'fallback-source',
   'fetched-empty',
   'connection-error',
+  // OAuth re-login affordance: a codex-subscription connection with a stored
+  // but expired OAuth token (hasSecret===true), focused so its detail sheet's
+  // 重新登录 button is visible.
+  'oauth-relogin',
   'turn-narrative',
   'artifact-pane',
   'artifact-errors',
@@ -301,6 +305,7 @@ export function getVisualSmokeState(fixture: VisualSmokeFixture | null): VisualS
       return { ...state, activeSessionId: TURN_SESSION_ID, openSettingsSection: 'models' };
     case 'fallback-source':
     case 'fetched-empty':
+    case 'oauth-relogin':
       return { ...state, activeSessionId: TURN_SESSION_ID, openSettingsSection: 'models' };
     case 'connection-error':
       return { ...state, activeSessionId: ERROR_SESSION_ID, openSettingsSection: 'account' };
@@ -943,6 +948,29 @@ async function writeConnections(workspaceRoot: string, now: number, scenario: Vi
       updatedAt: now - 8 * 60_000,
     },
   ];
+  if (scenario === 'oauth-relogin') {
+    // A codex-subscription (OAuth) connection whose last test came back
+    // needs_reauth. Its detail sheet must offer an inline 登录 / 重新登录
+    // button (driven by the shared OAuth login flow) instead of the old dead
+    // prose. Credential presence for OAuth connections is resolved through the
+    // subscription token store (empty here), so the button reads 登录; the
+    // hasSecret===true → 重新登录 label is pinned by the detail-sheet contract.
+    connections.push({
+      slug: 'codex-oauth',
+      name: 'OpenAI Codex Fixture',
+      providerType: 'codex-subscription',
+      defaultModel: 'gpt-5.5',
+      enabled: true,
+      models: [model('gpt-5.5', { reasoning: true, functionCalling: true }, 200_000)],
+      modelSource: 'fetched',
+      modelsFetchedAt: now - 6 * 60_000,
+      lastTestStatus: 'needs_reauth',
+      lastTestAt: new Date(now - 6 * 60_000).toISOString(),
+      lastTestMessage: '需要重新登录',
+      createdAt: now - 3_100_000,
+      updatedAt: now - 6 * 60_000,
+    });
+  }
   const focusSlug = connectionFocusSlug(scenario);
   const ordered = focusSlug
     ? [
@@ -962,6 +990,8 @@ function connectionFocusSlug(scenario: VisualSmokeScenario): string | null {
       return 'relay-fallback';
     case 'fetched-empty':
       return 'empty-fetched';
+    case 'oauth-relogin':
+      return 'codex-oauth';
     case 'connection-error':
       return 'broken-provider';
     default:

--- a/apps/desktop/src/renderer/settings/oauth-login-flow-guard.ts
+++ b/apps/desktop/src/renderer/settings/oauth-login-flow-guard.ts
@@ -1,0 +1,42 @@
+// Framework-free primitives behind useOAuthLoginFlow's async safety. Kept in a
+// React-free module so their behavior is unit-testable without a DOM (see
+// oauth-login-flow-guard.test.ts) and so the desktop test runner can import
+// them without pulling React into its program.
+
+// Synchronous one-shot action guard: rejects a second concurrent action before
+// React can re-render the disabled button. A plain closure (held in a ref by
+// the hook) so the check is synchronous, not subject to render batching.
+export interface OneShotActionGuard<Action> {
+  begin(action: Action): boolean;
+  finish(): void;
+  readonly current: Action | null;
+}
+
+export function createOneShotActionGuard<Action>(): OneShotActionGuard<Action> {
+  let current: Action | null = null;
+  return {
+    begin(action: Action): boolean {
+      if (current !== null) return false;
+      current = action;
+      return true;
+    },
+    finish(): void {
+      current = null;
+    },
+    get current(): Action | null {
+      return current;
+    },
+  };
+}
+
+// Cancel-on-unmount primitive: cancels a still-pending authorization request
+// and clears the holder so a late resolution cannot re-cancel it. No-ops when
+// nothing is pending.
+export function teardownPendingAuthorization(
+  holder: { current: string | null },
+  cancelAuthorization: (authRequestId: string) => void,
+): void {
+  const pendingAuthRequestId = holder.current;
+  holder.current = null;
+  if (pendingAuthRequestId) cancelAuthorization(pendingAuthRequestId);
+}

--- a/apps/desktop/src/renderer/settings/provider-connection-detail.tsx
+++ b/apps/desktop/src/renderer/settings/provider-connection-detail.tsx
@@ -13,18 +13,47 @@ import {
   type LlmConnection,
   type ModelCatalogEntry,
   type ModelInfo,
+  type ProviderType,
 } from '@maka/core';
 import { formatRelativeTimestamp } from '@maka/core';
 import { Button, Chip, FieldDescription, FieldRoot, Input, Label, useToast } from '@maka/ui';
 import { PasswordInput } from './password-input';
 import { buildCatalogModelChoices } from '../model-catalog-choices';
 import { providerDisplay } from './provider-display';
+import { useOAuthLoginFlow, type OAuthLoginFlowBridge } from './use-oauth-login-flow';
 import {
   categoryLabel,
   providerPanelActionErrorMessage,
   type ConnectionsBridge,
   type CredentialPresenceStatus,
 } from './provider-panel-shared';
+
+// Maps an OAuth model-connection provider type to the browser-loopback login
+// service that can re-run its authorization from inside the detail sheet. Only
+// the loopback / polling services (Codex, Antigravity) are one-button-drivable
+// here; Claude's paste-code flow and plain API-key providers return null so the
+// notice falls back to prose instead of rendering a dead button.
+interface OAuthLoginService {
+  bridge: OAuthLoginFlowBridge;
+  display: { name: string; shortName: string };
+}
+
+function oauthLoginServiceFor(providerType: ProviderType): OAuthLoginService | null {
+  switch (providerType) {
+    case 'codex-subscription':
+      return {
+        bridge: window.maka.codexSubscription as unknown as OAuthLoginFlowBridge,
+        display: { name: 'OpenAI Codex', shortName: 'Codex' },
+      };
+    case 'gemini-cli':
+      return {
+        bridge: window.maka.antigravitySubscription as unknown as OAuthLoginFlowBridge,
+        display: { name: 'Google Antigravity', shortName: 'Antigravity' },
+      };
+    default:
+      return null;
+  }
+}
 
 function formatFetchedAtSuffix(modelsFetchedAt: number | undefined): string {
   if (modelsFetchedAt === undefined) return '';
@@ -90,6 +119,7 @@ export function ConnectionDetail(props: {
   const toast = useToast();
   const needsApiKey = defaults.authKind === 'api_key';
   const needsOAuth = defaults.authKind === 'oauth_token';
+  const oauthLoginService = needsOAuth ? oauthLoginServiceFor(connection.providerType) : null;
   const hasFixedOAuthBaseUrl = needsOAuth && Boolean(defaults.baseUrl);
   const requiresCredential = defaults.authKind !== 'none';
   const credentialProbePending = requiresCredential && (hasSecret === 'loading' || hasSecret === 'error');
@@ -367,6 +397,23 @@ export function ConnectionDetail(props: {
     }
   }
 
+  // After a successful in-sheet OAuth re-login, re-probe the credential
+  // presence (an expired token still read hasSecret===true, so we must
+  // refresh it) and reload the connection so its status leaves 需要重新登录.
+  async function refreshAfterRelogin() {
+    const lifecycle = connectionDetailLifecycleRef.current;
+    try {
+      const nextHasSecret = await props.bridge.hasSecret(connection.slug);
+      if (!isConnectionDetailCurrent(lifecycle)) return;
+      setHasSecret(nextHasSecret);
+    } catch (error) {
+      if (!isConnectionDetailCurrent(lifecycle)) return;
+      setHasSecret('error');
+      toast.error('读取模型凭据状态失败', providerPanelActionErrorMessage(error));
+    }
+    await props.onChanged();
+  }
+
   return (
     <div className="providerEditor">
       <header>
@@ -412,26 +459,34 @@ export function ConnectionDetail(props: {
         </FieldRoot>
       )}
       {needsOAuth && (
-        <div className="providerUnavailableNotice" data-auth-kind="oauth">
-          <strong>
-            {hasSecret === true
-              ? 'OAuth 已登录'
-              : hasSecret === 'loading'
-                ? 'OAuth 状态读取中'
-                : hasSecret === 'error'
-                  ? 'OAuth 状态未知'
-                  : '等待 OAuth 登录'}
-          </strong>
-          <span>
-            {hasSecret === true
-              ? '该模型连接使用主进程保存的 OAuth access token，不在这里显示或编辑令牌。'
-              : hasSecret === 'loading'
-                ? '正在读取本机 OAuth 登录状态，读取完成前不会把未知状态显示成未登录。'
-                : hasSecret === 'error'
-                  ? '暂时无法读取本机 OAuth 登录状态；请刷新页面或重新打开设置。'
-                  : '请到上方 OAuth 分类完成登录；登录成功后会自动出现在模型连接里。'}
-          </span>
-        </div>
+        oauthLoginService ? (
+          <OAuthReloginNotice
+            service={oauthLoginService}
+            hasSecret={hasSecret}
+            onRelogin={refreshAfterRelogin}
+          />
+        ) : (
+          <div className="providerUnavailableNotice" data-auth-kind="oauth">
+            <strong>
+              {hasSecret === true
+                ? 'OAuth 已登录'
+                : hasSecret === 'loading'
+                  ? 'OAuth 状态读取中'
+                  : hasSecret === 'error'
+                    ? 'OAuth 状态未知'
+                    : '等待 OAuth 登录'}
+            </strong>
+            <span>
+              {hasSecret === true
+                ? '该模型连接使用主进程保存的 OAuth access token；若请求提示需要重新登录，请到 OAuth 分类的登录卡片重新授权。'
+                : hasSecret === 'loading'
+                  ? '正在读取本机 OAuth 登录状态，读取完成前不会把未知状态显示成未登录。'
+                  : hasSecret === 'error'
+                    ? '暂时无法读取本机 OAuth 登录状态；请刷新页面或重新打开设置。'
+                    : '请到 OAuth 分类的登录卡片完成登录；登录成功后会自动出现在模型连接里。'}
+            </span>
+          </div>
+        )
       )}
       {credentialProbePending && (
         <p className="providerError" role="alert">
@@ -473,6 +528,58 @@ export function ConnectionDetail(props: {
           {deleting ? '删除中…' : '删除'}
         </Button>
       </div>
+    </div>
+  );
+}
+
+// The OAuth notice for a re-loginable connection. The 重新登录 button drives
+// the SAME shared browser-loopback flow the OAuth catalog cards use, so an
+// expired connection can be re-authorized right where the problem surfaces.
+// The button shows in every credential state except 'loading' — an EXPIRED
+// token still reads hasSecret===true, so it must not hide behind
+// hasSecret===false.
+function OAuthReloginNotice(props: {
+  service: OAuthLoginService;
+  hasSecret: CredentialPresenceStatus;
+  onRelogin(): Promise<void>;
+}) {
+  const flow = useOAuthLoginFlow({
+    bridge: props.service.bridge,
+    display: props.service.display,
+    onLoginSuccess: props.onRelogin,
+  });
+  const { hasSecret } = props;
+  const loggedIn = hasSecret === true;
+  const loading = hasSecret === 'loading';
+  const errored = hasSecret === 'error';
+  const title = loggedIn
+    ? 'OAuth 已登录'
+    : loading
+      ? 'OAuth 状态读取中'
+      : errored
+        ? 'OAuth 状态未知'
+        : '等待 OAuth 登录';
+  const detail = loggedIn
+    ? '若请求提示需要重新登录，点这里重新走一遍授权。'
+    : loading
+      ? '正在读取本机 OAuth 登录状态，读取完成前不会把未知状态显示成未登录。'
+      : errored
+        ? '暂时无法读取本机 OAuth 登录状态；请刷新页面或重新打开设置。'
+        : '点下方按钮打开浏览器完成登录，授权成功后会自动刷新这里的状态。';
+  return (
+    <div className="providerUnavailableNotice" data-auth-kind="oauth">
+      <strong>{title}</strong>
+      <span>{detail}</span>
+      {!loading && (
+        <Button
+          type="button"
+          size="sm"
+          disabled={flow.actionBusy}
+          onClick={() => void flow.startLogin()}
+        >
+          {flow.pendingAction === 'login' ? '登录中…' : loggedIn ? '重新登录' : '登录'}
+        </Button>
+      )}
     </div>
   );
 }

--- a/apps/desktop/src/renderer/settings/provider-oauth-section.tsx
+++ b/apps/desktop/src/renderer/settings/provider-oauth-section.tsx
@@ -1,8 +1,6 @@
 import { useEffect, useRef, useState } from 'react';
 import { ChevronRight } from '@maka/ui/icons';
 import {
-  generalizedErrorMessageChinese,
-  redactSecrets,
   type ProviderType,
   type SubscriptionAccountState,
 } from '@maka/core';
@@ -22,6 +20,13 @@ import {
 import { type StatusTone } from './settings-status-badge';
 import { ProviderLogo } from './provider-display';
 import { ProviderSheet } from './provider-config-sheet';
+import {
+  useOAuthLoginFlow,
+  subscriptionActionErrorMessage,
+  subscriptionResultMessage,
+  type OAuthLoginFlowBridge,
+  type SubscriptionSnapshot,
+} from './use-oauth-login-flow';
 
 type OAuthCardId = 'claude' | 'codex' | 'antigravity' | 'cursor';
 type OAuthServiceId = OAuthCardId;
@@ -255,150 +260,17 @@ function ClaudeSubscriptionModal(props: { onClose(): void }) {
 }
 
 function SubscriptionLoginModal(props: { serviceId: BrowserOAuthServiceId; onClose(): void }) {
-  const toast = useToast();
   const bridge = pickSubscriptionBridge(props.serviceId);
-  const [state, setState] = useState<SubscriptionSnapshot | null>(null);
-  const [authRequestId, setAuthRequestId] = useState<string | null>(null);
-  const [stateHint, setStateHint] = useState<string | null>(null);
-  const [pendingAction, setPendingAction] = useState<BrowserSubscriptionPendingAction | null>(null);
-  const pendingActionRef = useRef<BrowserSubscriptionPendingAction | null>(null);
-  const authRequestIdRef = useRef<string | null>(null);
-  const browserSubscriptionMountedRef = useRef(false);
-  const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const display = subscriptionDisplay(props.serviceId);
-
-  async function refresh(): Promise<boolean> {
-    try {
-      const next = (await bridge.getAccountState()) as SubscriptionSnapshot;
-      if (!browserSubscriptionMountedRef.current) return false;
-      setState(next);
-      setErrorMessage(null);
-    } catch (error) {
-      if (!browserSubscriptionMountedRef.current) return false;
-      const message = subscriptionActionErrorMessage(error);
-      toast.error('刷新登录状态失败', message);
-      setErrorMessage(message);
-    }
-    return true;
-  }
-
-  useEffect(() => {
-    browserSubscriptionMountedRef.current = true;
-    void refresh();
-    return () => {
-      browserSubscriptionMountedRef.current = false;
-      pendingActionRef.current = null;
-      const pendingAuthRequestId = authRequestIdRef.current;
-      authRequestIdRef.current = null;
-      if (pendingAuthRequestId) void bridge.cancelAuthorization(pendingAuthRequestId);
-    };
-  }, []);
-
-  function beginPendingAction(action: BrowserSubscriptionPendingAction): boolean {
-    if (pendingActionRef.current !== null) return false;
-    pendingActionRef.current = action;
-    setPendingAction(action);
-    return true;
-  }
-
-  function finishPendingAction() {
-    pendingActionRef.current = null;
-    if (browserSubscriptionMountedRef.current) setPendingAction(null);
-  }
-
-  async function startLogin() {
-    if (!beginPendingAction('login')) return;
-    setErrorMessage(null);
-    try {
-      const payload = await bridge.getAuthUrl();
-      if ('ok' in payload) {
-        if (!browserSubscriptionMountedRef.current) return;
-        const failureMessage = payload.ok ? '请稍后再试。' : subscriptionResultMessage(payload.message, '无法开始登录，请稍后再试。');
-        toast.error('无法开始登录', failureMessage);
-        setErrorMessage(failureMessage);
-        return;
-      }
-      authRequestIdRef.current = payload.authRequestId;
-      if (!browserSubscriptionMountedRef.current) {
-        authRequestIdRef.current = null;
-        void bridge.cancelAuthorization(payload.authRequestId);
-        return;
-      }
-      setAuthRequestId(payload.authRequestId);
-      setStateHint(payload.stateHint);
-      const opened = await bridge.openAuthUrl(payload.authRequestId);
-      if (!browserSubscriptionMountedRef.current) return;
-      if (!opened.ok) {
-        const message = subscriptionResultMessage(opened.message, '无法打开浏览器，请稍后重试。');
-        toast.error('无法打开浏览器', message);
-        setErrorMessage(message);
-        void bridge.cancelAuthorization(payload.authRequestId);
-        authRequestIdRef.current = null;
-        setAuthRequestId(null);
-        setStateHint(null);
-        return;
-      }
-      const refreshed = await refresh();
-      if (!browserSubscriptionMountedRef.current || !refreshed) return;
-      // Loopback / polling — wait for the backend to complete.
-      const result = await bridge.completeAuthorization(payload.authRequestId);
-      if (!browserSubscriptionMountedRef.current) return;
-      authRequestIdRef.current = null;
-      setAuthRequestId(null);
-      setStateHint(null);
-      if (result.ok) {
-        toast.success('登录成功', `${display.name} 已绑定本机。`);
-        await refresh();
-      } else {
-        const message = subscriptionResultMessage(result.message, '登录未完成，请重新打开浏览器授权。');
-        toast.error('登录未完成', message);
-        setErrorMessage(message);
-      }
-    } catch (error) {
-      if (!browserSubscriptionMountedRef.current) return;
-      const pendingAuthRequestId = authRequestIdRef.current;
-      authRequestIdRef.current = null;
-      if (pendingAuthRequestId) void bridge.cancelAuthorization(pendingAuthRequestId);
-      setAuthRequestId(null);
-      setStateHint(null);
-      const message = subscriptionActionErrorMessage(error);
-      toast.error('登录失败', message);
-      setErrorMessage(message);
-    } finally {
-      finishPendingAction();
-    }
-  }
-
-  async function logout() {
-    if (!beginPendingAction('logout')) return;
-    try {
-      const ok = await toast.confirm({
-        title: `退出 ${display.name} 登录？`,
-        description: '将删除本机保存的订阅凭据，之后需要重新登录才能继续使用这些 OAuth 模型。',
-        confirmLabel: '退出登录',
-        cancelLabel: '取消',
-        destructive: true,
-      });
-      if (!ok) return;
-      const result = await bridge.logout();
-      if (!browserSubscriptionMountedRef.current) return;
-      if (result.ok) {
-        toast.success('已退出登录', '本地凭据已清除。');
-        await refresh();
-      } else {
-        toast.error('退出失败', subscriptionResultMessage(result.message, '退出登录失败，请稍后重试。'));
-      }
-    } catch (error) {
-      if (!browserSubscriptionMountedRef.current) return;
-      toast.error('退出失败', subscriptionActionErrorMessage(error));
-    } finally {
-      finishPendingAction();
-    }
-  }
-
-  const runtimeState = state?.runtimeState ?? 'loading';
-  const isLoggedIn = runtimeState === 'authenticated' || runtimeState === 'refreshing';
-  const actionBusy = pendingAction !== null;
+  // The whole browser-loopback login/logout controller (getAuthUrl ->
+  // openAuthUrl -> refresh -> completeAuthorization, one authRequestId
+  // lifecycle, synchronous pending-action guard, cancellation on unmount,
+  // localized toast copy) lives in useOAuthLoginFlow so the model connection
+  // detail sheet can drive the exact same flow behind its relogin button.
+  const flow = useOAuthLoginFlow({
+    bridge,
+    display: { name: display.name, shortName: display.shortName },
+  });
 
   return (
     <ProviderSheet onClose={props.onClose} ariaLabel={`${display.name} 登录`} dataSubscription={props.serviceId}>
@@ -416,85 +288,39 @@ function SubscriptionLoginModal(props: { serviceId: BrowserOAuthServiceId; onClo
             ×
           </Button>
         </header>
-        <div className="settingsConnectionRow" data-status={runtimeState}>
+        <div className="settingsConnectionRow" data-status={flow.runtimeState}>
           <p className="settingsConnectionDetail">
-            {presentSnapshotDetail(state, display)}
+            {presentSnapshotDetail(flow.state, display)}
           </p>
-          {stateHint && (
-            <small>提示：state 以 <code>{stateHint}</code> 开头。</small>
+          {flow.stateHint && (
+            <small>提示：state 以 <code>{flow.stateHint}</code> 开头。</small>
           )}
-          {errorMessage && (
-            <small className="settingsErrorText">{errorMessage}</small>
+          {flow.errorMessage && (
+            <small className="settingsErrorText">{flow.errorMessage}</small>
           )}
           <div className="settingsConnectionActions">
-            {!isLoggedIn ? (
+            {!flow.isLoggedIn ? (
               <Button
                 type="button"
-                onClick={() => void startLogin()}
-                disabled={actionBusy}
+                onClick={() => void flow.startLogin()}
+                disabled={flow.actionBusy}
               >
-                {pendingAction === 'login' ? '打开浏览器…' : `登录 ${display.shortName}`}
+                {flow.pendingAction === 'login' ? '打开浏览器…' : `登录 ${display.shortName}`}
               </Button>
             ) : (
               <Button
                 type="button"
                 variant="ghost"
-                onClick={() => void logout()}
-                disabled={actionBusy}
+                onClick={() => void flow.logout()}
+                disabled={flow.actionBusy}
               >
-                {pendingAction === 'logout' ? '退出中…' : '退出登录'}
+                {flow.pendingAction === 'logout' ? '退出中…' : '退出登录'}
               </Button>
             )}
           </div>
         </div>
       </ProviderSheet>
     );
-}
-
-type BrowserSubscriptionPendingAction = 'login' | 'logout';
-
-interface SubscriptionSnapshot {
-  runtimeState:
-    | 'not_logged_in'
-    | 'authorizing'
-    | 'authenticated'
-    | 'refreshing'
-    | 'refresh_failed'
-    | 'storage_failed'
-    | 'quota_unavailable'
-    | 'provider_rejected';
-  email?: string;
-  plan?: string;
-  status?: 'preview';
-  errorMessage?: string;
-}
-
-interface SubscriptionBridge {
-  getAuthUrl(): Promise<
-    { authRequestId: string; stateHint: string } | { ok: boolean; reason?: string; message: string }
-  >;
-  openAuthUrl(authRequestId: string): Promise<{ ok: true } | { ok: false; reason: string; message: string }>;
-  completeAuthorization(authRequestId: string): Promise<{ ok: true } | { ok: false; reason: string; message: string }>;
-  cancelAuthorization(authRequestId?: string): Promise<{ ok: true }>;
-  getAccountState(): Promise<unknown>;
-  logout(): Promise<{ ok: true } | { ok: false; reason: string; message: string }>;
-}
-
-function subscriptionActionErrorMessage(error: unknown): string {
-  const message = error instanceof Error
-    ? error.message
-    : typeof error === 'string'
-      ? error
-      : '';
-  return subscriptionResultMessage(message, '登录服务暂时不可用，请检查网络后重试。');
-}
-
-function subscriptionResultMessage(message: string | undefined, fallback: string): string {
-  const raw = redactSecrets(message ?? '').trim();
-  if (!raw) return fallback;
-  const classified = generalizedErrorMessageChinese(new Error(raw), '');
-  if (classified) return classified;
-  return /[\u4e00-\u9fff]/.test(raw) ? raw : fallback;
 }
 
 async function getSubscriptionSnapshot(serviceId: OAuthServiceId): Promise<SubscriptionSnapshot> {
@@ -509,14 +335,14 @@ async function getSubscriptionSnapshot(serviceId: OAuthServiceId): Promise<Subsc
   return (await pickSubscriptionBridge(serviceId).getAccountState()) as SubscriptionSnapshot;
 }
 
-function pickSubscriptionBridge(serviceId: BrowserOAuthServiceId): SubscriptionBridge {
+function pickSubscriptionBridge(serviceId: BrowserOAuthServiceId): OAuthLoginFlowBridge {
   switch (serviceId) {
     case 'codex':
-      return window.maka.codexSubscription as unknown as SubscriptionBridge;
+      return window.maka.codexSubscription as unknown as OAuthLoginFlowBridge;
     case 'cursor':
-      return window.maka.cursorSubscription as unknown as SubscriptionBridge;
+      return window.maka.cursorSubscription as unknown as OAuthLoginFlowBridge;
     case 'antigravity':
-      return window.maka.antigravitySubscription as unknown as SubscriptionBridge;
+      return window.maka.antigravitySubscription as unknown as OAuthLoginFlowBridge;
   }
 }
 

--- a/apps/desktop/src/renderer/settings/use-oauth-login-flow.ts
+++ b/apps/desktop/src/renderer/settings/use-oauth-login-flow.ts
@@ -1,0 +1,249 @@
+import { useEffect, useRef, useState } from 'react';
+import { generalizedErrorMessageChinese, redactSecrets } from '@maka/core';
+import { useToast } from '@maka/ui';
+import { createOneShotActionGuard, teardownPendingAuthorization } from './oauth-login-flow-guard';
+
+export { createOneShotActionGuard, teardownPendingAuthorization } from './oauth-login-flow-guard';
+
+// Shared OAuth (browser loopback / polling) login-flow controller.
+//
+// Extracted from the SubscriptionLoginModal `startLogin` flow so BOTH the
+// OAuth catalog login modals (codex / cursor / antigravity) AND the model
+// connection detail sheet's 重新登录 affordance drive the same
+// getAuthUrl -> openAuthUrl -> refresh -> completeAuthorization sequence with
+// one authRequestId lifecycle, one synchronous pending-action guard, and
+// cancellation-on-unmount. Claude's paste-code flow is deliberately NOT
+// routed through this hook -- it needs a manual authorization-code step and
+// its own experimental gate, so it keeps its bespoke card.
+
+export type OAuthLoginPendingAction = 'login' | 'logout';
+
+export interface SubscriptionSnapshot {
+  runtimeState:
+    | 'not_logged_in'
+    | 'authorizing'
+    | 'authenticated'
+    | 'refreshing'
+    | 'refresh_failed'
+    | 'storage_failed'
+    | 'quota_unavailable'
+    | 'provider_rejected';
+  email?: string;
+  plan?: string;
+  status?: 'preview';
+  errorMessage?: string;
+}
+
+export interface OAuthLoginFlowBridge {
+  getAuthUrl(): Promise<
+    { authRequestId: string; stateHint: string } | { ok: boolean; reason?: string; message: string }
+  >;
+  openAuthUrl(authRequestId: string): Promise<{ ok: true } | { ok: false; reason: string; message: string }>;
+  completeAuthorization(authRequestId: string): Promise<{ ok: true } | { ok: false; reason: string; message: string }>;
+  cancelAuthorization(authRequestId?: string): Promise<{ ok: true }>;
+  getAccountState(): Promise<unknown>;
+  logout(): Promise<{ ok: true } | { ok: false; reason: string; message: string }>;
+}
+
+export interface OAuthLoginFlowDisplay {
+  name: string;
+  shortName: string;
+}
+
+export interface OAuthLoginFlowController {
+  state: SubscriptionSnapshot | null;
+  runtimeState: SubscriptionSnapshot['runtimeState'] | 'loading';
+  isLoggedIn: boolean;
+  pendingAction: OAuthLoginPendingAction | null;
+  authRequestId: string | null;
+  stateHint: string | null;
+  errorMessage: string | null;
+  actionBusy: boolean;
+  startLogin(): Promise<void>;
+  logout(): Promise<void>;
+  refresh(): Promise<boolean>;
+}
+
+export function useOAuthLoginFlow(params: {
+  bridge: OAuthLoginFlowBridge;
+  display: OAuthLoginFlowDisplay;
+  // Fired after a successful completeAuthorization (browser handoff done).
+  // The detail sheet uses it to re-probe hasSecret + reload connection status;
+  // the modal leaves it undefined and relies on its own snapshot refresh.
+  onLoginSuccess?: () => void | Promise<void>;
+}): OAuthLoginFlowController {
+  const { bridge, display } = params;
+  const toast = useToast();
+  const [state, setState] = useState<SubscriptionSnapshot | null>(null);
+  const [authRequestId, setAuthRequestId] = useState<string | null>(null);
+  const [stateHint, setStateHint] = useState<string | null>(null);
+  const [pendingAction, setPendingAction] = useState<OAuthLoginPendingAction | null>(null);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const pendingGuard = useRef(createOneShotActionGuard<OAuthLoginPendingAction>()).current;
+  const authRequestIdRef = useRef<string | null>(null);
+  const oauthLoginFlowMountedRef = useRef(false);
+
+  async function refresh(): Promise<boolean> {
+    try {
+      const next = (await bridge.getAccountState()) as SubscriptionSnapshot;
+      if (!oauthLoginFlowMountedRef.current) return false;
+      setState(next);
+      setErrorMessage(null);
+    } catch (error) {
+      if (!oauthLoginFlowMountedRef.current) return false;
+      const message = subscriptionActionErrorMessage(error);
+      toast.error('刷新登录状态失败', message);
+      setErrorMessage(message);
+    }
+    return true;
+  }
+
+  useEffect(() => {
+    oauthLoginFlowMountedRef.current = true;
+    void refresh();
+    return () => {
+      oauthLoginFlowMountedRef.current = false;
+      pendingGuard.finish();
+      teardownPendingAuthorization(authRequestIdRef, (id) => void bridge.cancelAuthorization(id));
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  function beginPendingAction(action: OAuthLoginPendingAction): boolean {
+    if (!pendingGuard.begin(action)) return false;
+    setPendingAction(action);
+    return true;
+  }
+
+  function finishPendingAction() {
+    pendingGuard.finish();
+    if (oauthLoginFlowMountedRef.current) setPendingAction(null);
+  }
+
+  async function startLogin() {
+    if (!beginPendingAction('login')) return;
+    setErrorMessage(null);
+    try {
+      const payload = await bridge.getAuthUrl();
+      if ('ok' in payload) {
+        if (!oauthLoginFlowMountedRef.current) return;
+        const failureMessage = payload.ok ? '请稍后再试。' : subscriptionResultMessage(payload.message, '无法开始登录，请稍后再试。');
+        toast.error('无法开始登录', failureMessage);
+        setErrorMessage(failureMessage);
+        return;
+      }
+      authRequestIdRef.current = payload.authRequestId;
+      if (!oauthLoginFlowMountedRef.current) {
+        authRequestIdRef.current = null;
+        void bridge.cancelAuthorization(payload.authRequestId);
+        return;
+      }
+      setAuthRequestId(payload.authRequestId);
+      setStateHint(payload.stateHint);
+      const opened = await bridge.openAuthUrl(payload.authRequestId);
+      if (!oauthLoginFlowMountedRef.current) return;
+      if (!opened.ok) {
+        const message = subscriptionResultMessage(opened.message, '无法打开浏览器，请稍后重试。');
+        toast.error('无法打开浏览器', message);
+        setErrorMessage(message);
+        void bridge.cancelAuthorization(payload.authRequestId);
+        authRequestIdRef.current = null;
+        setAuthRequestId(null);
+        setStateHint(null);
+        return;
+      }
+      const refreshed = await refresh();
+      if (!oauthLoginFlowMountedRef.current || !refreshed) return;
+      // Loopback / polling -- wait for the backend to complete.
+      const result = await bridge.completeAuthorization(payload.authRequestId);
+      if (!oauthLoginFlowMountedRef.current) return;
+      authRequestIdRef.current = null;
+      setAuthRequestId(null);
+      setStateHint(null);
+      if (result.ok) {
+        toast.success('登录成功', `${display.name} 已绑定本机。`);
+        await refresh();
+        if (!oauthLoginFlowMountedRef.current) return;
+        if (params.onLoginSuccess) await params.onLoginSuccess();
+      } else {
+        const message = subscriptionResultMessage(result.message, '登录未完成，请重新打开浏览器授权。');
+        toast.error('登录未完成', message);
+        setErrorMessage(message);
+      }
+    } catch (error) {
+      if (!oauthLoginFlowMountedRef.current) return;
+      const pendingAuthRequestId = authRequestIdRef.current;
+      authRequestIdRef.current = null;
+      if (pendingAuthRequestId) void bridge.cancelAuthorization(pendingAuthRequestId);
+      setAuthRequestId(null);
+      setStateHint(null);
+      const message = subscriptionActionErrorMessage(error);
+      toast.error('登录失败', message);
+      setErrorMessage(message);
+    } finally {
+      finishPendingAction();
+    }
+  }
+
+  async function logout() {
+    if (!beginPendingAction('logout')) return;
+    try {
+      const ok = await toast.confirm({
+        title: `退出 ${display.name} 登录？`,
+        description: '将删除本机保存的订阅凭据，之后需要重新登录才能继续使用这些 OAuth 模型。',
+        confirmLabel: '退出登录',
+        cancelLabel: '取消',
+        destructive: true,
+      });
+      if (!ok) return;
+      const result = await bridge.logout();
+      if (!oauthLoginFlowMountedRef.current) return;
+      if (result.ok) {
+        toast.success('已退出登录', '本地凭据已清除。');
+        await refresh();
+      } else {
+        toast.error('退出失败', subscriptionResultMessage(result.message, '退出登录失败，请稍后重试。'));
+      }
+    } catch (error) {
+      if (!oauthLoginFlowMountedRef.current) return;
+      toast.error('退出失败', subscriptionActionErrorMessage(error));
+    } finally {
+      finishPendingAction();
+    }
+  }
+
+  const runtimeState = state?.runtimeState ?? 'loading';
+  const isLoggedIn = runtimeState === 'authenticated' || runtimeState === 'refreshing';
+  const actionBusy = pendingAction !== null;
+
+  return {
+    state,
+    runtimeState,
+    isLoggedIn,
+    pendingAction,
+    authRequestId,
+    stateHint,
+    errorMessage,
+    actionBusy,
+    startLogin,
+    logout,
+    refresh,
+  };
+}
+
+export function subscriptionActionErrorMessage(error: unknown): string {
+  const message = error instanceof Error
+    ? error.message
+    : typeof error === 'string'
+      ? error
+      : '';
+  return subscriptionResultMessage(message, '登录服务暂时不可用，请检查网络后重试。');
+}
+
+export function subscriptionResultMessage(message: string | undefined, fallback: string): string {
+  const raw = redactSecrets(message ?? '').trim();
+  if (!raw) return fallback;
+  const classified = generalizedErrorMessageChinese(new Error(raw), '');
+  if (classified) return classified;
+  return /[\u4e00-\u9fff]/.test(raw) ? raw : fallback;
+}

--- a/apps/desktop/src/renderer/styles/settings/provider-editor.css
+++ b/apps/desktop/src/renderer/styles/settings/provider-editor.css
@@ -123,6 +123,13 @@
   line-height: var(--leading-snug);
 }
 
+/* The 重新登录 / 登录 CTA keeps its natural width and sits below the copy,
+ * left-aligned, instead of stretching across the grid cell. */
+.providerUnavailableNotice > button {
+  justify-self: start;
+  margin-top: var(--space-1);
+}
+
 /* Direct child only: this is the sheet's own title/badges header. The
  * descendant form (`.providerEditor header`) also matched the nested
  * `.modelTableHeader`, leaking the close-button padding-right onto the

--- a/packages/core/src/visual-smoke.ts
+++ b/packages/core/src/visual-smoke.ts
@@ -8,6 +8,11 @@ export type VisualSmokeScenario =
   | 'fallback-source'
   | 'fetched-empty'
   | 'connection-error'
+  // OAuth re-login: seeds a codex-subscription (OAuth) connection that last
+  // tested needs_reauth and focuses its detail sheet, so the inline 登录 /
+  // 重新登录 affordance the detail sheet gained is visible where an expired
+  // OAuth login must be re-run — the surface that used to be dead prose.
+  | 'oauth-relogin'
   | 'turn-narrative'
   | 'artifact-pane'
   | 'artifact-errors'


### PR DESCRIPTION
User-reported: when Claude Code / Codex OAuth expires, there was no good way to log in again — the connection detail offered 保存/测试/删除 plus prose sending you hunting through the catalog, and an EXPIRED token still read as 已登录.

- Login flow extracted to a shared `useOAuthLoginFlow` hook (browser-loopback controller: getAuthUrl → openAuthUrl → completeAuthorization, authRequestId lifecycle, pending guard, cancel-on-unmount) — existing OAuth cards become thin consumers, zero behavior change; the guard/teardown is a React-free module with behavioral tests
- Connection detail's OAuth notice now renders a real 登录/重新登录 button (visible in every credential state except loading — expired tokens read hasSecret=true, so the button never hides behind 未登录); success re-probes credentials + reloads status
- providerType mapping: codex-subscription/gemini-cli → bridges; claude-subscription keeps honest prose (paste-code flow — no dead button)
- ~25 contract pins re-pointed to the hook source; new detail-sheet pin; new oauth-relogin visual-smoke fixture (honest about the state it can seed — safeStorage-backed tokens can't be faked cheaply)

Worktree verification: desktop 2315/2315 + ui 104/104, full typecheck, all five static checks + alignment auditor clean, CDP captures. Implemented by an opus worktree agent to the maintainer's spec.