### PR TITLE
feat: add StepFun Global Step Plan support

### DIFF
--- a/apps/desktop/e2e/providers.spec.ts
+++ b/apps/desktop/e2e/providers.spec.ts
@@ -442,6 +442,7 @@ for (const stepfun of [
   { label: 'StepFun (China)', providerType: 'stepfun', baseUrl: 'https://api.stepfun.com/v1', tab: 'API', model: 'step-3.7-flash' },
   { label: 'StepFun Step Plan (China)', providerType: 'stepfun-step-plan', baseUrl: 'https://api.stepfun.com/step_plan/v1', tab: '模型计划', model: 'step-3.7-flash' },
   { label: 'StepFun (Global)', providerType: 'stepfun-ai', baseUrl: 'https://api.stepfun.ai/v1', tab: 'API', model: 'step-3.7-flash' },
+  { label: 'StepFun Step Plan (Global)', providerType: 'stepfun-ai-step-plan', baseUrl: 'https://api.stepfun.ai/step_plan/v1', tab: '模型计划', model: 'step-3.7-flash' },
 ] as const) test(`adds ${stepfun.label} with its exact snapshot model, API-key field, and shared official mark`, async ({ window: page }) => {
   await page.getByRole('button', { name: '展开侧边栏' }).click();
   await page.getByRole('button', { name: '设置' }).click();

--- a/apps/desktop/src/main/__tests__/icon-governance-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/icon-governance-contract.test.ts
@@ -519,7 +519,7 @@ describe('icon + typography governance contract', () => {
     assert.match(componentSrc, /case 'stepfun':\s*return <ProviderAssetMask src=\{stepfunBrandMark\} \/>/);
     assert.match(
       componentSrc,
-      /case 'stepfun-step-plan':\s*case 'stepfun-ai':\s*case 'stepfun':\s*return <ProviderAssetMask src=\{stepfunBrandMark\} \/>/,
+      /case 'stepfun-ai-step-plan':\s*case 'stepfun-step-plan':\s*case 'stepfun-ai':\s*case 'stepfun':\s*return <ProviderAssetMask src=\{stepfunBrandMark\} \/>/,
       'catalog and detail must route every StepFun access path through the same shared mark and mask seam',
     );
   });

--- a/apps/desktop/src/renderer/settings/provider-brand-marks.tsx
+++ b/apps/desktop/src/renderer/settings/provider-brand-marks.tsx
@@ -328,6 +328,7 @@ export function ProviderBrandMark({ type }: { type: ProviderType }): ReactElemen
     case 'tencent-coding-plan':
     case 'tencent-token-plan':
       return <ProviderAssetMask src={tencentCloudBrandMark} />;
+    case 'stepfun-ai-step-plan':
     case 'stepfun-step-plan':
     case 'stepfun-ai':
     case 'stepfun':

--- a/packages/cli/src/__tests__/connection-target.test.ts
+++ b/packages/cli/src/__tests__/connection-target.test.ts
@@ -120,6 +120,29 @@ describe('default session target resolver', () => {
     assert.equal(target.model, 'step-router-v1');
   });
 
+  test('resolves StepFun Step Plan Global credentials without rewriting the selected model id', async () => {
+    const connection = makeConnection({
+      slug: 'stepfun-ai-step-plan',
+      name: 'StepFun Step Plan (Global)',
+      providerType: 'stepfun-ai-step-plan',
+      defaultModel: 'step-3.5-flash-2603',
+    });
+
+    const target = await resolveDefaultSessionTarget({
+      connectionStore: {
+        getDefault: async () => 'stepfun-ai-step-plan',
+        get: async (slug) => slug === 'stepfun-ai-step-plan' ? connection : null,
+      },
+      credentialStore: {
+        getSecret: async (_slug, kind) => kind === 'api_key' ? 'stepfun-global-step-plan-test-key' : null,
+      },
+    });
+
+    assert.equal(target.connection.providerType, 'stepfun-ai-step-plan');
+    assert.equal(target.apiKey, 'stepfun-global-step-plan-test-key');
+    assert.equal(target.model, 'step-3.5-flash-2603');
+  });
+
   test('resolves StepFun Global credentials without rewriting the selected model id', async () => {
     const connection = makeConnection({
       slug: 'stepfun-ai',

--- a/packages/core/src/__tests__/llm-connections.test.ts
+++ b/packages/core/src/__tests__/llm-connections.test.ts
@@ -52,6 +52,7 @@ describe('provider compatibility contract', () => {
       'tencent-tokenhub',
       'stepfun',
       'stepfun-step-plan',
+      'stepfun-ai-step-plan',
       'stepfun-ai',
       'volcengine-ark',
       'deepinfra',
@@ -96,6 +97,7 @@ describe('provider compatibility contract', () => {
       'deepinfra',
       'cohere',
       'vercel',
+      'stepfun-ai-step-plan',
     ]);
     assert.deepEqual(CATALOG_PROVIDER_TYPES, [
       'kimi-coding-plan',
@@ -130,6 +132,7 @@ describe('provider compatibility contract', () => {
       'deepinfra',
       'cohere',
       'vercel',
+      'stepfun-ai-step-plan',
     ]);
 
     for (const orderField of ['readyOrder', 'catalogOrder', 'recommendedOrder'] as const) {
@@ -528,6 +531,28 @@ describe('provider compatibility contract', () => {
       'step-3.5-flash-2603',
       'step-3.5-flash',
       'step-router-v1',
+    ]);
+  });
+
+  it('owns StepFun Step Plan Global behavior under the stable stepfun-ai-step-plan id', () => {
+    const plan = (PROVIDER_REGISTRY as Partial<Record<string, (typeof PROVIDER_REGISTRY)[keyof typeof PROVIDER_REGISTRY]>>)['stepfun-ai-step-plan'];
+
+    assert.ok(plan, 'StepFun Step Plan Global must have its own persisted provider id');
+    assert.equal(plan.label, 'StepFun Step Plan (Global)');
+    assert.equal(plan.baseUrl, 'https://api.stepfun.ai/step_plan/v1');
+    assert.equal(plan.authKind, 'api_key');
+    assert.equal(plan.protocol, 'openai');
+    assert.deepEqual(plan.runtimeAdapter, { kind: 'openai-compatible', name: 'provider' });
+    assert.deepEqual(plan.modelDiscovery, { kind: 'fallback' });
+    assert.equal(plan.category, 'overseas');
+    assert.equal(plan.catalogGroup, 'plans');
+    assert.equal(plan.catalogBadge, 'Plan');
+    assert.equal(plan.signupUrl, 'https://platform.stepfun.ai/interface-key');
+    assert.equal(plan.modelsDevId, 'stepfun-ai-step-plan');
+    assert.deepEqual(plan.fallbackModels, [
+      'step-3.7-flash',
+      'step-3.5-flash-2603',
+      'step-3.5-flash',
     ]);
   });
 

--- a/packages/core/src/__tests__/model-catalog.test.ts
+++ b/packages/core/src/__tests__/model-catalog.test.ts
@@ -39,6 +39,31 @@ describe('ModelCatalogEntry', () => {
     });
   });
 
+  it('uses the official StepFun Step Plan Global snapshot without inventing live model discovery', () => {
+    const entries = buildConnectionModelCatalogEntries({
+      connection: {
+        slug: 'stepfun-ai-step-plan',
+        providerType: 'stepfun-ai-step-plan',
+        defaultModel: 'step-3.7-flash',
+      },
+    });
+
+    assert.deepEqual(entries.map((entry) => entry.id), [
+      'step-3.7-flash',
+      'step-3.5-flash-2603',
+      'step-3.5-flash',
+    ]);
+    assert.equal(entries[0]?.source, 'static_catalog');
+    assert.equal(entries[0]?.provenance.modelSource, 'fallback');
+    assert.equal(entries[0]?.contextWindow, 256_000);
+    assert.equal(entries[0]?.maxOutputTokens, 256_000);
+    assert.deepEqual(entries[0]?.capabilities, {
+      vision: true,
+      reasoning: true,
+      functionCalling: true,
+    });
+  });
+
   it('uses the checked-in StepFun Global snapshot until account discovery succeeds', () => {
     const entries = buildConnectionModelCatalogEntries({
       connection: {

--- a/packages/core/src/__tests__/model-thinking.test.ts
+++ b/packages/core/src/__tests__/model-thinking.test.ts
@@ -68,6 +68,18 @@ describe('thinkingOptionsForModel', () => {
     assert.equal(thinkingOptionsForModel('stepfun-step-plan', 'step-router-v1'), undefined);
   });
 
+  test('StepFun Step Plan Global declares official effort levels per exact model id', () => {
+    assert.deepEqual(thinkingOptionsForModel('stepfun-ai-step-plan', 'step-3.7-flash'), {
+      efforts: ['low', 'medium', 'high'],
+    });
+    assert.deepEqual(thinkingOptionsForModel('stepfun-ai-step-plan', 'step-3.5-flash-2603'), {
+      efforts: ['low', 'high'],
+    });
+    assert.deepEqual(thinkingOptionsForModel('stepfun-ai-step-plan', 'step-3.5-flash'), {
+      efforts: ['low', 'high'],
+    });
+  });
+
   test('openai gpt-5.5 exposes none/low/medium/high/xhigh; gpt-5 exposes minimal/low/medium/high', () => {
     assert.deepEqual(thinkingOptionsForModel('openai', 'gpt-5.5'), { efforts: ['none', 'low', 'medium', 'high', 'xhigh'] });
     assert.deepEqual(thinkingOptionsForModel('openai', 'gpt-5'), { efforts: ['minimal', 'low', 'medium', 'high'] });

--- a/packages/core/src/__tests__/provider-auth.test.ts
+++ b/packages/core/src/__tests__/provider-auth.test.ts
@@ -100,6 +100,19 @@ describe('ProviderAuth contract', () => {
     expect(contract.actionAvailability.fetch_models).toBe('hidden');
   });
 
+  test('StepFun Step Plan Global uses an independent API-key credential and snapshot-model flow', () => {
+    const contract = deriveProviderAuthContract({
+      providerType: 'stepfun-ai-step-plan',
+      hasSecret: true,
+    });
+
+    expect(contract.providerType).toBe('stepfun-ai-step-plan');
+    expect(contract.setupMode).toBe('api_key');
+    expect(contract.requiresSecret).toBe(true);
+    expect(contract.actionAvailability.test_credentials).toBe('available');
+    expect(contract.actionAvailability.fetch_models).toBe('hidden');
+  });
+
   test('Volcengine Ark China uses the shared API-key credential and snapshot-model flow', () => {
     const contract = deriveProviderAuthContract({
       providerType: 'volcengine-ark',

--- a/packages/core/src/model-metadata.generated.ts
+++ b/packages/core/src/model-metadata.generated.ts
@@ -2,7 +2,7 @@
 // Do not edit by hand; put access-path-specific facts in model-metadata.ts.
 import type { ModelMetadata } from './model-metadata.js';
 
-export const GENERATED_MODELS_DEV_METADATA: Record<"anthropic" | "cerebras" | "cohere" | "deepinfra" | "deepseek" | "fireworks-ai" | "google" | "gemini-cli" | "MiniMax" | "MiniMax-cn" | "mistral" | "moonshot" | "nvidia" | "openai" | "siliconflow" | "stepfun" | "stepfun-ai" | "togetherai" | "tencent-coding-plan" | "tencent-token-plan" | "tencent-tokenhub" | "vercel" | "xai" | "zai-coding-plan", Record<string, ModelMetadata>> = {
+export const GENERATED_MODELS_DEV_METADATA: Record<"anthropic" | "cerebras" | "cohere" | "deepinfra" | "deepseek" | "fireworks-ai" | "google" | "gemini-cli" | "MiniMax" | "MiniMax-cn" | "mistral" | "moonshot" | "nvidia" | "openai" | "siliconflow" | "stepfun" | "stepfun-ai" | "stepfun-ai-step-plan" | "togetherai" | "tencent-coding-plan" | "tencent-token-plan" | "tencent-tokenhub" | "vercel" | "xai" | "zai-coding-plan", Record<string, ModelMetadata>> = {
   "anthropic": {
     "claude-fable-5": {"displayName":"Claude Fable 5","lifecycle":"active","docsUrl":"https://docs.anthropic.com/en/docs/about-claude/models","contextWindow":1000000,"maxOutputTokens":128000,"capabilities":{"vision":true,"reasoning":true,"functionCalling":true}},
     "claude-haiku-4-5": {"displayName":"Claude Haiku 4.5 (latest)","lifecycle":"active","docsUrl":"https://docs.anthropic.com/en/docs/about-claude/models","contextWindow":200000,"maxOutputTokens":64000,"capabilities":{"vision":true,"reasoning":true,"functionCalling":true}},
@@ -432,6 +432,11 @@ export const GENERATED_MODELS_DEV_METADATA: Record<"anthropic" | "cerebras" | "c
     "stepaudio-2.5-asr": {"displayName":"StepAudio 2.5 ASR","lifecycle":"active","docsUrl":"https://platform.stepfun.ai/docs/en/overview/concept","contextWindow":0,"maxOutputTokens":0,"capabilities":{"vision":false,"reasoning":false,"functionCalling":false}},
     "stepaudio-2.5-tts": {"displayName":"StepAudio 2.5 TTS","lifecycle":"active","docsUrl":"https://platform.stepfun.ai/docs/en/overview/concept","contextWindow":0,"maxOutputTokens":0,"capabilities":{"vision":false,"reasoning":false,"functionCalling":false}},
   },
+  "stepfun-ai-step-plan": {
+    "step-3.5-flash": {"displayName":"Step 3.5 Flash","lifecycle":"active","docsUrl":"https://platform.stepfun.ai/docs/en/step-plan/integrations/reasoning-api","contextWindow":256000,"maxOutputTokens":256000,"capabilities":{"vision":false,"reasoning":true,"functionCalling":true}},
+    "step-3.5-flash-2603": {"displayName":"Step 3.5 Flash 2603","lifecycle":"active","docsUrl":"https://platform.stepfun.ai/docs/en/step-plan/integrations/reasoning-api","contextWindow":256000,"maxOutputTokens":256000,"capabilities":{"vision":false,"reasoning":true,"functionCalling":true}},
+    "step-3.7-flash": {"displayName":"Step 3.7 Flash","lifecycle":"active","docsUrl":"https://platform.stepfun.ai/docs/en/step-plan/integrations/reasoning-api","contextWindow":256000,"maxOutputTokens":256000,"capabilities":{"vision":true,"reasoning":true,"functionCalling":true}},
+  },
   "togetherai": {
     "deepcogito/cogito-v2-1-671b": {"displayName":"Cogito v2.1 671B","lifecycle":"active","docsUrl":"https://docs.together.ai/docs/serverless-models","contextWindow":163840,"maxOutputTokens":163840,"capabilities":{"vision":false,"reasoning":true,"functionCalling":false}},
     "deepseek-ai/DeepSeek-R1": {"displayName":"DeepSeek-R1","lifecycle":"deprecated","docsUrl":"https://docs.together.ai/docs/serverless-models","contextWindow":163839,"maxOutputTokens":163839,"capabilities":{"vision":false,"reasoning":true,"functionCalling":false}},
@@ -816,7 +821,7 @@ export const GENERATED_MODELS_DEV_METADATA: Record<"anthropic" | "cerebras" | "c
   },
 };
 
-export const GENERATED_MODELS_DEV_PROVIDER_FACTS: Record<"anthropic" | "cerebras" | "cohere" | "deepinfra" | "deepseek" | "fireworks-ai" | "google" | "gemini-cli" | "MiniMax" | "MiniMax-cn" | "mistral" | "moonshot" | "nvidia" | "openai" | "siliconflow" | "stepfun" | "stepfun-ai" | "togetherai" | "tencent-coding-plan" | "tencent-token-plan" | "tencent-tokenhub" | "vercel" | "xai" | "zai-coding-plan", { id: string; name: string; api?: string; doc: string }> = {
+export const GENERATED_MODELS_DEV_PROVIDER_FACTS: Record<"anthropic" | "cerebras" | "cohere" | "deepinfra" | "deepseek" | "fireworks-ai" | "google" | "gemini-cli" | "MiniMax" | "MiniMax-cn" | "mistral" | "moonshot" | "nvidia" | "openai" | "siliconflow" | "stepfun" | "stepfun-ai" | "stepfun-ai-step-plan" | "togetherai" | "tencent-coding-plan" | "tencent-token-plan" | "tencent-tokenhub" | "vercel" | "xai" | "zai-coding-plan", { id: string; name: string; api?: string; doc: string }> = {
   "anthropic": {"id":"anthropic","name":"Anthropic","doc":"https://docs.anthropic.com/en/docs/about-claude/models"},
   "cerebras": {"id":"cerebras","name":"Cerebras","doc":"https://inference-docs.cerebras.ai/models/overview"},
   "cohere": {"id":"cohere","name":"Cohere","doc":"https://docs.cohere.com/docs/models"},
@@ -834,6 +839,7 @@ export const GENERATED_MODELS_DEV_PROVIDER_FACTS: Record<"anthropic" | "cerebras
   "siliconflow": {"id":"siliconflow","name":"SiliconFlow","api":"https://api.siliconflow.com/v1","doc":"https://cloud.siliconflow.com/models"},
   "stepfun": {"id":"stepfun","name":"StepFun (China)","api":"https://api.stepfun.com/v1","doc":"https://platform.stepfun.com/docs/zh/overview/concept"},
   "stepfun-ai": {"id":"stepfun-ai","name":"StepFun (Global)","api":"https://api.stepfun.ai/v1","doc":"https://platform.stepfun.ai/docs/en/overview/concept"},
+  "stepfun-ai-step-plan": {"id":"stepfun-ai-step-plan","name":"StepFun Step Plan (Global)","api":"https://api.stepfun.ai/step_plan/v1","doc":"https://platform.stepfun.ai/docs/en/step-plan/integrations/reasoning-api"},
   "togetherai": {"id":"togetherai","name":"Together AI","doc":"https://docs.together.ai/docs/serverless-models"},
   "tencent-coding-plan": {"id":"tencent-coding-plan","name":"Tencent Coding Plan (China)","api":"https://api.lkeap.cloud.tencent.com/coding/v3","doc":"https://cloud.tencent.com/document/product/1772/128947"},
   "tencent-token-plan": {"id":"tencent-token-plan","name":"Tencent Token Plan","api":"https://api.lkeap.cloud.tencent.com/plan/v3","doc":"https://cloud.tencent.com/document/product/1823/130060"},

--- a/packages/core/src/model-metadata.ts
+++ b/packages/core/src/model-metadata.ts
@@ -143,6 +143,11 @@ const STATIC_MODEL_METADATA: Partial<Record<ProviderType, Record<string, ModelMe
       capabilities: { vision: false, reasoning: true, functionCalling: true },
     },
   },
+  'stepfun-ai-step-plan': {
+    'step-3.7-flash': { thinkingOptions: { efforts: ['low', 'medium', 'high'] } },
+    'step-3.5-flash-2603': { thinkingOptions: { efforts: ['low', 'high'] } },
+    'step-3.5-flash': { thinkingOptions: { efforts: ['low', 'high'] } },
+  },
   'claude-subscription': CLAUDE_SUBSCRIPTION_MODEL_METADATA,
   openai: OPENAI_MODEL_OVERRIDES,
   google: GOOGLE_MODEL_OVERRIDES,

--- a/packages/core/src/provider-registry.ts
+++ b/packages/core/src/provider-registry.ts
@@ -196,6 +196,23 @@ for (const id of stepfunGlobalModelIds) {
     throw new Error(`models.dev StepFun Global snapshot is missing documented tool-capable model ${id}`);
   }
 }
+const stepfunGlobalStepPlan = GENERATED_MODELS_DEV_PROVIDER_FACTS['stepfun-ai-step-plan'];
+if (stepfunGlobalStepPlan.id !== 'stepfun-ai-step-plan') {
+  throw new Error('models.dev StepFun Global Step Plan provider facts are missing stable id stepfun-ai-step-plan');
+}
+if (!stepfunGlobalStepPlan.api) {
+  throw new Error('models.dev StepFun Global Step Plan provider facts are missing api');
+}
+const stepfunGlobalStepPlanModelIds = [
+  'step-3.7-flash',
+  'step-3.5-flash-2603',
+  'step-3.5-flash',
+] as const;
+for (const id of stepfunGlobalStepPlanModelIds) {
+  if (!GENERATED_MODELS_DEV_METADATA['stepfun-ai-step-plan'][id]?.capabilities?.functionCalling) {
+    throw new Error(`models.dev StepFun Global Step Plan snapshot is missing documented tool-capable model ${id}`);
+  }
+}
 
 const together = GENERATED_MODELS_DEV_PROVIDER_FACTS.togetherai;
 if (together.id !== 'togetherai') {
@@ -725,6 +742,25 @@ const providerRegistry = {
     modelsDevId: stepfun.id,
     readyOrder: 28,
     catalogOrder: 28,
+  },
+  'stepfun-ai-step-plan': {
+    label: stepfunGlobalStepPlan.name,
+    description: 'StepFun Global subscription access for interactive coding and agent tools.',
+    baseUrl: stepfunGlobalStepPlan.api,
+    authKind: 'api_key',
+    backendKind: 'ai-sdk',
+    fallbackModels: [...stepfunGlobalStepPlanModelIds],
+    status: 'ready',
+    protocol: 'openai',
+    runtimeAdapter: { kind: 'openai-compatible', name: 'provider' },
+    modelDiscovery: { kind: 'fallback' },
+    category: 'overseas',
+    catalogGroup: 'plans',
+    catalogBadge: 'Plan',
+    signupUrl: 'https://platform.stepfun.ai/interface-key',
+    modelsDevId: stepfunGlobalStepPlan.id,
+    readyOrder: 32,
+    catalogOrder: 32,
   },
   'stepfun-ai': {
     label: stepfunGlobal.name,

--- a/packages/headless/src/__tests__/harbor-cell.test.ts
+++ b/packages/headless/src/__tests__/harbor-cell.test.ts
@@ -2438,6 +2438,40 @@ setTimeout(() => {
     assert.equal(missing.apiKey, '');
   });
 
+  test('resolves StepFun Step Plan Global only from its independent credential env', () => {
+    const resolved = resolveHarborCellAiSdkEnv({
+      provider: 'stepfun-ai-step-plan',
+      model: 'step-3.5-flash-2603',
+      env: {
+        STEPFUN_AI_STEP_PLAN_API_KEY: 'stepfun-global-step-plan-key',
+        STEPFUN_AI_STEP_PLAN_BASE_URL: 'https://api.stepfun.ai/step_plan/v1',
+        STEPFUN_AI_API_KEY: 'global-direct-key-must-not-cross',
+        STEPFUN_STEP_PLAN_API_KEY: 'china-plan-key-must-not-cross',
+        STEPFUN_API_KEY: 'china-direct-key-must-not-cross',
+        OPENAI_API_KEY: 'openai-key-must-not-cross',
+      },
+      ts: 1,
+    });
+
+    assert.equal(resolved.apiKey, 'stepfun-global-step-plan-key');
+    assert.equal(resolved.connection.providerType, 'stepfun-ai-step-plan');
+    assert.equal(resolved.connection.defaultModel, 'step-3.5-flash-2603');
+    assert.equal(resolved.connection.baseUrl, 'https://api.stepfun.ai/step_plan/v1');
+
+    const missing = resolveHarborCellAiSdkEnv({
+      provider: 'stepfun-ai-step-plan',
+      model: 'step-3.5-flash-2603',
+      env: {
+        STEPFUN_AI_API_KEY: 'global-direct-key-must-not-cross',
+        STEPFUN_STEP_PLAN_API_KEY: 'china-plan-key-must-not-cross',
+        STEPFUN_API_KEY: 'china-direct-key-must-not-cross',
+        OPENAI_API_KEY: 'openai-key-must-not-cross',
+      },
+      ts: 1,
+    });
+    assert.equal(missing.apiKey, '');
+  });
+
   test('resolves StepFun Global only from its independent direct API credential env', () => {
     const resolved = resolveHarborCellAiSdkEnv({
       provider: 'stepfun-ai',

--- a/packages/headless/src/__tests__/provider-env.test.ts
+++ b/packages/headless/src/__tests__/provider-env.test.ts
@@ -127,6 +127,14 @@ test('StepFun Step Plan China uses an independent credential namespace', () => {
   });
 });
 
+test('StepFun Step Plan Global uses an independent credential namespace', () => {
+  assert.deepEqual(providerCredentialEnv('stepfun-ai-step-plan'), {
+    apiKeys: ['STEPFUN_AI_STEP_PLAN_API_KEY'],
+    apiKeyFile: 'STEPFUN_AI_STEP_PLAN_API_KEY_FILE',
+    baseUrls: ['STEPFUN_AI_STEP_PLAN_BASE_URL'],
+  });
+});
+
 test('StepFun Global keeps direct API credentials separate from China and plan identities', () => {
   assert.deepEqual(providerCredentialEnv('stepfun-ai'), {
     apiKeys: ['STEPFUN_AI_API_KEY'],

--- a/packages/headless/src/provider-env.ts
+++ b/packages/headless/src/provider-env.ts
@@ -31,6 +31,7 @@ const PROVIDER_CREDENTIAL_ENV = {
   stepfun: env('STEPFUN', ['STEPFUN_BASE_URL']),
   'stepfun-step-plan': env('STEPFUN_STEP_PLAN', ['STEPFUN_STEP_PLAN_BASE_URL']),
   'stepfun-ai': env('STEPFUN_AI', ['STEPFUN_AI_BASE_URL']),
+  'stepfun-ai-step-plan': env('STEPFUN_AI_STEP_PLAN', ['STEPFUN_AI_STEP_PLAN_BASE_URL']),
   'volcengine-ark': env('ARK', ['ARK_BASE_URL']),
   localai: env('LOCALAI', ['LOCALAI_BASE_URL']),
   'openai-compatible': env('OPENAI', ['OPENAI_BASE_URL']),

--- a/packages/runtime/src/__tests__/model-factory-thinking.test.ts
+++ b/packages/runtime/src/__tests__/model-factory-thinking.test.ts
@@ -87,6 +87,18 @@ describe('buildProviderOptions: thinking level', () => {
     assert.deepEqual(buildProviderOptions(conn('stepfun-step-plan'), 'step-router-v1', 'high'), {});
   });
 
+  test('StepFun Step Plan Global sends only officially supported reasoning effort levels', () => {
+    assert.deepEqual(
+      buildProviderOptions(conn('stepfun-ai-step-plan'), 'step-3.7-flash', 'medium'),
+      { 'stepfun-ai-step-plan': { reasoningEffort: 'medium' } },
+    );
+    assert.deepEqual(
+      buildProviderOptions(conn('stepfun-ai-step-plan'), 'step-3.5-flash-2603', 'low'),
+      { 'stepfun-ai-step-plan': { reasoningEffort: 'low' } },
+    );
+    assert.deepEqual(buildProviderOptions(conn('stepfun-ai-step-plan'), 'step-3.5-flash', 'medium'), {});
+  });
+
   test('Volcengine Ark sends its official thinking object and optional reasoning effort', () => {
     const modelId = 'doubao-seed-2-0-pro-260215';
     assert.deepEqual([...thinkingVariantsForModel('volcengine-ark', modelId)], ['off', 'minimal', 'low', 'medium', 'high']);

--- a/packages/runtime/src/__tests__/provider-conformance.test.ts
+++ b/packages/runtime/src/__tests__/provider-conformance.test.ts
@@ -1901,11 +1901,26 @@ describe('models.dev provider conformance', () => {
     assert.equal(result.text, 'Echoed hello.');
   });
 
-  test('StepFun Step Plan China preserves its snapshot model through the documented two-stage tool-call loop', async () => {
+  for (const stepfunPlan of [
+    {
+      label: 'China',
+      providerType: 'stepfun-step-plan',
+      name: 'StepFun Step Plan (China)',
+      apiKey: 'stepfun-step-plan-test-key',
+      models: ['step-3.7-flash', 'step-3.5-flash-2603', 'step-3.5-flash', 'step-router-v1'],
+    },
+    {
+      label: 'Global',
+      providerType: 'stepfun-ai-step-plan',
+      name: 'StepFun Step Plan (Global)',
+      apiKey: 'stepfun-global-step-plan-test-key',
+      models: ['step-3.7-flash', 'step-3.5-flash-2603', 'step-3.5-flash'],
+    },
+  ] as const) test(`StepFun Step Plan ${stepfunPlan.label} preserves its snapshot model through the documented two-stage tool-call loop`, async () => {
     const modelId = 'step-3.7-flash';
     const requestBodies: Array<Record<string, unknown>> = [];
     const server = await startJsonServer(async (request, response) => {
-      assert.equal(request.headers.authorization, 'Bearer stepfun-step-plan-test-key');
+      assert.equal(request.headers.authorization, `Bearer ${stepfunPlan.apiKey}`);
       assert.equal(request.method, 'POST');
       assert.equal(request.url, '/step_plan/v1/chat/completions');
       const body = JSON.parse(await readBody(request)) as Record<string, unknown>;
@@ -1949,9 +1964,9 @@ describe('models.dev provider conformance', () => {
       });
     });
     const connection: LlmConnection = {
-      slug: 'stepfun-step-plan',
-      name: 'StepFun Step Plan (China)',
-      providerType: 'stepfun-step-plan',
+      slug: stepfunPlan.providerType,
+      name: stepfunPlan.name,
+      providerType: stepfunPlan.providerType,
       baseUrl: `${server.url}/step_plan/v1`,
       defaultModel: modelId,
       enabled: true,
@@ -1959,16 +1974,11 @@ describe('models.dev provider conformance', () => {
       updatedAt: 1,
     };
 
-    const models = await fetchProviderModels(connection, 'stepfun-step-plan-test-key');
-    assert.deepEqual(models.map((model) => model.id), [
-      'step-3.7-flash',
-      'step-3.5-flash-2603',
-      'step-3.5-flash',
-      'step-router-v1',
-    ]);
+    const models = await fetchProviderModels(connection, stepfunPlan.apiKey);
+    assert.deepEqual(models.map((model) => model.id), [...stepfunPlan.models]);
 
     const result = await generateText({
-      model: getAIModel({ connection, apiKey: 'stepfun-step-plan-test-key', modelId: models[0]!.id }),
+      model: getAIModel({ connection, apiKey: stepfunPlan.apiKey, modelId: models[0]!.id }),
       prompt: 'Call echo with hello.',
       stopWhen: stepCountIs(2),
       tools: {

--- a/packages/runtime/src/model-factory.ts
+++ b/packages/runtime/src/model-factory.ts
@@ -173,6 +173,7 @@ export function buildProviderOptions(
     case 'tencent-token-plan':
     case 'zai-coding-plan':
     case 'stepfun-step-plan':
+    case 'stepfun-ai-step-plan':
       return level && level !== 'off'
         ? { [openaiCompatibleNamespace(connection.providerType)]: { reasoningEffort: level } }
         : {};

--- a/packages/storage/src/__tests__/connection-store.test.ts
+++ b/packages/storage/src/__tests__/connection-store.test.ts
@@ -178,6 +178,23 @@ describe('FileConnectionStore', () => {
     });
   });
 
+  test('persists the StepFun Step Plan Global provider id and exact default model', async () => {
+    await withConnectionStore(async (store, dir) => {
+      await store.create({
+        slug: 'stepfun-ai-step-plan',
+        name: 'StepFun Step Plan (Global)',
+        providerType: 'stepfun-ai-step-plan',
+        defaultModel: 'step-3.5-flash-2603',
+      });
+
+      const persisted = JSON.parse(await readFile(join(dir, 'llm-connections.json'), 'utf8')) as {
+        connections: Array<{ providerType: string; defaultModel: string }>;
+      };
+      assert.equal(persisted.connections[0]?.providerType, 'stepfun-ai-step-plan');
+      assert.equal(persisted.connections[0]?.defaultModel, 'step-3.5-flash-2603');
+    });
+  });
+
   test('persists the StepFun Global provider id and exact default model', async () => {
     await withConnectionStore(async (store, dir) => {
       await store.create({

--- a/scripts/sync-model-metadata.mjs
+++ b/scripts/sync-model-metadata.mjs
@@ -20,6 +20,7 @@ const PROVIDERS = {
   siliconflow: 'siliconflow',
   stepfun: 'stepfun',
   'stepfun-ai': 'stepfun-ai',
+  'stepfun-ai-step-plan': 'stepfun-ai-step-plan',
   togetherai: 'togetherai',
   'tencent-coding-plan': 'tencent-coding-plan',
   'tencent-token-plan': 'tencent-token-plan',

--- a/scripts/sync-model-metadata.test.mjs
+++ b/scripts/sync-model-metadata.test.mjs
@@ -7,7 +7,7 @@ import { promisify } from 'node:util';
 import test from 'node:test';
 
 const execFileAsync = promisify(execFile);
-const PROVIDER_IDS = ['anthropic', 'cerebras', 'cohere', 'deepinfra', 'deepseek', 'fireworks-ai', 'google', 'minimax', 'minimax-cn', 'mistral', 'moonshotai-cn', 'nvidia', 'openai', 'siliconflow', 'stepfun', 'stepfun-ai', 'tencent-coding-plan', 'tencent-token-plan', 'tencent-tokenhub', 'togetherai', 'vercel', 'xai', 'zai-coding-plan'];
+const PROVIDER_IDS = ['anthropic', 'cerebras', 'cohere', 'deepinfra', 'deepseek', 'fireworks-ai', 'google', 'minimax', 'minimax-cn', 'mistral', 'moonshotai-cn', 'nvidia', 'openai', 'siliconflow', 'stepfun', 'stepfun-ai', 'stepfun-ai-step-plan', 'tencent-coding-plan', 'tencent-token-plan', 'tencent-tokenhub', 'togetherai', 'vercel', 'xai', 'zai-coding-plan'];
 
 function withRequiredProviders(openai) {
   return Object.fromEntries(PROVIDER_IDS.map((id) => {
@@ -504,6 +504,48 @@ test('sync-model-metadata vendors StepFun Global direct provider facts and exact
   assert.match(generated, /"stepfun-ai": \{/);
   assert.match(generated, /"stepfun-ai": \{"id":"stepfun-ai","name":"StepFun \(Global\)","api":"https:\/\/api\.stepfun\.ai\/v1"/);
   assert.match(generated, /"step-3\.5-flash": \{"displayName":"Step 3\.5 Flash"/);
+  assert.match(generated, /"step-3\.7-flash": \{"displayName":"Step 3\.7 Flash"/);
+});
+
+test('sync-model-metadata vendors StepFun Global Step Plan provider facts and exact model ids', async () => {
+  const directory = await mkdtemp(join(tmpdir(), 'maka-model-metadata-'));
+  const input = join(directory, 'api.json');
+  const output = join(directory, 'generated.ts');
+  const catalog = withRequiredProviders({});
+  catalog['stepfun-ai-step-plan'] = {
+    id: 'stepfun-ai-step-plan',
+    name: 'StepFun Step Plan (Global)',
+    api: 'https://api.stepfun.ai/step_plan/v1',
+    doc: 'https://platform.stepfun.ai/docs/en/step-plan/integrations/reasoning-api',
+    models: {
+      'step-3.5-flash': {
+        id: 'step-3.5-flash', name: 'Step 3.5 Flash', reasoning: true, tool_call: true,
+        modalities: { input: ['text'], output: ['text'] },
+        limit: { context: 256_000, output: 256_000 },
+      },
+      'step-3.5-flash-2603': {
+        id: 'step-3.5-flash-2603', name: 'Step 3.5 Flash 2603', reasoning: true, tool_call: true,
+        modalities: { input: ['text'], output: ['text'] },
+        limit: { context: 256_000, output: 256_000 },
+      },
+      'step-3.7-flash': {
+        id: 'step-3.7-flash', name: 'Step 3.7 Flash', reasoning: true, tool_call: true,
+        modalities: { input: ['text', 'image', 'video'], output: ['text'] },
+        limit: { context: 256_000, output: 256_000 },
+      },
+    },
+  };
+  await writeFile(input, JSON.stringify(catalog));
+
+  await execFileAsync(process.execPath, [
+    'scripts/sync-model-metadata.mjs', '--input', input, '--output', output,
+  ]);
+
+  const generated = await readFile(output, 'utf8');
+  assert.match(generated, /"stepfun-ai-step-plan": \{/);
+  assert.match(generated, /"stepfun-ai-step-plan": \{"id":"stepfun-ai-step-plan","name":"StepFun Step Plan \(Global\)","api":"https:\/\/api\.stepfun\.ai\/step_plan\/v1"/);
+  assert.match(generated, /"step-3\.5-flash": \{"displayName":"Step 3\.5 Flash"/);
+  assert.match(generated, /"step-3\.5-flash-2603": \{"displayName":"Step 3\.5 Flash 2603"/);
   assert.match(generated, /"step-3\.7-flash": \{"displayName":"Step 3\.7 Flash"/);
 });
 


### PR DESCRIPTION
## Summary

- Add StepFun Step Plan (Global) as the independent persisted provider `stepfun-ai-step-plan`.
- Wire its official Global endpoint, snapshot model catalog, reasoning efforts, deterministic tool-call path, credentials, persistence, CLI/headless, and Desktop catalog/brand seams.
- Reuse the existing byte-identical StepFun SVG, shared `ProviderAssetMask`, and third-party notice without vendoring another asset.

## Why

Issue #860 Phase 4 needs a Global Step Plan slice that remains distinct from the China Step Plan and both direct API providers. The Global plan uses its own `.ai` account, key namespace, and `https://api.stepfun.ai/step_plan/v1` endpoint. Its public contract does not promise a `/models` endpoint, so this change uses an explicit snapshot allowlist instead of guessing discovery parity with another StepFun product.

Refs #860.

## Scope

This PR adds only `stepfun-ai-step-plan`. It does not change `stepfun-step-plan`, `stepfun-ai`, `stepfun`, any other provider, or Phase 7 behavior. The allowlist is exactly `step-3.7-flash`, `step-3.5-flash-2603`, and `step-3.5-flash`; Global Step Plan is the unique ready/catalog order 32 after Vercel order 31.

## Verification

- `npm run test:scripts` — 58/58 passed.
- `npm --workspace @maka/core test` — 906/906 passed.
- `npm --workspace @maka/runtime test` — 1,516 passed, 0 failed, 7 skipped.
- `npm --workspace @maka/storage test` — 255/255 passed.
- `npm --workspace @maka/headless test` — 886/886 passed.
- `npm --workspace maka-agent test` — 326/326 passed.
- `npm --workspace @maka/desktop test` — 2,471/2,471 passed.
- Targeted stable-ID, model-effort, provider-options, and deterministic two-stage tool-call tests — 4/4 passed.
- `npm run typecheck` passed for every workspace.
- `npm --workspace @maka/desktop run build:renderer` passed; the third-party-notice checker confirmed a byte-identical public notice.
- `npm run check:stale` and `git diff --check origin/main...HEAD` passed.
- `git merge-tree --write-tree HEAD origin/main` passed against #924 with no conflict.
- Existing StepFun SVG matches origin/main and its recorded provenance at SHA-256 `f46fbd1eee00a3dc7874395484bcc3e25a803e9eb4b79f07b7eec377a1e2f25c`; neither the SVG nor `THIRD_PARTY_LICENSES.txt` is in this diff.
- Named reviewer audited the final SHA and reported 0 findings.

No real-provider smoke was run: no authorized StepFun Global Step Plan credential was available, and the subscription is documented for interactive coding/agent use. The runtime behavior is covered by a local deterministic two-request mock server that asserts Bearer auth, the exact `/step_plan/v1/chat/completions` path, reasoning wire data, tool execution, and tool-result round-trip without logging secrets or raw responses.

Static screenshots are not applicable: this adds a provider entry while deliberately reusing the already-shipped StepFun mark and existing catalog/detail components. Desktop provider E2E coverage and the shared-brand governance contract are the substitute UI evidence.

## Impact

Users can configure and persist a StepFun Global Step Plan connection across Desktop, CLI, storage, and headless integrations. Headless callers may use the independent `STEPFUN_AI_STEP_PLAN_API_KEY`, `STEPFUN_AI_STEP_PLAN_API_KEY_FILE`, and `STEPFUN_AI_STEP_PLAN_BASE_URL` variables. There is no migration: existing provider IDs and connections remain unchanged. Release notes should mention the new provider option; no separate documentation change is required because the catalog exposes the official signup and model facts.

## Reviewer notes

Please focus on the independent provider boundary, the honest snapshot fallback, and the shared-brand route. The four commits are independently revertible by intent: registry/facts, runtime/thinking, host/persistence, and Desktop brand wiring.

## Ready for review

- [x] Verification is complete and the results above are current
- [x] Impact, compatibility, migration, documentation, and release-note needs are addressed
- [x] User-visible UI/UX changes include visual evidence, or `Verification` explains why it is not applicable
