### PR TITLE
fix(settings): lowercase providerType before deriving connection slug

### DIFF
--- a/apps/desktop/src/main/__tests__/provider-next-slug.test.ts
+++ b/apps/desktop/src/main/__tests__/provider-next-slug.test.ts
@@ -1,0 +1,53 @@
+import { strict as assert } from 'node:assert';
+import { mkdir, mkdtemp } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { dirname, resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { describe, it } from 'node:test';
+import { build } from 'esbuild';
+
+const REPO_ROOT = resolve(import.meta.dirname, '../../../../..');
+
+type ProviderPanelSharedModule = {
+  nextSlug(type: string, existing: string[]): string;
+};
+
+// dynamic import: provider-panel-shared lives under src/renderer, which is
+// outside tsconfig.main.json's include scope, so main-process tests cannot
+// import it statically — esbuild bundles it to a temp module first.
+async function importProviderPanelShared(): Promise<ProviderPanelSharedModule> {
+  const outdir = await mkdtemp(resolve(tmpdir(), 'maka-provider-panel-shared-'));
+  const outfile = resolve(outdir, 'provider-panel-shared.mjs');
+  await mkdir(dirname(outfile), { recursive: true });
+  await build({
+    entryPoints: [resolve(REPO_ROOT, 'apps/desktop/src/renderer/settings/provider-panel-shared.ts')],
+    outfile,
+    bundle: true,
+    platform: 'node',
+    format: 'esm',
+    target: 'node20',
+    logLevel: 'silent',
+  });
+  return await import(`${pathToFileURL(outfile).href}?t=${Date.now()}`) as ProviderPanelSharedModule;
+}
+
+describe('nextSlug', () => {
+  it('derives a validateSlug-compatible slug from a providerType with uppercase letters', async () => {
+    const { nextSlug } = await importProviderPanelShared();
+    const slugRe = /^[a-z0-9][a-z0-9-]*[a-z0-9]$/;
+
+    assert.equal(nextSlug('MiniMax', []), 'minimax');
+    assert.equal(nextSlug('MiniMax-cn', []), 'minimax-cn');
+
+    for (const type of ['MiniMax', 'MiniMax-cn', 'zai-coding-plan', 'cloudflare-workers-ai']) {
+      const slug = nextSlug(type, []);
+      assert.ok(slugRe.test(slug), `slug "${slug}" for providerType "${type}" must satisfy validateSlug`);
+    }
+  });
+
+  it('appends a numeric suffix when the base slug is already taken', async () => {
+    const { nextSlug } = await importProviderPanelShared();
+    assert.equal(nextSlug('MiniMax', ['minimax']), 'minimax-2');
+    assert.equal(nextSlug('MiniMax-cn', ['minimax-cn', 'minimax-cn-2']), 'minimax-cn-3');
+  });
+});

--- a/apps/desktop/src/renderer/settings/provider-panel-shared.ts
+++ b/apps/desktop/src/renderer/settings/provider-panel-shared.ts
@@ -43,7 +43,7 @@ export function categoryLabel(category: ProviderCategory): string {
 }
 
 export function nextSlug(type: ProviderType, existing: string[]): string {
-  const base = type.replace(/[^a-z0-9-]/g, '-');
+  const base = type.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '');
   if (!existing.includes(base)) return base;
   for (let i = 2; i < 100; i += 1) {
     const candidate = `${base}-${i}`;


### PR DESCRIPTION
## Summary

 `nextSlug` derived the default connection slug from `providerType` with `type.replace(/[^a-z0-9-]/g, '-')`, which strips uppercase letters instead of lowercasing them. For `MiniMax` / `MiniMax-cn` this produced slugs like `-ini-ax-cn` that fail `validateSlug`, so adding the MiniMax China provider was blocked until the user manually edited the slug. Lowercase the providerType, collapse separator runs, and trim leading/trailing hyphens so the derived slug always satisfies validation.

 ## Verification
   - `npm --workspace @maka/core run build`
   - `npm --workspace @maka/desktop run build:main`
   - `node --test dist/main/__tests__/provider-next-slug.test.js` — 2 pass
   - `node --test dist/main/__tests__/model-oauth-section-contract.test.js dist/main/__tests__/provider-navigation-contract.test.js` — 40 pass
   - Not run: full desktop test suite and real-window e2e (the fix is a pure string transform with unit coverage; no UI/DOM behavior changed)
 