### PR TITLE
feat(cli): add unified execution evidence inspect

### DIFF
--- a/packages/cli/src/__tests__/cli.test.ts
+++ b/packages/cli/src/__tests__/cli.test.ts
@@ -6,6 +6,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { promisify } from 'node:util';
 import { describe, test } from 'node:test';
+import { createSessionStore } from '@maka/storage';
 import {
   parseMakaCliArgs,
   formatStartupConnectionError,
@@ -44,6 +45,13 @@ describe('Maka CLI args', () => {
     });
   });
 
+  test('routes the unified inspect command without changing its arguments', () => {
+    assert.deepEqual(parseMakaCliArgs(['inspect', 'run-1', '--json'], '0.1.0'), {
+      kind: 'inspect',
+      args: ['run-1', '--json'],
+    });
+  });
+
   test('routes maka run and maka -p through the exact same command shape', () => {
     assert.deepEqual(parseMakaCliArgs(['run', 'hello', '--max-steps', '3'], '0.1.0'), {
       kind: 'run',
@@ -61,6 +69,7 @@ describe('Maka CLI args', () => {
     if (command.kind !== 'help') return;
     assert.match(command.text, /Usage: maka/);
     assert.match(command.text, /maka-agent/);
+    assert.match(command.text, /maka inspect/);
   });
 
   test('prints version', () => {
@@ -141,6 +150,27 @@ describe('Maka CLI args', () => {
     ]);
 
     assert.equal(stdout.trim(), '0.1.0');
+  });
+
+  test('inspects a Session through the executable entrypoint', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'maka-cli-inspect-'));
+    try {
+      const session = await createSessionStore(root).create({
+        cwd: '/tmp/workspace', name: 'CLI inspect', backend: 'fake',
+        llmConnectionSlug: 'fake', model: 'fake-model', permissionMode: 'ask',
+      });
+      const result = await runCliProcess(cliPath, [
+        'inspect', session.id, '--store', root, '--kind', 'session', '--json',
+      ]);
+
+      assert.equal(result.code, 0);
+      assert.equal(result.stderr, '');
+      const document = JSON.parse(result.stdout) as { schemaVersion: string; kind: string };
+      assert.equal(document.schemaVersion, 'maka.session_inspect.v1');
+      assert.equal(document.kind, 'session');
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
   });
 
   test('runs a fake evaluation through the unified executable', async () => {

--- a/packages/cli/src/__tests__/inspect-command.test.ts
+++ b/packages/cli/src/__tests__/inspect-command.test.ts
@@ -1,0 +1,107 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, test } from 'node:test';
+import type { AgentRunHeader } from '@maka/core';
+import { createTaskRunStore } from '@maka/headless';
+import { createAgentRunStore, createRuntimeEventStore, createSessionStore } from '@maka/storage';
+import {
+  inspectResolvedTarget,
+  resolveInspectTarget,
+  type InspectCommandStores,
+} from '../inspect-command.js';
+
+describe('unified inspect target resolution', () => {
+  test('does not guess when one id names multiple entity kinds and AgentRuns', async () => {
+    await withStores(async (stores) => {
+      const first = await createSession(stores, 'First');
+      const second = await createSession(stores, 'Second');
+      const sharedId = first.id;
+      await stores.agentRunStore.createRun(runHeader(first.id, sharedId));
+      await stores.agentRunStore.createRun(runHeader(second.id, sharedId));
+      await stores.taskRunStore.appendEvent(sharedId, {
+        type: 'task_run_created', id: 'task-created', taskRunId: sharedId,
+        ts: 1, taskId: 'task-1', configId: 'config-1',
+      });
+
+      const resolution = await resolveInspectTarget(stores, { id: sharedId });
+
+      assert.equal(resolution.status, 'ambiguous');
+      const agentSessionIds = [first.id, second.id].sort();
+      assert.deepEqual(resolution.document.candidates, [
+        { kind: 'agent-run', id: sharedId, sessionId: agentSessionIds[0] },
+        { kind: 'agent-run', id: sharedId, sessionId: agentSessionIds[1] },
+        { kind: 'session', id: sharedId },
+        { kind: 'task-run', id: sharedId },
+      ]);
+    });
+  });
+
+  test('uses explicit kind and Session to resolve duplicate AgentRun ids', async () => {
+    await withStores(async (stores) => {
+      const first = await createSession(stores, 'First');
+      const second = await createSession(stores, 'Second');
+      await stores.agentRunStore.createRun(runHeader(first.id, 'run-shared'));
+      await stores.agentRunStore.createRun(runHeader(second.id, 'run-shared'));
+
+      const ambiguous = await resolveInspectTarget(stores, {
+        id: 'run-shared', requestedKind: 'agent-run',
+      });
+      assert.equal(ambiguous.status, 'ambiguous');
+
+      const resolved = await resolveInspectTarget(stores, {
+        id: 'run-shared', requestedKind: 'agent-run', sessionId: second.id,
+      });
+      assert.equal(resolved.status, 'resolved');
+      if (resolved.status !== 'resolved') return;
+      const document = await inspectResolvedTarget(stores, resolved.candidate);
+      assert.equal(document.kind, 'agent_run');
+      if (document.kind !== 'agent_run') return;
+      assert.equal(document.agentRun.sessionId, second.id);
+    });
+  });
+
+  test('returns a stable not-found resolution document', async () => {
+    await withStores(async (stores) => {
+      const resolution = await resolveInspectTarget(stores, { id: 'missing' });
+      assert.equal(resolution.status, 'not_found');
+      assert.deepEqual(resolution.document, {
+        schemaVersion: 'maka.inspect_resolution.v1',
+        kind: 'inspect_resolution',
+        query: { id: 'missing' },
+        status: 'not_found',
+        candidates: [],
+      });
+    });
+  });
+});
+
+async function createSession(stores: InspectCommandStores, name: string) {
+  return stores.sessionStore.create({
+    cwd: '/tmp/workspace', name, backend: 'fake', llmConnectionSlug: 'fake',
+    model: 'fake-model', permissionMode: 'ask',
+  });
+}
+
+function runHeader(sessionId: string, runId: string): AgentRunHeader {
+  return {
+    runId, sessionId, turnId: `turn-${sessionId}`, status: 'completed',
+    backendKind: 'fake', llmConnectionSlug: 'fake', modelId: 'fake-model',
+    cwd: '/tmp/workspace', permissionMode: 'ask', createdAt: 1, updatedAt: 2, completedAt: 2,
+  };
+}
+
+async function withStores(run: (stores: InspectCommandStores) => Promise<void>): Promise<void> {
+  const root = await mkdtemp(join(tmpdir(), 'maka-unified-inspect-'));
+  try {
+    await run({
+      sessionStore: createSessionStore(root),
+      agentRunStore: createAgentRunStore(root),
+      runtimeEventStore: createRuntimeEventStore(root),
+      taskRunStore: createTaskRunStore(root),
+    });
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+}

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -15,6 +15,7 @@ export type MakaCliCommand =
   | { kind: 'tui' }
   | { kind: 'run'; args: string[] }
   | { kind: 'eval'; args: string[] }
+  | { kind: 'inspect'; args: string[] }
   | { kind: 'help'; text: string }
   | { kind: 'version'; text: string }
   | { kind: 'error'; message: string; exitCode: number };
@@ -26,6 +27,7 @@ export function parseMakaCliArgs(argv: string[], version: string): MakaCliComman
   if (first === '--version' || first === '-v') return { kind: 'version', text: version };
   if (first === 'run' || first === '-p') return { kind: 'run', args: argv.slice(1) };
   if (first === 'eval') return { kind: 'eval', args: argv.slice(1) };
+  if (first === 'inspect') return { kind: 'inspect', args: argv.slice(1) };
   return {
     kind: 'error',
     message: `Unexpected argument: ${first ?? ''}`,
@@ -77,6 +79,7 @@ function helpText(): string {
     '  maka run ...      Run one non-interactive model turn',
     '  maka -p ...       Alias for maka run',
     '  maka eval ...     Run evaluation and autonomous task commands',
+    '  maka inspect ...  Inspect Session, AgentRun, or TaskRun evidence',
     '',
     'Options:',
     '  -h, --help        Show help',
@@ -95,6 +98,10 @@ export async function runMakaCli(argv: string[] = process.argv.slice(2)): Promis
     case 'eval': {
       const { runMakaEvalCli } = await import('@maka/headless/eval-router');
       return runMakaEvalCli(command.args);
+    }
+    case 'inspect': {
+      const { runMakaInspectCli } = await import('./inspect-command.js');
+      return runMakaInspectCli(command.args);
     }
     case 'help':
       process.stdout.write(`${command.text}\n`);

--- a/packages/cli/src/inspect-command.ts
+++ b/packages/cli/src/inspect-command.ts
@@ -1,0 +1,329 @@
+import { resolve } from 'node:path';
+import type { AgentRunHeader, SessionHeader } from '@maka/core';
+import {
+  createTaskRunStore,
+  inspectTaskRun,
+  renderTaskRunInspectTree,
+  type TaskRunInspectDocument,
+  type TaskRunStore,
+} from '@maka/headless';
+import {
+  inspectAgentRunDocument,
+  inspectSessionDocument,
+  renderAgentRunInspectTree,
+  renderSessionInspectTree,
+  type AgentRunInspectDocument,
+  type SessionInspectDocument,
+} from '@maka/runtime';
+import {
+  createAgentRunStore,
+  createRuntimeEventStore,
+  createSessionStore,
+  type SessionStore,
+} from '@maka/storage';
+import type { AgentRunStore, RuntimeEventStore } from '@maka/core';
+import { resolveMakaWorkspaceRoot } from './workspace-root.js';
+
+export const INSPECT_RESOLUTION_SCHEMA_VERSION = 'maka.inspect_resolution.v1' as const;
+
+export type InspectEntityKind = 'session' | 'agent-run' | 'task-run';
+
+export interface InspectCandidateDescriptor {
+  kind: InspectEntityKind;
+  id: string;
+  sessionId?: string;
+}
+
+export interface InspectResolutionDocument {
+  schemaVersion: typeof INSPECT_RESOLUTION_SCHEMA_VERSION;
+  kind: 'inspect_resolution';
+  query: {
+    id: string;
+    requestedKind?: InspectEntityKind;
+    sessionId?: string;
+  };
+  status: 'not_found' | 'ambiguous';
+  candidates: InspectCandidateDescriptor[];
+}
+
+export type InspectDocument = SessionInspectDocument | AgentRunInspectDocument | TaskRunInspectDocument;
+
+export interface InspectCommandStores {
+  sessionStore: SessionStore;
+  agentRunStore: AgentRunStore;
+  runtimeEventStore: RuntimeEventStore;
+  taskRunStore: TaskRunStore;
+}
+
+interface SessionCandidate extends InspectCandidateDescriptor {
+  kind: 'session';
+  header: SessionHeader;
+}
+
+interface AgentRunCandidate extends InspectCandidateDescriptor {
+  kind: 'agent-run';
+  sessionId: string;
+  header: AgentRunHeader;
+}
+
+interface TaskRunCandidate extends InspectCandidateDescriptor {
+  kind: 'task-run';
+}
+
+type InspectCandidate = SessionCandidate | AgentRunCandidate | TaskRunCandidate;
+
+export type InspectResolution =
+  | { status: 'resolved'; candidate: InspectCandidate }
+  | { status: 'not_found' | 'ambiguous'; document: InspectResolutionDocument };
+
+export async function resolveInspectTarget(
+  stores: InspectCommandStores,
+  query: { id: string; requestedKind?: InspectEntityKind; sessionId?: string },
+): Promise<InspectResolution> {
+  let candidates: InspectCandidate[];
+  if (query.requestedKind === 'session') {
+    candidates = await findSessionCandidates(stores.sessionStore, query.id);
+  } else if (query.requestedKind === 'task-run') {
+    candidates = await findTaskRunCandidates(stores.taskRunStore, query.id);
+  } else if (query.requestedKind === 'agent-run') {
+    candidates = await findAgentRunCandidates(stores, query.id, query.sessionId);
+  } else {
+    const [sessions, agentRuns, taskRuns] = await Promise.all([
+      findSessionCandidates(stores.sessionStore, query.id),
+      findAgentRunCandidates(stores, query.id),
+      findTaskRunCandidates(stores.taskRunStore, query.id),
+    ]);
+    candidates = [...sessions, ...agentRuns, ...taskRuns];
+  }
+
+  candidates.sort(compareCandidates);
+  if (candidates.length === 1) return { status: 'resolved', candidate: candidates[0]! };
+  const status = candidates.length === 0 ? 'not_found' : 'ambiguous';
+  return {
+    status,
+    document: {
+      schemaVersion: INSPECT_RESOLUTION_SCHEMA_VERSION,
+      kind: 'inspect_resolution',
+      query: {
+        id: query.id,
+        ...(query.requestedKind ? { requestedKind: query.requestedKind } : {}),
+        ...(query.sessionId ? { sessionId: query.sessionId } : {}),
+      },
+      status,
+      candidates: candidates.map(({ kind, id, sessionId }) => ({
+        kind,
+        id,
+        ...(sessionId ? { sessionId } : {}),
+      })),
+    },
+  };
+}
+
+export async function inspectResolvedTarget(
+  stores: InspectCommandStores,
+  candidate: InspectCandidate,
+): Promise<InspectDocument> {
+  if (candidate.kind === 'task-run') {
+    return inspectTaskRun({
+      taskRunStore: stores.taskRunStore,
+      agentRunStore: stores.agentRunStore,
+      runtimeEventStore: stores.runtimeEventStore,
+    }, candidate.id);
+  }
+  if (candidate.kind === 'agent-run') {
+    return inspectAgentRunDocument(stores.agentRunStore, stores.runtimeEventStore, {
+      sessionId: candidate.sessionId,
+      agentRunId: candidate.id,
+      header: candidate.header,
+    });
+  }
+  return inspectSessionDocument(
+    { readHeader: (id) => stores.sessionStore.readHeaderSnapshot(id) },
+    stores.agentRunStore,
+    stores.runtimeEventStore,
+    candidate.id,
+    candidate.header,
+  );
+}
+
+export async function runMakaInspectCli(args: string[]): Promise<number> {
+  let parsed: ParsedInspectArgs;
+  try {
+    parsed = parseInspectArgs(args);
+  } catch (error) {
+    process.stderr.write(`${errorMessage(error)}\n\n${inspectUsage()}\n`);
+    return 2;
+  }
+  if (parsed.help) {
+    process.stdout.write(`${inspectUsage()}\n`);
+    return 0;
+  }
+  if (!parsed.id) {
+    process.stderr.write(`${inspectUsage()}\n`);
+    return 2;
+  }
+
+  const storageRoot = parsed.store ? resolve(parsed.store) : resolveMakaWorkspaceRoot();
+  const stores: InspectCommandStores = {
+    sessionStore: createSessionStore(storageRoot),
+    agentRunStore: createAgentRunStore(storageRoot),
+    runtimeEventStore: createRuntimeEventStore(storageRoot),
+    taskRunStore: createTaskRunStore(storageRoot),
+  };
+  const resolution = await resolveInspectTarget(stores, {
+    id: parsed.id,
+    ...(parsed.kind ? { requestedKind: parsed.kind } : {}),
+    ...(parsed.sessionId ? { sessionId: parsed.sessionId } : {}),
+  });
+  if (resolution.status !== 'resolved') {
+    if (parsed.json) {
+      process.stdout.write(`${JSON.stringify(resolution.document, null, 2)}\n`);
+    } else {
+      process.stderr.write(`${renderResolutionFailure(resolution.document)}\n`);
+    }
+    return resolution.status === 'ambiguous' ? 2 : 1;
+  }
+
+  const document = await inspectResolvedTarget(stores, resolution.candidate);
+  if (parsed.json) {
+    process.stdout.write(`${JSON.stringify(document, null, 2)}\n`);
+  } else if (document.kind === 'task_run') {
+    process.stdout.write(renderTaskRunInspectTree(document));
+  } else if (document.kind === 'agent_run') {
+    process.stdout.write(renderAgentRunInspectTree(document));
+  } else {
+    process.stdout.write(renderSessionInspectTree(document));
+  }
+  return 0;
+}
+
+interface ParsedInspectArgs {
+  id?: string;
+  store?: string;
+  kind?: InspectEntityKind;
+  sessionId?: string;
+  json: boolean;
+  help: boolean;
+}
+
+function parseInspectArgs(args: readonly string[]): ParsedInspectArgs {
+  const positional: string[] = [];
+  let store: string | undefined;
+  let kind: InspectEntityKind | undefined;
+  let sessionId: string | undefined;
+  let json = false;
+  let help = false;
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index]!;
+    if (arg === '--json') {
+      json = true;
+    } else if (arg === '--help' || arg === '-h') {
+      help = true;
+    } else if (arg === '--store' || arg === '--kind' || arg === '--session') {
+      const value = args[index + 1];
+      if (!value || value.startsWith('--')) throw new Error(`${arg} requires a value`);
+      index += 1;
+      if (arg === '--store') store = value;
+      else if (arg === '--session') sessionId = value;
+      else if (isInspectEntityKind(value)) kind = value;
+      else throw new Error(`invalid --kind: ${value}`);
+    } else if (arg.startsWith('-')) {
+      throw new Error(`unknown option: ${arg}`);
+    } else {
+      positional.push(arg);
+    }
+  }
+  if (positional.length > 1) throw new Error(`unexpected argument: ${positional[1]}`);
+  if (sessionId && kind !== 'agent-run') {
+    throw new Error('--session requires --kind agent-run');
+  }
+  return {
+    ...(positional[0] ? { id: positional[0] } : {}),
+    ...(store ? { store } : {}),
+    ...(kind ? { kind } : {}),
+    ...(sessionId ? { sessionId } : {}),
+    json,
+    help,
+  };
+}
+
+function isInspectEntityKind(value: string): value is InspectEntityKind {
+  return value === 'session' || value === 'agent-run' || value === 'task-run';
+}
+
+async function findSessionCandidates(store: SessionStore, id: string): Promise<SessionCandidate[]> {
+  const summaries = await store.list();
+  if (!summaries.some((session) => session.id === id)) return [];
+  return [{ kind: 'session', id, header: await store.readHeaderSnapshot(id) }];
+}
+
+async function findTaskRunCandidates(store: TaskRunStore, id: string): Promise<TaskRunCandidate[]> {
+  const records = await store.readEventRecords(id);
+  return records.length > 0 ? [{ kind: 'task-run', id }] : [];
+}
+
+async function findAgentRunCandidates(
+  stores: Pick<InspectCommandStores, 'sessionStore' | 'agentRunStore'>,
+  id: string,
+  sessionId?: string,
+): Promise<AgentRunCandidate[]> {
+  if (sessionId) {
+    try {
+      const header = await stores.agentRunStore.readRun(sessionId, id);
+      return [{ kind: 'agent-run', id, sessionId, header }];
+    } catch (error) {
+      if (isNotFound(error)) return [];
+      throw error;
+    }
+  }
+  const sessions = await stores.sessionStore.list();
+  const runLists = await Promise.all(sessions.map((session) =>
+    stores.agentRunStore.listSessionRuns(session.id)
+  ));
+  const candidates: AgentRunCandidate[] = [];
+  runLists.forEach((runs) => {
+    for (const header of runs) {
+      if (header.runId === id) {
+        candidates.push({ kind: 'agent-run', id, sessionId: header.sessionId, header });
+      }
+    }
+  });
+  return candidates;
+}
+
+function compareCandidates(a: InspectCandidate, b: InspectCandidate): number {
+  return a.kind.localeCompare(b.kind) || (a.sessionId ?? '').localeCompare(b.sessionId ?? '');
+}
+
+function renderResolutionFailure(document: InspectResolutionDocument): string {
+  if (document.status === 'not_found') {
+    return `No Session, AgentRun, or TaskRun found for ${document.query.id}.`;
+  }
+  const candidates = document.candidates.map((candidate) =>
+    candidate.kind === 'agent-run'
+      ? `  - agent-run ${candidate.id} in session ${candidate.sessionId}`
+      : `  - ${candidate.kind} ${candidate.id}`
+  );
+  return [
+    `Inspect target ${document.query.id} is ambiguous:`,
+    ...candidates,
+    'Choose one with --kind session|agent-run|task-run; add --session <id> for a duplicate AgentRun id.',
+  ].join('\n');
+}
+
+function inspectUsage(): string {
+  return [
+    'Usage: maka inspect <id> [--store <root>] [--kind session|agent-run|task-run] [--session <sessionId>] [--json]',
+    '',
+    'Inspects Session, AgentRun, or TaskRun evidence without copying raw model or tool payloads.',
+    'The default store is the current Maka desktop workspace.',
+  ].join('\n');
+}
+
+function isNotFound(error: unknown): boolean {
+  return (error as NodeJS.ErrnoException)?.code === 'ENOENT';
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/packages/runtime/src/__tests__/execution-inspect.test.ts
+++ b/packages/runtime/src/__tests__/execution-inspect.test.ts
@@ -1,0 +1,144 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, test } from 'node:test';
+import type { AgentRunEvent, AgentRunHeader, RuntimeEvent } from '@maka/core';
+import { createAgentRunStore, createRuntimeEventStore, createSessionStore } from '@maka/storage';
+import {
+  AGENT_RUN_INSPECT_DOCUMENT_VERSION,
+  SESSION_INSPECT_DOCUMENT_VERSION,
+  inspectAgentRunDocument,
+  inspectSessionDocument,
+  renderAgentRunInspectTree,
+  renderSessionInspectTree,
+} from '../execution-inspect.js';
+
+describe('versioned execution inspect documents', () => {
+  test('reports unknown tool outcomes without copying Runtime payloads', async () => {
+    await withWorkspace(async (root) => {
+      const sessionStore = createSessionStore(root);
+      const runStore = createAgentRunStore(root);
+      const runtimeStore = createRuntimeEventStore(root);
+      const session = await sessionStore.create({
+        cwd: '/tmp/workspace',
+        backend: 'fake',
+        llmConnectionSlug: 'fake',
+        model: 'fake-model',
+        permissionMode: 'ask',
+      });
+      const header = runHeader(session.id);
+      await runStore.createRun(header);
+      await runStore.appendEvent(session.id, RUN_ID, runEvent(session.id, 'run_completed'));
+      await runtimeStore.appendRuntimeEvent(session.id, RUN_ID, runtimeEvent(session.id, 'call', {
+        role: 'model',
+        author: 'agent',
+        content: {
+          kind: 'function_call',
+          id: 'tool-pending',
+          name: 'Write',
+          args: { path: 'private.txt', content: 'DO_NOT_COPY' },
+        },
+      }));
+      await runtimeStore.appendRuntimeEvent(session.id, RUN_ID, runtimeEvent(session.id, 'terminal', {
+        role: 'system', author: 'system', status: 'completed', actions: { endInvocation: true },
+      }));
+
+      const document = await inspectAgentRunDocument(runStore, runtimeStore, {
+        sessionId: session.id,
+        agentRunId: RUN_ID,
+      });
+
+      assert.equal(document.schemaVersion, AGENT_RUN_INSPECT_DOCUMENT_VERSION);
+      assert.deepEqual(document.tools.callsWithoutResponse, [{
+        toolCallId: 'tool-pending', toolName: 'Write', eventId: 'call',
+      }]);
+      assert.equal(document.sources.runtimeCoverage?.highWater.sequence, 1);
+      assert.equal(document.diagnostics.some((item) => item.code === 'tool_response_missing'), true);
+      const json = JSON.stringify(document);
+      assert.equal(json.includes('private.txt'), false);
+      assert.equal(json.includes('DO_NOT_COPY'), false);
+      assert.match(renderAgentRunInspectTree(document), /outcome and external side effects are unknown/);
+    });
+  });
+
+  test('projects a Session as bounded AgentRun documents without reading messages', async () => {
+    await withWorkspace(async (root) => {
+      const sessionStore = createSessionStore(root);
+      const runStore = createAgentRunStore(root);
+      const runtimeStore = createRuntimeEventStore(root);
+      const session = await sessionStore.create({
+        cwd: '/tmp/workspace', name: 'Inspectable session', backend: 'fake',
+        llmConnectionSlug: 'fake', model: 'fake-model', permissionMode: 'ask',
+      });
+      const header = runHeader(session.id);
+      await runStore.createRun(header);
+      await runStore.appendEvent(session.id, RUN_ID, runEvent(session.id, 'run_completed'));
+      await runtimeStore.appendRuntimeEvent(session.id, RUN_ID, runtimeEvent(session.id, 'terminal', {
+        role: 'system', author: 'system', status: 'completed', actions: { endInvocation: true },
+      }));
+
+      const document = await inspectSessionDocument(
+        { readHeader: (id) => sessionStore.readHeaderSnapshot(id) },
+        runStore,
+        runtimeStore,
+        session.id,
+      );
+
+      assert.equal(document.schemaVersion, SESSION_INSPECT_DOCUMENT_VERSION);
+      assert.equal(document.session.name, 'Inspectable session');
+      assert.equal(document.agentRuns[0]?.agentRun.agentRunId, RUN_ID);
+      assert.match(renderSessionInspectTree(document), /Runtime Events runtime_event:run-1 0–0/);
+    });
+  });
+});
+
+const RUN_ID = 'run-1';
+const TURN_ID = 'turn-1';
+const TS = 1_800_000_000_000;
+
+function runHeader(sessionId: string): AgentRunHeader {
+  return {
+    runId: RUN_ID,
+    invocationId: 'invocation-1',
+    sessionId,
+    turnId: TURN_ID,
+    status: 'completed',
+    backendKind: 'fake',
+    llmConnectionSlug: 'fake',
+    modelId: 'fake-model',
+    cwd: '/tmp/workspace',
+    permissionMode: 'ask',
+    createdAt: TS,
+    updatedAt: TS + 1,
+    completedAt: TS + 1,
+  };
+}
+
+function runEvent(sessionId: string, type: AgentRunEvent['type']): AgentRunEvent {
+  return { id: `op-${type}`, type, runId: RUN_ID, sessionId, turnId: TURN_ID, ts: TS + 1 };
+}
+
+function runtimeEvent(sessionId: string, id: string, overrides: Partial<RuntimeEvent>): RuntimeEvent {
+  return {
+    id,
+    invocationId: 'invocation-1',
+    runId: RUN_ID,
+    sessionId,
+    turnId: TURN_ID,
+    ts: TS,
+    partial: false,
+    role: 'system',
+    author: 'system',
+    ...overrides,
+  };
+}
+
+async function withWorkspace(run: (root: string) => Promise<void>): Promise<void> {
+  const root = await mkdtemp(join(tmpdir(), 'maka-execution-inspect-'));
+  try {
+    await run(root);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+}

--- a/packages/runtime/src/execution-inspect.ts
+++ b/packages/runtime/src/execution-inspect.ts
@@ -1,0 +1,354 @@
+import type {
+  AgentRunHeader,
+  AgentRunStore,
+  RuntimeEvent,
+  RuntimeEventStore,
+  SessionHeader,
+} from '@maka/core';
+import type { ExecutionLogCoverage } from '@maka/core/execution-evidence';
+import {
+  inspectAgentRunReadModel,
+  type AgentRunInspectDiagnostic as SourceDiagnostic,
+  type AgentRunInspectSourceHealth,
+} from './agent-run-inspect.js';
+import {
+  validateHistoryCompactCheckpointShape,
+  type HistoryCompactCheckpoint,
+} from './history-compact-checkpoint.js';
+
+export const AGENT_RUN_INSPECT_DOCUMENT_VERSION = 'maka.agent_run_inspect.v1' as const;
+export const SESSION_INSPECT_DOCUMENT_VERSION = 'maka.session_inspect.v1' as const;
+
+export type ExecutionInspectSeverity = 'error' | 'warning' | 'info';
+
+export interface ExecutionInspectDiagnostic {
+  severity: ExecutionInspectSeverity;
+  code: string;
+  message: string;
+  sessionId: string;
+  agentRunId?: string;
+  turnId?: string;
+  eventId?: string;
+}
+
+export interface AgentRunInspectIdentity {
+  sessionId: string;
+  agentRunId: string;
+  invocationId?: string;
+  turnId: string;
+  parentRunId?: string;
+  parentTurnId?: string;
+  agentId?: string;
+  status: AgentRunHeader['status'];
+  createdAt: number;
+  updatedAt: number;
+  completedAt?: number;
+  failureClass?: string;
+  abortSource?: string;
+}
+
+export interface AgentRunInspectToolFact {
+  toolCallId: string;
+  toolName: string;
+  eventId: string;
+}
+
+export interface AgentRunInspectToolSummary {
+  callCount: number;
+  responseCount: number;
+  errorResponseCount: number;
+  callsWithoutResponse: AgentRunInspectToolFact[];
+  responsesWithoutCall: AgentRunInspectToolFact[];
+}
+
+export interface AgentRunInspectCompactionCheckpoint {
+  eventId: string;
+  validation: 'shape_valid' | 'invalid';
+  checkpointId?: string;
+  policyVersion?: string;
+  sourceCoverage?: ExecutionLogCoverage;
+}
+
+export interface AgentRunInspectDocument {
+  schemaVersion: typeof AGENT_RUN_INSPECT_DOCUMENT_VERSION;
+  kind: 'agent_run';
+  agentRun: AgentRunInspectIdentity;
+  sources: {
+    operationalEventCount: number;
+    runtimeEventCount: number;
+    runtimeCoverage?: ExecutionLogCoverage;
+    health: AgentRunInspectSourceHealth;
+  };
+  tools: AgentRunInspectToolSummary;
+  compactionCheckpoints: AgentRunInspectCompactionCheckpoint[];
+  diagnostics: ExecutionInspectDiagnostic[];
+}
+
+export interface SessionInspectSummary {
+  sessionId: string;
+  name: string;
+  status: SessionHeader['status'];
+  createdAt: number;
+  lastUsedAt: number;
+  lastMessageAt?: number;
+  isArchived: boolean;
+  parentSessionId?: string;
+  branchOfTurnId?: string;
+}
+
+export interface SessionInspectDocument {
+  schemaVersion: typeof SESSION_INSPECT_DOCUMENT_VERSION;
+  kind: 'session';
+  session: SessionInspectSummary;
+  agentRuns: AgentRunInspectDocument[];
+  diagnostics: ExecutionInspectDiagnostic[];
+}
+
+export interface SessionHeaderReader {
+  readHeader(sessionId: string): Promise<SessionHeader>;
+}
+
+export async function inspectAgentRunDocument(
+  runStore: AgentRunStore,
+  runtimeEventStore: RuntimeEventStore,
+  input: { sessionId: string; agentRunId: string; header?: AgentRunHeader },
+): Promise<AgentRunInspectDocument> {
+  const model = await inspectAgentRunReadModel(runStore, runtimeEventStore, {
+    sessionId: input.sessionId,
+    runId: input.agentRunId,
+    ...(input.header ? { header: input.header } : {}),
+  });
+  const diagnostics = model.diagnostics.map((item) => sourceDiagnostic(model.header, item));
+  const tools = inspectTools(model.header, model.runtimeEvents, diagnostics);
+  const compactionCheckpoints = inspectCompactionCheckpoints(model.header, model.events, diagnostics);
+  const runtimeCoverage = coverageFor(model.header.runId, model.runtimeEvents);
+
+  return {
+    schemaVersion: AGENT_RUN_INSPECT_DOCUMENT_VERSION,
+    kind: 'agent_run',
+    agentRun: inspectIdentity(model.header),
+    sources: {
+      operationalEventCount: model.events.length,
+      runtimeEventCount: model.runtimeEvents.length,
+      ...(runtimeCoverage ? { runtimeCoverage } : {}),
+      health: model.sourceHealth,
+    },
+    tools,
+    compactionCheckpoints,
+    diagnostics,
+  };
+}
+
+export async function inspectSessionDocument(
+  sessionStore: SessionHeaderReader,
+  runStore: AgentRunStore,
+  runtimeEventStore: RuntimeEventStore,
+  sessionId: string,
+  header?: SessionHeader,
+): Promise<SessionInspectDocument> {
+  const resolvedHeader = header ?? await sessionStore.readHeader(sessionId);
+  const runHeaders = await runStore.listSessionRuns(sessionId);
+  const agentRuns: AgentRunInspectDocument[] = [];
+  for (const runHeader of runHeaders) {
+    agentRuns.push(await inspectAgentRunDocument(runStore, runtimeEventStore, {
+      sessionId,
+      agentRunId: runHeader.runId,
+      header: runHeader,
+    }));
+  }
+  return {
+    schemaVersion: SESSION_INSPECT_DOCUMENT_VERSION,
+    kind: 'session',
+    session: {
+      sessionId: resolvedHeader.id,
+      name: resolvedHeader.name,
+      status: resolvedHeader.status,
+      createdAt: resolvedHeader.createdAt,
+      lastUsedAt: resolvedHeader.lastUsedAt,
+      ...(resolvedHeader.lastMessageAt !== undefined ? { lastMessageAt: resolvedHeader.lastMessageAt } : {}),
+      isArchived: resolvedHeader.isArchived,
+      ...(resolvedHeader.parentSessionId ? { parentSessionId: resolvedHeader.parentSessionId } : {}),
+      ...(resolvedHeader.branchOfTurnId ? { branchOfTurnId: resolvedHeader.branchOfTurnId } : {}),
+    },
+    agentRuns,
+    diagnostics: agentRuns.flatMap((run) => run.diagnostics),
+  };
+}
+
+export function renderAgentRunInspectTree(document: AgentRunInspectDocument): string {
+  const run = document.agentRun;
+  const lines = [
+    `AgentRun ${run.agentRunId} [${run.status}]`,
+    `├─ Session ${run.sessionId}`,
+    `├─ Turn ${run.turnId}`,
+    `├─ Runtime Events ${formatCoverage(document.sources.runtimeCoverage)} (${document.sources.runtimeEventCount})`,
+    `├─ Operational Events ${document.sources.operationalEventCount}`,
+    `├─ Source Health [${document.sources.health.statusConsistency}]`,
+    `├─ Tools ${document.tools.callCount} calls / ${document.tools.responseCount} responses`,
+  ];
+  for (const checkpoint of document.compactionCheckpoints) {
+    lines.push(`├─ Compaction ${checkpoint.checkpointId ?? checkpoint.eventId} ${formatCoverage(checkpoint.sourceCoverage)} [${checkpoint.validation}]`);
+  }
+  appendDiagnostics(lines, document.diagnostics);
+  if (document.diagnostics.length === 0) lines.push('└─ Diagnostics (0)');
+  return `${lines.join('\n')}\n`;
+}
+
+export function renderSessionInspectTree(document: SessionInspectDocument): string {
+  const lines = [`Session ${document.session.sessionId} [${document.session.status}]`];
+  if (document.agentRuns.length === 0) {
+    lines.push('└─ AgentRuns (0)');
+    return `${lines.join('\n')}\n`;
+  }
+  document.agentRuns.forEach((run, index) => {
+    const last = index === document.agentRuns.length - 1;
+    const branch = last ? '└─' : '├─';
+    const child = last ? '   ' : '│  ';
+    lines.push(`${branch} AgentRun ${run.agentRun.agentRunId} [${run.agentRun.status}]`);
+    lines.push(`${child}├─ Turn ${run.agentRun.turnId}`);
+    lines.push(`${child}├─ Runtime Events ${formatCoverage(run.sources.runtimeCoverage)} (${run.sources.runtimeEventCount})`);
+    lines.push(`${child}├─ Tools ${run.tools.callCount} calls / ${run.tools.responseCount} responses`);
+    lines.push(`${child}└─ Diagnostics (${run.diagnostics.length})`);
+  });
+  return `${lines.join('\n')}\n`;
+}
+
+function inspectIdentity(header: AgentRunHeader): AgentRunInspectIdentity {
+  return {
+    sessionId: header.sessionId,
+    agentRunId: header.runId,
+    ...(header.invocationId ? { invocationId: header.invocationId } : {}),
+    turnId: header.turnId,
+    ...(header.parentRunId ? { parentRunId: header.parentRunId } : {}),
+    ...(header.parentTurnId ? { parentTurnId: header.parentTurnId } : {}),
+    ...(header.agentId ? { agentId: header.agentId } : {}),
+    status: header.status,
+    createdAt: header.createdAt,
+    updatedAt: header.updatedAt,
+    ...(header.completedAt !== undefined ? { completedAt: header.completedAt } : {}),
+    ...(header.failureClass ? { failureClass: header.failureClass } : {}),
+    ...(header.abortSource ? { abortSource: header.abortSource } : {}),
+  };
+}
+
+function inspectTools(
+  header: AgentRunHeader,
+  events: readonly RuntimeEvent[],
+  diagnostics: ExecutionInspectDiagnostic[],
+): AgentRunInspectToolSummary {
+  const calls = new Map<string, AgentRunInspectToolFact>();
+  const responses = new Map<string, AgentRunInspectToolFact & { isError: boolean }>();
+  for (const event of events) {
+    if (event.content?.kind === 'function_call') {
+      calls.set(event.content.id, {
+        toolCallId: event.content.id,
+        toolName: event.content.name,
+        eventId: event.id,
+      });
+    } else if (event.content?.kind === 'function_response') {
+      responses.set(event.content.id, {
+        toolCallId: event.content.id,
+        toolName: event.content.name,
+        eventId: event.id,
+        isError: event.content.isError === true,
+      });
+    }
+  }
+  const callsWithoutResponse = [...calls.values()].filter((call) => !responses.has(call.toolCallId));
+  const responsesWithoutCall = [...responses.values()]
+    .filter((response) => !calls.has(response.toolCallId))
+    .map(({ isError: _isError, ...response }) => response);
+  for (const call of callsWithoutResponse) {
+    diagnostics.push(diagnostic(header, 'tool_response_missing', 'warning',
+      `Tool Call ${call.toolCallId} has no committed Runtime response; its outcome and external side effects are unknown.`,
+      call.eventId));
+  }
+  for (const response of responsesWithoutCall) {
+    diagnostics.push(diagnostic(header, 'tool_call_missing', 'warning',
+      `Tool response ${response.toolCallId} has no matching Runtime call fact.`, response.eventId));
+  }
+  return {
+    callCount: calls.size,
+    responseCount: responses.size,
+    errorResponseCount: [...responses.values()].filter((response) => response.isError).length,
+    callsWithoutResponse,
+    responsesWithoutCall,
+  };
+}
+
+function inspectCompactionCheckpoints(
+  header: AgentRunHeader,
+  events: readonly { type: string; id: string; data?: Record<string, unknown> }[],
+  diagnostics: ExecutionInspectDiagnostic[],
+): AgentRunInspectCompactionCheckpoint[] {
+  const checkpoints: AgentRunInspectCompactionCheckpoint[] = [];
+  for (const event of events) {
+    if (event.type !== 'history_compact_checkpoint_recorded') continue;
+    const checkpoint = event.data?.checkpoint;
+    if (!validateHistoryCompactCheckpointShape(checkpoint, header.sessionId)) {
+      diagnostics.push(diagnostic(header, 'compaction_checkpoint_invalid', 'error',
+        'AgentRun contains an invalid durable Compaction checkpoint record.', event.id));
+      checkpoints.push({ eventId: event.id, validation: 'invalid' });
+      continue;
+    }
+    const valid = checkpoint as HistoryCompactCheckpoint;
+    checkpoints.push({
+      eventId: event.id,
+      validation: 'shape_valid',
+      checkpointId: valid.checkpointId,
+      ...(valid.source?.policyVersion ? { policyVersion: valid.source.policyVersion } : {}),
+      ...(valid.source?.coverage ? { sourceCoverage: valid.source.coverage } : {}),
+    });
+  }
+  return checkpoints;
+}
+
+function sourceDiagnostic(header: AgentRunHeader, source: SourceDiagnostic): ExecutionInspectDiagnostic {
+  const severity: ExecutionInspectSeverity = /read_failed|corrupt|mismatch/.test(source.code)
+    ? 'error'
+    : source.code.includes('missing') ? 'warning' : 'info';
+  return diagnostic(header, source.code, severity, source.message, source.eventId);
+}
+
+function diagnostic(
+  header: AgentRunHeader,
+  code: string,
+  severity: ExecutionInspectSeverity,
+  message: string,
+  eventId?: string,
+): ExecutionInspectDiagnostic {
+  return {
+    severity,
+    code,
+    message,
+    sessionId: header.sessionId,
+    agentRunId: header.runId,
+    turnId: header.turnId,
+    ...(eventId ? { eventId } : {}),
+  };
+}
+
+function coverageFor(runId: string, events: readonly RuntimeEvent[]): ExecutionLogCoverage | undefined {
+  const first = events[0];
+  const last = events.at(-1);
+  if (!first || !last) return undefined;
+  return {
+    lowWater: { ledger: 'runtime_event', streamId: runId, sequence: 0, eventId: first.id },
+    highWater: { ledger: 'runtime_event', streamId: runId, sequence: events.length - 1, eventId: last.id },
+    eventCount: events.length,
+  };
+}
+
+function appendDiagnostics(lines: string[], diagnostics: readonly ExecutionInspectDiagnostic[]): void {
+  if (diagnostics.length === 0) return;
+  lines.push(`└─ Diagnostics (${diagnostics.length})`);
+  diagnostics.forEach((item, index) => {
+    lines.push(`   ${index === diagnostics.length - 1 ? '└─' : '├─'} ${item.severity.toUpperCase()} ${item.code}: ${item.message}`);
+  });
+}
+
+function formatCoverage(coverage: ExecutionLogCoverage | undefined): string {
+  if (!coverage) return 'unknown';
+  const low = coverage.lowWater?.sequence ?? 0;
+  return `${coverage.highWater.ledger}:${coverage.highWater.streamId} ${low}–${coverage.highWater.sequence}`;
+}

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -673,6 +673,28 @@ export type {
   InspectAgentRunOptions,
 } from './agent-run-inspect.js';
 
+// execution-inspect.ts — payload-safe, versioned CLI inspection documents.
+export {
+  AGENT_RUN_INSPECT_DOCUMENT_VERSION,
+  SESSION_INSPECT_DOCUMENT_VERSION,
+  inspectAgentRunDocument,
+  inspectSessionDocument,
+  renderAgentRunInspectTree,
+  renderSessionInspectTree,
+} from './execution-inspect.js';
+export type {
+  AgentRunInspectCompactionCheckpoint,
+  AgentRunInspectDocument,
+  AgentRunInspectIdentity,
+  AgentRunInspectToolFact,
+  AgentRunInspectToolSummary,
+  ExecutionInspectDiagnostic,
+  ExecutionInspectSeverity,
+  SessionHeaderReader,
+  SessionInspectDocument,
+  SessionInspectSummary,
+} from './execution-inspect.js';
+
 // model-history.ts — policy-driven model-history projection.
 export { buildModelHistoryFromRuntimeEvents } from './model-history.js';
 export type {

--- a/packages/storage/src/__tests__/session-store.test.ts
+++ b/packages/storage/src/__tests__/session-store.test.ts
@@ -7,6 +7,17 @@ import type { CreateSessionInput, SessionHeader, StoredMessage } from '@maka/cor
 import { createSessionStore } from '../session-store.js';
 
 describe('FileSessionStore CRUD', () => {
+  test('list on a missing workspace is observational and does not create session storage', async () => {
+    const workspaceRoot = await mkdtemp(join(tmpdir(), 'maka-session-list-'));
+    try {
+      const sessionsRoot = join(workspaceRoot, 'sessions');
+      assert.deepEqual(await createSessionStore(workspaceRoot).list(), []);
+      await assert.rejects(() => readFile(sessionsRoot), { code: 'ENOENT' });
+    } finally {
+      await rm(workspaceRoot, { recursive: true, force: true });
+    }
+  });
+
   test('archive sets isArchived and archivedAt; unarchive clears them', async () => {
     await withStore(async (store) => {
       const header = await store.create(makeInput({ name: 'Archived me' }));
@@ -36,6 +47,19 @@ describe('FileSessionStore CRUD', () => {
       assert.equal(summary?.statusUpdatedAt, header.statusUpdatedAt);
       assert.equal(summary?.model, 'fake-model');
       assert.equal(summary?.cwd, '/tmp/cwd');
+    });
+  });
+
+  test('readHeaderSnapshot is observational and does not lock the connection', async () => {
+    await withStore(async (store) => {
+      const header = await store.create(makeInput({ name: 'Inspect me' }));
+      await store.appendMessage(header.id, {
+        type: 'user', id: 'user-1', turnId: 'turn-1', ts: 1, text: 'hello',
+      });
+
+      assert.equal((await store.readHeaderSnapshot(header.id)).connectionLocked, false);
+      assert.equal((await store.readHeaderSnapshot(header.id)).connectionLocked, false);
+      assert.equal((await store.readHeader(header.id)).connectionLocked, true);
     });
   });
 

--- a/packages/storage/src/session-store.ts
+++ b/packages/storage/src/session-store.ts
@@ -26,6 +26,8 @@ const SESSION_ID_PATTERN = /^[A-Za-z0-9_-]{1,128}$/;
 export interface SessionStore {
   create(input: CreateSessionInput): Promise<SessionHeader>;
   list(filter?: SessionListFilter): Promise<SessionSummary[]>;
+  /** Read only the durable header without triggering connection-lock self-healing. */
+  readHeaderSnapshot(sessionId: string): Promise<SessionHeader>;
   readHeader(sessionId: string): Promise<SessionHeader>;
   readMessages(sessionId: string): Promise<StoredMessage[]>;
   listTurns(sessionId: string): Promise<TurnRecord[]>;
@@ -110,8 +112,13 @@ class FileSessionStore implements SessionStore {
   }
 
   async list(filter?: SessionListFilter): Promise<SessionSummary[]> {
-    await mkdir(this.sessionsRoot, { recursive: true });
-    const entries = await import('node:fs/promises').then((fs) => fs.readdir(this.sessionsRoot, { withFileTypes: true }));
+    let entries;
+    try {
+      entries = await import('node:fs/promises').then((fs) => fs.readdir(this.sessionsRoot, { withFileTypes: true }));
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') return [];
+      throw error;
+    }
 
     // Phase 1: read each header plus a bounded tail preview. That keeps
     // list() proportional to the number of sessions rather than full
@@ -174,6 +181,10 @@ class FileSessionStore implements SessionStore {
       return this.updateHeader(sessionId, { connectionLocked: true });
     }
     return header;
+  }
+
+  async readHeaderSnapshot(sessionId: string): Promise<SessionHeader> {
+    return this.readHeaderOnly(sessionId);
   }
 
   async readMessages(sessionId: string): Promise<StoredMessage[]> {


### PR DESCRIPTION
## Summary

Phase 3B of #948 adds a single payload-safe inspection entrypoint across Maka's durable execution identities:

- add `maka inspect <id>` for Session, AgentRun, and TaskRun
- auto-resolve an id only when it has exactly one meaning
- surface cross-kind collisions and duplicate AgentRun ids as explicit ambiguity
- support `--kind session|agent-run|task-run` and `--session <id>` for deterministic disambiguation
- add stable JSON resolution failures for `not_found` and `ambiguous`

## Inspect documents

- add `maka.agent_run_inspect.v1`
- add `maka.session_inspect.v1`
- reuse Phase 3A's `maka.task_run_inspect.v1`
- render matching human-readable trees from the same bounded read models
- expose identity, event coverage, source health, Tool Call/Response pairing, Compaction metadata, and diagnostics
- never duplicate raw model messages, tool arguments, or tool results into the inspect surface

## Read-only behavior

Inspection is observational:

- add `SessionStore.readHeaderSnapshot()` so inspection cannot trigger connection-lock self-healing
- make listing a missing Session store return an empty result without creating storage directories

## Failure semantics

- no silent kind precedence
- no silent choice between duplicate AgentRun ids in different Sessions
- unmatched Tool Calls explicitly report unknown outcome and external side effects
- missing and inconsistent Runtime/operational ledgers remain visible as diagnostics

## Validation

- `npm --workspace @maka/storage test`
- `npm --workspace @maka/runtime test`
- `npm --workspace @maka/headless test`
- `npm --workspace maka-agent test`
- `npm run typecheck`
- executable CLI contract test for `maka inspect ... --json`
- contract tests for ambiguity, not-found output, payload hygiene, Session projection, and read-only storage behavior

This intentionally does not expand verifier behavior or Phase 4 AHE evolution lineage.