### PR TITLE
fix(skills): remove inert 技能示例 cards, make starter seeding idempotent, add per-row delete

### DIFF
--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -600,8 +600,12 @@ declare global {
           | { ok: false; reason: 'not_found' | 'blocked_path' | 'state_error' | 'write_failed' }
         >;
         createStarter(): Promise<
-          | { ok: true; skill: SkillEntry; filePath: string }
+          | { ok: true; created: boolean; skill: SkillEntry; filePath: string }
           | { ok: false; reason: 'blocked_path' | 'already_exists' | 'write_failed' }
+        >;
+        delete(id: string): Promise<
+          | { ok: true }
+          | { ok: false; reason: 'not_found' | 'blocked_path' | 'delete_failed' }
         >;
         open(id: string, target?: 'file' | 'directory'): Promise<
           | { ok: true; target: 'file' | 'directory' }

--- a/apps/desktop/src/main/__tests__/skills.test.ts
+++ b/apps/desktop/src/main/__tests__/skills.test.ts
@@ -1,7 +1,7 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { createHash } from 'node:crypto';
-import { lstat, mkdir, mkdtemp, readFile, realpath, rm, symlink, writeFile } from 'node:fs/promises';
+import { lstat, mkdir, mkdtemp, readFile, readdir, realpath, rm, symlink, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { readMainProcessCombinedSource } from './main-process-contract-source-helpers.js';
@@ -11,6 +11,7 @@ import {
   buildSkillAgentTool,
   buildSkillsPromptFragment,
   createStarterSkill,
+  deleteSkill,
   ensureBundledOfficeSkills,
   getSkillGovernanceDetails,
   installManagedSkill,
@@ -310,6 +311,7 @@ ${'A'.repeat(MAX_SKILL_TOOL_BODY_CHARS + 1000)}`);
       const result = await createStarterSkill(workspaceRoot);
       assert.equal(result.ok, true);
       if (!result.ok) return;
+      assert.equal(result.created, true);
       assert.equal(result.skill.id, 'starter-skill');
       assert.equal(result.skill.name, '示例技能');
       assert.equal(result.skill.path, join(workspaceRoot, 'skills', 'starter-skill'));
@@ -337,20 +339,24 @@ ${'A'.repeat(MAX_SKILL_TOOL_BODY_CHARS + 1000)}`);
       assert.equal(skills[0].sourceType, 'workspace');
       assert.equal(skills[0].validationStatus, 'missing_lock');
 
-      // Repeated creates mint DISTINGUISHABLE names (the id ordinal flows
-      // into the display name + front-matter) — three clicks used to
-      // produce three identical 「示例技能」 rows.
+      // Idempotent seeding: a repeat create REUSES the existing starter-skill
+      // (created:false) instead of minting a duplicate — three clicks used to
+      // produce three indistinguishable 「示例技能」 rows. No new dir appears.
       const second = await createStarterSkill(workspaceRoot);
       assert.equal(second.ok, true);
       if (second.ok) {
-        assert.equal(second.skill.id, 'starter-skill-2');
-        assert.equal(second.skill.name, '示例技能 2');
-        assert.match(await readFile(second.filePath, 'utf8'), /name: 示例技能 2/);
+        assert.equal(second.created, false);
+        assert.equal(second.skill.id, 'starter-skill');
+        assert.equal(second.filePath, join(workspaceRoot, 'skills', 'starter-skill', 'SKILL.md'));
       }
+      const dirs = (await readdir(join(workspaceRoot, 'skills'), { withFileTypes: true }))
+        .filter((entry) => entry.isDirectory())
+        .map((entry) => entry.name);
+      assert.deepEqual(dirs, ['starter-skill']);
     });
   });
 
-  it('creates the next starter skill without overwriting an existing one', async () => {
+  it('reuses an existing starter skill instead of minting a duplicate', async () => {
     await withWorkspace(async (workspaceRoot) => {
       await writeSkill(workspaceRoot, 'starter-skill', `---
 name: Existing
@@ -360,8 +366,44 @@ name: Existing
       const result = await createStarterSkill(workspaceRoot);
       assert.equal(result.ok, true);
       if (!result.ok) return;
-      assert.equal(result.skill.id, 'starter-skill-2');
+      // The existing starter-skill/SKILL.md is reused verbatim; no starter-skill-2
+      // is created and the user's content is left untouched.
+      assert.equal(result.created, false);
+      assert.equal(result.skill.id, 'starter-skill');
       assert.match(await readFile(join(workspaceRoot, 'skills', 'starter-skill', 'SKILL.md'), 'utf8'), /# Existing/);
+      await assert.rejects(lstat(join(workspaceRoot, 'skills', 'starter-skill-2')), { code: 'ENOENT' });
+    });
+  });
+
+  it('deletes an installed skill directory', async () => {
+    await withWorkspace(async (workspaceRoot) => {
+      await writeSkill(workspaceRoot, 'starter-skill', `---
+name: 示例技能
+---
+# 示例技能`);
+      assert.equal((await listInstalledSkills(workspaceRoot)).length, 1);
+
+      assert.deepEqual(await deleteSkill(workspaceRoot, 'starter-skill'), { ok: true });
+      assert.equal((await listInstalledSkills(workspaceRoot)).length, 0);
+      await assert.rejects(lstat(join(workspaceRoot, 'skills', 'starter-skill')), { code: 'ENOENT' });
+
+      // Deleting an absent skill is a clean not_found, not a throw.
+      assert.deepEqual(await deleteSkill(workspaceRoot, 'starter-skill'), { ok: false, reason: 'not_found' });
+    });
+  });
+
+  it('refuses to delete through a symlinked skill directory', async () => {
+    await withWorkspace(async (workspaceRoot) => {
+      const outside = await mkdtemp(join(tmpdir(), 'maka-skill-delete-outside-'));
+      try {
+        await mkdir(join(workspaceRoot, 'skills'), { recursive: true });
+        await symlink(outside, join(workspaceRoot, 'skills', 'outside'));
+        assert.deepEqual(await deleteSkill(workspaceRoot, 'outside'), { ok: false, reason: 'blocked_path' });
+        // The symlink target survives — deletion never followed the link.
+        await lstat(outside);
+      } finally {
+        await rm(outside, { recursive: true, force: true });
+      }
     });
   });
 
@@ -1118,8 +1160,11 @@ name: Writer
     assert.match(ui, /'创建中…'/);
     assert.match(ui, /'刷新中…'/);
     assert.match(ui, />\s*打开目录\s*</);
-    assert.match(ui, /title: '文档处理流'/);
-    assert.match(ui, /title: '演示资料流'/);
+    // The inert 技能示例 example cards were removed — 添加 seeds a real,
+    // editable starter skill instead. No decorative example rows may return.
+    assert.doesNotMatch(ui, /title: '文档处理流'/);
+    assert.doesNotMatch(ui, /title: '演示资料流'/);
+    assert.doesNotMatch(ui, /SKILL_EXAMPLE_CARDS/);
     assert.doesNotMatch(ui, /重启 Maka 后会出现在这里/);
     assert.match(renderer, /async function refreshSkills\(options: \{ shouldShowError\?: \(\) => boolean \} = \{\}\)/);
     assert.match(renderer, /async function createSkillTemplate\(\)/);
@@ -1130,12 +1175,15 @@ name: Writer
     assert.match(renderer, /onPreviewManagedSkillUpdate=\{\(skillId\) => previewManagedSkillUpdate\(skillId\)\}/);
     assert.match(renderer, /onUpdateManagedSkill=\{\(skillId, options\) => updateManagedSkill\(skillId, options\)\}/);
     assert.match(renderer, /onSetSkillEnabled=\{\(skillId, enabled\) => setSkillEnabled\(skillId, enabled\)\}/);
+    assert.match(renderer, /onDeleteSkill=\{\(skillId\) => deleteSkill\(skillId\)\}/);
     assert.match(preload, /createStarter\(\)/);
+    assert.match(preload, /delete\(id: string\)/);
     assert.match(preload, /open\(id: string, target: 'file' \| 'directory' = 'file'\)/);
     assert.match(preload, /previewUpdate\(skillId: string\)/);
     assert.match(preload, /updateManaged\(skillId: string, options\?: \{ force\?: boolean; expectedCurrentSha256\?: string; expectedSourceSha256\?: string \}\)/);
     assert.match(preload, /setEnabled\(skillId: string, enabled: boolean\)/);
     assert.match(main, /ipcMain\.handle\('skills:createStarter'/);
+    assert.match(main, /ipcMain\.handle\('skills:delete'/);
     assert.match(main, /ipcMain\.handle\('skills:open'/);
     assert.match(main, /ipcMain\.handle\('skills:details'/);
     assert.match(main, /ipcMain\.handle\('skills:previewUpdate'/);
@@ -1178,6 +1226,7 @@ name: Writer
     assert.match(skillsModuleMain, /onClick=\{\(\) => void runSkillAction\('folder', props\.onOpenSkillsFolder\)\}/);
     assert.match(skillsModuleMain, /onCreateSkillTemplate=\{props\.onCreateSkillTemplate \? \(\) => runSkillAction\('create', props\.onCreateSkillTemplate\) : undefined\}/);
     assert.match(skillsModuleMain, /onOpenSkill=\{props\.onOpenSkill \? \(skillId\) => runSkillAction\(`open:\$\{skillId\}`, \(\) => props\.onOpenSkill\?\.\(skillId\)\) : undefined\}/);
+    assert.match(skillsModuleMain, /onDeleteSkill=\{props\.onDeleteSkill \? \(skillId\) => runSkillAction\(`delete:\$\{skillId\}`, \(\) => props\.onDeleteSkill\?\.\(skillId\)\) : undefined\}/);
 
     assert.match(skillPanel, /actionBusy\?: boolean/);
     assert.match(skillPanel, /createPending\?: boolean/);
@@ -1185,12 +1234,14 @@ name: Writer
     assert.match(skillPanel, /managedSkillSources\?: ManagedSkillSourceEntry\[]/);
     assert.match(skillPanel, /installingSourceId\?: string \| null/);
     assert.match(skillPanel, /updatingSkillId\?: string \| null/);
-    assert.match(skillPanel, /const templates = \(/);
     assert.doesNotMatch(skillPanel, /maka-skill-workbench-rail/);
     assert.doesNotMatch(skillPanel, /maka-skill-workbench-summary/);
-    assert.match(skillPanel, /<section className="maka-skill-examples" aria-label="技能示例">/);
-    assert.match(skillPanel, /<ul className="maka-skill-example-grid" aria-label="技能模板示例">/);
-    assert.match(skillPanel, /className="maka-skill-template-row"/);
+    // 技能示例 removed: no inert example section/grid/rows may render under the
+    // installed list. 添加 seeds a real starter skill; there are no decorations.
+    assert.doesNotMatch(skillPanel, /const templates = \(/);
+    assert.doesNotMatch(skillPanel, /maka-skill-examples/);
+    assert.doesNotMatch(skillPanel, /maka-skill-example-grid/);
+    assert.doesNotMatch(skillPanel, /maka-skill-template-row/);
     assert.match(skillPanel, /<section className="maka-skill-installed" aria-label={label}>/);
     assert.match(skillPanel, /<div className="maka-skill-library" aria-busy=\{props\.actionBusy \? 'true' : undefined\}>/);
     assert.match(skillPanel, /<ul className="maka-skill-library-list" aria-label="技能列表">/);
@@ -1240,6 +1291,16 @@ name: Writer
     assert.match(skillPanel, /onUpdateManagedSkill\?\(skillId: string, options\?: \{ force\?: boolean; expectedCurrentSha256\?: string; expectedSourceSha256\?: string \}\): boolean \| Promise<boolean>/);
     assert.match(skillPanel, /onSetSkillEnabled\?\(skillId: string, enabled: boolean\): void \| Promise<void>/);
     assert.match(skillPanel, /<Switch[\s\S]*checked=\{skill\.enabled\}[\s\S]*onCheckedChange=\{\(next\) => props\.onSetSkillEnabled\?\.\(skill\.id, next === true\)\}/);
+    // Per-row delete: destructive two-step confirm (no dialog precedent here).
+    // First click arms 确认删除; a second within the window fires onDeleteSkill.
+    // aria-label names the skill and reflects the armed state (keyboard-safe).
+    assert.match(skillPanel, /onDeleteSkill\?\(skillId: string\): void \| Promise<void>/);
+    assert.match(skillPanel, /className="maka-skill-library-delete-button"/);
+    assert.match(skillPanel, /function requestDeleteSkill\(skill: SkillEntry\)/);
+    assert.match(skillPanel, /setConfirmingDeleteSkillId\(skill\.id\)[\s\S]*setTimeout\([\s\S]*setConfirmingDeleteSkillId\(null\)/, 'armed delete state must auto-revert so a stray first click cannot linger');
+    assert.match(skillPanel, /void props\.onDeleteSkill\(skill\.id\)/);
+    assert.match(skillPanel, /aria-label=\{confirmingDelete \? `确认删除 \$\{skill\.name\}` : `删除 \$\{skill\.name\}`\}/);
+    assert.match(skillPanel, /confirmingDelete \? '确认删除' : '删除'/);
     assert.match(skillPanel, /<div[\s\S]*className="maka-skill-library-row"[\s\S]*<\/div>/, 'Skill row body must be information, not the open-file control');
     assert.match(skillPanel, /className="maka-skill-library-open-button"[\s\S]*aria-label=\{`打开 \$\{skill\.name\} 的 SKILL\.md`\}/);
     assert.match(skillPanel, /<\/UiButton>\s*<Switch/, 'per-skill enable switch must sit next to the explicit open-file icon button');
@@ -1302,6 +1363,9 @@ name: Writer
     assert.doesNotMatch(createBlock, /await refreshSkills\(\);\s*toastApi\.success/, 'create success feedback must not be unconditional after refresh');
     assert.match(createBlock, /if \(isSkillsSurfaceActive\(\)\) toastApi\.error\('无法创建示例技能'/);
     assert.match(createBlock, /if \(isSkillsSurfaceActive\(\)\) toastApi\.error\('无法打开示例技能'/);
+    // Idempotent seeding: created:false reuses the existing 示例技能 and says so
+    // rather than claiming a fresh create; created:true keeps the create copy.
+    assert.match(createBlock, /if \(result\.created\) \{[\s\S]*'已创建示例技能'[\s\S]*\} else \{[\s\S]*'已打开现有示例技能', '示例技能已存在，直接打开了 SKILL\.md（不会重复创建）。'/);
     assert.match(openBlock, /if \(isSkillsSurfaceActive\(\)\) toastApi\.error\('无法打开 Skill'/);
     assert.doesNotMatch(openBlock, /if \(!result\.ok\) \{\s*toastApi\.error\('无法打开 Skill'/, 'open Skill structured failures must not toast unconditionally after leaving Skills');
     assert.doesNotMatch(openBlock, /catch \(error\) \{\s*toastApi\.error\('无法打开 Skill'/, 'open Skill thrown failures must not toast unconditionally after leaving Skills');

--- a/apps/desktop/src/main/skills.ts
+++ b/apps/desktop/src/main/skills.ts
@@ -120,8 +120,12 @@ export interface ManagedSkillUpdatePreview {
 }
 
 export type CreateStarterSkillResult =
-  | { ok: true; skill: InstalledSkill; filePath: string }
+  | { ok: true; created: boolean; skill: InstalledSkill; filePath: string }
   | { ok: false; reason: 'blocked_path' | 'already_exists' | 'write_failed' };
+
+export type DeleteSkillResult =
+  | { ok: true }
+  | { ok: false; reason: 'not_found' | 'blocked_path' | 'delete_failed' };
 
 export type SkillOpenTarget = 'file' | 'directory';
 export type ResolveSkillOpenPathResult =
@@ -391,6 +395,8 @@ function isMatchingBundledSkillLock(value: unknown, id: string, contentSha256: s
     value.contentSha256.toLowerCase() === contentSha256.toLowerCase();
 }
 
+const STARTER_SKILL_ID_PATTERN = /^starter-skill(?:-(\d+))?$/;
+
 export async function createStarterSkill(root: string): Promise<CreateStarterSkillResult> {
   const skillsDir = join(root, 'skills');
   try {
@@ -408,6 +414,27 @@ export async function createStarterSkill(root: string): Promise<CreateStarterSki
     skillsReal = await realpath(skillsDir);
   } catch {
     return { ok: false, reason: 'blocked_path' };
+  }
+
+  // Idempotent seeding: if a starter-skill (or starter-skill-N) already exists,
+  // reuse the lowest-ordinal one instead of minting another. Clicking 添加 used
+  // to spawn a fresh starter-skill-N per click, leaving duplicate 示例技能 rows
+  // the user could not tell apart. Reuse the shared loader so the returned skill
+  // carries the same parsed metadata every other surface sees.
+  const existingStarter = (await listInstalledSkills(root))
+    .map((skill) => {
+      const match = STARTER_SKILL_ID_PATTERN.exec(skill.id);
+      return match ? { skill, ordinal: match[1] ? Number(match[1]) : 1 } : null;
+    })
+    .filter((entry): entry is { skill: InstalledSkill; ordinal: number } => entry !== null)
+    .sort((a, b) => a.ordinal - b.ordinal)[0];
+  if (existingStarter) {
+    return {
+      ok: true,
+      created: false,
+      skill: existingStarter.skill,
+      filePath: join(existingStarter.skill.path, 'SKILL.md'),
+    };
   }
 
   for (let index = 1; index <= 99; index += 1) {
@@ -434,6 +461,7 @@ export async function createStarterSkill(root: string): Promise<CreateStarterSki
       await writeFile(filePath, starterSkillTemplate(id, name), { encoding: 'utf8', flag: 'wx', mode: 0o600 });
       return {
         ok: true,
+        created: true,
         filePath,
         skill: {
           id,
@@ -458,6 +486,47 @@ export async function createStarterSkill(root: string): Promise<CreateStarterSki
   }
 
   return { ok: false, reason: 'already_exists' };
+}
+
+/**
+ * Delete an installed skill directory under {root}/skills/<id>. Path-hardened
+ * exactly like createStarterSkill / installManagedSkill: the skills dir and the
+ * skill dir must both be real, contained directories (no symlinks, no escape
+ * outside the workspace) before anything is removed. The recursive rm also
+ * clears any managed-skill baseline metadata under the skill's .maka/ subtree.
+ */
+export async function deleteSkill(root: string, id: string): Promise<DeleteSkillResult> {
+  if (!isSafeSkillId(id)) return { ok: false, reason: 'not_found' };
+
+  const skillsDir = join(root, 'skills');
+  let skillsReal: string;
+  try {
+    const [rootReal, skillsStat] = await Promise.all([realpath(root), lstat(skillsDir)]);
+    if (!skillsStat.isDirectory() || skillsStat.isSymbolicLink()) return { ok: false, reason: 'blocked_path' };
+    skillsReal = await realpath(skillsDir);
+    if (!isContainedPath(rootReal, skillsReal)) return { ok: false, reason: 'blocked_path' };
+  } catch {
+    return { ok: false, reason: 'not_found' };
+  }
+
+  const skillDir = join(skillsDir, id);
+  let skillReal: string;
+  try {
+    const skillStat = await lstat(skillDir);
+    if (!skillStat.isDirectory() || skillStat.isSymbolicLink()) return { ok: false, reason: 'blocked_path' };
+    skillReal = await realpath(skillDir);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return { ok: false, reason: 'not_found' };
+    return { ok: false, reason: 'blocked_path' };
+  }
+  if (!isContainedPath(skillsReal, skillReal)) return { ok: false, reason: 'blocked_path' };
+
+  try {
+    await rm(skillReal, { recursive: true });
+    return { ok: true };
+  } catch {
+    return { ok: false, reason: 'delete_failed' };
+  }
 }
 
 export async function installManagedSkill(

--- a/apps/desktop/src/main/workspace-resources-ipc-main.ts
+++ b/apps/desktop/src/main/workspace-resources-ipc-main.ts
@@ -6,6 +6,7 @@ import { createArtifactStore, resolveArtifactPath } from '@maka/storage';
 import type { createMainWindowController } from './main-window.js';
 import {
   createStarterSkill,
+  deleteSkill,
   getSkillGovernanceDetails,
   installBundledSkill,
   installManagedSkill,
@@ -162,7 +163,10 @@ export function registerWorkspaceResourcesIpc(deps: WorkspaceResourcesIpcDeps): 
   ipcMain.handle('skills:createStarter', async () => {
     const result = await createStarterSkill(deps.workspaceRoot);
     if (!result.ok) return result;
-    return { ok: true as const, skill: toSkillEntry(result.skill), filePath: result.filePath };
+    return { ok: true as const, created: result.created, skill: toSkillEntry(result.skill), filePath: result.filePath };
+  });
+  ipcMain.handle('skills:delete', async (_event, id: string) => {
+    return deleteSkill(deps.workspaceRoot, id);
   });
   ipcMain.handle('skills:open', async (_event, id: string, target: 'file' | 'directory' = 'file') => {
     const resolved = await resolveSkillOpenPath(deps.workspaceRoot, id, target);

--- a/apps/desktop/src/preload/preload.ts
+++ b/apps/desktop/src/preload/preload.ts
@@ -1017,10 +1017,16 @@ contextBridge.exposeInMainWorld('maka', {
       return ipcRenderer.invoke('skills:setEnabled', skillId, enabled);
     },
     createStarter(): Promise<
-      | { ok: true; skill: SkillEntry; filePath: string }
+      | { ok: true; created: boolean; skill: SkillEntry; filePath: string }
       | { ok: false; reason: 'blocked_path' | 'already_exists' | 'write_failed' }
     > {
       return ipcRenderer.invoke('skills:createStarter');
+    },
+    delete(id: string): Promise<
+      | { ok: true }
+      | { ok: false; reason: 'not_found' | 'blocked_path' | 'delete_failed' }
+    > {
+      return ipcRenderer.invoke('skills:delete', id);
     },
     open(id: string, target: 'file' | 'directory' = 'file'): Promise<
       | { ok: true; target: 'file' | 'directory' }

--- a/apps/desktop/src/renderer/app-shell-skill-actions.ts
+++ b/apps/desktop/src/renderer/app-shell-skill-actions.ts
@@ -20,6 +20,7 @@ export interface AppShellSkillActions {
   previewManagedSkillUpdate(skillId: string): Promise<ManagedSkillUpdatePreview | null>;
   updateManagedSkill(skillId: string, options?: { force?: boolean; expectedCurrentSha256?: string; expectedSourceSha256?: string }): Promise<boolean>;
   setSkillEnabled(skillId: string, enabled: boolean): Promise<void>;
+  deleteSkill(skillId: string): Promise<void>;
   openSkill(skillId: string): Promise<void>;
 }
 
@@ -92,7 +93,14 @@ export function createAppShellSkillActions(deps: {
       }
       await refreshSkills({ shouldShowError: isSkillsSurfaceActive });
       if (!isSkillsSurfaceActive()) return;
-      toastApi.success('已创建示例技能', `${result.skill.id}/SKILL.md 已放到工作区 skills 目录。`);
+      // Idempotent seeding: a repeat 添加 click reuses the existing 示例技能
+      // instead of minting a duplicate. Tell the user we opened the existing
+      // one rather than pretending a new skill was created.
+      if (result.created) {
+        toastApi.success('已创建示例技能', `${result.skill.id}/SKILL.md 已放到工作区 skills 目录。`);
+      } else {
+        toastApi.success('已打开现有示例技能', '示例技能已存在，直接打开了 SKILL.md（不会重复创建）。');
+      }
       const openResult = await window.maka.skills.open(result.skill.id, 'file');
       if (!openResult.ok) {
         if (isSkillsSurfaceActive()) toastApi.error('无法打开示例技能', openSkillFailureCopy(openResult.reason));
@@ -193,6 +201,25 @@ export function createAppShellSkillActions(deps: {
     }
   }
 
+  async function deleteSkill(skillId: string) {
+    try {
+      const result = await window.maka.skills.delete(skillId);
+      if (!result.ok) {
+        if (isSkillsSurfaceActive()) toastApi.error('无法删除 Skill', deleteSkillFailureCopy(result.reason));
+        return;
+      }
+      await refreshSkills({ shouldShowError: isSkillsSurfaceActive });
+      // A deleted bundled skill must reappear as installable under 内置, so
+      // refresh the catalog's installed flags after removal.
+      await refreshBundledSkillCatalog({ shouldShowError: isSkillsSurfaceActive });
+      if (isSkillsSurfaceActive()) toastApi.success('已删除 Skill', `${skillId} 已从当前工作区移除。`);
+    } catch (error) {
+      if (isSkillsSurfaceActive()) {
+        toastApi.error('无法删除 Skill', generalizedErrorMessageChinese(error, '无法删除 Skill，请稍后重试。'));
+      }
+    }
+  }
+
   return {
     refreshSkills,
     refreshManagedSkillSources,
@@ -204,6 +231,7 @@ export function createAppShellSkillActions(deps: {
     previewManagedSkillUpdate,
     updateManagedSkill,
     setSkillEnabled,
+    deleteSkill,
     openSkill,
   };
 }
@@ -238,6 +266,12 @@ function managedPreviewFailureCopy(reason: 'not_managed' | 'source_missing' | 'm
   if (reason === 'metadata_error') return 'Skill 元数据异常，不能安全预览。';
   if (reason === 'blocked_path') return '目标路径不允许读取。';
   return '读取 Skill 内容失败，请检查文件权限。';
+}
+
+function deleteSkillFailureCopy(reason: 'not_found' | 'blocked_path' | 'delete_failed'): string {
+  if (reason === 'not_found') return '当前工作区找不到这个 Skill。';
+  if (reason === 'blocked_path') return 'Skill 路径不允许删除。';
+  return '删除 Skill 失败，请检查文件权限。';
 }
 
 function skillRuntimeFailureCopy(reason: 'not_found' | 'blocked_path' | 'state_error' | 'write_failed'): string {

--- a/apps/desktop/src/renderer/app-shell.tsx
+++ b/apps/desktop/src/renderer/app-shell.tsx
@@ -735,6 +735,7 @@ export function AppShell({
     previewManagedSkillUpdate,
     updateManagedSkill,
     setSkillEnabled,
+    deleteSkill,
     openSkill,
   } = useAppShellModuleData({
     isSkillsSurfaceActive,
@@ -1301,6 +1302,7 @@ export function AppShell({
                   onPreviewManagedSkillUpdate={(skillId) => previewManagedSkillUpdate(skillId)}
                   onUpdateManagedSkill={(skillId, options) => updateManagedSkill(skillId, options)}
                   onSetSkillEnabled={(skillId, enabled) => setSkillEnabled(skillId, enabled)}
+                  onDeleteSkill={(skillId) => deleteSkill(skillId)}
                 />
               ) : navSelection.section === 'automations' ? (
                 <AutomationsPage

--- a/apps/desktop/src/renderer/styles/module-pages/skills.css
+++ b/apps/desktop/src/renderer/styles/module-pages/skills.css
@@ -371,7 +371,6 @@ color: oklch(from var(--brand-deep) 0.55 min(c, 0.015) h);
   margin-top: auto;
 }
 
-.maka-skill-examples,
 .maka-skill-installed {
   display: grid;
   /* Atlas §14.6 quick-win — section internal gap aligned to reference's
@@ -386,86 +385,6 @@ color: oklch(from var(--brand-deep) 0.55 min(c, 0.015) h);
   font-weight: var(--font-weight-semibold);
   letter-spacing: var(--tracking-widest);
   text-transform: uppercase;
-}
-
-.maka-skill-example-grid {
-  margin: 0;
-  padding: 0;
-  list-style: none;
-  display: grid;
-  gap: var(--space-0-5);
-}
-
-.maka-skill-template-row {
-  min-width: 0;
-  display: grid;
-  /* 3 children in a 2-col grid need explicit placement — auto-flow dropped
-     the meta line under the ICON column and shattered the row. */
-  grid-template-columns: 18px minmax(0, 1fr);
-  grid-template-areas:
-    'icon copy'
-    '.    meta';
-  gap: var(--space-0-5) var(--space-1-5);
-  align-items: center;
-  padding: var(--space-1) var(--space-2);
-  border: 0;
-  border-radius: var(--radius-control);
-  background: transparent;
-  transition: background-color var(--duration-base) var(--ease-out-strong);
-}
-
-.maka-skill-template-row:hover {
-  background: var(--state-hover-bg);
-}
-
-.maka-skill-template-row > .maka-skill-template-icon { grid-area: icon; align-self: center; }
-.maka-skill-template-row > .maka-skill-template-copy { grid-area: copy; }
-.maka-skill-template-row > small { grid-area: meta; }
-
-.maka-skill-template-icon {
-  grid-row: span 2;
-  width: 18px;
-  height: 18px;
-  display: inline-grid;
-  place-items: center;
-  border-radius: var(--radius-control);
-  background: oklch(from var(--link) l c h / 0.08);
-  color: var(--link);
-}
-
-.maka-skill-template-copy {
-  min-width: 0;
-  display: grid;
-  gap: var(--space-0-5);
-}
-
-.maka-skill-template-copy strong {
-  min-width: 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  color: var(--foreground);
-  font-size: var(--font-size-ui);
-  font-weight: var(--font-weight-semibold);
-  line-height: var(--leading-snug);
-}
-
-.maka-skill-template-copy span {
-  min-width: 0;
-  color: var(--foreground-secondary);
-  font-size: var(--font-size-caption);
-  line-height: var(--leading-normal);
-}
-
-.maka-skill-template-row small {
-  grid-column: 2;
-  min-width: 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  color: var(--muted-foreground);
-  font-size: var(--font-size-caption);
-  line-height: var(--leading-snug);
 }
 
 .maka-skill-library-list {
@@ -486,7 +405,12 @@ color: oklch(from var(--brand-deep) 0.55 min(c, 0.015) h);
   --maka-skill-library-action-size: var(--h-control-sm);
   min-width: 0;
   display: grid;
-  grid-template-columns: minmax(0, 1fr) max-content max-content max-content;
+  /* Info column takes the slack; every trailing action (use / open / switch /
+     review / delete) flows into its own max-content implicit column, so the
+     row never wraps regardless of how many actions a skill surfaces. */
+  grid-template-columns: minmax(0, 1fr);
+  grid-auto-flow: column;
+  grid-auto-columns: max-content;
   align-items: center;
   gap: var(--space-2);
   padding-right: var(--space-3);
@@ -622,6 +546,18 @@ color: oklch(from var(--brand-deep) 0.55 min(c, 0.015) h);
 
 .maka-skill-library-runtime-switch {
   justify-self: end;
+}
+
+/* Per-row delete: neutral until armed. The two-step confirm state
+   (data-confirming) deepens to the destructive tone so 确认删除 reads as the
+   hot action, matching exception-only status color governance. */
+.maka-skill-library-delete-button {
+  justify-self: end;
+}
+
+.maka-skill-library-delete-button[data-confirming='true'] {
+  border-color: oklch(from var(--destructive) l c h / 0.4);
+  color: var(--destructive);
 }
 
 .maka-skill-installed-empty {

--- a/packages/ui/src/module-pages.tsx
+++ b/packages/ui/src/module-pages.tsx
@@ -54,6 +54,7 @@ export function SkillsPage(props: {
   onPreviewManagedSkillUpdate?(skillId: string): Promise<ManagedSkillUpdatePreview | null>;
   onUpdateManagedSkill?(skillId: string, options?: { force?: boolean; expectedCurrentSha256?: string; expectedSourceSha256?: string }): boolean | Promise<boolean>;
   onSetSkillEnabled?(skillId: string, enabled: boolean): void | Promise<void>;
+  onDeleteSkill?(skillId: string): void | Promise<void>;
 }) {
   const auditReport = deriveCapabilityAuditReport({
     skills: props.skills ?? [],

--- a/packages/ui/src/skills-panel.tsx
+++ b/packages/ui/src/skills-panel.tsx
@@ -8,6 +8,7 @@ import {
   Loader2,
   Plus,
   Search,
+  Trash2,
 } from './icons.js';
 import type { CapabilityAuditReport } from '@maka/core';
 import { deriveCapabilityAuditReport } from '@maka/core';
@@ -48,6 +49,7 @@ function SkillLibraryPanel(props: {
   onPreviewManagedSkillUpdate?(skillId: string): Promise<ManagedSkillUpdatePreview | null>;
   onUpdateManagedSkill?(skillId: string, options?: { force?: boolean; expectedCurrentSha256?: string; expectedSourceSha256?: string }): boolean | Promise<boolean>;
   onSetSkillEnabled?(skillId: string, enabled: boolean): void | Promise<void>;
+  onDeleteSkill?(skillId: string): void | Promise<void>;
   actionBusy?: boolean;
   refreshPending?: boolean;
   createPending?: boolean;
@@ -55,6 +57,7 @@ function SkillLibraryPanel(props: {
   installingSourceId?: string | null;
   updatingSkillId?: string | null;
   togglingSkillId?: string | null;
+  deletingSkillId?: string | null;
   searchQuery?: string;
   managedSkillSources?: ManagedSkillSourceEntry[];
   bundledSkillCatalog?: BundledSkillCatalogEntry[];
@@ -74,6 +77,33 @@ function SkillLibraryPanel(props: {
   });
   const [updatePreview, setUpdatePreview] = useState<ManagedSkillUpdatePreview | null>(null);
   const [reviewingSkillId, setReviewingSkillId] = useState<string | null>(null);
+  // Two-step in-place delete confirm (no dialog precedent in this panel): the
+  // first click arms 确认删除 on that row; a second click within the window
+  // deletes. The timeout reverts the armed state so a stray first click can't
+  // linger as a hot destructive control.
+  const [confirmingDeleteSkillId, setConfirmingDeleteSkillId] = useState<string | null>(null);
+  const deleteConfirmTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  useEffect(() => () => {
+    if (deleteConfirmTimerRef.current) clearTimeout(deleteConfirmTimerRef.current);
+  }, []);
+  function clearDeleteConfirmTimer() {
+    if (deleteConfirmTimerRef.current) {
+      clearTimeout(deleteConfirmTimerRef.current);
+      deleteConfirmTimerRef.current = null;
+    }
+  }
+  function requestDeleteSkill(skill: SkillEntry) {
+    if (!props.onDeleteSkill) return;
+    if (confirmingDeleteSkillId !== skill.id) {
+      clearDeleteConfirmTimer();
+      setConfirmingDeleteSkillId(skill.id);
+      deleteConfirmTimerRef.current = setTimeout(() => setConfirmingDeleteSkillId(null), 4000);
+      return;
+    }
+    clearDeleteConfirmTimer();
+    setConfirmingDeleteSkillId(null);
+    void props.onDeleteSkill(skill.id);
+  }
   const [marketCategory, setMarketCategory] = useState<ManagedSkillCategory | typeof MARKET_CATEGORY_ALL>(MARKET_CATEGORY_ALL);
   const [marketSort, setMarketSort] = useState<MarketSort>('name');
   const normalizedSkillQuery = props.searchQuery?.trim().toLowerCase() ?? '';
@@ -144,28 +174,6 @@ function SkillLibraryPanel(props: {
     });
     if (updated) setUpdatePreview(null);
   }
-
-  const templates = (
-    <section className="maka-skill-examples" aria-label="技能示例">
-      {/* Visible divider: without it the inert example rows read as more
-          installed skills floating under the real list. */}
-      <SectionHeader title="技能示例" as="span" className="maka-skill-section-row" />
-      <ul className="maka-skill-example-grid" aria-label="技能模板示例">
-        {SKILL_EXAMPLE_CARDS.map((example) => (
-          <li key={example.title} className="maka-skill-template-row">
-            <span className="maka-skill-template-icon" aria-hidden="true">
-              <example.Icon size={13} />
-            </span>
-            <span className="maka-skill-template-copy">
-              <strong>{example.title}</strong>
-              <span>{example.body}</span>
-            </span>
-            <small>{example.meta}</small>
-          </li>
-        ))}
-      </ul>
-    </section>
-  );
 
   const categoryOptions: ReadonlyArray<SettingsSelectOption<ManagedSkillCategory | typeof MARKET_CATEGORY_ALL>> = [
     [MARKET_CATEGORY_ALL, '全部分类'],
@@ -425,6 +433,8 @@ function SkillLibraryPanel(props: {
               const updating = props.updatingSkillId === skill.id;
               const toggling = props.togglingSkillId === skill.id;
               const reviewing = reviewingSkillId === skill.id;
+              const deleting = props.deletingSkillId === skill.id;
+              const confirmingDelete = confirmingDeleteSkillId === skill.id;
               const reviewableManagedUpdate = skill.managedUpdateStatus === 'update_available' || skill.managedUpdateStatus === 'local_modified';
               const canToggleSkill = Boolean(props.onSetSkillEnabled) && skill.runtimeStatus !== 'state_error';
               const hoverText = tools.length > 0
@@ -513,6 +523,21 @@ function SkillLibraryPanel(props: {
                       {reviewing ? '审查中…' : skill.managedUpdateStatus === 'local_modified' ? '查看差异' : '查看更新'}
                     </UiButton>
                   )}
+                  {props.onDeleteSkill && (
+                    <UiButton
+                      type="button"
+                      variant="secondary"
+                      size="sm"
+                      className="maka-skill-library-delete-button"
+                      data-confirming={confirmingDelete ? 'true' : undefined}
+                      onClick={() => requestDeleteSkill(skill)}
+                      disabled={props.actionBusy && !deleting}
+                      aria-label={confirmingDelete ? `确认删除 ${skill.name}` : `删除 ${skill.name}`}
+                    >
+                      {deleting ? <Loader2 size={15} aria-hidden="true" /> : <Trash2 size={15} aria-hidden="true" />}
+                      {confirmingDelete ? '确认删除' : '删除'}
+                    </UiButton>
+                  )}
                 </li>
               );
             })}
@@ -584,7 +609,6 @@ function SkillLibraryPanel(props: {
         <TabsPanel value="installed">
           {skillList(installedSkills, skillListEmptyTitle, skillListEmptyBody, '已安装技能')}
           {updateReview}
-          {templates}
         </TabsPanel>
       </TabsRoot>
       {props.skills && props.skills.length > 0 ? (
@@ -595,26 +619,6 @@ function SkillLibraryPanel(props: {
     </div>
   );
 }
-
-const SKILL_EXAMPLE_CARDS: ReadonlyArray<{
-  title: string;
-  body: string;
-  meta: string;
-  Icon: typeof FileEdit;
-}> = [
-  {
-    title: '文档处理流',
-    body: '润色、批注、检查 DOCX 内容，把重复文档步骤沉进 Skill。',
-    meta: 'Office · 审阅 · 导出',
-    Icon: FileEdit,
-  },
-  {
-    title: '演示资料流',
-    body: '生成结构、整理讲稿、检查 PPTX 页面，让演示准备更稳定。',
-    meta: 'Slides · 提纲 · 校对',
-    Icon: BookOpen,
-  },
-];
 
 function formatSkillLibraryDescription(skill: SkillEntry): string | undefined {
   const raw = skill.description?.trim();
@@ -703,6 +707,7 @@ export function SkillsModuleMain(props: {
   onPreviewManagedSkillUpdate?(skillId: string): Promise<ManagedSkillUpdatePreview | null>;
   onUpdateManagedSkill?(skillId: string, options?: { force?: boolean; expectedCurrentSha256?: string; expectedSourceSha256?: string }): boolean | Promise<boolean>;
   onSetSkillEnabled?(skillId: string, enabled: boolean): void | Promise<void>;
+  onDeleteSkill?(skillId: string): void | Promise<void>;
 }) {
   const [pendingSkillAction, setPendingSkillAction] = useState<string | null>(null);
   const [skillSearchQuery, setSkillSearchQuery] = useState('');
@@ -804,6 +809,7 @@ export function SkillsModuleMain(props: {
         onUpdateManagedSkill={props.onUpdateManagedSkill ? async (skillId, options) =>
           (await runSkillAction(`managed:update:${skillId}`, () => props.onUpdateManagedSkill?.(skillId, options))) === true : undefined}
         onSetSkillEnabled={props.onSetSkillEnabled ? (skillId, enabled) => runSkillAction(`runtime:set:${skillId}`, () => props.onSetSkillEnabled?.(skillId, enabled)) : undefined}
+        onDeleteSkill={props.onDeleteSkill ? (skillId) => runSkillAction(`delete:${skillId}`, () => props.onDeleteSkill?.(skillId)) : undefined}
         onUseSkill={props.onUseSkill}
         actionBusy={skillActionBusy}
         refreshPending={pendingSkillAction === 'refresh'}
@@ -813,6 +819,7 @@ export function SkillsModuleMain(props: {
         installingBundledId={pendingSkillAction?.startsWith('bundled:install:') ? pendingSkillAction.slice('bundled:install:'.length) : null}
         updatingSkillId={pendingSkillAction?.startsWith('managed:update:') ? pendingSkillAction.slice('managed:update:'.length) : null}
         togglingSkillId={pendingSkillAction?.startsWith('runtime:set:') ? pendingSkillAction.slice('runtime:set:'.length) : null}
+        deletingSkillId={pendingSkillAction?.startsWith('delete:') ? pendingSkillAction.slice('delete:'.length) : null}
         searchQuery={skillSearchQuery}
       />
     </main>


### PR DESCRIPTION
User-reported (screenshot): the 技能示例 section is meaningless, and three duplicate 示例技能 rows cannot be removed in-app. One PR fixes the whole chain.

## 1. 技能示例 section removed
The two cards (文档处理流 / 演示资料流) were hardcoded, inert decoration — no click behavior, nothing installable. Deleted with their CSS; contract pins converted to absence pins so inert example rows cannot return.

## 2. Idempotent 示例技能 seeding
skills:createStarter unconditionally minted a new starter-skill-N per click (the 1→99 ordinal loop) — three clicks = three identical rows. Now it scans for an existing starter skill first and returns it with `created: false`; the renderer toasts 「已打开现有示例技能 · 不会重复创建」 and opens the existing SKILL.md. The old "second create mints 示例技能 2" test converted to the reuse invariant (dir count unchanged).

## 3. Delete affordance (new)
Installed skills had NO removal path — duplicates were permanent. Added: `deleteSkill` in main (realpath + containment + symlink rejection per house style), skills:delete IPC + preload bridge, renderer action (refreshes 已安装 AND 内置 so a deleted bundled skill reappears installable), and a per-row 删除 button with two-step in-place confirm (arms 确认删除, 4s auto-revert, aria-label names the skill). Existing starter-skill-2/-3 dirs can now be removed in-app.

Also: `.maka-skill-library-item` grid switched to auto-flow column so trailing row actions never wrap (fixes a latent overflow when 使用 + update-review coexisted).

## Gates (merged tree with main)
desktop 2494/2494 (+2 new delete tests) · ui 136/136 · typecheck · check-dead-css clean · knip ×2 = 0. CDP light+dark captures on module-skills: section gone, row actions intact. Implemented by an opus worktree agent; verified post-merge.