### PR TITLE
fix(cu): require observed Electron page identity

### DIFF
--- a/packages/computer-use/src/__tests__/cua-driver-backend.test.ts
+++ b/packages/computer-use/src/__tests__/cua-driver-backend.test.ts
@@ -1297,6 +1297,35 @@ describe('cua-driver backend', () => {
     assert.equal(toolCalls(records, 'click').length, 0);
   });
 
+  it('rejects a bound Electron action when the observation had no page identity', async () => {
+    const { backend, logPath } = makeBackend({
+      processKind: 'electron',
+      pageTarget: testPageTarget(),
+      semanticPointerResult: {
+        supported: true,
+        ok: true,
+        kind: 'left_click',
+        clickEvents: 1,
+      },
+    });
+    const result = await backend.run(
+      { type: 'left_click', coordinate: { x: 400, y: 200 } } as CuAction,
+      new AbortController().signal,
+      {
+        ...DEFAULT_RUN_CONTEXT,
+        boundAction: boundCoordinateAction(),
+      },
+    );
+
+    assert.equal(result.outcome.ok, false);
+    if (!result.outcome.ok) {
+      assert.equal(result.outcome.error, 'page_target_changed');
+    }
+    const records = await readRecords(logPath);
+    assert.equal(businessPageCalls(records).length, 0);
+    assert.equal(toolCalls(records, 'click').length, 0);
+  });
+
   it('rejects a replaced Electron document with the same target id and URL', async () => {
     let reads = 0;
     const pageTarget = testPageTarget();

--- a/packages/computer-use/src/cua-driver-backend.ts
+++ b/packages/computer-use/src/cua-driver-backend.ts
@@ -1674,6 +1674,7 @@ export function createCuaDriverBackend(opts: CuaDriverBackendOptions): CuDispatc
     signal: AbortSignal,
     toolCallId: string,
     boundPage?: ComputerUsePageIdentity,
+    requireBoundPage = false,
   ): Promise<{
     handled: boolean;
     outcome?: CuRunResult['outcome'];
@@ -1682,6 +1683,16 @@ export function createCuaDriverBackend(opts: CuaDriverBackendOptions): CuDispatc
   }> {
     const processKind = await (opts.classifyProcess ?? classifyMacProcess)(window.pid);
     if (processKind !== 'electron') return { handled: false };
+    if (requireBoundPage && !boundPage) {
+      return {
+        handled: true,
+        outcome: {
+          ok: false,
+          error: 'page_target_changed',
+          message: 'bound Electron action is missing observed page identity',
+        },
+      };
+    }
     const resolvePageTextTarget = opts.resolvePageTextTarget ?? ((input) =>
       resolveCuaPageTextTarget(input));
     const pageTarget = await resolvePageTextTarget({
@@ -2112,6 +2123,7 @@ export function createCuaDriverBackend(opts: CuaDriverBackendOptions): CuDispatc
               signal,
               context.toolCallId,
               context.boundAction?.target?.page,
+              context.boundAction?.target !== undefined,
             );
             if (semantic.handled && semantic.outcome) {
               if (
@@ -2359,6 +2371,7 @@ export function createCuaDriverBackend(opts: CuaDriverBackendOptions): CuDispatc
             signal,
             context.toolCallId,
             context.boundAction?.target?.page,
+            context.boundAction?.target !== undefined,
           );
           if (semantic.handled && semantic.outcome) {
             return { outcome: semantic.outcome, resolvedScreenPoint: to.screenPoint };


### PR DESCRIPTION
## Summary
- fail closed when a bound Electron pointer or drag action has no page identity from its observation
- keep unbound direct backend calls compatible with existing behavior
- prevent both semantic page dispatch and pixel fallback in the missing-identity case

## Verification
- `npm --workspace @maka/computer-use test` (128/128 passing)
- `git diff --check`