### PR TITLE
chore(storage): clean superseded history compact artifacts

### DIFF
--- a/apps/desktop/src/main/__tests__/history-compact-artifacts.test.ts
+++ b/apps/desktop/src/main/__tests__/history-compact-artifacts.test.ts
@@ -1,4 +1,5 @@
 import assert from 'node:assert/strict';
+import { Buffer } from 'node:buffer';
 import { createHash } from 'node:crypto';
 import { mkdtemp, readFile, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
@@ -8,7 +9,6 @@ import type { RuntimeEvent } from '@maka/core/runtime-event';
 import {
   applyRuntimeEventHistoryCompact,
   buildHistoryCompactBlockFromSummary,
-  buildHistoryCompactCheckpoint,
   cleanupLegacyHistoryCompactArtifacts,
   type HistoryCompactBlock,
   type HistoryCompactWriteInput,
@@ -96,11 +96,7 @@ describe('desktop history compact artifact lifecycle', () => {
         },
       });
       const records = await store.list('session-1', { includeDeleted: true });
-      const checkpoint = buildHistoryCompactCheckpoint({
-        sessionId: 'session-1',
-        coveredRuntimeEvents: foldedEvents,
-        summary: 'V2 continuation summary',
-      });
+      const checkpoint = historyCompactCheckpoint(foldedEvents);
 
       const result = await cleanupLegacyHistoryCompactArtifacts({
         sessionId: 'session-1',
@@ -522,6 +518,51 @@ function historyCompactBlock(
     }),
     ...overrides,
   };
+}
+
+function historyCompactCheckpoint(events: readonly RuntimeEvent[]) {
+  const digest = createHash('sha256');
+  for (const event of events) {
+    const serialized = stableStringify(event);
+    digest.update(String(Buffer.byteLength(serialized, 'utf8')));
+    digest.update(':');
+    digest.update(serialized);
+    digest.update(';');
+  }
+  const lastEvent = events.at(-1)!;
+  return {
+    kind: 'maka.history_compact_checkpoint' as const,
+    version: 2 as const,
+    checkpointId: 'hcheckpoint-desktop-fixture',
+    sessionId: 'session-1',
+    createdAt: 1_800_000_000_000,
+    highWaterName: 'test-history-compact',
+    highWaterSeq: 1,
+    coverage: {
+      eventCount: events.length,
+      turnCount: new Set(events.map((event) => event.turnId)).size,
+      through: {
+        runId: lastEvent.runId,
+        turnId: lastEvent.turnId,
+        runtimeEventId: lastEvent.id,
+      },
+      sourceDigest: `sha256:${digest.digest('hex')}`,
+    },
+    summary: 'V2 continuation summary',
+    limitations: ['fixture'],
+    estimatedTokens: 1,
+  };
+}
+
+function stableStringify(value: unknown): string {
+  if (Array.isArray(value)) return `[${value.map(stableStringify).join(',')}]`;
+  if (value && typeof value === 'object') {
+    return `{${Object.entries(value)
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([key, item]) => `${JSON.stringify(key)}:${stableStringify(item)}`)
+      .join(',')}}`;
+  }
+  return JSON.stringify(value) ?? 'null';
 }
 
 function sha256(text: string): string {

--- a/apps/desktop/src/main/__tests__/history-compact-artifacts.test.ts
+++ b/apps/desktop/src/main/__tests__/history-compact-artifacts.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import { createHash } from 'node:crypto';
-import { mkdtemp, rm } from 'node:fs/promises';
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, test } from 'node:test';
@@ -8,6 +8,8 @@ import type { RuntimeEvent } from '@maka/core/runtime-event';
 import {
   applyRuntimeEventHistoryCompact,
   buildHistoryCompactBlockFromSummary,
+  buildHistoryCompactCheckpoint,
+  cleanupLegacyHistoryCompactArtifacts,
   type HistoryCompactBlock,
   type HistoryCompactWriteInput,
 } from '@maka/runtime';
@@ -70,6 +72,53 @@ describe('desktop history compact artifact lifecycle', () => {
       assert.equal(loaded.blocks.length, 1);
       assert.equal(loaded.blocks[0]?.blockId, write.blocks[0]?.blockId);
       assert.equal(loaded.skipped, undefined);
+    });
+  });
+
+  test('physically purges verified V1 files and metadata after V2 supersedes them', async () => {
+    await withStore(async (store, workspaceRoot) => {
+      const foldedEvents = [
+        textEvent('old-1', 'turn-1', 'alpha fact'),
+        textEvent('old-2', 'turn-2', 'beta fact'),
+      ];
+      await persistHistoryCompactBlocksToArtifacts(store, {
+        sessionId: 'session-1',
+        turnId: 'turn-write',
+        source: {
+          draftBlock: historyCompactBlock(foldedEvents, 'legacy summary'),
+          foldedRuntimeEvents: foldedEvents,
+        },
+        limits: {
+          maxBlocks: 1,
+          maxBlockEstimatedTokens: 1_024,
+          maxEstimatedTokens: 2_048,
+          charsPerToken: 4,
+        },
+      });
+      const records = await store.list('session-1', { includeDeleted: true });
+      const checkpoint = buildHistoryCompactCheckpoint({
+        sessionId: 'session-1',
+        coveredRuntimeEvents: foldedEvents,
+        summary: 'V2 continuation summary',
+      });
+
+      const result = await cleanupLegacyHistoryCompactArtifacts({
+        sessionId: 'session-1',
+        checkpoint,
+        runtimeEvents: foldedEvents,
+        artifactStore: store,
+      });
+
+      assert.equal(result.purgedArtifactIds.length, 3);
+      assert.deepEqual(await store.list('session-1', { includeDeleted: true }), []);
+      for (const record of records) {
+        await assert.rejects(
+          () => readFile(join(workspaceRoot, 'artifacts', record.relativePath), 'utf8'),
+          { code: 'ENOENT' },
+        );
+      }
+      const metadata = await readFile(join(workspaceRoot, 'artifacts', 'metadata.jsonl'), 'utf8');
+      assert.equal(metadata, '');
     });
   });
 
@@ -423,10 +472,12 @@ describe('desktop history compact artifact lifecycle', () => {
   });
 });
 
-async function withStore(fn: (store: ArtifactStore) => Promise<void>): Promise<void> {
+async function withStore(
+  fn: (store: ArtifactStore, workspaceRoot: string) => Promise<void>,
+): Promise<void> {
   const workspaceRoot = await mkdtemp(join(tmpdir(), 'maka-history-compact-artifacts-'));
   try {
-    await fn(createArtifactStore(workspaceRoot));
+    await fn(createArtifactStore(workspaceRoot), workspaceRoot);
   } finally {
     await rm(workspaceRoot, { recursive: true, force: true });
   }

--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -160,6 +160,7 @@ import { buildExploreAgentTool } from './explore-agent-tool.js';
 import { buildOfficeDocumentEditTool, buildOfficeDocumentTool } from './office-document-tool.js';
 import {
   buildLlmHistorySummarizer,
+  cleanupLegacyHistoryCompactArtifacts,
   loadHistoryCompactBlocksFromArtifacts,
 } from '@maka/runtime';
 import {
@@ -857,6 +858,9 @@ const runtime = new SessionManager({
     (await artifactStore.list(sessionId)).filter((artifact) =>
       artifact.turnId === turnId && artifact.status !== 'deleted'
     ),
+  cleanupHistoryCompactArtifacts: async (input) => {
+    await cleanupLegacyHistoryCompactArtifacts({ ...input, artifactStore });
+  },
   newId: randomUUID,
   now: Date.now,
 });

--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -859,7 +859,11 @@ const runtime = new SessionManager({
       artifact.turnId === turnId && artifact.status !== 'deleted'
     ),
   cleanupHistoryCompactArtifacts: async (input) => {
-    await cleanupLegacyHistoryCompactArtifacts({ ...input, artifactStore });
+    await cleanupLegacyHistoryCompactArtifacts({
+      ...input,
+      artifactStore,
+      onDiagnostic: (diagnostic) => console.warn('[history-compact-cleanup]', diagnostic),
+    });
   },
   newId: randomUUID,
   now: Date.now,

--- a/packages/cli/src/runtime-bootstrap.ts
+++ b/packages/cli/src/runtime-bootstrap.ts
@@ -239,7 +239,11 @@ export async function createMakaCliRuntimeContext(
     shellRuns,
     backends,
     cleanupHistoryCompactArtifacts: async (cleanupInput) => {
-      await cleanupLegacyHistoryCompactArtifacts({ ...cleanupInput, artifactStore });
+      await cleanupLegacyHistoryCompactArtifacts({
+        ...cleanupInput,
+        artifactStore,
+        onDiagnostic: (diagnostic) => console.warn('[history-compact-cleanup]', diagnostic),
+      });
     },
     newId: randomUUID,
     now: Date.now,

--- a/packages/cli/src/runtime-bootstrap.ts
+++ b/packages/cli/src/runtime-bootstrap.ts
@@ -15,6 +15,7 @@ import {
   buildDefaultContextBudgetPolicy,
   buildGoalTools,
   buildLlmHistorySummarizer,
+  cleanupLegacyHistoryCompactArtifacts,
   buildProviderOptions,
   buildSubscriptionModelFetch,
   evaluateAutomationCanFire,
@@ -237,6 +238,9 @@ export async function createMakaCliRuntimeContext(
     runtimeEventStore,
     shellRuns,
     backends,
+    cleanupHistoryCompactArtifacts: async (cleanupInput) => {
+      await cleanupLegacyHistoryCompactArtifacts({ ...cleanupInput, artifactStore });
+    },
     newId: randomUUID,
     now: Date.now,
   });

--- a/packages/runtime/src/__tests__/history-compact-cleanup.test.ts
+++ b/packages/runtime/src/__tests__/history-compact-cleanup.test.ts
@@ -129,18 +129,29 @@ describe('legacy history compact cleanup', () => {
       coveredRuntimeEvents: runtimeEvents,
       summary: 'valid V2 checkpoint',
     });
-
-    const result = await cleanupLegacyHistoryCompactArtifacts({
+    const diagnostics: unknown[] = [];
+    const cleanupInput = {
       sessionId: 'session-1',
       checkpoint,
       runtimeEvents,
       artifactStore: store,
-    });
+      onDiagnostic: (diagnostic: unknown) => diagnostics.push(diagnostic),
+    };
+
+    const result = await cleanupLegacyHistoryCompactArtifacts(cleanupInput);
 
     assert.deepEqual(result.purgedArtifactIds, []);
     assert.equal(result.skipped.find((item) => item.artifactId === block.id)?.reason, 'block_invalid_json');
     assert.equal(result.skipped.filter((item) => item.reason === 'source_unlinked').length, 3);
     assert.equal((await store.list('session-1', { includeDeleted: true })).length, 4);
+    assert.deepEqual(diagnostics, [{
+      kind: 'skipped',
+      artifactCount: 4,
+      reasonCounts: {
+        block_invalid_json: 1,
+        source_unlinked: 3,
+      },
+    }]);
   });
 
   test('preserves a V1 group when a linked source no longer matches the canonical event', async () => {
@@ -205,6 +216,37 @@ describe('legacy history compact cleanup', () => {
     assert.equal(first.purgedArtifactIds.length, 4);
     assert.deepEqual(first.skipped, []);
     assert.deepEqual(repeated, { purgedArtifactIds: [], skipped: [] });
+  });
+
+  test('reports one cleanup failure without changing the thrown error', async () => {
+    const store = memoryArtifactStore();
+    const runtimeEvents = [textEvent(0)];
+    const checkpoint = buildHistoryCompactCheckpoint({
+      sessionId: 'session-1',
+      coveredRuntimeEvents: runtimeEvents,
+      summary: 'valid V2 checkpoint',
+    });
+    const diagnostics: unknown[] = [];
+
+    await assert.rejects(
+      () => cleanupLegacyHistoryCompactArtifacts({
+        sessionId: 'session-1',
+        checkpoint,
+        runtimeEvents,
+        artifactStore: {
+          ...store,
+          async list() {
+            throw new Error('metadata unreadable');
+          },
+        },
+        onDiagnostic: (diagnostic) => diagnostics.push(diagnostic),
+      }),
+      /metadata unreadable/,
+    );
+    assert.deepEqual(diagnostics, [{
+      kind: 'failed',
+      message: 'metadata unreadable',
+    }]);
   });
 });
 

--- a/packages/runtime/src/__tests__/history-compact-cleanup.test.ts
+++ b/packages/runtime/src/__tests__/history-compact-cleanup.test.ts
@@ -1,0 +1,248 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+import type { RuntimeEvent } from '@maka/core/runtime-event';
+import { buildHistoryCompactBlockFromSummary } from '../context-budget.js';
+import { cleanupLegacyHistoryCompactArtifacts } from '../history-compact-cleanup.js';
+import { persistHistoryCompactBlocksToArtifacts } from '../history-compact-artifacts.js';
+import { buildHistoryCompactCheckpoint } from '../history-compact-checkpoint.js';
+import { memoryArtifactStore } from './memory-artifact-store.js';
+
+describe('legacy history compact cleanup', () => {
+  test('purges a verified V1 block and its sources after a later V2 checkpoint', async () => {
+    const store = memoryArtifactStore();
+    const legacyEvents = [textEvent(0), textEvent(1), textEvent(2)];
+    await writeLegacyArtifacts(store, legacyEvents);
+    const runtimeEvents = [...legacyEvents, textEvent(3)];
+    const checkpoint = buildHistoryCompactCheckpoint({
+      sessionId: 'session-1',
+      coveredRuntimeEvents: runtimeEvents,
+      summary: 'V2 covers the legacy prefix.',
+    });
+
+    const result = await cleanupLegacyHistoryCompactArtifacts({
+      sessionId: 'session-1',
+      checkpoint,
+      runtimeEvents,
+      artifactStore: store,
+    });
+
+    assert.equal(result.purgedArtifactIds.length, 4);
+    assert.deepEqual(result.skipped, []);
+    assert.deepEqual(await store.list('session-1', { includeDeleted: true }), []);
+  });
+
+  test('ignores non-compactable ledger facts when validating V2 coverage', async () => {
+    const store = memoryArtifactStore();
+    const compactableEvents = [textEvent(0), textEvent(1), textEvent(2)];
+    await writeLegacyArtifacts(store, compactableEvents);
+    const heartbeat: RuntimeEvent = {
+      ...textEvent(99),
+      id: 'tool-heartbeat',
+      partial: true,
+      role: 'tool',
+      author: 'tool',
+      content: undefined,
+      refs: { toolCallId: 'tool-call-1' },
+    };
+    const runtimeEvents = [compactableEvents[0]!, heartbeat, ...compactableEvents.slice(1)];
+    const checkpoint = buildHistoryCompactCheckpoint({
+      sessionId: 'session-1',
+      coveredRuntimeEvents: compactableEvents,
+      summary: 'V2 compactable prefix',
+    });
+
+    const result = await cleanupLegacyHistoryCompactArtifacts({
+      sessionId: 'session-1',
+      checkpoint,
+      runtimeEvents,
+      artifactStore: store,
+    });
+
+    assert.equal(result.purgedArtifactIds.length, 4);
+    assert.deepEqual(result.skipped, []);
+  });
+
+  test('preserves every legacy artifact when the V2 checkpoint no longer matches the ledger', async () => {
+    const store = memoryArtifactStore();
+    const runtimeEvents = [textEvent(0), textEvent(1), textEvent(2)];
+    await writeLegacyArtifacts(store, runtimeEvents);
+    const checkpoint = buildHistoryCompactCheckpoint({
+      sessionId: 'session-1',
+      coveredRuntimeEvents: runtimeEvents,
+      summary: 'checkpoint before corruption',
+    });
+    const changedEvents = [...runtimeEvents];
+    changedEvents[1] = { ...changedEvents[1]!, content: { kind: 'text', text: 'changed' } };
+
+    const result = await cleanupLegacyHistoryCompactArtifacts({
+      sessionId: 'session-1',
+      checkpoint,
+      runtimeEvents: changedEvents,
+      artifactStore: store,
+    });
+
+    assert.deepEqual(result.purgedArtifactIds, []);
+    assert.equal(result.skipped.length, 4);
+    assert.ok(result.skipped.every((item) => item.reason === 'checkpoint_source_hash_mismatch'));
+    assert.equal((await store.list('session-1', { includeDeleted: true })).length, 4);
+  });
+
+  test('preserves V1 data that extends beyond the valid V2 checkpoint prefix', async () => {
+    const store = memoryArtifactStore();
+    const runtimeEvents = [textEvent(0), textEvent(1), textEvent(2)];
+    await writeLegacyArtifacts(store, runtimeEvents);
+    const checkpoint = buildHistoryCompactCheckpoint({
+      sessionId: 'session-1',
+      coveredRuntimeEvents: runtimeEvents.slice(0, 2),
+      summary: 'shorter V2 checkpoint',
+    });
+
+    const result = await cleanupLegacyHistoryCompactArtifacts({
+      sessionId: 'session-1',
+      checkpoint,
+      runtimeEvents,
+      artifactStore: store,
+    });
+
+    assert.deepEqual(result.purgedArtifactIds, []);
+    assert.ok(result.skipped.some((item) => item.reason === 'block_coverage_mismatch'));
+    assert.equal((await store.list('session-1', { includeDeleted: true })).length, 4);
+  });
+
+  test('preserves a corrupt V1 block and its unverified source artifacts', async () => {
+    const store = memoryArtifactStore();
+    const runtimeEvents = [textEvent(0), textEvent(1), textEvent(2)];
+    await writeLegacyArtifacts(store, runtimeEvents);
+    const records = await store.list('session-1', { includeDeleted: true });
+    const block = records.find((record) => record.source === 'history_compact_block')!;
+    await store.create({
+      id: block.id,
+      sessionId: block.sessionId,
+      turnId: block.turnId,
+      name: block.name,
+      kind: 'file',
+      content: '{invalid json',
+      source: 'history_compact_block',
+    });
+    const checkpoint = buildHistoryCompactCheckpoint({
+      sessionId: 'session-1',
+      coveredRuntimeEvents: runtimeEvents,
+      summary: 'valid V2 checkpoint',
+    });
+
+    const result = await cleanupLegacyHistoryCompactArtifacts({
+      sessionId: 'session-1',
+      checkpoint,
+      runtimeEvents,
+      artifactStore: store,
+    });
+
+    assert.deepEqual(result.purgedArtifactIds, []);
+    assert.equal(result.skipped.find((item) => item.artifactId === block.id)?.reason, 'block_invalid_json');
+    assert.equal(result.skipped.filter((item) => item.reason === 'source_unlinked').length, 3);
+    assert.equal((await store.list('session-1', { includeDeleted: true })).length, 4);
+  });
+
+  test('preserves a V1 group when a linked source no longer matches the canonical event', async () => {
+    const store = memoryArtifactStore();
+    const runtimeEvents = [textEvent(0), textEvent(1), textEvent(2)];
+    await writeLegacyArtifacts(store, runtimeEvents);
+    const source = (await store.list('session-1', { includeDeleted: true }))
+      .find((record) => record.source === 'history_compact_source')!;
+    await store.create({
+      id: source.id,
+      sessionId: source.sessionId,
+      turnId: source.turnId,
+      name: source.name,
+      kind: 'file',
+      content: JSON.stringify({ ...runtimeEvents[0], content: { kind: 'text', text: 'tampered' } }),
+      source: 'history_compact_source',
+    });
+    const checkpoint = buildHistoryCompactCheckpoint({
+      sessionId: 'session-1',
+      coveredRuntimeEvents: runtimeEvents,
+      summary: 'valid V2 checkpoint',
+    });
+
+    const result = await cleanupLegacyHistoryCompactArtifacts({
+      sessionId: 'session-1',
+      checkpoint,
+      runtimeEvents,
+      artifactStore: store,
+    });
+
+    assert.deepEqual(result.purgedArtifactIds, []);
+    assert.ok(result.skipped.some((item) => item.reason === 'source_content_mismatch'));
+    assert.equal((await store.list('session-1', { includeDeleted: true })).length, 4);
+  });
+
+  test('purges a safely linked group after one source was soft deleted', async () => {
+    const store = memoryArtifactStore();
+    const runtimeEvents = [textEvent(0), textEvent(1), textEvent(2)];
+    await writeLegacyArtifacts(store, runtimeEvents);
+    const source = (await store.list('session-1', { includeDeleted: true }))
+      .find((record) => record.source === 'history_compact_source')!;
+    await store.delete(source.id);
+    const checkpoint = buildHistoryCompactCheckpoint({
+      sessionId: 'session-1',
+      coveredRuntimeEvents: runtimeEvents,
+      summary: 'valid V2 checkpoint',
+    });
+
+    const first = await cleanupLegacyHistoryCompactArtifacts({
+      sessionId: 'session-1',
+      checkpoint,
+      runtimeEvents,
+      artifactStore: store,
+    });
+    const repeated = await cleanupLegacyHistoryCompactArtifacts({
+      sessionId: 'session-1',
+      checkpoint,
+      runtimeEvents,
+      artifactStore: store,
+    });
+
+    assert.equal(first.purgedArtifactIds.length, 4);
+    assert.deepEqual(first.skipped, []);
+    assert.deepEqual(repeated, { purgedArtifactIds: [], skipped: [] });
+  });
+});
+
+async function writeLegacyArtifacts(
+  store: ReturnType<typeof memoryArtifactStore>,
+  events: readonly RuntimeEvent[],
+): Promise<void> {
+  await persistHistoryCompactBlocksToArtifacts(store, {
+    sessionId: 'session-1',
+    turnId: 'turn-write',
+    source: {
+      draftBlock: buildHistoryCompactBlockFromSummary({
+        sessionId: 'session-1',
+        foldedRuntimeEvents: events,
+        summary: 'legacy summary',
+      }),
+      foldedRuntimeEvents: [...events],
+    },
+    limits: {
+      maxBlocks: 1,
+      maxBlockEstimatedTokens: 1_024,
+      maxEstimatedTokens: 2_048,
+      charsPerToken: 4,
+    },
+  });
+}
+
+function textEvent(index: number): RuntimeEvent {
+  return {
+    id: `event-${index}`,
+    invocationId: `invocation-${index}`,
+    runId: `run-${index}`,
+    sessionId: 'session-1',
+    turnId: `turn-${index}`,
+    ts: index + 1,
+    partial: false,
+    role: 'user',
+    author: 'user',
+    content: { kind: 'text', text: `fact ${index}` },
+  };
+}

--- a/packages/runtime/src/__tests__/memory-artifact-store.ts
+++ b/packages/runtime/src/__tests__/memory-artifact-store.ts
@@ -30,6 +30,9 @@ export function memoryArtifactStore(): HistoryCompactArtifactStore {
       const entry = records.get(artifactId);
       if (entry) entry.record.status = 'deleted';
     },
+    async purge(artifactIds) {
+      for (const artifactId of artifactIds) records.delete(artifactId);
+    },
     async list() {
       return [...records.values()].map((entry) => entry.record);
     },

--- a/packages/runtime/src/__tests__/session-manager.test.ts
+++ b/packages/runtime/src/__tests__/session-manager.test.ts
@@ -3958,6 +3958,49 @@ describe('SessionManager permission mode updates', () => {
     expect(checkpoint?.summary).toBe('persist the bounded checkpoint');
   });
 
+  test('schedules legacy artifact cleanup only after the V2 checkpoint is durable', async () => {
+    const store = new MemorySessionStore();
+    const runStore = new MemoryAgentRunStore();
+    const cleanupCalled = makeGate();
+    let observed: {
+      checkpointId: string;
+      runtimeEventCount: number;
+      checkpointWasDurable: boolean;
+    } | undefined;
+    const backends = new BackendRegistry();
+    backends.register('fake', (ctx) => new HistoryCompactCheckpointBackend(ctx));
+    const manager = new SessionManager({
+      store,
+      runStore,
+      runtimeEventStore: runStore,
+      backends,
+      cleanupHistoryCompactArtifacts: async (input) => {
+        const runs = await runStore.listSessionRuns(input.sessionId);
+        const operationalEvents = await Promise.all(
+          runs.map((run) => runStore.readEvents(input.sessionId, run.runId)),
+        );
+        observed = {
+          checkpointId: input.checkpoint.checkpointId,
+          runtimeEventCount: input.runtimeEvents.length,
+          checkpointWasDurable: operationalEvents.flat().some(
+            (event) => event.type === 'history_compact_checkpoint_recorded',
+          ),
+        };
+        cleanupCalled.release();
+      },
+      newId: nextId(),
+      now: nextNow(12_792),
+    });
+    const session = await manager.createSession(makeInput());
+
+    await drain(manager.sendMessage(session.id, { turnId: 'turn-1', text: 'hello' }));
+    await cleanupCalled.promise;
+
+    expect(observed?.checkpointId).toBe('hcheckpoint-test');
+    expect((observed?.runtimeEventCount ?? 0) > 0).toBe(true);
+    expect(observed?.checkpointWasDurable).toBe(true);
+  });
+
   test('shares the latest history compact checkpoint across disposable child backends', async () => {
     const store = new MemorySessionStore();
     const runStore = new MemoryAgentRunStore();

--- a/packages/runtime/src/history-compact-artifacts.ts
+++ b/packages/runtime/src/history-compact-artifacts.ts
@@ -31,8 +31,9 @@ export interface HistoryCompactArtifactStore {
     now?: number;
   }): Promise<ArtifactRecord>;
   delete(artifactId: string): Promise<void>;
+  purge(artifactIds: readonly string[]): Promise<void>;
   list(sessionId: string, options?: { includeDeleted?: boolean }): Promise<ArtifactRecord[]>;
-  readText(artifactId: string, options?: { maxBytes?: number }): Promise<{ ok: true; text: string } | { ok: false; reason: string }>;
+  readText(artifactId: string, options?: { maxBytes?: number; includeDeleted?: boolean }): Promise<{ ok: true; text: string } | { ok: false; reason: string }>;
 }
 
 export interface PersistHistoryCompactBlocksDeps {

--- a/packages/runtime/src/history-compact-cleanup.ts
+++ b/packages/runtime/src/history-compact-cleanup.ts
@@ -25,12 +25,42 @@ export interface HistoryCompactCleanupResult {
   skipped: HistoryCompactCleanupSkip[];
 }
 
-export async function cleanupLegacyHistoryCompactArtifacts(input: {
+export type HistoryCompactCleanupDiagnostic =
+  | {
+      kind: 'skipped';
+      artifactCount: number;
+      reasonCounts: Record<string, number>;
+    }
+  | {
+      kind: 'failed';
+      message: string;
+    };
+
+interface HistoryCompactCleanupInput {
   sessionId: string;
   checkpoint: HistoryCompactCheckpoint;
   runtimeEvents: readonly RuntimeEvent[];
   artifactStore: Pick<HistoryCompactArtifactStore, 'list' | 'readText' | 'purge'>;
-}): Promise<HistoryCompactCleanupResult> {
+  onDiagnostic?: (diagnostic: HistoryCompactCleanupDiagnostic) => void;
+}
+
+export async function cleanupLegacyHistoryCompactArtifacts(
+  input: HistoryCompactCleanupInput,
+): Promise<HistoryCompactCleanupResult> {
+  try {
+    return await runLegacyHistoryCompactCleanup(input);
+  } catch (error) {
+    emitDiagnostic(input.onDiagnostic, {
+      kind: 'failed',
+      message: error instanceof Error ? error.message : String(error),
+    });
+    throw error;
+  }
+}
+
+async function runLegacyHistoryCompactCleanup(
+  input: HistoryCompactCleanupInput,
+): Promise<HistoryCompactCleanupResult> {
   const records = (await input.artifactStore.list(input.sessionId, { includeDeleted: true }))
     .filter((record) =>
       record.source === 'history_compact_block' || record.source === 'history_compact_source');
@@ -38,13 +68,13 @@ export async function cleanupLegacyHistoryCompactArtifacts(input: {
     estimateRuntimeEventsTokens([event], 4) > 0);
   const checkpointMatch = matchHistoryCompactCheckpointPrefix(input.checkpoint, compactableEvents);
   if (checkpointMatch.reason) {
-    return {
+    return reportCleanupResult(input.onDiagnostic, {
       purgedArtifactIds: [],
       skipped: records.map((record) => ({
         artifactId: record.id,
         reason: `checkpoint_${checkpointMatch.reason}`,
       })),
-    };
+    });
   }
 
   const recordsById = new Map(records.map((record) => [record.id, record] as const));
@@ -102,7 +132,7 @@ export async function cleanupLegacyHistoryCompactArtifacts(input: {
   }
   const purgedArtifactIds = [...eligibleIds].sort();
   if (purgedArtifactIds.length > 0) await input.artifactStore.purge(purgedArtifactIds);
-  return {
+  return reportCleanupResult(input.onDiagnostic, {
     purgedArtifactIds,
     skipped: records
       .filter((record) => !eligibleIds.has(record.id))
@@ -111,7 +141,35 @@ export async function cleanupLegacyHistoryCompactArtifacts(input: {
         reason: skipReasons.get(record.id) ?? 'unverified',
       }))
       .sort((a, b) => a.artifactId.localeCompare(b.artifactId)),
-  };
+  });
+}
+
+function reportCleanupResult(
+  onDiagnostic: ((diagnostic: HistoryCompactCleanupDiagnostic) => void) | undefined,
+  result: HistoryCompactCleanupResult,
+): HistoryCompactCleanupResult {
+  if (result.skipped.length === 0) return result;
+  const reasonCounts: Record<string, number> = {};
+  for (const item of result.skipped) {
+    reasonCounts[item.reason] = (reasonCounts[item.reason] ?? 0) + 1;
+  }
+  emitDiagnostic(onDiagnostic, {
+    kind: 'skipped',
+    artifactCount: result.skipped.length,
+    reasonCounts,
+  });
+  return result;
+}
+
+function emitDiagnostic(
+  onDiagnostic: ((diagnostic: HistoryCompactCleanupDiagnostic) => void) | undefined,
+  diagnostic: HistoryCompactCleanupDiagnostic,
+): void {
+  try {
+    onDiagnostic?.(diagnostic);
+  } catch {
+    // Reclaim diagnostics must not change cleanup or replay behavior.
+  }
 }
 
 function matchLegacyBlockPrefix(

--- a/packages/runtime/src/history-compact-cleanup.ts
+++ b/packages/runtime/src/history-compact-cleanup.ts
@@ -1,0 +1,239 @@
+import { Buffer } from 'node:buffer';
+import { createHash } from 'node:crypto';
+import type { ArtifactRecord } from '@maka/core';
+import type { RuntimeEvent } from '@maka/core/runtime-event';
+import {
+  estimateRuntimeEventsTokens,
+  validateHistoryCompactBlockShape,
+  type HistoryCompactBlock,
+  type HistoryCompactSourceArchiveRef,
+} from './context-budget.js';
+import type { HistoryCompactArtifactStore } from './history-compact-artifacts.js';
+import {
+  matchHistoryCompactCheckpointPrefix,
+  type HistoryCompactCheckpoint,
+} from './history-compact-checkpoint.js';
+import { stableStringify } from './request-shape.js';
+
+export interface HistoryCompactCleanupSkip {
+  artifactId: string;
+  reason: string;
+}
+
+export interface HistoryCompactCleanupResult {
+  purgedArtifactIds: string[];
+  skipped: HistoryCompactCleanupSkip[];
+}
+
+export async function cleanupLegacyHistoryCompactArtifacts(input: {
+  sessionId: string;
+  checkpoint: HistoryCompactCheckpoint;
+  runtimeEvents: readonly RuntimeEvent[];
+  artifactStore: Pick<HistoryCompactArtifactStore, 'list' | 'readText' | 'purge'>;
+}): Promise<HistoryCompactCleanupResult> {
+  const records = (await input.artifactStore.list(input.sessionId, { includeDeleted: true }))
+    .filter((record) =>
+      record.source === 'history_compact_block' || record.source === 'history_compact_source');
+  const compactableEvents = input.runtimeEvents.filter((event) =>
+    estimateRuntimeEventsTokens([event], 4) > 0);
+  const checkpointMatch = matchHistoryCompactCheckpointPrefix(input.checkpoint, compactableEvents);
+  if (checkpointMatch.reason) {
+    return {
+      purgedArtifactIds: [],
+      skipped: records.map((record) => ({
+        artifactId: record.id,
+        reason: `checkpoint_${checkpointMatch.reason}`,
+      })),
+    };
+  }
+
+  const recordsById = new Map(records.map((record) => [record.id, record] as const));
+  const eligibleIds = new Set<string>();
+  const skipReasons = new Map<string, string>();
+  for (const blockRecord of records.filter((record) => record.source === 'history_compact_block')) {
+    const read = await input.artifactStore.readText(blockRecord.id, {
+      maxBytes: blockRecord.sizeBytes,
+      includeDeleted: true,
+    });
+    if (!read.ok) {
+      skipReasons.set(blockRecord.id, `block_${read.reason}`);
+      continue;
+    }
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(read.text) as unknown;
+    } catch {
+      skipReasons.set(blockRecord.id, 'block_invalid_json');
+      continue;
+    }
+    if (!validateHistoryCompactBlockShape(parsed, input.sessionId)) {
+      skipReasons.set(blockRecord.id, 'block_invalid_schema');
+      continue;
+    }
+    const coveredEvents = matchLegacyBlockPrefix(parsed, checkpointMatch.coveredRuntimeEvents);
+    if (!coveredEvents) {
+      skipReasons.set(blockRecord.id, 'block_coverage_mismatch');
+      continue;
+    }
+    const group = await validateLinkedSourceArtifacts({
+      block: parsed,
+      coveredEvents,
+      recordsById,
+      artifactStore: input.artifactStore,
+    });
+    if (!group.ok) {
+      skipReasons.set(blockRecord.id, group.reason);
+      for (const artifactId of group.linkedArtifactIds) {
+        if (!skipReasons.has(artifactId)) skipReasons.set(artifactId, group.reason);
+      }
+      continue;
+    }
+    eligibleIds.add(blockRecord.id);
+    for (const artifactId of group.artifactIds) eligibleIds.add(artifactId);
+  }
+
+  for (const record of records) {
+    if (!eligibleIds.has(record.id) && !skipReasons.has(record.id)) {
+      skipReasons.set(
+        record.id,
+        record.source === 'history_compact_source' ? 'source_unlinked' : 'block_unverified',
+      );
+    }
+  }
+  const purgedArtifactIds = [...eligibleIds].sort();
+  if (purgedArtifactIds.length > 0) await input.artifactStore.purge(purgedArtifactIds);
+  return {
+    purgedArtifactIds,
+    skipped: records
+      .filter((record) => !eligibleIds.has(record.id))
+      .map((record) => ({
+        artifactId: record.id,
+        reason: skipReasons.get(record.id) ?? 'unverified',
+      }))
+      .sort((a, b) => a.artifactId.localeCompare(b.artifactId)),
+  };
+}
+
+function matchLegacyBlockPrefix(
+  block: HistoryCompactBlock,
+  checkpointEvents: readonly RuntimeEvent[],
+): RuntimeEvent[] | undefined {
+  const coverageIds = new Set(block.coverage.runtimeEventIds);
+  if (coverageIds.size !== block.coverage.runtimeEventIds.length) return undefined;
+  const coveredEvents: RuntimeEvent[] = [];
+  for (const event of checkpointEvents) {
+    if (!coverageIds.has(event.id)) break;
+    coveredEvents.push(event);
+  }
+  if (coveredEvents.length === 0 || coveredEvents.length !== coverageIds.size) return undefined;
+  if (!sameStrings(block.coverage.runtimeEventIds, uniqueSorted(coveredEvents.map((event) => event.id)))) {
+    return undefined;
+  }
+  if (!sameStrings(block.coverage.turnIds, uniqueSorted(coveredEvents.map((event) => event.turnId)))) {
+    return undefined;
+  }
+  if (!sameStrings(
+    block.coverage.contentKinds,
+    uniqueSorted(coveredEvents.map((event) => event.content?.kind ?? 'none')),
+  )) return undefined;
+  if (!sameStrings(
+    block.coverage.bodySha256,
+    uniqueSorted(coveredEvents.map((event) => sha256(stableStringify(event.content ?? {})))),
+  )) return undefined;
+  if (block.sourceRefs.length !== coveredEvents.length) return undefined;
+  for (let index = 0; index < coveredEvents.length; index += 1) {
+    const event = coveredEvents[index]!;
+    const ref = block.sourceRefs[index];
+    if (
+      ref?.kind !== 'runtime_event'
+      || ref.sessionId !== event.sessionId
+      || ref.turnId !== event.turnId
+      || ref.runtimeEventId !== event.id
+      || ref.role !== event.role
+      || ref.contentKind !== (event.content?.kind ?? 'none')
+    ) return undefined;
+  }
+  return coveredEvents;
+}
+
+async function validateLinkedSourceArtifacts(input: {
+  block: HistoryCompactBlock;
+  coveredEvents: readonly RuntimeEvent[];
+  recordsById: ReadonlyMap<string, ArtifactRecord>;
+  artifactStore: Pick<HistoryCompactArtifactStore, 'readText'>;
+}): Promise<
+  | { ok: true; artifactIds: string[] }
+  | { ok: false; reason: string; linkedArtifactIds: string[] }
+> {
+  const refs = input.block.sourceArchiveRefs;
+  if (!refs || refs.length !== input.coveredEvents.length) {
+    return { ok: false, reason: 'source_links_missing', linkedArtifactIds: refs?.map((ref) => ref.artifactId) ?? [] };
+  }
+  const refsByEventId = new Map<string, HistoryCompactSourceArchiveRef>();
+  for (const ref of refs) {
+    if (refsByEventId.has(ref.runtimeEventId)) {
+      return { ok: false, reason: 'source_links_duplicate', linkedArtifactIds: refs.map((item) => item.artifactId) };
+    }
+    refsByEventId.set(ref.runtimeEventId, ref);
+  }
+  const artifactIds: string[] = [];
+  for (const event of input.coveredEvents) {
+    const ref = refsByEventId.get(event.id);
+    if (!ref) {
+      return { ok: false, reason: 'source_link_missing', linkedArtifactIds: artifactIds };
+    }
+    const record = input.recordsById.get(ref.artifactId);
+    if (
+      !record
+      || record.sessionId !== event.sessionId
+      || record.source !== 'history_compact_source'
+      || record.kind !== 'file'
+    ) {
+      return { ok: false, reason: 'source_ownership_mismatch', linkedArtifactIds: [...artifactIds, ref.artifactId] };
+    }
+    const read = await input.artifactStore.readText(record.id, {
+      maxBytes: record.sizeBytes,
+      includeDeleted: true,
+    });
+    if (!read.ok) {
+      return { ok: false, reason: `source_${read.reason}`, linkedArtifactIds: [...artifactIds, record.id] };
+    }
+    let archivedEvent: unknown;
+    try {
+      archivedEvent = JSON.parse(read.text) as unknown;
+    } catch {
+      return { ok: false, reason: 'source_invalid_json', linkedArtifactIds: [...artifactIds, record.id] };
+    }
+    const body = serializeSourceBody(event.content ?? {});
+    if (
+      stableStringify(archivedEvent) !== stableStringify(event)
+      || ref.runtimeEventId !== event.id
+      || ref.bodySha256 !== sha256(body)
+      || ref.originalBytes !== Buffer.byteLength(body, 'utf8')
+    ) {
+      return { ok: false, reason: 'source_content_mismatch', linkedArtifactIds: [...artifactIds, record.id] };
+    }
+    artifactIds.push(record.id);
+  }
+  return { ok: true, artifactIds };
+}
+
+function uniqueSorted(values: readonly string[]): string[] {
+  return [...new Set(values)].sort();
+}
+
+function sameStrings(left: readonly string[], right: readonly string[]): boolean {
+  return left.length === right.length && left.every((value, index) => value === right[index]);
+}
+
+function serializeSourceBody(value: unknown): string {
+  try {
+    return JSON.stringify(value) ?? '';
+  } catch {
+    return String(value);
+  }
+}
+
+function sha256(value: string): string {
+  return createHash('sha256').update(value).digest('hex');
+}

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -325,6 +325,12 @@ export type {
   HistoryCompactArtifactStore,
   PersistHistoryCompactBlocksDeps,
 } from './history-compact-artifacts.js';
+export { cleanupLegacyHistoryCompactArtifacts } from './history-compact-cleanup.js';
+export type {
+  HistoryCompactCleanupResult,
+  HistoryCompactCleanupSkip,
+} from './history-compact-cleanup.js';
+export { buildHistoryCompactCheckpoint } from './history-compact-checkpoint.js';
 export { buildLlmHistorySummarizer } from './history-compact-summarizer.js';
 export type {
   BuildLlmHistorySummarizerOptions,

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -327,10 +327,10 @@ export type {
 } from './history-compact-artifacts.js';
 export { cleanupLegacyHistoryCompactArtifacts } from './history-compact-cleanup.js';
 export type {
+  HistoryCompactCleanupDiagnostic,
   HistoryCompactCleanupResult,
   HistoryCompactCleanupSkip,
 } from './history-compact-cleanup.js';
-export { buildHistoryCompactCheckpoint } from './history-compact-checkpoint.js';
 export { buildLlmHistorySummarizer } from './history-compact-summarizer.js';
 export type {
   BuildLlmHistorySummarizerOptions,

--- a/packages/runtime/src/runtime-kernel.ts
+++ b/packages/runtime/src/runtime-kernel.ts
@@ -1,4 +1,4 @@
-import type { AgentRunStore, RuntimeEventStore } from '@maka/core';
+import type { AgentRunStore, RuntimeEvent, RuntimeEventStore } from '@maka/core';
 import type { CompleteEvent, SessionEvent, TokenUsageEvent } from '@maka/core/events';
 import type {
   SessionBlockedReason,
@@ -58,6 +58,13 @@ export interface RuntimeKernelDeps {
   runtimeInvocationObserver?: (result: InvocationResult) => void | Promise<void>;
   repairRunRuntimeLedger?: (sessionId: string, runId: string) => Promise<boolean>;
   shellRuns?: ShellRunProcessManager;
+  cleanupHistoryCompactArtifacts?: (input: HistoryCompactCleanupRequest) => Promise<void>;
+}
+
+export interface HistoryCompactCleanupRequest {
+  sessionId: string;
+  checkpoint: HistoryCompactCheckpoint;
+  runtimeEvents: readonly RuntimeEvent[];
 }
 
 interface ActiveSession extends AgentRunActiveSession {
@@ -74,6 +81,7 @@ export class RuntimeKernel implements RuntimeKernelLike {
   private readonly historyCompactCheckpoints = new Map<string, HistoryCompactCheckpoint | undefined>();
   private readonly historyCompactCheckpointLoads = new Map<string, Promise<HistoryCompactCheckpoint | undefined>>();
   private readonly historyCompactCheckpointWrites = new Map<string, Promise<void>>();
+  private readonly historyCompactCleanupWrites = new Map<string, Promise<void>>();
 
   constructor(private readonly deps: RuntimeKernelDeps) {
     if (deps.runStore && !deps.runtimeEventStore) {
@@ -459,6 +467,7 @@ export class RuntimeKernel implements RuntimeKernelLike {
     let guardedLoad: Promise<HistoryCompactCheckpoint | undefined>;
     guardedLoad = loadLatestHistoryCompactCheckpointFromRunLedger(this.deps.runStore, sessionId)
       .then((checkpoint) => {
+        if (checkpoint) this.scheduleHistoryCompactCleanup(sessionId, checkpoint);
         if (
           this.historyCompactCheckpointLoads.get(sessionId) === guardedLoad
           && !this.historyCompactCheckpoints.has(sessionId)
@@ -495,6 +504,7 @@ export class RuntimeKernel implements RuntimeKernelLike {
         }
         await run.recordHistoryCompactCheckpoint(checkpoint);
         this.historyCompactCheckpoints.set(sessionId, checkpoint);
+        this.scheduleHistoryCompactCleanup(sessionId, checkpoint);
       })
       .finally(() => {
         if (this.historyCompactCheckpointWrites.get(sessionId) === tracked) {
@@ -503,6 +513,43 @@ export class RuntimeKernel implements RuntimeKernelLike {
       });
     this.historyCompactCheckpointWrites.set(sessionId, tracked);
     return tracked;
+  }
+
+  private scheduleHistoryCompactCleanup(
+    sessionId: string,
+    checkpoint: HistoryCompactCheckpoint,
+  ): void {
+    if (
+      !this.deps.cleanupHistoryCompactArtifacts
+      || !this.deps.runStore
+      || !this.deps.runtimeEventStore
+    ) return;
+    const previous = this.historyCompactCleanupWrites.get(sessionId) ?? Promise.resolve();
+    let tracked: Promise<void>;
+    tracked = previous
+      .catch(() => {})
+      .then(async () => {
+        const runs = (await this.deps.runStore!.listSessionRuns(sessionId))
+          .filter((run) => !run.parentRunId);
+        const runtimeEvents: RuntimeEvent[] = [];
+        for (const run of runs) {
+          runtimeEvents.push(...await this.deps.runtimeEventStore!.readRuntimeEvents(sessionId, run.runId));
+        }
+        await this.deps.cleanupHistoryCompactArtifacts!({
+          sessionId,
+          checkpoint,
+          runtimeEvents,
+        });
+      })
+      .catch(() => {
+        // Legacy cleanup is reclaim-only. Runtime replay must remain available on failure.
+      })
+      .finally(() => {
+        if (this.historyCompactCleanupWrites.get(sessionId) === tracked) {
+          this.historyCompactCleanupWrites.delete(sessionId);
+        }
+      });
+    this.historyCompactCleanupWrites.set(sessionId, tracked);
   }
 
   private async ensureActive(

--- a/packages/runtime/src/session-manager.ts
+++ b/packages/runtime/src/session-manager.ts
@@ -76,6 +76,7 @@ import type {
   InvocationSource,
 } from './invocation-context.js';
 import { RuntimeKernel, type RuntimeKernelLike } from './runtime-kernel.js';
+import type { HistoryCompactCleanupRequest } from './runtime-kernel.js';
 import {
   buildStatusPatch,
   buildTurnStateMessage,
@@ -251,6 +252,7 @@ export interface SessionManagerDeps {
   runtimeInvocationObserver?: (result: InvocationResult) => void | Promise<void>;
   runtimeKernel?: RuntimeKernelLike;
   shellRuns?: ShellRunProcessManager;
+  cleanupHistoryCompactArtifacts?: (input: HistoryCompactCleanupRequest) => Promise<void>;
 }
 
 export class SessionManager {

--- a/packages/storage/src/__tests__/artifact-store.test.ts
+++ b/packages/storage/src/__tests__/artifact-store.test.ts
@@ -212,7 +212,90 @@ describe('FileArtifactStore', () => {
       const [deleted] = await store.list('session-1', { includeDeleted: true });
       assert.equal(deleted?.status, 'deleted');
       assert.deepEqual(await store.readText('artifact-1'), { ok: false, reason: 'deleted' });
+      assert.deepEqual(
+        await store.readText('artifact-1', { includeDeleted: true }),
+        { ok: true, text: '<h1>Still on disk</h1>' },
+      );
       assert.deepEqual(await store.readBinary('artifact-1'), { ok: false, reason: 'deleted' });
+    });
+  });
+
+  test('batch purge removes file bytes and metadata records idempotently', async () => {
+    await withStore(async (store, workspaceRoot) => {
+      const first = await store.create({
+        id: 'artifact-1',
+        sessionId: 'session-1',
+        turnId: 'turn-1',
+        name: 'one.txt',
+        kind: 'file',
+        content: 'one',
+      });
+      const second = await store.create({
+        id: 'artifact-2',
+        sessionId: 'session-1',
+        turnId: 'turn-1',
+        name: 'two.txt',
+        kind: 'file',
+        content: 'two',
+      });
+      await store.create({
+        id: 'artifact-kept',
+        sessionId: 'session-1',
+        turnId: 'turn-1',
+        name: 'kept.txt',
+        kind: 'file',
+        content: 'kept',
+      });
+      await store.purge([first.id, second.id]);
+      await store.purge([first.id, second.id]);
+
+      assert.deepEqual(
+        (await store.list('session-1', { includeDeleted: true })).map((record) => record.id),
+        ['artifact-kept'],
+      );
+      await assert.rejects(
+        () => readFile(join(workspaceRoot, 'artifacts', first.relativePath), 'utf8'),
+        { code: 'ENOENT' },
+      );
+      await assert.rejects(
+        () => readFile(join(workspaceRoot, 'artifacts', second.relativePath), 'utf8'),
+        { code: 'ENOENT' },
+      );
+      const metadata = await readFile(join(workspaceRoot, 'artifacts', 'metadata.jsonl'), 'utf8');
+      assert.doesNotMatch(metadata, /artifact-1|artifact-2/);
+      assert.match(metadata, /artifact-kept/);
+    });
+  });
+
+  test('retries purge after file removal is interrupted before metadata commit', async () => {
+    await withStore(async (store, workspaceRoot) => {
+      const record = await store.create({
+        id: 'artifact-1',
+        sessionId: 'session-1',
+        turnId: 'turn-1',
+        name: 'one.txt',
+        kind: 'file',
+        content: 'one',
+      });
+      const metadataPath = join(workspaceRoot, 'artifacts', 'metadata.jsonl');
+      const metadata = await readFile(metadataPath, 'utf8');
+      await rm(metadataPath);
+      await mkdir(metadataPath);
+
+      await assert.rejects(() => store.purge([record.id]));
+
+      assert.equal((await store.get(record.id))?.id, record.id);
+      await assert.rejects(
+        () => readFile(join(workspaceRoot, 'artifacts', record.relativePath), 'utf8'),
+        { code: 'ENOENT' },
+      );
+
+      await rm(metadataPath, { recursive: true });
+      await writeFile(metadataPath, metadata, 'utf8');
+      const reopened = createArtifactStore(workspaceRoot);
+      await reopened.purge([record.id]);
+
+      assert.equal(await reopened.get(record.id), null);
     });
   });
 

--- a/packages/storage/src/__tests__/artifact-store.test.ts
+++ b/packages/storage/src/__tests__/artifact-store.test.ts
@@ -267,6 +267,127 @@ describe('FileArtifactStore', () => {
     });
   });
 
+  test('purge rejects symlink escapes without deleting files or metadata', async (t) => {
+    const workspaceRoot = await mkdtemp(join(tmpdir(), 'maka-artifact-store-'));
+    const outsideRoot = await mkdtemp(join(tmpdir(), 'maka-artifact-outside-'));
+    try {
+      const artifactRoot = join(workspaceRoot, 'artifacts');
+      await mkdir(artifactRoot, { recursive: true });
+      const outsidePath = join(outsideRoot, 'victim.txt');
+      await writeFile(outsidePath, 'keep', 'utf8');
+      try {
+        await symlink(outsideRoot, join(artifactRoot, 'linked'));
+      } catch (error) {
+        const code = (error as { code?: unknown }).code;
+        if (process.platform === 'win32' && (code === 'EPERM' || code === 'EACCES')) {
+          t.skip('Windows symlink creation requires elevated privileges or Developer Mode');
+          return;
+        }
+        throw error;
+      }
+      const store = createArtifactStore(workspaceRoot);
+      const safe = await store.create({
+        id: 'artifact-safe',
+        sessionId: 'session-1',
+        turnId: 'turn-1',
+        name: 'safe.txt',
+        kind: 'file',
+        content: 'safe',
+      });
+      await store.append({
+        id: 'artifact-escaped',
+        sessionId: 'session-1',
+        turnId: 'turn-1',
+        createdAt: 1,
+        name: 'victim.txt',
+        kind: 'file',
+        relativePath: 'linked/victim.txt',
+        sizeBytes: 4,
+        status: 'live',
+      });
+
+      await assert.rejects(
+        () => store.purge(['artifact-safe', 'artifact-escaped']),
+        /outside the artifact root/,
+      );
+
+      assert.equal(await readFile(outsidePath, 'utf8'), 'keep');
+      assert.equal(
+        await readFile(join(workspaceRoot, 'artifacts', safe.relativePath), 'utf8'),
+        'safe',
+      );
+      assert.equal((await store.get('artifact-safe'))?.id, 'artifact-safe');
+      assert.equal((await store.get('artifact-escaped'))?.id, 'artifact-escaped');
+    } finally {
+      await rm(workspaceRoot, { recursive: true, force: true });
+      await rm(outsideRoot, { recursive: true, force: true });
+    }
+  });
+
+  test('purge removes a final symlink without deleting its in-root target', async (t) => {
+    await withWorkspace(async (workspaceRoot) => {
+      const artifactRoot = join(workspaceRoot, 'artifacts');
+      const sessionRoot = join(artifactRoot, 'session-1');
+      await mkdir(sessionRoot, { recursive: true });
+      const targetPath = join(sessionRoot, 'target.txt');
+      await writeFile(targetPath, 'keep target', 'utf8');
+      try {
+        await symlink('target.txt', join(sessionRoot, 'linked.txt'));
+      } catch (error) {
+        const code = (error as { code?: unknown }).code;
+        if (process.platform === 'win32' && (code === 'EPERM' || code === 'EACCES')) {
+          t.skip('Windows symlink creation requires elevated privileges or Developer Mode');
+          return;
+        }
+        throw error;
+      }
+      const store = createArtifactStore(workspaceRoot);
+      await store.append({
+        id: 'artifact-link',
+        sessionId: 'session-1',
+        turnId: 'turn-1',
+        createdAt: 1,
+        name: 'linked.txt',
+        kind: 'file',
+        relativePath: 'session-1/linked.txt',
+        sizeBytes: 11,
+        status: 'live',
+      });
+
+      await store.purge(['artifact-link']);
+
+      assert.equal(await readFile(targetPath, 'utf8'), 'keep target');
+      await assert.rejects(
+        () => readFile(join(sessionRoot, 'linked.txt'), 'utf8'),
+        { code: 'ENOENT' },
+      );
+      assert.equal(await store.get('artifact-link'), null);
+    });
+  });
+
+  test('purge preserves files still referenced by a non-target record', async () => {
+    await withStore(async (store, workspaceRoot) => {
+      const first = await store.create({
+        id: 'artifact-1',
+        sessionId: 'session-1',
+        turnId: 'turn-1',
+        name: 'shared.txt',
+        kind: 'file',
+        content: 'shared bytes',
+      });
+      await store.append({ ...first, id: 'artifact-2' });
+
+      await assert.rejects(
+        () => store.purge(['artifact-1']),
+        /still referenced by artifact artifact-2/,
+      );
+
+      assert.equal(await readFile(join(workspaceRoot, 'artifacts', first.relativePath), 'utf8'), 'shared bytes');
+      assert.equal((await store.get('artifact-1'))?.id, 'artifact-1');
+      assert.equal((await store.get('artifact-2'))?.id, 'artifact-2');
+    });
+  });
+
   test('retries purge after file removal is interrupted before metadata commit', async () => {
     await withStore(async (store, workspaceRoot) => {
       const record = await store.create({

--- a/packages/storage/src/artifact-store.ts
+++ b/packages/storage/src/artifact-store.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from 'node:crypto';
 import { constants as fsConstants } from 'node:fs';
-import { access, mkdir, readFile, realpath, rename, stat, writeFile } from 'node:fs/promises';
+import { access, mkdir, readFile, realpath, rename, rm, stat, writeFile } from 'node:fs/promises';
 import { dirname, isAbsolute, join, relative, sep } from 'node:path';
 import type {
   ArtifactBinaryReadResult,
@@ -31,9 +31,10 @@ export interface ArtifactStore {
   append(record: ArtifactRecord): Promise<ArtifactRecord>;
   list(sessionId: string, opts?: { includeDeleted?: boolean }): Promise<ArtifactRecord[]>;
   get(artifactId: string): Promise<ArtifactRecord | null>;
-  readText(artifactId: string, opts?: { maxBytes?: number }): Promise<ArtifactTextReadResult>;
+  readText(artifactId: string, opts?: { maxBytes?: number; includeDeleted?: boolean }): Promise<ArtifactTextReadResult>;
   readBinary(artifactId: string, opts?: { maxBytes?: number }): Promise<ArtifactBinaryReadResult>;
   delete(artifactId: string): Promise<void>;
+  purge(artifactIds: readonly string[]): Promise<void>;
 }
 
 export function createArtifactStore(workspaceRoot: string): ArtifactStore {
@@ -110,8 +111,15 @@ class FileArtifactStore implements ArtifactStore {
     return record ? { ...record } : null;
   }
 
-  async readText(artifactId: string, opts: { maxBytes?: number } = {}): Promise<ArtifactTextReadResult> {
-    const prepared = await this.prepareRead(artifactId, opts.maxBytes ?? ARTIFACT_TEXT_PREVIEW_LIMIT_BYTES);
+  async readText(
+    artifactId: string,
+    opts: { maxBytes?: number; includeDeleted?: boolean } = {},
+  ): Promise<ArtifactTextReadResult> {
+    const prepared = await this.prepareRead(
+      artifactId,
+      opts.maxBytes ?? ARTIFACT_TEXT_PREVIEW_LIMIT_BYTES,
+      opts.includeDeleted ?? false,
+    );
     if (!prepared.ok) return prepared;
     try {
       return { ok: true, text: await readFile(prepared.path, 'utf8') };
@@ -143,16 +151,38 @@ class FileArtifactStore implements ArtifactStore {
     });
   }
 
+  async purge(artifactIds: readonly string[]): Promise<void> {
+    await this.load();
+    await this.enqueue(async () => {
+      const ids = new Set(artifactIds);
+      const records = this.records.filter((record) => ids.has(record.id));
+      if (records.length === 0) return;
+      for (const record of records) {
+        validateRelativeArtifactPath(record.relativePath);
+        await rm(join(this.artifactRoot, record.relativePath), { force: true });
+      }
+      const previous = this.records;
+      this.records = this.records.filter((record) => !ids.has(record.id));
+      try {
+        await this.writeMetadataUnlocked();
+      } catch (error) {
+        this.records = previous;
+        throw error;
+      }
+    });
+  }
+
   private async prepareRead(
     artifactId: string,
     maxBytes: number,
+    includeDeleted = false,
   ): Promise<
     | { ok: true; path: string; record: ArtifactRecord }
     | { ok: false; reason: 'not_found' | 'too_large' | 'read_failed' | 'not_allowed' | 'deleted' }
   > {
     const record = await this.get(artifactId);
     if (!record) return { ok: false, reason: 'not_found' };
-    if (record.status === 'deleted') return { ok: false, reason: 'deleted' };
+    if (record.status === 'deleted' && !includeDeleted) return { ok: false, reason: 'deleted' };
     const resolved = await resolveArtifactPath({
       artifactRoot: this.artifactRoot,
       relativePath: record.relativePath,

--- a/packages/storage/src/artifact-store.ts
+++ b/packages/storage/src/artifact-store.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from 'node:crypto';
 import { constants as fsConstants } from 'node:fs';
 import { access, mkdir, readFile, realpath, rename, rm, stat, writeFile } from 'node:fs/promises';
-import { dirname, isAbsolute, join, relative, sep } from 'node:path';
+import { basename, dirname, isAbsolute, join, relative, sep } from 'node:path';
 import type {
   ArtifactBinaryReadResult,
   ArtifactKind,
@@ -157,10 +157,33 @@ class FileArtifactStore implements ArtifactStore {
       const ids = new Set(artifactIds);
       const records = this.records.filter((record) => ids.has(record.id));
       if (records.length === 0) return;
+      const root = await ensureRealDirectory(this.artifactRoot);
+      const paths = new Map<string, ArtifactRecord>();
+      const relativePaths = new Map(records.map((record) => [record.relativePath, record] as const));
       for (const record of records) {
         validateRelativeArtifactPath(record.relativePath);
-        await rm(join(this.artifactRoot, record.relativePath), { force: true });
+        const path = await resolveArtifactRemovalEntry(this.artifactRoot, record.relativePath);
+        if (!path) continue;
+        if (!isInsideOrSamePath(root, dirname(path))) {
+          throw new Error(`Artifact ${record.id} resolves outside the artifact root`);
+        }
+        paths.set(path, record);
       }
+      for (const record of this.records) {
+        if (ids.has(record.id)) continue;
+        const exactTarget = relativePaths.get(record.relativePath);
+        if (exactTarget) {
+          throw new Error(
+            `Artifact ${exactTarget.id} path is still referenced by artifact ${record.id}`,
+          );
+        }
+        const path = await resolveArtifactRemovalEntry(this.artifactRoot, record.relativePath);
+        const target = path ? paths.get(path) : undefined;
+        if (target) {
+          throw new Error(`Artifact ${target.id} path is still referenced by artifact ${record.id}`);
+        }
+      }
+      for (const path of paths.keys()) await rm(path, { force: true });
       const previous = this.records;
       this.records = this.records.filter((record) => !ids.has(record.id));
       try {
@@ -306,6 +329,20 @@ async function ensureRealDirectory(path: string): Promise<string> {
   await mkdir(path, { recursive: true });
   await access(path, fsConstants.R_OK);
   return realpath(path);
+}
+
+async function resolveArtifactRemovalEntry(
+  artifactRoot: string,
+  relativePath: string,
+): Promise<string | undefined> {
+  const target = join(artifactRoot, relativePath);
+  try {
+    const parent = await realpath(dirname(target));
+    return join(parent, basename(target));
+  } catch (error) {
+    if (isNotFound(error)) return undefined;
+    throw error;
+  }
 }
 
 function isInsideOrSamePath(root: string, target: string): boolean {


### PR DESCRIPTION
## Summary

- Remove legacy history compact artifacts only when a valid V2 checkpoint provably supersedes them.
- Validate checkpoint coverage, source RuntimeEvents, artifact ownership, linkage, content, hashes, and byte counts before cleanup.
- Purge eligible files and metadata as one interruption-safe, retryable batch.

## Why

V1 history compaction can retain thousands of internal artifacts after V2 has safely replaced them. The cleanup must reclaim that storage without inferring ownership or weakening RuntimeEvent replay.

Closes #728

## Scope

Changed:

- Added strict V1-to-V2 supersession verification.
- Added batch artifact purge with containment and symlink preflight before deletion.
- Added idempotent cleanup after durable checkpoint creation.
- Added one aggregated cleanup diagnostic instead of one notification per artifact.
- Added storage, runtime, CLI, and desktop lifecycle coverage.

Not included:

- RuntimeEvent deletion
- Streaming event coalescing
- V2 checkpoint redesign
- Unrelated or age-based artifact cleanup
- Artifact index format redesign

## Verification

- `npm run -w @maka/storage test` (217 passed)
- `npm run -w @maka/runtime test` (1276 passed, 2 environment-dependent tests skipped)
- `npm run -w @maka/desktop test` (2316 passed)
- `npm run typecheck`

## User-facing impact

No UI, migration, or compatibility changes. Eligible internal legacy artifacts are reclaimed automatically; corrupt, unlinked, or unverifiable data is preserved and reported.

## Reviewer notes

The current artifact index is a monolithic JSONL file, so cleanup performs one atomic metadata rewrite per batch rather than one rewrite per artifact. Eliminating the single batch rewrite would require an out-of-scope index redesign.

## Checklist

- [x] Scope matches the linked issue and its non-goals
- [x] Tests cover safe cleanup, retries, partial cleanup, corrupt data, and path boundaries
- [x] Relevant tests and typecheck pass
- [x] No RuntimeEvents or unverifiable artifacts are deleted
- [x] Screenshots are not applicable
