### PR TITLE
fix(headless): harden harness A/B benchmark infrastructure

### DIFF
--- a/packages/headless/README.md
+++ b/packages/headless/README.md
@@ -178,6 +178,8 @@ node packages/headless/harbor/run-harness-ab.mjs
 
 For a live run, remove `MAKA_HARNESS_AB_DRY_RUN` and set `MAKA_HARNESS_AB_KEY_FILE` to a credential file outside git. Maka reads it in its host-side cell; OpenCode receives only a short-lived host proxy capability, never the provider key or key-file path. Use `MAKA_HARNESS_AB_LIMIT=2` for an operational canary, then resume with the same output directory and run id at `30` for the fixed pilot or `89` for the full suite; only missing cells run. The immutable manifest rejects other configuration changes.
 
+For an unattended run, invoke `node packages/headless/harbor/run-harness-ab-detached.mjs` with the same environment. It detaches the worker from the terminal and atomically journals `running`, `completed`, or `failed` in `background-run.json`; stdout and stderr go to `background-run.log`.
+
 Outputs are `harness-ab-report.json`, `.csv`, and `.md`. They report Pass@1 and cache-aware API-equivalent cost separately; they do not claim fixed-plan spend or publish results.
 
 ## Exit code

--- a/packages/headless/README.md
+++ b/packages/headless/README.md
@@ -176,7 +176,7 @@ MAKA_HARNESS_AB_DRY_RUN=1 \
 node packages/headless/harbor/run-harness-ab.mjs
 ```
 
-For a live run, remove `MAKA_HARNESS_AB_DRY_RUN` and set `MAKA_HARNESS_AB_KEY_FILE` to a credential file outside git. Maka reads it in its host-side cell; OpenCode receives only a short-lived host proxy capability, never the provider key or key-file path. Resume with the same output directory and run id; changing `MAKA_HARNESS_AB_LIMIT` from `30` to `89` runs only missing cells. The immutable manifest rejects other configuration changes.
+For a live run, remove `MAKA_HARNESS_AB_DRY_RUN` and set `MAKA_HARNESS_AB_KEY_FILE` to a credential file outside git. Maka reads it in its host-side cell; OpenCode receives only a short-lived host proxy capability, never the provider key or key-file path. Use `MAKA_HARNESS_AB_LIMIT=2` for an operational canary, then resume with the same output directory and run id at `30` for the fixed pilot or `89` for the full suite; only missing cells run. The immutable manifest rejects other configuration changes.
 
 Outputs are `harness-ab-report.json`, `.csv`, and `.md`. They report Pass@1 and cache-aware API-equivalent cost separately; they do not claim fixed-plan spend or publish results.
 

--- a/packages/headless/README.md
+++ b/packages/headless/README.md
@@ -163,7 +163,7 @@ embed environment variables, credentials, or hidden harness configuration.
 
 ## GLM-5.2 harness comparison
 
-`harbor/run-harness-ab.mjs` compares Maka and OpenCode 1.17.18 on the same Terminal-Bench 2.1 tasks with GLM-5.2 Max. The task root must match the 89 task ids and canonical task-tree fingerprint of the frozen official revision; a matching Harbor export with one task directory per id is accepted directly. The first 40 tasks are a fixed prefix of the full seeded order.
+`harbor/run-harness-ab.mjs` compares Maka and OpenCode 1.17.18 on the same Terminal-Bench 2.1 tasks with GLM-5.2 Max. The task root must match the 89 task ids and canonical task-tree fingerprint of the frozen official revision; a matching Harbor export with one task directory per id is accepted directly. The first 30 tasks are a fixed prefix of the full seeded order.
 
 Validate the manifest without reading a key or starting Harbor:
 
@@ -171,12 +171,12 @@ Validate the manifest without reading a key or starting Harbor:
 MAKA_HARNESS_AB_OUT_DIR=/path/to/out \
 MAKA_HARNESS_AB_TASKS_ROOT=/path/to/terminal-bench-2.1-tasks \
 MAKA_HARNESS_AB_RUN_ID=glm-5.2-harness-ab \
-MAKA_HARNESS_AB_LIMIT=40 \
+MAKA_HARNESS_AB_LIMIT=30 \
 MAKA_HARNESS_AB_DRY_RUN=1 \
 node packages/headless/harbor/run-harness-ab.mjs
 ```
 
-For a live run, remove `MAKA_HARNESS_AB_DRY_RUN` and set `MAKA_HARNESS_AB_KEY_FILE` to a credential file outside git. Maka reads it in its host-side cell; OpenCode receives only a short-lived host proxy capability, never the provider key or key-file path. Resume with the same output directory and run id; changing `MAKA_HARNESS_AB_LIMIT` from `40` to `89` runs only missing cells. The immutable manifest rejects other configuration changes.
+For a live run, remove `MAKA_HARNESS_AB_DRY_RUN` and set `MAKA_HARNESS_AB_KEY_FILE` to a credential file outside git. Maka reads it in its host-side cell; OpenCode receives only a short-lived host proxy capability, never the provider key or key-file path. Resume with the same output directory and run id; changing `MAKA_HARNESS_AB_LIMIT` from `30` to `89` runs only missing cells. The immutable manifest rejects other configuration changes.
 
 Outputs are `harness-ab-report.json`, `.csv`, and `.md`. They report Pass@1 and cache-aware API-equivalent cost separately; they do not claim fixed-plan spend or publish results.
 

--- a/packages/headless/README.md
+++ b/packages/headless/README.md
@@ -163,7 +163,7 @@ embed environment variables, credentials, or hidden harness configuration.
 
 ## GLM-5.2 harness comparison
 
-`harbor/run-harness-ab.mjs` compares Maka and OpenCode 1.17.18 on the same Terminal-Bench 2.1 tasks with GLM-5.2 Max. The task root must match the 89 task ids and canonical task-tree fingerprint of the frozen official revision; a matching Harbor export with one task directory per id is accepted directly. The first 30 tasks are a fixed prefix of the full seeded order.
+`harbor/run-harness-ab.mjs` compares Maka and OpenCode 1.17.18 on the same Terminal-Bench 2.1 tasks with GLM-5.2 Max. The task root must match the 89 task ids and canonical task-tree fingerprint of the frozen official revision; a matching Harbor export with one task directory per id is accepted directly. The first 30 tasks are a fixed prefix of the full seeded order. Maka keeps active and stale tool-result pruning enabled while semantic compact is explicitly disabled in both the manifest and runtime environment.
 
 Validate the manifest without reading a key or starting Harbor:
 

--- a/packages/headless/harbor/maka_agent.py
+++ b/packages/headless/harbor/maka_agent.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import concurrent.futures
 import json
 import os
 import secrets
@@ -440,6 +441,9 @@ class _ToolExecutorServer:
         self._loop: asyncio.AbstractEventLoop | None = None
         self._server: ThreadingHTTPServer | None = None
         self._thread: threading.Thread | None = None
+        self._futures: set[concurrent.futures.Future[Any]] = set()
+        self._futures_lock = threading.Lock()
+        self._accepting_requests = False
         self.token = secrets.token_urlsafe(32)
         self.command_scope = secrets.token_urlsafe(24)
         self.url = ""
@@ -456,24 +460,56 @@ class _ToolExecutorServer:
                 return
 
         self._server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
-        self._server.daemon_threads = True
         host, port = self._server.server_address
         self.url = f"http://{host}:{port}"
+        with self._futures_lock:
+            self._accepting_requests = True
         self._thread = threading.Thread(target=self._server.serve_forever, daemon=True)
         self._thread.start()
         return self
 
     async def __aexit__(self, exc_type: Any, exc: Any, tb: Any) -> None:
+        stop_error: BaseException | None = None
+        try:
+            await self._stop_server()
+        except BaseException as error:
+            stop_error = error
+        cleanup_error = await self._cleanup_all_scoped_processes()
+        if stop_error is not None:
+            raise stop_error
+        if cleanup_error is not None:
+            raise cleanup_error
+
+    async def _stop_server(self) -> None:
+        with self._futures_lock:
+            self._accepting_requests = False
+            futures = list(self._futures)
+        for future in futures:
+            future.cancel()
+        if futures:
+            await asyncio.gather(
+                *(asyncio.wrap_future(future) for future in futures),
+                return_exceptions=True,
+            )
+        if self._server is not None:
+            await asyncio.to_thread(self._server.shutdown)
+            await asyncio.to_thread(self._server.server_close)
+        if self._thread is not None:
+            await asyncio.to_thread(self._thread.join, 5)
+
+    async def _cleanup_all_scoped_processes(self) -> BaseException | None:
+        first_error: BaseException | None = None
         try:
             await self._cleanup_scoped_processes(signal="TERM")
-            await asyncio.sleep(0.2)
+        except BaseException as error:
+            first_error = error
+        await asyncio.sleep(0.2)
+        try:
             await self._cleanup_scoped_processes(signal="KILL")
-        finally:
-            if self._server is not None:
-                self._server.shutdown()
-                self._server.server_close()
-            if self._thread is not None:
-                self._thread.join(timeout=5)
+        except BaseException as error:
+            if first_error is None:
+                first_error = error
+        return first_error
 
     async def _cleanup_scoped_processes(self, signal: str) -> None:
         await self._agent.exec_as_agent(
@@ -498,15 +534,20 @@ class _ToolExecutorServer:
             timeout_ms = payload.get("timeoutMs")
             timeout_sec = _timeout_sec(timeout_ms)
             assert self._loop is not None
-            future = asyncio.run_coroutine_threadsafe(
-                self._agent.exec_as_agent(
-                    self._environment,
-                    command=_scoped_command(command, self.command_scope),
-                    cwd=cwd if isinstance(cwd, str) and cwd else None,
-                    timeout_sec=timeout_sec,
-                ),
-                self._loop,
-            )
+            with self._futures_lock:
+                if not self._accepting_requests:
+                    raise RuntimeError("tool executor is shutting down")
+                future = asyncio.run_coroutine_threadsafe(
+                    self._agent.exec_as_agent(
+                        self._environment,
+                        command=_scoped_command(command, self.command_scope),
+                        cwd=cwd if isinstance(cwd, str) and cwd else None,
+                        timeout_sec=timeout_sec,
+                    ),
+                    self._loop,
+                )
+                self._futures.add(future)
+            future.add_done_callback(self._discard_future)
             result = future.result(timeout=(timeout_sec or self._agent._cell_timeout_sec()) + 30)
             _write_http(handler, 200, {
                 "exitCode": _exec_exit_code(result),
@@ -515,6 +556,10 @@ class _ToolExecutorServer:
             })
         except Exception as exc:  # noqa: BLE001 - RPC boundary returns tool failure text.
             _write_http(handler, 500, {"error": str(exc)})
+
+    def _discard_future(self, future: concurrent.futures.Future[Any]) -> None:
+        with self._futures_lock:
+            self._futures.discard(future)
 
 
 def _scoped_command(command: str, scope: str) -> str:

--- a/packages/headless/harbor/maka_agent.py
+++ b/packages/headless/harbor/maka_agent.py
@@ -24,6 +24,7 @@ from trial_pricing import estimate_cost, pricing_from_env
 
 
 _COMMAND_SCOPE_ENV = "MAKA_HARBOR_COMMAND_SCOPE"
+_COMMAND_SCOPE_ROOT = "/tmp/maka-harbor-command-scopes"
 
 
 _HOST_NODE_ENV_ALLOWLIST = {
@@ -540,7 +541,11 @@ class _ToolExecutorServer:
                 future = asyncio.run_coroutine_threadsafe(
                     self._agent.exec_as_agent(
                         self._environment,
-                        command=_scoped_command(command, self.command_scope),
+                        command=_scoped_command(
+                            command,
+                            self.command_scope,
+                            secrets.token_urlsafe(12),
+                        ),
                         cwd=cwd if isinstance(cwd, str) and cwd else None,
                         timeout_sec=timeout_sec,
                     ),
@@ -562,21 +567,39 @@ class _ToolExecutorServer:
             self._futures.discard(future)
 
 
-def _scoped_command(command: str, scope: str) -> str:
-    return f"env {_COMMAND_SCOPE_ENV}={shlex.quote(scope)} bash -lc {shlex.quote(command)}"
+def _scoped_command(command: str, scope: str, command_id: str) -> str:
+    scope_dir = shlex.quote(f"{_COMMAND_SCOPE_ROOT}/{scope}")
+    pgid_path = shlex.quote(f"{_COMMAND_SCOPE_ROOT}/{scope}/{command_id}.pgid")
+    return (
+        f"mkdir -p -- {scope_dir}; "
+        f"env {_COMMAND_SCOPE_ENV}={shlex.quote(scope)} setsid bash -lc {shlex.quote(command)} & "
+        "command_pid=$!; "
+        f"printf '%s\\n' \"$command_pid\" > {pgid_path}; "
+        "wait \"$command_pid\"; command_status=$?; "
+        f"kill -0 -- \"-$command_pid\" 2>/dev/null || rm -f -- {pgid_path}; "
+        "exit \"$command_status\""
+    )
 
 
 def _scoped_process_cleanup_command(scope: str, signal: str) -> str:
     if signal not in ("TERM", "KILL"):
         raise ValueError(f"unsupported cleanup signal: {signal}")
     marker = shlex.quote(f"{_COMMAND_SCOPE_ENV}={scope}")
+    scope_dir = shlex.quote(f"{_COMMAND_SCOPE_ROOT}/{scope}")
     return (
+        f"for pgid_file in {scope_dir}/*.pgid; do "
+        "[ -r \"$pgid_file\" ] || continue; "
+        "pgid=$(cat -- \"$pgid_file\"); "
+        "case $pgid in ''|*[!0-9]*) continue;; esac; "
+        f"kill -{signal} -- \"-$pgid\" 2>/dev/null || true; "
+        "done; "
         "for env_file in /proc/[0-9]*/environ; do "
         "[ -r \"$env_file\" ] || continue; "
         f"if tr '\\000' '\\n' < \"$env_file\" | grep -Fqx -- {marker}; then "
         "pid=${env_file#/proc/}; pid=${pid%/environ}; "
         f"kill -{signal} \"$pid\" 2>/dev/null || true; "
         "fi; done"
+        + (f"; rm -rf -- {scope_dir}" if signal == "KILL" else "")
     )
 
 

--- a/packages/headless/harbor/maka_agent.py
+++ b/packages/headless/harbor/maka_agent.py
@@ -471,34 +471,60 @@ class _ToolExecutorServer:
 
     async def __aexit__(self, exc_type: Any, exc: Any, tb: Any) -> None:
         stop_error: BaseException | None = None
+        cleanup_error: BaseException | None = None
         try:
-            await self._stop_server()
+            cleanup_error = await self._stop_server(
+                reclaim_scoped_processes=exc_type is not None
+            )
         except BaseException as error:
             stop_error = error
-        cleanup_error = None
-        if exc_type is not None or stop_error is not None:
+        if stop_error is not None and exc_type is None:
             cleanup_error = await self._cleanup_all_scoped_processes()
         if stop_error is not None:
             raise stop_error
         if cleanup_error is not None:
             raise cleanup_error
 
-    async def _stop_server(self) -> None:
+    async def _stop_server(
+        self, *, reclaim_scoped_processes: bool
+    ) -> BaseException | None:
         with self._futures_lock:
             self._accepting_requests = False
             futures = list(self._futures)
-        for future in futures:
-            future.cancel()
-        if futures:
-            await asyncio.gather(
-                *(asyncio.wrap_future(future) for future in futures),
-                return_exceptions=True,
-            )
+        cleanup_error = (
+            await self._drain_futures_with_cleanup(futures)
+            if reclaim_scoped_processes
+            else await self._drain_futures(futures)
+        )
         if self._server is not None:
             await asyncio.to_thread(self._server.shutdown)
             await asyncio.to_thread(self._server.server_close)
         if self._thread is not None:
             await asyncio.to_thread(self._thread.join, 5)
+        return cleanup_error
+
+    async def _drain_futures(
+        self, futures: list[concurrent.futures.Future[Any]]
+    ) -> None:
+        if futures:
+            await asyncio.gather(
+                *(asyncio.wrap_future(future) for future in futures),
+                return_exceptions=True,
+            )
+
+    async def _drain_futures_with_cleanup(
+        self, futures: list[concurrent.futures.Future[Any]]
+    ) -> BaseException | None:
+        while any(not future.done() for future in futures):
+            cleanup_error = await self._cleanup_all_scoped_processes()
+            if cleanup_error is not None:
+                for future in futures:
+                    future.cancel()
+                await self._drain_futures(futures)
+                return cleanup_error
+            await asyncio.sleep(0.2)
+        await self._drain_futures(futures)
+        return await self._cleanup_all_scoped_processes()
 
     async def _cleanup_all_scoped_processes(self) -> BaseException | None:
         first_error: BaseException | None = None

--- a/packages/headless/harbor/maka_agent.py
+++ b/packages/headless/harbor/maka_agent.py
@@ -571,8 +571,8 @@ def _scoped_command(command: str, scope: str, command_id: str) -> str:
     scope_dir = shlex.quote(f"{_COMMAND_SCOPE_ROOT}/{scope}")
     pgid_path = shlex.quote(f"{_COMMAND_SCOPE_ROOT}/{scope}/{command_id}.pgid")
     return (
-        f"mkdir -p -- {scope_dir}; "
-        f"env {_COMMAND_SCOPE_ENV}={shlex.quote(scope)} setsid bash -lc {shlex.quote(command)} & "
+        f"mkdir -p -- {scope_dir}; set -m; "
+        f"env {_COMMAND_SCOPE_ENV}={shlex.quote(scope)} bash -lc {shlex.quote(command)} & "
         "command_pid=$!; "
         f"printf '%s\\n' \"$command_pid\" > {pgid_path}; "
         "wait \"$command_pid\"; command_status=$?; "

--- a/packages/headless/harbor/maka_agent.py
+++ b/packages/headless/harbor/maka_agent.py
@@ -475,7 +475,9 @@ class _ToolExecutorServer:
             await self._stop_server()
         except BaseException as error:
             stop_error = error
-        cleanup_error = await self._cleanup_all_scoped_processes()
+        cleanup_error = None
+        if exc_type is not None or stop_error is not None:
+            cleanup_error = await self._cleanup_all_scoped_processes()
         if stop_error is not None:
             raise stop_error
         if cleanup_error is not None:

--- a/packages/headless/harbor/maka_agent.py
+++ b/packages/headless/harbor/maka_agent.py
@@ -22,6 +22,9 @@ from harbor.utils.trajectory_utils import format_trajectory_json
 from trial_pricing import estimate_cost, pricing_from_env
 
 
+_COMMAND_SCOPE_ENV = "MAKA_HARBOR_COMMAND_SCOPE"
+
+
 _HOST_NODE_ENV_ALLOWLIST = {
     "PATH",
     "TMPDIR",
@@ -438,6 +441,7 @@ class _ToolExecutorServer:
         self._server: ThreadingHTTPServer | None = None
         self._thread: threading.Thread | None = None
         self.token = secrets.token_urlsafe(32)
+        self.command_scope = secrets.token_urlsafe(24)
         self.url = ""
 
     async def __aenter__(self) -> "_ToolExecutorServer":
@@ -452,6 +456,7 @@ class _ToolExecutorServer:
                 return
 
         self._server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+        self._server.daemon_threads = True
         host, port = self._server.server_address
         self.url = f"http://{host}:{port}"
         self._thread = threading.Thread(target=self._server.serve_forever, daemon=True)
@@ -459,11 +464,22 @@ class _ToolExecutorServer:
         return self
 
     async def __aexit__(self, exc_type: Any, exc: Any, tb: Any) -> None:
-        if self._server is not None:
-            self._server.shutdown()
-            self._server.server_close()
-        if self._thread is not None:
-            self._thread.join(timeout=5)
+        try:
+            await self._cleanup_scoped_processes(signal="TERM")
+            await asyncio.sleep(0.2)
+            await self._cleanup_scoped_processes(signal="KILL")
+        finally:
+            if self._server is not None:
+                self._server.shutdown()
+                self._server.server_close()
+            if self._thread is not None:
+                self._thread.join(timeout=5)
+
+    async def _cleanup_scoped_processes(self, signal: str) -> None:
+        await self._agent.exec_as_agent(
+            self._environment,
+            command=_scoped_process_cleanup_command(self.command_scope, signal),
+        )
 
     def _handle_post(self, handler: BaseHTTPRequestHandler) -> None:
         if handler.path != "/exec":
@@ -485,7 +501,7 @@ class _ToolExecutorServer:
             future = asyncio.run_coroutine_threadsafe(
                 self._agent.exec_as_agent(
                     self._environment,
-                    command=command,
+                    command=_scoped_command(command, self.command_scope),
                     cwd=cwd if isinstance(cwd, str) and cwd else None,
                     timeout_sec=timeout_sec,
                 ),
@@ -499,6 +515,24 @@ class _ToolExecutorServer:
             })
         except Exception as exc:  # noqa: BLE001 - RPC boundary returns tool failure text.
             _write_http(handler, 500, {"error": str(exc)})
+
+
+def _scoped_command(command: str, scope: str) -> str:
+    return f"env {_COMMAND_SCOPE_ENV}={shlex.quote(scope)} bash -lc {shlex.quote(command)}"
+
+
+def _scoped_process_cleanup_command(scope: str, signal: str) -> str:
+    if signal not in ("TERM", "KILL"):
+        raise ValueError(f"unsupported cleanup signal: {signal}")
+    marker = shlex.quote(f"{_COMMAND_SCOPE_ENV}={scope}")
+    return (
+        "for env_file in /proc/[0-9]*/environ; do "
+        "[ -r \"$env_file\" ] || continue; "
+        f"if tr '\\000' '\\n' < \"$env_file\" | grep -Fqx -- {marker}; then "
+        "pid=${env_file#/proc/}; pid=${pid%/environ}; "
+        f"kill -{signal} \"$pid\" 2>/dev/null || true; "
+        "fi; done"
+    )
 
 
 def _write_http(handler: BaseHTTPRequestHandler, status: int, payload: dict[str, Any]) -> None:

--- a/packages/headless/harbor/opencode-benchmark.json
+++ b/packages/headless/harbor/opencode-benchmark.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://opencode.ai/config.json",
+  "provider": {
+    "zai-coding-plan": {
+      "options": {
+        "apiKey": "{env:ZAI_API_KEY}",
+        "baseURL": "{env:ZAI_BASE_URL}"
+      }
+    }
+  }
+}

--- a/packages/headless/harbor/opencode_agent.py
+++ b/packages/headless/harbor/opencode_agent.py
@@ -51,6 +51,12 @@ class MakaOpenCodeAgent(OpenCode):
 
     def _apply_cost_metadata(self, context: AgentContext) -> None:
         totals = self._token_totals(context)
+        if totals is None:
+            context.metadata = {
+                **(context.metadata or {}),
+                "opencode_pricing_source": "missing_usage",
+            }
+            return
         reported_cost = context.cost_usd
         estimated_cost = context.cost_usd
         pricing_source = "opencode" if estimated_cost is not None else None
@@ -179,14 +185,19 @@ class MakaOpenCodeAgent(OpenCode):
                 env[key] = value
         return env
 
-    def _token_totals(self, context: AgentContext) -> dict[str, int]:
+    def _token_totals(self, context: AgentContext) -> dict[str, int] | None:
         parsed = self._token_totals_from_stdout()
         if parsed is not None:
             return parsed
 
-        input_tokens = int(getattr(context, "n_input_tokens", 0) or 0)
-        output_tokens = int(getattr(context, "n_output_tokens", 0) or 0)
-        cache_read = int(getattr(context, "n_cache_tokens", 0) or 0)
+        raw_input = getattr(context, "n_input_tokens", None)
+        raw_output = getattr(context, "n_output_tokens", None)
+        raw_cache_read = getattr(context, "n_cache_tokens", None)
+        if raw_input is None and raw_output is None and raw_cache_read is None:
+            return None
+        input_tokens = int(raw_input or 0)
+        output_tokens = int(raw_output or 0)
+        cache_read = int(raw_cache_read or 0)
         cache_miss = max(0, input_tokens - cache_read)
         return {
             "input": input_tokens,
@@ -277,6 +288,21 @@ class MakaOpenCodeAgent(OpenCode):
                 name = str(tool_name)
                 tool_call_counts[name] = tool_call_counts.get(name, 0) + 1
         tool_names = sorted(tool_call_counts)
+        token_summary = None
+        if totals is not None and context.cost_usd is not None:
+            token_summary = {
+                "input": totals["input"],
+                "cachedInput": totals["cache_read"],
+                "cacheHitInput": totals["cache_read"],
+                "cacheMissInput": totals["cache_miss"],
+                "cacheWriteInput": totals["cache_write"],
+                "cacheMissInputSource": "explicit",
+                "output": totals["output"],
+                "reasoning": totals["reasoning"],
+                "total": totals["input"] + totals["output"],
+                "costUsd": float(context.cost_usd),
+                "pricingSource": "runtime",
+            }
         self.logs_dir.mkdir(parents=True, exist_ok=True)
         runtime_events_path = self.logs_dir / "runtime-events.jsonl"
         source_events_path = self.logs_dir / "opencode.txt"
@@ -291,19 +317,7 @@ class MakaOpenCodeAgent(OpenCode):
             "runtimeEventsPath": "/logs/agent/runtime-events.jsonl",
             "promptHash": prompt_hash,
             "executionIdentity": execution_identity,
-            "tokenSummary": {
-                "input": totals["input"],
-                "cachedInput": totals["cache_read"],
-                "cacheHitInput": totals["cache_read"],
-                "cacheMissInput": totals["cache_miss"],
-                "cacheWriteInput": totals["cache_write"],
-                "cacheMissInputSource": "explicit",
-                "output": totals["output"],
-                "reasoning": totals["reasoning"],
-                "total": totals["input"] + totals["output"],
-                "costUsd": float(context.cost_usd or 0),
-                "pricingSource": "runtime",
-            },
+            **({"tokenSummary": token_summary} if token_summary is not None else {}),
             "toolSummary": {
                 "providerVisibleToolCount": 0,
                 "actualToolCalls": sum(tool_call_counts.values()),

--- a/packages/headless/harbor/opencode_agent.py
+++ b/packages/headless/harbor/opencode_agent.py
@@ -230,7 +230,7 @@ class MakaOpenCodeAgent(OpenCode):
             step_cache_write = (
                 _int_value(cache.get("write")) if isinstance(cache, dict) else 0
             )
-            input_tokens += step_input + step_cache_read
+            input_tokens += step_input + step_cache_read + step_cache_write
             output_tokens += step_output
             cache_read += step_cache_read
             cache_write += step_cache_write

--- a/packages/headless/harbor/opencode_agent.py
+++ b/packages/headless/harbor/opencode_agent.py
@@ -110,6 +110,7 @@ class MakaOpenCodeAgent(OpenCode):
         env = self._provider_env(provider)
         env["ZAI_BASE_URL"] = proxy_url
         env["ZAI_API_KEY"] = proxy_token
+        env["OPENCODE_CONFIG"] = self._opencode_config_path()
         env["OPENCODE_FAKE_VCS"] = "git"
 
         skills_command = self._build_register_skills_command()
@@ -148,6 +149,16 @@ class MakaOpenCodeAgent(OpenCode):
             / "headless"
             / "harbor"
             / "opencode-stop-runner.mjs"
+        )
+
+    def _opencode_config_path(self) -> str:
+        maka_repo = self._get_env("MAKA_REPO_ROOT") or "/opt/maka-agent"
+        return str(
+            Path(maka_repo)
+            / "packages"
+            / "headless"
+            / "harbor"
+            / "opencode-benchmark.json"
         )
 
     def _stop_grace_ms(self) -> int:

--- a/packages/headless/harbor/opencode_agent.py
+++ b/packages/headless/harbor/opencode_agent.py
@@ -231,7 +231,7 @@ class MakaOpenCodeAgent(OpenCode):
                 _int_value(cache.get("write")) if isinstance(cache, dict) else 0
             )
             input_tokens += step_input + step_cache_read + step_cache_write
-            output_tokens += step_output
+            output_tokens += step_output + step_reasoning
             cache_read += step_cache_read
             cache_write += step_cache_write
             reasoning += step_reasoning

--- a/packages/headless/harbor/run-harness-ab-detached.mjs
+++ b/packages/headless/harbor/run-harness-ab-detached.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 import { closeSync, openSync } from 'node:fs';
-import { mkdir } from 'node:fs/promises';
+import { mkdir, readFile } from 'node:fs/promises';
 import { homedir } from 'node:os';
 import { join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -48,8 +48,55 @@ async function launchDetached() {
   } finally {
     closeSync(logFd);
   }
+  const journalPath = join(runRoot, JOURNAL_FILENAME);
+  await waitForWorkerOwnership(child, journalPath, startedAt);
   child.unref();
-  console.log(`detached harness runner started: pid ${child.pid}; journal ${join(runRoot, JOURNAL_FILENAME)}`);
+  console.log(`detached harness runner started: pid ${child.pid}; journal ${journalPath}`);
+}
+
+function waitForWorkerOwnership(child, journalPath, startedAt) {
+  return new Promise((resolve, reject) => {
+    let settled = false;
+    let timer;
+    const finish = (error) => {
+      if (settled) return;
+      settled = true;
+      if (timer) clearTimeout(timer);
+      child.off('error', onError);
+      child.off('exit', onExit);
+      if (error) reject(error);
+      else resolve();
+    };
+    const journalMatches = async () => {
+      try {
+        const journal = JSON.parse(await readFile(journalPath, 'utf8'));
+        return journal.pid === child.pid && journal.startedAt === startedAt;
+      } catch {
+        return false;
+      }
+    };
+    const poll = async () => {
+      if (settled) return;
+      if (await journalMatches()) {
+        finish();
+        return;
+      }
+      timer = setTimeout(poll, 10);
+    };
+    const onError = (error) => finish(error);
+    const onExit = async (code, signal) => {
+      if (await journalMatches()) {
+        finish();
+        return;
+      }
+      finish(new Error(
+        `detached harness runner exited before acquiring the run lock (code ${code ?? 'null'}, signal ${signal ?? 'none'})`,
+      ));
+    };
+    child.once('error', onError);
+    child.once('exit', onExit);
+    void poll();
+  });
 }
 
 if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {

--- a/packages/headless/harbor/run-harness-ab-detached.mjs
+++ b/packages/headless/harbor/run-harness-ab-detached.mjs
@@ -1,0 +1,92 @@
+#!/usr/bin/env node
+
+import { closeSync, openSync } from 'node:fs';
+import { mkdir, rename, writeFile } from 'node:fs/promises';
+import { homedir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { spawn } from 'node:child_process';
+import { resolveFixedPromptRunRoot } from '#fixed-prompt-task-source';
+import { DEFAULT_HARNESS_AB_RUN_ID, main as runHarnessAb } from './run-harness-ab.mjs';
+
+const WORKER_ARG = '--worker';
+const JOURNAL_FILENAME = 'background-run.json';
+const LOG_FILENAME = 'background-run.log';
+
+function envPath(name) {
+  const raw = process.env[name];
+  if (!raw) throw new Error(`${name} is required`);
+  return raw.startsWith('~') ? join(homedir(), raw.slice(1)) : resolve(raw);
+}
+
+function detachedRunPaths() {
+  const outDir = envPath('MAKA_HARNESS_AB_OUT_DIR');
+  const runId = process.env.MAKA_HARNESS_AB_RUN_ID || DEFAULT_HARNESS_AB_RUN_ID;
+  const runRoot = resolveFixedPromptRunRoot(outDir, runId, 'MAKA_HARNESS_AB_RUN_ID');
+  return {
+    runRoot,
+    journalPath: join(runRoot, JOURNAL_FILENAME),
+    logPath: join(runRoot, LOG_FILENAME),
+  };
+}
+
+async function writeJournal(path, value) {
+  const pendingPath = `${path}.${process.pid}.tmp`;
+  await writeFile(pendingPath, `${JSON.stringify(value, null, 2)}\n`, { encoding: 'utf8', mode: 0o600 });
+  await rename(pendingPath, path);
+}
+
+async function runWorker() {
+  const { runRoot, journalPath, logPath } = detachedRunPaths();
+  await mkdir(runRoot, { recursive: true });
+  const startedAt = process.env.MAKA_HARNESS_AB_DETACHED_STARTED_AT || new Date().toISOString();
+  const base = {
+    schemaVersion: 1,
+    pid: process.pid,
+    startedAt,
+    logPath,
+  };
+  await writeJournal(journalPath, { ...base, status: 'running' });
+  let exitCode = 0;
+  try {
+    await runHarnessAb();
+  } catch (error) {
+    exitCode = 1;
+    console.error(error);
+  } finally {
+    await writeJournal(journalPath, {
+      ...base,
+      status: exitCode === 0 ? 'completed' : 'failed',
+      finishedAt: new Date().toISOString(),
+      exitCode,
+    });
+  }
+  process.exitCode = exitCode;
+}
+
+async function launchDetached() {
+  const { runRoot, logPath } = detachedRunPaths();
+  await mkdir(runRoot, { recursive: true });
+  const logFd = openSync(logPath, 'a', 0o600);
+  const startedAt = new Date().toISOString();
+  let child;
+  try {
+    child = spawn(process.execPath, [fileURLToPath(import.meta.url), WORKER_ARG], {
+      detached: true,
+      env: { ...process.env, MAKA_HARNESS_AB_DETACHED_STARTED_AT: startedAt },
+      stdio: ['ignore', logFd, logFd],
+    });
+  } finally {
+    closeSync(logFd);
+  }
+  child.unref();
+  console.log(`detached harness runner started: pid ${child.pid}; journal ${join(runRoot, JOURNAL_FILENAME)}`);
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  const action = process.argv.includes(WORKER_ARG) ? runWorker : launchDetached;
+  action().catch((error) => {
+    console.error(error);
+    process.exitCode = 1;
+  });
+}

--- a/packages/headless/harbor/run-harness-ab-detached.mjs
+++ b/packages/headless/harbor/run-harness-ab-detached.mjs
@@ -1,15 +1,14 @@
 #!/usr/bin/env node
 
 import { closeSync, openSync } from 'node:fs';
-import { mkdir, rename, writeFile } from 'node:fs/promises';
+import { mkdir } from 'node:fs/promises';
 import { homedir } from 'node:os';
 import { join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { spawn } from 'node:child_process';
 import { resolveFixedPromptRunRoot } from '#fixed-prompt-task-source';
-import { DEFAULT_HARNESS_AB_RUN_ID, main as runHarnessAb } from './run-harness-ab.mjs';
+import { DEFAULT_HARNESS_AB_RUN_ID } from './run-harness-ab.mjs';
 
-const WORKER_ARG = '--worker';
 const JOURNAL_FILENAME = 'background-run.json';
 const LOG_FILENAME = 'background-run.log';
 
@@ -25,43 +24,8 @@ function detachedRunPaths() {
   const runRoot = resolveFixedPromptRunRoot(outDir, runId, 'MAKA_HARNESS_AB_RUN_ID');
   return {
     runRoot,
-    journalPath: join(runRoot, JOURNAL_FILENAME),
     logPath: join(runRoot, LOG_FILENAME),
   };
-}
-
-async function writeJournal(path, value) {
-  const pendingPath = `${path}.${process.pid}.tmp`;
-  await writeFile(pendingPath, `${JSON.stringify(value, null, 2)}\n`, { encoding: 'utf8', mode: 0o600 });
-  await rename(pendingPath, path);
-}
-
-async function runWorker() {
-  const { runRoot, journalPath, logPath } = detachedRunPaths();
-  await mkdir(runRoot, { recursive: true });
-  const startedAt = process.env.MAKA_HARNESS_AB_DETACHED_STARTED_AT || new Date().toISOString();
-  const base = {
-    schemaVersion: 1,
-    pid: process.pid,
-    startedAt,
-    logPath,
-  };
-  await writeJournal(journalPath, { ...base, status: 'running' });
-  let exitCode = 0;
-  try {
-    await runHarnessAb();
-  } catch (error) {
-    exitCode = 1;
-    console.error(error);
-  } finally {
-    await writeJournal(journalPath, {
-      ...base,
-      status: exitCode === 0 ? 'completed' : 'failed',
-      finishedAt: new Date().toISOString(),
-      exitCode,
-    });
-  }
-  process.exitCode = exitCode;
 }
 
 async function launchDetached() {
@@ -69,11 +33,16 @@ async function launchDetached() {
   await mkdir(runRoot, { recursive: true });
   const logFd = openSync(logPath, 'a', 0o600);
   const startedAt = new Date().toISOString();
+  const workerPath = fileURLToPath(new URL('./run-harness-ab.mjs', import.meta.url));
   let child;
   try {
-    child = spawn(process.execPath, [fileURLToPath(import.meta.url), WORKER_ARG], {
+    child = spawn(process.execPath, [workerPath], {
       detached: true,
-      env: { ...process.env, MAKA_HARNESS_AB_DETACHED_STARTED_AT: startedAt },
+      env: {
+        ...process.env,
+        MAKA_HARNESS_AB_BACKGROUND_RUN: '1',
+        MAKA_HARNESS_AB_DETACHED_STARTED_AT: startedAt,
+      },
       stdio: ['ignore', logFd, logFd],
     });
   } finally {
@@ -84,8 +53,7 @@ async function launchDetached() {
 }
 
 if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
-  const action = process.argv.includes(WORKER_ARG) ? runWorker : launchDetached;
-  action().catch((error) => {
+  launchDetached().catch((error) => {
     console.error(error);
     process.exitCode = 1;
   });

--- a/packages/headless/harbor/run-harness-ab.mjs
+++ b/packages/headless/harbor/run-harness-ab.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { mkdir, readFile, rename, writeFile } from 'node:fs/promises';
 import { homedir } from 'node:os';
 import { join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -19,7 +19,10 @@ import {
   TERMINAL_BENCH_2_1_REVISION,
   TERMINAL_BENCH_2_1_TASK_IDS,
 } from '#harness-ab-manifest';
-import { runHarnessAbComparison } from '#harness-ab-run';
+import {
+  runHarnessAbComparisonUnlocked,
+  withHarnessAbRunLock,
+} from '#harness-ab-run';
 import {
   assertHarnessAbReportCompleted,
   buildHarnessAbReport,
@@ -51,6 +54,10 @@ const PRICING = {
   source: 'z.ai-public-2026-07-13',
 };
 const HARBOR_SETUP_TEARDOWN_GRACE_SEC = 15 * 60;
+const BACKGROUND_RUN_ENV = 'MAKA_HARNESS_AB_BACKGROUND_RUN';
+const BACKGROUND_STARTED_AT_ENV = 'MAKA_HARNESS_AB_DETACHED_STARTED_AT';
+const BACKGROUND_JOURNAL_FILENAME = 'background-run.json';
+const BACKGROUND_LOG_FILENAME = 'background-run.log';
 
 function envPath(name, fallback) {
   const raw = process.env[name] || fallback;
@@ -96,6 +103,29 @@ export async function main() {
   const runId = process.env.MAKA_HARNESS_AB_RUN_ID || DEFAULT_HARNESS_AB_RUN_ID;
   const limit = runLimit(process.env.MAKA_HARNESS_AB_LIMIT);
   const runRoot = resolveFixedPromptRunRoot(outDir, runId, 'MAKA_HARNESS_AB_RUN_ID');
+  await withHarnessAbRunLock(runRoot, async () => {
+    const journal = backgroundJournal(runRoot);
+    if (journal) await writeBackgroundJournal(journal.path, { ...journal.base, status: 'running' });
+    let exitCode = 0;
+    try {
+      await runLocked({ repoRoot, makaRepoPath, tasksRoot, runId, limit, runRoot });
+    } catch (error) {
+      exitCode = 1;
+      throw error;
+    } finally {
+      if (journal) {
+        await writeBackgroundJournal(journal.path, {
+          ...journal.base,
+          status: exitCode === 0 ? 'completed' : 'failed',
+          finishedAt: new Date().toISOString(),
+          exitCode,
+        });
+      }
+    }
+  });
+}
+
+async function runLocked({ repoRoot, makaRepoPath, tasksRoot, runId, limit, runRoot }) {
   const allTasks = await discoverCachedHarborTasks(tasksRoot);
   assertTerminalBench21TaskSet(allTasks.map((task) => task.id));
   const taskSourceFingerprint = await fingerprintFixedPromptTaskTree(allTasks);
@@ -203,7 +233,7 @@ export async function main() {
     model: MODEL,
     thinkingLevel: REASONING_EFFORT,
   });
-  const summary = await runHarnessAbComparison({
+  const summary = await runHarnessAbComparisonUnlocked({
     runId,
     runRoot,
     resultsJsonlPath: join(controllerDir, 'results.jsonl'),
@@ -239,6 +269,26 @@ export async function main() {
   await writeFile(join(runRoot, 'harness-ab-report.md'), renderHarnessAbReportMarkdown(report), 'utf8');
   assertHarnessAbReportCompleted(report);
   console.log(`completed: ${report.effectiveness.pairedEvaluated}/${report.completeness.expectedPerArm} paired Pass@1 cells -> ${runRoot}`);
+}
+
+function backgroundJournal(runRoot) {
+  if (process.env[BACKGROUND_RUN_ENV] !== '1') return null;
+  const logPath = join(runRoot, BACKGROUND_LOG_FILENAME);
+  return {
+    path: join(runRoot, BACKGROUND_JOURNAL_FILENAME),
+    base: {
+      schemaVersion: 1,
+      pid: process.pid,
+      startedAt: process.env[BACKGROUND_STARTED_AT_ENV] || new Date().toISOString(),
+      logPath,
+    },
+  };
+}
+
+async function writeBackgroundJournal(path, value) {
+  const pendingPath = `${path}.${process.pid}.tmp`;
+  await writeFile(pendingPath, `${JSON.stringify(value, null, 2)}\n`, { encoding: 'utf8', mode: 0o600 });
+  await rename(pendingPath, path);
 }
 
 if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {

--- a/packages/headless/harbor/run-harness-ab.mjs
+++ b/packages/headless/harbor/run-harness-ab.mjs
@@ -31,7 +31,7 @@ import {
 } from './run-prompt-ab.mjs';
 
 const EXPECTED_TASKS = TERMINAL_BENCH_2_1_TASK_IDS.length;
-const PILOT_TASKS = 40;
+const PILOT_TASKS = 30;
 const PROVIDER = 'zai-coding-plan';
 const MODEL = 'glm-5.2';
 const MODEL_SPEC = `${PROVIDER}/${MODEL}`;

--- a/packages/headless/harbor/run-harness-ab.mjs
+++ b/packages/headless/harbor/run-harness-ab.mjs
@@ -31,6 +31,7 @@ import {
 } from './run-prompt-ab.mjs';
 
 const EXPECTED_TASKS = TERMINAL_BENCH_2_1_TASK_IDS.length;
+const CANARY_TASKS = 2;
 const PILOT_TASKS = 30;
 const PROVIDER = 'zai-coding-plan';
 const MODEL = 'glm-5.2';
@@ -57,8 +58,8 @@ function envPath(name, fallback) {
 
 function runLimit(raw) {
   const parsed = Number(raw ?? PILOT_TASKS);
-  if (parsed !== PILOT_TASKS && parsed !== EXPECTED_TASKS) {
-    throw new Error(`MAKA_HARNESS_AB_LIMIT must be ${PILOT_TASKS} or ${EXPECTED_TASKS}`);
+  if (parsed !== CANARY_TASKS && parsed !== PILOT_TASKS && parsed !== EXPECTED_TASKS) {
+    throw new Error(`MAKA_HARNESS_AB_LIMIT must be ${CANARY_TASKS}, ${PILOT_TASKS}, or ${EXPECTED_TASKS}`);
   }
   return parsed;
 }

--- a/packages/headless/harbor/run-harness-ab.mjs
+++ b/packages/headless/harbor/run-harness-ab.mjs
@@ -66,6 +66,26 @@ function runLimit(raw) {
   return parsed;
 }
 
+export function harnessMakaContextBudgetEnv() {
+  return {
+    MAKA_CONTEXT_ACTIVE_TOOL_RESULT_PRUNE: 'on',
+    MAKA_CONTEXT_ACTIVE_TOOL_RESULT_MAX_ESTIMATED_TOKENS: String(
+      HARNESS_MAKA_CONTEXT_BUDGET.activeToolResultPrune.maxCurrentResultEstimatedTokens,
+    ),
+    MAKA_CONTEXT_ACTIVE_TOOL_RESULT_MIN_STEP_NUMBER: String(
+      HARNESS_MAKA_CONTEXT_BUDGET.activeToolResultPrune.minStepNumber,
+    ),
+    MAKA_CONTEXT_STALE_TOOL_RESULT_PRUNE: 'on',
+    MAKA_CONTEXT_STALE_TOOL_RESULT_MAX_ESTIMATED_TOKENS: String(
+      HARNESS_MAKA_CONTEXT_BUDGET.staleToolResultPrune.maxResultEstimatedTokens,
+    ),
+    MAKA_CONTEXT_STALE_TOOL_RESULT_MIN_RECENT_TURNS_FULL: String(
+      HARNESS_MAKA_CONTEXT_BUDGET.staleToolResultPrune.minRecentTurnsFull,
+    ),
+    MAKA_CONTEXT_SEMANTIC_COMPACT: 'off',
+  };
+}
+
 export async function main() {
   const repoRoot = resolve(fileURLToPath(new URL('../../..', import.meta.url)));
   const makaRepoPath = process.env.MAKA_HARNESS_AB_MAKA_REPO
@@ -175,22 +195,7 @@ export async function main() {
     agentEnv: { ZAI_BASE_URL: BASE_URL },
     timeoutMultiplier: 1,
   };
-  const makaContextBudgetEnv = {
-    MAKA_CONTEXT_ACTIVE_TOOL_RESULT_PRUNE: 'on',
-    MAKA_CONTEXT_ACTIVE_TOOL_RESULT_MAX_ESTIMATED_TOKENS: String(
-      HARNESS_MAKA_CONTEXT_BUDGET.activeToolResultPrune.maxCurrentResultEstimatedTokens,
-    ),
-    MAKA_CONTEXT_ACTIVE_TOOL_RESULT_MIN_STEP_NUMBER: String(
-      HARNESS_MAKA_CONTEXT_BUDGET.activeToolResultPrune.minStepNumber,
-    ),
-    MAKA_CONTEXT_STALE_TOOL_RESULT_PRUNE: 'on',
-    MAKA_CONTEXT_STALE_TOOL_RESULT_MAX_ESTIMATED_TOKENS: String(
-      HARNESS_MAKA_CONTEXT_BUDGET.staleToolResultPrune.maxResultEstimatedTokens,
-    ),
-    MAKA_CONTEXT_STALE_TOOL_RESULT_MIN_RECENT_TURNS_FULL: String(
-      HARNESS_MAKA_CONTEXT_BUDGET.staleToolResultPrune.minRecentTurnsFull,
-    ),
-  };
+  const makaContextBudgetEnv = harnessMakaContextBudgetEnv();
   const config = (id) => ({
     id: `harness-ab-${id}`,
     backend: 'ai-sdk',

--- a/packages/headless/harbor/run-harness-ab.mjs
+++ b/packages/headless/harbor/run-harness-ab.mjs
@@ -32,6 +32,7 @@ import {
 } from './run-prompt-ab.mjs';
 
 const EXPECTED_TASKS = TERMINAL_BENCH_2_1_TASK_IDS.length;
+export const DEFAULT_HARNESS_AB_RUN_ID = 'glm-5.2-maka-vs-opencode-tbench-2.1';
 const CANARY_TASKS = 2;
 const PILOT_TASKS = 30;
 const PROVIDER = 'zai-coding-plan';
@@ -65,14 +66,14 @@ function runLimit(raw) {
   return parsed;
 }
 
-async function main() {
+export async function main() {
   const repoRoot = resolve(fileURLToPath(new URL('../../..', import.meta.url)));
   const makaRepoPath = process.env.MAKA_HARNESS_AB_MAKA_REPO
     ? resolve(process.env.MAKA_HARNESS_AB_MAKA_REPO)
     : repoRoot;
   const outDir = envPath('MAKA_HARNESS_AB_OUT_DIR');
   const tasksRoot = envPath('MAKA_HARNESS_AB_TASKS_ROOT', join(homedir(), '.cache/harbor/tasks'));
-  const runId = process.env.MAKA_HARNESS_AB_RUN_ID || 'glm-5.2-maka-vs-opencode-tbench-2.1';
+  const runId = process.env.MAKA_HARNESS_AB_RUN_ID || DEFAULT_HARNESS_AB_RUN_ID;
   const limit = runLimit(process.env.MAKA_HARNESS_AB_LIMIT);
   const runRoot = resolveFixedPromptRunRoot(outDir, runId, 'MAKA_HARNESS_AB_RUN_ID');
   const allTasks = await discoverCachedHarborTasks(tasksRoot);

--- a/packages/headless/harbor/run-harness-ab.mjs
+++ b/packages/headless/harbor/run-harness-ab.mjs
@@ -15,6 +15,7 @@ import {
   assertTerminalBench21TaskSet,
   assertTerminalBench21TaskTreeFingerprint,
   buildHarnessAbRunManifest,
+  HARNESS_MAKA_CONTEXT_BUDGET,
   TERMINAL_BENCH_2_1_REVISION,
   TERMINAL_BENCH_2_1_TASK_IDS,
 } from '#harness-ab-manifest';
@@ -112,6 +113,7 @@ async function main() {
           reasoningEffort: REASONING_EFFORT,
           continuation: false,
           attemptPolicy: 'single',
+          contextBudget: HARNESS_MAKA_CONTEXT_BUDGET,
         },
       },
       {
@@ -172,6 +174,22 @@ async function main() {
     agentEnv: { ZAI_BASE_URL: BASE_URL },
     timeoutMultiplier: 1,
   };
+  const makaContextBudgetEnv = {
+    MAKA_CONTEXT_ACTIVE_TOOL_RESULT_PRUNE: 'on',
+    MAKA_CONTEXT_ACTIVE_TOOL_RESULT_MAX_ESTIMATED_TOKENS: String(
+      HARNESS_MAKA_CONTEXT_BUDGET.activeToolResultPrune.maxCurrentResultEstimatedTokens,
+    ),
+    MAKA_CONTEXT_ACTIVE_TOOL_RESULT_MIN_STEP_NUMBER: String(
+      HARNESS_MAKA_CONTEXT_BUDGET.activeToolResultPrune.minStepNumber,
+    ),
+    MAKA_CONTEXT_STALE_TOOL_RESULT_PRUNE: 'on',
+    MAKA_CONTEXT_STALE_TOOL_RESULT_MAX_ESTIMATED_TOKENS: String(
+      HARNESS_MAKA_CONTEXT_BUDGET.staleToolResultPrune.maxResultEstimatedTokens,
+    ),
+    MAKA_CONTEXT_STALE_TOOL_RESULT_MIN_RECENT_TURNS_FULL: String(
+      HARNESS_MAKA_CONTEXT_BUDGET.staleToolResultPrune.minRecentTurnsFull,
+    ),
+  };
   const config = (id) => ({
     id: `harness-ab-${id}`,
     backend: 'ai-sdk',
@@ -191,7 +209,11 @@ async function main() {
         id: 'maka',
         config: config('maka'),
         expectedPricingProfile: PRICING.source,
-        harborRunner: createHarborTaskRunner({ ...runnerOptions, agent: 'maka' }),
+        harborRunner: createHarborTaskRunner({
+          ...runnerOptions,
+          agent: 'maka',
+          agentEnv: { ...runnerOptions.agentEnv, ...makaContextBudgetEnv },
+        }),
       },
       {
         id: 'opencode',

--- a/packages/headless/harbor/run-host-cell.mjs
+++ b/packages/headless/harbor/run-host-cell.mjs
@@ -14,6 +14,7 @@ import {
   providerApiKeyEnvName,
   reasoningEffortFromEnv,
   runHarborCell,
+  writeHarborCellUsageCheckpoint,
 } from '#harbor-cell';
 
 const TRIAL_PRICING_ENV = [
@@ -70,6 +71,7 @@ export async function main(options = {}) {
       now,
       newId,
       ...(maxSteps !== undefined ? { maxSteps } : {}),
+      recordUsageCheckpoint: (usage) => writeHarborCellUsageCheckpoint(outputDir, usage),
     }),
     realBackendIsolation: {
       kind: 'external',

--- a/packages/headless/src/__tests__/ab-run.test.ts
+++ b/packages/headless/src/__tests__/ab-run.test.ts
@@ -139,6 +139,48 @@ describe('runAbComparison', () => {
     ]);
   });
 
+  test('drains every started pair and arm before propagating a rejection', async () => {
+    const started: string[] = [];
+    const finished: string[] = [];
+    let allStarted!: () => void;
+    const allStartedPromise = new Promise<void>((resolve) => { allStarted = resolve; });
+    const run = runAbComparison({
+      runId: 'ab-run',
+      arms: [
+        { id: 'maka', kind: 'harness', fingerprint: sha256('maka') },
+        { id: 'opencode', kind: 'harness', fingerprint: sha256('opencode') },
+      ],
+      evaluationTasks: [
+        { id: 't1', path: '/tasks/t1' },
+        { id: 't2', path: '/tasks/t2' },
+        { id: 't3', path: '/tasks/t3' },
+      ],
+      reps: 1,
+      maxConcurrency: 2,
+      runArm: async ({ arm, task }) => {
+        const id = `${task.id}:${arm.id}`;
+        started.push(id);
+        if (started.length === 4) allStarted();
+        await allStartedPromise;
+        if (id === 't1:maka') throw new Error('arm failed');
+        await new Promise<void>((resolve) => setTimeout(resolve, 25));
+        finished.push(id);
+        return completed(task.id, true);
+      },
+    });
+
+    await assert.rejects(run, /arm failed/);
+    const finishedAtReject = [...finished];
+    await new Promise<void>((resolve) => setTimeout(resolve, 40));
+
+    assert.deepEqual(new Set(started), new Set([
+      't1:maka', 't1:opencode', 't2:maka', 't2:opencode',
+    ]));
+    assert.deepEqual(new Set(finishedAtReject), new Set([
+      't1:opencode', 't2:maka', 't2:opencode',
+    ]));
+  });
+
   test('stops scheduling new pairs after the observed cost threshold is reached', async () => {
     const calls: string[] = [];
     const result = await runAbComparison({

--- a/packages/headless/src/__tests__/fixed-prompt-controller.test.ts
+++ b/packages/headless/src/__tests__/fixed-prompt-controller.test.ts
@@ -1,5 +1,7 @@
 import assert from 'node:assert/strict';
+import fs from 'node:fs';
 import { appendFile, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { syncBuiltinESMExports } from 'node:module';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, test } from 'node:test';
@@ -7,6 +9,7 @@ import type { Config } from '../contracts.js';
 import { tokenSummary } from './helpers/cell-output-fixtures.js';
 import { contextBudgetSummary } from './helpers/ab-summary-fixtures.js';
 import {
+  appendFixedPromptWalEvent,
   FixedPromptBudgetExhaustedError,
   hashSystemPrompt,
   readFixedPromptWal,
@@ -353,6 +356,52 @@ describe('fixed prompt controller', () => {
 
       assert.deepEqual(secondCalls, []);
       assert.deepEqual(second.taskIds, ['task-a', 'task-b']);
+    });
+  });
+
+  test('serializes concurrent WAL repair and append without losing events', async () => {
+    await withDir(async (dir) => {
+      const resultsJsonlPath = join(dir, 'results.jsonl');
+      const retained = taskCompletedEvent({ taskId: 'retained' });
+      await writeFile(resultsJsonlPath, `${JSON.stringify(retained)}\n{"torn"`, 'utf8');
+      const appended = [
+        taskCompletedEvent({ taskId: 'task-a' }),
+        taskCompletedEvent({ taskId: 'task-b' }),
+      ];
+      const originalTruncate = fs.promises.truncate;
+      const originalAppendFile = fs.promises.appendFile;
+      let truncateCalls = 0;
+      let firstAppendDone!: () => void;
+      const firstAppend = new Promise<void>((resolve) => {
+        firstAppendDone = resolve;
+      });
+      fs.promises.truncate = async (...args) => {
+        truncateCalls += 1;
+        if (truncateCalls === 2) await firstAppend;
+        return originalTruncate(...args);
+      };
+      fs.promises.appendFile = async (...args) => {
+        const result = await originalAppendFile(...args);
+        firstAppendDone();
+        return result;
+      };
+      syncBuiltinESMExports();
+
+      try {
+        await Promise.all(appended.map((event) => appendFixedPromptWalEvent(resultsJsonlPath, event)));
+      } finally {
+        fs.promises.truncate = originalTruncate;
+        fs.promises.appendFile = originalAppendFile;
+        syncBuiltinESMExports();
+      }
+
+      const events = await readFixedPromptWal(resultsJsonlPath);
+      assert.equal(events.length, appended.length + 1);
+      const taskIds = events.flatMap((event) => 'taskId' in event ? [event.taskId] : []);
+      assert.deepEqual(
+        new Set(taskIds),
+        new Set(['retained', 'task-a', 'task-b']),
+      );
     });
   });
 

--- a/packages/headless/src/__tests__/fixed-prompt-controller.test.ts
+++ b/packages/headless/src/__tests__/fixed-prompt-controller.test.ts
@@ -651,6 +651,10 @@ describe('fixed prompt controller', () => {
       assert.equal(result.totalCostUsd, 0.42);
       assert.equal(result.events[0]?.type, 'task_budget_exhausted');
       assert.deepEqual('tokenSummary' in result.events[0]! ? result.events[0].tokenSummary : undefined, retainedUsage);
+      assert.equal(
+        'tokenSummarySource' in result.events[0]! ? result.events[0].tokenSummarySource : undefined,
+        'checkpoint',
+      );
     });
   });
 
@@ -735,6 +739,7 @@ describe('fixed prompt controller', () => {
       assert.equal(event.evidenceErrorClass, undefined);
       assert.equal(event.tokenSummary?.total, 3);
       assert.equal(event.tokenSummary?.costUsd, 0.02);
+      assert.equal(event.tokenSummarySource, 'final');
       assert.equal(event.runtimeEventsPath, cell.runtimeEventsPath);
       assert.equal(event.traceEventsPath, cell.traceEventsPath);
       assert.deepEqual(

--- a/packages/headless/src/__tests__/harbor-adapter.test.ts
+++ b/packages/headless/src/__tests__/harbor-adapter.test.ts
@@ -1437,20 +1437,20 @@ try:
                         "input": 60,
                         "output": 20,
                         "reasoning": 5,
-                        "cache": {"read": 40, "write": 0},
+                        "cache": {"read": 40, "write": 10},
                     }
                 },
             },
             {"type": "tool", "part": {"type": "tool", "tool": "bash"}},
         ]
         agent.populate_context_post_run(context)
-        expected = (60 / 1_000_000 * 2) + (20 / 1_000_000 * 10) + (40 / 1_000_000 * 0.5)
+        expected = (60 / 1_000_000 * 2) + (20 / 1_000_000 * 10) + (40 / 1_000_000 * 0.5) + (10 / 1_000_000 * 3)
         assert abs(context.cost_usd - expected) < 1e-12, context.cost_usd
-        assert context.metadata["opencode_input_tokens"] == 100, context.metadata
+        assert context.metadata["opencode_input_tokens"] == 110, context.metadata
         assert context.metadata["opencode_output_tokens"] == 20, context.metadata
         assert context.metadata["opencode_cached_input_tokens"] == 40, context.metadata
         assert context.metadata["opencode_cache_miss_input_tokens"] == 60, context.metadata
-        assert context.metadata["opencode_cache_write_input_tokens"] == 0, context.metadata
+        assert context.metadata["opencode_cache_write_input_tokens"] == 10, context.metadata
         assert context.metadata["opencode_estimated_cost_usd"] == context.cost_usd, context.metadata
         assert context.metadata["opencode_reported_cost_usd"] == 0.99, context.metadata
         assert context.metadata["opencode_pricing_source"] == "xiaomi-env", context.metadata
@@ -1458,6 +1458,9 @@ try:
         assert cell["executionIdentity"]["model"] == "glm-5.2", cell
         assert cell["executionIdentity"]["reasoningEffort"] == "max", cell
         assert cell["tokenSummary"]["cachedInput"] == 40, cell
+        assert cell["tokenSummary"]["input"] == 110, cell
+        assert cell["tokenSummary"]["cacheMissInput"] == 60, cell
+        assert cell["tokenSummary"]["cacheWriteInput"] == 10, cell
         assert cell["tokenSummary"]["reasoning"] == 5, cell
         assert cell["toolSummary"]["actualToolCallCounts"] == {"bash": 1}, cell
         assert "test-zai-key" not in json.dumps(cell), cell

--- a/packages/headless/src/__tests__/harbor-adapter.test.ts
+++ b/packages/headless/src/__tests__/harbor-adapter.test.ts
@@ -793,7 +793,7 @@ import urllib.request
 
 scoped_command = maka_agent_mod._scoped_command("printf test", "cell-scope", "command-1")
 assert "MAKA_HARBOR_COMMAND_SCOPE=cell-scope" in scoped_command, scoped_command
-assert "setsid bash -lc" in scoped_command, scoped_command
+assert "set -m" in scoped_command, scoped_command
 assert "/tmp/maka-harbor-command-scopes/cell-scope/command-1.pgid" in scoped_command, scoped_command
 assert "bash -lc" in scoped_command, scoped_command
 term_cleanup = maka_agent_mod._scoped_process_cleanup_command("cell-scope", "TERM")

--- a/packages/headless/src/__tests__/harbor-adapter.test.ts
+++ b/packages/headless/src/__tests__/harbor-adapter.test.ts
@@ -812,48 +812,59 @@ class DelayedToolAgent:
     def __init__(self):
         self.started = asyncio.Event()
         self.spawned = []
+        self.cancelled = False
 
     def _cell_timeout_sec(self):
         return 1
 
     async def exec_as_agent(self, environment, command, **kwargs):
         if "/proc/[0-9]*/environ" in command:
+            if "kill -KILL" in command:
+                for process in self.spawned:
+                    if process.returncode is None:
+                        process.kill()
+                        await process.wait()
             return types.SimpleNamespace(stdout="", stderr="", exit_code=0)
         self.started.set()
-        await asyncio.sleep(0.5)
+        try:
+            await asyncio.sleep(0.5)
+        except asyncio.CancelledError:
+            self.cancelled = True
+            await asyncio.sleep(0.5)
         process = await asyncio.create_subprocess_exec("sleep", "30")
         self.spawned.append(process)
+        await process.wait()
         return types.SimpleNamespace(stdout="", stderr="", exit_code=0)
 
-async def assert_teardown_cancels_delayed_tool_start():
+async def assert_abnormal_teardown_drains_delayed_tool_start():
     agent = DelayedToolAgent()
     request_thread = None
-    async with maka_agent_mod._ToolExecutorServer(agent, object()) as server:
-        def send_request():
-            request = urllib.request.Request(
-                server.url + "/exec",
-                data=json.dumps({"command": "sleep 30 &"}).encode("utf-8"),
-                headers={"authorization": "Bearer " + server.token, "content-type": "application/json"},
-                method="POST",
-            )
-            try:
-                urllib.request.urlopen(request, timeout=2).read()
-            except Exception:
-                pass
+    try:
+        async with maka_agent_mod._ToolExecutorServer(agent, object()) as server:
+            def send_request():
+                request = urllib.request.Request(
+                    server.url + "/exec",
+                    data=json.dumps({"command": "sleep 30 &"}).encode("utf-8"),
+                    headers={"authorization": "Bearer " + server.token, "content-type": "application/json"},
+                    method="POST",
+                )
+                try:
+                    urllib.request.urlopen(request, timeout=3).read()
+                except Exception:
+                    pass
 
-        request_thread = threading.Thread(target=send_request, daemon=True)
-        request_thread.start()
-        await asyncio.wait_for(agent.started.wait(), timeout=1)
+            request_thread = threading.Thread(target=send_request, daemon=True)
+            request_thread.start()
+            await asyncio.wait_for(agent.started.wait(), timeout=1)
+            raise ValueError("cell failed")
+    except ValueError:
+        pass
 
-    await asyncio.sleep(0.7)
     request_thread.join(timeout=1)
-    spawned = list(agent.spawned)
-    for process in spawned:
-        process.kill()
-        await process.wait()
-    assert not spawned, "tool command started after executor teardown"
+    assert not agent.cancelled, "executor cancelled the Harbor Docker execution instead of draining it"
+    assert all(process.returncode is not None for process in agent.spawned), "tool command survived executor teardown"
 
-asyncio.run(assert_teardown_cancels_delayed_tool_start())
+asyncio.run(assert_abnormal_teardown_drains_delayed_tool_start())
 
 class FailingTermCleanupAgent:
     def __init__(self):

--- a/packages/headless/src/__tests__/harbor-adapter.test.ts
+++ b/packages/headless/src/__tests__/harbor-adapter.test.ts
@@ -865,7 +865,7 @@ async def assert_kill_cleanup_runs_after_term_failure():
     agent = FailingTermCleanupAgent()
     try:
         async with maka_agent_mod._ToolExecutorServer(agent, object()):
-            pass
+            raise ValueError("cell failed")
     except RuntimeError as error:
         assert "TERM cleanup failed" in str(error), error
     else:
@@ -873,6 +873,37 @@ async def assert_kill_cleanup_runs_after_term_failure():
     assert agent.signals == ["TERM", "KILL"], agent.signals
 
 asyncio.run(assert_kill_cleanup_runs_after_term_failure())
+
+class LocalCleanupAgent:
+    async def exec_as_agent(self, environment, command, **kwargs):
+        process = await asyncio.create_subprocess_exec("bash", "-lc", command)
+        await process.wait()
+        return types.SimpleNamespace(stdout="", stderr="", exit_code=process.returncode)
+
+async def assert_normal_exit_preserves_verifier_processes():
+    server = maka_agent_mod._ToolExecutorServer(LocalCleanupAgent(), object())
+    scope_dir = Path("/tmp/maka-harbor-command-scopes") / server.command_scope
+    scope_dir.mkdir(parents=True, exist_ok=True)
+    process = subprocess.Popen(
+        ["sleep", "30"],
+        start_new_session=True,
+        env={"PATH": os.environ.get("PATH", "")},
+    )
+    (scope_dir / "verifier-service.pgid").write_text(str(process.pid) + "\n", encoding="utf-8")
+    try:
+        async with server:
+            pass
+        assert process.poll() is None, "normal agent exit killed verifier-visible process"
+    finally:
+        if process.poll() is None:
+            os.killpg(process.pid, signal.SIGKILL)
+            process.wait()
+        if scope_dir.exists():
+            for path in scope_dir.glob("*"):
+                path.unlink()
+            scope_dir.rmdir()
+
+asyncio.run(assert_normal_exit_preserves_verifier_processes())
 
 scope = "env-cleared-" + str(os.getpid())
 scope_dir = Path("/tmp/maka-harbor-command-scopes") / scope

--- a/packages/headless/src/__tests__/harbor-adapter.test.ts
+++ b/packages/headless/src/__tests__/harbor-adapter.test.ts
@@ -48,6 +48,10 @@ describe('Harbor adapter contract', () => {
     assert.match(source, /MAKA_HARBOR_TOOL_EXECUTOR_URL/);
     assert.match(source, /_run_host_cell/);
     assert.match(source, /_ToolExecutorServer/);
+    assert.match(source, /MAKA_HARBOR_COMMAND_SCOPE/);
+    assert.match(source, /_cleanup_scoped_processes/);
+    assert.match(source, /signal="TERM"/);
+    assert.match(source, /signal="KILL"/);
     assert.match(source, /upload_file\(local_instruction_path, instruction_path\.as_posix\(\)\)/);
     assert.match(source, /bash -lc/);
     assert.match(source, /set -o pipefail/);
@@ -781,6 +785,15 @@ sys.path.insert(0, str(root / "packages" / "headless" / "harbor"))
 import maka_agent as maka_agent_mod
 from maka_agent import MakaAgent
 import asyncio
+
+scoped_command = maka_agent_mod._scoped_command("printf test", "cell-scope")
+assert "MAKA_HARBOR_COMMAND_SCOPE=cell-scope" in scoped_command, scoped_command
+assert "bash -lc" in scoped_command, scoped_command
+term_cleanup = maka_agent_mod._scoped_process_cleanup_command("cell-scope", "TERM")
+kill_cleanup = maka_agent_mod._scoped_process_cleanup_command("cell-scope", "KILL")
+assert "/proc/[0-9]*/environ" in term_cleanup, term_cleanup
+assert "kill -TERM" in term_cleanup, term_cleanup
+assert "kill -KILL" in kill_cleanup, kill_cleanup
 
 with tempfile.TemporaryDirectory() as tmp:
     install_agent = MakaAgent(Path(tmp))

--- a/packages/headless/src/__tests__/harbor-adapter.test.ts
+++ b/packages/headless/src/__tests__/harbor-adapter.test.ts
@@ -785,6 +785,8 @@ sys.path.insert(0, str(root / "packages" / "headless" / "harbor"))
 import maka_agent as maka_agent_mod
 from maka_agent import MakaAgent
 import asyncio
+import threading
+import urllib.request
 
 scoped_command = maka_agent_mod._scoped_command("printf test", "cell-scope")
 assert "MAKA_HARBOR_COMMAND_SCOPE=cell-scope" in scoped_command, scoped_command
@@ -794,6 +796,78 @@ kill_cleanup = maka_agent_mod._scoped_process_cleanup_command("cell-scope", "KIL
 assert "/proc/[0-9]*/environ" in term_cleanup, term_cleanup
 assert "kill -TERM" in term_cleanup, term_cleanup
 assert "kill -KILL" in kill_cleanup, kill_cleanup
+
+class DelayedToolAgent:
+    def __init__(self):
+        self.started = asyncio.Event()
+        self.spawned = []
+
+    def _cell_timeout_sec(self):
+        return 1
+
+    async def exec_as_agent(self, environment, command, **kwargs):
+        if "/proc/[0-9]*/environ" in command:
+            return types.SimpleNamespace(stdout="", stderr="", exit_code=0)
+        self.started.set()
+        await asyncio.sleep(0.5)
+        process = await asyncio.create_subprocess_exec("sleep", "30")
+        self.spawned.append(process)
+        return types.SimpleNamespace(stdout="", stderr="", exit_code=0)
+
+async def assert_teardown_cancels_delayed_tool_start():
+    agent = DelayedToolAgent()
+    request_thread = None
+    async with maka_agent_mod._ToolExecutorServer(agent, object()) as server:
+        def send_request():
+            request = urllib.request.Request(
+                server.url + "/exec",
+                data=json.dumps({"command": "sleep 30 &"}).encode("utf-8"),
+                headers={"authorization": "Bearer " + server.token, "content-type": "application/json"},
+                method="POST",
+            )
+            try:
+                urllib.request.urlopen(request, timeout=2).read()
+            except Exception:
+                pass
+
+        request_thread = threading.Thread(target=send_request, daemon=True)
+        request_thread.start()
+        await asyncio.wait_for(agent.started.wait(), timeout=1)
+
+    await asyncio.sleep(0.7)
+    request_thread.join(timeout=1)
+    spawned = list(agent.spawned)
+    for process in spawned:
+        process.kill()
+        await process.wait()
+    assert not spawned, "tool command started after executor teardown"
+
+asyncio.run(assert_teardown_cancels_delayed_tool_start())
+
+class FailingTermCleanupAgent:
+    def __init__(self):
+        self.signals = []
+
+    async def exec_as_agent(self, environment, command, **kwargs):
+        if "kill -TERM" in command:
+            self.signals.append("TERM")
+            raise RuntimeError("TERM cleanup failed")
+        if "kill -KILL" in command:
+            self.signals.append("KILL")
+        return types.SimpleNamespace(stdout="", stderr="", exit_code=0)
+
+async def assert_kill_cleanup_runs_after_term_failure():
+    agent = FailingTermCleanupAgent()
+    try:
+        async with maka_agent_mod._ToolExecutorServer(agent, object()):
+            pass
+    except RuntimeError as error:
+        assert "TERM cleanup failed" in str(error), error
+    else:
+        raise AssertionError("expected TERM cleanup failure")
+    assert agent.signals == ["TERM", "KILL"], agent.signals
+
+asyncio.run(assert_kill_cleanup_runs_after_term_failure())
 
 with tempfile.TemporaryDirectory() as tmp:
     install_agent = MakaAgent(Path(tmp))

--- a/packages/headless/src/__tests__/harbor-adapter.test.ts
+++ b/packages/headless/src/__tests__/harbor-adapter.test.ts
@@ -785,11 +785,16 @@ sys.path.insert(0, str(root / "packages" / "headless" / "harbor"))
 import maka_agent as maka_agent_mod
 from maka_agent import MakaAgent
 import asyncio
+import signal
+import subprocess
 import threading
+import time
 import urllib.request
 
-scoped_command = maka_agent_mod._scoped_command("printf test", "cell-scope")
+scoped_command = maka_agent_mod._scoped_command("printf test", "cell-scope", "command-1")
 assert "MAKA_HARBOR_COMMAND_SCOPE=cell-scope" in scoped_command, scoped_command
+assert "setsid bash -lc" in scoped_command, scoped_command
+assert "/tmp/maka-harbor-command-scopes/cell-scope/command-1.pgid" in scoped_command, scoped_command
 assert "bash -lc" in scoped_command, scoped_command
 term_cleanup = maka_agent_mod._scoped_process_cleanup_command("cell-scope", "TERM")
 kill_cleanup = maka_agent_mod._scoped_process_cleanup_command("cell-scope", "KILL")
@@ -868,6 +873,32 @@ async def assert_kill_cleanup_runs_after_term_failure():
     assert agent.signals == ["TERM", "KILL"], agent.signals
 
 asyncio.run(assert_kill_cleanup_runs_after_term_failure())
+
+scope = "env-cleared-" + str(os.getpid())
+scope_dir = Path("/tmp/maka-harbor-command-scopes") / scope
+scope_dir.mkdir(parents=True, exist_ok=True)
+env_cleared_process = subprocess.Popen(
+    ["sleep", "30"],
+    start_new_session=True,
+    env={"PATH": os.environ.get("PATH", "")},
+)
+(scope_dir / "command.pgid").write_text(str(env_cleared_process.pid) + "\n", encoding="utf-8")
+try:
+    subprocess.run(
+        ["bash", "-lc", maka_agent_mod._scoped_process_cleanup_command(scope, "TERM")],
+        check=True,
+    )
+    deadline = time.time() + 1
+    while env_cleared_process.poll() is None and time.time() < deadline:
+        time.sleep(0.01)
+    assert env_cleared_process.poll() is not None, "env-cleared process group survived scoped cleanup"
+finally:
+    if env_cleared_process.poll() is None:
+        os.killpg(env_cleared_process.pid, signal.SIGKILL)
+        env_cleared_process.wait()
+    for path in scope_dir.glob("*"):
+        path.unlink()
+    scope_dir.rmdir()
 
 with tempfile.TemporaryDirectory() as tmp:
     install_agent = MakaAgent(Path(tmp))

--- a/packages/headless/src/__tests__/harbor-adapter.test.ts
+++ b/packages/headless/src/__tests__/harbor-adapter.test.ts
@@ -1326,6 +1326,14 @@ try:
         assert "templated: hi" in command, command
         assert env["ZAI_API_KEY"] == "ephemeral-proxy-token", env
         assert env["ZAI_BASE_URL"] == "http://host.docker.internal:43210", env
+        assert env["OPENCODE_CONFIG"] == "/opt/maka-agent/packages/headless/harbor/opencode-benchmark.json", env
+        benchmark_config = json.loads(
+            (root / "packages" / "headless" / "harbor" / "opencode-benchmark.json").read_text(encoding="utf-8")
+        )
+        assert benchmark_config["provider"]["zai-coding-plan"]["options"] == {
+            "apiKey": "{env:ZAI_API_KEY}",
+            "baseURL": "{env:ZAI_BASE_URL}",
+        }, benchmark_config
         assert environment.uploaded_files == [], environment.uploaded_files
         assert 'cat --' not in command, command
         assert "test-zai-key" not in command, command

--- a/packages/headless/src/__tests__/harbor-adapter.test.ts
+++ b/packages/headless/src/__tests__/harbor-adapter.test.ts
@@ -114,6 +114,12 @@ describe('Harbor adapter contract', () => {
     assert.doesNotMatch(result.stderr, /does not provide an export named/);
   });
 
+  test('run-host-cell.mjs persists usage checkpoints for timed-out host cells', async () => {
+    const source = await readRepoFile('packages/headless/harbor/run-host-cell.mjs');
+
+    assert.match(source, /recordUsageCheckpoint:\s*\(usage\)\s*=>\s*writeHarborCellUsageCheckpoint\(outputDir, usage\)/);
+  });
+
   test('run-host-cell.mjs forwards Harbor cell context schema env keys to the backend', async () => {
     const tmp = mkdtempSync(resolve(tmpdir(), 'maka-host-cell-env-'));
     try {
@@ -1528,6 +1534,20 @@ try:
         assert cell["tokenSummary"]["reasoning"] == 5, cell
         assert cell["toolSummary"]["actualToolCallCounts"] == {"bash": 1}, cell
         assert "test-zai-key" not in json.dumps(cell), cell
+
+        missing_usage_agent = MakaOpenCodeAgent(Path(tmp), extra_env={
+            "MAKA_SYSTEM_PROMPT": "",
+            "MAKA_TRIAL_PRICING_SOURCE": "xiaomi-env",
+        }, model_name="zai-coding-plan/glm-5.2")
+        missing_usage_agent._parse_stdout = lambda: []
+        missing_usage_context = AgentContext()
+        missing_usage_context.n_input_tokens = None
+        missing_usage_context.n_output_tokens = None
+        missing_usage_context.n_cache_tokens = None
+        missing_usage_context.cost_usd = None
+        missing_usage_agent._write_cell_output(missing_usage_context)
+        missing_usage_cell = json.loads((Path(tmp) / "maka-cell-output.json").read_text(encoding="utf-8"))
+        assert "tokenSummary" not in missing_usage_cell, missing_usage_cell
 
         failing_agent = MakaOpenCodeAgent(Path(tmp), extra_env={
             "MAKA_OPENCODE_PROVIDER_PROXY_URL": "http://host.docker.internal:43210",

--- a/packages/headless/src/__tests__/harbor-adapter.test.ts
+++ b/packages/headless/src/__tests__/harbor-adapter.test.ts
@@ -1444,10 +1444,10 @@ try:
             {"type": "tool", "part": {"type": "tool", "tool": "bash"}},
         ]
         agent.populate_context_post_run(context)
-        expected = (60 / 1_000_000 * 2) + (20 / 1_000_000 * 10) + (40 / 1_000_000 * 0.5) + (10 / 1_000_000 * 3)
+        expected = (60 / 1_000_000 * 2) + (25 / 1_000_000 * 10) + (40 / 1_000_000 * 0.5) + (10 / 1_000_000 * 3)
         assert abs(context.cost_usd - expected) < 1e-12, context.cost_usd
         assert context.metadata["opencode_input_tokens"] == 110, context.metadata
-        assert context.metadata["opencode_output_tokens"] == 20, context.metadata
+        assert context.metadata["opencode_output_tokens"] == 25, context.metadata
         assert context.metadata["opencode_cached_input_tokens"] == 40, context.metadata
         assert context.metadata["opencode_cache_miss_input_tokens"] == 60, context.metadata
         assert context.metadata["opencode_cache_write_input_tokens"] == 10, context.metadata
@@ -1459,6 +1459,8 @@ try:
         assert cell["executionIdentity"]["reasoningEffort"] == "max", cell
         assert cell["tokenSummary"]["cachedInput"] == 40, cell
         assert cell["tokenSummary"]["input"] == 110, cell
+        assert cell["tokenSummary"]["output"] == 25, cell
+        assert cell["tokenSummary"]["total"] == 135, cell
         assert cell["tokenSummary"]["cacheMissInput"] == 60, cell
         assert cell["tokenSummary"]["cacheWriteInput"] == 10, cell
         assert cell["tokenSummary"]["reasoning"] == 5, cell

--- a/packages/headless/src/__tests__/harbor-cell.test.ts
+++ b/packages/headless/src/__tests__/harbor-cell.test.ts
@@ -31,9 +31,11 @@ import {
   HARBOR_CELL_CONTEXT_ENV_KEYS,
   HARBOR_CELL_OUTPUT_FILENAME,
   HARBOR_CELL_RUNTIME_EVENTS_FILENAME,
+  HARBOR_CELL_USAGE_CHECKPOINT_FILENAME,
   resolveHarborCellAiSdkEnv,
   runHarborCellFromEnv,
   runHarborCell,
+  writeHarborCellUsageCheckpoint,
 } from '../harbor-cell.js';
 
 const config: Config = {
@@ -300,6 +302,50 @@ function registerStepCapTwiceThenCompleteBackend(seen: { backend?: StepCapTwiceT
 }
 
 describe('runHarborCell', () => {
+  test('atomically replaces the cumulative completed-step usage checkpoint', async () => {
+    await withDirs(async ({ outputDir }) => {
+      const first = {
+        inputTokens: 100,
+        outputTokens: 5,
+        cacheHitInputTokens: 20,
+        cacheMissInputTokens: 80,
+        cacheMissInputSource: 'explicit' as const,
+        cacheWriteInputTokens: 0,
+        reasoningTokens: 1,
+        totalTokens: 105,
+        costUsd: 0.001,
+      };
+      await writeHarborCellUsageCheckpoint(outputDir, first);
+      await writeHarborCellUsageCheckpoint(outputDir, {
+        ...first,
+        inputTokens: 300,
+        outputTokens: 12,
+        cacheHitInputTokens: 100,
+        cacheMissInputTokens: 200,
+        reasoningTokens: 2,
+        totalTokens: 312,
+        costUsd: 0.003,
+      });
+
+      assert.deepEqual(
+        JSON.parse(await readFile(join(outputDir, HARBOR_CELL_USAGE_CHECKPOINT_FILENAME), 'utf8')),
+        {
+          input: 300,
+          output: 12,
+          cachedInput: 100,
+          cacheHitInput: 100,
+          cacheMissInput: 200,
+          cacheWriteInput: 0,
+          cacheMissInputSource: 'explicit',
+          reasoning: 2,
+          total: 312,
+          costUsd: 0.003,
+          pricingSource: 'runtime',
+        },
+      );
+    });
+  });
+
   test('runs in the provided workspace and writes the shared cell artifacts', async () => {
     await withDirs(async ({ workspaceDir, outputDir, storageRoot }) => {
       const result = await runHarborCell({

--- a/packages/headless/src/__tests__/harbor-cell.test.ts
+++ b/packages/headless/src/__tests__/harbor-cell.test.ts
@@ -346,6 +346,26 @@ describe('runHarborCell', () => {
     });
   });
 
+  test('does not turn unknown checkpoint cost into zero', async () => {
+    await withDirs(async ({ outputDir }) => {
+      await writeHarborCellUsageCheckpoint(outputDir, {
+        inputTokens: 100,
+        outputTokens: 5,
+        cacheHitInputTokens: 20,
+        cacheMissInputTokens: 80,
+        cacheMissInputSource: 'explicit',
+        cacheWriteInputTokens: 0,
+        reasoningTokens: 1,
+        totalTokens: 105,
+      });
+
+      await assert.rejects(
+        readFile(join(outputDir, HARBOR_CELL_USAGE_CHECKPOINT_FILENAME), 'utf8'),
+        (error: NodeJS.ErrnoException) => error.code === 'ENOENT',
+      );
+    });
+  });
+
   test('runs in the provided workspace and writes the shared cell artifacts', async () => {
     await withDirs(async ({ workspaceDir, outputDir, storageRoot }) => {
       const result = await runHarborCell({

--- a/packages/headless/src/__tests__/harbor-cell.test.ts
+++ b/packages/headless/src/__tests__/harbor-cell.test.ts
@@ -698,7 +698,7 @@ describe('runHarborCell', () => {
         staleToolResultPrune: {
           enabled: true,
           maxResultEstimatedTokens: 256,
-          minRecentTurnsFull: 2,
+          minRecentTurnsFull: 0,
         },
         activeToolResultPrune: {
           enabled: true,
@@ -1408,7 +1408,7 @@ describe('runHarborCell', () => {
         input: ReturnType<typeof buildHarborCellContextBudgetBackendOptions>;
       }).input;
       assert.equal(backendInput.contextBudget?.staleToolResultPrune?.enabled, true);
-      assert.equal(backendInput.contextBudget?.staleToolResultPrune?.minRecentTurnsFull, 2);
+      assert.equal(backendInput.contextBudget?.staleToolResultPrune?.minRecentTurnsFull, 0);
       assert.equal(backendInput.contextBudget?.archiveRetrieval?.enabled, true);
       assert.equal(backendInput.contextBudget?.archiveRetrieval?.mode, undefined);
       assert.ok(backendInput.archiveToolResult, 'expected archive writer for the placeholder producer');
@@ -1657,21 +1657,18 @@ describe('runHarborCell', () => {
   test('Harbor active tool result prune can be disabled with explicit off', () => {
     const options = buildHarborCellContextBudgetBackendOptions({ MAKA_CONTEXT_ACTIVE_TOOL_RESULT_PRUNE: 'off' });
     assert.equal(options.contextBudget?.activeToolResultPrune, undefined);
-    assert.deepEqual(options.contextBudget?.staleToolResultPrune, { enabled: true, minRecentTurnsFull: 2 });
+    assert.deepEqual(options.contextBudget?.staleToolResultPrune, { enabled: true, minRecentTurnsFull: 0 });
   });
 
   test('Harbor stale tool result prune is enabled by default without any env', () => {
     const backend = buildHarborCellContextBudgetBackendOptions({});
-    // minRecentTurnsFull is set explicitly so the runtime protection window
-    // matches the policy snapshot and desktop default instead of the runtime's
-    // internal ?? 1 fallback.
-    assert.deepEqual(backend.contextBudget?.staleToolResultPrune, { enabled: true, minRecentTurnsFull: 2 });
+    assert.deepEqual(backend.contextBudget?.staleToolResultPrune, { enabled: true, minRecentTurnsFull: 0 });
 
     const snapshot = buildHarborCellContextBudgetPolicySnapshot({});
     assert.equal(snapshot?.enabled, true);
     assert.equal(snapshot?.staleToolResultPrune?.enabled, true);
     assert.equal(snapshot?.staleToolResultPrune?.maxResultEstimatedTokens, 2048);
-    assert.equal(snapshot?.staleToolResultPrune?.minRecentTurnsFull, 2);
+    assert.equal(snapshot?.staleToolResultPrune?.minRecentTurnsFull, 0);
   });
 
   test('Harbor stale tool result prune can be disabled with explicit off', () => {
@@ -1680,9 +1677,9 @@ describe('runHarborCell', () => {
     assert.deepEqual(options.contextBudget?.activeToolResultPrune, { enabled: true });
   });
 
-  test('Harbor stale tool result prune min recent turns falls back to MAKA_CONTEXT_MIN_RECENT_TURNS', () => {
+  test('Harbor stale tool result prune does not inherit the general recent-turn window', () => {
     const fallback = buildHarborCellContextBudgetBackendOptions({ MAKA_CONTEXT_MIN_RECENT_TURNS: '3' });
-    assert.equal(fallback.contextBudget?.staleToolResultPrune?.minRecentTurnsFull, 3);
+    assert.equal(fallback.contextBudget?.staleToolResultPrune?.minRecentTurnsFull, 0);
 
     const explicit = buildHarborCellContextBudgetBackendOptions({
       MAKA_CONTEXT_MIN_RECENT_TURNS: '3',

--- a/packages/headless/src/__tests__/harbor-task-runner.test.ts
+++ b/packages/headless/src/__tests__/harbor-task-runner.test.ts
@@ -66,6 +66,7 @@ interface FakeOptions {
   reward?: string;
   cell?: HarborCellOutput | null;
   executionIdentity?: HarborCellExecutionIdentity;
+  usageCheckpoint?: HarborCellOutput['tokenSummary'];
   exitCode?: number;
   events?: string;
   verifierStdout?: string;
@@ -98,6 +99,13 @@ function fakeRunner(opts: FakeOptions): HarborProcessRunner {
       await writeFile(
         join(trialDir, 'agent', 'maka-cell-execution-identity.json'),
         JSON.stringify(opts.executionIdentity),
+        'utf8',
+      );
+    }
+    if (opts.usageCheckpoint) {
+      await writeFile(
+        join(trialDir, 'agent', 'maka-cell-usage-checkpoint.json'),
+        JSON.stringify(opts.usageCheckpoint),
         'utf8',
       );
     }
@@ -684,13 +692,26 @@ describe('createHarborTaskRunner', () => {
     });
   });
 
-  test('recovers early identity from an agent-timeout trial without cell output', async () => {
+  test('recovers early identity and completed-step usage from an agent-timeout trial without cell output', async () => {
     await withRun(async ({ jobsDir, repo }) => {
       const executionIdentity = {
         llmConnectionSlug: 'deepseek',
         model: 'deepseek-v4-flash',
         systemPromptHash: 'sha256:abc',
         pricingProfile: 'test-profile',
+      };
+      const usageCheckpoint: HarborCellOutput['tokenSummary'] = {
+        input: 12_000,
+        output: 800,
+        cachedInput: 10_000,
+        cacheHitInput: 10_000,
+        cacheMissInput: 2_000,
+        cacheWriteInput: 0,
+        cacheMissInputSource: 'explicit',
+        reasoning: 400,
+        total: 12_800,
+        costUsd: 0.01,
+        pricingSource: 'runtime',
       };
       const runner = createHarborTaskRunner({
         makaRepoPath: repo,
@@ -700,6 +721,7 @@ describe('createHarborTaskRunner', () => {
           reward: '0\n',
           cell: null,
           executionIdentity,
+          usageCheckpoint,
           trialResult: {
             exception_info: {
               exception_type: 'AgentTimeoutError',
@@ -715,6 +737,7 @@ describe('createHarborTaskRunner', () => {
           (error.artifactRefs as { executionIdentity?: HarborCellExecutionIdentity } | undefined)?.executionIdentity,
           executionIdentity,
         );
+        assert.deepEqual(error.artifactRefs?.tokenSummary, usageCheckpoint);
         return true;
       });
     });

--- a/packages/headless/src/__tests__/harbor-task-runner.test.ts
+++ b/packages/headless/src/__tests__/harbor-task-runner.test.ts
@@ -854,7 +854,9 @@ describe('buildHarborJobConfig', () => {
     const agent = (config.agents as Array<Record<string, unknown>>)[0]!;
     const env = agent.env as Record<string, string>;
 
-    assert.equal(agent.name, 'opencode');
+    // Harbor resolves built-in names before import_path, so setting both would
+    // silently bypass MakaOpenCodeAgent and its host-side auth proxy.
+    assert.equal(agent.name, undefined);
     assert.equal(agent.import_path, 'opencode_agent:MakaOpenCodeAgent');
     assert.equal(agent.model_name, 'zai-coding-plan/glm-5.2');
     assert.deepEqual(agent.kwargs, { version: '1.17.18' });

--- a/packages/headless/src/__tests__/harness-ab-cli.test.ts
+++ b/packages/headless/src/__tests__/harness-ab-cli.test.ts
@@ -9,6 +9,25 @@ import { TERMINAL_BENCH_2_1_TASK_IDS } from '../harness-ab-manifest.js';
 
 const execFileAsync = promisify(execFile);
 
+test('harness A/B CLI accepts the fixed 30-task pilot limit', async () => {
+  const dir = await mkdtemp(join(tmpdir(), 'maka-harness-ab-cli-'));
+  try {
+    const scriptPath = new URL('../../harbor/run-harness-ab.mjs', import.meta.url);
+    await assert.rejects(execFileAsync(process.execPath, [scriptPath.pathname], {
+      cwd: process.cwd(),
+      env: {
+        ...process.env,
+        MAKA_HARNESS_AB_OUT_DIR: join(dir, 'out'),
+        MAKA_HARNESS_AB_TASKS_ROOT: join(dir, 'missing-tasks'),
+        MAKA_HARNESS_AB_LIMIT: '30',
+        MAKA_HARNESS_AB_DRY_RUN: '1',
+      },
+    }), /Terminal-Bench 2\.1 task set mismatch/);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
 test('harness A/B CLI rejects modified task contents before reading credentials', async () => {
   const dir = await mkdtemp(join(tmpdir(), 'maka-harness-ab-cli-'));
   try {
@@ -27,7 +46,7 @@ test('harness A/B CLI rejects modified task contents before reading credentials'
         MAKA_HARNESS_AB_OUT_DIR: outDir,
         MAKA_HARNESS_AB_TASKS_ROOT: tasksRoot,
         MAKA_HARNESS_AB_RUN_ID: 'dry-run',
-        MAKA_HARNESS_AB_LIMIT: '40',
+        MAKA_HARNESS_AB_LIMIT: '30',
         MAKA_HARNESS_AB_DRY_RUN: '1',
         MAKA_HARNESS_AB_KEY_FILE: join(dir, 'must-not-be-read'),
         MAKA_HARNESS_AB_EXPLICIT_SUBJECT_FINGERPRINT: `sha256:${'a'.repeat(64)}`,

--- a/packages/headless/src/__tests__/harness-ab-cli.test.ts
+++ b/packages/headless/src/__tests__/harness-ab-cli.test.ts
@@ -93,7 +93,7 @@ test('duplicate detached launch does not overwrite the active run journal', asyn
     await writeFile(join(runRoot, 'background-run.json'), `${JSON.stringify(journal, null, 2)}\n`, 'utf8');
 
     const scriptPath = new URL('../../harbor/run-harness-ab-detached.mjs', import.meta.url);
-    await execFileAsync(process.execPath, [scriptPath.pathname], {
+    await assert.rejects(execFileAsync(process.execPath, [scriptPath.pathname], {
       cwd: process.cwd(),
       env: {
         ...process.env,
@@ -103,7 +103,7 @@ test('duplicate detached launch does not overwrite the active run journal', asyn
         MAKA_HARNESS_AB_LIMIT: '2',
         MAKA_HARNESS_AB_DRY_RUN: '1',
       },
-    });
+    }), /before acquiring the run lock/);
 
     await waitForFileMatch(join(runRoot, 'background-run.log'), /Terminal-Bench 2\.1 task set mismatch|A\/B run is already active/);
     assert.deepEqual(

--- a/packages/headless/src/__tests__/harness-ab-cli.test.ts
+++ b/packages/headless/src/__tests__/harness-ab-cli.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import { execFile } from 'node:child_process';
-import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { promisify } from 'node:util';
@@ -23,6 +23,36 @@ test('harness A/B CLI accepts a 2-task operational canary', async () => {
         MAKA_HARNESS_AB_DRY_RUN: '1',
       },
     }), /Terminal-Bench 2\.1 task set mismatch/);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test('detached harness launcher persists a terminal failed journal after the worker exits', async () => {
+  const dir = await mkdtemp(join(tmpdir(), 'maka-harness-ab-detached-'));
+  try {
+    const outDir = join(dir, 'out');
+    const runId = 'detached-smoke';
+    const scriptPath = new URL('../../harbor/run-harness-ab-detached.mjs', import.meta.url);
+    await execFileAsync(process.execPath, [scriptPath.pathname], {
+      cwd: process.cwd(),
+      env: {
+        ...process.env,
+        MAKA_HARNESS_AB_OUT_DIR: outDir,
+        MAKA_HARNESS_AB_RUN_ID: runId,
+        MAKA_HARNESS_AB_TASKS_ROOT: join(dir, 'missing-tasks'),
+        MAKA_HARNESS_AB_LIMIT: '2',
+        MAKA_HARNESS_AB_DRY_RUN: '1',
+      },
+    });
+
+    const journalPath = join(outDir, runId, 'background-run.json');
+    const journal = await waitForJournal(journalPath, (value) => value.status === 'failed');
+    assert.equal(journal.exitCode, 1);
+    assert.equal(typeof journal.pid, 'number');
+    assert.equal(typeof journal.startedAt, 'string');
+    assert.equal(typeof journal.finishedAt, 'string');
+    assert.match(await readFile(join(outDir, runId, 'background-run.log'), 'utf8'), /Terminal-Bench 2\.1 task set mismatch/);
   } finally {
     await rm(dir, { recursive: true, force: true });
   }
@@ -76,3 +106,20 @@ test('harness A/B CLI rejects modified task contents before reading credentials'
     await rm(dir, { recursive: true, force: true });
   }
 });
+
+async function waitForJournal(
+  path: string,
+  predicate: (value: Record<string, unknown>) => boolean,
+): Promise<Record<string, unknown>> {
+  const deadline = Date.now() + 5_000;
+  while (Date.now() < deadline) {
+    try {
+      const value = JSON.parse(await readFile(path, 'utf8')) as Record<string, unknown>;
+      if (predicate(value)) return value;
+    } catch {
+      // The detached worker may not have created the journal yet.
+    }
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  }
+  throw new Error(`timed out waiting for detached journal ${path}`);
+}

--- a/packages/headless/src/__tests__/harness-ab-cli.test.ts
+++ b/packages/headless/src/__tests__/harness-ab-cli.test.ts
@@ -28,6 +28,22 @@ test('harness A/B CLI accepts a 2-task operational canary', async () => {
   }
 });
 
+test('harness A/B runtime keeps pruning enabled and semantic compact disabled', async () => {
+  const { harnessMakaContextBudgetEnv } = await import(
+    new URL('../../harbor/run-harness-ab.mjs', import.meta.url).href
+  );
+
+  assert.deepEqual(harnessMakaContextBudgetEnv(), {
+    MAKA_CONTEXT_ACTIVE_TOOL_RESULT_PRUNE: 'on',
+    MAKA_CONTEXT_ACTIVE_TOOL_RESULT_MAX_ESTIMATED_TOKENS: '2048',
+    MAKA_CONTEXT_ACTIVE_TOOL_RESULT_MIN_STEP_NUMBER: '1',
+    MAKA_CONTEXT_STALE_TOOL_RESULT_PRUNE: 'on',
+    MAKA_CONTEXT_STALE_TOOL_RESULT_MAX_ESTIMATED_TOKENS: '2048',
+    MAKA_CONTEXT_STALE_TOOL_RESULT_MIN_RECENT_TURNS_FULL: '0',
+    MAKA_CONTEXT_SEMANTIC_COMPACT: 'off',
+  });
+});
+
 test('detached harness launcher persists a terminal failed journal after the worker exits', async () => {
   const dir = await mkdtemp(join(tmpdir(), 'maka-harness-ab-detached-'));
   try {

--- a/packages/headless/src/__tests__/harness-ab-cli.test.ts
+++ b/packages/headless/src/__tests__/harness-ab-cli.test.ts
@@ -74,6 +74,47 @@ test('detached harness launcher persists a terminal failed journal after the wor
   }
 });
 
+test('duplicate detached launch does not overwrite the active run journal', async () => {
+  const dir = await mkdtemp(join(tmpdir(), 'maka-harness-ab-detached-'));
+  try {
+    const outDir = join(dir, 'out');
+    const runId = 'detached-active';
+    const runRoot = join(outDir, runId);
+    const lockDir = join(runRoot, '.ab-run.lock');
+    await mkdir(lockDir, { recursive: true });
+    await writeFile(join(lockDir, 'owner.json'), `${JSON.stringify({ pid: process.pid, startedAt: Date.now() })}\n`, 'utf8');
+    const journal = {
+      schemaVersion: 1,
+      pid: process.pid,
+      startedAt: '2026-07-14T00:00:00.000Z',
+      logPath: join(runRoot, 'background-run.log'),
+      status: 'running',
+    };
+    await writeFile(join(runRoot, 'background-run.json'), `${JSON.stringify(journal, null, 2)}\n`, 'utf8');
+
+    const scriptPath = new URL('../../harbor/run-harness-ab-detached.mjs', import.meta.url);
+    await execFileAsync(process.execPath, [scriptPath.pathname], {
+      cwd: process.cwd(),
+      env: {
+        ...process.env,
+        MAKA_HARNESS_AB_OUT_DIR: outDir,
+        MAKA_HARNESS_AB_RUN_ID: runId,
+        MAKA_HARNESS_AB_TASKS_ROOT: join(dir, 'missing-tasks'),
+        MAKA_HARNESS_AB_LIMIT: '2',
+        MAKA_HARNESS_AB_DRY_RUN: '1',
+      },
+    });
+
+    await waitForFileMatch(join(runRoot, 'background-run.log'), /Terminal-Bench 2\.1 task set mismatch|A\/B run is already active/);
+    assert.deepEqual(
+      JSON.parse(await readFile(join(runRoot, 'background-run.json'), 'utf8')),
+      journal,
+    );
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
 test('harness A/B CLI accepts the fixed 30-task pilot limit', async () => {
   const dir = await mkdtemp(join(tmpdir(), 'maka-harness-ab-cli-'));
   try {
@@ -138,4 +179,17 @@ async function waitForJournal(
     await new Promise((resolve) => setTimeout(resolve, 25));
   }
   throw new Error(`timed out waiting for detached journal ${path}`);
+}
+
+async function waitForFileMatch(path: string, pattern: RegExp): Promise<void> {
+  const deadline = Date.now() + 5_000;
+  while (Date.now() < deadline) {
+    try {
+      if (pattern.test(await readFile(path, 'utf8'))) return;
+    } catch {
+      // The detached worker may not have written its log yet.
+    }
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  }
+  throw new Error(`timed out waiting for ${path} to match ${pattern}`);
 }

--- a/packages/headless/src/__tests__/harness-ab-cli.test.ts
+++ b/packages/headless/src/__tests__/harness-ab-cli.test.ts
@@ -9,6 +9,25 @@ import { TERMINAL_BENCH_2_1_TASK_IDS } from '../harness-ab-manifest.js';
 
 const execFileAsync = promisify(execFile);
 
+test('harness A/B CLI accepts a 2-task operational canary', async () => {
+  const dir = await mkdtemp(join(tmpdir(), 'maka-harness-ab-cli-'));
+  try {
+    const scriptPath = new URL('../../harbor/run-harness-ab.mjs', import.meta.url);
+    await assert.rejects(execFileAsync(process.execPath, [scriptPath.pathname], {
+      cwd: process.cwd(),
+      env: {
+        ...process.env,
+        MAKA_HARNESS_AB_OUT_DIR: join(dir, 'out'),
+        MAKA_HARNESS_AB_TASKS_ROOT: join(dir, 'missing-tasks'),
+        MAKA_HARNESS_AB_LIMIT: '2',
+        MAKA_HARNESS_AB_DRY_RUN: '1',
+      },
+    }), /Terminal-Bench 2\.1 task set mismatch/);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
 test('harness A/B CLI accepts the fixed 30-task pilot limit', async () => {
   const dir = await mkdtemp(join(tmpdir(), 'maka-harness-ab-cli-'));
   try {

--- a/packages/headless/src/__tests__/harness-ab-manifest.test.ts
+++ b/packages/headless/src/__tests__/harness-ab-manifest.test.ts
@@ -11,7 +11,7 @@ import {
 } from '../harness-ab-manifest.js';
 
 describe('harness A/B manifest', () => {
-  test('freezes adjacent active and stale tool-result pruning for Maka', () => {
+  test('freezes tool-result pruning on and semantic compact off for Maka', () => {
     assert.deepEqual(HARNESS_MAKA_CONTEXT_BUDGET, {
       activeToolResultPrune: {
         enabled: true,
@@ -22,6 +22,9 @@ describe('harness A/B manifest', () => {
         enabled: true,
         maxResultEstimatedTokens: 2048,
         minRecentTurnsFull: 0,
+      },
+      semanticCompact: {
+        enabled: false,
       },
     });
   });

--- a/packages/headless/src/__tests__/harness-ab-manifest.test.ts
+++ b/packages/headless/src/__tests__/harness-ab-manifest.test.ts
@@ -10,7 +10,7 @@ import {
 } from '../harness-ab-manifest.js';
 
 describe('harness A/B manifest', () => {
-  test('freezes one deterministic 40-task prefix inside the full task order', () => {
+  test('freezes one deterministic 30-task prefix inside the full task order', () => {
     const taskIds = Array.from({ length: 89 }, (_, index) => `task-${String(index + 1).padStart(2, '0')}`);
     const input = manifestInput(taskIds);
 
@@ -19,7 +19,7 @@ describe('harness A/B manifest', () => {
     assert.equal(manifest.experimentKind, 'harness');
     assert.equal(manifest.reps, 1);
     assert.equal(manifest.evaluationTaskIds.length, 89);
-    assert.deepEqual(manifest.pilotTaskIds, manifest.evaluationTaskIds.slice(0, 40));
+    assert.deepEqual(manifest.pilotTaskIds, manifest.evaluationTaskIds.slice(0, 30));
     assert.deepEqual(
       manifest.evaluationTaskIds,
       deterministicHarnessTaskOrder([...taskIds].reverse(), input.orderSeed),
@@ -35,7 +35,7 @@ describe('harness A/B manifest', () => {
         outerTimeoutGraceSec: 900,
       },
       metric: 'pass@1',
-      order: { algorithm: 'sha256-rank-v1', seed: 'maka-glm-5.2-v1', pilotTaskCount: 40 },
+      order: { algorithm: 'sha256-rank-v1', seed: 'maka-glm-5.2-v1', pilotTaskCount: 30 },
       model: { provider: 'zai-coding-plan', id: 'glm-5.2', reasoningEffort: 'max' },
       pricing: {
         currency: 'USD',
@@ -105,7 +105,7 @@ function manifestInput(taskIds: readonly string[]) {
     },
     taskIds,
     orderSeed: 'maka-glm-5.2-v1',
-    pilotTaskCount: Math.min(40, taskIds.length),
+    pilotTaskCount: Math.min(30, taskIds.length),
     model: { provider: 'zai-coding-plan', id: 'glm-5.2', reasoningEffort: 'max' as const },
     pricing: {
       currency: 'USD' as const,

--- a/packages/headless/src/__tests__/harness-ab-manifest.test.ts
+++ b/packages/headless/src/__tests__/harness-ab-manifest.test.ts
@@ -5,11 +5,27 @@ import {
   assertTerminalBench21TaskTreeFingerprint,
   buildHarnessAbRunManifest,
   deterministicHarnessTaskOrder,
+  HARNESS_MAKA_CONTEXT_BUDGET,
   TERMINAL_BENCH_2_1_TASK_IDS,
   TERMINAL_BENCH_2_1_TASK_TREE_FINGERPRINT,
 } from '../harness-ab-manifest.js';
 
 describe('harness A/B manifest', () => {
+  test('freezes adjacent active and stale tool-result pruning for Maka', () => {
+    assert.deepEqual(HARNESS_MAKA_CONTEXT_BUDGET, {
+      activeToolResultPrune: {
+        enabled: true,
+        maxCurrentResultEstimatedTokens: 2048,
+        minStepNumber: 1,
+      },
+      staleToolResultPrune: {
+        enabled: true,
+        maxResultEstimatedTokens: 2048,
+        minRecentTurnsFull: 0,
+      },
+    });
+  });
+
   test('freezes one deterministic 30-task prefix inside the full task order', () => {
     const taskIds = Array.from({ length: 89 }, (_, index) => `task-${String(index + 1).padStart(2, '0')}`);
     const input = manifestInput(taskIds);

--- a/packages/headless/src/__tests__/harness-ab-manifest.test.ts
+++ b/packages/headless/src/__tests__/harness-ab-manifest.test.ts
@@ -18,6 +18,8 @@ describe('harness A/B manifest', () => {
 
     assert.equal(manifest.experimentKind, 'harness');
     assert.equal(manifest.reps, 1);
+    assert.equal(manifest.maxConcurrency, 2);
+    assert.equal(manifest.maxConcurrentAttempts, 4);
     assert.equal(manifest.evaluationTaskIds.length, 89);
     assert.deepEqual(manifest.pilotTaskIds, manifest.evaluationTaskIds.slice(0, 30));
     assert.deepEqual(

--- a/packages/headless/src/__tests__/harness-ab-report.test.ts
+++ b/packages/headless/src/__tests__/harness-ab-report.test.ts
@@ -61,7 +61,7 @@ describe('harness A/B report', () => {
     assert.match(markdown, /No composite score/);
   });
 
-  test('reports effectiveness only over pairs evaluated by both harnesses', () => {
+  test('completes once both harness cells are terminal while excluding infra pairs from effectiveness', () => {
     const summary = summarizeAbComparison({
       runId: 'glm-harness-ab',
       roundId: 'ab-summary',
@@ -74,11 +74,8 @@ describe('harness A/B report', () => {
 
     const report = buildHarnessAbReport(summary);
 
-    assert.equal(report.runStatus, 'incomplete');
-    assert.throws(
-      () => assertHarnessAbReportCompleted(report),
-      /harness A\/B incomplete: 1\/2 paired attempts evaluated \(1 excluded, 0 missing\)/,
-    );
+    assert.equal(report.runStatus, 'completed');
+    assert.doesNotThrow(() => assertHarnessAbReportCompleted(report));
     assert.deepEqual(report.effectiveness.baseline, {
       armId: 'maka',
       passed: 1,

--- a/packages/headless/src/__tests__/harness-ab-report.test.ts
+++ b/packages/headless/src/__tests__/harness-ab-report.test.ts
@@ -141,6 +141,7 @@ describe('harness A/B report', () => {
     };
 
     assert.equal(report.effectiveness.pairedEvaluated, 2);
+    assert.equal(report.runStatus, 'incomplete');
     assert.equal(economy.pairedMetered, 1);
     assert.equal(economy.missingUsagePairs, 1);
     assert.equal(report.economy.baseline.totalTokens, 120);
@@ -148,6 +149,7 @@ describe('harness A/B report', () => {
     assert.equal(report.economy.baseline.costPerPassUsd, 0.1);
     assert.equal(report.economy.candidate.costPerPassUsd, 0.2);
     assert.match(renderHarnessAbReportMarkdown(report), /fully metered pairs: 1; missing usage: 1/);
+    assert.throws(() => assertHarnessAbReportCompleted(report), /missing usage for 1 pair/);
   });
 
   test('preserves an early stop in every report format and rejects completion', () => {

--- a/packages/headless/src/__tests__/harness-ab-report.test.ts
+++ b/packages/headless/src/__tests__/harness-ab-report.test.ts
@@ -8,7 +8,7 @@ import {
   renderHarnessAbReportCsv,
   renderHarnessAbReportMarkdown,
 } from '../harness-ab-report.js';
-import { completed, withUsage } from './helpers/ab-summary-fixtures.js';
+import { budgetExhausted, completed, withUsage } from './helpers/ab-summary-fixtures.js';
 
 describe('harness A/B report', () => {
   test('keeps effectiveness and economy as separate reproducible axes', () => {
@@ -50,9 +50,9 @@ describe('harness A/B report', () => {
     assert.equal('score' in report, false);
 
     const csv = renderHarnessAbReportCsv(report);
-    assert.match(csv, /^run_status,stop_reason,paired_expected,paired_evaluated,excluded_pairs,missing_pairs,axis,metric,baseline_arm,baseline_value,candidate_arm,candidate_value,candidate_minus_baseline\n/);
-    assert.match(csv, /completed,,2,2,0,0,effectiveness,pass_rate,maka,1,opencode,0.5,-0.5/);
-    assert.match(csv, /completed,,2,2,0,0,economy,total_tokens,maka,240,opencode,360,120/);
+    assert.match(csv, /^run_status,stop_reason,paired_expected,paired_evaluated,excluded_pairs,missing_pairs,paired_metered,missing_usage_pairs,axis,metric,baseline_arm,baseline_value,candidate_arm,candidate_value,candidate_minus_baseline\n/);
+    assert.match(csv, /completed,,2,2,0,0,2,0,effectiveness,pass_rate,maka,1,opencode,0.5,-0.5/);
+    assert.match(csv, /completed,,2,2,0,0,2,0,economy,total_tokens,maka,240,opencode,360,120/);
 
     const markdown = renderHarnessAbReportMarkdown(report);
     assert.match(markdown, /# Maka vs OpenCode — GLM-5\.2 Harness Comparison/);
@@ -113,8 +113,41 @@ describe('harness A/B report', () => {
     assert.equal(report.effectiveness.pairedEvaluated, 1);
     assert.equal(report.economy.baseline.totalTokens, 100);
     assert.equal(report.economy.candidate.totalTokens, 100);
-    assert.equal(report.economy.baseline.tokensPerEvaluated, 100);
-    assert.equal(report.economy.candidate.tokensPerEvaluated, 100);
+    assert.equal(report.economy.baseline.tokensPerMetered, 100);
+    assert.equal(report.economy.candidate.tokensPerMetered, 100);
+  });
+
+  test('excludes a pair from economy when either evaluated arm is missing usage', () => {
+    const summary = summarizeAbComparison({
+      runId: 'glm-harness-ab',
+      roundId: 'ab-summary',
+      baselineArmId: 'maka',
+      candidateArmId: 'opencode',
+      evaluationTaskIds: ['a', 'b'],
+      baselineRuns: [[
+        usage('a', true, 100, 40, 20, 0.1),
+        budgetExhausted('b'),
+      ]],
+      candidateRuns: [[
+        usage('a', true, 120, 50, 30, 0.2),
+        usage('b', true, 900, 0, 100, 0.9),
+      ]],
+    });
+
+    const report = buildHarnessAbReport(summary);
+    const economy = report.economy as typeof report.economy & {
+      pairedMetered: number;
+      missingUsagePairs: number;
+    };
+
+    assert.equal(report.effectiveness.pairedEvaluated, 2);
+    assert.equal(economy.pairedMetered, 1);
+    assert.equal(economy.missingUsagePairs, 1);
+    assert.equal(report.economy.baseline.totalTokens, 120);
+    assert.equal(report.economy.candidate.totalTokens, 150);
+    assert.equal(report.economy.baseline.costPerPassUsd, 0.1);
+    assert.equal(report.economy.candidate.costPerPassUsd, 0.2);
+    assert.match(renderHarnessAbReportMarkdown(report), /fully metered pairs: 1; missing usage: 1/);
   });
 
   test('preserves an early stop in every report format and rejects completion', () => {
@@ -134,8 +167,8 @@ describe('harness A/B report', () => {
 
     assert.equal(report.runStatus, 'stopped');
     assert.equal(report.stopReason, 'systemic_provider_failure');
-    assert.match(renderHarnessAbReportCsv(report), /^run_status,stop_reason,paired_expected,paired_evaluated,excluded_pairs,missing_pairs,axis,metric,/);
-    assert.match(renderHarnessAbReportCsv(report), /stopped,systemic_provider_failure,1,0,1,0,effectiveness,pass_rate/);
+    assert.match(renderHarnessAbReportCsv(report), /^run_status,stop_reason,paired_expected,paired_evaluated,excluded_pairs,missing_pairs,paired_metered,missing_usage_pairs,axis,metric,/);
+    assert.match(renderHarnessAbReportCsv(report), /stopped,systemic_provider_failure,1,0,1,0,0,0,effectiveness,pass_rate/);
     assert.match(renderHarnessAbReportMarkdown(report), /Status: stopped \(systemic_provider_failure\)\./);
     assert.throws(
       () => assertHarnessAbReportCompleted(report),

--- a/packages/headless/src/__tests__/harness-ab-report.test.ts
+++ b/packages/headless/src/__tests__/harness-ab-report.test.ts
@@ -152,6 +152,29 @@ describe('harness A/B report', () => {
     assert.throws(() => assertHarnessAbReportCompleted(report), /missing usage for 1 pair/);
   });
 
+  test('treats timeout usage checkpoints as incomplete metering', () => {
+    const checkpointOnlyTimeout = {
+      ...budgetExhausted('a'),
+      tokenSummary: usage('checkpoint', false, 100, 40, 20, 0.1).tokenSummary,
+      tokenSummarySource: 'checkpoint' as const,
+    };
+    const summary = summarizeAbComparison({
+      runId: 'glm-harness-ab',
+      roundId: 'ab-summary',
+      baselineArmId: 'maka',
+      candidateArmId: 'opencode',
+      evaluationTaskIds: ['a'],
+      baselineRuns: [[checkpointOnlyTimeout]],
+      candidateRuns: [[usage('a', true, 120, 50, 30, 0.2)]],
+    });
+
+    const report = buildHarnessAbReport(summary);
+
+    assert.equal(summary.pairedAttempts.fullyMeteredPairs, 0);
+    assert.deepEqual(summary.pairedAttempts.missingUsagePairIds, ['a#r0']);
+    assert.equal(report.runStatus, 'incomplete');
+  });
+
   test('preserves an early stop in every report format and rejects completion', () => {
     const summary = summarizeAbComparison({
       runId: 'glm-harness-ab',

--- a/packages/headless/src/__tests__/harness-ab-report.test.ts
+++ b/packages/headless/src/__tests__/harness-ab-report.test.ts
@@ -61,7 +61,7 @@ describe('harness A/B report', () => {
     assert.match(markdown, /No composite score/);
   });
 
-  test('completes once both harness cells are terminal while excluding infra pairs from effectiveness', () => {
+  test('stays incomplete when an infrastructure pair is excluded', () => {
     const summary = summarizeAbComparison({
       runId: 'glm-harness-ab',
       roundId: 'ab-summary',
@@ -74,8 +74,8 @@ describe('harness A/B report', () => {
 
     const report = buildHarnessAbReport(summary);
 
-    assert.equal(report.runStatus, 'completed');
-    assert.doesNotThrow(() => assertHarnessAbReportCompleted(report));
+    assert.equal(report.runStatus, 'incomplete');
+    assert.throws(() => assertHarnessAbReportCompleted(report), /1 excluded/);
     assert.deepEqual(report.effectiveness.baseline, {
       armId: 'maka',
       passed: 1,

--- a/packages/headless/src/__tests__/harness-ab-run.test.ts
+++ b/packages/headless/src/__tests__/harness-ab-run.test.ts
@@ -9,6 +9,52 @@ import { runHarnessAbComparison } from '../harness-ab-run.js';
 import { tokenSummary } from './helpers/cell-output-fixtures.js';
 
 describe('runHarnessAbComparison', () => {
+  test('runs two paired tasks concurrently with both harness arms in parallel', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'maka-harness-ab-concurrency-'));
+    try {
+      const promptPath = join(dir, 'empty-system-prompt.txt');
+      await writeFile(promptPath, '', 'utf8');
+      let release!: () => void;
+      const releasePromise = new Promise<void>((resolve) => { release = resolve; });
+      let fourStarted!: () => void;
+      const fourStartedPromise = new Promise<void>((resolve) => { fourStarted = resolve; });
+      let active = 0;
+      let maxActive = 0;
+      const calls: string[] = [];
+      const beforeRun = async () => {
+        active += 1;
+        maxActive = Math.max(maxActive, active);
+        if (active === 4) fourStarted();
+        await releasePromise;
+        active -= 1;
+      };
+      const comparison = runHarnessAbComparison({
+        runId: 'glm-harness-ab',
+        runRoot: dir,
+        resultsJsonlPath: join(dir, 'results.jsonl'),
+        systemPromptPath: promptPath,
+        resumeFingerprint: 'sha256:manifest',
+        evaluationTasks: ['a', 'b', 'c'].map((id) => ({ id, path: `/tasks/${id}` })),
+        arms: [
+          harnessArm('maka', calls, beforeRun),
+          harnessArm('opencode', calls, beforeRun),
+        ],
+      });
+
+      const observedFour = await Promise.race([
+        fourStartedPromise.then(() => true),
+        new Promise<false>((resolve) => setTimeout(() => resolve(false), 100)),
+      ]);
+      release();
+      await comparison;
+
+      assert.equal(observedFour, true);
+      assert.equal(maxActive, 4);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
   test('extends a completed prefix without rerunning valid cells', async () => {
     const dir = await mkdtemp(join(tmpdir(), 'maka-harness-ab-'));
     try {

--- a/packages/headless/src/__tests__/harness-ab-run.test.ts
+++ b/packages/headless/src/__tests__/harness-ab-run.test.ts
@@ -79,15 +79,17 @@ describe('runHarnessAbComparison', () => {
       const pilot = await runHarnessAbComparison({ ...common, evaluationTasks: tasks.slice(0, 2) });
       assert.equal(pilot.baseline.observed, 2);
       assert.equal(pilot.candidate.observed, 2);
-      assert.deepEqual(calls, ['a:maka', 'a:opencode', 'b:opencode', 'b:maka']);
+      assert.equal(calls.length, 4);
+      assert.deepEqual(new Set(calls), new Set(['a:maka', 'a:opencode', 'b:maka', 'b:opencode']));
 
       const full = await runHarnessAbComparison({ ...common, evaluationTasks: tasks });
       assert.equal(full.baseline.observed, 3);
       assert.equal(full.candidate.observed, 3);
-      assert.deepEqual(calls, [
-        'a:maka', 'a:opencode', 'b:opencode', 'b:maka',
-        'c:maka', 'c:opencode',
-      ]);
+      assert.equal(calls.length, 6);
+      assert.deepEqual(
+        new Set(calls),
+        new Set(['a:maka', 'a:opencode', 'b:maka', 'b:opencode', 'c:maka', 'c:opencode']),
+      );
       assert.deepEqual((await readdir(dir)).filter((name) => name.endsWith('.tsv')), []);
     } finally {
       await rm(dir, { recursive: true, force: true });

--- a/packages/headless/src/__tests__/harness-ab-run.test.ts
+++ b/packages/headless/src/__tests__/harness-ab-run.test.ts
@@ -5,7 +5,9 @@ import { join } from 'node:path';
 import { describe, test } from 'node:test';
 import { hashHarborSystemPrompt, type HarborCellOutput } from '../cell-output.js';
 import type { HarborTaskRunner } from '../fixed-prompt-controller.js';
+import { buildHarnessAbReport } from '../harness-ab-report.js';
 import { runHarnessAbComparison } from '../harness-ab-run.js';
+import { HarborInfraError } from '../harbor-task-runner.js';
 import { tokenSummary } from './helpers/cell-output-fixtures.js';
 
 describe('runHarnessAbComparison', () => {
@@ -160,6 +162,35 @@ describe('runHarnessAbComparison', () => {
 
       await runHarnessAbComparison(input);
       assert.equal(failingAttempts, 1);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  test('keeps the report incomplete when OpenCode usage output is missing', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'maka-harness-ab-missing-usage-'));
+    try {
+      const promptPath = join(dir, 'empty-system-prompt.txt');
+      await writeFile(promptPath, '', 'utf8');
+      const calls: string[] = [];
+      const opencodeArm = harnessArm('opencode', calls);
+      opencodeArm.harborRunner = async () => {
+        throw new HarborInfraError('maka-cell-output.json tokenSummary must be a JSON object');
+      };
+
+      const summary = await runHarnessAbComparison({
+        runId: 'glm-harness-ab',
+        runRoot: dir,
+        resultsJsonlPath: join(dir, 'results.jsonl'),
+        systemPromptPath: promptPath,
+        resumeFingerprint: 'sha256:manifest',
+        evaluationTasks: [{ id: 'a', path: '/tasks/a' }],
+        arms: [harnessArm('maka', calls), opencodeArm],
+      });
+      const report = buildHarnessAbReport(summary);
+
+      assert.equal(summary.pairedAttempts.excludedPairIds.length, 1);
+      assert.equal(report.runStatus, 'incomplete');
     } finally {
       await rm(dir, { recursive: true, force: true });
     }

--- a/packages/headless/src/ab-run.ts
+++ b/packages/headless/src/ab-run.ts
@@ -10,6 +10,13 @@ import type {
 import { assertFinitePositive, assertPositiveInt } from './numeric-guards.js';
 import { summarizeAbComparison } from './ab-summary.js';
 
+interface ActivePairResult {
+  pairIndex: number;
+  rep: number;
+  baseline: FixedPromptTaskWalEvent;
+  candidate: FixedPromptTaskWalEvent;
+}
+
 export async function runAbComparison(input: RunAbComparisonInput): Promise<AbComparisonSummary> {
   assertUniqueArmRoundIdSuffixes(input.arms);
   const reps = input.reps ?? 3;
@@ -26,12 +33,7 @@ export async function runAbComparison(input: RunAbComparisonInput): Promise<AbCo
   let nextPairIndex = 0;
   let observedCostUsd = 0;
   let stopReason: AbComparisonSummary['stopReason'];
-  const active = new Map<number, Promise<{
-    pairIndex: number;
-    rep: number;
-    baseline: FixedPromptTaskWalEvent;
-    candidate: FixedPromptTaskWalEvent;
-  }>>();
+  const active = new Map<number, Promise<ActivePairResult>>();
   const launchReadyPairs = () => {
     while (!stopReason && active.size < maxConcurrency && nextPairIndex < pairs.length) {
       const pairIndex = nextPairIndex;
@@ -42,7 +44,13 @@ export async function runAbComparison(input: RunAbComparisonInput): Promise<AbCo
 
   launchReadyPairs();
   while (active.size > 0) {
-    const result = await Promise.race(active.values());
+    let result: ActivePairResult;
+    try {
+      result = await Promise.race(active.values());
+    } catch (error) {
+      await Promise.allSettled(active.values());
+      throw error;
+    }
     active.delete(result.pairIndex);
     baselineRuns[result.rep]!.push(result.baseline);
     candidateRuns[result.rep]!.push(result.candidate);
@@ -101,17 +109,37 @@ async function runComparisonPair(
     return { rep: pair.rep, baseline, candidate };
   }
   if ((pair.rep + pair.taskIndex) % 2 === 0) {
-    const [baseline, candidate] = await Promise.all([
+    const [baseline, candidate] = await drainParallelArmRuns([
       runComparisonTaskArm(input, input.arms[0], pair),
       runComparisonTaskArm(input, input.arms[1], pair),
     ]);
     return { rep: pair.rep, baseline, candidate };
   }
-  const [candidate, baseline] = await Promise.all([
+  const [candidate, baseline] = await drainParallelArmRuns([
     runComparisonTaskArm(input, input.arms[1], pair),
     runComparisonTaskArm(input, input.arms[0], pair),
   ]);
   return { rep: pair.rep, baseline, candidate };
+}
+
+async function drainParallelArmRuns(
+  runs: readonly [Promise<FixedPromptTaskWalEvent>, Promise<FixedPromptTaskWalEvent>],
+): Promise<[FixedPromptTaskWalEvent, FixedPromptTaskWalEvent]> {
+  let firstError: unknown;
+  let rejected = false;
+  const values = await Promise.all(runs.map(async (run) => {
+    try {
+      return await run;
+    } catch (error) {
+      if (!rejected) {
+        rejected = true;
+        firstError = error;
+      }
+      return undefined;
+    }
+  }));
+  if (rejected) throw firstError;
+  return values as [FixedPromptTaskWalEvent, FixedPromptTaskWalEvent];
 }
 
 async function runComparisonTaskArm(

--- a/packages/headless/src/ab-summary.ts
+++ b/packages/headless/src/ab-summary.ts
@@ -520,7 +520,7 @@ function summarizeAttemptPairs(
       evaluatedPairs += 1;
       if (baseline.passed) baselinePassed += 1;
       if (candidate.passed) candidatePassed += 1;
-      if (hasTokenSummary(baseline) && hasTokenSummary(candidate)) {
+      if (hasCompleteTokenSummary(baseline) && hasCompleteTokenSummary(candidate)) {
         fullyMeteredPairs += 1;
         baselineEvaluatedEvents.push(baseline);
         candidateEvaluatedEvents.push(candidate);
@@ -558,6 +558,13 @@ function summarizeAttemptPairs(
     budgetDiscordantPairIds,
     infraOrPlumbingDiscordantPairIds,
   };
+}
+
+function hasCompleteTokenSummary(
+  event: FixedPromptTaskWalEvent,
+): event is FixedPromptTaskWalEvent & { tokenSummary: HarborCellTokenSummary } {
+  if (!hasTokenSummary(event)) return false;
+  return event.type !== 'task_budget_exhausted' || event.tokenSummarySource === 'final';
 }
 
 function hasTokenSummary(

--- a/packages/headless/src/ab-summary.ts
+++ b/packages/headless/src/ab-summary.ts
@@ -184,7 +184,7 @@ function pairTaskId(pairId: string): string {
 function summarizeTokenCost(
   events: readonly FixedPromptTaskWalEvent[],
 ): AbTokenCostSummary {
-  const withUsage = events.filter((event): event is FixedPromptTaskWalEvent & { tokenSummary: HarborCellTokenSummary } => 'tokenSummary' in event && event.tokenSummary !== undefined);
+  const withUsage = events.filter(hasTokenSummary);
   const durations = events.flatMap((event) => 'durationMs' in event && event.durationMs !== undefined ? [event.durationMs] : []);
   return {
     input: sum(withUsage.map((event) => event.tokenSummary.input)),
@@ -480,6 +480,7 @@ function summarizeAttemptPairs(
 ): AbAttemptPairSummary {
   const missingPairIds: string[] = [];
   const excludedPairIds: string[] = [];
+  const missingUsagePairIds: string[] = [];
   const budgetDiscordantPairIds: string[] = [];
   const infraOrPlumbingDiscordantPairIds: string[] = [];
   const baselineEvaluatedEvents: FixedPromptTaskWalEvent[] = [];
@@ -488,6 +489,9 @@ function summarizeAttemptPairs(
   let evaluatedPairs = 0;
   let baselinePassed = 0;
   let candidatePassed = 0;
+  let fullyMeteredPairs = 0;
+  let baselineMeteredPassed = 0;
+  let candidateMeteredPassed = 0;
   let wins = 0;
   let losses = 0;
   let ties = 0;
@@ -514,10 +518,17 @@ function summarizeAttemptPairs(
         continue;
       }
       evaluatedPairs += 1;
-      baselineEvaluatedEvents.push(baseline);
-      candidateEvaluatedEvents.push(candidate);
       if (baseline.passed) baselinePassed += 1;
       if (candidate.passed) candidatePassed += 1;
+      if (hasTokenSummary(baseline) && hasTokenSummary(candidate)) {
+        fullyMeteredPairs += 1;
+        baselineEvaluatedEvents.push(baseline);
+        candidateEvaluatedEvents.push(candidate);
+        if (baseline.passed) baselineMeteredPassed += 1;
+        if (candidate.passed) candidateMeteredPassed += 1;
+      } else {
+        missingUsagePairIds.push(pairId);
+      }
       if (candidate.passed === baseline.passed) {
         ties += 1;
       } else if (candidate.passed) {
@@ -533,6 +544,9 @@ function summarizeAttemptPairs(
     evaluatedPairs,
     baselinePassed,
     candidatePassed,
+    fullyMeteredPairs,
+    baselineMeteredPassed,
+    candidateMeteredPassed,
     baselineTokenCostSummary: summarizeTokenCost(baselineEvaluatedEvents),
     candidateTokenCostSummary: summarizeTokenCost(candidateEvaluatedEvents),
     wins,
@@ -540,9 +554,16 @@ function summarizeAttemptPairs(
     ties,
     missingPairIds,
     excludedPairIds,
+    missingUsagePairIds,
     budgetDiscordantPairIds,
     infraOrPlumbingDiscordantPairIds,
   };
+}
+
+function hasTokenSummary(
+  event: FixedPromptTaskWalEvent,
+): event is FixedPromptTaskWalEvent & { tokenSummary: HarborCellTokenSummary } {
+  return 'tokenSummary' in event && event.tokenSummary !== undefined;
 }
 
 function decide(

--- a/packages/headless/src/ab-types.ts
+++ b/packages/headless/src/ab-types.ts
@@ -197,6 +197,9 @@ export interface AbAttemptPairSummary {
   evaluatedPairs: number;
   baselinePassed: number;
   candidatePassed: number;
+  fullyMeteredPairs: number;
+  baselineMeteredPassed: number;
+  candidateMeteredPassed: number;
   baselineTokenCostSummary: AbTokenCostSummary;
   candidateTokenCostSummary: AbTokenCostSummary;
   wins: number;
@@ -204,6 +207,7 @@ export interface AbAttemptPairSummary {
   ties: number;
   missingPairIds: string[];
   excludedPairIds: string[];
+  missingUsagePairIds: string[];
   budgetDiscordantPairIds: string[];
   infraOrPlumbingDiscordantPairIds: string[];
 }

--- a/packages/headless/src/cell-output.ts
+++ b/packages/headless/src/cell-output.ts
@@ -169,7 +169,7 @@ export function validateHarborCellOutput(value: unknown): HarborCellOutput {
   const executionIdentity = 'executionIdentity' in value
     ? validateHarborCellExecutionIdentity(value.executionIdentity)
     : undefined;
-  const tokenSummary = validateTokenSummary(value.tokenSummary);
+  const tokenSummary = validateHarborCellTokenSummary(value.tokenSummary);
   const contextBudgetPolicy = 'contextBudgetPolicy' in value
     ? validateContextBudgetPolicySnapshot(value.contextBudgetPolicy)
     : undefined;
@@ -438,7 +438,7 @@ function taskToolSummaryField(
   return enabled || taskToolSummary.todoWriteCalls > 0 ? { taskToolSummary } : {};
 }
 
-function validateTokenSummary(value: unknown): HarborCellTokenSummary {
+export function validateHarborCellTokenSummary(value: unknown): HarborCellTokenSummary {
   if (!isRecord(value)) throw new Error('tokenSummary must be a JSON object');
   return {
     input: requireNumber(value.input, 'tokenSummary.input'),

--- a/packages/headless/src/fixed-prompt-controller.ts
+++ b/packages/headless/src/fixed-prompt-controller.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from 'node:crypto';
 import { appendFile, mkdir, readFile, truncate, writeFile } from 'node:fs/promises';
-import { dirname } from 'node:path';
+import { dirname, resolve } from 'node:path';
 import {
   validateHarborCellOutput,
   hashHarborSystemPrompt,
@@ -19,6 +19,7 @@ export const FIXED_PROMPT_WAL_SCHEMA_VERSION = 1;
 export const BUDGET_EXHAUSTED_RUNTIME_UNAVAILABLE_REASON = 'budget_exhausted_before_cell_output';
 const LEGACY_TIMEOUT_MISSING_EXECUTION_IDENTITY_ERROR = 'Timed-out Harbor attempt did not produce execution identity attestation';
 type UnscoredCellFailureClass = 'infra_failed' | 'setup_failed' | 'verification_error';
+const walWriteTails = new Map<string, Promise<void>>();
 
 export interface FixedPromptTask {
   id: string;
@@ -484,10 +485,21 @@ export async function readHarborTaskRunOutput(
   };
 }
 
-export async function appendFixedPromptWalEvent(path: string, event: FixedPromptWalEvent): Promise<void> {
-  await mkdir(dirname(path), { recursive: true });
-  await truncateTornWalTail(path);
-  await appendFile(path, `${JSON.stringify(event)}\n`, 'utf8');
+export function appendFixedPromptWalEvent(path: string, event: FixedPromptWalEvent): Promise<void> {
+  const key = resolve(path);
+  const previous = walWriteTails.get(key) ?? Promise.resolve();
+  const operation = async () => {
+    await mkdir(dirname(path), { recursive: true });
+    await truncateTornWalTail(path);
+    await appendFile(path, `${JSON.stringify(event)}\n`, 'utf8');
+  };
+  const write = previous.then(operation, operation);
+  const tail = write.then(() => {}, () => {});
+  walWriteTails.set(key, tail);
+  void tail.then(() => {
+    if (walWriteTails.get(key) === tail) walWriteTails.delete(key);
+  });
+  return write;
 }
 
 export async function writeFixedPromptResultsTsv(

--- a/packages/headless/src/fixed-prompt-controller.ts
+++ b/packages/headless/src/fixed-prompt-controller.ts
@@ -152,6 +152,7 @@ export interface FixedPromptTaskBudgetExhaustedEvent {
   traceEventsPath?: string;
   runtimeEventsUnavailableReason?: string;
   tokenSummary?: HarborCellTokenSummary;
+  tokenSummarySource?: 'final' | 'checkpoint';
   executionIdentity?: HarborCellExecutionIdentity;
   contextBudgetPolicy?: HarborCellContextBudgetPolicySnapshot;
   contextBudgetSummary?: HarborCellContextBudgetSummary;
@@ -955,6 +956,11 @@ function taskBudgetExhaustedEvent(input: {
     }
   }
   const tokenSummary = artifactRefs.cellOutput?.tokenSummary ?? artifactRefs.tokenSummary;
+  const tokenSummarySource = tokenSummary
+    ? artifactRefs.cellOutput
+      ? 'final'
+      : 'checkpoint'
+    : undefined;
   const executionIdentity = artifactRefs.cellOutput?.executionIdentity ?? artifactRefs.executionIdentity;
   const cellOutput = artifactRefs.cellOutput;
   const runtimeEventsPath = artifactRefs.runtimeEventsPath ?? cellOutput?.runtimeEventsPath;
@@ -986,6 +992,7 @@ function taskBudgetExhaustedEvent(input: {
       ? { runtimeEventsUnavailableReason: artifactRefs.runtimeEventsUnavailableReason }
       : {}),
     ...(tokenSummary ? { tokenSummary } : {}),
+    ...(tokenSummarySource ? { tokenSummarySource } : {}),
     ...(cellOutput?.contextBudgetPolicy ? { contextBudgetPolicy: cellOutput.contextBudgetPolicy } : {}),
     ...(cellOutput?.contextBudgetSummary ? { contextBudgetSummary: cellOutput.contextBudgetSummary } : {}),
     ...(cellOutput?.continuationSummary ? { continuationSummary: cellOutput.continuationSummary } : {}),

--- a/packages/headless/src/harbor-cell.ts
+++ b/packages/headless/src/harbor-cell.ts
@@ -1,4 +1,4 @@
-import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { mkdir, readFile, rename, writeFile } from 'node:fs/promises';
 import { readFileSync } from 'node:fs';
 import { exec as nodeExec } from 'node:child_process';
 import { createHash } from 'node:crypto';
@@ -67,6 +67,7 @@ import {
 export const HARBOR_CELL_OUTPUT_FILENAME = 'maka-cell-output.json';
 export const HARBOR_CELL_RUNTIME_EVENTS_FILENAME = 'runtime-events.jsonl';
 export const HARBOR_CELL_EXECUTION_IDENTITY_FILENAME = 'maka-cell-execution-identity.json';
+export const HARBOR_CELL_USAGE_CHECKPOINT_FILENAME = 'maka-cell-usage-checkpoint.json';
 const execAsync = promisify(nodeExec);
 const HARBOR_CELL_TOOL_MAX_BUFFER_BYTES = 10 * 1024 * 1024;
 
@@ -146,6 +147,18 @@ export interface HarborCellContextBudgetBackendOptions {
   contextBudget?: ContextBudgetPolicy;
   archiveToolResult?: ToolResultArchiveRecorder;
   readToolResultArchive?: ToolResultArchiveReader;
+}
+
+export interface HarborCellUsageCheckpoint {
+  inputTokens: number;
+  outputTokens: number;
+  cacheHitInputTokens: number;
+  cacheMissInputTokens: number;
+  cacheMissInputSource: 'explicit' | 'derived';
+  cacheWriteInputTokens: number;
+  reasoningTokens: number;
+  totalTokens: number;
+  costUsd?: number;
 }
 
 export interface HarborCellTaskLedgerExperimentPolicy {
@@ -459,6 +472,7 @@ export async function runHarborCellFromEnv(
         now,
         newId,
         ...(maxSteps !== undefined ? { maxSteps } : {}),
+        recordUsageCheckpoint: (usage) => writeHarborCellUsageCheckpoint(outputDir, usage),
       });
       break;
     }
@@ -657,6 +671,7 @@ export function buildAiSdkCellBackendRegistration(input: {
   now: () => number;
   newId: () => string;
   maxSteps?: number;
+  recordUsageCheckpoint?: (usage: HarborCellUsageCheckpoint) => void | Promise<void>;
 }): NonNullable<RunHarborCellInput['registerBackends']> {
   const { connection, apiKey } = resolveHarborCellAiSdkEnv({
     provider: input.provider,
@@ -724,12 +739,37 @@ export function buildAiSdkCellBackendRegistration(input: {
         recordRunTrace: ctx.recordRunTrace,
         recordActiveFullCompactBlock: ctx.recordActiveFullCompactBlock,
         recordSemanticCompactBlock: ctx.recordSemanticCompactBlock,
+        ...(input.recordUsageCheckpoint ? { recordUsageCheckpoint: input.recordUsageCheckpoint } : {}),
       });
     });
   };
 }
 
 export const buildHarborAiSdkBackendRegistration = buildAiSdkCellBackendRegistration;
+
+export async function writeHarborCellUsageCheckpoint(
+  outputDir: string,
+  usage: HarborCellUsageCheckpoint,
+): Promise<void> {
+  const tokenSummary: HarborCellOutput['tokenSummary'] = {
+    input: usage.inputTokens,
+    output: usage.outputTokens,
+    cachedInput: usage.cacheHitInputTokens,
+    cacheHitInput: usage.cacheHitInputTokens,
+    cacheMissInput: usage.cacheMissInputTokens,
+    cacheWriteInput: usage.cacheWriteInputTokens,
+    cacheMissInputSource: usage.cacheMissInputSource,
+    reasoning: usage.reasoningTokens,
+    total: usage.totalTokens,
+    costUsd: usage.costUsd ?? 0,
+    pricingSource: 'runtime',
+  };
+  await mkdir(outputDir, { recursive: true });
+  const path = join(outputDir, HARBOR_CELL_USAGE_CHECKPOINT_FILENAME);
+  const pendingPath = `${path}.${process.pid}.tmp`;
+  await writeFile(pendingPath, `${JSON.stringify(tokenSummary, null, 2)}\n`, 'utf8');
+  await rename(pendingPath, path);
+}
 
 export function buildHarborCellAiSdkTools(
   executor: IsolatedToolExecutor,

--- a/packages/headless/src/harbor-cell.ts
+++ b/packages/headless/src/harbor-cell.ts
@@ -751,6 +751,7 @@ export async function writeHarborCellUsageCheckpoint(
   outputDir: string,
   usage: HarborCellUsageCheckpoint,
 ): Promise<void> {
+  if (usage.costUsd === undefined) return;
   const tokenSummary: HarborCellOutput['tokenSummary'] = {
     input: usage.inputTokens,
     output: usage.outputTokens,
@@ -761,7 +762,7 @@ export async function writeHarborCellUsageCheckpoint(
     cacheMissInputSource: usage.cacheMissInputSource,
     reasoning: usage.reasoningTokens,
     total: usage.totalTokens,
-    costUsd: usage.costUsd ?? 0,
+    costUsd: usage.costUsd,
     pricingSource: 'runtime',
   };
   await mkdir(outputDir, { recursive: true });

--- a/packages/headless/src/harbor-cell.ts
+++ b/packages/headless/src/harbor-cell.ts
@@ -809,9 +809,9 @@ export function buildHarborCellContextBudgetBackendOptions(
     contextBudget.staleToolResultPrune = {
       enabled: true,
       ...(maxResultEstimatedTokens !== undefined ? { maxResultEstimatedTokens } : {}),
-      // Explicit so the runtime protection window matches the policy snapshot
-      // and desktop default (2) instead of the runtime's internal ?? 1 fallback.
-      minRecentTurnsFull: minRecentTurnsFull ?? minRecentTurns ?? 2,
+      // Active prune owns the current turn; stale prune must take over on the
+      // next replay without restoring a full-result protection window.
+      minRecentTurnsFull: minRecentTurnsFull ?? 0,
     };
   }
 

--- a/packages/headless/src/harbor-task-runner.ts
+++ b/packages/headless/src/harbor-task-runner.ts
@@ -8,6 +8,7 @@ import { fetchGitHubCopilotModels, isSupportedGitHubCopilotAccountToken } from '
 import {
   validateHarborCellExecutionIdentity,
   validateHarborCellOutput,
+  validateHarborCellTokenSummary,
   type HarborCellExecutionIdentity,
   type HarborCellOutput,
 } from './cell-output.js';
@@ -30,6 +31,7 @@ const execFileAsync = promisify(execFile);
 const CONTAINER_MAKA_REPO = '/opt/maka-agent';
 const TRIAL_CELL_OUTPUT = 'agent/maka-cell-output.json';
 const TRIAL_EXECUTION_IDENTITY = 'agent/maka-cell-execution-identity.json';
+const TRIAL_USAGE_CHECKPOINT = 'agent/maka-cell-usage-checkpoint.json';
 const TRIAL_RUNTIME_EVENTS = 'agent/runtime-events.jsonl';
 const TRIAL_REWARD = 'verifier/reward.txt';
 const TRIAL_VERIFIER_STDOUT = 'verifier/test-stdout.txt';
@@ -295,13 +297,29 @@ function cellArtifactRefs(cell: HarborCellOutput, hostEventsPath: string, trialD
 async function readTimedOutTrialArtifacts(trialDir: string, taskId: string) {
   const cell = await readOptionalCellOutput(join(trialDir, TRIAL_CELL_OUTPUT), taskId);
   if (cell) return cellArtifactRefs(cell, join(trialDir, TRIAL_RUNTIME_EVENTS), trialDir);
-  const executionIdentity = await readOptionalExecutionIdentity(join(trialDir, TRIAL_EXECUTION_IDENTITY));
-  return executionIdentity ? { executionIdentity } : null;
+  const [executionIdentity, tokenSummary] = await Promise.all([
+    readOptionalExecutionIdentity(join(trialDir, TRIAL_EXECUTION_IDENTITY)),
+    readOptionalTokenSummary(join(trialDir, TRIAL_USAGE_CHECKPOINT)),
+  ]);
+  return executionIdentity || tokenSummary
+    ? {
+        ...(executionIdentity ? { executionIdentity } : {}),
+        ...(tokenSummary ? { tokenSummary } : {}),
+      }
+    : null;
 }
 
 async function readOptionalExecutionIdentity(path: string): Promise<HarborCellExecutionIdentity | null> {
   try {
     return validateHarborCellExecutionIdentity(JSON.parse(await readFile(path, 'utf8')));
+  } catch {
+    return null;
+  }
+}
+
+async function readOptionalTokenSummary(path: string) {
+  try {
+    return validateHarborCellTokenSummary(JSON.parse(await readFile(path, 'utf8')));
   } catch {
     return null;
   }

--- a/packages/headless/src/harbor-task-runner.ts
+++ b/packages/headless/src/harbor-task-runner.ts
@@ -439,7 +439,7 @@ export function buildHarborJobConfig(
     metrics: [{ type: 'mean', kwargs: {} }],
     agents: [
       {
-        name: adapter,
+        ...(adapter === 'maka' ? { name: adapter } : {}),
         import_path: adapter === 'opencode' ? 'opencode_agent:MakaOpenCodeAgent' : 'maka_agent:MakaAgent',
         model_name: agentModel,
         kwargs: adapter === 'maka'

--- a/packages/headless/src/harness-ab-manifest.ts
+++ b/packages/headless/src/harness-ab-manifest.ts
@@ -4,6 +4,9 @@ import type { AbRunManifest } from './ab-types.js';
 
 export type HarnessAbArmId = 'maka' | 'opencode';
 
+export const HARNESS_AB_PAIR_CONCURRENCY = 2;
+export const HARNESS_AB_MAX_CONCURRENT_ATTEMPTS = HARNESS_AB_PAIR_CONCURRENCY * 2;
+
 // Authoritative snapshot: https://github.com/harbor-framework/terminal-bench-2-1
 export const TERMINAL_BENCH_2_1_REVISION = 'd49e28f1e4ddd13d289e85a5f312a66750951932';
 export const TERMINAL_BENCH_2_1_TASK_TREE_FINGERPRINT = 'sha256:456826aa4c47ed309716c964c96d2a3acc998764ebc84f3e8449c807d74bd4e7';
@@ -226,7 +229,8 @@ export function buildHarnessAbRunManifest(input: HarnessAbRunManifestInput): Har
     pilotTaskIds: evaluationTaskIds.slice(0, input.pilotTaskCount),
     reps: 1,
     candidateLimit: null,
-    maxConcurrency: 1,
+    maxConcurrency: HARNESS_AB_PAIR_CONCURRENCY,
+    maxConcurrentAttempts: HARNESS_AB_MAX_CONCURRENT_ATTEMPTS,
     selectionMode: 'explicit',
   });
   return manifest as HarnessAbRunManifest;

--- a/packages/headless/src/harness-ab-manifest.ts
+++ b/packages/headless/src/harness-ab-manifest.ts
@@ -6,6 +6,18 @@ export type HarnessAbArmId = 'maka' | 'opencode';
 
 export const HARNESS_AB_PAIR_CONCURRENCY = 2;
 export const HARNESS_AB_MAX_CONCURRENT_ATTEMPTS = HARNESS_AB_PAIR_CONCURRENCY * 2;
+export const HARNESS_MAKA_CONTEXT_BUDGET = {
+  activeToolResultPrune: {
+    enabled: true,
+    maxCurrentResultEstimatedTokens: 2048,
+    minStepNumber: 1,
+  },
+  staleToolResultPrune: {
+    enabled: true,
+    maxResultEstimatedTokens: 2048,
+    minRecentTurnsFull: 0,
+  },
+} as const;
 
 // Authoritative snapshot: https://github.com/harbor-framework/terminal-bench-2-1
 export const TERMINAL_BENCH_2_1_REVISION = 'd49e28f1e4ddd13d289e85a5f312a66750951932';

--- a/packages/headless/src/harness-ab-manifest.ts
+++ b/packages/headless/src/harness-ab-manifest.ts
@@ -17,6 +17,9 @@ export const HARNESS_MAKA_CONTEXT_BUDGET = {
     maxResultEstimatedTokens: 2048,
     minRecentTurnsFull: 0,
   },
+  semanticCompact: {
+    enabled: false,
+  },
 } as const;
 
 // Authoritative snapshot: https://github.com/harbor-framework/terminal-bench-2-1

--- a/packages/headless/src/harness-ab-report.ts
+++ b/packages/headless/src/harness-ab-report.ts
@@ -57,6 +57,7 @@ export function buildHarnessAbReport(summary: AbComparisonSummary): HarnessAbRep
     ? 'stopped'
     : summary.pairedAttempts.missingPairIds.length === 0
         && summary.pairedAttempts.missingUsagePairIds.length === 0
+        && summary.pairedAttempts.excludedPairIds.length === 0
       ? 'completed'
       : 'incomplete';
   return {

--- a/packages/headless/src/harness-ab-report.ts
+++ b/packages/headless/src/harness-ab-report.ts
@@ -53,7 +53,7 @@ export interface HarnessAbReport {
 export function buildHarnessAbReport(summary: AbComparisonSummary): HarnessAbReport {
   const runStatus = summary.stopReason
     ? 'stopped'
-    : summary.pairedAttempts.evaluatedPairs === summary.pairedAttempts.pairs
+    : summary.pairedAttempts.missingPairIds.length === 0
       ? 'completed'
       : 'incomplete';
   return {

--- a/packages/headless/src/harness-ab-report.ts
+++ b/packages/headless/src/harness-ab-report.ts
@@ -15,8 +15,8 @@ export interface HarnessAbArmEconomy {
   outputTokens: number;
   totalTokens: number;
   apiEquivalentCostUsd: number;
-  tokensPerEvaluated: number | null;
-  costPerEvaluatedUsd: number | null;
+  tokensPerMetered: number | null;
+  costPerMeteredUsd: number | null;
   costPerPassUsd: number | null;
 }
 
@@ -45,6 +45,8 @@ export interface HarnessAbReport {
   };
   economy: {
     basis: 'cache-aware-api-equivalent-usd';
+    pairedMetered: number;
+    missingUsagePairs: number;
     baseline: HarnessAbArmEconomy;
     candidate: HarnessAbArmEconomy;
   };
@@ -89,17 +91,19 @@ export function buildHarnessAbReport(summary: AbComparisonSummary): HarnessAbRep
     },
     economy: {
       basis: 'cache-aware-api-equivalent-usd',
+      pairedMetered: summary.pairedAttempts.fullyMeteredPairs,
+      missingUsagePairs: summary.pairedAttempts.missingUsagePairIds.length,
       baseline: armEconomy(
         summary.baselineArmId,
         summary.pairedAttempts.baselineTokenCostSummary,
-        summary.pairedAttempts.evaluatedPairs,
-        summary.pairedAttempts.baselinePassed,
+        summary.pairedAttempts.fullyMeteredPairs,
+        summary.pairedAttempts.baselineMeteredPassed,
       ),
       candidate: armEconomy(
         summary.candidateArmId,
         summary.pairedAttempts.candidateTokenCostSummary,
-        summary.pairedAttempts.evaluatedPairs,
-        summary.pairedAttempts.candidatePassed,
+        summary.pairedAttempts.fullyMeteredPairs,
+        summary.pairedAttempts.candidateMeteredPassed,
       ),
     },
   };
@@ -119,12 +123,12 @@ export function renderHarnessAbReportCsv(report: HarnessAbReport): string {
     ['economy', 'output_tokens', baselineEconomy.armId, baselineEconomy.outputTokens, candidateEconomy.armId, candidateEconomy.outputTokens, candidateEconomy.outputTokens - baselineEconomy.outputTokens],
     ['economy', 'total_tokens', baselineEconomy.armId, baselineEconomy.totalTokens, candidateEconomy.armId, candidateEconomy.totalTokens, candidateEconomy.totalTokens - baselineEconomy.totalTokens],
     ['economy', 'api_equivalent_cost_usd', baselineEconomy.armId, baselineEconomy.apiEquivalentCostUsd, candidateEconomy.armId, candidateEconomy.apiEquivalentCostUsd, candidateEconomy.apiEquivalentCostUsd - baselineEconomy.apiEquivalentCostUsd],
-    ['economy', 'tokens_per_evaluated', baselineEconomy.armId, baselineEconomy.tokensPerEvaluated, candidateEconomy.armId, candidateEconomy.tokensPerEvaluated, nullableDelta(candidateEconomy.tokensPerEvaluated, baselineEconomy.tokensPerEvaluated)],
-    ['economy', 'cost_per_evaluated_usd', baselineEconomy.armId, baselineEconomy.costPerEvaluatedUsd, candidateEconomy.armId, candidateEconomy.costPerEvaluatedUsd, nullableDelta(candidateEconomy.costPerEvaluatedUsd, baselineEconomy.costPerEvaluatedUsd)],
+    ['economy', 'tokens_per_metered', baselineEconomy.armId, baselineEconomy.tokensPerMetered, candidateEconomy.armId, candidateEconomy.tokensPerMetered, nullableDelta(candidateEconomy.tokensPerMetered, baselineEconomy.tokensPerMetered)],
+    ['economy', 'cost_per_metered_usd', baselineEconomy.armId, baselineEconomy.costPerMeteredUsd, candidateEconomy.armId, candidateEconomy.costPerMeteredUsd, nullableDelta(candidateEconomy.costPerMeteredUsd, baselineEconomy.costPerMeteredUsd)],
     ['economy', 'cost_per_pass_usd', baselineEconomy.armId, baselineEconomy.costPerPassUsd, candidateEconomy.armId, candidateEconomy.costPerPassUsd, nullableDelta(candidateEconomy.costPerPassUsd, baselineEconomy.costPerPassUsd)],
   ];
   return [
-    'run_status,stop_reason,paired_expected,paired_evaluated,excluded_pairs,missing_pairs,axis,metric,baseline_arm,baseline_value,candidate_arm,candidate_value,candidate_minus_baseline',
+    'run_status,stop_reason,paired_expected,paired_evaluated,excluded_pairs,missing_pairs,paired_metered,missing_usage_pairs,axis,metric,baseline_arm,baseline_value,candidate_arm,candidate_value,candidate_minus_baseline',
     ...rows.map((row) => [
       report.runStatus,
       report.stopReason ?? '',
@@ -132,6 +136,8 @@ export function renderHarnessAbReportCsv(report: HarnessAbReport): string {
       report.effectiveness.pairedEvaluated,
       report.completeness.excludedPairs,
       report.completeness.missingPairs,
+      report.economy.pairedMetered,
+      report.economy.missingUsagePairs,
       ...row,
     ].map(csvCell).join(',')),
   ].join('\n') + '\n';
@@ -146,6 +152,7 @@ export function renderHarnessAbReportMarkdown(report: HarnessAbReport): string {
     `Status: ${report.runStatus}${report.stopReason ? ` (${report.stopReason})` : ''}.`,
     '',
     `Run: ${report.runId}; tasks: ${report.taskCount}; paired evaluated: ${report.effectiveness.pairedEvaluated}; excluded: ${report.completeness.excludedPairs}; missing: ${report.completeness.missingPairs}.`,
+    `Economy coverage: fully metered pairs: ${report.economy.pairedMetered}; missing usage: ${report.economy.missingUsagePairs}.`,
     '',
     '## Effectiveness',
     '',
@@ -163,7 +170,7 @@ export function renderHarnessAbReportMarkdown(report: HarnessAbReport): string {
     `| Uncached input tokens | ${baselineEconomy.uncachedInputTokens} | ${candidateEconomy.uncachedInputTokens} |`,
     `| Output tokens | ${baselineEconomy.outputTokens} | ${candidateEconomy.outputTokens} |`,
     `| API-equivalent cost (USD) | ${baselineEconomy.apiEquivalentCostUsd} | ${candidateEconomy.apiEquivalentCostUsd} |`,
-    `| Cost per evaluated task (USD) | ${value(baselineEconomy.costPerEvaluatedUsd)} | ${value(candidateEconomy.costPerEvaluatedUsd)} |`,
+    `| Cost per fully metered task (USD) | ${value(baselineEconomy.costPerMeteredUsd)} | ${value(candidateEconomy.costPerMeteredUsd)} |`,
     `| Cost per pass (USD) | ${value(baselineEconomy.costPerPassUsd)} | ${value(candidateEconomy.costPerPassUsd)} |`,
     '',
     '## Interpretation boundary',
@@ -206,8 +213,8 @@ function armEconomy(
     outputTokens: tokens.output,
     totalTokens: tokens.total,
     apiEquivalentCostUsd: tokens.costUsd,
-    tokensPerEvaluated: divide(tokens.total, evaluated),
-    costPerEvaluatedUsd: divide(tokens.costUsd, evaluated),
+    tokensPerMetered: divide(tokens.total, evaluated),
+    costPerMeteredUsd: divide(tokens.costUsd, evaluated),
     costPerPassUsd: divide(tokens.costUsd, passed),
   };
 }

--- a/packages/headless/src/harness-ab-report.ts
+++ b/packages/headless/src/harness-ab-report.ts
@@ -56,6 +56,7 @@ export function buildHarnessAbReport(summary: AbComparisonSummary): HarnessAbRep
   const runStatus = summary.stopReason
     ? 'stopped'
     : summary.pairedAttempts.missingPairIds.length === 0
+        && summary.pairedAttempts.missingUsagePairIds.length === 0
       ? 'completed'
       : 'incomplete';
   return {
@@ -185,6 +186,11 @@ export function assertHarnessAbReportCompleted(report: HarnessAbReport): void {
     throw new Error(`harness A/B stopped: ${report.stopReason ?? 'unknown_reason'}`);
   }
   if (report.runStatus === 'incomplete') {
+    if (report.economy.missingUsagePairs > 0) {
+      throw new Error(
+        `harness A/B incomplete: missing usage for ${report.economy.missingUsagePairs} pair(s)`,
+      );
+    }
     throw new Error(
       `harness A/B incomplete: ${report.effectiveness.pairedEvaluated}/${report.completeness.expectedPerArm} paired attempts evaluated (${report.completeness.excludedPairs} excluded, ${report.completeness.missingPairs} missing)`,
     );

--- a/packages/headless/src/harness-ab-run.ts
+++ b/packages/headless/src/harness-ab-run.ts
@@ -8,7 +8,10 @@ import {
   type FixedPromptTask,
   type HarborTaskRunner,
 } from './fixed-prompt-controller.js';
-import type { HarnessAbArmId } from './harness-ab-manifest.js';
+import {
+  HARNESS_AB_PAIR_CONCURRENCY,
+  type HarnessAbArmId,
+} from './harness-ab-manifest.js';
 
 export interface HarnessAbRuntimeArm {
   id: HarnessAbArmId;
@@ -53,8 +56,8 @@ async function runHarnessAbComparisonUnlocked(
     ],
     evaluationTasks: input.evaluationTasks,
     reps: 1,
-    maxConcurrency: 1,
-    armExecution: 'sequential',
+    maxConcurrency: HARNESS_AB_PAIR_CONCURRENCY,
+    armExecution: 'parallel',
     runArm: async ({ roundId, arm, task }) => {
       const runtimeArm = input.arms.find((candidate) => candidate.id === arm.id);
       if (!runtimeArm) throw new Error(`harness A/B arm ${arm.id} is not configured`);

--- a/packages/headless/src/harness-ab-run.ts
+++ b/packages/headless/src/harness-ab-run.ts
@@ -38,7 +38,11 @@ export async function runHarnessAbComparison(
   return withAbRunLock(input.runRoot, () => runHarnessAbComparisonUnlocked(input));
 }
 
-async function runHarnessAbComparisonUnlocked(
+export function withHarnessAbRunLock<T>(runRoot: string, action: () => Promise<T>): Promise<T> {
+  return withAbRunLock(runRoot, action);
+}
+
+export async function runHarnessAbComparisonUnlocked(
   input: RunHarnessAbComparisonInput,
 ): Promise<AbComparisonSummary> {
   return runAbComparison({

--- a/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
+++ b/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
@@ -2345,7 +2345,7 @@ describe('AiSdkBackend model history', () => {
     const backend = new AiSdkBackend({
       sessionId: 'session-1',
       header: header(),
-      appendMessage: async (message) => {
+      appendMessage: async (message: StoredMessage) => {
         appended.push(message.type);
       },
       connection: connection(),
@@ -3668,6 +3668,7 @@ describe('AiSdkBackend usage telemetry', () => {
     const messages: unknown[] = [];
     const events: SessionEvent[] = [];
     const llmRecords: LlmCallRecord[] = [];
+    const usageCheckpoints: Array<{ inputTokens: number; outputTokens: number }> = [];
     let streamCalls = 0;
     const model = new MockLanguageModelV3({
       doStream: async () => {
@@ -3734,7 +3735,7 @@ describe('AiSdkBackend usage telemetry', () => {
     const backend = new AiSdkBackend({
       sessionId: 'session-1',
       header: header(),
-      appendMessage: async (message) => {
+      appendMessage: async (message: StoredMessage) => {
         messages.push(message);
       },
       connection: connection(),
@@ -3745,10 +3746,13 @@ describe('AiSdkBackend usage telemetry', () => {
       tools: [testTool('Read', z.object({ path: z.string() }))],
       newId: idGenerator(),
       now: monotonicClock(),
-      recordLlmCall: (record) => {
+      recordLlmCall: (record: LlmCallRecord) => {
         llmRecords.push(record);
       },
-    });
+      recordUsageCheckpoint: async (usage: { inputTokens: number; outputTokens: number }) => {
+        usageCheckpoints.push(usage);
+      },
+    } as never);
 
     for await (const event of backend.send({ turnId: 'turn-1', text: 'hi', context: [] })) {
       events.push(event);
@@ -3794,6 +3798,10 @@ describe('AiSdkBackend usage telemetry', () => {
     assert.equal(llmRecords[0]?.reasoningTokens, 2);
     assert.equal(llmRecords[0]?.totalTokens, 312);
     assert.equal(llmRecords[0]?.rawFinishReason, 'stop');
+    assert.deepEqual(usageCheckpoints.map(({ inputTokens, outputTokens }) => ({ inputTokens, outputTokens })), [
+      { inputTokens: 100, outputTokens: 5 },
+      { inputTokens: 300, outputTokens: 12 },
+    ]);
   });
 
   test('records active tool-result prune diagnostics in usage telemetry', async () => {

--- a/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
+++ b/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
@@ -3806,6 +3806,51 @@ describe('AiSdkBackend usage telemetry', () => {
     ]);
   });
 
+  test('keeps checkpoint cost unknown when model pricing is unavailable', async () => {
+    const usageCheckpoints: Array<{ costUsd?: number }> = [];
+    const model = new MockLanguageModelV3({
+      doStream: async () => ({
+        stream: simulateReadableStream({
+          chunks: [
+            { type: 'stream-start', warnings: [] },
+            {
+              type: 'finish',
+              finishReason: { unified: 'stop', raw: 'stop' },
+              usage: {
+                inputTokens: { total: 100, noCache: 100, cacheRead: 0, cacheWrite: 0 },
+                outputTokens: { total: 10, text: 10, reasoning: 0 },
+              },
+            },
+          ],
+          initialDelayInMs: null,
+          chunkDelayInMs: null,
+        }),
+      }),
+    });
+    const backend = new AiSdkBackend({
+      sessionId: 'session-1',
+      header: header(),
+      appendMessage: async () => {},
+      connection: connection(),
+      apiKey: 'sk-test',
+      modelId: 'unpriced-model',
+      permissionEngine: new PermissionEngine({ newId: () => 'permission-id', now: () => 1 }),
+      modelFactory: () => model,
+      tools: [],
+      newId: idGenerator(),
+      now: monotonicClock(),
+      lookupPricing: () => null,
+      recordUsageCheckpoint: async (usage: { costUsd?: number }) => {
+        usageCheckpoints.push(usage);
+      },
+    } as never);
+
+    await drain(backend.send({ turnId: 'turn-1', text: 'hi', context: [] }));
+
+    assert.equal(usageCheckpoints.length, 1);
+    assert.equal(usageCheckpoints[0]?.costUsd, undefined);
+  });
+
   test('records active tool-result prune diagnostics in usage telemetry', async () => {
     const messages: unknown[] = [];
     const events: SessionEvent[] = [];

--- a/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
+++ b/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
@@ -3664,7 +3664,7 @@ describe('AiSdkBackend usage telemetry', () => {
     assert.equal((events.at(-1) as Extract<SessionEvent, { type: 'complete' }>).stopReason as string, 'step_limit');
   });
 
-  test('records aggregate totalUsage across AI SDK tool-loop steps', async () => {
+  test('records cumulative usage checkpoints across tool-loop steps and turns', async () => {
     const messages: unknown[] = [];
     const events: SessionEvent[] = [];
     const llmRecords: LlmCallRecord[] = [];
@@ -3757,6 +3757,7 @@ describe('AiSdkBackend usage telemetry', () => {
     for await (const event of backend.send({ turnId: 'turn-1', text: 'hi', context: [] })) {
       events.push(event);
     }
+    await drain(backend.send({ turnId: 'turn-2', text: 'continue', context: [] }));
 
     const usageMessage = messages.find((message) =>
       (message as { type?: string }).type === 'token_usage'
@@ -3777,7 +3778,7 @@ describe('AiSdkBackend usage telemetry', () => {
       | Extract<SessionEvent, { type: 'token_usage' }>
       | undefined;
 
-    assert.equal(streamCalls, 2);
+    assert.equal(streamCalls, 3);
     assert.equal(usageMessage?.input, 300);
     assert.equal(usageMessage?.output, 12);
     assert.equal(usageMessage?.cacheHitInput, 100);
@@ -3801,6 +3802,7 @@ describe('AiSdkBackend usage telemetry', () => {
     assert.deepEqual(usageCheckpoints.map(({ inputTokens, outputTokens }) => ({ inputTokens, outputTokens })), [
       { inputTokens: 100, outputTokens: 5 },
       { inputTokens: 300, outputTokens: 12 },
+      { inputTokens: 500, outputTokens: 19 },
     ]);
   });
 

--- a/packages/runtime/src/__tests__/context-budget.test.ts
+++ b/packages/runtime/src/__tests__/context-budget.test.ts
@@ -24,6 +24,47 @@ import {
 import { historyCompactBlockToCompactionBoundary } from '../compaction-boundary.js';
 
 describe('context-budget archive retrieval', () => {
+  test('prunes the newest turn when the full-result protection window is zero', () => {
+    const sentinel = 'newest-turn-full-result-must-not-be-reinjected';
+    const originalResult = { kind: 'text', text: sentinel.repeat(4) };
+    const serialized = serializeToolResultForArchive(originalResult);
+    const events = [
+      toolCall('call-newest', 'turn-newest', 'tool-newest'),
+      toolResult('result-newest', 'turn-newest', 'tool-newest', originalResult),
+    ];
+
+    const budgeted = applyRuntimeEventContextBudget(events, {
+      staleToolResultPrune: {
+        enabled: true,
+        maxResultEstimatedTokens: 1,
+        minRecentTurnsFull: 0,
+        archiveRefs: [{
+          runtimeEventId: 'result-newest',
+          toolCallId: 'tool-newest',
+          toolName: 'Read',
+          artifactId: 'artifact-newest',
+          bodySha256: sha256(serialized),
+          originalEstimatedTokens: serialized.length,
+          originalBytes: utf8Bytes(serialized),
+          rewriteVersion: ARCHIVED_TOOL_RESULT_REWRITE_VERSION,
+          reason: 'stale_tool_result_pruned_before_compact',
+        }],
+      },
+      charsPerToken: 1,
+    });
+
+    assert.ok(budgeted);
+    assert.equal(budgeted.diagnostic.prunedToolResults, 1);
+    const result = budgeted.events.find((event) => event.id === 'result-newest');
+    assert.equal(
+      result?.content?.kind === 'function_response'
+        ? (result.content.result as { kind?: string }).kind
+        : undefined,
+      ARCHIVED_TOOL_RESULT_PLACEHOLDER_KIND,
+    );
+    assert.equal(JSON.stringify(budgeted.events).includes(sentinel), false);
+  });
+
   test('deserializes JSON, undefined, and fallback strings', () => {
     assert.deepEqual(deserializeToolResultArchive('{"kind":"text","text":"ok"}'), { kind: 'text', text: 'ok' });
     assert.equal(deserializeToolResultArchive('undefined'), undefined);

--- a/packages/runtime/src/ai-sdk-backend.ts
+++ b/packages/runtime/src/ai-sdk-backend.ts
@@ -460,6 +460,10 @@ export interface AiSdkBackendInput {
   /** Optional fire-and-forget telemetry hooks. Tool implementations remain unaware. */
   recordLlmCall?: LlmTelemetryRecorder;
   recordToolInvocation?: ToolTelemetryRecorder;
+  /** Durable cumulative usage checkpoint after each completed provider step. */
+  recordUsageCheckpoint?: (
+    usage: NormalizedAiSdkUsage & { costUsd?: number },
+  ) => void | Promise<void>;
   /** Optional pricing lookup shared with telemetry; defaults to builtin public pricing. */
   lookupPricing?: (modelKey: string) => PricingConfig | null;
   spawnChildAgent?: (input: {
@@ -813,6 +817,7 @@ export class AiSdkBackend implements AgentBackend {
     };
     let tokenUsage: NormalizedAiSdkUsage | undefined;
     let tokenUsageCostUsd: number | undefined;
+    let completedStepUsage: NormalizedAiSdkUsage | undefined;
     let streamStatus: LlmCallRecord['status'] = 'success';
     let streamErrorClass: string | undefined;
     let rawFinishReason: string | undefined;
@@ -1075,6 +1080,14 @@ export class AiSdkBackend implements AgentBackend {
           const isStepFinishChunk = chunk.type === 'finish-step' || chunk.type === 'step-finish';
           if (isStepFinishChunk) {
             runtimeSteps += 1;
+            const stepUsage = normalizeAiSdkUsage(chunk.usage, { rawFinishReason: chunk.finishReason });
+            if (stepUsage) {
+              completedStepUsage = mergeNormalizedUsage(completedStepUsage, stepUsage);
+              await this.input.recordUsageCheckpoint?.({
+                ...completedStepUsage,
+                costUsd: this.computeTokenUsageCostUsd(completedStepUsage),
+              });
+            }
           }
           if (chunk.type === 'finish' || isStepFinishChunk) {
             rawFinishReason = rawFinishReasonString(chunk.finishReason) ?? rawFinishReason;
@@ -2863,6 +2876,30 @@ function mergeActiveToolResultPruneDiagnosticPatches(
     ...sumOptionalCounts('activePrunedToolResults', left, right),
     ...sumOptionalCounts('activeArchiveFailures', left, right),
     ...sumOptionalCounts('activeEstimatedTokensSaved', left, right),
+  };
+}
+
+function mergeNormalizedUsage(
+  current: NormalizedAiSdkUsage | undefined,
+  next: NormalizedAiSdkUsage,
+): NormalizedAiSdkUsage {
+  if (!current) return next;
+  const cacheMissInputSource = current.cacheMissInputSource === 'explicit'
+    || next.cacheMissInputSource === 'explicit'
+    ? 'explicit'
+    : 'derived';
+  const cacheHitInputTokens = current.cacheHitInputTokens + next.cacheHitInputTokens;
+  return {
+    inputTokens: current.inputTokens + next.inputTokens,
+    outputTokens: current.outputTokens + next.outputTokens,
+    cacheHitInputTokens,
+    cacheMissInputTokens: current.cacheMissInputTokens + next.cacheMissInputTokens,
+    cacheMissInputSource,
+    cacheWriteInputTokens: current.cacheWriteInputTokens + next.cacheWriteInputTokens,
+    reasoningTokens: current.reasoningTokens + next.reasoningTokens,
+    totalTokens: current.totalTokens + next.totalTokens,
+    ...(next.rawFinishReason !== undefined ? { rawFinishReason: next.rawFinishReason } : {}),
+    cachedInputTokens: cacheHitInputTokens,
   };
 }
 

--- a/packages/runtime/src/ai-sdk-backend.ts
+++ b/packages/runtime/src/ai-sdk-backend.ts
@@ -1427,6 +1427,10 @@ export class AiSdkBackend implements AgentBackend {
 
   private computeTokenUsageCostUsd(usage: NormalizedAiSdkUsage): number | undefined {
     try {
+      const pricing = (this.input.lookupPricing ?? getBuiltinPricing)(
+        `${this.input.connection.providerType}:${this.input.modelId}`,
+      );
+      if (pricing === null) return undefined;
       return computeCost(
         {
           inputTokens: usage.inputTokens,
@@ -1435,7 +1439,7 @@ export class AiSdkBackend implements AgentBackend {
           cacheMissInputTokens: usage.cacheMissInputTokens,
           cacheWriteInputTokens: usage.cacheWriteInputTokens,
         },
-        (this.input.lookupPricing ?? getBuiltinPricing)(`${this.input.connection.providerType}:${this.input.modelId}`),
+        pricing,
       ).totalCost;
     } catch {
       return undefined;

--- a/packages/runtime/src/ai-sdk-backend.ts
+++ b/packages/runtime/src/ai-sdk-backend.ts
@@ -460,7 +460,7 @@ export interface AiSdkBackendInput {
   /** Optional fire-and-forget telemetry hooks. Tool implementations remain unaware. */
   recordLlmCall?: LlmTelemetryRecorder;
   recordToolInvocation?: ToolTelemetryRecorder;
-  /** Durable cumulative usage checkpoint after each completed provider step. */
+  /** Durable session-lifetime cumulative usage checkpoint after each completed provider step. */
   recordUsageCheckpoint?: (
     usage: NormalizedAiSdkUsage & { costUsd?: number },
   ) => void | Promise<void>;
@@ -563,6 +563,7 @@ export class AiSdkBackend implements AgentBackend {
   private currentWatchdog: StreamWatchdog | null = null;
   private currentRunTrace: RunTrace | null = null;
   private priorRequestShape: RequestShapeDiagnostic | undefined;
+  private cumulativeUsageCheckpoint: NormalizedAiSdkUsage | undefined;
   /**
    * Id of the assistant step currently streaming. Read by ToolRuntime via
    * `getCurrentStepId` so each tool call's `tool_start` carries the step it
@@ -817,7 +818,6 @@ export class AiSdkBackend implements AgentBackend {
     };
     let tokenUsage: NormalizedAiSdkUsage | undefined;
     let tokenUsageCostUsd: number | undefined;
-    let completedStepUsage: NormalizedAiSdkUsage | undefined;
     let streamStatus: LlmCallRecord['status'] = 'success';
     let streamErrorClass: string | undefined;
     let rawFinishReason: string | undefined;
@@ -1082,10 +1082,10 @@ export class AiSdkBackend implements AgentBackend {
             runtimeSteps += 1;
             const stepUsage = normalizeAiSdkUsage(chunk.usage, { rawFinishReason: chunk.finishReason });
             if (stepUsage) {
-              completedStepUsage = mergeNormalizedUsage(completedStepUsage, stepUsage);
+              this.cumulativeUsageCheckpoint = mergeNormalizedUsage(this.cumulativeUsageCheckpoint, stepUsage);
               await this.input.recordUsageCheckpoint?.({
-                ...completedStepUsage,
-                costUsd: this.computeTokenUsageCostUsd(completedStepUsage),
+                ...this.cumulativeUsageCheckpoint,
+                costUsd: this.computeTokenUsageCostUsd(this.cumulativeUsageCheckpoint),
               });
             }
           }


### PR DESCRIPTION
## Summary

- Harden the fixed 30-task GLM-5.2 Maka vs OpenCode comparison with a two-task canary, paired parallel execution, and a durable detached runner.
- Preserve timeout usage, isolate task-spawned processes, load the custom OpenCode adapter correctly, and report economy only on fully metered pairs.
- Explicitly disable semantic compact for the next run while keeping active and stale tool-result pruning enabled and fingerprinted.

## Why

The first 30-task pilot exposed several infrastructure gaps that made the run less reliable and its economy comparison incomplete:

- the runner could disappear with its parent PTY;
- background task processes could contaminate verification;
- timed-out Maka cells could lose already-reported token usage;
- OpenCode adapter and authentication plumbing could fail independently of model performance;
- terminal infrastructure exclusions prevented otherwise complete runs from finalizing;
- missing usage could distort aggregate cost reporting;
- semantic compact caused avoidable cache disruption and should not remain enabled without independent evidence of net benefit.

This change fixes those measurement and execution boundaries before another paid benchmark run.

## Scope

The first pilot results and analysis remain local diagnostic evidence and are not included in this PR.

This PR does not rerun the benchmark or attempt to repair semantic compact. The next run must use a new output directory and fingerprint rather than resume the previous experiment.

## Verification

- `npm --workspace @maka/runtime test` — passed
- `npm --workspace @maka/headless test` — 899 tests passed
- `node --test packages/headless/dist/__tests__/harbor-cell.test.js` — 89 tests passed after the final checkpoint-cost boundary change
- `npm run typecheck` — passed for all workspaces
- `npm run check:stale` — `dist is fresh`
- Python Harbor adapter compile and smoke checks — passed
- No paid GLM-5.2 benchmark was run; this PR intentionally prepares the infrastructure only.
- No user-visible UI changed, so visual evidence is not applicable.

## Impact

Benchmark operators get resumable detached execution, clearer terminal-state reporting, stricter paired economy accounting, and timeout usage recovery.

The fixed harness configuration now runs two task pairs concurrently, with at most four active cells. Semantic compact is explicitly off; active and stale tool-result pruning remain on.

There is no product UI, storage migration, or public API impact.

## Reviewer notes

- Economy totals and cost-per-pass use only pairs where both arms have valid usage. Missing usage is reported explicitly and is never treated as zero.
- Unknown checkpoint cost does not produce a zero-cost usage artifact.
- Process cleanup uses the Linux `/proc` environment available inside Harbor task containers.
- The previous pilot cannot be resumed into the next run because the configuration and source fingerprint intentionally change.

## Ready for review

- [x] Verification is complete and the results above are current
- [x] Impact, compatibility, migration, documentation, and release-note needs are addressed
- [x] User-visible UI/UX changes include visual evidence, or `Verification` explains why it is not applicable
