### PR TITLE
fix(headless): support no-auth Ollama contract

### DIFF
--- a/apps/desktop/src/main/__tests__/icon-governance-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/icon-governance-contract.test.ts
@@ -37,6 +37,7 @@ const MINIMAX_BRAND_ASSET_FILE = resolve(
 const XAI_BRAND_MARK_FILE = resolve(REPO_ROOT, 'apps/desktop/src/renderer/assets/provider-brands/xai.svg');
 const DESKTOP_PACKAGE_FILE = resolve(REPO_ROOT, 'apps/desktop/package.json');
 const THIRD_PARTY_NOTICES_FILE = resolve(REPO_ROOT, 'apps/desktop/src/renderer/public/THIRD_PARTY_LICENSES.txt');
+const ONBOARDING_HERO_FILE = resolve(REPO_ROOT, 'apps/desktop/src/renderer/OnboardingHero.tsx');
 
 // Fixed brand assets, not generic UI icons — their vendored SVGs keep
 // their own stroke weight and are exempt from the call-site stroke sweep.
@@ -197,6 +198,45 @@ describe('icon + typography governance contract', () => {
       /kind === 'detail' && selected[\s\S]*<ProviderPageHeader[\s\S]*providerType=\{selected\.providerType\}/,
       'saved connection detail must consume the shared provider logo seam',
     );
+  });
+
+  it('keeps the verified Ollama mark and routes it through catalog, detail, and first-run surfaces', async () => {
+    const [marks, catalog, providersPanel, onboardingHero, notices] = await Promise.all([
+      readFile(PROVIDER_BRAND_MARKS_FILE, 'utf8'),
+      readFile(PROVIDER_CATALOG_FILE, 'utf8'),
+      readFile(PROVIDERS_PANEL_FILE, 'utf8'),
+      readFile(ONBOARDING_HERO_FILE, 'utf8'),
+      readFile(THIRD_PARTY_NOTICES_FILE, 'utf8'),
+    ]);
+
+    assert.match(
+      marks,
+      /Vendored unchanged from @lobehub\/icons-static-svg@1\.91\.0:[\s\S]*github\.com\/lobehub\/lobe-icons\/blob\/32f4083f7a20b67ecdc7b29c0af031ada5a29c52\/packages\/static-svg\/icons\/ollama\.svg[\s\S]*MIT license/,
+      'the Ollama mark must record its repository, package version, commit, file path, license, and unchanged-vendor status',
+    );
+    const ollamaPath = marks.match(/function Ollama\(\)[\s\S]*?<path d="([^"]+)" \/>/)?.[1];
+    assert.ok(ollamaPath, 'the Ollama provider must render its vendored SVG path');
+    assert.equal(
+      createHash('sha256').update(ollamaPath).digest('hex'),
+      'fe847dff4bb6ae25ebec9a7def819ec2583023552b2e88a572c481aad2d32433',
+      'the complete Ollama path must remain byte-identical to the pinned Lobe Icons SVG',
+    );
+    assert.ok(
+      notices.includes(
+        '`apps/desktop/src/renderer/settings/provider-brand-marks.tsx` `Ollama` path\n' +
+          '    - Upstream path: `packages/static-svg/icons/ollama.svg`\n' +
+          '    - SHA-256: `fe847dff4bb6ae25ebec9a7def819ec2583023552b2e88a572c481aad2d32433`',
+      ),
+      'the shared Lobe Icons notice must inventory the vendored Ollama asset',
+    );
+    assert.match(marks, /case 'ollama':\s*return <Ollama \/>/);
+    assert.match(catalog, /<ProviderLogo type=\{props\.type\} \/>/);
+    assert.match(
+      providersPanel,
+      /providerType=\{selected\.providerType\}[\s\S]*function ProviderPageHeader[\s\S]*<ProviderLogo type=\{props\.providerType\} compact \/>/,
+      'the connection detail header must render the same provider mark as the catalog',
+    );
+    assert.match(onboardingHero, /<ProviderLogo type=\{type\} compact \/>/);
   });
 
   it('ships the Lobe Icons MIT notice beside vendored provider assets', async () => {

--- a/apps/desktop/src/renderer/public/THIRD_PARTY_LICENSES.txt
+++ b/apps/desktop/src/renderer/public/THIRD_PARTY_LICENSES.txt
@@ -13,6 +13,9 @@ This file records notices for third-party source assets vendored into the Maka d
   - `apps/desktop/src/renderer/assets/provider-brands/xai.svg`
     - Upstream path: `packages/static-svg/icons/xai.svg`
     - SHA-256: `89eb7de9f0d02a41cfecd9109e253d7fd3529e27467dee4254faa67f3ac21451`
+  - `apps/desktop/src/renderer/settings/provider-brand-marks.tsx` `Ollama` path
+    - Upstream path: `packages/static-svg/icons/ollama.svg`
+    - SHA-256: `fe847dff4bb6ae25ebec9a7def819ec2583023552b2e88a572c481aad2d32433`
 
 MIT License
 

--- a/apps/desktop/src/renderer/settings/provider-brand-marks.tsx
+++ b/apps/desktop/src/renderer/settings/provider-brand-marks.tsx
@@ -147,6 +147,9 @@ function GenericProviderMark(): ReactElement {
   );
 }
 
+// Vendored unchanged from @lobehub/icons-static-svg@1.91.0:
+// https://github.com/lobehub/lobe-icons/blob/32f4083f7a20b67ecdc7b29c0af031ada5a29c52/packages/static-svg/icons/ollama.svg
+// Lobe Icons is MIT licensed; this path is consumed verbatim, not redrawn here.
 function Ollama(): ReactElement {
   return (
     <svg viewBox="0 0 24 24" role="img" fill="currentColor" fillRule="evenodd" xmlns="http://www.w3.org/2000/svg">

--- a/packages/headless/harbor/maka_agent.py
+++ b/packages/headless/harbor/maka_agent.py
@@ -212,7 +212,11 @@ class MakaAgent(BaseInstalledAgent):
         return value if value > 0 else self._DEFAULT_CELL_TIMEOUT_SEC
 
     def _host_side_llm_enabled(self) -> bool:
-        return bool(self._get_env("MAKA_HOST_API_KEY_FILE") or self._get_env("MAKA_HOST_API_KEY"))
+        return bool(
+            self._get_env("MAKA_HOST_API_KEY_FILE")
+            or self._get_env("MAKA_HOST_API_KEY")
+            or self._get_env("MAKA_HOST_NO_AUTH") == "true"
+        )
 
     def _harbor_backend(self) -> str:
         backend = self._resolved_flags.get("backend", "") or self._get_env("MAKA_BACKEND") or "ai-sdk"
@@ -276,7 +280,7 @@ class MakaAgent(BaseInstalledAgent):
         economy_task_env = self._get_env("MAKA_ECONOMY_TASK_MODE")
         economy_task_mode = True if economy_task_flag is True else economy_task_env == "true"
         if backend == "ai-sdk" and not self._host_side_llm_enabled():
-            raise RuntimeError("backend=ai-sdk requires MAKA_HOST_API_KEY or MAKA_HOST_API_KEY_FILE")
+            raise RuntimeError("backend=ai-sdk requires host-side provider configuration")
         env = {
             "MAKA_BACKEND": backend,
             "MAKA_MODEL": model,

--- a/packages/headless/harbor/run-host-cell.mjs
+++ b/packages/headless/harbor/run-host-cell.mjs
@@ -3,6 +3,7 @@
 import { readFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { pathToFileURL } from 'node:url';
+import { PROVIDER_DEFAULTS } from '@maka/core';
 import {
   buildAiSdkCellBackendRegistration,
   buildHarborCellContextBudgetPolicySnapshot,
@@ -94,13 +95,14 @@ function economyTaskModeFromEnv(value) {
 }
 
 export async function backendEnv(env, provider) {
-  const keyEnvName = env.MAKA_HOST_API_KEY_ENV_NAME || providerApiKeyEnvName(provider);
-  const apiKey = await hostApiKey(env);
   const contextEnv = normalizeHarborCellContextEnv(env);
   const result = {
     MAKA_LLM_CONNECTION_SLUG: env.MAKA_LLM_CONNECTION_SLUG || provider,
-    [keyEnvName]: apiKey,
   };
+  if (PROVIDER_DEFAULTS[provider].authKind !== 'none') {
+    const keyEnvName = env.MAKA_HOST_API_KEY_ENV_NAME || providerApiKeyEnvName(provider);
+    result[keyEnvName] = await hostApiKey(env);
+  }
   if (env.MAKA_HOST_BASE_URL) result.MAKA_BASE_URL = env.MAKA_HOST_BASE_URL;
   for (const key of HOST_BACKEND_ENV_KEYS) {
     if (env[key] !== undefined) result[key] = env[key];

--- a/packages/headless/src/__tests__/harbor-adapter.test.ts
+++ b/packages/headless/src/__tests__/harbor-adapter.test.ts
@@ -153,6 +153,14 @@ describe('Harbor adapter contract', () => {
     }
   });
 
+  test('run-host-cell.mjs accepts Ollama without provider credentials', async () => {
+    const { backendEnv } = await import(new URL('../../harbor/run-host-cell.mjs', import.meta.url).href);
+
+    const env = await backendEnv({}, 'ollama');
+
+    assert.deepEqual(env, { MAKA_LLM_CONNECTION_SLUG: 'ollama' });
+  });
+
   test('run-host-cell.mjs rejects unknown context env instead of dropping it', async () => {
     const tmp = mkdtempSync(resolve(tmpdir(), 'maka-host-cell-env-'));
     try {
@@ -787,9 +795,18 @@ with tempfile.TemporaryDirectory() as tmp:
     try:
         MakaAgent(Path(tmp))._cell_env(Path("/logs/agent/instruction.txt"))
     except RuntimeError as exc:
-        assert "backend=ai-sdk requires MAKA_HOST_API_KEY or MAKA_HOST_API_KEY_FILE" in str(exc), str(exc)
+        assert "backend=ai-sdk requires host-side provider configuration" in str(exc), str(exc)
     else:
         raise AssertionError("expected ai-sdk without host-side credentials to fail")
+
+    ollama_env = MakaAgent(Path(tmp), extra_env={
+        "MAKA_HOST_NO_AUTH": "true",
+        "MAKA_PROVIDER": "ollama",
+        "MAKA_MODEL": "hf.co/bartowski/Qwen2.5-Coder-7B-Instruct-GGUF:Q4_K_M",
+    })._cell_env(Path("/logs/agent/instruction.txt"))
+    assert ollama_env["MAKA_PROVIDER"] == "ollama", ollama_env
+    assert ollama_env["MAKA_MODEL"] == "hf.co/bartowski/Qwen2.5-Coder-7B-Instruct-GGUF:Q4_K_M", ollama_env
+    assert "API_KEY" not in json.dumps(ollama_env), ollama_env
 
     agent = MakaAgent(Path(tmp))
     context = AgentContext()

--- a/packages/headless/src/__tests__/harbor-task-runner.test.ts
+++ b/packages/headless/src/__tests__/harbor-task-runner.test.ts
@@ -258,6 +258,29 @@ describe('createHarborTaskRunner', () => {
     });
   });
 
+  test('keeps no-auth providers on the existing OpenCode direct path', async () => {
+    await withRun(async ({ jobsDir, repo }) => {
+      let harborEnv: Record<string, string> | undefined;
+      const runner = createHarborTaskRunner({
+        makaRepoPath: repo,
+        jobsDir,
+        agent: 'opencode',
+        model: 'ollama/qwen2.5-coder:7b',
+        provider: 'ollama',
+        agentEnv: { MAKA_BASE_URL: 'http://host.docker.internal:11434/v1' },
+        runHarbor: async (request) => {
+          harborEnv = request.env;
+          return fakeRunner({ reward: '1\n' })(request);
+        },
+      });
+
+      await runner(runInput());
+
+      assert.equal(harborEnv?.MAKA_HOST_NO_AUTH, undefined);
+      assert.equal(harborEnv?.MAKA_OPENCODE_PROVIDER_PROXY_URL, undefined);
+    });
+  });
+
   test('routes SiliconFlow key files and base URLs through the host-side cell', async () => {
     await withRun(async ({ jobsDir, repo, keyFile }) => {
       let harborEnv: Record<string, string> | undefined;
@@ -281,6 +304,39 @@ describe('createHarborTaskRunner', () => {
       assert.equal(harborEnv?.MAKA_HOST_BASE_URL, 'https://api.siliconflow.cn/v1');
       const agent = (captured.config?.agents as Array<{ env: Record<string, string> }>)[0]!;
       assert.equal(agent.env.SILICONFLOW_BASE_URL, undefined);
+    });
+  });
+
+  test('routes no-auth Ollama through the host-side cell without exposing credentials', async () => {
+    await withRun(async ({ jobsDir, repo }) => {
+      let harborEnv: Record<string, string> | undefined;
+      const captured: { config?: Record<string, unknown> } = {};
+      const baseUrl = 'http://127.0.0.1:11434/v1';
+      const model = 'hf.co/bartowski/Qwen2.5-Coder-7B-Instruct-GGUF:Q4_K_M';
+      const runner = createHarborTaskRunner({
+        makaRepoPath: repo,
+        jobsDir,
+        model: `ollama/${model}`,
+        provider: 'ollama',
+        agentEnv: { MAKA_BASE_URL: baseUrl },
+        runHarbor: async (request) => {
+          harborEnv = request.env;
+          return fakeRunner({ reward: '1\n', captured })(request);
+        },
+      });
+
+      await runner(runInput());
+
+      assert.equal(harborEnv?.MAKA_HOST_REPO_ROOT, repo);
+      assert.equal(harborEnv?.MAKA_HOST_BASE_URL, baseUrl);
+      assert.equal(harborEnv?.MAKA_HOST_NO_AUTH, 'true');
+      assert.equal(harborEnv?.MAKA_HOST_API_KEY, undefined);
+      assert.equal(harborEnv?.MAKA_HOST_API_KEY_FILE, undefined);
+      const agent = (captured.config?.agents as Array<{ model_name: string; env: Record<string, string> }>)[0]!;
+      assert.equal(agent.model_name, model);
+      assert.equal(agent.env.MAKA_MODEL, model);
+      assert.equal(agent.env.MAKA_BASE_URL, undefined);
+      assert.doesNotMatch(JSON.stringify(captured.config), /API_KEY|127\.0\.0\.1:11434/);
     });
   });
 

--- a/packages/headless/src/harbor-task-runner.ts
+++ b/packages/headless/src/harbor-task-runner.ts
@@ -3,6 +3,7 @@ import { mkdir, readFile, readdir, rm } from 'node:fs/promises';
 import { writeFile } from 'node:fs/promises';
 import { basename, delimiter, join } from 'node:path';
 import { promisify } from 'node:util';
+import { PROVIDER_DEFAULTS, type ProviderType } from '@maka/core';
 import {
   validateHarborCellExecutionIdentity,
   validateHarborCellOutput,
@@ -17,7 +18,7 @@ import {
   HarborTaskRunner,
 } from './fixed-prompt-controller.js';
 import { startProviderAuthProxy } from './provider-auth-proxy.js';
-import { requireProviderCredentialEnv } from './provider-env.js';
+import { providerCredentialEnv, requireProviderCredentialEnv } from './provider-env.js';
 
 const execFileAsync = promisify(execFile);
 
@@ -153,14 +154,15 @@ export function createHarborTaskRunner(options: HarborTaskRunnerOptions): Harbor
       agentEnv: mergeAgentEnv(options.agentEnv, input.agentEnv),
     };
     assertNoProviderSecretsInAgentEnv(runnerOptions.agentEnv);
-    const hasHostProviderAuth = runnerOptions.apiKeyFile !== undefined;
+    const hasHostProviderRuntime = runnerOptions.apiKeyFile !== undefined
+      || (runnerOptions.agent !== 'opencode' && providerAuthKind(runnerOptions.provider) === 'none');
     const configPath = join(jobsDir, 'job-config.json');
     const { agentEnv: _attemptAgentEnv, ...inputWithoutAttemptEnv } = input;
     const config = buildHarborJobConfig(inputWithoutAttemptEnv, {
       ...runnerOptions,
       jobsDir,
       jobName,
-      ...(hasHostProviderAuth ? { agentEnv: taskAgentEnvWithoutProviderSecrets(runnerOptions) } : {}),
+      ...(hasHostProviderRuntime ? { agentEnv: taskAgentEnvWithoutProviderSecrets(runnerOptions) } : {}),
     });
     await writeFile(configPath, `${JSON.stringify(config, null, 2)}\n`, 'utf8');
 
@@ -459,18 +461,21 @@ async function hostSideProviderRuntime(options: HarborTaskRunnerOptions): Promis
   env: Record<string, string>;
   close?: () => Promise<void>;
 } | null> {
-  if (!options.apiKeyFile) return null;
   const provider = options.provider ?? 'deepseek';
-  const providerEnv = requireProviderCredentialEnv(provider);
-  const [primaryBaseUrl, ...fallbackBaseUrls] = providerEnv.baseUrls;
+  const authKind = providerAuthKind(provider);
+  if (!options.apiKeyFile && authKind !== 'none') return null;
+  const providerEnv = providerCredentialEnv(provider);
+  const [primaryBaseUrl, ...fallbackBaseUrls] = providerEnv?.baseUrls ?? [];
   const baseUrl = (primaryBaseUrl ? options.agentEnv?.[primaryBaseUrl] : undefined)
     ?? options.agentEnv?.MAKA_BASE_URL
     ?? fallbackBaseUrls.map((name) => options.agentEnv?.[name]).find(Boolean);
   if (options.agent === 'opencode') {
+    const apiKeyFile = options.apiKeyFile;
+    if (!apiKeyFile) return null;
     if (!baseUrl) throw new Error(`OpenCode provider ${provider} requires a base URL`);
     const proxy = await startProviderAuthProxy({
       upstreamBaseUrl: baseUrl,
-      apiKeyFile: options.apiKeyFile,
+      apiKeyFile,
     });
     return {
       env: {
@@ -480,21 +485,26 @@ async function hostSideProviderRuntime(options: HarborTaskRunnerOptions): Promis
       close: proxy.close,
     };
   }
+  const apiKeyEnvName = options.apiKeyFile
+    ? normalizeRawKeyEnvName(options.apiKeyEnvName ?? requireProviderCredentialEnv(provider).apiKeys[0]!)
+    : undefined;
   return {
     env: {
       MAKA_HOST_REPO_ROOT: options.makaRepoPath,
-      MAKA_HOST_API_KEY_FILE: options.apiKeyFile,
-      MAKA_HOST_API_KEY_ENV_NAME: normalizeRawKeyEnvName(options.apiKeyEnvName ?? providerEnv.apiKeys[0]!),
+      ...(options.apiKeyFile ? { MAKA_HOST_API_KEY_FILE: options.apiKeyFile } : {}),
+      ...(apiKeyEnvName ? { MAKA_HOST_API_KEY_ENV_NAME: apiKeyEnvName } : {}),
+      ...(authKind === 'none' ? { MAKA_HOST_NO_AUTH: 'true' } : {}),
       ...(baseUrl ? { MAKA_HOST_BASE_URL: baseUrl } : {}),
     },
   };
 }
 
 function taskAgentEnvWithoutProviderSecrets(options: HarborTaskRunnerOptions): Record<string, string> {
-  const providerEnv = requireProviderCredentialEnv(options.provider ?? 'deepseek');
+  const providerEnv = providerCredentialEnv(options.provider ?? 'deepseek');
   const result: Record<string, string> = {};
   for (const [key, value] of Object.entries(options.agentEnv ?? {})) {
-    if (providerEnv.apiKeys.includes(key) || key === providerEnv.apiKeyFile || providerEnv.baseUrls.includes(key)) continue;
+    if (providerEnv?.apiKeys.includes(key) || key === providerEnv?.apiKeyFile || providerEnv?.baseUrls.includes(key)) continue;
+    if (key === 'MAKA_BASE_URL') continue;
     if (/_API_KEY(_FILE)?$/.test(key)) continue;
     result[key] = value;
   }
@@ -517,6 +527,13 @@ function assertNoExperimentIdentityOverrides(agentEnv: Record<string, string> | 
 
 function normalizeRawKeyEnvName(name: string): string {
   return name.endsWith('_FILE') ? name.slice(0, -'_FILE'.length) : name;
+}
+
+function providerAuthKind(provider: string | undefined) {
+  const providerType = (provider ?? 'deepseek') as ProviderType;
+  const definition = PROVIDER_DEFAULTS[providerType];
+  if (!definition) throw new Error(`unsupported MAKA_PROVIDER: ${provider ?? ''}`);
+  return definition.authKind;
 }
 
 async function findTrialDir(jobDir: string, taskName: string): Promise<string> {

--- a/packages/runtime/src/__tests__/provider-conformance.test.ts
+++ b/packages/runtime/src/__tests__/provider-conformance.test.ts
@@ -243,6 +243,95 @@ describe('models.dev provider conformance', () => {
     assert.deepEqual(result.steps[0]?.toolResults[0]?.output, { echoed: 'hello' });
     assert.equal(result.text, 'Echoed hello.');
   });
+
+  test('Ollama discovers an exact local model id and completes a no-secret tool-call loop', async () => {
+    const modelId = 'hf.co/bartowski/Qwen2.5-Coder-7B-Instruct-GGUF:Q4_K_M';
+    const requestBodies: Array<Record<string, unknown>> = [];
+    const server = await startJsonServer(async (request, response) => {
+      if (request.method === 'GET' && request.url === '/api/tags') {
+        assert.equal(request.headers.authorization, undefined);
+        respondJson(response, 200, { models: [{ name: modelId, model: modelId }] });
+        return;
+      }
+      assert.equal(request.method, 'POST');
+      assert.equal(request.url, '/v1/chat/completions');
+      assert.equal(request.headers.authorization, 'Bearer ollama');
+      const body = JSON.parse(await readBody(request)) as Record<string, unknown>;
+      requestBodies.push(body);
+      if (requestBodies.length === 1) {
+        respondJson(response, 200, {
+          id: 'chatcmpl-ollama-tool',
+          object: 'chat.completion',
+          created: 1,
+          model: modelId,
+          choices: [{
+            index: 0,
+            message: {
+              role: 'assistant',
+              content: null,
+              tool_calls: [{
+                id: 'call_echo',
+                type: 'function',
+                function: { name: 'echo', arguments: '{"text":"hello"}' },
+              }],
+            },
+            finish_reason: 'tool_calls',
+          }],
+          usage: { prompt_tokens: 8, completion_tokens: 4, total_tokens: 12 },
+        });
+        return;
+      }
+      respondJson(response, 200, {
+        id: 'chatcmpl-ollama-final',
+        object: 'chat.completion',
+        created: 2,
+        model: modelId,
+        choices: [{
+          index: 0,
+          message: { role: 'assistant', content: 'Echoed hello.' },
+          finish_reason: 'stop',
+        }],
+        usage: { prompt_tokens: 12, completion_tokens: 3, total_tokens: 15 },
+      });
+    });
+    const connection: LlmConnection = {
+      slug: 'ollama-local',
+      name: 'Ollama',
+      providerType: 'ollama',
+      baseUrl: `${server.url}/v1`,
+      defaultModel: modelId,
+      enabled: true,
+      createdAt: 1,
+      updatedAt: 1,
+    };
+
+    assert.deepEqual(await fetchProviderModels(connection, ''), [{ id: modelId }]);
+
+    const result = await generateText({
+      model: getAIModel({ connection, apiKey: '', modelId }),
+      prompt: 'Call echo with hello, then report the result.',
+      tools: {
+        echo: tool({
+          description: 'Echo text',
+          inputSchema: z.object({ text: z.string() }),
+          execute: async ({ text }) => ({ text }),
+        }),
+      },
+      stopWhen: stepCountIs(2),
+    });
+
+    assert.equal(result.text, 'Echoed hello.');
+    assert.equal(requestBodies.length, 2);
+    assert.deepEqual(requestBodies.map((body) => body.model), [modelId, modelId]);
+    assert.deepEqual(
+      (requestBodies[0]?.tools as Array<{ function: { name: string } }>).map((entry) => entry.function.name),
+      ['echo'],
+    );
+    const secondMessages = requestBodies[1]?.messages as Array<{ role: string; content: string }>;
+    const toolMessage = secondMessages.find((message) => message.role === 'tool');
+    assert.ok(toolMessage);
+    assert.deepEqual(JSON.parse(toolMessage.content), { text: 'hello' });
+  });
 });
 
 async function startJsonServer(


### PR DESCRIPTION
## Summary

- Validate Ollama against the shared provider registry contract with deterministic coverage for no-auth discovery, exact model IDs, snapshot fallback, and a two-step local tool-call loop.
- Route registry-declared no-auth Ollama runs through the Maka Harbor host cell without requiring or exposing provider credentials, while preserving OpenCode's existing direct path.
- Pin the existing Ollama mark to Lobe Icons `@lobehub/icons-static-svg@1.91.0` at commit `32f4083f7a20b67ecdc7b29c0af031ada5a29c52`, lock its complete path SHA-256, and inventory it in the shared packaged MIT notice.

## Why

Issue #860 Phase 5 requires Ollama to satisfy the complete registry contract. The existing Desktop, CLI, and runtime paths already used the registry-owned `ollama` ID, `/api/tags` discovery, snapshot fallback, and exact model IDs, but the Harbor host runtime was gated on an API key file. That prevented a registry-declared no-auth provider from using the host-side runtime needed to reach a local Ollama daemon.

The existing Ollama mark was byte-identical to the Lobe Icons asset, but its source, complete content hash, and distributed license notice were not locked by governance evidence.

Refs #860

## Scope

This PR covers only the Ollama Phase 5 contract and the minimal shared no-auth Harbor seam demonstrated by tests. It does not implement Phase 7, change another provider contract, add an OpenCode no-auth proxy, create a parallel provider-detail seam, create a parallel third-party notice mechanism, or update Issue #860 status.

## Verification

- `npm run typecheck` — passed for all workspaces.
- `npm test` — all workspace package suites passed.
- `npm --workspace @maka/runtime test` — passed in the final package-only run.
- `npm --workspace @maka/headless test` — 843 passed, 1 fixture skipped in the final package-only run.
- `npm --workspace @maka/desktop run build:renderer` — passed; the shared third-party notice checker confirmed the packaged notice is byte-identical.
- `npm --workspace @maka/desktop run e2e -- e2e/first-run.spec.ts e2e/providers.spec.ts` — 5/5 passed using one Playwright worker.
- `npm run check:stale` — passed (`dist is fresh`).
- `git diff --check origin/main...HEAD` — passed.
- No live daemon smoke was run. It is non-blocking for this no-auth contract, and the deterministic local HTTP fixture covers discovery, OpenAI-compatible chat/tool calls, exact IDs, and secret handling without recording account data or raw responses.
- No new visual behavior is introduced: the existing Ollama SVG path is unchanged, and contract/E2E coverage verifies that catalog, detail, and first-run surfaces consume the shared `ProviderLogo` seam.

## Impact

Existing persisted provider IDs, registry ownership, model snapshot fallback, Desktop/CLI flows, keyed-provider behavior, and rendered Ollama appearance are unchanged. Harbor Maka runs can now use registry-declared no-auth providers without a credential file, while provider endpoints and credential fields remain outside the task container config. The packaged shared Lobe Icons MIT notice now inventories the Ollama asset. No migration or release-note change is required.

## Reviewer notes

Please focus on the adapter ownership boundary: registry `authKind` enables no-auth host-cell routing only for the Maka adapter, while OpenCode keeps its pre-existing direct path. The runtime conformance fixture intentionally uses `hf.co/bartowski/Qwen2.5-Coder-7B-Instruct-GGUF:Q4_K_M` to prove byte-for-byte model ID preservation through discovery and both tool-call turns.

The Ollama asset provenance is Lobe Icons repository commit `32f4083f7a20b67ecdc7b29c0af031ada5a29c52`, file `packages/static-svg/icons/ollama.svg`, MIT license. Its complete path SHA-256 is `fe847dff4bb6ae25ebec9a7def819ec2583023552b2e88a572c481aad2d32433`. This branch only extends the notice inventory and consumes the shared notice/build-check and `ProviderLogo` seams already on `main`.

## Ready for review

- [x] Verification is complete and the results above are current
- [x] Impact, compatibility, migration, documentation, and release-note needs are addressed
- [x] User-visible UI/UX changes include visual evidence, or `Verification` explains why it is not applicable
