### PR TITLE
fix(runtime): give FormatJson the edit activity kind

### DIFF
--- a/packages/runtime/src/__tests__/builtin-tools.test.ts
+++ b/packages/runtime/src/__tests__/builtin-tools.test.ts
@@ -21,6 +21,7 @@ describe('builtin tool activity kinds', () => {
       Read: 'read',
       Write: 'edit',
       Edit: 'edit',
+      FormatJson: 'edit',
       Glob: 'search',
       Grep: 'search',
     });

--- a/packages/runtime/src/builtin-tools.ts
+++ b/packages/runtime/src/builtin-tools.ts
@@ -134,6 +134,7 @@ export function buildBuiltinTools(options: BuildBuiltinToolsOptions = {}): MakaT
     },
     {
       name: 'FormatJson',
+      activityKind: 'edit',
       description:
         'Validate and normalize a JSON file in place. Reads the file at `path`, '
         + 'parses it (throwing a parse-error hint on invalid JSON), optionally sorts '


### PR DESCRIPTION
## Summary

Give the `FormatJson` builtin tool the `edit` activity kind, fixing the `test:dist` failure on `main`.

## Why

#658 added the `FormatJson` builtin but omitted `activityKind` and didn't update the `builtin-tools` semantic-category test expectation. The test `declares stable semantic categories independently of tool names` then saw `FormatJson: undefined` in the `name → activityKind` map and failed `toEqual`. `test:dist` has been red on `main` since (last 3+ CI runs, starting at `3127732a`).

Refs #658.

## Scope

Changed:
- `packages/runtime/src/builtin-tools.ts` — `FormatJson` gets `activityKind: 'edit'`.
- `packages/runtime/src/__tests__/builtin-tools.test.ts` — expectation table adds `FormatJson: 'edit'`.

Not included:
- No other tools touched; no UI/headless change. `grep` confirms no other `FormatJson` assertions across the repo.

## Verification

- `npm run -w @maka/runtime test` — pass 1228, fail 0 (was failing on `builtin-tools.test.js` before).
- `npm run typecheck` — clean across all workspaces.
- Confirmed no other `FormatJson` assertions exist outside `builtin-tools.test.ts`.

## User-facing impact

None. `activityKind` drives tool-activity grouping in the UI timeline; `FormatJson` now groups with `Write`/`Edit` (it reads + rewrites a file in place) instead of falling through to the unknown bucket. No changelog entry needed (tool added in #658, this only fixes its missing category).

## Reviewer notes

- One intent: give `FormatJson` the semantic category #658 should have shipped with — implementation + test expectation in one commit.
- `edit` is chosen over `command` because FormatJson's impl calls `writeFile` on an existing file, matching `Write`/`Edit`, not `Bash` (arbitrary command).
- This unblocks the red `main` so docs PR #725 (and anything else) can land green.

## Checklist

- [x] Scope matches the PR title and excludes unrelated changes
- [x] Verification lists commands/results, or explains why they were not run
- [x] User-facing impact, docs, changelog, migrations, and breaking changes are noted, or marked none
- [x] Risk, rollback, or review focus is called out for non-trivial changes
- [x] UI changes include screenshots/video, or explain why not applicable (N/A: no UI change)