### PR TITLE
fix(runtime): preserve canonical tool argument ownership

### DIFF
--- a/packages/runtime/src/__tests__/ai-sdk-flow.test.ts
+++ b/packages/runtime/src/__tests__/ai-sdk-flow.test.ts
@@ -658,6 +658,51 @@ describe('mapSessionEventToRuntimeEvent (pure)', () => {
     assert.equal(event.actions?.stateDelta?.activityKind, 'command');
   });
 
+  test('owns independent args across SessionEvent to RuntimeEvent mappings', () => {
+    const cases = [
+      {
+        event: (args: unknown) => ev({
+          type: 'tool_start',
+          toolUseId: 'tu-owned',
+          toolName: 'Write',
+          args,
+        }),
+        mappedArgs: (event: RuntimeEvent) => event.content?.kind === 'function_call'
+          ? event.content.args
+          : undefined,
+      },
+      {
+        event: (args: unknown) => ev({
+          type: 'permission_request',
+          requestId: 'permission-owned',
+          toolUseId: 'tu-owned',
+          toolName: 'Write',
+          category: 'file_write',
+          reason: 'file_write',
+          args,
+        }),
+        mappedArgs: (event: RuntimeEvent) => event.actions?.permissionRequest?.args,
+      },
+    ];
+
+    for (const scenario of cases) {
+      const sourceArgs = { content: 'approved', layout: { cols: 120 } };
+      const sourceEvent = scenario.event(sourceArgs);
+      const mappedArgs = scenario.mappedArgs(mapSessionEventToRuntimeEvent(
+        sourceEvent,
+        ctx,
+        createSessionEventMapMemory(),
+      )) as typeof sourceArgs;
+
+      assert.notStrictEqual(mappedArgs, sourceArgs);
+      assert.notStrictEqual(mappedArgs.layout, sourceArgs.layout);
+      sourceArgs.layout.cols = 80;
+      assert.equal(mappedArgs.layout.cols, 120);
+      mappedArgs.content = 'runtime';
+      assert.equal(sourceArgs.content, 'approved');
+    }
+  });
+
   test('plan_submitted maps to an agent-authored state delta', () => {
     const a = mapSessionEventToRuntimeEvent(
       ev({ type: 'plan_submitted', planId: 'p1', title: 'T', markdownPath: '/p.md' }),

--- a/packages/runtime/src/__tests__/pi-agent-backend.test.ts
+++ b/packages/runtime/src/__tests__/pi-agent-backend.test.ts
@@ -214,6 +214,289 @@ describe('PiAgentBackend skeleton', () => {
     assert.equal(third.value?.type === 'tool_result' ? third.value.isError : false, true);
   });
 
+  test('isolates canonical Pi args from transport, storage, permission, and event owners', async () => {
+    const initialArgs = {
+      command: 'printf password=super-secret',
+      options: { columns: 120 },
+    };
+    const projectedArgs = {
+      command: 'printf password=[redacted]',
+      options: { columns: 120 },
+    };
+    const permissionArgs = structuredClone(initialArgs);
+    const toolStartArgs = structuredClone(initialArgs);
+    let storedArgs: unknown;
+    const backend = new PiAgentBackend({
+      sessionId: 'session-1',
+      header: header({ permissionMode: 'ask' }),
+      appendMessage: async (message) => {
+        if (message.type !== 'tool_call') return;
+        storedArgs = structuredClone(message.args);
+        mutatePiArgs(message.args, 'storage');
+      },
+      permissionEngine: new PermissionEngine({ newId: nextId('permission'), now: nextNow(4_100) }),
+      transport: frames([
+        {
+          type: 'permission_request',
+          toolUseId: 'tool-1',
+          toolName: 'Bash',
+          args: permissionArgs,
+          categoryHint: 'shell_unsafe',
+        },
+        { type: 'tool_start', toolUseId: 'tool-1', toolName: 'Bash', args: toolStartArgs },
+        { type: 'tool_result', toolUseId: 'tool-1', content: { kind: 'text', text: 'executed' } },
+        { type: 'complete' },
+      ]),
+      newId: nextId('id'),
+      now: nextNow(4_200),
+    });
+
+    const iterator = backend.send({ turnId: 'turn-1', text: 'run command', context: [] })[Symbol.asyncIterator]();
+    const permission = await iterator.next();
+    assert.equal(permission.value?.type, 'permission_request');
+    if (permission.value?.type !== 'permission_request') return;
+    assert.deepEqual(permission.value.args, initialArgs);
+    mutatePiArgs(permissionArgs, 'transport');
+
+    await backend.respondToPermission({ requestId: permission.value.requestId, decision: 'allow' });
+    assert.equal((await iterator.next()).value?.type, 'permission_decision_ack');
+    const toolStart = await iterator.next();
+    assert.equal(toolStart.value?.type, 'tool_start');
+    assert.deepEqual(toolStart.value?.type === 'tool_start' ? toolStart.value.args : undefined, projectedArgs);
+    if (toolStart.value?.type === 'tool_start') mutatePiArgs(toolStart.value.args, 'event');
+
+    while (!(await iterator.next()).done) {
+      // Drain the turn so the backend releases its permission state.
+    }
+
+    assert.deepEqual(storedArgs, projectedArgs);
+    assert.equal(permissionArgs.command, 'transport');
+    assert.deepEqual(toolStartArgs, initialArgs);
+  });
+
+  test('snapshots a Pi tool-start frame before awaiting assistant persistence', async () => {
+    const approvedArgs = { command: 'printf approved' };
+    const driftingArgs = { command: 'rm -rf workspace' };
+    let signalAssistantAppend!: () => void;
+    const assistantAppendStarted = new Promise<void>((resolve) => { signalAssistantAppend = resolve; });
+    let releaseAssistantAppend!: () => void;
+    const assistantAppendReleased = new Promise<void>((resolve) => { releaseAssistantAppend = resolve; });
+    const backend = new PiAgentBackend({
+      sessionId: 'session-1',
+      header: header({ permissionMode: 'ask' }),
+      appendMessage: async (message) => {
+        if (message.type !== 'assistant') return;
+        signalAssistantAppend();
+        await assistantAppendReleased;
+      },
+      permissionEngine: new PermissionEngine({ newId: nextId('permission'), now: nextNow(4_250) }),
+      transport: frames([
+        {
+          type: 'permission_request',
+          toolUseId: 'tool-1',
+          toolName: 'Bash',
+          args: approvedArgs,
+          categoryHint: 'shell_unsafe',
+        },
+        { type: 'text_delta', text: 'running now' },
+        { type: 'tool_start', toolUseId: 'tool-1', toolName: 'Bash', args: driftingArgs },
+        { type: 'complete' },
+      ]),
+      newId: nextId('id'),
+      now: nextNow(4_275),
+    });
+
+    const iterator = backend.send({ turnId: 'turn-1', text: 'run command', context: [] })[Symbol.asyncIterator]();
+    const permission = await iterator.next();
+    assert.equal(permission.value?.type, 'permission_request');
+    if (permission.value?.type !== 'permission_request') return;
+    await backend.respondToPermission({ requestId: permission.value.requestId, decision: 'allow' });
+    assert.equal((await iterator.next()).value?.type, 'permission_decision_ack');
+    assert.equal((await iterator.next()).value?.type, 'text_delta');
+
+    const terminal = iterator.next();
+    await assistantAppendStarted;
+    driftingArgs.command = approvedArgs.command;
+    releaseAssistantAppend();
+
+    const error = await terminal;
+    assert.equal(error.value?.type, 'error');
+    assert.equal(error.value?.type === 'error' ? error.value.reason : undefined, 'pi_agent_transport_error');
+    assert.equal((await iterator.next()).value?.type, 'complete');
+  });
+
+  test('fails closed when a later Pi frame changes the canonical invocation', async (t) => {
+    const cases = [
+      {
+        name: 'tool name',
+        first: {
+          toolName: 'Bash',
+          args: { command: 'printf approved' },
+          categoryHint: 'shell_unsafe' as const,
+        },
+        later: { toolName: 'Write', args: { command: 'printf approved' } },
+        expectedStoredArgs: { command: 'printf approved' },
+      },
+      {
+        name: 'arguments',
+        first: {
+          toolName: 'Bash',
+          args: { command: 'printf approved' },
+          categoryHint: 'shell_unsafe' as const,
+        },
+        later: { toolName: 'Bash', args: { command: 'printf changed' } },
+        expectedStoredArgs: { command: 'printf approved' },
+      },
+      {
+        name: 'private Computer Use arguments with the same approval summary',
+        first: {
+          toolName: 'maka_computer',
+          args: {
+            action: 'type',
+            app: 'Example',
+            observation_id: 'frame-1',
+            text: 'first secret',
+            coordinate: [10, 20],
+          },
+          categoryHint: 'computer_use' as const,
+        },
+        later: {
+          toolName: 'maka_computer',
+          args: {
+            action: 'type',
+            app: 'Example',
+            observation_id: 'frame-1',
+            text: 'second secret',
+            coordinate: [30, 40],
+          },
+        },
+        expectedStoredArgs: {
+          action: 'type',
+          approvalClass: 'keyboard_mutation',
+          rememberForTurnAllowed: true,
+          app: 'Example',
+          observationId: 'frame-1',
+        },
+      },
+    ];
+
+    for (const drift of cases) {
+      await t.test(drift.name, async () => {
+        const messages: StoredMessage[] = [];
+        const backend = new PiAgentBackend({
+          sessionId: 'session-1',
+          header: header({ permissionMode: 'ask' }),
+          appendMessage: async (message) => { messages.push(message); },
+          permissionEngine: new PermissionEngine({ newId: nextId('permission'), now: nextNow(4_300) }),
+          transport: frames([
+            {
+              type: 'permission_request',
+              toolUseId: 'tool-1',
+              toolName: drift.first.toolName,
+              args: drift.first.args,
+              categoryHint: drift.first.categoryHint,
+            },
+            {
+              type: 'tool_start',
+              toolUseId: 'tool-1',
+              toolName: drift.later.toolName,
+              args: drift.later.args,
+            },
+            { type: 'tool_result', toolUseId: 'tool-1', content: { kind: 'text', text: 'executed' } },
+            { type: 'complete' },
+          ]),
+          newId: nextId('id'),
+          now: nextNow(4_400),
+        });
+
+        const iterator = backend.send({ turnId: 'turn-1', text: 'run command', context: [] })[Symbol.asyncIterator]();
+        const permission = await iterator.next();
+        assert.equal(permission.value?.type, 'permission_request');
+        if (permission.value?.type !== 'permission_request') return;
+        await backend.respondToPermission({ requestId: permission.value.requestId, decision: 'allow' });
+
+        const remaining: SessionEvent[] = [];
+        for (;;) {
+          const next = await iterator.next();
+          if (next.done) break;
+          remaining.push(next.value);
+        }
+
+        assert.deepEqual(remaining.map((event) => event.type), [
+          'permission_decision_ack',
+          'error',
+          'complete',
+        ]);
+        assert.equal(remaining.some((event) => event.type === 'tool_start' || event.type === 'tool_result'), false);
+        const storedCall = messages.find((message) => message.type === 'tool_call');
+        assert.deepEqual(
+          storedCall?.type === 'tool_call' ? storedCall.args : undefined,
+          drift.expectedStoredArgs,
+        );
+        if (drift.first.categoryHint === 'computer_use') {
+          assert.doesNotMatch(JSON.stringify(messages), /first secret|10|20/);
+        }
+      });
+    }
+  });
+
+  test('fails closed on Pi frame drift after permission suppression', async (t) => {
+    const cases = [
+      {
+        name: 'policy block',
+        permissionMode: 'explore' as const,
+        expectedTypes: ['tool_result', 'error', 'complete'],
+      },
+      {
+        name: 'user denial',
+        permissionMode: 'ask' as const,
+        expectedTypes: ['permission_request', 'permission_decision_ack', 'tool_result', 'error', 'complete'],
+      },
+    ];
+
+    for (const scenario of cases) {
+      await t.test(scenario.name, async () => {
+        const backend = new PiAgentBackend({
+          sessionId: 'session-1',
+          header: header({ permissionMode: scenario.permissionMode }),
+          appendMessage: async () => {},
+          permissionEngine: new PermissionEngine({ newId: nextId('permission'), now: nextNow(4_500) }),
+          transport: frames([
+            {
+              type: 'permission_request',
+              toolUseId: 'tool-1',
+              toolName: 'Bash',
+              args: { command: 'printf approved' },
+              categoryHint: 'shell_unsafe',
+            },
+            { type: 'tool_start', toolUseId: 'tool-1', toolName: 'Bash', args: { command: 'printf changed' } },
+            { type: 'complete' },
+          ]),
+          newId: nextId('id'),
+          now: nextNow(4_600),
+        });
+
+        const iterator = backend.send({ turnId: 'turn-1', text: 'run command', context: [] })[Symbol.asyncIterator]();
+        const events: SessionEvent[] = [];
+        const first = await iterator.next();
+        if (!first.done) events.push(first.value);
+        if (first.value?.type === 'permission_request') {
+          await backend.respondToPermission({ requestId: first.value.requestId, decision: 'deny' });
+        }
+        for (;;) {
+          const next = await iterator.next();
+          if (next.done) break;
+          events.push(next.value);
+        }
+
+        assert.deepEqual(events.map((event) => event.type), scenario.expectedTypes);
+        assert.equal(events.some((event) => event.type === 'tool_start'), false);
+        const error = events.find((event) => event.type === 'error');
+        assert.equal(error?.type === 'error' ? error.reason : undefined, 'pi_agent_transport_error');
+      });
+    }
+  });
+
   test('preserves the computer_use category and redacts Computer Use permission args', async () => {
     const messages: StoredMessage[] = [];
     const backend = new PiAgentBackend({
@@ -547,4 +830,10 @@ function nextNow(start: number): () => number {
 
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function mutatePiArgs(value: unknown, owner: string): void {
+  const mutable = value as { command: string; options: { columns: number } };
+  mutable.command = owner;
+  mutable.options.columns = owner.length;
 }

--- a/packages/runtime/src/__tests__/tool-runtime-argument-ownership.test.ts
+++ b/packages/runtime/src/__tests__/tool-runtime-argument-ownership.test.ts
@@ -1,0 +1,160 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+import type { LlmConnection, SessionEvent, SessionHeader } from '@maka/core';
+
+import { PermissionEngine } from '../permission-engine.js';
+import { ToolRuntime, type MakaTool } from '../tool-runtime.js';
+
+interface InvocationArgs {
+  path: string;
+  content: string;
+  layout: {
+    cols: number;
+  };
+}
+
+describe('ToolRuntime argument ownership', () => {
+  test('keeps each runtime owner isolated from the canonical invocation', async () => {
+    const initialArgs: InvocationArgs = {
+      path: 'notes.md',
+      content: 'approved',
+      layout: { cols: 120 },
+    };
+    const providerArgs = structuredClone(initialArgs);
+    const observed = new Map<string, InvocationArgs>();
+    const permissionEngine = new PermissionEngine({ newId: nextId(), now: () => 1 });
+    permissionEngine.beginTurn('turn-1');
+
+    let resolvePermission!: (event: Extract<SessionEvent, { type: 'permission_request' }>) => void;
+    const permissionRequested = new Promise<Extract<SessionEvent, { type: 'permission_request' }>>((resolve) => {
+      resolvePermission = resolve;
+    });
+    const runtime = new ToolRuntime({
+      sessionId: 'session-1',
+      header: testHeader(),
+      connection: testConnection(),
+      modelId: 'test-model',
+      appendMessage: async (message) => {
+        if (message.type !== 'tool_call') return;
+        observeAndMutate(observed, 'storage', message.args);
+      },
+      permissionEngine,
+      newId: nextId(),
+      now: () => 1,
+      getPermissionPauseTarget: () => null,
+      recordToolArtifacts: (input) => {
+        observeAndMutate(observed, 'artifact', input.args);
+      },
+    });
+    const tool: MakaTool<InvocationArgs> = {
+      name: 'Write',
+      description: 'Write a file',
+      parameters: {},
+      permissionArgs: (args) => {
+        observeAndMutate(observed, 'permissionProjection', args);
+        return structuredClone(initialArgs);
+      },
+      sandbox: ({ args }) => {
+        observeAndMutate(observed, 'sandbox', args);
+        return { platformSandboxAvailable: false };
+      },
+      impl: async (args) => {
+        observeAndMutate(observed, 'implementation', args);
+        return { ok: true, path: '/tmp/maka/notes.md' };
+      },
+    };
+    const execute = runtime.wrapToolExecute(tool, 'turn-1', {
+      push: (event) => {
+        if (event.type === 'tool_start') {
+          observeAndMutate(observed, 'event', event.args);
+        } else if (event.type === 'permission_request') {
+          observed.set('permission', structuredClone(event.args) as InvocationArgs);
+          resolvePermission(event);
+        }
+      },
+    });
+
+    const pending = execute(providerArgs, {
+      toolCallId: 'tool-1',
+      abortSignal: new AbortController().signal,
+    });
+    mutateArgs(providerArgs, 'provider');
+    const request = await permissionRequested;
+    permissionEngine.recordResponse('turn-1', {
+      requestId: request.requestId,
+      decision: 'allow',
+    });
+
+    await pending;
+    permissionEngine.endTurn('turn-1');
+
+    const owners = [
+      'storage',
+      'event',
+      'permissionProjection',
+      'sandbox',
+      'permission',
+      'implementation',
+      'artifact',
+    ];
+    for (const owner of owners) {
+      assert.deepEqual(observed.get(owner), initialArgs);
+    }
+    assert.equal(providerArgs.content, 'provider');
+  });
+});
+
+function observeAndMutate(
+  observed: Map<string, InvocationArgs>,
+  owner: string,
+  value: unknown,
+): void {
+  observed.set(owner, structuredClone(value) as InvocationArgs);
+  mutateArgs(value, owner);
+}
+
+function mutateArgs(value: unknown, owner: string): void {
+  const mutable = value as InvocationArgs;
+  mutable.content = owner;
+  mutable.layout.cols = owner.length;
+}
+
+function testHeader(): SessionHeader {
+  return {
+    id: 'session-1',
+    workspaceRoot: '/tmp/maka',
+    cwd: '/tmp/maka',
+    createdAt: 1,
+    lastUsedAt: 1,
+    name: 'Test',
+    isFlagged: false,
+    labels: [],
+    isArchived: false,
+    status: 'active',
+    statusUpdatedAt: 1,
+    hasUnread: false,
+    backend: 'ai-sdk',
+    llmConnectionSlug: 'test',
+    connectionLocked: true,
+    model: 'test-model',
+    permissionMode: 'ask',
+    schemaVersion: 1,
+  };
+}
+
+function testConnection(): LlmConnection {
+  return {
+    slug: 'test',
+    name: 'Test',
+    providerType: 'anthropic',
+    defaultModel: 'test-model',
+    enabled: true,
+    createdAt: 1,
+    updatedAt: 1,
+  };
+}
+
+function nextId(): () => string {
+  let id = 0;
+  return () => `id-${++id}`;
+}

--- a/packages/runtime/src/ai-sdk-flow.ts
+++ b/packages/runtime/src/ai-sdk-flow.ts
@@ -187,7 +187,7 @@ export function mapSessionEventToRuntimeEvent(
           kind: 'function_call',
           id: event.toolUseId,
           name: event.toolName,
-          args: event.args,
+          args: structuredClone(event.args),
         },
         refs: {
           toolCallId: event.toolUseId,
@@ -256,7 +256,7 @@ export function mapSessionEventToRuntimeEvent(
             toolName: event.toolName,
             category: event.category,
             reason: event.reason,
-            args: event.args,
+            args: structuredClone(event.args),
             ...(event.hint !== undefined ? { hint: event.hint } : {}),
           },
         },

--- a/packages/runtime/src/pi-agent-backend.ts
+++ b/packages/runtime/src/pi-agent-backend.ts
@@ -1,3 +1,5 @@
+import { isDeepStrictEqual } from 'node:util';
+
 import type {
   BackendKind,
   PermissionDecisionMessage,
@@ -79,7 +81,7 @@ export class PiAgentBackend implements AgentBackend {
   private stopped = false;
   private currentTurnId: string | null = null;
   private outputSeqByTool = new Map<string, number>();
-  private writtenToolCalls = new Set<string>();
+  private toolCallsByUseId = new Map<string, { toolName: string; args: unknown }>();
   private suppressedToolUseIds = new Set<string>();
 
   constructor(input: PiAgentBackendInput) {
@@ -102,7 +104,7 @@ export class PiAgentBackend implements AgentBackend {
     this.stopped = false;
     this.currentTurnId = turnId;
     this.outputSeqByTool = new Map();
-    this.writtenToolCalls = new Set();
+    this.toolCallsByUseId = new Map();
     this.suppressedToolUseIds = new Set();
     this.input.permissionEngine.beginTurn(turnId);
 
@@ -189,12 +191,24 @@ export class PiAgentBackend implements AgentBackend {
             break;
           }
           case 'tool_start': {
-            if (this.suppressedToolUseIds.has(frame.toolUseId)) break;
-            await persistAssistant();
+            const frameArgs = structuredClone(frame.args);
+            const suppressed = this.suppressedToolUseIds.has(frame.toolUseId);
+            if (!suppressed) await persistAssistant();
+            const canonicalArgs = await this.ensureToolCall(
+              turnId,
+              frame.toolUseId,
+              frame.toolName,
+              frameArgs,
+              {
+                ...(frame.displayName ? { displayName: frame.displayName } : {}),
+                ...(frame.intent ? { intent: frame.intent } : {}),
+                stepId: messageId,
+              },
+            );
+            if (suppressed) break;
             stepHasTools = true;
             activeToolUseIds.add(frame.toolUseId);
-            const projectedArgs = projectPiToolArgs(frame.toolName, frame.args);
-            await this.ensureToolCall(turnId, frame.toolUseId, frame.toolName, projectedArgs, frame.displayName, frame.intent, messageId);
+            const projectedArgs = projectPiToolArgs(frame.toolName, canonicalArgs);
             yield {
               type: 'tool_start',
               id: this.newId(),
@@ -310,7 +324,7 @@ export class PiAgentBackend implements AgentBackend {
       this.input.permissionEngine.endTurn(turnId, this.stopped ? 'aborted' : 'completed');
       this.currentTurnId = null;
       this.outputSeqByTool.clear();
-      this.writtenToolCalls.clear();
+      this.toolCallsByUseId.clear();
       this.suppressedToolUseIds.clear();
       this.stopped = false;
     }
@@ -340,18 +354,20 @@ export class PiAgentBackend implements AgentBackend {
     turnId: string,
     frame: Extract<PiAgentFrame, { type: 'permission_request' }>,
   ): AsyncIterable<SessionEvent> {
-    const projectedArgs = projectPiToolArgs(
+    const frameArgs = structuredClone(frame.args);
+    const canonicalArgs = await this.ensureToolCall(
+      turnId,
+      frame.toolUseId,
       frame.toolName,
-      frame.args,
-      frame.categoryHint,
+      frameArgs,
+      frame.categoryHint ? { categoryHint: frame.categoryHint } : {},
     );
-    await this.ensureToolCall(turnId, frame.toolUseId, frame.toolName, projectedArgs);
     const verdict = this.input.permissionEngine.evaluate({
       sessionId: this.sessionId,
       turnId,
       toolUseId: frame.toolUseId,
       toolName: frame.toolName,
-      args: frame.args,
+      args: structuredClone(canonicalArgs),
       ...(frame.categoryHint ? { categoryHint: frame.categoryHint } : {}),
       mode: this.input.header.permissionMode,
       ...(frame.hint ? { hint: redactBoundedText(frame.hint, 240) } : {}),
@@ -416,23 +432,34 @@ export class PiAgentBackend implements AgentBackend {
     toolUseId: string,
     toolName: string,
     args: unknown,
-    displayName?: string,
-    intent?: string,
-    stepId?: string,
-  ): Promise<void> {
-    if (this.writtenToolCalls.has(toolUseId)) return;
-    this.writtenToolCalls.add(toolUseId);
+    metadata: {
+      categoryHint?: ToolCategory;
+      displayName?: string;
+      intent?: string;
+      stepId?: string;
+    } = {},
+  ): Promise<unknown> {
+    const existing = this.toolCallsByUseId.get(toolUseId);
+    if (existing) {
+      if (existing.toolName !== toolName || !isDeepStrictEqual(existing.args, args)) {
+        throw new Error(`Pi tool call ${toolUseId} changed after its first frame`);
+      }
+      return structuredClone(existing.args);
+    }
+    const snapshot = structuredClone(args);
+    this.toolCallsByUseId.set(toolUseId, { toolName, args: snapshot });
     await this.input.appendMessage({
       type: 'tool_call',
       id: toolUseId,
       turnId,
       ts: this.now(),
       toolName,
-      ...(displayName ? { displayName } : {}),
-      ...(intent ? { intent: redactBoundedText(intent, 240) } : {}),
-      args: redactUnknown(args),
-      ...(stepId ? { stepId } : {}),
+      ...(metadata.displayName ? { displayName: metadata.displayName } : {}),
+      ...(metadata.intent ? { intent: redactBoundedText(metadata.intent, 240) } : {}),
+      args: projectPiToolArgs(toolName, snapshot, metadata.categoryHint),
+      ...(metadata.stepId ? { stepId: metadata.stepId } : {}),
     } satisfies ToolCallMessage);
+    return structuredClone(snapshot);
   }
 
   private async appendAssistant(turnId: string, messageId: string, text: string): Promise<void> {
@@ -513,9 +540,10 @@ function projectPiToolArgs(
   args: unknown,
   categoryHint?: ToolCategory,
 ): unknown {
-  return categoryHint === 'computer_use' || toolName === 'maka_computer'
+  const projected = categoryHint === 'computer_use' || toolName === 'maka_computer'
     ? computerUseApprovalSummary(args)
     : redactUnknown(args);
+  return structuredClone(projected);
 }
 
 export function normalizePiAgentFrame(frame: unknown): PiAgentFrame | null {

--- a/packages/runtime/src/tool-runtime.ts
+++ b/packages/runtime/src/tool-runtime.ts
@@ -72,7 +72,7 @@ export interface MakaTool<P = any, R = unknown> {
   categoryHint?: ToolCategory;
   /** Optional trusted facts about the executor that runs this tool. */
   executionFacts?: ToolExecutionFacts;
-  /** Optional permission/persistence projection derived from frozen execution args. */
+  /** Optional permission/persistence projection derived from isolated execution args. */
   permissionArgs?: (
     args: P,
     context: Pick<MakaToolContext, 'sessionId' | 'turnId' | 'toolCallId'>,
@@ -326,14 +326,14 @@ export class ToolRuntime {
     const executionArgs = snapshotToolArgs(args);
     const toolUseId = ctx.toolCallId;
     const permissionArgs = tool.permissionArgs
-      ? snapshotToolArgs(tool.permissionArgs(executionArgs as never, {
+      ? snapshotToolArgs(tool.permissionArgs(structuredClone(executionArgs) as never, {
           sessionId: this.input.sessionId,
           turnId,
           toolCallId: toolUseId,
         }))
       : executionArgs;
     const persistedArgs = tool.categoryHint === 'computer_use'
-      ? computerUseApprovalSummary(permissionArgs)
+      ? snapshotToolArgs(computerUseApprovalSummary(permissionArgs))
       : permissionArgs;
     const now = this.input.now();
     const toolIntent = describeToolIntent(tool, persistedArgs);
@@ -349,7 +349,7 @@ export class ToolRuntime {
       ...(tool.activityKind ? { activityKind: tool.activityKind } : {}),
       ...(tool.displayName ? { displayName: tool.displayName } : {}),
       ...(toolIntent ? { intent: toolIntent } : {}),
-      args: persistedArgs,
+      args: structuredClone(persistedArgs),
       // Persist the same step id the tool_start event carries so the UI
       // timeline and post-restart backfill can pair this call with its step.
       ...(stepId !== undefined ? { stepId } : {}),
@@ -363,7 +363,7 @@ export class ToolRuntime {
       toolUseId,
       toolName: tool.name,
       ...(tool.activityKind ? { activityKind: tool.activityKind } : {}),
-      args: persistedArgs,
+      args: structuredClone(persistedArgs),
       ...(tool.displayName ? { displayName: tool.displayName } : {}),
       ...(toolIntent ? { intent: toolIntent } : {}),
       ...(stepId !== undefined ? { stepId } : {}),
@@ -451,7 +451,7 @@ export class ToolRuntime {
         turnId,
         toolUseId,
         toolName: tool.name,
-        args: permissionArgs,
+        args: structuredClone(permissionArgs),
         ...(tool.categoryHint !== undefined ? { categoryHint: tool.categoryHint } : {}),
         ...(tool.executionFacts !== undefined ? { executionFacts: tool.executionFacts } : {}),
         permissionRequired: tool.permissionRequired !== false,
@@ -461,7 +461,7 @@ export class ToolRuntime {
             ? tool.sandbox({
               permissionMode: this.input.header.permissionMode,
               cwd: this.input.header.cwd,
-              args: executionArgs,
+              args: structuredClone(executionArgs),
             })
             : tool.sandbox,
         } : {}),
@@ -618,7 +618,7 @@ export class ToolRuntime {
       pauseTarget?.pause();
       try {
         const runId = this.input.getCurrentRunId?.();
-        const result = await tool.impl(executionArgs as never, {
+        const result = await tool.impl(structuredClone(executionArgs) as never, {
           sessionId: this.input.sessionId,
           turnId,
           ...(runId ? { runId } : {}),
@@ -689,7 +689,7 @@ export class ToolRuntime {
             toolUseId,
             toolName: tool.name,
             cwd: this.input.header.cwd,
-            args: persistedArgs,
+            args: structuredClone(persistedArgs),
             result,
           },
           this.input.recordToolArtifacts,


### PR DESCRIPTION
<details open>
<summary><strong>English</strong></summary>

Follow-up to #856.

## Summary

- Give each tool invocation one private canonical argument snapshot before Runtime crosses any asynchronous ownership boundary.
- Pass independent copies to persistence, session events, permission evaluation, the sandbox resolver, tool execution, and asynchronous artifact recording.
- In the Pi backend, make the first accepted `permission_request` or `tool_start` frame authoritative for a `toolUseId`, and fail closed if a later frame changes the tool name or arguments.
- Snapshot each delivered Pi `tool_start` frame before awaiting assistant persistence, so transport-owned mutation cannot rewrite or conceal frame drift.

## Why

Tool arguments currently cross several independently owned and potentially asynchronous consumers. Sharing one mutable object lets an event listener, permission consumer, sandbox resolver, storage callback, or tool implementation change what another consumer observes or what eventually executes.

Pi has a related transport boundary: permission and start frames can describe the same call at different times. Without one canonical value per `toolUseId`, history, authorization, events, and execution can diverge even though they appear to refer to one invocation.

## Key decisions

| Decision | Rationale |
| --- | --- |
| Keep one private snapshot inside Runtime and copy only when ownership is transferred. | The execution fact has one source of truth without exposing a mutable shared reference or introducing a general immutability framework. |
| Treat Pi's first accepted frame as authoritative and deep-compare later frames. | Both valid frame orders work, while transport drift fails before execution instead of silently choosing a newer value. |
| Snapshot a Pi `tool_start` frame before the first asynchronous persistence boundary. | The transport still owns the delivered object; capturing it at ingress closes the aliasing window without changing durable message order. |
| Validate frames even when a call is already denied or policy-suppressed. | Suppression must not hide an inconsistent transport sequence; existing assistant/tool-call persistence order remains unchanged. |
| Keep canonical identity separate from owner-specific projections. | Permission, persistence, and events retain their existing shapes; ordinary Pi history/events stay redacted and Computer Use stays summarized, while no projected value can mutate the private invocation snapshot. |

## Scope

Included:

- AI SDK Runtime argument ownership
- Pi first-frame canonicalization and repeated-frame consistency
- Ownership isolation for the sandbox resolver added on the current Runtime path
- Behavioral coverage that mutates each external copy and verifies execution remains canonical

Not included:

- Permission request shape or policy changes
- TUI permission queue behavior
- `WriteStdin` inspection, turn-memory, or runtime-resource contract changes
- A deep-freeze wrapper, immutable data framework, or second payload

## Verification

- Root `npm run build` and `npm run typecheck` passed.
- Runtime passed 1,555 tests with 7 existing platform skips.
- `git diff --check upstream/main...HEAD` passed.

No visual evidence is applicable because this change has no intended UI or interaction change.

## Impact

Tool providers and Runtime consumers receive ordinary mutable values, but mutations are now local to that owner. Existing redaction and approval-summary projections are unchanged; persisted history, permission facts, renderer events, sandbox decisions, and execution can no longer rewrite one another through shared references.

There is no schema migration, compatibility layer, dependency change, documentation requirement, or release-note impact.

## Reviewer notes

The highest-value review boundaries are:

1. `tool-runtime.ts`: where the private snapshot is created and where ownership is transferred.
2. `pi-agent-backend.ts`: first-frame authority, suppressed calls, and persistence ordering.
3. `ai-sdk-flow.ts`: transferring projected session-event arguments into independently owned Runtime events.

## Ready for review

- [x] Verification is complete and the results above are current
- [x] Impact, migration, documentation, and release-note needs are addressed
- [x] Visual evidence is not applicable and the reason is stated

</details>

<details>
<summary><strong>简体中文</strong></summary>

#856 的后续改进。

## 摘要

- 在 Runtime 跨越任何异步所有权边界前，为每次工具调用建立一份不外借的 canonical 参数快照。
- 分别向持久化、session event、权限评估、sandbox resolver、工具执行和异步 artifact recording 交付独立副本。
- 在 Pi backend 中，让某个 `toolUseId` 首个被接受的 `permission_request` 或 `tool_start` 帧成为权威值；后续帧若改变工具名或参数则 fail closed。
- 在等待 assistant 持久化前快照每个已交付的 Pi `tool_start` 帧，避免 transport 持有的对象被修改后改写首帧或掩盖帧漂移。

## 原因

工具参数会跨越多个彼此独立、且可能异步运行的消费者。共享同一个可写对象后，event listener、权限消费者、sandbox resolver、存储回调或工具实现都可能改变其它消费者看到的值，甚至改变最终执行内容。

Pi 还有一层对应的 transport 边界：permission 与 start 帧可能在不同时间描述同一调用。如果没有按 `toolUseId` 唯一确定的 canonical 值，历史、授权、事件与执行可能发生漂移，尽管它们表面上都指向同一次调用。

## 关键决策

| 决策 | 理由 |
| --- | --- |
| Runtime 内部只保留一份私有快照，仅在转移所有权时复制。 | 让执行事实只有一个来源，同时不暴露共享可写引用，也不引入通用 immutable 框架。 |
| 以 Pi 首个被接受的帧为权威，并深度比较后续帧。 | 两种合法帧顺序都能工作；transport 漂移会在执行前失败，而不是静默选择较新的值。 |
| 在首次异步持久化边界前快照 Pi `tool_start` 帧。 | Transport 仍持有已交付的对象；在入口捕获它可以关闭别名窗口，同时不改变 durable message 顺序。 |
| 即使调用已被拒绝或被 policy 抑制，也必须验证后续帧。 | Suppression 不能掩盖不一致的 transport 序列；现有 assistant/tool-call 持久化顺序保持不变。 |
| 将 canonical identity 与各所有者所需的 projection 分离。 | 权限、持久化与事件保留既有 shape；普通 Pi history/event 继续脱敏，Computer Use 继续使用摘要，同时任何 projection 都无法修改私有调用快照。 |

## 范围

包含：

- AI SDK Runtime 参数所有权
- Pi 首帧 canonicalization 与重复帧一致性
- 当前 Runtime 路径新增 sandbox resolver 的参数所有权隔离
- 主动修改每个外部副本、并验证执行仍保持 canonical 的行为测试

不包含：

- 权限请求 shape 或 policy 变更
- TUI permission queue 行为
- `WriteStdin` 检查、turn memory 或 runtime-resource 契约变更
- Deep-freeze wrapper、immutable data framework 或第二套 payload

## 验证

- 根级 `npm run build` 与 `npm run typecheck` 通过。
- Runtime 1,555 项测试通过，并保留 7 项既有平台 skip。
- `git diff --check upstream/main...HEAD` 通过。

本次没有预期的 UI 或交互变化，因此不适用视觉证据。

## 影响

工具 provider 与 Runtime 消费者仍会收到普通可写值，但任何修改只影响该所有者。既有脱敏与 approval-summary projection 保持不变；持久化历史、权限事实、renderer event、sandbox 决策和执行不再能通过共享引用相互改写。

本次没有 schema migration、兼容层、依赖变更、文档要求或 release-note 影响。

## 审查重点

最值得审查的边界是：

1. `tool-runtime.ts`：私有快照的建立位置和所有权转移位置。
2. `pi-agent-backend.ts`：首帧权威、suppressed call 与持久化顺序。
3. `ai-sdk-flow.ts`：把经过 projection 的 session-event 参数转移给独立所有的 Runtime event。

## 可供审查

- [x] 验证已经完成，以上结果均为当前结果
- [x] 影响、迁移、文档与 release-note 需求均已说明
- [x] 已说明不适用视觉证据的原因

</details>
