### PR TITLE
feat(cu): connect typed host lifecycle events

### DIFF
--- a/docs/computer-use-host-events-contract.md
+++ b/docs/computer-use-host-events-contract.md
@@ -1,0 +1,52 @@
+# Computer Use Host Events Contract
+
+This layer connects only events with a typed, attributable source.
+
+## Connected producers
+
+- Typed dispatch outcomes:
+  - `user_intervened` -> re-observe
+  - `screen_locked` -> locked
+  - `blocked_url` -> terminal URL block
+  - `outcome_unknown`, service unavailable, or service mismatch -> re-observe
+- cua-driver service release:
+  - clears executor-local observations and keyboard ownership
+  - advances the corresponding Runtime session to re-observe
+- Turn/session terminal events:
+  - synchronously clear Runtime, executor, and overlay ownership
+
+## Deliberate gaps
+
+- Maka does not infer physical user input from AX or DOM content changes.
+- Maka does not claim a global physical-input producer until it has a reliable,
+  attributable macOS event source.
+- Maka does not invoke Codex's signed `turn-ended` helper. That helper uses an
+  Apple Event lifecycle specific to the Codex native service, and helper process
+  exit is not proof that service cleanup completed.
+- Runtime URL, lock, and intervention states require typed driver outcomes; raw
+  error-message matching is not an accepted producer.
+- The current driver exposes no trustworthy intervention debounce deadline, so
+  a typed intervention advances directly to re-observe. The two-stage debounce
+  state remains reserved for a future attributable deadline producer.
+- Maka currently binds targets by PID/window/content/page identity. The V10
+  reverse-engineered boundary is stronger: canonical app path plus the current
+  live process instance. Maka does not claim that boundary until cua-driver or a
+  native host API can provide an atomic, high-precision process identity.
+
+## Verification
+
+The cross-layer deterministic harness covers:
+
+- bound target propagation;
+- observation-bound presentation and dispatch;
+- fresh post-action observation;
+- duplicate and stale rejection;
+- typed target-change cancellation;
+- unknown outcome requiring re-observation;
+- explicit session cleanup;
+- private UI content omission from persisted tool text while current-turn model
+  projection retains the UI evidence needed for action.
+
+Target/decoy execution, real process restart, persistence-level privacy,
+Desktop terminal lifecycle, real macOS event production, and real-window
+cumulative Electron verification remain separate release gates.

--- a/packages/computer-use/src/__tests__/computer-use-cumulative-e2e.test.ts
+++ b/packages/computer-use/src/__tests__/computer-use-cumulative-e2e.test.ts
@@ -1,0 +1,289 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+import type { CuAction } from '@maka/core';
+import {
+  buildComputerUseTools,
+  type CuDispatchBackend,
+  type CuObservation,
+  type CuRunContext,
+} from '@maka/runtime';
+import {
+  createComputerUseOverlayHook,
+  type OverlayCursorSink,
+} from '../computer-use-overlay-hook.js';
+
+function context(overrides: Partial<CuRunContext> = {}) {
+  return {
+    sessionId: 'session-1',
+    turnId: 'turn-1',
+    toolCallId: 'tool-1',
+    cwd: '/tmp',
+    abortSignal: new AbortController().signal,
+    emitOutput: () => {},
+    ...overrides,
+  };
+}
+
+function fixtureObservation(overrides: Partial<CuObservation> = {}): CuObservation {
+  return {
+    observationId: 'backend-observation-1',
+    appId: 'Fixture',
+    pid: 100,
+    windowId: 10,
+    windowBounds: { x: 100, y: 100, width: 600, height: 400 },
+    sourceBoundsPx: { x: 0, y: 0, width: 1200, height: 800 },
+    contentFingerprint: 'fixture-structure-a',
+    zIndex: 5,
+    elements: [{
+      elementId: '5',
+      role: 'AXButton',
+      label: 'Commit target',
+      identity: {
+        token: 'target-button-token',
+        role: 'AXButton',
+        label: 'Commit target',
+      },
+    }],
+    screenshot: {
+      base64: 'AA==',
+      mimeType: 'image/png',
+      widthPx: 1200,
+      heightPx: 800,
+    },
+    ...overrides,
+  };
+}
+
+function overlayRecorder() {
+  const events: Array<{
+    type: 'move' | 'complete' | 'cancel';
+    actionId: string;
+    sessionId: string;
+    x?: number;
+    y?: number;
+  }> = [];
+  const sink: OverlayCursorSink = {
+    ensure() {},
+    move(input) {
+      events.push({
+        type: 'move',
+        actionId: input.actionId,
+        sessionId: input.sessionId,
+        x: input.screenX,
+        y: input.screenY,
+      });
+      return {
+        readyForInteraction: Promise.resolve(),
+        finished: Promise.resolve(),
+      };
+    },
+    complete(input) {
+      events.push({
+        type: 'complete',
+        actionId: input.actionId,
+        sessionId: input.sessionId,
+        x: input.screenX,
+        y: input.screenY,
+      });
+    },
+    cancel(input) {
+      events.push({
+        type: 'cancel',
+        actionId: input.actionId,
+        sessionId: input.sessionId,
+      });
+    },
+  };
+  return { events, overlay: createComputerUseOverlayHook(sink) };
+}
+
+describe('Computer Use cross-layer deterministic contract', () => {
+  test('bound target propagation, presentation order, fresh state, and duplicate rejection', async () => {
+    const overlay = overlayRecorder();
+    const dispatches: Array<{ action: CuAction; context: CuRunContext }> = [];
+    let revision = 0;
+    const backend: CuDispatchBackend = {
+      async preflight() {
+        return { accessibility: true, screenRecording: true };
+      },
+      async observeApp(input) {
+        assert.equal(input.windowId, 10);
+        return fixtureObservation();
+      },
+      async run(action, _signal, runContext) {
+        dispatches.push({ action, context: runContext });
+        assert.equal(runContext.boundAction?.target.pid, 100);
+        assert.equal(runContext.boundAction?.target.windowId, 10);
+        revision += 1;
+        return {
+          outcome: {
+            ok: true,
+            tier: 'ax',
+            verified: true,
+            evidence: { effect: 'confirmed' },
+          },
+          resolvedScreenPoint: { x: 300, y: 200 },
+          observation: fixtureObservation({
+            observationId: `backend-observation-${revision + 1}`,
+            contentFingerprint: `fixture-structure-${revision + 1}`,
+          }),
+        };
+      },
+    };
+    const tools = buildComputerUseTools({
+      backend,
+      overlay: overlay.overlay,
+    });
+    const [tool] = tools;
+    const observed = await tool.impl({
+      action: 'observe',
+      app: 'Fixture',
+      window_id: 10,
+    } as never, context()) as { text: string; modelText?: string };
+    const observationId = JSON.parse(observed.modelText ?? '{}').observation_id;
+    const result = await tool.impl({
+      action: 'left_click',
+      observation_id: observationId,
+      coordinate: [400, 200],
+    } as never, context({ toolCallId: 'click-target' })) as {
+      text: string;
+      modelText?: string;
+    };
+
+    assert.equal(dispatches.length, 1);
+    assert.match(result.modelText ?? '', /Fresh observation/);
+    assert.deepEqual(overlay.events, [
+      {
+        type: 'move',
+        actionId: 'click-target',
+        sessionId: 'session-1',
+        x: 300,
+        y: 200,
+      },
+      {
+        type: 'complete',
+        actionId: 'click-target',
+        sessionId: 'session-1',
+        x: 300,
+        y: 200,
+      },
+    ]);
+
+    const replay = await tool.impl({
+      action: 'left_click',
+      observation_id: observationId,
+      coordinate: [400, 200],
+    } as never, context({ toolCallId: 'duplicate' })) as { text: string };
+    assert.match(replay.text, /duplicate_action|stale_frame|reobserve_required/);
+    assert.equal(dispatches.length, 1);
+  });
+
+  test('typed target change and unknown outcome both cancel, while unknown requires re-observation', async () => {
+    const overlay = overlayRecorder();
+    let mode: 'target_change' | 'unknown' = 'target_change';
+    const backend: CuDispatchBackend = {
+      async preflight() {
+        return { accessibility: true, screenRecording: true };
+      },
+      async observeApp() {
+        return fixtureObservation();
+      },
+      async run() {
+        return mode === 'target_change'
+          ? {
+              outcome: {
+                ok: false,
+                error: 'target_changed',
+                message: 'application process identity changed',
+              },
+            }
+          : {
+              outcome: {
+                ok: false,
+                error: 'outcome_unknown',
+                message: 'child exited after delivery',
+              },
+            };
+      },
+    };
+    const tools = buildComputerUseTools({
+      backend,
+      overlay: overlay.overlay,
+    });
+    const [tool] = tools;
+
+    const firstObservation = await tool.impl({
+      action: 'observe',
+      app: 'Fixture',
+      window_id: 10,
+    } as never, context()) as { modelText?: string };
+    await tool.impl({
+      action: 'left_click',
+      observation_id: JSON.parse(firstObservation.modelText ?? '{}').observation_id,
+      coordinate: [400, 200],
+    } as never, context({ toolCallId: 'target-change' }));
+    assert.equal(overlay.events.at(-1)?.type, 'cancel');
+
+    tools.sessionEvents.reobserveRequired('session-1');
+    const secondObservation = await tool.impl({
+      action: 'observe',
+      app: 'Fixture',
+      window_id: 10,
+    } as never, context({ turnId: 'turn-2' })) as { modelText?: string };
+    mode = 'unknown';
+    await tool.impl({
+      action: 'left_click',
+      observation_id: JSON.parse(secondObservation.modelText ?? '{}').observation_id,
+      coordinate: [400, 200],
+    } as never, context({ turnId: 'turn-2', toolCallId: 'unknown' }));
+    assert.equal(tools.sessionEvents.snapshot('session-1').status, 'reobserve_required');
+    assert.equal(overlay.events.at(-1)?.type, 'cancel');
+  });
+
+  test('explicit session cleanup fences late work and persisted projection omits private UI content', async () => {
+    const backend: CuDispatchBackend = {
+      async preflight() {
+        return { accessibility: true, screenRecording: true };
+      },
+      async observeApp() {
+        return fixtureObservation({
+          windowTitle: 'Private Window Title',
+          elements: [{
+            elementId: '5',
+            role: 'AXButton',
+            label: 'Private Customer Label',
+          }],
+        });
+      },
+      async run() {
+        return {
+          outcome: { ok: true, tier: 'ax', verified: true },
+          observation: fixtureObservation({
+            windowTitle: 'Private Window Title',
+          }),
+        };
+      },
+    };
+    const tools = buildComputerUseTools({ backend });
+    const [tool] = tools;
+    const observed = await tool.impl({
+      action: 'observe',
+      app: 'Fixture',
+      window_id: 10,
+    } as never, context()) as { text: string; modelText?: string };
+    assert.doesNotMatch(observed.text, /Private Window Title|Private Customer Label/);
+    assert.match(
+      observed.modelText ?? '',
+      /Private Window Title|Private Customer Label/,
+    );
+
+    tools.clearSession('session-1');
+    assert.equal(tools.sessionEvents.snapshot('session-1').status, 'user_stopped');
+    const afterTurn = await tool.impl({
+      action: 'left_click',
+      observation_id: JSON.parse(observed.modelText ?? '{}').observation_id,
+      coordinate: [400, 200],
+    } as never, context({ toolCallId: 'late-action' })) as { text: string };
+    assert.match(afterTurn.text, /user_stopped|no_active_frame/);
+  });
+});

--- a/packages/computer-use/src/__tests__/select-backend-host-events.test.ts
+++ b/packages/computer-use/src/__tests__/select-backend-host-events.test.ts
@@ -1,0 +1,66 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import type { CuDispatchBackend } from '@maka/runtime';
+import { selectComputerUseBackend } from '../select-backend.js';
+
+test('service invalidation producer advances Runtime to reobserve', async () => {
+  if (process.platform !== 'darwin') return;
+  let invalidate:
+    | ((input: {
+        sessionId: string;
+        reason: 'child_exit';
+        outcomeUnknown: boolean;
+      }) => void)
+    | undefined;
+  const backend: CuDispatchBackend = {
+    async preflight() {
+      return { accessibility: true, screenRecording: true };
+    },
+    async observeApp() {
+      return {
+        observationId: 'backend-observation',
+        appId: 'Fixture',
+        pid: 42,
+        windowId: 7,
+        elements: [],
+      };
+    },
+    async run() {
+      return { outcome: { ok: true, tier: 'ax', verified: true } };
+    },
+  };
+  const selected = selectComputerUseBackend({
+    binaryPath: '/tmp/fake-cua-driver',
+    expectedBinarySha256: '0'.repeat(64),
+    createBackend(options) {
+      invalidate = options.onSessionInvalidated as typeof invalidate;
+      return backend;
+    },
+  });
+  const [tool] = selected.tools;
+  await tool.impl({
+    action: 'observe',
+    app: 'Fixture',
+    include_screenshot: false,
+  } as never, {
+    sessionId: 'session-1',
+    turnId: 'turn-1',
+    toolCallId: 'observe',
+    cwd: '/tmp',
+    abortSignal: new AbortController().signal,
+    emitOutput() {},
+  });
+  assert.equal(
+    selected.tools.sessionEvents.snapshot('session-1').status,
+    'active',
+  );
+  invalidate?.({
+    sessionId: 'session-1',
+    reason: 'child_exit',
+    outcomeUnknown: false,
+  });
+  assert.equal(
+    selected.tools.sessionEvents.snapshot('session-1').status,
+    'reobserve_required',
+  );
+});

--- a/packages/computer-use/src/select-backend.ts
+++ b/packages/computer-use/src/select-backend.ts
@@ -5,6 +5,7 @@ import {
   type CuDispatchBackend,
 } from '@maka/runtime';
 import { createCuaDriverBackend } from './cua-driver-backend.js';
+import type { CuaDriverBackendOptions } from './cua-driver-backend.js';
 import type { CuaDriverRoleSnapshot } from './cua-driver-release.js';
 
 export type CuBackendId = 'cua-driver';
@@ -65,11 +66,15 @@ export function selectComputerUseBackend(deps?: {
   ) => { base64: string; mimeType: 'image/png' | 'image/jpeg' };
   physicalInputRecentlyActive?: () => boolean | Promise<boolean>;
   overlay?: CuOverlayHook;
+  createBackend?: (
+    options: CuaDriverBackendOptions,
+  ) => DisposableBackend;
 }): SelectedComputerUseBackend {
   if (process.platform !== 'darwin') return NONE;
   if (!deps?.binaryPath || !deps.expectedBinarySha256) return NONE;
   try {
-    const backend = createCuaDriverBackend({
+    let tools: ComputerUseToolSet | undefined;
+    const backend = (deps.createBackend ?? createCuaDriverBackend)({
       binaryPath: deps.binaryPath,
       hostBundleId: resolveHostBundleId(deps?.hostBundleId),
       expectedBinarySha256: deps.expectedBinarySha256,
@@ -86,13 +91,17 @@ export function selectComputerUseBackend(deps?: {
       ...(deps?.physicalInputRecentlyActive
         ? { physicalInputRecentlyActive: deps.physicalInputRecentlyActive }
         : {}),
+      onSessionInvalidated: ({ sessionId }) => {
+        tools?.sessionEvents.reobserveRequired(sessionId);
+      },
+    });
+    tools = buildComputerUseTools({
+      backend,
+      ...(deps.overlay ? { overlay: deps.overlay } : {}),
     });
     return {
       backend,
-      tools: buildComputerUseTools({
-        backend,
-        ...(deps.overlay ? { overlay: deps.overlay } : {}),
-      }),
+      tools,
       backendId: 'cua-driver',
     };
   } catch {

--- a/packages/runtime/src/__tests__/computer-use-tools.test.ts
+++ b/packages/runtime/src/__tests__/computer-use-tools.test.ts
@@ -1159,6 +1159,47 @@ describe('buildComputerUseTools — the `maka_computer` MakaTool', () => {
     assert.doesNotMatch(unlocked.text, /screen_locked|reobserve_required/);
   });
 
+  for (const [error, expectedStatus] of [
+    ['user_intervened', 'reobserve_required'],
+    ['screen_locked', 'screen_locked'],
+    ['blocked_url', 'blocked_url'],
+    ['outcome_unknown', 'reobserve_required'],
+    ['service_unavailable', 'reobserve_required'],
+  ] as const) {
+    test(`typed ${error} outcome advances Runtime to ${expectedStatus}`, async () => {
+      const backend = fakeBackend() as CuDispatchBackend & {
+        observeApp: NonNullable<CuDispatchBackend['observeApp']>;
+        captureObservation: NonNullable<CuDispatchBackend['captureObservation']>;
+      };
+      backend.observeApp = async () => observation();
+      backend.captureObservation = async () => observation({
+        observationId: 'backend-obs-2',
+      });
+      backend.run = async () => ({
+        outcome: {
+          ok: false,
+          error,
+          message: error,
+        },
+      });
+      const tools = buildComputerUseTools({ backend });
+      const [tool] = tools;
+      const observed = await tool.impl({
+        action: 'observe',
+        app: 'Fixture',
+      } as never, ctx()) as { text: string };
+      await tool.impl({
+        action: 'left_click',
+        observation_id: JSON.parse(observed.text).observation_id,
+        coordinate: [25, 30],
+      } as never, ctx());
+      assert.equal(
+        tools.sessionEvents.snapshot('s1').status,
+        expectedStatus,
+      );
+    });
+  }
+
   test('a queued keyboard mutation cannot silently target a newer frame', async () => {
     let releaseClick!: () => void;
     const clickGate = new Promise<void>((resolve) => {

--- a/packages/runtime/src/computer-use-tools.ts
+++ b/packages/runtime/src/computer-use-tools.ts
@@ -633,6 +633,34 @@ export function buildComputerUseTools(deps: {
     return validation.ok ? undefined : sessionFailure(validation.reason);
   }
 
+  function applyTypedOutcomeState(
+    state: CuaSessionState,
+    outcome: CuDispatchOutcome,
+  ): void {
+    if (outcome.ok) return;
+    switch (outcome.error) {
+      case 'user_intervened':
+        // The driver currently exposes no trustworthy debounce deadline.
+        // Re-observe immediately instead of entering an unrecoverable
+        // intervention_debounce state.
+        state.reobserveRequired();
+        return;
+      case 'screen_locked':
+        state.screenLocked();
+        return;
+      case 'blocked_url':
+        state.blockedUrlDetected();
+        return;
+      case 'outcome_unknown':
+      case 'service_unavailable':
+      case 'service_mismatch':
+        state.reobserveRequired();
+        return;
+      default:
+        return;
+    }
+  }
+
   function toObservationSnapshot(observation: CuObservation): CuaObservationSnapshot {
     const screenshotWidth = observation.screenshot?.widthPx;
     const screenshotHeight = observation.screenshot?.heightPx;
@@ -1301,6 +1329,7 @@ export function buildComputerUseTools(deps: {
             if (presentation.blocked) return presentation.blocked;
             if (!presentation.result) return bindingFailure('capture_failed');
             result = presentation.result;
+            applyTypedOutcomeState(state, result.outcome);
             const postDispatchFailure = validateActionLease(state, actionLease);
             if (postDispatchFailure) {
               presentation.finish();
@@ -1413,6 +1442,7 @@ export function buildComputerUseTools(deps: {
             );
             if (presentation.blocked) return presentation.blocked;
             result = presentation.result;
+            if (result) applyTypedOutcomeState(state, result.outcome);
             if (actionLease) {
               const leaseFailure = validateActionLease(state, actionLease);
               if (leaseFailure) {


### PR DESCRIPTION
## Upstream stack notice

This is stack PR G1. It depends on #896 and must not merge before it.

The Files tab is cumulative until preceding fork branches are rebased after merge.

Review the exact 6-file host-event net diff now in fork-local PR hqhq1025/maka-agent#6.

Current rebase verification: @maka/computer-use 113/113; Runtime 1466 passed with 7 platform skips; Desktop typecheck.

---

## Goal

Connect only Computer Use lifecycle events with a typed, attributable source, and add a scoped cross-layer deterministic contract.

This is G1, not the complete host-event or real-Electron E2E layer.

## What this PR does

- preserves typed cua-driver lifecycle errors instead of collapsing them to `capture_failed`
- maps typed dispatch outcomes into Runtime state:
  - `user_intervened` -> re-observe
  - `screen_locked` -> locked
  - `blocked_url` -> terminal URL block
  - `outcome_unknown`, service unavailable, or service mismatch -> re-observe
- propagates cua-driver child/generation loss into Runtime `reobserve_required`
- invalidates every session retaining observation or keyboard ownership when a shared service generation is lost
- keeps explicit `session_cleared` local to that session
- adds a backend-factory seam for hermetic host-event wiring tests
- adds a cross-layer deterministic contract for:
  - bound target propagation
  - presentation -> dispatch -> fresh observation ordering
  - duplicate/stale rejection
  - typed failure cancellation
  - unknown-outcome re-observation
  - explicit session cleanup
  - persisted-tool-text privacy projection
- documents connected producers and deliberate gaps

## Latest reverse-engineering constraints applied

Reviewed the current local reverse-engineering lab, including V10 and chapters 26/27.

Key consequences:

- Codex native target lifetime is canonical app path plus the current live process instance.
- Maka does not claim this stronger identity until cua-driver or a native host API exposes an atomic, high-precision process identity.
- A provisional `ps`/formatted-start-time implementation was rejected during review rather than shipped as false protection.
- Codex `turn-ended` is a signed-helper Apple Event lifecycle. Maka does not invoke or emulate it; helper exit is not proof of service cleanup.
- AX/DOM content changes are not treated as physical user-input evidence.
- The current driver provides no trustworthy intervention debounce deadline, so typed intervention advances directly to re-observe instead of entering an unrecoverable debounce state.

## Non-goals

- global physical-input producer
- intervention debounce timer producer
- screen-unlock producer
- Codex turn-ended helper integration
- canonical app path/current-process-instance production binding
- real target/decoy Electron execution
- real process-restart E2E
- persistence-level privacy audit
- real macOS/real-window cumulative E2E
- provider/model-loop matrix

## Verification

- `npm --workspace @maka/runtime test` — 1434 passed, 2 skipped
- focused Runtime/Frame producer tests — passed
- `npm --workspace @maka/computer-use test` — 109 passed
- cross-layer deterministic contract — 3 passed
- `npm --workspace @maka/desktop run typecheck`
- `git diff --check`

## Follow-up stack

1. native/driver-level canonical app path + live process-instance identity
2. deterministic target/decoy cua-driver harness
3. Desktop terminal lifecycle + persistence privacy verification
4. reliable macOS physical-input/unlock producers
5. real Electron and real macOS cumulative gates

Stacked on #5.