### PR TITLE
fix(cu): revalidate native keyboard targets

### DIFF
--- a/packages/computer-use/src/__tests__/cua-driver-backend.test.ts
+++ b/packages/computer-use/src/__tests__/cua-driver-backend.test.ts
@@ -1954,6 +1954,37 @@ describe('cua-driver backend', () => {
     assert.ok(!methodTrace(records).includes('tools/call:list_apps'), 'must never resolve a frontmost pid to type into');
   });
 
+  it('refetches the clicked editable field by identity after layout reflow', async () => {
+    const { backend, logPath } = makeBackend({ refetchMode: 'moved' });
+    const sig = new AbortController().signal;
+    const click = await backend.run(
+      { type: 'left_click', coordinate: { x: 600, y: 400 } } as CuAction,
+      sig,
+    );
+    assert.equal(click.outcome.ok, true);
+
+    const typed = await backend.run({ type: 'type', text: 'after reflow' } as CuAction, sig);
+    assert.equal(typed.outcome.ok, true);
+
+    const call = toolCall(await readRecords(logPath), 'set_value');
+    assert.equal(call?.element_index, 9);
+    assert.equal(call?.element_token, 'snapshot:9');
+  });
+
+  it('refuses native text when the clicked editable identity becomes ambiguous', async () => {
+    const { backend, logPath } = makeBackend({ refetchMode: 'ambiguous' });
+    const sig = new AbortController().signal;
+    const click = await backend.run(
+      { type: 'left_click', coordinate: { x: 600, y: 400 } } as CuAction,
+      sig,
+    );
+    assert.equal(click.outcome.ok, true);
+
+    const typed = await backend.run({ type: 'type', text: 'must-not-land' } as CuAction, sig);
+    assert.equal(typed.outcome.ok, false);
+    assert.equal(toolCalls(await readRecords(logPath), 'set_value').length, 0);
+  });
+
   it('parallel click then type waits for the new click target instead of using the old window', async () => {
     const { backend, logPath } = makeBackend({ delayTool: 'click', delayMs: 120 });
     const sig = new AbortController().signal;

--- a/packages/computer-use/src/cua-driver-backend.ts
+++ b/packages/computer-use/src/cua-driver-backend.ts
@@ -298,6 +298,11 @@ export function createCuaDriverBackend(opts: CuaDriverBackendOptions): CuDispatc
   interface KeyboardTarget {
     window: CuaResolvedWindow;
     editable: boolean;
+    nativeEditableIdentity?: {
+      role: string;
+      label?: string;
+      value?: string;
+    };
     pageTarget?: CuaResolvedPageTextTarget;
   }
   const targetsBySession = new Map<string, { turnId: string; target: KeyboardTarget }>();
@@ -1505,13 +1510,34 @@ export function createCuaDriverBackend(opts: CuaDriverBackendOptions): CuDispatc
         message: 'background text input requires an AX-addressable editable field',
       };
     }
+    const identity = target.nativeEditableIdentity;
+    if (!identity) {
+      return {
+        ok: false,
+        error: 'unsupported_action',
+        message: 'background text input requires the clicked editable field identity',
+      };
+    }
+    const resolveEditable = (elements: readonly CuaSnapshotElement[]) => {
+      const matches = elements.flatMap((candidate) => {
+        const element = normalizeCuaSnapshotElement(candidate);
+        if (
+          !element
+          || element.role !== identity.role
+          || element.label !== identity.label
+          || element.value !== identity.value
+        ) return [];
+        return [element];
+      });
+      return matches.length === 1 ? matches[0] : undefined;
+    };
     const snapshot = await snapshotTarget(target.window, signal);
-    const element = editableElementAtScreenPoint(snapshot.elements, target.window.screenPoint);
+    const element = resolveEditable(snapshot.elements);
     if (!element) {
       return {
         ok: false,
         error: 'unsupported_action',
-        message: 'editable field was not present in the fresh AX snapshot',
+        message: 'clicked editable field was missing or ambiguous in the fresh AX snapshot',
       };
     }
     if (element.value && element.value !== text) {
@@ -1544,10 +1570,17 @@ export function createCuaDriverBackend(opts: CuaDriverBackendOptions): CuDispatc
     );
     if (setResult?.isError) return normalizeCuaDriverOutcome(setResult);
     const after = await snapshotTarget(target.window, signal);
-    const verified = editableElementAtScreenPoint(
-      after.elements,
-      target.window.screenPoint,
-    )?.value === text;
+    const verifiedMatches = after.elements.flatMap((candidate) => {
+      const current = normalizeCuaSnapshotElement(candidate);
+      if (
+        !current
+        || current.role !== identity.role
+        || current.label !== identity.label
+        || current.value !== text
+      ) return [];
+      return [current];
+    });
+    const verified = verifiedMatches.length === 1;
     return verified
       ? {
           ok: true,
@@ -2235,6 +2268,19 @@ export function createCuaDriverBackend(opts: CuaDriverBackendOptions): CuDispatc
                 target: {
                   window: win,
                   editable: editableElement !== undefined,
+                  ...(editableElement
+                    ? {
+                        nativeEditableIdentity: {
+                          role: editableElement.role,
+                          ...(editableElement.label === undefined
+                            ? {}
+                            : { label: editableElement.label }),
+                          ...(editableElement.value === undefined
+                            ? {}
+                            : { value: editableElement.value }),
+                        },
+                      }
+                    : {}),
                 },
               });
             }


### PR DESCRIPTION
## Summary
- retain the clicked native editable field identity instead of reusing its old screen coordinate
- uniquely refetch the same AX field before `set_value`, so layout reflow cannot redirect text to another field
- fail closed when the original field is missing or ambiguous, and verify the write against a fresh identity match

Electron text identity is intentionally unchanged; stable DOM-local identity needs a separate protocol extension.

## Verification
- built `@maka/core`, `@maka/storage`, and `@maka/runtime` serially
- `npm --workspace @maka/computer-use test` (129/129 passing)
- `git diff --check`