### PR TITLE
fix(runtime): keep Read schema object-rooted

### DIFF
--- a/packages/runtime/src/__tests__/builtin-tools.test.ts
+++ b/packages/runtime/src/__tests__/builtin-tools.test.ts
@@ -3,6 +3,7 @@ import assert from 'node:assert/strict';
 import { mkdir, mkdtemp, readFile, symlink, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { zodSchema } from 'ai';
 import { z } from 'zod';
 import { createWorkspaceWritePermissionProfile } from '@maka/core/permission-profile';
 import { expect } from '../test-helpers.js';
@@ -349,8 +350,10 @@ describe('builtin Bash streaming output', () => {
     const read = buildBuiltinTools({ runtimeResources }).find((tool) => tool.name === 'Read');
     if (!read) throw new Error('Read tool missing');
     const parameters = read.parameters as z.ZodTypeAny;
+    expect(zodSchema(parameters).jsonSchema.type).toBe('object');
     expect(parameters.safeParse({ path: 'README.md', offset: 2, limit: 10 }).success).toBe(true);
     expect(parameters.safeParse({ ref: 'maka://runtime/background-tasks/shell-run-1' }).success).toBe(true);
+    expect(parameters.safeParse({}).success).toBe(false);
     expect(parameters.safeParse({
       ref: 'maka://runtime/background-tasks/shell-run-1',
       offset: 2,

--- a/packages/runtime/src/builtin-tools.ts
+++ b/packages/runtime/src/builtin-tools.ts
@@ -71,16 +71,19 @@ export function buildBuiltinTools(options: BuildBuiltinToolsOptions = {}): MakaT
     : 'Read a file from disk by path relative to session cwd.';
   const fileReadParameters = z.object({
     path: z.string().describe('A file path relative to the session cwd'),
-    offset: z.number().int().nonnegative().optional(),
-    limit: z.number().int().positive().optional(),
+    offset: z.number().int().nonnegative().describe('Zero-based file line offset').optional(),
+    limit: z.number().int().positive().describe('Maximum file lines to read').optional(),
+  }).strict();
+  const runtimeResourceReadParameters = z.object({
+    ref: z.string().describe('A runtime resource ref returned by another tool'),
   }).strict();
   const readParameters = options.runtimeResources
-    ? z.union([
-        fileReadParameters,
-        z.object({
-          ref: z.string().describe('A runtime resource ref returned by another tool'),
-        }).strict(),
-      ])
+    ? z.object({
+        ...fileReadParameters.shape,
+        ...runtimeResourceReadParameters.shape,
+      }).partial().strict()
+        .describe('Read a file with path, or a whole runtime resource with ref; provide exactly one')
+        .pipe(z.union([fileReadParameters, runtimeResourceReadParameters]))
     : fileReadParameters;
   const shell = options.shell ?? defaultShellPlan();
   const sandboxPlatform = options.sandboxPlatform ?? process.platform;


### PR DESCRIPTION
## Summary

A top-level Zod union serialized `Read` parameters as `anyOf` without a root `type`, so strict OpenAI-compatible providers such as DeepSeek rejected the tool schema.

- Keep the provider-facing schema rooted at `type: object`.
- Pipe that object into the existing strict file/runtime-resource union so runtime validation remains exact.
- Assert the AI SDK JSON Schema contract in the existing `Read` test.

## Validation

- Real `deepseek-v4-flash` request accepted the fixed schema
- `npm --workspace @maka/runtime test`
- `npm run typecheck`
- `npm run build`

<details>
<summary>中文</summary>

## 摘要

顶层 Zod union 会将 `Read` 参数序列化为没有根级 `type` 的 `anyOf`，导致 DeepSeek 等严格校验 schema 的 OpenAI-compatible provider 拒绝该工具。

- 保持 provider 可见 schema 的根级 `type: object`。
- 将该对象 pipe 到原有的文件/runtime resource 严格 union，保留精确的运行时校验。
- 在现有 `Read` 测试中断言 AI SDK 的 JSON Schema 契约。

## 验证

- 真实 `deepseek-v4-flash` 请求已接受修复后的 schema
- `npm --workspace @maka/runtime test`
- `npm run typecheck`
- `npm run build`

</details>
