### PR TITLE
feat(cli): route evaluation commands through maka eval

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9054,6 +9054,7 @@
       "dependencies": {
         "@earendil-works/pi-tui": "0.80.3",
         "@maka/core": "0.1.0",
+        "@maka/headless": "0.1.0",
         "@maka/runtime": "0.1.0",
         "@maka/storage": "0.1.0"
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -19,6 +19,7 @@
   "dependencies": {
     "@earendil-works/pi-tui": "0.80.3",
     "@maka/core": "0.1.0",
+    "@maka/headless": "0.1.0",
     "@maka/runtime": "0.1.0",
     "@maka/storage": "0.1.0"
   }

--- a/packages/cli/src/__tests__/cli.test.ts
+++ b/packages/cli/src/__tests__/cli.test.ts
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
 import { execFile, spawn } from 'node:child_process';
 import { once } from 'node:events';
-import { mkdtemp, rm, symlink } from 'node:fs/promises';
+import { mkdir, mkdtemp, readFile, rm, symlink, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { promisify } from 'node:util';
@@ -14,10 +14,33 @@ import {
 } from '../cli.js';
 
 const execFileAsync = promisify(execFile);
+const cliPath = new URL('../cli.js', import.meta.url).pathname;
+const legacyCliPath = new URL('../../../headless/dist/cli.js', import.meta.url).pathname;
+
+function runCliProcess(
+  entrypoint: string,
+  args: string[],
+): Promise<{ code: number | null; stdout: string; stderr: string }> {
+  return new Promise((resolve) => {
+    const child = spawn(process.execPath, [entrypoint, ...args]);
+    let stdout = '';
+    let stderr = '';
+    child.stdout.on('data', (chunk: Buffer) => { stdout += chunk.toString('utf8'); });
+    child.stderr.on('data', (chunk: Buffer) => { stderr += chunk.toString('utf8'); });
+    child.on('close', (code) => resolve({ code, stdout, stderr }));
+  });
+}
 
 describe('Maka CLI args', () => {
   test('runs the TUI for a bare command', () => {
-    assert.deepEqual(parseMakaCliArgs([], '0.1.0'), { kind: 'run' });
+    assert.deepEqual(parseMakaCliArgs([], '0.1.0'), { kind: 'tui' });
+  });
+
+  test('routes eval subcommands without changing their arguments', () => {
+    assert.deepEqual(parseMakaCliArgs(['eval', 'task-run', 'inspect', 'run-1'], '0.1.0'), {
+      kind: 'eval',
+      args: ['task-run', 'inspect', 'run-1'],
+    });
   });
 
   test('prints help', () => {
@@ -35,7 +58,7 @@ describe('Maka CLI args', () => {
     });
   });
 
-  test('rejects positional arguments in the first release', () => {
+  test('rejects unknown positional arguments', () => {
     assert.deepEqual(parseMakaCliArgs(['headless'], '0.1.0'), {
       kind: 'error',
       message: 'Unexpected argument: headless',
@@ -101,18 +124,64 @@ describe('Maka CLI args', () => {
 
   test('prints version from the executable entrypoint', async () => {
     const { stdout } = await execFileAsync(process.execPath, [
-      new URL('../cli.js', import.meta.url).pathname,
+      cliPath,
       '--version',
     ]);
 
     assert.equal(stdout.trim(), '0.1.0');
   });
 
+  test('runs a fake evaluation through the unified executable', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'maka-unified-eval-'));
+    try {
+      await mkdir(join(dir, 'fixture'), { recursive: true });
+      await writeFile(join(dir, 'fixture', 'marker.txt'), 'ok', 'utf8');
+      const specPath = join(dir, 'spec.json');
+      const outDir = join(dir, 'out');
+      await writeFile(specPath, JSON.stringify({
+        configs: [{ id: 'fake-cfg', backend: 'fake', llmConnectionSlug: 'fake', model: 'fake-model' }],
+        tasks: [{
+          id: 't-pass',
+          instruction: 'go',
+          workspaceDir: 'fixture',
+          verification: { command: 'test -f marker.txt', protectedPaths: [] },
+        }],
+      }), 'utf8');
+
+      const result = await runCliProcess(cliPath, ['eval', 'run', specPath, '--out', outDir]);
+
+      assert.equal(result.code, 0, result.stderr);
+      assert.doesNotMatch(result.stderr, /deprecated/);
+      assert.match(result.stdout, /t-pass/);
+      assert.match(await readFile(join(outDir, 'comparison.md'), 'utf8'), /t-pass/);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  test('keeps all five legacy command families on the unified router exit contract', async () => {
+    const pairs = [
+      { unified: ['eval', 'run'], legacy: ['eval'] },
+      { unified: ['eval', 'compare'], legacy: ['compare'] },
+      { unified: ['eval', 'task-run'], legacy: ['task'] },
+      { unified: ['eval', 'harbor'], legacy: ['harbor'] },
+      { unified: ['eval', 'ahe'], legacy: ['ahe'] },
+    ];
+    for (const pair of pairs) {
+      const unified = await runCliProcess(cliPath, pair.unified);
+      const legacy = await runCliProcess(legacyCliPath, pair.legacy);
+      assert.equal(legacy.code, unified.code, pair.unified.join(' '));
+      assert.equal(legacy.stdout, unified.stdout, pair.unified.join(' '));
+      assert.match(legacy.stderr, /maka-headless is deprecated/);
+      assert.doesNotMatch(unified.stderr, /maka-headless is deprecated/);
+    }
+  });
+
   test('runs when launched through a bin symlink', async () => {
     const tempDir = await mkdtemp(join(tmpdir(), 'maka-cli-bin-'));
     try {
       const linkPath = join(tempDir, 'maka');
-      await symlink(new URL('../cli.js', import.meta.url).pathname, linkPath);
+      await symlink(cliPath, linkPath);
       const { stdout } = await execFileAsync(linkPath, ['--version']);
 
       assert.equal(stdout.trim(), '0.1.0');

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -12,16 +12,18 @@ import { resolveMakaWorkspaceRoot } from './workspace-root.js';
 import { runMakaPiTui } from './pi-tui-runner.js';
 
 export type MakaCliCommand =
-  | { kind: 'run' }
+  | { kind: 'tui' }
+  | { kind: 'eval'; args: string[] }
   | { kind: 'help'; text: string }
   | { kind: 'version'; text: string }
   | { kind: 'error'; message: string; exitCode: number };
 
 export function parseMakaCliArgs(argv: string[], version: string): MakaCliCommand {
-  if (argv.length === 0) return { kind: 'run' };
+  if (argv.length === 0) return { kind: 'tui' };
   const [first] = argv;
   if (first === '--help' || first === '-h') return { kind: 'help', text: helpText() };
   if (first === '--version' || first === '-v') return { kind: 'version', text: version };
+  if (first === 'eval') return { kind: 'eval', args: argv.slice(1) };
   return {
     kind: 'error',
     message: `Unexpected argument: ${first ?? ''}`,
@@ -70,6 +72,7 @@ function helpText(): string {
     'Commands:',
     '  maka              Start the TUI',
     '  maka-agent        Start the TUI',
+    '  maka eval ...     Run evaluation and autonomous task commands',
     '',
     'Options:',
     '  -h, --help        Show help',
@@ -81,6 +84,10 @@ export async function runMakaCli(argv: string[] = process.argv.slice(2)): Promis
   const version = await readPackageVersion();
   const command = parseMakaCliArgs(argv, version);
   switch (command.kind) {
+    case 'eval': {
+      const { runMakaEvalCli } = await import('@maka/headless/eval-router');
+      return runMakaEvalCli(command.args);
+    }
     case 'help':
       process.stdout.write(`${command.text}\n`);
       return 0;
@@ -90,7 +97,7 @@ export async function runMakaCli(argv: string[] = process.argv.slice(2)): Promis
     case 'error':
       process.stderr.write(`${command.message}\n\n${helpText()}\n`);
       return command.exitCode;
-    case 'run': {
+    case 'tui': {
       const workspaceRoot = resolveMakaWorkspaceRoot();
       let context;
       try {

--- a/packages/headless/package.json
+++ b/packages/headless/package.json
@@ -17,6 +17,10 @@
     "./ahe-evidence-export": {
       "types": "./dist/ahe-evidence-export.d.ts",
       "default": "./dist/ahe-evidence-export.js"
+    },
+    "./eval-router": {
+      "types": "./dist/eval-router.d.ts",
+      "default": "./dist/eval-router.js"
     }
   },
   "imports": {
@@ -43,7 +47,7 @@
   },
   "scripts": {
     "clean": "node ../../scripts/clean-paths.mjs dist tsconfig.tsbuildinfo",
-    "build": "tsc -p tsconfig.json",
+    "build": "tsc -p tsconfig.json && node scripts/chmod-bin.mjs",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "test": "npm run clean && npm run build && node ../../scripts/run-headless-tests.mjs"
   },

--- a/packages/headless/scripts/chmod-bin.mjs
+++ b/packages/headless/scripts/chmod-bin.mjs
@@ -1,0 +1,6 @@
+#!/usr/bin/env node
+
+import { chmod } from 'node:fs/promises';
+import { join } from 'node:path';
+
+await chmod(join(process.cwd(), 'dist', 'cli.js'), 0o755);

--- a/packages/headless/src/__tests__/cli.test.ts
+++ b/packages/headless/src/__tests__/cli.test.ts
@@ -1,10 +1,12 @@
 import assert from 'node:assert/strict';
 import { spawn } from 'node:child_process';
-import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { constants } from 'node:fs';
+import { access, mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { describe, test } from 'node:test';
+import { mapLegacyMakaHeadlessArgs } from '../cli.js';
 import { readResults } from '../results.js';
 
 const cliPath = fileURLToPath(new URL('../cli.js', import.meta.url));
@@ -27,6 +29,25 @@ function runCli(
 }
 
 describe('maka-headless CLI', () => {
+  test('builds an executable legacy bin target', async () => {
+    await access(cliPath, constants.X_OK);
+  });
+
+  test('maps every legacy command family into the unified eval tree', () => {
+    assert.deepEqual(mapLegacyMakaHeadlessArgs(['eval', 'spec.json']), ['run', 'spec.json']);
+    assert.deepEqual(mapLegacyMakaHeadlessArgs(['compare', 'results.jsonl']), ['compare', 'results.jsonl']);
+    assert.deepEqual(mapLegacyMakaHeadlessArgs(['task', 'inspect', 'run-1']), ['task-run', 'inspect', 'run-1']);
+    assert.deepEqual(mapLegacyMakaHeadlessArgs(['harbor', 'run']), ['harbor', 'run']);
+    assert.deepEqual(mapLegacyMakaHeadlessArgs(['ahe', 'export']), ['ahe', 'export']);
+    assert.equal(mapLegacyMakaHeadlessArgs(['unknown']), null);
+  });
+
+  test('prints a deprecation warning from the legacy executable', async () => {
+    const result = await runCli([]);
+    assert.equal(result.code, 0);
+    assert.match(result.stderr, /maka-headless is deprecated/);
+  });
+
   test('eval executes a fake spec end-to-end and writes results + table', async () => {
     const dir = await mkdtemp(join(tmpdir(), 'maka-headless-cli-'));
     try {

--- a/packages/headless/src/cli.ts
+++ b/packages/headless/src/cli.ts
@@ -1,7 +1,9 @@
 #!/usr/bin/env node
 import { randomUUID } from 'node:crypto';
+import { realpathSync } from 'node:fs';
 import { readFile, stat, writeFile } from 'node:fs/promises';
 import { dirname, isAbsolute, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import type { Config, ResultRecord, Task } from './contracts.js';
 import { runAutonomousTask } from './autonomous-agent-loop.js';
 import { harborCommand } from './harbor-cli.js';
@@ -471,13 +473,22 @@ function parseArgs(args: string[], knownFlags: string[], boolFlags: string[] = [
   return { positional, flags, bools };
 }
 
-function printUsage(): void {
+function printLegacyUsage(): void {
   console.error('maka-headless — headless agent runner\n');
   console.error('  maka-headless eval <spec.json> [--out <dir>]   run configs × tasks, write results + table');
   console.error('  maka-headless compare <results.jsonl>          print the comparison table');
   console.error('  maka-headless task <command> ...               run, inspect, resume, retry, export task runs');
   console.error('  maka-headless ahe <command> ...                export AHE target snapshots and evidence');
   console.error('  maka-headless harbor <command> ...             run Harbor real-backend task/cell flows');
+}
+
+function printUnifiedUsage(): void {
+  console.error('maka eval — evaluation and autonomous task commands\n');
+  console.error('  maka eval run <spec.json> [--out <dir>]        run configs × tasks, write results + table');
+  console.error('  maka eval compare <results.jsonl>               print the comparison table');
+  console.error('  maka eval task-run <command> ...                run, inspect, resume, retry, export task runs');
+  console.error('  maka eval ahe <command> ...                     export AHE target snapshots and evidence');
+  console.error('  maka eval harbor <command> ...                  run Harbor real-backend task/cell flows');
 }
 
 function printTaskUsage(): void {
@@ -489,15 +500,38 @@ function printTaskUsage(): void {
   console.error('  task export <taskRunId> --store <out>/runs --out <dir> [--include-events]');
 }
 
-async function main(argv: string[]): Promise<number> {
+/** Canonical router shared by `maka eval` and the legacy compatibility bin. */
+export async function runMakaEvalCli(argv: string[]): Promise<number> {
   const [cmd, ...rest] = argv;
-  if (cmd === 'eval') return evalCommand(rest);
+  if (cmd === 'run') return evalCommand(rest);
   if (cmd === 'compare') return compareCommand(rest);
-  if (cmd === 'task') return taskCommand(rest);
+  if (cmd === 'task-run') return taskCommand(rest);
   if (cmd === 'ahe') return aheCommand(rest);
   if (cmd === 'harbor') return harborCommand(rest);
-  printUsage();
+  printUnifiedUsage();
   return cmd ? 1 : 0;
+}
+
+/** Translate the five supported legacy command families into the canonical tree. */
+export function mapLegacyMakaHeadlessArgs(argv: string[]): string[] | null {
+  const [cmd, ...rest] = argv;
+  if (cmd === undefined) return [];
+  if (cmd === 'eval') return ['run', ...rest];
+  if (cmd === 'compare') return ['compare', ...rest];
+  if (cmd === 'task') return ['task-run', ...rest];
+  if (cmd === 'ahe') return ['ahe', ...rest];
+  if (cmd === 'harbor') return ['harbor', ...rest];
+  return null;
+}
+
+async function runLegacyMakaHeadlessCli(argv: string[]): Promise<number> {
+  console.error('warning: maka-headless is deprecated; use `maka eval` instead');
+  const mapped = mapLegacyMakaHeadlessArgs(argv);
+  if (mapped === null || mapped.length === 0) {
+    printLegacyUsage();
+    return mapped === null ? 1 : 0;
+  }
+  return runMakaEvalCli(mapped);
 }
 
 async function loadSpec(specPath: string): Promise<ExperimentSpec> {
@@ -583,11 +617,22 @@ function printInspect(value: Record<string, unknown>): void {
   }
 }
 
-main(process.argv.slice(2))
-  .then((code) => {
-    process.exitCode = code;
-  })
-  .catch((error) => {
-    console.error(error);
-    process.exitCode = 1;
-  });
+if (isMainModule()) {
+  runLegacyMakaHeadlessCli(process.argv.slice(2))
+    .then((code) => {
+      process.exitCode = code;
+    })
+    .catch((error) => {
+      console.error(error);
+      process.exitCode = 1;
+    });
+}
+
+function isMainModule(): boolean {
+  if (!process.argv[1]) return false;
+  try {
+    return realpathSync(process.argv[1]) === realpathSync(fileURLToPath(import.meta.url));
+  } catch {
+    return false;
+  }
+}

--- a/packages/headless/src/eval-router.ts
+++ b/packages/headless/src/eval-router.ts
@@ -1,0 +1,1 @@
+export { runMakaEvalCli } from './cli.js';


### PR DESCRIPTION
Part of #730 — Slice 1 only.

## Summary

- add the canonical `maka eval run|compare|task-run|harbor|ahe` command tree
- route both the unified CLI and legacy `maka-headless` bin through one import-safe eval router
- keep bare `maka` launching the existing TUI
- preserve all five legacy command mappings while emitting a stderr deprecation warning
- ensure the legacy bin target remains executable after builds

## Testing

- `npm --workspace @maka/headless test` — 794 passed, 1 skipped
- `npm --workspace maka-agent test` — 252 passed
- process-boundary coverage for unified eval execution and all five legacy mappings
- direct executable smoke test for `maka-headless`

## Scope

Non-interactive `maka run`, permission controls, and session resume/continue remain deferred to Slices 2–4 as specified in #730.