### PR TITLE
docs: add Runtime Event Log architecture chapter

### DIFF
--- a/docs/architecture/runtime-core-architecture-draft.en.md
+++ b/docs/architecture/runtime-core-architecture-draft.en.md
@@ -1,0 +1,434 @@
+---
+doc_id: architecture.runtime-core
+title: "Chapter 1: Log Is the Runtime—Replaying an Agent's State Space"
+language: en
+source_language: zh-CN
+counterpart: ./runtime-core-architecture-draft.zh-CN.md
+implementation_status: current
+document_status: draft
+translation_status: synced
+last_verified: 2026-07-12
+owners:
+  - maka-backend
+---
+
+# Chapter 1: Log Is the Runtime—Replaying an Agent's State Space
+
+> This chapter answers one question: how does Maka preserve the state space an agent execution actually traversed, then recover it in the next turn, after a process restart, or through a new projection? The answer is the Runtime Event Log. The model loop produces facts; the Event Log preserves them; Sessions, Runs, the UI, model context, and recovery are consumers or projections of that log.
+
+This chapter is for engineers entering the Maka Runtime for the first time and maintainers changing its main execution path. The first half should give you a working map of the runtime boundaries. By the end, you should be able to locate the main implementation and understand the invariants that changes to termination, tools, or persistence must preserve.
+
+The chapter describes the implementation on the production path as verified on 2026-07-12. Phase plans in historical design documents are not treated as current behavior.
+
+## Start with a deceptively simple request
+
+Suppose a user asks Maka:
+
+> Find the failing tests in this project, fix the problem, and run the tests again.
+
+In a chat application, the path might be only three steps: send text to a model, wait, and display the reply. An agent execution looks more like this:
+
+1. The model inspects the project and test output.
+2. It calls file, search, or terminal tools.
+3. A tool may require user approval, temporarily parking execution.
+4. A tool may stream output, fail, time out, or be cancelled.
+5. The result goes back to the model, which chooses the next step.
+6. The model-to-tool-to-model cycle may repeat many times.
+7. The system must eventually decide whether the execution completed, failed, or was stopped by the user.
+
+Meanwhile, the UI needs live text and tool activity. The next model turn needs trustworthy history. After a process crash, the session must not remain “running” forever. After the user presses Stop, a late provider event must not rewrite the result to “completed.”
+
+The Runtime therefore solves a broader problem than calling an LLM API:
+
+> It records an open-ended loop containing streams, tool side effects, user intervention, and process failure as a fact history that can be interpreted and replayed again.
+
+## The conclusion first: state is a function of the log
+
+The central design decision in the Maka Runtime is not its choice of model SDK or the number of layers in its execution path. It is this:
+
+> **The Runtime Event Log is the semantic source of truth for agent interaction. System state at a point in time is a projection over that ordered log.**
+
+The relationship can be written simply:
+
+```text
+State(t) = Project(RuntimeEvents[0..t], policy, runtime configuration)
+```
+
+Different consumers can interpret the same log into different forms of state:
+
+- the Model History Projector builds the messages needed by the next model call;
+- the Runtime Read Model builds the conversation, tool activity, and Turn state shown by the UI;
+- the Terminal Fact Classifier determines the outcome of a Run;
+- recovery determines which facts were durable before the process exited;
+- context-budget and compaction policies build a smaller working context while preserving required semantics;
+- a future debugger can stop at any event boundary and inspect the agent state space at that point.
+
+```mermaid
+flowchart TD
+    L["Runtime Event Log\nordered semantic facts"]
+    L --> M["Model-history projection"]
+    L --> U["UI / Session projection"]
+    L --> T["Terminal fact / Run state"]
+    L --> R["Recovery and repair"]
+    L --> C["Context selection / compaction"]
+    M --> N["Next model request"]
+```
+
+Read this diagram from the center. The `Runtime Event Log` contains stable facts; every other node is a derived view that may evolve, be rebuilt, or be replaced. The event-production path is intentionally omitted and introduced later.
+
+This differs fundamentally from an application log. An application log usually describes what the code did after business logic ran and primarily helps humans diagnose it. A RuntimeEvent is itself part of the business semantics. User messages, model responses, thinking, function calls, function responses, permission actions, usage, and terminal status enter the log as strongly typed facts. Remove the log, and the system loses the reliable basis for reconstructing interaction state.
+
+## What one RuntimeEvent preserves
+
+`RuntimeEvent` is more than `role + text`. It separates a fact into orthogonal dimensions:
+
+| Dimension | Key fields | Meaning |
+|---|---|---|
+| Identity | `sessionId`, `invocationId`, `runId`, `turnId`, `branch` | Which conversation, call, execution attempt, and branch owns the fact |
+| Ordering | `id`, `ts`, and ledger order | The fact's position in causal history |
+| Source | `role`, `author` | Its lane in model history and the subsystem that produced it |
+| Content | text, thinking, function call/response, error | The semantic content of the AI interaction |
+| Actions | state delta, permission, artifact, usage, end invocation | The control-state change or side effect the Runtime must record |
+| Correlation | tool call, provider event, step, and artifact refs | How the same operation is paired across subsystems |
+| Lifecycle | `partial`, `status` | Whether it is a replaceable stream fragment, a durable fact, or a terminal fact |
+
+This preserves the original semantics of model interaction rather than a UI-formatted transcript. In particular:
+
+- thinking may carry a provider-required signature;
+- tool calls and results are paired by stable IDs;
+- a tool call can point to its assistant step;
+- permission requests and decisions are actions, not text pretending to be chat;
+- a terminal event closes an Invocation explicitly instead of relying on whether the last message looks like an answer.
+
+Model history therefore does not need to reverse-engineer the UI transcript. It can select non-partial, model-visible RuntimeEvents, preserve their order, and materialize text-only or provider-native messages according to provider capabilities. The UI is likewise a projection rather than the source of truth.
+
+## What “replaying the state space” means
+
+Replay has three levels that should be distinguished precisely.
+
+### Semantic replay: implemented today
+
+Given a RuntimeEvent ledger, Maka can reconstruct user and model text, thinking, tool calls and results, permission actions, usage, and terminal facts. The next model history and the completed Session read model already prefer this ledger.
+
+This lets the system answer: before a given event boundary, which interactions had the model seen? Which tools had it called? What had they returned? Which permissions had been requested or decided? Had the Invocation ended?
+
+### Provider-native replay: capability-gated
+
+Providers impose different requirements on tool history and signed thinking. Maka does not blindly feed every event back to every model. It first builds a replay plan that checks partials, tool call/result pairing, step IDs, thinking signatures, and provider support, then chooses provider-native replay, text-only replay, or an explicit degradation path.
+
+Replay does not mean “send the JSONL unchanged to any model.” It means preserving facts rich enough for a projector to produce valid history for a particular provider while reporting any semantic loss.
+
+### Bit-exact wire replay: not implied by the message log alone
+
+RuntimeEvents preserve canonical message semantics for AI interaction, but they are not a full byte-level snapshot of every provider HTTP request. The system prompt, tool schemas, provider options, model implementation version, and context-selection or compaction policy still participate in the final request. The current system records some identities, diagnostics, and hashes for these inputs, but it does not copy the entire wire request into the RuntimeEvent ledger.
+
+“State-space replay” in this chapter therefore means reconstructing interaction semantics and Runtime state first. A future promise of bit-exact deterministic replay would also require versioning or snapshotting runtime configuration, prompts, the tool catalog, projection policy, and provider request shape. This does not weaken the Event Log; it clarifies why the log is the correct foundation. Message facts remain stable while request materialization can evolve independently.
+
+## Two lines of intellectual influence
+
+The design has two explicit conceptual roots.
+
+The first is Google ADK. ADK treats a Session as a fact container with a chronological sequence of Events. An Event carries content, author, invocation identity, partial state, and actions; Session state is updated from event state deltas, while working model context is selected and transformed from event history. Maka borrows the deeper principle rather than merely a similar field layout: **Session history is fact; working context is a computed projection.**
+
+The second is the log-first tradition in distributed data systems. Database WALs, replicated logs, event sourcing, and Kafka share an intuition: do not let every downstream view become an independent truth. Preserve ordered, unambiguous change facts first, then let consumers rebuild their state. If order and commit boundaries are trustworthy, caches, indexes, search views, and even partially damaged state tables can be regenerated.
+
+Maka is not implementing Kafka inside one process, nor does it claim that RuntimeEventStore is a distributed consensus log. The borrowed principle is more fundamental:
+
+> **Log is the source of truth; state is a materialized view.**
+
+That principle directly explains the most important terminal invariant later in this chapter: a Run header cannot declare completion on its own; a terminal RuntimeEvent must support it.
+
+## Four identities that should not be collapsed
+
+Before following the main path, separate four concepts that are often used interchangeably in casual discussion.
+
+| Concept | Question it answers | Identity in the current implementation |
+|---|---|---|
+| Session | Which long-lived interaction owns these conversations and executions? | `sessionId` |
+| Turn | Which user-visible exchange is this? | `turnId` |
+| Run | Which concrete execution attempt is this, and what is its state? | `runId` / `AgentRun` |
+| Invocation | What is the standard start-to-terminal boundary of one Flow call? | `invocationId` / `RuntimeRunner` |
+
+On the default production path today, `AgentRun` creates a `runId` first and passes the same value to `RuntimeRunner` as the `invocationId`. The IDs are therefore usually equal, but the concepts remain distinct. A Run is a durable execution entity. An Invocation is the call boundary standardized by the Runner. Keeping both concepts leaves room for retries, scheduling, or multiple attempts without redefining the event protocol.
+
+The key distinction is simple: **a Turn is not a Run, and chat messages are not execution state.** A user-visible exchange needs a system-visible execution envelope. Without one, the system can only say that some messages appeared; it cannot reliably say whether the execution actually ended.
+
+## The execution path around the Event Log
+
+The interactive and generic Headless paths currently share this runtime spine:
+
+```mermaid
+flowchart LR
+    A["Caller"] --> B["SessionManager"]
+    B --> C["RuntimeKernel"]
+    C --> D["AgentRun"]
+    D --> E["RuntimeRunner"]
+    E --> F["AiSdkFlow"]
+    F --> G["AgentBackend"]
+    G --> H["ModelAdapter"]
+    G --> I["ToolRuntime"]
+    H --> J["Model Provider"]
+    I --> K["Tools / Workspace / Child Agents"]
+```
+
+Read the diagram from left to right. The left side is closer to product entry points and long-lived Sessions. The right side is closer to one provider request and concrete tool side effects. Persistence projections and ledgers are omitted here and introduced separately below.
+
+These layers do more than split a large function. More precisely, they divide responsibility for producing, normalizing, committing, and consuming the Event Log. Each protects a different kind of stability.
+
+### `SessionManager`: the stable product entry point
+
+`SessionManager.sendMessage()` is the public facade. It is now deliberately thin: public Session operations remain here, while execution is delegated to `RuntimeKernel.startTurn()`.
+
+Desktop, CLI, bot, and Headless callers therefore do not need to understand the Run ledger, Flow, or terminal facts. Runtime internals can evolve while callers continue to express one stable operation: send a user message to a Session.
+
+### `RuntimeKernel`: the control plane for active execution
+
+`RuntimeKernel` turns a Session request into an active Run. It is responsible for:
+
+- creating an `AgentRun`;
+- creating or reusing the Backend bound to a Session;
+- registering active Runs and maintaining the `turnId → runId` mapping;
+- routing stop and permission responses to the active Backend;
+- assembling `RuntimeRunner` and `AiSdkFlow`;
+- persisting the RuntimeEvent before returning the original `SessionEvent` stream to the caller;
+- ensuring `AgentRun.finalize()` runs when the Flow finishes.
+
+It is an orchestration boundary, not the model loop. A Backend should not own the set of active Runs for a Session, and a product entry point should not decide whether a terminal RuntimeEvent is durable. The Kernel centralizes this cross-layer coordination.
+
+### `AgentRun`: the durable execution envelope
+
+`AgentRun` gives one execution a durable identity and lifecycle. At startup it:
+
+1. creates an `AgentRunHeader` in `created` state;
+2. writes the user message and a `running` Turn projection for a top-level Run;
+3. writes the initial user `RuntimeEvent`;
+4. locks the Session's connection configuration;
+5. ensures a Backend exists and registers the active Run;
+6. marks the Run as `running`;
+7. builds model history from earlier RuntimeEvent ledgers.
+
+While execution is active, `AgentRun` receives both legacy `SessionEvent`s and canonical `RuntimeEvent`s and writes each to the projection or ledger it belongs to. At the end, it unregisters the active Run, converges Session and Turn state, and commits the final Run state.
+
+Think of `AgentRun` as the durable envelope around an execution. It does not choose which tool the model calls next. It guarantees which execution this is, which facts it produced, and how it ended.
+
+### `RuntimeRunner`: uniform Invocation semantics
+
+`RuntimeRunner` neither calls a provider nor executes a tool. It defines the protocol that every Flow must obey:
+
+- a failed preflight must not start the Flow or pretend that an Invocation was admitted;
+- the initial user RuntimeEvent must precede every Flow event;
+- the Flow must produce a terminal RuntimeEvent;
+- a thrown error, missing terminal event, denied permission, abort, or incomplete finish reason must produce a structured failure;
+- a successful result must contain non-empty final model text.
+
+The Runner returns an `InvocationResult` containing the ordered events, status, final output, or failure classification. This turns backend-specific streaming behavior into a stable invocation outcome.
+
+The Runner exposes an injectable preflight gate, but the current production path assembled by `RuntimeKernel` does not inject one. Preflight is therefore an implemented Runner capability, not a separate admission stage on the current desktop path.
+
+### `AiSdkFlow`: the bridge from legacy events to runtime facts
+
+The current model/tool loop still emits renderer-facing `SessionEvent`s through `AgentBackend.send()`. `AiSdkFlow` wraps the Backend and maps each event to a canonical `RuntimeEvent`:
+
+- model text and thinking become model content;
+- `tool_start` and `tool_result` become function calls and responses;
+- permission requests and decisions become first-class runtime actions;
+- token usage becomes a runtime action;
+- error, abort, and complete events become explicit failure or terminal facts.
+
+It also enforces a crucial rule: **one Invocation exposes only one accepted terminal RuntimeEvent.** A Backend may emit `abort` followed by `complete(user_stop)` during cancellation. The Flow accepts the first terminal fact and silently drains late events, preventing double termination.
+
+Despite its name, `AiSdkFlow` depends on the `AgentBackend` interface. It can wrap the production `AiSdkBackend` or another conforming Backend. It does not reimplement the model loop; it standardizes event semantics around it.
+
+### `AgentBackend`: where the model/tool loop actually runs
+
+For the default `AiSdkBackend`, the core loop remains inside `send()`. It:
+
+1. resolves the model and prepares the tools visible in this turn;
+2. constructs provider messages from RuntimeEvent history and applies context-budget policy;
+3. combines the system prompt, current user input, and attachments;
+4. starts AI SDK `streamText()` through `ModelAdapter`;
+5. consumes text, thinking, step boundaries, finish reasons, and usage;
+6. enters `ToolRuntime` when the model issues a tool call;
+7. returns the tool result to the next model step;
+8. repeats until the model finishes, reaches a limit, errors, or is aborted.
+
+The default step limit is 50. If the model still requests tools at the cap, the Runtime retains the completed tool results and, when no closing text exists, adds a deterministic notice that tells the user how to continue in a new Turn. The UI is not left with an unexplained final tool row.
+
+`ModelAdapter` isolates provider and AI SDK differences: model construction, stream startup, chunk normalization, usage normalization, and error classification. `ToolRuntime` isolates the high-risk side of execution: tool-availability enforcement, permissions, timeout and abort propagation, repeated-failure gating, output, telemetry, and artifact recording.
+
+## How the loop advances
+
+This sequence focuses on a normal execution that includes a tool call. It intentionally omits some telemetry and compatibility projections to show how control moves between the model and tools.
+
+```mermaid
+sequenceDiagram
+    participant U as User
+    participant K as RuntimeKernel
+    participant R as AgentRun
+    participant RR as RuntimeRunner
+    participant F as AiSdkFlow
+    participant B as AiSdkBackend
+    participant M as Model Provider
+    participant T as ToolRuntime
+
+    U->>K: sendMessage(turnId, text)
+    K->>R: begin()
+    R-->>K: backend + history + initial RuntimeEvent
+    K->>RR: run(InvocationRequest)
+    RR->>F: run(context, input)
+    F->>B: send(BackendSendInput)
+    B->>M: streamText(messages, tools)
+    M-->>B: thinking / text / tool call
+    B->>T: execute(tool, args)
+    T-->>B: tool result
+    B->>M: next step with tool result
+    M-->>B: final text + finish
+    B-->>F: SessionEvents
+    F-->>RR: RuntimeEvents + one terminal event
+    R->>R: commit terminal fact and finalize projections
+```
+
+An AI SDK step is the natural beat of this loop. Maka persists assistant text and thinking per step rather than flattening a whole Turn into one final assistant message. Tool calls carry the corresponding step ID, allowing replay to reconstruct the original ordering among thinking, text, and tool calls.
+
+The provider is silent while a tool runs. `ToolRuntime` pauses the model stream's idle watchdog because that silence is expected. Individual tools may still enforce their own timeouts, while an outer Run or evaluation layer remains the final backstop.
+
+## Permission is runtime control flow, not a dialog box
+
+When the model requests a tool that may cause side effects, `ToolRuntime` asks `PermissionEngine` to evaluate the call. The result is one of three kinds:
+
+- **allow**: execute the tool immediately;
+- **block**: record the denial and a synthetic tool error without running the implementation;
+- **prompt**: emit a permission request, pause the watchdog, and wait for the user.
+
+While waiting, the Session projects `waiting_for_user`, but the Invocation retains its execution identity. The decision is routed through `RuntimeKernel.respondToPermission()` to the active Backend. `ToolRuntime` records the permission decision and either continues execution or returns a denied tool result.
+
+The important point is that permission is not a UI-only pause. Requests and decisions enter the runtime fact model, so replay, diagnostics, and recovery can explain why execution stopped and how control returned.
+
+## One semantic truth, two supporting forms of state
+
+Maka currently maintains three forms of durable data. They are not three equal sources of truth, nor do they store the same chat three times. `RuntimeEventStore` is the canonical semantic log of AI interaction; the other stores carry product projections and operational Run state.
+
+| Store | Main contents | Question it answers best |
+|---|---|---|
+| `SessionStore` | `StoredMessage`s for users, assistants, tools, and Turn state | What should the UI and compatibility APIs display? What is the current in-flight projection? |
+| `AgentRunStore` | `run.json` and operational `events.jsonl` | When did this Run start, what is its state, and at which model or tool stage did it fail? |
+| `RuntimeEventStore` | canonical `runtime-events.jsonl` plus bounded partial snapshots | Which semantic facts occurred, and how should other state be rebuilt from them? |
+
+The file-backed implementation organizes these around this layout:
+
+```text
+sessions/<sessionId>/
+  ... session projection ...
+  runs/<runId>/
+    run.json
+    events.jsonl
+    runtime-events.jsonl
+    runtime-partials/
+```
+
+`AgentRunStore` events act more like an operational index: model stream started, tool started, permission requested, usage recorded. They help diagnose and manage a Run but do not replace the model-interaction log. `RuntimeEventStore` contains the reconstructable semantic facts: user content, model content, function calls and responses, permission actions, and the terminal fact.
+
+For completed Runs with a healthy ledger, reads and the next model replay prefer RuntimeEvents. `SessionStore` remains necessary for compatibility and in-flight projection, but it is no longer the only authority for completed runtime semantics.
+
+Streaming text and thinking deltas are not appended forever to immutable JSONL. The file RuntimeEventStore keeps bounded, replaceable partial snapshots. A final non-partial event supersedes the snapshot. This preserves output that was visible before a crash without turning 10,000 deltas into 10,000 permanent ledger rows.
+
+## The log-first invariant: terminal fact before terminal state
+
+One of the hardest runtime failure classes is disagreement about whether an execution ended. For example:
+
+- `run.json` says completed, but the RuntimeEvent ledger has no terminal event;
+- the user stopped the Run, but a late complete event rewrites the Session to active;
+- the Backend stream exhausts without saying whether it succeeded or failed;
+- the terminal event is durable, but the process crashes before updating the Run header.
+
+Maka protects this core invariant:
+
+> A terminal Run must have exactly one valid terminal RuntimeEvent, and a terminal Run header must be supported by that terminal fact.
+
+`AgentRun` therefore requires the terminal RuntimeEvent to be durable before committing a terminal Run header. A Flow without a terminal event becomes a `missing_terminal_event` failure. Duplicate terminal events are coalesced. Terminal events with a mismatched status, a different Run identity, or `partial: true` are rejected.
+
+If the terminal RuntimeEvent exists but an interrupted header remains `running`, the read model can treat the event as the stronger fact and recovery can repair the header. In the opposite direction, if a header claims termination without a trustworthy terminal fact, the system does not blindly trust the header; it conservatively repairs the Run as a `missing_terminal_event` failure.
+
+This invariant means recovery does not need to guess what the model intended to do next. It only needs to determine which facts are durable and converge all projections on one explainable outcome.
+
+## How stop, errors, and crashes converge
+
+### User stop
+
+`RuntimeKernel.stopSession()` first marks active `AgentRun`s as stopped, then calls Backend `stop()`. `AiSdkBackend` aborts the provider stream, ends permission waits, and emits abort/complete events. Even if a provider later produces a complete or error event, `AiSdkFlow` and `AgentRun` do not allow it to overwrite the established aborted semantics. The stop source, such as the renderer stop button, is retained in the terminal fact and Run header for diagnostics.
+
+### Provider or runtime error
+
+An error is first normalized as non-terminal error content, followed by a failed terminal event that closes the Invocation. `RuntimeRunner` does not allow a later completed event to mask an error it has already observed. If the Backend throws directly or exhausts without a terminal event, the Runner and Flow produce a structured failure instead of leaving a dangling Run.
+
+### Process crash and startup recovery
+
+Startup recovery does not re-execute model requests or tool side effects. It scans non-terminal Runs and RuntimeEvent ledgers, identifies stale model streams, tool tails, permission waits, and corrupt operational events, then conservatively commits failure or cancellation and repairs Session and Turn projections.
+
+This is state repair, not checkpoint resume. The current Runtime can retain partial output, recover a consistent terminal state, and provide the facts needed for future mid-run recovery. It does not automatically continue from the line after an interrupted tool call when the process restarts.
+
+## What this design buys—and what it costs
+
+### Capabilities gained
+
+- Product entry points do not depend on a specific provider or tool-loop implementation.
+- Different Backends can share Invocation and terminal semantics.
+- UI events and model-replayable facts have explicit, separate roles.
+- User stop, permissions, and tool side effects become diagnosable control flow.
+- Crash recovery can converge state from durable facts.
+- Headless runs, child agents, and future schedulers can reuse the same execution core.
+
+### Current costs
+
+- The migration period contains `SessionEvent`, `StoredMessage`, `RuntimeEvent`, and operational Run events, making event mapping expensive to maintain.
+- `AiSdkBackend` remains large and coordinates history, context budgets, tool availability, the step loop, usage, and telemetry.
+- `AiSdkFlow` is still a legacy-to-canonical adapter rather than consuming native RuntimeEvents from the Backend.
+- `SessionStore` and RuntimeEvent projection must cooperate for active and in-flight reads.
+- Startup recovery currently performs deterministic termination and repair, not arbitrary warm resume.
+- The Runner's preflight seam exists, but the production Kernel does not yet connect a dedicated Runtime gate.
+
+These are real architecture boundaries, not details to hide. Future Backend decomposition or checkpoint work must preserve request shape, tool visibility, event order, and the terminal invariant before optimizing for smaller files.
+
+## Code-reading map
+
+Read the current implementation in this order:
+
+1. `packages/runtime/src/session-manager.ts`: public and recovery entry points.
+2. `packages/runtime/src/runtime-kernel.ts`: active Run/Backend control and main-path assembly.
+3. `packages/runtime/src/agent-run.ts`: durable lifecycle, history construction, and terminal commit.
+4. `packages/runtime/src/runtime-runner.ts`: Invocation protocol and outcome classification.
+5. `packages/runtime/src/ai-sdk-flow.ts`: `SessionEvent → RuntimeEvent` mapping and the single-terminal guarantee.
+6. `packages/runtime/src/ai-sdk-backend.ts`: the AI SDK model/tool step loop.
+7. `packages/runtime/src/model-adapter.ts`: provider stream adaptation.
+8. `packages/runtime/src/tool-runtime.ts`: permissions, tool execution, and side-effect boundaries.
+9. `packages/core/src/runtime-event.ts`: the canonical RuntimeEvent contract.
+10. `packages/core/src/agent-run.ts` and `packages/storage/src/agent-run-store.ts`: file-backed Run and RuntimeEvent ledgers.
+
+The most relevant tests are:
+
+- `packages/runtime/src/__tests__/runtime-runner.test.ts`
+- `packages/runtime/src/__tests__/ai-sdk-flow.test.ts`
+- `packages/runtime/src/__tests__/session-manager.test.ts`
+- `packages/runtime/src/__tests__/session-manager-terminal-ledger.test.ts`
+- `packages/storage/src/__tests__/agent-run-store.test.ts`
+
+## Summary
+
+The core of the Maka Runtime is not one class, nor is it merely the AI SDK's multi-step tool loop. It is a Runtime Event Log that preserves and replays the state space of agent interaction. The execution protocol exists to produce, commit, and project those facts:
+
+```text
+model/tool stepping engine
+  → canonical RuntimeEvents
+  → durable semantic log
+  → model history / UI / Run state / recovery projections
+```
+
+`SessionManager` stabilizes the entry point. `RuntimeKernel` controls active execution. `AgentRun` commits durable facts. `RuntimeRunner` defines Invocation semantics. `AiSdkFlow` translates Backend events into canonical facts. `AiSdkBackend`, `ModelAdapter`, and `ToolRuntime` advance the model/tool loop itself. They cooperate around the Runtime Event Log instead of each retaining a private local truth.
+
+Together, these boundaries protect a simple promise: regardless of how many model steps, tool side effects, permission waits, and failures an agent task encounters, Maka first records what actually happened. As long as that ordered fact history remains, the system can reconstruct the interaction state, materialize new views, and let the next turn continue from trustworthy history.
+
+## Further reading
+
+- [Google ADK: Architecting an efficient context-aware multi-agent framework](https://developers.googleblog.com/architecting-efficient-context-aware-multi-agent-framework-for-production/)
+- [Google ADK Python: Runner lifecycle and event persistence](https://github.com/google/adk-python/blob/main/AGENTS.md)
+- [Apache Kafka Design: replicated logs, state machines, and event sourcing](https://kafka.apache.org/36/design/design/)

--- a/docs/architecture/runtime-core-architecture-draft.zh-CN.md
+++ b/docs/architecture/runtime-core-architecture-draft.zh-CN.md
@@ -1,0 +1,434 @@
+---
+doc_id: architecture.runtime-core
+title: "第一章：Log Is the Runtime——Maka 如何回放 Agent 的状态空间"
+language: zh-CN
+source_language: zh-CN
+counterpart: ./runtime-core-architecture-draft.en.md
+implementation_status: current
+document_status: draft
+translation_status: synced
+last_verified: 2026-07-12
+owners:
+  - maka-backend
+---
+
+# 第一章：Log Is the Runtime——Maka 如何回放 Agent 的状态空间
+
+> 本章回答一个核心问题：Maka 如何保存一次 Agent 运行真正经历过的状态空间，并在下一轮、进程重启或新投影中重新得到它？答案是 Runtime Event Log。模型循环负责产生事实；Event Log 保存事实；Session、Run、UI、模型上下文和恢复逻辑都是这份日志的消费者或投影。
+
+本文面向第一次进入 Maka Runtime 的工程师，也面向需要修改运行主链的维护者。读完前半部分，你应该能说清一次运行经过哪些边界；读完整章，你应该能定位主链代码，并理解修改终止、工具或持久化逻辑时必须保护哪些不变量。
+
+本文描述的是截至 2026-07-12 已在生产主链中落地的实现。历史设计文档中的阶段性计划不作为当前事实。
+
+## 从一个看似简单的请求开始
+
+假设用户对 Maka 说：
+
+> 找出这个项目里失败的测试，修复问题，然后重新运行测试。
+
+如果 Maka 只是一个聊天应用，执行路径可能只有三步：把文字发给模型、等待回复、把回复显示出来。但 Agent 的真实执行过程更像这样：
+
+1. 模型先阅读项目和测试输出。
+2. 模型调用文件、搜索或终端工具。
+3. 某些工具需要用户授权，运行暂时停住。
+4. 工具可能持续输出，也可能失败、超时或被取消。
+5. 工具结果回到模型，模型决定下一步。
+6. 这组“模型 → 工具 → 模型”的步骤重复多次。
+7. 最后，系统必须明确判断这次运行究竟完成、失败，还是被用户中止。
+
+过程中，界面需要实时显示文本和工具活动；下一轮模型需要读到可信历史；应用崩溃重启后，系统不能永远停在“运行中”；用户按下停止按钮后，迟到的 provider 事件也不能把状态重新写成“完成”。
+
+所以，Runtime 真正解决的不是“怎样调用一次 LLM API”，而是：
+
+> 如何把一个包含流式输出、工具副作用、用户介入和进程故障的开放式循环，记录成一段可以重新解释和回放的事实历史。
+
+## 先说结论：状态不是一张表，而是日志的函数
+
+Maka Runtime 最核心的设计判断，不是选择了哪个模型 SDK，也不是把执行逻辑拆成了多少层，而是：
+
+> **Runtime Event Log 才是 Agent 交互的语义事实源。系统在某一时刻的状态，是这段有序日志经过某种投影之后的结果。**
+
+可以把它写成一个简单的关系：
+
+```text
+State(t) = Project(RuntimeEvents[0..t], policy, runtime configuration)
+```
+
+同一段日志可以被不同消费者解释成不同状态：
+
+- Model History Projector 得到下一次模型调用需要看到的 messages；
+- Runtime Read Model 得到 UI 需要展示的对话、工具活动和 Turn 状态；
+- Terminal Fact Classifier 得到一次 Run 的最终结果；
+- Recovery 逻辑判断进程退出前哪些事实已经 durable；
+- Context Budget 与 compaction 策略得到一个更小、但保留关键语义的工作上下文；
+- 未来的调试器可以把读取位置停在任意事件边界，观察当时的 Agent 状态空间。
+
+```mermaid
+flowchart TD
+    L["Runtime Event Log\nordered semantic facts"]
+    L --> M["Model-history projection"]
+    L --> U["UI / Session projection"]
+    L --> T["Terminal fact / Run state"]
+    L --> R["Recovery and repair"]
+    L --> C["Context selection / compaction"]
+    M --> N["Next model request"]
+```
+
+这张图从中间开始读：`Runtime Event Log` 是稳定事实，其余节点是可以演进、重建或替换的派生视图。它刻意省略了事件生产路径；事件由哪些组件产生，会在后文解释。
+
+这与普通 application log 有本质区别。普通日志通常是在业务执行之后描述“代码做过什么”，主要供人排障；RuntimeEvent 本身就是业务语义的一部分。用户消息、模型回复、thinking、function call、function response、权限动作、usage 和 terminal status 都以强类型事实进入日志。删除这份日志，系统就失去了可靠重建交互状态的基础。
+
+## 一条 RuntimeEvent 保存了什么
+
+`RuntimeEvent` 不只是 `role + text`。它把一条事实拆成几组正交信息：
+
+| 维度 | 关键字段 | 意义 |
+|---|---|---|
+| Identity | `sessionId`, `invocationId`, `runId`, `turnId`, `branch` | 这条事实属于哪段会话、调用、执行尝试和分支 |
+| Ordering | `id`, `ts` 与 ledger 顺序 | 这条事实在因果历史中的位置 |
+| Source | `role`, `author` | 它在模型历史中扮演什么角色，由谁产生 |
+| Content | text, thinking, function call/response, error | AI 交互本身的语义内容 |
+| Actions | state delta, permission, artifact, usage, end invocation | 它要求 Runtime 怎样改变控制状态或记录副作用 |
+| Correlation | tool call、provider event、step 与 artifact refs | 怎样把跨系统的同一件事重新配对 |
+| Lifecycle | `partial`, `status` | 它是可替换的流式片段，还是持久事实或终止事实 |
+
+这种结构保留的不是 UI 已经格式化好的聊天文本，而是模型交互的原始语义。尤其是：
+
+- thinking 可以带 provider 需要的 signature；
+- tool call 与 tool result 通过稳定 ID 配对；
+- tool call 还能指向它所属的 assistant step；
+- permission request/decision 是 action，而不是一段伪装成聊天的文字；
+- terminal event 明确关闭一次 Invocation，而不是靠“最后一条消息看起来像回答”来猜测。
+
+因此，模型历史不需要从 UI transcript 反向解析。它可以从 RuntimeEvent 中选择 non-partial、model-visible 的事件，保持顺序，再根据 provider 能力物化成 text-only 或 provider-native messages。UI 同样不需要成为事实源，它只是另一种 projection。
+
+## “回放状态空间”究竟意味着什么
+
+这里的 replay 有三个层次，需要精确区分。
+
+### 语义回放：当前已经成立
+
+给定 RuntimeEvent ledger，Maka 可以重建用户/模型文本、thinking、工具调用与结果、权限动作、usage 和 terminal fact。下一轮模型历史与 completed Session read model 都已经优先从这份 ledger 构造。
+
+这意味着我们能回答：在某个事件边界之前，模型已经看到了哪些交互？它调用过什么工具？工具返回了什么？哪些权限被请求或决定？一次 Invocation 是否已经结束？
+
+### Provider-native 回放：有能力门控
+
+不同 provider 对 tool history 和 signed thinking 的要求不同。Maka 不会把所有事件盲目塞回模型，而是先建立 replay plan：检查 partial、tool call/result 配对、step ID、thinking signature 和 provider 支持，再决定走 provider-native、text-only，还是明确降级。
+
+这一步很重要。可回放不等于“把 JSONL 原样发给任何模型”；它意味着保留足够丰富的事实，让投影器能够为具体 provider 生成合法的历史，同时显式报告语义损失。
+
+### Bit-exact wire replay：不能只靠 message log 宣称
+
+RuntimeEvent 保存了 AI 交互的 canonical message semantics，但当前并不等于完整快照每次 provider HTTP 请求的原始字节。System prompt、工具 schema、provider options、模型实现版本以及 context selection/compaction policy 仍参与最终 request 的生成；当前系统记录了其中一些 identity、diagnostic 和 hash，但没有把整个 wire request 都复制进 RuntimeEvent ledger。
+
+因此，本章所说的“状态空间回放”首先是**交互语义与 Runtime 状态的可重建性**。如果未来要承诺 bit-exact deterministic replay，还需要对运行配置、prompt、tool catalog、投影策略和 provider request shape 做版本化或快照化。这不是削弱 Event Log 的价值，反而说明它提供了正确的基础：message facts 保持稳定，request materialization 可以独立演进。
+
+## 两条思想来源
+
+这个设计有两条明确的思想脉络。
+
+第一条来自 Google ADK。ADK 把 Session 看作带有时间顺序 Events 的事实容器；Event 同时承载 content、author、invocation identity、partial 标记与 actions，Session state 通过事件中的 state delta 更新，模型工作上下文则从事件历史选择和转换得到。Maka 借鉴的关键不是字段长得相似，而是：**Session history 是事实，working context 是计算出来的 projection。**
+
+第二条来自分布式数据系统中的 log-first 思想。数据库 WAL、replicated log、event sourcing 和 Kafka 共享一个重要直觉：不要把每个下游视图都当作独立真相；先保存有序、不可含糊的变化事实，再让消费者重建自己的状态。只要事件顺序和提交边界可信，缓存、索引、搜索视图乃至部分损坏的状态表都可以重新生成。
+
+Maka 并不是在进程内实现了 Kafka，也没有声称 RuntimeEventStore 是一个分布式共识日志。借鉴的是更基础的设计原则：
+
+> **Log is the source of truth; state is a materialized view.**
+
+这一原则直接解释了后文最重要的 terminal invariant：Run header 不能凭自己宣布完成，它必须得到 terminal RuntimeEvent 的支持。
+
+## 四个不要混在一起的身份
+
+理解主链之前，需要先分清四个经常被口语化混用的概念。
+
+| 概念 | 它回答的问题 | 当前实现中的身份 |
+|---|---|---|
+| Session | 这些对话和运行属于哪段长期交互？ | `sessionId` |
+| Turn | 用户界面中的这一轮问答是哪一轮？ | `turnId` |
+| Run | 这一次具体执行尝试是谁？状态是什么？ | `runId` / `AgentRun` |
+| Invocation | 一次 Flow 调用从开始到终止的标准边界是什么？ | `invocationId` / `RuntimeRunner` |
+
+在当前默认生产路径中，`AgentRun` 已经先创建了 `runId`，随后把同一个值交给 `RuntimeRunner` 作为 `invocationId`。因此这两个 ID 目前通常相同，但概念上仍然不同：Run 是可持久化的执行实体，Invocation 是 Runner 所规范的一次调用边界。保留这层区分，使未来的重试、调度或多次尝试不必重新定义整条事件协议。
+
+这里最重要的判断是：**Turn 不是 Run，聊天消息也不是执行状态。** 一个用户可见的回合需要一个系统可追踪的执行封套；否则，系统只能知道“出现过一些消息”，却无法可靠回答“这次执行是否真正结束”。
+
+## 围绕 Event Log 运转的执行主链
+
+当前交互式与通用 Headless 路径共用下面这条核心主链：
+
+```mermaid
+flowchart LR
+    A["Caller"] --> B["SessionManager"]
+    B --> C["RuntimeKernel"]
+    C --> D["AgentRun"]
+    D --> E["RuntimeRunner"]
+    E --> F["AiSdkFlow"]
+    F --> G["AgentBackend"]
+    G --> H["ModelAdapter"]
+    G --> I["ToolRuntime"]
+    H --> J["Model Provider"]
+    I --> K["Tools / Workspace / Child Agents"]
+```
+
+从左向右读这张图：越靠左，越接近产品入口和长期 Session；越靠右，越接近一次 provider 请求和具体工具副作用。图中省略了存储投影和事件账本，它们会在后文单独解释。
+
+这不是为了把一个函数拆成很多类。更准确地说，这些组件分担了 Event Log 的生产、规范化、提交和消费责任；每一层都在保护一种不同的稳定性：
+
+### `SessionManager`：稳定的产品入口
+
+`SessionManager.sendMessage()` 是外部调用者看到的门面。它现在很薄：读取和管理 Session 的公共能力保留在这里，而真正的执行直接委托给 `RuntimeKernel.startTurn()`。
+
+这个边界让桌面端、CLI、Bot 和 Headless 调用者不必理解 Run ledger、Flow 或 terminal fact。Runtime 内部可以演进，外部仍然只需要表达“给这个 Session 发送一条用户消息”。
+
+### `RuntimeKernel`：活跃执行的控制面
+
+`RuntimeKernel` 把一条 Session 请求组织成一次可运行的 Run。它负责：
+
+- 创建 `AgentRun`；
+- 创建或复用绑定到 Session 的 Backend；
+- 注册活跃 Run，并维护 `turnId → runId` 映射；
+- 把停止和权限响应路由到正在运行的 Backend；
+- 组装 `RuntimeRunner` 与 `AiSdkFlow`；
+- 让 RuntimeEvent 落盘后，再把原有 `SessionEvent` 流交还调用者；
+- 在 Flow 收尾时确保 `AgentRun.finalize()` 被执行。
+
+它是 orchestration boundary，而不是模型循环本身。Backend 不应该负责“这个 Session 目前有哪些活跃 Run”，产品入口也不应该负责“终止 RuntimeEvent 是否已经持久化”。这些跨层协调都收敛在 Kernel。
+
+### `AgentRun`：一次执行的 Durable Envelope
+
+`AgentRun` 让一次执行在持久世界里有身份和生命周期。开始运行时，它会：
+
+1. 创建 `AgentRunHeader`，初始状态为 `created`；
+2. 对顶层 Run 写入用户消息和 `running` Turn 投影；
+3. 写入本轮初始用户 `RuntimeEvent`；
+4. 锁定本 Session 的连接配置；
+5. 确保 Backend 已创建并注册为活跃 Run；
+6. 将 Run 标记为 `running`；
+7. 从此前的 RuntimeEvent ledger 构造模型历史。
+
+运行过程中，`AgentRun` 同时接收旧的 `SessionEvent` 与新的 `RuntimeEvent`，并把它们写入各自所属的投影或账本。结束时，它注销活跃 Run、收敛 Session/Turn 状态，并提交最终 Run 状态。
+
+可以把 `AgentRun` 理解成一次执行的“耐久封套”：它不决定模型下一步调用哪个工具，但它保证这次执行是谁、发生了什么、最后以什么状态结束。
+
+### `RuntimeRunner`：统一 Invocation 语义
+
+`RuntimeRunner` 不调用 provider，也不直接执行工具。它规定任何 Flow 都必须遵守的调用协议：
+
+- preflight 失败时，不得启动 Flow，也不得伪造一次已开始的调用；
+- 初始用户 RuntimeEvent 必须排在所有 Flow 事件之前；
+- Flow 必须产生 terminal RuntimeEvent；
+- Flow 抛错、没有终态、权限被拒绝、被中止或出现不完整 finish reason，都要得到结构化失败结果；
+- 成功结果必须包含非空的最终模型文本。
+
+`RuntimeRunner` 返回的是 `InvocationResult`，其中包含完整事件序列、状态、最终输出或失败分类。这个结果把 Backend 的流式细节收敛成稳定的 invocation outcome。
+
+Runner 已提供可注入的 preflight gate，但当前 `RuntimeKernel` 组装生产主链时没有注入 gate；因此这是已经实现的 Runner 能力，而不是当前桌面入口上的独立准入阶段。
+
+### `AiSdkFlow`：旧事件流与 Runtime 事实之间的桥
+
+当前模型/工具循环仍然由 `AgentBackend.send()` 产生 renderer-facing `SessionEvent`。`AiSdkFlow` 包住 Backend，并逐个映射成 canonical `RuntimeEvent`：
+
+- 模型文本和 thinking 变成 model content；
+- `tool_start` / `tool_result` 变成 function call / response；
+- 权限请求和决定变成一等 runtime actions；
+- token usage 变成 runtime action；
+- error、abort 和 complete 变成明确的失败或终止事实。
+
+它还有一个关键责任：**一条 Invocation 只向上游接受一个 terminal RuntimeEvent。** 例如 Backend 在中止时可能连续发出 `abort` 和 `complete(user_stop)`，Flow 会接受第一个终态并静默排空迟到事件，避免双重终止。
+
+名字虽然叫 `AiSdkFlow`，它实际依赖的是 `AgentBackend` 接口。生产中可包装 `AiSdkBackend`，也可以包装其他遵守该接口的 Backend。它不重新实现模型循环，只规范事件语义。
+
+### `AgentBackend`：模型与工具循环真正发生的地方
+
+对默认的 `AiSdkBackend` 来说，核心循环仍在 `send()` 内部。它会：
+
+1. 解析模型并准备本轮可见的工具集合；
+2. 从 RuntimeEvent 历史构造 provider messages，并应用上下文预算策略；
+3. 组合 system prompt、当前用户输入和附件；
+4. 通过 `ModelAdapter` 启动 AI SDK `streamText()`；
+5. 读取 text、thinking、step boundary、finish reason 和 usage；
+6. 让 AI SDK 在模型发起 tool call 时进入 `ToolRuntime`；
+7. 将工具结果交回下一步模型请求；
+8. 重复模型/工具 step，直到模型结束、达到上限、发生错误或被中止。
+
+默认 step 上限为 50。若模型在上限处仍要求继续调用工具，Runtime 会保留已经产生的工具结果，并在没有最终文本时补充一条确定性的提示，让用户可以在新 Turn 中继续，而不是留下一个没有收尾文本的界面。
+
+`ModelAdapter` 隔离 provider 与 AI SDK 差异，包括模型创建、stream 启动、chunk 归一化、usage 归一化和错误分类。`ToolRuntime` 则隔离工具执行的高风险部分，包括工具可用性防守、权限、超时/中止传递、重复失败拦截、工具输出、遥测和 artifact 记录。
+
+## 模型循环是怎样向前推进的
+
+下面这张时序图聚焦一次包含工具调用的正常运行。它刻意省略了部分遥测和兼容投影，只展示控制权如何在模型与工具之间转移。
+
+```mermaid
+sequenceDiagram
+    participant U as User
+    participant K as RuntimeKernel
+    participant R as AgentRun
+    participant RR as RuntimeRunner
+    participant F as AiSdkFlow
+    participant B as AiSdkBackend
+    participant M as Model Provider
+    participant T as ToolRuntime
+
+    U->>K: sendMessage(turnId, text)
+    K->>R: begin()
+    R-->>K: backend + history + initial RuntimeEvent
+    K->>RR: run(InvocationRequest)
+    RR->>F: run(context, input)
+    F->>B: send(BackendSendInput)
+    B->>M: streamText(messages, tools)
+    M-->>B: thinking / text / tool call
+    B->>T: execute(tool, args)
+    T-->>B: tool result
+    B->>M: next step with tool result
+    M-->>B: final text + finish
+    B-->>F: SessionEvents
+    F-->>RR: RuntimeEvents + one terminal event
+    R->>R: commit terminal fact and finalize projections
+```
+
+AI SDK 的 step 是这个循环的自然节拍。Maka 会按 step 持久化 assistant text/thinking，而不是把整个 Turn 压成一条最终 assistant message。工具调用会携带对应的 step ID，使 thinking、文本和工具调用在 replay 时仍能重新组成原来的执行顺序。
+
+工具运行期间，模型 provider 不会继续输出。`ToolRuntime` 会暂停模型流的 idle watchdog，因为这段安静是预期行为；具体工具仍然可以有自己的超时，而更外层的 Run 或评测系统继续充当最终 backstop。
+
+## 权限不是弹窗，而是 Runtime 控制流
+
+当模型请求一个可能产生副作用的工具时，`ToolRuntime` 先让 `PermissionEngine` 评估调用。结果有三类：
+
+- **allow**：直接执行工具；
+- **block**：写入拒绝决定和合成的工具错误，不执行真实实现；
+- **prompt**：发出权限请求，暂停 watchdog，并等待用户决定。
+
+等待期间，Session 会投影为 `waiting_for_user`，但调用本身仍保留运行身份。用户的决定通过 `RuntimeKernel.respondToPermission()` 路由回当前 Backend，再由 `ToolRuntime` 写入 permission decision，随后继续执行或返回拒绝结果。
+
+这个设计的关键是：权限不是 UI 自己暂停了一下。权限请求和决定都进入 Runtime 事实模型，因此重放、诊断和恢复能够知道运行为什么停住，以及控制权如何回来。
+
+## 一份语义事实，两类辅助状态
+
+Maka 当前同时维护三类持久数据。它们不是三个地位相同的“真相”，也不是重复保存同一份聊天。`RuntimeEventStore` 是 AI 交互的 canonical semantic log；另外两类存储承担产品投影与运行运维状态。
+
+| 存储 | 主要内容 | 它最适合回答的问题 |
+|---|---|---|
+| `SessionStore` | 用户、assistant、工具和 turn-state 等 `StoredMessage` | UI 与兼容接口要展示什么？活跃流有哪些即时投影？ |
+| `AgentRunStore` | `run.json` 与 operational `events.jsonl` | 这次 Run 何时开始、当前状态、在哪个模型或工具阶段失败？ |
+| `RuntimeEventStore` | canonical `runtime-events.jsonl` 与有界 partial snapshots | Agent 交互发生过哪些语义事实，其他状态应如何重建？ |
+
+在文件存储实现中，它们围绕下面的目录组织：
+
+```text
+sessions/<sessionId>/
+  ... session projection ...
+  runs/<runId>/
+    run.json
+    events.jsonl
+    runtime-events.jsonl
+    runtime-partials/
+```
+
+`AgentRunStore` 的事件更像 operational index：model stream 开始、tool started、permission requested、usage recorded。它帮助快速诊断和管理 Run，但不替代模型交互日志。`RuntimeEventStore` 的事件才是可重建的语义事实：用户内容、模型内容、function call/response、permission action 和 terminal fact。
+
+对于已经完成且 ledger 完整的 Run，读取与下一轮模型 replay 优先依赖 RuntimeEvent。`SessionStore` 仍然承担兼容投影和 in-flight 展示，不能简单删除；但它不再是 completed runtime 语义的唯一权威。
+
+流式 text/thinking partial 不会无限追加到 immutable JSONL。File RuntimeEventStore 会为可替换的流维护有界 partial snapshot，最终 non-partial 事件到达后覆盖其语义位置。这既保留崩溃时已经展示的部分输出，也避免 10,000 个 delta 变成 10,000 条长期账本记录。
+
+## Log-first 的关键不变量：先有终止事实，再提交终止状态
+
+Runtime 最容易出现的一类故障，是不同存储对“是否结束”给出不同答案。例如：
+
+- `run.json` 写成 completed，但 RuntimeEvent ledger 没有 terminal event；
+- 用户已经 stop，但迟到的 complete 又把 Session 写回 active；
+- Backend 流耗尽，却从未说明它是成功还是失败；
+- terminal event 已写入，但进程在更新 Run header 前崩溃。
+
+Maka 当前保护的核心不变量是：
+
+> 一个终止的 Run 必须有且只有一个有效 terminal RuntimeEvent；终止的 Run header 必须能够由这个 terminal fact 支撑。
+
+因此，`AgentRun` 在提交 terminal Run header 前，先要求 terminal RuntimeEvent 成功落盘。没有终态的 Flow 会被合成为 `missing_terminal_event` 失败；重复终态会被 Flow 合并；状态不匹配、来自其他 Run 或标记为 partial 的 terminal event 都会被拒绝。
+
+如果 terminal RuntimeEvent 已经存在，但 Run header 因中断仍是 `running`，read model 可以把 terminal event 作为更强事实来解释运行结果，并在恢复时修复 header。反过来，如果 header 声称已经结束却没有可信 terminal fact，系统不会盲目信任 header，而会保守地修复为 `missing_terminal_event` 失败。
+
+这条不变量让恢复不必“猜模型当时准备做什么”。系统只需要判断哪些事实已经 durable，然后把各个投影收敛到同一个可解释终态。
+
+## Stop、错误与崩溃如何收敛
+
+### 用户停止
+
+`RuntimeKernel.stopSession()` 会先把所有活跃 `AgentRun` 标记为 stopped，再调用 Backend 的 `stop()`。`AiSdkBackend` 会中止 provider stream、结束权限等待，并产生 abort/complete 事件。即使 provider 随后发送迟到的 complete 或 error，Flow 与 AgentRun 也不会允许它覆盖已经确定的 aborted 语义。停止来源，例如 renderer stop button，会进入 terminal fact 与 Run header，供诊断使用。
+
+### Provider 或 Runtime 错误
+
+错误首先被规范化为非终止 error content，随后由 failed terminal event 关闭 Invocation。`RuntimeRunner` 不允许后续的 completed event 掩盖之前已经观察到的错误。若 Backend 直接抛出异常或流没有终态，Runner/Flow 会产生结构化失败，而不是留下悬空运行。
+
+### 应用崩溃和启动恢复
+
+启动恢复不会重新执行模型请求或工具副作用。它扫描非终止 Run 与 RuntimeEvent ledger，识别 stale model stream、tool tail、permission wait、损坏的 operational event 等情况，然后保守地提交失败或取消状态，并修复 Session/Turn 投影。
+
+这是“状态修复”，不是 checkpoint resume。当前 Runtime 可以保留部分输出、恢复一致的最终状态，并为以后真正的中点恢复提供事实基础；它不会在进程重启后自动从某个工具调用的下一行继续执行。
+
+## 这套设计换来了什么，又付出了什么
+
+### 得到的能力
+
+- 产品入口不依赖具体 provider 或工具循环实现；
+- 不同 Backend 可以共享 Invocation 与 terminal 语义；
+- UI 事件与模型可重放事实被明确区分；
+- 用户停止、权限和工具副作用进入可诊断的控制流；
+- 崩溃后可以依据 durable facts 收敛状态；
+- Headless、子 Agent 和未来调度可以复用同一执行核心。
+
+### 当前代价
+
+- 迁移期同时存在 `SessionEvent`、`StoredMessage`、`RuntimeEvent` 和 operational Run events，事件映射的维护成本较高；
+- `AiSdkBackend` 仍然很重，同时组织 history、context budget、tool availability、step loop、usage 与 telemetry；
+- `AiSdkFlow` 仍承担 legacy-to-canonical adapter 角色，而不是 Backend 原生产 canonical events；
+- `SessionStore` 与 RuntimeEvent projection 需要在 active/in-flight 场景中协同；
+- 当前 startup recovery 是确定性终结与修复，不是任意位置的 warm resume。
+- Runner 的 preflight seam 已存在，但生产 Kernel 还没有接入独立的 Runtime gate。
+
+这些不是应该隐藏的实现细节，而是当前架构的真实边界。未来拆分 Backend 或加入 checkpoint 时，首要目标不是减少文件行数，而是保持 request shape、工具可见性、事件顺序和 terminal invariant 不变。
+
+## 代码阅读地图
+
+建议按照下面的顺序阅读当前实现：
+
+1. `packages/runtime/src/session-manager.ts`：公共入口与恢复入口。
+2. `packages/runtime/src/runtime-kernel.ts`：Run/Backend 的活跃控制与主链组装。
+3. `packages/runtime/src/agent-run.ts`：Durable lifecycle、历史构造和终态提交。
+4. `packages/runtime/src/runtime-runner.ts`：Invocation 协议与结果分类。
+5. `packages/runtime/src/ai-sdk-flow.ts`：`SessionEvent → RuntimeEvent` 映射与单终态保证。
+6. `packages/runtime/src/ai-sdk-backend.ts`：AI SDK 模型/工具 step loop。
+7. `packages/runtime/src/model-adapter.ts`：provider stream 适配。
+8. `packages/runtime/src/tool-runtime.ts`：权限、工具执行和副作用边界。
+9. `packages/core/src/runtime-event.ts`：canonical RuntimeEvent 契约。
+10. `packages/core/src/agent-run.ts` 与 `packages/storage/src/agent-run-store.ts`：Run 与 RuntimeEvent 的文件账本。
+
+对应的关键测试集中在：
+
+- `packages/runtime/src/__tests__/runtime-runner.test.ts`
+- `packages/runtime/src/__tests__/ai-sdk-flow.test.ts`
+- `packages/runtime/src/__tests__/session-manager.test.ts`
+- `packages/runtime/src/__tests__/session-manager-terminal-ledger.test.ts`
+- `packages/storage/src/__tests__/agent-run-store.test.ts`
+
+## 小结
+
+Maka Runtime 的核心不在某一个类，也不只是 AI SDK 的多步工具循环。核心是一个可以保留并回放 Agent 交互状态空间的 Runtime Event Log；执行协议围绕这份日志产生事实、提交事实并构造派生状态：
+
+```text
+model/tool stepping engine
+  → canonical RuntimeEvents
+  → durable semantic log
+  → model history / UI / Run state / recovery projections
+```
+
+`SessionManager` 稳住入口，`RuntimeKernel` 管理活跃执行，`AgentRun` 提交耐久事实，`RuntimeRunner` 规定 Invocation 语义，`AiSdkFlow` 把 Backend 事件翻译成 canonical facts，而 `AiSdkBackend`、`ModelAdapter` 与 `ToolRuntime` 真正推进模型和工具循环。它们都围绕 Runtime Event Log 协作，而不是各自保存一份局部真相。
+
+这套结构最终保护的是一件很朴素的事：无论一次 Agent 工作经历多少模型 step、工具副作用、权限等待和异常，Maka 都要先忠实记录发生过什么。只要这份有序事实仍在，系统就能重新构造当时的交互状态，生成新的视图，并让下一轮从可信历史继续。
+
+## 延伸阅读
+
+- [Google ADK: Architecting an efficient context-aware multi-agent framework](https://developers.googleblog.com/architecting-efficient-context-aware-multi-agent-framework-for-production/)
+- [Google ADK Python: Runner lifecycle and event persistence](https://github.com/google/adk-python/blob/main/AGENTS.md)
+- [Apache Kafka Design: replicated logs, state machines, and event sourcing](https://kafka.apache.org/36/design/design/)

--- a/skills/maka-architecture-docs/SKILL.md
+++ b/skills/maka-architecture-docs/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: maka-architecture-docs
+description: Draft, restructure, translate, or review bilingual Chinese-English architecture documentation for the Maka Agent backend. Use when Codex works on Maka technical narratives, component or mechanism explanations, architecture decisions, system flows, engineering guides, or documentation quality checks and needs blog-like clarity without losing architectural precision. Do not use it to impose a fixed topic list or information architecture unless the user asks for one.
+---
+
+# Maka Architecture Docs
+
+Create architecture documentation that is easy to enter, technically rigorous, and maintainable in both Chinese and English. Treat the user's chosen subject and document organization as constraints; this skill governs writing quality, evidence, bilingual consistency, and review.
+
+## Select the task mode
+
+- **Draft**: create a new document from code, design notes, interviews, or a user brief.
+- **Rewrite**: improve an existing document while preserving its technical meaning.
+- **Translate**: produce a natural counterpart in the other language, not a sentence-by-sentence transliteration.
+- **Review**: identify concrete gaps in clarity, evidence, correctness, or bilingual consistency.
+- **Standardize**: align multiple documents on terminology, metadata, status labels, and structure without forcing them into identical narratives.
+
+Confirm the intended mode from the request. Infer it when safe; ask only when different interpretations would materially change the output.
+
+## Follow the workflow
+
+1. **Establish the article contract.** State the one core question, intended reader, expected reading depth, source language, and claimed implementation status. Do not invent a topic or replace the user's outline.
+2. **Collect evidence.** Inspect the relevant code paths, tests, schemas, configuration, ADRs, and existing documents before presenting implementation details as facts. Separate verified behavior from plans and interpretation.
+3. **Build the narrative.** Move from problem and intuition to a concrete scenario, then mechanism, boundaries, failures, and trade-offs. Include only the sections that help answer the core question.
+4. **Add technical anchors.** Connect claims to real components, state transitions, invariants, interfaces, observability signals, or code locations as appropriate.
+5. **Create the bilingual counterpart.** Preserve concepts, status, examples, diagrams, and section identity while rewriting naturally for the target language.
+6. **Run the quality gate.** Review both language versions against `references/quality-gate.md`. Fix failed required checks before calling the document complete.
+
+Read `references/writing-standard.md` whenever drafting, rewriting, or standardizing architecture content. Read `references/bilingual-standard.md` whenever creating or reviewing both languages. Use `assets/article-template.md` as a starting scaffold only when it fits the chosen subject; remove irrelevant sections rather than filling them mechanically.
+
+## Apply non-negotiable rules
+
+- Start from a reader question or engineering problem, not a component inventory.
+- Distinguish **Current**, **Planned**, **Exploratory**, **Deprecated**, and **Historical** claims.
+- Never present an unverified design assumption as current implementation.
+- Explain important mechanisms through intuition, scenario, mechanism, and boundary.
+- Cover meaningful failure paths and trade-offs, not only the happy path.
+- Keep diagrams purposeful and language-neutral where practical; explain what each diagram includes and omits.
+- Use stable terms. Do not alternate among synonyms for variety when they represent the same Maka concept.
+- Prefer separate, complete Chinese and English documents with shared assets over interleaved paragraph-by-paragraph translation.
+- Preserve uncertainty. Translation must not strengthen or weaken a claim.
+- Optimize for progressive depth: a reader should gain value from the opening summary without reading the entire article.
+
+## Handle reviews
+
+Lead with actionable findings ordered by impact. Cite the exact section or line when possible. Check, in order:
+
+1. factual correctness and status confusion;
+2. missing boundaries, invariants, or failure behavior;
+3. broken narrative or unexplained concepts;
+4. bilingual semantic drift and terminology inconsistency;
+5. maintainability issues such as duplicated diagrams or unstable code references;
+6. style polish.
+
+If there are no material findings, say so and identify any verification limits.
+
+## Deliver artifacts
+
+When creating files, follow the repository's existing documentation layout. If no convention exists, recommend rather than silently establish a new repository-wide structure. Keep language counterparts at matching relative paths or give them stable shared document IDs. Report which technical claims were verified and which remain planned or uncertain.

--- a/skills/maka-architecture-docs/agents/openai.yaml
+++ b/skills/maka-architecture-docs/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Maka Architecture Docs"
+  short_description: "Write clear, rigorous bilingual Maka architecture documents"
+  default_prompt: "Use $maka-architecture-docs to draft or review a bilingual Maka backend architecture document."

--- a/skills/maka-architecture-docs/assets/article-template.md
+++ b/skills/maka-architecture-docs/assets/article-template.md
@@ -1,0 +1,60 @@
+---
+doc_id: architecture.<subject>
+language: <zh-CN|en>
+source_language: <zh-CN|en>
+status: <current|planned|exploratory|deprecated|historical>
+translation_status: <synced|needs-update|source-only>
+last_verified: YYYY-MM-DD
+owners:
+  - maka-backend
+---
+
+# <Reader-oriented title>
+
+> In one paragraph: what question this article answers, the conclusion, and why it matters.
+
+## Why this matters
+
+Describe the engineering or reader problem. Define the scope and relevant exclusions.
+
+## Mental model
+
+Give the simplest correct intuition. Define central terms before relying on them.
+
+## A concrete scenario
+
+Introduce one representative example that can continue through the article.
+
+## How it works
+
+Explain the mechanism, sequence, data, and component responsibilities. Add only diagrams that answer a specific question.
+
+## State and invariants
+
+Describe lifecycle, durable and ephemeral state, valid transitions, ownership, ordering, and conditions that must remain true.
+
+## Boundaries
+
+State what this mechanism owns, what it delegates, and what it explicitly does not guarantee.
+
+## Failure and recovery
+
+Cover timeouts, interruption, cancellation, retry, partial success, recovery, and irrecoverable failure as applicable.
+
+## Decisions and trade-offs
+
+Explain the chosen design, credible alternatives, benefits, costs, and revisit conditions.
+
+## Code and operational map
+
+Point to stable modules, types, interfaces, schemas, tests, logs, traces, and metrics appropriate to the promised reading depth.
+
+## Known limitations and future direction
+
+Keep Current, Planned, and Exploratory claims visibly separate.
+
+## Further reading
+
+Link related architecture documents, ADRs, API specifications, and code-owned references.
+
+<!-- Remove any section that does not help answer this article's core question. -->

--- a/skills/maka-architecture-docs/references/bilingual-standard.md
+++ b/skills/maka-architecture-docs/references/bilingual-standard.md
@@ -1,0 +1,84 @@
+# Maka Bilingual Documentation Standard
+
+## Default publishing model
+
+Maintain separate, complete Chinese and English documents. Give counterparts matching relative paths, filenames, or a shared stable `doc_id`. Reuse diagrams, code snippets, schemas, and other language-neutral assets.
+
+Avoid paragraph-by-paragraph interleaving unless the user explicitly needs a side-by-side artifact. Interleaving makes both versions harder to read and maintain.
+
+## Source and counterpart
+
+Choose one source language for each editing cycle. Draft and technically verify that version first, then create the counterpart. The counterpart is an adaptation for readers in the target language, not a literal transliteration.
+
+Both versions must preserve:
+
+- the core question and scope;
+- technical claims and their lifecycle status;
+- degree of certainty;
+- examples and identifiers;
+- diagram semantics;
+- decision rationale and trade-offs;
+- warnings, limitations, and failure behavior.
+
+Natural differences in sentence structure, section phrasing, and explanatory context are allowed. Do not add a technical claim to only one language version without intentionally updating or marking the other.
+
+## Terminology
+
+Maintain a project glossary with at least:
+
+| Field | Meaning |
+|---|---|
+| Chinese term | Preferred Chinese name |
+| English term | Canonical English name |
+| Code identifier | Type, field, API, or package spelling when relevant |
+| Definition | Language-neutral concept boundary |
+| Avoid | Ambiguous or deprecated synonyms |
+
+Preserve code identifiers exactly. On first use, introduce the counterpart when it helps recognition, for example `运行（Run）`; afterward, use the natural preferred term consistently.
+
+Do not translate product names, protocol names, type names, or identifiers merely to make the prose look fully localized.
+
+## Semantic parity checks
+
+Compare the two versions by meaning rather than sentence count:
+
+1. Do titles and summaries promise the same answer?
+2. Do scope and exclusions match?
+3. Are Current, Planned, Exploratory, Deprecated, and Historical labels identical in effect?
+4. Are MUST, SHOULD, MAY, guarantees, and possibilities equally strong?
+5. Do quantities, timeouts, limits, state names, and ordering rules match?
+6. Are failure and recovery behaviors equally complete?
+7. Do diagrams use terms recognized by both versions?
+8. Do links resolve to the appropriate language or shared source?
+
+Translation must not silently turn “may” into “will,” “planned” into “supported,” or “usually” into “always.”
+
+## Suggested metadata
+
+Use repository conventions first. When no convention exists, recommend metadata such as:
+
+```yaml
+doc_id: architecture.example
+language: zh-CN
+source_language: zh-CN
+counterpart: ../en/architecture/example.md
+status: current
+translation_status: synced
+last_verified: YYYY-MM-DD
+owners:
+  - maka-backend
+```
+
+Useful translation states are `synced`, `needs-update`, and `source-only`. Metadata is optional unless the project adopts it; semantic clarity is mandatory.
+
+## Writing voice
+
+In both languages:
+
+- prefer direct, concrete sentences;
+- explain necessary jargon at first use;
+- write headings as reader-oriented signposts;
+- avoid promotional claims and vague adjectives;
+- retain the same technical altitude, even when one language needs extra connective explanation.
+
+Chinese prose should read as native technical Chinese rather than English syntax with Chinese words. English prose should read as an original technical article rather than expose Chinese word order or omitted subjects.

--- a/skills/maka-architecture-docs/references/quality-gate.md
+++ b/skills/maka-architecture-docs/references/quality-gate.md
@@ -1,0 +1,56 @@
+# Architecture Document Quality Gate
+
+Use this checklist before marking a draft or review complete. Treat items marked **Required** as release blockers when they apply.
+
+## Purpose and narrative
+
+- [ ] **Required:** The opening states the core question and why it matters.
+- [ ] **Required:** The intended audience and scope can be inferred without reading the entire article.
+- [ ] The document provides a useful answer at more than one reading depth.
+- [ ] Central concepts are explained through intuition, scenario, mechanism, and boundary where needed.
+- [ ] A concrete example is used when abstraction would otherwise impede understanding.
+- [ ] Sections advance the core question instead of becoming a component inventory.
+
+## Technical integrity
+
+- [ ] **Required:** Current implementation is separated from Planned, Exploratory, Deprecated, and Historical material.
+- [ ] **Required:** Important implementation claims were verified against appropriate evidence or explicitly marked unverified.
+- [ ] **Required:** Responsibilities and non-responsibilities are clear.
+- [ ] **Required:** Meaningful failure paths, interruption, and recovery behavior are covered.
+- [ ] Relevant states, transitions, invariants, ordering, and idempotency rules are stated.
+- [ ] Important design choices include alternatives, costs, and revisit conditions.
+- [ ] Code, interface, schema, test, or observability anchors are provided at the depth the article promises.
+
+## Diagrams and examples
+
+- [ ] Every diagram answers a specific question.
+- [ ] Diagram terminology matches prose and implementation terminology.
+- [ ] Reading direction and important omissions are explained.
+- [ ] Examples do not imply guarantees that the system does not provide.
+
+## Bilingual parity
+
+- [ ] **Required:** Both versions preserve scope, lifecycle status, certainty, guarantees, and limitations.
+- [ ] **Required:** Canonical terms and code identifiers are consistent.
+- [ ] Numbers, limits, states, ordering, examples, and failure behavior match.
+- [ ] Each version reads naturally in its own language.
+- [ ] Shared diagrams and links work from both versions.
+- [ ] Counterpart metadata or translation status is accurate when used.
+
+## Maintainability
+
+- [ ] The document follows existing repository layout and metadata conventions.
+- [ ] Ownership and verification date are recorded when supported.
+- [ ] Fragile duplication and unstable line-number references are avoided.
+- [ ] Details owned elsewhere are linked rather than copied.
+- [ ] Known uncertainty or stale areas are visible to future maintainers.
+
+## Completion report
+
+When handing off a document, state:
+
+- files created or changed;
+- evidence used to verify current behavior;
+- planned or uncertain claims that remain;
+- whether both languages passed semantic parity review;
+- any checklist items intentionally left open and why.

--- a/skills/maka-architecture-docs/references/writing-standard.md
+++ b/skills/maka-architecture-docs/references/writing-standard.md
@@ -1,0 +1,126 @@
+# Maka Architecture Writing Standard
+
+## Purpose
+
+Use this standard to make each article approachable like a strong technical blog while retaining the precision required of an architecture record. It defines article-level quality, not a mandatory topic list or repository table of contents.
+
+## Article contract
+
+Before drafting, establish:
+
+- **Core question:** the single question the article must answer.
+- **Audience:** newcomer, active developer, technical lead, external integrator, or a deliberate combination.
+- **Reading depth:** orientation, working understanding, or implementation/debugging depth.
+- **Scope:** what the article covers and explicitly does not cover.
+- **Evidence basis:** code, tests, schemas, runtime observation, accepted decision, or proposal.
+- **Lifecycle status:** Current, Planned, Exploratory, Deprecated, or Historical.
+
+A document may serve multiple depths through progressive disclosure, but it must identify its primary audience.
+
+## Narrative model
+
+Prefer this progression when it fits the subject:
+
+1. **Problem:** what reader or system problem makes the subject matter.
+2. **Intuition:** the simplest correct mental model.
+3. **Concrete scenario:** one representative example that can continue through the article.
+4. **Mechanism:** components, sequence, data, and state involved.
+5. **Boundaries:** responsibilities, non-responsibilities, and interfaces.
+6. **Failure behavior:** expected failures, recovery, partial success, and irrecoverable cases.
+7. **Trade-offs:** benefits, costs, alternatives, and revisit conditions.
+8. **Technical anchors:** code map, schemas, APIs, tests, telemetry, or operational signals.
+
+Do not force this order when another narrative answers the core question more clearly. Do not start with a flat list of services unless the document's question is specifically about inventory or ownership.
+
+## Four-layer explanation
+
+For every concept central to the article, provide enough of these layers to prevent misunderstanding:
+
+1. **Intuition:** what it means in plain language.
+2. **Scenario:** why the system needs it.
+3. **Mechanism:** how it works internally.
+4. **Boundary:** what it does not mean or own.
+
+Define a term before relying on it. Prefer one stable term over stylistic synonym variation.
+
+## Precision rules
+
+### Separate lifecycle states
+
+- **Current:** verified in the current system.
+- **Planned:** agreed direction not yet fully implemented.
+- **Exploratory:** option under discussion, with no commitment implied.
+- **Deprecated:** still present but being removed or replaced.
+- **Historical:** retained only to explain past choices or migration context.
+
+Label mixed-status sections at the claim or subsection level. A document-level status alone is insufficient when current behavior and future design appear together.
+
+### Support claims with evidence
+
+Use the strongest available evidence:
+
+1. runtime behavior or passing tests;
+2. implementation and schema;
+3. accepted ADR or specification;
+4. design discussion or roadmap;
+5. author inference.
+
+Identify inference as inference. If code and prose disagree, report the discrepancy rather than silently choosing the more convenient story.
+
+### Describe state and invariants
+
+When behavior depends on lifecycle or concurrency, name:
+
+- states and valid transitions;
+- ownership of each transition;
+- durable versus ephemeral state;
+- invariants that must remain true;
+- idempotency or ordering expectations;
+- interruption, retry, timeout, and cancellation behavior.
+
+### Explain decisions
+
+For meaningful choices, capture:
+
+- context and constraints;
+- chosen approach;
+- credible alternatives;
+- reason for the choice;
+- benefits and costs;
+- conditions that should trigger reevaluation.
+
+Move long-lived, consequential choices into an ADR when the repository uses ADRs. The article may summarize and link to the decision.
+
+## Examples and diagrams
+
+Use a concrete example when it materially reduces abstraction. Keep the same example through multiple sections unless a second example reveals a distinct boundary.
+
+Choose a diagram by the relationship being explained:
+
+- context diagram for system boundaries;
+- component diagram for responsibilities and dependencies;
+- sequence diagram for interactions over time;
+- state diagram for lifecycle and recovery;
+- data-flow diagram for information movement;
+- deployment diagram for runtime placement and infrastructure.
+
+Every diagram must have a purpose statement. Explain its reading entry point and meaningful omissions. Keep names consistent with prose and code. Prefer shared, language-neutral diagram sources for bilingual documents.
+
+## Progressive depth
+
+Design for three reading passes where appropriate:
+
+- **Opening:** the reader understands the conclusion and why it matters.
+- **Main narrative:** the reader understands the end-to-end mechanism and boundaries.
+- **Deep sections:** the reader can implement, extend, or debug the behavior.
+
+Put essential meaning in prose. Tables, diagrams, and code snippets should clarify the prose rather than carry unexplained conclusions.
+
+## Maintainability
+
+- Prefer stable package, module, type, and interface links over fragile line-number references in committed documents.
+- Record document owner and verification date when the repository supports metadata.
+- Share diagrams and generated API/schema material between languages.
+- Link rather than duplicate details owned by another document.
+- Keep future direction separate enough that current behavior remains unambiguous.
+- Update or mark stale documents when implementation changes invalidate claims.


### PR DESCRIPTION
## Summary

- add a bilingual first architecture chapter centered on RuntimeEvent Log as Maka’s semantic source of truth
- explain semantic replay, provider-native replay, terminal invariants, projections, recovery, and the Google ADK / log-first design influences
- add a reusable `maka-architecture-docs` skill with bilingual writing standards, an article template, and a quality gate

## Verification

- `quick_validate.py skills/maka-architecture-docs`
- `git diff --check`
- 68 focused RuntimeRunner, AiSdkFlow, and terminal-ledger tests passed while verifying the documented behavior

## Notes

The chapter is intentionally marked as a draft so its narrative and terminology can be refined through review.