### PR TITLE
test(headless): isolate host environment

### DIFF
--- a/packages/headless/src/__tests__/harbor-cell.test.ts
+++ b/packages/headless/src/__tests__/harbor-cell.test.ts
@@ -2427,10 +2427,7 @@ setTimeout(() => {
     const missing = resolveHarborCellAiSdkEnv({
       provider: 'ollama-cloud',
       model: 'qwen3.5:397b',
-      env: {
-        OPENAI_API_KEY: 'must-not-cross-provider-boundary',
-        MAKA_CREDENTIALS_PATH: join(tmpdir(), 'maka-headless-ollama-cloud-missing-credentials.json'),
-      },
+      env: { OPENAI_API_KEY: 'must-not-cross-provider-boundary' },
       ts: 1,
     });
     assert.equal(missing.apiKey, '');

--- a/scripts/run-headless-tests.mjs
+++ b/scripts/run-headless-tests.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 /**
- * Run the headless Node test suite without inheriting machine-level Git config.
+ * Run the headless Node test suite without inheriting user config or credentials.
  *
  * Usage:
  *   node scripts/run-headless-tests.mjs
@@ -20,21 +20,37 @@ const testPattern = 'dist/**/*.test.js';
 
 const usage = `Usage: node scripts/run-headless-tests.mjs
 
-Runs packages/headless tests with an isolated, empty global Git config.
+Runs packages/headless tests with isolated user config, credentials, proxies, and Git config.
 `;
+
+const sensitiveEnvName = /(?:^|_)(?:API_KEY|ACCESS_KEY|PRIVATE_KEY|TOKEN|SECRET|PASSWORD|CREDENTIALS?)(?:_|$)/i;
+const proxyEnvName = /^(?:HTTP_PROXY|HTTPS_PROXY|ALL_PROXY|NO_PROXY)$/i;
 
 export function runHeadlessTests(options = {}) {
   const cwd = options.cwd ?? headlessDir;
   const spawn = options.spawnSync ?? spawnSync;
-  const tempDir = mkdtempSync(join(tmpdir(), 'maka-headless-git-config-'));
+  const inheritedEnv = options.env ?? process.env;
+  const tempDir = mkdtempSync(join(tmpdir(), 'maka-headless-test-env-'));
+  const credentialsPath = join(tempDir, 'credentials.json');
   const globalConfigPath = join(tempDir, 'gitconfig');
-  writeFileSync(globalConfigPath, '', { encoding: 'utf8', mode: 0o600 });
 
   try {
+    writeFileSync(credentialsPath, '{"version":1,"values":{}}\n', { encoding: 'utf8', mode: 0o600 });
+    writeFileSync(globalConfigPath, '', { encoding: 'utf8', mode: 0o600 });
     const result = spawn(process.execPath, ['--test', testPattern], {
       cwd,
       env: {
-        ...process.env,
+        ...Object.fromEntries(Object.entries(inheritedEnv).filter(
+          ([name]) => !sensitiveEnvName.test(name) && !proxyEnvName.test(name),
+        )),
+        HOME: tempDir,
+        USERPROFILE: tempDir,
+        XDG_CONFIG_HOME: join(tempDir, 'config'),
+        XDG_DATA_HOME: join(tempDir, 'data'),
+        XDG_STATE_HOME: join(tempDir, 'state'),
+        XDG_CACHE_HOME: join(tempDir, 'cache'),
+        APPDATA: join(tempDir, 'appdata'),
+        MAKA_CREDENTIALS_PATH: credentialsPath,
         GIT_CONFIG_GLOBAL: globalConfigPath,
         GIT_CONFIG_NOSYSTEM: '1',
       },

--- a/scripts/run-headless-tests.test.mjs
+++ b/scripts/run-headless-tests.test.mjs
@@ -1,20 +1,81 @@
 import assert from 'node:assert/strict';
-import { existsSync, readFileSync } from 'node:fs';
-import { resolve } from 'node:path';
+import { existsSync, readFileSync, statSync } from 'node:fs';
+import { dirname, relative, resolve } from 'node:path';
 import { test } from 'node:test';
 import { runHeadlessTests } from './run-headless-tests.mjs';
 
-test('runHeadlessTests isolates Git config and removes its temporary file', () => {
+test('runHeadlessTests isolates user state and removes its temporary files', () => {
   const cwd = resolve('packages/headless');
+  let credentialsPath;
   let globalConfigPath;
 
   const status = runHeadlessTests({
     cwd,
+    env: {
+      PATH: '/test/bin',
+      LANG: 'en_US.UTF-8',
+      CI: 'true',
+      NORMAL_VALUE: 'kept',
+      TOKENIZER_PATH: '/host/tokenizer',
+      HOME: '/host/home',
+      USERPROFILE: '/host/profile',
+      XDG_CONFIG_HOME: '/host/config',
+      XDG_DATA_HOME: '/host/data',
+      XDG_STATE_HOME: '/host/state',
+      XDG_CACHE_HOME: '/host/cache',
+      APPDATA: '/host/appdata',
+      GIT_CONFIG_GLOBAL: '/host/gitconfig',
+      GIT_CONFIG_NOSYSTEM: '0',
+      GROQ_API_KEY: 'secret',
+      huggingface_token: 'secret',
+      AWS_SECRET_ACCESS_KEY: 'secret',
+      SSH_PRIVATE_KEY_FILE: '/host/private-key',
+      MAKA_CREDENTIALS_PATH: '/host/credentials.json',
+      HTTP_PROXY: 'http://host-proxy',
+      https_proxy: 'http://host-proxy',
+      All_Proxy: 'http://host-proxy',
+      no_proxy: 'localhost',
+    },
     spawnSync(command, args, options) {
       assert.equal(command, process.execPath);
       assert.deepEqual(args, ['--test', 'dist/**/*.test.js']);
       assert.equal(options.cwd, cwd);
       assert.equal(options.stdio, 'inherit');
+      assert.equal(options.env.PATH, '/test/bin');
+      assert.equal(options.env.LANG, 'en_US.UTF-8');
+      assert.equal(options.env.CI, 'true');
+      assert.equal(options.env.NORMAL_VALUE, 'kept');
+      assert.equal(options.env.TOKENIZER_PATH, '/host/tokenizer');
+      for (const name of [
+        'GROQ_API_KEY',
+        'huggingface_token',
+        'AWS_SECRET_ACCESS_KEY',
+        'SSH_PRIVATE_KEY_FILE',
+        'HTTP_PROXY',
+        'https_proxy',
+        'All_Proxy',
+        'no_proxy',
+      ]) {
+        assert.equal(options.env[name], undefined);
+      }
+
+      const tempDir = options.env.HOME;
+      assert.equal(options.env.USERPROFILE, tempDir);
+      for (const name of [
+        'XDG_CONFIG_HOME',
+        'XDG_DATA_HOME',
+        'XDG_STATE_HOME',
+        'XDG_CACHE_HOME',
+        'APPDATA',
+        'MAKA_CREDENTIALS_PATH',
+        'GIT_CONFIG_GLOBAL',
+      ]) {
+        assert.equal(relative(tempDir, options.env[name]).startsWith('..'), false);
+      }
+
+      credentialsPath = options.env.MAKA_CREDENTIALS_PATH;
+      assert.equal(readFileSync(credentialsPath, 'utf8'), '{"version":1,"values":{}}\n');
+      assert.equal(statSync(credentialsPath).mode & 0o777, 0o600);
       assert.equal(options.env.GIT_CONFIG_NOSYSTEM, '1');
       globalConfigPath = options.env.GIT_CONFIG_GLOBAL;
       assert.equal(readFileSync(globalConfigPath, 'utf8'), '');
@@ -23,6 +84,8 @@ test('runHeadlessTests isolates Git config and removes its temporary file', () =
   });
 
   assert.equal(status, 0);
+  assert.equal(existsSync(dirname(credentialsPath)), false);
+  assert.equal(existsSync(credentialsPath), false);
   assert.equal(existsSync(globalConfigPath), false);
 });
 


### PR DESCRIPTION
## Summary

While adding providers for Refs #860, we found that Headless missing-credential tests could inherit real API keys and stored credentials from the developer's machine. This made the tests depend on host state and risked sending requests with real credentials.

- Make the Headless test runner replace `HOME`, `USERPROFILE`, XDG paths, `APPDATA`, credentials, proxies, and Git config with temporary test-owned state.
- Remove host variables whose names contain credential-related segments such as `API_KEY`, `TOKEN`, `SECRET`, or `PASSWORD`, while preserving ordinary values such as `PATH`, locale, and `CI`.
- Provide a valid empty `credentials.json` with `0600` permissions and clean it up with the rest of the temporary environment.
- Remove the Ollama Cloud case-level credentials-path workaround. Tests that explicitly exercise stored credentials still use their own fixtures.

This follows OpenCode's runner-owned isolation model. Its [test preload](https://github.com/anomalyco/opencode/blob/cb8be9ba1217c2e7a2b93cf513eb21b41a7f5365/packages/opencode/test/preload.ts) assigns temporary XDG and test-home paths and clears provider credentials. Its [CLI subprocess helper](https://github.com/anomalyco/opencode/blob/cb8be9ba1217c2e7a2b93cf513eb21b41a7f5365/packages/opencode/test/lib/cli-process.ts) passes the isolated home, XDG paths, and empty auth state to real child processes. Maka uses the same boundary but filters sensitive environment variable names by segment instead of maintaining a provider list.

## Verification

- `npm run test:scripts` — 82 passed, 0 failed.
- `npm --workspace @maka/headless test` with dummy Groq, DeepInfra, Hugging Face, GitHub credentials and proxy variables — 948 passed, 0 failed, 1 skipped.
- `npm run typecheck` — passed.
- `npm test` — passed.
- `git diff --check` — passed.
