### PR TITLE
feat(core): derive provider conformance matrix from registry declarations

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -40,6 +40,7 @@
     "./incognito": "./dist/incognito.js",
     "./backend-types": "./dist/backend-types.js",
     "./llm-connections": "./dist/llm-connections.js",
+    "./provider-contract-matrix": "./dist/provider-contract-matrix.js",
     "./model-metadata": "./dist/model-metadata.js",
     "./model-thinking": "./dist/model-thinking.js",
     "./connection-readiness": "./dist/connection-readiness.js",

--- a/packages/core/src/__tests__/provider-contract-matrix.test.ts
+++ b/packages/core/src/__tests__/provider-contract-matrix.test.ts
@@ -1,0 +1,234 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { PROVIDER_REGISTRY, type ProviderDefaults, type ProviderType } from '../provider-registry.js';
+import {
+  PROVIDER_CONTRACT_DIMENSIONS,
+  PROVIDER_CONTRACT_MATRIX_PLAN,
+  buildProviderContractMatrixPlan,
+  listProviderContractCells,
+  type ProviderContractCell,
+  type ProviderContractDimension,
+} from '../provider-contract-matrix.js';
+
+const plan = PROVIDER_CONTRACT_MATRIX_PLAN;
+
+function rowFor(providerType: ProviderType) {
+  const row = plan.rows.find((entry) => entry.providerType === providerType);
+  assert.ok(row, `expected a matrix row for ${providerType}`);
+  return row;
+}
+
+function cellFor(providerType: ProviderType, dimension: ProviderContractDimension): ProviderContractCell {
+  return rowFor(providerType).cells[dimension];
+}
+
+describe('provider contract matrix — row selection', () => {
+  it('includes every ready, wired provider and excludes experimental / unavailable ones', () => {
+    const rowTypes = new Set(plan.rows.map((row) => row.providerType));
+    for (const [providerType, def] of Object.entries(PROVIDER_REGISTRY) as Array<[ProviderType, ProviderDefaults]>) {
+      const shouldBeRow = def.status === 'ready' && def.runtimeAdapter.kind !== 'unavailable';
+      assert.equal(
+        rowTypes.has(providerType),
+        shouldBeRow,
+        `${providerType} row membership should be ${shouldBeRow}`,
+      );
+    }
+  });
+
+  it('keeps github-copilot as a row even though it has no readyOrder', () => {
+    // The whole point of not reusing READY_PROVIDER_TYPES: its membership is
+    // "has a readyOrder", which drops github-copilot.
+    assert.equal(PROVIDER_REGISTRY['github-copilot'].readyOrder, undefined);
+    assert.ok(plan.rows.some((row) => row.providerType === 'github-copilot'));
+  });
+
+  it('excludes the experimental oauth providers and the unavailable gemini-cli', () => {
+    for (const excluded of ['claude-subscription', 'codex-subscription', 'gemini-cli'] as const) {
+      assert.ok(!plan.rows.some((row) => row.providerType === excluded), `${excluded} must not be a row`);
+    }
+  });
+
+  it('exposes the four contract dimensions', () => {
+    assert.deepEqual(plan.dimensions, PROVIDER_CONTRACT_DIMENSIONS);
+    assert.deepEqual([...PROVIDER_CONTRACT_DIMENSIONS], [
+      'discovery',
+      'exact-model-id',
+      'tool-loop',
+      'reasoning-replay',
+    ]);
+  });
+});
+
+describe('provider contract matrix — every cell is exactly one of three states', () => {
+  it('assigns a known state with the state-specific payload to every cell', () => {
+    for (const { providerType, dimension, cell } of listProviderContractCells(plan)) {
+      const where = `${providerType}/${dimension}`;
+      switch (cell.state) {
+        case 'generated':
+          if (dimension === 'discovery') {
+            assert.ok(cell.discovery, `${where} generated discovery must carry a discovery plan`);
+          } else {
+            assert.ok(cell.wire, `${where} generated wire cell must carry a wire`);
+          }
+          break;
+        case 'override':
+          assert.equal(cell.overrideKey, `${providerType}:${dimension}`, `${where} override key`);
+          assert.ok(cell.contract.length > 0, `${where} override must state its contract`);
+          break;
+        case 'not-applicable':
+          assert.ok(cell.reason.length > 0, `${where} not-applicable must carry a reason`);
+          break;
+        default:
+          assert.fail(`${where} has an unknown cell state`);
+      }
+    }
+  });
+});
+
+describe('provider contract matrix — discovery derivation', () => {
+  it('marks protocol discovery generated and carries the derived request shape', () => {
+    const siliconflow = cellFor('siliconflow', 'discovery');
+    assert.equal(siliconflow.state, 'generated');
+    assert.equal(siliconflow.state === 'generated' && siliconflow.discovery?.protocol, 'openai');
+    assert.deepEqual(
+      siliconflow.state === 'generated' ? siliconflow.discovery?.query : undefined,
+      { sub_type: 'chat' },
+    );
+
+    const vercel = cellFor('vercel', 'discovery');
+    assert.equal(vercel.state, 'generated');
+    assert.equal(vercel.state === 'generated' && vercel.discovery?.auth, 'none');
+    assert.equal(vercel.state === 'generated' && vercel.discovery?.filter, 'language-models');
+  });
+
+  it('marks fireworks / cohere / ollama discovery as override', () => {
+    for (const providerType of ['fireworks-ai', 'cohere', 'ollama'] as const) {
+      const cell = cellFor(providerType, 'discovery');
+      assert.equal(cell.state, 'override', `${providerType} discovery should be override`);
+    }
+  });
+
+  it('marks github-copilot discovery as override (special subscription models wire)', () => {
+    assert.equal(cellFor('github-copilot', 'discovery').state, 'override');
+  });
+
+  it('marks fallback discovery not-applicable with a no-/models reverse assertion', () => {
+    for (const providerType of ['volcengine-ark', 'tencent-coding-plan', 'cloudflare-workers-ai'] as const) {
+      const cell = cellFor(providerType, 'discovery');
+      assert.equal(cell.state, 'not-applicable', `${providerType} discovery should be N/A`);
+      assert.equal(
+        cell.state === 'not-applicable' ? cell.reverseAssertion : undefined,
+        'must-not-request-models-endpoint',
+      );
+    }
+  });
+});
+
+describe('provider contract matrix — wire and reasoning derivation', () => {
+  it('generates wire cells for non-subscription adapters against the protocol wire', () => {
+    assert.deepEqual(
+      [cellFor('openai', 'tool-loop').state, cellFor('openai', 'exact-model-id').state],
+      ['generated', 'generated'],
+    );
+    const anthropicLoop = cellFor('anthropic', 'tool-loop');
+    assert.equal(anthropicLoop.state === 'generated' && anthropicLoop.wire, 'anthropic-messages');
+    const googleLoop = cellFor('google', 'tool-loop');
+    assert.equal(googleLoop.state === 'generated' && googleLoop.wire, 'google-generate');
+    const cohereLoop = cellFor('cohere', 'tool-loop');
+    assert.equal(cohereLoop.state === 'generated' && cohereLoop.wire, 'cohere-v2');
+  });
+
+  it('marks github-copilot wire dimensions as override', () => {
+    for (const dimension of ['exact-model-id', 'tool-loop', 'reasoning-replay'] as const) {
+      assert.equal(cellFor('github-copilot', dimension).state, 'override', `copilot ${dimension}`);
+    }
+  });
+
+  it('generates a plain reasoning_content round-trip for plain openai-compatible providers', () => {
+    const cell = cellFor('volcengine-ark', 'reasoning-replay');
+    assert.equal(cell.state, 'generated');
+    assert.deepEqual(
+      cell.state === 'generated' ? cell.reasoningReplay : undefined,
+      { sourceField: 'reasoning_content', replayField: 'reasoning_content' },
+    );
+  });
+
+  it('generates a reasoning field rename when the adapter declares replayAssistantReasoningAs', () => {
+    const cell = cellFor('ollama-cloud', 'reasoning-replay');
+    assert.equal(cell.state, 'generated');
+    assert.equal(
+      cell.state === 'generated' ? cell.reasoningReplay?.replayField : undefined,
+      'reasoning',
+    );
+  });
+
+  it('marks zenmux signed reasoning_details replay as override', () => {
+    assert.equal(cellFor('zenmux', 'reasoning-replay').state, 'override');
+  });
+
+  it('marks native-SDK adapters not-applicable for reasoning replay', () => {
+    for (const providerType of ['anthropic', 'openai', 'google', 'cohere'] as const) {
+      assert.equal(
+        cellFor(providerType, 'reasoning-replay').state,
+        'not-applicable',
+        `${providerType} reasoning-replay should be N/A`,
+      );
+    }
+  });
+});
+
+describe('provider contract matrix — sample model id derivation', () => {
+  it('uses the provider first fallback model when present', () => {
+    assert.equal(rowFor('anthropic').sampleModelId, PROVIDER_REGISTRY.anthropic.fallbackModels[0]);
+  });
+
+  it('never routes the OpenAI adapter sample id to the Responses wire', () => {
+    assert.ok(!/^gpt-5/i.test(rowFor('openai').sampleModelId));
+  });
+
+  it('falls back to a synthetic id when the provider ships no fallback snapshot', () => {
+    // openai-compatible custom and lm-studio have empty fallback snapshots.
+    assert.equal(rowFor('lm-studio').sampleModelId, 'conformance-sample-model');
+    assert.equal(rowFor('openai-compatible').sampleModelId, 'conformance-sample-model');
+  });
+});
+
+describe('provider contract matrix — derivation is a total function over a fixture registry', () => {
+  it('classifies a minimal ready openai-compatible fixture without touching the live registry', () => {
+    const fixture: Record<string, ProviderDefaults> = {
+      'fixture-provider': {
+        label: 'Fixture',
+        description: 'test',
+        baseUrl: 'https://example.test/v1',
+        authKind: 'api_key',
+        backendKind: 'ai-sdk',
+        fallbackModels: ['fixture-model'],
+        status: 'ready',
+        protocol: 'openai',
+        runtimeAdapter: { kind: 'openai-compatible', name: 'provider' },
+        modelDiscovery: { kind: 'protocol' },
+        category: 'overseas',
+      },
+      'fixture-experimental': {
+        label: 'Fixture Experimental',
+        description: 'test',
+        baseUrl: '',
+        authKind: 'oauth_token',
+        backendKind: 'ai-sdk',
+        fallbackModels: [],
+        status: 'phase3-experimental',
+        protocol: 'openai',
+        runtimeAdapter: { kind: 'unavailable' },
+        modelDiscovery: { kind: 'fallback' },
+        category: 'oauth',
+      },
+    };
+    const fixturePlan = buildProviderContractMatrixPlan(fixture);
+    assert.deepEqual(fixturePlan.rows.map((row) => row.providerType), ['fixture-provider']);
+    const row = fixturePlan.rows[0]!;
+    assert.equal(row.sampleModelId, 'fixture-model');
+    assert.equal(row.cells.discovery.state, 'generated');
+    assert.equal(row.cells['tool-loop'].state, 'generated');
+    assert.equal(row.cells['reasoning-replay'].state, 'generated');
+  });
+});

--- a/packages/core/src/__tests__/provider-contract-matrix.test.ts
+++ b/packages/core/src/__tests__/provider-contract-matrix.test.ts
@@ -101,6 +101,12 @@ describe('provider contract matrix — discovery derivation', () => {
     assert.equal(vercel.state === 'generated' && vercel.discovery?.filter, 'language-models');
   });
 
+  it('derives auth none when the provider has no credential to send', () => {
+    const lmStudio = cellFor('lm-studio', 'discovery');
+    assert.equal(lmStudio.state, 'generated');
+    assert.equal(lmStudio.state === 'generated' && lmStudio.discovery?.auth, 'none');
+  });
+
   it('marks fireworks / cohere / ollama discovery as override', () => {
     for (const providerType of ['fireworks-ai', 'cohere', 'ollama'] as const) {
       const cell = cellFor(providerType, 'discovery');

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -902,6 +902,31 @@ export {
   validateSlug,
 } from './llm-connections.js';
 
+// provider-contract-matrix.ts — registry-driven conformance matrix plan.
+export type {
+  ProviderContractCell,
+  ProviderContractCellEntry,
+  ProviderContractCellState,
+  ProviderContractDimension,
+  ProviderContractDiscoveryPlan,
+  ProviderContractGeneratedCell,
+  ProviderContractMatrixPlan,
+  ProviderContractNotApplicableCell,
+  ProviderContractOverrideCell,
+  ProviderContractReasoningReplayPlan,
+  ProviderContractReverseAssertion,
+  ProviderContractRow,
+  ProviderContractWire,
+} from './provider-contract-matrix.js';
+export {
+  PROVIDER_CONTRACT_DIMENSIONS,
+  PROVIDER_CONTRACT_MATRIX_PLAN,
+  SUBSCRIPTION_WIRE_ADAPTER_KINDS,
+  buildProviderContractMatrixPlan,
+  buildProviderContractRow,
+  listProviderContractCells,
+} from './provider-contract-matrix.js';
+
 // connection-readiness.ts (PR110a)
 export type {
   ChatConfigurationReason,

--- a/packages/core/src/provider-contract-matrix.ts
+++ b/packages/core/src/provider-contract-matrix.ts
@@ -1,0 +1,339 @@
+/**
+ * Provider conformance matrix — a registry-driven plan.
+ *
+ * Conformance is the interpreted execution of what `providerRegistry`
+ * *declares*. This module derives, for every ready provider and every contract
+ * dimension, one of three states:
+ *
+ *   - `generated`      the expectation is fully recoverable from the declaration
+ *                      (protocol, runtime adapter, model discovery), so a
+ *                      parametric wire test can stand in for a hand-written one.
+ *   - `override`       the declaration proves the dimension exists but its
+ *                      contract is provider-specific and cannot be recovered
+ *                      generically; a named hand-written test owns it.
+ *   - `not-applicable` the declaration proves the dimension does not apply, with
+ *                      a machine-readable reason (and, where useful, a reverse
+ *                      assertion the executor must still hold).
+ *
+ * The row set is discovered from the registry, never a hard-coded provider list:
+ * every `status: 'ready'` entry whose runtime adapter is wired (i.e. not
+ * `unavailable`) is a row. Crucially this is *not* `READY_PROVIDER_TYPES`, whose
+ * membership is "has a `readyOrder`" and would silently drop `github-copilot`
+ * (ready, but intentionally without a `readyOrder`).
+ *
+ * Pure: no IO, no network, no clock. Given the registry it is a total function.
+ */
+
+import { lookupModelProviderOverride } from './model-metadata.js';
+import {
+  PROVIDER_REGISTRY,
+  type ProviderDefaults,
+  type ProviderModelDiscovery,
+  type ProviderRuntimeAdapter,
+  type ProviderType,
+} from './provider-registry.js';
+
+export const PROVIDER_CONTRACT_DIMENSIONS = [
+  'discovery',
+  'exact-model-id',
+  'tool-loop',
+  'reasoning-replay',
+] as const;
+
+export type ProviderContractDimension = (typeof PROVIDER_CONTRACT_DIMENSIONS)[number];
+
+export type ProviderContractCellState = 'generated' | 'override' | 'not-applicable';
+
+/** The four request wires a generated cell can be executed against. */
+export type ProviderContractWire =
+  | 'openai-chat'
+  | 'anthropic-messages'
+  | 'google-generate'
+  | 'cohere-v2';
+
+/** Runtime-adapter kinds whose request wire is provider-specific (auth, headers,
+ * per-model protocol) and therefore cannot be generated from the declaration. */
+export const SUBSCRIPTION_WIRE_ADAPTER_KINDS: ReadonlySet<ProviderRuntimeAdapter['kind']> =
+  new Set(['claude-subscription', 'codex-subscription', 'github-copilot']);
+
+/** Derived expectation for a generated `discovery` cell. */
+export interface ProviderContractDiscoveryPlan {
+  protocol: ProviderDefaults['protocol'];
+  /** `none` when the model list is public; `default` when it carries provider auth. */
+  auth: 'default' | 'none';
+  path?: string;
+  query?: Readonly<Record<string, string>>;
+  responseShape?: 'array-or-data';
+  filter?: 'fallback-models' | 'language-models' | 'tool-capable';
+}
+
+/** Derived expectation for a generated `reasoning-replay` cell. */
+export interface ProviderContractReasoningReplayPlan {
+  /** Field the upstream response carries reasoning in. */
+  sourceField: 'reasoning_content';
+  /** Field the next request must carry the replayed reasoning in. */
+  replayField: 'reasoning_content' | 'reasoning';
+}
+
+export interface ProviderContractGeneratedCell {
+  state: 'generated';
+  dimension: ProviderContractDimension;
+  /** Present for wire dimensions (`exact-model-id`, `tool-loop`, `reasoning-replay`). */
+  wire?: ProviderContractWire;
+  /** Present for the `discovery` dimension. */
+  discovery?: ProviderContractDiscoveryPlan;
+  /** Present for the `reasoning-replay` dimension. */
+  reasoningReplay?: ProviderContractReasoningReplayPlan;
+}
+
+export interface ProviderContractOverrideCell {
+  state: 'override';
+  dimension: ProviderContractDimension;
+  /** Stable `${providerType}:${dimension}` key a named hand-written test registers against. */
+  overrideKey: string;
+  /** Human-readable statement of the provider-specific contract the override owns. */
+  contract: string;
+}
+
+export type ProviderContractReverseAssertion = 'must-not-request-models-endpoint';
+
+export interface ProviderContractNotApplicableCell {
+  state: 'not-applicable';
+  dimension: ProviderContractDimension;
+  /** Machine-readable justification derived from the declaration. */
+  reason: string;
+  /** An assertion the executor must still hold even though the dimension is N/A. */
+  reverseAssertion?: ProviderContractReverseAssertion;
+}
+
+export type ProviderContractCell =
+  | ProviderContractGeneratedCell
+  | ProviderContractOverrideCell
+  | ProviderContractNotApplicableCell;
+
+export interface ProviderContractRow {
+  providerType: ProviderType;
+  protocol: ProviderDefaults['protocol'];
+  adapterKind: ProviderRuntimeAdapter['kind'];
+  discoveryKind: ProviderModelDiscovery['kind'];
+  /** Deterministic model id generated cells drive through discovery and the wire. */
+  sampleModelId: string;
+  cells: Record<ProviderContractDimension, ProviderContractCell>;
+}
+
+export interface ProviderContractMatrixPlan {
+  dimensions: readonly ProviderContractDimension[];
+  rows: ProviderContractRow[];
+}
+
+const SYNTHETIC_SAMPLE_MODEL_ID = 'conformance-sample-model';
+
+function overrideKeyFor(providerType: ProviderType, dimension: ProviderContractDimension): string {
+  return `${providerType}:${dimension}`;
+}
+
+function wireForProtocol(protocol: ProviderDefaults['protocol']): ProviderContractWire {
+  switch (protocol) {
+    case 'openai':
+      return 'openai-chat';
+    case 'anthropic':
+      return 'anthropic-messages';
+    case 'google':
+      return 'google-generate';
+    case 'cohere':
+      return 'cohere-v2';
+  }
+}
+
+/**
+ * The generated wire tests the provider's *declared default* wire, so the sample
+ * model id must not divert to another one:
+ *
+ *   - a model carrying a per-model provider override (models.dev `npm`/`api`)
+ *     resolves to a different adapter/protocol at runtime (e.g. OpenCode routes
+ *     `gpt-5*` to the OpenAI Responses wire); that per-model contract is owned by
+ *     a hand-written test, not this generated default-wire cell.
+ *   - the native OpenAI adapter routes `gpt-5*` to the Responses API by id shape.
+ *
+ * The first fallback model that survives both filters is the most faithful
+ * choice — a real, exact id that also sits in any `fallback-models` discovery
+ * allowlist. Providers with no such model fall back to a synthetic id.
+ */
+function sampleModelIdFor(providerType: ProviderType, def: ProviderDefaults): string {
+  const usesDefaultWire = (id: string): boolean => {
+    if (lookupModelProviderOverride(providerType, id)) return false;
+    if (def.runtimeAdapter.kind === 'openai' && /^gpt-5/i.test(id)) return false;
+    return true;
+  };
+  return def.fallbackModels.find(usesDefaultWire) ?? SYNTHETIC_SAMPLE_MODEL_ID;
+}
+
+function discoveryCell(providerType: ProviderType, def: ProviderDefaults): ProviderContractCell {
+  const discovery = def.modelDiscovery;
+  switch (discovery.kind) {
+    case 'fallback':
+      return {
+        state: 'not-applicable',
+        dimension: 'discovery',
+        reason: 'declares-static-fallback-model-snapshot',
+        reverseAssertion: 'must-not-request-models-endpoint',
+      };
+    case 'fireworks':
+      return {
+        state: 'override',
+        dimension: 'discovery',
+        overrideKey: overrideKeyFor(providerType, 'discovery'),
+        contract: 'Fireworks account pagination discovery over /v1/accounts + per-account /models',
+      };
+    case 'cohere':
+      return {
+        state: 'override',
+        dimension: 'discovery',
+        overrideKey: overrideKeyFor(providerType, 'discovery'),
+        contract: 'Cohere native V2 paginated /v1/models discovery (endpoint=chat)',
+      };
+    case 'ollama':
+      return {
+        state: 'override',
+        dimension: 'discovery',
+        overrideKey: overrideKeyFor(providerType, 'discovery'),
+        contract: 'Ollama native /api/tags discovery',
+      };
+    case 'protocol':
+      if (discovery.auth === 'github-copilot') {
+        return {
+          state: 'override',
+          dimension: 'discovery',
+          overrideKey: overrideKeyFor(providerType, 'discovery'),
+          contract: 'GitHub Copilot subscription /models discovery (picker + endpoint gating)',
+        };
+      }
+      return {
+        state: 'generated',
+        dimension: 'discovery',
+        discovery: {
+          protocol: def.protocol,
+          auth: discovery.auth === 'none' ? 'none' : 'default',
+          ...(discovery.path !== undefined ? { path: discovery.path } : {}),
+          ...(discovery.query !== undefined ? { query: discovery.query } : {}),
+          ...(discovery.responseShape !== undefined ? { responseShape: discovery.responseShape } : {}),
+          ...(discovery.filter !== undefined ? { filter: discovery.filter } : {}),
+        },
+      };
+  }
+}
+
+function wireDimensionCell(
+  dimension: 'exact-model-id' | 'tool-loop',
+  providerType: ProviderType,
+  def: ProviderDefaults,
+): ProviderContractCell {
+  if (SUBSCRIPTION_WIRE_ADAPTER_KINDS.has(def.runtimeAdapter.kind)) {
+    return {
+      state: 'override',
+      dimension,
+      overrideKey: overrideKeyFor(providerType, dimension),
+      contract: `${def.runtimeAdapter.kind} subscription wire is provider-specific (per-model protocol, headers, auth)`,
+    };
+  }
+  return { state: 'generated', dimension, wire: wireForProtocol(def.protocol) };
+}
+
+function reasoningReplayCell(providerType: ProviderType, def: ProviderDefaults): ProviderContractCell {
+  const adapter = def.runtimeAdapter;
+  if (SUBSCRIPTION_WIRE_ADAPTER_KINDS.has(adapter.kind)) {
+    return {
+      state: 'override',
+      dimension: 'reasoning-replay',
+      overrideKey: overrideKeyFor(providerType, 'reasoning-replay'),
+      contract: `${adapter.kind} replays reasoning on its provider-specific per-model wire`,
+    };
+  }
+  if (adapter.kind === 'openai-compatible') {
+    if (adapter.replayAssistantReasoningDetails === true) {
+      return {
+        state: 'override',
+        dimension: 'reasoning-replay',
+        overrideKey: overrideKeyFor(providerType, 'reasoning-replay'),
+        contract: 'Signed reasoning_details are replayed byte-for-byte (ZenMux), beyond a plain field rename',
+      };
+    }
+    return {
+      state: 'generated',
+      dimension: 'reasoning-replay',
+      wire: 'openai-chat',
+      reasoningReplay: {
+        sourceField: 'reasoning_content',
+        replayField: adapter.replayAssistantReasoningAs ?? 'reasoning_content',
+      },
+    };
+  }
+  // Native Anthropic / OpenAI / Google / Cohere SDKs own signed reasoning replay
+  // opaquely; the maka provider layer adds no wire transform to derive from.
+  return {
+    state: 'not-applicable',
+    dimension: 'reasoning-replay',
+    reason: 'vendor-sdk-owns-signed-reasoning-replay',
+  };
+}
+
+function isRow(def: ProviderDefaults): boolean {
+  return def.status === 'ready' && def.runtimeAdapter.kind !== 'unavailable';
+}
+
+export function buildProviderContractRow(
+  providerType: ProviderType,
+  def: ProviderDefaults,
+): ProviderContractRow {
+  return {
+    providerType,
+    protocol: def.protocol,
+    adapterKind: def.runtimeAdapter.kind,
+    discoveryKind: def.modelDiscovery.kind,
+    sampleModelId: sampleModelIdFor(providerType, def),
+    cells: {
+      discovery: discoveryCell(providerType, def),
+      'exact-model-id': wireDimensionCell('exact-model-id', providerType, def),
+      'tool-loop': wireDimensionCell('tool-loop', providerType, def),
+      'reasoning-replay': reasoningReplayCell(providerType, def),
+    },
+  };
+}
+
+/**
+ * Derive the full conformance matrix plan from a provider registry. Defaults to
+ * the live {@link PROVIDER_REGISTRY}; accepts an explicit registry so tests can
+ * probe the derivation with fixtures.
+ */
+export function buildProviderContractMatrixPlan(
+  registry: Readonly<Record<string, ProviderDefaults>> = PROVIDER_REGISTRY,
+): ProviderContractMatrixPlan {
+  const rows = (Object.entries(registry) as Array<[ProviderType, ProviderDefaults]>)
+    .filter(([, def]) => isRow(def))
+    .map(([providerType, def]) => buildProviderContractRow(providerType, def));
+  return { dimensions: PROVIDER_CONTRACT_DIMENSIONS, rows };
+}
+
+/** A single (provider, dimension) coordinate flattened from the plan. */
+export interface ProviderContractCellEntry {
+  providerType: ProviderType;
+  dimension: ProviderContractDimension;
+  cell: ProviderContractCell;
+  row: ProviderContractRow;
+}
+
+/** Flatten the plan into one entry per (provider, dimension) cell, in a stable order. */
+export function listProviderContractCells(
+  plan: ProviderContractMatrixPlan,
+): ProviderContractCellEntry[] {
+  const entries: ProviderContractCellEntry[] = [];
+  for (const row of plan.rows) {
+    for (const dimension of plan.dimensions) {
+      entries.push({ providerType: row.providerType, dimension, cell: row.cells[dimension], row });
+    }
+  }
+  return entries;
+}
+
+/** The live plan for the current registry. */
+export const PROVIDER_CONTRACT_MATRIX_PLAN = buildProviderContractMatrixPlan();

--- a/packages/core/src/provider-contract-matrix.ts
+++ b/packages/core/src/provider-contract-matrix.ts
@@ -59,7 +59,8 @@ export const SUBSCRIPTION_WIRE_ADAPTER_KINDS: ReadonlySet<ProviderRuntimeAdapter
 /** Derived expectation for a generated `discovery` cell. */
 export interface ProviderContractDiscoveryPlan {
   protocol: ProviderDefaults['protocol'];
-  /** `none` when the model list is public; `default` when it carries provider auth. */
+  /** `none` when the request must carry no credential — a public model list, or a
+   * provider with no credential to send; `default` when it carries provider auth. */
   auth: 'default' | 'none';
   path?: string;
   query?: Readonly<Record<string, string>>;
@@ -213,7 +214,7 @@ function discoveryCell(providerType: ProviderType, def: ProviderDefaults): Provi
         dimension: 'discovery',
         discovery: {
           protocol: def.protocol,
-          auth: discovery.auth === 'none' ? 'none' : 'default',
+          auth: discovery.auth === 'none' || def.authKind === 'none' ? 'none' : 'default',
           ...(discovery.path !== undefined ? { path: discovery.path } : {}),
           ...(discovery.query !== undefined ? { query: discovery.query } : {}),
           ...(discovery.responseShape !== undefined ? { responseShape: discovery.responseShape } : {}),

--- a/packages/runtime/src/__tests__/provider-conformance.test.ts
+++ b/packages/runtime/src/__tests__/provider-conformance.test.ts
@@ -169,6 +169,31 @@ describe('models.dev provider conformance', () => {
     assert.equal(requestBodies[0]?.model, modelId);
     assert.equal(result.steps[0]?.reasoningText, 'I should use the echo tool.');
     assert.deepEqual(result.steps[0]?.toolResults[0]?.output, { echoed: 'hello' });
+    // Turn two must carry the exact model id, replay the assistant tool-call
+    // turn (original tool_calls id + reasoning_content verbatim), and link the
+    // tool result back through tool_call_id.
+    assert.equal(requestBodies[1]?.model, modelId);
+    const secondMessages = requestBodies[1]?.messages as Array<Record<string, unknown>>;
+    const assistant = secondMessages.find((message) => message.role === 'assistant');
+    assert.ok(assistant, 'turn two must replay the assistant tool-call turn');
+    assert.deepEqual(
+      (assistant.tool_calls as Array<{ id: string }>).map(({ id }) => id),
+      ['call-copilot-echo'],
+      'turn two must replay the original tool_calls id',
+    );
+    assert.equal(
+      assistant.reasoning_content,
+      'I should use the echo tool.',
+      'turn two must replay the first-turn reasoning verbatim as reasoning_content',
+    );
+    const toolMessage = secondMessages.find((message) => message.role === 'tool');
+    assert.ok(toolMessage, 'turn two must carry a tool message with the echo result');
+    assert.equal(toolMessage.tool_call_id, 'call-copilot-echo');
+    const toolMessageContent = JSON.stringify(toolMessage.content);
+    assert.ok(
+      toolMessageContent.includes('echoed') && toolMessageContent.includes('hello'),
+      `turn two tool message must carry the echo output, got ${toolMessageContent}`,
+    );
     assert.equal(result.text, 'Echoed hello.');
   });
 

--- a/packages/runtime/src/__tests__/provider-contract-matrix.test.ts
+++ b/packages/runtime/src/__tests__/provider-contract-matrix.test.ts
@@ -38,7 +38,6 @@ import {
   type ProviderContractGeneratedCell,
   type ProviderContractWire,
 } from '@maka/core';
-import { providerAuthSupportsApiKey } from '@maka/core/llm-connections';
 import { generateText, stepCountIs, tool } from 'ai';
 import { z } from 'zod';
 import { fetchProviderModels } from '../model-fetcher.js';
@@ -322,11 +321,7 @@ function assertDiscoveryRequest(
   }
   switch (discovery.protocol) {
     case 'openai':
-      if (providerAuthSupportsApiKey(row.providerType)) {
-        assert.equal(authorization, `Bearer ${API_KEY}`, `${where} must send its Bearer credential`);
-      } else {
-        assert.equal(authorization, undefined, `${where} has no API-key auth: it must not send Authorization`);
-      }
+      assert.equal(authorization, `Bearer ${API_KEY}`, `${where} must send its Bearer credential`);
       break;
     case 'anthropic':
       assert.equal(xApiKey, API_KEY, `${where} must send its x-api-key credential`);

--- a/packages/runtime/src/__tests__/provider-contract-matrix.test.ts
+++ b/packages/runtime/src/__tests__/provider-contract-matrix.test.ts
@@ -25,16 +25,20 @@
  */
 
 import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
 import { createServer, type IncomingMessage, type ServerResponse } from 'node:http';
 import { after, describe, test } from 'node:test';
+import { fileURLToPath } from 'node:url';
 import type { LlmConnection } from '@maka/core';
 import {
   PROVIDER_CONTRACT_MATRIX_PLAN,
   listProviderContractCells,
+  type ProviderContractDiscoveryPlan,
   type ProviderContractRow,
   type ProviderContractGeneratedCell,
   type ProviderContractWire,
 } from '@maka/core';
+import { providerAuthSupportsApiKey } from '@maka/core/llm-connections';
 import { generateText, stepCountIs, tool } from 'ai';
 import { z } from 'zod';
 import { fetchProviderModels } from '../model-fetcher.js';
@@ -52,30 +56,82 @@ after(async () => {
   await Promise.all(servers.map((server) => server.close()));
 });
 
+/** A named override binding a plan cell to a hand-written conformance test. */
+interface OverrideBinding {
+  /**
+   * Exact test title as it appears verbatim in the `provider-conformance.test.ts`
+   * source (for parametric tests, the literal template text including any
+   * `${...}` placeholder). The binding test below asserts this string still
+   * exists in the source, so deleting or renaming the hand-written test breaks
+   * the matrix instead of leaving a silent gap.
+   */
+  test: string;
+  /** Human-readable statement of the provider-specific contract the override owns. */
+  contract: string;
+}
+
+const GITHUB_COPILOT_OVERRIDE_TEST =
+  'GitHub Copilot discovers the account model and completes a reasoning tool loop on its exact wire';
+
 /**
  * Named overrides. Each key is a plan `overrideKey` (`${providerType}:${dimension}`)
- * and each value points at the hand-written test in `provider-conformance.test.ts`
+ * and each value binds the hand-written test in `provider-conformance.test.ts`
  * that owns the provider-specific contract the plan cannot generate. A missing
- * key here surfaces as a contract gap.
+ * key here surfaces as a contract gap; a stale `test` title fails the source
+ * binding test.
  */
-const OVERRIDE_REGISTRY: Readonly<Record<string, string>> = {
-  'cohere:discovery':
-    'provider-conformance.test.ts — "Cohere paginates account models and completes its native V2 tool-call loop"',
-  'fireworks-ai:discovery':
-    'provider-conformance.test.ts — "Fireworks discovers exact serverless model paths and completes a two-stage tool-call loop"',
-  'ollama:discovery':
-    'provider-conformance.test.ts — "Ollama preserves an exact ... through local discovery and a no-secret tool-call loop"',
-  'github-copilot:discovery':
-    'provider-conformance.test.ts — "GitHub Copilot discovers the account model and completes a reasoning tool loop on its exact wire"',
-  'github-copilot:exact-model-id':
-    'provider-conformance.test.ts — "GitHub Copilot discovers the account model and completes a reasoning tool loop on its exact wire"',
-  'github-copilot:tool-loop':
-    'provider-conformance.test.ts — "GitHub Copilot discovers the account model and completes a reasoning tool loop on its exact wire"',
-  'github-copilot:reasoning-replay':
-    'provider-conformance.test.ts — "GitHub Copilot discovers the account model and completes a reasoning tool loop on its exact wire"',
-  'zenmux:reasoning-replay':
-    'provider-conformance.test.ts — "ZenMux replays signed reasoning details in the streamed runtime tool loop"',
+const OVERRIDE_REGISTRY: Readonly<Record<string, OverrideBinding>> = {
+  'cohere:discovery': {
+    test: 'Cohere paginates account models and completes its native V2 tool-call loop',
+    contract: 'Cohere native V2 paginated /v1/models discovery (endpoint=chat)',
+  },
+  'fireworks-ai:discovery': {
+    test: 'Fireworks discovers exact serverless model paths and completes a two-stage tool-call loop',
+    contract: 'Fireworks account pagination discovery over /v1/accounts + per-account /models',
+  },
+  'ollama:discovery': {
+    // eslint-disable-next-line no-template-curly-in-string -- literal source text of a parametric title
+    test: 'Ollama preserves an exact ${testCase.label} through local discovery and a no-secret tool-call loop',
+    contract: 'Ollama native /api/tags discovery',
+  },
+  'github-copilot:discovery': {
+    test: GITHUB_COPILOT_OVERRIDE_TEST,
+    contract: 'GitHub Copilot subscription /models discovery (picker + endpoint gating)',
+  },
+  'github-copilot:exact-model-id': {
+    test: GITHUB_COPILOT_OVERRIDE_TEST,
+    contract: 'GitHub Copilot preserves the exact account model id on its subscription wire',
+  },
+  'github-copilot:tool-loop': {
+    test: GITHUB_COPILOT_OVERRIDE_TEST,
+    contract: 'GitHub Copilot completes a two-stage tool loop on its subscription wire',
+  },
+  'github-copilot:reasoning-replay': {
+    test: GITHUB_COPILOT_OVERRIDE_TEST,
+    contract: 'GitHub Copilot replays reasoning on its provider-specific per-model wire',
+  },
+  'zenmux:reasoning-replay': {
+    test: 'ZenMux replays signed reasoning details in the streamed runtime tool loop',
+    contract: 'Signed reasoning_details are replayed byte-for-byte, beyond a plain field rename',
+  },
 };
+
+/**
+ * The suite runs compiled from `dist/` (sibling `.js`) but can also run straight
+ * from `src/` (sibling `.ts`). Test titles survive compilation verbatim, so read
+ * whichever sibling exists, resolved relative to this test file.
+ */
+function readProviderConformanceSource(): string {
+  const errors: string[] = [];
+  for (const candidate of ['./provider-conformance.test.ts', './provider-conformance.test.js']) {
+    try {
+      return readFileSync(fileURLToPath(new URL(candidate, import.meta.url)), 'utf8');
+    } catch (error) {
+      errors.push(`${candidate}: ${(error as Error).message}`);
+    }
+  }
+  throw new Error(`provider-conformance test source not found next to the matrix suite:\n${errors.join('\n')}`);
+}
 
 const KNOWN_WIRES: ReadonlySet<ProviderContractWire> = new Set([
   'openai-chat',
@@ -122,6 +178,17 @@ describe('provider conformance matrix — gap report', () => {
       assert.ok(overrideKeys.has(key), `override registry key "${key}" has no matching override cell`);
     }
   });
+
+  test('every registered override title exists verbatim in provider-conformance.test.ts', () => {
+    const source = readProviderConformanceSource();
+    for (const [key, binding] of Object.entries(OVERRIDE_REGISTRY)) {
+      assert.ok(
+        source.includes(binding.test),
+        `override "${key}" is bound to a test title that no longer exists in provider-conformance.test.ts: `
+        + `"${binding.test}" — update the binding or restore the hand-written test`,
+      );
+    }
+  });
 });
 
 describe('provider conformance matrix — override cells reference a named hand-written test', () => {
@@ -130,7 +197,8 @@ describe('provider conformance matrix — override cells reference a named hand-
     test(`${providerType} · ${dimension} · override → ${cell.overrideKey}`, () => {
       const reference = OVERRIDE_REGISTRY[cell.overrideKey];
       assert.ok(reference, `expected a named override for ${cell.overrideKey}`);
-      assert.ok(reference.length > 0);
+      assert.ok(reference.test.length > 0, `override for ${cell.overrideKey} must name its hand-written test title`);
+      assert.ok(reference.contract.length > 0, `override for ${cell.overrideKey} must describe its contract`);
     });
   }
 });
@@ -171,27 +239,125 @@ async function runGeneratedDiscovery(
   cell: ProviderContractGeneratedCell & { discovery: NonNullable<ProviderContractGeneratedCell['discovery']> },
 ): Promise<void> {
   const sample = row.sampleModelId;
-  const { protocol, filter } = cell.discovery;
-  let requestCount = 0;
-  const server = await startJsonServer((request, response) => {
-    requestCount += 1;
-    assert.equal(request.method, 'GET', `${row.providerType} discovery must GET the model list`);
-    respondJson(response, 200, discoveryPayload(protocol, sample, filter));
-  });
-  const connection = baseConnection(row, server.url);
-  const models = await fetchProviderModels(connection, API_KEY);
-  assert.ok(requestCount >= 1, `${row.providerType} discovery must request the model list`);
-  assert.deepEqual(
-    models.map((model) => model.id),
-    [sample],
-    `${row.providerType} discovery should return exactly the scripted exact id`,
+  const discovery = cell.discovery;
+  // `array-or-data` (mistral) means the same endpoint may answer either
+  // `{data:[...]}` or a bare array; both fixtures must parse to the exact id.
+  const payloadShapes: ReadonlyArray<'data-object' | 'bare-array'> =
+    discovery.responseShape === 'array-or-data' ? ['data-object', 'bare-array'] : ['data-object'];
+  for (const shape of payloadShapes) {
+    const where = `${row.providerType} discovery (${shape} payload)`;
+    // Handler assertion failures are recorded and rethrown after the fetch so
+    // the test fails with the request-contract message instead of a generic
+    // "failed to fetch models" wrapper.
+    const handlerErrors: unknown[] = [];
+    let requestCount = 0;
+    const server = await startJsonServer((request, response) => {
+      requestCount += 1;
+      try {
+        assertDiscoveryRequest(row, discovery, request);
+      } catch (error) {
+        handlerErrors.push(error);
+      }
+      respondJson(response, 200, discoveryPayload(discovery.protocol, sample, discovery.filter, shape));
+    });
+    const connection = baseConnection(row, server.url);
+    const models = await fetchProviderModels(connection, API_KEY);
+    if (handlerErrors.length > 0) throw handlerErrors[0];
+    assert.ok(requestCount >= 1, `${where} must request the model list`);
+    assert.deepEqual(
+      models.map((model) => model.id),
+      [sample],
+      `${where} should return exactly the scripted exact id`,
+    );
+  }
+}
+
+/**
+ * Assert the discovery request against the full derived cell — path, query, and
+ * auth — mirroring `model-fetcher.ts`'s real URL/header construction:
+ *
+ *   - openai:    `{baseUrl}{path ?? '/models'}?{query}` with a Bearer credential
+ *                when the cell declares provider auth *and* the provider's
+ *                authKind actually supports an API key (lm-studio declares
+ *                `authKind: 'none'`, so its wire carries no credential).
+ *   - anthropic: `{baseUrl}/v1/models` with the `x-api-key` credential header.
+ *   - google:    `{baseUrl}/v1beta/models?key={apiKey}` — the credential rides
+ *                the `key` query parameter, never a header.
+ */
+function assertDiscoveryRequest(
+  row: ProviderContractRow,
+  discovery: ProviderContractDiscoveryPlan,
+  request: IncomingMessage,
+): void {
+  const where = `${row.providerType} discovery`;
+  assert.equal(request.method, 'GET', `${where} must GET the model list`);
+  const url = new URL(request.url ?? '', 'http://contract.test');
+
+  // Path: the declared path, or the protocol's default models path.
+  assert.equal(
+    url.pathname,
+    expectedDiscoveryPathname(discovery),
+    `${where} must request the declared models path`,
   );
+
+  // Query: exactly the declared parameters (google adds its key-query credential).
+  const expectedQuery: Record<string, string> = { ...(discovery.query ?? {}) };
+  if (discovery.protocol === 'google' && discovery.auth !== 'none') expectedQuery.key = API_KEY;
+  assert.deepEqual(
+    Object.fromEntries(url.searchParams),
+    expectedQuery,
+    `${where} must send exactly the declared query parameters`,
+  );
+
+  // Auth: public cells must carry no credential; default cells must carry the
+  // protocol's credential exactly as model-fetcher constructs it.
+  const authorization = request.headers.authorization;
+  const xApiKey = request.headers['x-api-key'];
+  const xGoogApiKey = request.headers['x-goog-api-key'];
+  if (discovery.auth === 'none') {
+    assert.equal(authorization, undefined, `${where} is public: it must not send an Authorization header`);
+    assert.equal(xApiKey, undefined, `${where} is public: it must not send an x-api-key header`);
+    assert.equal(xGoogApiKey, undefined, `${where} is public: it must not send an x-goog-api-key header`);
+    return;
+  }
+  switch (discovery.protocol) {
+    case 'openai':
+      if (providerAuthSupportsApiKey(row.providerType)) {
+        assert.equal(authorization, `Bearer ${API_KEY}`, `${where} must send its Bearer credential`);
+      } else {
+        assert.equal(authorization, undefined, `${where} has no API-key auth: it must not send Authorization`);
+      }
+      break;
+    case 'anthropic':
+      assert.equal(xApiKey, API_KEY, `${where} must send its x-api-key credential`);
+      break;
+    case 'google':
+      // Credential is the `key` query parameter asserted above; no auth header.
+      assert.equal(authorization, undefined, `${where} must carry its credential in the key query, not a header`);
+      break;
+    case 'cohere':
+      assert.fail(`${where}: cohere discovery is never generated`);
+  }
+}
+
+function expectedDiscoveryPathname(discovery: ProviderContractDiscoveryPlan): string {
+  switch (discovery.protocol) {
+    case 'anthropic':
+      return '/v1/models';
+    case 'google':
+      return '/v1beta/models';
+    default: {
+      const path = discovery.path ?? '/models';
+      return path.startsWith('/') ? path : `/${path}`;
+    }
+  }
 }
 
 function discoveryPayload(
   protocol: string,
   sample: string,
   filter: string | undefined,
+  shape: 'data-object' | 'bare-array',
 ): unknown {
   if (protocol === 'anthropic') return { data: [{ id: sample }] };
   if (protocol === 'google') return { models: [{ name: `models/${sample}` }] };
@@ -223,6 +389,7 @@ function discoveryPayload(
       ],
     };
   }
+  if (shape === 'bare-array') return [{ id: sample }];
   return { object: 'list', data: [{ id: sample }] };
 }
 
@@ -366,6 +533,10 @@ async function runOpenAiChatWire(
 async function runAnthropicMessagesWire(row: ProviderContractRow): Promise<void> {
   const sample = row.sampleModelId;
   const requestBodies: Array<Record<string, unknown>> = [];
+  // Second-turn contract violations are asserted in the handler before the
+  // final response, recorded, and rethrown after the call so the test fails
+  // with the wire-contract message instead of a destroyed-socket error.
+  const handlerErrors: unknown[] = [];
   const server = await startJsonServer(async (request, response) => {
     assert.equal(request.method, 'POST');
     assert.ok(request.url?.endsWith('/messages'), `unexpected anthropic path ${request.url}`);
@@ -383,6 +554,30 @@ async function runAnthropicMessagesWire(row: ProviderContractRow): Promise<void>
         usage: { input_tokens: 8, output_tokens: 4 },
       });
       return;
+    }
+    // Turn two must replay the tool result, keyed to the first-turn tool_use id,
+    // before the wire answers with the final text.
+    try {
+      const toolResults = (body.messages as Array<{ role: string; content: unknown }>)
+        .flatMap((message) => (Array.isArray(message.content) ? message.content as Array<Record<string, unknown>> : []))
+        .filter((block) => block.type === 'tool_result');
+      assert.equal(
+        toolResults.length,
+        1,
+        `${row.providerType} · tool-loop: turn two must replay exactly one tool_result block`,
+      );
+      assert.equal(
+        toolResults[0]?.tool_use_id,
+        'toolu_echo',
+        `${row.providerType} · tool-loop: the tool_result must reference the first-turn tool_use id`,
+      );
+      const toolResultContent = JSON.stringify(toolResults[0]?.content);
+      assert.ok(
+        toolResultContent.includes('echoed') && toolResultContent.includes('hello'),
+        `${row.providerType} · tool-loop: the tool_result must carry the echo output, got ${toolResultContent}`,
+      );
+    } catch (error) {
+      handlerErrors.push(error);
     }
     respondJson(response, 200, {
       id: 'msg_final',
@@ -403,6 +598,7 @@ async function runAnthropicMessagesWire(row: ProviderContractRow): Promise<void>
     tools: { echo: echoTool },
   });
 
+  if (handlerErrors.length > 0) throw handlerErrors[0];
   assert.equal(requestBodies.length, 2, `${row.providerType} should make two messages requests`);
   assert.deepEqual(
     requestBodies.map((body) => body.model),
@@ -421,10 +617,12 @@ async function runAnthropicMessagesWire(row: ProviderContractRow): Promise<void>
 async function runGoogleGenerateWire(row: ProviderContractRow): Promise<void> {
   const sample = row.sampleModelId;
   const requestUrls: string[] = [];
+  // See runAnthropicMessagesWire for why second-turn violations are recorded.
+  const handlerErrors: unknown[] = [];
   const server = await startJsonServer(async (request, response) => {
     assert.equal(request.method, 'POST');
     requestUrls.push(request.url ?? '');
-    await readBody(request);
+    const body = JSON.parse(await readBody(request)) as Record<string, unknown>;
     if (requestUrls.length === 1) {
       respondJson(response, 200, {
         candidates: [{
@@ -438,6 +636,31 @@ async function runGoogleGenerateWire(row: ProviderContractRow): Promise<void> {
         usageMetadata: { promptTokenCount: 8, candidatesTokenCount: 4, totalTokenCount: 12 },
       });
       return;
+    }
+    // Turn two must replay a functionResponse part for the first-turn `echo`
+    // functionCall before the wire answers with the final text.
+    try {
+      const functionResponses = (body.contents as Array<{ parts?: Array<Record<string, unknown>> }>)
+        .flatMap((content) => content.parts ?? [])
+        .map((part) => part.functionResponse as { name?: string; response?: unknown } | undefined)
+        .filter((part): part is { name?: string; response?: unknown } => part !== undefined);
+      assert.equal(
+        functionResponses.length,
+        1,
+        `${row.providerType} · tool-loop: turn two must replay exactly one functionResponse part`,
+      );
+      assert.equal(
+        functionResponses[0]?.name,
+        'echo',
+        `${row.providerType} · tool-loop: the functionResponse must correspond to the first-turn echo functionCall`,
+      );
+      const functionResponseJson = JSON.stringify(functionResponses[0]?.response);
+      assert.ok(
+        functionResponseJson.includes('echoed') && functionResponseJson.includes('hello'),
+        `${row.providerType} · tool-loop: the functionResponse must carry the echo output, got ${functionResponseJson}`,
+      );
+    } catch (error) {
+      handlerErrors.push(error);
     }
     respondJson(response, 200, {
       candidates: [{
@@ -456,6 +679,7 @@ async function runGoogleGenerateWire(row: ProviderContractRow): Promise<void> {
     tools: { echo: echoTool },
   });
 
+  if (handlerErrors.length > 0) throw handlerErrors[0];
   assert.ok(requestUrls.length >= 2, `${row.providerType} should make two generateContent requests`);
   assert.ok(
     requestUrls.every((url) => url.includes(`models/${sample}`)),
@@ -469,6 +693,8 @@ async function runGoogleGenerateWire(row: ProviderContractRow): Promise<void> {
 async function runCohereV2Wire(row: ProviderContractRow): Promise<void> {
   const sample = row.sampleModelId;
   const requestBodies: Array<Record<string, unknown>> = [];
+  // See runAnthropicMessagesWire for why second-turn violations are recorded.
+  const handlerErrors: unknown[] = [];
   const server = await startJsonServer(async (request, response) => {
     assert.equal(request.method, 'POST');
     assert.ok(request.url?.endsWith('/chat'), `unexpected cohere path ${request.url}`);
@@ -488,6 +714,29 @@ async function runCohereV2Wire(row: ProviderContractRow): Promise<void> {
       });
       return;
     }
+    // Turn two must replay the tool result message, keyed to the first-turn
+    // call id, before the wire answers with the final text.
+    try {
+      const toolMessages = (body.messages as Array<Record<string, unknown>>)
+        .filter((message) => message.role === 'tool');
+      assert.equal(
+        toolMessages.length,
+        1,
+        `${row.providerType} · tool-loop: turn two must replay exactly one tool message`,
+      );
+      assert.equal(
+        toolMessages[0]?.tool_call_id,
+        'call_echo',
+        `${row.providerType} · tool-loop: the tool message must reference the first-turn call id`,
+      );
+      const toolMessageContent = JSON.stringify(toolMessages[0]?.content);
+      assert.ok(
+        toolMessageContent.includes('echoed') && toolMessageContent.includes('hello'),
+        `${row.providerType} · tool-loop: the tool message must carry the echo output, got ${toolMessageContent}`,
+      );
+    } catch (error) {
+      handlerErrors.push(error);
+    }
     respondJson(response, 200, {
       generation_id: 'cohere-final-turn',
       finish_reason: 'COMPLETE',
@@ -503,6 +752,7 @@ async function runCohereV2Wire(row: ProviderContractRow): Promise<void> {
     tools: { echo: echoTool },
   });
 
+  if (handlerErrors.length > 0) throw handlerErrors[0];
   assert.equal(requestBodies.length, 2, `${row.providerType} should make two chat requests`);
   assert.deepEqual(
     requestBodies.map((body) => body.model),

--- a/packages/runtime/src/__tests__/provider-contract-matrix.test.ts
+++ b/packages/runtime/src/__tests__/provider-contract-matrix.test.ts
@@ -61,9 +61,9 @@ interface OverrideBinding {
    * Exact test title as it appears verbatim in the bound test source (for
    * parametric tests, the literal template text including any `${...}`
    * placeholder). The binding test below asserts the source still contains an
-   * enabled `test(` call opening with this title, so deleting, renaming, or
-   * skipping the hand-written test breaks the matrix instead of leaving a
-   * silent gap.
+   * enabled `test(` call whose complete quoted title equals this text, so
+   * deleting, renaming (even by suffix), or skipping the hand-written test
+   * breaks the matrix instead of leaving a silent gap.
    */
   test: string;
   /**
@@ -141,13 +141,18 @@ function readOverrideTestSource(file: string): string {
 }
 
 /**
- * True when the source contains an *enabled* `test(` call opening with the
- * bound title — `test('title`, `test("title`, or `` test(`title `` (the
- * backtick form covers parametric template-literal titles). `test.skip(` /
- * `test.todo(` never match because their call prefix differs.
+ * True when the source contains an *enabled* `test(` call whose complete quoted
+ * title equals the bound title — `test('title'`, `test("title"`, or
+ * `` test(`title` `` (the backtick form covers parametric template-literal
+ * titles, whose bound text includes the `${...}` placeholder verbatim).
+ * Requiring the closing quote means renaming the test — even by appending a
+ * suffix — breaks the binding. `test.skip(` / `test.todo(` never match because
+ * their call prefix differs. Known residual: this is a textual check, so a
+ * fully commented-out `test(...)` line still matches; the Phase 8 executable
+ * override binding removes that class.
  */
 function hasEnabledTestCall(source: string, title: string): boolean {
-  return ["'", '"', '`'].some((quote) => source.includes(`test(${quote}${title}`));
+  return ["'", '"', '`'].some((quote) => source.includes(`test(${quote}${title}${quote}`));
 }
 
 const KNOWN_WIRES: ReadonlySet<ProviderContractWire> = new Set([

--- a/packages/runtime/src/__tests__/provider-contract-matrix.test.ts
+++ b/packages/runtime/src/__tests__/provider-contract-matrix.test.ts
@@ -1,0 +1,568 @@
+/**
+ * Registry-driven provider conformance matrix — generative execution.
+ *
+ * This suite interprets {@link PROVIDER_CONTRACT_MATRIX_PLAN}: it does not carry
+ * a hard-coded provider list. For every (provider, dimension) cell the plan
+ * derives from the registry, one of three things happens here:
+ *
+ *   - `generated`      a parametric wire test is executed against a scripted
+ *                      local HTTP server (discovery, exact-model-id, tool-loop,
+ *                      reasoning-replay), driven entirely by the derived cell.
+ *   - `override`       the cell is asserted to have a named entry in
+ *                      {@link OVERRIDE_REGISTRY}, each pointing at the
+ *                      hand-written test in `provider-conformance.test.ts` that
+ *                      owns the provider-specific contract.
+ *   - `not-applicable` the machine-readable reason is asserted, and any reverse
+ *                      assertion (e.g. fallback discovery must not call /models)
+ *                      is executed.
+ *
+ * The gap report (`test('no contract gaps ...')`) fails loudly, listing
+ * provider + dimension + what is missing, whenever a ready provider's dimension
+ * satisfies none of the three states — this is Phase 7's gap reporting.
+ *
+ * This file is purely additive. It does not modify or replace the hand-written
+ * `provider-conformance.test.ts`; overlapping coverage is intentional.
+ */
+
+import assert from 'node:assert/strict';
+import { createServer, type IncomingMessage, type ServerResponse } from 'node:http';
+import { after, describe, test } from 'node:test';
+import type { LlmConnection } from '@maka/core';
+import {
+  PROVIDER_CONTRACT_MATRIX_PLAN,
+  listProviderContractCells,
+  type ProviderContractRow,
+  type ProviderContractGeneratedCell,
+  type ProviderContractWire,
+} from '@maka/core';
+import { generateText, stepCountIs, tool } from 'ai';
+import { z } from 'zod';
+import { fetchProviderModels } from '../model-fetcher.js';
+import { getAIModel } from '../model-factory.js';
+
+const REASONING_TEXT = 'I should call echo with the requested text.';
+const FINAL_TEXT = 'Echoed hello.';
+const API_KEY = 'contract-matrix-test-key';
+
+const plan = PROVIDER_CONTRACT_MATRIX_PLAN;
+
+const servers: Array<{ close(): Promise<void> }> = [];
+
+after(async () => {
+  await Promise.all(servers.map((server) => server.close()));
+});
+
+/**
+ * Named overrides. Each key is a plan `overrideKey` (`${providerType}:${dimension}`)
+ * and each value points at the hand-written test in `provider-conformance.test.ts`
+ * that owns the provider-specific contract the plan cannot generate. A missing
+ * key here surfaces as a contract gap.
+ */
+const OVERRIDE_REGISTRY: Readonly<Record<string, string>> = {
+  'cohere:discovery':
+    'provider-conformance.test.ts — "Cohere paginates account models and completes its native V2 tool-call loop"',
+  'fireworks-ai:discovery':
+    'provider-conformance.test.ts — "Fireworks discovers exact serverless model paths and completes a two-stage tool-call loop"',
+  'ollama:discovery':
+    'provider-conformance.test.ts — "Ollama preserves an exact ... through local discovery and a no-secret tool-call loop"',
+  'github-copilot:discovery':
+    'provider-conformance.test.ts — "GitHub Copilot discovers the account model and completes a reasoning tool loop on its exact wire"',
+  'github-copilot:exact-model-id':
+    'provider-conformance.test.ts — "GitHub Copilot discovers the account model and completes a reasoning tool loop on its exact wire"',
+  'github-copilot:tool-loop':
+    'provider-conformance.test.ts — "GitHub Copilot discovers the account model and completes a reasoning tool loop on its exact wire"',
+  'github-copilot:reasoning-replay':
+    'provider-conformance.test.ts — "GitHub Copilot discovers the account model and completes a reasoning tool loop on its exact wire"',
+  'zenmux:reasoning-replay':
+    'provider-conformance.test.ts — "ZenMux replays signed reasoning details in the streamed runtime tool loop"',
+};
+
+const KNOWN_WIRES: ReadonlySet<ProviderContractWire> = new Set([
+  'openai-chat',
+  'anthropic-messages',
+  'google-generate',
+  'cohere-v2',
+]);
+
+describe('provider conformance matrix — gap report', () => {
+  test('no contract gaps: every ready provider dimension is generated, overridden, or justified N/A', () => {
+    const gaps: string[] = [];
+    for (const { providerType, dimension, cell } of listProviderContractCells(plan)) {
+      const where = `${providerType} · ${dimension}`;
+      switch (cell.state) {
+        case 'generated':
+          if (dimension === 'discovery') {
+            if (!cell.discovery) gaps.push(`${where}: generated discovery cell is missing its derived plan`);
+          } else if (!cell.wire || !KNOWN_WIRES.has(cell.wire)) {
+            gaps.push(`${where}: generated wire cell has no executable wire (${String(cell.wire)})`);
+          }
+          break;
+        case 'override':
+          if (!OVERRIDE_REGISTRY[cell.overrideKey]) {
+            gaps.push(`${where}: no named override registered for key "${cell.overrideKey}"`);
+          }
+          break;
+        case 'not-applicable':
+          if (!cell.reason) gaps.push(`${where}: not-applicable cell is missing a machine-readable reason`);
+          break;
+        default:
+          gaps.push(`${where}: unknown cell state`);
+      }
+    }
+    assert.deepEqual(gaps, [], `provider contract gaps found:\n  ${gaps.join('\n  ')}`);
+  });
+
+  test('every registered override maps to a real override cell in the plan', () => {
+    const overrideKeys = new Set(
+      listProviderContractCells(plan)
+        .filter((entry) => entry.cell.state === 'override')
+        .map((entry) => (entry.cell.state === 'override' ? entry.cell.overrideKey : '')),
+    );
+    for (const key of Object.keys(OVERRIDE_REGISTRY)) {
+      assert.ok(overrideKeys.has(key), `override registry key "${key}" has no matching override cell`);
+    }
+  });
+});
+
+describe('provider conformance matrix — override cells reference a named hand-written test', () => {
+  for (const { providerType, dimension, cell } of listProviderContractCells(plan)) {
+    if (cell.state !== 'override') continue;
+    test(`${providerType} · ${dimension} · override → ${cell.overrideKey}`, () => {
+      const reference = OVERRIDE_REGISTRY[cell.overrideKey];
+      assert.ok(reference, `expected a named override for ${cell.overrideKey}`);
+      assert.ok(reference.length > 0);
+    });
+  }
+});
+
+describe('provider conformance matrix — discovery', () => {
+  for (const row of plan.rows) {
+    const cell = row.cells.discovery;
+    if (cell.state === 'generated' && cell.discovery) {
+      test(`${row.providerType} · discovery · generated (${cell.discovery.protocol})`, async () => {
+        await runGeneratedDiscovery(row, cell as ProviderContractGeneratedCell & { discovery: NonNullable<ProviderContractGeneratedCell['discovery']> });
+      });
+    } else if (cell.state === 'not-applicable' && cell.reverseAssertion === 'must-not-request-models-endpoint') {
+      test(`${row.providerType} · discovery · N/A (${cell.reason}) does not call /models`, async () => {
+        await assertFallbackDiscoveryMakesNoRequest(row);
+      });
+    }
+  }
+});
+
+describe('provider conformance matrix — wire (exact-model-id + tool-loop + reasoning-replay)', () => {
+  for (const row of plan.rows) {
+    const wireDims = (['exact-model-id', 'tool-loop', 'reasoning-replay'] as const)
+      .filter((dimension) => row.cells[dimension].state === 'generated');
+    if (wireDims.length === 0) continue;
+    const wire = wireOfRow(row);
+    test(`${row.providerType} · ${wire} · ${wireDims.join(' + ')}`, async () => {
+      await runGeneratedWire(row, wireDims);
+    });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Generated discovery execution
+// ---------------------------------------------------------------------------
+
+async function runGeneratedDiscovery(
+  row: ProviderContractRow,
+  cell: ProviderContractGeneratedCell & { discovery: NonNullable<ProviderContractGeneratedCell['discovery']> },
+): Promise<void> {
+  const sample = row.sampleModelId;
+  const { protocol, filter } = cell.discovery;
+  let requestCount = 0;
+  const server = await startJsonServer((request, response) => {
+    requestCount += 1;
+    assert.equal(request.method, 'GET', `${row.providerType} discovery must GET the model list`);
+    respondJson(response, 200, discoveryPayload(protocol, sample, filter));
+  });
+  const connection = baseConnection(row, server.url);
+  const models = await fetchProviderModels(connection, API_KEY);
+  assert.ok(requestCount >= 1, `${row.providerType} discovery must request the model list`);
+  assert.deepEqual(
+    models.map((model) => model.id),
+    [sample],
+    `${row.providerType} discovery should return exactly the scripted exact id`,
+  );
+}
+
+function discoveryPayload(
+  protocol: string,
+  sample: string,
+  filter: string | undefined,
+): unknown {
+  if (protocol === 'anthropic') return { data: [{ id: sample }] };
+  if (protocol === 'google') return { models: [{ name: `models/${sample}` }] };
+  // openai protocol — shape the survivor + a decoy the filter must drop.
+  if (filter === 'tool-capable') {
+    return {
+      object: 'list',
+      data: [
+        { id: sample, providers: [{ status: 'live', supports_tools: true }] },
+        { id: 'contract-decoy-no-tools', providers: [{ status: 'live', supports_tools: false }] },
+      ],
+    };
+  }
+  if (filter === 'language-models') {
+    return {
+      object: 'list',
+      data: [
+        { id: sample, type: 'language' },
+        { id: 'contract-decoy-embedding', type: 'embedding' },
+      ],
+    };
+  }
+  if (filter === 'fallback-models') {
+    return {
+      object: 'list',
+      data: [
+        { id: sample },
+        { id: 'contract-decoy-not-in-fallback' },
+      ],
+    };
+  }
+  return { object: 'list', data: [{ id: sample }] };
+}
+
+async function assertFallbackDiscoveryMakesNoRequest(row: ProviderContractRow): Promise<void> {
+  let requestCount = 0;
+  const server = await startJsonServer((_request, response) => {
+    requestCount += 1;
+    respondJson(response, 500, { error: 'fallback discovery must not reach the network' });
+  });
+  const connection = baseConnection(row, server.url);
+  const models = await fetchProviderModels(connection, API_KEY);
+  assert.equal(requestCount, 0, `${row.providerType} fallback discovery must not request any endpoint`);
+  assert.ok(models.length > 0, `${row.providerType} fallback discovery should return the static snapshot`);
+  assert.ok(
+    models.some((model) => model.id === row.sampleModelId),
+    `${row.providerType} fallback snapshot should include its sample model`,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Generated wire execution
+// ---------------------------------------------------------------------------
+
+function wireOfRow(row: ProviderContractRow): ProviderContractWire {
+  for (const dimension of ['tool-loop', 'exact-model-id', 'reasoning-replay'] as const) {
+    const cell = row.cells[dimension];
+    if (cell.state === 'generated' && cell.wire) return cell.wire;
+  }
+  throw new Error(`${row.providerType} has no generated wire cell`);
+}
+
+async function runGeneratedWire(
+  row: ProviderContractRow,
+  wireDims: ReadonlyArray<'exact-model-id' | 'tool-loop' | 'reasoning-replay'>,
+): Promise<void> {
+  const wire = wireOfRow(row);
+  const wantsReasoning = wireDims.includes('reasoning-replay');
+  const replayCell = row.cells['reasoning-replay'];
+  const replayField = replayCell.state === 'generated' && replayCell.reasoningReplay
+    ? replayCell.reasoningReplay.replayField
+    : undefined;
+  switch (wire) {
+    case 'openai-chat':
+      return runOpenAiChatWire(row, wantsReasoning, replayField);
+    case 'anthropic-messages':
+      return runAnthropicMessagesWire(row);
+    case 'google-generate':
+      return runGoogleGenerateWire(row);
+    case 'cohere-v2':
+      return runCohereV2Wire(row);
+  }
+}
+
+const echoTool = tool({
+  description: 'Echo text',
+  inputSchema: z.object({ text: z.string() }),
+  execute: async ({ text }) => ({ echoed: text }),
+});
+
+async function runOpenAiChatWire(
+  row: ProviderContractRow,
+  wantsReasoning: boolean,
+  replayField: 'reasoning' | 'reasoning_content' | undefined,
+): Promise<void> {
+  const sample = row.sampleModelId;
+  const requestBodies: Array<Record<string, unknown>> = [];
+  const server = await startJsonServer(async (request, response) => {
+    assert.equal(request.method, 'POST');
+    const body = JSON.parse(await readBody(request)) as Record<string, unknown>;
+    requestBodies.push(body);
+    if (requestBodies.length === 1) {
+      respondJson(response, 200, {
+        id: 'chatcmpl-tool',
+        object: 'chat.completion',
+        created: 1,
+        model: sample,
+        choices: [{
+          index: 0,
+          message: {
+            role: 'assistant',
+            content: null,
+            ...(wantsReasoning ? { reasoning_content: REASONING_TEXT } : {}),
+            tool_calls: [{
+              id: 'call_echo',
+              type: 'function',
+              function: { name: 'echo', arguments: '{"text":"hello"}' },
+            }],
+          },
+          finish_reason: 'tool_calls',
+        }],
+        usage: { prompt_tokens: 8, completion_tokens: 4, total_tokens: 12 },
+      });
+      return;
+    }
+    respondJson(response, 200, {
+      id: 'chatcmpl-final',
+      object: 'chat.completion',
+      created: 2,
+      model: sample,
+      choices: [{ index: 0, message: { role: 'assistant', content: FINAL_TEXT }, finish_reason: 'stop' }],
+      usage: { prompt_tokens: 12, completion_tokens: 3, total_tokens: 15 },
+    });
+  });
+  const connection = baseConnection(row, server.url);
+  const result = await generateText({
+    model: getAIModel({ connection, apiKey: API_KEY, modelId: sample }),
+    prompt: 'Call echo with hello.',
+    stopWhen: stepCountIs(2),
+    tools: { echo: echoTool },
+  });
+
+  assert.equal(requestBodies.length, 2, `${row.providerType} should make two chat requests`);
+  assert.deepEqual(
+    requestBodies.map((body) => body.model),
+    [sample, sample],
+    `${row.providerType} must send the exact model id on both requests`,
+  );
+  assert.deepEqual(
+    (requestBodies[0]?.tools as Array<{ function: { name: string } }>).map((entry) => entry.function.name),
+    ['echo'],
+  );
+  assert.deepEqual(
+    (requestBodies[1]?.messages as Array<{ role: string; content: string }>).find(({ role }) => role === 'tool'),
+    { role: 'tool', content: '{"echoed":"hello"}', tool_call_id: 'call_echo' },
+    `${row.providerType} must replay the tool result`,
+  );
+  assert.deepEqual(result.steps[0]?.toolResults[0]?.output, { echoed: 'hello' });
+  assert.equal(result.text, FINAL_TEXT);
+  if (wantsReasoning && replayField) {
+    assert.equal(result.steps[0]?.reasoningText, REASONING_TEXT, `${row.providerType} should surface reasoning`);
+    const assistant = (requestBodies[1]?.messages as Array<Record<string, unknown>>).find(({ role }) => role === 'assistant');
+    assert.ok(assistant, `${row.providerType} must replay the assistant turn`);
+    assert.equal(
+      assistant?.[replayField],
+      REASONING_TEXT,
+      `${row.providerType} must replay reasoning in the "${replayField}" field`,
+    );
+  }
+}
+
+async function runAnthropicMessagesWire(row: ProviderContractRow): Promise<void> {
+  const sample = row.sampleModelId;
+  const requestBodies: Array<Record<string, unknown>> = [];
+  const server = await startJsonServer(async (request, response) => {
+    assert.equal(request.method, 'POST');
+    assert.ok(request.url?.endsWith('/messages'), `unexpected anthropic path ${request.url}`);
+    const body = JSON.parse(await readBody(request)) as Record<string, unknown>;
+    requestBodies.push(body);
+    if (requestBodies.length === 1) {
+      respondJson(response, 200, {
+        id: 'msg_tool',
+        type: 'message',
+        role: 'assistant',
+        model: sample,
+        content: [{ type: 'tool_use', id: 'toolu_echo', name: 'echo', input: { text: 'hello' } }],
+        stop_reason: 'tool_use',
+        stop_sequence: null,
+        usage: { input_tokens: 8, output_tokens: 4 },
+      });
+      return;
+    }
+    respondJson(response, 200, {
+      id: 'msg_final',
+      type: 'message',
+      role: 'assistant',
+      model: sample,
+      content: [{ type: 'text', text: FINAL_TEXT }],
+      stop_reason: 'end_turn',
+      stop_sequence: null,
+      usage: { input_tokens: 12, output_tokens: 3 },
+    });
+  });
+  const connection = baseConnection(row, server.url);
+  const result = await generateText({
+    model: getAIModel({ connection, apiKey: API_KEY, modelId: sample }),
+    prompt: 'Call echo with hello.',
+    stopWhen: stepCountIs(2),
+    tools: { echo: echoTool },
+  });
+
+  assert.equal(requestBodies.length, 2, `${row.providerType} should make two messages requests`);
+  assert.deepEqual(
+    requestBodies.map((body) => body.model),
+    [sample, sample],
+    `${row.providerType} must send the exact model id on both requests`,
+  );
+  assert.deepEqual(
+    (requestBodies[0]?.tools as Array<{ name: string }>).map((entry) => entry.name),
+    ['echo'],
+  );
+  assert.equal(result.steps[0]?.toolCalls[0]?.toolName, 'echo');
+  assert.deepEqual(result.steps[0]?.toolResults[0]?.output, { echoed: 'hello' });
+  assert.equal(result.text, FINAL_TEXT);
+}
+
+async function runGoogleGenerateWire(row: ProviderContractRow): Promise<void> {
+  const sample = row.sampleModelId;
+  const requestUrls: string[] = [];
+  const server = await startJsonServer(async (request, response) => {
+    assert.equal(request.method, 'POST');
+    requestUrls.push(request.url ?? '');
+    await readBody(request);
+    if (requestUrls.length === 1) {
+      respondJson(response, 200, {
+        candidates: [{
+          index: 0,
+          content: {
+            role: 'model',
+            parts: [{ functionCall: { name: 'echo', args: { text: 'hello' } } }],
+          },
+          finishReason: 'STOP',
+        }],
+        usageMetadata: { promptTokenCount: 8, candidatesTokenCount: 4, totalTokenCount: 12 },
+      });
+      return;
+    }
+    respondJson(response, 200, {
+      candidates: [{
+        index: 0,
+        content: { role: 'model', parts: [{ text: FINAL_TEXT }] },
+        finishReason: 'STOP',
+      }],
+      usageMetadata: { promptTokenCount: 12, candidatesTokenCount: 3, totalTokenCount: 15 },
+    });
+  });
+  const connection = baseConnection(row, server.url);
+  const result = await generateText({
+    model: getAIModel({ connection, apiKey: API_KEY, modelId: sample }),
+    prompt: 'Call echo with hello.',
+    stopWhen: stepCountIs(2),
+    tools: { echo: echoTool },
+  });
+
+  assert.ok(requestUrls.length >= 2, `${row.providerType} should make two generateContent requests`);
+  assert.ok(
+    requestUrls.every((url) => url.includes(`models/${sample}`)),
+    `${row.providerType} must send the exact model id in the generateContent path`,
+  );
+  assert.equal(result.steps[0]?.toolCalls[0]?.toolName, 'echo');
+  assert.deepEqual(result.steps[0]?.toolResults[0]?.output, { echoed: 'hello' });
+  assert.equal(result.text, FINAL_TEXT);
+}
+
+async function runCohereV2Wire(row: ProviderContractRow): Promise<void> {
+  const sample = row.sampleModelId;
+  const requestBodies: Array<Record<string, unknown>> = [];
+  const server = await startJsonServer(async (request, response) => {
+    assert.equal(request.method, 'POST');
+    assert.ok(request.url?.endsWith('/chat'), `unexpected cohere path ${request.url}`);
+    const body = JSON.parse(await readBody(request)) as Record<string, unknown>;
+    requestBodies.push(body);
+    if (requestBodies.length === 1) {
+      respondJson(response, 200, {
+        generation_id: 'cohere-tool-turn',
+        finish_reason: 'TOOL_CALL',
+        message: {
+          role: 'assistant',
+          content: [],
+          tool_plan: 'Call echo.',
+          tool_calls: [{ id: 'call_echo', type: 'function', function: { name: 'echo', arguments: '{"text":"hello"}' } }],
+        },
+        usage: { billed_units: { input_tokens: 8, output_tokens: 4 }, tokens: { input_tokens: 8, output_tokens: 4 } },
+      });
+      return;
+    }
+    respondJson(response, 200, {
+      generation_id: 'cohere-final-turn',
+      finish_reason: 'COMPLETE',
+      message: { role: 'assistant', content: [{ type: 'text', text: FINAL_TEXT }] },
+      usage: { billed_units: { input_tokens: 12, output_tokens: 3 }, tokens: { input_tokens: 12, output_tokens: 3 } },
+    });
+  });
+  const connection = baseConnection(row, `${server.url}/v2`);
+  const result = await generateText({
+    model: getAIModel({ connection, apiKey: API_KEY, modelId: sample }),
+    prompt: 'Call echo with hello.',
+    stopWhen: stepCountIs(2),
+    tools: { echo: echoTool },
+  });
+
+  assert.equal(requestBodies.length, 2, `${row.providerType} should make two chat requests`);
+  assert.deepEqual(
+    requestBodies.map((body) => body.model),
+    [sample, sample],
+    `${row.providerType} must send the exact model id on both requests`,
+  );
+  assert.equal(result.steps[0]?.toolCalls[0]?.toolName, 'echo');
+  assert.deepEqual(result.steps[0]?.toolResults[0]?.output, { echoed: 'hello' });
+  assert.equal(result.text, FINAL_TEXT);
+}
+
+// ---------------------------------------------------------------------------
+// Shared infrastructure
+// ---------------------------------------------------------------------------
+
+function baseConnection(row: ProviderContractRow, baseUrl: string): LlmConnection {
+  return {
+    slug: `${row.providerType}-contract`,
+    name: row.providerType,
+    providerType: row.providerType,
+    baseUrl,
+    defaultModel: row.sampleModelId,
+    enabled: true,
+    createdAt: 1,
+    updatedAt: 1,
+  };
+}
+
+async function startJsonServer(
+  handler: (request: IncomingMessage, response: ServerResponse) => void | Promise<void>,
+): Promise<{ url: string; close(): Promise<void> }> {
+  const server = createServer((request, response) => {
+    void Promise.resolve(handler(request, response)).catch((error) => {
+      response.destroy(error as Error);
+    });
+  });
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const address = server.address();
+  assert.ok(address && typeof address === 'object');
+  const control = {
+    url: `http://127.0.0.1:${address.port}`,
+    close: () => new Promise<void>((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    }),
+  };
+  servers.push(control);
+  return control;
+}
+
+function readBody(request: IncomingMessage): Promise<string> {
+  return new Promise((resolve, reject) => {
+    let body = '';
+    request.setEncoding('utf8');
+    request.on('data', (chunk) => { body += chunk; });
+    request.on('end', () => resolve(body));
+    request.on('error', reject);
+  });
+}
+
+function respondJson(response: ServerResponse, status: number, body: unknown): void {
+  response.writeHead(status, { 'content-type': 'application/json' });
+  response.end(JSON.stringify(body));
+}

--- a/packages/runtime/src/__tests__/provider-contract-matrix.test.ts
+++ b/packages/runtime/src/__tests__/provider-contract-matrix.test.ts
@@ -10,8 +10,8 @@
  *                      reasoning-replay), driven entirely by the derived cell.
  *   - `override`       the cell is asserted to have a named entry in
  *                      {@link OVERRIDE_REGISTRY}, each pointing at the
- *                      hand-written test in `provider-conformance.test.ts` that
- *                      owns the provider-specific contract.
+ *                      hand-written test (in `provider-conformance.test.ts` by
+ *                      default) that owns the provider-specific contract.
  *   - `not-applicable` the machine-readable reason is asserted, and any reverse
  *                      assertion (e.g. fallback discovery must not call /models)
  *                      is executed.
@@ -58,26 +58,33 @@ after(async () => {
 /** A named override binding a plan cell to a hand-written conformance test. */
 interface OverrideBinding {
   /**
-   * Exact test title as it appears verbatim in the `provider-conformance.test.ts`
-   * source (for parametric tests, the literal template text including any
-   * `${...}` placeholder). The binding test below asserts this string still
-   * exists in the source, so deleting or renaming the hand-written test breaks
-   * the matrix instead of leaving a silent gap.
+   * Exact test title as it appears verbatim in the bound test source (for
+   * parametric tests, the literal template text including any `${...}`
+   * placeholder). The binding test below asserts the source still contains an
+   * enabled `test(` call opening with this title, so deleting, renaming, or
+   * skipping the hand-written test breaks the matrix instead of leaving a
+   * silent gap.
    */
   test: string;
+  /**
+   * Source file (sibling of this suite) that owns the bound test.
+   * Defaults to {@link DEFAULT_OVERRIDE_TEST_FILE}.
+   */
+  file?: string;
   /** Human-readable statement of the provider-specific contract the override owns. */
   contract: string;
 }
+
+const DEFAULT_OVERRIDE_TEST_FILE = 'provider-conformance.test.ts';
 
 const GITHUB_COPILOT_OVERRIDE_TEST =
   'GitHub Copilot discovers the account model and completes a reasoning tool loop on its exact wire';
 
 /**
  * Named overrides. Each key is a plan `overrideKey` (`${providerType}:${dimension}`)
- * and each value binds the hand-written test in `provider-conformance.test.ts`
- * that owns the provider-specific contract the plan cannot generate. A missing
- * key here surfaces as a contract gap; a stale `test` title fails the source
- * binding test.
+ * and each value binds the hand-written test that owns the provider-specific
+ * contract the plan cannot generate. A missing key here surfaces as a contract
+ * gap; a stale or disabled `test` title fails the source binding test.
  */
 const OVERRIDE_REGISTRY: Readonly<Record<string, OverrideBinding>> = {
   'cohere:discovery': {
@@ -94,7 +101,8 @@ const OVERRIDE_REGISTRY: Readonly<Record<string, OverrideBinding>> = {
     contract: 'Ollama native /api/tags discovery',
   },
   'github-copilot:discovery': {
-    test: GITHUB_COPILOT_OVERRIDE_TEST,
+    test: 'GitHub Copilot discovers only account-enabled tool models and preserves each exact endpoint wire',
+    file: 'model-fetcher.test.ts',
     contract: 'GitHub Copilot subscription /models discovery (picker + endpoint gating)',
   },
   'github-copilot:exact-model-id': {
@@ -120,16 +128,26 @@ const OVERRIDE_REGISTRY: Readonly<Record<string, OverrideBinding>> = {
  * from `src/` (sibling `.ts`). Test titles survive compilation verbatim, so read
  * whichever sibling exists, resolved relative to this test file.
  */
-function readProviderConformanceSource(): string {
+function readOverrideTestSource(file: string): string {
   const errors: string[] = [];
-  for (const candidate of ['./provider-conformance.test.ts', './provider-conformance.test.js']) {
+  for (const candidate of [`./${file}`, `./${file.replace(/\.ts$/, '.js')}`]) {
     try {
       return readFileSync(fileURLToPath(new URL(candidate, import.meta.url)), 'utf8');
     } catch (error) {
       errors.push(`${candidate}: ${(error as Error).message}`);
     }
   }
-  throw new Error(`provider-conformance test source not found next to the matrix suite:\n${errors.join('\n')}`);
+  throw new Error(`override test source "${file}" not found next to the matrix suite:\n${errors.join('\n')}`);
+}
+
+/**
+ * True when the source contains an *enabled* `test(` call opening with the
+ * bound title — `test('title`, `test("title`, or `` test(`title `` (the
+ * backtick form covers parametric template-literal titles). `test.skip(` /
+ * `test.todo(` never match because their call prefix differs.
+ */
+function hasEnabledTestCall(source: string, title: string): boolean {
+  return ["'", '"', '`'].some((quote) => source.includes(`test(${quote}${title}`));
 }
 
 const KNOWN_WIRES: ReadonlySet<ProviderContractWire> = new Set([
@@ -178,13 +196,23 @@ describe('provider conformance matrix — gap report', () => {
     }
   });
 
-  test('every registered override title exists verbatim in provider-conformance.test.ts', () => {
-    const source = readProviderConformanceSource();
+  test('every registered override title is an enabled test call in its bound source file', () => {
+    const sources = new Map<string, string>();
     for (const [key, binding] of Object.entries(OVERRIDE_REGISTRY)) {
-      assert.ok(
-        source.includes(binding.test),
-        `override "${key}" is bound to a test title that no longer exists in provider-conformance.test.ts: `
-        + `"${binding.test}" — update the binding or restore the hand-written test`,
+      const file = binding.file ?? DEFAULT_OVERRIDE_TEST_FILE;
+      let source = sources.get(file);
+      if (source === undefined) {
+        source = readOverrideTestSource(file);
+        sources.set(file, source);
+      }
+      if (hasEnabledTestCall(source, binding.test)) continue;
+      assert.fail(
+        source.includes(binding.test)
+          ? `override "${key}": the bound title exists in ${file} but is not an enabled test call `
+            + `(is it test.skip/test.todo, or referenced outside a test(...)?): "${binding.test}" `
+            + '— re-enable the hand-written test or update the binding'
+          : `override "${key}" is bound to a test title that no longer exists in ${file}: `
+            + `"${binding.test}" — update the binding or restore the hand-written test`,
       );
     }
   });


### PR DESCRIPTION
## Summary

Refs #860 (Phase 7: contract foundation; the issue stays open).

Provider conformance today is hand-enumerated per provider, so ready providers can silently lack coverage (anthropic, openai, google, deepseek and others have no cell in `provider-conformance.test.ts`) and every new provider must remember to add its own. This PR makes conformance an interpretation of the registry declarations instead:

- A new pure module `packages/core/src/provider-contract-matrix.ts` derives a matrix plan from `providerRegistry`: 42 rows (every `status === 'ready'` entry with a wired runtime adapter) × 4 dimensions (discovery, exact-model-id, tool-loop, reasoning-replay). Each cell resolves to exactly one of `generated` (145: expectations recoverable from `protocol` / `runtimeAdapter` / `modelDiscovery`), `override` (8: provider-specific contracts owned by named hand-written tests under stable `provider:dimension` keys), or `not-applicable` (15: machine-readable reasons; `fallback`-discovery providers still execute a reverse assertion that `/models` is never requested).
- A new runtime suite executes every generated cell against scripted local HTTP servers (openai-chat ×34, anthropic-messages ×5, google-generate ×1, cohere-v2 ×1) and fails CI when a ready provider's applicable dimension has neither a generated cell nor a registered override, naming the provider id and missing dimension. Future ready providers enter the matrix by declaration alone.

The row set is intentionally not `READY_PROVIDER_TYPES`: its membership is "has a `readyOrder`", which would silently drop `github-copilot`.

Per the Phase 7 constraints in #860 the change is additive only: no runtime behavior, existing suite, `READY_PROVIDER_TYPES` consumer, or compatibility path changes. Overlap with the hand-written `provider-conformance.test.ts` is intentional; consolidation belongs to Phase 8.

## Verification

- `@maka/core`: 968/968 pass, typecheck clean (includes the new 19-test plan-derivation suite).
- `@maka/runtime`: 1691 pass / 0 fail, 7 pre-existing skips, typecheck clean (includes the new 89-test generated-conformance suite).
- Both run after rebasing onto latest `main`.
- Not run locally: Desktop E2E (deferred to the CI gate per #860); no desktop surface is touched.
- All coverage is deterministic against scripted local servers; no secrets, credentials, or raw provider responses.

## Review focus

`sampleModelIdFor` knowingly duplicates the runtime's `/^gpt-5/i` Responses-routing fact (commented at the source). Lifting it into an `apiProtocol` declaration is deferred to a follow-up PR: the regex is an open-world pattern (a newly discovered `gpt-5.x` id still routes to Responses) while `apiProtocol` is declared per exact model id today, so a naive lift would regress routing for newly discovered models. The follow-up needs a pattern-level declaration seam; both duplication sites disappear with it.
