### PR TITLE
refactor(ui): isolate app shell session ownership

### DIFF
--- a/apps/desktop/src/main/__tests__/app-shell-session-owner-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/app-shell-session-owner-contract.test.ts
@@ -1,0 +1,27 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+import { describe, it } from 'node:test';
+
+const REPO_ROOT = resolve(import.meta.dirname, '../../../../..');
+const RENDERER_ROOT = resolve(REPO_ROOT, 'apps', 'desktop', 'src', 'renderer');
+
+describe('AppShell session-list ownership boundary', () => {
+  it('keeps session collection state and IPC behind one controller hook', async () => {
+    const [shell, owner] = await Promise.all([
+      readFile(resolve(RENDERER_ROOT, 'app-shell.tsx'), 'utf8'),
+      readFile(resolve(RENDERER_ROOT, 'use-app-shell-session-list.ts'), 'utf8'),
+    ]);
+
+    assert.match(shell, /useAppShellSessionList\(/);
+    assert.doesNotMatch(shell, /useState<SessionSummary\[\]>/);
+    assert.doesNotMatch(shell, /createSessionListRefresher\(/);
+    assert.doesNotMatch(shell, /window\.maka\.sessions\.list\(/);
+
+    assert.match(owner, /createSessionListRefresher\(/);
+    assert.match(owner, /window\.maka\.sessions\.list\(/);
+    assert.match(owner, /seedSessions/);
+    assert.match(owner, /markSessionRunningOptimistic/);
+    assert.match(owner, /markSessionReadLocally/);
+  });
+});

--- a/apps/desktop/src/main/__tests__/permission-response-ipc-boundary.test.ts
+++ b/apps/desktop/src/main/__tests__/permission-response-ipc-boundary.test.ts
@@ -310,6 +310,7 @@ describe('permission response IPC boundary', () => {
       'app-shell-quick-chat-actions.ts',
       'app-shell.tsx',
       'app-shell-effects.ts',
+      'use-app-shell-session-list.ts',
     ]);
     const setActiveId = renderer.match(/function setActiveId\(next: string \| undefined\): void \{[\s\S]*?\n  \}/);
     const refreshSessions = renderer.match(/async function refreshSessions\(\)(?:: Promise<SessionSummary\[]>)? \{[\s\S]*?\n  \}/);

--- a/apps/desktop/src/main/__tests__/renderer-shell-source-helpers.ts
+++ b/apps/desktop/src/main/__tests__/renderer-shell-source-helpers.ts
@@ -28,6 +28,7 @@ const sourcePaths = [
   'app-shell-session-events.ts',
   'app-shell-session-row-actions.ts',
   'app-shell-session-settings-actions.ts',
+  'use-app-shell-session-list.ts',
   'app-shell-visual-smoke.ts',
   'cached-theme-bootstrap.ts',
   'chat-model-selection.ts',

--- a/apps/desktop/src/renderer/app-shell-effects.ts
+++ b/apps/desktop/src/renderer/app-shell-effects.ts
@@ -45,8 +45,6 @@ export function useAppShellRefSync(options: {
   activeIdRef: RefBox<string | undefined>;
   navSelection: NavSelection;
   navSelectionRef: RefBox<NavSelection>;
-  sessions: SessionSummary[];
-  sessionsRef: RefBox<SessionSummary[]>;
 }) {
   useEffect(() => {
     options.activeIdRef.current = options.activeId;
@@ -55,10 +53,6 @@ export function useAppShellRefSync(options: {
   useEffect(() => {
     options.navSelectionRef.current = options.navSelection;
   }, [options.navSelection]);
-
-  useEffect(() => {
-    options.sessionsRef.current = options.sessions;
-  }, [options.sessions]);
 }
 
 export function useAppShellHostEffects(options: {

--- a/apps/desktop/src/renderer/app-shell.tsx
+++ b/apps/desktop/src/renderer/app-shell.tsx
@@ -61,7 +61,6 @@ import { deriveStaleSessionIds } from './stale-sessions';
 import { deriveProjectGroups } from './session-project-grouping';
 import { deriveSessionStatusGroups } from './session-status-grouping';
 import {
-  normalizeSessionSummaryForDisplay,
   presentSessionStatus,
   sessionStatusAriaLabel,
 } from './session-status-presentation';
@@ -74,7 +73,6 @@ import { hasInFlightToolActivity } from './session-event-health';
 import { MODEL_CONTINUING_DELAY_MS, MODEL_PROCESSING_DELAY_MS, deriveModelWait } from './model-wait-state';
 import { useDelayedFlag } from './use-delayed-flag';
 import { safeLocalStorageSet } from './browser-storage';
-import { applyLocalSessionRead, applySessionReadOverrides, createSessionListRefresher, type SessionListRefresher, type SessionReadBoundaries } from './session-read-state';
 import { filterSessions, readNavSelection } from './nav-selection';
 import {
   readSessionListCollapsed,
@@ -117,6 +115,7 @@ import {
   useSettledSessionTransientReconcile,
 } from './app-shell-effects';
 import { loadComposerDefaults, saveComposerDefaults } from './composer-defaults';
+import { useAppShellSessionList } from './use-app-shell-session-list';
 
 function connectionsEqual(a: LlmConnection[], b: LlmConnection[]): boolean {
   if (a.length !== b.length) return false;
@@ -169,28 +168,16 @@ export function AppShell({
   initialOnboardingSnapshot?: OnboardingSnapshot | null;
 } = {}) {
   const toastApi = useToast();
-  const [sessions, setSessions] = useState<SessionSummary[]>([]);
-  const sessionsRef = useRef<SessionSummary[]>([]);
-  const sessionReadBoundariesRef = useRef<SessionReadBoundaries>({});
-  const sessionListRefresherRef = useRef<SessionListRefresher | null>(null);
-  if (!sessionListRefresherRef.current) {
-    sessionListRefresherRef.current = createSessionListRefresher({
-      listSessions: () => window.maka.sessions.list(),
-      readBoundaries: () => sessionReadBoundariesRef.current,
-      currentSessions: () => sessionsRef.current,
-      commitSessions: (next) => {
-        // Display normalization at the state boundary: non-actionable
-        // blocked (missing terminal bookkeeping) reads as an ordinary
-        // resumable session everywhere in the renderer.
-        const displayNext = next.map(normalizeSessionSummaryForDisplay);
-        sessionsRef.current = displayNext;
-        setSessions(displayNext);
-      },
-      onError: (error) => {
-        toastApi.error('刷新会话列表失败', generalizedErrorMessageChinese(error, '刷新会话列表失败，请稍后重试。'));
-      },
-    });
-  }
+  const {
+    sessions,
+    sessionsRef,
+    setSessions,
+    refreshSessions,
+    seedSessions,
+    upsertSessionSummary,
+    markSessionRunningOptimistic,
+    markSessionReadLocally,
+  } = useAppShellSessionList(toastApi);
   const [activeId, setActiveIdState] = useState<string | undefined>();
   const [pendingByKey, setPendingByKey] = useState<PendingByKey<PendingAttachment>>({});
   const attachmentDraftKey = activeId ?? 'new-session';
@@ -828,10 +815,7 @@ export function AppShell({
     // sessions flash an 已阻塞 group on first paint until the first
     // refreshSessions() overwrites the seed.
     if (snapshot.sessions.length > 0) {
-      const next = applySessionReadOverrides(snapshot.sessions, sessionReadBoundariesRef.current)
-        .map(normalizeSessionSummaryForDisplay);
-      sessionsRef.current = next;
-      setSessions(next);
+      const next = seedSessions(snapshot.sessions);
       if (!activeIdRef.current && next[0]?.lastMessageAt) setActiveId(next[0].id);
     }
     // Seed connections — avoids separate connections:list + getDefault IPCs
@@ -1086,8 +1070,6 @@ export function AppShell({
     activeIdRef,
     navSelection,
     navSelectionRef,
-    sessions,
-    sessionsRef,
   });
   useAppShellHostEffects({
     activeId,
@@ -1186,10 +1168,6 @@ export function AppShell({
       && activeIdRef.current === owner.sessionId;
   }
 
-  async function refreshSessions(): Promise<SessionSummary[]> {
-    return sessionListRefresherRef.current!.refresh();
-  }
-
   async function refreshShellSettings() {
     try {
       const next = await window.maka.settings.get();
@@ -1212,69 +1190,6 @@ export function AppShell({
     } catch (error) {
       toastApi.error('载入外观设置失败', generalizedErrorMessageChinese(error, '外观设置暂时无法载入，请稍后重试。'));
     }
-  }
-
-  function upsertSessionSummary(session: SessionSummary): void {
-    setSessions((current) => {
-      const next = [
-        normalizeSessionSummaryForDisplay(session),
-        ...current.filter((entry) => entry.id !== session.id),
-      ];
-      sessionsRef.current = next;
-      return next;
-    });
-  }
-
-  // #646: on send() we KNOW locally that a turn is starting, but the session's
-  // persisted status only flips to 'running' after an IPC round-trip
-  // (runtime → subscribeChanges). The head "正在处理…" indicator is gated on
-  // `status === 'running'` (that gate self-heals a backgrounded session whose
-  // terminal event was missed), so without a local nudge the first-token wait
-  // races — and usually loses — against the lagging status. Set it optimistically
-  // so the gate opens synchronously; subscribeChanges reconciles the real value.
-  //
-  // Returns a restore callback (or undefined when nothing was nudged). If send()
-  // fails before the turn reaches the runtime, no subscribeChanges event will
-  // arrive to reconcile the optimistic value, so the caller must revert it — but
-  // only while it is STILL the optimistic 'running' (a real status that landed
-  // meanwhile wins). Prevents a failed send from leaving a phantom running dot
-  // that also blocks the permission-mode toggle until the next unrelated refresh.
-  function markSessionRunningOptimistic(sessionId: string): (() => void) | undefined {
-    const prior = sessionsRef.current.find((entry) => entry.id === sessionId);
-    if (!prior || prior.status === 'running') return undefined;
-    const priorStatus = prior.status;
-    setSessions((current) => {
-      let changed = false;
-      const next = current.map((entry) => {
-        if (entry.id !== sessionId || entry.status === 'running') return entry;
-        changed = true;
-        return { ...entry, status: 'running' as const };
-      });
-      if (!changed) return current;
-      sessionsRef.current = next;
-      return next;
-    });
-    return () => {
-      setSessions((current) => {
-        let changed = false;
-        const next = current.map((entry) => {
-          if (entry.id !== sessionId || entry.status !== 'running') return entry;
-          changed = true;
-          return { ...entry, status: priorStatus };
-        });
-        if (!changed) return current;
-        sessionsRef.current = next;
-        return next;
-      });
-    };
-  }
-
-  function markSessionReadLocally(sessionId: string, readMessages: readonly StoredMessage[]): void {
-    setSessions((current) => {
-      const next = applyLocalSessionRead(sessionReadBoundariesRef.current, current, sessionId, readMessages);
-      sessionsRef.current = next;
-      return next;
-    });
   }
 
   async function bootstrapSessions() {

--- a/apps/desktop/src/renderer/use-app-shell-session-list.ts
+++ b/apps/desktop/src/renderer/use-app-shell-session-list.ts
@@ -1,0 +1,107 @@
+import { useRef, useState } from 'react';
+import type { SessionSummary, StoredMessage } from '@maka/core';
+import { generalizedErrorMessageChinese } from '@maka/core';
+import { normalizeSessionSummaryForDisplay } from './session-status-presentation';
+import {
+  applyLocalSessionRead,
+  applySessionReadOverrides,
+  createSessionListRefresher,
+  type SessionListRefresher,
+  type SessionReadBoundaries,
+} from './session-read-state';
+
+type ToastApi = {
+  error(title: string, description?: string): void;
+};
+
+export function useAppShellSessionList(toastApi: ToastApi) {
+  const [sessions, setSessionsState] = useState<SessionSummary[]>([]);
+  const sessionsRef = useRef<SessionSummary[]>([]);
+  const sessionReadBoundariesRef = useRef<SessionReadBoundaries>({});
+  const refresherRef = useRef<SessionListRefresher | null>(null);
+
+  function commitSessions(next: SessionSummary[]): void {
+    sessionsRef.current = next;
+    setSessionsState(next);
+  }
+
+  function setSessions(updater: (current: SessionSummary[]) => SessionSummary[]): void {
+    setSessionsState((current) => {
+      const next = updater(current);
+      sessionsRef.current = next;
+      return next;
+    });
+  }
+
+  if (!refresherRef.current) {
+    refresherRef.current = createSessionListRefresher({
+      listSessions: () => window.maka.sessions.list(),
+      readBoundaries: () => sessionReadBoundariesRef.current,
+      currentSessions: () => sessionsRef.current,
+      commitSessions: (next) => commitSessions(next.map(normalizeSessionSummaryForDisplay)),
+      onError: (error) => {
+        toastApi.error('刷新会话列表失败', generalizedErrorMessageChinese(error, '刷新会话列表失败，请稍后重试。'));
+      },
+    });
+  }
+
+  async function refreshSessions(): Promise<SessionSummary[]> {
+    return refresherRef.current!.refresh();
+  }
+
+  function seedSessions(snapshotSessions: readonly SessionSummary[]): SessionSummary[] {
+    const next = applySessionReadOverrides([...snapshotSessions], sessionReadBoundariesRef.current)
+      .map(normalizeSessionSummaryForDisplay);
+    commitSessions(next);
+    return next;
+  }
+
+  function upsertSessionSummary(session: SessionSummary): void {
+    setSessions((current) => [
+      normalizeSessionSummaryForDisplay(session),
+      ...current.filter((entry) => entry.id !== session.id),
+    ]);
+  }
+
+  // Sending locally precedes the persisted running status. Open the UI gate
+  // optimistically, then let session refresh reconcile it. The restore only
+  // applies while this exact optimistic status still owns the entry, so a
+  // newer backend update always wins.
+  function markSessionRunningOptimistic(sessionId: string): (() => void) | undefined {
+    const prior = sessionsRef.current.find((entry) => entry.id === sessionId);
+    if (!prior || prior.status === 'running') return undefined;
+    const priorStatus = prior.status;
+    setSessions((current) => current.map((entry) => (
+      entry.id === sessionId && entry.status !== 'running'
+        ? { ...entry, status: 'running' as const }
+        : entry
+    )));
+    return () => {
+      setSessions((current) => current.map((entry) => (
+        entry.id === sessionId && entry.status === 'running'
+          ? { ...entry, status: priorStatus }
+          : entry
+      )));
+    };
+  }
+
+  function markSessionReadLocally(sessionId: string, readMessages: readonly StoredMessage[]): void {
+    setSessions((current) => applyLocalSessionRead(
+      sessionReadBoundariesRef.current,
+      current,
+      sessionId,
+      readMessages,
+    ));
+  }
+
+  return {
+    sessions,
+    sessionsRef,
+    setSessions,
+    refreshSessions,
+    seedSessions,
+    upsertSessionSummary,
+    markSessionRunningOptimistic,
+    markSessionReadLocally,
+  };
+}


### PR DESCRIPTION
## Summary
- move the session collection, current-state ref, read boundaries, and refresh IPC behind `useAppShellSessionList`
- keep snapshot seeding, optimistic running state, local read reconciliation, and session upserts in that single owner
- add an ownership contract and update existing selection-race coverage to follow the new seam

## Why
AppShell was still the direct owner of a cohesive session-list state machine and its IPC refresher. This final phase leaves AppShell as the composition root while making the existing session action/effect seams consume one explicit owner.

## Scope
- session-list controller hook
- AppShell wiring and obsolete ref-sync removal
- source ownership and session-selection contracts

## Verification
- `npm --workspace @maka/desktop run typecheck`
- `npm --workspace @maka/desktop test` — 2366 passed
- targeted session owner, selection-race, and read-boundary contracts
- Electron Playwright send-message journey — passed
- `$invoke` Codex review — PASS, no P0–P3 findings

## Impact
No intended visual or UX changes. The representative live Electron chat journey covers the session create/send/refresh path; static visual review is not required for this ownership-only refactor.

Closes #835