### PR TITLE
fix: preserve Ollama Cloud aliases without auth

### DIFF
--- a/apps/desktop/src/main/__tests__/model-catalog-choices.test.ts
+++ b/apps/desktop/src/main/__tests__/model-catalog-choices.test.ts
@@ -67,6 +67,34 @@ function connection(overrides: Partial<LlmConnection> & Pick<LlmConnection, 'slu
 }
 
 describe('model catalog picker helpers', () => {
+  it('keeps an Ollama cloud alias distinct and selects it unchanged', async () => {
+    const { buildCatalogChatModelChoices, pickCatalogDefaultChatModel } = await importModelCatalogChoices();
+    const ollama = connection({
+      slug: 'ollama-local',
+      providerType: 'ollama',
+      defaultModel: 'qwen3.5:cloud',
+      models: [{ id: 'qwen3.5' }, { id: 'qwen3.5:cloud' }],
+      modelSource: 'fetched',
+      modelsFetchedAt: 1_800_000_000_000,
+    });
+
+    assert.deepEqual(
+      buildCatalogChatModelChoices([ollama]).map(({ connectionSlug, providerType, model }) => ({
+        connectionSlug,
+        providerType,
+        model,
+      })),
+      [
+        { connectionSlug: 'ollama-local', providerType: 'ollama', model: 'qwen3.5' },
+        { connectionSlug: 'ollama-local', providerType: 'ollama', model: 'qwen3.5:cloud' },
+      ],
+    );
+    assert.deepEqual(pickCatalogDefaultChatModel(ollama), {
+      llmConnectionSlug: 'ollama-local',
+      model: 'qwen3.5:cloud',
+    });
+  });
+
   it('keeps Chat choices on send-wired providers and filters unsupported Codex ChatGPT models', async () => {
     const { buildCatalogChatModelChoices } = await importModelCatalogChoices();
 

--- a/packages/core/src/provider-registry.ts
+++ b/packages/core/src/provider-registry.ts
@@ -16,7 +16,6 @@ export type ProviderRuntimeAdapter =
   | {
       kind: 'openai-compatible';
       name: 'provider' | 'connection';
-      apiKeyFallback?: string;
       passFetch?: boolean;
       requireBaseUrl?: boolean;
     }
@@ -590,7 +589,7 @@ const providerRegistry = {
     fallbackModels: ['llama3.2', 'qwen2.5-coder', 'gemma3'],
     status: 'ready',
     protocol: 'openai',
-    runtimeAdapter: { kind: 'openai-compatible', name: 'provider', apiKeyFallback: 'ollama' },
+    runtimeAdapter: { kind: 'openai-compatible', name: 'provider' },
     modelDiscovery: { kind: 'ollama' },
     category: 'local',
     catalogGroup: 'local',

--- a/packages/headless/src/__tests__/harbor-task-runner.test.ts
+++ b/packages/headless/src/__tests__/harbor-task-runner.test.ts
@@ -307,38 +307,42 @@ describe('createHarborTaskRunner', () => {
     });
   });
 
-  test('routes no-auth Ollama through the host-side cell without exposing credentials', async () => {
-    await withRun(async ({ jobsDir, repo }) => {
-      let harborEnv: Record<string, string> | undefined;
-      const captured: { config?: Record<string, unknown> } = {};
-      const baseUrl = 'http://127.0.0.1:11434/v1';
-      const model = 'hf.co/bartowski/Qwen2.5-Coder-7B-Instruct-GGUF:Q4_K_M';
-      const runner = createHarborTaskRunner({
-        makaRepoPath: repo,
-        jobsDir,
-        model: `ollama/${model}`,
-        provider: 'ollama',
-        agentEnv: { MAKA_BASE_URL: baseUrl },
-        runHarbor: async (request) => {
-          harborEnv = request.env;
-          return fakeRunner({ reward: '1\n', captured })(request);
-        },
+  for (const model of [
+    'hf.co/bartowski/Qwen2.5-Coder-7B-Instruct-GGUF:Q4_K_M',
+    'qwen3.5:cloud',
+  ]) {
+    test(`routes no-auth Ollama model ${model} through the host-side cell without exposing credentials`, async () => {
+      await withRun(async ({ jobsDir, repo }) => {
+        let harborEnv: Record<string, string> | undefined;
+        const captured: { config?: Record<string, unknown> } = {};
+        const baseUrl = 'http://127.0.0.1:11434/v1';
+        const runner = createHarborTaskRunner({
+          makaRepoPath: repo,
+          jobsDir,
+          model: `ollama/${model}`,
+          provider: 'ollama',
+          agentEnv: { MAKA_BASE_URL: baseUrl },
+          runHarbor: async (request) => {
+            harborEnv = request.env;
+            return fakeRunner({ reward: '1\n', captured })(request);
+          },
+        });
+
+        await runner(runInput());
+
+        assert.equal(harborEnv?.MAKA_HOST_REPO_ROOT, repo);
+        assert.equal(harborEnv?.MAKA_HOST_BASE_URL, baseUrl);
+        assert.equal(harborEnv?.MAKA_HOST_NO_AUTH, 'true');
+        assert.equal(harborEnv?.MAKA_HOST_API_KEY, undefined);
+        assert.equal(harborEnv?.MAKA_HOST_API_KEY_FILE, undefined);
+        const agent = (captured.config?.agents as Array<{ model_name: string; env: Record<string, string> }>)[0]!;
+        assert.equal(agent.model_name, model);
+        assert.equal(agent.env.MAKA_MODEL, model);
+        assert.equal(agent.env.MAKA_BASE_URL, undefined);
+        assert.doesNotMatch(JSON.stringify(captured.config), /API_KEY|127\.0\.0\.1:11434/);
       });
-
-      await runner(runInput());
-
-      assert.equal(harborEnv?.MAKA_HOST_REPO_ROOT, repo);
-      assert.equal(harborEnv?.MAKA_HOST_BASE_URL, baseUrl);
-      assert.equal(harborEnv?.MAKA_HOST_NO_AUTH, 'true');
-      assert.equal(harborEnv?.MAKA_HOST_API_KEY, undefined);
-      assert.equal(harborEnv?.MAKA_HOST_API_KEY_FILE, undefined);
-      const agent = (captured.config?.agents as Array<{ model_name: string; env: Record<string, string> }>)[0]!;
-      assert.equal(agent.model_name, model);
-      assert.equal(agent.env.MAKA_MODEL, model);
-      assert.equal(agent.env.MAKA_BASE_URL, undefined);
-      assert.doesNotMatch(JSON.stringify(captured.config), /API_KEY|127\.0\.0\.1:11434/);
     });
-  });
+  }
 
   test('rejects provider secrets in agentEnv even when host-side key file is configured', async () => {
     await withRun(async ({ jobsDir, repo, keyFile }) => {

--- a/packages/runtime/src/__tests__/provider-conformance.test.ts
+++ b/packages/runtime/src/__tests__/provider-conformance.test.ts
@@ -793,94 +793,22 @@ describe('models.dev provider conformance', () => {
     assert.equal(result.text, 'Echoed hello.');
   });
 
-  test('Ollama discovers an exact local model id and completes a no-secret tool-call loop', async () => {
-    const modelId = 'hf.co/bartowski/Qwen2.5-Coder-7B-Instruct-GGUF:Q4_K_M';
-    const requestBodies: Array<Record<string, unknown>> = [];
-    const server = await startJsonServer(async (request, response) => {
-      if (request.method === 'GET' && request.url === '/api/tags') {
-        assert.equal(request.headers.authorization, undefined);
-        respondJson(response, 200, { models: [{ name: modelId, model: modelId }] });
-        return;
-      }
-      assert.equal(request.method, 'POST');
-      assert.equal(request.url, '/v1/chat/completions');
-      assert.equal(request.headers.authorization, 'Bearer ollama');
-      const body = JSON.parse(await readBody(request)) as Record<string, unknown>;
-      requestBodies.push(body);
-      if (requestBodies.length === 1) {
-        respondJson(response, 200, {
-          id: 'chatcmpl-ollama-tool',
-          object: 'chat.completion',
-          created: 1,
-          model: modelId,
-          choices: [{
-            index: 0,
-            message: {
-              role: 'assistant',
-              content: null,
-              tool_calls: [{
-                id: 'call_echo',
-                type: 'function',
-                function: { name: 'echo', arguments: '{"text":"hello"}' },
-              }],
-            },
-            finish_reason: 'tool_calls',
-          }],
-          usage: { prompt_tokens: 8, completion_tokens: 4, total_tokens: 12 },
-        });
-        return;
-      }
-      respondJson(response, 200, {
-        id: 'chatcmpl-ollama-final',
-        object: 'chat.completion',
-        created: 2,
-        model: modelId,
-        choices: [{
-          index: 0,
-          message: { role: 'assistant', content: 'Echoed hello.' },
-          finish_reason: 'stop',
-        }],
-        usage: { prompt_tokens: 12, completion_tokens: 3, total_tokens: 15 },
-      });
+  for (const testCase of [
+    {
+      label: 'complex local model id',
+      discoveredModelIds: ['hf.co/bartowski/Qwen2.5-Coder-7B-Instruct-GGUF:Q4_K_M'],
+      modelId: 'hf.co/bartowski/Qwen2.5-Coder-7B-Instruct-GGUF:Q4_K_M',
+    },
+    {
+      label: 'cloud alias distinct from its local model id',
+      discoveredModelIds: ['qwen3.5', 'qwen3.5:cloud'],
+      modelId: 'qwen3.5:cloud',
+    },
+  ] as const) {
+    test(`Ollama preserves an exact ${testCase.label} through local discovery and a no-secret tool-call loop`, async () => {
+      await assertOllamaModelContract(testCase.discoveredModelIds, testCase.modelId);
     });
-    const connection: LlmConnection = {
-      slug: 'ollama-local',
-      name: 'Ollama',
-      providerType: 'ollama',
-      baseUrl: `${server.url}/v1`,
-      defaultModel: modelId,
-      enabled: true,
-      createdAt: 1,
-      updatedAt: 1,
-    };
-
-    assert.deepEqual(await fetchProviderModels(connection, ''), [{ id: modelId }]);
-
-    const result = await generateText({
-      model: getAIModel({ connection, apiKey: '', modelId }),
-      prompt: 'Call echo with hello, then report the result.',
-      tools: {
-        echo: tool({
-          description: 'Echo text',
-          inputSchema: z.object({ text: z.string() }),
-          execute: async ({ text }) => ({ text }),
-        }),
-      },
-      stopWhen: stepCountIs(2),
-    });
-
-    assert.equal(result.text, 'Echoed hello.');
-    assert.equal(requestBodies.length, 2);
-    assert.deepEqual(requestBodies.map((body) => body.model), [modelId, modelId]);
-    assert.deepEqual(
-      (requestBodies[0]?.tools as Array<{ function: { name: string } }>).map((entry) => entry.function.name),
-      ['echo'],
-    );
-    const secondMessages = requestBodies[1]?.messages as Array<{ role: string; content: string }>;
-    const toolMessage = secondMessages.find((message) => message.role === 'tool');
-    assert.ok(toolMessage);
-    assert.deepEqual(JSON.parse(toolMessage.content), { text: 'hello' });
-  });
+  }
 
   test('Mistral discovers exact account model ids and completes its documented tool-call loop', async () => {
     const requestBodies: Array<Record<string, unknown>> = [];
@@ -1305,6 +1233,99 @@ describe('models.dev provider conformance', () => {
     assert.equal(result.text, 'Echoed hello.');
   });
 });
+
+async function assertOllamaModelContract(
+  discoveredModelIds: readonly string[],
+  modelId: string,
+): Promise<void> {
+  const requestBodies: Array<Record<string, unknown>> = [];
+  const server = await startJsonServer(async (request, response) => {
+    if (request.method === 'GET' && request.url === '/api/tags') {
+      assert.equal(request.headers.authorization, undefined);
+      respondJson(response, 200, {
+        models: discoveredModelIds.map((id) => ({ name: id, model: id })),
+      });
+      return;
+    }
+    assert.equal(request.method, 'POST');
+    assert.equal(request.url, '/v1/chat/completions');
+    assert.equal(request.headers.authorization, undefined);
+    const body = JSON.parse(await readBody(request)) as Record<string, unknown>;
+    requestBodies.push(body);
+    if (requestBodies.length === 1) {
+      respondJson(response, 200, {
+        id: 'chatcmpl-ollama-tool',
+        object: 'chat.completion',
+        created: 1,
+        model: modelId,
+        choices: [{
+          index: 0,
+          message: {
+            role: 'assistant',
+            content: null,
+            tool_calls: [{
+              id: 'call_echo',
+              type: 'function',
+              function: { name: 'echo', arguments: '{"text":"hello"}' },
+            }],
+          },
+          finish_reason: 'tool_calls',
+        }],
+        usage: { prompt_tokens: 8, completion_tokens: 4, total_tokens: 12 },
+      });
+      return;
+    }
+    respondJson(response, 200, {
+      id: 'chatcmpl-ollama-final',
+      object: 'chat.completion',
+      created: 2,
+      model: modelId,
+      choices: [{
+        index: 0,
+        message: { role: 'assistant', content: 'Echoed hello.' },
+        finish_reason: 'stop',
+      }],
+      usage: { prompt_tokens: 12, completion_tokens: 3, total_tokens: 15 },
+    });
+  });
+  const connection: LlmConnection = {
+    slug: 'ollama-local',
+    name: 'Ollama',
+    providerType: 'ollama',
+    baseUrl: `${server.url}/v1`,
+    defaultModel: modelId,
+    enabled: true,
+    createdAt: 1,
+    updatedAt: 1,
+  };
+
+  assert.deepEqual(await fetchProviderModels(connection, ''), discoveredModelIds.map((id) => ({ id })));
+
+  const result = await generateText({
+    model: getAIModel({ connection, apiKey: '', modelId }),
+    prompt: 'Call echo with hello, then report the result.',
+    tools: {
+      echo: tool({
+        description: 'Echo text',
+        inputSchema: z.object({ text: z.string() }),
+        execute: async ({ text }) => ({ text }),
+      }),
+    },
+    stopWhen: stepCountIs(2),
+  });
+
+  assert.equal(result.text, 'Echoed hello.');
+  assert.equal(requestBodies.length, 2);
+  assert.deepEqual(requestBodies.map((body) => body.model), [modelId, modelId]);
+  assert.deepEqual(
+    (requestBodies[0]?.tools as Array<{ function: { name: string } }>).map((entry) => entry.function.name),
+    ['echo'],
+  );
+  const secondMessages = requestBodies[1]?.messages as Array<{ role: string; content: string }>;
+  const toolMessage = secondMessages.find((message) => message.role === 'tool');
+  assert.ok(toolMessage);
+  assert.deepEqual(JSON.parse(toolMessage.content), { text: 'hello' });
+}
 
 async function startJsonServer(
   handler: (request: IncomingMessage, response: ServerResponse) => void | Promise<void>,

--- a/packages/runtime/src/model-factory.ts
+++ b/packages/runtime/src/model-factory.ts
@@ -73,7 +73,7 @@ export function getAIModel(input: ModelFactoryInput): LanguageModelV3 {
       const name = adapter.name === 'connection' ? connection.slug : connection.providerType;
       return createOpenAICompatible({
         name,
-        apiKey: adapter.apiKeyFallback ? apiKey || adapter.apiKeyFallback : apiKey,
+        apiKey,
         baseURL,
         ...(adapter.passFetch ? { fetch } : {}),
       }).chatModel(modelId);

--- a/packages/storage/src/__tests__/connection-store.test.ts
+++ b/packages/storage/src/__tests__/connection-store.test.ts
@@ -7,6 +7,41 @@ import { PROVIDER_DEFAULTS } from '@maka/core/llm-connections';
 import { createConnectionStore } from '../connection-store.js';
 
 describe('FileConnectionStore', () => {
+  test('persists the Ollama provider and exact cloud alias in discovery and selection state', async () => {
+    await withConnectionStore(async (store, dir) => {
+      const localModelId = 'qwen3.5';
+      const cloudModelId = 'qwen3.5:cloud';
+      const created = await store.create({
+        slug: 'ollama-local',
+        name: 'Ollama',
+        providerType: 'ollama',
+        defaultModel: localModelId,
+      });
+
+      await store.update(created.slug, {
+        defaultModel: cloudModelId,
+        models: [{ id: localModelId }, { id: cloudModelId }],
+        modelSource: 'fetched',
+        modelsFetchedAt: 1_800_000_000_000,
+      });
+
+      const persisted = JSON.parse(await readFile(join(dir, 'llm-connections.json'), 'utf8')) as {
+        connections: Array<{
+          providerType: string;
+          defaultModel: string;
+          models: Array<{ id: string }>;
+          modelSource: string;
+          modelsFetchedAt: number;
+        }>;
+      };
+      assert.equal(persisted.connections[0]?.providerType, 'ollama');
+      assert.equal(persisted.connections[0]?.defaultModel, cloudModelId);
+      assert.deepEqual(persisted.connections[0]?.models, [{ id: localModelId }, { id: cloudModelId }]);
+      assert.equal(persisted.connections[0]?.modelSource, 'fetched');
+      assert.equal(persisted.connections[0]?.modelsFetchedAt, 1_800_000_000_000);
+    });
+  });
+
   test('persists the Fireworks provider id and exact model path', async () => {
     await withConnectionStore(async (store, dir) => {
       await store.create({


### PR DESCRIPTION
## Summary

- Preserve exact Ollama Cloud `:cloud` aliases across local-daemon discovery, persisted model state, Desktop selection, Headless host-cell routing, and both turns of an agent tool-call loop.
- Keep the existing complex local Ollama model-ID regression while adding an independent `qwen3.5:cloud` contract.
- Stop injecting the dummy `Authorization: Bearer ollama` header into no-auth local daemon requests.

## Why

Refs #860.

Ollama Cloud models run through the existing signed-in local Ollama daemon and retain the existing persisted `ollama` provider ID. Ollama's local API requires no request authentication; the daemon owns its ollama.com sign-in state. The previous OpenAI-compatible adapter fallback injected a dummy bearer value even though `ollama` is registry-declared no-auth. Removing that single-purpose fallback restores the no-auth invariant without adding a Cloud provider, key, endpoint, or parallel runtime path.

## Scope

- No new persisted provider ID, hosted Ollama API preset, Cloud credential field, or migration.
- No Phase 7 conformance-matrix work.
- No branding changes: the existing verified Ollama SVG continues through the shared `ProviderLogo` path, and the existing provenance/notice contract remains green.

## Verification

- `npm run typecheck` — passed for every workspace.
- `npm --workspace @maka/core test` — passed.
- `npm --workspace @maka/storage test` — passed; includes exact local/Cloud discovery snapshot and selected-default persistence.
- `npm --workspace @maka/runtime test` — passed; includes separate complex local-ID and `qwen3.5:cloud` discovery/two-stage tool-call cases, with no Authorization header on discovery or chat.
- `npm --workspace @maka/headless test` — passed; includes separate complex local-ID and `qwen3.5:cloud` no-auth host-cell cases.
- `npm --workspace @maka/desktop test` — passed; includes exact local/Cloud catalog distinction and unchanged Cloud selection, plus the existing Ollama SVG/provenance/notice/shared-render-path contract.
- `npm run check:stale` — passed.
- `git diff --check origin/main...HEAD` — passed.
- Independent reviewer: 0 P0–P3.
- Live signed-in smoke was not run because the local environment has no Ollama CLI. This is non-blocking: no user models, tokens, or raw daemon responses were read or recorded, and deterministic local HTTP fixtures cover the protocol contract.
- Local Desktop E2E was deferred to CI as allowed by Issue #860; the CI E2E job remains a merge gate.

## Impact

Existing Ollama connections keep the same provider ID, local daemon endpoint, model discovery, selection, and runtime path. Exact local and Cloud model IDs remain unchanged. Local daemon requests no longer carry a dummy Authorization header. No migration, documentation, release-note, or user-visible UI change is required.

## Reviewer notes

Please focus on the local-daemon ownership boundary: Maka supplies no Cloud key or hosted endpoint, while a signed-in Ollama daemon handles Cloud access. The runtime fixture deliberately distinguishes `qwen3.5` from `qwen3.5:cloud`, and the pre-existing `hf.co/bartowski/Qwen2.5-Coder-7B-Instruct-GGUF:Q4_K_M` case remains independently covered.

Official contract references:

- https://docs.ollama.com/api/authentication
- https://docs.ollama.com/api/tags
- https://docs.ollama.com/api/chat
- https://docs.ollama.com/cloud

## Ready for review

- [x] Verification is complete and the results above are current
- [x] Impact, compatibility, migration, documentation, and release-note needs are addressed
- [x] User-visible UI/UX changes include visual evidence, or `Verification` explains why it is not applicable
