### PR TITLE
feat: expose thinking level for all Ollama Cloud reasoning models

### DIFF
--- a/packages/core/src/__tests__/model-thinking.test.ts
+++ b/packages/core/src/__tests__/model-thinking.test.ts
@@ -149,15 +149,31 @@ describe('thinkingOptionsForModel', () => {
     );
   });
 
-  test('Ollama Cloud exposes the documented OpenAI-compatible reasoning effort values', () => {
+  test('Ollama Cloud reasoning models expose off/low/medium/high/max; GPT-OSS low/medium/high only', () => {
     assert.deepEqual(
       thinkingOptionsForModel('ollama-cloud', 'qwen3.5:397b'),
-      { efforts: ['none', 'low', 'medium', 'high'], toggle: true },
+      { efforts: ['none', 'low', 'medium', 'high', 'max'], toggle: true },
     );
     assert.deepEqual(
       [...thinkingVariantsForModel('ollama-cloud', 'qwen3.5:397b')],
-      ['off', 'low', 'medium', 'high'],
+      ['off', 'low', 'medium', 'high', 'max'],
     );
+    // deepseek-v4-flash is another reasoning model using the standard wire
+    assert.deepEqual(
+      [...thinkingVariantsForModel('ollama-cloud', 'deepseek-v4-flash')],
+      ['off', 'low', 'medium', 'high', 'max'],
+    );
+    // GPT-OSS only accepts low/medium/high — no off, no max
+    assert.deepEqual(
+      thinkingOptionsForModel('ollama-cloud', 'gpt-oss:120b'),
+      { efforts: ['low', 'medium', 'high'] },
+    );
+    assert.deepEqual(
+      [...thinkingVariantsForModel('ollama-cloud', 'gpt-oss:120b')],
+      ['low', 'medium', 'high'],
+    );
+    // Non-reasoning models still yield nothing
+    assert.deepEqual([...thinkingVariantsForModel('ollama-cloud', 'devstral-2:123b')], []);
   });
 
   test('claude-subscription inherits anthropic thinking options (displayMetadataOnly preserves them)', () => {

--- a/packages/core/src/__tests__/model-thinking.test.ts
+++ b/packages/core/src/__tests__/model-thinking.test.ts
@@ -149,7 +149,7 @@ describe('thinkingOptionsForModel', () => {
     );
   });
 
-  test('Ollama Cloud reasoning models expose off/low/medium/high/max; GPT-OSS low/medium/high only', () => {
+  test('Ollama Cloud reasoning models expose off/low/medium/high/max; GPT-OSS low/medium/high only; deprecated excluded', () => {
     assert.deepEqual(
       thinkingOptionsForModel('ollama-cloud', 'qwen3.5:397b'),
       { efforts: ['none', 'low', 'medium', 'high', 'max'], toggle: true },
@@ -158,7 +158,7 @@ describe('thinkingOptionsForModel', () => {
       [...thinkingVariantsForModel('ollama-cloud', 'qwen3.5:397b')],
       ['off', 'low', 'medium', 'high', 'max'],
     );
-    // deepseek-v4-flash is another reasoning model using the standard wire
+    // deepseek-v4-flash is another active reasoning model using the standard wire
     assert.deepEqual(
       [...thinkingVariantsForModel('ollama-cloud', 'deepseek-v4-flash')],
       ['off', 'low', 'medium', 'high', 'max'],
@@ -174,6 +174,9 @@ describe('thinkingOptionsForModel', () => {
     );
     // Non-reasoning models still yield nothing
     assert.deepEqual([...thinkingVariantsForModel('ollama-cloud', 'devstral-2:123b')], []);
+    // Deprecated models (retired from the API) do not get thinking options
+    assert.deepEqual([...thinkingVariantsForModel('ollama-cloud', 'cogito-2.1:671b')], []);
+    assert.deepEqual([...thinkingVariantsForModel('ollama-cloud', 'kimi-k2-thinking')], []);
   });
 
   test('claude-subscription inherits anthropic thinking options (displayMetadataOnly preserves them)', () => {

--- a/packages/core/src/model-metadata.ts
+++ b/packages/core/src/model-metadata.ts
@@ -137,8 +137,10 @@ const VOLCENGINE_CODING_PLAN_MODEL_METADATA: Record<string, ModelMetadata> = {
  * Thinking-capable Ollama Cloud models that use the standard OpenAI-compatible
  * `reasoning_effort` wire (none/low/medium/high/max). GPT-OSS is excluded — it
  * only accepts low/medium/high and is declared separately in the ollama-cloud
- * override below. The model list is derived from the generated models.dev
- * snapshot so new reasoning models are picked up automatically on the next sync.
+ * override below. Deprecated models are filtered out — Ollama publishes concrete
+ * retirement dates and deprecated models are already gone from the API.
+ * The model list is derived from the generated models.dev snapshot so new
+ * reasoning models are picked up automatically on the next sync.
  */
 const OLLAMA_CLOUD_STANDARD_THINKING_OPTIONS: ThinkingOptions = {
   efforts: ['none', 'low', 'medium', 'high', 'max'],
@@ -147,7 +149,7 @@ const OLLAMA_CLOUD_STANDARD_THINKING_OPTIONS: ThinkingOptions = {
 
 const ollamaCloudStandardThinkingModels: Record<string, ModelMetadata> = Object.fromEntries(
   Object.entries(GENERATED_MODELS_DEV_METADATA['ollama-cloud'])
-    .filter(([id, m]) => m.capabilities?.reasoning && !id.startsWith('gpt-oss'))
+    .filter(([id, m]) => m.capabilities?.reasoning && m.lifecycle !== 'deprecated' && !id.startsWith('gpt-oss'))
     .map(([id]) => [id, { thinkingOptions: OLLAMA_CLOUD_STANDARD_THINKING_OPTIONS }]),
 );
 

--- a/packages/core/src/model-metadata.ts
+++ b/packages/core/src/model-metadata.ts
@@ -133,6 +133,24 @@ const VOLCENGINE_CODING_PLAN_MODEL_METADATA: Record<string, ModelMetadata> = {
   'kimi-k2.7-code': planModel('Kimi-K2.7-Code', true, 256_000, 32_000),
 };
 
+/**
+ * Thinking-capable Ollama Cloud models that use the standard OpenAI-compatible
+ * `reasoning_effort` wire (none/low/medium/high/max). GPT-OSS is excluded — it
+ * only accepts low/medium/high and is declared separately in the ollama-cloud
+ * override below. The model list is derived from the generated models.dev
+ * snapshot so new reasoning models are picked up automatically on the next sync.
+ */
+const OLLAMA_CLOUD_STANDARD_THINKING_OPTIONS: ThinkingOptions = {
+  efforts: ['none', 'low', 'medium', 'high', 'max'],
+  toggle: true,
+};
+
+const ollamaCloudStandardThinkingModels: Record<string, ModelMetadata> = Object.fromEntries(
+  Object.entries(GENERATED_MODELS_DEV_METADATA['ollama-cloud'])
+    .filter(([id, m]) => m.capabilities?.reasoning && !id.startsWith('gpt-oss'))
+    .map(([id]) => [id, { thinkingOptions: OLLAMA_CLOUD_STANDARD_THINKING_OPTIONS }]),
+);
+
 // Facts that models.dev cannot express: provider wire controls and
 // access-path-specific aliases/limits. Standard model facts stay generated.
 const STATIC_MODEL_METADATA: Partial<Record<ProviderType, Record<string, ModelMetadata>>> = {
@@ -225,10 +243,15 @@ const STATIC_MODEL_METADATA: Partial<Record<ProviderType, Record<string, ModelMe
       },
     },
   },
+  // Ollama's OpenAI-compatible endpoint globally accepts reasoning_effort
+  // (none/low/medium/high/max). GPT-OSS is the exception: it only accepts
+  // low/medium/high and its trace cannot be fully disabled. See:
+  //   https://docs.ollama.com/api/openai-compatibility  (reasoning_effort field)
+  //   https://docs.ollama.com/capabilities/thinking      (per-model think levels)
   'ollama-cloud': {
-    'qwen3.5:397b': {
-      thinkingOptions: { efforts: ['none', 'low', 'medium', 'high'], toggle: true },
-    },
+    ...ollamaCloudStandardThinkingModels,
+    'gpt-oss:120b': { thinkingOptions: { efforts: ['low', 'medium', 'high'] } },
+    'gpt-oss:20b': { thinkingOptions: { efforts: ['low', 'medium', 'high'] } },
   },
   deepseek: {
     'deepseek-v4-flash': { thinkingOptions: { efforts: ['high', 'max'], toggle: true } },

--- a/packages/core/src/model-metadata.ts
+++ b/packages/core/src/model-metadata.ts
@@ -134,23 +134,29 @@ const VOLCENGINE_CODING_PLAN_MODEL_METADATA: Record<string, ModelMetadata> = {
 };
 
 /**
- * Thinking-capable Ollama Cloud models that use the standard OpenAI-compatible
- * `reasoning_effort` wire (none/low/medium/high/max). GPT-OSS is excluded — it
- * only accepts low/medium/high and is declared separately in the ollama-cloud
- * override below. Deprecated models are filtered out — Ollama publishes concrete
- * retirement dates and deprecated models are already gone from the API.
- * The model list is derived from the generated models.dev snapshot so new
- * reasoning models are picked up automatically on the next sync.
+ * Thinking-capable Ollama Cloud models, derived from the generated models.dev
+ * snapshot so new reasoning models are picked up automatically on the next sync.
+ * The endpoint globally accepts `reasoning_effort` (none/low/medium/high/max),
+ * but GPT-OSS only accepts low/medium/high and cannot be fully disabled.
+ * Deprecated models are filtered — Ollama publishes concrete retirement dates.
  */
 const OLLAMA_CLOUD_STANDARD_THINKING_OPTIONS: ThinkingOptions = {
   efforts: ['none', 'low', 'medium', 'high', 'max'],
   toggle: true,
 };
 
-const ollamaCloudStandardThinkingModels: Record<string, ModelMetadata> = Object.fromEntries(
+const OLLAMA_CLOUD_GPT_OSS_THINKING_OPTIONS: ThinkingOptions = {
+  efforts: ['low', 'medium', 'high'],
+};
+
+const ollamaCloudThinkingModels: Record<string, ModelMetadata> = Object.fromEntries(
   Object.entries(GENERATED_MODELS_DEV_METADATA['ollama-cloud'])
-    .filter(([id, m]) => m.capabilities?.reasoning && m.lifecycle !== 'deprecated' && !id.startsWith('gpt-oss'))
-    .map(([id]) => [id, { thinkingOptions: OLLAMA_CLOUD_STANDARD_THINKING_OPTIONS }]),
+    .filter(([id, m]) => m.capabilities?.reasoning && m.lifecycle !== 'deprecated')
+    .map(([id]) => [id, {
+      thinkingOptions: id.startsWith('gpt-oss')
+        ? OLLAMA_CLOUD_GPT_OSS_THINKING_OPTIONS
+        : OLLAMA_CLOUD_STANDARD_THINKING_OPTIONS,
+    }]),
 );
 
 // Facts that models.dev cannot express: provider wire controls and
@@ -250,11 +256,7 @@ const STATIC_MODEL_METADATA: Partial<Record<ProviderType, Record<string, ModelMe
   // low/medium/high and its trace cannot be fully disabled. See:
   //   https://docs.ollama.com/api/openai-compatibility  (reasoning_effort field)
   //   https://docs.ollama.com/capabilities/thinking      (per-model think levels)
-  'ollama-cloud': {
-    ...ollamaCloudStandardThinkingModels,
-    'gpt-oss:120b': { thinkingOptions: { efforts: ['low', 'medium', 'high'] } },
-    'gpt-oss:20b': { thinkingOptions: { efforts: ['low', 'medium', 'high'] } },
-  },
+  'ollama-cloud': ollamaCloudThinkingModels,
   deepseek: {
     'deepseek-v4-flash': { thinkingOptions: { efforts: ['high', 'max'], toggle: true } },
   },

--- a/packages/runtime/src/__tests__/model-factory-thinking.test.ts
+++ b/packages/runtime/src/__tests__/model-factory-thinking.test.ts
@@ -174,6 +174,23 @@ describe('buildProviderOptions: thinking level', () => {
     assert.deepEqual(buildProviderOptions(conn('vercel'), 'grok-4.3', 'high'), {});
   });
 
+  test('Ollama Cloud sends reasoningEffort under its namespace; standard models expose off, GPT-OSS does not', () => {
+    // qwen3.5:397b — standard reasoning model: off/low/medium/high/max
+    assert.deepEqual([...thinkingVariantsForModel('ollama-cloud', 'qwen3.5:397b')], ['off', 'low', 'medium', 'high', 'max']);
+    assert.deepEqual(buildProviderOptions(conn('ollama-cloud'), 'qwen3.5:397b', 'high'), {
+      'ollama-cloud': { reasoningEffort: 'high' },
+    });
+    assert.deepEqual(buildProviderOptions(conn('ollama-cloud'), 'qwen3.5:397b', 'off'), {
+      'ollama-cloud': { reasoningEffort: 'none' },
+    });
+    // gpt-oss:120b — only low/medium/high, no off
+    assert.deepEqual([...thinkingVariantsForModel('ollama-cloud', 'gpt-oss:120b')], ['low', 'medium', 'high']);
+    assert.deepEqual(buildProviderOptions(conn('ollama-cloud'), 'gpt-oss:120b', 'high'), {
+      'ollama-cloud': { reasoningEffort: 'high' },
+    });
+    assert.deepEqual(buildProviderOptions(conn('ollama-cloud'), 'gpt-oss:120b', 'off'), {});
+  });
+
   test('a level the model does not support is dropped (defensive)', () => {
     assert.deepEqual(buildProviderOptions(conn('openai'), 'gpt-4o', 'high'), { openai: { store: false } });
     assert.deepEqual(buildProviderOptions(conn('anthropic'), 'claude-haiku-4-5', 'max'), { anthropic: {} });
@@ -258,6 +275,8 @@ describe('buildProviderOptions: resolver/options drift guard', () => {
     { providerType: 'groq', model: 'openai/gpt-oss-120b' },
     { providerType: 'openrouter', model: 'openai/gpt-5.6-sol' },
     { providerType: 'vercel', model: 'xai/grok-4.3' },
+    { providerType: 'ollama-cloud', model: 'qwen3.5:397b' },
+    { providerType: 'ollama-cloud', model: 'gpt-oss:120b' },
     { providerType: 'cloudflare-workers-ai', model: '@cf/moonshotai/kimi-k2.6' },
     { providerType: 'zai-coding-plan', model: 'glm-5.2', slug: 'zai-coding-plan' },
     { providerType: 'volcengine-ark', model: 'doubao-seed-2-0-pro-260215' },


### PR DESCRIPTION
## Summary

Ollama Cloud's OpenAI-compatible endpoint globally accepts `reasoning_effort` (`none`/`low`/`medium`/`high`/`max`), but the thinking-level switcher only appeared for `qwen3.5:397b`. Every other reasoning-capable model (deepseek-v4-flash, gpt-oss, kimi-k2.6, minimax-m3, etc.) silently returned `[]` and hid the menu, because models.dev does not carry `reasoning_options` for the `ollama-cloud` provider.

This was not a model-fetching or discovery bug — the model list and `reasoning: true` flags were correct. The gap was purely in the per-model `thinkingOptions` metadata.

**Fix:** derive `thinkingOptions` for every reasoning-capable ollama-cloud model from the generated models.dev snapshot, so new reasoning models are picked up automatically on the next metadata sync. GPT-OSS (`gpt-oss:120b`, `gpt-oss:20b`) is declared separately because it only accepts `low`/`medium`/`high` and its trace cannot be fully disabled. Also adds `max` to `qwen3.5:397b`, which the Ollama docs document but was previously missing.

Sources:
- https://docs.ollama.com/capabilities/thinking (per-model think levels)
- https://docs.ollama.com/api/openai-compatibility (`reasoning_effort` field: high/medium/low/max/none)

## Verification

- `@maka/core` — 996 pass, 0 fail
- `@maka/runtime` — 1789 pass, 7 skipped, 0 fail
- `@maka/desktop` — 2526 pass, 0 fail
- `check-stale-dist` — fresh
