### PR TITLE
fix(cu): harden runtime and executor correctness

### DIFF
--- a/docs/computer-use-runtime-hardening.md
+++ b/docs/computer-use-runtime-hardening.md
@@ -9,6 +9,15 @@ This follow-up addresses lifecycle gaps found during review of PR #892.
 - Read-only host actions did not acquire a session lease and could continue
   after `user_stopped`.
 - Later lifecycle events could overwrite `blocked_url` or `user_stopped`.
+- A process-wide executor queue blocked unrelated windows, while a first
+  per-session replacement allowed two sessions to interleave
+  snapshot/validation/dispatch against the same window.
+- The ambiguity gate included ephemeral element IDs even when a stable element
+  identity was available.
+- `cursor_position` formatting existed without a production backend result.
+- Service release reasons did not distinguish a session-only notification from
+  a real child-generation release, so `clearSession(A)` could discard retained
+  observations and keyboard ownership for unrelated session B.
 
 ## Root Cause
 
@@ -17,11 +26,27 @@ needed lifecycle fencing. Cleanup also mutated only an already-created state
 record, while terminal transitions shared the same unrestricted transition
 helper as recoverable states.
 
+The executor queue was scoped to the caller rather than the resource being
+validated. Ambiguity signatures also mixed stable identity with snapshot-local
+IDs, and the cursor result test used only a fake backend.
+
+The backend also inferred generation loss from the release reason. The
+no-in-flight `clearSession()` path emits `session_cleared` without stopping the
+child, so the reason alone cannot establish that shared executor state changed.
+
 ## Fix
 
 - Create the same-turn stop tombstone unconditionally during `clearSession()`.
 - Require an observation lease for every host-reading or waiting action.
 - Make `blocked_url` and `user_stopped` absorb later lifecycle events.
+- Serialize mutations by bound PID/window, with one conservative queue for
+  unbound mutations; unrelated bound windows may still progress independently.
+- Ignore ephemeral element IDs when a stable element identity is present.
+- Read `get_cursor_position` through the pinned cua-driver and return the
+  resolved point without moving the pointer.
+- Carry `generationReleased` as an explicit service release fact. Session-only
+  releases invalidate only their listed sessions; actual child exits sweep all
+  retained session observations and keyboard targets.
 
 A new turn still creates a fresh Computer Use session state, preserving the
 existing explicit recovery boundary.
@@ -29,5 +54,6 @@ existing explicit recovery boundary.
 ## Verification
 
 - `npm --workspace @maka/runtime run typecheck`
-- focused Computer Use and session-state tests: 52 passed
+- `npm --workspace @maka/runtime test`
+- `npm --workspace @maka/computer-use test`
 - `git diff --check`

--- a/packages/computer-use/src/__tests__/cua-driver-backend.test.ts
+++ b/packages/computer-use/src/__tests__/cua-driver-backend.test.ts
@@ -2666,10 +2666,7 @@ describe('cua-driver backend', () => {
     backend.clearSession('session-a');
     await pendingA;
 
-    assert.deepEqual(
-      [...new Set(invalidated)].sort(),
-      ['session-a', 'session-b'],
-    );
+    assert.deepEqual(invalidated.sort(), ['session-a', 'session-b']);
     const staleB = await backend.runSemantic?.({
       type: 'click_element',
       observationId: observedB.observationId,
@@ -2707,6 +2704,7 @@ describe('cua-driver backend', () => {
 
     backend.clearSession('session-a');
 
+    assert.deepEqual(invalidated, ['session-a']);
     assert.ok(!invalidated.includes('session-b'));
     const reusedObservationB = await backend.runSemantic?.({
       type: 'click_element',

--- a/packages/computer-use/src/__tests__/cua-driver-backend.test.ts
+++ b/packages/computer-use/src/__tests__/cua-driver-backend.test.ts
@@ -131,6 +131,7 @@ const SEMANTIC_OCCLUDED = process.env.CUA_MOCK_SEMANTIC_OCCLUDED === '1';
 const PAGE_EXEC_RESULT = process.env.CUA_MOCK_PAGE_EXEC_RESULT || '';
 const PAGE_READBACK_VALUE = process.env.CUA_MOCK_PAGE_READBACK_VALUE || '';
 const NATIVE_READBACK_VALUE = process.env.CUA_MOCK_NATIVE_READBACK_VALUE || '';
+const MALFORMED_AX_AFTER = Number(process.env.CUA_MOCK_MALFORMED_AX_AFTER || 0);
 const PAGE_DOCUMENT_MARKER = process.env.CUA_MOCK_PAGE_DOCUMENT_MARKER || 'document-a';
 let PAGE_FIELD_VALUE = process.env.CUA_MOCK_PAGE_FIELD_VALUE || '';
 let PAGE_INSERTED = false;
@@ -249,7 +250,9 @@ function handle(msg) {
             structuredContent: {
               screenshot_width: 1200,
               screenshot_height: 800,
-              elements: EMPTY_AX ? [] : refetchedElements,
+              elements: MALFORMED_AX_AFTER > 0 && WINDOW_STATE_CALLS >= MALFORMED_AX_AFTER
+                ? { malformed: true }
+                : EMPTY_AX ? [] : refetchedElements,
             },
           }), SNAPSHOT_DELAY_MS);
         return;
@@ -286,6 +289,9 @@ function handle(msg) {
         return;
       case 'get_screen_size':
         reply(id, { content: [], structuredContent: { width: 1512, height: 982, scale_factor: 2 } });
+        return;
+      case 'get_cursor_position':
+        reply(id, { content: [], structuredContent: { x: 321, y: 654 } });
         return;
       case 'list_windows':
         // Two layer-0 windows. Win 77 covers screen-points (100,100)-(700,500).
@@ -468,6 +474,7 @@ function makeBackend(opts: {
   pageFieldValue?: string;
   pageReadbackValue?: string;
   nativeReadbackValue?: string;
+  malformedAxAfter?: number;
   pageDocumentMarker?: string;
   resolvePageDocumentFingerprint?: CuaDriverBackendOptions['resolvePageDocumentFingerprint'];
   resolveContentFingerprint?: CuaDriverBackendOptions['resolveContentFingerprint'];
@@ -503,6 +510,7 @@ function makeBackend(opts: {
   process.env.CUA_MOCK_PAGE_FIELD_VALUE = opts.pageFieldValue ?? '';
   process.env.CUA_MOCK_PAGE_READBACK_VALUE = opts.pageReadbackValue ?? '';
   process.env.CUA_MOCK_NATIVE_READBACK_VALUE = opts.nativeReadbackValue ?? '';
+  process.env.CUA_MOCK_MALFORMED_AX_AFTER = String(opts.malformedAxAfter ?? 0);
   process.env.CUA_MOCK_PAGE_DOCUMENT_MARKER = opts.pageDocumentMarker ?? 'document-a';
   process.env.CUA_MOCK_SNAPSHOT_DELAY_MS = String(opts.snapshotDelayMs ?? 0);
   process.env.CUA_MOCK_REFETCH_MODE = opts.refetchMode ?? '';
@@ -1565,7 +1573,7 @@ describe('cua-driver backend', () => {
     });
   });
 
-  it('serializes fresh snapshot and action across the shared action client', async () => {
+  it('serializes same-window mutations across sessions', async () => {
     const { backend, logPath } = makeBackend({ snapshotDelayMs: 120 });
     const signal = new AbortController().signal;
     const first = backend.run(
@@ -1592,6 +1600,23 @@ describe('cua-driver backend', () => {
     assert.equal(clicks.length, 2);
     assert.ok(snapshots[0]!.index < clicks[0]!.index);
     assert.ok(clicks[0]!.index < snapshots[1]!.index, `trace=${trace.join(' -> ')}`);
+  });
+
+  it('returns the read-only cua-driver cursor position without pointer dispatch', async () => {
+    const { backend, logPath } = makeBackend();
+    const result = await backend.run(
+      { type: 'cursor_position' },
+      new AbortController().signal,
+      DEFAULT_RUN_CONTEXT,
+    );
+
+    assert.deepEqual(result, {
+      outcome: { ok: true, tier: 'coordinate-background' },
+      resolvedScreenPoint: { x: 321, y: 654 },
+    });
+    const records = await readRecords(logPath);
+    assert.equal(toolCalls(records, 'get_cursor_position').length, 1);
+    assert.equal(toolCalls(records, 'click').length, 0);
   });
 
   it('click on empty desktop (no window) fails closed — never warps', async () => {
@@ -2346,6 +2371,30 @@ describe('cua-driver backend', () => {
     assert.equal(toolCalls(await readRecords(logPath), 'set_value').length, 1);
   });
 
+  it('malformed native AX readback preserves outcome_unknown after delivery', async () => {
+    const { backend, logPath } = makeBackend({
+      malformedAxAfter: 3,
+    });
+    const signal = new AbortController().signal;
+    const click = await backend.run(
+      { type: 'left_click', coordinate: { x: 600, y: 400 } } as CuAction,
+      signal,
+    );
+    assert.equal(click.outcome.ok, true);
+
+    const result = await backend.run(
+      { type: 'type', text: 'expected' } as CuAction,
+      signal,
+    );
+
+    assert.equal(result.outcome.ok, false);
+    if (!result.outcome.ok) {
+      assert.equal(result.outcome.error, 'outcome_unknown');
+      assert.equal(result.outcome.evidence?.path, 'ax');
+    }
+    assert.equal(toolCalls(await readRecords(logPath), 'set_value').length, 1);
+  });
+
   it('CDP text inspection request failure preserves outcome_unknown', async () => {
     const { backend, logPath } = makeBackend({
       processKind: 'electron',
@@ -2581,7 +2630,7 @@ describe('cua-driver backend', () => {
     }]);
   });
 
-  it('shared service generation loss invalidates every session with retained ownership', async () => {
+  it('clearSession generation loss invalidates every session with retained ownership', async () => {
     const invalidated: string[] = [];
     const { backend, logPath } = makeBackend({
       hangOnceTool: 'click',
@@ -2614,7 +2663,7 @@ describe('cua-driver backend', () => {
       logPath,
       (record) => record.kind === 'blocked' && record.tool === 'click',
     );
-    controller.abort();
+    backend.clearSession('session-a');
     await pendingA;
 
     assert.deepEqual(
@@ -2632,20 +2681,130 @@ describe('cua-driver backend', () => {
     assert.equal(staleB?.outcome.ok, false);
   });
 
+  it('clearSession without generation loss preserves another session observation and keyboard target', async () => {
+    const invalidated: string[] = [];
+    const { backend, logPath } = makeBackend({
+      onSessionInvalidated: (event) => invalidated.push(event.sessionId),
+    });
+    const signal = new AbortController().signal;
+    const sessionB = {
+      sessionId: 'session-b',
+      turnId: 'turn-1',
+      toolCallId: 'observe-b',
+    };
+    const clickedB = await backend.run(
+      { type: 'left_click', coordinate: { x: 600, y: 400 } },
+      signal,
+      { ...sessionB, toolCallId: 'click-b' },
+    );
+    assert.equal(clickedB.outcome.ok, true);
+    const observedB = await backend.observeApp?.({
+      app: 'Fixture',
+      windowId: 77,
+      includeScreenshot: true,
+    }, signal, sessionB);
+    assert.ok(observedB);
+
+    backend.clearSession('session-a');
+
+    assert.ok(!invalidated.includes('session-b'));
+    const reusedObservationB = await backend.runSemantic?.({
+      type: 'click_element',
+      observationId: observedB.observationId,
+      elementId: '7',
+      elementIdentity: observedB.elements[0]!.identity,
+    }, signal, {
+      ...sessionB,
+      toolCallId: 'reuse-observation-b',
+      boundAction: boundElementAction(observedB, '7'),
+    });
+    assert.equal(reusedObservationB?.outcome.ok, true);
+    const typedB = await backend.run(
+      { type: 'type', text: 'still-owned' },
+      signal,
+      { ...sessionB, toolCallId: 'type-b' },
+    );
+    assert.equal(typedB.outcome.ok, true);
+    assert.equal(toolCalls(await readRecords(logPath), 'set_value').length, 1);
+  });
+
+  it('clearSession without generation loss does not invalidate another session mutation in flight', async () => {
+    const invalidated: string[] = [];
+    const { backend, logPath } = makeBackend({
+      delayTool: 'click',
+      delayMs: 100,
+      onSessionInvalidated: (event) => invalidated.push(event.sessionId),
+    });
+    const signal = new AbortController().signal;
+    const sessionB = {
+      sessionId: 'session-b',
+      turnId: 'turn-1',
+      toolCallId: 'observe-b',
+    };
+    const observedB = await backend.observeApp?.({
+      app: 'Fixture',
+      windowId: 77,
+      includeScreenshot: true,
+    }, signal, sessionB);
+    assert.ok(observedB);
+    const pendingB = backend.runSemantic!({
+      type: 'click_element',
+      observationId: observedB.observationId,
+      elementId: '7',
+      elementIdentity: observedB.elements[0]!.identity,
+    }, signal, {
+      ...sessionB,
+      toolCallId: 'click-b',
+      boundAction: boundElementAction(observedB, '7'),
+    });
+    await waitForRecord(
+      logPath,
+      (record) =>
+        record.kind === 'recv'
+        && record.method === 'tools/call'
+        && record.params?.name === 'click',
+    );
+    const generationsBeforeClear = backend.serviceState();
+
+    backend.clearSession('session-a');
+
+    const resultB = await pendingB;
+    assert.equal(resultB.outcome.ok, true);
+    assert.ok(!invalidated.includes('session-b'));
+    assert.deepEqual(backend.serviceState(), generationsBeforeClear);
+  });
+
   it('aborting a delivered action reports outcome_unknown without rejecting the queued session', async () => {
     const { backend, logPath } = makeBackend({ hangOnceTool: 'click' });
     const firstController = new AbortController();
     const first = backend.run(
       { type: 'left_click', coordinate: { x: 600, y: 400 } } as CuAction,
       firstController.signal,
-      { sessionId: 'session-a', turnId: 'turn-1', toolCallId: 'first' },
+      {
+        sessionId: 'session-a',
+        turnId: 'turn-1',
+        toolCallId: 'first',
+        boundAction: boundCoordinateAction(),
+      },
     );
     await waitForRecord(logPath, (record) => record.kind === 'blocked' && record.tool === 'click');
 
     const second = backend.run(
       { type: 'left_click', coordinate: { x: 2000, y: 400 } } as CuAction,
       new AbortController().signal,
-      { sessionId: 'session-b', turnId: 'turn-1', toolCallId: 'second' },
+      {
+        sessionId: 'session-b',
+        turnId: 'turn-1',
+        toolCallId: 'second',
+        boundAction: boundCoordinateAction({
+          pid: 5002,
+          windowId: 92,
+          bounds: { x: 950, y: 150, width: 300, height: 200 },
+          sourceBoundsPx: { x: 0, y: 0, width: 1200, height: 800 },
+          coordinate: { x: 200, y: 200 },
+          zIndex: 9,
+        }),
+      },
     );
     firstController.abort();
     const firstResult = await first;
@@ -2658,7 +2817,11 @@ describe('cua-driver backend', () => {
     assert.equal(secondResult.outcome.ok, true);
 
     const records = await readRecords(logPath);
-    assert.equal(records.filter((record) => record.kind === 'start').length, 2);
+    assert.equal(
+      records.filter((record) => record.kind === 'start').length,
+      2,
+      'the queued second session starts on a fresh child after the shared request aborts',
+    );
     const clicks = toolCalls(records, 'click');
     assert.equal(clicks.length, 2);
     assert.equal(clicks.at(-1)?.pid, 5002);

--- a/packages/computer-use/src/__tests__/cua-driver-service.test.ts
+++ b/packages/computer-use/src/__tests__/cua-driver-service.test.ts
@@ -242,7 +242,25 @@ describe('cua-driver service lifecycle', () => {
     assert.equal(instance.snapshot().state, 'idle');
     assert.ok(releases.some((event) =>
       event.reason === 'session_cleared'
+      && event.generationReleased
       && event.sessionIds.includes('session-clear')));
+  });
+
+  it('clearSession without a pending request keeps the child generation alive', async () => {
+    const releases: CuaDriverReleaseEvent[] = [];
+    const { instance } = service('', {
+      onRelease: (event) => releases.push(event),
+    });
+    await instance.callTool('ok', {});
+    const generation = instance.snapshot().generation;
+
+    instance.clearSession('session-idle');
+
+    assert.equal(instance.snapshot().generation, generation);
+    assert.ok(releases.some((event) =>
+      event.reason === 'session_cleared'
+      && !event.generationReleased
+      && event.sessionIds.includes('session-idle')));
   });
 
   it('exhausts a bounded restart budget and becomes unavailable', async () => {

--- a/packages/computer-use/src/cua-driver-backend.ts
+++ b/packages/computer-use/src/cua-driver-backend.ts
@@ -316,7 +316,7 @@ export function createCuaDriverBackend(opts: CuaDriverBackendOptions): CuDispatc
   }
   const observations = new Map<string, StoredObservation>();
   const observationIdsBySession = new Map<string, string[]>();
-  let operationQueue = Promise.resolve();
+  const operationQueues = new Map<string, Promise<void>>();
   let disposed = false;
 
   async function physicalInputFailure(): Promise<CuRunResult | undefined> {
@@ -457,14 +457,15 @@ export function createCuaDriverBackend(opts: CuaDriverBackendOptions): CuDispatc
 
   function onServiceRelease(event: CuaDriverReleaseEvent): void {
     if (event.reason === 'disposed') return;
-    if (event.reason === 'session_cleared') return;
     const sessions = [
       ...new Set([
         ...event.sessionIds,
-        ...targetsBySession.keys(),
-        ...[...observations.values()].map(
-          (observation) => observation.context.sessionId,
-        ),
+        ...(event.generationReleased ? targetsBySession.keys() : []),
+        ...(event.generationReleased
+          ? [...observations.values()].map(
+              (observation) => observation.context.sessionId,
+            )
+          : []),
       ]),
     ];
     for (const sessionId of sessions) {
@@ -591,14 +592,15 @@ export function createCuaDriverBackend(opts: CuaDriverBackendOptions): CuDispatc
     sessionId?: string,
   ): Promise<T> {
     if (disposed) throw new Error('cua-driver backend disposed');
+    const queueKey = '__shared_child__';
     const sessionGeneration = sessionId === undefined
       ? undefined
       : sessionGenerations.get(sessionId) ?? 0;
-    const previous = operationQueue;
+    const previous = operationQueues.get(queueKey) ?? Promise.resolve();
     let release!: () => void;
     const gate = new Promise<void>((resolve) => { release = resolve; });
     const current = previous.then(() => gate);
-    operationQueue = current;
+    operationQueues.set(queueKey, current);
     await previous;
     try {
       if (disposed) throw new Error('cua-driver backend disposed');
@@ -620,6 +622,9 @@ export function createCuaDriverBackend(opts: CuaDriverBackendOptions): CuDispatc
         captureClient.withSession(sessionId, operation));
     } finally {
       release();
+      if (operationQueues.get(queueKey) === current) {
+        operationQueues.delete(queueKey);
+      }
     }
   }
 
@@ -697,8 +702,11 @@ export function createCuaDriverBackend(opts: CuaDriverBackendOptions): CuDispatc
     if (!windowPoint) {
       throw new Error('cua-driver returned invalid window screenshot dimensions');
     }
+    if (!Array.isArray(structured.elements)) {
+      throw new Error('cua-driver returned invalid AX elements');
+    }
     return {
-      elements: (structured.elements ?? []) as CuaSnapshotElement[],
+      elements: structured.elements as CuaSnapshotElement[],
       screenshotWidthPx: Number(structured.screenshot_width),
       screenshotHeightPx: Number(structured.screenshot_height),
       windowPoint,
@@ -2581,6 +2589,29 @@ export function createCuaDriverBackend(opts: CuaDriverBackendOptions): CuDispatc
         case 'wait':
           await new Promise((res) => setTimeout(res, Math.min(action.durationMs, 10_000)));
           return { outcome: { ok: true, tier: 'coordinate-background' } };
+        case 'cursor_position': {
+          const result = await actionClient.callTool('get_cursor_position', {}, signal);
+          const structured = result?.structuredContent ?? {};
+          if (
+            result?.isError
+            || typeof structured.x !== 'number'
+            || !Number.isFinite(structured.x)
+            || typeof structured.y !== 'number'
+            || !Number.isFinite(structured.y)
+          ) {
+            return {
+              outcome: {
+                ok: false,
+                error: 'capture_failed',
+                message: 'cua-driver returned an invalid cursor position',
+              },
+            };
+          }
+          return {
+            outcome: { ok: true, tier: 'coordinate-background' },
+            resolvedScreenPoint: { x: structured.x, y: structured.y },
+          };
+        }
         case 'mouse_move':
           {
             const win = await coordinateTarget(

--- a/packages/computer-use/src/cua-driver-backend.ts
+++ b/packages/computer-use/src/cua-driver-backend.ts
@@ -317,6 +317,7 @@ export function createCuaDriverBackend(opts: CuaDriverBackendOptions): CuDispatc
   const observations = new Map<string, StoredObservation>();
   const observationIdsBySession = new Map<string, string[]>();
   const operationQueues = new Map<string, Promise<void>>();
+  let sessionClearReleaseEvents: CuaDriverReleaseEvent[] | undefined;
   let disposed = false;
 
   async function physicalInputFailure(): Promise<CuRunResult | undefined> {
@@ -455,13 +456,13 @@ export function createCuaDriverBackend(opts: CuaDriverBackendOptions): CuDispatc
     );
   }
 
-  function onServiceRelease(event: CuaDriverReleaseEvent): void {
-    if (event.reason === 'disposed') return;
+  function applyServiceRelease(events: readonly CuaDriverReleaseEvent[]): void {
+    const generationReleased = events.some((event) => event.generationReleased);
     const sessions = [
       ...new Set([
-        ...event.sessionIds,
-        ...(event.generationReleased ? targetsBySession.keys() : []),
-        ...(event.generationReleased
+        ...events.flatMap((event) => event.sessionIds),
+        ...(generationReleased ? targetsBySession.keys() : []),
+        ...(generationReleased
           ? [...observations.values()].map(
               (observation) => observation.context.sessionId,
             )
@@ -473,13 +474,22 @@ export function createCuaDriverBackend(opts: CuaDriverBackendOptions): CuDispatc
       try {
         opts.onSessionInvalidated?.({
           sessionId,
-          reason: event.reason,
-          outcomeUnknown: event.outcomeUnknown,
+          reason: events[0]!.reason,
+          outcomeUnknown: events.some((event) => event.outcomeUnknown),
         });
       } catch {
         // Host lifecycle observers cannot change service recovery.
       }
     }
+  }
+
+  function onServiceRelease(event: CuaDriverReleaseEvent): void {
+    if (event.reason === 'disposed') return;
+    if (event.reason === 'session_cleared' && sessionClearReleaseEvents) {
+      sessionClearReleaseEvents.push(event);
+      return;
+    }
+    applyServiceRelease([event]);
   }
 
   const actionClient = new CuaDriverService({
@@ -2653,9 +2663,19 @@ export function createCuaDriverBackend(opts: CuaDriverBackendOptions): CuDispatc
     },
 
     clearSession(sessionId) {
-      clearLocalSession(sessionId);
-      actionClient.clearSession(sessionId);
-      captureClient.clearSession(sessionId);
+      const releases: CuaDriverReleaseEvent[] = [];
+      sessionClearReleaseEvents = releases;
+      try {
+        actionClient.clearSession(sessionId);
+        captureClient.clearSession(sessionId);
+      } finally {
+        sessionClearReleaseEvents = undefined;
+      }
+      if (releases.length > 0) {
+        applyServiceRelease(releases);
+      } else {
+        clearLocalSession(sessionId);
+      }
     },
 
     dispose() {

--- a/packages/computer-use/src/cua-driver-release.ts
+++ b/packages/computer-use/src/cua-driver-release.ts
@@ -25,6 +25,7 @@ export interface CuaDriverRoleSnapshot {
 export interface CuaDriverReleaseEvent {
   role: CuaDriverRole;
   generation: number;
+  generationReleased: boolean;
   reason:
     | 'child_exit'
     | 'request_timeout'

--- a/packages/computer-use/src/cua-driver-service.ts
+++ b/packages/computer-use/src/cua-driver-service.ts
@@ -129,10 +129,12 @@ export class CuaDriverService {
     reason: CuaDriverReleaseEvent['reason'],
     sessionIds: readonly string[],
     outcomeUnknown: boolean,
+    generationReleased: boolean,
   ): void {
     this.opts.onRelease?.({
       role: this.opts.role,
       generation: this.generation,
+      generationReleased,
       reason,
       sessionIds: [...new Set(sessionIds)],
       outcomeUnknown,
@@ -191,7 +193,7 @@ export class CuaDriverService {
       }
     }
     this.state = 'unavailable';
-    this.emitRelease('restart_exhausted', [], false);
+    this.emitRelease('restart_exhausted', [], false, false);
     throw new CuaDriverLifecycleError(
       'service_unavailable',
       `cua-driver ${this.opts.role} restart budget exhausted: ${
@@ -410,7 +412,12 @@ export class CuaDriverService {
         ?? DEFAULT_RESTART_BACKOFF_MS;
       this.nextRestartAt = Date.now() + backoff;
     }
-    this.emitRelease(reason, sessionIds, potentiallyDelivered.length > 0);
+    this.emitRelease(
+      reason,
+      sessionIds,
+      potentiallyDelivered.length > 0,
+      true,
+    );
   }
 
   private notify(method: string, params?: unknown): void {
@@ -563,7 +570,7 @@ export class CuaDriverService {
       this.kill('session_cleared');
       return;
     }
-    this.emitRelease('session_cleared', [sessionId], false);
+    this.emitRelease('session_cleared', [sessionId], false, false);
   }
 
   private kill(reason: CuaDriverReleaseEvent['reason']): void {
@@ -584,7 +591,7 @@ export class CuaDriverService {
       // Disposal is best-effort; the sibling role still needs cleanup.
     }
     try {
-      this.emitRelease('disposed', [], false);
+      this.emitRelease('disposed', [], false, false);
     } catch {
       // Release observers must not interrupt process cleanup.
     }

--- a/packages/runtime/src/__tests__/computer-use-privacy-boundary.test.ts
+++ b/packages/runtime/src/__tests__/computer-use-privacy-boundary.test.ts
@@ -112,6 +112,57 @@ test('Computer Use snapshots execution args and persists only the approval summa
   assert.doesNotMatch(invocations[0]!.argsSummary ?? '', /secret|123|456/);
 });
 
+test('Computer Use validation failures still persist a redacted call and result', async () => {
+  const messages: StoredMessage[] = [];
+  const events: SessionEvent[] = [];
+  const invocations: ToolInvocationRecord[] = [];
+  const runtime = new ToolRuntime({
+    sessionId: 'session-1',
+    header: header(),
+    connection: connection(),
+    modelId: 'mock-model',
+    appendMessage: async (message) => { messages.push(message); },
+    permissionEngine: new PermissionEngine({ newId: nextId(), now: () => 1 }),
+    newId: nextId(),
+    now: () => 1,
+    getPermissionPauseTarget: () => null,
+    recordToolInvocation: (record) => { invocations.push(record); },
+  });
+  const tool: MakaTool = {
+    name: 'maka_computer',
+    description: 'test',
+    parameters: {},
+    categoryHint: 'computer_use',
+    permissionRequired: false,
+    permissionArgs: () => {
+      throw new Error('AX label: Customer SSN 123-45-6789');
+    },
+    impl: async () => {
+      assert.fail('invalid arguments must not reach the implementation');
+    },
+  };
+
+  const result = await runtime.wrapToolExecute(tool, 'turn-1', {
+    push: (event) => events.push(event),
+  })({
+    action: 'type',
+    text: 'private text',
+    coordinate: [123, 456],
+  }, {
+    toolCallId: 'tool-invalid',
+    abortSignal: new AbortController().signal,
+  }) as { error?: string };
+
+  assert.equal(result.error, 'Computer Use arguments failed validation');
+  const serialized = JSON.stringify({ messages, events, invocations });
+  assert.doesNotMatch(serialized, /Customer SSN|123-45-6789|private text|123|456/);
+  assert.equal(messages.some((message) => message.type === 'tool_call'), true);
+  assert.equal(messages.some((message) => message.type === 'tool_result'), true);
+  assert.equal(events.some((event) => event.type === 'tool_start'), true);
+  assert.equal(events.some((event) => event.type === 'tool_result'), true);
+  assert.equal(invocations[0]?.errorClass, 'InvalidArguments');
+});
+
 function nextId(): () => string {
   let sequence = 0;
   return () => `id-${++sequence}`;

--- a/packages/runtime/src/__tests__/computer-use-tools.test.ts
+++ b/packages/runtime/src/__tests__/computer-use-tools.test.ts
@@ -1387,6 +1387,43 @@ describe('buildComputerUseTools — the `maka_computer` MakaTool', () => {
     assert.equal(observeAppCalls, 0);
   });
 
+  test('clearSession fences a later turn that was queued before stop', async () => {
+    let release!: () => void;
+    let entered!: () => void;
+    let observeAppCalls = 0;
+    const gate = new Promise<void>((resolve) => { release = resolve; });
+    const started = new Promise<void>((resolve) => { entered = resolve; });
+    const backend = fakeBackend() as CuDispatchBackend & {
+      observeApp: NonNullable<CuDispatchBackend['observeApp']>;
+    };
+    backend.observeApp = async () => {
+      observeAppCalls += 1;
+      if (observeAppCalls === 1) {
+        entered();
+        await gate;
+      }
+      return observation();
+    };
+    const tools = buildComputerUseTools({ backend });
+    const [tool] = tools;
+    const first = tool.impl(
+      { action: 'observe', app: 'Fixture' } as never,
+      ctx(),
+    );
+    await started;
+    const second = tool.impl(
+      { action: 'observe', app: 'Fixture' } as never,
+      ctx(undefined, { turnId: 't2', toolCallId: 'observe-t2' }),
+    );
+    tools.clearSession('s1');
+    release();
+
+    const [firstResult, secondResult] = await Promise.all([first, second]) as Array<{ text: string }>;
+    assert.match(firstResult.text, /user_stopped/);
+    assert.match(secondResult.text, /user_stopped/);
+    assert.equal(observeAppCalls, 1);
+  });
+
   test('clearSession after a non-CU turn does not block the next turn observe', async () => {
     let observeAppCalls = 0;
     const backend = fakeBackend() as CuDispatchBackend & {
@@ -1491,6 +1528,94 @@ describe('buildComputerUseTools — the `maka_computer` MakaTool', () => {
       assert.match(result.text, /user_stopped/, action);
       assert.doesNotMatch(result.text, /service_unavailable/, action);
     }
+  });
+
+  test('ordinary failed host reads preserve their typed backend error', async () => {
+    for (const action of ['cursor_position', 'wait'] as const) {
+      const backend = fakeBackend({
+        result: {
+          outcome: {
+            ok: false,
+            error: 'service_unavailable',
+            message: 'service is unavailable',
+          },
+        },
+      });
+      const [tool] = buildComputerUseTools({ backend });
+      const result = await tool.impl(
+        action === 'wait'
+          ? { action, duration: 0.001 } as never
+          : { action } as never,
+        ctx(),
+      ) as { text: string; error?: string };
+
+      assert.equal(result.error, 'service_unavailable', action);
+      assert.match(result.text, /service_unavailable/, action);
+      assert.doesNotMatch(result.text, /reobserve_required/, action);
+    }
+  });
+
+  test('cursor_position returns the resolved screen point to the model', async () => {
+    const backend = fakeBackend({
+      result: {
+        outcome: { ok: true, tier: 'coordinate-background', verified: true },
+        resolvedScreenPoint: { x: 10, y: 20 },
+      },
+    });
+    const [tool] = buildComputerUseTools({ backend });
+    const result = await tool.impl(
+      { action: 'cursor_position' } as never,
+      ctx(),
+    ) as { text: string };
+
+    assert.match(result.text, /screen_point=10,20/);
+  });
+
+  test('fresh observations inherit a separately returned screenshot', async () => {
+    const backend = fakeBackend() as CuDispatchBackend & {
+      observeApp: NonNullable<CuDispatchBackend['observeApp']>;
+    };
+    backend.observeApp = async () => observation();
+    backend.run = async () => ({
+      outcome: { ok: true, tier: 'ax', verified: true },
+      observation: observation({
+        observationId: 'backend-obs-2',
+        screenshot: undefined,
+      }),
+      screenshot: {
+        base64: 'AQ==',
+        mimeType: 'image/png',
+        widthPx: 120,
+        heightPx: 90,
+      },
+    });
+    const [tool] = buildComputerUseTools({ backend });
+    const observed = await tool.impl(
+      { action: 'observe', app: 'Fixture' } as never,
+      ctx(),
+    ) as { text: string };
+    const result = await tool.impl({
+      action: 'left_click',
+      observation_id: JSON.parse(observed.text).observation_id,
+      coordinate: [25, 30],
+    } as never, ctx()) as {
+      modelText?: string;
+      screenshot?: { base64: string; mimeType: string };
+    };
+
+    assert.deepEqual(result.screenshot, {
+      base64: 'AQ==',
+      mimeType: 'image/png',
+    });
+    const freshObservationId = JSON.parse(
+      (result.modelText ?? '').split('Fresh observation:\n')[1] ?? '{}',
+    ).observation_id as string;
+    const followUp = await tool.impl({
+      action: 'left_click',
+      observation_id: freshObservationId,
+      coordinate: [30, 35],
+    } as never, ctx()) as { text: string };
+    assert.match(followUp.text, /computer\.left_click ok/);
   });
 
   test('S17: surfaces the typed backend failure code without leaking raw driver text', async () => {

--- a/packages/runtime/src/__tests__/computer-use-tools.test.ts
+++ b/packages/runtime/src/__tests__/computer-use-tools.test.ts
@@ -1272,6 +1272,74 @@ describe('buildComputerUseTools — the `maka_computer` MakaTool', () => {
     assert.equal(tools.sessionEvents.snapshot('s1').status, 'reobserve_required');
   });
 
+  for (const semantic of [false, true]) {
+    test(`clearSession cannot mask a delivered ${semantic ? 'semantic ' : ''}mutation outcome`, async () => {
+      let release!: () => void;
+      let started!: () => void;
+      const gate = new Promise<void>((resolve) => { release = resolve; });
+      const entered = new Promise<void>((resolve) => { started = resolve; });
+      const backend = fakeBackend() as CuDispatchBackend & {
+        observeApp: NonNullable<CuDispatchBackend['observeApp']>;
+        runSemantic: NonNullable<CuDispatchBackend['runSemantic']>;
+      };
+      backend.observeApp = async () => observation();
+      backend.run = async () => {
+        started();
+        await gate;
+        return {
+          outcome: {
+            ok: false,
+            error: 'outcome_unknown',
+            message: 'coordinate delivery may have occurred',
+          },
+        };
+      };
+      backend.runSemantic = async () => {
+        started();
+        await gate;
+        return {
+          outcome: {
+            ok: false,
+            error: 'capture_failed',
+            message: 'semantic verification failed after delivery',
+            completedSubSteps: 1,
+          },
+        };
+      };
+      const tools = buildComputerUseTools({ backend });
+      const [tool] = tools;
+      const observed = await tool.impl(
+        { action: 'observe', app: 'Fixture' } as never,
+        ctx(),
+      ) as { text: string };
+      const observationId = JSON.parse(observed.text).observation_id as string;
+      const pending = tool.impl(
+        semantic
+          ? {
+              action: 'click_element',
+              observation_id: observationId,
+              element_id: '5',
+            } as never
+          : {
+              action: 'left_click',
+              observation_id: observationId,
+              coordinate: [25, 30],
+            } as never,
+        ctx(),
+      );
+      await entered;
+
+      tools.clearSession('s1');
+      release();
+
+      const result = await pending as { text: string; error?: string };
+      assert.equal(result.error, 'outcome_unknown');
+      assert.match(result.text, /outcome_unknown/);
+      assert.doesNotMatch(result.text, /user_stopped|no_active_frame/);
+      assert.equal(tools.sessionEvents.snapshot('s1').status, 'user_stopped');
+    });
+  }
+
   test('a queued keyboard mutation cannot silently target a newer frame', async () => {
     let releaseClick!: () => void;
     const clickGate = new Promise<void>((resolve) => {

--- a/packages/runtime/src/__tests__/loop-gate.test.ts
+++ b/packages/runtime/src/__tests__/loop-gate.test.ts
@@ -204,8 +204,26 @@ function makeComputerFailureTool(
     parameters: z.object({}).passthrough(),
     permissionRequired: false,
     categoryHint: 'computer_use',
+    permissionArgs: (args) => {
+      const record = args as Record<string, unknown>;
+      return record.action === 'observe'
+        ? record
+        : {
+            ...record,
+            app: 'Fixture',
+            window_id: 7,
+            element_identity: {
+              token: `snapshot:${String(record.element_id ?? 'unknown')}`,
+              role: 'AXButton',
+              label: 'Duplicate',
+            },
+          };
+    },
     impl: (args) => {
       impl.push(JSON.stringify(args));
+      if ((args as { action?: string }).action === 'observe') {
+        return { text: 'observed' };
+      }
       return {
         text: 'maka_computer failed: stale_frame',
         error: 'stale_frame',
@@ -436,13 +454,17 @@ describe('loop-gate for repeated identical FAILING tool calls', () => {
     });
     assert.equal((first as { error?: string }).error, 'stale_frame');
 
+    await call(h, tool, {
+      action: 'observe',
+      app: 'Fixture',
+    });
     const second = await call(h, tool, {
       action: 'click_element',
       observation_id: 'obs-2',
-      element_id: 'duplicate',
+      element_id: 'renumbered-duplicate',
     });
     assert.deepEqual(second, { error: formatAmbiguousComputerLoopGateText() });
-    assert.equal(h.impl.length, 1, 'second ambiguous attempt never reaches the backend');
+    assert.equal(h.impl.length, 2, 'observe runs but the repeated mutation never reaches the backend');
   });
 
   test('repeated shell_run observations are not loop-gated by process status', async () => {

--- a/packages/runtime/src/computer-use-tools.ts
+++ b/packages/runtime/src/computer-use-tools.ts
@@ -484,7 +484,10 @@ function summarize(action: CuAction, result: CuRunResult): string {
   }
   const verified = outcome.verified === undefined ? 'n/a' : String(outcome.verified);
   const shot = result.screenshot ? `; screenshot ${result.screenshot.widthPx}x${result.screenshot.heightPx}` : '';
-  return `computer.${action.type} ok via ${outcome.tier} (verified=${verified})${evidence}${shot}`
+  const point = action.type === 'cursor_position' && result.resolvedScreenPoint
+    ? `; screen_point=${result.resolvedScreenPoint.x},${result.resolvedScreenPoint.y}`
+    : '';
+  return `computer.${action.type} ok via ${outcome.tier} (verified=${verified})${evidence}${point}${shot}`
     + (
       outcome.verified === false
         ? ' — dispatch could not be confirmed; re-screenshot before retrying'
@@ -869,7 +872,7 @@ export function buildComputerUseTools(deps: {
   ): Promise<CuObservation | undefined> {
     const observationLease = state.beforeObservation();
     if (!observationLease.ok) return undefined;
-    const fresh = result.observation ?? (
+    const captured = result.observation ?? (
       deps.backend.captureObservation && record.appId && record.windowId
         ? await deps.backend.captureObservation({
             app: record.appId,
@@ -878,6 +881,9 @@ export function buildComputerUseTools(deps: {
           }, signal, context)
         : undefined
     );
+    const fresh = captured && result.screenshot && !captured.screenshot
+      ? { ...captured, screenshot: result.screenshot }
+      : captured;
     if (
       !fresh
       || !state.validateObservationLease(observationLease.lease).ok
@@ -1143,6 +1149,12 @@ export function buildComputerUseTools(deps: {
         ...input,
         app: record.appId,
         window_id: record.windowId,
+        ...(
+          'element_id' in input
+          && record.elements?.get(input.element_id)?.identity
+            ? { element_identity: record.elements.get(input.element_id)!.identity }
+            : {}
+        ),
       };
     },
     impl: async (args, {
@@ -1157,6 +1169,9 @@ export function buildComputerUseTools(deps: {
       const releasePendingInvocation = trackPendingInvocation(sessionId, turnId);
       try {
         return await withInvocationQueue(sessionId, abortSignal, async () => {
+        if ((presentationGenerations.get(sessionId) ?? 0) !== invocationGeneration) {
+          return sessionFailure('user_stopped');
+        }
         const state = sessionState(sessionId, turnId);
         const requiresObservationLease = (
           input.action === 'observe'
@@ -1559,7 +1574,6 @@ export function buildComputerUseTools(deps: {
             result = presentation.result
               ? preservePartialDelivery(presentation.result)
               : undefined;
-            if (result) applyTypedOutcomeState(state, result.outcome);
             if (observationLease?.ok) {
               const validated = state.validateObservationLease(
                 observationLease.lease,
@@ -1569,6 +1583,7 @@ export function buildComputerUseTools(deps: {
                 return sessionFailure(validated.reason);
               }
             }
+            if (result) applyTypedOutcomeState(state, result.outcome);
             if (result?.outcome.ok && actionLease) {
               const leaseFailure = validateActionLease(state, actionLease);
               if (leaseFailure) {

--- a/packages/runtime/src/computer-use-tools.ts
+++ b/packages/runtime/src/computer-use-tools.ts
@@ -779,6 +779,17 @@ export function buildComputerUseTools(deps: {
     };
   }
 
+  function hasUncertainDeliveredOutcome(
+    result: CuRunResult | undefined,
+  ): result is CuRunResult {
+    return result !== undefined
+      && !result.outcome.ok
+      && (
+        result.outcome.error === 'outcome_unknown'
+        || (result.outcome.completedSubSteps ?? 0) > 0
+      );
+  }
+
   function deliveredWithoutFreshObservation(
     action: CuAction,
     result: CuRunResult,
@@ -1463,7 +1474,7 @@ export function buildComputerUseTools(deps: {
               state.reobserveRequired();
             }
           }
-          if (consumeFailure) {
+          if (consumeFailure && !hasUncertainDeliveredOutcome(result)) {
             presentation?.finish();
             return consumeFailure;
           }
@@ -1578,7 +1589,10 @@ export function buildComputerUseTools(deps: {
               const validated = state.validateObservationLease(
                 observationLease.lease,
               );
-              if (!validated.ok) {
+              if (
+                !validated.ok
+                && !hasUncertainDeliveredOutcome(result)
+              ) {
                 presentation.finish();
                 return sessionFailure(validated.reason);
               }
@@ -1603,7 +1617,7 @@ export function buildComputerUseTools(deps: {
           // bounded frame never bloats history.
           let bindingResult: ComputerToolResult | undefined;
           if (boundAction) bindingResult = consumeBoundAction(record, boundAction);
-          if (bindingResult) {
+          if (bindingResult && !hasUncertainDeliveredOutcome(result)) {
             presentation?.finish();
             return bindingResult;
           }

--- a/packages/runtime/src/tool-runtime.ts
+++ b/packages/runtime/src/tool-runtime.ts
@@ -368,13 +368,19 @@ export class ToolRuntime {
   ): Promise<unknown> {
     const executionArgs = snapshotToolArgs(args);
     const toolUseId = ctx.toolCallId;
-    const permissionArgs = tool.permissionArgs
-      ? snapshotToolArgs(tool.permissionArgs(structuredClone(executionArgs) as never, {
-          sessionId: this.input.sessionId,
-          turnId,
-          toolCallId: toolUseId,
-        }))
-      : executionArgs;
+    let permissionArgs = executionArgs;
+    let permissionArgsError: unknown;
+    try {
+      permissionArgs = tool.permissionArgs
+        ? snapshotToolArgs(tool.permissionArgs(structuredClone(executionArgs) as never, {
+            sessionId: this.input.sessionId,
+            turnId,
+            toolCallId: toolUseId,
+          }))
+        : executionArgs;
+    } catch (error) {
+      permissionArgsError = error;
+    }
     const persistedArgs = tool.categoryHint === 'computer_use'
       ? snapshotToolArgs(computerUseApprovalSummary(permissionArgs))
       : permissionArgs;
@@ -418,6 +424,41 @@ export class ToolRuntime {
       permissionRequired: tool.permissionRequired !== false,
       ...(tool.categoryHint !== undefined ? { categoryHint: tool.categoryHint } : {}),
     });
+    const callSignature = `${tool.name} ${loopGateArgsKey(executionArgs, toolUseId)}`;
+    const computerSemanticSignature = tool.categoryHint === 'computer_use'
+      ? computerUseSemanticSignature(permissionArgs)
+      : undefined;
+    if (permissionArgsError !== undefined) {
+      const msg = tool.categoryHint === 'computer_use'
+        ? 'Computer Use arguments failed validation'
+        : formatSyntheticToolErrorText(permissionArgsError);
+      await this.writeSyntheticToolResult(toolUseId, turnId, msg, queue);
+      this.input.recordToolInvocation?.({
+        sessionId: this.input.sessionId,
+        turnId,
+        toolCallId: toolUseId,
+        toolName: tool.name,
+        providerId: this.input.connection.providerType,
+        modelId: this.input.modelId,
+        durationMs: 0,
+        status: 'error',
+        errorClass: 'InvalidArguments',
+        argsSummary: tool.categoryHint === 'computer_use'
+          ? summarizePersistedArgs(persistedArgs)
+          : summarizeArgs(tool.name, executionArgs),
+        bytesIn: byteLength(persistedArgs),
+        bytesOut: byteLength(msg),
+        startedAt: now,
+      });
+      trace?.emit('tool', 'tool_failed', 'Tool arguments failed validation', {
+        toolUseId,
+        toolName: tool.name,
+        status: 'error',
+        errorClass: 'InvalidArguments',
+      });
+      this.recordLoopGateOutcome(callSignature, true);
+      return this.errorReturn(msg);
+    }
 
     // Loop-gate (#92): block this call up front — before the guards and the real
     // impl — if this exact call (tool + canonical args) has already FAILED
@@ -429,10 +470,6 @@ export class ToolRuntime {
     // so polling and iterate-then-retry are never gated. Recoverable: the model
     // is told to change its approach. The block itself records no outcome, so the
     // streak stays parked and every further identical repeat stays blocked.
-    const callSignature = `${tool.name} ${loopGateArgsKey(executionArgs, toolUseId)}`;
-    const computerSemanticSignature = tool.categoryHint === 'computer_use'
-      ? computerUseSemanticSignature(executionArgs)
-      : undefined;
     if (
       computerSemanticSignature
       && computerSemanticSignature === this.lastAmbiguousComputerSignature
@@ -449,6 +486,7 @@ export class ToolRuntime {
     }
     if (
       this.lastAmbiguousComputerSignature
+      && computerSemanticSignature
       && computerSemanticSignature !== this.lastAmbiguousComputerSignature
     ) {
       this.lastAmbiguousComputerSignature = undefined;
@@ -1076,9 +1114,11 @@ export class ToolRuntime {
         );
 
         attemptFailed = toolResultStatus !== 'success';
-        this.lastAmbiguousComputerSignature = isAmbiguousComputerFailure(result)
-          ? computerSemanticSignature
-          : undefined;
+        if (isAmbiguousComputerFailure(result)) {
+          this.lastAmbiguousComputerSignature = computerSemanticSignature;
+        } else if (computerSemanticSignature) {
+          this.lastAmbiguousComputerSignature = undefined;
+        }
         return result;
       } finally {
         pauseTarget?.resume();
@@ -1144,7 +1184,9 @@ export class ToolRuntime {
         });
         return this.errorReturn(terminalFailure.message);
       }
-      const msg = formatSyntheticToolErrorText(err);
+      const msg = tool.categoryHint === 'computer_use'
+        ? `Computer Use failed: ${classifyError(err)}`
+        : formatSyntheticToolErrorText(err);
       await this.writeSyntheticToolResult(toolUseId, turnId, msg, queue);
       this.input.recordToolInvocation?.({
         sessionId: this.input.sessionId,
@@ -1302,15 +1344,31 @@ function computerUseSemanticSignature(args: unknown): string | undefined {
     && record.action !== 'secondary_action'
   ) return undefined;
   try {
+    const elementIdentity = stableElementIdentity(record.element_identity);
     return stableHash({
       action: record.action,
-      element_id: record.element_id,
+      app: record.app,
+      window_id: record.window_id,
+      ...(elementIdentity === undefined
+        ? { element_id: record.element_id }
+        : { element_identity: elementIdentity }),
       value: record.value,
       text: record.text,
     });
   } catch {
     return undefined;
   }
+}
+
+function stableElementIdentity(value: unknown): unknown {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return value;
+  const record = value as Record<string, unknown>;
+  return {
+    role: record.role,
+    label: record.label,
+    value: record.value,
+    frame: record.frame,
+  };
 }
 
 /**


### PR DESCRIPTION
## Summary

Hardens Computer Use Runtime and the shared cua-driver executor without widening compatibility input.

- serialize complete host-state transactions around the shared cua-driver child;
- invalidate every retained session ownership record when the shared service generation changes;
- fence invocations queued before stop, including later turns;
- preserve typed host-read failures and separately returned screenshots;
- return the read-only cua-driver cursor position;
- persist redacted validation failures;
- bind ambiguity retries to stable app/window/element identity while excluding ephemeral element IDs and snapshot tokens;
- preserve delivered-but-unverified `outcome_unknown`.

True cross-window concurrency requires per-session child processes and is not claimed here.

## Verification

- Core: 1003 pass, 0 fail
- Runtime: 1940 pass, 7 skip, 0 fail
- Computer Use: 135 pass, 0 fail
- Regression: idle clearSession(A) preserves B observation/keyboard target; queued/in-flight B mutation completes without generation change