### PR TITLE
refactor(ui): share chat input behavior

### DIFF
--- a/apps/desktop/e2e/attachment.spec.ts
+++ b/apps/desktop/e2e/attachment.spec.ts
@@ -1,5 +1,36 @@
 import { test, expect } from './fixtures';
 
+test('chat input preserves an IME composition when a file paste arrives', async ({ window: page }) => {
+  const quickChat = page.locator('.maka-onboarding-quickchat-input');
+  await quickChat.fill('ime-paste-test');
+  await quickChat.press('Enter');
+  await expect(page.getByText(/Fake backend received: ime-paste-test/)).toBeVisible();
+
+  const composer = page.locator('.maka-composer');
+  await expect(composer).toHaveAttribute('data-maka-file-drop-target', 'true');
+  const textarea = composer.locator('textarea');
+
+  const pasteResults = await textarea.evaluate((input) => {
+    const dispatchFilePaste = () => {
+      const clipboardData = new DataTransfer();
+      clipboardData.items.add(new File(['content'], 'note.txt', { type: 'text/plain' }));
+      const event = new Event('paste', { bubbles: true, cancelable: true });
+      Object.defineProperty(event, 'clipboardData', { value: clipboardData });
+      input.dispatchEvent(event);
+      return event.defaultPrevented;
+    };
+
+    input.dispatchEvent(new CompositionEvent('compositionstart', { bubbles: true }));
+    const duringComposition = dispatchFilePaste();
+    input.dispatchEvent(new CompositionEvent('compositionend', { bubbles: true }));
+    const afterComposition = dispatchFilePaste();
+
+    return { duringComposition, afterComposition };
+  });
+
+  expect(pasteResults).toEqual({ duringComposition: false, afterComposition: true });
+});
+
 /**
  * Attachment upload + ingest: enter the chat view, drop a file onto the main
  * composer, confirm it shows as a pending card, then send the message and

--- a/apps/desktop/src/main/__tests__/composer-send-guard.test.ts
+++ b/apps/desktop/src/main/__tests__/composer-send-guard.test.ts
@@ -24,7 +24,7 @@ describe('composer send guard', () => {
     const toolbar = source.match(/<div className="maka-composer-toolbar[\s\S]*?<\/div>\n        <\/div>/)?.[0] ?? '';
 
     assert.match(sendCurrent, /sendPendingRef\.current/, 'composer must use a ref guard for same-tick duplicate submits');
-    assert.match(sendCurrent, /if \(props\.disabled \|\| sendPendingRef\.current \|\| pendingImportActionRef\.current\) return;/);
+    assert.match(sendCurrent, /if \(props\.disabled \|\| sendPendingRef\.current \|\| importActionOwnerRef\.current\?\.pending\) return;/);
     assert.match(sendCurrent, /sendPendingRef\.current = true;[\s\S]*setSendPending\(true\);/);
     assert.match(sendCurrent, /finally \{[\s\S]*sendPendingRef\.current = false;[\s\S]*if \(composerMountedRef\.current\) setSendPending\(false\);[\s\S]*\}/);
     assert.match(toolbar, /sendPending \? \(\s*copy\.sending\s*\)/, 'toolbar must surface the transient sending state');
@@ -58,7 +58,7 @@ describe('composer send guard', () => {
     assert.match(composerBlock, /const composerMountedRef = useRef\(true\)/);
     assert.match(
       composerBlock,
-      /useEffect\(\(\) => \{\s*composerMountedRef\.current = true;[\s\S]*?return \(\) => \{\s*composerMountedRef\.current = false;\s*sendPendingRef\.current = false;\s*pendingImportActionRef\.current = null;\s*\};\s*\}, \[\]\)/,
+      /useEffect\(\(\) => \{\s*composerMountedRef\.current = true;[\s\S]*?return \(\) => \{\s*composerMountedRef\.current = false;\s*sendPendingRef\.current = false;\s*importActionOwnerRef\.current\?\.reset\(\);\s*\};\s*\}, \[\]\)/,
       'Composer must release send/import pending owners when it unmounts or StrictMode replays cleanup',
     );
     assert.match(

--- a/apps/desktop/src/main/__tests__/first-run-task-suggestions.test.ts
+++ b/apps/desktop/src/main/__tests__/first-run-task-suggestions.test.ts
@@ -105,13 +105,14 @@ describe('FIRST_RUN_TASK_SUGGESTIONS', () => {
 
     assert.match(readyBlock, /const \[pendingImportAction, setPendingImportAction\] = useState<string \| null>\(null\)/);
     assert.match(readyBlock, /const readyHeroMountedRef = useRef\(true\)/);
-    assert.match(readyBlock, /const pendingImportActionRef = useRef<string \| null>\(null\)/);
+    assert.match(readyBlock, /const importActionOwnerRef = useRef<ChatInputActionOwner<string> \| null>\(null\)/);
+    assert.match(readyBlock, /importActionOwnerRef\.current = createChatInputActionOwner/);
     assert.match(readyBlock, /const importActionBusy = pendingImportAction !== null/);
     assert.match(readyBlock, /const appendImportedPrompt = useCallback\(\(prompt: string\) => \{[\s\S]*if \(!readyHeroMountedRef\.current\) return;[\s\S]*setDraft\(/);
     assert.match(
       gateBlock,
-      /if \(pendingImportActionRef\.current !== null \|\| quickChatBusy\) return;[\s\S]*pendingImportActionRef\.current = actionKey[\s\S]*setPendingImportAction\(actionKey\)[\s\S]*const prompt = await action\(\)[\s\S]*if \(prompt && readyHeroMountedRef\.current\) appendImportedPrompt\(prompt\)[\s\S]*pendingImportActionRef\.current = null[\s\S]*if \(readyHeroMountedRef\.current\) setPendingImportAction\(null\)/,
-      'first-run import actions must use a ref-backed pending gate and append only through one shared path',
+      /if \(quickChatBusy\) return;[\s\S]*const prompt = await importActionOwnerRef\.current\?\.run\(actionKey,[\s\S]*const prompt = await action\(\)[\s\S]*if \(prompt && readyHeroMountedRef\.current\) appendImportedPrompt\(prompt\)/,
+      'first-run import actions must use the shared synchronous pending owner and append only through one path',
     );
     assert.match(readyBlock, /runImportAction\('drop', async \(\) => props\.onImportDroppedTextFiles\?\.\(files\)\)/);
     assert.match(readyBlock, /runImportAction\('paste', async \(\) => props\.onImportDroppedTextFiles\?\.\(files\)\)/);

--- a/apps/desktop/src/main/__tests__/onboarding-hero-copy.test.ts
+++ b/apps/desktop/src/main/__tests__/onboarding-hero-copy.test.ts
@@ -406,7 +406,7 @@ describe('OnboardingHero Quick Chat draft lifecycle', () => {
     assert.match(readyBlock, /const readyHeroMountedRef = useRef\(true\)/);
     assert.match(
       readyBlock,
-      /useEffect\(\(\) => \{[\s\S]*readyHeroMountedRef\.current = true;[\s\S]*return \(\) => \{[\s\S]*readyHeroMountedRef\.current = false;[\s\S]*submitPendingRef\.current = false;[\s\S]*pendingImportActionRef\.current = null;[\s\S]*\};[\s\S]*\}, \[\]\)/,
+      /useEffect\(\(\) => \{[\s\S]*readyHeroMountedRef\.current = true;[\s\S]*return \(\) => \{[\s\S]*readyHeroMountedRef\.current = false;[\s\S]*submitPendingRef\.current = false;[\s\S]*importActionOwnerRef\.current\?\.reset\(\);[\s\S]*\};[\s\S]*\}, \[\]\)/,
       'ReadyEmptyHero must clear async pending owners on unmount and restore mounted state during StrictMode replay',
     );
     assert.match(readyBlock, /const quickChatBusy = props\.quickChatPending \|\| submitPending/);

--- a/apps/desktop/src/renderer/OnboardingHero.tsx
+++ b/apps/desktop/src/renderer/OnboardingHero.tsx
@@ -32,7 +32,12 @@ import {
   ItemTitle,
   Textarea,
   appendPromptContextDraft,
+  createChatInputActionOwner,
   detectUiLocale,
+  fileTransferContainsFiles,
+  focusTextInputAtEnd,
+  isChatInputComposing,
+  type ChatInputActionOwner,
   type UiLocale,
 } from '@maka/ui';
 import { ProviderLogo, providerDisplay } from './settings/provider-display';
@@ -544,14 +549,19 @@ function ReadyEmptyHero(props: {
   const inputRef = useRef<HTMLTextAreaElement | null>(null);
   const readyHeroMountedRef = useRef(true);
   const submitPendingRef = useRef(false);
-  const pendingImportActionRef = useRef<string | null>(null);
+  const importActionOwnerRef = useRef<ChatInputActionOwner<string> | null>(null);
+  if (!importActionOwnerRef.current) {
+    importActionOwnerRef.current = createChatInputActionOwner((action) => {
+      if (readyHeroMountedRef.current) setPendingImportAction(action);
+    });
+  }
 
   useEffect(() => {
     readyHeroMountedRef.current = true;
     return () => {
       readyHeroMountedRef.current = false;
       submitPendingRef.current = false;
-      pendingImportActionRef.current = null;
+      importActionOwnerRef.current?.reset();
     };
   }, []);
 
@@ -591,7 +601,7 @@ function ReadyEmptyHero(props: {
       // draft. The same guard at packages/ui/src/components.tsx:5640
       // already covers the main chat input; the onboarding-hero clone
       // had drifted.
-      if (event.nativeEvent.isComposing || event.key === 'Process') return;
+      if (isChatInputComposing(event)) return;
       // Enter (without modifier) → submit. Shift+Enter inserts newline.
       if (event.key === 'Enter' && !event.shiftKey && !event.metaKey && !event.ctrlKey) {
         event.preventDefault();
@@ -615,8 +625,7 @@ function ReadyEmptyHero(props: {
     window.requestAnimationFrame(() => {
       const input = inputRef.current;
       if (!input) return;
-      input.focus();
-      input.setSelectionRange(nextDraft.length, nextDraft.length);
+      focusTextInputAtEnd(input);
     });
   }, [quickChatBusy]);
 
@@ -631,8 +640,7 @@ function ReadyEmptyHero(props: {
     window.requestAnimationFrame(() => {
       const input = inputRef.current;
       if (!input) return;
-      input.focus();
-      input.setSelectionRange(nextDraft.length, nextDraft.length);
+      focusTextInputAtEnd(input);
     });
   }, []);
 
@@ -640,18 +648,12 @@ function ReadyEmptyHero(props: {
     actionKey: string,
     action: () => Promise<string | undefined>,
   ) => {
-    if (pendingImportActionRef.current !== null || quickChatBusy) return;
-    pendingImportActionRef.current = actionKey;
-    setPendingImportAction(actionKey);
-    try {
+    if (quickChatBusy) return;
+    const prompt = await importActionOwnerRef.current?.run(actionKey, async () => {
       const prompt = await action();
-      if (prompt && readyHeroMountedRef.current) appendImportedPrompt(prompt);
-    } finally {
-      if (pendingImportActionRef.current === actionKey) {
-        pendingImportActionRef.current = null;
-        if (readyHeroMountedRef.current) setPendingImportAction(null);
-      }
-    }
+      return prompt;
+    });
+    if (prompt && readyHeroMountedRef.current) appendImportedPrompt(prompt);
   }, [appendImportedPrompt, quickChatBusy]);
 
   const importActionBusy = pendingImportAction !== null;
@@ -661,11 +663,11 @@ function ReadyEmptyHero(props: {
   ), [importActionBusy, props.onImportDroppedTextFiles, quickChatBusy]);
 
   const hasDraggedFiles = useCallback((event: DragEvent<HTMLElement>) => (
-    Array.from(event.dataTransfer.types).includes('Files')
+    fileTransferContainsFiles(event.dataTransfer.types, event.dataTransfer.files.length)
   ), []);
 
   const hasPastedFiles = useCallback((event: ClipboardEvent<HTMLTextAreaElement>) => (
-    Array.from(event.clipboardData.types).includes('Files') || event.clipboardData.files.length > 0
+    fileTransferContainsFiles(event.clipboardData.types, event.clipboardData.files.length)
   ), []);
 
   const handleDragOver = useCallback((event: DragEvent<HTMLDivElement>) => {
@@ -704,6 +706,7 @@ function ReadyEmptyHero(props: {
   }, [dragActive]);
 
   const handlePaste = useCallback((event: ClipboardEvent<HTMLTextAreaElement>) => {
+    if (isChatInputComposing(event)) return;
     if (!hasPastedFiles(event)) return;
     if (!canAcceptDroppedTextFiles()) return;
     const files = Array.from(event.clipboardData.files);

--- a/apps/desktop/src/renderer/OnboardingHero.tsx
+++ b/apps/desktop/src/renderer/OnboardingHero.tsx
@@ -549,6 +549,7 @@ function ReadyEmptyHero(props: {
   const inputRef = useRef<HTMLTextAreaElement | null>(null);
   const readyHeroMountedRef = useRef(true);
   const submitPendingRef = useRef(false);
+  const compositionActiveRef = useRef(false);
   const importActionOwnerRef = useRef<ChatInputActionOwner<string> | null>(null);
   if (!importActionOwnerRef.current) {
     importActionOwnerRef.current = createChatInputActionOwner((action) => {
@@ -601,7 +602,7 @@ function ReadyEmptyHero(props: {
       // draft. The same guard at packages/ui/src/components.tsx:5640
       // already covers the main chat input; the onboarding-hero clone
       // had drifted.
-      if (isChatInputComposing(event)) return;
+      if (isChatInputComposing(event, compositionActiveRef.current)) return;
       // Enter (without modifier) → submit. Shift+Enter inserts newline.
       if (event.key === 'Enter' && !event.shiftKey && !event.metaKey && !event.ctrlKey) {
         event.preventDefault();
@@ -706,7 +707,7 @@ function ReadyEmptyHero(props: {
   }, [dragActive]);
 
   const handlePaste = useCallback((event: ClipboardEvent<HTMLTextAreaElement>) => {
-    if (isChatInputComposing(event)) return;
+    if (isChatInputComposing(event, compositionActiveRef.current)) return;
     if (!hasPastedFiles(event)) return;
     if (!canAcceptDroppedTextFiles()) return;
     const files = Array.from(event.clipboardData.files);
@@ -745,6 +746,8 @@ function ReadyEmptyHero(props: {
             onChange={(event) => setDraft(event.target.value)}
             onKeyDown={handleKey}
             onPaste={handlePaste}
+            onCompositionStart={() => { compositionActiveRef.current = true; }}
+            onCompositionEnd={() => { compositionActiveRef.current = false; }}
             disabled={quickChatBusy}
             aria-label={copy.quickChatAria}
           />

--- a/packages/ui/src/__tests__/chat-input-behavior.test.ts
+++ b/packages/ui/src/__tests__/chat-input-behavior.test.ts
@@ -1,0 +1,57 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import {
+  createChatInputActionOwner,
+  fileTransferContainsFiles,
+  focusTextInputAtEnd,
+  isChatInputComposing,
+} from '../chat-input-behavior.js';
+
+describe('shared chat input behavior', () => {
+  it('recognizes IME composition from either the native flag or Process key', () => {
+    assert.equal(isChatInputComposing({ key: 'Enter', nativeEvent: { isComposing: true } }), true);
+    assert.equal(isChatInputComposing({ key: 'Process', nativeEvent: {} }), true);
+    assert.equal(isChatInputComposing({ key: 'Enter', nativeEvent: {} }), false);
+  });
+
+  it('recognizes file drag and paste payloads without depending on one event type', () => {
+    assert.equal(fileTransferContainsFiles(['text/plain', 'Files'], 0), true);
+    assert.equal(fileTransferContainsFiles(['text/plain'], 1), true);
+    assert.equal(fileTransferContainsFiles(['text/plain'], 0), false);
+  });
+
+  it('focuses a text input and moves its selection to the visible value end', () => {
+    const calls: Array<string | [number, number]> = [];
+    const input = {
+      value: 'hello',
+      focus: () => calls.push('focus'),
+      setSelectionRange: (start: number, end: number) => calls.push([start, end]),
+    };
+    focusTextInputAtEnd(input);
+    assert.deepEqual(calls, ['focus', [5, 5]]);
+  });
+
+  it('owns async input actions synchronously and releases only the active action', async () => {
+    const states: Array<string | null> = [];
+    const owner = createChatInputActionOwner<string>((action) => states.push(action));
+    let release!: () => void;
+    const first = owner.run('drop', () => new Promise<string>((resolve) => { release = () => resolve('done'); }));
+    assert.equal(owner.pending, 'drop');
+    assert.equal(await owner.run('paste', async () => 'ignored'), undefined);
+    release();
+    assert.equal(await first, 'done');
+    assert.equal(owner.pending, null);
+    assert.deepEqual(states, ['drop', null]);
+  });
+
+  it('reset invalidates late completion cleanup', async () => {
+    const states: Array<string | null> = [];
+    const owner = createChatInputActionOwner<string>((action) => states.push(action));
+    let release!: () => void;
+    const action = owner.run('drop', () => new Promise<void>((resolve) => { release = resolve; }));
+    owner.reset();
+    release();
+    await action;
+    assert.deepEqual(states, ['drop']);
+  });
+});

--- a/packages/ui/src/__tests__/chat-input-behavior.test.ts
+++ b/packages/ui/src/__tests__/chat-input-behavior.test.ts
@@ -11,6 +11,7 @@ describe('shared chat input behavior', () => {
   it('recognizes IME composition from either the native flag or Process key', () => {
     assert.equal(isChatInputComposing({ key: 'Enter', nativeEvent: { isComposing: true } }), true);
     assert.equal(isChatInputComposing({ key: 'Process', nativeEvent: {} }), true);
+    assert.equal(isChatInputComposing({ nativeEvent: {} }, true), true);
     assert.equal(isChatInputComposing({ key: 'Enter', nativeEvent: {} }), false);
   });
 

--- a/packages/ui/src/chat-input-behavior.ts
+++ b/packages/ui/src/chat-input-behavior.ts
@@ -1,0 +1,61 @@
+export interface ChatInputCompositionEvent {
+  key?: string;
+  nativeEvent: object;
+}
+
+export function isChatInputComposing(event: ChatInputCompositionEvent): boolean {
+  return event.key === 'Process'
+    || ('isComposing' in event.nativeEvent && event.nativeEvent.isComposing === true);
+}
+
+export function fileTransferContainsFiles(types: Iterable<string>, fileCount: number): boolean {
+  return fileCount > 0 || Array.from(types).includes('Files');
+}
+
+export interface TextInputSelectionTarget {
+  value: string;
+  focus(): void;
+  setSelectionRange(start: number, end: number): void;
+}
+
+export function focusTextInputAtEnd(input: TextInputSelectionTarget): void {
+  input.focus();
+  const end = input.value.length;
+  input.setSelectionRange(end, end);
+}
+
+export interface ChatInputActionOwner<ActionId> {
+  readonly pending: ActionId | null;
+  run<Result>(actionId: ActionId, action: () => Promise<Result>): Promise<Result | undefined>;
+  reset(): void;
+}
+
+export function createChatInputActionOwner<ActionId>(
+  onPendingChange: (action: ActionId | null) => void,
+): ChatInputActionOwner<ActionId> {
+  let pending: ActionId | null = null;
+  let generation = 0;
+  return {
+    get pending() {
+      return pending;
+    },
+    async run<Result>(actionId: ActionId, action: () => Promise<Result>): Promise<Result | undefined> {
+      if (pending !== null) return undefined;
+      const ownedGeneration = ++generation;
+      pending = actionId;
+      onPendingChange(actionId);
+      try {
+        return await action();
+      } finally {
+        if (generation === ownedGeneration && pending === actionId) {
+          pending = null;
+          onPendingChange(null);
+        }
+      }
+    },
+    reset() {
+      generation += 1;
+      pending = null;
+    },
+  };
+}

--- a/packages/ui/src/chat-input-behavior.ts
+++ b/packages/ui/src/chat-input-behavior.ts
@@ -3,8 +3,11 @@ export interface ChatInputCompositionEvent {
   nativeEvent: object;
 }
 
-export function isChatInputComposing(event: ChatInputCompositionEvent): boolean {
-  return event.key === 'Process'
+export function isChatInputComposing(
+  event: ChatInputCompositionEvent,
+  trackedComposition = false,
+): boolean {
+  return trackedComposition || event.key === 'Process'
     || ('isComposing' in event.nativeEvent && event.nativeEvent.isComposing === true);
 }
 

--- a/packages/ui/src/composer.tsx
+++ b/packages/ui/src/composer.tsx
@@ -24,6 +24,13 @@ import {
   rememberComposerHistoryEntry,
 } from './composer-helpers.js';
 import { readGlobalInputHistory, saveGlobalInputHistoryEntry } from './input-history.js';
+import {
+  createChatInputActionOwner,
+  fileTransferContainsFiles,
+  focusTextInputAtEnd,
+  isChatInputComposing,
+  type ChatInputActionOwner,
+} from './chat-input-behavior.js';
 import type { AttachmentRef, PermissionMode, ProviderType, SessionSummary } from '@maka/core';
 import { Button as UiButton } from './ui.js';
 import { Textarea as UiTextarea } from './primitives/textarea.js';
@@ -223,7 +230,12 @@ export const Composer = forwardRef<
   const activeDraftKeyRef = useRef<string | undefined>(props.draftKey);
   const composerMountedRef = useRef(true);
   const sendPendingRef = useRef(false);
-  const pendingImportActionRef = useRef<ComposerImportActionId | null>(null);
+  const importActionOwnerRef = useRef<ChatInputActionOwner<ComposerImportActionId> | null>(null);
+  if (!importActionOwnerRef.current) {
+    importActionOwnerRef.current = createChatInputActionOwner((action) => {
+      if (composerMountedRef.current) setPendingImportAction(action);
+    });
+  }
   const promptHistoryRef = useRef<ComposerHistoryState>({ entries: readGlobalInputHistory() ?? [], index: -1, savedDraft: '' });
   // PR-UI-15: locale-aware copy for placeholder + toolbar states. We
   // detect once per render (cheap) rather than memoizing — the locale
@@ -239,7 +251,7 @@ export const Composer = forwardRef<
     return () => {
       composerMountedRef.current = false;
       sendPendingRef.current = false;
-      pendingImportActionRef.current = null;
+      importActionOwnerRef.current?.reset();
     };
   }, []);
 
@@ -298,10 +310,8 @@ export const Composer = forwardRef<
         el.value = text;
         saveCurrentDraft(text);
         autoResize();
-        el.focus();
         // Move caret to end so the user can keep typing.
-        const length = el.value.length;
-        el.setSelectionRange(length, length);
+        focusTextInputAtEnd(el);
       },
       appendText(text: string) {
         const el = textareaRef.current;
@@ -310,9 +320,7 @@ export const Composer = forwardRef<
         el.value = appendPromptContextDraft(el.value, text);
         saveCurrentDraft(el.value);
         autoResize();
-        el.focus();
-        const length = el.value.length;
-        el.setSelectionRange(length, length);
+        focusTextInputAtEnd(el);
       },
       focus() {
         textareaRef.current?.focus();
@@ -322,7 +330,7 @@ export const Composer = forwardRef<
   );
 
   async function sendCurrent() {
-    if (props.disabled || sendPendingRef.current || pendingImportActionRef.current) return;
+    if (props.disabled || sendPendingRef.current || importActionOwnerRef.current?.pending) return;
     const textarea = textareaRef.current;
     const form = formRef.current;
     const text = (textarea?.value ?? '').trim();
@@ -364,22 +372,15 @@ export const Composer = forwardRef<
   }
 
   async function runImportAction(actionId: ComposerImportActionId, action: (() => void | Promise<void>) | undefined) {
-    if (!action || props.disabled || props.streaming || pendingImportActionRef.current) return;
-    pendingImportActionRef.current = actionId;
-    setPendingImportAction(actionId);
-    try {
+    if (!action || props.disabled || props.streaming) return;
+    await importActionOwnerRef.current?.run(actionId, async () => {
       await action();
-    } finally {
-      if (pendingImportActionRef.current === actionId) {
-        pendingImportActionRef.current = null;
-        if (composerMountedRef.current) setPendingImportAction(null);
-      }
-    }
+    });
   }
 
   function onTextareaKeyDown(event: KeyboardEvent<HTMLTextAreaElement>) {
     // Skip when an IME composition is active so CJK input isn't interrupted.
-    if (event.nativeEvent.isComposing || event.key === 'Process') return;
+    if (isChatInputComposing(event)) return;
     // Esc while a drag-active highlight is showing should clear it
     // immediately. The existing useEffect listens for blur/dragend/drop
     // but not keydown, so a user who hits Esc to cancel a stuck drag
@@ -462,15 +463,15 @@ export const Composer = forwardRef<
   }
 
   function canAcceptDroppedFiles(): boolean {
-    return Boolean(props.onAttachFilePaths && !props.disabled && !props.streaming && !pendingImportActionRef.current);
+    return Boolean(props.onAttachFilePaths && !props.disabled && !props.streaming && !importActionOwnerRef.current?.pending);
   }
 
   function hasDraggedFiles(event: DragEvent<HTMLFormElement>): boolean {
-    return Array.from(event.dataTransfer.types).includes('Files');
+    return fileTransferContainsFiles(event.dataTransfer.types, event.dataTransfer.files.length);
   }
 
   function hasPastedFiles(event: ClipboardEvent<HTMLTextAreaElement>): boolean {
-    return Array.from(event.clipboardData.types).includes('Files') || event.clipboardData.files.length > 0;
+    return fileTransferContainsFiles(event.clipboardData.types, event.clipboardData.files.length);
   }
 
   function onComposerDragOver(event: DragEvent<HTMLFormElement>) {
@@ -509,8 +510,7 @@ export const Composer = forwardRef<
     // TypeScript types don't acknowledge that.) Use a narrow `in` check
     // + a typed cast so this compiles AND keeps working when the
     // browser does expose the flag.
-    const native = event.nativeEvent;
-    if ('isComposing' in native && (native as { isComposing?: boolean }).isComposing) return;
+    if (isChatInputComposing(event)) return;
     if (!hasPastedFiles(event)) return;
     if (!canAcceptDroppedFiles()) return;
     const files = Array.from(event.clipboardData.files);

--- a/packages/ui/src/composer.tsx
+++ b/packages/ui/src/composer.tsx
@@ -230,6 +230,7 @@ export const Composer = forwardRef<
   const activeDraftKeyRef = useRef<string | undefined>(props.draftKey);
   const composerMountedRef = useRef(true);
   const sendPendingRef = useRef(false);
+  const compositionActiveRef = useRef(false);
   const importActionOwnerRef = useRef<ChatInputActionOwner<ComposerImportActionId> | null>(null);
   if (!importActionOwnerRef.current) {
     importActionOwnerRef.current = createChatInputActionOwner((action) => {
@@ -380,7 +381,7 @@ export const Composer = forwardRef<
 
   function onTextareaKeyDown(event: KeyboardEvent<HTMLTextAreaElement>) {
     // Skip when an IME composition is active so CJK input isn't interrupted.
-    if (isChatInputComposing(event)) return;
+    if (isChatInputComposing(event, compositionActiveRef.current)) return;
     // Esc while a drag-active highlight is showing should clear it
     // immediately. The existing useEffect listens for blur/dragend/drop
     // but not keydown, so a user who hits Esc to cancel a stuck drag
@@ -510,7 +511,7 @@ export const Composer = forwardRef<
     // TypeScript types don't acknowledge that.) Use a narrow `in` check
     // + a typed cast so this compiles AND keeps working when the
     // browser does expose the flag.
-    if (isChatInputComposing(event)) return;
+    if (isChatInputComposing(event, compositionActiveRef.current)) return;
     if (!hasPastedFiles(event)) return;
     if (!canAcceptDroppedFiles()) return;
     const files = Array.from(event.clipboardData.files);
@@ -582,6 +583,8 @@ export const Composer = forwardRef<
           disabled={props.disabled}
           onKeyDown={onTextareaKeyDown}
           onPaste={onTextareaPaste}
+          onCompositionStart={() => { compositionActiveRef.current = true; }}
+          onCompositionEnd={() => { compositionActiveRef.current = false; }}
           onInput={onTextareaInput}
           rows={1}
           autoComplete="off"

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -6,6 +6,7 @@ export * from './clipboard-feedback.js';
 export * from './components.js';
 export type { SessionHistoryStatusGroup } from './session-history-list.js';
 export * from './composer-helpers.js';
+export * from './chat-input-behavior.js';
 export * from './input-history.js';
 export * from './daily-review-helpers.js';
 export * from './locale-helpers.js';


### PR DESCRIPTION
## Summary
- centralize shared chat-input IME, file-transfer, focus, and async action ownership behavior in `@maka/ui`
- adopt the shared behavior in both the main Composer and onboarding quick chat
- add pure contracts and Chromium interaction coverage for IME-safe file paste

## Why
The two chat inputs had drifted copies of keyboard, paste/drop, focus, and pending-action behavior. This phase gives those cross-cutting behaviors one owner while preserving each input's distinct product semantics.

## Scope
- shared `chat-input-behavior` module and exports
- Composer and ReadyEmptyHero integration
- unit/source contracts and targeted Electron Playwright coverage

## Verification
- `npm --workspace @maka/ui test` — 116 passed
- `npm --workspace @maka/desktop run typecheck`
- `npm --workspace @maka/desktop test` — 2365 passed
- targeted Playwright attachment/send journey — 3 passed
- `$invoke` Codex review — PASS, no P0–P3 findings

## Impact
No intended visual changes. Interaction behavior is exercised in the live Electron renderer, including the state variant that exposed the IME regression.

Refs #835