### PR TITLE
refactor(ui): isolate composer attachment owner

### DIFF
--- a/apps/desktop/src/main/__tests__/app-shell-composer-attachment-owner-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/app-shell-composer-attachment-owner-contract.test.ts
@@ -18,7 +18,8 @@ describe('AppShell composer attachment ownership', () => {
     assert.match(owner, /useState<PendingByKey<PendingAttachment>>/);
     assert.match(owner, /window\.maka\.attachments\.pickFiles\(\)/);
     assert.match(owner, /const ownerKey = options\.draftKey/);
-    assert.match(owner, /clearAttachments/);
+    assert.match(owner, /clearSubmittedAttachments/);
+    assert.match(owner, /removePendingItems\(map, ownerKey, submitted\)/);
   });
 
   it('keeps chat send and compact routing in the composition layer', async () => {

--- a/apps/desktop/src/main/__tests__/app-shell-composer-attachment-owner-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/app-shell-composer-attachment-owner-contract.test.ts
@@ -1,0 +1,34 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+import { describe, it } from 'node:test';
+
+const REPO_ROOT = resolve(import.meta.dirname, '../../../../..');
+const RENDERER_ROOT = resolve(REPO_ROOT, 'apps/desktop/src/renderer');
+
+describe('AppShell composer attachment ownership', () => {
+  it('keeps attachment state and picker IPC behind one owner', async () => {
+    const [shell, owner] = await Promise.all([
+      readFile(resolve(RENDERER_ROOT, 'app-shell.tsx'), 'utf8'),
+      readFile(resolve(RENDERER_ROOT, 'use-app-shell-composer-attachments.ts'), 'utf8'),
+    ]);
+
+    assert.match(shell, /useAppShellComposerAttachments\(\{ draftKey: attachmentDraftKey, toastApi \}\)/);
+    assert.doesNotMatch(shell, /useState<PendingByKey|window\.maka\.attachments\.pickFiles/);
+    assert.match(owner, /useState<PendingByKey<PendingAttachment>>/);
+    assert.match(owner, /window\.maka\.attachments\.pickFiles\(\)/);
+    assert.match(owner, /const ownerKey = options\.draftKey/);
+    assert.match(owner, /clearAttachments/);
+  });
+
+  it('keeps chat send and compact routing in the composition layer', async () => {
+    const [shell, owner] = await Promise.all([
+      readFile(resolve(RENDERER_ROOT, 'app-shell.tsx'), 'utf8'),
+      readFile(resolve(RENDERER_ROOT, 'use-app-shell-composer-attachments.ts'), 'utf8'),
+    ]);
+
+    assert.match(shell, /const ok = await send\(text, pending\)/);
+    assert.match(shell, /window\.maka\.sessions\.compact\(activeId\)/);
+    assert.doesNotMatch(owner, /sessions\.send|sessions\.compact/);
+  });
+});

--- a/apps/desktop/src/main/__tests__/app-shell-pending-attachments.test.ts
+++ b/apps/desktop/src/main/__tests__/app-shell-pending-attachments.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import { describe, test } from 'node:test';
-import { appendPending, clearPending, removePending, selectPending } from '../../renderer/app-shell-pending-attachments.js';
+import { appendPending, clearPending, removePending, removePendingItems, selectPending } from '../../renderer/app-shell-pending-attachments.js';
 
 describe('pending attachments by draft key', () => {
   test('selecting another key never leaks pending from a different session', () => {
@@ -23,5 +23,16 @@ describe('pending attachments by draft key', () => {
     const next = clearPending(map, 'a');
     assert.deepEqual(selectPending(next, 'a'), []);
     assert.deepEqual(selectPending(next, 'b'), ['b1']);
+  });
+
+  test('successful send removes only its submitted snapshot', () => {
+    const submitted = { name: 'submitted' };
+    const addedWhileSending = { name: 'added later' };
+    let map = appendPending({}, 'draft', [submitted]);
+    map = appendPending(map, 'draft', [addedWhileSending]);
+
+    const next = removePendingItems(map, 'draft', [submitted]);
+
+    assert.deepEqual(selectPending(next, 'draft'), [addedWhileSending]);
   });
 });

--- a/apps/desktop/src/renderer/app-shell-pending-attachments.ts
+++ b/apps/desktop/src/renderer/app-shell-pending-attachments.ts
@@ -17,6 +17,17 @@ export function removePending<T>(map: PendingByKey<T>, key: string, index: numbe
   return { ...map, [key]: current.filter((_, i) => i !== index) };
 }
 
+export function removePendingItems<T>(
+  map: PendingByKey<T>,
+  key: string,
+  items: readonly T[],
+): PendingByKey<T> {
+  const submitted = new Set(items);
+  const remaining = (map[key] ?? []).filter((item) => !submitted.has(item));
+  if (remaining.length === 0) return clearPending(map, key);
+  return { ...map, [key]: remaining };
+}
+
 export function clearPending<T>(map: PendingByKey<T>, key: string): PendingByKey<T> {
   const next = { ...map };
   delete next[key];

--- a/apps/desktop/src/renderer/app-shell.tsx
+++ b/apps/desktop/src/renderer/app-shell.tsx
@@ -163,7 +163,7 @@ export function AppShell({
     pickAttachments,
     attachFilePaths,
     removeAttachment,
-    clearAttachments,
+    clearSubmittedAttachments,
   } = useAppShellComposerAttachments({ draftKey: attachmentDraftKey, toastApi });
   // P3: session ids with a live embedded-browser view. The right-side
   // BrowserPanel mounts only for these, so ordinary chats reserve no space.
@@ -965,7 +965,7 @@ export function AppShell({
     }
     const pending = pendingAttachments.length > 0 ? pendingAttachments : undefined;
     const ok = await send(text, pending);
-    if (ok !== false) clearAttachments();
+    if (ok !== false && pending) clearSubmittedAttachments(pending);
     return ok;
   }
 

--- a/apps/desktop/src/renderer/app-shell.tsx
+++ b/apps/desktop/src/renderer/app-shell.tsx
@@ -12,7 +12,7 @@ import type {
   ThemePreference,
   ThinkingLevel,
 } from '@maka/core';
-import { generalizedErrorMessageChinese, hasSettledInitialOnboarding, thinkingVariantsForModel, attachmentKindFromMimeType, guessMimeFromName } from '@maka/core';
+import { generalizedErrorMessageChinese, hasSettledInitialOnboarding, thinkingVariantsForModel } from '@maka/core';
 import {
   type ChatHeaderAlert,
   type ChatModelChoice,
@@ -95,8 +95,7 @@ import { createAppShellProjectActions, type RendererAppInfo } from './app-shell-
 import { createAppShellSkillActions } from './app-shell-skill-actions';
 import { createAppShellSessionEventHandlers } from './app-shell-session-events';
 import { createAppShellVisualSmokeActions } from './app-shell-visual-smoke';
-import { createAppShellChatActions, type PendingAttachment } from './app-shell-chat-actions';
-import { appendPending, clearPending, removePending, selectPending, type PendingByKey } from './app-shell-pending-attachments';
+import { createAppShellChatActions } from './app-shell-chat-actions';
 import { createAppShellTurnActions } from './app-shell-turn-actions';
 import { createAppShellLayoutActions } from './app-shell-layout-actions';
 import { createAppShellQuickChatActions } from './app-shell-quick-chat-actions';
@@ -116,6 +115,7 @@ import {
 } from './app-shell-effects';
 import { loadComposerDefaults, saveComposerDefaults } from './composer-defaults';
 import { useAppShellSessionList } from './use-app-shell-session-list';
+import { useAppShellComposerAttachments } from './use-app-shell-composer-attachments';
 
 function connectionsEqual(a: LlmConnection[], b: LlmConnection[]): boolean {
   if (a.length !== b.length) return false;
@@ -129,28 +129,6 @@ type ComposerImportOwner = {
   sessionId: string | undefined;
   navSection: NavSelection['section'];
 };
-
-function approvalToPending(file: { approvalId: string; name: string; mimeType?: string; size: number }): PendingAttachment {
-  const mimeType = file.mimeType ?? guessMimeFromName(file.name);
-  return {
-    displayName: file.name,
-    mimeType,
-    kind: attachmentKindFromMimeType(mimeType, file.name),
-    size: file.size,
-    source: { type: 'approval', approvalId: file.approvalId, name: file.name },
-  };
-}
-
-function fileToPending(file: File): PendingAttachment {
-  const mimeType = file.type || undefined;
-  return {
-    displayName: file.name,
-    mimeType,
-    kind: attachmentKindFromMimeType(mimeType ?? '', file.name),
-    size: file.size,
-    source: { type: 'file', file },
-  };
-}
 
 /**
  * Grace period before the committed-history fallback force-settles a draining
@@ -179,9 +157,14 @@ export function AppShell({
     markSessionReadLocally,
   } = useAppShellSessionList(toastApi);
   const [activeId, setActiveIdState] = useState<string | undefined>();
-  const [pendingByKey, setPendingByKey] = useState<PendingByKey<PendingAttachment>>({});
   const attachmentDraftKey = activeId ?? 'new-session';
-  const pendingAttachments = selectPending(pendingByKey, attachmentDraftKey);
+  const {
+    pendingAttachments,
+    pickAttachments,
+    attachFilePaths,
+    removeAttachment,
+    clearAttachments,
+  } = useAppShellComposerAttachments({ draftKey: attachmentDraftKey, toastApi });
   // P3: session ids with a live embedded-browser view. The right-side
   // BrowserPanel mounts only for these, so ordinary chats reserve no space.
   const [liveBrowserSessionIds, setLiveBrowserSessionIds] = useState<string[]>([]);
@@ -975,25 +958,6 @@ export function AppShell({
     upsertSessionSummary,
   });
 
-  async function pickAttachments(): Promise<void> {
-    try {
-      const result = await window.maka.attachments.pickFiles();
-      if (!result.ok) return;
-      setPendingByKey((map) => appendPending(map, attachmentDraftKey, result.files.map(approvalToPending)));
-    } catch (error) {
-      toastApi.error('添加附件失败', generalizedErrorMessageChinese(error, '请稍后重试。'));
-    }
-  }
-
-  async function attachFilePaths(files: File[]): Promise<void> {
-    if (files.length === 0) return;
-    setPendingByKey((map) => appendPending(map, attachmentDraftKey, files.map(fileToPending)));
-  }
-
-  function removeAttachment(index: number): void {
-    setPendingByKey((map) => removePending(map, attachmentDraftKey, index));
-  }
-
   async function sendWithAttachments(text: string): Promise<boolean | void> {
     if (text.trim() === '/compact') {
       if (activeId) await window.maka.sessions.compact(activeId);
@@ -1001,7 +965,7 @@ export function AppShell({
     }
     const pending = pendingAttachments.length > 0 ? pendingAttachments : undefined;
     const ok = await send(text, pending);
-    if (ok !== false) setPendingByKey((map) => clearPending(map, attachmentDraftKey));
+    if (ok !== false) clearAttachments();
     return ok;
   }
 

--- a/apps/desktop/src/renderer/use-app-shell-composer-attachments.ts
+++ b/apps/desktop/src/renderer/use-app-shell-composer-attachments.ts
@@ -3,8 +3,8 @@ import { attachmentKindFromMimeType, generalizedErrorMessageChinese, guessMimeFr
 import type { PendingAttachment } from './app-shell-chat-actions';
 import {
   appendPending,
-  clearPending,
   removePending,
+  removePendingItems,
   selectPending,
   type PendingByKey,
 } from './app-shell-pending-attachments';
@@ -69,9 +69,9 @@ export function useAppShellComposerAttachments(options: {
     setPendingByKey((map) => removePending(map, ownerKey, index));
   }
 
-  function clearAttachments(): void {
+  function clearSubmittedAttachments(submitted: readonly PendingAttachment[]): void {
     const ownerKey = options.draftKey;
-    setPendingByKey((map) => clearPending(map, ownerKey));
+    setPendingByKey((map) => removePendingItems(map, ownerKey, submitted));
   }
 
   return {
@@ -79,6 +79,6 @@ export function useAppShellComposerAttachments(options: {
     pickAttachments,
     attachFilePaths,
     removeAttachment,
-    clearAttachments,
+    clearSubmittedAttachments,
   };
 }

--- a/apps/desktop/src/renderer/use-app-shell-composer-attachments.ts
+++ b/apps/desktop/src/renderer/use-app-shell-composer-attachments.ts
@@ -1,0 +1,84 @@
+import { useState } from 'react';
+import { attachmentKindFromMimeType, generalizedErrorMessageChinese, guessMimeFromName } from '@maka/core';
+import type { PendingAttachment } from './app-shell-chat-actions';
+import {
+  appendPending,
+  clearPending,
+  removePending,
+  selectPending,
+  type PendingByKey,
+} from './app-shell-pending-attachments';
+
+type ToastApi = {
+  error(title: string, description?: string): void;
+};
+
+function approvalToPending(file: {
+  approvalId: string;
+  name: string;
+  mimeType?: string;
+  size: number;
+}): PendingAttachment {
+  const mimeType = file.mimeType ?? guessMimeFromName(file.name);
+  return {
+    displayName: file.name,
+    mimeType,
+    kind: attachmentKindFromMimeType(mimeType, file.name),
+    size: file.size,
+    source: { type: 'approval', approvalId: file.approvalId, name: file.name },
+  };
+}
+
+function fileToPending(file: File): PendingAttachment {
+  const mimeType = file.type || undefined;
+  return {
+    displayName: file.name,
+    mimeType,
+    kind: attachmentKindFromMimeType(mimeType ?? '', file.name),
+    size: file.size,
+    source: { type: 'file', file },
+  };
+}
+
+export function useAppShellComposerAttachments(options: {
+  draftKey: string;
+  toastApi: ToastApi;
+}) {
+  const [pendingByKey, setPendingByKey] = useState<PendingByKey<PendingAttachment>>({});
+  const pendingAttachments = selectPending(pendingByKey, options.draftKey);
+
+  async function pickAttachments(): Promise<void> {
+    const ownerKey = options.draftKey;
+    try {
+      const result = await window.maka.attachments.pickFiles();
+      if (!result.ok) return;
+      setPendingByKey((map) => appendPending(map, ownerKey, result.files.map(approvalToPending)));
+    } catch (error) {
+      options.toastApi.error('添加附件失败', generalizedErrorMessageChinese(error, '请稍后重试。'));
+    }
+  }
+
+  async function attachFilePaths(files: File[]): Promise<void> {
+    if (files.length === 0) return;
+    const ownerKey = options.draftKey;
+    setPendingByKey((map) => appendPending(map, ownerKey, files.map(fileToPending)));
+  }
+
+  function removeAttachment(index: number): void {
+    const ownerKey = options.draftKey;
+    setPendingByKey((map) => removePending(map, ownerKey, index));
+  }
+
+  function clearAttachments(): void {
+    const ownerKey = options.draftKey;
+    setPendingByKey((map) => clearPending(map, ownerKey));
+  }
+
+  return {
+    pendingAttachments,
+    pickAttachments,
+    attachFilePaths,
+    removeAttachment,
+    clearAttachments,
+  };
+}


### PR DESCRIPTION
## Summary
- move composer attachment state, conversion, picker IPC, and per-draft mutations behind one owner hook
- keep chat send and /compact routing in AppShell
- consume only the submitted attachment snapshot after success so same-key additions survive
- preserve failed-send attachments and cross-session draft isolation

## Verification
- desktop typecheck
- desktop tests — 2373 passed
- attachment ownership, pending-map, and frontend contracts
- Electron attachment/send E2E — 3 passed
- $invoke Codex review round 2 — PASS, no P0–P2 findings

## Review follow-up
Round 1 found a verified P2: whole-key cleanup could remove attachments appended while a send was in flight. The owner now removes only submitted object identities; the pure regression test was observed RED then GREEN.

## Impact
No intended visual or UX changes.

Refs #844