### PR TITLE
test(cu): add guarded real-machine and concurrent-user E2E

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "typecheck": "npm run typecheck --workspaces --if-present",
     "test": "npm run test:scripts && npm --workspace @maka/core test && npm --workspace @maka/storage test && npm --workspace @maka/runtime test && npm --workspace @maka/computer-use test && npm --workspace @maka/headless test && npm --workspace maka-agent test && npm --workspace @maka/ui test && npm --workspace @maka/desktop test",
     "test:dist": "npm run test:scripts && npm exec -w @maka/core -- node --test \"dist/**/*.test.js\" && npm exec -w @maka/storage -- node --test \"dist/**/*.test.js\" && npm exec -w @maka/runtime -- node --test \"dist/**/*.test.js\" && npm exec -w @maka/computer-use -- node --test \"dist/**/*.test.js\" && npm exec -w @maka/headless -- node ../../scripts/run-headless-tests.mjs && npm exec -w maka-agent -- node --test \"dist/**/*.test.js\" && npm exec -w @maka/ui -- node --test \"dist/**/*.test.js\" && npm --workspace @maka/desktop run test:dist",
-    "test:scripts": "node --test scripts/run-headless-tests.test.mjs scripts/sync-model-metadata.test.mjs scripts/cua-driver-provenance.test.mjs",
+    "test:scripts": "node --test scripts/run-headless-tests.test.mjs scripts/sync-model-metadata.test.mjs scripts/cua-driver-provenance.test.mjs scripts/cu-real-e2e-contract.test.mjs",
     "dev": "npm --workspace @maka/desktop run dev:hmr --",
     "dev:full": "npm run build && npm --workspace @maka/desktop run start",
     "build": "npm --workspace @maka/core run build && npm --workspace @maka/storage run build && npm --workspace @maka/runtime run build && npm --workspace @maka/computer-use run build && npm --workspace @maka/headless run build && npm --workspace maka-agent run build && npm --workspace @maka/ui run build && npm --workspace @maka/desktop run build",
@@ -33,7 +33,9 @@
     "sync:model-metadata": "node scripts/sync-model-metadata.mjs",
     "cost:deepseek-baseline": "node scripts/deepseek-live-cost-baseline.mjs",
     "prepare:cua-driver": "node scripts/prepare-cua-driver.mjs",
-    "check:cua-driver-artifact": "node scripts/check-cua-driver-bundle.mjs"
+    "check:cua-driver-artifact": "node scripts/check-cua-driver-bundle.mjs",
+    "e2e:computer-use-real": "node scripts/cu-real-e2e-launcher.mjs",
+    "e2e:computer-use-concurrent": "node scripts/cu-real-e2e-launcher.mjs --concurrent-user"
   },
   "devDependencies": {
     "@types/node": "^25.0.0",

--- a/scripts/cu-real-e2e-contract.test.mjs
+++ b/scripts/cu-real-e2e-contract.test.mjs
@@ -40,7 +40,9 @@ test('concurrent mode allows user input without allowing fixture focus takeover'
   assert.match(monitor, /!concurrentUserMode && receivedPhysicalInput/);
   assert.match(harness, /fail_closed_occluded/);
   assert.match(harness, /fail_closed_hidden/);
-  assert.match(harness, /background_dispatch_succeeded/);
+  assert.match(harness, /concurrent-coordinate-policy-fail-closed/);
+  assert.match(harness, /semantic_background_succeeded/);
+  assert.match(harness, /allowCompatibilityInputDispatch: !concurrentUserMode/);
   assert.match(harness, /appId: `pid:\$\{baseline\.fixturePID\}`/);
   assert.match(harness, /invalid concurrent execution baseline/);
 });
@@ -62,10 +64,12 @@ test('harness validates exact synthetic provenance before real actions', () => {
   assert.match(harness, /baseline\.canonicalAppPath !== expectedAppPath/);
 });
 
-test('truth claims require pixel OOP evidence and fresh-refetch ambiguity evidence', () => {
+test('truth claims isolate pixel evidence and keep concurrent dispatch semantic', () => {
   assert.match(harness, /afterClick\.oop\.lastEventTrusted !== true/);
   assert.match(harness, /afterClick\.oop\.webContentPID === afterClick\.oop\.hostPID/);
   assert.match(harness, /dispatch\?\.address !== 'px'/);
+  assert.match(harness, /blockedFlow\?\.error !== 'unsupported_action'/);
+  assert.match(harness, /concurrent semantic action violated its oracle/);
   assert.match(harness, /duplicateFlow\?\.error !== 'stale_frame'/);
   assert.match(harness, /ambiguous semantic action did not fail closed in backend refetch/);
   assert.match(harness, /stale-missing, process restart, and canonical live-process identity require native or driver follow-up/);

--- a/scripts/cu-real-e2e-contract.test.mjs
+++ b/scripts/cu-real-e2e-contract.test.mjs
@@ -1,0 +1,80 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import test from 'node:test';
+
+const [packageJson, launcher, harness, monitor] = await Promise.all([
+  readFile(new URL('../package.json', import.meta.url), 'utf8'),
+  readFile(new URL('./cu-real-e2e-launcher.mjs', import.meta.url), 'utf8'),
+  readFile(new URL('./cu-real-e2e.mjs', import.meta.url), 'utf8'),
+  readFile(new URL('./cu-real-e2e-monitor.swift', import.meta.url), 'utf8'),
+]);
+
+test('real E2E builds the imported workspaces and runs in CI contract tests', () => {
+  assert.match(launcher, /@maka\/runtime[\s\S]*runBuilds/);
+  assert.match(launcher, /@maka\/computer-use[\s\S]*runBuilds/);
+  assert.match(launcher, /check:cua-driver-artifact/);
+  assert.match(packageJson, /cu-real-e2e-contract\.test\.mjs/);
+});
+
+test('launcher owns bounded cleanup, frontmost restoration, and sleep prevention', () => {
+  assert.match(launcher, /const originalFrontmost = await frontmostApplication/);
+  assert.match(launcher, /caffeinate', \['-dimsu'\]/);
+  assert.match(launcher, /terminateChild\(harness/);
+  assert.match(launcher, /SIGKILL/);
+  assert.match(launcher, /monitor\?\.stop/);
+  assert.match(launcher, /runFixtureScript\('stop\.sh'\)/);
+  assert.match(launcher, /restoreFrontmost\(originalFrontmost\)/);
+});
+
+test('concurrent mode allows user input without allowing fixture focus takeover', () => {
+  assert.match(packageJson, /e2e:computer-use-concurrent/);
+  assert.match(launcher, /--concurrent-user/);
+  assert.match(launcher, /MAKA_CU_REAL_E2E_MODE/);
+  assert.match(launcher, /baseline\.fixturePID = fixturePID/);
+  assert.match(launcher, /frontmostBeforeFixtureLaunch/);
+  assert.match(launcher, /await activateBundle\('com\.openai\.codex\.cualab'\)/);
+  assert.match(launcher, /concurrent-prepared\.json/);
+  assert.match(launcher, /concurrent-proceed\.json/);
+  assert.match(monitor, /synthetic fixture became frontmost during concurrent E2E/);
+  assert.match(monitor, /!concurrentUserMode && displacement > 4/);
+  assert.match(monitor, /!concurrentUserMode && receivedPhysicalInput/);
+  assert.match(harness, /fail_closed_occluded/);
+  assert.match(harness, /fail_closed_hidden/);
+  assert.match(harness, /background_dispatch_succeeded/);
+  assert.match(harness, /appId: `pid:\$\{baseline\.fixturePID\}`/);
+  assert.match(harness, /invalid concurrent execution baseline/);
+});
+
+test('monitor rejects lock, foreground change, pointer movement, and physical input', () => {
+  assert.match(monitor, /CGSSessionScreenIsLocked/);
+  assert.match(monitor, /screen became locked/);
+  assert.match(monitor, /frontmost PID changed/);
+  assert.match(monitor, /pointer moved during isolated E2E/);
+  assert.match(monitor, /physical user input detected/);
+});
+
+test('harness validates exact synthetic provenance before real actions', () => {
+  assert.match(harness, /state\.synthetic !== true/);
+  assert.match(harness, /state\.bundleIdentifier !== 'com\.openai\.codex\.cualab'/);
+  assert.match(harness, /state\.appPath !== expectedAppPath/);
+  assert.match(harness, /state\.oop\.hostPID !== fixture\.pid/);
+  assert.match(harness, /baseline\.frontmostPID !== fixture\.pid/);
+  assert.match(harness, /baseline\.canonicalAppPath !== expectedAppPath/);
+});
+
+test('truth claims require pixel OOP evidence and fresh-refetch ambiguity evidence', () => {
+  assert.match(harness, /afterClick\.oop\.lastEventTrusted !== true/);
+  assert.match(harness, /afterClick\.oop\.webContentPID === afterClick\.oop\.hostPID/);
+  assert.match(harness, /dispatch\?\.address !== 'px'/);
+  assert.match(harness, /duplicateFlow\?\.error !== 'stale_frame'/);
+  assert.match(harness, /ambiguous semantic action did not fail closed in backend refetch/);
+  assert.match(harness, /stale-missing, process restart, and canonical live-process identity require native or driver follow-up/);
+});
+
+test('reports and screenshots use launcher-owned exclusive temporary files', () => {
+  assert.match(harness, /MAKA_CU_REAL_E2E_TEMP_DIR/);
+  assert.match(harness, /relative\(resolve\(tmpdir\(\)\)/);
+  assert.match(harness, /flag: 'wx'/);
+  assert.doesNotMatch(harness, /\/tmp\/maka-cu-real-e2e/);
+  assert.match(launcher, /rm\(temporaryDirectory, \{ recursive: true, force: true \}\)/);
+});

--- a/scripts/cu-real-e2e-launcher.mjs
+++ b/scripts/cu-real-e2e-launcher.mjs
@@ -1,0 +1,317 @@
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { spawn } from 'node:child_process';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const repoRoot = join(here, '..');
+const monitorPath = join(here, 'cu-real-e2e-monitor.swift');
+const harnessPath = join(here, 'cu-real-e2e.mjs');
+const labRoot = '/Users/haoqing/Documents/Learning/codex-computer-use-lab';
+const statePath = join(labRoot, 'test-app', 'runtime', 'state.json');
+const concurrentUserMode = process.argv.includes('--concurrent-user');
+
+const delay = (milliseconds) =>
+  new Promise((resolve) => setTimeout(resolve, milliseconds));
+
+function runChild(file, args, options = {}) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(file, args, {
+      cwd: options.cwd,
+      env: options.env,
+      stdio: options.stdio ?? ['ignore', 'inherit', 'inherit'],
+    });
+    child.once('error', reject);
+    child.once('exit', (code, signal) => {
+      if (code === 0) resolve();
+      else reject(new Error(
+        `${file} failed (${signal ?? code})`,
+      ));
+    });
+  });
+}
+
+async function runFixtureScript(name) {
+  await runChild(join(labRoot, 'test-app', name), []);
+}
+
+async function runBuilds() {
+  await runChild('npm', ['--workspace', '@maka/core', 'run', 'build'], {
+    cwd: repoRoot,
+  });
+  await runChild('npm', ['--workspace', '@maka/runtime', 'run', 'build'], {
+    cwd: repoRoot,
+  });
+  await runChild('npm', ['--workspace', '@maka/computer-use', 'run', 'build'], {
+    cwd: repoRoot,
+  });
+  await runChild('npm', ['run', 'check:cua-driver-artifact'], {
+    cwd: repoRoot,
+  });
+}
+
+async function frontmostApplication() {
+  const script = [
+    'tell application "System Events"',
+    'set frontProcess to first application process whose frontmost is true',
+    'return (unix id of frontProcess as text) & tab & (bundle identifier of frontProcess as text)',
+    'end tell',
+  ].join('\n');
+  let output = '';
+  await new Promise((resolve, reject) => {
+    const child = spawn('/usr/bin/osascript', ['-e', script], {
+      stdio: ['ignore', 'pipe', 'inherit'],
+    });
+    child.stdout.setEncoding('utf8');
+    child.stdout.on('data', (chunk) => { output += chunk; });
+    child.once('error', reject);
+    child.once('exit', (code) => {
+      if (code === 0) resolve();
+      else reject(new Error(`failed to capture frontmost application (${code})`));
+    });
+  });
+  const [pid, bundleIdentifier] = output.trim().split('\t');
+  if (!Number.isInteger(Number(pid)) || !bundleIdentifier) {
+    throw new Error(`invalid frontmost application identity: ${output.trim()}`);
+  }
+  return { pid: Number(pid), bundleIdentifier };
+}
+
+async function activateBundle(bundleIdentifier) {
+  await runChild('/usr/bin/osascript', [
+    '-e',
+    `tell application id "${bundleIdentifier}" to activate`,
+  ], { stdio: ['ignore', 'ignore', 'inherit'] });
+  await delay(500);
+}
+
+async function restoreFrontmost(application) {
+  const escapedBundleIdentifier = application.bundleIdentifier
+    .replaceAll('\\', '\\\\')
+    .replaceAll('"', '\\"');
+  const script = [
+    'tell application "System Events"',
+    `if exists (first application process whose unix id is ${application.pid}) then`,
+    `set frontmost of first application process whose unix id is ${application.pid} to true`,
+    'else',
+    `tell application id "${escapedBundleIdentifier}" to activate`,
+    'end if',
+    'end tell',
+  ].join('\n');
+  await runChild('/usr/bin/osascript', ['-e', script], {
+    stdio: ['ignore', 'ignore', 'ignore'],
+  });
+}
+
+async function terminateChild(child, label, timeoutMs = 3_000) {
+  if (!child || child.exitCode !== null || child.signalCode !== null) return;
+  const exited = new Promise((resolve) => child.once('exit', resolve));
+  child.kill('SIGTERM');
+  if (await Promise.race([exited.then(() => true), delay(timeoutMs).then(() => false)])) {
+    return;
+  }
+  child.kill('SIGKILL');
+  if (!await Promise.race([exited.then(() => true), delay(timeoutMs).then(() => false)])) {
+    throw new Error(`${label} did not exit after SIGKILL`);
+  }
+}
+
+async function waitForJson(path, label, timeoutMs = 10_000) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    try {
+      return JSON.parse(await readFile(path, 'utf8'));
+    } catch (error) {
+      if (error?.code !== 'ENOENT' && !(error instanceof SyntaxError)) throw error;
+    }
+    await delay(50);
+  }
+  throw new Error(`${label} timeout`);
+}
+
+function startMonitor(input = {}) {
+  const args = [monitorPath];
+  if (input.concurrentUserMode) {
+    args.push('--concurrent-user', String(input.fixturePID));
+  }
+  const child = spawn('swift', args, {
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  let buffer = '';
+  let stderr = '';
+  let readyResolve;
+  let readyReject;
+  let failureResolve;
+  const ready = new Promise((resolve, reject) => {
+    readyResolve = resolve;
+    readyReject = reject;
+  });
+  const failure = new Promise((resolve) => { failureResolve = resolve; });
+  let readySettled = false;
+  let failureSettled = false;
+
+  const fail = (error) => {
+    const normalized = error instanceof Error ? error : new Error(String(error));
+    if (!readySettled) {
+      readySettled = true;
+      readyReject(normalized);
+    }
+    if (!failureSettled) {
+      failureSettled = true;
+      failureResolve(normalized);
+    }
+  };
+  child.stdout.setEncoding('utf8');
+  child.stdout.on('data', (chunk) => {
+    buffer += chunk;
+    const lines = buffer.split('\n');
+    buffer = lines.pop() ?? '';
+    for (const line of lines.map((value) => value.trim()).filter(Boolean)) {
+      const [kind, ...fields] = line.split('\t');
+      if (kind === 'READY') {
+        readySettled = true;
+        readyResolve({
+          mode: fields[0],
+          frontmostPID: Number(fields[1]),
+          pointer: { x: Number(fields[2]), y: Number(fields[3]) },
+          bundleIdentifier: fields[4],
+          canonicalAppPath: fields.slice(5).join('\t'),
+        });
+      } else if (kind === 'CHANGE' || kind === 'ERROR') {
+        fail(new Error(fields.join('\t') || line));
+      }
+    }
+  });
+  child.stderr.setEncoding('utf8');
+  child.stderr.on('data', (chunk) => { stderr += chunk; });
+  child.on('error', fail);
+  child.on('exit', (code, signal) => {
+    if (!failureSettled && code !== 0 && signal !== 'SIGTERM') {
+      fail(new Error(
+        `monitor exited (${signal ?? code})${stderr.trim() ? `: ${stderr.trim()}` : ''}`,
+      ));
+    }
+  });
+  return {
+    child,
+    ready,
+    failure,
+    stop: () => terminateChild(child, 'safety monitor'),
+  };
+}
+
+async function run() {
+  const originalFrontmost = await frontmostApplication();
+  const temporaryDirectory = await mkdtemp(join(tmpdir(), 'maka-cu-real-e2e-'));
+  let fixtureTouched = false;
+  let caffeinate;
+  let monitor;
+  let harness;
+  try {
+    caffeinate = spawn('/usr/bin/caffeinate', ['-dimsu'], {
+      stdio: ['ignore', 'ignore', 'inherit'],
+    });
+    await runBuilds();
+    fixtureTouched = true;
+    await runFixtureScript('stop.sh');
+    await runFixtureScript('reset.sh');
+    const frontmostBeforeFixtureLaunch = concurrentUserMode
+      ? await frontmostApplication()
+      : originalFrontmost;
+    await runFixtureScript('launch.sh');
+    const fixtureState = JSON.parse(await readFile(statePath, 'utf8'));
+    const fixturePID = fixtureState?.oop?.hostPID;
+    if (!Number.isInteger(fixturePID) || fixturePID <= 0) {
+      throw new Error('synthetic fixture did not publish a valid PID');
+    }
+    await activateBundle('com.openai.codex.cualab');
+    const preparedPath = join(temporaryDirectory, 'concurrent-prepared.json');
+    const proceedPath = join(temporaryDirectory, 'concurrent-proceed.json');
+    let baseline;
+    if (!concurrentUserMode) {
+      monitor = startMonitor({ concurrentUserMode, fixturePID });
+      baseline = await Promise.race([
+        monitor.ready,
+        delay(10_000).then(() => {
+          throw new Error('safety monitor startup timeout');
+        }),
+      ]);
+      baseline.fixturePID = fixturePID;
+    } else {
+      baseline = {
+        mode: 'concurrent_user',
+        fixturePID,
+        frontmostPID: frontmostBeforeFixtureLaunch.pid,
+        pointer: { x: 0, y: 0 },
+        bundleIdentifier: frontmostBeforeFixtureLaunch.bundleIdentifier,
+        canonicalAppPath: 'pending-concurrent-monitor',
+      };
+    }
+    harness = spawn(process.execPath, [harnessPath], {
+      cwd: repoRoot,
+      env: {
+        ...process.env,
+        MAKA_CU_REAL_E2E_BASELINE: JSON.stringify(baseline),
+        MAKA_CU_REAL_E2E_MODE: concurrentUserMode ? 'concurrent_user' : 'isolated',
+        MAKA_CU_REAL_E2E_TEMP_DIR: temporaryDirectory,
+      },
+      stdio: ['ignore', 'inherit', 'inherit'],
+    });
+    const exit = new Promise((resolve, reject) => {
+      harness.once('error', reject);
+      harness.once('exit', (code, signal) => resolve({ code, signal }));
+    });
+    if (concurrentUserMode) {
+      await Promise.race([
+        waitForJson(preparedPath, 'concurrent E2E prepare'),
+        exit.then((result) => {
+          throw new Error(
+            `real E2E exited before concurrent prepare (${result.signal ?? result.code})`,
+          );
+        }),
+      ]);
+      await restoreFrontmost(frontmostBeforeFixtureLaunch);
+      await delay(750);
+      monitor = startMonitor({ concurrentUserMode, fixturePID });
+      const concurrentBaseline = await Promise.race([
+        monitor.ready,
+        delay(10_000).then(() => {
+          throw new Error('concurrent safety monitor startup timeout');
+        }),
+      ]);
+      concurrentBaseline.fixturePID = fixturePID;
+      await runChild(process.execPath, [
+        '-e',
+        "require('fs').writeFileSync(process.argv[1], process.argv[2], {flag:'wx',mode:0o600})",
+        proceedPath,
+        JSON.stringify(concurrentBaseline),
+      ], { stdio: ['ignore', 'ignore', 'inherit'] });
+    }
+    const first = await Promise.race([
+      exit.then((result) => ({ type: 'exit', result })),
+      monitor.failure.then((error) => ({ type: 'safety', error })),
+    ]);
+    if (first.type === 'safety') {
+      await terminateChild(harness, 'real E2E harness');
+      throw first.error;
+    }
+    if (first.result.code !== 0) {
+      throw new Error(`real E2E failed (${first.result.signal ?? first.result.code})`);
+    }
+  } finally {
+    await terminateChild(harness, 'real E2E harness').catch(() => {});
+    await monitor?.stop().catch(() => {});
+    if (fixtureTouched) await runFixtureScript('stop.sh').catch(() => {});
+    if (!concurrentUserMode) {
+      await restoreFrontmost(originalFrontmost).catch(() => {});
+    }
+    await terminateChild(caffeinate, 'caffeinate').catch(() => {});
+    await rm(temporaryDirectory, { recursive: true, force: true });
+  }
+}
+
+run().catch((error) => {
+  console.error('Computer Use real E2E failed:', error);
+  process.exitCode = 1;
+});

--- a/scripts/cu-real-e2e-monitor.swift
+++ b/scripts/cu-real-e2e-monitor.swift
@@ -1,0 +1,109 @@
+import Cocoa
+import CoreGraphics
+import Darwin
+
+setbuf(stdout, nil)
+
+let concurrentUserMode = CommandLine.arguments.contains("--concurrent-user")
+let mode = concurrentUserMode ? "concurrent_user" : "isolated"
+let fixturePID: pid_t? = {
+    guard concurrentUserMode,
+          let flagIndex = CommandLine.arguments.firstIndex(of: "--concurrent-user"),
+          CommandLine.arguments.indices.contains(flagIndex + 1),
+          let value = Int32(CommandLine.arguments[flagIndex + 1])
+    else {
+        return nil
+    }
+    return value
+}()
+if concurrentUserMode && fixturePID == nil {
+    print("ERROR\tconcurrent mode requires the fixture PID")
+    exit(1)
+}
+
+func screenIsLocked() -> Bool {
+    guard let session = CGSessionCopyCurrentDictionary() as? [String: Any] else {
+        return true
+    }
+    return session["CGSSessionScreenIsLocked"] as? Bool ?? false
+}
+
+guard !screenIsLocked() else {
+    print("ERROR\tscreen is locked")
+    exit(1)
+}
+
+guard let initialApplication = NSWorkspace.shared.frontmostApplication else {
+    print("ERROR\tno frontmost application")
+    exit(1)
+}
+
+let frontmostPID = initialApplication.processIdentifier
+guard let bundleIdentifier = initialApplication.bundleIdentifier,
+      let bundlePath = initialApplication.bundleURL?.resolvingSymlinksInPath().path
+else {
+    print("ERROR\tfrontmost application identity is incomplete")
+    exit(1)
+}
+let initialPointer = NSEvent.mouseLocation
+let startedAt = ProcessInfo.processInfo.systemUptime
+let physicalEventTypes: [CGEventType] = [
+    .keyDown,
+    .leftMouseDown,
+    .rightMouseDown,
+    .otherMouseDown,
+    .mouseMoved,
+    .leftMouseDragged,
+    .rightMouseDragged,
+    .otherMouseDragged
+]
+print(
+    "READY\t\(mode)\t\(frontmostPID)\t\(initialPointer.x)\t\(initialPointer.y)"
+        + "\t\(bundleIdentifier)\t\(bundlePath)"
+)
+
+while true {
+    autoreleasepool {
+        if screenIsLocked() {
+            print("CHANGE\tscreen became locked")
+            exit(2)
+        }
+        let currentPID =
+            NSWorkspace.shared.frontmostApplication?.processIdentifier ?? -1
+        let currentPointer = NSEvent.mouseLocation
+        if concurrentUserMode && currentPID == fixturePID {
+            print("CHANGE\tsynthetic fixture became frontmost during concurrent E2E")
+            exit(3)
+        }
+        if !concurrentUserMode && currentPID != frontmostPID {
+            print("CHANGE\tfrontmost PID changed: \(frontmostPID) -> \(currentPID)")
+            exit(3)
+        }
+        let displacement = hypot(
+            currentPointer.x - initialPointer.x,
+            currentPointer.y - initialPointer.y
+        )
+        if !concurrentUserMode && displacement > 4 {
+            print(
+                "CHANGE\tpointer moved during isolated E2E: "
+                    + "(\(initialPointer.x),\(initialPointer.y)) -> "
+                    + "(\(currentPointer.x),\(currentPointer.y)); "
+                    + "displacement \(displacement)"
+            )
+            exit(4)
+        }
+        let elapsed = ProcessInfo.processInfo.systemUptime - startedAt
+        let receivedPhysicalInput = physicalEventTypes.contains { eventType in
+            let age = CGEventSource.secondsSinceLastEventType(
+                .hidSystemState,
+                eventType: eventType
+            )
+            return age + 0.02 < elapsed
+        }
+        if !concurrentUserMode && receivedPhysicalInput {
+            print("CHANGE\tphysical user input detected during isolated E2E")
+            exit(5)
+        }
+    }
+    usleep(5_000)
+}

--- a/scripts/cu-real-e2e.mjs
+++ b/scripts/cu-real-e2e.mjs
@@ -1,0 +1,510 @@
+import { execFile } from 'node:child_process';
+import { readFile, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join, relative, resolve } from 'node:path';
+import { createCuaDriverBackend, createComputerUseOverlayHook } from '../packages/computer-use/dist/index.js';
+import { buildComputerUseTools } from '../packages/runtime/dist/index.js';
+
+const repoRoot = new URL('..', import.meta.url).pathname;
+const binaryPath = join(repoRoot, 'apps/desktop/resources/bin/cua-driver');
+const labRoot = '/Users/haoqing/Documents/Learning/codex-computer-use-lab';
+const expectedAppPath = join(labRoot, 'test-app/build/Codex CUA Lab.app');
+const statePath = join(labRoot, 'test-app/runtime/state.json');
+const temporaryDirectory = process.env.MAKA_CU_REAL_E2E_TEMP_DIR;
+const e2eMode = process.env.MAKA_CU_REAL_E2E_MODE ?? 'isolated';
+const concurrentUserMode = e2eMode === 'concurrent_user';
+const expectedBinarySha256 =
+  '683dad5cccb47dd0a8bb5d534d62fbb9e6edfb1cded232509cf4c2b190066040';
+
+const resolvedTemporaryDirectory = resolve(temporaryDirectory ?? '');
+const temporaryRelativePath = relative(resolve(tmpdir()), resolvedTemporaryDirectory);
+if (
+  !temporaryDirectory
+  || temporaryRelativePath.startsWith('..')
+  || temporaryRelativePath === ''
+) {
+  throw new Error('real E2E requires a launcher-owned temporary directory');
+}
+const reportPath = join(resolvedTemporaryDirectory, 'report.json');
+const screenshotPath = join(resolvedTemporaryDirectory, 'observation.png');
+const concurrentPreparedPath = join(
+  resolvedTemporaryDirectory,
+  'concurrent-prepared.json',
+);
+const concurrentProceedPath = join(
+  resolvedTemporaryDirectory,
+  'concurrent-proceed.json',
+);
+
+const exec = (file, args) => new Promise((resolve, reject) => {
+  execFile(file, args, { encoding: 'utf8' }, (error, stdout, stderr) => {
+    if (error) reject(new Error(`${file} failed: ${stderr || error.message}`));
+    else resolve(stdout.trim());
+  });
+});
+const delay = (milliseconds) =>
+  new Promise((resolve) => setTimeout(resolve, milliseconds));
+const waitForJson = async (path, label, timeoutMs = 10_000) => {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    try {
+      return JSON.parse(await readFile(path, 'utf8'));
+    } catch (error) {
+      if (error?.code !== 'ENOENT' && !(error instanceof SyntaxError)) throw error;
+    }
+    await delay(50);
+  }
+  throw new Error(`${label} timeout`);
+};
+
+const baseline = JSON.parse(process.env.MAKA_CU_REAL_E2E_BASELINE ?? '{}');
+if (
+  !Number.isInteger(baseline.frontmostPID)
+  || !Number.isFinite(baseline.pointer?.x)
+  || !Number.isFinite(baseline.pointer?.y)
+  || typeof baseline.bundleIdentifier !== 'string'
+  || typeof baseline.canonicalAppPath !== 'string'
+  || baseline.mode !== e2eMode
+  || !Number.isInteger(baseline.fixturePID)
+) {
+  throw new Error('invalid safety baseline');
+}
+
+const overlayEvents = [];
+const invalidations = [];
+const traces = [];
+const idFlow = [];
+let latestObservationGeometry;
+const overlay = createComputerUseOverlayHook({
+  ensure() {},
+  move(input) {
+    overlayEvents.push({ phase: 'move', actionId: input.actionId });
+    return {
+      readyForInteraction: Promise.resolve(),
+      finished: Promise.resolve(),
+    };
+  },
+  complete(input) {
+    overlayEvents.push({ phase: 'complete', actionId: input.actionId });
+  },
+  cancel(input) {
+    overlayEvents.push({ phase: 'cancel', actionId: input.actionId });
+  },
+});
+const backend = createCuaDriverBackend({
+  binaryPath,
+  hostBundleId: 'com.maka.desktop',
+  expectedBinarySha256,
+  expectedServerName: 'cua-driver',
+  expectedServerVersion: '0.7.1',
+  expectedProtocolVersion: '2025-06-18',
+  timeoutMs: 10_000,
+  onSessionInvalidated(event) {
+    invalidations.push(event);
+  },
+  onTrace(event) {
+    traces.push(event);
+  },
+});
+const instrumentedBackend = {
+  ...backend,
+  async observeApp(input, signal, context) {
+    const observation = await backend.observeApp(input, signal, context);
+    latestObservationGeometry = {
+      windowBounds: observation.windowBounds,
+      sourceBoundsPx: observation.sourceBoundsPx,
+    };
+    idFlow.push({
+      phase: 'observe',
+      observationId: observation.observationId,
+      sessionId: context.sessionId,
+      turnId: context.turnId,
+    });
+    return observation;
+  },
+  async runSemantic(action, signal, context) {
+    idFlow.push({
+      phase: 'runSemantic',
+      observationId: action.observationId,
+      sessionId: context.sessionId,
+      turnId: context.turnId,
+    });
+    const result = await backend.runSemantic(action, signal, context);
+    idFlow.push({
+      phase: 'runSemanticResult',
+      ok: result.outcome.ok,
+      ...(!result.outcome.ok
+        ? { error: result.outcome.error, message: result.outcome.message }
+        : {}),
+    });
+    return result;
+  },
+  async run(action, signal, context) {
+    idFlow.push({
+      phase: 'run',
+      actionType: action.type,
+      sessionId: context.sessionId,
+      turnId: context.turnId,
+    });
+    const result = await backend.run(action, signal, context);
+    idFlow.push({
+      phase: 'runResult',
+      ok: result.outcome.ok,
+      ...(!result.outcome.ok
+        ? { error: result.outcome.error, message: result.outcome.message }
+        : {}),
+    });
+    return result;
+  },
+};
+const tools = buildComputerUseTools({ backend: instrumentedBackend, overlay });
+const [tool] = tools;
+const context = (toolCallId, turnId = 'turn-1') => ({
+  sessionId: 'real-e2e',
+  turnId,
+  toolCallId,
+  cwd: repoRoot,
+  abortSignal: new AbortController().signal,
+  emitOutput() {},
+});
+
+const readState = async () => JSON.parse(await readFile(statePath, 'utf8'));
+const call = (input, toolCallId, turnId) =>
+  tool.impl(input, context(toolCallId, turnId));
+const parseModel = (result) => JSON.parse(result.modelText ?? '{}');
+const findOccurrence = (observation, label, occurrence = 0) => {
+  const matches = observation.elements
+    .filter((element) => element.label === label)
+    .sort((left, right) => Number(left.element_id) - Number(right.element_id));
+  const selected = matches[occurrence];
+  if (!selected) {
+    throw new Error(
+      `${label} occurrence ${occurrence} missing; candidates=${matches.length}`,
+    );
+  }
+  return { selected, candidateCount: matches.length, occurrence };
+};
+const discoverFixture = async (turnId = 'turn-1') => {
+  if (concurrentUserMode) {
+    return {
+      appId: `pid:${baseline.fixturePID}`,
+      pid: baseline.fixturePID,
+    };
+  }
+  const listed = parseModel(await call(
+    { action: 'list_apps' },
+    `list-apps-${turnId}`,
+    turnId,
+  ));
+  const matches = listed.apps.filter((candidate) =>
+    candidate.name === 'Codex CUA Lab'
+    || candidate.windows?.some((window) => window.title === 'Codex CUA Lab'));
+  if (matches.length !== 1) {
+    throw new Error(`expected one synthetic fixture app, got ${matches.length}`);
+  }
+  const app = matches[0];
+  const windows = app.windows?.filter((window) => window.title === 'Codex CUA Lab') ?? [];
+  if (windows.length !== 1) throw new Error(`expected one fixture window, got ${windows.length}`);
+  return { appId: app.app_id, windowId: windows[0].window_id, pid: app.pid };
+};
+const observe = async (fixture, id, turnId) => {
+  const result = await call({
+    action: 'observe',
+    app: fixture.appId,
+    ...(fixture.windowId !== undefined ? { window_id: fixture.windowId } : {}),
+    include_screenshot: true,
+  }, id, turnId);
+  if (result.error || !result.modelText) {
+    throw new Error(`observe failed: ${result.error ?? result.text}`);
+  }
+  return {
+    result,
+    model: parseModel(result),
+    persisted: JSON.parse(result.text),
+    geometry: latestObservationGeometry,
+  };
+};
+const coordinateForElement = (observed, element) => {
+  const screenshot = observed.persisted.screenshot;
+  const frame = element.frame;
+  const window = observed.geometry?.windowBounds;
+  if (!screenshot || !frame || !window) {
+    throw new Error('coordinate conversion evidence is incomplete');
+  }
+  return [
+    Math.round(
+      (frame.x + frame.width / 2 - window.x)
+        / window.width * screenshot.width_px,
+    ),
+    Math.round(
+      (frame.y + frame.height / 2 - window.y)
+        / window.height * screenshot.height_px,
+    ),
+  ];
+};
+const screenCoordinateForElement = (element) => {
+  if (!element.frame) throw new Error('element has no screen frame');
+  return {
+    x: Math.round(element.frame.x + element.frame.width / 2),
+    y: Math.round(element.frame.y + element.frame.height / 2),
+  };
+};
+const validateFixtureIdentity = async (fixture, state) => {
+  if (
+    state.synthetic !== true
+    || state.syntheticMarker !== 'CUA Lab Synthetic Surface'
+    || state.bundleIdentifier !== 'com.openai.codex.cualab'
+    || state.appPath !== expectedAppPath
+    || state.oop.hostPID !== fixture.pid
+    || fixture.pid !== baseline.fixturePID
+    || (!concurrentUserMode && baseline.frontmostPID !== fixture.pid)
+    || (!concurrentUserMode && baseline.bundleIdentifier !== 'com.openai.codex.cualab')
+    || (!concurrentUserMode && baseline.canonicalAppPath !== expectedAppPath)
+    || (concurrentUserMode && baseline.frontmostPID === fixture.pid)
+  ) {
+    throw new Error('synthetic fixture provenance mismatch');
+  }
+};
+const fixtureCoordinateMutation = async (observed, label) => {
+  const target = findOccurrence(observed.model, label);
+  const coordinate = screenCoordinateForElement(target.selected);
+  const winner = await backend.inspectWindowAt(
+    coordinate,
+    new AbortController().signal,
+  );
+  if (!winner || winner.pid !== observed.model.pid || winner.windowId !== observed.model.window_id) {
+    throw new Error(`fixture mutation point is not owned by the fixture: ${label}`);
+  }
+  const result = await backend.run(
+    { type: 'left_click', coordinate },
+    new AbortController().signal,
+    {
+      sessionId: 'fixture-mutation',
+      turnId: 'mutation',
+      toolCallId: `mutate-${label}`,
+    },
+  );
+  if (!result.outcome.ok) {
+    throw new Error(`fixture mutation failed: ${result.outcome.message}`);
+  }
+};
+const writeReport = async (report) => {
+  await writeFile(reportPath, `${JSON.stringify(report, null, 2)}\n`, {
+    flag: 'wx',
+    mode: 0o600,
+  });
+};
+
+const report = {
+  schemaVersion: 2,
+  fixture: {
+    bundleIdentifier: 'com.openai.codex.cualab',
+    canonicalAppPath: expectedAppPath,
+  },
+  cases: [],
+  safety: {
+    mode: e2eMode,
+    frontmostPID: baseline.frontmostPID,
+    pointer: baseline.pointer,
+    targetPolicy: 'exact synthetic bundle, path, pid, and window only',
+    lockedComputerUse: false,
+  },
+};
+
+try {
+  const fixture = await discoverFixture();
+  const initial = await readState();
+  await validateFixtureIdentity(fixture, initial);
+  report.fixture = { ...report.fixture, pid: fixture.pid, windowId: fixture.windowId };
+
+  const observed = await observe(fixture, 'observe-oop', 'turn-oop');
+  if (observed.result.screenshot?.base64) {
+    await writeFile(
+      screenshotPath,
+      Buffer.from(observed.result.screenshot.base64, 'base64'),
+      { flag: 'wx', mode: 0o600 },
+    );
+  }
+  if (concurrentUserMode) {
+    await writeFile(
+      concurrentPreparedPath,
+      `${JSON.stringify({
+        observationId: observed.model.observation_id,
+        fixturePID: fixture.pid,
+      })}\n`,
+      { flag: 'wx', mode: 0o600 },
+    );
+    const concurrentBaseline = await waitForJson(
+      concurrentProceedPath,
+      'concurrent E2E proceed',
+    );
+    if (
+      concurrentBaseline.mode !== 'concurrent_user'
+      || concurrentBaseline.fixturePID !== fixture.pid
+      || concurrentBaseline.frontmostPID === fixture.pid
+    ) {
+      throw new Error('invalid concurrent execution baseline');
+    }
+    report.safety = {
+      ...report.safety,
+      frontmostPID: concurrentBaseline.frontmostPID,
+      pointer: concurrentBaseline.pointer,
+    };
+  }
+  const oop = findOccurrence(observed.model, 'CUA Lab OOP Button');
+  const oopCoordinate = coordinateForElement(observed, oop.selected);
+  let clickFailure;
+  let clicked;
+  try {
+    clicked = await call({
+      action: 'left_click',
+      observation_id: observed.model.observation_id,
+      coordinate: oopCoordinate,
+    }, 'click-oop', 'turn-oop');
+  } catch (error) {
+    clickFailure = error instanceof Error ? error.message : String(error);
+    if (!concurrentUserMode) throw error;
+  }
+  await delay(250);
+  const afterClick = await readState();
+  const dispatch = traces.find(
+    (event) => event.type === 'dispatch' && event.toolCallId === 'click-oop',
+  );
+  const runResult = idFlow.findLast((event) => event.phase === 'runResult');
+  const occluded = concurrentUserMode
+    && runResult?.ok === false
+    && runResult.error === 'target_occluded';
+  const hidden = concurrentUserMode
+    && /invalidApp: no visible window matched/.test(clickFailure ?? '');
+  const clickSucceeded = !clickFailure
+    && !clicked?.error
+    && afterClick.oop.clickCount === initial.oop.clickCount + 1;
+  const clickEvidenceInvalid = clickSucceeded && (
+    afterClick.oop.lastEventTrusted !== true
+    || afterClick.oop.webContentPID <= 0
+    || afterClick.oop.webContentPID === afterClick.oop.hostPID
+    || afterClick.oop.hostLocalMouseDownCount <= initial.oop.hostLocalMouseDownCount
+    || afterClick.oop.hostLocalMouseUpCount <= initial.oop.hostLocalMouseUpCount
+    || afterClick.oop.hostLocalMouseDownCount - initial.oop.hostLocalMouseDownCount
+      !== afterClick.oop.hostLocalMouseUpCount - initial.oop.hostLocalMouseUpCount
+    || dispatch?.address !== 'px'
+  );
+  if (
+    (!clickSucceeded && !occluded && !hidden)
+    || ((occluded || hidden) && afterClick.oop.clickCount !== initial.oop.clickCount)
+    || clickEvidenceInvalid
+  ) {
+    throw new Error(`OOP coordinate oracle did not prove trusted pixel dispatch: ${JSON.stringify({
+      clickFailure,
+      clickedError: clicked?.error,
+      clickedText: clicked?.text,
+      coordinate: oopCoordinate,
+      dispatch,
+      before: initial.oop,
+      after: afterClick.oop,
+    })}`);
+  }
+  report.cases.push({
+    id: concurrentUserMode
+      ? 'concurrent-user-background-coordinate'
+      : 'oop-webcontent-coordinate-click',
+    ok: true,
+    outcome: hidden
+      ? 'fail_closed_hidden'
+      : occluded
+        ? 'fail_closed_occluded'
+        : 'background_dispatch_succeeded',
+    dispatchAddress: dispatch?.address,
+    coordinate: oopCoordinate,
+    oracle: {
+      clickCount: [initial.oop.clickCount, afterClick.oop.clickCount],
+      lastEventTrusted: clickSucceeded ? afterClick.oop.lastEventTrusted : undefined,
+      hostPID: afterClick.oop.hostPID,
+      webContentPID: afterClick.oop.webContentPID,
+      hostMouseDown: [
+        initial.oop.hostLocalMouseDownCount,
+        afterClick.oop.hostLocalMouseDownCount,
+      ],
+      hostMouseUp: [
+        initial.oop.hostLocalMouseUpCount,
+        afterClick.oop.hostLocalMouseUpCount,
+      ],
+    },
+  });
+
+  if (concurrentUserMode) {
+    report.ok = true;
+    report.claimBoundary =
+      'concurrent mode proves no focus takeover; success still requires a visible, unoccluded target';
+    report.evidence = {
+      invalidations,
+      traceTypes: traces.map((event) => event.type),
+      idFlow,
+    };
+    await writeReport(report);
+    process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+    process.exitCode = 0;
+  } else {
+    tools.clearSession('real-e2e');
+    const duplicateObserved = await observe(fixture, 'observe-duplicate', 'turn-duplicate');
+    const duplicate = findOccurrence(
+      duplicateObserved.model,
+      'CUA Lab Duplicate Action',
+    );
+    if (duplicate.candidateCount < 2) {
+      throw new Error('duplicate semantic fixture is not ambiguous');
+    }
+    const duplicateAttempt = await call({
+      action: 'click_element',
+      observation_id: duplicateObserved.model.observation_id,
+      element_id: duplicate.selected.element_id,
+    }, 'semantic-duplicate', 'turn-duplicate');
+    const afterDuplicate = await readState();
+    const duplicateFlow = idFlow.findLast((event) => event.phase === 'runSemanticResult');
+    if (
+      duplicateFlow?.error !== 'stale_frame'
+      || !/ambiguous/.test(duplicateFlow.message ?? '')
+      || afterDuplicate.ambiguous.clickCount !== initial.ambiguous.clickCount
+    ) {
+      throw new Error('ambiguous semantic action did not fail closed in backend refetch');
+    }
+    report.cases.push({
+      id: 'semantic-duplicate-fail-closed',
+      ok: true,
+      runtimeError: duplicateAttempt.error,
+      backendError: duplicateFlow.error,
+      backendMessage: duplicateFlow.message,
+      candidateCount: duplicate.candidateCount,
+      oracle: [initial.ambiguous.clickCount, afterDuplicate.ambiguous.clickCount],
+    });
+
+    report.ok = report.cases.every((entry) => entry.ok);
+    report.claimBoundary =
+      'stale-missing, process restart, and canonical live-process identity require native or driver follow-up';
+    report.evidence = {
+      invalidations,
+      traceTypes: traces.map((event) => event.type),
+      idFlow,
+    };
+    await writeReport(report);
+    process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+  }
+} catch (error) {
+  const failureReport = {
+    ...report,
+    ok: false,
+    failure: error instanceof Error ? error.message : String(error),
+    evidence: {
+      invalidations,
+      traces,
+      idFlow,
+      overlayEvents,
+    },
+  };
+  await writeReport(failureReport).catch(() => {});
+  process.stderr.write(`${JSON.stringify(failureReport, null, 2)}\n`);
+  throw error;
+} finally {
+  tools.clearSession('real-e2e');
+  backend.dispose();
+}

--- a/scripts/cu-real-e2e.mjs
+++ b/scripts/cu-real-e2e.mjs
@@ -99,6 +99,7 @@ const backend = createCuaDriverBackend({
   expectedServerVersion: '0.7.1',
   expectedProtocolVersion: '2025-06-18',
   timeoutMs: 10_000,
+  allowCompatibilityInputDispatch: !concurrentUserMode,
   onSessionInvalidated(event) {
     invalidations.push(event);
   },
@@ -159,8 +160,12 @@ const instrumentedBackend = {
 };
 const tools = buildComputerUseTools({ backend: instrumentedBackend, overlay });
 const [tool] = tools;
-const context = (toolCallId, turnId = 'turn-1') => ({
-  sessionId: 'real-e2e',
+const context = (
+  toolCallId,
+  turnId = 'turn-1',
+  sessionId = 'real-e2e',
+) => ({
+  sessionId,
   turnId,
   toolCallId,
   cwd: repoRoot,
@@ -169,8 +174,8 @@ const context = (toolCallId, turnId = 'turn-1') => ({
 });
 
 const readState = async () => JSON.parse(await readFile(statePath, 'utf8'));
-const call = (input, toolCallId, turnId) =>
-  tool.impl(input, context(toolCallId, turnId));
+const call = (input, toolCallId, turnId, sessionId) =>
+  tool.impl(input, context(toolCallId, turnId, sessionId));
 const parseModel = (result) => JSON.parse(result.modelText ?? '{}');
 const findOccurrence = (observation, label, occurrence = 0) => {
   const matches = observation.elements
@@ -207,13 +212,13 @@ const discoverFixture = async (turnId = 'turn-1') => {
   if (windows.length !== 1) throw new Error(`expected one fixture window, got ${windows.length}`);
   return { appId: app.app_id, windowId: windows[0].window_id, pid: app.pid };
 };
-const observe = async (fixture, id, turnId) => {
+const observe = async (fixture, id, turnId, sessionId) => {
   const result = await call({
     action: 'observe',
     app: fixture.appId,
     ...(fixture.windowId !== undefined ? { window_id: fixture.windowId } : {}),
     include_screenshot: true,
-  }, id, turnId);
+  }, id, turnId, sessionId);
   if (result.error || !result.modelText) {
     throw new Error(`observe failed: ${result.error ?? result.text}`);
   }
@@ -318,6 +323,14 @@ try {
   report.fixture = { ...report.fixture, pid: fixture.pid, windowId: fixture.windowId };
 
   const observed = await observe(fixture, 'observe-oop', 'turn-oop');
+  const concurrentSemanticObserved = concurrentUserMode
+    ? await observe(
+        fixture,
+        'observe-concurrent-semantic',
+        'turn-concurrent-semantic',
+        'real-e2e-semantic',
+      )
+    : undefined;
   if (observed.result.screenshot?.base64) {
     await writeFile(
       screenshotPath,
@@ -351,91 +364,121 @@ try {
       pointer: concurrentBaseline.pointer,
     };
   }
-  const oop = findOccurrence(observed.model, 'CUA Lab OOP Button');
-  const oopCoordinate = coordinateForElement(observed, oop.selected);
-  let clickFailure;
-  let clicked;
-  try {
-    clicked = await call({
+  if (concurrentUserMode) {
+    const blockedTarget = findOccurrence(
+      observed.model,
+      'CUA Lab Coordinate Target',
+    );
+    const blockedCoordinate = coordinateForElement(
+      observed,
+      blockedTarget.selected,
+    );
+    const blockedToolCallId = 'concurrent-coordinate-policy';
+    const blockedAttempt = await call({
       action: 'left_click',
       observation_id: observed.model.observation_id,
-      coordinate: oopCoordinate,
-    }, 'click-oop', 'turn-oop');
-  } catch (error) {
-    clickFailure = error instanceof Error ? error.message : String(error);
-    if (!concurrentUserMode) throw error;
-  }
-  await delay(250);
-  const afterClick = await readState();
-  const dispatch = traces.find(
-    (event) => event.type === 'dispatch' && event.toolCallId === 'click-oop',
-  );
-  const runResult = idFlow.findLast((event) => event.phase === 'runResult');
-  const occluded = concurrentUserMode
-    && runResult?.ok === false
-    && runResult.error === 'target_occluded';
-  const hidden = concurrentUserMode
-    && /invalidApp: no visible window matched/.test(clickFailure ?? '');
-  const clickSucceeded = !clickFailure
-    && !clicked?.error
-    && afterClick.oop.clickCount === initial.oop.clickCount + 1;
-  const clickEvidenceInvalid = clickSucceeded && (
-    afterClick.oop.lastEventTrusted !== true
-    || afterClick.oop.webContentPID <= 0
-    || afterClick.oop.webContentPID === afterClick.oop.hostPID
-    || afterClick.oop.hostLocalMouseDownCount <= initial.oop.hostLocalMouseDownCount
-    || afterClick.oop.hostLocalMouseUpCount <= initial.oop.hostLocalMouseUpCount
-    || afterClick.oop.hostLocalMouseDownCount - initial.oop.hostLocalMouseDownCount
-      !== afterClick.oop.hostLocalMouseUpCount - initial.oop.hostLocalMouseUpCount
-    || dispatch?.address !== 'px'
-  );
-  if (
-    (!clickSucceeded && !occluded && !hidden)
-    || ((occluded || hidden) && afterClick.oop.clickCount !== initial.oop.clickCount)
-    || clickEvidenceInvalid
-  ) {
-    throw new Error(`OOP coordinate oracle did not prove trusted pixel dispatch: ${JSON.stringify({
-      clickFailure,
-      clickedError: clicked?.error,
-      clickedText: clicked?.text,
-      coordinate: oopCoordinate,
-      dispatch,
-      before: initial.oop,
-      after: afterClick.oop,
-    })}`);
-  }
-  report.cases.push({
-    id: concurrentUserMode
-      ? 'concurrent-user-background-coordinate'
-      : 'oop-webcontent-coordinate-click',
-    ok: true,
-    outcome: hidden
-      ? 'fail_closed_hidden'
-      : occluded
-        ? 'fail_closed_occluded'
-        : 'background_dispatch_succeeded',
-    dispatchAddress: dispatch?.address,
-    coordinate: oopCoordinate,
-    oracle: {
-      clickCount: [initial.oop.clickCount, afterClick.oop.clickCount],
-      lastEventTrusted: clickSucceeded ? afterClick.oop.lastEventTrusted : undefined,
-      hostPID: afterClick.oop.hostPID,
-      webContentPID: afterClick.oop.webContentPID,
-      hostMouseDown: [
-        initial.oop.hostLocalMouseDownCount,
-        afterClick.oop.hostLocalMouseDownCount,
-      ],
-      hostMouseUp: [
-        initial.oop.hostLocalMouseUpCount,
-        afterClick.oop.hostLocalMouseUpCount,
-      ],
-    },
-  });
+      coordinate: blockedCoordinate,
+    }, blockedToolCallId, 'turn-oop');
+    await delay(150);
+    const afterBlocked = await readState();
+    const blockedFlow = idFlow.findLast(
+      (event) => event.phase === 'runResult',
+    );
+    const blockedDispatch = traces.find(
+      (event) => event.type === 'dispatch'
+        && event.toolCallId === blockedToolCallId,
+    );
+    if (
+      blockedFlow?.error !== 'unsupported_action'
+      || blockedDispatch
+      || afterBlocked.coordinate.clickCount !== initial.coordinate.clickCount
+      || afterBlocked.coordinate.decoyClickCount
+        !== initial.coordinate.decoyClickCount
+    ) {
+      throw new Error('concurrent coordinate policy did not fail closed');
+    }
+    report.cases.push({
+      id: 'concurrent-coordinate-policy-fail-closed',
+      ok: true,
+      runtimeError: blockedAttempt.error,
+      backendError: blockedFlow.error,
+      dispatchAddress: blockedDispatch?.address,
+      oracle: {
+        target: [
+          initial.coordinate.clickCount,
+          afterBlocked.coordinate.clickCount,
+        ],
+        decoy: [
+          initial.coordinate.decoyClickCount,
+          afterBlocked.coordinate.decoyClickCount,
+        ],
+      },
+    });
 
-  if (concurrentUserMode) {
+    const semanticTarget = findOccurrence(
+      concurrentSemanticObserved.model,
+      'CUA Lab Coordinate Target',
+    );
+    let semanticAttempt;
+    let semanticFailure;
+    try {
+      semanticAttempt = await call({
+        action: 'click_element',
+        observation_id: concurrentSemanticObserved.model.observation_id,
+        element_id: semanticTarget.selected.element_id,
+      }, 'concurrent-semantic-click', 'turn-concurrent-semantic', 'real-e2e-semantic');
+    } catch (error) {
+      semanticFailure = error instanceof Error ? error.message : String(error);
+    }
+    await delay(150);
+    const afterSemantic = await readState();
+    const semanticFlow = idFlow.findLast(
+      (event) => event.phase === 'runSemanticResult',
+    );
+    const semanticOccluded = semanticFlow?.error === 'target_occluded';
+    const semanticHidden =
+      /invalidApp: no visible window matched/.test(semanticFailure ?? '');
+    const semanticSucceeded = semanticFlow?.ok === true
+      && afterSemantic.coordinate.clickCount
+        === initial.coordinate.clickCount + 1
+      && afterSemantic.coordinate.decoyClickCount
+        === initial.coordinate.decoyClickCount;
+    if (
+      (!semanticSucceeded && !semanticOccluded && !semanticHidden)
+      || ((semanticOccluded || semanticHidden) && (
+        afterSemantic.coordinate.clickCount !== initial.coordinate.clickCount
+        || afterSemantic.coordinate.decoyClickCount
+          !== initial.coordinate.decoyClickCount
+      ))
+    ) {
+      throw new Error('concurrent semantic action violated its oracle');
+    }
+    report.cases.push({
+      id: 'concurrent-background-semantic',
+      ok: true,
+      outcome: semanticOccluded
+        ? 'fail_closed_occluded'
+        : semanticHidden
+          ? 'fail_closed_hidden'
+        : 'semantic_background_succeeded',
+      runtimeError: semanticAttempt?.error,
+      runtimeFailure: semanticFailure,
+      backendError: semanticFlow?.error,
+      oracle: {
+        target: [
+          initial.coordinate.clickCount,
+          afterSemantic.coordinate.clickCount,
+        ],
+        decoy: [
+          initial.coordinate.decoyClickCount,
+          afterSemantic.coordinate.decoyClickCount,
+        ],
+      },
+    });
+
     report.ok = true;
     report.claimBoundary =
-      'concurrent mode proves no focus takeover; success still requires a visible, unoccluded target';
+      'concurrent mode keeps compatibility input disabled and proves only safe semantic background action or fail-closed occlusion';
     report.evidence = {
       invalidations,
       traceTypes: traces.map((event) => event.type),
@@ -445,6 +488,51 @@ try {
     process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
     process.exitCode = 0;
   } else {
+    const oop = findOccurrence(observed.model, 'CUA Lab OOP Button');
+    const oopCoordinate = coordinateForElement(observed, oop.selected);
+    const clicked = await call({
+      action: 'left_click',
+      observation_id: observed.model.observation_id,
+      coordinate: oopCoordinate,
+    }, 'click-oop', 'turn-oop');
+    await delay(250);
+    const afterClick = await readState();
+    const dispatch = traces.find(
+      (event) => event.type === 'dispatch' && event.toolCallId === 'click-oop',
+    );
+    const clickSucceeded = !clicked?.error
+      && afterClick.oop.clickCount === initial.oop.clickCount + 1;
+    if (
+      !clickSucceeded
+      || afterClick.oop.lastEventTrusted !== true
+      || afterClick.oop.webContentPID <= 0
+      || afterClick.oop.webContentPID === afterClick.oop.hostPID
+      || afterClick.oop.hostLocalMouseDownCount
+        <= initial.oop.hostLocalMouseDownCount
+      || afterClick.oop.hostLocalMouseUpCount
+        <= initial.oop.hostLocalMouseUpCount
+      || afterClick.oop.hostLocalMouseDownCount
+        - initial.oop.hostLocalMouseDownCount
+        !== afterClick.oop.hostLocalMouseUpCount
+          - initial.oop.hostLocalMouseUpCount
+      || dispatch?.address !== 'px'
+    ) {
+      throw new Error('isolated OOP coordinate oracle did not prove trusted pixel dispatch');
+    }
+    report.cases.push({
+      id: 'isolated-oop-webcontent-coordinate-click',
+      ok: true,
+      outcome: 'isolated_compatibility_dispatch_succeeded',
+      dispatchAddress: dispatch.address,
+      coordinate: oopCoordinate,
+      oracle: {
+        clickCount: [initial.oop.clickCount, afterClick.oop.clickCount],
+        lastEventTrusted: afterClick.oop.lastEventTrusted,
+        hostPID: afterClick.oop.hostPID,
+        webContentPID: afterClick.oop.webContentPID,
+      },
+    });
+
     tools.clearSession('real-e2e');
     const duplicateObserved = await observe(fixture, 'observe-duplicate', 'turn-duplicate');
     const duplicate = findOccurrence(


### PR DESCRIPTION
## Upstream stack notice

This is stack PR G2. It depends on #897 and must not merge before it.

The Files tab is cumulative until preceding fork branches are rebased after merge.

Review the exact 5-file E2E harness net diff now in fork-local PR hqhq1025/maka-agent#7.

Current isolated real-machine result: pixel dispatch address=px, trusted DOM event, distinct host/WebContent PIDs, click 0->1; semantic duplicate fails closed with mutation 0->0.

Current concurrent-user result while the user kept operating the Mac: prepare observation succeeded, execution did not steal focus, fully hidden target failed closed, click 0->0, mouse down/up 0->0, and no dispatch occurred.

---

## Goal

Add a reviewable, opt-in macOS E2E harness for the stacked Computer Use implementation. The harness uses only the synthetic `Codex CUA Lab.app`, the pinned real `cua-driver` binary, Runtime tool registration, and external state oracles.

## Proven by the real run

- explicit coordinate action remains on the pixel dispatch path (`address=px`)
- the in-memory WKWebView receives a trusted DOM event
- host PID and WebContent PID are distinct
- OOP click oracle changes exactly once
- duplicate semantic identity reaches backend fresh-refetch and fails closed as ambiguous
- the ambiguous action produces zero synthetic mutation

## Safety boundary

- unlocked sessions only; locked Computer Use is not enabled or tested
- exact synthetic bundle ID, canonical app path, PID, window, and oracle provenance are required before actions
- external Swift sentinel aborts on lock, frontmost-app change, pointer movement, or physical user input
- launcher owns `caffeinate -dimsu`, bounded TERM/KILL cleanup, fixture shutdown, temporary files, and frontmost-app restoration
- no real user apps, user documents, clipboard, network, approvals, or persistent screenshots are touched

## Deliberate non-claims and follow-up

This PR does not claim canonical live-process identity, PID-reuse safety, or process-restart isolation. Reverse-engineering V10 shows the native boundary is canonical app path plus the current live `NSRunningApplication`; that remains a separate native/driver security PR.

The dynamic stale-missing/ambiguous fixture also exposed a driver limitation: after the app removes or duplicates the control, `get_window_state` can retain one ghost AX node for more than five seconds. Those dynamic stale cases are not marked passing here. They require native element-lifetime evidence or a driver fix.

## Verification

- `npm run test:scripts` (12/12)
- `npm --workspace @maka/computer-use test` (113/113)
- `npm --workspace @maka/ui run build`
- `npm --workspace @maka/desktop run typecheck`
- `npm run e2e:computer-use-real`

Runtime full suite was also exercised: 1433 passed, 2 skipped, with one existing PTY timing test failing once and passing immediately when rerun in isolation.