### PR TITLE
feat(runtime): bind compaction checkpoints to source coverage

### DIFF
--- a/docs/execution-evidence-spine.md
+++ b/docs/execution-evidence-spine.md
@@ -1,6 +1,6 @@
 # Execution Identity and Evidence Spine
 
-Status: Phase 0 contract, Phase 1 Runtime-to-Task lineage, and Phase 2A Runtime provenance for compact task evidence. See [issue #948](https://github.com/maka-agent/maka-agent/issues/948).
+Status: Phase 0 contract, Phase 1 Runtime-to-Task lineage, and Phase 2A-2C evidence freshness and Compaction coverage. See [issue #948](https://github.com/maka-agent/maka-agent/issues/948).
 
 Maka already records the facts needed to explain an execution. Runtime Events preserve model and tool interaction facts, AgentRun records operational lifecycle, and Task Events preserve durable task-control decisions. The missing piece is a shared way to reference those facts across subsystem boundaries.
 
@@ -41,7 +41,23 @@ Phase 2A binds compact heavy-task evidence back to executor-owned Runtime facts:
 
 System-created artifacts, external verifier artifacts, and replay-derived Self-check envelopes keep their existing authority records. Phase 2A does not invent a Runtime source for facts that were not durably recorded from a Runtime tool call.
 
-The current delivery still does not add Task Event cursors, Self-check freshness or workspace invalidation, Compaction integration, AHE lineage, or a general inspection command.
+Phase 2B makes accepted heavy-task Self-check freshness replay-derived:
+
+- Task Event stores expose stable zero-based append cursors;
+- system-owned provenance binds the Self-check to its exact Runtime call/result range, Task Event high water, and post-run workspace manifest revision;
+- replay reports `current`, `stale`, or backward-compatible `unknown` freshness;
+- later mutation evidence invalidates a bound Self-check until a matching workspace observation revalidates it;
+- the completion gate rejects explicitly stale Self-checks without pretending that legacy evidence is fresh.
+
+Phase 2C binds each newly written Compaction checkpoint to the exact ordered Runtime Event projection it summarizes:
+
+- `maka.compactable_runtime_event_projection.v1` names the session-scoped ordering and filtering policy;
+- inclusive low/high cursors identify the first and last source Runtime Event, while the existing digest still validates the complete ordered prefix;
+- prefix matching returns the successor Runtime Events that remain outside the lossy projection;
+- legacy V2 checkpoints remain readable, but a source-bound checkpoint cannot be replaced or recovered behind a legacy checkpoint that cannot prove cursor semantics;
+- the canonical Runtime Event ledger remains untouched and authoritative.
+
+The current delivery still does not add AHE lineage, recovery modeling for ambiguous external side effects, or a general inspection command.
 
 ## Existing authorities
 
@@ -113,7 +129,7 @@ An ordered cursor has three required coordinates:
 
 ```ts
 interface ExecutionLogCursor {
-  ledger: 'runtime_event' | 'task_event';
+  ledger: 'runtime_event' | 'runtime_event_projection' | 'task_event';
   streamId: string;
   sequence: number;
   eventId?: string;
@@ -133,9 +149,10 @@ The planned stream bindings are:
 | Ledger | `streamId` |
 | --- | --- |
 | `runtime_event` | `execution.agentRunId` |
+| `runtime_event_projection` | session id, interpreted only with its adjacent projection policy version |
 | `task_event` | `task.taskRunId` |
 
-Phase 0 defines these semantics but does not claim that current stores already persist the ordinal. Existing Runtime Event ids are best-effort unique identifiers, not durable ordered cursors. Existing Compaction `highWaterSeq` values remain policy-local until a later integration explicitly maps them to source-log coverage.
+Canonical Runtime and Task cursors use physical append ordinals. A `runtime_event_projection` cursor is intentionally different: it is an ordinal in a named, versioned projection whose owner must publish the ordering and filtering policy beside the cursor. Cursors from that projection are therefore incomparable with canonical `runtime_event` cursors even when their boundary `eventId` values happen to match. Existing Runtime Event ids remain audit pointers, not ordering fields, and Compaction's legacy `highWaterSeq` remains a checkpoint-local value rather than a source-log cursor.
 
 For Phase 1 headless lineage, the persisted AgentRun Runtime Event JSONL is the ordered stream. Mutable partial snapshot files are excluded, while every physical JSONL row—including a lifecycle row that may carry `partial: true`—retains its append position. Those immutable positions are materialized as zero-based cursor sequences. A completed invocation therefore records coverage such as:
 
@@ -148,6 +165,8 @@ TaskRun task-42 / Attempt attempt-2
 The Task Event stores only these references and boundary event ids. Model messages, Tool Calls, Tool Results, and other Runtime facts remain solely in the Runtime Event ledger.
 
 Phase 2A applies the same rule at evidence granularity. A compact Task evidence envelope may display a bounded summary, but its `provenance` points to the immutable Runtime call/result range that owns the exact request and response. Maka requires the canonical `function_response` before creating that link; a planned or interrupted call alone is not proof of an executor result.
+
+Phase 2C applies the cursor contract without falsely describing the Compaction input as one AgentRun append log. Compaction operates on the session/model-context Runtime Event projection, so its checkpoint carries `runtime_event_projection` cursors plus `maka.compactable_runtime_event_projection.v1`. The policy fixes the projection's ordering/filtering semantics; the boundary ids and source digest then fail closed if replay no longer presents the exact covered prefix. Events after the high-water cursor are returned as explicit successor facts and remain raw in provider-visible context.
 
 Coverage is an inclusive range within one stream:
 
@@ -218,12 +237,10 @@ This object says where evidence came from. It does not assert that the evidence 
 
 Later phases should extend the contract without changing fact ownership:
 
-1. Materialize stable append ordinals for Task Event streams, including backward-compatible reads.
-2. Bind workspace observations and artifacts produced outside Runtime tool calls to their appropriate source authorities.
-3. Bind Self-check to Runtime and Task high waters plus a workspace revision, then define deterministic staleness rules.
-4. Map Compaction source coverage to the shared cursor contract while retaining explicit source-event validation.
-5. Carry target snapshot and execution lineage through AHE exports.
-6. Add human-readable and machine-readable inspection surfaces that expose missing, stale, conflicting, or ambiguous lineage.
+1. Bind workspace observations and artifacts produced outside Runtime tool calls to their appropriate source authorities.
+2. Carry target snapshot and execution lineage through AHE exports.
+3. Represent uncertain external-side-effect/commit windows in durable recovery lineage.
+4. Add human-readable and machine-readable inspection surfaces that expose missing, stale, conflicting, or ambiguous lineage.
 
 The guiding invariant is simple:
 

--- a/packages/core/src/__tests__/execution-evidence.test.ts
+++ b/packages/core/src/__tests__/execution-evidence.test.ts
@@ -162,6 +162,10 @@ describe('execution evidence spine contract', () => {
     assert.equal(compareExecutionLogCursors(first, { ...first, eventId: 'other-event' }), 'conflict');
     assert.equal(compareExecutionLogCursors(first, { ...first, streamId: 'run-2' }), 'incomparable');
     assert.equal(compareExecutionLogCursors(first, taskCursor(1, 'task-event-1')), 'incomparable');
+    assert.equal(compareExecutionLogCursors(first, {
+      ...first,
+      ledger: 'runtime_event_projection',
+    }), 'incomparable');
   });
 });
 

--- a/packages/core/src/execution-evidence.ts
+++ b/packages/core/src/execution-evidence.ts
@@ -9,7 +9,11 @@
 
 export const EXECUTION_EVIDENCE_REF_SCHEMA_VERSION = 'maka.execution_evidence_ref.v1' as const;
 
-export const EXECUTION_LOG_LEDGERS = ['runtime_event', 'task_event'] as const;
+export const EXECUTION_LOG_LEDGERS = [
+  'runtime_event',
+  'runtime_event_projection',
+  'task_event',
+] as const;
 export type ExecutionLogLedger = typeof EXECUTION_LOG_LEDGERS[number];
 
 export const WORKSPACE_REVISION_KINDS = [
@@ -44,12 +48,14 @@ export interface TaskIdentityRef {
 }
 
 /**
- * Ordered position in one append-only log stream.
+ * Ordered position in one log or explicitly versioned projection stream.
  *
  * `sequence` is the zero-based append ordinal within (`ledger`, `streamId`).
- * It is the only ordering field. `eventId` is an optional audit/dedup pointer
- * and MUST NOT be used to order events. Cursors from different streams are
- * incomparable.
+ * For canonical Runtime/Task ledgers it is the append ordinal. A
+ * `runtime_event_projection` owner MUST publish the ordering/filter policy
+ * beside the cursor. `sequence` is the only ordering field; `eventId` is an
+ * optional audit/dedup pointer and MUST NOT be used to order events. Cursors
+ * from different streams are incomparable.
  */
 export interface ExecutionLogCursor {
   ledger: ExecutionLogLedger;

--- a/packages/runtime/src/__tests__/history-compact-checkpoint.test.ts
+++ b/packages/runtime/src/__tests__/history-compact-checkpoint.test.ts
@@ -3,6 +3,7 @@ import { describe, test } from 'node:test';
 import type { AgentRunEvent, AgentRunHeader, AgentRunStore } from '@maka/core';
 import type { RuntimeEvent } from '@maka/core/runtime-event';
 import {
+  HISTORY_COMPACT_SOURCE_POLICY_VERSION,
   buildHistoryCompactCheckpoint,
   canReplaceHistoryCompactCheckpoint,
   historyCompactCheckpointToRuntimeEvent,
@@ -27,7 +28,25 @@ describe('history compact checkpoint', () => {
     assert.equal(checkpoint.coverage.eventCount, 10_000);
     assert.equal(checkpoint.coverage.turnCount, 5_000);
     assert.equal(checkpoint.coverage.through.runtimeEventId, 'event-9999');
-    assert.equal(matchHistoryCompactCheckpointPrefix(checkpoint, events).coveredEventCount, 10_000);
+    assert.equal(checkpoint.source?.policyVersion, HISTORY_COMPACT_SOURCE_POLICY_VERSION);
+    assert.deepEqual(checkpoint.source?.coverage, {
+      lowWater: {
+        ledger: 'runtime_event_projection',
+        streamId: 'session-1',
+        sequence: 0,
+        eventId: 'event-0',
+      },
+      highWater: {
+        ledger: 'runtime_event_projection',
+        streamId: 'session-1',
+        sequence: 9_999,
+        eventId: 'event-9999',
+      },
+      eventCount: 10_000,
+    });
+    const prefixMatch = matchHistoryCompactCheckpointPrefix(checkpoint, [...events, textEvent(10_000)]);
+    assert.equal(prefixMatch.coveredEventCount, 10_000);
+    assert.deepEqual(prefixMatch.successorRuntimeEvents.map((event) => event.id), ['event-10000']);
     const replay = applyRuntimeEventHistoryCompact([...events, textEvent(10_000)], {
       maxHistoryEstimatedTokens: 1_000_000,
       charsPerToken: 1,
@@ -50,7 +69,7 @@ describe('history compact checkpoint', () => {
     assert.equal(matchHistoryCompactCheckpointPrefix(checkpoint, changed).reason, 'source_hash_mismatch');
     assert.equal(
       matchHistoryCompactCheckpointPrefix(checkpoint, [events[1]!, events[0]!, ...events.slice(2)]).reason,
-      'source_hash_mismatch',
+      'coverage_miss',
     );
   });
 
@@ -60,6 +79,40 @@ describe('history compact checkpoint', () => {
       coveredRuntimeEvents: [textEvent(0)],
       summary: '   ',
     }), /non-empty summary/);
+  });
+
+  test('rejects a source projection assembled from more than one session', () => {
+    assert.throws(() => buildHistoryCompactCheckpoint({
+      sessionId: 'session-1',
+      coveredRuntimeEvents: [textEvent(0), { ...textEvent(1), sessionId: 'session-2' }],
+      summary: 'mixed source',
+    }), /one session/);
+  });
+
+  test('keeps legacy V2 checkpoints readable but rejects inconsistent projection cursors', () => {
+    const events = [textEvent(0), textEvent(1)];
+    const checkpoint = buildHistoryCompactCheckpoint({
+      sessionId: 'session-1', coveredRuntimeEvents: events, summary: 'source-bound',
+    });
+    const { source: _source, ...legacy } = checkpoint;
+    assert.equal(validateHistoryCompactCheckpointShape(legacy, 'session-1'), true);
+    assert.equal(
+      matchHistoryCompactCheckpointPrefix(legacy as typeof checkpoint, events).coveredEventCount,
+      events.length,
+    );
+
+    const invalid = {
+      ...checkpoint,
+      source: {
+        ...checkpoint.source!,
+        coverage: {
+          ...checkpoint.source!.coverage,
+          highWater: { ...checkpoint.source!.coverage.highWater, sequence: 99 },
+        },
+      },
+    };
+    assert.equal(validateHistoryCompactCheckpointShape(invalid, 'session-1'), false);
+    assert.equal(matchHistoryCompactCheckpointPrefix(invalid, events).reason, 'invalid_checkpoint');
   });
 
   test('only accepts an equal-coverage checkpoint as an explicit successor of the same source', () => {
@@ -83,6 +136,8 @@ describe('history compact checkpoint', () => {
     assert.equal(canReplaceHistoryCompactCheckpoint(current, successor), true);
     assert.equal(canReplaceHistoryCompactCheckpoint(current, stale), false);
     assert.equal(canReplaceHistoryCompactCheckpoint(current, differentSource), false);
+    const { source: _source, ...legacySuccessor } = successor;
+    assert.equal(canReplaceHistoryCompactCheckpoint(current, legacySuccessor as typeof successor), false);
   });
 
   test('loads the latest valid checkpoint from the run ledger', async () => {
@@ -136,6 +191,27 @@ describe('history compact checkpoint', () => {
     const loaded = await loadLatestHistoryCompactCheckpointFromRunLedger(store, 'session-1');
 
     assert.equal(loaded?.checkpointId, furthest.checkpointId);
+  });
+
+  test('prefers source-bound recovery over a legacy checkpoint that cannot prove cursor ordering', async () => {
+    const sourceBound = buildHistoryCompactCheckpoint({
+      sessionId: 'session-1', coveredRuntimeEvents: [textEvent(0), textEvent(1)], summary: 'bound',
+    });
+    const legacyBuilt = buildHistoryCompactCheckpoint({
+      sessionId: 'session-1', coveredRuntimeEvents: [textEvent(0), textEvent(1), textEvent(2)], summary: 'legacy',
+    });
+    const { source: _source, ...legacy } = legacyBuilt;
+    const store = new StubAgentRunStore([
+      run('run-bound', 10),
+      run('run-legacy', 20),
+    ], new Map([
+      ['run-bound', [checkpointEvent('ledger-bound', 'run-bound', sourceBound, 10)]],
+      ['run-legacy', [checkpointEvent('ledger-legacy', 'run-legacy', legacy as typeof legacyBuilt, 20)]],
+    ]));
+
+    const loaded = await loadLatestHistoryCompactCheckpointFromRunLedger(store, 'session-1');
+
+    assert.equal(loaded?.checkpointId, sourceBound.checkpointId);
   });
 
   test('recovers the tip of an out-of-order same-coverage successor chain across runs', async () => {

--- a/packages/runtime/src/ai-sdk-backend.ts
+++ b/packages/runtime/src/ai-sdk-backend.ts
@@ -2247,7 +2247,7 @@ export class AiSdkBackend implements AgentBackend {
       : undefined;
     const previousCheckpoint = checkpointMatch && !checkpointMatch.reason ? loadedCheckpoint : undefined;
     const newlyFoldedRuntimeEvents = previousCheckpoint
-      ? foldedRuntimeEvents.slice(checkpointMatch!.coveredEventCount)
+      ? checkpointMatch!.successorRuntimeEvents
       : foldedRuntimeEvents;
     const retainedRuntimeEvents = input.priorRuntimeContext.filter((event) =>
       !foldedIds.has(event.id) && !event.id.startsWith('history-compact:')

--- a/packages/runtime/src/context-budget.ts
+++ b/packages/runtime/src/context-budget.ts
@@ -729,8 +729,7 @@ export function applyRuntimeEventHistoryCompact(
     if (match.reason) {
       increment(skippedReasonCounts, match.reason);
     } else {
-      const uncoveredFoldedEvents = foldedEvents.slice(match.coveredEventCount);
-      const replayTail = [...uncoveredFoldedEvents, ...retainedEvents];
+      const replayTail = [...match.successorRuntimeEvents, ...retainedEvents];
       const fit = evaluateHistoryCompactCheckpointReplay(checkpoint, replayTail, policy!, {
         charsPerToken,
         maxHistoryEstimatedTokens: maxTokens,

--- a/packages/runtime/src/history-compact-checkpoint.ts
+++ b/packages/runtime/src/history-compact-checkpoint.ts
@@ -1,7 +1,18 @@
 import { createHash } from 'node:crypto';
 import { Buffer } from 'node:buffer';
+import type { ExecutionLogCoverage } from '@maka/core/execution-evidence';
 import type { RuntimeEvent } from '@maka/core/runtime-event';
 import { stableStringify } from './request-shape.js';
+
+export const HISTORY_COMPACT_SOURCE_POLICY_VERSION = 'maka.compactable_runtime_event_projection.v1' as const;
+
+export interface HistoryCompactCheckpointSource {
+  schemaVersion: 1;
+  kind: 'runtime_event_projection';
+  policyVersion: typeof HISTORY_COMPACT_SOURCE_POLICY_VERSION;
+  /** Inclusive cursor range in the policy-versioned, session-scoped projection. */
+  coverage: ExecutionLogCoverage;
+}
 
 export interface HistoryCompactCheckpointCoverage {
   eventCount: number;
@@ -22,6 +33,8 @@ export interface HistoryCompactCheckpoint {
   createdAt: number;
   highWaterName: string;
   highWaterSeq: number;
+  /** Present on evidence-spine checkpoints; omitted only on legacy V2 data. */
+  source?: HistoryCompactCheckpointSource;
   coverage: HistoryCompactCheckpointCoverage;
   summary: string;
   limitations: string[];
@@ -42,14 +55,27 @@ export interface BuildHistoryCompactCheckpointInput {
 }
 
 export type HistoryCompactCheckpointPrefixMatch =
-  | { coveredEventCount: number; coveredRuntimeEvents: RuntimeEvent[]; reason?: undefined }
-  | { coveredEventCount: 0; coveredRuntimeEvents: []; reason: 'invalid_checkpoint' | 'coverage_miss' | 'source_hash_mismatch' };
+  | {
+      coveredEventCount: number;
+      coveredRuntimeEvents: RuntimeEvent[];
+      successorRuntimeEvents: RuntimeEvent[];
+      reason?: undefined;
+    }
+  | {
+      coveredEventCount: 0;
+      coveredRuntimeEvents: [];
+      successorRuntimeEvents: [];
+      reason: 'invalid_checkpoint' | 'coverage_miss' | 'source_hash_mismatch';
+    };
 
 export function buildHistoryCompactCheckpoint(
   input: BuildHistoryCompactCheckpointInput,
 ): HistoryCompactCheckpoint {
   if (input.coveredRuntimeEvents.length === 0) {
     throw new Error('History compact checkpoint requires covered RuntimeEvents');
+  }
+  if (input.coveredRuntimeEvents.some((event) => event.sessionId !== input.sessionId)) {
+    throw new Error('History compact checkpoint source events must belong to one session');
   }
   const summary = input.summary.trim();
   if (summary.length === 0) {
@@ -77,11 +103,13 @@ export function buildHistoryCompactCheckpoint(
   };
   const highWaterName = input.highWaterName ?? 'history-compact-high-water';
   const highWaterSeq = input.highWaterSeq ?? createdAt;
+  const source = historyCompactCheckpointSource(input.sessionId, input.coveredRuntimeEvents);
   const checkpointId = `hcheckpoint-${sha256(stableStringify({
     version: 2,
     sessionId: input.sessionId,
     highWaterName,
     highWaterSeq,
+    source,
     coverage,
     summary: boundedSummary,
     previousCheckpointId: input.previousCheckpointId,
@@ -94,6 +122,7 @@ export function buildHistoryCompactCheckpoint(
     createdAt,
     highWaterName,
     highWaterSeq,
+    source,
     coverage,
     summary: boundedSummary,
     limitations: [
@@ -112,6 +141,9 @@ export function renderHistoryCompactCheckpoint(checkpoint: HistoryCompactCheckpo
     `<maka_history_compact_checkpoint id="${escapeAttribute(checkpoint.checkpointId)}" high_water="${escapeAttribute(checkpoint.highWaterName)}" seq="${checkpoint.highWaterSeq}" version="${checkpoint.version}">`,
     `summary: ${checkpoint.summary}`,
     `coverage: ${checkpoint.coverage.eventCount} runtime events across ${checkpoint.coverage.turnCount} turns`,
+    ...(checkpoint.source ? [
+      `source: ${checkpoint.source.policyVersion} ${checkpoint.source.coverage.lowWater?.sequence ?? 0}-${checkpoint.source.coverage.highWater.sequence}`,
+    ] : []),
     `limitations: ${checkpoint.limitations.join('; ')}`,
     '</maka_history_compact_checkpoint>',
   ].join('\n');
@@ -156,6 +188,11 @@ export function validateHistoryCompactCheckpointShape(
     && nonEmpty(through?.turnId)
     && nonEmpty(through?.runtimeEventId)
     && nonEmpty(coverage?.sourceDigest)
+    && (checkpoint.source === undefined || validHistoryCompactCheckpointSource(
+      checkpoint.source,
+      checkpoint.sessionId,
+      coverage,
+    ))
     && typeof checkpoint.summary === 'string'
     && checkpoint.summary.trim().length > 0
     && Array.isArray(checkpoint.limitations)
@@ -170,6 +207,10 @@ export function canReplaceHistoryCompactCheckpoint(
   current: HistoryCompactCheckpoint | undefined,
   candidate: HistoryCompactCheckpoint,
 ): boolean {
+  if (current?.source && !candidate.source) return false;
+  if (current?.source && candidate.source && !sameHistoryCompactSourceStream(current.source, candidate.source)) {
+    return false;
+  }
   if (!current || candidate.coverage.eventCount > current.coverage.eventCount) return true;
   if (
     candidate.coverage.eventCount !== current.coverage.eventCount
@@ -181,7 +222,8 @@ export function canReplaceHistoryCompactCheckpoint(
     && candidate.coverage.sourceDigest === current.coverage.sourceDigest
     && candidate.coverage.through.runId === current.coverage.through.runId
     && candidate.coverage.through.turnId === current.coverage.through.turnId
-    && candidate.coverage.through.runtimeEventId === current.coverage.through.runtimeEventId;
+    && candidate.coverage.through.runtimeEventId === current.coverage.through.runtimeEventId
+    && (!current.source || sameHistoryCompactSourceCoverage(current.source, candidate.source));
 }
 
 export function matchHistoryCompactCheckpointPrefix(
@@ -189,23 +231,111 @@ export function matchHistoryCompactCheckpointPrefix(
   events: readonly RuntimeEvent[],
 ): HistoryCompactCheckpointPrefixMatch {
   if (!validateHistoryCompactCheckpointShape(checkpoint)) {
-    return { coveredEventCount: 0, coveredRuntimeEvents: [], reason: 'invalid_checkpoint' };
+    return { coveredEventCount: 0, coveredRuntimeEvents: [], successorRuntimeEvents: [], reason: 'invalid_checkpoint' };
   }
   const coveredRuntimeEvents = events.slice(0, checkpoint.coverage.eventCount);
+  const successorRuntimeEvents = events.slice(checkpoint.coverage.eventCount);
+  const firstEvent = coveredRuntimeEvents[0];
   const lastEvent = coveredRuntimeEvents.at(-1);
   if (
     coveredRuntimeEvents.length !== checkpoint.coverage.eventCount
+    || coveredRuntimeEvents.some((event) => event.sessionId !== checkpoint.sessionId)
+    || !firstEvent
     || !lastEvent
     || lastEvent.runId !== checkpoint.coverage.through.runId
     || lastEvent.turnId !== checkpoint.coverage.through.turnId
     || lastEvent.id !== checkpoint.coverage.through.runtimeEventId
   ) {
-    return { coveredEventCount: 0, coveredRuntimeEvents: [], reason: 'coverage_miss' };
+    return { coveredEventCount: 0, coveredRuntimeEvents: [], successorRuntimeEvents: [], reason: 'coverage_miss' };
+  }
+  if (
+    checkpoint.source
+    && (
+      checkpoint.source.coverage.lowWater?.eventId !== firstEvent.id
+      || checkpoint.source.coverage.highWater.eventId !== lastEvent.id
+    )
+  ) {
+    return { coveredEventCount: 0, coveredRuntimeEvents: [], successorRuntimeEvents: [], reason: 'coverage_miss' };
   }
   if (historyCompactSourceDigest(coveredRuntimeEvents) !== checkpoint.coverage.sourceDigest) {
-    return { coveredEventCount: 0, coveredRuntimeEvents: [], reason: 'source_hash_mismatch' };
+    return { coveredEventCount: 0, coveredRuntimeEvents: [], successorRuntimeEvents: [], reason: 'source_hash_mismatch' };
   }
-  return { coveredEventCount: coveredRuntimeEvents.length, coveredRuntimeEvents };
+  return { coveredEventCount: coveredRuntimeEvents.length, coveredRuntimeEvents, successorRuntimeEvents };
+}
+
+function historyCompactCheckpointSource(
+  sessionId: string,
+  events: readonly RuntimeEvent[],
+): HistoryCompactCheckpointSource {
+  const first = events[0]!;
+  const last = events.at(-1)!;
+  return {
+    schemaVersion: 1,
+    kind: 'runtime_event_projection',
+    policyVersion: HISTORY_COMPACT_SOURCE_POLICY_VERSION,
+    coverage: {
+      lowWater: {
+        ledger: 'runtime_event_projection',
+        streamId: sessionId,
+        sequence: 0,
+        eventId: first.id,
+      },
+      highWater: {
+        ledger: 'runtime_event_projection',
+        streamId: sessionId,
+        sequence: events.length - 1,
+        eventId: last.id,
+      },
+      eventCount: events.length,
+    },
+  };
+}
+
+function validHistoryCompactCheckpointSource(
+  source: HistoryCompactCheckpointSource,
+  sessionId: string | undefined,
+  legacyCoverage: Partial<HistoryCompactCheckpointCoverage> | undefined,
+): boolean {
+  const low = source.coverage?.lowWater;
+  const high = source.coverage?.highWater;
+  return source.schemaVersion === 1
+    && source.kind === 'runtime_event_projection'
+    && source.policyVersion === HISTORY_COMPACT_SOURCE_POLICY_VERSION
+    && low?.ledger === 'runtime_event_projection'
+    && high?.ledger === 'runtime_event_projection'
+    && low.streamId === sessionId
+    && high.streamId === sessionId
+    && low.sequence === 0
+    && Number.isSafeInteger(high.sequence)
+    && high.sequence === (legacyCoverage?.eventCount ?? 0) - 1
+    && source.coverage.eventCount === legacyCoverage?.eventCount
+    && nonEmpty(low.eventId)
+    && nonEmpty(high.eventId)
+    && high.eventId === legacyCoverage?.through?.runtimeEventId;
+}
+
+function sameHistoryCompactSourceStream(
+  current: HistoryCompactCheckpointSource,
+  candidate: HistoryCompactCheckpointSource,
+): boolean {
+  return current.policyVersion === candidate.policyVersion
+    && current.coverage.highWater.ledger === candidate.coverage.highWater.ledger
+    && current.coverage.highWater.streamId === candidate.coverage.highWater.streamId;
+}
+
+function sameHistoryCompactSourceCoverage(
+  current: HistoryCompactCheckpointSource,
+  candidate: HistoryCompactCheckpointSource | undefined,
+): boolean {
+  return Boolean(
+    candidate
+    && sameHistoryCompactSourceStream(current, candidate)
+    && current.coverage.lowWater?.sequence === candidate.coverage.lowWater?.sequence
+    && current.coverage.lowWater?.eventId === candidate.coverage.lowWater?.eventId
+    && current.coverage.highWater.sequence === candidate.coverage.highWater.sequence
+    && current.coverage.highWater.eventId === candidate.coverage.highWater.eventId
+    && current.coverage.eventCount === candidate.coverage.eventCount,
+  );
 }
 
 function historyCompactSourceDigest(events: readonly RuntimeEvent[]): string {

--- a/packages/runtime/src/history-compact-ledger.ts
+++ b/packages/runtime/src/history-compact-ledger.ts
@@ -61,11 +61,16 @@ export async function loadLatestHistoryCompactCheckpointFromRunLedger(
 function selectRecoveredCheckpoint(
   candidates: readonly LedgerCheckpointCandidate[],
 ): LedgerCheckpointCandidate | undefined {
-  const maxCoverage = candidates.reduce(
+  // Once source-bound checkpoints exist, never recover a legacy checkpoint
+  // that cannot prove its projection ordering/cursors, even if it was written
+  // later by an older binary.
+  const sourceBound = candidates.filter((candidate) => candidate.checkpoint.source !== undefined);
+  const compatible = sourceBound.length > 0 ? sourceBound : candidates;
+  const maxCoverage = compatible.reduce(
     (max, candidate) => Math.max(max, candidate.checkpoint.coverage.eventCount),
     0,
   );
-  const furthest = candidates.filter(
+  const furthest = compatible.filter(
     (candidate) => candidate.checkpoint.coverage.eventCount === maxCoverage,
   );
   const byCheckpointId = new Map(

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -384,6 +384,22 @@ export type {
   HistoryCompactArtifactStore,
   PersistHistoryCompactBlocksDeps,
 } from './history-compact-artifacts.js';
+export {
+  HISTORY_COMPACT_SOURCE_POLICY_VERSION,
+  buildHistoryCompactCheckpoint,
+  canReplaceHistoryCompactCheckpoint,
+  historyCompactCheckpointToRuntimeEvent,
+  matchHistoryCompactCheckpointPrefix,
+  renderHistoryCompactCheckpoint,
+  validateHistoryCompactCheckpointShape,
+} from './history-compact-checkpoint.js';
+export type {
+  BuildHistoryCompactCheckpointInput,
+  HistoryCompactCheckpoint,
+  HistoryCompactCheckpointCoverage,
+  HistoryCompactCheckpointPrefixMatch,
+  HistoryCompactCheckpointSource,
+} from './history-compact-checkpoint.js';
 export { cleanupLegacyHistoryCompactArtifacts } from './history-compact-cleanup.js';
 export type {
   HistoryCompactCleanupDiagnostic,

--- a/packages/storage/src/__tests__/agent-run-store.test.ts
+++ b/packages/storage/src/__tests__/agent-run-store.test.ts
@@ -230,6 +230,60 @@ describe('AgentRunStore', () => {
     });
   });
 
+  it('does not let a legacy append or repair downgrade a source-bound checkpoint projection', async () => {
+    await withStore(async (store) => {
+      const projectionStore = store as typeof store & {
+        readEventProjection(
+          sessionId: string,
+          type: AgentRunEvent['type'],
+        ): Promise<AgentRunEvent | null | undefined>;
+        repairEventProjection(
+          sessionId: string,
+          type: AgentRunEvent['type'],
+          event: AgentRunEvent | null,
+        ): Promise<void>;
+      };
+      const sourceBound = makeEvent({
+        type: 'history_compact_checkpoint_recorded',
+        id: 'checkpoint-source-bound',
+        data: {
+          checkpoint: {
+            coverage: { eventCount: 2 },
+            source: { kind: 'runtime_event_projection' },
+          },
+        },
+      });
+      const legacy = makeEvent({
+        type: 'history_compact_checkpoint_recorded',
+        id: 'checkpoint-legacy',
+        data: { checkpoint: { coverage: { eventCount: 99 } } },
+      });
+      await store.createRun(makeHeader());
+      await store.appendEvent('session-1', sourceBound.runId, sourceBound);
+      await store.appendEvent('session-1', legacy.runId, legacy);
+
+      assert.equal(
+        (await projectionStore.readEventProjection(
+          'session-1',
+          'history_compact_checkpoint_recorded',
+        ))?.id,
+        sourceBound.id,
+      );
+
+      await projectionStore.repairEventProjection(
+        'session-1',
+        'history_compact_checkpoint_recorded',
+        legacy,
+      );
+
+      const projected = await projectionStore.readEventProjection(
+        'session-1',
+        'history_compact_checkpoint_recorded',
+      );
+      assert.equal(projected?.id, sourceBound.id);
+    });
+  });
+
   it('replaces the same parseable but semantically invalid projection during repair', async () => {
     await withStore(async (store, root) => {
       const projectionStore = store as typeof store & {

--- a/packages/storage/src/agent-run-store.ts
+++ b/packages/storage/src/agent-run-store.ts
@@ -99,9 +99,18 @@ class FileAgentRunStore implements AgentRunStore {
     assertSafeId(runId, 'Invalid run id');
     if (event.type === 'history_compact_checkpoint_recorded') {
       await this.withProjectionQueue(sessionId, event.type, async () => {
+        let current: AgentRunEvent | null | undefined;
+        try {
+          current = await this.readEventProjectionUnlocked(sessionId, event.type);
+        } catch {
+          current = undefined;
+        }
         await rm(this.eventProjectionPath(sessionId, event.type), { force: true });
         await this.appendRunEvent(sessionId, runId, event);
-        await this.writeEventProjectionUnlocked(sessionId, event.type, event).catch(() => {
+        const projected = shouldPreserveCheckpointProjectionDuringAppend(current, event)
+          ? current!
+          : event;
+        await this.writeEventProjectionUnlocked(sessionId, event.type, projected).catch(() => {
           // The canonical event is durable; a missing derived projection safely replays raw history.
         });
       });
@@ -281,6 +290,20 @@ class FileAgentRunStore implements AgentRunStore {
   }
 }
 
+function shouldPreserveCheckpointProjectionDuringAppend(
+  current: AgentRunEvent | null | undefined,
+  candidate: AgentRunEvent,
+): boolean {
+  if (!current) return false;
+  const currentSourceBound = historyCompactProjectionIsSourceBound(current);
+  const candidateSourceBound = historyCompactProjectionIsSourceBound(candidate);
+  if (currentSourceBound !== candidateSourceBound) return currentSourceBound;
+  const currentCoverage = historyCompactProjectionCoverage(current);
+  const candidateCoverage = historyCompactProjectionCoverage(candidate);
+  return currentCoverage !== undefined
+    && (candidateCoverage === undefined || currentCoverage > candidateCoverage);
+}
+
 function shouldPreserveProjectionDuringRepair(
   current: AgentRunEvent | null | undefined,
   candidate: AgentRunEvent | null,
@@ -288,10 +311,21 @@ function shouldPreserveProjectionDuringRepair(
 ): boolean {
   if (!current) return false;
   if (type !== 'history_compact_checkpoint_recorded') return true;
+  const currentSourceBound = historyCompactProjectionIsSourceBound(current);
+  const candidateSourceBound = candidate ? historyCompactProjectionIsSourceBound(candidate) : false;
+  if (currentSourceBound !== candidateSourceBound) return currentSourceBound;
   const currentCoverage = historyCompactProjectionCoverage(current);
   const candidateCoverage = candidate && historyCompactProjectionCoverage(candidate);
   return currentCoverage !== undefined
     && (candidateCoverage === null || candidateCoverage === undefined || currentCoverage >= candidateCoverage);
+}
+
+function historyCompactProjectionIsSourceBound(event: AgentRunEvent): boolean {
+  const checkpoint = event.data?.checkpoint;
+  if (!checkpoint || typeof checkpoint !== 'object') return false;
+  const source = (checkpoint as { source?: unknown }).source;
+  if (!source || typeof source !== 'object') return false;
+  return (source as { kind?: unknown }).kind === 'runtime_event_projection';
 }
 
 function historyCompactProjectionCoverage(event: AgentRunEvent): number | undefined {


### PR DESCRIPTION
## Summary

Phase 2C of #948 makes durable history Compaction checkpoints explicit projections over a validated source prefix.

- add a versioned runtime_event_projection cursor ledger for policy-owned ordered projections
- bind every newly built V2 checkpoint to the inclusive source range under maka.compactable_runtime_event_projection.v1
- validate session, boundary event ids, projection ordinals, event count, and the existing full-prefix digest before replay
- return successor Runtime Events from the prefix matcher and use that result in both replay and rolling Compaction
- preserve source-bound checkpoints against legacy downgrade during append, repair, and canonical-ledger recovery
- keep source-less legacy V2 checkpoints readable when no stronger source-bound checkpoint exists
- update the evidence-spine architecture document through Phase 2C

## Invariants

- Compaction remains a lossy provider-visible projection; Runtime Events remain canonical facts
- projection cursors are not misrepresented as AgentRun append-log cursors
- cursor sequence is meaningful only within the adjacent versioned projection policy and session stream
- exact source mismatch fails closed before a checkpoint can replace raw history
- successor facts remain outside the compacted prefix and replay raw

## Compatibility

The V2 durable shape remains backward compatible: source is optional only for records written before Phase 2C, while the current builder always writes it. Once a valid source-bound checkpoint exists, older binaries cannot silently move the bounded projection or recovery result back to an unbound legacy checkpoint.

## Verification

- npm --workspace @maka/core test
- npm --workspace @maka/storage test
- npm --workspace @maka/runtime test
- npm run typecheck
- git diff --check

All passed locally.