### PR TITLE
build(cu): pin cua-driver artifact integrity

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ skills-lock.json
 # The committed baseline lives in `apps/desktop/tests/screenshots-baseline/`.
 apps/desktop/tests/screenshots/
 deepseek.key
+
+# Generated cua-driver release artifact; provenance metadata stays tracked.
+apps/desktop/resources/bin/

--- a/apps/desktop/bundled-tools.json
+++ b/apps/desktop/bundled-tools.json
@@ -8,5 +8,34 @@
       "win32-arm64": "officecli-win-arm64.exe",
       "win32-x64": "officecli-win-x64.exe"
     }
+  },
+  "cuaDriver": {
+    "repo": "hqhq1025/cua",
+    "version": "v0.7.1-maka.2",
+    "expectedVersion": "0.7.1",
+    "expectedProtocolVersion": "2025-06-18",
+    "tag": "cua-driver-rs-v0.7.1-maka.2",
+    "asset": "cua-driver-rs-0.7.1-maka.2-darwin-universal-binary.tar.gz",
+    "binaryName": "cua-driver",
+    "sourceCommit": "35fa565846ec60747603fa3e7b94160f796c5ecf",
+    "upstreamTag": "cua-driver-rs-v0.7.1",
+    "upstreamCommit": "8c921b2b3bf13494724ead4f0a814d80c56a7e8b",
+    "upstreamMergeCommit": "fb5bc192a5311d0519447f1d301bdf0b0c93bbb0",
+    "patchPullRequest": "https://github.com/trycua/cua/pull/2166",
+    "cargoLockSha256": "87c1fe447c7d5b26f987fe3b91975fb3516013329c7cc0341b8b43e800123a1d",
+    "architectures": [
+      "arm64",
+      "x86_64"
+    ],
+    "signature": "adhoc",
+    "archiveSha256": "c15e65138200cac5a03d013c455201bcfae2b9a7fb16be7c9d332e595481862c",
+    "binarySha256": "683dad5cccb47dd0a8bb5d534d62fbb9e6edfb1cded232509cf4c2b190066040",
+    "licenseSha256": "c0779290c1d4783169aa3dbfb55feb505e563ef8a004bbf55298ceffcfbda8d9",
+    "sourceSha256": "8a9124055ed9a6473c8243325ccabb2c2d93dad3acab680488eb0e6af1dcfa13",
+    "buildProvenance": "unverified",
+    "artifactAttestation": "missing",
+    "thirdPartyNotices": "missing",
+    "notarization": "missing",
+    "distributionReady": false
   }
 }

--- a/apps/desktop/resources/licenses/cua-driver/LICENSE.md
+++ b/apps/desktop/resources/licenses/cua-driver/LICENSE.md
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Cua AI, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/apps/desktop/resources/licenses/cua-driver/SOURCE.json
+++ b/apps/desktop/resources/licenses/cua-driver/SOURCE.json
@@ -1,0 +1,16 @@
+{
+  "schemaVersion": 1,
+  "repository": "hqhq1025/cua",
+  "upstreamRepository": "trycua/cua",
+  "upstreamTag": "cua-driver-rs-v0.7.1",
+  "upstreamCommit": "8c921b2b3bf13494724ead4f0a814d80c56a7e8b",
+  "sourceCommit": "35fa565846ec60747603fa3e7b94160f796c5ecf",
+  "patchPullRequest": "https://github.com/trycua/cua/pull/2166",
+  "cargoLockSha256": "87c1fe447c7d5b26f987fe3b91975fb3516013329c7cc0341b8b43e800123a1d",
+  "rustc": "rustc 1.92.0 (ded5c06cf 2025-12-08)",
+  "architectures": [
+    "arm64",
+    "x86_64"
+  ],
+  "signature": "adhoc"
+}

--- a/docs/cua-driver-artifact-integrity.md
+++ b/docs/cua-driver-artifact-integrity.md
@@ -1,0 +1,25 @@
+# cua-driver Artifact Integrity Boundary
+
+This repository pins one macOS universal cua-driver compatibility artifact by
+release URL and SHA-256. The preparation and check scripts prove:
+
+- the downloaded archive bytes match the committed archive hash;
+- the extracted Mach-O bytes match a separately committed binary hash;
+- the binary reports the expected version and contains arm64 and x86_64;
+- the current code signature is structurally valid;
+- the tracked top-level license and source-claim files match their committed hashes;
+- archive paths and entry types are checked before extraction.
+
+They do not prove:
+
+- that the binary was reproducibly built from `sourceCommit` or `Cargo.lock`;
+- that the source commit or release asset has a trusted signature/attestation;
+- complete third-party dependency license notices or an SBOM;
+- Developer ID nested signing, notarization, stapling, Gatekeeper acceptance,
+  or the final packaged Maka.app responsibility chain.
+
+Accordingly, `check:cua-driver-artifact` is an integrity check for local
+development and pre-package inputs. It is intentionally not part of
+`check:release`. The manifest keeps `distributionReady: false` until a later
+release-pipeline change supplies verified build provenance, third-party
+notices, Developer ID signing, notarization, and packaged-app smoke evidence.

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "typecheck": "npm run typecheck --workspaces --if-present",
     "test": "npm run test:scripts && npm --workspace @maka/core test && npm --workspace @maka/storage test && npm --workspace @maka/runtime test && npm --workspace @maka/computer-use test && npm --workspace @maka/headless test && npm --workspace maka-agent test && npm --workspace @maka/ui test && npm --workspace @maka/desktop test",
     "test:dist": "npm run test:scripts && npm exec -w @maka/core -- node --test \"dist/**/*.test.js\" && npm exec -w @maka/storage -- node --test \"dist/**/*.test.js\" && npm exec -w @maka/runtime -- node --test \"dist/**/*.test.js\" && npm exec -w @maka/computer-use -- node --test \"dist/**/*.test.js\" && npm exec -w @maka/headless -- node ../../scripts/run-headless-tests.mjs && npm exec -w maka-agent -- node --test \"dist/**/*.test.js\" && npm exec -w @maka/ui -- node --test \"dist/**/*.test.js\" && npm --workspace @maka/desktop run test:dist",
-    "test:scripts": "node --test scripts/run-headless-tests.test.mjs scripts/sync-model-metadata.test.mjs",
+    "test:scripts": "node --test scripts/run-headless-tests.test.mjs scripts/sync-model-metadata.test.mjs scripts/cua-driver-provenance.test.mjs",
     "dev": "npm --workspace @maka/desktop run dev:hmr --",
     "dev:full": "npm run build && npm --workspace @maka/desktop run start",
     "build": "npm --workspace @maka/core run build && npm --workspace @maka/storage run build && npm --workspace @maka/runtime run build && npm --workspace @maka/computer-use run build && npm --workspace @maka/headless run build && npm --workspace maka-agent run build && npm --workspace @maka/ui run build && npm --workspace @maka/desktop run build",
@@ -31,7 +31,9 @@
     "check:release": "npm run check:stale && npm run check:officecli-bundle && node scripts/check-dead-css.mjs --check",
     "check:chat-visual": "electron scripts/check-chat-marker-computed-style.mjs",
     "sync:model-metadata": "node scripts/sync-model-metadata.mjs",
-    "cost:deepseek-baseline": "node scripts/deepseek-live-cost-baseline.mjs"
+    "cost:deepseek-baseline": "node scripts/deepseek-live-cost-baseline.mjs",
+    "prepare:cua-driver": "node scripts/prepare-cua-driver.mjs",
+    "check:cua-driver-artifact": "node scripts/check-cua-driver-bundle.mjs"
   },
   "devDependencies": {
     "@types/node": "^25.0.0",

--- a/scripts/check-cua-driver-bundle.mjs
+++ b/scripts/check-cua-driver-bundle.mjs
@@ -1,0 +1,149 @@
+#!/usr/bin/env node
+// Release gate: assert the cua-driver binary is present, non-empty, executable,
+// and matches the pinned checksum before packaging. Analogous to
+// scripts/check-officecli-bundle.mjs. macOS-only; a no-op elsewhere.
+import { execFile } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import { constants } from 'node:fs';
+import { access, readFile, stat } from 'node:fs/promises';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { promisify } from 'node:util';
+
+import {
+  assertPinnedCuaDriverChecksums,
+  cuaDriverSupported,
+} from './prepare-cua-driver.mjs';
+
+const scriptDir = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(scriptDir, '..');
+const manifestPath = join(repoRoot, 'apps', 'desktop', 'bundled-tools.json');
+const binDir = join(repoRoot, 'apps', 'desktop', 'resources', 'bin');
+const licenseDir = join(repoRoot, 'apps', 'desktop', 'resources', 'licenses', 'cua-driver');
+const execFileAsync = promisify(execFile);
+
+export async function checkCuaDriverBundle(targetPlatform = process.platform) {
+  if (!cuaDriverSupported(targetPlatform)) {
+    return { skipped: true };
+  }
+  const manifest = JSON.parse(await readFile(manifestPath, 'utf8'));
+  const cua = manifest.cuaDriver;
+  assertPinnedCuaDriverChecksums(cua);
+  const binaryPath = join(binDir, cua.binaryName);
+  const markerPath = join(binDir, '.cua-driver.json');
+  const licensePath = join(licenseDir, 'LICENSE.md');
+  const sourcePath = join(licenseDir, 'SOURCE.json');
+
+  try {
+    await access(binaryPath, constants.R_OK);
+  } catch {
+    throw new Error(
+      `cua-driver bundle missing (${cua.asset}). Run \`npm run prepare:cua-driver\` before packaging.`,
+    );
+  }
+  const info = await stat(binaryPath);
+  if (!info.isFile() || info.size <= 0) {
+    throw new Error(`cua-driver bundle is not a non-empty file: ${binaryPath}`);
+  }
+  await access(binaryPath, constants.X_OK);
+
+  // Authoritative check: re-hash the actual binary bytes and fail closed unless
+  // they match the pinned checksum. The plaintext marker is trusted only as a
+  // secondary signal (below), never on its own.
+  const bytes = await readFile(binaryPath);
+  const actualBinarySha256 = createHash('sha256').update(bytes).digest('hex');
+  if (actualBinarySha256 !== cua.binarySha256) {
+    throw new Error(
+      `cua-driver bundle checksum mismatch: expected ${cua.binarySha256}, got ${actualBinarySha256} (${binaryPath}). ` +
+      `Re-run \`npm run prepare:cua-driver\`.`,
+    );
+  }
+
+  let marker;
+  try {
+    marker = JSON.parse(await readFile(markerPath, 'utf8'));
+  } catch {
+    throw new Error(
+      `cua-driver bundle marker is missing or invalid: ${markerPath}. ` +
+      `Re-run \`npm run prepare:cua-driver\`.`,
+    );
+  }
+  if (
+    marker.version !== cua.version
+    || marker.expectedVersion !== cua.expectedVersion
+    || marker.expectedProtocolVersion !== cua.expectedProtocolVersion
+    || marker.sourceCommit !== cua.sourceCommit
+    || marker.upstreamCommit !== cua.upstreamCommit
+    || marker.upstreamMergeCommit !== cua.upstreamMergeCommit
+    || marker.archiveSha256 !== cua.archiveSha256
+    || marker.binarySha256 !== cua.binarySha256
+    || marker.licenseSha256 !== cua.licenseSha256
+    || marker.sourceSha256 !== cua.sourceSha256
+  ) {
+    throw new Error(
+      `cua-driver bundle marker mismatch: manifest ${cua.version}/${cua.archiveSha256}/${cua.binarySha256}, ` +
+      `on disk ${marker.version}/${marker.archiveSha256}/${marker.binarySha256}. Re-run \`npm run prepare:cua-driver\`.`,
+    );
+  }
+
+  const licenseBytes = await readFile(licensePath);
+  const sourceBytes = await readFile(sourcePath);
+  const actualLicenseSha256 = createHash('sha256').update(licenseBytes).digest('hex');
+  const actualSourceSha256 = createHash('sha256').update(sourceBytes).digest('hex');
+  if (actualLicenseSha256 !== cua.licenseSha256 || actualSourceSha256 !== cua.sourceSha256) {
+    throw new Error('cua-driver license/provenance checksum mismatch. Re-run `npm run prepare:cua-driver`.');
+  }
+  const source = JSON.parse(sourceBytes.toString('utf8'));
+  for (const [field, expected] of Object.entries({
+    repository: cua.repo,
+    upstreamTag: cua.upstreamTag,
+    upstreamCommit: cua.upstreamCommit,
+    sourceCommit: cua.sourceCommit,
+    patchPullRequest: cua.patchPullRequest,
+    cargoLockSha256: cua.cargoLockSha256,
+    signature: cua.signature,
+  })) {
+    if (source[field] !== expected) {
+      throw new Error(`cua-driver SOURCE.json ${field} mismatch`);
+    }
+  }
+  if (!cua.architectures.every((arch) => source.architectures?.includes(arch))) {
+    throw new Error('cua-driver SOURCE.json architectures mismatch');
+  }
+
+  const { stdout } = await execFileAsync(binaryPath, ['--version']);
+  if (stdout.trim() !== `cua-driver ${cua.expectedVersion}`) {
+    throw new Error(`cua-driver version mismatch: ${stdout.trim()}`);
+  }
+  await execFileAsync('lipo', [binaryPath, '-verify_arch', ...cua.architectures]);
+  await execFileAsync('codesign', ['--verify', '--strict', '--verbose=2', binaryPath]);
+  return {
+    skipped: false,
+    binaryPath,
+    version: cua.version,
+    signatureMode: cua.signature,
+    releaseSigningReady: false,
+  };
+}
+
+export function cuaDriverDistributionBlockers(entry) {
+  const blockers = [];
+  if (entry.signature !== 'developer-id') blockers.push('developer_id_signature');
+  if (entry.notarization !== 'verified') blockers.push('notarization');
+  if (entry.artifactAttestation !== 'verified') blockers.push('artifact_attestation');
+  if (entry.buildProvenance !== 'verified') blockers.push('build_provenance');
+  if (entry.thirdPartyNotices !== 'verified') blockers.push('third_party_notices');
+  if (entry.distributionReady !== true) blockers.push('distribution_ready');
+  return blockers;
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  const result = await checkCuaDriverBundle();
+  if (result.skipped) {
+    process.stdout.write('cua-driver bundle check skipped (non-macOS)\n');
+  } else {
+    process.stdout.write(
+      `Verified pinned cua-driver ${result.version} artifact integrity: ${result.binaryPath}\n`,
+    );
+  }
+}

--- a/scripts/cua-driver-provenance.test.mjs
+++ b/scripts/cua-driver-provenance.test.mjs
@@ -1,0 +1,89 @@
+import assert from 'node:assert/strict';
+import { createHash } from 'node:crypto';
+import { readFile } from 'node:fs/promises';
+import { test } from 'node:test';
+
+import {
+  assertPinnedCuaDriverChecksums,
+  assertSafeTarEntries,
+  assertSafeTarListing,
+  cuaDriverDownloadUrl,
+} from './prepare-cua-driver.mjs';
+import { cuaDriverDistributionBlockers } from './check-cua-driver-bundle.mjs';
+
+const manifest = JSON.parse(
+  await readFile(new URL('../apps/desktop/bundled-tools.json', import.meta.url)),
+);
+const cua = manifest.cuaDriver;
+
+test('cua-driver release pins archive, binary, source, and license independently', () => {
+  assertPinnedCuaDriverChecksums(cua);
+  assert.notEqual(cua.archiveSha256, cua.binarySha256);
+  assert.match(cua.sourceCommit, /^[a-f0-9]{40}$/);
+  assert.match(cua.upstreamCommit, /^[a-f0-9]{40}$/);
+  assert.match(cua.upstreamMergeCommit, /^[a-f0-9]{40}$/);
+  assert.deepEqual(cua.architectures, ['arm64', 'x86_64']);
+  assert.equal(cua.signature, 'adhoc');
+  assert.equal(
+    cuaDriverDownloadUrl(cua.tag, cua.asset),
+    `https://github.com/${cua.repo}/releases/download/${cua.tag}/${cua.asset}`,
+  );
+});
+
+test('tar entry validation rejects path traversal before extraction', () => {
+  assertSafeTarEntries(['bundle/cua-driver', 'bundle/LICENSE.md']);
+  assert.throws(() => assertSafeTarEntries(['../../tmp/escape']));
+  assert.throws(() => assertSafeTarEntries(['/absolute/path']));
+  assert.throws(() => assertSafeTarEntries(['windows\\escape']));
+  assertSafeTarListing([
+    'drwxr-xr-x user/group 0 2026-01-01 00:00 bundle/',
+    '-rwxr-xr-x user/group 1 2026-01-01 00:00 bundle/cua-driver',
+  ]);
+  assert.throws(() => assertSafeTarListing([
+    'lrwxr-xr-x user/group 0 2026-01-01 00:00 bundle/link -> /tmp/escape',
+  ]));
+});
+
+test('tracked license and source metadata match the manifest pins', async () => {
+  const license = await readFile(new URL(
+    '../apps/desktop/resources/licenses/cua-driver/LICENSE.md',
+    import.meta.url,
+  ));
+  const sourceBytes = await readFile(new URL(
+    '../apps/desktop/resources/licenses/cua-driver/SOURCE.json',
+    import.meta.url,
+  ));
+  assert.equal(sha256(license), cua.licenseSha256);
+  assert.equal(sha256(sourceBytes), cua.sourceSha256);
+  const source = JSON.parse(sourceBytes.toString('utf8'));
+  assert.equal(source.repository, cua.repo);
+  assert.equal(source.upstreamCommit, cua.upstreamCommit);
+  assert.equal(source.sourceCommit, cua.sourceCommit);
+  assert.equal(source.patchPullRequest, cua.patchPullRequest);
+  assert.equal(source.cargoLockSha256, cua.cargoLockSha256);
+});
+
+test('artifact checks remain separate from the distribution release gate', async () => {
+  const pkg = JSON.parse(await readFile(new URL('../package.json', import.meta.url)));
+  const checkSource = await readFile(
+    new URL('./check-cua-driver-bundle.mjs', import.meta.url),
+    'utf8',
+  );
+  assert.ok(pkg.scripts['check:cua-driver-artifact']);
+  assert.doesNotMatch(pkg.scripts['check:release'], /cua-driver/);
+  assert.match(checkSource, /releaseSigningReady:\s*false/);
+  assert.match(checkSource, /codesign/);
+  assert.doesNotMatch(checkSource, /notarytool|stapler|Developer ID Application/);
+  assert.deepEqual(cuaDriverDistributionBlockers(cua), [
+    'developer_id_signature',
+    'notarization',
+    'artifact_attestation',
+    'build_provenance',
+    'third_party_notices',
+    'distribution_ready',
+  ]);
+});
+
+function sha256(bytes) {
+  return createHash('sha256').update(bytes).digest('hex');
+}

--- a/scripts/prepare-cua-driver.mjs
+++ b/scripts/prepare-cua-driver.mjs
@@ -1,0 +1,343 @@
+#!/usr/bin/env node
+// Acquire + verify + extract the pinned cua-driver compatibility release for
+// bundling into Maka.app. The source patch remains published in hqhq1025/cua
+// and proposed upstream; Maka only consumes an immutable, provenance-carrying
+// release artifact. Mirrors scripts/prepare-officecli.mjs: single-source version pin in
+// apps/desktop/bundled-tools.json, checksum verified fail-closed, extracted to a
+// pinned repo path (resources/bin/cua-driver), idempotent via a marker file.
+//
+// cua-driver ships ONE darwin-universal tarball (arm64 + x64), so unlike
+// OfficeCLI there is no per-arch asset. This tool is macOS-only (the Tier-2
+// coordinate-injection backend); on other platforms this is a no-op.
+//
+// Dev usage: `npm run prepare:cua-driver`. The extracted binary is spawned as a
+// DIRECT child by cua-driver-backend.ts. This script verifies that the release
+// artifact has a valid code signature, but it does not claim Developer ID,
+// notarization, Gatekeeper, or final Maka.app nested-signature readiness.
+import { execFile } from 'node:child_process';
+import { createHash, randomUUID } from 'node:crypto';
+import { constants } from 'node:fs';
+import { access, chmod, mkdir, readFile, rename, rm, writeFile } from 'node:fs/promises';
+import { mkdtemp } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { promisify } from 'node:util';
+
+const execFileAsync = promisify(execFile);
+const scriptDir = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(scriptDir, '..');
+const manifestPath = join(repoRoot, 'apps', 'desktop', 'bundled-tools.json');
+const binDir = join(repoRoot, 'apps', 'desktop', 'resources', 'bin');
+const licenseDir = join(repoRoot, 'apps', 'desktop', 'resources', 'licenses', 'cua-driver');
+const DEFAULT_FETCH_TIMEOUT_MS = 300_000;
+const SHA256_PATTERN = /^[a-f0-9]{64}$/;
+
+const manifest = JSON.parse(await readFile(manifestPath, 'utf8'));
+const cua = manifest.cuaDriver;
+const FETCH_TIMEOUT_MS = readPositiveIntEnv('MAKA_CUA_DRIVER_FETCH_TIMEOUT_MS', DEFAULT_FETCH_TIMEOUT_MS);
+
+export function cuaDriverSupported(platform = process.platform) {
+  return platform === 'darwin';
+}
+
+export function cuaDriverDownloadUrl(tag, asset) {
+  return `https://github.com/${cua.repo}/releases/download/${tag}/${asset}`;
+}
+
+export function sha256(data) {
+  return createHash('sha256').update(Buffer.from(data)).digest('hex');
+}
+
+export function assertPinnedCuaDriverChecksums(entry) {
+  for (const field of ['archiveSha256', 'binarySha256', 'licenseSha256', 'sourceSha256']) {
+    if (!SHA256_PATTERN.test(entry?.[field] ?? '')) {
+      throw new Error(
+        `bundled-tools.json cuaDriver.${field} must be a pinned lowercase 64-character SHA-256 digest ` +
+        `(received ${JSON.stringify(entry?.[field])}).`,
+      );
+    }
+  }
+  if (entry.archiveSha256 === entry.binarySha256) {
+    throw new Error('bundled-tools.json must pin the cua-driver archive and extracted binary separately.');
+  }
+  if (Object.prototype.hasOwnProperty.call(entry, 'sha256')) {
+    throw new Error('bundled-tools.json cuaDriver.sha256 is ambiguous; use archiveSha256 and binarySha256.');
+  }
+  if (
+    typeof entry?.expectedVersion !== 'string'
+    || typeof entry?.expectedProtocolVersion !== 'string'
+    || typeof entry?.sourceCommit !== 'string'
+    || typeof entry?.upstreamCommit !== 'string'
+    || typeof entry?.upstreamMergeCommit !== 'string'
+    || typeof entry?.cargoLockSha256 !== 'string'
+    || !Array.isArray(entry?.architectures)
+    || entry.architectures.length === 0
+  ) {
+    throw new Error('bundled-tools.json cuaDriver must pin version, protocol, source commits, Cargo.lock, and architectures.');
+  }
+}
+
+function destinationPath() {
+  return join(binDir, cua.binaryName);
+}
+
+function markerPath() {
+  return join(binDir, '.cua-driver.json');
+}
+
+function expectedMarker() {
+  return {
+    version: cua.version,
+    expectedVersion: cua.expectedVersion,
+    expectedProtocolVersion: cua.expectedProtocolVersion,
+    sourceCommit: cua.sourceCommit,
+    upstreamCommit: cua.upstreamCommit,
+    upstreamMergeCommit: cua.upstreamMergeCommit,
+    archiveSha256: cua.archiveSha256,
+    binarySha256: cua.binarySha256,
+    licenseSha256: cua.licenseSha256,
+    sourceSha256: cua.sourceSha256,
+  };
+}
+
+function markerMatches(marker) {
+  const expected = expectedMarker();
+  return marker?.version === expected.version
+    && marker?.expectedVersion === expected.expectedVersion
+    && marker?.expectedProtocolVersion === expected.expectedProtocolVersion
+    && marker?.sourceCommit === expected.sourceCommit
+    && marker?.upstreamCommit === expected.upstreamCommit
+    && marker?.upstreamMergeCommit === expected.upstreamMergeCommit
+    && marker?.archiveSha256 === expected.archiveSha256
+    && marker?.binarySha256 === expected.binarySha256
+    && marker?.licenseSha256 === expected.licenseSha256
+    && marker?.sourceSha256 === expected.sourceSha256;
+}
+
+function readPositiveIntEnv(name, fallback) {
+  const raw = process.env[name];
+  if (!raw) return fallback;
+  const parsed = Number(raw);
+  if (!Number.isSafeInteger(parsed) || parsed <= 0) {
+    throw new Error(`${name} must be a positive integer timeout in milliseconds`);
+  }
+  return parsed;
+}
+
+function isTimeoutError(error) {
+  return Boolean(error && typeof error === 'object' && (error.name === 'AbortError' || error.name === 'TimeoutError'));
+}
+
+function timeoutError(url) {
+  return new Error(`Timed out downloading ${url} after ${FETCH_TIMEOUT_MS}ms`);
+}
+
+async function fetchBytes(url) {
+  let response;
+  try {
+    response = await fetch(url, { redirect: 'follow', signal: AbortSignal.timeout(FETCH_TIMEOUT_MS) });
+  } catch (error) {
+    if (isTimeoutError(error)) throw timeoutError(url);
+    throw error;
+  }
+  if (!response.ok) throw new Error(`Failed to download ${url}: HTTP ${response.status}`);
+  try {
+    return await response.arrayBuffer();
+  } catch (error) {
+    if (isTimeoutError(error)) throw timeoutError(url);
+    throw error;
+  }
+}
+
+// Idempotency: skip the network round-trip when the pinned version + checksum
+// already match the on-disk marker AND the binary is present + executable.
+async function alreadyPrepared() {
+  try {
+    await access(destinationPath(), constants.X_OK);
+    const marker = JSON.parse(await readFile(markerPath(), 'utf8'));
+    if (!markerMatches(marker)) return false;
+    // Re-hash the actual binary so a corrupted/swapped file with an intact marker
+    // is not silently trusted — on drift, fall through to re-download/re-verify.
+    const actualBinarySha256 = sha256(await readFile(destinationPath()));
+    const actualLicenseSha256 = sha256(await readFile(join(licenseDir, 'LICENSE.md')));
+    const actualSourceSha256 = sha256(await readFile(join(licenseDir, 'SOURCE.json')));
+    return actualBinarySha256 === cua.binarySha256
+      && actualLicenseSha256 === cua.licenseSha256
+      && actualSourceSha256 === cua.sourceSha256;
+  } catch {
+    return false;
+  }
+}
+
+async function verifyBinary(binaryPath) {
+  const { stdout } = await execFileAsync(binaryPath, ['--version']);
+  if (stdout.trim() !== `cua-driver ${cua.expectedVersion}`) {
+    throw new Error(
+      `Unexpected cua-driver version: expected ${cua.expectedVersion}, got ${JSON.stringify(stdout.trim())}`,
+    );
+  }
+  await execFileAsync('lipo', [binaryPath, '-verify_arch', ...cua.architectures]);
+  await execFileAsync('codesign', ['--verify', '--strict', '--verbose=2', binaryPath]);
+}
+
+export function assertSafeTarEntries(entries) {
+  for (const rawEntry of entries) {
+    const entry = rawEntry.trim();
+    if (!entry) continue;
+    if (
+      entry.startsWith('/')
+      || entry.split('/').includes('..')
+      || entry.includes('\\')
+    ) {
+      throw new Error(`Unsafe cua-driver archive entry: ${JSON.stringify(entry)}`);
+    }
+  }
+}
+
+export function assertSafeTarListing(lines) {
+  for (const line of lines) {
+    if (!line.trim()) continue;
+    const type = line[0];
+    if (type !== '-' && type !== 'd') {
+      throw new Error(`Unsupported cua-driver archive entry type: ${JSON.stringify(line)}`);
+    }
+  }
+}
+
+function assertSourceProvenance(source) {
+  const expected = {
+    repository: cua.repo,
+    upstreamTag: cua.upstreamTag,
+    upstreamCommit: cua.upstreamCommit,
+    sourceCommit: cua.sourceCommit,
+    patchPullRequest: cua.patchPullRequest,
+    cargoLockSha256: cua.cargoLockSha256,
+    signature: cua.signature,
+  };
+  for (const [field, value] of Object.entries(expected)) {
+    if (source?.[field] !== value) {
+      throw new Error(
+        `cua-driver SOURCE.json ${field} mismatch: expected ${JSON.stringify(value)}, got ${JSON.stringify(source?.[field])}`,
+      );
+    }
+  }
+  if (
+    !Array.isArray(source?.architectures)
+    || source.architectures.length !== cua.architectures.length
+    || !cua.architectures.every((arch) => source.architectures.includes(arch))
+  ) {
+    throw new Error('cua-driver SOURCE.json architectures do not match bundled-tools.json.');
+  }
+}
+
+export async function prepareCuaDriver(targetPlatform = process.platform) {
+  if (!cuaDriverSupported(targetPlatform)) {
+    return { skipped: true, reason: `cua-driver is macOS-only; skipping ${targetPlatform}` };
+  }
+  assertPinnedCuaDriverChecksums(cua);
+  if (await alreadyPrepared()) {
+    return { skipped: true, reason: 'up-to-date', destination: destinationPath(), version: cua.version };
+  }
+
+  const url = cuaDriverDownloadUrl(cua.tag, cua.asset);
+  const data = await fetchBytes(url);
+  const actualArchiveSha256 = sha256(data);
+  if (actualArchiveSha256 !== cua.archiveSha256) {
+    throw new Error(`Checksum mismatch for ${cua.asset}: expected ${cua.archiveSha256}, got ${actualArchiveSha256}`);
+  }
+
+  // Extract the tarball to a temp dir, then copy out the single `cua-driver`
+  // Mach-O. Tarball internal layout is not assumed — we locate the binary.
+  const workDir = await mkdtemp(join(tmpdir(), 'maka-cua-driver-'));
+  try {
+    const tarPath = join(workDir, cua.asset);
+    await writeFile(tarPath, Buffer.from(data));
+    const listed = await execFileAsync('tar', ['-tzf', tarPath]);
+    assertSafeTarEntries(listed.stdout.split('\n'));
+    const verboseListing = await execFileAsync('tar', ['-tvzf', tarPath]);
+    assertSafeTarListing(verboseListing.stdout.split('\n'));
+    await execFileAsync('tar', ['-xzf', tarPath, '-C', workDir]);
+    const { stdout } = await execFileAsync('find', [workDir, '-name', cua.binaryName, '-type', 'f']);
+    const found = stdout.split('\n').map((l) => l.trim()).filter(Boolean);
+    if (found.length !== 1) {
+      throw new Error(
+        `Extracted archive ${cua.asset} must contain exactly one '${cua.binaryName}' binary (found ${found.length})`,
+      );
+    }
+
+    const binaryBytes = await readFile(found[0]);
+    const actualBinarySha256 = sha256(binaryBytes);
+    if (actualBinarySha256 !== cua.binarySha256) {
+      throw new Error(
+        `Checksum mismatch for extracted ${cua.binaryName}: expected ${cua.binarySha256}, got ${actualBinarySha256}`,
+      );
+    }
+    await verifyBinary(found[0]);
+
+    const licensePaths = await execFileAsync('find', [workDir, '-name', 'LICENSE.md', '-type', 'f']);
+    const sourcePaths = await execFileAsync('find', [workDir, '-name', 'SOURCE.json', '-type', 'f']);
+    const licenses = licensePaths.stdout.split('\n').map((line) => line.trim()).filter(Boolean);
+    const sources = sourcePaths.stdout.split('\n').map((line) => line.trim()).filter(Boolean);
+    if (licenses.length !== 1 || sources.length !== 1) {
+      throw new Error(
+        `Extracted archive ${cua.asset} must contain exactly one LICENSE.md and SOURCE.json`,
+      );
+    }
+    const licenseBytes = await readFile(licenses[0]);
+    const sourceBytes = await readFile(sources[0]);
+    if (sha256(licenseBytes) !== cua.licenseSha256) {
+      throw new Error(`Checksum mismatch for extracted cua-driver LICENSE.md`);
+    }
+    if (sha256(sourceBytes) !== cua.sourceSha256) {
+      throw new Error(`Checksum mismatch for extracted cua-driver SOURCE.json`);
+    }
+    assertSourceProvenance(JSON.parse(sourceBytes.toString('utf8')));
+
+    await mkdir(binDir, { recursive: true });
+    await mkdir(licenseDir, { recursive: true });
+    const destination = destinationPath();
+    const marker = markerPath();
+    const installId = randomUUID();
+    const stagedBinary = `${destination}.${installId}.tmp`;
+    const stagedMarker = `${marker}.${installId}.tmp`;
+    try {
+      await writeFile(stagedBinary, binaryBytes);
+      await chmod(stagedBinary, 0o755);
+      // Best-effort: clear the download quarantine xattr so the dev Electron process
+      // can spawn it without a Gatekeeper prompt. Non-fatal if xattr is absent.
+      try {
+        await execFileAsync('xattr', ['-d', 'com.apple.quarantine', stagedBinary]);
+      } catch {
+        /* no quarantine attr — fine */
+      }
+      await writeFile(stagedMarker, `${JSON.stringify(expectedMarker(), null, 2)}\n`);
+      await rename(stagedBinary, destination);
+      await rename(stagedMarker, marker);
+      await writeFile(join(licenseDir, 'LICENSE.md'), licenseBytes);
+      await writeFile(join(licenseDir, 'SOURCE.json'), sourceBytes);
+    } finally {
+      await rm(stagedBinary, { force: true });
+      await rm(stagedMarker, { force: true });
+    }
+
+    return {
+      skipped: false,
+      destination,
+      version: cua.version,
+      signatureMode: cua.signature,
+      releaseSigningReady: false,
+    };
+  } finally {
+    await rm(workDir, { recursive: true, force: true });
+  }
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  const result = await prepareCuaDriver();
+  if (result.skipped) {
+    process.stdout.write(`cua-driver: ${result.reason}\n`);
+  } else {
+    process.stdout.write(`Prepared cua-driver ${result.version}: ${result.destination}\n`);
+  }
+}


### PR DESCRIPTION
## Upstream stack notice

This is stack PR D. It depends on #893 and must not merge before it.

The Files tab is cumulative until preceding fork branches are rebased after merge.

Review the exact 9-file provenance net diff now in fork-local PR hqhq1025/maka-agent#3.

Current rebase verification: script/provenance/model-metadata tests 11/11; pinned artifact integrity verified.

---

## Stack position

PR D, stacked on fork PR #2 (`codex/cu-executor-service`).

## Summary

Pins and verifies the local/pre-package cua-driver artifact without claiming that it is ready for public distribution.

- immutable release URL, archive hash, extracted binary hash, source/license hashes;
- source/upstream commit claims and Cargo.lock hash recorded as unverified claims;
- arm64+x86_64 universal binary and reported version checks;
- code-signature structural verification;
- marker plus authoritative re-hash on every artifact check;
- tar traversal, absolute path, backslash, symlink, and hardlink rejection before extraction;
- tracked top-level license and source metadata;
- generated binary and marker remain ignored;
- explicit distribution blockers for Developer ID, notarization, artifact attestation, reproducible build provenance, and third-party notices/SBOM.

## Trust boundary

`check:cua-driver-artifact` proves byte integrity for a pinned development/pre-package input. It is intentionally not part of `check:release` and returns `releaseSigningReady: false`.

The release asset and source commit are currently unsigned/self-published. The manifest therefore records:

- `buildProvenance: unverified`;
- `artifactAttestation: missing`;
- `thirdPartyNotices: missing`;
- `notarization: missing`;
- `distributionReady: false`.

A later release-pipeline PR must close those blockers and verify the final nested-signed/notarized Maka.app.

## Codex lab alignment

The lab observed a signed bundled source copied to a canonical executable before exact-path service spawn. This PR establishes the immutable artifact input and integrity checks only; canonical refresh, packaged-app signing, and TCC responsibility-chain validation remain later slices.

## Verification

- static provenance/script tests: 6/6;
- pinned artifact downloaded successfully;
- archive, binary, license, and source hashes verified;
- `cua-driver 0.7.1` version verified;
- arm64+x86_64 architecture verification passed;
- current codesign verification passed;
- full repository build passed;
- full repository typecheck passed;
- `git diff --check` passed.