### PR TITLE
docs: add pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,19 @@
+## Summary
+
+<!-- The problem this solves and the outcome it produces. If the approach
+is not the obvious one, say why. Link issues: "Closes #N" when this PR
+completes the issue, "Refs #N" for context only. -->
+
+## Verification
+
+<!-- The checks you actually ran and their results. Name relevant checks
+you did not run. For user-visible changes, attach the lightest evidence
+that demonstrates the behavior (screenshot, recording, or command output). -->
+
+<!--
+Add a section only when it changes how this PR should be reviewed,
+released, or operated, and name it after the real risk: e.g.
+Breaking change, Migration, Rollout, Root cause, Security, Review focus.
+If work intentionally remains, open as a draft and track it with a
+task list under its own section.
+-->


### PR DESCRIPTION
## Summary

Add a repository-wide pull request template that asks authors for two things reviewers cannot reliably recover from the diff: the change’s intent and its verification evidence.

The template keeps only `Summary` and `Verification` as fixed sections. It guides authors to add sections named after material risks when needed and reserves task lists for intentionally unfinished work instead of self-attestation checklists.

This applies to `maka-agent/maka-agent` only. It does not create an organization-level `maka-agent/.github` repository or enforce PR body fields.

## Verification

- `git diff --check origin/main...HEAD` — passed.
- Manually reviewed the Markdown structure and hidden author guidance.
- Runtime tests were not run because this only adds a GitHub Markdown template and does not affect production code.
