### PR TITLE
fix(runtime): project user question requests

### DIFF
--- a/packages/runtime/src/__tests__/runtime-event-read-model.test.ts
+++ b/packages/runtime/src/__tests__/runtime-event-read-model.test.ts
@@ -288,6 +288,62 @@ describe('projectRuntimeEventsToStoredMessages', () => {
     expect(out.diagnostics.map((diag) => diag.code)).toEqual(['context_remaining_unsupported']);
   });
 
+  test('projects an AskUserQuestion round trip without a legacy row for the live request', () => {
+    const out = projectRuntimeEventsToStoredMessages([
+      ev({
+        id: 'evt-question-call',
+        ts: ts + 1,
+        role: 'model',
+        author: 'agent',
+        content: {
+          kind: 'function_call',
+          id: 'question-tool-1',
+          name: 'AskUserQuestion',
+          args: { questions: [{ question: 'Choose', options: [{ label: 'Extend' }] }] },
+        },
+        refs: { toolCallId: 'question-tool-1' },
+      }),
+      ev({
+        id: 'evt-question-request',
+        ts: ts + 2,
+        actions: {
+          userQuestionRequest: {
+            requestId: 'question-1',
+            toolUseId: 'question-tool-1',
+            questions: [{ question: 'Choose', options: [{ label: 'Extend' }] }],
+          },
+        },
+        refs: { toolCallId: 'question-tool-1' },
+      }),
+      ev({
+        id: 'evt-question-result',
+        ts: ts + 3,
+        role: 'tool',
+        author: 'tool',
+        content: {
+          kind: 'function_response',
+          id: 'question-tool-1',
+          name: 'AskUserQuestion',
+          result: { kind: 'json', value: { answers: ['Extend'] } },
+        },
+        refs: { toolCallId: 'question-tool-1' },
+      }),
+      ev({
+        id: 'evt-question-complete',
+        ts: ts + 4,
+        status: 'completed',
+        actions: { endInvocation: true },
+      }),
+    ], { runHeaders: [header] });
+
+    expect(out.messages.map((message) => message.type)).toEqual([
+      'tool_call',
+      'tool_result',
+      'turn_state',
+    ]);
+    expect(out.diagnostics).toEqual([]);
+  });
+
   test('normalizes an exact legacy terminal result at RuntimeEvent restore', () => {
     const out = projectRuntimeEventsToStoredMessages([
       ev({

--- a/packages/runtime/src/runtime-event-read-model.ts
+++ b/packages/runtime/src/runtime-event-read-model.ts
@@ -156,6 +156,12 @@ export function projectRuntimeEventsToStoredMessages(
       projected = true;
     }
 
+    if (event.actions?.userQuestionRequest) {
+      // The matching function_call/function_response own the legacy rows;
+      // this request is live interaction state only.
+      projected = true;
+    }
+
     if (event.actions?.permissionDecision) {
       projected = projectPermissionDecision(event, state, messages) || projected;
     }


### PR DESCRIPTION
## Summary

RuntimeEvent reads rejected completed runs containing an action-only `userQuestionRequest`, even though the matching `AskUserQuestion` function call and response already own the legacy transcript rows.

Recognize the request as supported live interaction state without creating an additional `StoredMessage`. Add a complete function call → question request → function response → terminal regression test.

## Verification

- `npm --workspace @maka/runtime test`
  - 1888 tests
  - 1881 passed
  - 7 skipped
  - 0 failed
- Replayed the original affected local session through `RuntimeReadModel`
  - 1168 messages restored
  - 0 hard projection diagnostics

## Root cause

`AiSdkFlow` began writing `actions.userQuestionRequest`, but `projectRuntimeEventsToStoredMessages()` did not classify that action as supported. Because the event intentionally has no message content, it fell through to `unsupported_event`, causing the read model to reject the entire session.
