### PR TITLE
feat(headless): bind self-check evidence freshness

### DIFF
--- a/packages/headless/src/__tests__/heavy-task-self-check-gate.test.ts
+++ b/packages/headless/src/__tests__/heavy-task-self-check-gate.test.ts
@@ -303,6 +303,25 @@ describe('heavy-task self-check gate', () => {
     assert.equal(decision.action, 'allow_official_verifier_after_bounded_attempt');
     assert.match(decision.reason, /missing accepted public self-check/);
   });
+
+  test('stale Self-check evidence requires bounded revalidation', () => {
+    const gateProjection = projection(selfCheck('pass', {
+      command: 'npm test',
+      refs: ['/app/move.txt'],
+    }), plan(['/app/move.txt']));
+    assert.ok(gateProjection.latestHeavyTaskSelfCheck);
+    gateProjection.latestHeavyTaskSelfCheck.freshness = 'stale';
+    gateProjection.latestHeavyTaskSelfCheck.freshnessReasons = ['workspace_revision_changed'];
+
+    const decision = evaluateHeavyTaskSelfCheckGate({
+      task,
+      heavyTaskMode,
+      projection: gateProjection,
+    });
+
+    assert.equal(decision.action, 'repair_prompt');
+    assert.match(decision.reason, /self-check is stale: workspace_revision_changed/);
+  });
 });
 
 function projection(

--- a/packages/headless/src/__tests__/heavy-task-workspace-observation.test.ts
+++ b/packages/headless/src/__tests__/heavy-task-workspace-observation.test.ts
@@ -1,7 +1,11 @@
 import assert from 'node:assert/strict';
 import { describe, test } from 'node:test';
 import type { Task } from '../contracts.js';
-import { observeHeavyTaskWorkspace } from '../heavy-task-workspace-observation.js';
+import {
+  observeHeavyTaskWorkspace,
+  parseWorkspaceObservation,
+  workspaceManifestRevision,
+} from '../heavy-task-workspace-observation.js';
 import type { IsolatedCommandInput, IsolatedToolExecutor } from '../isolation.js';
 import type { HeavyTaskSelfCheckPlanState, TaskEvent } from '../task-contracts.js';
 import { projectTaskRun } from '../task-run-store.js';
@@ -56,7 +60,7 @@ describe('heavy-task workspace observation', () => {
         return {
           exitCode: 0,
           stdout: [
-            'file\t/app/polyglot/main.py.c\t',
+            'file\t/app/polyglot/main.py.c\t\t42\tabc123',
             'symlink\t/app/polyglot/main.py\tmain.py.c',
           ].join('\n'),
           stderr: '',
@@ -79,12 +83,32 @@ describe('heavy-task workspace observation', () => {
     assert.ok(event);
     assert.deepEqual(event.observation.roots, ['/app/polyglot']);
     assert.equal(event.observation.status, 'ok');
+    assert.match(event.observation.revision?.ref ?? '', /^sha256:[a-f0-9]{64}$/);
     assert.deepEqual(event.observation.entries, [
-      { path: '/app/polyglot/main.py.c', kind: 'file' },
+      { path: '/app/polyglot/main.py.c', kind: 'file', sizeBytes: 42, sha256: 'abc123' },
       { path: '/app/polyglot/main.py', kind: 'symlink', symlinkTarget: 'main.py.c' },
     ]);
     assert.equal(seenCommands[0]?.cwd, '/agent/workspace');
     assert.equal(seenCommands[0]?.timeoutMs, 30_000);
     assert.match(seenCommands[0]?.command ?? '', /\/app\/polyglot/);
+  });
+
+  test('includes file content facts in a deterministic manifest revision', () => {
+    const entries = parseWorkspaceObservation([
+      'file\t/app/project/result.txt\t\t12\tabc123',
+      'directory\t/app/project/cache\t\t\t',
+    ].join('\n'));
+    assert.deepEqual(entries, [
+      { path: '/app/project/result.txt', kind: 'file', sizeBytes: 12, sha256: 'abc123' },
+      { path: '/app/project/cache', kind: 'directory' },
+    ]);
+    assert.deepEqual(
+      workspaceManifestRevision(['/app/project'], entries),
+      workspaceManifestRevision(['/app/project'], [...entries].reverse()),
+    );
+    assert.notEqual(
+      workspaceManifestRevision(['/app/project'], entries).ref,
+      workspaceManifestRevision(['/app/project'], [{ ...entries[0]!, sha256: 'changed' }, entries[1]!]).ref,
+    );
   });
 });

--- a/packages/headless/src/__tests__/task-agent-controller.test.ts
+++ b/packages/headless/src/__tests__/task-agent-controller.test.ts
@@ -281,7 +281,7 @@ class ProgressToolBackend implements AgentBackend {
     }, toolCtx);
     await selfCheckPlanSubmit.impl({
       finalArtifacts: [{
-        path: 'README.md',
+        path: '/app/README.md',
         purpose: 'visible public artifact inspected by the check',
         publicReason: 'visible task notes are public',
       }],
@@ -291,7 +291,7 @@ class ProgressToolBackend implements AgentBackend {
         publicReason: 'public check outputs stay under scratch',
       },
       workspaceGuardPlan: {
-        checkedPaths: ['README.md'],
+        checkedPaths: ['/app/README.md'],
         expectedAddedPaths: [],
         expectedGeneratedPathsOutsideScratch: [],
         publicReason: 'public guard checks visible artifact paths',
@@ -302,7 +302,7 @@ class ProgressToolBackend implements AgentBackend {
       status: 'pass',
       publicReason: 'npm test passed using public README.md-backed fixture state.',
       commandEvidence: [{ command: 'npm test', exitCode: 0, outputExcerpt: 'public tests passed' }],
-      artifactEvidence: [{ path: 'README.md', kind: 'file', exists: true }],
+      artifactEvidence: [{ path: '/app/README.md', kind: 'file', exists: true }],
     }, toolCtx);
     const ts = Date.now();
     yield {
@@ -322,6 +322,24 @@ class ProgressToolBackend implements AgentBackend {
       toolUseId: 'bash-tool-call',
       isError: false,
       content: { kind: 'text', text: 'tests passed' },
+    };
+    yield {
+      type: 'tool_start',
+      id: 'progress-self-check-start',
+      turnId: input.turnId,
+      ts,
+      toolUseId: 'progress-tool-call',
+      toolName: 'self_check_submit',
+      args: { status: 'pass' },
+    };
+    yield {
+      type: 'tool_result',
+      id: 'progress-self-check-result',
+      turnId: input.turnId,
+      ts,
+      toolUseId: 'progress-tool-call',
+      isError: false,
+      content: { kind: 'text', text: 'self-check accepted' },
     };
     yield { type: 'complete', id: 'progress-complete', turnId: input.turnId, ts, stopReason: 'end_turn' };
   }
@@ -790,6 +808,23 @@ describe('runTaskOnce', () => {
       assert.equal(result.projection.latestHeavyTaskSelfCheck?.status, 'pass');
       assert.equal(result.projection.latestHeavyTaskSelfCheckPlan?.guard.status, 'accepted');
       assert.equal(result.projection.latestHeavyTaskSelfCheck?.guard.status, 'accepted');
+      assert.equal(
+        result.projection.latestHeavyTaskSelfCheck?.freshness,
+        'current',
+        JSON.stringify({
+          warnings: result.projection.warnings,
+          selfCheck: result.projection.latestHeavyTaskSelfCheck,
+          evidenceLinks: result.projection.events.filter((event) => event.type === 'heavy_task_self_check_evidence_linked'),
+          observations: result.projection.heavyTaskWorkspaceObservations,
+        }),
+      );
+      assert.ok(result.projection.latestHeavyTaskSelfCheck?.provenance?.runtimeCoverage);
+      assert.ok(result.projection.latestHeavyTaskSelfCheck?.provenance?.taskCoverage);
+      assert.equal(result.projection.latestHeavyTaskSelfCheck?.provenance?.workspace?.kind, 'manifest');
+      assert.equal(
+        result.projection.events.filter((event) => event.type === 'heavy_task_self_check_evidence_linked').length,
+        result.projection.heavyTaskSelfChecks.length,
+      );
       assert.equal(
         result.projection.events.filter((event) => event.type === 'heavy_task_inventory_recorded').length,
         2,

--- a/packages/headless/src/__tests__/task-run-store.test.ts
+++ b/packages/headless/src/__tests__/task-run-store.test.ts
@@ -104,6 +104,10 @@ describe('TaskRunStore', () => {
     for (const event of events) await store.appendEvent(event.taskRunId, event);
 
     assert.deepEqual(await store.readEvents('tr-1'), events);
+    assert.deepEqual((await store.readEventRecords('tr-1')).slice(0, 2).map((record) => record.cursor), [
+      { ledger: 'task_event', streamId: 'tr-1', sequence: 0, eventId: 'e-1' },
+      { ledger: 'task_event', streamId: 'tr-1', sequence: 1, eventId: 'e-2' },
+    ]);
   });
 
   test('projects status, attempts, observations, verifier, and score from replay', async () => {
@@ -529,6 +533,123 @@ describe('TaskRunStore', () => {
     assert.match(projection.warnings.join('\n'), /source guard did not accept/);
   });
 
+  test('replays Self-check source binding and invalidates freshness after later workspace mutations', () => {
+    const taskRunId = 'tr-self-check-freshness';
+    const attemptId = 'attempt-1';
+    const selfCheck = {
+      ...acceptedSelfCheck(taskRunId, 'self-check-1', 'pass', 'npm test passed.'),
+      attemptId,
+      source: {
+        kind: 'model_tool' as const,
+        toolCallId: 'self-check-call',
+        sessionId: 'session-1',
+        agentRunId: 'run-1',
+        turnId: 'turn-1',
+      },
+    };
+    const revision = { kind: 'manifest' as const, ref: 'sha256:workspace-1', dirty: false };
+    const workspaceObservation: Extract<TaskEvent, { type: 'heavy_task_workspace_observation_recorded' }>['observation'] = {
+      schemaVersion: 1,
+      observationId: 'workspace-1',
+      taskRunId,
+      ts: 3,
+      roots: ['/app/project'],
+      entries: [{ path: '/app/project/result.txt', kind: 'file', sizeBytes: 2, sha256: 'aa' }],
+      status: 'ok',
+      command: 'observe',
+      revision,
+      source: { kind: 'system', label: 'isolated workspace observation' },
+    };
+    const prefix: TaskEvent[] = [
+      { type: 'task_run_created', id: 'created', taskRunId, ts: 1, taskId: 'task-1', configId: 'cfg-1' },
+      { type: 'heavy_task_self_check_recorded', id: 'self-check-event', taskRunId, ts: 2, selfCheck },
+      {
+        type: 'heavy_task_workspace_observation_recorded',
+        id: 'workspace-event-1',
+        taskRunId,
+        ts: 3,
+        observation: workspaceObservation,
+      },
+      {
+        type: 'heavy_task_self_check_evidence_linked',
+        id: 'self-check-link',
+        taskRunId,
+        ts: 4,
+        selfCheckId: selfCheck.selfCheckId,
+        attemptId,
+        workspaceObservationId: 'workspace-1',
+        provenance: {
+          schemaVersion: 'maka.execution_evidence_ref.v1',
+          execution: { sessionId: 'session-1', invocationId: 'invocation-1', agentRunId: 'run-1', turnId: 'turn-1' },
+          task: { taskRunId, attemptId },
+          runtimeCoverage: {
+            lowWater: { ledger: 'runtime_event', streamId: 'run-1', sequence: 2, eventId: 'runtime-call' },
+            highWater: { ledger: 'runtime_event', streamId: 'run-1', sequence: 3, eventId: 'runtime-result' },
+            eventCount: 2,
+          },
+          taskCoverage: {
+            highWater: { ledger: 'task_event', streamId: taskRunId, sequence: 1, eventId: 'self-check-event' },
+            eventCount: 2,
+          },
+          workspace: revision,
+        },
+      },
+    ];
+
+    const current = projectTaskRun(prefix, taskRunId);
+    assert.equal(current.latestHeavyTaskSelfCheck?.freshness, 'current');
+    assert.equal(current.latestHeavyTaskSelfCheck?.provenance?.taskCoverage?.highWater.eventId, 'self-check-event');
+
+    const mutationBase = heavyTaskEvidenceEvent(
+      taskRunId,
+      'mutation',
+      'write-evidence',
+      'Bash',
+      5,
+    ) as Extract<TaskEvent, { type: 'heavy_task_evidence_recorded' }>;
+    const mutation: Extract<TaskEvent, { type: 'heavy_task_evidence_recorded' }> = {
+      ...mutationBase,
+      evidence: { ...mutationBase.evidence, attemptId },
+    };
+    const mutated = projectTaskRun([...prefix, mutation], taskRunId);
+    assert.equal(mutated.latestHeavyTaskSelfCheck?.freshness, 'stale');
+    assert.deepEqual(mutated.latestHeavyTaskSelfCheck?.freshnessReasons, ['later_workspace_mutation']);
+
+    const reobserved = projectTaskRun([
+      ...mutated.events,
+      {
+        type: 'heavy_task_workspace_observation_recorded',
+        id: 'workspace-event-2',
+        taskRunId,
+        ts: 6,
+        observation: {
+          ...workspaceObservation,
+          observationId: 'workspace-2',
+          ts: 6,
+        },
+      } as TaskEvent,
+    ], taskRunId);
+    assert.equal(reobserved.latestHeavyTaskSelfCheck?.freshness, 'current');
+
+    const changed = projectTaskRun([
+      ...reobserved.events,
+      {
+        type: 'heavy_task_workspace_observation_recorded',
+        id: 'workspace-event-3',
+        taskRunId,
+        ts: 7,
+        observation: {
+          ...workspaceObservation,
+          observationId: 'workspace-3',
+          ts: 7,
+          revision: { kind: 'manifest', ref: 'sha256:workspace-2', dirty: false },
+        },
+      } as TaskEvent,
+    ], taskRunId);
+    assert.equal(changed.latestHeavyTaskSelfCheck?.freshness, 'stale');
+    assert.deepEqual(changed.latestHeavyTaskSelfCheck?.freshnessReasons, ['workspace_revision_changed']);
+  });
+
   test('derives heavy-task completion from accepted self-checks and latest todos', () => {
     const taskRunId = 'tr-heavy-completion';
     const projection = projectTaskRun([
@@ -926,6 +1047,9 @@ describe('TaskRunStore', () => {
       assert.equal(replayed.length, 2);
       assert.equal(replayed[1]?.type, 'event_corrupt');
       assert.match((replayed[1] as { error?: string }).error ?? '', /Unexpected/);
+      const records = await store.readEventRecords('tr-corrupt');
+      assert.deepEqual(records.map((record) => record.cursor.sequence), [0, 1]);
+      assert.equal(records[1]?.cursor.eventId, 'corrupt-2');
     } finally {
       await rm(storageRoot, { recursive: true, force: true });
     }

--- a/packages/headless/src/__tests__/task-self-check-evidence.test.ts
+++ b/packages/headless/src/__tests__/task-self-check-evidence.test.ts
@@ -1,0 +1,144 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+import type { RuntimeEvent } from '@maka/core/runtime-event';
+import type {
+  HeavyTaskSelfCheckRecordedEvent,
+  HeavyTaskWorkspaceObservationRecordedEvent,
+} from '../task-contracts.js';
+import { bindSelfCheckEvidence } from '../task-self-check-evidence.js';
+
+describe('bindSelfCheckEvidence', () => {
+  test('binds Self-check to exact Runtime facts, Task high water, and workspace revision', () => {
+    const result = bindSelfCheckEvidence(bindingInput());
+    assert.equal(result.ok, true);
+    if (!result.ok) return;
+    assert.deepEqual(result.link.provenance.runtimeCoverage, {
+      lowWater: { ledger: 'runtime_event', streamId: 'run-1', sequence: 0, eventId: 'runtime-call' },
+      highWater: { ledger: 'runtime_event', streamId: 'run-1', sequence: 1, eventId: 'runtime-result' },
+      eventCount: 2,
+    });
+    assert.deepEqual(result.link.provenance.taskCoverage, {
+      highWater: { ledger: 'task_event', streamId: 'task-run-1', sequence: 7, eventId: 'self-check-event' },
+      eventCount: 8,
+    });
+    assert.equal(result.link.provenance.workspace?.ref, 'sha256:workspace-1');
+  });
+
+  test('does not bind without an executor-owned response or a workspace revision', () => {
+    const noResponse = bindingInput();
+    noResponse.runtimeEvents = noResponse.runtimeEvents.slice(0, 1);
+    assert.deepEqual(bindSelfCheckEvidence(noResponse), {
+      ok: false,
+      reason: 'Matching Self-check function call and response are required',
+    });
+
+    const noRevision = bindingInput();
+    delete noRevision.workspaceObservation.observation.revision;
+    assert.deepEqual(bindSelfCheckEvidence(noRevision), {
+      ok: false,
+      reason: 'A successful workspace manifest revision is required',
+    });
+  });
+
+  test('does not bind a Self-check from another AgentRun', () => {
+    const input = bindingInput();
+    input.selfCheckRecord.event.selfCheck.source.agentRunId = 'run-2';
+    assert.deepEqual(bindSelfCheckEvidence(input), {
+      ok: false,
+      reason: 'Self-check source does not match the Runtime invocation',
+    });
+  });
+});
+
+function bindingInput() {
+  const selfCheckEvent: HeavyTaskSelfCheckRecordedEvent = {
+    type: 'heavy_task_self_check_recorded',
+    id: 'self-check-event',
+    taskRunId: 'task-run-1',
+    ts: 2,
+    selfCheck: {
+      schemaVersion: 1,
+      selfCheckId: 'self-check-1',
+      taskRunId: 'task-run-1',
+      attemptId: 'attempt-1',
+      ts: 2,
+      status: 'pass',
+      publicReason: 'public tests passed',
+      commandEvidence: [{ command: 'npm test', exitCode: 0 }],
+      artifactEvidence: [],
+      guard: {
+        status: 'accepted',
+        checkedAt: 2,
+        categories: [],
+        publicReason: 'public evidence',
+      },
+      source: {
+        kind: 'model_tool',
+        toolCallId: 'self-check-call',
+        sessionId: 'session-1',
+        agentRunId: 'run-1',
+        turnId: 'turn-1',
+      },
+    },
+  };
+  const workspaceObservation: HeavyTaskWorkspaceObservationRecordedEvent = {
+    type: 'heavy_task_workspace_observation_recorded',
+    id: 'workspace-event',
+    taskRunId: 'task-run-1',
+    ts: 3,
+    observation: {
+      schemaVersion: 1,
+      observationId: 'workspace-1',
+      taskRunId: 'task-run-1',
+      ts: 3,
+      roots: ['/app/project'],
+      entries: [{ path: '/app/project/result.txt', kind: 'file', sizeBytes: 2, sha256: 'aa' }],
+      status: 'ok',
+      command: 'observe',
+      revision: { kind: 'manifest', ref: 'sha256:workspace-1', dirty: false },
+      source: { kind: 'system', label: 'isolated workspace observation' },
+    },
+  };
+  return {
+    taskRunId: 'task-run-1',
+    attemptId: 'attempt-1',
+    sessionId: 'session-1',
+    invocationId: 'invocation-1',
+    agentRunId: 'run-1',
+    turnId: 'turn-1',
+    runtimeEvents: [
+      runtimeEvent('runtime-call', {
+        role: 'model',
+        author: 'agent',
+        content: { kind: 'function_call', id: 'self-check-call', name: 'self_check_submit', args: {} },
+        refs: { toolCallId: 'self-check-call' },
+      }),
+      runtimeEvent('runtime-result', {
+        role: 'tool',
+        author: 'tool',
+        content: { kind: 'function_response', id: 'self-check-call', name: 'self_check_submit', result: { accepted: true } },
+        refs: { toolCallId: 'self-check-call' },
+      }),
+    ],
+    selfCheckRecord: {
+      event: selfCheckEvent,
+      cursor: { ledger: 'task_event' as const, streamId: 'task-run-1', sequence: 7, eventId: 'self-check-event' },
+    },
+    workspaceObservation,
+  };
+}
+
+function runtimeEvent(id: string, overrides: Partial<RuntimeEvent>): RuntimeEvent {
+  return {
+    id,
+    invocationId: 'invocation-1',
+    runId: 'run-1',
+    sessionId: 'session-1',
+    turnId: 'turn-1',
+    ts: 1,
+    partial: false,
+    role: 'system',
+    author: 'system',
+    ...overrides,
+  };
+}

--- a/packages/headless/src/heavy-task-finalization.ts
+++ b/packages/headless/src/heavy-task-finalization.ts
@@ -4,6 +4,7 @@ import type {
   AutonomousResultTaxonomy,
   HeavyTaskModeFacts,
   HeavyTaskSelfCheckPlanState,
+  HeavyTaskSelfCheckFreshness,
   HeavyTaskSelfCheckStatus,
   HeavyTaskSemanticSelfCheckState,
   HeavyTaskTodoItem,
@@ -63,7 +64,7 @@ export interface HeavyTaskCompletionInput {
   heavyTaskMode?: HeavyTaskModeFacts;
   latestHeavyTaskTodos?: HeavyTaskTodoState;
   latestHeavyTaskSelfCheckPlan?: HeavyTaskSelfCheckPlanState;
-  latestHeavyTaskSelfCheck?: HeavyTaskSemanticSelfCheckState;
+  latestHeavyTaskSelfCheck?: HeavyTaskSemanticSelfCheckState & { freshness?: HeavyTaskSelfCheckFreshness };
   decisions?: readonly AutonomousDecision[];
 }
 
@@ -120,6 +121,9 @@ function semanticStatusFromInput(input: HeavyTaskCompletionInput): HeavyTaskComp
   }
   if (!isAcceptedHeavyTaskSelfCheck(selfCheck)) {
     return { ...base, status: 'incomplete', reason: 'latest self-check evidence was not accepted as public' };
+  }
+  if (selfCheck.freshness === 'stale') {
+    return { ...base, status: 'incomplete', reason: 'latest self-check evidence is stale' };
   }
   if (selfCheck.status !== 'pass') {
     return { ...base, status: 'incomplete', reason: `latest self-check status is ${selfCheck.status}` };

--- a/packages/headless/src/heavy-task-self-check-gate.ts
+++ b/packages/headless/src/heavy-task-self-check-gate.ts
@@ -215,13 +215,16 @@ export function renderHeavyTaskSelfCheckGatePrompt(input: {
 }
 
 function gateBlockerReason(
-  selfCheck: HeavyTaskSemanticSelfCheckState | undefined,
+  selfCheck: TaskRunProjection['latestHeavyTaskSelfCheck'],
   plan: TaskRunProjection['latestHeavyTaskSelfCheckPlan'],
   semanticReason: string,
   checklist: readonly HeavyTaskAcceptanceCheck[],
 ): string | undefined {
   if (!selfCheck) return 'missing accepted public self-check evidence';
   if (!isAcceptedHeavyTaskSelfCheck(selfCheck)) return 'latest self-check evidence was not accepted as public';
+  if (selfCheck.freshness === 'stale') {
+    return `latest self-check is stale: ${selfCheck.freshnessReasons.join(', ') || 'workspace changed'}`;
+  }
   if (selfCheck.status !== 'pass') return `latest self-check status is ${selfCheck.status}`;
   if (selfCheck.commandEvidence.length + selfCheck.artifactEvidence.length === 0) {
     return 'latest pass self-check lacks concrete command or artifact evidence';

--- a/packages/headless/src/heavy-task-self-check.ts
+++ b/packages/headless/src/heavy-task-self-check.ts
@@ -460,7 +460,10 @@ export function heavyTaskSelfCheckWorkspaceGuardStatus(
 }
 
 export function renderHeavyTaskSelfCheckForPrompt(projection: {
-  latestHeavyTaskSelfCheck?: HeavyTaskSemanticSelfCheckState;
+  latestHeavyTaskSelfCheck?: HeavyTaskSemanticSelfCheckState & {
+    freshness?: 'current' | 'stale' | 'unknown';
+    freshnessReasons?: string[];
+  };
 }): string | undefined {
   const selfCheck = projection.latestHeavyTaskSelfCheck;
   if (!selfCheck) return undefined;
@@ -469,6 +472,12 @@ export function renderHeavyTaskSelfCheckForPrompt(projection: {
     `- Latest advisory status: ${selfCheck.status}`,
     `- Public reason: ${oneLine(selfCheck.publicReason, 240)}`,
   ];
+  if (selfCheck.freshness) {
+    lines.push(`- Evidence freshness: ${selfCheck.freshness}`);
+    if (selfCheck.freshnessReasons?.length) {
+      lines.push(`  - freshness reasons: ${selfCheck.freshnessReasons.join(', ')}`);
+    }
+  }
   for (const command of selfCheck.commandEvidence.slice(0, 5)) {
     lines.push(`  - command: ${oneLine(command.command, 160)} exit=${command.exitCode ?? 'unknown'}`);
   }

--- a/packages/headless/src/heavy-task-workspace-observation.ts
+++ b/packages/headless/src/heavy-task-workspace-observation.ts
@@ -1,6 +1,11 @@
+import { createHash } from 'node:crypto';
 import { posix as pathPosix } from 'node:path';
+import type { WorkspaceRevisionRef } from '@maka/core/execution-evidence';
 import type { IsolatedToolExecutor } from './isolation.js';
-import type { HeavyTaskWorkspaceObservationRecordedEvent } from './task-contracts.js';
+import type {
+  HeavyTaskWorkspaceObservationEntry,
+  HeavyTaskWorkspaceObservationRecordedEvent,
+} from './task-contracts.js';
 import type { TaskRunProjection } from './task-run-store.js';
 
 export async function observeHeavyTaskWorkspace(input: {
@@ -16,6 +21,10 @@ export async function observeHeavyTaskWorkspace(input: {
   if (roots.length === 0) return undefined;
   const command = workspaceObservationCommand(roots);
   const result = await input.executor.exec({ command, cwd: input.cwd, timeoutMs: 30_000 });
+  const entries = result.exitCode === 0 ? parseWorkspaceObservation(result.stdout) : [];
+  const revision = result.exitCode === 0 && workspaceManifestIsContentAddressed(entries)
+    ? workspaceManifestRevision(roots, entries)
+    : undefined;
   return {
     type: 'heavy_task_workspace_observation_recorded',
     id: input.newId(),
@@ -27,9 +36,10 @@ export async function observeHeavyTaskWorkspace(input: {
       taskRunId: input.taskRunId,
       ts: input.now(),
       roots,
-      entries: result.exitCode === 0 ? parseWorkspaceObservation(result.stdout) : [],
+      entries,
       status: result.exitCode === 0 ? 'ok' : 'error',
       command,
+      ...(revision ? { revision } : {}),
       ...(result.exitCode === 0 ? {} : { errorExcerpt: cleanOneLine(result.stderr || result.stdout, 500) }),
       source: { kind: 'system', label: 'isolated workspace observation' },
     },
@@ -42,7 +52,7 @@ function observationRoots(projection: TaskRunProjection): string[] {
     ...(projection.latestHeavyTaskSelfCheck?.executionHygiene?.workspaceGuard?.checkedPaths ?? []).map((path) => pathPosix.normalize(path)),
   ];
   return unique(candidates
-    .filter((root) => root.startsWith('/app/'))
+    .filter((root) => root === '/app' || root.startsWith('/app/'))
     .map((root) => root.replace(/\/+$/, '')))
     .slice(0, 12);
 }
@@ -57,29 +67,56 @@ function workspaceObservationCommand(roots: readonly string[]): string {
   return [
     `for root in ${args}; do`,
     '  if [ -e "$root" ]; then',
-    '    if [ -d "$root" ]; then find "$root" -mindepth 1 -maxdepth 1 -exec sh -c \'for p do if [ -L "$p" ]; then t=$(readlink "$p" 2>/dev/null || true); printf "symlink\\t%s\\t%s\\n" "$p" "$t"; elif [ -f "$p" ]; then printf "file\\t%s\\t\\n" "$p"; elif [ -d "$p" ]; then printf "directory\\t%s\\t\\n" "$p"; else printf "other\\t%s\\t\\n" "$p"; fi; done\' sh {} +;',
+    '    if [ -d "$root" ]; then find "$root" -mindepth 1 -maxdepth 1 -exec sh -c \'for p do if [ -L "$p" ]; then t=$(readlink "$p" 2>/dev/null || true); printf "symlink\\t%s\\t%s\\t\\t\\n" "$p" "$t"; elif [ -f "$p" ]; then s=$(wc -c < "$p" | tr -d " "); h=$(sha256sum "$p" | cut -d " " -f 1); printf "file\\t%s\\t\\t%s\\t%s\\n" "$p" "$s" "$h"; elif [ -d "$p" ]; then printf "directory\\t%s\\t\\t\\t\\n" "$p"; else printf "other\\t%s\\t\\t\\t\\n" "$p"; fi; done\' sh {} +;',
     '    elif [ -L "$root" ]; then t=$(readlink "$root" 2>/dev/null || true); printf "symlink\\t%s\\t%s\\n" "$root" "$t";',
-    '    elif [ -f "$root" ]; then printf "file\\t%s\\t\\n" "$root";',
+    '    elif [ -f "$root" ]; then s=$(wc -c < "$root" | tr -d " "); h=$(sha256sum "$root" | cut -d " " -f 1); printf "file\\t%s\\t\\t%s\\t%s\\n" "$root" "$s" "$h";',
     '    else printf "other\\t%s\\t\\n" "$root"; fi',
     '  fi',
     'done',
   ].join('\n');
 }
 
-function parseWorkspaceObservation(stdout: string) {
+export function parseWorkspaceObservation(stdout: string): HeavyTaskWorkspaceObservationEntry[] {
   return stdout.split(/\n/)
     .map((line) => line.trimEnd())
     .filter(Boolean)
     .map((line) => {
-      const [kind, path, symlinkTarget] = line.split('\t');
+      const [kind, path, symlinkTarget, sizeBytes, sha256] = line.split('\t');
       if (!isObservationKind(kind) || !path) return undefined;
+      const parsedSize = sizeBytes && /^\d+$/.test(sizeBytes) ? Number(sizeBytes) : undefined;
       return {
         path,
         kind,
         ...(kind === 'symlink' && symlinkTarget ? { symlinkTarget } : {}),
+        ...(kind === 'file' && parsedSize !== undefined ? { sizeBytes: parsedSize } : {}),
+        ...(kind === 'file' && sha256 ? { sha256 } : {}),
       };
     })
     .filter((entry): entry is NonNullable<typeof entry> => Boolean(entry));
+}
+
+export function workspaceManifestRevision(
+  roots: readonly string[],
+  entries: readonly HeavyTaskWorkspaceObservationEntry[],
+): WorkspaceRevisionRef {
+  const canonical = {
+    schemaVersion: 'maka.workspace_manifest.v1',
+    roots: [...roots].sort(),
+    entries: [...entries]
+      .map((entry) => ({ ...entry }))
+      .sort((left, right) => left.path.localeCompare(right.path) || left.kind.localeCompare(right.kind)),
+  };
+  return {
+    kind: 'manifest',
+    ref: `sha256:${createHash('sha256').update(JSON.stringify(canonical)).digest('hex')}`,
+  };
+}
+
+function workspaceManifestIsContentAddressed(entries: readonly HeavyTaskWorkspaceObservationEntry[]): boolean {
+  return entries.every((entry) => (
+    entry.kind !== 'file'
+      || (entry.sizeBytes !== undefined && typeof entry.sha256 === 'string' && entry.sha256.length > 0)
+  ));
 }
 
 function isObservationKind(value: string | undefined): value is 'file' | 'directory' | 'symlink' | 'other' {

--- a/packages/headless/src/index.ts
+++ b/packages/headless/src/index.ts
@@ -58,11 +58,15 @@ export type {
   HeavyTaskCommandEvidence,
   HeavyTaskProgressSource,
   HeavyTaskSelfCheckRecordedEvent,
+  HeavyTaskSelfCheckEvidenceLinkedEvent,
+  HeavyTaskSelfCheckFreshness,
+  HeavyTaskSelfCheckFreshnessReason,
   HeavyTaskSelfCheckGateAction,
   HeavyTaskSelfCheckGateRecordedEvent,
   HeavyTaskSelfCheckGateState,
   HeavyTaskSelfCheckStatus,
   HeavyTaskSemanticSelfCheckState,
+  HeavyTaskSelfCheckProjection,
   HeavyTaskSourceGuardResult,
   HeavyTaskToolEvidenceName,
   HeavyTaskTodoItem,
@@ -140,7 +144,7 @@ export {
   resourceScopeEquals,
   type NormalizedPermissionArgs,
 } from './permission-grants.js';
-export type { TaskRunProjection, TaskRunStore } from './task-run-store.js';
+export type { TaskEventLedgerEntry, TaskRunProjection, TaskRunStore } from './task-run-store.js';
 export { createInMemoryTaskRunStore, createTaskRunStore, projectTaskRun } from './task-run-store.js';
 export type { TaskEventsFromResultRecordOptions } from './task-run-adapter.js';
 export {
@@ -156,7 +160,9 @@ export type {
   TaskEvidenceRuntimeProvenanceInput,
   TaskEvidenceRuntimeProvenanceLink,
 } from './task-evidence-provenance.js';
-export { taskEvidenceRuntimeProvenanceLinks } from './task-evidence-provenance.js';
+export { runtimeToolFactCoverage, taskEvidenceRuntimeProvenanceLinks } from './task-evidence-provenance.js';
+export type { SelfCheckEvidenceBindingInput, SelfCheckEvidenceBindingResult } from './task-self-check-evidence.js';
+export { bindSelfCheckEvidence } from './task-self-check-evidence.js';
 export type {
   AutonomousDecisionInput,
   AutonomousDecisionPolicy,

--- a/packages/headless/src/task-agent-controller.ts
+++ b/packages/headless/src/task-agent-controller.ts
@@ -95,6 +95,7 @@ import {
 import { taskDefinitionFromTask } from './task-run-adapter.js';
 import { taskEvidenceRuntimeProvenanceLinks } from './task-evidence-provenance.js';
 import { taskAttemptExecutionEvidence } from './task-execution-lineage.js';
+import { bindSelfCheckEvidence } from './task-self-check-evidence.js';
 
 export interface RunTaskOnceDeps extends RunExperimentDeps {
   taskRunStore?: TaskRunStore;
@@ -382,12 +383,22 @@ export async function runTaskOnce(
     await appendRuntimeFeedback(taskRunStore, taskRunId, attemptId, now, newId, runtimeSummary);
     if (heavyTaskMode.enabled) {
       let gateProjection = await taskRunStore.project(taskRunId);
-      await appendHeavyTaskWorkspaceObservation({
+      const workspaceObservation = await appendHeavyTaskWorkspaceObservation({
         taskRunStore,
         taskRunId,
         projection: gateProjection,
         executor: deps.realBackendIsolation?.toolExecutor,
         cwd: agentWorkspaceDir,
+        now,
+        newId,
+      });
+      await appendHeavyTaskSelfCheckEvidenceLinks({
+        store: taskRunStore,
+        runtimeEventStore,
+        taskRunId,
+        attemptId,
+        invocation,
+        workspaceObservation,
         now,
         newId,
       });
@@ -477,12 +488,22 @@ export async function runTaskOnce(
         runtimeSummary = mergeRuntimeSummaries(runtimeSummary, repairSummary);
 
         let boundedProjection = await taskRunStore.project(taskRunId);
-        await appendHeavyTaskWorkspaceObservation({
+        const repairWorkspaceObservation = await appendHeavyTaskWorkspaceObservation({
           taskRunStore,
           taskRunId,
           projection: boundedProjection,
           executor: deps.realBackendIsolation?.toolExecutor,
           cwd: agentWorkspaceDir,
+          now,
+          newId,
+        });
+        await appendHeavyTaskSelfCheckEvidenceLinks({
+          store: taskRunStore,
+          runtimeEventStore,
+          taskRunId,
+          attemptId,
+          invocation,
+          workspaceObservation: repairWorkspaceObservation,
           now,
           newId,
         });
@@ -662,7 +683,7 @@ async function appendHeavyTaskWorkspaceObservation(input: {
   cwd: string;
   now: () => number;
   newId: () => string;
-}): Promise<void> {
+}): Promise<Extract<TaskEvent, { type: 'heavy_task_workspace_observation_recorded' }> | undefined> {
   const event = await observeHeavyTaskWorkspace({
     taskRunId: input.taskRunId,
     projection: input.projection,
@@ -672,6 +693,56 @@ async function appendHeavyTaskWorkspaceObservation(input: {
     newId: input.newId,
   });
   if (event) await appendTaskEvent(input.taskRunStore, input.taskRunId, event);
+  return event;
+}
+
+async function appendHeavyTaskSelfCheckEvidenceLinks(input: {
+  store: TaskRunStore;
+  runtimeEventStore: RuntimeEventStore;
+  taskRunId: string;
+  attemptId: string;
+  invocation: InvocationResult;
+  workspaceObservation?: Extract<TaskEvent, { type: 'heavy_task_workspace_observation_recorded' }>;
+  now: () => number;
+  newId: () => string;
+}): Promise<void> {
+  if (!input.workspaceObservation || !input.runtimeEventStore.readImmutableRuntimeEvents) return;
+  const [runtimeEvents, records] = await Promise.all([
+    input.runtimeEventStore.readImmutableRuntimeEvents(input.invocation.sessionId, input.invocation.runId),
+    input.store.readEventRecords(input.taskRunId),
+  ]);
+  const linkedSelfChecks = new Set(records.flatMap(({ event }) => (
+    event.type === 'heavy_task_self_check_evidence_linked' ? [event.selfCheckId] : []
+  )));
+  const candidates = records.filter((record): record is typeof record & {
+    event: Extract<TaskEvent, { type: 'heavy_task_self_check_recorded' }>;
+  } => (
+    record.event.type === 'heavy_task_self_check_recorded'
+    && record.event.selfCheck.attemptId === input.attemptId
+    && !linkedSelfChecks.has(record.event.selfCheck.selfCheckId)
+    && (!record.event.selfCheck.source.sessionId || record.event.selfCheck.source.sessionId === input.invocation.sessionId)
+    && (!record.event.selfCheck.source.agentRunId || record.event.selfCheck.source.agentRunId === input.invocation.runId)
+    && (!record.event.selfCheck.source.turnId || record.event.selfCheck.source.turnId === input.invocation.turnId)
+  ));
+  for (const selfCheckRecord of candidates) {
+    const binding = bindSelfCheckEvidence({
+      taskRunId: input.taskRunId,
+      attemptId: input.attemptId,
+      sessionId: input.invocation.sessionId,
+      invocationId: input.invocation.invocationId,
+      agentRunId: input.invocation.runId,
+      turnId: input.invocation.turnId,
+      runtimeEvents,
+      selfCheckRecord,
+      workspaceObservation: input.workspaceObservation,
+    });
+    if (!binding.ok) continue;
+    await appendTaskEvent(input.store, input.taskRunId, {
+      ...binding.link,
+      id: input.newId(),
+      ts: input.now(),
+    });
+  }
 }
 
 const DEFAULT_INTERVENTION_POLICY: TaskInterventionPolicy = { mode: 'fail_closed' };

--- a/packages/headless/src/task-contracts.ts
+++ b/packages/headless/src/task-contracts.ts
@@ -1,4 +1,4 @@
-import type { ExecutionEvidenceRef } from '@maka/core/execution-evidence';
+import type { ExecutionEvidenceRef, WorkspaceRevisionRef } from '@maka/core/execution-evidence';
 import type { ResultRecord, TaskVerification, VerifierSpec } from './contracts.js';
 
 export type TaskRunStatus =
@@ -446,6 +446,8 @@ export interface HeavyTaskWorkspaceObservationEntry {
   path: string;
   kind: 'file' | 'directory' | 'symlink' | 'other';
   symlinkTarget?: string;
+  sizeBytes?: number;
+  sha256?: string;
 }
 
 export interface HeavyTaskWorkspaceObservationState {
@@ -457,6 +459,8 @@ export interface HeavyTaskWorkspaceObservationState {
   entries: HeavyTaskWorkspaceObservationEntry[];
   status: 'ok' | 'error';
   command: string;
+  /** Deterministic digest of the public manifest when observation succeeded. */
+  revision?: WorkspaceRevisionRef;
   errorExcerpt?: string;
   source: { kind: 'system'; label: string };
 }
@@ -474,6 +478,22 @@ export interface HeavyTaskSemanticSelfCheckState {
   executionHygiene?: HeavyTaskSelfCheckExecutionHygiene;
   guard: HeavyTaskSourceGuardResult & { status: 'accepted' };
   source: HeavyTaskProgressSource;
+}
+
+export type HeavyTaskSelfCheckFreshness = 'current' | 'stale' | 'unknown';
+
+export type HeavyTaskSelfCheckFreshnessReason =
+  | 'source_binding_missing'
+  | 'workspace_observation_missing'
+  | 'workspace_revision_changed'
+  | 'later_workspace_mutation';
+
+/** Replay-derived Self-check state. Durable source facts remain separate events. */
+export interface HeavyTaskSelfCheckProjection extends HeavyTaskSemanticSelfCheckState {
+  provenance?: ExecutionEvidenceRef;
+  workspaceObservationId?: string;
+  freshness: HeavyTaskSelfCheckFreshness;
+  freshnessReasons: HeavyTaskSelfCheckFreshnessReason[];
 }
 
 export interface HeavyTaskAcceptanceCheck {
@@ -812,6 +832,15 @@ export interface HeavyTaskSelfCheckRecordedEvent extends BaseTaskEvent {
   selfCheck: HeavyTaskSemanticSelfCheckState;
 }
 
+export interface HeavyTaskSelfCheckEvidenceLinkedEvent extends BaseTaskEvent {
+  type: 'heavy_task_self_check_evidence_linked';
+  selfCheckId: string;
+  attemptId: string;
+  workspaceObservationId: string;
+  /** Canonical Runtime/Task coverage and the observed workspace revision. */
+  provenance: ExecutionEvidenceRef;
+}
+
 export interface HeavyTaskSelfCheckPlanRecordedEvent extends BaseTaskEvent {
   type: 'heavy_task_self_check_plan_recorded';
   plan: HeavyTaskSelfCheckPlanState;
@@ -970,6 +999,7 @@ export type TaskEvent =
   | HeavyTaskTodosRecordedEvent
   | HeavyTaskSelfCheckPlanRecordedEvent
   | HeavyTaskSelfCheckRecordedEvent
+  | HeavyTaskSelfCheckEvidenceLinkedEvent
   | HeavyTaskSelfCheckGateRecordedEvent
   | HeavyTaskWorkspaceObservationRecordedEvent
   | HeavyTaskEvidenceRecordedEvent

--- a/packages/headless/src/task-evidence-provenance.ts
+++ b/packages/headless/src/task-evidence-provenance.ts
@@ -2,6 +2,7 @@ import {
   EXECUTION_EVIDENCE_REF_SCHEMA_VERSION,
   validateExecutionEvidenceRef,
   type ExecutionEvidenceRef,
+  type ExecutionLogCoverage,
 } from '@maka/core/execution-evidence';
 import type { RuntimeEvent } from '@maka/core/runtime-event';
 import type { HeavyTaskCompactEvidenceEnvelope } from './task-contracts.js';
@@ -37,10 +38,16 @@ export function taskEvidenceRuntimeProvenanceLinks(
   for (const item of input.evidence) {
     if (item.provenance || !evidenceBelongsToInvocation(item, input)) continue;
 
-    const positions = toolFactPositions(item, input);
-    if (!positions) continue;
-    const low = input.runtimeEvents[positions.low]!;
-    const high = input.runtimeEvents[positions.high]!;
+    const runtimeCoverage = runtimeToolFactCoverage({
+      sessionId: input.sessionId,
+      invocationId: input.invocationId,
+      agentRunId: input.agentRunId,
+      turnId: input.turnId,
+      runtimeEvents: input.runtimeEvents,
+      toolCallId: item.source.toolCallId,
+      toolName: item.source.toolName,
+    });
+    if (!runtimeCoverage) continue;
     const provenance: ExecutionEvidenceRef = {
       schemaVersion: EXECUTION_EVIDENCE_REF_SCHEMA_VERSION,
       execution: {
@@ -53,21 +60,7 @@ export function taskEvidenceRuntimeProvenanceLinks(
         taskRunId: input.taskRunId,
         attemptId: item.attemptId ?? input.attemptId,
       },
-      runtimeCoverage: {
-        lowWater: {
-          ledger: 'runtime_event',
-          streamId: input.agentRunId,
-          sequence: positions.low,
-          eventId: low.id,
-        },
-        highWater: {
-          ledger: 'runtime_event',
-          streamId: input.agentRunId,
-          sequence: positions.high,
-          eventId: high.id,
-        },
-        eventCount: positions.high - positions.low + 1,
-      },
+      runtimeCoverage,
     };
     const validation = validateExecutionEvidenceRef(provenance);
     if (!validation.ok) {
@@ -98,10 +91,16 @@ function evidenceBelongsToInvocation(
   return true;
 }
 
-function toolFactPositions(
-  item: HeavyTaskCompactEvidenceEnvelope,
-  input: TaskEvidenceRuntimeProvenanceInput,
-): { low: number; high: number } | undefined {
+export function runtimeToolFactCoverage(input: {
+  sessionId: string;
+  invocationId: string;
+  agentRunId: string;
+  turnId: string;
+  runtimeEvents: readonly RuntimeEvent[];
+  toolCallId: string;
+  toolName?: string;
+  requireCall?: boolean;
+}): ExecutionLogCoverage | undefined {
   const matching: Array<{ index: number; event: RuntimeEvent }> = [];
   for (let index = 0; index < input.runtimeEvents.length; index += 1) {
     const event = input.runtimeEvents[index]!;
@@ -110,24 +109,40 @@ function toolFactPositions(
       && event.invocationId === input.invocationId
       && event.runId === input.agentRunId
       && event.turnId === input.turnId
-      && event.refs?.toolCallId === item.source.toolCallId
+      && event.refs?.toolCallId === input.toolCallId
     ) {
       matching.push({ index, event });
     }
   }
-  const result = matching.find(({ event }) => event.content?.kind === 'function_response');
-  if (!result || !toolNameMatches(item, result.event)) return undefined;
+  const results = matching.filter(({ event }) => event.content?.kind === 'function_response');
+  if (results.length !== 1) return undefined;
+  const result = results[0]!;
+  if (!toolNameMatches(input.toolName, result.event)) return undefined;
 
-  const call = matching.find(({ event }) => event.content?.kind === 'function_call');
-  if (call && !toolNameMatches(item, call.event)) return undefined;
+  const calls = matching.filter(({ event }) => event.content?.kind === 'function_call');
+  if (calls.length > 1) return undefined;
+  const call = calls[0];
+  if (call && (call.index > result.index || !toolNameMatches(input.toolName, call.event))) return undefined;
+  if (!call && input.requireCall) return undefined;
+  const low = call ?? result;
   return {
-    low: call && call.index <= result.index ? call.index : result.index,
-    high: result.index,
+    lowWater: {
+      ledger: 'runtime_event',
+      streamId: input.agentRunId,
+      sequence: low.index,
+      eventId: low.event.id,
+    },
+    highWater: {
+      ledger: 'runtime_event',
+      streamId: input.agentRunId,
+      sequence: result.index,
+      eventId: result.event.id,
+    },
+    eventCount: result.index - low.index + 1,
   };
 }
 
-function toolNameMatches(item: HeavyTaskCompactEvidenceEnvelope, event: RuntimeEvent): boolean {
-  const expected = item.source.toolName;
+function toolNameMatches(expected: string | undefined, event: RuntimeEvent): boolean {
   const content = event.content;
   if (!expected || (content?.kind !== 'function_call' && content?.kind !== 'function_response')) return true;
   return content.name.length === 0 || content.name === expected;

--- a/packages/headless/src/task-run-store.ts
+++ b/packages/headless/src/task-run-store.ts
@@ -3,6 +3,7 @@ import { join } from 'node:path';
 import {
   validateExecutionEvidenceRef,
   type ExecutionEvidenceRef,
+  type ExecutionLogCursor,
 } from '@maka/core/execution-evidence';
 import type { ResultRecord } from './contracts.js';
 import { compactArtifactEvidence, compactSelfCheckEvidence } from './heavy-task-evidence.js';
@@ -14,6 +15,8 @@ import type {
   HeavyTaskCompactEvidenceEnvelope,
   HeavyTaskSelfCheckPlanState,
   HeavyTaskSelfCheckGateState,
+  HeavyTaskSelfCheckFreshnessReason,
+  HeavyTaskSelfCheckProjection,
   HeavyTaskWorkspaceObservationState,
   EconomyTaskModeFacts,
   HeavyTaskInventoryState,
@@ -61,8 +64,8 @@ export interface TaskRunProjection extends TaskRun {
   latestHeavyTaskInventory?: HeavyTaskInventoryState;
   heavyTaskTodoStates: HeavyTaskTodoState[];
   latestHeavyTaskTodos?: HeavyTaskTodoState;
-  heavyTaskSelfChecks: HeavyTaskSemanticSelfCheckState[];
-  latestHeavyTaskSelfCheck?: HeavyTaskSemanticSelfCheckState;
+  heavyTaskSelfChecks: HeavyTaskSelfCheckProjection[];
+  latestHeavyTaskSelfCheck?: HeavyTaskSelfCheckProjection;
   heavyTaskSelfCheckPlans: HeavyTaskSelfCheckPlanState[];
   latestHeavyTaskSelfCheckPlan?: HeavyTaskSelfCheckPlanState;
   heavyTaskSelfCheckGates: HeavyTaskSelfCheckGateState[];
@@ -80,8 +83,14 @@ export interface TaskRunProjection extends TaskRun {
 
 export interface TaskRunStore {
   appendEvent(taskRunId: string, event: TaskEvent): Promise<void>;
+  readEventRecords(taskRunId: string): Promise<TaskEventLedgerEntry[]>;
   readEvents(taskRunId: string): Promise<TaskEvent[]>;
   project(taskRunId: string): Promise<TaskRunProjection>;
+}
+
+export interface TaskEventLedgerEntry {
+  event: TaskEvent;
+  cursor: ExecutionLogCursor;
 }
 
 export function createInMemoryTaskRunStore(initialEvents: readonly TaskEvent[] = []): TaskRunStore {
@@ -123,9 +132,12 @@ export function projectTaskRun(events: readonly TaskEvent[], taskRunId?: string)
   };
   const attempts = new Map<string, TaskAttempt>();
   const inboxItems = new Map<string, TaskInboxItem>();
+  const selfCheckRows = new Map<string, Array<{ sequence: number; projectionIndex: number; eventId: string }>>();
+  const workspaceObservationRows = new Map<string, { sequence: number; observation: HeavyTaskWorkspaceObservationState }>();
   let terminalEvents = 0;
 
-  for (const event of events) {
+  for (let sequence = 0; sequence < events.length; sequence += 1) {
+    const event = events[sequence]!;
     if (projectedTaskRunId && event.taskRunId !== projectedTaskRunId) {
       projection.warnings.push(`ignored event ${event.id}: taskRunId ${event.taskRunId} does not match ${projectedTaskRunId}`);
       continue;
@@ -245,8 +257,17 @@ export function projectTaskRun(events: readonly TaskEvent[], taskRunId?: string)
         break;
       case 'heavy_task_self_check_recorded':
         if (isAcceptedHeavyTaskSelfCheck(event.selfCheck)) {
-          projection.heavyTaskSelfChecks.push(event.selfCheck);
-          projection.latestHeavyTaskSelfCheck = event.selfCheck;
+          const projectedSelfCheck: HeavyTaskSelfCheckProjection = {
+            ...event.selfCheck,
+            freshness: 'unknown',
+            freshnessReasons: ['source_binding_missing'],
+          };
+          const projectionIndex = projection.heavyTaskSelfChecks.push(projectedSelfCheck) - 1;
+          selfCheckRows.set(event.selfCheck.selfCheckId, [
+            ...(selfCheckRows.get(event.selfCheck.selfCheckId) ?? []),
+            { sequence, projectionIndex, eventId: event.id },
+          ]);
+          projection.latestHeavyTaskSelfCheck = projectedSelfCheck;
           appendCompactEvidence(
             projection,
             ...compactSelfCheckEvidence({
@@ -258,6 +279,36 @@ export function projectTaskRun(events: readonly TaskEvent[], taskRunId?: string)
           projection.warnings.push(`ignored heavy-task self-check ${event.selfCheck.selfCheckId}: source guard did not accept public evidence`);
         }
         break;
+      case 'heavy_task_self_check_evidence_linked': {
+        const rows = selfCheckRows.get(event.selfCheckId) ?? [];
+        if (rows.length !== 1) {
+          const reason = rows.length === 0 ? 'was not recorded first' : 'is ambiguous';
+          projection.warnings.push(`ignored self-check evidence link ${event.id}: Self-check ${event.selfCheckId} ${reason}`);
+          break;
+        }
+        const row = rows[0]!;
+        const selfCheck = projection.heavyTaskSelfChecks[row.projectionIndex]!;
+        if (selfCheck.provenance) {
+          projection.warnings.push(`ignored self-check evidence link ${event.id}: Self-check ${event.selfCheckId} is already linked`);
+          break;
+        }
+        const observationRow = workspaceObservationRows.get(event.workspaceObservationId);
+        const provenance = validHeavyTaskSelfCheckProvenance(
+          event,
+          selfCheck,
+          row.sequence,
+          row.eventId,
+          observationRow,
+          projection.warnings,
+        );
+        if (!provenance) break;
+        projection.heavyTaskSelfChecks[row.projectionIndex] = {
+          ...selfCheck,
+          provenance,
+          workspaceObservationId: event.workspaceObservationId,
+        };
+        break;
+      }
       case 'heavy_task_self_check_gate_recorded':
         projection.heavyTaskSelfCheckGates.push(event.gate);
         projection.latestHeavyTaskSelfCheckGate = event.gate;
@@ -265,6 +316,10 @@ export function projectTaskRun(events: readonly TaskEvent[], taskRunId?: string)
       case 'heavy_task_workspace_observation_recorded':
         projection.heavyTaskWorkspaceObservations.push(event.observation);
         projection.latestHeavyTaskWorkspaceObservation = event.observation;
+        workspaceObservationRows.set(event.observation.observationId, {
+          sequence,
+          observation: event.observation,
+        });
         break;
       case 'heavy_task_evidence_recorded':
         if (!appendCompactEvidence(projection, event.evidence)) {
@@ -417,6 +472,7 @@ export function projectTaskRun(events: readonly TaskEvent[], taskRunId?: string)
 
   projection.attempts = [...attempts.values()];
   projection.inboxItems = [...inboxItems.values()];
+  refreshHeavyTaskSelfCheckFreshness(projection, events, workspaceObservationRows);
   projection.latestVerifierResult = preferredVerifierResult(projection.verifierResults);
   projection.latestScoreResult = preferredScoreResult(projection.scoreResults, projection.latestVerifierResult);
   if (projection.latestScoreResult) {
@@ -467,7 +523,14 @@ class InMemoryTaskRunStore implements TaskRunStore {
   }
 
   async readEvents(taskRunId: string): Promise<TaskEvent[]> {
-    return [...(this.events.get(taskRunId) ?? [])];
+    return (await this.readEventRecords(taskRunId)).map((record) => record.event);
+  }
+
+  async readEventRecords(taskRunId: string): Promise<TaskEventLedgerEntry[]> {
+    return (this.events.get(taskRunId) ?? []).map((event, sequence) => ({
+      event,
+      cursor: taskEventCursor(taskRunId, sequence, event.id),
+    }));
   }
 
   async project(taskRunId: string): Promise<TaskRunProjection> {
@@ -495,6 +558,10 @@ class FileTaskRunStore implements TaskRunStore {
   }
 
   async readEvents(taskRunId: string): Promise<TaskEvent[]> {
+    return (await this.readEventRecords(taskRunId)).map((record) => record.event);
+  }
+
+  async readEventRecords(taskRunId: string): Promise<TaskEventLedgerEntry[]> {
     let content: string;
     try {
       content = await readFile(this.taskRunPath(taskRunId), 'utf8');
@@ -504,24 +571,29 @@ class FileTaskRunStore implements TaskRunStore {
     }
 
     const lines = content.endsWith('\n') ? content.split('\n') : content.split('\n').slice(0, -1);
-    const events: TaskEvent[] = [];
+    const records: TaskEventLedgerEntry[] = [];
     for (let i = 0; i < lines.length; i += 1) {
       const line = lines[i];
       if (!line) continue;
+      let event: TaskEvent;
       try {
-        events.push(JSON.parse(line) as TaskEvent);
+        event = JSON.parse(line) as TaskEvent;
       } catch (error) {
-        events.push({
+        event = {
           type: 'event_corrupt',
           id: `corrupt-${i + 1}`,
           taskRunId,
           ts: 0,
           raw: line,
           error: errorMessage(error),
-        });
+        };
       }
+      records.push({
+        event,
+        cursor: taskEventCursor(taskRunId, records.length, event.id),
+      });
     }
-    return events;
+    return records;
   }
 
   async project(taskRunId: string): Promise<TaskRunProjection> {
@@ -540,6 +612,10 @@ class FileTaskRunStore implements TaskRunStore {
 function setOptionalRefs(projection: TaskRunProjection, sessionId: string | undefined, agentRunId: string | undefined): void {
   if (sessionId) projection.sessionId = sessionId;
   if (agentRunId) projection.agentRunId = agentRunId;
+}
+
+function taskEventCursor(taskRunId: string, sequence: number, eventId: string): ExecutionLogCursor {
+  return { ledger: 'task_event', streamId: taskRunId, sequence, eventId };
 }
 
 function validTaskAttemptExecutionEvidence(
@@ -604,6 +680,133 @@ function validHeavyTaskEvidenceProvenance(
   }
   return provenance;
 }
+
+function validHeavyTaskSelfCheckProvenance(
+  event: Extract<TaskEvent, { type: 'heavy_task_self_check_evidence_linked' }>,
+  selfCheck: HeavyTaskSelfCheckProjection,
+  selfCheckSequence: number,
+  selfCheckEventId: string,
+  observationRow: { sequence: number; observation: HeavyTaskWorkspaceObservationState } | undefined,
+  warnings: string[],
+): ExecutionEvidenceRef | undefined {
+  const validation = validateExecutionEvidenceRef(event.provenance);
+  if (!validation.ok) {
+    warnings.push(
+      `ignored self-check evidence link ${event.id}: ${validation.errors
+        .map((issue) => `${issue.path}: ${issue.message}`)
+        .join('; ')}`,
+    );
+    return undefined;
+  }
+  const provenance = validation.value;
+  if (
+    provenance.task?.taskRunId !== event.taskRunId
+    || provenance.task.attemptId !== event.attemptId
+    || selfCheck.taskRunId !== event.taskRunId
+    || selfCheck.attemptId !== event.attemptId
+  ) {
+    warnings.push(`ignored self-check evidence link ${event.id}: TaskRun or attempt identity does not match`);
+    return undefined;
+  }
+  if (!provenance.execution?.agentRunId || !provenance.runtimeCoverage || !provenance.taskCoverage || !provenance.workspace) {
+    warnings.push(`ignored self-check evidence link ${event.id}: Runtime coverage, Task coverage, and workspace revision are required`);
+    return undefined;
+  }
+  if (
+    (selfCheck.source.sessionId && selfCheck.source.sessionId !== provenance.execution.sessionId)
+    || (selfCheck.source.agentRunId && selfCheck.source.agentRunId !== provenance.execution.agentRunId)
+    || (selfCheck.source.turnId && selfCheck.source.turnId !== provenance.execution.turnId)
+  ) {
+    warnings.push(`ignored self-check evidence link ${event.id}: Runtime identity does not match the Self-check source`);
+    return undefined;
+  }
+  const taskHighWater = provenance.taskCoverage.highWater;
+  if (
+    taskHighWater.ledger !== 'task_event'
+    || taskHighWater.streamId !== event.taskRunId
+    || taskHighWater.sequence !== selfCheckSequence
+    || taskHighWater.eventId !== selfCheckEventId
+  ) {
+    warnings.push(`ignored self-check evidence link ${event.id}: Task high water does not identify the Self-check record`);
+    return undefined;
+  }
+  if (
+    !observationRow
+    || observationRow.sequence <= selfCheckSequence
+    || observationRow.observation.status !== 'ok'
+    || !observationRow.observation.revision
+  ) {
+    warnings.push(`ignored self-check evidence link ${event.id}: referenced post-check workspace observation is missing`);
+    return undefined;
+  }
+  if (!sameWorkspaceRevision(provenance.workspace, observationRow.observation.revision)) {
+    warnings.push(`ignored self-check evidence link ${event.id}: workspace revision does not match the referenced observation`);
+    return undefined;
+  }
+  return provenance;
+}
+
+function refreshHeavyTaskSelfCheckFreshness(
+  projection: TaskRunProjection,
+  events: readonly TaskEvent[],
+  observationRows: ReadonlyMap<string, { sequence: number; observation: HeavyTaskWorkspaceObservationState }>,
+): void {
+  projection.heavyTaskSelfChecks = projection.heavyTaskSelfChecks.map((selfCheck) => {
+    if (!selfCheck.provenance || !selfCheck.workspaceObservationId) {
+      return withSelfCheckFreshness(selfCheck, 'unknown', ['source_binding_missing']);
+    }
+    const baseline = observationRows.get(selfCheck.workspaceObservationId);
+    if (!baseline?.observation.revision) {
+      return withSelfCheckFreshness(selfCheck, 'unknown', ['workspace_observation_missing']);
+    }
+    const laterObservations = [...observationRows.values()]
+      .filter((row) => row.sequence >= baseline.sequence && row.observation.status === 'ok' && row.observation.revision)
+      .sort((left, right) => left.sequence - right.sequence);
+    const latestObservation = laterObservations.at(-1) ?? baseline;
+    if (!sameWorkspaceRevision(selfCheck.provenance.workspace, latestObservation.observation.revision)) {
+      return withSelfCheckFreshness(selfCheck, 'stale', ['workspace_revision_changed']);
+    }
+    const hasLaterMutation = events.some((event, sequence) => (
+      sequence > latestObservation.sequence
+      && invalidatesSelfCheckWorkspace(event, selfCheck.attemptId)
+    ));
+    if (hasLaterMutation) {
+      return withSelfCheckFreshness(selfCheck, 'stale', ['later_workspace_mutation']);
+    }
+    return withSelfCheckFreshness(selfCheck, 'current', []);
+  });
+  projection.latestHeavyTaskSelfCheck = projection.heavyTaskSelfChecks.at(-1);
+}
+
+function withSelfCheckFreshness(
+  selfCheck: HeavyTaskSelfCheckProjection,
+  freshness: HeavyTaskSelfCheckProjection['freshness'],
+  freshnessReasons: HeavyTaskSelfCheckFreshnessReason[],
+): HeavyTaskSelfCheckProjection {
+  return { ...selfCheck, freshness, freshnessReasons };
+}
+
+function invalidatesSelfCheckWorkspace(event: TaskEvent, attemptId: string | undefined): boolean {
+  if (event.type !== 'heavy_task_evidence_recorded') return false;
+  if (!attemptId || event.evidence.attemptId !== attemptId) return false;
+  if (event.evidence.kind === 'artifact') return true;
+  if (event.evidence.kind !== 'tool') return false;
+  return ['Bash', 'Write', 'Edit'].includes(event.evidence.tool?.name ?? event.evidence.source.toolName ?? '');
+}
+
+function sameWorkspaceRevision(
+  left: ExecutionEvidenceRef['workspace'],
+  right: ExecutionEvidenceRef['workspace'],
+): boolean {
+  return Boolean(
+    left
+    && right
+    && left.kind === right.kind
+    && left.ref === right.ref
+    && left.dirty === right.dirty,
+  );
+}
+
 
 function resultFromScore(score: ScoreResult | undefined, verifier: VerifierResult | undefined): TaskRunResult | undefined {
   if (!score) return undefined;

--- a/packages/headless/src/task-self-check-evidence.ts
+++ b/packages/headless/src/task-self-check-evidence.ts
@@ -1,0 +1,113 @@
+import {
+  EXECUTION_EVIDENCE_REF_SCHEMA_VERSION,
+  validateExecutionEvidenceRef,
+  type ExecutionEvidenceRef,
+} from '@maka/core/execution-evidence';
+import type { RuntimeEvent } from '@maka/core/runtime-event';
+import type {
+  HeavyTaskSelfCheckEvidenceLinkedEvent,
+  HeavyTaskSelfCheckRecordedEvent,
+  HeavyTaskWorkspaceObservationRecordedEvent,
+} from './task-contracts.js';
+import type { TaskEventLedgerEntry } from './task-run-store.js';
+import { runtimeToolFactCoverage } from './task-evidence-provenance.js';
+
+export interface SelfCheckEvidenceBindingInput {
+  taskRunId: string;
+  attemptId: string;
+  sessionId: string;
+  invocationId: string;
+  agentRunId: string;
+  turnId: string;
+  runtimeEvents: readonly RuntimeEvent[];
+  selfCheckRecord: TaskEventLedgerEntry & { event: HeavyTaskSelfCheckRecordedEvent };
+  workspaceObservation: HeavyTaskWorkspaceObservationRecordedEvent;
+}
+
+export type SelfCheckEvidenceBindingResult =
+  | {
+      ok: true;
+      link: Omit<HeavyTaskSelfCheckEvidenceLinkedEvent, 'id' | 'ts'>;
+    }
+  | { ok: false; reason: string };
+
+/**
+ * Bind a durable Self-check assertion to canonical executor facts, the exact
+ * Task Event row that recorded it, and a post-invocation workspace manifest.
+ */
+export function bindSelfCheckEvidence(
+  input: SelfCheckEvidenceBindingInput,
+): SelfCheckEvidenceBindingResult {
+  const selfCheck = input.selfCheckRecord.event.selfCheck;
+  const observation = input.workspaceObservation.observation;
+  if (selfCheck.taskRunId !== input.taskRunId || input.selfCheckRecord.event.taskRunId !== input.taskRunId) {
+    return { ok: false, reason: 'Self-check does not belong to the TaskRun' };
+  }
+  if (selfCheck.attemptId !== input.attemptId) {
+    return { ok: false, reason: 'Self-check does not belong to the attempt' };
+  }
+  if (
+    (selfCheck.source.sessionId && selfCheck.source.sessionId !== input.sessionId)
+    || (selfCheck.source.agentRunId && selfCheck.source.agentRunId !== input.agentRunId)
+    || (selfCheck.source.turnId && selfCheck.source.turnId !== input.turnId)
+  ) {
+    return { ok: false, reason: 'Self-check source does not match the Runtime invocation' };
+  }
+  if (
+    observation.taskRunId !== input.taskRunId
+    || input.workspaceObservation.taskRunId !== input.taskRunId
+    || observation.status !== 'ok'
+    || !observation.revision
+  ) {
+    return { ok: false, reason: 'A successful workspace manifest revision is required' };
+  }
+
+  const runtimeCoverage = runtimeToolFactCoverage({
+    sessionId: input.sessionId,
+    invocationId: input.invocationId,
+    agentRunId: input.agentRunId,
+    turnId: input.turnId,
+    runtimeEvents: input.runtimeEvents,
+    toolCallId: selfCheck.source.toolCallId,
+    toolName: 'self_check_submit',
+    requireCall: true,
+  });
+  if (!runtimeCoverage) {
+    return { ok: false, reason: 'Matching Self-check function call and response are required' };
+  }
+
+  const provenance: ExecutionEvidenceRef = {
+    schemaVersion: EXECUTION_EVIDENCE_REF_SCHEMA_VERSION,
+    execution: {
+      sessionId: input.sessionId,
+      invocationId: input.invocationId,
+      agentRunId: input.agentRunId,
+      turnId: input.turnId,
+    },
+    task: { taskRunId: input.taskRunId, attemptId: input.attemptId },
+    runtimeCoverage,
+    taskCoverage: {
+      highWater: input.selfCheckRecord.cursor,
+      eventCount: input.selfCheckRecord.cursor.sequence + 1,
+    },
+    workspace: observation.revision,
+  };
+  const validation = validateExecutionEvidenceRef(provenance);
+  if (!validation.ok) {
+    return {
+      ok: false,
+      reason: validation.errors.map((issue) => `${issue.path}: ${issue.message}`).join('; '),
+    };
+  }
+  return {
+    ok: true,
+    link: {
+      type: 'heavy_task_self_check_evidence_linked',
+      taskRunId: input.taskRunId,
+      selfCheckId: selfCheck.selfCheckId,
+      attemptId: input.attemptId,
+      workspaceObservationId: observation.observationId,
+      provenance: validation.value,
+    },
+  };
+}


### PR DESCRIPTION
## Summary

Phase 2B of #948 makes heavy-task Self-check freshness a replay-derived property of the execution evidence spine.

- add stable zero-based Task Event ledger cursors for in-memory and file-backed stores
- bind each accepted Self-check to its exact Runtime `function_call` / `function_response` range, the Self-check Task Event high water, and a post-run workspace manifest revision
- compute content-addressed workspace revisions from public file size/hash facts
- replay Self-check freshness as `current`, `stale`, or backward-compatible `unknown`
- invalidate a bound Self-check after later Bash/Write/Edit/artifact evidence until a matching workspace observation revalidates it
- make the heavy-task gate and semantic finalization reject explicitly stale Self-checks

## Invariants

- the model-authored Self-check payload cannot declare its own provenance
- provenance is appended as a separate system-owned Task Event
- Task Events reference canonical Runtime facts instead of copying raw tool payloads
- a Self-check link is accepted only when its Task high water identifies the exact durable Self-check row
- legacy Self-checks remain `unknown` rather than being falsely treated as freshly bound

## Verification

- `npm --workspace @maka/headless test` (924 tests: 923 passed, 1 skipped)
- `npm run typecheck`

Depends on and follows merged Phase 2A: #953.