### PR TITLE
fix(cu): harden desktop packaging and presentation

### DIFF
--- a/apps/desktop/bundled-tools.json
+++ b/apps/desktop/bundled-tools.json
@@ -28,6 +28,10 @@
       "x86_64"
     ],
     "signature": "adhoc",
+    "archiveSizeBytes": 10473137,
+    "binarySizeBytes": 25270080,
+    "licenseSizeBytes": 1069,
+    "sourceSizeBytes": 542,
     "archiveSha256": "c15e65138200cac5a03d013c455201bcfae2b9a7fb16be7c9d332e595481862c",
     "binarySha256": "683dad5cccb47dd0a8bb5d534d62fbb9e6edfb1cded232509cf4c2b190066040",
     "licenseSha256": "c0779290c1d4783169aa3dbfb55feb505e563ef8a004bbf55298ceffcfbda8d9",

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -29,7 +29,7 @@
     "screenshots:single": "npm --workspace @maka/core run build && npm --workspace @maka/storage run build && npm --workspace @maka/runtime run build && npm --workspace @maka/computer-use run build && npm --workspace @maka/ui run build && npm run build && node ../../scripts/capture-screenshots.mjs --scenario",
     "smoke:real-window": "npm --workspace @maka/core run build && npm --workspace @maka/storage run build && npm --workspace @maka/runtime run build && npm --workspace @maka/computer-use run build && npm --workspace @maka/ui run build && npm run build && node ../../scripts/desktop-real-window-smoke.mjs",
     "smoke:programmatic-window": "npm --workspace @maka/core run build && npm --workspace @maka/storage run build && npm --workspace @maka/runtime run build && npm --workspace @maka/computer-use run build && npm --workspace @maka/ui run build && npm run build && node ../../scripts/desktop-real-window-smoke.mjs --programmatic-only",
-    "smoke:browser": "npm --workspace @maka/core run build && npm run build:main && electron scripts/browser-observe-act-smoke.mjs",
+    "smoke:browser": "npm --workspace @maka/core run build && npm --workspace @maka/runtime run build && npm --workspace @maka/computer-use run build && npm run build:main && electron scripts/browser-observe-act-smoke.mjs",
     "screenshots:diff": "node ../../scripts/diff-screenshots.mjs",
     "screenshots:diff:stable": "node ../../scripts/diff-screenshots.mjs --subset stable",
     "screenshots:chat-chrome:check": "node ../../scripts/check-chat-chrome-screenshot.mjs",

--- a/apps/desktop/src/main/__tests__/computer-use-capability.test.ts
+++ b/apps/desktop/src/main/__tests__/computer-use-capability.test.ts
@@ -49,9 +49,26 @@ describe('Desktop Computer Use production wiring', () => {
     assert.ok(capability, 'Computer Use capability block must exist');
     assert.match(capability, /required_scoped_lease/);
     assert.match(capability, /input\?\.health\.state/);
+    assert.match(capability, /未找到通过完整性检查的 cua-driver artifact/);
+    assert.match(capability, /等待.*权限/);
+    assert.match(capability, /service 正在启动或恢复/);
+    assert.match(capability, /service 启动失败、已退出或已停止/);
     assert.doesNotMatch(capability, /required_per_action/);
     assert.match(main, /computerUse\.backend\?\.serviceState/);
     assert.match(main, /computerUseServiceHealth/);
+  });
+
+  it('does not expose screenshot-returning Computer Use tools to non-visual models', async () => {
+    const [main, packageJson] = await Promise.all([
+      readFile(resolve(ROOT, 'apps/desktop/src/main/main.ts'), 'utf8'),
+      readFile(resolve(ROOT, 'apps/desktop/package.json'), 'utf8'),
+    ]);
+    assert.match(main, /computerUseToolsForModel\([\s\S]*supportsVision/);
+    assert.match(main, /computerUseAvailabilityForModel\([\s\S]*supportsVision/);
+    assert.match(
+      packageJson,
+      /"smoke:browser":\s*"[^"]*@maka\/computer-use[^"]*build:main/,
+    );
   });
 
   it('wires a conservative physical-input quiet window', async () => {

--- a/apps/desktop/src/main/__tests__/computer-use-host.test.ts
+++ b/apps/desktop/src/main/__tests__/computer-use-host.test.ts
@@ -37,11 +37,14 @@ describe('Computer Use host health', () => {
     assert.equal(computerUseServiceHealth('cua-driver', {
       action: role('backing_off'),
       capture: { ...role('ready'), role: 'capture' },
-    }).state, 'degraded');
-    assert.equal(computerUseServiceHealth('cua-driver', {
+    }).reason, 'cua-driver service 正在启动或恢复。');
+    assert.deepEqual(computerUseServiceHealth('cua-driver', {
       action: role('unavailable'),
       capture: { ...role('ready'), role: 'capture' },
-    }).state, 'not_available');
+    }), {
+      state: 'not_available',
+      reason: 'cua-driver service 启动失败或已退出。',
+    });
     assert.deepEqual(computerUseServiceHealth('cua-driver', {
       action: role('ready'),
       capture: { ...role('idle'), role: 'capture' },
@@ -49,10 +52,13 @@ describe('Computer Use host health', () => {
       state: 'not_run',
       reason: 'cua-driver 部分服务已启动，其余服务将在需要时启动。',
     });
-    assert.equal(computerUseServiceHealth('cua-driver', {
+    assert.deepEqual(computerUseServiceHealth('cua-driver', {
       action: role('disposed'),
       capture: { ...role('ready'), role: 'capture' },
-    }).state, 'not_available');
+    }), {
+      state: 'not_available',
+      reason: 'cua-driver service 已停止。',
+    });
   });
 
   it('reports a missing backend as unavailable', () => {

--- a/apps/desktop/src/main/__tests__/computer-use-model-tools.test.ts
+++ b/apps/desktop/src/main/__tests__/computer-use-model-tools.test.ts
@@ -1,0 +1,40 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import type { MakaTool, ToolAvailabilityConfig } from '@maka/runtime';
+import {
+  computerUseAvailabilityForModel,
+  computerUseToolsForModel,
+} from '../computer-use-model-tools.js';
+
+const tool = (name: string): MakaTool => ({ name } as MakaTool);
+
+describe('Computer Use model tool visibility', () => {
+  const computer = tool('maka_computer');
+  const shell = tool('Bash');
+  const availability: ToolAvailabilityConfig = {
+    economy: true,
+    groups: [
+      { id: 'browser', toolNames: ['browser_navigate'] },
+      { id: 'computer_use', toolNames: ['maka_computer'] },
+    ],
+  };
+
+  it('removes screenshot-returning Computer Use tools and their group for text-only models', () => {
+    assert.deepEqual(
+      computerUseToolsForModel([shell, computer], [computer], false).map((candidate) => candidate.name),
+      ['Bash'],
+    );
+    assert.deepEqual(
+      computerUseAvailabilityForModel(availability, false).groups?.map((group) => group.id),
+      ['browser'],
+    );
+  });
+
+  it('preserves the complete tool surface for visual models', () => {
+    assert.deepEqual(
+      computerUseToolsForModel([shell, computer], [computer], true).map((candidate) => candidate.name),
+      ['Bash', 'maka_computer'],
+    );
+    assert.equal(computerUseAvailabilityForModel(availability, true), availability);
+  });
+});

--- a/apps/desktop/src/main/__tests__/cursor-engine.test.ts
+++ b/apps/desktop/src/main/__tests__/cursor-engine.test.ts
@@ -3,6 +3,7 @@
 // trycua/cua's cursor-overlay Rust source these were ported from.
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
 
 import { CursorEngine } from '../../renderer/computer-use-overlay/engine/cursor-engine.js';
 import { planDirectPath, planPath } from '../../renderer/computer-use-overlay/engine/dubins.js';
@@ -140,6 +141,7 @@ test('cursor bloom is centered on the arrow hotspot', () => {
   const e = new CursorEngine();
   e.completeAt(320, 240);
   const gradients: number[][] = [];
+  const arcs: number[][] = [];
   const gradient = { addColorStop() {} };
   const ctx = {
     createRadialGradient: (...args: number[]) => {
@@ -148,7 +150,7 @@ test('cursor bloom is centered on the arrow hotspot', () => {
     },
     createLinearGradient: () => gradient,
     beginPath() {},
-    arc() {},
+    arc(...args: number[]) { arcs.push(args); },
     fill() {},
     stroke() {},
     moveTo() {},
@@ -162,6 +164,30 @@ test('cursor bloom is centered on the arrow hotspot', () => {
 
   e.paint(ctx, 0, 0);
   assert.deepEqual(gradients[0]?.slice(0, 5), [320, 240, 0, 320, 240]);
+  assert.deepEqual(arcs[0]?.slice(0, 2), [320, 240]);
+});
+
+test('cancel clears cursor path, pressed state, and click pulse', () => {
+  const e = new CursorEngine();
+  e.moveTo(500, 300, undefined, true);
+  e.pressed = true;
+  e.triggerClick(500, 300);
+  assert.equal(e.isMoving(), true);
+  e.cancel();
+  assert.equal(e.isMoving(), false);
+  assert.equal(e.hasMotionPath(), false);
+  assert.equal(e.pressed, false);
+});
+
+test('overlay cancel waits for the renderer frame before reporting finished', async () => {
+  const source = await readFile(
+    new URL('../../../src/overlay/cursor-overlay.ts', import.meta.url),
+    'utf8',
+  );
+  const cancelBlock = source.match(/onCancel\(\(p\) => \{([\s\S]*?)\n\}\);/)?.[1] ?? '';
+  assert.match(cancelBlock, /engine\.cancel\(\)/);
+  assert.match(cancelBlock, /kick\(\)/);
+  assert.doesNotMatch(cancelBlock, /reportPhase\('finished'\)/);
 });
 
 test('direct path planner never detours for short moves', () => {

--- a/apps/desktop/src/main/__tests__/cursor-overlay-window.test.ts
+++ b/apps/desktop/src/main/__tests__/cursor-overlay-window.test.ts
@@ -355,7 +355,7 @@ test('complete() sends exact backend coordinate only for the live action', () =>
   });
 });
 
-test('cancel() settles the live fence and sends no coordinate', async () => {
+test('cancel() waits for renderer finished and sends no coordinate', async () => {
   const { controller, created } = harness();
   const fence = controller.move({
     actionId: 'failed',
@@ -371,7 +371,10 @@ test('cancel() settles the live fence and sends no coordinate', async () => {
   controller.cancel({ actionId: 'stale', sessionId: 's' });
   assert.equal(w.sent.filter((message) => message.channel === 'overlay:cancel').length, 0);
   controller.cancel({ actionId: 'failed', sessionId: 's' });
-  await Promise.all([fence.readyForInteraction, fence.finished]);
+  let finished = false;
+  fence.finished.then(() => { finished = true; });
+  await Promise.resolve();
+  assert.equal(finished, false);
 
   const cancelled = w.sent.filter((message) => message.channel === 'overlay:cancel');
   assert.deepEqual(cancelled, [{
@@ -380,6 +383,9 @@ test('cancel() settles the live fence and sends no coordinate', async () => {
   }]);
   assert.equal('x' in (cancelled[0]?.payload as object), false);
   assert.equal('y' in (cancelled[0]?.payload as object), false);
+  w.firePresentation('failed', 'finished');
+  await Promise.all([fence.readyForInteraction, fence.finished]);
+  assert.equal(finished, true);
 });
 
 test('complete() can present an executor-resolved semantic point without a speculative begin move', () => {

--- a/apps/desktop/src/main/__tests__/single-instance-lock-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/single-instance-lock-contract.test.ts
@@ -56,4 +56,14 @@ describe('single-instance lock contract', () => {
       'activate should share the exact same behavior as second-instance',
     );
   });
+
+  it('counts only the real main window, not cursor overlays, when deciding whether to focus', async () => {
+    const mainWindow = await readFile(
+      resolve(import.meta.dirname, '../../../../../apps/desktop/src/main/main-window.ts'),
+      'utf8',
+    );
+    const hasOpenWindows = mainWindow.match(/hasOpenWindows\(\) \{([\s\S]*?)\n    \}/)?.[1] ?? '';
+    assert.match(hasOpenWindows, /mainWindow !== null && !mainWindow\.isDestroyed\(\)/);
+    assert.doesNotMatch(hasOpenWindows, /BrowserWindow\.getAllWindows/);
+  });
 });

--- a/apps/desktop/src/main/capability-snapshot.ts
+++ b/apps/desktop/src/main/capability-snapshot.ts
@@ -146,18 +146,15 @@ function computerUseCapability(
   permissions: PermissionSnapshot['permissions'],
   now: number,
 ): CapabilitySnapshot {
-  const available = input?.backendId === 'cua-driver'
-    && input.health.state !== 'not_available';
+  const artifactAvailable = input?.backendId === 'cua-driver';
   return staticCapability({
     id: 'computer_use',
     label: 'Computer Use',
     now,
     feature: {
-      state: available ? 'enabled' : 'not_available',
+      state: artifactAvailable ? 'enabled' : 'not_available',
       source: 'runtime',
-      reason: available
-        ? 'cua-driver 已通过本地完整性检查；按目标与动作类别授权后可操作本机应用。'
-        : '未找到通过完整性检查的 cua-driver artifact。',
+      reason: computerUseCapabilityReason(input, permissions),
     },
     requiredPermissions: [
       { id: 'accessibility', required: true, status: permissions.accessibility.status },
@@ -175,6 +172,42 @@ function computerUseCapability(
       reason: input?.health.reason ?? 'cua-driver 后端当前不可用。',
     },
   });
+}
+
+function computerUseCapabilityReason(
+  input: {
+    backendId: 'cua-driver' | 'none';
+    health: ReturnType<typeof computerUseServiceHealth>;
+  } | undefined,
+  permissions: PermissionSnapshot['permissions'],
+): string {
+  if (input?.backendId !== 'cua-driver') {
+    return '未找到通过完整性检查的 cua-driver artifact。';
+  }
+
+  const reasons = ['cua-driver artifact 已通过本地完整性检查。'];
+  const missingPermissions = [
+    ['辅助功能', permissions.accessibility.status],
+    ['屏幕录制', permissions.screen_recording.status],
+  ].filter((entry) => entry[1] !== 'granted').map((entry) => entry[0]);
+  if (missingPermissions.length > 0) {
+    reasons.push(`等待${missingPermissions.join('、')}权限。`);
+  }
+  switch (input.health.state) {
+    case 'not_available':
+      reasons.push('cua-driver service 启动失败、已退出或已停止。');
+      break;
+    case 'degraded':
+      reasons.push('cua-driver service 正在启动或恢复。');
+      break;
+    case 'healthy':
+      reasons.push('操作与截图 service 已就绪；按目标与动作类别授权后可操作本机应用。');
+      break;
+    case 'not_run':
+      reasons.push('service 将在首次调用时启动；按目标与动作类别授权后可操作本机应用。');
+      break;
+  }
+  return reasons.join('');
 }
 
 function officeDocumentsCapability(probe: OfficeCliProbe | undefined, now: number): CapabilitySnapshot {

--- a/apps/desktop/src/main/computer-use-host.ts
+++ b/apps/desktop/src/main/computer-use-host.ts
@@ -135,14 +135,16 @@ export function computerUseServiceHealth(
     role.state === 'unavailable' || role.state === 'disposed')) {
     return {
       state: 'not_available',
-      reason: 'cua-driver 服务当前不可用。',
+      reason: roles.some((role) => role.state === 'disposed')
+        ? 'cua-driver service 已停止。'
+        : 'cua-driver service 启动失败或已退出。',
     };
   }
   if (roles.some((role) =>
     role.state === 'starting' || role.state === 'backing_off')) {
     return {
       state: 'degraded',
-      reason: 'cua-driver 服务正在启动或恢复。',
+      reason: 'cua-driver service 正在启动或恢复。',
     };
   }
   if (roles.every((role) => role.state === 'ready')) {

--- a/apps/desktop/src/main/computer-use-model-tools.ts
+++ b/apps/desktop/src/main/computer-use-model-tools.ts
@@ -1,0 +1,22 @@
+import type { MakaTool, ToolAvailabilityConfig } from '@maka/runtime';
+
+export function computerUseToolsForModel(
+  tools: readonly MakaTool[],
+  computerUseTools: readonly MakaTool[],
+  supportsVision: boolean,
+): MakaTool[] {
+  if (supportsVision || computerUseTools.length === 0) return [...tools];
+  const computerUseToolNames = new Set(computerUseTools.map((tool) => tool.name));
+  return tools.filter((tool) => !computerUseToolNames.has(tool.name));
+}
+
+export function computerUseAvailabilityForModel(
+  availability: ToolAvailabilityConfig,
+  supportsVision: boolean,
+): ToolAvailabilityConfig {
+  if (supportsVision || !availability.groups) return availability;
+  return {
+    ...availability,
+    groups: availability.groups.filter((group) => group.id !== 'computer_use'),
+  };
+}

--- a/apps/desktop/src/main/computer-use/cursor-overlay-window.ts
+++ b/apps/desktop/src/main/computer-use/cursor-overlay-window.ts
@@ -321,8 +321,6 @@ export function createCursorOverlayController(
     if (typeof input.sessionId !== 'string' || input.sessionId.length === 0) return;
     if (input.sessionId !== sessionId || input.actionId !== actionId) return;
     push('overlay:cancel', { actionId: input.actionId });
-    settlePresentation();
-    actionId = null;
   }
 
   function clearForSession(id: string): void {

--- a/apps/desktop/src/main/main-window.ts
+++ b/apps/desktop/src/main/main-window.ts
@@ -428,7 +428,7 @@ export function createMainWindowController(deps: MainWindowControllerDeps): Main
     getBrowserViews,
     disposeBrowserViews,
     hasOpenWindows() {
-      return BrowserWindow.getAllWindows().length > 0;
+      return mainWindow !== null && !mainWindow.isDestroyed();
     },
     focus() {
       // ChatGPT Pro review P2: second-instance / activate must not show() the

--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -187,6 +187,10 @@ import {
   applyComputerUseRealModelPolicy,
   parseComputerUseRealModelPolicy,
 } from './computer-use-real-model-policy.js';
+import {
+  computerUseAvailabilityForModel,
+  computerUseToolsForModel,
+} from './computer-use-model-tools.js';
 import { createComputerUseOverlayHook } from '@maka/computer-use';
 import { releaseBrowserSession } from './browser/session.js';
 import { createMainWindowController } from './main-window.js';
@@ -874,10 +878,10 @@ backends.register('ai-sdk', async (ctx) => {
   const modelFetch = buildSubscriptionModelFetch(connection, ctx.sessionId, model);
   const memoryPromptSnapshot = await systemPromptService.buildLocalMemoryPromptFragment();
   const supportsVision = modelSupportsVision(connection, model);
-  const backendTools = isComputerUseRealModelE2e
+  const candidateTools = isComputerUseRealModelE2e
     ? computerUseTools
     : [...(ctx.tools ?? builtinTools)];
-  const backendToolAvailability = isComputerUseRealModelE2e
+  const candidateToolAvailability = isComputerUseRealModelE2e
     ? { economy: false, groups: [] }
     : toolAvailability;
   // Expert-team lead: a main session (ctx.tools undefined) labeled
@@ -886,6 +890,15 @@ backends.register('ai-sdk', async (ctx) => {
   // get expert_dispatch — members cannot spawn nested teams.
   const expertTeamId = ctx.tools ? undefined : expertTeamIdFromLabels(ctx.header.labels);
   const expertDispatchTool = expertTeamId ? buildExpertDispatchToolForTeamId(expertTeamId) : undefined;
+  const backendTools = computerUseToolsForModel(
+    candidateTools,
+    computerUseTools,
+    supportsVision,
+  );
+  const backendToolAvailability = computerUseAvailabilityForModel(
+    candidateToolAvailability,
+    supportsVision,
+  );
 
   return new AiSdkBackend({
     sessionId: ctx.sessionId,

--- a/apps/desktop/src/overlay/cursor-overlay.ts
+++ b/apps/desktop/src/overlay/cursor-overlay.ts
@@ -127,7 +127,8 @@ window.cursorOverlay?.onComplete((p) => {
 });
 window.cursorOverlay?.onCancel((p) => {
   if (!activeActionId || p.actionId !== activeActionId) return;
+  engine.cancel();
+  readySent = true;
   waitForNativeCompletion = false;
-  reportPhase('finished');
-  activeActionId = null;
+  kick();
 });

--- a/apps/desktop/src/renderer/computer-use-overlay/engine/cursor-engine.ts
+++ b/apps/desktop/src/renderer/computer-use-overlay/engine/cursor-engine.ts
@@ -88,6 +88,15 @@ export class CursorEngine {
     this.clickT = 0;
   }
 
+  cancel(): void {
+    this.path = null;
+    this.dist = 0;
+    this.clickT = null;
+    this.clickPoint = null;
+    this.clickOnArrive = false;
+    this.pressed = false;
+  }
+
   /** True while a direct glide or click pulse is in progress. */
   isMoving(): boolean {
     return this.path !== null || this.clickT !== null;
@@ -161,7 +170,7 @@ export class CursorEngine {
     grad.addColorStop(1, rgba(p.bloomOuter, 0));
     ctx.fillStyle = grad;
     ctx.beginPath();
-    ctx.arc(px, py, bloomR, 0, 2 * PI);
+    ctx.arc(hotspotX, hotspotY, bloomR, 0, 2 * PI);
     ctx.fill();
 
     // --- Pressed state (dot + ring) ---

--- a/packages/core/src/__tests__/capabilities.test.ts
+++ b/packages/core/src/__tests__/capabilities.test.ts
@@ -114,6 +114,19 @@ describe('permission and capability snapshot contracts', () => {
     })).toBe('degraded');
   });
 
+  test('unavailable runtime probe degrades an otherwise enabled capability', () => {
+    expect(deriveCapabilityReadiness({
+      feature: enabledFeature,
+      configuration: presentConfig,
+      osPermissions: [requiredPermission('accessibility', 'granted')],
+      runtimeProbe: {
+        state: 'not_available',
+        source: 'runtime_probe',
+        reason: 'service exited',
+      },
+    })).toBe('degraded');
+  });
+
   test('degraded runtime probe still wins over partial feature copy', () => {
     expect(deriveCapabilityReadiness({
       feature: { state: 'partial', source: 'runtime', reason: 'local smoke only' },

--- a/packages/core/src/capabilities.ts
+++ b/packages/core/src/capabilities.ts
@@ -178,7 +178,10 @@ export function deriveCapabilityReadiness(input: DeriveCapabilityReadinessInput)
     return 'not_configured';
   }
 
-  if (input.runtimeProbe.state === 'degraded') return 'degraded';
+  if (
+    input.runtimeProbe.state === 'degraded'
+    || input.runtimeProbe.state === 'not_available'
+  ) return 'degraded';
   if (input.feature.state === 'partial') return 'not_configured';
   return 'enabled';
 }

--- a/packages/runtime/src/__tests__/computer-use-tools.test.ts
+++ b/packages/runtime/src/__tests__/computer-use-tools.test.ts
@@ -445,6 +445,7 @@ describe('buildComputerUseTools — the `maka_computer` MakaTool', () => {
   test('one visual overlay serializes presentation across independent sessions', async () => {
     const events: string[] = [];
     const ready = new Map<string, () => void>();
+    const finished = new Map<string, () => void>();
     const backend: CuDispatchBackend = {
       async preflight() {
         return { accessibility: true, screenRecording: true };
@@ -463,11 +464,14 @@ describe('buildComputerUseTools — the `maka_computer` MakaTool', () => {
             readyForInteraction: new Promise<void>((resolve) => {
               ready.set(context.sessionId, resolve);
             }),
-            finished: Promise.resolve(),
+            finished: new Promise<void>((resolve) => {
+              finished.set(context.sessionId, resolve);
+            }),
           };
         },
       },
       presentationReadyTimeoutMs: 10_000,
+      presentationFinishedTimeoutMs: 10_000,
     });
     const first = tool.impl(
       { action: 'wait' } as never,
@@ -483,6 +487,12 @@ describe('buildComputerUseTools — the `maka_computer` MakaTool', () => {
     assert.deepEqual(events, ['presentation:s1']);
     ready.get('s1')?.();
     await first;
+    await Promise.resolve();
+    assert.deepEqual(events, [
+      'presentation:s1',
+      'dispatch:s1',
+    ]);
+    finished.get('s1')?.();
     while (!ready.has('s2')) {
       await new Promise((resolve) => setImmediate(resolve));
     }
@@ -493,6 +503,7 @@ describe('buildComputerUseTools — the `maka_computer` MakaTool', () => {
     ]);
     ready.get('s2')?.();
     await second;
+    finished.get('s2')?.();
   });
 
   test('clearSession releases an action queued behind another presentation', async () => {

--- a/packages/runtime/src/computer-use-tools.ts
+++ b/packages/runtime/src/computer-use-tools.ts
@@ -562,8 +562,10 @@ export function buildComputerUseTools(deps: {
   backend: CuDispatchBackend;
   overlay?: CuOverlayHook;
   presentationReadyTimeoutMs?: number;
+  presentationFinishedTimeoutMs?: number;
 }): ComputerUseToolSet {
   const presentationReadyTimeoutMs = deps.presentationReadyTimeoutMs ?? 1_000;
+  const presentationFinishedTimeoutMs = deps.presentationFinishedTimeoutMs ?? 1_500;
   const invocationQueues = new Map<string, Promise<void>>();
   const presentationWaiters = new Map<string, Set<() => void>>();
   const presentationQueueWaiters = new Map<string, Set<() => void>>();
@@ -917,6 +919,23 @@ export function buildComputerUseTools(deps: {
     });
   }
 
+  async function waitForPresentationFinished(
+    fence: CuPresentationFence | undefined,
+  ): Promise<void> {
+    if (!fence) return;
+    await new Promise<void>((resolve) => {
+      let settled = false;
+      const finish = () => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        resolve();
+      };
+      const timer = setTimeout(finish, presentationFinishedTimeoutMs);
+      fence.finished.then(finish, finish);
+    });
+  }
+
   async function runWithPresentation(
     action: CuAction,
     context: CuRunContext,
@@ -1006,14 +1025,18 @@ export function buildComputerUseTools(deps: {
     const finish = (result?: CuRunResult) => {
       if (finished) return;
       finished = true;
+      let endPromise: Promise<void>;
       try {
-        void Promise.resolve(
+        endPromise = Promise.resolve(
           deps.overlay?.onActionEnd?.(action, result, overlayContext),
-        ).catch(() => {});
+        ).then(() => undefined, () => undefined);
       } catch {
         // Presentation is best-effort and cannot change execution outcome.
+        endPromise = Promise.resolve();
       }
-      releasePresentation?.();
+      void endPromise
+        .then(() => waitForPresentationFinished(fence))
+        .finally(() => releasePresentation?.());
     };
     try {
       if (fence) {

--- a/scripts/check-cua-driver-bundle.mjs
+++ b/scripts/check-cua-driver-bundle.mjs
@@ -12,7 +12,10 @@ import { promisify } from 'node:util';
 
 import {
   assertPinnedCuaDriverChecksums,
+  assertSourceProvenance,
   cuaDriverSupported,
+  verifyBinaryMetadata,
+  verifyBinaryVersion,
 } from './prepare-cua-driver.mjs';
 
 const scriptDir = dirname(fileURLToPath(import.meta.url));
@@ -42,8 +45,10 @@ export async function checkCuaDriverBundle(targetPlatform = process.platform) {
     );
   }
   const info = await stat(binaryPath);
-  if (!info.isFile() || info.size <= 0) {
-    throw new Error(`cua-driver bundle is not a non-empty file: ${binaryPath}`);
+  if (!info.isFile() || info.size !== cua.binarySizeBytes) {
+    throw new Error(
+      `cua-driver bundle size mismatch: expected ${cua.binarySizeBytes}, got ${info.size}: ${binaryPath}`,
+    );
   }
   await access(binaryPath, constants.X_OK);
 
@@ -75,6 +80,10 @@ export async function checkCuaDriverBundle(targetPlatform = process.platform) {
     || marker.sourceCommit !== cua.sourceCommit
     || marker.upstreamCommit !== cua.upstreamCommit
     || marker.upstreamMergeCommit !== cua.upstreamMergeCommit
+    || marker.archiveSizeBytes !== cua.archiveSizeBytes
+    || marker.binarySizeBytes !== cua.binarySizeBytes
+    || marker.licenseSizeBytes !== cua.licenseSizeBytes
+    || marker.sourceSizeBytes !== cua.sourceSizeBytes
     || marker.archiveSha256 !== cua.archiveSha256
     || marker.binarySha256 !== cua.binarySha256
     || marker.licenseSha256 !== cua.licenseSha256
@@ -88,35 +97,20 @@ export async function checkCuaDriverBundle(targetPlatform = process.platform) {
 
   const licenseBytes = await readFile(licensePath);
   const sourceBytes = await readFile(sourcePath);
+  if (
+    licenseBytes.byteLength !== cua.licenseSizeBytes
+    || sourceBytes.byteLength !== cua.sourceSizeBytes
+  ) {
+    throw new Error('cua-driver license/provenance size mismatch. Re-run `npm run prepare:cua-driver`.');
+  }
   const actualLicenseSha256 = createHash('sha256').update(licenseBytes).digest('hex');
   const actualSourceSha256 = createHash('sha256').update(sourceBytes).digest('hex');
   if (actualLicenseSha256 !== cua.licenseSha256 || actualSourceSha256 !== cua.sourceSha256) {
     throw new Error('cua-driver license/provenance checksum mismatch. Re-run `npm run prepare:cua-driver`.');
   }
-  const source = JSON.parse(sourceBytes.toString('utf8'));
-  for (const [field, expected] of Object.entries({
-    repository: cua.repo,
-    upstreamTag: cua.upstreamTag,
-    upstreamCommit: cua.upstreamCommit,
-    sourceCommit: cua.sourceCommit,
-    patchPullRequest: cua.patchPullRequest,
-    cargoLockSha256: cua.cargoLockSha256,
-    signature: cua.signature,
-  })) {
-    if (source[field] !== expected) {
-      throw new Error(`cua-driver SOURCE.json ${field} mismatch`);
-    }
-  }
-  if (!cua.architectures.every((arch) => source.architectures?.includes(arch))) {
-    throw new Error('cua-driver SOURCE.json architectures mismatch');
-  }
-
-  const { stdout } = await execFileAsync(binaryPath, ['--version']);
-  if (stdout.trim() !== `cua-driver ${cua.expectedVersion}`) {
-    throw new Error(`cua-driver version mismatch: ${stdout.trim()}`);
-  }
-  await execFileAsync('lipo', [binaryPath, '-verify_arch', ...cua.architectures]);
-  await execFileAsync('codesign', ['--verify', '--strict', '--verbose=2', binaryPath]);
+  assertSourceProvenance(JSON.parse(sourceBytes.toString('utf8')), cua);
+  await verifyBinaryMetadata(binaryPath, cua, execFileAsync);
+  await verifyBinaryVersion(binaryPath, cua, execFileAsync);
   return {
     skipped: false,
     binaryPath,

--- a/scripts/cua-driver-provenance.test.mjs
+++ b/scripts/cua-driver-provenance.test.mjs
@@ -1,13 +1,19 @@
 import assert from 'node:assert/strict';
 import { createHash } from 'node:crypto';
-import { readFile } from 'node:fs/promises';
+import { access, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { test } from 'node:test';
 
 import {
+  assertMachOHeader,
   assertPinnedCuaDriverChecksums,
   assertSafeTarEntries,
   assertSafeTarListing,
   cuaDriverDownloadUrl,
+  downloadFileWithSha256,
+  verifyBinaryMetadata,
+  verifyBinaryVersion,
 } from './prepare-cua-driver.mjs';
 import { cuaDriverDistributionBlockers } from './check-cua-driver-bundle.mjs';
 
@@ -24,10 +30,104 @@ test('cua-driver release pins archive, binary, source, and license independently
   assert.match(cua.upstreamMergeCommit, /^[a-f0-9]{40}$/);
   assert.deepEqual(cua.architectures, ['arm64', 'x86_64']);
   assert.equal(cua.signature, 'adhoc');
+  assert.equal(cua.archiveSizeBytes, 10473137);
+  assert.equal(cua.binarySizeBytes, 25270080);
+  assert.equal(cua.licenseSizeBytes, 1069);
+  assert.equal(cua.sourceSizeBytes, 542);
   assert.equal(
     cuaDriverDownloadUrl(cua.tag, cua.asset),
     `https://github.com/${cua.repo}/releases/download/${cua.tag}/${cua.asset}`,
   );
+});
+
+test('download streams to disk with a hard byte ceiling and incremental SHA-256', async () => {
+  const directory = await mkdtemp(join(tmpdir(), 'maka-cua-download-test-'));
+  try {
+    const destination = join(directory, 'archive.tar.gz');
+    const chunks = [Buffer.from('abc'), Buffer.from('def')];
+    const result = await downloadFileWithSha256('https://example.test/cua-driver', destination, {
+      maxBytes: 6,
+      fetchImpl: async () => new Response(new ReadableStream({
+        start(controller) {
+          for (const chunk of chunks) controller.enqueue(chunk);
+          controller.close();
+        },
+      })),
+    });
+    assert.deepEqual(result, {
+      bytes: 6,
+      sha256: sha256(Buffer.concat(chunks)),
+    });
+    assert.equal((await readFile(destination)).toString(), 'abcdef');
+
+    const oversized = join(directory, 'oversized.tar.gz');
+    await assert.rejects(
+      downloadFileWithSha256('https://example.test/oversized', oversized, {
+        maxBytes: 5,
+        fetchImpl: async () => new Response(new ReadableStream({
+          start(controller) {
+            controller.enqueue(Buffer.from('abc'));
+            controller.enqueue(Buffer.from('def'));
+            controller.close();
+          },
+        })),
+      }),
+      /received more than 5 bytes/,
+    );
+    await assert.rejects(access(oversized));
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test('Mach-O, architecture, and signature gates run before the binary version', async () => {
+  assert.doesNotThrow(() => assertMachOHeader(Buffer.from('cafebabe', 'hex')));
+  assert.throws(() => assertMachOHeader(Buffer.from('#!/b')));
+
+  const directory = await mkdtemp(join(tmpdir(), 'maka-cua-binary-gate-test-'));
+  try {
+    const binaryPath = join(directory, 'cua-driver');
+    await writeFile(binaryPath, Buffer.concat([
+      Buffer.from('cafebabe', 'hex'),
+      Buffer.alloc(4),
+    ]));
+    const entry = {
+      binarySizeBytes: 8,
+      architectures: ['arm64', 'x86_64'],
+      signature: 'adhoc',
+      expectedVersion: '0.7.1',
+    };
+    const calls = [];
+    const runCommand = async (command, args) => {
+      calls.push([command, ...args]);
+      if (command === 'codesign' && args[0] === '--display') {
+        return { stdout: '', stderr: 'Signature=adhoc\n' };
+      }
+      if (command === binaryPath) {
+        return { stdout: 'cua-driver 0.7.1\n', stderr: '' };
+      }
+      return { stdout: '', stderr: '' };
+    };
+    await verifyBinaryMetadata(binaryPath, entry, runCommand);
+    await verifyBinaryVersion(binaryPath, entry, runCommand);
+    assert.deepEqual(calls, [
+      ['lipo', binaryPath, '-verify_arch', 'arm64', 'x86_64'],
+      ['codesign', '--verify', '--strict', '--verbose=2', binaryPath],
+      ['codesign', '--display', '--verbose=4', binaryPath],
+      [binaryPath, '--version'],
+    ]);
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test('prepare gates provenance after metadata and before executing --version', async () => {
+  const source = await readFile(new URL('./prepare-cua-driver.mjs', import.meta.url), 'utf8');
+  const body = source.slice(source.indexOf('export async function prepareCuaDriver'));
+  const metadata = body.indexOf('await verifyBinaryMetadata(found[0])');
+  const provenance = body.indexOf('assertSourceProvenance(JSON.parse(sourceBytes.toString');
+  const version = body.indexOf('await verifyBinaryVersion(found[0])');
+  assert.ok(metadata >= 0 && provenance > metadata && version > provenance);
 });
 
 test('tar entry validation rejects path traversal before extraction', () => {
@@ -65,15 +165,19 @@ test('tracked license and source metadata match the manifest pins', async () => 
 
 test('artifact checks remain separate from the distribution release gate', async () => {
   const pkg = JSON.parse(await readFile(new URL('../package.json', import.meta.url)));
-  const checkSource = await readFile(
-    new URL('./check-cua-driver-bundle.mjs', import.meta.url),
-    'utf8',
-  );
+  const [checkSource, prepareSource] = await Promise.all([
+    readFile(new URL('./check-cua-driver-bundle.mjs', import.meta.url), 'utf8'),
+    readFile(new URL('./prepare-cua-driver.mjs', import.meta.url), 'utf8'),
+  ]);
   assert.ok(pkg.scripts['check:cua-driver-artifact']);
   assert.doesNotMatch(pkg.scripts['check:release'], /cua-driver/);
   assert.match(checkSource, /releaseSigningReady:\s*false/);
-  assert.match(checkSource, /codesign/);
-  assert.doesNotMatch(checkSource, /notarytool|stapler|Developer ID Application/);
+  assert.match(checkSource, /verifyBinaryMetadata/);
+  assert.match(prepareSource, /codesign/);
+  assert.doesNotMatch(
+    `${checkSource}\n${prepareSource}`,
+    /notarytool|stapler|Developer ID Application/,
+  );
   assert.deepEqual(cuaDriverDistributionBlockers(cua), [
     'developer_id_signature',
     'notarization',

--- a/scripts/prepare-cua-driver.mjs
+++ b/scripts/prepare-cua-driver.mjs
@@ -17,7 +17,17 @@
 import { execFile } from 'node:child_process';
 import { createHash, randomUUID } from 'node:crypto';
 import { constants } from 'node:fs';
-import { access, chmod, mkdir, readFile, rename, rm, writeFile } from 'node:fs/promises';
+import {
+  access,
+  chmod,
+  mkdir,
+  open,
+  readFile,
+  rename,
+  rm,
+  stat,
+  writeFile,
+} from 'node:fs/promises';
 import { mkdtemp } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
@@ -32,6 +42,16 @@ const binDir = join(repoRoot, 'apps', 'desktop', 'resources', 'bin');
 const licenseDir = join(repoRoot, 'apps', 'desktop', 'resources', 'licenses', 'cua-driver');
 const DEFAULT_FETCH_TIMEOUT_MS = 300_000;
 const SHA256_PATTERN = /^[a-f0-9]{64}$/;
+const MACH_O_MAGICS = new Set([
+  'feedface',
+  'feedfacf',
+  'cefaedfe',
+  'cffaedfe',
+  'cafebabe',
+  'bebafeca',
+  'cafebabf',
+  'bfbafeca',
+]);
 
 const manifest = JSON.parse(await readFile(manifestPath, 'utf8'));
 const cua = manifest.cuaDriver;
@@ -73,8 +93,12 @@ export function assertPinnedCuaDriverChecksums(entry) {
     || typeof entry?.cargoLockSha256 !== 'string'
     || !Array.isArray(entry?.architectures)
     || entry.architectures.length === 0
+    || !['archiveSizeBytes', 'binarySizeBytes', 'licenseSizeBytes', 'sourceSizeBytes']
+      .every((field) => Number.isSafeInteger(entry?.[field]) && entry[field] > 0)
   ) {
-    throw new Error('bundled-tools.json cuaDriver must pin version, protocol, source commits, Cargo.lock, and architectures.');
+    throw new Error(
+      'bundled-tools.json cuaDriver must pin version, protocol, source commits, Cargo.lock, architectures, and exact file sizes.',
+    );
   }
 }
 
@@ -94,6 +118,10 @@ function expectedMarker() {
     sourceCommit: cua.sourceCommit,
     upstreamCommit: cua.upstreamCommit,
     upstreamMergeCommit: cua.upstreamMergeCommit,
+    archiveSizeBytes: cua.archiveSizeBytes,
+    binarySizeBytes: cua.binarySizeBytes,
+    licenseSizeBytes: cua.licenseSizeBytes,
+    sourceSizeBytes: cua.sourceSizeBytes,
     archiveSha256: cua.archiveSha256,
     binarySha256: cua.binarySha256,
     licenseSha256: cua.licenseSha256,
@@ -109,6 +137,10 @@ function markerMatches(marker) {
     && marker?.sourceCommit === expected.sourceCommit
     && marker?.upstreamCommit === expected.upstreamCommit
     && marker?.upstreamMergeCommit === expected.upstreamMergeCommit
+    && marker?.archiveSizeBytes === expected.archiveSizeBytes
+    && marker?.binarySizeBytes === expected.binarySizeBytes
+    && marker?.licenseSizeBytes === expected.licenseSizeBytes
+    && marker?.sourceSizeBytes === expected.sourceSizeBytes
     && marker?.archiveSha256 === expected.archiveSha256
     && marker?.binarySha256 === expected.binarySha256
     && marker?.licenseSha256 === expected.licenseSha256
@@ -133,20 +165,63 @@ function timeoutError(url) {
   return new Error(`Timed out downloading ${url} after ${FETCH_TIMEOUT_MS}ms`);
 }
 
-async function fetchBytes(url) {
+export async function downloadFileWithSha256(
+  url,
+  destination,
+  {
+    maxBytes,
+    fetchImpl = fetch,
+    timeoutMs = FETCH_TIMEOUT_MS,
+  } = {},
+) {
+  if (!Number.isSafeInteger(maxBytes) || maxBytes <= 0) {
+    throw new Error('cua-driver download maxBytes must be a positive integer');
+  }
   let response;
   try {
-    response = await fetch(url, { redirect: 'follow', signal: AbortSignal.timeout(FETCH_TIMEOUT_MS) });
+    response = await fetchImpl(url, {
+      redirect: 'follow',
+      signal: AbortSignal.timeout(timeoutMs),
+    });
   } catch (error) {
     if (isTimeoutError(error)) throw timeoutError(url);
     throw error;
   }
   if (!response.ok) throw new Error(`Failed to download ${url}: HTTP ${response.status}`);
+  const declaredLength = Number(response.headers.get('content-length'));
+  if (Number.isFinite(declaredLength) && declaredLength > maxBytes) {
+    throw new Error(
+      `Refusing oversized cua-driver download: ${declaredLength} bytes exceeds ${maxBytes}`,
+    );
+  }
+  if (!response.body) {
+    throw new Error(`Failed to download ${url}: response body missing`);
+  }
+
+  const hash = createHash('sha256');
+  let bytes = 0;
+  let completed = false;
+  const file = await open(destination, 'wx', 0o600);
   try {
-    return await response.arrayBuffer();
+    for await (const rawChunk of response.body) {
+      const chunk = Buffer.from(rawChunk);
+      bytes += chunk.byteLength;
+      if (bytes > maxBytes) {
+        throw new Error(
+          `Refusing oversized cua-driver download: received more than ${maxBytes} bytes`,
+        );
+      }
+      hash.update(chunk);
+      await file.write(chunk);
+    }
+    completed = true;
+    return { bytes, sha256: hash.digest('hex') };
   } catch (error) {
     if (isTimeoutError(error)) throw timeoutError(url);
     throw error;
+  } finally {
+    await file.close();
+    if (!completed) await rm(destination, { force: true });
   }
 }
 
@@ -157,6 +232,16 @@ async function alreadyPrepared() {
     await access(destinationPath(), constants.X_OK);
     const marker = JSON.parse(await readFile(markerPath(), 'utf8'));
     if (!markerMatches(marker)) return false;
+    const [binaryInfo, licenseInfo, sourceInfo] = await Promise.all([
+      stat(destinationPath()),
+      stat(join(licenseDir, 'LICENSE.md')),
+      stat(join(licenseDir, 'SOURCE.json')),
+    ]);
+    if (
+      binaryInfo.size !== cua.binarySizeBytes
+      || licenseInfo.size !== cua.licenseSizeBytes
+      || sourceInfo.size !== cua.sourceSizeBytes
+    ) return false;
     // Re-hash the actual binary so a corrupted/swapped file with an intact marker
     // is not silently trusted — on drift, fall through to re-download/re-verify.
     const actualBinarySha256 = sha256(await readFile(destinationPath()));
@@ -170,15 +255,45 @@ async function alreadyPrepared() {
   }
 }
 
-async function verifyBinary(binaryPath) {
-  const { stdout } = await execFileAsync(binaryPath, ['--version']);
-  if (stdout.trim() !== `cua-driver ${cua.expectedVersion}`) {
+export function assertMachOHeader(bytes) {
+  const header = Buffer.from(bytes).subarray(0, 4);
+  const magic = header.toString('hex');
+  if (header.byteLength !== 4 || !MACH_O_MAGICS.has(magic)) {
+    throw new Error(`cua-driver is not a recognized Mach-O binary (magic ${magic || 'missing'})`);
+  }
+}
+
+export async function verifyBinaryMetadata(binaryPath, entry = cua, runCommand = execFileAsync) {
+  const info = await stat(binaryPath);
+  if (!info.isFile() || info.size !== entry.binarySizeBytes) {
     throw new Error(
-      `Unexpected cua-driver version: expected ${cua.expectedVersion}, got ${JSON.stringify(stdout.trim())}`,
+      `Unexpected cua-driver size: expected ${entry.binarySizeBytes}, got ${info.size}`,
     );
   }
-  await execFileAsync('lipo', [binaryPath, '-verify_arch', ...cua.architectures]);
-  await execFileAsync('codesign', ['--verify', '--strict', '--verbose=2', binaryPath]);
+  const handle = await open(binaryPath, 'r');
+  try {
+    const header = Buffer.alloc(4);
+    const { bytesRead } = await handle.read(header, 0, header.length, 0);
+    assertMachOHeader(header.subarray(0, bytesRead));
+  } finally {
+    await handle.close();
+  }
+  await runCommand('lipo', [binaryPath, '-verify_arch', ...entry.architectures]);
+  await runCommand('codesign', ['--verify', '--strict', '--verbose=2', binaryPath]);
+  const signature = await runCommand('codesign', ['--display', '--verbose=4', binaryPath]);
+  const signatureDetails = `${signature.stdout ?? ''}\n${signature.stderr ?? ''}`;
+  if (entry.signature === 'adhoc' && !/Signature=adhoc/.test(signatureDetails)) {
+    throw new Error('cua-driver signature mismatch: expected an ad hoc code signature');
+  }
+}
+
+export async function verifyBinaryVersion(binaryPath, entry = cua, runCommand = execFileAsync) {
+  const { stdout } = await runCommand(binaryPath, ['--version']);
+  if (stdout.trim() !== `cua-driver ${entry.expectedVersion}`) {
+    throw new Error(
+      `Unexpected cua-driver version: expected ${entry.expectedVersion}, got ${JSON.stringify(stdout.trim())}`,
+    );
+  }
 }
 
 export function assertSafeTarEntries(entries) {
@@ -205,15 +320,15 @@ export function assertSafeTarListing(lines) {
   }
 }
 
-function assertSourceProvenance(source) {
+export function assertSourceProvenance(source, entry = cua) {
   const expected = {
-    repository: cua.repo,
-    upstreamTag: cua.upstreamTag,
-    upstreamCommit: cua.upstreamCommit,
-    sourceCommit: cua.sourceCommit,
-    patchPullRequest: cua.patchPullRequest,
-    cargoLockSha256: cua.cargoLockSha256,
-    signature: cua.signature,
+    repository: entry.repo,
+    upstreamTag: entry.upstreamTag,
+    upstreamCommit: entry.upstreamCommit,
+    sourceCommit: entry.sourceCommit,
+    patchPullRequest: entry.patchPullRequest,
+    cargoLockSha256: entry.cargoLockSha256,
+    signature: entry.signature,
   };
   for (const [field, value] of Object.entries(expected)) {
     if (source?.[field] !== value) {
@@ -224,8 +339,8 @@ function assertSourceProvenance(source) {
   }
   if (
     !Array.isArray(source?.architectures)
-    || source.architectures.length !== cua.architectures.length
-    || !cua.architectures.every((arch) => source.architectures.includes(arch))
+    || source.architectures.length !== entry.architectures.length
+    || !entry.architectures.every((arch) => source.architectures.includes(arch))
   ) {
     throw new Error('cua-driver SOURCE.json architectures do not match bundled-tools.json.');
   }
@@ -240,19 +355,25 @@ export async function prepareCuaDriver(targetPlatform = process.platform) {
     return { skipped: true, reason: 'up-to-date', destination: destinationPath(), version: cua.version };
   }
 
-  const url = cuaDriverDownloadUrl(cua.tag, cua.asset);
-  const data = await fetchBytes(url);
-  const actualArchiveSha256 = sha256(data);
-  if (actualArchiveSha256 !== cua.archiveSha256) {
-    throw new Error(`Checksum mismatch for ${cua.asset}: expected ${cua.archiveSha256}, got ${actualArchiveSha256}`);
-  }
-
   // Extract the tarball to a temp dir, then copy out the single `cua-driver`
   // Mach-O. Tarball internal layout is not assumed — we locate the binary.
   const workDir = await mkdtemp(join(tmpdir(), 'maka-cua-driver-'));
   try {
     const tarPath = join(workDir, cua.asset);
-    await writeFile(tarPath, Buffer.from(data));
+    const url = cuaDriverDownloadUrl(cua.tag, cua.asset);
+    const downloaded = await downloadFileWithSha256(url, tarPath, {
+      maxBytes: cua.archiveSizeBytes,
+    });
+    if (downloaded.bytes !== cua.archiveSizeBytes) {
+      throw new Error(
+        `Size mismatch for ${cua.asset}: expected ${cua.archiveSizeBytes}, got ${downloaded.bytes}`,
+      );
+    }
+    if (downloaded.sha256 !== cua.archiveSha256) {
+      throw new Error(
+        `Checksum mismatch for ${cua.asset}: expected ${cua.archiveSha256}, got ${downloaded.sha256}`,
+      );
+    }
     const listed = await execFileAsync('tar', ['-tzf', tarPath]);
     assertSafeTarEntries(listed.stdout.split('\n'));
     const verboseListing = await execFileAsync('tar', ['-tvzf', tarPath]);
@@ -267,13 +388,18 @@ export async function prepareCuaDriver(targetPlatform = process.platform) {
     }
 
     const binaryBytes = await readFile(found[0]);
+    if (binaryBytes.byteLength !== cua.binarySizeBytes) {
+      throw new Error(
+        `Size mismatch for extracted ${cua.binaryName}: expected ${cua.binarySizeBytes}, got ${binaryBytes.byteLength}`,
+      );
+    }
     const actualBinarySha256 = sha256(binaryBytes);
     if (actualBinarySha256 !== cua.binarySha256) {
       throw new Error(
         `Checksum mismatch for extracted ${cua.binaryName}: expected ${cua.binarySha256}, got ${actualBinarySha256}`,
       );
     }
-    await verifyBinary(found[0]);
+    await verifyBinaryMetadata(found[0]);
 
     const licensePaths = await execFileAsync('find', [workDir, '-name', 'LICENSE.md', '-type', 'f']);
     const sourcePaths = await execFileAsync('find', [workDir, '-name', 'SOURCE.json', '-type', 'f']);
@@ -286,6 +412,16 @@ export async function prepareCuaDriver(targetPlatform = process.platform) {
     }
     const licenseBytes = await readFile(licenses[0]);
     const sourceBytes = await readFile(sources[0]);
+    if (licenseBytes.byteLength !== cua.licenseSizeBytes) {
+      throw new Error(
+        `Size mismatch for extracted cua-driver LICENSE.md: expected ${cua.licenseSizeBytes}, got ${licenseBytes.byteLength}`,
+      );
+    }
+    if (sourceBytes.byteLength !== cua.sourceSizeBytes) {
+      throw new Error(
+        `Size mismatch for extracted cua-driver SOURCE.json: expected ${cua.sourceSizeBytes}, got ${sourceBytes.byteLength}`,
+      );
+    }
     if (sha256(licenseBytes) !== cua.licenseSha256) {
       throw new Error(`Checksum mismatch for extracted cua-driver LICENSE.md`);
     }
@@ -293,6 +429,7 @@ export async function prepareCuaDriver(targetPlatform = process.platform) {
       throw new Error(`Checksum mismatch for extracted cua-driver SOURCE.json`);
     }
     assertSourceProvenance(JSON.parse(sourceBytes.toString('utf8')));
+    await verifyBinaryVersion(found[0]);
 
     await mkdir(binDir, { recursive: true });
     await mkdir(licenseDir, { recursive: true });


### PR DESCRIPTION
## Summary

Hardens Desktop packaging, capability state, model visibility, and presentation lifecycle.

- stream and verify cua-driver artifacts before execution;
- hide screenshot-returning tools from non-visual models;
- distinguish artifact, permission, startup, recovery, exit, and stopped states;
- report an unavailable runtime service as degraded instead of enabled;
- preserve expert-team wiring;
- count only the main window for activation;
- stop cancelled cursor animation and wait for renderer completion ownership.

## Verification

- Core: 955 pass
- Desktop focused: pass
- CI typecheck/test/e2e: pass
