### PR TITLE
fix(ui): keep in-flight live turn armed when persisted history covers all steps

### DIFF
--- a/packages/ui/src/__tests__/live-turn-projection.test.ts
+++ b/packages/ui/src/__tests__/live-turn-projection.test.ts
@@ -538,6 +538,18 @@ describe('reconcileTerminalLiveTurn', () => {
     ]), undefined);
   });
 
+  it('keeps a non-terminal projection armed once persisted history covers all steps', () => {
+    const inFlight: LiveTurnProjection = {
+      turnId: 'turn-1',
+      phase: 'streamed',
+      steps: toolOnly.steps,
+    };
+    assert.deepEqual(reconcileTerminalLiveTurn(inFlight, [
+      { type: 'tool_call', id: 'tool-1', turnId: 'turn-1', stepId: 'step-1', ts: 1, toolName: 'Bash', args: {} },
+      { type: 'tool_result', id: 'result-1', turnId: 'turn-1', ts: 2, toolUseId: 'tool-1', isError: false, content: { kind: 'text', text: 'ok' } },
+    ]), { turnId: 'turn-1', phase: 'streamed', steps: [] });
+  });
+
   it('retains terminal evidence while persisted history does not cover it', () => {
     assert.equal(reconcileTerminalLiveTurn(toolOnly, []), toolOnly);
   });

--- a/packages/ui/src/live-turn-projection.ts
+++ b/packages/ui/src/live-turn-projection.ts
@@ -384,6 +384,6 @@ export function reconcileTerminalLiveTurn(
     return !toolsCovered;
   });
   if (steps.length === current.steps.length) return current;
-  if (steps.length === 0) return undefined;
+  if (steps.length === 0 && current.terminal) return undefined;
   return { ...current, steps };
 }


### PR DESCRIPTION
## Summary

During a running turn, the desktop composer's busy indicator (streaming hint + Stop button) flickered off in every step-to-step lull — the moment a step's tool results and thinking were persisted and nothing was actively streaming — then reappeared on the next event. Users saw an idle composer while the sidebar and header still showed the session as 进行中. Refs #646.

Root cause: `reconcileTerminalLiveTurn` deleted the whole live-turn projection whenever the persisted transcript covered every live step, even for a non-terminal projection. The renderer reconciles on every `messages`/`activeLiveTurn` change (`app-shell.tsx`), so each mid-turn lull dropped `turnInFlight` — the arm that #646 introduced precisely to keep Stop available across those lulls.

Fix: delete an empty projection only when it is `terminal`, mirroring the existing guard in `settleLiveTurnStep`. A non-terminal projection now survives with empty steps, keeping the turn armed (composer shows the calm continuing hint instead of idle). Terminal cleanup via `complete`/`abort`/`error` is unchanged, so a backgrounded session still cannot get a stuck Stop button.

## Verification

- New regression test: a non-terminal projection fully covered by persisted history keeps its arm (`{ turnId, phase, steps: [] }`); it returned `undefined` before the fix and passes after.
- `packages/ui` suite: 153/153 pass.
- `apps/desktop` main suite (includes `streaming-handoff.test.ts`, which drives `reconcilePersistedMessages` over this seam): 2526/2526 pass.
- Not run: a live end-to-end run against a real provider. The symptom was pinned frame-by-frame from a 12s screen recording of a running GLM-5.2 session (composer idle at 0–8s and 10–11s while the session stayed `running`).