### PR TITLE
fix(ui): complete bootstrap snapshot handoff

### DIFF
--- a/apps/desktop/src/main/__tests__/bootstrap-selection-lease.test.ts
+++ b/apps/desktop/src/main/__tests__/bootstrap-selection-lease.test.ts
@@ -1,0 +1,69 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { createBootstrapSelectionLease } from '../../renderer/bootstrap-selection-lease.js';
+
+type Summary = { id: string; lastMessageAt?: number };
+
+function session(id: string, lastMessageAt?: number): Summary {
+  return { id, lastMessageAt };
+}
+
+function harness(activeId?: string) {
+  let active = activeId;
+  let revision = 0;
+  const lease = createBootstrapSelectionLease<Summary>({
+    readActiveId: () => active,
+    readSelectionRevision: () => revision,
+    select: (next) => {
+      revision += 1;
+      active = next;
+    },
+  });
+  return {
+    lease,
+    activeId: () => active,
+    select(next: string | undefined) {
+      revision += 1;
+      active = next;
+    },
+  };
+}
+
+describe('bootstrap selection lease', () => {
+  it('lets snapshot A and mounted pull B reconcile while bootstrap still owns selection', () => {
+    const state = harness();
+    assert.equal(state.lease.reconcile([session('a', 1)]), true);
+    assert.equal(state.activeId(), 'a');
+    assert.equal(state.lease.reconcile([session('b', 2)]), true);
+    assert.equal(state.activeId(), 'b');
+  });
+
+  it('cannot select history when the user starts a new task before the first snapshot', () => {
+    const state = harness();
+    state.select(undefined);
+    assert.equal(state.lease.reconcile([session('history', 1)]), false);
+    assert.equal(state.activeId(), undefined);
+  });
+
+  it('cannot replace a user selection made between snapshot A and B', () => {
+    const state = harness();
+    state.lease.reconcile([session('a', 1)]);
+    state.select('user-choice');
+    assert.equal(state.lease.reconcile([session('b', 2)]), false);
+    assert.equal(state.activeId(), 'user-choice');
+  });
+
+  it('clears a bootstrap-owned selection when the latest snapshot is empty', () => {
+    const state = harness();
+    state.lease.reconcile([session('a', 1)]);
+    assert.equal(state.lease.reconcile([]), true);
+    assert.equal(state.activeId(), undefined);
+  });
+
+  it('does not reconcile after release', () => {
+    const state = harness();
+    state.lease.release();
+    assert.equal(state.lease.reconcile([session('history', 1)]), false);
+    assert.equal(state.activeId(), undefined);
+  });
+});

--- a/apps/desktop/src/main/__tests__/permission-response-ipc-boundary.test.ts
+++ b/apps/desktop/src/main/__tests__/permission-response-ipc-boundary.test.ts
@@ -425,6 +425,40 @@ describe('permission response IPC boundary', () => {
     );
   });
 
+  it('reconciles the first mounted onboarding pull after the pre-mount snapshot seed', async () => {
+    const renderer = await readRendererShellSource('app-shell.tsx');
+    const onboardingSnapshotHook = await readFile(
+      fileURLToPath(new URL('../../../src/renderer/use-onboarding-snapshot.ts', import.meta.url)),
+      'utf8',
+    );
+
+    assert.match(
+      onboardingSnapshotHook,
+      /refreshGeneration:\s*number/,
+      'the snapshot owner must identify successful mounted pulls separately from the pre-mount seed',
+    );
+    assert.match(
+      renderer,
+      /onboarding\.refreshGeneration\s*>\s*1/,
+      'AppShell must reconcile the pre-mount snapshot and first mounted pull, then leave later refreshes to existing owners',
+    );
+    assert.doesNotMatch(
+      renderer,
+      /const seededRef = useRef\(false\)/,
+      'a one-shot seed drops a newer snapshot returned by the first mounted pull',
+    );
+    assert.match(
+      renderer,
+      /const next = seedSessions\(snapshot\.sessions\)/,
+      'the mounted pull must replace the session owner even when the latest list is empty',
+    );
+    assert.match(
+      renderer,
+      /setConnections\(snapshot\.connections\)/,
+      'the mounted pull must replace the connection owner even when the latest list is empty',
+    );
+  });
+
   it('keeps normal Composer first-send visible in the newly created session', async () => {
     const renderer = await readRendererShellSources([
       'app-shell-chat-actions.ts',

--- a/apps/desktop/src/main/__tests__/permission-response-ipc-boundary.test.ts
+++ b/apps/desktop/src/main/__tests__/permission-response-ipc-boundary.test.ts
@@ -345,8 +345,8 @@ describe('permission response IPC boundary', () => {
     );
     assert.match(
       bootstrapSessions[0],
-      /if \(!activeIdRef\.current && next\[0\] && next\[0\]\.lastMessageAt\) setActiveId\(next\[0\]\.id\)/,
-      'only bootstrapSessions() may auto-select the first existing chat on app startup',
+      /bootstrapSelectionLease\.reconcile\(next\);[\s\S]*bootstrapSelectionLease\.release\(\)/,
+      'the fallback bootstrap must share and then release the session owner\'s selection lease',
     );
     assert.match(
       renderer,

--- a/apps/desktop/src/main/__tests__/permission-response-ipc-boundary.test.ts
+++ b/apps/desktop/src/main/__tests__/permission-response-ipc-boundary.test.ts
@@ -434,13 +434,13 @@ describe('permission response IPC boundary', () => {
 
     assert.match(
       onboardingSnapshotHook,
-      /refreshGeneration:\s*number/,
-      'the snapshot owner must identify successful mounted pulls separately from the pre-mount seed',
+      /firstMountedSnapshot:\s*OnboardingSnapshot \| null/,
+      'the snapshot owner must latch the first successful mounted pull separately from the pre-mount seed',
     );
     assert.match(
       renderer,
-      /onboarding\.refreshGeneration\s*>\s*1/,
-      'AppShell must reconcile the pre-mount snapshot and first mounted pull, then leave later refreshes to existing owners',
+      /snapshot = onboarding\.firstMountedSnapshot/,
+      'AppShell must consume the latched mounted snapshot instead of inferring it from a cumulative generation',
     );
     assert.doesNotMatch(
       renderer,

--- a/apps/desktop/src/main/__tests__/use-onboarding-snapshot.test.ts
+++ b/apps/desktop/src/main/__tests__/use-onboarding-snapshot.test.ts
@@ -15,7 +15,9 @@ import { join } from 'node:path';
 import { describe, it } from 'node:test';
 import type { OnboardingState } from '@maka/core';
 import {
+  advanceOnboardingSnapshotState,
   createOnboardingSnapshotPoller,
+  createOnboardingSnapshotState,
   isSetupRequired,
 } from '../../renderer/use-onboarding-snapshot.js';
 import type { OnboardingSnapshot } from '../../global.js';
@@ -206,6 +208,20 @@ describe('createOnboardingSnapshotPoller', () => {
     poller.activate();
     await poller.pull();
     assert.deepEqual(events, [{ type: 'snap', payload: READY_SNAPSHOT }]);
+  });
+});
+
+describe('onboarding mounted snapshot handoff', () => {
+  it('latches B when B and a later C are reduced before React commits', () => {
+    const snapshotA = READY_SNAPSHOT;
+    const snapshotB = { ...READY_SNAPSHOT, defaultSlug: 'b' };
+    const snapshotC = { ...READY_SNAPSHOT, defaultSlug: 'c' };
+
+    const afterB = advanceOnboardingSnapshotState(createOnboardingSnapshotState(snapshotA), snapshotB);
+    const afterC = advanceOnboardingSnapshotState(afterB, snapshotC);
+
+    assert.equal(afterC.snapshot, snapshotC);
+    assert.equal(afterC.firstMountedSnapshot, snapshotB);
   });
 });
 

--- a/apps/desktop/src/renderer/app-shell.tsx
+++ b/apps/desktop/src/renderer/app-shell.tsx
@@ -773,7 +773,7 @@ export function AppShell({
   // already fetches the session list + connections internally, so separate
   // `sessions:list` / `connections:list` / `getDefault` IPCs are redundant.
   // This lets the UI show the sidebar + model picker immediately on first load.
-  const seededRef = useRef(false);
+  const seededRefreshGenerationRef = useRef(-1);
   // useLayoutEffect, NOT useEffect: the snapshot render flips
   // `isOnboardingLoading` off while `sessions` is still []. A passive
   // effect seeds sessions AFTER the browser paints that frame, so users
@@ -783,30 +783,31 @@ export function AppShell({
   useLayoutEffect(() => {
     // Snapshot IPC failed — the seed path will never run, so fall back
     // to the classic boot pull or the sidebar stays empty forever.
-    if (onboarding.error && !onboarding.snapshot && !seededRef.current) {
-      seededRef.current = true;
+    if (onboarding.error && !onboarding.snapshot && seededRefreshGenerationRef.current < 0) {
+      seededRefreshGenerationRef.current = Number.POSITIVE_INFINITY;
       void bootstrapSessions();
       void refreshConnections();
       return;
     }
     const snapshot = onboarding.snapshot;
-    if (!snapshot || seededRef.current) return;
-    seededRef.current = true;
+    if (
+      !snapshot ||
+      onboarding.refreshGeneration > 1 ||
+      seededRefreshGenerationRef.current === onboarding.refreshGeneration
+    ) return;
+    seededRefreshGenerationRef.current = onboarding.refreshGeneration;
     // Seed sessions. Display normalization MUST run here too — this is
     // a third renderer state entry alongside commitSessions /
     // upsertSessionSummary (#452): without it, legacy blocked/unknown
     // sessions flash an 已阻塞 group on first paint until the first
     // refreshSessions() overwrites the seed.
-    if (snapshot.sessions.length > 0) {
-      const next = seedSessions(snapshot.sessions);
-      if (!activeIdRef.current && next[0]?.lastMessageAt) setActiveId(next[0].id);
-    }
+    const next = seedSessions(snapshot.sessions);
+    if (activeIdRef.current && !next.some((session) => session.id === activeIdRef.current)) setActiveId(undefined);
+    if (!activeIdRef.current && next[0]?.lastMessageAt) setActiveId(next[0].id);
     // Seed connections — avoids separate connections:list + getDefault IPCs
-    if (snapshot.connections.length > 0) {
-      setConnections(snapshot.connections);
-      setDefaultConnection(snapshot.defaultSlug);
-    }
-  }, [onboarding.snapshot, onboarding.error]);
+    setConnections(snapshot.connections);
+    setDefaultConnection(snapshot.defaultSlug);
+  }, [onboarding.snapshot, onboarding.refreshGeneration, onboarding.error]);
   // PR110c (@kenji review): suppress hero AND the fallback EmptyChatHero
   // while the initial snapshot is in flight. Otherwise sessions.length===0
   // + snapshot===null flashes the prompt-suggestion EmptyChatHero before

--- a/apps/desktop/src/renderer/app-shell.tsx
+++ b/apps/desktop/src/renderer/app-shell.tsx
@@ -156,6 +156,7 @@ export function AppShell({
     markSessionReadLocally,
     activeId,
     activeIdRef,
+    bootstrapSelectionLease,
     setActiveId,
     startNewSession,
     clearOwnedSessionState,
@@ -802,11 +803,11 @@ export function AppShell({
     // sessions flash an 已阻塞 group on first paint until the first
     // refreshSessions() overwrites the seed.
     const next = seedSessions(snapshot.sessions);
-    if (activeIdRef.current && !next.some((session) => session.id === activeIdRef.current)) setActiveId(undefined);
-    if (!activeIdRef.current && next[0]?.lastMessageAt) setActiveId(next[0].id);
+    bootstrapSelectionLease.reconcile(next);
     // Seed connections — avoids separate connections:list + getDefault IPCs
     setConnections(snapshot.connections);
     setDefaultConnection(snapshot.defaultSlug);
+    if (onboarding.refreshGeneration === 1) bootstrapSelectionLease.release();
   }, [onboarding.snapshot, onboarding.refreshGeneration, onboarding.error]);
   // PR110c (@kenji review): suppress hero AND the fallback EmptyChatHero
   // while the initial snapshot is in flight. Otherwise sessions.length===0
@@ -1148,7 +1149,8 @@ export function AppShell({
 
   async function bootstrapSessions() {
     const next = await refreshSessions();
-    if (!activeIdRef.current && next[0] && next[0].lastMessageAt) setActiveId(next[0].id);
+    bootstrapSelectionLease.reconcile(next);
+    bootstrapSelectionLease.release();
   }
 
   async function refreshConnections() {

--- a/apps/desktop/src/renderer/app-shell.tsx
+++ b/apps/desktop/src/renderer/app-shell.tsx
@@ -774,7 +774,9 @@ export function AppShell({
   // already fetches the session list + connections internally, so separate
   // `sessions:list` / `connections:list` / `getDefault` IPCs are redundant.
   // This lets the UI show the sidebar + model picker immediately on first load.
-  const seededRefreshGenerationRef = useRef(-1);
+  const initialSnapshotSeededRef = useRef(false);
+  const mountedSnapshotSeededRef = useRef(false);
+  const bootstrapFallbackStartedRef = useRef(false);
   // useLayoutEffect, NOT useEffect: the snapshot render flips
   // `isOnboardingLoading` off while `sessions` is still []. A passive
   // effect seeds sessions AFTER the browser paints that frame, so users
@@ -784,19 +786,32 @@ export function AppShell({
   useLayoutEffect(() => {
     // Snapshot IPC failed — the seed path will never run, so fall back
     // to the classic boot pull or the sidebar stays empty forever.
-    if (onboarding.error && !onboarding.snapshot && seededRefreshGenerationRef.current < 0) {
-      seededRefreshGenerationRef.current = Number.POSITIVE_INFINITY;
+    if (
+      onboarding.error &&
+      !initialOnboardingSnapshot &&
+      !onboarding.firstMountedSnapshot &&
+      !bootstrapFallbackStartedRef.current
+    ) {
+      bootstrapFallbackStartedRef.current = true;
       void bootstrapSessions();
       void refreshConnections();
       return;
     }
-    const snapshot = onboarding.snapshot;
-    if (
-      !snapshot ||
-      onboarding.refreshGeneration > 1 ||
-      seededRefreshGenerationRef.current === onboarding.refreshGeneration
-    ) return;
-    seededRefreshGenerationRef.current = onboarding.refreshGeneration;
+    let snapshot: OnboardingSnapshot | null = null;
+    let releaseSelectionLease = false;
+    if (!initialSnapshotSeededRef.current && initialOnboardingSnapshot) {
+      initialSnapshotSeededRef.current = true;
+      snapshot = initialOnboardingSnapshot;
+    } else if (
+      !bootstrapFallbackStartedRef.current &&
+      !mountedSnapshotSeededRef.current &&
+      onboarding.firstMountedSnapshot
+    ) {
+      mountedSnapshotSeededRef.current = true;
+      snapshot = onboarding.firstMountedSnapshot;
+      releaseSelectionLease = true;
+    }
+    if (!snapshot) return;
     // Seed sessions. Display normalization MUST run here too — this is
     // a third renderer state entry alongside commitSessions /
     // upsertSessionSummary (#452): without it, legacy blocked/unknown
@@ -807,8 +822,8 @@ export function AppShell({
     // Seed connections — avoids separate connections:list + getDefault IPCs
     setConnections(snapshot.connections);
     setDefaultConnection(snapshot.defaultSlug);
-    if (onboarding.refreshGeneration === 1) bootstrapSelectionLease.release();
-  }, [onboarding.snapshot, onboarding.refreshGeneration, onboarding.error]);
+    if (releaseSelectionLease) bootstrapSelectionLease.release();
+  }, [initialOnboardingSnapshot, onboarding.firstMountedSnapshot, onboarding.error]);
   // PR110c (@kenji review): suppress hero AND the fallback EmptyChatHero
   // while the initial snapshot is in flight. Otherwise sessions.length===0
   // + snapshot===null flashes the prompt-suggestion EmptyChatHero before

--- a/apps/desktop/src/renderer/bootstrap-selection-lease.ts
+++ b/apps/desktop/src/renderer/bootstrap-selection-lease.ts
@@ -1,0 +1,35 @@
+export interface BootstrapSelectionLease<Summary extends { id: string; lastMessageAt?: number }> {
+  reconcile(sessions: readonly Summary[]): boolean;
+  release(): void;
+}
+
+export function createBootstrapSelectionLease<Summary extends { id: string; lastMessageAt?: number }>(options: {
+  readActiveId: () => string | undefined;
+  readSelectionRevision: () => number;
+  select: (sessionId: string | undefined) => void;
+}): BootstrapSelectionLease<Summary> {
+  let ownedRevision = options.readSelectionRevision();
+  let active = true;
+
+  return {
+    reconcile(sessions): boolean {
+      if (!active || options.readSelectionRevision() !== ownedRevision) {
+        active = false;
+        return false;
+      }
+
+      const current = options.readActiveId();
+      const next = current && sessions.some((session) => session.id === current)
+        ? current
+        : sessions[0]?.lastMessageAt
+          ? sessions[0].id
+          : undefined;
+      if (next !== current) options.select(next);
+      ownedRevision = options.readSelectionRevision();
+      return true;
+    },
+    release(): void {
+      active = false;
+    },
+  };
+}

--- a/apps/desktop/src/renderer/use-app-shell-session-workspace.ts
+++ b/apps/desktop/src/renderer/use-app-shell-session-workspace.ts
@@ -2,6 +2,7 @@ import { useRef, useState } from 'react';
 import type { StoredMessage } from '@maka/core';
 import { useAppShellSessionUiState } from './app-shell-session-ui-state';
 import { useAppShellSessionList } from './use-app-shell-session-list';
+import { createBootstrapSelectionLease } from './bootstrap-selection-lease';
 
 type ToastApi = {
   error(title: string, description?: string): void;
@@ -12,12 +13,15 @@ export function useAppShellSessionWorkspace(toastApi: ToastApi) {
   const sessionUi = useAppShellSessionUiState();
   const [activeId, setActiveIdState] = useState<string | undefined>();
   const activeIdRef = useRef<string | undefined>(undefined);
+  const selectionRevisionRef = useRef(0);
+  const bootstrapSelectionLeaseRef = useRef<ReturnType<typeof createBootstrapSelectionLease> | null>(null);
   const [messages, setMessages] = useState<StoredMessage[]>([]);
   const [messageLoadPending, setMessageLoadPending] = useState(false);
   const messageRetryPendingRef = useRef<Set<string>>(new Set());
   const stopPendingRef = useRef<Set<string>>(new Set());
 
   function setActiveId(next: string | undefined): void {
+    selectionRevisionRef.current += 1;
     // Clear here, not in the read effect: a layout-effect clear would wipe an
     // optimistic first message before the first paint.
     if (!next) {
@@ -28,6 +32,14 @@ export function useAppShellSessionWorkspace(toastApi: ToastApi) {
     }
     activeIdRef.current = next;
     setActiveIdState(next);
+  }
+
+  if (!bootstrapSelectionLeaseRef.current) {
+    bootstrapSelectionLeaseRef.current = createBootstrapSelectionLease({
+      readActiveId: () => activeIdRef.current,
+      readSelectionRevision: () => selectionRevisionRef.current,
+      select: setActiveId,
+    });
   }
 
   function startNewSession(): void {
@@ -45,6 +57,7 @@ export function useAppShellSessionWorkspace(toastApi: ToastApi) {
     ...sessionList,
     activeId,
     activeIdRef,
+    bootstrapSelectionLease: bootstrapSelectionLeaseRef.current,
     setActiveId,
     startNewSession,
     clearOwnedSessionState,

--- a/apps/desktop/src/renderer/use-onboarding-snapshot.ts
+++ b/apps/desktop/src/renderer/use-onboarding-snapshot.ts
@@ -27,8 +27,8 @@ import type { OnboardingSnapshot } from '../global';
  */
 export interface UseOnboardingSnapshotResult {
   snapshot: OnboardingSnapshot | null;
-  /** Number of successful mounted pulls; the pre-mount snapshot is generation 0. */
-  refreshGeneration: number;
+  /** First successful mounted pull, latched until AppShell consumes the bootstrap handoff. */
+  firstMountedSnapshot: OnboardingSnapshot | null;
   error: string | null;
   refresh: () => void;
   /** Sessions from the snapshot — populated on first load, before the separate sessions:list IPC. */
@@ -50,6 +50,25 @@ export interface UseOnboardingSnapshotDeps {
   subscribeInvalidations: (onInvalidate: () => void) => () => void;
 }
 
+export interface OnboardingSnapshotState {
+  snapshot: OnboardingSnapshot | null;
+  firstMountedSnapshot: OnboardingSnapshot | null;
+}
+
+export function createOnboardingSnapshotState(initialSnapshot: OnboardingSnapshot | null): OnboardingSnapshotState {
+  return { snapshot: initialSnapshot, firstMountedSnapshot: null };
+}
+
+export function advanceOnboardingSnapshotState(
+  current: OnboardingSnapshotState,
+  next: OnboardingSnapshot,
+): OnboardingSnapshotState {
+  return {
+    snapshot: next,
+    firstMountedSnapshot: current.firstMountedSnapshot ?? next,
+  };
+}
+
 /**
  * Pure-deps form. Renderer code uses `useOnboardingSnapshot()` (no
  * args); tests pass injected `deps` to drive the hook with fakes
@@ -64,10 +83,7 @@ export function useOnboardingSnapshotImpl(
   deps: UseOnboardingSnapshotDeps,
   initialSnapshot: OnboardingSnapshot | null = null,
 ): UseOnboardingSnapshotResult {
-  const [snapshotState, setSnapshotState] = useState(() => ({
-    snapshot: initialSnapshot,
-    refreshGeneration: 0,
-  }));
+  const [snapshotState, setSnapshotState] = useState(() => createOnboardingSnapshotState(initialSnapshot));
   const [error, setError] = useState<string | null>(null);
   const sessionsRef = useRef<SessionSummary[] | null>(initialSnapshot?.sessions ?? null);
   const connectionsRef = useRef<LlmConnection[] | null>(initialSnapshot?.connections ?? null);
@@ -77,10 +93,7 @@ export function useOnboardingSnapshotImpl(
   if (pollerRef.current === null) {
     pollerRef.current = createOnboardingSnapshotPoller(deps, {
       onSnapshot: (next) => {
-        setSnapshotState((current) => ({
-          snapshot: next,
-          refreshGeneration: current.refreshGeneration + 1,
-        }));
+        setSnapshotState((current) => advanceOnboardingSnapshotState(current, next));
         setError(null);
         if (next.sessions) sessionsRef.current = next.sessions;
         if (next.connections) connectionsRef.current = next.connections;
@@ -115,7 +128,7 @@ export function useOnboardingSnapshotImpl(
 
   return {
     snapshot: snapshotState.snapshot,
-    refreshGeneration: snapshotState.refreshGeneration,
+    firstMountedSnapshot: snapshotState.firstMountedSnapshot,
     error,
     refresh,
     getSessions,

--- a/apps/desktop/src/renderer/use-onboarding-snapshot.ts
+++ b/apps/desktop/src/renderer/use-onboarding-snapshot.ts
@@ -27,6 +27,8 @@ import type { OnboardingSnapshot } from '../global';
  */
 export interface UseOnboardingSnapshotResult {
   snapshot: OnboardingSnapshot | null;
+  /** Number of successful mounted pulls; the pre-mount snapshot is generation 0. */
+  refreshGeneration: number;
   error: string | null;
   refresh: () => void;
   /** Sessions from the snapshot — populated on first load, before the separate sessions:list IPC. */
@@ -62,7 +64,10 @@ export function useOnboardingSnapshotImpl(
   deps: UseOnboardingSnapshotDeps,
   initialSnapshot: OnboardingSnapshot | null = null,
 ): UseOnboardingSnapshotResult {
-  const [snapshot, setSnapshot] = useState<OnboardingSnapshot | null>(initialSnapshot);
+  const [snapshotState, setSnapshotState] = useState(() => ({
+    snapshot: initialSnapshot,
+    refreshGeneration: 0,
+  }));
   const [error, setError] = useState<string | null>(null);
   const sessionsRef = useRef<SessionSummary[] | null>(initialSnapshot?.sessions ?? null);
   const connectionsRef = useRef<LlmConnection[] | null>(initialSnapshot?.connections ?? null);
@@ -72,7 +77,10 @@ export function useOnboardingSnapshotImpl(
   if (pollerRef.current === null) {
     pollerRef.current = createOnboardingSnapshotPoller(deps, {
       onSnapshot: (next) => {
-        setSnapshot(next);
+        setSnapshotState((current) => ({
+          snapshot: next,
+          refreshGeneration: current.refreshGeneration + 1,
+        }));
         setError(null);
         if (next.sessions) sessionsRef.current = next.sessions;
         if (next.connections) connectionsRef.current = next.connections;
@@ -105,7 +113,15 @@ export function useOnboardingSnapshotImpl(
   const getConnections = useCallback((): LlmConnection[] | null => connectionsRef.current, []);
   const getDefaultSlug = useCallback((): string | null => defaultSlugRef.current, []);
 
-  return { snapshot, error, refresh, getSessions, getConnections, getDefaultSlug };
+  return {
+    snapshot: snapshotState.snapshot,
+    refreshGeneration: snapshotState.refreshGeneration,
+    error,
+    refresh,
+    getSessions,
+    getConnections,
+    getDefaultSlug,
+  };
 }
 
 /**


### PR DESCRIPTION
## Summary

- latch the first successful mounted onboarding snapshot so React batching cannot skip the bootstrap handoff
- keep startup session selection behind a one-shot lease owned by the active-session workspace
- preserve user selection across delayed snapshots and fallback refreshes

## Validation

- `npm --workspace @maka/desktop run typecheck`
- `npm --workspace @maka/desktop test` (2385 passed)
- targeted bootstrap/onboarding/session contract tests (35 passed)
- independent Codex review: PASS, no P0-P3 findings

Closes #844