### PR TITLE
feat(core): add Phase 0 execution evidence spine contract

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -24,6 +24,7 @@ This page is the authority map for Maka documentation. Code and contract tests r
 ### Runtime and Headless
 
 - [Session task ledger lifecycle](./session-task-ledger-lifecycle.md)
+- [Execution identity and evidence spine](./execution-evidence-spine.md)
 - [AHE target protocol and evidence export](./ahe-target-protocol.md)
 - [Skill catalog policy](./skill-catalog-policy.md)
 - [Backend architecture chapters](./architecture/)

--- a/docs/execution-evidence-spine.md
+++ b/docs/execution-evidence-spine.md
@@ -1,0 +1,199 @@
+# Execution Identity and Evidence Spine
+
+Status: Phase 0 contract and architecture audit. See [issue #948](https://github.com/maka-agent/maka-agent/issues/948).
+
+Maka already records the facts needed to explain an execution. Runtime Events preserve model and tool interaction facts, AgentRun records operational lifecycle, and Task Events preserve durable task-control decisions. The missing piece is a shared way to reference those facts across subsystem boundaries.
+
+The Execution Identity and Evidence Spine is that reference protocol. It answers:
+
+> Which execution, source-log prefix, workspace revision, and target snapshot support this projection or evidence claim?
+
+It is deliberately not a new event log, trace backend, or source of truth.
+
+## Phase 0 boundary
+
+Phase 0 adds a versioned shared contract in `@maka/core/execution-evidence`, runtime validation, cursor comparison rules, and this ownership audit. It does not yet:
+
+- assign or persist log sequence numbers;
+- change Runtime, AgentRun, Session, or TaskRun storage;
+- migrate durable data;
+- attach evidence references to Self-check, Compaction, or AHE exports;
+- add a lineage inspection command.
+
+Those integrations belong to later phases of issue #948. Defining the contract first prevents each integration from inventing a different meaning for identity, coverage, or freshness.
+
+## Existing authorities
+
+The spine references existing authorities instead of copying their facts.
+
+| Authority | Identity today | Owns | Does not own |
+| --- | --- | --- | --- |
+| `RuntimeEvent` | `sessionId`, `invocationId`, `runId`, `turnId`, `id` | Canonical model, tool, runtime-content, and terminal interaction facts | Task scheduling or task-level decisions |
+| `AgentRunHeader` and `AgentRunEvent` | `sessionId`, `runId`, `turnId`, event `id` | Operational run lifecycle, status, model resolution, permission, usage, and run-local checkpoints | A second copy of raw Runtime interaction history |
+| `SessionEvent` and stored messages | Session and turn-oriented identifiers | Compatibility and UI/session read models | Canonical Runtime history |
+| `TaskEvent` | `taskRunId`, optional event-specific `attemptId`, event `id` | Task lifecycle, attempts, policy decisions, evidence envelopes, permissions, and recovery-visible task state | Raw model messages, Tool Calls, or Tool Results already owned by Runtime Events |
+| `TaskRunProjection` | Fold of one `taskRunId` event stream | Current task read model derived from Task Events | Independent facts outside its source Task Events |
+| Compaction checkpoints and blocks | Checkpoint/block ids, policy-specific `highWaterName` and `highWaterSeq`, explicit Runtime Event ids | Lossy context projections and the source set required to validate those projections | Replacement of canonical Runtime Events or a universal log cursor |
+| Self-check records | Task and check-specific identifiers | Bounded completion claims and supporting task evidence | Executor-owned command, output, artifact, or workspace facts |
+| AHE exports | Target snapshot and exported trajectory references | A derived evaluation/evolution evidence package | Authority over the Runtime or Task facts it exports |
+
+This gives Maka two principal append-only evidence lanes:
+
+```text
+Runtime Event ledger                       Task Event ledger
+session / invocation / AgentRun / turn     TaskRun / attempt
+        |                                          |
+        +------------- evidence ref ---------------+
+                              |
+                   workspace + target snapshot
+```
+
+Task Events may reference a Runtime trajectory. They must not reproduce it. Projections may summarize either ledger, but their trust comes from source coverage that can be checked against the owning ledger.
+
+## Identity contract
+
+`ExecutionEvidenceRef` separates Runtime and Task identity lanes so similarly named runs cannot be confused:
+
+```ts
+interface ExecutionEvidenceRef {
+  schemaVersion: 'maka.execution_evidence_ref.v1';
+  execution?: {
+    sessionId: string;
+    invocationId?: string;
+    agentRunId?: string;
+    turnId?: string;
+  };
+  task?: {
+    taskRunId: string;
+    attemptId?: string;
+  };
+  runtimeCoverage?: ExecutionLogCoverage;
+  taskCoverage?: ExecutionLogCoverage;
+  workspace?: WorkspaceRevisionRef;
+  target?: TargetSnapshotRef;
+}
+```
+
+`execution.agentRunId` maps to the existing `AgentRunHeader.runId` and `RuntimeEvent.runId`. The longer cross-ledger name is intentional: `agentRunId` and `taskRunId` describe different lifecycles.
+
+The Runtime hierarchy remains:
+
+```text
+sessionId > invocationId > agentRunId > turnId
+```
+
+`invocationId` is the existing durable Runtime spine. `agentRunId` identifies a concrete execution attempt recorded by AgentRun. Current production paths may assign the same value to both; consumers must not rely on that implementation coincidence.
+
+Only `sessionId` is required inside an execution identity, and only `taskRunId` is required inside a task identity. At least one lane must be present. Optional descendants let readers represent legacy or partial knowledge honestly instead of fabricating identifiers.
+
+## Cursor contract
+
+An ordered cursor has three required coordinates:
+
+```ts
+interface ExecutionLogCursor {
+  ledger: 'runtime_event' | 'task_event';
+  streamId: string;
+  sequence: number;
+  eventId?: string;
+}
+```
+
+The semantics are strict:
+
+1. `sequence` is the zero-based append ordinal within one `(ledger, streamId)` pair.
+2. Only `sequence` determines order.
+3. `eventId` is an optional audit, lookup, and deduplication pointer. It must never determine order.
+4. Cursors from different ledgers or streams are incomparable.
+5. Different explicit event ids at the same stream position are a conflict, not an ordering result.
+
+The planned stream bindings are:
+
+| Ledger | `streamId` |
+| --- | --- |
+| `runtime_event` | `execution.agentRunId` |
+| `task_event` | `task.taskRunId` |
+
+Phase 0 defines these semantics but does not claim that current stores already persist the ordinal. Existing Runtime Event ids are best-effort unique identifiers, not durable ordered cursors. Existing Compaction `highWaterSeq` values remain policy-local until a later integration explicitly maps them to source-log coverage.
+
+Coverage is an inclusive range within one stream:
+
+```ts
+interface ExecutionLogCoverage {
+  lowWater?: ExecutionLogCursor;
+  highWater: ExecutionLogCursor;
+  eventCount?: number;
+}
+```
+
+`lowWater` may be omitted when only a prefix high water is known. `eventCount` counts observed rows and therefore need not equal the ordinal span when gaps are represented.
+
+## Example
+
+```ts
+const evidence = {
+  schemaVersion: 'maka.execution_evidence_ref.v1',
+  execution: {
+    sessionId: 'session-7',
+    invocationId: 'invocation-12',
+    agentRunId: 'run-12',
+    turnId: 'turn-3',
+  },
+  task: {
+    taskRunId: 'task-42',
+    attemptId: 'attempt-2',
+  },
+  runtimeCoverage: {
+    lowWater: {
+      ledger: 'runtime_event',
+      streamId: 'run-12',
+      sequence: 100,
+      eventId: 'runtime-event-100',
+    },
+    highWater: {
+      ledger: 'runtime_event',
+      streamId: 'run-12',
+      sequence: 246,
+      eventId: 'runtime-event-246',
+    },
+    eventCount: 147,
+  },
+  workspace: {
+    kind: 'workspace_snapshot',
+    ref: 'workspace-19',
+    dirty: true,
+  },
+  target: {
+    snapshotId: 'maka-ahe-abc123',
+    sourceLabel: 'git:abc123',
+  },
+} as const;
+```
+
+This object says where evidence came from. It does not assert that the evidence is correct, current, or complete. Those judgments require reading the referenced facts and comparing their source high waters with current ledger and workspace state.
+
+## Compatibility rules
+
+- Persisted references must carry `schemaVersion`.
+- Readers validate unknown input before trusting identity or cursor fields.
+- Missing optional identities mean unknown, not empty and not synthesized.
+- Legacy records can remain readable through partial identity lanes.
+- A future schema version must use an explicit migration or compatibility reader; it must not silently reinterpret v1 cursor ordering.
+- A projection must not claim coverage that its producer cannot prove.
+
+## Deferred integration work
+
+Later phases should make the contract concrete without changing fact ownership:
+
+1. Persist `invocationId` linkage where AgentRun metadata currently exposes only `runId`.
+2. Materialize stable append ordinals for Runtime and Task Event streams, including backward-compatible reads.
+3. Persist TaskRun/Attempt to AgentRun linkage and Runtime coverage.
+4. Bind executor-owned Tool Results, artifacts, and workspace observations to evidence references.
+5. Bind Self-check to Runtime and Task high waters plus a workspace revision, then define deterministic staleness rules.
+6. Map Compaction source coverage to the shared cursor contract while retaining explicit source-event validation.
+7. Carry target snapshot and execution lineage through AHE exports.
+8. Add human-readable and machine-readable inspection surfaces that expose missing, stale, conflicting, or ambiguous lineage.
+
+The guiding invariant is simple:
+
+> The evidence spine points to facts. It never becomes another place where those facts are rewritten.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -9,6 +9,7 @@
   "exports": {
     ".": "./dist/index.js",
     "./runtime-event": "./dist/runtime-event.js",
+    "./execution-evidence": "./dist/execution-evidence.js",
     "./events": "./dist/events.js",
     "./session": "./dist/session.js",
     "./agent-run": "./dist/agent-run.js",

--- a/packages/core/src/__tests__/execution-evidence.test.ts
+++ b/packages/core/src/__tests__/execution-evidence.test.ts
@@ -1,0 +1,184 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import {
+  EXECUTION_EVIDENCE_REF_SCHEMA_VERSION,
+  compareExecutionLogCursors,
+  executionLogCursorsShareStream,
+  isExecutionEvidenceRef,
+  validateExecutionEvidenceRef,
+  type ExecutionEvidenceRef,
+  type ExecutionLogCursor,
+} from '../execution-evidence.js';
+
+describe('execution evidence spine contract', () => {
+  it('accepts a complete cross-ledger reference', () => {
+    const ref: ExecutionEvidenceRef = {
+      schemaVersion: EXECUTION_EVIDENCE_REF_SCHEMA_VERSION,
+      execution: {
+        sessionId: 'session-1',
+        invocationId: 'invocation-1',
+        agentRunId: 'run-1',
+        turnId: 'turn-1',
+      },
+      task: {
+        taskRunId: 'task-run-1',
+        attemptId: 'attempt-2',
+      },
+      runtimeCoverage: {
+        lowWater: runtimeCursor(4, 'event-4'),
+        highWater: runtimeCursor(12, 'event-12'),
+        eventCount: 9,
+      },
+      taskCoverage: {
+        highWater: taskCursor(7, 'task-event-7'),
+        eventCount: 8,
+      },
+      workspace: {
+        kind: 'workspace_snapshot',
+        ref: 'workspace-snapshot-12',
+      },
+      target: {
+        snapshotId: 'maka-ahe-snapshot-1',
+        sourceLabel: 'git:abc123',
+      },
+    };
+
+    assert.deepEqual(validateExecutionEvidenceRef(ref), { ok: true, value: ref });
+    assert.equal(isExecutionEvidenceRef(ref), true);
+  });
+
+  it('represents honest partial knowledge without inventing child identities', () => {
+    const executionOnly = {
+      schemaVersion: EXECUTION_EVIDENCE_REF_SCHEMA_VERSION,
+      execution: { sessionId: 'session-1' },
+    };
+    const taskOnly = {
+      schemaVersion: EXECUTION_EVIDENCE_REF_SCHEMA_VERSION,
+      task: { taskRunId: 'task-run-1' },
+    };
+
+    assert.equal(validateExecutionEvidenceRef(executionOnly).ok, true);
+    assert.equal(validateExecutionEvidenceRef(taskOnly).ok, true);
+  });
+
+  it('requires an execution or task identity lane', () => {
+    const result = validateExecutionEvidenceRef({
+      schemaVersion: EXECUTION_EVIDENCE_REF_SCHEMA_VERSION,
+      target: { snapshotId: 'snapshot-1' },
+    });
+
+    assert.equal(result.ok, false);
+    if (!result.ok) assert(result.errors.some((error) => error.path === 'ref'));
+  });
+
+  it('rejects malformed ids, schema versions, cursors, and revision refs', () => {
+    const result = validateExecutionEvidenceRef({
+      schemaVersion: 'maka.execution_evidence_ref.v2',
+      execution: { sessionId: ' ', invocationId: '' },
+      runtimeCoverage: {
+        highWater: {
+          ledger: 'task_event',
+          streamId: '',
+          sequence: 1.5,
+          eventId: '',
+        },
+        eventCount: 0,
+      },
+      workspace: { kind: 'unknown', ref: '', dirty: 'yes' },
+    });
+
+    assert.equal(result.ok, false);
+    if (!result.ok) {
+      const paths = new Set(result.errors.map((error) => error.path));
+      assert(paths.has('schemaVersion'));
+      assert(paths.has('execution.sessionId'));
+      assert(paths.has('execution.invocationId'));
+      assert(paths.has('runtimeCoverage.highWater.ledger'));
+      assert(paths.has('runtimeCoverage.highWater.streamId'));
+      assert(paths.has('runtimeCoverage.highWater.sequence'));
+      assert(paths.has('runtimeCoverage.highWater.eventId'));
+      assert(paths.has('runtimeCoverage.eventCount'));
+      assert(paths.has('workspace.kind'));
+      assert(paths.has('workspace.ref'));
+      assert(paths.has('workspace.dirty'));
+    }
+  });
+
+  it('rejects inverted, mixed-stream, and conflicting coverage', () => {
+    const inverted = validateExecutionEvidenceRef({
+      schemaVersion: EXECUTION_EVIDENCE_REF_SCHEMA_VERSION,
+      execution: { sessionId: 'session-1', agentRunId: 'run-1' },
+      runtimeCoverage: {
+        lowWater: runtimeCursor(5, 'event-5'),
+        highWater: runtimeCursor(4, 'event-4'),
+      },
+    });
+    const mixed = validateExecutionEvidenceRef({
+      schemaVersion: EXECUTION_EVIDENCE_REF_SCHEMA_VERSION,
+      execution: { sessionId: 'session-1' },
+      runtimeCoverage: {
+        lowWater: runtimeCursor(1, 'event-1'),
+        highWater: { ...runtimeCursor(2, 'event-2'), streamId: 'run-2' },
+      },
+    });
+    const conflict = validateExecutionEvidenceRef({
+      schemaVersion: EXECUTION_EVIDENCE_REF_SCHEMA_VERSION,
+      execution: { sessionId: 'session-1' },
+      runtimeCoverage: {
+        lowWater: runtimeCursor(2, 'event-a'),
+        highWater: runtimeCursor(2, 'event-b'),
+      },
+    });
+
+    assert.equal(inverted.ok, false);
+    assert.equal(mixed.ok, false);
+    assert.equal(conflict.ok, false);
+  });
+
+  it('binds Runtime and Task coverage streams to known run identities', () => {
+    const result = validateExecutionEvidenceRef({
+      schemaVersion: EXECUTION_EVIDENCE_REF_SCHEMA_VERSION,
+      execution: { sessionId: 'session-1', agentRunId: 'run-expected' },
+      task: { taskRunId: 'task-run-expected' },
+      runtimeCoverage: { highWater: runtimeCursor(1, 'event-1') },
+      taskCoverage: { highWater: taskCursor(1, 'task-event-1') },
+    });
+
+    assert.equal(result.ok, false);
+    if (!result.ok) {
+      assert(result.errors.some((error) => error.path === 'runtimeCoverage.highWater.streamId'));
+      assert(result.errors.some((error) => error.path === 'taskCoverage.highWater.streamId'));
+    }
+  });
+
+  it('orders only cursors in the same stream and never orders by event id', () => {
+    const first = runtimeCursor(1, 'z-event');
+    const second = runtimeCursor(2, 'a-event');
+
+    assert.equal(executionLogCursorsShareStream(first, second), true);
+    assert.equal(compareExecutionLogCursors(first, second), 'before');
+    assert.equal(compareExecutionLogCursors(second, first), 'after');
+    assert.equal(compareExecutionLogCursors(first, { ...first, eventId: undefined }), 'equal');
+    assert.equal(compareExecutionLogCursors(first, { ...first, eventId: 'other-event' }), 'conflict');
+    assert.equal(compareExecutionLogCursors(first, { ...first, streamId: 'run-2' }), 'incomparable');
+    assert.equal(compareExecutionLogCursors(first, taskCursor(1, 'task-event-1')), 'incomparable');
+  });
+});
+
+function runtimeCursor(sequence: number, eventId?: string): ExecutionLogCursor {
+  return {
+    ledger: 'runtime_event',
+    streamId: 'run-1',
+    sequence,
+    ...(eventId ? { eventId } : {}),
+  };
+}
+
+function taskCursor(sequence: number, eventId?: string): ExecutionLogCursor {
+  return {
+    ledger: 'task_event',
+    streamId: 'task-run-1',
+    sequence,
+    ...(eventId ? { eventId } : {}),
+  };
+}

--- a/packages/core/src/execution-evidence.ts
+++ b/packages/core/src/execution-evidence.ts
@@ -1,0 +1,329 @@
+/**
+ * Shared identity and source-coverage contract for cross-ledger evidence.
+ *
+ * This module does not change Runtime or Task persistence. It gives later
+ * integration phases one vocabulary for describing which execution, task,
+ * log prefix, workspace revision, and target snapshot support a projection or
+ * evidence claim.
+ */
+
+export const EXECUTION_EVIDENCE_REF_SCHEMA_VERSION = 'maka.execution_evidence_ref.v1' as const;
+
+export const EXECUTION_LOG_LEDGERS = ['runtime_event', 'task_event'] as const;
+export type ExecutionLogLedger = typeof EXECUTION_LOG_LEDGERS[number];
+
+export const WORKSPACE_REVISION_KINDS = [
+  'git_commit',
+  'workspace_snapshot',
+  'manifest',
+  'opaque',
+] as const;
+export type WorkspaceRevisionKind = typeof WORKSPACE_REVISION_KINDS[number];
+
+/**
+ * Runtime identity lane.
+ *
+ * `invocationId` is the existing durable Runtime spine id. `agentRunId` maps
+ * to `AgentRunHeader.runId` and `RuntimeEvent.runId`; the longer field name
+ * avoids confusing an AgentRun with a TaskRun at cross-ledger boundaries.
+ *
+ * Only `sessionId` is required so callers can represent partial knowledge
+ * without inventing child identities.
+ */
+export interface ExecutionIdentityRef {
+  sessionId: string;
+  invocationId?: string;
+  agentRunId?: string;
+  turnId?: string;
+}
+
+/** Task identity lane. `attemptId` is meaningful only inside `taskRunId`. */
+export interface TaskIdentityRef {
+  taskRunId: string;
+  attemptId?: string;
+}
+
+/**
+ * Ordered position in one append-only log stream.
+ *
+ * `sequence` is the zero-based append ordinal within (`ledger`, `streamId`).
+ * It is the only ordering field. `eventId` is an optional audit/dedup pointer
+ * and MUST NOT be used to order events. Cursors from different streams are
+ * incomparable.
+ */
+export interface ExecutionLogCursor {
+  ledger: ExecutionLogLedger;
+  streamId: string;
+  sequence: number;
+  eventId?: string;
+}
+
+/** Inclusive coverage of one append-only log stream. */
+export interface ExecutionLogCoverage {
+  highWater: ExecutionLogCursor;
+  lowWater?: ExecutionLogCursor;
+  /** Observed rows represented by this coverage; gaps may make it smaller than the ordinal span. */
+  eventCount?: number;
+}
+
+export interface WorkspaceRevisionRef {
+  kind: WorkspaceRevisionKind;
+  ref: string;
+  dirty?: boolean;
+}
+
+export interface TargetSnapshotRef {
+  snapshotId: string;
+  sourceLabel?: string;
+}
+
+/**
+ * Versioned cross-ledger source reference.
+ *
+ * This is a reference to facts, not a new fact authority. At least one of the
+ * Runtime or Task identity lanes is required. Every other field is optional so
+ * old data and partially observed executions can be represented honestly.
+ */
+export interface ExecutionEvidenceRef {
+  schemaVersion: typeof EXECUTION_EVIDENCE_REF_SCHEMA_VERSION;
+  execution?: ExecutionIdentityRef;
+  task?: TaskIdentityRef;
+  runtimeCoverage?: ExecutionLogCoverage;
+  taskCoverage?: ExecutionLogCoverage;
+  workspace?: WorkspaceRevisionRef;
+  target?: TargetSnapshotRef;
+}
+
+export type ExecutionLogCursorComparison =
+  | 'before'
+  | 'equal'
+  | 'after'
+  | 'incomparable'
+  | 'conflict';
+
+export interface ExecutionEvidenceValidationIssue {
+  path: string;
+  message: string;
+}
+
+export type ExecutionEvidenceValidationResult =
+  | { ok: true; value: ExecutionEvidenceRef }
+  | { ok: false; errors: ExecutionEvidenceValidationIssue[] };
+
+/** True only when both cursors use the same ledger and stream identity. */
+export function executionLogCursorsShareStream(
+  left: Pick<ExecutionLogCursor, 'ledger' | 'streamId'>,
+  right: Pick<ExecutionLogCursor, 'ledger' | 'streamId'>,
+): boolean {
+  return left.ledger === right.ledger && left.streamId === right.streamId;
+}
+
+/**
+ * Compare append positions without guessing across streams.
+ *
+ * Different event ids at the same stream position are reported as `conflict`:
+ * the ordinal says the rows are equal while their audit identities disagree.
+ */
+export function compareExecutionLogCursors(
+  left: ExecutionLogCursor,
+  right: ExecutionLogCursor,
+): ExecutionLogCursorComparison {
+  if (!executionLogCursorsShareStream(left, right)) return 'incomparable';
+  if (left.sequence < right.sequence) return 'before';
+  if (left.sequence > right.sequence) return 'after';
+  if (left.eventId && right.eventId && left.eventId !== right.eventId) return 'conflict';
+  return 'equal';
+}
+
+export function validateExecutionEvidenceRef(value: unknown): ExecutionEvidenceValidationResult {
+  const errors: ExecutionEvidenceValidationIssue[] = [];
+  if (!isRecord(value)) return invalid('ref', 'expected an object');
+
+  if (value.schemaVersion !== EXECUTION_EVIDENCE_REF_SCHEMA_VERSION) {
+    errors.push({
+      path: 'schemaVersion',
+      message: `expected "${EXECUTION_EVIDENCE_REF_SCHEMA_VERSION}"`,
+    });
+  }
+
+  const execution = validateExecutionIdentity(value.execution, errors);
+  const task = validateTaskIdentity(value.task, errors);
+  if (!execution && !task) {
+    errors.push({ path: 'ref', message: 'expected at least one execution or task identity lane' });
+  }
+
+  const runtimeCoverage = validateCoverage(value.runtimeCoverage, 'runtimeCoverage', 'runtime_event', errors);
+  const taskCoverage = validateCoverage(value.taskCoverage, 'taskCoverage', 'task_event', errors);
+
+  if (execution?.agentRunId && runtimeCoverage && runtimeCoverage.highWater.streamId !== execution.agentRunId) {
+    errors.push({
+      path: 'runtimeCoverage.highWater.streamId',
+      message: 'expected streamId to match execution.agentRunId',
+    });
+  }
+  if (task?.taskRunId && taskCoverage && taskCoverage.highWater.streamId !== task.taskRunId) {
+    errors.push({
+      path: 'taskCoverage.highWater.streamId',
+      message: 'expected streamId to match task.taskRunId',
+    });
+  }
+
+  validateWorkspaceRevision(value.workspace, errors);
+  validateTargetSnapshot(value.target, errors);
+
+  return errors.length === 0
+    ? { ok: true, value: value as unknown as ExecutionEvidenceRef }
+    : { ok: false, errors };
+}
+
+export function isExecutionEvidenceRef(value: unknown): value is ExecutionEvidenceRef {
+  return validateExecutionEvidenceRef(value).ok;
+}
+
+function validateExecutionIdentity(
+  value: unknown,
+  errors: ExecutionEvidenceValidationIssue[],
+): ExecutionIdentityRef | undefined {
+  if (value === undefined) return undefined;
+  if (!isRecord(value)) {
+    errors.push({ path: 'execution', message: 'expected an object' });
+    return undefined;
+  }
+  requireNonEmptyString(value.sessionId, 'execution.sessionId', errors);
+  optionalNonEmptyString(value.invocationId, 'execution.invocationId', errors);
+  optionalNonEmptyString(value.agentRunId, 'execution.agentRunId', errors);
+  optionalNonEmptyString(value.turnId, 'execution.turnId', errors);
+  return value as unknown as ExecutionIdentityRef;
+}
+
+function validateTaskIdentity(
+  value: unknown,
+  errors: ExecutionEvidenceValidationIssue[],
+): TaskIdentityRef | undefined {
+  if (value === undefined) return undefined;
+  if (!isRecord(value)) {
+    errors.push({ path: 'task', message: 'expected an object' });
+    return undefined;
+  }
+  requireNonEmptyString(value.taskRunId, 'task.taskRunId', errors);
+  optionalNonEmptyString(value.attemptId, 'task.attemptId', errors);
+  return value as unknown as TaskIdentityRef;
+}
+
+function validateCoverage(
+  value: unknown,
+  path: string,
+  expectedLedger: ExecutionLogLedger,
+  errors: ExecutionEvidenceValidationIssue[],
+): ExecutionLogCoverage | undefined {
+  if (value === undefined) return undefined;
+  if (!isRecord(value)) {
+    errors.push({ path, message: 'expected an object' });
+    return undefined;
+  }
+
+  const highWater = validateCursor(value.highWater, `${path}.highWater`, expectedLedger, errors);
+  const lowWater = value.lowWater === undefined
+    ? undefined
+    : validateCursor(value.lowWater, `${path}.lowWater`, expectedLedger, errors);
+
+  if (lowWater && highWater) {
+    const comparison = compareExecutionLogCursors(lowWater, highWater);
+    if (comparison === 'incomparable') {
+      errors.push({ path: `${path}.lowWater`, message: 'expected lowWater and highWater in the same log stream' });
+    } else if (comparison === 'after') {
+      errors.push({ path: `${path}.lowWater.sequence`, message: 'expected lowWater at or before highWater' });
+    } else if (comparison === 'conflict') {
+      errors.push({ path: `${path}.lowWater.eventId`, message: 'conflicting event ids at the same log position' });
+    }
+  }
+
+  if (value.eventCount !== undefined && !isPositiveSafeInteger(value.eventCount)) {
+    errors.push({ path: `${path}.eventCount`, message: 'expected a positive safe integer' });
+  }
+  return highWater ? value as unknown as ExecutionLogCoverage : undefined;
+}
+
+function validateCursor(
+  value: unknown,
+  path: string,
+  expectedLedger: ExecutionLogLedger,
+  errors: ExecutionEvidenceValidationIssue[],
+): ExecutionLogCursor | undefined {
+  if (!isRecord(value)) {
+    errors.push({ path, message: 'expected an object' });
+    return undefined;
+  }
+  if (value.ledger !== expectedLedger) {
+    errors.push({ path: `${path}.ledger`, message: `expected "${expectedLedger}"` });
+  }
+  requireNonEmptyString(value.streamId, `${path}.streamId`, errors);
+  if (!isNonNegativeSafeInteger(value.sequence)) {
+    errors.push({ path: `${path}.sequence`, message: 'expected a non-negative safe integer' });
+  }
+  optionalNonEmptyString(value.eventId, `${path}.eventId`, errors);
+  return value as unknown as ExecutionLogCursor;
+}
+
+function validateWorkspaceRevision(value: unknown, errors: ExecutionEvidenceValidationIssue[]): void {
+  if (value === undefined) return;
+  if (!isRecord(value)) {
+    errors.push({ path: 'workspace', message: 'expected an object' });
+    return;
+  }
+  if (!isOneOf(value.kind, WORKSPACE_REVISION_KINDS)) {
+    errors.push({ path: 'workspace.kind', message: 'expected a known workspace revision kind' });
+  }
+  requireNonEmptyString(value.ref, 'workspace.ref', errors);
+  if (value.dirty !== undefined && typeof value.dirty !== 'boolean') {
+    errors.push({ path: 'workspace.dirty', message: 'expected a boolean when present' });
+  }
+}
+
+function validateTargetSnapshot(value: unknown, errors: ExecutionEvidenceValidationIssue[]): void {
+  if (value === undefined) return;
+  if (!isRecord(value)) {
+    errors.push({ path: 'target', message: 'expected an object' });
+    return;
+  }
+  requireNonEmptyString(value.snapshotId, 'target.snapshotId', errors);
+  optionalNonEmptyString(value.sourceLabel, 'target.sourceLabel', errors);
+}
+
+function requireNonEmptyString(
+  value: unknown,
+  path: string,
+  errors: ExecutionEvidenceValidationIssue[],
+): void {
+  if (typeof value !== 'string' || value.trim().length === 0) {
+    errors.push({ path, message: 'expected a non-empty string' });
+  }
+}
+
+function optionalNonEmptyString(
+  value: unknown,
+  path: string,
+  errors: ExecutionEvidenceValidationIssue[],
+): void {
+  if (value !== undefined) requireNonEmptyString(value, path, errors);
+}
+
+function isNonNegativeSafeInteger(value: unknown): value is number {
+  return typeof value === 'number' && Number.isSafeInteger(value) && value >= 0;
+}
+
+function isPositiveSafeInteger(value: unknown): value is number {
+  return typeof value === 'number' && Number.isSafeInteger(value) && value > 0;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function isOneOf<T extends readonly string[]>(value: unknown, values: T): value is T[number] {
+  return typeof value === 'string' && values.includes(value);
+}
+
+function invalid(path: string, message: string): ExecutionEvidenceValidationResult {
+  return { ok: false, errors: [{ path, message }] };
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -98,6 +98,33 @@ export {
   createRuntimeEventId,
 } from './runtime-event.js';
 
+// execution-evidence.ts — shared cross-ledger identity and source coverage.
+// This contract references canonical facts; it does not create another fact
+// authority. Subpath `@maka/core/execution-evidence` is preferred.
+export type {
+  ExecutionIdentityRef,
+  TaskIdentityRef,
+  ExecutionLogCursor,
+  ExecutionLogCoverage,
+  WorkspaceRevisionRef,
+  TargetSnapshotRef,
+  ExecutionEvidenceRef,
+  ExecutionLogLedger,
+  ExecutionLogCursorComparison,
+  WorkspaceRevisionKind,
+  ExecutionEvidenceValidationIssue,
+  ExecutionEvidenceValidationResult,
+} from './execution-evidence.js';
+export {
+  EXECUTION_EVIDENCE_REF_SCHEMA_VERSION,
+  EXECUTION_LOG_LEDGERS,
+  WORKSPACE_REVISION_KINDS,
+  executionLogCursorsShareStream,
+  compareExecutionLogCursors,
+  validateExecutionEvidenceRef,
+  isExecutionEvidenceRef,
+} from './execution-evidence.js';
+
 // runtime-event-store.ts
 export type {
   RuntimeEventStore,


### PR DESCRIPTION
Part of #948.

## Summary

- audit current Runtime Event, AgentRun, Session, Task Event, Compaction, Self-check, and AHE fact ownership
- add the versioned `maka.execution_evidence_ref.v1` contract in `@maka/core/execution-evidence`
- separate Runtime and Task identity lanes so AgentRun and TaskRun cannot be confused
- define comparable log cursors as `(ledger, streamId, sequence)` and explicitly forbid ordering by event id
- add validation, cursor comparison helpers, contract tests, and a stable documentation entry point

## Phase boundary

This is Phase 0 only. It defines the shared vocabulary and invariants without changing persistence or runtime behavior. Stable sequence materialization, TaskRun/Attempt to AgentRun linkage, Self-check freshness, Compaction coverage integration, inspect surfaces, and AHE lineage remain follow-up phases in #948.

## Verification

- `npm --workspace @maka/core run typecheck`
- `npm --workspace @maka/core test` — 926 passed, 0 failed
- package subpath import smoke for `@maka/core/execution-evidence`
- `git diff --cached --check`

## Repository-wide check note

`npm run typecheck` was also attempted. The affected `@maka/core` workspace passed, but the repository-wide command is currently blocked later by checkout/environment issues outside this diff: unavailable Runtime optional dependencies (`@ai-sdk/cohere`, `node-pty`, xterm packages) and downstream workspaces resolving stale generated exports. No files in those failing workspaces are changed by this PR.
