### PR TITLE
feat: add StepFun Global direct API support

### DIFF
--- a/apps/desktop/e2e/providers.spec.ts
+++ b/apps/desktop/e2e/providers.spec.ts
@@ -297,7 +297,10 @@ test('adds Tencent TokenHub with its exact snapshot model, API-key field, and sh
   await expect(page.getByRole('textbox', { name: '模型密钥' })).toBeVisible();
 });
 
-test('adds StepFun China with its exact snapshot model, API-key field, and shared official mark', async ({ window: page }) => {
+for (const stepfun of [
+  { label: 'StepFun (China)', providerType: 'stepfun', baseUrl: 'https://api.stepfun.com/v1' },
+  { label: 'StepFun (Global)', providerType: 'stepfun-ai', baseUrl: 'https://api.stepfun.ai/v1' },
+] as const) test(`adds ${stepfun.label} with its exact snapshot model, API-key field, and shared official mark`, async ({ window: page }) => {
   await page.getByRole('button', { name: '展开侧边栏' }).click();
   await page.getByRole('button', { name: '设置' }).click();
   await page.locator('[aria-label="设置分组"]').getByText('模型', { exact: true }).click();
@@ -306,20 +309,20 @@ test('adds StepFun China with its exact snapshot model, API-key field, and share
   await page.getByRole('tab', { name: 'API', exact: true }).click();
   await page.getByPlaceholder('搜索服务商').fill('StepFun');
   const catalogMark = page.locator(
-    '.providerCatalogRow[data-provider="stepfun"] .providerLogo .providerAssetMask',
+    `.providerCatalogRow[data-provider="${stepfun.providerType}"] .providerLogo .providerAssetMask`,
   );
   await expect(catalogMark).toBeVisible();
   expect(await catalogMark.evaluate(maskRenderContract)).toEqual({ usesAssetMask: true, followsForeground: true });
-  await page.getByRole('button', { name: /添加模型供应商：StepFun \(China\)/ }).click();
+  await page.getByRole('button', { name: `添加模型供应商：${stepfun.label}` }).click();
 
-  await expect(page.getByLabel('模型供应商连接标识')).toHaveValue('stepfun');
-  await expect(page.getByLabel('模型供应商服务地址')).toHaveValue('https://api.stepfun.com/v1');
+  await expect(page.getByLabel('模型供应商连接标识')).toHaveValue(stepfun.providerType);
+  await expect(page.getByLabel('模型供应商服务地址')).toHaveValue(stepfun.baseUrl);
   await expect(page.getByLabel('模型供应商默认模型')).toHaveValue('step-3.7-flash');
   await page.getByRole('button', { name: '保存供应商' }).click();
 
-  await expect(page.getByRole('heading', { name: 'StepFun (China)', exact: true }).first()).toBeVisible();
+  await expect(page.getByRole('heading', { name: stepfun.label, exact: true }).first()).toBeVisible();
   const detailMark = page.locator(
-    '.providerSubpageHeader .providerLogo[data-provider="stepfun"] .providerAssetMask',
+    `.providerSubpageHeader .providerLogo[data-provider="${stepfun.providerType}"] .providerAssetMask`,
   );
   await expect(detailMark).toBeVisible();
   expect(await detailMark.evaluate(maskRenderContract)).toEqual({ usesAssetMask: true, followsForeground: true });

--- a/apps/desktop/src/renderer/settings/provider-brand-marks.tsx
+++ b/apps/desktop/src/renderer/settings/provider-brand-marks.tsx
@@ -275,6 +275,7 @@ export function ProviderBrandMark({ type }: { type: ProviderType }): ReactElemen
       return <ProviderAssetMask src={hunyuanBrandMark} />;
     case 'tencent-coding-plan':
       return <ProviderAssetMask src={tencentCloudBrandMark} />;
+    case 'stepfun-ai':
     case 'stepfun':
       return <ProviderAssetMask src={stepfunBrandMark} />;
     default:

--- a/packages/cli/src/__tests__/connection-target.test.ts
+++ b/packages/cli/src/__tests__/connection-target.test.ts
@@ -50,6 +50,29 @@ describe('default session target resolver', () => {
     assert.equal(target.model, 'step-3.7-flash');
   });
 
+  test('resolves StepFun Global credentials without rewriting the selected model id', async () => {
+    const connection = makeConnection({
+      slug: 'stepfun-ai',
+      name: 'StepFun (Global)',
+      providerType: 'stepfun-ai',
+      defaultModel: 'step-3.7-flash',
+    });
+
+    const target = await resolveDefaultSessionTarget({
+      connectionStore: {
+        getDefault: async () => 'stepfun-ai',
+        get: async (slug) => slug === 'stepfun-ai' ? connection : null,
+      },
+      credentialStore: {
+        getSecret: async (_slug, kind) => kind === 'api_key' ? 'stepfun-global-test-key' : null,
+      },
+    });
+
+    assert.equal(target.connection.providerType, 'stepfun-ai');
+    assert.equal(target.apiKey, 'stepfun-global-test-key');
+    assert.equal(target.model, 'step-3.7-flash');
+  });
+
   test('resolves Tencent TokenHub credentials without rewriting the selected model id', async () => {
     const connection = makeConnection({
       slug: 'tencent-tokenhub',

--- a/packages/core/src/__tests__/llm-connections.test.ts
+++ b/packages/core/src/__tests__/llm-connections.test.ts
@@ -47,6 +47,7 @@ describe('provider compatibility contract', () => {
       'nvidia',
       'tencent-tokenhub',
       'stepfun',
+      'stepfun-ai',
       'ollama',
       'lm-studio',
       'openai-compatible',
@@ -78,6 +79,7 @@ describe('provider compatibility contract', () => {
       'tencent-tokenhub',
       'stepfun',
       'tencent-coding-plan',
+      'stepfun-ai',
     ]);
     assert.deepEqual(CATALOG_PROVIDER_TYPES, [
       'kimi-coding-plan',
@@ -103,6 +105,7 @@ describe('provider compatibility contract', () => {
       'tencent-tokenhub',
       'stepfun',
       'tencent-coding-plan',
+      'stepfun-ai',
     ]);
 
     for (const orderField of ['readyOrder', 'catalogOrder', 'recommendedOrder'] as const) {
@@ -340,6 +343,29 @@ describe('provider compatibility contract', () => {
     assert.equal(stepfun.signupUrl, 'https://platform.stepfun.com/interface-key');
     assert.equal(stepfun.modelsDevId, 'stepfun');
     assert.deepEqual(stepfun.fallbackModels, [
+      'step-3.7-flash',
+      'step-3.5-flash-2603',
+      'step-3.5-flash',
+      'step-1-32k',
+      'step-2-16k',
+    ]);
+  });
+
+  it('owns StepFun Global direct API behavior under the stable stepfun-ai id', () => {
+    const stepfunGlobal = (PROVIDER_REGISTRY as Partial<Record<string, (typeof PROVIDER_REGISTRY)[keyof typeof PROVIDER_REGISTRY]>>)['stepfun-ai'];
+
+    assert.ok(stepfunGlobal, 'StepFun Global direct API must be available through the shared provider registry');
+    assert.equal(stepfunGlobal.label, 'StepFun (Global)');
+    assert.equal(stepfunGlobal.baseUrl, 'https://api.stepfun.ai/v1');
+    assert.equal(stepfunGlobal.authKind, 'api_key');
+    assert.equal(stepfunGlobal.protocol, 'openai');
+    assert.deepEqual(stepfunGlobal.runtimeAdapter, { kind: 'openai-compatible', name: 'provider' });
+    assert.deepEqual(stepfunGlobal.modelDiscovery, { kind: 'protocol' });
+    assert.equal(stepfunGlobal.category, 'overseas');
+    assert.equal(stepfunGlobal.catalogGroup, 'api');
+    assert.equal(stepfunGlobal.signupUrl, 'https://platform.stepfun.ai/interface-key');
+    assert.equal(stepfunGlobal.modelsDevId, 'stepfun-ai');
+    assert.deepEqual(stepfunGlobal.fallbackModels, [
       'step-3.7-flash',
       'step-3.5-flash-2603',
       'step-3.5-flash',

--- a/packages/core/src/__tests__/llm-connections.test.ts
+++ b/packages/core/src/__tests__/llm-connections.test.ts
@@ -369,8 +369,6 @@ describe('provider compatibility contract', () => {
       'step-3.7-flash',
       'step-3.5-flash-2603',
       'step-3.5-flash',
-      'step-1-32k',
-      'step-2-16k',
     ]);
   });
 });

--- a/packages/core/src/__tests__/model-catalog.test.ts
+++ b/packages/core/src/__tests__/model-catalog.test.ts
@@ -9,6 +9,33 @@ import { isConnectionReady } from '../connection-readiness.js';
 import type { LlmConnection, ModelInfo, ProviderType } from '../llm-connections.js';
 
 describe('ModelCatalogEntry', () => {
+  it('uses the checked-in StepFun Global snapshot until account discovery succeeds', () => {
+    const entries = buildConnectionModelCatalogEntries({
+      connection: {
+        slug: 'stepfun-ai',
+        providerType: 'stepfun-ai',
+        defaultModel: 'step-3.7-flash',
+      },
+    });
+
+    assert.deepEqual(entries.map((entry) => entry.id), [
+      'step-3.7-flash',
+      'step-3.5-flash-2603',
+      'step-3.5-flash',
+      'step-1-32k',
+      'step-2-16k',
+    ]);
+    assert.equal(entries[0]?.source, 'static_catalog');
+    assert.equal(entries[0]?.provenance.modelSource, 'fallback');
+    assert.equal(entries[0]?.contextWindow, 256_000);
+    assert.equal(entries[0]?.maxOutputTokens, 256_000);
+    assert.deepEqual(entries[0]?.capabilities, {
+      vision: true,
+      reasoning: true,
+      functionCalling: true,
+    });
+  });
+
   it('uses the checked-in StepFun China snapshot until account discovery succeeds', () => {
     const entries = buildConnectionModelCatalogEntries({
       connection: {

--- a/packages/core/src/__tests__/model-catalog.test.ts
+++ b/packages/core/src/__tests__/model-catalog.test.ts
@@ -22,8 +22,6 @@ describe('ModelCatalogEntry', () => {
       'step-3.7-flash',
       'step-3.5-flash-2603',
       'step-3.5-flash',
-      'step-1-32k',
-      'step-2-16k',
     ]);
     assert.equal(entries[0]?.source, 'static_catalog');
     assert.equal(entries[0]?.provenance.modelSource, 'fallback');

--- a/packages/core/src/__tests__/provider-auth.test.ts
+++ b/packages/core/src/__tests__/provider-auth.test.ts
@@ -22,6 +22,19 @@ describe('ProviderAuth contract', () => {
     expect(contract.actionAvailability.fetch_models).toBe('hidden');
   });
 
+  test('StepFun Global uses an independent API-key credential and model-discovery flow', () => {
+    const contract = deriveProviderAuthContract({
+      providerType: 'stepfun-ai',
+      hasSecret: true,
+    });
+
+    expect(contract.providerType).toBe('stepfun-ai');
+    expect(contract.setupMode).toBe('api_key');
+    expect(contract.requiresSecret).toBe(true);
+    expect(contract.actionAvailability.test_credentials).toBe('available');
+    expect(contract.actionAvailability.fetch_models).toBe('available');
+  });
+
   test('StepFun China uses the shared API-key credential and model-discovery flow', () => {
     const contract = deriveProviderAuthContract({
       providerType: 'stepfun',

--- a/packages/core/src/model-metadata.generated.ts
+++ b/packages/core/src/model-metadata.generated.ts
@@ -2,7 +2,7 @@
 // Do not edit by hand; put access-path-specific facts in model-metadata.ts.
 import type { ModelMetadata } from './model-metadata.js';
 
-export const GENERATED_MODELS_DEV_METADATA: Record<"anthropic" | "cerebras" | "deepseek" | "fireworks-ai" | "google" | "gemini-cli" | "MiniMax" | "MiniMax-cn" | "mistral" | "moonshot" | "nvidia" | "openai" | "siliconflow" | "stepfun" | "togetherai" | "tencent-coding-plan" | "tencent-tokenhub" | "xai" | "zai-coding-plan", Record<string, ModelMetadata>> = {
+export const GENERATED_MODELS_DEV_METADATA: Record<"anthropic" | "cerebras" | "deepseek" | "fireworks-ai" | "google" | "gemini-cli" | "MiniMax" | "MiniMax-cn" | "mistral" | "moonshot" | "nvidia" | "openai" | "siliconflow" | "stepfun" | "stepfun-ai" | "togetherai" | "tencent-coding-plan" | "tencent-tokenhub" | "xai" | "zai-coding-plan", Record<string, ModelMetadata>> = {
   "anthropic": {
     "claude-fable-5": {"displayName":"Claude Fable 5","lifecycle":"active","docsUrl":"https://docs.anthropic.com/en/docs/about-claude/models","contextWindow":1000000,"maxOutputTokens":128000,"capabilities":{"vision":true,"reasoning":true,"functionCalling":true}},
     "claude-haiku-4-5": {"displayName":"Claude Haiku 4.5 (latest)","lifecycle":"active","docsUrl":"https://docs.anthropic.com/en/docs/about-claude/models","contextWindow":200000,"maxOutputTokens":64000,"capabilities":{"vision":true,"reasoning":true,"functionCalling":true}},
@@ -364,6 +364,16 @@ export const GENERATED_MODELS_DEV_METADATA: Record<"anthropic" | "cerebras" | "d
     "stepaudio-2.5-asr": {"displayName":"StepAudio 2.5 ASR","lifecycle":"active","docsUrl":"https://platform.stepfun.com/docs/zh/overview/concept","contextWindow":0,"maxOutputTokens":0,"capabilities":{"vision":false,"reasoning":false,"functionCalling":false}},
     "stepaudio-2.5-tts": {"displayName":"StepAudio 2.5 TTS","lifecycle":"active","docsUrl":"https://platform.stepfun.com/docs/zh/overview/concept","contextWindow":0,"maxOutputTokens":0,"capabilities":{"vision":false,"reasoning":false,"functionCalling":false}},
   },
+  "stepfun-ai": {
+    "step-1-32k": {"displayName":"Step 1 (32K)","lifecycle":"active","docsUrl":"https://platform.stepfun.ai/docs/en/overview/concept","contextWindow":32768,"maxOutputTokens":32768,"capabilities":{"vision":false,"reasoning":false,"functionCalling":true}},
+    "step-2-16k": {"displayName":"Step 2 (16K)","lifecycle":"active","docsUrl":"https://platform.stepfun.ai/docs/en/overview/concept","contextWindow":16384,"maxOutputTokens":8192,"capabilities":{"vision":false,"reasoning":false,"functionCalling":true}},
+    "step-3.5-flash": {"displayName":"Step 3.5 Flash","lifecycle":"active","docsUrl":"https://platform.stepfun.ai/docs/en/overview/concept","contextWindow":256000,"maxOutputTokens":256000,"capabilities":{"vision":false,"reasoning":true,"functionCalling":true}},
+    "step-3.5-flash-2603": {"displayName":"Step 3.5 Flash 2603","lifecycle":"active","docsUrl":"https://platform.stepfun.ai/docs/en/overview/concept","contextWindow":256000,"maxOutputTokens":256000,"capabilities":{"vision":false,"reasoning":true,"functionCalling":true}},
+    "step-3.7-flash": {"displayName":"Step 3.7 Flash","lifecycle":"active","docsUrl":"https://platform.stepfun.ai/docs/en/overview/concept","contextWindow":256000,"maxOutputTokens":256000,"capabilities":{"vision":true,"reasoning":true,"functionCalling":true}},
+    "step-tts-2": {"displayName":"Step TTS 2","lifecycle":"active","docsUrl":"https://platform.stepfun.ai/docs/en/overview/concept","contextWindow":0,"maxOutputTokens":0,"capabilities":{"vision":false,"reasoning":false,"functionCalling":false}},
+    "stepaudio-2.5-asr": {"displayName":"StepAudio 2.5 ASR","lifecycle":"active","docsUrl":"https://platform.stepfun.ai/docs/en/overview/concept","contextWindow":0,"maxOutputTokens":0,"capabilities":{"vision":false,"reasoning":false,"functionCalling":false}},
+    "stepaudio-2.5-tts": {"displayName":"StepAudio 2.5 TTS","lifecycle":"active","docsUrl":"https://platform.stepfun.ai/docs/en/overview/concept","contextWindow":0,"maxOutputTokens":0,"capabilities":{"vision":false,"reasoning":false,"functionCalling":false}},
+  },
   "togetherai": {
     "deepcogito/cogito-v2-1-671b": {"displayName":"Cogito v2.1 671B","lifecycle":"active","docsUrl":"https://docs.together.ai/docs/serverless-models","contextWindow":163840,"maxOutputTokens":163840,"capabilities":{"vision":false,"reasoning":true,"functionCalling":false}},
     "deepseek-ai/DeepSeek-R1": {"displayName":"DeepSeek-R1","lifecycle":"deprecated","docsUrl":"https://docs.together.ai/docs/serverless-models","contextWindow":163839,"maxOutputTokens":163839,"capabilities":{"vision":false,"reasoning":true,"functionCalling":false}},
@@ -433,7 +443,7 @@ export const GENERATED_MODELS_DEV_METADATA: Record<"anthropic" | "cerebras" | "d
   },
 };
 
-export const GENERATED_MODELS_DEV_PROVIDER_FACTS: Record<"anthropic" | "cerebras" | "deepseek" | "fireworks-ai" | "google" | "gemini-cli" | "MiniMax" | "MiniMax-cn" | "mistral" | "moonshot" | "nvidia" | "openai" | "siliconflow" | "stepfun" | "togetherai" | "tencent-coding-plan" | "tencent-tokenhub" | "xai" | "zai-coding-plan", { id: string; name: string; api?: string; doc: string }> = {
+export const GENERATED_MODELS_DEV_PROVIDER_FACTS: Record<"anthropic" | "cerebras" | "deepseek" | "fireworks-ai" | "google" | "gemini-cli" | "MiniMax" | "MiniMax-cn" | "mistral" | "moonshot" | "nvidia" | "openai" | "siliconflow" | "stepfun" | "stepfun-ai" | "togetherai" | "tencent-coding-plan" | "tencent-tokenhub" | "xai" | "zai-coding-plan", { id: string; name: string; api?: string; doc: string }> = {
   "anthropic": {"id":"anthropic","name":"Anthropic","doc":"https://docs.anthropic.com/en/docs/about-claude/models"},
   "cerebras": {"id":"cerebras","name":"Cerebras","doc":"https://inference-docs.cerebras.ai/models/overview"},
   "deepseek": {"id":"deepseek","name":"DeepSeek","api":"https://api.deepseek.com","doc":"https://api-docs.deepseek.com/quick_start/pricing"},
@@ -448,6 +458,7 @@ export const GENERATED_MODELS_DEV_PROVIDER_FACTS: Record<"anthropic" | "cerebras
   "openai": {"id":"openai","name":"OpenAI","doc":"https://platform.openai.com/docs/models"},
   "siliconflow": {"id":"siliconflow","name":"SiliconFlow","api":"https://api.siliconflow.com/v1","doc":"https://cloud.siliconflow.com/models"},
   "stepfun": {"id":"stepfun","name":"StepFun (China)","api":"https://api.stepfun.com/v1","doc":"https://platform.stepfun.com/docs/zh/overview/concept"},
+  "stepfun-ai": {"id":"stepfun-ai","name":"StepFun (Global)","api":"https://api.stepfun.ai/v1","doc":"https://platform.stepfun.ai/docs/en/overview/concept"},
   "togetherai": {"id":"togetherai","name":"Together AI","doc":"https://docs.together.ai/docs/serverless-models"},
   "tencent-coding-plan": {"id":"tencent-coding-plan","name":"Tencent Coding Plan (China)","api":"https://api.lkeap.cloud.tencent.com/coding/v3","doc":"https://cloud.tencent.com/document/product/1772/128947"},
   "tencent-tokenhub": {"id":"tencent-tokenhub","name":"Tencent TokenHub","api":"https://tokenhub.tencentmaas.com/v1","doc":"https://cloud.tencent.com/document/product/1823/130050"},

--- a/packages/core/src/provider-registry.ts
+++ b/packages/core/src/provider-registry.ts
@@ -134,11 +134,16 @@ if (stepfunGlobal.id !== 'stepfun-ai') {
   throw new Error('models.dev StepFun Global provider facts are missing stable id stepfun-ai');
 }
 if (!stepfunGlobal.api) throw new Error('models.dev StepFun Global provider facts are missing api');
-const stepfunGlobalModelIds = toolCallingModelIds(
-  'StepFun Global',
-  GENERATED_MODELS_DEV_METADATA['stepfun-ai'],
-  ['step-3.7-flash', 'step-3.5-flash-2603', 'step-3.5-flash'],
-);
+const stepfunGlobalModelIds = [
+  'step-3.7-flash',
+  'step-3.5-flash-2603',
+  'step-3.5-flash',
+];
+for (const id of stepfunGlobalModelIds) {
+  if (!GENERATED_MODELS_DEV_METADATA['stepfun-ai'][id]?.capabilities?.functionCalling) {
+    throw new Error(`models.dev StepFun Global snapshot is missing documented tool-capable model ${id}`);
+  }
+}
 
 const together = GENERATED_MODELS_DEV_PROVIDER_FACTS.togetherai;
 if (together.id !== 'togetherai') {

--- a/packages/core/src/provider-registry.ts
+++ b/packages/core/src/provider-registry.ts
@@ -129,6 +129,16 @@ const stepfunModelIds = toolCallingModelIds(
   GENERATED_MODELS_DEV_METADATA.stepfun,
   ['step-3.7-flash', 'step-3.5-flash-2603', 'step-3.5-flash'],
 );
+const stepfunGlobal = GENERATED_MODELS_DEV_PROVIDER_FACTS['stepfun-ai'];
+if (stepfunGlobal.id !== 'stepfun-ai') {
+  throw new Error('models.dev StepFun Global provider facts are missing stable id stepfun-ai');
+}
+if (!stepfunGlobal.api) throw new Error('models.dev StepFun Global provider facts are missing api');
+const stepfunGlobalModelIds = toolCallingModelIds(
+  'StepFun Global',
+  GENERATED_MODELS_DEV_METADATA['stepfun-ai'],
+  ['step-3.7-flash', 'step-3.5-flash-2603', 'step-3.5-flash'],
+);
 
 const together = GENERATED_MODELS_DEV_PROVIDER_FACTS.togetherai;
 if (together.id !== 'togetherai') {
@@ -546,6 +556,25 @@ const providerRegistry = {
     modelsDevId: stepfun.id,
     readyOrder: 22,
     catalogOrder: 22,
+  },
+  'stepfun-ai': {
+    label: stepfunGlobal.name,
+    description: 'StepFun Global models for multimodal reasoning and tool-use agents.',
+    baseUrl: stepfunGlobal.api,
+    authKind: 'api_key',
+    backendKind: 'ai-sdk',
+    fallbackModels: stepfunGlobalModelIds,
+    status: 'ready',
+    protocol: 'openai',
+    runtimeAdapter: { kind: 'openai-compatible', name: 'provider' },
+    modelDiscovery: { kind: 'protocol' },
+    category: 'overseas',
+    catalogGroup: 'api',
+    catalogBadge: 'API',
+    signupUrl: 'https://platform.stepfun.ai/interface-key',
+    modelsDevId: stepfunGlobal.id,
+    readyOrder: 24,
+    catalogOrder: 24,
   },
   ollama: {
     label: 'Ollama',

--- a/packages/headless/src/__tests__/harbor-cell.test.ts
+++ b/packages/headless/src/__tests__/harbor-cell.test.ts
@@ -2332,6 +2332,36 @@ setTimeout(() => {
     assert.equal(missing.apiKey, '');
   });
 
+  test('resolves StepFun Global only from its independent direct API credential env', () => {
+    const resolved = resolveHarborCellAiSdkEnv({
+      provider: 'stepfun-ai',
+      model: 'step-3.7-flash',
+      env: {
+        STEPFUN_AI_API_KEY: 'stepfun-global-key',
+        STEPFUN_AI_BASE_URL: 'https://api.stepfun.ai/v1',
+        STEPFUN_API_KEY: 'china-key-must-not-cross',
+        OPENAI_API_KEY: 'openai-key-must-not-cross',
+      },
+      ts: 1,
+    });
+
+    assert.equal(resolved.apiKey, 'stepfun-global-key');
+    assert.equal(resolved.connection.providerType, 'stepfun-ai');
+    assert.equal(resolved.connection.defaultModel, 'step-3.7-flash');
+    assert.equal(resolved.connection.baseUrl, 'https://api.stepfun.ai/v1');
+
+    const missing = resolveHarborCellAiSdkEnv({
+      provider: 'stepfun-ai',
+      model: 'step-3.7-flash',
+      env: {
+        STEPFUN_API_KEY: 'china-key-must-not-cross',
+        OPENAI_API_KEY: 'openai-key-must-not-cross',
+      },
+      ts: 1,
+    });
+    assert.equal(missing.apiKey, '');
+  });
+
   test('resolves Cerebras only from Cerebras credential env without rewriting the model id', () => {
     const resolved = resolveHarborCellAiSdkEnv({
       provider: 'cerebras',

--- a/packages/headless/src/__tests__/provider-env.test.ts
+++ b/packages/headless/src/__tests__/provider-env.test.ts
@@ -86,3 +86,11 @@ test('StepFun China keeps direct API credentials separate from global and plan i
     baseUrls: ['STEPFUN_BASE_URL'],
   });
 });
+
+test('StepFun Global keeps direct API credentials separate from China and plan identities', () => {
+  assert.deepEqual(providerCredentialEnv('stepfun-ai'), {
+    apiKeys: ['STEPFUN_AI_API_KEY'],
+    apiKeyFile: 'STEPFUN_AI_API_KEY_FILE',
+    baseUrls: ['STEPFUN_AI_BASE_URL'],
+  });
+});

--- a/packages/headless/src/provider-env.ts
+++ b/packages/headless/src/provider-env.ts
@@ -26,6 +26,7 @@ const PROVIDER_CREDENTIAL_ENV = {
   nvidia: env('NVIDIA', ['NVIDIA_BASE_URL']),
   'tencent-tokenhub': env('TENCENT_TOKENHUB', ['TENCENT_TOKENHUB_BASE_URL']),
   stepfun: env('STEPFUN', ['STEPFUN_BASE_URL']),
+  'stepfun-ai': env('STEPFUN_AI', ['STEPFUN_AI_BASE_URL']),
   'openai-compatible': env('OPENAI', ['OPENAI_BASE_URL']),
   'claude-subscription': env('ANTHROPIC'),
 } satisfies Partial<Record<ProviderType, ProviderCredentialEnv>>;

--- a/packages/runtime/src/__tests__/provider-conformance.test.ts
+++ b/packages/runtime/src/__tests__/provider-conformance.test.ts
@@ -1194,11 +1194,14 @@ describe('models.dev provider conformance', () => {
     assert.equal(result.text, 'Echoed hello.');
   });
 
-  test('StepFun China preserves its exact model id through discovery and the documented two-stage tool-call loop', async () => {
+  for (const stepfun of [
+    { label: 'StepFun China', providerType: 'stepfun', apiKey: 'stepfun-test-key' },
+    { label: 'StepFun Global', providerType: 'stepfun-ai', apiKey: 'stepfun-global-test-key' },
+  ] as const) test(`${stepfun.label} preserves its exact model id through discovery and the documented two-stage tool-call loop`, async () => {
     const modelId = 'step-3.7-flash';
     const requestBodies: Array<Record<string, unknown>> = [];
     const server = await startJsonServer(async (request, response) => {
-      assert.equal(request.headers.authorization, 'Bearer stepfun-test-key');
+      assert.equal(request.headers.authorization, `Bearer ${stepfun.apiKey}`);
       if (request.method === 'GET' && request.url === '/v1/models') {
         respondJson(response, 200, { object: 'list', data: [{ id: modelId }] });
         return;
@@ -1247,9 +1250,9 @@ describe('models.dev provider conformance', () => {
       });
     });
     const connection: LlmConnection = {
-      slug: 'stepfun',
-      name: 'StepFun (China)',
-      providerType: 'stepfun',
+      slug: stepfun.providerType,
+      name: stepfun.label,
+      providerType: stepfun.providerType,
       baseUrl: `${server.url}/v1`,
       defaultModel: modelId,
       enabled: true,
@@ -1257,11 +1260,11 @@ describe('models.dev provider conformance', () => {
       updatedAt: 1,
     };
 
-    const models = await fetchProviderModels(connection, 'stepfun-test-key');
+    const models = await fetchProviderModels(connection, stepfun.apiKey);
     assert.deepEqual(models, [{ id: modelId }]);
 
     const result = await generateText({
-      model: getAIModel({ connection, apiKey: 'stepfun-test-key', modelId: models[0]!.id }),
+      model: getAIModel({ connection, apiKey: stepfun.apiKey, modelId: models[0]!.id }),
       prompt: 'Call echo with hello.',
       stopWhen: stepCountIs(2),
       tools: {

--- a/packages/storage/src/__tests__/connection-store.test.ts
+++ b/packages/storage/src/__tests__/connection-store.test.ts
@@ -41,6 +41,23 @@ describe('FileConnectionStore', () => {
     });
   });
 
+  test('persists the StepFun Global provider id and exact default model', async () => {
+    await withConnectionStore(async (store, dir) => {
+      await store.create({
+        slug: 'stepfun-ai',
+        name: 'StepFun (Global)',
+        providerType: 'stepfun-ai',
+        defaultModel: 'step-3.7-flash',
+      });
+
+      const persisted = JSON.parse(await readFile(join(dir, 'llm-connections.json'), 'utf8')) as {
+        connections: Array<{ providerType: string; defaultModel: string }>;
+      };
+      assert.equal(persisted.connections[0]?.providerType, 'stepfun-ai');
+      assert.equal(persisted.connections[0]?.defaultModel, 'step-3.7-flash');
+    });
+  });
+
   test('persists the Tencent TokenHub provider id and exact default model', async () => {
     await withConnectionStore(async (store, dir) => {
       await store.create({

--- a/scripts/sync-model-metadata.mjs
+++ b/scripts/sync-model-metadata.mjs
@@ -17,6 +17,7 @@ const PROVIDERS = {
   openai: 'openai',
   siliconflow: 'siliconflow',
   stepfun: 'stepfun',
+  'stepfun-ai': 'stepfun-ai',
   togetherai: 'togetherai',
   'tencent-coding-plan': 'tencent-coding-plan',
   'tencent-tokenhub': 'tencent-tokenhub',

--- a/scripts/sync-model-metadata.test.mjs
+++ b/scripts/sync-model-metadata.test.mjs
@@ -7,7 +7,7 @@ import { promisify } from 'node:util';
 import test from 'node:test';
 
 const execFileAsync = promisify(execFile);
-const PROVIDER_IDS = ['anthropic', 'cerebras', 'deepseek', 'fireworks-ai', 'google', 'minimax', 'minimax-cn', 'mistral', 'moonshotai-cn', 'nvidia', 'openai', 'siliconflow', 'stepfun', 'tencent-coding-plan', 'tencent-tokenhub', 'togetherai', 'xai', 'zai-coding-plan'];
+const PROVIDER_IDS = ['anthropic', 'cerebras', 'deepseek', 'fireworks-ai', 'google', 'minimax', 'minimax-cn', 'mistral', 'moonshotai-cn', 'nvidia', 'openai', 'siliconflow', 'stepfun', 'stepfun-ai', 'tencent-coding-plan', 'tencent-tokenhub', 'togetherai', 'xai', 'zai-coding-plan'];
 
 function withRequiredProviders(openai) {
   return Object.fromEntries(PROVIDER_IDS.map((id) => {
@@ -346,6 +346,42 @@ test('sync-model-metadata vendors StepFun China direct provider facts and exact 
   const generated = await readFile(output, 'utf8');
   assert.match(generated, /"stepfun": \{/);
   assert.match(generated, /"stepfun": \{"id":"stepfun","name":"StepFun \(China\)","api":"https:\/\/api\.stepfun\.com\/v1"/);
+  assert.match(generated, /"step-3\.5-flash": \{"displayName":"Step 3\.5 Flash"/);
+  assert.match(generated, /"step-3\.7-flash": \{"displayName":"Step 3\.7 Flash"/);
+});
+
+test('sync-model-metadata vendors StepFun Global direct provider facts and exact model ids', async () => {
+  const directory = await mkdtemp(join(tmpdir(), 'maka-model-metadata-'));
+  const input = join(directory, 'api.json');
+  const output = join(directory, 'generated.ts');
+  const catalog = withRequiredProviders({});
+  catalog['stepfun-ai'] = {
+    id: 'stepfun-ai',
+    name: 'StepFun (Global)',
+    api: 'https://api.stepfun.ai/v1',
+    doc: 'https://platform.stepfun.ai/docs/en/overview/concept',
+    models: {
+      'step-3.5-flash': {
+        id: 'step-3.5-flash', name: 'Step 3.5 Flash', reasoning: true, tool_call: true,
+        modalities: { input: ['text'], output: ['text'] },
+        limit: { context: 256_000, output: 256_000 },
+      },
+      'step-3.7-flash': {
+        id: 'step-3.7-flash', name: 'Step 3.7 Flash', reasoning: true, tool_call: true,
+        modalities: { input: ['text', 'image'], output: ['text'] },
+        limit: { context: 256_000, output: 256_000 },
+      },
+    },
+  };
+  await writeFile(input, JSON.stringify(catalog));
+
+  await execFileAsync(process.execPath, [
+    'scripts/sync-model-metadata.mjs', '--input', input, '--output', output,
+  ]);
+
+  const generated = await readFile(output, 'utf8');
+  assert.match(generated, /"stepfun-ai": \{/);
+  assert.match(generated, /"stepfun-ai": \{"id":"stepfun-ai","name":"StepFun \(Global\)","api":"https:\/\/api\.stepfun\.ai\/v1"/);
   assert.match(generated, /"step-3\.5-flash": \{"displayName":"Step 3\.5 Flash"/);
   assert.match(generated, /"step-3\.7-flash": \{"displayName":"Step 3\.7 Flash"/);
 });


### PR DESCRIPTION
## Summary

- Add the StepFun Global direct API as the stable `stepfun-ai` provider at `https://api.stepfun.ai/v1`.
- Reuse the shared registry, protocol discovery, OpenAI-compatible runtime, exact model-id persistence, and Desktop provider-brand seams across Desktop, CLI, storage, headless, and runtime.
- Reuse #902's byte-identical StepFun SVG, provenance, MIT notice, mask rendering, and integrity checker without vendoring a second asset.

## Why

Issue #860 Phase 3 requires StepFun Global direct API access to remain separate from StepFun China and Step Plan because the console, API domain, credentials, billing path, and permitted models are separate account facts. This slice adds one registry-owned identity with account model discovery, a deterministic models.dev snapshot fallback, and a verified reasoning/tool-call loop.

Refs #860.

## Scope

This PR implements only the Global direct API identity `stepfun-ai` (`https://api.stepfun.ai/v1`). The existing China direct identity `stepfun`, Step Plan China/global identities, other providers, and Phase 7 are explicit non-goals.

The complete models.dev snapshot remains available as metadata. The fallback selector is intentionally limited to the three models that the current StepFun Global Tool Call documentation explicitly lists: `step-3.7-flash`, `step-3.5-flash-2603`, and `step-3.5-flash`.

## Verification

- `npm run typecheck` — passed for every workspace.
- `@maka/core` — 873 passed, 0 failed after the reviewer fix.
- `maka-agent` CLI — 311 passed, 0 failed.
- `@maka/storage` — 245 passed, 0 failed.
- `@maka/runtime` — 1,465 passed, 7 existing skips, 0 failed; the StepFun Global deterministic contract covers authenticated discovery, exact model IDs, the default `reasoning` response field, tool execution/result replay, and the final assistant turn.
- `@maka/headless` — 863 passed, 0 failed; post-fix provider-env and Harbor focused suites also passed.
- `npm --workspace @maka/desktop run build:renderer` — passed; the packaged third-party notice checker confirmed the byte-identical notice.
- `npm run check:stale`, the 14-test sync-model-metadata suite, and `git diff --check origin/main...HEAD` — passed.
- Immutable upstream SVG hash comparison — matched `lobehub/lobe-icons@e4302041fbb3039608d25f9f618bd462783b875e/packages/static-svg/icons/stepfun.svg`; SHA-256 `f46fbd1eee00a3dc7874395484bcc3e25a803e9eb4b79f07b7eec377a1e2f25c`.
- Independent reviewer — the initial P2 about over-broad fallback models was fixed and the re-review returned 0 findings.
- Validation audit note: one chained local validation command yielded at the tool's 30-second observation window while Runtime was still running. It produced no assertion failure, non-zero exit, or stack trace; the wrapper had not retained the returned session metadata. Runtime was then run independently with explicit `exit=0` and the 1,465/7/0 result above.

Local Desktop E2E was deferred to CI per the Issue #860 delivery boundary; CI E2E remains a merge gate. No new layout or interaction was introduced, so visual evidence is not applicable: catalog/detail rendering reuses the existing `ProviderAssetMask` path and the deterministic E2E contract now exercises both StepFun identities. A live API smoke was not run because no safe user credential was available; no credential or raw provider response was recorded.

## Impact

Users can configure StepFun Global independently from StepFun China, discover account-visible models, fall back to the documented tool-capable snapshot subset when discovery is unavailable, and preserve exact model IDs across Desktop, CLI, storage, headless, and runtime. Existing persisted provider IDs and Step Plan paths are unchanged. No migration is required.

## Reviewer notes

Authoritative protocol evidence:

- Global quickstart and endpoint: https://platform.stepfun.ai/docs/en/quickstart/overview
- Authenticated model discovery: https://platform.stepfun.ai/docs/en/api-reference/models/list
- Default `reasoning` field: https://platform.stepfun.ai/docs/en/api-reference/chat/chat-completion-create
- Two-stage Tool Call contract and supported model list: https://platform.stepfun.ai/docs/en/api-reference/tool-call

Rollback is a sequence of independently revertible commits. The provider has one registry owner and introduces no parallel discovery, runtime, brand asset, provenance, or notice state.

## Ready for review

- [x] Verification is complete and the results above are current
- [x] Impact, compatibility, migration, documentation, and release-note needs are addressed
- [x] User-visible UI/UX changes include visual evidence, or `Verification` explains why it is not applicable
