### PR TITLE
feat(cli): resume non-interactive sessions

### DIFF
--- a/packages/cli/src/__tests__/run-command-fixture.ts
+++ b/packages/cli/src/__tests__/run-command-fixture.ts
@@ -43,6 +43,9 @@ const summary = {
 
 const runtime: MakaRunRuntime = {
   async createSession(input) {
+    if (process.env.MAKA_RUN_EXPECT_NO_CREATE === '1') {
+      throw new Error('unexpected createSession call');
+    }
     if (
       process.env.MAKA_RUN_EXPECT_PERMISSION_MODE
       && input.permissionMode !== process.env.MAKA_RUN_EXPECT_PERMISSION_MODE
@@ -51,7 +54,13 @@ const runtime: MakaRunRuntime = {
     }
     return summary;
   },
-  async *sendMessage(_sessionId, input): AsyncIterable<SessionEvent> {
+  async *sendMessage(sessionId, input): AsyncIterable<SessionEvent> {
+    if (
+      process.env.MAKA_RUN_EXPECT_SESSION_ID
+      && sessionId !== process.env.MAKA_RUN_EXPECT_SESSION_ID
+    ) {
+      throw new Error(`unexpected sessionId ${sessionId}`);
+    }
     if (scenario === 'runtime-error') throw new Error('provider failed after startup');
     if (scenario === 'permission') {
       yield {
@@ -110,8 +119,33 @@ async function createContext(input: CreateMakaCliRuntimeContextInput): Promise<M
       throw new Error(`unexpected permissionRules ${actual}`);
     }
   }
+  if (process.env.MAKA_RUN_EXPECT_CONTEXT_CWD && input.cwd !== process.env.MAKA_RUN_EXPECT_CONTEXT_CWD) {
+    throw new Error(`unexpected context cwd ${input.cwd}`);
+  }
+  if (
+    process.env.MAKA_RUN_EXPECT_CONTEXT_CONNECTION
+    && input.requestedConnectionSlug !== process.env.MAKA_RUN_EXPECT_CONTEXT_CONNECTION
+  ) {
+    throw new Error(`unexpected context connection ${String(input.requestedConnectionSlug)}`);
+  }
+  if (
+    process.env.MAKA_RUN_EXPECT_CONTEXT_MODEL
+    && input.requestedModel !== process.env.MAKA_RUN_EXPECT_CONTEXT_MODEL
+  ) {
+    throw new Error(`unexpected context model ${String(input.requestedModel)}`);
+  }
+  if (process.env.MAKA_RUN_EXPECT_CWD_OVERRIDE) {
+    const actual = JSON.stringify(input.sessionCwdOverride);
+    if (actual !== process.env.MAKA_RUN_EXPECT_CWD_OVERRIDE) {
+      throw new Error(`unexpected sessionCwdOverride ${actual}`);
+    }
+  }
   observer = input.runtimeInvocationObserver;
   return { runtime, target, close: async () => {} };
+}
+
+async function listSessions(): Promise<SessionSummary[]> {
+  return JSON.parse(process.env.MAKA_RUN_FIXTURE_SESSIONS ?? '[]') as SessionSummary[];
 }
 
 function completedResult(finalOutput: string): InvocationResult {
@@ -146,7 +180,7 @@ async function notify(result: InvocationResult): Promise<void> {
   await observer?.(result);
 }
 
-runMakaTextCli(process.argv.slice(2), { createContext }).then(
+runMakaTextCli(process.argv.slice(2), { createContext, listSessions }).then(
   (code) => { process.exitCode = code; },
   (error) => {
     process.stderr.write(`${error instanceof Error ? error.stack : String(error)}\n`);

--- a/packages/cli/src/__tests__/run-command.test.ts
+++ b/packages/cli/src/__tests__/run-command.test.ts
@@ -1,8 +1,10 @@
 import assert from 'node:assert/strict';
 import { spawn } from 'node:child_process';
 import { once } from 'node:events';
+import { realpath } from 'node:fs/promises';
 import { fileURLToPath } from 'node:url';
 import { describe, test } from 'node:test';
+import type { SessionSummary } from '@maka/core/session';
 import { parseMakaRunArgs } from '../run-command.js';
 
 const fixturePath = fileURLToPath(new URL('./run-command-fixture.js', import.meta.url));
@@ -68,6 +70,33 @@ describe('maka run argument parsing', () => {
     assert.equal(parseMakaRunArgs(['x', '--allow', 'category:not-real']).kind, 'error');
     assert.equal(parseMakaRunArgs(['x', '--deny', 'Bash()']).kind, 'error');
     assert.equal(parseMakaRunArgs(['x', '--allow', 'Write(*)']).kind, 'error');
+  });
+
+  test('parses resume and continue session selectors and rejects combining them', () => {
+    assert.deepEqual(parseMakaRunArgs(['next', '--resume', 'session-1']), {
+      kind: 'run',
+      options: { prompt: 'next', stdinPrompt: false, resumeId: 'session-1' },
+    });
+    assert.deepEqual(parseMakaRunArgs(['next', '--continue']), {
+      kind: 'run',
+      options: { prompt: 'next', stdinPrompt: false, continueLatest: true },
+    });
+    assert.equal(
+      parseMakaRunArgs(['next', '--resume', 'session-1', '--continue']).kind,
+      'error',
+    );
+  });
+
+  test('preserves an explicit default thinking constraint for resumed sessions', () => {
+    assert.deepEqual(parseMakaRunArgs(['next', '--resume', 'session-1', '--thinking', 'default']), {
+      kind: 'run',
+      options: {
+        prompt: 'next',
+        stdinPrompt: false,
+        resumeId: 'session-1',
+        thinkingDefaultExplicit: true,
+      },
+    });
   });
 });
 
@@ -163,6 +192,89 @@ describe('maka run process contract', () => {
     assert.equal(result.stdout, '');
   });
 
+  test('resumes an explicit session without creating a new identity', async () => {
+    const cwd = await realpath(process.cwd());
+    const resumed = fixtureSession({
+      id: 'resume-me',
+      cwd,
+      llmConnectionSlug: 'fixture',
+      model: 'fixture-model',
+      permissionMode: 'execute',
+    });
+    const result = await runFixture([
+      'continue this',
+      '--resume', resumed.id,
+      '--connection', resumed.llmConnectionSlug,
+      '--model', resumed.model,
+      '--permission-mode', resumed.permissionMode,
+    ], {
+      input: '',
+      env: {
+        MAKA_RUN_FIXTURE_SESSIONS: JSON.stringify([resumed]),
+        MAKA_RUN_EXPECT_NO_CREATE: '1',
+        MAKA_RUN_EXPECT_SESSION_ID: resumed.id,
+        MAKA_RUN_EXPECT_CONTEXT_CWD: cwd,
+        MAKA_RUN_EXPECT_CONTEXT_CONNECTION: resumed.llmConnectionSlug,
+        MAKA_RUN_EXPECT_CONTEXT_MODEL: resumed.model,
+        MAKA_RUN_EXPECT_CWD_OVERRIDE: JSON.stringify({ sessionId: resumed.id, cwd }),
+      },
+    });
+
+    assert.equal(result.code, 0, result.stderr);
+    assert.equal(result.stdout, 'prompt=continue this\n');
+  });
+
+  test('returns exit 2 when explicit configuration conflicts with a resumed session', async () => {
+    const resumed = fixtureSession({ id: 'resume-me', cwd: process.cwd() });
+    const result = await runFixture([
+      'continue this',
+      '--resume', resumed.id,
+      '--model', 'different-model',
+    ], {
+      input: '',
+      env: { MAKA_RUN_FIXTURE_SESSIONS: JSON.stringify([resumed]) },
+    });
+
+    assert.equal(result.code, 2);
+    assert.match(result.stderr, /--model conflicts with resumed session/);
+    assert.equal(result.stdout, '');
+  });
+
+  test('continues the deterministic latest cwd-compatible session', async () => {
+    const cwd = await realpath(process.cwd());
+    const sessions = [
+      fixtureSession({ id: 'b', cwd, lastMessageAt: 200 }),
+      fixtureSession({ id: 'a', cwd, lastMessageAt: 200, status: 'aborted' }),
+      fixtureSession({ id: 'newer-other-cwd', cwd: '/missing-other', lastMessageAt: 300 }),
+    ];
+    const result = await runFixture(['continue this', '--continue'], {
+      input: '',
+      env: {
+        MAKA_RUN_FIXTURE_SESSIONS: JSON.stringify(sessions),
+        MAKA_RUN_EXPECT_NO_CREATE: '1',
+        MAKA_RUN_EXPECT_SESSION_ID: 'a',
+        MAKA_RUN_EXPECT_CONTEXT_CWD: cwd,
+        MAKA_RUN_EXPECT_CONTEXT_CONNECTION: 'fixture',
+        MAKA_RUN_EXPECT_CONTEXT_MODEL: 'fixture-model',
+        MAKA_RUN_EXPECT_CWD_OVERRIDE: JSON.stringify({ sessionId: 'a', cwd }),
+      },
+    });
+
+    assert.equal(result.code, 0, result.stderr);
+    assert.equal(result.stdout, 'prompt=continue this\n');
+  });
+
+  test('returns exit 2 when continue finds no compatible session', async () => {
+    const result = await runFixture(['continue this', '--continue'], {
+      input: '',
+      env: { MAKA_RUN_FIXTURE_SESSIONS: '[]' },
+    });
+
+    assert.equal(result.code, 2);
+    assert.match(result.stderr, /no compatible session found for cwd/);
+    assert.equal(result.stdout, '');
+  });
+
   test('returns exit 1 when the invocation timeout stops the run', async () => {
     const result = await runFixture(['hello', '--timeout', '0.05'], {
       scenario: 'slow',
@@ -222,4 +334,23 @@ function runFixture(
     child.on('close', (code) => resolve({ code, stdout, stderr }));
     child.stdin.end(options.input ?? '');
   });
+}
+
+function fixtureSession(overrides: Partial<SessionSummary> = {}): SessionSummary {
+  return {
+    id: 'fixture-existing',
+    cwd: process.cwd(),
+    name: 'Fixture existing',
+    isFlagged: false,
+    isArchived: false,
+    labels: [],
+    hasUnread: false,
+    lastMessageAt: 100,
+    status: 'active',
+    backend: 'ai-sdk',
+    llmConnectionSlug: 'fixture',
+    model: 'fixture-model',
+    permissionMode: 'explore',
+    ...overrides,
+  };
 }

--- a/packages/cli/src/__tests__/run-session-selection.test.ts
+++ b/packages/cli/src/__tests__/run-session-selection.test.ts
@@ -1,0 +1,175 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+import type { SessionSummary } from '@maka/core/session';
+import { selectMakaRunSession } from '../run-session-selection.js';
+
+describe('maka run session selection', () => {
+  test('new runs canonicalize the explicit cwd or process cwd', async () => {
+    const deps = canonicalizer({ '/link': '/repo', '/process': '/process-real' });
+
+    assert.deepEqual(await selectMakaRunSession({
+      sessions: [],
+      continueLatest: false,
+      explicitCwd: '/link',
+      processCwd: '/process',
+      thinkingSpecified: false,
+    }, deps), { kind: 'new', cwd: '/repo' });
+    assert.deepEqual(await selectMakaRunSession({
+      sessions: [],
+      continueLatest: false,
+      processCwd: '/process',
+      thinkingSpecified: false,
+    }, deps), { kind: 'new', cwd: '/process-real' });
+  });
+
+  test('resume uses the stored canonical cwd and ignores implicit process cwd', async () => {
+    const stored = session({ id: 'resume-me', cwd: '/stored-link' });
+    const selected = await selectMakaRunSession({
+      sessions: [stored],
+      resumeId: stored.id,
+      continueLatest: false,
+      processCwd: '/unrelated-process-cwd',
+      thinkingSpecified: false,
+    }, canonicalizer({ '/stored-link': '/repo' }));
+
+    assert.equal(selected.kind, 'existing');
+    assert.equal(selected.cwd, '/repo');
+    assert.equal(selected.kind === 'existing' ? selected.session : undefined, stored);
+    assert.equal(stored.cwd, '/stored-link');
+  });
+
+  test('resume accepts a canonically equal explicit cwd and rejects a conflict', async () => {
+    const stored = session({ id: 'resume-me', cwd: '/stored-link' });
+    const deps = canonicalizer({
+      '/stored-link': '/repo',
+      '/explicit-link': '/repo',
+      '/other': '/other',
+    });
+
+    const selected = await selectMakaRunSession({
+      sessions: [stored],
+      resumeId: stored.id,
+      continueLatest: false,
+      explicitCwd: '/explicit-link',
+      processCwd: '/ignored',
+      thinkingSpecified: false,
+    }, deps);
+    assert.equal(selected.cwd, '/repo');
+
+    await assert.rejects(selectMakaRunSession({
+      sessions: [stored],
+      resumeId: stored.id,
+      continueLatest: false,
+      explicitCwd: '/other',
+      processCwd: '/ignored',
+      thinkingSpecified: false,
+    }, deps), /--cwd conflicts/);
+  });
+
+  test('resume rejects missing cwd, ask mode, unsupported backend, and explicit config conflicts', async () => {
+    const deps = canonicalizer({ '/repo': '/repo' });
+    const base = session({ id: 'resume-me', cwd: '/repo', thinkingLevel: 'high' });
+
+    await assert.rejects(selectMakaRunSession({
+      sessions: [session({ id: 'resume-me', cwd: undefined })],
+      resumeId: 'resume-me',
+      continueLatest: false,
+      processCwd: '/ignored',
+      thinkingSpecified: false,
+    }, deps), /has no stored cwd/);
+    await assert.rejects(selectMakaRunSession({
+      sessions: [session({ id: 'resume-me', permissionMode: 'ask' })],
+      resumeId: 'resume-me',
+      continueLatest: false,
+      processCwd: '/ignored',
+      thinkingSpecified: false,
+    }, deps), /interactive permission mode ask/);
+    await assert.rejects(selectMakaRunSession({
+      sessions: [session({ id: 'resume-me', backend: 'pi-agent' })],
+      resumeId: 'resume-me',
+      continueLatest: false,
+      processCwd: '/ignored',
+      thinkingSpecified: false,
+    }, deps), /unsupported backend/);
+
+    for (const conflict of [
+      { explicitConnection: 'other' },
+      { explicitModel: 'other' },
+      { thinkingSpecified: true, explicitThinking: undefined },
+      { explicitPermissionMode: 'bypass' as const },
+    ]) {
+      await assert.rejects(selectMakaRunSession({
+        sessions: [base],
+        resumeId: base.id,
+        continueLatest: false,
+        processCwd: '/ignored',
+        thinkingSpecified: false,
+        ...conflict,
+      }, deps), /conflicts with resumed session/);
+    }
+  });
+
+  test('continue selects by lastMessageAt descending then id ascending after cwd filtering', async () => {
+    const selected = await selectMakaRunSession({
+      sessions: [
+        session({ id: 'archived', lastMessageAt: 500, isArchived: true }),
+        session({ id: 'done', lastMessageAt: 500, status: 'done' }),
+        session({ id: 'ask', lastMessageAt: 500, permissionMode: 'ask' }),
+        session({ id: 'missing-time', lastMessageAt: undefined }),
+        session({ id: 'inaccessible', cwd: '/missing', lastMessageAt: 400 }),
+        session({ id: 'b', cwd: '/repo-link', lastMessageAt: 300 }),
+        session({ id: 'a', cwd: '/repo', lastMessageAt: 300, status: 'aborted' }),
+        session({ id: 'older', cwd: '/repo', lastMessageAt: 200 }),
+      ],
+      continueLatest: true,
+      processCwd: '/process-link',
+      thinkingSpecified: false,
+    }, canonicalizer({
+      '/process-link': '/repo',
+      '/repo-link': '/repo',
+      '/repo': '/repo',
+    }));
+
+    assert.equal(selected.kind, 'existing');
+    assert.equal(selected.kind === 'existing' ? selected.session.id : undefined, 'a');
+    assert.equal(selected.cwd, '/repo');
+  });
+
+  test('continue returns a preflight failure when no cwd-compatible session exists', async () => {
+    await assert.rejects(selectMakaRunSession({
+      sessions: [session({ id: 'other', cwd: '/other', lastMessageAt: 10 })],
+      continueLatest: true,
+      processCwd: '/repo',
+      thinkingSpecified: false,
+    }, canonicalizer({ '/repo': '/repo', '/other': '/other' })), /no compatible session found/);
+  });
+});
+
+function session(overrides: Partial<SessionSummary> = {}): SessionSummary {
+  return {
+    id: 'session-1',
+    cwd: '/repo',
+    name: 'Session',
+    isFlagged: false,
+    isArchived: false,
+    labels: [],
+    hasUnread: false,
+    lastMessageAt: 100,
+    status: 'active',
+    backend: 'ai-sdk',
+    llmConnectionSlug: 'fixture',
+    model: 'fixture-model',
+    permissionMode: 'explore',
+    ...overrides,
+  };
+}
+
+function canonicalizer(paths: Record<string, string>) {
+  return {
+    async canonicalizeDirectory(path: string): Promise<string> {
+      const canonical = paths[path];
+      if (!canonical) throw new Error(`missing path: ${path}`);
+      return canonical;
+    },
+  };
+}

--- a/packages/cli/src/__tests__/runtime-bootstrap.test.ts
+++ b/packages/cli/src/__tests__/runtime-bootstrap.test.ts
@@ -4,7 +4,12 @@ import { mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, test } from 'node:test';
-import { createConnectionStore, createFileCredentialStore, createShellRunStore } from '@maka/storage';
+import {
+  createConnectionStore,
+  createFileCredentialStore,
+  createSessionStore,
+  createShellRunStore,
+} from '@maka/storage';
 import { BackendRegistry, type AiSdkBackendInput, type SessionStore, type ShellRunUpdate } from '@maka/runtime';
 import {
   createMakaCliRuntimeContext,
@@ -102,6 +107,49 @@ describe('Maka CLI runtime bootstrap', () => {
         assert.equal(backendInput.permissionRules, permissionRules);
         assert.equal(runtimeDeps.runtimeInvocationObserver, observer);
         assert.deepEqual(observed, []);
+      } finally {
+        await context.close();
+      }
+    });
+  });
+
+  test('uses a canonical cwd for one resumed backend without rewriting its stored header', async () => {
+    await withWorkspace(async (workspaceRoot) => {
+      const connectionStore = createConnectionStore(workspaceRoot);
+      await connectionStore.create({
+        slug: 'local',
+        name: 'Local',
+        providerType: 'ollama',
+        defaultModel: 'model-1',
+      });
+      const sessionStore = createSessionStore(workspaceRoot);
+      const stored = await sessionStore.create({
+        cwd: '/stored-link',
+        backend: 'ai-sdk',
+        llmConnectionSlug: 'local',
+        model: 'model-1',
+        permissionMode: 'explore',
+      });
+      const context = await createMakaCliRuntimeContext({
+        workspaceRoot,
+        cwd: '/canonical-repo',
+        requestedConnectionSlug: 'local',
+        requestedModel: 'model-1',
+        sessionCwdOverride: { sessionId: stored.id, cwd: '/canonical-repo' },
+      });
+      try {
+        const runtimeDeps = (context.runtime as unknown as RuntimeWithPrivateDeps).deps;
+        const header = await runtimeDeps.store.readHeader(stored.id);
+        const backend = await runtimeDeps.backends.build('ai-sdk', {
+          sessionId: stored.id,
+          workspaceRoot,
+          header,
+          store: runtimeDeps.store,
+        });
+        const backendInput = (backend as unknown as { input: AiSdkBackendInput }).input;
+
+        assert.equal(backendInput.header.cwd, '/canonical-repo');
+        assert.equal((await sessionStore.readHeader(stored.id)).cwd, '/stored-link');
       } finally {
         await context.close();
       }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -17,6 +17,12 @@ export {
   type ParseMakaRunArgsResult,
 } from './run-command.js';
 export {
+  selectMakaRunSession,
+  type MakaRunSessionSelection,
+  type MakaRunSessionSelectionDeps,
+  type MakaRunSessionSelectionInput,
+} from './run-session-selection.js';
+export {
   createMakaCliRuntimeContext,
   type CreateMakaCliRuntimeContextInput,
   type MakaCliRuntimeContext,

--- a/packages/cli/src/run-command.ts
+++ b/packages/cli/src/run-command.ts
@@ -11,11 +11,13 @@ import {
 import type { CreateSessionInput, UserMessageInput } from '@maka/core/runtime-inputs';
 import type { SessionSummary } from '@maka/core/session';
 import type { InvocationResult } from '@maka/runtime';
+import { createSessionStore } from '@maka/storage';
 import {
   createMakaCliRuntimeContext,
   type CreateMakaCliRuntimeContextInput,
 } from './runtime-bootstrap.js';
 import type { ReadySessionTarget } from './connection-target.js';
+import { selectMakaRunSession } from './run-session-selection.js';
 import { resolveMakaWorkspaceRoot } from './workspace-root.js';
 
 export type NonInteractivePermissionMode = Exclude<PermissionMode, 'ask'>;
@@ -31,6 +33,9 @@ export interface MakaRunOptions {
   maxSteps?: number;
   permissionMode?: NonInteractivePermissionMode;
   permissionRules?: ToolPermissionRule[];
+  resumeId?: string;
+  continueLatest?: boolean;
+  thinkingDefaultExplicit?: boolean;
 }
 
 export type ParseMakaRunArgsResult =
@@ -56,6 +61,7 @@ export interface MakaRunContext {
 
 export interface MakaRunDeps {
   createContext(input: CreateMakaCliRuntimeContextInput): Promise<MakaRunContext>;
+  listSessions(workspaceRoot: string): Promise<SessionSummary[]>;
   workspaceRoot(): string;
   processCwd(): string;
   stdinIsTTY(): boolean;
@@ -78,13 +84,16 @@ const VALUE_FLAGS = new Set([
   'permission-mode',
   'allow',
   'deny',
+  'resume',
 ]);
 
 const REPEATABLE_VALUE_FLAGS = new Set(['allow', 'deny']);
+const BOOLEAN_FLAGS = new Set(['continue']);
 
 export function parseMakaRunArgs(argv: readonly string[]): ParseMakaRunArgsResult {
   const positional: string[] = [];
   const flags = new Map<string, string>();
+  const booleanFlags = new Set<string>();
   const permissionRuleFlags: Array<{ effect: 'allow' | 'deny'; value: string }> = [];
   let literal = false;
   for (let index = 0; index < argv.length; index += 1) {
@@ -96,6 +105,11 @@ export function parseMakaRunArgs(argv: readonly string[]): ParseMakaRunArgsResul
     }
     if (!literal && arg.startsWith('--')) {
       const name = arg.slice(2);
+      if (BOOLEAN_FLAGS.has(name)) {
+        if (booleanFlags.has(name)) return { kind: 'error', message: `option repeated: ${arg}` };
+        booleanFlags.add(name);
+        continue;
+      }
       if (!VALUE_FLAGS.has(name)) return { kind: 'error', message: `unknown option: ${arg}` };
       if (!REPEATABLE_VALUE_FLAGS.has(name) && flags.has(name)) {
         return { kind: 'error', message: `option repeated: ${arg}` };
@@ -126,6 +140,11 @@ export function parseMakaRunArgs(argv: readonly string[]): ParseMakaRunArgsResul
   const maxSteps = flags.get('max-steps');
   const thinking = flags.get('thinking');
   const permissionMode = flags.get('permission-mode');
+  const resumeId = flags.get('resume');
+  const continueLatest = booleanFlags.has('continue');
+  if (resumeId !== undefined && continueLatest) {
+    return { kind: 'error', message: '--resume and --continue cannot be used together' };
+  }
   const timeoutSeconds = timeout === undefined ? undefined : Number(timeout);
   if (timeoutSeconds !== undefined && (!Number.isFinite(timeoutSeconds) || timeoutSeconds <= 0)) {
     return { kind: 'error', message: '--timeout must be a positive number of seconds' };
@@ -168,6 +187,9 @@ export function parseMakaRunArgs(argv: readonly string[]): ParseMakaRunArgsResul
       ...(parsedMaxSteps !== undefined ? { maxSteps: parsedMaxSteps } : {}),
       ...(permissionMode !== undefined ? { permissionMode } : {}),
       ...(permissionRules.length > 0 ? { permissionRules } : {}),
+      ...(resumeId !== undefined ? { resumeId } : {}),
+      ...(continueLatest ? { continueLatest: true } : {}),
+      ...(thinking === 'default' ? { thinkingDefaultExplicit: true } : {}),
     },
   };
 }
@@ -188,10 +210,32 @@ export async function runMakaTextCli(
   }
 
   let prompt: string;
-  let cwd: string;
+  let selection: Awaited<ReturnType<typeof selectMakaRunSession>>;
+  const workspaceRoot = deps.workspaceRoot();
   try {
     prompt = await resolveRunPrompt(parsed.options, deps);
-    cwd = await canonicalDirectory(parsed.options.cwd ?? deps.processCwd());
+    const sessions = parsed.options.resumeId !== undefined || parsed.options.continueLatest === true
+      ? await deps.listSessions(workspaceRoot)
+      : [];
+    selection = await selectMakaRunSession({
+      sessions,
+      ...(parsed.options.resumeId !== undefined ? { resumeId: parsed.options.resumeId } : {}),
+      continueLatest: parsed.options.continueLatest === true,
+      ...(parsed.options.cwd !== undefined ? { explicitCwd: parsed.options.cwd } : {}),
+      processCwd: deps.processCwd(),
+      ...(parsed.options.connection !== undefined
+        ? { explicitConnection: parsed.options.connection }
+        : {}),
+      ...(parsed.options.model !== undefined ? { explicitModel: parsed.options.model } : {}),
+      thinkingSpecified: parsed.options.thinking !== undefined
+        || parsed.options.thinkingDefaultExplicit === true,
+      ...(parsed.options.thinking !== undefined
+        ? { explicitThinking: parsed.options.thinking }
+        : {}),
+      ...(parsed.options.permissionMode !== undefined
+        ? { explicitPermissionMode: parsed.options.permissionMode }
+        : {}),
+    }, { canonicalizeDirectory: canonicalDirectory });
   } catch (error) {
     deps.writeStderr(`maka run: ${errorMessage(error)}\n`);
     return 2;
@@ -201,10 +245,25 @@ export async function runMakaTextCli(
   let context: MakaRunContext;
   try {
     context = await deps.createContext({
-      workspaceRoot: deps.workspaceRoot(),
-      cwd,
-      ...(parsed.options.connection ? { requestedConnectionSlug: parsed.options.connection } : {}),
-      ...(parsed.options.model ? { requestedModel: parsed.options.model } : {}),
+      workspaceRoot,
+      cwd: selection.cwd,
+      ...((selection.kind === 'existing' || parsed.options.connection)
+        ? {
+            requestedConnectionSlug: selection.kind === 'existing'
+              ? selection.session.llmConnectionSlug
+              : parsed.options.connection,
+          }
+        : {}),
+      ...((selection.kind === 'existing' || parsed.options.model)
+        ? {
+            requestedModel: selection.kind === 'existing'
+              ? selection.session.model
+              : parsed.options.model,
+          }
+        : {}),
+      ...(selection.kind === 'existing'
+        ? { sessionCwdOverride: { sessionId: selection.session.id, cwd: selection.cwd } }
+        : {}),
       ...(parsed.options.maxSteps !== undefined ? { maxSteps: parsed.options.maxSteps } : {}),
       ...(parsed.options.permissionRules !== undefined
         ? { permissionRules: parsed.options.permissionRules }
@@ -220,15 +279,17 @@ export async function runMakaTextCli(
 
   let session: SessionSummary;
   try {
-    session = await context.runtime.createSession({
-      cwd,
-      name: firstLine(prompt).slice(0, 42) || 'Maka run',
-      backend: 'ai-sdk',
-      llmConnectionSlug: context.target.connection.slug,
-      model: context.target.model,
-      permissionMode: parsed.options.permissionMode ?? 'explore',
-      ...(parsed.options.thinking !== undefined ? { thinkingLevel: parsed.options.thinking } : {}),
-    });
+    session = selection.kind === 'existing'
+      ? selection.session
+      : await context.runtime.createSession({
+          cwd: selection.cwd,
+          name: firstLine(prompt).slice(0, 42) || 'Maka run',
+          backend: 'ai-sdk',
+          llmConnectionSlug: context.target.connection.slug,
+          model: context.target.model,
+          permissionMode: parsed.options.permissionMode ?? 'explore',
+          ...(parsed.options.thinking !== undefined ? { thinkingLevel: parsed.options.thinking } : {}),
+        });
   } catch (error) {
     await context.close();
     deps.writeStderr(`maka run: ${errorMessage(error)}\n`);
@@ -336,6 +397,8 @@ function makaRunHelpText(): string {
     '  --permission-mode <mode>  explore|execute|bypass (default: explore)',
     '  --allow <rule>            Repeatable category:<name> or Bash(<exact command>)',
     '  --deny <rule>             Repeatable category:<name> or Bash(<exact command>)',
+    '  --resume <session-id>     Continue an explicit compatible session',
+    '  --continue                Continue the latest compatible session for cwd',
     '  -h, --help                Show help',
   ].join('\n');
 }
@@ -367,6 +430,7 @@ function parseToolPermissionRule(
 function defaultMakaRunDeps(): MakaRunDeps {
   return {
     createContext: createMakaCliRuntimeContext,
+    listSessions: (workspaceRoot) => createSessionStore(workspaceRoot).list(),
     workspaceRoot: () => resolveMakaWorkspaceRoot(),
     processCwd: () => process.cwd(),
     stdinIsTTY: () => process.stdin.isTTY === true,

--- a/packages/cli/src/run-session-selection.ts
+++ b/packages/cli/src/run-session-selection.ts
@@ -1,0 +1,149 @@
+import type { ThinkingLevel } from '@maka/core/model-thinking';
+import type { PermissionMode } from '@maka/core/permission';
+import type { SessionSummary } from '@maka/core/session';
+
+export interface MakaRunSessionSelectionInput {
+  sessions: readonly SessionSummary[];
+  resumeId?: string;
+  continueLatest: boolean;
+  explicitCwd?: string;
+  processCwd: string;
+  explicitConnection?: string;
+  explicitModel?: string;
+  thinkingSpecified: boolean;
+  explicitThinking?: ThinkingLevel;
+  explicitPermissionMode?: Exclude<PermissionMode, 'ask'>;
+}
+
+export type MakaRunSessionSelection =
+  | { kind: 'new'; cwd: string }
+  | { kind: 'existing'; cwd: string; session: SessionSummary };
+
+export interface MakaRunSessionSelectionDeps {
+  canonicalizeDirectory(path: string): Promise<string>;
+}
+
+export async function selectMakaRunSession(
+  input: MakaRunSessionSelectionInput,
+  deps: MakaRunSessionSelectionDeps,
+): Promise<MakaRunSessionSelection> {
+  if (input.resumeId !== undefined && input.continueLatest) {
+    throw new Error('--resume and --continue cannot be used together');
+  }
+  if (input.resumeId !== undefined) return selectExplicitSession(input, deps);
+  if (input.continueLatest) return selectLatestSession(input, deps);
+  return {
+    kind: 'new',
+    cwd: await deps.canonicalizeDirectory(input.explicitCwd ?? input.processCwd),
+  };
+}
+
+async function selectExplicitSession(
+  input: MakaRunSessionSelectionInput & { resumeId?: string },
+  deps: MakaRunSessionSelectionDeps,
+): Promise<Extract<MakaRunSessionSelection, { kind: 'existing' }>> {
+  const session = input.sessions.find((candidate) => candidate.id === input.resumeId);
+  if (!session) throw new Error(`session not found: ${input.resumeId}`);
+  assertSupportedSession(session);
+  const cwd = await canonicalSessionCwd(session, deps);
+  if (input.explicitCwd !== undefined) {
+    const explicitCwd = await deps.canonicalizeDirectory(input.explicitCwd);
+    if (explicitCwd !== cwd) {
+      throw new Error(`--cwd conflicts with resumed session ${session.id}`);
+    }
+  }
+  assertExplicitConfigurationCompatible(session, input);
+  return { kind: 'existing', cwd, session };
+}
+
+async function selectLatestSession(
+  input: MakaRunSessionSelectionInput,
+  deps: MakaRunSessionSelectionDeps,
+): Promise<Extract<MakaRunSessionSelection, { kind: 'existing' }>> {
+  const cwd = await deps.canonicalizeDirectory(input.explicitCwd ?? input.processCwd);
+  const candidates = input.sessions
+    .filter(isContinueCandidate)
+    .sort((left, right) => {
+      const timeDelta = right.lastMessageAt! - left.lastMessageAt!;
+      return timeDelta !== 0 ? timeDelta : left.id.localeCompare(right.id);
+    });
+  for (const session of candidates) {
+    const sessionCwd = await tryCanonicalSessionCwd(session, deps);
+    if (sessionCwd !== cwd) continue;
+    assertExplicitConfigurationCompatible(session, input);
+    return { kind: 'existing', cwd: sessionCwd, session };
+  }
+  throw new Error(`no compatible session found for cwd: ${cwd}`);
+}
+
+function isContinueCandidate(session: SessionSummary): boolean {
+  return !session.isArchived
+    && (session.status === 'active' || session.status === 'aborted')
+    && typeof session.lastMessageAt === 'number'
+    && Number.isFinite(session.lastMessageAt)
+    && session.backend === 'ai-sdk'
+    && session.permissionMode !== 'ask';
+}
+
+function assertSupportedSession(session: SessionSummary): void {
+  if (session.backend !== 'ai-sdk') {
+    throw new Error(`session ${session.id} uses unsupported backend: ${session.backend}`);
+  }
+  if (session.permissionMode === 'ask') {
+    throw new Error(`session ${session.id} uses interactive permission mode ask`);
+  }
+}
+
+function assertExplicitConfigurationCompatible(
+  session: SessionSummary,
+  input: Pick<
+    MakaRunSessionSelectionInput,
+    | 'explicitConnection'
+    | 'explicitModel'
+    | 'thinkingSpecified'
+    | 'explicitThinking'
+    | 'explicitPermissionMode'
+  >,
+): void {
+  if (
+    input.explicitConnection !== undefined
+    && input.explicitConnection !== session.llmConnectionSlug
+  ) {
+    throw new Error(`--connection conflicts with resumed session ${session.id}`);
+  }
+  if (input.explicitModel !== undefined && input.explicitModel !== session.model) {
+    throw new Error(`--model conflicts with resumed session ${session.id}`);
+  }
+  if (input.thinkingSpecified && input.explicitThinking !== session.thinkingLevel) {
+    throw new Error(`--thinking conflicts with resumed session ${session.id}`);
+  }
+  if (
+    input.explicitPermissionMode !== undefined
+    && input.explicitPermissionMode !== session.permissionMode
+  ) {
+    throw new Error(`--permission-mode conflicts with resumed session ${session.id}`);
+  }
+}
+
+async function canonicalSessionCwd(
+  session: SessionSummary,
+  deps: MakaRunSessionSelectionDeps,
+): Promise<string> {
+  if (!session.cwd) throw new Error(`session ${session.id} has no stored cwd`);
+  try {
+    return await deps.canonicalizeDirectory(session.cwd);
+  } catch {
+    throw new Error(`session ${session.id} cwd is missing or inaccessible: ${session.cwd}`);
+  }
+}
+
+async function tryCanonicalSessionCwd(
+  session: SessionSummary,
+  deps: MakaRunSessionSelectionDeps,
+): Promise<string | undefined> {
+  try {
+    return await canonicalSessionCwd(session, deps);
+  } catch {
+    return undefined;
+  }
+}

--- a/packages/cli/src/runtime-bootstrap.ts
+++ b/packages/cli/src/runtime-bootstrap.ts
@@ -70,6 +70,8 @@ export interface CreateMakaCliRuntimeContextInput {
   requestedModel?: string;
   maxSteps?: number;
   permissionRules?: readonly ToolPermissionRule[];
+  /** Canonical cwd used for one resumed session without rewriting its stored header. */
+  sessionCwdOverride?: { sessionId: string; cwd: string };
   runtimeInvocationObserver?: (result: InvocationResult) => void | Promise<void>;
   /**
    * Optional cron executor. When provided, the Automation tool advertises the
@@ -183,13 +185,16 @@ export async function createMakaCliRuntimeContext(
   const allTools = [...tools, automationTool, ...goalTools];
 
   backends.register('ai-sdk', async (ctx) => {
+    const header = input.sessionCwdOverride?.sessionId === ctx.sessionId
+      ? { ...ctx.header, cwd: input.sessionCwdOverride.cwd }
+      : ctx.header;
     // Resolve the session's own connection — not the global default — so a
     // /model switch that rebinds the session to another provider actually runs
     // on that provider (the desktop app resolves the backend the same way).
-    const ready = await resolveSessionTargetForSlug(ctx.header.llmConnectionSlug, {
+    const ready = await resolveSessionTargetForSlug(header.llmConnectionSlug, {
       connectionStore,
       credentialStore,
-      requestedModel: ctx.header.model,
+      requestedModel: header.model,
     });
     const modelFetch = buildSubscriptionModelFetch({
       connection: ready.connection,
@@ -205,7 +210,7 @@ export async function createMakaCliRuntimeContext(
     });
     return new AiSdkBackend({
       sessionId: ctx.sessionId,
-      header: { ...ctx.header, model: ready.model },
+      header: { ...header, model: ready.model },
       appendMessage: ctx.appendMessage ?? ((message) => ctx.store.appendMessage(ctx.sessionId, message)),
       connection: ready.connection,
       apiKey: ready.apiKey,
@@ -213,7 +218,7 @@ export async function createMakaCliRuntimeContext(
       permissionEngine,
       modelFactory: (modelInput) => getAIModel({ ...modelInput, fetch: modelFetch }),
       tools: allTools,
-      providerOptions: buildProviderOptions(ready.connection, ready.model, ctx.header.thinkingLevel),
+      providerOptions: buildProviderOptions(ready.connection, ready.model, header.thinkingLevel),
       contextBudget: buildCliContextBudgetPolicy(ready.connection, ready.model),
       loadHistoryCompact: (event) => loadHistoryCompactBlocksFromArtifacts(artifactStore, event),
       loadHistoryCompactCheckpoint: ctx.loadHistoryCompactCheckpoint,


### PR DESCRIPTION
## Summary

- add `maka run --resume <session-id>` while preserving the stored session identity, connection, model, thinking level, and permission mode
- add cwd-scoped `--continue` selection over non-archived active/aborted sessions with deterministic `lastMessageAt` descending and session-id ascending ordering
- canonicalize stored and requested cwd values for comparison, reject missing/inaccessible or conflicting paths, and use the canonical cwd at runtime without rewriting the stored header
- reject incompatible backends, interactive `ask` sessions, conflicting explicit configuration, missing sessions, and empty continue selections as preflight exit 2

Part of #730 (Slice 4).

## Testing

- focused session-selection, process-boundary, and runtime-bootstrap tests (41 passed)
- `npm --workspace maka-agent test` (285 passed)
- `npm run typecheck`
- `git diff --check upstream/main...HEAD`