### PR TITLE
refactor(ui): extract ChatView scroll lifecycle

### DIFF
--- a/apps/desktop/src/main/__tests__/search-modal-lifecycle-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/search-modal-lifecycle-contract.test.ts
@@ -43,6 +43,7 @@ import { renderSessionListPanel } from './session-list-render-helpers.js';
 const REPO_ROOT = resolve(import.meta.dirname, '../../../../..');
 const COMPONENTS_PATH = resolve(REPO_ROOT, 'packages', 'ui', 'src', 'chat-view.tsx');
 const CHAT_TURN_PATH = resolve(REPO_ROOT, 'packages', 'ui', 'src', 'chat-turn.tsx');
+const CHAT_SCROLL_PATH = resolve(REPO_ROOT, 'packages', 'ui', 'src', 'use-chat-scroll.ts');
 const SEARCH_MODAL_PATH = resolve(REPO_ROOT, 'packages', 'ui', 'src', 'search-modal.tsx');
 const COMMAND_PALETTE_CONTENT_PATH = join(REPO_ROOT, 'apps', 'desktop', 'src', 'renderer', 'command-palette-content-search.ts');
 
@@ -164,6 +165,7 @@ describe('SearchModal lifecycle contract (PR-SIDEBAR-IA-0 Phase 3 P0 fixup)', ()
     const searchModalSource = await readFile(SEARCH_MODAL_PATH, 'utf8');
     const components = await readFile(COMPONENTS_PATH, 'utf8');
     const chatTurn = await readFile(CHAT_TURN_PATH, 'utf8');
+    const chatScroll = await readFile(CHAT_SCROLL_PATH, 'utf8');
     const main = await readRendererShellCombinedSource();
     const contentSearch = await readFile(COMMAND_PALETTE_CONTENT_PATH, 'utf8');
 
@@ -203,18 +205,18 @@ describe('SearchModal lifecycle contract (PR-SIDEBAR-IA-0 Phase 3 P0 fixup)', ()
       'ChatView must expose a typed scroll target prop',
     );
     assert.match(
-      components,
-      /scrollIntoView\(\{\s*behavior:\s*props\.scrollBehavior\s*\?\?\s*'smooth',\s*block:\s*'center'/,
+      chatScroll,
+      /scrollIntoView\(\{\s*behavior:\s*input\.behavior\s*\?\?\s*'smooth',\s*block:\s*'center'/,
       'ChatView must scroll the matched turn into view',
     );
     assert.match(
-      components,
-      /function scrollToBottom\(\) \{[\s\S]*scrollTo\(\{\s*top:\s*el\.scrollHeight,\s*behavior:\s*props\.scrollBehavior\s*\?\?\s*'smooth'\s*\}\);/,
+      chatScroll,
+      /function scrollToBottom\(\) \{[\s\S]*scrollTo\(\{\s*top:\s*viewport\.scrollHeight,\s*behavior:\s*input\.behavior\s*\?\?\s*'smooth'\s*\}\);/,
       'ChatView jump-to-latest must honor the same reduced-motion/visual-smoke scroll policy as search navigation',
     );
     assert.match(
-      components,
-      /targetEl\.setAttribute\('tabindex', '-1'\);[\s\S]*targetEl\.focus\(\{ preventScroll: true \}\);/,
+      chatScroll,
+      /targetElement\.setAttribute\('tabindex', '-1'\);[\s\S]*targetElement\.focus\(\{ preventScroll: true \}\);/,
       'ChatView must move keyboard focus to the matched turn after search navigation',
     );
     assert.match(

--- a/packages/ui/src/chat-view.tsx
+++ b/packages/ui/src/chat-view.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
+import { useCallback, useMemo, useRef, type ReactNode } from 'react';
 import {
   AlertTriangle,
   ArrowDown,
@@ -9,8 +9,6 @@ import {
 } from './icons.js';
 import { DeepResearchEmptyHero, EmptyChatHero } from './chat-empty-hero.js';
 import type { ChatModelChoice } from './chat-model-helpers.js';
-import { createPinnedBottomFollower } from './pinned-bottom.js';
-import { createTurnSizeWarmup } from './turn-size-warmup.js';
 import { OverlayScrollArea } from './overlay-scroll-area.js';
 import { PromptAnchorRail } from './prompt-anchor-rail.js';
 import type { ProviderType, SessionSummary, StoredMessage } from '@maka/core';
@@ -28,6 +26,7 @@ import {
   type TurnFooterActionMeta,
   type TurnLineageBadge,
 } from './chat-turn.js';
+import { useChatScroll } from './use-chat-scroll.js';
 
 /**
  * Lifecycle status badge in the chat header (PR109b §9.8). Visual
@@ -59,8 +58,6 @@ function SessionStatusBadge(props: {
 
 
 
-
-const SCROLL_BOTTOM_THRESHOLD = 64; // px
 
 export interface ChatHeaderAlert {
   /** Visual tone — drives badge color in the chat header. */
@@ -310,128 +307,19 @@ export function ChatView(props: {
     (targetTurnId: string) => onLineageBadgeClickRef.current?.(targetTurnId),
     [],
   );
-  const scrollRef = useRef<HTMLDivElement>(null);
-  const [pinnedToBottom, setPinnedToBottom] = useState(true);
-  const pinnedToBottomRef = useRef(true);
-  const [highlightedTurnId, setHighlightedTurnId] = useState<string | null>(null);
-
-  // Reset to "pinned at bottom" whenever the active session changes. Without
-  // this, switching from a long history to a fresh chat would keep the
-  // previous scrollTop and the user wouldn't see their last message.
-  useEffect(() => {
-    pinnedToBottomRef.current = true;
-    setPinnedToBottom(true);
-    const el = scrollRef.current;
-    if (el) el.scrollTop = el.scrollHeight;
-  }, [props.activeSession?.id]);
-
-  // Follow the content's actual layout clock. The smoother reveals raw text
-  // on later RAF frames, so a state-driven scroll effect runs too early and
-  // leaves the viewport behind until the next upstream event.
-  useEffect(() => {
-    const viewport = scrollRef.current;
-    const content = viewport?.querySelector(':scope > [data-overlayscrollbars-content]');
-    if (!viewport || !content) return;
-    return createPinnedBottomFollower({
-      viewport,
-      content,
-      isPinned: () => pinnedToBottomRef.current,
-    });
-  }, [props.activeSession?.id]);
-
-  // Warm up `content-visibility: auto` turns once per transcript DOM so every
-  // turn's real height replaces the 250px `contain-intrinsic-size` estimate.
-  // Without this, scrolling up through never-rendered history keeps inflating
-  // the document and the top recedes ("endless scroll"). Keyed on hasTurns so
-  // the walk starts when history arrives, without re-walking per message.
-  // Section switches need no dependency here: since #831 ChatView mounts only
-  // for sessions, so leaving chat unmounts the component with its scroll DOM
-  // and returning re-runs every effect against the rebuilt `.maka-turn` nodes
-  // (which have no remembered sizes — the E2E mode-switch test locks this).
-  // Gated so sizes are remembered from the FINAL layout, not a transient one
-  // (a stale remembered size gets re-corrected on every viewport arrival —
-  // exactly the drift this walk exists to remove):
-  // - document.fonts.ready: fallback glyph metrics shift prose heights;
-  // - no `.maka-markdown-pending` left in the tree: until the lazy
-  //   markdown-body chunk commits, every bubble is the plain-text Suspense
-  //   fallback (~7.5px taller per turn). Awaiting the import is NOT enough —
-  //   the Suspense retry is a low-priority render that can commit after an
-  //   idle callback — so the DOM is the authority, polled until it settles.
-  //   No warm-anyway deadline: warming a layout the markdown commit is about
-  //   to replace would re-create the drift, and if the chunk never loads the
-  //   un-warmed placeholder geometry is the least of the session's problems.
-  const hasTurns = turns.length > 0;
-  useEffect(() => {
-    if (!hasTurns) return;
-    const root = scrollRef.current;
-    if (!root) return;
-    let disposed = false;
-    let cancelWarmup: (() => void) | undefined;
-    let pollTimer: number | undefined;
-    const warmOnceSettled = () => {
-      if (disposed) return;
-      if (root.querySelector('.maka-markdown-pending')) {
-        pollTimer = window.setTimeout(warmOnceSettled, 100);
-        return;
-      }
-      cancelWarmup = createTurnSizeWarmup({
-        turns: () => root.querySelectorAll<HTMLElement>('.maka-turn'),
-      });
-    };
-    const fontsReady: Promise<unknown> =
-      typeof document !== 'undefined' && document.fonts ? document.fonts.ready : Promise.resolve();
-    void fontsReady.then(warmOnceSettled);
-    return () => {
-      disposed = true;
-      window.clearTimeout(pollTimer);
-      cancelWarmup?.();
-    };
-  }, [props.activeSession?.id, hasTurns]);
-
-  useEffect(() => {
-    const target = props.scrollTargetTurn;
-    if (!target?.turnId) return;
-    const frame = window.requestAnimationFrame(() => {
-      const root = scrollRef.current;
-      if (!root) return;
-      const el = root.querySelector(`[data-turn-id="${CSS.escape(target.turnId)}"]`);
-      if (!el || !('scrollIntoView' in el)) return;
-      const targetEl = el as HTMLElement;
-      targetEl.setAttribute('tabindex', '-1');
-      targetEl.scrollIntoView({
-        behavior: props.scrollBehavior ?? 'smooth',
-        block: 'center',
-      });
-      targetEl.focus({ preventScroll: true });
-      pinnedToBottomRef.current = false;
-      setPinnedToBottom(false);
-      setHighlightedTurnId(target.turnId);
-    });
-    const clear = window.setTimeout(() => {
-      setHighlightedTurnId((current) => (current === target.turnId ? null : current));
-    }, 2200);
-    return () => {
-      window.cancelAnimationFrame(frame);
-      window.clearTimeout(clear);
-    };
-  }, [props.scrollTargetTurn?.turnId, props.scrollTargetTurn?.nonce, props.scrollBehavior, props.activeSession?.id, props.messages]);
-
-  function onScroll() {
-    const el = scrollRef.current;
-    if (!el) return;
-    const distanceFromBottom = el.scrollHeight - el.scrollTop - el.clientHeight;
-    const pinned = distanceFromBottom <= SCROLL_BOTTOM_THRESHOLD;
-    pinnedToBottomRef.current = pinned;
-    setPinnedToBottom(pinned);
-  }
-
-  function scrollToBottom() {
-    const el = scrollRef.current;
-    if (!el) return;
-    el.scrollTo({ top: el.scrollHeight, behavior: props.scrollBehavior ?? 'smooth' });
-    pinnedToBottomRef.current = true;
-    setPinnedToBottom(true);
-  }
+  const {
+    highlightedTurnId,
+    onScroll,
+    pinnedToBottom,
+    scrollToBottom,
+    viewportRef: scrollRef,
+  } = useChatScroll({
+    sessionId: props.activeSession?.id,
+    hasTurns: turns.length > 0,
+    messages: props.messages,
+    target: props.scrollTargetTurn,
+    behavior: props.scrollBehavior,
+  });
 
   if (!props.activeSession) {
     return (

--- a/packages/ui/src/use-chat-scroll.ts
+++ b/packages/ui/src/use-chat-scroll.ts
@@ -1,0 +1,123 @@
+import { useEffect, useRef, useState } from 'react';
+import type { StoredMessage } from '@maka/core';
+import { createPinnedBottomFollower } from './pinned-bottom.js';
+import { createTurnSizeWarmup } from './turn-size-warmup.js';
+
+const SCROLL_BOTTOM_THRESHOLD = 64;
+
+export function useChatScroll(input: {
+  sessionId?: string;
+  hasTurns: boolean;
+  messages: readonly StoredMessage[];
+  target?: { turnId: string; nonce: number };
+  behavior?: ScrollBehavior;
+}) {
+  const viewportRef = useRef<HTMLDivElement>(null);
+  const [pinnedToBottom, setPinnedToBottom] = useState(true);
+  const pinnedToBottomRef = useRef(true);
+  const [highlightedTurnId, setHighlightedTurnId] = useState<string | null>(null);
+
+  // A session owns one transcript DOM. Reset its initial position to latest.
+  useEffect(() => {
+    pinnedToBottomRef.current = true;
+    setPinnedToBottom(true);
+    const viewport = viewportRef.current;
+    if (viewport) viewport.scrollTop = viewport.scrollHeight;
+  }, [input.sessionId]);
+
+  // Follow the content's actual layout clock. Smooth streaming reveals text on
+  // later RAF frames, so a state-driven scroll effect runs too early.
+  useEffect(() => {
+    const viewport = viewportRef.current;
+    const content = viewport?.querySelector(':scope > [data-overlayscrollbars-content]');
+    if (!viewport || !content) return;
+    return createPinnedBottomFollower({
+      viewport,
+      content,
+      isPinned: () => pinnedToBottomRef.current,
+    });
+  }, [input.sessionId]);
+
+  // Replace content-visibility placeholders with final-layout remembered sizes.
+  // ChatView itself unmounts outside sessions, so every rebuilt transcript gets
+  // a fresh hook lifecycle without depending on navigation state.
+  useEffect(() => {
+    if (!input.hasTurns) return;
+    const root = viewportRef.current;
+    if (!root) return;
+    let disposed = false;
+    let cancelWarmup: (() => void) | undefined;
+    let pollTimer: number | undefined;
+    const warmOnceSettled = () => {
+      if (disposed) return;
+      if (root.querySelector('.maka-markdown-pending')) {
+        pollTimer = window.setTimeout(warmOnceSettled, 100);
+        return;
+      }
+      cancelWarmup = createTurnSizeWarmup({
+        turns: () => root.querySelectorAll<HTMLElement>('.maka-turn'),
+      });
+    };
+    const fontsReady: Promise<unknown> =
+      typeof document !== 'undefined' && document.fonts ? document.fonts.ready : Promise.resolve();
+    void fontsReady.then(warmOnceSettled);
+    return () => {
+      disposed = true;
+      window.clearTimeout(pollTimer);
+      cancelWarmup?.();
+    };
+  }, [input.sessionId, input.hasTurns]);
+
+  useEffect(() => {
+    const target = input.target;
+    if (!target?.turnId) return;
+    const frame = window.requestAnimationFrame(() => {
+      const root = viewportRef.current;
+      if (!root) return;
+      const element = root.querySelector(`[data-turn-id="${CSS.escape(target.turnId)}"]`);
+      if (!element || !('scrollIntoView' in element)) return;
+      const targetElement = element as HTMLElement;
+      targetElement.setAttribute('tabindex', '-1');
+      targetElement.scrollIntoView({
+        behavior: input.behavior ?? 'smooth',
+        block: 'center',
+      });
+      targetElement.focus({ preventScroll: true });
+      pinnedToBottomRef.current = false;
+      setPinnedToBottom(false);
+      setHighlightedTurnId(target.turnId);
+    });
+    const clear = window.setTimeout(() => {
+      setHighlightedTurnId((current) => (current === target.turnId ? null : current));
+    }, 2200);
+    return () => {
+      window.cancelAnimationFrame(frame);
+      window.clearTimeout(clear);
+    };
+  }, [input.target?.turnId, input.target?.nonce, input.behavior, input.sessionId, input.messages]);
+
+  function onScroll() {
+    const viewport = viewportRef.current;
+    if (!viewport) return;
+    const distanceFromBottom = viewport.scrollHeight - viewport.scrollTop - viewport.clientHeight;
+    const pinned = distanceFromBottom <= SCROLL_BOTTOM_THRESHOLD;
+    pinnedToBottomRef.current = pinned;
+    setPinnedToBottom(pinned);
+  }
+
+  function scrollToBottom() {
+    const viewport = viewportRef.current;
+    if (!viewport) return;
+    viewport.scrollTo({ top: viewport.scrollHeight, behavior: input.behavior ?? 'smooth' });
+    pinnedToBottomRef.current = true;
+    setPinnedToBottom(true);
+  }
+
+  return {
+    highlightedTurnId,
+    onScroll,
+    pinnedToBottom,
+    scrollToBottom,
+    viewportRef,
+  };
+}


### PR DESCRIPTION
## Summary

- Extract ChatView's transcript viewport ref, pinned state, warm-up, target navigation, highlighting, and scroll handlers into `useChatScroll`.
- Keep `pinned-bottom.ts` and `turn-size-warmup.ts` as the mechanism authorities; the hook only composes their lifecycles.
- Update the search-navigation source contract to assert behavior at the new scroll owner.

## Why

Stage 3 of #829. After page ownership and turn rendering were separated, ChatView still directly owned four coupled effects plus their shared refs and state. Encapsulating that one DOM lifecycle leaves ChatView responsible for chat composition while keeping scroll behavior chat-specific and testable through the existing geometry seam.

Refs #829.

## Scope

This is a behavior-preserving extraction. It does not generalize scrolling for other consumers, change the #828 algorithms, or alter DOM/layout/visuals.

## Verification

- `npm --workspace @maka/ui test` — 111 passed.
- `npm --workspace @maka/desktop test` — 2,351 passed.
- `npm --workspace @maka/desktop run e2e -- scroll-geometry.spec.ts` — 3 passed: pinned growth, honest upward geometry, and section-switch re-warm.
- UI and desktop typechecks passed during local and Codex review validation.
- Production renderer build passed during E2E setup.
- Codex review round 1: PASS, no P0–P3 findings. It explicitly compared dependencies, cleanup, target replay, highlight timing, warm-up gates, and both mechanism authorities against `main`.
- No visual evidence: no rendered structure or styling changed. The deterministic scroll-geometry E2E suite is the substitute evidence.

## Impact

No user-visible, API, storage, migration, documentation, or release-note impact.

## Reviewer notes

The hook intentionally accepts `messages` only as the existing target-replay dependency: a search target may arrive before its turn has rendered, so persisted message changes must retry the target effect. It has no navigation-mode input because Stage 1 aligned ChatView with the sessions DOM lifecycle.

## Ready for review

- [x] Verification is complete and the results above are current
- [x] Impact, compatibility, migration, documentation, and release-note needs are addressed
- [x] User-visible UI/UX changes include visual evidence, or `Verification` explains why it is not applicable
