### PR TITLE
fix(ui): restore quiet composer picker triggers

### DIFF
--- a/apps/desktop/src/main/__tests__/composer-picker-trigger-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/composer-picker-trigger-contract.test.ts
@@ -1,0 +1,41 @@
+import { strict as assert } from 'node:assert';
+import { readFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+import { test } from 'node:test';
+
+const REPO_ROOT = resolve(import.meta.dirname, '../../../../..');
+
+async function read(relativePath: string): Promise<string> {
+  return readFile(resolve(REPO_ROOT, relativePath), 'utf8');
+}
+
+test('composer permission and model pickers opt into quiet trigger chrome', async () => {
+  const [composer, permissionMode, chatModelSwitcher, modelPicker] = await Promise.all([
+    read('packages/ui/src/composer.tsx'),
+    read('packages/ui/src/permission-mode-menu.tsx'),
+    read('packages/ui/src/chat-model-switcher.tsx'),
+    read('packages/ui/src/model-picker.tsx'),
+  ]);
+
+  assert.match(
+    composer,
+    /<PermissionModeSelect[\s\S]*?appearance="quiet"[\s\S]*?activeMode=/,
+    'the composer permission picker must opt out of field chrome',
+  );
+  assert.match(
+    permissionMode,
+    /<SelectTrigger[\s\S]*?appearance=\{props\.appearance\}/,
+    'PermissionModeSelect must forward its trigger appearance',
+  );
+
+  const composerModelPickers = chatModelSwitcher.match(/<ModelPicker[\s\S]*?>/g) ?? [];
+  assert.equal(composerModelPickers.length, 2, 'both composer model picker variants must remain on the shared ModelPicker');
+  for (const picker of composerModelPickers) {
+    assert.match(picker, /triggerAppearance="quiet"/, 'each composer model picker must opt out of field chrome');
+  }
+  assert.match(
+    modelPicker,
+    /<ModelPickerTrigger[\s\S]*?appearance=\{props\.triggerAppearance\}/,
+    'ModelPicker must forward its requested trigger appearance',
+  );
+});

--- a/packages/ui/src/__tests__/picker-trigger.test.ts
+++ b/packages/ui/src/__tests__/picker-trigger.test.ts
@@ -1,0 +1,19 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { pickerTriggerClasses } from '../ui.js';
+
+test('picker triggers separate field chrome from quiet toolbar chrome', () => {
+  const field = pickerTriggerClasses('field');
+  const quiet = pickerTriggerClasses('quiet');
+
+  assert.match(field, /\bmin-h-9\b/);
+  assert.match(field, /\bw-full\b/);
+  assert.match(field, /\bshadow-sm\b/);
+
+  assert.doesNotMatch(quiet, /\bmin-h-9\b/);
+  assert.doesNotMatch(quiet, /\bw-full\b/);
+  assert.doesNotMatch(quiet, /\bshadow-/);
+  assert.doesNotMatch(quiet, /\bborder-input\b/);
+  assert.match(quiet, /focus-visible:ring-2/);
+  assert.match(quiet, /disabled:pointer-events-none/);
+});

--- a/packages/ui/src/chat-model-switcher.tsx
+++ b/packages/ui/src/chat-model-switcher.tsx
@@ -179,6 +179,7 @@ export function ChatModelSwitcher(props: {
       aria-busy={pending ? 'true' : undefined}
     >
       <ModelPicker
+        triggerAppearance="quiet"
         groups={grouped}
         value={currentValue}
         disabled={disabled}
@@ -267,6 +268,7 @@ export function NewChatModelPicker(props: {
   const grouped = modelMenuGroups(props.choices);
   return (
     <ModelPicker
+      triggerAppearance="quiet"
       groups={grouped}
       value={props.currentValue ?? ''}
       renderProviderMark={props.renderProviderMark}

--- a/packages/ui/src/composer.tsx
+++ b/packages/ui/src/composer.tsx
@@ -880,6 +880,7 @@ export const Composer = forwardRef<
                 normal chat. */}
             {props.onPermissionModeChange ? (
               <PermissionModeSelect
+                appearance="quiet"
                 activeMode={props.permissionMode ?? 'ask'}
                 onSelect={(mode) => {
                   void props.onPermissionModeChange?.(mode);

--- a/packages/ui/src/model-picker.tsx
+++ b/packages/ui/src/model-picker.tsx
@@ -18,7 +18,7 @@ import {
   type ModelPickerPinnedItem,
 } from './model-picker-internals.js';
 import { cn } from './utils.js';
-import { inputClasses } from './primitives/input.js';
+import { pickerTriggerClasses, type PickerTriggerAppearance } from './ui.js';
 
 export interface ModelPickerProps {
   groups: ModelMenuGroup[];
@@ -31,6 +31,7 @@ export interface ModelPickerProps {
   searchPlaceholder?: string;
   emptyMessage?: string;
   triggerClassName?: string;
+  triggerAppearance?: PickerTriggerAppearance;
   popupClassName?: string;
   ariaLabel: string;
   title?: string;
@@ -40,14 +41,17 @@ export interface ModelPickerProps {
   children: ReactNode;
 }
 
-const ModelPickerTrigger = forwardRef<HTMLButtonElement, React.ComponentPropsWithoutRef<typeof BaseCombobox.Trigger>>(function ModelPickerTrigger(
-  { className, children, ...props },
+const ModelPickerTrigger = forwardRef<
+  HTMLButtonElement,
+  React.ComponentPropsWithoutRef<typeof BaseCombobox.Trigger> & { appearance?: PickerTriggerAppearance }
+>(function ModelPickerTrigger(
+  { appearance = 'field', className, children, ...props },
   ref,
 ) {
   return (
     <BaseCombobox.Trigger
       ref={ref}
-      className={cn(inputClasses, 'justify-between', className)}
+      className={cn(pickerTriggerClasses(appearance), 'justify-between', className)}
       {...props}
     >
       {children}
@@ -200,6 +204,7 @@ export function ModelPicker(props: ModelPickerProps) {
       disabled={props.disabled}
     >
       <ModelPickerTrigger
+        appearance={props.triggerAppearance}
         className={props.triggerClassName}
         aria-label={props.ariaLabel}
         title={props.title}

--- a/packages/ui/src/permission-mode-menu.tsx
+++ b/packages/ui/src/permission-mode-menu.tsx
@@ -8,6 +8,7 @@ import {
   SelectRoot,
   SelectTrigger,
   SelectValue,
+  type PickerTriggerAppearance,
 } from './ui.js';
 
 export interface PermissionModeMeta {
@@ -80,6 +81,7 @@ export function PermissionModeSelect(props: {
   disabledReason?: string;
   ariaLabel?: string;
   className?: string;
+  appearance?: PickerTriggerAppearance;
 }) {
   const displayMode: PermissionMode = props.activeMode === 'explore' ? 'ask' : props.activeMode;
   const meta = PERMISSION_MODE_META[displayMode];
@@ -93,6 +95,7 @@ export function PermissionModeSelect(props: {
       }}
     >
       <SelectTrigger
+        appearance={props.appearance}
         aria-label={props.ariaLabel ?? `权限模式：${meta.label}`}
         title={props.disabledReason ?? meta.hint}
         className={props.className}

--- a/packages/ui/src/ui.tsx
+++ b/packages/ui/src/ui.tsx
@@ -19,6 +19,23 @@ import { inputClasses } from './primitives/input.js';
 
 export { cn } from './utils.js';
 
+export type PickerTriggerAppearance = 'field' | 'quiet';
+
+const quietPickerTriggerClasses = [
+  'inline-flex shrink-0 items-center',
+  'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
+  'disabled:pointer-events-none disabled:opacity-50',
+].join(' ');
+
+/**
+ * Picker triggers appear either as form fields or as quiet toolbar controls.
+ * The quiet variant intentionally carries only interaction states: its owning
+ * surface remains the single source of geometry and visual chrome.
+ */
+export function pickerTriggerClasses(appearance: PickerTriggerAppearance = 'field'): string {
+  return appearance === 'field' ? inputClasses : quietPickerTriggerClasses;
+}
+
 // === Base UI style-hook convention (#520 PR5 item 23) =========================
 // Every Base UI wrapper in this file exposes `data-slot="<name>"` so CSS can
 // target `[data-slot="..."]` (a stable hook that survives className drift);
@@ -257,14 +274,17 @@ export const AlertDialogContent = createModalContent({
 export { Tabs as TabsRoot, TabsList, TabsTab as TabsTrigger, TabsPanel } from './primitives/tabs.js';
 
 export const SelectRoot = BaseSelect.Root;
-export const SelectTrigger = forwardRef<HTMLButtonElement, React.ComponentPropsWithoutRef<typeof BaseSelect.Trigger>>(function SelectTrigger(
-  { className, children, ...props },
+export const SelectTrigger = forwardRef<
+  HTMLButtonElement,
+  React.ComponentPropsWithoutRef<typeof BaseSelect.Trigger> & { appearance?: PickerTriggerAppearance }
+>(function SelectTrigger(
+  { appearance = 'field', className, children, ...props },
   ref,
 ) {
   return (
     <BaseSelect.Trigger
       ref={ref}
-      className={cn(inputClasses, 'justify-between', className)}
+      className={cn(pickerTriggerClasses(appearance), 'justify-between', className)}
       data-slot="select-trigger"
       {...props}
     >


### PR DESCRIPTION
## Summary

- restore the composer permission and model pickers to their compact quiet-trigger appearance
- separate quiet toolbar trigger behavior from input-field chrome while preserving the default field appearance in Settings
- add regression contracts for the shared appearance API and both composer call paths

## Verification

- `npm --workspace @maka/ui test` — 153 passed
- `npm --workspace @maka/desktop test` — 2527 passed
- `npm --workspace @maka/desktop run typecheck`
- visual smoke: `turn-narrative`, light, 1280px
- live computed styles: permission and model triggers are both 26px high with transparent backgrounds and no box shadow

## Root cause

PR #901 moved Select and Combobox triggers onto the shared input-field class bundle. Its 36px minimum height and field elevation leaked into the composer even though that surface already owns a 26px quiet-trigger recipe. The new explicit `field | quiet` appearance keeps form consumers unchanged and lets the composer opt out of field chrome without adding override CSS.

## Visual comparison

<img width="5122" height="1712" alt="image" src="https://github.com/user-attachments/assets/6fc2c822-f83c-4f57-91ec-b58e35b04d27" />