### PR TITLE
perf(storage): coalesce durable stream partials

### DIFF
--- a/packages/storage/src/__tests__/agent-run-store.test.ts
+++ b/packages/storage/src/__tests__/agent-run-store.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { mkdir, mkdtemp, readFile, readdir, rm, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { describe, it } from 'node:test';
@@ -392,6 +392,262 @@ describe('AgentRunStore', () => {
       await runStore.createRun(makeHeader());
 
       assert.deepEqual(await runtimeEventStore.readRuntimeEvents('session-1', 'run-1'), []);
+    });
+  });
+
+  it('coalesces text stream chunks into one recoverable partial snapshot', async () => {
+    await withStores(async (runStore, runtimeEventStore) => {
+      await runStore.createRun(makeHeader());
+      for (const [index, text] of ['hel', 'lo', '!'].entries()) {
+        await runtimeEventStore.appendRuntimeEvent('session-1', 'run-1', makeRuntimeEvent({
+          id: `runtime-partial-${index}`,
+          ts: index + 1,
+          partial: true,
+          role: 'model',
+          author: 'agent',
+          content: { kind: 'text', text },
+          refs: { providerEventId: 'message-1' },
+        }));
+      }
+
+      const events = await runtimeEventStore.readRuntimeEvents('session-1', 'run-1');
+
+      assert.equal(events.length, 1);
+      assert.equal(events[0]?.partial, true);
+      assert.deepEqual(events[0]?.content, { kind: 'text', text: 'hello!' });
+    });
+  });
+
+  it('recovers the accumulated partial snapshot after reopening the store', async () => {
+    await withStores(async (runStore, runtimeEventStore, root) => {
+      await runStore.createRun(makeHeader());
+      for (const [index, text] of ['still ', 'working'].entries()) {
+        await runtimeEventStore.appendRuntimeEvent('session-1', 'run-1', makeRuntimeEvent({
+          id: `runtime-partial-${index}`,
+          partial: true,
+          role: 'model',
+          author: 'agent',
+          content: { kind: 'text', text },
+          refs: { providerEventId: 'message-1' },
+        }));
+      }
+
+      const reopened = createRuntimeEventStore(root);
+      const events = await reopened.readRuntimeEvents('session-1', 'run-1');
+
+      assert.equal(events.length, 1);
+      assert.deepEqual(events[0]?.content, { kind: 'text', text: 'still working' });
+    });
+  });
+
+  it('keeps a 10K-chunk text stream bounded to one durable partial snapshot', async () => {
+    await withStores(async (runStore, runtimeEventStore, root) => {
+      await runStore.createRun(makeHeader());
+      for (let index = 0; index < 10_000; index += 1) {
+        await runtimeEventStore.appendRuntimeEvent('session-1', 'run-1', makeRuntimeEvent({
+          id: `runtime-partial-${index}`,
+          partial: true,
+          role: 'model',
+          author: 'agent',
+          content: { kind: 'text', text: 'x' },
+          refs: { providerEventId: 'message-1' },
+        }));
+      }
+
+      const events = await runtimeEventStore.readRuntimeEvents('session-1', 'run-1');
+      const partialFiles = await readdir(join(
+        root,
+        'sessions',
+        'session-1',
+        'runs',
+        'run-1',
+        'runtime-partials',
+      ));
+
+      assert.equal(events.length, 1);
+      assert.equal(events[0]?.content?.kind === 'text' && events[0].content.text.length, 10_000);
+      assert.equal(partialFiles.filter((name) => name.endsWith('.json')).length, 1);
+      const immutableLedger = await readFile(join(
+        root,
+        'sessions',
+        'session-1',
+        'runs',
+        'run-1',
+        'runtime-events.jsonl',
+      ), 'utf8').catch((error) => {
+        if ((error as NodeJS.ErrnoException).code === 'ENOENT') return '';
+        throw error;
+      });
+      assert.equal(immutableLedger, '');
+    });
+  });
+
+  it('coalesces thinking chunks into one recoverable partial snapshot', async () => {
+    await withStores(async (runStore, runtimeEventStore) => {
+      await runStore.createRun(makeHeader());
+      for (const [index, text] of ['reason', 'ing ', 'continues'].entries()) {
+        await runtimeEventStore.appendRuntimeEvent('session-1', 'run-1', makeRuntimeEvent({
+          id: `runtime-thinking-${index}`,
+          partial: true,
+          role: 'model',
+          author: 'agent',
+          content: { kind: 'thinking', text },
+          refs: { providerEventId: 'message-1' },
+        }));
+      }
+
+      const events = await runtimeEventStore.readRuntimeEvents('session-1', 'run-1');
+
+      assert.equal(events.length, 1);
+      assert.deepEqual(events[0]?.content, { kind: 'thinking', text: 'reasoning continues' });
+    });
+  });
+
+  it('coalesces tool stream heartbeats until the durable tool result arrives', async () => {
+    await withStores(async (runStore, runtimeEventStore) => {
+      await runStore.createRun(makeHeader());
+      for (let index = 0; index < 100; index += 1) {
+        await runtimeEventStore.appendRuntimeEvent('session-1', 'run-1', makeRuntimeEvent({
+          id: `runtime-tool-progress-${index}`,
+          partial: true,
+          role: 'tool',
+          author: 'tool',
+          content: undefined,
+          refs: { toolCallId: 'tool-call-1' },
+        }));
+      }
+
+      assert.equal((await runtimeEventStore.readRuntimeEvents('session-1', 'run-1')).length, 1);
+
+      await runtimeEventStore.appendRuntimeEvent('session-1', 'run-1', makeRuntimeEvent({
+        id: 'runtime-tool-result',
+        ts: 2,
+        role: 'tool',
+        author: 'tool',
+        content: {
+          kind: 'function_response',
+          id: 'tool-call-1',
+          name: 'Bash',
+          result: 'done',
+        },
+        refs: { toolCallId: 'tool-call-1' },
+      }));
+
+      const events = await runtimeEventStore.readRuntimeEvents('session-1', 'run-1');
+      assert.deepEqual(events.map((event) => event.id), ['runtime-tool-result']);
+    });
+  });
+
+  it('keeps partial events with lifecycle actions as immutable facts', async () => {
+    await withStores(async (runStore, runtimeEventStore) => {
+      await runStore.createRun(makeHeader());
+      for (let index = 0; index < 2; index += 1) {
+        await runtimeEventStore.appendRuntimeEvent('session-1', 'run-1', makeRuntimeEvent({
+          id: `runtime-lifecycle-${index}`,
+          partial: true,
+          role: 'system',
+          author: 'system',
+          content: undefined,
+          actions: { stateDelta: { progress: index } },
+          refs: { toolCallId: 'tool-call-1' },
+        }));
+      }
+
+      const events = await runtimeEventStore.readRuntimeEvents('session-1', 'run-1');
+
+      assert.deepEqual(events.map((event) => event.id), [
+        'runtime-lifecycle-0',
+        'runtime-lifecycle-1',
+      ]);
+    });
+  });
+
+  it('replaces a text partial snapshot with the durable final event', async () => {
+    await withStores(async (runStore, runtimeEventStore) => {
+      await runStore.createRun(makeHeader());
+      await runtimeEventStore.appendRuntimeEvent('session-1', 'run-1', makeRuntimeEvent({
+        id: 'runtime-partial',
+        partial: true,
+        role: 'model',
+        author: 'agent',
+        content: { kind: 'text', text: 'hello' },
+        refs: { providerEventId: 'message-1' },
+      }));
+      await runtimeEventStore.appendRuntimeEvent('session-1', 'run-1', makeRuntimeEvent({
+        id: 'runtime-final',
+        ts: 2,
+        role: 'model',
+        author: 'agent',
+        content: { kind: 'text', text: 'hello world' },
+        refs: { providerEventId: 'message-1' },
+      }));
+
+      const events = await runtimeEventStore.readRuntimeEvents('session-1', 'run-1');
+
+      assert.deepEqual(events.map((event) => event.id), ['runtime-final']);
+      assert.deepEqual(events[0]?.content, { kind: 'text', text: 'hello world' });
+    });
+  });
+
+  it('ignores a stale partial snapshot when its final event is already durable', async () => {
+    await withStores(async (runStore, runtimeEventStore) => {
+      await runStore.createRun(makeHeader());
+      await runtimeEventStore.appendRuntimeEvent('session-1', 'run-1', makeRuntimeEvent({
+        id: 'runtime-final',
+        ts: 2,
+        role: 'model',
+        author: 'agent',
+        content: { kind: 'text', text: 'complete' },
+        refs: { providerEventId: 'message-1' },
+      }));
+      await runtimeEventStore.appendRuntimeEvent('session-1', 'run-1', makeRuntimeEvent({
+        id: 'runtime-stale-partial',
+        ts: 1,
+        partial: true,
+        role: 'model',
+        author: 'agent',
+        content: { kind: 'text', text: 'stale' },
+        refs: { providerEventId: 'message-1' },
+      }));
+
+      const events = await runtimeEventStore.readRuntimeEvents('session-1', 'run-1');
+
+      assert.deepEqual(events.map((event) => event.id), ['runtime-final']);
+    });
+  });
+
+  it('restores a retained partial snapshot before a later terminal event', async () => {
+    await withStores(async (runStore, runtimeEventStore) => {
+      await runStore.createRun(makeHeader());
+      await runtimeEventStore.appendRuntimeEvent('session-1', 'run-1', makeRuntimeEvent({
+        id: 'runtime-user',
+        ts: 1,
+      }));
+      await runtimeEventStore.appendRuntimeEvent('session-1', 'run-1', makeRuntimeEvent({
+        id: 'runtime-partial',
+        ts: 2,
+        partial: true,
+        role: 'model',
+        author: 'agent',
+        content: { kind: 'text', text: 'retained output' },
+        refs: { providerEventId: 'message-1' },
+      }));
+      await runtimeEventStore.appendRuntimeEvent('session-1', 'run-1', makeRuntimeEvent({
+        id: 'runtime-terminal',
+        ts: 1,
+        role: 'system',
+        author: 'system',
+        status: 'failed',
+        content: { kind: 'error', message: 'provider failed' },
+      }));
+
+      const events = await runtimeEventStore.readRuntimeEvents('session-1', 'run-1');
+
+      assert.deepEqual(events.map((event) => event.id), [
+        'runtime-user',
+        'runtime-partial',
+        'runtime-terminal',
+      ]);
     });
   });
 

--- a/packages/storage/src/__tests__/agent-run-store.test.ts
+++ b/packages/storage/src/__tests__/agent-run-store.test.ts
@@ -418,6 +418,42 @@ describe('AgentRunStore', () => {
     });
   });
 
+  it('does not merge partial streams across branch lineage', async () => {
+    await withStores(async (runStore, runtimeEventStore) => {
+      await runStore.createRun(makeHeader());
+      await runtimeEventStore.appendRuntimeEvent('session-1', 'run-1', makeRuntimeEvent({
+        id: 'runtime-branch-a',
+        ts: 1,
+        branch: 'agent-a',
+        partial: true,
+        role: 'model',
+        author: 'agent',
+        content: { kind: 'text', text: 'alpha' },
+        refs: { providerEventId: 'message-1' },
+      }));
+      await runtimeEventStore.appendRuntimeEvent('session-1', 'run-1', makeRuntimeEvent({
+        id: 'runtime-branch-b',
+        ts: 2,
+        branch: 'agent-b',
+        partial: true,
+        role: 'model',
+        author: 'agent',
+        content: { kind: 'text', text: 'beta' },
+        refs: { providerEventId: 'message-1' },
+      }));
+
+      const events = await runtimeEventStore.readRuntimeEvents('session-1', 'run-1');
+
+      assert.deepEqual(events.map((event) => ({
+        branch: event.branch,
+        text: event.content?.kind === 'text' ? event.content.text : undefined,
+      })), [
+        { branch: 'agent-a', text: 'alpha' },
+        { branch: 'agent-b', text: 'beta' },
+      ]);
+    });
+  });
+
   it('recovers the accumulated partial snapshot after reopening the store', async () => {
     await withStores(async (runStore, runtimeEventStore, root) => {
       await runStore.createRun(makeHeader());
@@ -466,7 +502,8 @@ describe('AgentRunStore', () => {
 
       assert.equal(events.length, 1);
       assert.equal(events[0]?.content?.kind === 'text' && events[0].content.text.length, 10_000);
-      assert.equal(partialFiles.filter((name) => name.endsWith('.json')).length, 1);
+      assert.equal(partialFiles.filter((name) => name.endsWith('.partial')).length, 1);
+      assert.equal(partialFiles.length, 1);
       const immutableLedger = await readFile(join(
         root,
         'sessions',
@@ -589,8 +626,44 @@ describe('AgentRunStore', () => {
     });
   });
 
+  it('produces equivalent durable replay for differently chunked final output', async () => {
+    const replayFor = async (chunks: readonly string[]) => {
+      let replay: RuntimeEvent[] = [];
+      await withStores(async (runStore, runtimeEventStore) => {
+        await runStore.createRun(makeHeader());
+        for (const [index, text] of chunks.entries()) {
+          await runtimeEventStore.appendRuntimeEvent('session-1', 'run-1', makeRuntimeEvent({
+            id: `runtime-partial-${index}`,
+            ts: index + 1,
+            partial: true,
+            role: 'model',
+            author: 'agent',
+            content: { kind: 'text', text },
+            refs: { providerEventId: 'message-1' },
+          }));
+        }
+        await runtimeEventStore.appendRuntimeEvent('session-1', 'run-1', makeRuntimeEvent({
+          id: 'runtime-final',
+          ts: 10,
+          role: 'model',
+          author: 'agent',
+          content: { kind: 'text', text: 'same final output' },
+          refs: { providerEventId: 'message-1' },
+        }));
+        replay = await runtimeEventStore.readRuntimeEvents('session-1', 'run-1');
+      });
+      return replay;
+    };
+
+    const finelyChunked = await replayFor(['same ', 'final ', 'output']);
+    const coarselyChunked = await replayFor(['same final output']);
+
+    assert.deepEqual(finelyChunked, coarselyChunked);
+    assert.deepEqual(finelyChunked.map((event) => event.id), ['runtime-final']);
+  });
+
   it('ignores a stale partial snapshot when its final event is already durable', async () => {
-    await withStores(async (runStore, runtimeEventStore) => {
+    await withStores(async (runStore, runtimeEventStore, root) => {
       await runStore.createRun(makeHeader());
       await runtimeEventStore.appendRuntimeEvent('session-1', 'run-1', makeRuntimeEvent({
         id: 'runtime-final',
@@ -611,8 +684,20 @@ describe('AgentRunStore', () => {
       }));
 
       const events = await runtimeEventStore.readRuntimeEvents('session-1', 'run-1');
+      const partialFiles = await readdir(join(
+        root,
+        'sessions',
+        'session-1',
+        'runs',
+        'run-1',
+        'runtime-partials',
+      )).catch((error) => {
+        if ((error as NodeJS.ErrnoException).code === 'ENOENT') return [];
+        throw error;
+      });
 
       assert.deepEqual(events.map((event) => event.id), ['runtime-final']);
+      assert.deepEqual(partialFiles, []);
     });
   });
 

--- a/packages/storage/src/agent-run-store.ts
+++ b/packages/storage/src/agent-run-store.ts
@@ -320,34 +320,34 @@ class FileRuntimeEventStore implements RuntimeEventStore {
       await mkdir(this.runDir(sessionId, runId), { recursive: true });
       const partial = partialRuntimeStream(event);
       if (partial) {
-        const metadataPath = this.runtimePartialMetadataPath(sessionId, runId, partial.key);
+        const partialPath = this.runtimePartialPath(sessionId, runId, partial.key);
         try {
-          await readFile(metadataPath, 'utf8');
+          await readFile(partialPath, 'utf8');
         } catch (error) {
           if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
           const immutableEvents = await readRuntimeEventJsonl(
             this.runtimeEventsPath(sessionId, runId),
             runId,
           );
+          if (immutableEvents.some((item) => completedPartialRuntimeStreamKey(item) === partial.key)) {
+            return;
+          }
           const metadata: RuntimePartialSnapshot = {
             version: 1,
             event: partial.snapshot,
             ...(immutableEvents.at(-1)?.id ? { afterEventId: immutableEvents.at(-1)!.id } : {}),
           };
-          await writeAtomic(metadataPath, JSON.stringify(metadata, sanitizeJson) + '\n');
+          await writeAtomic(partialPath, JSON.stringify(metadata, sanitizeJson) + '\n');
         }
         if (partial.text) {
-          await appendFile(this.runtimePartialContentPath(sessionId, runId, partial.key), partial.text, 'utf8');
+          await appendFile(partialPath, partial.text, 'utf8');
         }
         return;
       }
       await appendFile(this.runtimeEventsPath(sessionId, runId), JSON.stringify(event, sanitizeJson) + '\n', 'utf8');
       const completedPartialKey = completedPartialRuntimeStreamKey(event);
       if (completedPartialKey) {
-        await Promise.all([
-          rm(this.runtimePartialMetadataPath(sessionId, runId, completedPartialKey), { force: true }),
-          rm(this.runtimePartialContentPath(sessionId, runId, completedPartialKey), { force: true }),
-        ]).catch(() => {
+        await rm(this.runtimePartialPath(sessionId, runId, completedPartialKey), { force: true }).catch(() => {
           // The immutable final is already durable. Reads suppress any stale snapshot.
         });
       }
@@ -414,12 +414,8 @@ class FileRuntimeEventStore implements RuntimeEventStore {
     return join(this.runDir(sessionId, runId), 'runtime-partials');
   }
 
-  private runtimePartialMetadataPath(sessionId: string, runId: string, key: string): string {
-    return join(this.runtimePartialsDir(sessionId, runId), `${key}.json`);
-  }
-
-  private runtimePartialContentPath(sessionId: string, runId: string, key: string): string {
-    return join(this.runtimePartialsDir(sessionId, runId), `${key}.txt`);
+  private runtimePartialPath(sessionId: string, runId: string, key: string): string {
+    return join(this.runtimePartialsDir(sessionId, runId), `${key}.partial`);
   }
 
   private async readRuntimePartials(sessionId: string, runId: string): Promise<RuntimePartialSnapshot[]> {
@@ -432,24 +428,17 @@ class FileRuntimeEventStore implements RuntimeEventStore {
     }
     const partials: RuntimePartialSnapshot[] = [];
     for (const entry of entries) {
-      if (!entry.isFile() || !entry.name.endsWith('.json')) continue;
-      const key = entry.name.slice(0, -'.json'.length);
+      if (!entry.isFile() || !entry.name.endsWith('.partial')) continue;
+      const key = entry.name.slice(0, -'.partial'.length);
       try {
-        const snapshot = JSON.parse(await readFile(
-          this.runtimePartialMetadataPath(sessionId, runId, key),
-          'utf8',
-        )) as RuntimePartialSnapshot;
+        const stored = await readFile(this.runtimePartialPath(sessionId, runId, key), 'utf8');
+        const headerEnd = stored.indexOf('\n');
+        if (headerEnd < 0) continue;
+        const snapshot = JSON.parse(stored.slice(0, headerEnd)) as RuntimePartialSnapshot;
         if (snapshot.version !== 1 || !snapshot.event?.partial) continue;
         const event = snapshot.event;
         if (event.content?.kind === 'text' || event.content?.kind === 'thinking') {
-          const text = await readFile(
-            this.runtimePartialContentPath(sessionId, runId, key),
-            'utf8',
-          ).catch((error) => {
-            if ((error as NodeJS.ErrnoException).code === 'ENOENT') return '';
-            throw error;
-          });
-          event.content = { ...event.content, text };
+          event.content = { ...event.content, text: stored.slice(headerEnd + 1) };
         }
         partials.push({ ...snapshot, event });
       } catch {
@@ -526,7 +515,7 @@ function partialRuntimeStream(event: RuntimeEvent): {
     identity = `tool:call:${event.refs.toolCallId}`;
   }
   if (!identity) return undefined;
-  const key = runtimePartialStreamKey(identity);
+  const key = runtimePartialStreamKey(identity, event);
   const snapshot = content?.kind === 'text' || content?.kind === 'thinking'
     ? { ...event, content: { ...content, text: '' } }
     : event;
@@ -542,11 +531,20 @@ function completedPartialRuntimeStreamKey(event: RuntimeEvent): string | undefin
   } else if (content?.kind === 'function_response' && event.refs?.toolCallId) {
     identity = `tool:call:${event.refs.toolCallId}`;
   }
-  return identity ? runtimePartialStreamKey(identity) : undefined;
+  return identity ? runtimePartialStreamKey(identity, event) : undefined;
 }
 
-function runtimePartialStreamKey(identity: string): string {
-  return createHash('sha256').update(identity).digest('hex');
+function runtimePartialStreamKey(identity: string, event: RuntimeEvent): string {
+  return createHash('sha256').update(JSON.stringify([
+    identity,
+    event.sessionId,
+    event.invocationId,
+    event.runId,
+    event.turnId,
+    event.branch ?? null,
+    event.role,
+    event.author,
+  ])).digest('hex');
 }
 
 function hasOnlyKeys(value: object, allowed: readonly string[]): boolean {

--- a/packages/storage/src/agent-run-store.ts
+++ b/packages/storage/src/agent-run-store.ts
@@ -1,4 +1,4 @@
-import { randomUUID } from 'node:crypto';
+import { createHash, randomUUID } from 'node:crypto';
 import { appendFile, mkdir, readFile, readdir, rename, rm, writeFile } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
 import { chainWrite } from './write-queue.js';
@@ -14,6 +14,12 @@ import {
 } from '@maka/core';
 
 const SAFE_ID_PATTERN = /^[A-Za-z0-9_-]{1,128}$/;
+
+interface RuntimePartialSnapshot {
+  version: 1;
+  event: RuntimeEvent;
+  afterEventId?: string;
+}
 
 export function createAgentRunStore(workspaceRoot: string): AgentRunStore {
   return new FileAgentRunStore(workspaceRoot);
@@ -312,14 +318,55 @@ class FileRuntimeEventStore implements RuntimeEventStore {
     assertSafeId(runId, 'Invalid run id');
     await this.withQueue(sessionId, runId, async () => {
       await mkdir(this.runDir(sessionId, runId), { recursive: true });
+      const partial = partialRuntimeStream(event);
+      if (partial) {
+        const metadataPath = this.runtimePartialMetadataPath(sessionId, runId, partial.key);
+        try {
+          await readFile(metadataPath, 'utf8');
+        } catch (error) {
+          if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
+          const immutableEvents = await readRuntimeEventJsonl(
+            this.runtimeEventsPath(sessionId, runId),
+            runId,
+          );
+          const metadata: RuntimePartialSnapshot = {
+            version: 1,
+            event: partial.snapshot,
+            ...(immutableEvents.at(-1)?.id ? { afterEventId: immutableEvents.at(-1)!.id } : {}),
+          };
+          await writeAtomic(metadataPath, JSON.stringify(metadata, sanitizeJson) + '\n');
+        }
+        if (partial.text) {
+          await appendFile(this.runtimePartialContentPath(sessionId, runId, partial.key), partial.text, 'utf8');
+        }
+        return;
+      }
       await appendFile(this.runtimeEventsPath(sessionId, runId), JSON.stringify(event, sanitizeJson) + '\n', 'utf8');
+      const completedPartialKey = completedPartialRuntimeStreamKey(event);
+      if (completedPartialKey) {
+        await Promise.all([
+          rm(this.runtimePartialMetadataPath(sessionId, runId, completedPartialKey), { force: true }),
+          rm(this.runtimePartialContentPath(sessionId, runId, completedPartialKey), { force: true }),
+        ]).catch(() => {
+          // The immutable final is already durable. Reads suppress any stale snapshot.
+        });
+      }
     });
   }
 
   async readRuntimeEvents(sessionId: string, runId: string): Promise<RuntimeEvent[]> {
     assertSafeId(sessionId, 'Invalid session id');
     assertSafeId(runId, 'Invalid run id');
-    return readRuntimeEventJsonl(this.runtimeEventsPath(sessionId, runId), runId);
+    const events = await readRuntimeEventJsonl(this.runtimeEventsPath(sessionId, runId), runId);
+    const partials = await this.readRuntimePartials(sessionId, runId);
+    const completedPartialKeys = new Set(
+      events.map(completedPartialRuntimeStreamKey).filter((key): key is string => key !== undefined),
+    );
+    const visiblePartials = partials.filter(({ event }) => {
+      const key = partialRuntimeStream(event)?.key;
+      return !key || !completedPartialKeys.has(key);
+    });
+    return mergeRuntimePartialSnapshots(events, visiblePartials);
   }
 
   async readSessionRuntimeEvents(sessionId: string): Promise<RuntimeEvent[]> {
@@ -363,11 +410,147 @@ class FileRuntimeEventStore implements RuntimeEventStore {
     return join(this.runDir(sessionId, runId), 'runtime-events.jsonl');
   }
 
+  private runtimePartialsDir(sessionId: string, runId: string): string {
+    return join(this.runDir(sessionId, runId), 'runtime-partials');
+  }
+
+  private runtimePartialMetadataPath(sessionId: string, runId: string, key: string): string {
+    return join(this.runtimePartialsDir(sessionId, runId), `${key}.json`);
+  }
+
+  private runtimePartialContentPath(sessionId: string, runId: string, key: string): string {
+    return join(this.runtimePartialsDir(sessionId, runId), `${key}.txt`);
+  }
+
+  private async readRuntimePartials(sessionId: string, runId: string): Promise<RuntimePartialSnapshot[]> {
+    let entries;
+    try {
+      entries = await readdir(this.runtimePartialsDir(sessionId, runId), { withFileTypes: true });
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') return [];
+      throw error;
+    }
+    const partials: RuntimePartialSnapshot[] = [];
+    for (const entry of entries) {
+      if (!entry.isFile() || !entry.name.endsWith('.json')) continue;
+      const key = entry.name.slice(0, -'.json'.length);
+      try {
+        const snapshot = JSON.parse(await readFile(
+          this.runtimePartialMetadataPath(sessionId, runId, key),
+          'utf8',
+        )) as RuntimePartialSnapshot;
+        if (snapshot.version !== 1 || !snapshot.event?.partial) continue;
+        const event = snapshot.event;
+        if (event.content?.kind === 'text' || event.content?.kind === 'thinking') {
+          const text = await readFile(
+            this.runtimePartialContentPath(sessionId, runId, key),
+            'utf8',
+          ).catch((error) => {
+            if ((error as NodeJS.ErrnoException).code === 'ENOENT') return '';
+            throw error;
+          });
+          event.content = { ...event.content, text };
+        }
+        partials.push({ ...snapshot, event });
+      } catch {
+        // A replaceable partial snapshot must never make the immutable ledger unreadable.
+      }
+    }
+    return partials;
+  }
+
   private withQueue(sessionId: string, runId: string, operation: () => Promise<void>): Promise<void> {
     assertSafeId(sessionId, 'Invalid session id');
     assertSafeId(runId, 'Invalid run id');
     return chainWrite(this.writeQueues, `${sessionId}:${runId}`, operation);
   }
+}
+
+function mergeRuntimePartialSnapshots(
+  immutableEvents: readonly RuntimeEvent[],
+  snapshots: readonly RuntimePartialSnapshot[],
+): RuntimeEvent[] {
+  const leading: RuntimePartialSnapshot[] = [];
+  const afterEvent = new Map<string, RuntimePartialSnapshot[]>();
+  for (const snapshot of snapshots) {
+    if (!snapshot.afterEventId) {
+      leading.push(snapshot);
+      continue;
+    }
+    const grouped = afterEvent.get(snapshot.afterEventId) ?? [];
+    grouped.push(snapshot);
+    afterEvent.set(snapshot.afterEventId, grouped);
+  }
+  const order = (a: RuntimePartialSnapshot, b: RuntimePartialSnapshot) =>
+    a.event.ts - b.event.ts || a.event.id.localeCompare(b.event.id);
+  const merged = leading.sort(order).map(({ event }) => event);
+  for (const event of immutableEvents) {
+    merged.push(event);
+    const anchored = afterEvent.get(event.id);
+    if (!anchored) continue;
+    merged.push(...anchored.sort(order).map((snapshot) => snapshot.event));
+    afterEvent.delete(event.id);
+  }
+  for (const orphaned of afterEvent.values()) {
+    merged.push(...orphaned.sort(order).map((snapshot) => snapshot.event));
+  }
+  return merged;
+}
+
+function partialRuntimeStream(event: RuntimeEvent): {
+  key: string;
+  snapshot: RuntimeEvent;
+  text: string;
+} | undefined {
+  if (!event.partial || event.status !== undefined || event.actions) return undefined;
+  const content = event.content;
+  let identity: string | undefined;
+  let text = '';
+  if (
+    content?.kind === 'text'
+    && content.attachments === undefined
+    && event.refs?.providerEventId
+    && hasOnlyKeys(event.refs, ['providerEventId'])
+  ) {
+    identity = `${content.kind}:provider:${event.refs.providerEventId}`;
+    text = content.text;
+  } else if (
+    content?.kind === 'thinking'
+    && content.signature === undefined
+    && event.refs?.providerEventId
+    && hasOnlyKeys(event.refs, ['providerEventId'])
+  ) {
+    identity = `${content.kind}:provider:${event.refs.providerEventId}`;
+    text = content.text;
+  } else if (!content && event.refs?.toolCallId && hasOnlyKeys(event.refs, ['toolCallId'])) {
+    identity = `tool:call:${event.refs.toolCallId}`;
+  }
+  if (!identity) return undefined;
+  const key = runtimePartialStreamKey(identity);
+  const snapshot = content?.kind === 'text' || content?.kind === 'thinking'
+    ? { ...event, content: { ...content, text: '' } }
+    : event;
+  return { key, snapshot, text };
+}
+
+function completedPartialRuntimeStreamKey(event: RuntimeEvent): string | undefined {
+  if (event.partial) return undefined;
+  const content = event.content;
+  let identity: string | undefined;
+  if ((content?.kind === 'text' || content?.kind === 'thinking') && event.refs?.providerEventId) {
+    identity = `${content.kind}:provider:${event.refs.providerEventId}`;
+  } else if (content?.kind === 'function_response' && event.refs?.toolCallId) {
+    identity = `tool:call:${event.refs.toolCallId}`;
+  }
+  return identity ? runtimePartialStreamKey(identity) : undefined;
+}
+
+function runtimePartialStreamKey(identity: string): string {
+  return createHash('sha256').update(identity).digest('hex');
+}
+
+function hasOnlyKeys(value: object, allowed: readonly string[]): boolean {
+  return Object.keys(value).every((key) => allowed.includes(key));
 }
 
 async function readRuntimeEventJsonl(path: string, runId: string): Promise<RuntimeEvent[]> {


### PR DESCRIPTION
## Summary

- Coalesce safe partial streaming events at the durable storage boundary.
- Persist one recoverable partial sidecar per logical stream instead of one ledger row per provider chunk.
- Preserve final output, tool lifecycle, lineage, usage, permission, error, and terminal facts unchanged.

## Why

Provider chunk granularity should not determine durable ledger size. Large streamed turns currently increase write volume, recovery cost, and replay work without adding durable information.

Closes #727

## Scope

Changed:

- Added bounded durable handling for safe text, thinking, and tool-output partial streams.
- Included session, invocation, run, turn, branch, role, author, provider, and tool identity in stream isolation.
- Added recovery, reopen, stale partial, lineage, and chunk-equivalence coverage.

Not included:

- Renderer streaming cadence changes
- History compact checkpoint changes
- Legacy artifact cleanup
- Provider request shaping

## Verification

- `npm run -w @maka/storage test` (223 passed)
- `npm run -w @maka/runtime test` (1267 passed, 2 environment-dependent tests skipped)
- `npm run typecheck`

## User-facing impact

No UI or migration changes. Stream-heavy sessions use fewer durable writes and less ledger storage while retaining recoverable partial output.

## Reviewer notes

The sidecar contains JSON stream metadata followed by append-only raw text. The final durable event is written before sidecar cleanup, and an existing final event suppresses stale partial recovery.

## Checklist

- [x] Scope matches the linked issue and its non-goals
- [x] Tests cover the changed behavior and failure boundaries
- [x] Typecheck passes
- [x] No secrets, migrations, or breaking API changes
- [x] Screenshots are not applicable
