### PR TITLE
refactor(renderer): shared useMountedRef + last formatBytes fork (Round D-1)

### DIFF
--- a/apps/desktop/src/main/__tests__/daily-review-copy-feedback-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/daily-review-copy-feedback-contract.test.ts
@@ -276,7 +276,7 @@ describe('Daily Review copy feedback contract', () => {
     assert.match(pageBlock, /const runningModeRef = useRef<DailyReviewMode \| null>\(null\)/);
     assert.match(
       pageBlock,
-      /return \(\) => \{\s*mountedRef\.current = false;\s*savingKeyRef\.current = null;\s*runningModeRef\.current = null;\s*\};/,
+      /return \(\) => \{\s*savingKeyRef\.current = null;\s*runningModeRef\.current = null;\s*\};/,
       'Daily Review Settings async owners must be invalidated when Settings closes',
     );
     assert.match(

--- a/apps/desktop/src/main/__tests__/first-run-task-suggestions.test.ts
+++ b/apps/desktop/src/main/__tests__/first-run-task-suggestions.test.ts
@@ -130,12 +130,12 @@ describe('FIRST_RUN_TASK_SUGGESTIONS', () => {
     const setupBlock = hero.match(/interface SetupHeroProps[\s\S]*?function assertNever/)?.[0] ?? '';
 
     assert.match(rootBlock, /const \[refreshConnectionsPending, setRefreshConnectionsPending\] = useState\(false\)/);
-    assert.match(rootBlock, /const onboardingMountedRef = useRef\(true\)/);
+    assert.match(rootBlock, /const onboardingMountedRef = useMountedRef\(\)/);
     assert.match(rootBlock, /const refreshConnectionsPendingRef = useRef\(false\)/);
     assert.match(
       rootBlock,
-      /useEffect\(\(\) => \{[\s\S]*onboardingMountedRef\.current = true;[\s\S]*return \(\) => \{[\s\S]*onboardingMountedRef\.current = false;[\s\S]*refreshConnectionsPendingRef\.current = false;[\s\S]*\};[\s\S]*\}, \[\]\)/,
-      'first-run setup refresh must release pending ownership on unmount and restore mounted state during StrictMode replay',
+      /useEffect\(\(\) => \{[\s\S]*return \(\) => \{[\s\S]*refreshConnectionsPendingRef\.current = false;[\s\S]*\};[\s\S]*\}, \[\]\)/,
+      'first-run setup refresh must release pending ownership on unmount; the mounted flag is owned by the shared useMountedRef hook',
     );
     assert.match(
       rootBlock,

--- a/apps/desktop/src/main/__tests__/general-settings-configurable-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/general-settings-configurable-contract.test.ts
@@ -94,7 +94,7 @@ describe('General settings configurable contract', () => {
     assert.ok(cardBlock.length > 0, 'GeneralDefaultsCard source must be discoverable');
     assert.match(
       cardBlock,
-      /const mountedRef = useRef\(true\);/,
+      /const mountedRef = useMountedRef\(\);/,
       'GeneralDefaultsCard must track page-mounted ownership so a slow IPC write does not call setSaving(false) after Settings closes',
     );
     assert.match(

--- a/apps/desktop/src/main/__tests__/settings-form-a11y-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/settings-form-a11y-contract.test.ts
@@ -117,7 +117,7 @@ describe('Settings form accessibility labels', () => {
 
     assert.match(settings, /SettingsSelect,/);
     assert.match(settingsSelect, /SelectItem,[\s\S]*SelectPopup,[\s\S]*SelectPortal,[\s\S]*SelectPositioner,[\s\S]*SelectRoot,[\s\S]*SelectTrigger,[\s\S]*SelectValue,/);
-    assert.match(passwordInput, /import \{ Button, Input, useToast \} from '@maka\/ui';/);
+    assert.match(passwordInput, /import \{ Button, Input, useMountedRef, useToast \} from '@maka\/ui';/);
     // ProvidersPanel sources its UI from the shared @maka/ui primitives;
     // tolerant of single- vs multi-line import formatting.
     const providersPanelUiImports = providersPanel.match(/import \{[^}]*\} from '@maka\/ui';/g)?.join('\n') ?? '';
@@ -196,11 +196,11 @@ describe('Settings form accessibility labels', () => {
 
     assert.match(passwordInput, /const toast = useToast\(\)/);
     assert.match(passwordInput, /const copyingRef = useRef\(false\)/);
-    assert.match(passwordInput, /const mountedRef = useRef\(true\)/);
+    assert.match(passwordInput, /const mountedRef = useMountedRef\(\)/);
     assert.match(passwordInput, /const copyFeedbackTimerRef = useRef<number \| null>\(null\)/);
     assert.match(
       passwordInput,
-      /return \(\) => \{[\s\S]*mountedRef\.current = false;[\s\S]*copyingRef\.current = false;[\s\S]*window\.clearTimeout\(copyFeedbackTimerRef\.current\);/,
+      /return \(\) => \{[\s\S]*copyingRef\.current = false;[\s\S]*window\.clearTimeout\(copyFeedbackTimerRef\.current\);/,
       'PasswordInput must clear pending copy-feedback timers and invalidate clipboard state when it unmounts',
     );
     assert.match(

--- a/apps/desktop/src/main/__tests__/settings-roadmap-cleanup-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/settings-roadmap-cleanup-contract.test.ts
@@ -250,7 +250,7 @@ describe('Settings coming-soon cleanup contract', () => {
     assert.match(permissionPage, /const pendingPermActionRef = useRef<string \| null>\(null\)/);
     assert.match(
       permissionPage,
-      /return \(\) => \{[\s\S]*mountedRef\.current = false;[\s\S]*pendingPermActionRef\.current = null;/,
+      /return \(\) => \{[\s\S]*pendingPermActionRef\.current = null;/,
       'Permission Center must release the pending action owner when Settings closes',
     );
     assert.match(

--- a/apps/desktop/src/renderer/OnboardingHero.tsx
+++ b/apps/desktop/src/renderer/OnboardingHero.tsx
@@ -37,6 +37,7 @@ import {
   fileTransferContainsFiles,
   focusTextInputAtEnd,
   isChatInputComposing,
+  useMountedRef,
   type ChatInputActionOwner,
   type UiLocale,
 } from '@maka/ui';
@@ -147,13 +148,11 @@ export interface OnboardingHeroProps {
 export function OnboardingHero(props: OnboardingHeroProps) {
   const { state } = props;
   const [refreshConnectionsPending, setRefreshConnectionsPending] = useState(false);
-  const onboardingMountedRef = useRef(true);
+  const onboardingMountedRef = useMountedRef();
   const refreshConnectionsPendingRef = useRef(false);
 
   useEffect(() => {
-    onboardingMountedRef.current = true;
     return () => {
-      onboardingMountedRef.current = false;
       refreshConnectionsPendingRef.current = false;
     };
   }, []);
@@ -812,11 +811,7 @@ function ReadyEmptyHero(props: {
 
 function SkipButton(props: { onSkip: () => Promise<void> | void; label?: string }) {
   const [pending, setPending] = useState(false);
-  const mountedRef = useRef(true);
-  useEffect(() => {
-    mountedRef.current = true;
-    return () => { mountedRef.current = false; };
-  }, []);
+  const mountedRef = useMountedRef();
   const onClick = useCallback(async () => {
     if (pending) return;
     setPending(true);

--- a/apps/desktop/src/renderer/settings/daily-review-settings-page.tsx
+++ b/apps/desktop/src/renderer/settings/daily-review-settings-page.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import type { DailyReviewConfig, DailyReviewMode, LlmConnection } from '@maka/core';
-import { Alert, AlertDescription, Button, Input, SettingsSelect, SettingsSwitch as Switch, useToast } from '@maka/ui';
+import { Alert, AlertDescription, Button, Input, SettingsSelect, SettingsSwitch as Switch, useMountedRef, useToast } from '@maka/ui';
 import { buildCatalogDailyReviewModelOptions } from '../model-catalog-choices';
 import { settingsActionErrorMessage } from './settings-error-copy';
 import { SettingsRows } from './settings-rows';
@@ -49,14 +49,12 @@ export function DailyReviewSettingsPage(props: { connections: readonly LlmConnec
   const [loadError, setLoadError] = useState<string | null>(null);
   const [savingKey, setSavingKey] = useState<string | null>(null);
   const [runningMode, setRunningMode] = useState<DailyReviewMode | null>(null);
-  const mountedRef = useRef(true);
+  const mountedRef = useMountedRef();
   const savingKeyRef = useRef<string | null>(null);
   const runningModeRef = useRef<DailyReviewMode | null>(null);
 
   useEffect(() => {
-    mountedRef.current = true;
     return () => {
-      mountedRef.current = false;
       savingKeyRef.current = null;
       runningModeRef.current = null;
     };

--- a/apps/desktop/src/renderer/settings/general-settings-page.tsx
+++ b/apps/desktop/src/renderer/settings/general-settings-page.tsx
@@ -21,6 +21,7 @@ import {
   modelChoiceValue,
   modelMenuGroups,
   parseModelChoiceValue,
+  useMountedRef,
   useToast,
 } from '@maka/ui';
 import { ProviderLogo } from './ProvidersPanel';
@@ -117,16 +118,14 @@ function GeneralDefaultsCard(props: {
   onUpdate(patch: Parameters<typeof window.maka.settings.update>[0]): Promise<UpdateAppSettingsResult>;
 }) {
   const toast = useToast();
-  const mountedRef = useRef(true);
+  const mountedRef = useMountedRef();
   const savingRef = useRef(false);
   const [saving, setSaving] = useState(false);
   const savingPermissionModeRef = useRef(false);
   const [savingPermissionMode, setSavingPermissionMode] = useState(false);
 
   useEffect(() => {
-    mountedRef.current = true;
     return () => {
-      mountedRef.current = false;
       savingRef.current = false;
       savingPermissionModeRef.current = false;
     };

--- a/apps/desktop/src/renderer/settings/password-input.tsx
+++ b/apps/desktop/src/renderer/settings/password-input.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from 'react';
 import { Check, Copy, Eye, EyeOff } from '@maka/ui/icons';
-import { Button, Input, useToast } from '@maka/ui';
+import { Button, Input, useMountedRef, useToast } from '@maka/ui';
 
 /**
  * PR-BOT-SETTINGS-PASSWORD-EYE-0 / PR-BOT-SETTINGS-PASSWORD-COPY-0 /
@@ -30,13 +30,11 @@ export function PasswordInput(props: {
   const [justCopied, setJustCopied] = useState(false);
   const [copying, setCopying] = useState(false);
   const copyingRef = useRef(false);
-  const mountedRef = useRef(true);
+  const mountedRef = useMountedRef();
   const copyFeedbackTimerRef = useRef<number | null>(null);
 
   useEffect(() => {
-    mountedRef.current = true;
     return () => {
-      mountedRef.current = false;
       copyingRef.current = false;
       if (copyFeedbackTimerRef.current !== null) {
         window.clearTimeout(copyFeedbackTimerRef.current);

--- a/apps/desktop/src/renderer/settings/permission-center-page.tsx
+++ b/apps/desktop/src/renderer/settings/permission-center-page.tsx
@@ -18,7 +18,7 @@ import type {
   PermissionSnapshot,
 } from '@maka/core';
 import { OS_PERMISSION_IDS } from '@maka/core';
-import { Button, Badge, EmptyState, RelativeTime, PageHeader, SectionHeader, StatTile, useToast } from '@maka/ui';
+import { Button, Badge, EmptyState, RelativeTime, PageHeader, SectionHeader, StatTile, useMountedRef, useToast } from '@maka/ui';
 import { settingsActionErrorMessage } from './settings-error-copy';
 import { statusBadgeVariant } from './settings-status-badge';
 import { SettingsSkeletonStack } from './settings-skeleton';
@@ -109,13 +109,11 @@ export function PermissionCenterPage() {
   const [pendingPermAction, setPendingPermAction] = useState<string | null>(null);
   const [diagnosticsOpen, setDiagnosticsOpen] = useState(false);
   const toast = useToast();
-  const mountedRef = useRef(true);
+  const mountedRef = useMountedRef();
   const pendingPermActionRef = useRef<string | null>(null);
 
   useEffect(() => {
-    mountedRef.current = true;
     return () => {
-      mountedRef.current = false;
       pendingPermActionRef.current = null;
     };
   }, []);

--- a/apps/desktop/src/renderer/settings/voice-settings-page.tsx
+++ b/apps/desktop/src/renderer/settings/voice-settings-page.tsx
@@ -2,7 +2,7 @@ import { useEffect, useId, useRef, useState } from 'react';
 import { Volume2 } from '@maka/ui/icons';
 import type { VoicePermissionStatus } from '@maka/core';
 import { defaultVoiceCaptureCaps, validateVoiceCaptureRequest } from '@maka/core';
-import { Button, PageHeader, useToast } from '@maka/ui';
+import { Button, PageHeader, formatBytes, useToast } from '@maka/ui';
 
 type VoiceSmokeState =
   | { status: 'idle'; message: string }
@@ -103,7 +103,7 @@ export function VoiceModelsSettingsPage() {
         }
         return;
       }
-      const message = `录音链路可用：${formatVoiceDuration(durationMs)}，${formatVoiceBytes(audioBytes)}。样本未保存。`;
+      const message = `录音链路可用：${formatVoiceDuration(durationMs)}，${formatBytes(audioBytes)}。样本未保存。`;
       if (voicePageMountedRef.current) {
         setSmoke({ status: 'ok', message, durationMs, audioBytes });
         toast.success('语音自检通过', message);
@@ -240,12 +240,6 @@ function voiceValidationCopy(reason: string): string {
 
 function formatVoiceDuration(durationMs: number): string {
   return `${Math.max(0, durationMs / 1000).toFixed(1)} 秒`;
-}
-
-function formatVoiceBytes(bytes: number): string {
-  if (bytes < 1024) return `${bytes} B`;
-  if (bytes < 1024 * 1024) return `${Math.round(bytes / 1024)} KB`;
-  return `${(bytes / 1024 / 1024).toFixed(1)} MB`;
 }
 
 function waitMs(ms: number): Promise<void> {

--- a/notes/frontend-simplification-map-2026-07-13.md
+++ b/notes/frontend-simplification-map-2026-07-13.md
@@ -56,11 +56,21 @@ dist/**/*.test.js). Real finds verified by hand before acting.
   Gates: desktop 2397/2397, ui 125/125, typecheck 0, check-dead-css clean, knip desktop+ui 0,
   auditor exit 0. CDP light+dark captures (turn-narrative/module-skills/settings-general/first-run)
   before/after — no visual diff.
-- [ ] **D — duplicate helper sweep (measured SMALL — the convergence campaign paid
-  off)** — real dups found: formatBytes ×3 (artifact-preview-registry.ts:317,
-  tool-activity/preview-utils.ts:14, voice formatVoiceBytes) → one shared util;
-  mountedRef boilerplate ×6 → useMountedRef. Domain formatters are all distinct —
-  no action.
+- [x] **D-1 — SHIPPED: shared useMountedRef + last formatBytes fork.** Case-insensitive
+  re-census found the mounted-guard boilerplate at ×38 (not ×6 — the first grep missed
+  `fooMountedRef` casings). Shipped: `useMountedRef` lives in @maka/ui (exported from
+  index) so both workspaces reach it; converted the 6 canonical `mountedRef/
+  onboardingMountedRef` sites (OnboardingHero ×2, password-input, daily-review/
+  general/permission-center settings pages) and re-pinned 5 contracts to the
+  shared-hook form; voice formatVoiceBytes (last formatBytes fork) deleted in favor
+  of the @maka/ui helper. Deliberately NOT converted: use-workspace-instructions-
+  controller (lifecycle-counter variant, not boilerplate) and app-shell.tsx
+  rendererMountedRef (Round B owns that file).
+- [ ] **D-2 — mounted-guard long tail**: ~30 remaining `*MountedRef` sites across
+  renderer settings pages and packages/ui panels (see `grep -ri "mountedref = useRef"`).
+  Mechanical agent sweep: swap to useMountedRef, keep per-site companion-ref cleanup
+  effects, re-pin any contract that quotes the old shape. Watch the useRef(false)
+  variants — verify no pre-effect reads before flipping initial value semantics.
 
 Update checkboxes as rounds ship. Every round: suite + typecheck + dead-css +
 alignment auditor + CDP spot captures, exit-code gated.

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -3,6 +3,7 @@ export * from './assistant-stream.js';
 export * from './chat-empty-hero.js';
 export * from './chat-model-helpers.js';
 export * from './clipboard-feedback.js';
+export * from './use-mounted-ref.js';
 export * from './components.js';
 export type { SessionHistoryStatusGroup } from './session-history-list.js';
 export * from './session-status-presentation.js';

--- a/packages/ui/src/use-mounted-ref.ts
+++ b/packages/ui/src/use-mounted-ref.ts
@@ -1,0 +1,25 @@
+import { useEffect, useRef } from 'react';
+import type { RefObject } from 'react';
+
+/* PR-SIMPLIFY-ROUND-D-0: the fail-soft settings surfaces each hand-rolled
+   the same mounted guard (a ref set true on mount, false on unmount, read
+   before every post-await setState/toast). One shared hook replaces the
+   boilerplate; components that must also reset their own refs on unmount
+   keep a separate cleanup effect for those.
+
+   Starts true (not false) so reads during the first render — before
+   effects run — already report "mounted"; the effect re-arms it for
+   StrictMode's mount → unmount → remount double-invoke. Not for
+   lifecycle-scoped guards (use-workspace-instructions-controller owns a
+   variant conditioned on a lifecycle counter — that one is not
+   boilerplate and stays local). */
+export function useMountedRef(): RefObject<boolean> {
+  const mountedRef = useRef(true);
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
+  return mountedRef;
+}


### PR DESCRIPTION
Round D-1 of notes/frontend-simplification-map-2026-07-13.md.

## useMountedRef
The mounted-guard boilerplate (ref true on mount / false on unmount / checked before every post-await setState) was hand-rolled per component. Re-census (case-insensitive) puts it at **×38 sites**, not the ×6 the map originally estimated. This round ships the primitive in @maka/ui and converts the 6 canonical sites (OnboardingHero ×2, password-input, daily-review / general / permission-center settings pages); components keep separate cleanup effects for their own companion refs only. 5 contracts re-pinned to the shared-hook form — read-side pins (`mountedRef.current` guards) survive untouched because the hook returns the same-named ref.

Deliberately not converted: use-workspace-instructions-controller (lifecycle-counter variant — not boilerplate) and app-shell.tsx (Round B agent owns that file). The ~30-site long tail is staged as Round D-2 in the map.

## formatBytes
voice-settings-page's formatVoiceBytes was the last local fork (round-21 dedup killed the others) — replaced with the shared @maka/ui helper. Byte copy in the voice smoke toast gains one decimal of KB precision, matching every other surface.

## Gates
desktop 2397/2397 · ui 125/125 · typecheck · knip ×2 = 0 · check-dead-css clean.