### PR TITLE
feat: add Tencent Token Plan support

### DIFF
--- a/apps/desktop/e2e/providers.spec.ts
+++ b/apps/desktop/e2e/providers.spec.ts
@@ -123,6 +123,36 @@ test('adds Tencent Coding Plan with its exact access path and shared Tencent Clo
   await expect(page.getByRole('textbox', { name: '模型密钥' })).toBeVisible();
 });
 
+test('adds Tencent Token Plan with its exact access path and shared Tencent Cloud mark', async ({ window: page }) => {
+  await page.getByRole('button', { name: '展开侧边栏' }).click();
+  await page.getByRole('button', { name: '设置' }).click();
+  await page.locator('[aria-label="设置分组"]').getByText('模型', { exact: true }).click();
+  await page.getByRole('button', { name: '添加服务商' }).click();
+
+  await page.getByRole('tab', { name: '模型计划' }).click();
+  await page.getByPlaceholder('搜索服务商').fill('Tencent Token Plan');
+  const catalogMark = page.locator(
+    '.providerCatalogRow[data-provider="tencent-token-plan"] .providerLogo .providerAssetMask',
+  );
+  await expect(catalogMark).toBeVisible();
+  expect(await catalogMark.evaluate(maskRenderContract)).toEqual({ usesAssetMask: true, followsForeground: true });
+  await page.getByRole('button', { name: /添加模型供应商：Tencent Token Plan/ }).click();
+
+  await expect(page.getByLabel('模型供应商连接标识')).toHaveValue('tencent-token-plan');
+  await expect(page.getByLabel('模型供应商服务地址')).toHaveValue('https://api.lkeap.cloud.tencent.com/plan/v3');
+  await expect(page.getByLabel('模型供应商默认模型')).toHaveValue('tc-code-latest');
+  await page.getByRole('button', { name: '保存供应商' }).click();
+
+  await expect(page.getByRole('heading', { name: 'Tencent Token Plan', exact: true }).first()).toBeVisible();
+  const detailMark = page.locator(
+    '.providerSubpageHeader .providerLogo[data-provider="tencent-token-plan"] .providerAssetMask',
+  );
+  await expect(detailMark).toBeVisible();
+  expect(await detailMark.evaluate(maskRenderContract)).toEqual({ usesAssetMask: true, followsForeground: true });
+  await expect(page.getByText('tc-code-latest', { exact: true }).first()).toBeVisible();
+  await expect(page.getByRole('textbox', { name: '模型密钥' })).toBeVisible();
+});
+
 test('adds xAI with its exact snapshot model and API-key credential field', async ({ window: page }) => {
   await page.getByRole('button', { name: '展开侧边栏' }).click();
   await page.getByRole('button', { name: '设置' }).click();

--- a/apps/desktop/src/main/__tests__/icon-governance-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/icon-governance-contract.test.ts
@@ -460,7 +460,7 @@ describe('icon + typography governance contract', () => {
     );
   });
 
-  it('vendors and routes the byte-exact Tencent Cloud mark for Tencent Coding Plan', async () => {
+  it('routes Tencent plans through the shared byte-exact Tencent Cloud mark', async () => {
     const [tencentCloudMark, componentSrc, notices] = await Promise.all([
       readFile(TENCENT_CLOUD_BRAND_MARK_FILE),
       readFile(PROVIDER_BRAND_MARKS_FILE, 'utf8'),
@@ -484,7 +484,7 @@ describe('icon + typography governance contract', () => {
     );
     assert.match(
       componentSrc,
-      /case 'tencent-coding-plan':\s*return <ProviderAssetMask src=\{tencentCloudBrandMark\} \/>/,
+      /case 'tencent-coding-plan':\s*case 'tencent-token-plan':\s*return <ProviderAssetMask src=\{tencentCloudBrandMark\} \/>/,
     );
   });
 

--- a/apps/desktop/src/renderer/settings/provider-brand-marks.tsx
+++ b/apps/desktop/src/renderer/settings/provider-brand-marks.tsx
@@ -283,6 +283,7 @@ export function ProviderBrandMark({ type }: { type: ProviderType }): ReactElemen
     case 'tencent-tokenhub':
       return <ProviderAssetMask src={hunyuanBrandMark} />;
     case 'tencent-coding-plan':
+    case 'tencent-token-plan':
       return <ProviderAssetMask src={tencentCloudBrandMark} />;
     case 'stepfun-ai':
     case 'stepfun':

--- a/packages/cli/src/__tests__/connection-target.test.ts
+++ b/packages/cli/src/__tests__/connection-target.test.ts
@@ -166,6 +166,29 @@ describe('default session target resolver', () => {
     assert.equal(target.model, 'glm-5');
   });
 
+  test('resolves Tencent Token Plan credentials without rewriting the selected model id', async () => {
+    const connection = makeConnection({
+      slug: 'tencent-token-plan',
+      name: 'Tencent Token Plan',
+      providerType: 'tencent-token-plan',
+      defaultModel: 'deepseek-v4-pro-202606',
+    });
+
+    const target = await resolveDefaultSessionTarget({
+      connectionStore: {
+        getDefault: async () => 'tencent-token-plan',
+        get: async (slug) => slug === 'tencent-token-plan' ? connection : null,
+      },
+      credentialStore: {
+        getSecret: async (_slug, kind) => kind === 'api_key' ? 'tencent-token-plan-test-key' : null,
+      },
+    });
+
+    assert.equal(target.connection.providerType, 'tencent-token-plan');
+    assert.equal(target.apiKey, 'tencent-token-plan-test-key');
+    assert.equal(target.model, 'deepseek-v4-pro-202606');
+  });
+
   test('resolves LM Studio without reading a credential or rewriting the selected model id', async () => {
     const connection = makeConnection({
       slug: 'lm-studio',

--- a/packages/core/src/__tests__/llm-connections.test.ts
+++ b/packages/core/src/__tests__/llm-connections.test.ts
@@ -32,6 +32,7 @@ describe('provider compatibility contract', () => {
       'minimax-coding-plan',
       'tencent-coding-plan',
       'volcengine-coding-plan',
+      'tencent-token-plan',
       'openai',
       'google',
       'deepseek',
@@ -84,6 +85,7 @@ describe('provider compatibility contract', () => {
       'stepfun-ai',
       'volcengine-ark',
       'volcengine-coding-plan',
+      'tencent-token-plan',
     ]);
     assert.deepEqual(CATALOG_PROVIDER_TYPES, [
       'kimi-coding-plan',
@@ -112,6 +114,7 @@ describe('provider compatibility contract', () => {
       'stepfun-ai',
       'volcengine-ark',
       'volcengine-coding-plan',
+      'tencent-token-plan',
     ]);
 
     for (const orderField of ['readyOrder', 'catalogOrder', 'recommendedOrder'] as const) {
@@ -358,6 +361,35 @@ describe('provider compatibility contract', () => {
       'glm-5',
       'minimax-m2.5',
       'kimi-k2.5',
+    ]);
+  });
+
+  it('owns Tencent Token Plan behavior under its independent persisted id', () => {
+    const plan = (PROVIDER_REGISTRY as Partial<Record<string, (typeof PROVIDER_REGISTRY)[keyof typeof PROVIDER_REGISTRY]>>)['tencent-token-plan'];
+
+    assert.ok(plan, 'Tencent Token Plan must be available through the shared provider registry');
+    assert.equal(plan.label, 'Tencent Token Plan');
+    assert.equal(plan.baseUrl, 'https://api.lkeap.cloud.tencent.com/plan/v3');
+    assert.equal(plan.authKind, 'api_key');
+    assert.equal(plan.protocol, 'openai');
+    assert.deepEqual(plan.runtimeAdapter, { kind: 'openai-compatible', name: 'provider' });
+    assert.deepEqual(plan.modelDiscovery, { kind: 'fallback' });
+    assert.equal(plan.category, 'domestic');
+    assert.equal(plan.catalogGroup, 'plans');
+    assert.equal(plan.catalogBadge, 'Token');
+    assert.equal(plan.signupUrl, 'https://console.cloud.tencent.com/tokenhub/tokenplan/common');
+    assert.equal(plan.modelsDevId, 'tencent-token-plan');
+    assert.deepEqual(plan.fallbackModels, [
+      'tc-code-latest',
+      'deepseek-v4-flash-202605',
+      'deepseek-v4-pro-202606',
+      'minimax-m2.5',
+      'minimax-m2.7',
+      'glm-5',
+      'glm-5.1',
+      'kimi-k2.5',
+      'hy3',
+      'hy3-preview',
     ]);
   });
 

--- a/packages/core/src/__tests__/model-thinking.test.ts
+++ b/packages/core/src/__tests__/model-thinking.test.ts
@@ -138,6 +138,11 @@ describe('thinkingVariantsForModel', () => {
     assert.deepEqual([...thinkingVariantsForModel('deepseek', 'deepseek-chat')], []);
   });
 
+  test('Tencent Token Plan HY 3 models expose the documented low/medium/high efforts', () => {
+    assert.deepEqual([...thinkingVariantsForModel('tencent-token-plan', 'hy3')], ['low', 'medium', 'high']);
+    assert.deepEqual([...thinkingVariantsForModel('tencent-token-plan', 'hy3-preview')], ['low', 'medium', 'high']);
+  });
+
   test('zai glm-5.2 high/max; toggle-only GLM models expose none until an off wire is declared', () => {
     assert.deepEqual([...thinkingVariantsForModel('zai-coding-plan', 'glm-5.2')], ['high', 'max']);
     assert.deepEqual([...thinkingVariantsForModel('zai-coding-plan', 'glm-5.1')], []);

--- a/packages/core/src/__tests__/provider-auth.test.ts
+++ b/packages/core/src/__tests__/provider-auth.test.ts
@@ -22,6 +22,19 @@ describe('ProviderAuth contract', () => {
     expect(contract.actionAvailability.fetch_models).toBe('hidden');
   });
 
+  test('Tencent Token Plan uses an independent API key and fallback-model flow', () => {
+    const contract = deriveProviderAuthContract({
+      providerType: 'tencent-token-plan',
+      hasSecret: true,
+    });
+
+    expect(contract.providerType).toBe('tencent-token-plan');
+    expect(contract.setupMode).toBe('api_key');
+    expect(contract.requiresSecret).toBe(true);
+    expect(contract.actionAvailability.test_credentials).toBe('available');
+    expect(contract.actionAvailability.fetch_models).toBe('hidden');
+  });
+
   test('Tencent Coding Plan uses the shared API-key credential and fallback-model flow', () => {
     const contract = deriveProviderAuthContract({
       providerType: 'tencent-coding-plan',

--- a/packages/core/src/model-metadata.generated.ts
+++ b/packages/core/src/model-metadata.generated.ts
@@ -2,7 +2,7 @@
 // Do not edit by hand; put access-path-specific facts in model-metadata.ts.
 import type { ModelMetadata } from './model-metadata.js';
 
-export const GENERATED_MODELS_DEV_METADATA: Record<"anthropic" | "cerebras" | "deepseek" | "fireworks-ai" | "google" | "gemini-cli" | "MiniMax" | "MiniMax-cn" | "mistral" | "moonshot" | "nvidia" | "openai" | "siliconflow" | "stepfun" | "stepfun-ai" | "togetherai" | "tencent-coding-plan" | "tencent-tokenhub" | "xai" | "zai-coding-plan", Record<string, ModelMetadata>> = {
+export const GENERATED_MODELS_DEV_METADATA: Record<"anthropic" | "cerebras" | "deepseek" | "fireworks-ai" | "google" | "gemini-cli" | "MiniMax" | "MiniMax-cn" | "mistral" | "moonshot" | "nvidia" | "openai" | "siliconflow" | "stepfun" | "stepfun-ai" | "togetherai" | "tencent-coding-plan" | "tencent-token-plan" | "tencent-tokenhub" | "xai" | "zai-coding-plan", Record<string, ModelMetadata>> = {
   "anthropic": {
     "claude-fable-5": {"displayName":"Claude Fable 5","lifecycle":"active","docsUrl":"https://docs.anthropic.com/en/docs/about-claude/models","contextWindow":1000000,"maxOutputTokens":128000,"capabilities":{"vision":true,"reasoning":true,"functionCalling":true}},
     "claude-haiku-4-5": {"displayName":"Claude Haiku 4.5 (latest)","lifecycle":"active","docsUrl":"https://docs.anthropic.com/en/docs/about-claude/models","contextWindow":200000,"maxOutputTokens":64000,"capabilities":{"vision":true,"reasoning":true,"functionCalling":true}},
@@ -418,6 +418,9 @@ export const GENERATED_MODELS_DEV_METADATA: Record<"anthropic" | "cerebras" | "d
     "minimax-m2.5": {"displayName":"MiniMax-M2.5","lifecycle":"active","docsUrl":"https://cloud.tencent.com/document/product/1772/128947","contextWindow":204800,"maxOutputTokens":32768,"capabilities":{"vision":false,"reasoning":true,"functionCalling":true}},
     "tc-code-latest": {"displayName":"Auto","lifecycle":"active","docsUrl":"https://cloud.tencent.com/document/product/1772/128947","contextWindow":131072,"maxOutputTokens":16384,"capabilities":{"vision":false,"reasoning":false,"functionCalling":true}},
   },
+  "tencent-token-plan": {
+    "hy3": {"displayName":"Hy3","lifecycle":"active","docsUrl":"https://cloud.tencent.com/document/product/1823/130060","contextWindow":256000,"maxOutputTokens":64000,"capabilities":{"vision":false,"reasoning":true,"functionCalling":true}},
+  },
   "tencent-tokenhub": {
     "hy3": {"displayName":"Hy3","lifecycle":"active","docsUrl":"https://cloud.tencent.com/document/product/1823/130050","contextWindow":256000,"maxOutputTokens":64000,"capabilities":{"vision":false,"reasoning":true,"functionCalling":true}},
     "hy3-preview": {"displayName":"Hy3 preview","lifecycle":"active","docsUrl":"https://cloud.tencent.com/document/product/1823/130050","contextWindow":256000,"maxOutputTokens":64000,"capabilities":{"vision":false,"reasoning":true,"functionCalling":true}},
@@ -443,7 +446,7 @@ export const GENERATED_MODELS_DEV_METADATA: Record<"anthropic" | "cerebras" | "d
   },
 };
 
-export const GENERATED_MODELS_DEV_PROVIDER_FACTS: Record<"anthropic" | "cerebras" | "deepseek" | "fireworks-ai" | "google" | "gemini-cli" | "MiniMax" | "MiniMax-cn" | "mistral" | "moonshot" | "nvidia" | "openai" | "siliconflow" | "stepfun" | "stepfun-ai" | "togetherai" | "tencent-coding-plan" | "tencent-tokenhub" | "xai" | "zai-coding-plan", { id: string; name: string; api?: string; doc: string }> = {
+export const GENERATED_MODELS_DEV_PROVIDER_FACTS: Record<"anthropic" | "cerebras" | "deepseek" | "fireworks-ai" | "google" | "gemini-cli" | "MiniMax" | "MiniMax-cn" | "mistral" | "moonshot" | "nvidia" | "openai" | "siliconflow" | "stepfun" | "stepfun-ai" | "togetherai" | "tencent-coding-plan" | "tencent-token-plan" | "tencent-tokenhub" | "xai" | "zai-coding-plan", { id: string; name: string; api?: string; doc: string }> = {
   "anthropic": {"id":"anthropic","name":"Anthropic","doc":"https://docs.anthropic.com/en/docs/about-claude/models"},
   "cerebras": {"id":"cerebras","name":"Cerebras","doc":"https://inference-docs.cerebras.ai/models/overview"},
   "deepseek": {"id":"deepseek","name":"DeepSeek","api":"https://api.deepseek.com","doc":"https://api-docs.deepseek.com/quick_start/pricing"},
@@ -461,6 +464,7 @@ export const GENERATED_MODELS_DEV_PROVIDER_FACTS: Record<"anthropic" | "cerebras
   "stepfun-ai": {"id":"stepfun-ai","name":"StepFun (Global)","api":"https://api.stepfun.ai/v1","doc":"https://platform.stepfun.ai/docs/en/overview/concept"},
   "togetherai": {"id":"togetherai","name":"Together AI","doc":"https://docs.together.ai/docs/serverless-models"},
   "tencent-coding-plan": {"id":"tencent-coding-plan","name":"Tencent Coding Plan (China)","api":"https://api.lkeap.cloud.tencent.com/coding/v3","doc":"https://cloud.tencent.com/document/product/1772/128947"},
+  "tencent-token-plan": {"id":"tencent-token-plan","name":"Tencent Token Plan","api":"https://api.lkeap.cloud.tencent.com/plan/v3","doc":"https://cloud.tencent.com/document/product/1823/130060"},
   "tencent-tokenhub": {"id":"tencent-tokenhub","name":"Tencent TokenHub","api":"https://tokenhub.tencentmaas.com/v1","doc":"https://cloud.tencent.com/document/product/1823/130050"},
   "xai": {"id":"xai","name":"xAI","doc":"https://docs.x.ai/docs/models"},
   "zai-coding-plan": {"id":"zai-coding-plan","name":"Z.AI Coding Plan","api":"https://api.z.ai/api/coding/paas/v4","doc":"https://docs.z.ai/devpack/overview"},

--- a/packages/core/src/model-metadata.ts
+++ b/packages/core/src/model-metadata.ts
@@ -148,6 +148,9 @@ const STATIC_MODEL_METADATA: Partial<Record<ProviderType, Record<string, ModelMe
     },
   },
   'volcengine-coding-plan': VOLCENGINE_CODING_PLAN_MODEL_METADATA,
+  'tencent-token-plan': {
+    hy3: { thinkingOptions: { efforts: ['low', 'medium', 'high'] } },
+  },
   deepseek: {
     'deepseek-v4-flash': { thinkingOptions: { efforts: ['high', 'max'], toggle: true } },
   },

--- a/packages/core/src/model-metadata.ts
+++ b/packages/core/src/model-metadata.ts
@@ -150,6 +150,7 @@ const STATIC_MODEL_METADATA: Partial<Record<ProviderType, Record<string, ModelMe
   'volcengine-coding-plan': VOLCENGINE_CODING_PLAN_MODEL_METADATA,
   'tencent-token-plan': {
     hy3: { thinkingOptions: { efforts: ['low', 'medium', 'high'] } },
+    'hy3-preview': { thinkingOptions: { efforts: ['low', 'medium', 'high'] } },
   },
   deepseek: {
     'deepseek-v4-flash': { thinkingOptions: { efforts: ['high', 'max'], toggle: true } },

--- a/packages/core/src/provider-registry.ts
+++ b/packages/core/src/provider-registry.ts
@@ -134,6 +134,28 @@ const volcengineCodingPlanModelIds = [
   'kimi-k2.6',
   'kimi-k2.7-code',
 ] as const;
+const tencentTokenPlan = GENERATED_MODELS_DEV_PROVIDER_FACTS['tencent-token-plan'];
+if (tencentTokenPlan.id !== 'tencent-token-plan') {
+  throw new Error('models.dev Tencent Token Plan provider facts are missing stable id tencent-token-plan');
+}
+if (!tencentTokenPlan.api) throw new Error('models.dev Tencent Token Plan provider facts are missing api');
+if (!GENERATED_MODELS_DEV_METADATA['tencent-token-plan'].hy3?.capabilities?.functionCalling) {
+  throw new Error('models.dev Tencent Token Plan snapshot is missing tool-capable model hy3');
+}
+// Tencent's personal-plan docs are authoritative for this access-path allowlist.
+// The inference endpoint does not publish a /models discovery contract.
+const tencentTokenPlanModelIds = [
+  'tc-code-latest',
+  'deepseek-v4-flash-202605',
+  'deepseek-v4-pro-202606',
+  'minimax-m2.5',
+  'minimax-m2.7',
+  'glm-5',
+  'glm-5.1',
+  'kimi-k2.5',
+  'hy3',
+  'hy3-preview',
+] as const;
 const stepfun = GENERATED_MODELS_DEV_PROVIDER_FACTS.stepfun;
 if (stepfun.id !== 'stepfun') throw new Error('models.dev StepFun provider facts are missing stable id stepfun');
 if (!stepfun.api) throw new Error('models.dev StepFun provider facts are missing api');
@@ -286,6 +308,25 @@ const providerRegistry = {
     signupUrl: 'https://www.volcengine.com/activity/codingplan',
     readyOrder: 26,
     catalogOrder: 26,
+  },
+  'tencent-token-plan': {
+    label: tencentTokenPlan.name,
+    description: 'Tencent Cloud Token Plan for interactive personal agents and coding tools.',
+    baseUrl: tencentTokenPlan.api,
+    authKind: 'api_key',
+    backendKind: 'ai-sdk',
+    fallbackModels: [...tencentTokenPlanModelIds],
+    status: 'ready',
+    protocol: 'openai',
+    runtimeAdapter: { kind: 'openai-compatible', name: 'provider' },
+    modelDiscovery: { kind: 'fallback' },
+    category: 'domestic',
+    catalogGroup: 'plans',
+    catalogBadge: 'Token',
+    signupUrl: 'https://console.cloud.tencent.com/tokenhub/tokenplan/common',
+    modelsDevId: tencentTokenPlan.id,
+    readyOrder: 27,
+    catalogOrder: 27,
   },
   openai: {
     label: 'OpenAI',

--- a/packages/headless/src/__tests__/harbor-cell.test.ts
+++ b/packages/headless/src/__tests__/harbor-cell.test.ts
@@ -2306,6 +2306,33 @@ setTimeout(() => {
     }
   });
 
+  test('does not load Tencent Token Plan credentials in non-interactive Harbor runs', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'maka-cell-tencent-token-plan-'));
+    try {
+      const credentialsPath = join(dir, 'credentials.json');
+      await writeFile(credentialsPath, `${JSON.stringify({
+        version: 1,
+        values: { 'tencent-token-plan:apiKey': 'must-not-load-in-headless' },
+      })}\n`, 'utf8');
+
+      const resolved = resolveHarborCellAiSdkEnv({
+        provider: 'tencent-token-plan',
+        model: 'hy3',
+        env: {
+          MAKA_CREDENTIALS_PATH: credentialsPath,
+          TENCENT_TOKEN_PLAN_API_KEY: 'must-also-not-load-in-headless',
+        },
+        ts: 1,
+      });
+
+      assert.equal(resolved.apiKey, '');
+      assert.equal(resolved.connection.providerType, 'tencent-token-plan');
+      assert.equal(resolved.connection.defaultModel, 'hy3');
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
   test('resolves StepFun China only from its direct API credential env', () => {
     const resolved = resolveHarborCellAiSdkEnv({
       provider: 'stepfun',

--- a/packages/headless/src/__tests__/provider-env.test.ts
+++ b/packages/headless/src/__tests__/provider-env.test.ts
@@ -87,6 +87,14 @@ test('Volcengine Coding Plan is unavailable to non-interactive headless credenti
   );
 });
 
+test('Tencent Token Plan is unavailable to non-interactive headless credential loading', () => {
+  assert.equal(providerCredentialEnv('tencent-token-plan'), undefined);
+  assert.throws(
+    () => requireProviderCredentialEnv('tencent-token-plan'),
+    /provider does not support API key files: tencent-token-plan/,
+  );
+});
+
 test('StepFun China keeps direct API credentials separate from global and plan identities', () => {
   assert.deepEqual(providerCredentialEnv('stepfun'), {
     apiKeys: ['STEPFUN_API_KEY'],

--- a/packages/runtime/src/__tests__/model-factory-thinking.test.ts
+++ b/packages/runtime/src/__tests__/model-factory-thinking.test.ts
@@ -85,6 +85,15 @@ describe('buildProviderOptions: thinking level', () => {
     });
   });
 
+  test('Tencent Token Plan sends its documented reasoning effort under the stable provider namespace', () => {
+    assert.deepEqual([...thinkingVariantsForModel('tencent-token-plan', 'hy3')], ['low', 'medium', 'high']);
+    assert.deepEqual(
+      buildProviderOptions(conn('tencent-token-plan'), 'hy3', 'high'),
+      { 'tencent-token-plan': { reasoningEffort: 'high' } },
+    );
+    assert.deepEqual(buildProviderOptions(conn('tencent-token-plan'), 'hy3', 'off'), {});
+  });
+
   test('a level the model does not support is dropped (defensive)', () => {
     assert.deepEqual(buildProviderOptions(conn('openai'), 'gpt-4o', 'high'), { openai: {} });
     assert.deepEqual(buildProviderOptions(conn('anthropic'), 'claude-haiku-4-5', 'max'), { anthropic: {} });

--- a/packages/runtime/src/__tests__/provider-conformance.test.ts
+++ b/packages/runtime/src/__tests__/provider-conformance.test.ts
@@ -1234,6 +1234,118 @@ describe('models.dev provider conformance', () => {
     assert.equal(result.text, 'Echoed hello.');
   });
 
+  test('Tencent Token Plan uses its official snapshot and preserves the exact model id through a two-stage tool-call loop', async () => {
+    const modelId = 'hy3';
+    const requestBodies: Array<Record<string, unknown>> = [];
+    const server = await startJsonServer(async (request, response) => {
+      assert.equal(request.headers.authorization, 'Bearer tencent-token-plan-test-key');
+      assert.equal(request.method, 'POST');
+      assert.equal(request.url, '/plan/v3/chat/completions');
+      const body = JSON.parse(await readBody(request)) as Record<string, unknown>;
+      requestBodies.push(body);
+      if (requestBodies.length === 1) {
+        respondJson(response, 200, {
+          id: 'chatcmpl-tencent-token-plan-tool',
+          object: 'chat.completion',
+          created: 1,
+          model: modelId,
+          choices: [{
+            index: 0,
+            message: {
+              role: 'assistant',
+              content: null,
+              reasoning_content: 'I should call echo with the requested text.',
+              tool_calls: [{
+                id: 'call_tencent_token_plan_echo',
+                type: 'function',
+                function: { name: 'echo', arguments: '{"text":"hello"}' },
+              }],
+            },
+            finish_reason: 'tool_calls',
+          }],
+          usage: { prompt_tokens: 8, completion_tokens: 4, total_tokens: 12 },
+        });
+        return;
+      }
+
+      respondJson(response, 200, {
+        id: 'chatcmpl-tencent-token-plan-final',
+        object: 'chat.completion',
+        created: 2,
+        model: modelId,
+        choices: [{
+          index: 0,
+          message: { role: 'assistant', content: 'Echoed hello.' },
+          finish_reason: 'stop',
+        }],
+        usage: { prompt_tokens: 14, completion_tokens: 3, total_tokens: 17 },
+      });
+    });
+    const connection: LlmConnection = {
+      slug: 'tencent-token-plan',
+      name: 'Tencent Token Plan',
+      providerType: 'tencent-token-plan',
+      baseUrl: `${server.url}/plan/v3`,
+      defaultModel: modelId,
+      enabled: true,
+      createdAt: 1,
+      updatedAt: 1,
+    };
+
+    const models = await fetchProviderModels(connection, 'tencent-token-plan-test-key');
+    assert.deepEqual(models.map(({ id }) => id), [
+      'tc-code-latest',
+      'deepseek-v4-flash-202605',
+      'deepseek-v4-pro-202606',
+      'minimax-m2.5',
+      'minimax-m2.7',
+      'glm-5',
+      'glm-5.1',
+      'kimi-k2.5',
+      'hy3',
+      'hy3-preview',
+    ]);
+
+    const result = await generateText({
+      model: getAIModel({ connection, apiKey: 'tencent-token-plan-test-key', modelId }),
+      prompt: 'Call echo with hello.',
+      providerOptions: buildProviderOptions(connection, modelId, 'high') as Record<string, Record<string, string>>,
+      stopWhen: stepCountIs(2),
+      tools: {
+        echo: tool({
+          description: 'Echo text',
+          inputSchema: z.object({ text: z.string() }),
+          execute: async ({ text }) => ({ echoed: text }),
+        }),
+      },
+    });
+
+    assert.equal(requestBodies.length, 2);
+    assert.equal(requestBodies[0]?.reasoning_effort, 'high');
+    assert.equal(result.steps[0]?.reasoningText, 'I should call echo with the requested text.');
+    assert.deepEqual(requestBodies.map((body) => body.model), [modelId, modelId]);
+    assert.deepEqual(
+      (requestBodies[1]?.messages as Array<Record<string, unknown>>).find(({ role }) => role === 'assistant'),
+      {
+        role: 'assistant',
+        content: null,
+        reasoning_content: 'I should call echo with the requested text.',
+        tool_calls: [{
+          id: 'call_tencent_token_plan_echo',
+          type: 'function',
+          function: { name: 'echo', arguments: '{"text":"hello"}' },
+        }],
+      },
+    );
+    assert.deepEqual(
+      (requestBodies[1]?.messages as Array<{ role: string; content: string }>).find(({ role }) => role === 'tool'),
+      { role: 'tool', content: '{"echoed":"hello"}', tool_call_id: 'call_tencent_token_plan_echo' },
+    );
+    assert.equal(result.steps[0]?.toolCalls[0]?.toolName, 'echo');
+    assert.deepEqual(result.steps[0]?.toolResults[0]?.output, { echoed: 'hello' });
+    assert.equal(result.text, 'Echoed hello.');
+  });
+
   for (const stepfun of [
     { label: 'StepFun China', providerType: 'stepfun', apiKey: 'stepfun-test-key' },
     { label: 'StepFun Global', providerType: 'stepfun-ai', apiKey: 'stepfun-global-test-key' },

--- a/packages/runtime/src/model-factory.ts
+++ b/packages/runtime/src/model-factory.ts
@@ -148,6 +148,7 @@ export function buildProviderOptions(
     // (no thinking.disabled field), so it is a no-op override here.
     case 'deepseek':
     case 'moonshot':
+    case 'tencent-token-plan':
     case 'zai-coding-plan':
       return level && level !== 'off'
         ? { [openaiCompatibleNamespace(connection.providerType)]: { reasoningEffort: level } }

--- a/packages/storage/src/__tests__/connection-store.test.ts
+++ b/packages/storage/src/__tests__/connection-store.test.ts
@@ -162,6 +162,23 @@ describe('FileConnectionStore', () => {
     });
   });
 
+  test('persists the Tencent Token Plan provider id and exact default model', async () => {
+    await withConnectionStore(async (store, dir) => {
+      await store.create({
+        slug: 'tencent-token-plan',
+        name: 'Tencent Token Plan',
+        providerType: 'tencent-token-plan',
+        defaultModel: 'deepseek-v4-pro-202606',
+      });
+
+      const persisted = JSON.parse(await readFile(join(dir, 'llm-connections.json'), 'utf8')) as {
+        connections: Array<{ providerType: string; defaultModel: string }>;
+      };
+      assert.equal(persisted.connections[0]?.providerType, 'tencent-token-plan');
+      assert.equal(persisted.connections[0]?.defaultModel, 'deepseek-v4-pro-202606');
+    });
+  });
+
   test('persists the LM Studio provider id and exact local model id', async () => {
     await withConnectionStore(async (store, dir) => {
       await store.create({

--- a/scripts/sync-model-metadata.mjs
+++ b/scripts/sync-model-metadata.mjs
@@ -20,6 +20,7 @@ const PROVIDERS = {
   'stepfun-ai': 'stepfun-ai',
   togetherai: 'togetherai',
   'tencent-coding-plan': 'tencent-coding-plan',
+  'tencent-token-plan': 'tencent-token-plan',
   'tencent-tokenhub': 'tencent-tokenhub',
   xai: 'xai',
   'zai-coding-plan': 'zai-coding-plan',

--- a/scripts/sync-model-metadata.test.mjs
+++ b/scripts/sync-model-metadata.test.mjs
@@ -7,7 +7,7 @@ import { promisify } from 'node:util';
 import test from 'node:test';
 
 const execFileAsync = promisify(execFile);
-const PROVIDER_IDS = ['anthropic', 'cerebras', 'deepseek', 'fireworks-ai', 'google', 'minimax', 'minimax-cn', 'mistral', 'moonshotai-cn', 'nvidia', 'openai', 'siliconflow', 'stepfun', 'stepfun-ai', 'tencent-coding-plan', 'tencent-tokenhub', 'togetherai', 'xai', 'zai-coding-plan'];
+const PROVIDER_IDS = ['anthropic', 'cerebras', 'deepseek', 'fireworks-ai', 'google', 'minimax', 'minimax-cn', 'mistral', 'moonshotai-cn', 'nvidia', 'openai', 'siliconflow', 'stepfun', 'stepfun-ai', 'tencent-coding-plan', 'tencent-token-plan', 'tencent-tokenhub', 'togetherai', 'xai', 'zai-coding-plan'];
 
 function withRequiredProviders(openai) {
   return Object.fromEntries(PROVIDER_IDS.map((id) => {
@@ -312,6 +312,36 @@ test('sync-model-metadata vendors Tencent Coding Plan provider facts and exact m
   assert.match(generated, /"tencent-coding-plan": \{"id":"tencent-coding-plan","name":"Tencent Coding Plan \(China\)","api":"https:\/\/api\.lkeap\.cloud\.tencent\.com\/coding\/v3"/);
   assert.match(generated, /"tc-code-latest": \{"displayName":"Auto"/);
   assert.match(generated, /"glm-5": \{"displayName":"GLM-5"/);
+});
+
+test('sync-model-metadata vendors Tencent Token Plan provider facts and exact model ids', async () => {
+  const directory = await mkdtemp(join(tmpdir(), 'maka-model-metadata-'));
+  const input = join(directory, 'api.json');
+  const output = join(directory, 'generated.ts');
+  const catalog = withRequiredProviders({});
+  catalog['tencent-token-plan'] = {
+    ...catalog['tencent-token-plan'],
+    name: 'Tencent Token Plan',
+    api: 'https://api.lkeap.cloud.tencent.com/plan/v3',
+    doc: 'https://cloud.tencent.com/document/product/1823/130060',
+    models: {
+      hy3: {
+        id: 'hy3', name: 'Hy3', reasoning: true, tool_call: true,
+        modalities: { input: ['text'], output: ['text'] },
+        limit: { context: 256_000, output: 64_000 },
+      },
+    },
+  };
+  await writeFile(input, JSON.stringify(catalog));
+
+  await execFileAsync(process.execPath, [
+    'scripts/sync-model-metadata.mjs', '--input', input, '--output', output,
+  ]);
+
+  const generated = await readFile(output, 'utf8');
+  assert.match(generated, /"tencent-token-plan": \{/);
+  assert.match(generated, /"tencent-token-plan": \{"id":"tencent-token-plan","name":"Tencent Token Plan","api":"https:\/\/api\.lkeap\.cloud\.tencent\.com\/plan\/v3"/);
+  assert.match(generated, /"hy3": \{"displayName":"Hy3"/);
 });
 
 test('sync-model-metadata vendors StepFun China direct provider facts and exact model ids', async () => {


### PR DESCRIPTION
## Summary

- Add Tencent Token Plan as the independent persisted provider `tencent-token-plan`, with its own Token Plan credential, endpoint, model snapshot, and fallback-only discovery contract.
- Wire the provider through Core, Runtime, Storage, CLI, Headless fake-boundary coverage, and Desktop, including deterministic two-stage reasoning/tool-call replay.
- Reuse the existing Tencent Cloud brand asset and provenance path introduced by #904 without vendoring or licensing changes.

## Why

Tencent Token Plan is a separate personal subscription product from Tencent Coding Plan and Tencent's direct API. Maka needs a stable identity and product-specific transport contract so saved connections cannot drift between those access paths. Refs #860.

## Scope

This PR is limited to Phase 4 Tencent Token Plan. It does not add other Tencent products, providers, or Phase 7 work. Because Tencent documents Token Plan for interactive AI tools rather than scripts, backend services, or batch API use, Headless coverage proves only explicit fake wiring and intentionally does not load a Token Plan key from environment variables. Model discovery uses an honest registry snapshot because no public Token Plan model-list endpoint is documented.

## Verification

- `npm run typecheck`
- Rebase-sensitive Core/Runtime/Headless tests: 16/16 passed, covering registry/order/auth, both HY 3 reasoning variants, Tencent and Volcengine two-stage tool loops, provider env, and Harbor boundaries.
- Storage/CLI host tests: 2/2 passed for exact persisted provider/model and credential resolution.
- Desktop icon governance: 2/2 passed for the shared Tencent Cloud and Volcengine asset-mask routes.
- `npm run build` and final clean `npm run rebuild` (including overlay and renderer production builds)
- `npm run check:stale`
- `node scripts/check-third-party-notices.mjs` via the renderer build
- `git diff --check`
- Tencent Cloud SVG provenance rechecked against `lobehub/lobe-icons`, `@lobehub/icons-static-svg@1.91.0`, immutable commit `e4302041fbb3039608d25f9f618bd462783b875e`, `packages/static-svg/icons/tencentcloud.svg`, MIT, and SHA-256 `0563b1dbaa01aff4f20352bc9eb49bec17debeb3901a9ee80b044ac4d792c97d`; catalog and detail tests prove both Tencent plans consume the shared `ProviderAssetMask` / `currentColor` path.
- Live smoke was not run: no safe user-owned Token Plan key was available, and Tencent restricts the subscription to interactive AI-tool use. Deterministic fake transport tests cover the complete two-turn wire contract without logging secrets or raw responses.
- Static screenshots are not applicable: this adds an existing shared provider mark and catalog/detail metadata rather than a new visual design. Desktop contract/E2E coverage verifies the rendered catalog/detail route, mask URL, and computed `currentColor` behavior; CI E2E is the merge gate.

## Impact

Users can save and select Tencent Token Plan independently with the exact provider ID and supported model IDs. Existing Tencent direct API and Tencent Coding Plan connections are unchanged. There is no storage migration, new asset, new third-party notice, or secret-handling change outside this provider.

## Reviewer notes

Please focus on provider identity separation, fallback-only discovery, the reasoning/tool replay payload, the deliberate Headless credential boundary, and reuse of #904's shared Tencent Cloud SVG path.

## Ready for review

- [x] Verification is complete and the results above are current
- [x] Impact, compatibility, migration, documentation, and release-note needs are addressed
- [x] User-visible UI/UX changes include visual evidence, or `Verification` explains why it is not applicable
