### PR TITLE
feat: add Volcengine Ark Coding Plan (China)

### DIFF
--- a/apps/desktop/e2e/providers.spec.ts
+++ b/apps/desktop/e2e/providers.spec.ts
@@ -360,6 +360,37 @@ test('adds Volcengine Ark China with its exact snapshot model, API-key field, an
   await expect(page.getByRole('textbox', { name: '模型密钥' })).toBeVisible();
 });
 
+test('adds Volcengine Ark Coding Plan under its independent access path and shared official mark', async ({ window: page }) => {
+  await page.getByRole('button', { name: '展开侧边栏' }).click();
+  await page.getByRole('button', { name: '设置' }).click();
+  await page.locator('[aria-label="设置分组"]').getByText('模型', { exact: true }).click();
+  await page.getByRole('button', { name: '添加服务商' }).click();
+
+  await page.getByRole('tab', { name: '模型计划' }).click();
+  await page.getByPlaceholder('搜索服务商').fill('Volcengine');
+  const catalogMark = page.locator(
+    '.providerCatalogRow[data-provider="volcengine-coding-plan"] .providerLogo .providerAssetMask',
+  );
+  await expect(catalogMark).toBeVisible();
+  expect(await catalogMark.evaluate(maskRenderContract)).toEqual({ usesAssetMask: true, followsForeground: true });
+  await page.getByRole('button', { name: /添加模型供应商：Volcengine Ark Coding Plan \(China\)/ }).click();
+
+  await expect(page.getByLabel('模型供应商连接标识')).toHaveValue('volcengine-coding-plan');
+  await expect(page.getByLabel('模型供应商服务地址')).toHaveValue('https://ark.cn-beijing.volces.com/api/coding/v3');
+  await expect(page.getByLabel('模型供应商默认模型')).toHaveValue('ark-code-latest');
+  await page.getByRole('button', { name: '保存供应商' }).click();
+
+  await expect(page.getByRole('heading', { name: 'Volcengine Ark Coding Plan (China)', exact: true }).first()).toBeVisible();
+  const detailMark = page.locator(
+    '.providerSubpageHeader .providerLogo[data-provider="volcengine-coding-plan"] .providerAssetMask',
+  );
+  await expect(detailMark).toBeVisible();
+  expect(await detailMark.evaluate(maskRenderContract)).toEqual({ usesAssetMask: true, followsForeground: true });
+  await expect(page.getByText('ark-code-latest', { exact: true }).first()).toBeVisible();
+  await expect(page.getByRole('textbox', { name: '模型密钥' })).toBeVisible();
+  await expect(page.getByRole('button', { name: '刷新模型列表' })).toBeDisabled();
+});
+
 test('restores keyboard focus across provider child pages', async ({ window: page }) => {
   await page.getByRole('button', { name: '展开侧边栏' }).click();
   await page.getByRole('button', { name: '设置' }).click();

--- a/apps/desktop/src/main/__tests__/icon-governance-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/icon-governance-contract.test.ts
@@ -453,7 +453,11 @@ describe('icon + typography governance contract', () => {
       componentSrc,
       /Volcengine mark vendored byte-for-byte from Lobe Icons:[\s\S]*@lobehub\/icons-static-svg@1\.91\.0[\s\S]*e4302041fbb3039608d25f9f618bd462783b875e[\s\S]*packages\/static-svg\/icons\/volcengine\.svg[\s\S]*MIT[\s\S]*f29d0bdc284b33d8664ef221add7fbf06a5b370ef92767fa33f6020c914d3d33/,
     );
-    assert.match(componentSrc, /case 'volcengine-ark':\s*return <ProviderAssetMask src=\{volcengineBrandMark\} \/>/);
+    assert.match(
+      componentSrc,
+      /case 'volcengine-ark':\s*case 'volcengine-coding-plan':\s*return <ProviderAssetMask src=\{volcengineBrandMark\} \/>/,
+      'direct Ark and Coding Plan must share the single governed Volcengine asset route',
+    );
   });
 
   it('vendors and routes the byte-exact Tencent Cloud mark for Tencent Coding Plan', async () => {

--- a/apps/desktop/src/renderer/settings/provider-brand-marks.tsx
+++ b/apps/desktop/src/renderer/settings/provider-brand-marks.tsx
@@ -288,6 +288,7 @@ export function ProviderBrandMark({ type }: { type: ProviderType }): ReactElemen
     case 'stepfun':
       return <ProviderAssetMask src={stepfunBrandMark} />;
     case 'volcengine-ark':
+    case 'volcengine-coding-plan':
       return <ProviderAssetMask src={volcengineBrandMark} />;
     default:
       return <GenericProviderMark />;

--- a/packages/cli/src/__tests__/connection-target.test.ts
+++ b/packages/cli/src/__tests__/connection-target.test.ts
@@ -4,6 +4,29 @@ import type { LlmConnection } from '@maka/core/llm-connections';
 import { listReadyModelChoices, resolveDefaultSessionTarget } from '../connection-target.js';
 
 describe('default session target resolver', () => {
+  test('resolves Volcengine Coding Plan credentials without rewriting the selected model id', async () => {
+    const connection = makeConnection({
+      slug: 'volcengine-coding-plan',
+      name: 'Volcengine Ark Coding Plan (China)',
+      providerType: 'volcengine-coding-plan',
+      defaultModel: 'kimi-k2.7-code',
+    });
+
+    const target = await resolveDefaultSessionTarget({
+      connectionStore: {
+        getDefault: async () => 'volcengine-coding-plan',
+        get: async (slug) => slug === 'volcengine-coding-plan' ? connection : null,
+      },
+      credentialStore: {
+        getSecret: async (_slug, kind) => kind === 'api_key' ? 'volcengine-coding-plan-test-key' : null,
+      },
+    });
+
+    assert.equal(target.connection.providerType, 'volcengine-coding-plan');
+    assert.equal(target.apiKey, 'volcengine-coding-plan-test-key');
+    assert.equal(target.model, 'kimi-k2.7-code');
+  });
+
   test('resolves Volcengine Ark credentials without rewriting the snapshot model id', async () => {
     const modelId = 'doubao-seed-2-0-pro-260215';
     const connection = makeConnection({

--- a/packages/core/src/__tests__/llm-connections.test.ts
+++ b/packages/core/src/__tests__/llm-connections.test.ts
@@ -31,6 +31,7 @@ describe('provider compatibility contract', () => {
       'kimi-coding-plan',
       'minimax-coding-plan',
       'tencent-coding-plan',
+      'volcengine-coding-plan',
       'openai',
       'google',
       'deepseek',
@@ -82,6 +83,7 @@ describe('provider compatibility contract', () => {
       'tencent-coding-plan',
       'stepfun-ai',
       'volcengine-ark',
+      'volcengine-coding-plan',
     ]);
     assert.deepEqual(CATALOG_PROVIDER_TYPES, [
       'kimi-coding-plan',
@@ -109,6 +111,7 @@ describe('provider compatibility contract', () => {
       'tencent-coding-plan',
       'stepfun-ai',
       'volcengine-ark',
+      'volcengine-coding-plan',
     ]);
 
     for (const orderField of ['readyOrder', 'catalogOrder', 'recommendedOrder'] as const) {
@@ -139,6 +142,33 @@ describe('provider compatibility contract', () => {
     assert.deepEqual(PROVIDER_REGISTRY.siliconflow.modelDiscovery.query, { sub_type: 'chat' });
     assert.equal(PROVIDER_REGISTRY.ollama.modelDiscovery.kind, 'ollama');
     assert.equal(PROVIDER_REGISTRY['codex-subscription'].modelDiscovery.kind, 'fallback');
+  });
+
+  it('owns Volcengine Ark Coding Plan as a fallback-only interactive coding access path', () => {
+    const provider = (PROVIDER_REGISTRY as Partial<Record<string, (typeof PROVIDER_REGISTRY)[keyof typeof PROVIDER_REGISTRY]>>)['volcengine-coding-plan'];
+
+    assert.ok(provider);
+    assert.equal(provider.label, 'Volcengine Ark Coding Plan (China)');
+    assert.equal(provider.baseUrl, 'https://ark.cn-beijing.volces.com/api/coding/v3');
+    assert.equal(provider.authKind, 'api_key');
+    assert.equal(provider.protocol, 'openai');
+    assert.deepEqual(provider.runtimeAdapter, { kind: 'openai-compatible', name: 'provider' });
+    assert.deepEqual(provider.modelDiscovery, { kind: 'fallback' });
+    assert.equal(provider.catalogGroup, 'plans');
+    assert.deepEqual(provider.fallbackModels, [
+      'ark-code-latest',
+      'doubao-seed-2.0-code',
+      'doubao-seed-2.0-pro',
+      'doubao-seed-2.0-lite',
+      'doubao-seed-code',
+      'minimax-m2.7',
+      'minimax-m3',
+      'glm-5.2',
+      'deepseek-v4-flash',
+      'deepseek-v4-pro',
+      'kimi-k2.6',
+      'kimi-k2.7-code',
+    ]);
   });
 
   it('owns the complete xAI provider contract under the stable xai id', () => {

--- a/packages/core/src/__tests__/model-metadata.test.ts
+++ b/packages/core/src/__tests__/model-metadata.test.ts
@@ -4,6 +4,22 @@ import { lookupModelMetadata, resolveModelVisionSupport } from '../model-metadat
 import { PROVIDER_DEFAULTS, type ModelInfo, type ProviderType } from '../llm-connections.js';
 
 describe('model-metadata vision capability', () => {
+  it('uses Volcengine Coding Plan model facts for its exact fallback allowlist', () => {
+    for (const modelId of PROVIDER_DEFAULTS['volcengine-coding-plan'].fallbackModels) {
+      assert.equal(
+        lookupModelMetadata('volcengine-coding-plan', modelId).capabilities?.functionCalling,
+        true,
+        modelId,
+      );
+    }
+
+    const kimi = lookupModelMetadata('volcengine-coding-plan', 'kimi-k2.7-code');
+    assert.equal(kimi.capabilities?.vision, true);
+    assert.equal(kimi.capabilities?.reasoning, true);
+    assert.equal(kimi.contextWindow, 256_000);
+    assert.equal(kimi.maxOutputTokens, 32_000);
+  });
+
   it('reuses MiniMax snapshot facts for the Coding Plan access path', () => {
     assert.deepEqual(
       lookupModelMetadata('minimax-coding-plan', 'MiniMax-M3'),

--- a/packages/core/src/__tests__/provider-auth.test.ts
+++ b/packages/core/src/__tests__/provider-auth.test.ts
@@ -9,6 +9,19 @@ import {
 import type { LlmConnection } from '../llm-connections.js';
 
 describe('ProviderAuth contract', () => {
+  test('Volcengine Ark Coding Plan uses an isolated API key and hides unsupported refresh', () => {
+    const contract = deriveProviderAuthContract({
+      providerType: 'volcengine-coding-plan',
+      hasSecret: true,
+    });
+
+    expect(contract.providerType).toBe('volcengine-coding-plan');
+    expect(contract.setupMode).toBe('api_key');
+    expect(contract.requiresSecret).toBe(true);
+    expect(contract.actionAvailability.test_credentials).toBe('available');
+    expect(contract.actionAvailability.fetch_models).toBe('hidden');
+  });
+
   test('Tencent Coding Plan uses the shared API-key credential and fallback-model flow', () => {
     const contract = deriveProviderAuthContract({
       providerType: 'tencent-coding-plan',

--- a/packages/core/src/model-metadata.ts
+++ b/packages/core/src/model-metadata.ts
@@ -104,6 +104,22 @@ const SILICONFLOW_MODEL_OVERRIDES: Record<string, ModelMetadata> = Object.fromEn
     .map(([id]) => [id, { capabilities: { chat: true } }]),
 );
 
+const VOLCENGINE_CODING_PLAN_DOCS = 'https://www.volcengine.com/docs/82379/1925114';
+const VOLCENGINE_CODING_PLAN_MODEL_METADATA: Record<string, ModelMetadata> = {
+  'ark-code-latest': planModel('Ark Code Latest', false),
+  'doubao-seed-2.0-code': planModel('Doubao Seed 2.0 Code', true),
+  'doubao-seed-2.0-pro': planModel('Doubao Seed 2.0 Pro', true),
+  'doubao-seed-2.0-lite': planModel('Doubao Seed 2.0 Lite', true),
+  'doubao-seed-code': planModel('Doubao Seed Code', true),
+  'minimax-m2.7': planModel('MiniMax-M2.7', false, 200_000, 128_000),
+  'minimax-m3': planModel('MiniMax-M3', true, 512_000, 128_000),
+  'glm-5.2': planModel('GLM-5.2', false, 1_024_000, 128_000),
+  'deepseek-v4-flash': planModel('DeepSeek-V4-Flash', false, 1_024_000, 384_000),
+  'deepseek-v4-pro': planModel('DeepSeek-V4-Pro', false, 1_024_000, 384_000),
+  'kimi-k2.6': planModel('Kimi-K2.6', true, 256_000, 32_000),
+  'kimi-k2.7-code': planModel('Kimi-K2.7-Code', true, 256_000, 32_000),
+};
+
 // Facts that models.dev cannot express: provider wire controls and
 // access-path-specific aliases/limits. Standard model facts stay generated.
 const STATIC_MODEL_METADATA: Partial<Record<ProviderType, Record<string, ModelMetadata>>> = {
@@ -131,6 +147,7 @@ const STATIC_MODEL_METADATA: Partial<Record<ProviderType, Record<string, ModelMe
       },
     },
   },
+  'volcengine-coding-plan': VOLCENGINE_CODING_PLAN_MODEL_METADATA,
   deepseek: {
     'deepseek-v4-flash': { thinkingOptions: { efforts: ['high', 'max'], toggle: true } },
   },
@@ -146,6 +163,22 @@ const STATIC_MODEL_METADATA: Partial<Record<ProviderType, Record<string, ModelMe
     'kimi-for-coding-highspeed': { displayName: 'Kimi for Coding (HighSpeed)', lifecycle: 'active', docsUrl: 'https://www.kimi.com/code/docs/en/', contextWindow: 262_144, maxOutputTokens: 32_768, capabilities: { ...REASONING_FUNCTION_CALLING, vision: true } },
   },
 };
+
+function planModel(
+  displayName: string,
+  vision: boolean,
+  contextWindow?: number,
+  maxOutputTokens?: number,
+): ModelMetadata {
+  return {
+    displayName,
+    lifecycle: 'active',
+    docsUrl: VOLCENGINE_CODING_PLAN_DOCS,
+    ...(contextWindow === undefined ? {} : { contextWindow }),
+    ...(maxOutputTokens === undefined ? {} : { maxOutputTokens }),
+    capabilities: { ...REASONING_FUNCTION_CALLING, vision },
+  };
+}
 
 function displayMetadataOnly(
   source: Record<string, ModelMetadata>,

--- a/packages/core/src/provider-registry.ts
+++ b/packages/core/src/provider-registry.ts
@@ -120,6 +120,20 @@ for (const id of tencentCodingPlanModelIds) {
     throw new Error(`models.dev Tencent Coding Plan snapshot is missing tool-capable model ${id}`);
   }
 }
+const volcengineCodingPlanModelIds = [
+  'ark-code-latest',
+  'doubao-seed-2.0-code',
+  'doubao-seed-2.0-pro',
+  'doubao-seed-2.0-lite',
+  'doubao-seed-code',
+  'minimax-m2.7',
+  'minimax-m3',
+  'glm-5.2',
+  'deepseek-v4-flash',
+  'deepseek-v4-pro',
+  'kimi-k2.6',
+  'kimi-k2.7-code',
+] as const;
 const stepfun = GENERATED_MODELS_DEV_PROVIDER_FACTS.stepfun;
 if (stepfun.id !== 'stepfun') throw new Error('models.dev StepFun provider facts are missing stable id stepfun');
 if (!stepfun.api) throw new Error('models.dev StepFun provider facts are missing api');
@@ -254,6 +268,24 @@ const providerRegistry = {
     modelsDevId: tencentCodingPlan.id,
     readyOrder: 23,
     catalogOrder: 23,
+  },
+  'volcengine-coding-plan': {
+    label: 'Volcengine Ark Coding Plan (China)',
+    description: 'Volcengine Ark subscription for interactive AI coding tools.',
+    baseUrl: 'https://ark.cn-beijing.volces.com/api/coding/v3',
+    authKind: 'api_key',
+    backendKind: 'ai-sdk',
+    fallbackModels: [...volcengineCodingPlanModelIds],
+    status: 'ready',
+    protocol: 'openai',
+    runtimeAdapter: { kind: 'openai-compatible', name: 'provider' },
+    modelDiscovery: { kind: 'fallback' },
+    category: 'domestic',
+    catalogGroup: 'plans',
+    catalogBadge: 'Coding',
+    signupUrl: 'https://www.volcengine.com/activity/codingplan',
+    readyOrder: 24,
+    catalogOrder: 24,
   },
   openai: {
     label: 'OpenAI',

--- a/packages/core/src/provider-registry.ts
+++ b/packages/core/src/provider-registry.ts
@@ -284,8 +284,8 @@ const providerRegistry = {
     catalogGroup: 'plans',
     catalogBadge: 'Coding',
     signupUrl: 'https://www.volcengine.com/activity/codingplan',
-    readyOrder: 24,
-    catalogOrder: 24,
+    readyOrder: 26,
+    catalogOrder: 26,
   },
   openai: {
     label: 'OpenAI',

--- a/packages/headless/src/__tests__/provider-env.test.ts
+++ b/packages/headless/src/__tests__/provider-env.test.ts
@@ -79,6 +79,14 @@ test('Tencent Coding Plan is unavailable to non-interactive headless credential 
   );
 });
 
+test('Volcengine Coding Plan is unavailable to non-interactive headless credential loading', () => {
+  assert.equal(providerCredentialEnv('volcengine-coding-plan'), undefined);
+  assert.throws(
+    () => requireProviderCredentialEnv('volcengine-coding-plan'),
+    /provider does not support API key files: volcengine-coding-plan/,
+  );
+});
+
 test('StepFun China keeps direct API credentials separate from global and plan identities', () => {
   assert.deepEqual(providerCredentialEnv('stepfun'), {
     apiKeys: ['STEPFUN_API_KEY'],

--- a/packages/runtime/src/__tests__/provider-conformance.test.ts
+++ b/packages/runtime/src/__tests__/provider-conformance.test.ts
@@ -1122,6 +1122,118 @@ describe('models.dev provider conformance', () => {
     assert.equal(result.text, 'Echoed hello.');
   });
 
+  test('Volcengine Ark Coding Plan preserves fallback model reasoning through a two-stage tool-call loop', async () => {
+    const modelId = 'glm-5.2';
+    const requestBodies: Array<Record<string, unknown>> = [];
+    const server = await startJsonServer(async (request, response) => {
+      assert.equal(request.headers.authorization, 'Bearer volcengine-coding-plan-test-key');
+      assert.equal(request.method, 'POST');
+      assert.equal(request.url, '/api/coding/v3/chat/completions');
+      const body = JSON.parse(await readBody(request)) as Record<string, unknown>;
+      requestBodies.push(body);
+      if (requestBodies.length === 1) {
+        respondJson(response, 200, {
+          id: 'chatcmpl-volcengine-coding-plan-tool',
+          object: 'chat.completion',
+          created: 1,
+          model: modelId,
+          choices: [{
+            index: 0,
+            message: {
+              role: 'assistant',
+              content: null,
+              reasoning_content: 'I should call echo with the requested text.',
+              tool_calls: [{
+                id: 'call_volcengine_coding_plan_echo',
+                type: 'function',
+                function: { name: 'echo', arguments: '{"text":"hello"}' },
+              }],
+            },
+            finish_reason: 'tool_calls',
+          }],
+          usage: { prompt_tokens: 8, completion_tokens: 4, total_tokens: 12 },
+        });
+        return;
+      }
+
+      respondJson(response, 200, {
+        id: 'chatcmpl-volcengine-coding-plan-final',
+        object: 'chat.completion',
+        created: 2,
+        model: modelId,
+        choices: [{
+          index: 0,
+          message: { role: 'assistant', content: 'Echoed hello.' },
+          finish_reason: 'stop',
+        }],
+        usage: { prompt_tokens: 14, completion_tokens: 3, total_tokens: 17 },
+      });
+    });
+    const connection: LlmConnection = {
+      slug: 'volcengine-coding-plan',
+      name: 'Volcengine Ark Coding Plan (China)',
+      providerType: 'volcengine-coding-plan',
+      baseUrl: `${server.url}/api/coding/v3`,
+      defaultModel: modelId,
+      enabled: true,
+      createdAt: 1,
+      updatedAt: 1,
+    };
+
+    const models = await fetchProviderModels(connection, 'volcengine-coding-plan-test-key');
+    assert.deepEqual(models.map(({ id }) => id), [
+      'ark-code-latest',
+      'doubao-seed-2.0-code',
+      'doubao-seed-2.0-pro',
+      'doubao-seed-2.0-lite',
+      'doubao-seed-code',
+      'minimax-m2.7',
+      'minimax-m3',
+      'glm-5.2',
+      'deepseek-v4-flash',
+      'deepseek-v4-pro',
+      'kimi-k2.6',
+      'kimi-k2.7-code',
+    ]);
+
+    const result = await generateText({
+      model: getAIModel({ connection, apiKey: 'volcengine-coding-plan-test-key', modelId }),
+      prompt: 'Call echo with hello.',
+      stopWhen: stepCountIs(2),
+      tools: {
+        echo: tool({
+          description: 'Echo text',
+          inputSchema: z.object({ text: z.string() }),
+          execute: async ({ text }) => ({ echoed: text }),
+        }),
+      },
+    });
+
+    assert.equal(requestBodies.length, 2);
+    assert.equal(result.steps[0]?.reasoningText, 'I should call echo with the requested text.');
+    assert.deepEqual(requestBodies.map((body) => body.model), [modelId, modelId]);
+    assert.deepEqual(
+      (requestBodies[1]?.messages as Array<Record<string, unknown>>).find(({ role }) => role === 'assistant'),
+      {
+        role: 'assistant',
+        content: null,
+        reasoning_content: 'I should call echo with the requested text.',
+        tool_calls: [{
+          id: 'call_volcengine_coding_plan_echo',
+          type: 'function',
+          function: { name: 'echo', arguments: '{"text":"hello"}' },
+        }],
+      },
+    );
+    assert.deepEqual(
+      (requestBodies[1]?.messages as Array<{ role: string; content: string }>).find(({ role }) => role === 'tool'),
+      { role: 'tool', content: '{"echoed":"hello"}', tool_call_id: 'call_volcengine_coding_plan_echo' },
+    );
+    assert.equal(result.steps[0]?.toolCalls[0]?.toolName, 'echo');
+    assert.deepEqual(result.steps[0]?.toolResults[0]?.output, { echoed: 'hello' });
+    assert.equal(result.text, 'Echoed hello.');
+  });
+
   for (const stepfun of [
     { label: 'StepFun China', providerType: 'stepfun', apiKey: 'stepfun-test-key' },
     { label: 'StepFun Global', providerType: 'stepfun-ai', apiKey: 'stepfun-global-test-key' },

--- a/packages/storage/src/__tests__/connection-store.test.ts
+++ b/packages/storage/src/__tests__/connection-store.test.ts
@@ -7,6 +7,23 @@ import { PROVIDER_DEFAULTS } from '@maka/core/llm-connections';
 import { createConnectionStore } from '../connection-store.js';
 
 describe('FileConnectionStore', () => {
+  test('persists the Volcengine Coding Plan id and exact default model', async () => {
+    await withConnectionStore(async (store, dir) => {
+      await store.create({
+        slug: 'volcengine-coding-plan',
+        name: 'Volcengine Ark Coding Plan (China)',
+        providerType: 'volcengine-coding-plan',
+        defaultModel: 'kimi-k2.7-code',
+      });
+
+      const persisted = JSON.parse(await readFile(join(dir, 'llm-connections.json'), 'utf8')) as {
+        connections: Array<{ providerType: string; defaultModel: string }>;
+      };
+      assert.equal(persisted.connections[0]?.providerType, 'volcengine-coding-plan');
+      assert.equal(persisted.connections[0]?.defaultModel, 'kimi-k2.7-code');
+    });
+  });
+
   test('persists the Ollama provider and exact cloud alias in discovery and selection state', async () => {
     await withConnectionStore(async (store, dir) => {
       const localModelId = 'qwen3.5';


### PR DESCRIPTION
## Summary

- Add Volcengine Ark Coding Plan (China) as the independent persisted provider `volcengine-coding-plan`, with its dedicated API-key endpoint and official fallback model allowlist.
- Carry the access path through Core, Runtime, CLI, Storage, Headless policy, and Desktop catalog/detail surfaces, including deterministic reasoning plus two-stage tool-call coverage.
- Reuse the single byte-identical Volcengine SVG, asset-mask route, and third-party notice introduced by #909; no parallel brand asset or notice seam is added.

## Why

Volcengine documents Ark Coding Plan as a subscription for interactive AI coding tools, with its own OpenAI-compatible endpoint (`https://ark.cn-beijing.volces.com/api/coding/v3`) and Ark-console API key. It is not the Ark direct API, Ark Agent Plan, or BytePlus ModelArk access path. The public personal Plan API does not document a `/models` contract; the published `ListArkCodingPlanModel` operation uses IAM/HMAC authentication instead of the Plan API key, so this integration deliberately uses the documented static model list and disables model refresh.

Official contract references: [plan overview](https://www.volcengine.com/docs/82379/1925114), [quick start](https://www.volcengine.com/docs/82379/1928261), [FAQ and usage boundary](https://www.volcengine.com/docs/82379/2165245), [subscription terms](https://www.volcengine.com/docs/82379/2278469), and [`ListArkCodingPlanModel`](https://www.volcengine.com/docs/82379/2546386).

Refs #860.

## Scope

- No Phase 7 work.
- No Ark direct, Ark Agent Plan, or BytePlus ModelArk behavior is changed or aliased.
- Headless environment credential loading remains unavailable because the public Plan terms limit the subscription to supported AI coding tools; deterministic runtime tests use only synthetic local responses.
- No live provider smoke was run because no safe user credential was available. No secret or raw provider response was recorded.

## Verification

- `npm test` — passed before the final upstream rebase with zero failures across all workspaces.
- `npm run typecheck` — passed on final SHA after rebasing #894.
- `node ../../worktree-bootstrap.mjs` — passed on final SHA, including complete workspace build, Desktop renderer build, public notice check, and stale-dist check.
- Provider/credential/persistence/runtime/headless/Desktop governance and #895 Desktop Computer Use contracts — 211/211 passed on final SHA, including the exact `glm-5.2` reasoning and two-stage tool-call wire loop.
- `node --test scripts/cua-driver-provenance.test.mjs` — 4/4 passed, preserving #894 artifact-integrity coverage.
- Targeted local Electron provider journey — 1/1 passed for Coding Plan catalog, endpoint, persisted ID, default model, API-key field, disabled refresh, detail page, and shared mask rendering. CI E2E remains the release gate.
- Vendored Volcengine SVG compared byte-for-byte with `lobehub/lobe-icons` commit `e4302041fbb3039608d25f9f618bd462783b875e`, path `packages/static-svg/icons/volcengine.svg`; both SHA-256 values are `f29d0bdc284b33d8664ef221add7fbf06a5b370ef92767fa33f6020c914d3d33`.
- `git diff --check origin/main...HEAD` — passed; the branch does not modify the SVG or `THIRD_PARTY_LICENSES.txt`.

No screenshot is attached because this uses the existing registry-driven catalog/detail layout and the existing governed Volcengine mark without introducing new pixels or interaction design. The deterministic Electron journey and asset-mask governance contract are the direct UI evidence.

## Impact

Users in China can configure Ark Coding Plan independently from Ark direct API access. Existing persisted providers and credentials are unchanged; there is no migration. The new provider stores its own ID, endpoint, API key, and exact model selection through the existing connection seams.

## Reviewer notes

The main review boundary is access-path separation: `/api/coding/v3` plus fallback-only discovery and no headless env credential mapping must remain distinct from #909's `/api/v3` direct provider. Rollback is the four commits in this branch; the shared Volcengine asset remains owned by #909.

## Ready for review

- [x] Verification is complete and the results above are current
- [x] Impact, compatibility, migration, documentation, and release-note needs are addressed
- [x] User-visible UI/UX changes include visual evidence, or `Verification` explains why it is not applicable
