### PR TITLE
fix(ui): show provider marks in model picker triggers

### DIFF
--- a/apps/desktop/e2e/send-message.spec.ts
+++ b/apps/desktop/e2e/send-message.spec.ts
@@ -12,4 +12,7 @@ test('send a message and see the fake backend stream a reply', async ({ window: 
   await composer.press('Enter');
 
   await expect(page.getByText(/Fake backend received: hello e2e/)).toBeVisible();
+  await expect(
+    page.locator('.maka-model-switcher-trigger .maka-composer-provider-mark[data-provider="anthropic"] svg'),
+  ).toBeVisible();
 });

--- a/apps/desktop/src/renderer/app-shell.tsx
+++ b/apps/desktop/src/renderer/app-shell.tsx
@@ -351,6 +351,9 @@ export function AppShell({
     persistedComposerDefaults,
     openSettingsSection,
   });
+  const newChatProviderType = newChatModel
+    ? connections.find((connection) => connection.slug === newChatModel.llmConnectionSlug)?.providerType
+    : undefined;
 
   // PR109d-b: turn footer actions per turn. Derived from the
   // materialized turn list (status + lineage descendants) + pending
@@ -1473,6 +1476,7 @@ export function AppShell({
                 activeConnectionLabel={activeConnectionLabel}
                 activeModel={activeModel}
                 activeModelLabel={activeModelLabel}
+                activeProviderType={activeConnection?.providerType}
                 modelChoices={chatModelChoices}
                 renderProviderMark={(type) => <ProviderBrandMark type={type} />}
                 modelChangePending={activeId ? pendingSessionModelBySession[activeId] === true : false}
@@ -1481,6 +1485,7 @@ export function AppShell({
                 activeThinkingLevel={activeThinkingLevel}
                 onThinkingLevelChange={(level) => setSessionThinkingLevel(level)}
                 newChatModel={newChatModel}
+                newChatProviderType={newChatProviderType}
                 onPickNewChatModel={(input) => {
                   setPendingNewChatModel(input);
                   saveComposerDefaults({ model: input });

--- a/apps/desktop/src/renderer/styles/composer.css
+++ b/apps/desktop/src/renderer/styles/composer.css
@@ -124,6 +124,23 @@
   white-space: nowrap;
 }
 
+.maka-composer-provider-mark {
+  width: 16px;
+  height: 16px;
+  flex: 0 0 16px;
+  display: grid;
+  place-items: center;
+  color: inherit;
+}
+
+.maka-composer-provider-mark > svg,
+.maka-composer-provider-mark > img,
+.maka-composer-provider-mark > .providerAssetMask {
+  width: 100%;
+  height: 100%;
+  display: block;
+}
+
 .maka-composer-model-status {
   width: 6px;
   height: 6px;

--- a/packages/ui/src/chat-model-switcher.tsx
+++ b/packages/ui/src/chat-model-switcher.tsx
@@ -125,6 +125,7 @@ export function ChatModelSwitcher(props: {
   activeModel?: string;
   activeConnectionLabel?: string;
   activeModelLabel?: string;
+  currentProviderType?: ProviderType;
   choices: ChatModelChoice[];
   pending?: boolean;
   disabledReason?: string;
@@ -227,6 +228,11 @@ export function ChatModelSwitcher(props: {
           />
         )}
       >
+        {props.currentProviderType && props.renderProviderMark && (
+          <span className="maka-composer-provider-mark" data-provider={props.currentProviderType} aria-hidden="true">
+            {props.renderProviderMark(props.currentProviderType)}
+          </span>
+        )}
         <span className="maka-model-switcher-label">{pending ? '切换中' : '模型'}</span>
         <span className="maka-model-switcher-value">
           {displayLabel}
@@ -251,6 +257,7 @@ export function NewChatModelPicker(props: {
   label: string;
   choices: ChatModelChoice[];
   currentValue?: string;
+  currentProviderType?: ProviderType;
   renderProviderMark?(type: ProviderType): ReactNode;
   onPick(input: { llmConnectionSlug: string; model: string }): void | Promise<void>;
   thinkingLevels?: readonly ThinkingLevel[];
@@ -280,6 +287,11 @@ export function NewChatModelPicker(props: {
         />
       )}
     >
+      {props.currentProviderType && props.renderProviderMark && (
+        <span className="maka-composer-provider-mark" data-provider={props.currentProviderType} aria-hidden="true">
+          {props.renderProviderMark(props.currentProviderType)}
+        </span>
+      )}
       <span className="maka-composer-model-chip-text">{props.label}</span>
       {props.thinkingLevel && <span className="maka-thinking-level-tag">{thinkingLevelLabel(props.thinkingLevel)}</span>}
       {/* ModelPicker's trigger already renders a chevron — no manual one. */}

--- a/packages/ui/src/composer.tsx
+++ b/packages/ui/src/composer.tsx
@@ -157,6 +157,7 @@ export const Composer = forwardRef<
     activeConnectionLabel?: string;
     activeModel?: string;
     activeModelLabel?: string;
+    activeProviderType?: ProviderType;
     modelChoices?: ChatModelChoice[];
     /** Renders the provider brand mark on each group heading of the model menus;
      *  injected by the desktop app to keep the provider SVG library out of @maka/ui. */
@@ -177,6 +178,7 @@ export const Composer = forwardRef<
      * choose the new-chat model inline instead of only via Settings · 模型.
      */
     newChatModel?: { llmConnectionSlug: string; model: string };
+    newChatProviderType?: ProviderType;
     onPickNewChatModel?(input: { llmConnectionSlug: string; model: string }): void | Promise<void>;
     /**
      * Empty-state only: no models are configured yet, so the model chip is a
@@ -671,6 +673,7 @@ export const Composer = forwardRef<
                     activeModel={props.activeModel}
                     activeConnectionLabel={props.activeConnectionLabel}
                     activeModelLabel={props.activeModelLabel}
+                    currentProviderType={props.activeProviderType}
                     choices={props.modelChoices ?? []}
                     pending={props.modelChangePending}
                     disabledReason={modelSwitcherDisabledReason}
@@ -689,6 +692,7 @@ export const Composer = forwardRef<
                         ? modelChoiceValue(props.newChatModel.llmConnectionSlug, props.newChatModel.model)
                         : undefined
                     }
+                    currentProviderType={props.newChatProviderType}
                     renderProviderMark={props.renderProviderMark}
                     onPick={props.onPickNewChatModel}
                     thinkingLevels={props.newChatThinkingLevels}


### PR DESCRIPTION
## Summary

- show the active provider mark in the current-session model picker trigger
- show the selected provider mark in the new-chat model picker trigger
- carry provider identity from the desktop connection state through the shared Composer API
- add a fixed 16px, non-shrinking mark slot that supports inline SVG, image, and asset-mask marks

## Why

Provider marks were already rendered in model-menu group headings, but the trigger displayed only the model label. The desktop shell also knew the active provider type, yet that value stopped before the Composer. As a result, the model selector beside the input did not show which provider owned the selected model.

The change keeps provider artwork injected by the desktop app, so `@maka/ui` remains independent of the provider SVG library. The mark is decorative (`aria-hidden`) and follows the trigger's foreground color.

## Validation

- `npm --workspace @maka/ui run build`
- `npm --workspace @maka/desktop run typecheck`
- `npm --workspace @maka/desktop run e2e -- --grep "send a message and see the fake backend stream a reply" --workers=1`
- `git diff --check`

The E2E test uses the existing seeded Anthropic connection and asserts the provider mark in the active-session model trigger, so this PR does not depend on any new provider implementation.
