### PR TITLE
docs: add issue forms

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,43 @@
+name: Bug report
+description: Report a defect in Maka (Desktop, TUI/CLI, or Headless)
+labels: ["bug"]
+body:
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened
+      description: Describe the defect. If the expected behavior is not obvious, say what you expected instead.
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: How to reproduce
+      description: Steps from a fresh start. A stable minimal reproduction is not required—if it is intermittent, describe the conditions and how often it happens.
+      placeholder: |
+        1. Open Settings → Models
+        2. ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Fill in what you know. When running from source, obtain the commit with `git rev-parse --short HEAD`.
+      placeholder: |
+        - Maka version or commit:
+        - OS and version:
+        - Surface: Desktop / TUI / CLI / Headless
+        - Node.js version, if running from source:
+    validations:
+      required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Logs, screenshots, or additional context
+      description: Add anything else that helps. Redact API keys, tokens, and other credentials before sharing logs or screenshots.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Report a security vulnerability
+    url: https://github.com/maka-agent/maka-agent/security/policy
+    about: Do not open a public issue for vulnerabilities. The security policy explains private reporting via security@maka.app.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,27 @@
+name: Feature request
+description: Propose an improvement or new capability for Maka
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What can you not do today, or what is harder than it should be? Describe the situation rather than a specific implementation.
+    validations:
+      required: true
+
+  - type: textarea
+    id: desired-outcome
+    attributes:
+      label: Desired outcome
+      description: What would be true for you if this were solved?
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives or workarounds
+      description: What do you do today instead, and what other approaches have you considered?
+    validations:
+      required: false


### PR DESCRIPTION
## Summary

Add minimal GitHub Issue Forms for bug reports and feature requests.

The bug form requires the behavior, reproduction conditions, and environment needed for initial triage while allowing intermittent failures without a stable minimal reproduction. The feature form asks only for the problem and desired outcome, avoiding implementation bias. Both forms apply existing `bug` and `enhancement` labels automatically.

Keep blank issues available for RFCs, roadmaps, maintainer tasks, and non-standard reports. Route security vulnerabilities to the existing private reporting policy instead of exposing a public security form.

Refs #76 and #77, where external bug reports lacked the environment and reproduction context needed for initial triage.

## Verification

- Parsed all three YAML files and checked required top-level fields, body structure, supported element types, unique IDs, labels, and chooser configuration.
- Confirmed the repository has existing `bug` and `enhancement` labels.
- Confirmed `https://github.com/maka-agent/maka-agent/security/policy` returns HTTP 200.
- `git diff --check origin/main...HEAD` — passed.
- Product tests were not run because this change only adds GitHub issue configuration and does not affect runtime code.
