### PR TITLE
docs: drop stale stream-substrate cross-references from comments

### DIFF
--- a/apps/desktop/src/main/__tests__/chat-stream-cascade-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/chat-stream-cascade-contract.test.ts
@@ -58,7 +58,7 @@ describe('chat tool-output stream migration contract (#332 PR3)', () => {
       '.maka-tool-output-stream-chunk',
       '.maka-tool-output-stream-redacted-tag',
       '.maka-tool-output-stream-truncated-tag',
-      // the dot's per-feature breath is retired onto the shared `maka-pulse`.
+      // the dot's per-feature breath is retired.
       '@keyframes maka-tool-output-stream-pulse',
     ]) {
       assert.ok(

--- a/apps/desktop/src/main/__tests__/design-system-governance-406-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/design-system-governance-406-contract.test.ts
@@ -147,8 +147,8 @@ describe('issue #406 design-system governance contract', () => {
         if (raw.includes('animation: none') || raw.includes('[animation:none]')) continue;
         const captured = match.slice(1).find(Boolean) ?? raw;
         // Extract the first identifier (the animation-name) from the captured
-        // string. CSS form: "maka-pulse 1.4s ease-in-out infinite".
-        // Tailwind arbitrary: "maka-pulse_1.4s_ease-in-out_infinite".
+        // string. CSS form: "maka-tool-pulse 1.5s ease-in-out infinite".
+        // Tailwind arbitrary: "maka-tool-pulse_1.5s_ease-in-out_infinite".
         const animName = captured.replace(/[_\s].*$/, '').replace(/^@keyframes\s+/, '');
         if (functionalMotion.has(animName)) continue;
         violations.push(`${name}: ${raw}`);

--- a/apps/desktop/src/renderer/maka-tokens.css
+++ b/apps/desktop/src/renderer/maka-tokens.css
@@ -1442,7 +1442,7 @@
 /* Governance-level keyframe for the `TextShimmer` primitive (streaming UI
    rework). A named `@keyframes` is a global rule, not an element property, so
    it can't be a Tailwind leaf-literal — it lives here (the shared motion home)
-   like `maka-pulse` / `maka-tool-pulse`, with the shimmer's other declarations
+   like `maka-tool-pulse`, with the shimmer's other declarations
    as literal utilities in the primitive. Sweeps a clipped light band left→right
    across the glyph shape by translating `background-position`; the two-layer
    primitive keeps an opaque base underneath so the text stays readable. Frozen

--- a/packages/ui/src/primitives/chat.tsx
+++ b/packages/ui/src/primitives/chat.tsx
@@ -263,13 +263,13 @@ export function Marker({
  * (`background-clip: text` + transparent fill) so a light band travels across
  * the letters. The band motion is the one declaration that can't be a leaf
  * literal — it rides the governed `@keyframes maka-text-shimmer` in
- * maka-tokens.css (like `LiveIndicator`'s `maka-pulse`) plus the literal
+ * maka-tokens.css plus the literal
  * utilities here.
  *
  * `active={false}` (or reduced-motion) renders just the base text — callers
  * pass `active` false for settled/snap states so the sweep never runs in a
  * deterministic capture. Kept INTERNAL (off the package barrel, imported by
- * relative path) like `LiveIndicator` — its only consumers live in `@maka/ui`.
+ * relative path) — its only consumers live in `@maka/ui`.
  *
  * `delayed` (#646 run→done seam) holds the sweep at its resting frame for
  * `--duration-emphasized` (~200ms) before it starts — a purely CSS de-flicker so
@@ -331,7 +331,7 @@ export function TextShimmer({
  * Every value is a LITERAL arbitrary utility that compiles 1:1 to the
  * declaration it replaces, so the cva source string IS the computed-style proof
  * (the cascade contract asserts the exact strings, no browser needed). Literals
- * over the semantic scale for the same reason as `markerVariants` / `streamVariants`:
+ * over the semantic scale for the same reason as `markerVariants`:
  * the retired CSS hardcoded these pixels, so the literal is the faithful,
  * self-evidently-equal translation and is immune to later scale/token re-tuning
  * (the visual refresh, not this governance pass, owns adopting the scale).
@@ -341,7 +341,7 @@ export function TextShimmer({
  * pinned by the PR3b cascade contract (source strings + keyframe frames) rather
  * than the diff harness:
  *   1. the running status dot's `[animation:maka-tool-pulse …]` breath (the
- *      shorthand rides in the `dot` part here like `LiveIndicator`; only the
+ *      shorthand rides in the `dot` part here; only the
  *      `@keyframes maka-tool-pulse` stays in CSS — a keyframe is a global rule,
  *      not an element property, and `getComputedStyle` reads a phase-dependent
  *      value). The running dot's box-shadow RING is a leaf rest-state literal, so
@@ -349,13 +349,12 @@ export function TextShimmer({
  *   2. the native `<summary>` marker reset (`::-webkit-details-marker` /
  *      `::marker`) — pseudo-elements with no leaf-utility form. Kept as residue.
  * (The reduced-motion / visual-smoke suppression both ride GLOBAL `*` rules in
- * maka-tokens.css / base.css, so — unlike `LiveIndicator`, a reusable primitive
- * that carries its own `motion-reduce:` guards — the dot and card need no
- * per-element motion utilities; the same global rules cover them as before.)
+ * maka-tokens.css / base.css, so the dot and card need no per-element motion
+ * utilities; the same global rules cover them as before.)
  *
  * The single consumer (`ToolActivity`) renders a Base UI Collapsible and applies
  * these by `className`. `toolVariants` is kept OFF the package barrel for the
- * same reason as `markerVariants` / `streamVariants`: the only consumer imports
+ * same reason as `markerVariants`: the only consumer imports
  * it by relative path, so the part set stays an internal, freely-removable
  * styling detail.
  *
@@ -450,7 +449,7 @@ export { toolVariants };
  * to keep those shells pixel-identical; the PR4 cascade contract pins the absence
  * of the retired selectors + the escape literals). Literals over the semantic
  * scale for the same reason as
- * `markerVariants` / `streamVariants` / `toolVariants`: the retired CSS hardcoded
+ * `markerVariants` / `toolVariants`: the retired CSS hardcoded
  * these pixels, so the literal is the faithful, self-evidently-equal translation
  * and is immune to later scale/token re-tuning (the visual refresh, not this
  * governance pass, owns adopting the scale).

--- a/scripts/check-chat-marker-computed-style.mjs
+++ b/scripts/check-chat-marker-computed-style.mjs
@@ -4,9 +4,7 @@
  * tool live-output stream shell migration (#332 / PR3). Feed it a PRE-PR2
  * renderer CSS bundle as `main.css` — both the bespoke `.maka-turn-*` (marker)
  * and `.maka-tool-output-stream-*` (stream) families predate PR2, so a single
- * pre-PR2 baseline greens every row. The `LiveIndicator` pulse DOT is the one
- * element NOT diffed (animated → `getComputedStyle` is phase-dependent); it is
- * pinned by the cascade contract's `@keyframes maka-pulse` frames instead.
+ * pre-PR2 baseline greens every row.
  *
  * #332 requires the governance pass to be "locked by computed-style /
  * cascade contract tests + before/after screenshots". The cascade

--- a/scripts/check-chat-marker-computed-style.mjs
+++ b/scripts/check-chat-marker-computed-style.mjs
@@ -1,10 +1,12 @@
 #!/usr/bin/env node
 /**
- * Zero-visual proof for the chat `Marker` migration (#332 / PR2 #337) and the
- * tool live-output stream shell migration (#332 / PR3). Feed it a PRE-PR2
- * renderer CSS bundle as `main.css` — both the bespoke `.maka-turn-*` (marker)
- * and `.maka-tool-output-stream-*` (stream) families predate PR2, so a single
- * pre-PR2 baseline greens every row.
+ * Zero-visual proof for the chat `Marker` migration (#332 / PR2 #337). Feed it
+ * a PRE-PR2 renderer CSS bundle as `main.css` — the bespoke `.maka-turn-*`
+ * (marker) chrome predates PR2, so a pre-PR2 baseline supplies the retired
+ * chrome on the `main` side of the marker rows. (The PR3 tool live-output
+ * stream shell this harness was originally built to prove has since been
+ * retired; the quiet tool-output panel pinned on both sides with the same
+ * production classes is a layout-invariant check, not a stream migration pair.)
  *
  * #332 requires the governance pass to be "locked by computed-style /
  * cascade contract tests + before/after screenshots". The cascade
@@ -27,9 +29,9 @@
  * `footer-rest` must read `border-radius: 8px`, not the UA `0px`).
  *
  * What this renders + diffs `main` vs head: the resting box / typography /
- * color / transition style of all 9 marker families and the PR3 stream shell
- * (panel / header / flags + their data-variant pills / body / chunk, resting AND
- * with `data-live="true"` for the accent border + inset ring), plus the footer
+ * color / transition style of all 9 marker families and the quiet tool-output
+ * panel (panel / command / body — same production classes on both sides, a
+ * layout invariant rather than a retired stream migration pair), plus the footer
  * action across resting / pending / copy-pending / copied / failed —
  * including `main`'s old pending `secondary` variant vs the new always-
  * `quiet` shell, which proves that variant switch was visually inert (the


### PR DESCRIPTION
## Summary

Strips stale prose cross-references to the retired stream substrate (`streamVariants`, `LiveIndicator`, `@keyframes maka-pulse`) from comments across 5 files, and corrects the computed-style script header that still claimed to diff the retired PR3 stream shell. #736 already removed the symbols, keyframe, and their registry/guard; this PR finishes the removal at the documentation layer — comments only, no code or CSS declarations changed.

## Why

Refs #736

After #736 squash-merged (b1817414), comments still cited the removed symbols as if they existed ("like `LiveIndicator`'s `maka-pulse`", "for the same reason as `markerVariants` / `streamVariants`", "pinned by ... `@keyframes maka-pulse` frames", "retired onto the shared `maka-pulse`"), and the computed-style script header still claimed to diff the retired stream shell's header/flags/pills/chunk/`data-live`. A reader following those references hits dead ends (or the #736 "stays removed" guard), so the prose is stale.

## Scope

Changed (comments only):
- `packages/ui/src/primitives/chat.tsx` — TextShimmer / toolVariants / previewVariants doc comments no longer cite `LiveIndicator` / `maka-pulse` / `streamVariants` as live peers.
- `apps/desktop/src/renderer/maka-tokens.css` — `maka-text-shimmer` keyframe doc cites `maka-tool-pulse` (still in use) instead of the removed `maka-pulse`.
- `scripts/check-chat-marker-computed-style.mjs` — (1) header drops the stale `LiveIndicator` / `maka-pulse` "one element not diffed" sentence; (2) header's opening paragraph and "What this renders" passage corrected to state the current coverage (marker-migration baseline + quiet-panel layout-invariant check) instead of the retired stream shell's header/flags/pills/chunk/`data-live`. The PR3b section's `maka-tool-pulse` running-dot note still stands. (2) was found by Codex review.
- `apps/desktop/src/main/__tests__/design-system-governance-406-contract.test.ts` — animation-name extraction example uses `maka-tool-pulse` (in use) instead of `maka-pulse`.
- `apps/desktop/src/main/__tests__/chat-stream-cascade-contract.test.ts` — drop the dead "onto the shared `maka-pulse`" destination from the per-feature breath comment.

Not included (intentionally kept):
- The #736 "stays removed" guard code + its intent comments in `chat-stream-cascade-contract.test.ts` (the describe-block retirement narrative and the `streamVariants` / `LiveIndicator` / `@keyframes maka-pulse` absence assertions) — these are the guard itself and accurate history.
- `scripts/check-chat-marker-computed-style.mjs:113` "after streamVariants retirement" — an accurate retirement marker, not a stale cross-reference.
- `markerVariants` (chat-view.tsx), `toolVariants` (tool-activity.tsx), and `@keyframes maka-tool-pulse` — still in production; only mentioned in comments, not deletion targets.

## Verification

- `chat-stream-cascade-contract` + `chat-tool-card-cascade-contract` + `design-system-governance-406` contract tests: 15/15 pass (`node --test` on the compiled fixtures; covers the #736 "stays removed" guard, the governance motion guard, and the fixture-alignment assertions — which match code identifiers, not header prose).
- `@maka/ui` typecheck, `@maka/desktop` typecheck (main + renderer + storybook): all green.
- Comments-only diff (5 files); no code or CSS declarations changed.
- Codex review (effort=max, read-only): no P0/P1; one P2 (the script-header coverage claim) found and fixed in commit ea834815; the 11 symbol cross-reference edits confirmed correct and minimal.

## User-facing impact

None — comments only.

## Reviewer notes

The line between "stale cross-reference" (cleaned) and "accurate retirement narrative" (kept): a reference that presents a removed symbol as a current example/peer/destination was cleaned; a reference that explicitly marks a symbol as retired ("after X retirement", "X predate PR2", the guard's "stays removed" assertions) was kept. A Codex review flagged one P2 beyond the symbol-name grep — the script header still claimed to diff the retired PR3 stream shell's header/flags/pills/chunk/`data-live`. The guiding principle was expanded accordingly: comments must truthfully state current behavior/coverage; history must be explicitly framed as past. See "Not included" for the kept set and commit ea834815 for the header correction.

## Checklist

- [x] Scope matches the PR title and excludes unrelated changes
- [x] Verification lists commands/results, or explains why they were not run
- [x] User-facing impact, docs, changelog, migrations, and breaking changes are noted, or marked none
- [x] Risk, rollback, or review focus is called out for non-trivial changes
- [x] UI changes include screenshots/video, or explain why not applicable