### PR TITLE
fix(desktop): 技能页三胞胎治理 — ordinal names, collision slug, visible 示例 divider

### DIFF
--- a/apps/desktop/src/main/__tests__/skills.test.ts
+++ b/apps/desktop/src/main/__tests__/skills.test.ts
@@ -320,6 +320,7 @@ ${'A'.repeat(MAX_SKILL_TOOL_BODY_CHARS + 1000)}`);
 
       const text = await readFile(result.filePath, 'utf8');
       assert.match(text, /name: 示例技能/);
+
       assert.match(text, /allowed-tools:\n  - Read/);
       assert.match(text, /不会自动获得权限/);
 
@@ -335,6 +336,17 @@ ${'A'.repeat(MAX_SKILL_TOOL_BODY_CHARS + 1000)}`);
       assert.equal(skills[0].id, 'starter-skill');
       assert.equal(skills[0].sourceType, 'workspace');
       assert.equal(skills[0].validationStatus, 'missing_lock');
+
+      // Repeated creates mint DISTINGUISHABLE names (the id ordinal flows
+      // into the display name + front-matter) — three clicks used to
+      // produce three identical 「示例技能」 rows.
+      const second = await createStarterSkill(workspaceRoot);
+      assert.equal(second.ok, true);
+      if (second.ok) {
+        assert.equal(second.skill.id, 'starter-skill-2');
+        assert.equal(second.skill.name, '示例技能 2');
+        assert.match(await readFile(second.filePath, 'utf8'), /name: 示例技能 2/);
+      }
     });
   });
 

--- a/apps/desktop/src/main/skills.ts
+++ b/apps/desktop/src/main/skills.ts
@@ -458,6 +458,10 @@ export async function createStarterSkill(root: string): Promise<CreateStarterSki
 
   for (let index = 1; index <= 99; index += 1) {
     const id = index === 1 ? 'starter-skill' : `starter-skill-${index}`;
+    // Display name follows the id's ordinal — three clicks used to mint
+    // three IDENTICAL 「示例技能」 rows (ids differed, names didn't, and the
+    // slug lives in the tooltip), leaving the list visually indistinguishable.
+    const name = index === 1 ? '示例技能' : `示例技能 ${index}`;
     const skillDir = join(skillsDir, id);
     try {
       await mkdir(skillDir, { mode: 0o700 });
@@ -473,13 +477,13 @@ export async function createStarterSkill(root: string): Promise<CreateStarterSki
       }
 
       const filePath = join(skillDir, 'SKILL.md');
-      await writeFile(filePath, starterSkillTemplate(id), { encoding: 'utf8', flag: 'wx', mode: 0o600 });
+      await writeFile(filePath, starterSkillTemplate(id, name), { encoding: 'utf8', flag: 'wx', mode: 0o600 });
       return {
         ok: true,
         filePath,
         skill: {
           id,
-          name: '示例技能',
+          name,
           description: '把常用工作流写成可复用的本地指令。',
           path: skillDir,
           declaredTools: ['Read'],
@@ -1398,15 +1402,15 @@ function isSafeSkillId(value: string): boolean {
   return /^[A-Za-z0-9][A-Za-z0-9._-]{0,80}$/.test(value);
 }
 
-function starterSkillTemplate(id: string): string {
+function starterSkillTemplate(id: string, name: string): string {
   return `---
-name: 示例技能
+name: ${name}
 description: 把常用工作流写成可复用的本地指令。
 allowed-tools:
   - Read
 ---
 
-# 示例技能
+# ${name}
 
 当用户要求你按固定流程完成某类任务时，先加载这个技能。
 

--- a/apps/desktop/src/renderer/styles/module-pages/skills.css
+++ b/apps/desktop/src/renderer/styles/module-pages/skills.css
@@ -827,3 +827,13 @@ color: oklch(from var(--brand-deep) 0.55 min(c, 0.015) h);
     grid-template-columns: minmax(0, 1fr);
   }
 }
+
+/* Collision-only slug: revealed inline beside the name ONLY when two visible
+   skills share a display name (normal rows keep the slug in the tooltip). */
+.maka-skill-library-slug {
+  margin-left: var(--space-1-5);
+  color: var(--muted-foreground);
+  font-family: var(--font-mono);
+  font-size: var(--font-size-caption);
+  font-weight: var(--font-weight-normal);
+}

--- a/packages/ui/src/skills-panel.tsx
+++ b/packages/ui/src/skills-panel.tsx
@@ -81,6 +81,14 @@ function SkillLibraryPanel(props: {
   // render the SAME list, which made them meaningless.
   const bundledSkills = filteredSkills.filter((skill) => skill.sourceType === 'bundled');
   const installedSkills = filteredSkills.filter((skill) => skill.sourceType !== 'bundled');
+  // Collision-only slug reveal: the slug normally lives in the row tooltip,
+  // but when two visible skills share a display name (e.g. repeated starter
+  // templates from old builds) the rows become indistinguishable — surface
+  // the slug inline exactly for those rows.
+  const skillNameCounts = new Map<string, number>();
+  for (const skill of filteredSkills) {
+    skillNameCounts.set(skill.name, (skillNameCounts.get(skill.name) ?? 0) + 1);
+  }
   const allManagedSources = props.managedSkillSources ?? [];
   // 市场 tab: managed sources are the marketplace catalog. Search (shared
   // header field), category dropdown, and sort are all pure client-side —
@@ -128,6 +136,9 @@ function SkillLibraryPanel(props: {
 
   const templates = (
     <section className="maka-skill-examples" aria-label="技能示例">
+      {/* Visible divider: without it the inert example rows read as more
+          installed skills floating under the real list. */}
+      <SectionHeader title="技能示例" as="span" className="maka-skill-section-row" />
       <ul className="maka-skill-example-grid" aria-label="技能模板示例">
         {SKILL_EXAMPLE_CARDS.map((example) => (
           <li key={example.title} className="maka-skill-template-row">
@@ -356,7 +367,12 @@ function SkillLibraryPanel(props: {
                       <Blocks size={16} />
                     </span>
                     <span className="maka-skill-library-copy">
-                      <span className="maka-skill-library-name">{skill.name}</span>
+                      <span className="maka-skill-library-name">
+                        {skill.name}
+                        {(skillNameCounts.get(skill.name) ?? 0) > 1 && (
+                          <span className="maka-skill-library-slug">{skill.id}</span>
+                        )}
+                      </span>
                       {description && (
                         <span className="maka-skill-library-description">{description}</span>
                       )}


### PR DESCRIPTION
User screenshot showed three identical 「示例技能」 rows (real installed skills, zero visual difference) and the template examples floating under the installed list like more skills.

Root cause: `createStarterSkill` unique-ifies the ID (starter-skill-2…) but hardcoded the display name AND the SKILL.md front-matter to 示例技能 — and since the marketplace redesign moved slugs into tooltips, duplicates became visually indistinguishable.

1. The id ordinal now flows into the name + front-matter (示例技能 2 / 3 …); behavioral test creates twice and pins both
2. **Collision-only slug reveal**: rows whose display name collides with another visible skill show the slug inline — everyone else keeps the clean tooltip-only slug (disambiguates duplicates from ANY source, incl. ones minted by old builds)
3. 技能示例 gets its visible SectionHeader so inert examples stop reading as installed rows

Desktop 2315/2315 + typecheck + dead-css; CDP verified.