### PR TITLE
feat(runtime): add Linux bubblewrap sandbox backend

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,15 +31,17 @@ jobs:
         with:
           node-version: '22'
           cache: npm
-      # runtime's Grep tool shells out to ripgrep. Install only if the runner
-      # image doesn't already provide it (24.04 hasn't in practice).
-      - name: Ensure ripgrep
-        run: command -v rg >/dev/null 2>&1 || { sudo apt-get update && sudo apt-get install -y ripgrep; }
+      - name: Install Linux runtime dependencies
+        run: sudo apt-get update && sudo apt-get install -y ripgrep bubblewrap
       - run: npm ci
       # build:test skips the renderer bundle (vite); test:dist only consumes
       # tsc outputs (dist/main + dist/renderer side-files), never the vite
       # bundle. e2e builds its own renderer in a separate job.
       - run: npm run build:test
+      - name: Linux sandbox smoke
+        env:
+          MAKA_REQUIRE_LINUX_SANDBOX_SMOKE: '1'
+        run: npm exec -w @maka/runtime -- node --test dist/__tests__/linux-sandbox-smoke.test.js
       # test:dist runs the suites against the dist just built above. The
       # workspace `test` scripts each do `clean && build` first, which would
       # throw away this dist and rebuild every package a second time.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,16 @@ jobs:
           cache: npm
       - name: Install Linux runtime dependencies
         run: sudo apt-get update && sudo apt-get install -y ripgrep bubblewrap
+      # Ubuntu 24.04 hosted runners gate unprivileged user namespaces through
+      # AppArmor, which otherwise makes bwrap fail while configuring loopback.
+      - name: Enable bubblewrap user namespaces
+        run: |
+          if [[ -e /proc/sys/kernel/apparmor_restrict_unprivileged_userns ]]; then
+            sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
+          fi
+          if [[ -e /proc/sys/kernel/unprivileged_userns_clone ]]; then
+            sudo sysctl -w kernel.unprivileged_userns_clone=1
+          fi
       - run: npm ci
       # build:test skips the renderer bundle (vite); test:dist only consumes
       # tsc outputs (dist/main + dist/renderer side-files), never the vite

--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -73,6 +73,7 @@ import {
   PermissionEngine,
   SessionManager,
   buildBuiltinTools,
+  createBuiltinSandboxManager,
   buildChildAgentTools,
   buildSubagentProjectionTools,
   buildSubagentSpawnTool,
@@ -527,6 +528,7 @@ const shellRuns = new ShellRunProcessManager({
     safeSendToRenderer('shell-runs:update', update);
   },
 });
+const sandboxManager = createBuiltinSandboxManager();
 // Unified tool availability (issue #37). Deferred capability groups (Rive,
 // Office, browser, agent orchestration) are withheld from the
 // per-turn prompt and loaded on demand via `load_tools`, keeping their schemas
@@ -561,6 +563,7 @@ const builtinTools: MakaTool[] = [
     runtimeResources: shellRuns,
     backgroundTasks: shellRuns,
     ptyControls: shellRuns,
+    ...(sandboxManager ? { sandboxManager } : {}),
   }).filter((tool: MakaTool) => tool.name !== 'Edit'),
   // External reference lazy-skill pattern: the prompt lists available skills,
   // and this read-only tool loads the full SKILL.md only when the task matches.
@@ -589,7 +592,9 @@ const builtinTools: MakaTool[] = [
 // Child agents stay file-only for local reads; parent runtime refs such as
 // maka://runtime/background-tasks/<id> are not part of their tool surface.
 const childAgentTools = buildChildAgentTools([
-  ...buildBuiltinTools().filter((tool: MakaTool) => tool.name !== 'Edit'),
+  ...buildBuiltinTools({
+    ...(sandboxManager ? { sandboxManager } : {}),
+  }).filter((tool: MakaTool) => tool.name !== 'Edit'),
   webSearchTool,
 ]);
 let lookupPricing = buildPricingLookup();

--- a/docs/archive/2026-07-12-linux-bubblewrap-sandbox.md
+++ b/docs/archive/2026-07-12-linux-bubblewrap-sandbox.md
@@ -1,0 +1,152 @@
+# Linux Bubblewrap Sandbox Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a fail-closed Linux bubblewrap backend to Maka's existing `PermissionProfile` and `SandboxManager` runtime, then wire Bash execution through it on Linux.
+
+**Architecture:** Keep upstream's canonical permission model and registered `SandboxBackend` interface. Add Linux capability probing and a `LinuxBubblewrapBackend` that materializes path context into bubblewrap argv, register it in the default manager, and pass the effective session profile into foreground and background Bash execution. Commands remain argv-based so wrapper quoting cannot escape the sandbox.
+
+**Tech Stack:** TypeScript, Node.js child processes, bubblewrap (`bwrap`), Node test runner.
+
+---
+
+### Task 1: Synchronize With Upstream Sandbox Foundations
+
+**Files:**
+- Rebase: current worktree onto `origin/main`
+- Preserve: all tracked and untracked Linux sandbox work
+
+- [ ] **Step 1: Fetch and compare the remote heads**
+
+Run: `git fetch --prune origin && git rev-list --left-right --count HEAD...origin/main`
+
+Expected: remote refs update and the ahead/behind count is known.
+
+- [ ] **Step 2: Preserve the current implementation in a local commit**
+
+Run: `git add <sandbox-related-files> && git commit -m "feat(runtime): add Linux sandbox backend"`
+
+Expected: the worktree implementation is recoverable throughout the rebase.
+
+- [ ] **Step 3: Rebase onto the fetched main branch**
+
+Run: `git rebase origin/main`
+
+Expected: conflicts are limited to files upstream introduced or changed for the macOS sandbox foundation.
+
+- [ ] **Step 4: Resolve conflicts in favor of upstream abstractions**
+
+Keep `SandboxBackend`, `SandboxTransformRequest`, `SandboxTransformResult`, and `createDefaultSandboxManager`; port only Linux-specific behavior and shared Bash integration.
+
+### Task 2: Linux Capability Probe and Backend Contract
+
+**Files:**
+- Create: `packages/runtime/src/sandbox/linux-capability.ts`
+- Create: `packages/runtime/src/sandbox/linux-sandbox.ts`
+- Modify: `packages/runtime/src/sandbox/types.ts`
+- Modify: `packages/runtime/src/sandbox/index.ts`
+- Test: `packages/runtime/src/__tests__/linux-sandbox.test.ts`
+- Test: `packages/runtime/src/__tests__/sandbox-manager.test.ts`
+
+- [ ] **Step 1: Write tests for capability and backend selection**
+
+Cover non-Linux, missing `bwrap`, executable `bwrap`, registered Linux backend selection, and clear fail-closed errors.
+
+- [ ] **Step 2: Run tests and verify RED**
+
+Run: `npm --workspace @maka/runtime run build && node --test packages/runtime/dist/__tests__/linux-sandbox.test.js packages/runtime/dist/__tests__/sandbox-manager.test.js`
+
+Expected: Linux backend exports/selection tests fail because the backend is not yet registered.
+
+- [ ] **Step 3: Implement the minimal backend**
+
+Implement `LinuxBubblewrapBackend.transform()` using the existing result union. Probe the configured `bwrap` executable and return `backend_not_available` when enforcement cannot be provided.
+
+- [ ] **Step 4: Run tests and verify GREEN**
+
+Run the same focused test command.
+
+Expected: all contract tests pass.
+
+### Task 3: Bubblewrap Filesystem and Network Policy
+
+**Files:**
+- Modify: `packages/runtime/src/sandbox/linux-sandbox.ts`
+- Test: `packages/runtime/src/__tests__/linux-sandbox.test.ts`
+- Test: `packages/runtime/src/__tests__/linux-sandbox-smoke.test.ts`
+
+- [ ] **Step 1: Write argv contract tests**
+
+Cover read-only roots, writable workspace roots, writable temp paths, protected metadata read-only overlays, `--unshare-net` for restricted networking, no network namespace for enabled networking, cwd, inner argv, and unsupported deny entries.
+
+- [ ] **Step 2: Run tests and verify RED**
+
+Expected: missing mount/network arguments or unsupported policy behavior fails with precise assertions.
+
+- [ ] **Step 3: Materialize profile entries and path context**
+
+Resolve special paths from `SandboxPathContext`, mount required host runtime paths read-only, bind allowed write roots, overlay existing protected metadata read-only, create an isolated `/tmp`, and include process/session namespaces.
+
+- [ ] **Step 4: Fail closed for semantics bubblewrap cannot faithfully enforce**
+
+Return `invalid_request` for deny entries that cannot be represented and never fall back to host execution.
+
+- [ ] **Step 5: Run unit and Linux-only smoke tests**
+
+Smoke assertions: workspace write succeeds, outside write fails, existing protected metadata write fails, restricted network fails, and non-Linux or unavailable bubblewrap skips with an explicit reason.
+
+### Task 4: Register and Wire Linux Bash Execution
+
+**Files:**
+- Modify: `packages/runtime/src/sandbox/default-sandbox-manager.ts`
+- Modify: `packages/runtime/src/builtin-tools.ts`
+- Modify: `packages/runtime/src/shell-tools.ts`
+- Modify: `packages/runtime/src/shell-run-manager.ts`
+- Modify: `packages/runtime/src/tool-runtime.ts`
+- Modify: `packages/cli/src/runtime-bootstrap.ts`
+- Modify: `apps/desktop/src/main/main.ts`
+- Test: `packages/runtime/src/__tests__/builtin-tools.test.ts`
+- Test: `packages/runtime/src/__tests__/shell-exec.test.ts`
+
+- [ ] **Step 1: Write tests for session-derived profiles**
+
+Verify foreground and background Bash both compile `permissionMode + cwd`, consult real sandbox availability before permission evaluation, and execute the transformed argv.
+
+- [ ] **Step 2: Run tests and verify RED**
+
+Expected: current Bash tools bypass the default sandbox manager or lack argv metadata.
+
+- [ ] **Step 3: Wire the effective profile through tool runtime**
+
+Resolve sandbox metadata from the invocation context, retain permission prompts when Linux enforcement is unavailable, and pass `permissionMode` to tool implementations.
+
+- [ ] **Step 4: Execute transformed commands without shell re-parsing**
+
+Use `/bin/sh -lc <command>` as inner argv and spawn the final wrapper argv with `shell: false`; retain cwd, env, streaming, timeout, abort, and bounded output behavior.
+
+- [ ] **Step 5: Register Linux in production entrypoints**
+
+Use `createDefaultSandboxManager()` in CLI and Desktop so the same backend registry handles macOS and Linux.
+
+### Task 5: Documentation and Verification
+
+**Files:**
+- Modify: `docs/sandbox/agent-runtime-codex-sandbox-todo.md`
+
+- [ ] **Step 1: Document implemented scope and limitations**
+
+Record bubblewrap distribution expectations, fail-closed behavior, Linux entrypoint wiring, and the limitation that absent protected metadata directories cannot be overlaid read-only until they exist.
+
+- [ ] **Step 2: Run focused tests**
+
+Run all permission-profile, sandbox-manager, Linux backend, Bash integration, shell runner, and workspace executor tests.
+
+- [ ] **Step 3: Run full build and repository checks**
+
+Run: `npm run build` and `git diff --check`.
+
+Expected: build exits 0 and diff check reports no whitespace errors.
+
+- [ ] **Step 4: Review the final diff against Phase 10**
+
+Verify every Linux acceptance criterion has direct unit or smoke-test evidence; report platform-dependent tests as skipped when the current host is not Linux.

--- a/docs/archive/agent-runtime-codex-sandbox-todo.md
+++ b/docs/archive/agent-runtime-codex-sandbox-todo.md
@@ -561,6 +561,14 @@ SandboxTransformResult
 
 目标：在 macOS 主线稳定后，接入 Linux 权限兜底。
 
+> 实现结果：Linux backend 使用系统 `bubblewrap`，不额外分发 native helper。`linux-capability.ts` 会执行一次最小 user/PID namespace 启动探针并缓存结果，避免只检查文件存在；缺少 bwrap、user namespace 被 AppArmor/内核策略禁止或探针失败时均 fail closed。
+>
+> `LinuxBubblewrapBackend` 将 active `PermissionProfile + SandboxPathContext` 转换成 bwrap argv：系统运行目录只读挂载，workspace 按 profile read/write 挂载，临时目录使用独立 tmpfs，restricted network 同时使用 network namespace 和 seccomp。seccomp cBPF 由 TypeScript 在运行时生成，通过继承 FD 3 传给 `bwrap --seccomp 3`，当前审计并支持 x64/arm64；其他架构 fail closed。
+>
+> CLI 与 Desktop 在 Linux 上注入 `createDefaultSandboxManager()`。前台和可转后台 Bash 都从当前 `permissionMode + cwd` 编译 effective profile，以 `/bin/sh -lc <command>` 作为内层 argv，最终 wrapper 以 `shell: false` 执行。缺少 sandbox 时不会静默回退 host shell，`execute.shell_unsafe` 也不会自动放行。
+>
+> 已知限制：runtime 会有界扫描并把启动时已存在的任意层级 `.git/.agents/.codex` 重新只读挂载，但 bubblewrap 无法在不创建宿主 mountpoint 的情况下同时阻止尚不存在的同名路径首次创建。显式 `deny` entry 当前返回 `invalid_request`，不会弱化后继续执行。后续可用 Landlock 或 bundled native helper 完整表达不存在路径与更复杂的嵌套 carve-out。
+
 建议文件：
 
 - 新增：`packages/runtime/src/sandbox/linux-sandbox.ts`
@@ -570,16 +578,16 @@ SandboxTransformResult
 
 任务：
 
-- [ ] 确认 Linux backend 技术方案：bubblewrap + seccomp。
-- [ ] 确认 helper 分发方式。
-- [ ] 实现 filesystem view：workspace read/write，workspace 外限制。
-- [ ] 实现 protected metadata deny-write。
-- [ ] 实现 tmp write。
-- [ ] 实现 network restricted。
-- [ ] 实现 network enabled。
-- [ ] 接入 `SandboxManager.selectInitial()`。
-- [ ] 接入 `SandboxManager.transform()`。
-- [ ] Linux 不可用时 fail closed。
+- [x] 确认 Linux backend 技术方案：bubblewrap + seccomp。
+- [x] 确认 helper 分发方式：首版依赖系统 bwrap，seccomp cBPF 由 runtime 生成并通过 FD 传递，不分发 native helper。
+- [x] 实现 filesystem view：workspace read/write，workspace 外限制。
+- [x] 实现 protected metadata deny-write（已存在路径；不存在路径限制见上文）。
+- [x] 实现 tmp write。
+- [x] 实现 network restricted。
+- [x] 实现 network enabled。
+- [x] 接入 `SandboxManager.selectInitial()`。
+- [x] 接入 `SandboxManager.transform()`。
+- [x] Linux 不可用时 fail closed。
 
 验收标准：
 

--- a/docs/archive/agent-runtime-codex-sandbox-todo.md
+++ b/docs/archive/agent-runtime-codex-sandbox-todo.md
@@ -561,11 +561,11 @@ SandboxTransformResult
 
 目标：在 macOS 主线稳定后，接入 Linux 权限兜底。
 
-> 实现结果：Linux backend 使用系统 `bubblewrap`，不额外分发 native helper。`linux-capability.ts` 会执行一次最小 user/PID namespace 启动探针并缓存结果，避免只检查文件存在；缺少 bwrap、user namespace 被 AppArmor/内核策略禁止或探针失败时均 fail closed。
+> 实现结果：Linux backend 使用系统 `bubblewrap`，不额外分发 native helper。`linux-capability.ts` 会执行一次最小 user/PID namespace 启动探针并缓存结果，避免只检查文件存在。缺少 bwrap、user namespace 被 AppArmor/内核策略禁止或探针失败时，Bash 不获得 sandbox 自动批准；用户明确批准后走现有 host execution。
 >
 > `LinuxBubblewrapBackend` 将 active `PermissionProfile + SandboxPathContext` 转换成 bwrap argv：系统运行目录只读挂载，workspace 按 profile read/write 挂载，临时目录使用独立 tmpfs，restricted network 同时使用 network namespace 和 seccomp。seccomp cBPF 由 TypeScript 在运行时生成，通过继承 FD 3 传给 `bwrap --seccomp 3`，当前审计并支持 x64/arm64；其他架构 fail closed。
 >
-> CLI 与 Desktop 在 Linux 上注入 `createDefaultSandboxManager()`。前台和可转后台 Bash 都从当前 `permissionMode + cwd` 编译 effective profile，以 `/bin/sh -lc <command>` 作为内层 argv，最终 wrapper 以 `shell: false` 执行。缺少 sandbox 时不会静默回退 host shell，`execute.shell_unsafe` 也不会自动放行。
+> CLI 与 Desktop 在 Linux 上注入 `createBuiltinSandboxManager()`。前台和可转后台 Bash 都从当前 `permissionMode + cwd` 编译 effective profile，以 `/bin/sh -lc <command>` 作为内层 argv，最终 wrapper 以 `shell: false` 执行。缺少 sandbox 时 `execute.shell_unsafe` 不会自动放行，而是保留权限 prompt；用户批准后使用原有 host shell。若 capability 已确认可用但 transform 随后失败，仍 fail closed，不做静默降级。
 >
 > 已知限制：runtime 会有界扫描并把启动时已存在的任意层级 `.git/.agents/.codex` 重新只读挂载，但 bubblewrap 无法在不创建宿主 mountpoint 的情况下同时阻止尚不存在的同名路径首次创建。显式 `deny` entry 当前返回 `invalid_request`，不会弱化后继续执行。后续可用 Landlock 或 bundled native helper 完整表达不存在路径与更复杂的嵌套 carve-out。
 
@@ -587,7 +587,7 @@ SandboxTransformResult
 - [x] 实现 network enabled。
 - [x] 接入 `SandboxManager.selectInitial()`。
 - [x] 接入 `SandboxManager.transform()`。
-- [x] Linux 不可用时 fail closed。
+- [x] Linux 不可用时禁用自动批准；用户明确批准后走 host execution。
 
 验收标准：
 

--- a/packages/cli/src/runtime-bootstrap.ts
+++ b/packages/cli/src/runtime-bootstrap.ts
@@ -12,6 +12,7 @@ import {
   ShellRunProcessManager,
   buildAutomationTool,
   buildBuiltinTools,
+  createBuiltinSandboxManager,
   buildDefaultContextBudgetPolicy,
   buildSkillAgentTool,
   buildGoalTools,
@@ -131,11 +132,13 @@ export async function createMakaCliRuntimeContext(
       }
     },
   });
+  const sandboxManager = createBuiltinSandboxManager();
   const tools = buildBuiltinTools({
     shellRuns,
     runtimeResources: shellRuns,
     backgroundTasks: shellRuns,
     ptyControls: shellRuns,
+    ...(sandboxManager ? { sandboxManager } : {}),
   });
   const automationManager = new AutomationManager({
     generateId: () => randomUUID(),

--- a/packages/core/src/__tests__/permission.test.ts
+++ b/packages/core/src/__tests__/permission.test.ts
@@ -40,6 +40,28 @@ function evaluate(
   });
 }
 
+describe('sandbox-aware execute policy', () => {
+  test('auto-allows shell_unsafe only when platform sandbox enforcement is available', () => {
+    const common = {
+      toolName: 'Bash',
+      args: { command: 'npm install lodash' },
+      mode: 'execute' as const,
+      turnRemembered: new Set<string>(),
+    };
+
+    expect(preToolUse({
+      ...common,
+      sandbox: { platformSandboxAvailable: true },
+    }).proceed).toBe(true);
+    const unavailable = preToolUse({
+      ...common,
+      sandbox: { platformSandboxAvailable: false },
+    });
+    expect(unavailable.proceed).toBe(false);
+    expect(unavailable.needsPrompt).toBe(true);
+  });
+});
+
 describe('categorizeBash', () => {
   test('no shell command is auto-classified safe — categorizeBash never returns shell_safe', () => {
     // A shell command cannot be proven safe from its string: args can embed

--- a/packages/core/src/permission.ts
+++ b/packages/core/src/permission.ts
@@ -168,20 +168,9 @@ export const PERMISSION_POLICY: Record<PermissionMode, Record<ToolCategory, Poli
     network_send: 'allow',
     custom_tool: 'allow',
     subagent: 'allow',
-    // Fail-closed for shell: NO shell command auto-runs. A shell command cannot
-    // be proven safe from its string — args can embed execution (PowerShell
-    // `echo (Set-Content x)`, $(...), backtick, iex), so there is no reliable
-    // "safe" bucket. Read-only needs go through typed tools (Read/Glob/Grep:
-    // fixed argv, no shell). Both shell_safe (which categorizeBash no longer
-    // produces) and shell_unsafe prompt, so the boundary is structural — it
-    // does not ride on the destructive/privileged pattern list being complete;
-    // a missed variant is at most an extra confirmation, never a silent action.
-    // (Auto-running arbitrary shell inside an isolated worktree is a future
-    // capability, not a current escape hatch: it needs a worktree child
-    // executor with its OWN permission path. An agent's categoryPolicy only
-    // filters which tools the agent is GIVEN — it does not enter execution-time
-    // gating, which always flows through preToolUse → this policy table. Today
-    // the worktree implementation agent cannot even be spawned.)
+    // Shell stays prompt in the static table. policyDecisionForInput upgrades
+    // shell_unsafe to allow only when runtime proves the active profile can be
+    // enforced by a platform sandbox; otherwise this fail-closed default wins.
     shell_safe: 'prompt',
     shell_unsafe: 'prompt',
     // Irreversible ops ALWAYS prompt, even in execute mode.
@@ -474,6 +463,14 @@ export interface PreToolUseInput {
    * intentionally introduced in a later policy change.
    */
   executionFacts?: ToolExecutionFacts;
+  /**
+   * Platform sandbox availability for sandbox-aware policy decisions. Unsafe
+   * shell in execute mode is only auto-allowed when the runtime can actually
+   * enforce the active profile with a platform sandbox.
+   */
+  sandbox?: {
+    platformSandboxAvailable: boolean;
+  };
 }
 
 export interface PreToolUseResult {
@@ -504,7 +501,7 @@ export function preToolUse(input: PreToolUseInput): PreToolUseResult {
   const category = classifyToolUse(input);
 
   // (2) Policy lookup + turn-remembered check
-  const decision = PERMISSION_POLICY[input.mode][category];
+  const decision = policyDecisionForInput(input, category);
   const scopeKey = permissionScopeKey(input.toolName, input.args, category);
   if (decision === 'allow') {
     return { proceed: true, needsPrompt: false, category, scopeKey };
@@ -535,6 +532,14 @@ export function preToolUse(input: PreToolUseInput): PreToolUseResult {
       args: input.args,
     },
   };
+}
+
+function policyDecisionForInput(input: PreToolUseInput, category: ToolCategory): PolicyDecision {
+  const decision = PERMISSION_POLICY[input.mode][category];
+  if (input.mode === 'execute' && category === 'shell_unsafe') {
+    return input.sandbox?.platformSandboxAvailable === true ? 'allow' : 'prompt';
+  }
+  return decision;
 }
 
 export function permissionScopeKey(toolName: string, args: unknown, category: ToolCategory): string {

--- a/packages/runtime/src/__tests__/builtin-tools.test.ts
+++ b/packages/runtime/src/__tests__/builtin-tools.test.ts
@@ -4,8 +4,11 @@ import { mkdir, mkdtemp, readFile, symlink, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { z } from 'zod';
+import { createWorkspaceWritePermissionProfile } from '@maka/core/permission-profile';
 import { expect } from '../test-helpers.js';
 import { buildBuiltinTools } from '../builtin-tools.js';
+import { SandboxManager } from '../sandbox/sandbox-manager.js';
+import { LinuxBubblewrapBackend } from '../sandbox/linux-sandbox.js';
 import type { ShellRunLauncher } from '../shell-tools.js';
 import type {
   BackgroundTaskStopper,
@@ -208,6 +211,123 @@ describe('builtin Bash streaming output', () => {
     expect((calls[0] as { timeoutMs?: number }).timeoutMs).toBe(2_000);
     expect((calls[0] as { sourceRunId?: string }).sourceRunId).toBe('run-1');
     expect((calls[0] as { pty?: boolean }).pty).toBe(true);
+  });
+
+  test('wraps managed pipe Bash with bubblewrap argv and seccomp fd input', async () => {
+    const calls: any[] = [];
+    const shellRuns = {
+      async runForegroundBash(input: any) {
+        calls.push(input);
+        return {
+          kind: 'terminal', cwd: input.cwd, cmd: input.command, status: 'completed', exitCode: 0,
+          output: {
+            mode: 'pipes', stdout: '', stderr: '',
+            stdoutTruncated: false, stderrTruncated: false, redacted: false,
+          },
+        } as const;
+      },
+      async runBackgroundBash() { throw new Error('not used'); },
+    };
+    const bash = buildBuiltinTools({
+      shellRuns,
+      permissionProfile: createWorkspaceWritePermissionProfile(),
+      sandboxManager: availableLinuxManager(),
+      sandboxPlatform: 'linux',
+    }).find((candidate) => candidate.name === 'Bash');
+    if (!bash) throw new Error('Bash tool missing');
+
+    await bash.impl({ command: 'node --version' }, {
+      sessionId: 'session-1', turnId: 'turn-1', toolCallId: 'tool-1', cwd: '/workspace',
+      permissionMode: 'execute', abortSignal: new AbortController().signal, emitOutput: () => {},
+    });
+
+    expect(calls[0]?.argv?.[0]).toBe('/usr/bin/bwrap');
+    expect(calls[0]?.argv?.slice(-3)).toEqual(['/bin/sh', '-lc', 'node --version']);
+    expect(calls[0]?.fdInputs?.[0]?.fd).toBe(3);
+    expect(typeof bash.sandbox).toBe('function');
+    if (typeof bash.sandbox !== 'function') throw new Error('dynamic sandbox metadata missing');
+    expect(bash.sandbox({
+      permissionMode: 'execute',
+      cwd: '/workspace',
+      args: { command: 'node --version' },
+    })).toEqual({ platformSandboxAvailable: true });
+  });
+
+  test('does not claim sandbox enforcement for PTY Bash and leaves it on the approved host path', async () => {
+    const calls: any[] = [];
+    const shellRuns = {
+      async runForegroundBash() { throw new Error('not used'); },
+      async runBackgroundBash(input: any) {
+        calls.push(input);
+        return {
+          kind: 'shell_run', ref: 'maka://runtime/background-tasks/shell-run-1',
+          mode: 'pty', status: 'running', cwd: input.cwd, cmd: input.command,
+          startedAt: 1, updatedAt: 1, revision: 1,
+        } as const;
+      },
+    };
+    const bash = buildBuiltinTools({
+      shellRuns,
+      permissionProfile: createWorkspaceWritePermissionProfile(),
+      sandboxManager: availableLinuxManager(),
+      sandboxPlatform: 'linux',
+    }).find((candidate) => candidate.name === 'Bash');
+    if (!bash) throw new Error('Bash tool missing');
+
+    await bash.impl({ command: 'bash', run_in_background: true, pty: true }, {
+      sessionId: 'session-1', turnId: 'turn-1', toolCallId: 'tool-1', cwd: '/workspace',
+      permissionMode: 'execute', abortSignal: new AbortController().signal, emitOutput: () => {},
+    });
+
+    expect(calls[0]?.argv).toBe(undefined);
+    expect(calls[0]?.fdInputs).toBe(undefined);
+    expect(Boolean(calls[0]?.shell)).toBe(true);
+    expect(typeof bash.sandbox).toBe('function');
+    if (typeof bash.sandbox !== 'function') throw new Error('dynamic sandbox metadata missing');
+    expect(bash.sandbox({
+      permissionMode: 'execute',
+      cwd: '/workspace',
+      args: { command: 'bash', run_in_background: true, pty: true },
+    })).toEqual({ platformSandboxAvailable: false });
+  });
+
+  test('reports unavailable bubblewrap and keeps approved Bash on the host path', async () => {
+    const calls: any[] = [];
+    const shellRuns = {
+      async runForegroundBash(input: any) {
+        calls.push(input);
+        return {
+          kind: 'terminal', cwd: input.cwd, cmd: input.command, status: 'completed', exitCode: 0,
+          output: {
+            mode: 'pipes', stdout: 'host', stderr: '',
+            stdoutTruncated: false, stderrTruncated: false, redacted: false,
+          },
+        } as const;
+      },
+      async runBackgroundBash() { throw new Error('not used'); },
+    };
+    const bash = buildBuiltinTools({
+      shellRuns,
+      permissionProfile: createWorkspaceWritePermissionProfile(),
+      sandboxManager: unavailableLinuxManager(),
+      sandboxPlatform: 'linux',
+    }).find((candidate) => candidate.name === 'Bash');
+    if (!bash) throw new Error('Bash tool missing');
+
+    await bash.impl({ command: 'echo host' }, {
+      sessionId: 'session-1', turnId: 'turn-1', toolCallId: 'tool-1', cwd: '/workspace',
+      permissionMode: 'execute', abortSignal: new AbortController().signal, emitOutput: () => {},
+    });
+
+    expect(calls[0]?.argv).toBe(undefined);
+    expect(Boolean(calls[0]?.shell)).toBe(true);
+    expect(typeof bash.sandbox).toBe('function');
+    if (typeof bash.sandbox !== 'function') throw new Error('dynamic sandbox metadata missing');
+    expect(bash.sandbox({
+      permissionMode: 'execute',
+      cwd: '/workspace',
+      args: { command: 'echo host' },
+    })).toEqual({ platformSandboxAvailable: false });
   });
 
   test('Read treats runtime background task refs as whole resources', async () => {
@@ -1032,4 +1152,20 @@ function fakeExecutor(overrides: Partial<WorkspaceExecutor>): WorkspaceExecutor 
     grepFiles: async () => ({ matches: [] }),
   };
   return Object.assign(base, overrides);
+}
+
+function availableLinuxManager(): SandboxManager {
+  return new SandboxManager([
+    new LinuxBubblewrapBackend({
+      capability: { available: true, bwrapPath: '/usr/bin/bwrap' },
+    }),
+  ]);
+}
+
+function unavailableLinuxManager(): SandboxManager {
+  return new SandboxManager([
+    new LinuxBubblewrapBackend({
+      capability: { available: false, reason: 'missing-bwrap', bwrapPath: '/usr/bin/bwrap' },
+    }),
+  ]);
 }

--- a/packages/runtime/src/__tests__/default-sandbox-manager.test.ts
+++ b/packages/runtime/src/__tests__/default-sandbox-manager.test.ts
@@ -3,10 +3,13 @@ import { describe, it } from 'node:test';
 
 import { createWorkspaceWritePermissionProfile } from '@maka/core/permission-profile';
 
-import { createDefaultSandboxManager } from '../sandbox/default-sandbox-manager.js';
+import {
+  createBuiltinSandboxManager,
+  createDefaultSandboxManager,
+} from '../sandbox/default-sandbox-manager.js';
 
 describe('createDefaultSandboxManager', () => {
-  it('registers the macOS Seatbelt backend without requiring macOS at import time', () => {
+  it('registers platform backends without requiring the host platform at import time', () => {
     const manager = createDefaultSandboxManager();
 
     const result = manager.selectInitial({
@@ -16,5 +19,20 @@ describe('createDefaultSandboxManager', () => {
 
     assert.equal(result.ok, true);
     if (result.ok) assert.equal(result.sandboxType, 'macos-seatbelt');
+
+    const linux = manager.selectInitial({
+      profile: createWorkspaceWritePermissionProfile(),
+      platform: 'linux',
+    });
+    assert.equal(linux.ok, true);
+    if (linux.ok) assert.equal(linux.sandboxType, 'linux');
+  });
+});
+
+describe('createBuiltinSandboxManager', () => {
+  it('enables the production builtin sandbox only on Linux', () => {
+    assert.ok(createBuiltinSandboxManager('linux'));
+    assert.equal(createBuiltinSandboxManager('darwin'), undefined);
+    assert.equal(createBuiltinSandboxManager('win32'), undefined);
   });
 });

--- a/packages/runtime/src/__tests__/linux-sandbox-smoke.test.ts
+++ b/packages/runtime/src/__tests__/linux-sandbox-smoke.test.ts
@@ -1,12 +1,14 @@
 import { describe, test } from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdir, mkdtemp, readFile, stat } from 'node:fs/promises';
-import { tmpdir } from 'node:os';
+import { chmod, mkdir, mkdtemp, readFile, rm, stat, writeFile } from 'node:fs/promises';
+import { homedir, tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { createWorkspaceWritePermissionProfile } from '@maka/core/permission-profile';
-import { LinuxBubblewrapBackend } from '../sandbox/linux-sandbox.js';
+import { LinuxBubblewrapBackend, linuxExecutableRoots } from '../sandbox/linux-sandbox.js';
 import { detectLinuxSandboxCapability } from '../sandbox/linux-capability.js';
+import { SandboxManager } from '../sandbox/sandbox-manager.js';
 import { runProcessWithBoundedTail } from '../shell-exec.js';
+import { buildBuiltinTools } from '../builtin-tools.js';
 
 const capability = detectLinuxSandboxCapability();
 const requireLinuxSandboxSmoke = process.env.MAKA_REQUIRE_LINUX_SANDBOX_SMOKE === '1';
@@ -80,21 +82,30 @@ describe('Linux sandbox smoke', () => {
     await assert.rejects(() => readFile(join(workspace, 'packages', 'pkg', '.git', 'config'), 'utf8'));
   });
 
-  test('network-restricted applies the seccomp socket filter', { skip: skipReason }, async () => {
+  test('shell-launched Node uses runtime roots and the seccomp socket filter', { skip: skipReason }, async () => {
     if (!capability.available) return;
     const workspace = await mkdtemp(join(tmpdir(), 'maka-linux-sandbox-network-'));
     const backend = new LinuxBubblewrapBackend({ capability });
     const request = backend.transform({
       platform: 'linux',
       command: {
-        program: process.execPath,
+        program: '/bin/sh',
         args: [
-          '-e',
-          'const net=require("node:net");const s=net.connect(9,"127.0.0.1");s.on("error",e=>{process.stdout.write(e.code||"");process.exit(e.code==="EPERM"?0:2)})',
+          '-lc',
+          `node -e ${shellQuote('const net=require("node:net");const s=net.connect(9,"127.0.0.1");s.on("error",e=>{process.stdout.write(e.code||"");process.exit(e.code==="EPERM"?0:2)})')}`,
         ],
         cwd: workspace,
+        env: { ...process.env },
         profile: createWorkspaceWritePermissionProfile(),
-        pathContext: { workspaceRoots: [workspace], tmpdir: tmpdir(), slashTmp: '/tmp' },
+        pathContext: {
+          workspaceRoots: [workspace],
+          tmpdir: tmpdir(),
+          slashTmp: '/tmp',
+          minimalRoots: linuxExecutableRoots({
+            execPath: process.execPath,
+            path: process.env.PATH,
+          }),
+        },
       },
     });
     assert.equal(request.ok, true);
@@ -108,6 +119,47 @@ describe('Linux sandbox smoke', () => {
 
     assert.equal(result.exitCode, 0, result.stderr);
     assert.equal(result.stdout, 'EPERM');
+  });
+
+  test('builtin Bash executes a tool from a nonstandard host PATH inside bubblewrap', { skip: skipReason }, async () => {
+    if (!capability.available) return;
+    const workspace = await mkdtemp(join(tmpdir(), 'maka-linux-sandbox-builtin-'));
+    const toolRoot = await mkdtemp(join(homedir(), '.maka-linux-sandbox-tool-'));
+    const toolBin = join(toolRoot, 'bin');
+    const toolPath = join(toolBin, 'maka-path-probe');
+    await mkdir(toolBin);
+    await writeFile(toolPath, '#!/bin/sh\nprintf custom-tool-ok\n');
+    await chmod(toolPath, 0o755);
+    const previousPath = process.env.PATH;
+    process.env.PATH = `${toolBin}:${previousPath ?? ''}`;
+
+    try {
+      const manager = new SandboxManager([new LinuxBubblewrapBackend({ capability })]);
+      const bash = buildBuiltinTools({
+        permissionProfile: createWorkspaceWritePermissionProfile(),
+        sandboxManager: manager,
+        sandboxPlatform: 'linux',
+      }).find((candidate) => candidate.name === 'Bash');
+      if (!bash) throw new Error('Bash tool missing');
+
+      const result = await bash.impl({ command: 'maka-path-probe' }, {
+        sessionId: 'session-1',
+        turnId: 'turn-1',
+        toolCallId: 'tool-1',
+        cwd: workspace,
+        permissionMode: 'execute',
+        abortSignal: new AbortController().signal,
+        emitOutput: () => {},
+      }) as { output: { mode: string; stdout: string; stderr: string } };
+
+      assert.equal(result.output.mode, 'pipes');
+      assert.equal(result.output.stdout, 'custom-tool-ok');
+      assert.equal(result.output.stderr, '');
+    } finally {
+      if (previousPath === undefined) delete process.env.PATH;
+      else process.env.PATH = previousPath;
+      await rm(toolRoot, { recursive: true, force: true });
+    }
   });
 });
 

--- a/packages/runtime/src/__tests__/linux-sandbox-smoke.test.ts
+++ b/packages/runtime/src/__tests__/linux-sandbox-smoke.test.ts
@@ -1,0 +1,111 @@
+import { describe, test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdir, mkdtemp, readFile, stat } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { createWorkspaceWritePermissionProfile } from '@maka/core/permission-profile';
+import { LinuxBubblewrapBackend } from '../sandbox/linux-sandbox.js';
+import { detectLinuxSandboxCapability } from '../sandbox/linux-capability.js';
+import { runProcessWithBoundedTail } from '../shell-exec.js';
+
+const capability = detectLinuxSandboxCapability();
+const skipReason = process.platform !== 'linux'
+  ? 'Linux sandbox smoke runs only on Linux'
+  : capability.available
+    ? false
+    : 'bubblewrap is not available';
+
+describe('Linux sandbox smoke', () => {
+  test('workspace-write can write workspace files and blocks sibling paths', { skip: skipReason }, async () => {
+    if (!capability.available) return;
+    const workspace = await mkdtemp(join(tmpdir(), 'maka-linux-sandbox-workspace-'));
+    const outside = await mkdtemp(join(tmpdir(), 'maka-linux-sandbox-outside-'));
+    const backend = new LinuxBubblewrapBackend({ capability });
+    const request = backend.transform({
+      platform: 'linux',
+      command: {
+        program: '/bin/sh',
+        args: ['-lc', `echo ok > inside.txt && echo temp-ok > /tmp/maka-sandbox-temp.txt && ! echo nope > ${shellQuote(join(outside, 'outside.txt'))}`],
+        cwd: workspace,
+        profile: createWorkspaceWritePermissionProfile(),
+        pathContext: { workspaceRoots: [workspace], tmpdir: tmpdir(), slashTmp: '/tmp' },
+      },
+    });
+    assert.equal(request.ok, true);
+    if (!request.ok) return;
+
+    const result = await runProcessWithBoundedTail(request.exec.argv[0] ?? '', request.exec.argv.slice(1), {
+      cwd: workspace,
+      timeoutMs: 10_000,
+      fdInputs: request.exec.fdInputs,
+    });
+
+    assert.equal(result.exitCode, 0, result.stderr);
+    assert.equal(await readFile(join(workspace, 'inside.txt'), 'utf8'), 'ok\n');
+    await assert.rejects(() => stat(join(outside, 'outside.txt')));
+  });
+
+  test('workspace-write blocks protected metadata writes', { skip: skipReason }, async () => {
+    if (!capability.available) return;
+    const workspace = await mkdtemp(join(tmpdir(), 'maka-linux-sandbox-metadata-'));
+    await mkdir(join(workspace, '.git'), { recursive: true });
+    await mkdir(join(workspace, 'packages', 'pkg', '.git'), { recursive: true });
+    const backend = new LinuxBubblewrapBackend({ capability });
+    const request = backend.transform({
+      platform: 'linux',
+      command: {
+        program: '/bin/sh',
+        args: ['-lc', '! echo nope > .git/config && ! echo nope > packages/pkg/.git/config'],
+        cwd: workspace,
+        profile: createWorkspaceWritePermissionProfile(),
+        pathContext: { workspaceRoots: [workspace], tmpdir: tmpdir(), slashTmp: '/tmp' },
+      },
+    });
+    assert.equal(request.ok, true);
+    if (!request.ok) return;
+
+    const result = await runProcessWithBoundedTail(request.exec.argv[0] ?? '', request.exec.argv.slice(1), {
+      cwd: workspace,
+      timeoutMs: 10_000,
+      fdInputs: request.exec.fdInputs,
+    });
+
+    assert.equal(result.exitCode, 0, result.stderr);
+    await assert.rejects(() => readFile(join(workspace, '.git', 'config'), 'utf8'));
+    await assert.rejects(() => readFile(join(workspace, 'packages', 'pkg', '.git', 'config'), 'utf8'));
+  });
+
+  test('network-restricted applies the seccomp socket filter', { skip: skipReason }, async () => {
+    if (!capability.available) return;
+    const workspace = await mkdtemp(join(tmpdir(), 'maka-linux-sandbox-network-'));
+    const backend = new LinuxBubblewrapBackend({ capability });
+    const request = backend.transform({
+      platform: 'linux',
+      command: {
+        program: process.execPath,
+        args: [
+          '-e',
+          'const net=require("node:net");const s=net.connect(9,"127.0.0.1");s.on("error",e=>{process.stdout.write(e.code||"");process.exit(e.code==="EPERM"?0:2)})',
+        ],
+        cwd: workspace,
+        profile: createWorkspaceWritePermissionProfile(),
+        pathContext: { workspaceRoots: [workspace], tmpdir: tmpdir(), slashTmp: '/tmp' },
+      },
+    });
+    assert.equal(request.ok, true);
+    if (!request.ok) return;
+
+    const result = await runProcessWithBoundedTail(request.exec.argv[0] ?? '', request.exec.argv.slice(1), {
+      cwd: workspace,
+      timeoutMs: 10_000,
+      fdInputs: request.exec.fdInputs,
+    });
+
+    assert.equal(result.exitCode, 0, result.stderr);
+    assert.equal(result.stdout, 'EPERM');
+  });
+});
+
+function shellQuote(value: string): string {
+  return `'${value.replaceAll("'", "'\\''")}'`;
+}

--- a/packages/runtime/src/__tests__/linux-sandbox-smoke.test.ts
+++ b/packages/runtime/src/__tests__/linux-sandbox-smoke.test.ts
@@ -9,6 +9,7 @@ import { detectLinuxSandboxCapability } from '../sandbox/linux-capability.js';
 import { runProcessWithBoundedTail } from '../shell-exec.js';
 
 const capability = detectLinuxSandboxCapability();
+const requireLinuxSandboxSmoke = process.env.MAKA_REQUIRE_LINUX_SANDBOX_SMOKE === '1';
 const skipReason = process.platform !== 'linux'
   ? 'Linux sandbox smoke runs only on Linux'
   : capability.available
@@ -16,6 +17,10 @@ const skipReason = process.platform !== 'linux'
     : 'bubblewrap is not available';
 
 describe('Linux sandbox smoke', () => {
+  test('required Linux sandbox capability is available', { skip: !requireLinuxSandboxSmoke }, () => {
+    assert.equal(skipReason, false, capabilityFailureMessage());
+  });
+
   test('workspace-write can write workspace files and blocks sibling paths', { skip: skipReason }, async () => {
     if (!capability.available) return;
     const workspace = await mkdtemp(join(tmpdir(), 'maka-linux-sandbox-workspace-'));
@@ -105,6 +110,14 @@ describe('Linux sandbox smoke', () => {
     assert.equal(result.stdout, 'EPERM');
   });
 });
+
+function capabilityFailureMessage(): string {
+  if (process.platform !== 'linux') return 'Linux sandbox smoke requires a Linux runner';
+  if (capability.available) return '';
+  return `Linux sandbox smoke requires usable bubblewrap (${capability.reason})${
+    capability.detail ? `: ${capability.detail}` : ''
+  }`;
+}
 
 function shellQuote(value: string): string {
   return `'${value.replaceAll("'", "'\\''")}'`;

--- a/packages/runtime/src/__tests__/linux-sandbox.test.ts
+++ b/packages/runtime/src/__tests__/linux-sandbox.test.ts
@@ -16,6 +16,7 @@ import {
   buildBubblewrapArgv,
   buildNetworkSeccompFilter,
   discoverNestedProtectedMetadataPaths,
+  linuxExecutableRoots,
 } from '../sandbox/linux-sandbox.js';
 import { detectLinuxSandboxCapability } from '../sandbox/linux-capability.js';
 import {
@@ -155,6 +156,36 @@ describe('buildBubblewrapArgv', () => {
     assert.ok(hasPair(argv, '--dir', '/opt'));
     assert.ok(hasPair(argv, '--dir', '/opt/hostedtoolcache/node/22.23.1/x64'));
     assert.ok(hasTriple(argv, '--ro-bind', programDirectory, programDirectory));
+  });
+
+  it('mounts runtime roots needed by a shell-launched executable', () => {
+    const request = workspaceRequest(createWorkspaceWritePermissionProfile());
+    const runtimeRoot = '/opt/hostedtoolcache/node/22.23.1/x64';
+    const argv = buildBubblewrapArgv({
+      bwrapPath: '/usr/bin/bwrap',
+      command: {
+        ...request.command,
+        pathContext: {
+          ...request.command.pathContext,
+          minimalRoots: [runtimeRoot],
+        },
+      },
+    });
+
+    assert.ok(hasPair(argv, '--dir', '/opt'));
+    assert.ok(hasTriple(argv, '--ro-bind-try', runtimeRoot, runtimeRoot));
+  });
+});
+
+describe('linuxExecutableRoots', () => {
+  it('keeps the Node installation root and absolute PATH entries without nested duplicates', () => {
+    assert.deepEqual(linuxExecutableRoots({
+      execPath: '/opt/hostedtoolcache/node/22.23.1/x64/bin/node',
+      path: '/opt/hostedtoolcache/node/22.23.1/x64/bin:/home/runner/.local/bin:relative-bin',
+    }), [
+      '/opt/hostedtoolcache/node/22.23.1/x64',
+      '/home/runner/.local/bin',
+    ]);
   });
 });
 

--- a/packages/runtime/src/__tests__/linux-sandbox.test.ts
+++ b/packages/runtime/src/__tests__/linux-sandbox.test.ts
@@ -1,0 +1,255 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { mkdir, mkdtemp } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import {
+  createDangerFullAccessPermissionProfile,
+  createReadOnlyPermissionProfile,
+  createWorkspaceWritePermissionProfile,
+  type PermissionProfile,
+} from '@maka/core/permission-profile';
+
+import {
+  LinuxBubblewrapBackend,
+  buildBubblewrapArgv,
+  buildNetworkSeccompFilter,
+  discoverNestedProtectedMetadataPaths,
+} from '../sandbox/linux-sandbox.js';
+import { detectLinuxSandboxCapability } from '../sandbox/linux-capability.js';
+import {
+  LINUX_BWRAP_PROBE_ARGS,
+  LINUX_BWRAP_REQUIRED_OPTIONS,
+} from '../sandbox/linux-capability.js';
+import type { SandboxTransformRequest } from '../sandbox/types.js';
+
+function workspaceRequest(profile: PermissionProfile): SandboxTransformRequest {
+  return {
+    platform: 'linux',
+    command: {
+      program: '/bin/sh',
+      args: ['-lc', 'echo hi'],
+      cwd: '/repo/project',
+      profile,
+      pathContext: {
+        workspaceRoots: ['/repo/project'],
+        tmpdir: '/var/tmp/maka',
+        slashTmp: '/tmp',
+      },
+    },
+  };
+}
+
+function enabledNetworkProfile(): PermissionProfile {
+  const profile = createWorkspaceWritePermissionProfile();
+  return { ...profile, network: { kind: 'enabled' } };
+}
+
+function deniedChildProfile(): PermissionProfile {
+  const profile = createWorkspaceWritePermissionProfile();
+  return {
+    ...profile,
+    fileSystem: {
+      ...profile.fileSystem,
+      entries: [
+        ...profile.fileSystem.entries,
+        { kind: 'path', access: 'deny', path: '/repo/project/secret' },
+      ],
+    },
+  };
+}
+
+describe('detectLinuxSandboxCapability', () => {
+  it('probes every namespace used by production and requires seccomp support', () => {
+    for (const flag of [
+      '--unshare-user', '--unshare-pid', '--unshare-ipc', '--unshare-uts',
+      '--unshare-cgroup', '--unshare-net',
+    ]) {
+      assert.ok((LINUX_BWRAP_PROBE_ARGS as readonly string[]).includes(flag));
+    }
+    assert.ok(LINUX_BWRAP_REQUIRED_OPTIONS.includes('--seccomp'));
+  });
+
+  it('reports non-Linux platforms without probing bwrap', () => {
+    assert.deepEqual(detectLinuxSandboxCapability({ platform: 'win32' }), {
+      available: false,
+      reason: 'non-linux',
+    });
+  });
+
+  it('reports a missing configured bwrap executable', () => {
+    assert.deepEqual(detectLinuxSandboxCapability({
+      platform: 'linux',
+      bwrapPath: '/definitely/missing/maka-bwrap',
+    }), {
+      available: false,
+      reason: 'missing-bwrap',
+      bwrapPath: '/definitely/missing/maka-bwrap',
+    });
+  });
+
+  it('reports an executable that cannot create the bubblewrap sandbox', () => {
+    const capability = detectLinuxSandboxCapability({
+      platform: 'linux',
+      bwrapPath: process.execPath,
+    });
+
+    assert.equal(capability.available, false);
+    if (!capability.available) {
+      assert.equal(capability.reason, 'probe-failed');
+      assert.equal(capability.bwrapPath, process.execPath);
+    }
+  });
+});
+
+describe('buildBubblewrapArgv', () => {
+  it('mounts read-only profiles without a writable workspace bind', () => {
+    const request = workspaceRequest(createReadOnlyPermissionProfile());
+    const argv = buildBubblewrapArgv({ bwrapPath: '/usr/bin/bwrap', command: request.command });
+
+    assert.ok(hasTriple(argv, '--ro-bind', '/repo/project', '/repo/project'));
+    assert.equal(hasTriple(argv, '--bind', '/repo/project', '/repo/project'), false);
+  });
+
+  it('materializes workspace, temp, protected metadata, cwd, and network restrictions', () => {
+    const request = workspaceRequest(createWorkspaceWritePermissionProfile());
+    const argv = buildBubblewrapArgv({
+      bwrapPath: '/usr/bin/bwrap',
+      command: request.command,
+    });
+
+    assert.equal(argv[0], '/usr/bin/bwrap');
+    assert.ok(argv.includes('--die-with-parent'));
+    assert.ok(argv.includes('--new-session'));
+    assert.ok(argv.includes('--unshare-net'));
+    assert.ok(argv.includes('--unshare-user'));
+    assert.ok(hasPair(argv, '--seccomp', '3'));
+    assert.ok(hasTriple(argv, '--bind', '/repo/project', '/repo/project'));
+    assert.ok(hasTriple(argv, '--ro-bind-try', '/repo/project/.git', '/repo/project/.git'));
+    assert.ok(hasPair(argv, '--tmpfs', '/tmp'));
+    assert.ok(hasPair(argv, '--tmpfs', '/var/tmp/maka'));
+    assert.ok(hasPair(argv, '--chdir', '/repo/project'));
+    assert.deepEqual(argv.slice(-4), ['--', '/bin/sh', '-lc', 'echo hi']);
+  });
+
+  it('keeps the host network namespace when network is enabled', () => {
+    const request = workspaceRequest(enabledNetworkProfile());
+    const argv = buildBubblewrapArgv({ bwrapPath: '/usr/bin/bwrap', command: request.command });
+
+    assert.equal(argv.includes('--unshare-net'), false);
+    assert.equal(argv.includes('--seccomp'), false);
+  });
+});
+
+describe('buildNetworkSeccompFilter', () => {
+  it('builds a cBPF program for supported Linux architectures', () => {
+    const x64 = buildNetworkSeccompFilter('x64');
+    const arm64 = buildNetworkSeccompFilter('arm64');
+
+    assert.ok(x64.length > 0);
+    assert.equal(x64.length % 8, 0);
+    assert.ok(arm64.length > 0);
+    assert.equal(arm64.length % 8, 0);
+    assert.notDeepEqual(x64, arm64);
+  });
+
+  it('fails closed for architectures without audited syscall numbers', () => {
+    assert.throws(() => buildNetworkSeccompFilter('ia32'), /unsupported.*architecture/i);
+  });
+});
+
+describe('discoverNestedProtectedMetadataPaths', () => {
+  it('finds protected metadata at any existing nested path segment', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'maka-protected-scan-'));
+    await mkdir(join(root, 'packages', 'pkg', '.git'), { recursive: true });
+    await mkdir(join(root, '.git'), { recursive: true });
+
+    const paths = discoverNestedProtectedMetadataPaths({
+      writableRoots: [root],
+      names: ['.git', '.agents', '.codex'],
+    });
+
+    assert.equal(paths.length, 1);
+    assert.match(paths[0] ?? '', /packages[/\\]pkg[/\\]\.git$/);
+  });
+});
+
+describe('LinuxBubblewrapBackend', () => {
+  it('wraps a managed restricted command when bwrap is available', () => {
+    const backend = new LinuxBubblewrapBackend({
+      capability: { available: true, bwrapPath: '/usr/bin/bwrap' },
+    });
+    const result = backend.transform(workspaceRequest(createWorkspaceWritePermissionProfile()));
+
+    assert.equal(result.ok, true);
+    if (result.ok) {
+      assert.equal(result.exec.sandboxType, 'linux');
+      assert.equal(result.exec.argv[0], '/usr/bin/bwrap');
+      assert.deepEqual(result.exec.argv.slice(-3), ['/bin/sh', '-lc', 'echo hi']);
+      assert.equal(result.exec.fdInputs?.[0]?.fd, 3);
+      assert.ok((result.exec.fdInputs?.[0]?.data.byteLength ?? 0) > 0);
+    }
+  });
+
+  it('re-applies discovered nested protected metadata as read-only', () => {
+    const nested = '/repo/project/packages/pkg/.git';
+    const backend = new LinuxBubblewrapBackend({
+      capability: { available: true, bwrapPath: '/usr/bin/bwrap' },
+      discoverProtectedMetadataPaths: () => [nested],
+    });
+    const result = backend.transform(workspaceRequest(createWorkspaceWritePermissionProfile()));
+
+    assert.equal(result.ok, true);
+    if (result.ok) {
+      assert.ok(hasTriple(result.exec.argv, '--ro-bind', nested, nested));
+    }
+  });
+
+  it('fails closed with a clear result when bwrap is unavailable', () => {
+    const backend = new LinuxBubblewrapBackend({
+      capability: { available: false, reason: 'missing-bwrap', bwrapPath: '/usr/bin/bwrap' },
+    });
+    const result = backend.transform(workspaceRequest(createWorkspaceWritePermissionProfile()));
+
+    assert.equal(result.ok, false);
+    if (!result.ok) {
+      assert.equal(result.reason, 'backend_not_available');
+      assert.equal(result.sandboxType, 'linux');
+      assert.match(result.message ?? '', /bubblewrap.*not available/i);
+    }
+  });
+
+  it('rejects deny entries that cannot be represented without weakening policy', () => {
+    const backend = new LinuxBubblewrapBackend({
+      capability: { available: true, bwrapPath: '/usr/bin/bwrap' },
+    });
+    const result = backend.transform(workspaceRequest(deniedChildProfile()));
+
+    assert.equal(result.ok, false);
+    if (!result.ok) {
+      assert.equal(result.reason, 'invalid_request');
+      assert.match(result.message ?? '', /deny entries/i);
+    }
+  });
+
+  it('rejects profiles that should have selected no sandbox', () => {
+    const backend = new LinuxBubblewrapBackend({
+      capability: { available: true, bwrapPath: '/usr/bin/bwrap' },
+    });
+    const result = backend.transform(workspaceRequest(createDangerFullAccessPermissionProfile()));
+
+    assert.equal(result.ok, false);
+    if (!result.ok) assert.equal(result.reason, 'invalid_request');
+  });
+});
+
+function hasPair(argv: readonly string[], flag: string, value: string): boolean {
+  return argv.some((item, index) => item === flag && argv[index + 1] === value);
+}
+
+function hasTriple(argv: readonly string[], flag: string, left: string, right: string): boolean {
+  return argv.some((item, index) => (
+    item === flag && argv[index + 1] === left && argv[index + 2] === right
+  ));
+}

--- a/packages/runtime/src/__tests__/linux-sandbox.test.ts
+++ b/packages/runtime/src/__tests__/linux-sandbox.test.ts
@@ -140,6 +140,22 @@ describe('buildBubblewrapArgv', () => {
     assert.equal(argv.includes('--unshare-net'), false);
     assert.equal(argv.includes('--seccomp'), false);
   });
+
+  it('mounts an absolute program directory outside the default host paths', () => {
+    const request = workspaceRequest(createWorkspaceWritePermissionProfile());
+    const programDirectory = '/opt/hostedtoolcache/node/22.23.1/x64/bin';
+    const argv = buildBubblewrapArgv({
+      bwrapPath: '/usr/bin/bwrap',
+      command: {
+        ...request.command,
+        program: `${programDirectory}/node`,
+      },
+    });
+
+    assert.ok(hasPair(argv, '--dir', '/opt'));
+    assert.ok(hasPair(argv, '--dir', '/opt/hostedtoolcache/node/22.23.1/x64'));
+    assert.ok(hasTriple(argv, '--ro-bind', programDirectory, programDirectory));
+  });
 });
 
 describe('buildNetworkSeccompFilter', () => {

--- a/packages/runtime/src/__tests__/permission-engine.test.ts
+++ b/packages/runtime/src/__tests__/permission-engine.test.ts
@@ -239,6 +239,22 @@ describe('PermissionEngine.evaluate — block path', () => {
 });
 
 describe('PermissionEngine.evaluate — prompt path', () => {
+  test('allows execute shell_unsafe when the runtime reports an enforceable sandbox', () => {
+    const { engine } = makeEngine();
+    engine.beginTurn('t1');
+    const r = engine.evaluate({
+      sessionId: 's1',
+      turnId: 't1',
+      toolUseId: 'tu1',
+      toolName: 'Bash',
+      args: { command: 'npm install lodash' },
+      mode: 'execute',
+      sandbox: { platformSandboxAvailable: true },
+    });
+
+    expect(r.kind).toBe('allow');
+  });
+
   test('execution facts are accepted but do not (yet) downgrade host-local shell to allow', () => {
     // executionFacts is plumbed for forward-compat: a future sandbox-aware
     // policy may auto-allow unsafe shell inside an isolated worktree. On the

--- a/packages/runtime/src/__tests__/sandbox-export.test.ts
+++ b/packages/runtime/src/__tests__/sandbox-export.test.ts
@@ -3,22 +3,31 @@ import { describe, it } from 'node:test';
 
 import {
   MacosSeatbeltBackend,
+  LinuxBubblewrapBackend,
   SandboxManager,
   buildSeatbeltPolicy,
+  buildNetworkSeccompFilter,
   createDefaultSandboxManager,
+  createBuiltinSandboxManager,
 } from '../index.js';
 import {
   MacosSeatbeltBackend as MacosSeatbeltBackendFromSubpath,
+  LinuxBubblewrapBackend as LinuxBubblewrapBackendFromSubpath,
   SandboxManager as SandboxManagerFromSubpath,
   buildSeatbeltPolicy as buildSeatbeltPolicyFromSubpath,
+  buildNetworkSeccompFilter as buildNetworkSeccompFilterFromSubpath,
   createDefaultSandboxManager as createDefaultSandboxManagerFromSubpath,
+  createBuiltinSandboxManager as createBuiltinSandboxManagerFromSubpath,
 } from '../sandbox/index.js';
 
 describe('runtime sandbox exports', () => {
   it('exports sandbox APIs from the runtime barrel and sandbox subpath', () => {
     assert.equal(SandboxManager, SandboxManagerFromSubpath);
     assert.equal(MacosSeatbeltBackend, MacosSeatbeltBackendFromSubpath);
+    assert.equal(LinuxBubblewrapBackend, LinuxBubblewrapBackendFromSubpath);
     assert.equal(buildSeatbeltPolicy, buildSeatbeltPolicyFromSubpath);
+    assert.equal(buildNetworkSeccompFilter, buildNetworkSeccompFilterFromSubpath);
     assert.equal(createDefaultSandboxManager, createDefaultSandboxManagerFromSubpath);
+    assert.equal(createBuiltinSandboxManager, createBuiltinSandboxManagerFromSubpath);
   });
 });

--- a/packages/runtime/src/__tests__/sandbox-manager.test.ts
+++ b/packages/runtime/src/__tests__/sandbox-manager.test.ts
@@ -10,6 +10,7 @@ import {
 } from '@maka/core/permission-profile';
 
 import { SandboxManager } from '../sandbox/sandbox-manager.js';
+import { LinuxBubblewrapBackend } from '../sandbox/linux-sandbox.js';
 import type {
   SandboxBackend,
   SandboxTransformRequest,
@@ -106,19 +107,62 @@ describe('SandboxManager.selectInitial', () => {
     }
   });
 
-  it('returns backend_not_implemented for linux restricted profiles in Phase 3', () => {
-    const manager = new SandboxManager();
+  it('selects linux when a Linux backend is registered', () => {
+    const manager = new SandboxManager([
+      new LinuxBubblewrapBackend({
+        capability: { available: true, bwrapPath: '/usr/bin/bwrap' },
+      }),
+    ]);
 
     const result = manager.selectInitial({
       profile: createWorkspaceWritePermissionProfile(),
       platform: 'linux',
     });
 
-    assert.equal(result.ok, false);
-    if (!result.ok) {
-      assert.equal(result.reason, 'backend_not_implemented');
-      assert.equal(result.sandboxType, 'linux');
-    }
+    assert.equal(result.ok, true);
+    if (result.ok) assert.equal(result.sandboxType, 'linux');
+  });
+
+  it('reports whether the selected backend can enforce the profile', () => {
+    const available = new SandboxManager([
+      new LinuxBubblewrapBackend({
+        capability: { available: true, bwrapPath: '/usr/bin/bwrap' },
+      }),
+    ]);
+    const unavailable = new SandboxManager([
+      new LinuxBubblewrapBackend({
+        capability: { available: false, reason: 'missing-bwrap', bwrapPath: '/usr/bin/bwrap' },
+      }),
+    ]);
+    const profile = createWorkspaceWritePermissionProfile();
+
+    assert.equal(available.canEnforce({ profile, platform: 'linux' }), true);
+    assert.equal(unavailable.canEnforce({ profile, platform: 'linux' }), false);
+  });
+
+  it('does not report enforcement for Linux profiles the backend will reject', () => {
+    const unsupportedArch = new SandboxManager([
+      new LinuxBubblewrapBackend({
+        capability: { available: true, bwrapPath: '/usr/bin/bwrap' },
+        arch: 'ia32',
+      }),
+    ]);
+    const denied = createWorkspaceWritePermissionProfile();
+    denied.fileSystem.entries = [
+      ...denied.fileSystem.entries,
+      { kind: 'path', access: 'deny', path: '/repo/secret' },
+    ];
+    const available = new SandboxManager([
+      new LinuxBubblewrapBackend({
+        capability: { available: true, bwrapPath: '/usr/bin/bwrap' },
+      }),
+    ]);
+
+    assert.equal(unsupportedArch.canEnforce({
+      profile: createWorkspaceWritePermissionProfile(),
+      platform: 'linux',
+    }), false);
+    assert.equal(available.canEnforce({ profile: denied, platform: 'linux' }), false);
   });
 
   it('returns unsupported_platform for win32 restricted profiles', () => {

--- a/packages/runtime/src/__tests__/shell-run-manager.test.ts
+++ b/packages/runtime/src/__tests__/shell-run-manager.test.ts
@@ -59,6 +59,26 @@ describe('ShellRunProcessManager', () => {
     assert.ok(result.output.stdout.includes('exit $LASTEXITCODE'));
   });
 
+  test('runs explicit argv and supplies inherited fd payloads on the pipe path', async () => {
+    const manager = await createTestManager();
+    const result = await manager.runForegroundBash(shellInput({
+      cwd: await workspace(),
+      command: 'sandbox display command',
+      argv: [
+        process.execPath,
+        '-e',
+        'process.stdout.write(require("node:fs").readFileSync(3, "utf8"))',
+      ],
+      fdInputs: [{ fd: 3, data: Buffer.from('seccomp-payload') }],
+    }));
+
+    assert.equal(result.kind, 'terminal');
+    assert.equal(result.status, 'completed');
+    assert.equal(result.output.mode, 'pipes');
+    if (result.output.mode !== 'pipes') throw new Error('expected pipes output');
+    assert.equal(result.output.stdout, 'seccomp-payload');
+  });
+
   test('keeps foreground execution bounded and rejects PTY promotion', async () => {
     const cwd = await workspace();
     const store = createShellRunStore(await workspace());
@@ -1546,6 +1566,9 @@ async function createTestManager(
 function shellInput(input: {
   cwd: string;
   command: string;
+  argv?: readonly string[];
+  env?: NodeJS.ProcessEnv;
+  fdInputs?: readonly { fd: number; data: Uint8Array }[];
   pty?: boolean;
   timeoutMs?: number;
   abortSignal?: AbortSignal;
@@ -1559,6 +1582,9 @@ function shellInput(input: {
     sourceToolCallId: 'tool-1',
     cwd: input.cwd,
     command: input.command,
+    ...(input.argv !== undefined ? { argv: input.argv } : {}),
+    ...(input.env !== undefined ? { env: input.env } : {}),
+    ...(input.fdInputs !== undefined ? { fdInputs: input.fdInputs } : {}),
     ...(input.pty !== undefined ? { pty: input.pty } : {}),
     ...(input.timeoutMs !== undefined ? { timeoutMs: input.timeoutMs } : {}),
     ...(input.abortSignal !== undefined ? { abortSignal: input.abortSignal } : {}),

--- a/packages/runtime/src/__tests__/workspace-executor.test.ts
+++ b/packages/runtime/src/__tests__/workspace-executor.test.ts
@@ -47,6 +47,24 @@ describe('LocalWorkspaceExecutor exec', () => {
     expect(result.aborted).toBe(false);
   });
 
+  test('runs argv commands without routing through the host shell', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'maka-workspace-exec-argv-'));
+    const executor = new LocalWorkspaceExecutor();
+
+    const result = await executor.exec({
+      command: 'ignored display command',
+      argv: [process.execPath, '-e', 'process.stdout.write(process.argv[1])', 'literal $HOME && ok'],
+      cwd,
+      timeoutMs: 5_000,
+    });
+
+    expect(result).toMatchObject({
+      exitCode: 0,
+      stdout: 'literal $HOME && ok',
+      stderr: '',
+    });
+  });
+
   test('reports timeout with captured output', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'maka-workspace-exec-'));
     const executor = new LocalWorkspaceExecutor();

--- a/packages/runtime/src/builtin-tools.ts
+++ b/packages/runtime/src/builtin-tools.ts
@@ -6,7 +6,12 @@
 // Bash / Write / Edit go through PermissionEngine.
 
 import { z } from 'zod';
+import { tmpdir } from 'node:os';
 import { isAbsolute } from 'node:path';
+import {
+  compilePermissionProfile,
+  type PermissionProfile,
+} from '@maka/core';
 import { computeEditedSource } from './edit-replace.js';
 import {
   buildManagedBashTool,
@@ -34,6 +39,10 @@ import {
 import type { MakaTool, MakaToolContext } from './tool-runtime.js';
 export type { MakaTool, MakaToolContext };
 import { withFileWriteLock } from './file-write-lock.js';
+import type { SandboxManager } from './sandbox/sandbox-manager.js';
+import { linuxExecutableRoots } from './sandbox/linux-sandbox.js';
+import type { SandboxPlatform } from './sandbox/types.js';
+import type { ChildFdInput } from './child-fd-input.js';
 
 // Generous wall-clock cap for the ripgrep-backed Grep tool. A search should be
 // near-instant; this only bounds a pathological hang now that the stream
@@ -48,6 +57,10 @@ export interface BuildBuiltinToolsOptions {
   executor?: WorkspaceExecutor;
   /** Shell that runs Bash commands. Defaults to the process-wide detected shell. */
   shell?: ShellPlan;
+  permissionProfile?: PermissionProfile;
+  sandboxManager?: SandboxManager;
+  /** Test/embedding override. Production callers use the current process platform. */
+  sandboxPlatform?: SandboxPlatform;
 }
 
 export function buildBuiltinTools(options: BuildBuiltinToolsOptions = {}): MakaTool[] {
@@ -70,9 +83,32 @@ export function buildBuiltinTools(options: BuildBuiltinToolsOptions = {}): MakaT
       ])
     : fileReadParameters;
   const shell = options.shell ?? defaultShellPlan();
+  const sandboxPlatform = options.sandboxPlatform ?? process.platform;
   const bashTools = options.shellRuns
-    ? [buildManagedBashTool(options.shellRuns, { executionFacts, shell })]
-    : [buildExecutorBashTool(executor, shell)];
+    ? [buildManagedBashTool(options.shellRuns, {
+        executionFacts,
+        shell,
+        ...(options.sandboxManager ? {
+          sandbox: sandboxAvailabilityResolver(
+            options.sandboxManager,
+            options.permissionProfile,
+            sandboxPlatform,
+          ),
+          transformCommand: ({ command, pty, ctx }) => sandboxCommand(
+            options.sandboxManager!,
+            options.permissionProfile,
+            sandboxPlatform,
+            command,
+            pty,
+            ctx,
+          ),
+        } : {}),
+      })]
+    : [buildExecutorBashTool(executor, shell, {
+        ...(options.permissionProfile ? { permissionProfile: options.permissionProfile } : {}),
+        ...(options.sandboxManager ? { sandboxManager: options.sandboxManager } : {}),
+        sandboxPlatform,
+      })];
   const backgroundTools = [
     ...(options.backgroundTasks ? [buildStopBackgroundTaskTool(options.backgroundTasks)] : []),
     ...(options.ptyControls ? [buildWriteStdinTool(options.ptyControls)] : []),
@@ -270,7 +306,17 @@ export function buildBuiltinTools(options: BuildBuiltinToolsOptions = {}): MakaT
   ];
 }
 
-function buildExecutorBashTool(executor: WorkspaceExecutor, shell: ShellPlan): MakaTool {
+interface ExecutorBashSandboxOptions {
+  permissionProfile?: PermissionProfile;
+  sandboxManager?: SandboxManager;
+  sandboxPlatform: SandboxPlatform;
+}
+
+function buildExecutorBashTool(
+  executor: WorkspaceExecutor,
+  shell: ShellPlan,
+  sandboxOptions: ExecutorBashSandboxOptions,
+): MakaTool {
   return {
     name: 'Bash',
     activityKind: 'command',
@@ -282,11 +328,32 @@ function buildExecutorBashTool(executor: WorkspaceExecutor, shell: ShellPlan): M
     }),
     permissionRequired: true,
     executionFacts: executor.facts,
-    impl: async ({ command, timeout_ms }, { cwd, abortSignal, emitOutput }) => {
+    ...(sandboxOptions.sandboxManager ? {
+      sandbox: sandboxAvailabilityResolver(
+        sandboxOptions.sandboxManager,
+        sandboxOptions.permissionProfile,
+        sandboxOptions.sandboxPlatform,
+      ),
+    } : {}),
+    impl: async ({ command, timeout_ms }, ctx) => {
+      const { cwd, abortSignal, emitOutput } = ctx;
       const timeout = timeout_ms ?? 120_000;
+      const transformed = sandboxOptions.sandboxManager
+        ? sandboxCommand(
+            sandboxOptions.sandboxManager,
+            sandboxOptions.permissionProfile,
+            sandboxOptions.sandboxPlatform,
+            command,
+            false,
+            ctx,
+          )
+        : undefined;
       const result = await executor.exec({
         command,
-        cwd,
+        cwd: transformed?.cwd ?? cwd,
+        ...(transformed ? { argv: transformed.argv } : {}),
+        ...(transformed?.env ? { env: transformed.env } : {}),
+        ...(transformed?.fdInputs ? { fdInputs: transformed.fdInputs } : {}),
         timeoutMs: timeout,
         ...(abortSignal ? { abortSignal } : {}),
         emitOutput,
@@ -300,6 +367,91 @@ function buildExecutorBashTool(executor: WorkspaceExecutor, shell: ShellPlan): M
       return shapeTerminalResult({ cwd, command, result });
     },
   };
+}
+
+function sandboxAvailabilityResolver(
+  manager: SandboxManager,
+  explicitProfile: PermissionProfile | undefined,
+  platform: SandboxPlatform,
+): NonNullable<MakaTool['sandbox']> {
+  return ({ permissionMode, cwd, args }) => {
+    if (isPtyBashArgs(args)) return { platformSandboxAvailable: false };
+    const effective = effectivePermissionProfile(explicitProfile, permissionMode, cwd);
+    return {
+      platformSandboxAvailable: manager.canEnforce({
+        profile: effective.profile,
+        platform,
+      }),
+    };
+  };
+}
+
+function sandboxCommand(
+  manager: SandboxManager,
+  explicitProfile: PermissionProfile | undefined,
+  platform: SandboxPlatform,
+  command: string,
+  pty: boolean,
+  ctx: MakaToolContext,
+): {
+  argv: readonly string[];
+  cwd: string;
+  env?: NodeJS.ProcessEnv;
+  fdInputs?: readonly ChildFdInput[];
+} | undefined {
+  if (pty) return undefined;
+  const effective = effectivePermissionProfile(
+    explicitProfile,
+    ctx.permissionMode ?? 'ask',
+    ctx.cwd,
+  );
+  if (!manager.canEnforce({ profile: effective.profile, platform })) return undefined;
+
+  const env = { ...process.env };
+  const result = manager.transform({
+    platform,
+    command: {
+      program: '/bin/sh',
+      args: ['-lc', command],
+      cwd: ctx.cwd,
+      env,
+      profile: effective.profile,
+      pathContext: {
+        workspaceRoots: effective.workspaceRoots,
+        tmpdir: tmpdir(),
+        slashTmp: '/tmp',
+        ...(platform === 'linux' ? {
+          minimalRoots: linuxExecutableRoots({
+            execPath: process.execPath,
+            path: env.PATH,
+          }),
+        } : {}),
+      },
+    },
+  });
+  if (!result.ok) {
+    throw new Error(result.message ?? `Sandbox transform failed: ${result.reason}`);
+  }
+  return {
+    argv: result.exec.argv,
+    cwd: result.exec.cwd,
+    ...(result.exec.env ? { env: { ...result.exec.env } } : {}),
+    ...(result.exec.fdInputs ? { fdInputs: result.exec.fdInputs } : {}),
+  };
+}
+
+function effectivePermissionProfile(
+  explicitProfile: PermissionProfile | undefined,
+  permissionMode: NonNullable<MakaToolContext['permissionMode']>,
+  cwd: string,
+): { profile: PermissionProfile; workspaceRoots: readonly string[] } {
+  if (explicitProfile) return { profile: explicitProfile, workspaceRoots: [cwd] };
+  const compiled = compilePermissionProfile({ mode: permissionMode, cwd });
+  return { profile: compiled.profile, workspaceRoots: compiled.workspaceRoots };
+}
+
+function isPtyBashArgs(args: unknown): boolean {
+  return typeof args === 'object' && args !== null && (args as { pty?: unknown }).pty === true;
 }
 
 function terminalError(

--- a/packages/runtime/src/child-fd-input.ts
+++ b/packages/runtime/src/child-fd-input.ts
@@ -1,0 +1,38 @@
+import type { ChildProcess } from 'node:child_process';
+import type { Writable } from 'node:stream';
+
+export interface ChildFdInput {
+  fd: number;
+  data: Uint8Array;
+}
+
+export function buildSpawnStdio(
+  fdInputs: readonly ChildFdInput[] | undefined,
+): Array<'ignore' | 'pipe'> {
+  const stdio: Array<'ignore' | 'pipe'> = ['ignore', 'pipe', 'pipe'];
+  for (const input of fdInputs ?? []) {
+    if (!Number.isInteger(input.fd) || input.fd < 3 || input.fd > 16) {
+      throw new Error(`Child fd input must use an integer fd between 3 and 16; received ${input.fd}`);
+    }
+    while (stdio.length <= input.fd) stdio.push('ignore');
+    if (stdio[input.fd] === 'pipe') throw new Error(`Duplicate child fd input ${input.fd}`);
+    stdio[input.fd] = 'pipe';
+  }
+  return stdio;
+}
+
+export function writeChildFdInputs(
+  child: ChildProcess,
+  fdInputs: readonly ChildFdInput[] | undefined,
+): void {
+  for (const input of fdInputs ?? []) {
+    const stream = child.stdio[input.fd] as Writable | null | undefined;
+    if (!stream || typeof stream.end !== 'function') {
+      throw new Error(`Child fd ${input.fd} was not opened as a writable pipe`);
+    }
+    // A helper can exit before consuming the whole payload. Treat EPIPE as a
+    // child execution failure, not an unhandled host-process stream error.
+    stream.on('error', () => {});
+    stream.end(Buffer.from(input.data));
+  }
+}

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -160,8 +160,9 @@ export { computeEditedSource, COMPUTE_EDITED_SOURCE_FN_SOURCE } from './edit-rep
 export type { EditMatch, EditMatchStrategy } from './edit-replace.js';
 export { truncateToolOutput } from './tool-output.js';
 export type { TruncateToolOutputOptions, TruncatedToolOutput } from './tool-output.js';
-export { runShellWithBoundedTail, BASH_MAX_RETAINED_CHARS } from './shell-exec.js';
+export { runProcessWithBoundedTail, runShellWithBoundedTail, BASH_MAX_RETAINED_CHARS } from './shell-exec.js';
 export type { BoundedShellOptions, BoundedShellResult } from './shell-exec.js';
+export type { ChildFdInput } from './child-fd-input.js';
 export { detectShell, defaultShellPlan, buildShellSpawnPlan, bashToolShellGuidance } from './shell-detect.js';
 export type { ShellPlan, ShellKind, ShellSpawnPlan, DetectShellInput } from './shell-detect.js';
 export {
@@ -169,16 +170,26 @@ export {
   MACOS_SEATBELT_EXECUTABLE,
   MACOS_SEATBELT_PLATFORM_DEFAULTS_POLICY,
   MacosSeatbeltBackend,
+  LinuxBubblewrapBackend,
   SandboxManager,
+  buildBubblewrapArgv,
+  buildNetworkSeccompFilter,
+  discoverNestedProtectedMetadataPaths,
   buildSeatbeltPolicy,
   createDefaultSandboxManager,
+  createBuiltinSandboxManager,
   createSeatbeltExecArgs,
   escapeSeatbeltRegex,
+  detectLinuxSandboxCapability,
 } from './sandbox/index.js';
 export type {
   BuildSeatbeltPolicyInput,
   BuildSeatbeltPolicyResult,
+  BuildBubblewrapArgvInput,
   CreateSeatbeltExecArgsInput,
+  DetectLinuxSandboxCapabilityInput,
+  LinuxBubblewrapBackendOptions,
+  LinuxSandboxCapability,
 } from './sandbox/index.js';
 export type {
   SandboxBackend,

--- a/packages/runtime/src/permission-engine.ts
+++ b/packages/runtime/src/permission-engine.ts
@@ -97,6 +97,10 @@ export interface EvaluateInput {
   permissionRequired?: boolean;
   /** Invocation-local rules. Explicit deny wins over allow, then base mode applies. */
   permissionRules?: readonly ToolPermissionRule[];
+  /** Optional trusted platform sandbox availability for sandbox-aware policy. */
+  sandbox?: {
+    platformSandboxAvailable: boolean;
+  };
 }
 
 // ============================================================================
@@ -180,6 +184,7 @@ export class PermissionEngine {
       args: input.args,
       ...(input.categoryHint !== undefined ? { categoryHint: input.categoryHint } : {}),
       ...(input.executionFacts !== undefined ? { executionFacts: input.executionFacts } : {}),
+      ...(input.sandbox !== undefined ? { sandbox: input.sandbox } : {}),
       mode: input.mode,
       turnRemembered: state.remembered,
     });

--- a/packages/runtime/src/pipe-process-driver.ts
+++ b/packages/runtime/src/pipe-process-driver.ts
@@ -1,7 +1,12 @@
-import { spawn, type ChildProcessByStdio } from 'node:child_process';
+import { spawn, type ChildProcess } from 'node:child_process';
 import type { Readable } from 'node:stream';
 
 import type { ShellSpawnPlan } from './shell-detect.js';
+import {
+  buildSpawnStdio,
+  writeChildFdInputs,
+  type ChildFdInput,
+} from './child-fd-input.js';
 
 export interface PipeProcessExit {
   exitCode: number | null;
@@ -11,36 +16,51 @@ export interface PipeProcessExit {
 export interface PipeProcessDriverOptions {
   plan: ShellSpawnPlan;
   cwd: string;
+  env?: NodeJS.ProcessEnv;
+  fdInputs?: readonly ChildFdInput[];
   onData: (stream: 'stdout' | 'stderr', data: string) => void;
   onExit: (exit: PipeProcessExit) => void;
   onFailure: (error: Error) => void;
 }
 
-type PipeChild = ChildProcessByStdio<null, Readable, Readable>;
-
 export class PipeProcessDriver {
   readonly pid: number | undefined;
   readonly ready: Promise<void>;
 
-  private readonly child: PipeChild;
+  private readonly child: ChildProcess;
+  private readonly stdout: Readable;
+  private readonly stderr: Readable;
   private disposed = false;
   private exited = false;
 
   constructor(private readonly options: PipeProcessDriverOptions) {
     this.child = spawn(options.plan.file, options.plan.args, {
       cwd: options.cwd,
+      env: options.env,
       shell: options.plan.useShellOption,
-      stdio: ['ignore', 'pipe', 'pipe'],
+      stdio: buildSpawnStdio(options.fdInputs),
       detached: process.platform !== 'win32',
     });
+    if (!this.child.stdout || !this.child.stderr) {
+      this.child.kill('SIGKILL');
+      throw new Error('Pipe process did not expose stdout and stderr');
+    }
+    this.stdout = this.child.stdout;
+    this.stderr = this.child.stderr;
     this.pid = this.child.pid;
-    this.child.stdout.setEncoding('utf8');
-    this.child.stderr.setEncoding('utf8');
-    this.child.stdout.on('data', this.onStdout);
-    this.child.stderr.on('data', this.onStderr);
+    this.stdout.setEncoding('utf8');
+    this.stderr.setEncoding('utf8');
+    this.stdout.on('data', this.onStdout);
+    this.stderr.on('data', this.onStderr);
     this.child.on('close', this.onClose);
     this.child.on('error', this.onError);
     this.ready = waitForSpawn(this.child);
+    try {
+      writeChildFdInputs(this.child, options.fdInputs);
+    } catch (error) {
+      this.child.kill('SIGKILL');
+      throw error;
+    }
   }
 
   kill(signal: 'SIGTERM' | 'SIGKILL'): boolean {
@@ -50,8 +70,8 @@ export class PipeProcessDriver {
   dispose(): void {
     if (this.disposed) return;
     this.disposed = true;
-    this.child.stdout.off('data', this.onStdout);
-    this.child.stderr.off('data', this.onStderr);
+    this.stdout.off('data', this.onStdout);
+    this.stderr.off('data', this.onStderr);
     this.child.off('close', this.onClose);
     this.child.off('error', this.onError);
   }
@@ -75,7 +95,7 @@ export class PipeProcessDriver {
   };
 }
 
-function waitForSpawn(child: PipeChild): Promise<void> {
+function waitForSpawn(child: ChildProcess): Promise<void> {
   return new Promise((resolve, reject) => {
     const onSpawn = () => {
       cleanup();

--- a/packages/runtime/src/sandbox/default-sandbox-manager.ts
+++ b/packages/runtime/src/sandbox/default-sandbox-manager.ts
@@ -1,6 +1,17 @@
 import { SandboxManager } from './sandbox-manager.js';
 import { MacosSeatbeltBackend } from './macos-seatbelt.js';
+import { LinuxBubblewrapBackend } from './linux-sandbox.js';
+import type { SandboxPlatform } from './types.js';
 
 export function createDefaultSandboxManager(): SandboxManager {
-  return new SandboxManager([new MacosSeatbeltBackend()]);
+  return new SandboxManager([
+    new MacosSeatbeltBackend(),
+    new LinuxBubblewrapBackend(),
+  ]);
+}
+
+export function createBuiltinSandboxManager(
+  platform: SandboxPlatform = process.platform,
+): SandboxManager | undefined {
+  return platform === 'linux' ? createDefaultSandboxManager() : undefined;
 }

--- a/packages/runtime/src/sandbox/index.ts
+++ b/packages/runtime/src/sandbox/index.ts
@@ -1,5 +1,27 @@
 export { SandboxManager } from './sandbox-manager.js';
-export { createDefaultSandboxManager } from './default-sandbox-manager.js';
+export {
+  createBuiltinSandboxManager,
+  createDefaultSandboxManager,
+} from './default-sandbox-manager.js';
+export {
+  LinuxBubblewrapBackend,
+  buildBubblewrapArgv,
+  buildNetworkSeccompFilter,
+  discoverNestedProtectedMetadataPaths,
+} from './linux-sandbox.js';
+export type {
+  BuildBubblewrapArgvInput,
+  LinuxBubblewrapBackendOptions,
+} from './linux-sandbox.js';
+export {
+  LINUX_BWRAP_PROBE_ARGS,
+  LINUX_BWRAP_REQUIRED_OPTIONS,
+  detectLinuxSandboxCapability,
+} from './linux-capability.js';
+export type {
+  DetectLinuxSandboxCapabilityInput,
+  LinuxSandboxCapability,
+} from './linux-capability.js';
 export {
   MACOS_SEATBELT_BASE_POLICY,
   MACOS_SEATBELT_EXECUTABLE,

--- a/packages/runtime/src/sandbox/linux-capability.ts
+++ b/packages/runtime/src/sandbox/linux-capability.ts
@@ -1,0 +1,80 @@
+import { accessSync, constants } from 'node:fs';
+import { spawnSync } from 'node:child_process';
+
+import type { SandboxPlatform } from './types.js';
+
+export type LinuxSandboxCapability =
+  | { available: true; bwrapPath: string }
+  | {
+      available: false;
+      reason: 'non-linux' | 'missing-bwrap' | 'probe-failed';
+      bwrapPath?: string;
+      detail?: string;
+    };
+
+export interface DetectLinuxSandboxCapabilityInput {
+  platform?: SandboxPlatform;
+  bwrapPath?: string;
+}
+
+export const LINUX_BWRAP_REQUIRED_OPTIONS = ['--seccomp'] as const;
+
+export const LINUX_BWRAP_PROBE_ARGS = [
+  '--die-with-parent',
+  '--new-session',
+  '--unshare-user',
+  '--unshare-pid',
+  '--unshare-ipc',
+  '--unshare-uts',
+  '--unshare-cgroup',
+  '--unshare-net',
+  '--ro-bind',
+  '/',
+  '/',
+  '--proc',
+  '/proc',
+  '--dev',
+  '/dev',
+  '--',
+  '/bin/true',
+] as const;
+
+export function detectLinuxSandboxCapability(
+  input: DetectLinuxSandboxCapabilityInput = {},
+): LinuxSandboxCapability {
+  const platform = input.platform ?? process.platform;
+  if (platform !== 'linux') return { available: false, reason: 'non-linux' };
+
+  const bwrapPath = input.bwrapPath ?? '/usr/bin/bwrap';
+  try {
+    accessSync(bwrapPath, constants.X_OK);
+  } catch {
+    return { available: false, reason: 'missing-bwrap', bwrapPath };
+  }
+
+  const help = spawnSync(bwrapPath, ['--help'], {
+    encoding: 'utf8',
+    timeout: 5_000,
+    windowsHide: true,
+  });
+  const helpText = `${help.stdout ?? ''}\n${help.stderr ?? ''}`;
+  if (help.status !== 0 || LINUX_BWRAP_REQUIRED_OPTIONS.some((option) => !helpText.includes(option))) {
+    return {
+      available: false,
+      reason: 'probe-failed',
+      bwrapPath,
+      detail: 'bubblewrap does not advertise required seccomp support',
+    };
+  }
+
+  const probe = spawnSync(bwrapPath, [...LINUX_BWRAP_PROBE_ARGS], {
+    encoding: 'utf8',
+    timeout: 5_000,
+    windowsHide: true,
+  });
+  if (probe.status !== 0) {
+    const detail = probe.error?.message || probe.stderr.trim() || `exit ${probe.status ?? 'unknown'}`;
+    return { available: false, reason: 'probe-failed', bwrapPath, detail };
+  }
+  return { available: true, bwrapPath };
+}

--- a/packages/runtime/src/sandbox/linux-sandbox.ts
+++ b/packages/runtime/src/sandbox/linux-sandbox.ts
@@ -204,16 +204,23 @@ export function buildBubblewrapArgv(input: BuildBubblewrapArgvInput): readonly s
   }
 
   const programDirectory = absoluteProgramDirectory(command.program);
+  const profileCoverage = [
+    ...DEFAULT_READ_ONLY_HOST_PATHS,
+    ...roots.readableRoots,
+    ...roots.writableRoots,
+  ];
   const extraProgramDirectories = programDirectory
-    && !isCoveredByAnyRoot(programDirectory, [
-      ...DEFAULT_READ_ONLY_HOST_PATHS,
-      ...roots.readableRoots,
-      ...roots.writableRoots,
-    ])
+    && !isCoveredByAnyRoot(programDirectory, profileCoverage)
     ? [programDirectory]
     : [];
+  const extraRuntimeRoots = removeNestedRoots((command.pathContext.minimalRoots ?? []).filter((root) => (
+    posix.isAbsolute(root)
+    && posix.normalize(root) !== '/'
+    && !isCoveredByAnyRoot(root, profileCoverage)
+  )));
   const mountRoots = uniqueRoots([
     ...extraProgramDirectories,
+    ...extraRuntimeRoots,
     ...roots.tempRoots,
     ...roots.readableRoots,
     ...roots.writableRoots,
@@ -224,6 +231,9 @@ export function buildBubblewrapArgv(input: BuildBubblewrapArgvInput): readonly s
 
   for (const directory of extraProgramDirectories) {
     argv.push('--ro-bind', directory, directory);
+  }
+  for (const directory of extraRuntimeRoots) {
+    argv.push('--ro-bind-try', directory, directory);
   }
   for (const root of roots.tempRoots) argv.push('--tmpfs', root);
   for (const root of roots.readableRoots) argv.push('--ro-bind', root, root);
@@ -396,6 +406,25 @@ function absoluteProgramDirectory(program: string): string | undefined {
   return posix.isAbsolute(program) ? posix.dirname(program) : undefined;
 }
 
+export function linuxExecutableRoots(input: {
+  execPath: string;
+  path?: string;
+}): readonly string[] {
+  const roots: string[] = [];
+  if (posix.isAbsolute(input.execPath)) {
+    const executableDirectory = posix.dirname(posix.normalize(input.execPath));
+    roots.push(posix.basename(executableDirectory) === 'bin'
+      ? posix.dirname(executableDirectory)
+      : executableDirectory);
+  }
+  for (const entry of input.path?.split(':') ?? []) {
+    if (posix.isAbsolute(entry) && posix.normalize(entry) !== '/') {
+      roots.push(posix.normalize(entry));
+    }
+  }
+  return removeNestedRoots(roots);
+}
+
 function isCoveredByAnyRoot(path: string, roots: readonly string[]): boolean {
   return roots.some((root) => {
     const relative = posix.relative(root, path);
@@ -405,6 +434,13 @@ function isCoveredByAnyRoot(path: string, roots: readonly string[]): boolean {
 
 function removeCoveredRoots(roots: readonly string[], covering: readonly string[]): readonly string[] {
   return roots.filter((root) => !covering.includes(root));
+}
+
+function removeNestedRoots(roots: readonly string[]): readonly string[] {
+  const unique = [...new Set(roots.map((root) => posix.normalize(root)))];
+  return unique.filter((root) => !unique.some((candidate) => (
+    candidate !== root && isCoveredByAnyRoot(root, [candidate])
+  )));
 }
 
 function requiredParentDirectories(roots: readonly string[]): readonly string[] {

--- a/packages/runtime/src/sandbox/linux-sandbox.ts
+++ b/packages/runtime/src/sandbox/linux-sandbox.ts
@@ -1,0 +1,438 @@
+import { posix } from 'node:path';
+import { readdirSync } from 'node:fs';
+
+import type { PermissionProfile } from '@maka/core/permission-profile';
+
+import {
+  detectLinuxSandboxCapability,
+  type LinuxSandboxCapability,
+} from './linux-capability.js';
+import type {
+  SandboxBackend,
+  SandboxCommand,
+  SandboxPathContext,
+  SandboxTransformRequest,
+  SandboxTransformResult,
+} from './types.js';
+
+const DEFAULT_READ_ONLY_HOST_PATHS = [
+  '/usr',
+  '/bin',
+  '/sbin',
+  '/lib',
+  '/lib64',
+  '/etc',
+] as const;
+
+export interface LinuxBubblewrapBackendOptions {
+  capability?: LinuxSandboxCapability;
+  bwrapPath?: string;
+  arch?: NodeJS.Architecture;
+  discoverProtectedMetadataPaths?: (input: {
+    writableRoots: readonly string[];
+    names: readonly string[];
+  }) => readonly string[];
+}
+
+export interface BuildBubblewrapArgvInput {
+  bwrapPath: string;
+  command: SandboxCommand;
+  protectedMetadataPaths?: readonly string[];
+}
+
+interface ResolvedLinuxRoots {
+  readableRoots: readonly string[];
+  writableRoots: readonly string[];
+  tempRoots: readonly string[];
+  protectedWritableRoots: readonly string[];
+  protectedMetadataNames: readonly string[];
+  hasDenyEntries: boolean;
+}
+
+export class LinuxBubblewrapBackend implements SandboxBackend {
+  readonly type = 'linux' as const;
+  private detectedCapability?: LinuxSandboxCapability;
+
+  constructor(private readonly options: LinuxBubblewrapBackendOptions = {}) {}
+
+  isAvailable(platform = process.platform): boolean {
+    if (!this.capability(platform).available) return false;
+    try {
+      networkSyscalls(this.options.arch ?? process.arch);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  canEnforceProfile(profile: PermissionProfile): boolean {
+    if (profile.type !== 'managed' || profile.fileSystem.kind !== 'restricted') return false;
+    if (profile.fileSystem.entries.some((entry) => entry.access === 'deny')) return false;
+    if (networkRestricted(profile)) {
+      try {
+        networkSyscalls(this.options.arch ?? process.arch);
+      } catch {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  transform(request: SandboxTransformRequest): SandboxTransformResult {
+    const { command } = request;
+    const preference = request.preference ?? 'auto';
+    const platform = request.platform ?? process.platform;
+
+    if (command.profile.type !== 'managed' || command.profile.fileSystem.kind !== 'restricted') {
+      return failure(
+        'invalid_request',
+        'Linux bubblewrap backend only accepts managed restricted profiles.',
+        platform,
+        preference,
+      );
+    }
+
+    const roots = resolveRoots(command.profile, command.pathContext);
+    if (roots.hasDenyEntries) {
+      return failure(
+        'invalid_request',
+        'Linux sandbox deny entries are not supported by the bubblewrap backend.',
+        platform,
+        preference,
+      );
+    }
+
+    const capability = this.capability(platform);
+    if (!capability.available) {
+      return failure(
+        'backend_not_available',
+        `Linux bubblewrap sandbox is not available (${capability.reason}).`,
+        platform,
+        preference,
+      );
+    }
+
+    let seccompFilter: Uint8Array | undefined;
+    if (networkRestricted(command.profile)) {
+      try {
+        seccompFilter = buildNetworkSeccompFilter(this.options.arch ?? process.arch);
+      } catch (error) {
+        return failure(
+          'backend_not_available',
+          error instanceof Error ? error.message : String(error),
+          platform,
+          preference,
+        );
+      }
+    }
+
+    let nestedProtectedPaths: readonly string[];
+    try {
+      nestedProtectedPaths = (this.options.discoverProtectedMetadataPaths
+        ?? discoverNestedProtectedMetadataPaths)({
+        writableRoots: roots.protectedWritableRoots,
+        names: roots.protectedMetadataNames,
+      });
+    } catch (error) {
+      return failure(
+        'invalid_request',
+        `Unable to enumerate protected metadata: ${error instanceof Error ? error.message : String(error)}`,
+        platform,
+        preference,
+      );
+    }
+
+    return {
+      ok: true,
+      exec: {
+        argv: buildBubblewrapArgv({
+          bwrapPath: capability.bwrapPath,
+          command,
+          protectedMetadataPaths: nestedProtectedPaths,
+        }),
+        ...(seccompFilter ? { fdInputs: [{ fd: 3, data: seccompFilter }] } : {}),
+        cwd: command.cwd,
+        env: command.env,
+        sandboxType: 'linux',
+        effectiveProfile: command.profile,
+      },
+      sandboxType: 'linux',
+      requiresSandbox: true,
+      preference,
+    };
+  }
+
+  private capability(platform: string): LinuxSandboxCapability {
+    if (this.options.capability) return this.options.capability;
+    if (this.detectedCapability) return this.detectedCapability;
+    this.detectedCapability = detectLinuxSandboxCapability({
+      platform,
+      ...(this.options.bwrapPath ? { bwrapPath: this.options.bwrapPath } : {}),
+    });
+    return this.detectedCapability;
+  }
+}
+
+export function buildBubblewrapArgv(input: BuildBubblewrapArgvInput): readonly string[] {
+  const { command } = input;
+  const roots = resolveRoots(command.profile, command.pathContext);
+  if (roots.hasDenyEntries) {
+    throw new Error('Linux sandbox deny entries are not supported by the bubblewrap backend.');
+  }
+
+  const argv: string[] = [
+    input.bwrapPath,
+    '--die-with-parent',
+    '--new-session',
+    '--unshare-user',
+    '--unshare-pid',
+    '--unshare-ipc',
+    '--unshare-uts',
+    '--unshare-cgroup',
+    '--proc',
+    '/proc',
+    '--dev',
+    '/dev',
+  ];
+
+  if (networkRestricted(command.profile)) {
+    argv.push('--unshare-net', '--seccomp', '3');
+  }
+
+  for (const path of DEFAULT_READ_ONLY_HOST_PATHS) {
+    argv.push('--ro-bind-try', path, path);
+  }
+
+  const mountRoots = uniqueRoots([
+    ...roots.tempRoots,
+    ...roots.readableRoots,
+    ...roots.writableRoots,
+  ]);
+  for (const directory of requiredParentDirectories(mountRoots)) {
+    argv.push('--dir', directory);
+  }
+
+  for (const root of roots.tempRoots) argv.push('--tmpfs', root);
+  for (const root of roots.readableRoots) argv.push('--ro-bind', root, root);
+  for (const root of roots.writableRoots) argv.push('--bind', root, root);
+
+  for (const root of roots.protectedWritableRoots) {
+    for (const name of roots.protectedMetadataNames) {
+      const protectedPath = posix.join(root, name);
+      argv.push('--ro-bind-try', protectedPath, protectedPath);
+    }
+  }
+  for (const path of input.protectedMetadataPaths ?? []) {
+    argv.push('--ro-bind', path, path);
+  }
+
+  argv.push('--chdir', command.cwd, '--', command.program, ...command.args);
+  return argv;
+}
+
+/**
+ * Build a compiled classic-BPF seccomp program for bubblewrap's `--seccomp FD`.
+ * The filter validates the audit architecture, then denies socket creation.
+ * Network-restricted sandboxes receive no inherited network descriptors, so
+ * blocking socket/socketpair prevents opening a new network channel.
+ */
+export function buildNetworkSeccompFilter(arch: NodeJS.Architecture = process.arch): Uint8Array {
+  const syscall = networkSyscalls(arch);
+  const instructions: ReadonlyArray<readonly [code: number, jt: number, jf: number, value: number]> = [
+    [0x20, 0, 0, 4],
+    [0x15, 1, 0, syscall.auditArch],
+    [0x06, 0, 0, 0x80000000],
+    [0x20, 0, 0, 0],
+    [0x15, 0, 1, syscall.socket],
+    [0x06, 0, 0, 0x00050001],
+    [0x15, 0, 1, syscall.socketpair],
+    [0x06, 0, 0, 0x00050001],
+    [0x06, 0, 0, 0x7fff0000],
+  ];
+  const output = Buffer.alloc(instructions.length * 8);
+  instructions.forEach(([code, jt, jf, value], index) => {
+    const offset = index * 8;
+    output.writeUInt16LE(code, offset);
+    output.writeUInt8(jt, offset + 2);
+    output.writeUInt8(jf, offset + 3);
+    output.writeUInt32LE(value >>> 0, offset + 4);
+  });
+  return output;
+}
+
+function networkSyscalls(arch: NodeJS.Architecture): {
+  auditArch: number;
+  socket: number;
+  socketpair: number;
+} {
+  switch (arch) {
+    case 'x64':
+      return { auditArch: 0xc000003e, socket: 41, socketpair: 53 };
+    case 'arm64':
+      return { auditArch: 0xc00000b7, socket: 198, socketpair: 199 };
+    default:
+      throw new Error(`Linux seccomp network filter: unsupported architecture ${arch}`);
+  }
+}
+
+function failure(
+  reason: 'backend_not_available' | 'invalid_request',
+  message: string,
+  platform: string,
+  preference: 'auto' | 'require' | 'forbid',
+): SandboxTransformResult {
+  return {
+    ok: false,
+    reason,
+    sandboxType: 'linux',
+    requiresSandbox: true,
+    platform,
+    preference,
+    message,
+  };
+}
+
+function resolveRoots(
+  profile: PermissionProfile,
+  context: SandboxPathContext,
+): ResolvedLinuxRoots {
+  if (profile.type !== 'managed' || profile.fileSystem.kind !== 'restricted') {
+    return {
+      readableRoots: [],
+      writableRoots: [],
+      tempRoots: [],
+      protectedWritableRoots: [],
+      protectedMetadataNames: [],
+      hasDenyEntries: false,
+    };
+  }
+
+  const readableRoots: string[] = [];
+  const writableRoots: string[] = [];
+  const tempRoots: string[] = [];
+  const protectedWritableRoots: string[] = [];
+  let hasDenyEntries = false;
+
+  for (const entry of profile.fileSystem.entries) {
+    if (entry.access === 'deny') {
+      hasDenyEntries = true;
+      continue;
+    }
+
+    const roots = rootsForEntry(entry, context);
+    const isTemp = entry.kind === 'special'
+      && (entry.special === ':tmpdir' || entry.special === ':slash_tmp');
+
+    if (entry.access === 'write' && isTemp) {
+      addUnique(tempRoots, roots);
+      continue;
+    }
+    if (entry.access === 'write') {
+      addUnique(writableRoots, roots);
+      if (entry.kind === 'special' && entry.special === ':workspace_roots') {
+        addUnique(protectedWritableRoots, roots);
+      }
+      continue;
+    }
+    addUnique(readableRoots, roots);
+  }
+
+  return {
+    readableRoots: removeCoveredRoots(readableRoots, writableRoots),
+    writableRoots,
+    tempRoots,
+    protectedWritableRoots: profile.fileSystem.protectedMetadata ? protectedWritableRoots : [],
+    protectedMetadataNames: profile.fileSystem.protectedMetadata?.names ?? [],
+    hasDenyEntries,
+  };
+}
+
+type ProfileEntry = Extract<PermissionProfile, { type: 'managed' }>['fileSystem']['entries'][number];
+
+function rootsForEntry(entry: ProfileEntry, context: SandboxPathContext): readonly string[] {
+  if (entry.kind === 'path') return [entry.path];
+  switch (entry.special) {
+    case ':root':
+      return ['/'];
+    case ':workspace_roots':
+      return context.workspaceRoots;
+    case ':tmpdir':
+      return context.tmpdir ? [context.tmpdir] : [];
+    case ':slash_tmp':
+      return [context.slashTmp ?? '/tmp'];
+    case ':minimal':
+      return context.minimalRoots ?? [];
+  }
+}
+
+function networkRestricted(profile: PermissionProfile): boolean {
+  return profile.type !== 'managed' || profile.network.kind === 'restricted';
+}
+
+function addUnique(target: string[], roots: readonly string[]): void {
+  for (const root of roots) {
+    if (!target.includes(root)) target.push(root);
+  }
+}
+
+function uniqueRoots(roots: readonly string[]): readonly string[] {
+  return [...new Set(roots)];
+}
+
+function removeCoveredRoots(roots: readonly string[], covering: readonly string[]): readonly string[] {
+  return roots.filter((root) => !covering.includes(root));
+}
+
+function requiredParentDirectories(roots: readonly string[]): readonly string[] {
+  const parents = new Set<string>();
+  for (const root of roots) {
+    let current = posix.dirname(root);
+    while (current !== '/' && current !== '.') {
+      parents.add(current);
+      current = posix.dirname(current);
+    }
+  }
+  return [...parents].sort((left, right) => left.length - right.length);
+}
+
+const MAX_PROTECTED_SCAN_ENTRIES = 100_000;
+const MAX_PROTECTED_SCAN_DEPTH = 64;
+
+export function discoverNestedProtectedMetadataPaths(input: {
+  writableRoots: readonly string[];
+  names: readonly string[];
+}): readonly string[] {
+  const found: string[] = [];
+  let visited = 0;
+
+  for (const root of input.writableRoots) {
+    walk(root, 0, true);
+  }
+  return found;
+
+  function walk(directory: string, depth: number, isRoot: boolean): void {
+    if (depth > MAX_PROTECTED_SCAN_DEPTH) {
+      throw new Error(`protected metadata scan exceeded depth ${MAX_PROTECTED_SCAN_DEPTH}`);
+    }
+    let entries;
+    try {
+      entries = readdirSync(directory, { withFileTypes: true });
+    } catch (error) {
+      if (isRoot && (error as NodeJS.ErrnoException).code === 'ENOENT') return;
+      throw error;
+    }
+
+    for (const entry of entries) {
+      visited += 1;
+      if (visited > MAX_PROTECTED_SCAN_ENTRIES) {
+        throw new Error(`protected metadata scan exceeded ${MAX_PROTECTED_SCAN_ENTRIES} entries`);
+      }
+      const path = posix.join(directory, entry.name);
+      if (input.names.includes(entry.name)) {
+        if (!isRoot) found.push(path);
+        continue;
+      }
+      if (entry.isDirectory()) walk(path, depth + 1, false);
+    }
+  }
+}

--- a/packages/runtime/src/sandbox/linux-sandbox.ts
+++ b/packages/runtime/src/sandbox/linux-sandbox.ts
@@ -203,7 +203,17 @@ export function buildBubblewrapArgv(input: BuildBubblewrapArgvInput): readonly s
     argv.push('--ro-bind-try', path, path);
   }
 
+  const programDirectory = absoluteProgramDirectory(command.program);
+  const extraProgramDirectories = programDirectory
+    && !isCoveredByAnyRoot(programDirectory, [
+      ...DEFAULT_READ_ONLY_HOST_PATHS,
+      ...roots.readableRoots,
+      ...roots.writableRoots,
+    ])
+    ? [programDirectory]
+    : [];
   const mountRoots = uniqueRoots([
+    ...extraProgramDirectories,
     ...roots.tempRoots,
     ...roots.readableRoots,
     ...roots.writableRoots,
@@ -212,6 +222,9 @@ export function buildBubblewrapArgv(input: BuildBubblewrapArgvInput): readonly s
     argv.push('--dir', directory);
   }
 
+  for (const directory of extraProgramDirectories) {
+    argv.push('--ro-bind', directory, directory);
+  }
   for (const root of roots.tempRoots) argv.push('--tmpfs', root);
   for (const root of roots.readableRoots) argv.push('--ro-bind', root, root);
   for (const root of roots.writableRoots) argv.push('--bind', root, root);
@@ -377,6 +390,17 @@ function addUnique(target: string[], roots: readonly string[]): void {
 
 function uniqueRoots(roots: readonly string[]): readonly string[] {
   return [...new Set(roots)];
+}
+
+function absoluteProgramDirectory(program: string): string | undefined {
+  return posix.isAbsolute(program) ? posix.dirname(program) : undefined;
+}
+
+function isCoveredByAnyRoot(path: string, roots: readonly string[]): boolean {
+  return roots.some((root) => {
+    const relative = posix.relative(root, path);
+    return relative === '' || (relative !== '..' && !relative.startsWith('../'));
+  });
 }
 
 function removeCoveredRoots(roots: readonly string[], covering: readonly string[]): readonly string[] {

--- a/packages/runtime/src/sandbox/sandbox-manager.ts
+++ b/packages/runtime/src/sandbox/sandbox-manager.ts
@@ -70,14 +70,25 @@ export class SandboxManager {
     }
 
     if (platform === 'linux') {
+      if (this.backends.has('linux')) {
+        return {
+          ok: true,
+          sandboxType: 'linux',
+          requiresSandbox: true,
+          reason: 'platform_sandbox_selected',
+          platform,
+          preference,
+        };
+      }
+
       return {
         ok: false,
-        reason: 'backend_not_implemented',
+        reason: 'backend_not_available',
         sandboxType: 'linux',
         requiresSandbox: true,
         platform,
         preference,
-        message: 'Linux sandbox backend is planned for a later phase.',
+        message: 'Linux sandbox backend is not registered.',
       };
     }
 
@@ -89,6 +100,16 @@ export class SandboxManager {
       preference,
       message: `Sandbox enforcement is unsupported on platform ${platform}.`,
     };
+  }
+
+  canEnforce(input: SandboxSelectionInput): boolean {
+    const selected = this.selectInitial(input);
+    if (!selected.ok) return false;
+    if (selected.sandboxType === 'none') return true;
+    const backend = this.backends.get(selected.sandboxType);
+    if (!backend) return false;
+    if (!(backend.isAvailable?.(selected.platform) ?? true)) return false;
+    return backend.canEnforceProfile?.(input.profile) ?? true;
   }
 
   transform(request: SandboxTransformRequest): SandboxTransformResult {

--- a/packages/runtime/src/sandbox/types.ts
+++ b/packages/runtime/src/sandbox/types.ts
@@ -1,4 +1,5 @@
 import type { PermissionProfile } from '@maka/core/permission-profile';
+import type { ChildFdInput } from '../child-fd-input.js';
 
 export type SandboxType = 'none' | 'macos-seatbelt' | 'linux';
 
@@ -33,6 +34,7 @@ export interface SandboxCommand {
 
 export interface SandboxExecRequest {
   argv: readonly string[];
+  fdInputs?: readonly ChildFdInput[];
   cwd: string;
   env?: Readonly<Record<string, string | undefined>>;
   sandboxType: SandboxType;
@@ -90,5 +92,7 @@ export type SandboxTransformResult =
 
 export interface SandboxBackend {
   readonly type: Exclude<SandboxType, 'none'>;
+  isAvailable?(platform?: SandboxPlatform): boolean;
+  canEnforceProfile?(profile: PermissionProfile): boolean;
   transform(request: SandboxTransformRequest): SandboxTransformResult;
 }

--- a/packages/runtime/src/shell-exec.ts
+++ b/packages/runtime/src/shell-exec.ts
@@ -25,6 +25,11 @@ import {
   terminateChildProcessTree,
 } from './process-tree-terminator.js';
 import { OUTPUT_RECOVERY_HINT } from './tool-output.js';
+import {
+  buildSpawnStdio,
+  writeChildFdInputs,
+  type ChildFdInput,
+} from './child-fd-input.js';
 
 // Per-stream cap on the output RETAINED for the result (~1MB). This only bounds
 // what is kept to return. The tool layer (truncateToolOutput) trims this further
@@ -78,6 +83,8 @@ export interface BoundedShellOptions {
   emitOutput?: (stream: 'stdout' | 'stderr', chunk: string) => void;
   /** Shell to run the command with. Defaults to the process-wide detected shell. */
   shell?: ShellPlan;
+  /** Binary payloads exposed to the child on inherited file descriptors. */
+  fdInputs?: readonly ChildFdInput[];
 }
 
 export interface BoundedShellResult {
@@ -109,16 +116,34 @@ export function runShellWithBoundedTail(
   command: string,
   options: BoundedShellOptions,
 ): Promise<BoundedShellResult> {
+  const plan = buildShellSpawnPlan(options.shell ?? defaultShellPlan(), command);
+  return runSpawnedProcessWithBoundedTail(plan.file, plan.args, plan.useShellOption, options);
+}
+
+/** Run an argv command directly, without a second shell parsing pass. */
+export function runProcessWithBoundedTail(
+  program: string,
+  args: readonly string[],
+  options: BoundedShellOptions,
+): Promise<BoundedShellResult> {
+  return runSpawnedProcessWithBoundedTail(program, args, false, options);
+}
+
+function runSpawnedProcessWithBoundedTail(
+  program: string,
+  args: readonly string[],
+  useShellOption: boolean,
+  options: BoundedShellOptions,
+): Promise<BoundedShellResult> {
   const cap = options.maxRetainedChars ?? BASH_MAX_RETAINED_CHARS;
   const liveCap = options.maxLiveEmitChars ?? BASH_MAX_LIVE_EMIT_CHARS;
   const graceMs = options.killGraceMs ?? DEFAULT_PROCESS_TERMINATION_GRACE_MS;
-  const plan = buildShellSpawnPlan(options.shell ?? defaultShellPlan(), command);
   return new Promise<BoundedShellResult>((resolvePromise, reject) => {
-    const child = spawn(plan.file, plan.args, {
+    const child = spawn(program, [...args], {
       cwd: options.cwd,
       env: options.env,
-      shell: plan.useShellOption,
-      stdio: ['ignore', 'pipe', 'pipe'],
+      shell: useShellOption,
+      stdio: buildSpawnStdio(options.fdInputs),
       // POSIX: make the shell its own process-group leader (setsid). Termination
       // signals the group and removes descendants visible outside it at each
       // process-table snapshot.
@@ -163,6 +188,14 @@ export function runShellWithBoundedTail(
     if (options.abortSignal) {
       if (options.abortSignal.aborted) abort();
       else options.abortSignal.addEventListener('abort', abort, { once: true });
+    }
+    try {
+      writeChildFdInputs(child, options.fdInputs);
+    } catch (error) {
+      settled = true;
+      cleanup();
+      void terminateChildProcessTree(child, 'SIGKILL');
+      reject(error);
     }
 
     function append(stream: 'stdout' | 'stderr', chunk: string): void {

--- a/packages/runtime/src/shell-run-contract.ts
+++ b/packages/runtime/src/shell-run-contract.ts
@@ -1,6 +1,7 @@
 import { isShellRunId, type ShellRunStore, type ShellRunUpdate, type ToolResultContent } from '@maka/core';
 
 import type { ShellPlan } from './shell-detect.js';
+import type { ChildFdInput } from './child-fd-input.js';
 
 export const DEFAULT_BASH_TIMEOUT_MS = 120_000;
 export const MAX_FOREGROUND_BASH_TIMEOUT_MS = 10 * 60 * 1_000;
@@ -43,6 +44,11 @@ export interface ShellRunBashInput {
   sourceToolCallId: string;
   cwd: string;
   command: string;
+  /** Final executable argv. When present, bypasses host-shell parsing. */
+  argv?: readonly string[];
+  env?: NodeJS.ProcessEnv;
+  /** Binary payloads exposed to pipe-mode children on inherited descriptors. */
+  fdInputs?: readonly ChildFdInput[];
   pty?: boolean;
   timeoutMs?: number;
   abortSignal?: AbortSignal;

--- a/packages/runtime/src/shell-run-manager.ts
+++ b/packages/runtime/src/shell-run-manager.ts
@@ -505,6 +505,9 @@ export class ShellRunProcessManager implements RuntimeResourceReader, Background
   ): Promise<LiveShellRun> {
     const sessionEpoch = this.sessionTerminationEpoch(input.sessionId);
     this.assertStartAllowed(input.sessionId, sessionEpoch);
+    if (mode === 'pty' && (input.argv || input.fdInputs)) {
+      throw new Error('PTY Bash does not support transformed argv or inherited fd inputs');
+    }
     const slotReservation = this.reserveSlot(mode);
     try {
       const shellRunId = this.input.newId();
@@ -536,10 +539,18 @@ export class ShellRunProcessManager implements RuntimeResourceReader, Background
       else pending.push(callback);
     };
     const collector = new PipeTailCollector(this.maxRetainedChars);
-    const plan = buildShellSpawnPlan(input.shell ?? defaultShellPlan(), input.command);
+    const plan = input.argv
+      ? {
+          file: requireProgram(input.argv),
+          args: [...input.argv.slice(1)],
+          useShellOption: false,
+        }
+      : buildShellSpawnPlan(input.shell ?? defaultShellPlan(), input.command);
     const driver = new PipeProcessDriver({
       plan,
       cwd: input.cwd,
+      ...(input.env ? { env: input.env } : {}),
+      ...(input.fdInputs ? { fdInputs: input.fdInputs } : {}),
       onData: (stream, data) => dispatch((target) => this.onPipeData(target, stream, data)),
       onExit: (exit) => dispatch((target) => this.onDriverExit(target, { mode: 'pipes', value: exit })),
       onFailure: (error) => dispatch((target) => this.handleIntegrityFailure(target, error)),
@@ -614,7 +625,7 @@ export class ShellRunProcessManager implements RuntimeResourceReader, Background
         file: plan.file,
         args: plan.args,
         cwd: input.cwd,
-        env: process.env,
+        env: input.env ?? process.env,
         cols: PTY_INITIAL_COLS,
         rows: PTY_INITIAL_ROWS,
         onData: (data) => dispatch((target) => target.collector.accept(data)),
@@ -1425,6 +1436,12 @@ function normalizeBackgroundTimeoutMs(value: number | undefined): number | undef
     throw new Error(`Background Bash timeout must be between 1 and ${MAX_SHELL_RUN_TIMEOUT_MS}ms`);
   }
   return value;
+}
+
+function requireProgram(argv: readonly string[]): string {
+  const program = argv[0];
+  if (!program) throw new Error('Transformed Bash argv must include a program');
+  return program;
 }
 
 function normalizeForegroundTimeoutMs(value: number): number {

--- a/packages/runtime/src/shell-tools.ts
+++ b/packages/runtime/src/shell-tools.ts
@@ -20,6 +20,7 @@ import {
   type ShellRunBashInput,
   isWellFormedTerminalInput,
 } from './shell-run-contract.js';
+import type { ChildFdInput } from './child-fd-input.js';
 
 export interface ForegroundBashExecuteInput {
   command: string;
@@ -110,7 +111,21 @@ export function buildLocalForegroundBashTool(
 
 export function buildManagedBashTool(
   shellRuns: ShellRunLauncher,
-  options: { executionFacts?: ToolExecutionFacts; shell?: ShellPlan } = {},
+  options: {
+    executionFacts?: ToolExecutionFacts;
+    shell?: ShellPlan;
+    sandbox?: MakaTool['sandbox'];
+    transformCommand?: (input: {
+      command: string;
+      pty: boolean;
+      ctx: MakaToolContext;
+    }) => {
+      argv: readonly string[];
+      cwd: string;
+      env?: NodeJS.ProcessEnv;
+      fdInputs?: readonly ChildFdInput[];
+    } | undefined;
+  } = {},
 ): MakaTool {
   const shell = options.shell ?? defaultShellPlan();
   return {
@@ -147,21 +162,25 @@ export function buildManagedBashTool(
     }),
     permissionRequired: true,
     ...(options.executionFacts ? { executionFacts: options.executionFacts } : {}),
-    impl: async ({ command, timeout_ms, run_in_background, pty }, ctx) => shellRuns[
-      run_in_background ? 'runBackgroundBash' : 'runForegroundBash'
-    ]({
-      sessionId: ctx.sessionId,
-      ...(ctx.runId ? { sourceRunId: ctx.runId } : {}),
-      sourceTurnId: ctx.turnId,
-      sourceToolCallId: ctx.toolCallId,
-      cwd: ctx.cwd,
-      command,
-      ...(pty !== undefined ? { pty } : {}),
-      shell,
-      ...(timeout_ms !== undefined ? { timeoutMs: timeout_ms } : {}),
-      abortSignal: ctx.abortSignal,
-      emitOutput: ctx.emitOutput,
-    }),
+    ...(options.sandbox ? { sandbox: options.sandbox } : {}),
+    impl: async ({ command, timeout_ms, run_in_background, pty }, ctx) => {
+      const transformed = options.transformCommand?.({ command, pty: pty === true, ctx });
+      return shellRuns[run_in_background ? 'runBackgroundBash' : 'runForegroundBash']({
+        sessionId: ctx.sessionId,
+        ...(ctx.runId ? { sourceRunId: ctx.runId } : {}),
+        sourceTurnId: ctx.turnId,
+        sourceToolCallId: ctx.toolCallId,
+        cwd: transformed?.cwd ?? ctx.cwd,
+        command,
+        ...(pty !== undefined ? { pty } : {}),
+        ...(transformed ? { argv: transformed.argv } : { shell }),
+        ...(transformed?.env ? { env: transformed.env } : {}),
+        ...(transformed?.fdInputs ? { fdInputs: transformed.fdInputs } : {}),
+        ...(timeout_ms !== undefined ? { timeoutMs: timeout_ms } : {}),
+        abortSignal: ctx.abortSignal,
+        emitOutput: ctx.emitOutput,
+      });
+    },
   };
 }
 

--- a/packages/runtime/src/tool-runtime.ts
+++ b/packages/runtime/src/tool-runtime.ts
@@ -59,7 +59,7 @@ export interface MakaTool<P = any, R = unknown> {
   /** Optional trusted platform sandbox availability for this tool. */
   sandbox?: {
     platformSandboxAvailable: boolean;
-  } | ((context: { permissionMode: PermissionMode; cwd: string }) => {
+  } | ((context: { permissionMode: PermissionMode; cwd: string; args: P }) => {
     platformSandboxAvailable: boolean;
   });
   /** Real tool implementation. Called only after permission allows. */
@@ -357,7 +357,11 @@ export class ToolRuntime {
         ...(this.input.permissionRules !== undefined ? { permissionRules: this.input.permissionRules } : {}),
         ...(tool.sandbox !== undefined ? {
           sandbox: typeof tool.sandbox === 'function'
-            ? tool.sandbox({ permissionMode: this.input.header.permissionMode, cwd: this.input.header.cwd })
+            ? tool.sandbox({
+                permissionMode: this.input.header.permissionMode,
+                cwd: this.input.header.cwd,
+                args,
+              })
             : tool.sandbox,
         } : {}),
         mode: this.input.header.permissionMode,

--- a/packages/runtime/src/tool-runtime.ts
+++ b/packages/runtime/src/tool-runtime.ts
@@ -14,7 +14,12 @@ import type {
 } from '@maka/core/session';
 import type { PermissionDecision } from '@maka/core/backend-types';
 import type { AgentSpec } from '@maka/core/runtime-inputs';
-import type { ToolCategory, ToolExecutionFacts, ToolPermissionRule } from '@maka/core/permission';
+import type {
+  PermissionMode,
+  ToolCategory,
+  ToolExecutionFacts,
+  ToolPermissionRule,
+} from '@maka/core/permission';
 import type { LlmConnection } from '@maka/core/llm-connections';
 import type { SessionHeader } from '@maka/core/session';
 import type { ToolInvocationRecord } from '@maka/core/usage-stats/types';
@@ -51,6 +56,12 @@ export interface MakaTool<P = any, R = unknown> {
   categoryHint?: ToolCategory;
   /** Optional trusted facts about the executor that runs this tool. */
   executionFacts?: ToolExecutionFacts;
+  /** Optional trusted platform sandbox availability for this tool. */
+  sandbox?: {
+    platformSandboxAvailable: boolean;
+  } | ((context: { permissionMode: PermissionMode; cwd: string }) => {
+    platformSandboxAvailable: boolean;
+  });
   /** Real tool implementation. Called only after permission allows. */
   impl: (args: P, ctx: MakaToolContext) => Promise<R> | R;
 }
@@ -61,6 +72,7 @@ export interface MakaToolContext {
   turnId: string;
   /** Session working directory. */
   cwd: string;
+  permissionMode?: PermissionMode;
   toolCallId: string;
   abortSignal: AbortSignal;
   emitOutput: (stream: ToolOutputStream, chunk: string) => void;
@@ -343,6 +355,11 @@ export class ToolRuntime {
         ...(tool.executionFacts !== undefined ? { executionFacts: tool.executionFacts } : {}),
         permissionRequired: tool.permissionRequired !== false,
         ...(this.input.permissionRules !== undefined ? { permissionRules: this.input.permissionRules } : {}),
+        ...(tool.sandbox !== undefined ? {
+          sandbox: typeof tool.sandbox === 'function'
+            ? tool.sandbox({ permissionMode: this.input.header.permissionMode, cwd: this.input.header.cwd })
+            : tool.sandbox,
+        } : {}),
         mode: this.input.header.permissionMode,
       });
 
@@ -501,6 +518,7 @@ export class ToolRuntime {
           turnId,
           ...(runId ? { runId } : {}),
           cwd: this.input.header.cwd,
+          permissionMode: this.input.header.permissionMode,
           toolCallId: toolUseId,
           abortSignal: ctx.abortSignal,
           emitOutput: output.emit,

--- a/packages/runtime/src/workspace-executor.ts
+++ b/packages/runtime/src/workspace-executor.ts
@@ -4,7 +4,8 @@ import { glob as nodeGlob } from 'node:fs/promises';
 import { dirname, isAbsolute, relative, resolve } from 'node:path';
 import { promisify } from 'node:util';
 import type { ToolExecutionFacts } from '@maka/core/permission';
-import { runShellWithBoundedTail } from './shell-exec.js';
+import { runProcessWithBoundedTail, runShellWithBoundedTail } from './shell-exec.js';
+import type { ChildFdInput } from './child-fd-input.js';
 import type { ShellPlan } from './shell-detect.js';
 
 const execAsync = promisify(exec);
@@ -25,6 +26,10 @@ export const LOCAL_WORKSPACE_EXECUTOR_FACTS: WorkspaceExecutorFacts = {
 
 export interface WorkspaceExecInput {
   command: string;
+  /** Final executable argv. When provided, bypasses host-shell parsing. */
+  argv?: readonly string[];
+  env?: NodeJS.ProcessEnv;
+  fdInputs?: readonly ChildFdInput[];
   cwd: string;
   timeoutMs: number;
   abortSignal?: AbortSignal;
@@ -190,13 +195,18 @@ export class LocalWorkspaceExecutor implements WorkspaceExecutor {
   readonly facts = LOCAL_WORKSPACE_EXECUTOR_FACTS;
 
   async exec(input: WorkspaceExecInput): Promise<WorkspaceExecResult> {
-    const result = await runShellWithBoundedTail(input.command, {
+    const options = {
       cwd: input.cwd,
       timeoutMs: input.timeoutMs,
+      ...(input.env ? { env: input.env } : {}),
+      ...(input.fdInputs ? { fdInputs: input.fdInputs } : {}),
       ...(input.abortSignal ? { abortSignal: input.abortSignal } : {}),
       ...(input.emitOutput ? { emitOutput: input.emitOutput } : {}),
       ...(input.shell ? { shell: input.shell } : {}),
-    });
+    };
+    const result = input.argv
+      ? await runProcessWithBoundedTail(input.argv[0] ?? '', input.argv.slice(1), options)
+      : await runShellWithBoundedTail(input.command, options);
     return {
       stdout: result.stdout,
       stderr: result.stderr,


### PR DESCRIPTION
## Summary

This PR adds a fail-closed Linux sandbox backend based on `bubblewrap`.

It integrates Linux sandbox enforcement into the existing runtime, Bash tools,
CLI, and Desktop entry points. Shell auto-approval now depends on whether the
current platform can actually enforce the requested sandbox policy.

## Changes

- Add a Linux `bubblewrap` sandbox backend
- Add runtime-generated seccomp cBPF filters for x64 and arm64
- Pass seccomp programs to bubblewrap through an inherited file descriptor
- Probe the installed `bwrap` executable, required options, and namespace
  availability before advertising sandbox support
- Materialize permission profiles as read-only and writable filesystem mounts
- Isolate temporary directories using `tmpfs`
- Restrict network access with a seccomp socket filter
- Protect existing nested `.git`, `.agents`, and `.codex` directories by
  rebinding them as read-only
- Support direct argv execution and inherited FD payloads in foreground and
  background shell runners
- Preserve timeout, abort, streaming output, bounded-tail output, and
  background-task behavior
- Wire the built-in sandbox manager into CLI and Desktop
- Document Linux sandbox behavior and current limitations
- Fix the existing `FormatJson` activity classification by marking it as an
  `edit` operation

## Fail-Closed Behavior

The Linux backend refuses execution when:

- `bubblewrap` is missing or incompatible
- the required seccomp option is unavailable
- the namespace capability probe fails
- the CPU architecture is unsupported
- the permission profile contains unsupported deny entries
- sandbox command transformation fails

The permission engine only treats shell execution as sandbox-enforced when the
active backend reports that it can enforce the requested profile.

## Linux Verification

Tested in WSL2 with:

- Ubuntu 24.04
- Linux x86_64
- Node.js 22.23.1
- bubblewrap 0.9.0
- ripgrep 14.1.0

Results:

- [x] bubblewrap namespace capability probe passed
- [x] Linux sandbox smoke: 3 passed, 0 failed, 0 skipped
- [x] Runtime suite on Linux: 1255 passed, 0 failed, 2 skipped
- [x] Full repository build on Linux
- [x] Windows affected-test verification
- [x] `git diff --check`

The Linux smoke tests verify that:

- normal files can be written inside the workspace
- sibling paths outside the workspace cannot be written
- existing nested `.git` metadata remains read-only
- restricted network access is blocked by seccomp with `EPERM`

## Known Limitation

Protected metadata paths that do not exist when the sandbox starts cannot be
prevented from being created for the first time using bubblewrap alone without
creating mountpoints on the host filesystem.

Existing nested `.git`, `.agents`, and `.codex` paths are protected as
read-only. Strong protection for absent paths could be added in a follow-up
using Landlock or a native Linux helper.