### PR TITLE
refactor(ui): move section routing out of ChatView

### DIFF
--- a/apps/desktop/src/main/__tests__/attachment-frontend-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/attachment-frontend-contract.test.ts
@@ -125,7 +125,6 @@ describe('attachment frontend contract', () => {
     const markup = renderToStaticMarkup(createElement(ChatView, {
       messages,
       activeSession,
-      mode: 'sessions',
       onNew: () => {},
     } satisfies Parameters<typeof ChatView>[0]));
 

--- a/apps/desktop/src/main/__tests__/capability-audit-ui-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/capability-audit-ui-contract.test.ts
@@ -78,23 +78,23 @@ describe('capability audit visible system contract', () => {
     assert.notEqual(report.skills[0].permissionMode, 'execute');
   });
 
-  it('wires ChatView through a single derived audit report for Skills and Automations', async () => {
-    const components = await readFile(join(repoRoot, 'packages', 'ui', 'src', 'chat-view.tsx'), 'utf8');
+  it('derives capability audit reports at the Skills and Automations page boundaries', async () => {
+    const components = await readFile(join(repoRoot, 'packages', 'ui', 'src', 'module-pages.tsx'), 'utf8');
 
     assert.match(
       components,
-      /const capabilityAuditReport = useMemo\([\s\S]*deriveCapabilityAuditReport\(\{[\s\S]*skills: props\.skills \?\? \[\],[\s\S]*planReminders: props\.planReminders \?\? \[\],[\s\S]*\}\)/,
-      'ChatView must derive the capability audit report from the same skills and plan-reminder snapshots',
+      /function SkillsPage[\s\S]*deriveCapabilityAuditReport\(\{[\s\S]*skills: props\.skills \?\? \[\],[\s\S]*planReminders: props\.planReminders \?\? \[\]/,
+      'SkillsPage must derive its report from the same skills and plan-reminder snapshots',
     );
     assert.match(
       components,
-      /<SkillsModuleMain[\s\S]*auditReport=\{capabilityAuditReport\}/,
-      'Skills module must receive the shared capability audit report',
+      /<SkillsModuleMain \{\.\.\.props\} auditReport=\{auditReport\}/,
+      'Skills module must receive the page report',
     );
     assert.match(
       components,
-      /<PlanReminderPanel[\s\S]*auditReport=\{capabilityAuditReport\}/,
-      'Automations module must receive the shared capability audit report',
+      /<PlanReminderPanel \{\.\.\.props\} reminders=\{props\.reminders \?\? \[\]\} auditReport=\{auditReport\}/,
+      'Automations module must receive the page report',
     );
   });
 

--- a/apps/desktop/src/main/__tests__/daily-review-copy-feedback-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/daily-review-copy-feedback-contract.test.ts
@@ -16,7 +16,7 @@ function blockBetween(source: string, start: string, end: string): string {
 describe('Daily Review copy feedback contract', () => {
   it('lets the app shell own clipboard success and failure feedback', async () => {
     const ui = await readFile(resolve(REPO_ROOT, 'packages/ui/src/daily-review-panel.tsx'), 'utf8');
-    const chatView = await readFile(resolve(REPO_ROOT, 'packages/ui/src/chat-view.tsx'), 'utf8');
+    const modulePages = await readFile(resolve(REPO_ROOT, 'packages/ui/src/module-pages.tsx'), 'utf8');
     const main = await readRendererShellSources([
       'daily-review-actions.ts',
       'app-shell-daily-review-actions.ts',
@@ -24,14 +24,14 @@ describe('Daily Review copy feedback contract', () => {
       'app-shell.tsx',
     ]);
 
-    assert.match(chatView, /onCopyDailyReviewMarkdown\?: \(input:/);
-    assert.match(chatView, /onCopyMarkdown=\{props\.onCopyDailyReviewMarkdown\}/);
+    assert.match(modulePages, /onCopyMarkdown\?: \(input:/);
+    assert.match(modulePages, /<DailyReviewPanel \{\.\.\.props\} bridge=\{props\.bridge\}/);
     assert.match(ui, /onCopyMarkdown\?: \(input:/);
     assert.match(ui, /props\.onCopyMarkdown\?\.\(\{\s*markdown:\s*md,\s*label:\s*dayLabel,\s*summary: visibleSummary\s*\}\)/);
     assert.match(ui, /const hasDailyReviewActions = Boolean\(props\.onCopyMarkdown \|\| props\.onAppendMarkdown \|\| props\.onSaveMarkdown\)/);
     assert.match(ui, /visibleSummary && visibleSummary\.totals\.sessionCount \+ visibleSummary\.totals\.requestCount > 0 && hasDailyReviewActions/);
     assert.doesNotMatch(ui, /navigator\.clipboard\.writeText\(md\)\.catch\(\(\) => \{\}\)/);
-    assert.match(main, /onCopyDailyReviewMarkdown=\{\(input\) => copyDailyReviewMarkdown\(input, \{ shouldShowFeedback: isDailyReviewSurfaceActive \}\)\}/);
+    assert.match(main, /onCopyMarkdown=\{\(input\) => copyDailyReviewMarkdown\(input, \{ shouldShowFeedback: isDailyReviewSurfaceActive \}\)\}/);
     assert.match(main, /async function copyDailyReviewMarkdown\([\s\S]*?await navigator\.clipboard\.writeText\(input\.markdown\)/);
     assert.match(
       main,
@@ -75,16 +75,16 @@ describe('Daily Review copy feedback contract', () => {
 
   it('lets the Daily Review main panel append the current range to the composer', async () => {
     const ui = await readFile(resolve(REPO_ROOT, 'packages/ui/src/daily-review-panel.tsx'), 'utf8');
-    const chatView = await readFile(resolve(REPO_ROOT, 'packages/ui/src/chat-view.tsx'), 'utf8');
+    const modulePages = await readFile(resolve(REPO_ROOT, 'packages/ui/src/module-pages.tsx'), 'utf8');
     const main = await readRendererShellCombinedSource();
     const panelBlock = extractFunctionBlock(ui, 'DailyReviewPanel');
     const appendBlock = main.match(/function appendDailyReviewMarkdown\(input: DailyReviewMarkdownInput\): void \{[\s\S]*?^\s*}/m)?.[0] ?? '';
 
-    assert.match(chatView, /onAppendDailyReviewMarkdown\?: \(input:/);
-    assert.match(chatView, /onAppendMarkdown=\{props\.onAppendDailyReviewMarkdown\}/);
+    assert.match(modulePages, /onAppendMarkdown\?: \(input:/);
+    assert.match(modulePages, /<DailyReviewPanel \{\.\.\.props\} bridge=\{props\.bridge\}/);
     assert.match(panelBlock, /props\.onAppendMarkdown\?\.\(\{\s*markdown:\s*md,\s*label:\s*dayLabel,\s*summary: visibleSummary\s*\}\)/);
     assert.match(panelBlock, /pendingDailyReviewAction === 'append' \? '追加中…' : '粘到输入框'/);
-    assert.match(main, /onAppendDailyReviewMarkdown=\{appendDailyReviewMarkdown\}/);
+    assert.match(main, /onAppendMarkdown=\{appendDailyReviewMarkdown\}/);
     assert.match(appendBlock, /composerRef\.current\?\.appendText\(input\.markdown\)/);
     assert.match(appendBlock, /toastApi\.success\(\s*`已追加\$\{input\.label\}回顾到输入框`/);
     assert.doesNotMatch(appendBlock, /composerRef\.current\?\.setText\(input\.markdown\)/);
@@ -144,12 +144,12 @@ describe('Daily Review copy feedback contract', () => {
     assert.match(panelBlock, /保存中…/);
     assert.doesNotMatch(
       main,
-      /onSaveDailyReviewMarkdown=\{\(input\) => void saveDailyReviewMarkdown\(input\)\}/,
+      /onSaveMarkdown=\{\(input\) => void saveDailyReviewMarkdown\(input\)\}/,
       'renderer must return the save Promise to the Daily Review pending gate',
     );
     assert.match(
       main,
-      /onSaveDailyReviewMarkdown=\{\(input\) => saveDailyReviewMarkdown\(input, \{ shouldShowFeedback: isDailyReviewSurfaceActive \}\)\}/,
+      /onSaveMarkdown=\{\(input\) => saveDailyReviewMarkdown\(input, \{ shouldShowFeedback: isDailyReviewSurfaceActive \}\)\}/,
       'Daily Review save feedback must be gated to the active Daily Review surface',
     );
   });

--- a/apps/desktop/src/main/__tests__/daily-review-export-file-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/daily-review-export-file-contract.test.ts
@@ -15,7 +15,7 @@ describe('Daily Review export-to-file contract (PR-DAILY-REVIEW-EXPORT-FILE-0)',
     const palette = await readFile(resolve(REPO_ROOT, 'apps/desktop/src/renderer/command-palette.tsx'), 'utf8');
     const renderer = await readRendererShellCombinedSource();
     const ui = await readFile(resolve(REPO_ROOT, 'packages/ui/src/daily-review-panel.tsx'), 'utf8');
-    const chatView = await readFile(resolve(REPO_ROOT, 'packages/ui/src/chat-view.tsx'), 'utf8');
+    const modulePages = await readFile(resolve(REPO_ROOT, 'packages/ui/src/module-pages.tsx'), 'utf8');
     const sessionListPanel = await readFile(resolve(REPO_ROOT, 'packages/ui/src/session-list-panel.tsx'), 'utf8');
     const css = await readRendererContractCss();
 
@@ -46,7 +46,7 @@ describe('Daily Review export-to-file contract (PR-DAILY-REVIEW-EXPORT-FILE-0)',
     // The main Daily Review panel exposes save next to copy, so export
     // is not hidden behind command palette muscle memory.
     assert.doesNotMatch(sessionListPanel, /onSaveDailyReviewMarkdown\?\(input:\s*DailyReviewMarkdownActionInput\)/);
-    assert.match(chatView, /onSaveMarkdown=\{props\.onSaveDailyReviewMarkdown\}/);
+    assert.match(modulePages, /onSaveMarkdown\?: \(input: DailyReviewMarkdownActionInput\)/);
     assert.match(ui, /maka-daily-review-save[\s\S]*保存/);
     assert.match(css, /\.maka-daily-review-actions/);
   });

--- a/apps/desktop/src/main/__tests__/renderer-lazy-fallback-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/renderer-lazy-fallback-contract.test.ts
@@ -7,7 +7,7 @@ const REPO_ROOT = resolve(import.meta.dirname, '../../../../..');
 const RENDERER_ROOT = resolve(REPO_ROOT, 'apps', 'desktop', 'src', 'renderer');
 const APP_SHELL_PATH = resolve(RENDERER_ROOT, 'app-shell.tsx');
 const APP_SHELL_OVERLAYS_PATH = resolve(RENDERER_ROOT, 'app-shell-overlays.tsx');
-const CHAT_VIEW_PATH = resolve(REPO_ROOT, 'packages', 'ui', 'src', 'chat-view.tsx');
+const MODULE_PAGES_PATH = resolve(REPO_ROOT, 'packages', 'ui', 'src', 'module-pages.tsx');
 
 describe('renderer lazy fallback contract', () => {
   it('keeps visible shell lazy chunks on compact non-null fallbacks', async () => {
@@ -48,13 +48,13 @@ describe('renderer lazy fallback contract', () => {
   });
 
   it('keeps module lazy chunks on compact non-null fallbacks', async () => {
-    const chatView = await readFile(CHAT_VIEW_PATH, 'utf8');
+    const modulePages = await readFile(MODULE_PAGES_PATH, 'utf8');
 
-    assert.match(chatView, /function ModulePageFallback/, 'whole-page modules must reserve a module loading shell');
-    assert.match(chatView, /function ModulePanelFallback/, 'daily review content must reserve a panel loading shell');
-    assert.match(chatView, /<Suspense fallback=\{<ModulePageFallback label="技能" message="正在加载技能…" \/>\}>/);
-    assert.match(chatView, /<Suspense fallback=\{<ModulePageFallback label="定时任务" message="正在加载定时任务…" \/>\}>/);
-    assert.match(chatView, /<Suspense fallback=\{<ModulePanelFallback message="正在加载每日回顾…" \/>\}>/);
-    assert.doesNotMatch(chatView, /<Suspense fallback=\{null\}>/);
+    assert.match(modulePages, /function ModulePageFallback/, 'whole-page modules must reserve a module loading shell');
+    assert.match(modulePages, /function ModulePanelFallback/, 'daily review content must reserve a panel loading shell');
+    assert.match(modulePages, /<Suspense fallback=\{<ModulePageFallback label="技能" message="正在加载技能…" \/>\}>/);
+    assert.match(modulePages, /<Suspense fallback=\{<ModulePageFallback label="定时任务" message="正在加载定时任务…" \/>\}>/);
+    assert.match(modulePages, /<Suspense fallback=\{<ModulePanelFallback message="正在加载每日回顾…" \/>\}>/);
+    assert.doesNotMatch(modulePages, /<Suspense fallback=\{null\}>/);
   });
 });

--- a/apps/desktop/src/main/__tests__/session-open-routing-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/session-open-routing-contract.test.ts
@@ -22,12 +22,12 @@ describe('session open routing contract', () => {
 
     assert.doesNotMatch(
       main,
-      /<ChatView[\s\S]*?onSelectSession=\{setActiveId\}/,
-      'Daily Review session buttons live inside ChatView module mode and must route back to the chat surface',
+      /<DailyReviewPage[\s\S]*?onSelectSession=\{setActiveId\}/,
+      'Daily Review session buttons must route back through the chat surface',
     );
     assert.match(
       main,
-      /<ChatView[\s\S]*?onSelectSession=\{openSessionInChat\}/,
+      /<DailyReviewPage[\s\S]*?onSelectSession=\{openSessionInChat\}/,
       'Daily Review session buttons must use the shell-level session open helper',
     );
   });

--- a/apps/desktop/src/main/__tests__/skills.test.ts
+++ b/apps/desktop/src/main/__tests__/skills.test.ts
@@ -1146,19 +1146,18 @@ name: Writer
     const repoRoot = process.cwd().endsWith('apps/desktop')
       ? join(process.cwd(), '..', '..')
       : process.cwd();
-    const chatViewSource = await readFile(join(repoRoot, 'packages/ui/src/chat-view.tsx'), 'utf8');
+    const modulePagesSource = await readFile(join(repoRoot, 'packages/ui/src/module-pages.tsx'), 'utf8');
     const ui = await readFile(join(repoRoot, 'packages/ui/src/skills-panel.tsx'), 'utf8');
     const modulePanelTypes = await readFile(join(repoRoot, 'packages/ui/src/module-panel-types.ts'), 'utf8');
     const workspaceResourcesIpc = await readFile(join(repoRoot, 'apps/desktop/src/main/workspace-resources-ipc-main.ts'), 'utf8');
     const emptyStateSource = await readFile(join(repoRoot, 'packages/ui/src/empty-state.tsx'), 'utf8');
     const renderer = await readRendererShellCombinedSource();
-    const chatView = chatViewSource.match(/export function ChatView\([\s\S]*?if \(props\.mode === 'automations'\)/)?.[0] ?? '';
     const skillsModuleMain = extractFunctionBlock(ui, 'SkillsModuleMain');
     const skillPanel = ui.match(/function SkillLibraryPanel[\s\S]*?function SkillsModuleMain/)?.[0] ?? '';
     const skillEntryContract = modulePanelTypes.match(/export interface SkillEntry[\s\S]*?\n}/)?.[0] ?? '';
     const emptyState = emptyStateSource;
 
-    assert.match(chatView, /if \(props\.mode === 'skills'\) \{[\s\S]*<SkillsModuleMain/, 'Skills mode must mount its own main surface component');
+    assert.match(modulePagesSource, /export function SkillsPage[\s\S]*<SkillsModuleMain/, 'SkillsPage must mount the skills main surface');
     assert.match(skillsModuleMain, /const \[pendingSkillAction, setPendingSkillAction\] = useState<string \| null>\(null\)/);
     assert.match(skillsModuleMain, /const skillActionMountedRef = useRef\(true\)/);
     assert.match(skillsModuleMain, /const pendingSkillActionRef = useRef<string \| null>\(null\)/);

--- a/apps/desktop/src/main/__tests__/streaming-handoff.test.ts
+++ b/apps/desktop/src/main/__tests__/streaming-handoff.test.ts
@@ -42,7 +42,6 @@ function renderLiveTurn(liveTurn: LiveTurnProjection): string {
     },
     messages: [{ type: 'user', id: 'user-1', turnId: liveTurn.turnId, ts: 1, text: 'go' }],
     liveTurn,
-    mode: 'sessions',
     onNew() {},
   } satisfies Parameters<typeof ChatView>[0]));
 }
@@ -94,7 +93,6 @@ describe('single live-turn handoff', () => {
           tools: [],
         }],
       },
-      mode: 'sessions',
       onNew() {},
     } satisfies Parameters<typeof ChatView>[0]));
 
@@ -123,7 +121,6 @@ describe('single live-turn handoff', () => {
           tools: [{ toolUseId: 'tool-1', toolName: 'Bash', stepId: 'assistant-1', status: 'running', args: {} }],
         }],
       },
-      mode: 'sessions',
       onNew() {},
     } satisfies Parameters<typeof ChatView>[0]));
 

--- a/apps/desktop/src/renderer/app-shell.tsx
+++ b/apps/desktop/src/renderer/app-shell.tsx
@@ -16,13 +16,16 @@ import { generalizedErrorMessageChinese, hasSettledInitialOnboarding, thinkingVa
 import {
   type ChatHeaderAlert,
   type ChatModelChoice,
+  AutomationsPage,
   ChatView,
   Composer,
+  DailyReviewPage,
   type ComposerHandle,
   type MakaUriDest,
   MakaUriContext,
   type NavSelection,
   SessionListPanel,
+  SkillsPage,
   type ManagedSkillSourceEntry,
   type SessionViewMode,
   type SkillEntry,
@@ -1548,6 +1551,45 @@ export function AppShell({
           <MakaUriContext.Provider value={dispatchMakaUri}>
           <div className="maka-detail-with-artifacts">
             <div className="mainColumn" data-home-surface={homeSurfaceActive ? 'true' : undefined}>
+              {navSelection.section === 'skills' ? (
+                <SkillsPage
+                  skills={skills}
+                  planReminders={planReminders}
+                  onRefreshSkills={() => refreshSkills()}
+                  onRefreshManagedSkillSources={() => refreshManagedSkillSources()}
+                  onCreateSkillTemplate={() => createSkillTemplate()}
+                  onOpenSkill={(skillId) => openSkill(skillId)}
+                  onUseSkill={useSkillInChat}
+                  onOpenSkillsFolder={() => openSkillsFolder()}
+                  managedSkillSources={managedSkillSources}
+                  onImportManagedSkillSource={() => importManagedSkillSource()}
+                  onInstallManagedSkill={(sourceId) => installManagedSkill(sourceId)}
+                  onPreviewManagedSkillUpdate={(skillId) => previewManagedSkillUpdate(skillId)}
+                  onUpdateManagedSkill={(skillId, options) => updateManagedSkill(skillId, options)}
+                  onSetSkillEnabled={(skillId, enabled) => setSkillEnabled(skillId, enabled)}
+                />
+              ) : navSelection.section === 'automations' ? (
+                <AutomationsPage
+                  skills={skills}
+                  reminders={planReminders}
+                  onRefresh={() => refreshPlanReminders({ shouldShowError: isAutomationsSurfaceActive })}
+                  onCreate={(input) => createPlanReminder(input)}
+                  onUpdate={(id, patch) => updatePlanReminder(id, patch)}
+                  onToggle={(id, enabled) => togglePlanReminder(id, enabled)}
+                  onTriggerNow={(id) => triggerPlanReminderNow(id)}
+                  onSnooze={(id) => snoozePlanReminder(id)}
+                  onClearRunHistory={(id) => clearPlanReminderRunHistory(id)}
+                  onDelete={(id) => deletePlanReminder(id)}
+                />
+              ) : navSelection.section === 'daily-review' ? (
+                <DailyReviewPage
+                  bridge={dailyReviewBridge}
+                  onSelectSession={openSessionInChat}
+                  onCopyMarkdown={(input) => copyDailyReviewMarkdown(input, { shouldShowFeedback: isDailyReviewSurfaceActive })}
+                  onAppendMarkdown={appendDailyReviewMarkdown}
+                  onSaveMarkdown={(input) => saveDailyReviewMarkdown(input, { shouldShowFeedback: isDailyReviewSurfaceActive })}
+                />
+              ) : (
               <ChatView
                 messages={messages}
                 liveTurn={activeLiveTurn}
@@ -1566,7 +1608,6 @@ export function AppShell({
                 userLabel={userLabel}
                 memoryActive={memoryActive}
                 onOpenMemorySettings={() => openSettingsSection('memory')}
-                mode={navSelection.section}
                 connectionAlert={chatConnectionAlert}
                 eventStreamAlert={chatEventStreamAlert}
                 goalIndicator={activeGoal ? {
@@ -1586,33 +1627,6 @@ export function AppShell({
                 turnFailedRecoveryLabels={turnFailedRecoveryLabels}
                 turnLineageBadgesByTurn={turnLineageBadgesByTurn}
                 onLineageBadgeClick={handleLineageBadgeClick}
-                skills={skills}
-                managedSkillSources={managedSkillSources}
-                onRefreshSkills={() => refreshSkills()}
-                onRefreshManagedSkillSources={() => refreshManagedSkillSources()}
-                onCreateSkillTemplate={() => createSkillTemplate()}
-                onOpenSkill={(skillId) => openSkill(skillId)}
-                onUseSkill={useSkillInChat}
-                onOpenSkillsFolder={() => openSkillsFolder()}
-                onImportManagedSkillSource={() => importManagedSkillSource()}
-                onInstallManagedSkill={(sourceId) => installManagedSkill(sourceId)}
-                onPreviewManagedSkillUpdate={(skillId) => previewManagedSkillUpdate(skillId)}
-                onUpdateManagedSkill={(skillId, options) => updateManagedSkill(skillId, options)}
-                onSetSkillEnabled={(skillId, enabled) => setSkillEnabled(skillId, enabled)}
-                planReminders={planReminders}
-                onRefreshPlanReminders={() => refreshPlanReminders({ shouldShowError: isAutomationsSurfaceActive })}
-                onCreatePlanReminder={(input) => createPlanReminder(input)}
-                onUpdatePlanReminder={(id, patch) => updatePlanReminder(id, patch)}
-                onTogglePlanReminder={(id, enabled) => togglePlanReminder(id, enabled)}
-                onTriggerPlanReminderNow={(id) => triggerPlanReminderNow(id)}
-                onSnoozePlanReminder={(id) => snoozePlanReminder(id)}
-                onClearPlanReminderRunHistory={(id) => clearPlanReminderRunHistory(id)}
-                onDeletePlanReminder={(id) => deletePlanReminder(id)}
-                dailyReviewBridge={dailyReviewBridge}
-                onSelectSession={openSessionInChat}
-                onCopyDailyReviewMarkdown={(input) => copyDailyReviewMarkdown(input, { shouldShowFeedback: isDailyReviewSurfaceActive })}
-                onAppendDailyReviewMarkdown={appendDailyReviewMarkdown}
-                onSaveDailyReviewMarkdown={(input) => saveDailyReviewMarkdown(input, { shouldShowFeedback: isDailyReviewSurfaceActive })}
                 scrollTargetTurn={
                   activeId && searchScrollTarget?.sessionId === activeId
                     ? { turnId: searchScrollTarget.turnId, nonce: searchScrollTarget.nonce }
@@ -1669,6 +1683,7 @@ export function AppShell({
                 onNew={createSession}
                 onPromptSuggestion={(prompt) => composerRef.current?.appendText(prompt)}
               />
+              )}
               <Composer
                 ref={composerRef}
                 hidden={navSelection.section !== 'sessions' || onboardingComposerHidden}

--- a/apps/desktop/stories/app-shell.stories.tsx
+++ b/apps/desktop/stories/app-shell.stories.tsx
@@ -113,7 +113,6 @@ const baseChatProps: ChatViewProps = {
   activeModelLabel: 'Claude Sonnet 4.5',
   modelChoices,
   userLabel: '你',
-  mode: 'sessions',
   onNew: noop,
   onPromptSuggestion: noop,
 };

--- a/packages/ui/src/chat-view.tsx
+++ b/packages/ui/src/chat-view.tsx
@@ -1,4 +1,4 @@
-import { Fragment, lazy, memo, Suspense, useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
+import { Fragment, memo, useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
 import {
   AlertOctagon,
   AlertTriangle,
@@ -6,7 +6,6 @@ import {
   Ban,
   BookOpen,
   Brain,
-  CalendarDays,
   Check,
   ChevronRight,
   Copy,
@@ -29,8 +28,8 @@ import { tokenizeFade, useStreamFade, type StreamFade } from './stream-fade.js';
 import { OverlayScrollArea } from './overlay-scroll-area.js';
 import { DialogContent, DialogRoot } from './ui.js';
 import { PromptAnchorRail } from './prompt-anchor-rail.js';
-import type { AttachmentRef, PlanReminder, ProviderType, SessionSummary, StoredMessage } from '@maka/core';
-import { deriveCapabilityAuditReport, isDeepResearchSession } from '@maka/core';
+import type { AttachmentRef, ProviderType, SessionSummary, StoredMessage } from '@maka/core';
+import { isDeepResearchSession } from '@maka/core';
 import { materializeChat, materializeTurns, overlayLiveTurn, type TurnTimelineItem, type TurnViewModel } from './materialize.js';
 import type { LiveTurnProjection } from './live-turn-projection.js';
 import { Button as UiButton } from './ui.js';
@@ -39,43 +38,7 @@ import { Alert, AlertDescription } from './primitives/alert.js';
 import { Collapsible, CollapsibleTrigger, CollapsiblePanel } from './primitives/collapsible.js';
 import { Bubble, Marker, markerVariants, Message, TextShimmer } from './primitives/chat.js';
 import { Tooltip, TooltipTrigger, TooltipContent } from './primitives/tooltip.js';
-import type { NavSelection } from './nav-selection.js';
 import { EmptyState } from './empty-state.js';
-import type {
-  DailyReviewBridge,
-  DailyReviewMarkdownActionInput,
-  ManagedSkillSourceEntry,
-  ManagedSkillUpdatePreview,
-  PlanReminderDraftInput,
-  PlanReminderUpdatePatch,
-  SkillEntry,
-} from './module-panel-types.js';
-// The Skills / Automations / Daily-Review surfaces are whole nav sections of
-// their own — they only render when `mode` flips to `skills` / `automations` /
-// `daily-review`, never on the default chat first paint. Loading them lazily
-// keeps their code (incl. the base-ui Select primitive they pull in) out of
-// the initial chunk so the chat shell mounts faster.
-const SkillsModuleMain = lazy(() => import('./skills-panel.js').then((m) => ({ default: m.SkillsModuleMain })));
-const DailyReviewPanel = lazy(() => import('./daily-review-panel.js').then((m) => ({ default: m.DailyReviewPanel })));
-const PlanReminderPanel = lazy(() => import('./plan-reminder-panel.js').then((m) => ({ default: m.PlanReminderPanel })));
-
-function ModulePageFallback(props: { label: string; message: string }) {
-  return (
-    <main className="maka-main detailPane maka-module-main agents-chat-panel" aria-label={props.label}>
-      <div className="maka-lazy-fallback" data-surface="module" role="status" aria-busy="true">
-        {props.message}
-      </div>
-    </main>
-  );
-}
-
-function ModulePanelFallback(props: { message: string }) {
-  return (
-    <div className="maka-lazy-fallback" data-surface="module" role="status" aria-busy="true">
-      {props.message}
-    </div>
-  );
-}
 import { ToolTrow } from './tool-activity.js';
 
 /**
@@ -172,7 +135,6 @@ export function ChatView(props: {
   memoryActive?: boolean;
   /** Click target for the memory pill — usually opens Settings · 记忆. */
   onOpenMemorySettings?(): void;
-  mode: NavSelection['section'];
   /**
    * When the user has no real LLM connection configured, the empty state
    * defers to this slot. App renders `<OnboardingHero>` here; if undefined,
@@ -240,34 +202,6 @@ export function ChatView(props: {
   turnFailedRecoveryLabels?: Record<string, string>;
   turnLineageBadgesByTurn?: Record<string, TurnLineageBadge[]>;
   onLineageBadgeClick?: (targetTurnId: string) => void;
-  skills?: SkillEntry[];
-  onRefreshSkills?(): void | Promise<void>;
-  onCreateSkillTemplate?(): void | Promise<void>;
-  onOpenSkill?(skillId: string): void | Promise<void>;
-  /** 使用 button: seed the composer with a skill invocation (R5 follow-up). */
-  onUseSkill?(skillId: string, skillName: string): void;
-  onOpenSkillsFolder?(): void | Promise<void>;
-  managedSkillSources?: ManagedSkillSourceEntry[];
-  onRefreshManagedSkillSources?(): void | Promise<void>;
-  onImportManagedSkillSource?(): void | Promise<void>;
-  onInstallManagedSkill?(sourceId: string): void | Promise<void>;
-  onPreviewManagedSkillUpdate?(skillId: string): Promise<ManagedSkillUpdatePreview | null>;
-  onUpdateManagedSkill?(skillId: string, options?: { force?: boolean; expectedCurrentSha256?: string; expectedSourceSha256?: string }): boolean | Promise<boolean>;
-  onSetSkillEnabled?(skillId: string, enabled: boolean): void | Promise<void>;
-  planReminders?: PlanReminder[];
-  onRefreshPlanReminders?: () => void | Promise<void>;
-  onCreatePlanReminder?(input: PlanReminderDraftInput): boolean | Promise<boolean> | void | Promise<void>;
-  onUpdatePlanReminder?(id: string, patch: PlanReminderUpdatePatch): boolean | Promise<boolean> | void | Promise<void>;
-  onTogglePlanReminder?: (id: string, enabled: boolean) => void | Promise<void>;
-  onTriggerPlanReminderNow?: (id: string) => void | Promise<void>;
-  onSnoozePlanReminder?: (id: string) => void | Promise<void>;
-  onClearPlanReminderRunHistory?: (id: string) => void | Promise<void>;
-  onDeletePlanReminder?: (id: string) => void | Promise<void>;
-  dailyReviewBridge?: DailyReviewBridge;
-  onCopyDailyReviewMarkdown?: (input: DailyReviewMarkdownActionInput) => Promise<void> | void;
-  onAppendDailyReviewMarkdown?: (input: DailyReviewMarkdownActionInput) => Promise<void> | void;
-  onSaveDailyReviewMarkdown?: (input: DailyReviewMarkdownActionInput) => Promise<void> | void;
-  onSelectSession?: (sessionId: string) => void;
   /**
    * Search-result navigation target. The desktop shell owns session
    * switching and hands the matched turn id here after selection; the
@@ -388,13 +322,6 @@ export function ChatView(props: {
     (targetTurnId: string) => onLineageBadgeClickRef.current?.(targetTurnId),
     [],
   );
-  const capabilityAuditReport = useMemo(
-    () => deriveCapabilityAuditReport({
-      skills: props.skills ?? [],
-      planReminders: props.planReminders ?? [],
-    }),
-    [props.skills, props.planReminders],
-  );
   const scrollRef = useRef<HTMLDivElement>(null);
   const [pinnedToBottom, setPinnedToBottom] = useState(true);
   const pinnedToBottomRef = useRef(true);
@@ -422,7 +349,7 @@ export function ChatView(props: {
       content,
       isPinned: () => pinnedToBottomRef.current,
     });
-  }, [props.activeSession?.id, props.mode]);
+  }, [props.activeSession?.id]);
 
   useEffect(() => {
     const target = props.scrollTargetTurn;
@@ -467,84 +394,6 @@ export function ChatView(props: {
     el.scrollTo({ top: el.scrollHeight, behavior: props.scrollBehavior ?? 'smooth' });
     pinnedToBottomRef.current = true;
     setPinnedToBottom(true);
-  }
-
-  if (props.mode === 'skills') {
-    return (
-      <Suspense fallback={<ModulePageFallback label="技能" message="正在加载技能…" />}>
-        <SkillsModuleMain
-          skills={props.skills}
-          auditReport={capabilityAuditReport}
-          onRefreshSkills={props.onRefreshSkills}
-          onCreateSkillTemplate={props.onCreateSkillTemplate}
-          onOpenSkill={props.onOpenSkill}
-          onUseSkill={props.onUseSkill}
-          onOpenSkillsFolder={props.onOpenSkillsFolder}
-          managedSkillSources={props.managedSkillSources}
-          onRefreshManagedSkillSources={props.onRefreshManagedSkillSources}
-          onImportManagedSkillSource={props.onImportManagedSkillSource}
-          onInstallManagedSkill={props.onInstallManagedSkill}
-          onPreviewManagedSkillUpdate={props.onPreviewManagedSkillUpdate}
-          onUpdateManagedSkill={props.onUpdateManagedSkill}
-          onSetSkillEnabled={props.onSetSkillEnabled}
-        />
-      </Suspense>
-    );
-  }
-
-  if (props.mode === 'automations') {
-    return (
-      <Suspense fallback={<ModulePageFallback label="定时任务" message="正在加载定时任务…" />}>
-        <main className="maka-main detailPane maka-module-main agents-chat-panel" aria-label="定时任务">
-          <PlanReminderPanel
-            reminders={props.planReminders ?? []}
-            auditReport={capabilityAuditReport}
-            onRefresh={props.onRefreshPlanReminders}
-            onCreate={props.onCreatePlanReminder}
-            onUpdate={props.onUpdatePlanReminder}
-            onToggle={props.onTogglePlanReminder}
-            onTriggerNow={props.onTriggerPlanReminderNow}
-            onSnooze={props.onSnoozePlanReminder}
-            onClearRunHistory={props.onClearPlanReminderRunHistory}
-            onDelete={props.onDeletePlanReminder}
-          />
-        </main>
-      </Suspense>
-    );
-  }
-
-  if (props.mode === 'daily-review') {
-    return (
-      <main
-        className="maka-main detailPane maka-module-main agents-chat-panel"
-        data-module="daily-review"
-        aria-label="每日回顾"
-      >
-        <header className="maka-module-main-header">
-          <div>
-            <h2>每日回顾</h2>
-            <p>自动汇总本机对话，生成摘要、遗漏提醒与深度分析；可在设置中开启定时执行。</p>
-          </div>
-        </header>
-        {props.dailyReviewBridge ? (
-          <Suspense fallback={<ModulePanelFallback message="正在加载每日回顾…" />}>
-            <DailyReviewPanel
-              bridge={props.dailyReviewBridge}
-              onSelectSession={props.onSelectSession}
-              onCopyMarkdown={props.onCopyDailyReviewMarkdown}
-              onAppendMarkdown={props.onAppendDailyReviewMarkdown}
-              onSaveMarkdown={props.onSaveDailyReviewMarkdown}
-            />
-          </Suspense>
-        ) : (
-          <EmptyState
-            Icon={CalendarDays}
-            title="等待连接每日回顾数据"
-            body="桌面端数据桥当前未连接。"
-          />
-        )}
-      </main>
-    );
   }
 
   if (!props.activeSession) {

--- a/packages/ui/src/components.tsx
+++ b/packages/ui/src/components.tsx
@@ -9,6 +9,7 @@ export { formatBytes, OverlayHost, ToolActivity, ToolErrorDetails } from './tool
 export { PermissionDialog } from './permission-dialog.js';
 export { ChatView } from './chat-view.js';
 export type { ChatHeaderAlert, TurnFooterActionMeta, TurnLineageBadge } from './chat-view.js';
+export { AutomationsPage, DailyReviewPage, SkillsPage } from './module-pages.js';
 export { Composer } from './composer.js';
 export type { ComposerHandle } from './composer.js';
 export {

--- a/packages/ui/src/module-pages.tsx
+++ b/packages/ui/src/module-pages.tsx
@@ -1,0 +1,114 @@
+import { lazy, Suspense } from 'react';
+import type { PlanReminder } from '@maka/core';
+import { deriveCapabilityAuditReport } from '@maka/core';
+import { CalendarDays } from './icons.js';
+import { EmptyState } from './empty-state.js';
+import type {
+  DailyReviewBridge,
+  DailyReviewMarkdownActionInput,
+  ManagedSkillSourceEntry,
+  ManagedSkillUpdatePreview,
+  PlanReminderDraftInput,
+  PlanReminderUpdatePatch,
+  SkillEntry,
+} from './module-panel-types.js';
+
+const SkillsModuleMain = lazy(() => import('./skills-panel.js').then((module) => ({ default: module.SkillsModuleMain })));
+const DailyReviewPanel = lazy(() => import('./daily-review-panel.js').then((module) => ({ default: module.DailyReviewPanel })));
+const PlanReminderPanel = lazy(() => import('./plan-reminder-panel.js').then((module) => ({ default: module.PlanReminderPanel })));
+
+function ModulePageFallback(props: { label: string; message: string }) {
+  return (
+    <main className="maka-main detailPane maka-module-main agents-chat-panel" aria-label={props.label}>
+      <div className="maka-lazy-fallback" data-surface="module" role="status" aria-busy="true">
+        {props.message}
+      </div>
+    </main>
+  );
+}
+
+function ModulePanelFallback(props: { message: string }) {
+  return (
+    <div className="maka-lazy-fallback" data-surface="module" role="status" aria-busy="true">
+      {props.message}
+    </div>
+  );
+}
+
+export function SkillsPage(props: {
+  skills?: SkillEntry[];
+  planReminders?: PlanReminder[];
+  onRefreshSkills?(): void | Promise<void>;
+  onCreateSkillTemplate?(): void | Promise<void>;
+  onOpenSkill?(skillId: string): void | Promise<void>;
+  onUseSkill?(skillId: string, skillName: string): void;
+  onOpenSkillsFolder?(): void | Promise<void>;
+  managedSkillSources?: ManagedSkillSourceEntry[];
+  onRefreshManagedSkillSources?(): void | Promise<void>;
+  onImportManagedSkillSource?(): void | Promise<void>;
+  onInstallManagedSkill?(sourceId: string): void | Promise<void>;
+  onPreviewManagedSkillUpdate?(skillId: string): Promise<ManagedSkillUpdatePreview | null>;
+  onUpdateManagedSkill?(skillId: string, options?: { force?: boolean; expectedCurrentSha256?: string; expectedSourceSha256?: string }): boolean | Promise<boolean>;
+  onSetSkillEnabled?(skillId: string, enabled: boolean): void | Promise<void>;
+}) {
+  const auditReport = deriveCapabilityAuditReport({
+    skills: props.skills ?? [],
+    planReminders: props.planReminders ?? [],
+  });
+  return (
+    <Suspense fallback={<ModulePageFallback label="技能" message="正在加载技能…" />}>
+      <SkillsModuleMain {...props} auditReport={auditReport} />
+    </Suspense>
+  );
+}
+
+export function AutomationsPage(props: {
+  skills?: SkillEntry[];
+  reminders?: PlanReminder[];
+  onRefresh?: () => void | Promise<void>;
+  onCreate?(input: PlanReminderDraftInput): boolean | Promise<boolean> | void | Promise<void>;
+  onUpdate?(id: string, patch: PlanReminderUpdatePatch): boolean | Promise<boolean> | void | Promise<void>;
+  onToggle?: (id: string, enabled: boolean) => void | Promise<void>;
+  onTriggerNow?: (id: string) => void | Promise<void>;
+  onSnooze?: (id: string) => void | Promise<void>;
+  onClearRunHistory?: (id: string) => void | Promise<void>;
+  onDelete?: (id: string) => void | Promise<void>;
+}) {
+  const auditReport = deriveCapabilityAuditReport({
+    skills: props.skills ?? [],
+    planReminders: props.reminders ?? [],
+  });
+  return (
+    <Suspense fallback={<ModulePageFallback label="定时任务" message="正在加载定时任务…" />}>
+      <main className="maka-main detailPane maka-module-main agents-chat-panel" aria-label="定时任务">
+        <PlanReminderPanel {...props} reminders={props.reminders ?? []} auditReport={auditReport} />
+      </main>
+    </Suspense>
+  );
+}
+
+export function DailyReviewPage(props: {
+  bridge?: DailyReviewBridge;
+  onSelectSession?: (sessionId: string) => void;
+  onCopyMarkdown?: (input: DailyReviewMarkdownActionInput) => Promise<void> | void;
+  onAppendMarkdown?: (input: DailyReviewMarkdownActionInput) => Promise<void> | void;
+  onSaveMarkdown?: (input: DailyReviewMarkdownActionInput) => Promise<void> | void;
+}) {
+  return (
+    <main className="maka-main detailPane maka-module-main agents-chat-panel" data-module="daily-review" aria-label="每日回顾">
+      <header className="maka-module-main-header">
+        <div>
+          <h2>每日回顾</h2>
+          <p>自动汇总本机对话，生成摘要、遗漏提醒与深度分析；可在设置中开启定时执行。</p>
+        </div>
+      </header>
+      {props.bridge ? (
+        <Suspense fallback={<ModulePanelFallback message="正在加载每日回顾…" />}>
+          <DailyReviewPanel {...props} bridge={props.bridge} />
+        </Suspense>
+      ) : (
+        <EmptyState Icon={CalendarDays} title="等待连接每日回顾数据" body="桌面端数据桥当前未连接。" />
+      )}
+    </main>
+  );
+}

--- a/packages/ui/stories/attachment.stories.tsx
+++ b/packages/ui/stories/attachment.stories.tsx
@@ -101,7 +101,6 @@ const baseChat: ChatViewProps = {
   activeModelLabel: 'Claude Sonnet 4.5',
   modelChoices,
   userLabel: '你',
-  mode: 'sessions',
   onNew: noop,
   onPromptSuggestion: noop,
 };

--- a/packages/ui/stories/chat-surface.stories.tsx
+++ b/packages/ui/stories/chat-surface.stories.tsx
@@ -98,7 +98,6 @@ const baseChatProps: ChatViewProps = {
   activeModelLabel: 'Claude Sonnet 4.5',
   modelChoices,
   userLabel: '你',
-  mode: 'sessions',
   onNew: noop,
   onPromptSuggestion: noop,
 };


### PR DESCRIPTION
## Summary

- Move Skills, Automations, and Daily Review page composition behind explicit `@maka/ui` page components selected by app-shell.
- Make `ChatView` chat-only by removing section routing, `mode`, and all non-chat module props.
- Preserve module lazy chunks and update source contracts and stories to the new ownership boundary.

## Why

Stage 1 of #829. `navSelection` belongs to app-shell, but `ChatView` previously survived section switches while its scroll DOM did not. That split lifecycle forced every scroll effect to depend on navigation state individually and caused the defect class found in #828. Mounting `ChatView` only for sessions makes its component and DOM lifecycles coincide.

Refs #829.

## Scope

This PR changes page ownership only. Turn rendering and scroll-effect extraction remain for Stages 2 and 3. It does not redesign module pages, chat behavior, or visuals.

## Verification

- `npm --workspace @maka/ui test` — 105 passed.
- `npm --workspace @maka/desktop test` — 2,351 passed, including renderer source contracts and accessibility/copy checks.
- `npm run build` — production builds passed; Skills, Automations, and Daily Review remain separate lazy chunks.
- Codex review round 1: one P2 alleged lost scroll-position preservation. Verification showed the old early-return path already destroyed the scroll DOM and lost `scrollTop`; it only retained stale `pinned=false`, so the proposed keep-alive would restore the lifecycle defect this stage removes.
- Codex review round 2 with the required lifecycle invariant and old-path evidence: PASS, no P0–P2 findings.
- No visual evidence: this is a behavior-preserving ownership refactor. Existing render contracts, full UI/desktop tests, lazy-chunk build output, and external review are the substitute evidence.

## Impact

No user-visible, storage, API, migration, documentation, or release-note impact. The internal `@maka/ui` surface gains three page-level exports; `ChatView` drops non-chat props.

## Reviewer notes

Returning from a module now remounts a fresh transcript DOM pinned to the latest message. The old implementation did not preserve scroll position because its early return also destroyed that DOM; retaining the old `pinned=false` state merely left the rebuilt transcript at the top.

## Ready for review

- [x] Verification is complete and the results above are current
- [x] Impact, compatibility, migration, documentation, and release-note needs are addressed
- [x] User-visible UI/UX changes include visual evidence, or `Verification` explains why it is not applicable
