### PR TITLE
fix(headless): separate A/B outcomes from evidence

### DIFF
--- a/packages/headless/harbor/run-prompt-ab.mjs
+++ b/packages/headless/harbor/run-prompt-ab.mjs
@@ -420,7 +420,7 @@ async function main() {
   });
 
   const output = {
-    schemaVersion: 'maka.prompt_ab.v1',
+    schemaVersion: 'maka.prompt_ab.v2',
     runId,
     candidatePromptSourcePath,
     maxConcurrency,

--- a/packages/headless/src/__tests__/ab-render.test.ts
+++ b/packages/headless/src/__tests__/ab-render.test.ts
@@ -29,7 +29,8 @@ describe('renderAbComparisonMarkdown', () => {
 
     assert.match(markdown, /Decision: not cleared \(non_inferiority_confidence_interval_crosses_margin\)/);
     assert.match(markdown, /Budget: 600s task budget/);
-    assert.match(markdown, /Evaluation pass rate: A=1\/4 = 0.25, B=4\/4 = 1/);
+    assert.match(markdown, /Outcome pass rate: A=1\/4 = 0.25, B=4\/4 = 1/);
+    assert.match(markdown, /Paired outcome delta: B-A=0.75/);
     assert.match(markdown, /Task-level delta: mean=0.75/);
     assert.doesNotMatch(markdown, /held-in|held-out|keep|discard|acceptance/i);
   });
@@ -47,6 +48,30 @@ describe('renderAbComparisonMarkdown', () => {
     });
 
     assert.match(renderAbComparisonMarkdown(result), /Budget outcomes: A timed_out=0, B timed_out=1/);
+  });
+
+  test('separates run completeness, outcome rate, exclusions, and attestation warnings', () => {
+    const unattestedTimeout = {
+      ...budgetExhausted('long-task'),
+      eligible: false,
+      evidenceErrorClass: 'missing_execution_identity' as const,
+    };
+    const result = summarizeAbComparison({
+      runId: 'ab-run',
+      roundId: 'ab-summary',
+      baselineArmId: 'baseline',
+      candidateArmId: 'candidate',
+      evaluationTaskIds: ['long-task'],
+      baselineRuns: [[unattestedTimeout]],
+      candidateRuns: [[unattestedTimeout]],
+    });
+
+    const markdown = renderAbComparisonMarkdown(result);
+    assert.match(markdown, /Run completeness: A observed=1\/1 missing=0, B observed=1\/1 missing=0/);
+    assert.match(markdown, /Outcome pass rate: A=0\/1 = 0, B=0\/1 = 0/);
+    assert.match(markdown, /Attempt pairs: observed=1\/1 evaluated=1 excluded=0 missing=0/);
+    assert.match(markdown, /Attestation warnings: A=1, B=1/);
+    assert.doesNotMatch(markdown, /## Missing Tasks/);
   });
 
   test('renders context budget policy and active prune subset diagnostics', () => {
@@ -103,7 +128,7 @@ describe('renderAbComparisonMarkdown', () => {
     const markdown = renderAbComparisonMarkdown(result);
 
     assert.match(markdown, /Context budget: A activated=0\/2 stale_pruned=0 active_pruned=0 active_tokens_saved=0 active_archive_failures=0 archive_placeholders=0 archive_placeholder_reasons=\{\} archive_write_failures=0 retrieved=0 retrieved_tokens=0 retrieval_skipped=0 retrieval_skipped_reasons=\{\} retrieval_failures=0 retrieval_failure_reasons=\{\}, B activated=1\/2 stale_pruned=2 active_pruned=3 active_tokens_saved=450 active_archive_failures=1 archive_placeholders=2 archive_placeholder_reasons=\{"active_prune":2\} archive_write_failures=0 retrieved=1 retrieved_tokens=120 retrieval_skipped=3 retrieval_skipped_reasons=\{"max_bytes":2,"max_results":1\} retrieval_failures=1 retrieval_failure_reasons=\{"not_found":1\}/);
-    assert.match(markdown, /Active prune subset: A tasks=1 attempts=1 observed=1 missing=0 coverage=1 pass_rate=1 passed=1\/1 completed=1 timed_out=0 infra_failed=0 plumbing_failed=0 input=1 cache_hit=0 cache_miss=1 cache_write=0 output=1 total=2 cost_usd=0\.01 mean_duration_ms=100 activated=0\/1 stale_pruned=0 active_pruned=0 active_tokens_saved=0 active_archive_failures=0 archive_placeholders=0 archive_placeholder_reasons=\{\} archive_write_failures=0 retrieved=0 retrieved_tokens=0 retrieval_skipped=0 retrieval_skipped_reasons=\{\} retrieval_failures=0 retrieval_failure_reasons=\{\}, B tasks=1 attempts=1 observed=1 missing=0 coverage=1 pass_rate=1 passed=1\/1 completed=1 timed_out=0 infra_failed=0 plumbing_failed=0 input=1 cache_hit=0 cache_miss=1 cache_write=0 output=1 total=2 cost_usd=0\.01 mean_duration_ms=100 activated=1\/1 stale_pruned=2 active_pruned=3 active_tokens_saved=450 active_archive_failures=1 archive_placeholders=2 archive_placeholder_reasons=\{"active_prune":2\} archive_write_failures=0 retrieved=1 retrieved_tokens=120 retrieval_skipped=3 retrieval_skipped_reasons=\{"max_bytes":2,"max_results":1\} retrieval_failures=1 retrieval_failure_reasons=\{"not_found":1\}/);
+    assert.match(markdown, /Active prune subset: A tasks=1 attempts=1 observed=1 missing=0 coverage=1 pass_rate=1 passed=1\/1 completed=1 timed_out=0 infra_failed=0 plumbing_failed=0 attestation_warnings=0 input=1 cache_hit=0 cache_miss=1 cache_write=0 output=1 total=2 cost_usd=0\.01 mean_duration_ms=100 activated=0\/1 stale_pruned=0 active_pruned=0 active_tokens_saved=0 active_archive_failures=0 archive_placeholders=0 archive_placeholder_reasons=\{\} archive_write_failures=0 retrieved=0 retrieved_tokens=0 retrieval_skipped=0 retrieval_skipped_reasons=\{\} retrieval_failures=0 retrieval_failure_reasons=\{\}, B tasks=1 attempts=1 observed=1 missing=0 coverage=1 pass_rate=1 passed=1\/1 completed=1 timed_out=0 infra_failed=0 plumbing_failed=0 attestation_warnings=0 input=1 cache_hit=0 cache_miss=1 cache_write=0 output=1 total=2 cost_usd=0\.01 mean_duration_ms=100 activated=1\/1 stale_pruned=2 active_pruned=3 active_tokens_saved=450 active_archive_failures=1 archive_placeholders=2 archive_placeholder_reasons=\{"active_prune":2\} archive_write_failures=0 retrieved=1 retrieved_tokens=120 retrieval_skipped=3 retrieval_skipped_reasons=\{"max_bytes":2,"max_results":1\} retrieval_failures=1 retrieval_failure_reasons=\{"not_found":1\}/);
     assert.match(markdown, /Context budget policy: A enabled=0\/2 snapshots=\[{"enabled":false}\], B enabled=2\/2 snapshots=/);
   });
 
@@ -131,7 +156,7 @@ describe('renderAbComparisonMarkdown', () => {
       }]],
     });
 
-    assert.match(renderAbComparisonMarkdown(result), /Active prune subset: A tasks=1 attempts=1 observed=0 missing=1 coverage=0 pass_rate=null passed=0\/0 completed=0 timed_out=0 infra_failed=0 plumbing_failed=0 input=0 cache_hit=0 cache_miss=0 cache_write=0 output=0 total=0 cost_usd=0 mean_duration_ms=null activated=0\/0 stale_pruned=0 active_pruned=0 active_tokens_saved=0 active_archive_failures=0 archive_placeholders=0 archive_placeholder_reasons=\{\} archive_write_failures=0 retrieved=0 retrieved_tokens=0 retrieval_skipped=0 retrieval_skipped_reasons=\{\} retrieval_failures=0 retrieval_failure_reasons=\{\}, B tasks=1 attempts=1 observed=1 missing=0 coverage=1 pass_rate=1 passed=1\/1 completed=1 timed_out=0 infra_failed=0 plumbing_failed=0 input=10 cache_hit=3 cache_miss=4 cache_write=2 output=5 total=16 cost_usd=0\.02 mean_duration_ms=250 activated=1\/1 stale_pruned=0 active_pruned=1 active_tokens_saved=0 active_archive_failures=0 archive_placeholders=0 archive_placeholder_reasons=\{\} archive_write_failures=0 retrieved=0 retrieved_tokens=0 retrieval_skipped=0 retrieval_skipped_reasons=\{\} retrieval_failures=0 retrieval_failure_reasons=\{\}/);
+    assert.match(renderAbComparisonMarkdown(result), /Active prune subset: A tasks=1 attempts=1 observed=0 missing=1 coverage=0 pass_rate=null passed=0\/0 completed=0 timed_out=0 infra_failed=0 plumbing_failed=0 attestation_warnings=0 input=0 cache_hit=0 cache_miss=0 cache_write=0 output=0 total=0 cost_usd=0 mean_duration_ms=null activated=0\/0 stale_pruned=0 active_pruned=0 active_tokens_saved=0 active_archive_failures=0 archive_placeholders=0 archive_placeholder_reasons=\{\} archive_write_failures=0 retrieved=0 retrieved_tokens=0 retrieval_skipped=0 retrieval_skipped_reasons=\{\} retrieval_failures=0 retrieval_failure_reasons=\{\}, B tasks=1 attempts=1 observed=1 missing=0 coverage=1 pass_rate=1 passed=1\/1 completed=1 timed_out=0 infra_failed=0 plumbing_failed=0 attestation_warnings=0 input=10 cache_hit=3 cache_miss=4 cache_write=2 output=5 total=16 cost_usd=0\.02 mean_duration_ms=250 activated=1\/1 stale_pruned=0 active_pruned=1 active_tokens_saved=0 active_archive_failures=0 archive_placeholders=0 archive_placeholder_reasons=\{\} archive_write_failures=0 retrieved=0 retrieved_tokens=0 retrieval_skipped=0 retrieval_skipped_reasons=\{\} retrieval_failures=0 retrieval_failure_reasons=\{\}/);
   });
 
   test('renders token cost usage', () => {

--- a/packages/headless/src/__tests__/ab-summary.test.ts
+++ b/packages/headless/src/__tests__/ab-summary.test.ts
@@ -82,7 +82,7 @@ describe('summarizeAbComparison', () => {
     assert.equal(result.taskLevel.losses, 1);
   });
 
-  test('does not count an unattested budget exhaustion as valid A/B coverage', () => {
+  test('counts an unattested timeout as an observed budget failure with an attestation warning', () => {
     const unverifiedTimeout = {
       ...budgetExhausted('long-task'),
       eligible: false,
@@ -99,19 +99,21 @@ describe('summarizeAbComparison', () => {
       budgetMs: 600_000,
     });
 
-    assert.equal(result.baseline.budgetExhausted, 0);
-    assert.equal(result.baseline.plumbingFailed, 1);
-    assert.equal(result.baseline.valid, 0);
-    assert.equal(result.baseline.coverageRate, 0);
-    assert.equal(result.candidate.valid, 0);
-    assert.equal(result.candidate.coverageRate, 0);
-    assert.equal(result.pairedAttempts.observedPairs, 0);
-    assert.deepEqual(result.pairedAttempts.missingPairIds, ['long-task#r0']);
-    assert.equal(result.decision, 'invalid');
-    assert.equal(result.reason, 'plumbing_failure_observed');
+    assert.equal(result.baseline.budgetExhausted, 1);
+    assert.equal(result.baseline.plumbingFailed, 0);
+    assert.equal(result.baseline.valid, 1);
+    assert.equal(result.baseline.passRate, 0);
+    assert.equal(result.baseline.coverageRate, 1);
+    assert.equal(result.baseline.attestationWarnings, 1);
+    assert.equal(result.candidate.valid, 1);
+    assert.equal(result.candidate.coverageRate, 1);
+    assert.equal(result.pairedAttempts.observedPairs, 1);
+    assert.deepEqual(result.pairedAttempts.missingPairIds, []);
+    assert.equal(result.decision, 'diagnostic');
+    assert.equal(result.reason, 'single_rep_diagnostic_only');
   });
 
-  test('classifies a timeout with rate-limit evidence as an invalid infra outcome', () => {
+  test('excludes a provider timeout without reporting the observed pair as missing', () => {
     const providerTimeout = {
       ...budgetExhausted('task-a'),
       eligible: false,
@@ -131,12 +133,228 @@ describe('summarizeAbComparison', () => {
     assert.equal(result.baseline.infraFailed, 1);
     assert.equal(result.baseline.plumbingFailed, 0);
     assert.equal(result.baseline.budgetExhausted, 0);
+    assert.equal(result.baseline.missing, 0);
+    assert.equal(result.pairedAttempts.observedPairs, 1);
+    assert.equal(result.pairedAttempts.evaluatedPairs, 0);
+    assert.deepEqual(result.pairedAttempts.missingPairIds, []);
+    assert.deepEqual(result.pairedAttempts.excludedPairIds, ['task-a#r0']);
+    assert.deepEqual(result.taskLevel.missingTaskIds, []);
+    assert.deepEqual(result.taskLevel.excludedTaskIds, ['task-a']);
     assert.deepEqual(result.pairedAttempts.infraOrPlumbingDiscordantPairIds, ['task-a#r0']);
-    assert.equal(result.decision, 'invalid');
-    assert.equal(result.reason, 'infra_failure_observed');
+    assert.equal(result.decision, 'diagnostic');
+    assert.equal(result.reason, 'single_rep_diagnostic_only');
   });
 
-  test('does not count ineligible completed attempts as valid A/B coverage', () => {
+  test('allows an isolated provider exclusion at the effective coverage threshold', () => {
+    const taskIds = Array.from({ length: 10 }, (_, index) => `task-${index}`);
+    const providerTimeout = {
+      ...budgetExhausted(taskIds[0]!),
+      eligible: false,
+      evidenceErrorClass: 'provider_unavailable' as const,
+    };
+    const result = summarizeAbComparison({
+      runId: 'ab-run',
+      roundId: 'ab-summary',
+      baselineArmId: 'baseline',
+      candidateArmId: 'candidate',
+      evaluationTaskIds: taskIds,
+      baselineRuns: [[providerTimeout, ...taskIds.slice(1).map((taskId) => completed(taskId, true))]],
+      candidateRuns: [[...taskIds.map((taskId) => completed(taskId, true))]],
+    });
+
+    assert.equal(result.baseline.coverageRate, 0.9);
+    assert.equal(result.decision, 'diagnostic');
+    assert.equal(result.reason, 'single_rep_diagnostic_only');
+  });
+
+  test('uses evaluated pairs for both the formal point estimate and confidence bound', () => {
+    const taskIds = Array.from({ length: 10 }, (_, index) => `task-${index}`);
+    const baselineRuns = [0, 1].map((rep) => taskIds.map((taskId, index) => completed(taskId, rep === 0 && index < 3)));
+    const candidateRuns = [0, 1].map((rep) => taskIds.map((taskId, index) => {
+      if (rep === 0 && index < 2) {
+        return {
+          ...completed(taskId, false),
+          status: 'failed' as const,
+          scored: false,
+          eligible: false,
+          errorClass: 'network',
+        };
+      }
+      return completed(taskId, false);
+    }));
+    const result = summarizeAbComparison({
+      runId: 'ab-run',
+      roundId: 'ab-summary',
+      baselineArmId: 'baseline',
+      candidateArmId: 'candidate',
+      evaluationTaskIds: taskIds,
+      baselineRuns,
+      candidateRuns,
+    });
+
+    assert.equal(result.candidate.coverageRate, 0.9);
+    assert.equal(result.pairedAttempts.evaluatedPairs, 18);
+    assert.equal(result.pairedAttempts.losses, 1);
+    assert.equal(result.passRateDelta, -0.055555555556);
+    assert.equal(result.decision, 'not_cleared');
+    assert.equal(result.reason, 'non_inferiority_confidence_interval_crosses_margin');
+  });
+
+  test('classifies an unscored completed infra result as an infra exclusion', () => {
+    const infraResult = {
+      ...completed('task-a', false),
+      scored: false,
+      eligible: false,
+      errorClass: 'infra_failed',
+    };
+    const result = summarizeAbComparison({
+      runId: 'ab-run',
+      roundId: 'ab-summary',
+      baselineArmId: 'baseline',
+      candidateArmId: 'candidate',
+      evaluationTaskIds: ['task-a'],
+      baselineRuns: [[infraResult]],
+      candidateRuns: [[completed('task-a', true)]],
+    });
+
+    assert.equal(result.baseline.completed, 0);
+    assert.equal(result.baseline.infraFailed, 1);
+    assert.equal(result.baseline.missing, 0);
+    assert.deepEqual(result.pairedAttempts.excludedPairIds, ['task-a#r0']);
+  });
+
+  test('fails closed on an unscored completed provider error class', () => {
+    const providerFailure = {
+      ...completed('task-a', false),
+      status: 'failed' as const,
+      scored: false,
+      eligible: false,
+      errorClass: 'network',
+    };
+    const result = summarizeAbComparison({
+      runId: 'ab-run',
+      roundId: 'ab-summary',
+      baselineArmId: 'baseline',
+      candidateArmId: 'candidate',
+      evaluationTaskIds: ['task-a'],
+      baselineRuns: [[providerFailure]],
+      candidateRuns: [[completed('task-a', true)]],
+    });
+
+    assert.equal(result.baseline.valid, 0);
+    assert.equal(result.baseline.infraFailed, 1);
+    assert.deepEqual(result.pairedAttempts.excludedPairIds, ['task-a#r0']);
+  });
+
+  test('applies the effective coverage gate to evaluable pairs', () => {
+    const taskIds = Array.from({ length: 10 }, (_, index) => `t${index}`);
+    const excluded = (taskId: string) => ({
+      ...completed(taskId, false),
+      scored: false,
+      eligible: false,
+      errorClass: 'network' as const,
+    });
+    const baselineRun = taskIds.map((taskId, index) => index === 0 ? excluded(taskId) : completed(taskId, true));
+    const candidateRun = taskIds.map((taskId, index) => index === 1 ? excluded(taskId) : completed(taskId, true));
+    const result = summarizeAbComparison({
+      runId: 'ab-run',
+      roundId: 'ab-summary',
+      baselineArmId: 'baseline',
+      candidateArmId: 'candidate',
+      evaluationTaskIds: taskIds,
+      baselineRuns: [baselineRun, baselineRun],
+      candidateRuns: [candidateRun, candidateRun],
+    });
+
+    assert.equal(result.baseline.coverageRate, 0.9);
+    assert.equal(result.candidate.coverageRate, 0.9);
+    assert.equal(result.pairedAttempts.evaluatedPairs, 16);
+    assert.equal(result.decision, 'not_cleared');
+    assert.equal(result.reason, 'low_effective_coverage');
+  });
+
+  test('derives task-level outcomes from matching evaluable pairs', () => {
+    const excluded = { ...completed('task', false), scored: false, eligible: false, errorClass: 'network' as const };
+    const result = summarizeAbComparison({
+      runId: 'ab-run',
+      roundId: 'ab-summary',
+      baselineArmId: 'baseline',
+      candidateArmId: 'candidate',
+      evaluationTaskIds: ['task'],
+      baselineRuns: [[completed('task', false)], [excluded]],
+      candidateRuns: [[completed('task', false)], [completed('task', true)]],
+    });
+
+    assert.equal(result.taskLevel.tasks[0]?.passRateDelta, 0);
+    assert.equal(result.taskLevel.tasks[0]?.outcome, 'tie');
+  });
+
+  test('includes timeout task-tool evidence in the arm summary', () => {
+    const timeout = { ...budgetExhausted('task'), taskToolSummary: taskToolSummary({ todoWriteCalls: 7 }) };
+    const result = summarizeAbComparison({
+      runId: 'ab-run',
+      roundId: 'ab-summary',
+      baselineArmId: 'baseline',
+      candidateArmId: 'candidate',
+      evaluationTaskIds: ['task'],
+      baselineRuns: [[completed('task', false)]],
+      candidateRuns: [[timeout]],
+    });
+
+    assert.equal(result.candidate.taskTools?.activatedAttempts, 1);
+    assert.equal(result.candidate.taskTools?.todoWriteCalls, 7);
+  });
+
+  test('invalidates an explicit execution identity mismatch without reporting missing data', () => {
+    const identityMismatch = {
+      ...budgetExhausted('task-a'),
+      eligible: false,
+      evidenceErrorClass: 'execution_identity_mismatch' as const,
+    };
+    const result = summarizeAbComparison({
+      runId: 'ab-run',
+      roundId: 'ab-summary',
+      baselineArmId: 'baseline',
+      candidateArmId: 'candidate',
+      evaluationTaskIds: ['task-a'],
+      baselineRuns: [[identityMismatch]],
+      candidateRuns: [[completed('task-a', true)]],
+    });
+
+    assert.equal(result.baseline.plumbingFailed, 1);
+    assert.equal(result.baseline.attestationWarnings, 0);
+    assert.equal(result.baseline.missing, 0);
+    assert.deepEqual(result.pairedAttempts.missingPairIds, []);
+    assert.deepEqual(result.pairedAttempts.excludedPairIds, ['task-a#r0']);
+    assert.equal(result.decision, 'invalid');
+    assert.equal(result.reason, 'plumbing_failure_observed');
+  });
+
+  test('fails closed on a legacy completed execution identity mismatch', () => {
+    const identityMismatch = {
+      ...completed('task-a', false),
+      status: 'failed' as const,
+      scored: false,
+      eligible: false,
+      errorClass: 'execution_identity_mismatch',
+    };
+    const result = summarizeAbComparison({
+      runId: 'ab-run',
+      roundId: 'ab-summary',
+      baselineArmId: 'baseline',
+      candidateArmId: 'candidate',
+      evaluationTaskIds: ['task-a'],
+      baselineRuns: [[identityMismatch]],
+      candidateRuns: [[completed('task-a', true)]],
+    });
+
+    assert.equal(result.baseline.valid, 0);
+    assert.equal(result.baseline.plumbingFailed, 1);
+    assert.equal(result.decision, 'invalid');
+    assert.equal(result.reason, 'plumbing_failure_observed');
+  });
+
+  test('counts an observed verifier failure even when a legacy event marked it ineligible', () => {
     const ineligibleCompleted = { ...completed('task-a', false), eligible: false };
     const result = summarizeAbComparison({
       runId: 'ab-run',
@@ -149,19 +367,20 @@ describe('summarizeAbComparison', () => {
       budgetMs: 600_000,
     });
 
-    assert.equal(result.baseline.valid, 0);
-    assert.equal(result.baseline.coverageRate, 0);
-    assert.equal(result.candidate.valid, 0);
-    assert.equal(result.candidate.coverageRate, 0);
-    assert.equal(result.pairedAttempts.observedPairs, 0);
+    assert.equal(result.baseline.valid, 1);
+    assert.equal(result.baseline.passRate, 0);
+    assert.equal(result.baseline.coverageRate, 1);
+    assert.equal(result.candidate.valid, 1);
+    assert.equal(result.candidate.coverageRate, 1);
+    assert.equal(result.pairedAttempts.observedPairs, 1);
   });
 
-  test('counts an agent step-cap failure as a failed A/B outcome', () => {
+  test('counts a legacy ineligible step-cap event as a failed A/B outcome', () => {
     const stepCapFailure = {
       ...completed('task-a', false),
       status: 'failed' as const,
       scored: false,
-      eligible: true,
+      eligible: false,
       errorClass: 'tool_step_cap_reached',
     };
     const result = summarizeAbComparison({
@@ -270,6 +489,7 @@ describe('summarizeAbComparison', () => {
       budgetExhausted: 0,
       infraFailed: 0,
       plumbingFailed: 0,
+      attestationWarnings: 0,
       missing: 0,
       coverageRate: 1,
       totalCostUsd: 0.01,
@@ -317,6 +537,7 @@ describe('summarizeAbComparison', () => {
       budgetExhausted: 0,
       infraFailed: 0,
       plumbingFailed: 0,
+      attestationWarnings: 0,
       missing: 0,
       coverageRate: 1,
       totalCostUsd: 0.01,

--- a/packages/headless/src/__tests__/fixed-prompt-controller.test.ts
+++ b/packages/headless/src/__tests__/fixed-prompt-controller.test.ts
@@ -5,6 +5,7 @@ import { join } from 'node:path';
 import { describe, test } from 'node:test';
 import type { Config } from '../contracts.js';
 import { tokenSummary } from './helpers/cell-output-fixtures.js';
+import { contextBudgetSummary } from './helpers/ab-summary-fixtures.js';
 import {
   FixedPromptBudgetExhaustedError,
   hashSystemPrompt,
@@ -202,6 +203,7 @@ describe('fixed prompt controller', () => {
       const systemPromptPath = join(dir, 'system_prompt.md');
       const resultsJsonlPath = join(dir, 'results.jsonl');
       await writeFile(systemPromptPath, 'fixed prompt\n', 'utf8');
+      const retainedContextBudgetSummary = contextBudgetSummary({ activePrunedToolResults: 1 });
       await writeFile(resultsJsonlPath, `${JSON.stringify({
         schemaVersion: 1,
         type: 'task_plumbing_failed',
@@ -218,6 +220,11 @@ describe('fixed prompt controller', () => {
         errorClass: 'missing_execution_identity',
         error: 'Timed-out Harbor attempt did not produce execution identity attestation',
         expectedPromptHash: hashSystemPrompt('fixed prompt\n'),
+        contextBudgetPolicy: { enabled: true, minRecentTurns: 2 },
+        contextBudgetSummary: retainedContextBudgetSummary,
+        taskToolSummary: { todoWriteCalls: 3 },
+        steps: 42,
+        durationMs: 180_000,
       })}\n`, 'utf8');
       const originalWal = await readFile(resultsJsonlPath, 'utf8');
       const projectedWal = await readFixedPromptWal(resultsJsonlPath);
@@ -248,6 +255,10 @@ describe('fixed prompt controller', () => {
       if (event?.type !== 'task_budget_exhausted') assert.fail('expected budget exhaustion event');
       assert.equal(event.eligible, false);
       assert.equal(event.evidenceErrorClass, 'missing_execution_identity');
+      assert.deepEqual(event.contextBudgetSummary, retainedContextBudgetSummary);
+      assert.equal(event.taskToolSummary?.todoWriteCalls, 3);
+      assert.equal(event.steps, 42);
+      assert.equal(event.durationMs, 180_000);
       assert.equal(await readFile(resultsJsonlPath, 'utf8'), originalWal);
     });
   });
@@ -566,6 +577,7 @@ describe('fixed prompt controller', () => {
       await writeFile(systemPromptPath, 'fixed prompt\n', 'utf8');
       const cell = harborOutput({
         taskId: 'task-a',
+        errorClass: 'network',
         executionIdentity: {
           llmConnectionSlug: 'deepseek',
           model: 'wrong-model',
@@ -603,8 +615,11 @@ describe('fixed prompt controller', () => {
     await withDir(async (dir) => {
       const systemPromptPath = join(dir, 'system_prompt.md');
       await writeFile(systemPromptPath, 'fixed prompt\n', 'utf8');
+      const retainedContextBudgetSummary = contextBudgetSummary({ prunedToolResults: 2 });
       const cell = harborOutput({
         taskId: 'task-a',
+        contextBudgetPolicy: { enabled: true, minRecentTurns: 2 },
+        contextBudgetSummary: retainedContextBudgetSummary,
         executionIdentity: {
           llmConnectionSlug: 'fake',
           model: 'fake-model',
@@ -637,6 +652,12 @@ describe('fixed prompt controller', () => {
       assert.equal(event.evidenceErrorClass, undefined);
       assert.equal(event.tokenSummary?.total, 3);
       assert.equal(event.tokenSummary?.costUsd, 0.02);
+      assert.equal(event.runtimeEventsPath, cell.runtimeEventsPath);
+      assert.equal(event.traceEventsPath, cell.traceEventsPath);
+      assert.deepEqual(
+        'contextBudgetSummary' in event ? event.contextBudgetSummary : undefined,
+        retainedContextBudgetSummary,
+      );
       assert.equal(result.totalTokens, 3);
       assert.equal(result.totalCostUsd, 0.02);
     });
@@ -1674,6 +1695,7 @@ describe('fixed prompt controller', () => {
         tasks: [{ id: 'task-a', path: '/bench/task-a' }],
         harborRunner: async () => harborOutput({
           taskId: 'task-a',
+          errorClass: 'network',
           executionIdentity: {
             llmConnectionSlug: 'fake',
             model: 'wrong-model',

--- a/packages/headless/src/__tests__/runtime-policy-ab-lifecycle.test.ts
+++ b/packages/headless/src/__tests__/runtime-policy-ab-lifecycle.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { test } from 'node:test';
@@ -52,7 +52,7 @@ test('same-run pilot checkpoint gates full execution and resumes completed state
       evaluationTasks: [{ id: 'full', path: '/tasks/full' }],
       fullReps: 2,
       arms: [
-        { id: 'prune-off', contextEnv: { MAKA_CONTEXT_BUDGET: 'off' } },
+        { id: 'prune/off', contextEnv: { MAKA_CONTEXT_BUDGET: 'off' } },
         { id: 'prune-on', contextEnv: { MAKA_CONTEXT_STALE_TOOL_RESULT_PRUNE: 'on' } },
       ] as const,
       executionProfile,
@@ -70,6 +70,115 @@ test('same-run pilot checkpoint gates full execution and resumes completed state
 
     const resumed = await runRuntimePolicyAbLifecycle(input);
     assert.equal(resumed.status, 'full_completed');
+    assert.equal(calls.length, 6);
+  });
+});
+
+test('rebuilds a legacy terminal lifecycle summary from WAL before returning it', async () => {
+  await withDir(async (dir) => {
+    const promptPath = join(dir, 'prompt.md');
+    const statePath = join(dir, 'runtime-policy-ab-state.json');
+    await writeFile(promptPath, 'shared prompt\n', 'utf8');
+    const calls: string[] = [];
+    const input = {
+      runId: 'run-1',
+      runRoot: dir,
+      manifestFingerprint: 'sha256:manifest',
+      config,
+      systemPromptPath: promptPath,
+      resultsJsonlPath: join(dir, 'results.jsonl'),
+      pilotTasks: [{ id: 'pilot', path: '/tasks/pilot' }],
+      evaluationTasks: [{ id: 'full', path: '/tasks/full' }],
+      fullReps: 2,
+      arms: [
+        { id: 'prune/off', contextEnv: { MAKA_CONTEXT_BUDGET: 'off' } },
+        { id: 'prune-on', contextEnv: { MAKA_CONTEXT_STALE_TOOL_RESULT_PRUNE: 'on' } },
+      ] as const,
+      executionProfile,
+      harborRunner: async (runInput: HarborTaskRunInput) => {
+        calls.push(runInput.roundId);
+        return output(runInput, runInput.agentEnv?.MAKA_CONTEXT_STALE_TOOL_RESULT_PRUNE === 'on');
+      },
+    };
+    await runRuntimePolicyAbLifecycle(input);
+    const wal = await readFile(input.resultsJsonlPath, 'utf8');
+    const walEvents = wal.split('\n')
+      .filter(Boolean)
+      .map((line) => JSON.parse(line) as Record<string, any>);
+    const firstFullBaseline = walEvents
+      .find((event) => event.roundId === 'full-ab-prune-off-r0-full');
+    assert.ok(firstFullBaseline);
+    const staleRetry = {
+      ...firstFullBaseline,
+      id: 'stale-infra-before-successful-retry',
+      type: 'task_infra_failed',
+      status: 'infra_failed',
+      passed: false,
+      scored: false,
+      eligible: false,
+      errorClass: 'network',
+      error: 'transient failure before retry',
+    };
+    const legacy = JSON.parse(await readFile(statePath, 'utf8')) as Record<string, any>;
+    legacy.schemaVersion = 'maka.runtime_policy_ab.lifecycle.v1';
+    legacy.status = 'invalid';
+    legacy.reason = 'asymmetric_budget_exhaustion';
+    for (const summary of [legacy.pilot, legacy.full]) {
+      delete summary.baseline.attestationWarnings;
+      delete summary.candidate.attestationWarnings;
+      delete summary.taskLevel.excludedTaskIds;
+      delete summary.pairedAttempts.evaluatedPairs;
+      delete summary.pairedAttempts.excludedPairIds;
+    }
+    await writeFile(statePath, `${JSON.stringify(legacy)}\n`, 'utf8');
+
+    const ambiguousLegacyTimeout = {
+      ...walEvents[0],
+      type: 'task_plumbing_failed',
+      status: 'plumbing_failed',
+      passed: false,
+      scored: false,
+      eligible: false,
+      errorClass: 'missing_execution_identity',
+      error: 'Harbor cell did not attest the connection, model, prompt, and pricing profile that executed',
+    };
+    await writeFile(
+      input.resultsJsonlPath,
+      `${[ambiguousLegacyTimeout, ...walEvents.slice(1)].map((event) => JSON.stringify(event)).join('\n')}\n`,
+      'utf8',
+    );
+    await assert.rejects(
+      runRuntimePolicyAbLifecycle(input),
+      /legacy missing-identity event .* has no authoritative outcome/,
+    );
+
+    const staleAmbiguousRetry = {
+      ...firstFullBaseline,
+      id: 'stale-ambiguous-before-successful-retry',
+      type: 'task_plumbing_failed',
+      status: 'plumbing_failed',
+      passed: false,
+      scored: false,
+      eligible: false,
+      errorClass: 'missing_execution_identity',
+      error: 'ambiguous legacy result superseded by a successful retry',
+    };
+    const unrelatedAmbiguousEvent = {
+      ...staleAmbiguousRetry,
+      id: 'unrelated-run-ambiguous-event',
+      runId: 'another-run',
+    };
+    await writeFile(
+      input.resultsJsonlPath,
+      `${JSON.stringify(unrelatedAmbiguousEvent)}\n${JSON.stringify(staleAmbiguousRetry)}\n${JSON.stringify(staleRetry)}\n${wal}`,
+      'utf8',
+    );
+
+    const resumed = await runRuntimePolicyAbLifecycle(input);
+    assert.equal(resumed.schemaVersion, 'maka.runtime_policy_ab.lifecycle.v2');
+    assert.equal(resumed.status, 'full_completed');
+    assert.equal(resumed.reason, undefined);
+    assert.deepEqual(resumed.full?.pairedAttempts.excludedPairIds, []);
     assert.equal(calls.length, 6);
   });
 });
@@ -150,7 +259,7 @@ test('pilot candidate pass against an attested baseline timeout can launch full 
   });
 });
 
-test('pilot does not launch full execution after an unattested baseline timeout', async () => {
+test('pilot records an unattested baseline timeout warning and launches full execution', async () => {
   await withDir(async (dir) => {
     const promptPath = join(dir, 'prompt.md');
     await writeFile(promptPath, 'shared prompt\n', 'utf8');
@@ -178,9 +287,48 @@ test('pilot does not launch full execution after an unattested baseline timeout'
       },
     });
 
-    assert.equal(state.status, 'pilot_not_cleared');
-    assert.equal(state.reason, 'pilot_plumbing_failure');
-    assert.equal(calls.length, 2);
+    assert.equal(state.status, 'full_completed');
+    assert.equal(state.pilot?.baseline.attestationWarnings, 1);
+    assert.equal(state.pilot?.baseline.budgetExhausted, 1);
+    assert.equal(calls.length, 6);
+  });
+});
+
+test('pilot preserves candidate activation from an unattested timeout', async () => {
+  await withDir(async (dir) => {
+    const promptPath = join(dir, 'prompt.md');
+    await writeFile(promptPath, 'shared prompt\n', 'utf8');
+    const calls: string[] = [];
+    const state = await runRuntimePolicyAbLifecycle({
+      runId: 'run-1',
+      runRoot: dir,
+      manifestFingerprint: 'sha256:manifest',
+      config,
+      systemPromptPath: promptPath,
+      resultsJsonlPath: join(dir, 'results.jsonl'),
+      pilotTasks: [{ id: 'pilot', path: '/tasks/pilot' }],
+      evaluationTasks: [{ id: 'full', path: '/tasks/full' }],
+      fullReps: 2,
+      arms: [
+        { id: 'prune-off', contextEnv: { MAKA_CONTEXT_BUDGET: 'off' } },
+        { id: 'prune-on', contextEnv: { MAKA_CONTEXT_STALE_TOOL_RESULT_PRUNE: 'on' } },
+      ],
+      executionProfile,
+      harborRunner: async (runInput) => {
+        calls.push(runInput.roundId);
+        const candidate = runInput.agentEnv?.MAKA_CONTEXT_STALE_TOOL_RESULT_PRUNE === 'on';
+        if (runInput.roundId.startsWith('pilot-') && candidate) {
+          const { executionIdentity: _, ...cellOutput } = output(runInput, true).cell;
+          throw new FixedPromptBudgetExhaustedError('pilot budget exhausted', undefined, { cellOutput });
+        }
+        return output(runInput, candidate);
+      },
+    });
+
+    assert.equal(state.status, 'full_completed');
+    assert.equal(state.pilot?.candidate.attestationWarnings, 1);
+    assert.equal(state.pilot?.candidate.contextBudget?.activatedAttempts, 1);
+    assert.equal(calls.length, 6);
   });
 });
 

--- a/packages/headless/src/ab-render.ts
+++ b/packages/headless/src/ab-render.ts
@@ -27,13 +27,17 @@ export function renderAbComparisonMarkdown(summary: AbComparisonSummary): string
     `- Budget: ${summary.budgetMs !== undefined ? `${Math.round(summary.budgetMs / 1000)}s task budget` : 'not recorded'}`,
     `- Non-inferiority margin: ${rate(summary.nonInferiorityMargin)}`,
     `- Non-inferiority lower bound: ${rate(summary.nonInferiority.lowerBound)} (${rate(summary.nonInferiority.confidenceLevel)} one-sided confidence, ${summary.nonInferiority.method})`,
-    `- Evaluation pass rate: A=${summary.baseline.passed}/${summary.baseline.valid} = ${rate(summary.baseline.passRate)}, B=${summary.candidate.passed}/${summary.candidate.valid} = ${rate(summary.candidate.passRate)}`,
-    `- Evaluation pass-rate delta: B-A=${rate(summary.passRateDelta)}`,
-    `- Task-level delta: mean=${rate(summary.taskLevel.meanPassRateDelta)}, median=${rate(summary.taskLevel.medianPassRateDelta)}, wins=${summary.taskLevel.wins}, losses=${summary.taskLevel.losses}, ties=${summary.taskLevel.ties}, sign_test_p=${rate(summary.taskLevel.signTestPValue)}, missing=${summary.taskLevel.missingTaskIds.length}`,
-    `- Attempt-pair auxiliary: wins=${summary.pairedAttempts.wins}, losses=${summary.pairedAttempts.losses}, ties=${summary.pairedAttempts.ties}, missing=${summary.pairedAttempts.missingPairIds.length}`,
+    `- Run completeness: A observed=${summary.baseline.observed}/${summary.baseline.attempts} missing=${summary.baseline.missing}, B observed=${summary.candidate.observed}/${summary.candidate.attempts} missing=${summary.candidate.missing}`,
+    `- Outcome coverage: A evaluated=${summary.baseline.valid}/${summary.baseline.attempts} = ${rate(summary.baseline.coverageRate)}, B evaluated=${summary.candidate.valid}/${summary.candidate.attempts} = ${rate(summary.candidate.coverageRate)}`,
+    `- Outcome pass rate: A=${summary.baseline.passed}/${summary.baseline.valid} = ${rate(summary.baseline.passRate)}, B=${summary.candidate.passed}/${summary.candidate.valid} = ${rate(summary.candidate.passRate)}`,
+    `- Paired outcome delta: B-A=${rate(summary.passRateDelta)}`,
+    `- Task-level delta: mean=${rate(summary.taskLevel.meanPassRateDelta)}, median=${rate(summary.taskLevel.medianPassRateDelta)}, wins=${summary.taskLevel.wins}, losses=${summary.taskLevel.losses}, ties=${summary.taskLevel.ties}, sign_test_p=${rate(summary.taskLevel.signTestPValue)}, missing=${summary.taskLevel.missingTaskIds.length}, excluded=${summary.taskLevel.excludedTaskIds.length}`,
+    `- Attempt pairs: observed=${summary.pairedAttempts.observedPairs}/${summary.pairedAttempts.pairs} evaluated=${summary.pairedAttempts.evaluatedPairs} excluded=${summary.pairedAttempts.excludedPairIds.length} missing=${summary.pairedAttempts.missingPairIds.length}; wins=${summary.pairedAttempts.wins}, losses=${summary.pairedAttempts.losses}, ties=${summary.pairedAttempts.ties}`,
     `- Token/cost: A ${renderTokenCost(summary.baseline.tokenCostSummary)}, B ${renderTokenCost(summary.candidate.tokenCostSummary)}`,
     `- Budget outcomes: A timed_out=${summary.baseline.budgetExhausted}, B timed_out=${summary.candidate.budgetExhausted}`,
-    `- Infra outcomes: A infra_failed=${summary.baseline.infraFailed}, B infra_failed=${summary.candidate.infraFailed}; A plumbing_failed=${summary.baseline.plumbingFailed}, B plumbing_failed=${summary.candidate.plumbingFailed}`,
+    `- Infra exclusions: A=${summary.baseline.infraFailed}, B=${summary.candidate.infraFailed}`,
+    `- Attestation warnings: A=${summary.baseline.attestationWarnings}, B=${summary.candidate.attestationWarnings}`,
+    `- Plumbing failures: A=${summary.baseline.plumbingFailed}, B=${summary.candidate.plumbingFailed}`,
     ...(contextBudgetPolicyLine ? [contextBudgetPolicyLine] : []),
     ...(continuationLine ? [continuationLine] : []),
     ...(taskToolLine ? [taskToolLine] : []),
@@ -47,6 +51,9 @@ export function renderAbComparisonMarkdown(summary: AbComparisonSummary): string
   ];
   if (summary.taskLevel.missingTaskIds.length > 0) {
     lines.push('## Missing Tasks', '', ...summary.taskLevel.missingTaskIds.map((taskId) => `- ${taskId}`), '');
+  }
+  if (summary.taskLevel.excludedTaskIds.length > 0) {
+    lines.push('## Excluded Tasks', '', ...summary.taskLevel.excludedTaskIds.map((taskId) => `- ${taskId}`), '');
   }
   const losses = summary.taskLevel.tasks.filter((task) => task.outcome === 'baseline_win');
   if (losses.length > 0) {
@@ -222,6 +229,7 @@ function renderActivePruneSubsetMetrics(summary: NonNullable<AbComparisonSummary
     `timed_out=${summary.budgetExhausted}`,
     `infra_failed=${summary.infraFailed}`,
     `plumbing_failed=${summary.plumbingFailed}`,
+    `attestation_warnings=${summary.attestationWarnings}`,
     renderTokenCost(summary.tokenCostSummary),
     renderContextBudgetMetrics(contextBudget),
   ].join(' ');
@@ -263,6 +271,7 @@ function activePruneSubsetOrZero(
     budgetExhausted: 0,
     infraFailed: 0,
     plumbingFailed: 0,
+    attestationWarnings: 0,
     missing: 0,
     coverageRate: 1,
     totalCostUsd: 0,

--- a/packages/headless/src/ab-run.ts
+++ b/packages/headless/src/ab-run.ts
@@ -109,8 +109,7 @@ async function runComparisonTaskArm(
   arm: AbArmSpec,
   pair: { rep: number; task: FixedPromptTask },
 ): Promise<FixedPromptTaskWalEvent> {
-  const prefix = input.roundIdPrefix ? `${roundIdArmSuffix(input.roundIdPrefix)}-` : '';
-  const roundId = `${prefix}ab-${roundIdArmSuffix(arm.id)}-r${pair.rep}-${roundIdTaskSuffix(pair.task.id)}`;
+  const roundId = buildAbRoundId(input.roundIdPrefix, arm.id, pair.rep, pair.task.id);
   const event = await input.runArm({
     runId: input.runId,
     roundId,
@@ -120,6 +119,11 @@ async function runComparisonTaskArm(
   });
   if (event.taskId !== pair.task.id) throw new Error(`A/B arm ${roundId} produced event for ${event.taskId}, expected ${pair.task.id}`);
   return event;
+}
+
+export function buildAbRoundId(prefix: string | undefined, armId: string, rep: number, taskId: string): string {
+  const normalizedPrefix = prefix ? `${roundIdArmSuffix(prefix)}-` : '';
+  return `${normalizedPrefix}ab-${roundIdArmSuffix(armId)}-r${rep}-${roundIdTaskSuffix(taskId)}`;
 }
 
 function roundIdArmSuffix(armId: string): string {

--- a/packages/headless/src/ab-summary.ts
+++ b/packages/headless/src/ab-summary.ts
@@ -43,8 +43,8 @@ export function summarizeAbComparison(input: SummarizeAbComparisonInput): AbComp
   const taskLevel = summarizeTasks(input.baselineRuns, input.candidateRuns, taskIds, reps);
   const pairedAttempts = summarizeAttemptPairs(input.baselineRuns, input.candidateRuns, taskIds);
   const investigationRefs = summarizeInvestigationRefs(input.baselineRuns, input.candidateRuns, taskIds);
-  const passRateDelta = baseline.passRate !== null && candidate.passRate !== null
-    ? roundRateDelta(candidate.passRate - baseline.passRate)
+  const passRateDelta = pairedAttempts.evaluatedPairs > 0
+    ? roundRateDelta((pairedAttempts.wins - pairedAttempts.losses) / pairedAttempts.evaluatedPairs)
     : null;
   const nonInferiority = summarizeNonInferiority(pairedAttempts, passRateDelta);
   const formalDecision = decide(baseline, candidate, pairedAttempts, passRateDelta, nonInferiority, nonInferiorityMargin);
@@ -91,7 +91,7 @@ function summarizeArm(
   const attempts = taskIds.length * reps;
   const observedAttempts = observedArmAttempts(runs, taskIds, arm);
   const observed = observedAttempts.map((attempt) => attempt.event);
-  const valid = observed.filter(isValidBudgetedOutcome);
+  const valid = observed.filter(isEvaluatedOutcome);
   const budgetedRuns = valid.filter(
     (event): event is Extract<FixedPromptTaskWalEvent, { type: 'task_completed' }> =>
       event.type === 'task_completed' && abOutcomeCategory(event) !== 'budget',
@@ -114,6 +114,7 @@ function summarizeArm(
     budgetExhausted: observed.filter((event) => abOutcomeCategory(event) === 'budget').length,
     infraFailed: observed.filter((event) => abOutcomeCategory(event) === 'infra').length,
     plumbingFailed: observed.filter((event) => abOutcomeCategory(event) === 'plumbing').length,
+    attestationWarnings: observed.filter(isMissingExecutionIdentityTimeout).length,
     missing: attempts - observed.length,
     coverageRate: attempts > 0 ? valid.length / attempts : 1,
     totalCostUsd: tokenCostSummary.costUsd,
@@ -142,7 +143,7 @@ function summarizeActivePruneSubset(
   if (activePrunePairIds.size === 0) return undefined;
   const sliceAttempts = attempts.filter((attempt) => activePrunePairIds.has(attemptPairId(attempt)));
   const observed = sliceAttempts.map((attempt) => attempt.event);
-  const valid = observed.filter(isValidBudgetedOutcome);
+  const valid = observed.filter(isEvaluatedOutcome);
   const budgetedRuns = valid.filter(
     (event): event is Extract<FixedPromptTaskWalEvent, { type: 'task_completed' }> =>
       event.type === 'task_completed' && abOutcomeCategory(event) !== 'budget',
@@ -162,6 +163,7 @@ function summarizeActivePruneSubset(
     budgetExhausted: observed.filter((event) => abOutcomeCategory(event) === 'budget').length,
     infraFailed: observed.filter((event) => abOutcomeCategory(event) === 'infra').length,
     plumbingFailed: observed.filter((event) => abOutcomeCategory(event) === 'plumbing').length,
+    attestationWarnings: observed.filter(isMissingExecutionIdentityTimeout).length,
     missing: activePrunePairIds.size - observed.length,
     coverageRate: activePrunePairIds.size > 0 ? valid.length / activePrunePairIds.size : 1,
     totalCostUsd: tokenCostSummary.costUsd,
@@ -284,7 +286,7 @@ function summarizeContinuation(
 function summarizeTaskTools(events: readonly FixedPromptTaskWalEvent[]): AbTaskToolSummary | undefined {
   const summaries: { event: FixedPromptTaskWalEvent; summary: HarborCellTaskToolSummary }[] = [];
   for (const event of events) {
-    if ((event.type === 'task_completed' || event.type === 'task_plumbing_failed') && event.taskToolSummary) {
+    if ('taskToolSummary' in event && event.taskToolSummary) {
       summaries.push({ event, summary: event.taskToolSummary });
     }
   }
@@ -334,7 +336,7 @@ function summarizeInvestigationRefs(
       const baselineEvent = baseline?.event;
       const candidateEvent = candidate?.event;
       if (baselineEvent && candidateEvent) {
-        if (isValidBudgetedOutcome(baselineEvent) && isValidBudgetedOutcome(candidateEvent) && baselineEvent.passed && !candidateEvent.passed) {
+        if (isEvaluatedOutcome(baselineEvent) && isEvaluatedOutcome(candidateEvent) && baselineEvent.passed && !candidateEvent.passed) {
           candidateLosses.push(pairRef(pairId, baseline, candidate));
         }
         if (isBudgetExhaustedOutcome(baselineEvent) !== isBudgetExhaustedOutcome(candidateEvent)) {
@@ -409,7 +411,10 @@ function summarizeTasks(
     ties,
     signTestNonTieTasks,
     signTestPValue: signTestNonTieTasks > 0 ? exactTwoSidedSignTestPValue(signTestNonTieTasks, Math.max(wins, losses)) : null,
-    missingTaskIds: tasks.filter((task) => task.outcome === 'missing').map((task) => task.taskId),
+    missingTaskIds: tasks
+      .filter((task) => task.baseline.missing > 0 || task.candidate.missing > 0)
+      .map((task) => task.taskId),
+    excludedTaskIds: tasks.filter((task) => task.outcome === 'excluded').map((task) => task.taskId),
     meanPassRateDelta: deltas.length > 0 ? sum(deltas) / deltas.length : null,
     medianPassRateDelta: median(deltas),
     tasks,
@@ -424,12 +429,22 @@ function summarizeTask(
 ): AbTaskComparison {
   const baseline = summarizeTaskArm(taskId, baselineRuns, reps);
   const candidate = summarizeTaskArm(taskId, candidateRuns, reps);
-  const passRateDelta = baseline.passRate !== null && candidate.passRate !== null
-    ? candidate.passRate - baseline.passRate
+  const evaluatedPairs = baselineRuns.flatMap((run, rep) => {
+    const baselineEvent = run.find((event) => event.taskId === taskId);
+    const candidateEvent = candidateRuns[rep]?.find((event) => event.taskId === taskId);
+    return baselineEvent && candidateEvent && isEvaluatedOutcome(baselineEvent) && isEvaluatedOutcome(candidateEvent)
+      ? [{ baseline: baselineEvent, candidate: candidateEvent }]
+      : [];
+  });
+  const passRateDelta = evaluatedPairs.length > 0
+    ? (evaluatedPairs.filter(({ candidate }) => candidate.passed).length
+      - evaluatedPairs.filter(({ baseline: event }) => event.passed).length) / evaluatedPairs.length
     : null;
   let outcome: AbTaskComparison['outcome'] = 'missing';
   if (passRateDelta !== null) {
     outcome = passRateDelta > 0 ? 'candidate_win' : passRateDelta < 0 ? 'baseline_win' : 'tie';
+  } else if (baseline.missing === 0 && candidate.missing === 0) {
+    outcome = 'excluded';
   }
   return { taskId, baseline, candidate, passRateDelta, outcome };
 }
@@ -442,7 +457,7 @@ function summarizeTaskArm(
   const observed = runs
     .map((run) => run.find((event) => event.taskId === taskId))
     .filter((event): event is FixedPromptTaskWalEvent => event !== undefined);
-  const valid = observed.filter(isValidBudgetedOutcome);
+  const valid = observed.filter(isEvaluatedOutcome);
   const passed = valid.filter((event) => event.passed).length;
   return {
     observed: observed.length,
@@ -453,6 +468,7 @@ function summarizeTaskArm(
     budgetExhausted: observed.filter((event) => abOutcomeCategory(event) === 'budget').length,
     infraFailed: observed.filter((event) => abOutcomeCategory(event) === 'infra').length,
     plumbingFailed: observed.filter((event) => abOutcomeCategory(event) === 'plumbing').length,
+    attestationWarnings: observed.filter(isMissingExecutionIdentityTimeout).length,
     missing: reps - observed.length,
   };
 }
@@ -463,9 +479,11 @@ function summarizeAttemptPairs(
   taskIds: readonly string[],
 ): AbAttemptPairSummary {
   const missingPairIds: string[] = [];
+  const excludedPairIds: string[] = [];
   const budgetDiscordantPairIds: string[] = [];
   const infraOrPlumbingDiscordantPairIds: string[] = [];
   let observedPairs = 0;
+  let evaluatedPairs = 0;
   let wins = 0;
   let losses = 0;
   let ties = 0;
@@ -480,17 +498,18 @@ function summarizeAttemptPairs(
         missingPairIds.push(pairId);
         continue;
       }
+      observedPairs += 1;
       if (isBudgetExhaustedOutcome(baseline) !== isBudgetExhaustedOutcome(candidate)) {
         budgetDiscordantPairIds.push(pairId);
       }
       if (isInfraOrPlumbingOutcome(baseline) !== isInfraOrPlumbingOutcome(candidate)) {
         infraOrPlumbingDiscordantPairIds.push(pairId);
       }
-      if (!isValidBudgetedOutcome(baseline) || !isValidBudgetedOutcome(candidate)) {
-        missingPairIds.push(pairId);
+      if (!isEvaluatedOutcome(baseline) || !isEvaluatedOutcome(candidate)) {
+        excludedPairIds.push(pairId);
         continue;
       }
-      observedPairs += 1;
+      evaluatedPairs += 1;
       if (candidate.passed === baseline.passed) {
         ties += 1;
       } else if (candidate.passed) {
@@ -503,10 +522,12 @@ function summarizeAttemptPairs(
   return {
     pairs: taskIds.length * baselineRuns.length,
     observedPairs,
+    evaluatedPairs,
     wins,
     losses,
     ties,
     missingPairIds,
+    excludedPairIds,
     budgetDiscordantPairIds,
     infraOrPlumbingDiscordantPairIds,
   };
@@ -520,14 +541,10 @@ function decide(
   nonInferiority: AbNonInferioritySummary,
   nonInferiorityMargin: number,
 ): { decision: AbDecision; reason: string } {
-  const coverage = Math.min(baseline.coverageRate, candidate.coverageRate);
-  if (baseline.infraFailed + candidate.infraFailed > 0) return { decision: 'invalid', reason: 'infra_failure_observed' };
+  const coverage = pairedAttempts.pairs > 0 ? pairedAttempts.evaluatedPairs / pairedAttempts.pairs : 0;
   if (baseline.plumbingFailed + candidate.plumbingFailed > 0) return { decision: 'invalid', reason: 'plumbing_failure_observed' };
   if (coverage < 0.9) return { decision: 'not_cleared', reason: 'low_effective_coverage' };
   if (pairedAttempts.missingPairIds.length > 0) return { decision: 'not_cleared', reason: 'missing_attempt_pair' };
-  if (pairedAttempts.infraOrPlumbingDiscordantPairIds.length > 0) {
-    return { decision: 'invalid', reason: 'asymmetric_infra_or_plumbing' };
-  }
   if (passRateDelta === null) return { decision: 'not_cleared', reason: 'missing_pass_rate_delta' };
   if (passRateDelta < -nonInferiorityMargin) return { decision: 'inferior', reason: 'pass_rate_delta_below_non_inferiority_margin' };
   if (nonInferiority.lowerBound !== null && nonInferiority.lowerBound >= -nonInferiorityMargin) {
@@ -540,11 +557,11 @@ function summarizeNonInferiority(
   pairedAttempts: AbAttemptPairSummary,
   passRateDelta: number | null,
 ): AbNonInferioritySummary {
-  if (passRateDelta === null || pairedAttempts.observedPairs === 0) {
+  if (passRateDelta === null || pairedAttempts.evaluatedPairs === 0) {
     return { method: 'unavailable', confidenceLevel: NON_INFERIORITY_CONFIDENCE_LEVEL, lowerBound: null };
   }
-  const winInterval = wilsonScoreInterval(pairedAttempts.wins, pairedAttempts.observedPairs, ONE_SIDED_97_5_Z);
-  const lossInterval = wilsonScoreInterval(pairedAttempts.losses, pairedAttempts.observedPairs, ONE_SIDED_97_5_Z);
+  const winInterval = wilsonScoreInterval(pairedAttempts.wins, pairedAttempts.evaluatedPairs, ONE_SIDED_97_5_Z);
+  const lossInterval = wilsonScoreInterval(pairedAttempts.losses, pairedAttempts.evaluatedPairs, ONE_SIDED_97_5_Z);
   return {
     method: 'paired_bonferroni_wilson',
     confidenceLevel: NON_INFERIORITY_CONFIDENCE_LEVEL,
@@ -564,10 +581,16 @@ function wilsonScoreInterval(passed: number, total: number, z: number): { lower:
   };
 }
 
-function isValidBudgetedOutcome(
+function isEvaluatedOutcome(
   event: FixedPromptTaskWalEvent,
 ): event is Extract<FixedPromptTaskWalEvent, { type: 'task_completed' | 'task_budget_exhausted' }> {
-  return event.eligible && (event.type === 'task_completed' || event.type === 'task_budget_exhausted');
+  const category = abOutcomeCategory(event);
+  return (event.type === 'task_completed' || event.type === 'task_budget_exhausted')
+    && (category === 'completed' || category === 'budget');
+}
+
+function isMissingExecutionIdentityTimeout(event: FixedPromptTaskWalEvent): boolean {
+  return event.type === 'task_budget_exhausted' && event.evidenceErrorClass === 'missing_execution_identity';
 }
 
 function isBudgetExhaustedOutcome(event: FixedPromptTaskWalEvent): boolean {
@@ -585,17 +608,20 @@ function abOutcomeCategory(event: FixedPromptTaskWalEvent): AbOutcomeCategory {
   if (event.type === 'task_infra_failed') return 'infra';
   if (event.type === 'task_plumbing_failed') return 'plumbing';
   if (event.type === 'task_completed') {
-    return event.errorClass === 'tool_step_cap_reached' ? 'budget' : 'completed';
+    if (isHardPlumbingErrorClass(event.errorClass)) return 'plumbing';
+    if (event.errorClass === 'tool_step_cap_reached') return 'budget';
+    return event.scored ? 'completed' : 'infra';
   }
-  if (event.evidenceErrorClass === undefined) return 'budget';
-  if (
-    event.evidenceErrorClass === 'zero_cost_with_tokens'
-    || event.evidenceErrorClass === 'prompt_hash_mismatch'
-    || event.evidenceErrorClass === 'missing_prompt_hash'
-    || event.evidenceErrorClass === 'missing_execution_identity'
-    || event.evidenceErrorClass === 'execution_identity_mismatch'
-  ) return 'plumbing';
+  if (event.evidenceErrorClass === undefined || event.evidenceErrorClass === 'missing_execution_identity') return 'budget';
+  if (isHardPlumbingErrorClass(event.evidenceErrorClass)) return 'plumbing';
   return 'infra';
+}
+
+function isHardPlumbingErrorClass(errorClass: string | undefined): boolean {
+  return errorClass === 'zero_cost_with_tokens'
+    || errorClass === 'prompt_hash_mismatch'
+    || errorClass === 'missing_prompt_hash'
+    || errorClass === 'execution_identity_mismatch';
 }
 
 function median(values: readonly number[]): number | null {

--- a/packages/headless/src/ab-types.ts
+++ b/packages/headless/src/ab-types.ts
@@ -62,6 +62,7 @@ export interface AbArmSummary {
   budgetExhausted: number;
   infraFailed: number;
   plumbingFailed: number;
+  attestationWarnings: number;
   missing: number;
   coverageRate: number;
   totalCostUsd: number;
@@ -85,6 +86,7 @@ export interface AbActivePruneSubsetSummary {
   budgetExhausted: number;
   infraFailed: number;
   plumbingFailed: number;
+  attestationWarnings: number;
   missing: number;
   coverageRate: number;
   totalCostUsd: number;
@@ -162,6 +164,7 @@ export interface AbTaskArmSummary {
   budgetExhausted: number;
   infraFailed: number;
   plumbingFailed: number;
+  attestationWarnings: number;
   missing: number;
 }
 
@@ -170,7 +173,7 @@ export interface AbTaskComparison {
   baseline: AbTaskArmSummary;
   candidate: AbTaskArmSummary;
   passRateDelta: number | null;
-  outcome: 'candidate_win' | 'baseline_win' | 'tie' | 'missing';
+  outcome: 'candidate_win' | 'baseline_win' | 'tie' | 'missing' | 'excluded';
 }
 
 export interface AbTaskLevelSummary {
@@ -181,6 +184,7 @@ export interface AbTaskLevelSummary {
   signTestNonTieTasks: number;
   signTestPValue: number | null;
   missingTaskIds: string[];
+  excludedTaskIds: string[];
   meanPassRateDelta: number | null;
   medianPassRateDelta: number | null;
   tasks: AbTaskComparison[];
@@ -189,10 +193,12 @@ export interface AbTaskLevelSummary {
 export interface AbAttemptPairSummary {
   pairs: number;
   observedPairs: number;
+  evaluatedPairs: number;
   wins: number;
   losses: number;
   ties: number;
   missingPairIds: string[];
+  excludedPairIds: string[];
   budgetDiscordantPairIds: string[];
   infraOrPlumbingDiscordantPairIds: string[];
 }

--- a/packages/headless/src/fixed-prompt-controller.ts
+++ b/packages/headless/src/fixed-prompt-controller.ts
@@ -152,6 +152,12 @@ export interface FixedPromptTaskBudgetExhaustedEvent {
   runtimeEventsUnavailableReason?: string;
   tokenSummary?: HarborCellTokenSummary;
   executionIdentity?: HarborCellExecutionIdentity;
+  contextBudgetPolicy?: HarborCellContextBudgetPolicySnapshot;
+  contextBudgetSummary?: HarborCellContextBudgetSummary;
+  continuationSummary?: HarborCellContinuationSummary;
+  taskToolSummary?: HarborCellTaskToolSummary;
+  steps?: number;
+  durationMs?: number;
 }
 
 export interface FixedPromptTaskPlumbingFailedEvent {
@@ -610,6 +616,19 @@ function taskEventFromOutput(input: {
   id: string;
   ts: number;
 }): FixedPromptTaskCompletedEvent | FixedPromptTaskPlumbingFailedEvent | FixedPromptTaskInfraFailedEvent {
+  const identityMismatch = classifyExplicitIdentityMismatch(
+    input.output.cell.executionIdentity,
+    input.expectedPromptHash,
+    input.expectedConfig,
+    input.expectedPricingProfile,
+  );
+  if (identityMismatch) {
+    return taskPlumbingFailedEvent({
+      ...input,
+      errorClass: identityMismatch.errorClass,
+      error: identityMismatch.error,
+    });
+  }
   if (isProviderInfraFailure(input.output.cell.errorClass)) {
     return taskInfraFailedEvent({
       ...input,
@@ -805,6 +824,19 @@ function classifyExecutionIdentityFailure(
   return undefined;
 }
 
+function classifyExplicitIdentityMismatch(
+  identity: HarborCellExecutionIdentity | undefined,
+  expectedPromptHash: string,
+  expectedConfig: Config,
+  expectedPricingProfile: string | undefined,
+): { errorClass: 'execution_identity_mismatch'; error: string } | undefined {
+  if (!identity) return undefined;
+  const failure = classifyExecutionIdentityFailure(identity, expectedPromptHash, expectedConfig, false, expectedPricingProfile);
+  return failure?.errorClass === 'execution_identity_mismatch'
+    ? { errorClass: failure.errorClass, error: failure.error }
+    : undefined;
+}
+
 function taskInfraFailedEvent(input: {
   error: unknown;
   errorClass?: FixedPromptTaskInfraFailedEvent['errorClass'];
@@ -853,7 +885,13 @@ function taskBudgetExhaustedEvent(input: {
   } | undefined;
   if (artifactRefs.cellOutput) {
     const output = { harbor: { reward: 0 }, cell: artifactRefs.cellOutput };
-    evidenceFailure = isProviderInfraFailure(output.cell.errorClass)
+    const identityMismatch = classifyExplicitIdentityMismatch(
+      output.cell.executionIdentity,
+      input.expectedPromptHash,
+      input.expectedConfig,
+      input.expectedPricingProfile,
+    );
+    evidenceFailure = identityMismatch ?? (isProviderInfraFailure(output.cell.errorClass)
       ? {
           errorClass: output.cell.errorClass,
           error: `Harbor cell failed with ${output.cell.errorClass}`,
@@ -869,7 +907,7 @@ function taskBudgetExhaustedEvent(input: {
             input.expectedConfig,
             input.requireExecutionIdentity ?? false,
             input.expectedPricingProfile,
-          );
+          ));
   } else {
     evidenceFailure = classifyExecutionIdentityFailure(
       artifactRefs.executionIdentity,
@@ -884,6 +922,9 @@ function taskBudgetExhaustedEvent(input: {
   }
   const tokenSummary = artifactRefs.cellOutput?.tokenSummary ?? artifactRefs.tokenSummary;
   const executionIdentity = artifactRefs.cellOutput?.executionIdentity ?? artifactRefs.executionIdentity;
+  const cellOutput = artifactRefs.cellOutput;
+  const runtimeEventsPath = artifactRefs.runtimeEventsPath ?? cellOutput?.runtimeEventsPath;
+  const traceEventsPath = artifactRefs.traceEventsPath ?? cellOutput?.traceEventsPath;
   return {
     schemaVersion: FIXED_PROMPT_WAL_SCHEMA_VERSION,
     type: 'task_budget_exhausted',
@@ -905,12 +946,17 @@ function taskBudgetExhaustedEvent(input: {
     } : {}),
     expectedPromptHash: input.expectedPromptHash,
     ...(executionIdentity ? { executionIdentity } : {}),
-    ...(artifactRefs.runtimeEventsPath ? { runtimeEventsPath: artifactRefs.runtimeEventsPath } : {}),
-    ...(artifactRefs.traceEventsPath ? { traceEventsPath: artifactRefs.traceEventsPath } : {}),
+    ...(runtimeEventsPath ? { runtimeEventsPath } : {}),
+    ...(traceEventsPath ? { traceEventsPath } : {}),
     ...(artifactRefs.runtimeEventsUnavailableReason
       ? { runtimeEventsUnavailableReason: artifactRefs.runtimeEventsUnavailableReason }
       : {}),
     ...(tokenSummary ? { tokenSummary } : {}),
+    ...(cellOutput?.contextBudgetPolicy ? { contextBudgetPolicy: cellOutput.contextBudgetPolicy } : {}),
+    ...(cellOutput?.contextBudgetSummary ? { contextBudgetSummary: cellOutput.contextBudgetSummary } : {}),
+    ...(cellOutput?.continuationSummary ? { continuationSummary: cellOutput.continuationSummary } : {}),
+    ...(cellOutput?.taskToolSummary ? { taskToolSummary: cellOutput.taskToolSummary } : {}),
+    ...(cellOutput ? { steps: cellOutput.steps, durationMs: cellOutput.durationMs } : {}),
   };
 }
 
@@ -944,6 +990,12 @@ function projectLegacyTimeoutOutcome(event: FixedPromptWalEvent): FixedPromptWal
     ...(event.tokenSummary ? { tokenSummary: event.tokenSummary } : {}),
     ...(event.runtimeEventsPath ? { runtimeEventsPath: event.runtimeEventsPath } : {}),
     ...(event.traceEventsPath ? { traceEventsPath: event.traceEventsPath } : {}),
+    ...(event.contextBudgetPolicy ? { contextBudgetPolicy: event.contextBudgetPolicy } : {}),
+    ...(event.contextBudgetSummary ? { contextBudgetSummary: event.contextBudgetSummary } : {}),
+    ...(event.continuationSummary ? { continuationSummary: event.continuationSummary } : {}),
+    ...(event.taskToolSummary ? { taskToolSummary: event.taskToolSummary } : {}),
+    ...(event.steps !== undefined ? { steps: event.steps } : {}),
+    ...(event.durationMs !== undefined ? { durationMs: event.durationMs } : {}),
   };
 }
 
@@ -1003,6 +1055,16 @@ function roundTaskEvents(
     byTask.set(event.taskId, event);
   }
   return byTask;
+}
+
+export function selectFixedPromptRoundTaskEvents(
+  events: readonly FixedPromptWalEvent[],
+  runId: string,
+  roundId: string,
+  expectedPromptHash: string,
+  resumeFingerprint: string,
+): Map<string, FixedPromptTaskWalEvent> {
+  return roundTaskEvents(events, runId, roundId, expectedPromptHash, resumeFingerprint);
 }
 
 function eventMatchesResumeIdentity(

--- a/packages/headless/src/prompt-ab-types.ts
+++ b/packages/headless/src/prompt-ab-types.ts
@@ -1,9 +1,14 @@
 import type { Config } from './contracts.js';
 import type {
+  AbArmSummary,
   AbArmSpec,
+  AbAttemptPairSummary,
   AbComparisonSummary,
   AbDecision,
   AbRunManifest,
+  AbTaskArmSummary,
+  AbTaskComparison,
+  AbTaskLevelSummary,
 } from './ab-types.js';
 import type {
   FixedPromptTask,
@@ -43,65 +48,11 @@ export interface RunPromptAbComparisonInput {
 
 export type PromptAbDecision = AbDecision;
 
-export interface PromptAbArmSummary {
-  attempts: number;
-  observed: number;
-  valid: number;
-  passed: number;
-  passRate: number | null;
-  completed: number;
-  budgetExhausted: number;
-  infraFailed: number;
-  plumbingFailed: number;
-  missing: number;
-  coverageRate: number;
-  totalCostUsd: number;
-  meanDurationMs: number | null;
-}
-
-export interface PromptAbTaskArmSummary {
-  observed: number;
-  valid: number;
-  passed: number;
-  passRate: number | null;
-  completed: number;
-  budgetExhausted: number;
-  infraFailed: number;
-  plumbingFailed: number;
-  missing: number;
-}
-
-export interface PromptAbTaskComparison {
-  taskId: string;
-  baseline: PromptAbTaskArmSummary;
-  candidate: PromptAbTaskArmSummary;
-  passRateDelta: number | null;
-  outcome: 'candidate_win' | 'baseline_win' | 'tie' | 'missing';
-}
-
-export interface PromptAbTaskLevelSummary {
-  comparableTasks: number;
-  wins: number;
-  losses: number;
-  ties: number;
-  signTestNonTieTasks: number;
-  signTestPValue: number | null;
-  missingTaskIds: string[];
-  meanPassRateDelta: number | null;
-  medianPassRateDelta: number | null;
-  tasks: PromptAbTaskComparison[];
-}
-
-export interface PromptAbAttemptPairSummary {
-  pairs: number;
-  observedPairs: number;
-  wins: number;
-  losses: number;
-  ties: number;
-  missingPairIds: string[];
-  budgetDiscordantPairIds: string[];
-  infraOrPlumbingDiscordantPairIds: string[];
-}
+export type PromptAbArmSummary = AbArmSummary;
+export type PromptAbTaskArmSummary = AbTaskArmSummary;
+export type PromptAbTaskComparison = AbTaskComparison;
+export type PromptAbTaskLevelSummary = AbTaskLevelSummary;
+export type PromptAbAttemptPairSummary = AbAttemptPairSummary;
 
 export interface PromptAbComparisonSummary extends AbComparisonSummary {
   baselinePromptId: string;

--- a/packages/headless/src/runtime-policy-ab-lifecycle.ts
+++ b/packages/headless/src/runtime-policy-ab-lifecycle.ts
@@ -1,7 +1,16 @@
 import { readFile, rename, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { withAbRunLock } from './ab-run-lock.js';
+import { buildAbRoundId } from './ab-run.js';
+import { summarizeAbComparison } from './ab-summary.js';
 import {
+  hashSystemPrompt,
+  readFixedPromptWal,
+  selectFixedPromptRoundTaskEvents,
+  type FixedPromptTaskWalEvent,
+} from './fixed-prompt-controller.js';
+import {
+  runtimePolicyArmResumeFingerprint,
   runRuntimePolicyAbComparisonUnlocked,
   type RunRuntimePolicyAbComparisonInput,
   type RuntimePolicyAbComparisonSummary,
@@ -15,12 +24,21 @@ export interface RunRuntimePolicyAbLifecycleInput extends Omit<RunRuntimePolicyA
 }
 
 export interface RuntimePolicyAbLifecycleState {
-  schemaVersion: 'maka.runtime_policy_ab.lifecycle.v1';
+  schemaVersion: 'maka.runtime_policy_ab.lifecycle.v2';
   manifestFingerprint: string;
   status: 'pilot_pending' | 'pilot_not_cleared' | 'pilot_cleared' | 'full_completed' | 'invalid';
   reason?: string;
   pilot?: RuntimePolicyAbComparisonSummary;
   full?: RuntimePolicyAbComparisonSummary;
+}
+
+interface LegacyRuntimePolicyAbLifecycleState {
+  schemaVersion: 'maka.runtime_policy_ab.lifecycle.v1';
+  manifestFingerprint: string;
+  status: RuntimePolicyAbLifecycleState['status'];
+  reason?: string;
+  pilot?: Pick<RuntimePolicyAbComparisonSummary, 'stopReason'>;
+  full?: Pick<RuntimePolicyAbComparisonSummary, 'stopReason'>;
 }
 
 export async function runRuntimePolicyAbLifecycle(
@@ -29,6 +47,10 @@ export async function runRuntimePolicyAbLifecycle(
   return withAbRunLock(input.runRoot, async () => {
     const statePath = join(input.runRoot, 'runtime-policy-ab-state.json');
     let state = await readState(statePath, input.manifestFingerprint);
+    if (state.schemaVersion === 'maka.runtime_policy_ab.lifecycle.v1') {
+      state = await rebuildLegacyState(input, state);
+      await writeState(statePath, state);
+    }
     if (state.status === 'full_completed' || state.status === 'invalid' || state.status === 'pilot_not_cleared') return state;
 
     if (state.status === 'pilot_pending') {
@@ -41,7 +63,7 @@ export async function runRuntimePolicyAbLifecycle(
       const pilot: RuntimePolicyAbComparisonSummary = pilotResult;
       const clearanceFailure = pilotClearanceFailure(pilot);
       state = {
-        schemaVersion: 'maka.runtime_policy_ab.lifecycle.v1',
+        schemaVersion: 'maka.runtime_policy_ab.lifecycle.v2',
         manifestFingerprint: input.manifestFingerprint,
         status: clearanceFailure ? 'pilot_not_cleared' : 'pilot_cleared',
         ...(clearanceFailure ? { reason: clearanceFailure } : {}),
@@ -91,20 +113,115 @@ function pilotClearanceFailure(summary: RuntimePolicyAbComparisonSummary): strin
   return undefined;
 }
 
-async function readState(path: string, manifestFingerprint: string): Promise<RuntimePolicyAbLifecycleState> {
+async function readState(
+  path: string,
+  manifestFingerprint: string,
+): Promise<RuntimePolicyAbLifecycleState | LegacyRuntimePolicyAbLifecycleState> {
   try {
-    const state = JSON.parse(await readFile(path, 'utf8')) as RuntimePolicyAbLifecycleState;
-    if (state.schemaVersion !== 'maka.runtime_policy_ab.lifecycle.v1') throw new Error('unsupported runtime policy A/B lifecycle state');
+    const state = JSON.parse(await readFile(path, 'utf8')) as RuntimePolicyAbLifecycleState | LegacyRuntimePolicyAbLifecycleState;
+    if (
+      state.schemaVersion !== 'maka.runtime_policy_ab.lifecycle.v1'
+      && state.schemaVersion !== 'maka.runtime_policy_ab.lifecycle.v2'
+    ) throw new Error('unsupported runtime policy A/B lifecycle state');
     if (state.manifestFingerprint !== manifestFingerprint) throw new Error('runtime policy A/B lifecycle state does not match manifest');
     return state;
   } catch (error) {
     if (!isNotFound(error)) throw error;
     return {
-      schemaVersion: 'maka.runtime_policy_ab.lifecycle.v1',
+      schemaVersion: 'maka.runtime_policy_ab.lifecycle.v2',
       manifestFingerprint,
       status: 'pilot_pending',
     };
   }
+}
+
+async function rebuildLegacyState(
+  input: RunRuntimePolicyAbLifecycleInput,
+  legacy: LegacyRuntimePolicyAbLifecycleState,
+): Promise<RuntimePolicyAbLifecycleState> {
+  const events = (await readFixedPromptWal(input.resultsJsonlPath)).filter(
+    (event): event is FixedPromptTaskWalEvent =>
+      event.type === 'task_completed'
+      || event.type === 'task_budget_exhausted'
+      || event.type === 'task_infra_failed'
+      || event.type === 'task_plumbing_failed',
+  );
+  const expectedPromptHash = hashSystemPrompt(await readFile(input.systemPromptPath, 'utf8'));
+  const pilot = legacy.pilot
+    ? summarizeRecordedRound(input, events, expectedPromptHash, 'pilot', input.pilotTasks, 1, legacy.pilot.stopReason)
+    : undefined;
+  const full = legacy.full
+    ? summarizeRecordedRound(input, events, expectedPromptHash, 'full', input.evaluationTasks, input.fullReps, legacy.full.stopReason)
+    : undefined;
+  if (full) {
+    const invalidReason = full.stopReason ?? (full.decision === 'invalid' ? full.reason : undefined);
+    return {
+      schemaVersion: 'maka.runtime_policy_ab.lifecycle.v2',
+      manifestFingerprint: input.manifestFingerprint,
+      status: invalidReason ? 'invalid' : 'full_completed',
+      ...(invalidReason ? { reason: invalidReason } : {}),
+      ...(pilot ? { pilot } : {}),
+      full,
+    };
+  }
+  if (pilot) {
+    const reason = pilotClearanceFailure(pilot);
+    return {
+      schemaVersion: 'maka.runtime_policy_ab.lifecycle.v2',
+      manifestFingerprint: input.manifestFingerprint,
+      status: reason ? 'pilot_not_cleared' : 'pilot_cleared',
+      ...(reason ? { reason } : {}),
+      pilot,
+    };
+  }
+  return {
+    schemaVersion: 'maka.runtime_policy_ab.lifecycle.v2',
+    manifestFingerprint: input.manifestFingerprint,
+    status: 'pilot_pending',
+  };
+}
+
+function summarizeRecordedRound(
+  input: RunRuntimePolicyAbLifecycleInput,
+  events: readonly FixedPromptTaskWalEvent[],
+  expectedPromptHash: string,
+  prefix: 'pilot' | 'full',
+  tasks: RunRuntimePolicyAbComparisonInput['evaluationTasks'],
+  reps: number,
+  stopReason: RuntimePolicyAbComparisonSummary['stopReason'],
+): RuntimePolicyAbComparisonSummary {
+  const runsFor = (arm: RunRuntimePolicyAbComparisonInput['arms'][number]): FixedPromptTaskWalEvent[][] => {
+    const resumeFingerprint = runtimePolicyArmResumeFingerprint(input, arm);
+    const runs = Array.from({ length: reps }, (_, rep) => tasks.flatMap((task) => {
+      const roundId = buildAbRoundId(prefix, arm.id, rep, task.id);
+      const event = selectFixedPromptRoundTaskEvents(
+        events,
+        input.runId,
+        roundId,
+        expectedPromptHash,
+        resumeFingerprint,
+      ).get(task.id);
+      if (!event && !stopReason) throw new Error(`cannot rebuild runtime policy A/B state: missing WAL event for ${roundId}`);
+      if (event?.type === 'task_plumbing_failed' && event.errorClass === 'missing_execution_identity') {
+        throw new Error(`cannot rebuild runtime policy A/B state: legacy missing-identity event ${event.id} has no authoritative outcome`);
+      }
+      return event ? [event] : [];
+    }));
+    if (runs.every((run) => run.length === 0)) throw new Error(`cannot rebuild runtime policy A/B state: no WAL evidence for ${prefix} round`);
+    return runs;
+  };
+  const summary = summarizeAbComparison({
+    runId: input.runId,
+    roundId: 'ab-summary',
+    baselineArmId: input.arms[0].id,
+    candidateArmId: input.arms[1].id,
+    evaluationTaskIds: tasks.map((task) => task.id),
+    baselineRuns: runsFor(input.arms[0]),
+    candidateRuns: runsFor(input.arms[1]),
+    ...(input.budgetMs !== undefined ? { budgetMs: input.budgetMs } : {}),
+    ...(input.nonInferiorityMargin !== undefined ? { nonInferiorityMargin: input.nonInferiorityMargin } : {}),
+  });
+  return stopReason ? { ...summary, stopReason } : summary;
 }
 
 async function writeState(path: string, state: RuntimePolicyAbLifecycleState): Promise<void> {

--- a/packages/headless/src/runtime-policy-ab-run.ts
+++ b/packages/headless/src/runtime-policy-ab-run.ts
@@ -102,7 +102,6 @@ export async function runRuntimePolicyAbComparisonUnlocked(
 ): Promise<RuntimePolicyAbComparisonSummary> {
   assertProfileIdentity(input.executionProfile, input.config);
   const maxConcurrency = pairConcurrency(input.executionProfile.maxConcurrentAttempts);
-  const sharedConfigFingerprint = runtimePolicySharedConfigFingerprint(input.config);
   const sharedAgentEnv = sanitizeSharedAgentEnv(input.sharedAgentEnv ?? {});
   return runAbComparison({
     runId: input.runId,
@@ -118,12 +117,7 @@ export async function runRuntimePolicyAbComparisonUnlocked(
       const runtimeArm = input.arms.find((candidate) => candidate.id === arm.id);
       if (!runtimeArm) throw new Error(`runtime policy A/B arm ${arm.id} is not configured`);
       const contextEnv = sanitizeContextEnv(runtimeArm.contextEnv);
-      const resumeFingerprint = runtimePolicyResumeFingerprint({
-        sharedConfigFingerprint,
-        sharedAgentEnvFingerprint: sharedAgentEnvFingerprint(sharedAgentEnv),
-        armContextEnvFingerprint: contextEnvFingerprint(contextEnv),
-        callerResumeFingerprint: input.resumeFingerprint,
-      });
+      const resumeFingerprint = runtimePolicyArmResumeFingerprint(input, runtimeArm);
       const agentEnv = { ...sharedAgentEnv, ...contextEnv };
       const result = await runFixedPromptController({
         runId: input.runId,
@@ -225,6 +219,18 @@ function runtimePolicyResumeFingerprint(input: {
     armContextEnvFingerprint: input.armContextEnvFingerprint,
     callerResumeFingerprint: input.callerResumeFingerprint,
   })).digest('hex')}`;
+}
+
+export function runtimePolicyArmResumeFingerprint(
+  input: Pick<RunRuntimePolicyAbComparisonInput, 'config' | 'sharedAgentEnv' | 'resumeFingerprint'>,
+  arm: RuntimePolicyAbArmInput,
+): string {
+  return runtimePolicyResumeFingerprint({
+    sharedConfigFingerprint: runtimePolicySharedConfigFingerprint(input.config),
+    sharedAgentEnvFingerprint: sharedAgentEnvFingerprint(sanitizeSharedAgentEnv(input.sharedAgentEnv ?? {})),
+    armContextEnvFingerprint: contextEnvFingerprint(sanitizeContextEnv(arm.contextEnv)),
+    callerResumeFingerprint: input.resumeFingerprint,
+  });
 }
 
 function canonicalJson(value: unknown): string {


### PR DESCRIPTION
## Summary

- count observed timeouts and step-cap outcomes as task failures without conflating them with missing data
- separate evaluated outcomes, infrastructure exclusions, attestation warnings, and hard plumbing failures
- make pair-level inference use evaluated pairs while preserving actual observed and missing counts
- update runtime A/B reports and pilot behavior to reflect the same taxonomy

## Why

The A/B summary used `eligible` for two different questions: whether a task produced an outcome and whether its execution identity was fully attested. This excluded real timeout and legacy step-cap failures from pass-rate denominators and reported fully observed task pairs as missing.

## Scope

Changed:

- A/B arm, task, active-subset, and pair classification
- missing execution identity handling for timeout outcomes
- provider and unscored infrastructure exclusions
- explicit identity mismatch fail-closed behavior
- runtime A/B Markdown reporting
- pilot lifecycle behavior for unattested timeout warnings
- regression coverage for current and legacy WAL shapes

Not included:

- WAL schema changes
- benchmark reruns
- provider-side proof of physical upstream model routing
- changes to product runtime behavior

## Verification

- `npm run -w @maka/headless test` — 798 passed, 1 conditional skip
- `npm run typecheck`
- replayed the completed 81-task stale-prune WAL through the updated summary:
  - both arms observed 81/81 outcomes
  - no missing tasks or pairs
  - 80 evaluated pairs, one infrastructure exclusion
  - 19 missing-identity timeouts retained as failures with attestation warnings

## User-facing impact

Runtime A/B reports now distinguish run completeness, outcome pass rate, infrastructure exclusions, attestation warnings, and plumbing failures. No migration or changelog entry is required.

## Reviewer notes

Please focus on the boundary between outcome classification and evidence quality:

- timeout without execution identity is a budget failure plus warning
- explicit identity mismatch remains a hard plumbing failure
- provider/network failures are excluded and governed by the existing effective-coverage gate
- `missing` now means no WAL event exists
