### PR TITLE
fix(core): restore pre-status terminal results

### DIFF
--- a/packages/core/src/__tests__/shell-run-result.test.ts
+++ b/packages/core/src/__tests__/shell-run-result.test.ts
@@ -157,6 +157,52 @@ describe('ShellRun view updates', () => {
 });
 
 describe('normalizeShellToolResultContent', () => {
+  it('normalizes the exact pre-status terminal result and preserves its truncation marker', () => {
+    assert.deepEqual(normalizeShellToolResultContent({
+      kind: 'terminal',
+      cwd: '/repo',
+      cmd: 'printf ok',
+      exitCode: 0,
+      stdout: '...12 bytes truncated. historical recovery guidance\n\nok',
+      stderr: '',
+    }), {
+      state: 'valid',
+      content: {
+        kind: 'terminal',
+        cwd: '/repo',
+        cmd: 'printf ok',
+        status: 'completed',
+        exitCode: 0,
+        output: {
+          mode: 'pipes',
+          stdout: '...12 bytes truncated. historical recovery guidance\n\nok',
+          stderr: '',
+          stdoutTruncated: true,
+          stderrTruncated: false,
+          redacted: false,
+        },
+      },
+    });
+  });
+
+  it('rejects incomplete or contradictory pre-status terminal results', () => {
+    const historical = {
+      kind: 'terminal',
+      cwd: '/repo',
+      cmd: 'printf ok',
+      exitCode: 0,
+      stdout: 'ok',
+      stderr: '',
+    };
+    for (const value of [
+      { ...historical, exitCode: 1 },
+      { ...historical, status: 'completed' },
+      { kind: 'terminal', cwd: '/repo', cmd: 'printf ok', exitCode: 0, stdout: 'ok' },
+    ]) {
+      assert.equal(normalizeShellToolResultContent(value).state, 'invalid');
+    }
+  });
+
   it('accepts canonical current terminal state and rejects contradictory exit status', () => {
     const current = {
       kind: 'terminal',

--- a/packages/core/src/shell-run-result.ts
+++ b/packages/core/src/shell-run-result.ts
@@ -122,6 +122,15 @@ const LEGACY_TERMINAL_RESULT_KEYS = new Set([
   'stderrTruncated',
 ]);
 
+const PRE_STATUS_TERMINAL_RESULT_KEYS = new Set([
+  'kind',
+  'cwd',
+  'cmd',
+  'exitCode',
+  'stdout',
+  'stderr',
+]);
+
 const LEGACY_SHELL_RUN_RESULT_KEYS = new Set([
   'kind',
   'ref',
@@ -154,11 +163,44 @@ export function normalizeShellToolResultContent(value: unknown): ShellToolResult
     : currentShellRunResult(value);
   if (current) return { state: 'valid', content: current };
   const legacy = value.kind === 'terminal'
-    ? normalizeLegacyTerminalResult(value)
+    ? normalizeLegacyTerminalResult(value) ?? normalizePreStatusTerminalResult(value)
     : normalizeLegacyShellRunResult(value);
   return legacy
     ? { state: 'valid', content: legacy }
     : { state: 'invalid' };
+}
+
+function normalizePreStatusTerminalResult(
+  value: Record<string, unknown>,
+): Extract<ToolResultContent, { kind: 'terminal' }> | undefined {
+  if (
+    !hasOnlyKeys(value, PRE_STATUS_TERMINAL_RESULT_KEYS)
+    || typeof value.cwd !== 'string'
+    || typeof value.cmd !== 'string'
+    || value.exitCode !== 0
+    || typeof value.stdout !== 'string'
+    || typeof value.stderr !== 'string'
+  ) return undefined;
+
+  return {
+    kind: 'terminal',
+    cwd: value.cwd,
+    cmd: value.cmd,
+    status: 'completed',
+    exitCode: 0,
+    output: {
+      mode: 'pipes',
+      stdout: value.stdout,
+      stderr: value.stderr,
+      stdoutTruncated: hasLegacyTruncationMarker(value.stdout),
+      stderrTruncated: hasLegacyTruncationMarker(value.stderr),
+      redacted: false,
+    },
+  };
+}
+
+function hasLegacyTruncationMarker(value: string): boolean {
+  return /^\.\.\.\d+ (?:bytes|lines) truncated\./.test(value);
 }
 
 function currentTerminalResult(value: Record<string, unknown>): TerminalToolResult | undefined {


### PR DESCRIPTION
## Summary

Closes #1001

Restore the exact successful terminal-result shape emitted before Bash results carried explicit status and truncation fields.

The compatibility path requires the historical key set and `exitCode === 0`, restores `status: completed`, and derives truncation flags from the writer's embedded truncation marker. Incomplete, extra-field, and contradictory variants remain invalid.

## Verification

- `npm --workspace @maka/core test`
  - 998 passed
  - 0 failed
- Built `@maka/runtime` and ran `runtime-event-read-model.test.js`
  - 22 passed
  - 0 failed
- Replayed all 76 local sessions through `RuntimeReadModel`
  - the three sessions blocked by pre-status terminal results became readable
  - failure count dropped from 4 to 1
  - the remaining failure is the independent `userQuestionRequest` regression fixed by `fix/runtime-project-user-question`

## Migration

This is a read-time compatibility normalization only. It does not rewrite persisted RuntimeEvents and does not relax validation for unknown shell-result shapes.
