### PR TITLE
fix(ui): tighten the composer's constant footprint (#740)

### DIFF
--- a/apps/desktop/src/main/__tests__/composer-constant-footprint-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/composer-constant-footprint-contract.test.ts
@@ -138,14 +138,11 @@ describe('PR-COMPOSER-CONSTANT-FOOTPRINT-0 contract (issue #740)', () => {
     assert.doesNotMatch(textareaLine!, /min-h-[a-z0-9]+/i, '.maka-composer-textarea className must not carry a Tailwind min-h-* utility (CSS min-height: var(--h-composer-min) is the single source)');
   });
 
-  it('send (icon-sm) and stop (sm) buttons share h-8/32px — toolbar height is stable across normal/streaming (no 4px chat-boundary jump)', async () => {
+  it('stop button uses an h-8 size (icon-sm or sm, 32px) — streaming toolbar height matches send (icon-sm/32px, locked by control-height-converge-contract), no 4px chat-boundary jump', async () => {
     const source = await readFile(COMPOSER_TSX, 'utf8');
-    const sendBlock = source.match(/<UiButton[\s\S]*?maka-composer-send-button[\s\S]*?<\/UiButton>/);
-    assert.ok(sendBlock, 'send button block not found');
-    assert.match(sendBlock[0], /size="icon-sm"/, 'send button must use size="icon-sm" (h-8/32px)');
     const stopBlock = source.match(/props\.streaming\s*\?\s*\(\s*<UiButton[\s\S]*?<\/UiButton>/);
     assert.ok(stopBlock, 'stop button block (streaming branch) not found');
-    assert.match(stopBlock[0], /size="(?:icon-sm|sm)"/, 'stop button must use size="icon-sm" or size="sm" (h-8/32px), NOT default md (h-9/36px) which jumps the chat boundary 4px when streaming swaps send→stop');
+    assert.match(stopBlock[0], /size="(?:icon-sm|sm)"/, 'stop button must use size="icon-sm" or size="sm" (h-8/32px), NOT default md (h-9/36px) which jumps the chat boundary 4px when streaming swaps send→stop; send is locked to 32px by control-height-converge-contract (.maka-composer-send-button height = --h-control-lg = 32px)');
   });
 
   it('negative cases: same-block duplicate, selector-list companion, compound .maka-composer.composer padding return, .maka-composer padding return, textarea min-h-* return, stop md return', () => {
@@ -172,6 +169,8 @@ describe('PR-COMPOSER-CONSTANT-FOOTPRINT-0 contract (issue #740)', () => {
     const tsxReturn = '          className="maka-composer-textarea min-h-11 resize-none"';
     assert.match(tsxReturn, /min-h-[a-z0-9]+/i, 'a returned textarea min-h-* utility must be caught');
     const stopMdReturn = 'props.streaming ? (\n  <UiButton\n    className="maka-button"\n    variant="default"\n    type="button"\n  >\n    停止\n  </UiButton>\n)';
-    assert.doesNotMatch(stopMdReturn, /size="(icon-sm|sm)"/, 'a stop button defaulting to md (no size) must be caught (h-9/36px ≠ send h-8/32px)');
+    const stopMdBlock = stopMdReturn.match(/props\.streaming\s*\?\s*\(\s*<UiButton[\s\S]*?<\/UiButton>/);
+    assert.ok(stopMdBlock, 'stop block extraction must work on the fixture');
+    assert.throws(() => assert.match(stopMdBlock[0]!, /size="(?:icon-sm|sm)"/), 'a stop button defaulting to md (no size) must be caught end-to-end (h-9/36px ≠ send h-8/32px)');
   });
 });

--- a/apps/desktop/src/main/__tests__/composer-constant-footprint-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/composer-constant-footprint-contract.test.ts
@@ -1,9 +1,7 @@
 /**
  * PR-COMPOSER-CONSTANT-FOOTPRINT-0 (issue #740):
  * lock the Composer's constant vertical footprint so the empty composer can't
- * drift back to the ~200px that ate a quarter of an 820px window — AND lock that
- * no state selector, no second DOM-class source, and no token override can
- * re-introduce an idle/active geometry switch.
+ * drift back to the ~200px that ate a quarter of an 820px window.
  *
  * The cut is static — no `[data-compact]` state machine, no idle/active mode.
  * The Composer is the highest-frequency surface and sits at the bottom of the
@@ -14,37 +12,33 @@
  * COMPOSER_MAX_HEIGHT in @maka/ui), so content-driven "expand" is the textarea's
  * own growth — no enter/leave transition, no reduced-motion special-casing.
  *
- * The <form> carries TWO class aliases — `.maka-composer` AND `.composer` — so
- * a "single source" claim must cover both: .composer owns the padding, and
- * .maka-composer must NOT re-add it. The textarea's min-height must come from
- * CSS (var(--h-composer-min)), not a Tailwind min-h-* utility that could win if
- * the CSS rule is removed.
+ * Stability is locked at two layers:
+ *   (a) FORM GEOMETRY — five rest levers pinned exactly-once, plus the <form>'s
+ *       second class .maka-composer must NOT re-add padding (single source).
+ *   (b) TOOLBAR GEOMETRY — the send button (size="icon-sm", h-8/32px) and the
+ *       stop button (size="sm", h-8/32px) share the same height, so swapping
+ *       send→stop on streaming does NOT change the toolbar height (a prior 4px
+ *       jump from stop defaulting to md/h-9 is now fixed).
  *
- * Six invariants pin the vertical budget (each measured against the 820px
- * window: composer outer 200px, inner 128px, textarea 56px):
+ * This contract does NOT attempt to lock "no state selector can ever change
+ * the footprint" via a property blacklist — CSS selectors are unbounded (compound
+ * aliases, pseudo-elements, display/border-width changes), so such a guard is
+ * fail-open and dishonest. #740's "no mode switch" is upheld by product code
+ * (no [data-compact] state is introduced) + the two stability layers above;
+ * a future state rule that re-introduces a footprint switch is a review
+ * responsibility, not a static-scan one.
  *
- *   1. --h-composer-min (textarea min-height) is 44px, not 56px.
- *   2. .composer vertical padding is var(--space-2) (8px) top + bottom; .maka-
- *      composer declares NO padding (single source for the form's two classes).
- *   3. .maka-composer-inner padding-block is var(--space-2)/var(--space-1-5)
- *      (8/6px) with a var(--space-1-5) (6px) gap, not 10/8px + 10px.
- *   4. .composerActions margin-top is var(--space-1) (4px), not 8px.
- *   5. .maka-composer-textarea min-height is var(--h-composer-min) (CSS), and
- *      its className carries no Tailwind min-h-* utility (TSX).
- *   6. No state selector on .composer / .maka-composer / .maka-composer-inner
- *      (state = :hover/:focus-within/[data-…], but NOT ::before/::after which
- *      are the streaming sweep pseudo-elements) declares any vertical-geometry
- *      property — padding* (shorthand + all physical/logical longhands), gap*,
- *      margin* (shorthand + longhands), height/block-size/max-* and min-*, or a
- *      local --h-composer-min override. This is the core #740 lock: an
- *      idle/active mode switch is impossible if no state selector can change
- *      the footprint. (State selectors may still change border/box-shadow/
- *      background/color/position/overflow — those don't affect the form height.)
- *
- * Combined invariants 1–5 drop an empty composer from ~200px to ~164px (≥18%).
- * Each lever is pinned exactly-once (a later rest block, a selector-list
- * companion, OR a same-block duplicate would all win the cascade) so a
- * regression is caught before it ships.
+ * Six invariants (820px window baseline: composer outer 200px, inner 128px,
+ * textarea 56px → 200/128/56 tightened to ~164/104/44):
+ *   1. --h-composer-min is 44px.
+ *   2. .composer padding is var(--space-2) var(--space-6) var(--space-2);
+ *      .maka-composer (the form's other class) declares NO padding.
+ *   3. .maka-composer-inner padding is var(--space-2) var(--space-3)
+ *      var(--space-1-5); gap is var(--space-1-5).
+ *   4. .composerActions margin-top is var(--space-1).
+ *   5. .maka-composer-textarea min-height is var(--h-composer-min) (CSS) and
+ *      its className carries no Tailwind min-h-* (TSX).
+ *   6. send + stop buttons both use an h-8 size (icon-sm or sm, 32px).
  */
 
 import { strict as assert } from 'node:assert';
@@ -74,49 +68,41 @@ function declarationsIn(body: string, prop: string): string[] {
   return [...body.matchAll(re)].map((m) => m[1].trim().replace(/\s+/g, ' '));
 }
 
-function restBlocks(css: string, subjectSelector: string): string[] {
+/** The subject of a selector — the last simple-selector sequence after any
+ *  combinator (descendant ` `, child `>`, sibling `+`/`~`). `.composer .inner`
+ *  → `.inner`; `.maka-composer.composer` → `.maka-composer.composer`. */
+function subjectOf(sel: string): string {
+  const parts = sel.split(/\s(?:[>+~]\s)?\s|\s/).filter(Boolean);
+  return parts[parts.length - 1] ?? sel;
+}
+
+/** Classes on the subject (`.foo.bar` → [`.foo`, `.bar`]). Hyphenated names
+ *  stay one class (`.maka-composer` ≠ `.maka` + `.composer`). */
+function subjectClasses(sel: string): string[] {
+  return [...subjectOf(sel).matchAll(/\.([\w-]+)/g)].map((m) => `.${m[1]}`);
+}
+
+/** Rest blocks whose subject carries `subjectClass` and has no state pseudo /
+ *  attribute. Matching by SUBJECT (not whole-selector equality) catches a
+ *  compound alias like `.maka-composer.composer { padding }` that a strict
+ *  `.composer` equality would miss, while excluding descendant selectors whose
+ *  subject is a different element (`.composer .maka-composer-inner`). */
+function restBlocks(css: string, subjectClass: string): string[] {
   const blocks: string[] = [];
   for (const [prelude, body] of styleRules(css)) {
     if (!prelude || prelude.startsWith('@')) continue;
     const selectors = prelude.split(',').map((s) => s.trim());
-    if (selectors.some((sel) => sel === subjectSelector && !/[:[]/.test(sel))) {
+    if (selectors.some((sel) => subjectClasses(sel).includes(subjectClass) && !/[:[]/.test(subjectOf(sel)))) {
       blocks.push(body);
     }
   }
   return blocks;
 }
 
-function assertExactlyOnce(css: string, selector: string, prop: string, expected: string, label: string): void {
-  const decls = restBlocks(css, selector).flatMap((b) => declarationsIn(b, prop));
-  assert.equal(decls.length, 1, `${label}: ${prop} must be declared exactly once (a later rest block, a selector-list companion, OR a same-block duplicate would all win the cascade); got ${decls.length}: ${JSON.stringify(decls)}`);
+function assertExactlyOnce(css: string, subjectClass: string, prop: string, expected: string, label: string): void {
+  const decls = restBlocks(css, subjectClass).flatMap((b) => declarationsIn(b, prop));
+  assert.equal(decls.length, 1, `${label}: ${prop} must be declared exactly once on a rest block whose subject carries ${subjectClass} (a later rest block, a selector-list companion, a compound alias, OR a same-block duplicate would all win the cascade); got ${decls.length}: ${JSON.stringify(decls)}`);
   assert.equal(decls[0], expected, `${label}: ${prop} must be ${expected}; got ${decls[0]}`);
-}
-
-/** State-selector blocks: any selector referencing .composer / .maka-composer /
- *  .maka-composer-inner WITH a state pseudo/attribute, but NOT ::before/::after
- *  (those are the streaming sweep pseudo-elements — their height/position is the
- *  sweep line, not the composer footprint). */
-function stateComposerBlocks(css: string): string[] {
-  const blocks: string[] = [];
-  for (const [prelude, body] of styleRules(css)) {
-    if (!prelude || prelude.startsWith('@')) continue;
-    const selectors = prelude.split(',').map((s) => s.trim());
-    if (selectors.some((sel) => /(^|\s)(?:\.maka-composer-inner|\.composer|\.maka-composer)(?![\w-])/.test(sel) && /[:[]/.test(sel) && !/::(?:before|after)/.test(sel))) {
-      blocks.push(body);
-    }
-  }
-  return blocks;
-}
-
-/** Any vertical-geometry property + a local --h-composer-min override.
- *  padding/gap/margin cover shorthand + all physical/logical longhands
- *  (padding-block-start/end, margin-block-start/end, …); height/block-size/
- *  max-* and min-* cover explicit box height; --h-composer-min covers a state rule
- *  locally overriding the token that drives textarea min-height. */
-const GEO_PROP_RE = /(?:^|[;\n])\s*(?:padding(?:-block(?:-start|-end)?|-inline(?:-start|-end)?|-top|-right|-bottom|-left)?|gap|row-gap|column-gap|margin(?:-block(?:-start|-end)?|-inline(?:-start|-end)?|-top|-right|-bottom|-left)?|height|block-size|max-height|max-block-size|min-height|min-block-size|--h-composer-min)\s*:/gi;
-
-function geoDeclarationsIn(body: string): string[] {
-  return [...body.matchAll(GEO_PROP_RE)].map((m) => m[0].trim().replace(/\s+/g, ' '));
 }
 
 describe('PR-COMPOSER-CONSTANT-FOOTPRINT-0 contract (issue #740)', () => {
@@ -125,17 +111,17 @@ describe('PR-COMPOSER-CONSTANT-FOOTPRINT-0 contract (issue #740)', () => {
     assertCustomPropPinnedOnce(tokens, '--h-composer-min', '44px', 'maka-tokens.css');
   });
 
-  it('.composer rest padding is var(--space-2) var(--space-6) var(--space-2) AND .maka-composer declares no padding (form carries both classes — single source)', async () => {
+  it('.composer rest padding is var(--space-2) var(--space-6) var(--space-2) AND .maka-composer (form alias) declares no padding (single source)', async () => {
     const css = stripCssComments(await readAllRendererCss());
     assertExactlyOnce(css, '.composer', 'padding', 'var(--space-2) var(--space-6) var(--space-2)', '.composer padding');
-    const makaComposerPadding = restBlocks(css, '.maka-composer').flatMap((b) => declarationsIn(b, 'padding'));
-    assert.equal(makaComposerPadding.length, 0, `.maka-composer must not declare padding (the <form> carries .maka-composer + .composer; .composer is the single padding source); got ${JSON.stringify(makaComposerPadding)}`);
+    const makaPadding = restBlocks(css, '.maka-composer').flatMap((b) => declarationsIn(b, 'padding'));
+    assert.equal(makaPadding.length, 0, `.maka-composer must not declare padding (the <form> carries .maka-composer + .composer; .composer is the single source); got ${JSON.stringify(makaPadding)}`);
   });
 
   it('.maka-composer-inner rest padding + gap are the constant footprint', async () => {
     const css = stripCssComments(await readAllRendererCss());
-    assertExactlyOnce(css, '.composer .maka-composer-inner', 'padding', 'var(--space-2) var(--space-3) var(--space-1-5)', '.maka-composer-inner padding');
-    assertExactlyOnce(css, '.composer .maka-composer-inner', 'gap', 'var(--space-1-5)', '.maka-composer-inner gap');
+    assertExactlyOnce(css, '.maka-composer-inner', 'padding', 'var(--space-2) var(--space-3) var(--space-1-5)', '.maka-composer-inner padding');
+    assertExactlyOnce(css, '.maka-composer-inner', 'gap', 'var(--space-1-5)', '.maka-composer-inner gap');
   });
 
   it('.composerActions rest margin-top is var(--space-1) (4px)', async () => {
@@ -145,20 +131,24 @@ describe('PR-COMPOSER-CONSTANT-FOOTPRINT-0 contract (issue #740)', () => {
 
   it('.maka-composer-textarea min-height is var(--h-composer-min) (CSS) AND its className carries no Tailwind min-h-* (TSX single source)', async () => {
     const css = stripCssComments(await readAllRendererCss());
-    assertExactlyOnce(css, '.composer .maka-composer-textarea', 'min-height', 'var(--h-composer-min)', '.maka-composer-textarea min-height');
+    assertExactlyOnce(css, '.maka-composer-textarea', 'min-height', 'var(--h-composer-min)', '.maka-composer-textarea min-height');
     const source = await readFile(COMPOSER_TSX, 'utf8');
     const textareaLine = source.split('\n').find((l) => l.includes('maka-composer-textarea'));
     assert.ok(textareaLine, 'maka-composer-textarea className line not found in composer.tsx');
     assert.doesNotMatch(textareaLine!, /min-h-[a-z0-9]+/i, '.maka-composer-textarea className must not carry a Tailwind min-h-* utility (CSS min-height: var(--h-composer-min) is the single source)');
   });
 
-  it('no state selector on .composer/.maka-composer/.maka-composer-inner changes vertical geometry or overrides --h-composer-min (no idle/active mode switch)', async () => {
-    const css = stripCssComments(await readAllRendererCss());
-    const geoDecls = stateComposerBlocks(css).flatMap((b) => geoDeclarationsIn(b));
-    assert.equal(geoDecls.length, 0, `state selectors on .composer/.maka-composer/.maka-composer-inner must not change vertical geometry or override --h-composer-min (no idle/active mode switch per #740); found: ${JSON.stringify(geoDecls)}`);
+  it('send (icon-sm) and stop (sm) buttons share h-8/32px — toolbar height is stable across normal/streaming (no 4px chat-boundary jump)', async () => {
+    const source = await readFile(COMPOSER_TSX, 'utf8');
+    const sendBlock = source.match(/<UiButton[\s\S]*?maka-composer-send-button[\s\S]*?<\/UiButton>/);
+    assert.ok(sendBlock, 'send button block not found');
+    assert.match(sendBlock[0], /size="icon-sm"/, 'send button must use size="icon-sm" (h-8/32px)');
+    const stopBlock = source.match(/props\.streaming\s*\?\s*\(\s*<UiButton[\s\S]*?<\/UiButton>/);
+    assert.ok(stopBlock, 'stop button block (streaming branch) not found');
+    assert.match(stopBlock[0], /size="(?:icon-sm|sm)"/, 'stop button must use size="icon-sm" or size="sm" (h-8/32px), NOT default md (h-9/36px) which jumps the chat boundary 4px when streaming swaps send→stop');
   });
 
-  it('negative cases: same-block duplicate, selector-list companion, state [data-compact] height + token override + ::before sweep exclusion, .maka-composer padding return, textarea min-h-* return', () => {
+  it('negative cases: same-block duplicate, selector-list companion, compound .maka-composer.composer padding return, .maka-composer padding return, textarea min-h-* return, stop md return', () => {
     const sameBlock = '.composer { padding: var(--space-2) var(--space-6) var(--space-2); padding: var(--space-3) var(--space-6) var(--space-4); }';
     assert.throws(
       () => assertExactlyOnce(sameBlock, '.composer', 'padding', 'var(--space-2) var(--space-6) var(--space-2)', '.composer padding'),
@@ -171,15 +161,17 @@ describe('PR-COMPOSER-CONSTANT-FOOTPRINT-0 contract (issue #740)', () => {
       /var\(--space-3\)/,
       'a selector-list companion setting padding must be caught',
     );
-    const stateHeight = '.composer[data-compact="true"] { height: 120px; }';
-    assert.equal(stateComposerBlocks(stateHeight).flatMap((b) => geoDeclarationsIn(b)).length, 1, 'a .composer[data-compact] height override must be flagged end-to-end');
-    const stateTokenOverride = '.composer[data-compact="true"] { --h-composer-min: 32px; }';
-    assert.equal(stateComposerBlocks(stateTokenOverride).flatMap((b) => geoDeclarationsIn(b)).length, 1, 'a .composer[data-compact] --h-composer-min override must be flagged (it drives textarea min-height)');
-    const sweep = '.maka-composer-inner[data-streaming="true"]::before { height: 1px; top: 0; }';
-    assert.equal(stateComposerBlocks(sweep).flatMap((b) => geoDeclarationsIn(b)).length, 0, '::before/::after state pseudo-elements must NOT be flagged (streaming sweep, not footprint)');
+    const compound = '.maka-composer.composer { padding: var(--space-3) var(--space-6) var(--space-4); }';
+    assert.throws(
+      () => assertExactlyOnce(compound, '.composer', 'padding', 'var(--space-2) var(--space-6) var(--space-2)', '.composer padding'),
+      /var\(--space-3\)/,
+      'a compound alias .maka-composer.composer setting padding must be caught (subject carries .composer)',
+    );
     const makaReturn = '.maka-composer { padding: var(--space-4) var(--space-6); }';
-    assert.equal(restBlocks(makaReturn, '.maka-composer').flatMap((b) => declarationsIn(b, 'padding')).length, 1, 'a .maka-composer padding return must be caught (form carries both classes)');
+    assert.equal(restBlocks(makaReturn, '.maka-composer').flatMap((b) => declarationsIn(b, 'padding')).length, 1, 'a .maka-composer padding return must be caught (form alias)');
     const tsxReturn = '          className="maka-composer-textarea min-h-11 resize-none"';
     assert.match(tsxReturn, /min-h-[a-z0-9]+/i, 'a returned textarea min-h-* utility must be caught');
+    const stopMdReturn = 'props.streaming ? (\n  <UiButton\n    className="maka-button"\n    variant="default"\n    type="button"\n  >\n    停止\n  </UiButton>\n)';
+    assert.doesNotMatch(stopMdReturn, /size="(icon-sm|sm)"/, 'a stop button defaulting to md (no size) must be caught (h-9/36px ≠ send h-8/32px)');
   });
 });

--- a/apps/desktop/src/main/__tests__/composer-constant-footprint-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/composer-constant-footprint-contract.test.ts
@@ -1,7 +1,8 @@
 /**
  * PR-COMPOSER-CONSTANT-FOOTPRINT-0 (issue #740):
  * lock the Composer's constant vertical footprint so the empty composer can't
- * drift back to the ~200px that ate a quarter of an 820px window.
+ * drift back to the ~200px that ate a quarter of an 820px window — AND lock that
+ * no state selector ever introduces an idle/active geometry switch.
  *
  * The cut is static — no `[data-compact]` state machine, no idle/active mode.
  * The Composer is the highest-frequency surface and sits at the bottom of the
@@ -12,9 +13,8 @@
  * COMPOSER_MAX_HEIGHT in @maka/ui), so content-driven "expand" is the textarea's
  * own growth — no enter/leave transition, no reduced-motion special-casing.
  *
- * Seven invariants pin the vertical budget (each measured against the 820px
- * window: composer outer 200px, inner 128px, textarea 56px, workspace/branch
- * row 36px):
+ * Six invariants pin the vertical budget (each measured against the 820px
+ * window: composer outer 200px, inner 128px, textarea 56px):
  *
  *   1. --h-composer-min (textarea min-height) is 44px (single-line natural),
  *      not 56px.
@@ -25,12 +25,16 @@
  *   4. .composerActions margin-top is var(--space-1) (4px), not 8px.
  *   5. .maka-composer-textarea min-height is var(--h-composer-min) — the
  *      textarea follows the token, not a bare value that could drift.
- *   6. .maka-composer-workspace-row margin-top stays var(--space-2) (8px) —
- *      the workspace/branch row is a constant, mounted control; it is NOT
- *      tightened (stability: the row's footprint never changes).
+ *   6. No state selector on .composer/.maka-composer (:hover, :focus-within,
+ *      [data-compact], [data-streaming], [data-drag-active], …) declares any
+ *      vertical-geometry property (padding* / gap* / margin* / min-height /
+ *      min-block-size, including longhands). This is the core #740 lock: an
+ *      idle/active mode switch is impossible if no state selector can change
+ *      the footprint. (State selectors may still change border/box-shadow/
+ *      background/color — those don't affect height.)
  *
- * Combined this drops an empty composer from ~200px to ~164px (≥18%). The
- * contract pins each lever exactly-once (a later rest block, a selector-list
+ * Combined invariants 1–5 drop an empty composer from ~200px to ~164px (≥18%).
+ * The contract pins each lever exactly-once (a later rest block, a selector-list
  * companion, OR a same-block duplicate would all win the cascade) so a
  * regression to the old footprint is caught before it ships.
  */
@@ -61,9 +65,8 @@ function declarationsIn(body: string, prop: string): string[] {
 }
 
 /** Rest blocks whose selector list CONTAINS `subjectSelector` as a whole
- *  selector (split on top-level commas, so `.other, .composer` is scanned for
- *  `.composer`). State pseudo / attribute variants are excluded — only the
- *  plain subject counts as the rest definition. */
+ *  selector (split on top-level commas). State pseudo / attribute variants are
+ *  excluded — only the plain subject counts as the rest definition. */
 function restBlocks(css: string, subjectSelector: string): string[] {
   const blocks: string[] = [];
   for (const [prelude, body] of styleRules(css)) {
@@ -76,13 +79,36 @@ function restBlocks(css: string, subjectSelector: string): string[] {
   return blocks;
 }
 
-/** Assert `prop` is declared exactly once across all rest blocks of `selector`
- *  with `expected` value (a later rest block, a selector-list companion, or a
- *  same-block duplicate each fail). */
 function assertExactlyOnce(css: string, selector: string, prop: string, expected: string, label: string): void {
   const decls = restBlocks(css, selector).flatMap((b) => declarationsIn(b, prop));
   assert.equal(decls.length, 1, `${label}: ${prop} must be declared exactly once (a later rest block, a selector-list companion, OR a same-block duplicate would all win the cascade); got ${decls.length}: ${JSON.stringify(decls)}`);
   assert.equal(decls[0], expected, `${label}: ${prop} must be ${expected}; got ${decls[0]}`);
+}
+
+/** State-selector blocks: any selector in the list that references
+ *  `.composer` or `.maka-composer` AND carries a state pseudo / attribute
+ *  (`:hover`, `[data-compact]`, …). These are the only places an idle/active
+ *  geometry switch could sneak in. */
+function stateComposerBlocks(css: string): string[] {
+  const blocks: string[] = [];
+  for (const [prelude, body] of styleRules(css)) {
+    if (!prelude || prelude.startsWith('@')) continue;
+    const selectors = prelude.split(',').map((s) => s.trim());
+    if (selectors.some((sel) => /(^|\s)(?:\.maka-composer-inner|\.composer|\.maka-composer)(?![\w-])/.test(sel) && /[:[]/.test(sel))) {
+      blocks.push(body);
+    }
+  }
+  return blocks;
+}
+
+/** Any vertical-geometry property declaration: padding* (shorthand + all
+ *  longhands), gap* (shorthand + row/column), margin* (shorthand + longhands),
+ *  min-height, min-block-size. Catches `padding-block` / `row-gap` etc. that a
+ *  shorthand-only scan would miss. */
+const GEO_PROP_RE = /(?:^|[;\n])\s*(?:padding(?:-block|-inline|-top|-right|-bottom|-left)?|gap|row-gap|column-gap|margin(?:-block|-inline|-top|-right|-bottom|-left)?|min-height|min-block-size)\s*:/gi;
+
+function geoDeclarationsIn(body: string): string[] {
+  return [...body.matchAll(GEO_PROP_RE)].map((m) => m[0].trim().replace(/\s+/g, ' '));
 }
 
 describe('PR-COMPOSER-CONSTANT-FOOTPRINT-0 contract (issue #740)', () => {
@@ -112,12 +138,13 @@ describe('PR-COMPOSER-CONSTANT-FOOTPRINT-0 contract (issue #740)', () => {
     assertExactlyOnce(css, '.composer .maka-composer-textarea', 'min-height', 'var(--h-composer-min)', '.maka-composer-textarea min-height');
   });
 
-  it('.maka-composer-workspace-row margin stays var(--space-2) auto 0 — NOT tightened (stability)', async () => {
+  it('no state selector on .composer/.maka-composer changes vertical geometry (no idle/active mode switch)', async () => {
     const css = stripCssComments(await readAllRendererCss());
-    assertExactlyOnce(css, '.maka-composer-workspace-row', 'margin', 'var(--space-2) auto 0', '.maka-composer-workspace-row margin (constant, not tightened)');
+    const geoDecls = stateComposerBlocks(css).flatMap((b) => geoDeclarationsIn(b));
+    assert.equal(geoDecls.length, 0, `state selectors on .composer/.maka-composer must not change vertical geometry (no idle/active mode switch per #740); found: ${JSON.stringify(geoDecls)}`);
   });
 
-  it('assertExactlyOnce flags a same-block duplicate AND a selector-list companion (negative cases)', () => {
+  it('assertExactlyOnce flags a same-block duplicate AND a selector-list companion; state-geometry guard flags a [data-compact] padding override (negative cases)', () => {
     const sameBlock = '.composer { padding: var(--space-2) var(--space-6) var(--space-2); padding: var(--space-3) var(--space-6) var(--space-4); }';
     assert.throws(
       () => assertExactlyOnce(sameBlock, '.composer', 'padding', 'var(--space-2) var(--space-6) var(--space-2)', '.composer padding'),
@@ -129,6 +156,13 @@ describe('PR-COMPOSER-CONSTANT-FOOTPRINT-0 contract (issue #740)', () => {
       () => assertExactlyOnce(selectorList, '.composer', 'padding', 'var(--space-2) var(--space-6) var(--space-2)', '.composer padding'),
       /var\(--space-3\)/,
       'a selector-list companion setting padding must be caught (the override won the cascade)',
+    );
+    const stateCompact = '.composer[data-compact="true"] { padding-block: var(--space-1); }';
+    const stateCompactBody = styleRules(stateCompact)[0]?.[1] ?? '';
+    assert.equal(
+      geoDeclarationsIn(stateCompactBody).length,
+      1,
+      'a .composer[data-compact] padding-block override must be flagged by the state-geometry guard (longhand, not just shorthand)',
     );
   });
 });

--- a/apps/desktop/src/main/__tests__/composer-constant-footprint-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/composer-constant-footprint-contract.test.ts
@@ -1,0 +1,134 @@
+/**
+ * PR-COMPOSER-CONSTANT-FOOTPRINT-0 (issue #740):
+ * lock the Composer's constant vertical footprint so the empty composer can't
+ * drift back to the ~200px that ate a quarter of an 820px window.
+ *
+ * The cut is static — no `[data-compact]` state machine, no idle/active mode.
+ * The Composer is the highest-frequency surface and sits at the bottom of the
+ * chat column; an idle↔active height switch would push the chat viewport
+ * boundary and jump the conversation. Stability takes priority over peak space
+ * savings, so the footprint is tightened once via static CSS and stays put. The
+ * textarea already auto-resizes as content arrives (capped at
+ * COMPOSER_MAX_HEIGHT in @maka/ui), so content-driven "expand" is the textarea's
+ * own growth — no enter/leave transition, no reduced-motion special-casing.
+ *
+ * Seven invariants pin the vertical budget (each measured against the 820px
+ * window: composer outer 200px, inner 128px, textarea 56px, workspace/branch
+ * row 36px):
+ *
+ *   1. --h-composer-min (textarea min-height) is 44px (single-line natural),
+ *      not 56px.
+ *   2. .composer vertical padding is var(--space-2) (8px) top + bottom, not
+ *      12/16px.
+ *   3. .maka-composer-inner padding-block is var(--space-2)/var(--space-1-5)
+ *      (8/6px) with a var(--space-1-5) (6px) gap, not 10/8px + 10px.
+ *   4. .composerActions margin-top is var(--space-1) (4px), not 8px.
+ *   5. .maka-composer-textarea min-height is var(--h-composer-min) — the
+ *      textarea follows the token, not a bare value that could drift.
+ *   6. .maka-composer-workspace-row margin-top stays var(--space-2) (8px) —
+ *      the workspace/branch row is a constant, mounted control; it is NOT
+ *      tightened (stability: the row's footprint never changes).
+ *
+ * Combined this drops an empty composer from ~200px to ~164px (≥18%). The
+ * contract pins each lever exactly-once (a later rest block, a selector-list
+ * companion, OR a same-block duplicate would all win the cascade) so a
+ * regression to the old footprint is caught before it ships.
+ */
+
+import { strict as assert } from 'node:assert';
+import { readFile } from 'node:fs/promises';
+import { describe, it } from 'node:test';
+import {
+  TOKENS_FILE,
+  readAllRendererCss,
+  stripCssComments,
+  assertCustomPropPinnedOnce,
+} from './css-test-helpers.js';
+
+function styleRules(css: string): Array<[string, string]> {
+  const stripped = stripCssComments(css);
+  return [...stripped.matchAll(/([^{}]+)\{([^{}]*)\}/g)].map((m) => {
+    const prelude = m[1].replace(/^[\s\S]*;/, '').trim();
+    return [prelude, m[2]] as [string, string];
+  });
+}
+
+/** ALL declarations of `prop` within one block (global match), so a
+ *  `padding: a; padding: b` same-block override surfaces as two, not one. */
+function declarationsIn(body: string, prop: string): string[] {
+  const re = new RegExp(`(?:^|[\\n;])\\s*${prop}\\s*:\\s*([^;}]*)`, 'ig');
+  return [...body.matchAll(re)].map((m) => m[1].trim().replace(/\s+/g, ' '));
+}
+
+/** Rest blocks whose selector list CONTAINS `subjectSelector` as a whole
+ *  selector (split on top-level commas, so `.other, .composer` is scanned for
+ *  `.composer`). State pseudo / attribute variants are excluded — only the
+ *  plain subject counts as the rest definition. */
+function restBlocks(css: string, subjectSelector: string): string[] {
+  const blocks: string[] = [];
+  for (const [prelude, body] of styleRules(css)) {
+    if (!prelude || prelude.startsWith('@')) continue;
+    const selectors = prelude.split(',').map((s) => s.trim());
+    if (selectors.some((sel) => sel === subjectSelector && !/[:[]/.test(sel))) {
+      blocks.push(body);
+    }
+  }
+  return blocks;
+}
+
+/** Assert `prop` is declared exactly once across all rest blocks of `selector`
+ *  with `expected` value (a later rest block, a selector-list companion, or a
+ *  same-block duplicate each fail). */
+function assertExactlyOnce(css: string, selector: string, prop: string, expected: string, label: string): void {
+  const decls = restBlocks(css, selector).flatMap((b) => declarationsIn(b, prop));
+  assert.equal(decls.length, 1, `${label}: ${prop} must be declared exactly once (a later rest block, a selector-list companion, OR a same-block duplicate would all win the cascade); got ${decls.length}: ${JSON.stringify(decls)}`);
+  assert.equal(decls[0], expected, `${label}: ${prop} must be ${expected}; got ${decls[0]}`);
+}
+
+describe('PR-COMPOSER-CONSTANT-FOOTPRINT-0 contract (issue #740)', () => {
+  it('--h-composer-min is pinned to 44px (single-line natural, not 56px)', async () => {
+    const tokens = await readFile(TOKENS_FILE, 'utf8');
+    assertCustomPropPinnedOnce(tokens, '--h-composer-min', '44px', 'maka-tokens.css');
+  });
+
+  it('.composer rest padding is var(--space-2) var(--space-6) var(--space-2) (8/24/8)', async () => {
+    const css = stripCssComments(await readAllRendererCss());
+    assertExactlyOnce(css, '.composer', 'padding', 'var(--space-2) var(--space-6) var(--space-2)', '.composer padding');
+  });
+
+  it('.maka-composer-inner rest padding + gap are the constant footprint', async () => {
+    const css = stripCssComments(await readAllRendererCss());
+    assertExactlyOnce(css, '.composer .maka-composer-inner', 'padding', 'var(--space-2) var(--space-3) var(--space-1-5)', '.maka-composer-inner padding');
+    assertExactlyOnce(css, '.composer .maka-composer-inner', 'gap', 'var(--space-1-5)', '.maka-composer-inner gap');
+  });
+
+  it('.composerActions rest margin-top is var(--space-1) (4px)', async () => {
+    const css = stripCssComments(await readAllRendererCss());
+    assertExactlyOnce(css, '.composerActions', 'margin-top', 'var(--space-1)', '.composerActions margin-top');
+  });
+
+  it('.maka-composer-textarea min-height follows --h-composer-min (not a bare value)', async () => {
+    const css = stripCssComments(await readAllRendererCss());
+    assertExactlyOnce(css, '.composer .maka-composer-textarea', 'min-height', 'var(--h-composer-min)', '.maka-composer-textarea min-height');
+  });
+
+  it('.maka-composer-workspace-row margin stays var(--space-2) auto 0 — NOT tightened (stability)', async () => {
+    const css = stripCssComments(await readAllRendererCss());
+    assertExactlyOnce(css, '.maka-composer-workspace-row', 'margin', 'var(--space-2) auto 0', '.maka-composer-workspace-row margin (constant, not tightened)');
+  });
+
+  it('assertExactlyOnce flags a same-block duplicate AND a selector-list companion (negative cases)', () => {
+    const sameBlock = '.composer { padding: var(--space-2) var(--space-6) var(--space-2); padding: var(--space-3) var(--space-6) var(--space-4); }';
+    assert.throws(
+      () => assertExactlyOnce(sameBlock, '.composer', 'padding', 'var(--space-2) var(--space-6) var(--space-2)', '.composer padding'),
+      /got 2/,
+      'a same-block padding duplicate must be caught',
+    );
+    const selectorList = '.other, .composer { padding: var(--space-3) var(--space-6) var(--space-4); }';
+    assert.throws(
+      () => assertExactlyOnce(selectorList, '.composer', 'padding', 'var(--space-2) var(--space-6) var(--space-2)', '.composer padding'),
+      /var\(--space-3\)/,
+      'a selector-list companion setting padding must be caught (the override won the cascade)',
+    );
+  });
+});

--- a/apps/desktop/src/main/__tests__/composer-constant-footprint-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/composer-constant-footprint-contract.test.ts
@@ -2,7 +2,8 @@
  * PR-COMPOSER-CONSTANT-FOOTPRINT-0 (issue #740):
  * lock the Composer's constant vertical footprint so the empty composer can't
  * drift back to the ~200px that ate a quarter of an 820px window — AND lock that
- * no state selector ever introduces an idle/active geometry switch.
+ * no state selector, no second DOM-class source, and no token override can
+ * re-introduce an idle/active geometry switch.
  *
  * The cut is static — no `[data-compact]` state machine, no idle/active mode.
  * The Composer is the highest-frequency surface and sits at the bottom of the
@@ -13,41 +14,52 @@
  * COMPOSER_MAX_HEIGHT in @maka/ui), so content-driven "expand" is the textarea's
  * own growth — no enter/leave transition, no reduced-motion special-casing.
  *
+ * The <form> carries TWO class aliases — `.maka-composer` AND `.composer` — so
+ * a "single source" claim must cover both: .composer owns the padding, and
+ * .maka-composer must NOT re-add it. The textarea's min-height must come from
+ * CSS (var(--h-composer-min)), not a Tailwind min-h-* utility that could win if
+ * the CSS rule is removed.
+ *
  * Six invariants pin the vertical budget (each measured against the 820px
  * window: composer outer 200px, inner 128px, textarea 56px):
  *
- *   1. --h-composer-min (textarea min-height) is 44px (single-line natural),
- *      not 56px.
- *   2. .composer vertical padding is var(--space-2) (8px) top + bottom, not
- *      12/16px.
+ *   1. --h-composer-min (textarea min-height) is 44px, not 56px.
+ *   2. .composer vertical padding is var(--space-2) (8px) top + bottom; .maka-
+ *      composer declares NO padding (single source for the form's two classes).
  *   3. .maka-composer-inner padding-block is var(--space-2)/var(--space-1-5)
  *      (8/6px) with a var(--space-1-5) (6px) gap, not 10/8px + 10px.
  *   4. .composerActions margin-top is var(--space-1) (4px), not 8px.
- *   5. .maka-composer-textarea min-height is var(--h-composer-min) — the
- *      textarea follows the token, not a bare value that could drift.
- *   6. No state selector on .composer/.maka-composer (:hover, :focus-within,
- *      [data-compact], [data-streaming], [data-drag-active], …) declares any
- *      vertical-geometry property (padding* / gap* / margin* / min-height /
- *      min-block-size, including longhands). This is the core #740 lock: an
+ *   5. .maka-composer-textarea min-height is var(--h-composer-min) (CSS), and
+ *      its className carries no Tailwind min-h-* utility (TSX).
+ *   6. No state selector on .composer / .maka-composer / .maka-composer-inner
+ *      (state = :hover/:focus-within/[data-…], but NOT ::before/::after which
+ *      are the streaming sweep pseudo-elements) declares any vertical-geometry
+ *      property — padding* (shorthand + all physical/logical longhands), gap*,
+ *      margin* (shorthand + longhands), height/block-size/max-* and min-*, or a
+ *      local --h-composer-min override. This is the core #740 lock: an
  *      idle/active mode switch is impossible if no state selector can change
  *      the footprint. (State selectors may still change border/box-shadow/
- *      background/color — those don't affect height.)
+ *      background/color/position/overflow — those don't affect the form height.)
  *
  * Combined invariants 1–5 drop an empty composer from ~200px to ~164px (≥18%).
- * The contract pins each lever exactly-once (a later rest block, a selector-list
+ * Each lever is pinned exactly-once (a later rest block, a selector-list
  * companion, OR a same-block duplicate would all win the cascade) so a
- * regression to the old footprint is caught before it ships.
+ * regression is caught before it ships.
  */
 
 import { strict as assert } from 'node:assert';
 import { readFile } from 'node:fs/promises';
+import { join } from 'node:path';
 import { describe, it } from 'node:test';
 import {
+  REPO_ROOT,
   TOKENS_FILE,
   readAllRendererCss,
   stripCssComments,
   assertCustomPropPinnedOnce,
 } from './css-test-helpers.js';
+
+const COMPOSER_TSX = join(REPO_ROOT, 'packages/ui/src/composer.tsx');
 
 function styleRules(css: string): Array<[string, string]> {
   const stripped = stripCssComments(css);
@@ -57,16 +69,11 @@ function styleRules(css: string): Array<[string, string]> {
   });
 }
 
-/** ALL declarations of `prop` within one block (global match), so a
- *  `padding: a; padding: b` same-block override surfaces as two, not one. */
 function declarationsIn(body: string, prop: string): string[] {
   const re = new RegExp(`(?:^|[\\n;])\\s*${prop}\\s*:\\s*([^;}]*)`, 'ig');
   return [...body.matchAll(re)].map((m) => m[1].trim().replace(/\s+/g, ' '));
 }
 
-/** Rest blocks whose selector list CONTAINS `subjectSelector` as a whole
- *  selector (split on top-level commas). State pseudo / attribute variants are
- *  excluded — only the plain subject counts as the rest definition. */
 function restBlocks(css: string, subjectSelector: string): string[] {
   const blocks: string[] = [];
   for (const [prelude, body] of styleRules(css)) {
@@ -85,27 +92,28 @@ function assertExactlyOnce(css: string, selector: string, prop: string, expected
   assert.equal(decls[0], expected, `${label}: ${prop} must be ${expected}; got ${decls[0]}`);
 }
 
-/** State-selector blocks: any selector in the list that references
- *  `.composer` or `.maka-composer` AND carries a state pseudo / attribute
- *  (`:hover`, `[data-compact]`, …). These are the only places an idle/active
- *  geometry switch could sneak in. */
+/** State-selector blocks: any selector referencing .composer / .maka-composer /
+ *  .maka-composer-inner WITH a state pseudo/attribute, but NOT ::before/::after
+ *  (those are the streaming sweep pseudo-elements — their height/position is the
+ *  sweep line, not the composer footprint). */
 function stateComposerBlocks(css: string): string[] {
   const blocks: string[] = [];
   for (const [prelude, body] of styleRules(css)) {
     if (!prelude || prelude.startsWith('@')) continue;
     const selectors = prelude.split(',').map((s) => s.trim());
-    if (selectors.some((sel) => /(^|\s)(?:\.maka-composer-inner|\.composer|\.maka-composer)(?![\w-])/.test(sel) && /[:[]/.test(sel))) {
+    if (selectors.some((sel) => /(^|\s)(?:\.maka-composer-inner|\.composer|\.maka-composer)(?![\w-])/.test(sel) && /[:[]/.test(sel) && !/::(?:before|after)/.test(sel))) {
       blocks.push(body);
     }
   }
   return blocks;
 }
 
-/** Any vertical-geometry property declaration: padding* (shorthand + all
- *  longhands), gap* (shorthand + row/column), margin* (shorthand + longhands),
- *  min-height, min-block-size. Catches `padding-block` / `row-gap` etc. that a
- *  shorthand-only scan would miss. */
-const GEO_PROP_RE = /(?:^|[;\n])\s*(?:padding(?:-block|-inline|-top|-right|-bottom|-left)?|gap|row-gap|column-gap|margin(?:-block|-inline|-top|-right|-bottom|-left)?|min-height|min-block-size)\s*:/gi;
+/** Any vertical-geometry property + a local --h-composer-min override.
+ *  padding/gap/margin cover shorthand + all physical/logical longhands
+ *  (padding-block-start/end, margin-block-start/end, …); height/block-size/
+ *  max-* and min-* cover explicit box height; --h-composer-min covers a state rule
+ *  locally overriding the token that drives textarea min-height. */
+const GEO_PROP_RE = /(?:^|[;\n])\s*(?:padding(?:-block(?:-start|-end)?|-inline(?:-start|-end)?|-top|-right|-bottom|-left)?|gap|row-gap|column-gap|margin(?:-block(?:-start|-end)?|-inline(?:-start|-end)?|-top|-right|-bottom|-left)?|height|block-size|max-height|max-block-size|min-height|min-block-size|--h-composer-min)\s*:/gi;
 
 function geoDeclarationsIn(body: string): string[] {
   return [...body.matchAll(GEO_PROP_RE)].map((m) => m[0].trim().replace(/\s+/g, ' '));
@@ -117,9 +125,11 @@ describe('PR-COMPOSER-CONSTANT-FOOTPRINT-0 contract (issue #740)', () => {
     assertCustomPropPinnedOnce(tokens, '--h-composer-min', '44px', 'maka-tokens.css');
   });
 
-  it('.composer rest padding is var(--space-2) var(--space-6) var(--space-2) (8/24/8)', async () => {
+  it('.composer rest padding is var(--space-2) var(--space-6) var(--space-2) AND .maka-composer declares no padding (form carries both classes — single source)', async () => {
     const css = stripCssComments(await readAllRendererCss());
     assertExactlyOnce(css, '.composer', 'padding', 'var(--space-2) var(--space-6) var(--space-2)', '.composer padding');
+    const makaComposerPadding = restBlocks(css, '.maka-composer').flatMap((b) => declarationsIn(b, 'padding'));
+    assert.equal(makaComposerPadding.length, 0, `.maka-composer must not declare padding (the <form> carries .maka-composer + .composer; .composer is the single padding source); got ${JSON.stringify(makaComposerPadding)}`);
   });
 
   it('.maka-composer-inner rest padding + gap are the constant footprint', async () => {
@@ -133,18 +143,22 @@ describe('PR-COMPOSER-CONSTANT-FOOTPRINT-0 contract (issue #740)', () => {
     assertExactlyOnce(css, '.composerActions', 'margin-top', 'var(--space-1)', '.composerActions margin-top');
   });
 
-  it('.maka-composer-textarea min-height follows --h-composer-min (not a bare value)', async () => {
+  it('.maka-composer-textarea min-height is var(--h-composer-min) (CSS) AND its className carries no Tailwind min-h-* (TSX single source)', async () => {
     const css = stripCssComments(await readAllRendererCss());
     assertExactlyOnce(css, '.composer .maka-composer-textarea', 'min-height', 'var(--h-composer-min)', '.maka-composer-textarea min-height');
+    const source = await readFile(COMPOSER_TSX, 'utf8');
+    const textareaLine = source.split('\n').find((l) => l.includes('maka-composer-textarea'));
+    assert.ok(textareaLine, 'maka-composer-textarea className line not found in composer.tsx');
+    assert.doesNotMatch(textareaLine!, /min-h-[a-z0-9]+/i, '.maka-composer-textarea className must not carry a Tailwind min-h-* utility (CSS min-height: var(--h-composer-min) is the single source)');
   });
 
-  it('no state selector on .composer/.maka-composer changes vertical geometry (no idle/active mode switch)', async () => {
+  it('no state selector on .composer/.maka-composer/.maka-composer-inner changes vertical geometry or overrides --h-composer-min (no idle/active mode switch)', async () => {
     const css = stripCssComments(await readAllRendererCss());
     const geoDecls = stateComposerBlocks(css).flatMap((b) => geoDeclarationsIn(b));
-    assert.equal(geoDecls.length, 0, `state selectors on .composer/.maka-composer must not change vertical geometry (no idle/active mode switch per #740); found: ${JSON.stringify(geoDecls)}`);
+    assert.equal(geoDecls.length, 0, `state selectors on .composer/.maka-composer/.maka-composer-inner must not change vertical geometry or override --h-composer-min (no idle/active mode switch per #740); found: ${JSON.stringify(geoDecls)}`);
   });
 
-  it('assertExactlyOnce flags a same-block duplicate AND a selector-list companion; state-geometry guard flags a [data-compact] padding override (negative cases)', () => {
+  it('negative cases: same-block duplicate, selector-list companion, state [data-compact] height + token override + ::before sweep exclusion, .maka-composer padding return, textarea min-h-* return', () => {
     const sameBlock = '.composer { padding: var(--space-2) var(--space-6) var(--space-2); padding: var(--space-3) var(--space-6) var(--space-4); }';
     assert.throws(
       () => assertExactlyOnce(sameBlock, '.composer', 'padding', 'var(--space-2) var(--space-6) var(--space-2)', '.composer padding'),
@@ -155,14 +169,17 @@ describe('PR-COMPOSER-CONSTANT-FOOTPRINT-0 contract (issue #740)', () => {
     assert.throws(
       () => assertExactlyOnce(selectorList, '.composer', 'padding', 'var(--space-2) var(--space-6) var(--space-2)', '.composer padding'),
       /var\(--space-3\)/,
-      'a selector-list companion setting padding must be caught (the override won the cascade)',
+      'a selector-list companion setting padding must be caught',
     );
-    const stateCompact = '.composer[data-compact="true"] { padding-block: var(--space-1); }';
-    const stateCompactBody = styleRules(stateCompact)[0]?.[1] ?? '';
-    assert.equal(
-      geoDeclarationsIn(stateCompactBody).length,
-      1,
-      'a .composer[data-compact] padding-block override must be flagged by the state-geometry guard (longhand, not just shorthand)',
-    );
+    const stateHeight = '.composer[data-compact="true"] { height: 120px; }';
+    assert.equal(stateComposerBlocks(stateHeight).flatMap((b) => geoDeclarationsIn(b)).length, 1, 'a .composer[data-compact] height override must be flagged end-to-end');
+    const stateTokenOverride = '.composer[data-compact="true"] { --h-composer-min: 32px; }';
+    assert.equal(stateComposerBlocks(stateTokenOverride).flatMap((b) => geoDeclarationsIn(b)).length, 1, 'a .composer[data-compact] --h-composer-min override must be flagged (it drives textarea min-height)');
+    const sweep = '.maka-composer-inner[data-streaming="true"]::before { height: 1px; top: 0; }';
+    assert.equal(stateComposerBlocks(sweep).flatMap((b) => geoDeclarationsIn(b)).length, 0, '::before/::after state pseudo-elements must NOT be flagged (streaming sweep, not footprint)');
+    const makaReturn = '.maka-composer { padding: var(--space-4) var(--space-6); }';
+    assert.equal(restBlocks(makaReturn, '.maka-composer').flatMap((b) => declarationsIn(b, 'padding')).length, 1, 'a .maka-composer padding return must be caught (form carries both classes)');
+    const tsxReturn = '          className="maka-composer-textarea min-h-11 resize-none"';
+    assert.match(tsxReturn, /min-h-[a-z0-9]+/i, 'a returned textarea min-h-* utility must be caught');
   });
 });

--- a/apps/desktop/src/renderer/maka-tokens.css
+++ b/apps/desktop/src/renderer/maka-tokens.css
@@ -1265,17 +1265,6 @@
 
   /* ---- Composer --------------------------------------------------- */
 
-  .maka-composer {
-    /* PR-UI-LAYOUT-8: remove the visible 1px divider between chat
-     * surface and composer — on the warm canvas the divider read as
-     * a strong horizontal line slicing the panel. The composer's
-     * own border + rounded chrome below is sufficient visual
-     * separation; no extra line needed.
-     *
-     * #740/#546: padding moved to .composer in styles/composer.css as the
-     * single source (this rule is now background-only). */
-    background: var(--background);
-  }
   .maka-composer[data-drag-active="true"] .maka-composer-inner {
     border-color: oklch(from var(--focus-ring) l c h / 0.46);
     background: oklch(from var(--focus-ring) 0.98 calc(c * 0.20) h / 0.35);

--- a/apps/desktop/src/renderer/maka-tokens.css
+++ b/apps/desktop/src/renderer/maka-tokens.css
@@ -1270,8 +1270,10 @@
      * surface and composer — on the warm canvas the divider read as
      * a strong horizontal line slicing the panel. The composer's
      * own border + rounded chrome below is sufficient visual
-     * separation; no extra line needed. */
-    padding: var(--space-4) var(--space-6);
+     * separation; no extra line needed.
+     *
+     * #740/#546: padding moved to .composer in styles/composer.css as the
+     * single source (this rule is now background-only). */
     background: var(--background);
   }
   .maka-composer[data-drag-active="true"] .maka-composer-inner {

--- a/apps/desktop/src/renderer/maka-tokens.css
+++ b/apps/desktop/src/renderer/maka-tokens.css
@@ -499,7 +499,7 @@
   --w-rail: 240px;
   --h-titlebar: 36px;
   --h-toolbar: 40px;
-  --h-composer-min: 56px;
+  --h-composer-min: 44px;
 
   /* titlebar control baseline (macOS traffic-light center) */
   --maka-titlebar-control-safe-left: 94px;

--- a/apps/desktop/src/renderer/styles/composer.css
+++ b/apps/desktop/src/renderer/styles/composer.css
@@ -4,7 +4,7 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  padding: var(--space-3) var(--space-6) var(--space-4);
+  padding: var(--space-2) var(--space-6) var(--space-2);
   /* PR-GRAY-CARD-LIFT-5 (WAWQAQ msg `d4277aba` round 3): the composer
      outer used to paint a vertical white-fade over `--background`,
      designed for the older parchment shell where the page bg was
@@ -28,7 +28,7 @@
   align-items: center;
   justify-content: space-between;
   gap: var(--space-2);
-  margin-top: var(--space-2);
+  margin-top: var(--space-1);
   padding-top: var(--space-0-5);
   border-top: 0;
 }
@@ -202,7 +202,7 @@
   position: relative;
   display: flex;
   flex-direction: column;
-  gap: var(--space-2-5);
+  gap: var(--space-1-5);
   width: min(var(--maka-chat-measure), 100%);
   max-width: var(--maka-chat-measure);
   margin: 0 auto;
@@ -210,7 +210,7 @@
   box-sizing: border-box;
   border: var(--border-width-hairline) solid var(--color-border-tertiary);
   border-radius: var(--radius-modal);
-  padding: var(--space-2-5) var(--space-3) var(--space-2);
+  padding: var(--space-2) var(--space-3) var(--space-1-5);
   background-color: var(--agents-content-area-bg);
   /* Ring alpha is a token so dark mode can strengthen the edge without a
      second rest rule (composer-container-single-source-contract). In dark

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -274,7 +274,7 @@ spinner、status pulse、streaming caret、shimmer，以及必要的 hover/press
 
 **规则**：
 
-1. **新组件按 surface 明确写出稳定间距**。聊天主 surface 当前使用 18px turn gap、24px horizontal message padding、18px composer vertical padding。
+1. **新组件按 surface 明确写出稳定间距**。聊天主 surface 当前使用 18px turn gap、24px horizontal message padding、14px composer vertical padding (8px top / 6px bottom)。
 
 2. **不要用全局密度切换改 typography**。字号、行高保持稳定；具体页面需要更紧或更松时，在该页面局部调整。
 

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -247,7 +247,7 @@ spinner、status pulse、streaming caret、shimmer，以及必要的 hover/press
 | `--w-rail` | 240px | 右侧（artifact panel 等） |
 | `--h-titlebar` | 36px | 标题栏 |
 | `--h-toolbar` | 40px | 二级工具栏 |
-| `--h-composer-min` | 56px | composer 最小高 |
+| `--h-composer-min` | 44px | 输入框(textarea)最小高 |
 
 ---
 

--- a/packages/ui/src/composer.tsx
+++ b/packages/ui/src/composer.tsx
@@ -576,7 +576,7 @@ export const Composer = forwardRef<
           ref={textareaRef}
           unstyled
           name="text"
-          className="maka-composer-textarea min-h-11 resize-none"
+          className="maka-composer-textarea resize-none"
           placeholder={copy.placeholder}
           aria-label={copy.textareaAriaLabel}
           disabled={props.disabled}

--- a/packages/ui/src/composer.tsx
+++ b/packages/ui/src/composer.tsx
@@ -703,6 +703,7 @@ export const Composer = forwardRef<
               <UiButton
                 className="maka-button"
                 variant="default"
+                size="sm"
                 type="button"
                 disabled={props.stopPending}
                 onClick={() => {

--- a/packages/ui/stories/spacing.stories.tsx
+++ b/packages/ui/stories/spacing.stories.tsx
@@ -32,7 +32,7 @@ const layoutGeometry = [
   ['--w-sessionlist', '240px', '会话列表宽度'],
   ['--h-titlebar', '36px', '标题栏高度'],
   ['--h-toolbar', '40px', '工具栏高度'],
-  ['--h-composer-min', '56px', '输入框最小高度'],
+  ['--h-composer-min', '44px', '输入框最小高度'],
   ['--h-list-header', '52px', '列表头高度'],
 ] as const;
 


### PR DESCRIPTION
## Summary
Tighten the Composer's **constant** vertical footprint from ~200px to ~164px by statically tightening five levers (textarea min-height, composer/inner padding, inner gap, actions margin-top). **No idle/active mode switch** — the Composer is the highest-frequency surface at the bottom of the chat column, so an idle↔active height switch would jump the conversation. Stability takes priority. The textarea already auto-resizes to the 240px cap; controls and the workspace/branch row stay mounted.

Also fixes a real 4px chat-boundary jump: streaming swapped the send button (icon-sm/h-8/32px) for a stop button defaulting to md (h-9/36px); stop now uses size="sm" (32px) so the toolbar height is stable across normal/streaming.

## Why
An empty composer occupied ~200px — nearly a quarter of an 820px window — before the user typed. Closes #740.

## Scope
Static geometry only. Five tightened levers:
- `--h-composer-min` 56→44 (textarea min-height, single-line natural)
- `.composer` padding 12/16→8/8
- `.maka-composer-inner` padding 10/8→8/6, gap 10→6
- `.composerActions` margin-top 8→4
Plus single-source cleanup + stability:
- removed redundant `.maka-composer` rest padding (form carries .composer + .maka-composer; .composer is the single padding source)
- removed redundant Tailwind `min-h-11` on the textarea (CSS `min-height: var(--h-composer-min)` is the single source)
- removed dead `.maka-composer { background }` rule (overridden by `.composer { background: transparent }`)
- stop button `size="sm"` (h-8/32px) = send `icon-sm` — no 4px streaming jump
- workspace/branch row margin NOT tightened (constant mounted control, stability)

No TSX state machine; no transition/reduced-motion special-casing.

## Verification
- RED→GREEN contract `composer-constant-footprint-contract`: 5 rest levers exactly-once (subject-based matching catches compound alias `.maka-composer.composer` + selector-list + same-block duplicate) + .maka-composer no-padding form alias + textarea no `min-h-*` (TSX) + stop button h-8 size. Send height is locked by the existing `control-height-converge-contract` (.maka-composer-send-button height = --h-control-lg = 32px), not re-asserted here.
- `npm run -w @maka/desktop test` — 2344/2344 pass (serial; parallel has pre-existing fs/watch flakiness unrelated to this PR).
- `typecheck` + `test:checks` — pass.
- CDP on turn-narrative (send) + model-processing (stop): composer 200→164, toolbar 34 both, send 32, stop 32 — no chat-boundary jump across normal/streaming.
- docs/design-system.md + spacing.stories.tsx synced to 44px / 14px (8 top / 6 bottom).

## Impact
Empty composer ~36px shorter (18%); controls, focus ring, attachments, permission/streaming states, workspace/branch row remain usable; streaming no longer jumps the chat boundary 4px. No behavior, API, or migration change. Issue #740 body updated to match (no idle/active mode switch).

## Reviewer notes
Chose a static tighten over a stateful `[data-compact]` + transition (the original AC's "expand only when requires / enters or leaves compact mode" implied a mode switch): the Composer is the highest-frequency surface at the bottom of the chat column, so a mode switch would jump the conversation. The textarea's existing auto-resize already provides content-driven expand; the workspace/branch row stays mounted. The contract intentionally does NOT lock "no state selector ever changes the footprint" via a property blacklist (CSS selectors are unbounded — compound/pseudo/display/border-width); #740's no-mode-switch is upheld by product code (no [data-compact]) + two stability layers (rest levers + send/stop same height), an explicit scope choice. Reviewed through 4 Codex fresh-eye passes; all P0-P2 resolved, final pass clean (1 P3 false-negative fixed).

## Ready for review
- [x] Verification complete and current
- [x] Impact/compatibility/migration/docs/release-note needs addressed
- [x] Visual evidence included (CDP computed sizes)
