### PR TITLE
fix(desktop): re-sync native window chrome on runtime theme switch

### DIFF
--- a/apps/desktop/src/main/__tests__/theme-source.test.ts
+++ b/apps/desktop/src/main/__tests__/theme-source.test.ts
@@ -65,6 +65,13 @@ describe('theme-source', () => {
       assert.match(body, /target !== mainWindow/, 'must reject senders that are not the tracked main window');
       assert.match(body, /isThemePreference\(themePref\)/, 'must reject values that are not a valid ThemePreference');
       assert.match(body, /nativeTheme\.themeSource = toNativeThemeSource\(themePref\)/, 'must assign via the shared mapping helper');
+      // A runtime theme switch must deterministically re-sync the native
+      // chrome: nativeTheme.themeSource alone does not update the window's
+      // captured-at-creation backgroundColor, nor reliably re-tint the macOS
+      // vibrancy material (Reduce Transparency / some macOS builds leave the
+      // frosted sidebar on the old theme). Re-assert both here.
+      assert.match(body, /setBackgroundColor\(/, 'must refresh the window backgroundColor on theme change (it is captured once at creation otherwise)');
+      assert.match(body, /setVibrancy\(null\)[\s\S]*setVibrancy\(MAIN_WINDOW_VIBRANCY\)/, 'must recreate the macOS vibrancy view so it re-reads the new effective appearance');
     });
 
     it('createWindow syncs nativeTheme.themeSource before creating the BrowserWindow, not only via the later IPC call', async () => {

--- a/apps/desktop/src/main/main-window.ts
+++ b/apps/desktop/src/main/main-window.ts
@@ -71,6 +71,18 @@ export function safeSendToRenderer(channel: string, ...args: unknown[]): void {
 const MAIN_WINDOW_TRAFFIC_LIGHT_POSITION = { x: 14, y: 14 } as const;
 const HIDDEN_TRAFFIC_LIGHT_POSITION = { x: -100, y: -100 } as const;
 
+// Window base fill per resolved theme. Used both for the first-frame
+// `backgroundColor` at creation AND for the runtime re-sync on theme change
+// (setThemeSource), so the two can't drift.
+const WINDOW_BG_DARK = '#1c1d21';
+const WINDOW_BG_LIGHT = '#f3f3f5';
+
+// macOS sidebar vibrancy material. The window is created with this on darwin
+// (outside visual-smoke); setThemeSource re-asserts it on theme change.
+const MAIN_WINDOW_VIBRANCY = 'sidebar' as const;
+const MAIN_WINDOW_USES_VIBRANCY =
+  process.platform === 'darwin' && !process.env.MAKA_VISUAL_SMOKE_FIXTURE;
+
 // PR-SHOW-AFTER-FIRST-COMMIT: fallback reveal delay for a renderer that never
 // signals its first painted frame (window:notifyRendererReady). main.tsx's
 // onboarding prefetch bails at 2500ms; the remainder is headroom for React +
@@ -163,7 +175,7 @@ export function createMainWindowController(deps: MainWindowControllerDeps): Main
     const isDark =
       themePref === 'dark' ||
       (themePref === 'auto' && nativeTheme.shouldUseDarkColors);
-    const initialBg = isDark ? '#1c1d21' : '#f3f3f5';
+    const initialBg = isDark ? WINDOW_BG_DARK : WINDOW_BG_LIGHT;
     // Astro-Han review (#493): sync nativeTheme here too, not only via the
     // renderer's later setThemeSource() IPC call -- otherwise the vibrancy
     // material behind the sidebar can still flash the *system* theme's tint
@@ -240,9 +252,7 @@ export function createMainWindowController(deps: MainWindowControllerDeps): Main
       // Skip vibrancy under MAKA_VISUAL_SMOKE_FIXTURE — capture environments
       // can't paint native window material reliably, and the auto-capture
       // renderer would stall waiting for compositor frames that never settle.
-      ...(process.platform === 'darwin' && !process.env.MAKA_VISUAL_SMOKE_FIXTURE
-        ? { vibrancy: 'sidebar' as const }
-        : {}),
+      ...(MAIN_WINDOW_USES_VIBRANCY ? { vibrancy: MAIN_WINDOW_VIBRANCY } : {}),
       webPreferences: {
         preload: join(import.meta.dirname, '..', 'preload', 'preload.cjs'),
         // Defense-in-depth flags (@kenji PR96 review). The external-link guard
@@ -402,6 +412,27 @@ export function createMainWindowController(deps: MainWindowControllerDeps): Main
       if (!target || target !== mainWindow) return;
       if (!isThemePreference(themePref)) return;
       nativeTheme.themeSource = toNativeThemeSource(themePref);
+
+      // Setting nativeTheme.themeSource alone is NOT enough to re-sync the
+      // window's native chrome on a runtime theme switch:
+      //  - `backgroundColor` is captured once at createWindow() from the boot
+      //    theme and is otherwise never updated, so after a dark→light switch a
+      //    window created in dark keeps a dark base fill behind the sidebar.
+      //  - the macOS `vibrancy: 'sidebar'` material (NSVisualEffectView) does
+      //    not reliably re-read the window's effective appearance when
+      //    themeSource flips at runtime — under Reduce Transparency, or on some
+      //    macOS builds, the frosted sidebar stays tinted to the OLD theme while
+      //    the (opaque, CSS-var-driven) content pane repaints to the new one.
+      //    Symptom: dark sidebar + light content after switching to light.
+      // Re-assert both here so the native backdrop deterministically follows the
+      // in-app theme instead of relying on an implicit auto-update.
+      const isDark = nativeTheme.shouldUseDarkColors;
+      mainWindow.setBackgroundColor(isDark ? WINDOW_BG_DARK : WINDOW_BG_LIGHT);
+      if (MAIN_WINDOW_USES_VIBRANCY) {
+        // Recreate the vibrancy view so it picks up the current appearance.
+        mainWindow.setVibrancy(null);
+        mainWindow.setVibrancy(MAIN_WINDOW_VIBRANCY);
+      }
     },
     setTitleBarOverlayTheme(sender, isDark) {
       const target = BrowserWindow.fromWebContents(sender);


### PR DESCRIPTION
## Symptom
Switching dark→light leaves the **sidebar/backdrop stuck dark** while the content pane correctly goes light.

## Root cause
The runtime theme handler `setThemeSource` only set `nativeTheme.themeSource` and relied on the OS to auto-update the native chrome. It never re-synced two things:

1. **`backgroundColor`** — captured once at `createWindow()` from the boot theme, never updated afterward. A window created in dark keeps a dark base fill behind the transparent (vibrancy) sidebar after switching to light. (Confirmed: no `setBackgroundColor` call exists on any runtime path.)
2. **macOS `sidebar` vibrancy material** — `NSVisualEffectView` does not reliably re-read the window's effective appearance when `themeSource` flips at runtime — notably under **Reduce Transparency**, and on some macOS builds — so the frosted sidebar stays tinted to the old theme.

## Fix
`setThemeSource` now deterministically re-asserts both: `setBackgroundColor(resolved)` + `setVibrancy(null)`/`setVibrancy('sidebar')` (recreates the material against the current appearance). Boot bg colors + the vibrancy material name are extracted to shared constants so the creation path and the re-sync can't drift. New contract assertions pin the re-sync.

## Verification note
On the reviewer's machine (macOS 26.2, Reduce Transparency OFF) the OS auto-flips vibrancy, so the exact stuck-dark symptom could not be reproduced locally — but the runtime path provably never re-synced the native backdrop, which is the class of bug being reported. The fix makes the backdrop follow the in-app theme deterministically across environments rather than depending on an implicit auto-update. CDP-verified no regression on the already-working dark↔light flip; theme-source contract 9/9.