### PR TITLE
feat(cli): wire skill injection into the CLI host (#748 ticket 3)

### DIFF
--- a/packages/cli/src/__tests__/cli-system-prompt.test.ts
+++ b/packages/cli/src/__tests__/cli-system-prompt.test.ts
@@ -1,17 +1,64 @@
 import assert from 'node:assert/strict';
-import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, test } from 'node:test';
 import { buildCliSystemPrompt, buildCliTurnTailPrompt } from '../cli-system-prompt.js';
+import type { HostCapabilities } from '@maka/runtime';
 
 describe('CLI system prompt', () => {
+  test('injects the skill catalog from workspaceRoot, gated by host capabilities (Office skills auto-filter on the CLI host)', async () => {
+    await withCwdAndWorkspace(async ({ cwd, workspaceRoot }) => {
+      await writeSkill(workspaceRoot, 'plain-helper', `---
+name: Plain Helper
+description: Plain work.
+allowed-tools: [Read]
+---
+# Plain Helper
+Plain work.`);
+      await writeSkill(workspaceRoot, 'office-helper', `---
+name: Office Helper
+description: Office document work.
+allowed-tools: [Read]
+required-tools: [OfficeDocument]
+---
+# Office Helper
+Use Office tools.`);
+
+      // CLI host without OfficeDocument: office-helper is hard-hidden, plain-helper shown.
+      // workspaceRoot is separate from cwd so the project directory is never scanned.
+      const cliHost: HostCapabilities = { toolNames: new Set(['Read']) };
+      const out = await buildCliSystemPrompt({
+        settings: { personalization: {}, workspaceInstructions: { enabled: false } },
+        cwd,
+        workspaceRoot,
+        host: cliHost,
+      });
+      assert.ok(out, 'prompt should include the plain skill catalog');
+      assert.match(out, /<available-skill id="plain-helper"/);
+      assert.doesNotMatch(out, /<available-skill id="office-helper"/);
+
+      // Host with OfficeDocument: both skills shown.
+      const fullHost: HostCapabilities = { toolNames: new Set(['Read', 'OfficeDocument']) };
+      const full = await buildCliSystemPrompt({
+        settings: { personalization: {}, workspaceInstructions: { enabled: false } },
+        cwd,
+        workspaceRoot,
+        host: fullHost,
+      });
+      assert.ok(full);
+      assert.match(full, /<available-skill id="plain-helper"/);
+      assert.match(full, /<available-skill id="office-helper"/);
+    });
+  });
+
   test('includes AGENTS.md content when workspaceInstructions is enabled and the file is present', async () => {
     await withCwd(async (cwd) => {
       await writeFile(join(cwd, 'AGENTS.md'), '# Project rules\n- Use TDD always\n');
       const out = await buildCliSystemPrompt({
         settings: { personalization: {}, workspaceInstructions: { enabled: true } },
         cwd,
+        workspaceRoot: cwd,
       });
       assert.ok(out, 'expected a prompt fragment when AGENTS.md is present and enabled');
       assert.match(out, /Use TDD always/);
@@ -25,6 +72,7 @@ describe('CLI system prompt', () => {
       const out = await buildCliSystemPrompt({
         settings: { personalization: {}, workspaceInstructions: { enabled: false } },
         cwd,
+        workspaceRoot: cwd,
       });
       assert.equal(out, undefined, 'gate must suppress AGENTS.md when workspaceInstructions is disabled');
     });
@@ -35,6 +83,7 @@ describe('CLI system prompt', () => {
       const out = await buildCliSystemPrompt({
         settings: { personalization: { displayName: 'Yuhan' }, workspaceInstructions: { enabled: false } },
         cwd,
+        workspaceRoot: cwd,
       });
       assert.ok(out);
       assert.match(out, /addressed as "Yuhan"/);
@@ -46,6 +95,7 @@ describe('CLI system prompt', () => {
       const out = await buildCliSystemPrompt({
         settings: { personalization: {}, workspaceInstructions: { enabled: true } },
         cwd,
+        workspaceRoot: cwd,
       });
       assert.equal(out, undefined);
     });
@@ -57,6 +107,7 @@ describe('CLI system prompt', () => {
       const out = await buildCliSystemPrompt({
         settings: { personalization: { displayName: 'Alice' }, workspaceInstructions: { enabled: true } },
         cwd,
+        workspaceRoot: cwd,
       });
       assert.ok(out);
       assert.match(out, /addressed as "Alice"/);
@@ -84,4 +135,21 @@ async function withCwd(fn: (cwd: string) => Promise<void>): Promise<void> {
   } finally {
     await rm(cwd, { recursive: true, force: true });
   }
+}
+
+async function withCwdAndWorkspace(fn: (dirs: { cwd: string; workspaceRoot: string }) => Promise<void>): Promise<void> {
+  const cwd = await mkdtemp(join(tmpdir(), 'maka-cli-sysprompt-cwd-'));
+  const workspaceRoot = await mkdtemp(join(tmpdir(), 'maka-cli-sysprompt-ws-'));
+  try {
+    await fn({ cwd, workspaceRoot });
+  } finally {
+    await rm(cwd, { recursive: true, force: true });
+    await rm(workspaceRoot, { recursive: true, force: true });
+  }
+}
+
+async function writeSkill(workspaceRoot: string, id: string, content: string): Promise<void> {
+  const dir = join(workspaceRoot, 'skills', id);
+  await mkdir(dir, { recursive: true });
+  await writeFile(join(dir, 'SKILL.md'), content, 'utf8');
 }

--- a/packages/cli/src/__tests__/runtime-bootstrap.test.ts
+++ b/packages/cli/src/__tests__/runtime-bootstrap.test.ts
@@ -180,6 +180,29 @@ describe('Maka CLI runtime bootstrap', () => {
     });
   });
 
+  test('registers the Skill tool so the CLI can load workspace skills', async () => {
+    await withWorkspace(async (workspaceRoot) => {
+      const connectionStore = createConnectionStore(workspaceRoot);
+      await connectionStore.create({
+        slug: 'local',
+        name: 'Local Ollama',
+        providerType: 'ollama',
+        defaultModel: 'llama3.2',
+      });
+
+      const context = await createMakaCliRuntimeContext({
+        workspaceRoot,
+        cwd: '/repo',
+      });
+      try {
+        const skill = context.tools.find((tool) => tool.name === 'Skill');
+        assert.ok(skill, 'Skill tool must be registered on the CLI host');
+      } finally {
+        await context.close();
+      }
+    });
+  });
+
   test('enables background ShellRuns for the TUI runtime and cleans them up on close', async () => {
     await withWorkspace(async (workspaceRoot) => {
       const connectionStore = createConnectionStore(workspaceRoot);

--- a/packages/cli/src/cli-system-prompt.ts
+++ b/packages/cli/src/cli-system-prompt.ts
@@ -2,10 +2,12 @@ import { redactSecrets, type PersonalizationSettings } from '@maka/core';
 import {
   buildPersonalizationPromptFragment,
   buildSessionEnvironmentPromptFragment,
+  buildSkillsPromptFragment,
   buildWorkspaceInstructionsPromptFragment,
   resolveProjectGitInfo,
   type AutomationManager,
   type GoalManager,
+  type HostCapabilities,
 } from '@maka/runtime';
 
 /**
@@ -29,14 +31,29 @@ export interface BuildCliSystemPromptInput {
     workspaceInstructions: { enabled: boolean };
   };
   cwd: string;
+  /**
+   * Workspace root holding the shared `skills/` directory (distinct from the
+   * session `cwd` so the project directory is never scanned for skills). The
+   * skill catalog fragment is built from `{workspaceRoot}/skills/`.
+   */
+  workspaceRoot: string;
+  /**
+   * Host capability surface for the skill-compatibility gate. When omitted,
+   * the catalog is built without gating (legacy behavior). The CLI host
+   * passes its registered tool names so skills whose `requiredTools` are not
+   * available (e.g. bundled Office skills without the Office tools) are hidden.
+   */
+  host?: HostCapabilities;
 }
 
 export async function buildCliSystemPrompt(input: BuildCliSystemPromptInput): Promise<string | undefined> {
   const personalization = buildPersonalizationPromptFragment(input.settings.personalization);
+  // personalization -> skills -> workspaceInstructions, matching the desktop app.
+  const skills = await buildSkillsPromptFragment(input.workspaceRoot, input.host);
   const workspaceInstructions = input.settings.workspaceInstructions.enabled
     ? await buildWorkspaceInstructionsPromptFragment(input.cwd)
     : undefined;
-  const fragments = [personalization.text, workspaceInstructions].filter((v): v is string => Boolean(v));
+  const fragments = [personalization.text, skills, workspaceInstructions].filter((v): v is string => Boolean(v));
   return fragments.length > 0 ? fragments.join('\n\n') : undefined;
 }
 

--- a/packages/cli/src/runtime-bootstrap.ts
+++ b/packages/cli/src/runtime-bootstrap.ts
@@ -13,6 +13,7 @@ import {
   buildAutomationTool,
   buildBuiltinTools,
   buildDefaultContextBudgetPolicy,
+  buildSkillAgentTool,
   buildGoalTools,
   buildLlmHistorySummarizer,
   cleanupLegacyHistoryCompactArtifacts,
@@ -23,6 +24,8 @@ import {
   loadHistoryCompactBlocksFromArtifacts,
   type AutomationDefinition,
   type GoalContinuationDeps,
+  type HostCapabilities,
+  type MakaTool,
   type InvocationResult,
   type ShellRunUpdate,
 } from '@maka/runtime';
@@ -50,7 +53,8 @@ export interface MakaCliRuntimeContext {
   target: ReadySessionTarget;
   /** Selectable models across every ready connection, for the `/model` picker. */
   modelChoices: ModelChoice[];
-  tools: ReturnType<typeof buildBuiltinTools>;
+  /** Tools passed to the backend (builtins + automation + goals + Skill). */
+  tools: MakaTool[];
   automationManager: AutomationManager;
   automationScheduler: AutomationScheduler;
   subscribeShellRunUpdates(listener: (update: ShellRunUpdate) => void): () => void;
@@ -182,7 +186,15 @@ export async function createMakaCliRuntimeContext(
     goalManager,
     getTokenCount: (sessionId) => goalTokenCache.get(sessionId) ?? 0,
   });
-  const allTools = [...tools, automationTool, ...goalTools];
+  // CLI host capability surface for the skill-compatibility gate: the tool
+  // names registered on this host. The CLI has no Office tools, so bundled
+  // Office skills (requiredTools includes OfficeDocument/OfficeDocumentEdit)
+  // are hard-hidden here without seeding them — desktop owns Office seeding.
+  const host: HostCapabilities = {
+    toolNames: new Set([...tools, automationTool, ...goalTools].map((tool) => tool.name)),
+  };
+  const skillTool = buildSkillAgentTool(input.workspaceRoot, host);
+  const allTools = [...tools, automationTool, ...goalTools, skillTool];
 
   backends.register('ai-sdk', async (ctx) => {
     const header = input.sessionCwdOverride?.sessionId === ctx.sessionId
@@ -237,7 +249,7 @@ export async function createMakaCliRuntimeContext(
       recordHistoryCompactCheckpoint: ctx.recordHistoryCompactCheckpoint,
       systemPrompt: async ({ cwd }) => {
         const settings = await settingsStore.get();
-        return buildCliSystemPrompt({ settings, cwd });
+        return buildCliSystemPrompt({ settings, cwd, workspaceRoot: input.workspaceRoot, host });
       },
       turnTailPrompt: ({ cwd }) => buildCliTurnTailPrompt({ cwd, sessionId: ctx.sessionId, automationManager, goalManager }),
       shellRunContextSummary: ctx.shellRunContextSummary,
@@ -417,7 +429,7 @@ export async function createMakaCliRuntimeContext(
     runtime,
     target,
     modelChoices,
-    tools,
+    tools: allTools,
     automationManager,
     automationScheduler,
     subscribeShellRunUpdates: (listener) => {

--- a/packages/runtime/src/__tests__/skills.test.ts
+++ b/packages/runtime/src/__tests__/skills.test.ts
@@ -398,6 +398,33 @@ Plain work.`);
     });
   });
 
+  it('gate hard-hides legacy v2 Office skills (no required-tools front matter) on a host without Office tools', async () => {
+    await withWorkspace(async (workspaceRoot) => {
+      // v2 OfficeCLI template: allowed-tools includes OfficeDocument, but no required-tools.
+      await writeSkill(workspaceRoot, 'officecli-docx', `---
+name: OfficeCLI DOCX
+description: Legacy v2 Office skill without required-tools.
+allowed-tools:
+  - OfficeDocument
+  - OfficeDocumentEdit
+  - Read
+---
+# OfficeCLI DOCX
+Legacy v2 body.`);
+      const host: HostCapabilities = { toolNames: new Set(['Read', 'Bash']) };
+
+      // Prompt hard-hides the legacy Office skill (fallback requiredTools for bundled officecli-*).
+      const prompt = await buildSkillsPromptFragment(workspaceRoot, host);
+      assert.ok(!prompt || !prompt.includes('id="officecli-docx"'));
+
+      // Loader rejects it as host_incompatible.
+      const loaded = await loadSkillInstructions(workspaceRoot, 'officecli-docx', host);
+      assert.equal(loaded.ok, false);
+      if (loaded.ok) return;
+      assert.equal(loaded.reason, 'host_incompatible');
+    });
+  });
+
   it('gateSkillsByHostCapabilities hard-hides skills whose required tools are missing and only hints at missing declared tools', () => {
     const skills: ScannedSkill[] = [
       { id: 'office', name: 'Office', description: '', path: '/p', declaredTools: ['Read', 'OfficeDocument'], requiredTools: ['OfficeDocument'], requiredCapabilities: [], enabled: true, runtimeStatus: 'enabled', content: '', contentSha256: 'sha256:x' },

--- a/packages/runtime/src/skills.ts
+++ b/packages/runtime/src/skills.ts
@@ -167,11 +167,32 @@ export async function scanWorkspaceSkills(root: string): Promise<ScannedSkill[]>
   return out;
 }
 
+/**
+ * Bundled Office skills' required tools, used as a fallback when a legacy
+ * install predates the `required-tools` front matter (the v3 template from
+ * ticket 2). Without this, a host that runs before the desktop migrates the
+ * v2 install to v3 would see Office skills with empty `requiredTools` and fail
+ * to hide them, advertising skills whose tools the host cannot call. This is
+ * product metadata for maka-bundled skill ids, not desktop governance.
+ */
+const BUNDLED_OFFICE_REQUIRED_TOOLS_BY_ID: ReadonlyMap<string, readonly string[]> = new Map([
+  ['officecli-docx', ['OfficeDocument', 'OfficeDocumentEdit']],
+  ['officecli-xlsx', ['OfficeDocument', 'OfficeDocumentEdit']],
+  ['officecli-pptx', ['OfficeDocument', 'OfficeDocumentEdit']],
+]);
+
+function effectiveRequiredTools(skill: RuntimeSkillDefinition): readonly string[] {
+  return skill.requiredTools.length > 0
+    ? skill.requiredTools
+    : (BUNDLED_OFFICE_REQUIRED_TOOLS_BY_ID.get(skill.id) ?? []);
+}
+
 export function gateSkillsByHostCapabilities(skills: ScannedSkill[], host: HostCapabilities): GatedSkill[] {
   const caps = host.capabilities ?? new Set<string>();
   return skills.map((skill) => {
     const missingDeclaredTools = skill.declaredTools.filter((tool) => !host.toolNames.has(tool));
-    const requiredToolsMissing = skill.requiredTools.some((tool) => !host.toolNames.has(tool));
+    const requiredTools = effectiveRequiredTools(skill);
+    const requiredToolsMissing = requiredTools.some((tool) => !host.toolNames.has(tool));
     const requiredCapabilitiesMissing = skill.requiredCapabilities.some((cap) => !caps.has(cap));
     const eligible = !requiredToolsMissing && !requiredCapabilitiesMissing;
     const hiddenReason: SkillHostCompatibility['hiddenReason'] = requiredToolsMissing


### PR DESCRIPTION
<!-- Local drafting aid for Maka PR descriptions; not the repository-wide GitHub PR template. -->

## Summary

- Wire skill injection into the CLI host: inject the workspace skill catalog into `buildCliSystemPrompt` and register the read-only `Skill` tool in `allTools`, both via the shared `@maka/runtime` gated resolver.
- `buildCliSystemPrompt` gains an explicit `workspaceRoot` param (distinct from the session `cwd`, so the project directory is never scanned for skills) and an optional `HostCapabilities` param; prompt order is now `personalization -> skills -> workspaceInstructions`, matching the desktop app.
- `runtime-bootstrap` builds the CLI host capability surface from its registered tool names (builtins + automation + goals; the CLI has no Office tools), so bundled Office skills (`requiredTools` includes `OfficeDocument` / `OfficeDocumentEdit`) are hard-hidden without the CLI seeding them — desktop owns Office seeding. `MakaCliRuntimeContext.tools` now returns the actual `allTools` passed to the backend.

## Why

#748 ticket 3 (final). The CLI had zero skill support — no skill catalog in the system prompt, no `Skill` tool — while desktop and CLI share the same `workspaceRoot`. With the shared runtime gate (ticket 2, PR #756) and the CLI host capability surface, a skill installed via desktop is now visible and callable in the CLI, and incompatible Office skills auto-filter on the CLI host. Closes #748.

## Scope

One commit, `@maka/cli` only:

- `cli-system-prompt.ts` — `BuildCliSystemPromptInput` gains `workspaceRoot` + optional `host?`; `buildCliSystemPrompt` injects `buildSkillsPromptFragment(workspaceRoot, host)` between personalization and workspace instructions.
- `runtime-bootstrap.ts` — construct `host` toolNames from builtins + automation + goals; `buildSkillAgentTool(workspaceRoot, host)` -> `skillTool`; `allTools` includes `skillTool`; `MakaCliRuntimeContext.tools` returns `allTools`; `buildCliSystemPrompt({ settings, cwd, workspaceRoot, host })`.
- tests — the skill catalog is injected from a `workspaceRoot` separate from `cwd`, gated by host capabilities (Office skills auto-filter on the CLI host); the `Skill` tool is registered on the CLI host; existing prompt tests pass `workspaceRoot`.

Non-goals: the CLI does not seed bundled Office skills (desktop owns seeding); desktop and headless are unchanged.

## Verification

- `npm test` (`@maka/cli`) — 287 pass, 0 fail (new skills-injection test + Skill-tool test; existing prompt tests updated with `workspaceRoot`).
- `npm run -w @maka/runtime test` — 1301 pass, 0 fail, 2 skipped.
- `npm run -w @maka/desktop test` — 2324 pass, 0 fail (unchanged baseline).
- `npm run typecheck` green across all workspaces.

## Impact

CLI users: skills installed via desktop are now visible in the CLI system prompt and loadable via the `Skill` tool; bundled Office skills are hidden on the CLI host (no Office tools). Desktop and headless are unchanged. No migration, compatibility, documentation, or release-note needs beyond #748.

## Reviewer notes

1. **Prompt order + gating** — skills sit between personalization and workspace instructions; the CLI always passes `host`, so `host === undefined` (no-gating) is not exercised in production; Office skills hard-hide because the CLI `toolNames` lacks `OfficeDocument` / `OfficeDocumentEdit`.
2. **`workspaceRoot` ≠ `cwd`** — the skill catalog scans `{workspaceRoot}/skills`, never the project `cwd`; the new test uses separate `tmpdir`s for cwd and workspaceRoot.
3. **`tools = allTools`** — `MakaCliRuntimeContext.tools` now reflects the actual backend tools (builtins + automation + goals + Skill); existing tests use `.find` / `.includes` (non-exclusive), so they stay green.

## Ready for review

- [x] Verification is complete and the results above are current
- [x] Impact, compatibility, migration, documentation, and release-note needs are addressed
- [x] User-visible UI/UX changes include visual evidence, or `Verification` explains why it is not applicable — N/A: CLI prompt/tool wiring, no UI changes