### PR TITLE
feat(runtime): orchestrate one-shot additional permissions

### DIFF
--- a/packages/runtime/src/__tests__/tool-runtime-additional-permissions.test.ts
+++ b/packages/runtime/src/__tests__/tool-runtime-additional-permissions.test.ts
@@ -1,0 +1,335 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, test } from 'node:test';
+import type {
+  AdditionalPermissionRequestEvent,
+  LlmConnection,
+  SessionEvent,
+  SessionHeader,
+  StoredMessage,
+} from '@maka/core';
+
+import {
+  AdditionalPermissionError,
+  buildAdditionalPermissionProposal,
+  normalizeAdditionalPermissionProfile,
+  type AdditionalPermissionProposal,
+} from '../additional-permissions.js';
+import { PermissionEngine } from '../permission-engine.js';
+import { ToolRuntime, type MakaTool, type MakaToolContext } from '../tool-runtime.js';
+
+interface Harness {
+  runtime: ToolRuntime;
+  permissionEngine: PermissionEngine;
+  events: SessionEvent[];
+  messages: StoredMessage[];
+}
+
+function createHarness(cwd = '/tmp'): Harness {
+  let id = 0;
+  const events: SessionEvent[] = [];
+  const messages: StoredMessage[] = [];
+  const permissionEngine = new PermissionEngine({
+    newId: () => `permission-${++id}`,
+    now: () => 100,
+  });
+  permissionEngine.beginTurn('turn-1');
+  const runtime = new ToolRuntime({
+    sessionId: 'session-1',
+    header: testHeader(cwd),
+    connection: testConnection(),
+    modelId: 'test-model',
+    appendMessage: async (message) => {
+      messages.push(message);
+    },
+    permissionEngine,
+    newId: () => `runtime-${++id}`,
+    now: () => 100,
+    getPermissionPauseTarget: () => null,
+  });
+  return { runtime, permissionEngine, events, messages };
+}
+
+function networkProposal(input: {
+  toolName: string;
+  args: unknown;
+  cwd?: string;
+}): AdditionalPermissionProposal {
+  return buildAdditionalPermissionProposal({
+    profile: { network: { enabled: true } },
+    normalizedPaths: [],
+    justification: 'Access the requested network service.',
+    toolName: input.toolName,
+    args: input.args,
+    workspaceRoots: [input.cwd ?? '/tmp'],
+  });
+}
+
+describe('ToolRuntime additional permission orchestration', () => {
+  test('forces one-shot approval, consumes the grant, and exposes it to one implementation', async () => {
+    const harness = createHarness();
+    const args = { command: 'curl http://127.0.0.1:8080' };
+    const proposal = networkProposal({ toolName: 'Bash', args });
+    let receivedContext: MakaToolContext['permissionContext'];
+    let plannerCalls = 0;
+    const tool: MakaTool<typeof args> = {
+      name: 'Bash',
+      description: 'test',
+      parameters: {},
+      permissionRequired: false,
+      planAdditionalPermissions: (plannerArgs, context) => {
+        plannerCalls += 1;
+        assert.equal(Object.isFrozen(plannerArgs), true);
+        assert.equal(Object.isFrozen(context), true);
+        assert.equal(Object.isFrozen(context.args), true);
+        assert.equal(context.category, 'shell_unsafe');
+        assert.equal(context.toolUseId, 'tool-1');
+        return { kind: 'request', proposal };
+      },
+      impl: (_implementationArgs, context) => {
+        receivedContext = context.permissionContext;
+        return { ok: true };
+      },
+    };
+    const execute = harness.runtime.wrapToolExecute(tool, 'turn-1', {
+      push: (event) => harness.events.push(event),
+    });
+
+    const pending = execute(args, {
+      toolCallId: 'tool-1',
+      abortSignal: new AbortController().signal,
+    });
+    const request = await waitForAdditionalRequest(harness.events);
+    assert.equal(request.alsoApprovesToolExecution, false);
+    harness.permissionEngine.recordResponse('turn-1', {
+      requestId: request.requestId,
+      decision: 'allow',
+    });
+
+    assert.deepEqual(await pending, { ok: true });
+    assert.equal(plannerCalls, 1);
+    assert.equal(receivedContext?.additionalGrant?.permissionsHash, proposal.permissionsHash);
+    assert.equal(receivedContext?.additionalGrant?.toolUseId, 'tool-1');
+    assert.equal(Object.isFrozen(receivedContext), true);
+    assert.throws(
+      () => harness.permissionEngine.consumeAdditionalPermissionGrant({
+        sessionId: 'session-1',
+        turnId: 'turn-1',
+        toolUseId: 'tool-1',
+        toolName: 'Bash',
+        intentHash: proposal.intentHash,
+      }),
+      (error: unknown) => (
+        error instanceof AdditionalPermissionError
+        && error.reason === 'grant_already_consumed'
+      ),
+    );
+  });
+
+  test('denial never invokes the implementation', async () => {
+    const harness = createHarness();
+    const args = { command: 'curl http://127.0.0.1:8080' };
+    const proposal = networkProposal({ toolName: 'Bash', args });
+    let implementationCalled = false;
+    const tool: MakaTool<typeof args> = {
+      name: 'Bash',
+      description: 'test',
+      parameters: {},
+      planAdditionalPermissions: () => ({ kind: 'request', proposal }),
+      impl: () => {
+        implementationCalled = true;
+        return { ok: true };
+      },
+    };
+    const pending = harness.runtime.wrapToolExecute(tool, 'turn-1', {
+      push: (event) => harness.events.push(event),
+    })(args, {
+      toolCallId: 'tool-1',
+      abortSignal: new AbortController().signal,
+    });
+
+    const request = await waitForAdditionalRequest(harness.events);
+    harness.permissionEngine.recordResponse('turn-1', {
+      requestId: request.requestId,
+      decision: 'deny',
+    });
+
+    assert.deepEqual(await pending, { error: '用户已拒绝权限请求' });
+    assert.equal(implementationCalled, false);
+  });
+
+  test('fails closed when an approved grant cannot be consumed', async () => {
+    const harness = createHarness();
+    const args = { command: 'curl http://127.0.0.1:8080' };
+    const proposal = networkProposal({ toolName: 'Bash', args });
+    let implementationCalled = false;
+    const tool: MakaTool<typeof args> = {
+      name: 'Bash',
+      description: 'test',
+      parameters: {},
+      planAdditionalPermissions: () => ({ kind: 'request', proposal }),
+      impl: () => {
+        implementationCalled = true;
+        return { ok: true };
+      },
+    };
+    const pending = harness.runtime.wrapToolExecute(tool, 'turn-1', {
+      push: (event) => harness.events.push(event),
+    })(args, {
+      toolCallId: 'tool-1',
+      abortSignal: new AbortController().signal,
+    });
+
+    const request = await waitForAdditionalRequest(harness.events);
+    harness.permissionEngine.recordResponse('turn-1', {
+      requestId: request.requestId,
+      decision: 'allow',
+    });
+    harness.permissionEngine.consumeAdditionalPermissionGrant = () => undefined;
+
+    const result = await pending;
+    assert.equal(implementationCalled, false);
+    assert.match(JSON.stringify(result), /grant was unavailable/);
+  });
+
+  test('planner blocks and malformed planner results fail closed', async () => {
+    for (const planAdditionalPermissions of [
+      () => ({
+        kind: 'block' as const,
+        reason: 'additional_permissions_conflict_with_deny' as const,
+        message: 'The requested path is explicitly denied.',
+      }),
+      () => undefined as never,
+    ]) {
+      const harness = createHarness();
+      let implementationCalled = false;
+      const tool: MakaTool<{ path: string }> = {
+        name: 'Write',
+        description: 'test',
+        parameters: {},
+        permissionRequired: false,
+        planAdditionalPermissions,
+        impl: () => {
+          implementationCalled = true;
+          return { ok: true };
+        },
+      };
+
+      const result = await harness.runtime.wrapToolExecute(tool, 'turn-1', {
+        push: (event) => harness.events.push(event),
+      })({ path: '/outside/file.txt' }, {
+        toolCallId: 'tool-1',
+        abortSignal: new AbortController().signal,
+      });
+
+      assert.equal(implementationCalled, false);
+      assert.equal(harness.events.some((event) => event.type === 'permission_request'), false);
+      assert.match(JSON.stringify(result), /explicitly denied|invalid result/);
+    }
+  });
+
+  test('revalidates approved paths immediately before grant consumption', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'maka-tool-runtime-additional-'));
+    try {
+      const target = join(cwd, 'created-after-approval.txt');
+      const normalized = await normalizeAdditionalPermissionProfile({
+        profile: {
+          fileSystem: {
+            entries: [{ path: target, access: 'write', scope: 'exact' }],
+          },
+        },
+        cwd,
+      });
+      const args = { path: target, content: 'ok' };
+      const proposal = buildAdditionalPermissionProposal({
+        profile: normalized.profile,
+        normalizedPaths: normalized.normalizedPaths,
+        justification: 'Write the requested file.',
+        toolName: 'Write',
+        args,
+        workspaceRoots: [cwd],
+      });
+      const harness = createHarness(cwd);
+      let implementationCalled = false;
+      const tool: MakaTool<typeof args> = {
+        name: 'Write',
+        description: 'test',
+        parameters: {},
+        planAdditionalPermissions: () => ({ kind: 'request', proposal }),
+        impl: () => {
+          implementationCalled = true;
+          return { ok: true };
+        },
+      };
+      const pending = harness.runtime.wrapToolExecute(tool, 'turn-1', {
+        push: (event) => harness.events.push(event),
+      })(args, {
+        toolCallId: 'tool-1',
+        abortSignal: new AbortController().signal,
+      });
+
+      const request = await waitForAdditionalRequest(harness.events);
+      await writeFile(target, 'changed target type', 'utf8');
+      harness.permissionEngine.recordResponse('turn-1', {
+        requestId: request.requestId,
+        decision: 'allow',
+      });
+
+      const result = await pending;
+      assert.equal(implementationCalled, false);
+      assert.match(JSON.stringify(result), /changed type/);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+});
+
+async function waitForAdditionalRequest(
+  events: readonly SessionEvent[],
+): Promise<AdditionalPermissionRequestEvent> {
+  for (let attempt = 0; attempt < 100; attempt += 1) {
+    const request = events.find((event): event is AdditionalPermissionRequestEvent => (
+      event.type === 'permission_request' && event.kind === 'additional_permissions'
+    ));
+    if (request) return request;
+    await new Promise((resolve) => setTimeout(resolve, 1));
+  }
+  throw new Error('Timed out waiting for an additional permission request.');
+}
+
+function testHeader(cwd: string): SessionHeader {
+  return {
+    id: 'session-1',
+    workspaceRoot: cwd,
+    cwd,
+    createdAt: 1,
+    lastUsedAt: 1,
+    name: 'Test',
+    isFlagged: false,
+    labels: [],
+    isArchived: false,
+    status: 'active',
+    statusUpdatedAt: 1,
+    hasUnread: false,
+    backend: 'ai-sdk',
+    llmConnectionSlug: 'test',
+    connectionLocked: true,
+    model: 'test-model',
+    permissionMode: 'ask',
+    schemaVersion: 1,
+  };
+}
+
+function testConnection(): LlmConnection {
+  return {
+    slug: 'test',
+    name: 'Test',
+    providerType: 'anthropic',
+    defaultModel: 'test-model',
+    enabled: true,
+    createdAt: 1,
+    updatedAt: 1,
+  };
+}

--- a/packages/runtime/src/additional-permissions.ts
+++ b/packages/runtime/src/additional-permissions.ts
@@ -18,7 +18,7 @@ import {
   type PermissionProfile,
   type PermissionProfileMatchContext,
 } from '@maka/core/permission-profile';
-import type { PermissionMode } from '@maka/core/permission';
+import type { PermissionMode, ToolCategory } from '@maka/core/permission';
 
 import { hashAdditionalPermissionProfile } from './additional-permission-hash.js';
 import { stableHash } from './request-shape.js';
@@ -35,6 +35,7 @@ export type AdditionalPermissionErrorReason =
   | 'additional_permission_aborted'
   | 'grant_expired'
   | 'grant_already_consumed'
+  | 'grant_unavailable'
   | 'grant_intent_mismatch'
   | 'grant_path_changed';
 
@@ -91,10 +92,26 @@ export interface AdditionalPermissionGrant {
   readonly expiresAt: number;
 }
 
+export interface ToolExecutionPermissionContext {
+  readonly additionalGrant?: AdditionalPermissionGrant;
+}
+
 export type AdditionalPermissionPlanResult =
   | { kind: 'not_required' }
   | { kind: 'request'; proposal: AdditionalPermissionProposal }
   | { kind: 'block'; reason: AdditionalPermissionErrorReason; message: string };
+
+/** Immutable invocation metadata supplied to a trusted tool permission planner. */
+export interface AdditionalPermissionPlannerContext {
+  readonly sessionId: string;
+  readonly turnId: string;
+  readonly toolUseId: string;
+  readonly toolName: string;
+  readonly category: ToolCategory;
+  readonly cwd: string;
+  readonly mode: PermissionMode;
+  readonly args: unknown;
+}
 
 export interface AdditionalPermissionPlanningContext {
   readonly profile: PermissionProfile;

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -41,9 +41,11 @@ export type {
   AdditionalPermissionErrorReason,
   AdditionalPermissionGrant,
   AdditionalPermissionPlanResult,
+  AdditionalPermissionPlannerContext,
   AdditionalPermissionPlanningContext,
   AdditionalPermissionProposal,
   NormalizedAdditionalPermissionPath,
+  ToolExecutionPermissionContext,
 } from './additional-permissions.js';
 export { hashAdditionalPermissionProfile } from './additional-permission-hash.js';
 

--- a/packages/runtime/src/tool-runtime.ts
+++ b/packages/runtime/src/tool-runtime.ts
@@ -20,6 +20,7 @@ import type {
   ToolExecutionFacts,
   ToolPermissionRule,
 } from '@maka/core/permission';
+import { classifyToolUse } from '@maka/core/permission';
 import type { LlmConnection } from '@maka/core/llm-connections';
 import type {
   UserQuestion,
@@ -42,6 +43,13 @@ import { truncateToolOutput } from './tool-output.js';
 import { stableHash } from './request-shape.js';
 import type { RunTraceLike } from './run-trace.js';
 import { TurnScopedAwaitRegistry } from './turn-scoped-await-registry.js';
+import {
+  AdditionalPermissionError,
+  revalidateAdditionalPermissionProposal,
+  type AdditionalPermissionPlannerContext,
+  type AdditionalPermissionPlanResult,
+  type ToolExecutionPermissionContext,
+} from './additional-permissions.js';
 
 export type ToolModelOutputPart =
   | { type: 'text'; text: string }
@@ -83,6 +91,11 @@ export interface MakaTool<P = any, R = unknown> {
   } | ((context: { permissionMode: PermissionMode; cwd: string; args: P }) => {
     platformSandboxAvailable: boolean;
   });
+  /** Trusted runtime planner for one-call permission expansion. */
+  planAdditionalPermissions?: (
+    args: P,
+    context: AdditionalPermissionPlannerContext,
+  ) => Promise<AdditionalPermissionPlanResult> | AdditionalPermissionPlanResult;
   /** Real tool implementation. Called only after permission allows. */
   impl: (args: P, ctx: MakaToolContext) => Promise<R> | R;
   /** Optional provider-visible content mapping, used for screenshot image parts. */
@@ -103,6 +116,8 @@ export interface MakaToolContext {
   toolCallId: string;
   abortSignal: AbortSignal;
   emitOutput: (stream: ToolOutputStream, chunk: string) => void;
+  /** One-call grants already approved and consumed by ToolRuntime. */
+  permissionContext?: ToolExecutionPermissionContext;
   spawnChildAgent?: (input: {
     spec: AgentSpec;
     prompt: string;
@@ -447,13 +462,69 @@ export class ToolRuntime {
       return this.errorReturn(reason);
     }
 
-    if (tool.permissionRequired !== false || (this.input.permissionRules?.length ?? 0) > 0) {
+    let additionalPlan: AdditionalPermissionPlanResult = { kind: 'not_required' };
+    if (tool.planAdditionalPermissions) {
+      try {
+        const plannerContext: AdditionalPermissionPlannerContext = Object.freeze({
+          sessionId: this.input.sessionId,
+          turnId,
+          toolUseId,
+          toolName: tool.name,
+          category: classifyToolUse({
+            toolName: tool.name,
+            args: executionArgs,
+            ...(tool.categoryHint !== undefined ? { categoryHint: tool.categoryHint } : {}),
+          }),
+          cwd: this.input.header.cwd,
+          mode: this.input.header.permissionMode,
+          args: executionArgs,
+        });
+        const planned = await tool.planAdditionalPermissions(
+          executionArgs as never,
+          plannerContext,
+        );
+        if (!isAdditionalPermissionPlanResult(planned)) {
+          throw new AdditionalPermissionError({
+            stage: 'planning',
+            reason: 'invalid_additional_permissions',
+            message: 'Additional permission planner returned an invalid result.',
+          });
+        }
+        additionalPlan = planned;
+      } catch (error) {
+        additionalPlan = {
+          kind: 'block',
+          reason: 'invalid_additional_permissions',
+          message: formatSyntheticToolErrorText(error),
+        };
+      }
+      if (additionalPlan.kind === 'block') {
+        const reason = formatSyntheticToolErrorText(additionalPlan.message);
+        trace?.emit('permission', 'permission_failed', 'Additional permission planning failed', {
+          toolUseId,
+          toolName: tool.name,
+          requestKind: 'additional_permissions',
+          reason: additionalPlan.reason,
+        });
+        await this.writeSyntheticToolResult(toolUseId, turnId, reason, queue);
+        this.recordLoopGateOutcome(callSignature, true);
+        return this.errorReturn(reason);
+      }
+    }
+
+    if (
+      tool.permissionRequired !== false
+      || (this.input.permissionRules?.length ?? 0) > 0
+      || additionalPlan.kind === 'request'
+    ) {
       const verdict = this.input.permissionEngine.evaluate({
         sessionId: this.input.sessionId,
         turnId,
         toolUseId,
         toolName: tool.name,
-        args: structuredClone(permissionArgs),
+        args: structuredClone(
+          additionalPlan.kind === 'request' ? executionArgs : permissionArgs,
+        ),
         ...(tool.categoryHint !== undefined ? { categoryHint: tool.categoryHint } : {}),
         ...(tool.executionFacts !== undefined ? { executionFacts: tool.executionFacts } : {}),
         permissionRequired: tool.permissionRequired !== false,
@@ -468,6 +539,10 @@ export class ToolRuntime {
             : tool.sandbox,
         } : {}),
         mode: this.input.header.permissionMode,
+        cwd: this.input.header.cwd,
+        ...(additionalPlan.kind === 'request'
+          ? { additionalPermissionProposal: additionalPlan.proposal }
+          : {}),
       });
 
       if (verdict.kind === 'block') {
@@ -507,6 +582,7 @@ export class ToolRuntime {
           toolUseId,
           toolName: tool.name,
           category: verdict.event.category,
+          requestKind: verdict.event.kind ?? 'tool_permission',
         });
         let response: PermissionDecision;
         try {
@@ -518,7 +594,8 @@ export class ToolRuntime {
             requestId: verdict.event.requestId,
             toolUseId,
             toolName: tool.name,
-            reason,
+            requestKind: verdict.event.kind ?? 'tool_permission',
+            reason: err instanceof AdditionalPermissionError ? err.reason : reason,
           });
           await this.writeSyntheticToolResult(toolUseId, turnId, reason, queue);
           trace?.emit('tool', 'tool_failed', 'Tool execution failed before implementation', {
@@ -557,6 +634,7 @@ export class ToolRuntime {
           toolUseId,
           toolName: tool.name,
           decision: response.decision,
+          requestKind: verdict.event.kind ?? 'tool_permission',
           ...(response.rememberForTurn !== undefined ? { rememberForTurn: response.rememberForTurn } : {}),
         });
 
@@ -592,6 +670,45 @@ export class ToolRuntime {
       await this.writeSyntheticToolResult(toolUseId, turnId, SUBAGENT_TOOL_LIMIT_MESSAGE, queue);
       this.recordLoopGateOutcome(callSignature, true);
       return this.errorReturn(SUBAGENT_TOOL_LIMIT_MESSAGE);
+    }
+
+    let permissionContext: ToolExecutionPermissionContext | undefined;
+    if (additionalPlan.kind === 'request') {
+      try {
+        await revalidateAdditionalPermissionProposal({
+          proposal: additionalPlan.proposal,
+          cwd: this.input.header.cwd,
+        });
+        const additionalGrant = this.input.permissionEngine.consumeAdditionalPermissionGrant({
+          sessionId: this.input.sessionId,
+          turnId,
+          toolUseId,
+          toolName: tool.name,
+          intentHash: additionalPlan.proposal.intentHash,
+        });
+        if (!additionalGrant) {
+          throw new AdditionalPermissionError({
+            stage: 'consume',
+            reason: 'grant_unavailable',
+            message: 'Approved additional permission grant was unavailable.',
+          });
+        }
+        permissionContext = Object.freeze({ additionalGrant });
+      } catch (error) {
+        const reason = formatSyntheticToolErrorText(error);
+        trace?.emit('permission', 'permission_failed', 'Additional permission could not be applied', {
+          toolUseId,
+          toolName: tool.name,
+          requestKind: 'additional_permissions',
+          reason: error instanceof AdditionalPermissionError
+            ? error.reason
+            : 'invalid_additional_permissions',
+        });
+        await this.writeSyntheticToolResult(toolUseId, turnId, reason, queue);
+        this.recordLoopGateOutcome(callSignature, true);
+        this.releaseSubagentSlot(tool);
+        return this.errorReturn(reason);
+      }
     }
     const startedAt = this.input.now();
     const output = createToolOutputDeltaEmitter({
@@ -629,6 +746,7 @@ export class ToolRuntime {
           toolCallId: toolUseId,
           abortSignal: ctx.abortSignal,
           emitOutput: output.emit,
+          ...(permissionContext ? { permissionContext } : {}),
           ...(this.input.listChildAgents ? { listChildAgents: this.input.listChildAgents } : {}),
           ...(this.input.readChildAgentOutput ? { readChildAgentOutput: this.input.readChildAgentOutput } : {}),
           ...(this.buildSpawnChildAgentContext(ctx.abortSignal)),
@@ -1140,6 +1258,20 @@ function describeToolIntent(tool: MakaTool, args: unknown): string | undefined {
   if (normalized.length === 0) return undefined;
   const capped = normalized.length <= 180 ? normalized : `${normalized.slice(0, 179)}…`;
   return `只读探索：${capped}`;
+}
+
+function isAdditionalPermissionPlanResult(
+  value: unknown,
+): value is AdditionalPermissionPlanResult {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
+  const result = value as Record<string, unknown>;
+  if (result.kind === 'not_required') return true;
+  if (result.kind === 'request') {
+    return Boolean(result.proposal && typeof result.proposal === 'object');
+  }
+  return result.kind === 'block'
+    && typeof result.reason === 'string'
+    && typeof result.message === 'string';
 }
 
 function byteLength(value: unknown): number {


### PR DESCRIPTION
## Summary

- add a trusted per-tool additional-permission planner hook
- route one-call proposals through PermissionEngine even for otherwise permission-free tools
- revalidate approved paths and consume intent-bound grants immediately before execution
- expose the consumed immutable grant through MakaToolContext
- fail closed on planner errors, malformed results, denial, changed targets, or unavailable grants

## Scope

Refs #509.

This follows #960, #964, and #969 and is extracted from #880.

This slice only adds ToolRuntime orchestration. It does not register planners on built-in Bash/file tools, apply grants to Seatbelt or filesystem execution, or add Desktop/CLI approval UI. Therefore the default runtime path remains unchanged until the next execution-enforcement slices.

## Verification

- `npm test --workspace @maka/runtime` (1609 tests, 1602 passed, 7 skipped, 0 failed)
- `npm run build`
- `npm run typecheck`
- `git diff --check`