### PR TITLE
refactor(ui): consolidate session workspace owner

### DIFF
--- a/apps/desktop/src/main/__tests__/app-shell-session-owner-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/app-shell-session-owner-contract.test.ts
@@ -6,22 +6,32 @@ import { describe, it } from 'node:test';
 const REPO_ROOT = resolve(import.meta.dirname, '../../../../..');
 const RENDERER_ROOT = resolve(REPO_ROOT, 'apps', 'desktop', 'src', 'renderer');
 
-describe('AppShell session-list ownership boundary', () => {
-  it('keeps session collection state and IPC behind one controller hook', async () => {
-    const [shell, owner] = await Promise.all([
+describe('AppShell session workspace ownership boundary', () => {
+  it('keeps active session, messages, session collection, and transient UI behind one workspace owner', async () => {
+    const [shell, workspace, listOwner] = await Promise.all([
       readFile(resolve(RENDERER_ROOT, 'app-shell.tsx'), 'utf8'),
+      readFile(resolve(RENDERER_ROOT, 'use-app-shell-session-workspace.ts'), 'utf8'),
       readFile(resolve(RENDERER_ROOT, 'use-app-shell-session-list.ts'), 'utf8'),
     ]);
 
-    assert.match(shell, /useAppShellSessionList\(/);
+    assert.match(shell, /useAppShellSessionWorkspace\(/);
     assert.doesNotMatch(shell, /useState<SessionSummary\[\]>/);
+    assert.doesNotMatch(shell, /useState<string \| undefined>\(\)/);
+    assert.doesNotMatch(shell, /useState<StoredMessage\[\]>/);
+    assert.doesNotMatch(shell, /useAppShellSessionList|useAppShellSessionUiState/);
     assert.doesNotMatch(shell, /createSessionListRefresher\(/);
     assert.doesNotMatch(shell, /window\.maka\.sessions\.list\(/);
 
-    assert.match(owner, /createSessionListRefresher\(/);
-    assert.match(owner, /window\.maka\.sessions\.list\(/);
-    assert.match(owner, /seedSessions/);
-    assert.match(owner, /markSessionRunningOptimistic/);
-    assert.match(owner, /markSessionReadLocally/);
+    assert.match(workspace, /useAppShellSessionList\(toastApi\)/);
+    assert.match(workspace, /useAppShellSessionUiState\(\)/);
+    assert.match(workspace, /function setActiveId/);
+    assert.match(workspace, /function startNewSession/);
+    assert.match(workspace, /function clearOwnedSessionState/);
+    assert.match(workspace, /const \[messages, setMessages\] = useState<StoredMessage\[\]>/);
+    assert.match(listOwner, /createSessionListRefresher\(/);
+    assert.match(listOwner, /window\.maka\.sessions\.list\(/);
+    assert.match(listOwner, /seedSessions/);
+    assert.match(listOwner, /markSessionRunningOptimistic/);
+    assert.match(listOwner, /markSessionReadLocally/);
   });
 });

--- a/apps/desktop/src/main/__tests__/app-shell-session-owner-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/app-shell-session-owner-contract.test.ts
@@ -8,10 +8,11 @@ const RENDERER_ROOT = resolve(REPO_ROOT, 'apps', 'desktop', 'src', 'renderer');
 
 describe('AppShell session workspace ownership boundary', () => {
   it('keeps active session, messages, session collection, and transient UI behind one workspace owner', async () => {
-    const [shell, workspace, listOwner] = await Promise.all([
+    const [shell, workspace, listOwner, effects] = await Promise.all([
       readFile(resolve(RENDERER_ROOT, 'app-shell.tsx'), 'utf8'),
       readFile(resolve(RENDERER_ROOT, 'use-app-shell-session-workspace.ts'), 'utf8'),
       readFile(resolve(RENDERER_ROOT, 'use-app-shell-session-list.ts'), 'utf8'),
+      readFile(resolve(RENDERER_ROOT, 'app-shell-effects.ts'), 'utf8'),
     ]);
 
     assert.match(shell, /useAppShellSessionWorkspace\(/);
@@ -25,6 +26,8 @@ describe('AppShell session workspace ownership boundary', () => {
     assert.match(workspace, /useAppShellSessionList\(toastApi\)/);
     assert.match(workspace, /useAppShellSessionUiState\(\)/);
     assert.match(workspace, /function setActiveId/);
+    assert.match(workspace, /activeIdRef\.current = next/);
+    assert.doesNotMatch(effects, /activeIdRef\.current\s*=(?!=)/);
     assert.match(workspace, /function startNewSession/);
     assert.match(workspace, /function clearOwnedSessionState/);
     assert.match(workspace, /const \[messages, setMessages\] = useState<StoredMessage\[\]>/);

--- a/apps/desktop/src/main/__tests__/permission-response-ipc-boundary.test.ts
+++ b/apps/desktop/src/main/__tests__/permission-response-ipc-boundary.test.ts
@@ -147,6 +147,7 @@ describe('permission response IPC boundary', () => {
       'app-shell.tsx',
       'app-shell-stop-action.ts',
       'app-shell-chat-actions.ts',
+      'use-app-shell-session-workspace.ts',
     ]);
     // Match `async function stop()` body up to its closing brace.
     const stop = renderer.match(/async function stop\(\)\s*\{[\s\S]*?\n  \}/);
@@ -311,6 +312,7 @@ describe('permission response IPC boundary', () => {
       'app-shell.tsx',
       'app-shell-effects.ts',
       'use-app-shell-session-list.ts',
+      'use-app-shell-session-workspace.ts',
     ]);
     const setActiveId = renderer.match(/function setActiveId\(next: string \| undefined\): void \{[\s\S]*?\n  \}/);
     const refreshSessions = renderer.match(/async function refreshSessions\(\)(?:: Promise<SessionSummary\[]>)? \{[\s\S]*?\n  \}/);

--- a/apps/desktop/src/main/__tests__/renderer-shell-source-helpers.ts
+++ b/apps/desktop/src/main/__tests__/renderer-shell-source-helpers.ts
@@ -29,6 +29,7 @@ const sourcePaths = [
   'app-shell-session-row-actions.ts',
   'app-shell-session-settings-actions.ts',
   'use-app-shell-session-list.ts',
+  'use-app-shell-session-workspace.ts',
   'app-shell-visual-smoke.ts',
   'cached-theme-bootstrap.ts',
   'chat-model-selection.ts',

--- a/apps/desktop/src/main/__tests__/session-message-lifecycle-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/session-message-lifecycle-contract.test.ts
@@ -20,6 +20,7 @@ describe('active session message lifecycle contract', () => {
       'app-shell-chat-actions.ts',
       'app-shell.tsx',
       'app-shell-copy.ts',
+      'use-app-shell-session-workspace.ts',
     ]);
     const ui = await readFile(join(process.cwd(), '..', '..', 'packages', 'ui', 'src', 'chat-view.tsx'), 'utf8');
     const activeSessionEffect = src.match(/useLayoutEffect\(\(\) => \{\s*if \(!activeId\) return;[\s\S]*?readMessages\(activeId\)[\s\S]*?\}, \[activeId\]\);/)?.[0] ?? '';
@@ -107,9 +108,12 @@ describe('active session message lifecycle contract', () => {
       /catch \(error\) \{[\s\S]*setMessages\(\[\]\)/,
       'background message refresh failures must preserve the visible conversation instead of blanking the chat',
     );
+    assert.match(src, /const sessionUi = useAppShellSessionUiState\(\)/);
+    assert.match(src, /const messageRetryPendingRef = useRef<Set<string>>\(new Set\(\)\)/);
+    assert.match(src, /setMessageRetryPendingBySession: sessionUi\.setMessageRetryPendingBySession/);
     assert.match(
       src,
-      /const messageRetryPendingRef = useRef<Set<string>>\(new Set\(\)\);[\s\S]*const \{[\s\S]*setMessageRetryPendingBySession,[\s\S]*\} = useAppShellSessionUiState\(\);[\s\S]*const \{[\s\S]*messageRetryPendingBySession,[\s\S]*\} = sessionUiState;/,
+      /const \{[\s\S]*messageRetryPendingBySession,[\s\S]*\} = sessionUiState;/,
       'desktop shell must keep the ref-backed duplicate guard while exposing per-session retry pending state from the shell UI reducer',
     );
     assert.match(

--- a/apps/desktop/src/main/__tests__/session-open-routing-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/session-open-routing-contract.test.ts
@@ -2,7 +2,7 @@ import { strict as assert } from 'node:assert';
 import { readFile } from 'node:fs/promises';
 import { resolve } from 'node:path';
 import { describe, it } from 'node:test';
-import { readRendererShellSource } from './renderer-shell-source-helpers.js';
+import { readRendererShellSource, readRendererShellSources } from './renderer-shell-source-helpers.js';
 
 const REPO_ROOT = resolve(import.meta.dirname, '../../../../..');
 
@@ -79,13 +79,15 @@ describe('session open routing contract', () => {
   });
 
   it('new-chat navigation does not wipe other sessions live renderer state', async () => {
-    const main = await readRendererShellSource('app-shell.tsx');
-    const createSession = main.match(/async function createSession\(\) \{[\s\S]*?\n  \}/)?.[0] ?? '';
+    const source = await readRendererShellSources(['app-shell.tsx', 'use-app-shell-session-workspace.ts']);
+    const createSession = source.match(/async function createSession\(\) \{[\s\S]*?\n  \}/)?.[0] ?? '';
+    const startNewSession = source.match(/function startNewSession\(\): void \{[\s\S]*?\n  \}/)?.[0] ?? '';
 
-    assert.match(createSession, /setActiveId\(undefined\);/);
+    assert.match(createSession, /startNewSession\(\);/);
+    assert.match(startNewSession, /setActiveId\(undefined\);/);
     assert.match(createSession, /setNavSelection\(\{ section: 'sessions', filter: 'chats' \}\);/);
     assert.match(createSession, /setSearchScrollTarget\(null\);/);
-    assert.match(createSession, /setMessages\(\[\]\);/);
+    assert.match(startNewSession, /setMessages\(\[\]\);/);
     assert.doesNotMatch(
       createSession,
       /setStreamingBySession\(\{\}\)|setLiveToolsBySession\(\{\}\)|setPermissionBySession\(\{\}\)/,

--- a/apps/desktop/src/main/__tests__/session-row-actions-fail-soft-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/session-row-actions-fail-soft-contract.test.ts
@@ -40,19 +40,18 @@ describe('session row actions fail soft', () => {
 
   it('cleans active session renderer state consistently after archive or delete', async () => {
     const main = await readRendererShellCombinedSource();
-    const cleanupBlock = main.slice(
-      main.indexOf('function clearSessionRendererState'),
-      main.indexOf('// PR109e: per-turn auxiliary view-model'),
-    );
+    const cleanupBlock = main.match(/function clearSessionRendererState\(sessionId: string\): void \{[\s\S]*?\n  \}/)?.[0] ?? '';
+    const ownedCleanupBlock = main.match(/function clearOwnedSessionState\(sessionId: string\): void \{[\s\S]*?\n  \}/)?.[0] ?? '';
 
-    assert.match(cleanupBlock, /messageRetryPendingRef\.current\.delete\(sessionId\);/);
-    assert.match(cleanupBlock, /stopPendingRef\.current\.delete\(sessionId\);/);
+    assert.match(cleanupBlock, /clearOwnedSessionState\(sessionId\);/);
+    assert.match(ownedCleanupBlock, /messageRetryPendingRef\.current\.delete\(sessionId\);/);
+    assert.match(ownedCleanupBlock, /stopPendingRef\.current\.delete\(sessionId\);/);
     assert.match(cleanupBlock, /clearPendingTurnActionsForSession\(sessionId\);/);
     assert.match(cleanupBlock, /pendingPermissionModeChangesRef\.current\.delete\(sessionId\);/);
     assert.match(cleanupBlock, /pendingSessionModelChangesRef\.current\.delete\(sessionId\);/);
     assert.match(
-      cleanupBlock,
-      /clearSessionUiState\(sessionId\);/,
+      ownedCleanupBlock,
+      /sessionUi\.clearSessionUiState\(sessionId\);/,
       'archive/delete cleanup must use the centralized per-session UI state cleanup',
     );
 

--- a/apps/desktop/src/main/__tests__/session-status-presentation.test.ts
+++ b/apps/desktop/src/main/__tests__/session-status-presentation.test.ts
@@ -219,7 +219,7 @@ describe('permission mode transition guard copy', () => {
     const setPermissionModeBlock = renderer.match(/async function setPermissionMode[\s\S]*?async function setSessionModel/)?.[0] ?? '';
 
     assert.match(renderer, /const pendingPermissionModeChangesRef = useRef<Set<string>>\(new Set\(\)\);/);
-    assert.match(renderer, /const \{[\s\S]*setPendingPermissionModeBySession,[\s\S]*\} = useAppShellSessionUiState\(\);/);
+    assert.match(renderer, /const sessionUi = useAppShellSessionUiState\(\);[\s\S]*setPendingPermissionModeBySession: sessionUi\.setPendingPermissionModeBySession/);
     assert.match(renderer, /const \{[\s\S]*pendingPermissionModeBySession,[\s\S]*\} = sessionUiState;/);
     assert.match(
       setPermissionModeBlock,

--- a/apps/desktop/src/main/__tests__/session-sticky-model-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/session-sticky-model-contract.test.ts
@@ -86,7 +86,7 @@ describe('PR-SESSION-STICKY-MODEL-0 contract', () => {
     assert.match(globalTypes, /setModel\(sessionId: string, input: \{ llmConnectionSlug: string; model: string \}\): Promise<SessionSummary>/);
     assert.match(renderer, /modelChoices=\{chatModelChoices\}/);
     assert.match(renderer, /const pendingSessionModelChangesRef = useRef<Set<string>>\(new Set\(\)\);/);
-    assert.match(renderer, /const \{[\s\S]*setPendingSessionModelBySession,[\s\S]*\} = useAppShellSessionUiState\(\);/);
+    assert.match(renderer, /const sessionUi = useAppShellSessionUiState\(\);[\s\S]*setPendingSessionModelBySession: sessionUi\.setPendingSessionModelBySession/);
     assert.match(renderer, /const \{[\s\S]*pendingSessionModelBySession,[\s\S]*\} = sessionUiState;/);
     assert.match(renderer, /const sessionId = activeIdRef\.current;[\s\S]*pendingSessionModelChangesRef\.current\.has\(sessionId\)[\s\S]*window\.maka\.sessions\.setModel\(sessionId, input\)[\s\S]*finally \{[\s\S]*pendingSessionModelChangesRef\.current\.delete\(sessionId\);/);
     assert.match(

--- a/apps/desktop/src/renderer/app-shell-effects.ts
+++ b/apps/desktop/src/renderer/app-shell-effects.ts
@@ -40,16 +40,10 @@ type ToastApi = {
   }): void;
 };
 
-export function useAppShellRefSync(options: {
-  activeId: string | undefined;
-  activeIdRef: RefBox<string | undefined>;
+export function useAppShellNavRefSync(options: {
   navSelection: NavSelection;
   navSelectionRef: RefBox<NavSelection>;
 }) {
-  useEffect(() => {
-    options.activeIdRef.current = options.activeId;
-  }, [options.activeId]);
-
   useEffect(() => {
     options.navSelectionRef.current = options.navSelection;
   }, [options.navSelection]);

--- a/apps/desktop/src/renderer/app-shell.tsx
+++ b/apps/desktop/src/renderer/app-shell.tsx
@@ -108,7 +108,7 @@ import {
   useAppShellBootstrapSubscriptions,
   useAppShellHostEffects,
   useAppShellPersistenceEffects,
-  useAppShellRefSync,
+  useAppShellNavRefSync,
   useSessionEventHealthPolling,
   useSettledSessionTransientReconcile,
 } from './app-shell-effects';
@@ -1019,9 +1019,7 @@ export function AppShell({
 
   const hasModalOpen = Boolean(activePermission) || helpOpen || paletteOpen || searchModalOpen;
 
-  useAppShellRefSync({
-    activeId,
-    activeIdRef,
+  useAppShellNavRefSync({
     navSelection,
     navSelectionRef,
   });

--- a/apps/desktop/src/renderer/app-shell.tsx
+++ b/apps/desktop/src/renderer/app-shell.tsx
@@ -7,7 +7,6 @@ import type {
   PlanReminder,
   SessionSummary,
   SettingsSection,
-  StoredMessage,
   ThemePalette,
   ThemePreference,
   ThinkingLevel,
@@ -104,7 +103,6 @@ import { createAppShellDailyReviewActions } from './app-shell-daily-review-actio
 import { createAppShellSessionRowActions } from './app-shell-session-row-actions';
 import { createAppShellSessionSettingsActions } from './app-shell-session-settings-actions';
 import { createAppShellStopAction } from './app-shell-stop-action';
-import { useAppShellSessionUiState } from './app-shell-session-ui-state';
 import {
   useActiveSessionEvents,
   useAppShellBootstrapSubscriptions,
@@ -115,8 +113,8 @@ import {
   useSettledSessionTransientReconcile,
 } from './app-shell-effects';
 import { loadComposerDefaults, saveComposerDefaults } from './composer-defaults';
-import { useAppShellSessionList } from './use-app-shell-session-list';
 import { useAppShellComposerAttachments } from './use-app-shell-composer-attachments';
+import { useAppShellSessionWorkspace } from './use-app-shell-session-workspace';
 
 function connectionsEqual(a: LlmConnection[], b: LlmConnection[]): boolean {
   if (a.length !== b.length) return false;
@@ -156,8 +154,30 @@ export function AppShell({
     upsertSessionSummary,
     markSessionRunningOptimistic,
     markSessionReadLocally,
-  } = useAppShellSessionList(toastApi);
-  const [activeId, setActiveIdState] = useState<string | undefined>();
+    activeId,
+    activeIdRef,
+    setActiveId,
+    startNewSession,
+    clearOwnedSessionState,
+    messages,
+    setMessages,
+    messageLoadPending,
+    setMessageLoadPending,
+    messageRetryPendingRef,
+    stopPendingRef,
+    sessionUiState,
+    liveTurnBySessionRef,
+    sessionEventHealthBySessionRef,
+    setMessageLoadErrorBySession,
+    setMessageRetryPendingBySession,
+    setStopPendingBySession,
+    setLiveTurnBySession,
+    setPermissionBySession,
+    setSessionEventHealthBySession,
+    setPendingPermissionModeBySession,
+    setPendingSessionModelBySession,
+    clearTurnTransientState,
+  } = useAppShellSessionWorkspace(toastApi);
   const attachmentDraftKey = activeId ?? 'new-session';
   const {
     pendingAttachments,
@@ -171,25 +191,6 @@ export function AppShell({
   const [liveBrowserSessionIds, setLiveBrowserSessionIds] = useState<string[]>([]);
   const [navSelection, setNavSelection] = useState<NavSelection>(() => readNavSelection());
   const navSelectionRef = useRef<NavSelection>(navSelection);
-  const [messages, setMessages] = useState<StoredMessage[]>([]);
-  const [messageLoadPending, setMessageLoadPending] = useState(false);
-  const messageRetryPendingRef = useRef<Set<string>>(new Set());
-  const stopPendingRef = useRef<Set<string>>(new Set());
-  const {
-    state: sessionUiState,
-    liveTurnBySessionRef,
-    sessionEventHealthBySessionRef,
-    setMessageLoadErrorBySession,
-    setMessageRetryPendingBySession,
-    setStopPendingBySession,
-    setLiveTurnBySession,
-    setPermissionBySession,
-    setSessionEventHealthBySession,
-    setPendingPermissionModeBySession,
-    setPendingSessionModelBySession,
-    clearSessionUiState,
-    clearTurnTransientState,
-  } = useAppShellSessionUiState();
   const {
     messageLoadErrorBySession,
     messageRetryPendingBySession,
@@ -268,7 +269,6 @@ export function AppShell({
     });
   }
   const composerRef = useRef<ComposerHandle>(null);
-  const activeIdRef = useRef<string | undefined>(undefined);
   const rendererMountedRef = useRef(true);
   const projectPickerPendingRef = useRef(false);
   const projectPickerRequestRef = useRef(0);
@@ -543,12 +543,10 @@ export function AppShell({
   }
 
   function clearSessionRendererState(sessionId: string): void {
-    messageRetryPendingRef.current.delete(sessionId);
-    stopPendingRef.current.delete(sessionId);
+    clearOwnedSessionState(sessionId);
     clearPendingTurnActionsForSession(sessionId);
     pendingPermissionModeChangesRef.current.delete(sessionId);
     pendingSessionModelChangesRef.current.delete(sessionId);
-    clearSessionUiState(sessionId);
   }
 
   const sessionRowActionHandlers = createAppShellSessionRowActions({
@@ -824,19 +822,6 @@ export function AppShell({
     sessionListWidth,
     setSessionListWidth,
   });
-
-  function setActiveId(next: string | undefined): void {
-    // Clear here, not in the read effect: a layout-effect clear would wipe an
-    // optimistic first message before the first paint.
-    if (!next) {
-      setMessageLoadPending(false);
-    } else if (next !== activeIdRef.current) {
-      setMessages([]);
-      setMessageLoadPending(true);
-    }
-    activeIdRef.current = next;
-    setActiveIdState(next);
-  }
 
   function isAutomationsSurfaceActive(): boolean {
     return navSelectionRef.current.section === 'automations';
@@ -1181,11 +1166,9 @@ export function AppShell({
   }
 
   async function createSession() {
-    setActiveId(undefined);
+    startNewSession();
     setNavSelection({ section: 'sessions', filter: 'chats' });
     setSearchScrollTarget(null);
-    setMessageLoadPending(false);
-    setMessages([]);
     // New-task affordances reset to the empty-state composer; move focus
     // there so the user can start typing immediately.
     window.requestAnimationFrame(() => composerRef.current?.focus());

--- a/apps/desktop/src/renderer/use-app-shell-session-workspace.ts
+++ b/apps/desktop/src/renderer/use-app-shell-session-workspace.ts
@@ -1,0 +1,70 @@
+import { useRef, useState } from 'react';
+import type { StoredMessage } from '@maka/core';
+import { useAppShellSessionUiState } from './app-shell-session-ui-state';
+import { useAppShellSessionList } from './use-app-shell-session-list';
+
+type ToastApi = {
+  error(title: string, description?: string): void;
+};
+
+export function useAppShellSessionWorkspace(toastApi: ToastApi) {
+  const sessionList = useAppShellSessionList(toastApi);
+  const sessionUi = useAppShellSessionUiState();
+  const [activeId, setActiveIdState] = useState<string | undefined>();
+  const activeIdRef = useRef<string | undefined>(undefined);
+  const [messages, setMessages] = useState<StoredMessage[]>([]);
+  const [messageLoadPending, setMessageLoadPending] = useState(false);
+  const messageRetryPendingRef = useRef<Set<string>>(new Set());
+  const stopPendingRef = useRef<Set<string>>(new Set());
+
+  function setActiveId(next: string | undefined): void {
+    // Clear here, not in the read effect: a layout-effect clear would wipe an
+    // optimistic first message before the first paint.
+    if (!next) {
+      setMessageLoadPending(false);
+    } else if (next !== activeIdRef.current) {
+      setMessages([]);
+      setMessageLoadPending(true);
+    }
+    activeIdRef.current = next;
+    setActiveIdState(next);
+  }
+
+  function startNewSession(): void {
+    setActiveId(undefined);
+    setMessages([]);
+  }
+
+  function clearOwnedSessionState(sessionId: string): void {
+    messageRetryPendingRef.current.delete(sessionId);
+    stopPendingRef.current.delete(sessionId);
+    sessionUi.clearSessionUiState(sessionId);
+  }
+
+  return {
+    ...sessionList,
+    activeId,
+    activeIdRef,
+    setActiveId,
+    startNewSession,
+    clearOwnedSessionState,
+    messages,
+    setMessages,
+    messageLoadPending,
+    setMessageLoadPending,
+    messageRetryPendingRef,
+    stopPendingRef,
+    sessionUiState: sessionUi.state,
+    liveTurnBySessionRef: sessionUi.liveTurnBySessionRef,
+    sessionEventHealthBySessionRef: sessionUi.sessionEventHealthBySessionRef,
+    setMessageLoadErrorBySession: sessionUi.setMessageLoadErrorBySession,
+    setMessageRetryPendingBySession: sessionUi.setMessageRetryPendingBySession,
+    setStopPendingBySession: sessionUi.setStopPendingBySession,
+    setLiveTurnBySession: sessionUi.setLiveTurnBySession,
+    setPermissionBySession: sessionUi.setPermissionBySession,
+    setSessionEventHealthBySession: sessionUi.setSessionEventHealthBySession,
+    setPendingPermissionModeBySession: sessionUi.setPendingPermissionModeBySession,
+    setPendingSessionModelBySession: sessionUi.setPendingSessionModelBySession,
+    clearTurnTransientState: sessionUi.clearTurnTransientState,
+  };
+}


### PR DESCRIPTION
## Summary
- compose session list, active identity, messages/loading, and transient session UI behind one workspace owner
- keep activeIdRef synchronous and single-owned by the workspace
- expose intent operations for new-session reset and owned deletion cleanup
- preserve existing action/effect seams and AppShell coordination

## Verification
- desktop typecheck
- desktop tests — 2378 passed
- session ownership, lifecycle, routing, deletion, read-boundary, and pending-state contracts
- Electron send/session-management E2E — 2 passed
- $invoke Codex review round 2 — PASS, no P0–P3 findings

## Review follow-up
Round 1 passed with two P3 findings. Both were verified and closed because they directly affected the ownership goal: redundant activeIdRef effect assignment was removed, and the deletion cleanup contract now extracts exact function bodies instead of matching across an invalid marker.

## Impact
No intended visual or UX changes.

Refs #844