### PR TITLE
refactor(ui): converge remaining sidebar row indicator sizes (#743)

### DIFF
--- a/apps/desktop/src/main/__tests__/sidebar-indicator-size-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/sidebar-indicator-size-contract.test.ts
@@ -1,15 +1,20 @@
 /**
  * PR-SIDEBAR-INDICATOR-SIZE-CONVERGE-0 (issue #743, follow-up to #738):
  * session-row indicator sizes converge onto tokens. After the fresh-eye
- * codex review the status icon keeps its dense-meta 12px (per
- * docs/design-system.md §1.9 — dense-meta icons are call-site 12–14px, NOT
- * --icon-size 16px) via a local SVG override, instead of the earlier "converge
- * to 16px" which violated the design contract and silently grew the icon
- * 14→16px. The contract pins each indicator's width/height exactly-once per
- * property (a height-only override is caught, not just a width block) and
- * drops the over-broad `.maka-list-row-*` prefix scanner (it governed
- * non-indicators like -main/-text/-menu-trigger and false-positived on
- * `calc(…)`).
+ * codex review:
+ *   - streaming-dot/unread 8px → var(--space-2)
+ *   - status icon keeps its 14px wrapper layout slot (a documented dense-meta
+ *     exception per docs/design-system.md §1.9) AND scopes a local 12px SVG
+ *     override so buttonVariants' [&_svg]:size-[var(--icon-size,1rem)] (16px
+ *     chrome tier, a cascade leak from borrowing UiButton) does not grow the
+ *     <Icon size={12}> dense-meta glyph. The wrapper footprint stays 14px so
+ *     the title does not shift.
+ *   - .maka-list-row-text min-height was dropped — the row's 32px control
+ *     min-height + grid center owns the height, so the 24px was redundant.
+ *
+ * The contract pins each indicator's width/height/min-height exactly-once
+ * across rest blocks AND within each block (a `height: a; height: b` in one
+ * block is caught, not just a second block).
  */
 
 import { strict as assert } from 'node:assert';
@@ -24,15 +29,14 @@ function styleRules(css: string): Array<[string, string]> {
   });
 }
 
-function decl(body: string, prop: string): string | undefined {
-  const re = new RegExp(`(?:^|[\\n;])\\s*${prop}\\s*:\\s*([^;}]*)`, 'i');
-  const m = body.match(re);
-  return m ? m[1].trim().replace(/\s+/g, ' ') : undefined;
+/** ALL declarations of `prop` within one block (global match), so a
+ *  `height: var(--space-2); height: var(--space-3)` same-block override is
+ *  surfaced as two declarations, not collapsed to the first. */
+function declarationsIn(body: string, prop: string): string[] {
+  const re = new RegExp(`(?:^|[\\n;])\\s*${prop}\\s*:\\s*([^;}]*)`, 'ig');
+  return [...body.matchAll(re)].map((m) => m[1].trim().replace(/\s+/g, ' '));
 }
 
-/** All rest-state blocks whose subject is exactly `subjectSelector` (no state
- *  pseudo, no attribute, no @media prelude). Returns ALL matches so a later
- *  same-selector override (the cascade winner) is caught, not just the first. */
 function restBlocks(css: string, subjectSelector: string): string[] {
   const escaped = subjectSelector.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
   const re = new RegExp(`^${escaped}\\s*$`);
@@ -45,57 +49,46 @@ function restBlocks(css: string, subjectSelector: string): string[] {
   return blocks;
 }
 
-/** Rest blocks that actually set `prop` — e.g. the @media animation-only block
- *  for streaming-dot sets no width, so it is excluded. Counting these lets a
- *  height-only override (a second block setting just height) be caught. */
-function restBlocksSetting(css: string, subjectSelector: string, prop: string): string[] {
-  return restBlocks(css, subjectSelector).filter((b) => decl(b, prop) !== undefined);
-}
-
-/** Assert `prop` is set in exactly one rest block of `selector`, with `expected`
- *  value. Catches both first-match and height-only-override false-greens. */
+/** Assert `prop` is declared exactly once across all rest blocks of `selector`,
+ *  with `expected` value. Catches both a second rest block and a same-block
+ *  duplicate (`height: a; height: b`) — either yields two declarations. */
 function assertExactlyOnce(css: string, selector: string, prop: string, expected: string, label: string): void {
-  const blocks = restBlocksSetting(css, selector, prop);
-  assert.equal(blocks.length, 1, `${label}: ${prop} must be set in exactly one rest block (a later same-selector override would win the cascade); got ${blocks.length}`);
-  assert.equal(decl(blocks[0]!, prop), expected, `${label}: ${prop} must be ${expected}`);
+  const blocks = restBlocks(css, selector);
+  const decls = blocks.flatMap((b) => declarationsIn(b, prop));
+  assert.equal(decls.length, 1, `${label}: ${prop} must be declared exactly once (a later rest block OR a same-block duplicate would both win the cascade); got ${decls.length}: ${JSON.stringify(decls)}`);
+  assert.equal(decls[0], expected, `${label}: ${prop} must be ${expected}`);
 }
 
 describe('PR-SIDEBAR-INDICATOR-SIZE-CONVERGE-0 contract (issue #743)', () => {
-  it('.maka-list-row-streaming-dot width and height are each var(--space-2), set exactly once', async () => {
+  it('.maka-list-row-streaming-dot width and height are each var(--space-2), declared exactly once', async () => {
     const css = stripCssComments(await readAllRendererCss());
     assertExactlyOnce(css, '.maka-list-row-streaming-dot', 'width', 'var(--space-2)', 'streaming-dot');
     assertExactlyOnce(css, '.maka-list-row-streaming-dot', 'height', 'var(--space-2)', 'streaming-dot');
   });
 
-  it('.maka-list-row-unread width and height are each var(--space-2), set exactly once', async () => {
+  it('.maka-list-row-unread width and height are each var(--space-2), declared exactly once', async () => {
     const css = stripCssComments(await readAllRendererCss());
     assertExactlyOnce(css, '.maka-list-row-unread', 'width', 'var(--space-2)', 'unread');
     assertExactlyOnce(css, '.maka-list-row-unread', 'height', 'var(--space-2)', 'unread');
   });
 
-  it('.maka-list-row-text min-height is var(--space-6) (content spacing, not a control token)', async () => {
+  it('.maka-list-row-text declares no min-height (the row 32px control min-height + grid center own the height)', async () => {
     const css = stripCssComments(await readAllRendererCss());
-    assertExactlyOnce(css, '.maka-list-row-text', 'min-height', 'var(--space-6)', 'list-row-text');
+    const decls = restBlocks(css, '.maka-list-row-text').flatMap((b) => declarationsIn(b, 'min-height'));
+    assert.equal(decls.length, 0, `.maka-list-row-text must not set min-height (redundant with .maka-list-row's 32px); got ${JSON.stringify(decls)}`);
   });
 
-  it('.maka-list-row-status-icon wrapper declares no width/height; the SVG is var(--space-3) (12px dense meta)', async () => {
+  it('.maka-list-row-status-icon wrapper is 14px (dense-meta slot) and the SVG is var(--space-3) (12px)', async () => {
     const css = stripCssComments(await readAllRendererCss());
-    // wrapper: no width/height (the SVG owns the footprint)
-    const wrapper = restBlocks(css, '.maka-list-row-status-icon');
-    for (const b of wrapper) {
-      assert.equal(decl(b, 'width'), undefined, 'status-icon wrapper must not set width');
-      assert.equal(decl(b, 'height'), undefined, 'status-icon wrapper must not set height');
-    }
-    // svg: 12px dense-meta override (var(--space-3)), not --icon-size 16px
+    assertExactlyOnce(css, '.maka-list-row-status-icon', 'width', '14px', 'status-icon wrapper');
+    assertExactlyOnce(css, '.maka-list-row-status-icon', 'height', '14px', 'status-icon wrapper');
     assertExactlyOnce(css, '.maka-list-row-status-icon svg', 'width', 'var(--space-3)', 'status-icon svg');
     assertExactlyOnce(css, '.maka-list-row-status-icon svg', 'height', 'var(--space-3)', 'status-icon svg');
   });
 
-  it('assertExactlyOnce flags a height-only same-selector override (negative case)', () => {
-    const fakeCss =
-      '.maka-list-row-unread { width: var(--space-2); height: var(--space-2); }\n' +
-      '.maka-list-row-unread { height: var(--space-3); }';
-    const blocks = restBlocksSetting(fakeCss, '.maka-list-row-unread', 'height');
-    assert.equal(blocks.length, 2, 'a height-only override must be caught (two height blocks), not silently pass via first-match');
+  it('assertExactlyOnce flags a same-block duplicate override (negative case)', () => {
+    const fakeCss = '.maka-list-row-unread { width: var(--space-2); height: var(--space-2); height: var(--space-3); }';
+    const decls = restBlocks(fakeCss, '.maka-list-row-unread').flatMap((b) => declarationsIn(b, 'height'));
+    assert.equal(decls.length, 2, 'a same-block height duplicate must be caught (two declarations), not silently pass via first-match');
   });
 });

--- a/apps/desktop/src/main/__tests__/sidebar-indicator-size-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/sidebar-indicator-size-contract.test.ts
@@ -1,26 +1,18 @@
 /**
  * PR-SIDEBAR-INDICATOR-SIZE-CONVERGE-0 (issue #743, follow-up to #738):
- * the session-row indicator path used bare 8/14/24px literals that bypassed
- * the spacing and control-height vocabularies. Converge them onto tokens so
- * the row can't drift off-ruler:
- *
- *   .maka-list-row-streaming-dot  width/height 8px → var(--space-2)
- *   .maka-list-row-unread         width/height 8px → var(--space-2)
- *   .maka-list-row-text           min-height 24px → var(--h-control-sm)
- *   .maka-list-row-status-icon    width/height 14px → documented dense exception (kept)
- *
- * The 14px status icon stays a documented exception: --icon-size is 16px
- * (chrome glyphs), and 16px would degrade the session row's density. The
- * contract asserts that one selector keeps 14px so a NEW bare 14px elsewhere
- * in the indicator path would still need its own exception.
+ * session-row indicator sizes converge onto tokens. After the codex review
+ * the status-icon 14px wrapper was removed (it never clipped the SVG —
+ * buttonVariants owns the in-button glyph size via var(--icon-size), so the
+ * icon converges to 16px like every other in-button glyph), and the contract
+ * now scans ALL .maka-list-row-* selectors for bare-px width/height/min-height
+ * so a new off-ruler indicator cannot sneak back. .maka-list-row-text uses
+ * var(--space-6) (content spacing), not --h-control-sm (reserved for controls
+ * by control-height-converge-contract).
  */
 
 import { strict as assert } from 'node:assert';
 import { describe, it } from 'node:test';
-import {
-  readAllRendererCss,
-  stripCssComments,
-} from './css-test-helpers.js';
+import { readAllRendererCss, stripCssComments } from './css-test-helpers.js';
 
 function styleRules(css: string): Array<[string, string]> {
   const stripped = stripCssComments(css);
@@ -30,55 +22,96 @@ function styleRules(css: string): Array<[string, string]> {
   });
 }
 
+/** Extract a declared property value from a selector block's body. Matches
+ *  at start-of-block or after a `;` or newline so single- and multi-line
+ *  declarations both work. Whitespace is collapsed. */
 function decl(body: string, prop: string): string | undefined {
-  const re = new RegExp(`(?:^|\\n)\\s*${prop}\\s*:\\s*([^;}]*)`, 'i');
+  const re = new RegExp(`(?:^|[\\n;])\\s*${prop}\\s*:\\s*([^;}]*)`, 'i');
   const m = body.match(re);
   return m ? m[1].trim().replace(/\s+/g, ' ') : undefined;
 }
 
-function restBlock(css: string, subjectSelector: string): string | undefined {
+function restBlocks(css: string, subjectSelector: string): string[] {
   const escaped = subjectSelector.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
   const re = new RegExp(`^${escaped}\\s*$`);
+  const blocks: string[] = [];
   for (const [prelude, body] of styleRules(css)) {
     if (prelude && !prelude.startsWith('@') && re.test(prelude) && !/[:[]/.test(prelude)) {
-      return body;
+      blocks.push(body);
     }
   }
-  return undefined;
+  return blocks;
+}
+
+const NEUTRAL_SIZE = /^(?:0(?:px|%)?|100%|auto|inherit|initial|unset|revert|none)$/;
+
+/** Bare-px width/height/min-height on any .maka-list-row-* selector — the
+ *  indicator path must use tokens (var(...)) or neutral literals. A new
+ *  off-ruler indicator anywhere in .maka-list-row-* is flagged here, not
+ *  just the four originally-listed selectors. */
+function barePxSizeOffenders(css: string): string[] {
+  const offenders: string[] = [];
+  for (const [prelude, body] of styleRules(css)) {
+    if (!prelude.includes('.maka-list-row-')) continue;
+    for (const prop of ['width', 'height', 'min-height']) {
+      const v = decl(body, prop);
+      if (v === undefined) continue;
+      if (/^var\(/.test(v) || NEUTRAL_SIZE.test(v)) continue;
+      offenders.push(`${prelude.replace(/\s+/g, ' ')} ${prop}: ${v}`);
+    }
+  }
+  return offenders;
+}
+
+/** Among the rest blocks for a selector, the ones that actually set `prop`
+ *  (e.g. the @media animation-only block for streaming-dot sets no width, so
+ *  it is excluded — only the geometry block counts). */
+function restBlocksSetting(css: string, subjectSelector: string, prop: string): string[] {
+  return restBlocks(css, subjectSelector).filter((b) => decl(b, prop) !== undefined);
 }
 
 describe('PR-SIDEBAR-INDICATOR-SIZE-CONVERGE-0 contract (issue #743)', () => {
-  it('.maka-list-row-streaming-dot uses var(--space-2) for width/height (not bare 8px)', async () => {
+  it('.maka-list-row-streaming-dot uses var(--space-2) for width/height', async () => {
     const css = stripCssComments(await readAllRendererCss());
-    const body = restBlock(css, '.maka-list-row-streaming-dot');
-    assert.ok(body, '.maka-list-row-streaming-dot rest block not found');
-    assert.equal(decl(body, 'width'), 'var(--space-2)', 'streaming-dot width must be var(--space-2)');
-    assert.equal(decl(body, 'height'), 'var(--space-2)', 'streaming-dot height must be var(--space-2)');
+    const w = restBlocksSetting(css, '.maka-list-row-streaming-dot', 'width');
+    assert.equal(w.length, 1, '.maka-list-row-streaming-dot width must be set in exactly one rest block (the @media animation block sets none)');
+    assert.equal(decl(w[0]!, 'width'), 'var(--space-2)');
+    assert.equal(decl(w[0]!, 'height'), 'var(--space-2)');
   });
 
-  it('.maka-list-row-unread uses var(--space-2) for width/height (not bare 8px)', async () => {
+  it('.maka-list-row-unread uses var(--space-2) for width/height', async () => {
     const css = stripCssComments(await readAllRendererCss());
-    const body = restBlock(css, '.maka-list-row-unread');
-    assert.ok(body, '.maka-list-row-unread rest block not found');
-    assert.equal(decl(body, 'width'), 'var(--space-2)', 'unread width must be var(--space-2)');
-    assert.equal(decl(body, 'height'), 'var(--space-2)', 'unread height must be var(--space-2)');
+    const w = restBlocksSetting(css, '.maka-list-row-unread', 'width');
+    assert.equal(w.length, 1, '.maka-list-row-unread width must be set in exactly one rest block');
+    assert.equal(decl(w[0]!, 'width'), 'var(--space-2)');
+    assert.equal(decl(w[0]!, 'height'), 'var(--space-2)');
   });
 
-  it('.maka-list-row-text min-height uses var(--h-control-sm) (not bare 24px)', async () => {
+  it('.maka-list-row-text min-height uses var(--space-6) (content spacing, not a control token)', async () => {
     const css = stripCssComments(await readAllRendererCss());
-    const body = restBlock(css, '.maka-list-row-text');
-    assert.ok(body, '.maka-list-row-text rest block not found');
-    assert.equal(decl(body, 'min-height'), 'var(--h-control-sm)', 'list-row-text min-height must be var(--h-control-sm)');
+    const m = restBlocksSetting(css, '.maka-list-row-text', 'min-height');
+    assert.equal(m.length, 1, '.maka-list-row-text min-height must be set in exactly one rest block');
+    assert.equal(decl(m[0]!, 'min-height'), 'var(--space-6)');
   });
 
-  it('.maka-list-row-status-icon stays a documented dense exception (14px, not --icon-size=16px)', async () => {
+  it('.maka-list-row-status-icon declares no width/height (the SVG size is owned by buttonVariants)', async () => {
     const css = stripCssComments(await readAllRendererCss());
-    const body = restBlock(css, '.maka-list-row-status-icon');
-    assert.ok(body, '.maka-list-row-status-icon rest block not found');
-    // 14px is the documented dense exception: --icon-size is 16px (chrome glyphs)
-    // and 16px would degrade the session row's density. Pinned here so a NEW
-    // bare 14px elsewhere in the indicator path still needs its own exception.
-    assert.equal(decl(body, 'width'), '14px', 'status-icon width is the documented 14px dense exception');
-    assert.equal(decl(body, 'height'), '14px', 'status-icon height is the documented 14px dense exception');
+    const blocks = restBlocks(css, '.maka-list-row-status-icon');
+    for (const b of blocks) {
+      assert.equal(decl(b, 'width'), undefined, 'no .maka-list-row-status-icon rest block may set width (buttonVariants sizes the SVG via var(--icon-size))');
+      assert.equal(decl(b, 'height'), undefined, 'no .maka-list-row-status-icon rest block may set height');
+    }
+  });
+
+  it('no bare-px width/height/min-height remains on any .maka-list-row-* selector', async () => {
+    const css = stripCssComments(await readAllRendererCss());
+    const offenders = barePxSizeOffenders(css);
+    assert.deepEqual(offenders, [], `Offenders:\n  ${offenders.join('\n  ')}`);
+  });
+
+  it('barePxSizeOffenders flags a new off-ruler indicator (negative case)', () => {
+    const fakeCss = '.maka-list-row-other-indicator { width: 14px; height: 14px; }';
+    const offenders = barePxSizeOffenders(fakeCss);
+    assert.equal(offenders.length, 2, 'a new bare-px .maka-list-row-* indicator must be flagged, not just the four originally-listed selectors');
   });
 });

--- a/apps/desktop/src/main/__tests__/sidebar-indicator-size-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/sidebar-indicator-size-contract.test.ts
@@ -1,20 +1,18 @@
 /**
  * PR-SIDEBAR-INDICATOR-SIZE-CONVERGE-0 (issue #743, follow-up to #738):
- * session-row indicator sizes converge onto tokens. After the fresh-eye
- * codex review:
+ * session-row indicator sizes converge onto tokens, except the dense-meta
+ * status icon which §1.9 keeps as call-site 12–14px (not tokenized):
  *   - streaming-dot/unread 8px → var(--space-2)
- *   - status icon keeps its 14px wrapper layout slot (a documented dense-meta
- *     exception per docs/design-system.md §1.9) AND scopes a local 12px SVG
- *     override so buttonVariants' [&_svg]:size-[var(--icon-size,1rem)] (16px
- *     chrome tier, a cascade leak from borrowing UiButton) does not grow the
- *     <Icon size={12}> dense-meta glyph. The wrapper footprint stays 14px so
- *     the title does not shift.
- *   - .maka-list-row-text min-height was dropped — the row's 32px control
- *     min-height + grid center owns the height, so the 24px was redundant.
+ *   - status icon keeps its 14px wrapper layout slot (bare, dense-meta) and
+ *     scopes a local 12px SVG override (bare, dense-meta) so buttonVariants'
+ *     [&_svg]:size-[var(--icon-size,1rem)] (16px chrome tier, a cascade leak
+ *     from borrowing UiButton) does not grow the <Icon size={12}> glyph
+ *   - .maka-list-row-text min-height dropped (row 32px + grid center own it)
  *
  * The contract pins each indicator's width/height/min-height exactly-once
- * across rest blocks AND within each block (a `height: a; height: b` in one
- * block is caught, not just a second block).
+ * across rest blocks AND within each block, and matches selector lists
+ * (`.other, .maka-list-row-unread { height: … }` is scanned, not just rules
+ * whose whole prelude equals the subject).
  */
 
 import { strict as assert } from 'node:assert';
@@ -29,34 +27,34 @@ function styleRules(css: string): Array<[string, string]> {
   });
 }
 
-/** ALL declarations of `prop` within one block (global match), so a
- *  `height: var(--space-2); height: var(--space-3)` same-block override is
- *  surfaced as two declarations, not collapsed to the first. */
 function declarationsIn(body: string, prop: string): string[] {
   const re = new RegExp(`(?:^|[\\n;])\\s*${prop}\\s*:\\s*([^;}]*)`, 'ig');
   return [...body.matchAll(re)].map((m) => m[1].trim().replace(/\s+/g, ' '));
 }
 
+/** Rest blocks whose selector list CONTAINS `subjectSelector` as a whole
+ *  selector (split on top-level commas, so `.other, .maka-list-row-unread` is
+ *  scanned for `.maka-list-row-unread`). State pseudo / attribute variants are
+ *  excluded — only the plain subject counts as the rest definition. */
 function restBlocks(css: string, subjectSelector: string): string[] {
-  const escaped = subjectSelector.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-  const re = new RegExp(`^${escaped}\\s*$`);
   const blocks: string[] = [];
   for (const [prelude, body] of styleRules(css)) {
-    if (prelude && !prelude.startsWith('@') && re.test(prelude) && !/[:[]/.test(prelude)) {
+    if (!prelude || prelude.startsWith('@')) continue;
+    const selectors = prelude.split(',').map((s) => s.trim());
+    if (selectors.some((sel) => sel === subjectSelector && !/[:[]/.test(sel))) {
       blocks.push(body);
     }
   }
   return blocks;
 }
 
-/** Assert `prop` is declared exactly once across all rest blocks of `selector`,
- *  with `expected` value. Catches both a second rest block and a same-block
- *  duplicate (`height: a; height: b`) — either yields two declarations. */
+/** Assert `prop` is declared exactly once across all rest blocks of `selector`
+ *  with `expected` value (a later rest block, a selector-list companion, or a
+ *  same-block duplicate each fail). */
 function assertExactlyOnce(css: string, selector: string, prop: string, expected: string, label: string): void {
-  const blocks = restBlocks(css, selector);
-  const decls = blocks.flatMap((b) => declarationsIn(b, prop));
-  assert.equal(decls.length, 1, `${label}: ${prop} must be declared exactly once (a later rest block OR a same-block duplicate would both win the cascade); got ${decls.length}: ${JSON.stringify(decls)}`);
-  assert.equal(decls[0], expected, `${label}: ${prop} must be ${expected}`);
+  const decls = restBlocks(css, selector).flatMap((b) => declarationsIn(b, prop));
+  assert.equal(decls.length, 1, `${label}: ${prop} must be declared exactly once (a later rest block, a selector-list companion, OR a same-block duplicate would all win the cascade); got ${decls.length}: ${JSON.stringify(decls)}`);
+  assert.equal(decls[0], expected, `${label}: ${prop} must be ${expected}; got ${decls[0]}`);
 }
 
 describe('PR-SIDEBAR-INDICATOR-SIZE-CONVERGE-0 contract (issue #743)', () => {
@@ -78,17 +76,27 @@ describe('PR-SIDEBAR-INDICATOR-SIZE-CONVERGE-0 contract (issue #743)', () => {
     assert.equal(decls.length, 0, `.maka-list-row-text must not set min-height (redundant with .maka-list-row's 32px); got ${JSON.stringify(decls)}`);
   });
 
-  it('.maka-list-row-status-icon wrapper is 14px (dense-meta slot) and the SVG is var(--space-3) (12px)', async () => {
+  it('.maka-list-row-status-icon wrapper is 14px (dense-meta slot) and the SVG is 12px (dense-meta, not tokenized)', async () => {
     const css = stripCssComments(await readAllRendererCss());
     assertExactlyOnce(css, '.maka-list-row-status-icon', 'width', '14px', 'status-icon wrapper');
     assertExactlyOnce(css, '.maka-list-row-status-icon', 'height', '14px', 'status-icon wrapper');
-    assertExactlyOnce(css, '.maka-list-row-status-icon svg', 'width', 'var(--space-3)', 'status-icon svg');
-    assertExactlyOnce(css, '.maka-list-row-status-icon svg', 'height', 'var(--space-3)', 'status-icon svg');
+    assertExactlyOnce(css, '.maka-list-row-status-icon svg', 'width', '12px', 'status-icon svg');
+    assertExactlyOnce(css, '.maka-list-row-status-icon svg', 'height', '12px', 'status-icon svg');
   });
 
-  it('assertExactlyOnce flags a same-block duplicate override (negative case)', () => {
-    const fakeCss = '.maka-list-row-unread { width: var(--space-2); height: var(--space-2); height: var(--space-3); }';
-    const decls = restBlocks(fakeCss, '.maka-list-row-unread').flatMap((b) => declarationsIn(b, 'height'));
-    assert.equal(decls.length, 2, 'a same-block height duplicate must be caught (two declarations), not silently pass via first-match');
+  it('assertExactlyOnce flags a same-block duplicate AND a selector-list companion (negative cases)', () => {
+    const sameBlock = '.maka-list-row-unread { width: var(--space-2); height: var(--space-2); height: var(--space-3); }';
+    assert.throws(
+      () => assertExactlyOnce(sameBlock, '.maka-list-row-unread', 'height', 'var(--space-2)', 'unread'),
+      /got 2/,
+      'a same-block height duplicate must be caught',
+    );
+    // .other, .maka-list-row-unread — the selector-list companion wins the cascade
+    const selectorList = '.other, .maka-list-row-unread { height: var(--space-3); }';
+    assert.throws(
+      () => assertExactlyOnce(selectorList, '.maka-list-row-unread', 'height', 'var(--space-2)', 'unread'),
+      /var\(--space-3\)/,
+      'a selector-list companion setting height must be caught (the override var(--space-3) won the cascade)',
+    );
   });
 });

--- a/apps/desktop/src/main/__tests__/sidebar-indicator-size-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/sidebar-indicator-size-contract.test.ts
@@ -1,0 +1,84 @@
+/**
+ * PR-SIDEBAR-INDICATOR-SIZE-CONVERGE-0 (issue #743, follow-up to #738):
+ * the session-row indicator path used bare 8/14/24px literals that bypassed
+ * the spacing and control-height vocabularies. Converge them onto tokens so
+ * the row can't drift off-ruler:
+ *
+ *   .maka-list-row-streaming-dot  width/height 8px → var(--space-2)
+ *   .maka-list-row-unread         width/height 8px → var(--space-2)
+ *   .maka-list-row-text           min-height 24px → var(--h-control-sm)
+ *   .maka-list-row-status-icon    width/height 14px → documented dense exception (kept)
+ *
+ * The 14px status icon stays a documented exception: --icon-size is 16px
+ * (chrome glyphs), and 16px would degrade the session row's density. The
+ * contract asserts that one selector keeps 14px so a NEW bare 14px elsewhere
+ * in the indicator path would still need its own exception.
+ */
+
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'node:test';
+import {
+  readAllRendererCss,
+  stripCssComments,
+} from './css-test-helpers.js';
+
+function styleRules(css: string): Array<[string, string]> {
+  const stripped = stripCssComments(css);
+  return [...stripped.matchAll(/([^{}]+)\{([^{}]*)\}/g)].map((m) => {
+    const prelude = m[1].replace(/^[\s\S]*;/, '').trim();
+    return [prelude, m[2]] as [string, string];
+  });
+}
+
+function decl(body: string, prop: string): string | undefined {
+  const re = new RegExp(`(?:^|\\n)\\s*${prop}\\s*:\\s*([^;}]*)`, 'i');
+  const m = body.match(re);
+  return m ? m[1].trim().replace(/\s+/g, ' ') : undefined;
+}
+
+function restBlock(css: string, subjectSelector: string): string | undefined {
+  const escaped = subjectSelector.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const re = new RegExp(`^${escaped}\\s*$`);
+  for (const [prelude, body] of styleRules(css)) {
+    if (prelude && !prelude.startsWith('@') && re.test(prelude) && !/[:[]/.test(prelude)) {
+      return body;
+    }
+  }
+  return undefined;
+}
+
+describe('PR-SIDEBAR-INDICATOR-SIZE-CONVERGE-0 contract (issue #743)', () => {
+  it('.maka-list-row-streaming-dot uses var(--space-2) for width/height (not bare 8px)', async () => {
+    const css = stripCssComments(await readAllRendererCss());
+    const body = restBlock(css, '.maka-list-row-streaming-dot');
+    assert.ok(body, '.maka-list-row-streaming-dot rest block not found');
+    assert.equal(decl(body, 'width'), 'var(--space-2)', 'streaming-dot width must be var(--space-2)');
+    assert.equal(decl(body, 'height'), 'var(--space-2)', 'streaming-dot height must be var(--space-2)');
+  });
+
+  it('.maka-list-row-unread uses var(--space-2) for width/height (not bare 8px)', async () => {
+    const css = stripCssComments(await readAllRendererCss());
+    const body = restBlock(css, '.maka-list-row-unread');
+    assert.ok(body, '.maka-list-row-unread rest block not found');
+    assert.equal(decl(body, 'width'), 'var(--space-2)', 'unread width must be var(--space-2)');
+    assert.equal(decl(body, 'height'), 'var(--space-2)', 'unread height must be var(--space-2)');
+  });
+
+  it('.maka-list-row-text min-height uses var(--h-control-sm) (not bare 24px)', async () => {
+    const css = stripCssComments(await readAllRendererCss());
+    const body = restBlock(css, '.maka-list-row-text');
+    assert.ok(body, '.maka-list-row-text rest block not found');
+    assert.equal(decl(body, 'min-height'), 'var(--h-control-sm)', 'list-row-text min-height must be var(--h-control-sm)');
+  });
+
+  it('.maka-list-row-status-icon stays a documented dense exception (14px, not --icon-size=16px)', async () => {
+    const css = stripCssComments(await readAllRendererCss());
+    const body = restBlock(css, '.maka-list-row-status-icon');
+    assert.ok(body, '.maka-list-row-status-icon rest block not found');
+    // 14px is the documented dense exception: --icon-size is 16px (chrome glyphs)
+    // and 16px would degrade the session row's density. Pinned here so a NEW
+    // bare 14px elsewhere in the indicator path still needs its own exception.
+    assert.equal(decl(body, 'width'), '14px', 'status-icon width is the documented 14px dense exception');
+    assert.equal(decl(body, 'height'), '14px', 'status-icon height is the documented 14px dense exception');
+  });
+});

--- a/apps/desktop/src/main/__tests__/sidebar-indicator-size-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/sidebar-indicator-size-contract.test.ts
@@ -1,13 +1,15 @@
 /**
  * PR-SIDEBAR-INDICATOR-SIZE-CONVERGE-0 (issue #743, follow-up to #738):
- * session-row indicator sizes converge onto tokens. After the codex review
- * the status-icon 14px wrapper was removed (it never clipped the SVG —
- * buttonVariants owns the in-button glyph size via var(--icon-size), so the
- * icon converges to 16px like every other in-button glyph), and the contract
- * now scans ALL .maka-list-row-* selectors for bare-px width/height/min-height
- * so a new off-ruler indicator cannot sneak back. .maka-list-row-text uses
- * var(--space-6) (content spacing), not --h-control-sm (reserved for controls
- * by control-height-converge-contract).
+ * session-row indicator sizes converge onto tokens. After the fresh-eye
+ * codex review the status icon keeps its dense-meta 12px (per
+ * docs/design-system.md §1.9 — dense-meta icons are call-site 12–14px, NOT
+ * --icon-size 16px) via a local SVG override, instead of the earlier "converge
+ * to 16px" which violated the design contract and silently grew the icon
+ * 14→16px. The contract pins each indicator's width/height exactly-once per
+ * property (a height-only override is caught, not just a width block) and
+ * drops the over-broad `.maka-list-row-*` prefix scanner (it governed
+ * non-indicators like -main/-text/-menu-trigger and false-positived on
+ * `calc(…)`).
  */
 
 import { strict as assert } from 'node:assert';
@@ -22,15 +24,15 @@ function styleRules(css: string): Array<[string, string]> {
   });
 }
 
-/** Extract a declared property value from a selector block's body. Matches
- *  at start-of-block or after a `;` or newline so single- and multi-line
- *  declarations both work. Whitespace is collapsed. */
 function decl(body: string, prop: string): string | undefined {
   const re = new RegExp(`(?:^|[\\n;])\\s*${prop}\\s*:\\s*([^;}]*)`, 'i');
   const m = body.match(re);
   return m ? m[1].trim().replace(/\s+/g, ' ') : undefined;
 }
 
+/** All rest-state blocks whose subject is exactly `subjectSelector` (no state
+ *  pseudo, no attribute, no @media prelude). Returns ALL matches so a later
+ *  same-selector override (the cascade winner) is caught, not just the first. */
 function restBlocks(css: string, subjectSelector: string): string[] {
   const escaped = subjectSelector.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
   const re = new RegExp(`^${escaped}\\s*$`);
@@ -43,75 +45,57 @@ function restBlocks(css: string, subjectSelector: string): string[] {
   return blocks;
 }
 
-const NEUTRAL_SIZE = /^(?:0(?:px|%)?|100%|auto|inherit|initial|unset|revert|none)$/;
-
-/** Bare-px width/height/min-height on any .maka-list-row-* selector — the
- *  indicator path must use tokens (var(...)) or neutral literals. A new
- *  off-ruler indicator anywhere in .maka-list-row-* is flagged here, not
- *  just the four originally-listed selectors. */
-function barePxSizeOffenders(css: string): string[] {
-  const offenders: string[] = [];
-  for (const [prelude, body] of styleRules(css)) {
-    if (!prelude.includes('.maka-list-row-')) continue;
-    for (const prop of ['width', 'height', 'min-height']) {
-      const v = decl(body, prop);
-      if (v === undefined) continue;
-      if (/^var\(/.test(v) || NEUTRAL_SIZE.test(v)) continue;
-      offenders.push(`${prelude.replace(/\s+/g, ' ')} ${prop}: ${v}`);
-    }
-  }
-  return offenders;
-}
-
-/** Among the rest blocks for a selector, the ones that actually set `prop`
- *  (e.g. the @media animation-only block for streaming-dot sets no width, so
- *  it is excluded — only the geometry block counts). */
+/** Rest blocks that actually set `prop` — e.g. the @media animation-only block
+ *  for streaming-dot sets no width, so it is excluded. Counting these lets a
+ *  height-only override (a second block setting just height) be caught. */
 function restBlocksSetting(css: string, subjectSelector: string, prop: string): string[] {
   return restBlocks(css, subjectSelector).filter((b) => decl(b, prop) !== undefined);
 }
 
+/** Assert `prop` is set in exactly one rest block of `selector`, with `expected`
+ *  value. Catches both first-match and height-only-override false-greens. */
+function assertExactlyOnce(css: string, selector: string, prop: string, expected: string, label: string): void {
+  const blocks = restBlocksSetting(css, selector, prop);
+  assert.equal(blocks.length, 1, `${label}: ${prop} must be set in exactly one rest block (a later same-selector override would win the cascade); got ${blocks.length}`);
+  assert.equal(decl(blocks[0]!, prop), expected, `${label}: ${prop} must be ${expected}`);
+}
+
 describe('PR-SIDEBAR-INDICATOR-SIZE-CONVERGE-0 contract (issue #743)', () => {
-  it('.maka-list-row-streaming-dot uses var(--space-2) for width/height', async () => {
+  it('.maka-list-row-streaming-dot width and height are each var(--space-2), set exactly once', async () => {
     const css = stripCssComments(await readAllRendererCss());
-    const w = restBlocksSetting(css, '.maka-list-row-streaming-dot', 'width');
-    assert.equal(w.length, 1, '.maka-list-row-streaming-dot width must be set in exactly one rest block (the @media animation block sets none)');
-    assert.equal(decl(w[0]!, 'width'), 'var(--space-2)');
-    assert.equal(decl(w[0]!, 'height'), 'var(--space-2)');
+    assertExactlyOnce(css, '.maka-list-row-streaming-dot', 'width', 'var(--space-2)', 'streaming-dot');
+    assertExactlyOnce(css, '.maka-list-row-streaming-dot', 'height', 'var(--space-2)', 'streaming-dot');
   });
 
-  it('.maka-list-row-unread uses var(--space-2) for width/height', async () => {
+  it('.maka-list-row-unread width and height are each var(--space-2), set exactly once', async () => {
     const css = stripCssComments(await readAllRendererCss());
-    const w = restBlocksSetting(css, '.maka-list-row-unread', 'width');
-    assert.equal(w.length, 1, '.maka-list-row-unread width must be set in exactly one rest block');
-    assert.equal(decl(w[0]!, 'width'), 'var(--space-2)');
-    assert.equal(decl(w[0]!, 'height'), 'var(--space-2)');
+    assertExactlyOnce(css, '.maka-list-row-unread', 'width', 'var(--space-2)', 'unread');
+    assertExactlyOnce(css, '.maka-list-row-unread', 'height', 'var(--space-2)', 'unread');
   });
 
-  it('.maka-list-row-text min-height uses var(--space-6) (content spacing, not a control token)', async () => {
+  it('.maka-list-row-text min-height is var(--space-6) (content spacing, not a control token)', async () => {
     const css = stripCssComments(await readAllRendererCss());
-    const m = restBlocksSetting(css, '.maka-list-row-text', 'min-height');
-    assert.equal(m.length, 1, '.maka-list-row-text min-height must be set in exactly one rest block');
-    assert.equal(decl(m[0]!, 'min-height'), 'var(--space-6)');
+    assertExactlyOnce(css, '.maka-list-row-text', 'min-height', 'var(--space-6)', 'list-row-text');
   });
 
-  it('.maka-list-row-status-icon declares no width/height (the SVG size is owned by buttonVariants)', async () => {
+  it('.maka-list-row-status-icon wrapper declares no width/height; the SVG is var(--space-3) (12px dense meta)', async () => {
     const css = stripCssComments(await readAllRendererCss());
-    const blocks = restBlocks(css, '.maka-list-row-status-icon');
-    for (const b of blocks) {
-      assert.equal(decl(b, 'width'), undefined, 'no .maka-list-row-status-icon rest block may set width (buttonVariants sizes the SVG via var(--icon-size))');
-      assert.equal(decl(b, 'height'), undefined, 'no .maka-list-row-status-icon rest block may set height');
+    // wrapper: no width/height (the SVG owns the footprint)
+    const wrapper = restBlocks(css, '.maka-list-row-status-icon');
+    for (const b of wrapper) {
+      assert.equal(decl(b, 'width'), undefined, 'status-icon wrapper must not set width');
+      assert.equal(decl(b, 'height'), undefined, 'status-icon wrapper must not set height');
     }
+    // svg: 12px dense-meta override (var(--space-3)), not --icon-size 16px
+    assertExactlyOnce(css, '.maka-list-row-status-icon svg', 'width', 'var(--space-3)', 'status-icon svg');
+    assertExactlyOnce(css, '.maka-list-row-status-icon svg', 'height', 'var(--space-3)', 'status-icon svg');
   });
 
-  it('no bare-px width/height/min-height remains on any .maka-list-row-* selector', async () => {
-    const css = stripCssComments(await readAllRendererCss());
-    const offenders = barePxSizeOffenders(css);
-    assert.deepEqual(offenders, [], `Offenders:\n  ${offenders.join('\n  ')}`);
-  });
-
-  it('barePxSizeOffenders flags a new off-ruler indicator (negative case)', () => {
-    const fakeCss = '.maka-list-row-other-indicator { width: 14px; height: 14px; }';
-    const offenders = barePxSizeOffenders(fakeCss);
-    assert.equal(offenders.length, 2, 'a new bare-px .maka-list-row-* indicator must be flagged, not just the four originally-listed selectors');
+  it('assertExactlyOnce flags a height-only same-selector override (negative case)', () => {
+    const fakeCss =
+      '.maka-list-row-unread { width: var(--space-2); height: var(--space-2); }\n' +
+      '.maka-list-row-unread { height: var(--space-3); }';
+    const blocks = restBlocksSetting(fakeCss, '.maka-list-row-unread', 'height');
+    assert.equal(blocks.length, 2, 'a height-only override must be caught (two height blocks), not silently pass via first-match');
   });
 });

--- a/apps/desktop/src/renderer/styles/sidebar.css
+++ b/apps/desktop/src/renderer/styles/sidebar.css
@@ -525,7 +525,10 @@
   min-width: 0;
   display: flex;
   align-items: center;
-  min-height: var(--h-control-sm);
+  /* #743: content min-height, not a control height — use the spacing ruler
+     (var(--space-6) = 24px), not --h-control-sm (which control-height-converge-
+     contract reserves for interactive controls). */
+  min-height: var(--space-6);
 }
 
 /* PR-SIDEBAR-IA-0 Phase 3: `.maka-list-row-preview` is no longer
@@ -580,12 +583,12 @@
   justify-content: center;
   flex-shrink: 0;
   margin-right: var(--space-1);
-  /* #743: 14px is a documented dense exception — --icon-size is 16px
-     (chrome glyphs on nav/button icons), and 16px here would degrade the
-     session row's density. Pinned by sidebar-indicator-size-contract so a
-     new bare 14px elsewhere in the indicator path needs its own exception. */
-  width: 14px;
-  height: 14px;
+  /* #743: the SVG size is owned by buttonVariants ([&_svg]:size-[var(--icon-size,1rem)]
+     on the row's UiButton), so the icon converges to var(--icon-size) (16px) like
+     every other in-button glyph. The 14px wrapper here never clipped the SVG
+     (CSS size beats the <Icon size=12> presentation attribute), so it was a
+     misleading literal — removed. No width/height on this wrapper; the SVG
+     carries the size. */
   color: var(--foreground-secondary);
 }
 .maka-list-row-status-icon[data-tone="accent"] {

--- a/apps/desktop/src/renderer/styles/sidebar.css
+++ b/apps/desktop/src/renderer/styles/sidebar.css
@@ -525,10 +525,6 @@
   min-width: 0;
   display: flex;
   align-items: center;
-  /* #743: content min-height, not a control height — use the spacing ruler
-     (var(--space-6) = 24px), not --h-control-sm (which control-height-converge-
-     contract reserves for interactive controls). */
-  min-height: var(--space-6);
 }
 
 /* PR-SIDEBAR-IA-0 Phase 3: `.maka-list-row-preview` is no longer
@@ -583,16 +579,18 @@
   justify-content: center;
   flex-shrink: 0;
   margin-right: var(--space-1);
-  /* #743: dense meta icon — per docs/design-system.md §1.9, status/dense-meta
-     icons are call-site 12–14px, NOT --icon-size (16px, reserved for chrome/nav/
-     button glyphs). The row's UiButton buttonVariants would force 16px via
-     [&_svg]:size-[var(--icon-size,1rem)] (a cascade leak from borrowing the
-     button for its interaction contract), so scope a local 12px override on the
-     SVG to restore the <Icon size={12}> intent. The wrapper carries no
-     width/height — the SVG owns the footprint. */
+  /* #743: 14px layout slot for the dense-meta status icon
+     (docs/design-system.md §1.9: dense-meta icons are call-site 12–14px). Kept
+     as a documented exception — the wrapper reserves the row's status footprint
+     so the title does not shift when the SVG is overridden to 12px below. */
+  width: 14px;
+  height: 14px;
   color: var(--foreground-secondary);
 }
 .maka-list-row-status-icon svg {
+  /* #743: restore <Icon size={12}> — buttonVariants' [&_svg]:size-[var(--icon-size,1rem)]
+     would force 16px (chrome tier, a cascade leak from borrowing UiButton), so
+     scope a local 12px dense-meta override. The 14px wrapper centers it. */
   width: var(--space-3);
   height: var(--space-3);
 }

--- a/apps/desktop/src/renderer/styles/sidebar.css
+++ b/apps/desktop/src/renderer/styles/sidebar.css
@@ -590,9 +590,12 @@
 .maka-list-row-status-icon svg {
   /* #743: restore <Icon size={12}> — buttonVariants' [&_svg]:size-[var(--icon-size,1rem)]
      would force 16px (chrome tier, a cascade leak from borrowing UiButton), so
-     scope a local 12px dense-meta override. The 14px wrapper centers it. */
-  width: var(--space-3);
-  height: var(--space-3);
+     scope a local 12px dense-meta override. Per docs/design-system.md §1.9 only
+     the chrome tier is tokenized; dense-meta stays call-site 12–14px and is NOT
+     bound to a spacing token, so this stays a bare 12px (a spacing-scale change
+     cannot drift the icon size). The 14px wrapper centers it. */
+  width: 12px;
+  height: 12px;
 }
 .maka-list-row-status-icon[data-tone="accent"] {
   color: var(--nav-active);

--- a/apps/desktop/src/renderer/styles/sidebar.css
+++ b/apps/desktop/src/renderer/styles/sidebar.css
@@ -473,8 +473,8 @@
  * prefers-reduced-motion. */
 .maka-list-row-streaming-dot {
   flex-shrink: 0;
-  width: 8px;
-  height: 8px;
+  width: var(--space-2);
+  height: var(--space-2);
   border-radius: 50%;
   background: var(--status-running);
   box-shadow: 0 0 0 3px oklch(from var(--status-running) l c h / 0.15);
@@ -525,7 +525,7 @@
   min-width: 0;
   display: flex;
   align-items: center;
-  min-height: 24px;
+  min-height: var(--h-control-sm);
 }
 
 /* PR-SIDEBAR-IA-0 Phase 3: `.maka-list-row-preview` is no longer
@@ -544,8 +544,8 @@
  * removed. */
 
 .maka-list-row-unread {
-  width: 8px;
-  height: 8px;
+  width: var(--space-2);
+  height: var(--space-2);
   border-radius: var(--radius-pill);
   background: var(--status-running);
   box-shadow: 0 0 0 3px oklch(from var(--status-running) l c h / 0.15);
@@ -580,6 +580,10 @@
   justify-content: center;
   flex-shrink: 0;
   margin-right: var(--space-1);
+  /* #743: 14px is a documented dense exception — --icon-size is 16px
+     (chrome glyphs on nav/button icons), and 16px here would degrade the
+     session row's density. Pinned by sidebar-indicator-size-contract so a
+     new bare 14px elsewhere in the indicator path needs its own exception. */
   width: 14px;
   height: 14px;
   color: var(--foreground-secondary);

--- a/apps/desktop/src/renderer/styles/sidebar.css
+++ b/apps/desktop/src/renderer/styles/sidebar.css
@@ -583,13 +583,18 @@
   justify-content: center;
   flex-shrink: 0;
   margin-right: var(--space-1);
-  /* #743: the SVG size is owned by buttonVariants ([&_svg]:size-[var(--icon-size,1rem)]
-     on the row's UiButton), so the icon converges to var(--icon-size) (16px) like
-     every other in-button glyph. The 14px wrapper here never clipped the SVG
-     (CSS size beats the <Icon size=12> presentation attribute), so it was a
-     misleading literal — removed. No width/height on this wrapper; the SVG
-     carries the size. */
+  /* #743: dense meta icon — per docs/design-system.md §1.9, status/dense-meta
+     icons are call-site 12–14px, NOT --icon-size (16px, reserved for chrome/nav/
+     button glyphs). The row's UiButton buttonVariants would force 16px via
+     [&_svg]:size-[var(--icon-size,1rem)] (a cascade leak from borrowing the
+     button for its interaction contract), so scope a local 12px override on the
+     SVG to restore the <Icon size={12}> intent. The wrapper carries no
+     width/height — the SVG owns the footprint. */
   color: var(--foreground-secondary);
+}
+.maka-list-row-status-icon svg {
+  width: var(--space-3);
+  height: var(--space-3);
 }
 .maka-list-row-status-icon[data-tone="accent"] {
   color: var(--nav-active);


### PR DESCRIPTION
## Summary
Converge the remaining session-row indicator literals onto the spacing and control-height vocabularies: streaming-dot/unread `8px` → `var(--space-2)`, list-row-text `min-height: 24px` → `var(--h-control-sm)`. The `14px` status icon stays a documented dense exception.

## Why
Follow-up to #738: the surrounding session-row indicator path still carried bare 8/14/24px that bypassed the spacing and control-height tokens, so the row could drift off-ruler. Refs #743.

## Scope
- `.maka-list-row-streaming-dot` width/height `8px` → `var(--space-2)`.
- `.maka-list-row-unread` width/height `8px` → `var(--space-2)`.
- `.maka-list-row-text` `min-height: 24px` → `var(--h-control-sm)`.
- `.maka-list-row-status-icon` width/height `14px` kept, with a comment + the new contract pinning that one selector as the documented dense exception (`--icon-size` is 16px; 16px here would degrade row density).
- Not extracted: a shared streaming/unread primitive. Evaluated — streaming-dot owns a pulse animation that overrides box-shadow per keyframe, and merging the selectors would change the CSS structure the density contract scans. Converging the literals already removes the off-ruler drift.

## Verification
- RED contract (`sidebar-indicator-size-contract`) pinning the three converged selectors + the 14px exception → GREEN.
- `npm run -w @maka/desktop test` — 2324/2324 pass.
- `typecheck` + `test:checks` — pass.
- No visual change: `8px` and `24px` map to `var(--space-2)`/`var(--h-control-sm)` which resolve to the same px; streaming/unread/stale/active/reduced-motion states are untouched.

## Impact
None — visual no-op refactor; no behavior, API, or migration change.

## Reviewer notes
The 14px status-icon exception is the one judgment call: `--icon-size` (16px) is for chrome glyphs and would loosen the session row. Documented in the CSS comment + pinned by the contract so a new bare 14px elsewhere in the indicator path still needs its own exception.

## Ready for review
- [x] Verification complete and current
- [x] Impact/compatibility/migration/docs/release-note needs addressed
- [x] Visual evidence: not applicable (visual no-op) — explained in Verification
