### PR TITLE
docs(ui): correct BrowserPanel narrow-layout comment to reflect #824

### DIFF
--- a/apps/desktop/src/renderer/styles/chat-detail.css
+++ b/apps/desktop/src/renderer/styles/chat-detail.css
@@ -647,8 +647,9 @@
    so it already occupies the explicit `auto` row; ArtifactPane as the third
    child uses an implicit `auto` row (grid-auto-rows defaults to auto), so no
    extra explicit row is needed. With both auxiliary panels open on a very
-   short window the chat column can collapse; the user recovers by collapsing
-   ArtifactPane or closing the browser (tracked in the PR notes). */
+   short window the chat row can collapse (two 220px minima); a shared-height
+   policy is tracked in #824, and recovery may require closing the browser
+   and/or collapsing ArtifactPane. */
 @media (max-width: 990px) {
   .maka-detail-with-artifacts {
     display: grid;


### PR DESCRIPTION
## Summary

Corrects one CSS comment in `apps/desktop/src/renderer/styles/chat-detail.css` to accurately describe the both-present + short-window recovery path and point at the durable tracker. Doc-only — no behavior change.

## Why

The narrow-layout comment landed by #818 read: "the user recovers by collapsing ArtifactPane or closing the browser (tracked in the PR notes)." That overstates reachability at the shortest window heights (closing the browser alone usually recovers the chat column, but at extreme short heights the ArtifactPane collapse control may be clipped, so recovery may require both) and references the ephemeral PR notes instead of the durable tracker. A review consult on #818 recommended the more accurate wording; the edit was prepared for #818 but lost during its TDD mutation proof (a `git checkout` restored the file before the comment edit was committed), so it lands here as a separate doc-only PR.

## Scope

- One comment block: "the chat column can collapse" -> "the chat row can collapse (two 220px minima)"; "recovers by collapsing ArtifactPane or closing the browser (tracked in the PR notes)" -> "a shared-height policy is tracked in #824, and recovery may require closing the browser and/or collapsing ArtifactPane".

Non-goals: any behavior change; the shared-height policy itself (tracked in #824).

## Verification

- `browser-panel-layout.test.ts` strips comments before parsing, so the contract is unaffected — 2/2 green. `npm run build:main` passes.
- No behavior change to verify.

## Impact

None — doc-only, no IPC/contract/data or visual change.

## Reviewer notes

Follow-up to #818 (which is merged). The comment edit was intended for #818 but discarded by a `git checkout -- chat-detail.css` during #818's TDD mutation proof (HEAD did not yet contain the comment edit, so the checkout reverted it); #818 merged with the old wording. This PR lands the accurate wording. Refs #546.

## Ready for review

- [x] Verification is complete and the results above are current
- [x] Impact, compatibility, migration, documentation, and release-note needs are addressed (none — doc-only)
- [x] User-visible UI/UX changes include visual evidence, or `Verification` explains why it is not applicable (no UI change)