### PR TITLE
test(desktop): stop flaky gateway SSE stream-count race by retaining response refs

### DIFF
--- a/apps/desktop/src/main/__tests__/open-gateway.test.ts
+++ b/apps/desktop/src/main/__tests__/open-gateway.test.ts
@@ -586,11 +586,15 @@ describe('OpenGatewayService', () => {
     const status = await service.sync(createGatewaySettings({ enabled: true, port: 0, token: 'dev-token' }).openGateway);
     assert.ok(status.baseUrl);
 
-    const controllers: AbortController[] = [];
+    // Retain the whole opened stream (controller + response) for the lifetime of the
+    // assertions. undici tears down a fetch connection when its response body is
+    // garbage-collected without being consumed, so dropping the response here would let
+    // GC (heavier under load) abort registered streams before the count is checked.
+    const streams: Array<{ controller: AbortController; response: Response }> = [];
     try {
       for (let index = 0; index < 3; index += 1) {
         const opened = await openEventStream(status.baseUrl, 'same-session');
-        controllers.push(opened.controller);
+        streams.push(opened);
         assert.equal(opened.response.status, 200);
       }
       assert.equal(service.getStatus().activeEventStreams, 3);
@@ -603,7 +607,7 @@ describe('OpenGatewayService', () => {
 
       for (let index = 0; index < 7; index += 1) {
         const opened = await openEventStream(status.baseUrl, `other-${index}`);
-        controllers.push(opened.controller);
+        streams.push(opened);
         assert.equal(opened.response.status, 200);
       }
       assert.equal(service.getStatus().activeEventStreams, 10);
@@ -614,7 +618,7 @@ describe('OpenGatewayService', () => {
       assert.doesNotMatch(globalRejected.headers.get('content-type') ?? '', /^text\/event-stream/);
       assert.equal(service.getStatus().activeEventStreams, 10);
     } finally {
-      for (const controller of controllers) controller.abort();
+      for (const stream of streams) stream.controller.abort();
       await waitFor(() => service.getStatus().activeEventStreams === 0);
     }
   });


### PR DESCRIPTION
## Summary

`open-gateway.test.ts` › "rejects excess SSE streams" was intermittently failing at `assert.equal(activeEventStreams, 10)`, reading 2–7 instead of 10 under load (#993).

Root cause is in the test, not the gateway. The test opened 10 held-open SSE `fetch`es but kept only each `AbortController`, discarding the `Response`. undici aborts a fetch connection when its unread response body is garbage-collected, so under heavier GC (load) the client tore down already-registered streams before the assertion ran. The gateway itself registered all 10 correctly and only removed them on client-initiated `req 'close'`.

Fix: retain the whole opened stream (controller + response) through the assertions so the bodies stay reachable and the connections stay open.

Closes #993

## Verification

- Reproduced on `main` under 2× CPU load: full-file loop **7/12 failed** (`2 !== 10`, `4 !== 10`). Instrumented `openSessionEventStream`/`removeEventClient` and confirmed all 10 streams registered, then `req close … aborted=true` tore them down before the assertion; instrumentation reverted.
- After fix, same load: affected file **20/20 pass**; full desktop main suite (2528 tests) **10/10 pass**.
- Swept other SSE tests — abuse-contract is a static source scan, runtime/headless parse mock streams — none share this class.

## Root cause

undici GC-aborts unconsumed fetch response bodies; the test dropped its `Response` refs, so GC (load-sensitive) closed registered streams before the count assertion.