### PR TITLE
refactor(ui): separate memory settings owners

### DIFF
--- a/apps/desktop/src/main/__tests__/local-memory-ui-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/local-memory-ui-contract.test.ts
@@ -349,7 +349,7 @@ describe('local MEMORY.md Settings UI contract', () => {
     assert.match(resetBlock, /await runMemoryWriteAction\('reset', async \(isCurrent\) => \{[\s\S]*const next = await window\.maka\.memory\.reset\(\);[\s\S]*if \(!isCurrent\(\)\) return;[\s\S]*setState\(next\);/);
     assert.match(restoreLatestBlock, /await runMemoryWriteAction\('restore', async \(isCurrent\) => \{[\s\S]*if \(!isCurrent\(\)\) return;[\s\S]*const result = await window\.maka\.memory\.restoreLatestBackup\(\);[\s\S]*if \(!isCurrent\(\)\) return;[\s\S]*setState\(result\.state\);/);
     assert.match(restoreCandidateBlock, /await runMemoryWriteAction\('restore', async \(isCurrent\) => \{[\s\S]*if \(!isCurrent\(\)\) return;[\s\S]*const result = await window\.maka\.memory\.restoreBackup\(backup\.kind\);[\s\S]*if \(!isCurrent\(\)\) return;[\s\S]*setState\(result\.state\);/);
-    assert.match(createInstructionBlock, /await runWriteAction\(`instruction:\$\{file\}:create`, async \(isActionCurrent\) => \{[\s\S]*const result = await window\.maka\.workspaceInstructions\.createFile\(file\);[\s\S]*if \(!isActionCurrent\(\)\) return;[\s\S]*await reload\(\);/);
+    assert.match(createInstructionBlock, /await runWriteAction\(`instruction:\$\{file\}:create`, async \(isActionCurrent\) => \{[\s\S]*const result = await window\.maka\.workspaceInstructions\.createFile\(file\);[\s\S]*if \(!isActionCurrent\(\)\) return;[\s\S]*const refreshed = await reload\(\);/);
     assert.match(updateStatusBlock, /await runMemoryWriteAction\('entry-status', async \(isCurrent\) => \{[\s\S]*const next = await window\.maka\.memory\.save\(result\.draft\);[\s\S]*if \(!isCurrent\(\)\) return;[\s\S]*setState\(next\);/);
     assert.match(
       actionBlock,

--- a/apps/desktop/src/main/__tests__/local-memory-ui-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/local-memory-ui-contract.test.ts
@@ -16,7 +16,7 @@ describe('local MEMORY.md Settings UI contract', () => {
   it('wires every behavior-bearing controller output at the page composition root', async () => {
     const page = await readRepo('apps/desktop/src/renderer/settings/memory-settings-page.tsx');
 
-    assert.match(page, /<WorkspaceInstructionsSection[\s\S]*state=\{workspaceInstructionState\}[\s\S]*disabled=\{memoryControlsDisabled\}[\s\S]*isActionPending=\{isMemoryActionPending\}[\s\S]*onOpen=\{openWorkspaceInstructionFile\}[\s\S]*onCreate=\{createWorkspaceInstructionFile\}/);
+    assert.match(page, /<WorkspaceInstructionsSection[\s\S]*state=\{workspaceInstructions\.state\}[\s\S]*disabled=\{memoryControlsDisabled\}[\s\S]*isActionPending=\{workspaceInstructions\.isActionPending\}[\s\S]*onOpen=\{workspaceInstructions\.openFile\}[\s\S]*onCreate=\{workspaceInstructions\.createFile\}/);
     assert.match(page, /<MemoryPromptPreviewSection[\s\S]*active=\{promptPreviewWillInject\}[\s\S]*preview=\{localMemoryPromptPreview\}[\s\S]*budgetLabel=\{localMemoryPromptPreviewBudgetLabel\}[\s\S]*blockedReason=\{promptPreviewBlockedReason\}[\s\S]*safeMode=\{effective\.status === 'safe_mode'\}[\s\S]*copyPending=\{isMemoryActionPending\('memory:prompt-preview:copy'\)\}[\s\S]*onCopy=\{copyLocalMemoryPromptPreview\}/);
 
     const entryLists = [...page.matchAll(/<MemoryEntryList[\s\S]*?\/>/g)].map((match) => match[0]);
@@ -112,7 +112,7 @@ describe('local MEMORY.md Settings UI contract', () => {
 
     assert.match(src, /LOCAL_MEMORY_PROMPT_MAX_CHARS/);
     assert.match(src, /buildLocalMemoryPromptBody/);
-    assert.match(pageBlock, /const localMemoryPromptPreview = useMemo\(\(\) => buildLocalMemoryPromptBody\(draft\) \?\? '', \[draft\]\)/);
+    assert.match(pageBlock, /const localMemoryPromptPreview = buildLocalMemoryPromptBody\(input\.draft\) \?\? ''/);
     assert.match(pageBlock, /localMemoryPromptPreviewBlockedReason\(effective\)/);
     assert.match(pageBlock, /localMemoryPromptPreviewTruncated/);
     assert.match(pageBlock, /localMemoryPromptPreviewBudgetLabel/);
@@ -218,8 +218,8 @@ describe('local MEMORY.md Settings UI contract', () => {
     assert.match(memoryPage, /aria-label=\{`创建项目指令文件 \$\{file\.file\}`\}/);
     assert.match(memoryPage, /props\.onOpen\(file\.file\)/);
     assert.match(memoryPage, /props\.onCreate\(file\.file\)/);
-    assert.match(page, /onOpen=\{openWorkspaceInstructionFile\}/);
-    assert.match(page, /onCreate=\{createWorkspaceInstructionFile\}/);
+    assert.match(page, /onOpen=\{workspaceInstructions\.openFile\}/);
+    assert.match(page, /onCreate=\{workspaceInstructions\.createFile\}/);
   });
 
   it('gates local memory file actions with visible per-action pending feedback', async () => {
@@ -233,8 +233,8 @@ describe('local MEMORY.md Settings UI contract', () => {
     assert.match(memoryPage, /pendingMemoryActionKeysRef\.current\.delete\(key\)/);
     assert.match(memoryPage, /const isMemoryActionPending = \(key: string\) => pendingMemoryActions\.has\(key\)/);
 
-    assert.match(memoryPage, /runMemoryAction\(`instruction:\$\{file\}:open`/);
-    assert.match(memoryPage, /runMemoryAction\(`instruction:\$\{file\}:create`/);
+    assert.match(memoryPage, /runAction\(`instruction:\$\{file\}:open`/);
+    assert.match(memoryPage, /runWriteAction\(`instruction:\$\{file\}:create`/);
     assert.match(memoryPage, /runMemoryAction\(`backup:\$\{backup\.kind\}:open`/);
     assert.match(memoryPage, /runMemoryAction\(`backup:\$\{backup\.kind\}:restore`/);
     assert.match(memoryPage, /runMemoryAction\(`backup:\$\{backup\.kind\}:copy`/);
@@ -260,7 +260,7 @@ describe('local MEMORY.md Settings UI contract', () => {
     const src = await readSettingsCombinedSource();
     const memoryPage = src.match(/function MemorySettingsPage\([\s\S]*?function MemoryEntryList/)?.[0] ?? '';
 
-    assert.match(memoryPage, /type MemoryWriteAction =[\s\S]*'save'[\s\S]*'reset'[\s\S]*'restore'[\s\S]*'entry-status'[\s\S]*'instruction-create'/);
+    assert.match(memoryPage, /type MemoryWriteAction =[\s\S]*'save'[\s\S]*'reset'[\s\S]*'restore'[\s\S]*'entry-status'/);
     assert.match(memoryPage, /const \[pendingMemoryWriteAction, setPendingMemoryWriteAction\] = useState<MemoryWriteAction \| null>\(null\)/);
     assert.match(memoryPage, /const memoryWriteBusyRef = useRef\(false\)/);
     assert.match(
@@ -276,12 +276,11 @@ describe('local MEMORY.md Settings UI contract', () => {
     assert.match(memoryPage, /await runMemoryWriteAction\('reload'/);
     assert.match(memoryPage, /await runMemoryWriteAction\('enable'/);
     assert.match(memoryPage, /await runMemoryWriteAction\('agent-read'/);
-    assert.match(memoryPage, /await runMemoryWriteAction\('workspace-instructions'/);
     assert.match(memoryPage, /await runMemoryWriteAction\('save'/);
     assert.match(memoryPage, /await runMemoryWriteAction\('reset'/);
     assert.match(memoryPage, /await runMemoryWriteAction\('restore'/);
     assert.match(memoryPage, /await runMemoryWriteAction\('entry-status'/);
-    assert.match(memoryPage, /await runMemoryWriteAction\('instruction-create'/);
+    assert.match(memoryPage, /useWorkspaceInstructionsController/);
     assert.match(memoryPage, /pendingMemoryWriteAction === 'save' \? '保存中…' : memoryDraftDirty \? '保存' : '已保存'/);
     assert.match(memoryPage, /pendingMemoryWriteAction === 'reload' \? '载入中…' : '重新载入'/);
     assert.match(memoryPage, /pendingMemoryWriteAction === 'reset' \? '重置中…' : '重置并备份'/);
@@ -292,7 +291,7 @@ describe('local MEMORY.md Settings UI contract', () => {
     const memoryPage = src.match(/function MemorySettingsPage\([\s\S]*?function MemoryEntryList/)?.[0] ?? '';
     const reloadBlock = memoryPage.match(/async function reload\(\)[\s\S]*?async function reloadDraftFromDisk/)?.[0] ?? '';
     const enableBlock = memoryPage.match(/async function setEnabled\(enabled: boolean\)[\s\S]*?async function setAgentReadEnabled/)?.[0] ?? '';
-    const agentReadBlock = memoryPage.match(/async function setAgentReadEnabled[\s\S]*?async function setWorkspaceInstructionsEnabled/)?.[0] ?? '';
+    const agentReadBlock = memoryPage.match(/async function setAgentReadEnabled[\s\S]*?async function save/)?.[0] ?? '';
     const saveBlock = memoryPage.match(/async function save\(\)[\s\S]*?async function reset/)?.[0] ?? '';
     const resetBlock = memoryPage.match(/async function reset\(\)[\s\S]*?async function restoreLatestBackup/)?.[0] ?? '';
     const restoreLatestBlock = memoryPage.match(/async function restoreLatestBackup\(\)[\s\S]*?async function restoreBackupCandidate/)?.[0] ?? '';
@@ -300,13 +299,13 @@ describe('local MEMORY.md Settings UI contract', () => {
     const openFileBlock = memoryPage.match(/async function openFile\(\)[\s\S]*?async function openLatestBackup/)?.[0] ?? '';
     const openLatestBlock = memoryPage.match(/async function openLatestBackup\(\)[\s\S]*?async function openBackupCandidate/)?.[0] ?? '';
     const openCandidateBlock = memoryPage.match(/async function openBackupCandidate[\s\S]*?async function openFolder/)?.[0] ?? '';
-    const openFolderBlock = memoryPage.match(/async function openFolder\(\)[\s\S]*?async function openWorkspaceInstructionFile/)?.[0] ?? '';
-    const openInstructionBlock = memoryPage.match(/async function openWorkspaceInstructionFile[\s\S]*?async function createWorkspaceInstructionFile/)?.[0] ?? '';
-    const createInstructionBlock = memoryPage.match(/async function createWorkspaceInstructionFile[\s\S]*?async function copyPath/)?.[0] ?? '';
+    const openFolderBlock = memoryPage.match(/async function openFolder\(\)[\s\S]*?async function copyPath/)?.[0] ?? '';
+    const openInstructionBlock = memoryPage.match(/async function openFile\(file: string\)[\s\S]*?async function createFile/)?.[0] ?? '';
+    const createInstructionBlock = memoryPage.match(/async function createFile[\s\S]*?return \{/)?.[0] ?? '';
     const copyPathBlock = memoryPage.match(/async function copyPath\(\)[\s\S]*?async function copyBackupReference/)?.[0] ?? '';
     const copyBackupBlock = memoryPage.match(/async function copyBackupReference[\s\S]*?async function copyLatestBackupReference/)?.[0] ?? '';
     const copyEntryBlock = memoryPage.match(/async function copyMemoryEntryReference[\s\S]*?function focusMemoryEntryInDraft/)?.[0] ?? '';
-    const updateStatusBlock = memoryPage.match(/async function updateMemoryEntryStatus[\s\S]*?\n  }\n\n  const effective =/)?.[0] ?? '';
+    const updateStatusBlock = memoryPage.match(/async function updateMemoryEntryStatus[\s\S]*?\n  }\n\n  const viewModel =/)?.[0] ?? '';
     const promptPreviewCopyBlock = memoryPage.match(/async function copyLocalMemoryPromptPreview\(\)[\s\S]*?return \{/)?.[0] ?? '';
     const writeActionBlock = memoryPage.match(/async function runMemoryWriteAction<T>[\s\S]*?async function runMemoryAction/)?.[0] ?? '';
     const actionBlock = memoryPage.match(/async function runMemoryAction<T>[\s\S]*?async function reload/)?.[0] ?? '';
@@ -326,7 +325,7 @@ describe('local MEMORY.md Settings UI contract', () => {
     );
     assert.match(
       reloadBlock,
-      /const lifecycle = memoryPageLifecycleRef\.current;[\s\S]*const ticket = \+\+memoryReloadTicketRef\.current;[\s\S]*await Promise\.all\([\s\S]*if \(!isMemoryPageCurrent\(lifecycle\) \|\| ticket !== memoryReloadTicketRef\.current\) return false;[\s\S]*setState\(next\);/,
+      /const lifecycle = memoryPageLifecycleRef\.current;[\s\S]*const ticket = \+\+memoryReloadTicketRef\.current;[\s\S]*await window\.maka\.memory\.getState\(\);[\s\S]*if \(!isMemoryPageCurrent\(lifecycle\) \|\| ticket !== memoryReloadTicketRef\.current\) return false;[\s\S]*setState\(next\);/,
       'Local memory reload must not write loaded state after unmount or a stale reload ticket',
     );
     assert.match(
@@ -350,7 +349,7 @@ describe('local MEMORY.md Settings UI contract', () => {
     assert.match(resetBlock, /await runMemoryWriteAction\('reset', async \(isCurrent\) => \{[\s\S]*const next = await window\.maka\.memory\.reset\(\);[\s\S]*if \(!isCurrent\(\)\) return;[\s\S]*setState\(next\);/);
     assert.match(restoreLatestBlock, /await runMemoryWriteAction\('restore', async \(isCurrent\) => \{[\s\S]*if \(!isCurrent\(\)\) return;[\s\S]*const result = await window\.maka\.memory\.restoreLatestBackup\(\);[\s\S]*if \(!isCurrent\(\)\) return;[\s\S]*setState\(result\.state\);/);
     assert.match(restoreCandidateBlock, /await runMemoryWriteAction\('restore', async \(isCurrent\) => \{[\s\S]*if \(!isCurrent\(\)\) return;[\s\S]*const result = await window\.maka\.memory\.restoreBackup\(backup\.kind\);[\s\S]*if \(!isCurrent\(\)\) return;[\s\S]*setState\(result\.state\);/);
-    assert.match(createInstructionBlock, /await runMemoryWriteAction\('instruction-create', async \(isCurrent\) => \{[\s\S]*const result = await window\.maka\.workspaceInstructions\.createFile\(file\);[\s\S]*if \(!isCurrent\(\)\) return;[\s\S]*const instructions = await window\.maka\.workspaceInstructions\.getState\(\);[\s\S]*if \(!isCurrent\(\)\) return;[\s\S]*setWorkspaceInstructionState\(instructions\);/);
+    assert.match(createInstructionBlock, /await runWriteAction\(`instruction:\$\{file\}:create`, async \(isActionCurrent\) => \{[\s\S]*const result = await window\.maka\.workspaceInstructions\.createFile\(file\);[\s\S]*if \(!isActionCurrent\(\)\) return;[\s\S]*await reload\(\);/);
     assert.match(updateStatusBlock, /await runMemoryWriteAction\('entry-status', async \(isCurrent\) => \{[\s\S]*const next = await window\.maka\.memory\.save\(result\.draft\);[\s\S]*if \(!isCurrent\(\)\) return;[\s\S]*setState\(next\);/);
     assert.match(
       actionBlock,
@@ -361,8 +360,8 @@ describe('local MEMORY.md Settings UI contract', () => {
     assert.match(openLatestBlock, /await runMemoryAction\('backup:latest:open', async \(isCurrent\) => \{[\s\S]*const result = await window\.maka\.memory\.openLatestBackup\(\);[\s\S]*if \(!isCurrent\(\)\) return;[\s\S]*if \(!result\.ok\) toast\.error/);
     assert.match(openCandidateBlock, /await runMemoryAction\(`backup:\$\{backup\.kind\}:open`, async \(isCurrent\) => \{[\s\S]*const result = await window\.maka\.memory\.openBackup\(backup\.kind\);[\s\S]*if \(!isCurrent\(\)\) return;[\s\S]*if \(!result\.ok\)/);
     assert.match(openFolderBlock, /await runMemoryAction\('memory:folder:open', async \(isCurrent\) => \{[\s\S]*const result = await window\.maka\.app\.openPath\('memory'\);[\s\S]*if \(!isCurrent\(\)\) return;[\s\S]*if \(!result\.ok\)/);
-    assert.match(openInstructionBlock, /await runMemoryAction\(`instruction:\$\{file\}:open`, async \(isCurrent\) => \{[\s\S]*const result = await window\.maka\.workspaceInstructions\.openFile\(file\);[\s\S]*if \(!isCurrent\(\)\) return;[\s\S]*if \(!result\.ok\)/);
-    assert.match(createInstructionBlock, /await runMemoryAction\(`instruction:\$\{file\}:create`, async \(isActionCurrent\) => \{[\s\S]*catch \(error\) \{[\s\S]*if \(isActionCurrent\(\)\) toast\.error\('创建项目指令失败', settingsActionErrorMessage\(error\)\);/);
+    assert.match(openInstructionBlock, /await runAction\(`instruction:\$\{file\}:open`, async \(isActionCurrent\) => \{[\s\S]*const result = await window\.maka\.workspaceInstructions\.openFile\(file\);[\s\S]*if \(isActionCurrent\(\) && !result\.ok\)/);
+    assert.match(createInstructionBlock, /await runWriteAction\(`instruction:\$\{file\}:create`, async \(isActionCurrent\) => \{[\s\S]*catch \(error\) \{[\s\S]*if \(isActionCurrent\(\)\) toast\.error\('创建项目指令失败', settingsActionErrorMessage\(error\)\);/);
     assert.match(copyPathBlock, /await navigator\.clipboard\.writeText\(state\.path\);[\s\S]*if \(isCurrent\(\)\) toast\.success\('已复制路径', state\.path\);[\s\S]*catch \{[\s\S]*if \(isCurrent\(\)\) toast\.error\('复制失败'/);
     assert.match(copyBackupBlock, /await navigator\.clipboard\.writeText\(reference\);[\s\S]*if \(isCurrent\(\)\) toast\.success\('已复制上一版引用'/);
     assert.match(copyEntryBlock, /await navigator\.clipboard\.writeText\(reference\);[\s\S]*if \(isCurrent\(\)\) toast\.success\('已复制记忆引用', entry\.id\);/);
@@ -394,7 +393,7 @@ describe('local MEMORY.md Settings UI contract', () => {
   it('keeps archive and restore draft-only when MEMORY.md has unsaved edits', async () => {
     const src = await readSettingsCombinedSource();
     const css = await readRendererContractCss();
-    const updateBlock = src.match(/async function updateMemoryEntryStatus[\s\S]*?\n  }\n\n  const effective =/)?.[0] ?? '';
+    const updateBlock = src.match(/async function updateMemoryEntryStatus[\s\S]*?\n  }\n\n  const viewModel =/)?.[0] ?? '';
     const listBlock = src.match(/function MemoryEntryList\([\s\S]*?function filterLocalMemoryEntries/)?.[0] ?? '';
 
     assert.match(updateBlock, /if \(memoryDraftDirty\) \{/);
@@ -434,7 +433,7 @@ describe('local MEMORY.md Settings UI contract', () => {
     assert.match(saveBlock, /const redacted = next\.content !== draft/);
     assert.match(saveBlock, /已保存并遮蔽敏感字段/);
     assert.match(saveBlock, /token、API key 或密码/);
-    assert.match(pageBlock, /const memoryDraftHasSensitiveFields = useMemo\(\(\) => redactSecrets\(draft\) !== draft, \[draft\]\)/);
+    assert.match(pageBlock, /memoryDraftHasSensitiveFields: redactSecrets\(input\.draft\) !== input\.draft/);
     assert.match(pageBlock, /settingsMemoryDraftWarning/);
     assert.match(pageBlock, /role="status"/);
     assert.match(pageBlock, /草稿含疑似敏感字段/);
@@ -472,7 +471,7 @@ describe('local MEMORY.md Settings UI contract', () => {
     const css = await readRendererContractCss();
     const pageBlock = src.match(/function MemorySettingsPage\([\s\S]*?function MemoryEntryList/)?.[0] ?? '';
 
-    assert.match(pageBlock, /const memoryDraftDirty = draft !== effective\.content/);
+    assert.match(pageBlock, /const memoryDraftDirty = input\.draft !== effective\.content/);
     assert.match(pageBlock, /settingsMemoryDirtyState/);
     assert.match(pageBlock, /有未保存修改/);
     assert.match(pageBlock, /草稿已保存/);
@@ -486,7 +485,7 @@ describe('local MEMORY.md Settings UI contract', () => {
     const pageBlock = src.match(/function MemorySettingsPage\([\s\S]*?function MemoryEntryList/)?.[0] ?? '';
 
     assert.match(src, /parseLocalMemoryMarkdown/);
-    assert.match(pageBlock, /const draftMemoryEntries = useMemo\(\(\) => parseLocalMemoryMarkdown\(draft\), \[draft\]\)/);
+    assert.match(pageBlock, /const draftMemoryEntries = parseLocalMemoryMarkdown\(input\.draft\)/);
     assert.match(pageBlock, /const visibleMemoryEntries = memoryDraftDirty \? draftMemoryEntries : effective/);
     assert.match(pageBlock, /visibleMemoryEntries\.activeEntries/);
     assert.match(pageBlock, /visibleMemoryEntries\.archivedEntries/);
@@ -544,10 +543,10 @@ describe('local MEMORY.md Settings UI contract', () => {
     const openFileBlock = pageBlock.match(/async function openFile\(\)[\s\S]*?async function openLatestBackup/)?.[0] ?? '';
     const openLatestBlock = pageBlock.match(/async function openLatestBackup\(\)[\s\S]*?async function openBackupCandidate/)?.[0] ?? '';
     const openCandidateBlock = pageBlock.match(/async function openBackupCandidate[\s\S]*?async function openFolder/)?.[0] ?? '';
-    const openFolderBlock = pageBlock.match(/async function openFolder\(\)[\s\S]*?async function openWorkspaceInstructionFile/)?.[0] ?? '';
-    const openInstructionBlock = pageBlock.match(/async function openWorkspaceInstructionFile[\s\S]*?async function createWorkspaceInstructionFile/)?.[0] ?? '';
-    const createInstructionBlock = pageBlock.match(/async function createWorkspaceInstructionFile[\s\S]*?async function copyPath/)?.[0] ?? '';
-    const updateStatusBlock = pageBlock.match(/async function updateMemoryEntryStatus[\s\S]*?\n  }\n\n  const effective =/)?.[0] ?? '';
+    const openFolderBlock = pageBlock.match(/async function openFolder\(\)[\s\S]*?async function copyPath/)?.[0] ?? '';
+    const openInstructionBlock = pageBlock.match(/async function openFile\(file: string\)[\s\S]*?async function createFile/)?.[0] ?? '';
+    const createInstructionBlock = pageBlock.match(/async function createFile[\s\S]*?return \{/)?.[0] ?? '';
+    const updateStatusBlock = pageBlock.match(/async function updateMemoryEntryStatus[\s\S]*?\n  }\n\n  const viewModel =/)?.[0] ?? '';
 
     assert.match(src, /function settingsActionErrorMessage\(error: unknown\)/);
     assert.match(reloadBlock, /catch \(error\) \{[\s\S]*toast\.error\('载入本地记忆失败', settingsActionErrorMessage\(error\)\)/);

--- a/apps/desktop/src/main/__tests__/memory-settings-ownership-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/memory-settings-ownership-contract.test.ts
@@ -20,6 +20,11 @@ describe('Memory Settings ownership', () => {
     assert.doesNotMatch(instructionOwner, /window\.maka\.memory/);
     assert.match(documentOwner, /runMemoryWriteAction\('restore'/);
     assert.match(instructionOwner, /runWriteAction\(`instruction:\$\{file\}:create`/);
+    assert.match(
+      instructionOwner,
+      /const refreshed = await reload\(\);[\s\S]*if \(!refreshed \|\| !isActionCurrent\(\)\) return;[\s\S]*toast\.success\('已创建项目指令'/,
+      'a failed post-create refresh must not claim success or open a file that the visible state still reports missing',
+    );
   });
 
   it('keeps filtering and prompt-preview derivation pure', async () => {

--- a/apps/desktop/src/main/__tests__/memory-settings-ownership-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/memory-settings-ownership-contract.test.ts
@@ -1,0 +1,33 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+import { describe, it } from 'node:test';
+
+const REPO_ROOT = resolve(import.meta.dirname, '../../../../..');
+const SETTINGS_ROOT = resolve(REPO_ROOT, 'apps/desktop/src/renderer/settings');
+
+describe('Memory Settings ownership', () => {
+  it('keeps document and workspace-instruction IPC in separate owners', async () => {
+    const [page, documentOwner, instructionOwner] = await Promise.all([
+      readFile(resolve(SETTINGS_ROOT, 'memory-settings-page.tsx'), 'utf8'),
+      readFile(resolve(SETTINGS_ROOT, 'use-memory-settings-controller.ts'), 'utf8'),
+      readFile(resolve(SETTINGS_ROOT, 'use-workspace-instructions-controller.ts'), 'utf8'),
+    ]);
+
+    assert.match(page, /useMemoryDocumentController/);
+    assert.match(page, /useWorkspaceInstructionsController/);
+    assert.doesNotMatch(documentOwner, /window\.maka\.workspaceInstructions/);
+    assert.doesNotMatch(instructionOwner, /window\.maka\.memory/);
+    assert.match(documentOwner, /runMemoryWriteAction\('restore'/);
+    assert.match(instructionOwner, /runWriteAction\(`instruction:\$\{file\}:create`/);
+  });
+
+  it('keeps filtering and prompt-preview derivation pure', async () => {
+    const viewModel = await readFile(resolve(SETTINGS_ROOT, 'memory-settings-view-model.ts'), 'utf8');
+
+    assert.match(viewModel, /export function deriveMemorySettingsViewModel/);
+    assert.match(viewModel, /parseLocalMemoryMarkdown/);
+    assert.match(viewModel, /buildLocalMemoryPromptBody/);
+    assert.doesNotMatch(viewModel, /window\.maka|useState|useEffect|useRef/);
+  });
+});

--- a/apps/desktop/src/main/__tests__/memory-settings-view-model.test.ts
+++ b/apps/desktop/src/main/__tests__/memory-settings-view-model.test.ts
@@ -1,0 +1,48 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { deriveMemorySettingsViewModel } from '../../renderer/settings/memory-settings-view-model.js';
+
+describe('Memory Settings view model', () => {
+  it('derives entry filtering and prompt preview from the visible draft', () => {
+    const draft = [
+      '# Maka Memory',
+      '',
+      '## Writing style',
+      '<!-- maka-memory: id=writing origin=manual status=active tags=preference -->',
+      'Prefer concise answers.',
+      '',
+      '## Old preference',
+      '<!-- maka-memory: id=old origin=manual status=archived -->',
+      'Use verbose answers.',
+    ].join('\n');
+
+    const result = deriveMemorySettingsViewModel({
+      state: null,
+      localMemorySettings: { enabled: true, agentReadEnabled: true },
+      draft,
+      query: 'concise',
+    });
+
+    assert.equal(result.memoryDraftDirty, true);
+    assert.equal(result.visibleMemoryEntries.activeEntries.length, 1);
+    assert.equal(result.visibleMemoryEntries.archivedEntries.length, 1);
+    assert.deepEqual(result.filteredActiveEntries.map((entry) => entry.id), ['writing']);
+    assert.equal(result.filteredArchivedEntries.length, 0);
+    assert.match(result.localMemoryPromptPreview, /Prefer concise answers\./);
+    assert.doesNotMatch(result.localMemoryPromptPreview, /Use verbose answers\./);
+  });
+
+  it('falls back to persisted settings before the document state loads', () => {
+    const result = deriveMemorySettingsViewModel({
+      state: null,
+      localMemorySettings: { enabled: true, agentReadEnabled: false },
+      draft: '',
+      query: '  ',
+    });
+
+    assert.equal(result.effective.enabled, true);
+    assert.equal(result.effective.agentReadEnabled, false);
+    assert.equal(result.normalizedMemoryEntryQuery, '');
+    assert.equal(result.promptPreviewWillInject, false);
+  });
+});

--- a/apps/desktop/src/main/__tests__/settings-contract-source-helpers.ts
+++ b/apps/desktop/src/main/__tests__/settings-contract-source-helpers.ts
@@ -19,6 +19,8 @@ const sourcePaths = [
   'web-search-settings-page.tsx',
   'memory-settings-page.tsx',
   'use-memory-settings-controller.ts',
+  'use-workspace-instructions-controller.ts',
+  'memory-settings-view-model.ts',
   'memory-settings-sections.tsx',
   'memory-entry-list.tsx',
   'memory-settings-labels.ts',

--- a/apps/desktop/src/renderer/settings/memory-settings-page.tsx
+++ b/apps/desktop/src/renderer/settings/memory-settings-page.tsx
@@ -3,7 +3,8 @@ import { Button, Chip, Input, RelativeTime, SettingsSwitch as Switch, Textarea }
 import { SettingsRows } from './settings-rows';
 import { MemoryEntryList } from './memory-entry-list';
 import { MemoryPromptPreviewSection, WorkspaceInstructionsSection } from './memory-settings-sections';
-import { useMemorySettingsController } from './use-memory-settings-controller';
+import { useMemoryDocumentController } from './use-memory-settings-controller';
+import { useWorkspaceInstructionsController } from './use-workspace-instructions-controller';
 import {
   displayMemoryPath,
   localMemoryBackupKindLabel,
@@ -18,7 +19,6 @@ export function MemorySettingsPage(props: {
   onReloadSettings(): Promise<void>;
 }) {
   const {
-    workspaceInstructionState,
     draft,
     setDraft,
     newMemoryTitle,
@@ -36,7 +36,6 @@ export function MemorySettingsPage(props: {
     reloadDraftFromDisk,
     setEnabled,
     setAgentReadEnabled,
-    setWorkspaceInstructionsEnabled,
     save,
     reset,
     restoreLatestBackup,
@@ -45,8 +44,6 @@ export function MemorySettingsPage(props: {
     openLatestBackup,
     openBackupCandidate,
     openFolder,
-    openWorkspaceInstructionFile,
-    createWorkspaceInstructionFile,
     copyPath,
     copyBackupReference,
     copyLatestBackupReference,
@@ -67,10 +64,18 @@ export function MemorySettingsPage(props: {
     promptPreviewWillInject,
     localMemoryPromptPreviewBudgetLabel,
     memoryDraftHasSensitiveFields,
-    memoryControlsDisabled,
+    memoryControlsDisabled: memoryDocumentControlsDisabled,
     isMemoryActionPending,
     copyLocalMemoryPromptPreview,
-  } = useMemorySettingsController(props);
+  } = useMemoryDocumentController({
+    settings: props.settings,
+    onReloadSettings: props.onReloadSettings,
+  });
+  const workspaceInstructions = useWorkspaceInstructionsController({
+    onUpdate: props.onUpdate,
+    onReloadSettings: props.onReloadSettings,
+  });
+  const memoryControlsDisabled = memoryDocumentControlsDisabled || workspaceInstructions.busy;
 
   return (
     <div className="settingsStructuredPage">
@@ -113,17 +118,17 @@ export function MemorySettingsPage(props: {
             ariaLabel="启用项目指令文件"
             checked={props.settings.workspaceInstructions.enabled}
             disabled={memoryControlsDisabled}
-            onChange={(enabled) => void setWorkspaceInstructionsEnabled(enabled)}
+            onChange={(enabled) => void workspaceInstructions.setEnabled(enabled)}
           />
         </div>
       </SettingsRows>
 
       <WorkspaceInstructionsSection
-        state={workspaceInstructionState}
+        state={workspaceInstructions.state}
         disabled={memoryControlsDisabled}
-        isActionPending={isMemoryActionPending}
-        onOpen={openWorkspaceInstructionFile}
-        onCreate={createWorkspaceInstructionFile}
+        isActionPending={workspaceInstructions.isActionPending}
+        onOpen={workspaceInstructions.openFile}
+        onCreate={workspaceInstructions.createFile}
       />
 
       <div className="settingsConnectionMeta settingsMemoryMeta">

--- a/apps/desktop/src/renderer/settings/memory-settings-view-model.ts
+++ b/apps/desktop/src/renderer/settings/memory-settings-view-model.ts
@@ -1,0 +1,67 @@
+import type { AppSettings, LocalMemoryState } from '@maka/core';
+import {
+  LOCAL_MEMORY_PROMPT_MAX_CHARS,
+  buildLocalMemoryPromptBody,
+  parseLocalMemoryMarkdown,
+} from '@maka/core';
+import { redactSecrets } from '@maka/ui';
+import { filterLocalMemoryEntries, localMemoryPromptPreviewBlockedReason } from './memory-settings-labels.js';
+
+export function deriveMemorySettingsViewModel(input: {
+  state: LocalMemoryState | null;
+  localMemorySettings: AppSettings['localMemory'];
+  draft: string;
+  query: string;
+}) {
+  const effective = input.state ?? {
+    path: '',
+    enabled: input.localMemorySettings.enabled,
+    agentReadEnabled: input.localMemorySettings.agentReadEnabled,
+    status: 'disabled',
+    content: '',
+    entryCount: 0,
+    activeEntryCount: 0,
+    archivedEntryCount: 0,
+    entries: [],
+    activeEntries: [],
+    archivedEntries: [],
+  } satisfies LocalMemoryState;
+  const memoryDraftDirty = input.draft !== effective.content;
+  const draftMemoryEntries = parseLocalMemoryMarkdown(input.draft);
+  const visibleMemoryEntries = memoryDraftDirty ? draftMemoryEntries : effective;
+  const memoryEntryPreviewBlockedReason = memoryDraftDirty && draftMemoryEntries.safeMode
+    ? '草稿过大，条目预览已暂停；保存前请先删减 MEMORY.md 内容。'
+    : '';
+  const normalizedMemoryEntryQuery = input.query.trim();
+  const filteredActiveEntries = filterLocalMemoryEntries(
+    visibleMemoryEntries.activeEntries,
+    normalizedMemoryEntryQuery,
+  );
+  const filteredArchivedEntries = filterLocalMemoryEntries(
+    visibleMemoryEntries.archivedEntries,
+    normalizedMemoryEntryQuery,
+  );
+  const localMemoryPromptPreview = buildLocalMemoryPromptBody(input.draft) ?? '';
+  const promptPreviewBlockedReason = localMemoryPromptPreviewBlockedReason(effective);
+  const localMemoryPromptPreviewTruncated = localMemoryPromptPreview.includes('[本地记忆已按长度截断]');
+
+  return {
+    effective,
+    memoryDraftDirty,
+    visibleMemoryEntries,
+    memoryEntryPreviewBlockedReason,
+    normalizedMemoryEntryQuery,
+    filteredActiveEntries,
+    filteredArchivedEntries,
+    filteredEntryCount: filteredActiveEntries.length + filteredArchivedEntries.length,
+    localMemoryPromptPreview,
+    promptPreviewBlockedReason,
+    promptPreviewWillInject: localMemoryPromptPreview.length > 0 && !promptPreviewBlockedReason,
+    localMemoryPromptPreviewBudgetLabel: localMemoryPromptPreview
+      ? localMemoryPromptPreviewTruncated
+        ? `预览已按 ${LOCAL_MEMORY_PROMPT_MAX_CHARS.toLocaleString('zh-CN')} 字符上限截断`
+        : `预览 ${localMemoryPromptPreview.length.toLocaleString('zh-CN')} / ${LOCAL_MEMORY_PROMPT_MAX_CHARS.toLocaleString('zh-CN')} 字符`
+      : `prompt 上限 ${LOCAL_MEMORY_PROMPT_MAX_CHARS.toLocaleString('zh-CN')} 字符`,
+    memoryDraftHasSensitiveFields: redactSecrets(input.draft) !== input.draft,
+  };
+}

--- a/apps/desktop/src/renderer/settings/use-memory-settings-controller.ts
+++ b/apps/desktop/src/renderer/settings/use-memory-settings-controller.ts
@@ -1,48 +1,39 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
-import type { AppSettings, LocalMemoryState, UpdateAppSettingsResult } from '@maka/core';
+import type { AppSettings, LocalMemoryState } from '@maka/core';
 import {
-  LOCAL_MEMORY_PROMPT_MAX_CHARS,
   appendManualLocalMemoryEntryDraft,
-  buildLocalMemoryPromptBody,
   findLocalMemoryEntryDraftRange,
-  parseLocalMemoryMarkdown,
   setLocalMemoryEntryStatusDraft,
 } from '@maka/core';
-import { redactSecrets, useToast } from '@maka/ui';
+import { useToast } from '@maka/ui';
 import { openPathFailureCopy, openPathActionLabel } from '../open-path';
 import { settingsActionErrorMessage } from './settings-error-copy';
 import {
-  filterLocalMemoryEntries,
   formatLocalMemorySaveSummary,
   localMemoryBackupKindLabel,
   localMemoryBackupSummary,
-  localMemoryPromptPreviewBlockedReason,
   memoryEntryStatusLabel,
   memoryOriginLabel,
 } from './memory-settings-labels';
+import { deriveMemorySettingsViewModel } from './memory-settings-view-model';
 
-export interface MemorySettingsControllerProps {
+export interface MemoryDocumentControllerProps {
   settings: AppSettings;
-  onUpdate(patch: Parameters<typeof window.maka.settings.update>[0]): Promise<UpdateAppSettingsResult>;
   onReloadSettings(): Promise<void>;
 }
 
-export function useMemorySettingsController(props: MemorySettingsControllerProps) {
+/** Owns the MEMORY.md document lifecycle; workspace instructions have a separate authority. */
+export function useMemoryDocumentController(props: MemoryDocumentControllerProps) {
   type MemoryWriteAction =
     | 'reload'
     | 'enable'
     | 'agent-read'
-    | 'workspace-instructions'
     | 'save'
     | 'reset'
     | 'restore'
-    | 'entry-status'
-    | 'instruction-create';
+    | 'entry-status';
 
   const [state, setState] = useState<LocalMemoryState | null>(null);
-  const [workspaceInstructionState, setWorkspaceInstructionState] = useState<Awaited<
-    ReturnType<typeof window.maka.workspaceInstructions.getState>
-  > | null>(null);
   const [draft, setDraft] = useState('');
   const [newMemoryTitle, setNewMemoryTitle] = useState('');
   const [newMemoryTags, setNewMemoryTags] = useState('');
@@ -130,13 +121,9 @@ export function useMemorySettingsController(props: MemorySettingsControllerProps
     const lifecycle = memoryPageLifecycleRef.current;
     const ticket = ++memoryReloadTicketRef.current;
     try {
-      const [next, instructions] = await Promise.all([
-        window.maka.memory.getState(),
-        window.maka.workspaceInstructions.getState(),
-      ]);
+      const next = await window.maka.memory.getState();
       if (!isMemoryPageCurrent(lifecycle) || ticket !== memoryReloadTicketRef.current) return false;
       setState(next);
-      setWorkspaceInstructionState(instructions);
       setDraft(next.content);
       setLastSaveSummary(null);
       return true;
@@ -188,17 +175,6 @@ export function useMemorySettingsController(props: MemorySettingsControllerProps
       });
     } catch (error) {
       toast.error('更新模型读取权限失败', settingsActionErrorMessage(error));
-    }
-  }
-
-  async function setWorkspaceInstructionsEnabled(enabled: boolean) {
-    try {
-      await runMemoryWriteAction('workspace-instructions', async () => {
-        await props.onUpdate({ workspaceInstructions: { enabled } });
-        await props.onReloadSettings();
-      });
-    } catch (error) {
-      toast.error('更新项目指令开关失败', settingsActionErrorMessage(error));
     }
   }
 
@@ -362,42 +338,6 @@ export function useMemorySettingsController(props: MemorySettingsControllerProps
     });
   }
 
-  async function openWorkspaceInstructionFile(file: string) {
-    await runMemoryAction(`instruction:${file}:open`, async (isCurrent) => {
-      try {
-        const result = await window.maka.workspaceInstructions.openFile(file);
-        if (!isCurrent()) return;
-        if (!result.ok) {
-          toast.error('打开项目指令失败', result.message);
-        }
-      } catch (error) {
-        if (isCurrent()) toast.error('打开项目指令失败', settingsActionErrorMessage(error));
-      }
-    });
-  }
-
-  async function createWorkspaceInstructionFile(file: string) {
-    await runMemoryAction(`instruction:${file}:create`, async (isActionCurrent) => {
-      try {
-        await runMemoryWriteAction('instruction-create', async (isCurrent) => {
-          const result = await window.maka.workspaceInstructions.createFile(file);
-          if (!isCurrent()) return;
-          if (!result.ok) {
-            toast.error('创建项目指令失败', result.message);
-            return;
-          }
-          const instructions = await window.maka.workspaceInstructions.getState();
-          if (!isCurrent()) return;
-          setWorkspaceInstructionState(instructions);
-          toast.success('已创建项目指令', file);
-          await openWorkspaceInstructionFile(file);
-        });
-      } catch (error) {
-        if (isActionCurrent()) toast.error('创建项目指令失败', settingsActionErrorMessage(error));
-      }
-    });
-  }
-
   async function copyPath() {
     await runMemoryAction('memory:path:copy', async (isCurrent) => {
       if (!state?.path) return;
@@ -540,46 +480,30 @@ export function useMemorySettingsController(props: MemorySettingsControllerProps
     }
   }
 
-  const effective = state ?? {
-    path: '',
-    enabled: props.settings.localMemory.enabled,
-    agentReadEnabled: props.settings.localMemory.agentReadEnabled,
-    status: 'disabled',
-    content: '',
-    entryCount: 0,
-    activeEntryCount: 0,
-    archivedEntryCount: 0,
-    entries: [],
-    activeEntries: [],
-    archivedEntries: [],
-  } satisfies LocalMemoryState;
-  const memoryDraftDirty = draft !== effective.content;
-  const draftMemoryEntries = useMemo(() => parseLocalMemoryMarkdown(draft), [draft]);
-  const visibleMemoryEntries = memoryDraftDirty ? draftMemoryEntries : effective;
-  const memoryEntryPreviewBlockedReason =
-    memoryDraftDirty && draftMemoryEntries.safeMode
-      ? '草稿过大，条目预览已暂停；保存前请先删减 MEMORY.md 内容。'
-      : '';
-  const normalizedMemoryEntryQuery = memoryEntryQuery.trim();
-  const filteredActiveEntries = useMemo(
-    () => filterLocalMemoryEntries(visibleMemoryEntries.activeEntries, normalizedMemoryEntryQuery),
-    [visibleMemoryEntries.activeEntries, normalizedMemoryEntryQuery],
+  const viewModel = useMemo(
+    () => deriveMemorySettingsViewModel({
+      state,
+      localMemorySettings: props.settings.localMemory,
+      draft,
+      query: memoryEntryQuery,
+    }),
+    [state, props.settings, draft, memoryEntryQuery],
   );
-  const filteredArchivedEntries = useMemo(
-    () => filterLocalMemoryEntries(visibleMemoryEntries.archivedEntries, normalizedMemoryEntryQuery),
-    [visibleMemoryEntries.archivedEntries, normalizedMemoryEntryQuery],
-  );
-  const filteredEntryCount = filteredActiveEntries.length + filteredArchivedEntries.length;
-  const localMemoryPromptPreview = useMemo(() => buildLocalMemoryPromptBody(draft) ?? '', [draft]);
-  const promptPreviewBlockedReason = localMemoryPromptPreviewBlockedReason(effective);
-  const promptPreviewWillInject = localMemoryPromptPreview.length > 0 && !promptPreviewBlockedReason;
-  const localMemoryPromptPreviewTruncated = localMemoryPromptPreview.includes('[本地记忆已按长度截断]');
-  const localMemoryPromptPreviewBudgetLabel = localMemoryPromptPreview
-    ? localMemoryPromptPreviewTruncated
-      ? `预览已按 ${LOCAL_MEMORY_PROMPT_MAX_CHARS.toLocaleString('zh-CN')} 字符上限截断`
-      : `预览 ${localMemoryPromptPreview.length.toLocaleString('zh-CN')} / ${LOCAL_MEMORY_PROMPT_MAX_CHARS.toLocaleString('zh-CN')} 字符`
-    : `prompt 上限 ${LOCAL_MEMORY_PROMPT_MAX_CHARS.toLocaleString('zh-CN')} 字符`;
-  const memoryDraftHasSensitiveFields = useMemo(() => redactSecrets(draft) !== draft, [draft]);
+  const {
+    effective,
+    memoryDraftDirty,
+    visibleMemoryEntries,
+    memoryEntryPreviewBlockedReason,
+    normalizedMemoryEntryQuery,
+    filteredActiveEntries,
+    filteredArchivedEntries,
+    filteredEntryCount,
+    localMemoryPromptPreview,
+    promptPreviewBlockedReason,
+    promptPreviewWillInject,
+    localMemoryPromptPreviewBudgetLabel,
+    memoryDraftHasSensitiveFields,
+  } = viewModel;
   const memoryControlsDisabled = loadingMemory || busy;
   const isMemoryActionPending = (key: string) => pendingMemoryActions.has(key);
 
@@ -596,7 +520,6 @@ export function useMemorySettingsController(props: MemorySettingsControllerProps
   }
 
   return {
-    workspaceInstructionState,
     draft,
     setDraft,
     newMemoryTitle,
@@ -614,7 +537,6 @@ export function useMemorySettingsController(props: MemorySettingsControllerProps
     reloadDraftFromDisk,
     setEnabled,
     setAgentReadEnabled,
-    setWorkspaceInstructionsEnabled,
     save,
     reset,
     restoreLatestBackup,
@@ -623,8 +545,6 @@ export function useMemorySettingsController(props: MemorySettingsControllerProps
     openLatestBackup,
     openBackupCandidate,
     openFolder,
-    openWorkspaceInstructionFile,
-    createWorkspaceInstructionFile,
     copyPath,
     copyBackupReference,
     copyLatestBackupReference,
@@ -650,4 +570,3 @@ export function useMemorySettingsController(props: MemorySettingsControllerProps
     copyLocalMemoryPromptPreview,
   };
 }
-

--- a/apps/desktop/src/renderer/settings/use-workspace-instructions-controller.ts
+++ b/apps/desktop/src/renderer/settings/use-workspace-instructions-controller.ts
@@ -1,0 +1,138 @@
+import { useEffect, useRef, useState } from 'react';
+import type { UpdateAppSettingsResult } from '@maka/core';
+import { useToast } from '@maka/ui';
+import { settingsActionErrorMessage } from './settings-error-copy';
+
+type WorkspaceInstructionState = Awaited<ReturnType<typeof window.maka.workspaceInstructions.getState>>;
+
+export interface WorkspaceInstructionsControllerProps {
+  onUpdate(patch: Parameters<typeof window.maka.settings.update>[0]): Promise<UpdateAppSettingsResult>;
+  onReloadSettings(): Promise<void>;
+}
+
+export function useWorkspaceInstructionsController(props: WorkspaceInstructionsControllerProps) {
+  const [state, setState] = useState<WorkspaceInstructionState | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [pendingActions, setPendingActions] = useState<Set<string>>(() => new Set());
+  const mountedRef = useRef(false);
+  const lifecycleRef = useRef(0);
+  const pendingActionOwnersRef = useRef<Map<string, number>>(new Map());
+  const actionOwnerSequenceRef = useRef(0);
+  const writeOwnerRef = useRef<number | null>(null);
+  const toast = useToast();
+
+  useEffect(() => {
+    const lifecycle = ++lifecycleRef.current;
+    mountedRef.current = true;
+    void reload(lifecycle);
+    return () => {
+      if (lifecycleRef.current !== lifecycle) return;
+      mountedRef.current = false;
+      pendingActionOwnersRef.current.clear();
+      writeOwnerRef.current = null;
+    };
+  }, []);
+
+  function isCurrent(lifecycle: number): boolean {
+    return mountedRef.current && lifecycleRef.current === lifecycle;
+  }
+
+  async function reload(lifecycle = lifecycleRef.current): Promise<void> {
+    try {
+      const next = await window.maka.workspaceInstructions.getState();
+      if (isCurrent(lifecycle)) setState(next);
+    } catch (error) {
+      if (isCurrent(lifecycle)) toast.error('载入项目指令失败', settingsActionErrorMessage(error));
+    } finally {
+      if (isCurrent(lifecycle)) setLoading(false);
+    }
+  }
+
+  async function runAction(key: string, action: (isActionCurrent: () => boolean) => Promise<void>): Promise<void> {
+    if (pendingActionOwnersRef.current.has(key)) return;
+    const lifecycle = lifecycleRef.current;
+    const owner = ++actionOwnerSequenceRef.current;
+    pendingActionOwnersRef.current.set(key, owner);
+    setPendingActions((current) => new Set(current).add(key));
+    try {
+      await action(() => isCurrent(lifecycle));
+    } finally {
+      if (pendingActionOwnersRef.current.get(key) === owner) {
+        pendingActionOwnersRef.current.delete(key);
+      }
+      if (isCurrent(lifecycle)) {
+        setPendingActions((current) => {
+          const next = new Set(current);
+          next.delete(key);
+          return next;
+        });
+      }
+    }
+  }
+
+  async function runWriteAction(
+    key: string,
+    action: (isActionCurrent: () => boolean) => Promise<void>,
+  ): Promise<void> {
+    if (writeOwnerRef.current !== null) return;
+    const owner = ++actionOwnerSequenceRef.current;
+    writeOwnerRef.current = owner;
+    try {
+      await runAction(key, action);
+    } finally {
+      if (writeOwnerRef.current === owner) writeOwnerRef.current = null;
+    }
+  }
+
+  async function setEnabled(enabled: boolean): Promise<void> {
+    await runWriteAction('instruction:settings:update', async (isActionCurrent) => {
+      try {
+        await props.onUpdate({ workspaceInstructions: { enabled } });
+        await props.onReloadSettings();
+      } catch (error) {
+        if (isActionCurrent()) toast.error('更新项目指令开关失败', settingsActionErrorMessage(error));
+      }
+    });
+  }
+
+  async function openFile(file: string): Promise<void> {
+    await runAction(`instruction:${file}:open`, async (isActionCurrent) => {
+      try {
+        const result = await window.maka.workspaceInstructions.openFile(file);
+        if (isActionCurrent() && !result.ok) toast.error('打开项目指令失败', result.message);
+      } catch (error) {
+        if (isActionCurrent()) toast.error('打开项目指令失败', settingsActionErrorMessage(error));
+      }
+    });
+  }
+
+  async function createFile(file: string): Promise<void> {
+    await runWriteAction(`instruction:${file}:create`, async (isActionCurrent) => {
+      try {
+        const result = await window.maka.workspaceInstructions.createFile(file);
+        if (!isActionCurrent()) return;
+        if (!result.ok) {
+          toast.error('创建项目指令失败', result.message);
+          return;
+        }
+        await reload();
+        if (!isActionCurrent()) return;
+        toast.success('已创建项目指令', file);
+        await openFile(file);
+      } catch (error) {
+        if (isActionCurrent()) toast.error('创建项目指令失败', settingsActionErrorMessage(error));
+      }
+    });
+  }
+
+  return {
+    state,
+    busy: loading || pendingActions.has('instruction:settings:update')
+      || Array.from(pendingActions).some((key) => key.endsWith(':create')),
+    pendingActions,
+    isActionPending: (key: string) => pendingActions.has(key),
+    setEnabled,
+    openFile,
+    createFile,
+  };
+}

--- a/apps/desktop/src/renderer/settings/use-workspace-instructions-controller.ts
+++ b/apps/desktop/src/renderer/settings/use-workspace-instructions-controller.ts
@@ -37,12 +37,15 @@ export function useWorkspaceInstructionsController(props: WorkspaceInstructionsC
     return mountedRef.current && lifecycleRef.current === lifecycle;
   }
 
-  async function reload(lifecycle = lifecycleRef.current): Promise<void> {
+  async function reload(lifecycle = lifecycleRef.current): Promise<boolean> {
     try {
       const next = await window.maka.workspaceInstructions.getState();
-      if (isCurrent(lifecycle)) setState(next);
+      if (!isCurrent(lifecycle)) return false;
+      setState(next);
+      return true;
     } catch (error) {
       if (isCurrent(lifecycle)) toast.error('载入项目指令失败', settingsActionErrorMessage(error));
+      return false;
     } finally {
       if (isCurrent(lifecycle)) setLoading(false);
     }
@@ -115,8 +118,8 @@ export function useWorkspaceInstructionsController(props: WorkspaceInstructionsC
           toast.error('创建项目指令失败', result.message);
           return;
         }
-        await reload();
-        if (!isActionCurrent()) return;
+        const refreshed = await reload();
+        if (!refreshed || !isActionCurrent()) return;
         toast.success('已创建项目指令', file);
         await openFile(file);
       } catch (error) {


### PR DESCRIPTION
## Summary
- keep MEMORY.md state, backups, and the shared write guard in the document controller
- move workspace-instruction state and IPC into a dedicated lifecycle owner
- extract filtering and prompt-preview derivation into a pure, directly tested view model
- preserve cross-owner disabled semantics at the page composition boundary

## Verification
- desktop typecheck
- desktop tests — 2370 passed
- targeted Memory Settings, workspace-instruction, ownership, and view-model contracts
- Electron settings E2E
- $invoke Codex review round 2 — PASS, no P0–P2 findings

## Review follow-up
Round 1 found a verified P2 in the post-create refresh failure path. The workspace owner now stops before success/open when refresh fails; the regression contract was observed RED then GREEN.

## Impact
No intended visual or UX changes.

Refs #844