### PR TITLE
refactor(ui): tokenize tab indicator duration

### DIFF
--- a/apps/desktop/src/main/__tests__/primitives-design-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/primitives-design-contract.test.ts
@@ -5,7 +5,8 @@
  * count, fail when new ones creep in OR when stale allowlist entries
  * point at content that no longer exists.
  *
- * tabs.tsx has 2 `transition-[<list>]` patterns and 1 `duration-200`.
+ * tabs.tsx has 2 `transition-[<list>]` patterns. The indicator duration and
+ * easing both use the renderer's canonical motion tokens.
  * The counts here are derived from `grep -o ... | wc -l`.
  */
 
@@ -29,18 +30,6 @@ const TABS_ALLOWED: ReadonlyArray<{ pattern: string; count: number; reason: stri
     count: 1,
     reason:
       'tabs trigger paint transition. No layout properties. Safe; allowlisted for completeness.',
-  },
-  {
-    pattern: 'duration-200',
-    count: 1,
-    reason:
-      'tabs indicator settle duration. Matches --duration-base (200ms) by value but uses the bare Tailwind utility; could tokenize.',
-  },
-  {
-    pattern: 'ease-in-out',
-    count: 1,
-    reason:
-      "tabs indicator easing. Generic Tailwind easing, not the project's canonical --ease-out-strong. Mismatch is small for this micro-motion but flagged for future review.",
   },
 ];
 
@@ -74,5 +63,12 @@ describe('PR-FE-BUG-HUNT-13 tabs.tsx design contract', () => {
       [],
       `Found unexpected transition-[<bracketed>] patterns in tabs.tsx: ${JSON.stringify(unexpected)}. Add to TABS_ALLOWED with a justification, or refactor.`,
     );
+  });
+
+  it('uses canonical motion tokens for the indicator transition', async () => {
+    const src = await readFile(TABS_FILE, 'utf8');
+    assert.match(src, /duration-\[var\(--duration-base\)\]/);
+    assert.match(src, /ease-\[var\(--ease-in-out-strong\)\]/);
+    assert.doesNotMatch(src, /\bduration-200\b/);
   });
 });

--- a/apps/desktop/src/main/__tests__/primitives-design-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/primitives-design-contract.test.ts
@@ -67,8 +67,11 @@ describe('PR-FE-BUG-HUNT-13 tabs.tsx design contract', () => {
 
   it('uses canonical motion tokens for the indicator transition', async () => {
     const src = await readFile(TABS_FILE, 'utf8');
-    assert.match(src, /duration-\[var\(--duration-base\)\]/);
-    assert.match(src, /ease-\[var\(--ease-in-out-strong\)\]/);
-    assert.doesNotMatch(src, /\bduration-200\b/);
+    const indicator = src.match(/<TabsPrimitive\.Indicator[\s\S]*?data-slot="tab-indicator"[\s\S]*?\/>/)?.[0] ?? '';
+    assert.ok(indicator, 'TabsPrimitive.Indicator block must remain discoverable');
+    assert.match(indicator, /transition-\[width,translate\]/);
+    assert.match(indicator, /duration-\[var\(--duration-base\)\]/);
+    assert.match(indicator, /ease-\[var\(--ease-in-out-strong\)\]/);
+    assert.doesNotMatch(indicator, /\bduration-200\b/);
   });
 });

--- a/packages/ui/src/primitives/tabs.tsx
+++ b/packages/ui/src/primitives/tabs.tsx
@@ -47,7 +47,7 @@ export function TabsList({
       {children}
       <TabsPrimitive.Indicator
         className={cn(
-          "absolute bottom-0 left-0 h-(--active-tab-height) w-(--active-tab-width) translate-x-(--active-tab-left) -translate-y-(--active-tab-bottom) transition-[width,translate] duration-200 ease-[var(--ease-in-out-strong)]",
+          "absolute bottom-0 left-0 h-(--active-tab-height) w-(--active-tab-width) translate-x-(--active-tab-left) -translate-y-(--active-tab-bottom) transition-[width,translate] duration-[var(--duration-base)] ease-[var(--ease-in-out-strong)]",
           variant === "underline"
             ? "z-10 bg-foreground data-[orientation=horizontal]:h-0.5 data-[orientation=vertical]:w-0.5 data-[orientation=vertical]:-translate-x-px data-[orientation=horizontal]:translate-y-px"
             : variant === "pill"


### PR DESCRIPTION
## Summary

- Route the shared Tabs indicator duration through `--duration-base`.
- Tighten the design contract so transition, duration, and easing are asserted on the Indicator itself.
- Remove stale escape-hatch documentation for the already-tokenized easing.

## Why

Phase 1 of #835 closes the remaining directly actionable Tabs motion-token escape hatch without replacing the intentionally allowlisted variable-width transition.

Refs #835.

## Scope

The indicator's width/translate transition and `--ease-in-out-strong` easing remain unchanged. This does not introduce measurement infrastructure or alter other Tabs styling.

## Verification

- `npm --workspace @maka/ui test` — 111 passed.
- `npm --workspace @maka/desktop run typecheck` — passed.
- `npm --workspace @maka/desktop test` — 2,357 passed.
- Tabs + motion-token contract tests — 13 passed during the focused TDD loop.
- `node scripts/check-dead-css.mjs --check` — passed.
- Codex review: initial P2 about contract scope fixed; re-review PASS with no remaining P0–P2 or P3 findings.
- Visual evidence: the deterministic `module-skills/light-1280-motion` smoke scenario rendered the shared underline Tabs correctly after the change. A static before/after pair is not meaningful for a duration-only change; the Tailwind compile check verified `transition-duration: var(--duration-base)`, and the generated scenario was inspected for layout regressions. The screenshot harness did not exit after the first successful variant, so the remaining repeated variants were stopped rather than reported as passed.

## Impact

The Tabs indicator now settles in the canonical 150ms base duration instead of the bare 200ms utility. No compatibility, migration, documentation, or release-note work is required.

## Ready for review

- [x] Verification is complete and the results above are current
- [x] Impact, compatibility, migration, documentation, and release-note needs are addressed
- [x] User-visible UI/UX changes include visual evidence, or `Verification` explains why it is not applicable