### PR TITLE
feat(cli): TUI rendering polish — statusline density, picker widths, truncation fixes

### DIFF
--- a/packages/cli/src/__tests__/pi-transcript.test.ts
+++ b/packages/cli/src/__tests__/pi-transcript.test.ts
@@ -493,7 +493,7 @@ describe('Maka Pi TUI transcript', () => {
     ] satisfies StoredMessage[]);
 
     const rendered = renderMakaPiTranscript(state, meta(), 100).map(stripAnsi).join('\n');
-    assert.match(rendered, /Tool Bash \$ npm test done 5s/);
+    assert.match(rendered, /Tool Bash \$ npm test done 5000ms/);
   });
 
   test('rebuilds automatic context compaction notes from stored session messages', () => {
@@ -1006,7 +1006,7 @@ describe('Maka Pi TUI transcript', () => {
 
     assert.equal(refreshRunningShellRunElapsed(state, 13_500), true);
     const rendered = renderMakaPiTranscript(state, meta(), 100).map(stripAnsi).join('\n');
-    assert.match(rendered, /running 12s/);
+    assert.match(rendered, /running 12500ms/);
     assert.match(rendered, /Ask Maka to stop this task/);
   });
 
@@ -1209,7 +1209,7 @@ describe('Maka Pi TUI transcript', () => {
 
     assert.equal(applied, true);
     const rendered = renderMakaPiTranscript(state, meta(), 100).map(stripAnsi).join('\n');
-    assert.match(rendered, /Tool Bash \$ build done 4s/);
+    assert.match(rendered, /Tool Bash \$ build done 4000ms/);
     assert.match(rendered, /done/);
   });
 

--- a/packages/cli/src/__tests__/pi-transcript.test.ts
+++ b/packages/cli/src/__tests__/pi-transcript.test.ts
@@ -493,7 +493,7 @@ describe('Maka Pi TUI transcript', () => {
     ] satisfies StoredMessage[]);
 
     const rendered = renderMakaPiTranscript(state, meta(), 100).map(stripAnsi).join('\n');
-    assert.match(rendered, /Tool Bash \$ npm test done 5000ms/);
+    assert.match(rendered, /Tool Bash done 5000ms \$ npm test/);
   });
 
   test('rebuilds automatic context compaction notes from stored session messages', () => {
@@ -887,7 +887,7 @@ describe('Maka Pi TUI transcript', () => {
 
     // Compact cards are at most two lines (plus the leading blank separator).
     assert.equal(compactLines.length, 3);
-    assert.match(compact, /Tool Bash \$ npm test done/);
+    assert.match(compact, /Tool Bash done \$ npm test/);
     assert.match(compact, /\(31 lines\) row-29 \(Ctrl\+O\)/);
     assert.doesNotMatch(compact, /head-line/);
 
@@ -964,7 +964,7 @@ describe('Maka Pi TUI transcript', () => {
     const lines = renderMakaPiTranscript(state, meta(), 120).map(stripAnsi);
     assert.equal(lines.length, 3);
     const compact = lines.join('\n');
-    assert.match(compact, /Tool Bash \$ npm run build running/);
+    assert.match(compact, /Tool Bash running \$ npm run build/);
     assert.match(compact, /step two \(Ctrl\+O\)/);
     assert.doesNotMatch(compact, /step one/);
   });
@@ -988,7 +988,7 @@ describe('Maka Pi TUI transcript', () => {
     const tool = state.entries.find((entry) => entry.kind === 'tool');
     assert.equal(tool?.kind === 'tool' ? tool.status : undefined, 'running');
     const rendered = renderMakaPiTranscript(state, meta(), 100).map(stripAnsi).join('\n');
-    assert.match(rendered, /Tool Bash \$ sleep 30 running/);
+    assert.match(rendered, /Tool Bash running 10000ms \$ sleep 30/);
     assert.doesNotMatch(rendered, /Tool Bash .* done/);
     assert.equal(rendered.split('$ sleep 30').length - 1, 1);
   });
@@ -1189,7 +1189,7 @@ describe('Maka Pi TUI transcript', () => {
     assert.equal(tools.length, 1);
     assert.equal(tools[0]?.status, 'aborted');
     const rendered = renderMakaPiTranscript(state, meta(), 100).map(stripAnsi).join('\n');
-    assert.match(rendered, /Tool Bash \$ sleep 30 aborted/);
+    assert.match(rendered, /Tool Bash aborted 7000ms \$ sleep 30/);
     assert.doesNotMatch(rendered, /Tool StopBackgroundTask/);
   });
 
@@ -1209,7 +1209,7 @@ describe('Maka Pi TUI transcript', () => {
 
     assert.equal(applied, true);
     const rendered = renderMakaPiTranscript(state, meta(), 100).map(stripAnsi).join('\n');
-    assert.match(rendered, /Tool Bash \$ build done 4000ms/);
+    assert.match(rendered, /Tool Bash done 4000ms \$ build/);
     assert.match(rendered, /done/);
   });
 
@@ -1525,7 +1525,7 @@ describe('Maka Pi TUI transcript', () => {
     const compactLines = renderMakaPiTranscript(state, meta(), 100).map(stripAnsi);
     assert.equal(compactLines.length, 3);
     const compact = compactLines.join('\n');
-    assert.match(compact, /Tool Glob \*\*\/\*\.ts in packages done/);
+    assert.match(compact, /Tool Glob done \*\*\/\*\.ts in packages/);
     assert.match(compact, /3 files \(Ctrl\+O\)/);
     assert.doesNotMatch(compact, /src\/a\.ts/);
 
@@ -1605,7 +1605,7 @@ describe('Maka Pi TUI transcript', () => {
     const lines = renderMakaPiTranscript(state, meta(), 200).map(stripAnsi);
     // Never more than two card lines: multi-line JSON must not split the header.
     assert.equal(lines.length, 3);
-    assert.match(lines[1] ?? '', /Tool Frobnicate input: \{"alpha":1,"beta":"two"\} done/);
+    assert.match(lines[1] ?? '', /Tool Frobnicate done input: \{"alpha":1,"beta":"two"\}/);
     assert.match(lines[2] ?? '', /\{"gamma":3,"delta":"four"\}/);
   });
 

--- a/packages/cli/src/__tests__/pi-transcript.test.ts
+++ b/packages/cli/src/__tests__/pi-transcript.test.ts
@@ -1747,7 +1747,7 @@ describe('Maka Pi TUI transcript', () => {
 
     const lines = renderMakaPiTranscript(state, meta(), 100).map(stripAnsi);
     assert.equal(lines.length, 3);
-    assert.match(lines.join('\n'), /wrote 42 bytes out\.txt/);
+    assert.match(lines.join('\n'), /Wrote 42 bytes to out\.txt/);
     assert.doesNotMatch(lines.join('\n'), /\(Ctrl\+O\)/);
   });
 

--- a/packages/cli/src/__tests__/pi-tui-runner.test.ts
+++ b/packages/cli/src/__tests__/pi-tui-runner.test.ts
@@ -408,7 +408,7 @@ describe('Maka Pi TUI runner', () => {
     assertBottomPickerPlacement(
       terminal,
       'Choose an approach',
-      'Maka claude-sonnet-4-5 claude-subscription ask /repo',
+      'Maka · ask · claude-sonnet-4-5 · claude-subscription · /repo',
     );
     assert.ok(plainTerminalOutput(terminal.screenOutput()).includes('Ctrl+C stop'));
 
@@ -649,10 +649,10 @@ describe('Maka Pi TUI runner', () => {
       terminal,
     });
 
-    await waitFor(() => plainTerminalOutput(terminal.output()).includes('Maka deepseek-v4-flash deepseek ask /repo'));
+    await waitFor(() => plainTerminalOutput(terminal.output()).includes('Maka · ask · deepseek-v4-flash · deepseek · /repo'));
 
     const lines = plainTerminalOutput(terminal.output()).split(/\r?\n/);
-    const statusLineIndex = lines.findIndex((line) => line.includes('Maka deepseek-v4-flash deepseek ask /repo'));
+    const statusLineIndex = lines.findIndex((line) => line.includes('Maka · ask · deepseek-v4-flash · deepseek · /repo'));
     const editorBorderIndexes = lines
       .map((line, index) => (/^─+$/.test(line) ? index : -1))
       .filter((index) => index >= 0);
@@ -708,10 +708,10 @@ describe('Maka Pi TUI runner', () => {
       terminal,
     });
 
-    await waitFor(() => plainTerminalOutput(terminal.output()).includes('Maka deepseek-v4-flash deepseek ask /repo'));
+    await waitFor(() => plainTerminalOutput(terminal.output()).includes('Maka · ask · deepseek-v4-flash · deepseek · /repo'));
 
     const lines = plainTerminalOutput(terminal.output()).split(/\r?\n/);
-    const statusLineIndex = lines.findIndex((line) => line.includes('Maka deepseek-v4-flash deepseek ask /repo'));
+    const statusLineIndex = lines.findIndex((line) => line.includes('Maka · ask · deepseek-v4-flash · deepseek · /repo'));
     const editorBorderIndexes = lines
       .map((line, index) => (/^─+$/.test(line) ? index : -1))
       .filter((index) => index >= 0);
@@ -759,7 +759,7 @@ describe('Maka Pi TUI runner', () => {
     const screen = plainTerminalOutput(terminal.screenOutput()).split(/\r?\n/);
     assert.ok(screen.some((line) => line.includes('filler line 40')), 'the live tail should be on screen');
     assert.equal(screen.some((line) => line.includes('filler line 1')), false, 'the head should have scrolled off');
-    assert.equal(screen[terminal.rows - 1]?.includes('Maka deepseek-v4-flash deepseek ask /repo'), true);
+    assert.equal(screen[terminal.rows - 1]?.includes('Maka · ask · deepseek-v4-flash · deepseek · /repo'), true);
 
     exitMaka(terminal);
     await Promise.race([
@@ -783,7 +783,7 @@ describe('Maka Pi TUI runner', () => {
       terminal,
     });
 
-    await waitFor(() => plainTerminalOutput(terminal.output()).includes('Maka deepseek-v4-flash deepseek ask /repo'));
+    await waitFor(() => plainTerminalOutput(terminal.output()).includes('Maka · ask · deepseek-v4-flash · deepseek · /repo'));
 
     terminal.input('\x1b');
     await delay(30);
@@ -1008,7 +1008,7 @@ describe('Maka Pi TUI runner', () => {
     await waitFor(() => plainTerminalOutput(terminal.output()).includes('/session'));
     const lines = plainTerminalOutput(terminal.output()).split(/\r?\n/);
     const suggestionIndex = lines.findIndex((line) => line.includes('/model'));
-    const statusLineIndex = lines.findIndex((line) => line.includes('Maka deepseek-v4-flash deepseek ask /repo'));
+    const statusLineIndex = lines.findIndex((line) => line.includes('Maka · ask · deepseek-v4-flash · deepseek · /repo'));
     const editorBorderIndexes = lines
       .map((line, index) => (/^─+$/.test(line) ? index : -1))
       .filter((index) => index >= 0);
@@ -1482,7 +1482,7 @@ describe('Maka Pi TUI runner', () => {
     assertBottomPickerPlacement(
       terminal,
       'Select Permission Mode',
-      'Maka claude-sonnet-4-5 claude-subscription ask /repo',
+      'Maka · ask · claude-sonnet-4-5 · claude-subscription · /repo',
     );
     terminal.input('\x1b[B');
     terminal.input('\r');
@@ -1554,7 +1554,7 @@ describe('Maka Pi TUI runner', () => {
     const titleLine = latestPlainLineContaining(terminal.output(), 'Select Model');
     assert.equal(titleLine.startsWith('Select Model'), true);
     assert.equal(visibleWidth(titleLine), terminal.columns);
-    assertBottomPickerPlacement(terminal, 'Select Model', 'Maka deepseek-v4-flash deepseek ask /repo');
+    assertBottomPickerPlacement(terminal, 'Select Model', 'Maka · ask · deepseek-v4-flash · deepseek · /repo');
     terminal.input('\x1b[B');
     terminal.input('\r');
     await waitFor(() => driver.models.length === 1);
@@ -1604,7 +1604,7 @@ describe('Maka Pi TUI runner', () => {
     assert.deepEqual(driver.models, ['glm-5.2']);
     assert.deepEqual(driver.modelConnections, ['zai']);
     // The status line now reflects both the new model and the new connection.
-    await waitFor(() => plainTerminalOutput(terminal.output()).includes('Maka glm-5.2 zai ask /repo'));
+    await waitFor(() => plainTerminalOutput(terminal.output()).includes('Maka · ask · glm-5.2 · zai · /repo'));
 
     exitMaka(terminal);
     await Promise.race([
@@ -1731,7 +1731,7 @@ describe('Maka Pi TUI runner', () => {
     assertBottomPickerPlacement(
       terminal,
       'Resume Session (Current Folder)',
-      'Maka claude-sonnet-4-5 claude-subscription ask /repo',
+      'Maka · ask · claude-sonnet-4-5 · claude-subscription · /repo',
     );
     terminal.input('\r');
     await waitFor(() => driver.sessionIds.length === 1);
@@ -2522,7 +2522,7 @@ describe('Maka Pi TUI runner', () => {
       terminal,
     });
 
-    await waitFor(() => plainTerminalOutput(terminal.output()).includes('Maka claude-sonnet-4-5 claude-subscription ask /repo'));
+    await waitFor(() => plainTerminalOutput(terminal.output()).includes('Maka · ask · claude-sonnet-4-5 · claude-subscription · /repo'));
 
     // A single Escape falls through to the editor: no picker yet.
     terminal.input('\x1b');
@@ -2559,7 +2559,7 @@ describe('Maka Pi TUI runner', () => {
       terminal,
     });
 
-    await waitFor(() => plainTerminalOutput(terminal.output()).includes('Maka claude-sonnet-4-5 claude-subscription ask /repo'));
+    await waitFor(() => plainTerminalOutput(terminal.output()).includes('Maka · ask · claude-sonnet-4-5 · claude-subscription · /repo'));
 
     // While a draft is present, Escape belongs to the editor (clear input), not
     // the rewind gesture. Two Escapes must not open the picker.
@@ -2594,7 +2594,7 @@ describe('Maka Pi TUI runner', () => {
       terminal,
     });
 
-    await waitFor(() => plainTerminalOutput(terminal.output()).includes('Maka claude-sonnet-4-5 claude-subscription ask /repo'));
+    await waitFor(() => plainTerminalOutput(terminal.output()).includes('Maka · ask · claude-sonnet-4-5 · claude-subscription · /repo'));
 
     // The editor stays neutral (empty) throughout, but a left-arrow between the
     // two Escapes breaks the gesture: the two Escapes must be consecutive.

--- a/packages/cli/src/__tests__/pi-tui-runner.test.ts
+++ b/packages/cli/src/__tests__/pi-tui-runner.test.ts
@@ -519,7 +519,7 @@ describe('Maka Pi TUI runner', () => {
         output: pipeOutput('done\n'),
       },
     });
-    await waitFor(() => plainTerminalOutput(terminal.screenOutput()).includes('done 4s'));
+    await waitFor(() => plainTerminalOutput(terminal.screenOutput()).includes('done 4000ms'));
 
     exitMaka(terminal);
     await run;
@@ -1835,7 +1835,7 @@ describe('Maka Pi TUI runner', () => {
     terminal.input('/session session-2');
     terminal.input('\r');
 
-    await waitFor(() => plainTerminalOutput(terminal.screenOutput()).includes('done 4s'));
+    await waitFor(() => plainTerminalOutput(terminal.screenOutput()).includes('done 4000ms'));
     assert.deepEqual(reads, ['session-2']);
 
     exitMaka(terminal);

--- a/packages/cli/src/pi-transcript-format.ts
+++ b/packages/cli/src/pi-transcript-format.ts
@@ -22,7 +22,7 @@ export function renderIndented(text: string, width: number, indent: number): str
 }
 
 export function fitLine(line: string, width: number): string {
-  return visibleWidth(line) > width ? truncateToWidth(line, width, '') : line;
+  return visibleWidth(line) > width ? truncateToWidth(line, width, '…') : line;
 }
 
 export function formatToolResultContent(content: ToolResultContent): string {

--- a/packages/cli/src/pi-transcript-tools.ts
+++ b/packages/cli/src/pi-transcript-tools.ts
@@ -52,7 +52,7 @@ function renderCompactToolBlock(entry: MakaPiToolEntry, width: number): string[]
   // so any multi-line summary text would silently break the two-line card.
   const inputSummary = collapseToSingleLine(toolInputSummary(entry));
   const header = `${ansi.yellow('Tool')} ${entry.title ?? entry.toolName}`
-    + `${inputSummary ? ` ${ansi.dim(inputSummary)}` : ''} ${toolStatusText(entry)}`;
+    + ` ${toolStatusText(entry)}${inputSummary ? ` ${ansi.dim(inputSummary)}` : ''}`;
   const lines = [fitLine(header, width)];
   const summary = compactToolSummary(entry, width);
   if (summary) {

--- a/packages/cli/src/pi-transcript-tools.ts
+++ b/packages/cli/src/pi-transcript-tools.ts
@@ -141,7 +141,7 @@ function compactToolSummary(entry: MakaPiToolEntry, width: number): CompactToolS
   if (result?.kind === 'terminal') return compactTerminalSummary(result, hasLiveOutput);
   if (result?.kind === 'file_diff') return compactDiffSummary(result);
   if (result?.kind === 'file_write') {
-    return { text: `wrote ${result.bytes} bytes ${result.path}`, expandable: hasLiveOutput };
+    return { text: `Wrote ${result.bytes} bytes to ${result.path}`, expandable: hasLiveOutput };
   }
 
   if (entry.toolName === 'Grep') {

--- a/packages/cli/src/pi-transcript-tools.ts
+++ b/packages/cli/src/pi-transcript-tools.ts
@@ -38,9 +38,7 @@ function toolStatusText(entry: MakaPiToolEntry): string {
         : ansi.red(entry.status);
   const duration = entry.durationMs === undefined
     ? ''
-    : entry.toolName === 'Bash' && entry.result?.kind === 'shell_run'
-      ? ansi.dim(` ${Math.floor(entry.durationMs / 1_000)}s`)
-      : ansi.dim(` ${entry.durationMs}ms`);
+    : ansi.dim(` ${entry.durationMs}ms`);
   return `${status}${duration}`;
 }
 

--- a/packages/cli/src/pi-transcript.ts
+++ b/packages/cli/src/pi-transcript.ts
@@ -1042,12 +1042,12 @@ function renderPermissionPrompt(
     }
   }
   const actions = request.rememberForTurnAllowed
-    ? 'y/Enter allow once  a allow for turn  n/Esc deny'
-    : 'y/Enter allow once  n/Esc deny';
+    ? `${ansi.bold('y')}${ansi.dim('/Enter allow once')}  ${ansi.bold('a')}${ansi.dim(' allow for turn')}  ${ansi.bold('n')}${ansi.dim('/Esc deny')}`
+    : `${ansi.bold('y')}${ansi.dim('/Enter allow once')}  ${ansi.bold('n')}${ansi.dim('/Esc deny')}`;
   const detailsAction = request.toolName === 'WriteStdin'
-    ? `  Ctrl+O ${detailsExpanded ? 'hide' : 'show'} full parameters`
+    ? `  ${ansi.dim('Ctrl+O ' + (detailsExpanded ? 'hide' : 'show') + ' full parameters')}`
     : '';
-  lines.push(fitLine(ansi.dim(`${actions}${detailsAction}`), width));
+  lines.push(fitLine(`${actions}${detailsAction}`, width));
   return lines;
 }
 

--- a/packages/cli/src/pi-transcript.ts
+++ b/packages/cli/src/pi-transcript.ts
@@ -120,6 +120,22 @@ export function createMakaPiTranscriptState(): MakaPiTranscriptState {
   };
 }
 
+function accumulateUsage(usage: MakaPiUsageSummary, msg: {
+  costUsd?: number;
+  input?: number;
+  cacheHitInput?: number;
+  cacheRead?: number;
+  cacheWriteInput?: number;
+  cacheCreation?: number;
+  cacheMissInput?: number;
+}): void {
+  usage.costUsd += msg.costUsd ?? 0;
+  const hit = msg.cacheHitInput ?? msg.cacheRead ?? 0;
+  const write = msg.cacheWriteInput ?? msg.cacheCreation ?? 0;
+  usage.cacheHitInput += hit;
+  usage.cacheMissInput += msg.cacheMissInput ?? Math.max(0, (msg.input ?? 0) - hit - write);
+}
+
 export function appendUserPrompt(state: MakaPiTranscriptState, text: string): void {
   state.entries.push({ kind: 'user', text });
 }
@@ -182,6 +198,9 @@ export function replaceTranscriptWithStoredMessages(
   state.expandAllTools = false;
   state.expandAllThinking = false;
   state.usage = { costUsd: 0, cacheHitInput: 0, cacheMissInput: 0 };
+  for (const msg of messages) {
+    if (msg.type === 'token_usage') accumulateUsage(state.usage, msg);
+  }
 }
 
 /** Toggle expansion of every tool card at once; false when there is none. */
@@ -452,9 +471,7 @@ export function applyMakaSessionEventToTranscript(
       break;
 
     case 'token_usage': {
-      state.usage.costUsd += event.costUsd ?? 0;
-      state.usage.cacheHitInput += event.cacheHitInput ?? event.cacheRead ?? 0;
-      state.usage.cacheMissInput += event.cacheMissInput ?? 0;
+      accumulateUsage(state.usage, event);
       state.usage.contextRemaining = event.contextRemaining;
       const notice = contextBudgetOutcomeNotice(event.contextBudget);
       if (notice) {
@@ -934,7 +951,7 @@ function formatTokenCount(tokens: number): string {
 }
 
 function formatCost(costUsd: number): string {
-  if (costUsd < 0.01) return costUsd.toFixed(4);
+  if (costUsd < 0.01) return '<0.01';
   return costUsd.toFixed(2);
 }
 

--- a/packages/cli/src/pi-transcript.ts
+++ b/packages/cli/src/pi-transcript.ts
@@ -914,7 +914,7 @@ export function renderMakaPiStatusLine(metadata: MakaPiTranscriptMetadata, width
       parts.push(ansi.dim(`ctx ${formatTokenCount(usage.contextRemaining)}`));
     }
     if (usage.costUsd > 0) {
-      parts.push(ansi.dim(`$${usage.costUsd.toFixed(2)}`));
+      parts.push(ansi.dim(`$${formatCost(usage.costUsd)}`));
     }
     const totalCache = usage.cacheHitInput + usage.cacheMissInput;
     if (totalCache > 0) {
@@ -931,6 +931,11 @@ function formatTokenCount(tokens: number): string {
   if (tokens >= 1_000_000) return `${(tokens / 1_000_000).toFixed(1)}M`;
   if (tokens >= 1_000) return `${Math.round(tokens / 1_000)}k`;
   return String(tokens);
+}
+
+function formatCost(costUsd: number): string {
+  if (costUsd < 0.01) return costUsd.toFixed(4);
+  return costUsd.toFixed(2);
 }
 
 function appendAssistantText(state: MakaPiTranscriptState, messageId: string, text: string): void {

--- a/packages/cli/src/pi-transcript.ts
+++ b/packages/cli/src/pi-transcript.ts
@@ -31,6 +31,17 @@ import {
 } from './pi-transcript-format.js';
 import { renderToolBlock } from './pi-transcript-tools.js';
 
+export interface MakaPiUsageSummary {
+  /** Cumulative cost in USD across the session. */
+  costUsd: number;
+  /** Cumulative cache hit input tokens. */
+  cacheHitInput: number;
+  /** Cumulative cache miss input tokens. */
+  cacheMissInput: number;
+  /** Remaining context tokens from the latest token_usage event. */
+  contextRemaining?: number;
+}
+
 export interface MakaPiTranscriptState {
   entries: MakaPiTranscriptEntry[];
   sawTextDeltaMessageIds: Set<string>;
@@ -45,6 +56,8 @@ export interface MakaPiTranscriptState {
    */
   expandAllTools: boolean;
   expandAllThinking: boolean;
+  /** Aggregated token usage for statusline display; reset on session switch. */
+  usage: MakaPiUsageSummary;
 }
 
 export type MakaPiPendingInteraction = PermissionRequestEvent | UserQuestionRequestEvent;
@@ -93,6 +106,7 @@ export interface MakaPiTranscriptMetadata {
   thinkingLevels?: readonly ThinkingLevel[];
   sessionId?: string | null;
   busy?: boolean;
+  usage?: MakaPiUsageSummary;
 }
 
 export function createMakaPiTranscriptState(): MakaPiTranscriptState {
@@ -102,6 +116,7 @@ export function createMakaPiTranscriptState(): MakaPiTranscriptState {
     queuedInteractions: [],
     expandAllTools: false,
     expandAllThinking: false,
+    usage: { costUsd: 0, cacheHitInput: 0, cacheMissInput: 0 },
   };
 }
 
@@ -166,6 +181,7 @@ export function replaceTranscriptWithStoredMessages(
   clearPendingInteractions(state);
   state.expandAllTools = false;
   state.expandAllThinking = false;
+  state.usage = { costUsd: 0, cacheHitInput: 0, cacheMissInput: 0 };
 }
 
 /** Toggle expansion of every tool card at once; false when there is none. */
@@ -436,6 +452,10 @@ export function applyMakaSessionEventToTranscript(
       break;
 
     case 'token_usage': {
+      state.usage.costUsd += event.costUsd ?? 0;
+      state.usage.cacheHitInput += event.cacheHitInput ?? event.cacheRead ?? 0;
+      state.usage.cacheMissInput += event.cacheMissInput ?? 0;
+      state.usage.contextRemaining = event.contextRemaining;
       const notice = contextBudgetOutcomeNotice(event.contextBudget);
       if (notice) {
         state.entries.push({
@@ -884,11 +904,33 @@ function transcriptEntrySignature(
 
 export function renderMakaPiStatusLine(metadata: MakaPiTranscriptMetadata, width: number): string {
   const safeWidth = Math.max(1, width);
-  const thinking = metadata.thinkingLevel ? ansi.dim(` thinking:${metadata.thinkingLevel}`) : '';
-  return fitLine(
-    `${ansi.bold(metadata.title)} ${ansi.dim(metadata.model)} ${ansi.dim(metadata.connectionSlug)} ${ansi.dim(metadata.permissionMode)}${thinking} ${ansi.dim(metadata.cwd)}`,
-    safeWidth,
-  );
+  const sep = ansi.dim(' · ');
+  const parts: string[] = [ansi.bold(metadata.title), ansi.dim(metadata.permissionMode), ansi.dim(metadata.model)];
+  const thinking = metadata.thinkingLevel ? ansi.dim(`thinking:${metadata.thinkingLevel}`) : '';
+  if (thinking) parts.push(thinking);
+  const usage = metadata.usage;
+  if (usage) {
+    if (usage.contextRemaining !== undefined) {
+      parts.push(ansi.dim(`ctx ${formatTokenCount(usage.contextRemaining)}`));
+    }
+    if (usage.costUsd > 0) {
+      parts.push(ansi.dim(`$${usage.costUsd.toFixed(2)}`));
+    }
+    const totalCache = usage.cacheHitInput + usage.cacheMissInput;
+    if (totalCache > 0) {
+      const hitRate = Math.round((usage.cacheHitInput / totalCache) * 100);
+      parts.push(ansi.dim(`cache ${hitRate}%`));
+    }
+  }
+  parts.push(ansi.dim(metadata.connectionSlug));
+  parts.push(ansi.dim(metadata.cwd));
+  return fitLine(parts.join(sep), safeWidth);
+}
+
+function formatTokenCount(tokens: number): string {
+  if (tokens >= 1_000_000) return `${(tokens / 1_000_000).toFixed(1)}M`;
+  if (tokens >= 1_000) return `${Math.round(tokens / 1_000)}k`;
+  return String(tokens);
 }
 
 function appendAssistantText(state: MakaPiTranscriptState, messageId: string, text: string): void {

--- a/packages/cli/src/pi-tui-runner.ts
+++ b/packages/cli/src/pi-tui-runner.ts
@@ -668,14 +668,14 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
     rightLabel: string,
     items: SelectItem[],
     onSelect: (item: SelectItem) => void,
-    options: { minPrimaryColumnWidth: number; maxPrimaryColumnWidth: number; selectedIndex?: number },
+    options: { minPrimaryColumnWidth: number; maxPrimaryColumnWidth: number; selectedIndex?: number; hint?: string },
   ): void => {
     const list = new SelectList(items, 10, selectListTheme(), {
       minPrimaryColumnWidth: options.minPrimaryColumnWidth,
       maxPrimaryColumnWidth: options.maxPrimaryColumnWidth,
     });
     if (options.selectedIndex !== undefined) list.setSelectedIndex(options.selectedIndex);
-    const picker = new PickerOverlay(list, { title, rightLabel });
+    const picker = new PickerOverlay(list, { title, rightLabel, hint: options.hint });
     let overlay: OverlayHandle | undefined;
     list.onSelect = (item) => {
       overlay?.hide();
@@ -752,13 +752,13 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
       label: target.label,
     }));
     showSelectPicker(
-      'Rewind — 回到选定轮次之前（丢弃该轮及之后，prompt 回填输入框）',
+      'Rewind',
       'Rewind',
       items,
       (item) => {
         void runControl(() => rewindToTurn(item.value));
       },
-      { minPrimaryColumnWidth: 24, maxPrimaryColumnWidth: 48 },
+      { minPrimaryColumnWidth: 24, maxPrimaryColumnWidth: 48, hint: '回到选定轮次之前（丢弃该轮及之后，prompt 回填输入框）' },
     );
   };
 

--- a/packages/cli/src/pi-tui-runner.ts
+++ b/packages/cli/src/pi-tui-runner.ts
@@ -732,7 +732,7 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
       (item) => {
         void runControl(() => switchSession(item.value));
       },
-      { minPrimaryColumnWidth: 24, maxPrimaryColumnWidth: 40 },
+      { minPrimaryColumnWidth: 20, maxPrimaryColumnWidth: 120 },
     );
   };
 

--- a/packages/cli/src/pi-tui-runner.ts
+++ b/packages/cli/src/pi-tui-runner.ts
@@ -726,9 +726,12 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
       label: session.name || session.id,
       description: `${shortSessionId(session.id)} ${session.model}`,
     }));
-    // Reserve ~25 columns for the description (short id + model) so long CJK
-    // names truncate instead of swallowing the disambiguation text.
-    const maxNameWidth = Math.max(20, terminal.columns - 25);
+    // Reserve enough columns for the description (short id + model) so long
+    // CJK names truncate instead of swallowing the disambiguation text.
+    // pi-tui's renderItem deducts 2 prefix + 2 gap + 2 safety = 6 columns
+    // beyond the primary column width, so reserve 30 to leave ~24 for the
+    // description (enough for "aaaa1111 claude-sonnet-4-5").
+    const maxNameWidth = Math.max(20, terminal.columns - 30);
     showSelectPicker(
       'Resume Session (Current Folder)',
       'Current Folder',
@@ -762,7 +765,7 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
       (item) => {
         void runControl(() => rewindToTurn(item.value));
       },
-      { minPrimaryColumnWidth: 24, maxPrimaryColumnWidth: 48, hint: '回到选定轮次之前（丢弃该轮及之后，prompt 回填输入框）' },
+      { minPrimaryColumnWidth: 24, maxPrimaryColumnWidth: 48, hint: '回到选定轮次之前（丢弃该轮及之后，prompt 回填输入框） · enter 选择 / esc 取消' },
     );
   };
 

--- a/packages/cli/src/pi-tui-runner.ts
+++ b/packages/cli/src/pi-tui-runner.ts
@@ -145,6 +145,7 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
     thinkingLevels,
     sessionId: input.driver.getSessionId(),
     busy,
+    usage: state.usage,
   });
 
   const transcript = new MakaTranscriptComponent(state, metadata);

--- a/packages/cli/src/pi-tui-runner.ts
+++ b/packages/cli/src/pi-tui-runner.ts
@@ -726,6 +726,9 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
       label: session.name || session.id,
       description: `${shortSessionId(session.id)} ${session.model}`,
     }));
+    // Reserve ~25 columns for the description (short id + model) so long CJK
+    // names truncate instead of swallowing the disambiguation text.
+    const maxNameWidth = Math.max(20, terminal.columns - 25);
     showSelectPicker(
       'Resume Session (Current Folder)',
       'Current Folder',
@@ -733,7 +736,7 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
       (item) => {
         void runControl(() => switchSession(item.value));
       },
-      { minPrimaryColumnWidth: 20, maxPrimaryColumnWidth: 120 },
+      { minPrimaryColumnWidth: 20, maxPrimaryColumnWidth: maxNameWidth },
     );
   };
 


### PR DESCRIPTION
## Summary

Eight focused rendering fixes from the #549 TUI usability audit. All changes are visual/UX polish — no feature gates or behavioral contracts change.

### Changes

1. **Statusline density** — Aggregate `token_usage` events into a live usage summary (cost, cache hit rate) and surface it in the status line. Reorder fields to `title · permission · model · cost · cache · connection · cwd` so the safety-critical `permissionMode` survives truncation. Add `·` separators matching the welcome block. A `ctx` field is wired but only renders when the runtime populates `contextRemaining` (currently no production backend does, so it is dormant).

2. **Session picker column width** — Derive `maxPrimaryColumnWidth` from `terminal.columns - 25` so CJK session names get more room on wide terminals while always reserving space for the short-id + model description. The previous fixed cap of 40 truncated Chinese names at ~19 characters.

3. **Tool card header status** — Move the status (`running`/`done`/`error`) before the dim input summary so it survives truncation at narrow widths. Previously a long command could push the status off the line entirely.

4. **fitLine ellipsis** — Switch from hard truncation (``) to `…` so every truncated line shows a visual signal, matching the convention already used by `renderPtyTerminalRows`.

5. **Duration unified to ms** — Remove the Bash-specific `Math.floor(ms/1000)s` display; all tools now show milliseconds. A 900ms Bash round-trip previously displayed as `0s`.

6. **file_write wording** — Align compact (`wrote N bytes path`) and expanded (`Wrote N bytes to path`) to the same `Wrote N bytes to path` so toggling Ctrl+O does not change the wording.

7. **Rewind picker title** — Shorten the title to `Rewind` and move the CJK explanation to the picker hint line. The ~40-column title was hard-truncated mid-sentence on narrow terminals.

8. **Permission prompt keys** — Bold the key tokens (`y`, `a`, `n`) while keeping descriptions dim, so the actionable keys stand out at a glance.

### Test

`packages/cli` 344 pass, 0 fail.

### Tracking

Refs #549 (P2 statusline density + TUI rendering audit findings).