### PR TITLE
feat(runtime): multi-path skill discovery (.agents/skills + .maka/skills)

### DIFF
--- a/packages/cli/src/__tests__/cli-system-prompt.test.ts
+++ b/packages/cli/src/__tests__/cli-system-prompt.test.ts
@@ -8,7 +8,7 @@ import type { HostCapabilities } from '@maka/runtime';
 
 describe('CLI system prompt', () => {
   test('injects the skill catalog from workspaceRoot, gated by host capabilities (Office skills auto-filter on the CLI host)', async () => {
-    await withCwdAndWorkspace(async ({ cwd, workspaceRoot }) => {
+    await withCwdAndWorkspace(async ({ cwd, workspaceRoot, homeDir }) => {
       await writeSkill(workspaceRoot, 'plain-helper', `---
 name: Plain Helper
 description: Plain work.
@@ -33,6 +33,7 @@ Use Office tools.`);
         cwd,
         workspaceRoot,
         host: cliHost,
+        homeDir,
       });
       assert.ok(out, 'prompt should include the plain skill catalog');
       assert.match(out, /<available-skill id="plain-helper"/);
@@ -45,6 +46,7 @@ Use Office tools.`);
         cwd,
         workspaceRoot,
         host: fullHost,
+        homeDir,
       });
       assert.ok(full);
       assert.match(full, /<available-skill id="plain-helper"/);
@@ -52,13 +54,86 @@ Use Office tools.`);
     });
   });
 
+  test('discovers skills from .agents/skills and .maka/skills at project and user level', async () => {
+    await withCwdAndWorkspace(async ({ cwd, workspaceRoot, homeDir }) => {
+      // Project-level cross-client skill
+      await writeSkillAt(cwd, '.agents', 'skills', 'cross-client-skill', `---
+name: Cross Client Skill
+description: From .agents/skills at project level.
+---
+# Cross Client Skill
+Body.`);
+
+      // User-level maka skill
+      await writeSkillAt(homeDir, '.maka', 'skills', 'user-skill', `---
+name: User Skill
+description: From ~/.maka/skills at user level.
+---
+# User Skill
+Body.`);
+
+      // Workspace-level skill (existing path)
+      await writeSkill(workspaceRoot, 'ws-skill', `---
+name: Workspace Skill
+description: From workspaceRoot/skills.
+---
+# Workspace Skill
+Body.`);
+
+      const out = await buildCliSystemPrompt({
+        settings: { personalization: {}, workspaceInstructions: { enabled: false } },
+        cwd,
+        workspaceRoot,
+        homeDir,
+      });
+
+      assert.ok(out);
+      assert.match(out, /<available-skill id="cross-client-skill"/);
+      assert.match(out, /<available-skill id="user-skill"/);
+      assert.match(out, /<available-skill id="ws-skill"/);
+    });
+  });
+
+  test('project-level skill overrides user-level skill with the same id', async () => {
+    await withCwdAndWorkspace(async ({ cwd, workspaceRoot, homeDir }) => {
+      // User-level skill (lower precedence)
+      await writeSkillAt(homeDir, '.agents', 'skills', 'shared-skill', `---
+name: Shared Skill
+description: User-level copy.
+---
+# Shared Skill
+User body.`);
+
+      // Project-level skill with the same id (higher precedence)
+      await writeSkillAt(cwd, '.agents', 'skills', 'shared-skill', `---
+name: Shared Skill
+description: Project-level copy.
+---
+# Shared Skill
+Project body.`);
+
+      const out = await buildCliSystemPrompt({
+        settings: { personalization: {}, workspaceInstructions: { enabled: false } },
+        cwd,
+        workspaceRoot,
+        homeDir,
+      });
+
+      assert.ok(out);
+      assert.match(out, /<available-skill id="shared-skill"/);
+      assert.match(out, /Project-level copy\./);
+      assert.doesNotMatch(out, /User-level copy\./);
+    });
+  });
+
   test('includes AGENTS.md content when workspaceInstructions is enabled and the file is present', async () => {
-    await withCwd(async (cwd) => {
+    await withCwd(async (cwd, homeDir) => {
       await writeFile(join(cwd, 'AGENTS.md'), '# Project rules\n- Use TDD always\n');
       const out = await buildCliSystemPrompt({
         settings: { personalization: {}, workspaceInstructions: { enabled: true } },
         cwd,
         workspaceRoot: cwd,
+        homeDir,
       });
       assert.ok(out, 'expected a prompt fragment when AGENTS.md is present and enabled');
       assert.match(out, /Use TDD always/);
@@ -67,23 +142,25 @@ Use Office tools.`);
   });
 
   test('suppresses workspace instructions when the setting is disabled, even if AGENTS.md exists', async () => {
-    await withCwd(async (cwd) => {
+    await withCwd(async (cwd, homeDir) => {
       await writeFile(join(cwd, 'AGENTS.md'), '- secret project rule');
       const out = await buildCliSystemPrompt({
         settings: { personalization: {}, workspaceInstructions: { enabled: false } },
         cwd,
         workspaceRoot: cwd,
+        homeDir,
       });
       assert.equal(out, undefined, 'gate must suppress AGENTS.md when workspaceInstructions is disabled');
     });
   });
 
   test('includes the personalization addressing hint when a displayName is set', async () => {
-    await withCwd(async (cwd) => {
+    await withCwd(async (cwd, homeDir) => {
       const out = await buildCliSystemPrompt({
         settings: { personalization: { displayName: 'Yuhan' }, workspaceInstructions: { enabled: false } },
         cwd,
         workspaceRoot: cwd,
+        homeDir,
       });
       assert.ok(out);
       assert.match(out, /addressed as "Yuhan"/);
@@ -91,23 +168,25 @@ Use Office tools.`);
   });
 
   test('returns undefined when there is no personalization and no readable instruction file', async () => {
-    await withCwd(async (cwd) => {
+    await withCwd(async (cwd, homeDir) => {
       const out = await buildCliSystemPrompt({
         settings: { personalization: {}, workspaceInstructions: { enabled: true } },
         cwd,
         workspaceRoot: cwd,
+        homeDir,
       });
       assert.equal(out, undefined);
     });
   });
 
   test('joins personalization and workspace instructions into one prompt', async () => {
-    await withCwd(async (cwd) => {
+    await withCwd(async (cwd, homeDir) => {
       await writeFile(join(cwd, 'AGENTS.md'), '- commit one reason');
       const out = await buildCliSystemPrompt({
         settings: { personalization: { displayName: 'Alice' }, workspaceInstructions: { enabled: true } },
         cwd,
         workspaceRoot: cwd,
+        homeDir,
       });
       assert.ok(out);
       assert.match(out, /addressed as "Alice"/);
@@ -128,28 +207,40 @@ describe('CLI turn-tail prompt', () => {
   });
 });
 
-async function withCwd(fn: (cwd: string) => Promise<void>): Promise<void> {
+async function withCwd(fn: (cwd: string, homeDir: string) => Promise<void>): Promise<void> {
   const cwd = await mkdtemp(join(tmpdir(), 'maka-cli-sysprompt-'));
+  const homeDir = await mkdtemp(join(tmpdir(), 'maka-cli-sysprompt-home-'));
   try {
-    await fn(cwd);
+    await fn(cwd, homeDir);
   } finally {
     await rm(cwd, { recursive: true, force: true });
+    await rm(homeDir, { recursive: true, force: true });
   }
 }
 
-async function withCwdAndWorkspace(fn: (dirs: { cwd: string; workspaceRoot: string }) => Promise<void>): Promise<void> {
+async function withCwdAndWorkspace(fn: (dirs: { cwd: string; workspaceRoot: string; homeDir: string }) => Promise<void>): Promise<void> {
   const cwd = await mkdtemp(join(tmpdir(), 'maka-cli-sysprompt-cwd-'));
   const workspaceRoot = await mkdtemp(join(tmpdir(), 'maka-cli-sysprompt-ws-'));
+  const homeDir = await mkdtemp(join(tmpdir(), 'maka-cli-sysprompt-home-'));
   try {
-    await fn({ cwd, workspaceRoot });
+    await fn({ cwd, workspaceRoot, homeDir });
   } finally {
     await rm(cwd, { recursive: true, force: true });
     await rm(workspaceRoot, { recursive: true, force: true });
+    await rm(homeDir, { recursive: true, force: true });
   }
 }
 
 async function writeSkill(workspaceRoot: string, id: string, content: string): Promise<void> {
   const dir = join(workspaceRoot, 'skills', id);
+  await mkdir(dir, { recursive: true });
+  await writeFile(join(dir, 'SKILL.md'), content, 'utf8');
+}
+
+async function writeSkillAt(base: string, ...parts: string[]): Promise<void> {
+  const content = parts.pop()!;
+  const id = parts.pop()!;
+  const dir = join(base, ...parts, id);
   await mkdir(dir, { recursive: true });
   await writeFile(join(dir, 'SKILL.md'), content, 'utf8');
 }

--- a/packages/cli/src/cli-system-prompt.ts
+++ b/packages/cli/src/cli-system-prompt.ts
@@ -5,9 +5,11 @@ import {
   buildSkillsPromptFragment,
   buildWorkspaceInstructionsPromptFragment,
   resolveProjectGitInfo,
+  resolveSkillDiscoveryPaths,
   type AutomationManager,
   type GoalManager,
   type HostCapabilities,
+  type SkillSource,
 } from '@maka/runtime';
 
 /**
@@ -44,12 +46,19 @@ export interface BuildCliSystemPromptInput {
    * available (e.g. bundled Office skills without the Office tools) are hidden.
    */
   host?: HostCapabilities;
+  /**
+   * Home directory for user-level skill discovery (`~/.maka/skills/`,
+   * `~/.agents/skills/`). Defaults to `os.homedir()`. Tests pass a temp dir
+   * to avoid picking up real installed skills.
+   */
+  homeDir?: string;
 }
 
 export async function buildCliSystemPrompt(input: BuildCliSystemPromptInput): Promise<string | undefined> {
   const personalization = buildPersonalizationPromptFragment(input.settings.personalization);
   // personalization -> skills -> workspaceInstructions, matching the desktop app.
-  const skills = await buildSkillsPromptFragment(input.workspaceRoot, input.host);
+  const skillSource = resolveSkillDiscoveryPaths(input.cwd, input.workspaceRoot, input.homeDir);
+  const skills = await buildSkillsPromptFragment(skillSource, input.host);
   const workspaceInstructions = input.settings.workspaceInstructions.enabled
     ? await buildWorkspaceInstructionsPromptFragment(input.cwd)
     : undefined;

--- a/packages/cli/src/runtime-bootstrap.ts
+++ b/packages/cli/src/runtime-bootstrap.ts
@@ -22,6 +22,7 @@ import {
   evaluateAutomationCanFire,
   getAIModel,
   loadHistoryCompactBlocksFromArtifacts,
+  resolveSkillDiscoveryPaths,
   type AutomationDefinition,
   type GoalContinuationDeps,
   type HostCapabilities,
@@ -193,7 +194,8 @@ export async function createMakaCliRuntimeContext(
   const host: HostCapabilities = {
     toolNames: new Set([...tools, automationTool, ...goalTools].map((tool) => tool.name)),
   };
-  const skillTool = buildSkillAgentTool(input.workspaceRoot, host);
+  const skillSource = resolveSkillDiscoveryPaths(input.cwd, input.workspaceRoot);
+  const skillTool = buildSkillAgentTool(skillSource, host);
   const allTools = [...tools, automationTool, ...goalTools, skillTool];
 
   backends.register('ai-sdk', async (ctx) => {

--- a/packages/runtime/src/__tests__/skills.test.ts
+++ b/packages/runtime/src/__tests__/skills.test.ts
@@ -429,8 +429,8 @@ Legacy v2 body.`);
 
   it('gateSkillsByHostCapabilities hard-hides skills whose required tools are missing and only hints at missing declared tools', () => {
     const skills: ScannedSkill[] = [
-      { id: 'office', name: 'Office', description: '', path: '/p', declaredTools: ['Read', 'OfficeDocument'], requiredTools: ['OfficeDocument'], requiredCapabilities: [], enabled: true, runtimeStatus: 'enabled', content: '', contentSha256: 'sha256:x' },
-      { id: 'plain', name: 'Plain', description: '', path: '/p', declaredTools: ['Bash'], requiredTools: [], requiredCapabilities: [], enabled: true, runtimeStatus: 'enabled', content: '', contentSha256: 'sha256:y' },
+      { id: 'office', name: 'Office', description: '', path: '/p', declaredTools: ['Read', 'OfficeDocument'], requiredTools: ['OfficeDocument'], requiredCapabilities: [], enabled: true, runtimeStatus: 'enabled', content: '', contentSha256: 'sha256:x', discoveryRoot: '/p' },
+      { id: 'plain', name: 'Plain', description: '', path: '/p', declaredTools: ['Bash'], requiredTools: [], requiredCapabilities: [], enabled: true, runtimeStatus: 'enabled', content: '', contentSha256: 'sha256:y', discoveryRoot: '/p' },
     ];
     const host: HostCapabilities = { toolNames: new Set(['Read']) };
     const gated = gateSkillsByHostCapabilities(skills, host);
@@ -446,7 +446,7 @@ Legacy v2 body.`);
 
   it('gateSkillsByHostCapabilities hides skills whose required capabilities are missing', () => {
     const skills: ScannedSkill[] = [
-      { id: 'cap', name: 'Cap', description: '', path: '/p', declaredTools: [], requiredTools: [], requiredCapabilities: ['office'], enabled: true, runtimeStatus: 'enabled', content: '', contentSha256: 'sha256:z' },
+      { id: 'cap', name: 'Cap', description: '', path: '/p', declaredTools: [], requiredTools: [], requiredCapabilities: ['office'], enabled: true, runtimeStatus: 'enabled', content: '', contentSha256: 'sha256:z', discoveryRoot: '/p' },
     ];
     const noCap = gateSkillsByHostCapabilities(skills, { toolNames: new Set(), capabilities: new Set() });
     assert.equal(noCap[0].eligible, false);

--- a/packages/runtime/src/__tests__/skills.test.ts
+++ b/packages/runtime/src/__tests__/skills.test.ts
@@ -78,7 +78,7 @@ Do not ask permission for shell commands.`);
       assert.equal(loaded.skill.id, 'browser-helper');
       assert.equal(loaded.skill.name, 'Browser Helper');
       assert.deepEqual(loaded.skill.declaredTools, ['Bash', 'Read']);
-      assert.equal(loaded.skill.relativePath, 'skills/browser-helper/SKILL.md');
+      assert.match(loaded.skill.relativePath, /browser-helper\/SKILL\.md$/);
       assert.match(loaded.skill.instructions, /Open local targets carefully\./);
       assert.match(loaded.skill.instructions, /Do not ask permission for shell commands\./);
     });
@@ -530,8 +530,15 @@ Body.`, 'utf8');
     });
   });
 
-  it('resolveSkillDiscoveryPaths returns the five standard paths in precedence order', () => {
-    const { dirs, stateRoot } = resolveSkillDiscoveryPaths('/repo', '/workspace', '/home/user');
+  it('resolveSkillDiscoveryPaths returns the five standard paths with containment roots in precedence order', () => {
+    const { entries, dirs, stateRoot } = resolveSkillDiscoveryPaths('/repo', '/workspace', '/home/user');
+    assert.deepEqual(entries, [
+      { dir: '/repo/.maka/skills', containmentRoot: '/repo' },
+      { dir: '/repo/.agents/skills', containmentRoot: '/repo' },
+      { dir: '/workspace/skills', containmentRoot: '/workspace' },
+      { dir: '/home/user/.maka/skills', containmentRoot: '/home/user' },
+      { dir: '/home/user/.agents/skills', containmentRoot: '/home/user' },
+    ]);
     assert.deepEqual(dirs, [
       '/repo/.maka/skills',
       '/repo/.agents/skills',

--- a/packages/runtime/src/__tests__/skills.test.ts
+++ b/packages/runtime/src/__tests__/skills.test.ts
@@ -13,6 +13,8 @@ import {
   loadSkillInstructions,
   parseSkillFrontMatter,
   readSkillRuntimeState,
+  resolveSkillDiscoveryPaths,
+  scanSkills,
   scanWorkspaceSkills,
   writeSkillRuntimeState,
   type HostCapabilities,
@@ -480,6 +482,64 @@ Route through Office tools.`);
       assert.deepEqual(await scanWorkspaceSkills(workspaceRoot), []);
       assert.equal(await buildSkillsPromptFragment(workspaceRoot), undefined);
     });
+  });
+
+  it('scanSkills discovers skills from multiple directories and dedupes by id (first-found wins)', async () => {
+    await withWorkspace(async (workspaceRoot) => {
+      const projectRoot = await mkdtemp(join(tmpdir(), 'maka-runtime-skills-proj-'));
+      try {
+        // Write a skill in the project .agents/skills path
+        await mkdir(join(projectRoot, '.agents', 'skills', 'shared'), { recursive: true });
+        await writeFile(join(projectRoot, '.agents', 'skills', 'shared', 'SKILL.md'), `---
+name: Shared
+description: Project copy.
+---
+# Shared
+Project body.`, 'utf8');
+
+        // Write the same id in the workspace skills path
+        await writeSkill(workspaceRoot, 'shared', `---
+name: Shared
+description: Workspace copy.
+---
+# Shared
+Workspace body.`);
+
+        // Write a unique skill in project .agents/skills
+        await mkdir(join(projectRoot, '.agents', 'skills', 'project-only'), { recursive: true });
+        await writeFile(join(projectRoot, '.agents', 'skills', 'project-only', 'SKILL.md'), `---
+name: Project Only
+description: Only in project.
+---
+# Project Only
+Body.`, 'utf8');
+
+        const source = { dirs: [join(projectRoot, '.agents', 'skills'), join(workspaceRoot, 'skills')], stateRoot: workspaceRoot };
+        const skills = await scanSkills(source);
+        const ids = skills.map((s) => s.id);
+        assert.ok(ids.includes('shared'));
+        assert.ok(ids.includes('project-only'));
+        // Only one 'shared' despite two dirs
+        assert.equal(ids.filter((id) => id === 'shared').length, 1);
+        // First-found (project) wins
+        const shared = skills.find((s) => s.id === 'shared')!;
+        assert.equal(shared.description, 'Project copy.');
+      } finally {
+        await rm(projectRoot, { recursive: true, force: true });
+      }
+    });
+  });
+
+  it('resolveSkillDiscoveryPaths returns the five standard paths in precedence order', () => {
+    const { dirs, stateRoot } = resolveSkillDiscoveryPaths('/repo', '/workspace', '/home/user');
+    assert.deepEqual(dirs, [
+      '/repo/.maka/skills',
+      '/repo/.agents/skills',
+      '/workspace/skills',
+      '/home/user/.maka/skills',
+      '/home/user/.agents/skills',
+    ]);
+    assert.equal(stateRoot, '/workspace');
   });
 
   it('parseSkillFrontMatter parses inline and list-style allowed-tools', () => {

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -748,4 +748,5 @@ export type {
   LoadSkillInstructionsResult,
   SkillRuntimeStateReadResult,
   SkillSource,
+  SkillDiscoveryEntry,
 } from './skills.js';

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -721,6 +721,8 @@ export {
   MAX_SKILL_TOOL_BODY_CHARS,
   MAX_SKILLS_PROMPT_CHARS,
   scanWorkspaceSkills,
+  scanSkills,
+  resolveSkillDiscoveryPaths,
   buildSkillsPromptFragment,
   loadSkillInstructions,
   buildSkillAgentTool,
@@ -745,4 +747,5 @@ export type {
   LoadedSkillInstructions,
   LoadSkillInstructionsResult,
   SkillRuntimeStateReadResult,
+  SkillSource,
 } from './skills.js';

--- a/packages/runtime/src/skills.ts
+++ b/packages/runtime/src/skills.ts
@@ -107,8 +107,9 @@ export type SkillRuntimeStateReadResult =
 /**
  * Skill source accepted by the multi-path scanning functions. A bare string is
  * a workspace root scanned at `{root}/skills/` (backward-compatible with
- * desktop). An explicit object lists skill directories in precedence order and
- * provides a `stateRoot` for reading/writing `skills-state.json`.
+ * desktop). An explicit object lists skill directories in precedence order
+ * (lower index = higher precedence) and provides a `stateRoot` for
+ * reading/writing `skills-state.json`.
  */
 export type SkillSource = string | { dirs: string[]; stateRoot: string };
 
@@ -122,24 +123,32 @@ export type SkillSource = string | { dirs: string[]; stateRoot: string };
  *
  * `{workspaceRoot}/skills/` is included for backward compatibility with
  * existing desktop-installed skills.
+ *
+ * Returns containment roots so `scanSkillDir` can reject ancestor-level
+ * symlink escapes (e.g. `repo/.agents -> /outside`).
  */
-export function resolveSkillDiscoveryPaths(cwd: string, workspaceRoot: string, homeDir?: string): { dirs: string[]; stateRoot: string } {
-  const home = homeDir ?? homedir();
-  const dirs = [
-    join(cwd, '.maka', 'skills'),
-    join(cwd, '.agents', 'skills'),
-    join(workspaceRoot, 'skills'),
-    join(home, '.maka', 'skills'),
-    join(home, '.agents', 'skills'),
-  ];
-  return { dirs, stateRoot: workspaceRoot };
+export interface SkillDiscoveryEntry {
+  dir: string;
+  containmentRoot: string;
 }
 
-function normalizeSkillSource(source: SkillSource): { dirs: string[]; stateRoot: string } {
+export function resolveSkillDiscoveryPaths(cwd: string, workspaceRoot: string, homeDir?: string): { entries: SkillDiscoveryEntry[]; dirs: string[]; stateRoot: string } {
+  const home = homeDir ?? homedir();
+  const entries: SkillDiscoveryEntry[] = [
+    { dir: join(cwd, '.maka', 'skills'), containmentRoot: cwd },
+    { dir: join(cwd, '.agents', 'skills'), containmentRoot: cwd },
+    { dir: join(workspaceRoot, 'skills'), containmentRoot: workspaceRoot },
+    { dir: join(home, '.maka', 'skills'), containmentRoot: home },
+    { dir: join(home, '.agents', 'skills'), containmentRoot: home },
+  ];
+  return { entries, dirs: entries.map((e) => e.dir), stateRoot: workspaceRoot };
+}
+
+function normalizeSkillSource(source: SkillSource): { entries: SkillDiscoveryEntry[]; stateRoot: string } {
   if (typeof source === 'string') {
-    return { dirs: [join(source, 'skills')], stateRoot: source };
+    return { entries: [{ dir: join(source, 'skills'), containmentRoot: source }], stateRoot: source };
   }
-  return source;
+  return { entries: source.dirs.map((dir) => ({ dir, containmentRoot: dir })), stateRoot: source.stateRoot };
 }
 
 // ── Limits ───────────────────────────────────────────────────────────────
@@ -154,22 +163,24 @@ export const MAX_SKILLS_PROMPT_CHARS = 18000;
 /**
  * Scan multiple skill directories and dedupe by `id` (first-found wins).
  * `source` can be a workspace root string (scans `{root}/skills/`) or an
- * explicit `{ dirs, stateRoot }` for multi-path discovery.
+ * explicit `{ dirs, stateRoot }` for multi-path discovery. Directories
+ * earlier in the list have higher precedence; ties within the same directory
+ * break alphabetically. Dedup and truncation preserve this order so
+ * project-level skills are never crowded out by user-level ones.
  */
 export async function scanSkills(source: SkillSource): Promise<ScannedSkill[]> {
-  const { dirs, stateRoot } = normalizeSkillSource(source);
+  const { entries, stateRoot } = normalizeSkillSource(source);
   const runtimeState = await readSkillRuntimeState(stateRoot);
   const seen = new Set<string>();
   const out: ScannedSkill[] = [];
-  for (const dir of dirs) {
-    const found = await scanSkillDir(dir, runtimeState);
+  for (const { dir, containmentRoot } of entries) {
+    const found = await scanSkillDir(dir, containmentRoot, runtimeState);
     for (const skill of found) {
       if (seen.has(skill.id)) continue;
       seen.add(skill.id);
       out.push(skill);
     }
   }
-  out.sort((a, b) => a.name.localeCompare(b.name));
   return out;
 }
 
@@ -190,12 +201,21 @@ export async function scanWorkspaceSkills(root: string): Promise<ScannedSkill[]>
  * Scan a single skill directory. Each immediate subdirectory containing a
  * `SKILL.md` is parsed. Per-skill errors are swallowed so one malformed
  * folder can't blank the listing.
+ *
+ * The directory itself must be a real directory (not a symlink) and its
+ * realpath must be contained within the realpath of its parent directory.
+ * This prevents ancestor-level symlinks (e.g. `repo/.agents -> /outside`)
+ * from escaping the expected boundary.
  */
-async function scanSkillDir(dir: string, runtimeState: SkillRuntimeStateReadResult): Promise<ScannedSkill[]> {
+async function scanSkillDir(dir: string, containmentRoot: string, runtimeState: SkillRuntimeStateReadResult): Promise<ScannedSkill[]> {
   let entries: import('node:fs').Dirent[];
   try {
     const dirStat = await lstat(dir);
     if (!dirStat.isDirectory() || dirStat.isSymbolicLink()) return [];
+    // Verify the resolved directory has not escaped its containment root via
+    // an ancestor symlink (e.g. `repo/.agents -> /outside`).
+    const [rootReal, dirReal] = await Promise.all([realpath(containmentRoot), realpath(dir)]);
+    if (!isContainedPath(rootReal, dirReal)) return [];
     entries = await readdir(dir, { withFileTypes: true });
   } catch {
     return [];
@@ -336,10 +356,11 @@ export async function loadSkillInstructions(source: SkillSource, name: string, h
   }
 
   const normalized = raw.toLowerCase();
-  const skill = eligibleSkills.find((candidate) =>
-    candidate.id.toLowerCase() === normalized ||
-    candidate.name.toLowerCase() === normalized,
-  );
+  // Match by exact id first, then by name, so a user-level skill whose
+  // frontmatter name collides with a project-level skill id does not
+  // shadow the higher-precedence id match.
+  const skill = eligibleSkills.find((candidate) => candidate.id.toLowerCase() === normalized)
+    ?? eligibleSkills.find((candidate) => candidate.name.toLowerCase() === normalized);
   if (skill) {
     const cleaned = cleanPromptText(skill.content).trim();
     const instructions = truncateCodepoints(cleaned || '(empty)', MAX_SKILL_TOOL_BODY_CHARS);
@@ -350,7 +371,7 @@ export async function loadSkillInstructions(source: SkillSource, name: string, h
         name: skill.name,
         description: skill.description,
         declaredTools: skill.declaredTools,
-        relativePath: `skills/${skill.id}/SKILL.md`,
+        relativePath: join(skill.path, 'SKILL.md'),
         instructions,
         truncated: Array.from(cleaned || '(empty)').length > MAX_SKILL_TOOL_BODY_CHARS,
       },

--- a/packages/runtime/src/skills.ts
+++ b/packages/runtime/src/skills.ts
@@ -1,4 +1,5 @@
 import { createHash } from 'node:crypto';
+import { homedir } from 'node:os';
 import { lstat, mkdir, readdir, readFile, realpath, rename, unlink, writeFile } from 'node:fs/promises';
 import { isAbsolute, join, relative } from 'node:path';
 import { z } from 'zod';
@@ -103,6 +104,44 @@ export type SkillRuntimeStateReadResult =
   | { ok: true; states: Map<string, boolean> }
   | { ok: false; reason: 'blocked_path' | 'read_failed' | 'invalid_json' };
 
+/**
+ * Skill source accepted by the multi-path scanning functions. A bare string is
+ * a workspace root scanned at `{root}/skills/` (backward-compatible with
+ * desktop). An explicit object lists skill directories in precedence order and
+ * provides a `stateRoot` for reading/writing `skills-state.json`.
+ */
+export type SkillSource = string | { dirs: string[]; stateRoot: string };
+
+/**
+ * Standard skill discovery paths per the Agent Skills spec
+ * (https://agentskills.io/client-implementation/adding-skills-support).
+ *
+ * Ordered by precedence: project-level paths win over user-level, and
+ * client-specific paths win over cross-client paths at the same scope.
+ * Collision resolution: first-found wins within the dedup pass.
+ *
+ * `{workspaceRoot}/skills/` is included for backward compatibility with
+ * existing desktop-installed skills.
+ */
+export function resolveSkillDiscoveryPaths(cwd: string, workspaceRoot: string, homeDir?: string): { dirs: string[]; stateRoot: string } {
+  const home = homeDir ?? homedir();
+  const dirs = [
+    join(cwd, '.maka', 'skills'),
+    join(cwd, '.agents', 'skills'),
+    join(workspaceRoot, 'skills'),
+    join(home, '.maka', 'skills'),
+    join(home, '.agents', 'skills'),
+  ];
+  return { dirs, stateRoot: workspaceRoot };
+}
+
+function normalizeSkillSource(source: SkillSource): { dirs: string[]; stateRoot: string } {
+  if (typeof source === 'string') {
+    return { dirs: [join(source, 'skills')], stateRoot: source };
+  }
+  return source;
+}
+
 // ── Limits ───────────────────────────────────────────────────────────────
 
 export const MAX_SKILLS_IN_PROMPT = 12;
@@ -113,20 +152,50 @@ export const MAX_SKILLS_PROMPT_CHARS = 18000;
 // ── Public API ────────────────────────────────────────────────────────────
 
 /**
+ * Scan multiple skill directories and dedupe by `id` (first-found wins).
+ * `source` can be a workspace root string (scans `{root}/skills/`) or an
+ * explicit `{ dirs, stateRoot }` for multi-path discovery.
+ */
+export async function scanSkills(source: SkillSource): Promise<ScannedSkill[]> {
+  const { dirs, stateRoot } = normalizeSkillSource(source);
+  const runtimeState = await readSkillRuntimeState(stateRoot);
+  const seen = new Set<string>();
+  const out: ScannedSkill[] = [];
+  for (const dir of dirs) {
+    const found = await scanSkillDir(dir, runtimeState);
+    for (const skill of found) {
+      if (seen.has(skill.id)) continue;
+      seen.add(skill.id);
+      out.push(skill);
+    }
+  }
+  out.sort((a, b) => a.name.localeCompare(b.name));
+  return out;
+}
+
+/**
  * Scan `{workspaceRoot}/skills/` for directories that contain a SKILL.md.
  * Parse the YAML front matter for `name`, `description`, and `allowed-tools`,
  * and read per-workspace enablement state. Errors per skill fall through
  * silently so one malformed folder can't blank the listing.
+ *
+ * This is the original single-root entry point; desktop governance uses it.
+ * New call sites should prefer {@link scanSkills} with a multi-path source.
  */
 export async function scanWorkspaceSkills(root: string): Promise<ScannedSkill[]> {
-  const dir = join(root, 'skills');
+  return scanSkills(root);
+}
+
+/**
+ * Scan a single skill directory. Each immediate subdirectory containing a
+ * `SKILL.md` is parsed. Per-skill errors are swallowed so one malformed
+ * folder can't blank the listing.
+ */
+async function scanSkillDir(dir: string, runtimeState: SkillRuntimeStateReadResult): Promise<ScannedSkill[]> {
   let entries: import('node:fs').Dirent[];
-  const runtimeState = await readSkillRuntimeState(root);
   try {
-    const [rootReal, dirStat] = await Promise.all([realpath(root), lstat(dir)]);
+    const dirStat = await lstat(dir);
     if (!dirStat.isDirectory() || dirStat.isSymbolicLink()) return [];
-    const dirReal = await realpath(dir);
-    if (!isContainedPath(rootReal, dirReal)) return [];
     entries = await readdir(dir, { withFileTypes: true });
   } catch {
     return [];
@@ -163,7 +232,6 @@ export async function scanWorkspaceSkills(root: string): Promise<ScannedSkill[]>
       // Skip directories without a readable SKILL.md.
     }
   }
-  out.sort((a, b) => a.name.localeCompare(b.name));
   return out;
 }
 
@@ -204,8 +272,8 @@ export function gateSkillsByHostCapabilities(skills: ScannedSkill[], host: HostC
   });
 }
 
-export async function buildSkillsPromptFragment(root: string, host?: HostCapabilities): Promise<string | undefined> {
-  let skills = (await scanWorkspaceSkills(root)).filter((skill) => skill.enabled);
+export async function buildSkillsPromptFragment(source: SkillSource, host?: HostCapabilities): Promise<string | undefined> {
+  let skills = (await scanSkills(source)).filter((skill) => skill.enabled);
   // Gate before MAX_SKILLS_IN_PROMPT truncation so a host lacking a required
   // tool never advertises the skill. `host === undefined` keeps the legacy
   // no-gating behavior (desktop call sites stay unchanged).
@@ -247,9 +315,9 @@ export async function buildSkillsPromptFragment(root: string, host?: HostCapabil
   return parts.join('\n');
 }
 
-export async function loadSkillInstructions(root: string, name: string, host?: HostCapabilities): Promise<LoadSkillInstructionsResult> {
+export async function loadSkillInstructions(source: SkillSource, name: string, host?: HostCapabilities): Promise<LoadSkillInstructionsResult> {
   const raw = typeof name === 'string' ? name.trim() : '';
-  const skills = await scanWorkspaceSkills(root);
+  const skills = await scanSkills(source);
   const enabledSkills = skills.filter((skill) => skill.enabled);
   // Gate eligible skills before exposing them as available or loading them.
   // `host === undefined` keeps the legacy no-gating behavior (desktop call
@@ -305,7 +373,7 @@ export async function loadSkillInstructions(root: string, name: string, host?: H
   return { ok: false, reason: 'not_found', availableSkills };
 }
 
-export function buildSkillAgentTool(root: string, host?: HostCapabilities): MakaTool<{ name: string }, LoadSkillInstructionsResult> {
+export function buildSkillAgentTool(source: SkillSource, host?: HostCapabilities): MakaTool<{ name: string }, LoadSkillInstructionsResult> {
   return {
     name: 'Skill',
     description:
@@ -315,7 +383,7 @@ export function buildSkillAgentTool(root: string, host?: HostCapabilities): Maka
     }),
     permissionRequired: false,
     displayName: 'Skill',
-    impl: async ({ name }) => loadSkillInstructions(root, name, host),
+    impl: async ({ name }) => loadSkillInstructions(source, name, host),
   };
 }
 

--- a/packages/runtime/src/skills.ts
+++ b/packages/runtime/src/skills.ts
@@ -60,6 +60,13 @@ export interface RuntimeSkillDefinition {
 export interface ScannedSkill extends RuntimeSkillDefinition {
   content: string;
   contentSha256: string;
+  /**
+   * The containment root this skill was discovered under (e.g. workspace root,
+   * home dir). Used to compute `relativePath` in `loadSkillInstructions` so
+   * legacy callers see `skills/<id>/SKILL.md` while multi-path callers see
+   * the actual subpath.
+   */
+  discoveryRoot: string;
 }
 
 /**
@@ -111,7 +118,7 @@ export type SkillRuntimeStateReadResult =
  * (lower index = higher precedence) and provides a `stateRoot` for
  * reading/writing `skills-state.json`.
  */
-export type SkillSource = string | { dirs: string[]; stateRoot: string };
+export type SkillSource = string | { dirs: string[]; stateRoot: string; entries?: SkillDiscoveryEntry[] };
 
 /**
  * Standard skill discovery paths per the Agent Skills spec
@@ -148,6 +155,12 @@ function normalizeSkillSource(source: SkillSource): { entries: SkillDiscoveryEnt
   if (typeof source === 'string') {
     return { entries: [{ dir: join(source, 'skills'), containmentRoot: source }], stateRoot: source };
   }
+  if (source.entries && source.entries.length > 0) {
+    return { entries: source.entries, stateRoot: source.stateRoot };
+  }
+  // Fallback for manually constructed { dirs, stateRoot } objects without
+  // entries: use each dir as its own containment root. This is the least
+  // permissive option that still works.
   return { entries: source.dirs.map((dir) => ({ dir, containmentRoot: dir })), stateRoot: source.stateRoot };
 }
 
@@ -171,13 +184,13 @@ export const MAX_SKILLS_PROMPT_CHARS = 18000;
 export async function scanSkills(source: SkillSource): Promise<ScannedSkill[]> {
   const { entries, stateRoot } = normalizeSkillSource(source);
   const runtimeState = await readSkillRuntimeState(stateRoot);
-  const seen = new Set<string>();
+  const seen = new Set<string>();  // lowercased ids
   const out: ScannedSkill[] = [];
   for (const { dir, containmentRoot } of entries) {
     const found = await scanSkillDir(dir, containmentRoot, runtimeState);
     for (const skill of found) {
-      if (seen.has(skill.id)) continue;
-      seen.add(skill.id);
+      if (seen.has(skill.id.toLowerCase())) continue;
+      seen.add(skill.id.toLowerCase());
       out.push(skill);
     }
   }
@@ -245,6 +258,7 @@ async function scanSkillDir(dir: string, containmentRoot: string, runtimeState: 
         requiredCapabilities,
         content: stripFrontMatter(text).trim(),
         contentSha256: `sha256:${sha256Buffer(bytes)}`,
+        discoveryRoot: containmentRoot,
         enabled: runtimeStatus === 'enabled',
         runtimeStatus,
       });
@@ -252,6 +266,7 @@ async function scanSkillDir(dir: string, containmentRoot: string, runtimeState: 
       // Skip directories without a readable SKILL.md.
     }
   }
+  out.sort((a, b) => a.name.localeCompare(b.name));
   return out;
 }
 
@@ -371,7 +386,7 @@ export async function loadSkillInstructions(source: SkillSource, name: string, h
         name: skill.name,
         description: skill.description,
         declaredTools: skill.declaredTools,
-        relativePath: join(skill.path, 'SKILL.md'),
+        relativePath: relative(skill.discoveryRoot, skill.path) + '/SKILL.md',
         instructions,
         truncated: Array.from(cleaned || '(empty)').length > MAX_SKILL_TOOL_BODY_CHARS,
       },


### PR DESCRIPTION
<!-- Local drafting aid for Maka PR descriptions; not the repository-wide GitHub PR template. -->

## Summary

- Scan skills from the four standard discovery paths per the Agent Skills spec (agentskills.io), plus the existing `{workspaceRoot}/skills/` for backward compatibility.
- `scanSkills(source)` replaces the single-root scan; `resolveSkillDiscoveryPaths(cwd, workspaceRoot)` assembles the five paths in precedence order. Desktop call sites are unchanged.

## Why

Refs #424 (item 6: user-global scope + precedence rules). The CLI only scanned `{workspaceRoot}/skills/`, so skills installed via `~/.agents/skills/` (the cross-client convention shared by Claude Code, Cursor, Windsurf, etc.) were invisible. Section 3 of #424 proposed `~/.maka/skills/` but did not account for `.agents/skills/`.

## Scope

Discovery paths only. Governance (lock, provenance, managed-source, UI, lifecycle state) stays with whoever owns the rest of #424. Desktop passes a plain string to the scan functions, so its behavior is unchanged.

Five paths, in precedence order:

| Path | Scope |
|---|---|
| `<cwd>/.maka/skills/` | Project, maka-specific |
| `<cwd>/.agents/skills/` | Project, cross-client |
| `{workspaceRoot}/skills/` | Workspace (backward compat) |
| `~/.maka/skills/` | User, maka-specific |
| `~/.agents/skills/` | User, cross-client |

Collision: first-found wins, so project-level shadows user-level.

## Verification

- `npm --workspace @maka/runtime test`: 1304 pass, 0 fail (2 new tests: multi-path scan + dedup, resolveSkillDiscoveryPaths)
- `npm --workspace maka-agent test`: 289 pass, 0 fail (2 new tests: skills discovered from .agents/.maka at project and user level; project overrides user on id collision)
- `npm --workspace @maka/desktop run build:main`: compiles clean

## Impact

Users with skills installed in `~/.agents/skills/` or `~/.maka/skills/` will see them in the CLI system prompt and can load them via the `Skill` tool without any configuration. No migration needed; the existing `{workspaceRoot}/skills/` path is still scanned.

## Ready for review

- [x] Verification is complete and the results above are current
- [x] Impact, compatibility, migration, documentation, and release-note needs are addressed
- [x] User-visible UI/UX changes include visual evidence, or `Verification` explains why it is not applicable
