### PR TITLE
fix(runtime): remove the default step limit

### DIFF
--- a/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
+++ b/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
@@ -3502,6 +3502,53 @@ describe('AiSdkBackend usage telemetry', () => {
     });
   });
 
+  test('lets an unconfigured turn continue past the former 50-step default', async () => {
+    const loop = countingToolLoopModel(51);
+    const backend = new AiSdkBackend({
+      sessionId: 'session-1',
+      header: header(),
+      appendMessage: async () => {},
+      connection: connection(),
+      apiKey: 'sk-test',
+      modelId: 'mock-model-id',
+      permissionEngine: new PermissionEngine({ newId: () => 'permission-id', now: () => 1 }),
+      modelFactory: () => loop.model,
+      tools: [testTool('Read', z.object({ path: z.string() }))],
+      newId: idGenerator(),
+      now: monotonicClock(),
+    });
+
+    const events: SessionEvent[] = [];
+    for await (const event of backend.send({ turnId: 'turn-1', text: 'hi', context: [] })) {
+      events.push(event);
+    }
+
+    assert.equal(loop.callCount(), 52);
+    assert.equal(events.at(-1)?.type, 'complete');
+  });
+
+  test('keeps an explicitly configured step limit', async () => {
+    const loop = countingToolLoopModel();
+    const backend = new AiSdkBackend({
+      sessionId: 'session-1',
+      header: header(),
+      appendMessage: async () => {},
+      connection: connection(),
+      apiKey: 'sk-test',
+      modelId: 'mock-model-id',
+      permissionEngine: new PermissionEngine({ newId: () => 'permission-id', now: () => 1 }),
+      modelFactory: () => loop.model,
+      tools: [testTool('Read', z.object({ path: z.string() }))],
+      maxSteps: 3,
+      newId: idGenerator(),
+      now: monotonicClock(),
+    });
+
+    await drain(backend.send({ turnId: 'turn-1', text: 'hi', context: [] }));
+
+    assert.equal(loop.callCount(), 3);
+  });
+
   test('records aggregate totalUsage across AI SDK tool-loop steps', async () => {
     const messages: unknown[] = [];
     const events: SessionEvent[] = [];
@@ -6744,6 +6791,7 @@ describe('AiSdkBackend thinking persistence', () => {
       permissionEngine: new PermissionEngine({ newId: () => 'permission-id', now: () => 1 }),
       modelFactory: () => completionModel(),
       tools: [testTool('Read', z.object({ path: z.string() }))],
+      maxSteps: 2,
       newId: idGenerator(),
       now: monotonicClock(),
     });
@@ -7062,6 +7110,47 @@ function completionModel(): MockLanguageModelV3 {
       }),
     },
   });
+}
+
+function countingToolLoopModel(toolCallsBeforeStop?: number): {
+  model: MockLanguageModelV3;
+  callCount: () => number;
+} {
+  let calls = 0;
+  const model = new MockLanguageModelV3({
+    doStream: async () => {
+      calls += 1;
+      const shouldStop = toolCallsBeforeStop !== undefined && calls > toolCallsBeforeStop;
+      const chunks: LanguageModelV3StreamPart[] = shouldStop
+        ? [
+            { type: 'stream-start', warnings: [] },
+            { type: 'text-start', id: 'text-final' },
+            { type: 'text-delta', id: 'text-final', delta: 'done' },
+            { type: 'text-end', id: 'text-final' },
+            {
+              type: 'finish',
+              finishReason: { unified: 'stop', raw: 'stop' },
+              usage: { inputTokens: { total: 1, noCache: 1, cacheRead: 0, cacheWrite: 0 }, outputTokens: { total: 1, text: 1, reasoning: 0 } },
+            },
+          ]
+        : [
+            { type: 'stream-start', warnings: [] },
+            {
+              type: 'tool-call',
+              toolCallId: `tool-${calls}`,
+              toolName: 'Read',
+              input: JSON.stringify({ path: `notes-${calls}.md` }),
+            },
+            {
+              type: 'finish',
+              finishReason: { unified: 'tool-calls', raw: 'tool_calls' },
+              usage: { inputTokens: { total: 1, noCache: 1, cacheRead: 0, cacheWrite: 0 }, outputTokens: { total: 1, text: 1, reasoning: 0 } },
+            },
+          ];
+      return { stream: simulateReadableStream({ chunks, initialDelayInMs: null, chunkDelayInMs: null }) };
+    },
+  });
+  return { model, callCount: () => calls };
 }
 
 function runtimeTextEvent(input: {

--- a/packages/runtime/src/ai-sdk-backend.ts
+++ b/packages/runtime/src/ai-sdk-backend.ts
@@ -6,11 +6,11 @@
  * machinery: PermissionEngine (policy + park/resume), materializer,
  * AsyncEventQueue, SessionStore JSONL persistence.
  *
- * The agent loop (multi-step tool calling) is owned by ai-sdk's
- * `streamText` with `stopWhen: stepCountIs(N)`. Permission gating happens
- * inside each tool's `execute()` callback — that's the seam where we
- * consult PermissionEngine and either run, deny synthetically, or park
- * awaiting user.
+ * The agent loop (multi-step tool calling) is owned by ai-sdk's `streamText`.
+ * An explicit `maxSteps` uses `stopWhen: stepCountIs(N)`; otherwise the loop
+ * has no step cap. Permission gating happens inside each tool's `execute()`
+ * callback — that's the seam where we consult PermissionEngine and either run,
+ * deny synthetically, or park awaiting user.
  *
  * Design:
  *   send()
@@ -436,7 +436,7 @@ export interface AiSdkBackendInput {
   newId?: () => string;
   /** Clock; default `Date.now()`. */
   now?: () => number;
-  /** Cap on tool-call steps per turn; default 50. */
+  /** Optional cap on tool-call steps per turn; omitted means no step cap. */
   maxSteps?: number;
   /** Timeout before first SDK stream event; default 30s. */
   streamConnectTimeoutMs?: number;
@@ -1122,10 +1122,10 @@ export class AiSdkBackend implements AgentBackend {
           publishTurnDiagnostics(computeTurnDiagnostics(finalActiveTools));
         }
 
-        // PR-AGENT-ITERATION-GRACE-0 (external bot research #A1): when the
-        // ai-sdk loop exits with `finishReason === 'tool-calls'` it
-        // means we tripped `stopWhen: stepCountIs(maxSteps)` mid-loop
-        // — the model wanted to keep calling tools but we capped it.
+        // PR-AGENT-ITERATION-GRACE-0 (external bot research #A1): with an
+        // explicit maxSteps, `finishReason === 'tool-calls'` means we tripped
+        // `stopWhen: stepCountIs(maxSteps)` mid-loop — the model wanted to keep
+        // calling tools but we capped it.
         // The user previously saw no closing assistant text in that
         // path; just the last tool result. Inject a deterministic
         // "step cap reached" notice so the UI has SOMETHING and the

--- a/packages/runtime/src/ai-sdk-backend.ts
+++ b/packages/runtime/src/ai-sdk-backend.ts
@@ -542,7 +542,7 @@ export class AiSdkBackend implements AgentBackend {
   private readonly input: AiSdkBackendInput;
   private readonly newId: () => string;
   private readonly now: () => number;
-  private readonly maxSteps: number;
+  private readonly maxSteps: number | undefined;
   private readonly toolRuntime: ToolRuntime;
   private readonly modelAdapter: ModelAdapter;
   private readonly toolAvailabilityRuntime: ToolAvailabilityRuntime;
@@ -570,7 +570,7 @@ export class AiSdkBackend implements AgentBackend {
     this.sessionId = input.sessionId;
     this.newId = input.newId ?? (() => crypto.randomUUID());
     this.now = input.now ?? (() => Date.now());
-    this.maxSteps = input.maxSteps ?? 50;
+    this.maxSteps = input.maxSteps;
     this.toolAvailabilityRuntime = new ToolAvailabilityRuntime(
       input.tools,
       input.toolAvailability,
@@ -1132,7 +1132,11 @@ export class AiSdkBackend implements AgentBackend {
         // user can choose to send "继续" for a fresh turn.
         const finishReasonForGrace = await result.finishReason.catch(() => 'stop');
         rawFinishReason = rawFinishReason ?? rawFinishReasonString(finishReasonForGrace);
-        if (finishReasonForGrace === 'tool-calls' && runtimeSteps < this.maxSteps) {
+        if (
+          this.maxSteps !== undefined
+          && finishReasonForGrace === 'tool-calls'
+          && runtimeSteps < this.maxSteps
+        ) {
           runtimeSteps = this.maxSteps;
         }
         // Step-cap grace notice: when the loop tripped `stepCountIs(maxSteps)`
@@ -1141,6 +1145,7 @@ export class AiSdkBackend implements AgentBackend {
         // the user can send "继续" for a fresh turn.
         if (
           !this.aborted
+          && this.maxSteps !== undefined
           && !turnHadAnyText
           && finishReasonForGrace === 'tool-calls'
         ) {

--- a/packages/runtime/src/model-adapter.ts
+++ b/packages/runtime/src/model-adapter.ts
@@ -42,7 +42,7 @@ export interface ModelAdapterInput {
   modelId: string;
   modelFactory: ModelFactory;
   providerOptions?: Record<string, unknown>;
-  maxSteps: number;
+  maxSteps?: number;
   newId: () => string;
   now: () => number;
 }
@@ -147,9 +147,10 @@ export class ModelAdapter {
     const ai = await import('ai').catch((err) => {
       throw new Error(`Failed to load 'ai' package. Run \`npm install ai\`. Inner: ${(err as Error).message}`);
     });
-    const { streamText, stepCountIs } = ai as unknown as {
+    const { streamText, stepCountIs, isLoopFinished } = ai as unknown as {
       streamText: (opts: Record<string, unknown>) => StreamTextResult;
       stepCountIs: (n: number) => unknown;
+      isLoopFinished: () => unknown;
     };
 
     return streamText({
@@ -161,7 +162,11 @@ export class ModelAdapter {
       experimental_repairToolCall: input.repairToolCall,
       system: input.system,
       providerOptions: this.input.providerOptions,
-      stopWhen: stepCountIs(this.input.maxSteps),
+      // streamText defaults to one step when stopWhen is omitted. Its exported
+      // non-stopping condition is required for an unbounded tool loop.
+      stopWhen: this.input.maxSteps === undefined
+        ? isLoopFinished()
+        : stepCountIs(this.input.maxSteps),
       abortSignal: input.abortSignal,
     });
   }


### PR DESCRIPTION
## Summary

- Remove the implicit 50-step limit from normal product turns.
- Keep explicit `maxSteps` limits for CLI, programmatic, Harbor, and benchmark callers.
- Keep step-cap grace behavior scoped to explicitly limited turns.

## Why

A live CLI turn stopped after exactly 50 tool calls while the model was still working. The runtime treated the hidden default as a normal end of turn, leaving the task incomplete.

Normal turns should continue until the model stops or the user interrupts them. Callers that need a fixed budget can still configure one.

Closes #760. Refs #759.

## Scope

This PR does not add the `step_limit` terminal reason or change TUI/Desktop rendering. That work remains in #761.

## Verification

- `npm test -w @maka/runtime`  
  1304 passed, 2 skipped.
- `npm run typecheck`  
  Passed across all workspaces.
- Regression test drives 51 tool calls without an explicit limit, then verifies the model reaches its natural stop on call 52.
- Explicit `maxSteps: 3` still stops after three model steps.
- No visual evidence is applicable because this changes runtime continuation behavior without changing rendered UI.

## Impact

Interactive and other unconfigured product turns no longer stop after 50 steps. Existing explicit limits remain compatible.

## Reviewer notes

Vercel AI SDK defaults `streamText` to one step when `stopWhen` is omitted. The unlimited path therefore uses its exported `isLoopFinished()` non-stopping condition. Explicit limits continue to use `stepCountIs(maxSteps)`.

Codex max-effort review passed with no P0/P1/P2 findings. Its only P3, stale default-50 contract comments, was fixed in `f7334b2d`.

## Ready for review

- [x] Verification is complete and the results above are current
- [x] Impact, compatibility, migration, documentation, and release-note needs are addressed
- [x] User-visible UI/UX changes include visual evidence, or `Verification` explains why it is not applicable
