### PR TITLE
fix(ui): tokenize composer branch-picker min-height + cover it in the control-height contract

### DIFF
--- a/apps/desktop/src/main/__tests__/control-height-converge-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/control-height-converge-contract.test.ts
@@ -108,6 +108,7 @@ const CONTROL_HEIGHT: ControlHeightCheck[] = [
   // composer controls
   { selector: '.maka-composer-send-button', props: ['width', 'height'], token: '--h-control-lg' },
   { selector: '.maka-composer-workspace-picker', props: ['min-height'], token: '--h-control-sm' },
+  { selector: '.maka-composer-branch-picker', props: ['min-height'], token: '--h-control-sm' },
 ];
 
 /** Values that are always allowed (not a control-height beat). `100%`

--- a/apps/desktop/src/renderer/styles/composer.css
+++ b/apps/desktop/src/renderer/styles/composer.css
@@ -384,7 +384,7 @@
   -webkit-app-region: no-drag;
   appearance: none;
   min-width: 0;
-  min-height: 24px;
+  min-height: var(--h-control-sm);
   display: inline-flex;
   align-items: center;
   gap: var(--space-1);


### PR DESCRIPTION
## Summary

- Swap `.maka-composer-branch-picker` `min-height` from a bare `24px` to `var(--h-control-sm)`, matching the adjacent workspace-picker.
- Add `.maka-composer-branch-picker` to the `control-height-converge` contract's CONTROL_HEIGHT list so the existing owner contract guards both pickers.

## Why

The branch-picker carried a bare `min-height: 24px` while the adjacent workspace-picker used `var(--h-control-sm)` (both resolve to 24px). The bare literal is exactly the drift the `control-height-converge` contract exists to prevent — the branch-picker was simply missing from its CONTROL_HEIGHT list (the workspace-picker was already covered). Fix at the owner: swap the token and add the missing list entry, instead of a parallel guard. Found by the #546 Composer combined-state audit. Refs #546.

## Scope

- One CSS value (branch-picker `min-height`) + one contract list entry. No new contract file, no helper changes, no other surfaces.

## Verification

- `npm run -w @maka/desktop test` — 2346/2346 pass (the `control-height-converge` contract now covers both pickers).
- `npm run -w @maka/desktop typecheck` + `test:checks` (console/a11y/copy) — clean.
- CDP text-evidence on the live `model-processing` fixture (light-990 / dark-990 / light-990-reduced-motion): both pickers render `min-height: 24px`, content height 36px — the swap is a visual no-op. Per the repo's "style/cascade invariant: computed-style or text-contract" guidance, the `control-height-converge` contract is the locking layer; CDP computed-style is the substitute evidence.
- No screenshot: pixel-level appearance is unchanged (`24px` → token resolving to `24px`); the contract + CDP computed-style are the locking layers.

## Impact

None — visual no-op; no behavior, API, or migration change.

## Reviewer notes

- An earlier iteration added a separate 83-line per-selector contract (`composer-row-picker-size-contract`) duplicating helpers from `sidebar-indicator-size-contract`; a Codex review flagged that as over-engineered (the owner contract already existed) and proposed merging the two picker CSS rules. The merge broke two existing contracts (`control-height-converge` and `project-context-badge`) that assert `.maka-composer-workspace-picker {` as a standalone rule — the repo's established convention (per #743) is per-selector contracts guarding drift, not merging rules. Reassessment from first principles: the real root cause was the branch-picker missing from the owner contract's list, so the clean minimal fix is the one-line swap + one-line list entry.

## Ready for review

- [x] Verification is complete and the results above are current
- [x] Impact, compatibility, migration, documentation, and release-note needs are addressed (none)
- [x] User-visible UI/UX changes include visual evidence, or `Verification` explains why it is not applicable (visual no-op; substitute evidence above)