### PR TITLE
feat(headless): inspect end-to-end task lineage

### DIFF
--- a/docs/execution-evidence-spine.md
+++ b/docs/execution-evidence-spine.md
@@ -1,6 +1,6 @@
 # Execution Identity and Evidence Spine
 
-Status: Phase 0 contract, Phase 1 Runtime-to-Task lineage, and Phase 2A-2C evidence freshness and Compaction coverage. See [issue #948](https://github.com/maka-agent/maka-agent/issues/948).
+Status: Phase 0 contract, Phase 1 Runtime-to-Task lineage, Phase 2A-2C evidence freshness and Compaction coverage, and Phase 3A TaskRun inspection. See [issue #948](https://github.com/maka-agent/maka-agent/issues/948).
 
 Maka already records the facts needed to explain an execution. Runtime Events preserve model and tool interaction facts, AgentRun records operational lifecycle, and Task Events preserve durable task-control decisions. The missing piece is a shared way to reference those facts across subsystem boundaries.
 
@@ -57,7 +57,16 @@ Phase 2C binds each newly written Compaction checkpoint to the exact ordered Run
 - legacy V2 checkpoints remain readable, but a source-bound checkpoint cannot be replaced or recovered behind a legacy checkpoint that cannot prove cursor semantics;
 - the canonical Runtime Event ledger remains untouched and authoritative.
 
-The current delivery still does not add AHE lineage, recovery modeling for ambiguous external side effects, or a general inspection command.
+Phase 3A makes the TaskRun lineage directly inspectable:
+
+- `maka eval task-run inspect <taskRunId> --store <root>` renders a human-readable TaskRun → Attempt → AgentRun tree;
+- `--json` emits the versioned `maka.task_run_inspect.v1` machine contract from the same read model;
+- the inspector joins Task Event cursors to linked AgentRun and Runtime ledgers, then checks claimed Runtime coverage against observed boundary facts;
+- Tool Call/Response gaps, stale or unknown Self-checks, invalid Compaction records, missing AgentRuns, and projection warnings remain explicit structured diagnostics;
+- output carries identities, cursors, counts, and health facts, not copies of raw model messages, tool arguments, or tool results;
+- a Tool Call without a committed response is reported as an unknown outcome whose external side effects may have occurred, never inferred as success or failure.
+
+The current delivery still does not add AHE lineage, durable recovery modeling for ambiguous external side effects, or the general `maka inspect <sessionId|agentRunId|taskRunId>` resolver.
 
 ## Existing authorities
 
@@ -240,7 +249,7 @@ Later phases should extend the contract without changing fact ownership:
 1. Bind workspace observations and artifacts produced outside Runtime tool calls to their appropriate source authorities.
 2. Carry target snapshot and execution lineage through AHE exports.
 3. Represent uncertain external-side-effect/commit windows in durable recovery lineage.
-4. Add human-readable and machine-readable inspection surfaces that expose missing, stale, conflicting, or ambiguous lineage.
+4. Extend the Phase 3A TaskRun inspector into a general Session/AgentRun/TaskRun id resolver without weakening its explicit unknown and gap semantics.
 
 The guiding invariant is simple:
 

--- a/packages/headless/src/__tests__/cli.test.ts
+++ b/packages/headless/src/__tests__/cli.test.ts
@@ -407,7 +407,16 @@ describe('maka-headless CLI', () => {
 
       const inspect = await runCli(['task', 'inspect', 'task-run-1', '--store', join(outDir, 'runs'), '--json']);
       assert.equal(inspect.code, 0, inspect.stderr);
-      assert.equal(JSON.parse(inspect.stdout).taxonomy, 'verification_failed');
+      const inspectDocument = JSON.parse(inspect.stdout);
+      assert.equal(inspectDocument.schemaVersion, 'maka.task_run_inspect.v1');
+      assert.equal(inspectDocument.kind, 'task_run');
+      assert.equal(inspectDocument.taskRun.result.taxonomy, 'verification_failed');
+      assert.ok(Array.isArray(inspectDocument.attempts));
+
+      const humanInspect = await runCli(['task', 'inspect', 'task-run-1', '--store', join(outDir, 'runs')]);
+      assert.equal(humanInspect.code, 0, humanInspect.stderr);
+      assert.match(humanInspect.stdout, /TaskRun task-run-1 \[/);
+      assert.match(humanInspect.stdout, /Task Events task_event:task-run-1/);
 
       const exportDir = join(dir, 'manual-export');
       const exported = await runCli([
@@ -533,10 +542,11 @@ describe('maka-headless CLI', () => {
       const inspect = await runCli(['task', 'inspect', taskRunId, '--store', join(outDir, 'runs'), '--json']);
       assert.equal(inspect.code, 0, inspect.stderr);
       const projected = JSON.parse(inspect.stdout);
-      assert.equal(projected.status, 'completed');
-      assert.equal(projected.taxonomy, 'passed');
-      assert.equal(projected.attempts, 2);
-      assert.equal(projected.parked, undefined);
+      assert.equal(projected.taskRun.status, 'completed');
+      assert.equal(projected.taskRun.result.taxonomy, 'passed');
+      assert.equal(projected.taskRun.attemptCount, 2);
+      assert.equal(projected.attempts.length, 2);
+      assert.equal(projected.taskRun.parked, undefined);
 
       const exported = JSON.parse(await readFile(join(outDir, 'exports', taskRunId, 'task-run.json'), 'utf8'));
       assert.equal(exported.taskRun.status, 'completed');

--- a/packages/headless/src/__tests__/task-run-inspect.test.ts
+++ b/packages/headless/src/__tests__/task-run-inspect.test.ts
@@ -1,0 +1,280 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, test } from 'node:test';
+import type { AgentRunEvent, AgentRunHeader, RuntimeEvent } from '@maka/core';
+import { buildHistoryCompactCheckpoint } from '@maka/runtime';
+import { createAgentRunStore, createRuntimeEventStore } from '@maka/storage';
+import type { HeavyTaskSemanticSelfCheckState, TaskEvent } from '../task-contracts.js';
+import { taskAttemptExecutionEvidence } from '../task-execution-lineage.js';
+import { createInMemoryTaskRunStore } from '../task-run-store.js';
+import {
+  TASK_RUN_INSPECT_SCHEMA_VERSION,
+  inspectTaskRun,
+  renderTaskRunInspectTree,
+} from '../task-run-inspect.js';
+
+describe('TaskRun inspection', () => {
+  test('joins Task, AgentRun, Runtime, tool, Self-check, and Compaction facts', async () => {
+    await withStores(async ({ taskRunStore, agentRunStore, runtimeEventStore }) => {
+      const runtimeEvents = [
+        runtimeEvent('runtime-user', { role: 'user', author: 'user', content: { kind: 'text', text: 'go' } }),
+        runtimeEvent('runtime-call', {
+          role: 'model', author: 'agent',
+          content: { kind: 'function_call', id: 'tool-1', name: 'Bash', args: { command: 'npm test' } },
+        }),
+        runtimeEvent('runtime-response', {
+          role: 'tool', author: 'tool',
+          content: { kind: 'function_response', id: 'tool-1', name: 'Bash', result: { exitCode: 0 } },
+        }),
+        runtimeEvent('runtime-complete', {
+          role: 'system', author: 'system', status: 'completed', actions: { endInvocation: true },
+        }),
+      ];
+      await agentRunStore.createRun(runHeader());
+      await agentRunStore.appendEvent(SESSION_ID, RUN_ID, runEvent('run-started', 'run_started'));
+      for (const event of runtimeEvents) await runtimeEventStore.appendRuntimeEvent(SESSION_ID, RUN_ID, event);
+      const checkpoint = buildHistoryCompactCheckpoint({
+        sessionId: SESSION_ID,
+        coveredRuntimeEvents: runtimeEvents.slice(0, 2),
+        summary: 'User requested a public test run.',
+      });
+      await agentRunStore.appendEvent(SESSION_ID, RUN_ID, {
+        ...runEvent('checkpoint-recorded', 'history_compact_checkpoint_recorded'),
+        data: { checkpoint },
+      });
+      await agentRunStore.appendEvent(SESSION_ID, RUN_ID, runEvent('run-completed', 'run_completed'));
+
+      const events: TaskEvent[] = [
+        { type: 'task_run_created', id: 'task-created', taskRunId: TASK_RUN_ID, ts: 1, taskId: 'task-1', configId: 'config-1' },
+        { type: 'task_attempt_started', id: 'attempt-started', taskRunId: TASK_RUN_ID, ts: 2, attemptId: ATTEMPT_ID },
+        {
+          type: 'task_attempt_execution_linked', id: 'execution-linked', taskRunId: TASK_RUN_ID, ts: 3,
+          attemptId: ATTEMPT_ID,
+          evidence: taskAttemptExecutionEvidence({
+            taskRunId: TASK_RUN_ID,
+            attemptId: ATTEMPT_ID,
+            sessionId: SESSION_ID,
+            agentRunId: RUN_ID,
+            invocationId: INVOCATION_ID,
+            turnId: TURN_ID,
+            runtimeEvents,
+          }),
+        },
+        {
+          type: 'heavy_task_self_check_recorded', id: 'self-check-recorded', taskRunId: TASK_RUN_ID, ts: 4,
+          selfCheck: acceptedSelfCheck(),
+        },
+        {
+          type: 'task_attempt_completed', id: 'attempt-completed', taskRunId: TASK_RUN_ID, ts: 5,
+          attemptId: ATTEMPT_ID, status: 'completed',
+        },
+        {
+          type: 'task_run_completed', id: 'task-completed', taskRunId: TASK_RUN_ID, ts: 6,
+          result: { passed: true, taxonomy: 'passed' },
+        },
+      ];
+      for (const event of events) await taskRunStore.appendEvent(TASK_RUN_ID, event);
+
+      const inspected = await inspectTaskRun({ taskRunStore, agentRunStore, runtimeEventStore }, TASK_RUN_ID);
+
+      assert.equal(inspected.schemaVersion, TASK_RUN_INSPECT_SCHEMA_VERSION);
+      assert.deepEqual(inspected.taskEventSource.coverage, {
+        lowWater: { ledger: 'task_event', streamId: TASK_RUN_ID, sequence: 0, eventId: 'task-created' },
+        highWater: { ledger: 'task_event', streamId: TASK_RUN_ID, sequence: 5, eventId: 'task-completed' },
+        eventCount: 6,
+      });
+      assert.equal(inspected.taskRun.result?.taxonomy, 'passed');
+      assert.equal(inspected.attempts[0]?.agentRuns[0]?.coverageStatus, 'matched');
+      assert.equal(inspected.attempts[0]?.agentRuns[0]?.runtimeEventCount, 4);
+      assert.deepEqual(inspected.attempts[0]?.agentRuns[0]?.tools, {
+        callCount: 1,
+        responseCount: 1,
+        errorResponseCount: 0,
+        callsWithoutResponse: [],
+        responsesWithoutCall: [],
+      });
+      assert.equal(inspected.attempts[0]?.agentRuns[0]?.compactionCheckpoints[0]?.checkpointId, checkpoint.checkpointId);
+      assert.equal(inspected.attempts[0]?.selfChecks[0]?.freshness, 'unknown');
+      assert.equal(inspected.diagnostics.some((item) => item.code === 'self_check_source_unknown'), true);
+      const tree = renderTaskRunInspectTree(inspected);
+      assert.match(tree, /TaskRun task-run-1 \[completed\]/);
+      assert.match(tree, /AgentRun run-1 \[completed\]/);
+      assert.match(tree, /Runtime Events runtime_event:run-1 0–3 \[matched\]/);
+      assert.match(tree, /Compaction hcheckpoint-/);
+      assert.match(tree, /Self-check self-check-1 \[pass; unknown\]/);
+    });
+  });
+
+  test('fails coverage closed and reports unknown tool outcomes without copying payloads', async () => {
+    await withStores(async ({ taskRunStore, agentRunStore, runtimeEventStore }) => {
+      const runtimeEvents = [
+        runtimeEvent('runtime-call', {
+          role: 'model', author: 'agent',
+          content: { kind: 'function_call', id: 'tool-pending', name: 'Write', args: { path: 'secret.txt', content: 'secret' } },
+        }),
+        runtimeEvent('runtime-complete', {
+          role: 'system', author: 'system', status: 'failed', actions: { endInvocation: true },
+        }),
+      ];
+      await agentRunStore.createRun(runHeader({ status: 'failed', failureClass: 'tool_failed' }));
+      await agentRunStore.appendEvent(SESSION_ID, RUN_ID, {
+        ...runEvent('invalid-checkpoint', 'history_compact_checkpoint_recorded'),
+        data: { checkpoint: { kind: 'maka.history_compact_checkpoint', version: 2 } },
+      });
+      await agentRunStore.appendEvent(SESSION_ID, RUN_ID, runEvent('run-failed', 'run_failed'));
+      for (const event of runtimeEvents) await runtimeEventStore.appendRuntimeEvent(SESSION_ID, RUN_ID, event);
+      const evidence = taskAttemptExecutionEvidence({
+        taskRunId: TASK_RUN_ID,
+        attemptId: ATTEMPT_ID,
+        sessionId: SESSION_ID,
+        agentRunId: RUN_ID,
+        runtimeEvents,
+      });
+      evidence.runtimeCoverage!.highWater.eventId = 'not-the-terminal-event';
+      const events: TaskEvent[] = [
+        { type: 'task_run_created', id: 'task-created', taskRunId: TASK_RUN_ID, ts: 1, taskId: 'task-1', configId: 'config-1' },
+        { type: 'task_attempt_started', id: 'attempt-started', taskRunId: TASK_RUN_ID, ts: 2, attemptId: ATTEMPT_ID },
+        {
+          type: 'task_attempt_execution_linked', id: 'execution-linked', taskRunId: TASK_RUN_ID, ts: 3,
+          attemptId: ATTEMPT_ID, evidence,
+        },
+      ];
+      for (const event of events) await taskRunStore.appendEvent(TASK_RUN_ID, event);
+
+      const inspected = await inspectTaskRun({ taskRunStore, agentRunStore, runtimeEventStore }, TASK_RUN_ID);
+
+      assert.equal(inspected.attempts[0]?.agentRuns[0]?.coverageStatus, 'mismatch');
+      assert.deepEqual(inspected.attempts[0]?.agentRuns[0]?.tools.callsWithoutResponse, [{
+        toolCallId: 'tool-pending', toolName: 'Write', eventId: 'runtime-call',
+      }]);
+      assert.equal(inspected.diagnostics.some((item) => item.code === 'runtime_coverage_mismatch'), true);
+      assert.equal(inspected.diagnostics.some((item) => item.code === 'tool_response_missing'), true);
+      assert.equal(inspected.diagnostics.some((item) => item.code === 'compaction_checkpoint_invalid'), true);
+      assert.equal(inspected.attempts[0]?.agentRuns[0]?.compactionCheckpoints[0]?.validation, 'invalid');
+      assert.equal(JSON.stringify(inspected).includes('secret.txt'), false);
+      assert.match(
+        inspected.diagnostics.find((item) => item.code === 'tool_response_missing')?.message ?? '',
+        /side effects are unknown/,
+      );
+    });
+  });
+
+  test('keeps legacy unknowns visible when AgentRun source facts or Self-check scope are absent', async () => {
+    await withStores(async ({ taskRunStore, agentRunStore, runtimeEventStore }) => {
+      const events: TaskEvent[] = [
+        { type: 'task_run_created', id: 'task-created', taskRunId: TASK_RUN_ID, ts: 1, taskId: 'task-1', configId: 'config-1' },
+        { type: 'task_attempt_started', id: 'attempt-started', taskRunId: TASK_RUN_ID, ts: 2, attemptId: ATTEMPT_ID },
+        {
+          type: 'task_attempt_execution_linked', id: 'legacy-link', taskRunId: TASK_RUN_ID, ts: 3,
+          attemptId: ATTEMPT_ID,
+          evidence: {
+            schemaVersion: 'maka.execution_evidence_ref.v1',
+            execution: { sessionId: SESSION_ID, agentRunId: 'missing-run' },
+            task: { taskRunId: TASK_RUN_ID, attemptId: ATTEMPT_ID },
+          },
+        },
+        {
+          type: 'heavy_task_self_check_recorded', id: 'legacy-self-check', taskRunId: TASK_RUN_ID, ts: 4,
+          selfCheck: acceptedSelfCheck(null),
+        },
+      ];
+      for (const event of events) await taskRunStore.appendEvent(TASK_RUN_ID, event);
+
+      const inspected = await inspectTaskRun({ taskRunStore, agentRunStore, runtimeEventStore }, TASK_RUN_ID);
+
+      assert.equal(inspected.attempts[0]?.agentRuns[0]?.identity?.agentRunId, 'missing-run');
+      assert.equal(inspected.attempts[0]?.agentRuns[0]?.coverageStatus, 'source_missing');
+      assert.equal(inspected.unscopedSelfChecks[0]?.selfCheckId, 'self-check-1');
+      assert.equal(inspected.diagnostics.some((item) => item.code === 'agent_run_unavailable'), true);
+      assert.equal(inspected.diagnostics.some((item) => item.code === 'self_check_source_unknown'), true);
+      assert.match(renderTaskRunInspectTree(inspected), /Self-check self-check-1 \[pass; unknown\] \(unscoped\)/);
+    });
+  });
+});
+
+const TASK_RUN_ID = 'task-run-1';
+const ATTEMPT_ID = 'attempt-1';
+const SESSION_ID = 'session-1';
+const RUN_ID = 'run-1';
+const INVOCATION_ID = 'invocation-1';
+const TURN_ID = 'turn-1';
+
+async function withStores(
+  run: (stores: {
+    taskRunStore: ReturnType<typeof createInMemoryTaskRunStore>;
+    agentRunStore: ReturnType<typeof createAgentRunStore>;
+    runtimeEventStore: ReturnType<typeof createRuntimeEventStore>;
+  }) => Promise<void>,
+): Promise<void> {
+  const root = await mkdtemp(join(tmpdir(), 'maka-task-run-inspect-'));
+  try {
+    await run({
+      taskRunStore: createInMemoryTaskRunStore(),
+      agentRunStore: createAgentRunStore(root),
+      runtimeEventStore: createRuntimeEventStore(root),
+    });
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+}
+
+function runHeader(overrides: Partial<AgentRunHeader> = {}): AgentRunHeader {
+  return {
+    runId: RUN_ID,
+    invocationId: INVOCATION_ID,
+    sessionId: SESSION_ID,
+    turnId: TURN_ID,
+    status: 'completed',
+    backendKind: 'fake',
+    llmConnectionSlug: 'fake',
+    modelId: 'fake-model',
+    cwd: '/tmp/workspace',
+    permissionMode: 'ask',
+    createdAt: 1,
+    updatedAt: 10,
+    completedAt: 10,
+    ...overrides,
+  };
+}
+
+function runEvent(id: string, type: AgentRunEvent['type']): AgentRunEvent {
+  return { id, type, runId: RUN_ID, sessionId: SESSION_ID, turnId: TURN_ID, ts: 10 };
+}
+
+function runtimeEvent(id: string, overrides: Partial<RuntimeEvent>): RuntimeEvent {
+  return {
+    id,
+    invocationId: INVOCATION_ID,
+    runId: RUN_ID,
+    sessionId: SESSION_ID,
+    turnId: TURN_ID,
+    ts: 5,
+    partial: false,
+    role: 'system',
+    author: 'system',
+    ...overrides,
+  };
+}
+
+function acceptedSelfCheck(attemptId: string | null = ATTEMPT_ID): HeavyTaskSemanticSelfCheckState {
+  return {
+    schemaVersion: 1,
+    selfCheckId: 'self-check-1',
+    taskRunId: TASK_RUN_ID,
+    ...(attemptId ? { attemptId } : {}),
+    ts: 4,
+    status: 'pass',
+    publicReason: 'Public test completed.',
+    commandEvidence: [{ command: 'npm test', exitCode: 0, outputExcerpt: 'passed' }],
+    artifactEvidence: [],
+    guard: {
+      status: 'accepted',
+      checkedAt: 4,
+      categories: [],
+      publicReason: 'Accepted public evidence.',
+    },
+    source: { kind: 'model_tool', toolCallId: 'self-check-tool' },
+  };
+}

--- a/packages/headless/src/cli.ts
+++ b/packages/headless/src/cli.ts
@@ -4,6 +4,7 @@ import { realpathSync } from 'node:fs';
 import { readFile, stat, writeFile } from 'node:fs/promises';
 import { dirname, isAbsolute, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { createAgentRunStore, createRuntimeEventStore } from '@maka/storage';
 import type { Config, ResultRecord, Task } from './contracts.js';
 import { runAutonomousTask } from './autonomous-agent-loop.js';
 import { harborCommand } from './harbor-cli.js';
@@ -21,6 +22,7 @@ import { backendNeedsIsolation, validateTaskVerification } from './runner.js';
 import { runTaskOnce } from './task-agent-controller.js';
 import { isTerminalTaskRunStatus, type TaskPermissionGrant } from './task-contracts.js';
 import { createTaskRunStore, type TaskRunProjection } from './task-run-store.js';
+import { inspectTaskRun, renderTaskRunInspectTree } from './task-run-inspect.js';
 import { readResults, toComparisonTable, writeResults } from './results.js';
 
 /**
@@ -181,11 +183,16 @@ async function taskInspectCommand(args: string[]): Promise<number> {
     console.error('usage: maka eval task-run inspect <taskRunId> --store <out>/runs [--json]');
     return 1;
   }
-  const projection = await createTaskRunStore(resolve(parsed.flags.store)).project(taskRunId);
+  const storageRoot = resolve(parsed.flags.store);
+  const document = await inspectTaskRun({
+    taskRunStore: createTaskRunStore(storageRoot),
+    agentRunStore: createAgentRunStore(storageRoot),
+    runtimeEventStore: createRuntimeEventStore(storageRoot),
+  }, taskRunId);
   if (parsed.bools.json) {
-    process.stdout.write(`${JSON.stringify(compactInspect(projection), null, 2)}\n`);
+    process.stdout.write(`${JSON.stringify(document, null, 2)}\n`);
   } else {
-    printInspect(compactInspect(projection));
+    process.stdout.write(renderTaskRunInspectTree(document));
   }
   return 0;
 }
@@ -583,38 +590,6 @@ function positiveInt(raw: string, flagName: string): number {
   const value = Number(raw);
   if (!Number.isInteger(value) || value < 1) throw new Error(`${flagName} must be a positive integer`);
   return value;
-}
-
-function compactInspect(projection: TaskRunProjection): Record<string, unknown> {
-  const score = projection.latestScoreResult;
-  const verifier = projection.latestVerifierResult;
-  return {
-    taskRunId: projection.taskRunId,
-    taskId: projection.taskId,
-    configId: projection.configId,
-    status: projection.status,
-    terminal: isTerminalTaskRunStatus(projection.status),
-    taxonomy: score?.taxonomy ?? projection.result?.taxonomy,
-    passed: score?.passed ?? projection.result?.passed,
-    scored: score?.scored,
-    eligible: score?.eligible,
-    errorClass: score?.errorClass ?? verifier?.errorClass ?? projection.error?.class,
-    verifier: verifier
-      ? { id: verifier.id, kind: verifier.kind, exitCode: verifier.exitCode ?? null, passed: verifier.passed }
-      : undefined,
-    score: score ? { id: score.id, score: score.score, maxScore: score.maxScore } : undefined,
-    attempts: projection.attempts.length,
-    parked: projection.parked,
-    isolation: projection.isolation?.label ?? projection.isolation?.mode,
-    warnings: projection.warnings,
-  };
-}
-
-function printInspect(value: Record<string, unknown>): void {
-  for (const [key, item] of Object.entries(value)) {
-    if (item === undefined) continue;
-    process.stdout.write(`${key}: ${typeof item === 'object' ? JSON.stringify(item) : String(item)}\n`);
-  }
 }
 
 if (isMainModule()) {

--- a/packages/headless/src/index.ts
+++ b/packages/headless/src/index.ts
@@ -146,6 +146,27 @@ export {
 } from './permission-grants.js';
 export type { TaskEventLedgerEntry, TaskRunProjection, TaskRunStore } from './task-run-store.js';
 export { createInMemoryTaskRunStore, createTaskRunStore, projectTaskRun } from './task-run-store.js';
+export {
+  TASK_RUN_INSPECT_SCHEMA_VERSION,
+  inspectTaskRun,
+  renderTaskRunInspectTree,
+} from './task-run-inspect.js';
+export type {
+  InspectTaskRunDependencies,
+  TaskRunInspectAgentRun,
+  TaskRunInspectAttempt,
+  TaskRunInspectCompactionCheckpoint,
+  TaskRunInspectCoverageStatus,
+  TaskRunInspectDiagnostic,
+  TaskRunInspectDiagnosticCode,
+  TaskRunInspectDocument,
+  TaskRunInspectSelfCheck,
+  TaskRunInspectSeverity,
+  TaskRunInspectSummary,
+  TaskRunInspectTaskEventSource,
+  TaskRunInspectToolFact,
+  TaskRunInspectToolSummary,
+} from './task-run-inspect.js';
 export type { TaskEventsFromResultRecordOptions } from './task-run-adapter.js';
 export {
   resultRecordFromTaskRunProjection,

--- a/packages/headless/src/task-run-inspect.ts
+++ b/packages/headless/src/task-run-inspect.ts
@@ -1,0 +1,585 @@
+import type {
+  AgentRunHeader,
+  AgentRunStore,
+  RuntimeEvent,
+  RuntimeEventStore,
+} from '@maka/core';
+import type {
+  ExecutionEvidenceRef,
+  ExecutionIdentityRef,
+  ExecutionLogCoverage,
+  WorkspaceRevisionRef,
+} from '@maka/core/execution-evidence';
+import {
+  inspectAgentRunReadModel,
+  type AgentRunInspectDiagnostic,
+  type AgentRunInspectSourceHealth,
+} from '@maka/runtime/agent-run-inspect';
+import {
+  validateHistoryCompactCheckpointShape,
+  type HistoryCompactCheckpoint,
+} from '@maka/runtime';
+import { isTerminalTaskRunStatus, type HeavyTaskSelfCheckProjection, type TaskAttempt } from './task-contracts.js';
+import { projectTaskRun, type TaskRunProjection, type TaskRunStore } from './task-run-store.js';
+
+export const TASK_RUN_INSPECT_SCHEMA_VERSION = 'maka.task_run_inspect.v1' as const;
+
+export type TaskRunInspectSeverity = 'error' | 'warning' | 'info';
+
+export type TaskRunInspectDiagnosticCode =
+  | 'task_projection_warning'
+  | 'attempt_execution_missing'
+  | 'execution_identity_missing'
+  | 'agent_run_unavailable'
+  | 'agent_run_source_diagnostic'
+  | 'runtime_coverage_unknown'
+  | 'runtime_coverage_source_missing'
+  | 'runtime_coverage_mismatch'
+  | 'tool_response_missing'
+  | 'tool_call_missing'
+  | 'self_check_stale'
+  | 'self_check_source_unknown'
+  | 'compaction_checkpoint_invalid';
+
+export interface TaskRunInspectDiagnostic {
+  severity: TaskRunInspectSeverity;
+  code: TaskRunInspectDiagnosticCode;
+  message: string;
+  taskRunId: string;
+  attemptId?: string;
+  sessionId?: string;
+  agentRunId?: string;
+  eventId?: string;
+  detail?: Record<string, unknown>;
+}
+
+export interface TaskRunInspectSummary {
+  taskRunId: string;
+  taskId: string;
+  configId: string;
+  status: TaskRunProjection['status'];
+  terminal: boolean;
+  attemptCount: number;
+  eventCount: number;
+  startedAt?: number;
+  finishedAt?: number;
+  result?: {
+    passed: boolean;
+    taxonomy: string;
+  };
+  errorClass?: string;
+  parked?: TaskRunProjection['parked'];
+}
+
+export interface TaskRunInspectTaskEventSource {
+  eventCount: number;
+  coverage?: ExecutionLogCoverage;
+}
+
+export type TaskRunInspectCoverageStatus =
+  | 'matched'
+  | 'unknown'
+  | 'source_missing'
+  | 'mismatch';
+
+export interface TaskRunInspectToolFact {
+  toolCallId: string;
+  toolName: string;
+  eventId: string;
+}
+
+export interface TaskRunInspectToolSummary {
+  callCount: number;
+  responseCount: number;
+  errorResponseCount: number;
+  callsWithoutResponse: TaskRunInspectToolFact[];
+  responsesWithoutCall: TaskRunInspectToolFact[];
+}
+
+export interface TaskRunInspectCompactionCheckpoint {
+  eventId: string;
+  validation: 'shape_valid' | 'invalid';
+  checkpointId?: string;
+  policyVersion?: string;
+  sourceCoverage?: ExecutionLogCoverage;
+}
+
+export interface TaskRunInspectAgentRun {
+  identity?: ExecutionIdentityRef;
+  status?: AgentRunHeader['status'];
+  claimedCoverage?: ExecutionLogCoverage;
+  observedCoverage?: ExecutionLogCoverage;
+  coverageStatus: TaskRunInspectCoverageStatus;
+  runtimeEventCount: number;
+  sourceHealth?: AgentRunInspectSourceHealth;
+  tools: TaskRunInspectToolSummary;
+  compactionCheckpoints: TaskRunInspectCompactionCheckpoint[];
+}
+
+export interface TaskRunInspectSelfCheck {
+  selfCheckId: string;
+  status: HeavyTaskSelfCheckProjection['status'];
+  freshness: HeavyTaskSelfCheckProjection['freshness'];
+  freshnessReasons: HeavyTaskSelfCheckProjection['freshnessReasons'];
+  workspace?: WorkspaceRevisionRef;
+  runtimeCoverage?: ExecutionLogCoverage;
+  taskCoverage?: ExecutionLogCoverage;
+}
+
+export interface TaskRunInspectAttempt {
+  attemptId: string;
+  status: TaskAttempt['status'];
+  startedAt: number;
+  finishedAt?: number;
+  agentRuns: TaskRunInspectAgentRun[];
+  selfChecks: TaskRunInspectSelfCheck[];
+}
+
+export interface TaskRunInspectDocument {
+  schemaVersion: typeof TASK_RUN_INSPECT_SCHEMA_VERSION;
+  kind: 'task_run';
+  taskRun: TaskRunInspectSummary;
+  taskEventSource: TaskRunInspectTaskEventSource;
+  attempts: TaskRunInspectAttempt[];
+  unscopedSelfChecks: TaskRunInspectSelfCheck[];
+  diagnostics: TaskRunInspectDiagnostic[];
+}
+
+export interface InspectTaskRunDependencies {
+  taskRunStore: TaskRunStore;
+  agentRunStore: AgentRunStore;
+  runtimeEventStore: RuntimeEventStore;
+}
+
+export async function inspectTaskRun(
+  dependencies: InspectTaskRunDependencies,
+  taskRunId: string,
+): Promise<TaskRunInspectDocument> {
+  const records = await dependencies.taskRunStore.readEventRecords(taskRunId);
+  // Project the exact rows whose source coverage is reported below. Calling
+  // `project()` separately could observe a later append and produce a read
+  // model whose advertised Task high water is already stale.
+  const projection = projectTaskRun(records.map((record) => record.event), taskRunId);
+  const diagnostics: TaskRunInspectDiagnostic[] = projection.warnings.map((message) => ({
+    severity: 'warning',
+    code: 'task_projection_warning',
+    message,
+    taskRunId,
+  }));
+  const attempts: TaskRunInspectAttempt[] = [];
+  const attemptIds = new Set(projection.attempts.map((attempt) => attempt.attemptId));
+
+  for (const attempt of projection.attempts) {
+    const agentRuns: TaskRunInspectAgentRun[] = [];
+    if (attempt.executionLineage.length === 0) {
+      diagnostics.push(diagnostic(taskRunId, 'attempt_execution_missing', 'warning',
+        'Attempt has no durable AgentRun execution link.', { attemptId: attempt.attemptId }));
+    }
+    for (const evidence of attempt.executionLineage) {
+      agentRuns.push(await inspectLinkedAgentRun(dependencies, taskRunId, attempt.attemptId, evidence, diagnostics));
+    }
+    const selfChecks = projection.heavyTaskSelfChecks
+      .filter((selfCheck) => selfCheck.attemptId === attempt.attemptId)
+      .map((selfCheck) => inspectSelfCheck(taskRunId, attempt.attemptId, selfCheck, diagnostics));
+    attempts.push({
+      attemptId: attempt.attemptId,
+      status: attempt.status,
+      startedAt: attempt.startedAt,
+      ...(attempt.finishedAt !== undefined ? { finishedAt: attempt.finishedAt } : {}),
+      agentRuns,
+      selfChecks,
+    });
+  }
+
+  return {
+    schemaVersion: TASK_RUN_INSPECT_SCHEMA_VERSION,
+    kind: 'task_run',
+    taskRun: taskRunSummary(projection),
+    taskEventSource: taskEventSource(records),
+    attempts,
+    unscopedSelfChecks: projection.heavyTaskSelfChecks
+      .filter((selfCheck) => !selfCheck.attemptId || !attemptIds.has(selfCheck.attemptId))
+      .map((selfCheck) => inspectSelfCheck(taskRunId, selfCheck.attemptId, selfCheck, diagnostics)),
+    diagnostics,
+  };
+}
+
+async function inspectLinkedAgentRun(
+  dependencies: InspectTaskRunDependencies,
+  taskRunId: string,
+  attemptId: string,
+  evidence: ExecutionEvidenceRef,
+  diagnostics: TaskRunInspectDiagnostic[],
+): Promise<TaskRunInspectAgentRun> {
+  const identity = evidence.execution;
+  if (!identity?.sessionId || !identity.agentRunId) {
+    diagnostics.push(diagnostic(taskRunId, 'execution_identity_missing', 'warning',
+      'Execution link does not identify an AgentRun; source facts remain unknown.', { attemptId }));
+    return emptyAgentRun(identity, evidence.runtimeCoverage);
+  }
+
+  const refs = { attemptId, sessionId: identity.sessionId, agentRunId: identity.agentRunId };
+  try {
+    const inspected = await inspectAgentRunReadModel(
+      dependencies.agentRunStore,
+      dependencies.runtimeEventStore,
+      { sessionId: identity.sessionId, runId: identity.agentRunId },
+    );
+    for (const sourceDiagnostic of inspected.diagnostics) {
+      diagnostics.push(agentRunDiagnostic(taskRunId, refs, sourceDiagnostic));
+    }
+    const observedCoverage = runtimeCoverage(identity.agentRunId, inspected.runtimeEvents);
+    const coverageStatus = inspectRuntimeCoverage(
+      taskRunId,
+      refs,
+      evidence.runtimeCoverage,
+      inspected.runtimeEvents,
+      diagnostics,
+    );
+    const tools = inspectToolFacts(taskRunId, refs, inspected.runtimeEvents, diagnostics);
+    const compactionCheckpoints = inspectCompactionCheckpoints(
+      taskRunId,
+      refs,
+      inspected.events,
+      diagnostics,
+    );
+    return {
+      identity,
+      status: inspected.header.status,
+      ...(evidence.runtimeCoverage ? { claimedCoverage: evidence.runtimeCoverage } : {}),
+      ...(observedCoverage ? { observedCoverage } : {}),
+      coverageStatus,
+      runtimeEventCount: inspected.runtimeEvents.length,
+      sourceHealth: inspected.sourceHealth,
+      tools,
+      compactionCheckpoints,
+    };
+  } catch (error) {
+    diagnostics.push(diagnostic(taskRunId, 'agent_run_unavailable', 'error',
+      'Linked AgentRun could not be read.', {
+        ...refs,
+        detail: { error: errorMessage(error) },
+      }));
+    if (evidence.runtimeCoverage) {
+      diagnostics.push(diagnostic(taskRunId, 'runtime_coverage_source_missing', 'error',
+        'Claimed Runtime coverage cannot be checked because its AgentRun source is unavailable.', refs));
+    }
+    return emptyAgentRun(identity, evidence.runtimeCoverage, 'source_missing');
+  }
+}
+
+function inspectRuntimeCoverage(
+  taskRunId: string,
+  refs: Pick<TaskRunInspectDiagnostic, 'attemptId' | 'sessionId' | 'agentRunId'>,
+  claimed: ExecutionLogCoverage | undefined,
+  events: readonly RuntimeEvent[],
+  diagnostics: TaskRunInspectDiagnostic[],
+): TaskRunInspectCoverageStatus {
+  if (!claimed) {
+    diagnostics.push(diagnostic(taskRunId, 'runtime_coverage_unknown', 'info',
+      'Execution identity is known, but this legacy link has no Runtime Event coverage.', refs));
+    return 'unknown';
+  }
+  if (events.length === 0) {
+    diagnostics.push(diagnostic(taskRunId, 'runtime_coverage_source_missing', 'error',
+      'Claimed Runtime coverage has no readable source events.', refs));
+    return 'source_missing';
+  }
+  const lowSequence = claimed.lowWater?.sequence ?? 0;
+  const highSequence = claimed.highWater.sequence;
+  const low = events[lowSequence];
+  const high = events[highSequence];
+  const observedCount = highSequence >= lowSequence ? highSequence - lowSequence + 1 : 0;
+  const matches = claimed.highWater.ledger === 'runtime_event'
+    && claimed.highWater.streamId === refs.agentRunId
+    && (!claimed.lowWater || (
+      claimed.lowWater.ledger === 'runtime_event'
+      && claimed.lowWater.streamId === refs.agentRunId
+    ))
+    && low !== undefined
+    && high !== undefined
+    && (!claimed.lowWater?.eventId || claimed.lowWater.eventId === low.id)
+    && (!claimed.highWater.eventId || claimed.highWater.eventId === high.id)
+    && (claimed.eventCount === undefined || claimed.eventCount === observedCount);
+  if (matches) return 'matched';
+  diagnostics.push(diagnostic(taskRunId, 'runtime_coverage_mismatch', 'error',
+    'Claimed Runtime coverage does not match the observed AgentRun ledger boundaries.', {
+      ...refs,
+      detail: {
+        claimedLow: claimed.lowWater,
+        claimedHigh: claimed.highWater,
+        claimedEventCount: claimed.eventCount,
+        observedLowEventId: low?.id,
+        observedHighEventId: high?.id,
+        observedEventCount: observedCount,
+      },
+    }));
+  return 'mismatch';
+}
+
+function inspectToolFacts(
+  taskRunId: string,
+  refs: Pick<TaskRunInspectDiagnostic, 'attemptId' | 'sessionId' | 'agentRunId'>,
+  events: readonly RuntimeEvent[],
+  diagnostics: TaskRunInspectDiagnostic[],
+): TaskRunInspectToolSummary {
+  const calls = new Map<string, TaskRunInspectToolFact>();
+  const responses = new Map<string, TaskRunInspectToolFact & { isError: boolean }>();
+  for (const event of events) {
+    if (event.content?.kind === 'function_call') {
+      calls.set(event.content.id, {
+        toolCallId: event.content.id,
+        toolName: event.content.name,
+        eventId: event.id,
+      });
+    } else if (event.content?.kind === 'function_response') {
+      responses.set(event.content.id, {
+        toolCallId: event.content.id,
+        toolName: event.content.name,
+        eventId: event.id,
+        isError: event.content.isError === true,
+      });
+    }
+  }
+  const callsWithoutResponse = [...calls.values()].filter((call) => !responses.has(call.toolCallId));
+  const responsesWithoutCall = [...responses.values()]
+    .filter((response) => !calls.has(response.toolCallId))
+    .map(({ isError: _isError, ...response }) => response);
+  for (const call of callsWithoutResponse) {
+    diagnostics.push(diagnostic(taskRunId, 'tool_response_missing', 'warning',
+      `Tool Call ${call.toolCallId} has no committed Runtime response; its outcome and external side effects are unknown.`, {
+        ...refs,
+        eventId: call.eventId,
+        detail: { toolCallId: call.toolCallId, toolName: call.toolName },
+      }));
+  }
+  for (const response of responsesWithoutCall) {
+    diagnostics.push(diagnostic(taskRunId, 'tool_call_missing', 'warning',
+      `Tool response ${response.toolCallId} has no matching Runtime call fact.`, {
+        ...refs,
+        eventId: response.eventId,
+        detail: { toolCallId: response.toolCallId, toolName: response.toolName },
+      }));
+  }
+  return {
+    callCount: calls.size,
+    responseCount: responses.size,
+    errorResponseCount: [...responses.values()].filter((response) => response.isError).length,
+    callsWithoutResponse,
+    responsesWithoutCall,
+  };
+}
+
+function inspectCompactionCheckpoints(
+  taskRunId: string,
+  refs: Pick<TaskRunInspectDiagnostic, 'attemptId' | 'sessionId' | 'agentRunId'>,
+  events: readonly { type: string; id: string; data?: Record<string, unknown> }[],
+  diagnostics: TaskRunInspectDiagnostic[],
+): TaskRunInspectCompactionCheckpoint[] {
+  const checkpoints: TaskRunInspectCompactionCheckpoint[] = [];
+  for (const event of events) {
+    if (event.type !== 'history_compact_checkpoint_recorded') continue;
+    const checkpoint = event.data?.checkpoint;
+    if (!validateHistoryCompactCheckpointShape(checkpoint, refs.sessionId)) {
+      diagnostics.push(diagnostic(taskRunId, 'compaction_checkpoint_invalid', 'error',
+        'AgentRun contains an invalid durable Compaction checkpoint record.', { ...refs, eventId: event.id }));
+      checkpoints.push({ eventId: event.id, validation: 'invalid' });
+      continue;
+    }
+    const valid = checkpoint as HistoryCompactCheckpoint;
+    checkpoints.push({
+      eventId: event.id,
+      validation: 'shape_valid',
+      checkpointId: valid.checkpointId,
+      ...(valid.source?.policyVersion ? { policyVersion: valid.source.policyVersion } : {}),
+      ...(valid.source?.coverage ? { sourceCoverage: valid.source.coverage } : {}),
+    });
+  }
+  return checkpoints;
+}
+
+function inspectSelfCheck(
+  taskRunId: string,
+  attemptId: string | undefined,
+  selfCheck: HeavyTaskSelfCheckProjection,
+  diagnostics: TaskRunInspectDiagnostic[],
+): TaskRunInspectSelfCheck {
+  if (selfCheck.freshness === 'stale') {
+    diagnostics.push(diagnostic(taskRunId, 'self_check_stale', 'warning',
+      `Self-check ${selfCheck.selfCheckId} is stale.`, {
+        ...(attemptId ? { attemptId } : {}),
+        detail: { freshnessReasons: selfCheck.freshnessReasons },
+      }));
+  } else if (selfCheck.freshness === 'unknown') {
+    diagnostics.push(diagnostic(taskRunId, 'self_check_source_unknown', 'info',
+      `Self-check ${selfCheck.selfCheckId} has no fully validated source binding.`, {
+        ...(attemptId ? { attemptId } : {}),
+        detail: { freshnessReasons: selfCheck.freshnessReasons },
+      }));
+  }
+  return {
+    selfCheckId: selfCheck.selfCheckId,
+    status: selfCheck.status,
+    freshness: selfCheck.freshness,
+    freshnessReasons: [...selfCheck.freshnessReasons],
+    ...(selfCheck.provenance?.workspace ? { workspace: selfCheck.provenance.workspace } : {}),
+    ...(selfCheck.provenance?.runtimeCoverage ? { runtimeCoverage: selfCheck.provenance.runtimeCoverage } : {}),
+    ...(selfCheck.provenance?.taskCoverage ? { taskCoverage: selfCheck.provenance.taskCoverage } : {}),
+  };
+}
+
+export function renderTaskRunInspectTree(document: TaskRunInspectDocument): string {
+  const hasRootTail = document.attempts.length > 0
+    || document.unscopedSelfChecks.length > 0
+    || document.diagnostics.length > 0;
+  const lines = [
+    `TaskRun ${document.taskRun.taskRunId} [${document.taskRun.status}]`,
+    `${hasRootTail ? '├─' : '└─'} Task Events ${formatCoverage(document.taskEventSource.coverage)} (${document.taskEventSource.eventCount})`,
+  ];
+  document.attempts.forEach((attempt, attemptIndex) => {
+    const isLastRootNode = attemptIndex === document.attempts.length - 1
+      && document.unscopedSelfChecks.length === 0
+      && document.diagnostics.length === 0;
+    const rootBranch = isLastRootNode ? '└─' : '├─';
+    const childPrefix = isLastRootNode ? '   ' : '│  ';
+    lines.push(`${rootBranch} Attempt ${attempt.attemptId} [${attempt.status}]`);
+    const attemptChildCount = attempt.agentRuns.length + attempt.selfChecks.length;
+    if (attemptChildCount === 0) lines.push(`${childPrefix}└─ No linked execution facts`);
+    let attemptChildIndex = 0;
+    for (const agentRun of attempt.agentRuns) {
+      attemptChildIndex += 1;
+      const lastAgent = attemptChildIndex === attemptChildCount;
+      const detailPrefix = `${childPrefix}${lastAgent ? '   ' : '│  '}`;
+      lines.push(`${childPrefix}${lastAgent ? '└─' : '├─'} AgentRun ${agentRun.identity?.agentRunId ?? 'unknown'} [${agentRun.status ?? 'unknown'}]`);
+      const details = [
+        `Runtime Events ${formatCoverage(agentRun.claimedCoverage)} [${agentRun.coverageStatus}]`,
+        `Tool Calls ${agentRun.tools.callCount} / Responses ${agentRun.tools.responseCount}`,
+        ...agentRun.compactionCheckpoints.map((checkpoint) =>
+          `Compaction ${checkpoint.checkpointId ?? checkpoint.eventId} ${formatCoverage(checkpoint.sourceCoverage)} [${checkpoint.validation}]`
+        ),
+      ];
+      details.forEach((detail, index) => {
+        lines.push(`${detailPrefix}${index === details.length - 1 ? '└─' : '├─'} ${detail}`);
+      });
+    }
+    for (const selfCheck of attempt.selfChecks) {
+      attemptChildIndex += 1;
+      const lastSelfCheck = attemptChildIndex === attemptChildCount;
+      lines.push(`${childPrefix}${lastSelfCheck ? '└─' : '├─'} Self-check ${selfCheck.selfCheckId} [${selfCheck.status}; ${selfCheck.freshness}]`);
+      if (selfCheck.workspace) {
+        const detailPrefix = `${childPrefix}${lastSelfCheck ? '   ' : '│  '}`;
+        lines.push(`${detailPrefix}└─ Workspace ${selfCheck.workspace.kind}:${selfCheck.workspace.ref}`);
+      }
+    }
+  });
+  document.unscopedSelfChecks.forEach((selfCheck, index) => {
+    const isLast = index === document.unscopedSelfChecks.length - 1 && document.diagnostics.length === 0;
+    lines.push(`${isLast ? '└─' : '├─'} Self-check ${selfCheck.selfCheckId} [${selfCheck.status}; ${selfCheck.freshness}] (unscoped)`);
+  });
+  if (document.diagnostics.length > 0) {
+    lines.push(`└─ Diagnostics (${document.diagnostics.length})`);
+    document.diagnostics.forEach((item, index) => {
+      lines.push(`   ${index === document.diagnostics.length - 1 ? '└─' : '├─'} ${item.severity.toUpperCase()} ${item.code}: ${item.message}`);
+    });
+  }
+  return `${lines.join('\n')}\n`;
+}
+
+function taskRunSummary(projection: TaskRunProjection): TaskRunInspectSummary {
+  return {
+    taskRunId: projection.taskRunId,
+    taskId: projection.taskId,
+    configId: projection.configId,
+    status: projection.status,
+    terminal: isTerminalTaskRunStatus(projection.status),
+    attemptCount: projection.attempts.length,
+    eventCount: projection.events.length,
+    ...(projection.startedAt !== undefined ? { startedAt: projection.startedAt } : {}),
+    ...(projection.finishedAt !== undefined ? { finishedAt: projection.finishedAt } : {}),
+    ...(projection.result ? { result: {
+      passed: projection.result.passed,
+      taxonomy: projection.result.taxonomy,
+    } } : {}),
+    ...(projection.error?.class ? { errorClass: projection.error.class } : {}),
+    ...(projection.parked ? { parked: projection.parked } : {}),
+  };
+}
+
+function taskEventSource(
+  records: Awaited<ReturnType<TaskRunStore['readEventRecords']>>,
+): TaskRunInspectTaskEventSource {
+  const first = records[0]?.cursor;
+  const last = records.at(-1)?.cursor;
+  return {
+    eventCount: records.length,
+    ...(first && last ? { coverage: { lowWater: first, highWater: last, eventCount: records.length } } : {}),
+  };
+}
+
+function runtimeCoverage(runId: string, events: readonly RuntimeEvent[]): ExecutionLogCoverage | undefined {
+  const first = events[0];
+  const last = events.at(-1);
+  if (!first || !last) return undefined;
+  return {
+    lowWater: { ledger: 'runtime_event', streamId: runId, sequence: 0, eventId: first.id },
+    highWater: { ledger: 'runtime_event', streamId: runId, sequence: events.length - 1, eventId: last.id },
+    eventCount: events.length,
+  };
+}
+
+function emptyAgentRun(
+  identity: ExecutionIdentityRef | undefined,
+  claimedCoverage?: ExecutionLogCoverage,
+  coverageStatus: TaskRunInspectCoverageStatus = 'unknown',
+): TaskRunInspectAgentRun {
+  return {
+    ...(identity ? { identity } : {}),
+    ...(claimedCoverage ? { claimedCoverage } : {}),
+    coverageStatus,
+    runtimeEventCount: 0,
+    tools: {
+      callCount: 0,
+      responseCount: 0,
+      errorResponseCount: 0,
+      callsWithoutResponse: [],
+      responsesWithoutCall: [],
+    },
+    compactionCheckpoints: [],
+  };
+}
+
+function agentRunDiagnostic(
+  taskRunId: string,
+  refs: Pick<TaskRunInspectDiagnostic, 'attemptId' | 'sessionId' | 'agentRunId'>,
+  source: AgentRunInspectDiagnostic,
+): TaskRunInspectDiagnostic {
+  const severity: TaskRunInspectSeverity = /read_failed|corrupt|mismatch/.test(source.code) ? 'error' : 'warning';
+  return diagnostic(taskRunId, 'agent_run_source_diagnostic', severity, source.message, {
+    ...refs,
+    ...(source.eventId ? { eventId: source.eventId } : {}),
+    // Runtime read-model details may contain the offending RuntimeEvent. The
+    // inspect contract reports the stable diagnostic code and event pointer,
+    // never copies model or tool payloads into a second evidence surface.
+    detail: { sourceCode: source.code },
+  });
+}
+
+function diagnostic(
+  taskRunId: string,
+  code: TaskRunInspectDiagnosticCode,
+  severity: TaskRunInspectSeverity,
+  message: string,
+  refs: Partial<Omit<TaskRunInspectDiagnostic, 'taskRunId' | 'code' | 'severity' | 'message'>> = {},
+): TaskRunInspectDiagnostic {
+  return { severity, code, message, taskRunId, ...refs };
+}
+
+function formatCoverage(coverage: ExecutionLogCoverage | undefined): string {
+  if (!coverage) return 'unknown';
+  const low = coverage.lowWater?.sequence ?? 0;
+  return `${coverage.highWater.ledger}:${coverage.highWater.streamId} ${low}–${coverage.highWater.sequence}`;
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}


### PR DESCRIPTION
## Summary

Phase 3A of #948 turns the existing flat TaskRun inspect command into a first-class execution-lineage surface.

- add the versioned maka.task_run_inspect.v1 machine contract
- build one coherent read model from an exact Task Event snapshot and its reported high water
- join TaskRun Attempts to linked AgentRuns and canonical Runtime Event ledgers
- validate claimed Runtime coverage against observed cursor boundaries and event counts
- summarize executor-owned Tool Call and Tool Response facts without copying arguments or results
- surface Self-check freshness, workspace revision refs, and durable Compaction checkpoint source coverage
- render human tree and JSON output from the same typed document
- keep missing, legacy, stale, corrupt, and ambiguous facts explicit as structured diagnostics

## Commands

```sh
maka eval task-run inspect <taskRunId> --store <root>
maka eval task-run inspect <taskRunId> --store <root> --json
```

The human view renders TaskRun -> Attempt -> AgentRun -> Runtime coverage, Tool facts, Compaction checkpoints, Self-check state, and diagnostics. JSON consumers receive the same facts under a stable schema version.

## Evidence invariants

- the inspector is a read model, never another fact authority
- Task and Runtime source coverage are reported with their actual ledger cursors
- a claimed boundary mismatch fails closed and remains visible
- a Tool Call without a committed response is an unknown outcome; success, failure, and external side effects are never inferred
- legacy identity-only links and unscoped Self-checks remain visible as unknown instead of receiving fabricated provenance
- Runtime diagnostic payloads are not copied into inspect output; only stable codes and event pointers cross the boundary
- this phase does not add or expand verifier behavior

## Compatibility

The existing task-run inspect command remains the entry point, but its previous unversioned flat JSON is replaced by maka.task_run_inspect.v1. Existing durable TaskRun, AgentRun, Runtime Event, Self-check, and Compaction records remain unchanged and backward-readable.

## Verification

- npm --workspace @maka/headless test: 942 passed
- npm --workspace maka-agent test: 336 passed
- npm run typecheck
- git diff --check

All passed after rebasing onto current main, including #956.