### PR TITLE
feat(cli): add non-interactive text runs

### DIFF
--- a/packages/cli/src/__tests__/cli.test.ts
+++ b/packages/cli/src/__tests__/cli.test.ts
@@ -28,6 +28,7 @@ function runCliProcess(
     child.stdout.on('data', (chunk: Buffer) => { stdout += chunk.toString('utf8'); });
     child.stderr.on('data', (chunk: Buffer) => { stderr += chunk.toString('utf8'); });
     child.on('close', (code) => resolve({ code, stdout, stderr }));
+    child.stdin.end();
   });
 }
 
@@ -40,6 +41,17 @@ describe('Maka CLI args', () => {
     assert.deepEqual(parseMakaCliArgs(['eval', 'task-run', 'inspect', 'run-1'], '0.1.0'), {
       kind: 'eval',
       args: ['task-run', 'inspect', 'run-1'],
+    });
+  });
+
+  test('routes maka run and maka -p through the exact same command shape', () => {
+    assert.deepEqual(parseMakaCliArgs(['run', 'hello', '--max-steps', '3'], '0.1.0'), {
+      kind: 'run',
+      args: ['hello', '--max-steps', '3'],
+    });
+    assert.deepEqual(parseMakaCliArgs(['-p', 'hello', '--max-steps', '3'], '0.1.0'), {
+      kind: 'run',
+      args: ['hello', '--max-steps', '3'],
     });
   });
 
@@ -157,6 +169,24 @@ describe('Maka CLI args', () => {
     } finally {
       await rm(dir, { recursive: true, force: true });
     }
+  });
+
+  test('exposes identical run help through maka run and maka -p', async () => {
+    const run = await runCliProcess(cliPath, ['run', '--help']);
+    const alias = await runCliProcess(cliPath, ['-p', '--help']);
+
+    assert.equal(run.code, 0, run.stderr);
+    assert.equal(alias.code, 0, alias.stderr);
+    assert.equal(alias.stdout, run.stdout);
+    assert.match(run.stdout, /Usage: maka run/);
+  });
+
+  test('returns exit 2 for missing non-interactive input before configuration startup', async () => {
+    const result = await runCliProcess(cliPath, ['run']);
+
+    assert.equal(result.code, 2);
+    assert.match(result.stderr, /missing prompt input/);
+    assert.equal(result.stdout, '');
   });
 
   test('keeps all five legacy command families on the unified router exit contract', async () => {

--- a/packages/cli/src/__tests__/run-command-fixture.ts
+++ b/packages/cli/src/__tests__/run-command-fixture.ts
@@ -1,0 +1,143 @@
+import type { SessionEvent } from '@maka/core/events';
+import type { SessionSummary } from '@maka/core/session';
+import type { InvocationResult } from '@maka/runtime';
+import {
+  runMakaTextCli,
+  type MakaRunContext,
+  type MakaRunRuntime,
+} from '../run-command.js';
+import type { CreateMakaCliRuntimeContextInput } from '../runtime-bootstrap.js';
+import type { ReadySessionTarget } from '../connection-target.js';
+
+const scenario = process.env.MAKA_RUN_FIXTURE_SCENARIO ?? 'completed';
+let observer: CreateMakaCliRuntimeContextInput['runtimeInvocationObserver'];
+let permissionDenied = false;
+let releaseStop: (() => void) | undefined;
+
+const target = {
+  connection: {
+    slug: 'fixture',
+    name: 'Fixture',
+    providerType: 'ollama',
+    enabled: true,
+    defaultModel: 'fixture-model',
+  },
+  apiKey: '',
+  model: 'fixture-model',
+} as ReadySessionTarget;
+
+const summary = {
+  id: 'session-fixture',
+  cwd: process.cwd(),
+  name: 'fixture',
+  isFlagged: false,
+  isArchived: false,
+  labels: [],
+  hasUnread: false,
+  status: 'active',
+  backend: 'ai-sdk',
+  llmConnectionSlug: 'fixture',
+  model: 'fixture-model',
+  permissionMode: 'explore',
+} satisfies SessionSummary;
+
+const runtime: MakaRunRuntime = {
+  async createSession() {
+    return summary;
+  },
+  async *sendMessage(_sessionId, input): AsyncIterable<SessionEvent> {
+    if (scenario === 'runtime-error') throw new Error('provider failed after startup');
+    if (scenario === 'permission') {
+      yield {
+        type: 'permission_request',
+        id: 'event-permission',
+        turnId: input.turnId,
+        ts: 1,
+        requestId: 'permission-1',
+        toolUseId: 'tool-1',
+        toolName: 'WebSearch',
+        category: 'web_read',
+        reason: 'network',
+        args: { query: 'example' },
+      };
+      if (!permissionDenied) throw new Error('permission prompt was not denied');
+      await notify(failedResult('permission_denied', 'permission request permission-1 was denied'));
+      return;
+    }
+    if (scenario === 'slow') {
+      process.stderr.write('fixture-ready\n');
+      const keepAlive = setInterval(() => {}, 1_000);
+      await new Promise<void>((resolve) => { releaseStop = resolve; });
+      clearInterval(keepAlive);
+      await notify(failedResult('aborted', 'fixture stopped'));
+      return;
+    }
+    if (scenario === 'missing-output') {
+      await notify(failedResult('missing_final_output', 'completed invocation produced no final output'));
+      return;
+    }
+    const maxSteps = process.env.MAKA_RUN_EXPECT_MAX_STEPS;
+    const output = maxSteps
+      ? `maxSteps=${maxSteps};prompt=${input.text}`
+      : `prompt=${input.text}`;
+    await notify(completedResult(output));
+  },
+  async respondToPermission(_sessionId, response) {
+    permissionDenied = response.decision === 'deny' && response.requestId === 'permission-1';
+  },
+  async stopSession() {
+    releaseStop?.();
+  },
+};
+
+async function createContext(input: CreateMakaCliRuntimeContextInput): Promise<MakaRunContext> {
+  if (scenario === 'config-error') throw new Error('unknown connection fixture-missing');
+  if (
+    process.env.MAKA_RUN_EXPECT_MAX_STEPS
+    && input.maxSteps !== Number(process.env.MAKA_RUN_EXPECT_MAX_STEPS)
+  ) {
+    throw new Error(`unexpected maxSteps ${String(input.maxSteps)}`);
+  }
+  observer = input.runtimeInvocationObserver;
+  return { runtime, target, close: async () => {} };
+}
+
+function completedResult(finalOutput: string): InvocationResult {
+  return {
+    invocationId: 'invocation-fixture',
+    runId: 'run-fixture',
+    sessionId: summary.id,
+    turnId: 'turn-fixture',
+    status: 'completed',
+    finalOutput,
+    events: [],
+    startedAt: 1,
+    finishedAt: 2,
+  };
+}
+
+function failedResult(failureClass: string, message: string): InvocationResult {
+  return {
+    invocationId: 'invocation-fixture',
+    runId: 'run-fixture',
+    sessionId: summary.id,
+    turnId: 'turn-fixture',
+    status: 'failed',
+    events: [],
+    failure: { class: failureClass, message },
+    startedAt: 1,
+    finishedAt: 2,
+  };
+}
+
+async function notify(result: InvocationResult): Promise<void> {
+  await observer?.(result);
+}
+
+runMakaTextCli(process.argv.slice(2), { createContext }).then(
+  (code) => { process.exitCode = code; },
+  (error) => {
+    process.stderr.write(`${error instanceof Error ? error.stack : String(error)}\n`);
+    process.exitCode = 1;
+  },
+);

--- a/packages/cli/src/__tests__/run-command.test.ts
+++ b/packages/cli/src/__tests__/run-command.test.ts
@@ -1,0 +1,167 @@
+import assert from 'node:assert/strict';
+import { spawn } from 'node:child_process';
+import { once } from 'node:events';
+import { fileURLToPath } from 'node:url';
+import { describe, test } from 'node:test';
+import { parseMakaRunArgs } from '../run-command.js';
+
+const fixturePath = fileURLToPath(new URL('./run-command-fixture.js', import.meta.url));
+
+describe('maka run argument parsing', () => {
+  test('parses prompt, target, thinking, timeout, and max steps', () => {
+    assert.deepEqual(parseMakaRunArgs([
+      'explain this',
+      '--cwd', '/repo',
+      '--connection', 'local',
+      '--model', 'model-1',
+      '--thinking', 'high',
+      '--timeout', '1.5',
+      '--max-steps', '7',
+    ]), {
+      kind: 'run',
+      options: {
+        prompt: 'explain this',
+        stdinPrompt: false,
+        cwd: '/repo',
+        connection: 'local',
+        model: 'model-1',
+        thinking: 'high',
+        timeoutMs: 1500,
+        maxSteps: 7,
+      },
+    });
+  });
+
+  test('recognizes stdin prompt mode and rejects malformed limits', () => {
+    assert.deepEqual(parseMakaRunArgs(['-']), {
+      kind: 'run',
+      options: { stdinPrompt: true },
+    });
+    assert.equal(parseMakaRunArgs(['x', '--timeout', '0']).kind, 'error');
+    assert.equal(parseMakaRunArgs(['x', '--max-steps', '1.5']).kind, 'error');
+  });
+});
+
+describe('maka run process contract', () => {
+  test('writes only the final answer to stdout', async () => {
+    const result = await runFixture(['hello'], { input: '' });
+    assert.equal(result.code, 0, result.stderr);
+    assert.equal(result.stdout, 'prompt=hello\n');
+    assert.equal(result.stderr, '');
+  });
+
+  test('uses stdin as the complete prompt for run -', async () => {
+    const result = await runFixture(['-'], { input: 'from stdin\nsecond line' });
+    assert.equal(result.code, 0, result.stderr);
+    assert.equal(result.stdout, 'prompt=from stdin\nsecond line\n');
+  });
+
+  test('uses non-TTY stdin as the prompt when no positional prompt is provided', async () => {
+    const result = await runFixture([], { input: 'implicit stdin prompt' });
+    assert.equal(result.code, 0, result.stderr);
+    assert.equal(result.stdout, 'prompt=implicit stdin prompt\n');
+  });
+
+  test('combines a positional instruction with piped stdin context', async () => {
+    const result = await runFixture(['summarize'], { input: 'document body' });
+    assert.equal(result.code, 0, result.stderr);
+    assert.equal(result.stdout, 'prompt=summarize\n\ndocument body\n');
+  });
+
+  test('returns exit 2 for missing input and pre-invocation configuration errors', async () => {
+    const missing = await runFixture([], { input: '' });
+    assert.equal(missing.code, 2);
+    assert.match(missing.stderr, /missing prompt input/);
+
+    const config = await runFixture(['hello'], { scenario: 'config-error', input: '' });
+    assert.equal(config.code, 2);
+    assert.match(config.stderr, /unknown connection/);
+  });
+
+  test('returns exit 1 for runtime failure and missing final output', async () => {
+    const runtime = await runFixture(['hello'], { scenario: 'runtime-error', input: '' });
+    assert.equal(runtime.code, 1);
+    assert.match(runtime.stderr, /provider failed after startup/);
+
+    const missing = await runFixture(['hello'], { scenario: 'missing-output', input: '' });
+    assert.equal(missing.code, 1);
+    assert.match(missing.stderr, /no final output/);
+  });
+
+  test('denies an unresolved permission prompt and exits 1', async () => {
+    const result = await runFixture(['hello'], { scenario: 'permission', input: '' });
+    assert.equal(result.code, 1);
+    assert.match(result.stderr, /denied permission request for WebSearch/);
+    assert.match(result.stderr, /permission request permission-1 was denied/);
+    assert.equal(result.stdout, '');
+  });
+
+  test('passes max steps as an invocation-local context limit', async () => {
+    const result = await runFixture(['hello', '--max-steps', '3'], {
+      input: '',
+      env: { MAKA_RUN_EXPECT_MAX_STEPS: '3' },
+    });
+    assert.equal(result.code, 0, result.stderr);
+    assert.match(result.stdout, /^maxSteps=3;/);
+  });
+
+  test('returns exit 1 when the invocation timeout stops the run', async () => {
+    const result = await runFixture(['hello', '--timeout', '0.05'], {
+      scenario: 'slow',
+      input: '',
+    });
+    assert.equal(result.code, 1);
+    assert.match(result.stderr, /timed out after 50ms/);
+  });
+
+  test('returns exit 130 on SIGINT', async () => {
+    const child = spawn(process.execPath, [fixturePath, 'hello'], {
+      env: { ...process.env, MAKA_RUN_FIXTURE_SCENARIO: 'slow' },
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    child.stdin.end();
+    let stdout = '';
+    let stderr = '';
+    child.stdout.on('data', (chunk: Buffer) => { stdout += chunk.toString('utf8'); });
+    const ready = new Promise<void>((resolve) => {
+      child.stderr.on('data', (chunk: Buffer) => {
+        stderr += chunk.toString('utf8');
+        if (stderr.includes('fixture-ready')) resolve();
+      });
+    });
+    await ready;
+    child.kill('SIGINT');
+
+    const [code, signal] = await once(child, 'exit') as [number | null, NodeJS.Signals | null];
+
+    assert.equal(signal, null);
+    assert.equal(code, 130, stderr);
+    assert.equal(stdout, '');
+  });
+});
+
+function runFixture(
+  args: string[],
+  options: {
+    scenario?: string;
+    input?: string;
+    env?: NodeJS.ProcessEnv;
+  } = {},
+): Promise<{ code: number | null; stdout: string; stderr: string }> {
+  return new Promise((resolve) => {
+    const child = spawn(process.execPath, [fixturePath, ...args], {
+      env: {
+        ...process.env,
+        ...(options.scenario ? { MAKA_RUN_FIXTURE_SCENARIO: options.scenario } : {}),
+        ...options.env,
+      },
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    let stdout = '';
+    let stderr = '';
+    child.stdout.on('data', (chunk: Buffer) => { stdout += chunk.toString('utf8'); });
+    child.stderr.on('data', (chunk: Buffer) => { stderr += chunk.toString('utf8'); });
+    child.on('close', (code) => resolve({ code, stdout, stderr }));
+    child.stdin.end(options.input ?? '');
+  });
+}

--- a/packages/cli/src/__tests__/runtime-bootstrap.test.ts
+++ b/packages/cli/src/__tests__/runtime-bootstrap.test.ts
@@ -44,6 +44,65 @@ describe('Maka CLI runtime bootstrap', () => {
     });
   });
 
+  test('uses an explicit connection and forwards one-shot limits and invocation results', async () => {
+    await withWorkspace(async (workspaceRoot) => {
+      const connectionStore = createConnectionStore(workspaceRoot);
+      await connectionStore.create({
+        slug: 'default-local',
+        name: 'Default local',
+        providerType: 'ollama',
+        defaultModel: 'default-model',
+      });
+      await connectionStore.create({
+        slug: 'selected-local',
+        name: 'Selected local',
+        providerType: 'ollama',
+        defaultModel: 'selected-model',
+      });
+      await connectionStore.update('selected-local', {
+        models: [{ id: 'requested-model' }],
+      });
+      const observed: unknown[] = [];
+      const observer = (result: unknown): void => { observed.push(result); };
+
+      const context = await createMakaCliRuntimeContext({
+        workspaceRoot,
+        cwd: '/repo',
+        requestedConnectionSlug: 'selected-local',
+        requestedModel: 'requested-model',
+        maxSteps: 3,
+        runtimeInvocationObserver: observer,
+      });
+      try {
+        assert.equal(context.target.connection.slug, 'selected-local');
+        assert.equal(context.target.model, 'requested-model');
+        const session = await context.runtime.createSession({
+          cwd: context.cwd,
+          backend: 'ai-sdk',
+          llmConnectionSlug: context.target.connection.slug,
+          model: context.target.model,
+          permissionMode: 'explore',
+          name: 'one-shot',
+        });
+        const runtimeDeps = (context.runtime as unknown as RuntimeWithPrivateDeps).deps;
+        const header = await runtimeDeps.store.readHeader(session.id);
+        const backend = await runtimeDeps.backends.build('ai-sdk', {
+          sessionId: session.id,
+          workspaceRoot,
+          header,
+          store: runtimeDeps.store,
+        });
+        const backendInput = (backend as unknown as { input: AiSdkBackendInput }).input;
+
+        assert.equal(backendInput.maxSteps, 3);
+        assert.equal(runtimeDeps.runtimeInvocationObserver, observer);
+        assert.deepEqual(observed, []);
+      } finally {
+        await context.close();
+      }
+    });
+  });
+
   test('registers Edit in the TUI runtime toolset and still requires permission', async () => {
     await withWorkspace(async (workspaceRoot) => {
       const connectionStore = createConnectionStore(workspaceRoot);
@@ -410,6 +469,7 @@ interface RuntimeWithPrivateDeps {
   deps: {
     backends: BackendRegistry;
     store: SessionStore;
+    runtimeInvocationObserver?: (result: unknown) => void | Promise<void>;
   };
 }
 

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -13,6 +13,7 @@ import { runMakaPiTui } from './pi-tui-runner.js';
 
 export type MakaCliCommand =
   | { kind: 'tui' }
+  | { kind: 'run'; args: string[] }
   | { kind: 'eval'; args: string[] }
   | { kind: 'help'; text: string }
   | { kind: 'version'; text: string }
@@ -23,6 +24,7 @@ export function parseMakaCliArgs(argv: string[], version: string): MakaCliComman
   const [first] = argv;
   if (first === '--help' || first === '-h') return { kind: 'help', text: helpText() };
   if (first === '--version' || first === '-v') return { kind: 'version', text: version };
+  if (first === 'run' || first === '-p') return { kind: 'run', args: argv.slice(1) };
   if (first === 'eval') return { kind: 'eval', args: argv.slice(1) };
   return {
     kind: 'error',
@@ -72,6 +74,8 @@ function helpText(): string {
     'Commands:',
     '  maka              Start the TUI',
     '  maka-agent        Start the TUI',
+    '  maka run ...      Run one non-interactive model turn',
+    '  maka -p ...       Alias for maka run',
     '  maka eval ...     Run evaluation and autonomous task commands',
     '',
     'Options:',
@@ -84,6 +88,10 @@ export async function runMakaCli(argv: string[] = process.argv.slice(2)): Promis
   const version = await readPackageVersion();
   const command = parseMakaCliArgs(argv, version);
   switch (command.kind) {
+    case 'run': {
+      const { runMakaTextCli } = await import('./run-command.js');
+      return runMakaTextCli(command.args);
+    }
     case 'eval': {
       const { runMakaEvalCli } = await import('@maka/headless/eval-router');
       return runMakaEvalCli(command.args);

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -9,6 +9,13 @@ export {
   type MakaCliCommand,
 } from './cli.js';
 export {
+  parseMakaRunArgs,
+  runMakaTextCli,
+  type MakaRunDeps,
+  type MakaRunOptions,
+  type ParseMakaRunArgsResult,
+} from './run-command.js';
+export {
   createMakaCliRuntimeContext,
   type CreateMakaCliRuntimeContextInput,
   type MakaCliRuntimeContext,

--- a/packages/cli/src/run-command.ts
+++ b/packages/cli/src/run-command.ts
@@ -1,0 +1,337 @@
+import { randomUUID } from 'node:crypto';
+import { realpath, stat } from 'node:fs/promises';
+import { resolve } from 'node:path';
+import type { SessionEvent } from '@maka/core/events';
+import { isThinkingLevel, type ThinkingLevel } from '@maka/core/model-thinking';
+import type { CreateSessionInput, UserMessageInput } from '@maka/core/runtime-inputs';
+import type { SessionSummary } from '@maka/core/session';
+import type { InvocationResult } from '@maka/runtime';
+import {
+  createMakaCliRuntimeContext,
+  type CreateMakaCliRuntimeContextInput,
+} from './runtime-bootstrap.js';
+import type { ReadySessionTarget } from './connection-target.js';
+import { resolveMakaWorkspaceRoot } from './workspace-root.js';
+
+export interface MakaRunOptions {
+  prompt?: string;
+  stdinPrompt: boolean;
+  cwd?: string;
+  connection?: string;
+  model?: string;
+  thinking?: ThinkingLevel;
+  timeoutMs?: number;
+  maxSteps?: number;
+}
+
+export type ParseMakaRunArgsResult =
+  | { kind: 'run'; options: MakaRunOptions }
+  | { kind: 'help' }
+  | { kind: 'error'; message: string };
+
+export interface MakaRunRuntime {
+  createSession(input: CreateSessionInput): Promise<SessionSummary>;
+  sendMessage(sessionId: string, input: UserMessageInput): AsyncIterable<SessionEvent>;
+  respondToPermission(
+    sessionId: string,
+    response: { requestId: string; decision: 'deny'; rememberForTurn?: boolean },
+  ): Promise<void>;
+  stopSession(sessionId: string, input?: { source?: 'stop_button' }): Promise<void>;
+}
+
+export interface MakaRunContext {
+  runtime: MakaRunRuntime;
+  target: ReadySessionTarget;
+  close(): Promise<void>;
+}
+
+export interface MakaRunDeps {
+  createContext(input: CreateMakaCliRuntimeContextInput): Promise<MakaRunContext>;
+  workspaceRoot(): string;
+  processCwd(): string;
+  stdinIsTTY(): boolean;
+  readStdin(): Promise<string>;
+  writeStdout(text: string): void;
+  writeStderr(text: string): void;
+  onSigint(handler: () => void): () => void;
+  setTimer(handler: () => void, ms: number): unknown;
+  clearTimer(timer: unknown): void;
+  newId(): string;
+}
+
+const VALUE_FLAGS = new Set([
+  'cwd',
+  'connection',
+  'model',
+  'thinking',
+  'timeout',
+  'max-steps',
+]);
+
+export function parseMakaRunArgs(argv: readonly string[]): ParseMakaRunArgsResult {
+  const positional: string[] = [];
+  const flags = new Map<string, string>();
+  let literal = false;
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index]!;
+    if (!literal && (arg === '--help' || arg === '-h')) return { kind: 'help' };
+    if (!literal && arg === '--') {
+      literal = true;
+      continue;
+    }
+    if (!literal && arg.startsWith('--')) {
+      const name = arg.slice(2);
+      if (!VALUE_FLAGS.has(name)) return { kind: 'error', message: `unknown option: ${arg}` };
+      if (flags.has(name)) return { kind: 'error', message: `option repeated: ${arg}` };
+      const value = argv[index + 1];
+      if (value === undefined || value.startsWith('--')) {
+        return { kind: 'error', message: `option ${arg} needs a value` };
+      }
+      flags.set(name, value);
+      index += 1;
+      continue;
+    }
+    if (!literal && arg.startsWith('-') && arg !== '-') {
+      return { kind: 'error', message: `unknown option: ${arg}` };
+    }
+    positional.push(arg);
+  }
+
+  if (positional.length > 1) {
+    return { kind: 'error', message: 'maka run accepts at most one positional prompt' };
+  }
+  const prompt = positional[0];
+  const timeout = flags.get('timeout');
+  const maxSteps = flags.get('max-steps');
+  const thinking = flags.get('thinking');
+  const timeoutSeconds = timeout === undefined ? undefined : Number(timeout);
+  if (timeoutSeconds !== undefined && (!Number.isFinite(timeoutSeconds) || timeoutSeconds <= 0)) {
+    return { kind: 'error', message: '--timeout must be a positive number of seconds' };
+  }
+  const parsedMaxSteps = maxSteps === undefined ? undefined : Number(maxSteps);
+  if (parsedMaxSteps !== undefined && (!Number.isInteger(parsedMaxSteps) || parsedMaxSteps < 1)) {
+    return { kind: 'error', message: '--max-steps must be a positive integer' };
+  }
+  if (thinking !== undefined && thinking !== 'default' && !isThinkingLevel(thinking)) {
+    return { kind: 'error', message: `unknown thinking level: ${thinking}` };
+  }
+
+  return {
+    kind: 'run',
+    options: {
+      ...(prompt !== undefined && prompt !== '-' ? { prompt } : {}),
+      stdinPrompt: prompt === '-',
+      ...(flags.get('cwd') !== undefined ? { cwd: flags.get('cwd') } : {}),
+      ...(flags.get('connection') !== undefined ? { connection: flags.get('connection') } : {}),
+      ...(flags.get('model') !== undefined ? { model: flags.get('model') } : {}),
+      ...(thinking !== undefined && thinking !== 'default' ? { thinking } : {}),
+      ...(timeoutSeconds !== undefined ? { timeoutMs: Math.ceil(timeoutSeconds * 1_000) } : {}),
+      ...(parsedMaxSteps !== undefined ? { maxSteps: parsedMaxSteps } : {}),
+    },
+  };
+}
+
+export async function runMakaTextCli(
+  argv: readonly string[],
+  overrides: Partial<MakaRunDeps> = {},
+): Promise<number> {
+  const deps = { ...defaultMakaRunDeps(), ...overrides };
+  const parsed = parseMakaRunArgs(argv);
+  if (parsed.kind === 'help') {
+    deps.writeStdout(`${makaRunHelpText()}\n`);
+    return 0;
+  }
+  if (parsed.kind === 'error') {
+    deps.writeStderr(`maka run: ${parsed.message}\n\n${makaRunHelpText()}\n`);
+    return 2;
+  }
+
+  let prompt: string;
+  let cwd: string;
+  try {
+    prompt = await resolveRunPrompt(parsed.options, deps);
+    cwd = await canonicalDirectory(parsed.options.cwd ?? deps.processCwd());
+  } catch (error) {
+    deps.writeStderr(`maka run: ${errorMessage(error)}\n`);
+    return 2;
+  }
+
+  let invocation: InvocationResult | undefined;
+  let context: MakaRunContext;
+  try {
+    context = await deps.createContext({
+      workspaceRoot: deps.workspaceRoot(),
+      cwd,
+      ...(parsed.options.connection ? { requestedConnectionSlug: parsed.options.connection } : {}),
+      ...(parsed.options.model ? { requestedModel: parsed.options.model } : {}),
+      ...(parsed.options.maxSteps !== undefined ? { maxSteps: parsed.options.maxSteps } : {}),
+      runtimeInvocationObserver: (result) => {
+        invocation = result;
+      },
+    });
+  } catch (error) {
+    deps.writeStderr(`maka run: ${errorMessage(error)}\n`);
+    return 2;
+  }
+
+  let session: SessionSummary;
+  try {
+    session = await context.runtime.createSession({
+      cwd,
+      name: firstLine(prompt).slice(0, 42) || 'Maka run',
+      backend: 'ai-sdk',
+      llmConnectionSlug: context.target.connection.slug,
+      model: context.target.model,
+      permissionMode: 'explore',
+      ...(parsed.options.thinking !== undefined ? { thinkingLevel: parsed.options.thinking } : {}),
+    });
+  } catch (error) {
+    await context.close();
+    deps.writeStderr(`maka run: ${errorMessage(error)}\n`);
+    return 2;
+  }
+
+  let interrupted = false;
+  let timedOut = false;
+  let streamFailed = false;
+  let stopPromise: Promise<void> | undefined;
+  const stop = (): void => {
+    if (stopPromise) return;
+    stopPromise = context.runtime.stopSession(session.id, { source: 'stop_button' });
+    void stopPromise.catch(() => {});
+  };
+  const removeSigint = deps.onSigint(() => {
+    interrupted = true;
+    stop();
+  });
+  const timer = parsed.options.timeoutMs === undefined
+    ? undefined
+    : deps.setTimer(() => {
+      timedOut = true;
+      stop();
+    }, parsed.options.timeoutMs);
+
+  try {
+    for await (const event of context.runtime.sendMessage(session.id, {
+      turnId: deps.newId(),
+      text: prompt,
+    })) {
+      if (event.type === 'permission_request') {
+        deps.writeStderr(`maka run: denied permission request for ${event.toolName}\n`);
+        await context.runtime.respondToPermission(session.id, {
+          requestId: event.requestId,
+          decision: 'deny',
+        });
+      }
+    }
+    await stopPromise;
+  } catch (error) {
+    streamFailed = true;
+    await stopPromise?.catch(() => undefined);
+    if (!interrupted && !timedOut) {
+      deps.writeStderr(`maka run: ${errorMessage(error)}\n`);
+    }
+  } finally {
+    removeSigint();
+    if (timer !== undefined) deps.clearTimer(timer);
+    await context.close();
+  }
+
+  if (interrupted) return 130;
+  if (timedOut) {
+    deps.writeStderr(`maka run: timed out after ${parsed.options.timeoutMs}ms\n`);
+    return 1;
+  }
+  if (streamFailed) return 1;
+  if (!invocation) {
+    deps.writeStderr('maka run: runtime produced no InvocationResult\n');
+    return 1;
+  }
+  if (invocation.status !== 'completed' || invocation.finalOutput === undefined) {
+    const detail = invocation.failure?.message ?? invocation.failure?.class ?? 'runtime failure';
+    deps.writeStderr(`maka run: ${detail}\n`);
+    return 1;
+  }
+  deps.writeStdout(withTrailingNewline(invocation.finalOutput));
+  return 0;
+}
+
+async function resolveRunPrompt(options: MakaRunOptions, deps: MakaRunDeps): Promise<string> {
+  const shouldReadStdin = options.stdinPrompt || !deps.stdinIsTTY();
+  const stdin = shouldReadStdin ? await deps.readStdin() : '';
+  if (options.stdinPrompt || options.prompt === undefined) {
+    if (stdin.trim().length === 0) throw new Error('missing prompt input');
+    return stdin;
+  }
+  if (options.prompt.trim().length === 0) throw new Error('missing prompt input');
+  return stdin.trim().length > 0 ? `${options.prompt}\n\n${stdin}` : options.prompt;
+}
+
+async function canonicalDirectory(input: string): Promise<string> {
+  const canonical = await realpath(resolve(input));
+  if (!(await stat(canonical)).isDirectory()) throw new Error(`cwd is not a directory: ${input}`);
+  return canonical;
+}
+
+function makaRunHelpText(): string {
+  return [
+    'Usage: maka run [PROMPT] [options]',
+    '       maka -p [PROMPT] [options]',
+    '',
+    'Input:',
+    '  -                         Read the complete prompt from stdin',
+    '  PROMPT with piped stdin   Use PROMPT as instruction and stdin as context',
+    '',
+    'Options:',
+    '  --cwd <path>              Working directory (default: current directory)',
+    '  --connection <slug>       Model connection to use',
+    '  --model <id>              Model to use',
+    '  --thinking <level>        off|minimal|low|medium|high|xhigh|max|default',
+    '  --timeout <seconds>       Invocation timeout',
+    '  --max-steps <count>       Tool-step cap',
+    '  -h, --help                Show help',
+  ].join('\n');
+}
+
+function defaultMakaRunDeps(): MakaRunDeps {
+  return {
+    createContext: createMakaCliRuntimeContext,
+    workspaceRoot: () => resolveMakaWorkspaceRoot(),
+    processCwd: () => process.cwd(),
+    stdinIsTTY: () => process.stdin.isTTY === true,
+    readStdin: readProcessStdin,
+    writeStdout: (text) => { process.stdout.write(text); },
+    writeStderr: (text) => { process.stderr.write(text); },
+    onSigint: (handler) => {
+      process.on('SIGINT', handler);
+      return () => process.off('SIGINT', handler);
+    },
+    setTimer: (handler, ms) => {
+      const timer = setTimeout(handler, ms);
+      timer.unref();
+      return timer;
+    },
+    clearTimer: (timer) => clearTimeout(timer as ReturnType<typeof setTimeout>),
+    newId: randomUUID,
+  };
+}
+
+async function readProcessStdin(): Promise<string> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of process.stdin) {
+    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+  }
+  return Buffer.concat(chunks).toString('utf8');
+}
+
+function firstLine(text: string): string {
+  return text.split('\n').map((line) => line.trim()).find(Boolean) ?? '';
+}
+
+function withTrailingNewline(text: string): string {
+  return text.endsWith('\n') ? text : `${text}\n`;
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/packages/cli/src/runtime-bootstrap.ts
+++ b/packages/cli/src/runtime-bootstrap.ts
@@ -23,6 +23,7 @@ import {
   loadHistoryCompactBlocksFromArtifacts,
   type AutomationDefinition,
   type GoalContinuationDeps,
+  type InvocationResult,
   type ShellRunUpdate,
 } from '@maka/runtime';
 import {
@@ -64,7 +65,10 @@ export interface MakaCliRuntimeContext {
 export interface CreateMakaCliRuntimeContextInput {
   workspaceRoot: string;
   cwd: string;
+  requestedConnectionSlug?: string;
   requestedModel?: string;
+  maxSteps?: number;
+  runtimeInvocationObserver?: (result: InvocationResult) => void | Promise<void>;
   /**
    * Optional cron executor. When provided, the Automation tool advertises the
    * cron kind and cron fires spawn a fresh session + run via this callback
@@ -95,11 +99,14 @@ export async function createMakaCliRuntimeContext(
   const connectionStore = createConnectionStore(input.workspaceRoot);
   const credentialStore = createFileCredentialStore(input.workspaceRoot);
   const settingsStore = createSettingsStore(input.workspaceRoot);
-  const target = await resolveDefaultSessionTarget({
+  const targetInput = {
     connectionStore,
     credentialStore,
     requestedModel: input.requestedModel,
-  });
+  };
+  const target = input.requestedConnectionSlug
+    ? await resolveSessionTargetForSlug(input.requestedConnectionSlug, targetInput)
+    : await resolveDefaultSessionTarget(targetInput);
   const modelChoices = await listReadyModelChoices({ connectionStore, credentialStore });
   const permissionEngine = new PermissionEngine({ newId: randomUUID, now: Date.now });
   const backends = new BackendRegistry();
@@ -229,6 +236,7 @@ export async function createMakaCliRuntimeContext(
       shellRunContextSummary: ctx.shellRunContextSummary,
       newId: randomUUID,
       now: Date.now,
+      ...(input.maxSteps !== undefined ? { maxSteps: input.maxSteps } : {}),
     });
   });
 
@@ -238,6 +246,7 @@ export async function createMakaCliRuntimeContext(
     runtimeEventStore,
     shellRuns,
     backends,
+    runtimeInvocationObserver: input.runtimeInvocationObserver,
     cleanupHistoryCompactArtifacts: async (cleanupInput) => {
       await cleanupLegacyHistoryCompactArtifacts({
         ...cleanupInput,

--- a/packages/headless/src/__tests__/harbor-cell.test.ts
+++ b/packages/headless/src/__tests__/harbor-cell.test.ts
@@ -83,6 +83,7 @@ class CellReportingBackend implements AgentBackend {
       costUsd: 0.0042,
       systemPromptHash: 'sha256:cell-prompt',
     };
+    yield { type: 'text_complete', id: 'cell-text', messageId: 'cell-message', turnId: input.turnId, ts, text: 'cell complete' };
     yield { type: 'complete', id: 'cell-complete', turnId: input.turnId, ts, stopReason: 'end_turn' };
   }
 
@@ -145,6 +146,7 @@ class StepCapThenCompleteBackend implements AgentBackend {
         rawFinishReason: 'tool-calls',
         runtimeSteps: 50,
       };
+      yield { type: 'text_complete', id: 'text-step-cap', messageId: 'step-cap-message', turnId: input.turnId, ts, text: 'continue' };
       yield { type: 'complete', id: 'complete-step-cap', turnId: input.turnId, ts, stopReason: 'end_turn' };
       return;
     }
@@ -160,6 +162,7 @@ class StepCapThenCompleteBackend implements AgentBackend {
       costUsd: 0.02,
       rawFinishReason: 'stop',
     };
+    yield { type: 'text_complete', id: 'text-done', messageId: 'done-message', turnId: input.turnId, ts, text: 'done' };
     yield { type: 'complete', id: 'complete-done', turnId: input.turnId, ts, stopReason: 'end_turn' };
   }
 
@@ -232,6 +235,7 @@ class NoisyStepCapThenCompleteBackend extends StepCapThenCompleteBackend {
       rawFinishReason: 'tool-calls',
       runtimeSteps: 50,
     };
+    yield { type: 'text_complete', id: 'text-step-cap-noisy', messageId: 'step-cap-noisy-message', turnId: input.turnId, ts, text: 'continue' };
     yield { type: 'complete', id: 'complete-step-cap-noisy', turnId: input.turnId, ts, stopReason: 'end_turn' };
   }
 }
@@ -264,6 +268,7 @@ class StepCapTwiceThenCompleteBackend extends StepCapThenCompleteBackend {
         rawFinishReason: 'tool-calls',
         runtimeSteps: 50,
       };
+      yield { type: 'text_complete', id: `text-step-cap-${this.prompts.length}`, messageId: `step-cap-message-${this.prompts.length}`, turnId: input.turnId, ts, text: 'continue' };
       yield { type: 'complete', id: `complete-step-cap-${this.prompts.length}`, turnId: input.turnId, ts, stopReason: 'end_turn' };
       return;
     }
@@ -279,6 +284,7 @@ class StepCapTwiceThenCompleteBackend extends StepCapThenCompleteBackend {
       costUsd: 0.02,
       rawFinishReason: 'stop',
     };
+    yield { type: 'text_complete', id: 'text-done', messageId: 'done-message', turnId: input.turnId, ts, text: 'done' };
     yield { type: 'complete', id: 'complete-done', turnId: input.turnId, ts, stopReason: 'end_turn' };
   }
 }
@@ -1911,6 +1917,7 @@ writeFileSync('pi-env.json', JSON.stringify({
   google: process.env.GOOGLE_API_KEY,
   xiaomi: process.env.XIAOMI_TOKEN_PLAN_CN_API_KEY,
 }));
+console.log(JSON.stringify({ type: 'message_update', assistantMessageEvent: { type: 'text_delta', delta: 'pi ok' } }));
 console.log(JSON.stringify({ type: 'agent_end', messages: [{ role: 'assistant', usage: { input: 5, output: 2, totalTokens: 7 } }] }));
 `,
         'utf8',
@@ -2033,6 +2040,7 @@ const prompt = await new Promise((resolve) => {
 });
 writeFileSync('pi-long-argv.json', JSON.stringify(argv));
 writeFileSync('pi-long-prompt-length.txt', String(prompt.length));
+console.log(JSON.stringify({ type: 'message_update', assistantMessageEvent: { type: 'text_delta', delta: 'pi ok' } }));
 console.log(JSON.stringify({ type: 'agent_end', messages: [{ role: 'assistant', usage: { input: 5, output: 2, totalTokens: 7 } }] }));
 `,
         'utf8',

--- a/packages/runtime/src/__tests__/ai-sdk-flow.test.ts
+++ b/packages/runtime/src/__tests__/ai-sdk-flow.test.ts
@@ -217,7 +217,10 @@ describe('AiSdkFlow seam', () => {
       },
     ];
     const backend = new ScriptedBackend({
-      events: [ev({ type: 'complete', stopReason: 'end_turn' })],
+      events: [
+        ev({ type: 'text_complete', messageId: 'm1', text: 'ok' }),
+        ev({ type: 'complete', stopReason: 'end_turn' }),
+      ],
     });
     const flow = new AiSdkFlow({ backend });
     let idSeq = 0;
@@ -240,6 +243,7 @@ describe('AiSdkFlow seam', () => {
     });
 
     assert.equal(result.status, 'completed');
+    assert.equal(result.finalOutput, 'ok');
     assert.equal(backend.sendInputs.length, 1);
     assert.deepEqual(backend.sendInputs[0], {
       runId: 'rt-2',

--- a/packages/runtime/src/__tests__/runtime-runner.test.ts
+++ b/packages/runtime/src/__tests__/runtime-runner.test.ts
@@ -210,6 +210,7 @@ describe('RuntimeRunner', () => {
     const result = await runner.run(makeRequest({ text: 'ping' }));
 
     expect(result.status).toBe('completed');
+    expect(result.finalOutput).toBe('hello');
     expect(result.events).toHaveLength(3);
 
     const userEvent = result.events[0]!;
@@ -237,6 +238,38 @@ describe('RuntimeRunner', () => {
     expect(result.events).toHaveLength(2);
     expect(result.events[0]!.author).toBe('user');
     expect(result.events[1]!.author).toBe('agent');
+  });
+
+  test('uses the last non-partial non-empty model text as finalOutput', async () => {
+    const providers = makeProviders();
+    const flow = new ScriptFlow((ctx) => [
+      flowTextEvent(ctx, 'first answer'),
+      { ...flowTextEvent(ctx, 'streaming draft'), partial: true },
+      flowTextEvent(ctx, '   '),
+      flowTextEvent(ctx, 'final answer'),
+      flowTerminalEvent(ctx, 'completed'),
+    ]);
+    const runner = new RuntimeRunner({ flow, providers });
+
+    const result = await runner.run(makeRequest());
+
+    expect(result.status).toBe('completed');
+    expect(result.finalOutput).toBe('final answer');
+  });
+
+  test('completed terminal without non-empty model text fails as missing_final_output', async () => {
+    const providers = makeProviders();
+    const flow = new ScriptFlow((ctx) => [
+      flowTextEvent(ctx, '   '),
+      flowTerminalEvent(ctx, 'completed'),
+    ]);
+    const runner = new RuntimeRunner({ flow, providers });
+
+    const result = await runner.run(makeRequest());
+
+    expect(result.status).toBe('failed');
+    expect(result.finalOutput).toBeUndefined();
+    expect(result.failure?.class).toBe('missing_final_output');
   });
 
   test('caller-provided invocationId and runId are used across result, user event, and flow', async () => {
@@ -573,6 +606,7 @@ describe('RuntimeRunner', () => {
     const flow: RunnableAgentFlow = {
       async *run(ctx, input) {
         seenInput = input;
+        yield flowTextEvent(ctx, 'done');
         yield flowTerminalEvent(ctx, 'completed');
       },
     };

--- a/packages/runtime/src/__tests__/session-manager.test.ts
+++ b/packages/runtime/src/__tests__/session-manager.test.ts
@@ -437,7 +437,7 @@ describe('SessionManager permission mode updates', () => {
     const runtimeEventStore = new MemoryRuntimeEventStore();
     const backends = new BackendRegistry();
     const observed: InvocationResult[] = [];
-    backends.register('fake', (ctx) => new TestBackend(ctx));
+    backends.register('fake', (ctx) => new FinalTextTestBackend(ctx));
     const manager = new SessionManager({
       store,
       runStore,
@@ -456,8 +456,8 @@ describe('SessionManager permission mode updates', () => {
       manager.sendMessage(session.id, { turnId: 'turn-1', text: 'hello' }),
     );
 
-    expect(sessionEvents.map((event) => event.type)).toEqual(['text_delta', 'complete']);
-    expect(sessionEvents.map((event) => event.id)).toEqual(['turn-1-delta', 'turn-1-complete']);
+    expect(sessionEvents.map((event) => event.type)).toEqual(['text_complete', 'complete']);
+    expect(sessionEvents.map((event) => event.id)).toEqual(['turn-1-final', 'turn-1-complete']);
     expect(observed.length).toBe(1);
 
     const [run] = await runStore.listSessionRuns(session.id);
@@ -467,6 +467,7 @@ describe('SessionManager permission mode updates', () => {
     expect(result.sessionId).toBe(session.id);
     expect(result.turnId).toBe('turn-1');
     expect(result.status).toBe('completed');
+    expect(result.finalOutput).toBe('ok');
     expect(result.events.map((event) => event.runId)).toEqual([run.runId, run.runId, run.runId]);
     expect(result.events.map((event) => event.sessionId)).toEqual([session.id, session.id, session.id]);
     expect(result.events.map((event) => event.turnId)).toEqual(['turn-1', 'turn-1', 'turn-1']);
@@ -5318,6 +5319,27 @@ class TestBackend implements AgentBackend {
     if (this.ctx.store instanceof MemorySessionStore) {
       this.ctx.store.disposeCount += 1;
     }
+  }
+}
+
+class FinalTextTestBackend extends TestBackend {
+  override async *send(input: BackendSendInput): AsyncIterable<SessionEvent> {
+    this.sendInputs.push(input);
+    yield {
+      type: 'text_complete',
+      id: `${input.turnId}-final`,
+      turnId: input.turnId,
+      ts: 1,
+      messageId: `${input.turnId}-m`,
+      text: 'ok',
+    };
+    yield {
+      type: 'complete',
+      id: `${input.turnId}-complete`,
+      turnId: input.turnId,
+      ts: 2,
+      stopReason: 'end_turn',
+    };
   }
 }
 

--- a/packages/runtime/src/invocation-context.ts
+++ b/packages/runtime/src/invocation-context.ts
@@ -175,6 +175,8 @@ export interface InvocationResult {
   sessionId: string;
   turnId: string;
   status: InvocationResultStatus;
+  /** Last non-partial model text from a successfully completed invocation. */
+  finalOutput?: string;
   /** Every RuntimeEvent collected, in emission order (user event first). */
   events: RuntimeEvent[];
   /** Present when status === 'failed'. */

--- a/packages/runtime/src/runtime-runner.ts
+++ b/packages/runtime/src/runtime-runner.ts
@@ -255,7 +255,15 @@ export class RuntimeRunner {
       };
     }
 
-    const status: InvocationResultStatus = failure ? 'failed' : 'completed';
+    let status: InvocationResultStatus = failure ? 'failed' : 'completed';
+    const finalOutput = status === 'completed' ? finalOutputFromEvents(events) : undefined;
+    if (status === 'completed' && finalOutput === undefined) {
+      status = 'failed';
+      failure = {
+        class: 'missing_final_output',
+        message: 'completed invocation produced no non-empty final model text',
+      };
+    }
     return this.buildResult({
       request,
       invocationId,
@@ -264,6 +272,7 @@ export class RuntimeRunner {
       finishedAt: this.providers.now(),
       status,
       events,
+      ...(finalOutput !== undefined ? { finalOutput } : {}),
       ...(failure ? { failure } : {}),
     });
   }
@@ -276,6 +285,7 @@ export class RuntimeRunner {
     finishedAt: number;
     status: InvocationResultStatus;
     events: RuntimeEvent[];
+    finalOutput?: string;
     failure?: InvocationFailure;
   }): InvocationResult {
     return {
@@ -284,12 +294,28 @@ export class RuntimeRunner {
       sessionId: args.request.sessionId,
       turnId: args.request.turnId,
       status: args.status,
+      ...(args.finalOutput !== undefined ? { finalOutput: args.finalOutput } : {}),
       events: args.events,
       ...(args.failure ? { failure: args.failure } : {}),
       startedAt: args.startedAt,
       finishedAt: args.finishedAt,
     };
   }
+}
+
+function finalOutputFromEvents(events: readonly RuntimeEvent[]): string | undefined {
+  for (let index = events.length - 1; index >= 0; index -= 1) {
+    const event = events[index]!;
+    if (
+      event.role === 'model'
+      && event.partial !== true
+      && event.content?.kind === 'text'
+      && event.content.text.trim().length > 0
+    ) {
+      return event.content.text;
+    }
+  }
+  return undefined;
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary

- add `maka run [PROMPT]` and the exact `maka -p` alias with positional/stdin input handling
- expose strict `InvocationResult.finalOutput` semantics and fail completed invocations with no final model text
- enforce fail-closed permission prompts, canonical cwd, per-invocation timeout/max-step limits, signals, and stable exit codes
- cover argv, stdin, stdout/stderr, permissions, timeout, SIGINT, and runtime result behavior at process/runtime seams

Part of #730 (Slice 2).

## Testing

- `npm --workspace maka-agent test` (268 passed)
- `npm --workspace @maka/runtime test` (1278 passed, 2 skipped)
- `npm --workspace @maka/headless test` (794 passed, 1 skipped)
- workspace typechecks; UI build followed by desktop typecheck
- `git diff --check`