### PR TITLE
feat(ui): add BrowserPanel chrome visual-smoke fixture + source contract (#819)

### DIFF
--- a/apps/desktop/src/main/__tests__/browser-panel-chrome.test.ts
+++ b/apps/desktop/src/main/__tests__/browser-panel-chrome.test.ts
@@ -1,0 +1,105 @@
+/**
+ * Source contract for BrowserPanel renderer chrome invariants (#819).
+ *
+ * Symmetric to `artifact-pane-layout.test.ts` (regex over the component's
+ * source). The visual-smoke `browser-empty` fixture owns screenshot
+ * verification of the chrome layout; this test locks the declarative
+ * wirings that produce the chrome's state-dependent DOM — the invariants
+ * the issue lists as not needing a screenshot:
+ *
+ *  - back / forward buttons `:disabled` track `canGoBack` / `canGoForward`;
+ *  - reload / stop icon swaps with `loading` (+ aria-label + onClick branch);
+ *  - address bar snaps to the live URL on blur when not editing;
+ *  - empty state present when `!hasPage`.
+ *
+ * These are declarative (`disabled={expr}`, `cond ? <X/> : <Y/>`,
+ * `onBlur={...}`, `!hasPage && <Empty>`) — the wiring IS the rendered DOM,
+ * so a source contract is a reliable proxy without a render harness. The
+ * repo has no jsdom/testing-library, and `BrowserPanel` is IPC-driven via
+ * `window.maka.browser`, so a render test would need heavy mocking for no
+ * extra guarantee over the declarative wiring. Cascade-effective CSS
+ * (overlapping rules, `all:initial`) is out of scope here and belongs to
+ * the #819 computed-style fixture layer.
+ */
+
+import { strict as assert } from 'node:assert';
+import { readFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+import { before, describe, it } from 'node:test';
+import { CONTRACT_RENDERER_ROOT } from './contract-css-helpers.js';
+
+const BROWSER_PANEL_SOURCE = resolve(CONTRACT_RENDERER_ROOT, 'browser-panel.tsx');
+
+describe('BrowserPanel renderer chrome source contract (#819)', () => {
+  let source!: string;
+
+  before(async () => {
+    source = await readFile(BROWSER_PANEL_SOURCE, 'utf8');
+    assert.ok(source.length > 0, 'browser-panel.tsx source must be non-empty');
+  });
+
+  it('back button :disabled tracks canGoBack', () => {
+    // The back nav button must bind `disabled` to `!canGoBack` so the DOM
+    // disabled attribute reflects the browser's back-history state.
+    // `!state.canGoBack` is unique to the back button, so the expression
+    // match locks the binding without depending on attribute order/adjacency
+    // (innocent JSX reformatting / attribute insertion must not false-positive).
+    assert.match(source, /disabled=\{!state\.canGoBack\}/, 'back button disabled must track !state.canGoBack');
+  });
+
+  it('forward button :disabled tracks canGoForward', () => {
+    // `!state.canGoForward` is unique to the forward button.
+    assert.match(source, /disabled=\{!state\.canGoForward\}/, 'forward button disabled must track !state.canGoForward');
+  });
+
+  it('reload/stop icon swaps with loading (+ aria-label + onClick branch)', () => {
+    // The third nav button swaps its icon (X stop vs RotateCw reload), its
+    // aria-label, and its onClick target between stop/reload based on
+    // state.loading — all three must branch on the same flag.
+    assert.match(
+      source,
+      /aria-label=\{state\.loading\s*\?\s*'停止加载页面'\s*:\s*'刷新页面'\}/,
+      'reload/stop aria-label must swap with state.loading',
+    );
+    assert.match(
+      source,
+      /\{state\.loading\s*\?\s*<X[^>]*\/>\s*:\s*<RotateCw[^>]*\/>\}/,
+      'reload/stop icon must swap X (stop) / RotateCw (reload) with state.loading',
+    );
+    assert.match(
+      source,
+      /state\.loading\s*\?\s*void window\.maka\.browser\.stop\(sessionId\)\s*:\s*void window\.maka\.browser\.reload\(sessionId\)/,
+      'reload/stop onClick must branch stop vs reload on state.loading',
+    );
+  });
+
+  it('address bar snaps to the live URL on blur when not editing', () => {
+    // The address input is editable (onChange updates local `address`);
+    // onFocus marks editing so a mid-edit state push doesn't clobber typing;
+    // onBlur clears editing + snaps back to the live URL.
+    assert.match(
+      source,
+      /value=\{address\}/,
+      'address input value must bind to the editable local `address`',
+    );
+    assert.match(
+      source,
+      /onFocus=\{\(\)\s*=>\s*\{\s*editingRef\.current\s*=\s*true;\s*\}\}/,
+      'onFocus must mark editingRef true so state pushes do not clobber typing',
+    );
+    assert.match(
+      source,
+      /onBlur=\{\(\)\s*=>\s*\{\s*editingRef\.current\s*=\s*false;\s*setAddress\(state\.url\);\s*\}\}/,
+      'onBlur must clear editingRef + snap address back to the live state.url',
+    );
+  });
+
+  it('empty state present when !hasPage', () => {
+    // The strip renders the Empty chrome only when no page is loaded.
+    assert.match(
+      source,
+      /\{!state\.hasPage\s*&&\s*\(\s*<Empty className="maka-browser-empty/,
+      'empty state must render when !state.hasPage',
+    );
+  });
+});

--- a/apps/desktop/src/main/__tests__/visual-smoke-fixture.test.ts
+++ b/apps/desktop/src/main/__tests__/visual-smoke-fixture.test.ts
@@ -1211,6 +1211,47 @@ describe('visual smoke fixture mode', () => {
   });
 });
 
+describe('browser-empty chrome fixture (#819)', () => {
+  it('seeds a live browser session id so BrowserPanel mounts over the turn chat in empty state', () => {
+    const fixture = resolveVisualSmokeFixture('browser-empty', false);
+    assert.ok(fixture, 'browser-empty should resolve');
+    const state = getVisualSmokeState(fixture);
+    assert.equal(state?.scenario, 'browser-empty');
+    // Active session is the standard turn session so the chat surface
+    // behind the browser panel renders meaningful context.
+    assert.equal(state?.activeSessionId, 'visual-smoke-turn');
+    // liveBrowserSessionIds is the contract the renderer reads to mount
+    // BrowserPanel (app-shell gates on activeId && liveBrowserSessionIds
+    // .includes(activeId)). Seeding the active session makes the panel
+    // mount; with no real WebContentsView in visual-smoke mode,
+    // browser.getState returns null → BrowserPanel renders EMPTY_STATE →
+    // the empty-state chrome (#818 defect surface) is what screenshots.
+    assert.deepEqual(state?.liveBrowserSessionIds, ['visual-smoke-turn']);
+  });
+
+  it('reuses the always-seeded turn session so no browser-specific on-disk seed is needed', async () => {
+    const workspaceRoot = await mkdtemp(join(tmpdir(), 'maka-visual-smoke-browser-empty-'));
+    try {
+      const fixture = resolveVisualSmokeFixture('browser-empty', false);
+      assert.ok(fixture);
+      await seedVisualSmokeFixture({
+        workspaceRoot,
+        fixture,
+        credentialStore: fakeCredentialStore(),
+        now: 1_700_000_000_000,
+      });
+      // The turn session is part of the standard seed (always written),
+      // so the active browser session has a real on-disk chat behind the
+      // panel without a browser-specific seed branch.
+      const file = await readFile(join(workspaceRoot, 'sessions', 'visual-smoke-turn', 'session.jsonl'), 'utf8');
+      const header = JSON.parse(file.split('\n')[0]!) as { id: string };
+      assert.equal(header.id, 'visual-smoke-turn');
+    } finally {
+      await rm(workspaceRoot, { recursive: true, force: true });
+    }
+  });
+});
+
 function fakeCredentialStore(secrets: string[] = []) {
   return {
     async setSecret(slug: string, field: string): Promise<void> {

--- a/apps/desktop/src/main/visual-smoke-fixture.ts
+++ b/apps/desktop/src/main/visual-smoke-fixture.ts
@@ -121,6 +121,12 @@ const VISUAL_SMOKE_SCENARIOS = new Set<VisualSmokeScenario>([
   // session on boot, so off-screen turns mount as content-visibility
   // placeholders (see e2e/scroll-geometry.spec.ts).
   'long-transcript',
+  // #819: BrowserPanel renderer-chrome fixture. Seeds `liveBrowserSessionIds`
+  // with the active turn session so `BrowserPanel` mounts; with no native
+  // `WebContentsView` in visual-smoke mode, `browser.getState` resolves null
+  // → `EMPTY_STATE` → the empty-state chrome (toolbar all-nav-disabled +
+  // `<Empty>` strip) the #818 narrow-layout defect regressed against.
+  'browser-empty',
 ]);
 
 // Fixed clock for screenshot fixtures. All seeded timestamps and
@@ -325,6 +331,16 @@ export function getVisualSmokeState(fixture: VisualSmokeFixture | null): VisualS
       return { ...state, activeSessionId: ARTIFACT_SESSION_ID };
     case 'turn-narrative':
       return { ...state, activeSessionId: TURN_SESSION_ID };
+    case 'browser-empty':
+      // #819: the active turn session is also seeded as a live browser
+      // session so BrowserPanel mounts over the chat. No native
+      // WebContentsView exists in visual-smoke mode, so browser.getState
+      // resolves null → BrowserPanel renders EMPTY_STATE → the empty-state
+      // chrome is what screenshots capture (the #818 defect surface).
+      // Loaded / loading / nav chrome states are locked by the
+      // `browser-panel-chrome` source contract; their screenshots add no
+      // layout value over this empty-state baseline.
+      return { ...state, activeSessionId: TURN_SESSION_ID, liveBrowserSessionIds: [TURN_SESSION_ID] };
     case 'streaming-sidebar':
       return {
         ...state,

--- a/apps/desktop/src/renderer/app-shell-visual-smoke.ts
+++ b/apps/desktop/src/renderer/app-shell-visual-smoke.ts
@@ -15,6 +15,7 @@ export function createAppShellVisualSmokeActions(options: {
   openSettingsSection: (section: SettingsSection) => void;
   refreshSessions: () => Promise<unknown>;
   setActiveId: (sessionId: string | undefined) => void;
+  setLiveBrowserSessionIds: Dispatch<SetStateAction<string[]>>;
   setLiveTurnBySession: StateUpdater<Record<string, LiveTurnProjection>>;
   setNavSelection: Dispatch<SetStateAction<NavSelection>>;
   setPermissionBySession: StateUpdater<PermissionQueues>;
@@ -27,6 +28,7 @@ export function createAppShellVisualSmokeActions(options: {
     openSettingsSection,
     refreshSessions,
     setActiveId,
+    setLiveBrowserSessionIds,
     setLiveTurnBySession,
     setNavSelection,
     setPermissionBySession,
@@ -102,6 +104,13 @@ export function createAppShellVisualSmokeActions(options: {
     await refreshSessions();
     if (state.activeSessionId) {
       setActiveId(state.activeSessionId);
+    }
+    // #819: seed live browser session ids so BrowserPanel mounts for the
+    // active session (app-shell gates on `activeId &&
+    // liveBrowserSessionIds.includes(activeId)`). Only the `browser-empty`
+    // scenario sets this; real users never receive a visual smoke state.
+    if (state.liveBrowserSessionIds) {
+      setLiveBrowserSessionIds(state.liveBrowserSessionIds);
     }
     if (state.sidebarCollapsed !== undefined) {
       setSessionListCollapsed(state.sidebarCollapsed);

--- a/apps/desktop/src/renderer/app-shell.tsx
+++ b/apps/desktop/src/renderer/app-shell.tsx
@@ -941,6 +941,7 @@ export function AppShell({
     openSettingsSection,
     refreshSessions,
     setActiveId,
+    setLiveBrowserSessionIds,
     setLiveTurnBySession,
     setNavSelection,
     setPermissionBySession,

--- a/packages/core/src/visual-smoke.ts
+++ b/packages/core/src/visual-smoke.ts
@@ -119,7 +119,18 @@ export type VisualSmokeScenario =
   // 250px content-visibility placeholders, so this seed exercises the
   // warm-up + pinned-bottom geometry invariants (E2E scroll-geometry spec)
   // and gives screenshots a long-transcript surface.
-  | 'long-transcript';
+  | 'long-transcript'
+  // #819: BrowserPanel renderer-chrome fixture. Seeds `liveBrowserSessionIds`
+  // with the active turn session so `BrowserPanel` mounts (app-shell gates
+  // on `activeId && liveBrowserSessionIds.includes(activeId)`). In
+  // visual-smoke mode there is no native `WebContentsView`, so
+  // `browser.getState` resolves null and `BrowserPanel` renders `EMPTY_STATE`
+  // — the empty-state chrome (toolbar with all nav buttons disabled + the
+  // `<Empty>` strip) that the #818 narrow-layout defect regressed against.
+  // Loaded / loading / nav chrome states are locked by the
+  // `browser-panel-chrome` source contract (their wiring IS the behavior);
+  // their screenshots add no layout value over this empty-state baseline.
+  | 'browser-empty';
 
 export interface VisualSmokeLiveTool {
   toolUseId: string;
@@ -158,6 +169,15 @@ export interface VisualSmokeState {
    */
   now?: number;
   activeSessionId?: string;
+  /**
+   * #819: session ids with a live embedded-browser view, mirrorring the
+   * renderer's `liveBrowserSessionIds` state (app-shell gates `BrowserPanel`
+   * mounting on `activeId && liveBrowserSessionIds.includes(activeId)`).
+   * Seeded only by the `browser-empty` scenario so the renderer chrome can
+   * be screenshot-captured. Real users never receive a visual smoke state, so
+   * this never drives production `browser:live` wiring.
+   */
+  liveBrowserSessionIds?: string[];
   openSettingsSection?: SettingsSection;
   liveTurnBySession?: Record<string, VisualSmokeLiveTurnProjection>;
   permissionBySession?: Record<string, PermissionRequestEvent>;

--- a/scripts/capture-screenshots.mjs
+++ b/scripts/capture-screenshots.mjs
@@ -131,6 +131,14 @@ const ALL_SCENARIOS = [
   // Reviewers should see the single overflow trigger cleanly painted with
   // NO `Nm ago` peeking through and NO unread dot stacked behind.
   'sidebar-row-actions-visible',
+  // #819: BrowserPanel renderer-chrome fixture. Seeds
+  // `liveBrowserSessionIds` with the active turn session so the panel
+  // mounts; with no native WebContentsView in visual-smoke mode,
+  // browser.getState resolves null → EMPTY_STATE → the empty-state
+  // chrome (toolbar all-nav-disabled + <Empty> strip) the #818
+  // narrow-layout defect regressed against. 1280/990 × light/dark
+  // variants baseline the chrome layout at wide + narrow gates.
+  'browser-empty',
 ];
 
 const VARIANTS = [


### PR DESCRIPTION
## Summary

- Add a `browser-empty` visual-smoke fixture scenario that mounts `BrowserPanel` (via a new `VisualSmokeState.liveBrowserSessionIds` field wired into `applyVisualSmokeFixture`) so the renderer chrome can be screenshot-captured in the empty state — the #818 narrow-layout defect surface.
- Add a `browser-panel-chrome` source contract (symmetric to `artifact-pane-layout.test.ts`) locking the 5 declarative chrome invariants that don't need a screenshot: back/forward `:disabled` track `canGoBack`/`canGoForward`; reload/stop icon + aria-label + onClick swap with `loading`; address bar snaps to live URL on blur when not editing; empty state present when `!hasPage`.

## Why

`BrowserPanel` (`apps/desktop/src/renderer/browser-panel.tsx`) is the renderer chrome over a native Electron `WebContentsView`; the native page can't be captured in a deterministic fixture, but the chrome is renderer DOM. The chrome had no deterministic visual or DOM/computed-style coverage, so layout/a11y regressions (e.g. the narrow-layout defect fixed in #818) could only be caught by manual real-window smoke.

Closes #819.

## Scope

- **Loaded / loading / nav chrome states are intentionally not screenshot-fixture'd.** Their layout is identical to empty (#818 is a layout defect, not a state defect), loading/nav are transient and can't be deterministically captured, and their state invariants are locked by the source contract. Seeding `BrowserState` for a loaded screenshot would need a production test-seam (a main-side visual-smoke `browser:state` emit hook, or a visual-smoke read inside `BrowserPanel`) for no layout-regression value — rejected on first-principles/Occam's-razor grounds.
- **Source contract over render test.** The repo has no jsdom/testing-library, and `BrowserPanel` is IPC-driven via `window.maka.browser`. The 5 invariants are declarative (`disabled={expr}`, `cond ? <X/> : <Y/>`, `onBlur={...}`, `!hasPage && <Empty>`) — the wiring IS the rendered DOM, so a source regex is a reliable proxy without a render harness + heavy mocking. This matches the cited symmetry (`artifact-pane-layout.test.ts`).
- **`liveBrowserSessionIds` is a natural seam.** It's the exact state the renderer already uses to gate `BrowserPanel` mounting (`activeId && liveBrowserSessionIds.includes(activeId)`); adding it to `VisualSmokeState` extends the existing fixture contract, no production behavior change. Real users never receive a visual smoke state.

## Verification

- `typecheck` ✓ (main + renderer + storybook)
- `test` ✓ — 2363/2363 (was 2354; +2 `browser-empty` fixture tests, +5 `browser-panel-chrome` contract tests)
- `browser-panel-chrome` ✓ 5/5 (back/forward disabled, reload/stop swap, address blur-snap, empty-state)
- `visual-smoke-fixture` ✓ — `browser-empty` scenario resolves, `activeSessionId` + `liveBrowserSessionIds` seeded correctly, turn session on disk (reused, no browser-specific seed)
- 8 baseline PNGs generated at `apps/desktop/tests/screenshots/browser-empty/` (gitignored generated captures): `1280/990 × light/dark × motion/reduced`. Dimensions verified via `sips` (1280→2560×1640, 990→1980×1640 Retina; sizes 249KB light / 729KB-1MB dark, non-blank). motion == reduced-motion byte-for-byte (empty chrome has no animation).
- **Visual evidence:** I can't read images, so I can't visually verify the PNGs. The chrome *layout* regression surface is locked by the existing `browser-panel-layout` CSS contract (#818/#824, already merged) + the empty-state fixture; the 5 *behavioral* invariants are locked by the source contract. The generated PNGs are a **stable-subset candidate** pending visual review + promotion to `screenshots-baseline/` via a separate baseline commit (the established pattern — baselines are committed separately from fixture code, e.g. `e1d1344e`, `12ad19aa`; `--update-baseline` is designed for a full `--all` re-capture, not single-scenario promotion).

## Impact

None on users — visual-smoke mode only; real users never receive a visual smoke state, so `liveBrowserSessionIds` never drives production `browser:live` wiring. Dev/test impact: a new fixture scenario + a new source contract test; the capture script's `ALL_SCENARIOS` includes `browser-empty` for baseline runs.

## Reviewer notes

- The `browser-empty` scenario reuses the always-seeded turn session (`TURN_SESSION_ID`), so it adds no on-disk seed branch — `getVisualSmokeState` returns `liveBrowserSessionIds: [TURN_SESSION_ID]` + `activeSessionId: TURN_SESSION_ID`; `seedVisualSmokeFixture` already writes the turn session unconditionally.
- Per-capture wall time was ~60s (right at the capture script's 60s subprocess timeout) — the app doesn't self-exit after the capture marker, so the script kills it at the timeout; all 8 variants still produced valid PNGs. This is pre-existing capture-script behavior, not introduced here.

## Ready for review

- [x] Verification is complete and the results above are current
- [x] Impact, compatibility, migration, documentation, and release-note needs are addressed
- [x] User-visible UI/UX changes include visual evidence, or `Verification` explains why it is not applicable