### PR TITLE
fix(cu): classify and gate semantic failures

### DIFF
--- a/packages/runtime/src/__tests__/loop-gate.test.ts
+++ b/packages/runtime/src/__tests__/loop-gate.test.ts
@@ -8,6 +8,7 @@ import type { ToolInvocationRecord } from '@maka/core/usage-stats/types';
 import {
   ToolRuntime,
   formatLoopGateText,
+  formatAmbiguousComputerLoopGateText,
   formatDeferredNotLoadedText,
   LOOP_GATE_IDENTICAL_THRESHOLD,
   type MakaTool,
@@ -189,6 +190,27 @@ function makeShellRunTool(name: string, impl: string[], status: ObservedShellRun
           redacted: false,
         },
       } satisfies ShellRunToolResult;
+    },
+  };
+}
+
+function makeComputerFailureTool(
+  impl: string[],
+  failureClass?: 'ambiguous_target',
+): MakaTool {
+  return {
+    name: 'maka_computer',
+    description: 'computer',
+    parameters: z.object({}).passthrough(),
+    permissionRequired: false,
+    categoryHint: 'computer_use',
+    impl: (args) => {
+      impl.push(JSON.stringify(args));
+      return {
+        text: 'maka_computer failed: stale_frame',
+        error: 'stale_frame',
+        ...(failureClass ? { failureClass } : {}),
+      };
     },
   };
 }
@@ -385,6 +407,42 @@ describe('loop-gate for repeated identical FAILING tool calls', () => {
       assert.equal(event?.type === 'tool_result' ? event.isError : true, false, status);
       assert.equal(h.invocations[0]?.status, 'success', status);
     }
+  });
+
+  test('a returned top-level error is classified as a failed tool result', async () => {
+    const h = makeHarness();
+    const tool = makeComputerFailureTool(h.impl);
+    const result = await call(h, tool, {
+      action: 'click_element',
+      observation_id: 'obs-1',
+      element_id: 'duplicate',
+    });
+    assert.deepEqual(result, {
+      text: 'maka_computer failed: stale_frame',
+      error: 'stale_frame',
+    });
+    const event = h.pushed.find((candidate) => candidate.type === 'tool_result');
+    assert.equal(event?.type === 'tool_result' ? event.isError : false, true);
+    assert.equal(h.invocations[0]?.status, 'error');
+  });
+
+  test('an ambiguous semantic target is gated across fresh observation ids', async () => {
+    const h = makeHarness();
+    const tool = makeComputerFailureTool(h.impl, 'ambiguous_target');
+    const first = await call(h, tool, {
+      action: 'click_element',
+      observation_id: 'obs-1',
+      element_id: 'duplicate',
+    });
+    assert.equal((first as { error?: string }).error, 'stale_frame');
+
+    const second = await call(h, tool, {
+      action: 'click_element',
+      observation_id: 'obs-2',
+      element_id: 'duplicate',
+    });
+    assert.deepEqual(second, { error: formatAmbiguousComputerLoopGateText() });
+    assert.equal(h.impl.length, 1, 'second ambiguous attempt never reaches the backend');
   });
 
   test('repeated shell_run observations are not loop-gated by process status', async () => {

--- a/packages/runtime/src/computer-use-tools.ts
+++ b/packages/runtime/src/computer-use-tools.ts
@@ -505,6 +505,7 @@ interface ComputerToolResult {
   text: string;
   modelText?: string;
   error?: ComputerUseErrorCode;
+  failureClass?: 'ambiguous_target';
   screenshot?: { base64: string; mimeType: string };
 }
 
@@ -1370,6 +1371,10 @@ export function buildComputerUseTools(deps: {
           }
           presentation?.finish(result);
           const text = summarize(summaryAction, result);
+          const failureClass = !result.outcome.ok
+            && /ambiguous/i.test(result.outcome.message)
+            ? 'ambiguous_target' as const
+            : undefined;
           const freshModelState = freshObservation
             ? `\nFresh observation:\n${observationText(freshObservation)}`
             : '';
@@ -1381,15 +1386,19 @@ export function buildComputerUseTools(deps: {
             ? {
                 text: `${text}${freshPersistedState}`,
                 modelText: `${text}${freshModelState}`,
+                ...(!result.outcome.ok ? { error: result.outcome.error } : {}),
+                ...(failureClass ? { failureClass } : {}),
                 screenshot: {
                   base64: screenshot.base64,
                   mimeType: screenshot.mimeType,
                 },
               }
             : {
-                text: `${text}${freshPersistedState}`,
-                modelText: `${text}${freshModelState}`,
-              };
+              text: `${text}${freshPersistedState}`,
+              modelText: `${text}${freshModelState}`,
+              ...(!result.outcome.ok ? { error: result.outcome.error } : {}),
+              ...(failureClass ? { failureClass } : {}),
+            };
         }
         const modelAction = adaptToCuAction(input);
         const action = modelAction;
@@ -1502,14 +1511,25 @@ export function buildComputerUseTools(deps: {
               : '';
           const text = `${summarize(modelAction, result)}${persistedRefresh}`;
           const modelText = `${summarize(modelAction, result)}${modelRefresh}`;
+          const failureClass = !result.outcome.ok
+            && /ambiguous/i.test(result.outcome.message)
+            ? 'ambiguous_target' as const
+            : undefined;
           const screenshot = freshObservation?.screenshot ?? result.screenshot;
           return screenshot
             ? {
                 text,
                 modelText,
+                ...(!result.outcome.ok ? { error: result.outcome.error } : {}),
+                ...(failureClass ? { failureClass } : {}),
                 screenshot: { base64: screenshot.base64, mimeType: screenshot.mimeType },
               }
-            : { text, modelText };
+            : {
+                text,
+                modelText,
+                ...(!result.outcome.ok ? { error: result.outcome.error } : {}),
+                ...(failureClass ? { failureClass } : {}),
+              };
         }
       });
     },

--- a/packages/runtime/src/tool-runtime.ts
+++ b/packages/runtime/src/tool-runtime.ts
@@ -199,6 +199,7 @@ export class ToolRuntime {
    */
   private lastFailedToolCallSignature: string | undefined;
   private failedToolCallStreak = 0;
+  private lastAmbiguousComputerSignature: string | undefined;
 
   constructor(private readonly input: ToolRuntimeInput) {}
 
@@ -261,6 +262,7 @@ export class ToolRuntime {
     this.gating = undefined;
     this.lastFailedToolCallSignature = undefined;
     this.failedToolCallStreak = 0;
+    this.lastAmbiguousComputerSignature = undefined;
   }
 
   /**
@@ -385,6 +387,29 @@ export class ToolRuntime {
     // is told to change its approach. The block itself records no outcome, so the
     // streak stays parked and every further identical repeat stays blocked.
     const callSignature = `${tool.name} ${loopGateArgsKey(executionArgs, toolUseId)}`;
+    const computerSemanticSignature = tool.categoryHint === 'computer_use'
+      ? computerUseSemanticSignature(executionArgs)
+      : undefined;
+    if (
+      computerSemanticSignature
+      && computerSemanticSignature === this.lastAmbiguousComputerSignature
+    ) {
+      const reason = formatAmbiguousComputerLoopGateText();
+      await this.writeSyntheticToolResult(toolUseId, turnId, reason, queue);
+      trace?.emit('tool', 'tool_failed', 'Blocked repeated ambiguous Computer Use target', {
+        toolUseId,
+        toolName: tool.name,
+        status: 'error',
+        errorClass: 'AmbiguousComputerTarget',
+      });
+      return this.errorReturn(reason);
+    }
+    if (
+      this.lastAmbiguousComputerSignature
+      && computerSemanticSignature !== this.lastAmbiguousComputerSignature
+    ) {
+      this.lastAmbiguousComputerSignature = undefined;
+    }
     if (
       callSignature === this.lastFailedToolCallSignature
       && this.failedToolCallStreak >= LOOP_GATE_IDENTICAL_THRESHOLD - 1
@@ -611,7 +636,7 @@ export class ToolRuntime {
         const durationMs = this.input.now() - startedAt;
 
         const content = coerceResultContent(result);
-        const toolResultStatus = deriveToolResultStatus(content);
+        const toolResultStatus = deriveToolResultStatus(content, result);
         const resultMsg: ToolResultMessage = {
           type: 'tool_result',
           id: this.input.newId(),
@@ -681,6 +706,9 @@ export class ToolRuntime {
         );
 
         attemptFailed = toolResultStatus !== 'success';
+        this.lastAmbiguousComputerSignature = isAmbiguousComputerFailure(result)
+          ? computerSemanticSignature
+          : undefined;
         return result;
       } finally {
         pauseTarget?.resume();
@@ -883,6 +911,27 @@ function loopGateArgsKey(args: unknown, callId: string): string {
   }
 }
 
+function computerUseSemanticSignature(args: unknown): string | undefined {
+  if (!args || typeof args !== 'object' || Array.isArray(args)) return undefined;
+  const record = args as Record<string, unknown>;
+  if (
+    record.action !== 'click_element'
+    && record.action !== 'set_value'
+    && record.action !== 'select_text'
+    && record.action !== 'secondary_action'
+  ) return undefined;
+  try {
+    return stableHash({
+      action: record.action,
+      element_id: record.element_id,
+      value: record.value,
+      text: record.text,
+    });
+  } catch {
+    return undefined;
+  }
+}
+
 /**
  * Recoverable message returned when the loop-gate blocks a repeated identical
  * failing call. Tells the model the retry is pointless and to change its approach.
@@ -893,6 +942,14 @@ export function formatLoopGateText(toolName: string): string {
     `repeatedly with no change between attempts, so it was not run again — the result ` +
     `would be the same. Change the arguments or take a different step (for example ` +
     `Read the file or inspect the relevant state) before retrying.`
+  );
+}
+
+export function formatAmbiguousComputerLoopGateText(): string {
+  return (
+    'Blocked: this Computer Use semantic target was already rejected as ambiguous '
+    + 'after a fresh observation. Do not retry the same element identity or guess '
+    + 'between duplicates; choose a uniquely identified target or stop.'
   );
 }
 
@@ -1007,7 +1064,16 @@ function buildTerminalFailureMessage(code: number, stdout: string, stderr: strin
   return parts.join('\n\n');
 }
 
-function deriveToolResultStatus(content: ToolResultContent): ToolInvocationRecord['status'] {
+function deriveToolResultStatus(
+  content: ToolResultContent,
+  raw?: unknown,
+): ToolInvocationRecord['status'] {
+  if (
+    raw
+    && typeof raw === 'object'
+    && typeof (raw as { error?: unknown }).error === 'string'
+    && (raw as { error: string }).error.length > 0
+  ) return 'error';
   if (content.kind === 'explore_agent' && content.ok === false) {
     return content.reason === 'aborted' ? 'aborted' : 'error';
   }
@@ -1038,6 +1104,15 @@ function deriveToolResultStatus(content: ToolResultContent): ToolInvocationRecor
   // ShellRun observations: their embedded process status stays model-visible,
   // but reading or returning the observation itself succeeded.
   return 'success';
+}
+
+function isAmbiguousComputerFailure(raw: unknown): boolean {
+  return Boolean(
+    raw
+    && typeof raw === 'object'
+    && (raw as { error?: unknown }).error === 'stale_frame'
+    && (raw as { failureClass?: unknown }).failureClass === 'ambiguous_target',
+  );
 }
 
 function summarizeArgs(toolName: string, args: unknown): string {


### PR DESCRIPTION
## Summary

Fixes two Runtime issues found by a real-provider, real-AppKit AX model run:

- returned Computer Use failures such as `{ text, error: 'stale_frame' }` were projected to text and incorrectly classified as successful tool invocations;
- a model could repeat the same ambiguity-rejected semantic target after every fresh observation because the generic loop signature included the changing `observation_id`.

## Changes

- preserve typed Computer Use failure codes on action results;
- mark top-level returned `error` values as failed tool results for persistence, events, telemetry, and the generic loop gate;
- label only explicit ambiguous semantic refetch failures as `ambiguous_target`;
- cache a stable semantic signature of action + element identity/value while ignoring `observation_id`;
- block the next identical ambiguous semantic target before the backend runs;
- clear the ambiguity gate when the model changes target or action;
- keep `user_intervened`, `target_missing`, and ordinary stale/re-observe recovery uncached.

## Real evidence

A live `gpt-5.6-sol` run through `AiSdkBackend -> ToolRuntime -> maka_computer -> cua-driver -> AppKit AX` attempted a duplicated stale element. Before this fix, the `stale_frame` result was recorded as telemetry success and the model could retry after another observation. The real run remained safe (zero model dispatch and zero target mutation), but the Runtime accounting and retry control were wrong.

## Verification

- Runtime full suite: 1499 pass, 7 skip, 0 fail.
- Full repository build and typecheck pass.
- Focused loop-gate and Computer Use tests cover returned-error classification and ambiguity gating across changing observation IDs.
- No native executor files are modified.
