### PR TITLE
docs: add backend architecture index

### DIFF
--- a/ARCHITECTURE.en.md
+++ b/ARCHITECTURE.en.md
@@ -1,0 +1,115 @@
+[中文](./ARCHITECTURE.md)
+
+# Maka Backend Architecture
+
+> This is the entry point for Maka Agent backend architecture. It does not repeat each deep-dive article. It establishes the system spine and helps readers reach the right chapter by engineering question. The current series covers Runtime, tools and context, durable Headless tasks, Self-check, and the AHE self-iteration boundary.
+
+## Architecture in one sentence
+
+Maka is a **log-first, projection-driven** Agent Runtime. Execution facts enter append-only logs; Session state, model context, TaskRun, Self-check, and evolution evidence are projections of those facts for different consumers.
+
+```mermaid
+flowchart LR
+    U["Desktop / CLI / Bot / Gateway"] --> S["SessionManager"]
+    S --> R["AgentRun + Runtime Runner"]
+    R --> T["Tool Runtime"]
+    R --> L["Runtime Event Log"]
+    R --> H["Headless Task Event Log"]
+    T --> L
+
+    L --> C["Provider Context Projection"]
+    L --> V["Session / UI Read Models"]
+    L -. "trajectory refs" .-> H
+
+    H --> P["TaskRun Projection"]
+    P --> K["Bounded Self-check"]
+    P --> E["AHE Evidence Export"]
+    E --> A["External Evolution Loop"]
+```
+
+Read left to right. Entry points hand user intent to Runtime; model and tool execution produce facts; those facts are projected into model context, interactive views, durable task state, and evolution evidence. Providers, concrete storage implementations, and UI components are omitted so the diagram can preserve the backend spine shared by this series.
+
+## A three-layer mental model
+
+### 1. Execution facts
+
+An Agent Run produces model messages, Tool Calls, Tool Results, permission decisions, and termination facts. Runtime Event Log is the canonical source for those interaction semantics. Context pruning and Compaction may change what the model sees next, but cannot rewrite facts that already occurred.
+
+Relevant chapters: 1, 2, and 3.
+
+### 2. Durable tasks
+
+When a task outlives one Turn or process, Headless uses an independent task identity, Task Event Log, and TaskRun projection to preserve progress across Attempts. Self-check provides bounded feedback inside that task loop but does not own final fact authority.
+
+Relevant chapters: 4 and 5.
+
+### 3. Evolution
+
+AHE organizes outcomes and traces from multiple TaskRuns into evolution evidence bound to target identity. It remains outside the interactive Runtime and advances system changes through a constrained change surface, falsifiable manifests, candidate evaluation, and rollback lineage.
+
+Relevant chapter: 6.
+
+## Six-chapter index
+
+| Chapter | Core question | Implementation status | Read |
+|---|---|---|---|
+| 1. Log Is the Runtime | How does Maka preserve and replay the state space of an Agent Run? | Current | [English](./docs/architecture/runtime-core-architecture-draft.en.md) · [中文](./docs/architecture/runtime-core-architecture-draft.zh-CN.md) |
+| 2. Evidence Before Compression | How can a large Tool Result leave Turn-level evidence without exhausting active context? | Current + Target | [English](./docs/architecture/turn-evidence-tools-active-prune-draft.en.md) · [中文](./docs/architecture/turn-evidence-tools-active-prune-draft.zh-CN.md) |
+| 3. Compaction Is a Projection | How can the LLM forget old context without losing historical facts? | Current | [English](./docs/architecture/llm-compaction-events-log-projection-draft.en.md) · [中文](./docs/architecture/llm-compaction-events-log-projection-draft.zh-CN.md) |
+| 4. The Durable Task Loop | How does Maka continue a task that outlives a Turn, Run, or process? | Current + Target | [English](./docs/architecture/durable-task-loop-headless-draft.en.md) · [中文](./docs/architecture/durable-task-loop-headless-draft.zh-CN.md) |
+| 5. Self-Check Is Not Self-Trust | How can an Agent inspect and repair its work without turning self-report into authority? | Current + Target | [English](./docs/architecture/self-check-bounded-feedback-loop-draft.en.md) · [中文](./docs/architecture/self-check-bounded-feedback-loop-draft.zh-CN.md) |
+| 6. Self-Iteration Happens Outside the Runtime | How does Maka turn run experience into falsifiable and reversible system improvement? | Current + Target | [English](./docs/architecture/ahe-self-iteration-boundary-draft.en.md) · [中文](./docs/architecture/ahe-self-iteration-boundary-draft.zh-CN.md) |
+
+**Current + Target** means the article covers verified implementation and visibly labeled target direction. It does not mean Target sections are implemented. The `implementation_status` and `last_verified` fields in each article's front matter are the more precise status source.
+
+## Choose a reading path by problem
+
+### Entering Runtime for the first time
+
+Read `1 → 2 → 3`. Start with the fact log, then move to tool evidence and context projections.
+
+### Changing Tools, Context, or Compaction
+
+Read `1` for the canonical-fact boundary, then `2 → 3`. Add `4` if the change affects evidence consumed by durable tasks.
+
+### Changing Headless or task recovery
+
+Read `1 → 4 → 5`. Chapter 3 adds context recovery, while Chapter 2 adds the Tool Result evidence boundary.
+
+### Changing Self-check or completion conditions
+
+Read `4 → 5`, then revisit Chapter 2's rule that context pruning must not delete evidence.
+
+### Changing AHE or self-iteration
+
+Read `1 → 4 → 5 → 6`. Chapter 6 depends on the Event Log, TaskRun projection, and authority boundaries established earlier.
+
+## Code boundaries
+
+| Area | Primary responsibility |
+|---|---|
+| `packages/core` | Pure contracts for Session, Runtime Event, AgentRun, and permission |
+| `packages/storage` | File-backed stores for sessions, settings, and run ledgers |
+| `packages/runtime` | SessionManager, AgentRun, model adapters, tool execution, context, and recovery |
+| `packages/headless` | TaskRun, Autonomous Loop, Self-check, result export, and AHE protocol |
+| `apps/desktop/src/main` | Electron main-process composition, IPC, and product-entry adapters |
+
+The “code map” in each deep-dive article is the preferred implementation entry point. Earlier design and evolution material remains available in:
+
+- [`docs/runtime-kernel.md`](./docs/runtime-kernel.md)
+- [`docs/runtime-v2-architecture-evolution.md`](./docs/runtime-v2-architecture-evolution.md)
+- [`docs/runtime-v2-implementation-notes.md`](./docs/runtime-v2-implementation-notes.md)
+
+Those documents provide historical design context and implementation notes. The six chapters indexed here are the narrative entry point for current backend mechanisms.
+
+## Documentation layout
+
+`docs/architecture/` currently remains flat. One mechanism owns one stable slug with separate `.zh-CN.md` and `.en.md` counterparts. While the collection is still easy to scan, avoiding another `chapters/` level keeps links and counterpart paths shallow.
+
+Maintenance rules:
+
+- Every new deep dive needs a stable `doc_id`, implementation status, verification date, and owner;
+- Chinese and English counterparts must preserve scope, Current/Target boundaries, diagrams, and limitations;
+- This index stores one-sentence questions and links; mechanism details remain in the deep dives;
+- Adding, renaming, or publishing an article requires updating both architecture indexes;
+- The `-draft` filename suffix must agree with front matter `document_status`; publication should remove the suffix and update all index links in the same change.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,115 @@
+[ENGLISH](./ARCHITECTURE.en.md)
+
+# Maka Backend Architecture
+
+> 这是 Maka Agent 后端架构的总入口。它不重复每篇专题文章，而是先给出系统主线，再帮助读者按问题快速找到对应章节。当前系列聚焦 Runtime、工具与上下文、Headless 长程任务、Self-check 和 AHE 自迭代边界。
+
+## 一句话架构
+
+Maka 是一个 **log-first、projection-driven** 的 Agent Runtime：运行事实进入 append-only log；Session、模型上下文、TaskRun、Self-check 和演化证据都是这些事实面向不同消费者的投影。
+
+```mermaid
+flowchart LR
+    U["Desktop / CLI / Bot / Gateway"] --> S["SessionManager"]
+    S --> R["AgentRun + Runtime Runner"]
+    R --> T["Tool Runtime"]
+    R --> L["Runtime Event Log"]
+    R --> H["Headless Task Event Log"]
+    T --> L
+
+    L --> C["Provider Context Projection"]
+    L --> V["Session / UI Read Models"]
+    L -. "trajectory refs" .-> H
+
+    H --> P["TaskRun Projection"]
+    P --> K["Bounded Self-check"]
+    P --> E["AHE Evidence Export"]
+    E --> A["External Evolution Loop"]
+```
+
+从左向右读：入口把用户意图交给 Runtime；模型和工具执行产生事实；同一组事实随后被投影成模型上下文、交互界面、长程任务状态和演化证据。图中省略了 provider、具体存储实现和 UI 组件，只保留本系列文档共同解释的后端主线。
+
+## 三层心智模型
+
+### 1. 运行事实层
+
+一次 Agent Run 产生模型消息、Tool Call、Tool Result、权限和终止事实。Runtime Event Log 是这些交互语义的 canonical source。上下文裁剪与 Compaction 可以改变模型下一次看到什么，但不能反向改写已经发生的事实。
+
+对应章节：第一章、第二章、第三章。
+
+### 2. 长程任务层
+
+当任务长于一次 Turn 或一个进程时，Headless 通过独立的 Task identity、Task Event Log 和 TaskRun projection 保存跨 Attempt 的进度。Self-check 在这个任务循环内提供一次受限反馈，但不拥有最终事实 authority。
+
+对应章节：第四章、第五章。
+
+### 3. 演化层
+
+AHE 把多次 TaskRun 的结果和 trace 组织成带 target identity 的演化证据。它位于交互 Runtime 外部，通过受限 change surface、可证伪 manifest、candidate evaluation 和 rollback lineage 推进系统改进。
+
+对应章节：第六章。
+
+## 六章索引
+
+| 章节 | 核心问题 | 实现状态 | 阅读 |
+|---|---|---|---|
+| 1. Log Is the Runtime | Maka 如何保存并回放一次 Agent Run 的状态空间？ | Current | [中文](./docs/architecture/runtime-core-architecture-draft.zh-CN.md) · [English](./docs/architecture/runtime-core-architecture-draft.en.md) |
+| 2. Evidence Before Compression | 巨大的 Tool Result 如何留下 Turn 级证据，又不拖垮当前上下文？ | Current + Target | [中文](./docs/architecture/turn-evidence-tools-active-prune-draft.zh-CN.md) · [English](./docs/architecture/turn-evidence-tools-active-prune-draft.en.md) |
+| 3. Compaction Is a Projection | LLM 如何忘记旧上下文，同时不丢失历史事实？ | Current | [中文](./docs/architecture/llm-compaction-events-log-projection-draft.zh-CN.md) · [English](./docs/architecture/llm-compaction-events-log-projection-draft.en.md) |
+| 4. The Durable Task Loop | 一个任务长于 Turn、Run 和进程时，Maka 如何持续推进？ | Current + Target | [中文](./docs/architecture/durable-task-loop-headless-draft.zh-CN.md) · [English](./docs/architecture/durable-task-loop-headless-draft.en.md) |
+| 5. Self-Check Is Not Self-Trust | Agent 如何检查和修复自己的工作，而不把自述变成 authority？ | Current + Target | [中文](./docs/architecture/self-check-bounded-feedback-loop-draft.zh-CN.md) · [English](./docs/architecture/self-check-bounded-feedback-loop-draft.en.md) |
+| 6. Self-Iteration Happens Outside the Runtime | Maka 如何把运行经验变成可证伪、可回滚的系统改进？ | Current + Target | [中文](./docs/architecture/ahe-self-iteration-boundary-draft.zh-CN.md) · [English](./docs/architecture/ahe-self-iteration-boundary-draft.en.md) |
+
+这里的 **Current + Target** 表示文章同时记录已验证实现与明确标注的目标方向，不表示 Target 部分已经落地。每篇文章 front matter 中的 `implementation_status` 和 `last_verified` 是更细的状态来源。
+
+## 按问题选择阅读路径
+
+### 第一次进入 Runtime
+
+按 `1 → 2 → 3` 阅读。你会先理解事实日志，再理解工具证据和上下文投影。
+
+### 修改 Tool、Context 或 Compaction
+
+先读 `1` 建立 canonical fact 边界，再读 `2 → 3`。如果改动会影响长程任务的证据消费，再补 `4`。
+
+### 修改 Headless 或任务恢复
+
+按 `1 → 4 → 5` 阅读。第四章解释 durability，第三章可以补充上下文恢复，第二章可以补充 Tool Result 的证据边界。
+
+### 修改 Self-check 或完成条件
+
+按 `4 → 5` 阅读，再回看 `2` 中“证据不能被上下文裁剪删除”的原则。
+
+### 修改 AHE 或自迭代流程
+
+按 `1 → 4 → 5 → 6` 阅读。第六章依赖前面建立的 Event Log、TaskRun projection 和 authority 边界。
+
+## 代码边界
+
+| 区域 | 主要职责 |
+|---|---|
+| `packages/core` | Session、Runtime Event、AgentRun、permission 等纯 contract |
+| `packages/storage` | Session、settings、run ledger 等 file-backed store |
+| `packages/runtime` | SessionManager、AgentRun、模型适配、工具执行、上下文与恢复 |
+| `packages/headless` | TaskRun、Autonomous Loop、Self-check、结果导出与 AHE protocol |
+| `apps/desktop/src/main` | Electron main-process composition、IPC 与产品入口适配 |
+
+专题文章中的“代码地图”是定位实现的首选入口。更早的设计和演进材料仍保留在：
+
+- [`docs/runtime-kernel.md`](./docs/runtime-kernel.md)
+- [`docs/runtime-v2-architecture-evolution.md`](./docs/runtime-v2-architecture-evolution.md)
+- [`docs/runtime-v2-implementation-notes.md`](./docs/runtime-v2-implementation-notes.md)
+
+这些文档提供历史设计背景和实现笔记；本页索引的六章是当前后端机制的叙事入口。
+
+## 文档目录约定
+
+`docs/architecture/` 当前保持扁平结构：一项机制对应一个稳定 slug，并分别提供 `.zh-CN.md` 与 `.en.md`。在专题数量仍可快速浏览时，不增加 `chapters/` 层级，避免链接和 counterpart 路径无谓变深。
+
+维护规则：
+
+- 新专题必须有稳定 `doc_id`、实现状态、验证日期和 owner；
+- 中英文 counterpart 必须保持 scope、Current/Target 边界、图表和限制一致；
+- 本页只保存一句话问题和入口，机制细节留在专题文章中；
+- 新增、重命名或发布专题时，同时更新中英文总索引；
+- 文件名中的 `-draft` 与 front matter 的 `document_status` 一致；正式发布时应在同一次变更中移除该后缀并修正所有索引链接。

--- a/README.en.md
+++ b/README.en.md
@@ -199,6 +199,8 @@ Key principles:
 
 See also:
 
+- [`ARCHITECTURE.en.md`](./ARCHITECTURE.en.md): backend architecture overview,
+  six-chapter index, and problem-oriented reading paths.
 - `docs/runtime-kernel.md`
 - `docs/runtime-v2-architecture-evolution.md`
 - `docs/runtime-v2-implementation-notes.md`

--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ SessionManager
 
 更多细节见：
 
+- [`ARCHITECTURE.md`](./ARCHITECTURE.md)：后端架构总览、六章专题索引和按问题阅读路径。
 - `docs/runtime-kernel.md`
 - `docs/runtime-v2-architecture-evolution.md`
 - `docs/runtime-v2-implementation-notes.md`


### PR DESCRIPTION
## Summary

- add bilingual root-level backend architecture entry points
- organize the backend model into execution facts, durable tasks, and evolution layers
- index all six Chinese and English architecture chapters
- provide problem-oriented reading paths for Runtime, tools/context, Headless, Self-check, and AHE work
- document package boundaries and the flat `docs/architecture` maintenance convention
- link the new architecture entry point from both repository READMEs

## Verification

- confirmed every local Markdown link resolves
- confirmed Chinese and English heading and diagram parity
- passed staged whitespace and diff checks

## Core idea

Maka is a log-first, projection-driven Agent Runtime.