### PR TITLE
fix(desktop): stabilize and silence E2E runs

### DIFF
--- a/apps/desktop/e2e/attachment.spec.ts
+++ b/apps/desktop/e2e/attachment.spec.ts
@@ -16,6 +16,10 @@ test('dropping a file onto the composer delivers it to the backend on send', asy
   // Drop a file onto the main composer
   const composer = page.locator('.maka-composer');
   await expect(composer).toBeVisible();
+  // Assistant text becomes visible before the turn's terminal event can clear
+  // the streaming state. The composer intentionally rejects attachments until
+  // that happens, so synchronize on its actual file-drop readiness contract.
+  await expect(composer).toHaveAttribute('data-maka-file-drop-target', 'true');
   const dataTransfer = await page.evaluateHandle(() => new DataTransfer());
   await dataTransfer.evaluate((dt: DataTransfer) => {
     dt.items.add(new File(['hello attachment content'], 'note.txt', { type: 'text/plain' }));

--- a/apps/desktop/e2e/fixtures.ts
+++ b/apps/desktop/e2e/fixtures.ts
@@ -55,12 +55,12 @@ function buildE2eEnv(userDataDir: string, visualSmokeScenario?: string): NodeJS.
   env.MAKA_E2E = '1';
   env.MAKA_E2E_USER_DATA_DIR = userDataDir;
   if (visualSmokeScenario) env.MAKA_VISUAL_SMOKE_FIXTURE = visualSmokeScenario;
-  // E2E windows launch hidden so local runs never steal the developer's
-  // focus. On CI there is no desktop to protect, and a hidden window's
-  // compositor is throttled to ~1fps on Linux — content-visibility turns
-  // never inflate and frame-paced protocols crawl (measured: 38 frames in
-  // 31s in the scroll-geometry climb). Under xvfb, show the window.
-  if (process.env.CI) env.MAKA_E2E_SHOW_WINDOW = '1';
+  // E2E windows launch hidden so local and macOS runs never steal the
+  // developer's focus. Linux CI runs under xvfb, where a hidden window's
+  // compositor is throttled to ~1fps — content-visibility turns never inflate
+  // and frame-paced protocols crawl. Only that isolated display needs a
+  // visible window.
+  if (process.env.CI && process.platform === 'linux') env.MAKA_E2E_SHOW_WINDOW = '1';
   return env;
 }
 

--- a/apps/desktop/src/main/__tests__/notifications-policy.test.ts
+++ b/apps/desktop/src/main/__tests__/notifications-policy.test.ts
@@ -8,7 +8,7 @@ import {
 } from '../notifications-policy.js';
 
 describe('shouldRaiseRunNotification gate', () => {
-  const base = { enabled: true, supported: true, windowFocused: false, incognito: false };
+  const base = { enabled: true, supported: true, windowFocused: false, incognito: false, e2e: false };
 
   it('raises a notification only when enabled, supported, unfocused, and not incognito', () => {
     assert.equal(shouldRaiseRunNotification(base), true);
@@ -28,6 +28,10 @@ describe('shouldRaiseRunNotification gate', () => {
 
   it('suppresses in incognito mode (no session name/preview outside the app)', () => {
     assert.equal(shouldRaiseRunNotification({ ...base, incognito: true }), false);
+  });
+
+  it('suppresses native notifications during E2E runs', () => {
+    assert.equal(shouldRaiseRunNotification({ ...base, e2e: true }), false);
   });
 });
 

--- a/apps/desktop/src/main/__tests__/window-reveal-after-first-commit-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/window-reveal-after-first-commit-contract.test.ts
@@ -229,6 +229,15 @@ describe('window reveal gate (PR-SHOW-AFTER-FIRST-COMMIT)', () => {
 });
 
 describe('window reveal wiring (PR-SHOW-AFTER-FIRST-COMMIT)', () => {
+  it('only reveals E2E windows for Linux CI under xvfb', async () => {
+    const src = await readRepoFile('apps/desktop/e2e/fixtures.ts');
+    assert.match(
+      src,
+      /if \(process\.env\.CI && process\.platform === 'linux'\) env\.MAKA_E2E_SHOW_WINDOW = '1';/,
+      'visible E2E windows are only needed for Linux compositor pacing under xvfb',
+    );
+  });
+
   it('main-window creates the window hidden and wires the reveal fallback timer', async () => {
     const src = await readRepoFile('apps/desktop/src/main/main-window.ts');
     // Every run now creates hidden — no `!app.isPackaged && startHidden` gate.

--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -1130,7 +1130,7 @@ function registerIpc(): void {
   );
   registerMemoryIpc({ localMemory });
   registerConfigIpc({ connectionStore, settingsStore, credentialStore, workspaceRoot });
-  registerNotificationsIpc({ settingsStore, mainWindowController });
+  registerNotificationsIpc({ settingsStore, mainWindowController, e2e: isE2e });
   ipcMain.handle('workspaceInstructions:getState', async () => getWorkspaceInstructionsState(await currentProjectRoot()));
   ipcMain.handle(
     'workspaceInstructions:openFile',

--- a/apps/desktop/src/main/notifications-ipc-main.ts
+++ b/apps/desktop/src/main/notifications-ipc-main.ts
@@ -12,6 +12,7 @@ type MainWindowController = ReturnType<typeof createMainWindowController>;
 interface NotificationsIpcDeps {
   settingsStore: { get(): Promise<AppSettings> };
   mainWindowController: MainWindowController;
+  e2e: boolean;
 }
 
 /**
@@ -39,6 +40,7 @@ export function registerNotificationsIpc(deps: NotificationsIpcDeps): void {
       supported,
       windowFocused: deps.mainWindowController.isFocused(),
       incognito: settings.privacy.incognitoActive,
+      e2e: deps.e2e,
     };
     if (!shouldRaiseRunNotification(gate)) return;
 

--- a/apps/desktop/src/main/notifications-policy.ts
+++ b/apps/desktop/src/main/notifications-policy.ts
@@ -33,6 +33,8 @@ export interface RunNotificationGate {
    * — consistent with incognito pausing local memory / search.
    */
   readonly incognito: boolean;
+  /** Automated desktop runs must never emit native OS notifications. */
+  readonly e2e: boolean;
 }
 
 /**
@@ -41,7 +43,7 @@ export interface RunNotificationGate {
  * the predicate is a plain conjunction.
  */
 export function shouldRaiseRunNotification(gate: RunNotificationGate): boolean {
-  return gate.enabled && gate.supported && !gate.windowFocused && !gate.incognito;
+  return gate.enabled && gate.supported && !gate.windowFocused && !gate.incognito && !gate.e2e;
 }
 
 export interface RunNotificationCopy {


### PR DESCRIPTION
## Summary

- Synchronize the attachment E2E with the composer's authoritative file-drop readiness signal.
- Keep E2E windows hidden outside Linux CI under xvfb.
- Suppress native run-completion notifications during E2E runs.

## Why

The attachment test treated visible assistant text as proof that the turn had fully settled. Assistant text can render before the terminal event clears the composer's streaming state, so a drop dispatched in that interval is intentionally rejected. The latent race dates to the initial Electron E2E test in `d9e04c09`; the additional rendering work in `8a47301a` first made it fail consistently on `main`.

E2E runs should also remain unobtrusive on developer machines: visible windows are only required for compositor pacing on Linux CI under xvfb, and automated turns must never emit native notifications.

## Scope

This does not change attachment behavior or notification behavior in normal application runs.

## Verification

- Attachment E2E repeated 20 times: 20 passed.
- Full Electron E2E suite: 8 passed.
- Desktop typecheck: passed.
- Desktop test suite: 2,353 passed.
- `git diff --check`: passed.
- Visual evidence is not applicable: the changes affect test synchronization and E2E process behavior, with automated contract and E2E coverage used instead.

## Impact

Normal application behavior is unchanged. Local and macOS E2E runs remain hidden and no longer emit native run-completion notifications; Linux CI under xvfb remains visible for compositor pacing.

## Ready for review

- [x] Verification is complete and the results above are current
- [x] Impact, compatibility, migration, documentation, and release-note needs are addressed
- [x] User-visible UI/UX changes include visual evidence, or `Verification` explains why it is not applicable
