### PR TITLE
fix(ui): consolidate session row actions into menu

### DIFF
--- a/apps/desktop/src/main/__tests__/control-height-converge-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/control-height-converge-contract.test.ts
@@ -88,6 +88,7 @@ interface ControlHeightCheck {
 const CONTROL_HEIGHT: ControlHeightCheck[] = [
   // sidebar / 会话 rows
   { selector: '.maka-list-row', props: ['min-height'], token: '--h-control-lg' },
+  { selector: '.maka-list-row-menu-trigger', props: ['width', 'height'], token: '--h-control-lg' },
   // .maka-search-modal-close retired: the close button is the shared
   // DialogHeader's quiet icon-sm Button, sized by buttonVariants, not a
   // search-modal-specific class.

--- a/apps/desktop/src/main/__tests__/menu-highlight-recipe-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/menu-highlight-recipe-contract.test.ts
@@ -66,4 +66,17 @@ describe('menu highlight recipe contract (#546 menu-hover governance)', () => {
       'MenuItem recipe must pin data-highlighted:bg-[var(--state-selected-bg)] to match palette/search list-highlight.',
     );
   });
+
+  it('uses the readable destructive text token for destructive menu items', async () => {
+    const src = await readMenuSource();
+
+    assert.ok(
+      src.includes('data-[variant=destructive]:text-destructive-text'),
+      'destructive menu items sit on a neutral popup and must use --destructive-text',
+    );
+    assert.ok(
+      !src.includes('data-[variant=destructive]:text-destructive-foreground'),
+      '--destructive-foreground is reserved for text placed on a solid destructive background',
+    );
+  });
 });

--- a/apps/desktop/src/main/__tests__/menu-highlight-recipe-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/menu-highlight-recipe-contract.test.ts
@@ -23,9 +23,11 @@ import { strict as assert } from 'node:assert';
 import { readFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { describe, it } from 'node:test';
+import { compile } from 'tailwindcss';
 import { REPO_ROOT } from './css-test-helpers.js';
 
 const MENU_PRIMITIVE = join(REPO_ROOT, 'packages', 'ui', 'src', 'primitives', 'menu.tsx');
+const MAKA_TOKENS = join(REPO_ROOT, 'apps', 'desktop', 'src', 'renderer', 'maka-tokens.css');
 
 async function readMenuSource(): Promise<string> {
   return readFile(MENU_PRIMITIVE, 'utf8');
@@ -77,6 +79,17 @@ describe('menu highlight recipe contract (#546 menu-hover governance)', () => {
     assert.ok(
       !src.includes('data-[variant=destructive]:text-destructive-foreground'),
       '--destructive-foreground is reserved for text placed on a solid destructive background',
+    );
+  });
+
+  it('generates the destructive menu text utility from the canonical token bridge', async () => {
+    const tokens = await readFile(MAKA_TOKENS, 'utf8');
+    const compiler = await compile(`${tokens}\n@tailwind utilities;`);
+    const css = compiler.build(['data-[variant=destructive]:text-destructive-text']);
+
+    assert.match(
+      css,
+      /\.data-\\\[variant\\=destructive\\\]\\:text-destructive-text\s*\{[\s\S]*?color:\s*var\(--destructive-text\);/,
     );
   });
 });

--- a/apps/desktop/src/main/__tests__/radius-converge-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/radius-converge-contract.test.ts
@@ -192,7 +192,6 @@ const COMPONENT_RADIUS: ComponentRadiusCheck[] = [
   { file: 'packages/ui/src/primitives/toolbar.tsx', name: 'Toolbar', tier: 'surface' },
   { file: 'packages/ui/src/session-sidebar-nav.tsx', name: 'navRowVariants', tier: 'control' },
   { file: 'packages/ui/src/session-sidebar-nav.tsx', name: 'settingsButtonClass', tier: 'control' },
-  { file: 'packages/ui/src/session-history-list.tsx', name: 'rowActionVariants', tier: 'control' },
 ];
 
 /** Extract the body of a component declaration by brace-matching from the

--- a/apps/desktop/src/main/__tests__/session-row-actions-fail-soft-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/session-row-actions-fail-soft-contract.test.ts
@@ -73,7 +73,7 @@ describe('session row actions fail soft', () => {
     );
   });
 
-  it('renders visible busy state while a sidebar row action is pending', async () => {
+  it('keeps sidebar menu actions single-flight while a row action is pending', async () => {
     const ui = await readRenderedSessionHistorySource();
 
     assert.match(ui, /type SessionRowActionId = 'flag' \| 'archive' \| 'rename' \| 'delete';/);
@@ -96,16 +96,12 @@ describe('session row actions fail soft', () => {
       /pendingActionRef\.current = null;[\s\S]*if \(rowMountedRef\.current\) setPendingAction\(null\);/,
       'SessionRow action cleanup must not write pending state after the row unmounts',
     );
-    assert.match(ui, /disabled=\{actionBusy\}/);
-    assert.match(ui, /aria-busy=\{pendingAction === 'flag' \? 'true' : undefined\}/);
-    assert.match(ui, /data-pending=\{pendingAction === 'archive' \? 'true' : undefined\}/);
-    assert.match(ui, /aria-busy=\{pendingAction === 'delete' \? 'true' : undefined\}/);
-    const rowActionVariantCalls = [...ui.matchAll(/cn\('maka-list-row-action', rowActionVariants/g)];
-    assert.equal(rowActionVariantCalls.length, 4, 'all 4 row action buttons (flag, rename, archive, delete) must call rowActionVariants');
     assert.match(
       ui,
-      /data-\[pending=true\]:cursor-progress data-\[pending=true\]:bg-foreground\/5 data-\[pending=true\]:text-foreground data-\[pending=true\]:opacity-78/,
-      'rowActionVariants cva must carry a visible pending state (cursor + bg + opacity)',
+      /<MenuTrigger[\s\S]*?disabled=\{actionBusy\}[\s\S]*?<MenuPopup[\s\S]*?<MenuItem[\s\S]*?disabled=\{actionBusy\}/,
+      'the overflow trigger and its menu actions must be disabled while the row owns an action',
     );
+    assert.doesNotMatch(ui, /aria-busy=\{pendingAction ===/);
+    assert.doesNotMatch(ui, /data-pending=\{pendingAction ===/);
   });
 });

--- a/apps/desktop/src/main/__tests__/session-row-menu.test.ts
+++ b/apps/desktop/src/main/__tests__/session-row-menu.test.ts
@@ -1,6 +1,10 @@
 import { strict as assert } from 'node:assert';
+import { readFile } from 'node:fs/promises';
+import { join } from 'node:path';
 import { describe, it } from 'node:test';
+import { REPO_ROOT } from './css-test-helpers.js';
 import { renderSessionListPanel } from './session-list-render-helpers.js';
+import { readRenderedSessionHistorySource } from './session-history-owner-source-helpers.js';
 
 describe('sidebar session row menu', () => {
   it('exposes one overflow trigger instead of four inline management buttons', () => {
@@ -11,5 +15,20 @@ describe('sidebar session row menu', () => {
     assert.doesNotMatch(markup, /aria-label="重命名对话"/);
     assert.doesNotMatch(markup, /aria-label="归档对话"/);
     assert.doesNotMatch(markup, /aria-label="删除对话"/);
+  });
+
+  it('keeps row metadata hidden while the portaled menu owns focus', async () => {
+    const [source, styles] = await Promise.all([
+      readRenderedSessionHistorySource(),
+      readFile(join(REPO_ROOT, 'apps/desktop/src/renderer/styles/sidebar.css'), 'utf8'),
+    ]);
+
+    assert.match(source, /data-menu-open=\{menuOpen \? 'true' : undefined\}/);
+    assert.match(
+      styles,
+      /\.maka-list-row\[data-menu-open="true"\] \.maka-list-row-meta,[\s\S]*?\.maka-list-row\[data-menu-open="true"\] \.maka-list-row-unread\s*\{[\s\S]*?visibility:\s*hidden;/,
+    );
+    assert.doesNotMatch(source, /<MenuPopup[^>]*sideOffset=\{4\}/);
+    assert.doesNotMatch(styles, /\.maka-list-row-menu\s*\{[\s\S]*?min-width:\s*144px;/);
   });
 });

--- a/apps/desktop/src/main/__tests__/session-row-menu.test.ts
+++ b/apps/desktop/src/main/__tests__/session-row-menu.test.ts
@@ -1,0 +1,15 @@
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'node:test';
+import { renderSessionListPanel } from './session-list-render-helpers.js';
+
+describe('sidebar session row menu', () => {
+  it('exposes one overflow trigger instead of four inline management buttons', () => {
+    const markup = renderSessionListPanel();
+
+    assert.match(markup, /<button(?=[^>]*data-slot="menu-trigger")(?=[^>]*aria-label="对话操作")[^>]*>/);
+    assert.doesNotMatch(markup, /aria-label="置顶对话"/);
+    assert.doesNotMatch(markup, /aria-label="重命名对话"/);
+    assert.doesNotMatch(markup, /aria-label="归档对话"/);
+    assert.doesNotMatch(markup, /aria-label="删除对话"/);
+  });
+});

--- a/apps/desktop/src/main/__tests__/visual-smoke-fixture.test.ts
+++ b/apps/desktop/src/main/__tests__/visual-smoke-fixture.test.ts
@@ -659,7 +659,7 @@ describe('visual smoke fixture mode', () => {
     }
   });
 
-  it('sidebar-row-actions-visible shares the 60-session seed and sets focusActiveRow so the action overlay shows (PR-SIDEBAR-IA-0 Phase 3 P0 fixup v4)', async () => {
+  it('sidebar-row-actions-visible shares the 60-session seed and sets focusActiveRow so the action trigger shows (PR-SIDEBAR-IA-0 Phase 3 P0 fixup v4)', async () => {
     // PR-SIDEBAR-IA-0 Phase 3 P0 fixup v4 (WAWQAQ msg `5dd1c348`,
     // kenji `b3d156e9`): the sidebar-row-actions-visible scenario
     // reuses the 60-session seed so the sidebar is identical to
@@ -667,7 +667,7 @@ describe('visual smoke fixture mode', () => {
     // `VisualSmokeState.focusActiveRow=true`, which the renderer
     // reads to focus the active row's button after mount. That
     // triggers `:focus-within` and reveals the
-    // `.maka-list-row-actions` overlay — the screenshot then proves
+    // `.maka-list-row-menu-trigger` — the screenshot then proves
     // the time meta / unread dot are correctly hidden underneath.
     const workspaceRoot = await mkdtemp(join(tmpdir(), 'maka-visual-smoke-row-actions-'));
     try {

--- a/apps/desktop/src/main/visual-smoke-fixture.ts
+++ b/apps/desktop/src/main/visual-smoke-fixture.ts
@@ -113,7 +113,7 @@ const VISUAL_SMOKE_SCENARIOS = new Set<VisualSmokeScenario>([
   // kenji `b3d156e9`): same 60-session seed; differs in
   // `focusActiveRow: true`, which programmatically focuses the
   // active row's button after mount so `:focus-within` triggers
-  // and the `.maka-list-row-actions` overlay becomes visible.
+  // and the `.maka-list-row-menu-trigger` becomes visible.
   // Captures the actions-revealed state so reviewers can verify
   // the time meta + unread dot are hidden underneath (no overlap).
   'sidebar-row-actions-visible',
@@ -466,7 +466,7 @@ export function getVisualSmokeState(fixture: VisualSmokeFixture | null): VisualS
       // PR-SIDEBAR-IA-0 Phase 3 P0 fixup v4 (WAWQAQ msg `5dd1c348`):
       // same 60-session seed; `focusActiveRow: true` makes the
       // renderer focus the active row's button after mount so
-      // `:focus-within` triggers and the action overlay shows.
+      // `:focus-within` triggers and the overflow action appears.
       // Captures the actions-revealed state for the overlap gate.
       return {
         ...state,

--- a/apps/desktop/src/main/visual-smoke-fixture.ts
+++ b/apps/desktop/src/main/visual-smoke-fixture.ts
@@ -114,7 +114,7 @@ const VISUAL_SMOKE_SCENARIOS = new Set<VisualSmokeScenario>([
   // `focusActiveRow: true`, which programmatically focuses the
   // active row's button after mount so `:focus-within` triggers
   // and the `.maka-list-row-menu-trigger` becomes visible.
-  // Captures the actions-revealed state so reviewers can verify
+  // Captures the overflow-trigger state so reviewers can verify
   // the time meta + unread dot are hidden underneath (no overlap).
   'sidebar-row-actions-visible',
 ]);
@@ -467,7 +467,7 @@ export function getVisualSmokeState(fixture: VisualSmokeFixture | null): VisualS
       // same 60-session seed; `focusActiveRow: true` makes the
       // renderer focus the active row's button after mount so
       // `:focus-within` triggers and the overflow action appears.
-      // Captures the actions-revealed state for the overlap gate.
+      // Captures the overflow-trigger state for the overlap gate.
       return {
         ...state,
         activeSessionId: LONG_SIDEBAR_SESSION_PREFIX + '00',

--- a/apps/desktop/src/renderer/app-shell-visual-smoke.ts
+++ b/apps/desktop/src/renderer/app-shell-visual-smoke.ts
@@ -136,8 +136,8 @@ export function createAppShellVisualSmokeActions(options: {
     // kenji `b3d156e9`): when the fixture sets `focusActiveRow`,
     // focus the active row's button after the next paint so the
     // row's `:focus-within` triggers and the `.maka-list-row-menu-trigger`
-    // overlay becomes visible. The auto-capture then shows the
-    // actions cluster against the slim row, proving the time meta
+    // becomes visible. The auto-capture then shows the overflow
+    // trigger against the slim row, proving the time meta
     // + unread dot are hidden underneath (no overlap with the
     // action icons — the bug WAWQAQ flagged). Two RAFs let React
     // commit the active selection before we query the DOM.

--- a/apps/desktop/src/renderer/app-shell-visual-smoke.ts
+++ b/apps/desktop/src/renderer/app-shell-visual-smoke.ts
@@ -135,7 +135,7 @@ export function createAppShellVisualSmokeActions(options: {
     // PR-SIDEBAR-IA-0 Phase 3 P0 fixup v4 (WAWQAQ msg `5dd1c348`,
     // kenji `b3d156e9`): when the fixture sets `focusActiveRow`,
     // focus the active row's button after the next paint so the
-    // row's `:focus-within` triggers and the `.maka-list-row-actions`
+    // row's `:focus-within` triggers and the `.maka-list-row-menu-trigger`
     // overlay becomes visible. The auto-capture then shows the
     // actions cluster against the slim row, proving the time meta
     // + unread dot are hidden underneath (no overlap with the
@@ -172,7 +172,7 @@ export function createAppShellVisualSmokeActions(options: {
             // PR-SIDEBAR-IA-0 Phase 3 P0 fixup v4 exception (WAWQAQ
             // msg `5dd1c348`): when the fixture asks for a focused
             // active row (e.g. the `sidebar-row-actions-visible`
-            // scenario, which proves the action overlay doesn't
+            // scenario, which proves the overflow action doesn't
             // overlap the time meta), the blur step would defeat the
             // whole point of the capture. Skip the blur in that
             // narrow case; other captures still get a clean (focusless)

--- a/apps/desktop/src/renderer/maka-tokens.css
+++ b/apps/desktop/src/renderer/maka-tokens.css
@@ -919,6 +919,7 @@
   --color-info: var(--info);
   --color-success: var(--success);
   --color-destructive: var(--destructive);
+  --color-destructive-text: var(--destructive-text);
 
   --color-foreground-2:  var(--foreground-2);
   --color-foreground-3:  var(--foreground-3);

--- a/apps/desktop/src/renderer/styles/sidebar.css
+++ b/apps/desktop/src/renderer/styles/sidebar.css
@@ -343,10 +343,10 @@
 
 .maka-list-row-menu-trigger {
   position: absolute;
-  top: var(--space-0-5);
+  top: 0;
   right: var(--space-1);
-  width: var(--h-control-sm);
-  height: var(--h-control-sm);
+  width: var(--h-control-lg);
+  height: var(--h-control-lg);
   display: grid;
   place-items: center;
   padding: 0;

--- a/apps/desktop/src/renderer/styles/sidebar.css
+++ b/apps/desktop/src/renderer/styles/sidebar.css
@@ -280,13 +280,13 @@
  * a sidebar of 60 sessions.
  *
  * After Phase 3:
- *   - 30px min-height, single line: status indicator + name + time.
+ *   - 32px min-height, single line: status indicator + name + time.
  *   - Flat list (no border, no radius, no shadow); the surrounding
  *     `.maka-list-stackContent` provides the row stack, so rows just need
  *     to read as a list, not a stack of cards.
  *   - Snippet drops out of the default DOM (lives only in a native
  *     `title=` tooltip on hover) — see SessionRow render path.
- *   - Row actions still slide in on hover (current behavior preserved).
+ *   - A single overflow trigger replaces the time/unread slot on hover or focus.
  *   - Active row uses a neutral flat fill instead of the old accent rail.
  */
 .maka-list-row {
@@ -387,12 +387,10 @@
 .maka-list-row:hover .maka-list-row-meta,
 .maka-list-row:hover .maka-list-row-unread,
 .maka-list-row:focus-within .maka-list-row-meta,
-.maka-list-row:focus-within .maka-list-row-unread {
+.maka-list-row:focus-within .maka-list-row-unread,
+.maka-list-row[data-menu-open="true"] .maka-list-row-meta,
+.maka-list-row[data-menu-open="true"] .maka-list-row-unread {
   visibility: hidden;
-}
-
-.maka-list-row-menu {
-  min-width: 144px;
 }
 
 .maka-list-row-rename-input {

--- a/apps/desktop/src/renderer/styles/sidebar.css
+++ b/apps/desktop/src/renderer/styles/sidebar.css
@@ -341,90 +341,49 @@
   text-align: left;
 }
 
-.maka-list-row-actions {
-  /* PR-SIDEBAR-IA-0 Phase 3 (xuan `2d4526b5` + kenji `e949119d`):
-   * actions overlay via absolute positioning instead of occupying
-   * a reserved flex column. In a 280px narrow sidebar a 126px
-   * reserved area left only ~74px for the title — kenji's math
-   * showed long Chinese names like "Artifact Pane 验收" would
-   * truncate too early. Absolute overlay gives the title the
-   * row's full content width in every state, so a narrow row never
-   * loses more title characters than the icons actually cover.
-   *
-   * Bug fix: the gradient below is what's supposed to visually hide
-   * the tail of the title/meta text this cluster paints over. It used
-   * to fade into `var(--state-hover-bg)` / `var(--state-selected-bg)`
-   * directly — those are a 4%/6.5%-alpha tint of `--foreground`, i.e.
-   * partially SEE-THROUGH. A translucent layer can't occlude the
-   * full-opacity text underneath it, so the icons rendered visibly on
-   * top of fully-legible title text (session-row title/actions overlap
-   * bug). Reserving layout space instead (shrinking the title column on
-   * hover) was tried and reverted — on the app's actual narrow sidebar
-   * width it truncated titles far more aggressively than the original
-   * bug's readable-but-smudged tail, which read as a worse regression.
-   * The fix that keeps maximum title length AND fully hides the
-   * covered portion: flatten the translucent tint into an opaque
-   * color via `color-mix()` against the real surface it sits on
-   * (`--background`) — same visual tint, zero transparency, so
-   * whatever text is under the buttons is actually gone, not just
-   * dimmed.
-   *
-   * Layout shift invariant still holds: actions don't participate
-   * in row flex layout in either state, so showing/hiding them
-   * never resizes the title column.
-   *
-   * A short leading fade (16px) softens the cut-off where the title
-   * text disappears under the action cluster. This works because the
-   * opaque stop is genuinely opaque (color-mix flattened) — the
-   * previous version's fade used a 4%-alpha tint as the "opaque" end
-   * and couldn't actually hide anything. With a real solid color,
-   * the fade zone shows the title tail dissolving smoothly instead of
-   * a hard vertical edge, and anything past the 16px mark is fully
-   * occluded. */
+.maka-list-row-menu-trigger {
   position: absolute;
-  top: 0;
-  right: 0;
-  bottom: 0;
-  display: flex;
-  align-items: center;
-  gap: var(--space-0-5);
-  padding: 0 var(--space-2);
-  /* Opaque re-derivation of --state-hover-bg's tint (4% of --foreground
-   * over --background) — NOT `color-mix(..., var(--state-hover-bg) ..., ...)`,
-   * which would just mix an already-4%-alpha color at some percentage of
-   * itself and stay translucent. Recreating the tint from the opaque
-   * --foreground/--background pair is what actually removes the alpha. */
-  background: linear-gradient(
-    to right,
-    transparent 0,
-    color-mix(in oklch, var(--foreground) 4%, var(--background)) 16px,
-    color-mix(in oklch, var(--foreground) 4%, var(--background)) 100%
-  );
+  top: var(--space-0-5);
+  right: var(--space-1);
+  width: var(--h-control-sm);
+  height: var(--h-control-sm);
+  display: grid;
+  place-items: center;
+  padding: 0;
+  border: 0;
+  border-radius: var(--radius-control);
+  background: transparent;
+  color: var(--foreground-secondary);
   opacity: 0;
-  transform: translateX(8px);
+  transform: translateX(var(--space-1));
   transition:
     opacity var(--duration-base) var(--ease-out-strong),
-    transform var(--duration-base) var(--ease-out-strong);
+    transform var(--duration-base) var(--ease-out-strong),
+    background-color var(--duration-base) var(--ease-out-strong),
+    color var(--duration-base) var(--ease-out-strong);
   pointer-events: none;
 }
 
-.maka-list-row:hover .maka-list-row-actions,
-.maka-list-row:focus-within .maka-list-row-actions {
+.maka-list-row-menu-trigger:hover,
+.maka-list-row-menu-trigger:focus-visible,
+.maka-list-row-menu-trigger[data-popup-open] {
+  background: var(--state-hover-bg);
+  color: var(--foreground);
+}
+
+.maka-list-row-menu-trigger:focus-visible {
+  outline: var(--focus-ring-width) solid var(--focus-ring);
+  outline-offset: var(--focus-ring-offset);
+}
+
+.maka-list-row:hover .maka-list-row-menu-trigger,
+.maka-list-row:focus-within .maka-list-row-menu-trigger,
+.maka-list-row-menu-trigger[data-visible="true"] {
   opacity: 1;
   transform: translateX(0);
   pointer-events: auto;
 }
 
-/* PR-SIDEBAR-IA-0 Phase 3 P0 fixup v4 (WAWQAQ msg `5dd1c348`):
- * when row actions appear, hide the meta (time) and unread dot so
- * they don't show through the absolute-positioned actions overlay.
- * The gradient bg below was supposed to mask them visually but
- * couldn't match every row state (transparent default vs hover bg
- * vs accent-tinted selected bg), so the time text leaked through
- * the actions cluster on selected rows ("9m ago" overlapping with
- * 📌 ✏️ 📦 🗑️). `visibility: hidden` preserves layout (the auto
- * grid column still reserves the time slot), so the actions slide
- * in without shifting anything around them. */
 .maka-list-row:hover .maka-list-row-meta,
 .maka-list-row:hover .maka-list-row-unread,
 .maka-list-row:focus-within .maka-list-row-meta,
@@ -432,22 +391,9 @@
   visibility: hidden;
 }
 
-.maka-list-row[data-active="true"] .maka-list-row-actions {
-  /* Opaque re-derivation of --state-selected-bg's tint (6.5% of
-   * --foreground over --background) — see the hover variant above for
-   * why this can't just be color-mix(..., var(--state-selected-bg), ...),
-   * and why there's no leading fade. */
-  background: linear-gradient(
-    to right,
-    transparent 0,
-    color-mix(in oklch, var(--foreground) 6.5%, var(--background)) 16px,
-    color-mix(in oklch, var(--foreground) 6.5%, var(--background)) 100%
-  );
+.maka-list-row-menu {
+  min-width: 144px;
 }
-
-/* Row action buttons: visual via rowActionVariants cva.
-   .maka-list-row-action class kept as a stable hook for the
-   action overlay positioning + reveal animation on the parent. */
 
 .maka-list-row-rename-input {
   width: 100%;

--- a/packages/ui/src/primitives/menu.tsx
+++ b/packages/ui/src/primitives/menu.tsx
@@ -92,7 +92,7 @@ export function MenuItem({
   return (
     <MenuPrimitive.Item
       className={cn(
-        "flex min-h-8 cursor-default select-none items-center gap-2 rounded-sm px-2 py-1 text-base text-foreground outline-none data-disabled:pointer-events-none data-highlighted:bg-[var(--state-selected-bg)] data-inset:ps-8 data-[variant=destructive]:text-destructive-foreground data-disabled:opacity-64 sm:min-h-7 sm:text-sm [&>svg:not([class*='opacity-'])]:opacity-80 [&>svg:not([class*='size-'])]:size-4.5 sm:[&>svg:not([class*='size-'])]:size-4 [&>svg]:pointer-events-none [&>svg]:-mx-0.5 [&>svg]:shrink-0",
+        "flex min-h-8 cursor-default select-none items-center gap-2 rounded-sm px-2 py-1 text-base text-foreground outline-none data-disabled:pointer-events-none data-highlighted:bg-[var(--state-selected-bg)] data-inset:ps-8 data-[variant=destructive]:text-destructive-text data-disabled:opacity-64 sm:min-h-7 sm:text-sm [&>svg:not([class*='opacity-'])]:opacity-80 [&>svg:not([class*='size-'])]:size-4.5 sm:[&>svg:not([class*='size-'])]:size-4 [&>svg]:pointer-events-none [&>svg]:-mx-0.5 [&>svg]:shrink-0",
         className,
       )}
       data-inset={inset}
@@ -116,7 +116,7 @@ export function MenuLinkItem({
   return (
     <MenuPrimitive.LinkItem
       className={cn(
-        "flex min-h-8 cursor-default select-none items-center gap-2 rounded-sm px-2 py-1 text-base text-foreground outline-none data-disabled:pointer-events-none data-highlighted:bg-[var(--state-selected-bg)] data-inset:ps-8 data-[variant=destructive]:text-destructive-foreground data-disabled:opacity-64 sm:min-h-7 sm:text-sm [&>svg:not([class*='opacity-'])]:opacity-80 [&>svg:not([class*='size-'])]:size-4.5 sm:[&>svg:not([class*='size-'])]:size-4 [&>svg]:pointer-events-none [&>svg]:-mx-0.5 [&>svg]:shrink-0",
+        "flex min-h-8 cursor-default select-none items-center gap-2 rounded-sm px-2 py-1 text-base text-foreground outline-none data-disabled:pointer-events-none data-highlighted:bg-[var(--state-selected-bg)] data-inset:ps-8 data-[variant=destructive]:text-destructive-text data-disabled:opacity-64 sm:min-h-7 sm:text-sm [&>svg:not([class*='opacity-'])]:opacity-80 [&>svg:not([class*='size-'])]:size-4.5 sm:[&>svg:not([class*='size-'])]:size-4 [&>svg]:pointer-events-none [&>svg]:-mx-0.5 [&>svg]:shrink-0",
         className,
       )}
       closeOnClick={closeOnClick}

--- a/packages/ui/src/session-history-list.tsx
+++ b/packages/ui/src/session-history-list.tsx
@@ -1,4 +1,4 @@
-import { memo, useEffect, useRef, useState, type FocusEvent, type KeyboardEvent, type MouseEvent } from 'react';
+import { memo, useEffect, useRef, useState, type FocusEvent, type KeyboardEvent } from 'react';
 import type { SessionSummary } from '@maka/core';
 import { formatCompactTimestamp } from '@maka/core';
 import {
@@ -12,6 +12,7 @@ import {
   Hourglass,
   Loader2,
   MessageSquare,
+  MoreHorizontal,
   Pencil,
   Pin,
   PinOff,
@@ -20,36 +21,8 @@ import {
 } from './icons.js';
 import { EmptyState } from './empty-state.js';
 import { OverlayScrollArea } from './overlay-scroll-area.js';
-import { Button as UiButton, cn } from './ui.js';
-import { cva } from 'class-variance-authority';
-
-const rowActionVariants = cva(
-  [
-    'grid h-7 w-7 place-items-center rounded-sm border-0 bg-transparent',
-    'text-[var(--foreground-secondary)]',
-    'transition-[background-color,color,box-shadow] duration-[var(--duration-quick)] ease-[var(--ease-out-strong)]',
-    'hover:bg-foreground/5 hover:text-foreground',
-    'focus-visible:outline-none focus-visible:bg-foreground/5 focus-visible:text-foreground focus-visible:ring-[3px] focus-visible:ring-accent/14',
-    'disabled:cursor-default disabled:bg-transparent disabled:text-[var(--muted-foreground)] disabled:shadow-none',
-    'disabled:hover:bg-transparent disabled:hover:text-[var(--muted-foreground)]',
-    'data-[active=true]:text-accent',
-    'data-[pending=true]:cursor-progress data-[pending=true]:bg-foreground/5 data-[pending=true]:text-foreground data-[pending=true]:opacity-78',
-  ],
-  {
-    variants: {
-      tone: {
-        default: '',
-        danger: [
-          'hover:bg-destructive/10 hover:text-destructive-text',
-          'focus-visible:bg-destructive/10 focus-visible:text-destructive-text focus-visible:ring-destructive/18',
-        ],
-      },
-    },
-    defaultVariants: {
-      tone: 'default',
-    },
-  },
-);
+import { Menu, MenuItem, MenuPopup, MenuSeparator, MenuTrigger } from './primitives/menu.js';
+import { Button as UiButton } from './ui.js';
 
 type SessionRowActionId = 'flag' | 'archive' | 'rename' | 'delete';
 type SessionHistoryGroupVariant = 'status' | 'project';
@@ -549,6 +522,7 @@ const SessionRow = memo(function SessionRow(props: {
   const { session, active, streaming, stale, actions, onSelect } = props;
   const [editing, setEditing] = useState(false);
   const [actionsVisible, setActionsVisible] = useState(false);
+  const [menuOpen, setMenuOpen] = useState(false);
   const [pendingAction, setPendingAction] = useState<SessionRowActionId | null>(null);
   const rowMountedRef = useRef(true);
   const pendingActionRef = useRef<SessionRowActionId | null>(null);
@@ -560,7 +534,7 @@ const SessionRow = memo(function SessionRow(props: {
   // would silently commit the user's typed value despite the cancel.
   const escapeCancelledRef = useRef(false);
   const actionBusy = pendingAction !== null;
-  const actionTabIndex = actionsVisible ? 0 : -1;
+  const actionTriggerVisible = actionsVisible || menuOpen;
 
   useEffect(() => {
     rowMountedRef.current = true;
@@ -580,12 +554,7 @@ const SessionRow = memo(function SessionRow(props: {
     input.select();
   }, [editing]);
 
-  const stopPropagation = (event: MouseEvent<HTMLButtonElement>) => {
-    event.stopPropagation();
-  };
-
-  function startRename(event: MouseEvent<HTMLButtonElement>) {
-    stopPropagation(event);
+  function startRename() {
     if (!actions || pendingActionRef.current) return;
     setEditing(true);
   }
@@ -614,8 +583,7 @@ const SessionRow = memo(function SessionRow(props: {
     runRowAction('rename', () => actions.onRename(session.id, trimmed));
   }
 
-  function handleDelete(event: MouseEvent<HTMLButtonElement>) {
-    stopPropagation(event);
+  function handleDelete() {
     if (!actions) return;
     // Delegation: the App-level handler owns the confirmation flow via the
     // toast system (PR24), so SessionRow stays presentation-only.
@@ -779,97 +747,56 @@ const SessionRow = memo(function SessionRow(props: {
         </UiButton>
       )}
       {actions && !editing && (
-        <div
-          className="maka-list-row-actions"
-          aria-label="对话操作"
-          aria-hidden={actionsVisible ? undefined : 'true'}
-          data-visible={actionsVisible ? 'true' : undefined}
-        >
-          {/* PR-SESSION-ROW-ACTIONS-PRIMITIVE-0 (round 8/30):
-              four hover-revealed action buttons routed through
-              UiButton variant="quiet" size="icon-sm". Custom
-              `.maka-list-row-action` still owns the overlay
-              positioning + reveal animation; primitive carries
-              the disabled, focus-visible, and `:active` contract.
-              The danger variant only adds a destructive color
-              tint via class override, not a different primitive
-              variant — keeps the overlay shape uniform. */}
-          <UiButton
-            type="button"
-            variant="quiet"
-            size="nav"
-            className={cn('maka-list-row-action', rowActionVariants())}
-            tabIndex={actionTabIndex}
-            onClick={(event) => {
-              stopPropagation(event);
-              runRowAction('flag', () => actions.onToggleFlag(session.id, !session.isFlagged));
-            }}
-            aria-label={session.isFlagged ? '取消置顶对话' : '置顶对话'}
-            aria-busy={pendingAction === 'flag' ? 'true' : undefined}
-            data-active={session.isFlagged}
-            data-pending={pendingAction === 'flag' ? 'true' : undefined}
+        <Menu open={menuOpen} onOpenChange={setMenuOpen}>
+          <MenuTrigger
+            aria-label="对话操作"
+            aria-hidden={actionTriggerVisible ? undefined : 'true'}
+            className="maka-list-row-menu-trigger"
+            data-visible={actionTriggerVisible ? 'true' : undefined}
             disabled={actionBusy}
-            title={session.isFlagged ? '取消置顶对话' : '置顶对话'}
+            tabIndex={actionTriggerVisible ? 0 : -1}
           >
-            {session.isFlagged
-              ? <PinOff size={14} aria-hidden="true" />
-              : <Pin size={14} aria-hidden="true" />}
-          </UiButton>
-          <UiButton
-            type="button"
-            variant="quiet"
-            size="nav"
-            className={cn('maka-list-row-action', rowActionVariants())}
-            tabIndex={actionTabIndex}
-            onClick={startRename}
-            aria-label="重命名对话"
-            aria-busy={pendingAction === 'rename' ? 'true' : undefined}
-            data-pending={pendingAction === 'rename' ? 'true' : undefined}
-            disabled={actionBusy}
-            title="重命名（双击行名也可）"
-          >
-            <Pencil size={14} aria-hidden="true" />
-          </UiButton>
-          <UiButton
-            type="button"
-            variant="quiet"
-            size="nav"
-            className={cn('maka-list-row-action', rowActionVariants())}
-            tabIndex={actionTabIndex}
-            onClick={(event) => {
-              stopPropagation(event);
-              runRowAction('archive', () => (
+            <MoreHorizontal size={16} aria-hidden="true" />
+          </MenuTrigger>
+          <MenuPopup className="maka-list-row-menu" align="end" side="bottom" sideOffset={4}>
+            <MenuItem
+              disabled={actionBusy}
+              onClick={() => runRowAction('flag', () => actions.onToggleFlag(session.id, !session.isFlagged))}
+            >
+              {session.isFlagged
+                ? <PinOff size={16} aria-hidden="true" />
+                : <Pin size={16} aria-hidden="true" />}
+              {session.isFlagged ? '取消置顶' : '置顶'}
+            </MenuItem>
+            <MenuItem disabled={actionBusy} onClick={startRename}>
+              <Pencil size={16} aria-hidden="true" />
+              重命名
+            </MenuItem>
+            <MenuItem
+              disabled={actionBusy}
+              onClick={() => runRowAction('archive', () => (
                 session.isArchived
                   ? actions.onUnarchive(session.id)
                   : actions.onArchive(session.id)
-              ));
-            }}
-            aria-label={session.isArchived ? '取消归档对话' : '归档对话'}
-            aria-busy={pendingAction === 'archive' ? 'true' : undefined}
-            data-pending={pendingAction === 'archive' ? 'true' : undefined}
-            disabled={actionBusy}
-            title={session.isArchived ? '取消归档' : '归档'}
-          >
-            {session.isArchived
-              ? <ArchiveRestore size={14} aria-hidden="true" />
-              : <Archive size={14} aria-hidden="true" />}
-          </UiButton>
-          <UiButton
-            type="button"
-            variant="quiet"
-            size="nav"
-            className={cn('maka-list-row-action', rowActionVariants({ tone: 'danger' }))}
-            tabIndex={actionTabIndex}
-            onClick={handleDelete}
-            aria-label="删除对话"
-            aria-busy={pendingAction === 'delete' ? 'true' : undefined}
-            data-pending={pendingAction === 'delete' ? 'true' : undefined}
-            disabled={actionBusy}
-            title="删除"
-          >
-            <Trash2 size={14} aria-hidden="true" />
-          </UiButton>
-        </div>
+              ))}
+            >
+              {session.isArchived
+                ? <ArchiveRestore size={16} aria-hidden="true" />
+                : <Archive size={16} aria-hidden="true" />}
+              {session.isArchived ? '取消归档' : '归档'}
+            </MenuItem>
+            <MenuSeparator />
+            <MenuItem
+              className="text-destructive-text"
+              variant="destructive"
+              disabled={actionBusy}
+              onClick={handleDelete}
+            >
+              <Trash2 size={16} aria-hidden="true" />
+              删除
+            </MenuItem>
+          </MenuPopup>
+        </Menu>
       )}
     </div>
   );

--- a/packages/ui/src/session-history-list.tsx
+++ b/packages/ui/src/session-history-list.tsx
@@ -600,6 +600,7 @@ const SessionRow = memo(function SessionRow(props: {
       className="maka-list-row"
       data-active={active}
       data-editing={editing}
+      data-menu-open={menuOpen ? 'true' : undefined}
       data-streaming={streaming ? 'true' : undefined}
       data-stale={stale ? 'true' : undefined}
       onMouseEnter={() => setActionsVisible(true)}
@@ -758,7 +759,7 @@ const SessionRow = memo(function SessionRow(props: {
           >
             <MoreHorizontal size={16} aria-hidden="true" />
           </MenuTrigger>
-          <MenuPopup className="maka-list-row-menu" align="end" side="bottom" sideOffset={4}>
+          <MenuPopup align="end" side="bottom">
             <MenuItem
               disabled={actionBusy}
               onClick={() => runRowAction('flag', () => actions.onToggleFlag(session.id, !session.isFlagged))}

--- a/packages/ui/src/session-history-list.tsx
+++ b/packages/ui/src/session-history-list.tsx
@@ -787,7 +787,6 @@ const SessionRow = memo(function SessionRow(props: {
             </MenuItem>
             <MenuSeparator />
             <MenuItem
-              className="text-destructive-text"
               variant="destructive"
               disabled={actionBusy}
               onClick={handleDelete}

--- a/packages/ui/stories/session-list-panel.stories.tsx
+++ b/packages/ui/stories/session-list-panel.stories.tsx
@@ -88,19 +88,28 @@ function StoryFrame(props: {
   width?: number;
   height?: number;
   focusActiveRow?: boolean;
+  openActiveRowMenu?: boolean;
 }) {
-  const { children, width = 240, height = 680, focusActiveRow = false } = props;
+  const { children, width = 240, height = 680, focusActiveRow = false, openActiveRowMenu = false } = props;
   const ref = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
-    if (!focusActiveRow) return;
-    const timeout = window.setTimeout(() => {
-      ref.current
-        ?.querySelector<HTMLButtonElement>('.maka-list-row[data-active="true"] .maka-list-row-main')
-        ?.focus({ preventScroll: true });
+    if (!focusActiveRow && !openActiveRowMenu) return;
+    let menuTimeout: number | undefined;
+    const focusTimeout = window.setTimeout(() => {
+      const activeRow = ref.current?.querySelector<HTMLElement>('.maka-list-row[data-active="true"]');
+      activeRow?.querySelector<HTMLButtonElement>('.maka-list-row-main')?.focus({ preventScroll: true });
+      if (openActiveRowMenu) {
+        menuTimeout = window.setTimeout(() => {
+          activeRow?.querySelector<HTMLButtonElement>('[aria-label="对话操作"]')?.click();
+        }, 0);
+      }
     }, 0);
-    return () => window.clearTimeout(timeout);
-  }, [focusActiveRow]);
+    return () => {
+      window.clearTimeout(focusTimeout);
+      if (menuTimeout !== undefined) window.clearTimeout(menuTimeout);
+    };
+  }, [focusActiveRow, openActiveRowMenu]);
 
   return (
     <div
@@ -270,7 +279,7 @@ const longTitleSessions = [
   }),
   makeSession({
     id: 'long-title-stale',
-    name: 'Artifact Pane 验收路径和 sidebar row action overlay 的长标题组合测试',
+    name: 'Artifact Pane 验收路径和 sidebar row overflow menu 的长标题组合测试',
     status: 'blocked',
     blockedReason: 'permission_required',
     lastMessageAt: NOW - 31 * 60 * 1000,
@@ -319,6 +328,19 @@ export const StatusGroups: Story = {
 export const RowActions: Story = {
   render: () => (
     <StoryFrame focusActiveRow>
+      <SessionListPanel {...panelProps({
+        sessions: coreSessions,
+        activeId: 'session-active',
+        streamingSessionIds: new Set(['session-running']),
+        staleSessionIds: new Set(['session-stale']),
+      })} />
+    </StoryFrame>
+  ),
+};
+
+export const RowMenuOpen: Story = {
+  render: () => (
+    <StoryFrame openActiveRowMenu>
       <SessionListPanel {...panelProps({
         sessions: coreSessions,
         activeId: 'session-active',

--- a/scripts/capture-screenshots.mjs
+++ b/scripts/capture-screenshots.mjs
@@ -122,13 +122,13 @@ const ALL_SCENARIOS = [
   // InputGroup input shell; reuses the 60-session sidebar seed.
   'command-palette-open',
   // PR-SIDEBAR-IA-0 Phase 3 P0 fixup v4 (WAWQAQ msg `5dd1c348`,
-  // kenji `b3d156e9`): baseline gate proving the row action overlay
+  // kenji `b3d156e9`): baseline gate proving the row action trigger
   // does NOT overlap the time meta / unread dot on the focused
   // (or active) row. Reuses the 60-session seed and sets
   // `VisualSmokeState.focusActiveRow=true` so the renderer focuses
   // the active row's button after mount, making `:focus-within`
-  // trigger and the `.maka-list-row-actions` overlay become visible.
-  // Reviewers should see the 4 action icons cleanly painted with
+  // trigger and the `.maka-list-row-menu-trigger` become visible.
+  // Reviewers should see the single overflow trigger cleanly painted with
   // NO `Nm ago` peeking through and NO unread dot stacked behind.
   'sidebar-row-actions-visible',
 ];


### PR DESCRIPTION
## Summary

- consolidate four inline session-row actions into one Base UI overflow menu
- preserve pin, rename, archive, delete-confirmation, and single-flight behavior
- keep hover, focus, Portal, and destructive-color states aligned with shared primitives and tokens

## Why

The previous four-button overlay crowded the highest-frequency sidebar surface and required masking CSS to prevent actions from overlapping session titles and metadata.

A single overflow menu restores scanning space without removing management actions or keyboard access.

Closes #738

## Scope

This PR does not add a context menu or change delete confirmation, persistence, or session lifecycle behavior. Pre-existing sidebar indicator-size cleanup is tracked separately in #743.

## Verification

<img width="2560" height="1640" alt="Session row overflow menu in the live Electron sidebar" src="https://github.com/user-attachments/assets/bc7a8650-4d2b-4824-9417-178c4b3e1e26" />

- `npm run -w @maka/desktop typecheck` — passed
- `npm run -w @maka/desktop test` — 2320 tests passed
- `npm run -w @maka/desktop build-storybook` — passed
- `node scripts/audit-alignment.mjs` — all fixtures clean
- Playwright E2E — 5 tests passed in the first CI run
- live Electron checked at 1280px and 990px
- CDP confirmed the destructive menu item resolves to `--destructive-text`
- independent `reviewer` profile review using `gpt-5.6-sol`, max reasoning, and a read-only sandbox — PASS with no P0–P3 findings
- GitHub Actions CI — typecheck, test, and e2e passed

## Impact

Users get a quieter session list with the same management capabilities behind one familiar overflow menu. There are no migrations, compatibility changes, documentation updates, or release-note requirements.

## Reviewer notes

Please focus on Portal focus restoration, metadata visibility while the menu is open, destructive contrast, and preservation of async action guards.

## Ready for review

- [x] Verification is complete and the results above are current
- [x] Impact, compatibility, migration, documentation, and release-note needs are addressed
- [x] User-visible UI/UX changes include visual evidence, or `Verification` explains why it is not applicable
