### PR TITLE
feat(headless): persist Phase 1 Runtime-to-Task lineage

### DIFF
--- a/docs/execution-evidence-spine.md
+++ b/docs/execution-evidence-spine.md
@@ -1,6 +1,6 @@
 # Execution Identity and Evidence Spine
 
-Status: Phase 0 contract and architecture audit. See [issue #948](https://github.com/maka-agent/maka-agent/issues/948).
+Status: Phase 0 contract plus Phase 1 Runtime-to-Task lineage. See [issue #948](https://github.com/maka-agent/maka-agent/issues/948).
 
 Maka already records the facts needed to explain an execution. Runtime Events preserve model and tool interaction facts, AgentRun records operational lifecycle, and Task Events preserve durable task-control decisions. The missing piece is a shared way to reference those facts across subsystem boundaries.
 
@@ -10,9 +10,9 @@ The Execution Identity and Evidence Spine is that reference protocol. It answers
 
 It is deliberately not a new event log, trace backend, or source of truth.
 
-## Phase 0 boundary
+## Delivery boundary
 
-Phase 0 adds a versioned shared contract in `@maka/core/execution-evidence`, runtime validation, cursor comparison rules, and this ownership audit. It does not yet:
+Phase 0 added a versioned shared contract in `@maka/core/execution-evidence`, runtime validation, cursor comparison rules, and this ownership audit. At that boundary it did not:
 
 - assign or persist log sequence numbers;
 - change Runtime, AgentRun, Session, or TaskRun storage;
@@ -20,7 +20,18 @@ Phase 0 adds a versioned shared contract in `@maka/core/execution-evidence`, run
 - attach evidence references to Self-check, Compaction, or AHE exports;
 - add a lineage inspection command.
 
-Those integrations belong to later phases of issue #948. Defining the contract first prevents each integration from inventing a different meaning for identity, coverage, or freshness.
+Defining the contract first prevents each integration from inventing a different meaning for identity, coverage, or freshness.
+
+Phase 1 makes the Runtime-to-Task portion concrete:
+
+- new AgentRun headers persist `invocationId` while legacy headers remain readable;
+- every finished headless Runtime invocation appends a `task_attempt_execution_linked` Task Event;
+- the event references TaskRun, Attempt, Session, Invocation, AgentRun, Turn, and inclusive Runtime Event coverage;
+- one Attempt may link multiple AgentRuns, including the bounded heavy-task repair run;
+- `TaskRunProjection.executionLineage` and each `TaskAttempt.executionLineage` expose the replayed links;
+- legacy `ResultRecord` imports produce an honest identity-only link when Runtime coverage is unavailable.
+
+Phase 1 still does not add Task Event cursors, evidence freshness, Compaction integration, AHE lineage, or a general inspection command.
 
 ## Existing authorities
 
@@ -29,7 +40,7 @@ The spine references existing authorities instead of copying their facts.
 | Authority | Identity today | Owns | Does not own |
 | --- | --- | --- | --- |
 | `RuntimeEvent` | `sessionId`, `invocationId`, `runId`, `turnId`, `id` | Canonical model, tool, runtime-content, and terminal interaction facts | Task scheduling or task-level decisions |
-| `AgentRunHeader` and `AgentRunEvent` | `sessionId`, `runId`, `turnId`, event `id` | Operational run lifecycle, status, model resolution, permission, usage, and run-local checkpoints | A second copy of raw Runtime interaction history |
+| `AgentRunHeader` and `AgentRunEvent` | `sessionId`, optional legacy-compatible `invocationId`, `runId`, `turnId`, event `id` | Operational run lifecycle, status, model resolution, permission, usage, and run-local checkpoints | A second copy of raw Runtime interaction history |
 | `SessionEvent` and stored messages | Session and turn-oriented identifiers | Compatibility and UI/session read models | Canonical Runtime history |
 | `TaskEvent` | `taskRunId`, optional event-specific `attemptId`, event `id` | Task lifecycle, attempts, policy decisions, evidence envelopes, permissions, and recovery-visible task state | Raw model messages, Tool Calls, or Tool Results already owned by Runtime Events |
 | `TaskRunProjection` | Fold of one `taskRunId` event stream | Current task read model derived from Task Events | Independent facts outside its source Task Events |
@@ -116,6 +127,16 @@ The planned stream bindings are:
 
 Phase 0 defines these semantics but does not claim that current stores already persist the ordinal. Existing Runtime Event ids are best-effort unique identifiers, not durable ordered cursors. Existing Compaction `highWaterSeq` values remain policy-local until a later integration explicitly maps them to source-log coverage.
 
+For Phase 1 headless lineage, the persisted AgentRun Runtime Event JSONL is the ordered stream. Mutable partial snapshot files are excluded, while every physical JSONL row—including a lifecycle row that may carry `partial: true`—retains its append position. Those immutable positions are materialized as zero-based cursor sequences. A completed invocation therefore records coverage such as:
+
+```text
+TaskRun task-42 / Attempt attempt-2
+  -> AgentRun run-a: Runtime Events [0..146]
+  -> AgentRun run-b: Runtime Events [0..38]   # bounded repair run
+```
+
+The Task Event stores only these references and boundary event ids. Model messages, Tool Calls, Tool Results, and other Runtime facts remain solely in the Runtime Event ledger.
+
 Coverage is an inclusive range within one stream:
 
 ```ts
@@ -183,16 +204,14 @@ This object says where evidence came from. It does not assert that the evidence 
 
 ## Deferred integration work
 
-Later phases should make the contract concrete without changing fact ownership:
+Later phases should extend the contract without changing fact ownership:
 
-1. Persist `invocationId` linkage where AgentRun metadata currently exposes only `runId`.
-2. Materialize stable append ordinals for Runtime and Task Event streams, including backward-compatible reads.
-3. Persist TaskRun/Attempt to AgentRun linkage and Runtime coverage.
-4. Bind executor-owned Tool Results, artifacts, and workspace observations to evidence references.
-5. Bind Self-check to Runtime and Task high waters plus a workspace revision, then define deterministic staleness rules.
-6. Map Compaction source coverage to the shared cursor contract while retaining explicit source-event validation.
-7. Carry target snapshot and execution lineage through AHE exports.
-8. Add human-readable and machine-readable inspection surfaces that expose missing, stale, conflicting, or ambiguous lineage.
+1. Materialize stable append ordinals for Task Event streams, including backward-compatible reads.
+2. Bind executor-owned Tool Results, artifacts, and workspace observations to evidence references.
+3. Bind Self-check to Runtime and Task high waters plus a workspace revision, then define deterministic staleness rules.
+4. Map Compaction source coverage to the shared cursor contract while retaining explicit source-event validation.
+5. Carry target snapshot and execution lineage through AHE exports.
+6. Add human-readable and machine-readable inspection surfaces that expose missing, stale, conflicting, or ambiguous lineage.
 
 The guiding invariant is simple:
 

--- a/packages/core/src/agent-run.ts
+++ b/packages/core/src/agent-run.ts
@@ -14,6 +14,8 @@ export type AgentRunStatus = typeof AGENT_RUN_STATUSES[number];
 
 export interface AgentRunHeader {
   runId: string;
+  /** Durable Runtime invocation spine. Optional only for legacy run headers. */
+  invocationId?: string;
   sessionId: string;
   turnId: string;
   status: AgentRunStatus;

--- a/packages/core/src/runtime-event-store.ts
+++ b/packages/core/src/runtime-event-store.ts
@@ -3,5 +3,7 @@ import type { RuntimeEvent } from './runtime-event.js';
 export interface RuntimeEventStore {
   appendRuntimeEvent(sessionId: string, runId: string, event: RuntimeEvent): Promise<void>;
   readRuntimeEvents(sessionId: string, runId: string): Promise<RuntimeEvent[]>;
+  /** Physical append-log rows only; excludes mutable partial snapshots. */
+  readImmutableRuntimeEvents?(sessionId: string, runId: string): Promise<RuntimeEvent[]>;
   readSessionRuntimeEvents(sessionId: string): Promise<RuntimeEvent[]>;
 }

--- a/packages/headless/src/__tests__/task-agent-controller.test.ts
+++ b/packages/headless/src/__tests__/task-agent-controller.test.ts
@@ -625,6 +625,7 @@ describe('runTaskOnce', () => {
             'tool_executor_identity_recorded',
             'task_run_started',
             'task_attempt_started',
+            'task_attempt_execution_linked',
             'feedback_observed',
             'task_run_verifying',
             'verifier_result_recorded',
@@ -642,6 +643,25 @@ describe('runTaskOnce', () => {
         assert.equal(tools.actualToolCalls, 0);
         assert.deepEqual(tools.actualToolNames, []);
         assert.deepEqual(tools.actualToolCallCounts, {});
+        const runtimeLedger = await readRuntimeEventLedger(
+          storageRoot,
+          result.invocation.sessionId,
+          result.invocation.runId,
+        );
+        const lineage = result.projection.attempts[0]?.executionLineage[0];
+        assert.equal(lineage?.execution?.invocationId, result.invocation.invocationId);
+        assert.equal(lineage?.execution?.agentRunId, result.invocation.runId);
+        assert.equal(lineage?.runtimeCoverage?.lowWater?.sequence, 0);
+        assert.equal(lineage?.runtimeCoverage?.lowWater?.eventId, runtimeLedger[0]?.id);
+        assert.equal(lineage?.runtimeCoverage?.highWater.sequence, runtimeLedger.length - 1);
+        assert.equal(lineage?.runtimeCoverage?.highWater.eventId, runtimeLedger.at(-1)?.id);
+        assert.equal(lineage?.runtimeCoverage?.eventCount, runtimeLedger.length);
+        const runHeader = await readAgentRunHeader(
+          storageRoot,
+          result.invocation.sessionId,
+          result.invocation.runId,
+        );
+        assert.equal(runHeader.invocationId, result.invocation.invocationId);
       } finally {
         SessionManager.prototype.sendMessage = original;
       }
@@ -809,6 +829,10 @@ describe('runTaskOnce', () => {
       assert.equal(result.projection.latestHeavyTaskSelfCheckGate?.action, 'allow_finalize');
       assert.equal(result.projection.latestVerifierResult?.passed, true);
       assert.equal(result.resultRecord.passed, true);
+      assert.equal(result.projection.attempts[0]?.executionLineage.length, 2);
+      assert.equal(new Set(
+        result.projection.attempts[0]?.executionLineage.map((ref) => ref.execution?.agentRunId),
+      ).size, 2);
       const gateIndexes = result.projection.events
         .map((event, index) => event.type === 'heavy_task_self_check_gate_recorded' ? index : -1)
         .filter((index) => index >= 0);

--- a/packages/headless/src/__tests__/task-execution-lineage.test.ts
+++ b/packages/headless/src/__tests__/task-execution-lineage.test.ts
@@ -1,0 +1,94 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+import type { RuntimeEvent } from '@maka/core/runtime-event';
+import { taskAttemptExecutionEvidence } from '../task-execution-lineage.js';
+
+describe('taskAttemptExecutionEvidence', () => {
+  test('builds inclusive stable coverage from every immutable Runtime log row', () => {
+    const evidence = taskAttemptExecutionEvidence({
+      taskRunId: 'task-run-1',
+      attemptId: 'attempt-1',
+      sessionId: 'session-1',
+      invocationId: 'invocation-1',
+      agentRunId: 'run-1',
+      turnId: 'turn-1',
+      runtimeEvents: [
+        runtimeEvent('event-1'),
+        runtimeEvent('partial-lifecycle-event', {
+          partial: true,
+          role: 'system',
+          author: 'system',
+          actions: { stateDelta: { progress: 1 } },
+        }),
+        runtimeEvent('event-2'),
+        runtimeEvent('event-3'),
+      ],
+    });
+
+    assert.deepEqual(evidence.runtimeCoverage, {
+      lowWater: {
+        ledger: 'runtime_event',
+        streamId: 'run-1',
+        sequence: 0,
+        eventId: 'event-1',
+      },
+      highWater: {
+        ledger: 'runtime_event',
+        streamId: 'run-1',
+        sequence: 3,
+        eventId: 'event-3',
+      },
+      eventCount: 4,
+    });
+  });
+
+  test('keeps an honest identity-only link when legacy data has no event coverage', () => {
+    const evidence = taskAttemptExecutionEvidence({
+      taskRunId: 'task-run-1',
+      attemptId: 'attempt-1',
+      sessionId: 'session-1',
+      agentRunId: 'run-1',
+      runtimeEvents: [],
+    });
+
+    assert.deepEqual(evidence.execution, {
+      sessionId: 'session-1',
+      agentRunId: 'run-1',
+    });
+    assert.deepEqual(evidence.task, {
+      taskRunId: 'task-run-1',
+      attemptId: 'attempt-1',
+    });
+    assert.equal(evidence.runtimeCoverage, undefined);
+  });
+
+  test('refuses to claim coverage over events from another Runtime stream', () => {
+    assert.throws(
+      () => taskAttemptExecutionEvidence({
+        taskRunId: 'task-run-1',
+        attemptId: 'attempt-1',
+        sessionId: 'session-1',
+        invocationId: 'invocation-1',
+        agentRunId: 'run-1',
+        turnId: 'turn-1',
+        runtimeEvents: [runtimeEvent('event-1', { runId: 'run-2' })],
+      }),
+      /runId does not match lineage agentRunId/,
+    );
+  });
+});
+
+function runtimeEvent(id: string, overrides: Partial<RuntimeEvent> = {}): RuntimeEvent {
+  return {
+    id,
+    invocationId: 'invocation-1',
+    runId: 'run-1',
+    sessionId: 'session-1',
+    turnId: 'turn-1',
+    ts: 1,
+    partial: false,
+    role: 'model',
+    author: 'agent',
+    ...overrides,
+  };
+}

--- a/packages/headless/src/__tests__/task-run-adapter.test.ts
+++ b/packages/headless/src/__tests__/task-run-adapter.test.ts
@@ -60,6 +60,9 @@ describe('taskEventsFromResultRecord', () => {
 
     assert.equal(taxonomyFromResultRecord(original), 'passed');
     assert.equal(projection.latestScoreResult?.taxonomy, 'passed');
+    assert.equal(projection.executionLineage[0]?.execution?.sessionId, original.sessionId);
+    assert.equal(projection.executionLineage[0]?.execution?.agentRunId, original.runId);
+    assert.equal(projection.executionLineage[0]?.runtimeCoverage, undefined);
     assert.deepEqual(resultRecordFromTaskRunProjection(projection), original);
   });
 

--- a/packages/headless/src/__tests__/task-run-store.test.ts
+++ b/packages/headless/src/__tests__/task-run-store.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, test } from 'node:test';
 import type { HeavyTaskSelfCheckPlanState, HeavyTaskSemanticSelfCheckState, TaskEvent } from '../task-contracts.js';
+import { taskAttemptExecutionEvidence } from '../task-execution-lineage.js';
 import { createInMemoryTaskRunStore, createTaskRunStore, projectTaskRun } from '../task-run-store.js';
 
 function eventIdFactory(): () => string {
@@ -116,6 +117,7 @@ describe('TaskRunStore', () => {
     assert.equal(projection.sessionId, 's-1');
     assert.equal(projection.agentRunId, 'r-1');
     assert.equal(projection.attempts[0]?.status, 'completed');
+    assert.deepEqual(projection.attempts[0]?.executionLineage, []);
     assert.equal(projection.selfChecks[0]?.summary, 'looks solved');
     assert.equal(projection.feedback[0]?.summary, 'tests passed');
     assert.equal(projection.decisions[0]?.decision, 'stop');
@@ -127,6 +129,85 @@ describe('TaskRunStore', () => {
       verifierResultId: 'v-1',
       scoreResultId: 'score-1',
     });
+  });
+
+  test('projects every AgentRun linked to one attempt without copying Runtime facts', () => {
+    const taskRunId = 'tr-lineage';
+    const attemptId = 'attempt-1';
+    const events: TaskEvent[] = [
+      { type: 'task_run_created', id: 'e-1', taskRunId, ts: 1, taskId: 'task-1', configId: 'cfg-1' },
+      { type: 'task_run_started', id: 'e-2', taskRunId, ts: 2, sessionId: 'session-1', agentRunId: 'run-1' },
+      { type: 'task_attempt_started', id: 'e-3', taskRunId, ts: 3, attemptId, sessionId: 'session-1', agentRunId: 'run-1' },
+      {
+        type: 'task_attempt_execution_linked',
+        id: 'e-4',
+        taskRunId,
+        attemptId,
+        ts: 4,
+        evidence: taskAttemptExecutionEvidence({
+          taskRunId,
+          attemptId,
+          sessionId: 'session-1',
+          invocationId: 'invocation-1',
+          agentRunId: 'run-1',
+          turnId: 'turn-1',
+          runtimeEvents: [],
+        }),
+      },
+      {
+        type: 'task_attempt_execution_linked',
+        id: 'e-5',
+        taskRunId,
+        attemptId,
+        ts: 5,
+        evidence: taskAttemptExecutionEvidence({
+          taskRunId,
+          attemptId,
+          sessionId: 'session-1',
+          invocationId: 'invocation-2',
+          agentRunId: 'run-2',
+          turnId: 'turn-2',
+          runtimeEvents: [],
+        }),
+      },
+      { type: 'task_attempt_completed', id: 'e-6', taskRunId, ts: 6, attemptId, status: 'completed' },
+    ];
+
+    const projection = projectTaskRun(events, taskRunId);
+
+    assert.equal(projection.agentRunId, 'run-1');
+    assert.deepEqual(
+      projection.executionLineage.map((ref) => ref.execution?.agentRunId),
+      ['run-1', 'run-2'],
+    );
+    assert.deepEqual(
+      projection.attempts[0]?.executionLineage.map((ref) => ref.execution?.agentRunId),
+      ['run-1', 'run-2'],
+    );
+  });
+
+  test('rejects lineage whose task identity does not match the owning event', () => {
+    const taskRunId = 'tr-lineage-invalid';
+    const projection = projectTaskRun([
+      { type: 'task_attempt_started', id: 'e-1', taskRunId, ts: 1, attemptId: 'attempt-1' },
+      {
+        type: 'task_attempt_execution_linked',
+        id: 'e-2',
+        taskRunId,
+        attemptId: 'attempt-1',
+        ts: 2,
+        evidence: taskAttemptExecutionEvidence({
+          taskRunId: 'another-task-run',
+          attemptId: 'attempt-1',
+          sessionId: 'session-1',
+          agentRunId: 'run-1',
+          runtimeEvents: [],
+        }),
+      },
+    ], taskRunId);
+
+    assert.equal(projection.executionLineage.length, 0);
+    assert.match(projection.warnings[0] ?? '', /task identity does not match/);
   });
 
   test('projects first-class task-run artifacts', () => {

--- a/packages/headless/src/index.ts
+++ b/packages/headless/src/index.ts
@@ -80,6 +80,7 @@ export type {
   ScoreResult,
   SelfCheckObservation,
   TaskAttempt,
+  TaskAttemptExecutionLinkedEvent,
   TaskAttemptStatus,
   TaskDefinition,
   TaskEvent,
@@ -148,6 +149,8 @@ export {
 } from './task-run-adapter.js';
 export type { RunTaskOnceDeps, RunTaskOnceResult } from './task-agent-controller.js';
 export { runTaskOnce, TaskAgentController } from './task-agent-controller.js';
+export type { TaskAttemptExecutionEvidenceInput } from './task-execution-lineage.js';
+export { taskAttemptExecutionEvidence } from './task-execution-lineage.js';
 export type {
   AutonomousDecisionInput,
   AutonomousDecisionPolicy,

--- a/packages/headless/src/task-agent-controller.ts
+++ b/packages/headless/src/task-agent-controller.ts
@@ -93,6 +93,7 @@ import {
   type TaskRunStore,
 } from './task-run-store.js';
 import { taskDefinitionFromTask } from './task-run-adapter.js';
+import { taskAttemptExecutionEvidence } from './task-execution-lineage.js';
 
 export interface RunTaskOnceDeps extends RunExperimentDeps {
   taskRunStore?: TaskRunStore;
@@ -342,6 +343,15 @@ export async function runTaskOnce(
     } finally {
       await active.dispose();
     }
+    await appendTaskAttemptExecutionLink({
+      store: taskRunStore,
+      runtimeEventStore,
+      taskRunId,
+      attemptId,
+      invocation: runtimeInvocation,
+      now,
+      newId,
+    });
     const permissionHandling = await handlePermissionIntervention({
       invocation: runtimeInvocation,
       store: taskRunStore,
@@ -428,6 +438,15 @@ export async function runTaskOnce(
         } finally {
           await repairActive.dispose();
         }
+        await appendTaskAttemptExecutionLink({
+          store: taskRunStore,
+          runtimeEventStore,
+          taskRunId,
+          attemptId,
+          invocation: repairInvocation,
+          now,
+          newId,
+        });
         const repairPermissionHandling = await handlePermissionIntervention({
           invocation: repairInvocation,
           store: taskRunStore,
@@ -672,6 +691,39 @@ function toolNamesForIdentity(hasIsolatedExecutor: boolean, heavyTaskEnabled: bo
   const names = hasIsolatedExecutor ? [...ISOLATED_HEADLESS_TOOL_NAMES] : ['registered_backend'];
   if (heavyTaskEnabled && hasIsolatedExecutor) names.push(...HEAVY_TASK_PROGRESS_TOOL_NAMES, ...HEAVY_TASK_SELF_CHECK_TOOL_NAMES);
   return names;
+}
+
+async function appendTaskAttemptExecutionLink(input: {
+  store: TaskRunStore;
+  runtimeEventStore: RuntimeEventStore;
+  taskRunId: string;
+  attemptId: string;
+  invocation: InvocationResult;
+  now: () => number;
+  newId: () => string;
+}): Promise<void> {
+  const runtimeEvents = input.runtimeEventStore.readImmutableRuntimeEvents
+    ? await input.runtimeEventStore.readImmutableRuntimeEvents(
+        input.invocation.sessionId,
+        input.invocation.runId,
+      )
+    : [];
+  await appendTaskEvent(input.store, input.taskRunId, {
+    type: 'task_attempt_execution_linked',
+    id: input.newId(),
+    taskRunId: input.taskRunId,
+    attemptId: input.attemptId,
+    ts: input.now(),
+    evidence: taskAttemptExecutionEvidence({
+      taskRunId: input.taskRunId,
+      attemptId: input.attemptId,
+      sessionId: input.invocation.sessionId,
+      invocationId: input.invocation.invocationId,
+      agentRunId: input.invocation.runId,
+      turnId: input.invocation.turnId,
+      runtimeEvents,
+    }),
+  });
 }
 
 interface PermissionInterventionInput {

--- a/packages/headless/src/task-contracts.ts
+++ b/packages/headless/src/task-contracts.ts
@@ -1,3 +1,4 @@
+import type { ExecutionEvidenceRef } from '@maka/core/execution-evidence';
 import type { ResultRecord, TaskVerification, VerifierSpec } from './contracts.js';
 
 export type TaskRunStatus =
@@ -154,6 +155,8 @@ export interface TaskAttempt {
   status: TaskAttemptStatus;
   sessionId?: string;
   agentRunId?: string;
+  /** Ordered references to every AgentRun that contributed to this attempt. */
+  executionLineage: ExecutionEvidenceRef[];
   error?: TaskRunError;
 }
 
@@ -738,6 +741,13 @@ export interface TaskAttemptStartedEvent extends BaseTaskEvent {
   agentRunId?: string;
 }
 
+export interface TaskAttemptExecutionLinkedEvent extends BaseTaskEvent {
+  type: 'task_attempt_execution_linked';
+  attemptId: string;
+  /** Cross-ledger identity and Runtime source coverage; never copied Runtime facts. */
+  evidence: ExecutionEvidenceRef;
+}
+
 export interface SelfCheckObservedEvent extends BaseTaskEvent {
   type: 'self_check_observed';
   observation: SelfCheckObservation;
@@ -935,6 +945,7 @@ export type TaskEvent =
   | TaskRunStartedEvent
   | TaskRunVerifyingEvent
   | TaskAttemptStartedEvent
+  | TaskAttemptExecutionLinkedEvent
   | SelfCheckObservedEvent
   | FeedbackObservedEvent
   | AutonomousDecisionRecordedEvent

--- a/packages/headless/src/task-execution-lineage.ts
+++ b/packages/headless/src/task-execution-lineage.ts
@@ -1,0 +1,95 @@
+import {
+  EXECUTION_EVIDENCE_REF_SCHEMA_VERSION,
+  validateExecutionEvidenceRef,
+  type ExecutionEvidenceRef,
+} from '@maka/core/execution-evidence';
+import type { RuntimeEvent } from '@maka/core/runtime-event';
+
+export interface TaskAttemptExecutionEvidenceInput {
+  taskRunId: string;
+  attemptId: string;
+  sessionId: string;
+  agentRunId: string;
+  invocationId?: string;
+  turnId?: string;
+  /** Immutable Runtime Events read from the persisted AgentRun stream in append order. */
+  runtimeEvents: readonly RuntimeEvent[];
+}
+
+/**
+ * Build a Task-to-Runtime lineage reference without copying Runtime facts.
+ *
+ * The input is the physical immutable append stream, so its zero-based indexes
+ * are stable cursor sequences. Some immutable lifecycle rows may still carry
+ * `partial: true`; callers must exclude mutable partial snapshot files by
+ * reading the RuntimeEventStore immutable stream.
+ */
+export function taskAttemptExecutionEvidence(
+  input: TaskAttemptExecutionEvidenceInput,
+): ExecutionEvidenceRef {
+  const durableEvents = input.runtimeEvents;
+  for (const event of durableEvents) assertRuntimeIdentity(event, input);
+
+  const first = durableEvents[0];
+  const last = durableEvents.at(-1);
+  const ref: ExecutionEvidenceRef = {
+    schemaVersion: EXECUTION_EVIDENCE_REF_SCHEMA_VERSION,
+    execution: {
+      sessionId: input.sessionId,
+      ...(input.invocationId ? { invocationId: input.invocationId } : {}),
+      agentRunId: input.agentRunId,
+      ...(input.turnId ? { turnId: input.turnId } : {}),
+    },
+    task: {
+      taskRunId: input.taskRunId,
+      attemptId: input.attemptId,
+    },
+    ...(first && last
+      ? {
+          runtimeCoverage: {
+            lowWater: {
+              ledger: 'runtime_event',
+              streamId: input.agentRunId,
+              sequence: 0,
+              eventId: first.id,
+            },
+            highWater: {
+              ledger: 'runtime_event',
+              streamId: input.agentRunId,
+              sequence: durableEvents.length - 1,
+              eventId: last.id,
+            },
+            eventCount: durableEvents.length,
+          },
+        }
+      : {}),
+  };
+
+  const validation = validateExecutionEvidenceRef(ref);
+  if (!validation.ok) {
+    throw new Error(
+      `invalid task execution lineage: ${validation.errors
+        .map((issue) => `${issue.path}: ${issue.message}`)
+        .join('; ')}`,
+    );
+  }
+  return validation.value;
+}
+
+function assertRuntimeIdentity(
+  event: RuntimeEvent,
+  input: TaskAttemptExecutionEvidenceInput,
+): void {
+  if (event.sessionId !== input.sessionId) {
+    throw new Error(`RuntimeEvent ${event.id} sessionId does not match lineage sessionId`);
+  }
+  if (event.runId !== input.agentRunId) {
+    throw new Error(`RuntimeEvent ${event.id} runId does not match lineage agentRunId`);
+  }
+  if (input.invocationId && event.invocationId !== input.invocationId) {
+    throw new Error(`RuntimeEvent ${event.id} invocationId does not match lineage invocationId`);
+  }
+  if (input.turnId && event.turnId !== input.turnId) {
+    throw new Error(`RuntimeEvent ${event.id} turnId does not match lineage turnId`);
+  }
+}

--- a/packages/headless/src/task-run-adapter.ts
+++ b/packages/headless/src/task-run-adapter.ts
@@ -13,6 +13,7 @@ import {
   type VerifierResult,
 } from './task-contracts.js';
 import type { TaskRunProjection } from './task-run-store.js';
+import { taskAttemptExecutionEvidence } from './task-execution-lineage.js';
 
 export interface TaskEventsFromResultRecordOptions {
   task?: Task;
@@ -109,6 +110,23 @@ export function taskEventsFromResultRecord(
       ...(record.runId ? { agentRunId: record.runId } : {}),
     },
   ];
+
+  if (record.sessionId && record.runId) {
+    events.push({
+      type: 'task_attempt_execution_linked',
+      id: eventId(),
+      taskRunId,
+      attemptId,
+      ts: record.finishedAt,
+      evidence: taskAttemptExecutionEvidence({
+        taskRunId,
+        attemptId,
+        sessionId: record.sessionId,
+        agentRunId: record.runId,
+        runtimeEvents: [],
+      }),
+    });
+  }
 
   if (verifierResult) {
     events.push({ type: 'verifier_result_recorded', id: eventId(), taskRunId, ts: record.finishedAt, result: verifierResult });

--- a/packages/headless/src/task-run-store.ts
+++ b/packages/headless/src/task-run-store.ts
@@ -1,5 +1,9 @@
 import { appendFile, mkdir, readFile } from 'node:fs/promises';
 import { join } from 'node:path';
+import {
+  validateExecutionEvidenceRef,
+  type ExecutionEvidenceRef,
+} from '@maka/core/execution-evidence';
 import type { ResultRecord } from './contracts.js';
 import { compactArtifactEvidence, compactSelfCheckEvidence } from './heavy-task-evidence.js';
 import { evaluateHeavyTaskCompletionStatus, type HeavyTaskCompletionStatus } from './heavy-task-finalization.js';
@@ -37,6 +41,7 @@ import type {
 export interface TaskRunProjection extends TaskRun {
   events: TaskEvent[];
   attempts: TaskAttempt[];
+  executionLineage: ExecutionEvidenceRef[];
   selfChecks: SelfCheckObservation[];
   feedback: FeedbackObservation[];
   decisions: AutonomousDecision[];
@@ -96,6 +101,7 @@ export function projectTaskRun(events: readonly TaskEvent[], taskRunId?: string)
     status: 'queued',
     events: [],
     attempts: [],
+    executionLineage: [],
     selfChecks: [],
     feedback: [],
     decisions: [],
@@ -147,6 +153,7 @@ export function projectTaskRun(events: readonly TaskEvent[], taskRunId?: string)
         projection.status = 'verifying';
         break;
       case 'task_attempt_started': {
+        const previous = attempts.get(event.attemptId);
         const attempt: TaskAttempt = {
           attemptId: event.attemptId,
           taskRunId: event.taskRunId,
@@ -154,9 +161,37 @@ export function projectTaskRun(events: readonly TaskEvent[], taskRunId?: string)
           status: 'running',
           ...(event.sessionId ? { sessionId: event.sessionId } : {}),
           ...(event.agentRunId ? { agentRunId: event.agentRunId } : {}),
+          executionLineage: previous?.executionLineage ?? [],
         };
         attempts.set(event.attemptId, attempt);
         setOptionalRefs(projection, event.sessionId, event.agentRunId);
+        break;
+      }
+      case 'task_attempt_execution_linked': {
+        const evidence = validTaskAttemptExecutionEvidence(event, projection.warnings);
+        if (!evidence) break;
+        projection.executionLineage.push(evidence);
+        const previous = attempts.get(event.attemptId);
+        attempts.set(event.attemptId, {
+          ...(previous ?? {
+            attemptId: event.attemptId,
+            taskRunId: event.taskRunId,
+            startedAt: event.ts,
+            status: 'running',
+            executionLineage: [],
+          }),
+          ...(evidence.execution?.sessionId ? { sessionId: evidence.execution.sessionId } : {}),
+          ...(!previous?.agentRunId && evidence.execution?.agentRunId
+            ? { agentRunId: evidence.execution.agentRunId }
+            : {}),
+          executionLineage: [...(previous?.executionLineage ?? []), evidence],
+        });
+        if (!projection.sessionId && evidence.execution?.sessionId) {
+          projection.sessionId = evidence.execution.sessionId;
+        }
+        if (!projection.agentRunId && evidence.execution?.agentRunId) {
+          projection.agentRunId = evidence.execution.agentRunId;
+        }
         break;
       }
       case 'self_check_observed':
@@ -277,7 +312,12 @@ export function projectTaskRun(events: readonly TaskEvent[], taskRunId?: string)
           if (event.attemptId) {
             const previous = attempts.get(event.attemptId);
             attempts.set(event.attemptId, {
-              ...(previous ?? { attemptId: event.attemptId, taskRunId: event.taskRunId, startedAt: event.ts }),
+              ...(previous ?? {
+                attemptId: event.attemptId,
+                taskRunId: event.taskRunId,
+                startedAt: event.ts,
+                executionLineage: [],
+              }),
               status: 'needs_approval',
               finishedAt: event.ts,
             });
@@ -290,6 +330,7 @@ export function projectTaskRun(events: readonly TaskEvent[], taskRunId?: string)
             attemptId: event.attemptId,
             taskRunId: event.taskRunId,
             startedAt: event.ts,
+            executionLineage: [],
           }),
           status: event.status,
           finishedAt: event.finishedAt ?? event.ts,
@@ -475,6 +516,27 @@ class FileTaskRunStore implements TaskRunStore {
 function setOptionalRefs(projection: TaskRunProjection, sessionId: string | undefined, agentRunId: string | undefined): void {
   if (sessionId) projection.sessionId = sessionId;
   if (agentRunId) projection.agentRunId = agentRunId;
+}
+
+function validTaskAttemptExecutionEvidence(
+  event: Extract<TaskEvent, { type: 'task_attempt_execution_linked' }>,
+  warnings: string[],
+): ExecutionEvidenceRef | undefined {
+  const validation = validateExecutionEvidenceRef(event.evidence);
+  if (!validation.ok) {
+    warnings.push(`ignored execution lineage ${event.id}: ${validation.errors.map((issue) => `${issue.path}: ${issue.message}`).join('; ')}`);
+    return undefined;
+  }
+  const evidence = validation.value;
+  if (evidence.task?.taskRunId !== event.taskRunId || evidence.task.attemptId !== event.attemptId) {
+    warnings.push(`ignored execution lineage ${event.id}: task identity does not match the owning attempt`);
+    return undefined;
+  }
+  if (!evidence.execution?.agentRunId) {
+    warnings.push(`ignored execution lineage ${event.id}: execution.agentRunId is required`);
+    return undefined;
+  }
+  return evidence;
 }
 
 function resultFromScore(score: ScoreResult | undefined, verifier: VerifierResult | undefined): TaskRunResult | undefined {

--- a/packages/runtime/src/agent-run.ts
+++ b/packages/runtime/src/agent-run.ts
@@ -592,6 +592,7 @@ export class AgentRun {
     const createdAt = this.input.now();
     const header: AgentRunHeader = {
       runId: this.runId,
+      invocationId: this.runId,
       sessionId: this.sessionId,
       turnId: this.turnId,
       status: 'created',

--- a/packages/storage/src/__tests__/agent-run-store.test.ts
+++ b/packages/storage/src/__tests__/agent-run-store.test.ts
@@ -9,7 +9,7 @@ import type { AgentRunEvent, AgentRunHeader, RuntimeEvent } from '@maka/core';
 describe('AgentRunStore', () => {
   it('creates, reads, updates, and lists runs under a session', async () => {
     await withStore(async (store, root) => {
-      const first = makeHeader({ runId: 'run-1', createdAt: 1, updatedAt: 1 });
+      const first = makeHeader({ runId: 'run-1', invocationId: 'invocation-1', createdAt: 1, updatedAt: 1 });
       const second = makeHeader({ runId: 'run-2', turnId: 'turn-2', createdAt: 2, updatedAt: 2 });
 
       await store.createRun(second);
@@ -23,6 +23,7 @@ describe('AgentRunStore', () => {
       const read = await store.readRun('session-1', 'run-1');
       assert.equal(read.status, 'completed');
       assert.equal(read.completedAt, 10);
+      assert.equal(read.invocationId, 'invocation-1');
       assert.deepEqual((await store.listSessionRuns('session-1')).map((run) => run.runId), ['run-1', 'run-2']);
       assert.equal(
         JSON.parse(await readFile(join(root, 'sessions', 'session-1', 'runs', 'run-1', 'run.json'), 'utf8')).runId,
@@ -411,10 +412,14 @@ describe('AgentRunStore', () => {
       }
 
       const events = await runtimeEventStore.readRuntimeEvents('session-1', 'run-1');
+      const readImmutable = runtimeEventStore.readImmutableRuntimeEvents;
+      assert.ok(readImmutable);
+      const immutableEvents = await readImmutable.call(runtimeEventStore, 'session-1', 'run-1');
 
       assert.equal(events.length, 1);
       assert.equal(events[0]?.partial, true);
       assert.deepEqual(events[0]?.content, { kind: 'text', text: 'hello!' });
+      assert.deepEqual(immutableEvents, []);
     });
   });
 
@@ -591,8 +596,15 @@ describe('AgentRunStore', () => {
       }
 
       const events = await runtimeEventStore.readRuntimeEvents('session-1', 'run-1');
+      const readImmutable = runtimeEventStore.readImmutableRuntimeEvents;
+      assert.ok(readImmutable);
+      const immutableEvents = await readImmutable.call(runtimeEventStore, 'session-1', 'run-1');
 
       assert.deepEqual(events.map((event) => event.id), [
+        'runtime-lifecycle-0',
+        'runtime-lifecycle-1',
+      ]);
+      assert.deepEqual(immutableEvents.map((event) => event.id), [
         'runtime-lifecycle-0',
         'runtime-lifecycle-1',
       ]);

--- a/packages/storage/src/agent-run-store.ts
+++ b/packages/storage/src/agent-run-store.ts
@@ -369,6 +369,12 @@ class FileRuntimeEventStore implements RuntimeEventStore {
     return mergeRuntimePartialSnapshots(events, visiblePartials);
   }
 
+  async readImmutableRuntimeEvents(sessionId: string, runId: string): Promise<RuntimeEvent[]> {
+    assertSafeId(sessionId, 'Invalid session id');
+    assertSafeId(runId, 'Invalid run id');
+    return readRuntimeEventJsonl(this.runtimeEventsPath(sessionId, runId), runId);
+  }
+
   async readSessionRuntimeEvents(sessionId: string): Promise<RuntimeEvent[]> {
     assertSafeId(sessionId, 'Invalid session id');
     const runsRoot = this.runsRoot(sessionId);
@@ -622,6 +628,7 @@ function normalizeAgentRunHeader(value: unknown, sessionId: string, runId: strin
     record.cwd,
   ];
   const optionalStrings = [
+    record.invocationId,
     record.parentRunId,
     record.agentId,
     record.agentName,


### PR DESCRIPTION
## Summary

Refs #948.

Phase 1 makes the Runtime-to-Task portion of the Execution Evidence Spine durable:

- persist `invocationId` in new AgentRun headers while preserving legacy reads
- expose the physical immutable Runtime Event stream separately from mutable partial snapshots
- append `task_attempt_execution_linked` after every finished headless invocation, including bounded repair runs
- project every linked AgentRun and its inclusive Runtime coverage onto the owning TaskRun and Attempt
- validate replayed evidence references and ignore invalid cross-task lineage with explicit warnings
- import legacy `ResultRecord` lineage as identity-only when Runtime coverage is unavailable
- document the Phase 1 ownership and cursor boundary

Task Events store identities and cursor boundaries only. Raw model messages, Tool Calls, Tool Results, and other interaction facts remain owned by the Runtime Event ledger. Mutable partial snapshot files do not occupy cursor positions; immutable lifecycle rows do, even when they carry `partial: true`.

## Verification

- `npm run build`
- `npm run typecheck`
- `npm --workspace @maka/core test` — 926 passed
- `npm --workspace @maka/storage test` — 262 passed, 1 skipped
- `npm --workspace @maka/runtime test` — 1,542 passed, 7 skipped
- `npm --workspace @maka/headless test` — 906 passed, 1 skipped
- `git diff --check upstream/main...HEAD`

## Phase boundary

This PR intentionally does not add Task Event cursors, self-check freshness, Compaction lineage, AHE lineage, or a general inspection command. Those remain later phases of #948.
