### PR TITLE
docs(readme): brand-badge language switcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-[中文](./README.zh-CN.md)
+<a href="./README.md"><img alt="English" src="https://img.shields.io/badge/English-2ea44f?style=for-the-badge&logo=googletranslate&logoColor=white"></a>
+<a href="./README.zh-CN.md"><img alt="简体中文" src="https://img.shields.io/badge/%E7%AE%80%E4%BD%93%E4%B8%AD%E6%96%87-555?style=for-the-badge&logo=googletranslate&logoColor=white"></a>
 
 # Maka
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,4 +1,5 @@
-[English](./README.md)
+<a href="./README.md"><img alt="English" src="https://img.shields.io/badge/English-555?style=for-the-badge&logo=googletranslate&logoColor=white"></a>
+<a href="./README.zh-CN.md"><img alt="简体中文" src="https://img.shields.io/badge/%E7%AE%80%E4%BD%93%E4%B8%AD%E6%96%87-2ea44f?style=for-the-badge&logo=googletranslate&logoColor=white"></a>
 
 # Maka
 


### PR DESCRIPTION
Replace the plain-text 中文 / English cross-links at the top of `README.md` and `README.zh-CN.md` with shields.io `for-the-badge` language badges — current language highlighted green, the other neutral grey, with a translate glyph — so the language switch reads as a brand element instead of a bare hyperlink.

Preview (English README): **English** (green) · 简体中文 (grey). The Chinese README flips the highlight.