### PR TITLE
refactor(settings): present model connections as first-class rows

### DIFF
--- a/apps/desktop/src/main/__tests__/chip-converge-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/chip-converge-contract.test.ts
@@ -95,6 +95,16 @@ test('chip converge (#520 PR9)', async () => {
   assert.match(chipSrc, /bg-warning\/18/, 'Chip warning variant must keep /18 alpha');
   assert.match(chipSrc, /bg-destructive\/15/, 'Chip destructive variant must keep /15 alpha (not solid red)');
 
+  // 8b. Chip accent variant (default-connection marker) — brand tone on the
+  // background only. Raw --nav-active text is 2.66:1 on white (fails WCAG AA;
+  // see design-system-governance-406 permission-mode chip contract), so the
+  // label must use --foreground-secondary like the readable-accent precedent.
+  assert.match(
+    chipSrc,
+    /accent: "bg-nav-active\/14 text-\[var\(--foreground-secondary\)\]/,
+    'Chip accent variant must keep the nav-active /14 wash with foreground-secondary text (never raw nav-active text)',
+  );
+
   // 9. Badge primitive stays pill — dual-track Badge (pill) + Chip (squared) preserved
   const badgeSrc = read('packages/ui/src/primitives/badge.tsx');
   assert.match(badgeSrc, /rounded-\[var\(--radius-pill\)\]/, 'Badge stays pill (dual-track with Chip)');

--- a/apps/desktop/src/main/__tests__/model-oauth-section-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/model-oauth-section-contract.test.ts
@@ -61,8 +61,7 @@ describe('Model OAuth catalog contract (PR-MODEL-OAUTH-ALL-0 + PR-CLAUDE-CARD-MO
     for (const name of [
       'Button',
       'PrimitiveTabs', 'PrimitiveTabsList', 'PrimitiveTabsTrigger',
-      'PrimitiveAccordion', 'PrimitiveAccordionItem', 'PrimitiveAccordionTrigger', 'PrimitiveAccordionPanel',
-      'Item', 'ItemContent', 'ItemTitle', 'ItemActions',
+      'Item', 'ItemMedia', 'ItemContent', 'ItemTitle', 'ItemDescription', 'ItemActions',
       'Input', 'RelativeTime', 'Textarea', 'useToast',
     ]) {
       assert.ok(

--- a/apps/desktop/src/main/__tests__/model-oauth-section-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/model-oauth-section-contract.test.ts
@@ -353,7 +353,7 @@ describe('Model OAuth catalog contract (PR-MODEL-OAUTH-ALL-0 + PR-CLAUDE-CARD-MO
     );
     assert.match(
       src,
-      /import \{[^}]*chipStatusText[^}]*\} from '\.\/provider-connection-status'/,
+      /import \{[^}]*connectionChipStatus[^}]*\} from '\.\/provider-connection-status'/,
       'status copy must come from the dedicated provider-connection-status helper (behaviour is covered by provider-connection-status.test.ts), not be parsed out of the chip title',
     );
     assert.match(

--- a/apps/desktop/src/main/__tests__/provider-connection-status.test.ts
+++ b/apps/desktop/src/main/__tests__/provider-connection-status.test.ts
@@ -7,10 +7,9 @@
  * These cover the P2 fix: a lapsed OAuth subscription is persisted as
  * `enabled:false + lastTestStatus:'needs_reauth'` (main.ts subscription
  * sync keeps the connection but flags it). Before the fix the status copy
- * short-circuited on `!enabled` to "已禁用" and the group rollup only
- * looked at enabled connections, so a group holding nothing but a lapsed
- * login read as idle and hid the "please log back in" signal. Both
- * assertions below are red against that previous behaviour.
+ * short-circuited on `!enabled` to "已禁用", hiding the "please log back in"
+ * signal. `chipStatusTone` colors the same signal and must branch in
+ * lockstep with `chipStatusText`.
  */
 
 import { strict as assert } from 'node:assert';
@@ -18,7 +17,7 @@ import { describe, it } from 'node:test';
 import type { LlmConnection } from '@maka/core';
 import {
   chipStatusText,
-  rollupForGroup,
+  chipStatusTone,
 } from '../../renderer/settings/provider-connection-status.js';
 
 function conn(input: Partial<LlmConnection> = {}): LlmConnection {
@@ -70,36 +69,28 @@ describe('chipStatusText', () => {
   });
 });
 
-describe('rollupForGroup', () => {
-  it('raises a warn for a group holding only a lapsed login (was hidden as idle)', () => {
-    assert.equal(
-      rollupForGroup([conn({ enabled: false, lastTestStatus: 'needs_reauth' })]),
-      'warn',
-    );
+describe('chipStatusTone', () => {
+  it('tones a lapsed OAuth login as info even when enabled:false (needs_reauth wins)', () => {
+    // Mirrors the chipStatusText priority: needs_reauth must not fall through
+    // to the disabled/neutral branch, so the dot reads as actionable info.
+    assert.equal(chipStatusTone(conn({ enabled: false, lastTestStatus: 'needs_reauth' })), 'info');
+    assert.equal(chipStatusTone(conn({ enabled: true, lastTestStatus: 'needs_reauth' })), 'info');
   });
 
-  it('raises an err for a disabled connection that last errored', () => {
-    assert.equal(rollupForGroup([conn({ enabled: false, lastTestStatus: 'error' })]), 'err');
+  it('tones a bare disabled connection as neutral', () => {
+    assert.equal(chipStatusTone(conn({ enabled: false, lastTestStatus: undefined })), 'neutral');
   });
 
-  it('reports ok when a verified connection is present', () => {
-    assert.equal(rollupForGroup([conn({ enabled: true, lastTestStatus: 'verified' })]), 'ok');
+  it('tones verified as success, last failure as destructive, untested as neutral', () => {
+    assert.equal(chipStatusTone(conn({ lastTestStatus: 'verified' })), 'success');
+    assert.equal(chipStatusTone(conn({ lastTestStatus: 'error' })), 'destructive');
+    assert.equal(chipStatusTone(conn({ lastTestStatus: undefined })), 'neutral');
   });
 
-  it('reports idle for an untested group', () => {
-    assert.equal(rollupForGroup([conn({ lastTestStatus: undefined })]), 'idle');
-  });
-
-  it('prioritises err over warn over ok across mixed connections', () => {
-    const mixed = [
-      conn({ slug: 'a', lastTestStatus: 'verified' }),
-      conn({ slug: 'b', enabled: false, lastTestStatus: 'needs_reauth' }),
-      conn({ slug: 'c', lastTestStatus: 'error' }),
-    ];
-    assert.equal(rollupForGroup(mixed), 'err');
-    assert.equal(
-      rollupForGroup(mixed.filter((c) => c.lastTestStatus !== 'error')),
-      'warn',
-    );
+  it('tones a disabled+error connection neutral, mirroring the !enabled "暂不可用" copy', () => {
+    // !enabled short-circuits before the error branch, exactly like
+    // chipStatusText — the tone must never disagree with the visible copy.
+    assert.equal(chipStatusTone(conn({ enabled: false, lastTestStatus: 'error' })), 'neutral');
+    assert.equal(chipStatusText(conn({ enabled: false, lastTestStatus: 'error' })), '暂不可用');
   });
 });

--- a/apps/desktop/src/main/__tests__/provider-connection-status.test.ts
+++ b/apps/desktop/src/main/__tests__/provider-connection-status.test.ts
@@ -1,24 +1,22 @@
 /**
  * Behavioural tests for the Settings → 模型 connection-status logic that
- * `ProvidersPanel` renders. The helpers are pure (no React, no DOM) so we
- * exercise them directly from the desktop test runner, the same pattern as
+ * `ProvidersPanel` renders. The helper is pure (no React, no DOM) so we
+ * exercise it directly from the desktop test runner, the same pattern as
  * `connection-status.test.ts`.
  *
  * These cover the P2 fix: a lapsed OAuth subscription is persisted as
  * `enabled:false + lastTestStatus:'needs_reauth'` (main.ts subscription
  * sync keeps the connection but flags it). Before the fix the status copy
  * short-circuited on `!enabled` to "已禁用", hiding the "please log back in"
- * signal. `chipStatusTone` colors the same signal and must branch in
- * lockstep with `chipStatusText`.
+ * signal. And the PR #988 review fix: label and tone come from ONE state
+ * machine, so a disabled connection that last errored keeps its
+ * destructive signal instead of washing out to neutral.
  */
 
 import { strict as assert } from 'node:assert';
 import { describe, it } from 'node:test';
 import type { LlmConnection } from '@maka/core';
-import {
-  chipStatusText,
-  chipStatusTone,
-} from '../../renderer/settings/provider-connection-status.js';
+import { connectionChipStatus } from '../../renderer/settings/provider-connection-status.js';
 
 function conn(input: Partial<LlmConnection> = {}): LlmConnection {
   return {
@@ -33,27 +31,54 @@ function conn(input: Partial<LlmConnection> = {}): LlmConnection {
   };
 }
 
-describe('chipStatusText', () => {
-  it('shows "需要重新登录" for a lapsed OAuth login, never "已禁用"', () => {
-    const status = chipStatusText(conn({ enabled: false, lastTestStatus: 'needs_reauth' }));
-    assert.equal(status, '需要重新登录');
-    assert.notEqual(status, '已禁用');
+describe('connectionChipStatus', () => {
+  it('shows "需要重新登录" / info for a lapsed OAuth login, never "已禁用"', () => {
+    const status = connectionChipStatus(conn({ enabled: false, lastTestStatus: 'needs_reauth' }));
+    assert.deepEqual(status, { label: '需要重新登录', tone: 'info' });
+    assert.notEqual(status.label, '已禁用');
   });
 
-  it('shows "需要重新登录" for a still-enabled connection that needs reauth', () => {
-    assert.equal(chipStatusText(conn({ enabled: true, lastTestStatus: 'needs_reauth' })), '需要重新登录');
+  it('shows "需要重新登录" / info for a still-enabled connection that needs reauth', () => {
+    assert.deepEqual(
+      connectionChipStatus(conn({ enabled: true, lastTestStatus: 'needs_reauth' })),
+      { label: '需要重新登录', tone: 'info' },
+    );
+  });
+
+  it('keeps the failure signal for a disabled connection that last errored', () => {
+    // oauth-model-connections-main.ts failDiscovery() persists
+    // enabled:false + lastTestStatus:'error'. The disabled state must not
+    // swallow the failure: the label carries both facts and the tone stays
+    // destructive (PR #988 review P1).
+    assert.deepEqual(
+      connectionChipStatus(conn({ enabled: false, lastTestStatus: 'error' })),
+      { label: '暂不可用 · 上次连接失败', tone: 'destructive' },
+    );
   });
 
   it('falls back to a neutral "暂不可用" for a bare disabled connection', () => {
     // Only the legacy V1→V2 migration sets enabled:false without a
     // lastTestStatus; it must not read as a user-killed "已禁用".
-    assert.equal(chipStatusText(conn({ enabled: false, lastTestStatus: undefined })), '暂不可用');
+    assert.deepEqual(
+      connectionChipStatus(conn({ enabled: false, lastTestStatus: undefined })),
+      { label: '暂不可用', tone: 'neutral' },
+    );
+  });
+
+  it('does not paint a stale verified green on a disabled connection', () => {
+    // Intentional divergence from the retired is-verified CSS: a disabled
+    // connection with an old verified result reads neutral "暂不可用" —
+    // green on an unusable connection is misleading.
+    assert.deepEqual(
+      connectionChipStatus(conn({ enabled: false, lastTestStatus: 'verified' })),
+      { label: '暂不可用', tone: 'neutral' },
+    );
   });
 
   it('reports credential-only verification, last failure, and untested states', () => {
-    assert.equal(chipStatusText(conn({ lastTestStatus: 'verified' })), '凭据已验证');
-    assert.equal(chipStatusText(conn({ lastTestStatus: 'error' })), '上次连接失败');
-    assert.equal(chipStatusText(conn({ lastTestStatus: undefined })), '等待验证');
+    assert.deepEqual(connectionChipStatus(conn({ lastTestStatus: 'verified' })), { label: '凭据已验证', tone: 'success' });
+    assert.deepEqual(connectionChipStatus(conn({ lastTestStatus: 'error' })), { label: '上次连接失败', tone: 'destructive' });
+    assert.deepEqual(connectionChipStatus(conn({ lastTestStatus: undefined })), { label: '等待验证', tone: 'neutral' });
   });
 
   it('never labels any connection "已禁用"', () => {
@@ -61,36 +86,11 @@ describe('chipStatusText', () => {
       { enabled: false, lastTestStatus: 'needs_reauth' },
       { enabled: false, lastTestStatus: undefined },
       { enabled: false, lastTestStatus: 'error' },
+      { enabled: false, lastTestStatus: 'verified' },
       { enabled: true, lastTestStatus: 'verified' },
     ];
     for (const input of cases) {
-      assert.notEqual(chipStatusText(conn(input)), '已禁用');
+      assert.notEqual(connectionChipStatus(conn(input)).label, '已禁用');
     }
-  });
-});
-
-describe('chipStatusTone', () => {
-  it('tones a lapsed OAuth login as info even when enabled:false (needs_reauth wins)', () => {
-    // Mirrors the chipStatusText priority: needs_reauth must not fall through
-    // to the disabled/neutral branch, so the dot reads as actionable info.
-    assert.equal(chipStatusTone(conn({ enabled: false, lastTestStatus: 'needs_reauth' })), 'info');
-    assert.equal(chipStatusTone(conn({ enabled: true, lastTestStatus: 'needs_reauth' })), 'info');
-  });
-
-  it('tones a bare disabled connection as neutral', () => {
-    assert.equal(chipStatusTone(conn({ enabled: false, lastTestStatus: undefined })), 'neutral');
-  });
-
-  it('tones verified as success, last failure as destructive, untested as neutral', () => {
-    assert.equal(chipStatusTone(conn({ lastTestStatus: 'verified' })), 'success');
-    assert.equal(chipStatusTone(conn({ lastTestStatus: 'error' })), 'destructive');
-    assert.equal(chipStatusTone(conn({ lastTestStatus: undefined })), 'neutral');
-  });
-
-  it('tones a disabled+error connection neutral, mirroring the !enabled "暂不可用" copy', () => {
-    // !enabled short-circuits before the error branch, exactly like
-    // chipStatusText — the tone must never disagree with the visible copy.
-    assert.equal(chipStatusTone(conn({ enabled: false, lastTestStatus: 'error' })), 'neutral');
-    assert.equal(chipStatusText(conn({ enabled: false, lastTestStatus: 'error' })), '暂不可用');
   });
 });

--- a/apps/desktop/src/main/__tests__/renderer-style-pruning-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/renderer-style-pruning-contract.test.ts
@@ -14,17 +14,6 @@ const DYNAMIC_STYLE_HOOKS = new Set([
   // `os-theme-maka` theme at runtime.
   'os-scrollbar-horizontal',
   'os-scrollbar-vertical',
-  // ProvidersPanel builds these status modifiers with template strings:
-  // `enabledRollup is-${group.rollup}` and
-  // `enabledConnStatus is-${connection.lastTestStatus ?? 'untested'}`.
-  'is-err',
-  'is-error',
-  'is-idle',
-  'is-needs_reauth',
-  'is-ok',
-  'is-untested',
-  'is-verified',
-  'is-warn',
   // Token/runtime utility hooks defined in maka-tokens.css. These are
   // intentionally available to markdown renderers, prose plugins, and
   // shell surfaces without requiring a literal JSX className consumer.

--- a/apps/desktop/src/renderer/settings/ProvidersPanel.tsx
+++ b/apps/desktop/src/renderer/settings/ProvidersPanel.tsx
@@ -10,15 +10,14 @@ import {
   type ProviderType,
 } from '@maka/core';
 import {
-  Button,
+  Button, Chip,
   InputGroup, InputGroupAddon, InputGroupInput,
   PrimitiveTabs, PrimitiveTabsList, PrimitiveTabsTrigger, PrimitiveTabsPanel,
-  PrimitiveAccordion, PrimitiveAccordionItem, PrimitiveAccordionHeader, PrimitiveAccordionTrigger, PrimitiveAccordionPanel,
-  Item, ItemContent, ItemTitle, ItemActions,
+  Item, ItemMedia, ItemContent, ItemTitle, ItemDescription, ItemActions,
   useMountedRef,
   useToast,
 } from '@maka/ui';
-import { chipStatusText, rollupForGroup } from './provider-connection-status';
+import { chipStatusText, chipStatusTone } from './provider-connection-status';
 import { AddProviderForm } from './provider-add-form';
 import { ProviderCatalogCard } from './provider-catalog';
 import { ConnectionDetail } from './provider-connection-detail';
@@ -127,45 +126,6 @@ export function ProvidersPanel({ bridge, initialPage = 'connections' }: {
       : null,
     [connections, page],
   );
-
-  const providerGroups = useMemo(() => {
-    const order: ProviderType[] = [];
-    const byType = new Map<ProviderType, LlmConnection[]>();
-    for (const connection of connections) {
-      const list = byType.get(connection.providerType);
-      if (list) list.push(connection);
-      else {
-        byType.set(connection.providerType, [connection]);
-        order.push(connection.providerType);
-      }
-    }
-    return order.map((type) => {
-      const groupConnections = byType.get(type) ?? [];
-      return {
-        type,
-        name: providerDisplay(type).name,
-        connections: groupConnections,
-        rollup: rollupForGroup(groupConnections),
-      };
-    });
-  }, [connections]);
-
-  const defaultOpenGroups = useMemo(
-    () => providerGroups
-      .filter((group) =>
-        group.rollup === 'err' ||
-        group.rollup === 'warn' ||
-        group.connections.some((connection) => connection.slug === defaultSlug))
-      .map((group) => group.type),
-    [providerGroups, defaultSlug],
-  );
-  const pendingFocus = pendingFocusRef.current;
-  const focusRestoreGroup = pendingFocus?.kind === 'connection'
-    ? connections.find((connection) => connection.slug === pendingFocus.slug)?.providerType
-    : undefined;
-  const initialOpenGroups = focusRestoreGroup && !defaultOpenGroups.includes(focusRestoreGroup)
-    ? [...defaultOpenGroups, focusRestoreGroup]
-    : defaultOpenGroups;
 
   function chipTitle(connection: LlmConnection): string {
     return `${connection.name} · ${chipStatusText(connection)}`;
@@ -340,7 +300,7 @@ export function ProvidersPanel({ bridge, initialPage = 'connections' }: {
         <div className="enabledStrip" aria-label="模型连接">
           <div className="enabledStripHeader">
             <h3>已配置</h3>
-            {connections.length > 0 && <span>{providerGroups.length} 个服务商 · {connections.length} 个连接</span>}
+            {connections.length > 0 && <span>{connections.length} 个连接</span>}
           </div>
           {loadError ? (
             <BaseButton className="enabledEmptyChip enabledEmptyAction" type="button" onClick={() => void reload()}>
@@ -353,65 +313,35 @@ export function ProvidersPanel({ bridge, initialPage = 'connections' }: {
               <small>点击右上角“添加服务商”开始配置。</small>
             </div>
           ) : (
-            <PrimitiveAccordion className="enabledAccordion" multiple defaultValue={initialOpenGroups}>
-              {providerGroups.map((group) => {
-                const single = group.connections.length === 1;
-                const problem = group.rollup === 'err' || group.rollup === 'warn';
-                const rollupLabel = problem
-                  ? single
-                    ? chipStatusText(group.connections[0])
-                    : group.rollup === 'err' ? '有连接异常' : '需重新登录'
-                  : `${group.connections.length} 连接`;
-                return (
-                  <PrimitiveAccordionItem key={group.type} value={group.type} className="enabledProvider">
-                    <PrimitiveAccordionHeader className="enabledProviderHead">
-                      <PrimitiveAccordionTrigger className="enabledProviderTrigger">
-                        <ProviderLogo type={group.type} compact />
-                        <span className="enabledProviderName">{group.name}</span>
-                        <span className="enabledProviderMeta">
-                          <span className={`enabledRollup is-${group.rollup}`}>
-                            <span className="enabledStatusDot" aria-hidden="true" />
-                            {rollupLabel}
-                          </span>
-                          <ChevronRight className="enabledChevron" size={15} aria-hidden="true" />
-                        </span>
-                      </PrimitiveAccordionTrigger>
-                    </PrimitiveAccordionHeader>
-                    <PrimitiveAccordionPanel className="enabledProviderPanel">
-                      <ul role="list">
-                        {group.connections.map((connection) => (
-                          <li key={connection.slug}>
-                            <Item
-                              className="enabledConnRow mx-2 py-2 pr-6 pl-10"
-                              selected={connection.slug === defaultSlug}
-                              data-test-status={connection.lastTestStatus ?? 'untested'}
-                              data-connection-slug={connection.slug}
-                              data-disabled={connection.enabled ? undefined : 'true'}
-                              aria-label={chipAriaLabel(connection)}
-                              title={chipTitle(connection)}
-                              render={<button type="button" onClick={() => navigate({ kind: 'detail', slug: connection.slug }, { kind: 'child-back' })} />}
-                            >
-                              <ItemContent>
-                                <ItemTitle className="enabledConnTitle">
-                                  {connection.name}
-                                  {connection.slug === defaultSlug && <span className="enabledDefaultTag">默认</span>}
-                                </ItemTitle>
-                              </ItemContent>
-                              <ItemActions>
-                                <span className={`enabledConnStatus is-${connection.lastTestStatus ?? 'untested'}`}>
-                                  <span className="enabledStatusDot" aria-hidden="true" />
-                                  {chipStatusText(connection)}
-                                </span>
-                              </ItemActions>
-                            </Item>
-                          </li>
-                        ))}
-                      </ul>
-                    </PrimitiveAccordionPanel>
-                  </PrimitiveAccordionItem>
-                );
-              })}
-            </PrimitiveAccordion>
+            <ul className="connectionList" role="list">
+              {connections.map((connection) => (
+                <li key={connection.slug}>
+                  <Item
+                    className="connectionRow"
+                    selected={connection.slug === defaultSlug}
+                    data-test-status={connection.lastTestStatus ?? 'untested'}
+                    data-connection-slug={connection.slug}
+                    data-disabled={connection.enabled ? undefined : 'true'}
+                    aria-label={chipAriaLabel(connection)}
+                    title={chipTitle(connection)}
+                    render={<button type="button" onClick={() => navigate({ kind: 'detail', slug: connection.slug }, { kind: 'child-back' })} />}
+                  >
+                    <ItemMedia><ProviderLogo type={connection.providerType} compact /></ItemMedia>
+                    <ItemContent>
+                      <ItemTitle>
+                        {connection.name}
+                        {connection.slug === defaultSlug && <Chip size="sm" variant="accent">默认</Chip>}
+                      </ItemTitle>
+                      <ItemDescription>{providerDisplay(connection.providerType).name}</ItemDescription>
+                    </ItemContent>
+                    <ItemActions>
+                      <Chip dot size="sm" variant={chipStatusTone(connection)}>{chipStatusText(connection)}</Chip>
+                      <ChevronRight size={16} aria-hidden="true" />
+                    </ItemActions>
+                  </Item>
+                </li>
+              ))}
+            </ul>
           )}
         </div>
 

--- a/apps/desktop/src/renderer/settings/ProvidersPanel.tsx
+++ b/apps/desktop/src/renderer/settings/ProvidersPanel.tsx
@@ -17,7 +17,7 @@ import {
   useMountedRef,
   useToast,
 } from '@maka/ui';
-import { chipStatusText, chipStatusTone } from './provider-connection-status';
+import { connectionChipStatus } from './provider-connection-status';
 import { AddProviderForm } from './provider-add-form';
 import { ProviderCatalogCard } from './provider-catalog';
 import { ConnectionDetail } from './provider-connection-detail';
@@ -128,13 +128,13 @@ export function ProvidersPanel({ bridge, initialPage = 'connections' }: {
   );
 
   function chipTitle(connection: LlmConnection): string {
-    return `${connection.name} · ${chipStatusText(connection)}`;
+    return `${connection.name} · ${connectionChipStatus(connection).label}`;
   }
 
   function chipAriaLabel(connection: LlmConnection): string {
     const provider = providerDisplay(connection.providerType).name;
     const defaultSuffix = connection.slug === defaultSlug ? '，默认连接' : '';
-    return `模型连接：${connection.name}，供应商：${provider}${defaultSuffix}，${chipStatusText(connection)}`;
+    return `模型连接：${connection.name}，供应商：${provider}${defaultSuffix}，${connectionChipStatus(connection).label}`;
   }
 
   const configuredByType = (type: ProviderType) =>
@@ -314,33 +314,35 @@ export function ProvidersPanel({ bridge, initialPage = 'connections' }: {
             </div>
           ) : (
             <ul className="connectionList" role="list">
-              {connections.map((connection) => (
-                <li key={connection.slug}>
-                  <Item
-                    className="connectionRow"
-                    selected={connection.slug === defaultSlug}
-                    data-test-status={connection.lastTestStatus ?? 'untested'}
-                    data-connection-slug={connection.slug}
-                    data-disabled={connection.enabled ? undefined : 'true'}
-                    aria-label={chipAriaLabel(connection)}
-                    title={chipTitle(connection)}
-                    render={<button type="button" onClick={() => navigate({ kind: 'detail', slug: connection.slug }, { kind: 'child-back' })} />}
-                  >
-                    <ItemMedia><ProviderLogo type={connection.providerType} compact /></ItemMedia>
-                    <ItemContent>
-                      <ItemTitle>
-                        {connection.name}
-                        {connection.slug === defaultSlug && <Chip size="sm" variant="accent">默认</Chip>}
-                      </ItemTitle>
-                      <ItemDescription>{providerDisplay(connection.providerType).name}</ItemDescription>
-                    </ItemContent>
-                    <ItemActions>
-                      <Chip dot size="sm" variant={chipStatusTone(connection)}>{chipStatusText(connection)}</Chip>
-                      <ChevronRight size={16} aria-hidden="true" />
-                    </ItemActions>
-                  </Item>
-                </li>
-              ))}
+              {connections.map((connection) => {
+                const status = connectionChipStatus(connection);
+                return (
+                  <li key={connection.slug}>
+                    <Item
+                      className="connectionRow"
+                      selected={connection.slug === defaultSlug}
+                      data-connection-slug={connection.slug}
+                      data-disabled={connection.enabled ? undefined : 'true'}
+                      aria-label={chipAriaLabel(connection)}
+                      title={chipTitle(connection)}
+                      render={<button type="button" onClick={() => navigate({ kind: 'detail', slug: connection.slug }, { kind: 'child-back' })} />}
+                    >
+                      <ItemMedia><ProviderLogo type={connection.providerType} compact /></ItemMedia>
+                      <ItemContent>
+                        <ItemTitle>
+                          {connection.name}
+                          {connection.slug === defaultSlug && <Chip size="sm" variant="accent">默认</Chip>}
+                        </ItemTitle>
+                        <ItemDescription>{providerDisplay(connection.providerType).name}</ItemDescription>
+                      </ItemContent>
+                      <ItemActions>
+                        <Chip dot size="sm" variant={status.tone}>{status.label}</Chip>
+                        <ChevronRight size={16} aria-hidden="true" />
+                      </ItemActions>
+                    </Item>
+                  </li>
+                );
+              })}
             </ul>
           )}
         </div>

--- a/apps/desktop/src/renderer/settings/provider-connection-status.ts
+++ b/apps/desktop/src/renderer/settings/provider-connection-status.ts
@@ -1,4 +1,4 @@
-// Pure status helpers for the Settings → 模型 connection list. Kept out
+// Pure status helper for the Settings → 模型 connection list. Kept out
 // of `ProvidersPanel.tsx` (no React, no DOM) so the decision logic can be
 // exercised directly from the desktop test runner, the same way
 // `connection-status.ts` is. Behavioural tests live in
@@ -7,52 +7,50 @@
 import type { LlmConnection } from '@maka/core';
 import type { StatusTone } from './settings-status-badge';
 
-/**
- * Status copy for one connection in the 模型连接 list. A lapsed OAuth
- * subscription login arrives as enabled:false + needs_reauth (main.ts
- * subscription sync keeps the connection but flags it). That is a
- * "please log back in" signal, not a user-killed connection, so
- * needs_reauth wins over the disabled check and must never read as
- * "已禁用". A bare enabled:false (only the legacy V1→V2 migration sets
- * that, untested) falls through to the neutral "暂不可用".
- */
-export function chipStatusText(connection: LlmConnection): string {
-  if (connection.lastTestStatus === 'needs_reauth') return '需要重新登录';
-  if (!connection.enabled) return '暂不可用';
-  switch (connection.lastTestStatus) {
-    case 'verified':
-      // PR-UI-AUDIT-1 (@kenji msg 7a16aa0b): `verified` is a
-      // credential-validation result only; it does NOT prove
-      // agent send / stream / interrupt paths are operational
-      // (provider-auth contract). Older copy
-      // "已验证可用" conflated validation with operational
-      // readiness, fixed to credential-only language. Matches
-      // the doc warning at SettingsModal `验证通过 ≠ 运行可用`.
-      return '凭据已验证';
-    case 'error':
-      return '上次连接失败';
-    default:
-      return '等待验证';
-  }
+export interface ConnectionChipStatus {
+  label: string;
+  tone: StatusTone;
 }
 
 /**
- * Status tone for one connection's Chip in the 模型连接 list. The branch
- * order mirrors `chipStatusText` exactly so the dot color and the copy can
- * never disagree: a lapsed OAuth login (enabled:false + needs_reauth) reads
- * as an actionable `info` ("please log back in"), a bare disabled connection
- * as `neutral`, verified as `success`, a last failure as `destructive`, and
- * an untested connection as `neutral`.
+ * Status copy + tone for one connection's Chip in the 模型连接 list. One
+ * state machine returns both so the color can never disagree with the
+ * visible copy (PR #988 review: split label/tone helpers drifted — a
+ * disabled connection that last errored kept the failure copy but lost the
+ * destructive tone).
+ *
+ * Branches, in priority order:
+ * - needs_reauth: a lapsed OAuth subscription login arrives as
+ *   enabled:false + needs_reauth (main.ts subscription sync keeps the
+ *   connection but flags it). That is a "please log back in" signal, not a
+ *   user-killed connection, so needs_reauth wins over the disabled check
+ *   and must never read as "已禁用".
+ * - !enabled + error: oauth-model-connections-main.ts failDiscovery()
+ *   persists enabled:false + lastTestStatus:'error', so the failure signal
+ *   must survive the disabled state — label carries both facts, tone stays
+ *   destructive.
+ * - !enabled (bare, or disabled+verified): neutral "暂不可用". A stale
+ *   verified result must not paint a green light on an unusable connection.
+ * - verified: PR-UI-AUDIT-1 (@kenji msg 7a16aa0b): `verified` is a
+ *   credential-validation result only; it does NOT prove agent send /
+ *   stream / interrupt paths are operational (provider-auth contract).
+ *   Older copy "已验证可用" conflated validation with operational
+ *   readiness, fixed to credential-only language. Matches the doc warning
+ *   at SettingsModal `验证通过 ≠ 运行可用`.
  */
-export function chipStatusTone(connection: LlmConnection): StatusTone {
-  if (connection.lastTestStatus === 'needs_reauth') return 'info';
-  if (!connection.enabled) return 'neutral';
+export function connectionChipStatus(connection: LlmConnection): ConnectionChipStatus {
+  if (connection.lastTestStatus === 'needs_reauth') return { label: '需要重新登录', tone: 'info' };
+  if (!connection.enabled) {
+    return connection.lastTestStatus === 'error'
+      ? { label: '暂不可用 · 上次连接失败', tone: 'destructive' }
+      : { label: '暂不可用', tone: 'neutral' };
+  }
   switch (connection.lastTestStatus) {
     case 'verified':
-      return 'success';
+      return { label: '凭据已验证', tone: 'success' };
     case 'error':
-      return 'destructive';
+      return { label: '上次连接失败', tone: 'destructive' };
     default:
-      return 'neutral';
+      return { label: '等待验证', tone: 'neutral' };
   }
 }

--- a/apps/desktop/src/renderer/settings/provider-connection-status.ts
+++ b/apps/desktop/src/renderer/settings/provider-connection-status.ts
@@ -5,6 +5,7 @@
 // `provider-connection-status.test.ts`.
 
 import type { LlmConnection } from '@maka/core';
+import type { StatusTone } from './settings-status-badge';
 
 /**
  * Status copy for one connection in the 模型连接 list. A lapsed OAuth
@@ -35,18 +36,23 @@ export function chipStatusText(connection: LlmConnection): string {
   }
 }
 
-export type GroupRollup = 'err' | 'warn' | 'ok' | 'idle';
-
 /**
- * Worst-status rollup for a provider group's collapsed header, computed
- * over the FULL group rather than only enabled connections: a lapsed
- * OAuth subscription (enabled:false + needs_reauth) must still raise the
- * header so the user sees they need to log back in. An enabled-only
- * rollup read such a group as idle and hid the problem.
+ * Status tone for one connection's Chip in the 模型连接 list. The branch
+ * order mirrors `chipStatusText` exactly so the dot color and the copy can
+ * never disagree: a lapsed OAuth login (enabled:false + needs_reauth) reads
+ * as an actionable `info` ("please log back in"), a bare disabled connection
+ * as `neutral`, verified as `success`, a last failure as `destructive`, and
+ * an untested connection as `neutral`.
  */
-export function rollupForGroup(connections: LlmConnection[]): GroupRollup {
-  if (connections.some((c) => c.lastTestStatus === 'error')) return 'err';
-  if (connections.some((c) => c.lastTestStatus === 'needs_reauth')) return 'warn';
-  if (connections.some((c) => c.lastTestStatus === 'verified')) return 'ok';
-  return 'idle';
+export function chipStatusTone(connection: LlmConnection): StatusTone {
+  if (connection.lastTestStatus === 'needs_reauth') return 'info';
+  if (!connection.enabled) return 'neutral';
+  switch (connection.lastTestStatus) {
+    case 'verified':
+      return 'success';
+    case 'error':
+      return 'destructive';
+    default:
+      return 'neutral';
+  }
 }

--- a/apps/desktop/src/renderer/styles/settings/models.css
+++ b/apps/desktop/src/renderer/styles/settings/models.css
@@ -1,147 +1,32 @@
-/* ---- Enabled models: provider → connection hierarchy (Base UI Accordion).
- * Each provider is a collapsible row; its connections live in the panel, so
- * the list reads as provider over connection instead of a flat peer list.
- * Problem providers open by default (see defaultOpenGroups). ---- */
-/* Seamless list: no card box (it was the heaviest element on the page and
- * clashed with the catalog below). Hairline top/bottom bounds the group;
- * whitespace + the logo plates carry the structure. */
-.enabledAccordion {
+/* ---- Enabled models: flat connection list. Each connection is one
+ * top-level row (logo · name + provider · status chip · chevron), sorted
+ * strictly in bridge.list() order. The Item primitive carries the row
+ * chrome (media / content / actions, hover + selected fills); this file
+ * only owns the scroll container, the hairline between rows, and the
+ * disabled dimming. Status tone lives on the Chip primitive, the default
+ * marker on the Chip `accent` variant — no bespoke status/tag CSS here. */
+.connectionList {
   max-height: 360px;
   overflow-y: auto;
-}
-
-.enabledProvider + .enabledProvider {
-  border-top: var(--border-width-hairline) solid oklch(from var(--foreground) l c h / 0.06);
-}
-
-.enabledProviderHead { margin: 0; }
-
-.enabledProviderTrigger {
-  display: flex;
-  align-items: center;
-  gap: var(--space-3);
-  width: 100%;
-  /* pad-x 6 + logo 32 + gap 11 = 49 → connection name (pl-[49px]) sits
-   * directly under the provider name; pr keeps the rollup status right
-   * edge aligned with the connection status (pr-[32px] = 6 + chevron 15 +
-   * meta gap 11). */
-  padding: var(--space-3) var(--space-1-5);
-  background: transparent;
-  border: 0;
-  color: var(--foreground);
-  font: inherit;
-  text-align: left;
-  transition: background-color var(--duration-quick) var(--ease-out-strong);
-}
-
-/* Round 10: interactive fills in the seamless list are ROUNDED like every
-   other row surface in the app (sidebar nav, session list) — square
-   full-bleed bands broke the radius language. */
-.enabledProviderTrigger { border-radius: var(--radius-control); }
-.enabledProviderTrigger:hover { background: var(--state-hover-bg); }
-
-.enabledProviderName {
-  font-size: var(--font-size-ui);
-  font-weight: var(--font-weight-semibold);
-  letter-spacing: var(--tracking-normal);
-  min-width: 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.enabledProviderMeta {
-  margin-left: auto;
-  flex: 0 0 auto;
-  display: flex;
-  align-items: center;
-  gap: var(--space-3);
-}
-
-.enabledChevron {
-  color: var(--muted-foreground);
-  transition: transform var(--duration-base) var(--ease-out-strong);
-}
-
-.enabledProviderTrigger[data-panel-open] .enabledChevron,
-.enabledProvider[data-open] .enabledChevron {
-  transform: rotate(90deg);
-}
-
-/* status line, shared by the provider rollup and each connection row;
- * the dot inherits the text color via currentColor. */
-.enabledRollup,
-.enabledConnStatus {
-  display: inline-flex;
-  align-items: center;
-  gap: var(--space-1-5);
-  font-size: var(--font-size-ui);
-  white-space: nowrap;
-  color: var(--muted-foreground);
-}
-
-.enabledStatusDot {
-  width: 7px;
-  height: 7px;
-  border-radius: 50%;
-  background: currentColor;
-  flex: 0 0 auto;
-}
-
-.enabledRollup.is-ok,
-.enabledConnStatus.is-verified { color: var(--success); }
-.enabledRollup.is-warn,
-.enabledConnStatus.is-needs_reauth { color: var(--info-text); }
-.enabledRollup.is-err,
-.enabledConnStatus.is-error { color: var(--destructive); }
-.enabledRollup.is-idle,
-.enabledConnStatus.is-untested { color: var(--muted-foreground); }
-
-/* Connection-row harmonization: the expanded panel used to paint a
-   full-bleed 2% wash + top border from x=0 — an edge-to-edge band under
-   the logo column that read as a different component from the catalog
-   rows below. The panel is transparent now; the rounded row fills
-   (hover / selected) carry the state, inset from the edges like every
-   other row surface. */
-.enabledProviderPanel {
-  padding-bottom: var(--space-1);
-}
-
-.enabledProviderPanel ul {
   margin: 0;
   padding: 0;
   list-style: none;
 }
 
-.enabledProviderPanel li + li .enabledConnRow {
-  border-top: var(--border-width-hairline) solid oklch(from var(--foreground) l c h / 0.07);
-}
-
-.enabledConnRow {
+.connectionRow {
   border-radius: var(--radius-control);
 }
 
-/* The default-connection selected wash now rides the Item `selected` prop
-   (data-selected → --state-selected-bg), so no bespoke [data-default] fill
-   rule remains here — one selected-row implementation across the app. */
+.connectionList li + li .connectionRow {
+  border-top: var(--border-width-hairline) solid oklch(from var(--foreground) l c h / 0.06);
+}
 
-.enabledConnRow[data-disabled="true"] {
+/* The default-connection selected wash rides the Item `selected` prop
+   (data-selected → --state-selected-bg), one selected-row implementation
+   across the app. */
+
+.connectionRow[data-disabled="true"] {
   opacity: var(--opacity-muted);
-}
-
-.enabledConnTitle {
-  display: inline-flex;
-  align-items: center;
-  gap: var(--space-2);
-}
-
-.enabledDefaultTag {
-  font-size: var(--font-size-caption);
-  font-weight: var(--font-weight-semibold);
-  color: var(--nav-active);
-  background: oklch(from var(--nav-active) l c h / 0.14);
-  border-radius: var(--radius-pill);
-  padding: 1px var(--space-2);
 }
 
 .catalogPillTabs,

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -112,8 +112,9 @@ export type { BadgeProps } from './primitives/badge.js';
 // PR-USE-SHADCN-BASE-UI-CHIP: squared compact status label. #520 PR9 collapsed
 // .settingsBadge + .settingsConnectionBadge CSS chips onto this one. Chip is
 // the squared (radius-control) counterpart to pill Badge, for dense settings
-// status rows. Variants mirror StatusTone: neutral / info / success / warning
-// / destructive.
+// status rows. Status variants mirror StatusTone: neutral / info / success /
+// warning / destructive; `accent` is the separate brand-accent marker
+// (default-connection flags) outside the status scale.
 export { Chip, chipVariants } from './primitives/chip.js';
 export type { ChipProps } from './primitives/chip.js';
 // PageHeader — the shared page-header shell (convergence round 3). One shell

--- a/packages/ui/src/primitives/chip.tsx
+++ b/packages/ui/src/primitives/chip.tsx
@@ -11,10 +11,12 @@ import type React from "react";
 // squared counterpart to the pill Badge primitive:
 //   - Badge = emphasis marker (pill, radius-pill) — health/permission center
 //   - Chip  = status label (squared, radius-control) — settings rows
-// Variants mirror StatusTone so settings callers pass the tone straight
-// through with no mapping function. Visual values reproduce the retired
-// .settingsConnectionBadge oklch alphas (success /12, info /14, warning /18,
-// destructive /15) and the .settingsBadge neutral (foreground-5) base.
+// The status variants mirror StatusTone so settings callers pass the tone
+// straight through with no mapping function; `accent` is a separate
+// brand-accent marker (default-connection flags) outside the status scale.
+// Visual values reproduce the retired .settingsConnectionBadge oklch alphas
+// (success /12, info /14, warning /18, destructive /15) and the .settingsBadge
+// neutral (foreground-5) base.
 export const chipVariants = cva(
   "inline-flex items-center whitespace-nowrap rounded-[var(--radius-control)] text-xs outline-none [&_svg]:pointer-events-none [&_svg]:shrink-0",
   {
@@ -34,6 +36,11 @@ export const chipVariants = cva(
         success: "bg-success/12 text-success",
         warning: "bg-warning/18 text-warning-foreground font-bold",
         destructive: "bg-destructive/15 text-destructive font-bold",
+        // Brand-accent marker for "default connection" style flags. Visual
+        // values reproduce the retired .enabledDefaultTag (nav-active text on
+        // a nav-active /14 wash) so the 默认 marker reads as brand accent, not
+        // a status tone.
+        accent: "bg-nav-active/14 text-nav-active font-semibold",
       },
     },
   },

--- a/packages/ui/src/primitives/chip.tsx
+++ b/packages/ui/src/primitives/chip.tsx
@@ -36,11 +36,15 @@ export const chipVariants = cva(
         success: "bg-success/12 text-success",
         warning: "bg-warning/18 text-warning-foreground font-bold",
         destructive: "bg-destructive/15 text-destructive font-bold",
-        // Brand-accent marker for "default connection" style flags. Visual
-        // values reproduce the retired .enabledDefaultTag (nav-active text on
-        // a nav-active /14 wash) so the 默认 marker reads as brand accent, not
-        // a status tone.
-        accent: "bg-nav-active/14 text-nav-active font-semibold",
+        // Brand-accent marker for "default connection" style flags — the
+        // nav-active /14 wash carries the brand tone, not a status tone.
+        // Text is foreground-secondary, NOT raw nav-active: the
+        // design-system-governance-406 contract records raw --nav-active
+        // text at 2.66:1 on white (fails WCAG AA 4.5:1); the readable-accent
+        // precedent (permission-mode chip) keeps the tone on the background
+        // and uses --foreground-secondary (~8:1 light / ~7.5:1 dark) for
+        // the label.
+        accent: "bg-nav-active/14 text-[var(--foreground-secondary)] font-semibold",
       },
     },
   },


### PR DESCRIPTION
## Summary

Settings → Models grouped saved connections under per-provider accordions, hiding each connection's default/enabled/test state behind an expansion step. This PR renders every saved connection as one top-level row — provider logo and name become row metadata (`ItemMedia` + `ItemDescription`), while the connection name, default marker, enabled state, and latest test status are all visible without expansion. Rows keep `bridge.list()` order and route to the existing detail child page; default/test/delete flows are untouched. Closes #864.

Page-level governance ships with the refactor instead of leaving parallel styling behind:

- Bespoke status dot/text CSS (`.enabledConnStatus`, `.enabledStatusDot`, `.enabledRollup`) migrates to the `Chip` primitive (`dot`, `size="sm"`), matching the bot-channel rows; a new pure `chipStatusTone()` maps connection state to `StatusTone`.
- `.enabledDefaultTag` leaked `--nav-active` into a hand-rolled pill; the 默认 marker now uses a new `accent` variant on `Chip`, added at the primitive seam.
- `rollupForGroup`, the accordion open-state machine (`providerGroups` / `defaultOpenGroups` / `initialOpenGroups`), and ~115 lines of accordion CSS are deleted; hairline separators unified to the 0.06 foreground alpha.

Net: 7 files, +100/−293.

## Screenshots

<img width="2608" height="877" alt="image" src="https://github.com/user-attachments/assets/eb4486ee-5e04-45ed-aa2b-fbe769a2ad91" />

## Verification

- `npm --workspace @maka/ui run build` + `typecheck`; `npm --workspace @maka/desktop run typecheck` (main / renderer / storybook): pass.
- Desktop main test suite after rebasing onto latest `main`: 2516 pass / 0 fail, including provider-navigation, storybook-baseline, renderer-style-pruning, and the new `chipStatusTone` unit tests.
- E2E `providers.spec.ts -g "restores keyboard focus across provider child pages"`: 1 passed (focus restore via `data-connection-slug` is preserved).
- Real-window screenshot harness re-run for `provider-workspace` (light 1280/990 × motion/reduced-motion); visually confirmed flat rows, accent default chip, all four status tones, hairlines, and bridge ordering.
- Not run: full E2E suite (unrelated to this surface); stories already cover same-provider connections, the default connection, problem states, and a disabled connection (`configuredConnections` / `problemConnections`).