### PR TITLE
feat(headless): link Phase 2A task evidence to Runtime facts

### DIFF
--- a/docs/execution-evidence-spine.md
+++ b/docs/execution-evidence-spine.md
@@ -1,6 +1,6 @@
 # Execution Identity and Evidence Spine
 
-Status: Phase 0 contract plus Phase 1 Runtime-to-Task lineage. See [issue #948](https://github.com/maka-agent/maka-agent/issues/948).
+Status: Phase 0 contract, Phase 1 Runtime-to-Task lineage, and Phase 2A Runtime provenance for compact task evidence. See [issue #948](https://github.com/maka-agent/maka-agent/issues/948).
 
 Maka already records the facts needed to explain an execution. Runtime Events preserve model and tool interaction facts, AgentRun records operational lifecycle, and Task Events preserve durable task-control decisions. The missing piece is a shared way to reference those facts across subsystem boundaries.
 
@@ -31,7 +31,17 @@ Phase 1 makes the Runtime-to-Task portion concrete:
 - `TaskRunProjection.executionLineage` and each `TaskAttempt.executionLineage` expose the replayed links;
 - legacy `ResultRecord` imports produce an honest identity-only link when Runtime coverage is unavailable.
 
-Phase 1 still does not add Task Event cursors, evidence freshness, Compaction integration, AHE lineage, or a general inspection command.
+Phase 2A binds compact heavy-task evidence back to executor-owned Runtime facts:
+
+- new tool-derived evidence records the producing AgentRun when Runtime supplies it, while legacy evidence remains readable;
+- after each headless invocation, Maka matches the evidence `toolCallId` to immutable Runtime `function_call` and `function_response` rows;
+- a `heavy_task_evidence_provenance_linked` Task Event stores only the resulting `ExecutionEvidenceRef` and inclusive Runtime range;
+- TaskRun replay overlays the validated provenance onto durably recorded compact tool and artifact evidence;
+- a missing function response, conflicting tool name, or mismatched Runtime identity produces no provenance claim.
+
+System-created artifacts, external verifier artifacts, and replay-derived Self-check envelopes keep their existing authority records. Phase 2A does not invent a Runtime source for facts that were not durably recorded from a Runtime tool call.
+
+The current delivery still does not add Task Event cursors, Self-check freshness or workspace invalidation, Compaction integration, AHE lineage, or a general inspection command.
 
 ## Existing authorities
 
@@ -137,6 +147,8 @@ TaskRun task-42 / Attempt attempt-2
 
 The Task Event stores only these references and boundary event ids. Model messages, Tool Calls, Tool Results, and other Runtime facts remain solely in the Runtime Event ledger.
 
+Phase 2A applies the same rule at evidence granularity. A compact Task evidence envelope may display a bounded summary, but its `provenance` points to the immutable Runtime call/result range that owns the exact request and response. Maka requires the canonical `function_response` before creating that link; a planned or interrupted call alone is not proof of an executor result.
+
 Coverage is an inclusive range within one stream:
 
 ```ts
@@ -207,7 +219,7 @@ This object says where evidence came from. It does not assert that the evidence 
 Later phases should extend the contract without changing fact ownership:
 
 1. Materialize stable append ordinals for Task Event streams, including backward-compatible reads.
-2. Bind executor-owned Tool Results, artifacts, and workspace observations to evidence references.
+2. Bind workspace observations and artifacts produced outside Runtime tool calls to their appropriate source authorities.
 3. Bind Self-check to Runtime and Task high waters plus a workspace revision, then define deterministic staleness rules.
 4. Map Compaction source coverage to the shared cursor contract while retaining explicit source-event validation.
 5. Carry target snapshot and execution lineage through AHE exports.

--- a/packages/headless/src/__tests__/heavy-task-self-check.test.ts
+++ b/packages/headless/src/__tests__/heavy-task-self-check.test.ts
@@ -102,12 +102,13 @@ describe('heavy-task semantic self-check tools', () => {
         },
         publicReason: 'temporary compile artifacts stayed under scratch and no deliverable files were left behind',
       },
-    }, toolContext) as { accepted: true; selfCheck: HeavyTaskSemanticSelfCheckState };
+    }, { ...toolContext, runId: 'agent-run-1' }) as { accepted: true; selfCheck: HeavyTaskSemanticSelfCheckState };
 
     assert.equal(result.accepted, true);
     assert.equal(result.selfCheck.status, 'pass');
     assert.equal(result.selfCheck.guard.status, 'accepted');
     assert.equal(result.selfCheck.source.toolCallId, 'tool-1');
+    assert.equal(result.selfCheck.source.agentRunId, 'agent-run-1');
     assert.equal(result.selfCheck.executionHygiene?.sandbox?.root, '/tmp/maka-self-check/run-1');
     assert.equal(result.selfCheck.executionHygiene?.scratchUsed, true);
     assert.equal(result.selfCheck.executionHygiene?.workspaceSideEffects, 'none');

--- a/packages/headless/src/__tests__/task-agent-controller.test.ts
+++ b/packages/headless/src/__tests__/task-agent-controller.test.ts
@@ -250,10 +250,12 @@ class ProgressToolBackend implements AgentBackend {
   }
 
   async *send(input: BackendSendInput): AsyncIterable<SessionEvent> {
+    const bash = this.ctx.tools.find((tool) => tool.name === 'Bash');
     const inventorySubmit = this.ctx.tools.find((tool) => tool.name === 'inventory_submit');
     const todoUpdate = this.ctx.tools.find((tool) => tool.name === 'todo_update');
     const selfCheckPlanSubmit = this.ctx.tools.find((tool) => tool.name === 'self_check_plan_submit');
     const selfCheckSubmit = this.ctx.tools.find((tool) => tool.name === 'self_check_submit');
+    assert.ok(bash);
     assert.ok(inventorySubmit);
     assert.ok(todoUpdate);
     assert.ok(selfCheckPlanSubmit);
@@ -266,6 +268,7 @@ class ProgressToolBackend implements AgentBackend {
       abortSignal: new AbortController().signal,
       emitOutput: () => {},
     };
+    await bash.impl({ command: 'npm test' }, { ...toolCtx, toolCallId: 'bash-tool-call' });
     await inventorySubmit.impl({
       summary: 'Inspected public files.',
       items: [{ path: 'README.md', kind: 'file', status: 'observed' }],
@@ -302,6 +305,24 @@ class ProgressToolBackend implements AgentBackend {
       artifactEvidence: [{ path: 'README.md', kind: 'file', exists: true }],
     }, toolCtx);
     const ts = Date.now();
+    yield {
+      type: 'tool_start',
+      id: 'progress-bash-start',
+      turnId: input.turnId,
+      ts,
+      toolUseId: 'bash-tool-call',
+      toolName: 'Bash',
+      args: { command: 'npm test' },
+    };
+    yield {
+      type: 'tool_result',
+      id: 'progress-bash-result',
+      turnId: input.turnId,
+      ts,
+      toolUseId: 'bash-tool-call',
+      isError: false,
+      content: { kind: 'text', text: 'tests passed' },
+    };
     yield { type: 'complete', id: 'progress-complete', turnId: input.turnId, ts, stopReason: 'end_turn' };
   }
 
@@ -789,6 +810,27 @@ describe('runTaskOnce', () => {
         result.projection.events.filter((event) => event.type === 'heavy_task_self_check_gate_recorded').length,
         2,
       );
+      const linkedEvidence = result.projection.heavyTaskEvidence.filter((item) => item.provenance);
+      const linkedAgentRuns = new Set(
+        result.projection.executionLineage.map((item) => item.execution?.agentRunId),
+      );
+      assert.ok(linkedEvidence.length > 0);
+      assert.ok(linkedEvidence.every((item) => {
+        const provenance = item.provenance;
+        return provenance !== undefined
+          && linkedAgentRuns.has(provenance.execution?.agentRunId)
+          && provenance.execution?.turnId === item.source.turnId
+          && Boolean(provenance.runtimeCoverage?.highWater.eventId);
+      }));
+      assert.equal(
+        result.projection.events.filter((event) => event.type === 'heavy_task_evidence_provenance_linked').length,
+        linkedEvidence.length,
+      );
+      const replayDerivedSelfCheckEvidence = result.projection.heavyTaskEvidence.filter((item) => (
+        item.evidenceId.includes(':compact-')
+      ));
+      assert.ok(replayDerivedSelfCheckEvidence.length > 0);
+      assert.ok(replayDerivedSelfCheckEvidence.every((item) => item.provenance === undefined));
     });
   });
 

--- a/packages/headless/src/__tests__/task-evidence-provenance.test.ts
+++ b/packages/headless/src/__tests__/task-evidence-provenance.test.ts
@@ -1,0 +1,171 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+import type { RuntimeEvent } from '@maka/core/runtime-event';
+import type { HeavyTaskCompactEvidenceEnvelope } from '../task-contracts.js';
+import { taskEvidenceRuntimeProvenanceLinks } from '../task-evidence-provenance.js';
+
+describe('taskEvidenceRuntimeProvenanceLinks', () => {
+  test('links compact evidence to its immutable Runtime call/result range', () => {
+    const links = taskEvidenceRuntimeProvenanceLinks({
+      ...identity,
+      runtimeEvents: [
+        runtimeEvent('user-event'),
+        runtimeEvent('call-event', {
+          role: 'model',
+          author: 'agent',
+          content: { kind: 'function_call', id: 'tool-1', name: 'Bash', args: { command: 'npm test' } },
+          refs: { toolCallId: 'tool-1' },
+        }),
+        runtimeEvent('progress-event', {
+          partial: true,
+          role: 'tool',
+          author: 'tool',
+          refs: { toolCallId: 'tool-1' },
+        }),
+        runtimeEvent('result-event', {
+          role: 'tool',
+          author: 'tool',
+          content: { kind: 'function_response', id: 'tool-1', name: 'Bash', result: { exitCode: 0 } },
+          refs: { toolCallId: 'tool-1' },
+        }),
+      ],
+      evidence: [toolEvidence()],
+    });
+
+    assert.equal(links.length, 1);
+    assert.deepEqual(links[0]?.provenance.runtimeCoverage, {
+      lowWater: {
+        ledger: 'runtime_event',
+        streamId: 'run-1',
+        sequence: 1,
+        eventId: 'call-event',
+      },
+      highWater: {
+        ledger: 'runtime_event',
+        streamId: 'run-1',
+        sequence: 3,
+        eventId: 'result-event',
+      },
+      eventCount: 3,
+    });
+  });
+
+  test('requires the executor-owned function response before claiming provenance', () => {
+    const links = taskEvidenceRuntimeProvenanceLinks({
+      ...identity,
+      runtimeEvents: [runtimeEvent('call-event', {
+        role: 'model',
+        author: 'agent',
+        content: { kind: 'function_call', id: 'tool-1', name: 'Bash', args: {} },
+        refs: { toolCallId: 'tool-1' },
+      })],
+      evidence: [toolEvidence()],
+    });
+
+    assert.deepEqual(links, []);
+  });
+
+  test('keeps evidence from another AgentRun or tool name unlinked', () => {
+    const runtimeEvents = [runtimeEvent('result-event', {
+      role: 'tool',
+      author: 'tool',
+      content: { kind: 'function_response', id: 'tool-1', name: 'Read', result: 'ok' },
+      refs: { toolCallId: 'tool-1' },
+    })];
+
+    assert.deepEqual(taskEvidenceRuntimeProvenanceLinks({
+      ...identity,
+      runtimeEvents,
+      evidence: [toolEvidence({ source: { ...toolEvidence().source, agentRunId: 'run-2' } })],
+    }), []);
+    assert.deepEqual(taskEvidenceRuntimeProvenanceLinks({
+      ...identity,
+      runtimeEvents,
+      evidence: [toolEvidence()],
+    }), []);
+    assert.deepEqual(taskEvidenceRuntimeProvenanceLinks({
+      ...identity,
+      runtimeEvents: [runtimeEvent('foreign-result', {
+        runId: 'run-2',
+        role: 'tool',
+        author: 'tool',
+        content: { kind: 'function_response', id: 'tool-1', name: 'Bash', result: 'ok' },
+        refs: { toolCallId: 'tool-1' },
+      })],
+      evidence: [toolEvidence()],
+    }), []);
+  });
+
+  test('links legacy evidence by session and turn without inventing an AgentRun source field', () => {
+    const legacy = toolEvidence();
+    delete legacy.source.agentRunId;
+    const links = taskEvidenceRuntimeProvenanceLinks({
+      ...identity,
+      runtimeEvents: [runtimeEvent('result-event', {
+        role: 'tool',
+        author: 'tool',
+        content: { kind: 'function_response', id: 'tool-1', name: 'Bash', result: 'ok' },
+        refs: { toolCallId: 'tool-1' },
+      })],
+      evidence: [legacy],
+    });
+
+    assert.equal(links[0]?.provenance.execution?.agentRunId, 'run-1');
+  });
+});
+
+const identity = {
+  taskRunId: 'task-run-1',
+  attemptId: 'attempt-1',
+  sessionId: 'session-1',
+  invocationId: 'invocation-1',
+  agentRunId: 'run-1',
+  turnId: 'turn-1',
+};
+
+function toolEvidence(
+  overrides: Partial<HeavyTaskCompactEvidenceEnvelope> = {},
+): HeavyTaskCompactEvidenceEnvelope {
+  return {
+    schemaVersion: 1,
+    evidenceId: 'evidence-1',
+    taskRunId: 'task-run-1',
+    attemptId: 'attempt-1',
+    ts: 1,
+    kind: 'tool',
+    public: true,
+    source: {
+      kind: 'model_tool',
+      toolCallId: 'tool-1',
+      toolName: 'Bash',
+      sessionId: 'session-1',
+      agentRunId: 'run-1',
+      turnId: 'turn-1',
+    },
+    tool: {
+      name: 'Bash',
+      inputSummary: { command: 'npm test' },
+      exitCode: 0,
+      ok: true,
+      outputs: [],
+      diff: { status: 'not_applicable' },
+    },
+    ...overrides,
+  };
+}
+
+function runtimeEvent(id: string, overrides: Partial<RuntimeEvent> = {}): RuntimeEvent {
+  return {
+    id,
+    invocationId: 'invocation-1',
+    runId: 'run-1',
+    sessionId: 'session-1',
+    turnId: 'turn-1',
+    ts: 1,
+    partial: false,
+    role: 'user',
+    author: 'user',
+    content: { kind: 'text', text: 'x' },
+    ...overrides,
+  };
+}

--- a/packages/headless/src/__tests__/task-run-store.test.ts
+++ b/packages/headless/src/__tests__/task-run-store.test.ts
@@ -210,6 +210,99 @@ describe('TaskRunStore', () => {
     assert.match(projection.warnings[0] ?? '', /task identity does not match/);
   });
 
+  test('projects Runtime provenance onto compact evidence without copying Runtime facts', () => {
+    const taskRunId = 'tr-evidence-provenance';
+    const recorded = heavyTaskEvidenceEvent(taskRunId, 'e-1', 'evidence-1', 'Bash', 1);
+    if (recorded.type !== 'heavy_task_evidence_recorded') throw new Error('expected evidence event');
+    recorded.evidence.attemptId = 'attempt-1';
+    recorded.evidence.source = {
+      ...recorded.evidence.source,
+      sessionId: 'session-1',
+      agentRunId: 'run-1',
+      turnId: 'turn-1',
+    };
+    const events: TaskEvent[] = [
+      recorded,
+      {
+        type: 'heavy_task_evidence_provenance_linked',
+        id: 'e-2',
+        taskRunId,
+        attemptId: 'attempt-1',
+        ts: 2,
+        evidenceId: 'evidence-1',
+        provenance: {
+          schemaVersion: 'maka.execution_evidence_ref.v1',
+          execution: {
+            sessionId: 'session-1',
+            invocationId: 'invocation-1',
+            agentRunId: 'run-1',
+            turnId: 'turn-1',
+          },
+          task: { taskRunId, attemptId: 'attempt-1' },
+          runtimeCoverage: {
+            lowWater: { ledger: 'runtime_event', streamId: 'run-1', sequence: 4, eventId: 'call-1' },
+            highWater: { ledger: 'runtime_event', streamId: 'run-1', sequence: 6, eventId: 'result-1' },
+            eventCount: 3,
+          },
+        },
+      },
+    ];
+
+    const projection = projectTaskRun(events, taskRunId);
+
+    assert.equal(projection.heavyTaskEvidence[0]?.provenance?.execution?.agentRunId, 'run-1');
+    assert.equal(projection.heavyTaskEvidence[0]?.provenance?.runtimeCoverage?.highWater.eventId, 'result-1');
+    assert.equal(projection.events[1]?.type, 'heavy_task_evidence_provenance_linked');
+  });
+
+  test('rejects evidence provenance from a different Runtime source', () => {
+    const taskRunId = 'tr-evidence-provenance-invalid';
+    const recorded = heavyTaskEvidenceEvent(taskRunId, 'e-1', 'evidence-1', 'Bash', 1);
+    if (recorded.type !== 'heavy_task_evidence_recorded') throw new Error('expected evidence event');
+    recorded.evidence.source.agentRunId = 'run-1';
+    const projection = projectTaskRun([
+      recorded,
+      {
+        type: 'heavy_task_evidence_provenance_linked',
+        id: 'e-2',
+        taskRunId,
+        attemptId: 'attempt-1',
+        ts: 2,
+        evidenceId: 'evidence-1',
+        provenance: {
+          schemaVersion: 'maka.execution_evidence_ref.v1',
+          execution: { sessionId: 'session-1', agentRunId: 'run-2' },
+          task: { taskRunId, attemptId: 'attempt-1' },
+          runtimeCoverage: {
+            highWater: { ledger: 'runtime_event', streamId: 'run-2', sequence: 1, eventId: 'result-1' },
+          },
+        },
+      },
+    ], taskRunId);
+
+    assert.equal(projection.heavyTaskEvidence[0]?.provenance, undefined);
+    assert.match(projection.warnings[0] ?? '', /Runtime identity does not match/);
+  });
+
+  test('does not trust provenance embedded in the compact evidence fact', () => {
+    const taskRunId = 'tr-embedded-provenance';
+    const recorded = heavyTaskEvidenceEvent(taskRunId, 'e-1', 'evidence-1', 'Bash', 1);
+    if (recorded.type !== 'heavy_task_evidence_recorded') throw new Error('expected evidence event');
+    recorded.evidence.provenance = {
+      schemaVersion: 'maka.execution_evidence_ref.v1',
+      execution: { sessionId: 'session-1', agentRunId: 'run-1' },
+      task: { taskRunId, attemptId: 'attempt-1' },
+      runtimeCoverage: {
+        highWater: { ledger: 'runtime_event', streamId: 'run-1', sequence: 1, eventId: 'forged-result' },
+      },
+    };
+
+    const projection = projectTaskRun([recorded], taskRunId);
+
+    assert.equal(projection.heavyTaskEvidence[0]?.provenance, undefined);
+    assert.match(projection.warnings[0] ?? '', /provenance link event is required/);
+  });
+
   test('projects first-class task-run artifacts', () => {
     const projection = projectTaskRun([
       { type: 'task_run_created', id: 'e-1', taskRunId: 'tr-artifact', ts: 1, taskId: 'task-1', configId: 'cfg-1' },

--- a/packages/headless/src/__tests__/tools.test.ts
+++ b/packages/headless/src/__tests__/tools.test.ts
@@ -483,7 +483,7 @@ describe('isolated headless tools', () => {
         return { matches: ['src/file.ts:1:needle'] };
       },
     }, { heavyTaskEvidence: recorder });
-    const ctx = toolCtx('/workspace');
+    const ctx = { ...toolCtx('/workspace'), runId: 'agent-run-1' };
 
     await tool(tools, 'Bash').impl({ command: 'npm test' }, ctx);
     await tool(tools, 'Read').impl({ path: 'src/file.ts', limit: 10 }, ctx);
@@ -493,6 +493,7 @@ describe('isolated headless tools', () => {
 
     const projection = await store.project('run-evidence');
     assert.deepEqual(projection.heavyTaskEvidence.map((item) => item.tool?.name), ['Bash', 'Read', 'Grep', 'Write', 'Edit']);
+    assert.ok(projection.heavyTaskEvidence.every((item) => item.source.agentRunId === 'agent-run-1'));
     assert.equal(projection.latestHeavyTaskEvidence?.tool?.name, 'Edit');
     assert.equal(projection.heavyTaskEvidence[0]?.tool?.outputs[0]?.truncated, true);
     const serialized = JSON.stringify(projection.heavyTaskEvidence);

--- a/packages/headless/src/heavy-task-evidence.ts
+++ b/packages/headless/src/heavy-task-evidence.ts
@@ -433,6 +433,7 @@ function sourceFromContext(ctx: MakaToolContext, toolName: HeavyTaskToolEvidence
     kind: 'model_tool',
     toolCallId: ctx.toolCallId,
     ...(ctx.sessionId ? { sessionId: ctx.sessionId } : {}),
+    ...(ctx.runId ? { agentRunId: ctx.runId } : {}),
     ...(ctx.turnId ? { turnId: ctx.turnId } : {}),
     toolName,
   };
@@ -443,6 +444,7 @@ function sourceFromPartialContext(ctx: Partial<MakaToolContext> | undefined): He
     kind: 'model_tool',
     toolCallId: ctx?.toolCallId ?? 'system-artifact',
     ...(ctx?.sessionId ? { sessionId: ctx.sessionId } : {}),
+    ...(ctx?.runId ? { agentRunId: ctx.runId } : {}),
     ...(ctx?.turnId ? { turnId: ctx.turnId } : {}),
   };
 }

--- a/packages/headless/src/heavy-task-self-check.ts
+++ b/packages/headless/src/heavy-task-self-check.ts
@@ -647,6 +647,7 @@ function sourceFromContext(ctx: MakaToolContext): HeavyTaskSemanticSelfCheckStat
     kind: 'model_tool',
     toolCallId: ctx.toolCallId,
     ...(ctx.sessionId ? { sessionId: ctx.sessionId } : {}),
+    ...(ctx.runId ? { agentRunId: ctx.runId } : {}),
     ...(ctx.turnId ? { turnId: ctx.turnId } : {}),
   };
 }

--- a/packages/headless/src/index.ts
+++ b/packages/headless/src/index.ts
@@ -47,6 +47,7 @@ export type {
   HeavyTaskCompactEvidenceEnvelope,
   HeavyTaskDiffSummary,
   HeavyTaskEvidenceKind,
+  HeavyTaskEvidenceProvenanceLinkedEvent,
   HeavyTaskEvidenceRecordedEvent,
   HeavyTaskOutputSummary,
   HeavyTaskInventoryItem,
@@ -151,6 +152,11 @@ export type { RunTaskOnceDeps, RunTaskOnceResult } from './task-agent-controller
 export { runTaskOnce, TaskAgentController } from './task-agent-controller.js';
 export type { TaskAttemptExecutionEvidenceInput } from './task-execution-lineage.js';
 export { taskAttemptExecutionEvidence } from './task-execution-lineage.js';
+export type {
+  TaskEvidenceRuntimeProvenanceInput,
+  TaskEvidenceRuntimeProvenanceLink,
+} from './task-evidence-provenance.js';
+export { taskEvidenceRuntimeProvenanceLinks } from './task-evidence-provenance.js';
 export type {
   AutonomousDecisionInput,
   AutonomousDecisionPolicy,

--- a/packages/headless/src/task-agent-controller.ts
+++ b/packages/headless/src/task-agent-controller.ts
@@ -93,6 +93,7 @@ import {
   type TaskRunStore,
 } from './task-run-store.js';
 import { taskDefinitionFromTask } from './task-run-adapter.js';
+import { taskEvidenceRuntimeProvenanceLinks } from './task-evidence-provenance.js';
 import { taskAttemptExecutionEvidence } from './task-execution-lineage.js';
 
 export interface RunTaskOnceDeps extends RunExperimentDeps {
@@ -724,6 +725,38 @@ async function appendTaskAttemptExecutionLink(input: {
       runtimeEvents,
     }),
   });
+  if (runtimeEvents.length === 0) return;
+
+  const projection = await input.store.project(input.taskRunId);
+  const projectedEvidence = new Map(
+    projection.heavyTaskEvidence.map((item) => [item.evidenceId, item]),
+  );
+  const durableEvidence = projection.events.flatMap((event) => (
+    event.type === 'heavy_task_evidence_recorded'
+      ? [projectedEvidence.get(event.evidence.evidenceId) ?? event.evidence]
+      : []
+  ));
+  const provenanceLinks = taskEvidenceRuntimeProvenanceLinks({
+    taskRunId: input.taskRunId,
+    attemptId: input.attemptId,
+    sessionId: input.invocation.sessionId,
+    invocationId: input.invocation.invocationId,
+    agentRunId: input.invocation.runId,
+    turnId: input.invocation.turnId,
+    runtimeEvents,
+    evidence: durableEvidence,
+  });
+  for (const link of provenanceLinks) {
+    await appendTaskEvent(input.store, input.taskRunId, {
+      type: 'heavy_task_evidence_provenance_linked',
+      id: input.newId(),
+      taskRunId: input.taskRunId,
+      attemptId: link.attemptId,
+      ts: input.now(),
+      evidenceId: link.evidenceId,
+      provenance: link.provenance,
+    });
+  }
 }
 
 interface PermissionInterventionInput {

--- a/packages/headless/src/task-contracts.ts
+++ b/packages/headless/src/task-contracts.ts
@@ -297,6 +297,8 @@ export interface HeavyTaskProgressSource {
   kind: 'model_tool';
   toolCallId: string;
   sessionId?: string;
+  /** AgentRun that executed the tool. Optional only for legacy evidence. */
+  agentRunId?: string;
   turnId?: string;
 }
 
@@ -540,6 +542,8 @@ export interface HeavyTaskCompactEvidenceEnvelope {
     runtimeEventId?: string;
     toolName?: HeavyTaskToolEvidenceName;
   };
+  /** Runtime source range that proves where this compact evidence came from. */
+  provenance?: ExecutionEvidenceRef;
   tool?: {
     name: HeavyTaskToolEvidenceName;
     inputSummary: Record<string, unknown>;
@@ -828,6 +832,14 @@ export interface HeavyTaskEvidenceRecordedEvent extends BaseTaskEvent {
   evidence: HeavyTaskCompactEvidenceEnvelope;
 }
 
+export interface HeavyTaskEvidenceProvenanceLinkedEvent extends BaseTaskEvent {
+  type: 'heavy_task_evidence_provenance_linked';
+  evidenceId: string;
+  attemptId: string;
+  /** Reference to canonical Runtime facts; never a copy of their payloads. */
+  provenance: ExecutionEvidenceRef;
+}
+
 export interface WorkspaceLeaseRecordedEvent extends BaseTaskEvent {
   type: 'workspace_lease_recorded';
   lease: WorkspaceLeaseFacts;
@@ -961,6 +973,7 @@ export type TaskEvent =
   | HeavyTaskSelfCheckGateRecordedEvent
   | HeavyTaskWorkspaceObservationRecordedEvent
   | HeavyTaskEvidenceRecordedEvent
+  | HeavyTaskEvidenceProvenanceLinkedEvent
   | IsolationPolicyRecordedEvent
   | WorkspaceLeaseRecordedEvent
   | ToolExecutorIdentityRecordedEvent

--- a/packages/headless/src/task-evidence-provenance.ts
+++ b/packages/headless/src/task-evidence-provenance.ts
@@ -1,0 +1,134 @@
+import {
+  EXECUTION_EVIDENCE_REF_SCHEMA_VERSION,
+  validateExecutionEvidenceRef,
+  type ExecutionEvidenceRef,
+} from '@maka/core/execution-evidence';
+import type { RuntimeEvent } from '@maka/core/runtime-event';
+import type { HeavyTaskCompactEvidenceEnvelope } from './task-contracts.js';
+
+export interface TaskEvidenceRuntimeProvenanceInput {
+  taskRunId: string;
+  attemptId: string;
+  sessionId: string;
+  invocationId: string;
+  agentRunId: string;
+  turnId: string;
+  runtimeEvents: readonly RuntimeEvent[];
+  evidence: readonly HeavyTaskCompactEvidenceEnvelope[];
+}
+
+export interface TaskEvidenceRuntimeProvenanceLink {
+  evidenceId: string;
+  attemptId: string;
+  provenance: ExecutionEvidenceRef;
+}
+
+/**
+ * Resolve compact Task evidence to the immutable Runtime call/result range.
+ *
+ * The compact envelope keeps bounded display data. The returned reference
+ * points back to the canonical function_call/function_response facts without
+ * copying either Runtime payload into the Task Event ledger.
+ */
+export function taskEvidenceRuntimeProvenanceLinks(
+  input: TaskEvidenceRuntimeProvenanceInput,
+): TaskEvidenceRuntimeProvenanceLink[] {
+  const links: TaskEvidenceRuntimeProvenanceLink[] = [];
+  for (const item of input.evidence) {
+    if (item.provenance || !evidenceBelongsToInvocation(item, input)) continue;
+
+    const positions = toolFactPositions(item, input);
+    if (!positions) continue;
+    const low = input.runtimeEvents[positions.low]!;
+    const high = input.runtimeEvents[positions.high]!;
+    const provenance: ExecutionEvidenceRef = {
+      schemaVersion: EXECUTION_EVIDENCE_REF_SCHEMA_VERSION,
+      execution: {
+        sessionId: input.sessionId,
+        invocationId: input.invocationId,
+        agentRunId: input.agentRunId,
+        turnId: input.turnId,
+      },
+      task: {
+        taskRunId: input.taskRunId,
+        attemptId: item.attemptId ?? input.attemptId,
+      },
+      runtimeCoverage: {
+        lowWater: {
+          ledger: 'runtime_event',
+          streamId: input.agentRunId,
+          sequence: positions.low,
+          eventId: low.id,
+        },
+        highWater: {
+          ledger: 'runtime_event',
+          streamId: input.agentRunId,
+          sequence: positions.high,
+          eventId: high.id,
+        },
+        eventCount: positions.high - positions.low + 1,
+      },
+    };
+    const validation = validateExecutionEvidenceRef(provenance);
+    if (!validation.ok) {
+      throw new Error(
+        `invalid task evidence provenance: ${validation.errors
+          .map((issue) => `${issue.path}: ${issue.message}`)
+          .join('; ')}`,
+      );
+    }
+    links.push({
+      evidenceId: item.evidenceId,
+      attemptId: item.attemptId ?? input.attemptId,
+      provenance: validation.value,
+    });
+  }
+  return links;
+}
+
+function evidenceBelongsToInvocation(
+  item: HeavyTaskCompactEvidenceEnvelope,
+  input: TaskEvidenceRuntimeProvenanceInput,
+): boolean {
+  if (item.taskRunId !== input.taskRunId) return false;
+  if (item.attemptId && item.attemptId !== input.attemptId) return false;
+  if (item.source.sessionId && item.source.sessionId !== input.sessionId) return false;
+  if (item.source.agentRunId && item.source.agentRunId !== input.agentRunId) return false;
+  if (item.source.turnId && item.source.turnId !== input.turnId) return false;
+  return true;
+}
+
+function toolFactPositions(
+  item: HeavyTaskCompactEvidenceEnvelope,
+  input: TaskEvidenceRuntimeProvenanceInput,
+): { low: number; high: number } | undefined {
+  const matching: Array<{ index: number; event: RuntimeEvent }> = [];
+  for (let index = 0; index < input.runtimeEvents.length; index += 1) {
+    const event = input.runtimeEvents[index]!;
+    if (
+      event.sessionId === input.sessionId
+      && event.invocationId === input.invocationId
+      && event.runId === input.agentRunId
+      && event.turnId === input.turnId
+      && event.refs?.toolCallId === item.source.toolCallId
+    ) {
+      matching.push({ index, event });
+    }
+  }
+  const result = matching.find(({ event }) => event.content?.kind === 'function_response');
+  if (!result || !toolNameMatches(item, result.event)) return undefined;
+
+  const call = matching.find(({ event }) => event.content?.kind === 'function_call');
+  if (call && !toolNameMatches(item, call.event)) return undefined;
+  return {
+    low: call && call.index <= result.index ? call.index : result.index,
+    high: result.index,
+  };
+}
+
+function toolNameMatches(item: HeavyTaskCompactEvidenceEnvelope, event: RuntimeEvent): boolean {
+  const expected = item.source.toolName;
+  const content = event.content;
+  if (!expected || (content?.kind !== 'function_call' && content?.kind !== 'function_response')) return true;
+  return content.name.length === 0 || content.name === expected;
+}

--- a/packages/headless/src/task-run-store.ts
+++ b/packages/headless/src/task-run-store.ts
@@ -271,6 +271,30 @@ export function projectTaskRun(events: readonly TaskEvent[], taskRunId?: string)
           projection.warnings.push(`ignored heavy-task evidence ${event.evidence.evidenceId}: evidence must be public and match taskRunId`);
         }
         break;
+      case 'heavy_task_evidence_provenance_linked': {
+        const matchingIndexes = projection.heavyTaskEvidence.flatMap((item, index) => (
+          item.evidenceId === event.evidenceId ? [index] : []
+        ));
+        if (matchingIndexes.length !== 1) {
+          const reason = matchingIndexes.length === 0 ? 'was not recorded first' : 'is ambiguous';
+          projection.warnings.push(`ignored evidence provenance ${event.id}: evidence ${event.evidenceId} ${reason}`);
+          break;
+        }
+        const index = matchingIndexes[0]!;
+        const evidence = projection.heavyTaskEvidence[index]!;
+        const provenance = validHeavyTaskEvidenceProvenance(event, evidence, projection.warnings);
+        if (!provenance) break;
+        if (evidence.provenance) {
+          projection.warnings.push(`ignored evidence provenance ${event.id}: evidence ${event.evidenceId} is already linked`);
+          break;
+        }
+        const linked = { ...evidence, provenance };
+        projection.heavyTaskEvidence[index] = linked;
+        if (projection.latestHeavyTaskEvidence?.evidenceId === event.evidenceId) {
+          projection.latestHeavyTaskEvidence = linked;
+        }
+        break;
+      }
       case 'isolation_policy_recorded':
         projection.isolation = event.facts;
         break;
@@ -539,6 +563,48 @@ function validTaskAttemptExecutionEvidence(
   return evidence;
 }
 
+function validHeavyTaskEvidenceProvenance(
+  event: Extract<TaskEvent, { type: 'heavy_task_evidence_provenance_linked' }>,
+  subject: HeavyTaskCompactEvidenceEnvelope,
+  warnings: string[],
+): ExecutionEvidenceRef | undefined {
+  const validation = validateExecutionEvidenceRef(event.provenance);
+  if (!validation.ok) {
+    warnings.push(
+      `ignored evidence provenance ${event.id}: ${validation.errors
+        .map((issue) => `${issue.path}: ${issue.message}`)
+        .join('; ')}`,
+    );
+    return undefined;
+  }
+  const provenance = validation.value;
+  if (provenance.task?.taskRunId !== event.taskRunId) {
+    warnings.push(`ignored evidence provenance ${event.id}: task identity does not match the owning TaskRun`);
+    return undefined;
+  }
+  const attemptId = event.attemptId;
+  if (
+    (subject.attemptId && event.attemptId !== subject.attemptId)
+    || provenance.task?.attemptId !== attemptId
+  ) {
+    warnings.push(`ignored evidence provenance ${event.id}: attempt identity does not match the evidence`);
+    return undefined;
+  }
+  if (!provenance.execution?.agentRunId || !provenance.runtimeCoverage) {
+    warnings.push(`ignored evidence provenance ${event.id}: AgentRun identity and Runtime coverage are required`);
+    return undefined;
+  }
+  if (
+    (subject.source.sessionId && subject.source.sessionId !== provenance.execution.sessionId)
+    || (subject.source.agentRunId && subject.source.agentRunId !== provenance.execution.agentRunId)
+    || (subject.source.turnId && subject.source.turnId !== provenance.execution.turnId)
+  ) {
+    warnings.push(`ignored evidence provenance ${event.id}: Runtime identity does not match the evidence source`);
+    return undefined;
+  }
+  return provenance;
+}
+
 function resultFromScore(score: ScoreResult | undefined, verifier: VerifierResult | undefined): TaskRunResult | undefined {
   if (!score) return undefined;
   return {
@@ -593,8 +659,14 @@ function appendCompactEvidence(projection: TaskRunProjection, ...evidence: Heavy
       ok = false;
       continue;
     }
-    projection.heavyTaskEvidence.push(item);
-    projection.latestHeavyTaskEvidence = item;
+    if (item.provenance) {
+      projection.warnings.push(
+        `ignored embedded provenance on heavy-task evidence ${item.evidenceId}: a provenance link event is required`,
+      );
+    }
+    const { provenance: _embeddedProvenance, ...unlinked } = item;
+    projection.heavyTaskEvidence.push(unlinked);
+    projection.latestHeavyTaskEvidence = unlinked;
   }
   return ok;
 }


### PR DESCRIPTION
## Summary

Refs #948.

Phase 2A gives durably recorded compact Task evidence a verifiable source in the canonical Runtime Event Log:

- record the producing AgentRun on new tool-derived evidence while preserving legacy evidence reads
- match each durable evidence `toolCallId` to immutable Runtime `function_call` and `function_response` rows after an invocation finishes
- require the canonical function response before making any executor-result provenance claim
- append `heavy_task_evidence_provenance_linked` with an `ExecutionEvidenceRef` and inclusive Runtime coverage
- replay validated links onto TaskRun compact tool/artifact evidence without copying Runtime payloads
- reject cross-task, cross-attempt, cross-AgentRun, duplicate, embedded, or otherwise invalid provenance

The Task Event ledger stores only the cross-ledger link. Runtime remains the authority for exact tool inputs and results. Evidence without a matching immutable result remains honestly unlinked.

## Verification

- `npm run build`
- `npm run typecheck`
- `npm --workspace @maka/headless test` — 917 passed, 1 skipped
- focused controller/provenance/replay tests — 45 passed
- `git diff --check upstream/main...HEAD`

## Phase boundary

This PR intentionally links only first-class `heavy_task_evidence_recorded` facts. Replay-derived Self-check envelopes are not durable subjects and are not linked by derived ids.

The next Phase 2 slices remain:

- stable Task Event cursors plus Self-check Runtime/Task high waters and workspace revision
- deterministic Self-check staleness/invalidation after relevant mutations
- Compaction source coverage mapped to the shared cursor contract
