### PR TITLE
fix(runtime): replace history compact artifacts with ledger checkpoints

### DIFF
--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -161,7 +161,6 @@ import { buildOfficeDocumentEditTool, buildOfficeDocumentTool } from './office-d
 import {
   buildLlmHistorySummarizer,
   loadHistoryCompactBlocksFromArtifacts,
-  persistHistoryCompactBlocksToArtifacts,
 } from '@maka/runtime';
 import {
   loadSynthesisCacheBlocksFromArtifacts,
@@ -792,22 +791,13 @@ backends.register('ai-sdk', async (ctx) => {
     readAttachmentBytes: createAttachmentByteReader({ artifactStore, sessionId: ctx.sessionId }),
     supportsVision,
     loadHistoryCompact: (event) => loadHistoryCompactBlocksFromArtifacts(artifactStore, event),
-    writeHistoryCompact: (event) => persistHistoryCompactBlocksToArtifacts(artifactStore, event, {
-      summarize: buildLlmHistorySummarizer({
-        // Reuse the same connection/model the session already drives, so the
-        // summary stays consistent with the model that will consume it.
-        resolveModel: () =>
-          getAIModel({ connection, apiKey: apiKey ?? '', modelId: model, fetch: modelFetch }),
-        maxOutputTokens: 4096,
-      }),
-      onArtifactCreated: (artifact) => {
-        safeSendToRenderer('artifacts:changed', {
-          reason: 'created',
-          artifactId: artifact.id,
-          sessionId: artifact.sessionId,
-          ts: Date.now(),
-        });
-      },
+    loadHistoryCompactCheckpoint: ctx.loadHistoryCompactCheckpoint,
+    summarizeHistoryCompact: buildLlmHistorySummarizer({
+      // Reuse the same connection/model the session already drives, so the
+      // summary stays consistent with the model that will consume it.
+      resolveModel: () =>
+        getAIModel({ connection, apiKey: apiKey ?? '', modelId: model, fetch: modelFetch }),
+      maxOutputTokens: 4096,
     }),
     loadSynthesisCache: (event) => loadSynthesisCacheBlocksFromArtifacts(artifactStore, event),
     writeSynthesisCache: (event) => persistSynthesisCacheBlocksToArtifacts(artifactStore, event, {
@@ -821,6 +811,7 @@ backends.register('ai-sdk', async (ctx) => {
       },
     }),
     recordRunTrace: ctx.recordRunTrace,
+    recordHistoryCompactCheckpoint: ctx.recordHistoryCompactCheckpoint,
     recordActiveFullCompactBlock: ctx.recordActiveFullCompactBlock,
     recordSemanticCompactBlock: ctx.recordSemanticCompactBlock,
     newId: randomUUID,

--- a/packages/cli/src/__tests__/pi-transcript.test.ts
+++ b/packages/cli/src/__tests__/pi-transcript.test.ts
@@ -368,6 +368,24 @@ describe('Maka Pi TUI transcript', () => {
     ]);
   });
 
+  test('rebuilds fail-open notes without claiming history was trimmed', () => {
+    const state = createMakaPiTranscriptState();
+
+    replaceTranscriptWithStoredMessages(state, [{
+      type: 'system_note',
+      id: 'note-failed-open',
+      turnId: 'turn-1',
+      ts: 1,
+      kind: 'context_compaction_failed_open',
+    }] satisfies StoredMessage[]);
+
+    assert.deepEqual(state.entries.filter((entry) => entry.kind === 'notice'), [{
+      kind: 'notice',
+      level: 'info',
+      text: 'Context summary failed; the session continued and will retry next turn.',
+    }]);
+  });
+
   test('renders every transcript line within the terminal width', () => {
     const state = createMakaPiTranscriptState();
     appendUserPrompt(state, 'please inspect a very long path under packages/runtime/src');

--- a/packages/cli/src/__tests__/pi-transcript.test.ts
+++ b/packages/cli/src/__tests__/pi-transcript.test.ts
@@ -382,7 +382,7 @@ describe('Maka Pi TUI transcript', () => {
     assert.deepEqual(state.entries.filter((entry) => entry.kind === 'notice'), [{
       kind: 'notice',
       level: 'info',
-      text: 'Context summary failed; the session continued and will retry next turn.',
+      text: 'Context summary failed; the session continued without a new summary.',
     }]);
   });
 

--- a/packages/cli/src/pi-transcript.ts
+++ b/packages/cli/src/pi-transcript.ts
@@ -626,6 +626,8 @@ function systemNoteText(message: SystemNoteMessage): string | undefined {
       return 'Model changed.';
     case 'context_compacted':
       return 'Context compacted to keep this session within the model window.';
+    case 'context_compaction_failed_open':
+      return 'Context summary failed; older details were trimmed and will be retried next turn.';
     case 'error':
       return 'Session recorded an error.';
     case 'abort':

--- a/packages/cli/src/pi-transcript.ts
+++ b/packages/cli/src/pi-transcript.ts
@@ -627,7 +627,7 @@ function systemNoteText(message: SystemNoteMessage): string | undefined {
     case 'context_compacted':
       return 'Context compacted to keep this session within the model window.';
     case 'context_compaction_failed_open':
-      return 'Context summary failed; the session continued and will retry next turn.';
+      return 'Context summary failed; the session continued without a new summary.';
     case 'error':
       return 'Session recorded an error.';
     case 'abort':

--- a/packages/cli/src/pi-transcript.ts
+++ b/packages/cli/src/pi-transcript.ts
@@ -627,7 +627,7 @@ function systemNoteText(message: SystemNoteMessage): string | undefined {
     case 'context_compacted':
       return 'Context compacted to keep this session within the model window.';
     case 'context_compaction_failed_open':
-      return 'Context summary failed; older details were trimmed and will be retried next turn.';
+      return 'Context summary failed; the session continued and will retry next turn.';
     case 'error':
       return 'Session recorded an error.';
     case 'abort':

--- a/packages/cli/src/runtime-bootstrap.ts
+++ b/packages/cli/src/runtime-bootstrap.ts
@@ -20,7 +20,6 @@ import {
   evaluateAutomationCanFire,
   getAIModel,
   loadHistoryCompactBlocksFromArtifacts,
-  persistHistoryCompactBlocksToArtifacts,
   type AutomationDefinition,
   type GoalContinuationDeps,
   type ShellRunUpdate,
@@ -207,20 +206,20 @@ export async function createMakaCliRuntimeContext(
       providerOptions: buildProviderOptions(ready.connection, ready.model, ctx.header.thinkingLevel),
       contextBudget: buildCliContextBudgetPolicy(ready.connection, ready.model),
       loadHistoryCompact: (event) => loadHistoryCompactBlocksFromArtifacts(artifactStore, event),
-      writeHistoryCompact: (event) => persistHistoryCompactBlocksToArtifacts(artifactStore, event, {
-        summarize: buildLlmHistorySummarizer({
-          // Reuse the same connection/model the session already drives, so the
-          // summary stays consistent with the model that will consume it.
-          resolveModel: () =>
-            getAIModel({
-              connection: ready.connection,
-              apiKey: ready.apiKey,
-              modelId: ready.model,
-              fetch: modelFetch,
-            }),
-          maxOutputTokens: 4096,
-        }),
+      loadHistoryCompactCheckpoint: ctx.loadHistoryCompactCheckpoint,
+      summarizeHistoryCompact: buildLlmHistorySummarizer({
+        // Reuse the same connection/model the session already drives, so the
+        // summary stays consistent with the model that will consume it.
+        resolveModel: () =>
+          getAIModel({
+            connection: ready.connection,
+            apiKey: ready.apiKey,
+            modelId: ready.model,
+            fetch: modelFetch,
+          }),
+        maxOutputTokens: 4096,
       }),
+      recordHistoryCompactCheckpoint: ctx.recordHistoryCompactCheckpoint,
       systemPrompt: async ({ cwd }) => {
         const settings = await settingsStore.get();
         return buildCliSystemPrompt({ settings, cwd });

--- a/packages/core/src/agent-run.ts
+++ b/packages/core/src/agent-run.ts
@@ -63,6 +63,7 @@ export type AgentRunEventType =
   | 'permission_decided'
   | 'permission_failed'
   | 'usage_recorded'
+  | 'history_compact_checkpoint_recorded'
   | 'active_full_compact_block_recorded'
   | 'semantic_compact_block_recorded'
   | 'abort_requested'

--- a/packages/core/src/agent-run.ts
+++ b/packages/core/src/agent-run.ts
@@ -91,4 +91,15 @@ export interface AgentRunStore {
   listSessionRuns(sessionId: string): Promise<AgentRunHeader[]>;
   appendEvent(sessionId: string, runId: string, event: AgentRunEvent): Promise<void>;
   readEvents(sessionId: string, runId: string): Promise<AgentRunEvent[]>;
+  /** `undefined` means uninitialized; `null` is an initialized empty projection. */
+  readEventProjection?(
+    sessionId: string,
+    type: AgentRunEventType,
+  ): Promise<AgentRunEvent | null | undefined>;
+  /** Writes a rebuildable bounded projection without changing the canonical run ledger. */
+  writeEventProjection?(
+    sessionId: string,
+    type: AgentRunEventType,
+    event: AgentRunEvent | null,
+  ): Promise<void>;
 }

--- a/packages/core/src/agent-run.ts
+++ b/packages/core/src/agent-run.ts
@@ -101,5 +101,6 @@ export interface AgentRunStore {
     sessionId: string,
     type: AgentRunEventType,
     event: AgentRunEvent | null,
+    options?: { replaceEventId?: string },
   ): Promise<void>;
 }

--- a/packages/core/src/agent-run.ts
+++ b/packages/core/src/agent-run.ts
@@ -96,4 +96,10 @@ export interface AgentRunStore {
     sessionId: string,
     type: AgentRunEventType,
   ): Promise<AgentRunEvent | null | undefined>;
+  /** Rewrites derived state after the canonical event ledger repairs an absent or damaged projection. */
+  repairEventProjection?(
+    sessionId: string,
+    type: AgentRunEventType,
+    event: AgentRunEvent | null,
+  ): Promise<void>;
 }

--- a/packages/core/src/agent-run.ts
+++ b/packages/core/src/agent-run.ts
@@ -96,10 +96,4 @@ export interface AgentRunStore {
     sessionId: string,
     type: AgentRunEventType,
   ): Promise<AgentRunEvent | null | undefined>;
-  /** Writes a rebuildable bounded projection without changing the canonical run ledger. */
-  writeEventProjection?(
-    sessionId: string,
-    type: AgentRunEventType,
-    event: AgentRunEvent | null,
-  ): Promise<void>;
 }

--- a/packages/core/src/session.ts
+++ b/packages/core/src/session.ts
@@ -332,6 +332,7 @@ export interface SystemNoteMessage {
     | 'mode_change'
     | 'model_change'
     | 'context_compacted'
+    | 'context_compaction_failed_open'
     | 'error'
     | 'abort';
   /** Shape depends on `kind`. */

--- a/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
+++ b/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
@@ -1585,6 +1585,64 @@ describe('AiSdkBackend model history', () => {
     assert.equal(result.contextBudget?.compactionDecisions?.[0]?.decision, 'replaced');
   });
 
+  test('manual compactHistory writes a V2 checkpoint without the legacy artifact writer', async () => {
+    const recorded: HistoryCompactCheckpoint[] = [];
+    const backend = new AiSdkBackend({
+      sessionId: 'session-1',
+      header: header(),
+      appendMessage: async () => {},
+      connection: connection(),
+      apiKey: 'sk-test',
+      modelId: 'mock-model-id',
+      permissionEngine: new PermissionEngine({ newId: () => 'permission-id', now: () => 1 }),
+      modelFactory: () => completionModel(),
+      tools: [],
+      newId: idGenerator(),
+      now: monotonicClock(),
+      contextBudget: {
+        name: 'manual-v2-compact-test',
+        maxHistoryEstimatedTokens: 10_000,
+        minRecentTurns: 1,
+        charsPerToken: 1,
+      },
+      summarizeHistoryCompact: async () => 'MANUAL_V2_HISTORY_COMPACT_SENTINEL',
+      recordHistoryCompactCheckpoint: (checkpoint) => { recorded.push(checkpoint); },
+    });
+
+    const result = await backend.compactHistory({
+      turnId: 'turn-compact',
+      runtimeContext: [
+        runtimeTextEvent({
+          id: 'manual-v2-old-1',
+          turnId: 'turn-old-1',
+          role: 'user',
+          author: 'user',
+          text: 'manual v2 old alpha '.repeat(12),
+        }),
+        runtimeTextEvent({
+          id: 'manual-v2-old-2',
+          turnId: 'turn-old-2',
+          role: 'model',
+          author: 'agent',
+          text: 'manual v2 old beta '.repeat(12),
+        }),
+        runtimeTextEvent({
+          id: 'manual-v2-recent',
+          turnId: 'turn-recent',
+          role: 'user',
+          author: 'user',
+          text: 'manual v2 recent retained context',
+        }),
+      ],
+    });
+
+    assert.equal(recorded.length, 1);
+    assert.equal(recorded[0]?.summary, 'MANUAL_V2_HISTORY_COMPACT_SENTINEL');
+    assert.deepEqual(recorded[0]?.coverage.eventCount, 2);
+    assert.equal(result.contextBudget?.historyCompactBlocksWritten, 1);
+    assert.equal(result.contextBudget?.compactionDecisions?.[0]?.decision, 'replaced');
+  });
+
   test('manual compactHistory writes the current fold instead of reusing a loaded prefix block', async () => {
     const covered = [
       runtimeTextEvent({

--- a/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
+++ b/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
@@ -1643,6 +1643,82 @@ describe('AiSdkBackend model history', () => {
     assert.equal(result.contextBudget?.compactionDecisions?.[0]?.decision, 'replaced');
   });
 
+  test('manual compactHistory rolls forward from the previous V2 checkpoint', async () => {
+    const oldEvents = [
+      runtimeTextEvent({
+        id: 'manual-v2-roll-old-1',
+        turnId: 'manual-v2-roll-turn-1',
+        role: 'user',
+        author: 'user',
+        text: 'manual v2 roll old alpha '.repeat(12),
+      }),
+      runtimeTextEvent({
+        id: 'manual-v2-roll-old-2',
+        turnId: 'manual-v2-roll-turn-2',
+        role: 'model',
+        author: 'agent',
+        text: 'manual v2 roll old beta '.repeat(12),
+      }),
+    ];
+    const previous = buildHistoryCompactCheckpoint({
+      sessionId: 'session-1',
+      coveredRuntimeEvents: oldEvents.slice(0, 1),
+      summary: 'MANUAL_V2_PREVIOUS_SUMMARY',
+      charsPerToken: 1,
+    });
+    const summaryInputs: Array<{ previous?: string; newlyFoldedIds: string[] }> = [];
+    const recorded: HistoryCompactCheckpoint[] = [];
+    const backend = new AiSdkBackend({
+      sessionId: 'session-1',
+      header: header(),
+      appendMessage: async () => {},
+      connection: connection(),
+      apiKey: 'sk-test',
+      modelId: 'mock-model-id',
+      permissionEngine: new PermissionEngine({ newId: () => 'permission-id', now: () => 1 }),
+      modelFactory: () => completionModel(),
+      tools: [],
+      newId: idGenerator(),
+      now: monotonicClock(),
+      contextBudget: {
+        name: 'manual-v2-roll-test',
+        maxHistoryEstimatedTokens: 10_000,
+        minRecentTurns: 1,
+        charsPerToken: 1,
+      },
+      loadHistoryCompactCheckpoint: () => previous,
+      summarizeHistoryCompact: async (input) => {
+        summaryInputs.push({
+          previous: input.previousCheckpoint?.summary,
+          newlyFoldedIds: (input.newlyFoldedRuntimeEvents ?? []).map((event) => event.id),
+        });
+        return 'MANUAL_V2_ROLLED_SUMMARY';
+      },
+      recordHistoryCompactCheckpoint: (checkpoint) => { recorded.push(checkpoint); },
+    });
+
+    await backend.compactHistory({
+      turnId: 'turn-compact',
+      runtimeContext: [
+        ...oldEvents,
+        runtimeTextEvent({
+          id: 'manual-v2-roll-recent',
+          turnId: 'manual-v2-roll-recent-turn',
+          role: 'user',
+          author: 'user',
+          text: 'manual v2 roll retained context',
+        }),
+      ],
+    });
+
+    assert.deepEqual(summaryInputs, [{
+      previous: 'MANUAL_V2_PREVIOUS_SUMMARY',
+      newlyFoldedIds: ['manual-v2-roll-old-2'],
+    }]);
+    assert.equal(recorded[0]?.previousCheckpointId, previous.checkpointId);
+    assert.equal(recorded[0]?.coverage.eventCount, 2);
+  });
+
   test('manual compactHistory writes the current fold instead of reusing a loaded prefix block', async () => {
     const covered = [
       runtimeTextEvent({
@@ -2299,7 +2375,6 @@ describe('AiSdkBackend model history', () => {
     });
     const recorded: HistoryCompactCheckpoint[] = [];
     const summaryInputs: Array<{ previous?: string; newlyFoldedIds: string[] }> = [];
-    let checkpointLoadCalls = 0;
     const firstModel = completionModel();
     const firstBackend = new AiSdkBackend({
       sessionId: 'session-1', header: header(), appendMessage: async () => {},
@@ -2314,10 +2389,7 @@ describe('AiSdkBackend model history', () => {
           maxSummaryEstimatedTokens: 500,
         },
       },
-      loadHistoryCompactCheckpoint: () => {
-        checkpointLoadCalls += 1;
-        return previous;
-      },
+      loadHistoryCompactCheckpoint: () => previous,
       summarizeHistoryCompact: async (input) => {
         summaryInputs.push({
           previous: input.previousCheckpoint?.summary,
@@ -2340,14 +2412,6 @@ describe('AiSdkBackend model history', () => {
     assert.match(firstPrompt, /V2_ROLLED_SUMMARY/);
     assert.equal(firstPrompt.includes('V2 old source one'), false);
     assert.equal(firstPrompt.includes('V2 old source two'), false);
-
-    await drain(firstBackend.send({
-      turnId: 'turn-same-backend', text: 'continue in the same session', context: [], runtimeContext: [...oldEvents, recent],
-    }));
-
-    assert.equal(checkpointLoadCalls, 1);
-    assert.deepEqual(summaryInputs, [{ previous: 'V2_PREVIOUS_SUMMARY', newlyFoldedIds: ['v2-old-2'] }]);
-    assert.match(JSON.stringify(firstModel.doStreamCalls[1]?.prompt), /V2_ROLLED_SUMMARY/);
 
     let reuseSummaryCalls = 0;
     const secondModel = completionModel();

--- a/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
+++ b/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
@@ -40,6 +40,7 @@ import {
   type HistoryCompactBlock,
   type SynthesisCacheBlock,
 } from '../context-budget.js';
+import { buildHistoryCompactCheckpoint, type HistoryCompactCheckpoint } from '../history-compact-checkpoint.js';
 import {
   loadHistoryCompactBlocksFromArtifacts,
   persistHistoryCompactBlocksToArtifacts,
@@ -2216,6 +2217,188 @@ describe('AiSdkBackend model history', () => {
       storedMessages.some((message) => message.type === 'system_note' && message.kind === 'context_compacted'),
       true,
     );
+  });
+
+  test('rolls a V2 checkpoint from the prior summary plus only newly evicted events, then reuses it', async () => {
+    const oldEvents = [
+      runtimeTextEvent({
+        id: 'v2-old-1', turnId: 'v2-turn-1', role: 'user', author: 'user',
+        text: 'V2 old source one '.repeat(20),
+      }),
+      runtimeTextEvent({
+        id: 'v2-old-2', turnId: 'v2-turn-2', role: 'model', author: 'agent',
+        text: 'V2 old source two '.repeat(80),
+      }),
+    ];
+    const recent = runtimeTextEvent({
+      id: 'v2-recent', turnId: 'v2-turn-recent', role: 'user', author: 'user', text: 'V2 retained tail',
+    });
+    const previous = buildHistoryCompactCheckpoint({
+      sessionId: 'session-1',
+      coveredRuntimeEvents: oldEvents.slice(0, 1),
+      summary: 'V2_PREVIOUS_SUMMARY',
+      charsPerToken: 1,
+    });
+    const recorded: HistoryCompactCheckpoint[] = [];
+    const summaryInputs: Array<{ previous?: string; newlyFoldedIds: string[] }> = [];
+    const firstModel = completionModel();
+    const firstBackend = new AiSdkBackend({
+      sessionId: 'session-1', header: header(), appendMessage: async () => {},
+      connection: connection(), apiKey: 'sk-test', modelId: 'mock-model-id',
+      permissionEngine: new PermissionEngine({ newId: () => 'permission-id', now: () => 1 }),
+      modelFactory: () => firstModel, tools: [], newId: idGenerator(), now: monotonicClock(),
+      contextBudget: {
+        maxHistoryEstimatedTokens: 1_500,
+        charsPerToken: 1,
+        historyCompact: {
+          enabled: true, mode: 'read_write', highWaterRatio: 0.01, tailEstimatedTokens: 20,
+          maxSummaryEstimatedTokens: 500,
+        },
+      },
+      loadHistoryCompactCheckpoint: () => previous,
+      summarizeHistoryCompact: async (input) => {
+        summaryInputs.push({
+          previous: input.previousCheckpoint?.summary,
+          newlyFoldedIds: (input.newlyFoldedRuntimeEvents ?? []).map((event) => event.id),
+        });
+        return 'V2_ROLLED_SUMMARY';
+      },
+      recordHistoryCompactCheckpoint: (checkpoint) => { recorded.push(checkpoint); },
+    });
+
+    await drain(firstBackend.send({
+      turnId: 'turn-current', text: 'continue', context: [], runtimeContext: [...oldEvents, recent],
+    }));
+
+    assert.deepEqual(summaryInputs, [{ previous: 'V2_PREVIOUS_SUMMARY', newlyFoldedIds: ['v2-old-2'] }]);
+    assert.equal(recorded.length, 1);
+    assert.equal(recorded[0]?.previousCheckpointId, previous.checkpointId);
+    assert.equal(recorded[0]?.coverage.eventCount, 2);
+    const firstPrompt = JSON.stringify(compactPrompt(firstModel));
+    assert.match(firstPrompt, /V2_ROLLED_SUMMARY/);
+    assert.equal(firstPrompt.includes('V2 old source one'), false);
+    assert.equal(firstPrompt.includes('V2 old source two'), false);
+
+    let reuseSummaryCalls = 0;
+    const secondModel = completionModel();
+    const secondBackend = new AiSdkBackend({
+      sessionId: 'session-1', header: header(), appendMessage: async () => {},
+      connection: connection(), apiKey: 'sk-test', modelId: 'mock-model-id',
+      permissionEngine: new PermissionEngine({ newId: () => 'permission-id', now: () => 1 }),
+      modelFactory: () => secondModel, tools: [], newId: idGenerator(), now: monotonicClock(),
+      contextBudget: {
+        maxHistoryEstimatedTokens: 1_500,
+        charsPerToken: 1,
+        historyCompact: {
+          enabled: true, mode: 'read_write', highWaterRatio: 0.01, tailEstimatedTokens: 20,
+          maxSummaryEstimatedTokens: 500,
+        },
+      },
+      loadHistoryCompactCheckpoint: () => recorded[0],
+      summarizeHistoryCompact: async () => { reuseSummaryCalls += 1; return 'unexpected'; },
+      recordHistoryCompactCheckpoint: () => { throw new Error('must not rewrite a reusable checkpoint'); },
+    });
+    await drain(secondBackend.send({
+      turnId: 'turn-next', text: 'continue again', context: [], runtimeContext: [...oldEvents, recent],
+    }));
+
+    assert.equal(reuseSummaryCalls, 0);
+    assert.match(JSON.stringify(compactPrompt(secondModel)), /V2_ROLLED_SUMMARY/);
+  });
+
+  test('V2 blank summary fails open to the retained tail and emits one visible notice', async () => {
+    const model = completionModel();
+    const storedMessages: StoredMessage[] = [];
+    let recordCalls = 0;
+    const backend = new AiSdkBackend({
+      sessionId: 'session-1', header: header(), appendMessage: async (message) => { storedMessages.push(message); },
+      connection: connection(), apiKey: 'sk-test', modelId: 'mock-model-id',
+      permissionEngine: new PermissionEngine({ newId: () => 'permission-id', now: () => 1 }),
+      modelFactory: () => model, tools: [], newId: idGenerator(), now: monotonicClock(),
+      contextBudget: {
+        maxHistoryEstimatedTokens: 1_500,
+        charsPerToken: 1,
+        historyCompact: {
+          enabled: true, mode: 'read_write', highWaterRatio: 0.01, tailEstimatedTokens: 20,
+          maxSummaryEstimatedTokens: 500,
+        },
+      },
+      summarizeHistoryCompact: async () => '   ',
+      recordHistoryCompactCheckpoint: () => { recordCalls += 1; },
+    });
+    await drain(backend.send({
+      turnId: 'turn-current', text: 'continue', context: [],
+      runtimeContext: [
+        runtimeTextEvent({
+          id: 'blank-old-1', turnId: 'blank-turn-1', role: 'user', author: 'user',
+          text: 'blank old source one '.repeat(30),
+        }),
+        runtimeTextEvent({
+          id: 'blank-old-2', turnId: 'blank-turn-2', role: 'model', author: 'agent',
+          text: 'blank old source two '.repeat(50),
+        }),
+        runtimeTextEvent({
+          id: 'blank-recent', turnId: 'blank-recent-turn', role: 'user', author: 'user', text: 'BLANK_RETAINED_TAIL',
+        }),
+      ],
+    }));
+
+    const prompt = JSON.stringify(compactPrompt(model));
+    assert.equal(prompt.includes('blank old source one'), false);
+    assert.equal(prompt.includes('blank old source two'), false);
+    assert.match(prompt, /BLANK_RETAINED_TAIL/);
+    assert.equal(recordCalls, 0);
+    assert.equal(
+      storedMessages.filter((message) =>
+        message.type === 'system_note' && message.kind === 'context_compaction_failed_open'
+      ).length,
+      1,
+    );
+  });
+
+  test('V2 rolling failure keeps the prior checkpoint and the newest complete raw turns that fit', async () => {
+    const model = completionModel();
+    const old = runtimeTextEvent({
+      id: 'fallback-covered', turnId: 'fallback-turn-1', role: 'user', author: 'user',
+      text: 'FALLBACK_ALREADY_COVERED_RAW '.repeat(20),
+    });
+    const evicted = runtimeTextEvent({
+      id: 'fallback-evicted', turnId: 'fallback-turn-2', role: 'model', author: 'agent',
+      text: 'FALLBACK_NEWLY_EVICTED_RAW '.repeat(80),
+    });
+    const recent = runtimeTextEvent({
+      id: 'fallback-recent', turnId: 'fallback-turn-3', role: 'user', author: 'user',
+      text: 'FALLBACK_NEWEST_COMPLETE_TURN',
+    });
+    const previous = buildHistoryCompactCheckpoint({
+      sessionId: 'session-1', coveredRuntimeEvents: [old], summary: 'FALLBACK_PRIOR_SUMMARY', charsPerToken: 1,
+    });
+    const backend = new AiSdkBackend({
+      sessionId: 'session-1', header: header(), appendMessage: async () => {},
+      connection: connection(), apiKey: 'sk-test', modelId: 'mock-model-id',
+      permissionEngine: new PermissionEngine({ newId: () => 'permission-id', now: () => 1 }),
+      modelFactory: () => model, tools: [], newId: idGenerator(), now: monotonicClock(),
+      contextBudget: {
+        maxHistoryEstimatedTokens: 1_500, charsPerToken: 1,
+        historyCompact: {
+          enabled: true, mode: 'read_write', highWaterRatio: 0.01, tailEstimatedTokens: 40,
+          maxSummaryEstimatedTokens: 500,
+        },
+      },
+      loadHistoryCompactCheckpoint: () => previous,
+      summarizeHistoryCompact: async () => undefined,
+      recordHistoryCompactCheckpoint: () => { throw new Error('failed summary must not be recorded'); },
+    });
+
+    await drain(backend.send({
+      turnId: 'turn-current', text: 'continue', context: [], runtimeContext: [old, evicted, recent],
+    }));
+
+    const prompt = JSON.stringify(compactPrompt(model));
+    assert.match(prompt, /FALLBACK_PRIOR_SUMMARY/);
+    assert.match(prompt, /FALLBACK_NEWEST_COMPLETE_TURN/);
+    assert.equal(prompt.includes('FALLBACK_ALREADY_COVERED_RAW'), false);
+    assert.equal(prompt.includes('FALLBACK_NEWLY_EVICTED_RAW'), false);
   });
 
   test('read_write history compact fail-open sends original history when durable write fails', async () => {

--- a/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
+++ b/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
@@ -1874,6 +1874,44 @@ describe('AiSdkBackend model history', () => {
     }
   });
 
+  test('manual compactHistory does not record a rebuilt checkpoint whose envelope exceeds current limits', async () => {
+    let recordCalls = 0;
+    const backend = new AiSdkBackend({
+      sessionId: 'session-1', header: header(), appendMessage: async () => {},
+      connection: connection(), apiKey: 'sk-test', modelId: 'mock-model-id',
+      permissionEngine: new PermissionEngine({ newId: () => 'permission-id', now: () => 1 }),
+      modelFactory: () => completionModel(), tools: [], newId: idGenerator(), now: monotonicClock(),
+      contextBudget: {
+        name: 'manual-v2-envelope-budget-test', maxHistoryEstimatedTokens: 10_000,
+        minRecentTurns: 1, charsPerToken: 1,
+        historyCompact: { enabled: true, maxBlockEstimatedTokens: 100, maxEstimatedTokens: 10_000 },
+      },
+      summarizeHistoryCompact: async () => 'TINY_SUMMARY',
+      recordHistoryCompactCheckpoint: () => { recordCalls += 1; },
+    });
+
+    const result = await backend.compactHistory({
+      turnId: 'turn-compact',
+      runtimeContext: [
+        runtimeTextEvent({
+          id: 'manual-v2-envelope-old-1', turnId: 'manual-v2-envelope-turn-1',
+          role: 'user', author: 'user', text: 'old alpha '.repeat(20),
+        }),
+        runtimeTextEvent({
+          id: 'manual-v2-envelope-old-2', turnId: 'manual-v2-envelope-turn-2',
+          role: 'model', author: 'agent', text: 'old beta '.repeat(20),
+        }),
+        runtimeTextEvent({
+          id: 'manual-v2-envelope-recent', turnId: 'manual-v2-envelope-recent-turn',
+          role: 'user', author: 'user', text: 'recent tail',
+        }),
+      ],
+    });
+
+    assert.equal(recordCalls, 0);
+    assert.equal(result.contextBudget?.historyCompactWriteFailures, 1);
+  });
+
   test('manual compactHistory writes the current fold instead of reusing a loaded prefix block', async () => {
     const covered = [
       runtimeTextEvent({
@@ -2688,6 +2726,51 @@ describe('AiSdkBackend model history', () => {
     assert.match(prompt, /FALLBACK_NEWEST_COMPLETE_TURN/);
     assert.equal(prompt.includes('FALLBACK_ALREADY_COVERED_RAW'), false);
     assert.equal(prompt.includes('FALLBACK_NEWLY_EVICTED_RAW'), false);
+  });
+
+  test('V2 rolling failure does not replay a prior checkpoint outside current compact limits', async () => {
+    const model = completionModel();
+    const old = runtimeTextEvent({
+      id: 'invalid-fallback-covered', turnId: 'invalid-fallback-turn-1', role: 'user', author: 'user',
+      text: 'INVALID_FALLBACK_COVERED_RAW '.repeat(20),
+    });
+    const evicted = runtimeTextEvent({
+      id: 'invalid-fallback-evicted', turnId: 'invalid-fallback-turn-2', role: 'model', author: 'agent',
+      text: 'INVALID_FALLBACK_EVICTED_RAW '.repeat(50),
+    });
+    const recent = runtimeTextEvent({
+      id: 'invalid-fallback-recent', turnId: 'invalid-fallback-turn-3', role: 'user', author: 'user',
+      text: 'INVALID_FALLBACK_RETAINED_TAIL',
+    });
+    const previous = buildHistoryCompactCheckpoint({
+      sessionId: 'session-1', coveredRuntimeEvents: [old],
+      summary: 'INVALID_FALLBACK_PRIOR_SUMMARY '.repeat(20), charsPerToken: 1,
+    });
+    assert.ok(previous.estimatedTokens > 100);
+    const backend = new AiSdkBackend({
+      sessionId: 'session-1', header: header(), appendMessage: async () => {},
+      connection: connection(), apiKey: 'sk-test', modelId: 'mock-model-id',
+      permissionEngine: new PermissionEngine({ newId: () => 'permission-id', now: () => 1 }),
+      modelFactory: () => model, tools: [], newId: idGenerator(), now: monotonicClock(),
+      contextBudget: {
+        maxHistoryEstimatedTokens: 1_500, charsPerToken: 1,
+        historyCompact: {
+          enabled: true, mode: 'read_write', highWaterRatio: 0.01, tailEstimatedTokens: 40,
+          maxBlockEstimatedTokens: 10_000, maxEstimatedTokens: 100,
+        },
+      },
+      loadHistoryCompactCheckpoint: () => previous,
+      summarizeHistoryCompact: async () => undefined,
+      recordHistoryCompactCheckpoint: () => { throw new Error('failed summary must not be recorded'); },
+    });
+
+    await drain(backend.send({
+      turnId: 'turn-current', text: 'continue', context: [], runtimeContext: [old, evicted, recent],
+    }));
+
+    const prompt = JSON.stringify(compactPrompt(model));
+    assert.equal(prompt.includes('INVALID_FALLBACK_PRIOR_SUMMARY'), false);
+    assert.match(prompt, /INVALID_FALLBACK_RETAINED_TAIL/);
   });
 
   test('read_write history compact fail-open sends original history when durable write fails', async () => {

--- a/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
+++ b/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
@@ -1794,6 +1794,86 @@ describe('AiSdkBackend model history', () => {
     assert.equal(result.contextBudget?.compactionDecisions?.[0]?.reason, 'already_compacted');
   });
 
+  test('manual compactHistory rewrites a fully covered checkpoint that exceeds current limits', async () => {
+    const oldEvents = [
+      runtimeTextEvent({
+        id: 'manual-v2-refit-old-1',
+        turnId: 'manual-v2-refit-turn-1',
+        role: 'user',
+        author: 'user',
+        text: 'manual v2 refit old alpha '.repeat(12),
+      }),
+      runtimeTextEvent({
+        id: 'manual-v2-refit-old-2',
+        turnId: 'manual-v2-refit-turn-2',
+        role: 'model',
+        author: 'agent',
+        text: 'manual v2 refit old beta '.repeat(12),
+      }),
+    ];
+    const previous = buildHistoryCompactCheckpoint({
+      sessionId: 'session-1',
+      coveredRuntimeEvents: oldEvents,
+      summary: 'OVERSIZED_PREVIOUS_SUMMARY '.repeat(100),
+      charsPerToken: 1,
+    });
+
+    for (const limits of [
+      { maxHistoryEstimatedTokens: 10_000, maxBlockEstimatedTokens: 500 },
+      { maxHistoryEstimatedTokens: 1_400, maxBlockEstimatedTokens: 10_000 },
+    ]) {
+      let summarizeCalls = 0;
+      const recorded: HistoryCompactCheckpoint[] = [];
+      const backend = new AiSdkBackend({
+        sessionId: 'session-1',
+        header: header(),
+        appendMessage: async () => {},
+        connection: connection(),
+        apiKey: 'sk-test',
+        modelId: 'mock-model-id',
+        permissionEngine: new PermissionEngine({ newId: () => 'permission-id', now: () => 1 }),
+        modelFactory: () => completionModel(),
+        tools: [],
+        newId: idGenerator(),
+        now: monotonicClock(),
+        contextBudget: {
+          name: 'manual-v2-refit-test',
+          maxHistoryEstimatedTokens: limits.maxHistoryEstimatedTokens,
+          minRecentTurns: 1,
+          charsPerToken: 1,
+          historyCompact: {
+            enabled: true,
+            maxBlockEstimatedTokens: limits.maxBlockEstimatedTokens,
+          },
+        },
+        loadHistoryCompactCheckpoint: () => previous,
+        summarizeHistoryCompact: async () => {
+          summarizeCalls += 1;
+          return 'REFITTED_SUMMARY';
+        },
+        recordHistoryCompactCheckpoint: (checkpoint) => { recorded.push(checkpoint); },
+      });
+
+      const result = await backend.compactHistory({
+        turnId: 'turn-compact',
+        runtimeContext: [
+          ...oldEvents,
+          runtimeTextEvent({
+            id: 'manual-v2-refit-recent',
+            turnId: 'manual-v2-refit-recent-turn',
+            role: 'user',
+            author: 'user',
+            text: 'manual v2 refit retained context',
+          }),
+        ],
+      });
+
+      assert.equal(summarizeCalls, 1);
+      assert.equal(recorded.length, 1);
+      assert.equal(result.contextBudget?.compactionDecisions?.[0]?.decision, 'replaced');
+    }
+  });
+
   test('manual compactHistory writes the current fold instead of reusing a loaded prefix block', async () => {
     const covered = [
       runtimeTextEvent({

--- a/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
+++ b/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
@@ -1719,6 +1719,81 @@ describe('AiSdkBackend model history', () => {
     assert.equal(recorded[0]?.coverage.eventCount, 2);
   });
 
+  test('manual compactHistory reuses a checkpoint that already covers the full fold', async () => {
+    const oldEvents = [
+      runtimeTextEvent({
+        id: 'manual-v2-reuse-old-1',
+        turnId: 'manual-v2-reuse-turn-1',
+        role: 'user',
+        author: 'user',
+        text: 'manual v2 reuse old alpha '.repeat(12),
+      }),
+      runtimeTextEvent({
+        id: 'manual-v2-reuse-old-2',
+        turnId: 'manual-v2-reuse-turn-2',
+        role: 'model',
+        author: 'agent',
+        text: 'manual v2 reuse old beta '.repeat(12),
+      }),
+    ];
+    const previous = buildHistoryCompactCheckpoint({
+      sessionId: 'session-1',
+      coveredRuntimeEvents: oldEvents,
+      summary: 'MANUAL_V2_REUSED_SUMMARY',
+      charsPerToken: 1,
+    });
+    let summarizeCalls = 0;
+    let recordCalls = 0;
+    const backend = new AiSdkBackend({
+      sessionId: 'session-1',
+      header: header(),
+      appendMessage: async () => {},
+      connection: connection(),
+      apiKey: 'sk-test',
+      modelId: 'mock-model-id',
+      permissionEngine: new PermissionEngine({ newId: () => 'permission-id', now: () => 1 }),
+      modelFactory: () => completionModel(),
+      tools: [],
+      newId: idGenerator(),
+      now: monotonicClock(),
+      contextBudget: {
+        name: 'manual-v2-reuse-test',
+        maxHistoryEstimatedTokens: 10_000,
+        minRecentTurns: 1,
+        charsPerToken: 1,
+      },
+      loadHistoryCompactCheckpoint: () => previous,
+      summarizeHistoryCompact: async () => {
+        summarizeCalls += 1;
+        return 'must not resummarize an already covered fold';
+      },
+      recordHistoryCompactCheckpoint: () => {
+        recordCalls += 1;
+        throw new Error('equal coverage must not reach the recorder');
+      },
+    });
+
+    const result = await backend.compactHistory({
+      turnId: 'turn-compact',
+      runtimeContext: [
+        ...oldEvents,
+        runtimeTextEvent({
+          id: 'manual-v2-reuse-recent',
+          turnId: 'manual-v2-reuse-recent-turn',
+          role: 'user',
+          author: 'user',
+          text: 'manual v2 reuse retained context',
+        }),
+      ],
+    });
+
+    assert.equal(summarizeCalls, 0);
+    assert.equal(recordCalls, 0);
+    assert.equal(result.contextBudget?.historyCompactWriteFailures ?? 0, 0);
+    assert.equal(result.contextBudget?.compactionDecisions?.[0]?.decision, 'unchanged');
+    assert.equal(result.contextBudget?.compactionDecisions?.[0]?.reason, 'already_compacted');
+  });
+
   test('manual compactHistory writes the current fold instead of reusing a loaded prefix block', async () => {
     const covered = [
       runtimeTextEvent({

--- a/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
+++ b/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
@@ -2733,6 +2733,67 @@ describe('AiSdkBackend model history', () => {
     );
   });
 
+  test('falls back to V1 blocks when the V2 checkpoint loader fails', async () => {
+    const model = completionModel();
+    const events: SessionEvent[] = [];
+    const oldEvents = [
+      runtimeTextEvent({
+        id: 'v2-load-fail-old-1', turnId: 'v2-load-fail-turn-1', role: 'user', author: 'user',
+        text: 'v2 load failure old alpha '.repeat(12),
+      }),
+      runtimeTextEvent({
+        id: 'v2-load-fail-old-2', turnId: 'v2-load-fail-turn-2', role: 'model', author: 'agent',
+        text: 'v2 load failure old beta '.repeat(12),
+      }),
+    ];
+    const loadedBlock = buildHistoryCompactBlockFromSummary({
+      sessionId: 'session-1',
+      foldedRuntimeEvents: oldEvents,
+      summary: 'V1_FALLBACK_AFTER_V2_LOAD_FAILURE',
+      highWaterName: 'v1-fallback-after-v2-failure',
+      highWaterSeq: 2,
+      charsPerToken: 1,
+    });
+    let v1LoadCalls = 0;
+    const backend = new AiSdkBackend({
+      sessionId: 'session-1', header: header(), appendMessage: async () => {},
+      connection: connection(), apiKey: 'sk-test', modelId: 'mock-model-id',
+      permissionEngine: new PermissionEngine({ newId: () => 'permission-id', now: () => 1 }),
+      modelFactory: () => model, tools: [], newId: idGenerator(), now: monotonicClock(),
+      contextBudget: {
+        maxHistoryEstimatedTokens: 10_000, minRecentTurns: 1, charsPerToken: 1,
+        historyCompact: {
+          enabled: true, mode: 'read_write', highWaterRatio: 0.000001, targetRatio: 0.2,
+          tailEstimatedTokens: 1, minRecentTurns: 1, maxBlocks: 1, maxEstimatedTokens: 4096,
+        },
+      },
+      loadHistoryCompactCheckpoint: async () => { throw new Error('checkpoint ledger unavailable'); },
+      loadHistoryCompact: async () => {
+        v1LoadCalls += 1;
+        return { blocks: [loadedBlock] };
+      },
+    });
+
+    for await (const event of backend.send({
+      turnId: 'turn-current', text: 'continue', context: [],
+      runtimeContext: [
+        ...oldEvents,
+        runtimeTextEvent({
+          id: 'v2-load-fail-recent', turnId: 'v2-load-fail-recent-turn', role: 'user', author: 'user',
+          text: 'V2_LOAD_FAIL_RETAINED_TAIL',
+        }),
+      ],
+    })) events.push(event);
+
+    assert.equal(v1LoadCalls, 1);
+    assert.match(JSON.stringify(compactPrompt(model)), /V1_FALLBACK_AFTER_V2_LOAD_FAILURE/);
+    const usage = events.find((event): event is Extract<SessionEvent, { type: 'token_usage' }> =>
+      event.type === 'token_usage'
+    );
+    assert.equal(usage?.contextBudget?.historyCompactLoadFailures, 1);
+    assert.equal(usage?.contextBudget?.historyCompactBlocksLoaded, 1);
+  });
+
   test('replays a persisted compact block whose provenance JSON outgrows the token budget', async () => {
     const model = completionModel();
     const events: SessionEvent[] = [];

--- a/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
+++ b/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
@@ -2299,6 +2299,7 @@ describe('AiSdkBackend model history', () => {
     });
     const recorded: HistoryCompactCheckpoint[] = [];
     const summaryInputs: Array<{ previous?: string; newlyFoldedIds: string[] }> = [];
+    let checkpointLoadCalls = 0;
     const firstModel = completionModel();
     const firstBackend = new AiSdkBackend({
       sessionId: 'session-1', header: header(), appendMessage: async () => {},
@@ -2313,7 +2314,10 @@ describe('AiSdkBackend model history', () => {
           maxSummaryEstimatedTokens: 500,
         },
       },
-      loadHistoryCompactCheckpoint: () => previous,
+      loadHistoryCompactCheckpoint: () => {
+        checkpointLoadCalls += 1;
+        return previous;
+      },
       summarizeHistoryCompact: async (input) => {
         summaryInputs.push({
           previous: input.previousCheckpoint?.summary,
@@ -2336,6 +2340,14 @@ describe('AiSdkBackend model history', () => {
     assert.match(firstPrompt, /V2_ROLLED_SUMMARY/);
     assert.equal(firstPrompt.includes('V2 old source one'), false);
     assert.equal(firstPrompt.includes('V2 old source two'), false);
+
+    await drain(firstBackend.send({
+      turnId: 'turn-same-backend', text: 'continue in the same session', context: [], runtimeContext: [...oldEvents, recent],
+    }));
+
+    assert.equal(checkpointLoadCalls, 1);
+    assert.deepEqual(summaryInputs, [{ previous: 'V2_PREVIOUS_SUMMARY', newlyFoldedIds: ['v2-old-2'] }]);
+    assert.match(JSON.stringify(firstModel.doStreamCalls[1]?.prompt), /V2_ROLLED_SUMMARY/);
 
     let reuseSummaryCalls = 0;
     const secondModel = completionModel();

--- a/packages/runtime/src/__tests__/history-compact-artifacts.test.ts
+++ b/packages/runtime/src/__tests__/history-compact-artifacts.test.ts
@@ -1,4 +1,5 @@
 import assert from 'node:assert/strict';
+import { Buffer } from 'node:buffer';
 import { describe, test } from 'node:test';
 import type { RuntimeEvent } from '@maka/core/runtime-event';
 import { buildHistoryCompactBlockFromSummary } from '../context-budget.js';
@@ -87,6 +88,40 @@ describe('history compact artifacts', () => {
 
     assert.deepEqual(loaded.skippedReasonCounts, undefined);
     assert.equal(loaded.blocks[0]?.blockId, write.blocks[0]?.blockId);
+  });
+
+  test('keeps read-only compatibility with legacy V1 blocks larger than 1 MiB', async () => {
+    const store = memoryArtifactStore();
+    const foldedEvents = Array.from({ length: 6_000 }, (_, index) =>
+      textEvent(`legacy-${index}`, `legacy-turn-${Math.floor(index / 4)}`, `legacy fact ${index}`));
+    const block = buildHistoryCompactBlockFromSummary({
+      sessionId: 'session-1',
+      foldedRuntimeEvents: foldedEvents,
+      summary: 'legacy V1 summary',
+      highWaterName: 'legacy-history-compact',
+      highWaterSeq: 1,
+      now: 1_800_000_000_000,
+      charsPerToken: 4,
+    });
+    const serialized = JSON.stringify(block);
+    assert.ok(Buffer.byteLength(serialized, 'utf8') > 1_048_576);
+    await store.create({
+      sessionId: 'session-1',
+      turnId: 'turn-write',
+      name: `history-compact-${block.blockId}.json`,
+      kind: 'file',
+      content: serialized,
+      mimeType: 'application/json',
+      source: 'history_compact_block',
+    });
+
+    const loaded = await loadHistoryCompactBlocksFromArtifacts(store, {
+      sessionId: 'session-1',
+      maxBlocks: 1,
+      maxEstimatedTokens: 2_048,
+    });
+
+    assert.equal(loaded.blocks[0]?.blockId, block.blockId);
   });
 
   test('skips a block whose persisted token estimate understates its rendered size', async () => {

--- a/packages/runtime/src/__tests__/history-compact-checkpoint.test.ts
+++ b/packages/runtime/src/__tests__/history-compact-checkpoint.test.ts
@@ -143,16 +143,42 @@ describe('history compact checkpoint', () => {
     assert.equal(loaded, undefined);
   });
 
-  test('fails open from a damaged bounded projection without enumerating run ledgers', async () => {
+  test('recovers and repairs an uninitialized bounded projection from the canonical ledger', async () => {
+    const checkpoint = buildHistoryCompactCheckpoint({
+      sessionId: 'session-1',
+      coveredRuntimeEvents: [textEvent(0), textEvent(1)],
+      summary: 'recovered checkpoint',
+    });
+    const event = checkpointEvent('recovered-event', 'run-recovered', checkpoint, 20);
+    const repaired: Array<AgentRunEvent | null> = [];
     const store = {
-      readEventProjection: async () => { throw new Error('damaged projection'); },
-      listSessionRuns: async () => { throw new Error('run enumeration must stay cold'); },
-      readEvents: async () => { throw new Error('run ledger reads must stay cold'); },
+      readEventProjection: async () => undefined,
+      repairEventProjection: async (
+        _sessionId: string,
+        _type: AgentRunEvent['type'],
+        repairedEvent: AgentRunEvent | null,
+      ) => { repaired.push(repairedEvent); },
+      listSessionRuns: async () => [run('run-recovered', 10)],
+      readEvents: async () => [event],
     };
 
     const loaded = await loadLatestHistoryCompactCheckpointFromRunLedger(store, 'session-1');
 
-    assert.equal(loaded, undefined);
+    assert.equal(loaded?.checkpointId, checkpoint.checkpointId);
+    assert.deepEqual(repaired, [event]);
+  });
+
+  test('propagates recovery failure from a damaged bounded projection', async () => {
+    const store = {
+      readEventProjection: async () => { throw new Error('damaged projection'); },
+      listSessionRuns: async () => { throw new Error('ledger recovery failed'); },
+      readEvents: async () => [],
+    };
+
+    await assert.rejects(
+      loadLatestHistoryCompactCheckpointFromRunLedger(store, 'session-1'),
+      /ledger recovery failed/,
+    );
   });
 
   test('replays a matching checkpoint with only the uncovered raw tail', () => {

--- a/packages/runtime/src/__tests__/history-compact-checkpoint.test.ts
+++ b/packages/runtime/src/__tests__/history-compact-checkpoint.test.ts
@@ -4,6 +4,7 @@ import type { AgentRunEvent, AgentRunHeader, AgentRunStore } from '@maka/core';
 import type { RuntimeEvent } from '@maka/core/runtime-event';
 import {
   buildHistoryCompactCheckpoint,
+  canReplaceHistoryCompactCheckpoint,
   matchHistoryCompactCheckpointPrefix,
   validateHistoryCompactCheckpointShape,
 } from '../history-compact-checkpoint.js';
@@ -58,6 +59,29 @@ describe('history compact checkpoint', () => {
       coveredRuntimeEvents: [textEvent(0)],
       summary: '   ',
     }), /non-empty summary/);
+  });
+
+  test('only accepts an equal-coverage checkpoint as an explicit successor of the same source', () => {
+    const source = [textEvent(0), textEvent(1)];
+    const current = buildHistoryCompactCheckpoint({
+      sessionId: 'session-1', coveredRuntimeEvents: source, summary: 'current',
+    });
+    const successor = buildHistoryCompactCheckpoint({
+      sessionId: 'session-1', coveredRuntimeEvents: source, summary: 'smaller replacement',
+      previousCheckpointId: current.checkpointId,
+    });
+    const stale = buildHistoryCompactCheckpoint({
+      sessionId: 'session-1', coveredRuntimeEvents: source, summary: 'stale replacement',
+      previousCheckpointId: 'another-checkpoint',
+    });
+    const differentSource = buildHistoryCompactCheckpoint({
+      sessionId: 'session-1', coveredRuntimeEvents: [textEvent(2), textEvent(3)], summary: 'different source',
+      previousCheckpointId: current.checkpointId,
+    });
+
+    assert.equal(canReplaceHistoryCompactCheckpoint(current, successor), true);
+    assert.equal(canReplaceHistoryCompactCheckpoint(current, stale), false);
+    assert.equal(canReplaceHistoryCompactCheckpoint(current, differentSource), false);
   });
 
   test('loads the latest valid checkpoint from the run ledger', async () => {
@@ -240,6 +264,7 @@ describe('history compact checkpoint', () => {
     assert.deepEqual(replay.events.slice(1).map((event) => event.id), events.slice(4).map((event) => event.id));
     assert.equal(replay.checkpoints[0]?.checkpointId, checkpoint.checkpointId);
   });
+
 });
 
 function textEvent(index: number): RuntimeEvent {

--- a/packages/runtime/src/__tests__/history-compact-checkpoint.test.ts
+++ b/packages/runtime/src/__tests__/history-compact-checkpoint.test.ts
@@ -143,28 +143,16 @@ describe('history compact checkpoint', () => {
     assert.equal(loaded, undefined);
   });
 
-  test('backfills the bounded projection after a legacy ledger scan', async () => {
-    const checkpoint = buildHistoryCompactCheckpoint({
-      sessionId: 'session-1',
-      coveredRuntimeEvents: [textEvent(0)],
-      summary: 'legacy scan result',
-    });
-    const event = checkpointEvent('legacy-event', 'legacy-run', checkpoint, 20);
-    let backfilled: AgentRunEvent | null | undefined;
+  test('fails open from a damaged bounded projection without enumerating run ledgers', async () => {
     const store = {
-      readEventProjection: async () => undefined,
-      writeEventProjection: async (
-        _sessionId: string,
-        _type: AgentRunEvent['type'],
-        projected: AgentRunEvent | null,
-      ) => { backfilled = projected; },
-      listSessionRuns: async () => [run('legacy-run', 10)],
-      readEvents: async () => [event],
+      readEventProjection: async () => { throw new Error('damaged projection'); },
+      listSessionRuns: async () => { throw new Error('run enumeration must stay cold'); },
+      readEvents: async () => { throw new Error('run ledger reads must stay cold'); },
     };
 
-    await loadLatestHistoryCompactCheckpointFromRunLedger(store, 'session-1');
+    const loaded = await loadLatestHistoryCompactCheckpointFromRunLedger(store, 'session-1');
 
-    assert.equal(backfilled?.id, event.id);
+    assert.equal(loaded, undefined);
   });
 
   test('replays a matching checkpoint with only the uncovered raw tail', () => {

--- a/packages/runtime/src/__tests__/history-compact-checkpoint.test.ts
+++ b/packages/runtime/src/__tests__/history-compact-checkpoint.test.ts
@@ -5,11 +5,12 @@ import type { RuntimeEvent } from '@maka/core/runtime-event';
 import {
   buildHistoryCompactCheckpoint,
   canReplaceHistoryCompactCheckpoint,
+  historyCompactCheckpointToRuntimeEvent,
   matchHistoryCompactCheckpointPrefix,
   validateHistoryCompactCheckpointShape,
 } from '../history-compact-checkpoint.js';
 import { loadLatestHistoryCompactCheckpointFromRunLedger } from '../history-compact-ledger.js';
-import { applyRuntimeEventHistoryCompact } from '../context-budget.js';
+import { applyRuntimeEventHistoryCompact, estimateRuntimeEventsTokens } from '../context-budget.js';
 
 describe('history compact checkpoint', () => {
   test('keeps 10K-event coverage bounded and validates the exact ordered prefix', () => {
@@ -319,6 +320,32 @@ describe('history compact checkpoint', () => {
 
     assert.equal(replay.checkpoints.length, 0);
     assert.equal(replay.events.some((event) => event.id === `history-compact:${checkpoint.checkpointId}`), false);
+  });
+
+  test('applies max-history overrides to checkpoint replay validation', () => {
+    const events = Array.from({ length: 8 }, (_, index) => ({
+      ...textEvent(index),
+      content: { kind: 'text' as const, text: `payload-${index} `.repeat(20) },
+    }));
+    const checkpoint = buildHistoryCompactCheckpoint({
+      sessionId: 'session-1', coveredRuntimeEvents: events.slice(0, 6), summary: 'short checkpoint', charsPerToken: 1,
+    });
+    const checkpointTokens = estimateRuntimeEventsTokens([
+      historyCompactCheckpointToRuntimeEvent(checkpoint),
+    ], 1);
+    const overrideMax = checkpointTokens + 1;
+
+    const replay = applyRuntimeEventHistoryCompact(events, {
+      maxHistoryEstimatedTokens: 10_000,
+      charsPerToken: 1,
+      historyCompact: {
+        enabled: true, mode: 'read_write', checkpoints: [checkpoint],
+        maxBlockEstimatedTokens: 10_000, maxEstimatedTokens: 10_000,
+        highWaterRatio: 0.000001, tailEstimatedTokens: 1,
+      },
+    }, { maxHistoryEstimatedTokens: overrideMax });
+
+    assert.equal(replay.checkpoints.length, 0);
   });
 
 

--- a/packages/runtime/src/__tests__/history-compact-checkpoint.test.ts
+++ b/packages/runtime/src/__tests__/history-compact-checkpoint.test.ts
@@ -113,6 +113,60 @@ describe('history compact checkpoint', () => {
     assert.equal(loaded?.checkpointId, furthest.checkpointId);
   });
 
+  test('loads a bounded checkpoint projection without enumerating run ledgers', async () => {
+    const checkpoint = buildHistoryCompactCheckpoint({
+      sessionId: 'session-1',
+      coveredRuntimeEvents: [textEvent(0), textEvent(1)],
+      summary: 'bounded projection',
+    });
+    const projectedEvent = checkpointEvent('projection-event', 'run-projection', checkpoint, 20);
+    const store = {
+      readEventProjection: async () => projectedEvent,
+      listSessionRuns: async () => { throw new Error('run enumeration must stay cold'); },
+      readEvents: async () => { throw new Error('run ledger reads must stay cold'); },
+    };
+
+    const loaded = await loadLatestHistoryCompactCheckpointFromRunLedger(store, 'session-1');
+
+    assert.equal(loaded?.checkpointId, checkpoint.checkpointId);
+  });
+
+  test('uses an empty bounded projection without enumerating run ledgers', async () => {
+    const store = {
+      readEventProjection: async () => null,
+      listSessionRuns: async () => { throw new Error('run enumeration must stay cold'); },
+      readEvents: async () => { throw new Error('run ledger reads must stay cold'); },
+    };
+
+    const loaded = await loadLatestHistoryCompactCheckpointFromRunLedger(store, 'session-1');
+
+    assert.equal(loaded, undefined);
+  });
+
+  test('backfills the bounded projection after a legacy ledger scan', async () => {
+    const checkpoint = buildHistoryCompactCheckpoint({
+      sessionId: 'session-1',
+      coveredRuntimeEvents: [textEvent(0)],
+      summary: 'legacy scan result',
+    });
+    const event = checkpointEvent('legacy-event', 'legacy-run', checkpoint, 20);
+    let backfilled: AgentRunEvent | null | undefined;
+    const store = {
+      readEventProjection: async () => undefined,
+      writeEventProjection: async (
+        _sessionId: string,
+        _type: AgentRunEvent['type'],
+        projected: AgentRunEvent | null,
+      ) => { backfilled = projected; },
+      listSessionRuns: async () => [run('legacy-run', 10)],
+      readEvents: async () => [event],
+    };
+
+    await loadLatestHistoryCompactCheckpointFromRunLedger(store, 'session-1');
+
+    assert.equal(backfilled?.id, event.id);
+  });
+
   test('replays a matching checkpoint with only the uncovered raw tail', () => {
     const events = Array.from({ length: 8 }, (_, index) => textEvent(index));
     const checkpoint = buildHistoryCompactCheckpoint({

--- a/packages/runtime/src/__tests__/history-compact-checkpoint.test.ts
+++ b/packages/runtime/src/__tests__/history-compact-checkpoint.test.ts
@@ -34,12 +34,12 @@ describe('history compact checkpoint', () => {
       historyCompact: {
         enabled: true,
         mode: 'read_write',
-        checkpoints: [checkpoint],
+        checkpoint,
         highWaterRatio: 0.000001,
         tailEstimatedTokens: 1,
       },
     });
-    assert.equal(replay.checkpoints[0]?.checkpointId, checkpoint.checkpointId);
+    assert.equal(replay.checkpoint?.checkpointId, checkpoint.checkpointId);
     assert.ok(Buffer.byteLength(JSON.stringify(replay.diagnosticPatch), 'utf8') < 16 * 1024);
 
     const changed = [...events];
@@ -279,7 +279,7 @@ describe('history compact checkpoint', () => {
       historyCompact: {
         enabled: true,
         mode: 'read_write',
-        checkpoints: [checkpoint],
+        checkpoint,
         highWaterRatio: 0.01,
         tailEstimatedTokens: 1,
       },
@@ -291,7 +291,7 @@ describe('history compact checkpoint', () => {
       /checkpoint summary/,
     );
     assert.deepEqual(replay.events.slice(1).map((event) => event.id), events.slice(4).map((event) => event.id));
-    assert.equal(replay.checkpoints[0]?.checkpointId, checkpoint.checkpointId);
+    assert.equal(replay.checkpoint?.checkpointId, checkpoint.checkpointId);
   });
 
   test('does not replay a checkpoint above the total compact budget', () => {
@@ -310,7 +310,7 @@ describe('history compact checkpoint', () => {
       historyCompact: {
         enabled: true,
         mode: 'read_write',
-        checkpoints: [checkpoint],
+        checkpoint,
         maxBlockEstimatedTokens: 10_000,
         maxEstimatedTokens: 100,
         highWaterRatio: 0.000001,
@@ -318,7 +318,7 @@ describe('history compact checkpoint', () => {
       },
     });
 
-    assert.equal(replay.checkpoints.length, 0);
+    assert.equal(replay.checkpoint, undefined);
     assert.equal(replay.events.some((event) => event.id === `history-compact:${checkpoint.checkpointId}`), false);
   });
 
@@ -339,13 +339,13 @@ describe('history compact checkpoint', () => {
       maxHistoryEstimatedTokens: 10_000,
       charsPerToken: 1,
       historyCompact: {
-        enabled: true, mode: 'read_write', checkpoints: [checkpoint],
+        enabled: true, mode: 'read_write', checkpoint,
         maxBlockEstimatedTokens: 10_000, maxEstimatedTokens: 10_000,
         highWaterRatio: 0.000001, tailEstimatedTokens: 1,
       },
     }, { maxHistoryEstimatedTokens: overrideMax });
 
-    assert.equal(replay.checkpoints.length, 0);
+    assert.equal(replay.checkpoint, undefined);
   });
 
 

--- a/packages/runtime/src/__tests__/history-compact-checkpoint.test.ts
+++ b/packages/runtime/src/__tests__/history-compact-checkpoint.test.ts
@@ -137,6 +137,34 @@ describe('history compact checkpoint', () => {
     assert.equal(loaded?.checkpointId, furthest.checkpointId);
   });
 
+  test('recovers the tip of an out-of-order same-coverage successor chain across runs', async () => {
+    const source = [textEvent(0), textEvent(1)];
+    const first = buildHistoryCompactCheckpoint({
+      sessionId: 'session-1', coveredRuntimeEvents: source, summary: 'first', now: 10,
+    });
+    const second = buildHistoryCompactCheckpoint({
+      sessionId: 'session-1', coveredRuntimeEvents: source, summary: 'second',
+      previousCheckpointId: first.checkpointId, now: 20,
+    });
+    const tip = buildHistoryCompactCheckpoint({
+      sessionId: 'session-1', coveredRuntimeEvents: source, summary: 'tip',
+      previousCheckpointId: second.checkpointId, now: 30,
+    });
+    const store = new StubAgentRunStore([
+      run('parent-created-first', 10),
+      run('child-created-later', 20),
+    ], new Map([
+      ['parent-created-first', [
+        checkpointEvent('ledger-second', 'parent-created-first', second, 20),
+        checkpointEvent('ledger-tip', 'parent-created-first', tip, 30),
+      ]],
+      ['child-created-later', [checkpointEvent('ledger-first', 'child-created-later', first, 10)]],
+    ]));
+    const loaded = await loadLatestHistoryCompactCheckpointFromRunLedger(store, 'session-1');
+
+    assert.equal(loaded?.checkpointId, tip.checkpointId);
+  });
+
   test('loads a bounded checkpoint projection without enumerating run ledgers', async () => {
     const checkpoint = buildHistoryCompactCheckpoint({
       sessionId: 'session-1',
@@ -292,6 +320,7 @@ describe('history compact checkpoint', () => {
     assert.equal(replay.checkpoints.length, 0);
     assert.equal(replay.events.some((event) => event.id === `history-compact:${checkpoint.checkpointId}`), false);
   });
+
 
 });
 

--- a/packages/runtime/src/__tests__/history-compact-checkpoint.test.ts
+++ b/packages/runtime/src/__tests__/history-compact-checkpoint.test.ts
@@ -168,6 +168,37 @@ describe('history compact checkpoint', () => {
     assert.deepEqual(repaired, [event]);
   });
 
+  test('identifies a parseable but invalid projection when repairing from the canonical ledger', async () => {
+    const checkpoint = buildHistoryCompactCheckpoint({
+      sessionId: 'session-1',
+      coveredRuntimeEvents: [textEvent(0)],
+      summary: 'canonical checkpoint',
+    });
+    const canonicalEvent = checkpointEvent('canonical-event', 'run-canonical', checkpoint, 20);
+    const invalidProjection = {
+      ...canonicalEvent,
+      id: 'invalid-projection-event',
+      data: { checkpoint: { coverage: { eventCount: 999 } } },
+    } as AgentRunEvent;
+    const replacedEventIds: Array<string | undefined> = [];
+    const store = {
+      readEventProjection: async () => invalidProjection,
+      repairEventProjection: async (
+        _sessionId: string,
+        _type: AgentRunEvent['type'],
+        _event: AgentRunEvent | null,
+        options?: { replaceEventId?: string },
+      ) => { replacedEventIds.push(options?.replaceEventId); },
+      listSessionRuns: async () => [run('run-canonical', 10)],
+      readEvents: async () => [canonicalEvent],
+    };
+
+    const loaded = await loadLatestHistoryCompactCheckpointFromRunLedger(store, 'session-1');
+
+    assert.equal(loaded?.checkpointId, checkpoint.checkpointId);
+    assert.deepEqual(replacedEventIds, [invalidProjection.id]);
+  });
+
   test('propagates recovery failure from a damaged bounded projection', async () => {
     const store = {
       readEventProjection: async () => { throw new Error('damaged projection'); },

--- a/packages/runtime/src/__tests__/history-compact-checkpoint.test.ts
+++ b/packages/runtime/src/__tests__/history-compact-checkpoint.test.ts
@@ -1,0 +1,188 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+import type { AgentRunEvent, AgentRunHeader, AgentRunStore } from '@maka/core';
+import type { RuntimeEvent } from '@maka/core/runtime-event';
+import {
+  buildHistoryCompactCheckpoint,
+  matchHistoryCompactCheckpointPrefix,
+  validateHistoryCompactCheckpointShape,
+} from '../history-compact-checkpoint.js';
+import { loadLatestHistoryCompactCheckpointFromRunLedger } from '../history-compact-ledger.js';
+import { applyRuntimeEventHistoryCompact } from '../context-budget.js';
+
+describe('history compact checkpoint', () => {
+  test('keeps 10K-event coverage bounded and validates the exact ordered prefix', () => {
+    const events = Array.from({ length: 10_000 }, (_, index) => textEvent(index));
+    const checkpoint = buildHistoryCompactCheckpoint({
+      sessionId: 'session-1',
+      coveredRuntimeEvents: events,
+      summary: 'A bounded continuation summary.',
+      now: 1_800_000_010_000,
+    });
+
+    assert.equal(validateHistoryCompactCheckpointShape(checkpoint, 'session-1'), true);
+    assert.ok(Buffer.byteLength(JSON.stringify(checkpoint), 'utf8') < 64 * 1024);
+    assert.equal(checkpoint.coverage.eventCount, 10_000);
+    assert.equal(checkpoint.coverage.turnCount, 5_000);
+    assert.equal(checkpoint.coverage.through.runtimeEventId, 'event-9999');
+    assert.equal(matchHistoryCompactCheckpointPrefix(checkpoint, events).coveredEventCount, 10_000);
+    const replay = applyRuntimeEventHistoryCompact([...events, textEvent(10_000)], {
+      maxHistoryEstimatedTokens: 1_000_000,
+      charsPerToken: 1,
+      historyCompact: {
+        enabled: true,
+        mode: 'read_write',
+        checkpoints: [checkpoint],
+        highWaterRatio: 0.000001,
+        tailEstimatedTokens: 1,
+      },
+    });
+    assert.equal(replay.checkpoints[0]?.checkpointId, checkpoint.checkpointId);
+    assert.ok(Buffer.byteLength(JSON.stringify(replay.diagnosticPatch), 'utf8') < 16 * 1024);
+
+    const changed = [...events];
+    changed[4_999] = {
+      ...changed[4_999]!,
+      content: { kind: 'text', text: 'changed source fact' },
+    };
+    assert.equal(matchHistoryCompactCheckpointPrefix(checkpoint, changed).reason, 'source_hash_mismatch');
+    assert.equal(
+      matchHistoryCompactCheckpointPrefix(checkpoint, [events[1]!, events[0]!, ...events.slice(2)]).reason,
+      'source_hash_mismatch',
+    );
+  });
+
+  test('rejects blank summaries instead of persisting an unusable checkpoint', () => {
+    assert.throws(() => buildHistoryCompactCheckpoint({
+      sessionId: 'session-1',
+      coveredRuntimeEvents: [textEvent(0)],
+      summary: '   ',
+    }), /non-empty summary/);
+  });
+
+  test('loads the latest valid checkpoint from the run ledger', async () => {
+    const first = buildHistoryCompactCheckpoint({
+      sessionId: 'session-1',
+      coveredRuntimeEvents: [textEvent(0)],
+      summary: 'first',
+      now: 10,
+    });
+    const latest = buildHistoryCompactCheckpoint({
+      sessionId: 'session-1',
+      coveredRuntimeEvents: [textEvent(0), textEvent(1)],
+      summary: 'latest',
+      previousCheckpointId: first.checkpointId,
+      now: 20,
+    });
+    const store = new StubAgentRunStore([
+      run('run-1', 10),
+      run('run-2', 20),
+      run('run-3', 30),
+    ], new Map([
+      ['run-1', [checkpointEvent('ledger-1', 'run-1', first, 10)]],
+      ['run-2', [checkpointEvent('ledger-2', 'run-2', latest, 20)]],
+      ['run-3', [{ ...checkpointEvent('ledger-3', 'run-3', latest, 30), data: { checkpoint: { ...latest, summary: ' ' } } }]],
+    ]));
+
+    const loaded = await loadLatestHistoryCompactCheckpointFromRunLedger(store, 'session-1');
+
+    assert.equal(loaded?.checkpointId, latest.checkpointId);
+  });
+
+  test('replays a matching checkpoint with only the uncovered raw tail', () => {
+    const events = Array.from({ length: 8 }, (_, index) => textEvent(index));
+    const checkpoint = buildHistoryCompactCheckpoint({
+      sessionId: 'session-1',
+      coveredRuntimeEvents: events.slice(0, 4),
+      summary: 'checkpoint summary',
+    });
+
+    const replay = applyRuntimeEventHistoryCompact(events, {
+      maxHistoryEstimatedTokens: 1_000,
+      charsPerToken: 1,
+      historyCompact: {
+        enabled: true,
+        mode: 'read_write',
+        checkpoints: [checkpoint],
+        highWaterRatio: 0.01,
+        tailEstimatedTokens: 1,
+      },
+    });
+
+    assert.equal(replay.events[0]?.id, `history-compact:${checkpoint.checkpointId}`);
+    assert.match(
+      replay.events[0]?.content?.kind === 'text' ? replay.events[0].content.text : '',
+      /checkpoint summary/,
+    );
+    assert.deepEqual(replay.events.slice(1).map((event) => event.id), events.slice(4).map((event) => event.id));
+    assert.equal(replay.checkpoints[0]?.checkpointId, checkpoint.checkpointId);
+  });
+});
+
+function textEvent(index: number): RuntimeEvent {
+  return {
+    id: `event-${index}`,
+    sessionId: 'session-1',
+    runId: `run-${Math.floor(index / 2)}`,
+    turnId: `turn-${Math.floor(index / 2)}`,
+    invocationId: `invocation-${Math.floor(index / 2)}`,
+    ts: 1_800_000_000_000 + index,
+    partial: false,
+    role: index % 2 === 0 ? 'user' : 'model',
+    author: index % 2 === 0 ? 'user' : 'agent',
+    content: { kind: 'text', text: `payload-${index}` },
+  };
+}
+
+function run(runId: string, createdAt: number): AgentRunHeader {
+  return {
+    runId,
+    sessionId: 'session-1',
+    turnId: `turn-${runId}`,
+    status: 'completed',
+    backendKind: 'ai-sdk',
+    llmConnectionSlug: 'test',
+    modelId: 'test',
+    cwd: '/tmp',
+    permissionMode: 'ask',
+    createdAt,
+    updatedAt: createdAt,
+  };
+}
+
+function checkpointEvent(
+  id: string,
+  runId: string,
+  checkpoint: ReturnType<typeof buildHistoryCompactCheckpoint>,
+  ts: number,
+): AgentRunEvent {
+  return {
+    type: 'history_compact_checkpoint_recorded',
+    id,
+    runId,
+    sessionId: 'session-1',
+    turnId: `turn-${runId}`,
+    ts,
+    data: { checkpoint },
+  };
+}
+
+class StubAgentRunStore implements AgentRunStore {
+  constructor(
+    private readonly runs: AgentRunHeader[],
+    private readonly events: Map<string, AgentRunEvent[]>,
+  ) {}
+
+  async listSessionRuns(): Promise<AgentRunHeader[]> {
+    return this.runs;
+  }
+
+  async readEvents(_sessionId: string, runId: string): Promise<AgentRunEvent[]> {
+    return this.events.get(runId) ?? [];
+  }
+
+  async createRun(): Promise<AgentRunHeader> { throw new Error('not implemented'); }
+  async updateRun(): Promise<AgentRunHeader> { throw new Error('not implemented'); }
+  async readRun(): Promise<AgentRunHeader> { throw new Error('not implemented'); }
+  async appendEvent(): Promise<void> { throw new Error('not implemented'); }
+}

--- a/packages/runtime/src/__tests__/history-compact-checkpoint.test.ts
+++ b/packages/runtime/src/__tests__/history-compact-checkpoint.test.ts
@@ -265,6 +265,34 @@ describe('history compact checkpoint', () => {
     assert.equal(replay.checkpoints[0]?.checkpointId, checkpoint.checkpointId);
   });
 
+  test('does not replay a checkpoint above the total compact budget', () => {
+    const events = Array.from({ length: 8 }, (_, index) => textEvent(index));
+    const checkpoint = buildHistoryCompactCheckpoint({
+      sessionId: 'session-1',
+      coveredRuntimeEvents: events.slice(0, 4),
+      summary: 'checkpoint summary '.repeat(20),
+      charsPerToken: 1,
+    });
+    assert.ok(checkpoint.estimatedTokens > 100);
+
+    const replay = applyRuntimeEventHistoryCompact(events, {
+      maxHistoryEstimatedTokens: 10_000,
+      charsPerToken: 1,
+      historyCompact: {
+        enabled: true,
+        mode: 'read_write',
+        checkpoints: [checkpoint],
+        maxBlockEstimatedTokens: 10_000,
+        maxEstimatedTokens: 100,
+        highWaterRatio: 0.000001,
+        tailEstimatedTokens: 1,
+      },
+    });
+
+    assert.equal(replay.checkpoints.length, 0);
+    assert.equal(replay.events.some((event) => event.id === `history-compact:${checkpoint.checkpointId}`), false);
+  });
+
 });
 
 function textEvent(index: number): RuntimeEvent {

--- a/packages/runtime/src/__tests__/history-compact-checkpoint.test.ts
+++ b/packages/runtime/src/__tests__/history-compact-checkpoint.test.ts
@@ -89,6 +89,30 @@ describe('history compact checkpoint', () => {
     assert.equal(loaded?.checkpointId, latest.checkpointId);
   });
 
+  test('loads the furthest checkpoint when a later run records stale coverage', async () => {
+    const furthest = buildHistoryCompactCheckpoint({
+      sessionId: 'session-1',
+      coveredRuntimeEvents: [textEvent(0), textEvent(1), textEvent(2)],
+      summary: 'furthest coverage',
+    });
+    const stale = buildHistoryCompactCheckpoint({
+      sessionId: 'session-1',
+      coveredRuntimeEvents: [textEvent(0), textEvent(1)],
+      summary: 'stale coverage',
+    });
+    const store = new StubAgentRunStore([
+      run('run-furthest', 10),
+      run('run-stale', 20),
+    ], new Map([
+      ['run-furthest', [checkpointEvent('ledger-furthest', 'run-furthest', furthest, 30)]],
+      ['run-stale', [checkpointEvent('ledger-stale', 'run-stale', stale, 40)]],
+    ]));
+
+    const loaded = await loadLatestHistoryCompactCheckpointFromRunLedger(store, 'session-1');
+
+    assert.equal(loaded?.checkpointId, furthest.checkpointId);
+  });
+
   test('replays a matching checkpoint with only the uncovered raw tail', () => {
     const events = Array.from({ length: 8 }, (_, index) => textEvent(index));
     const checkpoint = buildHistoryCompactCheckpoint({

--- a/packages/runtime/src/__tests__/history-compact-summarizer.test.ts
+++ b/packages/runtime/src/__tests__/history-compact-summarizer.test.ts
@@ -9,6 +9,7 @@ import { expect } from '../test-helpers.js';
 import type { RuntimeEvent, RuntimeEventContent } from '@maka/core/runtime-event';
 import type { HistoryCompactWriteInput } from '../ai-sdk-backend.js';
 import { buildLlmHistorySummarizer, type AiSdkGenerateTextLike } from '../history-compact-summarizer.js';
+import { buildHistoryCompactCheckpoint } from '../history-compact-checkpoint.js';
 
 const ts = 1_700_000_000_000;
 let __seq = 0;
@@ -142,5 +143,34 @@ describe('buildLlmHistorySummarizer', () => {
 
     expect(result).toBe(undefined);
     expect(called).toBe(false);
+  });
+
+  test('rolling summary sends the prior summary plus only newly folded events', async () => {
+    const seen: unknown[] = [];
+    const summarize = buildLlmHistorySummarizer({
+      resolveModel: () => 'fake-model',
+      generateText: async (options) => {
+        seen.push(options.messages);
+        return { text: 'rolled' };
+      },
+    });
+    const old = ev({ role: 'user', author: 'user', content: { kind: 'text', text: 'ALREADY_SUMMARIZED_RAW' } });
+    const newer = ev({ role: 'model', author: 'agent', content: { kind: 'text', text: 'NEWLY_EVICTED_RAW' } });
+    const previousCheckpoint = buildHistoryCompactCheckpoint({
+      sessionId: 'sess-1', coveredRuntimeEvents: [old], summary: 'PRIOR_SUMMARY',
+    });
+    const input = inputWith([old, newer]);
+
+    const result = await summarize({
+      ...input,
+      previousCheckpoint,
+      newlyFoldedRuntimeEvents: [newer],
+    });
+
+    expect(result).toBe('rolled');
+    const serialized = JSON.stringify(seen[0]);
+    expect(serialized).toContain('PRIOR_SUMMARY');
+    expect(serialized).toContain('NEWLY_EVICTED_RAW');
+    expect(serialized.includes('ALREADY_SUMMARIZED_RAW')).toBe(false);
   });
 });

--- a/packages/runtime/src/__tests__/session-manager.test.ts
+++ b/packages/runtime/src/__tests__/session-manager.test.ts
@@ -4043,6 +4043,66 @@ describe('SessionManager permission mode updates', () => {
     expect(recordedCoverage).toEqual([2]);
   });
 
+  test('serializes accepted checkpoint persistence across parent and child runs', async () => {
+    const store = new MemorySessionStore();
+    const parentWriteGate = makeGate();
+    const parentWriteStarted = makeGate();
+    const childRecorderCalled = makeGate();
+    const physicalCoverage: number[] = [];
+    const recorderReturnedPromises: boolean[] = [];
+    const runStore = new MemoryAgentRunStore({
+      beforeAgentRunEventAppend: async (_sessionId, _runId, event) => {
+        if (event.type !== 'history_compact_checkpoint_recorded') return;
+        const coverage = (event.data?.checkpoint as HistoryCompactCheckpoint).coverage.eventCount;
+        if (coverage === 1) {
+          parentWriteStarted.release();
+          await parentWriteGate.promise;
+        }
+        physicalCoverage.push(coverage);
+      },
+    });
+    const backends = new BackendRegistry();
+    backends.register('fake', (ctx) => new SerializedCheckpointProbeBackend(
+      ctx,
+      childRecorderCalled,
+      recorderReturnedPromises,
+    ));
+    const manager = new SessionManager({
+      store,
+      runStore,
+      runtimeEventStore: runStore,
+      backends,
+      childTools: [testTool('Read'), testTool('Glob'), testTool('Grep')],
+      newId: nextId(),
+      now: nextNow(12_797),
+    });
+    const session = await manager.createSession(makeInput());
+
+    const parentTurn = drain(manager.sendMessage(session.id, { turnId: 'parent-delayed', text: 'hello' }));
+    await parentWriteStarted.promise;
+    const parentRun = (await runStore.listSessionRuns(session.id)).find((run) => run.turnId === 'parent-delayed');
+    if (!parentRun) throw new Error('parent run was not recorded');
+    const childTurn = drain(manager.startChildTurn(session.id, {
+      turnId: 'child-furthest',
+      parentRunId: parentRun.runId,
+      spec: {
+        id: LOCAL_READ_AGENT_ID,
+        name: LOCAL_READ_AGENT_DEFINITION.name,
+        systemPrompt: LOCAL_READ_AGENT_DEFINITION.systemPrompt,
+      },
+      prompt: 'inspect the repo',
+    }));
+    await childRecorderCalled.promise;
+    try {
+      expect(recorderReturnedPromises).toEqual([true]);
+    } finally {
+      parentWriteGate.release();
+    }
+    await Promise.all([parentTurn, childTurn]);
+
+    expect(physicalCoverage).toEqual([1, 2]);
+  });
+
   test('startup recovery marks persisted running turns as failed instead of leaving them stuck', async () => {
     const store = new MemorySessionStore();
     const backends = new BackendRegistry();
@@ -5399,6 +5459,50 @@ class HistoryCompactCheckpointMonotonicProbeBackend implements AgentBackend {
   async dispose(): Promise<void> {}
 }
 
+class SerializedCheckpointProbeBackend implements AgentBackend {
+  readonly kind = 'fake' as const;
+  readonly sessionId: string;
+
+  constructor(
+    private readonly ctx: BackendFactoryContext,
+    private readonly childRecorderCalled: Gate,
+    private readonly recorderReturnedPromises: boolean[],
+  ) {
+    this.sessionId = ctx.sessionId;
+  }
+
+  async *send(input: BackendSendInput): AsyncIterable<SessionEvent> {
+    const coverage = input.turnId === 'parent-delayed' ? 1 : 2;
+    const coveredRuntimeEvents = Array.from({ length: coverage }, (_, index): RuntimeEvent => ({
+      id: `serialized-source-event-${index}`,
+      sessionId: this.sessionId,
+      runId: `serialized-source-run-${index}`,
+      turnId: `serialized-source-turn-${index}`,
+      invocationId: `serialized-source-invocation-${index}`,
+      ts: index + 1,
+      partial: false,
+      role: 'user',
+      author: 'user',
+      content: { kind: 'text', text: `source ${index}` },
+    }));
+    const write = this.ctx.recordHistoryCompactCheckpoint?.(buildHistoryCompactCheckpoint({
+      sessionId: this.sessionId,
+      coveredRuntimeEvents,
+      summary: `${input.turnId} checkpoint`,
+    }), input.turnId);
+    if (input.turnId === 'child-furthest') {
+      this.recorderReturnedPromises.push(Boolean(write && typeof (write as PromiseLike<void>).then === 'function'));
+      this.childRecorderCalled.release();
+    }
+    await write;
+    yield { type: 'complete', id: `${input.turnId}-complete`, turnId: input.turnId, ts: 4, stopReason: 'end_turn' };
+  }
+
+  async stop(): Promise<void> {}
+  async respondToPermission(_decision: PermissionDecision): Promise<void> {}
+  async dispose(): Promise<void> {}
+}
+
 function activeCompactBlockFixture(sessionId: string, turnId: string): ActiveFullCompactBlock {
   return {
     kind: 'maka.active_full_compact_block',
@@ -5582,6 +5686,7 @@ class MemoryAgentRunStore implements AgentRunStore, RuntimeEventStore {
     failUpdateRunOnce?: boolean;
     failUpdateRunStatusOnce?: AgentRunHeader['status'];
     beforeRuntimeEventRead?: (sessionId: string, runId: string) => Promise<void> | void;
+    beforeAgentRunEventAppend?: (sessionId: string, runId: string, event: AgentRunEvent) => Promise<void> | void;
   } = {}) {}
 
   async createRun(header: AgentRunHeader): Promise<AgentRunHeader> {
@@ -5619,6 +5724,7 @@ class MemoryAgentRunStore implements AgentRunStore, RuntimeEventStore {
   }
 
   async appendEvent(sessionId: string, runId: string, event: AgentRunEvent): Promise<void> {
+    await this.options.beforeAgentRunEventAppend?.(sessionId, runId, event);
     const eventKey = key(sessionId, runId);
     this.events.set(eventKey, [...(this.events.get(eventKey) ?? []), copyEvent(event)]);
   }

--- a/packages/runtime/src/__tests__/session-manager.test.ts
+++ b/packages/runtime/src/__tests__/session-manager.test.ts
@@ -4372,6 +4372,71 @@ describe('SessionManager permission mode updates', () => {
     expect(checkpointCoverage).toEqual([10]);
   });
 
+  test('recovers a missing projection before rejecting a shorter cold-start checkpoint', async () => {
+    const store = new MemorySessionStore();
+    const runStore = new MissingCheckpointProjectionAgentRunStore();
+    const writeOutcomes: string[] = [];
+    const backends = new BackendRegistry();
+    backends.register('fake', (ctx) => new CheckpointRecorderContractProbeBackend(
+      ctx,
+      async () => {},
+      writeOutcomes,
+    ));
+    const manager = new SessionManager({
+      store,
+      runStore,
+      runtimeEventStore: runStore,
+      backends,
+      newId: nextId(),
+      now: nextNow(12_803),
+    });
+    const session = await manager.createSession(makeInput());
+    const durableCheckpoint = buildHistoryCompactCheckpoint({
+      sessionId: session.id,
+      coveredRuntimeEvents: Array.from({ length: 10 }, (_, index): RuntimeEvent => ({
+        id: `cold-durable-event-${index}`,
+        sessionId: session.id,
+        runId: `cold-durable-run-${index}`,
+        turnId: `cold-durable-turn-${index}`,
+        invocationId: `cold-durable-invocation-${index}`,
+        ts: index + 1,
+        partial: false,
+        role: 'user',
+        author: 'user',
+        content: { kind: 'text', text: `source ${index}` },
+      })),
+      summary: 'durable checkpoint before projection loss',
+    });
+    const durableEvent = makeRunEvent({
+      sessionId: session.id,
+      runId: 'cold-seed-run',
+      turnId: 'cold-seed-turn',
+      type: 'history_compact_checkpoint_recorded',
+      ts: 1,
+      data: { checkpoint: durableCheckpoint },
+    });
+    await seedRun(runStore, makeRunHeader({
+      sessionId: session.id,
+      runId: 'cold-seed-run',
+      turnId: 'cold-seed-turn',
+      status: 'completed',
+    }), [durableEvent]);
+
+    await drain(manager.sendMessage(session.id, { turnId: 'cold-stale-after-projection-loss', text: 'hello' }));
+
+    expect(writeOutcomes).toEqual(['cold-stale-after-projection-loss:rejected']);
+    expect(runStore.repairedProjection?.id).toBe(durableEvent.id);
+    const checkpointCoverage: number[] = [];
+    for (const run of await runStore.listSessionRuns(session.id)) {
+      for (const event of await runStore.readEvents(session.id, run.runId)) {
+        if (event.type === 'history_compact_checkpoint_recorded') {
+          checkpointCoverage.push((event.data?.checkpoint as HistoryCompactCheckpoint).coverage.eventCount);
+        }
+      }
+    }
+    expect(checkpointCoverage).toEqual([10]);
+  });
+
   test('startup recovery marks persisted running turns as failed instead of leaving them stuck', async () => {
     const store = new MemorySessionStore();
     const backends = new BackendRegistry();
@@ -6201,6 +6266,22 @@ class OrderingAgentRunStore extends MemoryAgentRunStore {
   override async appendRuntimeEvent(sessionId: string, runId: string, event: RuntimeEvent): Promise<void> {
     await super.appendRuntimeEvent(sessionId, runId, event);
     if (isTerminalRuntimeEvent(event)) this.operations.push('terminalRuntimeEvent');
+  }
+}
+
+class MissingCheckpointProjectionAgentRunStore extends MemoryAgentRunStore {
+  repairedProjection: AgentRunEvent | null | undefined;
+
+  async readEventProjection(): Promise<undefined> {
+    return undefined;
+  }
+
+  async repairEventProjection(
+    _sessionId: string,
+    _type: AgentRunEvent['type'],
+    event: AgentRunEvent | null,
+  ): Promise<void> {
+    this.repairedProjection = event;
   }
 }
 

--- a/packages/runtime/src/__tests__/session-manager.test.ts
+++ b/packages/runtime/src/__tests__/session-manager.test.ts
@@ -3932,6 +3932,45 @@ describe('SessionManager permission mode updates', () => {
     expect(checkpoint?.summary).toBe('persist the bounded checkpoint');
   });
 
+  test('shares the latest history compact checkpoint across disposable child backends', async () => {
+    const store = new MemorySessionStore();
+    const runStore = new MemoryAgentRunStore();
+    const observedCheckpointIds: Array<string | undefined> = [];
+    const backends = new BackendRegistry();
+    backends.register('fake', (ctx) => new HistoryCompactCheckpointCacheProbeBackend(ctx, observedCheckpointIds));
+    const manager = new SessionManager({
+      store,
+      runStore,
+      runtimeEventStore: runStore,
+      backends,
+      childTools: [testTool('Read'), testTool('Glob'), testTool('Grep')],
+      newId: nextId(),
+      now: nextNow(12_795),
+    });
+    const session = await manager.createSession(makeInput());
+
+    await drain(manager.sendMessage(session.id, { turnId: 'parent-turn', text: 'hello' }));
+    const parentRun = (await runStore.listSessionRuns(session.id)).find((run) => run.turnId === 'parent-turn');
+    if (!parentRun) throw new Error('parent run was not recorded');
+    runStore.readEventsCalls = 0;
+
+    for (const turnId of ['child-turn-1', 'child-turn-2']) {
+      await drain(manager.startChildTurn(session.id, {
+        turnId,
+        parentRunId: parentRun.runId,
+        spec: {
+          id: LOCAL_READ_AGENT_ID,
+          name: LOCAL_READ_AGENT_DEFINITION.name,
+          systemPrompt: LOCAL_READ_AGENT_DEFINITION.systemPrompt,
+        },
+        prompt: 'inspect the repo',
+      }));
+    }
+
+    expect(observedCheckpointIds).toEqual([undefined, 'hcheckpoint-shared', 'hcheckpoint-shared']);
+    expect(runStore.readEventsCalls).toBe(0);
+  });
+
   test('startup recovery marks persisted running turns as failed instead of leaving them stuck', async () => {
     const store = new MemorySessionStore();
     const backends = new BackendRegistry();
@@ -5176,6 +5215,47 @@ class HistoryCompactCheckpointBackend implements AgentBackend {
   async dispose(): Promise<void> {}
 }
 
+class HistoryCompactCheckpointCacheProbeBackend implements AgentBackend {
+  readonly kind = 'fake' as const;
+  readonly sessionId: string;
+
+  constructor(
+    private readonly ctx: BackendFactoryContext,
+    private readonly observedCheckpointIds: Array<string | undefined>,
+  ) {
+    this.sessionId = ctx.sessionId;
+  }
+
+  async *send(input: BackendSendInput): AsyncIterable<SessionEvent> {
+    const loaded = await this.ctx.loadHistoryCompactCheckpoint?.();
+    this.observedCheckpointIds.push(loaded?.checkpointId);
+    if (input.turnId === 'parent-turn') {
+      const checkpoint = buildHistoryCompactCheckpoint({
+        sessionId: this.sessionId,
+        coveredRuntimeEvents: [{
+          id: 'shared-source-event',
+          sessionId: this.sessionId,
+          runId: 'shared-source-run',
+          turnId: 'shared-source-turn',
+          invocationId: 'shared-source-invocation',
+          ts: 1,
+          partial: false,
+          role: 'user',
+          author: 'user',
+          content: { kind: 'text', text: 'source' },
+        }],
+        summary: 'share this checkpoint across session backends',
+      });
+      this.ctx.recordHistoryCompactCheckpoint?.({ ...checkpoint, checkpointId: 'hcheckpoint-shared' }, input.turnId);
+    }
+    yield { type: 'complete', id: `${input.turnId}-complete`, turnId: input.turnId, ts: 4, stopReason: 'end_turn' };
+  }
+
+  async stop(): Promise<void> {}
+  async respondToPermission(_decision: PermissionDecision): Promise<void> {}
+  async dispose(): Promise<void> {}
+}
+
 function activeCompactBlockFixture(sessionId: string, turnId: string): ActiveFullCompactBlock {
   return {
     kind: 'maka.active_full_compact_block',
@@ -5346,6 +5426,7 @@ class MemorySessionStore implements SessionStore {
 
 class MemoryAgentRunStore implements AgentRunStore, RuntimeEventStore {
   listSessionRunsCalls = 0;
+  readEventsCalls = 0;
   private headers = new Map<string, AgentRunHeader>();
   private events = new Map<string, AgentRunEvent[]>();
   private runtimeEvents = new Map<string, RuntimeEvent[]>();
@@ -5400,6 +5481,7 @@ class MemoryAgentRunStore implements AgentRunStore, RuntimeEventStore {
   }
 
   async readEvents(sessionId: string, runId: string): Promise<AgentRunEvent[]> {
+    this.readEventsCalls += 1;
     return (this.events.get(key(sessionId, runId)) ?? []).map(copyEvent);
   }
 

--- a/packages/runtime/src/__tests__/session-manager.test.ts
+++ b/packages/runtime/src/__tests__/session-manager.test.ts
@@ -4103,6 +4103,77 @@ describe('SessionManager permission mode updates', () => {
     expect(physicalCoverage).toEqual([1, 2]);
   });
 
+  test('keeps failed checkpoint writes out of the cache and continues the session write queue', async () => {
+    const store = new MemorySessionStore();
+    const parentWriteGate = makeGate();
+    const parentWriteStarted = makeGate();
+    const childRecorderCalled = makeGate();
+    const physicalCoverage: number[] = [];
+    const observedCoverage: Array<number | undefined> = [];
+    const writeOutcomes: string[] = [];
+    const runStore = new MemoryAgentRunStore({
+      beforeAgentRunEventAppend: async (_sessionId, _runId, event) => {
+        if (event.type !== 'history_compact_checkpoint_recorded') return;
+        const coverage = (event.data?.checkpoint as HistoryCompactCheckpoint).coverage.eventCount;
+        physicalCoverage.push(coverage);
+        if (coverage === 1) {
+          parentWriteStarted.release();
+          await parentWriteGate.promise;
+          throw new Error('checkpoint append failed');
+        }
+      },
+    });
+    const backends = new BackendRegistry();
+    backends.register('fake', (ctx) => new RecoveringCheckpointWriteProbeBackend(
+      ctx,
+      childRecorderCalled,
+      observedCoverage,
+      writeOutcomes,
+    ));
+    const manager = new SessionManager({
+      store,
+      runStore,
+      runtimeEventStore: runStore,
+      backends,
+      childTools: [testTool('Read'), testTool('Glob'), testTool('Grep')],
+      newId: nextId(),
+      now: nextNow(12_798),
+    });
+    const session = await manager.createSession(makeInput());
+
+    const parentTurn = drain(manager.sendMessage(session.id, { turnId: 'parent-failing', text: 'hello' }));
+    await parentWriteStarted.promise;
+    const parentRun = (await runStore.listSessionRuns(session.id)).find((run) => run.turnId === 'parent-failing');
+    if (!parentRun) throw new Error('parent run was not recorded');
+    const childTurn = drain(manager.startChildTurn(session.id, {
+      turnId: 'child-succeeding',
+      parentRunId: parentRun.runId,
+      spec: {
+        id: LOCAL_READ_AGENT_ID,
+        name: LOCAL_READ_AGENT_DEFINITION.name,
+        systemPrompt: LOCAL_READ_AGENT_DEFINITION.systemPrompt,
+      },
+      prompt: 'inspect the repo',
+    }));
+    await childRecorderCalled.promise;
+    parentWriteGate.release();
+    await Promise.all([parentTurn, childTurn]);
+    await drain(manager.startChildTurn(session.id, {
+      turnId: 'child-observe',
+      parentRunId: parentRun.runId,
+      spec: {
+        id: LOCAL_READ_AGENT_ID,
+        name: LOCAL_READ_AGENT_DEFINITION.name,
+        systemPrompt: LOCAL_READ_AGENT_DEFINITION.systemPrompt,
+      },
+      prompt: 'inspect the repo',
+    }));
+
+    expect(observedCoverage).toEqual([undefined, undefined, 2]);
+    expect(writeOutcomes).toEqual(['parent-failing:rejected', 'child-succeeding:fulfilled']);
+    expect(physicalCoverage).toEqual([1, 2]);
+  });
+
   test('startup recovery marks persisted running turns as failed instead of leaving them stuck', async () => {
     const store = new MemorySessionStore();
     const backends = new BackendRegistry();
@@ -5495,6 +5566,57 @@ class SerializedCheckpointProbeBackend implements AgentBackend {
       this.childRecorderCalled.release();
     }
     await write;
+    yield { type: 'complete', id: `${input.turnId}-complete`, turnId: input.turnId, ts: 4, stopReason: 'end_turn' };
+  }
+
+  async stop(): Promise<void> {}
+  async respondToPermission(_decision: PermissionDecision): Promise<void> {}
+  async dispose(): Promise<void> {}
+}
+
+class RecoveringCheckpointWriteProbeBackend implements AgentBackend {
+  readonly kind = 'fake' as const;
+  readonly sessionId: string;
+
+  constructor(
+    private readonly ctx: BackendFactoryContext,
+    private readonly childRecorderCalled: Gate,
+    private readonly observedCoverage: Array<number | undefined>,
+    private readonly writeOutcomes: string[],
+  ) {
+    this.sessionId = ctx.sessionId;
+  }
+
+  async *send(input: BackendSendInput): AsyncIterable<SessionEvent> {
+    const loaded = await this.ctx.loadHistoryCompactCheckpoint?.();
+    this.observedCoverage.push(loaded?.coverage.eventCount);
+    if (input.turnId !== 'child-observe') {
+      const coverage = input.turnId === 'parent-failing' ? 1 : 2;
+      const coveredRuntimeEvents = Array.from({ length: coverage }, (_, index): RuntimeEvent => ({
+        id: `recovering-source-event-${index}`,
+        sessionId: this.sessionId,
+        runId: `recovering-source-run-${index}`,
+        turnId: `recovering-source-turn-${index}`,
+        invocationId: `recovering-source-invocation-${index}`,
+        ts: index + 1,
+        partial: false,
+        role: 'user',
+        author: 'user',
+        content: { kind: 'text', text: `source ${index}` },
+      }));
+      const write = this.ctx.recordHistoryCompactCheckpoint?.(buildHistoryCompactCheckpoint({
+        sessionId: this.sessionId,
+        coveredRuntimeEvents,
+        summary: `${input.turnId} checkpoint`,
+      }), input.turnId);
+      if (input.turnId === 'child-succeeding') this.childRecorderCalled.release();
+      try {
+        await write;
+        this.writeOutcomes.push(`${input.turnId}:fulfilled`);
+      } catch {
+        this.writeOutcomes.push(`${input.turnId}:rejected`);
+      }
+    }
     yield { type: 'complete', id: `${input.turnId}-complete`, turnId: input.turnId, ts: 4, stopReason: 'end_turn' };
   }
 

--- a/packages/runtime/src/__tests__/session-manager.test.ts
+++ b/packages/runtime/src/__tests__/session-manager.test.ts
@@ -3997,6 +3997,43 @@ describe('SessionManager permission mode updates', () => {
     expect(runStore.readEventsCalls).toBe(0);
   });
 
+  test('does not let a stale child checkpoint move the session cache backward', async () => {
+    const store = new MemorySessionStore();
+    const runStore = new MemoryAgentRunStore();
+    const observedCoverage: Array<number | undefined> = [];
+    const backends = new BackendRegistry();
+    backends.register('fake', (ctx) => new HistoryCompactCheckpointMonotonicProbeBackend(ctx, observedCoverage));
+    const manager = new SessionManager({
+      store,
+      runStore,
+      runtimeEventStore: runStore,
+      backends,
+      childTools: [testTool('Read'), testTool('Glob'), testTool('Grep')],
+      newId: nextId(),
+      now: nextNow(12_796),
+    });
+    const session = await manager.createSession(makeInput());
+
+    await drain(manager.sendMessage(session.id, { turnId: 'parent-furthest', text: 'hello' }));
+    const parentRun = (await runStore.listSessionRuns(session.id)).find((run) => run.turnId === 'parent-furthest');
+    if (!parentRun) throw new Error('parent run was not recorded');
+
+    for (const turnId of ['child-stale', 'child-observe']) {
+      await drain(manager.startChildTurn(session.id, {
+        turnId,
+        parentRunId: parentRun.runId,
+        spec: {
+          id: LOCAL_READ_AGENT_ID,
+          name: LOCAL_READ_AGENT_DEFINITION.name,
+          systemPrompt: LOCAL_READ_AGENT_DEFINITION.systemPrompt,
+        },
+        prompt: 'inspect the repo',
+      }));
+    }
+
+    expect(observedCoverage).toEqual([undefined, 2, 2]);
+  });
+
   test('startup recovery marks persisted running turns as failed instead of leaving them stuck', async () => {
     const store = new MemorySessionStore();
     const backends = new BackendRegistry();
@@ -5302,6 +5339,48 @@ class HistoryCompactCheckpointCacheProbeBackend implements AgentBackend {
         summary: 'share this checkpoint across session backends',
       });
       this.ctx.recordHistoryCompactCheckpoint?.({ ...checkpoint, checkpointId: 'hcheckpoint-shared' }, input.turnId);
+    }
+    yield { type: 'complete', id: `${input.turnId}-complete`, turnId: input.turnId, ts: 4, stopReason: 'end_turn' };
+  }
+
+  async stop(): Promise<void> {}
+  async respondToPermission(_decision: PermissionDecision): Promise<void> {}
+  async dispose(): Promise<void> {}
+}
+
+class HistoryCompactCheckpointMonotonicProbeBackend implements AgentBackend {
+  readonly kind = 'fake' as const;
+  readonly sessionId: string;
+
+  constructor(
+    private readonly ctx: BackendFactoryContext,
+    private readonly observedCoverage: Array<number | undefined>,
+  ) {
+    this.sessionId = ctx.sessionId;
+  }
+
+  async *send(input: BackendSendInput): AsyncIterable<SessionEvent> {
+    const loaded = await this.ctx.loadHistoryCompactCheckpoint?.();
+    this.observedCoverage.push(loaded?.coverage.eventCount);
+    const coverage = input.turnId === 'parent-furthest' ? 2 : input.turnId === 'child-stale' ? 1 : 0;
+    if (coverage > 0) {
+      const coveredRuntimeEvents = Array.from({ length: coverage }, (_, index): RuntimeEvent => ({
+        id: `monotonic-source-event-${index}`,
+        sessionId: this.sessionId,
+        runId: `monotonic-source-run-${index}`,
+        turnId: `monotonic-source-turn-${index}`,
+        invocationId: `monotonic-source-invocation-${index}`,
+        ts: index + 1,
+        partial: false,
+        role: 'user',
+        author: 'user',
+        content: { kind: 'text', text: `source ${index}` },
+      }));
+      this.ctx.recordHistoryCompactCheckpoint?.(buildHistoryCompactCheckpoint({
+        sessionId: this.sessionId,
+        coveredRuntimeEvents,
+        summary: `${input.turnId} checkpoint`,
+      }), input.turnId);
     }
     yield { type: 'complete', id: `${input.turnId}-complete`, turnId: input.turnId, ts: 4, stopReason: 'end_turn' };
   }

--- a/packages/runtime/src/__tests__/session-manager.test.ts
+++ b/packages/runtime/src/__tests__/session-manager.test.ts
@@ -4225,6 +4225,7 @@ describe('SessionManager permission mode updates', () => {
     const store = new MemorySessionStore();
     const furthestWriteGate = makeGate();
     const furthestWriteStarted = makeGate();
+    const staleRecorderCalled = makeGate();
     const writeOutcomes: string[] = [];
     const physicalCoverage: number[] = [];
     const runStore = new MemoryAgentRunStore({
@@ -4241,7 +4242,9 @@ describe('SessionManager permission mode updates', () => {
     const backends = new BackendRegistry();
     backends.register('fake', (ctx) => new CheckpointRecorderContractProbeBackend(
       ctx,
-      async () => {},
+      async (turnId) => {
+        if (turnId === 'child-stale-in-flight') staleRecorderCalled.release();
+      },
       writeOutcomes,
     ));
     const manager = new SessionManager({
@@ -4259,7 +4262,7 @@ describe('SessionManager permission mode updates', () => {
     await furthestWriteStarted.promise;
     const parentRun = (await runStore.listSessionRuns(session.id)).find((run) => run.turnId === 'parent-furthest-in-flight');
     if (!parentRun) throw new Error('parent run was not recorded');
-    await drain(manager.startChildTurn(session.id, {
+    const childTurn = drain(manager.startChildTurn(session.id, {
       turnId: 'child-stale-in-flight',
       parentRunId: parentRun.runId,
       spec: {
@@ -4269,11 +4272,104 @@ describe('SessionManager permission mode updates', () => {
       },
       prompt: 'inspect the repo',
     }));
+    await staleRecorderCalled.promise;
     furthestWriteGate.release();
-    await parentTurn;
+    await Promise.all([parentTurn, childTurn]);
 
-    expect(writeOutcomes).toEqual(['child-stale-in-flight:rejected', 'parent-furthest-in-flight:fulfilled']);
+    expect(writeOutcomes).toEqual(['parent-furthest-in-flight:fulfilled', 'child-stale-in-flight:rejected']);
     expect(physicalCoverage).toEqual([2]);
+  });
+
+  test('waits for the initial durable checkpoint load before accepting a write', async () => {
+    const store = new MemorySessionStore();
+    const initialLoadGate = makeGate();
+    const initialLoadStarted = makeGate();
+    const staleRecorderCalled = makeGate();
+    const observedCoverage: Array<number | undefined> = [];
+    const writeOutcomes: string[] = [];
+    const runStore = new MemoryAgentRunStore({
+      beforeAgentRunEventRead: async (_sessionId, runId) => {
+        if (runId !== 'seed-checkpoint-run') return;
+        initialLoadStarted.release();
+        await initialLoadGate.promise;
+      },
+    });
+    const backends = new BackendRegistry();
+    backends.register('fake', (ctx) => new InitialCheckpointLoadRaceProbeBackend(
+      ctx,
+      staleRecorderCalled,
+      observedCoverage,
+      writeOutcomes,
+    ));
+    const manager = new SessionManager({
+      store,
+      runStore,
+      runtimeEventStore: runStore,
+      backends,
+      childTools: [testTool('Read'), testTool('Glob'), testTool('Grep')],
+      newId: nextId(),
+      now: nextNow(12_802),
+    });
+    const session = await manager.createSession(makeInput());
+    const durableCheckpoint = buildHistoryCompactCheckpoint({
+      sessionId: session.id,
+      coveredRuntimeEvents: Array.from({ length: 10 }, (_, index): RuntimeEvent => ({
+        id: `durable-source-event-${index}`,
+        sessionId: session.id,
+        runId: `durable-source-run-${index}`,
+        turnId: `durable-source-turn-${index}`,
+        invocationId: `durable-source-invocation-${index}`,
+        ts: index + 1,
+        partial: false,
+        role: 'user',
+        author: 'user',
+        content: { kind: 'text', text: `source ${index}` },
+      })),
+      summary: 'durable checkpoint',
+    });
+    await seedRun(runStore, makeRunHeader({
+      sessionId: session.id,
+      runId: 'seed-checkpoint-run',
+      turnId: 'seed-checkpoint-turn',
+      status: 'completed',
+    }), [makeRunEvent({
+      sessionId: session.id,
+      runId: 'seed-checkpoint-run',
+      turnId: 'seed-checkpoint-turn',
+      type: 'history_compact_checkpoint_recorded',
+      ts: 1,
+      data: { checkpoint: durableCheckpoint },
+    })]);
+
+    const parentTurn = drain(manager.sendMessage(session.id, { turnId: 'parent-initial-load', text: 'hello' }));
+    await initialLoadStarted.promise;
+    const parentRun = (await runStore.listSessionRuns(session.id)).find((run) => run.turnId === 'parent-initial-load');
+    if (!parentRun) throw new Error('parent run was not recorded');
+    const childTurn = drain(manager.startChildTurn(session.id, {
+      turnId: 'child-stale-during-load',
+      parentRunId: parentRun.runId,
+      spec: {
+        id: LOCAL_READ_AGENT_ID,
+        name: LOCAL_READ_AGENT_DEFINITION.name,
+        systemPrompt: LOCAL_READ_AGENT_DEFINITION.systemPrompt,
+      },
+      prompt: 'inspect the repo',
+    }));
+    await staleRecorderCalled.promise;
+    initialLoadGate.release();
+    await Promise.all([parentTurn, childTurn]);
+
+    expect(observedCoverage).toEqual([10]);
+    expect(writeOutcomes).toEqual(['child-stale-during-load:rejected']);
+    const checkpointCoverage: number[] = [];
+    for (const run of await runStore.listSessionRuns(session.id)) {
+      for (const event of await runStore.readEvents(session.id, run.runId)) {
+        if (event.type === 'history_compact_checkpoint_recorded') {
+          checkpointCoverage.push((event.data?.checkpoint as HistoryCompactCheckpoint).coverage.eventCount);
+        }
+      }
+    }
+    expect(checkpointCoverage).toEqual([10]);
   });
 
   test('startup recovery marks persisted running turns as failed instead of leaving them stuck', async () => {
@@ -5772,6 +5868,57 @@ class CheckpointRecorderContractProbeBackend implements AgentBackend {
   async dispose(): Promise<void> {}
 }
 
+class InitialCheckpointLoadRaceProbeBackend implements AgentBackend {
+  readonly kind = 'fake' as const;
+  readonly sessionId: string;
+
+  constructor(
+    private readonly ctx: BackendFactoryContext,
+    private readonly staleRecorderCalled: Gate,
+    private readonly observedCoverage: Array<number | undefined>,
+    private readonly writeOutcomes: string[],
+  ) {
+    this.sessionId = ctx.sessionId;
+  }
+
+  async *send(input: BackendSendInput): AsyncIterable<SessionEvent> {
+    if (input.turnId === 'parent-initial-load') {
+      const loaded = await this.ctx.loadHistoryCompactCheckpoint?.();
+      this.observedCoverage.push(loaded?.coverage.eventCount);
+    } else {
+      const coveredRuntimeEvents = Array.from({ length: 5 }, (_, index): RuntimeEvent => ({
+        id: `stale-load-race-event-${index}`,
+        sessionId: this.sessionId,
+        runId: `stale-load-race-run-${index}`,
+        turnId: `stale-load-race-turn-${index}`,
+        invocationId: `stale-load-race-invocation-${index}`,
+        ts: index + 1,
+        partial: false,
+        role: 'user',
+        author: 'user',
+        content: { kind: 'text', text: `source ${index}` },
+      }));
+      const write = this.ctx.recordHistoryCompactCheckpoint?.(buildHistoryCompactCheckpoint({
+        sessionId: this.sessionId,
+        coveredRuntimeEvents,
+        summary: 'stale checkpoint during initial load',
+      }), input.turnId);
+      this.staleRecorderCalled.release();
+      try {
+        await write;
+        this.writeOutcomes.push(`${input.turnId}:fulfilled`);
+      } catch {
+        this.writeOutcomes.push(`${input.turnId}:rejected`);
+      }
+    }
+    yield { type: 'complete', id: `${input.turnId}-complete`, turnId: input.turnId, ts: 4, stopReason: 'end_turn' };
+  }
+
+  async stop(): Promise<void> {}
+  async respondToPermission(_decision: PermissionDecision): Promise<void> {}
+  async dispose(): Promise<void> {}
+}
+
 function activeCompactBlockFixture(sessionId: string, turnId: string): ActiveFullCompactBlock {
   return {
     kind: 'maka.active_full_compact_block',
@@ -5956,6 +6103,7 @@ class MemoryAgentRunStore implements AgentRunStore, RuntimeEventStore {
     failUpdateRunStatusOnce?: AgentRunHeader['status'];
     beforeRuntimeEventRead?: (sessionId: string, runId: string) => Promise<void> | void;
     beforeAgentRunEventAppend?: (sessionId: string, runId: string, event: AgentRunEvent) => Promise<void> | void;
+    beforeAgentRunEventRead?: (sessionId: string, runId: string) => Promise<void> | void;
   } = {}) {}
 
   async createRun(header: AgentRunHeader): Promise<AgentRunHeader> {
@@ -6000,6 +6148,7 @@ class MemoryAgentRunStore implements AgentRunStore, RuntimeEventStore {
 
   async readEvents(sessionId: string, runId: string): Promise<AgentRunEvent[]> {
     this.readEventsCalls += 1;
+    await this.options.beforeAgentRunEventRead?.(sessionId, runId);
     return (this.events.get(key(sessionId, runId)) ?? []).map(copyEvent);
   }
 

--- a/packages/runtime/src/__tests__/session-manager.test.ts
+++ b/packages/runtime/src/__tests__/session-manager.test.ts
@@ -4032,6 +4032,15 @@ describe('SessionManager permission mode updates', () => {
     }
 
     expect(observedCoverage).toEqual([undefined, 2, 2]);
+    const recordedCoverage: number[] = [];
+    for (const run of await runStore.listSessionRuns(session.id)) {
+      for (const event of await runStore.readEvents(session.id, run.runId)) {
+        if (event.type === 'history_compact_checkpoint_recorded') {
+          recordedCoverage.push((event.data?.checkpoint as HistoryCompactCheckpoint).coverage.eventCount);
+        }
+      }
+    }
+    expect(recordedCoverage).toEqual([2]);
   });
 
   test('startup recovery marks persisted running turns as failed instead of leaving them stuck', async () => {

--- a/packages/runtime/src/__tests__/session-manager.test.ts
+++ b/packages/runtime/src/__tests__/session-manager.test.ts
@@ -31,6 +31,7 @@ import type { AgentBackend } from '@maka/core/backend-types';
 import type { MakaTool } from '../tool-runtime.js';
 import type { InvocationResult } from '../invocation-context.js';
 import type { ActiveFullCompactBlock } from '../active-full-compact.js';
+import { buildHistoryCompactCheckpoint, type HistoryCompactCheckpoint } from '../history-compact-checkpoint.js';
 import {
   AGENT_WORKSPACE_WORKTREE,
   IMPLEMENTATION_AGENT_ID,
@@ -3912,6 +3913,25 @@ describe('SessionManager permission mode updates', () => {
     expect(block?.sourceRefs[0]?.sourceId).toBe('provider-message:0');
   });
 
+  test('durable run ledger records bounded history compact checkpoints asynchronously', async () => {
+    const store = new MemorySessionStore();
+    const runStore = new MemoryAgentRunStore();
+    const backends = new BackendRegistry();
+    backends.register('fake', (ctx) => new HistoryCompactCheckpointBackend(ctx));
+    const manager = new SessionManager({ store, runStore, runtimeEventStore: runStore, backends, newId: nextId(), now: nextNow(12_790) });
+    const session = await manager.createSession(makeInput());
+
+    await drain(manager.sendMessage(session.id, { turnId: 'turn-1', text: 'hello' }));
+
+    const [run] = await runStore.listSessionRuns(session.id);
+    const events = await runStore.readEvents(session.id, run!.runId);
+    const checkpointEvent = events.find((event) => event.type === 'history_compact_checkpoint_recorded');
+    expect(checkpointEvent?.data?.checkpointId).toBe('hcheckpoint-test');
+    expect(checkpointEvent?.data?.boundaryKind).toBe('historyCompact');
+    const checkpoint = checkpointEvent?.data?.checkpoint as HistoryCompactCheckpoint | undefined;
+    expect(checkpoint?.summary).toBe('persist the bounded checkpoint');
+  });
+
   test('startup recovery marks persisted running turns as failed instead of leaving them stuck', async () => {
     const store = new MemorySessionStore();
     const backends = new BackendRegistry();
@@ -5114,6 +5134,40 @@ class ActiveCompactBlockBackend implements AgentBackend {
 
   async *send(input: BackendSendInput): AsyncIterable<SessionEvent> {
     this.ctx.recordActiveFullCompactBlock?.(activeCompactBlockFixture(this.sessionId, input.turnId));
+    yield { type: 'complete', id: `${input.turnId}-complete`, turnId: input.turnId, ts: 4, stopReason: 'end_turn' };
+  }
+
+  async stop(): Promise<void> {}
+  async respondToPermission(_decision: PermissionDecision): Promise<void> {}
+  async dispose(): Promise<void> {}
+}
+
+class HistoryCompactCheckpointBackend implements AgentBackend {
+  readonly kind = 'fake' as const;
+  readonly sessionId: string;
+
+  constructor(private readonly ctx: BackendFactoryContext) {
+    this.sessionId = ctx.sessionId;
+  }
+
+  async *send(input: BackendSendInput): AsyncIterable<SessionEvent> {
+    const checkpoint = buildHistoryCompactCheckpoint({
+      sessionId: this.sessionId,
+      coveredRuntimeEvents: [{
+        id: 'source-event',
+        sessionId: this.sessionId,
+        runId: 'source-run',
+        turnId: 'source-turn',
+        invocationId: 'source-invocation',
+        ts: 1,
+        partial: false,
+        role: 'user',
+        author: 'user',
+        content: { kind: 'text', text: 'source' },
+      }],
+      summary: 'persist the bounded checkpoint',
+    });
+    this.ctx.recordHistoryCompactCheckpoint?.({ ...checkpoint, checkpointId: 'hcheckpoint-test' }, input.turnId);
     yield { type: 'complete', id: `${input.turnId}-complete`, turnId: input.turnId, ts: 4, stopReason: 'end_turn' };
   }
 

--- a/packages/runtime/src/__tests__/session-manager.test.ts
+++ b/packages/runtime/src/__tests__/session-manager.test.ts
@@ -4174,6 +4174,108 @@ describe('SessionManager permission mode updates', () => {
     expect(physicalCoverage).toEqual([1, 2]);
   });
 
+  test('does not expose a durable checkpoint recorder without an AgentRun store', async () => {
+    const store = new MemorySessionStore();
+    let recorderExposed: boolean | undefined;
+    const backends = new BackendRegistry();
+    backends.register('fake', (ctx) => {
+      recorderExposed = ctx.recordHistoryCompactCheckpoint !== undefined;
+      return new TestBackend(ctx);
+    });
+    const manager = new SessionManager({ store, backends, newId: nextId(), now: nextNow(12_799) });
+    const session = await manager.createSession(makeInput());
+
+    await drain(manager.sendMessage(session.id, { turnId: 'turn-without-run-store', text: 'hello' }));
+
+    expect(recorderExposed).toBe(false);
+  });
+
+  test('rejects checkpoint recording after the current AgentRun store becomes unavailable', async () => {
+    const store = new MemorySessionStore();
+    const runStoreUnavailable = makeGate();
+    const writeOutcomes: string[] = [];
+    const runStore = new MemoryAgentRunStore({
+      beforeAgentRunEventAppend: async (_sessionId, _runId, event) => {
+        if (event.type === 'run_started') throw new Error('run ledger append failed');
+        if (event.type === 'trace_write_failed') runStoreUnavailable.release();
+      },
+    });
+    const backends = new BackendRegistry();
+    backends.register('fake', (ctx) => new CheckpointRecorderContractProbeBackend(
+      ctx,
+      async () => runStoreUnavailable.promise,
+      writeOutcomes,
+    ));
+    const manager = new SessionManager({
+      store,
+      runStore,
+      runtimeEventStore: runStore,
+      backends,
+      newId: nextId(),
+      now: nextNow(12_800),
+    });
+    const session = await manager.createSession(makeInput());
+
+    await drain(manager.sendMessage(session.id, { turnId: 'store-unavailable', text: 'hello' }));
+
+    expect(writeOutcomes).toEqual(['store-unavailable:rejected']);
+  });
+
+  test('rejects a stale checkpoint candidate while a further checkpoint is in flight', async () => {
+    const store = new MemorySessionStore();
+    const furthestWriteGate = makeGate();
+    const furthestWriteStarted = makeGate();
+    const writeOutcomes: string[] = [];
+    const physicalCoverage: number[] = [];
+    const runStore = new MemoryAgentRunStore({
+      beforeAgentRunEventAppend: async (_sessionId, _runId, event) => {
+        if (event.type !== 'history_compact_checkpoint_recorded') return;
+        const coverage = (event.data?.checkpoint as HistoryCompactCheckpoint).coverage.eventCount;
+        physicalCoverage.push(coverage);
+        if (coverage === 2) {
+          furthestWriteStarted.release();
+          await furthestWriteGate.promise;
+        }
+      },
+    });
+    const backends = new BackendRegistry();
+    backends.register('fake', (ctx) => new CheckpointRecorderContractProbeBackend(
+      ctx,
+      async () => {},
+      writeOutcomes,
+    ));
+    const manager = new SessionManager({
+      store,
+      runStore,
+      runtimeEventStore: runStore,
+      backends,
+      childTools: [testTool('Read'), testTool('Glob'), testTool('Grep')],
+      newId: nextId(),
+      now: nextNow(12_801),
+    });
+    const session = await manager.createSession(makeInput());
+
+    const parentTurn = drain(manager.sendMessage(session.id, { turnId: 'parent-furthest-in-flight', text: 'hello' }));
+    await furthestWriteStarted.promise;
+    const parentRun = (await runStore.listSessionRuns(session.id)).find((run) => run.turnId === 'parent-furthest-in-flight');
+    if (!parentRun) throw new Error('parent run was not recorded');
+    await drain(manager.startChildTurn(session.id, {
+      turnId: 'child-stale-in-flight',
+      parentRunId: parentRun.runId,
+      spec: {
+        id: LOCAL_READ_AGENT_ID,
+        name: LOCAL_READ_AGENT_DEFINITION.name,
+        systemPrompt: LOCAL_READ_AGENT_DEFINITION.systemPrompt,
+      },
+      prompt: 'inspect the repo',
+    }));
+    furthestWriteGate.release();
+    await parentTurn;
+
+    expect(writeOutcomes).toEqual(['child-stale-in-flight:rejected', 'parent-furthest-in-flight:fulfilled']);
+    expect(physicalCoverage).toEqual([2]);
+  });
+
   test('startup recovery marks persisted running turns as failed instead of leaving them stuck', async () => {
     const store = new MemorySessionStore();
     const backends = new BackendRegistry();
@@ -5516,11 +5618,11 @@ class HistoryCompactCheckpointMonotonicProbeBackend implements AgentBackend {
         author: 'user',
         content: { kind: 'text', text: `source ${index}` },
       }));
-      this.ctx.recordHistoryCompactCheckpoint?.(buildHistoryCompactCheckpoint({
+      await this.ctx.recordHistoryCompactCheckpoint?.(buildHistoryCompactCheckpoint({
         sessionId: this.sessionId,
         coveredRuntimeEvents,
         summary: `${input.turnId} checkpoint`,
-      }), input.turnId);
+      }), input.turnId).catch(() => {});
     }
     yield { type: 'complete', id: `${input.turnId}-complete`, turnId: input.turnId, ts: 4, stopReason: 'end_turn' };
   }
@@ -5616,6 +5718,51 @@ class RecoveringCheckpointWriteProbeBackend implements AgentBackend {
       } catch {
         this.writeOutcomes.push(`${input.turnId}:rejected`);
       }
+    }
+    yield { type: 'complete', id: `${input.turnId}-complete`, turnId: input.turnId, ts: 4, stopReason: 'end_turn' };
+  }
+
+  async stop(): Promise<void> {}
+  async respondToPermission(_decision: PermissionDecision): Promise<void> {}
+  async dispose(): Promise<void> {}
+}
+
+class CheckpointRecorderContractProbeBackend implements AgentBackend {
+  readonly kind = 'fake' as const;
+  readonly sessionId: string;
+
+  constructor(
+    private readonly ctx: BackendFactoryContext,
+    private readonly beforeRecord: (turnId: string) => Promise<void>,
+    private readonly writeOutcomes: string[],
+  ) {
+    this.sessionId = ctx.sessionId;
+  }
+
+  async *send(input: BackendSendInput): AsyncIterable<SessionEvent> {
+    await this.beforeRecord(input.turnId);
+    const coverage = input.turnId === 'parent-furthest-in-flight' ? 2 : 1;
+    const coveredRuntimeEvents = Array.from({ length: coverage }, (_, index): RuntimeEvent => ({
+      id: `contract-source-event-${index}`,
+      sessionId: this.sessionId,
+      runId: `contract-source-run-${index}`,
+      turnId: `contract-source-turn-${index}`,
+      invocationId: `contract-source-invocation-${index}`,
+      ts: index + 1,
+      partial: false,
+      role: 'user',
+      author: 'user',
+      content: { kind: 'text', text: `source ${index}` },
+    }));
+    try {
+      await this.ctx.recordHistoryCompactCheckpoint?.(buildHistoryCompactCheckpoint({
+        sessionId: this.sessionId,
+        coveredRuntimeEvents,
+        summary: `${input.turnId} checkpoint`,
+      }), input.turnId);
+      this.writeOutcomes.push(`${input.turnId}:fulfilled`);
+    } catch {
+      this.writeOutcomes.push(`${input.turnId}:rejected`);
     }
     yield { type: 'complete', id: `${input.turnId}-complete`, turnId: input.turnId, ts: 4, stopReason: 'end_turn' };
   }

--- a/packages/runtime/src/__tests__/session-manager.test.ts
+++ b/packages/runtime/src/__tests__/session-manager.test.ts
@@ -79,6 +79,32 @@ describe('SessionManager manual compaction', () => {
     expect((await runStore.readRuntimeEvents(session.id, compactRun!.runId)).some((event) => event.actions?.tokenUsage?.contextBudget)).toBe(true);
   });
 
+  test('persists one visible warning when manual compaction fails open', async () => {
+    const store = new MemorySessionStore();
+    const runStore = new MemoryAgentRunStore();
+    const backends = new BackendRegistry();
+    backends.register('fake', (ctx) => new FailOpenCompactingBackend(ctx));
+    const manager = new SessionManager({
+      store,
+      runStore,
+      runtimeEventStore: runStore,
+      backends,
+      newId: nextId(),
+      now: nextNow(12_000),
+    });
+    const session = await manager.createSession(makeInput({ backend: 'fake', permissionMode: 'bypass' }));
+
+    await drain(manager.sendMessage(session.id, { turnId: 'turn-1', text: 'hello' }));
+    await drain(manager.compactSession(session.id, { turnId: 'turn-compact' }));
+
+    const warnings = (await store.readMessages(session.id)).filter((message) =>
+      message.type === 'system_note'
+      && message.turnId === 'turn-compact'
+      && message.kind === 'context_compaction_failed_open'
+    );
+    expect(warnings).toHaveLength(1);
+  });
+
   test('manual compaction stopped before backend start does not write compact artifacts', async () => {
     const store = new MemorySessionStore();
     const readGate = makeGate();
@@ -4817,6 +4843,12 @@ class BlockingCompactBackend extends TestBackend {
   }
 }
 
+class FailOpenCompactingBackend extends TestBackend {
+  async compactHistory(_input: { turnId: string; runtimeContext: readonly RuntimeEvent[] }) {
+    return compactHistoryFailOpenResult();
+  }
+}
+
 class ActiveTurnBackend extends TestBackend {
   constructor(
     ctx: BackendFactoryContext,
@@ -4857,6 +4889,29 @@ function compactHistoryResult() {
         decision: 'replaced' as const,
         boundaryKind: 'historyCompact',
         estimatedTokensSaved: 600,
+      }],
+    },
+  };
+}
+
+function compactHistoryFailOpenResult() {
+  return {
+    contextBudget: {
+      enabled: true,
+      policyName: 'unit-budget',
+      estimatedTokensBefore: 1000,
+      estimatedTokensAfter: 400,
+      keptTurns: 1,
+      droppedTurns: 1,
+      keptEvents: 1,
+      droppedEvents: 1,
+      historyCompactWriteFailures: 1,
+      compactionDecisions: [{
+        stage: 'priorReplay' as const,
+        sourceKind: 'runtimeEvents' as const,
+        decision: 'failedOpen' as const,
+        boundaryKind: 'historyCompact',
+        failOpenReason: 'write_failed',
       }],
     },
   };

--- a/packages/runtime/src/__tests__/session-manager.test.ts
+++ b/packages/runtime/src/__tests__/session-manager.test.ts
@@ -4043,6 +4043,39 @@ describe('SessionManager permission mode updates', () => {
     expect(recordedCoverage).toEqual([2]);
   });
 
+  test('persists an explicit same-coverage successor checkpoint', async () => {
+    const store = new MemorySessionStore();
+    const runStore = new MemoryAgentRunStore();
+    const writeOutcomes: string[] = [];
+    const backends = new BackendRegistry();
+    backends.register('fake', (ctx) => new SameCoverageCheckpointReplacementProbeBackend(ctx, writeOutcomes));
+    const manager = new SessionManager({
+      store,
+      runStore,
+      runtimeEventStore: runStore,
+      backends,
+      newId: nextId(),
+      now: nextNow(12_796),
+    });
+    const session = await manager.createSession(makeInput());
+
+    await drain(manager.sendMessage(session.id, { turnId: 'same-coverage-initial', text: 'hello' }));
+    await drain(manager.sendMessage(session.id, { turnId: 'same-coverage-replacement', text: 'hello again' }));
+
+    expect(writeOutcomes).toEqual(['same-coverage-initial:fulfilled', 'same-coverage-replacement:fulfilled']);
+    const checkpoints: HistoryCompactCheckpoint[] = [];
+    for (const run of await runStore.listSessionRuns(session.id)) {
+      for (const event of await runStore.readEvents(session.id, run.runId)) {
+        if (event.type === 'history_compact_checkpoint_recorded') {
+          checkpoints.push(event.data?.checkpoint as HistoryCompactCheckpoint);
+        }
+      }
+    }
+    expect(checkpoints).toHaveLength(2);
+    expect(checkpoints[1]?.previousCheckpointId).toBe(checkpoints[0]?.checkpointId);
+    expect(checkpoints[1]?.coverage).toEqual(checkpoints[0]?.coverage);
+  });
+
   test('serializes accepted checkpoint persistence across parent and child runs', async () => {
     const store = new MemorySessionStore();
     const parentWriteGate = makeGate();
@@ -5784,6 +5817,50 @@ class HistoryCompactCheckpointMonotonicProbeBackend implements AgentBackend {
         coveredRuntimeEvents,
         summary: `${input.turnId} checkpoint`,
       }), input.turnId).catch(() => {});
+    }
+    yield { type: 'complete', id: `${input.turnId}-complete`, turnId: input.turnId, ts: 4, stopReason: 'end_turn' };
+  }
+
+  async stop(): Promise<void> {}
+  async respondToPermission(_decision: PermissionDecision): Promise<void> {}
+  async dispose(): Promise<void> {}
+}
+
+class SameCoverageCheckpointReplacementProbeBackend implements AgentBackend {
+  readonly kind = 'fake' as const;
+  readonly sessionId: string;
+
+  constructor(
+    private readonly ctx: BackendFactoryContext,
+    private readonly writeOutcomes: string[],
+  ) {
+    this.sessionId = ctx.sessionId;
+  }
+
+  async *send(input: BackendSendInput): AsyncIterable<SessionEvent> {
+    const current = await this.ctx.loadHistoryCompactCheckpoint?.();
+    const coveredRuntimeEvents: RuntimeEvent[] = [{
+      id: 'same-coverage-source-event',
+      sessionId: this.sessionId,
+      runId: 'same-coverage-source-run',
+      turnId: 'same-coverage-source-turn',
+      invocationId: 'same-coverage-source-invocation',
+      ts: 1,
+      partial: false,
+      role: 'user',
+      author: 'user',
+      content: { kind: 'text', text: 'same source' },
+    }];
+    try {
+      await this.ctx.recordHistoryCompactCheckpoint?.(buildHistoryCompactCheckpoint({
+        sessionId: this.sessionId,
+        coveredRuntimeEvents,
+        summary: `${input.turnId} summary`,
+        ...(current ? { previousCheckpointId: current.checkpointId } : {}),
+      }), input.turnId);
+      this.writeOutcomes.push(`${input.turnId}:fulfilled`);
+    } catch {
+      this.writeOutcomes.push(`${input.turnId}:rejected`);
     }
     yield { type: 'complete', id: `${input.turnId}-complete`, turnId: input.turnId, ts: 4, stopReason: 'end_turn' };
   }

--- a/packages/runtime/src/agent-run.ts
+++ b/packages/runtime/src/agent-run.ts
@@ -200,7 +200,7 @@ export class AgentRun {
           checkpoint,
         },
       });
-    });
+    }, { rethrow: true });
   }
 
   recordSemanticCompactBlock(block: SemanticCompactBlock): void {
@@ -903,11 +903,16 @@ export class AgentRun {
     await this.traceQueue.catch(() => {});
   }
 
-  private enqueueRunStore(label: string, operation: () => Promise<void>): Promise<void> {
+  private enqueueRunStore(
+    label: string,
+    operation: () => Promise<void>,
+    options: { rethrow?: boolean } = {},
+  ): Promise<void> {
     if (!this.input.runStore || !this.runStoreAvailable) return Promise.resolve();
     const next = this.traceQueue.then(operation, operation).catch(async (error) => {
       this.runStoreAvailable = false;
       await this.enqueueTraceWriteFailure(error, label);
+      if (options.rethrow) throw error;
     });
     this.traceQueue = next.catch(() => {});
     return next;

--- a/packages/runtime/src/agent-run.ts
+++ b/packages/runtime/src/agent-run.ts
@@ -183,7 +183,8 @@ export class AgentRun {
   }
 
   recordHistoryCompactCheckpoint(checkpoint: HistoryCompactCheckpoint): Promise<void> {
-    if (!this.input.runStore || !this.runStoreAvailable) return Promise.resolve();
+    if (!this.input.runStore) return Promise.reject(new Error('AgentRun store is not configured'));
+    if (!this.runStoreAvailable) return Promise.reject(new Error('AgentRun store is unavailable'));
     return this.enqueueRunStore('append history compact checkpoint', async () => {
       await this.input.runStore?.appendEvent(this.sessionId, this.runId, {
         type: 'history_compact_checkpoint_recorded',

--- a/packages/runtime/src/agent-run.ts
+++ b/packages/runtime/src/agent-run.ts
@@ -17,6 +17,7 @@ import type { RunTraceEvent } from './run-trace.js';
 import type { SessionStore, StopSessionInput } from './session-manager.js';
 import type { ActiveFullCompactBlock } from './active-full-compact.js';
 import type { SemanticCompactBlock } from './semantic-compact.js';
+import type { HistoryCompactCheckpoint } from './history-compact-checkpoint.js';
 import { buildRuntimeEventModelReplayPlan } from './model-history.js';
 import {
   classifyRuntimeEventTerminalFact,
@@ -176,6 +177,27 @@ export class AgentRun {
           highWaterSeq: block.highWaterSeq,
           boundaryKind: 'activeFullCompact',
           block,
+        },
+      });
+    });
+  }
+
+  recordHistoryCompactCheckpoint(checkpoint: HistoryCompactCheckpoint): void {
+    if (!this.input.runStore || !this.runStoreAvailable) return;
+    this.enqueueRunStore('append history compact checkpoint', async () => {
+      await this.input.runStore?.appendEvent(this.sessionId, this.runId, {
+        type: 'history_compact_checkpoint_recorded',
+        id: this.input.newId(),
+        runId: this.runId,
+        sessionId: this.sessionId,
+        turnId: this.turnId,
+        ts: this.input.now(),
+        data: {
+          checkpointId: checkpoint.checkpointId,
+          highWaterName: checkpoint.highWaterName,
+          highWaterSeq: checkpoint.highWaterSeq,
+          boundaryKind: 'historyCompact',
+          checkpoint,
         },
       });
     });

--- a/packages/runtime/src/agent-run.ts
+++ b/packages/runtime/src/agent-run.ts
@@ -182,9 +182,9 @@ export class AgentRun {
     });
   }
 
-  recordHistoryCompactCheckpoint(checkpoint: HistoryCompactCheckpoint): void {
-    if (!this.input.runStore || !this.runStoreAvailable) return;
-    this.enqueueRunStore('append history compact checkpoint', async () => {
+  recordHistoryCompactCheckpoint(checkpoint: HistoryCompactCheckpoint): Promise<void> {
+    if (!this.input.runStore || !this.runStoreAvailable) return Promise.resolve();
+    return this.enqueueRunStore('append history compact checkpoint', async () => {
       await this.input.runStore?.appendEvent(this.sessionId, this.runId, {
         type: 'history_compact_checkpoint_recorded',
         id: this.input.newId(),

--- a/packages/runtime/src/ai-sdk-backend.ts
+++ b/packages/runtime/src/ai-sdk-backend.ts
@@ -623,8 +623,7 @@ export class AiSdkBackend implements AgentBackend {
       if (
         budgeted?.historyCompactBlocks?.length &&
         contextBudget.historyCompact?.mode === 'read_write' &&
-        (this.input.summarizeHistoryCompact && this.input.recordHistoryCompactCheckpoint
-          || this.input.writeHistoryCompact)
+        this.hasHistoryCompactWriter()
       ) {
         const loadedBlockIds = new Set((contextBudget.historyCompact.blocks ?? []).map((block) => block.blockId));
         const draftBlocks = budgeted.historyCompactBlocks.filter((block) => !loadedBlockIds.has(block.blockId));
@@ -673,7 +672,11 @@ export class AiSdkBackend implements AgentBackend {
   private buildManualHistoryCompactPolicy(
     runtimeContext: readonly RuntimeEvent[],
   ): ContextBudgetPolicy | undefined {
-    if (runtimeContext.length === 0 || !this.input.contextBudget || !this.input.writeHistoryCompact) return undefined;
+    if (
+      runtimeContext.length === 0
+      || !this.input.contextBudget
+      || !this.hasHistoryCompactWriter()
+    ) return undefined;
     const base = this.input.contextBudget;
     const charsPerToken = base.charsPerToken ?? 4;
     const estimatedTokens = Math.max(1, estimateRuntimeEventsTokens(runtimeContext, charsPerToken));
@@ -700,6 +703,13 @@ export class AiSdkBackend implements AgentBackend {
         highWaterName: current?.highWaterName ?? `${base.name ?? 'manual'}-manual-history-compact`,
       },
     };
+  }
+
+  private hasHistoryCompactWriter(): boolean {
+    return Boolean(
+      this.input.writeHistoryCompact
+      || (this.input.summarizeHistoryCompact && this.input.recordHistoryCompactCheckpoint),
+    );
   }
 
   // --------------------------------------------------------------------------
@@ -1467,8 +1477,7 @@ export class AiSdkBackend implements AgentBackend {
     if (
       budgeted?.historyCompactBlocks?.length &&
       contextBudget?.historyCompact?.mode === 'read_write' &&
-      (this.input.summarizeHistoryCompact && this.input.recordHistoryCompactCheckpoint
-        || this.input.writeHistoryCompact)
+      this.hasHistoryCompactWriter()
     ) {
       const loadedBlockIds = new Set((contextBudget.historyCompact.blocks ?? []).map((block) => block.blockId));
       const draftBlocks = budgeted.historyCompactBlocks.filter((block) => !loadedBlockIds.has(block.blockId));

--- a/packages/runtime/src/ai-sdk-backend.ts
+++ b/packages/runtime/src/ai-sdk-backend.ts
@@ -159,6 +159,7 @@ import {
   runtimeEventTurnKey,
   selectSynthesisCacheForReplay,
   shouldAppendContextCompactedNote,
+  shouldAppendContextCompactionFailedOpenNote,
   type ContextBudgetPolicy,
   type HistoryCompactBlock,
   type ActiveArchivedToolResultPlaceholder,
@@ -170,6 +171,12 @@ import {
   type ToolResultArchiveReader,
   type ToolResultArchiveRef,
 } from './context-budget.js';
+import {
+  buildHistoryCompactCheckpoint,
+  historyCompactCheckpointToRuntimeEvent,
+  matchHistoryCompactCheckpointPrefix,
+  type HistoryCompactCheckpoint,
+} from './history-compact-checkpoint.js';
 
 export {
   DEFAULT_PERMISSION_TIMEOUT_MS,
@@ -374,6 +381,15 @@ export type HistoryCompactLoader = (
 export type HistoryCompactWriter = (
   input: HistoryCompactWriteInput,
 ) => Promise<HistoryCompactWriteResult | void> | HistoryCompactWriteResult | void;
+export interface HistoryCompactSummaryInput extends HistoryCompactWriteInput {
+  previousCheckpoint?: HistoryCompactCheckpoint;
+  newlyFoldedRuntimeEvents?: RuntimeEvent[];
+}
+export type HistoryCompactSummarizer = (
+  input: HistoryCompactSummaryInput,
+) => Promise<string | undefined> | string | undefined;
+export type HistoryCompactCheckpointLoader = () => Promise<HistoryCompactCheckpoint | undefined> | HistoryCompactCheckpoint | undefined;
+export type HistoryCompactCheckpointRecorder = (checkpoint: HistoryCompactCheckpoint, turnId: string) => void | Promise<void>;
 export type ActiveFullCompactBlockRecorder = (block: ActiveFullCompactBlock) => void | Promise<void>;
 export type SemanticCompactBlockRecorder = (block: SemanticCompactBlock) => void | Promise<void>;
 
@@ -488,6 +504,12 @@ export interface AiSdkBackendInput {
   loadHistoryCompact?: HistoryCompactLoader;
   /** Optional best-effort source-bearing history compact block writer/summarizer. */
   writeHistoryCompact?: HistoryCompactWriter;
+  /** Preferred bounded V2 checkpoint loader. Legacy artifact blocks remain a read-only fallback. */
+  loadHistoryCompactCheckpoint?: HistoryCompactCheckpointLoader;
+  /** Produces a checkpoint summary from the prior summary plus newly evicted RuntimeEvents. */
+  summarizeHistoryCompact?: HistoryCompactSummarizer;
+  /** Best-effort durable recorder for accepted V2 checkpoints. */
+  recordHistoryCompactCheckpoint?: HistoryCompactCheckpointRecorder;
   /** Optional best-effort durable recorder for accepted active full compact blocks. */
   recordActiveFullCompactBlock?: ActiveFullCompactBlockRecorder;
   /** Optional best-effort durable recorder for accepted semantic compact blocks. */
@@ -601,26 +623,42 @@ export class AiSdkBackend implements AgentBackend {
       if (
         budgeted?.historyCompactBlocks?.length &&
         contextBudget.historyCompact?.mode === 'read_write' &&
-        this.input.writeHistoryCompact
+        (this.input.summarizeHistoryCompact && this.input.recordHistoryCompactCheckpoint
+          || this.input.writeHistoryCompact)
       ) {
         const loadedBlockIds = new Set((contextBudget.historyCompact.blocks ?? []).map((block) => block.blockId));
         const draftBlocks = budgeted.historyCompactBlocks.filter((block) => !loadedBlockIds.has(block.blockId));
         if (draftBlocks.length > 0) {
-          const writePatch = await this.writeHistoryCompactBlocks({
-            turnId: input.turnId,
-            contextBudget,
-            priorRuntimeContext: runtimeContext,
-            draftBlocks,
-            abortSignal: historyCompactAbortController.signal,
-          });
-          if (historyCompactAbortController.signal.aborted) return {};
-          if (writePatch.replacementBlocks.length === 0) {
-            contextBudgetDiagnostic = buildContextBudgetDiagnosticShell(runtimeContext, runtimeContext, contextBudget);
+          if (this.input.summarizeHistoryCompact && this.input.recordHistoryCompactCheckpoint) {
+            const writePatch = await this.writeHistoryCompactCheckpoint({
+              turnId: input.turnId,
+              contextBudget,
+              priorRuntimeContext: runtimeContext,
+              draftBlock: draftBlocks[0]!,
+              abortSignal: historyCompactAbortController.signal,
+            });
+            if (historyCompactAbortController.signal.aborted) return {};
+            contextBudgetDiagnostic = mergeContextBudgetDiagnostic(
+              contextBudgetDiagnostic ?? buildContextBudgetDiagnosticShell(runtimeContext, budgeted.events, contextBudget),
+              writePatch.diagnosticPatch,
+            );
+          } else {
+            const writePatch = await this.writeHistoryCompactBlocks({
+              turnId: input.turnId,
+              contextBudget,
+              priorRuntimeContext: runtimeContext,
+              draftBlocks,
+              abortSignal: historyCompactAbortController.signal,
+            });
+            if (historyCompactAbortController.signal.aborted) return {};
+            if (writePatch.replacementBlocks.length === 0) {
+              contextBudgetDiagnostic = buildContextBudgetDiagnosticShell(runtimeContext, runtimeContext, contextBudget);
+            }
+            contextBudgetDiagnostic = mergeContextBudgetDiagnostic(
+              contextBudgetDiagnostic ?? buildContextBudgetDiagnosticShell(runtimeContext, budgeted.events, contextBudget),
+              writePatch.diagnosticPatch,
+            );
           }
-          contextBudgetDiagnostic = mergeContextBudgetDiagnostic(
-            contextBudgetDiagnostic ?? buildContextBudgetDiagnosticShell(runtimeContext, budgeted.events, contextBudget),
-            writePatch.diagnosticPatch,
-          );
         }
       }
 
@@ -757,6 +795,7 @@ export class AiSdkBackend implements AgentBackend {
     let promptSegmentsForTelemetry: PromptSegmentEstimate[] = [];
     let contextBudgetForTelemetry: ContextBudgetDiagnostic | undefined;
     let contextCompactedNoteWritten = false;
+    let contextCompactionFailedOpenNoteWritten = false;
     const trace = new RunTrace({
       sessionId: this.sessionId,
       turnId,
@@ -1160,6 +1199,20 @@ export class AiSdkBackend implements AgentBackend {
               ...(contextBudgetForUsage ? { contextBudget: contextBudgetForUsage } : {}),
             };
             await this.input.appendMessage(tu).catch(() => {});
+            if (
+              !contextCompactionFailedOpenNoteWritten
+              && shouldAppendContextCompactionFailedOpenNote(contextBudgetForUsage)
+            ) {
+              contextCompactionFailedOpenNoteWritten = true;
+              const note: SystemNoteMessage = {
+                type: 'system_note',
+                id: this.newId(),
+                turnId,
+                ts: this.now(),
+                kind: 'context_compaction_failed_open',
+              };
+              await this.input.appendMessage(note).catch(() => {});
+            }
             if (!contextCompactedNoteWritten && shouldAppendContextCompactedNote(contextBudgetForUsage)) {
               contextCompactedNoteWritten = true;
               const note: SystemNoteMessage = {
@@ -1414,28 +1467,58 @@ export class AiSdkBackend implements AgentBackend {
     if (
       budgeted?.historyCompactBlocks?.length &&
       contextBudget?.historyCompact?.mode === 'read_write' &&
-      this.input.writeHistoryCompact
+      (this.input.summarizeHistoryCompact && this.input.recordHistoryCompactCheckpoint
+        || this.input.writeHistoryCompact)
     ) {
       const loadedBlockIds = new Set((contextBudget.historyCompact.blocks ?? []).map((block) => block.blockId));
       const draftBlocks = budgeted.historyCompactBlocks.filter((block) => !loadedBlockIds.has(block.blockId));
       if (draftBlocks.length > 0) {
-        const writePatch = await this.writeHistoryCompactBlocks({
-          turnId: input.turnId,
-          contextBudget,
-          priorRuntimeContext,
-          draftBlocks,
-          abortSignal: this.abortController?.signal,
-        });
-        if (writePatch.replacementBlocks.length > 0) {
-          runtimeContext = replaceHistoryCompactReplayBlocks(runtimeContext, writePatch.replacementBlocks);
+        if (this.input.summarizeHistoryCompact && this.input.recordHistoryCompactCheckpoint) {
+          const writePatch = await this.writeHistoryCompactCheckpoint({
+            turnId: input.turnId,
+            contextBudget,
+            priorRuntimeContext,
+            draftBlock: draftBlocks[0]!,
+            abortSignal: this.abortController?.signal,
+          });
+          if (writePatch.replacementCheckpoint) {
+            runtimeContext = [
+              historyCompactCheckpointToRuntimeEvent(writePatch.replacementCheckpoint),
+              ...runtimeContext.filter((event) => !event.id.startsWith('history-compact:')),
+            ];
+          } else {
+            runtimeContext = writePatch.fallbackCheckpoint
+              ? buildHistoryCompactCheckpointFailOpenContext(
+                  writePatch.fallbackCheckpoint,
+                  priorRuntimeContext,
+                  contextBudget,
+                  runtimeContext.filter((event) => !event.id.startsWith('history-compact:')),
+                )
+              : runtimeContext.filter((event) => !event.id.startsWith('history-compact:'));
+          }
+          contextBudgetDiagnostic = mergeContextBudgetDiagnostic(
+            contextBudgetDiagnostic ?? buildContextBudgetDiagnosticShell(priorRuntimeContext, runtimeContext, contextBudget),
+            writePatch.diagnosticPatch,
+          );
         } else {
-          runtimeContext = priorRuntimeContext;
-          contextBudgetDiagnostic = buildContextBudgetDiagnosticShell(priorRuntimeContext, runtimeContext, contextBudget);
+          const writePatch = await this.writeHistoryCompactBlocks({
+            turnId: input.turnId,
+            contextBudget,
+            priorRuntimeContext,
+            draftBlocks,
+            abortSignal: this.abortController?.signal,
+          });
+          if (writePatch.replacementBlocks.length > 0) {
+            runtimeContext = replaceHistoryCompactReplayBlocks(runtimeContext, writePatch.replacementBlocks);
+          } else {
+            runtimeContext = priorRuntimeContext;
+            contextBudgetDiagnostic = buildContextBudgetDiagnosticShell(priorRuntimeContext, runtimeContext, contextBudget);
+          }
+          contextBudgetDiagnostic = mergeContextBudgetDiagnostic(
+            contextBudgetDiagnostic ?? buildContextBudgetDiagnosticShell(priorRuntimeContext, runtimeContext, contextBudget),
+            writePatch.diagnosticPatch,
+          );
         }
-        contextBudgetDiagnostic = mergeContextBudgetDiagnostic(
-          contextBudgetDiagnostic ?? buildContextBudgetDiagnosticShell(priorRuntimeContext, runtimeContext, contextBudget),
-          writePatch.diagnosticPatch,
-        );
       }
     }
 
@@ -1931,13 +2014,32 @@ export class AiSdkBackend implements AgentBackend {
     policy: ContextBudgetPolicy,
   ): Promise<{ policy: ContextBudgetPolicy; diagnosticPatch?: Partial<ContextBudgetDiagnostic> }> {
     const historyCompact = policy.historyCompact;
-    if (historyCompact?.enabled !== true || !this.input.loadHistoryCompact) {
+    if (
+      historyCompact?.enabled !== true
+      || (!this.input.loadHistoryCompactCheckpoint && !this.input.loadHistoryCompact)
+    ) {
       return { policy };
     }
-    if ((historyCompact.blocks?.length ?? 0) > 0) {
+    if ((historyCompact.checkpoints?.length ?? 0) > 0 || (historyCompact.blocks?.length ?? 0) > 0) {
       return { policy };
     }
     try {
+      const checkpoint = await Promise.resolve(this.input.loadHistoryCompactCheckpoint?.());
+      if (checkpoint) {
+        return {
+          policy: {
+            ...policy,
+            historyCompact: { ...historyCompact, checkpoints: [checkpoint] },
+          },
+          diagnosticPatch: {
+            historyCompactEnabled: true,
+            historyCompactMode: historyCompact.mode ?? 'deterministic',
+            historyCompactBlocksLoaded: 1,
+            historyCompactBlocksAvailable: 1,
+          },
+        };
+      }
+      if (!this.input.loadHistoryCompact) return { policy };
       // No maxBytes here: the block JSON carries per-event provenance and
       // legitimately outgrows the token budget; the loader caps reads by
       // storage size, and token limits are enforced on the loaded blocks.
@@ -2082,6 +2184,121 @@ export class AiSdkBackend implements AgentBackend {
         synthesisCacheMode: 'read_write',
         synthesisCacheWritesAttempted: 1,
         synthesisCacheWriteFailures: 1,
+      };
+    }
+  }
+
+  private async writeHistoryCompactCheckpoint(input: {
+    turnId: string;
+    contextBudget: ContextBudgetPolicy;
+    priorRuntimeContext: readonly RuntimeEvent[];
+    draftBlock: HistoryCompactBlock;
+    abortSignal?: AbortSignal;
+  }): Promise<{
+    diagnosticPatch: Partial<ContextBudgetDiagnostic>;
+    replacementCheckpoint?: HistoryCompactCheckpoint;
+    fallbackCheckpoint?: HistoryCompactCheckpoint;
+  }> {
+    const summarizer = this.input.summarizeHistoryCompact;
+    const recorder = this.input.recordHistoryCompactCheckpoint;
+    if (!summarizer || !recorder) return { diagnosticPatch: {} };
+    const foldedIds = new Set(input.draftBlock.coverage.runtimeEventIds);
+    const foldedRuntimeEvents = input.priorRuntimeContext.filter((event) => foldedIds.has(event.id));
+    if (foldedRuntimeEvents.length === 0) {
+      return {
+        diagnosticPatch: {
+          historyCompactWritesAttempted: 0,
+          historyCompactWriteSkipped: 1,
+          historyCompactWriteSkippedReasonCounts: { source_missing: 1 },
+        },
+      };
+    }
+    const loadedCheckpoint = input.contextBudget.historyCompact?.checkpoints?.[0];
+    const checkpointMatch = loadedCheckpoint
+      ? matchHistoryCompactCheckpointPrefix(loadedCheckpoint, foldedRuntimeEvents)
+      : undefined;
+    const previousCheckpoint = checkpointMatch && !checkpointMatch.reason ? loadedCheckpoint : undefined;
+    const newlyFoldedRuntimeEvents = previousCheckpoint
+      ? foldedRuntimeEvents.slice(checkpointMatch!.coveredEventCount)
+      : foldedRuntimeEvents;
+    try {
+      const summary = await Promise.resolve(summarizer({
+        sessionId: this.sessionId,
+        turnId: input.turnId,
+        source: { draftBlock: input.draftBlock, foldedRuntimeEvents },
+        limits: {
+          maxBlocks: 1,
+          maxBlockEstimatedTokens:
+            input.contextBudget.historyCompact?.maxBlockEstimatedTokens
+            ?? input.contextBudget.historyCompact?.maxSummaryEstimatedTokens
+            ?? 1_024,
+          maxEstimatedTokens: input.contextBudget.historyCompact?.maxEstimatedTokens ?? 2_048,
+          charsPerToken: input.contextBudget.charsPerToken ?? 4,
+        },
+        ...(previousCheckpoint ? { previousCheckpoint } : {}),
+        newlyFoldedRuntimeEvents,
+        requestShapeHashBefore: this.priorRequestShape?.requestShapeHash,
+        abortSignal: input.abortSignal,
+      }));
+      if (!summary?.trim()) {
+        return {
+          ...(previousCheckpoint ? { fallbackCheckpoint: previousCheckpoint } : {}),
+          diagnosticPatch: {
+            historyCompactEnabled: true,
+            historyCompactMode: 'read_write',
+            historyCompactWritesAttempted: 1,
+            historyCompactWriteFailures: 1,
+            historyCompactWriteSkippedReasonCounts: { empty_summary: 1 },
+            ...compactionDecisionDiagnosticPatch({
+              stage: 'priorReplay', sourceKind: 'runtimeEvents', decision: 'failedOpen',
+              boundaryKind: 'historyCompact', failOpenReason: 'empty_summary',
+            }),
+          },
+        };
+      }
+      const checkpoint = buildHistoryCompactCheckpoint({
+        sessionId: this.sessionId,
+        coveredRuntimeEvents: foldedRuntimeEvents,
+        summary,
+        highWaterName: input.draftBlock.highWaterName,
+        highWaterSeq: input.draftBlock.highWaterSeq,
+        maxSummaryEstimatedTokens: input.contextBudget.historyCompact?.maxBlockEstimatedTokens
+          ?? input.contextBudget.historyCompact?.maxSummaryEstimatedTokens,
+        ...(previousCheckpoint ? { previousCheckpointId: previousCheckpoint.checkpointId } : {}),
+        requestShapeHashBefore: this.priorRequestShape?.requestShapeHash,
+        charsPerToken: input.contextBudget.charsPerToken,
+        now: this.now(),
+      });
+      await Promise.resolve(recorder(checkpoint, input.turnId));
+      return {
+        replacementCheckpoint: checkpoint,
+        diagnosticPatch: {
+          historyCompactEnabled: true,
+          historyCompactMode: 'read_write',
+          historyCompactWritesAttempted: 1,
+          historyCompactBlocksWritten: 1,
+          historyCompactWrittenBlockIds: [checkpoint.checkpointId],
+          historyCompactWriteEstimatedTokens: checkpoint.estimatedTokens,
+          historyCompactBlockIds: [checkpoint.checkpointId],
+          historyCompactedEstimatedTokensAfter: checkpoint.estimatedTokens,
+          highWaterName: checkpoint.highWaterName,
+          highWaterSeq: checkpoint.highWaterSeq,
+          highWaterReason: 'history_compact',
+        },
+      };
+    } catch {
+      return {
+        ...(previousCheckpoint ? { fallbackCheckpoint: previousCheckpoint } : {}),
+        diagnosticPatch: {
+          historyCompactEnabled: true,
+          historyCompactMode: 'read_write',
+          historyCompactWritesAttempted: 1,
+          historyCompactWriteFailures: 1,
+          ...compactionDecisionDiagnosticPatch({
+            stage: 'priorReplay', sourceKind: 'runtimeEvents', decision: 'failedOpen',
+            boundaryKind: 'historyCompact', failOpenReason: 'write_failed',
+          }),
+        },
       };
     }
   }
@@ -2622,6 +2839,44 @@ function contextBudgetWithActivePrepareStepDiagnostics(
   const mergedPatch = mergeContextBudgetDiagnosticPatches(prunePatch, activeFullCompactPatch);
   if (!mergedPatch) return base;
   return mergeContextBudgetDiagnostic(base ?? minimalContextBudgetDiagnostic(), mergedPatch);
+}
+
+function buildHistoryCompactCheckpointFailOpenContext(
+  checkpoint: HistoryCompactCheckpoint,
+  priorRuntimeContext: readonly RuntimeEvent[],
+  policy: ContextBudgetPolicy,
+  retainedCandidates: readonly RuntimeEvent[],
+): RuntimeEvent[] {
+  const charsPerToken = policy.charsPerToken ?? 4;
+  const compactableEvents = priorRuntimeContext.filter((event) =>
+    estimateRuntimeEventsTokens([event], charsPerToken) > 0
+  );
+  const match = matchHistoryCompactCheckpointPrefix(checkpoint, compactableEvents);
+  if (match.reason) return [...retainedCandidates];
+  const coveredIds = new Set(match.coveredRuntimeEvents.map((event) => event.id));
+  const candidates = retainedCandidates.filter((event) => !coveredIds.has(event.id));
+  const turnOrder: string[] = [];
+  const byTurn = new Map<string, RuntimeEvent[]>();
+  for (const event of candidates) {
+    const group = byTurn.get(event.turnId);
+    if (group) group.push(event);
+    else {
+      turnOrder.push(event.turnId);
+      byTurn.set(event.turnId, [event]);
+    }
+  }
+  const checkpointEvent = historyCompactCheckpointToRuntimeEvent(checkpoint);
+  const maxTokens = policy.maxHistoryEstimatedTokens ?? Number.POSITIVE_INFINITY;
+  let selectedTokens = estimateRuntimeEventsTokens([checkpointEvent], charsPerToken);
+  const selectedGroups: RuntimeEvent[][] = [];
+  for (let index = turnOrder.length - 1; index >= 0; index -= 1) {
+    const group = byTurn.get(turnOrder[index]!) ?? [];
+    const groupTokens = estimateRuntimeEventsTokens(group, charsPerToken);
+    if (selectedTokens + groupTokens > maxTokens) break;
+    selectedGroups.unshift(group);
+    selectedTokens += groupTokens;
+  }
+  return [checkpointEvent, ...selectedGroups.flat()];
 }
 
 function incrementRecord(counts: Record<string, number>, key: string): void {

--- a/packages/runtime/src/ai-sdk-backend.ts
+++ b/packages/runtime/src/ai-sdk-backend.ts
@@ -146,6 +146,7 @@ import {
   buildHistorySearchSource,
   buildPromptSegmentEstimates,
   collectStaleToolResultArchiveCandidates,
+  evaluateHistoryCompactCheckpointReplay,
   estimateRuntimeEventsTokens,
   mergeContextBudgetDiagnostic,
   mergeContextBudgetDiagnosticPatches,
@@ -2260,26 +2261,15 @@ export class AiSdkBackend implements AgentBackend {
     const newlyFoldedRuntimeEvents = previousCheckpoint
       ? foldedRuntimeEvents.slice(checkpointMatch!.coveredEventCount)
       : foldedRuntimeEvents;
-    const maxCheckpointTokensInput = input.contextBudget.historyCompact?.maxBlockEstimatedTokens
-      ?? input.contextBudget.historyCompact?.maxSummaryEstimatedTokens;
-    const maxCheckpointTokens = typeof maxCheckpointTokensInput === 'number'
-      && Number.isFinite(maxCheckpointTokensInput)
-      && maxCheckpointTokensInput > 0
-      ? maxCheckpointTokensInput
-      : 1_024;
     const retainedRuntimeEvents = input.priorRuntimeContext.filter((event) =>
       !foldedIds.has(event.id) && !event.id.startsWith('history-compact:')
     );
-    const maxHistoryEstimatedTokens = input.contextBudget.maxHistoryEstimatedTokens;
     const previousCheckpointFitsCurrentLimits = previousCheckpoint !== undefined
-      && previousCheckpoint.estimatedTokens <= maxCheckpointTokens
-      && (
-        maxHistoryEstimatedTokens === undefined
-        || estimateRuntimeEventsTokens([
-          historyCompactCheckpointToRuntimeEvent(previousCheckpoint),
-          ...retainedRuntimeEvents,
-        ], input.contextBudget.charsPerToken ?? 4) <= maxHistoryEstimatedTokens
-      );
+      && evaluateHistoryCompactCheckpointReplay(
+        previousCheckpoint,
+        retainedRuntimeEvents,
+        input.contextBudget,
+      ).fits;
     if (previousCheckpoint && newlyFoldedRuntimeEvents.length === 0 && previousCheckpointFitsCurrentLimits) {
       return {
         fallbackCheckpoint: previousCheckpoint,
@@ -2355,6 +2345,13 @@ export class AiSdkBackend implements AgentBackend {
         charsPerToken: input.contextBudget.charsPerToken,
         now: this.now(),
       });
+      if (!evaluateHistoryCompactCheckpointReplay(
+        checkpoint,
+        retainedRuntimeEvents,
+        input.contextBudget,
+      ).fits) {
+        throw new Error('History compact checkpoint exceeds current replay limits');
+      }
       await Promise.resolve(recorder(checkpoint, input.turnId));
       return {
         replacementCheckpoint: checkpoint,
@@ -2962,7 +2959,10 @@ function buildHistoryCompactCheckpointFailOpenContext(
     selectedGroups.unshift(group);
     selectedTokens += groupTokens;
   }
-  return [checkpointEvent, ...selectedGroups.flat()];
+  const replayTail = selectedGroups.flat();
+  return evaluateHistoryCompactCheckpointReplay(checkpoint, replayTail, policy).fits
+    ? [checkpointEvent, ...replayTail]
+    : [...retainedCandidates];
 }
 
 function incrementRecord(counts: Record<string, number>, key: string): void {

--- a/packages/runtime/src/ai-sdk-backend.ts
+++ b/packages/runtime/src/ai-sdk-backend.ts
@@ -554,6 +554,8 @@ export class AiSdkBackend implements AgentBackend {
   private currentWatchdog: StreamWatchdog | null = null;
   private currentRunTrace: RunTrace | null = null;
   private priorRequestShape: RequestShapeDiagnostic | undefined;
+  private historyCompactCheckpointLoaded = false;
+  private historyCompactCheckpoint: HistoryCompactCheckpoint | undefined;
   /**
    * Id of the assistant step currently streaming. Read by ToolRuntime via
    * `getCurrentStepId` so each tool call's `tool_start` carries the step it
@@ -2033,7 +2035,12 @@ export class AiSdkBackend implements AgentBackend {
       return { policy };
     }
     try {
-      const checkpoint = await Promise.resolve(this.input.loadHistoryCompactCheckpoint?.());
+      let checkpoint = this.historyCompactCheckpoint;
+      if (!this.historyCompactCheckpointLoaded) {
+        checkpoint = await Promise.resolve(this.input.loadHistoryCompactCheckpoint?.());
+        this.historyCompactCheckpoint = checkpoint;
+        this.historyCompactCheckpointLoaded = true;
+      }
       if (checkpoint) {
         return {
           policy: {
@@ -2279,6 +2286,8 @@ export class AiSdkBackend implements AgentBackend {
         now: this.now(),
       });
       await Promise.resolve(recorder(checkpoint, input.turnId));
+      this.historyCompactCheckpoint = checkpoint;
+      this.historyCompactCheckpointLoaded = true;
       return {
         replacementCheckpoint: checkpoint,
         diagnosticPatch: {

--- a/packages/runtime/src/ai-sdk-backend.ts
+++ b/packages/runtime/src/ai-sdk-backend.ts
@@ -554,8 +554,6 @@ export class AiSdkBackend implements AgentBackend {
   private currentWatchdog: StreamWatchdog | null = null;
   private currentRunTrace: RunTrace | null = null;
   private priorRequestShape: RequestShapeDiagnostic | undefined;
-  private historyCompactCheckpointLoaded = false;
-  private historyCompactCheckpoint: HistoryCompactCheckpoint | undefined;
   /**
    * Id of the assistant step currently streaming. Read by ToolRuntime via
    * `getCurrentStepId` so each tool call's `tool_start` carries the step it
@@ -631,9 +629,21 @@ export class AiSdkBackend implements AgentBackend {
         const draftBlocks = budgeted.historyCompactBlocks.filter((block) => !loadedBlockIds.has(block.blockId));
         if (draftBlocks.length > 0) {
           if (this.input.summarizeHistoryCompact && this.input.recordHistoryCompactCheckpoint) {
+            let writeContextBudget = contextBudget;
+            try {
+              const checkpoint = await Promise.resolve(this.input.loadHistoryCompactCheckpoint?.());
+              if (checkpoint) {
+                writeContextBudget = {
+                  ...contextBudget,
+                  historyCompact: { ...contextBudget.historyCompact!, checkpoints: [checkpoint] },
+                };
+              }
+            } catch {
+              // A missing previous checkpoint only loses rolling reuse; the current fold remains safe to summarize.
+            }
             const writePatch = await this.writeHistoryCompactCheckpoint({
               turnId: input.turnId,
-              contextBudget,
+              contextBudget: writeContextBudget,
               priorRuntimeContext: runtimeContext,
               draftBlock: draftBlocks[0]!,
               abortSignal: historyCompactAbortController.signal,
@@ -685,6 +695,7 @@ export class AiSdkBackend implements AgentBackend {
     const current = base.historyCompact;
     const currentWithoutBlocks = { ...current };
     delete currentWithoutBlocks.blocks;
+    delete currentWithoutBlocks.checkpoints;
     const maxHistoryEstimatedTokens = base.maxHistoryEstimatedTokens ?? Math.max(estimatedTokens, 32_000);
     return {
       name: base.name ?? 'manual-history-compact',
@@ -2035,12 +2046,7 @@ export class AiSdkBackend implements AgentBackend {
       return { policy };
     }
     try {
-      let checkpoint = this.historyCompactCheckpoint;
-      if (!this.historyCompactCheckpointLoaded) {
-        checkpoint = await Promise.resolve(this.input.loadHistoryCompactCheckpoint?.());
-        this.historyCompactCheckpoint = checkpoint;
-        this.historyCompactCheckpointLoaded = true;
-      }
+      const checkpoint = await Promise.resolve(this.input.loadHistoryCompactCheckpoint?.());
       if (checkpoint) {
         return {
           policy: {
@@ -2286,8 +2292,6 @@ export class AiSdkBackend implements AgentBackend {
         now: this.now(),
       });
       await Promise.resolve(recorder(checkpoint, input.turnId));
-      this.historyCompactCheckpoint = checkpoint;
-      this.historyCompactCheckpointLoaded = true;
       return {
         replacementCheckpoint: checkpoint,
         diagnosticPatch: {

--- a/packages/runtime/src/ai-sdk-backend.ts
+++ b/packages/runtime/src/ai-sdk-backend.ts
@@ -2045,23 +2045,38 @@ export class AiSdkBackend implements AgentBackend {
     if ((historyCompact.checkpoints?.length ?? 0) > 0 || (historyCompact.blocks?.length ?? 0) > 0) {
       return { policy };
     }
+    let loadFailures = 0;
+    let checkpoint: HistoryCompactCheckpoint | undefined;
     try {
-      const checkpoint = await Promise.resolve(this.input.loadHistoryCompactCheckpoint?.());
-      if (checkpoint) {
-        return {
-          policy: {
-            ...policy,
-            historyCompact: { ...historyCompact, checkpoints: [checkpoint] },
-          },
-          diagnosticPatch: {
-            historyCompactEnabled: true,
-            historyCompactMode: historyCompact.mode ?? 'deterministic',
-            historyCompactBlocksLoaded: 1,
-            historyCompactBlocksAvailable: 1,
-          },
-        };
-      }
-      if (!this.input.loadHistoryCompact) return { policy };
+      checkpoint = await Promise.resolve(this.input.loadHistoryCompactCheckpoint?.());
+    } catch {
+      loadFailures += 1;
+    }
+    if (checkpoint) {
+      return {
+        policy: {
+          ...policy,
+          historyCompact: { ...historyCompact, checkpoints: [checkpoint] },
+        },
+        diagnosticPatch: {
+          historyCompactEnabled: true,
+          historyCompactMode: historyCompact.mode ?? 'deterministic',
+          historyCompactBlocksLoaded: 1,
+          historyCompactBlocksAvailable: 1,
+        },
+      };
+    }
+    if (!this.input.loadHistoryCompact) {
+      return loadFailures > 0 ? {
+        policy,
+        diagnosticPatch: {
+          historyCompactEnabled: true,
+          historyCompactMode: historyCompact.mode ?? 'deterministic',
+          historyCompactLoadFailures: loadFailures,
+        },
+      } : { policy };
+    }
+    try {
       // No maxBytes here: the block JSON carries per-event provenance and
       // legitimately outgrows the token budget; the loader caps reads by
       // storage size, and token limits are enforced on the loaded blocks.
@@ -2084,17 +2099,19 @@ export class AiSdkBackend implements AgentBackend {
           historyCompactMode: historyCompact.mode ?? 'deterministic',
           historyCompactBlocksLoaded: blocks.length,
           historyCompactBlocksAvailable: blocks.length,
+          ...(loadFailures > 0 ? { historyCompactLoadFailures: loadFailures } : {}),
           ...(result.skipped && result.skipped > 0 ? { historyCompactLoadSkipped: result.skipped } : {}),
           ...(result.skippedReasonCounts ? { historyCompactLoadSkippedReasonCounts: result.skippedReasonCounts } : {}),
         },
       };
     } catch {
+      loadFailures += 1;
       return {
         policy,
         diagnosticPatch: {
           historyCompactEnabled: true,
           historyCompactMode: historyCompact.mode ?? 'deterministic',
-          historyCompactLoadFailures: 1,
+          historyCompactLoadFailures: loadFailures,
         },
       };
     }

--- a/packages/runtime/src/ai-sdk-backend.ts
+++ b/packages/runtime/src/ai-sdk-backend.ts
@@ -2260,6 +2260,33 @@ export class AiSdkBackend implements AgentBackend {
     const newlyFoldedRuntimeEvents = previousCheckpoint
       ? foldedRuntimeEvents.slice(checkpointMatch!.coveredEventCount)
       : foldedRuntimeEvents;
+    if (previousCheckpoint && newlyFoldedRuntimeEvents.length === 0) {
+      return {
+        fallbackCheckpoint: previousCheckpoint,
+        diagnosticPatch: {
+          historyCompactEnabled: true,
+          historyCompactMode: 'read_write',
+          historyCompactWritesAttempted: 0,
+          historyCompactWriteSkipped: 1,
+          historyCompactWriteSkippedReasonCounts: { already_compacted: 1 },
+          historyCompactBlocksAvailable: 1,
+          historyCompactBlocksSelected: 1,
+          historyCompactBlockIds: [previousCheckpoint.checkpointId],
+          historyCompactedTurns: previousCheckpoint.coverage.turnCount,
+          historyCompactedEvents: previousCheckpoint.coverage.eventCount,
+          historyCompactedEstimatedTokensAfter: previousCheckpoint.estimatedTokens,
+          historyCompactCoverageHashes: [previousCheckpoint.coverage.sourceDigest],
+          ...compactionDecisionDiagnosticPatch({
+            stage: 'priorReplay',
+            sourceKind: 'runtimeEvents',
+            decision: 'unchanged',
+            boundaryKind: 'historyCompact',
+            boundaryIds: [previousCheckpoint.checkpointId],
+            reason: 'already_compacted',
+          }),
+        },
+      };
+    }
     try {
       const summary = await Promise.resolve(summarizer({
         sessionId: this.sessionId,

--- a/packages/runtime/src/ai-sdk-backend.ts
+++ b/packages/runtime/src/ai-sdk-backend.ts
@@ -636,7 +636,7 @@ export class AiSdkBackend implements AgentBackend {
               if (checkpoint) {
                 writeContextBudget = {
                   ...contextBudget,
-                  historyCompact: { ...contextBudget.historyCompact!, checkpoints: [checkpoint] },
+                  historyCompact: { ...contextBudget.historyCompact!, checkpoint },
                 };
               }
             } catch {
@@ -696,7 +696,7 @@ export class AiSdkBackend implements AgentBackend {
     const current = base.historyCompact;
     const currentWithoutBlocks = { ...current };
     delete currentWithoutBlocks.blocks;
-    delete currentWithoutBlocks.checkpoints;
+    delete currentWithoutBlocks.checkpoint;
     const maxHistoryEstimatedTokens = base.maxHistoryEstimatedTokens ?? Math.max(estimatedTokens, 32_000);
     return {
       name: base.name ?? 'manual-history-compact',
@@ -2043,7 +2043,7 @@ export class AiSdkBackend implements AgentBackend {
     ) {
       return { policy };
     }
-    if ((historyCompact.checkpoints?.length ?? 0) > 0 || (historyCompact.blocks?.length ?? 0) > 0) {
+    if (historyCompact.checkpoint !== undefined || (historyCompact.blocks?.length ?? 0) > 0) {
       return { policy };
     }
     let loadFailures = 0;
@@ -2057,7 +2057,7 @@ export class AiSdkBackend implements AgentBackend {
       return {
         policy: {
           ...policy,
-          historyCompact: { ...historyCompact, checkpoints: [checkpoint] },
+          historyCompact: { ...historyCompact, checkpoint },
         },
         diagnosticPatch: {
           historyCompactEnabled: true,
@@ -2253,7 +2253,7 @@ export class AiSdkBackend implements AgentBackend {
         },
       };
     }
-    const loadedCheckpoint = input.contextBudget.historyCompact?.checkpoints?.[0];
+    const loadedCheckpoint = input.contextBudget.historyCompact?.checkpoint;
     const checkpointMatch = loadedCheckpoint
       ? matchHistoryCompactCheckpointPrefix(loadedCheckpoint, foldedRuntimeEvents)
       : undefined;
@@ -2341,7 +2341,6 @@ export class AiSdkBackend implements AgentBackend {
         maxSummaryEstimatedTokens: input.contextBudget.historyCompact?.maxBlockEstimatedTokens
           ?? input.contextBudget.historyCompact?.maxSummaryEstimatedTokens,
         ...(previousCheckpoint ? { previousCheckpointId: previousCheckpoint.checkpointId } : {}),
-        requestShapeHashBefore: this.priorRequestShape?.requestShapeHash,
         charsPerToken: input.contextBudget.charsPerToken,
         now: this.now(),
       });

--- a/packages/runtime/src/ai-sdk-backend.ts
+++ b/packages/runtime/src/ai-sdk-backend.ts
@@ -2260,7 +2260,27 @@ export class AiSdkBackend implements AgentBackend {
     const newlyFoldedRuntimeEvents = previousCheckpoint
       ? foldedRuntimeEvents.slice(checkpointMatch!.coveredEventCount)
       : foldedRuntimeEvents;
-    if (previousCheckpoint && newlyFoldedRuntimeEvents.length === 0) {
+    const maxCheckpointTokensInput = input.contextBudget.historyCompact?.maxBlockEstimatedTokens
+      ?? input.contextBudget.historyCompact?.maxSummaryEstimatedTokens;
+    const maxCheckpointTokens = typeof maxCheckpointTokensInput === 'number'
+      && Number.isFinite(maxCheckpointTokensInput)
+      && maxCheckpointTokensInput > 0
+      ? maxCheckpointTokensInput
+      : 1_024;
+    const retainedRuntimeEvents = input.priorRuntimeContext.filter((event) =>
+      !foldedIds.has(event.id) && !event.id.startsWith('history-compact:')
+    );
+    const maxHistoryEstimatedTokens = input.contextBudget.maxHistoryEstimatedTokens;
+    const previousCheckpointFitsCurrentLimits = previousCheckpoint !== undefined
+      && previousCheckpoint.estimatedTokens <= maxCheckpointTokens
+      && (
+        maxHistoryEstimatedTokens === undefined
+        || estimateRuntimeEventsTokens([
+          historyCompactCheckpointToRuntimeEvent(previousCheckpoint),
+          ...retainedRuntimeEvents,
+        ], input.contextBudget.charsPerToken ?? 4) <= maxHistoryEstimatedTokens
+      );
+    if (previousCheckpoint && newlyFoldedRuntimeEvents.length === 0 && previousCheckpointFitsCurrentLimits) {
       return {
         fallbackCheckpoint: previousCheckpoint,
         diagnosticPatch: {

--- a/packages/runtime/src/context-budget.ts
+++ b/packages/runtime/src/context-budget.ts
@@ -275,8 +275,8 @@ export interface HistoryCompactPolicy {
   mode?: 'deterministic' | 'lookup' | 'read_write';
   /** Source-bearing compact blocks available for the current replay projection. */
   blocks?: readonly HistoryCompactBlock[];
-  /** Bounded V2 checkpoints loaded from the run ledger. Preferred over legacy V1 blocks. */
-  checkpoints?: readonly HistoryCompactCheckpoint[];
+  /** V2 checkpoint loaded from the run ledger. Preferred over legacy V1 blocks. */
+  checkpoint?: HistoryCompactCheckpoint;
   /** Defaults to 1 to keep replay bounded and deterministic. */
   maxBlocks?: number;
   /** Defaults to 2048 to keep replay bounded and deterministic. */
@@ -343,7 +343,7 @@ export interface HistoryCompactCoverage {
 export interface HistoryCompactReplayResult {
   events: RuntimeEvent[];
   blocks: HistoryCompactBlock[];
-  checkpoints: HistoryCompactCheckpoint[];
+  checkpoint?: HistoryCompactCheckpoint;
   diagnosticPatch: Partial<ContextBudgetDiagnostic>;
 }
 
@@ -543,7 +543,7 @@ export function applyRuntimeEventContextBudget(
     policy,
     { charsPerToken, maxHistoryEstimatedTokens: maxTokens },
   );
-  const hasCompactedReplay = compacted.blocks.length > 0 || compacted.checkpoints.length > 0;
+  const hasCompactedReplay = compacted.blocks.length > 0 || compacted.checkpoint !== undefined;
   const budgetEvents = hasCompactedReplay ? compacted.events : pruned.events;
   const turnGroups = groupEventsByTurn(budgetEvents.filter(isHistoryCompactContentEvent), charsPerToken);
 
@@ -580,7 +580,7 @@ export function applyRuntimeEventContextBudget(
     keptTurns: keptTurnIds.size,
     droppedTurns: hasCompactedReplay
       ? compacted.blocks.reduce((total, block) => total + block.coverage.turnIds.length, 0)
-        + compacted.checkpoints.reduce((total, checkpoint) => total + checkpoint.coverage.turnCount, 0)
+        + (compacted.checkpoint?.coverage.turnCount ?? 0)
       : Math.max(0, turnGroups.length - keptTurnIds.size),
     keptEvents: keptEvents.length,
     droppedEvents: Math.max(
@@ -627,7 +627,7 @@ export function applyRuntimeEventHistoryCompact(
 ): HistoryCompactReplayResult {
   const compactPolicy = policy?.historyCompact;
   if (compactPolicy?.enabled !== true) {
-    return { events: [...events], blocks: [], checkpoints: [], diagnosticPatch: {} };
+    return { events: [...events], blocks: [], diagnosticPatch: {} };
   }
 
   const charsPerToken = options.charsPerToken ?? policy?.charsPerToken ?? 4;
@@ -642,7 +642,6 @@ export function applyRuntimeEventHistoryCompact(
     return {
       events: [...events],
       blocks: [],
-      checkpoints: [],
       diagnosticPatch: {
         ...basePatch,
         historyCompactSkipped: 1,
@@ -661,7 +660,6 @@ export function applyRuntimeEventHistoryCompact(
     return {
       events: [...events],
       blocks: [],
-      checkpoints: [],
       diagnosticPatch: {
         ...basePatch,
         historyCompactSkipped: 1,
@@ -677,7 +675,6 @@ export function applyRuntimeEventHistoryCompact(
     return {
       events: [...events],
       blocks: [],
-      checkpoints: [],
       diagnosticPatch: {
         ...basePatch,
         historyCompactSkipped: 1,
@@ -703,7 +700,6 @@ export function applyRuntimeEventHistoryCompact(
     return {
       events: [...events],
       blocks: [],
-      checkpoints: [],
       diagnosticPatch: {
         ...basePatch,
         historyCompactSkipped: 1,
@@ -718,7 +714,6 @@ export function applyRuntimeEventHistoryCompact(
     return {
       events: [...events],
       blocks: [],
-      checkpoints: [],
       diagnosticPatch: {
         ...basePatch,
         historyCompactSkipped: 1,
@@ -728,55 +723,56 @@ export function applyRuntimeEventHistoryCompact(
     };
   }
 
-  for (const checkpoint of compactPolicy.checkpoints ?? []) {
+  const checkpoint = compactPolicy.checkpoint;
+  if (checkpoint) {
     const match = matchHistoryCompactCheckpointPrefix(checkpoint, foldedEvents);
     if (match.reason) {
       increment(skippedReasonCounts, match.reason);
-      continue;
-    }
-    const uncoveredFoldedEvents = foldedEvents.slice(match.coveredEventCount);
-    const replayTail = [...uncoveredFoldedEvents, ...retainedEvents];
-    const fit = evaluateHistoryCompactCheckpointReplay(checkpoint, replayTail, policy!, {
-      charsPerToken,
-      maxHistoryEstimatedTokens: maxTokens,
-    });
-    if (!fit.fits) {
-      increment(skippedReasonCounts, fit.reason);
-      continue;
-    }
-    const outputEvents = [historyCompactCheckpointToRuntimeEvent(checkpoint), ...replayTail];
-    const checkpointTokens = fit.checkpointTokens;
-    return {
-      events: outputEvents,
-      blocks: [],
-      checkpoints: [checkpoint],
-      diagnosticPatch: {
-        ...basePatch,
-        historyCompactBlocksAvailable: compactPolicy.checkpoints?.length ?? 0,
-        historyCompactBlocksSelected: 1,
-        historyCompactBlockIds: [checkpoint.checkpointId],
-        historyCompactedTurns: checkpoint.coverage.turnCount,
-        historyCompactedEvents: checkpoint.coverage.eventCount,
-        historyCompactedEstimatedTokensBefore: estimateRuntimeEventsTokens(match.coveredRuntimeEvents, charsPerToken),
-        historyCompactedEstimatedTokensAfter: checkpointTokens,
-        historyCompactCoverageHashes: [checkpoint.coverage.sourceDigest],
-        highWaterName: checkpoint.highWaterName,
-        highWaterSeq: checkpoint.highWaterSeq,
-        highWaterReason: 'history_compact',
-        ...compactionDecisionDiagnosticPatch({
-          stage: 'priorReplay',
-          sourceKind: 'runtimeEvents',
-          decision: 'replaced',
-          boundaryKind: 'historyCompact',
-          boundaryIds: [checkpoint.checkpointId],
-          coverage: {
-            bodySha256: [checkpoint.coverage.sourceDigest],
+    } else {
+      const uncoveredFoldedEvents = foldedEvents.slice(match.coveredEventCount);
+      const replayTail = [...uncoveredFoldedEvents, ...retainedEvents];
+      const fit = evaluateHistoryCompactCheckpointReplay(checkpoint, replayTail, policy!, {
+        charsPerToken,
+        maxHistoryEstimatedTokens: maxTokens,
+      });
+      if (!fit.fits) {
+        increment(skippedReasonCounts, fit.reason);
+      } else {
+        const outputEvents = [historyCompactCheckpointToRuntimeEvent(checkpoint), ...replayTail];
+        const checkpointTokens = fit.checkpointTokens;
+        return {
+          events: outputEvents,
+          blocks: [],
+          checkpoint,
+          diagnosticPatch: {
+            ...basePatch,
+            historyCompactBlocksAvailable: 1,
+            historyCompactBlocksSelected: 1,
+            historyCompactBlockIds: [checkpoint.checkpointId],
+            historyCompactedTurns: checkpoint.coverage.turnCount,
+            historyCompactedEvents: checkpoint.coverage.eventCount,
+            historyCompactedEstimatedTokensBefore: estimateRuntimeEventsTokens(match.coveredRuntimeEvents, charsPerToken),
+            historyCompactedEstimatedTokensAfter: checkpointTokens,
+            historyCompactCoverageHashes: [checkpoint.coverage.sourceDigest],
+            highWaterName: checkpoint.highWaterName,
+            highWaterSeq: checkpoint.highWaterSeq,
+            highWaterReason: 'history_compact',
+            ...compactionDecisionDiagnosticPatch({
+              stage: 'priorReplay',
+              sourceKind: 'runtimeEvents',
+              decision: 'replaced',
+              boundaryKind: 'historyCompact',
+              boundaryIds: [checkpoint.checkpointId],
+              coverage: {
+                bodySha256: [checkpoint.coverage.sourceDigest],
+              },
+              estimatedTokensBefore: estimateRuntimeEventsTokens(match.coveredRuntimeEvents, charsPerToken),
+              estimatedTokensAfter: checkpointTokens,
+            }),
           },
-          estimatedTokensBefore: estimateRuntimeEventsTokens(match.coveredRuntimeEvents, charsPerToken),
-          estimatedTokensAfter: checkpointTokens,
-        }),
-      },
-    };
+        };
+      }
+    }
   }
 
   const loaded = selectLoadedHistoryCompactBlock(
@@ -803,7 +799,6 @@ export function applyRuntimeEventHistoryCompact(
       return {
         events: outputEvents,
         blocks: [loadedBlock],
-        checkpoints: [],
         diagnosticPatch: {
           ...basePatch,
           historyCompactBlocksAvailable: compactPolicy.blocks?.length ?? 0,
@@ -845,7 +840,6 @@ export function applyRuntimeEventHistoryCompact(
       return {
         events: [...events],
         blocks: [],
-        checkpoints: [],
         diagnosticPatch: {
           ...basePatch,
           historyCompactSkipped: 1,
@@ -863,7 +857,6 @@ export function applyRuntimeEventHistoryCompact(
     return {
       events: [...events],
       blocks: [],
-      checkpoints: [],
       diagnosticPatch: {
         ...basePatch,
         historyCompactSkipped: 1,
@@ -892,7 +885,6 @@ export function applyRuntimeEventHistoryCompact(
     return {
       events: [...events],
       blocks: [],
-      checkpoints: [],
       diagnosticPatch: {
         ...basePatch,
         historyCompactSkipped: 1,
@@ -904,7 +896,6 @@ export function applyRuntimeEventHistoryCompact(
   return {
     events: outputEvents,
     blocks: [block],
-    checkpoints: [],
     diagnosticPatch: {
       ...basePatch,
       historyCompactBlockIds: [block.blockId],

--- a/packages/runtime/src/context-budget.ts
+++ b/packages/runtime/src/context-budget.ts
@@ -72,13 +72,19 @@ export type HistoryCompactCheckpointReplayFit =
       reason: 'max_block_tokens' | 'max_total_tokens' | 'prefix_over_budget';
     };
 
+export interface HistoryCompactReplayOptions {
+  charsPerToken?: number;
+  maxHistoryEstimatedTokens?: number;
+}
+
 /** The single current-policy gate for every checkpoint entering model replay. */
 export function evaluateHistoryCompactCheckpointReplay(
   checkpoint: HistoryCompactCheckpoint,
   replayTail: readonly RuntimeEvent[],
   policy: ContextBudgetPolicy,
+  options: HistoryCompactReplayOptions = {},
 ): HistoryCompactCheckpointReplayFit {
-  const charsPerToken = policy.charsPerToken ?? 4;
+  const charsPerToken = options.charsPerToken ?? policy.charsPerToken ?? 4;
   const checkpointEvent = historyCompactCheckpointToRuntimeEvent(checkpoint);
   const checkpointTokens = estimateRuntimeEventsTokens([checkpointEvent], charsPerToken);
   const replayTokens = estimateRuntimeEventsTokens([checkpointEvent, ...replayTail], charsPerToken);
@@ -93,7 +99,9 @@ export function evaluateHistoryCompactCheckpointReplay(
   if (checkpointTokens > maxTotalTokens) {
     return { fits: false, checkpointTokens, replayTokens, reason: 'max_total_tokens' };
   }
-  const maxHistoryTokens = finitePositive(policy.maxHistoryEstimatedTokens);
+  const maxHistoryTokens = finitePositive(
+    options.maxHistoryEstimatedTokens ?? policy.maxHistoryEstimatedTokens,
+  );
   if (maxHistoryTokens !== undefined && replayTokens > maxHistoryTokens) {
     return { fits: false, checkpointTokens, replayTokens, reason: 'prefix_over_budget' };
   }
@@ -615,10 +623,7 @@ export function applyRuntimeEventContextBudget(
 export function applyRuntimeEventHistoryCompact(
   events: readonly RuntimeEvent[],
   policy: ContextBudgetPolicy | undefined,
-  options: {
-    charsPerToken?: number;
-    maxHistoryEstimatedTokens?: number;
-  } = {},
+  options: HistoryCompactReplayOptions = {},
 ): HistoryCompactReplayResult {
   const compactPolicy = policy?.historyCompact;
   if (compactPolicy?.enabled !== true) {
@@ -731,7 +736,10 @@ export function applyRuntimeEventHistoryCompact(
     }
     const uncoveredFoldedEvents = foldedEvents.slice(match.coveredEventCount);
     const replayTail = [...uncoveredFoldedEvents, ...retainedEvents];
-    const fit = evaluateHistoryCompactCheckpointReplay(checkpoint, replayTail, policy!);
+    const fit = evaluateHistoryCompactCheckpointReplay(checkpoint, replayTail, policy!, {
+      charsPerToken,
+      maxHistoryEstimatedTokens: maxTokens,
+    });
     if (!fit.fits) {
       increment(skippedReasonCounts, fit.reason);
       continue;

--- a/packages/runtime/src/context-budget.ts
+++ b/packages/runtime/src/context-budget.ts
@@ -14,6 +14,12 @@ import {
 import type { ActiveFullCompactPolicy } from './active-full-compact.js';
 import type { SemanticCompactPolicy } from './semantic-compact.js';
 import type { CompactionDecisionKind } from './compaction-boundary.js';
+import {
+  historyCompactCheckpointToRuntimeEvent,
+  matchHistoryCompactCheckpointPrefix,
+  renderHistoryCompactCheckpoint,
+  type HistoryCompactCheckpoint,
+} from './history-compact-checkpoint.js';
 
 export interface ContextBudgetPolicy {
   name?: string;
@@ -224,6 +230,8 @@ export interface HistoryCompactPolicy {
   mode?: 'deterministic' | 'lookup' | 'read_write';
   /** Source-bearing compact blocks available for the current replay projection. */
   blocks?: readonly HistoryCompactBlock[];
+  /** Bounded V2 checkpoints loaded from the run ledger. Preferred over legacy V1 blocks. */
+  checkpoints?: readonly HistoryCompactCheckpoint[];
   /** Defaults to 1 to keep replay bounded and deterministic. */
   maxBlocks?: number;
   /** Defaults to 2048 to keep replay bounded and deterministic. */
@@ -290,6 +298,7 @@ export interface HistoryCompactCoverage {
 export interface HistoryCompactReplayResult {
   events: RuntimeEvent[];
   blocks: HistoryCompactBlock[];
+  checkpoints: HistoryCompactCheckpoint[];
   diagnosticPatch: Partial<ContextBudgetDiagnostic>;
 }
 
@@ -489,12 +498,13 @@ export function applyRuntimeEventContextBudget(
     policy,
     { charsPerToken, maxHistoryEstimatedTokens: maxTokens },
   );
-  const budgetEvents = compacted.blocks.length > 0 ? compacted.events : pruned.events;
+  const hasCompactedReplay = compacted.blocks.length > 0 || compacted.checkpoints.length > 0;
+  const budgetEvents = hasCompactedReplay ? compacted.events : pruned.events;
   const turnGroups = groupEventsByTurn(budgetEvents.filter(isHistoryCompactContentEvent), charsPerToken);
 
   const keptTurnIds = new Set<string>();
   let keptEvents: RuntimeEvent[];
-  if (compacted.blocks.length > 0) {
+  if (hasCompactedReplay) {
     keptEvents = budgetEvents;
     for (const event of keptEvents) keptTurnIds.add(turnKey(event));
   } else {
@@ -523,13 +533,14 @@ export function applyRuntimeEventContextBudget(
     estimatedTokensBefore,
     estimatedTokensAfter: estimateRuntimeEventsTokens(keptEvents, charsPerToken),
     keptTurns: keptTurnIds.size,
-    droppedTurns: compacted.blocks.length > 0
+    droppedTurns: hasCompactedReplay
       ? compacted.blocks.reduce((total, block) => total + block.coverage.turnIds.length, 0)
+        + compacted.checkpoints.reduce((total, checkpoint) => total + checkpoint.coverage.turnCount, 0)
       : Math.max(0, turnGroups.length - keptTurnIds.size),
     keptEvents: keptEvents.length,
     droppedEvents: Math.max(
       0,
-      (compacted.blocks.length > 0 ? pruned.events.length : budgetEvents.length) - keptEvents.length,
+      (hasCompactedReplay ? pruned.events.length : budgetEvents.length) - keptEvents.length,
     ),
     ...(policy.historyRewrite?.enabled === true
       ? {
@@ -574,7 +585,7 @@ export function applyRuntimeEventHistoryCompact(
 ): HistoryCompactReplayResult {
   const compactPolicy = policy?.historyCompact;
   if (compactPolicy?.enabled !== true) {
-    return { events: [...events], blocks: [], diagnosticPatch: {} };
+    return { events: [...events], blocks: [], checkpoints: [], diagnosticPatch: {} };
   }
 
   const charsPerToken = options.charsPerToken ?? policy?.charsPerToken ?? 4;
@@ -589,6 +600,7 @@ export function applyRuntimeEventHistoryCompact(
     return {
       events: [...events],
       blocks: [],
+      checkpoints: [],
       diagnosticPatch: {
         ...basePatch,
         historyCompactSkipped: 1,
@@ -607,6 +619,7 @@ export function applyRuntimeEventHistoryCompact(
     return {
       events: [...events],
       blocks: [],
+      checkpoints: [],
       diagnosticPatch: {
         ...basePatch,
         historyCompactSkipped: 1,
@@ -622,6 +635,7 @@ export function applyRuntimeEventHistoryCompact(
     return {
       events: [...events],
       blocks: [],
+      checkpoints: [],
       diagnosticPatch: {
         ...basePatch,
         historyCompactSkipped: 1,
@@ -647,6 +661,7 @@ export function applyRuntimeEventHistoryCompact(
     return {
       events: [...events],
       blocks: [],
+      checkpoints: [],
       diagnosticPatch: {
         ...basePatch,
         historyCompactSkipped: 1,
@@ -661,11 +676,71 @@ export function applyRuntimeEventHistoryCompact(
     return {
       events: [...events],
       blocks: [],
+      checkpoints: [],
       diagnosticPatch: {
         ...basePatch,
         historyCompactSkipped: 1,
         historyCompactSkippedReasonCounts: skippedReasonCounts,
         ...historyCompactSkippedDecisionPatch(skippedReasonCounts),
+      },
+    };
+  }
+
+  for (const checkpoint of compactPolicy.checkpoints ?? []) {
+    const match = matchHistoryCompactCheckpointPrefix(checkpoint, foldedEvents);
+    if (match.reason) {
+      increment(skippedReasonCounts, match.reason);
+      continue;
+    }
+    const checkpointText = renderHistoryCompactCheckpoint(checkpoint);
+    const checkpointTokens = checkpoint.estimatedTokens
+      ?? estimateTokens(checkpointText.length, charsPerToken);
+    const maxCheckpointTokens = finitePositive(compactPolicy.maxBlockEstimatedTokens)
+      ?? finitePositive(compactPolicy.maxSummaryEstimatedTokens)
+      ?? 1_024;
+    if (checkpointTokens > maxCheckpointTokens) {
+      increment(skippedReasonCounts, 'max_block_tokens');
+      continue;
+    }
+    const uncoveredFoldedEvents = foldedEvents.slice(match.coveredEventCount);
+    const outputEvents = [
+      historyCompactCheckpointToRuntimeEvent(checkpoint),
+      ...uncoveredFoldedEvents,
+      ...retainedEvents,
+    ];
+    if (!fitsHistoryBudget(outputEvents, maxTokens, charsPerToken)) {
+      increment(skippedReasonCounts, 'prefix_over_budget');
+      continue;
+    }
+    return {
+      events: outputEvents,
+      blocks: [],
+      checkpoints: [checkpoint],
+      diagnosticPatch: {
+        ...basePatch,
+        historyCompactBlocksAvailable: compactPolicy.checkpoints?.length ?? 0,
+        historyCompactBlocksSelected: 1,
+        historyCompactBlockIds: [checkpoint.checkpointId],
+        historyCompactedTurns: checkpoint.coverage.turnCount,
+        historyCompactedEvents: checkpoint.coverage.eventCount,
+        historyCompactedEstimatedTokensBefore: estimateRuntimeEventsTokens(match.coveredRuntimeEvents, charsPerToken),
+        historyCompactedEstimatedTokensAfter: checkpointTokens,
+        historyCompactCoverageHashes: [checkpoint.coverage.sourceDigest],
+        highWaterName: checkpoint.highWaterName,
+        highWaterSeq: checkpoint.highWaterSeq,
+        highWaterReason: 'history_compact',
+        ...compactionDecisionDiagnosticPatch({
+          stage: 'priorReplay',
+          sourceKind: 'runtimeEvents',
+          decision: 'replaced',
+          boundaryKind: 'historyCompact',
+          boundaryIds: [checkpoint.checkpointId],
+          coverage: {
+            bodySha256: [checkpoint.coverage.sourceDigest],
+          },
+          estimatedTokensBefore: estimateRuntimeEventsTokens(match.coveredRuntimeEvents, charsPerToken),
+          estimatedTokensAfter: checkpointTokens,
+        }),
       },
     };
   }
@@ -694,6 +769,7 @@ export function applyRuntimeEventHistoryCompact(
       return {
         events: outputEvents,
         blocks: [loadedBlock],
+        checkpoints: [],
         diagnosticPatch: {
           ...basePatch,
           historyCompactBlocksAvailable: compactPolicy.blocks?.length ?? 0,
@@ -735,6 +811,7 @@ export function applyRuntimeEventHistoryCompact(
       return {
         events: [...events],
         blocks: [],
+        checkpoints: [],
         diagnosticPatch: {
           ...basePatch,
           historyCompactSkipped: 1,
@@ -752,6 +829,7 @@ export function applyRuntimeEventHistoryCompact(
     return {
       events: [...events],
       blocks: [],
+      checkpoints: [],
       diagnosticPatch: {
         ...basePatch,
         historyCompactSkipped: 1,
@@ -780,6 +858,7 @@ export function applyRuntimeEventHistoryCompact(
     return {
       events: [...events],
       blocks: [],
+      checkpoints: [],
       diagnosticPatch: {
         ...basePatch,
         historyCompactSkipped: 1,
@@ -791,6 +870,7 @@ export function applyRuntimeEventHistoryCompact(
   return {
     events: outputEvents,
     blocks: [block],
+    checkpoints: [],
     diagnosticPatch: {
       ...basePatch,
       historyCompactBlockIds: [block.blockId],
@@ -2743,6 +2823,15 @@ export function shouldAppendContextCompactedNote(contextBudget: ContextBudgetDia
     && decision.boundaryKind === 'historyCompact'
     && decision.decision === 'replaced'
   ) === true;
+}
+
+export function shouldAppendContextCompactionFailedOpenNote(contextBudget: ContextBudgetDiagnostic | undefined): boolean {
+  return (contextBudget?.historyCompactWriteFailures ?? 0) > 0
+    && contextBudget?.compactionDecisions?.some((decision) =>
+      decision.stage === 'priorReplay'
+      && decision.boundaryKind === 'historyCompact'
+      && decision.decision === 'failedOpen'
+    ) === true;
 }
 
 export function minimalContextBudgetDiagnostic(): ContextBudgetDiagnostic {

--- a/packages/runtime/src/context-budget.ts
+++ b/packages/runtime/src/context-budget.ts
@@ -63,6 +63,43 @@ export interface ContextBudgetPolicy {
   historyRewrite?: HistoryRewriteGatePolicy;
 }
 
+export type HistoryCompactCheckpointReplayFit =
+  | { fits: true; checkpointTokens: number; replayTokens: number }
+  | {
+      fits: false;
+      checkpointTokens: number;
+      replayTokens: number;
+      reason: 'max_block_tokens' | 'max_total_tokens' | 'prefix_over_budget';
+    };
+
+/** The single current-policy gate for every checkpoint entering model replay. */
+export function evaluateHistoryCompactCheckpointReplay(
+  checkpoint: HistoryCompactCheckpoint,
+  replayTail: readonly RuntimeEvent[],
+  policy: ContextBudgetPolicy,
+): HistoryCompactCheckpointReplayFit {
+  const charsPerToken = policy.charsPerToken ?? 4;
+  const checkpointEvent = historyCompactCheckpointToRuntimeEvent(checkpoint);
+  const checkpointTokens = estimateRuntimeEventsTokens([checkpointEvent], charsPerToken);
+  const replayTokens = estimateRuntimeEventsTokens([checkpointEvent, ...replayTail], charsPerToken);
+  const compactPolicy = policy.historyCompact;
+  const maxBlockTokens = finitePositive(compactPolicy?.maxBlockEstimatedTokens)
+    ?? finitePositive(compactPolicy?.maxSummaryEstimatedTokens)
+    ?? 1_024;
+  if (checkpointTokens > maxBlockTokens) {
+    return { fits: false, checkpointTokens, replayTokens, reason: 'max_block_tokens' };
+  }
+  const maxTotalTokens = finitePositive(compactPolicy?.maxEstimatedTokens) ?? 2_048;
+  if (checkpointTokens > maxTotalTokens) {
+    return { fits: false, checkpointTokens, replayTokens, reason: 'max_total_tokens' };
+  }
+  const maxHistoryTokens = finitePositive(policy.maxHistoryEstimatedTokens);
+  if (maxHistoryTokens !== undefined && replayTokens > maxHistoryTokens) {
+    return { fits: false, checkpointTokens, replayTokens, reason: 'prefix_over_budget' };
+  }
+  return { fits: true, checkpointTokens, replayTokens };
+}
+
 export interface StaleToolResultPrunePolicy {
   enabled: boolean;
   /** Tool result payloads above this estimate are replaced with archive placeholders. Defaults to 2048. */
@@ -692,26 +729,15 @@ export function applyRuntimeEventHistoryCompact(
       increment(skippedReasonCounts, match.reason);
       continue;
     }
-    const checkpointText = renderHistoryCompactCheckpoint(checkpoint);
-    const checkpointTokens = checkpoint.estimatedTokens
-      ?? estimateTokens(checkpointText.length, charsPerToken);
-    const maxCheckpointTokens = finitePositive(compactPolicy.maxBlockEstimatedTokens)
-      ?? finitePositive(compactPolicy.maxSummaryEstimatedTokens)
-      ?? 1_024;
-    if (checkpointTokens > maxCheckpointTokens) {
-      increment(skippedReasonCounts, 'max_block_tokens');
-      continue;
-    }
     const uncoveredFoldedEvents = foldedEvents.slice(match.coveredEventCount);
-    const outputEvents = [
-      historyCompactCheckpointToRuntimeEvent(checkpoint),
-      ...uncoveredFoldedEvents,
-      ...retainedEvents,
-    ];
-    if (!fitsHistoryBudget(outputEvents, maxTokens, charsPerToken)) {
-      increment(skippedReasonCounts, 'prefix_over_budget');
+    const replayTail = [...uncoveredFoldedEvents, ...retainedEvents];
+    const fit = evaluateHistoryCompactCheckpointReplay(checkpoint, replayTail, policy!);
+    if (!fit.fits) {
+      increment(skippedReasonCounts, fit.reason);
       continue;
     }
+    const outputEvents = [historyCompactCheckpointToRuntimeEvent(checkpoint), ...replayTail];
+    const checkpointTokens = fit.checkpointTokens;
     return {
       events: outputEvents,
       blocks: [],

--- a/packages/runtime/src/history-compact-artifacts.ts
+++ b/packages/runtime/src/history-compact-artifacts.ts
@@ -135,7 +135,9 @@ export async function loadHistoryCompactBlocksFromArtifacts(
   const maxEstimatedTokens = input.maxEstimatedTokens ?? 2_048;
   // The block JSON carries per-event provenance and grows with the folded
   // event count; cap reads defensively by storage size, not by token budget.
-  const maxBytes = input.maxBytes ?? 1_048_576;
+  // V1 provenance fan-out produced multi-megabyte blocks in real sessions.
+  // This path is read-only compatibility; V2 checkpoints stay bounded in the run ledger.
+  const maxBytes = input.maxBytes ?? 16 * 1_048_576;
   const skippedReasonCounts: Record<string, number> = {};
   const blocks: HistoryCompactBlock[] = [];
   const records = await artifactStore.list(input.sessionId, { includeDeleted: true });

--- a/packages/runtime/src/history-compact-checkpoint.ts
+++ b/packages/runtime/src/history-compact-checkpoint.ts
@@ -1,0 +1,229 @@
+import { createHash } from 'node:crypto';
+import { Buffer } from 'node:buffer';
+import type { RuntimeEvent } from '@maka/core/runtime-event';
+import { stableStringify } from './request-shape.js';
+
+export interface HistoryCompactCheckpointCoverage {
+  eventCount: number;
+  turnCount: number;
+  through: {
+    runId: string;
+    turnId: string;
+    runtimeEventId: string;
+  };
+  sourceDigest: string;
+}
+
+export interface HistoryCompactCheckpoint {
+  kind: 'maka.history_compact_checkpoint';
+  version: 2;
+  checkpointId: string;
+  sessionId: string;
+  createdAt: number;
+  highWaterName: string;
+  highWaterSeq: number;
+  coverage: HistoryCompactCheckpointCoverage;
+  summary: string;
+  limitations: string[];
+  estimatedTokens: number;
+  previousCheckpointId?: string;
+  requestShapeHashBefore?: string;
+  requestShapeHashAfter?: string;
+}
+
+export interface BuildHistoryCompactCheckpointInput {
+  sessionId: string;
+  coveredRuntimeEvents: readonly RuntimeEvent[];
+  summary: string;
+  highWaterName?: string;
+  highWaterSeq?: number;
+  maxSummaryEstimatedTokens?: number;
+  previousCheckpointId?: string;
+  requestShapeHashBefore?: string;
+  requestShapeHashAfter?: string;
+  now?: number;
+  charsPerToken?: number;
+}
+
+export type HistoryCompactCheckpointPrefixMatch =
+  | { coveredEventCount: number; coveredRuntimeEvents: RuntimeEvent[]; reason?: undefined }
+  | { coveredEventCount: 0; coveredRuntimeEvents: []; reason: 'invalid_checkpoint' | 'coverage_miss' | 'source_hash_mismatch' };
+
+export function buildHistoryCompactCheckpoint(
+  input: BuildHistoryCompactCheckpointInput,
+): HistoryCompactCheckpoint {
+  if (input.coveredRuntimeEvents.length === 0) {
+    throw new Error('History compact checkpoint requires covered RuntimeEvents');
+  }
+  const summary = input.summary.trim();
+  if (summary.length === 0) {
+    throw new Error('History compact checkpoint requires a non-empty summary');
+  }
+  const charsPerToken = input.charsPerToken ?? 4;
+  const maxSummaryChars = Math.max(80, (input.maxSummaryEstimatedTokens ?? 1_024) * Math.max(1, charsPerToken));
+  const boundedSummary = summary.length <= maxSummaryChars
+    ? summary
+    : `${summary.slice(0, Math.max(0, maxSummaryChars - 1)).trimEnd()}…`;
+  const lastEvent = input.coveredRuntimeEvents.at(-1)!;
+  const createdAt = input.coveredRuntimeEvents.reduce(
+    (latest, event) => Math.max(latest, event.ts),
+    input.now ?? 1,
+  );
+  const coverage: HistoryCompactCheckpointCoverage = {
+    eventCount: input.coveredRuntimeEvents.length,
+    turnCount: new Set(input.coveredRuntimeEvents.map((event) => event.turnId)).size,
+    through: {
+      runId: lastEvent.runId,
+      turnId: lastEvent.turnId,
+      runtimeEventId: lastEvent.id,
+    },
+    sourceDigest: historyCompactSourceDigest(input.coveredRuntimeEvents),
+  };
+  const highWaterName = input.highWaterName ?? 'history-compact-high-water';
+  const highWaterSeq = input.highWaterSeq ?? createdAt;
+  const checkpointId = `hcheckpoint-${sha256(stableStringify({
+    version: 2,
+    sessionId: input.sessionId,
+    highWaterName,
+    highWaterSeq,
+    coverage,
+    summary: boundedSummary,
+    previousCheckpointId: input.previousCheckpointId,
+  })).slice(0, 32)}`;
+  const checkpoint: HistoryCompactCheckpoint = {
+    kind: 'maka.history_compact_checkpoint',
+    version: 2,
+    checkpointId,
+    sessionId: input.sessionId,
+    createdAt,
+    highWaterName,
+    highWaterSeq,
+    coverage,
+    summary: boundedSummary,
+    limitations: [
+      'Replay-time summary of the covered RuntimeEvent prefix.',
+      'RuntimeEvent ledger remains the source of truth when exact wording matters.',
+    ],
+    estimatedTokens: 0,
+    ...(input.previousCheckpointId ? { previousCheckpointId: input.previousCheckpointId } : {}),
+    ...(input.requestShapeHashBefore ? { requestShapeHashBefore: input.requestShapeHashBefore } : {}),
+    ...(input.requestShapeHashAfter ? { requestShapeHashAfter: input.requestShapeHashAfter } : {}),
+  };
+  checkpoint.estimatedTokens = estimateTokens(renderHistoryCompactCheckpoint(checkpoint).length, charsPerToken);
+  return checkpoint;
+}
+
+export function renderHistoryCompactCheckpoint(checkpoint: HistoryCompactCheckpoint): string {
+  return [
+    `<maka_history_compact_checkpoint id="${escapeAttribute(checkpoint.checkpointId)}" high_water="${escapeAttribute(checkpoint.highWaterName)}" seq="${checkpoint.highWaterSeq}" version="${checkpoint.version}">`,
+    `summary: ${checkpoint.summary}`,
+    `coverage: ${checkpoint.coverage.eventCount} runtime events across ${checkpoint.coverage.turnCount} turns`,
+    `limitations: ${checkpoint.limitations.join('; ')}`,
+    '</maka_history_compact_checkpoint>',
+  ].join('\n');
+}
+
+export function historyCompactCheckpointToRuntimeEvent(checkpoint: HistoryCompactCheckpoint): RuntimeEvent {
+  return {
+    id: `history-compact:${checkpoint.checkpointId}`,
+    sessionId: checkpoint.sessionId,
+    runId: `history-compact:${checkpoint.checkpointId}`,
+    turnId: `history-compact:${checkpoint.highWaterSeq}`,
+    invocationId: `history-compact:${checkpoint.checkpointId}`,
+    ts: checkpoint.createdAt,
+    partial: false,
+    role: 'user',
+    author: 'system',
+    content: { kind: 'text', text: renderHistoryCompactCheckpoint(checkpoint) },
+  };
+}
+
+export function validateHistoryCompactCheckpointShape(
+  value: unknown,
+  sessionId?: string,
+): value is HistoryCompactCheckpoint {
+  if (!value || typeof value !== 'object') return false;
+  const checkpoint = value as Partial<HistoryCompactCheckpoint>;
+  const coverage = checkpoint.coverage as Partial<HistoryCompactCheckpointCoverage> | undefined;
+  const through = coverage?.through as Partial<HistoryCompactCheckpointCoverage['through']> | undefined;
+  return checkpoint.kind === 'maka.history_compact_checkpoint'
+    && checkpoint.version === 2
+    && nonEmpty(checkpoint.checkpointId)
+    && nonEmpty(checkpoint.sessionId)
+    && (sessionId === undefined || checkpoint.sessionId === sessionId)
+    && Number.isFinite(checkpoint.createdAt)
+    && nonEmpty(checkpoint.highWaterName)
+    && Number.isFinite(checkpoint.highWaterSeq)
+    && Number.isInteger(coverage?.eventCount)
+    && (coverage?.eventCount ?? 0) > 0
+    && Number.isInteger(coverage?.turnCount)
+    && (coverage?.turnCount ?? 0) > 0
+    && nonEmpty(through?.runId)
+    && nonEmpty(through?.turnId)
+    && nonEmpty(through?.runtimeEventId)
+    && nonEmpty(coverage?.sourceDigest)
+    && typeof checkpoint.summary === 'string'
+    && checkpoint.summary.trim().length > 0
+    && Array.isArray(checkpoint.limitations)
+    && checkpoint.limitations.every(nonEmpty)
+    && Number.isFinite(checkpoint.estimatedTokens)
+    && (checkpoint.estimatedTokens ?? -1) >= 0
+    && (checkpoint.previousCheckpointId === undefined || nonEmpty(checkpoint.previousCheckpointId));
+}
+
+export function matchHistoryCompactCheckpointPrefix(
+  checkpoint: HistoryCompactCheckpoint,
+  events: readonly RuntimeEvent[],
+): HistoryCompactCheckpointPrefixMatch {
+  if (!validateHistoryCompactCheckpointShape(checkpoint)) {
+    return { coveredEventCount: 0, coveredRuntimeEvents: [], reason: 'invalid_checkpoint' };
+  }
+  const coveredRuntimeEvents = events.slice(0, checkpoint.coverage.eventCount);
+  const lastEvent = coveredRuntimeEvents.at(-1);
+  if (
+    coveredRuntimeEvents.length !== checkpoint.coverage.eventCount
+    || !lastEvent
+    || lastEvent.runId !== checkpoint.coverage.through.runId
+    || lastEvent.turnId !== checkpoint.coverage.through.turnId
+    || lastEvent.id !== checkpoint.coverage.through.runtimeEventId
+  ) {
+    return { coveredEventCount: 0, coveredRuntimeEvents: [], reason: 'coverage_miss' };
+  }
+  if (historyCompactSourceDigest(coveredRuntimeEvents) !== checkpoint.coverage.sourceDigest) {
+    return { coveredEventCount: 0, coveredRuntimeEvents: [], reason: 'source_hash_mismatch' };
+  }
+  return { coveredEventCount: coveredRuntimeEvents.length, coveredRuntimeEvents };
+}
+
+function historyCompactSourceDigest(events: readonly RuntimeEvent[]): string {
+  const hash = createHash('sha256');
+  for (const event of events) {
+    const serialized = stableStringify(event);
+    hash.update(String(Buffer.byteLength(serialized, 'utf8')));
+    hash.update(':');
+    hash.update(serialized);
+    hash.update(';');
+  }
+  return `sha256:${hash.digest('hex')}`;
+}
+
+function sha256(value: string): string {
+  return createHash('sha256').update(value).digest('hex');
+}
+
+function nonEmpty(value: unknown): value is string {
+  return typeof value === 'string' && value.length > 0;
+}
+
+function escapeAttribute(value: string): string {
+  return value
+    .replaceAll('&', '&amp;')
+    .replaceAll('"', '&quot;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;');
+}
+
+function estimateTokens(charCount: number, charsPerToken: number): number {
+  if (charCount <= 0) return 0;
+  return Math.max(1, Math.ceil(charCount / Math.max(1, charsPerToken)));
+}

--- a/packages/runtime/src/history-compact-checkpoint.ts
+++ b/packages/runtime/src/history-compact-checkpoint.ts
@@ -175,8 +175,28 @@ export function selectFurthestHistoryCompactCheckpoint(
   current: HistoryCompactCheckpoint | undefined,
   candidate: HistoryCompactCheckpoint,
 ): HistoryCompactCheckpoint {
-  if (!current || candidate.coverage.eventCount > current.coverage.eventCount) return candidate;
+  if (!current) return candidate;
+  if (canReplaceHistoryCompactCheckpoint(current, candidate)) return candidate;
   return current;
+}
+
+/** Accept forward progress, or a compare-and-swap rewrite of the exact same source coverage. */
+export function canReplaceHistoryCompactCheckpoint(
+  current: HistoryCompactCheckpoint | undefined,
+  candidate: HistoryCompactCheckpoint,
+): boolean {
+  if (!current || candidate.coverage.eventCount > current.coverage.eventCount) return true;
+  if (
+    candidate.coverage.eventCount !== current.coverage.eventCount
+    || candidate.previousCheckpointId !== current.checkpointId
+  ) {
+    return false;
+  }
+  return candidate.coverage.turnCount === current.coverage.turnCount
+    && candidate.coverage.sourceDigest === current.coverage.sourceDigest
+    && candidate.coverage.through.runId === current.coverage.through.runId
+    && candidate.coverage.through.turnId === current.coverage.through.turnId
+    && candidate.coverage.through.runtimeEventId === current.coverage.through.runtimeEventId;
 }
 
 export function matchHistoryCompactCheckpointPrefix(

--- a/packages/runtime/src/history-compact-checkpoint.ts
+++ b/packages/runtime/src/history-compact-checkpoint.ts
@@ -171,6 +171,14 @@ export function validateHistoryCompactCheckpointShape(
     && (checkpoint.previousCheckpointId === undefined || nonEmpty(checkpoint.previousCheckpointId));
 }
 
+export function selectFurthestHistoryCompactCheckpoint(
+  current: HistoryCompactCheckpoint | undefined,
+  candidate: HistoryCompactCheckpoint,
+): HistoryCompactCheckpoint {
+  if (!current || candidate.coverage.eventCount > current.coverage.eventCount) return candidate;
+  return current;
+}
+
 export function matchHistoryCompactCheckpointPrefix(
   checkpoint: HistoryCompactCheckpoint,
   events: readonly RuntimeEvent[],

--- a/packages/runtime/src/history-compact-checkpoint.ts
+++ b/packages/runtime/src/history-compact-checkpoint.ts
@@ -27,8 +27,6 @@ export interface HistoryCompactCheckpoint {
   limitations: string[];
   estimatedTokens: number;
   previousCheckpointId?: string;
-  requestShapeHashBefore?: string;
-  requestShapeHashAfter?: string;
 }
 
 export interface BuildHistoryCompactCheckpointInput {
@@ -39,8 +37,6 @@ export interface BuildHistoryCompactCheckpointInput {
   highWaterSeq?: number;
   maxSummaryEstimatedTokens?: number;
   previousCheckpointId?: string;
-  requestShapeHashBefore?: string;
-  requestShapeHashAfter?: string;
   now?: number;
   charsPerToken?: number;
 }
@@ -106,8 +102,6 @@ export function buildHistoryCompactCheckpoint(
     ],
     estimatedTokens: 0,
     ...(input.previousCheckpointId ? { previousCheckpointId: input.previousCheckpointId } : {}),
-    ...(input.requestShapeHashBefore ? { requestShapeHashBefore: input.requestShapeHashBefore } : {}),
-    ...(input.requestShapeHashAfter ? { requestShapeHashAfter: input.requestShapeHashAfter } : {}),
   };
   checkpoint.estimatedTokens = estimateTokens(renderHistoryCompactCheckpoint(checkpoint).length, charsPerToken);
   return checkpoint;
@@ -169,15 +163,6 @@ export function validateHistoryCompactCheckpointShape(
     && Number.isFinite(checkpoint.estimatedTokens)
     && (checkpoint.estimatedTokens ?? -1) >= 0
     && (checkpoint.previousCheckpointId === undefined || nonEmpty(checkpoint.previousCheckpointId));
-}
-
-export function selectFurthestHistoryCompactCheckpoint(
-  current: HistoryCompactCheckpoint | undefined,
-  candidate: HistoryCompactCheckpoint,
-): HistoryCompactCheckpoint {
-  if (!current) return candidate;
-  if (canReplaceHistoryCompactCheckpoint(current, candidate)) return candidate;
-  return current;
 }
 
 /** Accept forward progress, or a compare-and-swap rewrite of the exact same source coverage. */

--- a/packages/runtime/src/history-compact-ledger.ts
+++ b/packages/runtime/src/history-compact-ledger.ts
@@ -12,6 +12,7 @@ export async function loadLatestHistoryCompactCheckpointFromRunLedger(
   >,
   sessionId: string,
 ): Promise<HistoryCompactCheckpoint | undefined> {
+  let replaceEventId: string | undefined;
   if (runStore.readEventProjection) {
     try {
       const projected = await runStore.readEventProjection(
@@ -21,6 +22,7 @@ export async function loadLatestHistoryCompactCheckpointFromRunLedger(
       if (projected === null) return undefined;
       const checkpoint = projected?.data?.checkpoint;
       if (validateHistoryCompactCheckpointShape(checkpoint, sessionId)) return checkpoint;
+      replaceEventId = projected?.id;
     } catch {
       // Recover the derived projection from the canonical ledger below.
     }
@@ -48,6 +50,7 @@ export async function loadLatestHistoryCompactCheckpointFromRunLedger(
     sessionId,
     'history_compact_checkpoint_recorded',
     selectedEvent,
+    replaceEventId ? { replaceEventId } : undefined,
   ).catch(() => {
     // Recovery succeeded; a later cold read can retry this derived-state repair.
   });

--- a/packages/runtime/src/history-compact-ledger.ts
+++ b/packages/runtime/src/history-compact-ledger.ts
@@ -1,4 +1,4 @@
-import type { AgentRunStore } from '@maka/core';
+import type { AgentRunEvent, AgentRunStore } from '@maka/core';
 import {
   validateHistoryCompactCheckpointShape,
   selectFurthestHistoryCompactCheckpoint,
@@ -6,11 +6,28 @@ import {
 } from './history-compact-checkpoint.js';
 
 export async function loadLatestHistoryCompactCheckpointFromRunLedger(
-  runStore: Pick<AgentRunStore, 'listSessionRuns' | 'readEvents'>,
+  runStore: Pick<
+    AgentRunStore,
+    'listSessionRuns' | 'readEvents' | 'readEventProjection' | 'writeEventProjection'
+  >,
   sessionId: string,
 ): Promise<HistoryCompactCheckpoint | undefined> {
+  if (runStore.readEventProjection) {
+    try {
+      const projected = await runStore.readEventProjection(
+        sessionId,
+        'history_compact_checkpoint_recorded',
+      );
+      if (projected === null) return undefined;
+      const checkpoint = projected?.data?.checkpoint;
+      if (validateHistoryCompactCheckpointShape(checkpoint, sessionId)) return checkpoint;
+    } catch {
+      // Missing or damaged projections are rebuilt from the canonical run ledger below.
+    }
+  }
   const runs = await runStore.listSessionRuns(sessionId);
   let selected: HistoryCompactCheckpoint | undefined;
+  let selectedEvent: AgentRunEvent | undefined;
   for (let runIndex = runs.length - 1; runIndex >= 0; runIndex -= 1) {
     const run = runs[runIndex]!;
     const events = await runStore.readEvents(sessionId, run.runId);
@@ -19,8 +36,21 @@ export async function loadLatestHistoryCompactCheckpointFromRunLedger(
       if (event.type !== 'history_compact_checkpoint_recorded') continue;
       const checkpoint = event.data?.checkpoint;
       if (validateHistoryCompactCheckpointShape(checkpoint, sessionId)) {
-        selected = selectFurthestHistoryCompactCheckpoint(selected, checkpoint);
+        const next = selectFurthestHistoryCompactCheckpoint(selected, checkpoint);
+        if (next !== selected) selectedEvent = event;
+        selected = next;
       }
+    }
+  }
+  if (runStore.writeEventProjection) {
+    try {
+      await runStore.writeEventProjection(
+        sessionId,
+        'history_compact_checkpoint_recorded',
+        selectedEvent ?? null,
+      );
+    } catch {
+      // The run ledger remains canonical; a later load can retry projection repair.
     }
   }
   return selected;

--- a/packages/runtime/src/history-compact-ledger.ts
+++ b/packages/runtime/src/history-compact-ledger.ts
@@ -1,0 +1,23 @@
+import type { AgentRunStore } from '@maka/core';
+import {
+  validateHistoryCompactCheckpointShape,
+  type HistoryCompactCheckpoint,
+} from './history-compact-checkpoint.js';
+
+export async function loadLatestHistoryCompactCheckpointFromRunLedger(
+  runStore: Pick<AgentRunStore, 'listSessionRuns' | 'readEvents'>,
+  sessionId: string,
+): Promise<HistoryCompactCheckpoint | undefined> {
+  const runs = await runStore.listSessionRuns(sessionId);
+  for (let runIndex = runs.length - 1; runIndex >= 0; runIndex -= 1) {
+    const run = runs[runIndex]!;
+    const events = await runStore.readEvents(sessionId, run.runId);
+    for (let eventIndex = events.length - 1; eventIndex >= 0; eventIndex -= 1) {
+      const event = events[eventIndex]!;
+      if (event.type !== 'history_compact_checkpoint_recorded') continue;
+      const checkpoint = event.data?.checkpoint;
+      if (validateHistoryCompactCheckpointShape(checkpoint, sessionId)) return checkpoint;
+    }
+  }
+  return undefined;
+}

--- a/packages/runtime/src/history-compact-ledger.ts
+++ b/packages/runtime/src/history-compact-ledger.ts
@@ -1,9 +1,14 @@
 import type { AgentRunEvent, AgentRunStore } from '@maka/core';
 import {
+  canReplaceHistoryCompactCheckpoint,
   validateHistoryCompactCheckpointShape,
-  selectFurthestHistoryCompactCheckpoint,
   type HistoryCompactCheckpoint,
 } from './history-compact-checkpoint.js';
+
+interface LedgerCheckpointCandidate {
+  checkpoint: HistoryCompactCheckpoint;
+  event: AgentRunEvent;
+}
 
 export async function loadLatestHistoryCompactCheckpointFromRunLedger(
   runStore: Pick<
@@ -28,8 +33,7 @@ export async function loadLatestHistoryCompactCheckpointFromRunLedger(
     }
   }
   const runs = await runStore.listSessionRuns(sessionId);
-  let selected: HistoryCompactCheckpoint | undefined;
-  let selectedEvent: AgentRunEvent | null = null;
+  const candidates: LedgerCheckpointCandidate[] = [];
   for (let runIndex = runs.length - 1; runIndex >= 0; runIndex -= 1) {
     const run = runs[runIndex]!;
     const events = await runStore.readEvents(sessionId, run.runId);
@@ -38,21 +42,52 @@ export async function loadLatestHistoryCompactCheckpointFromRunLedger(
       if (event.type !== 'history_compact_checkpoint_recorded') continue;
       const checkpoint = event.data?.checkpoint;
       if (validateHistoryCompactCheckpointShape(checkpoint, sessionId)) {
-        const next = selectFurthestHistoryCompactCheckpoint(selected, checkpoint);
-        if (next === checkpoint) {
-          selected = checkpoint;
-          selectedEvent = event;
-        }
+        candidates.push({ checkpoint, event });
       }
     }
   }
+  const selected = selectRecoveredCheckpoint(candidates);
   await runStore.repairEventProjection?.(
     sessionId,
     'history_compact_checkpoint_recorded',
-    selectedEvent,
+    selected?.event ?? null,
     replaceEventId ? { replaceEventId } : undefined,
   ).catch(() => {
     // Recovery succeeded; a later cold read can retry this derived-state repair.
   });
-  return selected;
+  return selected?.checkpoint;
+}
+
+function selectRecoveredCheckpoint(
+  candidates: readonly LedgerCheckpointCandidate[],
+): LedgerCheckpointCandidate | undefined {
+  const maxCoverage = candidates.reduce(
+    (max, candidate) => Math.max(max, candidate.checkpoint.coverage.eventCount),
+    0,
+  );
+  const furthest = candidates.filter(
+    (candidate) => candidate.checkpoint.coverage.eventCount === maxCoverage,
+  );
+  const byCheckpointId = new Map(
+    furthest.map((candidate) => [candidate.checkpoint.checkpointId, candidate] as const),
+  );
+  const checkpointsWithSuccessors = new Set<string>();
+  for (const candidate of furthest) {
+    const previousId = candidate.checkpoint.previousCheckpointId;
+    const previous = previousId ? byCheckpointId.get(previousId) : undefined;
+    if (previous && canReplaceHistoryCompactCheckpoint(previous.checkpoint, candidate.checkpoint)) {
+      checkpointsWithSuccessors.add(previous.checkpoint.checkpointId);
+    }
+  }
+  const tips = furthest.filter(
+    (candidate) => !checkpointsWithSuccessors.has(candidate.checkpoint.checkpointId),
+  );
+  const pool = tips.length > 0 ? tips : furthest;
+  return pool.reduce<LedgerCheckpointCandidate | undefined>((selected, candidate) => {
+    if (!selected) return candidate;
+    if (candidate.event.ts !== selected.event.ts) {
+      return candidate.event.ts > selected.event.ts ? candidate : selected;
+    }
+    return candidate.event.id > selected.event.id ? candidate : selected;
+  }, undefined);
 }

--- a/packages/runtime/src/history-compact-ledger.ts
+++ b/packages/runtime/src/history-compact-ledger.ts
@@ -1,6 +1,7 @@
 import type { AgentRunStore } from '@maka/core';
 import {
   validateHistoryCompactCheckpointShape,
+  selectFurthestHistoryCompactCheckpoint,
   type HistoryCompactCheckpoint,
 } from './history-compact-checkpoint.js';
 
@@ -9,6 +10,7 @@ export async function loadLatestHistoryCompactCheckpointFromRunLedger(
   sessionId: string,
 ): Promise<HistoryCompactCheckpoint | undefined> {
   const runs = await runStore.listSessionRuns(sessionId);
+  let selected: HistoryCompactCheckpoint | undefined;
   for (let runIndex = runs.length - 1; runIndex >= 0; runIndex -= 1) {
     const run = runs[runIndex]!;
     const events = await runStore.readEvents(sessionId, run.runId);
@@ -16,8 +18,10 @@ export async function loadLatestHistoryCompactCheckpointFromRunLedger(
       const event = events[eventIndex]!;
       if (event.type !== 'history_compact_checkpoint_recorded') continue;
       const checkpoint = event.data?.checkpoint;
-      if (validateHistoryCompactCheckpointShape(checkpoint, sessionId)) return checkpoint;
+      if (validateHistoryCompactCheckpointShape(checkpoint, sessionId)) {
+        selected = selectFurthestHistoryCompactCheckpoint(selected, checkpoint);
+      }
     }
   }
-  return undefined;
+  return selected;
 }

--- a/packages/runtime/src/history-compact-ledger.ts
+++ b/packages/runtime/src/history-compact-ledger.ts
@@ -1,4 +1,4 @@
-import type { AgentRunStore } from '@maka/core';
+import type { AgentRunEvent, AgentRunStore } from '@maka/core';
 import {
   validateHistoryCompactCheckpointShape,
   selectFurthestHistoryCompactCheckpoint,
@@ -8,7 +8,7 @@ import {
 export async function loadLatestHistoryCompactCheckpointFromRunLedger(
   runStore: Pick<
     AgentRunStore,
-    'listSessionRuns' | 'readEvents' | 'readEventProjection'
+    'listSessionRuns' | 'readEvents' | 'readEventProjection' | 'repairEventProjection'
   >,
   sessionId: string,
 ): Promise<HistoryCompactCheckpoint | undefined> {
@@ -22,12 +22,12 @@ export async function loadLatestHistoryCompactCheckpointFromRunLedger(
       const checkpoint = projected?.data?.checkpoint;
       if (validateHistoryCompactCheckpointShape(checkpoint, sessionId)) return checkpoint;
     } catch {
-      // A damaged derived projection safely falls back to raw RuntimeEvent history.
+      // Recover the derived projection from the canonical ledger below.
     }
-    return undefined;
   }
   const runs = await runStore.listSessionRuns(sessionId);
   let selected: HistoryCompactCheckpoint | undefined;
+  let selectedEvent: AgentRunEvent | null = null;
   for (let runIndex = runs.length - 1; runIndex >= 0; runIndex -= 1) {
     const run = runs[runIndex]!;
     const events = await runStore.readEvents(sessionId, run.runId);
@@ -36,9 +36,20 @@ export async function loadLatestHistoryCompactCheckpointFromRunLedger(
       if (event.type !== 'history_compact_checkpoint_recorded') continue;
       const checkpoint = event.data?.checkpoint;
       if (validateHistoryCompactCheckpointShape(checkpoint, sessionId)) {
-        selected = selectFurthestHistoryCompactCheckpoint(selected, checkpoint);
+        const next = selectFurthestHistoryCompactCheckpoint(selected, checkpoint);
+        if (next === checkpoint) {
+          selected = checkpoint;
+          selectedEvent = event;
+        }
       }
     }
   }
+  await runStore.repairEventProjection?.(
+    sessionId,
+    'history_compact_checkpoint_recorded',
+    selectedEvent,
+  ).catch(() => {
+    // Recovery succeeded; a later cold read can retry this derived-state repair.
+  });
   return selected;
 }

--- a/packages/runtime/src/history-compact-ledger.ts
+++ b/packages/runtime/src/history-compact-ledger.ts
@@ -1,4 +1,4 @@
-import type { AgentRunEvent, AgentRunStore } from '@maka/core';
+import type { AgentRunStore } from '@maka/core';
 import {
   validateHistoryCompactCheckpointShape,
   selectFurthestHistoryCompactCheckpoint,
@@ -8,7 +8,7 @@ import {
 export async function loadLatestHistoryCompactCheckpointFromRunLedger(
   runStore: Pick<
     AgentRunStore,
-    'listSessionRuns' | 'readEvents' | 'readEventProjection' | 'writeEventProjection'
+    'listSessionRuns' | 'readEvents' | 'readEventProjection'
   >,
   sessionId: string,
 ): Promise<HistoryCompactCheckpoint | undefined> {
@@ -22,12 +22,12 @@ export async function loadLatestHistoryCompactCheckpointFromRunLedger(
       const checkpoint = projected?.data?.checkpoint;
       if (validateHistoryCompactCheckpointShape(checkpoint, sessionId)) return checkpoint;
     } catch {
-      // Missing or damaged projections are rebuilt from the canonical run ledger below.
+      // A damaged derived projection safely falls back to raw RuntimeEvent history.
     }
+    return undefined;
   }
   const runs = await runStore.listSessionRuns(sessionId);
   let selected: HistoryCompactCheckpoint | undefined;
-  let selectedEvent: AgentRunEvent | undefined;
   for (let runIndex = runs.length - 1; runIndex >= 0; runIndex -= 1) {
     const run = runs[runIndex]!;
     const events = await runStore.readEvents(sessionId, run.runId);
@@ -36,21 +36,8 @@ export async function loadLatestHistoryCompactCheckpointFromRunLedger(
       if (event.type !== 'history_compact_checkpoint_recorded') continue;
       const checkpoint = event.data?.checkpoint;
       if (validateHistoryCompactCheckpointShape(checkpoint, sessionId)) {
-        const next = selectFurthestHistoryCompactCheckpoint(selected, checkpoint);
-        if (next !== selected) selectedEvent = event;
-        selected = next;
+        selected = selectFurthestHistoryCompactCheckpoint(selected, checkpoint);
       }
-    }
-  }
-  if (runStore.writeEventProjection) {
-    try {
-      await runStore.writeEventProjection(
-        sessionId,
-        'history_compact_checkpoint_recorded',
-        selectedEvent ?? null,
-      );
-    } catch {
-      // The run ledger remains canonical; a later load can retry projection repair.
     }
   }
   return selected;

--- a/packages/runtime/src/history-compact-summarizer.ts
+++ b/packages/runtime/src/history-compact-summarizer.ts
@@ -82,8 +82,7 @@ export function buildLlmHistorySummarizer(options: BuildLlmHistorySummarizerOpti
       });
       return result.text;
     } catch {
-      // Fail-open: a summarizer failure returns undefined so the runtime
-      // keeps the deterministic draft summary instead of aborting the compact.
+      // Fail-open: the caller chooses the safe fallback for an initial or rolling summary failure.
       return undefined;
     }
   };

--- a/packages/runtime/src/history-compact-summarizer.ts
+++ b/packages/runtime/src/history-compact-summarizer.ts
@@ -1,7 +1,7 @@
 import type { ModelMessage } from 'ai';
 import { buildRuntimeEventModelReplayPlan } from './model-history.js';
 import { toolResultOutput } from './ai-sdk-tool-output.js';
-import type { HistoryCompactWriteInput } from './ai-sdk-backend.js';
+import type { HistoryCompactSummaryInput } from './ai-sdk-backend.js';
 
 export interface AiSdkGenerateTextOptions {
   model: unknown;
@@ -57,11 +57,21 @@ const SUMMARIZATION_SYSTEM_PROMPT = [
 ].join('\n');
 
 export function buildLlmHistorySummarizer(options: BuildLlmHistorySummarizerOptions) {
-  return async (input: HistoryCompactWriteInput): Promise<string | undefined> => {
-    if (input.source.foldedRuntimeEvents.length === 0) return undefined;
+  return async (input: HistoryCompactSummaryInput): Promise<string | undefined> => {
+    const newlyFoldedRuntimeEvents = input.newlyFoldedRuntimeEvents ?? input.source.foldedRuntimeEvents;
+    if (newlyFoldedRuntimeEvents.length === 0) return input.previousCheckpoint?.summary;
     try {
-      const plan = buildRuntimeEventModelReplayPlan(input.source.foldedRuntimeEvents);
+      const plan = buildRuntimeEventModelReplayPlan(newlyFoldedRuntimeEvents);
       const messages = replayPlanItemsToModelMessages(plan.items);
+      if (input.previousCheckpoint) {
+        messages.unshift({
+          role: 'user',
+          content: [{
+            type: 'text',
+            text: `Previous continuation summary:\n${input.previousCheckpoint.summary}\n\nUpdate it using the newer conversation events that follow.`,
+          }],
+        });
+      }
       const generateText = options.generateText ?? (await loadAiSdkGenerateText());
       const result = await generateText({
         model: options.resolveModel(),

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -330,20 +330,6 @@ export type {
   BuildLlmHistorySummarizerOptions,
 } from './history-compact-summarizer.js';
 export {
-  buildHistoryCompactCheckpoint,
-  historyCompactCheckpointToRuntimeEvent,
-  matchHistoryCompactCheckpointPrefix,
-  renderHistoryCompactCheckpoint,
-  validateHistoryCompactCheckpointShape,
-} from './history-compact-checkpoint.js';
-export type {
-  BuildHistoryCompactCheckpointInput,
-  HistoryCompactCheckpoint,
-  HistoryCompactCheckpointCoverage,
-  HistoryCompactCheckpointPrefixMatch,
-} from './history-compact-checkpoint.js';
-export { loadLatestHistoryCompactCheckpointFromRunLedger } from './history-compact-ledger.js';
-export {
   ACTIVE_ARCHIVED_TOOL_RESULT_PLACEHOLDER_KIND,
   ARCHIVED_TOOL_RESULT_PLACEHOLDER_KIND,
   ARCHIVED_TOOL_RESULT_REWRITE_VERSION,
@@ -367,8 +353,6 @@ export {
   searchRuntimeEventHistory,
   serializeToolResultForArchive,
   stableSynthesisBlockId,
-  shouldAppendContextCompactedNote,
-  shouldAppendContextCompactionFailedOpenNote,
   validateHistoryCompactBlockShape,
   validateSynthesisCacheBlockShape,
 } from './context-budget.js';

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -50,6 +50,10 @@ export type {
   HistoryCompactWriter,
   HistoryCompactWriteInput,
   HistoryCompactWriteResult,
+  HistoryCompactCheckpointLoader,
+  HistoryCompactCheckpointRecorder,
+  HistoryCompactSummarizer,
+  HistoryCompactSummaryInput,
   SynthesisCacheLoader,
   SynthesisCacheLoadInput,
   SynthesisCacheLoadResult,
@@ -326,6 +330,20 @@ export type {
   BuildLlmHistorySummarizerOptions,
 } from './history-compact-summarizer.js';
 export {
+  buildHistoryCompactCheckpoint,
+  historyCompactCheckpointToRuntimeEvent,
+  matchHistoryCompactCheckpointPrefix,
+  renderHistoryCompactCheckpoint,
+  validateHistoryCompactCheckpointShape,
+} from './history-compact-checkpoint.js';
+export type {
+  BuildHistoryCompactCheckpointInput,
+  HistoryCompactCheckpoint,
+  HistoryCompactCheckpointCoverage,
+  HistoryCompactCheckpointPrefixMatch,
+} from './history-compact-checkpoint.js';
+export { loadLatestHistoryCompactCheckpointFromRunLedger } from './history-compact-ledger.js';
+export {
   ACTIVE_ARCHIVED_TOOL_RESULT_PLACEHOLDER_KIND,
   ARCHIVED_TOOL_RESULT_PLACEHOLDER_KIND,
   ARCHIVED_TOOL_RESULT_REWRITE_VERSION,
@@ -349,6 +367,8 @@ export {
   searchRuntimeEventHistory,
   serializeToolResultForArchive,
   stableSynthesisBlockId,
+  shouldAppendContextCompactedNote,
+  shouldAppendContextCompactionFailedOpenNote,
   validateHistoryCompactBlockShape,
   validateSynthesisCacheBlockShape,
 } from './context-budget.js';

--- a/packages/runtime/src/runtime-kernel.ts
+++ b/packages/runtime/src/runtime-kernel.ts
@@ -477,11 +477,14 @@ export class RuntimeKernel implements RuntimeKernelLike {
     return guardedLoad;
   }
 
-  private cacheHistoryCompactCheckpoint(sessionId: string, checkpoint: HistoryCompactCheckpoint): void {
-    this.historyCompactCheckpoints.set(
-      sessionId,
-      selectFurthestHistoryCompactCheckpoint(this.historyCompactCheckpoints.get(sessionId), checkpoint),
+  private cacheHistoryCompactCheckpoint(sessionId: string, checkpoint: HistoryCompactCheckpoint): boolean {
+    const selected = selectFurthestHistoryCompactCheckpoint(
+      this.historyCompactCheckpoints.get(sessionId),
+      checkpoint,
     );
+    if (selected !== checkpoint) return false;
+    this.historyCompactCheckpoints.set(sessionId, checkpoint);
+    return true;
   }
 
   private async ensureActive(
@@ -508,7 +511,7 @@ export class RuntimeKernel implements RuntimeKernelLike {
         loadHistoryCompactCheckpoint: () => this.loadHistoryCompactCheckpoint(sessionId),
       } : {}),
       recordHistoryCompactCheckpoint: (checkpoint, turnId) => {
-        this.cacheHistoryCompactCheckpoint(sessionId, checkpoint);
+        if (!this.cacheHistoryCompactCheckpoint(sessionId, checkpoint)) return;
         const active = this.active.get(sessionId);
         const runId = active?.turnToRunId.get(turnId);
         const run = runId ? active?.activeRuns.get(runId) : undefined;
@@ -569,7 +572,7 @@ export class RuntimeKernel implements RuntimeKernelLike {
         loadHistoryCompactCheckpoint: () => this.loadHistoryCompactCheckpoint(sessionId),
       } : {}),
       recordHistoryCompactCheckpoint: (checkpoint, turnId) => {
-        this.cacheHistoryCompactCheckpoint(sessionId, checkpoint);
+        if (!this.cacheHistoryCompactCheckpoint(sessionId, checkpoint)) return;
         const active = this.childActive.get(activeKey);
         const runId = active?.turnToRunId.get(turnId);
         const run = runId ? active?.activeRuns.get(runId) : undefined;

--- a/packages/runtime/src/runtime-kernel.ts
+++ b/packages/runtime/src/runtime-kernel.ts
@@ -495,7 +495,10 @@ export class RuntimeKernel implements RuntimeKernelLike {
     checkpoint: HistoryCompactCheckpoint,
     run: AgentRun | undefined,
   ): Promise<void> {
-    if (!run || !this.acceptHistoryCompactCheckpoint(sessionId, checkpoint)) return Promise.resolve();
+    if (!run) return Promise.reject(new Error('No active AgentRun for history compact checkpoint'));
+    if (!this.acceptHistoryCompactCheckpoint(sessionId, checkpoint)) {
+      return Promise.reject(new Error('History compact checkpoint was superseded before persistence'));
+    }
     const previous = this.historyCompactCheckpointWrites.get(sessionId) ?? Promise.resolve();
     let tracked: Promise<void>;
     tracked = previous
@@ -544,13 +547,13 @@ export class RuntimeKernel implements RuntimeKernelLike {
       },
       ...(this.deps.runStore ? {
         loadHistoryCompactCheckpoint: () => this.loadHistoryCompactCheckpoint(sessionId),
+        recordHistoryCompactCheckpoint: (checkpoint: HistoryCompactCheckpoint, turnId: string) => {
+          const active = this.active.get(sessionId);
+          const runId = active?.turnToRunId.get(turnId);
+          const run = runId ? active?.activeRuns.get(runId) : undefined;
+          return this.recordHistoryCompactCheckpoint(sessionId, checkpoint, run);
+        },
       } : {}),
-      recordHistoryCompactCheckpoint: (checkpoint, turnId) => {
-        const active = this.active.get(sessionId);
-        const runId = active?.turnToRunId.get(turnId);
-        const run = runId ? active?.activeRuns.get(runId) : undefined;
-        return this.recordHistoryCompactCheckpoint(sessionId, checkpoint, run);
-      },
       recordActiveFullCompactBlock: (block) => {
         const active = this.active.get(sessionId);
         const runId = active?.turnToRunId.get(block.turnId);
@@ -604,13 +607,13 @@ export class RuntimeKernel implements RuntimeKernelLike {
       },
       ...(this.deps.runStore ? {
         loadHistoryCompactCheckpoint: () => this.loadHistoryCompactCheckpoint(sessionId),
+        recordHistoryCompactCheckpoint: (checkpoint: HistoryCompactCheckpoint, turnId: string) => {
+          const active = this.childActive.get(activeKey);
+          const runId = active?.turnToRunId.get(turnId);
+          const run = runId ? active?.activeRuns.get(runId) : undefined;
+          return this.recordHistoryCompactCheckpoint(sessionId, checkpoint, run);
+        },
       } : {}),
-      recordHistoryCompactCheckpoint: (checkpoint, turnId) => {
-        const active = this.childActive.get(activeKey);
-        const runId = active?.turnToRunId.get(turnId);
-        const run = runId ? active?.activeRuns.get(runId) : undefined;
-        return this.recordHistoryCompactCheckpoint(sessionId, checkpoint, run);
-      },
       recordActiveFullCompactBlock: (block) => {
         const active = this.childActive.get(activeKey);
         const runId = active?.turnToRunId.get(block.turnId);

--- a/packages/runtime/src/runtime-kernel.ts
+++ b/packages/runtime/src/runtime-kernel.ts
@@ -30,6 +30,7 @@ import {
 } from './agent-catalog.js';
 import { loadLatestHistoryCompactCheckpointFromRunLedger } from './history-compact-ledger.js';
 import type { HistoryCompactCheckpoint } from './history-compact-checkpoint.js';
+import { shouldAppendContextCompactionFailedOpenNote } from './context-budget.js';
 
 export interface RuntimeKernelLike {
   startTurn(sessionId: string, input: UserMessageInput): AsyncIterable<SessionEvent>;
@@ -185,6 +186,16 @@ export class RuntimeKernel implements RuntimeKernelLike {
       if (run.isStopped()) return;
       await run.recordStoredSessionEvent(tokenUsageEvent);
       if (run.isStopped()) return;
+      if (shouldAppendContextCompactionFailedOpenNote(result.contextBudget)) {
+        const note: SystemNoteMessage = {
+          type: 'system_note',
+          id: this.deps.newId(),
+          turnId: run.turnId,
+          ts: this.deps.now(),
+          kind: 'context_compaction_failed_open',
+        };
+        await this.deps.store.appendMessage(sessionId, note).catch(() => {});
+      }
       yield tokenUsageEvent;
       if (run.isStopped()) return;
       await run.acceptMappedEvent(

--- a/packages/runtime/src/runtime-kernel.ts
+++ b/packages/runtime/src/runtime-kernel.ts
@@ -73,7 +73,6 @@ export class RuntimeKernel implements RuntimeKernelLike {
   private readonly childActive = new Map<string, ActiveSession>();
   private readonly historyCompactCheckpoints = new Map<string, HistoryCompactCheckpoint | undefined>();
   private readonly historyCompactCheckpointLoads = new Map<string, Promise<HistoryCompactCheckpoint | undefined>>();
-  private readonly historyCompactCheckpointWriteFrontiers = new Map<string, HistoryCompactCheckpoint>();
   private readonly historyCompactCheckpointWrites = new Map<string, Promise<void>>();
 
   constructor(private readonly deps: RuntimeKernelDeps) {
@@ -479,44 +478,25 @@ export class RuntimeKernel implements RuntimeKernelLike {
     return guardedLoad;
   }
 
-  private acceptHistoryCompactCheckpoint(sessionId: string, checkpoint: HistoryCompactCheckpoint): boolean {
-    const selected = selectFurthestHistoryCompactCheckpoint(
-      this.historyCompactCheckpointWriteFrontiers.get(sessionId)
-        ?? this.historyCompactCheckpoints.get(sessionId),
-      checkpoint,
-    );
-    if (selected !== checkpoint) return false;
-    this.historyCompactCheckpointWriteFrontiers.set(sessionId, checkpoint);
-    return true;
-  }
-
   private recordHistoryCompactCheckpoint(
     sessionId: string,
     checkpoint: HistoryCompactCheckpoint,
     run: AgentRun | undefined,
   ): Promise<void> {
     if (!run) return Promise.reject(new Error('No active AgentRun for history compact checkpoint'));
-    if (!this.acceptHistoryCompactCheckpoint(sessionId, checkpoint)) {
-      return Promise.reject(new Error('History compact checkpoint was superseded before persistence'));
-    }
     const previous = this.historyCompactCheckpointWrites.get(sessionId) ?? Promise.resolve();
     let tracked: Promise<void>;
     tracked = previous
-      .then(
-        () => run.recordHistoryCompactCheckpoint(checkpoint),
-        () => run.recordHistoryCompactCheckpoint(checkpoint),
-      )
-      .then(() => {
-        const selected = selectFurthestHistoryCompactCheckpoint(
-          this.historyCompactCheckpoints.get(sessionId),
-          checkpoint,
-        );
-        if (selected === checkpoint) this.historyCompactCheckpoints.set(sessionId, checkpoint);
+      .catch(() => {})
+      .then(async () => {
+        const durableCheckpoint = await this.loadHistoryCompactCheckpoint(sessionId);
+        if (selectFurthestHistoryCompactCheckpoint(durableCheckpoint, checkpoint) !== checkpoint) {
+          throw new Error('History compact checkpoint was superseded before persistence');
+        }
+        await run.recordHistoryCompactCheckpoint(checkpoint);
+        this.historyCompactCheckpoints.set(sessionId, checkpoint);
       })
       .finally(() => {
-        if (this.historyCompactCheckpointWriteFrontiers.get(sessionId) === checkpoint) {
-          this.historyCompactCheckpointWriteFrontiers.delete(sessionId);
-        }
         if (this.historyCompactCheckpointWrites.get(sessionId) === tracked) {
           this.historyCompactCheckpointWrites.delete(sessionId);
         }

--- a/packages/runtime/src/runtime-kernel.ts
+++ b/packages/runtime/src/runtime-kernel.ts
@@ -73,6 +73,7 @@ export class RuntimeKernel implements RuntimeKernelLike {
   private readonly childActive = new Map<string, ActiveSession>();
   private readonly historyCompactCheckpoints = new Map<string, HistoryCompactCheckpoint | undefined>();
   private readonly historyCompactCheckpointLoads = new Map<string, Promise<HistoryCompactCheckpoint | undefined>>();
+  private readonly historyCompactCheckpointWriteFrontiers = new Map<string, HistoryCompactCheckpoint>();
   private readonly historyCompactCheckpointWrites = new Map<string, Promise<void>>();
 
   constructor(private readonly deps: RuntimeKernelDeps) {
@@ -478,13 +479,14 @@ export class RuntimeKernel implements RuntimeKernelLike {
     return guardedLoad;
   }
 
-  private cacheHistoryCompactCheckpoint(sessionId: string, checkpoint: HistoryCompactCheckpoint): boolean {
+  private acceptHistoryCompactCheckpoint(sessionId: string, checkpoint: HistoryCompactCheckpoint): boolean {
     const selected = selectFurthestHistoryCompactCheckpoint(
-      this.historyCompactCheckpoints.get(sessionId),
+      this.historyCompactCheckpointWriteFrontiers.get(sessionId)
+        ?? this.historyCompactCheckpoints.get(sessionId),
       checkpoint,
     );
     if (selected !== checkpoint) return false;
-    this.historyCompactCheckpoints.set(sessionId, checkpoint);
+    this.historyCompactCheckpointWriteFrontiers.set(sessionId, checkpoint);
     return true;
   }
 
@@ -493,12 +495,25 @@ export class RuntimeKernel implements RuntimeKernelLike {
     checkpoint: HistoryCompactCheckpoint,
     run: AgentRun | undefined,
   ): Promise<void> {
-    if (!this.cacheHistoryCompactCheckpoint(sessionId, checkpoint) || !run) return Promise.resolve();
+    if (!run || !this.acceptHistoryCompactCheckpoint(sessionId, checkpoint)) return Promise.resolve();
     const previous = this.historyCompactCheckpointWrites.get(sessionId) ?? Promise.resolve();
     let tracked: Promise<void>;
     tracked = previous
-      .then(() => run.recordHistoryCompactCheckpoint(checkpoint))
+      .then(
+        () => run.recordHistoryCompactCheckpoint(checkpoint),
+        () => run.recordHistoryCompactCheckpoint(checkpoint),
+      )
+      .then(() => {
+        const selected = selectFurthestHistoryCompactCheckpoint(
+          this.historyCompactCheckpoints.get(sessionId),
+          checkpoint,
+        );
+        if (selected === checkpoint) this.historyCompactCheckpoints.set(sessionId, checkpoint);
+      })
       .finally(() => {
+        if (this.historyCompactCheckpointWriteFrontiers.get(sessionId) === checkpoint) {
+          this.historyCompactCheckpointWriteFrontiers.delete(sessionId);
+        }
         if (this.historyCompactCheckpointWrites.get(sessionId) === tracked) {
           this.historyCompactCheckpointWrites.delete(sessionId);
         }

--- a/packages/runtime/src/runtime-kernel.ts
+++ b/packages/runtime/src/runtime-kernel.ts
@@ -29,7 +29,10 @@ import {
   requireBuiltinAgentDefinition,
 } from './agent-catalog.js';
 import { loadLatestHistoryCompactCheckpointFromRunLedger } from './history-compact-ledger.js';
-import type { HistoryCompactCheckpoint } from './history-compact-checkpoint.js';
+import {
+  selectFurthestHistoryCompactCheckpoint,
+  type HistoryCompactCheckpoint,
+} from './history-compact-checkpoint.js';
 import { shouldAppendContextCompactionFailedOpenNote } from './context-budget.js';
 
 export interface RuntimeKernelLike {
@@ -475,7 +478,10 @@ export class RuntimeKernel implements RuntimeKernelLike {
   }
 
   private cacheHistoryCompactCheckpoint(sessionId: string, checkpoint: HistoryCompactCheckpoint): void {
-    this.historyCompactCheckpoints.set(sessionId, checkpoint);
+    this.historyCompactCheckpoints.set(
+      sessionId,
+      selectFurthestHistoryCompactCheckpoint(this.historyCompactCheckpoints.get(sessionId), checkpoint),
+    );
   }
 
   private async ensureActive(

--- a/packages/runtime/src/runtime-kernel.ts
+++ b/packages/runtime/src/runtime-kernel.ts
@@ -30,7 +30,7 @@ import {
 } from './agent-catalog.js';
 import { loadLatestHistoryCompactCheckpointFromRunLedger } from './history-compact-ledger.js';
 import {
-  selectFurthestHistoryCompactCheckpoint,
+  canReplaceHistoryCompactCheckpoint,
   type HistoryCompactCheckpoint,
 } from './history-compact-checkpoint.js';
 import { shouldAppendContextCompactionFailedOpenNote } from './context-budget.js';
@@ -490,7 +490,7 @@ export class RuntimeKernel implements RuntimeKernelLike {
       .catch(() => {})
       .then(async () => {
         const durableCheckpoint = await this.loadHistoryCompactCheckpoint(sessionId);
-        if (selectFurthestHistoryCompactCheckpoint(durableCheckpoint, checkpoint) !== checkpoint) {
+        if (!canReplaceHistoryCompactCheckpoint(durableCheckpoint, checkpoint)) {
           throw new Error('History compact checkpoint was superseded before persistence');
         }
         await run.recordHistoryCompactCheckpoint(checkpoint);

--- a/packages/runtime/src/runtime-kernel.ts
+++ b/packages/runtime/src/runtime-kernel.ts
@@ -29,6 +29,7 @@ import {
   requireBuiltinAgentDefinition,
 } from './agent-catalog.js';
 import { loadLatestHistoryCompactCheckpointFromRunLedger } from './history-compact-ledger.js';
+import type { HistoryCompactCheckpoint } from './history-compact-checkpoint.js';
 
 export interface RuntimeKernelLike {
   startTurn(sessionId: string, input: UserMessageInput): AsyncIterable<SessionEvent>;
@@ -66,6 +67,8 @@ interface ActiveSession extends AgentRunActiveSession {
 export class RuntimeKernel implements RuntimeKernelLike {
   private readonly active = new Map<string, ActiveSession>();
   private readonly childActive = new Map<string, ActiveSession>();
+  private readonly historyCompactCheckpoints = new Map<string, HistoryCompactCheckpoint | undefined>();
+  private readonly historyCompactCheckpointLoads = new Map<string, Promise<HistoryCompactCheckpoint | undefined>>();
 
   constructor(private readonly deps: RuntimeKernelDeps) {
     if (deps.runStore && !deps.runtimeEventStore) {
@@ -406,6 +409,8 @@ export class RuntimeKernel implements RuntimeKernelLike {
   async disposeBackend(sessionId: string): Promise<void> {
     const activeSessions = this.activeSessionsFor(sessionId);
     this.active.delete(sessionId);
+    this.historyCompactCheckpoints.delete(sessionId);
+    this.historyCompactCheckpointLoads.delete(sessionId);
     for (const [key, active] of this.childActive.entries()) {
       if (active.sessionId === sessionId) this.childActive.delete(key);
     }
@@ -426,6 +431,40 @@ export class RuntimeKernel implements RuntimeKernelLike {
       if (child.sessionId === sessionId) sessions.push(child);
     }
     return sessions;
+  }
+
+  private loadHistoryCompactCheckpoint(sessionId: string): Promise<HistoryCompactCheckpoint | undefined> {
+    if (this.historyCompactCheckpoints.has(sessionId)) {
+      return Promise.resolve(this.historyCompactCheckpoints.get(sessionId));
+    }
+    const existing = this.historyCompactCheckpointLoads.get(sessionId);
+    if (existing) return existing;
+    if (!this.deps.runStore) return Promise.resolve(undefined);
+
+    let guardedLoad: Promise<HistoryCompactCheckpoint | undefined>;
+    guardedLoad = loadLatestHistoryCompactCheckpointFromRunLedger(this.deps.runStore, sessionId)
+      .then((checkpoint) => {
+        if (
+          this.historyCompactCheckpointLoads.get(sessionId) === guardedLoad
+          && !this.historyCompactCheckpoints.has(sessionId)
+        ) {
+          this.historyCompactCheckpoints.set(sessionId, checkpoint);
+        }
+        return this.historyCompactCheckpoints.has(sessionId)
+          ? this.historyCompactCheckpoints.get(sessionId)
+          : checkpoint;
+      })
+      .finally(() => {
+        if (this.historyCompactCheckpointLoads.get(sessionId) === guardedLoad) {
+          this.historyCompactCheckpointLoads.delete(sessionId);
+        }
+      });
+    this.historyCompactCheckpointLoads.set(sessionId, guardedLoad);
+    return guardedLoad;
+  }
+
+  private cacheHistoryCompactCheckpoint(sessionId: string, checkpoint: HistoryCompactCheckpoint): void {
+    this.historyCompactCheckpoints.set(sessionId, checkpoint);
   }
 
   private async ensureActive(
@@ -449,9 +488,10 @@ export class RuntimeKernel implements RuntimeKernelLike {
         run?.recordRunTrace(event);
       },
       ...(this.deps.runStore ? {
-        loadHistoryCompactCheckpoint: () => loadLatestHistoryCompactCheckpointFromRunLedger(this.deps.runStore!, sessionId),
+        loadHistoryCompactCheckpoint: () => this.loadHistoryCompactCheckpoint(sessionId),
       } : {}),
       recordHistoryCompactCheckpoint: (checkpoint, turnId) => {
+        this.cacheHistoryCompactCheckpoint(sessionId, checkpoint);
         const active = this.active.get(sessionId);
         const runId = active?.turnToRunId.get(turnId);
         const run = runId ? active?.activeRuns.get(runId) : undefined;
@@ -509,9 +549,10 @@ export class RuntimeKernel implements RuntimeKernelLike {
         run?.recordRunTrace(event);
       },
       ...(this.deps.runStore ? {
-        loadHistoryCompactCheckpoint: () => loadLatestHistoryCompactCheckpointFromRunLedger(this.deps.runStore!, sessionId),
+        loadHistoryCompactCheckpoint: () => this.loadHistoryCompactCheckpoint(sessionId),
       } : {}),
       recordHistoryCompactCheckpoint: (checkpoint, turnId) => {
+        this.cacheHistoryCompactCheckpoint(sessionId, checkpoint);
         const active = this.childActive.get(activeKey);
         const runId = active?.turnToRunId.get(turnId);
         const run = runId ? active?.activeRuns.get(runId) : undefined;

--- a/packages/runtime/src/runtime-kernel.ts
+++ b/packages/runtime/src/runtime-kernel.ts
@@ -28,6 +28,7 @@ import {
   buildToolsForAgentDefinition,
   requireBuiltinAgentDefinition,
 } from './agent-catalog.js';
+import { loadLatestHistoryCompactCheckpointFromRunLedger } from './history-compact-ledger.js';
 
 export interface RuntimeKernelLike {
   startTurn(sessionId: string, input: UserMessageInput): AsyncIterable<SessionEvent>;
@@ -447,6 +448,15 @@ export class RuntimeKernel implements RuntimeKernelLike {
         const run = runId ? active?.activeRuns.get(runId) : undefined;
         run?.recordRunTrace(event);
       },
+      ...(this.deps.runStore ? {
+        loadHistoryCompactCheckpoint: () => loadLatestHistoryCompactCheckpointFromRunLedger(this.deps.runStore!, sessionId),
+      } : {}),
+      recordHistoryCompactCheckpoint: (checkpoint, turnId) => {
+        const active = this.active.get(sessionId);
+        const runId = active?.turnToRunId.get(turnId);
+        const run = runId ? active?.activeRuns.get(runId) : undefined;
+        run?.recordHistoryCompactCheckpoint(checkpoint);
+      },
       recordActiveFullCompactBlock: (block) => {
         const active = this.active.get(sessionId);
         const runId = active?.turnToRunId.get(block.turnId);
@@ -497,6 +507,15 @@ export class RuntimeKernel implements RuntimeKernelLike {
         const runId = active?.turnToRunId.get(event.turnId);
         const run = runId ? active?.activeRuns.get(runId) : undefined;
         run?.recordRunTrace(event);
+      },
+      ...(this.deps.runStore ? {
+        loadHistoryCompactCheckpoint: () => loadLatestHistoryCompactCheckpointFromRunLedger(this.deps.runStore!, sessionId),
+      } : {}),
+      recordHistoryCompactCheckpoint: (checkpoint, turnId) => {
+        const active = this.childActive.get(activeKey);
+        const runId = active?.turnToRunId.get(turnId);
+        const run = runId ? active?.activeRuns.get(runId) : undefined;
+        run?.recordHistoryCompactCheckpoint(checkpoint);
       },
       recordActiveFullCompactBlock: (block) => {
         const active = this.childActive.get(activeKey);

--- a/packages/runtime/src/runtime-kernel.ts
+++ b/packages/runtime/src/runtime-kernel.ts
@@ -73,6 +73,7 @@ export class RuntimeKernel implements RuntimeKernelLike {
   private readonly childActive = new Map<string, ActiveSession>();
   private readonly historyCompactCheckpoints = new Map<string, HistoryCompactCheckpoint | undefined>();
   private readonly historyCompactCheckpointLoads = new Map<string, Promise<HistoryCompactCheckpoint | undefined>>();
+  private readonly historyCompactCheckpointWrites = new Map<string, Promise<void>>();
 
   constructor(private readonly deps: RuntimeKernelDeps) {
     if (deps.runStore && !deps.runtimeEventStore) {
@@ -487,6 +488,25 @@ export class RuntimeKernel implements RuntimeKernelLike {
     return true;
   }
 
+  private recordHistoryCompactCheckpoint(
+    sessionId: string,
+    checkpoint: HistoryCompactCheckpoint,
+    run: AgentRun | undefined,
+  ): Promise<void> {
+    if (!this.cacheHistoryCompactCheckpoint(sessionId, checkpoint) || !run) return Promise.resolve();
+    const previous = this.historyCompactCheckpointWrites.get(sessionId) ?? Promise.resolve();
+    let tracked: Promise<void>;
+    tracked = previous
+      .then(() => run.recordHistoryCompactCheckpoint(checkpoint))
+      .finally(() => {
+        if (this.historyCompactCheckpointWrites.get(sessionId) === tracked) {
+          this.historyCompactCheckpointWrites.delete(sessionId);
+        }
+      });
+    this.historyCompactCheckpointWrites.set(sessionId, tracked);
+    return tracked;
+  }
+
   private async ensureActive(
     sessionId: string,
     header: SessionHeader,
@@ -511,11 +531,10 @@ export class RuntimeKernel implements RuntimeKernelLike {
         loadHistoryCompactCheckpoint: () => this.loadHistoryCompactCheckpoint(sessionId),
       } : {}),
       recordHistoryCompactCheckpoint: (checkpoint, turnId) => {
-        if (!this.cacheHistoryCompactCheckpoint(sessionId, checkpoint)) return;
         const active = this.active.get(sessionId);
         const runId = active?.turnToRunId.get(turnId);
         const run = runId ? active?.activeRuns.get(runId) : undefined;
-        run?.recordHistoryCompactCheckpoint(checkpoint);
+        return this.recordHistoryCompactCheckpoint(sessionId, checkpoint, run);
       },
       recordActiveFullCompactBlock: (block) => {
         const active = this.active.get(sessionId);
@@ -572,11 +591,10 @@ export class RuntimeKernel implements RuntimeKernelLike {
         loadHistoryCompactCheckpoint: () => this.loadHistoryCompactCheckpoint(sessionId),
       } : {}),
       recordHistoryCompactCheckpoint: (checkpoint, turnId) => {
-        if (!this.cacheHistoryCompactCheckpoint(sessionId, checkpoint)) return;
         const active = this.childActive.get(activeKey);
         const runId = active?.turnToRunId.get(turnId);
         const run = runId ? active?.activeRuns.get(runId) : undefined;
-        run?.recordHistoryCompactCheckpoint(checkpoint);
+        return this.recordHistoryCompactCheckpoint(sessionId, checkpoint, run);
       },
       recordActiveFullCompactBlock: (block) => {
         const active = this.childActive.get(activeKey);

--- a/packages/runtime/src/session-manager.ts
+++ b/packages/runtime/src/session-manager.ts
@@ -208,7 +208,7 @@ export interface BackendFactoryContext {
   tools?: readonly MakaTool[];
   recordRunTrace?: RunTraceRecorder;
   loadHistoryCompactCheckpoint?: () => Promise<HistoryCompactCheckpoint | undefined>;
-  recordHistoryCompactCheckpoint?: (checkpoint: HistoryCompactCheckpoint, turnId: string) => void;
+  recordHistoryCompactCheckpoint?: (checkpoint: HistoryCompactCheckpoint, turnId: string) => Promise<void>;
   recordActiveFullCompactBlock?: (block: ActiveFullCompactBlock) => void;
   recordSemanticCompactBlock?: (block: SemanticCompactBlock) => void;
   shellRunContextSummary?: () => Promise<string | undefined>;

--- a/packages/runtime/src/session-manager.ts
+++ b/packages/runtime/src/session-manager.ts
@@ -68,6 +68,7 @@ import type { RunTraceRecorder } from './run-trace.js';
 import type { ShellRunProcessManager } from './shell-run-manager.js';
 import type { ActiveFullCompactBlock } from './active-full-compact.js';
 import type { SemanticCompactBlock } from './semantic-compact.js';
+import type { HistoryCompactCheckpoint } from './history-compact-checkpoint.js';
 import type { AgentRunLineage } from './agent-run.js';
 import { classifyAgentRunRecovery, type AgentRunRecoveryDecision } from './agent-run-recovery.js';
 import type {
@@ -206,6 +207,8 @@ export interface BackendFactoryContext {
   systemPrompt?: string;
   tools?: readonly MakaTool[];
   recordRunTrace?: RunTraceRecorder;
+  loadHistoryCompactCheckpoint?: () => Promise<HistoryCompactCheckpoint | undefined>;
+  recordHistoryCompactCheckpoint?: (checkpoint: HistoryCompactCheckpoint, turnId: string) => void;
   recordActiveFullCompactBlock?: (block: ActiveFullCompactBlock) => void;
   recordSemanticCompactBlock?: (block: SemanticCompactBlock) => void;
   shellRunContextSummary?: () => Promise<string | undefined>;

--- a/packages/storage/src/__tests__/agent-run-store.test.ts
+++ b/packages/storage/src/__tests__/agent-run-store.test.ts
@@ -229,6 +229,65 @@ describe('AgentRunStore', () => {
     });
   });
 
+  it('replaces the same parseable but semantically invalid projection during repair', async () => {
+    await withStore(async (store, root) => {
+      const projectionStore = store as typeof store & {
+        readEventProjection(
+          sessionId: string,
+          type: AgentRunEvent['type'],
+        ): Promise<AgentRunEvent | null | undefined>;
+        repairEventProjection(
+          sessionId: string,
+          type: AgentRunEvent['type'],
+          event: AgentRunEvent | null,
+          options?: { replaceEventId?: string },
+        ): Promise<void>;
+      };
+      await store.createRun(makeHeader());
+      const invalidProjection = makeEvent({
+        type: 'history_compact_checkpoint_recorded',
+        id: 'invalid-projection-event',
+        data: { checkpoint: { coverage: { eventCount: 999 } } },
+      });
+      const canonicalEvent = makeEvent({
+        type: 'history_compact_checkpoint_recorded',
+        id: 'canonical-projection-event',
+        data: {
+          checkpoint: {
+            kind: 'maka.history_compact_checkpoint',
+            version: 2,
+            checkpointId: 'hcheckpoint-canonical',
+            sessionId: 'session-1',
+            coverage: { eventCount: 1 },
+          },
+        },
+      });
+      await writeFile(
+        join(
+          root,
+          'sessions',
+          'session-1',
+          'projections',
+          'history_compact_checkpoint_recorded.json',
+        ),
+        JSON.stringify({ version: 1, event: invalidProjection }) + '\n',
+      );
+
+      await projectionStore.repairEventProjection(
+        'session-1',
+        'history_compact_checkpoint_recorded',
+        canonicalEvent,
+        { replaceEventId: invalidProjection.id },
+      );
+
+      const projected = await projectionStore.readEventProjection(
+        'session-1',
+        'history_compact_checkpoint_recorded',
+      );
+      assert.equal(projected?.id, canonicalEvent.id);
+    });
+  });
+
   it('does not retain a checkpoint projection when the canonical ledger append fails', async () => {
     await withStore(async (store, root) => {
       const projectionStore = store as typeof store & {

--- a/packages/storage/src/__tests__/agent-run-store.test.ts
+++ b/packages/storage/src/__tests__/agent-run-store.test.ts
@@ -129,6 +129,45 @@ describe('AgentRunStore', () => {
     });
   });
 
+  it('does not retain a checkpoint projection when the canonical ledger append fails', async () => {
+    await withStore(async (store, root) => {
+      const projectionStore = store as typeof store & {
+        readEventProjection(
+          sessionId: string,
+          type: AgentRunEvent['type'],
+        ): Promise<AgentRunEvent | null | undefined>;
+      };
+      await store.createRun(makeHeader());
+      const checkpointEvent = (checkpointId: string, eventCount: number): AgentRunEvent => makeEvent({
+        type: 'history_compact_checkpoint_recorded',
+        data: {
+          checkpoint: {
+            kind: 'maka.history_compact_checkpoint',
+            version: 2,
+            checkpointId,
+            sessionId: 'session-1',
+            coverage: { eventCount },
+          },
+        },
+      });
+      await store.appendEvent('session-1', 'run-1', checkpointEvent('hcheckpoint-previous', 1));
+      const eventsPath = join(root, 'sessions', 'session-1', 'runs', 'run-1', 'events.jsonl');
+      await rm(eventsPath);
+      await mkdir(eventsPath);
+
+      await assert.rejects(() => store.appendEvent(
+        'session-1',
+        'run-1',
+        checkpointEvent('hcheckpoint-orphan', 2),
+      ));
+
+      assert.equal(
+        await projectionStore.readEventProjection('session-1', 'history_compact_checkpoint_recorded'),
+        undefined,
+      );
+    });
+  });
+
   it('recovers corrupt event lines without hiding later events', async () => {
     await withStore(async (store, root) => {
       await store.createRun(makeHeader());

--- a/packages/storage/src/__tests__/agent-run-store.test.ts
+++ b/packages/storage/src/__tests__/agent-run-store.test.ts
@@ -129,6 +129,50 @@ describe('AgentRunStore', () => {
     });
   });
 
+  it('initializes an empty checkpoint projection for a new session', async () => {
+    await withStore(async (store) => {
+      const projectionStore = store as typeof store & {
+        readEventProjection(
+          sessionId: string,
+          type: AgentRunEvent['type'],
+        ): Promise<AgentRunEvent | null | undefined>;
+      };
+
+      await store.createRun(makeHeader());
+
+      assert.equal(
+        await projectionStore.readEventProjection('session-1', 'history_compact_checkpoint_recorded'),
+        null,
+      );
+    });
+  });
+
+  it('preserves a missing checkpoint projection when prior runs require recovery', async () => {
+    await withStore(async (store, root) => {
+      const projectionStore = store as typeof store & {
+        readEventProjection(
+          sessionId: string,
+          type: AgentRunEvent['type'],
+        ): Promise<AgentRunEvent | null | undefined>;
+      };
+      await store.createRun(makeHeader({ runId: 'run-before-crash' }));
+      await rm(join(
+        root,
+        'sessions',
+        'session-1',
+        'projections',
+        'history_compact_checkpoint_recorded.json',
+      ));
+
+      await store.createRun(makeHeader({ runId: 'run-after-restart' }));
+
+      assert.equal(
+        await projectionStore.readEventProjection('session-1', 'history_compact_checkpoint_recorded'),
+        undefined,
+      );
+    });
+  });
+
   it('does not retain a checkpoint projection when the canonical ledger append fails', async () => {
     await withStore(async (store, root) => {
       const projectionStore = store as typeof store & {

--- a/packages/storage/src/__tests__/agent-run-store.test.ts
+++ b/packages/storage/src/__tests__/agent-run-store.test.ts
@@ -173,6 +173,62 @@ describe('AgentRunStore', () => {
     });
   });
 
+  it('does not let a stale repair overwrite a further checkpoint projection', async () => {
+    await withStore(async (store, root) => {
+      const projectionStore = store as typeof store & {
+        readEventProjection(
+          sessionId: string,
+          type: AgentRunEvent['type'],
+        ): Promise<AgentRunEvent | null | undefined>;
+        repairEventProjection(
+          sessionId: string,
+          type: AgentRunEvent['type'],
+          event: AgentRunEvent | null,
+        ): Promise<void>;
+      };
+      const checkpointEvent = (runId: string, eventCount: number): AgentRunEvent => makeEvent({
+        type: 'history_compact_checkpoint_recorded',
+        id: `checkpoint-${runId}`,
+        runId,
+        turnId: `turn-${runId}`,
+        data: {
+          checkpoint: {
+            kind: 'maka.history_compact_checkpoint',
+            version: 2,
+            checkpointId: `hcheckpoint-${runId}`,
+            sessionId: 'session-1',
+            coverage: { eventCount },
+          },
+        },
+      });
+      const stale = checkpointEvent('run-stale-repair', 1);
+      const further = checkpointEvent('run-further-write', 2);
+      await store.createRun(makeHeader({ runId: stale.runId }));
+      await store.createRun(makeHeader({ runId: further.runId }));
+      await store.appendEvent('session-1', stale.runId, stale);
+      await rm(join(
+        root,
+        'sessions',
+        'session-1',
+        'projections',
+        'history_compact_checkpoint_recorded.json',
+      ));
+
+      await store.appendEvent('session-1', further.runId, further);
+      await projectionStore.repairEventProjection(
+        'session-1',
+        'history_compact_checkpoint_recorded',
+        stale,
+      );
+
+      const projected = await projectionStore.readEventProjection(
+        'session-1',
+        'history_compact_checkpoint_recorded',
+      );
+      assert.equal(projected?.id, further.id);
+    });
+  });
+
   it('does not retain a checkpoint projection when the canonical ledger append fails', async () => {
     await withStore(async (store, root) => {
       const projectionStore = store as typeof store & {

--- a/packages/storage/src/__tests__/agent-run-store.test.ts
+++ b/packages/storage/src/__tests__/agent-run-store.test.ts
@@ -90,6 +90,47 @@ describe('AgentRunStore', () => {
     });
   });
 
+  it('keeps a bounded monotonic projection for history compact checkpoints', async () => {
+    await withStore(async (store) => {
+      const projectionStore = store as typeof store & {
+        readEventProjection(
+          sessionId: string,
+          type: AgentRunEvent['type'],
+        ): Promise<AgentRunEvent | null | undefined>;
+      };
+      await store.createRun(makeHeader({ runId: 'run-furthest' }));
+      await store.createRun(makeHeader({ runId: 'run-stale', turnId: 'turn-stale' }));
+      const checkpointEvent = (runId: string, eventCount: number): AgentRunEvent => makeEvent({
+        type: 'history_compact_checkpoint_recorded',
+        id: `checkpoint-${runId}`,
+        runId,
+        turnId: `turn-${runId}`,
+        data: {
+          checkpoint: {
+            kind: 'maka.history_compact_checkpoint',
+            version: 2,
+            checkpointId: `hcheckpoint-${runId}`,
+            sessionId: 'session-1',
+            coverage: { eventCount },
+          },
+        },
+      });
+
+      await store.appendEvent('session-1', 'run-furthest', checkpointEvent('run-furthest', 3));
+      await store.appendEvent('session-1', 'run-stale', checkpointEvent('run-stale', 2));
+
+      const projected = await projectionStore.readEventProjection(
+        'session-1',
+        'history_compact_checkpoint_recorded',
+      );
+      assert.equal(
+        projected?.data?.checkpoint
+          && (projected.data.checkpoint as { checkpointId?: string }).checkpointId,
+        'hcheckpoint-run-furthest',
+      );
+    });
+  });
+
   it('recovers corrupt event lines without hiding later events', async () => {
     await withStore(async (store, root) => {
       await store.createRun(makeHeader());

--- a/packages/storage/src/__tests__/agent-run-store.test.ts
+++ b/packages/storage/src/__tests__/agent-run-store.test.ts
@@ -90,7 +90,7 @@ describe('AgentRunStore', () => {
     });
   });
 
-  it('keeps a bounded monotonic projection for history compact checkpoints', async () => {
+  it('writes a bounded projection for accepted history compact checkpoints', async () => {
     await withStore(async (store) => {
       const projectionStore = store as typeof store & {
         readEventProjection(
@@ -98,8 +98,7 @@ describe('AgentRunStore', () => {
           type: AgentRunEvent['type'],
         ): Promise<AgentRunEvent | null | undefined>;
       };
-      await store.createRun(makeHeader({ runId: 'run-furthest' }));
-      await store.createRun(makeHeader({ runId: 'run-stale', turnId: 'turn-stale' }));
+      await store.createRun(makeHeader({ runId: 'run-accepted' }));
       const checkpointEvent = (runId: string, eventCount: number): AgentRunEvent => makeEvent({
         type: 'history_compact_checkpoint_recorded',
         id: `checkpoint-${runId}`,
@@ -116,8 +115,7 @@ describe('AgentRunStore', () => {
         },
       });
 
-      await store.appendEvent('session-1', 'run-furthest', checkpointEvent('run-furthest', 3));
-      await store.appendEvent('session-1', 'run-stale', checkpointEvent('run-stale', 2));
+      await store.appendEvent('session-1', 'run-accepted', checkpointEvent('run-accepted', 3));
 
       const projected = await projectionStore.readEventProjection(
         'session-1',
@@ -126,7 +124,7 @@ describe('AgentRunStore', () => {
       assert.equal(
         projected?.data?.checkpoint
           && (projected.data.checkpoint as { checkpointId?: string }).checkpointId,
-        'hcheckpoint-run-furthest',
+        'hcheckpoint-run-accepted',
       );
     });
   });

--- a/packages/storage/src/agent-run-store.ts
+++ b/packages/storage/src/agent-run-store.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from 'node:crypto';
-import { appendFile, mkdir, readFile, readdir, rename, writeFile } from 'node:fs/promises';
+import { appendFile, mkdir, readFile, readdir, rename, rm, writeFile } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
 import { chainWrite } from './write-queue.js';
 import {
@@ -83,8 +83,19 @@ class FileAgentRunStore implements AgentRunStore {
     assertSafeId(sessionId, 'Invalid session id');
     assertSafeId(runId, 'Invalid run id');
     if (event.type === 'history_compact_checkpoint_recorded') {
-      await this.advanceEventProjection(sessionId, event.type, event);
+      await this.withProjectionQueue(sessionId, event.type, async () => {
+        await rm(this.eventProjectionPath(sessionId, event.type), { force: true });
+        await this.appendRunEvent(sessionId, runId, event);
+        await this.writeEventProjectionUnlocked(sessionId, event.type, event).catch(() => {
+          // The canonical event is durable; a missing derived projection safely replays raw history.
+        });
+      });
+      return;
     }
+    await this.appendRunEvent(sessionId, runId, event);
+  }
+
+  private async appendRunEvent(sessionId: string, runId: string, event: AgentRunEvent): Promise<void> {
     await this.withQueue(sessionId, runId, async () => {
       await mkdir(this.runDir(sessionId, runId), { recursive: true });
       await appendFile(this.eventsPath(sessionId, runId), JSON.stringify(event, sanitizeJson) + '\n', 'utf8');
@@ -177,16 +188,6 @@ class FileAgentRunStore implements AgentRunStore {
     operation: () => Promise<void>,
   ): Promise<void> {
     return chainWrite(this.projectionWriteQueues, `${sessionId}:${type}`, operation);
-  }
-
-  private async advanceEventProjection(
-    sessionId: string,
-    type: AgentRunEventType,
-    candidate: AgentRunEvent,
-  ): Promise<void> {
-    await this.withProjectionQueue(sessionId, type, async () => {
-      await this.writeEventProjectionUnlocked(sessionId, type, candidate);
-    });
   }
 
   private async readEventProjectionUnlocked(

--- a/packages/storage/src/agent-run-store.ts
+++ b/packages/storage/src/agent-run-store.ts
@@ -161,6 +161,7 @@ class FileAgentRunStore implements AgentRunStore {
     sessionId: string,
     type: AgentRunEventType,
     event: AgentRunEvent | null,
+    options: { replaceEventId?: string } = {},
   ): Promise<void> {
     assertSafeId(sessionId, 'Invalid session id');
     if (event !== null && !isProjectedAgentRunEvent(event, sessionId, type)) {
@@ -173,7 +174,10 @@ class FileAgentRunStore implements AgentRunStore {
       } catch {
         current = undefined;
       }
-      if (shouldPreserveProjectionDuringRepair(current, event, type)) return;
+      if (
+        current?.id !== options.replaceEventId
+        && shouldPreserveProjectionDuringRepair(current, event, type)
+      ) return;
       await this.writeEventProjectionUnlocked(sessionId, type, event);
     });
   }

--- a/packages/storage/src/agent-run-store.ts
+++ b/packages/storage/src/agent-run-store.ts
@@ -82,15 +82,13 @@ class FileAgentRunStore implements AgentRunStore {
   async appendEvent(sessionId: string, runId: string, event: AgentRunEvent): Promise<void> {
     assertSafeId(sessionId, 'Invalid session id');
     assertSafeId(runId, 'Invalid run id');
+    if (event.type === 'history_compact_checkpoint_recorded') {
+      await this.advanceEventProjection(sessionId, event.type, event);
+    }
     await this.withQueue(sessionId, runId, async () => {
       await mkdir(this.runDir(sessionId, runId), { recursive: true });
       await appendFile(this.eventsPath(sessionId, runId), JSON.stringify(event, sanitizeJson) + '\n', 'utf8');
     });
-    if (event.type === 'history_compact_checkpoint_recorded') {
-      await this.advanceEventProjection(sessionId, event.type, event).catch(() => {
-        // The projection is a rebuildable accelerator; the appended run event remains canonical.
-      });
-    }
   }
 
   async readEvents(sessionId: string, runId: string): Promise<AgentRunEvent[]> {
@@ -137,17 +135,6 @@ class FileAgentRunStore implements AgentRunStore {
   ): Promise<AgentRunEvent | null | undefined> {
     assertSafeId(sessionId, 'Invalid session id');
     return this.readEventProjectionUnlocked(sessionId, type);
-  }
-
-  async writeEventProjection(
-    sessionId: string,
-    type: AgentRunEventType,
-    event: AgentRunEvent | null,
-  ): Promise<void> {
-    assertSafeId(sessionId, 'Invalid session id');
-    await this.withProjectionQueue(sessionId, type, async () => {
-      await this.mergeEventProjectionUnlocked(sessionId, type, event);
-    });
   }
 
   private async readRunUnlocked(sessionId: string, runId: string): Promise<AgentRunHeader> {
@@ -198,27 +185,8 @@ class FileAgentRunStore implements AgentRunStore {
     candidate: AgentRunEvent,
   ): Promise<void> {
     await this.withProjectionQueue(sessionId, type, async () => {
-      await this.mergeEventProjectionUnlocked(sessionId, type, candidate);
+      await this.writeEventProjectionUnlocked(sessionId, type, candidate);
     });
-  }
-
-  private async mergeEventProjectionUnlocked(
-    sessionId: string,
-    type: AgentRunEventType,
-    candidate: AgentRunEvent | null,
-  ): Promise<void> {
-    let current: AgentRunEvent | null | undefined;
-    try {
-      current = await this.readEventProjectionUnlocked(sessionId, type);
-    } catch {
-      current = undefined;
-    }
-    const selected = candidate === null
-      ? current ?? null
-      : selectProjectedEvent(current, candidate);
-    if (selected !== current) {
-      await this.writeEventProjectionUnlocked(sessionId, type, selected);
-    }
   }
 
   private async readEventProjectionUnlocked(
@@ -351,29 +319,6 @@ async function readRuntimeEventJsonl(path: string, runId: string): Promise<Runti
     }
   }
   return events;
-}
-
-function selectProjectedEvent(
-  current: AgentRunEvent | null | undefined,
-  candidate: AgentRunEvent,
-): AgentRunEvent {
-  if (!current) return candidate;
-  if (
-    candidate.type === 'history_compact_checkpoint_recorded'
-    && projectedCheckpointCoverage(candidate) <= projectedCheckpointCoverage(current)
-  ) {
-    return current;
-  }
-  return candidate;
-}
-
-function projectedCheckpointCoverage(event: AgentRunEvent): number {
-  const checkpoint = event.data?.checkpoint;
-  if (!checkpoint || typeof checkpoint !== 'object') return -1;
-  const coverage = (checkpoint as { coverage?: unknown }).coverage;
-  if (!coverage || typeof coverage !== 'object') return -1;
-  const eventCount = (coverage as { eventCount?: unknown }).eventCount;
-  return Number.isInteger(eventCount) && (eventCount as number) > 0 ? eventCount as number : -1;
 }
 
 function isProjectedAgentRunEvent(

--- a/packages/storage/src/agent-run-store.ts
+++ b/packages/storage/src/agent-run-store.ts
@@ -39,6 +39,15 @@ class FileAgentRunStore implements AgentRunStore {
       await mkdir(this.runDir(header.sessionId, header.runId), { recursive: true });
       await writeAtomic(this.runPath(header.sessionId, header.runId), JSON.stringify(header, sanitizeJson) + '\n');
     });
+    await this.withProjectionQueue(header.sessionId, 'history_compact_checkpoint_recorded', async () => {
+      await this.initializeEventProjectionUnlocked(
+        header.sessionId,
+        header.runId,
+        'history_compact_checkpoint_recorded',
+      );
+    }).catch(() => {
+      // Projection initialization is derived state; recovery can rebuild it from the run ledger.
+    });
     return header;
   }
 
@@ -148,6 +157,20 @@ class FileAgentRunStore implements AgentRunStore {
     return this.readEventProjectionUnlocked(sessionId, type);
   }
 
+  async repairEventProjection(
+    sessionId: string,
+    type: AgentRunEventType,
+    event: AgentRunEvent | null,
+  ): Promise<void> {
+    assertSafeId(sessionId, 'Invalid session id');
+    if (event !== null && !isProjectedAgentRunEvent(event, sessionId, type)) {
+      throw new Error(`Invalid AgentRun event projection repair for ${type}`);
+    }
+    await this.withProjectionQueue(sessionId, type, async () => {
+      await this.writeEventProjectionUnlocked(sessionId, type, event);
+    });
+  }
+
   private async readRunUnlocked(sessionId: string, runId: string): Promise<AgentRunHeader> {
     assertSafeId(sessionId, 'Invalid session id');
     assertSafeId(runId, 'Invalid run id');
@@ -221,6 +244,23 @@ class FileAgentRunStore implements AgentRunStore {
       this.eventProjectionPath(sessionId, type),
       JSON.stringify({ version: 1, event }, sanitizeJson) + '\n',
     );
+  }
+
+  private async initializeEventProjectionUnlocked(
+    sessionId: string,
+    currentRunId: string,
+    type: AgentRunEventType,
+  ): Promise<void> {
+    try {
+      await readFile(this.eventProjectionPath(sessionId, type), 'utf8');
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
+      const runs = await readdir(this.runsRoot(sessionId), { withFileTypes: true });
+      if (runs.some((entry) => entry.isDirectory() && isSafeId(entry.name) && entry.name !== currentRunId)) {
+        return;
+      }
+      await this.writeEventProjectionUnlocked(sessionId, type, null);
+    }
   }
 }
 

--- a/packages/storage/src/agent-run-store.ts
+++ b/packages/storage/src/agent-run-store.ts
@@ -167,6 +167,13 @@ class FileAgentRunStore implements AgentRunStore {
       throw new Error(`Invalid AgentRun event projection repair for ${type}`);
     }
     await this.withProjectionQueue(sessionId, type, async () => {
+      let current: AgentRunEvent | null | undefined;
+      try {
+        current = await this.readEventProjectionUnlocked(sessionId, type);
+      } catch {
+        current = undefined;
+      }
+      if (shouldPreserveProjectionDuringRepair(current, event, type)) return;
       await this.writeEventProjectionUnlocked(sessionId, type, event);
     });
   }
@@ -262,6 +269,30 @@ class FileAgentRunStore implements AgentRunStore {
       await this.writeEventProjectionUnlocked(sessionId, type, null);
     }
   }
+}
+
+function shouldPreserveProjectionDuringRepair(
+  current: AgentRunEvent | null | undefined,
+  candidate: AgentRunEvent | null,
+  type: AgentRunEventType,
+): boolean {
+  if (!current) return false;
+  if (type !== 'history_compact_checkpoint_recorded') return true;
+  const currentCoverage = historyCompactProjectionCoverage(current);
+  const candidateCoverage = candidate && historyCompactProjectionCoverage(candidate);
+  return currentCoverage !== undefined
+    && (candidateCoverage === null || candidateCoverage === undefined || currentCoverage >= candidateCoverage);
+}
+
+function historyCompactProjectionCoverage(event: AgentRunEvent): number | undefined {
+  const checkpoint = event.data?.checkpoint;
+  if (!checkpoint || typeof checkpoint !== 'object') return undefined;
+  const coverage = (checkpoint as { coverage?: unknown }).coverage;
+  if (!coverage || typeof coverage !== 'object') return undefined;
+  const eventCount = (coverage as { eventCount?: unknown }).eventCount;
+  return typeof eventCount === 'number' && Number.isSafeInteger(eventCount) && eventCount >= 0
+    ? eventCount
+    : undefined;
 }
 
 class FileRuntimeEventStore implements RuntimeEventStore {

--- a/packages/storage/src/agent-run-store.ts
+++ b/packages/storage/src/agent-run-store.ts
@@ -6,6 +6,7 @@ import {
   AGENT_RUN_STATUSES,
   isPermissionMode,
   type AgentRunEvent,
+  type AgentRunEventType,
   type AgentRunHeader,
   type AgentRunStore,
   type RuntimeEvent,
@@ -25,6 +26,7 @@ export function createRuntimeEventStore(workspaceRoot: string): RuntimeEventStor
 class FileAgentRunStore implements AgentRunStore {
   private readonly sessionsRoot: string;
   private readonly writeQueues = new Map<string, Promise<void>>();
+  private readonly projectionWriteQueues = new Map<string, Promise<void>>();
 
   constructor(workspaceRoot: string) {
     this.sessionsRoot = join(workspaceRoot, 'sessions');
@@ -84,6 +86,11 @@ class FileAgentRunStore implements AgentRunStore {
       await mkdir(this.runDir(sessionId, runId), { recursive: true });
       await appendFile(this.eventsPath(sessionId, runId), JSON.stringify(event, sanitizeJson) + '\n', 'utf8');
     });
+    if (event.type === 'history_compact_checkpoint_recorded') {
+      await this.advanceEventProjection(sessionId, event.type, event).catch(() => {
+        // The projection is a rebuildable accelerator; the appended run event remains canonical.
+      });
+    }
   }
 
   async readEvents(sessionId: string, runId: string): Promise<AgentRunEvent[]> {
@@ -124,6 +131,25 @@ class FileAgentRunStore implements AgentRunStore {
     return events;
   }
 
+  async readEventProjection(
+    sessionId: string,
+    type: AgentRunEventType,
+  ): Promise<AgentRunEvent | null | undefined> {
+    assertSafeId(sessionId, 'Invalid session id');
+    return this.readEventProjectionUnlocked(sessionId, type);
+  }
+
+  async writeEventProjection(
+    sessionId: string,
+    type: AgentRunEventType,
+    event: AgentRunEvent | null,
+  ): Promise<void> {
+    assertSafeId(sessionId, 'Invalid session id');
+    await this.withProjectionQueue(sessionId, type, async () => {
+      await this.mergeEventProjectionUnlocked(sessionId, type, event);
+    });
+  }
+
   private async readRunUnlocked(sessionId: string, runId: string): Promise<AgentRunHeader> {
     assertSafeId(sessionId, 'Invalid session id');
     assertSafeId(runId, 'Invalid run id');
@@ -148,10 +174,84 @@ class FileAgentRunStore implements AgentRunStore {
     return join(this.runDir(sessionId, runId), 'events.jsonl');
   }
 
+  private eventProjectionPath(sessionId: string, type: AgentRunEventType): string {
+    return join(this.sessionsRoot, sessionId, 'projections', `${type}.json`);
+  }
+
   private withQueue(sessionId: string, runId: string, operation: () => Promise<void>): Promise<void> {
     assertSafeId(sessionId, 'Invalid session id');
     assertSafeId(runId, 'Invalid run id');
     return chainWrite(this.writeQueues, `${sessionId}:${runId}`, operation);
+  }
+
+  private withProjectionQueue(
+    sessionId: string,
+    type: AgentRunEventType,
+    operation: () => Promise<void>,
+  ): Promise<void> {
+    return chainWrite(this.projectionWriteQueues, `${sessionId}:${type}`, operation);
+  }
+
+  private async advanceEventProjection(
+    sessionId: string,
+    type: AgentRunEventType,
+    candidate: AgentRunEvent,
+  ): Promise<void> {
+    await this.withProjectionQueue(sessionId, type, async () => {
+      await this.mergeEventProjectionUnlocked(sessionId, type, candidate);
+    });
+  }
+
+  private async mergeEventProjectionUnlocked(
+    sessionId: string,
+    type: AgentRunEventType,
+    candidate: AgentRunEvent | null,
+  ): Promise<void> {
+    let current: AgentRunEvent | null | undefined;
+    try {
+      current = await this.readEventProjectionUnlocked(sessionId, type);
+    } catch {
+      current = undefined;
+    }
+    const selected = candidate === null
+      ? current ?? null
+      : selectProjectedEvent(current, candidate);
+    if (selected !== current) {
+      await this.writeEventProjectionUnlocked(sessionId, type, selected);
+    }
+  }
+
+  private async readEventProjectionUnlocked(
+    sessionId: string,
+    type: AgentRunEventType,
+  ): Promise<AgentRunEvent | null | undefined> {
+    let raw: string;
+    try {
+      raw = await readFile(this.eventProjectionPath(sessionId, type), 'utf8');
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') return undefined;
+      throw error;
+    }
+    const parsed = JSON.parse(raw) as { version?: unknown; event?: unknown };
+    if (parsed.version !== 1 || !Object.hasOwn(parsed, 'event')) {
+      throw new Error(`Invalid AgentRun event projection for ${type}`);
+    }
+    if (parsed.event === null) return null;
+    if (!isProjectedAgentRunEvent(parsed.event, sessionId, type)) {
+      throw new Error(`Invalid AgentRun event projection for ${type}`);
+    }
+    return parsed.event;
+  }
+
+  private async writeEventProjectionUnlocked(
+    sessionId: string,
+    type: AgentRunEventType,
+    event: AgentRunEvent | null,
+  ): Promise<void> {
+    await writeAtomic(
+      this.eventProjectionPath(sessionId, type),
+      JSON.stringify({ version: 1, event }, sanitizeJson) + '\n',
+    );
   }
 }
 
@@ -251,6 +351,44 @@ async function readRuntimeEventJsonl(path: string, runId: string): Promise<Runti
     }
   }
   return events;
+}
+
+function selectProjectedEvent(
+  current: AgentRunEvent | null | undefined,
+  candidate: AgentRunEvent,
+): AgentRunEvent {
+  if (!current) return candidate;
+  if (
+    candidate.type === 'history_compact_checkpoint_recorded'
+    && projectedCheckpointCoverage(candidate) <= projectedCheckpointCoverage(current)
+  ) {
+    return current;
+  }
+  return candidate;
+}
+
+function projectedCheckpointCoverage(event: AgentRunEvent): number {
+  const checkpoint = event.data?.checkpoint;
+  if (!checkpoint || typeof checkpoint !== 'object') return -1;
+  const coverage = (checkpoint as { coverage?: unknown }).coverage;
+  if (!coverage || typeof coverage !== 'object') return -1;
+  const eventCount = (coverage as { eventCount?: unknown }).eventCount;
+  return Number.isInteger(eventCount) && (eventCount as number) > 0 ? eventCount as number : -1;
+}
+
+function isProjectedAgentRunEvent(
+  value: unknown,
+  sessionId: string,
+  type: AgentRunEventType,
+): value is AgentRunEvent {
+  if (!value || typeof value !== 'object') return false;
+  const event = value as Partial<AgentRunEvent>;
+  return event.type === type
+    && event.sessionId === sessionId
+    && typeof event.id === 'string'
+    && typeof event.runId === 'string'
+    && typeof event.turnId === 'string'
+    && Number.isFinite(event.ts);
 }
 
 async function writeAtomic(path: string, content: string): Promise<void> {

--- a/packages/ui/src/__tests__/materialize.test.ts
+++ b/packages/ui/src/__tests__/materialize.test.ts
@@ -57,7 +57,7 @@ describe('materializeChat attachments', () => {
     assert.equal(items[0].role, 'system');
     assert.equal(
       items[0].text,
-      'Context summary failed; the session continued and will retry next turn.',
+      'Context summary failed; the session continued without a new summary.',
     );
   });
 });

--- a/packages/ui/src/__tests__/materialize.test.ts
+++ b/packages/ui/src/__tests__/materialize.test.ts
@@ -57,7 +57,7 @@ describe('materializeChat attachments', () => {
     assert.equal(items[0].role, 'system');
     assert.equal(
       items[0].text,
-      'Context summary failed; older details were trimmed and will be retried next turn.',
+      'Context summary failed; the session continued and will retry next turn.',
     );
   });
 });

--- a/packages/ui/src/__tests__/materialize.test.ts
+++ b/packages/ui/src/__tests__/materialize.test.ts
@@ -47,4 +47,17 @@ describe('materializeChat attachments', () => {
     assert.equal(items[0].role, 'system');
     assert.equal(items[0].text, 'Context compacted to keep this session within the model window.');
   });
+
+  test('surfaces history compaction fail-open notices inline', () => {
+    const messages: StoredMessage[] = [
+      { type: 'system_note', id: 'note-1', turnId: 't1', ts: 1, kind: 'context_compaction_failed_open' },
+    ];
+    const items = materializeChat(messages);
+    assert.equal(items.length, 1);
+    assert.equal(items[0].role, 'system');
+    assert.equal(
+      items[0].text,
+      'Context summary failed; older details were trimmed and will be retried next turn.',
+    );
+  });
 });

--- a/packages/ui/src/materialize.ts
+++ b/packages/ui/src/materialize.ts
@@ -81,10 +81,12 @@ export interface ToolActivityItem {
 // the conversation reads like a conversation, not a debug log.
 const VISIBLE_SYSTEM_NOTES = new Set<string>([
   'context_compacted',
+  'context_compaction_failed_open',
 ]);
 
 const SYSTEM_NOTE_LABELS: Record<string, string> = {
   context_compacted: 'Context compacted to keep this session within the model window.',
+  context_compaction_failed_open: 'Context summary failed; older details were trimmed and will be retried next turn.',
   mode_change: 'Permission mode changed',
   turn_aborted: 'Turn aborted',
 };

--- a/packages/ui/src/materialize.ts
+++ b/packages/ui/src/materialize.ts
@@ -86,7 +86,7 @@ const VISIBLE_SYSTEM_NOTES = new Set<string>([
 
 const SYSTEM_NOTE_LABELS: Record<string, string> = {
   context_compacted: 'Context compacted to keep this session within the model window.',
-  context_compaction_failed_open: 'Context summary failed; older details were trimmed and will be retried next turn.',
+  context_compaction_failed_open: 'Context summary failed; the session continued and will retry next turn.',
   mode_change: 'Permission mode changed',
   turn_aborted: 'Turn aborted',
 };

--- a/packages/ui/src/materialize.ts
+++ b/packages/ui/src/materialize.ts
@@ -86,7 +86,7 @@ const VISIBLE_SYSTEM_NOTES = new Set<string>([
 
 const SYSTEM_NOTE_LABELS: Record<string, string> = {
   context_compacted: 'Context compacted to keep this session within the model window.',
-  context_compaction_failed_open: 'Context summary failed; the session continued and will retry next turn.',
+  context_compaction_failed_open: 'Context summary failed; the session continued without a new summary.',
   mode_change: 'Permission mode changed',
   turn_aborted: 'Turn aborted',
 };


### PR DESCRIPTION
## Summary

Replace History Compaction V1 artifact fan-out with bounded V2 checkpoints stored in the run ledger.

V2 preserves automatic compaction while rolling summaries forward from the previous checkpoint plus only newly evicted turns.

## Why

History Compaction V1 created one source artifact per folded RuntimeEvent and rewrote artifact metadata repeatedly. Large histories could therefore create thousands of artifacts, multi-megabyte compact blocks, excessive IPC notifications, and severe write amplification.

Refs #727, #728

## Scope

Changed:

- Add a bounded V2 history compact checkpoint containing a prefix cursor, aggregate source digest, event/turn counts, and continuation summary.
- Persist accepted checkpoints through the existing AgentRun ledger recorder pattern.
- Load and validate the latest checkpoint against the canonical RuntimeEvent prefix.
- Roll summaries forward from the previous summary plus newly evicted complete turns.
- Reuse unchanged checkpoints without another summarizer call.
- Reject blank summaries.
- Fail open to the retained tail on initial summary failure and show one visible notice.
- Preserve the previous checkpoint plus the newest complete raw turns that fit when a rolling update fails.
- Stop Desktop and CLI from writing new history compact source/block artifacts.
- Keep V1 artifact loading as a read-only fallback, including legacy blocks up to 16 MiB.
- Keep V2 checkpoint and diagnostic size bounded for large histories.

Not included:

- Durable streaming RuntimeEvent coalescing
- Automatic deletion of legacy history compact artifacts
- Active or semantic compaction redesign
- Settings UI changes

## Verification

- `npm run -w @maka/runtime test`
- `npm run -w @maka/storage test`
- `npm run -w @maka/ui test`
- `npm run -w maka-agent test`
- `npm run -w @maka/desktop test`
- `npm run typecheck`
- `git diff --check`

Regression coverage includes:

- 10K-event bounded checkpoint and diagnostic size
- Exact ordered-prefix validation
- Run-ledger recording and latest-checkpoint loading
- Rolling summary input
- Same-checkpoint reuse without another summarizer call
- Blank and failed summary fallback
- Previous-checkpoint fallback after rolling failure
- Visible fail-open notices
- Large V1 block read compatibility

## User-facing impact

Long sessions no longer create one internal artifact per compacted RuntimeEvent. Automatic compaction continues to retain recent raw history while using a bounded continuation checkpoint for older context.

If summary generation fails, the session continues and shows one concise warning.

No existing artifacts are automatically deleted. No breaking API or data migration is introduced.

## Reviewer notes

Review focus:

- Checkpoint prefix validation and bounded metadata
- Ledger write/read ordering
- Rolling summary inputs
- Fail-open behavior
- V1 read-only compatibility
- Desktop and CLI removal of V1 writes

Rollback is the single commit in this PR. Existing V1 artifact data remains untouched.

UI changes are limited to transcript materialization of the fail-open notice; screenshots are not applicable.

## Checklist

- [x] Scope matches the PR title and excludes unrelated changes
- [x] Verification lists commands and results
- [x] User-facing impact and migration behavior are documented
- [x] Risk, rollback, and review focus are called out
- [x] UI changes do not require screenshots
