### PR TITLE
fix(storage): retry Windows session replacement under read locks

### DIFF
--- a/packages/storage/src/__tests__/session-store.test.ts
+++ b/packages/storage/src/__tests__/session-store.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { mkdir, mkdtemp, open, readFile, rm, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { describe, test } from 'node:test';
@@ -146,6 +146,26 @@ describe('FileSessionStore CRUD', () => {
       await store.rename(header.id, overly);
       const bounded = await store.readHeader(header.id);
       assert.equal(bounded.name.length, 80);
+    });
+  });
+
+  test('retries a Windows atomic header replacement while a reader briefly holds the session file open', {
+    skip: process.platform !== 'win32',
+  }, async () => {
+    await withStore(async (store, workspaceRoot) => {
+      const header = await store.create(makeInput({ name: 'Reader overlap' }));
+      const sessionPath = join(workspaceRoot, 'sessions', header.id, 'session.jsonl');
+      const reader = await open(sessionPath, 'r');
+      const releaseReader = setTimeout(() => void reader.close(), 40);
+
+      try {
+        const updated = await store.updateHeader(header.id, { name: 'Write survived' });
+        assert.equal(updated.name, 'Write survived');
+        assert.equal((await store.readHeader(header.id)).name, 'Write survived');
+      } finally {
+        clearTimeout(releaseReader);
+        await reader.close().catch(() => {});
+      }
     });
   });
 

--- a/packages/storage/src/session-store.ts
+++ b/packages/storage/src/session-store.ts
@@ -1,6 +1,7 @@
 import { mkdir, open, readFile, rename, rm, writeFile } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
 import { randomUUID } from 'node:crypto';
+import { setTimeout as delay } from 'node:timers/promises';
 import { chainWrite } from './write-queue.js';
 import {
   deriveTurnRecords,
@@ -364,14 +365,33 @@ class FileSessionStore implements SessionStore {
 
   private async writeAtomic(path: string, content: string): Promise<void> {
     await mkdir(dirname(path), { recursive: true });
-    const tempPath = `${path}.${process.pid}.${Date.now()}.tmp`;
+    const tempPath = `${path}.${process.pid}.${Date.now()}.${randomUUID()}.tmp`;
     await writeFile(tempPath, content, 'utf8');
-    await rename(tempPath, path);
+    try {
+      await replaceFileWithWindowsReaderRetry(tempPath, path);
+    } finally {
+      await rm(tempPath, { force: true }).catch(() => {});
+    }
   }
 
   private withQueue(sessionId: string, operation: () => Promise<void>): Promise<void> {
     assertSafeSessionId(sessionId);
     return chainWrite(this.writeQueues, sessionId, operation);
+  }
+}
+
+async function replaceFileWithWindowsReaderRetry(tempPath: string, path: string): Promise<void> {
+  const attempts = process.platform === 'win32' ? 6 : 1;
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    try {
+      await rename(tempPath, path);
+      return;
+    } catch (error) {
+      const code = (error as NodeJS.ErrnoException).code;
+      const retryable = process.platform === 'win32' && (code === 'EPERM' || code === 'EACCES');
+      if (!retryable || attempt === attempts) throw error;
+      await delay(attempt * 10);
+    }
   }
 }
 


### PR DESCRIPTION
## Summary

- retry Windows session-file replacement when a short-lived reader causes `EPERM` or `EACCES`
- give atomic-write temp files UUID-qualified names
- clean up temp files after both successful and failed replacement attempts
- add a Windows regression test that holds the destination open while a header update begins

## Root cause

`FileSessionStore.updateHeader()` safely rewrites `session.jsonl` through a temporary file and atomic rename. On Windows, replacing the destination fails with `EPERM` while another reader briefly has `session.jsonl` open. Session list and preview reads can overlap this header update, so a transient read lock could fail a turn before the provider request was made and surface as `missing_terminal_event`.

The replacement now retries only the Windows lock-related error codes, with a small bounded backoff. Persistent permission errors still surface after the retry budget; non-Windows behavior remains a single attempt.

## Validation

- `node --test packages/storage/dist/__tests__/session-store.test.js` — 40 passed
- `npm run typecheck`
- `git diff --check`

The regression test uses a real Windows file handle rather than mocking the error: the old implementation fails with `EPERM`, while the retry succeeds after the reader releases the file.
