### PR TITLE
fix(ui): stabilize long-session scroll geometry for content-visibility turns

### DIFF
--- a/apps/desktop/e2e/fixtures.ts
+++ b/apps/desktop/e2e/fixtures.ts
@@ -36,13 +36,14 @@ async function seedE2eConnection(userDataDir: string): Promise<void> {
  * CoreFoundation / X11 / sandbox session) that an allow-list would silently
  * drop and break the launch.
  */
-function buildE2eEnv(userDataDir: string): NodeJS.ProcessEnv {
+function buildE2eEnv(userDataDir: string, visualSmokeScenario?: string): NodeJS.ProcessEnv {
   const env = { ...process.env };
   for (const key of Object.keys(env)) {
     if (
       key === 'VITE_DEV_SERVER_URL' ||
       key === 'MAKA_E2E' ||
       key === 'MAKA_E2E_USER_DATA_DIR' ||
+      key === 'MAKA_VISUAL_SMOKE_FIXTURE' ||
       /_API_KEY$/.test(key) ||
       /_API_TOKEN$/.test(key) ||
       /_API_SECRET$/.test(key)
@@ -52,6 +53,7 @@ function buildE2eEnv(userDataDir: string): NodeJS.ProcessEnv {
   }
   env.MAKA_E2E = '1';
   env.MAKA_E2E_USER_DATA_DIR = userDataDir;
+  if (visualSmokeScenario) env.MAKA_VISUAL_SMOKE_FIXTURE = visualSmokeScenario;
   return env;
 }
 
@@ -64,13 +66,17 @@ function buildE2eEnv(userDataDir: string): NodeJS.ProcessEnv {
  */
 async function launchE2eApp(
   userDataDir: string,
-  { seed, readinessSelector }: { seed: boolean; readinessSelector: string },
+  { seed, readinessSelector, visualSmokeScenario }: {
+    seed: boolean;
+    readinessSelector: string;
+    visualSmokeScenario?: string;
+  },
 ): Promise<{ app: ElectronApplication; page: Page }> {
   if (seed) await seedE2eConnection(userDataDir);
   const app = await electron.launch({
     args: ['.'],
     cwd: DESKTOP_ROOT,
-    env: buildE2eEnv(userDataDir),
+    env: buildE2eEnv(userDataDir, visualSmokeScenario),
   });
   const page = await app.firstWindow();
   // Centralize the cold-start wait so test bodies are flake-free under retries:0.
@@ -86,13 +92,17 @@ async function launchE2eApp(
  * Electron and a leaked `maka-e2e-*` directory.
  */
 async function withE2eWindow(
-  { seed, readinessSelector }: { seed: boolean; readinessSelector: string },
+  { seed, readinessSelector, visualSmokeScenario }: {
+    seed: boolean;
+    readinessSelector: string;
+    visualSmokeScenario?: string;
+  },
   use: (page: Page) => Promise<void>,
 ): Promise<void> {
   const userDataDir = await mkdtemp(path.join(tmpdir(), 'maka-e2e-'));
   let app: ElectronApplication | undefined;
   try {
-    const launched = await launchE2eApp(userDataDir, { seed, readinessSelector });
+    const launched = await launchE2eApp(userDataDir, { seed, readinessSelector, visualSmokeScenario });
     app = launched.app;
     await use(launched.page);
   } finally {
@@ -101,7 +111,7 @@ async function withE2eWindow(
   }
 }
 
-export const test = base.extend<{ window: Page; emptyWindow: Page }>({
+export const test = base.extend<{ window: Page; emptyWindow: Page; longTranscriptWindow: Page }>({
   // Seeded: a pre-staged connection clears onboarding so the composer is ready.
   // Used by chat / session / settings / attachment specs.
   window: async ({}, use) => {
@@ -111,6 +121,18 @@ export const test = base.extend<{ window: Page; emptyWindow: Page }>({
   // Used by first-run only.
   emptyWindow: async ({}, use) => {
     await withE2eWindow({ seed: false, readinessSelector: '#root' }, use);
+  },
+  // Long transcript: boots the visual-smoke `long-transcript` fixture, which
+  // seeds a 24-turn (~1300px each) session and opens it as the active
+  // session. Fixture mode seeds its own connections, so no connection is
+  // pre-staged here. Readiness = turns on screen: the session is open and
+  // above-viewport turns sit at their content-visibility placeholder size.
+  // Used by the scroll-geometry spec.
+  longTranscriptWindow: async ({}, use) => {
+    await withE2eWindow(
+      { seed: false, readinessSelector: '.maka-turn', visualSmokeScenario: 'long-transcript' },
+      use,
+    );
   },
 });
 

--- a/apps/desktop/e2e/fixtures.ts
+++ b/apps/desktop/e2e/fixtures.ts
@@ -43,6 +43,7 @@ function buildE2eEnv(userDataDir: string, visualSmokeScenario?: string): NodeJS.
       key === 'VITE_DEV_SERVER_URL' ||
       key === 'MAKA_E2E' ||
       key === 'MAKA_E2E_USER_DATA_DIR' ||
+      key === 'MAKA_E2E_SHOW_WINDOW' ||
       key === 'MAKA_VISUAL_SMOKE_FIXTURE' ||
       /_API_KEY$/.test(key) ||
       /_API_TOKEN$/.test(key) ||
@@ -54,6 +55,12 @@ function buildE2eEnv(userDataDir: string, visualSmokeScenario?: string): NodeJS.
   env.MAKA_E2E = '1';
   env.MAKA_E2E_USER_DATA_DIR = userDataDir;
   if (visualSmokeScenario) env.MAKA_VISUAL_SMOKE_FIXTURE = visualSmokeScenario;
+  // E2E windows launch hidden so local runs never steal the developer's
+  // focus. On CI there is no desktop to protect, and a hidden window's
+  // compositor is throttled to ~1fps on Linux — content-visibility turns
+  // never inflate and frame-paced protocols crawl (measured: 38 frames in
+  // 31s in the scroll-geometry climb). Under xvfb, show the window.
+  if (process.env.CI) env.MAKA_E2E_SHOW_WINDOW = '1';
   return env;
 }
 

--- a/apps/desktop/e2e/scroll-geometry.spec.ts
+++ b/apps/desktop/e2e/scroll-geometry.spec.ts
@@ -22,6 +22,11 @@ const probeScroller = `(() => {
     scrollHeight: scroller.scrollHeight,
     clientHeight: scroller.clientHeight,
     distanceFromBottom: Math.round(scroller.scrollHeight - scroller.scrollTop - scroller.clientHeight),
+    // The warm-up forces inline content-visibility per chunk and clears it on
+    // release; any remaining forced turn means the walk is still in flight.
+    // Guards against a stalled compositor freezing MID-WALK geometry into a
+    // false "settled" (frozen reads are equal reads).
+    warming: Boolean(document.querySelector('.maka-turn[style*="content-visibility"]')),
   };
 })()`;
 
@@ -35,8 +40,13 @@ const WARMED_HEIGHT_FLOOR = 24 * 800;
 async function settleGeometry(page: import('@playwright/test').Page, options: { pinned: boolean }): Promise<void> {
   let previousHeight = -1;
   await expect.poll(async () => {
-    const current = await page.evaluate(probeScroller) as { scrollHeight: number; distanceFromBottom: number };
-    const settled = current.scrollHeight > WARMED_HEIGHT_FLOOR
+    const current = await page.evaluate(probeScroller) as {
+      scrollHeight: number;
+      distanceFromBottom: number;
+      warming: boolean;
+    };
+    const settled = !current.warming
+      && current.scrollHeight > WARMED_HEIGHT_FLOOR
       && current.scrollHeight === previousHeight
       && (!options.pinned || current.distanceFromBottom === 0);
     previousHeight = current.scrollHeight;

--- a/apps/desktop/e2e/scroll-geometry.spec.ts
+++ b/apps/desktop/e2e/scroll-geometry.spec.ts
@@ -25,6 +25,25 @@ const probeScroller = `(() => {
   };
 })()`;
 
+// The fixture's 24 turns are 60 filler lines each (>1000px real, 250px as a
+// placeholder), so the whole transcript is ~15k px un-warmed vs ~32k warmed.
+// A settle check must first see final-scale height — two early reads agreeing
+// on the PLACEHOLDER height would otherwise declare "settled" before the
+// warm-up even starts (fonts / lazy-markdown gates delay it on slow machines).
+const WARMED_HEIGHT_FLOOR = 24 * 800;
+
+async function settleGeometry(page: import('@playwright/test').Page, options: { pinned: boolean }): Promise<void> {
+  let previousHeight = -1;
+  await expect.poll(async () => {
+    const current = await page.evaluate(probeScroller) as { scrollHeight: number; distanceFromBottom: number };
+    const settled = current.scrollHeight > WARMED_HEIGHT_FLOOR
+      && current.scrollHeight === previousHeight
+      && (!options.pinned || current.distanceFromBottom === 0);
+    previousHeight = current.scrollHeight;
+    return settled;
+  }, { timeout: 15_000, intervals: [500] }).toBe(true);
+}
+
 test('long session opens pinned to bottom and stays pinned while geometry settles', async ({ longTranscriptWindow: page }) => {
   await expect(page.locator('.maka-turn')).toHaveCount(24);
 
@@ -34,31 +53,13 @@ test('long session opens pinned to bottom and stays pinned while geometry settle
   // distance stays 0 while scrollHeight rises to its final value.
   await expect.poll(async () => (await page.evaluate(probeScroller)).distanceFromBottom).toBe(0);
 
-  // Geometry settled = two consecutive reads agree on scrollHeight while
-  // still pinned. A fixed sleep would race the warm-up on slow machines.
-  let previousHeight = -1;
-  await expect.poll(async () => {
-    const current = await page.evaluate(probeScroller) as { scrollHeight: number; distanceFromBottom: number };
-    const settled = current.scrollHeight === previousHeight && current.distanceFromBottom === 0;
-    previousHeight = current.scrollHeight;
-    return settled;
-  }, { timeout: 15_000, intervals: [500] }).toBe(true);
+  // Geometry settled = final-scale height and two consecutive reads agreeing
+  // on it while still pinned. A fixed sleep would race the warm-up.
+  await settleGeometry(page, { pinned: true });
 });
 
-test('scrolling a settled long session to the top never inflates the document', async ({ longTranscriptWindow: page }) => {
-  await expect(page.locator('.maka-turn')).toHaveCount(24);
-
-  // Wait for the warm-up to settle so this test isolates invariant (b);
-  // the pinned test above owns the during-warm-up behavior.
-  let previousHeight = -1;
-  await expect.poll(async () => {
-    const current = await page.evaluate(probeScroller) as { scrollHeight: number };
-    const settled = current.scrollHeight === previousHeight;
-    previousHeight = current.scrollHeight;
-    return settled;
-  }, { timeout: 15_000, intervals: [500] }).toBe(true);
-
-  const run = await page.evaluate(async () => {
+async function climbToTop(page: import('@playwright/test').Page) {
+  return await page.evaluate(async () => {
     const scroller = document.querySelector('.maka-chatViewport') as HTMLElement;
     const frame = () => new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)));
     scroller.scrollTop = scroller.scrollHeight;
@@ -80,11 +81,23 @@ test('scrolling a settled long session to the top never inflates the document', 
       honestSteps: Math.ceil(scroller.scrollHeight / scroller.clientHeight),
     };
   });
+}
 
+function expectHonestClimb(run: Awaited<ReturnType<typeof climbToTop>>): void {
   expect(run.atTop).toBe(true);
   // One height for the whole climb: no placeholder inflated mid-scroll.
   expect(run.distinctHeights).toHaveLength(1);
   // And the climb took the honest number of steps — the "endless scroll"
   // symptom was precisely needing ~2x more.
   expect(run.steps).toBeLessThanOrEqual(run.honestSteps + 2);
+}
+
+test('scrolling a settled long session to the top never inflates the document', async ({ longTranscriptWindow: page }) => {
+  await expect(page.locator('.maka-turn')).toHaveCount(24);
+
+  // Wait for the warm-up to settle so this test isolates invariant (b);
+  // the pinned test above owns the during-warm-up behavior.
+  await settleGeometry(page, { pinned: false });
+
+  expectHonestClimb(await climbToTop(page));
 });

--- a/apps/desktop/e2e/scroll-geometry.spec.ts
+++ b/apps/desktop/e2e/scroll-geometry.spec.ts
@@ -101,3 +101,20 @@ test('scrolling a settled long session to the top never inflates the document', 
 
   expectHonestClimb(await climbToTop(page));
 });
+
+test('returning to the session after visiting skills re-settles the new transcript DOM', async ({ longTranscriptWindow: page }) => {
+  await expect(page.locator('.maka-turn')).toHaveCount(24);
+  await settleGeometry(page, { pinned: true });
+
+  // A mode switch unmounts the chat scroller; coming back rebuilds every
+  // `.maka-turn` node with no remembered size, so the warm-up must walk the
+  // NEW DOM. Fixture windows don't pass OS hit-testing — dispatch clicks.
+  await page.locator('button[aria-label="展开侧边栏"]').dispatchEvent('click');
+  await page.locator('button[aria-label="技能"]').dispatchEvent('click');
+  await expect(page.locator('.maka-turn')).toHaveCount(0);
+  await page.getByText('超长会话滚动几何').first().dispatchEvent('click');
+  await expect(page.locator('.maka-turn')).toHaveCount(24);
+
+  await settleGeometry(page, { pinned: true });
+  expectHonestClimb(await climbToTop(page));
+});

--- a/apps/desktop/e2e/scroll-geometry.spec.ts
+++ b/apps/desktop/e2e/scroll-geometry.spec.ts
@@ -1,0 +1,90 @@
+import { test, expect } from './fixtures';
+
+/**
+ * Scroll-geometry contract for content-visibility chat turns.
+ *
+ * `.maka-turn` renders off-screen turns at a 250px contain-intrinsic-size
+ * placeholder. On a fresh mount of a long session that geometry is a ~25x
+ * underestimate, which used to (a) strand the pinned viewport mid-document
+ * once turns inflated (inflation fires no mutation and no scroll event) and
+ * (b) make upward scrolling "endless": the document grew turn by turn while
+ * scroll anchoring kept repositioning. The idle warm-up + the pinned-bottom
+ * ResizeObserver channel fix both; this spec locks the two user-visible
+ * invariants.
+ *
+ * Probes read only scroller metrics. Per-turn getBoundingClientRect would
+ * force-render skipped turns and mask the regression being tested.
+ */
+
+const probeScroller = `(() => {
+  const scroller = document.querySelector('.maka-chatViewport');
+  return {
+    scrollHeight: scroller.scrollHeight,
+    clientHeight: scroller.clientHeight,
+    distanceFromBottom: Math.round(scroller.scrollHeight - scroller.scrollTop - scroller.clientHeight),
+  };
+})()`;
+
+test('long session opens pinned to bottom and stays pinned while geometry settles', async ({ longTranscriptWindow: page }) => {
+  await expect(page.locator('.maka-turn')).toHaveCount(24);
+
+  // Pinned from the start: the session-open pin must hold. During the idle
+  // warm-up the document grows by thousands of pixels with no mutation and
+  // no scroll event — the follower must ride every growth step, so the
+  // distance stays 0 while scrollHeight rises to its final value.
+  await expect.poll(async () => (await page.evaluate(probeScroller)).distanceFromBottom).toBe(0);
+
+  // Geometry settled = two consecutive reads agree on scrollHeight while
+  // still pinned. A fixed sleep would race the warm-up on slow machines.
+  let previousHeight = -1;
+  await expect.poll(async () => {
+    const current = await page.evaluate(probeScroller) as { scrollHeight: number; distanceFromBottom: number };
+    const settled = current.scrollHeight === previousHeight && current.distanceFromBottom === 0;
+    previousHeight = current.scrollHeight;
+    return settled;
+  }, { timeout: 15_000, intervals: [500] }).toBe(true);
+});
+
+test('scrolling a settled long session to the top never inflates the document', async ({ longTranscriptWindow: page }) => {
+  await expect(page.locator('.maka-turn')).toHaveCount(24);
+
+  // Wait for the warm-up to settle so this test isolates invariant (b);
+  // the pinned test above owns the during-warm-up behavior.
+  let previousHeight = -1;
+  await expect.poll(async () => {
+    const current = await page.evaluate(probeScroller) as { scrollHeight: number };
+    const settled = current.scrollHeight === previousHeight;
+    previousHeight = current.scrollHeight;
+    return settled;
+  }, { timeout: 15_000, intervals: [500] }).toBe(true);
+
+  const run = await page.evaluate(async () => {
+    const scroller = document.querySelector('.maka-chatViewport') as HTMLElement;
+    const frame = () => new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)));
+    scroller.scrollTop = scroller.scrollHeight;
+    await frame();
+    const heights = new Set<number>([scroller.scrollHeight]);
+    let steps = 0;
+    // Viewport-sized steps, like a fast user scroll. The cap is a runaway
+    // guard far above the honest step count.
+    for (; steps < 120; steps++) {
+      scroller.scrollBy(0, -scroller.clientHeight);
+      await frame();
+      heights.add(scroller.scrollHeight);
+      if (scroller.scrollTop === 0) break;
+    }
+    return {
+      atTop: scroller.scrollTop === 0,
+      distinctHeights: [...heights],
+      steps,
+      honestSteps: Math.ceil(scroller.scrollHeight / scroller.clientHeight),
+    };
+  });
+
+  expect(run.atTop).toBe(true);
+  // One height for the whole climb: no placeholder inflated mid-scroll.
+  expect(run.distinctHeights).toHaveLength(1);
+  // And the climb took the honest number of steps — the "endless scroll"
+  // symptom was precisely needing ~2x more.
+  expect(run.steps).toBeLessThanOrEqual(run.honestSteps + 2);
+});

--- a/apps/desktop/e2e/scroll-geometry.spec.ts
+++ b/apps/desktop/e2e/scroll-geometry.spec.ts
@@ -71,7 +71,27 @@ test('long session opens pinned to bottom and stays pinned while geometry settle
 async function climbToTop(page: import('@playwright/test').Page) {
   return await page.evaluate(async () => {
     const scroller = document.querySelector('.maka-chatViewport') as HTMLElement;
-    const frame = () => new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)));
+    const started = performance.now();
+    // Self-imposed deadline well under the 60s test timeout: a stalled or
+    // crawling compositor must produce a diagnosable assertion failure with
+    // the numbers below, never a test-timeout hang inside this evaluate
+    // ("Target page ... closed" says nothing).
+    const deadline = started + 30_000;
+    let frames = 0;
+    let maxFrameGapMs = 0;
+    const frame = () => new Promise<void>((resolve) => {
+      const t0 = performance.now();
+      let done = false;
+      const finish = () => {
+        if (done) return;
+        done = true;
+        maxFrameGapMs = Math.max(maxFrameGapMs, performance.now() - t0);
+        resolve();
+      };
+      requestAnimationFrame(() => requestAnimationFrame(() => { frames += 2; finish(); }));
+      // Watchdog: never wait on a compositor that stopped ticking.
+      setTimeout(finish, 2_000);
+    });
     scroller.scrollTop = scroller.scrollHeight;
     await frame();
     const heights = new Set<number>([scroller.scrollHeight]);
@@ -79,6 +99,7 @@ async function climbToTop(page: import('@playwright/test').Page) {
     // Viewport-sized steps, like a fast user scroll. The cap is a runaway
     // guard far above the honest step count.
     for (; steps < 120; steps++) {
+      if (performance.now() > deadline) break;
       scroller.scrollBy(0, -scroller.clientHeight);
       await frame();
       heights.add(scroller.scrollHeight);
@@ -89,17 +110,26 @@ async function climbToTop(page: import('@playwright/test').Page) {
       distinctHeights: [...heights],
       steps,
       honestSteps: Math.ceil(scroller.scrollHeight / scroller.clientHeight),
+      frames,
+      maxFrameGapMs: Math.round(maxFrameGapMs),
+      elapsedMs: Math.round(performance.now() - started),
+      timedOut: performance.now() > deadline,
     };
   });
 }
 
 function expectHonestClimb(run: Awaited<ReturnType<typeof climbToTop>>): void {
-  expect(run.atTop).toBe(true);
+  const diagnostics = JSON.stringify(run);
+  // A climb that hit the deadline or was paced by the watchdog instead of
+  // real frames proves nothing about geometry — fail with the frame stats.
+  expect(run.timedOut, diagnostics).toBe(false);
+  expect(run.maxFrameGapMs, diagnostics).toBeLessThan(2_000);
+  expect(run.atTop, diagnostics).toBe(true);
   // One height for the whole climb: no placeholder inflated mid-scroll.
-  expect(run.distinctHeights).toHaveLength(1);
+  expect(run.distinctHeights, diagnostics).toHaveLength(1);
   // And the climb took the honest number of steps — the "endless scroll"
   // symptom was precisely needing ~2x more.
-  expect(run.steps).toBeLessThanOrEqual(run.honestSteps + 2);
+  expect(run.steps, diagnostics).toBeLessThanOrEqual(run.honestSteps + 2);
 }
 
 test('scrolling a settled long session to the top never inflates the document', async ({ longTranscriptWindow: page }) => {

--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -469,7 +469,13 @@ const systemPromptService = createSystemPromptMainService({
 // Window is created hidden for E2E and visual-smoke runs so it never steals
 // focus. Derived from the same isE2e gate as userData/fake-backend so the
 // hidden-window switch stays in lockstep with the rest of the E2E isolation.
-const startHidden = Boolean(visualSmokeFixture) || isE2e;
+// MAKA_E2E_SHOW_WINDOW opts back into a visible window where there is no
+// focus to steal (CI under xvfb): hidden windows only get ~1fps compositor
+// BeginFrames on Linux, which stalls content-visibility inflation and any
+// frame-paced E2E protocol (measured in the scroll-geometry climb: 38 frames
+// over 31s). The E2E harness sets it, not the workflow — see fixtures.ts.
+const startHidden = (Boolean(visualSmokeFixture) || isE2e)
+  && process.env.MAKA_E2E_SHOW_WINDOW !== '1';
 const mainWindowController = createMainWindowController({
   workspaceRoot,
   visualSmokeFixture,

--- a/apps/desktop/src/main/visual-smoke-fixture.ts
+++ b/apps/desktop/src/main/visual-smoke-fixture.ts
@@ -117,6 +117,10 @@ const VISUAL_SMOKE_SCENARIOS = new Set<VisualSmokeScenario>([
   // Captures the overflow-trigger state so reviewers can verify
   // the time meta + unread dot are hidden underneath (no overlap).
   'sidebar-row-actions-visible',
+  // Scroll-geometry contract seed: 24 tall turns opened as the active
+  // session on boot, so off-screen turns mount as content-visibility
+  // placeholders (see e2e/scroll-geometry.spec.ts).
+  'long-transcript',
 ]);
 
 // Fixed clock for screenshot fixtures. All seeded timestamps and
@@ -474,6 +478,11 @@ export function getVisualSmokeState(fixture: VisualSmokeFixture | null): VisualS
         sidebarCollapsed: false,
         focusActiveRow: true,
       };
+    case 'long-transcript':
+      // Scroll-geometry contract: boot straight into the 24-turn session so
+      // above-viewport turns mount render-skipped (never rendered), the
+      // exact state the warm-up + pinned-bottom invariants protect.
+      return { ...state, activeSessionId: LONG_TRANSCRIPT_SESSION_ID };
     case 'all':
       return {
         ...state,
@@ -526,6 +535,12 @@ export async function seedVisualSmokeFixture(input: {
     for (const seed of workstationStatusSessions(now)) {
       await writeSession(input.workspaceRoot, seed.header, seed.messages);
     }
+  }
+  // Scroll-geometry contract (e2e/scroll-geometry.spec.ts): a session tall
+  // enough that most turns mount as render-skipped content-visibility
+  // placeholders — the state the warm-up and pinned-bottom invariants cover.
+  if (input.fixture.scenario === 'long-transcript') {
+    await writeSession(input.workspaceRoot, longTranscriptSession(now), longTranscriptMessages(now));
   }
   // PR109f (g): all three turn-control-* scenarios share the same
   // on-disk seed; only the active session selection differs. Seeding
@@ -663,6 +678,7 @@ const TURN_CONTROL_SCENARIOS = new Set<VisualSmokeScenario>([
 ]);
 
 const TURN_SESSION_ID = 'visual-smoke-turn';
+const LONG_TRANSCRIPT_SESSION_ID = 'visual-smoke-long-transcript';
 const PROCESSING_SESSION_ID = 'visual-smoke-processing';
 const STREAMING_SESSION_ID = 'visual-smoke-streaming';
 // PR-STREAM-TURN-CENTER: realistic multi-block markdown (heading + paragraph +
@@ -1016,6 +1032,51 @@ function turnSession(now: number): SessionHeader {
     now,
     lastMessageAt: now - 9 * 60_000,
   });
+}
+
+function longTranscriptSession(now: number): SessionHeader {
+  return header({
+    id: LONG_TRANSCRIPT_SESSION_ID,
+    name: '超长会话滚动几何',
+    connection: 'zai-live',
+    model: 'glm-5.1',
+    now,
+    lastMessageAt: now - 5 * 60_000,
+  });
+}
+
+/**
+ * 24 turns, each ~1300px tall once rendered, so the transcript is ~25x the
+ * 250px contain-intrinsic-size placeholder per turn and dozens of viewports
+ * tall overall. Plain text on purpose: the contract under test is scroll
+ * geometry, not markdown rendering.
+ */
+function longTranscriptMessages(now: number): StoredMessage[] {
+  const filler = Array.from(
+    { length: 60 },
+    (_, line) => `第 ${line + 1} 行 — 用于撑高单个 turn 的占位正文内容。`,
+  ).join('  \n');
+  const messages: StoredMessage[] = [];
+  const base = now - 60 * 60_000;
+  for (let turn = 0; turn < 24; turn++) {
+    const turnId = `long-transcript-turn-${turn}`;
+    messages.push({
+      type: 'user',
+      id: `long-transcript-user-${turn}`,
+      turnId,
+      ts: base + turn * 60_000,
+      text: `长会话问题 ${turn + 1}`,
+    });
+    messages.push({
+      type: 'assistant',
+      id: `long-transcript-assistant-${turn}`,
+      turnId,
+      ts: base + turn * 60_000 + 30_000,
+      text: `长会话回答 ${turn + 1}\n\n${filler}`,
+      modelId: 'glm-5.1',
+    });
+  }
+  return messages;
 }
 
 function turnMessages(now: number): StoredMessage[] {

--- a/apps/desktop/src/renderer/maka-tokens.css
+++ b/apps/desktop/src/renderer/maka-tokens.css
@@ -1212,9 +1212,12 @@
     /* Long-conversation first render: skip layout/paint for off-screen
        turns (vercel react-best-practices rendering-content-visibility —
        ~10x initial-render win on long sessions, keeps native Cmd+F and
-       text selection, no virtualization library). `auto 250px` keeps a
-       placeholder estimate until first render, then the remembered
-       actual size prevents scrollbar jumps. */
+       text selection, no virtualization library). `auto 250px` is only a
+       placeholder until a turn is first rendered; the remembered actual
+       size then keeps scroll geometry exact. Never-rendered history would
+       otherwise inflate turn by turn while scrolling up ("endless scroll"),
+       so chat-view runs an idle-time bottom-up warm-up after session load —
+       see packages/ui/src/turn-size-warmup.ts. */
     content-visibility: auto;
     contain-intrinsic-size: auto 250px;
   }

--- a/packages/core/src/visual-smoke.ts
+++ b/packages/core/src/visual-smoke.ts
@@ -113,7 +113,13 @@ export type VisualSmokeScenario =
   // becomes visible (via `:focus-within`). Verifies that the
   // time meta + unread dot do NOT leak through the action icons
   // — the bug WAWQAQ flagged.
-  | 'sidebar-row-actions-visible';
+  | 'sidebar-row-actions-visible'
+  // Scroll-geometry contract: a 24-turn session whose turns are each ~1300px
+  // tall, opened as the active session on boot. Off-screen turns mount as
+  // 250px content-visibility placeholders, so this seed exercises the
+  // warm-up + pinned-bottom geometry invariants (E2E scroll-geometry spec)
+  // and gives screenshots a long-transcript surface.
+  | 'long-transcript';
 
 export interface VisualSmokeLiveTool {
   toolUseId: string;

--- a/packages/ui/src/__tests__/pinned-bottom.test.ts
+++ b/packages/ui/src/__tests__/pinned-bottom.test.ts
@@ -52,4 +52,89 @@ describe('createPinnedBottomFollower', () => {
     notifyContentCommit();
     assert.equal(viewport.scrollTop, 100);
   });
+
+  // Render-skipped turns (content-visibility: auto) inflate from their
+  // placeholder to their real height without any DOM mutation, so the
+  // follower needs a size channel alongside the mutation channel.
+  it('follows child size growth that produces no mutation', () => {
+    const childA = {} as Element;
+    const childB = {} as Element;
+    const viewport = { scrollTop: 100, scrollHeight: 200 };
+    const content = { children: [childA, childB] } as unknown as Element;
+    let notifySizeChange!: () => void;
+    const sizeObserved: Element[] = [];
+    createPinnedBottomFollower({
+      viewport,
+      content,
+      isPinned: () => true,
+      createObserver: () => ({ observe: () => {}, disconnect: () => {} }),
+      createSizeObserver: (callback) => {
+        notifySizeChange = callback;
+        return {
+          observe: (element) => { sizeObserved.push(element); },
+          disconnect: () => {},
+        };
+      },
+    });
+
+    assert.deepEqual(sizeObserved, [childA, childB]);
+    viewport.scrollHeight = 1400;
+    notifySizeChange();
+    assert.equal(viewport.scrollTop, 1400);
+  });
+
+  it('starts observing children appended after a mutation, exactly once each', () => {
+    const childA = {} as Element;
+    const childB = {} as Element;
+    const children: Element[] = [childA];
+    const viewport = { scrollTop: 0, scrollHeight: 100 };
+    const content = { children } as unknown as Element;
+    let notifyContentCommit!: () => void;
+    const sizeObserved: Element[] = [];
+    createPinnedBottomFollower({
+      viewport,
+      content,
+      isPinned: () => true,
+      createObserver: (callback) => {
+        notifyContentCommit = callback;
+        return { observe: () => {}, disconnect: () => {} };
+      },
+      createSizeObserver: () => ({
+        observe: (element) => { sizeObserved.push(element); },
+        disconnect: () => {},
+      }),
+    });
+
+    children.push(childB);
+    notifyContentCommit();
+    notifyContentCommit();
+    assert.deepEqual(sizeObserved, [childA, childB]);
+  });
+
+  it('does not move the viewport on size growth after the user unpins, and stop disconnects both observers', () => {
+    const viewport = { scrollTop: 50, scrollHeight: 100 };
+    const content = { children: [{} as Element] } as unknown as Element;
+    let pinned = true;
+    let notifySizeChange!: () => void;
+    let mutationDisconnected = false;
+    let sizeDisconnected = false;
+    const stop = createPinnedBottomFollower({
+      viewport,
+      content,
+      isPinned: () => pinned,
+      createObserver: () => ({ observe: () => {}, disconnect: () => { mutationDisconnected = true; } }),
+      createSizeObserver: (callback) => {
+        notifySizeChange = callback;
+        return { observe: () => {}, disconnect: () => { sizeDisconnected = true; } };
+      },
+    });
+
+    pinned = false;
+    viewport.scrollHeight = 900;
+    notifySizeChange();
+    assert.equal(viewport.scrollTop, 50);
+    stop();
+    assert.equal(mutationDisconnected, true);
+    assert.equal(sizeDisconnected, true);
+  });
 });

--- a/packages/ui/src/__tests__/turn-size-warmup.test.ts
+++ b/packages/ui/src/__tests__/turn-size-warmup.test.ts
@@ -1,0 +1,94 @@
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'node:test';
+import { createTurnSizeWarmup, type WarmupScheduler } from '../turn-size-warmup.js';
+
+function fakeTurn(overrides: { live?: boolean; connected?: boolean } = {}) {
+  return {
+    isConnected: overrides.connected ?? true,
+    hasAttribute: (name: string) => name === 'data-live-streaming' && (overrides.live ?? false),
+    style: { contentVisibility: '' },
+  };
+}
+
+function fakeScheduler() {
+  const idle: Array<() => void> = [];
+  const frames: Array<() => void> = [];
+  const remove = (queue: Array<() => void>, callback: () => void) => {
+    const index = queue.indexOf(callback);
+    if (index >= 0) queue.splice(index, 1);
+  };
+  const scheduler: WarmupScheduler = {
+    requestIdle(callback) {
+      idle.push(callback);
+      return () => remove(idle, callback);
+    },
+    requestFrame(callback) {
+      frames.push(callback);
+      return () => remove(frames, callback);
+    },
+  };
+  return {
+    scheduler,
+    flushIdle: () => { idle.splice(0).forEach((callback) => callback()); },
+    flushFrame: () => { frames.splice(0).forEach((callback) => callback()); },
+    pending: () => idle.length + frames.length,
+  };
+}
+
+function forced(turns: Array<{ style: { contentVisibility: string } }>): number[] {
+  return turns.flatMap((turn, index) => turn.style.contentVisibility === 'visible' ? [index] : []);
+}
+
+describe('createTurnSizeWarmup', () => {
+  it('walks bottom-up in chunks, forcing each chunk across a full frame then releasing it', () => {
+    const turns = [fakeTurn(), fakeTurn(), fakeTurn(), fakeTurn(), fakeTurn()];
+    const { scheduler, flushIdle, flushFrame, pending } = fakeScheduler();
+    createTurnSizeWarmup({ turns: () => turns, chunkSize: 2, scheduler });
+
+    assert.deepEqual(forced(turns), []);
+    flushIdle();
+    assert.deepEqual(forced(turns), [3, 4]);
+    // The chunk must stay forced across the frame that lays it out (the first
+    // frame callback fires before that layout) and release on the next frame.
+    flushFrame();
+    assert.deepEqual(forced(turns), [3, 4]);
+    flushFrame();
+    assert.deepEqual(forced(turns), []);
+
+    flushIdle();
+    assert.deepEqual(forced(turns), [1, 2]);
+    flushFrame();
+    flushFrame();
+    flushIdle();
+    assert.deepEqual(forced(turns), [0]);
+    flushFrame();
+    flushFrame();
+    assert.deepEqual(forced(turns), []);
+    assert.equal(pending(), 0);
+  });
+
+  it('skips the live-streaming tail and disconnected turns', () => {
+    const turns = [fakeTurn(), fakeTurn({ connected: false }), fakeTurn(), fakeTurn({ live: true })];
+    const { scheduler, flushIdle } = fakeScheduler();
+    createTurnSizeWarmup({ turns: () => turns, chunkSize: 4, scheduler });
+
+    flushIdle();
+    assert.deepEqual(forced(turns), [0, 2]);
+  });
+
+  it('cancel releases the in-flight chunk and stops the walk', () => {
+    const turns = [fakeTurn(), fakeTurn(), fakeTurn()];
+    const { scheduler, flushIdle, flushFrame, pending } = fakeScheduler();
+    const stop = createTurnSizeWarmup({ turns: () => turns, chunkSize: 2, scheduler });
+
+    flushIdle();
+    assert.deepEqual(forced(turns), [1, 2]);
+    stop();
+    assert.deepEqual(forced(turns), []);
+    flushFrame();
+    flushFrame();
+    flushIdle();
+    assert.deepEqual(forced(turns), []);
+    assert.equal(pending(), 0);
+  });
+});

--- a/packages/ui/src/__tests__/turn-size-warmup.test.ts
+++ b/packages/ui/src/__tests__/turn-size-warmup.test.ts
@@ -6,7 +6,7 @@ function fakeTurn(overrides: { live?: boolean; connected?: boolean } = {}) {
   return {
     isConnected: overrides.connected ?? true,
     hasAttribute: (name: string) => name === 'data-live-streaming' && (overrides.live ?? false),
-    style: { contentVisibility: '' },
+    style: { contentVisibility: '', contain: '' },
   };
 }
 
@@ -35,8 +35,9 @@ function fakeScheduler() {
   };
 }
 
-function forced(turns: Array<{ style: { contentVisibility: string } }>): number[] {
-  return turns.flatMap((turn, index) => turn.style.contentVisibility === 'visible' ? [index] : []);
+function forced(turns: Array<{ style: { contentVisibility: string; contain: string } }>): number[] {
+  return turns.flatMap((turn, index) =>
+    turn.style.contentVisibility === 'visible' && turn.style.contain === 'layout style paint' ? [index] : []);
 }
 
 describe('createTurnSizeWarmup', () => {
@@ -54,6 +55,9 @@ describe('createTurnSizeWarmup', () => {
     assert.deepEqual(forced(turns), [3, 4]);
     flushFrame();
     assert.deepEqual(forced(turns), []);
+    // Release must fully restore the stylesheet state — both properties.
+    assert.equal(turns[3].style.contentVisibility, '');
+    assert.equal(turns[3].style.contain, '');
 
     flushIdle();
     assert.deepEqual(forced(turns), [1, 2]);

--- a/packages/ui/src/chat-view.tsx
+++ b/packages/ui/src/chat-view.tsx
@@ -357,14 +357,43 @@ export function ChatView(props: {
   // Without this, scrolling up through never-rendered history keeps inflating
   // the document and the top recedes ("endless scroll"). Keyed on hasTurns so
   // the walk starts when history arrives, without re-walking per message.
+  // Gated so sizes are remembered from the FINAL layout, not a transient one
+  // (a stale remembered size gets re-corrected on every viewport arrival —
+  // exactly the drift this walk exists to remove):
+  // - document.fonts.ready: fallback glyph metrics shift prose heights;
+  // - no `.maka-markdown-pending` left in the tree: until the lazy
+  //   markdown-body chunk commits, every bubble is the plain-text Suspense
+  //   fallback (~7.5px taller per turn). Awaiting the import is NOT enough —
+  //   the Suspense retry is a low-priority render that can commit after an
+  //   idle callback — so the DOM is the authority, polled with a bounded
+  //   timeout that degrades to warming anyway (e.g. chunk load failure).
   const hasTurns = turns.length > 0;
   useEffect(() => {
     if (!hasTurns) return;
     const root = scrollRef.current;
     if (!root) return;
-    return createTurnSizeWarmup({
-      turns: () => root.querySelectorAll<HTMLElement>('.maka-turn'),
-    });
+    let disposed = false;
+    let cancelWarmup: (() => void) | undefined;
+    let pollTimer: number | undefined;
+    let attempts = 0;
+    const warmOnceSettled = () => {
+      if (disposed) return;
+      if (root.querySelector('.maka-markdown-pending') && attempts++ < 50) {
+        pollTimer = window.setTimeout(warmOnceSettled, 100);
+        return;
+      }
+      cancelWarmup = createTurnSizeWarmup({
+        turns: () => root.querySelectorAll<HTMLElement>('.maka-turn'),
+      });
+    };
+    const fontsReady: Promise<unknown> =
+      typeof document !== 'undefined' && document.fonts ? document.fonts.ready : Promise.resolve();
+    void fontsReady.then(warmOnceSettled);
+    return () => {
+      disposed = true;
+      window.clearTimeout(pollTimer);
+      cancelWarmup?.();
+    };
   }, [props.activeSession?.id, hasTurns]);
 
   useEffect(() => {

--- a/packages/ui/src/chat-view.tsx
+++ b/packages/ui/src/chat-view.tsx
@@ -367,8 +367,10 @@ export function ChatView(props: {
   //   markdown-body chunk commits, every bubble is the plain-text Suspense
   //   fallback (~7.5px taller per turn). Awaiting the import is NOT enough —
   //   the Suspense retry is a low-priority render that can commit after an
-  //   idle callback — so the DOM is the authority, polled with a bounded
-  //   timeout that degrades to warming anyway (e.g. chunk load failure).
+  //   idle callback — so the DOM is the authority, polled until it settles.
+  //   No warm-anyway deadline: warming a layout the markdown commit is about
+  //   to replace would re-create the drift, and if the chunk never loads the
+  //   un-warmed placeholder geometry is the least of the session's problems.
   const hasTurns = turns.length > 0;
   useEffect(() => {
     if (!hasTurns) return;
@@ -377,10 +379,9 @@ export function ChatView(props: {
     let disposed = false;
     let cancelWarmup: (() => void) | undefined;
     let pollTimer: number | undefined;
-    let attempts = 0;
     const warmOnceSettled = () => {
       if (disposed) return;
-      if (root.querySelector('.maka-markdown-pending') && attempts++ < 50) {
+      if (root.querySelector('.maka-markdown-pending')) {
         pollTimer = window.setTimeout(warmOnceSettled, 100);
         return;
       }

--- a/packages/ui/src/chat-view.tsx
+++ b/packages/ui/src/chat-view.tsx
@@ -356,9 +356,11 @@ export function ChatView(props: {
   // turn's real height replaces the 250px `contain-intrinsic-size` estimate.
   // Without this, scrolling up through never-rendered history keeps inflating
   // the document and the top recedes ("endless scroll"). Keyed on hasTurns so
-  // the walk starts when history arrives, without re-walking per message, and
-  // on mode (like the follower above) because leaving chat unmounts the
-  // scroller — the rebuilt `.maka-turn` nodes have no remembered sizes.
+  // the walk starts when history arrives, without re-walking per message.
+  // Section switches need no dependency here: since #831 ChatView mounts only
+  // for sessions, so leaving chat unmounts the component with its scroll DOM
+  // and returning re-runs every effect against the rebuilt `.maka-turn` nodes
+  // (which have no remembered sizes — the E2E mode-switch test locks this).
   // Gated so sizes are remembered from the FINAL layout, not a transient one
   // (a stale remembered size gets re-corrected on every viewport arrival —
   // exactly the drift this walk exists to remove):
@@ -397,7 +399,7 @@ export function ChatView(props: {
       window.clearTimeout(pollTimer);
       cancelWarmup?.();
     };
-  }, [props.activeSession?.id, props.mode, hasTurns]);
+  }, [props.activeSession?.id, hasTurns]);
 
   useEffect(() => {
     const target = props.scrollTargetTurn;

--- a/packages/ui/src/chat-view.tsx
+++ b/packages/ui/src/chat-view.tsx
@@ -24,6 +24,7 @@ import { formatAbsoluteTimestamp, formatClockTime, turnAbortMarkerLabel } from '
 import type { ChatModelChoice } from './chat-model-helpers.js';
 import { prepareSmoothStreamText, useSmoothStreamContent } from './smooth-stream.js';
 import { createPinnedBottomFollower } from './pinned-bottom.js';
+import { createTurnSizeWarmup } from './turn-size-warmup.js';
 import { tokenizeFade, useStreamFade, type StreamFade } from './stream-fade.js';
 import { OverlayScrollArea } from './overlay-scroll-area.js';
 import { DialogContent, DialogRoot } from './ui.js';
@@ -350,6 +351,21 @@ export function ChatView(props: {
       isPinned: () => pinnedToBottomRef.current,
     });
   }, [props.activeSession?.id]);
+
+  // Warm up `content-visibility: auto` turns once per session load so every
+  // turn's real height replaces the 250px `contain-intrinsic-size` estimate.
+  // Without this, scrolling up through never-rendered history keeps inflating
+  // the document and the top recedes ("endless scroll"). Keyed on hasTurns so
+  // the walk starts when history arrives, without re-walking per message.
+  const hasTurns = turns.length > 0;
+  useEffect(() => {
+    if (!hasTurns) return;
+    const root = scrollRef.current;
+    if (!root) return;
+    return createTurnSizeWarmup({
+      turns: () => root.querySelectorAll<HTMLElement>('.maka-turn'),
+    });
+  }, [props.activeSession?.id, hasTurns]);
 
   useEffect(() => {
     const target = props.scrollTargetTurn;

--- a/packages/ui/src/chat-view.tsx
+++ b/packages/ui/src/chat-view.tsx
@@ -352,11 +352,13 @@ export function ChatView(props: {
     });
   }, [props.activeSession?.id]);
 
-  // Warm up `content-visibility: auto` turns once per session load so every
+  // Warm up `content-visibility: auto` turns once per transcript DOM so every
   // turn's real height replaces the 250px `contain-intrinsic-size` estimate.
   // Without this, scrolling up through never-rendered history keeps inflating
   // the document and the top recedes ("endless scroll"). Keyed on hasTurns so
-  // the walk starts when history arrives, without re-walking per message.
+  // the walk starts when history arrives, without re-walking per message, and
+  // on mode (like the follower above) because leaving chat unmounts the
+  // scroller — the rebuilt `.maka-turn` nodes have no remembered sizes.
   // Gated so sizes are remembered from the FINAL layout, not a transient one
   // (a stale remembered size gets re-corrected on every viewport arrival —
   // exactly the drift this walk exists to remove):
@@ -394,7 +396,7 @@ export function ChatView(props: {
       window.clearTimeout(pollTimer);
       cancelWarmup?.();
     };
-  }, [props.activeSession?.id, hasTurns]);
+  }, [props.activeSession?.id, props.mode, hasTurns]);
 
   useEffect(() => {
     const target = props.scrollTargetTurn;

--- a/packages/ui/src/pinned-bottom.ts
+++ b/packages/ui/src/pinned-bottom.ts
@@ -10,17 +10,33 @@ export interface PinnedBottomObserver {
 
 export type PinnedBottomObserverFactory = (callback: () => void) => PinnedBottomObserver;
 
+export interface PinnedBottomSizeObserver {
+  observe(element: Element): void;
+  disconnect(): void;
+}
+
+export type PinnedBottomSizeObserverFactory = (callback: () => void) => PinnedBottomSizeObserver;
+
 /**
  * Follows the scroll content's actual commit clock. Streaming text is revealed
  * by requestAnimationFrame after raw deltas arrive, while OverlayScrollbars
  * keeps the outer content box viewport-sized; observing raw state or that fixed
  * box cannot keep a pinned viewport aligned with each visible growth step.
+ *
+ * Two channels feed the follower:
+ * - a MutationObserver on the content subtree — streaming text and appended
+ *   turns commit as DOM mutations;
+ * - a ResizeObserver on the content's element children — render-skipped turns
+ *   (`content-visibility: auto`) inflate from their 250px placeholder to
+ *   their real height with NO mutation and no scroll event, which otherwise
+ *   strands a pinned viewport mid-document after a long session mounts.
  */
 export function createPinnedBottomFollower(options: {
   viewport: PinnedBottomViewport;
   content: Element;
   isPinned: () => boolean;
   createObserver?: PinnedBottomObserverFactory;
+  createSizeObserver?: PinnedBottomSizeObserverFactory;
 }): () => void {
   const follow = (): void => {
     if (options.isPinned()) options.viewport.scrollTop = options.viewport.scrollHeight;
@@ -30,7 +46,28 @@ export function createPinnedBottomFollower(options: {
       ? (callback: () => void) => new MutationObserver(callback)
       : undefined);
   if (!createObserver) return () => {};
-  const observer = createObserver(follow);
+  const createSizeObserver = options.createSizeObserver
+    ?? (typeof ResizeObserver === 'function'
+      ? (callback: () => void) => new ResizeObserver(callback)
+      : undefined);
+  const sizeObserver = createSizeObserver?.(follow);
+  const sizeObserved = new WeakSet<Element>();
+  const observeNewChildren = (): void => {
+    if (!sizeObserver) return;
+    for (const child of options.content.children) {
+      if (sizeObserved.has(child)) continue;
+      sizeObserved.add(child);
+      sizeObserver.observe(child);
+    }
+  };
+  observeNewChildren();
+  const observer = createObserver(() => {
+    follow();
+    observeNewChildren();
+  });
   observer.observe(options.content, { childList: true, subtree: true, characterData: true });
-  return () => observer.disconnect();
+  return () => {
+    observer.disconnect();
+    sizeObserver?.disconnect();
+  };
 }

--- a/packages/ui/src/turn-size-warmup.ts
+++ b/packages/ui/src/turn-size-warmup.ts
@@ -1,0 +1,96 @@
+/**
+ * Chunked, bottom-up warm-up for `content-visibility: auto` chat turns.
+ *
+ * Off-screen turns are render-skipped and occupy only the
+ * `contain-intrinsic-size: auto 250px` placeholder until first rendered, so a
+ * long session's scroll geometry is badly underestimated. Scrolling up then
+ * inflates each turn from 250px to its real height; scroll anchoring
+ * compensates and the top keeps receding ("endless scroll"). Rendering every
+ * turn once records its last remembered size (the `auto` keyword), after which
+ * the geometry stays exact for the life of the DOM node.
+ *
+ * The walk is chunked over idle time (no one-shot full-history layout jank)
+ * and runs bottom-up: the user starts pinned at the bottom, so true sizes are
+ * laid down in the direction they will scroll.
+ */
+
+export interface WarmupTurnElement {
+  readonly isConnected: boolean;
+  hasAttribute(qualifiedName: string): boolean;
+  readonly style: { contentVisibility: string };
+}
+
+export interface WarmupScheduler {
+  /** Schedule work for idle time; returns a cancel function. */
+  requestIdle(callback: () => void): () => void;
+  /** Schedule work at the next rendering opportunity; returns a cancel function. */
+  requestFrame(callback: () => void): () => void;
+}
+
+function defaultScheduler(): WarmupScheduler | undefined {
+  if (typeof requestAnimationFrame !== 'function') return undefined;
+  return {
+    requestIdle: typeof requestIdleCallback === 'function'
+      ? (callback) => {
+        const id = requestIdleCallback(callback);
+        return () => cancelIdleCallback(id);
+      }
+      : (callback) => {
+        const id = setTimeout(callback, 1);
+        return () => clearTimeout(id);
+      },
+    requestFrame: (callback) => {
+      const id = requestAnimationFrame(callback);
+      return () => cancelAnimationFrame(id);
+    },
+  };
+}
+
+export function createTurnSizeWarmup(options: {
+  turns: () => ArrayLike<WarmupTurnElement>;
+  chunkSize?: number;
+  scheduler?: WarmupScheduler;
+}): () => void {
+  const scheduler = options.scheduler ?? defaultScheduler();
+  if (!scheduler) return () => {};
+  const chunkSize = options.chunkSize ?? 16;
+  // Bottom-up queue. The live-streaming tail is already forced visible by CSS
+  // and grows every frame — leave it alone.
+  const queue = Array.from(options.turns())
+    .filter((turn) => !turn.hasAttribute('data-live-streaming'))
+    .reverse();
+  let forcedChunk: WarmupTurnElement[] = [];
+  let cancelScheduled: (() => void) | undefined;
+
+  const release = (): void => {
+    for (const turn of forcedChunk) turn.style.contentVisibility = '';
+    forcedChunk = [];
+  };
+
+  const step = (): void => {
+    let chunk: WarmupTurnElement[] = [];
+    while (chunk.length === 0 && queue.length > 0) {
+      chunk = queue.splice(0, chunkSize).filter((turn) => turn.isConnected);
+    }
+    if (chunk.length === 0) return;
+    forcedChunk = chunk;
+    for (const turn of forcedChunk) turn.style.contentVisibility = 'visible';
+    // Hold the forced styles across one full rendering opportunity: the first
+    // frame callback fires before the layout that renders the chunk (and
+    // records its remembered sizes), so release on the following frame.
+    cancelScheduled = scheduler.requestFrame(() => {
+      cancelScheduled = scheduler.requestFrame(() => {
+        release();
+        if (queue.length > 0) cancelScheduled = scheduler.requestIdle(step);
+      });
+    });
+  };
+
+  cancelScheduled = scheduler.requestIdle(step);
+  return () => {
+    cancelScheduled?.();
+    cancelScheduled = undefined;
+    release();
+    queue.length = 0;
+  };
+}

--- a/packages/ui/src/turn-size-warmup.ts
+++ b/packages/ui/src/turn-size-warmup.ts
@@ -17,7 +17,7 @@
 export interface WarmupTurnElement {
   readonly isConnected: boolean;
   hasAttribute(qualifiedName: string): boolean;
-  readonly style: { contentVisibility: string };
+  readonly style: { contentVisibility: string; contain: string };
 }
 
 export interface WarmupScheduler {
@@ -63,7 +63,10 @@ export function createTurnSizeWarmup(options: {
   let cancelScheduled: (() => void) | undefined;
 
   const release = (): void => {
-    for (const turn of forcedChunk) turn.style.contentVisibility = '';
+    for (const turn of forcedChunk) {
+      turn.style.contentVisibility = '';
+      turn.style.contain = '';
+    }
     forcedChunk = [];
   };
 
@@ -74,7 +77,16 @@ export function createTurnSizeWarmup(options: {
     }
     if (chunk.length === 0) return;
     forcedChunk = chunk;
-    for (const turn of forcedChunk) turn.style.contentVisibility = 'visible';
+    for (const turn of forcedChunk) {
+      turn.style.contentVisibility = 'visible';
+      // `content-visibility: auto` keeps layout/style/paint containment even
+      // while an element is on screen; a bare `visible` drops it, and the
+      // containment difference shifts layout by a few pixels per turn. The
+      // remembered size must be measured under the SAME containment the turn
+      // will have when it later scrolls into view, or every arrival corrects
+      // the height and the scrollbar drifts.
+      turn.style.contain = 'layout style paint';
+    }
     // Hold the forced styles across one full rendering opportunity: the first
     // frame callback fires before the layout that renders the chunk (and
     // records its remembered sizes), so release on the following frame.


### PR DESCRIPTION
## Summary

- Warm up `content-visibility: auto` turns in idle-time chunks so each turn's real height replaces the 250px `contain-intrinsic-size` estimate — upward scrolling stops "receding".
- Add a ResizeObserver channel to the pinned-bottom follower so placeholder inflation (no mutation, no scroll event) can't strand a freshly opened long session mid-document.
- Record warm-up sizes only from the final layout (fonts ready, lazy markdown committed, same containment as later viewport arrivals), and re-walk when a mode switch rebuilds the transcript DOM.
- Lock both user-visible invariants with a deterministic `long-transcript` visual-smoke fixture and an E2E scroll-geometry contract.

## Why

Closes #827. Long sessions felt endless when scrolling up and could open mid-document: the un-warmed transcript underestimates true height ~2x (14640 vs 31872 on the fixture-scale session), placeholders inflate per viewport arrival, and scroll anchoring keeps repositioning. Root cause and measurements in #827.

## Verification

- Unit (node:test): `@maka/ui` 111 pass (new `turn-size-warmup` + pinned-bottom size-channel tests); full workspace suite 2346 pass; typecheck clean.
- E2E (Playwright + Electron): 8/8 including 3 scroll-geometry tests; each RED-verified — reverting the corresponding fix makes exactly that test fail.
- Live A/B in the running app: mount scrollHeight 14640 → settles at 31872 with distanceFromBottom pinned at 0 throughout; settled scroll-up climb sees a single scrollHeight and the honest step count; a user scroll position (1848) is preserved untouched during warm-up.
- External review (Codex), two rounds: round-1 findings (P1 mode-switch re-warm, P2 warm-anyway deadline, P2 E2E settle gate) fixed and locked; round 2 PASS with no open P0–P3.
- CI E2E initially failed: hidden windows only get ~1fps compositor frames on Linux, hanging the frame-paced climb. Fixed at the root — E2E windows are shown under xvfb (`MAKA_E2E_SHOW_WINDOW`, CI-only); the climb is now hang-proof and reports frame statistics on failure; the settle check refuses an in-flight warm-up walk.
- No before/after video: the defect is scroll-anchoring drift, which static screenshots can't show; the numeric E2E contract (honest step count, single scrollHeight) is the substitute evidence.

## Impact

User-visible fix only — long sessions open pinned to bottom and scroll honestly. No API, storage, or migration impact. Adds the test-only `long-transcript` visual-smoke scenario. Release note: one fix line.

## Reviewer notes

- The warm-up forces `contain: layout style paint` together with `content-visibility: visible`: `auto` keeps containment even while on screen, so remembered sizes must be measured under the same containment or every later arrival re-corrects the height.
- Structural root cause of the review P1 (ChatView owning non-chat mode dispatch) is tracked separately in #829; this PR takes the minimal in-place fix (`props.mode` dep).
- Consciously rejected (review P3): unobserving removed children in the follower's ResizeObserver — removals are rare and inert, and both observers disconnect on session/mode cleanup.

## Ready for review

- [x] Verification is complete and the results above are current
- [x] Impact, compatibility, migration, documentation, and release-note needs are addressed
- [x] User-visible UI/UX changes include visual evidence, or `Verification` explains why it is not applicable


