### PR TITLE
fix(runtime): report explicit step limits as incomplete

### DIFF
--- a/apps/desktop/src/main/__tests__/session-status-presentation.test.ts
+++ b/apps/desktop/src/main/__tests__/session-status-presentation.test.ts
@@ -315,6 +315,19 @@ describe('describeTurnErrorClass (PR109e-d @kenji gate #3)', () => {
     assert.match(describeTurnErrorClass('tool_failed'), /工具/);
   });
 
+  it('distinguishes a tool step cap from a failed tool call', () => {
+    assert.equal(describeTurnErrorClass('tool_step_cap_reached'), '达到工具步骤上限');
+    assert.deepEqual(deriveFailedTurnRecovery({
+      errorClass: 'tool_step_cap_reached',
+      partialOutputRetained: true,
+      toolActivityCount: 1,
+      erroredToolCount: 0,
+    }), {
+      action: 'continue',
+      label: '任务可能尚未完成，可以继续',
+    });
+  });
+
   it('returns a specific Chinese label for app restart recovery', () => {
     assert.equal(describeTurnErrorClass('app_restarted'), '本地应用重启，上一轮没有完成');
   });

--- a/apps/desktop/src/main/__tests__/turn-stream-outcome.test.ts
+++ b/apps/desktop/src/main/__tests__/turn-stream-outcome.test.ts
@@ -1,0 +1,18 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+
+import { turnFailureMessageFromSessionEvent } from '../turn-stream-outcome.js';
+
+describe('turnFailureMessageFromSessionEvent', () => {
+  test('treats step_limit as incomplete while leaving clean completions alone', () => {
+    const base = { id: 'event-1', turnId: 'turn-1', ts: 1 };
+    assert.equal(
+      turnFailureMessageFromSessionEvent({ ...base, type: 'complete', stopReason: 'step_limit' }),
+      'turn ended: tool_step_cap_reached',
+    );
+    assert.equal(
+      turnFailureMessageFromSessionEvent({ ...base, type: 'complete', stopReason: 'end_turn' }),
+      undefined,
+    );
+  });
+});

--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -53,6 +53,7 @@ import {
   normalizeSessionSendCommand,
   normalizeStopSessionInput,
 } from './permission-response-guard.js';
+import { turnFailureMessageFromSessionEvent } from './turn-stream-outcome.js';
 import { ClaudeSubscriptionService } from './oauth/claude-subscription-service.js';
 import { CodexSubscriptionService } from './oauth/codex-subscription-service.js';
 import { CursorSubscriptionService } from './oauth/cursor-subscription-service.js';
@@ -1756,15 +1757,7 @@ async function streamEvents(
       if (event.type === 'abort' || (event.type === 'complete' && event.stopReason === 'user_stop')) {
         turnAborted = true;
       }
-      if (event.type === 'error') {
-        turnError = event.message ?? event.reason ?? 'turn error';
-      }
-      // A non-throwing error finish (e.g. content-filter) arrives as
-      // complete{stopReason:'error'} with no separate `error` event — record it
-      // so goal continuation is skipped (and `ok` is not mis-reported true).
-      if (event.type === 'complete' && event.stopReason === 'error') {
-        turnError = turnError ?? 'turn ended in error';
-      }
+      turnError = turnError ?? turnFailureMessageFromSessionEvent(event);
       safeSendToRenderer(`sessions:event:${sessionId}`, event);
       openGateway.publishSessionEvent(sessionId, event);
       if (isStatusChangingSessionEvent(event)) {

--- a/apps/desktop/src/main/turn-stream-outcome.ts
+++ b/apps/desktop/src/main/turn-stream-outcome.ts
@@ -1,0 +1,12 @@
+import {
+  failureClassFromCompleteStopReason,
+  type SessionEvent,
+} from '@maka/core/events';
+
+export function turnFailureMessageFromSessionEvent(event: SessionEvent): string | undefined {
+  if (event.type === 'error') return event.message ?? event.reason ?? 'turn error';
+  if (event.type !== 'complete') return undefined;
+  const failureClass = failureClassFromCompleteStopReason(event.stopReason);
+  if (failureClass) return `turn ended: ${failureClass}`;
+  return undefined;
+}

--- a/apps/desktop/src/renderer/session-status-presentation.ts
+++ b/apps/desktop/src/renderer/session-status-presentation.ts
@@ -164,6 +164,7 @@ export function describeTurnErrorClass(errorClass: string | undefined): string {
     return '网络错误';
   }
   if (lower === 'provider_unavailable' || /\b5\d\d\b/.test(lower)) return '模型服务返回错误';
+  if (lower === 'tool_step_cap_reached') return '达到工具步骤上限';
   if (lower === 'tool_failed' || lower.includes('tool')) return '工具调用失败';
   if (lower === 'permission_required' || lower.includes('permission')) return '等待权限确认';
   if (lower === 'app_restarted') return '本地应用重启，上一轮没有完成';
@@ -193,6 +194,9 @@ export interface FailedTurnRecoveryInput {
  */
 export function deriveFailedTurnRecovery(input: FailedTurnRecoveryInput): FailedTurnRecoveryPresentation {
   const lower = input.errorClass?.toLowerCase() ?? '';
+  if (lower === 'tool_step_cap_reached') {
+    return { action: 'continue', label: '任务可能尚未完成，可以继续' };
+  }
   if (input.erroredToolCount > 0 || lower === 'tool_failed' || lower.includes('tool')) {
     return { action: 'inspect_tool', label: '先检查工具结果，再决定是否重试' };
   }

--- a/packages/cli/src/__tests__/pi-transcript.test.ts
+++ b/packages/cli/src/__tests__/pi-transcript.test.ts
@@ -150,6 +150,41 @@ describe('Maka Pi TUI transcript', () => {
     assert.equal(outcome.aborted, false);
   });
 
+  test('shows a fixed system notice when the configured step limit is reached', () => {
+    const state = createMakaPiTranscriptState();
+
+    applyMakaSessionEventToTranscript(state, event({ type: 'complete', stopReason: 'step_limit' }));
+
+    assert.deepEqual(state.entries, [{
+      kind: 'notice',
+      level: 'info',
+      text: 'Reached the configured step limit. The task may be incomplete. Send “continue” to resume.',
+    }]);
+  });
+
+  test('restores the step-limit system notice from stored history', () => {
+    const state = createMakaPiTranscriptState();
+
+    replaceTranscriptWithStoredMessages(state, [
+      { type: 'system_note', id: 'notice-1', turnId: 'turn-1', ts: 1, kind: 'step_limit' },
+    ]);
+
+    assert.deepEqual(state.entries, [{
+      kind: 'notice',
+      level: 'info',
+      text: 'Reached the configured step limit. The task may be incomplete. Send “continue” to resume.',
+    }]);
+  });
+
+  test('step_limit prevents automatic goal continuation', async () => {
+    const state = createMakaPiTranscriptState();
+    const driver = new RecordingDriver([event({ type: 'complete', stopReason: 'step_limit' })]);
+
+    const outcome = await submitPromptToTranscript({ state, driver, prompt: 'hi' });
+
+    assert.deepEqual(outcome, { aborted: false, errored: true });
+  });
+
   test('reports a thrown sendPrompt as errored', async () => {
     const state = createMakaPiTranscriptState();
     const driver = {

--- a/packages/cli/src/__tests__/run-command-fixture.ts
+++ b/packages/cli/src/__tests__/run-command-fixture.ts
@@ -91,6 +91,10 @@ const runtime: MakaRunRuntime = {
       await notify(failedResult('missing_final_output', 'completed invocation produced no final output'));
       return;
     }
+    if (scenario === 'step-limit') {
+      await notify(failedResult('step_limit', 'explicit tool-step limit reached; send continue to resume'));
+      return;
+    }
     const maxSteps = process.env.MAKA_RUN_EXPECT_MAX_STEPS;
     const output = maxSteps
       ? `maxSteps=${maxSteps};prompt=${input.text}`

--- a/packages/cli/src/__tests__/run-command.test.ts
+++ b/packages/cli/src/__tests__/run-command.test.ts
@@ -146,6 +146,14 @@ describe('maka run process contract', () => {
     assert.match(missing.stderr, /no final output/);
   });
 
+  test('returns exit 1 without successful output when the explicit step limit is reached', async () => {
+    const result = await runFixture(['hello'], { scenario: 'step-limit', input: '' });
+
+    assert.equal(result.code, 1);
+    assert.equal(result.stdout, '');
+    assert.match(result.stderr, /tool-step limit reached/);
+  });
+
   test('denies an unresolved permission prompt and exits 1', async () => {
     const result = await runFixture(['hello'], { scenario: 'permission', input: '' });
     assert.equal(result.code, 1);

--- a/packages/cli/src/pi-transcript.ts
+++ b/packages/cli/src/pi-transcript.ts
@@ -5,7 +5,7 @@ import type {
   ToolOutputStream,
   ToolResultContent,
 } from '@maka/core/events';
-import type { StoredMessage, SystemNoteMessage } from '@maka/core/session';
+import { STEP_LIMIT_NOTICE_TEXT, type StoredMessage, type SystemNoteMessage } from '@maka/core/session';
 import type { ContextBudgetDiagnostic } from '@maka/core/usage-stats/types';
 import type { ThinkingLevel } from '@maka/core/model-thinking';
 import { materializeSession, type ChatItem, type ToolActivityItem } from '@maka/runtime';
@@ -222,7 +222,10 @@ export async function submitPromptToTranscript(input: {
       // complete{stopReason:'error'} with no separate `error` event — treat it as
       // errored too, so goal continuation never re-injects into a failed turn
       // (self-sufficient, not reliant on the session-status backstop).
-      if (event.type === 'complete' && event.stopReason === 'error') {
+      if (
+        event.type === 'complete'
+        && (event.stopReason === 'error' || event.stopReason === 'step_limit')
+      ) {
         errored = true;
       }
       input.onChange?.();
@@ -439,6 +442,9 @@ export function applyMakaSessionEventToTranscript(
           text: 'Stopped: max tokens',
         });
       }
+      if (event.stopReason === 'step_limit') {
+        state.entries.push({ kind: 'notice', level: 'info', text: STEP_LIMIT_NOTICE_TEXT });
+      }
       break;
   }
 }
@@ -628,6 +634,8 @@ function systemNoteText(message: SystemNoteMessage): string | undefined {
       return 'Context compacted to keep this session within the model window.';
     case 'context_compaction_failed_open':
       return 'Context summary failed; the session continued without a new summary.';
+    case 'step_limit':
+      return STEP_LIMIT_NOTICE_TEXT;
     case 'error':
       return 'Session recorded an error.';
     case 'abort':

--- a/packages/cli/src/pi-transcript.ts
+++ b/packages/cli/src/pi-transcript.ts
@@ -5,6 +5,7 @@ import type {
   ToolOutputStream,
   ToolResultContent,
 } from '@maka/core/events';
+import { failureClassFromCompleteStopReason } from '@maka/core/events';
 import { STEP_LIMIT_NOTICE_TEXT, type StoredMessage, type SystemNoteMessage } from '@maka/core/session';
 import type { ContextBudgetDiagnostic } from '@maka/core/usage-stats/types';
 import type { ThinkingLevel } from '@maka/core/model-thinking';
@@ -224,7 +225,7 @@ export async function submitPromptToTranscript(input: {
       // (self-sufficient, not reliant on the session-status backstop).
       if (
         event.type === 'complete'
-        && (event.stopReason === 'error' || event.stopReason === 'step_limit')
+        && failureClassFromCompleteStopReason(event.stopReason) !== undefined
       ) {
         errored = true;
       }

--- a/packages/core/src/__tests__/events.test.ts
+++ b/packages/core/src/__tests__/events.test.ts
@@ -1,6 +1,7 @@
 import { describe, test } from 'node:test';
 import { expect } from '../test-helpers.js';
 import {
+  failureClassFromCompleteStopReason,
   TOOL_OUTPUT_DELTA_MAX_CHARS,
   TOOL_OUTPUT_STREAMS,
   type SessionEvent,
@@ -32,5 +33,17 @@ describe('ToolOutputDelta event contract', () => {
     if (event.type !== 'tool_output_delta') throw new Error('unreachable');
     expect(event.seq).toBe(1);
     expect(event.stream).toBe('stdout');
+  });
+});
+
+describe('failureClassFromCompleteStopReason', () => {
+  test('defines the shared failure vocabulary for incomplete turns', () => {
+    expect(failureClassFromCompleteStopReason('error')).toBe('runtime_error');
+    expect(failureClassFromCompleteStopReason('step_limit')).toBe('tool_step_cap_reached');
+    expect(failureClassFromCompleteStopReason('end_turn')).toBe(undefined);
+    expect(failureClassFromCompleteStopReason('max_tokens')).toBe(undefined);
+    expect(failureClassFromCompleteStopReason('plan_handoff')).toBe(undefined);
+    expect(failureClassFromCompleteStopReason('permission_handoff')).toBe(undefined);
+    expect(failureClassFromCompleteStopReason('user_stop')).toBe(undefined);
   });
 });

--- a/packages/core/src/events.ts
+++ b/packages/core/src/events.ts
@@ -447,6 +447,7 @@ export interface CompleteEvent extends BaseEvent {
     | 'error'
     | 'plan_handoff'
     | 'permission_handoff'
+    | 'step_limit'
     | 'max_tokens';
 }
 

--- a/packages/core/src/events.ts
+++ b/packages/core/src/events.ts
@@ -451,6 +451,17 @@ export interface CompleteEvent extends BaseEvent {
     | 'max_tokens';
 }
 
+export type CompleteStopReason = CompleteEvent['stopReason'];
+
+/** Stable failure taxonomy for complete events that did not finish the turn. */
+export function failureClassFromCompleteStopReason(
+  reason: CompleteStopReason,
+): 'runtime_error' | 'tool_step_cap_reached' | undefined {
+  if (reason === 'error') return 'runtime_error';
+  if (reason === 'step_limit') return 'tool_step_cap_reached';
+  return undefined;
+}
+
 export interface AbortEvent extends BaseEvent {
   type: 'abort';
   reason: 'user_stop' | 'redirect' | 'timeout' | 'crash';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -114,6 +114,7 @@ export {
   SESSION_STATUSES,
   SESSION_BLOCKED_REASONS,
   TURN_STATUSES,
+  STEP_LIMIT_NOTICE_TEXT,
   deriveTurnRecords,
   isSessionStatus,
   isSessionBlockedReason,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -33,8 +33,10 @@ export type {
   StorageRef,
   AttachmentRef,
   AttachmentIngestItem,
+  CompleteStopReason,
 } from './events.js';
 export {
+  failureClassFromCompleteStopReason,
   TOOL_ACTIVITY_KINDS,
   TOOL_OUTPUT_DELTA_MAX_CHARS,
   TOOL_OUTPUT_STREAMS,

--- a/packages/core/src/session.ts
+++ b/packages/core/src/session.ts
@@ -333,11 +333,15 @@ export interface SystemNoteMessage {
     | 'model_change'
     | 'context_compacted'
     | 'context_compaction_failed_open'
+    | 'step_limit'
     | 'error'
     | 'abort';
   /** Shape depends on `kind`. */
   data?: unknown;
 }
+
+export const STEP_LIMIT_NOTICE_TEXT =
+  'Reached the configured step limit. The task may be incomplete. Send “continue” to resume.';
 
 export function deriveTurnRecords(messages: readonly StoredMessage[]): TurnRecord[] {
   const order: string[] = [];

--- a/packages/core/src/usage-stats/types.ts
+++ b/packages/core/src/usage-stats/types.ts
@@ -54,7 +54,7 @@ export interface UsageBucket {
 export interface UsageLogRow {
   id: string;
   ts: number;
-  callKind?: 'main' | 'semantic_compact';
+  callKind?: 'main' | 'semantic_compact' | 'step_limit_finalization';
   callId?: string;
   connectionSlug?: string;
   providerId: string;
@@ -99,7 +99,7 @@ export interface LlmCallRecord {
    * Distinguishes the main agent stream from auxiliary model calls such as
    * semantic compaction. Omitted means the historical main stream call.
    */
-  callKind?: 'main' | 'semantic_compact';
+  callKind?: 'main' | 'semantic_compact' | 'step_limit_finalization';
   /** Stable id for auxiliary calls so multiple records in one turn do not collide. */
   callId?: string;
   connectionSlug?: string;

--- a/packages/core/src/usage-stats/types.ts
+++ b/packages/core/src/usage-stats/types.ts
@@ -54,7 +54,7 @@ export interface UsageBucket {
 export interface UsageLogRow {
   id: string;
   ts: number;
-  callKind?: 'main' | 'semantic_compact' | 'step_limit_finalization';
+  callKind?: 'main' | 'semantic_compact';
   callId?: string;
   connectionSlug?: string;
   providerId: string;
@@ -99,7 +99,7 @@ export interface LlmCallRecord {
    * Distinguishes the main agent stream from auxiliary model calls such as
    * semantic compaction. Omitted means the historical main stream call.
    */
-  callKind?: 'main' | 'semantic_compact' | 'step_limit_finalization';
+  callKind?: 'main' | 'semantic_compact';
   /** Stable id for auxiliary calls so multiple records in one turn do not collide. */
   callId?: string;
   connectionSlug?: string;

--- a/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
+++ b/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
@@ -3549,6 +3549,80 @@ describe('AiSdkBackend usage telemetry', () => {
     assert.equal(loop.callCount(), 3);
   });
 
+  test('finalizes an explicit step limit without tools even after earlier assistant text', async () => {
+    const appended: StoredMessage[] = [];
+    const llmRecords: LlmCallRecord[] = [];
+    let streamCalls = 0;
+    const model = new MockLanguageModelV3({
+      doGenerate: {
+        content: [{ type: 'text', text: 'Completed the edits; verification is still pending. Send continue to resume.' }],
+        finishReason: { unified: 'stop', raw: 'stop' },
+        usage: {
+          inputTokens: { total: 5, noCache: 5, cacheRead: 0, cacheWrite: 0 },
+          outputTokens: { total: 4, text: 4, reasoning: 0 },
+        },
+        warnings: [],
+      },
+      doStream: async () => {
+        streamCalls += 1;
+        return {
+          stream: simulateReadableStream({
+            chunks: [
+              { type: 'stream-start', warnings: [] },
+              { type: 'text-start', id: `text-${streamCalls}` },
+              { type: 'text-delta', id: `text-${streamCalls}`, delta: 'Still working.' },
+              { type: 'text-end', id: `text-${streamCalls}` },
+              {
+                type: 'tool-call',
+                toolCallId: `tool-${streamCalls}`,
+                toolName: 'Read',
+                input: JSON.stringify({ path: `notes-${streamCalls}.md` }),
+              },
+              {
+                type: 'finish',
+                finishReason: { unified: 'tool-calls', raw: 'tool_calls' },
+                usage: { inputTokens: { total: 1, noCache: 1, cacheRead: 0, cacheWrite: 0 }, outputTokens: { total: 1, text: 1, reasoning: 0 } },
+              },
+            ],
+            initialDelayInMs: null,
+            chunkDelayInMs: null,
+          }),
+        };
+      },
+    });
+    const backend = new AiSdkBackend({
+      sessionId: 'session-1',
+      header: header(),
+      appendMessage: async (message) => { appended.push(message); },
+      connection: connection(),
+      apiKey: 'sk-test',
+      modelId: 'mock-model-id',
+      permissionEngine: new PermissionEngine({ newId: () => 'permission-id', now: () => 1 }),
+      modelFactory: () => model,
+      tools: [testTool('Read', z.object({ path: z.string() }))],
+      maxSteps: 2,
+      recordLlmCall: (record) => { llmRecords.push(record); },
+      newId: idGenerator(),
+      now: monotonicClock(),
+    });
+
+    const events: SessionEvent[] = [];
+    for await (const event of backend.send({ turnId: 'turn-1', text: 'finish the task', context: [] })) {
+      events.push(event);
+    }
+
+    assert.equal(streamCalls, 2);
+    assert.equal(model.doGenerateCalls.length, 1);
+    assert.equal(model.doGenerateCalls[0]?.tools, undefined);
+    assert.equal(llmRecords.filter((record) => record.callKind === 'step_limit_finalization').length, 1);
+    assert.equal(
+      appended.filter((message): message is AssistantMessage => message.type === 'assistant').at(-1)?.text,
+      'Completed the edits; verification is still pending. Send continue to resume.',
+    );
+    assert.equal(events.at(-1)?.type, 'complete');
+    assert.equal((events.at(-1) as Extract<SessionEvent, { type: 'complete' }>).stopReason as string, 'step_limit');
+  });
+
   test('records aggregate totalUsage across AI SDK tool-loop steps', async () => {
     const messages: unknown[] = [];
     const events: SessionEvent[] = [];

--- a/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
+++ b/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
@@ -3549,9 +3549,8 @@ describe('AiSdkBackend usage telemetry', () => {
     assert.equal(loop.callCount(), 3);
   });
 
-  test('finalizes an explicit step limit without tools even after earlier assistant text', async () => {
+  test('reports an explicit step limit without making an auxiliary model call', async () => {
     const appended: StoredMessage[] = [];
-    const llmRecords: LlmCallRecord[] = [];
     let streamCalls = 0;
     const model = new MockLanguageModelV3({
       doGenerate: {
@@ -3601,7 +3600,6 @@ describe('AiSdkBackend usage telemetry', () => {
       modelFactory: () => model,
       tools: [testTool('Read', z.object({ path: z.string() }))],
       maxSteps: 2,
-      recordLlmCall: (record) => { llmRecords.push(record); },
       newId: idGenerator(),
       now: monotonicClock(),
     });
@@ -3612,12 +3610,10 @@ describe('AiSdkBackend usage telemetry', () => {
     }
 
     assert.equal(streamCalls, 2);
-    assert.equal(model.doGenerateCalls.length, 1);
-    assert.equal(model.doGenerateCalls[0]?.tools, undefined);
-    assert.equal(llmRecords.filter((record) => record.callKind === 'step_limit_finalization').length, 1);
+    assert.equal(model.doGenerateCalls.length, 0);
     assert.equal(
       appended.filter((message): message is AssistantMessage => message.type === 'assistant').at(-1)?.text,
-      'Completed the edits; verification is still pending. Send continue to resume.',
+      'Still working.',
     );
     assert.equal(events.at(-1)?.type, 'complete');
     assert.equal((events.at(-1) as Extract<SessionEvent, { type: 'complete' }>).stopReason as string, 'step_limit');
@@ -6842,13 +6838,7 @@ describe('AiSdkBackend thinking persistence', () => {
     assert.match(prompt, /sig-omitted/);
   });
 
-  test('grace notice never reuses a taken step id when the stream ends without a trailing finish-step', async () => {
-    // ChatGPT P2: on the catch-all path (no trailing finish-step) the last
-    // step's id is already taken — by the thinking-only AssistantMessage the
-    // catch-all flush just wrote, and by the tool step's tool_start.stepId. The
-    // grace notice must mint its own id or the ledger gets a duplicate message
-    // id / replay adopts the grace text as the tool step's closer.
-    //
+  test('does not synthesize assistant text when a capped stream ends without a trailing finish-step', async () => {
     // streamText always synthesizes trailing step boundaries, so drive the
     // backend through a patched startStream: step 1 runs a real tool via the
     // wrapped execute (genuine tool_start.stepId), step 2 is thinking-only and
@@ -6895,20 +6885,12 @@ describe('AiSdkBackend thinking persistence', () => {
     }
 
     const assistants = appended.filter((m): m is AssistantMessage => m.type === 'assistant');
-    // Catch-all flush persisted the thinking-only step; grace added its own row.
-    assert.equal(assistants.length, 2);
+    // Catch-all flush persists the thinking-only step, but the harness owns the
+    // visible step-limit notice instead of fabricating another assistant row.
+    assert.equal(assistants.length, 1);
     const thinkingOnly = assistants.find((m) => m.thinking?.signature === 'sig-last');
-    const grace = assistants.find((m) => m.text.includes('步工具调用上限'));
     assert.ok(thinkingOnly, 'thinking-only last step must persist');
-    assert.ok(grace, 'grace notice must persist');
-    // The grace id collides with nothing: not the last step's assistant row...
-    assert.notEqual(grace.id, thinkingOnly.id);
-    // ...and not any tool step's stepId.
-    const toolStepIds = events
-      .filter((event): event is Extract<SessionEvent, { type: 'tool_start' }> => event.type === 'tool_start')
-      .map((event) => event.stepId);
-    assert.equal(toolStepIds.length, 1);
-    assert.equal(toolStepIds.includes(grace.id), false);
+    assert.equal(thinkingOnly.text, '');
     // No duplicate message ids anywhere in the ledger.
     const ids = appended.map((m) => (m as { id: string }).id);
     assert.equal(new Set(ids).size, ids.length, `duplicate ledger ids: ${ids.join(', ')}`);

--- a/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
+++ b/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
@@ -2381,6 +2381,47 @@ describe('AiSdkBackend model history', () => {
     );
   });
 
+  test('aborting during post-stream persistence wins over step-limit completion', async () => {
+    const loop = countingToolLoopModel();
+    const gate = makeGate();
+    let usagePersistenceStarted = false;
+    const backend = new AiSdkBackend({
+      sessionId: 'session-1',
+      header: header(),
+      appendMessage: async (message) => {
+        if (message.type !== 'token_usage') return;
+        usagePersistenceStarted = true;
+        await gate.promise;
+      },
+      connection: connection(),
+      apiKey: 'sk-test',
+      modelId: 'mock-model-id',
+      permissionEngine: new PermissionEngine({ newId: () => 'permission-id', now: () => 1 }),
+      modelFactory: () => loop.model,
+      tools: [testTool('Read', z.object({ path: z.string() }))],
+      maxSteps: 1,
+      newId: idGenerator(),
+      now: monotonicClock(),
+    });
+    const events: SessionEvent[] = [];
+    const sendPromise = (async () => {
+      for await (const event of backend.send({ turnId: 'turn-1', text: 'hi', context: [] })) {
+        events.push(event);
+      }
+    })();
+
+    await waitFor(() => usagePersistenceStarted);
+    await backend.stop('user_stop');
+    gate.release();
+    await sendPromise;
+
+    assert.equal(events.some((event) => event.type === 'abort' && event.reason === 'user_stop'), true);
+    assert.equal(
+      events.some((event) => event.type === 'complete' && event.stopReason === 'step_limit'),
+      false,
+    );
+  });
+
   test('provider error mid-step still persists the streamed partial text (partialOutputRetained)', async () => {
     // Codex P1: the non-abort error exit (provider failure / watchdog timeout)
     // must flush the in-flight step's partial accumulators just like the abort

--- a/packages/runtime/src/__tests__/ai-sdk-flow.test.ts
+++ b/packages/runtime/src/__tests__/ai-sdk-flow.test.ts
@@ -608,6 +608,19 @@ describe('mapSessionEventToRuntimeEvent (pure)', () => {
     assert.equal(mapCompleteStopReason('step_limit'), 'failed');
   });
 
+  test('step_limit uses the established tool-step-cap failure class', () => {
+    const mapped = mapSessionEventToRuntimeEvent(
+      ev({ type: 'complete', stopReason: 'step_limit' }),
+      ctx,
+      createSessionEventMapMemory(),
+    );
+
+    assert.deepEqual(mapped.actions?.stateDelta, {
+      stopReason: 'step_limit',
+      failureClass: 'tool_step_cap_reached',
+    });
+  });
+
   test('tool_output_delta and tool_progress map to partial tool-role heartbeats', () => {
     const mem = createSessionEventMapMemory();
     const a = mapSessionEventToRuntimeEvent(

--- a/packages/runtime/src/__tests__/ai-sdk-flow.test.ts
+++ b/packages/runtime/src/__tests__/ai-sdk-flow.test.ts
@@ -605,6 +605,7 @@ describe('mapSessionEventToRuntimeEvent (pure)', () => {
     assert.equal(mapCompleteStopReason('permission_handoff'), 'completed');
     assert.equal(mapCompleteStopReason('user_stop'), 'aborted');
     assert.equal(mapCompleteStopReason('error'), 'failed');
+    assert.equal(mapCompleteStopReason('step_limit'), 'failed');
   });
 
   test('tool_output_delta and tool_progress map to partial tool-role heartbeats', () => {

--- a/packages/runtime/src/__tests__/runtime-event-read-model.test.ts
+++ b/packages/runtime/src/__tests__/runtime-event-read-model.test.ts
@@ -596,6 +596,30 @@ describe('projectRuntimeEventsToStoredMessages', () => {
     expect(out.diagnostics).toEqual([]);
   });
 
+  test('tool step cap terminal fact projects a persistent system notice', () => {
+    const out = projectRuntimeEventsToStoredMessages([
+      ev({
+        id: 'evt-step-limit',
+        ts: ts + 9,
+        status: 'failed',
+        actions: {
+          endInvocation: true,
+          stateDelta: { stopReason: 'step_limit', failureClass: 'tool_step_cap_reached' },
+        },
+      }),
+    ], {
+      runHeaders: [{ ...header, status: 'failed', failureClass: 'tool_step_cap_reached' }],
+    });
+
+    expect(out.messages.find((message) => message.type === 'system_note')).toEqual({
+      type: 'system_note',
+      id: 'evt-step-limit:step-limit-notice',
+      turnId,
+      ts: ts + 9,
+      kind: 'step_limit',
+    });
+  });
+
   test('aborted terminal RuntimeEvent preserves abort source from runtime state', () => {
     const out = projectRuntimeEventsToStoredMessages([
       ev({

--- a/packages/runtime/src/__tests__/runtime-runner.test.ts
+++ b/packages/runtime/src/__tests__/runtime-runner.test.ts
@@ -493,7 +493,7 @@ describe('RuntimeRunner', () => {
       ...flowTerminalEvent(ctx, 'failed'),
       actions: {
         endInvocation: true,
-        stateDelta: { stopReason: 'step_limit', failureClass: 'step_limit' },
+        stateDelta: { stopReason: 'step_limit', failureClass: 'tool_step_cap_reached' },
       },
     }]);
     const runner = new RuntimeRunner({ flow, providers });
@@ -501,7 +501,7 @@ describe('RuntimeRunner', () => {
     const result = await runner.run(makeRequest());
 
     expect(result.status).toBe('failed');
-    expect(result.failure?.class).toBe('step_limit');
+    expect(result.failure?.class).toBe('tool_step_cap_reached');
     expect(result.failure?.terminalStatus).toBe('failed');
   });
 

--- a/packages/runtime/src/__tests__/runtime-runner.test.ts
+++ b/packages/runtime/src/__tests__/runtime-runner.test.ts
@@ -487,6 +487,24 @@ describe('RuntimeRunner', () => {
     expect(result.failure?.terminalStatus).toBe('failed');
   });
 
+  test('a failed terminal event preserves its state-delta failure class', async () => {
+    const providers = makeProviders();
+    const flow = new ScriptFlow((ctx) => [{
+      ...flowTerminalEvent(ctx, 'failed'),
+      actions: {
+        endInvocation: true,
+        stateDelta: { stopReason: 'step_limit', failureClass: 'step_limit' },
+      },
+    }]);
+    const runner = new RuntimeRunner({ flow, providers });
+
+    const result = await runner.run(makeRequest());
+
+    expect(result.status).toBe('failed');
+    expect(result.failure?.class).toBe('step_limit');
+    expect(result.failure?.terminalStatus).toBe('failed');
+  });
+
   test('omitting the gate means preflight always passes', async () => {
     const providers = makeProviders();
     const flow = new ScriptFlow((ctx) => [

--- a/packages/runtime/src/__tests__/session-manager-terminal-ledger.test.ts
+++ b/packages/runtime/src/__tests__/session-manager-terminal-ledger.test.ts
@@ -196,17 +196,13 @@ describe('SessionManager terminal ledger invariants', () => {
     expect(terminals.map((event) => event.id)).toEqual(['terminal-one']);
   });
 
-  test('synthetic finalization claims its terminal outcome before persistence', async () => {
-    const terminalAppendStarted = deferred<void>();
-    const releaseTerminalAppend = deferred<void>();
+  test('synthetic finalization claims its terminal outcome before its first await', async () => {
+    const headerUpdateStarted = deferred<void>();
+    const releaseHeaderUpdate = deferred<void>();
     const store = new TinySessionStore();
-    const runStore = new TinyAgentRunStore({
-      beforeTerminalRuntimeEventAppend: async () => {
-        terminalAppendStarted.resolve();
-        await releaseTerminalAppend.promise;
-      },
-    });
+    const runStore = new TinyAgentRunStore();
     const session = await store.create(makeInput());
+    const hooks = inertAgentRunHooks(store);
     const run = new AgentRun({
       sessionId: session.id,
       header: session,
@@ -216,7 +212,14 @@ describe('SessionManager terminal ledger invariants', () => {
       runtimeEventStore: runStore,
       newId: nextId(),
       now: nextNow(23_000),
-      hooks: inertAgentRunHooks(store),
+      hooks: {
+        ...hooks,
+        updateHeader: async (sessionId, patch) => {
+          headerUpdateStarted.resolve();
+          await releaseHeaderUpdate.promise;
+          return store.updateHeader(sessionId, patch);
+        },
+      },
     });
     await runStore.createRun(makeRunHeader({
       sessionId: session.id,
@@ -225,9 +228,9 @@ describe('SessionManager terminal ledger invariants', () => {
     }));
 
     const finalization = run.finalize();
-    await terminalAppendStarted.promise;
+    await headerUpdateStarted.promise;
     expect(run.stop('stop_button')).toBe(false);
-    releaseTerminalAppend.resolve();
+    releaseHeaderUpdate.resolve();
     await finalization;
 
     const header = await runStore.readRun(session.id, run.runId);

--- a/packages/runtime/src/__tests__/session-manager-terminal-ledger.test.ts
+++ b/packages/runtime/src/__tests__/session-manager-terminal-ledger.test.ts
@@ -105,6 +105,46 @@ describe('SessionManager terminal ledger invariants', () => {
     expect(terminalEvents[0]?.actions?.stateDelta?.abortSource).toBe('renderer.stop_button');
   });
 
+  test('terminal acceptance wins over a later stop during terminal persistence', async () => {
+    const terminalAppendStarted = deferred<void>();
+    const releaseTerminalAppend = deferred<void>();
+    const store = new TinySessionStore();
+    const runStore = new TinyAgentRunStore({
+      beforeTerminalRuntimeEventAppend: async () => {
+        terminalAppendStarted.resolve();
+        await releaseTerminalAppend.promise;
+      },
+    });
+    const backends = new BackendRegistry();
+    backends.register('fake', (ctx) => new ScriptBackend(ctx, [
+      { type: 'complete', stopReason: 'step_limit' },
+    ]));
+    const manager = new SessionManager({
+      store,
+      runStore,
+      runtimeEventStore: runStore,
+      backends,
+      newId: nextId(),
+      now: nextNow(21_000),
+      runtimeSource: 'test',
+    });
+    const session = await manager.createSession(makeInput());
+
+    const sendPromise = drain(manager.sendMessage(session.id, { turnId: 'turn-1', text: 'hello' }));
+    await terminalAppendStarted.promise;
+    await manager.stopSession(session.id, { source: 'stop_button' });
+    releaseTerminalAppend.resolve();
+    await sendPromise;
+
+    expect((await store.readHeader(session.id)).status).toBe('active');
+    const [run] = await runStore.listSessionRuns(session.id);
+    expect(run?.status).toBe('failed');
+    expect(run?.failureClass).toBe('tool_step_cap_reached');
+    const terminalEvents = (await runStore.readRuntimeEvents(session.id, run!.runId)).filter(isTerminalRuntimeEvent);
+    expect(terminalEvents).toHaveLength(1);
+    expect(terminalEvents[0]?.status).toBe('failed');
+  });
+
   test('terminal run commits reject mismatched terminal RuntimeEvent statuses', async () => {
     const runStore = new TinyAgentRunStore();
     const run = makeRunHeader({ status: 'running' });
@@ -1237,7 +1277,10 @@ class TinyAgentRunStore implements AgentRunStore, RuntimeEventStore {
   private events = new Map<string, AgentRunEvent[]>();
   private runtimeEvents = new Map<string, RuntimeEvent[]>();
 
-  constructor(private readonly options: { failTerminalRuntimeEventAppends?: boolean } = {}) {}
+  constructor(private readonly options: {
+    failTerminalRuntimeEventAppends?: boolean;
+    beforeTerminalRuntimeEventAppend?: () => Promise<void>;
+  } = {}) {}
 
   async createRun(header: AgentRunHeader): Promise<AgentRunHeader> {
     this.headers.set(key(header.sessionId, header.runId), clone(header));
@@ -1277,6 +1320,7 @@ class TinyAgentRunStore implements AgentRunStore, RuntimeEventStore {
     if (this.options.failTerminalRuntimeEventAppends && isTerminalRuntimeEvent(event)) {
       throw new Error('terminal runtime event append failed');
     }
+    if (isTerminalRuntimeEvent(event)) await this.options.beforeTerminalRuntimeEventAppend?.();
     const eventKey = key(sessionId, runId);
     this.runtimeEvents.set(eventKey, [...(this.runtimeEvents.get(eventKey) ?? []), clone(event)]);
   }

--- a/packages/runtime/src/__tests__/session-manager-terminal-ledger.test.ts
+++ b/packages/runtime/src/__tests__/session-manager-terminal-ledger.test.ts
@@ -145,6 +145,99 @@ describe('SessionManager terminal ledger invariants', () => {
     expect(terminalEvents[0]?.status).toBe('failed');
   });
 
+  test('concurrent terminal writes reserve exactly one terminal fact', async () => {
+    const terminalAppendStarted = deferred<void>();
+    const releaseTerminalAppend = deferred<void>();
+    const store = new TinySessionStore();
+    const runStore = new TinyAgentRunStore({
+      beforeTerminalRuntimeEventAppend: async () => {
+        terminalAppendStarted.resolve();
+        await releaseTerminalAppend.promise;
+      },
+    });
+    const session = await store.create(makeInput());
+    const run = new AgentRun({
+      sessionId: session.id,
+      header: session,
+      userInput: { turnId: 'turn-1', text: 'hello' },
+      store,
+      runStore,
+      runtimeEventStore: runStore,
+      newId: nextId(),
+      now: nextNow(22_000),
+      hooks: inertAgentRunHooks(store),
+    });
+    await runStore.createRun(makeRunHeader({
+      sessionId: session.id,
+      runId: run.runId,
+      turnId: run.turnId,
+    }));
+    const first = run.recordRuntimeEvents([runtimeEvent({
+      id: 'terminal-one',
+      sessionId: session.id,
+      runId: run.runId,
+      turnId: run.turnId,
+      status: 'completed',
+      actions: { endInvocation: true },
+    })]);
+    await terminalAppendStarted.promise;
+    const second = run.recordRuntimeEvents([runtimeEvent({
+      id: 'terminal-two',
+      sessionId: session.id,
+      runId: run.runId,
+      turnId: run.turnId,
+      status: 'failed',
+      actions: { endInvocation: true },
+    })]);
+    releaseTerminalAppend.resolve();
+    await Promise.all([first, second]);
+
+    const terminals = (await runStore.readRuntimeEvents(session.id, run.runId)).filter(isTerminalRuntimeEvent);
+    expect(terminals.map((event) => event.id)).toEqual(['terminal-one']);
+  });
+
+  test('synthetic finalization claims its terminal outcome before persistence', async () => {
+    const terminalAppendStarted = deferred<void>();
+    const releaseTerminalAppend = deferred<void>();
+    const store = new TinySessionStore();
+    const runStore = new TinyAgentRunStore({
+      beforeTerminalRuntimeEventAppend: async () => {
+        terminalAppendStarted.resolve();
+        await releaseTerminalAppend.promise;
+      },
+    });
+    const session = await store.create(makeInput());
+    const run = new AgentRun({
+      sessionId: session.id,
+      header: session,
+      userInput: { turnId: 'turn-1', text: 'hello' },
+      store,
+      runStore,
+      runtimeEventStore: runStore,
+      newId: nextId(),
+      now: nextNow(23_000),
+      hooks: inertAgentRunHooks(store),
+    });
+    await runStore.createRun(makeRunHeader({
+      sessionId: session.id,
+      runId: run.runId,
+      turnId: run.turnId,
+    }));
+
+    const finalization = run.finalize();
+    await terminalAppendStarted.promise;
+    expect(run.stop('stop_button')).toBe(false);
+    releaseTerminalAppend.resolve();
+    await finalization;
+
+    const header = await runStore.readRun(session.id, run.runId);
+    expect(header.status).toBe('failed');
+    expect(header.failureClass).toBe('missing_terminal_event');
+    const terminals = (await runStore.readRuntimeEvents(session.id, run.runId)).filter(isTerminalRuntimeEvent);
+    expect(terminals).toHaveLength(1);
+    expect(terminals[0]?.status).toBe('failed');
+  });
+
   test('terminal run commits reject mismatched terminal RuntimeEvent statuses', async () => {
     const runStore = new TinyAgentRunStore();
     const run = makeRunHeader({ status: 'running' });
@@ -1399,6 +1492,19 @@ function nextId(): () => string {
 function nextNow(start: number): () => number {
   let ts = start;
   return () => ++ts;
+}
+
+function inertAgentRunHooks(store: TinySessionStore) {
+  return {
+    ensureActive: async () => {
+      throw new Error('ensureActive should not be called');
+    },
+    registerRun: () => {},
+    unregisterRun: () => {},
+    updateHeader: (sessionId: string, patch: Partial<SessionHeader>) => store.updateHeader(sessionId, patch),
+    updateStatus: async () => {},
+    appendTurnState: async () => {},
+  };
 }
 
 async function drain(iterable: AsyncIterable<unknown>): Promise<void> {

--- a/packages/runtime/src/__tests__/session-manager.test.ts
+++ b/packages/runtime/src/__tests__/session-manager.test.ts
@@ -3233,6 +3233,43 @@ describe('SessionManager permission mode updates', () => {
     while (!(await child.next()).done) {}
   });
 
+  test('stopSession retries only unfinished projections', async () => {
+    const store = new MemorySessionStore();
+    const runStore = new MemoryAgentRunStore();
+    const backends = new BackendRegistry();
+    const sendGate = makeGate();
+    let backend: CountingStopBackend | undefined;
+    backends.register('fake', (ctx) => {
+      backend = new CountingStopBackend(ctx, sendGate);
+      return backend;
+    });
+    const manager = new SessionManager({
+      store,
+      runStore,
+      runtimeEventStore: runStore,
+      backends,
+      newId: nextId(),
+      now: nextNow(6_849),
+      runtimeSource: 'test',
+    });
+    const session = await manager.createSession(makeInput());
+    const turn = manager.sendMessage(session.id, { turnId: 'turn-1', text: 'hello' })[Symbol.asyncIterator]();
+    await turn.next();
+    store.failNextAppendMessage = (message) => message.type === 'system_note' && message.kind === 'abort';
+
+    await expectRejects(manager.stopSession(session.id, { source: 'stop_button' }), /append message failed/);
+    await manager.stopSession(session.id, { source: 'stop_button' });
+
+    expect(backend?.stopCalls).toBe(1);
+    const messages = await store.readMessages(session.id);
+    expect(messages.filter((message) =>
+      message.type === 'turn_state' && message.turnId === 'turn-1' && message.status === 'aborted'
+    )).toHaveLength(1);
+    expect(messages.filter((message) => message.type === 'system_note' && message.kind === 'abort')).toHaveLength(1);
+    sendGate.release();
+    while (!(await turn.next()).done) {}
+  });
+
   test('spawnChildAgent fails closed instead of running a degraded catalog agent', async () => {
     const store = new MemorySessionStore();
     const runStore = new MemoryAgentRunStore();
@@ -6406,6 +6443,7 @@ class MemorySessionStore implements SessionStore {
   readonly failListTurnsFor = new Set<string>();
   readonly failUpdateHeaderFor = new Set<string>();
   readonly interleaveBeforeMarkSessionReadWriteFor = new Map<string, () => Promise<void> | void>();
+  failNextAppendMessage: ((message: StoredMessage) => boolean) | undefined;
   disposeCount = 0;
 
   async create(input: CreateSessionInput): Promise<SessionHeader> {
@@ -6470,6 +6508,10 @@ class MemorySessionStore implements SessionStore {
   }
 
   async appendMessages(sessionId: string, messages: StoredMessage[]): Promise<void> {
+    if (this.failNextAppendMessage && messages.some(this.failNextAppendMessage)) {
+      this.failNextAppendMessage = undefined;
+      throw new Error('append message failed');
+    }
     this.messages.set(sessionId, [...(this.messages.get(sessionId) ?? []), ...messages]);
   }
 

--- a/packages/runtime/src/__tests__/session-manager.test.ts
+++ b/packages/runtime/src/__tests__/session-manager.test.ts
@@ -3255,7 +3255,7 @@ describe('SessionManager permission mode updates', () => {
     const session = await manager.createSession(makeInput());
     const turn = manager.sendMessage(session.id, { turnId: 'turn-1', text: 'hello' })[Symbol.asyncIterator]();
     await turn.next();
-    store.failNextAppendMessage = (message) => message.type === 'system_note' && message.kind === 'abort';
+    store.failAfterNextAppendMessage = (message) => message.type === 'system_note' && message.kind === 'abort';
 
     await expectRejects(manager.stopSession(session.id, { source: 'stop_button' }), /append message failed/);
     await manager.stopSession(session.id, { source: 'stop_button' });
@@ -6444,6 +6444,7 @@ class MemorySessionStore implements SessionStore {
   readonly failUpdateHeaderFor = new Set<string>();
   readonly interleaveBeforeMarkSessionReadWriteFor = new Map<string, () => Promise<void> | void>();
   failNextAppendMessage: ((message: StoredMessage) => boolean) | undefined;
+  failAfterNextAppendMessage: ((message: StoredMessage) => boolean) | undefined;
   disposeCount = 0;
 
   async create(input: CreateSessionInput): Promise<SessionHeader> {
@@ -6513,6 +6514,10 @@ class MemorySessionStore implements SessionStore {
       throw new Error('append message failed');
     }
     this.messages.set(sessionId, [...(this.messages.get(sessionId) ?? []), ...messages]);
+    if (this.failAfterNextAppendMessage && messages.some(this.failAfterNextAppendMessage)) {
+      this.failAfterNextAppendMessage = undefined;
+      throw new Error('append message failed');
+    }
   }
 
   async updateHeader(sessionId: string, patch: Partial<SessionHeader>): Promise<SessionHeader> {

--- a/packages/runtime/src/__tests__/session-manager.test.ts
+++ b/packages/runtime/src/__tests__/session-manager.test.ts
@@ -3676,13 +3676,13 @@ describe('SessionManager permission mode updates', () => {
     expect((await store.readHeader(session.id)).status).toBe('active');
     const [turn] = await store.listTurns(session.id);
     expect(turn?.status).toBe('failed');
-    expect(turn?.errorClass).toBe('step_limit');
+    expect(turn?.errorClass).toBe('tool_step_cap_reached');
     const [run] = await runStore.listSessionRuns(session.id);
     expect(run?.status).toBe('failed');
-    expect(run?.failureClass).toBe('step_limit');
+    expect(run?.failureClass).toBe('tool_step_cap_reached');
     const terminal = (await runStore.readRuntimeEvents(session.id, run!.runId)).find((event) => event.actions?.endInvocation);
     expect(terminal?.status).toBe('failed');
-    expect(terminal?.actions?.stateDelta).toMatchObject({ stopReason: 'step_limit', failureClass: 'step_limit' });
+    expect(terminal?.actions?.stateDelta).toMatchObject({ stopReason: 'step_limit', failureClass: 'tool_step_cap_reached' });
   });
 
   test('does not let a late complete event overwrite a prior turn error', async () => {

--- a/packages/runtime/src/__tests__/session-manager.test.ts
+++ b/packages/runtime/src/__tests__/session-manager.test.ts
@@ -3659,6 +3659,32 @@ describe('SessionManager permission mode updates', () => {
     expect(run?.failureClass).toBe('runtime_error');
   });
 
+  test('marks an explicit step limit incomplete without blocking the session', async () => {
+    const store = new MemorySessionStore();
+    const runStore = new MemoryAgentRunStore();
+    const backends = new BackendRegistry();
+    backends.register('fake', (ctx) => new EventBackend(ctx, [
+      { type: 'complete', stopReason: 'step_limit' },
+    ]));
+    const manager = new SessionManager({
+      store, runStore, runtimeEventStore: runStore, backends, newId: nextId(), now: nextNow(10_000),
+    });
+    const session = await manager.createSession(makeInput());
+
+    await drain(manager.sendMessage(session.id, { turnId: 'turn-1', text: 'hello' }));
+
+    expect((await store.readHeader(session.id)).status).toBe('active');
+    const [turn] = await store.listTurns(session.id);
+    expect(turn?.status).toBe('failed');
+    expect(turn?.errorClass).toBe('step_limit');
+    const [run] = await runStore.listSessionRuns(session.id);
+    expect(run?.status).toBe('failed');
+    expect(run?.failureClass).toBe('step_limit');
+    const terminal = (await runStore.readRuntimeEvents(session.id, run!.runId)).find((event) => event.actions?.endInvocation);
+    expect(terminal?.status).toBe('failed');
+    expect(terminal?.actions?.stateDelta).toMatchObject({ stopReason: 'step_limit', failureClass: 'step_limit' });
+  });
+
   test('does not let a late complete event overwrite a prior turn error', async () => {
     const store = new MemorySessionStore();
     const backends = new BackendRegistry();

--- a/packages/runtime/src/__tests__/session-manager.test.ts
+++ b/packages/runtime/src/__tests__/session-manager.test.ts
@@ -3139,6 +3139,45 @@ describe('SessionManager permission mode updates', () => {
     expect(childRun?.status).toBe('cancelled');
   });
 
+  test('concurrent stopSession calls share one stop attempt', async () => {
+    const store = new MemorySessionStore();
+    const runStore = new MemoryAgentRunStore();
+    const backends = new BackendRegistry();
+    const stopStarted = makeGate();
+    const releaseStop = makeGate();
+    let backend: ConcurrentStopBackend | undefined;
+    backends.register('fake', (ctx) => {
+      backend = new ConcurrentStopBackend(ctx, stopStarted, releaseStop);
+      return backend;
+    });
+    const manager = new SessionManager({
+      store,
+      runStore,
+      runtimeEventStore: runStore,
+      backends,
+      newId: nextId(),
+      now: nextNow(6_847),
+      runtimeSource: 'test',
+    });
+    const session = await manager.createSession(makeInput());
+    const turn = manager.sendMessage(session.id, { turnId: 'turn-1', text: 'hello' })[Symbol.asyncIterator]();
+    await turn.next();
+
+    const firstStop = manager.stopSession(session.id, { source: 'stop_button' });
+    await stopStarted.promise;
+    const secondStop = manager.stopSession(session.id, { source: 'stop_button' });
+    releaseStop.release();
+    await Promise.all([firstStop, secondStop]);
+    while (!(await turn.next()).done) {}
+
+    expect(backend?.stopCalls).toBe(1);
+    const messages = await store.readMessages(session.id);
+    expect(messages.filter((message) => message.type === 'system_note' && message.kind === 'abort')).toHaveLength(1);
+    expect(messages.filter((message) =>
+      message.type === 'turn_state' && message.turnId === 'turn-1' && message.status === 'aborted'
+    )).toHaveLength(1);
+  });
+
   test('spawnChildAgent fails closed instead of running a degraded catalog agent', async () => {
     const store = new MemorySessionStore();
     const runStore = new MemoryAgentRunStore();
@@ -5430,6 +5469,22 @@ class RetryStopBackend extends TestBackend {
     this.stopCalls += 1;
     if (this.stopCalls === 1) throw new Error('first stop failed');
     this.stopGate.release();
+  }
+}
+
+class ConcurrentStopBackend extends TestBackend {
+  constructor(
+    ctx: BackendFactoryContext,
+    private readonly stopStarted: Gate,
+    private readonly releaseStop: Gate,
+  ) {
+    super(ctx, releaseStop);
+  }
+
+  override async stop(): Promise<void> {
+    this.stopCalls += 1;
+    this.stopStarted.release();
+    await this.releaseStop.promise;
   }
 }
 

--- a/packages/runtime/src/__tests__/session-manager.test.ts
+++ b/packages/runtime/src/__tests__/session-manager.test.ts
@@ -2991,6 +2991,33 @@ describe('SessionManager permission mode updates', () => {
     expect(childTerminalEvents).toHaveLength(1);
   });
 
+  test('spawnChildAgent preserves step-limit failure without a run store', async () => {
+    const store = new MemorySessionStore();
+    const backends = new BackendRegistry();
+    backends.register('fake', (ctx) => new EventBackend(ctx, [
+      { type: 'complete', stopReason: 'step_limit' },
+    ]));
+    const manager = new SessionManager({
+      store,
+      backends,
+      childTools: [testTool('Read'), testTool('Glob'), testTool('Grep')],
+      newId: nextId(),
+      now: nextNow(6_844),
+      runtimeSource: 'test',
+    });
+    const session = await manager.createSession(makeInput({ permissionMode: 'ask' }));
+
+    const result = await manager.spawnChildAgent(session.id, {
+      turnId: 'child-turn',
+      parentRunId: 'parent-run',
+      spec: { id: LOCAL_READ_AGENT_ID, name: 'Researcher', systemPrompt: 'read only' },
+      prompt: 'inspect',
+    });
+
+    expect(result.status).toBe('failed');
+    expect(result.failureClass).toBe('tool_step_cap_reached');
+  });
+
   test('spawnChildAgent summarizes high-volume child output without returning the full stream', async () => {
     const store = new MemorySessionStore();
     const runStore = new MemoryAgentRunStore();

--- a/packages/runtime/src/__tests__/session-manager.test.ts
+++ b/packages/runtime/src/__tests__/session-manager.test.ts
@@ -3084,6 +3084,8 @@ describe('SessionManager permission mode updates', () => {
     await child.next();
 
     await manager.stopSession(session.id, { source: 'stop_button' });
+    expect(backendInstances[0]?.stopCalls).toBe(0);
+    expect(backendInstances[1]?.stopCalls).toBe(1);
     childGate.release();
     await child.next();
     await child.next();
@@ -5353,6 +5355,7 @@ class TestBackend implements AgentBackend {
   readonly kind = 'fake' as const;
   readonly sessionId: string;
   readonly sendInputs: BackendSendInput[] = [];
+  stopCalls = 0;
 
   constructor(private readonly ctx: BackendFactoryContext, private readonly gate?: Gate) {
     this.sessionId = ctx.sessionId;
@@ -5365,7 +5368,9 @@ class TestBackend implements AgentBackend {
     yield { type: 'complete', id: `${input.turnId}-complete`, turnId: input.turnId, ts: 2, stopReason: 'end_turn' };
   }
 
-  async stop(): Promise<void> {}
+  async stop(): Promise<void> {
+    this.stopCalls += 1;
+  }
   async respondToPermission(_decision: PermissionDecision): Promise<void> {}
 
   async dispose(): Promise<void> {

--- a/packages/runtime/src/__tests__/session-manager.test.ts
+++ b/packages/runtime/src/__tests__/session-manager.test.ts
@@ -3098,6 +3098,47 @@ describe('SessionManager permission mode updates', () => {
     expect((await store.readHeader(session.id)).permissionMode).toBe('execute');
   });
 
+  test('stopSession retries a pending stop after the backend rejects', async () => {
+    const store = new MemorySessionStore();
+    const runStore = new MemoryAgentRunStore();
+    const backends = new BackendRegistry();
+    const childGate = makeGate();
+    let childBackend: RetryStopBackend | undefined;
+    backends.register('fake', (ctx) => {
+      if (ctx.header.permissionMode !== 'explore') return new TestBackend(ctx);
+      childBackend = new RetryStopBackend(ctx, childGate);
+      return childBackend;
+    });
+    const manager = new SessionManager({
+      store,
+      runStore,
+      runtimeEventStore: runStore,
+      backends,
+      childTools: [testTool('Read'), testTool('Glob'), testTool('Grep')],
+      newId: nextId(),
+      now: nextNow(6_846),
+      runtimeSource: 'test',
+    });
+    const session = await manager.createSession(makeInput({ permissionMode: 'ask' }));
+    await drain(manager.sendMessage(session.id, { turnId: 'parent-turn', text: 'parent context' }));
+    const [parentRun] = await runStore.listSessionRuns(session.id);
+    if (!parentRun) throw new Error('parent run was not recorded');
+    const child = manager.startChildTurn(session.id, {
+      turnId: 'child-turn',
+      parentRunId: parentRun.runId,
+      spec: { id: LOCAL_READ_AGENT_ID, name: 'Researcher', systemPrompt: 'read only' },
+      prompt: 'inspect slowly',
+    })[Symbol.asyncIterator]();
+    await child.next();
+
+    await expectRejects(manager.stopSession(session.id, { source: 'stop_button' }), /first stop failed/);
+    await manager.stopSession(session.id, { source: 'stop_button' });
+    expect(childBackend?.stopCalls).toBe(2);
+    while (!(await child.next()).done) {}
+    const childRun = (await runStore.listSessionRuns(session.id)).find((run) => run.turnId === 'child-turn');
+    expect(childRun?.status).toBe('cancelled');
+  });
+
   test('spawnChildAgent fails closed instead of running a degraded catalog agent', async () => {
     const store = new MemorySessionStore();
     const runStore = new MemoryAgentRunStore();
@@ -5377,6 +5418,18 @@ class TestBackend implements AgentBackend {
     if (this.ctx.store instanceof MemorySessionStore) {
       this.ctx.store.disposeCount += 1;
     }
+  }
+}
+
+class RetryStopBackend extends TestBackend {
+  constructor(ctx: BackendFactoryContext, private readonly stopGate: Gate) {
+    super(ctx, stopGate);
+  }
+
+  override async stop(): Promise<void> {
+    this.stopCalls += 1;
+    if (this.stopCalls === 1) throw new Error('first stop failed');
+    this.stopGate.release();
   }
 }
 

--- a/packages/runtime/src/__tests__/session-manager.test.ts
+++ b/packages/runtime/src/__tests__/session-manager.test.ts
@@ -3165,7 +3165,13 @@ describe('SessionManager permission mode updates', () => {
 
     const firstStop = manager.stopSession(session.id, { source: 'stop_button' });
     await stopStarted.promise;
-    const secondStop = manager.stopSession(session.id, { source: 'stop_button' });
+    let secondStopSettled = false;
+    const secondStop = manager.stopSession(session.id, { source: 'stop_button' }).finally(() => {
+      secondStopSettled = true;
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(secondStopSettled).toBe(false);
     releaseStop.release();
     await Promise.all([firstStop, secondStop]);
     while (!(await turn.next()).done) {}
@@ -3176,6 +3182,55 @@ describe('SessionManager permission mode updates', () => {
     expect(messages.filter((message) =>
       message.type === 'turn_state' && message.turnId === 'turn-1' && message.status === 'aborted'
     )).toHaveLength(1);
+  });
+
+  test('stopSession retries only backends that failed in a multi-session stop', async () => {
+    const store = new MemorySessionStore();
+    const runStore = new MemoryAgentRunStore();
+    const backends = new BackendRegistry();
+    const parentGate = makeGate();
+    const childGate = makeGate();
+    let parentBackend: CountingStopBackend | undefined;
+    let childBackend: RetryStopBackend | undefined;
+    backends.register('fake', (ctx) => {
+      if (ctx.header.permissionMode === 'explore') {
+        childBackend = new RetryStopBackend(ctx, childGate);
+        return childBackend;
+      }
+      parentBackend = new CountingStopBackend(ctx, parentGate);
+      return parentBackend;
+    });
+    const manager = new SessionManager({
+      store,
+      runStore,
+      runtimeEventStore: runStore,
+      backends,
+      childTools: [testTool('Read'), testTool('Glob'), testTool('Grep')],
+      newId: nextId(),
+      now: nextNow(6_848),
+      runtimeSource: 'test',
+    });
+    const session = await manager.createSession(makeInput({ permissionMode: 'ask' }));
+    const parent = manager.sendMessage(session.id, { turnId: 'parent-turn', text: 'parent' })[Symbol.asyncIterator]();
+    await parent.next();
+    const [parentRun] = await runStore.listSessionRuns(session.id);
+    if (!parentRun) throw new Error('parent run was not recorded');
+    const child = manager.startChildTurn(session.id, {
+      turnId: 'child-turn',
+      parentRunId: parentRun.runId,
+      spec: { id: LOCAL_READ_AGENT_ID, name: 'Researcher', systemPrompt: 'read only' },
+      prompt: 'child',
+    })[Symbol.asyncIterator]();
+    await child.next();
+
+    await expectRejects(manager.stopSession(session.id, { source: 'stop_button' }), /first stop failed/);
+    await manager.stopSession(session.id, { source: 'stop_button' });
+
+    expect(parentBackend?.stopCalls).toBe(1);
+    expect(childBackend?.stopCalls).toBe(2);
+    parentGate.release();
+    while (!(await parent.next()).done) {}
+    while (!(await child.next()).done) {}
   });
 
   test('spawnChildAgent fails closed instead of running a degraded catalog agent', async () => {
@@ -5485,6 +5540,12 @@ class ConcurrentStopBackend extends TestBackend {
     this.stopCalls += 1;
     this.stopStarted.release();
     await this.releaseStop.promise;
+  }
+}
+
+class CountingStopBackend extends TestBackend {
+  override async stop(): Promise<void> {
+    this.stopCalls += 1;
   }
 }
 

--- a/packages/runtime/src/agent-run.ts
+++ b/packages/runtime/src/agent-run.ts
@@ -1041,7 +1041,7 @@ function turnStatusFromEvent(event: SessionEvent): { status: TurnRecord['status'
     case 'complete':
       if (event.stopReason === 'user_stop') return { status: 'aborted' };
       if (event.stopReason === 'error') return { status: 'failed', errorClass: 'runtime_error' };
-      if (event.stopReason === 'step_limit') return { status: 'failed', errorClass: 'step_limit' };
+      if (event.stopReason === 'step_limit') return { status: 'failed', errorClass: 'tool_step_cap_reached' };
       if (event.stopReason === 'permission_handoff') return { status: 'running' };
       return { status: 'completed' };
     default:

--- a/packages/runtime/src/agent-run.ts
+++ b/packages/runtime/src/agent-run.ts
@@ -29,6 +29,7 @@ import {
   normalizeStopSessionSource,
 } from './session-projection-helpers.js';
 import {
+  buildSyntheticTerminalRuntimeEvent,
   commitOrCreateTerminalRunFact,
   effectiveRunHeaderFromTerminalFact,
 } from './terminal-run-commit.js';
@@ -123,10 +124,13 @@ export class AgentRun {
   private finalStatus: { status: SessionStatus; blockedReason?: SessionBlockedReason } | undefined;
   private turnFailed = false;
   private finalized = false;
-  private terminalRuntimeEventRecorded = false;
-  private terminalRuntimeEventForRunCommit: RuntimeEvent | undefined;
   private terminalRunHeaderCommitted = false;
-  private terminalDecision: 'open' | 'event' | 'stop' = 'open';
+  private terminalClaim: {
+    owner: 'event' | 'stop';
+    event?: RuntimeEvent;
+    write?: Promise<void>;
+    persisted?: boolean;
+  } | undefined;
 
   constructor(private readonly input: AgentRunInput) {
     if (input.runStore && !input.runtimeEventStore) {
@@ -147,8 +151,8 @@ export class AgentRun {
   }
 
   stop(source: StopSessionInput['source'] | undefined): boolean {
-    if (this.terminalDecision !== 'open') return false;
-    this.terminalDecision = 'stop';
+    if (this.terminalClaim) return false;
+    this.terminalClaim = { owner: 'stop' };
     this.stopped = true;
     this.abortSource = normalizeStopSessionSource(source);
     return true;
@@ -472,28 +476,36 @@ export class AgentRun {
     if (events.length === 0) return;
     for (const event of events) {
       const terminal = isTerminalRuntimeEvent(event);
-      if (terminal && this.terminalRuntimeEventRecorded) continue;
-      const eventForStore = this.runtimeEventForStore(event);
+      const eventForStore = terminal ? this.reserveTerminalEvent(event) : event;
+      if (!eventForStore) continue;
       if (!this.input.runtimeEventStore || !this.runtimeEventStoreAvailable) {
         if (terminal && options.requireTerminalWrite) {
           throw new Error('terminal RuntimeEvent store is unavailable');
         }
         continue;
       }
-      await this.enqueueRuntimeEventStore('append runtime event', async () => {
+      const write = this.enqueueRuntimeEventStore('append runtime event', async () => {
         await this.input.runtimeEventStore?.appendRuntimeEvent(this.sessionId, this.runId, eventForStore);
       }, { rethrow: terminal || options.requireTerminalWrite });
+      if (terminal && this.terminalClaim) this.terminalClaim.write = write;
+      await write;
       if (terminal) {
-        this.terminalRuntimeEventRecorded = true;
-        this.terminalRuntimeEventForRunCommit = eventForStore;
+        if (this.terminalClaim) this.terminalClaim.persisted = true;
       }
     }
   }
 
-  private runtimeEventForStore(event: RuntimeEvent): RuntimeEvent {
-    if (!isTerminalRuntimeEvent(event)) return event;
-    if (this.terminalDecision === 'open') this.terminalDecision = 'event';
-    if (this.terminalDecision !== 'stop') return event;
+  private reserveTerminalEvent(event: RuntimeEvent): RuntimeEvent | undefined {
+    if (this.terminalClaim?.event) return undefined;
+    this.terminalClaim ??= { owner: 'event' };
+    const eventForStore = this.terminalClaim.owner === 'stop'
+      ? this.abortedRuntimeEvent(event)
+      : event;
+    this.terminalClaim.event = eventForStore;
+    return eventForStore;
+  }
+
+  private abortedRuntimeEvent(event: RuntimeEvent): RuntimeEvent {
     const { content: _content, ...rest } = event;
     void _content;
     return {
@@ -866,7 +878,26 @@ export class AgentRun {
     const fallbackFailureClass = 'missing_terminal_event';
     const fallbackFailureMessage = this.failureMessage ?? 'run finalized without a terminal RuntimeEvent';
     try {
-      const result = await commitOrCreateTerminalRunFact({
+      let createdTerminalEvent = false;
+      if (!this.terminalClaim?.event) {
+        createdTerminalEvent = true;
+        const claimedStatus = this.terminalClaim?.owner === 'stop' ? 'cancelled' : fallbackStatus;
+        const syntheticEvent = buildSyntheticTerminalRuntimeEvent({
+          id: this.input.newId(),
+          invocationId: this.runId,
+          run: { sessionId: this.sessionId, runId: this.runId, turnId: this.turnId },
+          status: claimedStatus,
+          ts,
+          ...(claimedStatus === 'failed' ? { failureClass: fallbackFailureClass, message: fallbackFailureMessage } : {}),
+          ...(claimedStatus === 'cancelled' ? { abortSource: this.abortSource ?? 'user_stop' } : {}),
+        });
+        this.reserveTerminalEvent(syntheticEvent);
+      }
+      const terminalClaim = this.terminalClaim;
+      const terminalEvent = terminalClaim?.event;
+      if (!terminalEvent) throw new Error('terminal RuntimeEvent claim is missing');
+      await terminalClaim.write;
+      const commit = commitOrCreateTerminalRunFact({
         runStore,
         runtimeEventStore,
         newId: this.input.newId,
@@ -874,12 +905,8 @@ export class AgentRun {
         runId: this.runId,
         turnId: this.turnId,
         ts,
-        ...(this.terminalRuntimeEventForRunCommit
-          ? {
-              terminalEvent: this.terminalRuntimeEventForRunCommit,
-              terminalEventAlreadyPersisted: true,
-            }
-          : {}),
+        terminalEvent,
+        terminalEventAlreadyPersisted: terminalClaim.persisted === true,
         ...(this.failureClass ?? finalStatus?.blockedReason
           ? { failureClass: this.failureClass ?? finalStatus?.blockedReason }
           : {}),
@@ -892,12 +919,13 @@ export class AgentRun {
         ...(fallbackStatus === 'failed' ? { fallbackFailureClass, fallbackFailureMessage } : {}),
         allowHeaderCommitFailure: true,
       });
-      if (result.createdTerminalEvent && result.status === 'failed') {
+      if (!terminalClaim.write) terminalClaim.write = commit.then(() => undefined);
+      const result = await commit;
+      if (createdTerminalEvent && result.status === 'failed') {
         this.failureClass = result.failureClass ?? fallbackFailureClass;
         this.failureMessage = fallbackFailureMessage;
       }
-      this.terminalRuntimeEventRecorded = true;
-      this.terminalRuntimeEventForRunCommit = result.terminalEvent;
+      terminalClaim.persisted = true;
       this.terminalRunHeaderCommitted = result.headerCommitted;
       if (result.headerCommitError !== undefined) {
         await this.enqueueTraceWriteFailure(result.headerCommitError, 'commit terminal run header');

--- a/packages/runtime/src/agent-run.ts
+++ b/packages/runtime/src/agent-run.ts
@@ -126,6 +126,7 @@ export class AgentRun {
   private terminalRuntimeEventRecorded = false;
   private terminalRuntimeEventForRunCommit: RuntimeEvent | undefined;
   private terminalRunHeaderCommitted = false;
+  private terminalDecision: 'open' | 'event' | 'stop' = 'open';
 
   constructor(private readonly input: AgentRunInput) {
     if (input.runStore && !input.runtimeEventStore) {
@@ -145,9 +146,12 @@ export class AgentRun {
     };
   }
 
-  stop(source: StopSessionInput['source'] | undefined): void {
+  stop(source: StopSessionInput['source'] | undefined): boolean {
+    if (this.terminalDecision !== 'open') return false;
+    this.terminalDecision = 'stop';
     this.stopped = true;
     this.abortSource = normalizeStopSessionSource(source);
+    return true;
   }
 
   isStopped(): boolean {
@@ -467,9 +471,9 @@ export class AgentRun {
   ): Promise<void> {
     if (events.length === 0) return;
     for (const event of events) {
-      const eventForStore = this.runtimeEventForStore(event);
-      const terminal = isTerminalRuntimeEvent(eventForStore);
+      const terminal = isTerminalRuntimeEvent(event);
       if (terminal && this.terminalRuntimeEventRecorded) continue;
+      const eventForStore = this.runtimeEventForStore(event);
       if (!this.input.runtimeEventStore || !this.runtimeEventStoreAvailable) {
         if (terminal && options.requireTerminalWrite) {
           throw new Error('terminal RuntimeEvent store is unavailable');
@@ -487,7 +491,9 @@ export class AgentRun {
   }
 
   private runtimeEventForStore(event: RuntimeEvent): RuntimeEvent {
-    if (!this.stopped || !isTerminalRuntimeEvent(event)) return event;
+    if (!isTerminalRuntimeEvent(event)) return event;
+    if (this.terminalDecision === 'open') this.terminalDecision = 'event';
+    if (this.terminalDecision !== 'stop') return event;
     const { content: _content, ...rest } = event;
     void _content;
     return {

--- a/packages/runtime/src/agent-run.ts
+++ b/packages/runtime/src/agent-run.ts
@@ -131,6 +131,7 @@ export class AgentRun {
     write?: Promise<void>;
     persisted?: boolean;
     stopCompleted?: boolean;
+    stopAttemptInFlight?: boolean;
   } | undefined;
 
   constructor(private readonly input: AgentRunInput) {
@@ -163,12 +164,25 @@ export class AgentRun {
     return this.stopped;
   }
 
-  hasPendingStop(): boolean {
-    return this.terminalClaim?.owner === 'stop' && this.terminalClaim.stopCompleted !== true;
+  claimStopAttempt(): boolean {
+    if (
+      this.terminalClaim?.owner !== 'stop' ||
+      this.terminalClaim.stopCompleted === true ||
+      this.terminalClaim.stopAttemptInFlight === true
+    ) return false;
+    this.terminalClaim.stopAttemptInFlight = true;
+    return true;
+  }
+
+  releaseStopAttempt(): void {
+    if (this.terminalClaim?.owner === 'stop') this.terminalClaim.stopAttemptInFlight = false;
   }
 
   completeStop(): void {
-    if (this.terminalClaim?.owner === 'stop') this.terminalClaim.stopCompleted = true;
+    if (this.terminalClaim?.owner === 'stop') {
+      this.terminalClaim.stopAttemptInFlight = false;
+      this.terminalClaim.stopCompleted = true;
+    }
   }
 
   recordRunTrace(event: RunTraceEvent): void {

--- a/packages/runtime/src/agent-run.ts
+++ b/packages/runtime/src/agent-run.ts
@@ -417,10 +417,10 @@ export class AgentRun {
       this.finalStatus = this.stopped
         ? { status: 'aborted' }
         : (transition ?? { status: 'active' });
-      // A complete(error) without a preceding error event leaves failureClass
-      // unset — record it now so finalize does not fall back to 'unknown'.
+      // A terminal complete event can carry a failure without a preceding
+      // error event. Record it now so finalize preserves the precise class.
       if (turnStatus?.status === 'failed' && turnStatus.errorClass && !this.failureClass && !this.stopped) {
-        this.markRunFailed(turnStatus.errorClass, 'turn ended with stopReason=error', ev.ts);
+        this.markRunFailed(turnStatus.errorClass, `turn ended with stopReason=${ev.type === 'complete' ? ev.stopReason : 'unknown'}`, ev.ts);
       }
     }
     if (transition && !this.stopped) {
@@ -843,7 +843,7 @@ export class AgentRun {
     finalStatus: { status: SessionStatus; blockedReason?: SessionBlockedReason } | undefined,
   ): AgentRunHeader['status'] {
     if (this.stopped || finalStatus?.status === 'aborted') return 'cancelled';
-    if (finalStatus?.status === 'blocked') return 'failed';
+    if (this.failureClass || finalStatus?.status === 'blocked') return 'failed';
     if (finalStatus?.status === 'waiting_for_user') return 'waiting_permission';
     return 'completed';
   }
@@ -1041,6 +1041,7 @@ function turnStatusFromEvent(event: SessionEvent): { status: TurnRecord['status'
     case 'complete':
       if (event.stopReason === 'user_stop') return { status: 'aborted' };
       if (event.stopReason === 'error') return { status: 'failed', errorClass: 'runtime_error' };
+      if (event.stopReason === 'step_limit') return { status: 'failed', errorClass: 'step_limit' };
       if (event.stopReason === 'permission_handoff') return { status: 'running' };
       return { status: 'completed' };
     default:

--- a/packages/runtime/src/agent-run.ts
+++ b/packages/runtime/src/agent-run.ts
@@ -131,7 +131,6 @@ export class AgentRun {
     write?: Promise<void>;
     persisted?: boolean;
     stopCompleted?: boolean;
-    stopAttemptInFlight?: boolean;
   } | undefined;
 
   constructor(private readonly input: AgentRunInput) {
@@ -164,25 +163,12 @@ export class AgentRun {
     return this.stopped;
   }
 
-  claimStopAttempt(): boolean {
-    if (
-      this.terminalClaim?.owner !== 'stop' ||
-      this.terminalClaim.stopCompleted === true ||
-      this.terminalClaim.stopAttemptInFlight === true
-    ) return false;
-    this.terminalClaim.stopAttemptInFlight = true;
-    return true;
-  }
-
-  releaseStopAttempt(): void {
-    if (this.terminalClaim?.owner === 'stop') this.terminalClaim.stopAttemptInFlight = false;
+  hasPendingStop(): boolean {
+    return this.terminalClaim?.owner === 'stop' && this.terminalClaim.stopCompleted !== true;
   }
 
   completeStop(): void {
-    if (this.terminalClaim?.owner === 'stop') {
-      this.terminalClaim.stopAttemptInFlight = false;
-      this.terminalClaim.stopCompleted = true;
-    }
+    if (this.terminalClaim?.owner === 'stop') this.terminalClaim.stopCompleted = true;
   }
 
   recordRunTrace(event: RunTraceEvent): void {

--- a/packages/runtime/src/agent-run.ts
+++ b/packages/runtime/src/agent-run.ts
@@ -130,6 +130,7 @@ export class AgentRun {
     event?: RuntimeEvent;
     write?: Promise<void>;
     persisted?: boolean;
+    stopCompleted?: boolean;
   } | undefined;
 
   constructor(private readonly input: AgentRunInput) {
@@ -160,6 +161,14 @@ export class AgentRun {
 
   isStopped(): boolean {
     return this.stopped;
+  }
+
+  hasPendingStop(): boolean {
+    return this.terminalClaim?.owner === 'stop' && this.terminalClaim.stopCompleted !== true;
+  }
+
+  completeStop(): void {
+    if (this.terminalClaim?.owner === 'stop') this.terminalClaim.stopCompleted = true;
   }
 
   recordRunTrace(event: RunTraceEvent): void {
@@ -540,13 +549,14 @@ export class AgentRun {
     if (this.finalized) return;
     this.finalized = true;
     const lastTs = this.lastTs || this.input.now();
-    if (this.active) {
-      await this.input.hooks.unregisterRun(this.active, this);
-      if (this.stopped) this.finalStatus = { status: 'aborted' };
-    }
-    if (!this.finalStatus && !this.stopped) {
+    if (this.stopped) this.finalStatus = { status: 'aborted' };
+    if (!this.finalStatus) {
       this.finalStatus = { status: 'blocked', blockedReason: 'unknown' };
       this.markRunFailed('missing_terminal_event', 'run finalized without a terminal SessionEvent', lastTs);
+    }
+    this.reserveFinalizationTerminal(this.finalStatus, lastTs);
+    if (this.active) {
+      await this.input.hooks.unregisterRun(this.active, this);
     }
     const nextStatus = this.active && this.active.activeRuns.size > 0
       ? { status: 'running' as const }
@@ -878,21 +888,6 @@ export class AgentRun {
     const fallbackFailureClass = 'missing_terminal_event';
     const fallbackFailureMessage = this.failureMessage ?? 'run finalized without a terminal RuntimeEvent';
     try {
-      let createdTerminalEvent = false;
-      if (!this.terminalClaim?.event) {
-        createdTerminalEvent = true;
-        const claimedStatus = this.terminalClaim?.owner === 'stop' ? 'cancelled' : fallbackStatus;
-        const syntheticEvent = buildSyntheticTerminalRuntimeEvent({
-          id: this.input.newId(),
-          invocationId: this.runId,
-          run: { sessionId: this.sessionId, runId: this.runId, turnId: this.turnId },
-          status: claimedStatus,
-          ts,
-          ...(claimedStatus === 'failed' ? { failureClass: fallbackFailureClass, message: fallbackFailureMessage } : {}),
-          ...(claimedStatus === 'cancelled' ? { abortSource: this.abortSource ?? 'user_stop' } : {}),
-        });
-        this.reserveTerminalEvent(syntheticEvent);
-      }
       const terminalClaim = this.terminalClaim;
       const terminalEvent = terminalClaim?.event;
       if (!terminalEvent) throw new Error('terminal RuntimeEvent claim is missing');
@@ -921,10 +916,6 @@ export class AgentRun {
       });
       if (!terminalClaim.write) terminalClaim.write = commit.then(() => undefined);
       const result = await commit;
-      if (createdTerminalEvent && result.status === 'failed') {
-        this.failureClass = result.failureClass ?? fallbackFailureClass;
-        this.failureMessage = fallbackFailureMessage;
-      }
       terminalClaim.persisted = true;
       this.terminalRunHeaderCommitted = result.headerCommitted;
       if (result.headerCommitError !== undefined) {
@@ -936,6 +927,33 @@ export class AgentRun {
       throw error;
     }
     await this.traceQueue.catch(() => {});
+  }
+
+  private reserveFinalizationTerminal(
+    finalStatus: { status: SessionStatus; blockedReason?: SessionBlockedReason } | undefined,
+    ts: number,
+  ): void {
+    if (this.terminalClaim?.event) return;
+    const runStatus = this.runStatusForFinalStatus(finalStatus);
+    if (runStatus !== 'completed' && runStatus !== 'failed' && runStatus !== 'cancelled') return;
+    const status = this.terminalClaim?.owner === 'stop' || this.stopped || finalStatus?.status === 'aborted'
+      ? 'cancelled'
+      : 'failed';
+    const failureClass = 'missing_terminal_event';
+    const failureMessage = this.failureMessage ?? 'run finalized without a terminal RuntimeEvent';
+    if (status === 'failed') {
+      this.failureClass = failureClass;
+      this.failureMessage = failureMessage;
+    }
+    this.reserveTerminalEvent(buildSyntheticTerminalRuntimeEvent({
+      id: this.input.newId(),
+      invocationId: this.runId,
+      run: { sessionId: this.sessionId, runId: this.runId, turnId: this.turnId },
+      status,
+      ts,
+      ...(status === 'failed' ? { failureClass, message: failureMessage } : {}),
+      ...(status === 'cancelled' ? { abortSource: this.abortSource ?? 'user_stop' } : {}),
+    }));
   }
 
   private enqueueRunStore(

--- a/packages/runtime/src/agent-run.ts
+++ b/packages/runtime/src/agent-run.ts
@@ -11,7 +11,7 @@ import type {
   UserMessage,
 } from '@maka/core/session';
 import type { UserMessageInput } from '@maka/core/runtime-inputs';
-import type { SessionEvent } from '@maka/core/events';
+import { failureClassFromCompleteStopReason, type SessionEvent } from '@maka/core/events';
 import type { AgentBackend, BackendSendInput } from '@maka/core/backend-types';
 import type { RunTraceEvent } from './run-trace.js';
 import type { SessionStore, StopSessionInput } from './session-manager.js';
@@ -1040,8 +1040,8 @@ function turnStatusFromEvent(event: SessionEvent): { status: TurnRecord['status'
       return { status: 'failed', errorClass: event.reason ?? event.code ?? 'unknown' };
     case 'complete':
       if (event.stopReason === 'user_stop') return { status: 'aborted' };
-      if (event.stopReason === 'error') return { status: 'failed', errorClass: 'runtime_error' };
-      if (event.stopReason === 'step_limit') return { status: 'failed', errorClass: 'tool_step_cap_reached' };
+      const errorClass = failureClassFromCompleteStopReason(event.stopReason);
+      if (errorClass) return { status: 'failed', errorClass };
       if (event.stopReason === 'permission_handoff') return { status: 'running' };
       return { status: 'completed' };
     default:

--- a/packages/runtime/src/ai-sdk-backend.ts
+++ b/packages/runtime/src/ai-sdk-backend.ts
@@ -100,6 +100,7 @@ import {
   type PrepareStepLike,
   type PrepareStepResultLike,
   type RepairableAiSdkToolCall,
+  type StreamTextResult,
 } from './model-adapter.js';
 import {
   rewriteActiveToolResultsInMessages,
@@ -756,7 +757,6 @@ export class AiSdkBackend implements AgentBackend {
     let stepSignature: string | undefined;
     // Whether any step flushed non-empty text this turn — drives the step-cap
     // grace notice below (a turn whose every step was tool-only gets the notice).
-    let turnHadAnyText = false;
     const startedAt = this.now();
 
     // Flush the current step's AssistantMessage (text + thinking) and the paired
@@ -808,7 +808,6 @@ export class AiSdkBackend implements AgentBackend {
         messageId: stepId,
         text: stepText,
       } satisfies TextCompleteEvent);
-      if (stepText.length > 0) turnHadAnyText = true;
       stepText = '';
       stepThinking = '';
       stepSignature = undefined;
@@ -1122,33 +1121,16 @@ export class AiSdkBackend implements AgentBackend {
           publishTurnDiagnostics(computeTurnDiagnostics(finalActiveTools));
         }
 
-        // PR-AGENT-ITERATION-GRACE-0 (external bot research #A1): with an
-        // explicit maxSteps, `finishReason === 'tool-calls'` means we tripped
-        // `stopWhen: stepCountIs(maxSteps)` mid-loop — the model wanted to keep
-        // calling tools but we capped it.
-        // The user previously saw no closing assistant text in that
-        // path; just the last tool result. Inject a deterministic
-        // "step cap reached" notice so the UI has SOMETHING and the
-        // user can choose to send "继续" for a fresh turn.
+        // With an explicit maxSteps, `finishReason === 'tool-calls'` means the
+        // model wanted another tool step but the configured budget stopped it.
         const finishReasonForGrace = await result.finishReason.catch(() => 'stop');
+        const stepLimit = this.maxSteps;
+        const stepLimitReached = stepLimit !== undefined && finishReasonForGrace === 'tool-calls';
         rawFinishReason = rawFinishReason ?? rawFinishReasonString(finishReasonForGrace);
-        if (
-          this.maxSteps !== undefined
-          && finishReasonForGrace === 'tool-calls'
-          && runtimeSteps < this.maxSteps
-        ) {
-          runtimeSteps = this.maxSteps;
+        if (stepLimitReached && runtimeSteps < stepLimit) {
+          runtimeSteps = stepLimit;
         }
-        // Step-cap grace notice: when the loop tripped `stepCountIs(maxSteps)`
-        // mid-tool-loop and no step ever produced closing text, append a final
-        // assistant message (its own step id) so the UI has a closing line and
-        // the user can send "继续" for a fresh turn.
-        if (
-          !this.aborted
-          && this.maxSteps !== undefined
-          && !turnHadAnyText
-          && finishReasonForGrace === 'tool-calls'
-        ) {
+        if (!this.aborted && stepLimitReached) {
           // Always a fresh id. When the stream closed without a trailing
           // finish-step, `currentStepMessageId` is already taken: the catch-all
           // flush just used it for a thinking-only last step's AssistantMessage
@@ -1156,9 +1138,14 @@ export class AiSdkBackend implements AgentBackend {
           // tool_starts carry it as stepId (replay would adopt the grace text
           // as that step's closer). A rotated-but-unused id is discardable.
           const graceId = this.newId();
-          const graceText =
-            `⚠️ 已达到本轮 ${this.maxSteps} 步工具调用上限。\n\n`
-            + '上一步工具调用已落盘；如果还需要继续，请发一条新消息让对话进入下一回合（可以直接输入「继续」）。';
+          const graceText = await this.generateStepLimitFinalization({
+            result,
+            model,
+            messages,
+            maxSteps: stepLimit,
+            turnId,
+            abortSignal: this.abortController!.signal,
+          });
           await this.input.appendMessage({
             type: 'assistant',
             id: graceId,
@@ -1175,7 +1162,6 @@ export class AiSdkBackend implements AgentBackend {
             messageId: graceId,
             text: graceText,
           } satisfies TextCompleteEvent);
-          turnHadAnyText = true;
         }
 
         // Final usage event. AI SDK `usage` is the last step only; `totalUsage`
@@ -1289,7 +1275,9 @@ export class AiSdkBackend implements AgentBackend {
         }
 
         const finishReason = await result.finishReason.catch(() => 'stop');
-        const stopReason = this.mapFinishReason(finishReason);
+        const stopReason = this.maxSteps !== undefined && finishReason === 'tool-calls'
+          ? 'step_limit'
+          : this.mapFinishReason(finishReason);
         trace.modelStreamCompleted(stopReason);
         queue.push({
           type: 'complete',
@@ -1439,6 +1427,59 @@ export class AiSdkBackend implements AgentBackend {
     queue: AsyncEventQueue<SessionEvent>,
   ): Promise<void> {
     return this.toolRuntime.writeSyntheticToolResult(toolUseId, turnId, text, queue);
+  }
+
+  private async generateStepLimitFinalization(input: {
+    result: StreamTextResult;
+    model: unknown;
+    messages: ModelMessage[];
+    maxSteps: number;
+    turnId: string;
+    abortSignal: AbortSignal;
+  }): Promise<string> {
+    const fallback =
+      `⚠️ 已达到本轮 ${input.maxSteps} 步工具调用上限。\n\n`
+      + '上一步工具调用已落盘；任务可能尚未完成。如需继续，可以直接输入「继续」。';
+    const startedAt = this.now();
+    const callId = `step_limit_finalization_${input.turnId}_${startedAt}`;
+    try {
+      const response = await input.result.response;
+      const generated = await this.modelAdapter.generateTextWithoutTools({
+        model: input.model,
+        system:
+          'The explicit tool-step limit ended this Maka agent turn before it could continue. '
+          + 'Tools are unavailable. Give the user a concise final update in their language: '
+          + 'what was completed, what remains unfinished or unverified, and that they can send "continue" to resume. '
+          + 'Do not claim the task is complete unless the conversation proves it.',
+        messages: [...input.messages, ...(response?.messages ?? [])],
+        maxOutputTokens: 1_024,
+        abortSignal: input.abortSignal,
+      });
+      this.recordAuxiliaryModelCall({
+        callKind: 'step_limit_finalization',
+        callId,
+        turnId: input.turnId,
+        modelId: this.input.modelId,
+        startedAt,
+        latencyMs: Math.max(0, this.now() - startedAt),
+        usage: generated.usage,
+        finishReason: generated.finishReason,
+        status: 'success',
+      });
+      return generated.text.trim() || fallback;
+    } catch (error) {
+      this.recordAuxiliaryModelCall({
+        callKind: 'step_limit_finalization',
+        callId,
+        turnId: input.turnId,
+        modelId: this.input.modelId,
+        startedAt,
+        latencyMs: Math.max(0, this.now() - startedAt),
+        status: input.abortSignal.aborted ? 'aborted' : 'error',
+        errorClass: this.modelAdapter.classifyError(error),
+      });
+      return fallback;
+    }
   }
 
   /** Map ai-sdk finishReason → our CompleteEvent.stopReason. */
@@ -1878,7 +1919,8 @@ export class AiSdkBackend implements AgentBackend {
               maxOutputTokens: request.maxOutputTokens,
               abortSignal: request.abortSignal,
             });
-            this.recordSemanticCompactSummaryCall({
+            this.recordAuxiliaryModelCall({
+              callKind: 'semantic_compact',
               callId,
               turnId,
               modelId: summarizerModelId,
@@ -1890,7 +1932,8 @@ export class AiSdkBackend implements AgentBackend {
             });
             return result;
           } catch (error) {
-            this.recordSemanticCompactSummaryCall({
+            this.recordAuxiliaryModelCall({
+              callKind: 'semantic_compact',
               callId,
               turnId,
               modelId: summarizerModelId,
@@ -1967,7 +2010,8 @@ export class AiSdkBackend implements AgentBackend {
     };
   }
 
-  private recordSemanticCompactSummaryCall(input: {
+  private recordAuxiliaryModelCall(input: {
+    callKind: Exclude<NonNullable<LlmCallRecord['callKind']>, 'main'>;
     callId: string;
     turnId: string;
     modelId: string;
@@ -1982,7 +2026,7 @@ export class AiSdkBackend implements AgentBackend {
     this.input.recordLlmCall?.({
       sessionId: this.sessionId,
       turnId: input.turnId,
-      callKind: 'semantic_compact',
+      callKind: input.callKind,
       callId: input.callId,
       connectionSlug: this.input.connection.slug,
       providerId: this.input.connection.providerType,

--- a/packages/runtime/src/ai-sdk-backend.ts
+++ b/packages/runtime/src/ai-sdk-backend.ts
@@ -100,7 +100,6 @@ import {
   type PrepareStepLike,
   type PrepareStepResultLike,
   type RepairableAiSdkToolCall,
-  type StreamTextResult,
 } from './model-adapter.js';
 import {
   rewriteActiveToolResultsInMessages,
@@ -755,8 +754,6 @@ export class AiSdkBackend implements AgentBackend {
     let stepText = '';
     let stepThinking = '';
     let stepSignature: string | undefined;
-    // Whether any step flushed non-empty text this turn — drives the step-cap
-    // grace notice below (a turn whose every step was tool-only gets the notice).
     const startedAt = this.now();
 
     // Flush the current step's AssistantMessage (text + thinking) and the paired
@@ -1130,39 +1127,6 @@ export class AiSdkBackend implements AgentBackend {
         if (stepLimitReached && runtimeSteps < stepLimit) {
           runtimeSteps = stepLimit;
         }
-        if (!this.aborted && stepLimitReached) {
-          // Always a fresh id. When the stream closed without a trailing
-          // finish-step, `currentStepMessageId` is already taken: the catch-all
-          // flush just used it for a thinking-only last step's AssistantMessage
-          // (reuse would duplicate a ledger id), and a pure-tool last step's
-          // tool_starts carry it as stepId (replay would adopt the grace text
-          // as that step's closer). A rotated-but-unused id is discardable.
-          const graceId = this.newId();
-          const graceText = await this.generateStepLimitFinalization({
-            result,
-            model,
-            messages,
-            maxSteps: stepLimit,
-            turnId,
-            abortSignal: this.abortController!.signal,
-          });
-          await this.input.appendMessage({
-            type: 'assistant',
-            id: graceId,
-            turnId,
-            ts: this.now(),
-            text: graceText,
-            modelId: this.input.modelId,
-          });
-          queue.push({
-            type: 'text_complete',
-            id: this.newId(),
-            turnId,
-            ts: this.now(),
-            messageId: graceId,
-            text: graceText,
-          } satisfies TextCompleteEvent);
-        }
 
         // Final usage event. AI SDK `usage` is the last step only; `totalUsage`
         // is the billing-relevant sum across all internal tool-loop steps.
@@ -1427,59 +1391,6 @@ export class AiSdkBackend implements AgentBackend {
     queue: AsyncEventQueue<SessionEvent>,
   ): Promise<void> {
     return this.toolRuntime.writeSyntheticToolResult(toolUseId, turnId, text, queue);
-  }
-
-  private async generateStepLimitFinalization(input: {
-    result: StreamTextResult;
-    model: unknown;
-    messages: ModelMessage[];
-    maxSteps: number;
-    turnId: string;
-    abortSignal: AbortSignal;
-  }): Promise<string> {
-    const fallback =
-      `⚠️ 已达到本轮 ${input.maxSteps} 步工具调用上限。\n\n`
-      + '上一步工具调用已落盘；任务可能尚未完成。如需继续，可以直接输入「继续」。';
-    const startedAt = this.now();
-    const callId = `step_limit_finalization_${input.turnId}_${startedAt}`;
-    try {
-      const response = await input.result.response;
-      const generated = await this.modelAdapter.generateTextWithoutTools({
-        model: input.model,
-        system:
-          'The explicit tool-step limit ended this Maka agent turn before it could continue. '
-          + 'Tools are unavailable. Give the user a concise final update in their language: '
-          + 'what was completed, what remains unfinished or unverified, and that they can send "continue" to resume. '
-          + 'Do not claim the task is complete unless the conversation proves it.',
-        messages: [...input.messages, ...(response?.messages ?? [])],
-        maxOutputTokens: 1_024,
-        abortSignal: input.abortSignal,
-      });
-      this.recordAuxiliaryModelCall({
-        callKind: 'step_limit_finalization',
-        callId,
-        turnId: input.turnId,
-        modelId: this.input.modelId,
-        startedAt,
-        latencyMs: Math.max(0, this.now() - startedAt),
-        usage: generated.usage,
-        finishReason: generated.finishReason,
-        status: 'success',
-      });
-      return generated.text.trim() || fallback;
-    } catch (error) {
-      this.recordAuxiliaryModelCall({
-        callKind: 'step_limit_finalization',
-        callId,
-        turnId: input.turnId,
-        modelId: this.input.modelId,
-        startedAt,
-        latencyMs: Math.max(0, this.now() - startedAt),
-        status: input.abortSignal.aborted ? 'aborted' : 'error',
-        errorClass: this.modelAdapter.classifyError(error),
-      });
-      return fallback;
-    }
   }
 
   /** Map ai-sdk finishReason → our CompleteEvent.stopReason. */
@@ -1919,8 +1830,7 @@ export class AiSdkBackend implements AgentBackend {
               maxOutputTokens: request.maxOutputTokens,
               abortSignal: request.abortSignal,
             });
-            this.recordAuxiliaryModelCall({
-              callKind: 'semantic_compact',
+            this.recordSemanticCompactSummaryCall({
               callId,
               turnId,
               modelId: summarizerModelId,
@@ -1932,8 +1842,7 @@ export class AiSdkBackend implements AgentBackend {
             });
             return result;
           } catch (error) {
-            this.recordAuxiliaryModelCall({
-              callKind: 'semantic_compact',
+            this.recordSemanticCompactSummaryCall({
               callId,
               turnId,
               modelId: summarizerModelId,
@@ -2010,8 +1919,7 @@ export class AiSdkBackend implements AgentBackend {
     };
   }
 
-  private recordAuxiliaryModelCall(input: {
-    callKind: Exclude<NonNullable<LlmCallRecord['callKind']>, 'main'>;
+  private recordSemanticCompactSummaryCall(input: {
     callId: string;
     turnId: string;
     modelId: string;
@@ -2026,7 +1934,7 @@ export class AiSdkBackend implements AgentBackend {
     this.input.recordLlmCall?.({
       sessionId: this.sessionId,
       turnId: input.turnId,
-      callKind: input.callKind,
+      callKind: 'semantic_compact',
       callId: input.callId,
       connectionSlug: this.input.connection.slug,
       providerId: this.input.connection.providerType,

--- a/packages/runtime/src/ai-sdk-backend.ts
+++ b/packages/runtime/src/ai-sdk-backend.ts
@@ -1120,10 +1120,10 @@ export class AiSdkBackend implements AgentBackend {
 
         // With an explicit maxSteps, `finishReason === 'tool-calls'` means the
         // model wanted another tool step but the configured budget stopped it.
-        const finishReasonForGrace = await result.finishReason.catch(() => 'stop');
+        const finishReason = await result.finishReason.catch(() => 'stop');
         const stepLimit = this.maxSteps;
-        const stepLimitReached = stepLimit !== undefined && finishReasonForGrace === 'tool-calls';
-        rawFinishReason = rawFinishReason ?? rawFinishReasonString(finishReasonForGrace);
+        const stepLimitReached = stepLimit !== undefined && finishReason === 'tool-calls';
+        rawFinishReason = rawFinishReason ?? rawFinishReasonString(finishReason);
         if (stepLimitReached && runtimeSteps < stepLimit) {
           runtimeSteps = stepLimit;
         }
@@ -1238,7 +1238,9 @@ export class AiSdkBackend implements AgentBackend {
           // best-effort; ai-sdk usage promise may reject on abort
         }
 
-        const finishReason = await result.finishReason.catch(() => 'stop');
+        // Nothing may await between this check and terminal emission: Stop must
+        // win even when it arrives during post-stream usage persistence.
+        if (this.aborted) throw Object.assign(new Error('aborted'), { name: 'AbortError' });
         const stopReason = this.maxSteps !== undefined && finishReason === 'tool-calls'
           ? 'step_limit'
           : this.mapFinishReason(finishReason);

--- a/packages/runtime/src/ai-sdk-flow.ts
+++ b/packages/runtime/src/ai-sdk-flow.ts
@@ -56,13 +56,15 @@ export type CompleteStopReason = CompleteEvent['stopReason'];
  * `end_turn` / `max_tokens` / `*_handoff` all represent the streaming phase
  * ending normally (control may be handed off, but the run is not a failure),
  * so they map to `completed`. `user_stop` maps to `aborted`; `error` to
- * `failed`. Phase 5+ may introduce a richer `waiting`/`handoff` status.
+ * `failed`. An explicit `step_limit` is also failed because the requested work
+ * may be incomplete. Phase 5+ may introduce a richer `waiting`/`handoff` status.
  */
 export function mapCompleteStopReason(reason: CompleteStopReason): RuntimeEventStatus {
   switch (reason) {
     case 'user_stop':
       return 'aborted';
     case 'error':
+    case 'step_limit':
       return 'failed';
     case 'end_turn':
     case 'max_tokens':
@@ -395,7 +397,9 @@ function completeRuntimeEvent(
     ? 'failed'
     : mapCompleteStopReason(stopReason);
   const stateDelta: Record<string, unknown> = { stopReason };
-  if (status === 'failed') stateDelta.failureClass = memory.failureClass ?? 'runtime_error';
+  if (status === 'failed') {
+    stateDelta.failureClass = memory.failureClass ?? (stopReason === 'step_limit' ? 'step_limit' : 'runtime_error');
+  }
   if (status === 'aborted') stateDelta.abortSource = stopReason;
   return {
     ...base,

--- a/packages/runtime/src/ai-sdk-flow.ts
+++ b/packages/runtime/src/ai-sdk-flow.ts
@@ -31,7 +31,11 @@
  *   - own model-history projection (Phase 7) or tool-event actions (Phase 5).
  */
 
-import type { CompleteEvent, SessionEvent } from '@maka/core/events';
+import {
+  failureClassFromCompleteStopReason,
+  type CompleteEvent,
+  type SessionEvent,
+} from '@maka/core/events';
 import type { PermissionDecision } from '@maka/core/backend-types';
 import { isTerminalRuntimeEvent, type RuntimeEvent, type RuntimeEventStatus } from '@maka/core/runtime-event';
 
@@ -60,20 +64,8 @@ export type CompleteStopReason = CompleteEvent['stopReason'];
  * may be incomplete. Phase 5+ may introduce a richer `waiting`/`handoff` status.
  */
 export function mapCompleteStopReason(reason: CompleteStopReason): RuntimeEventStatus {
-  switch (reason) {
-    case 'user_stop':
-      return 'aborted';
-    case 'error':
-    case 'step_limit':
-      return 'failed';
-    case 'end_turn':
-    case 'max_tokens':
-    case 'plan_handoff':
-    case 'permission_handoff':
-      return 'completed';
-    default:
-      return 'completed';
-  }
+  if (reason === 'user_stop') return 'aborted';
+  return failureClassFromCompleteStopReason(reason) ? 'failed' : 'completed';
 }
 
 /**
@@ -399,7 +391,8 @@ function completeRuntimeEvent(
   const stateDelta: Record<string, unknown> = { stopReason };
   if (status === 'failed') {
     stateDelta.failureClass = memory.failureClass
-      ?? (stopReason === 'step_limit' ? 'tool_step_cap_reached' : 'runtime_error');
+      ?? failureClassFromCompleteStopReason(stopReason)
+      ?? 'runtime_error';
   }
   if (status === 'aborted') stateDelta.abortSource = stopReason;
   return {

--- a/packages/runtime/src/ai-sdk-flow.ts
+++ b/packages/runtime/src/ai-sdk-flow.ts
@@ -398,7 +398,8 @@ function completeRuntimeEvent(
     : mapCompleteStopReason(stopReason);
   const stateDelta: Record<string, unknown> = { stopReason };
   if (status === 'failed') {
-    stateDelta.failureClass = memory.failureClass ?? (stopReason === 'step_limit' ? 'step_limit' : 'runtime_error');
+    stateDelta.failureClass = memory.failureClass
+      ?? (stopReason === 'step_limit' ? 'tool_step_cap_reached' : 'runtime_error');
   }
   if (status === 'aborted') stateDelta.abortSource = stopReason;
   return {

--- a/packages/runtime/src/model-adapter.ts
+++ b/packages/runtime/src/model-adapter.ts
@@ -71,26 +71,20 @@ export type PrepareStepFunctionLike = (
   options: PrepareStepLike,
 ) => PrepareStepResultLike | undefined | PromiseLike<PrepareStepResultLike | undefined>;
 
-export interface NoToolsTextRequest {
+export interface CompactSummaryRequest {
   model: unknown;
   system: string;
   messages: readonly ModelMessage[];
-  maxOutputTokens?: number;
+  maxOutputTokens: number;
   abortSignal?: AbortSignal;
 }
 
-export interface NoToolsTextResult {
+export interface CompactSummaryResult {
   text: string;
   usage?: NormalizedAiSdkUsage;
   finishReason?: string;
   providerRequestId?: string;
 }
-
-export interface CompactSummaryRequest extends NoToolsTextRequest {
-  maxOutputTokens: number;
-}
-
-export type CompactSummaryResult = NoToolsTextResult;
 
 export interface ModelAdapterStreamInput {
   model: unknown;
@@ -178,10 +172,6 @@ export class ModelAdapter {
   }
 
   async generateCompactSummary(input: CompactSummaryRequest): Promise<CompactSummaryResult> {
-    return this.generateTextWithoutTools(input);
-  }
-
-  async generateTextWithoutTools(input: NoToolsTextRequest): Promise<NoToolsTextResult> {
     const ai = await import('ai').catch((err) => {
       throw new Error(`Failed to load 'ai' package. Run \`npm install ai\`. Inner: ${(err as Error).message}`);
     });
@@ -200,7 +190,7 @@ export class ModelAdapter {
       model: input.model,
       system: input.system,
       messages: input.messages,
-      ...(input.maxOutputTokens !== undefined ? { maxOutputTokens: input.maxOutputTokens } : {}),
+      maxOutputTokens: input.maxOutputTokens,
       abortSignal: input.abortSignal,
     });
     const usage = normalizeAiSdkUsage(result.totalUsage ?? result.usage, {
@@ -360,7 +350,6 @@ export interface StreamTextResult {
   usage: Promise<AiSdkUsageLike | undefined>;
   totalUsage?: Promise<AiSdkUsageLike | undefined>;
   finishReason: Promise<unknown>;
-  response?: PromiseLike<{ messages: ModelMessage[] }>;
 }
 
 type TokenCountBreakdown = {

--- a/packages/runtime/src/model-adapter.ts
+++ b/packages/runtime/src/model-adapter.ts
@@ -71,20 +71,26 @@ export type PrepareStepFunctionLike = (
   options: PrepareStepLike,
 ) => PrepareStepResultLike | undefined | PromiseLike<PrepareStepResultLike | undefined>;
 
-export interface CompactSummaryRequest {
+export interface NoToolsTextRequest {
   model: unknown;
   system: string;
   messages: readonly ModelMessage[];
-  maxOutputTokens: number;
+  maxOutputTokens?: number;
   abortSignal?: AbortSignal;
 }
 
-export interface CompactSummaryResult {
+export interface NoToolsTextResult {
   text: string;
   usage?: NormalizedAiSdkUsage;
   finishReason?: string;
   providerRequestId?: string;
 }
+
+export interface CompactSummaryRequest extends NoToolsTextRequest {
+  maxOutputTokens: number;
+}
+
+export type CompactSummaryResult = NoToolsTextResult;
 
 export interface ModelAdapterStreamInput {
   model: unknown;
@@ -172,6 +178,10 @@ export class ModelAdapter {
   }
 
   async generateCompactSummary(input: CompactSummaryRequest): Promise<CompactSummaryResult> {
+    return this.generateTextWithoutTools(input);
+  }
+
+  async generateTextWithoutTools(input: NoToolsTextRequest): Promise<NoToolsTextResult> {
     const ai = await import('ai').catch((err) => {
       throw new Error(`Failed to load 'ai' package. Run \`npm install ai\`. Inner: ${(err as Error).message}`);
     });
@@ -190,7 +200,7 @@ export class ModelAdapter {
       model: input.model,
       system: input.system,
       messages: input.messages,
-      maxOutputTokens: input.maxOutputTokens,
+      ...(input.maxOutputTokens !== undefined ? { maxOutputTokens: input.maxOutputTokens } : {}),
       abortSignal: input.abortSignal,
     });
     const usage = normalizeAiSdkUsage(result.totalUsage ?? result.usage, {
@@ -350,6 +360,7 @@ export interface StreamTextResult {
   usage: Promise<AiSdkUsageLike | undefined>;
   totalUsage?: Promise<AiSdkUsageLike | undefined>;
   finishReason: Promise<unknown>;
+  response?: PromiseLike<{ messages: ModelMessage[] }>;
 }
 
 type TokenCountBreakdown = {

--- a/packages/runtime/src/runtime-event-read-model.ts
+++ b/packages/runtime/src/runtime-event-read-model.ts
@@ -693,6 +693,15 @@ function projectTerminalTurnState(
     ...(status === 'failed' ? { errorClass: failureClass ?? 'unknown' } : {}),
     partialOutputRetained,
   });
+  if (failureClass === 'tool_step_cap_reached') {
+    messages.push({
+      type: 'system_note',
+      id: `${event.id}:step-limit-notice`,
+      turnId: event.turnId,
+      ts: event.ts,
+      kind: 'step_limit',
+    });
+  }
   if (status === 'failed' && !failureClass) {
     diagnostic(state, event, 'incomplete_event', 'failed terminal event did not carry an exact AgentRunHeader.failureClass');
   }

--- a/packages/runtime/src/runtime-kernel.ts
+++ b/packages/runtime/src/runtime-kernel.ts
@@ -4,9 +4,12 @@ import type {
   SessionBlockedReason,
   SessionHeader,
   SessionStatus,
+  StoredMessage,
   SystemNoteMessage,
   TurnRecord,
+  TurnStateMessage,
 } from '@maka/core/session';
+import { isDeepStrictEqual } from 'node:util';
 import type { ChildAgentTurnInput, UserMessageInput } from '@maka/core/runtime-inputs';
 import type { PermissionResponse } from '@maka/core/permission';
 import { AgentRun, type AgentRunActiveSession, type AgentRunBeginResult, type AgentRunLineage } from './agent-run.js';
@@ -85,8 +88,8 @@ interface StopOperation {
   abortSource: string | undefined;
   ts: number;
   statusProjected: boolean;
-  turnProjections: Map<AgentRun, { id: string; projected: boolean }>;
-  abortNoteId: string;
+  turnProjections: Map<AgentRun, { id: string; message?: TurnStateMessage; projected: boolean }>;
+  abortNote: SystemNoteMessage;
   abortNoteProjected: boolean;
   targets: Map<ActiveSession, StopTarget>;
 }
@@ -419,12 +422,20 @@ export class RuntimeKernel implements RuntimeKernelLike {
     const activeSessions = this.activeSessionsFor(sessionId);
     let operation = this.stopOperations.get(sessionId);
     if (!operation) {
+      const abortSource = normalizeStopSessionSource(input.source);
+      const ts = this.deps.now();
       operation = {
-        abortSource: normalizeStopSessionSource(input.source),
-        ts: this.deps.now(),
+        abortSource,
+        ts,
         statusProjected: false,
         turnProjections: new Map(),
-        abortNoteId: this.deps.newId(),
+        abortNote: {
+          type: 'system_note',
+          id: this.deps.newId(),
+          ts,
+          kind: 'abort',
+          ...(abortSource ? { data: { source: abortSource } } : {}),
+        },
         abortNoteProjected: false,
         targets: new Map(),
       };
@@ -463,27 +474,35 @@ export class RuntimeKernel implements RuntimeKernelLike {
     }
     for (const [run, projection] of operation.turnProjections) {
       if (projection.projected) continue;
-      await this.appendTurnState(
-        sessionId,
-        run.turnId,
-        'aborted',
-        run.lineage,
-        { id: projection.id, ts: operation.ts, abortSource: operation.abortSource },
-      );
+      projection.message ??= buildTurnStateMessage({
+        id: projection.id,
+        turnId: run.turnId,
+        ts: operation.ts,
+        status: 'aborted',
+        lineage: run.lineage,
+        ...(operation.abortSource ? { abortSource: operation.abortSource } : {}),
+        partialOutputRetained: await this.turnHasRetainedOutput(sessionId, run.turnId),
+      });
+      await this.appendStopProjection(sessionId, projection.message);
       projection.projected = true;
     }
     if (!operation.abortNoteProjected) {
-      await this.deps.store.appendMessage(sessionId, {
-        type: 'system_note',
-        id: operation.abortNoteId,
-        ts: operation.ts,
-        kind: 'abort',
-        ...(operation.abortSource ? { data: { source: operation.abortSource } } : {}),
-      } satisfies SystemNoteMessage);
+      await this.appendStopProjection(sessionId, operation.abortNote);
       operation.abortNoteProjected = true;
     }
     for (const run of stoppedRuns) run.completeStop();
     this.stopOperations.delete(sessionId);
+  }
+
+  private async appendStopProjection(sessionId: string, message: StoredMessage): Promise<void> {
+    const existing = (await this.deps.store.readMessages(sessionId)).find((candidate) => candidate.id === message.id);
+    if (existing) {
+      if (!isDeepStrictEqual(existing, message)) {
+        throw new Error(`stop projection ${message.id} conflicts with an existing message`);
+      }
+      return;
+    }
+    await this.deps.store.appendMessage(sessionId, message);
   }
 
   async respondToPermission(sessionId: string, response: PermissionResponse): Promise<void> {

--- a/packages/runtime/src/runtime-kernel.ts
+++ b/packages/runtime/src/runtime-kernel.ts
@@ -395,30 +395,35 @@ export class RuntimeKernel implements RuntimeKernelLike {
       active,
       stoppedRuns: [...active.activeRuns.values()].filter((run) => {
         run.stop(input.source);
-        return run.hasPendingStop();
+        return run.claimStopAttempt();
       }),
     })).filter(({ stoppedRuns }) => stoppedRuns.length > 0);
     const stoppedRuns = stoppedSessions.flatMap(({ stoppedRuns: runs }) => runs);
     if (stoppedRuns.length === 0) return;
-    await Promise.all(stoppedSessions.map(({ active }) => active.backend.stop('user_stop')));
-    await this.updateStatus(sessionId, 'aborted');
-    for (const run of stoppedRuns.filter((activeRun) => !activeRun.lineage.parentRunId)) {
-      await this.appendTurnState(
-        sessionId,
-        run.turnId,
-        'aborted',
-        run.lineage,
-        { ts: this.deps.now(), abortSource },
-      ).catch(() => {});
+    try {
+      await Promise.all(stoppedSessions.map(({ active }) => active.backend.stop('user_stop')));
+      await this.updateStatus(sessionId, 'aborted');
+      for (const run of stoppedRuns.filter((activeRun) => !activeRun.lineage.parentRunId)) {
+        await this.appendTurnState(
+          sessionId,
+          run.turnId,
+          'aborted',
+          run.lineage,
+          { ts: this.deps.now(), abortSource },
+        ).catch(() => {});
+      }
+      await this.deps.store.appendMessage(sessionId, {
+        type: 'system_note',
+        id: this.deps.newId(),
+        ts: this.deps.now(),
+        kind: 'abort',
+        ...(abortSource ? { data: { source: abortSource } } : {}),
+      } satisfies SystemNoteMessage);
+      for (const run of stoppedRuns) run.completeStop();
+    } catch (error) {
+      for (const run of stoppedRuns) run.releaseStopAttempt();
+      throw error;
     }
-    await this.deps.store.appendMessage(sessionId, {
-      type: 'system_note',
-      id: this.deps.newId(),
-      ts: this.deps.now(),
-      kind: 'abort',
-      ...(abortSource ? { data: { source: abortSource } } : {}),
-    } satisfies SystemNoteMessage);
-    for (const run of stoppedRuns) run.completeStop();
   }
 
   async respondToPermission(sessionId: string, response: PermissionResponse): Promise<void> {

--- a/packages/runtime/src/runtime-kernel.ts
+++ b/packages/runtime/src/runtime-kernel.ts
@@ -392,12 +392,11 @@ export class RuntimeKernel implements RuntimeKernelLike {
     if (activeSessions.length === 0) return;
     const abortSource = normalizeStopSessionSource(input.source);
     const activeRuns = activeSessions.flatMap((active) => [...active.activeRuns.values()]);
-    for (const run of activeRuns) {
-      run.stop(input.source);
-    }
+    const stoppedRuns = activeRuns.filter((run) => run.stop(input.source));
+    if (stoppedRuns.length === 0) return;
     await Promise.all(activeSessions.map((active) => active.backend.stop('user_stop')));
     await this.updateStatus(sessionId, 'aborted');
-    for (const run of activeRuns.filter((activeRun) => !activeRun.lineage.parentRunId)) {
+    for (const run of stoppedRuns.filter((activeRun) => !activeRun.lineage.parentRunId)) {
       await this.appendTurnState(
         sessionId,
         run.turnId,

--- a/packages/runtime/src/runtime-kernel.ts
+++ b/packages/runtime/src/runtime-kernel.ts
@@ -83,6 +83,11 @@ interface StopTarget {
 
 interface StopOperation {
   abortSource: string | undefined;
+  ts: number;
+  statusProjected: boolean;
+  turnProjections: Map<AgentRun, { id: string; projected: boolean }>;
+  abortNoteId: string;
+  abortNoteProjected: boolean;
   targets: Map<ActiveSession, StopTarget>;
 }
 
@@ -416,6 +421,11 @@ export class RuntimeKernel implements RuntimeKernelLike {
     if (!operation) {
       operation = {
         abortSource: normalizeStopSessionSource(input.source),
+        ts: this.deps.now(),
+        statusProjected: false,
+        turnProjections: new Map(),
+        abortNoteId: this.deps.newId(),
+        abortNoteProjected: false,
         targets: new Map(),
       };
     }
@@ -426,7 +436,12 @@ export class RuntimeKernel implements RuntimeKernelLike {
       });
       if (stoppedRuns.length === 0) continue;
       const target = operation.targets.get(active) ?? { active, runs: new Set(), delivered: false };
-      for (const run of stoppedRuns) target.runs.add(run);
+      for (const run of stoppedRuns) {
+        target.runs.add(run);
+        if (!run.lineage.parentRunId && !operation.turnProjections.has(run)) {
+          operation.turnProjections.set(run, { id: this.deps.newId(), projected: false });
+        }
+      }
       operation.targets.set(active, target);
     }
     if (operation.targets.size === 0) return;
@@ -442,23 +457,31 @@ export class RuntimeKernel implements RuntimeKernelLike {
     if (stopError !== undefined) throw stopError;
 
     const stoppedRuns = [...new Set([...operation.targets.values()].flatMap((target) => [...target.runs]))];
-    await this.updateStatus(sessionId, 'aborted');
-    for (const run of stoppedRuns.filter((activeRun) => !activeRun.lineage.parentRunId)) {
+    if (!operation.statusProjected) {
+      await this.updateStatus(sessionId, 'aborted', undefined, operation.ts);
+      operation.statusProjected = true;
+    }
+    for (const [run, projection] of operation.turnProjections) {
+      if (projection.projected) continue;
       await this.appendTurnState(
         sessionId,
         run.turnId,
         'aborted',
         run.lineage,
-        { ts: this.deps.now(), abortSource: operation.abortSource },
-      ).catch(() => {});
+        { id: projection.id, ts: operation.ts, abortSource: operation.abortSource },
+      );
+      projection.projected = true;
     }
-    await this.deps.store.appendMessage(sessionId, {
-      type: 'system_note',
-      id: this.deps.newId(),
-      ts: this.deps.now(),
-      kind: 'abort',
-      ...(operation.abortSource ? { data: { source: operation.abortSource } } : {}),
-    } satisfies SystemNoteMessage);
+    if (!operation.abortNoteProjected) {
+      await this.deps.store.appendMessage(sessionId, {
+        type: 'system_note',
+        id: operation.abortNoteId,
+        ts: operation.ts,
+        kind: 'abort',
+        ...(operation.abortSource ? { data: { source: operation.abortSource } } : {}),
+      } satisfies SystemNoteMessage);
+      operation.abortNoteProjected = true;
+    }
     for (const run of stoppedRuns) run.completeStop();
     this.stopOperations.delete(sessionId);
   }
@@ -763,11 +786,11 @@ export class RuntimeKernel implements RuntimeKernelLike {
     turnId: string,
     status: TurnRecord['status'],
     lineage: AgentRunLineage = {},
-    options: { ts?: number; errorClass?: string; abortSource?: string } = {},
+    options: { id?: string; ts?: number; errorClass?: string; abortSource?: string } = {},
   ): Promise<void> {
     const ts = options.ts ?? this.deps.now();
     await this.deps.store.appendMessage(sessionId, buildTurnStateMessage({
-      id: this.deps.newId(),
+      id: options.id ?? this.deps.newId(),
       turnId,
       ts,
       status,

--- a/packages/runtime/src/runtime-kernel.ts
+++ b/packages/runtime/src/runtime-kernel.ts
@@ -75,9 +75,22 @@ interface ActiveSession extends AgentRunActiveSession {
   turnToRunId: Map<string, string>;
 }
 
+interface StopTarget {
+  active: ActiveSession;
+  runs: Set<AgentRun>;
+  delivered: boolean;
+}
+
+interface StopOperation {
+  abortSource: string | undefined;
+  targets: Map<ActiveSession, StopTarget>;
+}
+
 export class RuntimeKernel implements RuntimeKernelLike {
   private readonly active = new Map<string, ActiveSession>();
   private readonly childActive = new Map<string, ActiveSession>();
+  private readonly stopOperations = new Map<string, StopOperation>();
+  private readonly stopAttempts = new Map<string, Promise<void>>();
   private readonly historyCompactCheckpoints = new Map<string, HistoryCompactCheckpoint | undefined>();
   private readonly historyCompactCheckpointLoads = new Map<string, Promise<HistoryCompactCheckpoint | undefined>>();
   private readonly historyCompactCheckpointWrites = new Map<string, Promise<void>>();
@@ -387,43 +400,67 @@ export class RuntimeKernel implements RuntimeKernelLike {
     };
   }
 
-  async stopSession(sessionId: string, input: StopSessionInput = {}): Promise<void> {
+  stopSession(sessionId: string, input: StopSessionInput = {}): Promise<void> {
+    const existing = this.stopAttempts.get(sessionId);
+    if (existing) return existing;
+    const attempt = this.stopSessionAttempt(sessionId, input).finally(() => {
+      if (this.stopAttempts.get(sessionId) === attempt) this.stopAttempts.delete(sessionId);
+    });
+    this.stopAttempts.set(sessionId, attempt);
+    return attempt;
+  }
+
+  private async stopSessionAttempt(sessionId: string, input: StopSessionInput): Promise<void> {
     const activeSessions = this.activeSessionsFor(sessionId);
-    if (activeSessions.length === 0) return;
-    const abortSource = normalizeStopSessionSource(input.source);
-    const stoppedSessions = activeSessions.map((active) => ({
-      active,
-      stoppedRuns: [...active.activeRuns.values()].filter((run) => {
-        run.stop(input.source);
-        return run.claimStopAttempt();
-      }),
-    })).filter(({ stoppedRuns }) => stoppedRuns.length > 0);
-    const stoppedRuns = stoppedSessions.flatMap(({ stoppedRuns: runs }) => runs);
-    if (stoppedRuns.length === 0) return;
-    try {
-      await Promise.all(stoppedSessions.map(({ active }) => active.backend.stop('user_stop')));
-      await this.updateStatus(sessionId, 'aborted');
-      for (const run of stoppedRuns.filter((activeRun) => !activeRun.lineage.parentRunId)) {
-        await this.appendTurnState(
-          sessionId,
-          run.turnId,
-          'aborted',
-          run.lineage,
-          { ts: this.deps.now(), abortSource },
-        ).catch(() => {});
-      }
-      await this.deps.store.appendMessage(sessionId, {
-        type: 'system_note',
-        id: this.deps.newId(),
-        ts: this.deps.now(),
-        kind: 'abort',
-        ...(abortSource ? { data: { source: abortSource } } : {}),
-      } satisfies SystemNoteMessage);
-      for (const run of stoppedRuns) run.completeStop();
-    } catch (error) {
-      for (const run of stoppedRuns) run.releaseStopAttempt();
-      throw error;
+    let operation = this.stopOperations.get(sessionId);
+    if (!operation) {
+      operation = {
+        abortSource: normalizeStopSessionSource(input.source),
+        targets: new Map(),
+      };
     }
+    for (const active of activeSessions) {
+      const stoppedRuns = [...active.activeRuns.values()].filter((run) => {
+        run.stop(input.source);
+        return run.hasPendingStop();
+      });
+      if (stoppedRuns.length === 0) continue;
+      const target = operation.targets.get(active) ?? { active, runs: new Set(), delivered: false };
+      for (const run of stoppedRuns) target.runs.add(run);
+      operation.targets.set(active, target);
+    }
+    if (operation.targets.size === 0) return;
+    this.stopOperations.set(sessionId, operation);
+
+    const undelivered = [...operation.targets.values()].filter((target) => !target.delivered);
+    const results = await Promise.allSettled(undelivered.map((target) => target.active.backend.stop('user_stop')));
+    let stopError: unknown;
+    results.forEach((result, index) => {
+      if (result.status === 'fulfilled') undelivered[index]!.delivered = true;
+      else stopError ??= result.reason;
+    });
+    if (stopError !== undefined) throw stopError;
+
+    const stoppedRuns = [...new Set([...operation.targets.values()].flatMap((target) => [...target.runs]))];
+    await this.updateStatus(sessionId, 'aborted');
+    for (const run of stoppedRuns.filter((activeRun) => !activeRun.lineage.parentRunId)) {
+      await this.appendTurnState(
+        sessionId,
+        run.turnId,
+        'aborted',
+        run.lineage,
+        { ts: this.deps.now(), abortSource: operation.abortSource },
+      ).catch(() => {});
+    }
+    await this.deps.store.appendMessage(sessionId, {
+      type: 'system_note',
+      id: this.deps.newId(),
+      ts: this.deps.now(),
+      kind: 'abort',
+      ...(operation.abortSource ? { data: { source: operation.abortSource } } : {}),
+    } satisfies SystemNoteMessage);
+    for (const run of stoppedRuns) run.completeStop();
+    this.stopOperations.delete(sessionId);
   }
 
   async respondToPermission(sessionId: string, response: PermissionResponse): Promise<void> {

--- a/packages/runtime/src/runtime-kernel.ts
+++ b/packages/runtime/src/runtime-kernel.ts
@@ -391,10 +391,13 @@ export class RuntimeKernel implements RuntimeKernelLike {
     const activeSessions = this.activeSessionsFor(sessionId);
     if (activeSessions.length === 0) return;
     const abortSource = normalizeStopSessionSource(input.source);
-    const activeRuns = activeSessions.flatMap((active) => [...active.activeRuns.values()]);
-    const stoppedRuns = activeRuns.filter((run) => run.stop(input.source));
+    const stoppedSessions = activeSessions.map((active) => ({
+      active,
+      stoppedRuns: [...active.activeRuns.values()].filter((run) => run.stop(input.source)),
+    })).filter(({ stoppedRuns }) => stoppedRuns.length > 0);
+    const stoppedRuns = stoppedSessions.flatMap(({ stoppedRuns: runs }) => runs);
     if (stoppedRuns.length === 0) return;
-    await Promise.all(activeSessions.map((active) => active.backend.stop('user_stop')));
+    await Promise.all(stoppedSessions.map(({ active }) => active.backend.stop('user_stop')));
     await this.updateStatus(sessionId, 'aborted');
     for (const run of stoppedRuns.filter((activeRun) => !activeRun.lineage.parentRunId)) {
       await this.appendTurnState(

--- a/packages/runtime/src/runtime-kernel.ts
+++ b/packages/runtime/src/runtime-kernel.ts
@@ -393,7 +393,10 @@ export class RuntimeKernel implements RuntimeKernelLike {
     const abortSource = normalizeStopSessionSource(input.source);
     const stoppedSessions = activeSessions.map((active) => ({
       active,
-      stoppedRuns: [...active.activeRuns.values()].filter((run) => run.stop(input.source)),
+      stoppedRuns: [...active.activeRuns.values()].filter((run) => {
+        run.stop(input.source);
+        return run.hasPendingStop();
+      }),
     })).filter(({ stoppedRuns }) => stoppedRuns.length > 0);
     const stoppedRuns = stoppedSessions.flatMap(({ stoppedRuns: runs }) => runs);
     if (stoppedRuns.length === 0) return;
@@ -415,6 +418,7 @@ export class RuntimeKernel implements RuntimeKernelLike {
       kind: 'abort',
       ...(abortSource ? { data: { source: abortSource } } : {}),
     } satisfies SystemNoteMessage);
+    for (const run of stoppedRuns) run.completeStop();
   }
 
   async respondToPermission(sessionId: string, response: PermissionResponse): Promise<void> {

--- a/packages/runtime/src/runtime-runner.ts
+++ b/packages/runtime/src/runtime-runner.ts
@@ -419,8 +419,9 @@ function failureFromTerminalEvent(event: RuntimeEvent): InvocationFailure | unde
   if (status === 'failed') {
     const message = content?.kind === 'error' ? content.message : undefined;
     const classFromContent = content?.kind === 'error' ? (content.reason ?? content.code) : undefined;
+    const classFromState = event.actions?.stateDelta?.failureClass;
     return {
-      class: classFromContent ?? 'runtime_error',
+      class: classFromContent ?? (typeof classFromState === 'string' ? classFromState : 'runtime_error'),
       ...(message ? { message } : {}),
       terminalStatus: status,
     };

--- a/packages/runtime/src/session-manager.ts
+++ b/packages/runtime/src/session-manager.ts
@@ -46,7 +46,11 @@ import type {
 } from '@maka/core/runtime-inputs';
 import type { PermissionResponse } from '@maka/core/permission';
 import type { PermissionMode } from '@maka/core/permission';
-import { DEEP_RESEARCH_SESSION_LABEL, isDeepResearchSession } from '@maka/core';
+import {
+  DEEP_RESEARCH_SESSION_LABEL,
+  failureClassFromCompleteStopReason,
+  isDeepResearchSession,
+} from '@maka/core';
 import type { AgentRunEvent, AgentRunHeader, AgentRunStore, ArtifactRecord, RuntimeEvent, RuntimeEventStore } from '@maka/core';
 import {
   type RuntimeEventTerminalFact,
@@ -532,6 +536,7 @@ export class SessionManager {
 
     const completedAt = this.deps.now();
     const run = await this.findRunByTurnId(sessionId, turnId);
+    const failureClass = run?.failureClass ?? summary.failureClass;
     const artifacts = this.deps.listArtifactsForTurn
       ? await this.deps.listArtifactsForTurn(sessionId, turnId)
       : [];
@@ -548,7 +553,7 @@ export class SessionManager {
       completedAt,
       durationMs: Math.max(0, completedAt - startedAt),
       eventCount: summary.eventCount,
-      ...(run?.failureClass ? { failureClass: run.failureClass } : {}),
+      ...(failureClass ? { failureClass } : {}),
     };
   }
 
@@ -1068,6 +1073,7 @@ function trimSummary(text: string): string {
 
 class ChildAgentSummaryAccumulator {
   eventCount = 0;
+  failureClass: string | undefined;
   private terminalStatus: SpawnChildAgentResult['status'] | undefined;
   private lastTextComplete = '';
   private textDeltaTail = '';
@@ -1091,7 +1097,8 @@ class ChildAgentSummaryAccumulator {
         this.terminalStatus = 'cancelled';
         break;
       case 'complete':
-        if (event.stopReason === 'error') this.terminalStatus = 'failed';
+        this.failureClass = failureClassFromCompleteStopReason(event.stopReason);
+        if (this.failureClass) this.terminalStatus = 'failed';
         else if (event.stopReason === 'user_stop') this.terminalStatus = 'cancelled';
         else this.terminalStatus = 'completed';
         break;

--- a/packages/ui/src/__tests__/materialize.test.ts
+++ b/packages/ui/src/__tests__/materialize.test.ts
@@ -60,4 +60,17 @@ describe('materializeChat attachments', () => {
       'Context summary failed; the session continued without a new summary.',
     );
   });
+
+  test('surfaces a step-limit system notice inline', () => {
+    const items = materializeChat([
+      { type: 'system_note', id: 'note-1', turnId: 't1', ts: 1, kind: 'step_limit' },
+    ]);
+
+    assert.equal(items.length, 1);
+    assert.equal(items[0].role, 'system');
+    assert.equal(
+      items[0].text,
+      'Reached the configured step limit. The task may be incomplete. Send “continue” to resume.',
+    );
+  });
 });

--- a/packages/ui/src/materialize.ts
+++ b/packages/ui/src/materialize.ts
@@ -1,4 +1,4 @@
-import { deriveTurnRecords, toolResultActivityStatus } from '@maka/core';
+import { deriveTurnRecords, STEP_LIMIT_NOTICE_TEXT, toolResultActivityStatus } from '@maka/core';
 import type { AttachmentRef, StoredMessage, ToolActivityKind, ToolResultContent, TurnRecord, TurnStatus } from '@maka/core';
 import type { LiveTurnProjection } from './live-turn-projection.js';
 
@@ -82,11 +82,13 @@ export interface ToolActivityItem {
 const VISIBLE_SYSTEM_NOTES = new Set<string>([
   'context_compacted',
   'context_compaction_failed_open',
+  'step_limit',
 ]);
 
 const SYSTEM_NOTE_LABELS: Record<string, string> = {
   context_compacted: 'Context compacted to keep this session within the model window.',
   context_compaction_failed_open: 'Context summary failed; the session continued without a new summary.',
+  step_limit: STEP_LIMIT_NOTICE_TEXT,
   mode_change: 'Permission mode changed',
   turn_aborted: 'Turn aborted',
 };


### PR DESCRIPTION
## Summary

- Report an explicit tool-step limit as `step_limit` instead of a successful turn.
- Show a deterministic, non-assistant system notice without making another model request.
- Keep the session active so the existing composer can continue the task.

## Why

An explicit `maxSteps` can stop a turn before the requested work is complete. Treating that outcome as success hides unfinished work from users, persistence, CLI callers, and benchmark consumers.

The runtime should report this fact directly. Asking the model to summarize after the budget is exhausted adds cost, latency, lifecycle edge cases, and the risk of misleading completion claims without improving the underlying result.

Fixes #761.

## Scope

Automatic continuation in interactive clients, new UI controls, default step budgets, and general loop detection remain out of scope. Existing Headless harnesses retain their own continuation policies.

## Verification

- `npm test -w @maka/core`
- `npm test -w @maka/runtime`
- `npm test -w packages/cli`
- `npm test -w @maka/ui`
- `npm test -w @maka/headless`
- All passed.
- Runtime tests verify that no auxiliary model request or synthetic assistant text is produced.
- Persistence tests verify that the turn and run use `tool_step_cap_reached` while the session remains active.
- CLI tests verify the live notice, history replay, continuation guard, and non-zero `maka run` result.
- UI tests verify that the existing system-note component renders the fixed notice.
- Visual evidence is not included because this reuses the existing system-note presentation without changing layout or interaction; text and materialization contracts cover the visible change.

## Impact

Explicitly configured step limits now produce a non-success result and a fixed system notice. Consumers continue to use the established `tool_step_cap_reached` failure class. No migration or configuration changes are required.

The change makes no additional model request, so reaching the limit adds no model latency or token cost.

## Reviewer notes

The terminal RuntimeEvent is the single persisted source of truth. Live clients and history projection derive the same notice from it rather than storing a second business fact.

The implementation deliberately avoids a new lifecycle status: the turn and run fail, while the session remains active for manual continuation.

## Ready for review

- [x] Verification is complete and the results above are current
- [x] Impact, compatibility, migration, documentation, and release-note needs are addressed
- [x] User-visible UI/UX changes include visual evidence, or `Verification` explains why it is not applicable
