### PR TITLE
fix(cu): bind Electron text to clicked element

### DIFF
--- a/packages/computer-use/src/__tests__/cua-driver-backend.test.ts
+++ b/packages/computer-use/src/__tests__/cua-driver-backend.test.ts
@@ -331,6 +331,7 @@ function handle(msg) {
                   : PAGE_FIELD_VALUE,
                 tagName: 'textarea',
                 inputType: '',
+                elementToken: 'element-1',
               })
             : PAGE_EXEC_RESULT
           : 'inserted through CDP';
@@ -2055,6 +2056,7 @@ describe('cua-driver backend', () => {
         kind: 'left_click',
         editable: true,
         tagName: 'textarea',
+        elementToken: 'element-1',
         clickEvents: 1,
       },
     });
@@ -2240,6 +2242,7 @@ describe('cua-driver backend', () => {
         kind: 'left_click',
         editable: true,
         tagName: 'textarea',
+        elementToken: 'element-1',
         clickEvents: 1,
       },
     });
@@ -2265,6 +2268,7 @@ describe('cua-driver backend', () => {
         kind: 'left_click',
         editable: true,
         tagName: 'textarea',
+        elementToken: 'element-1',
         clickEvents: 1,
       },
     });
@@ -2282,6 +2286,32 @@ describe('cua-driver backend', () => {
       'insert_text',
       'execute_javascript',
     ]);
+  });
+
+  it('refuses Electron text ownership when the semantic click has no DOM element token', async () => {
+    const { backend, logPath } = makeBackend({
+      processKind: 'electron',
+      pageTarget: testPageTarget(),
+      emptyAx: true,
+      semanticPointerResult: {
+        supported: true,
+        ok: true,
+        kind: 'left_click',
+        editable: true,
+        tagName: 'textarea',
+        clickEvents: 1,
+      },
+    });
+    const signal = new AbortController().signal;
+    const click = await backend.run(
+      { type: 'left_click', coordinate: { x: 600, y: 400 } } as CuAction,
+      signal,
+    );
+    assert.equal(click.outcome.ok, true);
+
+    const typed = await backend.run({ type: 'type', text: 'must-not-land' } as CuAction, signal);
+    assert.equal(typed.outcome.ok, false);
+    assert.equal(businessPageCalls(await readRecords(logPath)).length, 1);
   });
 
   it('native AX text readback mismatch preserves outcome_unknown', async () => {

--- a/packages/computer-use/src/__tests__/cua-driver-page-target.test.ts
+++ b/packages/computer-use/src/__tests__/cua-driver-page-target.test.ts
@@ -2,7 +2,7 @@ import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 
 import {
-  CUA_INSPECT_PREPARED_ELEMENT_SCRIPT,
+  buildCuaInspectElementTokenScript,
   buildCuaPrepareElementAtScreenPointScript,
   buildCuaSemanticPointerActionScript,
   parseCuaFocusedPageElement,
@@ -112,19 +112,23 @@ describe('semantic pointer action script', () => {
   it('builds read-only element scripts and parses their JSON result', () => {
     const prepare = buildCuaPrepareElementAtScreenPointScript({ x: 10, y: 20 });
     assert.match(prepare, /elementFromPoint/);
-    assert.match(prepare, /__makaComputerUseTarget/);
+    assert.match(prepare, /__makaComputerUseElements/);
     assert.doesNotMatch(prepare, /\.focus\s*\(/);
-    assert.match(CUA_INSPECT_PREPARED_ELEMENT_SCRIPT, /__makaComputerUseReadElement/);
+    const inspect = buildCuaInspectElementTokenScript('element-1');
+    assert.match(inspect, /__makaComputerUseReadElement/);
+    assert.match(inspect, /document\.activeElement !== element/);
     assert.deepEqual(
       parseCuaFocusedPageElement(JSON.stringify({
         editable: true,
         value: 'ready',
         tagName: 'textarea',
+        elementToken: 'element-1',
       })),
       {
         editable: true,
         value: 'ready',
         tagName: 'textarea',
+        elementToken: 'element-1',
       },
     );
   });

--- a/packages/computer-use/src/cua-driver-backend.ts
+++ b/packages/computer-use/src/cua-driver-backend.ts
@@ -55,8 +55,7 @@ import {
   type CuaDriverJsonRpcResponse,
 } from './cua-driver-service.js';
 import {
-  CUA_INSPECT_PREPARED_ELEMENT_SCRIPT,
-  buildCuaPrepareElementAtScreenPointScript,
+  buildCuaInspectElementTokenScript,
   buildCuaSemanticPointerActionScript,
   parseCuaFocusedPageElement,
   parseCuaSemanticPointerResult,
@@ -298,6 +297,7 @@ export function createCuaDriverBackend(opts: CuaDriverBackendOptions): CuDispatc
   interface KeyboardTarget {
     window: CuaResolvedWindow;
     editable: boolean;
+    pageElementToken?: string;
     pageTarget?: CuaResolvedPageTextTarget;
   }
   const targetsBySession = new Map<string, { turnId: string; target: KeyboardTarget }>();
@@ -1575,6 +1575,14 @@ export function createCuaDriverBackend(opts: CuaDriverBackendOptions): CuDispatc
         message: 'background Electron text requires a verified text-editable click target',
       };
     }
+    const pageElementToken = target.pageElementToken;
+    if (!pageElementToken) {
+      return {
+        ok: false,
+        error: 'unsupported_action',
+        message: 'background Electron text requires the clicked DOM element identity',
+      };
+    }
     const pageTarget = target.pageTarget ?? await (
       opts.resolvePageTextTarget ?? ((input) => resolveCuaPageTextTarget(input))
     )({
@@ -1608,9 +1616,7 @@ export function createCuaDriverBackend(opts: CuaDriverBackendOptions): CuDispatc
       )?.text;
       return { response, element: parseCuaFocusedPageElement(text) };
     };
-    const prepared = await executePageScript(
-      buildCuaPrepareElementAtScreenPointScript(target.window.screenPoint),
-    );
+    const prepared = await executePageScript(buildCuaInspectElementTokenScript(pageElementToken));
     if (prepared.response?.isError) return normalizeCuaDriverOutcome(prepared.response);
     const before = prepared.element;
     if (!before?.editable) {
@@ -1650,7 +1656,7 @@ export function createCuaDriverBackend(opts: CuaDriverBackendOptions): CuDispatc
       signal,
     );
     if (result?.isError) return normalizeCuaDriverOutcome(result);
-    const inspected = await executePageScript(CUA_INSPECT_PREPARED_ELEMENT_SCRIPT);
+    const inspected = await executePageScript(buildCuaInspectElementTokenScript(pageElementToken));
     if (inspected.response?.isError) return normalizeCuaDriverOutcome(inspected.response);
     const after = inspected.element;
     return after?.editable === true && after.value === text
@@ -2124,6 +2130,9 @@ export function createCuaDriverBackend(opts: CuaDriverBackendOptions): CuDispatc
                   target: {
                     window: win,
                     editable: semantic.result?.editable === true,
+                    ...(semantic.result?.elementToken
+                      ? { pageElementToken: semantic.result.elementToken }
+                      : {}),
                     ...(semantic.pageTarget ? { pageTarget: semantic.pageTarget } : {}),
                   },
                 });

--- a/packages/computer-use/src/cua-driver-page-target.ts
+++ b/packages/computer-use/src/cua-driver-page-target.ts
@@ -13,6 +13,7 @@ export interface CuaFocusedPageElement {
   value: string;
   tagName: string;
   inputType?: string;
+  elementToken?: string;
 }
 
 export interface CuaResolvedPageTextTarget {
@@ -41,6 +42,7 @@ export interface CuaSemanticPointerResult {
   editable?: boolean;
   tagName?: string;
   inputType?: string;
+  elementToken?: string;
   clickEvents?: number;
   doubleClickEvents?: number;
   contextMenuEvents?: number;
@@ -58,11 +60,19 @@ export interface CuaPageTargetResolverDeps {
   fetchTargets?: (port: number, signal: AbortSignal) => Promise<CuaCdpPageTarget[]>;
 }
 
-export const CUA_INSPECT_PREPARED_ELEMENT_SCRIPT = `(() => {
-  const element = globalThis.__makaComputerUseTarget;
-  if (!element) return JSON.stringify({ editable: false, value: '', tagName: '' });
-  return JSON.stringify(globalThis.__makaComputerUseReadElement(element));
-})()`;
+export function buildCuaInspectElementTokenScript(elementToken: string): string {
+  return `(() => {
+    const token = ${JSON.stringify(elementToken)};
+    const element = globalThis.__makaComputerUseElements?.get(token);
+    if (!element || !element.isConnected || document.activeElement !== element) {
+      return JSON.stringify({ editable: false, value: '', tagName: '', elementToken: token });
+    }
+    return JSON.stringify({
+      ...globalThis.__makaComputerUseReadElement(element),
+      elementToken: token
+    });
+  })()`;
+}
 
 const TEXT_INPUT_TYPES = [
   'email',
@@ -175,11 +185,18 @@ export function buildCuaPrepareElementAtScreenPointScript(screenPoint: CuPoint):
       element = element.parentElement;
     }
     if (!element) {
-      globalThis.__makaComputerUseTarget = undefined;
       return JSON.stringify({ editable: false, value: '', tagName: '' });
     }
-    globalThis.__makaComputerUseTarget = element;
-    return JSON.stringify(globalThis.__makaComputerUseReadElement(element));
+    globalThis.__makaComputerUseElements ||= new Map();
+    globalThis.__makaComputerUseElements.clear();
+    globalThis.__makaComputerUseElementSequence =
+      (globalThis.__makaComputerUseElementSequence || 0) + 1;
+    const elementToken = String(globalThis.__makaComputerUseElementSequence);
+    globalThis.__makaComputerUseElements.set(elementToken, element);
+    return JSON.stringify({
+      ...globalThis.__makaComputerUseReadElement(element),
+      elementToken
+    });
   })()`;
 }
 
@@ -243,6 +260,15 @@ export function buildCuaSemanticPointerActionScript(
       const checkedChanged = beforeChecked !== undefined && element.checked !== beforeChecked;
       const valueChanged = beforeValue !== undefined && String(element.value ?? '') !== beforeValue;
       const focusedEditable = editable && document.activeElement === element;
+      let elementToken;
+      if (focusedEditable) {
+        globalThis.__makaComputerUseElements ||= new Map();
+        globalThis.__makaComputerUseElements.clear();
+        globalThis.__makaComputerUseElementSequence =
+          (globalThis.__makaComputerUseElementSequence || 0) + 1;
+        elementToken = String(globalThis.__makaComputerUseElementSequence);
+        globalThis.__makaComputerUseElements.set(elementToken, element);
+      }
       const ok = focusedEditable || checkedChanged || valueChanged || mutations > 0;
       return JSON.stringify({
         supported: true,
@@ -260,6 +286,7 @@ export function buildCuaSemanticPointerActionScript(
         editable,
         tagName,
         inputType,
+        ...(elementToken ? { elementToken } : {}),
         clickEvents,
         mutations,
         ...(typeof element.checked === 'boolean' ? { checked: element.checked } : {}),
@@ -431,6 +458,7 @@ export function parseCuaSemanticPointerResult(
       ...(typeof result.editable === 'boolean' ? { editable: result.editable } : {}),
       ...(typeof result.tagName === 'string' ? { tagName: result.tagName } : {}),
       ...(typeof result.inputType === 'string' ? { inputType: result.inputType } : {}),
+      ...(typeof result.elementToken === 'string' ? { elementToken: result.elementToken } : {}),
       ...(typeof result.clickEvents === 'number' ? { clickEvents: result.clickEvents } : {}),
       ...(typeof result.doubleClickEvents === 'number' ? { doubleClickEvents: result.doubleClickEvents } : {}),
       ...(typeof result.contextMenuEvents === 'number' ? { contextMenuEvents: result.contextMenuEvents } : {}),
@@ -531,5 +559,6 @@ function focusedPageElement(value: unknown): CuaFocusedPageElement {
     value: typeof result.value === 'string' ? result.value : '',
     tagName: typeof result.tagName === 'string' ? result.tagName : '',
     ...(typeof result.inputType === 'string' ? { inputType: result.inputType } : {}),
+    ...(typeof result.elementToken === 'string' ? { elementToken: result.elementToken } : {}),
   };
 }

--- a/packages/computer-use/src/index.ts
+++ b/packages/computer-use/src/index.ts
@@ -33,7 +33,7 @@ export type {
   CuaSemanticPointerResult,
 } from './cua-driver-page-target.js';
 export {
-  CUA_INSPECT_PREPARED_ELEMENT_SCRIPT,
+  buildCuaInspectElementTokenScript,
   buildCuaPrepareElementAtScreenPointScript,
   buildCuaSemanticPointerActionScript,
   parseCuaFocusedPageElement,


### PR DESCRIPTION
## Summary
- assign a document-local token to the exact editable DOM element focused by a semantic Electron click
- require the same connected, editable, active element before and after `insert_text`
- fail closed before dispatch when the click result lacks element identity or the document/element was replaced
- bound the page-side identity map to the latest focused element

This removes the old type-time `elementFromPoint` lookup, so same-page layout reflow cannot redirect text to a different field.

## Verification
- built `@maka/core`, `@maka/storage`, and `@maka/runtime` serially
- `npm --workspace @maka/computer-use test` (128/128 passing)
- `git diff --check`