### PR TITLE
feat(cli): add non-interactive permission controls

### DIFF
--- a/packages/cli/src/__tests__/run-command-fixture.ts
+++ b/packages/cli/src/__tests__/run-command-fixture.ts
@@ -42,7 +42,13 @@ const summary = {
 } satisfies SessionSummary;
 
 const runtime: MakaRunRuntime = {
-  async createSession() {
+  async createSession(input) {
+    if (
+      process.env.MAKA_RUN_EXPECT_PERMISSION_MODE
+      && input.permissionMode !== process.env.MAKA_RUN_EXPECT_PERMISSION_MODE
+    ) {
+      throw new Error(`unexpected permissionMode ${input.permissionMode}`);
+    }
     return summary;
   },
   async *sendMessage(_sessionId, input): AsyncIterable<SessionEvent> {
@@ -97,6 +103,12 @@ async function createContext(input: CreateMakaCliRuntimeContextInput): Promise<M
     && input.maxSteps !== Number(process.env.MAKA_RUN_EXPECT_MAX_STEPS)
   ) {
     throw new Error(`unexpected maxSteps ${String(input.maxSteps)}`);
+  }
+  if (process.env.MAKA_RUN_EXPECT_PERMISSION_RULES) {
+    const actual = JSON.stringify(input.permissionRules ?? []);
+    if (actual !== process.env.MAKA_RUN_EXPECT_PERMISSION_RULES) {
+      throw new Error(`unexpected permissionRules ${actual}`);
+    }
   }
   observer = input.runtimeInvocationObserver;
   return { runtime, target, close: async () => {} };

--- a/packages/cli/src/__tests__/run-command.test.ts
+++ b/packages/cli/src/__tests__/run-command.test.ts
@@ -40,6 +40,35 @@ describe('maka run argument parsing', () => {
     assert.equal(parseMakaRunArgs(['x', '--timeout', '0']).kind, 'error');
     assert.equal(parseMakaRunArgs(['x', '--max-steps', '1.5']).kind, 'error');
   });
+
+  test('parses a non-interactive permission mode and repeatable exact rules', () => {
+    assert.deepEqual(parseMakaRunArgs([
+      'run tools',
+      '--permission-mode', 'execute',
+      '--allow', 'category:file_write',
+      '--deny', 'Bash(npm  test)',
+      '--allow', 'Bash(npm test)',
+    ]), {
+      kind: 'run',
+      options: {
+        prompt: 'run tools',
+        stdinPrompt: false,
+        permissionMode: 'execute',
+        permissionRules: [
+          { effect: 'allow', kind: 'category', category: 'file_write' },
+          { effect: 'deny', kind: 'bash_exact', command: 'npm  test' },
+          { effect: 'allow', kind: 'bash_exact', command: 'npm test' },
+        ],
+      },
+    });
+  });
+
+  test('rejects interactive ask mode and malformed permission rules', () => {
+    assert.equal(parseMakaRunArgs(['x', '--permission-mode', 'ask']).kind, 'error');
+    assert.equal(parseMakaRunArgs(['x', '--allow', 'category:not-real']).kind, 'error');
+    assert.equal(parseMakaRunArgs(['x', '--deny', 'Bash()']).kind, 'error');
+    assert.equal(parseMakaRunArgs(['x', '--allow', 'Write(*)']).kind, 'error');
+  });
 });
 
 describe('maka run process contract', () => {
@@ -103,6 +132,35 @@ describe('maka run process contract', () => {
     });
     assert.equal(result.code, 0, result.stderr);
     assert.match(result.stdout, /^maxSteps=3;/);
+  });
+
+  test('passes permission mode and rules only to this invocation', async () => {
+    const permissionRules = [
+      { effect: 'deny', kind: 'category', category: 'read' },
+      { effect: 'allow', kind: 'bash_exact', command: 'npm test' },
+    ];
+    const result = await runFixture([
+      'hello',
+      '--permission-mode', 'bypass',
+      '--deny', 'category:read',
+      '--allow', 'Bash(npm test)',
+    ], {
+      input: '',
+      env: {
+        MAKA_RUN_EXPECT_PERMISSION_MODE: 'bypass',
+        MAKA_RUN_EXPECT_PERMISSION_RULES: JSON.stringify(permissionRules),
+      },
+    });
+
+    assert.equal(result.code, 0, result.stderr);
+    assert.equal(result.stdout, 'prompt=hello\n');
+  });
+
+  test('returns exit 2 for ask mode before runtime startup', async () => {
+    const result = await runFixture(['hello', '--permission-mode', 'ask'], { input: '' });
+    assert.equal(result.code, 2);
+    assert.match(result.stderr, /permission-mode must be explore, execute, or bypass/);
+    assert.equal(result.stdout, '');
   });
 
   test('returns exit 1 when the invocation timeout stops the run', async () => {

--- a/packages/cli/src/__tests__/runtime-bootstrap.test.ts
+++ b/packages/cli/src/__tests__/runtime-bootstrap.test.ts
@@ -64,6 +64,9 @@ describe('Maka CLI runtime bootstrap', () => {
       });
       const observed: unknown[] = [];
       const observer = (result: unknown): void => { observed.push(result); };
+      const permissionRules = [
+        { effect: 'deny', kind: 'category', category: 'read' },
+      ] as const;
 
       const context = await createMakaCliRuntimeContext({
         workspaceRoot,
@@ -71,6 +74,7 @@ describe('Maka CLI runtime bootstrap', () => {
         requestedConnectionSlug: 'selected-local',
         requestedModel: 'requested-model',
         maxSteps: 3,
+        permissionRules,
         runtimeInvocationObserver: observer,
       });
       try {
@@ -95,6 +99,7 @@ describe('Maka CLI runtime bootstrap', () => {
         const backendInput = (backend as unknown as { input: AiSdkBackendInput }).input;
 
         assert.equal(backendInput.maxSteps, 3);
+        assert.equal(backendInput.permissionRules, permissionRules);
         assert.equal(runtimeDeps.runtimeInvocationObserver, observer);
         assert.deepEqual(observed, []);
       } finally {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -13,6 +13,7 @@ export {
   runMakaTextCli,
   type MakaRunDeps,
   type MakaRunOptions,
+  type NonInteractivePermissionMode,
   type ParseMakaRunArgsResult,
 } from './run-command.js';
 export {

--- a/packages/cli/src/run-command.ts
+++ b/packages/cli/src/run-command.ts
@@ -3,6 +3,11 @@ import { realpath, stat } from 'node:fs/promises';
 import { resolve } from 'node:path';
 import type { SessionEvent } from '@maka/core/events';
 import { isThinkingLevel, type ThinkingLevel } from '@maka/core/model-thinking';
+import {
+  isToolCategory,
+  type PermissionMode,
+  type ToolPermissionRule,
+} from '@maka/core/permission';
 import type { CreateSessionInput, UserMessageInput } from '@maka/core/runtime-inputs';
 import type { SessionSummary } from '@maka/core/session';
 import type { InvocationResult } from '@maka/runtime';
@@ -13,6 +18,8 @@ import {
 import type { ReadySessionTarget } from './connection-target.js';
 import { resolveMakaWorkspaceRoot } from './workspace-root.js';
 
+export type NonInteractivePermissionMode = Exclude<PermissionMode, 'ask'>;
+
 export interface MakaRunOptions {
   prompt?: string;
   stdinPrompt: boolean;
@@ -22,6 +29,8 @@ export interface MakaRunOptions {
   thinking?: ThinkingLevel;
   timeoutMs?: number;
   maxSteps?: number;
+  permissionMode?: NonInteractivePermissionMode;
+  permissionRules?: ToolPermissionRule[];
 }
 
 export type ParseMakaRunArgsResult =
@@ -66,11 +75,17 @@ const VALUE_FLAGS = new Set([
   'thinking',
   'timeout',
   'max-steps',
+  'permission-mode',
+  'allow',
+  'deny',
 ]);
+
+const REPEATABLE_VALUE_FLAGS = new Set(['allow', 'deny']);
 
 export function parseMakaRunArgs(argv: readonly string[]): ParseMakaRunArgsResult {
   const positional: string[] = [];
   const flags = new Map<string, string>();
+  const permissionRuleFlags: Array<{ effect: 'allow' | 'deny'; value: string }> = [];
   let literal = false;
   for (let index = 0; index < argv.length; index += 1) {
     const arg = argv[index]!;
@@ -82,12 +97,18 @@ export function parseMakaRunArgs(argv: readonly string[]): ParseMakaRunArgsResul
     if (!literal && arg.startsWith('--')) {
       const name = arg.slice(2);
       if (!VALUE_FLAGS.has(name)) return { kind: 'error', message: `unknown option: ${arg}` };
-      if (flags.has(name)) return { kind: 'error', message: `option repeated: ${arg}` };
+      if (!REPEATABLE_VALUE_FLAGS.has(name) && flags.has(name)) {
+        return { kind: 'error', message: `option repeated: ${arg}` };
+      }
       const value = argv[index + 1];
       if (value === undefined || value.startsWith('--')) {
         return { kind: 'error', message: `option ${arg} needs a value` };
       }
-      flags.set(name, value);
+      if (REPEATABLE_VALUE_FLAGS.has(name)) {
+        permissionRuleFlags.push({ effect: name as 'allow' | 'deny', value });
+      } else {
+        flags.set(name, value);
+      }
       index += 1;
       continue;
     }
@@ -104,6 +125,7 @@ export function parseMakaRunArgs(argv: readonly string[]): ParseMakaRunArgsResul
   const timeout = flags.get('timeout');
   const maxSteps = flags.get('max-steps');
   const thinking = flags.get('thinking');
+  const permissionMode = flags.get('permission-mode');
   const timeoutSeconds = timeout === undefined ? undefined : Number(timeout);
   if (timeoutSeconds !== undefined && (!Number.isFinite(timeoutSeconds) || timeoutSeconds <= 0)) {
     return { kind: 'error', message: '--timeout must be a positive number of seconds' };
@@ -114,6 +136,23 @@ export function parseMakaRunArgs(argv: readonly string[]): ParseMakaRunArgsResul
   }
   if (thinking !== undefined && thinking !== 'default' && !isThinkingLevel(thinking)) {
     return { kind: 'error', message: `unknown thinking level: ${thinking}` };
+  }
+  if (
+    permissionMode !== undefined
+    && permissionMode !== 'explore'
+    && permissionMode !== 'execute'
+    && permissionMode !== 'bypass'
+  ) {
+    return {
+      kind: 'error',
+      message: '--permission-mode must be explore, execute, or bypass',
+    };
+  }
+  const permissionRules: ToolPermissionRule[] = [];
+  for (const { effect, value } of permissionRuleFlags) {
+    const rule = parseToolPermissionRule(value, effect);
+    if (!rule.ok) return { kind: 'error', message: rule.message };
+    permissionRules.push(rule.value);
   }
 
   return {
@@ -127,6 +166,8 @@ export function parseMakaRunArgs(argv: readonly string[]): ParseMakaRunArgsResul
       ...(thinking !== undefined && thinking !== 'default' ? { thinking } : {}),
       ...(timeoutSeconds !== undefined ? { timeoutMs: Math.ceil(timeoutSeconds * 1_000) } : {}),
       ...(parsedMaxSteps !== undefined ? { maxSteps: parsedMaxSteps } : {}),
+      ...(permissionMode !== undefined ? { permissionMode } : {}),
+      ...(permissionRules.length > 0 ? { permissionRules } : {}),
     },
   };
 }
@@ -165,6 +206,9 @@ export async function runMakaTextCli(
       ...(parsed.options.connection ? { requestedConnectionSlug: parsed.options.connection } : {}),
       ...(parsed.options.model ? { requestedModel: parsed.options.model } : {}),
       ...(parsed.options.maxSteps !== undefined ? { maxSteps: parsed.options.maxSteps } : {}),
+      ...(parsed.options.permissionRules !== undefined
+        ? { permissionRules: parsed.options.permissionRules }
+        : {}),
       runtimeInvocationObserver: (result) => {
         invocation = result;
       },
@@ -182,7 +226,7 @@ export async function runMakaTextCli(
       backend: 'ai-sdk',
       llmConnectionSlug: context.target.connection.slug,
       model: context.target.model,
-      permissionMode: 'explore',
+      permissionMode: parsed.options.permissionMode ?? 'explore',
       ...(parsed.options.thinking !== undefined ? { thinkingLevel: parsed.options.thinking } : {}),
     });
   } catch (error) {
@@ -289,8 +333,35 @@ function makaRunHelpText(): string {
     '  --thinking <level>        off|minimal|low|medium|high|xhigh|max|default',
     '  --timeout <seconds>       Invocation timeout',
     '  --max-steps <count>       Tool-step cap',
+    '  --permission-mode <mode>  explore|execute|bypass (default: explore)',
+    '  --allow <rule>            Repeatable category:<name> or Bash(<exact command>)',
+    '  --deny <rule>             Repeatable category:<name> or Bash(<exact command>)',
     '  -h, --help                Show help',
   ].join('\n');
+}
+
+function parseToolPermissionRule(
+  input: string,
+  effect: 'allow' | 'deny',
+): { ok: true; value: ToolPermissionRule } | { ok: false; message: string } {
+  if (input.startsWith('category:')) {
+    const category = input.slice('category:'.length);
+    if (!isToolCategory(category)) {
+      return { ok: false, message: `invalid --${effect} category rule: ${input}` };
+    }
+    return { ok: true, value: { effect, kind: 'category', category } };
+  }
+  if (input.startsWith('Bash(') && input.endsWith(')')) {
+    const command = input.slice('Bash('.length, -1);
+    if (command.length === 0) {
+      return { ok: false, message: `invalid --${effect} Bash rule: command is empty` };
+    }
+    return { ok: true, value: { effect, kind: 'bash_exact', command } };
+  }
+  return {
+    ok: false,
+    message: `invalid --${effect} rule: expected category:<name> or Bash(<exact command>)`,
+  };
 }
 
 function defaultMakaRunDeps(): MakaRunDeps {

--- a/packages/cli/src/runtime-bootstrap.ts
+++ b/packages/cli/src/runtime-bootstrap.ts
@@ -38,6 +38,7 @@ import {
   createShellRunStore,
 } from '@maka/storage';
 import type { ToolResultContent } from '@maka/core/events';
+import type { ToolPermissionRule } from '@maka/core/permission';
 import type { ModelChoice, ReadySessionTarget } from './connection-target.js';
 import { listReadyModelChoices, resolveDefaultSessionTarget, resolveSessionTargetForSlug } from './connection-target.js';
 import { buildCliSystemPrompt, buildCliTurnTailPrompt } from './cli-system-prompt.js';
@@ -68,6 +69,7 @@ export interface CreateMakaCliRuntimeContextInput {
   requestedConnectionSlug?: string;
   requestedModel?: string;
   maxSteps?: number;
+  permissionRules?: readonly ToolPermissionRule[];
   runtimeInvocationObserver?: (result: InvocationResult) => void | Promise<void>;
   /**
    * Optional cron executor. When provided, the Automation tool advertises the
@@ -237,6 +239,7 @@ export async function createMakaCliRuntimeContext(
       newId: randomUUID,
       now: Date.now,
       ...(input.maxSteps !== undefined ? { maxSteps: input.maxSteps } : {}),
+      ...(input.permissionRules !== undefined ? { permissionRules: input.permissionRules } : {}),
     });
   });
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -192,6 +192,8 @@ export type {
   PreToolUseResult,
   PermissionRequest,
   PermissionResponse,
+  ToolPermissionRule,
+  ToolPermissionRuleMatchInput,
 } from './permission.js';
 export {
   PERMISSION_MODES,
@@ -203,8 +205,10 @@ export {
   FS_DESTRUCTIVE_PATTERNS,
   DESTRUCTIVE_GIT_PATTERNS,
   categorizeBash,
+  classifyToolUse,
   isPermissionMode,
   isToolCategory,
+  matchToolPermissionRules,
   preToolUse,
 } from './permission.js';
 

--- a/packages/core/src/permission.ts
+++ b/packages/core/src/permission.ts
@@ -55,6 +55,47 @@ export function isToolCategory(value: unknown): value is ToolCategory {
   return typeof value === 'string' && (TOOL_CATEGORIES as readonly string[]).includes(value);
 }
 
+export type ToolPermissionRule =
+  | {
+      effect: 'allow' | 'deny';
+      kind: 'category';
+      category: ToolCategory;
+    }
+  | {
+      effect: 'allow' | 'deny';
+      kind: 'bash_exact';
+      command: string;
+    };
+
+export interface ToolPermissionRuleMatchInput {
+  toolName: string;
+  args: unknown;
+  category: ToolCategory;
+  rules: readonly ToolPermissionRule[];
+}
+
+/** Explicit deny rules always win over explicit allow rules, regardless of argv order. */
+export function matchToolPermissionRules(
+  input: ToolPermissionRuleMatchInput,
+): 'allow' | 'deny' | undefined {
+  if (input.rules.some((rule) => rule.effect === 'deny' && toolPermissionRuleMatches(rule, input))) {
+    return 'deny';
+  }
+  if (input.rules.some((rule) => rule.effect === 'allow' && toolPermissionRuleMatches(rule, input))) {
+    return 'allow';
+  }
+  return undefined;
+}
+
+function toolPermissionRuleMatches(
+  rule: ToolPermissionRule,
+  input: Omit<ToolPermissionRuleMatchInput, 'rules'>,
+): boolean {
+  if (rule.kind === 'category') return rule.category === input.category;
+  const command = (input.args as { command?: unknown } | null)?.command;
+  return input.toolName === 'Bash' && typeof command === 'string' && command === rule.command;
+}
+
 // ============================================================================
 // Tool execution environment facts
 // ============================================================================
@@ -440,15 +481,22 @@ export interface PreToolUseResult {
   blockReason?: string;
 }
 
-export function preToolUse(input: PreToolUseInput): PreToolUseResult {
-  // (1) Classify
+export function classifyToolUse(input: {
+  toolName: string;
+  args: unknown;
+  categoryHint?: ToolCategory;
+}): ToolCategory {
   let category: ToolCategory = input.categoryHint ?? BUILTIN_TOOL_CATEGORY[input.toolName] ?? 'custom_tool';
   if (category === 'shell_unsafe') {
-    const cmd = (input.args as { command?: unknown })?.command;
-    if (typeof cmd === 'string') {
-      category = categorizeBash(cmd);
-    }
+    const cmd = (input.args as { command?: unknown } | null)?.command;
+    if (typeof cmd === 'string') category = categorizeBash(cmd);
   }
+  return category;
+}
+
+export function preToolUse(input: PreToolUseInput): PreToolUseResult {
+  // (1) Classify
+  const category = classifyToolUse(input);
 
   // (2) Policy lookup + turn-remembered check
   const decision = PERMISSION_POLICY[input.mode][category];

--- a/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
+++ b/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
@@ -5229,6 +5229,62 @@ describe('AiSdkBackend tool permission category hints', () => {
     assert.equal(JSON.stringify(telemetry).includes('correct-horse-battery-staple'), false);
   });
 
+  test('an invocation deny rule blocks a permission-free tool and emits an auditable denial', async () => {
+    const messages: unknown[] = [];
+    const events: SessionEvent[] = [];
+    let implCalled = false;
+    const backend = new AiSdkBackend({
+      sessionId: 'session-1',
+      header: header('bypass'),
+      appendMessage: async (message) => { messages.push(message); },
+      connection: connection(),
+      apiKey: 'sk-test',
+      modelId: 'claude-sonnet-4-5-20250929',
+      permissionEngine: new PermissionEngine({ newId: idGenerator(), now: () => 1 }),
+      permissionRules: [{ effect: 'deny', kind: 'category', category: 'read' }],
+      modelFactory: () => ({}),
+      tools: [],
+      newId: idGenerator(),
+      now: monotonicClock(),
+    });
+    const tool: MakaTool = {
+      name: 'Read',
+      description: 'read file',
+      parameters: {},
+      permissionRequired: false,
+      impl: async () => {
+        implCalled = true;
+        return { kind: 'text', text: 'should not run' };
+      },
+    };
+    const execute = (backend as unknown as {
+      wrapToolExecute(
+        tool: MakaTool,
+        turnId: string,
+        queue: { push(event: SessionEvent): void },
+      ): (args: unknown, ctx: { toolCallId: string; abortSignal: AbortSignal }) => Promise<unknown>;
+    }).wrapToolExecute(tool, 'turn-1', { push: (event) => events.push(event) });
+
+    await execute(
+      { path: 'notes.md' },
+      { toolCallId: 'tool-1', abortSignal: new AbortController().signal },
+    );
+
+    assert.equal(implCalled, false);
+    assert.deepEqual(messages.map((message) => (message as { type?: string }).type), [
+      'tool_call',
+      'permission_decision',
+      'tool_result',
+    ]);
+    assert.deepEqual(events.map((event) => event.type), [
+      'tool_start',
+      'permission_decision_ack',
+      'tool_result',
+    ]);
+    const decision = events.find((event) => event.type === 'permission_decision_ack');
+    assert.equal(decision?.decision, 'deny');
+  });
+
   test('permission prompt timeout expires one request, resumes watchdog, and writes an error result', async () => {
     const messages: unknown[] = [];
     const events: SessionEvent[] = [];

--- a/packages/runtime/src/__tests__/permission-engine.test.ts
+++ b/packages/runtime/src/__tests__/permission-engine.test.ts
@@ -92,6 +92,89 @@ describe('PermissionEngine.evaluate — allow path', () => {
 
 });
 
+describe('PermissionEngine.evaluate — invocation-local rules', () => {
+  test('explicit deny wins over allow and applies to permission-free tools in bypass mode', () => {
+    const { engine } = makeEngine();
+    engine.beginTurn('t1');
+    const result = engine.evaluate({
+      sessionId: 's1',
+      turnId: 't1',
+      toolUseId: 'tu1',
+      toolName: 'Read',
+      args: { path: '/repo/file.ts' },
+      mode: 'bypass',
+      permissionRequired: false,
+      permissionRules: [
+        { effect: 'allow', kind: 'category', category: 'read' },
+        { effect: 'deny', kind: 'category', category: 'read' },
+      ],
+    });
+
+    assert.equal(result.kind, 'block');
+    if (result.kind !== 'block') return;
+    assert.equal(result.category, 'read');
+    assert.equal(result.decisionEvent?.decision, 'deny');
+    assert.equal(result.decisionEvent?.toolUseId, 'tu1');
+  });
+
+  test('explicit category allow overrides the explore policy block', () => {
+    const { engine } = makeEngine();
+    const result = engine.evaluate({
+      sessionId: 's1',
+      turnId: 't1',
+      toolUseId: 'tu1',
+      toolName: 'Write',
+      args: { path: '/repo/file.ts' },
+      mode: 'explore',
+      permissionRules: [{ effect: 'allow', kind: 'category', category: 'file_write' }],
+    });
+
+    assert.equal(result.kind, 'allow');
+  });
+
+  test('Bash rules use exact command equality without whitespace rewriting', () => {
+    const rules = [{ effect: 'allow', kind: 'bash_exact', command: 'npm  test' }] as const;
+    const { engine } = makeEngine();
+    const exact = engine.evaluate({
+      sessionId: 's1',
+      turnId: 't1',
+      toolUseId: 'tu1',
+      toolName: 'Bash',
+      args: { command: 'npm  test' },
+      mode: 'explore',
+      permissionRules: rules,
+    });
+    const normalized = engine.evaluate({
+      sessionId: 's1',
+      turnId: 't1',
+      toolUseId: 'tu2',
+      toolName: 'Bash',
+      args: { command: 'npm test' },
+      mode: 'explore',
+      permissionRules: rules,
+    });
+
+    assert.equal(exact.kind, 'allow');
+    assert.equal(normalized.kind, 'block');
+  });
+
+  test('an unrelated rule preserves the permission-free tool fast path', () => {
+    const { engine } = makeEngine();
+    const result = engine.evaluate({
+      sessionId: 's1',
+      turnId: 't1',
+      toolUseId: 'tu1',
+      toolName: 'Read',
+      args: { path: '/repo/file.ts' },
+      mode: 'explore',
+      permissionRequired: false,
+      permissionRules: [{ effect: 'deny', kind: 'category', category: 'file_write' }],
+    });
+
+    assert.equal(result.kind, 'allow');
+  });
+});
+
 describe('PermissionEngine.evaluate — block path', () => {
   test('block in explore mode', () => {
     const { engine } = makeEngine();

--- a/packages/runtime/src/ai-sdk-backend.ts
+++ b/packages/runtime/src/ai-sdk-backend.ts
@@ -65,6 +65,7 @@ import type {
 import type { AgentSpec } from '@maka/core/runtime-inputs';
 import type { LlmConnection } from '@maka/core/llm-connections';
 import type { RuntimeEvent } from '@maka/core/runtime-event';
+import type { ToolPermissionRule } from '@maka/core/permission';
 import type {
   LlmCallRecord,
   PricingConfig,
@@ -443,6 +444,8 @@ export interface AiSdkBackendInput {
   streamIdleTimeoutMs?: number;
   /** Timeout for a renderer/user permission decision. Default 300s. */
   permissionTimeoutMs?: number;
+  /** Invocation-local allow/deny rules evaluated before the session mode. */
+  permissionRules?: readonly ToolPermissionRule[];
   /** Optional system prompt (skills + workspace AGENTS.md merged upstream). */
   systemPrompt?: string | ((context: SystemPromptContext) => string | undefined | Promise<string | undefined>);
   /** Optional provider-visible current-turn tail kept out of the durable system prefix. */
@@ -595,6 +598,7 @@ export class AiSdkBackend implements AgentBackend {
       getPermissionPauseTarget: () => this.currentWatchdog,
       getCurrentRunId: () => this.currentRunId ?? undefined,
       getCurrentStepId: () => this.currentStepMessageId ?? undefined,
+      permissionRules: input.permissionRules,
       spawnChildAgent: input.spawnChildAgent,
       listChildAgents: input.listChildAgents,
       readChildAgentOutput: input.readChildAgentOutput,

--- a/packages/runtime/src/permission-engine.ts
+++ b/packages/runtime/src/permission-engine.ts
@@ -23,6 +23,8 @@
  */
 
 import {
+  classifyToolUse,
+  matchToolPermissionRules,
   preToolUse,
   type PermissionMode,
   type PermissionRequest,
@@ -30,8 +32,9 @@ import {
   type PreToolUseResult,
   type ToolCategory,
   type ToolExecutionFacts,
+  type ToolPermissionRule,
 } from '@maka/core/permission';
-import type { PermissionRequestEvent } from '@maka/core/events';
+import type { PermissionDecisionAckEvent, PermissionRequestEvent } from '@maka/core/events';
 
 // ============================================================================
 // Per-turn state
@@ -60,7 +63,13 @@ interface ParkedRequest {
 
 export type EvaluateResult =
   | { kind: 'allow'; category: ToolCategory }
-  | { kind: 'block'; category: ToolCategory; reason: string }
+  | {
+      kind: 'block';
+      category: ToolCategory;
+      reason: string;
+      /** Present for an invocation-local explicit deny so observers record a failed invocation. */
+      decisionEvent?: PermissionDecisionAckEvent;
+    }
   | {
       kind: 'prompt';
       category: ToolCategory;
@@ -85,6 +94,10 @@ export interface EvaluateInput {
   hint?: string;
   /** Optional trusted facts about the executor that would run this tool. */
   executionFacts?: ToolExecutionFacts;
+  /** Whether the tool participates in the base mode policy when no explicit rule matches. */
+  permissionRequired?: boolean;
+  /** Invocation-local rules. Explicit deny wins over allow, then base mode applies. */
+  permissionRules?: readonly ToolPermissionRule[];
 }
 
 // ============================================================================
@@ -129,6 +142,39 @@ export class PermissionEngine {
    */
   evaluate(input: EvaluateInput): EvaluateResult {
     const state = this.requireTurn(input.turnId);
+
+    const category = classifyToolUse({
+      toolName: input.toolName,
+      args: input.args,
+      ...(input.categoryHint !== undefined ? { categoryHint: input.categoryHint } : {}),
+    });
+    const ruleDecision = matchToolPermissionRules({
+      toolName: input.toolName,
+      args: input.args,
+      category,
+      rules: input.permissionRules ?? [],
+    });
+    if (ruleDecision === 'allow') return { kind: 'allow', category };
+    if (ruleDecision === 'deny') {
+      const requestId = this.deps.newId();
+      return {
+        kind: 'block',
+        category,
+        reason: `Tool ${input.toolName} was denied by an invocation permission rule`,
+        decisionEvent: {
+          type: 'permission_decision_ack',
+          id: this.deps.newId(),
+          turnId: input.turnId,
+          ts: this.deps.now(),
+          requestId,
+          toolUseId: input.toolUseId,
+          decision: 'deny',
+        },
+      };
+    }
+    if (ruleDecision === undefined && input.permissionRequired === false) {
+      return { kind: 'allow', category };
+    }
 
     const pre: PreToolUseResult = preToolUse({
       toolName: input.toolName,

--- a/packages/runtime/src/tool-runtime.ts
+++ b/packages/runtime/src/tool-runtime.ts
@@ -13,7 +13,7 @@ import type {
 } from '@maka/core/session';
 import type { PermissionDecision } from '@maka/core/backend-types';
 import type { AgentSpec } from '@maka/core/runtime-inputs';
-import type { ToolCategory, ToolExecutionFacts } from '@maka/core/permission';
+import type { ToolCategory, ToolExecutionFacts, ToolPermissionRule } from '@maka/core/permission';
 import type { LlmConnection } from '@maka/core/llm-connections';
 import type { SessionHeader } from '@maka/core/session';
 import type { ToolInvocationRecord } from '@maka/core/usage-stats/types';
@@ -38,8 +38,8 @@ export interface MakaTool<P = any, R = unknown> {
   /** Zod schema describing the tool's argument shape. */
   parameters: unknown;
   /**
-   * If `false`, the wrap layer skips PermissionEngine.evaluate() entirely.
-   * Defaults to `true` (always go through the engine).
+   * If `false`, the base mode policy is skipped unless invocation-local rules
+   * are present. Explicit deny rules still apply to every tool.
    */
   permissionRequired?: boolean;
   /** Optional UI display name. */
@@ -132,6 +132,7 @@ export interface ToolRuntimeInput {
   readChildAgentOutput?: (input: { runId?: string; turnId?: string; maxEvents?: number }) => Promise<unknown>;
   getRunTrace?: () => RunTraceLike | null;
   permissionTimeoutMs?: number;
+  permissionRules?: readonly ToolPermissionRule[];
   recordToolInvocation?: ToolTelemetryRecorder;
   recordToolArtifacts?: ToolArtifactRecorder;
 }
@@ -330,7 +331,7 @@ export class ToolRuntime {
       return this.errorReturn(reason);
     }
 
-    if (tool.permissionRequired !== false) {
+    if (tool.permissionRequired !== false || (this.input.permissionRules?.length ?? 0) > 0) {
       const verdict = this.input.permissionEngine.evaluate({
         sessionId: this.input.sessionId,
         turnId,
@@ -339,10 +340,24 @@ export class ToolRuntime {
         args,
         ...(tool.categoryHint !== undefined ? { categoryHint: tool.categoryHint } : {}),
         ...(tool.executionFacts !== undefined ? { executionFacts: tool.executionFacts } : {}),
+        permissionRequired: tool.permissionRequired !== false,
+        ...(this.input.permissionRules !== undefined ? { permissionRules: this.input.permissionRules } : {}),
         mode: this.input.header.permissionMode,
       });
 
       if (verdict.kind === 'block') {
+        if (verdict.decisionEvent) {
+          await this.input.appendMessage({
+            type: 'permission_decision',
+            id: verdict.decisionEvent.requestId,
+            turnId,
+            ts: verdict.decisionEvent.ts,
+            toolUseId,
+            toolName: tool.name,
+            decision: 'deny',
+          });
+          queue.push(verdict.decisionEvent);
+        }
         trace?.emit('permission', 'permission_failed', 'Permission blocked tool execution', {
           toolUseId,
           toolName: tool.name,


### PR DESCRIPTION
## Summary

- add `--permission-mode explore|execute|bypass` to `maka run` / `maka -p` while keeping `explore` as the default and rejecting interactive `ask`
- add repeatable `--allow` / `--deny` rules for canonical `category:<name>` matches and exact `Bash(<command>)` matches
- evaluate explicit deny before allow and the base mode, including for bypass mode and tools that normally skip permission prompts
- keep rules invocation-local and emit auditable deny decisions so RuntimeRunner preserves the exit-1 permission failure contract

Part of #730 (Slice 3).

## Testing

- `npm --workspace @maka/core test` (802 passed)
- `npm --workspace @maka/runtime test` (1283 passed, 2 skipped)
- `npm --workspace maka-agent test` (272 passed)
- `npm --workspace @maka/headless test` (794 passed, 1 skipped)
- `npm run typecheck`
- `git diff --check upstream/main...HEAD`