### PR TITLE
fix(headless): attest A/B budget outcomes

### DIFF
--- a/packages/headless/src/__tests__/ab-summary.test.ts
+++ b/packages/headless/src/__tests__/ab-summary.test.ts
@@ -72,8 +72,8 @@ describe('summarizeAbComparison', () => {
       budgetMs: 600_000,
     });
 
-    assert.equal(result.decision, 'invalid');
-    assert.equal(result.reason, 'asymmetric_budget_exhaustion');
+    assert.equal(result.decision, 'diagnostic');
+    assert.equal(result.reason, 'single_rep_diagnostic_only');
     assert.equal(result.candidate.passRate, 0);
     assert.equal(result.candidate.budgetExhausted, 1);
     assert.equal(result.candidate.infraFailed, 0);
@@ -82,7 +82,7 @@ describe('summarizeAbComparison', () => {
     assert.equal(result.taskLevel.losses, 1);
   });
 
-  test('does not count an unverified budget exhaustion as valid A/B coverage', () => {
+  test('does not count an unattested budget exhaustion as valid A/B coverage', () => {
     const unverifiedTimeout = {
       ...budgetExhausted('long-task'),
       eligible: false,
@@ -99,11 +99,41 @@ describe('summarizeAbComparison', () => {
       budgetMs: 600_000,
     });
 
-    assert.equal(result.baseline.budgetExhausted, 1);
+    assert.equal(result.baseline.budgetExhausted, 0);
+    assert.equal(result.baseline.plumbingFailed, 1);
     assert.equal(result.baseline.valid, 0);
     assert.equal(result.baseline.coverageRate, 0);
     assert.equal(result.candidate.valid, 0);
     assert.equal(result.candidate.coverageRate, 0);
+    assert.equal(result.pairedAttempts.observedPairs, 0);
+    assert.deepEqual(result.pairedAttempts.missingPairIds, ['long-task#r0']);
+    assert.equal(result.decision, 'invalid');
+    assert.equal(result.reason, 'plumbing_failure_observed');
+  });
+
+  test('classifies a timeout with rate-limit evidence as an invalid infra outcome', () => {
+    const providerTimeout = {
+      ...budgetExhausted('task-a'),
+      eligible: false,
+      evidenceErrorClass: 'rate_limit' as const,
+      evidenceError: 'provider rate limited the request',
+    };
+    const result = summarizeAbComparison({
+      runId: 'ab-run',
+      roundId: 'ab-summary',
+      baselineArmId: 'baseline',
+      candidateArmId: 'candidate',
+      evaluationTaskIds: ['task-a'],
+      baselineRuns: [[providerTimeout]],
+      candidateRuns: [[completed('task-a', true)]],
+    });
+
+    assert.equal(result.baseline.infraFailed, 1);
+    assert.equal(result.baseline.plumbingFailed, 0);
+    assert.equal(result.baseline.budgetExhausted, 0);
+    assert.deepEqual(result.pairedAttempts.infraOrPlumbingDiscordantPairIds, ['task-a#r0']);
+    assert.equal(result.decision, 'invalid');
+    assert.equal(result.reason, 'infra_failure_observed');
   });
 
   test('does not count ineligible completed attempts as valid A/B coverage', () => {
@@ -124,6 +154,37 @@ describe('summarizeAbComparison', () => {
     assert.equal(result.candidate.valid, 0);
     assert.equal(result.candidate.coverageRate, 0);
     assert.equal(result.pairedAttempts.observedPairs, 0);
+  });
+
+  test('counts an agent step-cap failure as a failed A/B outcome', () => {
+    const stepCapFailure = {
+      ...completed('task-a', false),
+      status: 'failed' as const,
+      scored: false,
+      eligible: true,
+      errorClass: 'tool_step_cap_reached',
+    };
+    const result = summarizeAbComparison({
+      runId: 'ab-run',
+      roundId: 'ab-summary',
+      baselineArmId: 'maka-baseline',
+      candidateArmId: 'candidate',
+      evaluationTaskIds: ['task-a'],
+      baselineRuns: [[stepCapFailure]],
+      candidateRuns: [[stepCapFailure]],
+      budgetMs: 600_000,
+    });
+
+    assert.equal(result.baseline.valid, 1);
+    assert.equal(result.baseline.passRate, 0);
+    assert.equal(result.baseline.completed, 0);
+    assert.equal(result.baseline.budgetExhausted, 1);
+    assert.equal(result.candidate.valid, 1);
+    assert.equal(result.candidate.passRate, 0);
+    assert.equal(result.taskLevel.tasks[0]?.baseline.completed, 0);
+    assert.equal(result.taskLevel.tasks[0]?.baseline.budgetExhausted, 1);
+    assert.equal(result.pairedAttempts.observedPairs, 1);
+    assert.equal(result.pairedAttempts.ties, 1);
   });
 
   test('summarizes context budget activation in the A/B report', () => {
@@ -320,6 +381,32 @@ describe('summarizeAbComparison', () => {
       ]],
     });
 
+  });
+
+  test('classifies step-cap consistently inside the active-prune subset', () => {
+    const stepCapFailure = {
+      ...completed('t1', false),
+      status: 'failed' as const,
+      scored: false,
+      eligible: true,
+      errorClass: 'tool_step_cap_reached',
+    };
+    const result = summarizeAbComparison({
+      runId: 'ab-run',
+      roundId: 'ab-summary',
+      baselineArmId: 'baseline',
+      candidateArmId: 'candidate',
+      evaluationTaskIds: ['t1'],
+      baselineRuns: [[stepCapFailure]],
+      candidateRuns: [[{
+        ...stepCapFailure,
+        contextBudgetSummary: contextBudgetSummary({ activePrunedToolResults: 1 }),
+      }]],
+    });
+
+    assert.equal(result.candidate.activePruneSubset?.completed, 0);
+    assert.equal(result.candidate.activePruneSubset?.budgetExhausted, 1);
+    assert.equal(result.candidate.activePruneSubset?.meanDurationMs, null);
   });
 
   test('summarizes A/B token cost usage for prune benefit review', () => {
@@ -781,8 +868,8 @@ describe('summarizeAbComparison', () => {
     assert.equal(result.candidate.passed, 1);
     assert.equal(result.pairedAttempts.wins, 1);
     assert.deepEqual(result.pairedAttempts.budgetDiscordantPairIds, ['t1#r0']);
-    assert.equal(result.decision, 'invalid');
-    assert.equal(result.reason, 'asymmetric_budget_exhaustion');
+    assert.equal(result.decision, 'diagnostic');
+    assert.equal(result.reason, 'single_rep_diagnostic_only');
   });
 
   test('counts baseline pass and candidate timeout as an effective B loss', () => {
@@ -800,11 +887,35 @@ describe('summarizeAbComparison', () => {
     assert.equal(result.candidate.budgetExhausted, 1);
     assert.equal(result.pairedAttempts.losses, 1);
     assert.deepEqual(result.pairedAttempts.budgetDiscordantPairIds, ['t1#r0']);
-    assert.equal(result.decision, 'invalid');
-    assert.equal(result.reason, 'asymmetric_budget_exhaustion');
+    assert.equal(result.decision, 'diagnostic');
+    assert.equal(result.reason, 'single_rep_diagnostic_only');
   });
 
-  test('reports budget-discordant refs and invalidates a powered non-inferiority decision', () => {
+  test('reports an asymmetric step-cap failure as budget discordance', () => {
+    const stepCapFailure = {
+      ...completed('t1', false),
+      status: 'failed' as const,
+      scored: false,
+      eligible: true,
+      errorClass: 'tool_step_cap_reached',
+    };
+    const result = summarizeAbComparison({
+      runId: 'ab-run',
+      roundId: 'ab-summary',
+      baselineArmId: 'baseline',
+      candidateArmId: 'candidate',
+      evaluationTaskIds: ['t1'],
+      baselineRuns: [[stepCapFailure]],
+      candidateRuns: [[completed('t1', true)]],
+    });
+
+    assert.equal(result.pairedAttempts.wins, 1);
+    assert.deepEqual(result.pairedAttempts.budgetDiscordantPairIds, ['t1#r0']);
+    assert.equal(result.decision, 'diagnostic');
+    assert.equal(result.reason, 'single_rep_diagnostic_only');
+  });
+
+  test('reports budget-discordant refs without invalidating the comparison', () => {
     const taskIds = Array.from({ length: 100 }, (_, index) => `t${index}`);
     const result = summarizeAbComparison({
       runId: 'ab-run',
@@ -818,8 +929,8 @@ describe('summarizeAbComparison', () => {
 
     assert.deepEqual(result.pairedAttempts.budgetDiscordantPairIds, ['t0#r0']);
     assert.equal(result.investigationRefs.budgetDiscordantPairs[0]?.pairId, 't0#r0');
-    assert.equal(result.decision, 'invalid');
-    assert.equal(result.reason, 'asymmetric_budget_exhaustion');
+    assert.equal(result.decision, 'diagnostic');
+    assert.equal(result.reason, 'single_rep_diagnostic_only');
   });
 });
 

--- a/packages/headless/src/__tests__/fixed-prompt-controller.test.ts
+++ b/packages/headless/src/__tests__/fixed-prompt-controller.test.ts
@@ -499,7 +499,7 @@ describe('fixed prompt controller', () => {
     });
   });
 
-  test('keeps an unattested timeout as an ineligible budget exhaustion', async () => {
+  test('keeps an unattested timeout ineligible for A/B attribution', async () => {
     await withDir(async (dir) => {
       const systemPromptPath = join(dir, 'system_prompt.md');
       await writeFile(systemPromptPath, 'fixed prompt\n', 'utf8');
@@ -642,6 +642,45 @@ describe('fixed prompt controller', () => {
     });
   });
 
+  test('uses early execution identity to attribute a timeout before cell output', async () => {
+    await withDir(async (dir) => {
+      const systemPromptPath = join(dir, 'system_prompt.md');
+      await writeFile(systemPromptPath, 'fixed prompt\n', 'utf8');
+      const executionIdentity = {
+        llmConnectionSlug: 'fake',
+        model: 'fake-model',
+        systemPromptHash: hashSystemPrompt('fixed prompt\n'),
+        pricingProfile: 'test-profile',
+      };
+      const result = await runFixedPromptController({
+        runId: 'run-1',
+        roundId: 'round-1',
+        config,
+        systemPromptPath,
+        resultsJsonlPath: join(dir, 'results.jsonl'),
+        resultsTsvPath: join(dir, 'results.tsv'),
+        tasks: [{ id: 'task-a', path: '/bench/task-a' }],
+        requireExecutionIdentity: true,
+        expectedPricingProfile: 'test-profile',
+        harborRunner: async () => {
+          throw new FixedPromptBudgetExhaustedError('agent timed out', undefined, { executionIdentity });
+        },
+        now: () => 100,
+        newId: idFactory(),
+      });
+
+      const event = result.events[0];
+      assert.equal(event?.type, 'task_budget_exhausted');
+      if (event?.type !== 'task_budget_exhausted') assert.fail('expected budget exhaustion event');
+      assert.equal(event.eligible, true);
+      assert.equal(event.evidenceErrorClass, undefined);
+      assert.deepEqual(
+        (event as { executionIdentity?: typeof executionIdentity }).executionIdentity,
+        executionIdentity,
+      );
+    });
+  });
+
   test('keeps a provider-error timeout ineligible and stops the controller', async () => {
     await withDir(async (dir) => {
       const systemPromptPath = join(dir, 'system_prompt.md');
@@ -724,6 +763,46 @@ describe('fixed prompt controller', () => {
       });
     });
   }
+
+  test('keeps a timeout with rate-limit evidence ineligible', async () => {
+    await withDir(async (dir) => {
+      const systemPromptPath = join(dir, 'system_prompt.md');
+      await writeFile(systemPromptPath, 'fixed prompt\n', 'utf8');
+      const cell = harborOutput({
+        taskId: 'task-a',
+        status: 'failed',
+        errorClass: 'rate_limit',
+        executionIdentity: {
+          llmConnectionSlug: 'fake',
+          model: 'fake-model',
+          systemPromptHash: hashSystemPrompt('fixed prompt\n'),
+          pricingProfile: 'test-profile',
+        },
+      }).cell;
+      const result = await runFixedPromptController({
+        runId: 'run-1',
+        roundId: 'round-1',
+        config,
+        systemPromptPath,
+        resultsJsonlPath: join(dir, 'results.jsonl'),
+        resultsTsvPath: join(dir, 'results.tsv'),
+        tasks: [{ id: 'task-a', path: '/bench/task-a' }],
+        requireExecutionIdentity: true,
+        expectedPricingProfile: 'test-profile',
+        harborRunner: async () => {
+          throw new FixedPromptBudgetExhaustedError('agent timed out', undefined, { cellOutput: cell });
+        },
+        now: () => 100,
+        newId: idFactory(),
+      });
+
+      const event = result.events[0];
+      assert.equal(event?.type, 'task_budget_exhausted');
+      if (event?.type !== 'task_budget_exhausted') assert.fail('expected budget exhaustion event');
+      assert.equal(event.eligible, false);
+      assert.equal((event as { evidenceErrorClass?: string }).evidenceErrorClass, 'rate_limit');
+    });
+  });
 
   test('reruns budget-exhausted WAL events instead of reusing a timeout', async () => {
     await withDir(async (dir) => {
@@ -1373,6 +1452,123 @@ describe('fixed prompt controller', () => {
       assert.equal(result.events[0]?.scored, true);
       assert.equal(result.events[0]?.eligible, true);
       assert.equal(result.events[0]?.errorClass, 'verification_failed');
+    });
+  });
+
+  test('keeps Harbor step-cap failures eligible as failed benchmark outcomes', async () => {
+    await withDir(async (dir) => {
+      const systemPromptPath = join(dir, 'system_prompt.md');
+      await writeFile(systemPromptPath, 'fixed prompt\n', 'utf8');
+
+      const result = await runFixedPromptController({
+        runId: 'run-1',
+        roundId: 'round-1',
+        config,
+        systemPromptPath,
+        resultsJsonlPath: join(dir, 'results.jsonl'),
+        resultsTsvPath: join(dir, 'results.tsv'),
+        tasks: [{ id: 'task-a', path: '/bench/task-a' }],
+        harborRunner: async () => harborOutput({
+          taskId: 'task-a',
+          reward: 0,
+          status: 'failed',
+          errorClass: 'tool_step_cap_reached',
+        }),
+        now: () => 100,
+        newId: idFactory(),
+      });
+
+      assert.equal(result.events[0]?.type, 'task_completed');
+      assert.equal(result.events[0]?.passed, false);
+      assert.equal(result.events[0]?.scored, false);
+      assert.equal(result.events[0]?.eligible, true);
+      assert.equal(result.events[0]?.errorClass, 'tool_step_cap_reached');
+    });
+  });
+
+  test('classifies provider rate limits as infrastructure failures', async () => {
+    await withDir(async (dir) => {
+      const systemPromptPath = join(dir, 'system_prompt.md');
+      await writeFile(systemPromptPath, 'fixed prompt\n', 'utf8');
+
+      const result = await runFixedPromptController({
+        runId: 'run-1',
+        roundId: 'round-1',
+        config,
+        systemPromptPath,
+        resultsJsonlPath: join(dir, 'results.jsonl'),
+        resultsTsvPath: join(dir, 'results.tsv'),
+        tasks: [{ id: 'task-a', path: '/bench/task-a' }],
+        harborRunner: async () => harborOutput({
+          taskId: 'task-a',
+          reward: 0,
+          status: 'failed',
+          errorClass: 'rate_limit',
+        }),
+        now: () => 100,
+        newId: idFactory(),
+      });
+
+      assert.equal(result.events[0]?.type, 'task_infra_failed');
+      assert.equal(result.events[0]?.eligible, false);
+      assert.equal(result.events[0]?.errorClass, 'rate_limit');
+    });
+  });
+
+  test('classifies network failures as infrastructure failures', async () => {
+    await withDir(async (dir) => {
+      const systemPromptPath = join(dir, 'system_prompt.md');
+      await writeFile(systemPromptPath, 'fixed prompt\n', 'utf8');
+
+      const result = await runFixedPromptController({
+        runId: 'run-1',
+        roundId: 'round-1',
+        config,
+        systemPromptPath,
+        resultsJsonlPath: join(dir, 'results.jsonl'),
+        resultsTsvPath: join(dir, 'results.tsv'),
+        tasks: [{ id: 'task-a', path: '/bench/task-a' }],
+        harborRunner: async () => harborOutput({
+          taskId: 'task-a',
+          reward: 0,
+          status: 'failed',
+          errorClass: 'network',
+        }),
+        now: () => 100,
+        newId: idFactory(),
+      });
+
+      assert.equal(result.events[0]?.type, 'task_infra_failed');
+      assert.equal(result.events[0]?.eligible, false);
+      assert.equal(result.events[0]?.errorClass, 'network');
+    });
+  });
+
+  test('does not infer A/B eligibility from limit-like error text', async () => {
+    await withDir(async (dir) => {
+      const systemPromptPath = join(dir, 'system_prompt.md');
+      await writeFile(systemPromptPath, 'fixed prompt\n', 'utf8');
+
+      const result = await runFixedPromptController({
+        runId: 'run-1',
+        roundId: 'round-1',
+        config,
+        systemPromptPath,
+        resultsJsonlPath: join(dir, 'results.jsonl'),
+        resultsTsvPath: join(dir, 'results.tsv'),
+        tasks: [{ id: 'task-a', path: '/bench/task-a' }],
+        harborRunner: async () => harborOutput({
+          taskId: 'task-a',
+          reward: 0,
+          status: 'failed',
+          errorClass: 'request_limit_exceeded',
+        }),
+        now: () => 100,
+        newId: idFactory(),
+      });
+
+      assert.equal(result.events[0]?.type, 'task_completed');
+      assert.equal(result.events[0]?.eligible, false);
     });
   });
 

--- a/packages/headless/src/__tests__/harbor-cell.test.ts
+++ b/packages/headless/src/__tests__/harbor-cell.test.ts
@@ -326,6 +326,57 @@ describe('runHarborCell', () => {
     });
   });
 
+  test('writes execution identity before the first model call', async () => {
+    await withDirs(async ({ workspaceDir, outputDir, storageRoot }) => {
+      let observedIdentity: unknown;
+      class IdentityObservingBackend implements AgentBackend {
+        readonly kind: BackendKind = 'fake';
+        readonly sessionId: string;
+
+        constructor(sessionId: string) {
+          this.sessionId = sessionId;
+        }
+
+        async *send(input: BackendSendInput): AsyncIterable<SessionEvent> {
+          observedIdentity = JSON.parse(await readFile(
+            join(outputDir, 'maka-cell-execution-identity.json'),
+            'utf8',
+          ));
+          yield {
+            type: 'complete',
+            id: 'identity-observed',
+            turnId: input.turnId,
+            ts: Date.now(),
+            stopReason: 'end_turn',
+          };
+        }
+
+        async stop(): Promise<void> {}
+        async respondToPermission(_decision: PermissionDecision): Promise<void> {}
+        async dispose(): Promise<void> {}
+      }
+
+      await runHarborCell({
+        config,
+        instruction: 'observe identity',
+        cwd: workspaceDir,
+        outputDir,
+        storageRoot,
+        pricingProfile: 'deepseek-v4-flash-tbench-v1',
+        registerBackends: (registry) => {
+          registry.register('fake', (ctx) => new IdentityObservingBackend(ctx.sessionId));
+        },
+      });
+
+      assert.deepEqual(observedIdentity, {
+        llmConnectionSlug: 'fake',
+        model: 'fake-model',
+        systemPromptHash: `sha256:${createHash('sha256').update(JSON.stringify(config.systemPrompt)).digest('hex')}`,
+        pricingProfile: 'deepseek-v4-flash-tbench-v1',
+      });
+    });
+  });
+
   test('env entrypoint reads instruction files and writes the same cell artifacts', async () => {
     await withDirs(async ({ workspaceDir, outputDir, storageRoot }) => {
       const instructionFile = join(outputDir, 'instruction.txt');

--- a/packages/headless/src/__tests__/harbor-task-runner.test.ts
+++ b/packages/headless/src/__tests__/harbor-task-runner.test.ts
@@ -4,7 +4,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, test } from 'node:test';
 import { tokenSummary } from './helpers/cell-output-fixtures.js';
-import type { HarborCellOutput } from '../cell-output.js';
+import type { HarborCellExecutionIdentity, HarborCellOutput } from '../cell-output.js';
 import { FixedPromptBudgetExhaustedError, type HarborTaskRunInput } from '../fixed-prompt-controller.js';
 import {
   buildHarborJobConfig,
@@ -50,6 +50,7 @@ function runInput(overrides: Partial<HarborTaskRunInput> = {}): HarborTaskRunInp
 interface FakeOptions {
   reward?: string;
   cell?: HarborCellOutput | null;
+  executionIdentity?: HarborCellExecutionIdentity;
   exitCode?: number;
   events?: string;
   verifierStdout?: string;
@@ -77,6 +78,13 @@ function fakeRunner(opts: FakeOptions): HarborProcessRunner {
     }
     if (opts.cell !== null) {
       await writeFile(join(trialDir, 'agent', 'maka-cell-output.json'), JSON.stringify(opts.cell ?? cellOutput()), 'utf8');
+    }
+    if (opts.executionIdentity) {
+      await writeFile(
+        join(trialDir, 'agent', 'maka-cell-execution-identity.json'),
+        JSON.stringify(opts.executionIdentity),
+        'utf8',
+      );
     }
     if (opts.trialResult) {
       await writeFile(join(trialDir, 'result.json'), JSON.stringify(opts.trialResult), 'utf8');
@@ -368,6 +376,42 @@ describe('createHarborTaskRunner', () => {
         assert.ok(error instanceof FixedPromptBudgetExhaustedError);
         assert.deepEqual(error.artifactRefs?.tokenSummary, timedCell.tokenSummary);
         assert.deepEqual(error.artifactRefs?.cellOutput?.executionIdentity, timedCell.executionIdentity);
+        return true;
+      });
+    });
+  });
+
+  test('recovers early identity from an agent-timeout trial without cell output', async () => {
+    await withRun(async ({ jobsDir, repo }) => {
+      const executionIdentity = {
+        llmConnectionSlug: 'deepseek',
+        model: 'deepseek-v4-flash',
+        systemPromptHash: 'sha256:abc',
+        pricingProfile: 'test-profile',
+      };
+      const runner = createHarborTaskRunner({
+        makaRepoPath: repo,
+        jobsDir,
+        model: 'deepseek/deepseek-v4-flash',
+        runHarbor: fakeRunner({
+          reward: '0\n',
+          cell: null,
+          executionIdentity,
+          trialResult: {
+            exception_info: {
+              exception_type: 'AgentTimeoutError',
+              exception_message: 'Agent execution timed out after 60.0 seconds',
+            },
+          },
+        }),
+      });
+
+      await assert.rejects(runner(runInput()), (error: unknown) => {
+        assert.ok(error instanceof FixedPromptBudgetExhaustedError);
+        assert.deepEqual(
+          (error.artifactRefs as { executionIdentity?: HarborCellExecutionIdentity } | undefined)?.executionIdentity,
+          executionIdentity,
+        );
         return true;
       });
     });
@@ -676,6 +720,36 @@ describe('createHarborTaskRunner timeout', () => {
         assert.ok(error instanceof FixedPromptBudgetExhaustedError);
         assert.equal(error.artifactRefs?.tokenSummary?.total, 150);
         assert.equal(error.artifactRefs?.cellOutput?.executionIdentity?.model, 'deepseek-v4-flash');
+        return true;
+      });
+    });
+  });
+
+  test('recovers early execution identity when wall timeout precedes cell output', async () => {
+    await withRun(async ({ jobsDir, repo }) => {
+      const executionIdentity = {
+        llmConnectionSlug: 'deepseek',
+        model: 'deepseek-v4-flash',
+        systemPromptHash: 'sha256:abc',
+        pricingProfile: 'test-profile',
+      };
+      const writeArtifacts = fakeRunner({ cell: null, executionIdentity });
+      const runner = createHarborTaskRunner({
+        makaRepoPath: repo,
+        jobsDir,
+        model: 'deepseek/deepseek-v4-flash',
+        runHarbor: async (request) => {
+          await writeArtifacts(request);
+          return { exitCode: 1, stdout: '', stderr: 'timed out', timedOut: true, signal: 'SIGKILL' };
+        },
+      });
+
+      await assert.rejects(runner(runInput()), (error: unknown) => {
+        assert.ok(error instanceof FixedPromptBudgetExhaustedError);
+        assert.deepEqual(
+          (error.artifactRefs as { executionIdentity?: HarborCellExecutionIdentity } | undefined)?.executionIdentity,
+          executionIdentity,
+        );
         return true;
       });
     });

--- a/packages/headless/src/__tests__/runtime-policy-ab-lifecycle.test.ts
+++ b/packages/headless/src/__tests__/runtime-policy-ab-lifecycle.test.ts
@@ -4,7 +4,12 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { test } from 'node:test';
 import type { Config } from '../contracts.js';
-import { hashSystemPrompt, type HarborTaskRunInput, type HarborTaskRunOutput } from '../fixed-prompt-controller.js';
+import {
+  FixedPromptBudgetExhaustedError,
+  hashSystemPrompt,
+  type HarborTaskRunInput,
+  type HarborTaskRunOutput,
+} from '../fixed-prompt-controller.js';
 import { runRuntimePolicyAbLifecycle } from '../runtime-policy-ab-lifecycle.js';
 import { contextBudgetSummary } from './helpers/ab-summary-fixtures.js';
 import { tokenSummary } from './helpers/cell-output-fixtures.js';
@@ -97,6 +102,84 @@ test('pilot without candidate activation does not launch full execution', async 
 
     assert.equal(state.status, 'pilot_not_cleared');
     assert.equal(state.reason, 'pilot_candidate_not_activated');
+    assert.equal(calls.length, 2);
+  });
+});
+
+test('pilot candidate pass against an attested baseline timeout can launch full execution', async () => {
+  await withDir(async (dir) => {
+    const promptPath = join(dir, 'prompt.md');
+    await writeFile(promptPath, 'shared prompt\n', 'utf8');
+    const calls: string[] = [];
+    const state = await runRuntimePolicyAbLifecycle({
+      runId: 'run-1',
+      runRoot: dir,
+      manifestFingerprint: 'sha256:manifest',
+      config,
+      systemPromptPath: promptPath,
+      resultsJsonlPath: join(dir, 'results.jsonl'),
+      pilotTasks: [{ id: 'pilot', path: '/tasks/pilot' }],
+      evaluationTasks: [{ id: 'full', path: '/tasks/full' }],
+      fullReps: 2,
+      arms: [
+        { id: 'prune-off', contextEnv: { MAKA_CONTEXT_BUDGET: 'off' } },
+        { id: 'prune-on', contextEnv: { MAKA_CONTEXT_STALE_TOOL_RESULT_PRUNE: 'on' } },
+      ],
+      executionProfile,
+      harborRunner: async (runInput) => {
+        calls.push(runInput.roundId);
+        const candidate = runInput.agentEnv?.MAKA_CONTEXT_STALE_TOOL_RESULT_PRUNE === 'on';
+        if (runInput.roundId.startsWith('pilot-') && !candidate) {
+          throw new FixedPromptBudgetExhaustedError('pilot budget exhausted', undefined, {
+            executionIdentity: {
+              llmConnectionSlug: 'deepseek',
+              model: 'deepseek-v4-flash',
+              systemPromptHash: hashSystemPrompt(runInput.systemPrompt),
+              pricingProfile: 'test-profile',
+            },
+          });
+        }
+        return output(runInput, candidate);
+      },
+    });
+
+    assert.equal(state.status, 'full_completed');
+    assert.equal(state.pilot?.baseline.budgetExhausted, 1);
+    assert.equal(state.pilot?.candidate.passed, 1);
+    assert.equal(calls.length, 6);
+  });
+});
+
+test('pilot does not launch full execution after an unattested baseline timeout', async () => {
+  await withDir(async (dir) => {
+    const promptPath = join(dir, 'prompt.md');
+    await writeFile(promptPath, 'shared prompt\n', 'utf8');
+    const calls: string[] = [];
+    const state = await runRuntimePolicyAbLifecycle({
+      runId: 'run-1',
+      runRoot: dir,
+      manifestFingerprint: 'sha256:manifest',
+      config,
+      systemPromptPath: promptPath,
+      resultsJsonlPath: join(dir, 'results.jsonl'),
+      pilotTasks: [{ id: 'pilot', path: '/tasks/pilot' }],
+      evaluationTasks: [{ id: 'full', path: '/tasks/full' }],
+      fullReps: 2,
+      arms: [
+        { id: 'prune-off', contextEnv: { MAKA_CONTEXT_BUDGET: 'off' } },
+        { id: 'prune-on', contextEnv: { MAKA_CONTEXT_STALE_TOOL_RESULT_PRUNE: 'on' } },
+      ],
+      executionProfile,
+      harborRunner: async (runInput) => {
+        calls.push(runInput.roundId);
+        const candidate = runInput.agentEnv?.MAKA_CONTEXT_STALE_TOOL_RESULT_PRUNE === 'on';
+        if (!candidate) throw new FixedPromptBudgetExhaustedError('pilot budget exhausted');
+        return output(runInput, true);
+      },
+    });
+
+    assert.equal(state.status, 'pilot_not_cleared');
+    assert.equal(state.reason, 'pilot_plumbing_failure');
     assert.equal(calls.length, 2);
   });
 });

--- a/packages/headless/src/ab-summary.ts
+++ b/packages/headless/src/ab-summary.ts
@@ -92,7 +92,10 @@ function summarizeArm(
   const observedAttempts = observedArmAttempts(runs, taskIds, arm);
   const observed = observedAttempts.map((attempt) => attempt.event);
   const valid = observed.filter(isValidBudgetedOutcome);
-  const budgetedRuns = valid.filter((event) => event.type !== 'task_budget_exhausted');
+  const budgetedRuns = valid.filter(
+    (event): event is Extract<FixedPromptTaskWalEvent, { type: 'task_completed' }> =>
+      event.type === 'task_completed' && abOutcomeCategory(event) !== 'budget',
+  );
   const passed = valid.filter((event) => event.passed).length;
   const durations = budgetedRuns.map((event) => event.durationMs);
   const contextBudget = summarizeContextBudget(observedAttempts);
@@ -107,10 +110,10 @@ function summarizeArm(
     valid: valid.length,
     passed,
     passRate: valid.length > 0 ? passed / valid.length : null,
-    completed: observed.filter((event) => event.type === 'task_completed').length,
-    budgetExhausted: observed.filter((event) => event.type === 'task_budget_exhausted').length,
-    infraFailed: observed.filter((event) => event.type === 'task_infra_failed').length,
-    plumbingFailed: observed.filter((event) => event.type === 'task_plumbing_failed').length,
+    completed: observed.filter((event) => abOutcomeCategory(event) === 'completed').length,
+    budgetExhausted: observed.filter((event) => abOutcomeCategory(event) === 'budget').length,
+    infraFailed: observed.filter((event) => abOutcomeCategory(event) === 'infra').length,
+    plumbingFailed: observed.filter((event) => abOutcomeCategory(event) === 'plumbing').length,
     missing: attempts - observed.length,
     coverageRate: attempts > 0 ? valid.length / attempts : 1,
     totalCostUsd: tokenCostSummary.costUsd,
@@ -140,7 +143,10 @@ function summarizeActivePruneSubset(
   const sliceAttempts = attempts.filter((attempt) => activePrunePairIds.has(attemptPairId(attempt)));
   const observed = sliceAttempts.map((attempt) => attempt.event);
   const valid = observed.filter(isValidBudgetedOutcome);
-  const budgetedRuns = valid.filter((event) => event.type !== 'task_budget_exhausted');
+  const budgetedRuns = valid.filter(
+    (event): event is Extract<FixedPromptTaskWalEvent, { type: 'task_completed' }> =>
+      event.type === 'task_completed' && abOutcomeCategory(event) !== 'budget',
+  );
   const passed = valid.filter((event) => event.passed).length;
   const durations = budgetedRuns.map((event) => event.durationMs);
   const tokenCostSummary = summarizeTokenCost(observed);
@@ -152,10 +158,10 @@ function summarizeActivePruneSubset(
     valid: valid.length,
     passed,
     passRate: valid.length > 0 ? passed / valid.length : null,
-    completed: observed.filter((event) => event.type === 'task_completed').length,
-    budgetExhausted: observed.filter((event) => event.type === 'task_budget_exhausted').length,
-    infraFailed: observed.filter((event) => event.type === 'task_infra_failed').length,
-    plumbingFailed: observed.filter((event) => event.type === 'task_plumbing_failed').length,
+    completed: observed.filter((event) => abOutcomeCategory(event) === 'completed').length,
+    budgetExhausted: observed.filter((event) => abOutcomeCategory(event) === 'budget').length,
+    infraFailed: observed.filter((event) => abOutcomeCategory(event) === 'infra').length,
+    plumbingFailed: observed.filter((event) => abOutcomeCategory(event) === 'plumbing').length,
     missing: activePrunePairIds.size - observed.length,
     coverageRate: activePrunePairIds.size > 0 ? valid.length / activePrunePairIds.size : 1,
     totalCostUsd: tokenCostSummary.costUsd,
@@ -443,10 +449,10 @@ function summarizeTaskArm(
     valid: valid.length,
     passed,
     passRate: valid.length > 0 ? passed / valid.length : null,
-    completed: observed.filter((event) => event.type === 'task_completed').length,
-    budgetExhausted: observed.filter((event) => event.type === 'task_budget_exhausted').length,
-    infraFailed: observed.filter((event) => event.type === 'task_infra_failed').length,
-    plumbingFailed: observed.filter((event) => event.type === 'task_plumbing_failed').length,
+    completed: observed.filter((event) => abOutcomeCategory(event) === 'completed').length,
+    budgetExhausted: observed.filter((event) => abOutcomeCategory(event) === 'budget').length,
+    infraFailed: observed.filter((event) => abOutcomeCategory(event) === 'infra').length,
+    plumbingFailed: observed.filter((event) => abOutcomeCategory(event) === 'plumbing').length,
     missing: reps - observed.length,
   };
 }
@@ -517,7 +523,6 @@ function decide(
   const coverage = Math.min(baseline.coverageRate, candidate.coverageRate);
   if (baseline.infraFailed + candidate.infraFailed > 0) return { decision: 'invalid', reason: 'infra_failure_observed' };
   if (baseline.plumbingFailed + candidate.plumbingFailed > 0) return { decision: 'invalid', reason: 'plumbing_failure_observed' };
-  if (pairedAttempts.budgetDiscordantPairIds.length > 0) return { decision: 'invalid', reason: 'asymmetric_budget_exhaustion' };
   if (coverage < 0.9) return { decision: 'not_cleared', reason: 'low_effective_coverage' };
   if (pairedAttempts.missingPairIds.length > 0) return { decision: 'not_cleared', reason: 'missing_attempt_pair' };
   if (pairedAttempts.infraOrPlumbingDiscordantPairIds.length > 0) {
@@ -566,11 +571,31 @@ function isValidBudgetedOutcome(
 }
 
 function isBudgetExhaustedOutcome(event: FixedPromptTaskWalEvent): boolean {
-  return event.type === 'task_budget_exhausted';
+  return abOutcomeCategory(event) === 'budget';
 }
 
 function isInfraOrPlumbingOutcome(event: FixedPromptTaskWalEvent): boolean {
-  return event.type === 'task_infra_failed' || event.type === 'task_plumbing_failed';
+  const category = abOutcomeCategory(event);
+  return category === 'infra' || category === 'plumbing';
+}
+
+type AbOutcomeCategory = 'completed' | 'budget' | 'infra' | 'plumbing';
+
+function abOutcomeCategory(event: FixedPromptTaskWalEvent): AbOutcomeCategory {
+  if (event.type === 'task_infra_failed') return 'infra';
+  if (event.type === 'task_plumbing_failed') return 'plumbing';
+  if (event.type === 'task_completed') {
+    return event.errorClass === 'tool_step_cap_reached' ? 'budget' : 'completed';
+  }
+  if (event.evidenceErrorClass === undefined) return 'budget';
+  if (
+    event.evidenceErrorClass === 'zero_cost_with_tokens'
+    || event.evidenceErrorClass === 'prompt_hash_mismatch'
+    || event.evidenceErrorClass === 'missing_prompt_hash'
+    || event.evidenceErrorClass === 'missing_execution_identity'
+    || event.evidenceErrorClass === 'execution_identity_mismatch'
+  ) return 'plumbing';
+  return 'infra';
 }
 
 function median(values: readonly number[]): number | null {

--- a/packages/headless/src/cell-output.ts
+++ b/packages/headless/src/cell-output.ts
@@ -165,7 +165,7 @@ export function validateHarborCellOutput(value: unknown): HarborCellOutput {
   const runtimeEventsPath = requireString(value.runtimeEventsPath, 'runtimeEventsPath');
   const promptHash = 'promptHash' in value ? requireOptionalString(value.promptHash, 'promptHash') : undefined;
   const executionIdentity = 'executionIdentity' in value
-    ? validateExecutionIdentity(value.executionIdentity)
+    ? validateHarborCellExecutionIdentity(value.executionIdentity)
     : undefined;
   const tokenSummary = validateTokenSummary(value.tokenSummary);
   const contextBudgetPolicy = 'contextBudgetPolicy' in value
@@ -208,7 +208,7 @@ export function validateHarborCellOutput(value: unknown): HarborCellOutput {
   return output;
 }
 
-function validateExecutionIdentity(value: unknown): HarborCellExecutionIdentity {
+export function validateHarborCellExecutionIdentity(value: unknown): HarborCellExecutionIdentity {
   if (!isRecord(value)) throw new Error('executionIdentity must be a JSON object');
   return {
     llmConnectionSlug: requireString(value.llmConnectionSlug, 'executionIdentity.llmConnectionSlug'),

--- a/packages/headless/src/fixed-prompt-controller.ts
+++ b/packages/headless/src/fixed-prompt-controller.ts
@@ -7,6 +7,7 @@ import {
   type HarborCellContextBudgetPolicySnapshot,
   type HarborCellContextBudgetSummary,
   type HarborCellContinuationSummary,
+  type HarborCellExecutionIdentity,
   type HarborCellOutput,
   type HarborCellTaskToolSummary,
   type HarborCellTokenSummary,
@@ -61,6 +62,7 @@ export interface FixedPromptBudgetExhaustedArtifactRefs {
   runtimeEventsUnavailableReason?: string;
   tokenSummary?: HarborCellTokenSummary;
   cellOutput?: HarborTaskRunCellOutput;
+  executionIdentity?: HarborCellExecutionIdentity;
 }
 
 export class FixedPromptBudgetExhaustedError extends Error {
@@ -94,6 +96,7 @@ export interface FixedPromptTaskCompletedEvent {
   eligible: boolean;
   errorClass?: string;
   promptHash?: string;
+  executionIdentity?: HarborCellExecutionIdentity;
   tokenSummary: HarborCellTokenSummary;
   contextBudgetPolicy?: HarborCellContextBudgetPolicySnapshot;
   contextBudgetSummary?: HarborCellContextBudgetSummary;
@@ -122,7 +125,7 @@ export interface FixedPromptTaskInfraFailedEvent {
   passed: false;
   scored: false;
   eligible: false;
-  errorClass: 'infra_error' | 'provider_billing' | 'auth';
+  errorClass: 'infra_error' | 'provider_billing' | 'auth' | 'rate_limit' | 'provider_unavailable' | 'network';
   error: string;
 }
 
@@ -141,13 +144,14 @@ export interface FixedPromptTaskBudgetExhaustedEvent {
   eligible: boolean;
   errorClass: 'budget_exhausted';
   error: string;
-  evidenceErrorClass?: FixedPromptTaskPlumbingFailedEvent['errorClass'] | UnscoredCellFailureClass | 'provider_billing' | 'auth';
+  evidenceErrorClass?: FixedPromptTaskPlumbingFailedEvent['errorClass'] | UnscoredCellFailureClass | FixedPromptTaskInfraFailedEvent['errorClass'];
   evidenceError?: string;
   expectedPromptHash: string;
   runtimeEventsPath?: string;
   traceEventsPath?: string;
   runtimeEventsUnavailableReason?: string;
   tokenSummary?: HarborCellTokenSummary;
+  executionIdentity?: HarborCellExecutionIdentity;
 }
 
 export interface FixedPromptTaskPlumbingFailedEvent {
@@ -606,7 +610,7 @@ function taskEventFromOutput(input: {
   id: string;
   ts: number;
 }): FixedPromptTaskCompletedEvent | FixedPromptTaskPlumbingFailedEvent | FixedPromptTaskInfraFailedEvent {
-  if (isSystemicProviderFailure(input.output.cell.errorClass)) {
+  if (isProviderInfraFailure(input.output.cell.errorClass)) {
     return taskInfraFailedEvent({
       ...input,
       errorClass: input.output.cell.errorClass,
@@ -643,6 +647,7 @@ function taskCompletedEvent(input: {
   const passed = output.cell.status === 'completed' && output.harbor.reward > 0;
   const errorClass = output.cell.errorClass ?? (passed ? undefined : 'verification_failed');
   const scored = output.cell.status === 'completed' && !isUnscoredCellFailure(errorClass);
+  const agentFailure = output.cell.status === 'failed' && errorClass === 'tool_step_cap_reached';
   return {
     schemaVersion: FIXED_PROMPT_WAL_SCHEMA_VERSION,
     type: 'task_completed',
@@ -655,9 +660,10 @@ function taskCompletedEvent(input: {
     status: output.cell.status,
     passed,
     scored,
-    eligible: scored,
+    eligible: scored || agentFailure,
     ...(errorClass ? { errorClass } : {}),
     ...(output.cell.promptHash ? { promptHash: output.cell.promptHash } : {}),
+    ...(output.cell.executionIdentity ? { executionIdentity: output.cell.executionIdentity } : {}),
     tokenSummary: output.cell.tokenSummary,
     ...(output.cell.contextBudgetPolicy ? { contextBudgetPolicy: output.cell.contextBudgetPolicy } : {}),
     ...(output.cell.contextBudgetSummary ? { contextBudgetSummary: output.cell.contextBudgetSummary } : {}),
@@ -734,7 +740,45 @@ function classifyPlumbingFailure(output: HarborTaskRunOutput, expectedPromptHash
   errorClass: FixedPromptTaskPlumbingFailedEvent['errorClass'];
   error: string;
 } | undefined {
-  const identity = output.cell.executionIdentity;
+  const identityFailure = classifyExecutionIdentityFailure(
+    output.cell.executionIdentity,
+    expectedPromptHash,
+    expectedConfig,
+    requireExecutionIdentity,
+    expectedPricingProfile,
+  );
+  if (identityFailure) return identityFailure;
+  if (output.cell.status === 'completed' && output.cell.promptHash === undefined) {
+    return {
+      errorClass: 'missing_prompt_hash',
+      error: `Harbor cell did not report prompt hash ${expectedPromptHash}`,
+    };
+  }
+  if (output.cell.promptHash !== undefined && output.cell.promptHash !== expectedPromptHash) {
+    return {
+      errorClass: 'prompt_hash_mismatch',
+      error: `Harbor cell prompt hash ${output.cell.promptHash} did not match ${expectedPromptHash}`,
+    };
+  }
+  if (output.cell.tokenSummary.total > 0 && output.cell.tokenSummary.costUsd === 0) {
+    return {
+      errorClass: 'zero_cost_with_tokens',
+      error: 'Harbor cell reported token usage but zero costUsd',
+    };
+  }
+  return undefined;
+}
+
+function classifyExecutionIdentityFailure(
+  identity: HarborCellExecutionIdentity | undefined,
+  expectedPromptHash: string,
+  expectedConfig: Config,
+  requireExecutionIdentity: boolean,
+  expectedPricingProfile: string | undefined,
+): {
+  errorClass: Extract<FixedPromptTaskPlumbingFailedEvent['errorClass'], 'missing_execution_identity' | 'execution_identity_mismatch'>;
+  error: string;
+} | undefined {
   if (requireExecutionIdentity && !identity) {
     return {
       errorClass: 'missing_execution_identity',
@@ -757,24 +801,6 @@ function classifyPlumbingFailure(output: HarborTaskRunOutput, expectedPromptHash
         error: 'Harbor cell execution identity did not match the configured connection, model, and prompt',
       };
     }
-  }
-  if (output.cell.status === 'completed' && output.cell.promptHash === undefined) {
-    return {
-      errorClass: 'missing_prompt_hash',
-      error: `Harbor cell did not report prompt hash ${expectedPromptHash}`,
-    };
-  }
-  if (output.cell.promptHash !== undefined && output.cell.promptHash !== expectedPromptHash) {
-    return {
-      errorClass: 'prompt_hash_mismatch',
-      error: `Harbor cell prompt hash ${output.cell.promptHash} did not match ${expectedPromptHash}`,
-    };
-  }
-  if (output.cell.tokenSummary.total > 0 && output.cell.tokenSummary.costUsd === 0) {
-    return {
-      errorClass: 'zero_cost_with_tokens',
-      error: 'Harbor cell reported token usage but zero costUsd',
-    };
   }
   return undefined;
 }
@@ -827,7 +853,7 @@ function taskBudgetExhaustedEvent(input: {
   } | undefined;
   if (artifactRefs.cellOutput) {
     const output = { harbor: { reward: 0 }, cell: artifactRefs.cellOutput };
-    evidenceFailure = isSystemicProviderFailure(output.cell.errorClass)
+    evidenceFailure = isProviderInfraFailure(output.cell.errorClass)
       ? {
           errorClass: output.cell.errorClass,
           error: `Harbor cell failed with ${output.cell.errorClass}`,
@@ -844,13 +870,20 @@ function taskBudgetExhaustedEvent(input: {
             input.requireExecutionIdentity ?? false,
             input.expectedPricingProfile,
           );
-  } else if (input.requireExecutionIdentity) {
-    evidenceFailure = {
-      errorClass: 'missing_execution_identity',
-      error: LEGACY_TIMEOUT_MISSING_EXECUTION_IDENTITY_ERROR,
-    };
+  } else {
+    evidenceFailure = classifyExecutionIdentityFailure(
+      artifactRefs.executionIdentity,
+      input.expectedPromptHash,
+      input.expectedConfig,
+      input.requireExecutionIdentity ?? false,
+      input.expectedPricingProfile,
+    );
+    if (evidenceFailure?.errorClass === 'missing_execution_identity') {
+      evidenceFailure = { ...evidenceFailure, error: LEGACY_TIMEOUT_MISSING_EXECUTION_IDENTITY_ERROR };
+    }
   }
   const tokenSummary = artifactRefs.cellOutput?.tokenSummary ?? artifactRefs.tokenSummary;
+  const executionIdentity = artifactRefs.cellOutput?.executionIdentity ?? artifactRefs.executionIdentity;
   return {
     schemaVersion: FIXED_PROMPT_WAL_SCHEMA_VERSION,
     type: 'task_budget_exhausted',
@@ -871,6 +904,7 @@ function taskBudgetExhaustedEvent(input: {
       evidenceError: evidenceFailure.error,
     } : {}),
     expectedPromptHash: input.expectedPromptHash,
+    ...(executionIdentity ? { executionIdentity } : {}),
     ...(artifactRefs.runtimeEventsPath ? { runtimeEventsPath: artifactRefs.runtimeEventsPath } : {}),
     ...(artifactRefs.traceEventsPath ? { traceEventsPath: artifactRefs.traceEventsPath } : {}),
     ...(artifactRefs.runtimeEventsUnavailableReason
@@ -916,7 +950,17 @@ function projectLegacyTimeoutOutcome(event: FixedPromptWalEvent): FixedPromptWal
 function budgetExhaustedArtifactRefs(error: unknown): FixedPromptBudgetExhaustedArtifactRefs {
   if (isBudgetExhaustedError(error)) {
     const refs = (error as { artifactRefs?: FixedPromptBudgetExhaustedArtifactRefs }).artifactRefs;
-    if (refs && (refs.runtimeEventsPath || refs.traceEventsPath || refs.runtimeEventsUnavailableReason || refs.tokenSummary || refs.cellOutput)) return refs;
+    if (
+      refs
+      && (
+        refs.runtimeEventsPath
+        || refs.traceEventsPath
+        || refs.runtimeEventsUnavailableReason
+        || refs.tokenSummary
+        || refs.cellOutput
+        || refs.executionIdentity
+      )
+    ) return refs;
   }
   return { runtimeEventsUnavailableReason: BUDGET_EXHAUSTED_RUNTIME_UNAVAILABLE_REASON };
 }
@@ -1018,6 +1062,15 @@ function controllerStopReason(input: {
 
 function isSystemicProviderFailure(errorClass: string | undefined): errorClass is 'provider_billing' | 'auth' {
   return errorClass === 'provider_billing' || errorClass === 'auth';
+}
+
+function isProviderInfraFailure(
+  errorClass: string | undefined,
+): errorClass is 'provider_billing' | 'auth' | 'rate_limit' | 'provider_unavailable' | 'network' {
+  return isSystemicProviderFailure(errorClass)
+    || errorClass === 'rate_limit'
+    || errorClass === 'provider_unavailable'
+    || errorClass === 'network';
 }
 
 function infraFailureRate(events: readonly FixedPromptTaskWalEvent[], taskCount: number): number {

--- a/packages/headless/src/harbor-cell.ts
+++ b/packages/headless/src/harbor-cell.ts
@@ -58,6 +58,7 @@ import {
 
 export const HARBOR_CELL_OUTPUT_FILENAME = 'maka-cell-output.json';
 export const HARBOR_CELL_RUNTIME_EVENTS_FILENAME = 'runtime-events.jsonl';
+export const HARBOR_CELL_EXECUTION_IDENTITY_FILENAME = 'maka-cell-execution-identity.json';
 const execAsync = promisify(nodeExec);
 const HARBOR_CELL_TOOL_MAX_BUFFER_BYTES = 10 * 1024 * 1024;
 
@@ -298,6 +299,19 @@ export async function runHarborCell(input: RunHarborCellInput): Promise<RunHarbo
       ? { realBackendIsolation: input.realBackendIsolation, toolExecutor: input.realBackendIsolation?.toolExecutor }
       : {}),
   });
+  if (!config.model) throw new Error('Harbor cell config must include a model for execution identity');
+  const executionIdentity = {
+    llmConnectionSlug: config.llmConnectionSlug,
+    model: config.model,
+    systemPromptHash: hashHarborSystemPrompt(config.systemPrompt ?? ''),
+    pricingProfile: input.pricingProfile ?? 'unconfigured',
+  };
+  await mkdir(input.outputDir, { recursive: true });
+  await writeFile(
+    join(input.outputDir, HARBOR_CELL_EXECUTION_IDENTITY_FILENAME),
+    `${JSON.stringify(executionIdentity, null, 2)}\n`,
+    'utf8',
+  );
 
   let invocation: InvocationResult | undefined;
   const manager = new SessionManager({
@@ -366,7 +380,6 @@ export async function runHarborCell(input: RunHarborCellInput): Promise<RunHarbo
     throw new Error('Harbor cell finished without a runtime invocation result');
   }
   const combinedInvocation = combineInvocations(invocations);
-  if (!config.model) throw new Error('Harbor cell config must include a model for execution identity');
   const continuationSummary = continuationPolicy.enabled
     ? buildContinuationSummary(continuationPolicy, invocations, stepCapHits)
     : undefined;
@@ -378,12 +391,7 @@ export async function runHarborCell(input: RunHarborCellInput): Promise<RunHarbo
   const output = validateHarborCellOutput(buildHarborCellOutput({
     invocation: combinedInvocation,
     runtimeEventsPath,
-    executionIdentity: {
-      llmConnectionSlug: config.llmConnectionSlug,
-      model: config.model,
-      systemPromptHash: hashHarborSystemPrompt(config.systemPrompt ?? ''),
-      pricingProfile: input.pricingProfile ?? 'unconfigured',
-    },
+    executionIdentity,
     ...(input.contextBudgetPolicy ? { contextBudgetPolicy: input.contextBudgetPolicy } : {}),
     ...(continuationSummary ? { continuationSummary } : {}),
     ...(input.taskToolSummaryEnabled !== undefined ? { taskToolSummaryEnabled: input.taskToolSummaryEnabled } : {}),

--- a/packages/headless/src/harbor-task-runner.ts
+++ b/packages/headless/src/harbor-task-runner.ts
@@ -3,7 +3,12 @@ import { mkdir, readFile, readdir, rm } from 'node:fs/promises';
 import { writeFile } from 'node:fs/promises';
 import { basename, delimiter, join } from 'node:path';
 import { promisify } from 'node:util';
-import { validateHarborCellOutput, type HarborCellOutput } from './cell-output.js';
+import {
+  validateHarborCellExecutionIdentity,
+  validateHarborCellOutput,
+  type HarborCellExecutionIdentity,
+  type HarborCellOutput,
+} from './cell-output.js';
 import {
   FixedPromptBudgetExhaustedError,
   type FixedPromptBudgetExhaustedError as FixedPromptBudgetExhaustedErrorType,
@@ -16,6 +21,7 @@ const execFileAsync = promisify(execFile);
 
 const CONTAINER_MAKA_REPO = '/opt/maka-agent';
 const TRIAL_CELL_OUTPUT = 'agent/maka-cell-output.json';
+const TRIAL_EXECUTION_IDENTITY = 'agent/maka-cell-execution-identity.json';
 const TRIAL_RUNTIME_EVENTS = 'agent/runtime-events.jsonl';
 const TRIAL_REWARD = 'verifier/reward.txt';
 const TRIAL_VERIFIER_STDOUT = 'verifier/test-stdout.txt';
@@ -196,11 +202,11 @@ export function createHarborTaskRunner(options: HarborTaskRunnerOptions): Harbor
 
     const trialException = await readTrialException(resultPath);
     if (trialException && isBudgetExhaustedTrialException(trialException)) {
-      const cell = await readOptionalCellOutput(cellOutputPath, input.task.id);
+      const artifactRefs = await readTimedOutTrialArtifacts(trialDir, input.task.id);
       throw new FixedPromptBudgetExhaustedError(
         `agent budget exhausted for task ${input.task.id}`,
         trialException,
-        cell ? cellArtifactRefs(cell, hostEventsPath, trialDir) : undefined,
+        artifactRefs ?? undefined,
       );
     }
     const reward = await readReward(rewardPath, resultPath, input.task.id);
@@ -263,8 +269,22 @@ function cellArtifactRefs(cell: HarborCellOutput, hostEventsPath: string, trialD
 async function readTimedOutCellArtifacts(jobDir: string, taskName: string, taskId: string) {
   try {
     const trialDir = await findTrialDir(jobDir, taskName);
-    const cell = await readOptionalCellOutput(join(trialDir, TRIAL_CELL_OUTPUT), taskId);
-    return cell ? cellArtifactRefs(cell, join(trialDir, TRIAL_RUNTIME_EVENTS), trialDir) : null;
+    return await readTimedOutTrialArtifacts(trialDir, taskId);
+  } catch {
+    return null;
+  }
+}
+
+async function readTimedOutTrialArtifacts(trialDir: string, taskId: string) {
+  const cell = await readOptionalCellOutput(join(trialDir, TRIAL_CELL_OUTPUT), taskId);
+  if (cell) return cellArtifactRefs(cell, join(trialDir, TRIAL_RUNTIME_EVENTS), trialDir);
+  const executionIdentity = await readOptionalExecutionIdentity(join(trialDir, TRIAL_EXECUTION_IDENTITY));
+  return executionIdentity ? { executionIdentity } : null;
+}
+
+async function readOptionalExecutionIdentity(path: string): Promise<HarborCellExecutionIdentity | null> {
+  try {
+    return validateHarborCellExecutionIdentity(JSON.parse(await readFile(path, 'utf8')));
   } catch {
     return null;
   }

--- a/packages/headless/src/runtime-policy-ab-lifecycle.ts
+++ b/packages/headless/src/runtime-policy-ab-lifecycle.ts
@@ -84,10 +84,9 @@ export async function runRuntimePolicyAbLifecycle(
 
 function pilotClearanceFailure(summary: RuntimePolicyAbComparisonSummary): string | undefined {
   if (summary.stopReason) return summary.stopReason;
-  if (summary.pairedAttempts.budgetDiscordantPairIds.length > 0) return 'pilot_asymmetric_budget_exhaustion';
-  if (summary.baseline.coverageRate !== 1 || summary.candidate.coverageRate !== 1) return 'pilot_incomplete';
   if (summary.baseline.infraFailed + summary.candidate.infraFailed > 0) return 'pilot_infra_failure';
   if (summary.baseline.plumbingFailed + summary.candidate.plumbingFailed > 0) return 'pilot_plumbing_failure';
+  if (summary.baseline.coverageRate !== 1 || summary.candidate.coverageRate !== 1) return 'pilot_incomplete';
   if ((summary.candidate.contextBudget?.activatedAttempts ?? 0) === 0) return 'pilot_candidate_not_activated';
   return undefined;
 }


### PR DESCRIPTION
## Summary

- attest timeout outcomes with execution identity before A/B attribution
- classify budget, infrastructure, and plumbing outcomes consistently across summaries and pilot gates
- preserve recoverable WAL results while failing closed on unattested or provider-failed attempts

## Why

Timeout and step-cap outcomes could previously be misclassified across controller, summary, and lifecycle layers. This could distort coverage, cost, and A/B validity decisions.

## Scope

Changed:

- execution identity sidecar and timeout recovery
- canonical A/B outcome classification
- network/provider failure handling
- WAL compatibility and pilot gating
- regression coverage for timeout, step-cap, identity, and provider failures

Not included:

- provider-side proof of the physical upstream model route
- benchmark experiment result changes

## Verification

- `npm run -w @maka/headless test` — 791 passed, 1 conditional skip
- `npm run typecheck`
- independent fresh-eye review — Go

## User-facing impact

None. No migration, documentation, or changelog changes required.

## Reviewer notes

The main review boundary is whether persisted evidence remains the sole authority for A/B attribution. Unknown evidence fails closed as infrastructure failure.
