### PR TITLE
fix(ui): collapse verbose tool failure details behind a disclosure (#741)

### DIFF
--- a/apps/desktop/src/main/__tests__/tool-error-collapse-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/tool-error-collapse-contract.test.ts
@@ -96,4 +96,15 @@ describe('PR-TOOL-ERROR-COLLAPSE-0 contract (issue #741)', () => {
     const markup = renderToStaticMarkup(createElement(ToolErrorDetails, { open: false, children: TAIL_MARKER }));
     assert.doesNotMatch(markup, new RegExp(TAIL_MARKER), 'a collapsed disclosure must not render the raw payload');
   });
+
+  it('caps the banner summary at 4 logical lines so a multi-line error cannot grow it to ~2.6kpx', () => {
+    // #741 P2: a 240-char slice kept newlines, so a 180-line error still
+    // rendered ~161 lines (~2656px). The summary now caps both chars and lines.
+    const multiLine = Array.from({ length: 180 }, (_, i) => `line ${i}`).join('\n');
+    const markup = renderErrored(multiLine);
+    const m = markup.match(/data-slot="alert-description"[^>]*>([\s\S]*?)<\/div>/);
+    const summary = m?.[1] ?? '';
+    assert.ok(summary.split('\n').length <= 4, `banner summary must cap at 4 lines, got ${summary.split('\n').length}`);
+    assert.ok(summary.endsWith('…'), 'a truncated multi-line summary must end with an ellipsis');
+  });
 });

--- a/apps/desktop/src/main/__tests__/tool-error-collapse-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/tool-error-collapse-contract.test.ts
@@ -21,7 +21,7 @@ import { createElement } from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
 import { describe, it } from 'node:test';
 import type { ToolActivityItem } from '@maka/ui';
-import { ToolActivity } from '@maka/ui';
+import { ToolActivity, ToolErrorDetails } from '@maka/ui';
 
 const TAIL_MARKER = 'TAIL_MARKER_SCHEMA_DETAILS';
 
@@ -71,5 +71,29 @@ describe('PR-TOOL-ERROR-COLLAPSE-0 contract (issue #741)', () => {
     const markup = renderErrored('short failure reason');
     assert.match(markup, /short failure reason/, 'a short error must still appear in the banner');
     assert.match(markup, /显示原始诊断/, '...and still offers the raw-details disclosure');
+  });
+
+  it('does not render an empty shared output panel for an errored tool with no invocation (args:{})', () => {
+    // #741 P2: args:{} + errored + non-owned used to leave an empty destructive
+    // tool-output box (the raw moved to the disclosure, but showResult kept the
+    // shared panel open with nothing in it).
+    const markup = renderToStaticMarkup(createElement(ToolActivity, { items: [{
+      toolUseId: 'tu_empty', toolName: 'unknown_tool', status: 'errored', args: {},
+      result: { kind: 'text', text: 'validation failed' },
+    }] }));
+    assert.doesNotMatch(markup, /data-slot="tool-output"/, 'an errored tool whose raw lives in the disclosure must not also render an empty shared output panel');
+  });
+
+  it('renders the raw payload inside the disclosure when expanded (open=true)', () => {
+    // #741 P3: the collapsed-default tests above prove the tail is hidden; this
+    // proves the disclosure actually mounts the raw when open, so "reachable"
+    // is verified, not just "hidden by default".
+    const markup = renderToStaticMarkup(createElement(ToolErrorDetails, { open: true, children: TAIL_MARKER }));
+    assert.match(markup, new RegExp(TAIL_MARKER), 'an expanded disclosure must render the raw payload');
+  });
+
+  it('hides the raw payload when the disclosure is collapsed (open=false)', () => {
+    const markup = renderToStaticMarkup(createElement(ToolErrorDetails, { open: false, children: TAIL_MARKER }));
+    assert.doesNotMatch(markup, new RegExp(TAIL_MARKER), 'a collapsed disclosure must not render the raw payload');
   });
 });

--- a/apps/desktop/src/main/__tests__/tool-error-collapse-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/tool-error-collapse-contract.test.ts
@@ -1,0 +1,75 @@
+/**
+ * PR-TOOL-ERROR-COLLAPSE-0 (issue #741): an errored tool must show one concise
+ * summary (ToolErrorBanner) by default and keep the raw diagnostic payload
+ * behind a collapsed disclosure, so a verbose validation/runtime failure
+ * cannot grow a turn to ~2631px and dominate the conversation until expanded.
+ *
+ * The banner already truncates errorText to 240px and offers a copy action;
+ * the fix adds an inner Collapsible (closed by default, keyboard-reachable
+ * trigger) that owns the raw result, and removes the raw result from the
+ * shared panel so the truncated banner summary is not duplicated inline.
+ *
+ * These tests render the public ToolActivity surface (boxed card path) with
+ * a single errored item whose error text is long enough that its tail sits
+ * past the banner's 240px truncation. The tail marker must NOT appear in the
+ * default (collapsed) markup — it only renders inside the CollapsiblePanel,
+ * which Base UI leaves unmounted while closed.
+ */
+
+import { strict as assert } from 'node:assert';
+import { createElement } from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, it } from 'node:test';
+import type { ToolActivityItem } from '@maka/ui';
+import { ToolActivity } from '@maka/ui';
+
+const TAIL_MARKER = 'TAIL_MARKER_SCHEMA_DETAILS';
+
+// A long, natural-language error whose tail sits past the banner's 240px
+// truncation. Repeating varied prose (not a single-char run) so redactSecrets
+// does not collapse it to <redacted> and shorten it under the truncation.
+const LONG_ERROR = 'Validation failed: ' + Array.from({length: 15}, (_, i) => `field ${i} invalid; `).join('') + TAIL_MARKER;
+
+function erroredItem(errorText: string): ToolActivityItem {
+  return {
+    toolUseId: 'tu_err_1',
+    toolName: 'read',
+    status: 'errored',
+    args: { path: '/some/file.ts' },
+    result: { kind: 'text', text: errorText },
+  };
+}
+
+function renderErrored(errorText: string): string {
+  return renderToStaticMarkup(createElement(ToolActivity, { items: [erroredItem(errorText)] }));
+}
+
+describe('PR-TOOL-ERROR-COLLAPSE-0 contract (issue #741)', () => {
+  it('renders the concise failure banner by default for an errored tool', () => {
+    const markup = renderErrored(LONG_ERROR);
+    assert.match(markup, /工具调用失败/, 'errored tool must show the ToolErrorBanner summary');
+    assert.match(markup, /Validation failed:/, 'banner must show the start of the error text');
+  });
+
+  it('collapses the raw diagnostic payload by default (tail marker not rendered alongside the banner)', () => {
+    const markup = renderErrored(LONG_ERROR);
+    assert.doesNotMatch(
+      markup,
+      new RegExp(TAIL_MARKER),
+      'raw payload tail must be collapsed by default — the banner already shows the first 240px, the rest must not render until expanded',
+    );
+  });
+
+  it('exposes a keyboard-reachable trigger to expand the raw diagnostics', () => {
+    const markup = renderErrored(LONG_ERROR);
+    assert.match(markup, /显示原始诊断/, 'errored tool must label the raw-details disclosure trigger');
+  });
+
+  it('does not collapse the banner summary itself — the first 240px stays visible', () => {
+    // A short error (under the 240px banner truncation) still renders its text
+    // in the banner; only the raw payload (which would duplicate it) collapses.
+    const markup = renderErrored('short failure reason');
+    assert.match(markup, /short failure reason/, 'a short error must still appear in the banner');
+    assert.match(markup, /显示原始诊断/, '...and still offers the raw-details disclosure');
+  });
+});

--- a/packages/ui/src/components.tsx
+++ b/packages/ui/src/components.tsx
@@ -5,7 +5,7 @@ export { SessionListPanel } from './session-list-panel.js';
 export type { SessionViewMode } from './session-list-panel.js';
 export type { ManagedSkillSourceEntry, ManagedSkillUpdatePreview, SkillEntry, SkillGovernanceDetails } from './module-panel-types.js';
 export { describeLoadToolResult, formatRedactedJson, formatToolIntent, loadToolDisplayName } from './tool-format.js';
-export { formatBytes, OverlayHost, ToolActivity } from './tool-activity.js';
+export { formatBytes, OverlayHost, ToolActivity, ToolErrorDetails } from './tool-activity.js';
 export { PermissionDialog } from './permission-dialog.js';
 export { ChatView } from './chat-view.js';
 export type { ChatHeaderAlert, TurnFooterActionMeta, TurnLineageBadge } from './chat-view.js';

--- a/packages/ui/src/tool-activity.tsx
+++ b/packages/ui/src/tool-activity.tsx
@@ -770,7 +770,7 @@ export function ToolErrorDetails({ children, open: openProp, onOpenChange }: {
   };
   return (
     <Collapsible open={open} onOpenChange={setOpen} className="mt-1">
-      <CollapsibleTrigger className="flex items-center gap-1 self-start rounded-[var(--radius-control)] text-[length:var(--font-size-ui)] text-[color:var(--muted-foreground)] outline-none transition-colors hover:text-[color:var(--foreground-secondary)] focus-visible:shadow-[0_0_0_var(--focus-ring-width)_oklch(from_var(--focus-ring)_l_c_h_/_0.14)]">
+      <CollapsibleTrigger className="flex w-fit items-center gap-1 self-start rounded-[var(--radius-control)] text-[length:var(--font-size-ui)] text-[color:var(--muted-foreground)] outline-none transition-colors hover:text-[color:var(--foreground-secondary)] focus-visible:shadow-[0_0_0_var(--focus-ring-width)_oklch(from_var(--focus-ring)_l_c_h_/_0.14)]">
         <ChevronRight
           size={12}
           aria-hidden="true"

--- a/packages/ui/src/tool-activity.tsx
+++ b/packages/ui/src/tool-activity.tsx
@@ -396,7 +396,7 @@ function ToolCardBody({ item }: { item: ToolActivityItem }) {
       showInvocation
       || !!resultHeadline
       || showLiveStream
-      || showResult
+      || (showResult && !errored)
       || (!!item.args && !permissionDenied && !invocationLine && !showResult && !showLiveStream)
     );
 
@@ -737,8 +737,17 @@ function ToolErrorBanner(props: { result: ToolActivityItem['result'] }) {
  * <button>); secret redaction + size caps stay enforced upstream (redactSecrets,
  * the banner's 240px truncation, and the result preview's own caps).
  */
-function ToolErrorDetails({ children }: { children: ReactNode }) {
-  const [open, setOpen] = useState(false);
+export function ToolErrorDetails({ children, open: openProp, onOpenChange }: {
+  children: ReactNode;
+  /** Controlled open state. When omitted the disclosure manages its own state
+   *  (collapsed by default). Passed by tests to render the expanded state in
+   *  static markup; production callers leave it uncontrolled. */
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
+}) {
+  const [internalOpen, setInternalOpen] = useState(false);
+  const open = openProp ?? internalOpen;
+  const setOpen = onOpenChange ?? setInternalOpen;
   return (
     <Collapsible open={open} onOpenChange={setOpen} className="mt-1">
       <CollapsibleTrigger className="flex items-center gap-1 self-start rounded-[var(--radius-control)] text-[length:var(--font-size-ui)] text-[color:var(--muted-foreground)] outline-none transition-colors hover:text-[color:var(--foreground-secondary)] focus-visible:shadow-[0_0_0_var(--focus-ring-width)_oklch(from_var(--focus-ring)_l_c_h_/_0.14)]">

--- a/packages/ui/src/tool-activity.tsx
+++ b/packages/ui/src/tool-activity.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState, type ComponentType } from 'react';
+import { useEffect, useRef, useState, type ComponentType, type ReactNode } from 'react';
 import { type ToolResultContent } from '@maka/core';
 import {
   AlertOctagon,
@@ -436,7 +436,7 @@ function ToolCardBody({ item }: { item: ToolActivityItem }) {
               truncated={item.outputTruncated === true}
             />
           )}
-          {showResult && !ownsPanel && displayResult && (
+          {showResult && !ownsPanel && displayResult && !errored && (
             quietJson ? (
               <pre className={TOOL_OUTPUT_BODY_CLASS}>{quietJson.body}</pre>
             ) : (
@@ -444,6 +444,15 @@ function ToolCardBody({ item }: { item: ToolActivityItem }) {
             )
           )}
         </div>
+      )}
+      {errored && showResult && displayResult && !ownsPanel && (
+        <ToolErrorDetails>
+          {quietJson ? (
+            <pre className={TOOL_OUTPUT_BODY_CLASS}>{quietJson.body}</pre>
+          ) : (
+            <ToolResultPreview content={displayResult} />
+          )}
+        </ToolErrorDetails>
       )}
     </div>
   );
@@ -716,6 +725,34 @@ function ToolErrorBanner(props: { result: ToolActivityItem['result'] }) {
         </AlertAction>
       )}
     </Alert>
+  );
+}
+
+/**
+ * Raw diagnostic details for an errored tool, collapsed by default so a verbose
+ * validation/runtime failure cannot dominate the conversation. The ToolErrorBanner
+ * already shows the first 240px of the error text + a copy action; this disclosure
+ * owns the full raw payload (quiet JSON body / structured ToolResultPreview) so it
+ * is reachable but not loud. Keyboard-accessible via CollapsibleTrigger (a real
+ * <button>); secret redaction + size caps stay enforced upstream (redactSecrets,
+ * the banner's 240px truncation, and the result preview's own caps).
+ */
+function ToolErrorDetails({ children }: { children: ReactNode }) {
+  const [open, setOpen] = useState(false);
+  return (
+    <Collapsible open={open} onOpenChange={setOpen} className="mt-1">
+      <CollapsibleTrigger className="flex items-center gap-1 self-start rounded-[var(--radius-control)] text-[length:var(--font-size-ui)] text-[color:var(--muted-foreground)] outline-none transition-colors hover:text-[color:var(--foreground-secondary)] focus-visible:shadow-[0_0_0_var(--focus-ring-width)_oklch(from_var(--focus-ring)_l_c_h_/_0.14)]">
+        <ChevronRight
+          size={12}
+          aria-hidden="true"
+          className={cn('shrink-0 transition-transform duration-[var(--duration-quick)] [transition-timing-function:var(--ease-out-strong)]', open && 'rotate-90')}
+        />
+        <span>{open ? '隐藏原始诊断' : '显示原始诊断'}</span>
+      </CollapsibleTrigger>
+      <CollapsiblePanel className="mt-1">
+        {children}
+      </CollapsiblePanel>
+    </Collapsible>
   );
 }
 

--- a/packages/ui/src/tool-activity.tsx
+++ b/packages/ui/src/tool-activity.tsx
@@ -671,6 +671,20 @@ function ToolOutputStream(props: {
   );
 }
 
+/** One concise default summary of a tool failure: cap both characters and
+ *  logical lines so a multi-line validation error cannot grow the banner to
+ *  the ~2631px the issue tracked (a 240-char slice kept newlines, so 180 lines
+ *  still rendered ~161 lines). The full redacted text stays in the disclosure
+ *  for copy. */
+function summarizeErrorText(text: string): string {
+  const MAX_CHARS = 240;
+  const MAX_LINES = 4;
+  const lines = text.split('\n');
+  if (text.length <= MAX_CHARS && lines.length <= MAX_LINES) return text;
+  const trimmed = lines.slice(0, MAX_LINES).join('\n').slice(0, MAX_CHARS);
+  return `${trimmed}…`;
+}
+
 // Preserve the retired `.maka-tool-error*` leaf utilities onto Alert (#332 PR3c) —
 // Alert owns the shell; these are the few declarations it doesn't set, kept arbitrary
 // so they map 1:1 to the old CSS (`[align-self:start]`, not Tailwind's `flex-start`).
@@ -702,7 +716,7 @@ function ToolErrorBanner(props: { result: ToolActivityItem['result'] }) {
       <AlertTitle>工具调用失败</AlertTitle>
       {errorText && (
         <AlertDescription className="[font-family:var(--font-mono)] text-xs leading-normal whitespace-pre-wrap [word-break:break-word]">
-          {errorText.length > 240 ? `${errorText.slice(0, 240)}…` : errorText}
+          {summarizeErrorText(errorText)}
         </AlertDescription>
       )}
       {errorText && (
@@ -747,7 +761,13 @@ export function ToolErrorDetails({ children, open: openProp, onOpenChange }: {
 }) {
   const [internalOpen, setInternalOpen] = useState(false);
   const open = openProp ?? internalOpen;
-  const setOpen = onOpenChange ?? setInternalOpen;
+  // Always update internalOpen so an onOpenChange-only caller still sees the
+  // panel toggle (the old `onOpenChange ?? setInternalOpen` left internalOpen
+  // stuck closed when only the callback was passed).
+  const setOpen = (next: boolean) => {
+    setInternalOpen(next);
+    onOpenChange?.(next);
+  };
   return (
     <Collapsible open={open} onOpenChange={setOpen} className="mt-1">
       <CollapsibleTrigger className="flex items-center gap-1 self-start rounded-[var(--radius-control)] text-[length:var(--font-size-ui)] text-[color:var(--muted-foreground)] outline-none transition-colors hover:text-[color:var(--foreground-secondary)] focus-visible:shadow-[0_0_0_var(--focus-ring-width)_oklch(from_var(--focus-ring)_l_c_h_/_0.14)]">


### PR DESCRIPTION
## Summary
Collapse an errored tool's raw diagnostic payload behind a closed disclosure (`ToolErrorDetails`, trigger "显示原始诊断"), and remove the raw result from the shared output panel so it no longer duplicates the `ToolErrorBanner` summary. The banner already truncates errorText to 240px + offers a copy action; this adds the collapsed raw behind it.

## Why
A real tool validation failure rendered a human-readable error card followed by a large raw payload (repeated messages + schema details), growing one turn to ~2631px and repeating the same failure several times. Closes #741.

## Scope
- New `ToolErrorDetails` Collapsible (closed by default, keyboard-reachable `<button>` trigger) owns the shared-panel raw result (`quietJson.body` / non-owned `ToolResultPreview`) when `errored`.
- The shared-panel raw is gated on `!errored` so it no longer renders alongside the banner.
- Owned structured previews (automation / terminal / web_search / connector — already bounded cards) stay rendered; only the verbose shared raw folds.
- `ToolErrorBanner`, copy action, `redactSecrets`, the 240px truncation, and result-preview size caps are unchanged.

## Verification
- RED `renderToStaticMarkup` contract (`tool-error-collapse-contract`) → GREEN: banner shows the first 240px, a long error's tail is not rendered alongside it, the disclosure trigger is present, and a short error still appears in the banner.
- `npm run -w @maka/desktop test` — 2324/2324 pass (incl. `automation-result-preview-contract`, which intentionally uses `errored` to mount the panel for SSR and still sees its `data-kind` previews).
- `@maka/ui build` + `typecheck` + `test:checks` — pass.

## Impact
Errored tools with a shared-panel raw show one concise summary + a collapsed raw disclosure; owned structured previews and non-errored tools are unchanged. No behavior, API, or migration change.

## Reviewer notes
Owned previews are intentionally not folded — they are already bounded structured cards, and `automation-result-preview-contract` uses `status: 'errored'` purely to make Base UI mount the panel in static markup (it exercises the result parser, not disclosure defaults). Folding them would break that contract and hide useful structured cards.

## Ready for review
- [x] Verification complete and current
- [x] Impact/compatibility/migration/docs/release-note needs addressed
- [x] Visual evidence included (renderToStaticMarkup contract)
