### PR TITLE
docs: rewrite project README

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -2,76 +2,152 @@
 
 # Maka
 
-Maka is a local-first desktop AI workspace. It brings model connections,
-sessions, tool permissions, file I/O, terminal execution, search, bot entry
-points, and run recovery into one Electron app, with the goal of letting users
-run an observable, controllable, recoverable agent on their own computer.
+[![CI](https://github.com/Maka-Agent/maka-agent/actions/workflows/ci.yml/badge.svg)](https://github.com/Maka-Agent/maka-agent/actions/workflows/ci.yml)
 
-This repository is under active development. The README currently serves two
-audiences:
+**A local-first Agent workspace built for real work.**
 
-- First-time Maka users: understand why AI setup comes first, where data lives,
-  and which capabilities are already available.
-- Engineers continuing Maka development: get the app running quickly, verify
-  changes, and find the key packages and design docs.
+Maka does more than answer questions. With controlled permissions, it can inspect projects, execute tools, produce artifacts, and preserve model messages, tool calls, and durable-task progress as recoverable execution facts. The same Runtime is available through the desktop app, terminal TUI, non-interactive CLI, and Headless runner.
 
-## What You Will See
+![Maka desktop artifact workflow](./apps/desktop/tests/screenshots-baseline/artifact-pane/dark-1280-motion.png)
 
-When you enter Maka for the first time, if there is no usable model connection,
-the first screen guides you through AI setup instead of showing an empty chat
-box that cannot send. The recommended path is:
+> [!IMPORTANT]
+> Maka is under active development and currently targets users running from source or contributing to the project. Data formats, CLI commands, and experimental capabilities may still change.
 
-1. Open `Settings -> Models`.
-2. Choose a real model provider and enter an API key or complete login for a
-   supported account flow.
-3. Test the connection and select a default model.
-4. Return to the home screen and start your first conversation from the quick
-   input.
+## Why Maka
 
-Currently supported model connection types include:
+- **Local-first instead of hosted-first**: sessions, settings, and run records stay on your machine by default. You choose the model connection: cloud API, local model, or compatible gateway.
+- **Log is the Runtime**: model messages, Tool Calls, Tool Results, and termination facts enter Runtime Event Log. Sessions, UI, model context, and recovery are projections over that log.
+- **Context is not history**: Tool Result pruning and LLM Compaction change what the next inference sees without treating recorded evidence as disposable context.
+- **A task may outlive a Turn**: Headless uses TaskRun, Task Event Log, budgets, and continuation to advance interruptible and inspectable durable work.
+- **Feedback is not fact authority**: Self-check may produce evidence and one bounded repair opportunity, but “I checked it” does not become a system fact.
 
-- Global APIs: Anthropic, OpenAI, Google Gemini.
-- China APIs: DeepSeek, Moonshot, Z.AI Coding Plan, Kimi Coding Plan.
-- Local models: Ollama.
-- Custom gateways: OpenAI-compatible endpoints.
-- Account subscription entries: Claude Subscription, Codex Subscription,
-  Gemini CLI, and others are shown separately according to their experimental
-  or available status. Entries that are not wired into the send path are not
-  presented as usable.
+Read [Maka Backend Architecture](./ARCHITECTURE.en.md) for the complete design.
 
-## Current Capabilities
+## Surfaces
 
-Maka is not just a chat demo. It already includes these core surfaces:
+| Entry point | Best for | Current capability |
+|---|---|---|
+| **Desktop** | Daily interaction, file and Artifact workflows, model and permission setup | Electron + React with streaming sessions, tool timelines, branching, search, and recovery |
+| **TUI / CLI** | Using Maka in the current project directory or running one non-interactive Turn | `maka`, `maka run`; shares workspace and model connections with Desktop |
+| **Headless** | Durable tasks, recoverable TaskRuns, experiments, and evaluation | `maka eval` / `maka-headless` with task logs, export, resume, and comparison |
 
-- **Desktop sessions**: create, switch, archive, search, rename, stop, retry,
-  regenerate, and branch from a turn.
-- **Model runtime**: a provider runtime based on the Vercel AI SDK, supporting
-  streaming model output, tool calls, usage accounting, error classification,
-  and startup recovery.
-- **Local tools**: `Read`, `Write`, `Edit`, `Bash`, `Glob`, `Grep`. File writes
-  and command execution go through the permission policy.
-- **First-run guidance**: different states for "finish setup / choose default
-  connection / choose default model / start chatting" based on the real
-  connection state.
-- **Settings center**: models, accounts, usage stats, daily review, local
-  memory, voice models, open gateway, bot conversations, web search, network
-  proxy, permissions and capabilities, health, data, and about.
-- **Local memory**: `MEMORY.md` management, manual add, archive/restore, and
-  an agent read toggle.
-- **Web search**: Tavily credential setup, connection testing, and agent tool
-  boundaries.
-- **Bot entry points**: configuration, testing, and run-status framework for
-  Telegram, Feishu, WeCom, WeChat iLink, Discord, DingTalk, and QQ.
-- **Open gateway**: local HTTP/SSE APIs, protected by tokens, for external
-  access to session state, events, capabilities, and health summaries.
-- **Office document workflow**: enabled after local `officecli` detection for
-  read, validation, and per-action authorized edits.
-- **Runtime kernel**: `AgentRun` ledger, `RuntimeEvent` read model,
-  `ToolRuntime`, `ModelAdapter`, `RunTrace`, and recovery logic.
+## Current capabilities
 
-## Local Storage And Privacy Boundary
+### Agent Runtime
 
-By default, Maka stores workspace data under Electron `userData`:
+- Multiple model connections, streaming output, thinking, usage accounting, and provider-error normalization;
+- Local tools including `Read`, `Write`, `Edit`, `Bash`, `Glob`, and `Grep`;
+- Tool schema validation, dynamic availability, permission policy, watchdogs, abort, and error classification;
+- Runtime Event Log, AgentRun ledger, startup recovery, Turn Evidence, active Tool Result pruning, and history compaction.
+
+### Desktop workspace
+
+- Create, archive, search, rename, retry, regenerate, and branch sessions from a Turn;
+- Artifact lists and previews, workspace instructions, model settings, and permission settings;
+- Local memory, web search, an open HTTP/SSE gateway, bot entry points, and Office workflows;
+- Integrations are configured independently, and not every experimental entry is available by default.
+
+### Durable tasks and evolution
+
+- Append-only Task Event Log and TaskRun projection;
+- Budgets, permission pauses, continuation, result export, and failed-task retry;
+- Plan-first, source-guarded, and attempt-bounded Heavy-task Self-check;
+- AHE target protocol and evidence export; complete automatic self-iteration remains an external or experimental workflow.
+
+## Quick start
+
+### Requirements
+
+- Node.js 22 (the current CI baseline);
+- npm (the lockfile and scripts use npm; the current `packageManager` is npm 11);
+- Git;
+- `ripgrep`, used by Runtime's `Grep` tool.
+
+### Start Desktop
+
+```sh
+git clone https://github.com/Maka-Agent/maka-agent.git
+cd maka-agent
+npm ci
+npm run dev
+```
+
+`npm run dev` starts the Desktop development environment with HMR. To build every workspace before starting Electron, use:
+
+```sh
+npm run dev:full
+```
+
+If dependencies were installed with `ELECTRON_SKIP_BINARY_DOWNLOAD=1`, install the Electron platform binary before starting:
+
+```sh
+node node_modules/electron/install.js
+```
+
+### First run
+
+Maka does not bundle a shared model account. On first launch:
+
+1. Open `Settings → Models`;
+2. Add an API, local-model, or supported account connection;
+3. Test it and choose a default model;
+4. Return to the workspace and start a task.
+
+The app distinguishes configured, send-ready, and experimental connection states. An account flow that is not wired into Runtime is not presented as a usable model.
+
+## Terminal entry points
+
+Build the workspaces first:
+
+```sh
+npm run build
+```
+
+Then start the TUI or run one Turn:
+
+```sh
+npm --workspace maka-agent exec -- maka
+npm --workspace maka-agent exec -- maka run "Summarize this repository and identify its most important risk"
+npm --workspace maka-agent exec -- maka --help
+```
+
+The CLI reads the same model connections and workspace configuration written by Desktop. See [`packages/headless/README.md`](./packages/headless/README.md) for Headless commands and its trust posture.
+
+## Architecture
+
+The backend spine is:
+
+```text
+Desktop / TUI / Headless
+          ↓
+SessionManager → AgentRun → Model + Tool Runtime
+          ↓
+Runtime Event Log → Context / Session / UI projections
+          ↓
+Task Event Log → TaskRun → Self-check / AHE evidence
+```
+
+Start with [ARCHITECTURE.en.md](./ARCHITECTURE.en.md). It provides the system map, code boundaries, problem-oriented reading paths, and six bilingual deep dives.
+
+## Repository layout
+
+```text
+apps/desktop/       Electron main / preload / React renderer
+
+packages/core/      Pure contracts for Sessions, Events, Permissions, and Connections
+packages/storage/   File-backed stores and run ledgers
+packages/runtime/   AgentRun, model adapters, tools, context, and recovery
+packages/headless/  TaskRun, Autonomous Loop, Self-check, eval, and AHE
+packages/cli/       TUI and non-interactive CLI
+packages/ui/        Shared conversation, Markdown, Artifact, and UI primitives
+
+docs/               Architecture, product, security, privacy, and test contracts
+scripts/            Build hygiene, visual checks, smoke tests, and release helpers
+```
+
+## Local data and security boundary
+
+Maka stores workspace data under Electron `userData` by default:
 
 ```text
 <Electron userData>/workspaces/default/
@@ -81,178 +157,52 @@ By default, Maka stores workspace data under Electron `userData`:
   sessions/
 ```
 
-Important boundaries:
+Current boundaries that matter:
 
-- Provider connection metadata and session JSONL stay in the local filesystem.
-- Runtime credentials such as provider API keys, bot tokens, proxy passwords,
-  gateway tokens, and Tavily keys are written to local `credentials.json`. The
-  current format is file-first plaintext JSON behind the OS account boundary,
-  with POSIX directory mode `0700` and file mode `0600` enforced.
-- Subscription OAuth tokens for Claude, Codex, Cursor, Antigravity, and similar
-  account services use their own Electron `safeStorage` token stores. Those
-  stores fail closed when `safeStorage` is unavailable.
-- The renderer does not receive plaintext secrets. Settings surfaces only show
-  masked status and test results.
-- File I/O, shell access, and dangerous operations go through the permission
-  engine.
-- Incognito/privacy context, memory, voice, and workspace instructions are
-  constrained by their own contract docs.
+- Sessions and connection metadata live in the local filesystem;
+- Runtime credentials such as API keys, bot tokens, and proxy passwords currently live in local plaintext `credentials.json`, behind the OS account boundary, with POSIX directory mode `0700` and file mode `0600` enforced;
+- Supported subscription OAuth tokens use Electron `safeStorage` and fail closed when it is unavailable;
+- Renderer does not receive plaintext credentials. File writes, Shell, and dangerous tool calls pass through the permission engine;
+- Headless real-model evaluation fails closed by default and requires an explicit external isolation boundary.
 
-## Quick Start
+Read [SECURITY.md](./SECURITY.md) for security reporting and policy. Detailed privacy and threat-model documents live under `docs/`.
 
-The repository uses npm workspaces. Although `pnpm-workspace.yaml` exists, the
-current scripts and lockfile are based on npm.
+## Development and verification
 
-```sh
-npm install
-npm run dev
-```
-
-`npm run dev` first builds all workspaces, then starts the Electron desktop
-app.
-
-If you set `ELECTRON_SKIP_BINARY_DOWNLOAD=1` while installing dependencies,
-install the Electron platform binary before starting:
-
-```sh
-node node_modules/electron/install.js
-```
-
-Common development commands:
+Common repository-level commands:
 
 ```sh
 npm run build
 npm run typecheck
-npm --workspace @maka/desktop run test
-npm --workspace @maka/runtime run test
-npm --workspace @maka/core run test
+npm test
+npm run check:release
 ```
 
-Desktop visual and real-window verification:
+Run one workspace in isolation:
 
 ```sh
+npm --workspace @maka/runtime test
+npm --workspace @maka/headless test
+npm --workspace @maka/desktop test
+```
+
+Desktop real-window and visual verification:
+
+```sh
+npm --workspace @maka/desktop run e2e
 npm --workspace @maka/desktop run screenshots
 npm --workspace @maka/desktop run screenshots:diff:stable
 npm --workspace @maka/desktop run smoke:real-window
 ```
 
-Basic checks before release:
+Before submitting code, run typecheck, build, and focused tests proportionate to the change, followed by `git diff --check`.
 
-```sh
-npm run check:release
-```
+## Documentation
 
-## Optional Environment Variables
-
-These variables only affect local development or specific capabilities:
-
-| Variable | Purpose |
-| --- | --- |
-| `ANTHROPIC_API_KEY` | Bootstrap an Anthropic connection on first launch. |
-| `OPENAI_API_KEY` | Bootstrap an OpenAI connection on first launch. |
-| `TAVILY_API_KEY` / `MAKA_TAVILY_API_KEY` | Sources for Tavily web search credentials. |
-| `MAKA_RIVE_BIN` / `RIVE_BIN` | Specify the `rive` CLI used by the Rive workflow. |
-| `MAKA_VISUAL_SMOKE_FIXTURE` | Enable deterministic visual fixtures, only for dev/test builds. |
-
-## Project Structure
-
-```text
-apps/desktop/
-  src/main/        Electron main process, IPC, settings, OAuth, bot, gateway
-  src/preload/     window.maka preload bridge
-  src/renderer/    React desktop UI and Settings surfaces
-
-packages/core/     Pure contracts: sessions, events, settings, permissions, model connections
-packages/storage/  File-backed session, settings, connection, run-ledger stores
-packages/runtime/  SessionManager, AgentRun, AI SDK runtime, tools, bots, telemetry
-packages/ui/       Shared rendering components, markdown, artifacts, redaction helpers
-
-docs/              Product, runtime, design-system, privacy and test-plan contracts
-scripts/           Build hygiene, screenshot, smoke and release helpers
-```
-
-## Runtime Architecture
-
-The runtime has already been broken down from a single large flow into clearer
-kernel boundaries:
-
-```text
-SessionManager
-  -> AgentRun
-      -> AiSdkBackend
-          -> ModelAdapter
-          -> ToolRuntime
-      -> RunTrace
-      -> AgentRunStore
-```
-
-Key principles:
-
-- `SessionManager` remains the public runtime API exposed to the desktop app,
-  bots, and gateway.
-- `AgentRun` owns the durable facts for a single turn and startup recovery.
-- `ToolRuntime` owns tool input validation, permissions, watchdogs, abort,
-  telemetry, artifact candidates, and error classification.
-- `ModelAdapter` isolates provider stream, error, and usage normalization.
-- `RunTrace` is best-effort and must not block user conversations if trace
-  writes fail.
-
-See also:
-
-- [`ARCHITECTURE.en.md`](./ARCHITECTURE.en.md): backend architecture overview,
-  six-chapter index, and problem-oriented reading paths.
-- `docs/runtime-kernel.md`
-- `docs/runtime-v2-architecture-evolution.md`
-- `docs/runtime-v2-implementation-notes.md`
-
-## UI And Product Quality Contracts
-
-Maka's UI is not assembled casually. It already has dedicated design-system and
-test-plan contracts:
-
-- `docs/design-system.md`: color, density, states, motion, Settings IA, copy,
-  and accessibility contracts.
-- `docs/ui-quality-plan.md`: real-window checks, visual screenshots,
-  interaction states, and regression verification strategy.
-- `docs/full-product-test-plan.md`: the full QA path from first run, settings,
-  sessions, tools, search, bots, and gateway to failure paths.
-
-When changing UI, do not stop at TypeScript checks. At minimum, add:
-
-1. A node:test contract for the affected surface.
-2. Passing `check-console` / `check-a11y`.
-3. A visual fixture or real-window smoke test when needed.
-
-## Checks Before Contributing
-
-For ordinary code changes, at minimum run:
-
-```sh
-npm run typecheck --workspaces --if-present
-npm run build
-git diff --check
-```
-
-For desktop renderer, Settings, or IPC changes, also run a focused suite such
-as:
-
-```sh
-npm --workspace @maka/desktop run test -- settings-form-a11y-contract visible-copy-hygiene-contract
-```
-
-For runtime or storage changes, also run the corresponding workspace tests:
-
-```sh
-npm --workspace @maka/runtime run test
-npm --workspace @maka/storage run test
-```
-
-## Related Documents
-
-- `CHANGELOG.md`: summary of unreleased changes.
-- `SECURITY.md`: security boundary and reporting process.
-- `docs/workspace-privacy-context.md`: workspace privacy context.
-- `docs/search-service-threat-model.md`: search service threat model.
-- `docs/memory-threat-model.md`: local memory threat model.
-- `docs/voice-threat-model.md`: voice capability boundary.
-- `docs/maka-capability-audit-v1.md`: capability maturity audit and follow-up roadmap.
+- [Backend architecture](./ARCHITECTURE.en.md)
+- [Headless usage and isolation](./packages/headless/README.md)
+- [Design system](./docs/design-system.md)
+- [Full product test plan](./docs/full-product-test-plan.md)
+- [Workspace privacy context](./docs/workspace-privacy-context.md)
+- [Capability maturity audit](./docs/maka-capability-audit-v1.md)
+- [Security policy](./SECURITY.md)

--- a/README.md
+++ b/README.md
@@ -1,50 +1,153 @@
- [ENGLISH](./README.en.md)
+[English](./README.en.md)
 
 # Maka
 
-Maka 是一个本地优先的桌面 AI 工作台。它把模型连接、会话、工具权限、文件读写、终端执行、搜索、机器人入口和运行恢复放在一个 Electron 应用里，目标是让用户在自己的电脑上跑一个可观察、可控、可持续恢复的 agent。
+[![CI](https://github.com/Maka-Agent/maka-agent/actions/workflows/ci.yml/badge.svg)](https://github.com/Maka-Agent/maka-agent/actions/workflows/ci.yml)
 
-这个仓库还在活跃开发中。README 先服务两类人：
+**一个为真实工作而生的本地优先 Agent 工作台。**
 
-- 第一次打开 Maka 的用户：知道为什么要先配置 AI、数据放在哪里、哪些能力已经可用。
-- 继续开发 Maka 的工程师：能快速启动、验证、定位关键包和设计文档。
+Maka 不只回答问题。它可以在受控权限下阅读项目、执行工具、生成产物，并把模型消息、工具调用和长程任务进度保存为可恢复的运行事实。你可以从桌面应用、终端 TUI、非交互 CLI 或 Headless runner 使用同一套 Runtime。
 
-## 你会看到什么
+![Maka desktop artifact workflow](./apps/desktop/tests/screenshots-baseline/artifact-pane/dark-1280-motion.png)
 
-首次进入 Maka 时，如果还没有可用模型连接，首屏会引导你完成 AI 配置，而不是直接给一个不能发送的空聊天框。推荐路径是：
+> [!IMPORTANT]
+> Maka 仍在活跃开发中，当前主要面向从源码运行和参与开发的用户。数据格式、CLI 和实验能力仍可能变化。
 
-1. 打开 `设置 -> 模型`。
-2. 选择一个真实模型供应商，填写 API key 或完成已接入的账号登录。
-3. 测试连接并选择默认模型。
-4. 回到首屏，用快速输入开始第一条对话。
+## 为什么是 Maka
 
-已接入的模型类型包括：
+- **本地优先，而不是云端托管优先**：会话、设置和运行记录默认保存在本机；模型连接由你配置，可以使用云 API、本地模型或兼容网关。
+- **Log is the Runtime**：模型消息、Tool Call、Tool Result 和终止事实进入 Runtime Event Log，Session、UI、模型上下文和恢复逻辑从日志生成投影。
+- **上下文不是历史本身**：Tool Result prune 和 LLM Compaction 只改变下一次推理看到什么，不把已记录的证据当作上下文垃圾删除。
+- **任务可以长于一个 Turn**：Headless 使用 TaskRun、Task Event Log、预算和 continuation 机制推进可中断、可检查的长程任务。
+- **反馈不等于事实 authority**：Self-check 可以产生证据和一次受限修复机会，但不能把“我检查过了”变成系统事实。
 
-- 海外 API：Anthropic、OpenAI、Google Gemini。
-- 国内 API：DeepSeek、Moonshot、Z.AI Coding Plan、Kimi Coding Plan。
-- 本地模型：Ollama。
-- 自定义网关：OpenAI Compatible endpoint。
-- 账号订阅入口：Claude Subscription、Codex Subscription、Gemini CLI 等仍按实验/可用状态分开呈现，未接入发送链路的入口不会伪装成可用。
+完整设计见 [Maka Backend Architecture](./ARCHITECTURE.md)。
+
+## 运行形态
+
+| 入口 | 适合什么 | 当前能力 |
+|---|---|---|
+| **Desktop** | 日常交互、文件与 Artifact 工作流、模型和权限配置 | Electron + React，支持流式会话、工具时间线、分支、搜索和恢复 |
+| **TUI / CLI** | 在当前工程目录中使用 Maka，或执行单次非交互 Turn | `maka`、`maka run`，复用 Desktop 的 workspace 和模型连接 |
+| **Headless** | 长程任务、可恢复 TaskRun、实验和评估 | `maka eval` / `maka-headless`，支持任务日志、导出、恢复和对比 |
 
 ## 当前能力
 
-Maka 当前不是简单 chat demo，已经有这些核心面：
+### Agent Runtime
 
-- **桌面会话**：创建、切换、归档、搜索、重命名、停止、重试、重新生成、从 turn 分支。
-- **模型运行时**：基于 Vercel AI SDK 的 provider runtime，支持模型流式输出、工具调用、usage 记录、错误分类和启动恢复。
-- **本地工具**：`Read`、`Write`、`Edit`、`Bash`、`Glob`、`Grep`，写文件和命令执行走权限策略。
-- **首跑引导**：根据真实连接状态展示“补配置 / 选默认连接 / 选默认模型 / 开始对话”的不同状态。
-- **设置中心**：模型、账号、使用统计、每日回顾、本地记忆、语音模型、开放网关、机器人对话、联网搜索、网络代理、权限与能力、健康状态、数据与关于。
-- **本地记忆**：`MEMORY.md` 管理、手动添加、归档/恢复、agent 读取开关。
-- **联网搜索**：Tavily 凭据配置、测试和 agent tool 边界。
-- **机器人入口**：Telegram、飞书、企业微信、微信 iLink、Discord、钉钉、QQ 的配置/测试/运行状态框架。
-- **开放网关**：本地 HTTP/SSE API，用 token 保护外部读取会话状态、事件、能力和健康摘要。
-- **Office 文档工作流**：通过本地 `officecli` 探测后启用读取、校验和按次授权编辑。
-- **运行内核**：`AgentRun` ledger、`RuntimeEvent` read model、`ToolRuntime`、`ModelAdapter`、`RunTrace` 和恢复逻辑。
+- 多模型连接、流式输出、thinking、usage 和 provider error normalization；
+- `Read`、`Write`、`Edit`、`Bash`、`Glob`、`Grep` 等本地工具；
+- Tool schema validation、动态 availability、permission policy、watchdog、abort 和错误分类；
+- Runtime Event Log、AgentRun ledger、启动恢复、Turn Evidence、active tool prune 与 history compaction。
 
-## 本地与隐私边界
+### Desktop Workspace
 
-Maka 默认把工作数据放在 Electron `userData` 下的工作区目录：
+- 会话创建、归档、搜索、重命名、重试、重新生成和从 Turn 分支；
+- Artifact 列表与预览、workspace instructions、模型与权限设置；
+- 本地记忆、联网搜索、开放 HTTP/SSE gateway、机器人入口和 Office 工作流；
+- 不同集成需要单独配置，并非所有实验入口默认可用。
+
+### Durable Tasks and Evolution
+
+- Append-only Task Event Log 与 TaskRun projection；
+- 预算、权限暂停、continuation、结果导出和失败任务重试；
+- 有计划、source-guarded、次数受限的 Heavy-task Self-check；
+- AHE target protocol 与 evidence export；完整自动自迭代仍属于外部/实验流程。
+
+## 快速开始
+
+### 环境要求
+
+- Node.js 22（当前 CI 基线）；
+- npm（仓库 lockfile 和 scripts 以 npm 为准，`packageManager` 当前为 npm 11）；
+- Git；
+- `ripgrep`，供 Runtime 的 `Grep` 工具使用。
+
+### 启动 Desktop
+
+```sh
+git clone https://github.com/Maka-Agent/maka-agent.git
+cd maka-agent
+npm ci
+npm run dev
+```
+
+`npm run dev` 启动带 HMR 的 Desktop 开发环境。需要先完整构建再启动 Electron 时使用：
+
+```sh
+npm run dev:full
+```
+
+如果安装时设置过 `ELECTRON_SKIP_BINARY_DOWNLOAD=1`，启动前需要补装 Electron 平台二进制：
+
+```sh
+node node_modules/electron/install.js
+```
+
+### 第一次运行
+
+Maka 不内置共享模型账号。第一次打开时：
+
+1. 进入 `设置 → 模型`；
+2. 添加一个 API、本地模型或已经接通的账号连接；
+3. 测试连接并选择默认模型；
+4. 返回工作台开始任务。
+
+应用会根据真实连接状态区分“已配置”“可发送”和“实验入口”，不会把没有接入 Runtime 的账号展示成可用模型。
+
+## 使用终端入口
+
+先构建 workspace：
+
+```sh
+npm run build
+```
+
+然后可以启动 TUI 或执行单次 Turn：
+
+```sh
+npm --workspace maka-agent exec -- maka
+npm --workspace maka-agent exec -- maka run "总结当前仓库并指出最重要的风险"
+npm --workspace maka-agent exec -- maka --help
+```
+
+CLI 读取 Desktop 写入的同一份模型连接和 workspace 配置。Headless 的完整命令与 trust posture 见 [`packages/headless/README.md`](./packages/headless/README.md)。
+
+## 架构
+
+Maka 后端可以用一条主线概括：
+
+```text
+Desktop / TUI / Headless
+          ↓
+SessionManager → AgentRun → Model + Tool Runtime
+          ↓
+Runtime Event Log → Context / Session / UI projections
+          ↓
+Task Event Log → TaskRun → Self-check / AHE evidence
+```
+
+从 [ARCHITECTURE.md](./ARCHITECTURE.md) 开始阅读。它提供总体架构图、代码边界、按问题组织的阅读路径，以及六篇中英双语深度文章。
+
+## 仓库结构
+
+```text
+apps/desktop/       Electron main / preload / React renderer
+
+packages/core/      Session、Event、Permission、Connection 等纯 contracts
+packages/storage/   File-backed stores 与 run ledgers
+packages/runtime/   AgentRun、模型适配、工具、上下文和恢复
+packages/headless/  TaskRun、Autonomous Loop、Self-check、eval 与 AHE
+packages/cli/       TUI 和非交互 CLI
+packages/ui/        共享对话、Markdown、Artifact 与 UI primitives
+
+docs/               架构、产品、安全、隐私和测试契约
+scripts/            Build hygiene、视觉检查、smoke 和 release helpers
+```
+
+## 本地数据与安全边界
+
+Maka 默认把 workspace 数据放在 Electron `userData` 下：
 
 ```text
 <Electron userData>/workspaces/default/
@@ -54,157 +157,52 @@ Maka 默认把工作数据放在 Electron `userData` 下的工作区目录：
   sessions/
 ```
 
-重要边界：
+需要明确的当前边界：
 
-- Provider 连接元数据和 session JSONL 在本地文件系统。
-- Provider/API key、bot token、proxy password、gateway token、Tavily key 等运行凭据写入本地 `credentials.json`；当前格式是 file-first plaintext JSON，依赖 OS 账号边界，并在 POSIX 上强制目录 `0700`、文件 `0600`。
-- Claude、Codex、Cursor、Antigravity 等 subscription OAuth token 使用各自独立的 Electron `safeStorage` 存储路径；`safeStorage` 不可用时这些 token store 会 fail closed。
-- Renderer 不直接拿明文密钥；Settings 只显示 masked 状态和测试结果。
-- 文件读写、shell、危险操作需要经过 permission engine。
-- Incognito / privacy context、memory、voice、workspace instructions 等能力有单独 contract 文档约束。
+- 会话和连接元数据保存在本地文件系统；
+- API key、bot token、proxy password 等运行凭据当前保存在本地 plaintext `credentials.json`，依赖 OS 账号边界，并在 POSIX 上强制目录 `0700`、文件 `0600`；
+- 已接通的 subscription OAuth token 使用 Electron `safeStorage`；不可用时 fail closed；
+- Renderer 不接收明文凭据；文件写入、Shell 和危险工具调用需要经过 permission engine；
+- Headless real-model eval 默认 fail closed，要求调用方显式提供外部隔离边界。
 
-## 快速开始
+安全问题请阅读 [SECURITY.md](./SECURITY.md)。更细的隐私与 threat model 位于 `docs/`。
 
-仓库使用 npm workspaces。虽然存在 `pnpm-workspace.yaml`，当前脚本和 lockfile 以 npm 为准。
+## 开发与验证
 
-```sh
-npm install
-npm run dev
-```
-
-`npm run dev` 会先 build 全部 workspace，再启动 Electron desktop app。
-
-如果安装依赖时设置过 `ELECTRON_SKIP_BINARY_DOWNLOAD=1`，启动前需要补 Electron 平台二进制：
-
-```sh
-node node_modules/electron/install.js
-```
-
-常用开发命令：
+常用仓库级命令：
 
 ```sh
 npm run build
 npm run typecheck
-npm --workspace @maka/desktop run test
-npm --workspace @maka/runtime run test
-npm --workspace @maka/core run test
+npm test
+npm run check:release
 ```
 
-桌面视觉和真实窗口验证：
+针对单个 workspace：
 
 ```sh
+npm --workspace @maka/runtime test
+npm --workspace @maka/headless test
+npm --workspace @maka/desktop test
+```
+
+Desktop 的真实窗口与视觉验证：
+
+```sh
+npm --workspace @maka/desktop run e2e
 npm --workspace @maka/desktop run screenshots
 npm --workspace @maka/desktop run screenshots:diff:stable
 npm --workspace @maka/desktop run smoke:real-window
 ```
 
-Release 前的基础检查：
+提交代码前至少运行与改动范围相称的 typecheck、build 和 focused tests，并执行 `git diff --check`。
 
-```sh
-npm run check:release
-```
+## 文档入口
 
-## 可选环境变量
-
-这些变量只影响本地开发或特定能力：
-
-| 变量 | 用途 |
-| --- | --- |
-| `ANTHROPIC_API_KEY` | 首次启动时可用来 bootstrap Anthropic 连接。 |
-| `OPENAI_API_KEY` | 首次启动时可用来 bootstrap OpenAI 连接。 |
-| `TAVILY_API_KEY` / `MAKA_TAVILY_API_KEY` | 联网搜索的 Tavily 凭据来源。 |
-| `MAKA_RIVE_BIN` / `RIVE_BIN` | 指定 Rive workflow 使用的 `rive` CLI。 |
-| `MAKA_VISUAL_SMOKE_FIXTURE` | 启用确定性视觉 fixture，仅限 dev/test build。 |
-
-## 项目结构
-
-```text
-apps/desktop/
-  src/main/        Electron main process, IPC, settings, OAuth, bot, gateway
-  src/preload/     window.maka preload bridge
-  src/renderer/    React desktop UI and Settings surfaces
-
-packages/core/     Pure contracts: sessions, events, settings, permissions, model connections
-packages/storage/  File-backed session, settings, connection, run-ledger stores
-packages/runtime/  SessionManager, AgentRun, AI SDK runtime, tools, bots, telemetry
-packages/ui/       Shared rendering components, markdown, artifacts, redaction helpers
-
-docs/              Product, runtime, design-system, privacy and test-plan contracts
-scripts/           Build hygiene, screenshot, smoke and release helpers
-```
-
-## Runtime 架构
-
-当前 runtime 已从单一大流程拆成更清楚的内核边界：
-
-```text
-SessionManager
-  -> AgentRun
-      -> AiSdkBackend
-          -> ModelAdapter
-          -> ToolRuntime
-      -> RunTrace
-      -> AgentRunStore
-```
-
-关键原则：
-
-- `SessionManager` 仍是对桌面、bot、gateway 暴露的公共 runtime API。
-- `AgentRun` 负责单次 turn 的 durable run 事实和启动恢复。
-- `ToolRuntime` 负责工具输入校验、权限、watchdog、abort、telemetry、artifact candidate 和错误分类。
-- `ModelAdapter` 隔离 provider stream / error / usage normalization。
-- `RunTrace` 是 best-effort，不允许因为 trace 写失败影响用户对话。
-
-更多细节见：
-
-- [`ARCHITECTURE.md`](./ARCHITECTURE.md)：后端架构总览、六章专题索引和按问题阅读路径。
-- `docs/runtime-kernel.md`
-- `docs/runtime-v2-architecture-evolution.md`
-- `docs/runtime-v2-implementation-notes.md`
-
-## UI 与产品质量契约
-
-Maka 的 UI 不是随手堆页面，已有单独的设计系统和测试计划：
-
-- `docs/design-system.md`：颜色、密度、状态、动效、Settings IA、copy 和 a11y 契约。
-- `docs/ui-quality-plan.md`：真实窗口、视觉截图、交互状态、回归验证策略。
-- `docs/full-product-test-plan.md`：从首跑、设置、会话、工具、搜索、bot、gateway 到失败路径的完整 QA 路线。
-
-改 UI 时不要只跑 TypeScript。至少要配套：
-
-1. 对应 surface 的 node:test contract。
-2. `check-console` / `check-a11y` 通过。
-3. 必要时补视觉 fixture 或真实窗口 smoke。
-
-## 贡献前检查
-
-常规代码改动建议至少跑：
-
-```sh
-npm run typecheck --workspaces --if-present
-npm run build
-git diff --check
-```
-
-涉及 desktop renderer / Settings / IPC 的改动，再跑对应 focused suite，例如：
-
-```sh
-npm --workspace @maka/desktop run test -- settings-form-a11y-contract visible-copy-hygiene-contract
-```
-
-涉及 runtime / storage 的改动，再跑对应 workspace 测试：
-
-```sh
-npm --workspace @maka/runtime run test
-npm --workspace @maka/storage run test
-```
-
-## 相关文档
-
-- `CHANGELOG.md`：当前未发布变更摘要。
-- `SECURITY.md`：安全边界和报告方式。
-- `docs/workspace-privacy-context.md`：工作区隐私上下文。
-- `docs/search-service-threat-model.md`：搜索服务威胁模型。
-- `docs/memory-threat-model.md`：本地记忆威胁模型。
-- `docs/voice-threat-model.md`：语音能力边界。
-- `docs/maka-capability-audit-v1.md`：能力成熟度审计和后续路线。
+- [后端架构总览](./ARCHITECTURE.md)
+- [Headless 使用与隔离边界](./packages/headless/README.md)
+- [设计系统](./docs/design-system.md)
+- [产品测试计划](./docs/full-product-test-plan.md)
+- [Workspace 隐私上下文](./docs/workspace-privacy-context.md)
+- [能力成熟度审计](./docs/maka-capability-audit-v1.md)
+- [安全政策](./SECURITY.md)


### PR DESCRIPTION
## Summary

- rewrite the Chinese and English READMEs around Maka as a local-first Agent workspace for real work
- present Desktop, TUI/CLI, and Headless as first-class surfaces over the same Runtime
- bring the README up to date with Event Log, context projection, durable TaskRun, bounded Self-check, and AHE evidence capabilities
- replace fragile provider and Settings inventories with stable capability and availability boundaries
- correct the current HMR, full-build, CLI, workspace, and verification commands
- add the current Desktop artifact workflow screenshot, CI badge, repository layout, architecture entry point, and explicit security posture

## Verification

- confirmed all local Markdown links resolve
- verified the documented Maka CLI help command against the current workspace binary
- confirmed Chinese and English heading and scope parity
- passed staged whitespace and diff checks

## Positioning

Maka is a local-first Agent workspace built for real work: observable execution, controlled side effects, durable tasks, and recoverable facts.