### PR TITLE
feat(core): add scoped additional permission profiles

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -17,6 +17,7 @@
     "./session-event-health": "./dist/session-event-health.js",
     "./permission": "./dist/permission.js",
     "./permission-profile": "./dist/permission-profile.js",
+    "./additional-permissions": "./dist/additional-permissions.js",
     "./permission-profile-compiler": "./dist/permission-profile-compiler.js",
     "./permission-request-health": "./dist/permission-request-health.js",
     "./user-question": "./dist/user-question.js",

--- a/packages/core/src/__tests__/additional-permissions.test.ts
+++ b/packages/core/src/__tests__/additional-permissions.test.ts
@@ -1,0 +1,152 @@
+import { describe, test } from 'node:test';
+import { expect } from '../test-helpers.js';
+import {
+  additionalPermissionAllowsPath,
+  applyAdditionalPermissionProfile,
+  compactAdditionalFileSystemPermissions,
+  serializeAdditionalPermissionProfile,
+  validateAdditionalPermissionProfile,
+  type AdditionalPermissionProfile,
+} from '../additional-permissions.js';
+import {
+  canReadPath,
+  canWritePath,
+  createWorkspaceWritePermissionProfile,
+  type PermissionProfile,
+} from '../permission-profile.js';
+
+const CONTEXT = { workspaceRoots: ['/workspace/project'] };
+
+describe('AdditionalPermissionProfile validation', () => {
+  test('accepts and canonicalizes a minimal filesystem permission', () => {
+    const result = validateAdditionalPermissionProfile({
+      fileSystem: {
+        entries: [{ path: '/outside/file.txt', access: 'write', scope: 'exact' }],
+      },
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.profile).toEqual({
+      fileSystem: {
+        entries: [{ path: '/outside/file.txt', access: 'write', scope: 'exact' }],
+      },
+    });
+  });
+
+  test('accepts one-command network enable', () => {
+    expect(validateAdditionalPermissionProfile({ network: { enabled: true } })).toEqual({
+      ok: true,
+      profile: { network: { enabled: true } },
+    });
+  });
+
+  test('rejects empty, relative, malformed, and policy-shaped profiles', () => {
+    for (const profile of [
+      {},
+      { fileSystem: { entries: [] } },
+      { fileSystem: { entries: [{ path: '../outside', access: 'read', scope: 'exact' }] } },
+      { fileSystem: { entries: [{ path: '/outside', access: 'deny', scope: 'exact' }] } },
+      { fileSystem: { entries: [{ path: '/outside', access: 'read', scope: 'special' }] } },
+      { fileSystem: { entries: [{ path: '/outside', access: 'read', scope: 'exact', kind: 'path' }] } },
+      { network: { enabled: false } },
+      { type: 'managed', network: { enabled: true } },
+    ]) {
+      expect(validateAdditionalPermissionProfile(profile).ok).toBe(false);
+    }
+  });
+
+  test('compacts covered and duplicate entries deterministically', () => {
+    expect(compactAdditionalFileSystemPermissions([
+      { path: '/outside/tree/file.txt', access: 'read', scope: 'exact' },
+      { path: '/outside/tree', access: 'read', scope: 'subtree' },
+      { path: '/outside/tree', access: 'read', scope: 'subtree' },
+      { path: '/outside/write.txt', access: 'read', scope: 'exact' },
+      { path: '/outside/write.txt', access: 'write', scope: 'exact' },
+    ])).toEqual([
+      { path: '/outside/tree', access: 'read', scope: 'subtree' },
+      { path: '/outside/write.txt', access: 'write', scope: 'exact' },
+    ]);
+  });
+
+  test('canonical serialization is stable across input order', () => {
+    const first: AdditionalPermissionProfile = {
+      fileSystem: { entries: [
+        { path: '/b', access: 'read', scope: 'exact' },
+        { path: '/a', access: 'write', scope: 'subtree' },
+      ] },
+      network: { enabled: true },
+    };
+    const second: AdditionalPermissionProfile = {
+      network: { enabled: true },
+      fileSystem: { entries: [...first.fileSystem!.entries].reverse() },
+    };
+    expect(serializeAdditionalPermissionProfile(first)).toBe(serializeAdditionalPermissionProfile(second));
+  });
+});
+
+describe('Additional permission matching and effective profiles', () => {
+  test('exact matches only one path while subtree includes descendants', () => {
+    const profile: AdditionalPermissionProfile = {
+      fileSystem: { entries: [
+        { path: '/outside/exact.txt', access: 'read', scope: 'exact' },
+        { path: '/outside/tree', access: 'write', scope: 'subtree' },
+      ] },
+    };
+    expect(additionalPermissionAllowsPath(profile, '/outside/exact.txt', 'read')).toBe(true);
+    expect(additionalPermissionAllowsPath(profile, '/outside/exact.txt/sibling', 'read')).toBe(false);
+    expect(additionalPermissionAllowsPath(profile, '/outside/tree/child.txt', 'write')).toBe(true);
+    expect(additionalPermissionAllowsPath(profile, '/outside/tree2/child.txt', 'write')).toBe(false);
+  });
+
+  test('write permission implies read permission', () => {
+    const profile: AdditionalPermissionProfile = {
+      fileSystem: { entries: [{ path: '/outside/file.txt', access: 'write', scope: 'exact' }] },
+    };
+    expect(additionalPermissionAllowsPath(profile, '/outside/file.txt', 'read')).toBe(true);
+    expect(additionalPermissionAllowsPath(profile, '/outside/file.txt', 'write')).toBe(true);
+  });
+
+  test('effective profile grants one outside path without mutating the base profile', () => {
+    const base = createWorkspaceWritePermissionProfile();
+    const effective = applyAdditionalPermissionProfile(base, {
+      fileSystem: { entries: [{ path: '/outside/file.txt', access: 'write', scope: 'exact' }] },
+    });
+    expect(canWritePath(base, '/outside/file.txt', CONTEXT)).toBe(false);
+    expect(canWritePath(effective, '/outside/file.txt', CONTEXT)).toBe(true);
+    expect(canWritePath(effective, '/outside/sibling.txt', CONTEXT)).toBe(false);
+  });
+
+  test('explicit path grant overrides protected metadata default for its exact target', () => {
+    const effective = applyAdditionalPermissionProfile(createWorkspaceWritePermissionProfile(), {
+      fileSystem: { entries: [{ path: '/workspace/project/.git/config', access: 'write', scope: 'exact' }] },
+    });
+    expect(canWritePath(effective, '/workspace/project/.git/config', CONTEXT)).toBe(true);
+    expect(canReadPath(effective, '/workspace/project/.git/config', CONTEXT)).toBe(true);
+    expect(canWritePath(effective, '/workspace/project/.git/HEAD', CONTEXT)).toBe(false);
+  });
+
+  test('explicit deny remains stronger than an additional allow', () => {
+    const base: PermissionProfile = {
+      type: 'managed',
+      name: 'custom',
+      fileSystem: {
+        kind: 'restricted',
+        entries: [{ kind: 'path', access: 'deny', path: '/outside/locked', match: 'subtree' }],
+      },
+      network: { kind: 'restricted' },
+    };
+    const effective = applyAdditionalPermissionProfile(base, {
+      fileSystem: { entries: [{ path: '/outside/locked/file.txt', access: 'write', scope: 'exact' }] },
+    });
+    expect(canReadPath(effective, '/outside/locked/file.txt')).toBe(false);
+    expect(canWritePath(effective, '/outside/locked/file.txt')).toBe(false);
+  });
+
+  test('network enable changes only the effective managed profile', () => {
+    const base = createWorkspaceWritePermissionProfile();
+    const effective = applyAdditionalPermissionProfile(base, { network: { enabled: true } });
+    expect(base.network.kind).toBe('restricted');
+    expect(effective.type).toBe('managed');
+    if (effective.type === 'managed') expect(effective.network.kind).toBe('enabled');
+  });
+});

--- a/packages/core/src/additional-permissions.ts
+++ b/packages/core/src/additional-permissions.ts
@@ -1,0 +1,264 @@
+import {
+  canReadPath,
+  canWritePath,
+  type FileSystemPathMatch,
+  type PermissionProfile,
+  type PermissionProfileManaged,
+  type PermissionProfileMatchContext,
+} from './permission-profile.js';
+
+export const ADDITIONAL_PERMISSION_ACCESS_MODES = ['read', 'write'] as const;
+export type AdditionalPermissionAccess = typeof ADDITIONAL_PERMISSION_ACCESS_MODES[number];
+
+export const ADDITIONAL_PERMISSION_SCOPES = ['exact', 'subtree'] as const;
+export type AdditionalPermissionScope = typeof ADDITIONAL_PERMISSION_SCOPES[number];
+
+export const MAX_ADDITIONAL_FILESYSTEM_ENTRIES = 32;
+export const MAX_ADDITIONAL_PERMISSION_PATH_CHARS = 4096;
+export const MAX_ADDITIONAL_PERMISSION_SERIALIZED_BYTES = 64 * 1024;
+
+export interface AdditionalFileSystemPermission {
+  readonly path: string;
+  readonly access: AdditionalPermissionAccess;
+  readonly scope: AdditionalPermissionScope;
+}
+
+export interface AdditionalPermissionProfile {
+  readonly fileSystem?: {
+    readonly entries: readonly AdditionalFileSystemPermission[];
+  };
+  readonly network?: {
+    readonly enabled: true;
+  };
+}
+
+export type AdditionalPermissionValidationFailureReason =
+  | 'invalid_profile'
+  | 'empty_profile'
+  | 'too_many_entries'
+  | 'invalid_entry'
+  | 'invalid_path'
+  | 'path_too_long'
+  | 'payload_too_large';
+
+export type AdditionalPermissionValidationResult =
+  | { ok: true; profile: AdditionalPermissionProfile }
+  | { ok: false; reason: AdditionalPermissionValidationFailureReason; message: string };
+
+export function validateAdditionalPermissionProfile(
+  input: unknown,
+): AdditionalPermissionValidationResult {
+  if (!isRecord(input)) return invalid('invalid_profile', 'Additional permission profile must be an object.');
+  if (hasUnexpectedKeys(input, ['fileSystem', 'network'])) {
+    return invalid('invalid_profile', 'Additional permission profile contains unsupported fields.');
+  }
+
+  const entriesResult = validateFilesystem(input.fileSystem);
+  if (!entriesResult.ok) return entriesResult;
+  const networkResult = validateNetwork(input.network);
+  if (!networkResult.ok) return networkResult;
+  if (entriesResult.entries.length === 0 && !networkResult.enabled) {
+    return invalid('empty_profile', 'Additional permission profile must contain at least one permission.');
+  }
+
+  const profile: AdditionalPermissionProfile = {
+    ...(entriesResult.entries.length > 0
+      ? { fileSystem: { entries: compactAdditionalFileSystemPermissions(entriesResult.entries) } }
+      : {}),
+    ...(networkResult.enabled ? { network: { enabled: true as const } } : {}),
+  };
+  if (serializedByteLength(profile) > MAX_ADDITIONAL_PERMISSION_SERIALIZED_BYTES) {
+    return invalid('payload_too_large', 'Additional permission profile exceeds the serialized size limit.');
+  }
+  return { ok: true, profile };
+}
+
+export function compactAdditionalFileSystemPermissions(
+  entries: readonly AdditionalFileSystemPermission[],
+): readonly AdditionalFileSystemPermission[] {
+  const sorted = [...entries]
+    .map((entry) => ({ ...entry, path: trimTrailingSlashes(entry.path) }))
+    .sort(compareEntries);
+  const compacted: AdditionalFileSystemPermission[] = [];
+  for (const entry of sorted) {
+    if (compacted.some((existing) => permissionCovers(existing, entry))) continue;
+    for (let index = compacted.length - 1; index >= 0; index -= 1) {
+      if (permissionCovers(entry, compacted[index]!)) compacted.splice(index, 1);
+    }
+    compacted.push(entry);
+  }
+  return compacted.sort(compareEntries);
+}
+
+export function additionalPermissionMatchesPath(
+  entry: AdditionalFileSystemPermission,
+  path: string,
+  access: AdditionalPermissionAccess,
+): boolean {
+  if (access === 'write' && entry.access !== 'write') return false;
+  if (entry.scope === 'exact') return samePath(path, entry.path);
+  return pathWithinRoot(path, entry.path);
+}
+
+export function additionalPermissionAllowsPath(
+  profile: AdditionalPermissionProfile,
+  path: string,
+  access: AdditionalPermissionAccess,
+): boolean {
+  return profile.fileSystem?.entries.some((entry) => (
+    additionalPermissionMatchesPath(entry, path, access)
+  )) ?? false;
+}
+
+export function applyAdditionalPermissionProfile(
+  base: PermissionProfile,
+  additional: AdditionalPermissionProfile,
+): PermissionProfile {
+  if (base.type !== 'managed' || base.fileSystem.kind === 'unrestricted') return base;
+
+  const entries = additional.fileSystem?.entries ?? [];
+  const fileSystemEntries = [
+    ...base.fileSystem.entries,
+    ...entries.map((entry) => ({
+      kind: 'path' as const,
+      access: entry.access,
+      path: entry.path,
+      match: entry.scope satisfies FileSystemPathMatch,
+    })),
+  ];
+
+  return {
+    ...base,
+    fileSystem: {
+      ...base.fileSystem,
+      entries: fileSystemEntries,
+    },
+    network: additional.network?.enabled ? { kind: 'enabled' } : base.network,
+  } satisfies PermissionProfileManaged;
+}
+
+export function additionalPermissionRequiredForPath(input: {
+  profile: PermissionProfile;
+  path: string;
+  access: AdditionalPermissionAccess;
+  context?: PermissionProfileMatchContext;
+}): boolean {
+  return input.access === 'write'
+    ? !canWritePath(input.profile, input.path, input.context)
+    : !canReadPath(input.profile, input.path, input.context);
+}
+
+export function serializeAdditionalPermissionProfile(
+  profile: AdditionalPermissionProfile,
+): string {
+  const validated = validateAdditionalPermissionProfile(profile);
+  if (!validated.ok) throw new Error(validated.message);
+  return JSON.stringify(validated.profile);
+}
+
+function validateFilesystem(
+  input: unknown,
+): { ok: true; entries: AdditionalFileSystemPermission[] } | Extract<AdditionalPermissionValidationResult, { ok: false }> {
+  if (input === undefined) return { ok: true, entries: [] };
+  if (!isRecord(input) || hasUnexpectedKeys(input, ['entries']) || !Array.isArray(input.entries)) {
+    return invalid('invalid_profile', 'fileSystem must contain an entries array.');
+  }
+  if (input.entries.length > MAX_ADDITIONAL_FILESYSTEM_ENTRIES) {
+    return invalid('too_many_entries', `Additional filesystem permissions are limited to ${MAX_ADDITIONAL_FILESYSTEM_ENTRIES} entries.`);
+  }
+  const entries: AdditionalFileSystemPermission[] = [];
+  for (const candidate of input.entries) {
+    if (!isRecord(candidate) || hasUnexpectedKeys(candidate, ['path', 'access', 'scope'])) {
+      return invalid('invalid_entry', 'Additional filesystem permission contains unsupported fields.');
+    }
+    if (
+      typeof candidate.path !== 'string'
+      || !ADDITIONAL_PERMISSION_ACCESS_MODES.includes(candidate.access as AdditionalPermissionAccess)
+      || !ADDITIONAL_PERMISSION_SCOPES.includes(candidate.scope as AdditionalPermissionScope)
+    ) {
+      return invalid('invalid_entry', 'Additional filesystem permission must contain path, access, and scope.');
+    }
+    if (!isNormalizedAbsolutePath(candidate.path)) {
+      return invalid('invalid_path', 'Additional filesystem permission path must be a normalized absolute POSIX path.');
+    }
+    if (candidate.path.length > MAX_ADDITIONAL_PERMISSION_PATH_CHARS) {
+      return invalid('path_too_long', 'Additional filesystem permission path exceeds the length limit.');
+    }
+    entries.push({
+      path: trimTrailingSlashes(candidate.path),
+      access: candidate.access as AdditionalPermissionAccess,
+      scope: candidate.scope as AdditionalPermissionScope,
+    });
+  }
+  return { ok: true, entries };
+}
+
+function validateNetwork(
+  input: unknown,
+): { ok: true; enabled: boolean } | Extract<AdditionalPermissionValidationResult, { ok: false }> {
+  if (input === undefined) return { ok: true, enabled: false };
+  if (!isRecord(input) || hasUnexpectedKeys(input, ['enabled']) || input.enabled !== true) {
+    return invalid('invalid_profile', 'network additional permission only supports enabled: true.');
+  }
+  return { ok: true, enabled: true };
+}
+
+function permissionCovers(
+  existing: AdditionalFileSystemPermission,
+  candidate: AdditionalFileSystemPermission,
+): boolean {
+  if (candidate.access === 'write' && existing.access !== 'write') return false;
+  if (existing.scope === 'exact') {
+    return candidate.scope === 'exact' && samePath(existing.path, candidate.path);
+  }
+  return pathWithinRoot(candidate.path, existing.path);
+}
+
+function compareEntries(a: AdditionalFileSystemPermission, b: AdditionalFileSystemPermission): number {
+  return a.path.localeCompare(b.path)
+    || (a.scope === b.scope ? 0 : a.scope === 'subtree' ? -1 : 1)
+    || (a.access === b.access ? 0 : a.access === 'write' ? -1 : 1);
+}
+
+function isNormalizedAbsolutePath(path: string): boolean {
+  if (!path.startsWith('/') || path.includes('\0') || path.includes('\\')) return false;
+  if (path.length > 1 && path.endsWith('/')) return false;
+  return !path.split('/').some((segment, index) => index > 0 && (segment === '' || segment === '.' || segment === '..'));
+}
+
+function pathWithinRoot(path: string, root: string): boolean {
+  const normalizedPath = trimTrailingSlashes(path);
+  const normalizedRoot = trimTrailingSlashes(root);
+  if (normalizedRoot === '/') return normalizedPath.startsWith('/');
+  return normalizedPath === normalizedRoot || normalizedPath.startsWith(`${normalizedRoot}/`);
+}
+
+function samePath(a: string, b: string): boolean {
+  return trimTrailingSlashes(a) === trimTrailingSlashes(b);
+}
+
+function trimTrailingSlashes(value: string): string {
+  if (value === '/') return value;
+  return value.replace(/\/+$/g, '');
+}
+
+function serializedByteLength(value: unknown): number {
+  const json = JSON.stringify(value);
+  if (typeof TextEncoder !== 'undefined') return new TextEncoder().encode(json).byteLength;
+  return json.length;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function hasUnexpectedKeys(value: Record<string, unknown>, allowed: readonly string[]): boolean {
+  return Object.keys(value).some((key) => !allowed.includes(key));
+}
+
+function invalid(
+  reason: AdditionalPermissionValidationFailureReason,
+  message: string,
+): Extract<AdditionalPermissionValidationResult, { ok: false }> {
+  return { ok: false, reason, message };
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -319,6 +319,7 @@ export type {
   PermissionProfileName,
   FileSystemAccessMode,
   FileSystemProtectedMetadataPolicy,
+  FileSystemPathMatch,
   FileSystemSandboxEntry,
   FileSystemSandboxKind,
   FileSystemSandboxPolicy,
@@ -329,6 +330,7 @@ export type {
 } from './permission-profile.js';
 export {
   FILE_SYSTEM_ACCESS_MODES,
+  FILE_SYSTEM_PATH_MATCHES,
   FILE_SYSTEM_SANDBOX_KINDS,
   FILE_SYSTEM_SPECIAL_PATHS,
   NETWORK_SANDBOX_KINDS,
@@ -342,6 +344,30 @@ export {
   isDeniedPath,
   isProtectedMetadataPath,
 } from './permission-profile.js';
+
+// additional-permissions.ts
+export type {
+  AdditionalFileSystemPermission,
+  AdditionalPermissionAccess,
+  AdditionalPermissionProfile,
+  AdditionalPermissionScope,
+  AdditionalPermissionValidationFailureReason,
+  AdditionalPermissionValidationResult,
+} from './additional-permissions.js';
+export {
+  ADDITIONAL_PERMISSION_ACCESS_MODES,
+  ADDITIONAL_PERMISSION_SCOPES,
+  MAX_ADDITIONAL_FILESYSTEM_ENTRIES,
+  MAX_ADDITIONAL_PERMISSION_PATH_CHARS,
+  MAX_ADDITIONAL_PERMISSION_SERIALIZED_BYTES,
+  additionalPermissionAllowsPath,
+  additionalPermissionMatchesPath,
+  additionalPermissionRequiredForPath,
+  applyAdditionalPermissionProfile,
+  compactAdditionalFileSystemPermissions,
+  serializeAdditionalPermissionProfile,
+  validateAdditionalPermissionProfile,
+} from './additional-permissions.js';
 
 // permission-profile-compiler.ts
 export type {

--- a/packages/core/src/permission-profile.ts
+++ b/packages/core/src/permission-profile.ts
@@ -12,6 +12,8 @@ export type FileSystemSandboxKind = typeof FILE_SYSTEM_SANDBOX_KINDS[number];
 export const FILE_SYSTEM_ACCESS_MODES = ['read', 'write', 'deny'] as const;
 export type FileSystemAccessMode = typeof FILE_SYSTEM_ACCESS_MODES[number];
 
+export const FILE_SYSTEM_PATH_MATCHES = ['exact', 'subtree'] as const;
+export type FileSystemPathMatch = typeof FILE_SYSTEM_PATH_MATCHES[number];
 export const FILE_SYSTEM_SPECIAL_PATHS = [
   ':root',
   ':workspace_roots',
@@ -26,6 +28,8 @@ export type FileSystemSandboxEntry =
       kind: 'path';
       access: FileSystemAccessMode;
       path: string;
+      /** Defaults to subtree for backward compatibility with profile roots. */
+      match?: FileSystemPathMatch;
     }
   | {
       kind: 'special';
@@ -176,7 +180,7 @@ export function canWritePath(
   const policy = fileSystemPolicy(profile);
   if (!policy) return true;
   if (isDeniedPath(profile, path, context)) return false;
-  if (isProtectedWriteDenied(policy, path, context)) return false;
+  if (isProtectedWriteDenied(policy, path, context) && !hasExplicitPathWrite(policy, path, context)) return false;
   if (policy.kind === 'unrestricted' || policy.kind === 'external_sandbox') return true;
   return hasMatchingAccess(policy, path, context, ['write']);
 }
@@ -223,9 +227,23 @@ function entryMatchesPath(
   path: string,
   context: PermissionProfileMatchContext,
 ): boolean {
+  if (entry.kind === 'path' && entry.match === 'exact') {
+    return samePath(path, entry.path);
+  }
   return entryRoots(entry, context).some((root) => pathWithinRoot(path, root));
 }
 
+function hasExplicitPathWrite(
+  policy: FileSystemSandboxPolicy,
+  path: string,
+  context: PermissionProfileMatchContext,
+): boolean {
+  return policy.entries.some((entry) => (
+    entry.kind === 'path'
+    && entry.access === 'write'
+    && entryMatchesPath(entry, path, context)
+  ));
+}
 function entryRoots(entry: FileSystemSandboxEntry, context: PermissionProfileMatchContext): readonly string[] {
   if (entry.kind === 'path') return [entry.path];
   switch (entry.special) {
@@ -270,6 +288,9 @@ function pathWithinRoot(path: string, root: string): boolean {
   return normalizedPath === normalizedRoot || normalizedPath.startsWith(normalizedRoot + '/');
 }
 
+function samePath(path: string, expected: string): boolean {
+  return trimTrailingSlashes(path) === trimTrailingSlashes(expected);
+}
 function trimTrailingSlashes(value: string): string {
   if (!value) return '';
   const trimmed = value.replace(/\/+$/, '');


### PR DESCRIPTION
## Summary

Refs #509  
Extracted from #880 as an independently reviewable slice.

This PR adds the platform-independent Core contract for granting narrowly scoped, one-call additional permissions.

- Defines filesystem permissions with `read` / `write` access
- Supports `exact` path and `subtree` scopes
- Supports temporarily enabling network access
- Validates and bounds permission payloads
- Canonicalizes, compacts, and deterministically serializes permission profiles
- Applies additional permissions without mutating the base `PermissionProfile`
- Preserves explicit deny precedence
- Allows an explicit path grant to override protected-metadata default write denial only for the granted target

## Scope

This PR only introduces the Core data model and matching primitives.

It does not:

- request approval from the user
- store additional permissions across tool calls
- integrate permissions into Runtime tool execution
- change the default sandbox execution path
- implement unsandboxed retry

Runtime orchestration and approval handling will be submitted as separate slices.

## Behavior

- A `write` grant also permits reading the same target
- An `exact` grant does not permit sibling or descendant paths
- A `subtree` grant includes the target directory and its descendants
- Explicit deny entries remain stronger than additional allows
- The original permission profile remains unchanged
- Filesystem entries and serialized payloads have defensive size limits

## Verification

- `npm test --workspace @maka/core`
- `npm run build`
- `npm run typecheck`

Core tests: 930 passed, 0 failed.

The full `test:dist` run reached the existing Desktop `open-gateway.test.js` pending-promise issue; all other completed Desktop tests passed (2474 passed, 1 cancelled when the hanging run was stopped).