### PR TITLE
fix: converge chrome icon size and color across sidebar and titlebar

### DIFF
--- a/apps/desktop/src/main/__tests__/icon-system-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/icon-system-contract.test.ts
@@ -44,6 +44,28 @@ describe('icon system contract (single chrome size token)', () => {
     assert.match(navRow, /grid-template-columns:\s*var\(--icon-size\)/, 'nav-row glyph column tracks the token');
   });
 
+  it('keeps every .maka-nav-icon selector free of px sizes and color (PR-ICON-CHROME-CONSISTENCY)', async () => {
+    const styles = await readRendererContractCss();
+    // The gear once carried a qualified 18px + currentColor override
+    // (`.maka-sidebar-settings-button .maka-nav-icon`), and the base rule
+    // carried `color: var(--muted-foreground)` — unlayered CSS that
+    // silently beat the tone/active color utilities in
+    // session-sidebar-nav.tsx. Geometry belongs to the token; color
+    // belongs to the component variants via inheritance.
+    const rules = [...styles.matchAll(/(?:^|\n)([^{}\n]*\.maka-nav-icon[^{}\n]*)\{([^}]*)\}/g)];
+    assert.ok(rules.length > 0, 'the .maka-nav-icon base rule must exist');
+    for (const [, selector, body] of rules) {
+      assert.ok(
+        !/(?<!-)\b(width|height)\s*:\s*\d/.test(body),
+        `\`${selector.trim()}\` must not hardcode px sizes — route through --icon-size`,
+      );
+      assert.ok(
+        !/(?<!-)\bcolor\s*:/.test(body),
+        `\`${selector.trim()}\` must not declare color — glyphs inherit the row text color`,
+      );
+    }
+  });
+
   it('routes the shared button icon through the same token', async () => {
     const ui = await readFile(join(repoRoot, 'packages', 'ui', 'src', 'ui.tsx'), 'utf8');
     assert.match(

--- a/apps/desktop/src/main/__tests__/icon-system-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/icon-system-contract.test.ts
@@ -51,19 +51,56 @@ describe('icon system contract (single chrome size token)', () => {
     // carried `color: var(--muted-foreground)` — unlayered CSS that
     // silently beat the tone/active color utilities in
     // session-sidebar-nav.tsx. Geometry belongs to the token; color
-    // belongs to the component variants via inheritance.
-    const rules = [...styles.matchAll(/(?:^|\n)([^{}\n]*\.maka-nav-icon[^{}\n]*)\{([^}]*)\}/g)];
+    // belongs to the component variants.
+    const rules = [...styles.matchAll(/([^{}]*\.maka-nav-icon[^{}]*)\{([^}]*)\}/g)];
     assert.ok(rules.length > 0, 'the .maka-nav-icon base rule must exist');
     for (const [, selector, body] of rules) {
-      assert.ok(
-        !/(?<!-)\b(width|height)\s*:\s*\d/.test(body),
-        `\`${selector.trim()}\` must not hardcode px sizes — route through --icon-size`,
-      );
+      const sel = selector.trim().replace(/\s+/g, ' ');
+      for (const [, prop, value] of body.matchAll(/(?<!-)\b(width|height)\s*:\s*([^;]+)/g)) {
+        assert.equal(
+          value.trim(),
+          'var(--icon-size)',
+          `\`${sel}\` ${prop} must be exactly var(--icon-size), got \`${value.trim()}\``,
+        );
+      }
       assert.ok(
         !/(?<!-)\bcolor\s*:/.test(body),
-        `\`${selector.trim()}\` must not declare color — glyphs inherit the row text color`,
+        `\`${sel}\` must not declare color — glyph color is owned by the component variants`,
       );
     }
+  });
+
+  it('locks the nav glyph color model in the component variants (PR-ICON-CHROME-CONSISTENCY)', async () => {
+    const nav = await readFile(
+      join(repoRoot, 'packages', 'ui', 'src', 'session-sidebar-nav.tsx'),
+      'utf8',
+    );
+    // The darwin glass override (theme-glass.css) forces nav-row TEXT to
+    // full foreground, so glyphs must be tinted directly, not inherit:
+    // 80%-ink base (same tone as the titlebar icon actions), elevated to
+    // foreground on the active row. Without these utilities the icons
+    // silently follow the row color and go full-black on macOS.
+    assert.match(
+      nav,
+      /\[&_\.maka-nav-icon\]:text-\[var\(--foreground-secondary\)\]/,
+      'nav glyphs must pin to the 80%-ink chrome tone in the variants base',
+    );
+    assert.match(
+      nav,
+      /data-\[active=true\]:\[&_\.maka-nav-icon\]:text-foreground/,
+      'active rows must elevate the glyph to full foreground',
+    );
+  });
+
+  it('keeps the settings gear on the shared nav glyph column (PR-ICON-CHROME-CONSISTENCY)', async () => {
+    const styles = await readRendererContractCss();
+    const settings = ruleBody(styles, '.maka-sidebar-settings-button');
+    assert.ok(settings, 'the settings button rule must exist');
+    assert.match(
+      settings!,
+      /grid-template-columns:\s*var\(--icon-size\)/,
+      'settings gear column tracks --icon-size so it shares the nav rows\' icon axis',
+    );
   });
 
   it('routes the shared button icon through the same token', async () => {

--- a/apps/desktop/src/renderer/app-shell-chrome-actions.tsx
+++ b/apps/desktop/src/renderer/app-shell-chrome-actions.tsx
@@ -22,7 +22,7 @@ export function AppShellTopbarActions(props: {
           onClick={props.onOpenSearchModal}
           aria-label="搜索对话"
         >
-          <Search size={16} aria-hidden="true" />
+          <Search aria-hidden="true" />
         </TooltipTrigger>
         <TooltipContent>搜索对话</TooltipContent>
       </Tooltip>
@@ -36,9 +36,9 @@ export function AppShellTopbarActions(props: {
           aria-expanded={!props.sidebarCollapsed}
         >
           {props.sidebarCollapsed ? (
-            <PanelLeftOpen size={16} aria-hidden="true" />
+            <PanelLeftOpen aria-hidden="true" />
           ) : (
-            <PanelLeftClose size={16} aria-hidden="true" />
+            <PanelLeftClose aria-hidden="true" />
           )}
         </TooltipTrigger>
         <TooltipContent>{props.sidebarCollapsed ? '展开侧边栏' : '收起侧边栏'}</TooltipContent>
@@ -52,7 +52,7 @@ export function AppShellTopbarActions(props: {
             onClick={props.onCreateSession}
             aria-label="新任务"
           >
-            <SquarePen size={16} aria-hidden="true" />
+            <SquarePen aria-hidden="true" />
           </TooltipTrigger>
           <TooltipContent>新任务</TooltipContent>
         </Tooltip>
@@ -77,7 +77,7 @@ export function AppShellWorkspaceTopActions(props: {
           onClick={props.onOpenFeedback}
           aria-label="问题反馈"
         >
-          <MessageCircleQuestion size={15} aria-hidden="true" />
+          <MessageCircleQuestion aria-hidden="true" />
         </TooltipTrigger>
         <TooltipContent>问题反馈 · 打开关于与环境信息</TooltipContent>
       </Tooltip>
@@ -89,7 +89,7 @@ export function AppShellWorkspaceTopActions(props: {
           onClick={props.onOpenPalette}
           aria-label="打开命令面板"
         >
-          <Grid3X3 size={15} aria-hidden="true" />
+          <Grid3X3 aria-hidden="true" />
         </TooltipTrigger>
         <TooltipContent>打开命令面板</TooltipContent>
       </Tooltip>
@@ -101,7 +101,7 @@ export function AppShellWorkspaceTopActions(props: {
           onClick={props.onOpenHelp}
           aria-label="打开帮助"
         >
-          <HelpCircle size={15} aria-hidden="true" />
+          <HelpCircle aria-hidden="true" />
         </TooltipTrigger>
         <TooltipContent>打开帮助</TooltipContent>
       </Tooltip>
@@ -113,7 +113,7 @@ export function AppShellWorkspaceTopActions(props: {
           onClick={props.onOpenHealth}
           aria-label="打开健康中心"
         >
-          <CircleGauge size={15} aria-hidden="true" />
+          <CircleGauge aria-hidden="true" />
         </TooltipTrigger>
         <TooltipContent>打开健康中心</TooltipContent>
       </Tooltip>

--- a/apps/desktop/src/renderer/styles/sidebar.css
+++ b/apps/desktop/src/renderer/styles/sidebar.css
@@ -96,20 +96,18 @@
    我们没有账户"). About / version still reachable via Settings → 关于. */
 .maka-sidebar-settings-button {
   display: inline-grid;
-  grid-template-columns: 24px minmax(0, 1fr);
+  /* Same glyph column as .maka-nav-row so the gear shares the nav rows'
+     icon axis and 16px chrome size (icon-system contract). */
+  grid-template-columns: var(--icon-size) minmax(0, 1fr);
   align-items: center;
 }
 
-.maka-sidebar-settings-button .maka-nav-icon {
-  width: 18px;
-  height: 18px;
-  color: currentColor;
-}
-
+/* Color intentionally not declared: glyphs inherit the row's text color,
+   so state tints (hover/active/tone) stay in the component variants —
+   an unlayered color here would silently beat those utilities. */
 .maka-nav-icon {
   width: var(--icon-size);
   height: var(--icon-size);
-  color: var(--muted-foreground);
   justify-self: center;
 }
 

--- a/apps/desktop/src/renderer/styles/sidebar.css
+++ b/apps/desktop/src/renderer/styles/sidebar.css
@@ -102,9 +102,10 @@
   align-items: center;
 }
 
-/* Color intentionally not declared: glyphs inherit the row's text color,
-   so state tints (hover/active/tone) stay in the component variants —
-   an unlayered color here would silently beat those utilities. */
+/* Color intentionally not declared: nav glyphs are tinted by the
+   navRowVariants utilities (80%-ink base, foreground when active) and the
+   settings gear inherits its button's text color — an unlayered color
+   here would silently beat those utilities. */
 .maka-nav-icon {
   width: var(--icon-size);
   height: var(--icon-size);

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -266,6 +266,7 @@ spinner、status pulse、streaming caret、shimmer，以及必要的 hover/press
 
 - **chrome 是唯一被 token 化的档。** nav 图标（`.maka-nav-icon`）和 `packages/ui/src/ui.tsx` 的 `buttonVariants`（`[&_svg]:size-[var(--icon-size,1rem)]`）都消费 `--icon-size`，所以两者不会再各走各的（历史缺陷：nav 18px 而按钮 1rem）。改这一个 token 同时移动两者。
 - **密集 / hero 是 call-site 刻意值，不收敛。** 它们是有意的视觉层级，不是漂移；不要用全局 `svg.lucide { width }` 之类的规则一锅端，那会把 11–14px 的小图标静默放大、把 hero 压小。
+- **chrome 图标统一 80% ink（`--foreground-secondary`），颜色由组件 variants 声明，不写在 unlayered CSS 里。** 按钮内图标继承按钮文字色即可；nav 行因 darwin glass 把行文字提到 100%（`theme-glass.css` 的 `html[data-os="darwin"] .maka-nav-row`），图标由 `navRowVariants` 的 `[&_.maka-nav-icon]` utility 钉在 80%，active 行提亮到 100%。不要在 unlayered CSS（如 `.maka-nav-icon`）里写 `color`——它会静默压过 `@layer utilities` 里的全部状态意图（历史缺陷：nav 图标被钉在 `--muted-foreground`（50% ink），active/tone 提亮失效，且与 titlebar 图标的 80% ink 不一致）。
 - `packages/ui/src/primitives/*` 是另一套组件库，有自己的响应式图标尺寸（`size-4.5`/`size-4`），不归本节管。
 
 ---

--- a/packages/ui/src/session-sidebar-nav.tsx
+++ b/packages/ui/src/session-sidebar-nav.tsx
@@ -8,6 +8,10 @@ const navRowVariants = cva(
   [
     'min-h-[var(--h-control-lg)] gap-2 rounded-sm border-0 bg-transparent px-1.5 py-0.5',
     'text-left text-sm font-medium text-[var(--foreground-secondary)]',
+    // Glyphs pin to the 80%-ink chrome tone (same as titlebar icon actions)
+    // instead of inheriting: the darwin glass override forces row TEXT to
+    // full foreground, and icons must not follow it.
+    '[&_.maka-nav-icon]:text-[var(--foreground-secondary)]',
     'transition-[background-color,color] duration-[var(--duration-base)] ease-[var(--ease-out-strong)]',
     'hover:bg-[var(--state-hover-bg)] hover:text-foreground',
     'data-[active=true]:bg-[var(--state-selected-bg)] data-[active=true]:font-semibold data-[active=true]:text-foreground data-[active=true]:shadow-none',
@@ -21,7 +25,7 @@ const navRowVariants = cva(
     variants: {
       tone: {
         default: '',
-        newTask: 'text-foreground [&_.maka-nav-icon]:text-[var(--foreground-secondary)]',
+        newTask: 'text-foreground',
       },
     },
     defaultVariants: {
@@ -33,7 +37,7 @@ const navRowVariants = cva(
 type ModuleNavId = 'daily-review' | 'skills' | 'automations';
 
 const settingsButtonClass =
-  'w-full min-w-0 gap-2 rounded-sm border-0 bg-transparent px-2 py-1.5 ' +
+  'w-full min-w-0 gap-2 rounded-sm border-0 bg-transparent px-1.5 py-1.5 ' +
   'text-left text-sm font-medium text-[var(--foreground-secondary)] ' +
   'transition-[background-color,color] duration-[var(--duration-base)] ease-[var(--ease-out-strong)] ' +
   'hover:bg-[var(--state-hover-bg)] hover:text-foreground';


### PR DESCRIPTION
## Summary

- Sidebar nav glyphs, the settings gear, and titlebar icon actions now share one chrome icon system: 16px boxes via `--icon-size`, 80% ink via `--foreground-secondary`, and one glyph axis in the sidebar.
- Icon color moves out of unlayered CSS into `navRowVariants`; active rows elevate glyphs to full foreground. The gear's 18px / 24px-track special case and the dead `size={15}`/`size={16}` call-site props are removed.
- New icon-system contract assertions forbid any `.maka-nav-icon` selector from re-hardcoding px sizes or declaring `color`.

## Why

Sidebar nav icons rendered at `--muted-foreground` (50% ink) while titlebar icon actions sit at `--foreground-secondary` (80% ink) — a visible mismatch, and per `docs/design-system.md` color roles the sidebar rows belong to the 80% tier. The root cause was an unlayered `.maka-nav-icon { color }` rule that also silently defeated the tone/active icon utilities in `session-sidebar-nav.tsx` (`@layer utilities` always loses to unlayered CSS), so the intended active/tone elevation never fired. The settings gear additionally hardcoded 18px and a 24px grid track, off-size and off-axis from the nav rows above it.

Glyphs cannot simply inherit row text color: `theme-glass.css` deliberately forces nav-row text to full foreground on darwin for glass legibility. So glyphs pin to `--foreground-secondary` via a `[&_.maka-nav-icon]` utility in the variants base (generalizing the pattern the 新任务 row already declared), with `data-[active=true]` elevating to foreground.

## Verification

<img width="1032" height="672" alt="image" src="https://github.com/user-attachments/assets/0d51dfc0-c312-4775-93bb-9e7bb36896df" />

- `apps/desktop`: 2347 node tests pass (including the new contract assertions); `@maka/ui`: 105 pass; renderer + main + ui typechecks clean.
- Screenshot pixel measurement (`sidebar-long-sessions`, light-1280): all four nav glyphs, the gear, and all four titlebar glyphs render as 16px boxes at gray 55 (`--foreground-secondary`); gear and nav glyphs share the same axis (center x = 21.8). Dark variant: identical brightness (184) across sidebar, gear, and titlebar samples.
- Visual evidence: before = the bug-report screenshot (sidebar icons visibly lighter than titlebar); after = harness captures above. Substitute evidence is the pixel measurements; screenshots attached in a follow-up comment.

## Impact

Visual only, intended: sidebar icons darken from 50% to 80% ink, the gear shrinks 18px → 16px onto the shared axis, and active module rows now show full-foreground glyphs (previously dead styling). No API or behavior changes; `docs/design-system.md` §1.9 registers the color rule.

## Reviewer notes

The darwin glass override (`theme-glass.css` `html[data-os="darwin"] .maka-nav-row`) is the constraint that rules out color inheritance — see the comment added at `.maka-nav-icon`.

## Ready for review

- [x] Verification is complete and the results above are current
- [x] Impact, compatibility, migration, documentation, and release-note needs are addressed
- [x] User-visible UI/UX changes include visual evidence, or `Verification` explains why it is not applicable