### PR TITLE
fix(runtime): require explicit Bash background execution

### DIFF
--- a/packages/cli/src/__tests__/pi-transcript.test.ts
+++ b/packages/cli/src/__tests__/pi-transcript.test.ts
@@ -699,7 +699,7 @@ describe('Maka Pi TUI transcript', () => {
     assert.doesNotMatch(compact, /step one/);
   });
 
-  test('keeps a yielded background Bash card running until the process settles', () => {
+  test('keeps a background Bash card running until the process settles', () => {
     const state = createMakaPiTranscriptState();
     applyMakaSessionEventToTranscript(state, event({
       type: 'tool_start', toolUseId: 'bash-bg', toolName: 'Bash',
@@ -786,7 +786,7 @@ describe('Maka Pi TUI transcript', () => {
     assert.match(rendered, /still running/);
   });
 
-  test('shows polled background output instead of the stale pre-yield live delta', () => {
+  test('shows polled background output instead of a stale live delta', () => {
     const state = createMakaPiTranscriptState();
     const ref = 'maka://runtime/background-tasks/bg-1';
     applyMakaSessionEventToTranscript(state, event({
@@ -1109,7 +1109,7 @@ describe('Maka Pi TUI transcript', () => {
     assert.match(expanded, /boom-stderr/);
   });
 
-  test('does not repeat the command when a Bash yield already shows it', () => {
+  test('does not repeat the command when a background Bash result already shows it', () => {
     const state = createMakaPiTranscriptState();
     // A Bash background yield carries the command on both the input and the
     // shell_run result; the expanded card must print `$ cmd` once, not twice.
@@ -1132,7 +1132,7 @@ describe('Maka Pi TUI transcript', () => {
     assert.match(expanded, /cwd: \/repo/); // cwd is not in the input summary, so shown once here
   });
 
-  test('renders the full command for a multiline background Bash yield', () => {
+  test('renders the full command for a multiline background Bash result', () => {
     const state = createMakaPiTranscriptState();
     // The Bash input summary shows only the first line, so a multiline command
     // must be rendered in full by the result or the rest is lost.

--- a/packages/cli/src/__tests__/runtime-bootstrap.test.ts
+++ b/packages/cli/src/__tests__/runtime-bootstrap.test.ts
@@ -227,7 +227,7 @@ describe('Maka CLI runtime bootstrap', () => {
         assert.ok(read);
         const command = `${JSON.stringify(process.execPath)} -e "process.stdout.write('start'); setTimeout(() => {}, 5000)"`;
         const result = await bash.impl(
-          { command, yield_time_ms: 250 },
+          { command, run_in_background: true },
           {
             sessionId: 'session-1',
             runId: 'run-1',
@@ -244,6 +244,7 @@ describe('Maka CLI runtime bootstrap', () => {
         assert.equal(result.stdout, '');
         assert.ok(result.ref);
         if (!result.ref) throw new Error('expected background task resource ref');
+        await new Promise((resolve) => setTimeout(resolve, 50));
 
         const detail = await read.impl(
           { path: result.ref },
@@ -271,7 +272,7 @@ describe('Maka CLI runtime bootstrap', () => {
     });
   });
 
-  test('publishes yielded ShellRun completion without a model resource read', async () => {
+  test('publishes background ShellRun completion without a model resource read', async () => {
     await withWorkspace(async (workspaceRoot) => {
       const connectionStore = createConnectionStore(workspaceRoot);
       await connectionStore.create({
@@ -285,7 +286,7 @@ describe('Maka CLI runtime bootstrap', () => {
         assert.ok(bash);
         const command = `${JSON.stringify(process.execPath)} -e "process.stdout.write('start'); setTimeout(() => process.stdout.write('done'), 500)"`;
         const result = await bash.impl(
-          { command, yield_time_ms: 250 },
+          { command, run_in_background: true },
           {
             sessionId: 'session-1', runId: 'run-1', turnId: 'turn-1',
             cwd: workspaceRoot, toolCallId: 'tool-1',
@@ -328,7 +329,7 @@ describe('Maka CLI runtime bootstrap', () => {
         assert.ok(bash);
         const command = `${JSON.stringify(process.execPath)} -e "setTimeout(() => {}, 5000)"`;
         const started = await bash.impl(
-          { command, yield_time_ms: 250 },
+          { command, run_in_background: true },
           {
             sessionId: parent.id, runId: 'run-1', turnId: 'turn-1',
             cwd: workspaceRoot, toolCallId: 'tool-1',
@@ -359,7 +360,7 @@ describe('Maka CLI runtime bootstrap', () => {
         assert.ok(bash);
         const command = `${JSON.stringify(process.execPath)} -e "setTimeout(() => {}, 500)"`;
         const started = await bash.impl(
-          { command, yield_time_ms: 250 },
+          { command, run_in_background: true },
           {
             sessionId: 'session-1', runId: 'run-1', turnId: 'turn-1',
             cwd: workspaceRoot, toolCallId: 'tool-1',

--- a/packages/runtime/src/__tests__/builtin-tools.test.ts
+++ b/packages/runtime/src/__tests__/builtin-tools.test.ts
@@ -29,7 +29,8 @@ describe('builtin tool activity kinds', () => {
 
   test('categorizes background task controls as command activity', () => {
     const shellRuns = {
-      runBash: () => Promise.reject(new Error('not used')),
+      runForegroundBash: () => Promise.reject(new Error('not used')),
+      runBackgroundBash: () => Promise.reject(new Error('not used')),
       readResource: () => Promise.reject(new Error('not used')),
       stopResource: () => Promise.reject(new Error('not used')),
     } satisfies ShellRunToolController;
@@ -90,10 +91,65 @@ describe('builtin Bash description declares the executing shell', () => {
 });
 
 describe('builtin Bash streaming output', () => {
-  test('background-capable Bash returns runtime refs and forwards yield_time_ms', async () => {
+  test('Bash schema exposes only explicit background execution', () => {
+    const bash = buildBuiltinTools({ shellRuns: {
+      runForegroundBash: () => Promise.reject(new Error('not used')),
+      runBackgroundBash: () => Promise.reject(new Error('not used')),
+      readResource: () => Promise.reject(new Error('not used')),
+      stopResource: () => Promise.reject(new Error('not used')),
+    } }).find((tool) => tool.name === 'Bash');
+    if (!bash) throw new Error('Bash tool missing');
+    const parameters = bash.parameters as { safeParse(input: unknown): { success: boolean } };
+
+    expect(parameters.safeParse({ command: 'sleep 60', run_in_background: true }).success).toBe(true);
+    expect(parameters.safeParse({ command: 'sleep 60', yield_time_ms: 250 }).success).toBe(false);
+    expect(parameters.safeParse({ command: 'sleep 60', timeout_ms: 600_001 }).success).toBe(false);
+    expect(parameters.safeParse({ command: 'sleep 60', timeout_ms: 600_001, run_in_background: true }).success).toBe(true);
+  });
+
+  test('background-capable Bash stays foreground unless explicitly requested', async () => {
+    const calls: string[] = [];
+    const shellRuns = {
+      async runForegroundBash() {
+        calls.push('foreground');
+        return {
+          kind: 'terminal', cwd: '/workspace', cmd: 'sleep 60', status: 'completed', exitCode: 0,
+          stdout: '', stderr: '', stdoutTruncated: false, stderrTruncated: false,
+        } as const;
+      },
+      async runBackgroundBash() {
+        calls.push('background');
+        throw new Error('unexpected background execution');
+      },
+      async readResource() {
+        throw new Error('not used');
+      },
+      async stopResource() {
+        throw new Error('not used');
+      },
+    };
+    const bash = buildBuiltinTools({ shellRuns }).find((tool) => tool.name === 'Bash');
+    if (!bash) throw new Error('Bash tool missing');
+
+    const result = await bash.impl(
+      { command: 'sleep 60' },
+      {
+        sessionId: 'session-1', turnId: 'turn-1', toolCallId: 'tool-1', cwd: '/workspace',
+        abortSignal: new AbortController().signal, emitOutput: () => {},
+      },
+    );
+
+    expect((result as { kind: string }).kind).toBe('terminal');
+    expect(calls).toEqual(['foreground']);
+  });
+
+  test('explicit background Bash returns runtime refs and forwards its optional timeout', async () => {
     const calls: unknown[] = [];
     const shellRuns = {
-      async runBash(input: unknown) {
+      async runForegroundBash() {
+        throw new Error('not used');
+      },
+      async runBackgroundBash(input: unknown) {
         calls.push(input);
         return {
           kind: 'shell_run',
@@ -124,7 +180,7 @@ describe('builtin Bash streaming output', () => {
     const bash = tools.find((tool) => tool.name === 'Bash');
     if (!bash) throw new Error('Bash tool missing');
     const result = await bash.impl(
-      { command: 'sleep 60', timeout_ms: 2_000, yield_time_ms: 1_234 },
+      { command: 'sleep 60', timeout_ms: 2_000, run_in_background: true },
       {
         sessionId: 'session-1',
         runId: 'run-1',
@@ -138,7 +194,6 @@ describe('builtin Bash streaming output', () => {
 
     expect((result as { kind: string }).kind).toBe('shell_run');
     expect((result as { ref?: string }).ref).toBe('maka://runtime/background-tasks/shell-run-1');
-    expect((calls[0] as { yieldTimeMs?: number }).yieldTimeMs).toBe(1_234);
     expect((calls[0] as { timeoutMs?: number }).timeoutMs).toBe(2_000);
     expect((calls[0] as { sourceRunId?: string }).sourceRunId).toBe('run-1');
   });
@@ -146,7 +201,10 @@ describe('builtin Bash streaming output', () => {
   test('Read treats runtime background task refs as whole resources', async () => {
     const calls: unknown[] = [];
     const shellRuns = {
-      async runBash() {
+      async runForegroundBash() {
+        throw new Error('not used');
+      },
+      async runBackgroundBash() {
         throw new Error('not used');
       },
       async readResource(sessionId: string, ref: string) {
@@ -193,7 +251,10 @@ describe('builtin Bash streaming output', () => {
   test('StopBackgroundTask stops a runtime ref in the current session', async () => {
     const calls: unknown[] = [];
     const shellRuns = {
-      async runBash() {
+      async runForegroundBash() {
+        throw new Error('not used');
+      },
+      async runBackgroundBash() {
         throw new Error('not used');
       },
       async readResource() {

--- a/packages/runtime/src/__tests__/shell-run-manager.test.ts
+++ b/packages/runtime/src/__tests__/shell-run-manager.test.ts
@@ -141,8 +141,34 @@ describe('ShellRunProcessManager', () => {
     await sleep(20);
 
     assert.equal(initial.kind, 'shell_run');
+    assert.equal(initial.status, 'completed');
+    assert.equal(initial.stdout, 'done');
+    assert.equal(initial.exitCode, 0);
     assert.equal(updates.at(-1)?.result.status, 'completed');
     assert.equal(updates.at(-1)?.result.stdout, 'done');
+  });
+
+  test('background commands honor an explicit timeout', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'maka-shell-run-'));
+    const manager = createManager(new MemoryShellRunStore());
+
+    const initial = await manager.runBackgroundBash(shellInput({ cwd, command: 'sleep 5', timeoutMs: 50 }));
+    await sleep(100);
+
+    assert.ok(initial.ref);
+    assert.equal((await manager.readResource('session-1', initial.ref)).status, 'timed_out');
+    assert.equal(manager.liveCount(), 0);
+  });
+
+  test('background commands reject timeouts above twenty-four hours', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'maka-shell-run-'));
+    const manager = createManager(new MemoryShellRunStore());
+
+    await assert.rejects(
+      manager.runBackgroundBash(shellInput({ cwd, command: 'true', timeoutMs: 86_400_001 })),
+      /Background Bash timeout/,
+    );
+    assert.equal(manager.liveCount(), 0);
   });
 
   test('publishes the terminal state when a background ShellRun settles without a resource read', async () => {

--- a/packages/runtime/src/__tests__/shell-run-manager.test.ts
+++ b/packages/runtime/src/__tests__/shell-run-manager.test.ts
@@ -13,10 +13,9 @@ describe('ShellRunProcessManager', () => {
     const store = new MemoryShellRunStore();
     const manager = createManager(store);
 
-    const result = await manager.runBash(shellInput({
+    const result = await manager.runForegroundBash(shellInput({
       cwd,
       command: 'printf "hello"',
-      yieldTimeMs: 30_000,
     }));
 
     assert.equal(result.kind, 'terminal');
@@ -38,10 +37,9 @@ describe('ShellRunProcessManager', () => {
     const store = new MemoryShellRunStore();
     const manager = createManager(store);
 
-    const result = await manager.runBash(shellInput({
+    const result = await manager.runForegroundBash(shellInput({
       cwd,
       command: 'echo wired-marker',
-      yieldTimeMs: 30_000,
       shell: { kind: 'pwsh', displayName: 'PowerShell 7 (pwsh)', exe: '/bin/echo' },
     }));
 
@@ -59,10 +57,9 @@ describe('ShellRunProcessManager', () => {
     const store = new MemoryShellRunStore({ createDelayMs: 100 });
     const manager = createManager(store);
 
-    const result = await manager.runBash(shellInput({
+    const result = await manager.runForegroundBash(shellInput({
       cwd,
       command: 'printf "done"',
-      yieldTimeMs: 30_000,
     }));
 
     assert.equal(result.kind, 'terminal');
@@ -70,15 +67,43 @@ describe('ShellRunProcessManager', () => {
     assert.equal(manager.liveCount(), 0);
   });
 
-  test('yields long commands as running ShellRuns and observes them through resource reads', async () => {
+  test('foreground commands default to a two-minute timeout', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'maka-shell-run-'));
+    const store = new MemoryShellRunStore();
+    const manager = createManager(store);
+    const abort = new AbortController();
+
+    const running = manager.runForegroundBash(shellInput({
+      cwd,
+      command: 'sleep 5',
+      abortSignal: abort.signal,
+    }));
+    await sleep(20);
+
+    assert.equal((await store.readShellRun('session-1', 'shell-run-1')).timeoutMs, 120_000);
+    abort.abort();
+    assert.equal((await running).status, 'cancelled');
+  });
+
+  test('foreground commands reject timeouts above ten minutes', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'maka-shell-run-'));
+    const manager = createManager(new MemoryShellRunStore());
+
+    await assert.rejects(
+      manager.runForegroundBash(shellInput({ cwd, command: 'true', timeoutMs: 600_001 })),
+      /Foreground Bash timeout/,
+    );
+    assert.equal(manager.liveCount(), 0);
+  });
+
+  test('starts background commands as running ShellRuns without a yield window', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'maka-shell-run-'));
     const store = new MemoryShellRunStore();
     const manager = createManager(store);
 
-    const initial = await manager.runBash(shellInput({
+    const initial = await manager.runBackgroundBash(shellInput({
       cwd,
       command: 'printf "start"; sleep 0.5; printf "done"',
-      yieldTimeMs: 250,
     }));
 
     assert.equal(initial.kind, 'shell_run');
@@ -86,12 +111,12 @@ describe('ShellRunProcessManager', () => {
     assert.equal(initial.ref, 'maka://runtime/background-tasks/shell-run-1');
     assert.equal(initial.stdout, '');
     assert.equal(manager.liveCount(), 1);
+    assert.equal((await store.readShellRun('session-1', 'shell-run-1')).timeoutMs, undefined);
     if (!initial.ref) throw new Error('expected ShellRun resource ref');
 
     const detail = await manager.readResource('session-1', initial.ref);
     assert.equal(detail.kind, 'shell_run');
     assert.equal(detail.status, 'running');
-    assert.equal(detail.stdout, 'start');
 
     const summary = await manager.buildContextSummary('session-1');
     assert.match(summary ?? '', /ref=maka:\/\/runtime\/background-tasks\/shell-run-1/);
@@ -106,16 +131,29 @@ describe('ShellRunProcessManager', () => {
     assert.equal(await manager.buildContextSummary('session-1'), undefined);
   });
 
-  test('publishes the terminal state when a yielded ShellRun settles without a resource read', async () => {
+  test('publishes terminal state when a background command exits during startup', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'maka-shell-run-'));
+    const store = new MemoryShellRunStore({ createDelayMs: 100 });
+    const updates: ShellRunUpdate[] = [];
+    const manager = createManager(store, (update) => updates.push(update));
+
+    const initial = await manager.runBackgroundBash(shellInput({ cwd, command: 'printf "done"' }));
+    await sleep(20);
+
+    assert.equal(initial.kind, 'shell_run');
+    assert.equal(updates.at(-1)?.result.status, 'completed');
+    assert.equal(updates.at(-1)?.result.stdout, 'done');
+  });
+
+  test('publishes the terminal state when a background ShellRun settles without a resource read', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'maka-shell-run-'));
     const store = new MemoryShellRunStore();
     const updates: ShellRunUpdate[] = [];
     const manager = createManager(store, (update) => updates.push(update));
 
-    const initial = await manager.runBash(shellInput({
+    const initial = await manager.runBackgroundBash(shellInput({
       cwd,
       command: 'printf "start"; sleep 0.5; printf "done"',
-      yieldTimeMs: 250,
     }));
     assert.equal(initial.kind, 'shell_run');
     assert.equal(initial.status, 'running');
@@ -134,14 +172,13 @@ describe('ShellRunProcessManager', () => {
     const updates: ShellRunUpdate[] = [];
     const manager = createManager(store, (update) => updates.push(update));
 
-    const initial = await manager.runBash(shellInput({
+    const initial = await manager.runBackgroundBash(shellInput({
       cwd,
       command: 'printf "start"; sleep 0.1; printf "middle"; sleep 0.1',
-      yieldTimeMs: 50,
     }));
     assert.equal(initial.kind, 'shell_run');
 
-    await sleep(750);
+    await sleep(1_300);
     const latestRunning = updates.filter((update) => update.result.status === 'running').at(-1);
     const terminal = updates.find((update) => update.result.status === 'completed');
     assert.ok(latestRunning);
@@ -155,10 +192,9 @@ describe('ShellRunProcessManager', () => {
     const updates: ShellRunUpdate[] = [];
     const manager = createManager(store, (update) => updates.push(update));
 
-    const initial = await manager.runBash(shellInput({
+    const initial = await manager.runBackgroundBash(shellInput({
       cwd,
       command: 'printf "warning\\n" >&2; sleep 0.5; printf "99%%\\n"',
-      yieldTimeMs: 250,
     }));
     assert.equal(initial.kind, 'shell_run');
 
@@ -177,10 +213,9 @@ describe('ShellRunProcessManager', () => {
     const updates: ShellRunUpdate[] = [];
     const manager = createManager(store, (update) => updates.push(update));
 
-    const initial = await manager.runBash(shellInput({
+    const initial = await manager.runBackgroundBash(shellInput({
       cwd,
       command: 'printf "99%%\\n"; sleep 0.5; printf "warning\\n" >&2',
-      yieldTimeMs: 250,
     }));
     assert.equal(initial.kind, 'shell_run');
 
@@ -189,19 +224,19 @@ describe('ShellRunProcessManager', () => {
     assert.equal(terminal?.result.latestOutputStream, 'stderr');
   });
 
-  test('publishes retained output after a ShellRun yields', async () => {
+  test('publishes retained output after a ShellRun starts in the background', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'maka-shell-run-'));
     const store = new MemoryShellRunStore();
     const updates: ShellRunUpdate[] = [];
     const manager = createManager(store, (update) => updates.push(update));
 
-    const initial = await manager.runBash(shellInput({
+    const initial = await manager.runBackgroundBash(shellInput({
       cwd,
       command: 'printf "start"; sleep 5',
-      yieldTimeMs: 250,
     }));
     assert.equal(initial.kind, 'shell_run');
-    const running = updates.find((update) => update.result.status === 'running');
+    await sleep(50);
+    const running = updates.filter((update) => update.result.status === 'running').at(-1);
     assert.equal(running?.result.stdout, 'start');
 
     await manager.terminateAll();
@@ -212,10 +247,9 @@ describe('ShellRunProcessManager', () => {
     const store = new MemoryShellRunStore();
     const manager = createManager(store);
 
-    const initial = await manager.runBash(shellInput({
+    const initial = await manager.runBackgroundBash(shellInput({
       cwd,
       command: 'printf "start"; sleep 5',
-      yieldTimeMs: 250,
     }));
     assert.equal(initial.kind, 'shell_run');
     if (!initial.ref) throw new Error('expected ShellRun resource ref');
@@ -233,10 +267,9 @@ describe('ShellRunProcessManager', () => {
     const store = new MemoryShellRunStore({ updateDelayMs: 300 });
     const manager = createManager(store);
 
-    const initial = await manager.runBash(shellInput({
+    const initial = await manager.runBackgroundBash(shellInput({
       cwd,
       command: 'printf "start"; sleep 0.2; printf "done"',
-      yieldTimeMs: 50,
     }));
     assert.equal(initial.kind, 'shell_run');
     assert.equal(initial.ref, 'maka://runtime/background-tasks/shell-run-1');
@@ -255,10 +288,9 @@ describe('ShellRunProcessManager', () => {
     const store = new MemoryShellRunStore({ updateDelayMs: 300 });
     const manager = createManager(store);
 
-    const initial = await manager.runBash(shellInput({
+    const initial = await manager.runBackgroundBash(shellInput({
       cwd,
       command: 'sleep 0.2',
-      yieldTimeMs: 50,
     }));
     assert.equal(initial.kind, 'shell_run');
     assert.equal(initial.ref, 'maka://runtime/background-tasks/shell-run-1');
@@ -290,16 +322,15 @@ describe('ShellRunProcessManager', () => {
     );
   });
 
-  test('aborting before the initial yield cancels instead of backgrounding', async () => {
+  test('aborting a foreground command cancels it without backgrounding', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'maka-shell-run-'));
     const store = new MemoryShellRunStore();
     const manager = createManager(store);
     const abort = new AbortController();
 
-    const result = await manager.runBash(shellInput({
+    const result = await manager.runForegroundBash(shellInput({
       cwd,
       command: 'printf "start"; sleep 5',
-      yieldTimeMs: 30_000,
       abortSignal: abort.signal,
       emitOutput: () => abort.abort(),
     }));
@@ -444,7 +475,7 @@ function createManager(
 function shellInput(input: {
   cwd: string;
   command: string;
-  yieldTimeMs?: number;
+  timeoutMs?: number;
   abortSignal?: AbortSignal;
   emitOutput?: (stream: 'stdout' | 'stderr', chunk: string) => void;
   shell?: ShellPlan;
@@ -456,7 +487,7 @@ function shellInput(input: {
     sourceToolCallId: 'tool-1',
     cwd: input.cwd,
     command: input.command,
-    ...(input.yieldTimeMs !== undefined ? { yieldTimeMs: input.yieldTimeMs } : {}),
+    ...(input.timeoutMs !== undefined ? { timeoutMs: input.timeoutMs } : {}),
     ...(input.abortSignal !== undefined ? { abortSignal: input.abortSignal } : {}),
     ...(input.shell !== undefined ? { shell: input.shell } : {}),
     emitOutput: input.emitOutput ?? (() => {}),

--- a/packages/runtime/src/__tests__/shell-tools.test.ts
+++ b/packages/runtime/src/__tests__/shell-tools.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import { describe, test } from 'node:test';
-import { buildBackgroundBashTool, buildLocalForegroundBashTool } from '../shell-tools.js';
+import { buildLocalForegroundBashTool, buildManagedBashTool } from '../shell-tools.js';
 import type { ShellPlan } from '../shell-detect.js';
 
 const pwshPlan: ShellPlan = { kind: 'pwsh', displayName: 'PowerShell 7 (pwsh)', exe: 'C:\\pf\\pwsh.exe' };
@@ -8,7 +8,7 @@ const pwshPlan: ShellPlan = { kind: 'pwsh', displayName: 'PowerShell 7 (pwsh)', 
 describe('Bash tool description declares the executing shell', () => {
   test('foreground and background variants declare command activity', () => {
     assert.equal(buildLocalForegroundBashTool().activityKind, 'command');
-    assert.equal(buildBackgroundBashTool(fakeShellRuns()).activityKind, 'command');
+    assert.equal(buildManagedBashTool(fakeShellRuns()).activityKind, 'command');
   });
 
   test('foreground tool tells the model commands run under PowerShell 7', () => {
@@ -26,10 +26,10 @@ describe('Bash tool description declares the executing shell', () => {
   });
 
   test('background tool tells the model commands run under PowerShell 7', () => {
-    const tool = buildBackgroundBashTool(fakeShellRuns(), { shell: pwshPlan });
+    const tool = buildManagedBashTool(fakeShellRuns(), { shell: pwshPlan });
     assert.match(tool.description, /PowerShell 7 \(pwsh\)/);
     assert.match(tool.description, /git ls-files/);
-    assert.match(tool.description, /outlive yield_time_ms/);
+    assert.match(tool.description, /run_in_background=true/);
   });
 });
 
@@ -52,15 +52,16 @@ describe('Bash tool shell is threaded through to execution, not just the descrip
   test('background tool forwards its shell to the shell-run controller', async () => {
     const captured: unknown[] = [];
     const controller = {
-      runBash: (input: unknown) => {
+      runForegroundBash: () => Promise.reject(new Error('not used')),
+      runBackgroundBash: (input: unknown) => {
         captured.push(input);
         return Promise.resolve({ kind: 'terminal', cwd: '.', cmd: '', status: 'completed', exitCode: 0, stdout: '', stderr: '', stdoutTruncated: false, stderrTruncated: false } as never);
       },
       readResource: () => Promise.reject(new Error('not used')),
       stopResource: () => Promise.reject(new Error('not used')),
     };
-    const tool = buildBackgroundBashTool(controller, { shell: pwshPlan });
-    await tool.impl({ command: 'echo hi' }, fakeToolContext());
+    const tool = buildManagedBashTool(controller, { shell: pwshPlan });
+    await tool.impl({ command: 'echo hi', run_in_background: true }, fakeToolContext());
     assert.deepEqual((captured[0] as { shell?: unknown }).shell, pwshPlan);
   });
 });
@@ -78,7 +79,8 @@ function fakeToolContext() {
 
 function fakeShellRuns() {
   return {
-    runBash: () => Promise.reject(new Error('not used')),
+    runForegroundBash: () => Promise.reject(new Error('not used')),
+    runBackgroundBash: () => Promise.reject(new Error('not used')),
     readResource: () => Promise.reject(new Error('not used')),
     stopResource: () => Promise.reject(new Error('not used')),
   };

--- a/packages/runtime/src/builtin-tools.ts
+++ b/packages/runtime/src/builtin-tools.ts
@@ -9,7 +9,7 @@ import { z } from 'zod';
 import { isAbsolute } from 'node:path';
 import { computeEditedSource } from './edit-replace.js';
 import {
-  buildBackgroundBashTool,
+  buildManagedBashTool,
   buildStopBackgroundTaskTool,
   shapeTerminalResult,
   withShellGuidance,
@@ -51,7 +51,7 @@ export function buildBuiltinTools(options: BuildBuiltinToolsOptions = {}): MakaT
   const shell = options.shell ?? defaultShellPlan();
   const bashTools = options.shellRuns
     ? [
-      buildBackgroundBashTool(options.shellRuns, { executionFacts, shell }),
+      buildManagedBashTool(options.shellRuns, { executionFacts, shell }),
       buildStopBackgroundTaskTool(options.shellRuns),
     ]
     : [buildExecutorBashTool(executor, shell)];

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -79,7 +79,6 @@ export type {
   MakaToolContext as BuiltinMakaToolContext,
 } from './builtin-tools.js';
 export {
-  buildBackgroundBashTool,
   buildManagedBashTool,
   buildForegroundBashTool,
   buildLocalForegroundBashTool,

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -80,6 +80,7 @@ export type {
 } from './builtin-tools.js';
 export {
   buildBackgroundBashTool,
+  buildManagedBashTool,
   buildForegroundBashTool,
   buildLocalForegroundBashTool,
   buildStopBackgroundTaskTool,
@@ -92,14 +93,12 @@ export type {
   ShellRunToolController,
 } from './shell-tools.js';
 export {
-  DEFAULT_BASH_YIELD_TIME_MS,
   DEFAULT_BASH_TIMEOUT_MS,
   DEFAULT_MAX_LIVE_SHELL_RUNS,
   DEFAULT_SHELL_RUN_FLUSH_BYTES,
   DEFAULT_SHELL_RUN_FLUSH_INTERVAL_MS,
-  MAX_BASH_YIELD_TIME_MS,
+  MAX_FOREGROUND_BASH_TIMEOUT_MS,
   MAX_SHELL_RUN_TIMEOUT_MS,
-  MIN_BASH_YIELD_TIME_MS,
   SHELL_RUN_CONTEXT_SUMMARY_LIMIT,
   SHELL_RUN_RESOURCE_PREFIX,
   ShellRunProcessManager,

--- a/packages/runtime/src/shell-run-manager.ts
+++ b/packages/runtime/src/shell-run-manager.ts
@@ -21,10 +21,8 @@ import {
 import { buildShellSpawnPlan, defaultShellPlan, type ShellPlan } from './shell-detect.js';
 import { truncateToolOutput } from './tool-output.js';
 
-export const DEFAULT_BASH_YIELD_TIME_MS = 10_000;
 export const DEFAULT_BASH_TIMEOUT_MS = 120_000;
-export const MIN_BASH_YIELD_TIME_MS = 250;
-export const MAX_BASH_YIELD_TIME_MS = 30_000;
+export const MAX_FOREGROUND_BASH_TIMEOUT_MS = 10 * 60 * 1_000;
 export const MAX_SHELL_RUN_TIMEOUT_MS = 24 * 60 * 60 * 1000;
 export const DEFAULT_MAX_LIVE_SHELL_RUNS = 64;
 export const DEFAULT_SHELL_RUN_FLUSH_INTERVAL_MS = 1_000;
@@ -58,7 +56,6 @@ export interface ShellRunBashInput {
   sourceToolCallId: string;
   cwd: string;
   command: string;
-  yieldTimeMs?: number;
   timeoutMs?: number;
   abortSignal?: AbortSignal;
   emitOutput: (stream: 'stdout' | 'stderr', chunk: string) => void;
@@ -125,36 +122,29 @@ export class ShellRunProcessManager {
     this.killGraceMs = input.killGraceMs ?? SIGKILL_GRACE_MS;
   }
 
-  async runBash(input: ShellRunBashInput): Promise<TerminalToolResult | ShellRunToolResult> {
+  async runBackgroundBash(input: ShellRunBashInput): Promise<ShellRunToolResult> {
     if (input.abortSignal?.aborted) {
       throw new Error('Command aborted before shell process started');
     }
-    const yieldTimeMs = clampInt(
-      input.yieldTimeMs ?? DEFAULT_BASH_YIELD_TIME_MS,
-      MIN_BASH_YIELD_TIME_MS,
-      MAX_BASH_YIELD_TIME_MS,
-    );
-    const timeoutMs = normalizeTimeoutMs(input.timeoutMs ?? DEFAULT_BASH_TIMEOUT_MS);
-    const live = await this.start(input, timeoutMs);
-    const initial = await Promise.race([
-      live.finished.then(() => 'finished' as const),
-      sleep(yieldTimeMs).then(() => 'yield' as const),
-      waitForAbort(input.abortSignal).then(() => 'abort' as const),
-    ]);
-    if (initial === 'finished') {
-      const finished = await live.finished;
-      return this.markObservedAndReturnTerminal(finished);
-    }
-    if (initial === 'abort') {
-      this.beginTermination(live, { kind: 'cancel' });
-      const cancelled = await live.finished;
-      return this.markObservedAndReturnTerminal(cancelled);
-    }
-
-    live.forwardLive = false;
+    const timeoutMs = normalizeBackgroundTimeoutMs(input.timeoutMs);
+    const live = await this.start(input, timeoutMs, false);
     await this.flushLive(live);
     const record = await this.input.store.readShellRun(input.sessionId, live.shellRunId);
     return shellRunRefContent(record);
+  }
+
+  async runForegroundBash(input: ShellRunBashInput): Promise<TerminalToolResult> {
+    if (input.abortSignal?.aborted) {
+      throw new Error('Command aborted before shell process started');
+    }
+    const timeoutMs = normalizeForegroundTimeoutMs(input.timeoutMs ?? DEFAULT_BASH_TIMEOUT_MS);
+    const live = await this.start(input, timeoutMs, true);
+    const outcome = await Promise.race([
+      live.finished.then(() => 'finished' as const),
+      waitForAbort(input.abortSignal).then(() => 'abort' as const),
+    ]);
+    if (outcome === 'abort') this.beginTermination(live, { kind: 'cancel' });
+    return this.markObservedAndReturnTerminal(await live.finished);
   }
 
   private async cancelShellRun(sessionId: string, shellRunId: string): Promise<ShellRunToolResult> {
@@ -236,9 +226,13 @@ export class ShellRunProcessManager {
     return this.live.size;
   }
 
-  private async start(input: ShellRunBashInput, timeoutMs: number | undefined): Promise<LiveShellRun> {
+  private async start(
+    input: ShellRunBashInput,
+    timeoutMs: number | undefined,
+    forwardLive: boolean,
+  ): Promise<LiveShellRun> {
     if (this.live.size >= this.maxLiveShellRuns) {
-      throw new Error(`Too many live background tasks (${this.maxLiveShellRuns}); read or stop an existing task first`);
+      throw new Error(`Too many live shell commands (${this.maxLiveShellRuns}); wait for or stop an existing command first`);
     }
 
     const shellRunId = this.input.newId();
@@ -280,7 +274,7 @@ export class ShellRunProcessManager {
       finished,
       ...(timeoutMs !== undefined ? { timeoutMs } : {}),
       settled: false,
-      forwardLive: true,
+      forwardLive,
       liveEmitted: { stdout: 0, stderr: 0 },
       liveSuppressed: { stdout: false, stderr: false },
       emitOutput: input.emitOutput,
@@ -643,9 +637,19 @@ function failureMessageFor(status: ShellRunStatus, timeoutMs: number | undefined
   }
 }
 
-function normalizeTimeoutMs(value: number | undefined): number | undefined {
+function normalizeBackgroundTimeoutMs(value: number | undefined): number | undefined {
   if (value === undefined) return undefined;
-  return clampInt(value, 1, MAX_SHELL_RUN_TIMEOUT_MS);
+  if (!Number.isInteger(value) || value <= 0 || value > MAX_SHELL_RUN_TIMEOUT_MS) {
+    throw new Error(`Background Bash timeout must be between 1 and ${MAX_SHELL_RUN_TIMEOUT_MS}ms`);
+  }
+  return value;
+}
+
+function normalizeForegroundTimeoutMs(value: number): number {
+  if (!Number.isInteger(value) || value <= 0 || value > MAX_FOREGROUND_BASH_TIMEOUT_MS) {
+    throw new Error(`Foreground Bash timeout must be between 1 and ${MAX_FOREGROUND_BASH_TIMEOUT_MS}ms`);
+  }
+  return value;
 }
 
 export function shellRunResourceRef(shellRunId: string): string {
@@ -683,15 +687,6 @@ function parseShellRunResourceRef(ref: string): ShellRunResourceTarget | null {
     }
   }
   return null;
-}
-
-function clampInt(value: number, min: number, max: number): number {
-  if (!Number.isFinite(value)) return min;
-  return Math.min(max, Math.max(min, Math.trunc(value)));
-}
-
-function sleep(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
 function waitForAbort(signal: AbortSignal | undefined): Promise<void> {

--- a/packages/runtime/src/shell-run-manager.ts
+++ b/packages/runtime/src/shell-run-manager.ts
@@ -130,6 +130,9 @@ export class ShellRunProcessManager {
     const live = await this.start(input, timeoutMs, false);
     await this.flushLive(live);
     const record = await this.input.store.readShellRun(input.sessionId, live.shellRunId);
+    if (isTerminalShellRunStatus(record.status)) {
+      return shellRunContent(await this.markObserved(record));
+    }
     return shellRunRefContent(record);
   }
 

--- a/packages/runtime/src/shell-tools.ts
+++ b/packages/runtime/src/shell-tools.ts
@@ -152,9 +152,6 @@ export function buildManagedBashTool(
   };
 }
 
-/** @deprecated Use buildManagedBashTool. */
-export const buildBackgroundBashTool = buildManagedBashTool;
-
 export function withShellGuidance(lead: string, shell: ShellPlan): string {
   const guidance = bashToolShellGuidance(shell);
   return guidance ? `${lead} ${guidance}` : lead;

--- a/packages/runtime/src/shell-tools.ts
+++ b/packages/runtime/src/shell-tools.ts
@@ -7,7 +7,9 @@ import { runShellWithBoundedTail, type BoundedShellResult } from './shell-exec.j
 import { bashToolShellGuidance, defaultShellPlan, type ShellPlan } from './shell-detect.js';
 import { truncateToolOutput } from './tool-output.js';
 import {
+  DEFAULT_BASH_TIMEOUT_MS,
   MAX_SHELL_RUN_TIMEOUT_MS,
+  MAX_FOREGROUND_BASH_TIMEOUT_MS,
   type ShellRunBashInput,
 } from './shell-run-manager.js';
 
@@ -46,7 +48,8 @@ type TerminalToolResult = Extract<ToolResultContent, { kind: 'terminal' }>;
 type ShellRunToolResult = Extract<ToolResultContent, { kind: 'shell_run' }>;
 
 export interface ShellRunToolController {
-  runBash(input: ShellRunBashInput): Promise<TerminalToolResult | ShellRunToolResult>;
+  runForegroundBash(input: ShellRunBashInput): Promise<TerminalToolResult>;
+  runBackgroundBash(input: ShellRunBashInput): Promise<ShellRunToolResult>;
   readResource(
     sessionId: string,
     ref: string,
@@ -102,7 +105,7 @@ export function buildLocalForegroundBashTool(
   });
 }
 
-export function buildBackgroundBashTool(
+export function buildManagedBashTool(
   shellRuns: ShellRunToolController,
   options: { executionFacts?: ToolExecutionFacts; shell?: ShellPlan } = {},
 ): MakaTool {
@@ -112,15 +115,29 @@ export function buildBackgroundBashTool(
     activityKind: 'command',
     description:
       withShellGuidance('Run a shell command in the session cwd.', shell)
-      + ' Commands that outlive yield_time_ms continue as runtime background tasks; use the returned ref with Read to inspect them. Subject to permission policy.',
+      + ` Foreground is the default (timeout ${DEFAULT_BASH_TIMEOUT_MS}ms, maximum ${MAX_FOREGROUND_BASH_TIMEOUT_MS}ms).`
+      + ` Set run_in_background=true only when the command should continue as a tracked runtime background task; background commands have no default timeout (maximum explicit timeout ${MAX_SHELL_RUN_TIMEOUT_MS}ms). Use the returned ref with Read to inspect it. Subject to permission policy.`,
     parameters: z.object({
       command: z.string().describe('The shell command to execute'),
       timeout_ms: z.number().int().positive().max(MAX_SHELL_RUN_TIMEOUT_MS).optional(),
-      yield_time_ms: z.number().int().positive().optional(),
+      run_in_background: z.boolean().optional(),
+    }).strict().superRefine(({ timeout_ms, run_in_background }, ctx) => {
+      if (!run_in_background && timeout_ms !== undefined && timeout_ms > MAX_FOREGROUND_BASH_TIMEOUT_MS) {
+        ctx.addIssue({
+          code: 'too_big',
+          maximum: MAX_FOREGROUND_BASH_TIMEOUT_MS,
+          origin: 'number',
+          inclusive: true,
+          path: ['timeout_ms'],
+          message: `Foreground Bash timeout may not exceed ${MAX_FOREGROUND_BASH_TIMEOUT_MS}ms`,
+        });
+      }
     }),
     permissionRequired: true,
     ...(options.executionFacts ? { executionFacts: options.executionFacts } : {}),
-    impl: async ({ command, timeout_ms, yield_time_ms }, ctx) => shellRuns.runBash({
+    impl: async ({ command, timeout_ms, run_in_background }, ctx) => shellRuns[
+      run_in_background ? 'runBackgroundBash' : 'runForegroundBash'
+    ]({
       sessionId: ctx.sessionId,
       ...(ctx.runId ? { sourceRunId: ctx.runId } : {}),
       sourceTurnId: ctx.turnId,
@@ -128,13 +145,15 @@ export function buildBackgroundBashTool(
       cwd: ctx.cwd,
       command,
       shell,
-      ...(yield_time_ms !== undefined ? { yieldTimeMs: yield_time_ms } : {}),
       ...(timeout_ms !== undefined ? { timeoutMs: timeout_ms } : {}),
       abortSignal: ctx.abortSignal,
       emitOutput: ctx.emitOutput,
     }),
   };
 }
+
+/** @deprecated Use buildManagedBashTool. */
+export const buildBackgroundBashTool = buildManagedBashTool;
 
 export function withShellGuidance(lead: string, shell: ShellPlan): string {
   const guidance = bashToolShellGuidance(shell);


### PR DESCRIPTION
## Summary

- Keep Bash commands in the foreground unless the model explicitly sets `run_in_background: true`.
- Split managed shell execution into explicit foreground and background paths while sharing process persistence, output, cancellation, and cleanup.
- Remove `yield_time_ms`; foreground commands default to a 2-minute timeout with a 10-minute maximum, while background commands return a ref immediately and have no default timeout.

## Why

Maka currently converts every Bash command that outlives a short yield window into a background task, even when background execution was not requested. In one CLI turn, a model passed `yield_time_ms: 600000` to wait, but the runtime silently clamped it to 30 seconds and returned `running`. The model repeated the command, creating 12 distinct shell runs and leaving 10 concurrent `sleep 600` processes.

Runtime duration should not change execution intent. Foreground and background execution are separate choices and must be represented explicitly in the Bash contract.

Fixes #762.

## Scope

This changes the shared managed Bash contract used by CLI and Desktop. It does not change the headless foreground-only Bash path, add duplicate-command detection, alter the repeated-failure loop gate, add new UI, or make background processes survive host shutdown.

## Verification

- `npm --workspace @maka/runtime test` — 1311 passed, 2 skipped because PowerShell is unavailable.
- `npm --workspace maka-agent test` — 289 passed.
- `npm run typecheck` — passed for all workspaces, including CLI and Desktop.
- `git diff --check` — passed.
- TDD regression coverage verifies default foreground execution, explicit immediate background execution, timeout boundaries, background execution without a default timeout, process-tree cancellation, shutdown cleanup, fast-exit terminal results, terminal updates, and CLI integration.
- Two Codex read-only reviews completed. The first found a fast-background completion race and an unnecessary compatibility alias; both were fixed. The second review reported no P0–P3 findings and returned PASS.
- Visual evidence is not applicable: the existing TUI/Desktop background-task presentation is unchanged. Runtime and CLI integration tests cover the behavior change.

## Impact

This is an intentional Bash tool-schema change for interactive CLI and Desktop sessions:

- models must use `run_in_background: true` to start a tracked background task;
- `yield_time_ms` is removed and rejected;
- foreground commands default to 2 minutes and cannot exceed 10 minutes;
- background commands have no timeout unless `timeout_ms` is provided.

Existing stored shell-run records and transcript replay remain compatible. `Read(ref)` and `StopBackgroundTask(ref)` are unchanged. No data migration is required.

## Reviewer notes

Please focus on the foreground/background lifecycle split, timeout validation at both schema and manager boundaries, immediate background startup, and fast-exit terminal result ordering.

## Ready for review

- [x] Verification is complete and the results above are current
- [x] Impact, compatibility, migration, documentation, and release-note needs are addressed
- [x] User-visible UI/UX changes include visual evidence, or `Verification` explains why it is not applicable

