### PR TITLE
fix(desktop): hide runtime artifacts from generated files

### DIFF
--- a/apps/desktop/src/main/__tests__/artifact-pane-lifecycle-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/artifact-pane-lifecycle-contract.test.ts
@@ -64,8 +64,8 @@ describe('ArtifactPane async lifecycle contract', () => {
     );
     assert.match(
       src,
-      /const activeRecords = useMemo\([\s\S]*recordsSessionId === sessionId \? records\.filter\(\(record\) => record\.source !== 'user_upload'\) : \[\][\s\S]*\[records, recordsSessionId, sessionId\]/,
-      'rendering must filter artifact records by the current active session id and exclude user uploads from the generated-file pane',
+      /const activeRecords = useMemo\([\s\S]*recordsSessionId === sessionId \? filterUserVisibleArtifacts\(records\) : \[\][\s\S]*\[records, recordsSessionId, sessionId\]/,
+      'rendering must filter artifact records by the current active session id and generated-file visibility policy',
     );
     assert.doesNotMatch(
       src,

--- a/apps/desktop/src/main/__tests__/artifact-visibility.test.ts
+++ b/apps/desktop/src/main/__tests__/artifact-visibility.test.ts
@@ -1,0 +1,46 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import type { ArtifactRecord, ArtifactSource } from '@maka/core';
+import { filterUserVisibleArtifacts } from '../../renderer/artifact-visibility.js';
+
+function artifact(source?: ArtifactSource): ArtifactRecord {
+  return {
+    id: source ?? 'legacy',
+    sessionId: 'session-1',
+    turnId: 'turn-1',
+    source,
+    kind: 'file',
+    name: `${source ?? 'legacy'}.json`,
+    relativePath: `${source ?? 'legacy'}.json`,
+    sizeBytes: 4096,
+    createdAt: 1,
+    status: 'live',
+  };
+}
+
+describe('generated artifact visibility', () => {
+  it('excludes runtime context state and user-upload snapshots', () => {
+    const hiddenSources: ArtifactSource[] = [
+      'tool_result_archive',
+      'synthesis_cache_block',
+      'history_compact_block',
+      'history_compact_source',
+      'user_upload',
+    ];
+
+    assert.deepEqual(filterUserVisibleArtifacts(hiddenSources.map(artifact)), []);
+  });
+
+  it('preserves user-facing generated files and legacy records without a source', () => {
+    const visibleSources: Array<ArtifactSource | undefined> = [
+      'tool_result',
+      'export',
+      'snapshot',
+      'fixture',
+      undefined,
+    ];
+    const records = visibleSources.map(artifact);
+
+    assert.deepEqual(filterUserVisibleArtifacts(records), records);
+  });
+});

--- a/apps/desktop/src/main/__tests__/attachment-frontend-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/attachment-frontend-contract.test.ts
@@ -6,6 +6,7 @@ import { createElement } from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
 import type { AttachmentRef, SessionSummary, StoredMessage } from '@maka/core';
 import { ChatView } from '@maka/ui';
+import { filterUserVisibleArtifacts } from '../../renderer/artifact-visibility.js';
 
 const REPO_ROOT = process.cwd().endsWith('apps/desktop')
   ? resolve(process.cwd(), '..', '..')
@@ -72,14 +73,24 @@ describe('attachment frontend contract', () => {
     assert.match(appShell, /onAttachFilePaths=\{attachFilePaths\}/);
   });
 
-  it('generated-files pane excludes user-uploaded attachments', async () => {
-    const artifactPane = await readRepo('apps/desktop/src/renderer/artifact-pane.tsx');
+  it('generated-files pane excludes user-uploaded attachments', () => {
+    const records = filterUserVisibleArtifacts([
+      {
+        id: 'upload-1',
+        sessionId: 'session-1',
+        turnId: 'turn-1',
+        source: 'user_upload',
+        kind: 'file',
+        name: 'notes.txt',
+        mimeType: 'text/plain',
+        relativePath: 'notes.txt',
+        sizeBytes: 5,
+        createdAt: 1,
+        status: 'live',
+      },
+    ]);
 
-    assert.match(
-      artifactPane,
-      /record\.source !== 'user_upload'/,
-      'ArtifactPane is labeled generated files and must not list user-uploaded attachment snapshots',
-    );
+    assert.deepEqual(records, [], 'user-uploaded snapshots are not generated files');
   });
 
   it('passes selected model vision capability to the runtime attachment renderer', async () => {

--- a/apps/desktop/src/main/__tests__/attachment-frontend-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/attachment-frontend-contract.test.ts
@@ -6,7 +6,6 @@ import { createElement } from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
 import type { AttachmentRef, SessionSummary, StoredMessage } from '@maka/core';
 import { ChatView } from '@maka/ui';
-import { filterUserVisibleArtifacts } from '../../renderer/artifact-visibility.js';
 
 const REPO_ROOT = process.cwd().endsWith('apps/desktop')
   ? resolve(process.cwd(), '..', '..')
@@ -71,26 +70,6 @@ describe('attachment frontend contract', () => {
     assert.match(chatActions, /sessions\.send[\s\S]*attachmentItems/);
     assert.match(appShell, /onPickAttachments=\{pickAttachments\}/);
     assert.match(appShell, /onAttachFilePaths=\{attachFilePaths\}/);
-  });
-
-  it('generated-files pane excludes user-uploaded attachments', () => {
-    const records = filterUserVisibleArtifacts([
-      {
-        id: 'upload-1',
-        sessionId: 'session-1',
-        turnId: 'turn-1',
-        source: 'user_upload',
-        kind: 'file',
-        name: 'notes.txt',
-        mimeType: 'text/plain',
-        relativePath: 'notes.txt',
-        sizeBytes: 5,
-        createdAt: 1,
-        status: 'live',
-      },
-    ]);
-
-    assert.deepEqual(records, [], 'user-uploaded snapshots are not generated files');
   });
 
   it('passes selected model vision capability to the runtime attachment renderer', async () => {

--- a/apps/desktop/src/renderer/artifact-pane.tsx
+++ b/apps/desktop/src/renderer/artifact-pane.tsx
@@ -77,6 +77,7 @@ import {
 } from '@maka/ui';
 import { ArtifactPreview } from './artifact-preview';
 import { nextArtifactListAction } from './artifact-list-keyboard';
+import { filterUserVisibleArtifacts } from './artifact-visibility';
 import { safeLocalStorageGet, safeLocalStorageSet } from './browser-storage';
 import { openPathFailureCopy } from './open-path';
 
@@ -168,7 +169,7 @@ export function ArtifactPane(props: { sessionId: string | undefined }) {
   }, [collapsed]);
 
   const activeRecords = useMemo(
-    () => (recordsSessionId === sessionId ? records.filter((record) => record.source !== 'user_upload') : []),
+    () => (recordsSessionId === sessionId ? filterUserVisibleArtifacts(records) : []),
     [records, recordsSessionId, sessionId],
   );
 

--- a/apps/desktop/src/renderer/artifact-visibility.ts
+++ b/apps/desktop/src/renderer/artifact-visibility.ts
@@ -1,0 +1,19 @@
+import type { ArtifactRecord, ArtifactSource } from '@maka/core';
+
+const USER_VISIBLE_ARTIFACT_SOURCES = {
+  tool_result: true,
+  tool_result_archive: false,
+  synthesis_cache_block: false,
+  history_compact_block: false,
+  history_compact_source: false,
+  user_upload: false,
+  export: true,
+  snapshot: true,
+  fixture: true,
+} satisfies Record<ArtifactSource, boolean>;
+
+export function filterUserVisibleArtifacts(records: readonly ArtifactRecord[]): ArtifactRecord[] {
+  return records.filter(
+    (record) => record.source === undefined || USER_VISIBLE_ARTIFACT_SOURCES[record.source],
+  );
+}


### PR DESCRIPTION
## Summary

Hide runtime-only artifact records from the Generated Files pane while preserving user-facing generated files and legacy records.

## Why

Context replay and cache features persist internal state through ArtifactStore. ArtifactPane previously treated nearly every stored artifact as a user-generated file, so sessions could show files such as tool-result archives even when the user had not created one.

Refs #546

## Scope

Changed:

- classify every ArtifactSource at the renderer visibility boundary
- hide tool-result archives, synthesis cache blocks, legacy history-compaction records, and user-upload snapshots
- preserve tool results, exports, snapshots, visual fixtures, and legacy records without a source
- add behavior tests and keep the ArtifactPane integration contract

Not included:

- artifact persistence or replay behavior
- deleted-artifact actions
- unrelated ArtifactPane layout issues

## Verification

- `npm run -w @maka/desktop typecheck`
- `npm run -w @maka/desktop test`
- 2318 tests passed
- independent agent review: no P0–P3 findings

## User-facing impact

Internal runtime/cache files no longer appear in Generated Files. No migration, documentation, changelog, or breaking change is required.

## Reviewer notes

The visibility map uses `satisfies Record<ArtifactSource, boolean>`, so adding a new source requires an explicit visibility decision. Runtime persistence remains unchanged.

## Checklist

- [x] Scope matches the PR title and excludes unrelated changes
- [x] Verification lists commands/results
- [x] User-facing impact and migration status are noted
- [x] Risk and review focus are called out
- [x] Screenshots are not applicable because this removes unintended rows without changing layout
