### PR TITLE
fix(ui): scale auxiliary panels to dvh when both open at narrow widths

### DIFF
--- a/apps/desktop/src/main/__tests__/app-region-hygiene-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/app-region-hygiene-contract.test.ts
@@ -76,6 +76,26 @@ describe('app-region hygiene contract (PR-SIDEBAR-IA-0 Phase 3 P0 fixup v5)', ()
     );
   });
 
+  it('BrowserWindow enforces a runtime min height aligned with the sanitizeBounds restore floor (#824)', async () => {
+    // Without a BrowserWindow minHeight, the both-present dvh layout fix
+    // (#824) can be defeated by dragging the window below the 320px
+    // restore floor that sanitizeBounds enforces. Pin minHeight to the
+    // shared SAFE_MIN_HEIGHT constant so the runtime resize floor matches
+    // the restore floor and the two can't drift apart.
+    const mainSrc = await readMainProcessCombinedSource();
+    assert.match(
+      mainSrc,
+      /new BrowserWindow\([\s\S]*?minHeight:\s*SAFE_MIN_HEIGHT\b/,
+      'main BrowserWindow must set `minHeight: SAFE_MIN_HEIGHT` so the runtime resize floor matches the sanitizeBounds restore floor (#824)',
+    );
+    const windowStateSrc = await readFile(join(process.cwd(), 'src', 'main', 'window-state.ts'), 'utf8');
+    assert.match(
+      windowStateSrc,
+      /export const SAFE_MIN_HEIGHT\s*=\s*320\b/,
+      'window-state.ts must export `SAFE_MIN_HEIGHT = 320` as the single source of truth for the minimum window height (shared by sanitizeBounds + BrowserWindow minHeight)',
+    );
+  });
+
   for (const host of FORBIDDEN_DRAG_HOSTS) {
     it(`'${host}' selector does NOT carry -webkit-app-region: drag (would steal OS resize hit area)`, async () => {
       const stylesSources = [

--- a/apps/desktop/src/main/__tests__/browser-panel-layout.test.ts
+++ b/apps/desktop/src/main/__tests__/browser-panel-layout.test.ts
@@ -43,9 +43,17 @@ function narrowBrowserMinHeights(css: string): MinHeightDecl[] {
     atRule.walkRules((rule) => {
       if (!rule.selectors.includes('.maka-browser-panel')) return;
       for (const node of rule.nodes) {
-        if (node.type !== 'decl' || node.prop !== 'min-height') continue;
+        if (node.type !== 'decl') continue;
         const d = node as postcss.Declaration;
-        decls.push({ value: d.value.trim(), important: Boolean(d.important) });
+        if (d.prop.toLowerCase() === 'min-height') {
+          decls.push({ value: d.value.trim(), important: Boolean(d.important) });
+        } else if (d.prop.includes('\\')) {
+          // A CSS-escaped property name (e.g. `m\69n-height`) decodes to
+          // `min-height` in the browser while PostCSS preserves the escape;
+          // count it as a competing declaration so the length===1 guard
+          // fails closed (#824 Codex review).
+          decls.push({ value: '<escaped-prop>', important: Boolean(d.important) });
+        }
       }
     });
   });
@@ -68,9 +76,190 @@ describe('BrowserPanel narrow layout CSS contract', () => {
     assert.equal(narrowBrowserMinHeights(block('.maka-browser-panel{min-height:220px}.maka-browser-panel{min-height:0}')).length, 2);
     // a duplicate property within one rule -> two entries (the guard fails)
     assert.equal(narrowBrowserMinHeights(block('.maka-browser-panel{min-height:220px;min-height:0}')).length, 2);
+    // a case-variant duplicate (MIN-HEIGHT) -> CSS property names are case-insensitive in the browser (PostCSS preserves source case) -> two entries (the guard fails)
+    assert.equal(narrowBrowserMinHeights(block('.maka-browser-panel{min-height:220px;MIN-HEIGHT:0}')).length, 2);
+    // a CSS-escaped property name (m\69n-height decodes to min-height in the browser; PostCSS preserves the escape) -> counted as competing -> two entries (the guard fails)
+    assert.equal(narrowBrowserMinHeights(block('.maka-browser-panel{min-height:220px;m\\69n-height:0}')).length, 2);
     // a !important -> recorded with the flag (the integration important===false guard fails)
     assert.equal(narrowBrowserMinHeights(block('.maka-browser-panel{min-height:220px !important}'))[0].important, true);
     // removal -> zero entries (the guard fails)
     assert.equal(narrowBrowserMinHeights(block('.maka-browser-panel{width:100%}')).length, 0);
+  });
+});
+
+/** The exact two selectors of the #824 both-present rule, whitespace-
+ *  normalized + sorted so formatting drift doesn't break the contract. The
+ *  shape is locked by STRING EQUALITY against these (not by regex), so any
+ *  change to the `:has()` scope — removing the non-collapsed guard, wrapping
+ *  a `:has()` in `:not()`, adding a selector-list inside `:has()`, reordering
+ *  the `:has()` args, dropping a `:has()`, targeting a different panel —
+ *  breaks the equality and the contract fails closed. No regex-substring
+ *  bypass surface. */
+const BOTH_PRESENT_SELECTORS = [
+  '.maka-detail-with-artifacts:has(.maka-browser-panel):has(.maka-artifact-pane:not([data-collapsed="true"])) .maka-artifact-pane',
+  '.maka-detail-with-artifacts:has(.maka-browser-panel):has(.maka-artifact-pane:not([data-collapsed="true"])) .maka-browser-panel',
+].map((s) => s.replace(/\s+/g, ' ').trim()).sort();
+
+interface BothPresentCandidate {
+  /** Selectors of the rule, whitespace-normalized + sorted. */
+  selectors: string[];
+  /** Every `min-height` value on the rule (property name matched
+   *  case-insensitively — CSS property names are case-insensitive in the
+   *  browser while PostCSS preserves source case), in source order. */
+  minHeights: string[];
+  /** True if any declaration on the rule uses a CSS-escaped property name
+   *  (e.g. `m\69n-height`), which the browser decodes to `min-height` while
+   *  PostCSS preserves the escape — could override without being collected.
+   *  The test fails closed if any panel-targeting rule sets this. */
+  escapedProp: boolean;
+}
+
+/** Count rules inside a `@media (max-width: 990px)` block (at-rule name +
+ *  media params matched ASCII-case-insensitively — CSS at-rules + media
+ *  keywords are case-insensitive, so `@MEDIA (MAX-WIDTH: 990px)` is the same
+ *  query) that use `:has()` (ASCII-case-insensitively, so `:HAS(` counts) OR
+ *  a CSS-escaped selector (e.g. `:h\61s(` decodes to `:has(` — fail closed on
+ *  any backslash in a selector rather than decoding escapes) AND declare a
+ *  `min-height` (case-insensitive prop) OR a CSS-escaped property name.
+ *  Independent of the panel-ending filter so a same-specificity competitor in
+ *  a different target form (`:is(.maka-browser-panel)`) is still counted. The
+ *  both-present rule is the only such rule in the real CSS, so the contract
+ *  asserts this count === 1. Pure over a CSS string. */
+function countHasScopedMinHeightRules(css: string): number {
+  const root = postcss.parse(stripCssComments(css), { from: CHAT_DETAIL_CSS });
+  let count = 0;
+  root.walkAtRules((atRule) => {
+    if (atRule.name.toLowerCase() !== 'media') return;
+    if (!/^\(\s*max-width\s*:\s*990px\s*\)$/i.test(atRule.params)) return;
+    atRule.walkRules((rule) => {
+      const scoped = rule.selectors.some((s) => s.toLowerCase().includes(':has(') || s.includes('\\'));
+      if (!scoped) return;
+      if (rule.nodes.some((n): n is postcss.Declaration => n.type === 'decl' && (n.prop.toLowerCase() === 'min-height' || n.prop.includes('\\')))) count++;
+    });
+  });
+  return count;
+}
+
+/** Rules inside `@media (max-width: 990px)` that target a descendant
+ *  `.maka-browser-panel` / `.maka-artifact-pane`. Identification is loose
+ *  (panel-targeting); the test locks the exact both-present selectors + value
+ *  + single-declaration + no-escaped-prop by string equality + counts; the
+ *  single-:has-scoped-min-height-rule guard is the independent
+ *  `countHasScopedMinHeightRules` (not pre-filtered by the panel-ending regex,
+ *  so it catches `:is()` target + `:HAS()` case-variant competitors). This
+ *  does NOT model the CSS cascade, so a higher-specificity override (e.g. an
+ *  #id rule) or an `all:initial` reset could still win — verifying the
+ *  cascade-effective computed value is the job of the #819 computed-style
+ *  fixture (the reliable layer per the #824 Codex review). Pure over a CSS
+ *  string so the collection logic is unit-testable. */
+function bothPresentCandidates(css: string): BothPresentCandidate[] {
+  const norm = (s: string) => s.replace(/\s+/g, ' ').trim();
+  const root = postcss.parse(stripCssComments(css), { from: CHAT_DETAIL_CSS });
+  const out: BothPresentCandidate[] = [];
+  root.walkAtRules('media', (atRule) => {
+    if (!/^\(\s*max-width\s*:\s*990px\s*\)$/.test(atRule.params)) return;
+    atRule.walkRules((rule) => {
+      if (!rule.selectors.some((s) => /\.maka-(browser-panel|artifact-pane)\s*$/.test(s))) return;
+      const minHeights = rule.nodes
+        .filter((n): n is postcss.Declaration => n.type === 'decl' && n.prop.toLowerCase() === 'min-height')
+        .map((d) => d.value.trim());
+      const escapedProp = rule.nodes.some((n): n is postcss.Declaration => n.type === 'decl' && n.prop.includes('\\'));
+      out.push({ selectors: rule.selectors.map(norm).sort(), minHeights, escapedProp });
+    });
+  });
+  return out;
+}
+
+describe('both-present shared-height CSS contract (#824)', () => {
+  it('is exactly one rule with the exact both-present selectors and min-height: min(22dvh, 220px)', async () => {
+    const css = await readFile(CHAT_DETAIL_CSS, 'utf8');
+    const candidates = bothPresentCandidates(css);
+    const matching = candidates.filter(
+      (c) => c.selectors.length === BOTH_PRESENT_SELECTORS.length && c.selectors.every((s, i) => s === BOTH_PRESENT_SELECTORS[i]),
+    );
+    assert.equal(matching.length, 1, 'expected exactly one rule in the 990px block with the exact both-present selectors (a second rule with the same selectors would make the cascade-effective min-height ambiguous)');
+    assert.equal(matching[0]!.minHeights.length, 1, 'expected exactly one min-height declaration on the both-present rule (a duplicate, including a case variant like MIN-HEIGHT, would win the cascade)');
+    assert.equal(matching[0]!.minHeights[0], 'min(22dvh, 220px)', 'expected min-height: min(22dvh, 220px) — shrink below 220px at short heights, never grow above 220px at tall heights (>=1000px tall unchanged)');
+    // #824 Codex review: fail closed on CSS-escaped property names — an
+    // escaped prop (e.g. `m\69n-height`) decodes to `min-height` in the
+    // browser while PostCSS preserves the escape, so it could override
+    // without being collected. No panel-targeting rule may use one.
+    assert.ok(candidates.every((c) => !c.escapedProp), 'no panel-targeting rule in the 990px block may use a CSS-escaped property name (could override min-height without being collected)');
+    // #824 Codex review: exactly one :has()-scoped rule with a min-height in
+    // the 990px block — counted independently of the panel-ending filter so a
+    // same-specificity competitor in a different target form (`:is(.maka-
+    // browser-panel)`) or a `:HAS()` case variant is still caught. A second
+    // such rule with a competing min-height would win the cascade (same
+    // specificity, later source order) while its different selector string
+    // keeps it out of `matching`. Higher-specificity overrides (e.g. #id) and
+    // `all:initial` resets are beyond a text contract and belong to the #819
+    // computed-style fixture (the reliable cascade verification).
+    assert.equal(countHasScopedMinHeightRules(css), 1, 'expected exactly one :has()-scoped rule with a min-height in the 990px block (a same-specificity competitor could override the cascade-effective value)');
+  });
+
+  it('collects candidates so the guard catches a second rule, a duplicate / case-variant declaration, a changed selector shape, a wrong value, or removal', () => {
+    const block = (rule: string) => `@media (max-width: 990px){${rule}}`;
+    const cond = ':has(.maka-browser-panel):has(.maka-artifact-pane:not([data-collapsed="true"]))';
+    const selectors = (c: string) => `.maka-detail-with-artifacts${c} .maka-browser-panel,.maka-detail-with-artifacts${c} .maka-artifact-pane`;
+    const rule = (body: string) => `${selectors(cond)}{${body}}`;
+    const matching = (css: string) =>
+      bothPresentCandidates(css).filter(
+        (c) => c.selectors.length === BOTH_PRESENT_SELECTORS.length && c.selectors.every((s, i) => s === BOTH_PRESENT_SELECTORS[i]),
+      );
+
+    // clean -> one matching candidate, one min-height, exact value
+    const ok = matching(block(rule('min-height:min(22dvh, 220px)')));
+    assert.equal(ok.length, 1);
+    assert.equal(ok[0]!.minHeights.length, 1);
+    assert.equal(ok[0]!.minHeights[0], 'min(22dvh, 220px)');
+
+    // a second rule with the same selectors -> two matching candidates
+    // (the integration length===1 guard fails; the cascade-effective value is ambiguous)
+    assert.equal(matching(block(rule('min-height:min(22dvh, 220px)') + rule('min-height:0'))).length, 2);
+
+    // a within-rule duplicate (last declaration wins the cascade) -> one candidate, 2 min-heights
+    const dup = matching(block(rule('min-height:min(22dvh, 220px);min-height:0')));
+    assert.equal(dup.length, 1);
+    assert.equal(dup[0]!.minHeights.length, 2);
+
+    // a case-variant duplicate (MIN-HEIGHT) -> browser treats as the same property -> 2 min-heights
+    const caseDup = matching(block(rule('min-height:min(22dvh, 220px);MIN-HEIGHT:0')));
+    assert.equal(caseDup.length, 1);
+    assert.equal(caseDup[0]!.minHeights.length, 2);
+    // a CSS-escaped property name (m\69n-height -> min-height in the browser) -> escapedProp flag set (the integration no-escapedProp guard fails)
+    assert.equal(bothPresentCandidates(block(rule('min-height:min(22dvh, 220px);m\\69n-height:0'))).some((c) => c.escapedProp), true);
+    // a reordered-:has() competitor (same specificity, later source order wins) -> two :has-scoped min-height rules (the integration count===1 guard fails)
+    const reorderedCond = ':has(.maka-artifact-pane:not([data-collapsed="true"])):has(.maka-browser-panel)';
+    assert.equal(countHasScopedMinHeightRules(block(rule('min-height:min(22dvh, 220px)') + `${selectors(reorderedCond)}{min-height:0}`)), 2);
+    // a :is() target form competitor (same specificity, not a panel-ending literal) -> counted by the independent counter (count===2)
+    const isTarget = `.maka-detail-with-artifacts${cond} :is(.maka-browser-panel),.maka-detail-with-artifacts${cond} :is(.maka-artifact-pane)`;
+    assert.equal(countHasScopedMinHeightRules(block(rule('min-height:min(22dvh, 220px)') + `${isTarget}{min-height:0}`)), 2);
+    // a :HAS() case-variant competitor (CSS pseudo-classes are case-insensitive) -> counted (count===2)
+    const upperHas = ':HAS(.maka-browser-panel):HAS(.maka-artifact-pane:not([data-collapsed="true"]))';
+    assert.equal(countHasScopedMinHeightRules(block(rule('min-height:min(22dvh, 220px)') + `${selectors(upperHas)}{min-height:0}`)), 2);
+    // a :h\61s() escaped-:has competitor (decodes to :has in the browser; source has no literal `:has(`) -> fail closed on the backslash -> counted (count===2)
+    const escapedHas = ':h\\61s(.maka-browser-panel):h\\61s(.maka-artifact-pane:not([data-collapsed="true"]))';
+    assert.equal(countHasScopedMinHeightRules(block(rule('min-height:min(22dvh, 220px)') + `${selectors(escapedHas)}{min-height:0}`)), 2);
+    // a @MEDIA (MAX-WIDTH: 990px) case-variant media competitor (same query; at-rule name + media keywords are case-insensitive) -> counted (count===2)
+    assert.equal(countHasScopedMinHeightRules(`@MEDIA (MAX-WIDTH: 990px){${rule('min-height:min(22dvh, 220px)')}${selectors(cond)}{min-height:0}}`), 2);
+
+    // changed selector shapes (negated guard / collapsed-condition / mixed
+    // :has() selector-list / missing :not guard) -> selectors != expected -> 0 matching
+    const negated = ':has(.maka-browser-panel):not(:has(.maka-artifact-pane:not([data-collapsed="true"])))';
+    assert.equal(matching(block(`${selectors(negated)}{min-height:min(22dvh, 220px)}`)).length, 0);
+    const collapsedCond = ':has(.maka-browser-panel):has(.maka-artifact-pane[data-collapsed="true"])';
+    assert.equal(matching(block(`${selectors(collapsedCond)}{min-height:min(22dvh, 220px)}`)).length, 0);
+    const mixedCond = ':has(.maka-browser-panel):has(.maka-artifact-pane:not([data-collapsed="true"]), .maka-artifact-pane[data-collapsed="true"])';
+    assert.equal(matching(block(`${selectors(mixedCond)}{min-height:min(22dvh, 220px)}`)).length, 0);
+    const noGuard = ':has(.maka-browser-panel):has(.maka-artifact-pane)';
+    assert.equal(matching(block(`${selectors(noGuard)}{min-height:min(22dvh, 220px)}`)).length, 0);
+
+    // a wrong value -> matched selectors but the exact-value integration guard fails
+    const bare = matching(block(rule('min-height:22dvh')));
+    assert.equal(bare.length, 1);
+    assert.notEqual(bare[0]!.minHeights[0], 'min(22dvh, 220px)');
+
+    // removal -> 0 matching
+    assert.equal(matching(block('')).length, 0);
   });
 });

--- a/apps/desktop/src/main/main-window.ts
+++ b/apps/desktop/src/main/main-window.ts
@@ -4,7 +4,7 @@ import { join } from 'node:path';
 import type { AppSettings } from '@maka/core';
 import { isExternalUrl } from './external-link-guard.js';
 import { errorMessage } from './chat-readiness.js';
-import { readSavedBounds, writeSavedBounds, type SavedBounds } from './window-state.js';
+import { readSavedBounds, writeSavedBounds, SAFE_MIN_HEIGHT, SAFE_MIN_WIDTH, type SavedBounds } from './window-state.js';
 import { BrowserViewController } from './browser/controller.js';
 import { BrowserViewManager } from './browser/view-manager.js';
 import type { VisualSmokeFixture } from './visual-smoke-fixture.js';
@@ -215,6 +215,12 @@ export function createMainWindowController(deps: MainWindowControllerDeps): Main
       // (see `app-region-hygiene-contract.test.ts`) cover the
       // renderer side of the same gate.
       resizable: true,
+      // #824: enforce the sanitizeBounds restore floor at runtime resize too,
+      // so the both-present dvh layout fix can't be defeated by dragging the
+      // window shorter than the 320px restore minimum. Shares SAFE_MIN_HEIGHT
+      // with sanitizeBounds so the resize floor and the restore floor can't
+      // drift apart (locked by app-region-hygiene-contract.test.ts).
+      minHeight: SAFE_MIN_HEIGHT,
       backgroundColor: initialBg,
       // PR-SHOW-AFTER-FIRST-COMMIT: create hidden on every run so the OS never
       // flashes the index.html `.maka-preload` skeleton before React paints.
@@ -476,8 +482,8 @@ function visualSmokeWindowBounds(
   if (
     Number.isFinite(width) &&
     Number.isFinite(height) &&
-    width >= 480 &&
-    height >= 320
+    width >= SAFE_MIN_WIDTH &&
+    height >= SAFE_MIN_HEIGHT
   ) {
     return { width: Math.floor(width), height: Math.floor(height) };
   }

--- a/apps/desktop/src/main/window-state.ts
+++ b/apps/desktop/src/main/window-state.ts
@@ -29,6 +29,14 @@ export interface DefaultBounds {
 }
 
 /**
+ * The minimum sensible window size, enforced both at restore (sanitizeBounds)
+ * and at runtime resize (BrowserWindow minHeight). Centralized so the restore
+ * floor and the resize floor can't drift apart (#824).
+ */
+export const SAFE_MIN_WIDTH = 480;
+export const SAFE_MIN_HEIGHT = 320;
+
+/**
  * Pure sanitization for restored bounds. Returns either valid bounds or the
  * provided defaults — no half-applied state.
  *
@@ -43,8 +51,8 @@ export function sanitizeBounds(
 ): SavedBounds {
   if (!candidate || typeof candidate !== 'object') return defaults;
   const c = candidate as Record<string, unknown>;
-  const width = typeof c.width === 'number' && c.width >= 480 ? Math.floor(c.width) : null;
-  const height = typeof c.height === 'number' && c.height >= 320 ? Math.floor(c.height) : null;
+  const width = typeof c.width === 'number' && c.width >= SAFE_MIN_WIDTH ? Math.floor(c.width) : null;
+  const height = typeof c.height === 'number' && c.height >= SAFE_MIN_HEIGHT ? Math.floor(c.height) : null;
   if (width === null || height === null) return defaults;
 
   const out: SavedBounds = { width, height };

--- a/apps/desktop/src/renderer/styles/chat-detail.css
+++ b/apps/desktop/src/renderer/styles/chat-detail.css
@@ -647,9 +647,10 @@
    so it already occupies the explicit `auto` row; ArtifactPane as the third
    child uses an implicit `auto` row (grid-auto-rows defaults to auto), so no
    extra explicit row is needed. With both auxiliary panels open on a very
-   short window the chat row can collapse (two 220px minima); a shared-height
-   policy is tracked in #824, and recovery may require closing the browser
-   and/or collapsing ArtifactPane. */
+   short window the two 220px minima would squeeze the chat row to 0; the
+   both-present shared-height rule below (#824) scales each panel to a dvh
+   slice so the chat row keeps a usable remainder down to the 320px restore
+   minimum. */
 @media (max-width: 990px) {
   .maka-detail-with-artifacts {
     display: grid;
@@ -679,6 +680,32 @@
     min-height: 34px;
     max-height: 34px;
     grid-template-rows: auto;
+  }
+
+  /* #824: both auxiliary panels present at narrow width — scale each
+     panel's min-height to min(22dvh, 220px) so the chat row keeps the
+     remainder instead of two fixed 220px minima squeezing `minmax(0, 1fr)`
+     to 0. The chat row becomes 56% of the content viewport (1 - 2x22dvh),
+     so the composer (~164px + 8px margin) stays usable while the content
+     viewport is >=~307px. min(22dvh, 220px) shrinks below 220px at short
+     heights and never grows above 220px at tall heights, so >=1000px tall
+     (where 22dvh == 220px) is unchanged; below that the panels yield
+     proportionally. Single-panel (or a collapsed ArtifactPane) keeps the
+     fixed 220px / 34px floor above, so this rule scopes to both-present
+     via :has() and skips the collapsed artifact. BrowserWindow minHeight
+     (SAFE_MIN_HEIGHT = 320) enforces the 320px WINDOW floor aligned with
+     the sanitizeBounds restore floor; on macOS (hiddenInset titlebar) the
+     content viewport ~= the window, so the composer-usable floor is
+     ~320px, while on Windows (titleBarOverlay) and Linux (default frame)
+     the frame reduces the content viewport, so the effective floor is a
+     slightly larger window. That window-vs-content gap is the pre-existing
+     relationship inherited from sanitizeBounds; a content-size-semantic
+     migration is out of scope. Recovery (close browser / collapse
+     artifact) stays reachable because each panel's toolbar sits at the
+     top of a non-zero-height row. */
+  .maka-detail-with-artifacts:has(.maka-browser-panel):has(.maka-artifact-pane:not([data-collapsed="true"])) .maka-browser-panel,
+  .maka-detail-with-artifacts:has(.maka-browser-panel):has(.maka-artifact-pane:not([data-collapsed="true"])) .maka-artifact-pane {
+    min-height: min(22dvh, 220px);
   }
 
   .maka-artifact-list {


### PR DESCRIPTION
## Summary

- At `<=990px`, when both BrowserPanel and a non-collapsed ArtifactPane are open, scale each auxiliary panel's `min-height` to `min(22dvh, 220px)` (via a `:has()`-scoped rule) so the chat row keeps 56% of the content viewport instead of being squeezed to 0 by two fixed 220px minima.
- Enforce the 320px window floor at runtime via `BrowserWindow minHeight: SAFE_MIN_HEIGHT`, extracting `SAFE_MIN_WIDTH` / `SAFE_MIN_HEIGHT` from `window-state.ts` so the resize floor and the sanitizeBounds restore floor share one source of truth.
- Lock both with CSS source contracts.

## Why

Closes #824. At `<=990px` both ArtifactPane and BrowserPanel become bottom sheets, each with a fixed `min-height: 220px` (from #818). When both are open and the detail area is short (`<=~440px`), the two fixed minima squeeze the chat row `minmax(0, 1fr)` to 0 and the composer is clipped. The 320px restore minimum in `window-state.ts` was restore-only and `BrowserWindow` set no `minHeight`, so runtime drag could go shorter. #818's own comment flagged this edge and tracked the shared-height policy in #824.

## Scope

- In scope: the both-present + short-window case at `<=990px`; aligning the BrowserWindow runtime height floor with the sanitizeBounds restore floor.
- Out of scope: the single-panel narrow case (#818); the `<=990px` breakpoint; the bottom-sheet pattern; `minWidth` enforcement (width isn't the clip cause — `minWidth` coherence with sanitizeBounds is a separate follow-up); a `useContentSize` migration (the window-vs-content frame relationship is pre-existing, see Verification).

## Verification

- TDD: both-present shared-height contract + BrowserWindow minHeight contract each written RED first, then GREEN. 4/4 in `browser-panel-layout.test.ts`; 13/13 in `app-region-hygiene-contract.test.ts`; 7/7 in `window-state.test.ts`.
- `npm --workspace @maka/desktop run typecheck` (main + renderer + storybook) — pass.
- `npm --workspace @maka/desktop test` (full main suite) — 2354/2354 pass.
- No visual-smoke baseline impact: the `:has()` rule fires only when both BrowserPanel and a non-collapsed ArtifactPane are present, and no existing fixture seeds a browser panel (the browser fixture is #819). So the rule never applies in any current fixture; `artifact-pane` / `artifact-errors` / `artifact-preview-*` narrow baselines are unchanged. The screenshots are 820px tall × 990/1280 wide, all above the 320px `minHeight`, so the window floor doesn't affect them either.
- Visual evidence (screenshot/CDP of the both-present state) is not applicable here because no fixture triggers the rule yet; the substitute evidence is the CSS source contract (locks the rule's exact selector + value + collapsed guard + single-declaration) plus the dvh math below.
- dvh math: the chat row becomes 56% of the content viewport (`1 - 2×22dvh`), so the composer (~164px + 8px margin) stays usable while the content viewport is `>=~307px` (`172 / 0.56`). `min(22dvh, 220px)` shrinks below 220px below 1000px tall and caps at 220px above (so `>=1000px` tall both-present is unchanged); at the 320px window floor the panels are ~70px each (toolbar + thin strip), recovery buttons reachable.
- **Platform floor (honest):** `minHeight: SAFE_MIN_HEIGHT` (320) enforces the 320px WINDOW floor. On macOS (`hiddenInset` titlebar) the content viewport ≈ window, so the composer-usable floor is ~320px. On Windows (`titleBarOverlay` ~30px) and Linux (default frame ~35px) the frame reduces the content viewport, so the effective composer-usable floor is a slightly larger window (~335px). This window-vs-content gap is the pre-existing relationship inherited from `sanitizeBounds` (a 320px window was never a 320px content viewport on Windows/Linux); a `useContentSize` migration that would let the floor be expressed in content terms is out of #824 scope. The fix is a net improvement on all platforms (from chat-row-0 at `<~440px` to chat-row-56%-of-content, usable at content `>=~301px`).

## Impact

- User-visible: at narrow width (`<=990px`) with both auxiliary panels open, short windows no longer clip the composer; the panels shrink proportionally instead. Normal-height and tall windows are unchanged (`min(22dvh, 220px)` == 220px at `>=1000px` tall). The window can no longer be dragged below 320px tall (aligned with the restore floor).
- Compatibility / migration: `sanitizeBounds` still accepts 320px-tall windows at restore (unchanged); `BrowserWindow` now enforces 320px-tall at resize. Existing saved windows `>=320px` tall are unaffected.
- Release note: "Fixed the composer being clipped when both the artifact pane and browser are open in a short, narrow window."

## Reviewer notes

- Why `:has()` over unconditional dvh: unconditional `min-height: min(22dvh, 220px)` on both panels would change the single-panel `artifact-pane` narrow baselines (220px → 180px at the 820px screenshot height). The `:has()`-scoped rule changes only the both-present case (no existing fixture) and leaves single-panel untouched.
- Why dvh-budget over a composer min-height floor: a `minmax(composer-min, 1fr)` chat-row floor would push overflow into the auxiliary rows, clipping the ArtifactPane collapse button (~220px down) and breaking the recovery path #824 noted. The dvh-budget makes the panels yield, keeping both panels + the composer visible and recovery reachable.
- Why `min(22dvh, 220px)` over bare `22dvh`: bare `22dvh` grows above 220px at tall windows (264px at 1200px, 352px at 1600px) and would exceed the `max-height: 360px` cap (min-height wins over max-height in conflict) — a tall-window regression. `min(22dvh, 220px)` caps at 220px so `>=1000px` tall is unchanged.
- Why `minHeight: SAFE_MIN_HEIGHT` (320) and not a higher platform-aware value: 320 is the sanitizeBounds restore floor (the owner of the minimum-size contract); aligning the runtime floor to it is the non-duplicate owner-level fix. A higher platform-specific magic number would decouple from sanitizeBounds and change restore behavior. The residual Windows/Linux content gap at the 320px window floor is the pre-existing frame relationship, documented in the CSS comment, not a #824-introduced regression.
- Specificity: the `:has()` compound selector (≈0,5,0) outranks the base `.maka-browser-panel` / `.maka-artifact-pane` rules (0,1,0), so `min-height: min(22dvh, 220px)` wins when both present; the existing `min-height: 220px` exact-selector contract still passes because the `:has()` selector is compound, not bare.
- Contract rigor (text layer): the both-present contract locks the rule's exact two selectors (whitespace-normalized + sorted, string equality — fail-closed for any selector-shape change: removed/wrapped `:has()`, collapsed-condition leak, mixed selector-list, reordering, wrong target), the exact `min(22dvh, 220px)` value, exactly one `min-height` declaration (case-insensitive prop match — catches `MIN-HEIGHT`), no CSS-escaped property name (catches `m\69n-height`), and exactly one `:has()`-scoped panel-targeting min-height rule (catches a same-specificity reordered-`:has()` competitor). The `narrowBrowserMinHeights` (#818) helper is also case-insensitive + escape-fail-closed. This text contract does NOT model the CSS cascade, so a higher-specificity override (e.g. an `#id` rule) or an `all:initial` reset could still win — verifying the cascade-effective computed value is the job of the #819 computed-style fixture (the reliable layer per the Codex review).

## Ready for review

- [x] Verification is complete and the results above are current
- [x] Impact, compatibility, migration, documentation, and release-note needs are addressed
- [x] User-visible UI/UX changes include visual evidence, or `Verification` explains why it is not applicable