### PR TITLE
feat(providers): add xAI support

### DIFF
--- a/apps/desktop/e2e/providers.spec.ts
+++ b/apps/desktop/e2e/providers.spec.ts
@@ -53,11 +53,17 @@ test('adds xAI with its exact snapshot model and API-key credential field', asyn
 
   await page.getByRole('tab', { name: 'API', exact: true }).click();
   await page.getByPlaceholder('搜索服务商').fill('xAI');
+  await expect(
+    page.locator('.providerCatalogRow[data-provider="xai"] .providerLogo img[src^="data:image/svg+xml"]'),
+  ).toBeVisible();
   await page.getByRole('button', { name: /添加模型供应商：xAI/ }).click();
   await expect(page.getByLabel('模型供应商默认模型')).toHaveValue('grok-4.5');
   await page.getByRole('button', { name: '保存供应商' }).click();
 
   await expect(page.getByRole('heading', { name: 'xAI', exact: true }).first()).toBeVisible();
+  await expect(
+    page.locator('.providerSubpageHeader .providerLogo[data-provider="xai"] img[src^="data:image/svg+xml"]'),
+  ).toBeVisible();
   await expect(page.getByText('grok-4.5', { exact: true }).first()).toBeVisible();
   await expect(page.getByRole('textbox', { name: '模型密钥' })).toBeVisible();
 });

--- a/apps/desktop/e2e/providers.spec.ts
+++ b/apps/desktop/e2e/providers.spec.ts
@@ -53,20 +53,28 @@ test('adds xAI with its exact snapshot model and API-key credential field', asyn
 
   await page.getByRole('tab', { name: 'API', exact: true }).click();
   await page.getByPlaceholder('搜索服务商').fill('xAI');
-  await expect(
-    page.locator('.providerCatalogRow[data-provider="xai"] .providerLogo img[src^="data:image/svg+xml"]'),
-  ).toBeVisible();
+  const catalogMark = page.locator('.providerCatalogRow[data-provider="xai"] .providerLogo .xaiProviderMark');
+  await expect(catalogMark).toBeVisible();
+  expect(await catalogMark.evaluate(maskRenderContract)).toEqual({ usesAssetMask: true, followsForeground: true });
   await page.getByRole('button', { name: /添加模型供应商：xAI/ }).click();
   await expect(page.getByLabel('模型供应商默认模型')).toHaveValue('grok-4.5');
   await page.getByRole('button', { name: '保存供应商' }).click();
 
   await expect(page.getByRole('heading', { name: 'xAI', exact: true }).first()).toBeVisible();
-  await expect(
-    page.locator('.providerSubpageHeader .providerLogo[data-provider="xai"] img[src^="data:image/svg+xml"]'),
-  ).toBeVisible();
+  const detailMark = page.locator('.providerSubpageHeader .providerLogo[data-provider="xai"] .xaiProviderMark');
+  await expect(detailMark).toBeVisible();
+  expect(await detailMark.evaluate(maskRenderContract)).toEqual({ usesAssetMask: true, followsForeground: true });
   await expect(page.getByText('grok-4.5', { exact: true }).first()).toBeVisible();
   await expect(page.getByRole('textbox', { name: '模型密钥' })).toBeVisible();
 });
+
+function maskRenderContract(element: Element): { usesAssetMask: boolean; followsForeground: boolean } {
+  const style = getComputedStyle(element);
+  return {
+    usesAssetMask: style.maskImage.includes('data:image/svg+xml'),
+    followsForeground: style.backgroundColor === style.color,
+  };
+}
 
 test('restores keyboard focus across provider child pages', async ({ window: page }) => {
   await page.getByRole('button', { name: '展开侧边栏' }).click();

--- a/apps/desktop/e2e/providers.spec.ts
+++ b/apps/desktop/e2e/providers.spec.ts
@@ -45,6 +45,23 @@ test('adds MiniMax Coding Plan under its independent provider id with an exact s
   await expect(page.getByText('MiniMax-M3', { exact: true }).first()).toBeVisible();
 });
 
+test('adds xAI with its exact snapshot model and API-key credential field', async ({ window: page }) => {
+  await page.getByRole('button', { name: '展开侧边栏' }).click();
+  await page.getByRole('button', { name: '设置' }).click();
+  await page.locator('[aria-label="设置分组"]').getByText('模型', { exact: true }).click();
+  await page.getByRole('button', { name: '添加服务商' }).click();
+
+  await page.getByRole('tab', { name: 'API', exact: true }).click();
+  await page.getByPlaceholder('搜索服务商').fill('xAI');
+  await page.getByRole('button', { name: /添加模型供应商：xAI/ }).click();
+  await expect(page.getByLabel('模型供应商默认模型')).toHaveValue('grok-4.5');
+  await page.getByRole('button', { name: '保存供应商' }).click();
+
+  await expect(page.getByRole('heading', { name: 'xAI', exact: true }).first()).toBeVisible();
+  await expect(page.getByText('grok-4.5', { exact: true }).first()).toBeVisible();
+  await expect(page.getByRole('textbox', { name: '模型密钥' })).toBeVisible();
+});
+
 test('restores keyboard focus across provider child pages', async ({ window: page }) => {
   await page.getByRole('button', { name: '展开侧边栏' }).click();
   await page.getByRole('button', { name: '设置' }).click();

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -16,7 +16,7 @@
     "clean:main": "node ../../scripts/clean-paths.mjs dist/main tsconfig.main.tsbuildinfo",
     "build:main": "tsc -p tsconfig.main.json",
     "build:preload": "esbuild src/preload/preload.ts --bundle --platform=node --format=cjs --outfile=dist/preload/preload.cjs --external:electron",
-    "build:renderer": "vite build",
+    "build:renderer": "vite build && node ../../scripts/check-third-party-notices.mjs",
     "typecheck": "tsc -p tsconfig.main.json --noEmit && tsc -p tsconfig.renderer.json --noEmit && tsc -p tsconfig.storybook.json --noEmit",
     "typecheck:stories": "tsc -p tsconfig.storybook.json --noEmit",
     "pretest": "npm --workspace @maka/core run build && npm --workspace @maka/storage run build && npm --workspace @maka/runtime run build && npm --workspace @maka/ui run build && npm run test:checks",

--- a/apps/desktop/resources/THIRD_PARTY_NOTICES.md
+++ b/apps/desktop/resources/THIRD_PARTY_NOTICES.md
@@ -1,0 +1,36 @@
+# Third-Party Notices
+
+This file records notices for third-party source assets vendored into the Maka desktop application. Each entry identifies the upstream revision and every covered vendored file so the notice remains useful in source and packaged distributions.
+
+## Lobe Icons
+
+- Repository: https://github.com/lobehub/lobe-icons
+- Package: `@lobehub/icons-static-svg` version `1.91.0`
+- Upstream commit: `32f4083f7a20b67ecdc7b29c0af031ada5a29c52`
+- License: MIT
+- Covered vendored files:
+  - `apps/desktop/src/renderer/assets/provider-brands/xai.svg`
+    - Upstream path: `packages/static-svg/icons/xai.svg`
+    - SHA-256: `89eb7de9f0d02a41cfecd9109e253d7fd3529e27467dee4254faa67f3ac21451`
+
+MIT License
+
+Copyright (c) 2023 LobeHub
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/apps/desktop/src/main/__tests__/icon-governance-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/icon-governance-contract.test.ts
@@ -28,10 +28,13 @@ const REPO_ROOT = resolve(import.meta.dirname, '../../../../..');
 const ICONS_FILE = resolve(REPO_ROOT, 'packages/ui/src/icons.tsx');
 const SIDEBAR_NAV_FILE = resolve(REPO_ROOT, 'packages/ui/src/session-sidebar-nav.tsx');
 const PROVIDER_BRAND_MARKS_FILE = resolve(REPO_ROOT, 'apps/desktop/src/renderer/settings/provider-brand-marks.tsx');
+const PROVIDER_CATALOG_FILE = resolve(REPO_ROOT, 'apps/desktop/src/renderer/settings/provider-catalog.tsx');
+const PROVIDERS_PANEL_FILE = resolve(REPO_ROOT, 'apps/desktop/src/renderer/settings/ProvidersPanel.tsx');
 const MINIMAX_BRAND_ASSET_FILE = resolve(
   REPO_ROOT,
   'apps/desktop/src/renderer/assets/provider-brands/minimax-logo-only-vertical-color-bg-white-text.svg',
 );
+const XAI_BRAND_MARK_FILE = resolve(REPO_ROOT, 'apps/desktop/src/renderer/assets/provider-brands/xai.svg');
 
 // Fixed brand assets, not generic UI icons — their vendored SVGs keep
 // their own stroke weight and are exempt from the call-site stroke sweep.
@@ -164,6 +167,33 @@ describe('icon + typography governance contract', () => {
       componentSrc,
       /function MiniMaxMark\(\): ReactElement \{\s*return <img src=\{minimaxBrandMark\} alt="" \/>;\s*\}/,
       'MiniMax providers must render the vendored official file, never an inline hand-drawn path',
+    );
+  });
+
+  it('uses the unmodified upstream xAI mark across catalog and provider detail surfaces', async () => {
+    const [marks, catalog, providersPanel, xaiMark] = await Promise.all([
+      readFile(PROVIDER_BRAND_MARKS_FILE, 'utf8'),
+      readFile(PROVIDER_CATALOG_FILE, 'utf8'),
+      readFile(PROVIDERS_PANEL_FILE, 'utf8'),
+      readFile(XAI_BRAND_MARK_FILE),
+    ]);
+
+    assert.equal(
+      createHash('sha256').update(xaiMark).digest('hex'),
+      '89eb7de9f0d02a41cfecd9109e253d7fd3529e27467dee4254faa67f3ac21451',
+      'the vendored xAI mark must remain byte-identical to @lobehub/icons-static-svg@1.91.0 xai.svg',
+    );
+    assert.match(
+      marks,
+      /Real xAI\/Grok mark vendored byte-for-byte from Lobe Icons:[\s\S]*@lobehub\/icons-static-svg@1\.91\.0[\s\S]*32f4083f7a20b67ecdc7b29c0af031ada5a29c52[\s\S]*packages\/static-svg\/icons\/xai\.svg[\s\S]*license: MIT[\s\S]*function XAI\(\)[\s\S]*<img src=\{xaiMarkUrl\}/,
+      'xAI must render the traceable upstream SVG asset instead of a generic or hand-drawn mark',
+    );
+    assert.match(marks, /case 'xai':\s*return <XAI \/>/, 'the stable xai provider id must resolve to the upstream mark');
+    assert.match(catalog, /<ProviderLogo type=\{props\.type\} \/>/, 'catalog cards must consume the shared provider logo seam');
+    assert.match(
+      providersPanel,
+      /kind === 'detail' && selected[\s\S]*<ProviderPageHeader[\s\S]*providerType=\{selected\.providerType\}/,
+      'saved connection detail must consume the shared provider logo seam',
     );
   });
 });

--- a/apps/desktop/src/main/__tests__/icon-governance-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/icon-governance-contract.test.ts
@@ -35,6 +35,7 @@ const MINIMAX_BRAND_ASSET_FILE = resolve(
   'apps/desktop/src/renderer/assets/provider-brands/minimax-logo-only-vertical-color-bg-white-text.svg',
 );
 const XAI_BRAND_MARK_FILE = resolve(REPO_ROOT, 'apps/desktop/src/renderer/assets/provider-brands/xai.svg');
+const THIRD_PARTY_NOTICES_FILE = resolve(REPO_ROOT, 'apps/desktop/resources/THIRD_PARTY_NOTICES.md');
 
 // Fixed brand assets, not generic UI icons — their vendored SVGs keep
 // their own stroke weight and are exempt from the call-site stroke sweep.
@@ -195,5 +196,20 @@ describe('icon + typography governance contract', () => {
       /kind === 'detail' && selected[\s\S]*<ProviderPageHeader[\s\S]*providerType=\{selected\.providerType\}/,
       'saved connection detail must consume the shared provider logo seam',
     );
+  });
+
+  it('ships the Lobe Icons MIT notice beside vendored provider assets', async () => {
+    const notices = await readFile(THIRD_PARTY_NOTICES_FILE, 'utf8');
+
+    assert.match(notices, /## Lobe Icons/);
+    assert.match(notices, /https:\/\/github\.com\/lobehub\/lobe-icons/);
+    assert.match(notices, /@lobehub\/icons-static-svg` version `1\.91\.0`/);
+    assert.match(notices, /32f4083f7a20b67ecdc7b29c0af031ada5a29c52/);
+    assert.match(
+      notices,
+      /apps\/desktop\/src\/renderer\/assets\/provider-brands\/xai\.svg[\s\S]*packages\/static-svg\/icons\/xai\.svg[\s\S]*89eb7de9f0d02a41cfecd9109e253d7fd3529e27467dee4254faa67f3ac21451/,
+    );
+    assert.match(notices, /MIT License[\s\S]*Copyright \(c\) 2023 LobeHub[\s\S]*Permission is hereby granted/);
+    assert.match(notices, /THE SOFTWARE IS PROVIDED "AS IS"/);
   });
 });

--- a/apps/desktop/src/main/__tests__/icon-governance-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/icon-governance-contract.test.ts
@@ -187,8 +187,8 @@ describe('icon + typography governance contract', () => {
     );
     assert.match(
       marks,
-      /Real xAI\/Grok mark vendored byte-for-byte from Lobe Icons:[\s\S]*@lobehub\/icons-static-svg@1\.91\.0[\s\S]*32f4083f7a20b67ecdc7b29c0af031ada5a29c52[\s\S]*packages\/static-svg\/icons\/xai\.svg[\s\S]*license: MIT[\s\S]*function XAI\(\)[\s\S]*<img src=\{xaiMarkUrl\}/,
-      'xAI must render the traceable upstream SVG asset instead of a generic or hand-drawn mark',
+      /Real xAI\/Grok mark vendored byte-for-byte from Lobe Icons:[\s\S]*@lobehub\/icons-static-svg@1\.91\.0[\s\S]*32f4083f7a20b67ecdc7b29c0af031ada5a29c52[\s\S]*packages\/static-svg\/icons\/xai\.svg[\s\S]*license: MIT[\s\S]*function XAI\(\)[\s\S]*url\("\$\{xaiMarkUrl\}"\)[\s\S]*className="xaiProviderMark"[\s\S]*maskImage: mask/,
+      'xAI must render the traceable upstream SVG asset as a currentColor mask instead of a generic or hand-drawn mark',
     );
     assert.match(marks, /case 'xai':\s*return <XAI \/>/, 'the stable xai provider id must resolve to the upstream mark');
     assert.match(catalog, /<ProviderLogo type=\{props\.type\} \/>/, 'catalog cards must consume the shared provider logo seam');

--- a/apps/desktop/src/main/__tests__/icon-governance-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/icon-governance-contract.test.ts
@@ -35,7 +35,8 @@ const MINIMAX_BRAND_ASSET_FILE = resolve(
   'apps/desktop/src/renderer/assets/provider-brands/minimax-logo-only-vertical-color-bg-white-text.svg',
 );
 const XAI_BRAND_MARK_FILE = resolve(REPO_ROOT, 'apps/desktop/src/renderer/assets/provider-brands/xai.svg');
-const THIRD_PARTY_NOTICES_FILE = resolve(REPO_ROOT, 'apps/desktop/resources/THIRD_PARTY_NOTICES.md');
+const DESKTOP_PACKAGE_FILE = resolve(REPO_ROOT, 'apps/desktop/package.json');
+const THIRD_PARTY_NOTICES_FILE = resolve(REPO_ROOT, 'apps/desktop/src/renderer/public/THIRD_PARTY_LICENSES.txt');
 
 // Fixed brand assets, not generic UI icons — their vendored SVGs keep
 // their own stroke weight and are exempt from the call-site stroke sweep.
@@ -199,7 +200,10 @@ describe('icon + typography governance contract', () => {
   });
 
   it('ships the Lobe Icons MIT notice beside vendored provider assets', async () => {
-    const notices = await readFile(THIRD_PARTY_NOTICES_FILE, 'utf8');
+    const [desktopPackage, notices] = await Promise.all([
+      readFile(DESKTOP_PACKAGE_FILE, 'utf8'),
+      readFile(THIRD_PARTY_NOTICES_FILE, 'utf8'),
+    ]);
 
     assert.match(notices, /## Lobe Icons/);
     assert.match(notices, /https:\/\/github\.com\/lobehub\/lobe-icons/);
@@ -211,5 +215,10 @@ describe('icon + typography governance contract', () => {
     );
     assert.match(notices, /MIT License[\s\S]*Copyright \(c\) 2023 LobeHub[\s\S]*Permission is hereby granted/);
     assert.match(notices, /THE SOFTWARE IS PROVIDED "AS IS"/);
+    assert.match(
+      desktopPackage,
+      /"build:renderer": "vite build && node \.\.\/\.\.\/scripts\/check-third-party-notices\.mjs"/,
+      'renderer builds must verify that the public notice was copied byte-for-byte into dist-renderer',
+    );
   });
 });

--- a/apps/desktop/src/renderer/assets/provider-brands/xai.svg
+++ b/apps/desktop/src/renderer/assets/provider-brands/xai.svg
@@ -1,0 +1,1 @@
+<svg fill="currentColor" fill-rule="evenodd" height="1em" style="flex:none;line-height:1" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg"><title>Grok</title><path d="M6.469 8.776L16.512 23h-4.464L2.005 8.776H6.47zm-.004 7.9l2.233 3.164L6.467 23H2l4.465-6.324zM22 2.582V23h-3.659V7.764L22 2.582zM22 1l-9.952 14.095-2.233-3.163L17.533 1H22z"></path></svg>

--- a/apps/desktop/src/renderer/public/THIRD_PARTY_LICENSES.txt
+++ b/apps/desktop/src/renderer/public/THIRD_PARTY_LICENSES.txt
@@ -1,4 +1,5 @@
-# Third-Party Notices
+Third-Party Licenses
+====================
 
 This file records notices for third-party source assets vendored into the Maka desktop application. Each entry identifies the upstream revision and every covered vendored file so the notice remains useful in source and packaged distributions.
 

--- a/apps/desktop/src/renderer/settings/provider-brand-marks.tsx
+++ b/apps/desktop/src/renderer/settings/provider-brand-marks.tsx
@@ -25,7 +25,8 @@ import xaiMarkUrl from '../assets/provider-brands/xai.svg';
 // - path: packages/static-svg/icons/xai.svg
 // - license: MIT (repository LICENSE)
 function XAI(): ReactElement {
-  return <img src={xaiMarkUrl} alt="" />;
+  const mask = `url("${xaiMarkUrl}")`;
+  return <span className="xaiProviderMark" style={{ maskImage: mask, WebkitMaskImage: mask }} aria-hidden="true" />;
 }
 
 function Claude(): ReactElement {

--- a/apps/desktop/src/renderer/settings/provider-brand-marks.tsx
+++ b/apps/desktop/src/renderer/settings/provider-brand-marks.tsx
@@ -16,6 +16,17 @@
 import type { ProviderType } from '@maka/core';
 import type { ReactElement } from 'react';
 import minimaxBrandMark from '../assets/provider-brands/minimax-logo-only-vertical-color-bg-white-text.svg';
+import xaiMarkUrl from '../assets/provider-brands/xai.svg';
+
+// Real xAI/Grok mark vendored byte-for-byte from Lobe Icons:
+// - repository: https://github.com/lobehub/lobe-icons
+// - package/version: @lobehub/icons-static-svg@1.91.0
+// - commit: 32f4083f7a20b67ecdc7b29c0af031ada5a29c52
+// - path: packages/static-svg/icons/xai.svg
+// - license: MIT (repository LICENSE)
+function XAI(): ReactElement {
+  return <img src={xaiMarkUrl} alt="" />;
+}
 
 function Claude(): ReactElement {
   return (
@@ -149,6 +160,8 @@ function Ollama(): ReactElement {
  */
 export function ProviderBrandMark({ type }: { type: ProviderType }): ReactElement {
   switch (type) {
+    case 'xai':
+      return <XAI />;
     case 'siliconflow':
       return <SiliconCloud />;
     case 'anthropic':

--- a/apps/desktop/src/renderer/styles/settings/models.css
+++ b/apps/desktop/src/renderer/styles/settings/models.css
@@ -220,13 +220,22 @@
   border-radius: var(--radius-surface); /* 28.1% — matches md ratio */
 }
 
-/* Color marks keep their own fill; monochrome marks declare
-   `fill="currentColor"` and inherit the plate color (= foreground). */
+/* Color marks keep their own fill. Inline monochrome SVGs inherit the plate
+   color; external monochrome assets use a mask because `<img>` documents do
+   not inherit `currentColor`. */
 .providerLogo svg,
-.providerLogo img {
+.providerLogo img,
+.providerLogo .xaiProviderMark {
   width: 64%;
   height: 64%;
   display: block;
+}
+
+.xaiProviderMark {
+  background: currentColor;
+  mask-position: center;
+  mask-repeat: no-repeat;
+  mask-size: contain;
 }
 
 

--- a/packages/cli/src/__tests__/connection-target.test.ts
+++ b/packages/cli/src/__tests__/connection-target.test.ts
@@ -27,6 +27,29 @@ describe('default session target resolver', () => {
     assert.equal(target.model, 'MiniMax-M2.7-highspeed');
   });
 
+  test('resolves an xAI API-key connection without rewriting its exact model id', async () => {
+    const connection = makeConnection({
+      slug: 'xai',
+      name: 'xAI',
+      providerType: 'xai',
+      defaultModel: 'grok-4.5',
+    });
+
+    const target = await resolveDefaultSessionTarget({
+      connectionStore: {
+        getDefault: async () => 'xai',
+        get: async (slug) => slug === 'xai' ? connection : null,
+      },
+      credentialStore: {
+        getSecret: async (_slug, kind) => kind === 'api_key' ? 'xai-test-key' : null,
+      },
+    });
+
+    assert.equal(target.connection.providerType, 'xai');
+    assert.equal(target.apiKey, 'xai-test-key');
+    assert.equal(target.model, 'grok-4.5');
+  });
+
   test('resolves a SiliconFlow registry connection without rewriting its model id', async () => {
     const connection = makeConnection({
       slug: 'siliconflow',

--- a/packages/core/src/__tests__/llm-connections.test.ts
+++ b/packages/core/src/__tests__/llm-connections.test.ts
@@ -38,6 +38,7 @@ describe('provider compatibility contract', () => {
       'MiniMax',
       'MiniMax-cn',
       'siliconflow',
+      'xai',
       'ollama',
       'openai-compatible',
       'claude-subscription',
@@ -54,6 +55,7 @@ describe('provider compatibility contract', () => {
       'MiniMax',
       'MiniMax-cn',
       'siliconflow',
+      'xai',
       'ollama',
       'kimi-coding-plan',
       'openai-compatible',
@@ -71,6 +73,7 @@ describe('provider compatibility contract', () => {
       'anthropic',
       'openai',
       'google',
+      'xai',
       'ollama',
       'openai-compatible',
     ]);
@@ -95,6 +98,34 @@ describe('provider compatibility contract', () => {
     assert.deepEqual(PROVIDER_REGISTRY.siliconflow.modelDiscovery.query, { sub_type: 'chat' });
     assert.equal(PROVIDER_REGISTRY.ollama.modelDiscovery.kind, 'ollama');
     assert.equal(PROVIDER_REGISTRY['codex-subscription'].modelDiscovery.kind, 'fallback');
+  });
+
+  it('owns the complete xAI provider contract under the stable xai id', () => {
+    assert.deepEqual(PROVIDER_REGISTRY.xai, {
+      label: 'xAI',
+      description: 'Grok models for chat, reasoning, vision, and tool use.',
+      baseUrl: 'https://api.x.ai/v1',
+      authKind: 'api_key',
+      backendKind: 'ai-sdk',
+      fallbackModels: [
+        'grok-4.5',
+        'grok-4.20-0309-non-reasoning',
+        'grok-4.20-0309-reasoning',
+        'grok-4.3',
+        'grok-build-0.1',
+      ],
+      status: 'ready',
+      protocol: 'openai',
+      runtimeAdapter: { kind: 'openai-compatible', name: 'provider' },
+      modelDiscovery: { kind: 'protocol' },
+      category: 'overseas',
+      catalogGroup: 'api',
+      catalogBadge: 'API',
+      signupUrl: 'https://console.x.ai/',
+      modelsDevId: 'xai',
+      readyOrder: 10,
+      catalogOrder: 12,
+    });
   });
 });
 

--- a/packages/core/src/__tests__/model-catalog.test.ts
+++ b/packages/core/src/__tests__/model-catalog.test.ts
@@ -9,6 +9,31 @@ import { isConnectionReady } from '../connection-readiness.js';
 import type { LlmConnection, ModelInfo, ProviderType } from '../llm-connections.js';
 
 describe('ModelCatalogEntry', () => {
+  it('uses the checked-in xAI snapshot until account discovery succeeds', () => {
+    const entries = buildConnectionModelCatalogEntries({
+      connection: {
+        slug: 'xai',
+        providerType: 'xai',
+        defaultModel: 'grok-4.5',
+      },
+    });
+
+    assert.deepEqual(entries.map((entry) => entry.id), [
+      'grok-4.5',
+      'grok-4.20-0309-non-reasoning',
+      'grok-4.20-0309-reasoning',
+      'grok-4.3',
+      'grok-build-0.1',
+    ]);
+    assert.equal(entries[0]?.source, 'static_catalog');
+    assert.equal(entries[0]?.provenance.modelSource, 'fallback');
+    assert.deepEqual(entries[0]?.capabilities, {
+      vision: true,
+      reasoning: true,
+      functionCalling: true,
+    });
+  });
+
   it('uses models.dev fallback metadata for a SiliconFlow connection before live discovery', () => {
     const entries = buildConnectionModelCatalogEntries({
       connection: {

--- a/packages/core/src/model-metadata.generated.ts
+++ b/packages/core/src/model-metadata.generated.ts
@@ -2,7 +2,7 @@
 // Do not edit by hand; put access-path-specific facts in model-metadata.ts.
 import type { ModelMetadata } from './model-metadata.js';
 
-export const GENERATED_MODELS_DEV_METADATA: Record<"anthropic" | "deepseek" | "google" | "gemini-cli" | "MiniMax" | "MiniMax-cn" | "moonshot" | "openai" | "siliconflow" | "zai-coding-plan", Record<string, ModelMetadata>> = {
+export const GENERATED_MODELS_DEV_METADATA: Record<"anthropic" | "deepseek" | "google" | "gemini-cli" | "MiniMax" | "MiniMax-cn" | "moonshot" | "openai" | "siliconflow" | "xai" | "zai-coding-plan", Record<string, ModelMetadata>> = {
   "anthropic": {
     "claude-fable-5": {"displayName":"Claude Fable 5","lifecycle":"active","docsUrl":"https://docs.anthropic.com/en/docs/about-claude/models","contextWindow":1000000,"maxOutputTokens":128000,"capabilities":{"vision":true,"reasoning":true,"functionCalling":true}},
     "claude-haiku-4-5": {"displayName":"Claude Haiku 4.5 (latest)","lifecycle":"active","docsUrl":"https://docs.anthropic.com/en/docs/about-claude/models","contextWindow":200000,"maxOutputTokens":64000,"capabilities":{"vision":true,"reasoning":true,"functionCalling":true}},
@@ -213,6 +213,17 @@ export const GENERATED_MODELS_DEV_METADATA: Record<"anthropic" | "deepseek" | "g
     "zai-org/GLM-5.2": {"displayName":"GLM-5.2","lifecycle":"active","docsUrl":"https://cloud.siliconflow.com/models","contextWindow":1049000,"maxOutputTokens":262000,"capabilities":{"vision":false,"reasoning":true,"functionCalling":true}},
     "zai-org/GLM-5V-Turbo": {"displayName":"zai-org/GLM-5V-Turbo","lifecycle":"active","docsUrl":"https://cloud.siliconflow.com/models","contextWindow":200000,"maxOutputTokens":131072,"capabilities":{"vision":true,"reasoning":true,"functionCalling":true}},
   },
+  "xai": {
+    "grok-4.20-0309-non-reasoning": {"displayName":"Grok 4.20 (Non-Reasoning)","lifecycle":"active","docsUrl":"https://docs.x.ai/docs/models","contextWindow":1000000,"maxOutputTokens":30000,"capabilities":{"vision":true,"reasoning":false,"functionCalling":true}},
+    "grok-4.20-0309-reasoning": {"displayName":"Grok 4.20 (Reasoning)","lifecycle":"active","docsUrl":"https://docs.x.ai/docs/models","contextWindow":1000000,"maxOutputTokens":30000,"capabilities":{"vision":true,"reasoning":true,"functionCalling":true}},
+    "grok-4.20-multi-agent-0309": {"displayName":"Grok 4.20 Multi-Agent","lifecycle":"active","docsUrl":"https://docs.x.ai/docs/models","contextWindow":1000000,"maxOutputTokens":30000,"capabilities":{"vision":true,"reasoning":true,"functionCalling":false}},
+    "grok-4.3": {"displayName":"Grok 4.3","lifecycle":"active","docsUrl":"https://docs.x.ai/docs/models","contextWindow":1000000,"maxOutputTokens":30000,"capabilities":{"vision":true,"reasoning":true,"functionCalling":true}},
+    "grok-4.5": {"displayName":"Grok 4.5","lifecycle":"active","docsUrl":"https://docs.x.ai/docs/models","contextWindow":500000,"maxOutputTokens":500000,"capabilities":{"vision":true,"reasoning":true,"functionCalling":true}},
+    "grok-build-0.1": {"displayName":"Grok Build 0.1","lifecycle":"active","docsUrl":"https://docs.x.ai/docs/models","contextWindow":256000,"maxOutputTokens":256000,"capabilities":{"vision":true,"reasoning":true,"functionCalling":true}},
+    "grok-imagine-image": {"displayName":"Grok Imagine Image","lifecycle":"active","docsUrl":"https://docs.x.ai/docs/models","contextWindow":8000,"maxOutputTokens":0,"capabilities":{"vision":true,"reasoning":false,"functionCalling":false}},
+    "grok-imagine-image-quality": {"displayName":"Grok Imagine Image Quality","lifecycle":"active","docsUrl":"https://docs.x.ai/docs/models","contextWindow":8000,"maxOutputTokens":0,"capabilities":{"vision":true,"reasoning":false,"functionCalling":false}},
+    "grok-imagine-video": {"displayName":"Grok Imagine Video","lifecycle":"active","docsUrl":"https://docs.x.ai/docs/models","contextWindow":1024,"maxOutputTokens":0,"capabilities":{"vision":true,"reasoning":false,"functionCalling":false}},
+  },
   "zai-coding-plan": {
     "glm-4.5-air": {"displayName":"GLM-4.5-Air","lifecycle":"active","docsUrl":"https://docs.z.ai/devpack/overview","contextWindow":131072,"maxOutputTokens":98304,"capabilities":{"vision":false,"reasoning":true,"functionCalling":true}},
     "glm-4.7": {"displayName":"GLM-4.7","lifecycle":"active","docsUrl":"https://docs.z.ai/devpack/overview","contextWindow":204800,"maxOutputTokens":131072,"capabilities":{"vision":false,"reasoning":true,"functionCalling":true}},
@@ -223,7 +234,7 @@ export const GENERATED_MODELS_DEV_METADATA: Record<"anthropic" | "deepseek" | "g
   },
 };
 
-export const GENERATED_MODELS_DEV_PROVIDER_FACTS: Record<"anthropic" | "deepseek" | "google" | "gemini-cli" | "MiniMax" | "MiniMax-cn" | "moonshot" | "openai" | "siliconflow" | "zai-coding-plan", { id: string; name: string; api?: string; doc: string }> = {
+export const GENERATED_MODELS_DEV_PROVIDER_FACTS: Record<"anthropic" | "deepseek" | "google" | "gemini-cli" | "MiniMax" | "MiniMax-cn" | "moonshot" | "openai" | "siliconflow" | "xai" | "zai-coding-plan", { id: string; name: string; api?: string; doc: string }> = {
   "anthropic": {"id":"anthropic","name":"Anthropic","doc":"https://docs.anthropic.com/en/docs/about-claude/models"},
   "deepseek": {"id":"deepseek","name":"DeepSeek","api":"https://api.deepseek.com","doc":"https://api-docs.deepseek.com/quick_start/pricing"},
   "google": {"id":"google","name":"Google","doc":"https://ai.google.dev/gemini-api/docs/models"},
@@ -233,5 +244,6 @@ export const GENERATED_MODELS_DEV_PROVIDER_FACTS: Record<"anthropic" | "deepseek
   "moonshot": {"id":"moonshotai-cn","name":"Moonshot AI (China)","api":"https://api.moonshot.cn/v1","doc":"https://platform.moonshot.cn/docs/api/chat"},
   "openai": {"id":"openai","name":"OpenAI","doc":"https://platform.openai.com/docs/models"},
   "siliconflow": {"id":"siliconflow","name":"SiliconFlow","api":"https://api.siliconflow.com/v1","doc":"https://cloud.siliconflow.com/models"},
+  "xai": {"id":"xai","name":"xAI","doc":"https://docs.x.ai/docs/models"},
   "zai-coding-plan": {"id":"zai-coding-plan","name":"Z.AI Coding Plan","api":"https://api.z.ai/api/coding/paas/v4","doc":"https://docs.z.ai/devpack/overview"},
 };

--- a/packages/core/src/provider-registry.ts
+++ b/packages/core/src/provider-registry.ts
@@ -50,36 +50,35 @@ export interface ProviderDefaults {
 
 const siliconflow = GENERATED_MODELS_DEV_PROVIDER_FACTS.siliconflow;
 if (!siliconflow.api) throw new Error('models.dev SiliconFlow provider facts are missing api');
-const SILICONFLOW_RECOMMENDED_MODEL_IDS = ['moonshotai/Kimi-K2.6'];
-const MINIMAX_PLAN_RECOMMENDED_MODEL_IDS = ['MiniMax-M3'];
+const siliconflowModelIds = toolCallingModelIds(
+  'SiliconFlow',
+  GENERATED_MODELS_DEV_METADATA.siliconflow,
+  ['moonshotai/Kimi-K2.6'],
+);
+const minimaxPlanModelIds = toolCallingModelIds('MiniMax', GENERATED_MODELS_DEV_METADATA.MiniMax, ['MiniMax-M3']);
 
-const minimaxPlanModelEntries = Object.entries(GENERATED_MODELS_DEV_METADATA.MiniMax);
-const minimaxPlanModelsById = new Map(minimaxPlanModelEntries);
-const minimaxPlanModelIds = [
-  ...MINIMAX_PLAN_RECOMMENDED_MODEL_IDS.map((id) => {
-    const model = minimaxPlanModelsById.get(id);
-    if (!model) throw new Error(`models.dev MiniMax snapshot is missing recommended plan model ${id}`);
-    return [id, model] as const;
-  }),
-  ...minimaxPlanModelEntries.filter(([id]) => !MINIMAX_PLAN_RECOMMENDED_MODEL_IDS.includes(id)),
-]
-  .filter(([, model]) => model.capabilities?.functionCalling)
-  .map(([id]) => id);
+const xai = GENERATED_MODELS_DEV_PROVIDER_FACTS.xai;
+if (xai.id !== 'xai') throw new Error('models.dev xAI provider facts are missing stable id xai');
+const xaiModelIds = toolCallingModelIds('xAI', GENERATED_MODELS_DEV_METADATA.xai, ['grok-4.5']);
 
-const siliconflowModelEntries = Object.entries(GENERATED_MODELS_DEV_METADATA.siliconflow);
-const siliconflowModelsById = new Map(siliconflowModelEntries);
-const orderedSiliconflowModels = [
-  ...SILICONFLOW_RECOMMENDED_MODEL_IDS.map((id) => {
-    const model = siliconflowModelsById.get(id);
-    if (!model) throw new Error(`models.dev SiliconFlow snapshot is missing recommended model ${id}`);
-    return [id, model] as const;
-  }),
-  ...siliconflowModelEntries.filter(([id]) => !SILICONFLOW_RECOMMENDED_MODEL_IDS.includes(id)),
-];
-
-const siliconflowModelIds = orderedSiliconflowModels
-  .filter(([, model]) => model.capabilities?.functionCalling)
-  .map(([id]) => id);
+function toolCallingModelIds(
+  providerLabel: string,
+  models: Readonly<Record<string, { capabilities?: { functionCalling?: boolean } }>>,
+  recommendedIds: readonly string[],
+): string[] {
+  const entries = Object.entries(models);
+  const modelsById = new Map(entries);
+  return [
+    ...recommendedIds.map((id) => {
+      const model = modelsById.get(id);
+      if (!model) throw new Error(`models.dev ${providerLabel} snapshot is missing recommended model ${id}`);
+      return [id, model] as const;
+    }),
+    ...entries.filter(([id]) => !recommendedIds.includes(id)),
+  ]
+    .filter(([, model]) => model.capabilities?.functionCalling)
+    .map(([id]) => id);
+}
 
 const providerRegistry = {
   anthropic: {
@@ -121,7 +120,7 @@ const providerRegistry = {
     catalogGroup: 'plans',
     catalogBadge: 'Coding',
     signupUrl: 'https://www.kimi.com/code/console',
-    readyOrder: 11,
+    readyOrder: 12,
     catalogOrder: 1,
     recommendedOrder: 5,
   },
@@ -141,7 +140,7 @@ const providerRegistry = {
     catalogBadge: 'Coding',
     signupUrl: 'https://platform.minimax.io/subscribe/coding-plan',
     modelsDevId: GENERATED_MODELS_DEV_PROVIDER_FACTS.MiniMax.id,
-    readyOrder: 13,
+    readyOrder: 14,
     catalogOrder: 2,
   },
   openai: {
@@ -293,6 +292,25 @@ const providerRegistry = {
     catalogOrder: 8,
     recommendedOrder: 1,
   },
+  xai: {
+    label: xai.name,
+    description: 'Grok models for chat, reasoning, vision, and tool use.',
+    baseUrl: 'https://api.x.ai/v1',
+    authKind: 'api_key',
+    backendKind: 'ai-sdk',
+    fallbackModels: xaiModelIds,
+    status: 'ready',
+    protocol: 'openai',
+    runtimeAdapter: { kind: 'openai-compatible', name: 'provider' },
+    modelDiscovery: { kind: 'protocol' },
+    category: 'overseas',
+    catalogGroup: 'api',
+    catalogBadge: 'API',
+    signupUrl: 'https://console.x.ai/',
+    modelsDevId: xai.id,
+    readyOrder: 10,
+    catalogOrder: 12,
+  },
   ollama: {
     label: 'Ollama',
     description: 'Local models from Ollama on localhost.',
@@ -307,8 +325,8 @@ const providerRegistry = {
     category: 'local',
     catalogGroup: 'local',
     catalogBadge: 'Local',
-    readyOrder: 10,
-    catalogOrder: 12,
+    readyOrder: 11,
+    catalogOrder: 13,
     recommendedOrder: 7,
   },
   'openai-compatible': {
@@ -325,7 +343,7 @@ const providerRegistry = {
     category: 'custom',
     catalogGroup: 'aggregators',
     catalogBadge: 'Custom',
-    readyOrder: 12,
+    readyOrder: 13,
     catalogOrder: 14,
   },
   'claude-subscription': {

--- a/packages/headless/src/__tests__/harbor-cell.test.ts
+++ b/packages/headless/src/__tests__/harbor-cell.test.ts
@@ -2210,6 +2210,32 @@ setTimeout(() => {
     assert.equal(missing.apiKey, '');
   });
 
+  test('resolves xAI only from xAI credential env without rewriting the model id', () => {
+    const resolved = resolveHarborCellAiSdkEnv({
+      provider: 'xai',
+      model: 'grok-4.5',
+      env: {
+        XAI_API_KEY: 'xai-key',
+        XAI_BASE_URL: 'https://api.x.ai/v1',
+        OPENAI_API_KEY: 'openai-key',
+      },
+      ts: 1,
+    });
+
+    assert.equal(resolved.apiKey, 'xai-key');
+    assert.equal(resolved.connection.providerType, 'xai');
+    assert.equal(resolved.connection.defaultModel, 'grok-4.5');
+    assert.equal(resolved.connection.baseUrl, 'https://api.x.ai/v1');
+
+    const missing = resolveHarborCellAiSdkEnv({
+      provider: 'xai',
+      model: 'grok-4.5',
+      env: { OPENAI_API_KEY: 'must-not-cross-provider-boundary' },
+      ts: 1,
+    });
+    assert.equal(missing.apiKey, '');
+  });
+
   test('resolves ai-sdk api key from a *_API_KEY_FILE without exposing the secret on argv', async () => {
     const dir = await mkdtemp(join(tmpdir(), 'maka-cell-key-'));
     try {

--- a/packages/headless/src/__tests__/provider-env.test.ts
+++ b/packages/headless/src/__tests__/provider-env.test.ts
@@ -14,3 +14,11 @@ test('MiniMax Coding Plan uses a credential namespace separate from MiniMax dire
     baseUrls: ['MINIMAX_BASE_URL'],
   });
 });
+
+test('xAI keeps provider-scoped credential environment names', () => {
+  assert.deepEqual(providerCredentialEnv('xai'), {
+    apiKeys: ['XAI_API_KEY'],
+    apiKeyFile: 'XAI_API_KEY_FILE',
+    baseUrls: ['XAI_BASE_URL'],
+  });
+});

--- a/packages/headless/src/provider-env.ts
+++ b/packages/headless/src/provider-env.ts
@@ -18,6 +18,7 @@ const PROVIDER_CREDENTIAL_ENV = {
   MiniMax: env('MINIMAX', ['MINIMAX_BASE_URL']),
   'MiniMax-cn': env('MINIMAX', ['MINIMAX_BASE_URL']),
   siliconflow: env('SILICONFLOW', ['SILICONFLOW_BASE_URL']),
+  xai: env('XAI', ['XAI_BASE_URL']),
   'openai-compatible': env('OPENAI', ['OPENAI_BASE_URL']),
   'claude-subscription': env('ANTHROPIC'),
 } satisfies Partial<Record<ProviderType, ProviderCredentialEnv>>;

--- a/packages/runtime/src/__tests__/provider-conformance.test.ts
+++ b/packages/runtime/src/__tests__/provider-conformance.test.ts
@@ -2,7 +2,7 @@ import assert from 'node:assert/strict';
 import { createServer, type IncomingMessage, type ServerResponse } from 'node:http';
 import { after, describe, test } from 'node:test';
 import type { LlmConnection } from '@maka/core';
-import { generateText, tool } from 'ai';
+import { generateText, stepCountIs, tool } from 'ai';
 import { z } from 'zod';
 import { fetchProviderModels } from '../model-fetcher.js';
 import { getAIModel } from '../model-factory.js';
@@ -151,8 +151,8 @@ describe('models.dev provider conformance', () => {
     assert.deepEqual(result.toolCalls[0]?.input, { text: 'hello' });
   });
 
-  test('xAI discovers exact account model ids and completes an OpenAI-compatible tool-call turn', async () => {
-    let requestBody: Record<string, unknown> | undefined;
+  test('xAI discovers exact account model ids and completes an OpenAI-compatible tool-call loop', async () => {
+    const requestBodies: Array<Record<string, unknown>> = [];
     const server = await startJsonServer(async (request, response) => {
       assert.equal(request.headers.authorization, 'Bearer xai-test-key');
       if (request.method === 'GET' && request.url === '/v1/models') {
@@ -164,7 +164,22 @@ describe('models.dev provider conformance', () => {
       }
       assert.equal(request.method, 'POST');
       assert.equal(request.url, '/v1/chat/completions');
-      requestBody = JSON.parse(await readBody(request)) as Record<string, unknown>;
+      requestBodies.push(JSON.parse(await readBody(request)) as Record<string, unknown>);
+      if (requestBodies.length === 2) {
+        respondJson(response, 200, {
+          id: 'chatcmpl-xai-final',
+          object: 'chat.completion',
+          created: 2,
+          model: 'grok-4.5',
+          choices: [{
+            index: 0,
+            message: { role: 'assistant', content: 'Echoed hello.' },
+            finish_reason: 'stop',
+          }],
+          usage: { prompt_tokens: 12, completion_tokens: 3, total_tokens: 15 },
+        });
+        return;
+      }
       respondJson(response, 200, {
         id: 'chatcmpl-xai',
         object: 'chat.completion',
@@ -203,21 +218,30 @@ describe('models.dev provider conformance', () => {
     const result = await generateText({
       model: getAIModel({ connection, apiKey: 'xai-test-key', modelId: 'grok-4.5' }),
       prompt: 'Call echo with hello.',
+      stopWhen: stepCountIs(2),
       tools: {
         echo: tool({
           description: 'Echo text',
           inputSchema: z.object({ text: z.string() }),
+          execute: async ({ text }) => ({ echoed: text }),
         }),
       },
     });
 
-    assert.equal(requestBody?.model, 'grok-4.5');
+    assert.equal(requestBodies.length, 2);
+    assert.deepEqual(requestBodies.map((body) => body.model), ['grok-4.5', 'grok-4.5']);
     assert.deepEqual(
-      (requestBody?.tools as Array<{ function: { name: string } }>).map((entry) => entry.function.name),
+      (requestBodies[0]?.tools as Array<{ function: { name: string } }>).map((entry) => entry.function.name),
       ['echo'],
     );
-    assert.equal(result.toolCalls[0]?.toolName, 'echo');
-    assert.deepEqual(result.toolCalls[0]?.input, { text: 'hello' });
+    assert.deepEqual(
+      (requestBodies[1]?.messages as Array<{ role: string; content: string }>).find(({ role }) => role === 'tool'),
+      { role: 'tool', content: '{"echoed":"hello"}', tool_call_id: 'call_echo' },
+    );
+    assert.equal(result.steps[0]?.toolCalls[0]?.toolName, 'echo');
+    assert.deepEqual(result.steps[0]?.toolCalls[0]?.input, { text: 'hello' });
+    assert.deepEqual(result.steps[0]?.toolResults[0]?.output, { echoed: 'hello' });
+    assert.equal(result.text, 'Echoed hello.');
   });
 });
 

--- a/packages/runtime/src/__tests__/provider-conformance.test.ts
+++ b/packages/runtime/src/__tests__/provider-conformance.test.ts
@@ -150,6 +150,75 @@ describe('models.dev provider conformance', () => {
     assert.equal(result.toolCalls[0]?.toolName, 'echo');
     assert.deepEqual(result.toolCalls[0]?.input, { text: 'hello' });
   });
+
+  test('xAI discovers exact account model ids and completes an OpenAI-compatible tool-call turn', async () => {
+    let requestBody: Record<string, unknown> | undefined;
+    const server = await startJsonServer(async (request, response) => {
+      assert.equal(request.headers.authorization, 'Bearer xai-test-key');
+      if (request.method === 'GET' && request.url === '/v1/models') {
+        respondJson(response, 200, {
+          object: 'list',
+          data: [{ id: 'grok-4.5', object: 'model', owned_by: 'xai' }],
+        });
+        return;
+      }
+      assert.equal(request.method, 'POST');
+      assert.equal(request.url, '/v1/chat/completions');
+      requestBody = JSON.parse(await readBody(request)) as Record<string, unknown>;
+      respondJson(response, 200, {
+        id: 'chatcmpl-xai',
+        object: 'chat.completion',
+        created: 1,
+        model: 'grok-4.5',
+        choices: [{
+          index: 0,
+          message: {
+            role: 'assistant',
+            content: null,
+            tool_calls: [{
+              id: 'call_echo',
+              type: 'function',
+              function: { name: 'echo', arguments: '{"text":"hello"}' },
+            }],
+          },
+          finish_reason: 'tool_calls',
+        }],
+        usage: { prompt_tokens: 8, completion_tokens: 4, total_tokens: 12 },
+      });
+    });
+    const connection: LlmConnection = {
+      slug: 'xai',
+      name: 'xAI',
+      providerType: 'xai',
+      baseUrl: `${server.url}/v1`,
+      defaultModel: 'grok-4.5',
+      enabled: true,
+      createdAt: 1,
+      updatedAt: 1,
+    };
+
+    const models = await fetchProviderModels(connection, 'xai-test-key');
+    assert.deepEqual(models, [{ id: 'grok-4.5' }]);
+
+    const result = await generateText({
+      model: getAIModel({ connection, apiKey: 'xai-test-key', modelId: 'grok-4.5' }),
+      prompt: 'Call echo with hello.',
+      tools: {
+        echo: tool({
+          description: 'Echo text',
+          inputSchema: z.object({ text: z.string() }),
+        }),
+      },
+    });
+
+    assert.equal(requestBody?.model, 'grok-4.5');
+    assert.deepEqual(
+      (requestBody?.tools as Array<{ function: { name: string } }>).map((entry) => entry.function.name),
+      ['echo'],
+    );
+    assert.equal(result.toolCalls[0]?.toolName, 'echo');
+    assert.deepEqual(result.toolCalls[0]?.input, { text: 'hello' });
+  });
 });
 
 async function startJsonServer(

--- a/scripts/check-third-party-notices.mjs
+++ b/scripts/check-third-party-notices.mjs
@@ -1,0 +1,13 @@
+import { readFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+
+const repoRoot = resolve(import.meta.dirname, '..');
+const sourcePath = resolve(repoRoot, 'apps/desktop/src/renderer/public/THIRD_PARTY_LICENSES.txt');
+const artifactPath = resolve(repoRoot, 'apps/desktop/dist-renderer/THIRD_PARTY_LICENSES.txt');
+
+const [source, artifact] = await Promise.all([readFile(sourcePath), readFile(artifactPath)]);
+if (!source.equals(artifact)) {
+  throw new Error('dist-renderer/THIRD_PARTY_LICENSES.txt does not match the governed public source');
+}
+
+console.log('[third-party-notices] OK — renderer artifact contains the byte-identical public notice.');

--- a/scripts/sync-model-metadata.mjs
+++ b/scripts/sync-model-metadata.mjs
@@ -12,6 +12,7 @@ const PROVIDERS = {
   moonshot: 'moonshotai-cn',
   openai: 'openai',
   siliconflow: 'siliconflow',
+  xai: 'xai',
   'zai-coding-plan': 'zai-coding-plan',
 };
 

--- a/scripts/sync-model-metadata.test.mjs
+++ b/scripts/sync-model-metadata.test.mjs
@@ -7,7 +7,7 @@ import { promisify } from 'node:util';
 import test from 'node:test';
 
 const execFileAsync = promisify(execFile);
-const PROVIDER_IDS = ['anthropic', 'deepseek', 'google', 'minimax', 'minimax-cn', 'moonshotai-cn', 'openai', 'siliconflow', 'zai-coding-plan'];
+const PROVIDER_IDS = ['anthropic', 'deepseek', 'google', 'minimax', 'minimax-cn', 'moonshotai-cn', 'openai', 'siliconflow', 'xai', 'zai-coding-plan'];
 
 function withRequiredProviders(openai) {
   return Object.fromEntries(PROVIDER_IDS.map((id) => {
@@ -61,6 +61,34 @@ test('sync-model-metadata maps models.dev modalities into Maka metadata', async 
   assert.match(generated, /"unknown-modality-model".*"capabilities":\{"reasoning":false,"functionCalling":false\}/);
   assert.match(generated, /export const GENERATED_MODELS_DEV_METADATA/);
   assert.match(generated, /export const GENERATED_MODELS_DEV_PROVIDER_FACTS/);
+});
+
+test('sync-model-metadata vendors xAI provider facts and exact model ids', async () => {
+  const directory = await mkdtemp(join(tmpdir(), 'maka-model-metadata-'));
+  const input = join(directory, 'api.json');
+  const output = join(directory, 'generated.ts');
+  const catalog = withRequiredProviders({});
+  catalog.xai = {
+    ...catalog.xai,
+    name: 'xAI',
+    models: {
+      'grok-4.5': {
+        id: 'grok-4.5', name: 'Grok 4.5', reasoning: true, tool_call: true,
+        modalities: { input: ['text', 'image'], output: ['text'] },
+        limit: { context: 500_000, output: 500_000 },
+      },
+    },
+  };
+  await writeFile(input, JSON.stringify(catalog));
+
+  await execFileAsync(process.execPath, [
+    'scripts/sync-model-metadata.mjs', '--input', input, '--output', output,
+  ]);
+
+  const generated = await readFile(output, 'utf8');
+  assert.match(generated, /"xai": \{/);
+  assert.match(generated, /"xai": \{"id":"xai","name":"xAI"/);
+  assert.match(generated, /"grok-4\.5": \{"displayName":"Grok 4\.5"/);
 });
 
 test('sync-model-metadata rejects incomplete upstream model data', async () => {


### PR DESCRIPTION
## Summary

- Add xAI as a first-class `xai` provider backed by the shared registry and checked-in models.dev snapshot.
- Wire xAI API-key credentials, account model discovery, exact model selection, and OpenAI-compatible runtime execution across Desktop, CLI, and headless.
- Render a traceable upstream xAI SVG through the shared provider-logo seam and ship the complete Lobe Icons MIT notice in the renderer distribution.

## Why

xAI is the next Phase 3 hosted API slice in #860. This extends the Phase 2 registry seam instead of adding provider-specific lists or routing layers, while preserving exact Grok model IDs and using `/v1/models` as the account-specific source of truth.

Refs #860

## Scope

This PR adds only the xAI direct API provider and the shared third-party notice delivery check required by its vendored Lobe Icons asset. It consumes the provider detail-header seam from #872 and does not add a parallel implementation. It does not implement other Phase 3 providers, Phase 7 conformance cleanup, or live-credential smoke evidence.

## Verification

- `npm run typecheck` — passed
- `npm test` — all affected package suites passed; one resource-timing run hit the existing Rive child pid-file timeout, then the complete Desktop suite passed 2403/2403 on serial rerun
- `npm --workspace @maka/desktop run e2e` — 15/15 passed with one worker
- `npm run check:stale` — passed
- Renderer build copied `src/renderer/public/THIRD_PARTY_LICENSES.txt` to `dist-renderer` byte-for-byte and the post-build notice contract passed
- Deterministic xAI runtime conformance verified Bearer authentication, `GET /v1/models`, exact `grok-4.5` preservation across both tool-loop requests, local tool execution and result round-trip, and the final assistant response
- xAI catalog and saved-detail E2E verified that the real upstream SVG is consumed as a theme-aware CSS mask whose computed background follows the provider-logo foreground color

No standalone visual artifact is included because this extends the existing provider catalog/detail interaction; the deterministic Desktop E2E covers both rendered entry points and their computed asset contract.

## Impact

Adds the persisted provider ID `xai` and the `XAI_API_KEY`, `XAI_API_KEY_FILE`, and `XAI_BASE_URL` headless configuration. Existing provider IDs and behavior remain compatible.

The vendored `xai.svg` is byte-identical to `@lobehub/icons-static-svg@1.91.0` at Lobe Icons commit `32f4083f7a20b67ecdc7b29c0af031ada5a29c52`, upstream path `packages/static-svg/icons/xai.svg`, SHA-256 `89eb7de9f0d02a41cfecd9109e253d7fd3529e27467dee4254faa67f3ac21451`. The renderer distribution includes the complete upstream MIT notice.

No migration or release-note change is required.

## Reviewer notes

The models.dev snapshot supplies model facts but currently omits xAI’s API base URL, so the registry pins the official `https://api.x.ai/v1` endpoint. xAI uses the existing OpenAI-compatible adapter because the exercised official contract supports chat completions and model listing; no provider override was added.

The xAI SVG declares `fill="currentColor"`. Because external `<img>` SVG documents do not inherit the parent color, the shared mark implementation consumes the byte-identical file as a CSS mask with `background: currentColor`; this keeps it legible across themes without modifying the upstream asset.

The required independent reviewer found no remaining findings and explicitly passed the final rebased diff after the dark-theme rendering fix.

## Ready for review

- [x] Verification is complete and the results above are current
- [x] Impact, compatibility, migration, documentation, and release-note needs are addressed
- [x] User-visible UI/UX changes include visual evidence, or `Verification` explains why it is not applicable
