### PR TITLE
fix(cu): fence compatibility input dispatch

### DIFF
--- a/apps/desktop/src/main/__tests__/computer-use-host.test.ts
+++ b/apps/desktop/src/main/__tests__/computer-use-host.test.ts
@@ -139,4 +139,11 @@ describe('Computer Use host health', () => {
     assert.match(source, /physicalInputRecentlyActive/);
     assert.match(source, /selectComputerUseBackend/);
   });
+
+  it('wires a one-second physical-input quiet window', async () => {
+    const source = await import('node:fs/promises').then(({ readFile }) =>
+      readFile(join(process.cwd(), 'src/main/main.ts'), 'utf8'));
+    assert.match(source, /physicalInputRecentlyActive/);
+    assert.match(source, /powerMonitor\.getSystemIdleTime\(\) < 1/);
+  });
 });

--- a/docs/computer-use-physical-input-guard.md
+++ b/docs/computer-use-physical-input-guard.md
@@ -80,9 +80,15 @@ Unit and integration coverage proves:
 - the Desktop production source uses the Electron idle-time signal;
 - existing Computer Use behavior remains green.
 
-The real soak harness uses the same policy semantics through a high-resolution
-macOS HID event-age snapshot. It accepts `user_intervened` only with no
-dispatch and zero target/decoy mutation.
+The real restart soak no longer emits compatibility mouse or keyboard events.
+It proves stale-process rejection and fresh-process recovery with native AX
+`set_value` plus exact state readback. Physical-input fencing remains covered
+by unit/integration tests without synthesizing global HID events.
+
+The soak still launches and orders a real visible AppKit fixture window.
+`open -g` avoids explicit activation, but launch can remain noticeable and may
+perturb WindowServer responsiveness. It is not a zero-disturbance
+background-run proof.
 
 ## Remaining Boundary
 

--- a/docs/computer-use-physical-input-guard.md
+++ b/docs/computer-use-physical-input-guard.md
@@ -1,0 +1,91 @@
+# Computer Use Physical-Input Guard
+
+## Reported Symptom
+
+During the no-focus process-restart soak, the user's pointer did not move and
+the synthetic fixture never became frontmost. The user still observed
+occasional abnormal physical clicking while continuing to use the Mac.
+
+The symptom cannot be dismissed as general system load. The Computer Use pixel
+path posts mouse down/up events to a target PID. Those events do not warp the
+real cursor, but they can still interleave with physical mouse events in the
+system and application event queues.
+
+## Root Cause
+
+Runtime already models physical intervention:
+
+```text
+physical input
+  -> user_intervened
+  -> invalidate the observation
+  -> require a new observation
+```
+
+Desktop did not provide a real macOS physical-input producer or pre-dispatch
+guard. The concurrent E2E allowed user input while the backend continued to
+dispatch target-PID mouse events.
+
+## Final Fix
+
+Desktop supplies a host-owned guard using:
+
+```ts
+powerMonitor.getSystemIdleTime() < 1
+```
+
+Electron reports whole idle seconds, so this is a conservative approximately
+one-second quiet window rather than a precise millisecond deadline.
+
+The backend checks the guard at the last practical boundary before every
+mouse, keyboard, semantic, scroll, drag, or text dispatch. If input is active,
+or if the guard cannot establish the idle state, it returns:
+
+```text
+user_intervened
+```
+
+No cua-driver input tool is called. Runtime invalidates the consumed
+observation and requires an explicit new observation before another action.
+
+Live testing then proved the quiet window alone was not a sufficient safety
+claim: PID-bound CGEvent mouse delivery can still interfere with physical
+button state when the user and agent overlap.
+
+The production policy therefore also disables the compatibility event backend
+by default:
+
+- coordinate click, right/middle/double/triple click: blocked;
+- scroll and drag: blocked;
+- `press_key`: blocked;
+- semantic action fallback to pixel: blocked.
+
+The retained paths are:
+
+- observation, screenshots, wait, zoom, and virtual cursor presentation;
+- native AX element actions and `set_value`;
+- uniquely targeted Electron CDP semantic actions and `insertText`.
+
+Compatibility dispatch can only be re-enabled through an explicit backend
+option used by controlled tests. Desktop does not set that option.
+
+## Verification
+
+Unit and integration coverage proves:
+
+- coordinate and semantic input return `user_intervened`;
+- no `click` call reaches cua-driver;
+- no dispatch trace is emitted for a guarded action;
+- selector and Desktop host wiring preserve the guard;
+- the Desktop production source uses the Electron idle-time signal;
+- existing Computer Use behavior remains green.
+
+The real soak harness uses the same policy semantics through a high-resolution
+macOS HID event-age snapshot. It accepts `user_intervened` only with no
+dispatch and zero target/decoy mutation.
+
+## Remaining Boundary
+
+Re-enabling coordinate input requires a native executor that can prove its
+event backend does not affect global physical button state. A host-side quiet
+window alone is not sufficient evidence.

--- a/docs/computer-use-process-restart-e2e.md
+++ b/docs/computer-use-process-restart-e2e.md
@@ -63,6 +63,7 @@ repeat 5 times with one backend/Runtime instance:
   -> execute fresh coordinate action
   -> if visible, require px dispatch, target 0 -> 1, decoy 0 -> 0
   -> if covered by the user's window, require target_occluded and mutation 0 -> 0
+  -> if physical user input is recent, require user_intervened and mutation 0 -> 0
   -> require cua-driver generations stable and restartAttempts == 0
 ```
 

--- a/docs/computer-use-process-restart-e2e.md
+++ b/docs/computer-use-process-restart-e2e.md
@@ -60,10 +60,9 @@ repeat 5 times with one backend/Runtime instance:
   -> require target_missing, no dispatch, mutation 0 -> 0
   -> clear session
   -> observe new PID/window
-  -> execute fresh coordinate action
-  -> if visible, require px dispatch, target 0 -> 1, decoy 0 -> 0
-  -> if covered by the user's window, require target_occluded and mutation 0 -> 0
-  -> if physical user input is recent, require user_intervened and mutation 0 -> 0
+  -> execute fresh native AX set_value action
+  -> if visible, require exact readback on the new process
+  -> if covered by the user's window, require target_occluded and zero mutation
   -> require cua-driver generations stable and restartAttempts == 0
 ```
 
@@ -77,14 +76,20 @@ the synthetic fixture ever becomes frontmost or the screen locks. Cleanup
 preserves the user's current application; restoration is only an emergency
 path if the fixture itself stole focus.
 
+The fixture is still a real visible AppKit window. Background launch avoids
+explicit activation, but window creation and `orderFrontRegardless` can remain
+noticeable and can perturb WindowServer responsiveness. This is an attended
+release test, not a zero-disturbance background-run proof.
+
 Physical user pointer movement is allowed and reported as observation data.
 When the user's window occludes the target, the stronger non-interference
 proof is that the backend emits no dispatch and both target and decoy mutation
 remain zero.
 
-## Verified Result
+## Historical Pixel Result
 
-The July 14, 2026 five-round no-focus soak proved:
+Before compatibility input was disabled, the July 14, 2026 five-round
+no-focus pixel soak proved:
 
 ```text
 restart rounds:             5
@@ -126,6 +131,37 @@ The test command is:
 ```bash
 npm run e2e:computer-use-process-restart
 ```
+
+## Current AX-Only Result
+
+The replacement soak uses AX `set_value`, not pixel input. The corrected
+five-round run proved:
+
+```text
+restart rounds:             5
+old observation:
+  target_missing:           5/5
+  native dispatch:          0
+
+fresh observation:
+  AX set_value + readback:  5/5
+
+cua-driver service:
+  action generation:        1 throughout
+  capture generation:       0 throughout
+  restartAttempts:          0 throughout
+
+desktop concurrency:
+  fixture became frontmost: never
+  user pointer moved:       217.1 logical points
+  user mouse/keyboard:      reported normal
+```
+
+The first AX-only attempt had already confirmed stale-process rejection and a
+successful fresh AX mutation, but used the wrong external oracle: direct
+AXValue mutation does not invoke the fixture's Cocoa callback that writes
+`state.json`. The final run instead verified the fresh AX observation returned
+by Runtime.
 
 ## Remaining Boundary
 

--- a/packages/computer-use/src/__tests__/select-backend-host-events.test.ts
+++ b/packages/computer-use/src/__tests__/select-backend-host-events.test.ts
@@ -1,6 +1,7 @@
 import assert from 'node:assert/strict';
 import { test } from 'node:test';
 import type { CuDispatchBackend } from '@maka/runtime';
+import type { CuaDriverBackendOptions } from '../cua-driver-backend.js';
 import { selectComputerUseBackend } from '../select-backend.js';
 
 test('service invalidation producer advances Runtime to reobserve', async () => {
@@ -63,4 +64,28 @@ test('service invalidation producer advances Runtime to reobserve', async () => 
     selected.tools.sessionEvents.snapshot('session-1').status,
     'reobserve_required',
   );
+});
+
+test('physical input policy is passed to the selected backend', () => {
+  if (process.platform !== 'darwin') return;
+  const physicalInputRecentlyActive = () => true;
+  let received: CuaDriverBackendOptions['physicalInputRecentlyActive'];
+  const backend: CuDispatchBackend = {
+    async preflight() {
+      return { accessibility: true, screenRecording: true };
+    },
+    async run() {
+      return { outcome: { ok: true, tier: 'ax', verified: true } };
+    },
+  };
+  selectComputerUseBackend({
+    binaryPath: '/tmp/fake-cua-driver',
+    expectedBinarySha256: '0'.repeat(64),
+    physicalInputRecentlyActive,
+    createBackend(options) {
+      received = options.physicalInputRecentlyActive;
+      return backend;
+    },
+  });
+  assert.equal(received, physicalInputRecentlyActive);
 });

--- a/scripts/cu-physical-input-probe.swift
+++ b/scripts/cu-physical-input-probe.swift
@@ -1,0 +1,46 @@
+import Cocoa
+import CoreGraphics
+import Darwin
+
+let eventTypes: [CGEventType] = [
+    .keyDown,
+    .leftMouseDown,
+    .rightMouseDown,
+    .otherMouseDown,
+    .mouseMoved,
+    .leftMouseDragged,
+    .rightMouseDragged,
+    .otherMouseDragged,
+]
+
+func physicalInputAge() -> Double {
+    eventTypes.map { eventType in
+        CGEventSource.secondsSinceLastEventType(
+            .hidSystemState,
+            eventType: eventType
+        )
+    }.min() ?? .infinity
+}
+
+switch CommandLine.arguments.dropFirst().first {
+case "age":
+    print(physicalInputAge())
+case "pulse":
+    guard let source = CGEventSource(stateID: .hidSystemState),
+          let event = CGEvent(
+              mouseEventSource: source,
+              mouseType: .mouseMoved,
+              mouseCursorPosition: NSEvent.mouseLocation,
+              mouseButton: .left
+          )
+    else {
+        fputs("failed to create physical-input pulse\n", stderr)
+        exit(1)
+    }
+    event.post(tap: .cghidEventTap)
+    usleep(20_000)
+    print(physicalInputAge())
+default:
+    fputs("usage: cu-physical-input-probe <age|pulse>\n", stderr)
+    exit(2)
+}

--- a/scripts/cu-process-restart-e2e-contract.test.mjs
+++ b/scripts/cu-process-restart-e2e-contract.test.mjs
@@ -25,40 +25,37 @@ test('process restart E2E owns the real fixture lifecycle', () => {
   assert.match(launcher, /restart-request-\$\{round\}\.json/);
   assert.match(launcher, /restart-complete-\$\{round\}\.json/);
   assert.match(launcher, /SOAK_ROUNDS = 5/);
-  assert.match(launcher, /cu-physical-input-probe/);
   assert.match(launcher, /--deny-frontmost-bundle/);
   assert.match(launcher, /--concurrent-user',[\s\S]*'0'/);
   assert.match(launcher, /for \(let round = 1; round <= SOAK_ROUNDS; round \+= 1\)/);
   assert.match(launcher, /caffeinate', \['-dimsu'\]/);
 });
 
-test('old observation is rejected and fresh-process actions succeed or fail occluded', () => {
+test('old observation is rejected and fresh-process AX actions succeed or fail occluded', () => {
   assert.match(harness, /old-observation-after-restart/);
   assert.match(harness, /oldRunResult\?\.error !== 'target_missing'/);
+  assert.match(harness, /phase: 'runSemanticResult'/);
   assert.match(harness, /staleAttempt\.modelText/);
-  assert.match(harness, /newState\.coordinate\.clickCount !== 0/);
-  assert.match(harness, /fresh-process-coordinate-click/);
+  assert.match(harness, /newState\.controls\.setValue !== ''/);
+  assert.match(harness, /fresh-process-set-value/);
+  assert.match(harness, /Fresh observation:/);
+  assert.match(harness, /freshField\?\.value === freshValue/);
   assert.match(harness, /observeUntilElement/);
   assert.match(harness, /invalidApp: no visible window matched/);
-  assert.match(harness, /CUA Lab Coordinate Target/);
+  assert.match(harness, /CUA Lab Set Value Field/);
   assert.match(harness, /candidateCount/);
   assert.match(harness, /freshSucceeded/);
   assert.match(harness, /freshOccluded/);
-  assert.match(harness, /freshUserIntervened/);
   assert.match(harness, /fail_closed_occluded/);
-  assert.match(harness, /fail_closed_user_intervened/);
-  assert.match(harness, /background_dispatch_succeeded/);
+  assert.match(harness, /ax_set_value_succeeded/);
   assert.match(harness, /currentPID === newPID/);
   assert.match(harness, /currentWebContentPID === newWebContentPID/);
   assert.match(harness, /for \(let round = 1; round <= soakRounds; round \+= 1\)/);
   assert.match(harness, /seenHostPIDs/);
   assert.match(harness, /seenWebContentPIDs/);
   assert.match(harness, /serviceState/);
-  assert.match(harness, /physicalInputRecentlyActive/);
-  assert.match(harness, /ageSeconds < 1/);
-  assert.match(harness, /pulsePhysicalInput/);
-  assert.match(harness, /physical-input pulse did not fence dispatch/);
-  assert.match(harness, /did not recover after the physical-input quiet window/);
+  assert.doesNotMatch(harness, /allowCompatibilityInputDispatch/);
+  assert.doesNotMatch(harness, /fresh-process-coordinate-click/);
 });
 
 test('restart reports are private launcher-owned temporary files', () => {

--- a/scripts/cu-process-restart-e2e-contract.test.mjs
+++ b/scripts/cu-process-restart-e2e-contract.test.mjs
@@ -25,6 +25,7 @@ test('process restart E2E owns the real fixture lifecycle', () => {
   assert.match(launcher, /restart-request-\$\{round\}\.json/);
   assert.match(launcher, /restart-complete-\$\{round\}\.json/);
   assert.match(launcher, /SOAK_ROUNDS = 5/);
+  assert.match(launcher, /cu-physical-input-probe/);
   assert.match(launcher, /--deny-frontmost-bundle/);
   assert.match(launcher, /--concurrent-user',[\s\S]*'0'/);
   assert.match(launcher, /for \(let round = 1; round <= SOAK_ROUNDS; round \+= 1\)/);
@@ -43,7 +44,9 @@ test('old observation is rejected and fresh-process actions succeed or fail occl
   assert.match(harness, /candidateCount/);
   assert.match(harness, /freshSucceeded/);
   assert.match(harness, /freshOccluded/);
+  assert.match(harness, /freshUserIntervened/);
   assert.match(harness, /fail_closed_occluded/);
+  assert.match(harness, /fail_closed_user_intervened/);
   assert.match(harness, /background_dispatch_succeeded/);
   assert.match(harness, /currentPID === newPID/);
   assert.match(harness, /currentWebContentPID === newWebContentPID/);
@@ -51,6 +54,11 @@ test('old observation is rejected and fresh-process actions succeed or fail occl
   assert.match(harness, /seenHostPIDs/);
   assert.match(harness, /seenWebContentPIDs/);
   assert.match(harness, /serviceState/);
+  assert.match(harness, /physicalInputRecentlyActive/);
+  assert.match(harness, /ageSeconds < 1/);
+  assert.match(harness, /pulsePhysicalInput/);
+  assert.match(harness, /physical-input pulse did not fence dispatch/);
+  assert.match(harness, /did not recover after the physical-input quiet window/);
 });
 
 test('restart reports are private launcher-owned temporary files', () => {

--- a/scripts/cu-process-restart-e2e-launcher.mjs
+++ b/scripts/cu-process-restart-e2e-launcher.mjs
@@ -8,6 +8,7 @@ const here = dirname(fileURLToPath(import.meta.url));
 const repoRoot = join(here, '..');
 const harnessPath = join(here, 'cu-process-restart-e2e.mjs');
 const monitorPath = join(here, 'cu-real-e2e-monitor.swift');
+const physicalInputProbeSource = join(here, 'cu-physical-input-probe.swift');
 const labRoot = '/Users/haoqing/Documents/Learning/codex-computer-use-lab';
 const statePath = join(labRoot, 'test-app', 'runtime', 'state.json');
 const SOAK_ROUNDS = 5;
@@ -245,7 +246,8 @@ function startFocusMonitor() {
         readyResolve({
           frontmostPID: Number(fields[1]),
           pointer: { x: Number(fields[2]), y: Number(fields[3]) },
-          bundleIdentifier: fields[4],
+          physicalInputAgeSeconds: Number(fields[4]),
+          bundleIdentifier: fields[5],
         });
       } else if (kind === 'CHANGE' || kind === 'ERROR') {
         fail(new Error(fields.join('\t') || line));
@@ -283,6 +285,15 @@ async function run() {
       stdio: ['ignore', 'ignore', 'inherit'],
     });
     await runBuilds();
+    const physicalInputProbePath = join(
+      temporaryDirectory,
+      'cu-physical-input-probe',
+    );
+    await runChild('swiftc', [
+      physicalInputProbeSource,
+      '-o',
+      physicalInputProbePath,
+    ], { stdio: ['ignore', 'ignore', 'inherit'] });
     fixtureTouched = true;
     await runFixtureScript('stop.sh');
     await runFixtureScript('reset.sh');
@@ -309,6 +320,7 @@ async function run() {
         MAKA_CU_RESTART_OLD_PID: String(oldPID),
         MAKA_CU_RESTART_SOAK_ROUNDS: String(SOAK_ROUNDS),
         MAKA_CU_RESTART_TEMP_DIR: temporaryDirectory,
+        MAKA_CU_PHYSICAL_INPUT_PROBE: physicalInputProbePath,
       },
       stdio: ['ignore', 'inherit', 'inherit'],
     });

--- a/scripts/cu-process-restart-e2e-launcher.mjs
+++ b/scripts/cu-process-restart-e2e-launcher.mjs
@@ -8,7 +8,6 @@ const here = dirname(fileURLToPath(import.meta.url));
 const repoRoot = join(here, '..');
 const harnessPath = join(here, 'cu-process-restart-e2e.mjs');
 const monitorPath = join(here, 'cu-real-e2e-monitor.swift');
-const physicalInputProbeSource = join(here, 'cu-physical-input-probe.swift');
 const labRoot = '/Users/haoqing/Documents/Learning/codex-computer-use-lab';
 const statePath = join(labRoot, 'test-app', 'runtime', 'state.json');
 const SOAK_ROUNDS = 5;
@@ -285,15 +284,6 @@ async function run() {
       stdio: ['ignore', 'ignore', 'inherit'],
     });
     await runBuilds();
-    const physicalInputProbePath = join(
-      temporaryDirectory,
-      'cu-physical-input-probe',
-    );
-    await runChild('swiftc', [
-      physicalInputProbeSource,
-      '-o',
-      physicalInputProbePath,
-    ], { stdio: ['ignore', 'ignore', 'inherit'] });
     fixtureTouched = true;
     await runFixtureScript('stop.sh');
     await runFixtureScript('reset.sh');
@@ -320,7 +310,6 @@ async function run() {
         MAKA_CU_RESTART_OLD_PID: String(oldPID),
         MAKA_CU_RESTART_SOAK_ROUNDS: String(SOAK_ROUNDS),
         MAKA_CU_RESTART_TEMP_DIR: temporaryDirectory,
-        MAKA_CU_PHYSICAL_INPUT_PROBE: physicalInputProbePath,
       },
       stdio: ['ignore', 'inherit', 'inherit'],
     });

--- a/scripts/cu-process-restart-e2e.mjs
+++ b/scripts/cu-process-restart-e2e.mjs
@@ -1,4 +1,5 @@
 import { readFile, writeFile } from 'node:fs/promises';
+import { execFile } from 'node:child_process';
 import { tmpdir } from 'node:os';
 import { join, relative, resolve } from 'node:path';
 import { createCuaDriverBackend } from '../packages/computer-use/dist/index.js';
@@ -9,7 +10,9 @@ const binaryPath = join(repoRoot, 'apps/desktop/resources/bin/cua-driver');
 const labRoot = '/Users/haoqing/Documents/Learning/codex-computer-use-lab';
 const expectedAppPath = join(labRoot, 'test-app/build/Codex CUA Lab.app');
 const statePath = join(labRoot, 'test-app/runtime/state.json');
+const monitorPath = join(repoRoot, 'scripts/cu-real-e2e-monitor.swift');
 const temporaryDirectory = process.env.MAKA_CU_RESTART_TEMP_DIR;
+const physicalInputProbe = process.env.MAKA_CU_PHYSICAL_INPUT_PROBE;
 const oldPID = Number(process.env.MAKA_CU_RESTART_OLD_PID);
 const soakRounds = Number(process.env.MAKA_CU_RESTART_SOAK_ROUNDS);
 const expectedBinarySha256 =
@@ -26,6 +29,7 @@ if (
   || !Number.isInteger(soakRounds)
   || soakRounds < 1
   || soakRounds > 20
+  || !physicalInputProbe
 ) {
   throw new Error('process restart E2E requires launcher-owned inputs');
 }
@@ -37,6 +41,38 @@ const restartCompletePath = (round) =>
   join(resolvedTemporaryDirectory, `restart-complete-${round}.json`);
 const delay = (milliseconds) =>
   new Promise((resolvePromise) => setTimeout(resolvePromise, milliseconds));
+async function physicalInputRecentlyActive() {
+  const output = await new Promise((resolvePromise, reject) => {
+    execFile(physicalInputProbe, ['age'], {
+      encoding: 'utf8',
+      timeout: 1_000,
+    }, (error, stdout, stderr) => {
+      if (error) reject(new Error(stderr || error.message));
+      else resolvePromise(stdout.trim());
+    });
+  });
+  const ageSeconds = Number(output);
+  if (!Number.isFinite(ageSeconds)) {
+    throw new Error(`invalid physical input snapshot: ${output}`);
+  }
+  return ageSeconds < 1;
+}
+
+async function pulsePhysicalInput() {
+  const output = await new Promise((resolvePromise, reject) => {
+    execFile(physicalInputProbe, ['pulse'], {
+      encoding: 'utf8',
+      timeout: 1_000,
+    }, (error, stdout, stderr) => {
+      if (error) reject(new Error(stderr || error.message));
+      else resolvePromise(stdout.trim());
+    });
+  });
+  const ageSeconds = Number(output);
+  if (!Number.isFinite(ageSeconds) || ageSeconds >= 1) {
+    throw new Error(`physical-input pulse did not reset idle age: ${output}`);
+  }
+}
 
 async function waitForJson(path, label, timeoutMs = 15_000) {
   const deadline = Date.now() + timeoutMs;
@@ -62,6 +98,7 @@ const backend = createCuaDriverBackend({
   expectedServerVersion: '0.7.1',
   expectedProtocolVersion: '2025-06-18',
   timeoutMs: 10_000,
+  physicalInputRecentlyActive,
   onTrace(event) {
     traces.push(event);
   },
@@ -316,6 +353,7 @@ try {
       freshReady.element,
     );
     const freshToolCallId = `fresh-process-coordinate-click-r${round}`;
+    if (round === 1) await pulsePhysicalInput();
     const freshClick = await call({
       action: 'left_click',
       observation_id: freshReady.observed.model.observation_id,
@@ -332,13 +370,14 @@ try {
         && event.toolCallId === freshToolCallId,
     );
     const freshOccluded = freshRunResult?.error === 'target_occluded';
+    const freshUserIntervened = freshRunResult?.error === 'user_intervened';
     const freshSucceeded = !freshClick.error
       && dispatch?.address === 'px'
       && newStateAfterClick.coordinate.clickCount === 1
       && newStateAfterClick.coordinate.decoyClickCount === 0;
     if (
-      (!freshSucceeded && !freshOccluded)
-      || (freshOccluded && (
+      (!freshSucceeded && !freshOccluded && !freshUserIntervened)
+      || ((freshOccluded || freshUserIntervened) && (
         dispatch
         || newStateAfterClick.coordinate.clickCount !== 0
         || newStateAfterClick.coordinate.decoyClickCount !== 0
@@ -347,6 +386,45 @@ try {
       || newStateAfterClick.oop.webContentPID !== newWebContentPID
     ) {
       throw new Error(`round ${round} fresh process action violated its oracle`);
+    }
+
+    if (round === 1) {
+      if (!freshUserIntervened) {
+        throw new Error('round 1 physical-input pulse did not fence dispatch');
+      }
+      await delay(1_100);
+      tools.clearSession('process-restart-e2e');
+      const recoveryReady = await observeUntilElement(
+        newPID,
+        'CUA Lab Coordinate Target',
+        'observe-after-intervention-r1',
+        'turn-recovery-r1',
+      );
+      const recoveryCoordinate = coordinateForElement(
+        recoveryReady.observed,
+        recoveryReady.element,
+      );
+      const recoveryToolCallId = 'fresh-process-recovery-click-r1';
+      const recoveryClick = await call({
+        action: 'left_click',
+        observation_id: recoveryReady.observed.model.observation_id,
+        coordinate: recoveryCoordinate,
+      }, recoveryToolCallId, 'turn-recovery-r1');
+      await delay(150);
+      const recoveryState = await readState();
+      const recoveryDispatch = traces.find(
+        (event) => event.type === 'dispatch'
+          && event.toolCallId === recoveryToolCallId,
+      );
+      if (
+        recoveryClick.error
+        || recoveryDispatch?.address !== 'px'
+        || recoveryState.coordinate.clickCount !== 1
+        || recoveryState.coordinate.decoyClickCount !== 0
+      ) {
+        throw new Error('round 1 did not recover after the physical-input quiet window');
+      }
+      newStateAfterClick.coordinate = recoveryState.coordinate;
     }
 
     const serviceState = backend.serviceState();
@@ -382,6 +460,8 @@ try {
       fresh: {
         outcome: freshOccluded
           ? 'fail_closed_occluded'
+          : freshUserIntervened
+            ? 'fail_closed_user_intervened'
           : 'background_dispatch_succeeded',
         dispatchAddress: dispatch?.address,
         mutation: [

--- a/scripts/cu-process-restart-e2e.mjs
+++ b/scripts/cu-process-restart-e2e.mjs
@@ -1,5 +1,4 @@
 import { readFile, writeFile } from 'node:fs/promises';
-import { execFile } from 'node:child_process';
 import { tmpdir } from 'node:os';
 import { join, relative, resolve } from 'node:path';
 import { createCuaDriverBackend } from '../packages/computer-use/dist/index.js';
@@ -10,9 +9,7 @@ const binaryPath = join(repoRoot, 'apps/desktop/resources/bin/cua-driver');
 const labRoot = '/Users/haoqing/Documents/Learning/codex-computer-use-lab';
 const expectedAppPath = join(labRoot, 'test-app/build/Codex CUA Lab.app');
 const statePath = join(labRoot, 'test-app/runtime/state.json');
-const monitorPath = join(repoRoot, 'scripts/cu-real-e2e-monitor.swift');
 const temporaryDirectory = process.env.MAKA_CU_RESTART_TEMP_DIR;
-const physicalInputProbe = process.env.MAKA_CU_PHYSICAL_INPUT_PROBE;
 const oldPID = Number(process.env.MAKA_CU_RESTART_OLD_PID);
 const soakRounds = Number(process.env.MAKA_CU_RESTART_SOAK_ROUNDS);
 const expectedBinarySha256 =
@@ -29,7 +26,6 @@ if (
   || !Number.isInteger(soakRounds)
   || soakRounds < 1
   || soakRounds > 20
-  || !physicalInputProbe
 ) {
   throw new Error('process restart E2E requires launcher-owned inputs');
 }
@@ -41,39 +37,6 @@ const restartCompletePath = (round) =>
   join(resolvedTemporaryDirectory, `restart-complete-${round}.json`);
 const delay = (milliseconds) =>
   new Promise((resolvePromise) => setTimeout(resolvePromise, milliseconds));
-async function physicalInputRecentlyActive() {
-  const output = await new Promise((resolvePromise, reject) => {
-    execFile(physicalInputProbe, ['age'], {
-      encoding: 'utf8',
-      timeout: 1_000,
-    }, (error, stdout, stderr) => {
-      if (error) reject(new Error(stderr || error.message));
-      else resolvePromise(stdout.trim());
-    });
-  });
-  const ageSeconds = Number(output);
-  if (!Number.isFinite(ageSeconds)) {
-    throw new Error(`invalid physical input snapshot: ${output}`);
-  }
-  return ageSeconds < 1;
-}
-
-async function pulsePhysicalInput() {
-  const output = await new Promise((resolvePromise, reject) => {
-    execFile(physicalInputProbe, ['pulse'], {
-      encoding: 'utf8',
-      timeout: 1_000,
-    }, (error, stdout, stderr) => {
-      if (error) reject(new Error(stderr || error.message));
-      else resolvePromise(stdout.trim());
-    });
-  });
-  const ageSeconds = Number(output);
-  if (!Number.isFinite(ageSeconds) || ageSeconds >= 1) {
-    throw new Error(`physical-input pulse did not reset idle age: ${output}`);
-  }
-}
-
 async function waitForJson(path, label, timeoutMs = 15_000) {
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
@@ -98,7 +61,6 @@ const backend = createCuaDriverBackend({
   expectedServerVersion: '0.7.1',
   expectedProtocolVersion: '2025-06-18',
   timeoutMs: 10_000,
-  physicalInputRecentlyActive,
   onTrace(event) {
     traces.push(event);
   },
@@ -119,6 +81,18 @@ const instrumentedBackend = {
       turnId: context.turnId,
     });
     return observation;
+  },
+  async runSemantic(action, signal, context) {
+    const result = await backend.runSemantic(action, signal, context);
+    idFlow.push({
+      phase: 'runSemanticResult',
+      toolCallId: context.toolCallId,
+      ok: result.outcome.ok,
+      ...(!result.outcome.ok
+        ? { error: result.outcome.error, message: result.outcome.message }
+        : {}),
+    });
+    return result;
   },
   async run(action, signal, context) {
     const result = await backend.run(action, signal, context);
@@ -147,6 +121,13 @@ const call = (input, toolCallId, turnId) =>
   tool.impl(input, context(toolCallId, turnId));
 const parseModel = (result) => JSON.parse(result.modelText ?? '{}');
 const readState = async () => JSON.parse(await readFile(statePath, 'utf8'));
+
+function freshObservationFrom(result) {
+  const marker = '\nFresh observation:\n';
+  const markerIndex = result.modelText?.indexOf(marker) ?? -1;
+  if (markerIndex < 0) return undefined;
+  return JSON.parse(result.modelText.slice(markerIndex + marker.length));
+}
 
 async function observe(pid, toolCallId, turnId) {
   const result = await call({
@@ -207,25 +188,6 @@ async function observeUntilElement(pid, label, toolCallPrefix, turnId, timeoutMs
   );
 }
 
-function coordinateForElement(observed, element) {
-  const screenshot = observed.persisted.screenshot;
-  const frame = element.frame;
-  const window = observed.geometry?.windowBounds;
-  if (!screenshot || !frame || !window) {
-    throw new Error('restart coordinate evidence is incomplete');
-  }
-  return [
-    Math.round(
-      (frame.x + frame.width / 2 - window.x)
-        / window.width * screenshot.width_px,
-    ),
-    Math.round(
-      (frame.y + frame.height / 2 - window.y)
-        / window.height * screenshot.height_px,
-    ),
-  ];
-}
-
 async function writeReport(report) {
   await writeFile(reportPath, `${JSON.stringify(report, null, 2)}\n`, {
     flag: 'wx',
@@ -273,15 +235,11 @@ try {
 
     const oldReady = await observeUntilElement(
       currentPID,
-      'CUA Lab Coordinate Target',
+      'CUA Lab Set Value Field',
       `observe-old-process-r${round}`,
       `turn-old-r${round}`,
     );
     const oldObserved = oldReady.observed;
-    const oldCoordinate = coordinateForElement(
-      oldObserved,
-      oldReady.element,
-    );
     await writeFile(
       restartRequestPath(round),
       `${JSON.stringify({
@@ -317,14 +275,15 @@ try {
 
     const staleToolCallId = `old-observation-after-restart-r${round}`;
     const staleAttempt = await call({
-      action: 'left_click',
+      action: 'set_value',
       observation_id: oldObserved.model.observation_id,
-      coordinate: oldCoordinate,
+      element_id: oldReady.element.element_id,
+      value: `stale-value-r${round}`,
     }, staleToolCallId, `turn-old-r${round}`);
     await delay(150);
     const newState = await readState();
     const oldRunResult = idFlow.find(
-      (event) => event.phase === 'runResult'
+      (event) => event.phase === 'runSemanticResult'
         && event.toolCallId === staleToolCallId,
     );
     const staleDispatch = traces.find(
@@ -335,8 +294,7 @@ try {
       oldRunResult?.error !== 'target_missing'
       || !/target_missing/.test(staleAttempt.modelText ?? '')
       || staleDispatch
-      || newState.coordinate.clickCount !== 0
-      || newState.coordinate.decoyClickCount !== 0
+      || newState.controls.setValue !== ''
     ) {
       throw new Error(`round ${round} old observation crossed process restart`);
     }
@@ -344,87 +302,45 @@ try {
     tools.clearSession('process-restart-e2e');
     const freshReady = await observeUntilElement(
       newPID,
-      'CUA Lab Coordinate Target',
+      'CUA Lab Set Value Field',
       `observe-new-process-r${round}`,
       `turn-new-r${round}`,
     );
-    const freshCoordinate = coordinateForElement(
-      freshReady.observed,
-      freshReady.element,
-    );
-    const freshToolCallId = `fresh-process-coordinate-click-r${round}`;
-    if (round === 1) await pulsePhysicalInput();
-    const freshClick = await call({
-      action: 'left_click',
+    const freshValue = `fresh-value-r${round}`;
+    const freshToolCallId = `fresh-process-set-value-r${round}`;
+    const freshAction = await call({
+      action: 'set_value',
       observation_id: freshReady.observed.model.observation_id,
-      coordinate: freshCoordinate,
+      element_id: freshReady.element.element_id,
+      value: freshValue,
     }, freshToolCallId, `turn-new-r${round}`);
     await delay(150);
-    const newStateAfterClick = await readState();
+    const newStateAfterAction = await readState();
     const dispatch = traces.find(
       (event) => event.type === 'dispatch'
         && event.toolCallId === freshToolCallId,
     );
     const freshRunResult = idFlow.find(
-      (event) => event.phase === 'runResult'
+      (event) => event.phase === 'runSemanticResult'
         && event.toolCallId === freshToolCallId,
     );
+    const freshObservation = freshObservationFrom(freshAction);
+    const freshField = freshObservation?.elements?.find(
+      (element) => element.label === 'CUA Lab Set Value Field',
+    );
     const freshOccluded = freshRunResult?.error === 'target_occluded';
-    const freshUserIntervened = freshRunResult?.error === 'user_intervened';
-    const freshSucceeded = !freshClick.error
-      && dispatch?.address === 'px'
-      && newStateAfterClick.coordinate.clickCount === 1
-      && newStateAfterClick.coordinate.decoyClickCount === 0;
+    const freshSucceeded = !freshAction.error
+      && freshField?.value === freshValue;
     if (
-      (!freshSucceeded && !freshOccluded && !freshUserIntervened)
-      || ((freshOccluded || freshUserIntervened) && (
+      (!freshSucceeded && !freshOccluded)
+      || (freshOccluded && (
         dispatch
-        || newStateAfterClick.coordinate.clickCount !== 0
-        || newStateAfterClick.coordinate.decoyClickCount !== 0
+        || freshField?.value === freshValue
       ))
-      || newStateAfterClick.oop.hostPID !== newPID
-      || newStateAfterClick.oop.webContentPID !== newWebContentPID
+      || newStateAfterAction.oop.hostPID !== newPID
+      || newStateAfterAction.oop.webContentPID !== newWebContentPID
     ) {
       throw new Error(`round ${round} fresh process action violated its oracle`);
-    }
-
-    if (round === 1) {
-      if (!freshUserIntervened) {
-        throw new Error('round 1 physical-input pulse did not fence dispatch');
-      }
-      await delay(1_100);
-      tools.clearSession('process-restart-e2e');
-      const recoveryReady = await observeUntilElement(
-        newPID,
-        'CUA Lab Coordinate Target',
-        'observe-after-intervention-r1',
-        'turn-recovery-r1',
-      );
-      const recoveryCoordinate = coordinateForElement(
-        recoveryReady.observed,
-        recoveryReady.element,
-      );
-      const recoveryToolCallId = 'fresh-process-recovery-click-r1';
-      const recoveryClick = await call({
-        action: 'left_click',
-        observation_id: recoveryReady.observed.model.observation_id,
-        coordinate: recoveryCoordinate,
-      }, recoveryToolCallId, 'turn-recovery-r1');
-      await delay(150);
-      const recoveryState = await readState();
-      const recoveryDispatch = traces.find(
-        (event) => event.type === 'dispatch'
-          && event.toolCallId === recoveryToolCallId,
-      );
-      if (
-        recoveryClick.error
-        || recoveryDispatch?.address !== 'px'
-        || recoveryState.coordinate.clickCount !== 1
-        || recoveryState.coordinate.decoyClickCount !== 0
-      ) {
-        throw new Error('round 1 did not recover after the physical-input quiet window');
-      }
-      newStateAfterClick.coordinate = recoveryState.coordinate;
     }
 
     const serviceState = backend.serviceState();
@@ -454,23 +370,16 @@ try {
       newWebContentPID,
       stale: {
         error: oldRunResult.error,
-        mutation: [0, newState.coordinate.clickCount],
+        mutation: ['', newState.controls.setValue],
         dispatch: false,
       },
       fresh: {
         outcome: freshOccluded
           ? 'fail_closed_occluded'
-          : freshUserIntervened
-            ? 'fail_closed_user_intervened'
-          : 'background_dispatch_succeeded',
-        dispatchAddress: dispatch?.address,
+          : 'ax_set_value_succeeded',
         mutation: [
-          newState.coordinate.clickCount,
-          newStateAfterClick.coordinate.clickCount,
-        ],
-        decoyMutation: [
-          newState.coordinate.decoyClickCount,
-          newStateAfterClick.coordinate.decoyClickCount,
+          '',
+          freshField?.value,
         ],
       },
       serviceGenerations: generations,
@@ -481,7 +390,7 @@ try {
 
   report.ok = true;
   report.claim =
-    'old observations never cross repeated real app-process restarts; fresh background actions either dispatch to the new process or fail occluded without side effects';
+    'old observations never cross repeated real app-process restarts; fresh AX set_value actions target only the new process or fail occluded without side effects';
   report.evidence = {
     seenHostPIDs: [...seenHostPIDs],
     seenWebContentPIDs: [...seenWebContentPIDs],

--- a/scripts/cu-real-e2e-contract.test.mjs
+++ b/scripts/cu-real-e2e-contract.test.mjs
@@ -53,6 +53,7 @@ test('monitor rejects lock, foreground change, pointer movement, and physical in
   assert.match(monitor, /frontmost PID changed/);
   assert.match(monitor, /pointer moved during isolated E2E/);
   assert.match(monitor, /physical user input detected/);
+  assert.match(monitor, /initialPhysicalInputAge/);
 });
 
 test('harness validates exact synthetic provenance before real actions', () => {

--- a/scripts/cu-real-e2e-contract.test.mjs
+++ b/scripts/cu-real-e2e-contract.test.mjs
@@ -26,7 +26,7 @@ test('launcher owns bounded cleanup, frontmost restoration, and sleep prevention
   assert.match(launcher, /restoreFrontmost\(originalFrontmost\)/);
 });
 
-test('concurrent mode allows user input without allowing fixture focus takeover', () => {
+test('concurrent mode allows user input while compatibility dispatch stays disabled', () => {
   assert.match(packageJson, /e2e:computer-use-concurrent/);
   assert.match(launcher, /--concurrent-user/);
   assert.match(launcher, /MAKA_CU_REAL_E2E_MODE/);
@@ -38,11 +38,9 @@ test('concurrent mode allows user input without allowing fixture focus takeover'
   assert.match(monitor, /synthetic fixture became frontmost during concurrent E2E/);
   assert.match(monitor, /!concurrentUserMode && displacement > 4/);
   assert.match(monitor, /!concurrentUserMode && receivedPhysicalInput/);
-  assert.match(harness, /fail_closed_occluded/);
-  assert.match(harness, /fail_closed_hidden/);
-  assert.match(harness, /concurrent-coordinate-policy-fail-closed/);
-  assert.match(harness, /semantic_background_succeeded/);
-  assert.match(harness, /allowCompatibilityInputDispatch: !concurrentUserMode/);
+  assert.match(harness, /concurrent-user-coordinate-disabled/);
+  assert.match(harness, /fail_closed_unsupported/);
+  assert.match(harness, /zero dispatch and zero mutation/);
   assert.match(harness, /appId: `pid:\$\{baseline\.fixturePID\}`/);
   assert.match(harness, /invalid concurrent execution baseline/);
 });
@@ -65,12 +63,12 @@ test('harness validates exact synthetic provenance before real actions', () => {
   assert.match(harness, /baseline\.canonicalAppPath !== expectedAppPath/);
 });
 
-test('truth claims isolate pixel evidence and keep concurrent dispatch semantic', () => {
-  assert.match(harness, /afterClick\.oop\.lastEventTrusted !== true/);
-  assert.match(harness, /afterClick\.oop\.webContentPID === afterClick\.oop\.hostPID/);
-  assert.match(harness, /dispatch\?\.address !== 'px'/);
-  assert.match(harness, /blockedFlow\?\.error !== 'unsupported_action'/);
-  assert.match(harness, /concurrent semantic action violated its oracle/);
+test('truth claims require compatibility input rejection and fresh-refetch ambiguity evidence', () => {
+  assert.match(harness, /clicked\.error !== 'unsupported_action'/);
+  assert.match(harness, /runResult\?\.error !== 'unsupported_action'/);
+  assert.match(harness, /afterClick\.oop\.hostLocalMouseDownCount !== initial\.oop\.hostLocalMouseDownCount/);
+  assert.match(harness, /afterClick\.oop\.hostLocalMouseUpCount !== initial\.oop\.hostLocalMouseUpCount/);
+  assert.doesNotMatch(harness, /allowCompatibilityInputDispatch/);
   assert.match(harness, /duplicateFlow\?\.error !== 'stale_frame'/);
   assert.match(harness, /ambiguous semantic action did not fail closed in backend refetch/);
   assert.match(harness, /stale-missing, process restart, and canonical live-process identity require native or driver follow-up/);

--- a/scripts/cu-real-e2e-launcher.mjs
+++ b/scripts/cu-real-e2e-launcher.mjs
@@ -175,8 +175,9 @@ function startMonitor(input = {}) {
           mode: fields[0],
           frontmostPID: Number(fields[1]),
           pointer: { x: Number(fields[2]), y: Number(fields[3]) },
-          bundleIdentifier: fields[4],
-          canonicalAppPath: fields.slice(5).join('\t'),
+          physicalInputAgeSeconds: Number(fields[4]),
+          bundleIdentifier: fields[5],
+          canonicalAppPath: fields.slice(6).join('\t'),
         });
       } else if (kind === 'CHANGE' || kind === 'ERROR') {
         fail(new Error(fields.join('\t') || line));

--- a/scripts/cu-real-e2e-monitor.swift
+++ b/scripts/cu-real-e2e-monitor.swift
@@ -68,9 +68,15 @@ let physicalEventTypes: [CGEventType] = [
     .rightMouseDragged,
     .otherMouseDragged
 ]
+let initialPhysicalInputAge = physicalEventTypes.map { eventType in
+    CGEventSource.secondsSinceLastEventType(
+        .hidSystemState,
+        eventType: eventType
+    )
+}.min() ?? .infinity
 print(
     "READY\t\(mode)\t\(frontmostPID)\t\(initialPointer.x)\t\(initialPointer.y)"
-        + "\t\(bundleIdentifier)\t\(bundlePath)"
+        + "\t\(initialPhysicalInputAge)\t\(bundleIdentifier)\t\(bundlePath)"
 )
 if snapshotMode {
     exit(0)

--- a/scripts/cu-real-e2e.mjs
+++ b/scripts/cu-real-e2e.mjs
@@ -1,4 +1,3 @@
-import { execFile } from 'node:child_process';
 import { readFile, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join, relative, resolve } from 'node:path';
@@ -36,12 +35,6 @@ const concurrentProceedPath = join(
   'concurrent-proceed.json',
 );
 
-const exec = (file, args) => new Promise((resolve, reject) => {
-  execFile(file, args, { encoding: 'utf8' }, (error, stdout, stderr) => {
-    if (error) reject(new Error(`${file} failed: ${stderr || error.message}`));
-    else resolve(stdout.trim());
-  });
-});
 const delay = (milliseconds) =>
   new Promise((resolve) => setTimeout(resolve, milliseconds));
 const waitForJson = async (path, label, timeoutMs = 10_000) => {
@@ -99,7 +92,6 @@ const backend = createCuaDriverBackend({
   expectedServerVersion: '0.7.1',
   expectedProtocolVersion: '2025-06-18',
   timeoutMs: 10_000,
-  allowCompatibilityInputDispatch: !concurrentUserMode,
   onSessionInvalidated(event) {
     invalidations.push(event);
   },
@@ -247,13 +239,6 @@ const coordinateForElement = (observed, element) => {
     ),
   ];
 };
-const screenCoordinateForElement = (element) => {
-  if (!element.frame) throw new Error('element has no screen frame');
-  return {
-    x: Math.round(element.frame.x + element.frame.width / 2),
-    y: Math.round(element.frame.y + element.frame.height / 2),
-  };
-};
 const validateFixtureIdentity = async (fixture, state) => {
   if (
     state.synthetic !== true
@@ -268,29 +253,6 @@ const validateFixtureIdentity = async (fixture, state) => {
     || (concurrentUserMode && baseline.frontmostPID === fixture.pid)
   ) {
     throw new Error('synthetic fixture provenance mismatch');
-  }
-};
-const fixtureCoordinateMutation = async (observed, label) => {
-  const target = findOccurrence(observed.model, label);
-  const coordinate = screenCoordinateForElement(target.selected);
-  const winner = await backend.inspectWindowAt(
-    coordinate,
-    new AbortController().signal,
-  );
-  if (!winner || winner.pid !== observed.model.pid || winner.windowId !== observed.model.window_id) {
-    throw new Error(`fixture mutation point is not owned by the fixture: ${label}`);
-  }
-  const result = await backend.run(
-    { type: 'left_click', coordinate },
-    new AbortController().signal,
-    {
-      sessionId: 'fixture-mutation',
-      turnId: 'mutation',
-      toolCallId: `mutate-${label}`,
-    },
-  );
-  if (!result.outcome.ok) {
-    throw new Error(`fixture mutation failed: ${result.outcome.message}`);
   }
 };
 const writeReport = async (report) => {
@@ -323,14 +285,6 @@ try {
   report.fixture = { ...report.fixture, pid: fixture.pid, windowId: fixture.windowId };
 
   const observed = await observe(fixture, 'observe-oop', 'turn-oop');
-  const concurrentSemanticObserved = concurrentUserMode
-    ? await observe(
-        fixture,
-        'observe-concurrent-semantic',
-        'turn-concurrent-semantic',
-        'real-e2e-semantic',
-      )
-    : undefined;
   if (observed.result.screenshot?.base64) {
     await writeFile(
       screenshotPath,
@@ -364,121 +318,62 @@ try {
       pointer: concurrentBaseline.pointer,
     };
   }
+  const oop = findOccurrence(observed.model, 'CUA Lab OOP Button');
+  const oopCoordinate = coordinateForElement(observed, oop.selected);
+  const clicked = await call({
+    action: 'left_click',
+    observation_id: observed.model.observation_id,
+    coordinate: oopCoordinate,
+  }, 'click-oop', 'turn-oop');
+  await delay(250);
+  const afterClick = await readState();
+  const dispatch = traces.find(
+    (event) => event.type === 'dispatch' && event.toolCallId === 'click-oop',
+  );
+  const runResult = idFlow.findLast((event) => event.phase === 'runResult');
+  if (
+    clicked.error !== 'unsupported_action'
+    || runResult?.error !== 'unsupported_action'
+    || dispatch
+    || afterClick.oop.clickCount !== initial.oop.clickCount
+    || afterClick.oop.hostLocalMouseDownCount !== initial.oop.hostLocalMouseDownCount
+    || afterClick.oop.hostLocalMouseUpCount !== initial.oop.hostLocalMouseUpCount
+  ) {
+    throw new Error(`OOP coordinate oracle did not fail closed: ${JSON.stringify({
+      clickedError: clicked?.error,
+      clickedText: clicked?.text,
+      coordinate: oopCoordinate,
+      dispatch,
+      before: initial.oop,
+      after: afterClick.oop,
+    })}`);
+  }
+  report.cases.push({
+    id: concurrentUserMode
+      ? 'concurrent-user-coordinate-disabled'
+      : 'oop-coordinate-disabled',
+    ok: true,
+    outcome: 'fail_closed_unsupported',
+    coordinate: oopCoordinate,
+    oracle: {
+      clickCount: [initial.oop.clickCount, afterClick.oop.clickCount],
+      hostPID: afterClick.oop.hostPID,
+      webContentPID: afterClick.oop.webContentPID,
+      hostMouseDown: [
+        initial.oop.hostLocalMouseDownCount,
+        afterClick.oop.hostLocalMouseDownCount,
+      ],
+      hostMouseUp: [
+        initial.oop.hostLocalMouseUpCount,
+        afterClick.oop.hostLocalMouseUpCount,
+      ],
+    },
+  });
+
   if (concurrentUserMode) {
-    const blockedTarget = findOccurrence(
-      observed.model,
-      'CUA Lab Coordinate Target',
-    );
-    const blockedCoordinate = coordinateForElement(
-      observed,
-      blockedTarget.selected,
-    );
-    const blockedToolCallId = 'concurrent-coordinate-policy';
-    const blockedAttempt = await call({
-      action: 'left_click',
-      observation_id: observed.model.observation_id,
-      coordinate: blockedCoordinate,
-    }, blockedToolCallId, 'turn-oop');
-    await delay(150);
-    const afterBlocked = await readState();
-    const blockedFlow = idFlow.findLast(
-      (event) => event.phase === 'runResult',
-    );
-    const blockedDispatch = traces.find(
-      (event) => event.type === 'dispatch'
-        && event.toolCallId === blockedToolCallId,
-    );
-    if (
-      blockedFlow?.error !== 'unsupported_action'
-      || blockedDispatch
-      || afterBlocked.coordinate.clickCount !== initial.coordinate.clickCount
-      || afterBlocked.coordinate.decoyClickCount
-        !== initial.coordinate.decoyClickCount
-    ) {
-      throw new Error('concurrent coordinate policy did not fail closed');
-    }
-    report.cases.push({
-      id: 'concurrent-coordinate-policy-fail-closed',
-      ok: true,
-      runtimeError: blockedAttempt.error,
-      backendError: blockedFlow.error,
-      dispatchAddress: blockedDispatch?.address,
-      oracle: {
-        target: [
-          initial.coordinate.clickCount,
-          afterBlocked.coordinate.clickCount,
-        ],
-        decoy: [
-          initial.coordinate.decoyClickCount,
-          afterBlocked.coordinate.decoyClickCount,
-        ],
-      },
-    });
-
-    const semanticTarget = findOccurrence(
-      concurrentSemanticObserved.model,
-      'CUA Lab Coordinate Target',
-    );
-    let semanticAttempt;
-    let semanticFailure;
-    try {
-      semanticAttempt = await call({
-        action: 'click_element',
-        observation_id: concurrentSemanticObserved.model.observation_id,
-        element_id: semanticTarget.selected.element_id,
-      }, 'concurrent-semantic-click', 'turn-concurrent-semantic', 'real-e2e-semantic');
-    } catch (error) {
-      semanticFailure = error instanceof Error ? error.message : String(error);
-    }
-    await delay(150);
-    const afterSemantic = await readState();
-    const semanticFlow = idFlow.findLast(
-      (event) => event.phase === 'runSemanticResult',
-    );
-    const semanticOccluded = semanticFlow?.error === 'target_occluded';
-    const semanticHidden =
-      /invalidApp: no visible window matched/.test(semanticFailure ?? '');
-    const semanticSucceeded = semanticFlow?.ok === true
-      && afterSemantic.coordinate.clickCount
-        === initial.coordinate.clickCount + 1
-      && afterSemantic.coordinate.decoyClickCount
-        === initial.coordinate.decoyClickCount;
-    if (
-      (!semanticSucceeded && !semanticOccluded && !semanticHidden)
-      || ((semanticOccluded || semanticHidden) && (
-        afterSemantic.coordinate.clickCount !== initial.coordinate.clickCount
-        || afterSemantic.coordinate.decoyClickCount
-          !== initial.coordinate.decoyClickCount
-      ))
-    ) {
-      throw new Error('concurrent semantic action violated its oracle');
-    }
-    report.cases.push({
-      id: 'concurrent-background-semantic',
-      ok: true,
-      outcome: semanticOccluded
-        ? 'fail_closed_occluded'
-        : semanticHidden
-          ? 'fail_closed_hidden'
-        : 'semantic_background_succeeded',
-      runtimeError: semanticAttempt?.error,
-      runtimeFailure: semanticFailure,
-      backendError: semanticFlow?.error,
-      oracle: {
-        target: [
-          initial.coordinate.clickCount,
-          afterSemantic.coordinate.clickCount,
-        ],
-        decoy: [
-          initial.coordinate.decoyClickCount,
-          afterSemantic.coordinate.decoyClickCount,
-        ],
-      },
-    });
-
     report.ok = true;
     report.claimBoundary =
-      'concurrent mode keeps compatibility input disabled and proves only safe semantic background action or fail-closed occlusion';
+      'concurrent mode proves coordinate compatibility input remains disabled with zero dispatch and zero mutation';
     report.evidence = {
       invalidations,
       traceTypes: traces.map((event) => event.type),
@@ -488,51 +383,6 @@ try {
     process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
     process.exitCode = 0;
   } else {
-    const oop = findOccurrence(observed.model, 'CUA Lab OOP Button');
-    const oopCoordinate = coordinateForElement(observed, oop.selected);
-    const clicked = await call({
-      action: 'left_click',
-      observation_id: observed.model.observation_id,
-      coordinate: oopCoordinate,
-    }, 'click-oop', 'turn-oop');
-    await delay(250);
-    const afterClick = await readState();
-    const dispatch = traces.find(
-      (event) => event.type === 'dispatch' && event.toolCallId === 'click-oop',
-    );
-    const clickSucceeded = !clicked?.error
-      && afterClick.oop.clickCount === initial.oop.clickCount + 1;
-    if (
-      !clickSucceeded
-      || afterClick.oop.lastEventTrusted !== true
-      || afterClick.oop.webContentPID <= 0
-      || afterClick.oop.webContentPID === afterClick.oop.hostPID
-      || afterClick.oop.hostLocalMouseDownCount
-        <= initial.oop.hostLocalMouseDownCount
-      || afterClick.oop.hostLocalMouseUpCount
-        <= initial.oop.hostLocalMouseUpCount
-      || afterClick.oop.hostLocalMouseDownCount
-        - initial.oop.hostLocalMouseDownCount
-        !== afterClick.oop.hostLocalMouseUpCount
-          - initial.oop.hostLocalMouseUpCount
-      || dispatch?.address !== 'px'
-    ) {
-      throw new Error('isolated OOP coordinate oracle did not prove trusted pixel dispatch');
-    }
-    report.cases.push({
-      id: 'isolated-oop-webcontent-coordinate-click',
-      ok: true,
-      outcome: 'isolated_compatibility_dispatch_succeeded',
-      dispatchAddress: dispatch.address,
-      coordinate: oopCoordinate,
-      oracle: {
-        clickCount: [initial.oop.clickCount, afterClick.oop.clickCount],
-        lastEventTrusted: afterClick.oop.lastEventTrusted,
-        hostPID: afterClick.oop.hostPID,
-        webContentPID: afterClick.oop.webContentPID,
-      },
-    });
-
     tools.clearSession('real-e2e');
     const duplicateObserved = await observe(fixture, 'observe-duplicate', 'turn-duplicate');
     const duplicate = findOccurrence(


### PR DESCRIPTION
## Stack position

P0 safety follow-up after #903. This PR should merge before the Computer Use stack is described as safe for concurrent user operation.

## Live user finding

During real no-focus testing, the pointer did not move and the synthetic target never became frontmost. The user nevertheless confirmed that physical mouse clicks became unreliable while the agent operated another display.

This is not a focus or cursor-warp bug. The compatibility executor posts mouse down/up events to a target PID through the CGEvent/SLEvent backend. Those events can still interfere with global physical mouse button state.

## Root cause

Runtime already has a `physicalUserIntervened` state machine, but Desktop had no real macOS producer or late dispatch guard. More importantly, a host-side quiet window cannot prove that the compatibility CGEvent backend is atomically isolated from physical HID delivery.

## Final fail-closed policy

Desktop provides an approximately one-second physical-input quiet window through:

```ts
powerMonitor.getSystemIdleTime() < 1
```

Active input or an unreadable signal returns typed `user_intervened`, emits no dispatch trace, calls no cua-driver input tool, and requires a fresh observation.

The compatibility event backend is disabled by default:

- coordinate left/right/middle/double/triple click: blocked;
- scroll and drag: blocked;
- `press_key`: blocked;
- semantic `supported:false` fallback to pixel: blocked.

Retained paths:

- observation, screenshots, wait, zoom, and virtual cursor presentation;
- native AX element actions and `set_value`;
- uniquely targeted Electron CDP semantic actions and `insertText`.

Controlled unit tests can explicitly opt into compatibility dispatch. Desktop production and real-machine E2E do not.

## Real-machine evidence

The replacement process-restart soak now uses only native AX `set_value` plus fresh AX readback. It sends no compatibility click, scroll, drag, key event, or HID pulse.

Five-round real macOS result:

- stale observation rejected as `target_missing`: 5/5;
- stale native dispatch: 0;
- fresh AX `set_value` with exact readback: 5/5;
- cua-driver action generation: 1 throughout;
- cua-driver capture generation: 0 throughout;
- restartAttempts: 0 throughout;
- fixture became frontmost: never;
- physical pointer displacement during the run: 217.1 logical points;
- user reported normal mouse and keyboard input during the AX-only run.

The visible AppKit fixture can still be noticeable when launched or ordered on another display. This proves input-path isolation, not zero user-perceived WindowServer disturbance.

## Verification

Passed locally:

- full repository `npm test`;
- full repository `npm run typecheck`;
- full repository `npm run build`;
- `@maka/computer-use`: 119/119;
- Computer Use script contracts: 10/10;
- real macOS AX-only process-restart soak: 5/5 rounds.

`npx knip` was also run. It reports the repository's existing baseline findings (unused Harbor/scripts files, unlisted dependencies/binaries, and existing unused exports); none point to a new unused symbol introduced by this follow-up.

## Remaining boundary

Re-enabling coordinate input requires a native executor that can prove its event backend does not affect global physical button state. A timing-only quiet window is mitigation, not sufficient evidence for safe concurrent CGEvent delivery. PID reuse also remains unproven.
