### PR TITLE
fix(tui): queue concurrent permission requests

### DIFF
--- a/packages/cli/src/__tests__/pi-transcript.test.ts
+++ b/packages/cli/src/__tests__/pi-transcript.test.ts
@@ -190,12 +190,18 @@ describe('Maka Pi TUI transcript', () => {
     const state = createMakaPiTranscriptState();
     const driver = {
       async *sendPrompt(): AsyncIterable<SessionEvent> {
+        yield event({
+          type: 'permission_request', requestId: 'permission-1', toolUseId: 'tool-1',
+          toolName: 'Bash', category: 'shell_unsafe', reason: 'shell_dangerous', args: {},
+        });
         throw new Error('network down');
       },
     };
     const outcome = await submitPromptToTranscript({ state, driver, prompt: 'hi' });
     assert.equal(outcome.errored, true);
     assert.equal(outcome.aborted, false);
+    assert.equal(state.pendingInteraction, undefined);
+    assert.deepEqual(state.queuedInteractions, []);
   });
 
   test('reports completed manual compact runs when there was nothing to compact', async () => {
@@ -679,6 +685,77 @@ describe('Maka Pi TUI transcript', () => {
 
     applyMakaSessionEventToTranscript(state, event({
       type: 'permission_decision_ack', requestId: 'permission-1', toolUseId: 'tool-1', decision: 'allow',
+    }));
+    assert.equal(state.pendingInteraction?.requestId, 'question-1');
+    assert.deepEqual(state.queuedInteractions, []);
+  });
+
+  test('deduplicates interactions and expires permissions by their lifecycle ids', () => {
+    const state = createMakaPiTranscriptState();
+    const first = event({
+      type: 'permission_request', requestId: 'permission-1', toolUseId: 'tool-1',
+      toolName: 'Bash', category: 'shell_unsafe', reason: 'shell_dangerous',
+      args: { command: 'printf first' },
+    });
+    const question = event({
+      type: 'user_question_request', requestId: 'question-1', toolUseId: 'question-tool',
+      questions: [{ question: 'Choose', options: [{ label: 'A' }, { label: 'B' }] }],
+    });
+    const second = event({
+      type: 'permission_request', requestId: 'permission-2', toolUseId: 'tool-2',
+      toolName: 'Bash', category: 'shell_unsafe', reason: 'shell_dangerous',
+      args: { command: 'printf second' },
+    });
+    const third = event({
+      type: 'permission_request', requestId: 'permission-3', toolUseId: 'tool-3',
+      toolName: 'Bash', category: 'shell_unsafe', reason: 'shell_dangerous',
+      args: { command: 'printf third' },
+    });
+
+    applyMakaSessionEventToTranscript(state, first);
+    applyMakaSessionEventToTranscript(state, question);
+    applyMakaSessionEventToTranscript(state, second);
+    applyMakaSessionEventToTranscript(state, third);
+    applyMakaSessionEventToTranscript(state, event({
+      ...first,
+      id: 'permission-request-replay',
+      args: { command: 'printf replayed-first' },
+    }));
+
+    assert.equal(state.pendingInteraction?.requestId, 'permission-1');
+    assert.deepEqual(
+      state.pendingInteraction?.type === 'permission_request'
+        ? state.pendingInteraction.args
+        : undefined,
+      { command: 'printf first' },
+    );
+    assert.deepEqual(state.queuedInteractions.map((item) => item.requestId), [
+      'question-1',
+      'permission-2',
+      'permission-3',
+    ]);
+
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'permission_decision_ack', requestId: 'permission-3', toolUseId: 'tool-3', decision: 'deny',
+    }));
+    assert.deepEqual(state.queuedInteractions.map((item) => item.requestId), [
+      'question-1',
+      'permission-2',
+    ]);
+
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_result', toolUseId: 'tool-2', isError: true,
+      content: { kind: 'text', text: 'permission expired' },
+    }));
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_result', toolUseId: 'unrelated-tool', isError: false,
+      content: { kind: 'text', text: 'ok' },
+    }));
+    assert.deepEqual(state.queuedInteractions.map((item) => item.requestId), ['question-1']);
+
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_result', toolUseId: 'tool-1', isError: true,
+      content: { kind: 'text', text: 'permission expired' },
     }));
     assert.equal(state.pendingInteraction?.requestId, 'question-1');
     assert.deepEqual(state.queuedInteractions, []);

--- a/packages/cli/src/__tests__/pi-tui-runner.test.ts
+++ b/packages/cli/src/__tests__/pi-tui-runner.test.ts
@@ -281,6 +281,64 @@ describe('Maka Pi TUI runner', () => {
     ]);
   });
 
+  test('waits for permission acknowledgement before advancing concurrent requests', async () => {
+    const terminal = new FakeTerminal();
+    let releaseFirstAck!: () => void;
+    const firstAck = new Promise<void>((resolve) => {
+      releaseFirstAck = resolve;
+    });
+    const driver = new PermissionPromptDriver(
+      ['printf first', 'printf second'],
+      async (index) => {
+        if (index === 0) await firstAck;
+      },
+    );
+    const run = runMakaPiTui({
+      title: 'Maka',
+      driver,
+      cwd: '/repo',
+      model: 'claude-sonnet-4-5',
+      connectionSlug: 'claude-subscription',
+      permissionMode: 'ask',
+      terminal,
+    });
+
+    terminal.input('r');
+    terminal.input('u');
+    terminal.input('n');
+    terminal.input('\r');
+
+    await waitFor(() => driver.permissionRequests === 2);
+    await waitFor(() => plainTerminalOutput(terminal.screenOutput()).includes('printf first'));
+    assert.doesNotMatch(plainTerminalOutput(terminal.screenOutput()), /printf second/);
+
+    terminal.input('n');
+    await waitFor(() => driver.permissionResponses.length === 1);
+    terminal.input('y');
+    await delay(0);
+    assert.equal(driver.permissionResponses.length, 1);
+    assert.match(plainTerminalOutput(terminal.screenOutput()), /printf first/);
+    assert.doesNotMatch(plainTerminalOutput(terminal.screenOutput()), /printf second/);
+
+    releaseFirstAck();
+    await waitFor(() => plainTerminalOutput(terminal.screenOutput()).includes('printf second'));
+
+    terminal.input('y');
+    await waitFor(() => driver.permissionResponses.length === 2);
+    assert.deepEqual(driver.permissionResponses, [
+      { requestId: 'permission-1', decision: 'deny' },
+      { requestId: 'permission-2', decision: 'allow', rememberForTurn: false },
+    ]);
+
+    exitMaka(terminal);
+    await Promise.race([
+      run,
+      delay(50).then(() => {
+        throw new Error('TUI did not close during test cleanup');
+      }),
+    ]);
+  });
+
   test('answers sequential questions with a choice, Escape, and Other input', async () => {
     const terminal = new FakeTerminal();
     const driver = new UserQuestionPromptDriver();
@@ -2969,7 +3027,12 @@ class PermissionPromptDriver implements MakaSessionDriver {
   readonly permissionResponses: PermissionResponse[] = [];
   permissionRequests = 0;
   stopCalls = 0;
-  private continueAfterPermission: (() => void) | null = null;
+  private permissionResponseWaiter: (() => void) | null = null;
+
+  constructor(
+    private readonly commands: readonly string[] = ['npm test'],
+    private readonly beforePermissionAck: (index: number) => Promise<void> = async () => {},
+  ) {}
 
   async listSessions(): Promise<SessionSummary[]> {
     return [];
@@ -2978,38 +3041,48 @@ class PermissionPromptDriver implements MakaSessionDriver {
   async *compactSession(): AsyncIterable<never> {}
 
   async *sendPrompt(_prompt: string): AsyncIterable<SessionEvent> {
-    this.permissionRequests += 1;
-    yield {
-      type: 'permission_request',
-      id: 'event-permission',
-      turnId: 'turn-1',
-      ts: 1,
-      requestId: 'permission-1',
-      toolUseId: 'tool-1',
-      toolName: 'Bash',
-      category: 'shell_unsafe',
-      reason: 'shell_dangerous',
-      args: { command: 'npm test' },
-      rememberForTurnAllowed: true,
-    };
-    await new Promise<void>((resolve) => {
-      this.continueAfterPermission = resolve;
-    });
-    yield {
-      type: 'permission_decision_ack',
-      id: 'event-decision',
-      turnId: 'turn-1',
-      ts: 2,
-      requestId: 'permission-1',
-      toolUseId: 'tool-1',
-      decision: 'allow',
-      rememberForTurn: true,
-    };
+    for (const [index, command] of this.commands.entries()) {
+      this.permissionRequests += 1;
+      yield {
+        type: 'permission_request',
+        id: `event-permission-${index + 1}`,
+        turnId: 'turn-1',
+        ts: index + 1,
+        requestId: `permission-${index + 1}`,
+        toolUseId: `tool-${index + 1}`,
+        toolName: 'Bash',
+        category: 'shell_unsafe',
+        reason: 'shell_dangerous',
+        args: { command },
+        rememberForTurnAllowed: true,
+      };
+    }
+    for (const index of this.commands.keys()) {
+      while (this.permissionResponses.length <= index) {
+        await new Promise<void>((resolve) => {
+          this.permissionResponseWaiter = resolve;
+        });
+      }
+      const response = this.permissionResponses[index]!;
+      await this.beforePermissionAck(index);
+      yield {
+        type: 'permission_decision_ack',
+        id: `event-decision-${index + 1}`,
+        turnId: 'turn-1',
+        ts: this.commands.length + index + 1,
+        requestId: response.requestId,
+        toolUseId: `tool-${index + 1}`,
+        decision: response.decision,
+        ...(response.rememberForTurn !== undefined
+          ? { rememberForTurn: response.rememberForTurn }
+          : {}),
+      };
+    }
     yield {
       type: 'complete',
       id: 'event-complete',
       turnId: 'turn-1',
-      ts: 3,
+      ts: this.commands.length * 2 + 1,
       stopReason: 'end_turn',
     };
   }
@@ -3020,7 +3093,9 @@ class PermissionPromptDriver implements MakaSessionDriver {
 
   async respondToPermission(response: PermissionResponse): Promise<void> {
     this.permissionResponses.push(response);
-    this.continueAfterPermission?.();
+    const waiter = this.permissionResponseWaiter;
+    this.permissionResponseWaiter = null;
+    waiter?.();
   }
   async renameSession(): Promise<void> {}
   async setModel(): Promise<void> {}

--- a/packages/cli/src/pi-transcript.ts
+++ b/packages/cli/src/pi-transcript.ts
@@ -235,6 +235,7 @@ export async function submitPromptToTranscript(input: {
     }
   } catch (error) {
     errored = true;
+    clearPendingInteractions(input.state);
     input.state.entries.push({
       kind: 'notice',
       level: 'error',
@@ -317,6 +318,7 @@ export function applyMakaSessionEventToTranscript(
       break;
 
     case 'tool_result': {
+      completePendingPermissionsForToolUseId(state, event.toolUseId);
       const tool = findToolEntry(state, event.toolUseId);
       const shellRun = event.content.kind === 'shell_run' ? event.content : undefined;
       const parent = shellRun
@@ -725,8 +727,23 @@ function enqueuePendingInteraction(
   state: MakaPiTranscriptState,
   request: MakaPiPendingInteraction,
 ): void {
+  if (findPendingInteraction(state, request.requestId)) return;
   if (!state.pendingInteraction) state.pendingInteraction = request;
   else state.queuedInteractions.push(request);
+}
+
+function completePendingPermissionsForToolUseId(
+  state: MakaPiTranscriptState,
+  toolUseId: string,
+): void {
+  const requestIds = [state.pendingInteraction, ...state.queuedInteractions]
+    .filter(
+      (request): request is PermissionRequestEvent => (
+        request?.type === 'permission_request' && request.toolUseId === toolUseId
+      ),
+    )
+    .map((request) => request.requestId);
+  for (const requestId of requestIds) completePendingInteraction(state, requestId);
 }
 
 function findPendingInteraction(

--- a/packages/cli/src/pi-tui-runner.ts
+++ b/packages/cli/src/pi-tui-runner.ts
@@ -114,7 +114,7 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
     : [];
   let busy = false;
   let closed = false;
-  let permissionInFlight = false;
+  let permissionResponseInFlightRequestId: string | null = null;
   let userQuestionInFlight = false;
   let userQuestionOverlay: OverlayHandle | undefined;
   let userQuestionProgress: {
@@ -356,32 +356,20 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
     rememberForTurn = false,
   ): boolean => {
     const request = activePermissionRequest(state);
-    if (!request || permissionInFlight) return false;
-    permissionInFlight = true;
+    if (!request || permissionResponseInFlightRequestId !== null) return false;
+    permissionResponseInFlightRequestId = request.requestId;
     // Keep the prompt visible until the driver accepts the response. If it
-    // rejects, the user can retry with y/n instead of being stuck.
+    // rejects, the user can retry with y/n instead of being stuck. A resolved
+    // call only means the response was submitted; the event stream owns dequeue.
     void input.driver.respondToPermission({
       requestId: request.requestId,
       decision,
       ...(decision === 'allow' ? { rememberForTurn } : {}),
     })
-      .then(() => {
-        permissionInFlight = false;
-        // The turn may have ended (error/abort/complete) and cleared the pending
-        // prompt while this response was in flight; only record success if the
-        // request is still the active one.
-        if (activePermissionRequest(state)?.requestId !== request.requestId) return;
-        completePendingInteraction(state, request.requestId);
-        state.entries.push({
-          kind: 'notice',
-          level: 'info',
-          text: `Permission ${decision}ed for ${request.toolName}`,
-        });
-        requestRender();
-        syncUserQuestionOverlay();
-      })
       .catch((error) => {
-        permissionInFlight = false;
+        if (permissionResponseInFlightRequestId === request.requestId) {
+          permissionResponseInFlightRequestId = null;
+        }
         reportError(error);
       });
     return true;
@@ -428,6 +416,12 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
       // ran — a quick failure in a background tab would otherwise stay silent.
       onError: () => attention.attentionNeeded(),
       onChange: () => {
+        if (
+          permissionResponseInFlightRequestId !== null
+          && activePermissionRequest(state)?.requestId !== permissionResponseInFlightRequestId
+        ) {
+          permissionResponseInFlightRequestId = null;
+        }
         // A pending decision blocks the turn; ring an unfocused terminal once when
         // the prompt first appears (not on every render) so the user is not left
         // waiting on a prompt they cannot see.


### PR DESCRIPTION
<details open>
<summary><strong>English</strong></summary>

Follow-up to #856.

## Summary

- Harden the TUI's shared pending-interaction FIFO so concurrent permission requests are retained and duplicate transport events are ignored.
- Keep only the queue head actionable and visible, while preserving the existing shared queue and overlay behavior for `AskUserQuestion`.
- Let `permission_decision_ack`, a matching terminal `tool_result`, or turn termination advance permission state; completing `respondToPermission()` alone does not.

## Why

Runtime may park more than one tool call at the permission boundary. The shared interaction queue provides the right common structure for permission requests and user questions, but permission lifecycle edges still need precise identity and terminal cleanup so overlapping or replayed events cannot lose or duplicate an actionable request.

The response API has a second timing boundary: its Promise confirms that a response was submitted, not that Runtime has committed the decision. Advancing locally at that point can expose a stale sibling request that Runtime already resolved through turn memory. The event stream is the authoritative lifecycle source for both cases.

## Key decisions

| Decision | Rationale |
| --- | --- |
| Keep permission requests in the existing generic interaction FIFO and deduplicate by `requestId`. | Every distinct request remains actionable, replayed transport frames do not create duplicate prompts, and `AskUserQuestion` does not need a parallel queue. |
| Render and accept input for the head only. | The existing interaction stays simple and deterministic; this is a correctness fix rather than a queue-management UI. |
| Remove acknowledgements by `requestId`, including out of order. | Runtime events identify the request whose lifecycle changed; local head assumptions cannot override that fact. |
| Remove terminal tool results by `toolUseId`. | Timeout or expiry paths can finish without a separate permission acknowledgement. |
| Keep a submitted response in flight until an authoritative event removes that request. | Repeated keys cannot submit twice or answer the next request before Runtime has advanced. A rejected submission leaves the head visible for retry. |
| Clear the queue on error, abort, complete, thrown stream failure, or session replacement. | Requests from a finished or replaced event stream are no longer actionable. |

## Scope

Included:

- Generic TUI interaction state as it applies to permission handling
- Interleaving permission requests with the existing `AskUserQuestion` interaction
- Duplicate, overlapping, and out-of-order permission events
- Missing-ack terminal cleanup and abnormal stream cleanup
- Deterministic TUI coverage with response completion separated from acknowledgement

Not included:

- Desktop queue changes
- A visible pending-request list or queue controls
- Permission policy, turn-memory capability, or request-schema changes
- `WriteStdin`-specific behavior, inspection UI, or runtime contracts

## Verification

- Root `npm run typecheck`, `npm test`, and `npm run build` passed.
- GitHub CI passed typecheck, test, and e2e on the rebased head.
- `git diff --check upstream/main...HEAD` passed.

No visual artifact is included because the existing prompt layout is unchanged; the user-visible difference occurs only when permission events overlap, and that lifecycle is covered through the real TUI runner surface.

## Impact

Concurrent TUI permission requests can no longer disappear, duplicate, or be answered before Runtime advances them. Ordinary single-request prompts retain the same keys and presentation, and user-question interactions continue through the same generic queue.

There is no schema migration, dependency change, compatibility layer, documentation requirement, or release-note impact.

## Reviewer notes

The highest-value review boundaries are:

1. `pi-transcript.ts`: shared interaction identity, permission-specific terminal cleanup, and duplicate suppression.
2. `pi-tui-runner.ts`: response in-flight state versus authoritative event-driven dequeue.
3. The parallel-permission runner test: a resolved response Promise is deliberately separated from its delayed acknowledgement.

## Ready for review

- [x] Verification is complete and the results above are current
- [x] Impact, migration, documentation, and release-note needs are addressed
- [x] Visual evidence is not applicable and the reason is stated

</details>

<details>
<summary><strong>简体中文</strong></summary>

#856 的后续改进。

## 摘要

- 加固 TUI 既有的共享 pending-interaction FIFO，确保并发 permission request 都会保留，并忽略重复 transport event。
- 仍然只让队首可操作、可见，同时保留 `AskUserQuestion` 既有的共享队列与 overlay 行为。
- 只有 `permission_decision_ack`、匹配的 terminal `tool_result` 或 turn 终止才能推进 permission 状态；`respondToPermission()` 自身完成不能推进。

## 原因

Runtime 可能在权限边界同时 park 多个工具调用。共享 interaction queue 是 permission request 与 user question 的正确通用结构，但 permission 生命周期边界仍需精确的身份与 terminal cleanup，避免重叠或重放事件丢失请求或制造重复的可操作项。

Response API 还有第二个时序边界：它的 Promise 只确认响应已经提交，并不代表 Runtime 已经提交决策。如果此时由本地提前推进，TUI 可能展示一条已被 Runtime 通过 turn memory 自动处理的 stale sibling request。两种情况下都应以 event stream 作为权威生命周期来源。

## 关键决策

| 决策 | 理由 |
| --- | --- |
| 将 permission request 保留在既有通用 interaction FIFO 中，并按 `requestId` 去重。 | 每个不同请求都保持可操作，重放的 transport frame 不会产生重复提示，`AskUserQuestion` 也不需要另一套队列。 |
| 只渲染队首，也只接受针对队首的输入。 | 保持现有交互简单、确定；本次是正确性修复，不是 queue-management UI。 |
| 按 `requestId` 删除 ack，包括乱序 ack。 | Runtime event 已明确指出哪个请求的生命周期发生变化，本地不能用队首假设覆盖该事实。 |
| 按 `toolUseId` 删除 terminal tool result。 | Timeout 或 expiry 路径可能结束而不再产生单独的 permission ack。 |
| 已提交响应保持 in-flight，直到权威事件删除该请求。 | 连续按键不能重复提交，也不能在 Runtime 推进前回答下一项；提交被拒绝时队首仍可见并允许重试。 |
| Error、abort、complete、stream 直接抛错或 session replacement 时清空队列。 | 已结束或被替换的 event stream 中的请求不再可操作。 |

## 范围

包含：

- 通用 TUI interaction state 中与 permission handling 相关的部分
- Permission request 与既有 `AskUserQuestion` interaction 的交错
- 重复、重叠和乱序 permission event
- 缺少 ack 时的 terminal cleanup 与异常 stream cleanup
- 将 response 完成与 acknowledgement 分离的确定性 TUI 覆盖

不包含：

- Desktop queue 变更
- 可见 pending-request 列表或队列控制
- Permission policy、turn-memory capability 或 request schema 变更
- `WriteStdin` 专用行为、检查 UI 或 runtime contract

## 验证

- 根级 `npm run typecheck`、`npm test` 与 `npm run build` 通过。
- Rebase 后 head 的 GitHub CI typecheck、test 与 e2e 均通过。
- `git diff --check upstream/main...HEAD` 通过。

现有 permission prompt 布局没有变化，因此不附视觉 artifact；用户可见差异只发生在 permission event 重叠时，该生命周期已通过真实 TUI runner surface 覆盖。

## 影响

并发 TUI permission request 不再丢失、重复，也不能在 Runtime 推进前被提前回答。普通单请求 prompt 的按键和展示保持不变，user-question interaction 继续使用同一通用队列。

本次没有 schema migration、依赖变更、兼容层、文档要求或 release-note 影响。

## 审查重点

最值得审查的边界是：

1. `pi-transcript.ts`：共享 interaction 身份、permission 专用 terminal cleanup 与重复抑制。
2. `pi-tui-runner.ts`：response in-flight 状态与由权威事件驱动的出队。
3. 并行 permission runner 测试：已完成的 response Promise 会与延迟 ack 被刻意分开。

## 可供审查

- [x] 验证已经完成，以上结果均为当前结果
- [x] 影响、迁移、文档与 release-note 需求均已说明
- [x] 已说明不适用视觉证据的原因

</details>
