### PR TITLE
fix(cu): preserve unknown dispatch outcomes

### DIFF
--- a/packages/runtime/src/__tests__/computer-use-tools.test.ts
+++ b/packages/runtime/src/__tests__/computer-use-tools.test.ts
@@ -1200,6 +1200,67 @@ describe('buildComputerUseTools — the `maka_computer` MakaTool', () => {
     });
   }
 
+  test('generic outcome_unknown remains model-visible while requiring reobserve', async () => {
+    const backend = fakeBackend() as CuDispatchBackend & {
+      observeApp: NonNullable<CuDispatchBackend['observeApp']>;
+    };
+    backend.observeApp = async () => observation();
+    backend.run = async () => ({
+      outcome: {
+        ok: false,
+        error: 'outcome_unknown',
+        message: 'delivery may have occurred',
+      },
+    });
+    const tools = buildComputerUseTools({ backend });
+    const [tool] = tools;
+    const observed = await tool.impl(
+      { action: 'observe', app: 'Fixture' } as never,
+      ctx(),
+    ) as { text: string };
+
+    const result = await tool.impl({
+      action: 'left_click',
+      observation_id: JSON.parse(observed.text).observation_id,
+      coordinate: [25, 30],
+    } as never, ctx()) as { text: string };
+
+    assert.match(result.text, /outcome_unknown/);
+    assert.doesNotMatch(result.text, /failed: reobserve_required/);
+    assert.equal(tools.sessionEvents.snapshot('s1').status, 'reobserve_required');
+  });
+
+  test('semantic outcome_unknown remains model-visible while requiring reobserve', async () => {
+    const backend = fakeBackend() as CuDispatchBackend & {
+      observeApp: NonNullable<CuDispatchBackend['observeApp']>;
+      runSemantic: NonNullable<CuDispatchBackend['runSemantic']>;
+    };
+    backend.observeApp = async () => observation();
+    backend.runSemantic = async () => ({
+      outcome: {
+        ok: false,
+        error: 'outcome_unknown',
+        message: 'semantic delivery may have occurred',
+      },
+    });
+    const tools = buildComputerUseTools({ backend });
+    const [tool] = tools;
+    const observed = await tool.impl(
+      { action: 'observe', app: 'Fixture' } as never,
+      ctx(),
+    ) as { text: string };
+
+    const result = await tool.impl({
+      action: 'click_element',
+      observation_id: JSON.parse(observed.text).observation_id,
+      element_id: '5',
+    } as never, ctx()) as { text: string };
+
+    assert.match(result.text, /outcome_unknown/);
+    assert.doesNotMatch(result.text, /failed: reobserve_required/);
+    assert.equal(tools.sessionEvents.snapshot('s1').status, 'reobserve_required');
+  });
+
   test('a queued keyboard mutation cannot silently target a newer frame', async () => {
     let releaseClick!: () => void;
     const clickGate = new Promise<void>((resolve) => {

--- a/packages/runtime/src/computer-use-tools.ts
+++ b/packages/runtime/src/computer-use-tools.ts
@@ -1368,10 +1368,15 @@ export function buildComputerUseTools(deps: {
             if (!presentation.result) return bindingFailure('capture_failed');
             result = presentation.result;
             applyTypedOutcomeState(state, result.outcome);
-            const postDispatchFailure = validateActionLease(state, actionLease);
-            if (postDispatchFailure) {
-              presentation.finish();
-              return postDispatchFailure;
+            if (result.outcome.ok) {
+              const postDispatchFailure = validateActionLease(
+                state,
+                actionLease,
+              );
+              if (postDispatchFailure) {
+                presentation.finish();
+                return postDispatchFailure;
+              }
             }
           } finally {
             consumeFailure = consumeBoundAction(record, binding);
@@ -1481,7 +1486,7 @@ export function buildComputerUseTools(deps: {
             if (presentation.blocked) return presentation.blocked;
             result = presentation.result;
             if (result) applyTypedOutcomeState(state, result.outcome);
-            if (observationLease?.ok) {
+            if (result?.outcome.ok && observationLease?.ok) {
               const validated = state.validateObservationLease(
                 observationLease.lease,
               );
@@ -1490,7 +1495,7 @@ export function buildComputerUseTools(deps: {
                 return sessionFailure(validated.reason);
               }
             }
-            if (actionLease) {
+            if (result?.outcome.ok && actionLease) {
               const leaseFailure = validateActionLease(state, actionLease);
               if (leaseFailure) {
                 presentation.finish();


### PR DESCRIPTION
## Summary

Follow-up to the non-blocking Runtime finding on merged #911.

- preserve typed backend failures such as `outcome_unknown` after dispatch
- keep the session fenced in `reobserve_required`
- run post-dispatch lease rejection only for backend successes
- cover both generic coordinate and semantic element action paths

## Root cause

`applyTypedOutcomeState()` correctly advanced the session after `outcome_unknown`, but the subsequent old-lease validation replaced the backend result with `reobserve_required`. The state was safe, but the model lost the critical signal that delivery may already have occurred and could retry an action incorrectly.

## Verification

- Runtime typecheck
- focused Computer Use/session-state suite: 69/69
- `git diff --check`
