### PR TITLE
feat(runtime): enforce one-shot Bash sandbox permissions

### DIFF
--- a/packages/runtime/src/__tests__/additional-permissions.test.ts
+++ b/packages/runtime/src/__tests__/additional-permissions.test.ts
@@ -325,6 +325,7 @@ describe('runtime additional permission planning', () => {
         cwd: fixture.workspace,
         mode: 'execute',
         command: `printf blocked > ${join(fixture.outside, 'file.txt')}`,
+        args: { command: `printf blocked > ${join(fixture.outside, 'file.txt')}` },
         context,
       }), { kind: 'not_required' });
 
@@ -342,6 +343,10 @@ describe('runtime additional permission planning', () => {
         cwd: fixture.workspace,
         mode: 'execute',
         command: `printf ok > ${join(fixture.outside, 'file.txt')}`,
+        args: {
+          command: `printf ok > ${join(fixture.outside, 'file.txt')}`,
+          sandbox_permissions: declaration,
+        },
         context,
       });
       assert.equal(plan.kind, 'request');

--- a/packages/runtime/src/__tests__/builtin-tools.test.ts
+++ b/packages/runtime/src/__tests__/builtin-tools.test.ts
@@ -1,16 +1,21 @@
 import { describe, test } from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdir, mkdtemp, readFile, symlink, writeFile } from 'node:fs/promises';
+import { mkdir, mkdtemp, readFile, realpath, rm, symlink, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { zodSchema } from 'ai';
 import { z } from 'zod';
 import { SHELL_RUN_ID_MAX_CHARS } from '@maka/core';
-import { createWorkspaceWritePermissionProfile } from '@maka/core/permission-profile';
+import {
+  createWorkspaceWritePermissionProfile,
+  type PermissionProfile,
+} from '@maka/core/permission-profile';
 import { expect } from '../test-helpers.js';
 import { buildBuiltinTools } from '../builtin-tools.js';
+import { assertAdditionalPermissionProposal } from '../additional-permissions.js';
 import { SandboxManager } from '../sandbox/sandbox-manager.js';
 import { LinuxBubblewrapBackend } from '../sandbox/linux-sandbox.js';
+import { MacosSeatbeltBackend } from '../sandbox/macos-seatbelt.js';
 import type { ShellRunLauncher } from '../shell-tools.js';
 import {
   MAX_SHELL_RUN_RESOURCE_REF_CHARS,
@@ -115,6 +120,21 @@ describe('builtin Bash description declares the executing shell', () => {
 });
 
 describe('builtin Bash streaming output', () => {
+  test('requires a sandbox manager before enabling Bash additional permissions', () => {
+    assert.throws(
+      () => buildBuiltinTools({ enableBashAdditionalPermissions: true }),
+      /require a sandbox manager/,
+    );
+    assert.throws(
+      () => buildBuiltinTools({
+        sandboxManager: availableLinuxManager(),
+        sandboxPlatform: 'linux',
+        enableBashAdditionalPermissions: true,
+      }),
+      /supported only on macOS/,
+    );
+  });
+
   test('Bash schema exposes only explicit background execution', () => {
     const bash = buildBuiltinTools({ shellRuns: {
       runForegroundBash: () => Promise.reject(new Error('not used')),
@@ -129,6 +149,10 @@ describe('builtin Bash streaming output', () => {
     expect(parameters.safeParse({ command: 'sleep 60', yield_time_ms: 250 }).success).toBe(false);
     expect(parameters.safeParse({ command: 'sleep 60', timeout_ms: 600_001 }).success).toBe(false);
     expect(parameters.safeParse({ command: 'sleep 60', timeout_ms: 600_001, run_in_background: true }).success).toBe(true);
+    expect(parameters.safeParse({
+      command: 'sleep 60',
+      sandbox_permissions: { mode: 'use_default' },
+    }).success).toBe(false);
   });
 
   test('background-capable Bash stays foreground unless explicitly requested', async () => {
@@ -247,7 +271,7 @@ describe('builtin Bash streaming output', () => {
     });
 
     expect(calls[0]?.argv?.[0]).toBe('/usr/bin/bwrap');
-    expect(calls[0]?.argv?.slice(-3)).toEqual(['/bin/sh', '-lc', 'node --version']);
+    expect(calls[0]?.argv?.slice(-3)).toEqual(['/bin/sh', '-c', 'node --version']);
     expect(calls[0]?.fdInputs?.[0]?.fd).toBe(3);
     expect(typeof bash.sandbox).toBe('function');
     if (typeof bash.sandbox !== 'function') throw new Error('dynamic sandbox metadata missing');
@@ -333,6 +357,135 @@ describe('builtin Bash streaming output', () => {
       cwd: '/workspace',
       args: { command: 'echo host' },
     })).toEqual({ platformSandboxAvailable: false });
+  });
+
+  test('plans and applies one-call Bash permissions to the macOS sandbox argv', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'maka-bash-additional-'));
+    try {
+      const workspace = join(root, 'workspace');
+      const outside = join(root, 'outside');
+      await Promise.all([mkdir(workspace), mkdir(outside)]);
+      const canonicalWorkspace = await realpath(workspace);
+      const target = join(await realpath(outside), 'allowed.txt');
+      const profile: PermissionProfile = {
+        type: 'managed',
+        name: 'custom',
+        fileSystem: {
+          kind: 'restricted',
+          entries: [{ kind: 'path', access: 'write', path: canonicalWorkspace }],
+        },
+        network: { kind: 'restricted' },
+      };
+      let execInput: WorkspaceExecInput | undefined;
+      const executor = fakeExecutor({
+        exec: async (input) => {
+          execInput = input;
+          return { exitCode: 0, stdout: '', stderr: '', timedOut: false, aborted: false };
+        },
+      });
+      const sandboxManager = new SandboxManager([new MacosSeatbeltBackend()]);
+      const disabledBash = buildBuiltinTools({
+        executor,
+        permissionProfile: profile,
+        sandboxManager,
+        sandboxPlatform: 'darwin',
+      }).find((candidate) => candidate.name === 'Bash');
+      assert.equal(disabledBash?.planAdditionalPermissions, undefined);
+      assert.equal((disabledBash?.parameters as z.ZodTypeAny).safeParse({
+        command: 'echo unchanged',
+        sandbox_permissions: { mode: 'use_default' },
+      }).success, false);
+
+      const bash = buildBuiltinTools({
+        executor,
+        permissionProfile: profile,
+        sandboxManager,
+        enableBashAdditionalPermissions: true,
+        sandboxPlatform: 'darwin',
+      }).find((candidate) => candidate.name === 'Bash');
+      if (!bash?.planAdditionalPermissions) throw new Error('Bash additional permission planner missing');
+
+      const args = {
+        command: `printf ok > ${JSON.stringify(target)}`,
+        sandbox_permissions: {
+          mode: 'with_additional_permissions' as const,
+          file_system: {
+            entries: [{ path: target, access: 'write' as const, scope: 'exact' as const }],
+          },
+          network: true as const,
+          justification: 'Write the selected output and notify a service.',
+        },
+      };
+      const parameters = bash.parameters as z.ZodTypeAny;
+      expect(parameters.safeParse(args).success).toBe(true);
+      expect(parameters.safeParse({
+        command: 'echo unsafe',
+        sandbox_permissions: { mode: 'require_escalated', justification: 'Not in this slice.' },
+      }).success).toBe(false);
+
+      const plannerContext = {
+        sessionId: 'session-1',
+        turnId: 'turn-1',
+        toolUseId: 'tool-1',
+        toolName: 'Bash',
+        category: 'shell_unsafe' as const,
+        cwd: canonicalWorkspace,
+        mode: 'execute' as const,
+        args,
+      };
+      const plan = await bash.planAdditionalPermissions(args, plannerContext);
+      assert.equal(plan.kind, 'request');
+      if (plan.kind !== 'request') throw new Error('Additional permission request missing');
+      assert.doesNotThrow(() => assertAdditionalPermissionProposal({
+        proposal: plan.proposal,
+        toolName: 'Bash',
+        args,
+      }));
+
+      await bash.impl(args, {
+        sessionId: 'session-1',
+        turnId: 'turn-1',
+        toolCallId: 'tool-1',
+        cwd: canonicalWorkspace,
+        permissionMode: 'execute',
+        abortSignal: new AbortController().signal,
+        emitOutput: () => {},
+        permissionContext: {
+          additionalGrant: {
+            grantId: 'grant-1',
+            sessionId: 'session-1',
+            turnId: 'turn-1',
+            toolUseId: 'tool-1',
+            toolName: 'Bash',
+            intentHash: plan.proposal.intentHash,
+            permissionsHash: plan.proposal.permissionsHash,
+            profile: plan.proposal.profile,
+            normalizedPaths: plan.proposal.normalizedPaths,
+            risk: plan.proposal.risk,
+            issuedAt: 1,
+            expiresAt: 2,
+          },
+        },
+      });
+
+      const argv = execInput?.argv;
+      assert.ok(argv);
+      assert.equal(argv[0], '/usr/bin/sandbox-exec');
+      assert.deepEqual(argv.slice(-3), ['/bin/sh', '-c', args.command]);
+      const policy = argv.find((value) => value.includes('(version 1)')) ?? '';
+      assert.match(policy, /\(literal \(param "WRITABLE_ROOT_1"\)\)/);
+      assert.match(policy, /\(allow network\*\)/);
+      assert.equal(profile.network.kind, 'restricted');
+
+      const ptyPlan = await bash.planAdditionalPermissions(
+        { ...args, run_in_background: true, pty: true },
+        { ...plannerContext, args: { ...args, run_in_background: true, pty: true } },
+      );
+      assert.equal(ptyPlan.kind, 'block');
+      if (ptyPlan.kind === 'block') assert.match(ptyPlan.message, /PTY/);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
   });
 
   test('Read treats runtime background task refs as whole resources', async () => {

--- a/packages/runtime/src/__tests__/macos-seatbelt-smoke.test.ts
+++ b/packages/runtime/src/__tests__/macos-seatbelt-smoke.test.ts
@@ -10,11 +10,13 @@ import {
   createWorkspaceWritePermissionProfile,
   type PermissionProfile,
 } from '@maka/core/permission-profile';
+import type { AdditionalPermissionProfile } from '@maka/core/additional-permissions';
 
 import {
   MACOS_SEATBELT_EXECUTABLE,
   MacosSeatbeltBackend,
 } from '../sandbox/macos-seatbelt.js';
+import { SandboxManager } from '../sandbox/sandbox-manager.js';
 
 const canRunSeatbelt = process.platform === 'darwin' && existsSync(MACOS_SEATBELT_EXECUTABLE);
 
@@ -49,9 +51,10 @@ function runSeatbeltCommand(
   workspaceRoot: string,
   command: string,
   profile: PermissionProfile = createWorkspaceWritePermissionProfile(),
+  additionalPermissions?: AdditionalPermissionProfile,
 ) {
-  const backend = new MacosSeatbeltBackend();
-  const result = backend.transform({
+  const manager = new SandboxManager([new MacosSeatbeltBackend()]);
+  const result = manager.transform({
     platform: 'darwin',
     command: {
       program: '/bin/sh',
@@ -62,6 +65,7 @@ function runSeatbeltCommand(
         workspaceRoots: [workspaceRoot],
       },
     },
+    ...(additionalPermissions ? { additionalPermissions } : {}),
   });
 
   assert.equal(result.ok, true);
@@ -100,6 +104,40 @@ describe('macOS Seatbelt smoke', { skip: !canRunSeatbelt }, () => {
     const child = runSeatbeltCommand(workspaceRoot, `printf nope > ${JSON.stringify(outsideFile)}`);
 
     assert.notEqual(child.status, 0);
+  });
+
+  it('allows only the exact outside path granted for one command', async () => {
+    const workspaceRoot = await makeWorkspace();
+    const outsideRoot = await realpath(await mkdtemp(join(tmpdir(), 'maka-seatbelt-additional-')));
+    cleanup.push(workspaceRoot, outsideRoot);
+    const allowedFile = resolve(outsideRoot, 'allowed.txt');
+    const siblingFile = resolve(outsideRoot, 'sibling.txt');
+
+    const allowed = runSeatbeltCommand(
+      workspaceRoot,
+      `printf ok > ${JSON.stringify(allowedFile)}`,
+      createWorkspaceWritePermissionProfile(),
+      {
+        fileSystem: {
+          entries: [{ path: allowedFile, access: 'write', scope: 'exact' }],
+        },
+      },
+    );
+    assert.equal(allowed.status, 0, allowed.stderr);
+    assert.equal(await readFile(allowedFile, 'utf8'), 'ok');
+
+    const sibling = runSeatbeltCommand(
+      workspaceRoot,
+      `printf nope > ${JSON.stringify(siblingFile)}`,
+      createWorkspaceWritePermissionProfile(),
+      {
+        fileSystem: {
+          entries: [{ path: allowedFile, access: 'write', scope: 'exact' }],
+        },
+      },
+    );
+    assert.notEqual(sibling.status, 0);
+    assert.equal(existsSync(siblingFile), false);
   });
 
   it('denies writes to protected metadata under the workspace root', async () => {

--- a/packages/runtime/src/__tests__/macos-seatbelt.test.ts
+++ b/packages/runtime/src/__tests__/macos-seatbelt.test.ts
@@ -205,6 +205,55 @@ describe('buildSeatbeltPolicy', () => {
     assert.match(policyText(createWorkspaceWritePermissionProfile()), /\(deny network\*\)/);
     assert.match(policyText(restrictedProfileWithEnabledNetwork()), /\(allow network\*\)/);
   });
+
+  it('renders exact path entries as literal and subtree entries as subpath', () => {
+    const profile: PermissionProfile = {
+      type: 'managed',
+      name: 'custom',
+      fileSystem: {
+        kind: 'restricted',
+        entries: [
+          { kind: 'path', access: 'write', path: '/outside/file.txt', match: 'exact' },
+          { kind: 'path', access: 'read', path: '/outside/tree', match: 'subtree' },
+        ],
+      },
+      network: { kind: 'restricted' },
+    };
+    const result = buildSeatbeltPolicy({
+      profile,
+      pathContext: { workspaceRoots: ['/repo'] },
+    });
+
+    assert.match(result.policy, /\(literal \(param "READABLE_ROOT_0"\)\)/);
+    assert.match(result.policy, /\(subpath \(param "READABLE_ROOT_1"\)\)/);
+    assert.match(result.policy, /\(literal \(param "WRITABLE_ROOT_0"\)\)/);
+    assert.deepEqual(result.definitionArgs.slice(0, 3), [
+      '-DREADABLE_ROOT_0=/outside/file.txt',
+      '-DREADABLE_ROOT_1=/outside/tree',
+      '-DWRITABLE_ROOT_0=/outside/file.txt',
+    ]);
+  });
+
+  it('keeps explicit exact deny requirements on every allow clause', () => {
+    const profile: PermissionProfile = {
+      type: 'managed',
+      name: 'custom',
+      fileSystem: {
+        kind: 'restricted',
+        entries: [
+          { kind: 'path', access: 'write', path: '/outside', match: 'subtree' },
+          { kind: 'path', access: 'deny', path: '/outside/locked.txt', match: 'exact' },
+        ],
+      },
+      network: { kind: 'restricted' },
+    };
+
+    const policy = buildSeatbeltPolicy({
+      profile,
+      pathContext: { workspaceRoots: ['/repo'] },
+    }).policy;
+    assert.match(policy, /\(require-not \(literal "\/outside\/locked\.txt"\)\)/);
+  });
 });
 
 describe('createSeatbeltExecArgs', () => {

--- a/packages/runtime/src/__tests__/sandbox-manager.test.ts
+++ b/packages/runtime/src/__tests__/sandbox-manager.test.ts
@@ -254,4 +254,35 @@ describe('SandboxManager.transform', () => {
     assert.equal(result.ok, false);
     if (!result.ok) assert.equal(result.reason, 'backend_not_available');
   });
+
+  it('builds an effective profile from one-call permissions without mutating the base', () => {
+    const backend = new FakeMacosBackend();
+    const manager = new SandboxManager([backend]);
+    const base = createWorkspaceWritePermissionProfile();
+    const result = manager.transform({
+      command: command(base),
+      platform: 'darwin',
+      additionalPermissions: {
+        fileSystem: {
+          entries: [{ path: '/outside/file.txt', access: 'write', scope: 'exact' }],
+        },
+        network: { enabled: true },
+      },
+    });
+
+    assert.equal(result.ok, true);
+    assert.equal(base.network.kind, 'restricted');
+    assert.equal(backend.calls.length, 1);
+    const effective = backend.calls[0]!.command.profile;
+    assert.equal(effective.type, 'managed');
+    if (effective.type === 'managed') {
+      assert.equal(effective.network.kind, 'enabled');
+      assert.deepEqual(effective.fileSystem.entries.at(-1), {
+        kind: 'path',
+        access: 'write',
+        path: '/outside/file.txt',
+        match: 'exact',
+      });
+    }
+  });
 });

--- a/packages/runtime/src/additional-permissions.ts
+++ b/packages/runtime/src/additional-permissions.ts
@@ -367,6 +367,7 @@ export async function planDeclaredBashAdditionalPermission(input: {
   cwd: string;
   mode: PermissionMode;
   command: string;
+  args: unknown;
   context: AdditionalPermissionPlanningContext;
 }): Promise<AdditionalPermissionPlanResult> {
   if (input.declaration === undefined) return { kind: 'not_required' };
@@ -459,7 +460,7 @@ export async function planDeclaredBashAdditionalPermission(input: {
       normalizedPaths: requiredPaths,
       justification,
       toolName: 'Bash',
-      args: { command: input.command, sandbox_permissions: input.declaration },
+      args: input.args,
       workspaceRoots: input.context.workspaceRoots,
     }),
   };

--- a/packages/runtime/src/builtin-tools.ts
+++ b/packages/runtime/src/builtin-tools.ts
@@ -9,6 +9,7 @@ import { z } from 'zod';
 import { tmpdir } from 'node:os';
 import { isAbsolute } from 'node:path';
 import {
+  applyAdditionalPermissionProfile,
   compilePermissionProfile,
   type PermissionProfile,
 } from '@maka/core';
@@ -17,10 +18,11 @@ import {
   buildManagedBashTool,
   buildStopBackgroundTaskTool,
   buildWriteStdinTool,
+  bashSandboxPermissionsSchema,
   shapeTerminalResult,
   withShellGuidance,
 } from './shell-tools.js';
-import type { ShellRunLauncher } from './shell-tools.js';
+import type { ManagedBashPermissionArgs, ShellRunLauncher } from './shell-tools.js';
 import { defaultShellPlan, type ShellPlan } from './shell-detect.js';
 import type {
   BackgroundTaskStopper,
@@ -43,6 +45,11 @@ import type { SandboxManager } from './sandbox/sandbox-manager.js';
 import { linuxExecutableRoots } from './sandbox/linux-sandbox.js';
 import type { SandboxPlatform } from './sandbox/types.js';
 import type { ChildFdInput } from './child-fd-input.js';
+import {
+  planDeclaredBashAdditionalPermission,
+  type AdditionalPermissionPlannerContext,
+  type AdditionalPermissionPlanResult,
+} from './additional-permissions.js';
 
 // Generous wall-clock cap for the ripgrep-backed Grep tool. A search should be
 // near-instant; this only bounds a pathological hang now that the stream
@@ -59,11 +66,16 @@ export interface BuildBuiltinToolsOptions {
   shell?: ShellPlan;
   permissionProfile?: PermissionProfile;
   sandboxManager?: SandboxManager;
+  /** Enable only when the host consumes additional-permission approval events. */
+  enableBashAdditionalPermissions?: boolean;
   /** Test/embedding override. Production callers use the current process platform. */
   sandboxPlatform?: SandboxPlatform;
 }
 
 export function buildBuiltinTools(options: BuildBuiltinToolsOptions = {}): MakaTool[] {
+  if (options.enableBashAdditionalPermissions && !options.sandboxManager) {
+    throw new Error('Bash additional permissions require a sandbox manager.');
+  }
   const executor = options.executor ?? createLocalWorkspaceExecutor();
   const executionFacts = executor.facts;
   const readDescription = options.runtimeResources
@@ -87,6 +99,17 @@ export function buildBuiltinTools(options: BuildBuiltinToolsOptions = {}): MakaT
     : fileReadParameters;
   const shell = options.shell ?? defaultShellPlan();
   const sandboxPlatform = options.sandboxPlatform ?? process.platform;
+  if (options.enableBashAdditionalPermissions && sandboxPlatform !== 'darwin') {
+    throw new Error('Bash additional permissions are currently supported only on macOS.');
+  }
+  const bashAdditionalPermissionPlanner = options.sandboxManager
+    && options.enableBashAdditionalPermissions
+    ? createBashAdditionalPermissionPlanner(
+        options.sandboxManager,
+        options.permissionProfile,
+        sandboxPlatform,
+      )
+    : undefined;
   const bashTools = options.shellRuns
     ? [buildManagedBashTool(options.shellRuns, {
         executionFacts,
@@ -106,10 +129,16 @@ export function buildBuiltinTools(options: BuildBuiltinToolsOptions = {}): MakaT
             ctx,
           ),
         } : {}),
+        ...(bashAdditionalPermissionPlanner
+          ? { planAdditionalPermissions: bashAdditionalPermissionPlanner }
+          : {}),
       })]
     : [buildExecutorBashTool(executor, shell, {
         ...(options.permissionProfile ? { permissionProfile: options.permissionProfile } : {}),
         ...(options.sandboxManager ? { sandboxManager: options.sandboxManager } : {}),
+        ...(bashAdditionalPermissionPlanner
+          ? { planAdditionalPermissions: bashAdditionalPermissionPlanner }
+          : {}),
         sandboxPlatform,
       })];
   const backgroundTools = [
@@ -313,7 +342,13 @@ interface ExecutorBashSandboxOptions {
   permissionProfile?: PermissionProfile;
   sandboxManager?: SandboxManager;
   sandboxPlatform: SandboxPlatform;
+  planAdditionalPermissions?: BashAdditionalPermissionPlanner;
 }
+
+type BashAdditionalPermissionPlanner = (
+  args: ManagedBashPermissionArgs,
+  context: AdditionalPermissionPlannerContext,
+) => Promise<AdditionalPermissionPlanResult> | AdditionalPermissionPlanResult;
 
 function buildExecutorBashTool(
   executor: WorkspaceExecutor,
@@ -324,13 +359,24 @@ function buildExecutorBashTool(
     name: 'Bash',
     activityKind: 'command',
     description: withShellGuidance('Run a shell command in the session cwd.', shell)
-      + ' Subject to permission policy.',
+      + ' Subject to permission policy.'
+      + (sandboxOptions.planAdditionalPermissions
+        ? ' One-call filesystem or network access can be requested with sandbox_permissions.'
+        : ''),
     parameters: z.object({
       command: z.string().describe('The shell command to execute'),
       timeout_ms: z.number().int().positive().max(600_000).optional(),
-    }),
+      ...(sandboxOptions.planAdditionalPermissions ? {
+        sandbox_permissions: bashSandboxPermissionsSchema
+          .describe('Optional one-call filesystem or network permission request.')
+          .optional(),
+      } : {}),
+    }).strict(),
     permissionRequired: true,
     executionFacts: executor.facts,
+    ...(sandboxOptions.planAdditionalPermissions
+      ? { planAdditionalPermissions: sandboxOptions.planAdditionalPermissions }
+      : {}),
     ...(sandboxOptions.sandboxManager ? {
       sandbox: sandboxAvailabilityResolver(
         sandboxOptions.sandboxManager,
@@ -411,11 +457,12 @@ function sandboxCommand(
   if (!manager.canEnforce({ profile: effective.profile, platform })) return undefined;
 
   const env = { ...process.env };
+  const additionalPermissions = ctx.permissionContext?.additionalGrant?.profile;
   const result = manager.transform({
     platform,
     command: {
       program: '/bin/sh',
-      args: ['-lc', command],
+      args: ['-c', command],
       cwd: ctx.cwd,
       env,
       profile: effective.profile,
@@ -431,6 +478,7 @@ function sandboxCommand(
         } : {}),
       },
     },
+    ...(additionalPermissions ? { additionalPermissions } : {}),
   });
   if (!result.ok) {
     throw new Error(result.message ?? `Sandbox transform failed: ${result.reason}`);
@@ -451,6 +499,52 @@ function effectivePermissionProfile(
   if (explicitProfile) return { profile: explicitProfile, workspaceRoots: [cwd] };
   const compiled = compilePermissionProfile({ mode: permissionMode, cwd });
   return { profile: compiled.profile, workspaceRoots: compiled.workspaceRoots };
+}
+
+function createBashAdditionalPermissionPlanner(
+  manager: SandboxManager,
+  explicitProfile: PermissionProfile | undefined,
+  platform: SandboxPlatform,
+): BashAdditionalPermissionPlanner {
+  return async (args, context) => {
+    const effective = effectivePermissionProfile(explicitProfile, context.mode, context.cwd);
+    const plan = await planDeclaredBashAdditionalPermission({
+      declaration: args.sandbox_permissions,
+      cwd: context.cwd,
+      mode: context.mode,
+      command: args.command,
+      args: context.args,
+      context: {
+        profile: effective.profile,
+        workspaceRoots: effective.workspaceRoots,
+        pathContext: {
+          tmpdir: tmpdir(),
+          slashTmp: '/tmp',
+        },
+      },
+    });
+    if (plan.kind !== 'request') return plan;
+    if (args.pty === true) {
+      return {
+        kind: 'block',
+        reason: 'invalid_additional_permissions',
+        message: 'Additional Bash permissions cannot be applied to PTY execution.',
+      };
+    }
+
+    const effectiveWithAdditional = applyAdditionalPermissionProfile(
+      effective.profile,
+      plan.proposal.profile,
+    );
+    if (!manager.canEnforce({ profile: effectiveWithAdditional, platform })) {
+      return {
+        kind: 'block',
+        reason: 'invalid_additional_permissions',
+        message: `Additional Bash permissions cannot be enforced on platform ${platform}.`,
+      };
+    }
+    return plan;
+  };
 }
 
 function isPtyBashArgs(args: unknown): boolean {

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -146,11 +146,14 @@ export {
   buildStopBackgroundTaskTool,
   buildWriteStdinTool,
   shapeTerminalResult,
+  bashSandboxPermissionsSchema,
 } from './shell-tools.js';
 export type {
+  BashSandboxPermissionsDeclaration,
   BuildForegroundBashToolOptions,
   ForegroundBashExecuteInput,
   ForegroundBashResult,
+  ManagedBashPermissionArgs,
   ShellRunLauncher,
 } from './shell-tools.js';
 export {

--- a/packages/runtime/src/sandbox/macos-seatbelt.ts
+++ b/packages/runtime/src/sandbox/macos-seatbelt.ts
@@ -196,11 +196,16 @@ export interface CreateSeatbeltExecArgsInput extends BuildSeatbeltPolicyInput {
 }
 
 interface ResolvedRoots {
-  readableRoots: readonly string[];
-  writableRoots: readonly string[];
-  deniedRoots: readonly string[];
+  readableRoots: readonly ResolvedRoot[];
+  writableRoots: readonly ResolvedRoot[];
+  deniedRoots: readonly ResolvedRoot[];
   protectedWritableRoots: readonly string[];
   protectedMetadataNames: readonly string[];
+}
+
+interface ResolvedRoot {
+  path: string;
+  match: 'exact' | 'subtree';
 }
 
 export function escapeSeatbeltRegex(value: string): string {
@@ -210,8 +215,8 @@ export function escapeSeatbeltRegex(value: string): string {
 export function buildSeatbeltPolicy(input: BuildSeatbeltPolicyInput): BuildSeatbeltPolicyResult {
   const roots = resolveRoots(input.profile, input.pathContext);
   const definitionArgs = [
-    ...roots.readableRoots.map((root, index) => `-DREADABLE_ROOT_${index}=${root}`),
-    ...roots.writableRoots.map((root, index) => `-DWRITABLE_ROOT_${index}=${root}`),
+    ...roots.readableRoots.map((root, index) => `-DREADABLE_ROOT_${index}=${root.path}`),
+    ...roots.writableRoots.map((root, index) => `-DWRITABLE_ROOT_${index}=${root.path}`),
   ];
 
   const sections = [
@@ -286,25 +291,25 @@ function resolveRoots(profile: PermissionProfile, pathContext: SandboxPathContex
     };
   }
 
-  const readableRoots: string[] = [];
-  const writableRoots: string[] = [];
-  const deniedRoots: string[] = [];
+  const readableRoots: ResolvedRoot[] = [];
+  const writableRoots: ResolvedRoot[] = [];
+  const deniedRoots: ResolvedRoot[] = [];
   const protectedWritableRoots: string[] = [];
 
   for (const entry of profile.fileSystem.entries) {
     const roots = rootsForEntry(entry, pathContext);
     if (entry.access === 'deny') {
-      addUniqueRoots(deniedRoots, roots);
+      addUniqueResolvedRoots(deniedRoots, roots);
       continue;
     }
 
     if (entry.access === 'read' || entry.access === 'write') {
-      addUniqueRoots(readableRoots, roots);
+      addUniqueResolvedRoots(readableRoots, roots);
     }
     if (entry.access === 'write') {
-      addUniqueRoots(writableRoots, roots);
+      addUniqueResolvedRoots(writableRoots, roots);
       if (entry.kind === 'special' && entry.special === ':workspace_roots') {
-        addUniqueRoots(protectedWritableRoots, roots);
+        addUniqueRoots(protectedWritableRoots, roots.map((root) => root.path));
       }
     }
   }
@@ -321,20 +326,30 @@ function resolveRoots(profile: PermissionProfile, pathContext: SandboxPathContex
 function rootsForEntry(
   entry: PermissionProfileManagedEntry,
   pathContext: SandboxPathContext,
-): readonly string[] {
-  if (entry.kind === 'path') return [entry.path];
+): readonly ResolvedRoot[] {
+  if (entry.kind === 'path') {
+    return [{ path: entry.path, match: entry.match ?? 'subtree' }];
+  }
 
   switch (entry.special) {
     case ':root':
-      return ['/'];
+      return [{ path: '/', match: 'subtree' }];
     case ':workspace_roots':
-      return pathContext.workspaceRoots;
+      return pathContext.workspaceRoots.map((path) => ({ path, match: 'subtree' as const }));
     case ':tmpdir':
-      return pathContext.tmpdir ? [pathContext.tmpdir] : [];
+      return pathContext.tmpdir ? [{ path: pathContext.tmpdir, match: 'subtree' }] : [];
     case ':slash_tmp':
-      return [pathContext.slashTmp ?? '/tmp'];
+      return [{ path: pathContext.slashTmp ?? '/tmp', match: 'subtree' }];
     case ':minimal':
-      return pathContext.minimalRoots ?? [];
+      return (pathContext.minimalRoots ?? []).map((path) => ({ path, match: 'subtree' as const }));
+  }
+}
+
+function addUniqueResolvedRoots(target: ResolvedRoot[], roots: readonly ResolvedRoot[]): void {
+  for (const root of roots) {
+    if (!target.some((existing) => existing.path === root.path && existing.match === root.match)) {
+      target.push(root);
+    }
   }
 }
 
@@ -349,7 +364,10 @@ function buildReadableRootsPolicy(roots: ResolvedRoots): string {
 
   const denyRequirements = deniedRootRequirements(roots.deniedRoots);
   const params = roots.readableRoots
-    .map((_, index) => accessRootClause(`(subpath (param "READABLE_ROOT_${index}"))`, denyRequirements))
+    .map((root, index) => accessRootClause(
+      seatbeltPathClause(root, `READABLE_ROOT_${index}`),
+      denyRequirements,
+    ))
     .join('\n');
   return `(allow file-read*\n${params})`;
 }
@@ -364,15 +382,15 @@ function buildWritableRootsPolicy(roots: ResolvedRoots): string {
 }
 
 function writableRootClause(
-  root: string,
+  root: ResolvedRoot,
   index: number,
   roots: ResolvedRoots,
 ): string {
-  const rootParam = `(subpath (param "WRITABLE_ROOT_${index}"))`;
+  const rootParam = seatbeltPathClause(root, `WRITABLE_ROOT_${index}`);
   const requirements = [...deniedRootRequirements(roots.deniedRoots)];
 
-  if (roots.protectedWritableRoots.includes(root)) {
-    requirements.push(...roots.protectedMetadataNames.map((name) => protectedMetadataRequirement(root, name)));
+  if (roots.protectedWritableRoots.includes(root.path)) {
+    requirements.push(...roots.protectedMetadataNames.map((name) => protectedMetadataRequirement(root.path, name)));
   }
 
   return accessRootClause(rootParam, requirements);
@@ -385,14 +403,25 @@ function accessRootClause(rootParam: string, requirements: readonly string[]): s
   return `  (require-all\n    ${rootParam}\n${requirementLines}\n  )`;
 }
 
-function deniedRootRequirements(deniedRoots: readonly string[]): readonly string[] {
+function deniedRootRequirements(deniedRoots: readonly ResolvedRoot[]): readonly string[] {
   return deniedRoots.map(deniedRootRequirement);
 }
 
-function deniedRootRequirement(root: string): string {
-  const trimmedRoot = trimTrailingSlash(root);
+function deniedRootRequirement(root: ResolvedRoot): string {
+  const trimmedRoot = trimTrailingSlash(root.path);
+  if (root.match === 'exact') {
+    return `(require-not (literal "${escapeSeatbeltString(trimmedRoot)}"))`;
+  }
   if (trimmedRoot === '/') return '(require-not (regex #"^/.*$"))';
   return `(require-not (regex #"^${escapeSeatbeltRegex(trimmedRoot)}(/.*)?$"))`;
+}
+
+function seatbeltPathClause(root: ResolvedRoot, parameter: string): string {
+  return `(${root.match === 'exact' ? 'literal' : 'subpath'} (param "${parameter}"))`;
+}
+
+function escapeSeatbeltString(value: string): string {
+  return value.replaceAll('\\', '\\\\').replaceAll('"', '\\"');
 }
 
 function protectedMetadataRequirement(root: string, name: string): string {

--- a/packages/runtime/src/sandbox/sandbox-manager.ts
+++ b/packages/runtime/src/sandbox/sandbox-manager.ts
@@ -1,4 +1,5 @@
 import type { PermissionProfile } from '@maka/core/permission-profile';
+import { applyAdditionalPermissionProfile } from '@maka/core/additional-permissions';
 
 import type {
   SandboxBackend,
@@ -113,8 +114,18 @@ export class SandboxManager {
   }
 
   transform(request: SandboxTransformRequest): SandboxTransformResult {
+    const effectiveProfile = request.additionalPermissions
+      ? applyAdditionalPermissionProfile(request.command.profile, request.additionalPermissions)
+      : request.command.profile;
+    const effectiveRequest: SandboxTransformRequest = {
+      ...request,
+      command: {
+        ...request.command,
+        profile: effectiveProfile,
+      },
+    };
     const selected = this.selectInitial({
-      profile: request.command.profile,
+      profile: effectiveProfile,
       preference: request.preference,
       platform: request.platform,
     });
@@ -122,7 +133,7 @@ export class SandboxManager {
     if (!selected.ok) return selected;
 
     if (selected.sandboxType === 'none') {
-      const { command } = request;
+      const { command } = effectiveRequest;
       return {
         ok: true,
         exec: {
@@ -152,7 +163,7 @@ export class SandboxManager {
     }
 
     return backend.transform({
-      ...request,
+      ...effectiveRequest,
       preference: selected.preference,
       platform: selected.platform,
     });

--- a/packages/runtime/src/sandbox/types.ts
+++ b/packages/runtime/src/sandbox/types.ts
@@ -1,4 +1,5 @@
 import type { PermissionProfile } from '@maka/core/permission-profile';
+import type { AdditionalPermissionProfile } from '@maka/core/additional-permissions';
 import type { ChildFdInput } from '../child-fd-input.js';
 
 export type SandboxType = 'none' | 'macos-seatbelt' | 'linux';
@@ -68,6 +69,8 @@ export type SandboxSelectionResult =
 
 export interface SandboxTransformRequest {
   command: SandboxCommand;
+  /** One-call permissions merged into command.profile for this transform only. */
+  additionalPermissions?: AdditionalPermissionProfile;
   preference?: SandboxablePreference;
   platform?: SandboxPlatform;
 }

--- a/packages/runtime/src/shell-tools.ts
+++ b/packages/runtime/src/shell-tools.ts
@@ -2,7 +2,13 @@ import { z } from 'zod';
 import { redactSecrets } from '@maka/core/redaction';
 import type { ToolResultContent } from '@maka/core/events';
 import type { ToolExecutionFacts } from '@maka/core/permission';
+import { MAX_ADDITIONAL_FILESYSTEM_ENTRIES } from '@maka/core/additional-permissions';
 import type { MakaTool, MakaToolContext } from './tool-runtime.js';
+import {
+  MAX_ADDITIONAL_PERMISSION_JUSTIFICATION_CHARS,
+  type AdditionalPermissionPlannerContext,
+  type AdditionalPermissionPlanResult,
+} from './additional-permissions.js';
 import { runShellWithBoundedTail, type BoundedShellResult } from './shell-exec.js';
 import { bashToolShellGuidance, defaultShellPlan, type ShellPlan } from './shell-detect.js';
 import { truncateToolOutput } from './tool-output.js';
@@ -61,6 +67,34 @@ type ShellRunToolResult = Extract<ToolResultContent, { kind: 'shell_run' }>;
 export interface ShellRunLauncher {
   runForegroundBash(input: ShellRunBashInput): Promise<TerminalToolResult>;
   runBackgroundBash(input: ShellRunBashInput): Promise<ShellRunToolResult>;
+}
+
+const additionalFilesystemEntrySchema = z.object({
+  path: z.string(),
+  access: z.enum(['read', 'write']),
+  scope: z.enum(['exact', 'subtree']),
+}).strict();
+
+export const bashSandboxPermissionsSchema = z.discriminatedUnion('mode', [
+  z.object({ mode: z.literal('use_default') }).strict(),
+  z.object({
+    mode: z.literal('with_additional_permissions'),
+    file_system: z.object({
+      entries: z.array(additionalFilesystemEntrySchema).max(MAX_ADDITIONAL_FILESYSTEM_ENTRIES),
+    }).strict().optional(),
+    network: z.literal(true).optional(),
+    justification: z.string().min(1).max(MAX_ADDITIONAL_PERMISSION_JUSTIFICATION_CHARS),
+  }).strict(),
+]);
+
+export type BashSandboxPermissionsDeclaration = z.infer<typeof bashSandboxPermissionsSchema>;
+
+export interface ManagedBashPermissionArgs {
+  command: string;
+  timeout_ms?: number;
+  run_in_background?: boolean;
+  pty?: boolean;
+  sandbox_permissions?: BashSandboxPermissionsDeclaration;
 }
 
 export function buildForegroundBashTool(options: BuildForegroundBashToolOptions): MakaTool {
@@ -127,9 +161,16 @@ export function buildManagedBashTool(
       env?: NodeJS.ProcessEnv;
       fdInputs?: readonly ChildFdInput[];
     } | undefined;
+    planAdditionalPermissions?: (
+      args: ManagedBashPermissionArgs,
+      context: AdditionalPermissionPlannerContext,
+    ) => Promise<AdditionalPermissionPlanResult> | AdditionalPermissionPlanResult;
   } = {},
 ): MakaTool {
   const shell = options.shell ?? defaultShellPlan();
+  const additionalPermissionDescription = options.planAdditionalPermissions
+    ? ' One-call filesystem or network access can be requested with sandbox_permissions.'
+    : '';
   return {
     name: 'Bash',
     activityKind: 'command',
@@ -137,12 +178,18 @@ export function buildManagedBashTool(
       withShellGuidance('Run a shell command in the session cwd.', shell)
       + ` Foreground is the default (timeout ${DEFAULT_BASH_TIMEOUT_MS}ms, maximum ${MAX_FOREGROUND_BASH_TIMEOUT_MS}ms).`
       + ` Set run_in_background=true only when the command should continue as a tracked runtime background task; background commands have no default timeout (maximum explicit timeout ${MAX_SHELL_RUN_TIMEOUT_MS}ms).`
-      + ' Set pty=true together with run_in_background=true only for terminal semantics or later input; use the returned ref with Read or WriteStdin. Subject to permission policy.',
+      + ' Set pty=true together with run_in_background=true only for terminal semantics or later input; use the returned ref with Read or WriteStdin. Subject to permission policy.'
+      + additionalPermissionDescription,
     parameters: z.object({
       command: z.string().describe('The shell command to execute'),
       timeout_ms: z.number().int().positive().max(MAX_SHELL_RUN_TIMEOUT_MS).optional(),
       run_in_background: z.boolean().optional(),
       pty: z.boolean().optional(),
+      ...(options.planAdditionalPermissions ? {
+        sandbox_permissions: bashSandboxPermissionsSchema
+          .describe('Optional one-call filesystem or network permission request.')
+          .optional(),
+      } : {}),
     }).strict().superRefine(({ timeout_ms, run_in_background, pty }, ctx) => {
       if (!run_in_background && timeout_ms !== undefined && timeout_ms > MAX_FOREGROUND_BASH_TIMEOUT_MS) {
         ctx.addIssue({
@@ -165,6 +212,9 @@ export function buildManagedBashTool(
     permissionRequired: true,
     ...(options.executionFacts ? { executionFacts: options.executionFacts } : {}),
     ...(options.sandbox ? { sandbox: options.sandbox } : {}),
+    ...(options.planAdditionalPermissions
+      ? { planAdditionalPermissions: options.planAdditionalPermissions }
+      : {}),
     impl: async ({ command, timeout_ms, run_in_background, pty }, ctx) => {
       const transformed = options.transformCommand?.({ command, pty: pty === true, ctx });
       return shellRuns[run_in_background ? 'runBackgroundBash' : 'runForegroundBash']({


### PR DESCRIPTION
## Summary

- merge an approved one-call permission profile into a single sandbox transform without mutating the base profile
- preserve exact versus subtree path scope in macOS Seatbelt policies, including explicit deny rules
- add an opt-in Bash `sandbox_permissions` schema and trusted planner for scoped filesystem/network requests
- pass the consumed grant into foreground and background pipe Bash sandbox argv
- fail closed for PTY execution, unsupported platforms, missing managers, and unenforceable profiles
- run sandboxed commands with `/bin/sh -c` so the wrapper does not read login-shell profiles

## Scope

Refs #509.

This follows #960, #964, #969, and #973 and is extracted from #880.

Bash registration is intentionally opt-in through `enableBashAdditionalPermissions`. Desktop and CLI currently do not present `additional_permissions` events, so this PR does not enable the feature in production assembly yet. That approval surface and production wiring belong in the next slice.

This PR does not implement `require_escalated`, file-tool grants, Linux exact-path enforcement, or UI changes.

## Verification

- `npm test --workspace @maka/runtime` (1615 tests, 1608 passed, 7 skipped, 0 failed)
- macOS Seatbelt smoke: exact outside path allowed while sibling remains denied
- `npm run build`
- `npm run typecheck`
- `git diff --check`