### PR TITLE
fix(goal): make turn settlement atomic

### DIFF
--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -491,7 +491,6 @@ const goalWiring = createMainGoalWiring({
       .map((task) => task.key);
   },
   recordTaskGateDecision: async (trace) => {
-    if (!trace.turnId) return;
     const runs = await runStore.listSessionRuns(trace.sessionId);
     const run = runs.find((candidate) => candidate.turnId === trace.turnId);
     if (!run) return;

--- a/packages/cli/src/__tests__/pi-transcript.test.ts
+++ b/packages/cli/src/__tests__/pi-transcript.test.ts
@@ -113,26 +113,41 @@ describe('Maka Pi TUI transcript', () => {
   // Goal kill-switch (B1): the turn outcome must distinguish a clean end from a
   // user-stop / abort / error so the runner can skip goal auto-continuation and
   // never re-inject after the user interrupts (or after a failing turn).
-  test('reports a clean turn as not aborted / not errored', async () => {
+  test('reports a clean turn with the terminal event identity', async () => {
     const state = createMakaPiTranscriptState();
     const driver = new RecordingDriver([event({ type: 'complete', stopReason: 'end_turn' })]);
     const outcome = await submitPromptToTranscript({ state, driver, prompt: 'hi' });
-    assert.deepEqual(outcome, { aborted: false, errored: false });
+    assert.deepEqual(outcome, { kind: 'completed', turnId: 'turn-1' });
+  });
+
+  test('treats EOF without a terminal event as an errored turn', async () => {
+    const state = createMakaPiTranscriptState();
+    const outcome = await submitPromptToTranscript({
+      state,
+      driver: new RecordingDriver([]),
+      prompt: 'hi',
+    });
+
+    assert.deepEqual(outcome, { kind: 'errored' });
+    assert.ok(state.entries.some(
+      (entry) => entry.kind === 'notice'
+        && entry.level === 'error'
+        && entry.text === 'Session turn ended without a completion event',
+    ));
   });
 
   test('reports a user_stop completion as aborted (Stop affordance)', async () => {
     const state = createMakaPiTranscriptState();
     const driver = new RecordingDriver([event({ type: 'complete', stopReason: 'user_stop' })]);
     const outcome = await submitPromptToTranscript({ state, driver, prompt: 'hi' });
-    assert.equal(outcome.aborted, true);
-    assert.equal(outcome.errored, false);
+    assert.deepEqual(outcome, { kind: 'aborted', turnId: 'turn-1' });
   });
 
   test('reports an abort event as aborted', async () => {
     const state = createMakaPiTranscriptState();
     const driver = new RecordingDriver([event({ type: 'abort', reason: 'user_stop' })]);
     const outcome = await submitPromptToTranscript({ state, driver, prompt: 'hi' });
-    assert.equal(outcome.aborted, true);
+    assert.deepEqual(outcome, { kind: 'aborted', turnId: 'turn-1' });
   });
 
   test('reports a stream error event as errored', async () => {
@@ -140,7 +155,7 @@ describe('Maka Pi TUI transcript', () => {
     const driver = new RecordingDriver([event({ type: 'error', recoverable: false, message: 'boom' })]);
     let errorRaised = false;
     const outcome = await submitPromptToTranscript({ state, driver, prompt: 'hi', onError: () => { errorRaised = true; } });
-    assert.equal(outcome.errored, true);
+    assert.deepEqual(outcome, { kind: 'errored', turnId: 'turn-1' });
     assert.equal(errorRaised, true);
   });
 
@@ -148,8 +163,7 @@ describe('Maka Pi TUI transcript', () => {
     const state = createMakaPiTranscriptState();
     const driver = new RecordingDriver([event({ type: 'complete', stopReason: 'error' })]);
     const outcome = await submitPromptToTranscript({ state, driver, prompt: 'hi' });
-    assert.equal(outcome.errored, true);
-    assert.equal(outcome.aborted, false);
+    assert.deepEqual(outcome, { kind: 'errored', turnId: 'turn-1' });
   });
 
   test('shows a fixed system notice when the configured step limit is reached', () => {
@@ -184,7 +198,7 @@ describe('Maka Pi TUI transcript', () => {
 
     const outcome = await submitPromptToTranscript({ state, driver, prompt: 'hi' });
 
-    assert.deepEqual(outcome, { aborted: false, errored: true });
+    assert.deepEqual(outcome, { kind: 'errored', turnId: 'turn-1' });
   });
 
   test('reports a thrown sendPrompt as errored', async () => {
@@ -199,8 +213,7 @@ describe('Maka Pi TUI transcript', () => {
       },
     };
     const outcome = await submitPromptToTranscript({ state, driver, prompt: 'hi' });
-    assert.equal(outcome.errored, true);
-    assert.equal(outcome.aborted, false);
+    assert.equal(outcome.kind, 'errored');
     assert.equal(state.pendingInteraction, undefined);
     assert.deepEqual(state.queuedInteractions, []);
   });

--- a/packages/cli/src/__tests__/pi-tui-runner.test.ts
+++ b/packages/cli/src/__tests__/pi-tui-runner.test.ts
@@ -764,6 +764,31 @@ describe('Maka Pi TUI runner', () => {
     ]);
   });
 
+  test('passes the runtime terminal turn identity to the completion callback', async () => {
+    const terminal = new FakeTerminal();
+    const driver = new RuntimeTurnIdentityDriver();
+    const completedTurnIds: string[] = [];
+    const run = runMakaPiTui({
+      title: 'Maka',
+      driver,
+      cwd: '/repo',
+      model: 'deepseek-v4-flash',
+      connectionSlug: 'deepseek',
+      permissionMode: 'ask',
+      terminal,
+      onTurnComplete: (turnId) => { completedTurnIds.push(turnId); },
+    });
+
+    terminal.input('run');
+    terminal.input('\r');
+    await waitFor(() => completedTurnIds.length === 1);
+
+    assert.deepEqual(completedTurnIds, ['runtime-turn-42']);
+
+    exitMaka(terminal);
+    await run;
+  });
+
   test('flows a transcript taller than the viewport into scrollback, untruncated and un-paged', async () => {
     const terminal = new FakeTerminal();
     const driver = new LongTranscriptDriver();
@@ -3619,6 +3644,19 @@ class SlashCommandDriver implements MakaSessionDriver {
   }
   getSessionId(): string {
     return this.sessionId;
+  }
+}
+
+class RuntimeTurnIdentityDriver extends SlashCommandDriver {
+  override async *sendPrompt(prompt: string): AsyncIterable<SessionEvent> {
+    this.prompts.push(prompt);
+    yield {
+      type: 'complete',
+      id: 'event-complete',
+      turnId: 'runtime-turn-42',
+      ts: 1,
+      stopReason: 'end_turn',
+    };
   }
 }
 

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -152,12 +152,13 @@ export async function runMakaCli(argv: string[] = process.argv.slice(2)): Promis
           subscribeShellRunUpdates: context.subscribeShellRunUpdates,
           listShellRunUpdates: context.listShellRunUpdates,
           onProcessExit: handleMakaCliProcessExit,
-          onTurnComplete: (injectTurn) => {
+          onTurnComplete: (turnId, injectTurn) => {
             const sessionId = driver.getSessionId();
             if (!sessionId) return;
             void handleGoalContinuation(
               { ...context.goalContinuationDeps, injectTurn: (_s, text) => injectTurn(text) },
               sessionId,
+              turnId,
             ).catch(() => {});
           },
         });

--- a/packages/cli/src/pi-transcript.ts
+++ b/packages/cli/src/pi-transcript.ts
@@ -230,12 +230,14 @@ export function togglePendingPermissionDetails(state: MakaPiTranscriptState): bo
   return true;
 }
 
-export interface TurnOutcome {
-  /** The turn was user-stopped or aborted (double-Escape → driver.stop()). */
-  aborted: boolean;
-  /** The turn ended in an error (stream `error` event or thrown failure). */
-  errored: boolean;
-}
+export type TurnOutcome =
+  | {
+      kind: 'completed';
+      /** Stable identity from the runtime's terminal event. */
+      turnId: string;
+    }
+  | { kind: 'aborted'; turnId?: string }
+  | { kind: 'errored'; turnId?: string };
 
 export async function submitPromptToTranscript(input: {
   state: MakaPiTranscriptState;
@@ -252,35 +254,34 @@ export async function submitPromptToTranscript(input: {
   appendUserPrompt(input.state, input.prompt);
   input.onChange?.();
 
-  // Surface how the turn ended so the host can gate goal auto-continuation: a
-  // user_stop/abort (the Stop affordance) or an errored turn must NOT trigger
-  // another autonomous turn — mirrors the desktop `turnAborted` guard.
-  let aborted = false;
-  let errored = false;
+  // A single terminal outcome gates goal auto-continuation. Error outranks
+  // abort, which outranks success if a malformed stream emits several terminal
+  // events; well-formed runtime streams emit exactly one.
+  let outcome: TurnOutcome | undefined;
   try {
     for await (const event of input.driver.sendPrompt(input.prompt)) {
-      applyMakaSessionEventToTranscript(input.state, event);
-      if (event.type === 'abort' || (event.type === 'complete' && event.stopReason === 'user_stop')) {
-        aborted = true;
-      }
-      if (event.type === 'error') {
-        errored = true;
-        input.onError?.();
-      }
-      // A non-throwing error finish (e.g. content-filter) arrives as
-      // complete{stopReason:'error'} with no separate `error` event — treat it as
-      // errored too, so goal continuation never re-injects into a failed turn
-      // (self-sufficient, not reliant on the session-status backstop).
-      if (
-        event.type === 'complete'
-        && failureClassFromCompleteStopReason(event.stopReason) !== undefined
+      const failed = event.type === 'complete'
+        && failureClassFromCompleteStopReason(event.stopReason) !== undefined;
+      if (event.type === 'error' || failed) {
+        outcome = { kind: 'errored', turnId: event.turnId };
+      } else if (
+        outcome?.kind !== 'errored'
+        && (event.type === 'abort' || (event.type === 'complete' && event.stopReason === 'user_stop'))
       ) {
-        errored = true;
+        outcome = { kind: 'aborted', turnId: event.turnId };
+      } else if (outcome === undefined && event.type === 'complete') {
+        outcome = { kind: 'completed', turnId: event.turnId };
+      }
+
+      applyMakaSessionEventToTranscript(input.state, event);
+      if (event.type === 'error') {
+        input.onError?.();
       }
       input.onChange?.();
     }
+    if (!outcome) throw new Error('Session turn ended without a completion event');
+    return outcome;
   } catch (error) {
-    errored = true;
     clearPendingInteractions(input.state);
     input.state.entries.push({
       kind: 'notice',
@@ -289,8 +290,8 @@ export async function submitPromptToTranscript(input: {
     });
     input.onError?.();
     input.onChange?.();
+    return { kind: 'errored', ...(outcome?.turnId ? { turnId: outcome.turnId } : {}) };
   }
-  return { aborted, errored };
 }
 
 export async function submitCompactToTranscript(input: {

--- a/packages/cli/src/pi-tui-runner.ts
+++ b/packages/cli/src/pi-tui-runner.ts
@@ -36,6 +36,7 @@ import {
   toggleAllToolExpansion,
   togglePendingPermissionDetails,
   type MakaPiTranscriptMetadata,
+  type TurnOutcome,
 } from './pi-transcript.js';
 import { editorTheme, selectListTheme } from './tui-ansi.js';
 import { MakaAutocompleteAboveEditorComponent } from './tui-autocomplete-layout.js';
@@ -95,7 +96,7 @@ export interface MakaPiTuiInput {
    * new turn rendered in the transcript — used for goal auto-continuation so
    * continuation turns are visible and chain correctly.
    */
-  onTurnComplete?: (injectTurn: (text: string) => void) => void;
+  onTurnComplete?: (turnId: string, injectTurn: (text: string) => void) => void;
 }
 
 export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
@@ -411,7 +412,7 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
     requestRender();
 
     let permissionAlerted = false;
-    let turnOutcome = { aborted: false, errored: false };
+    let turnOutcome: TurnOutcome | undefined;
     void submitPromptToTranscript({
       state,
       driver: input.driver,
@@ -456,8 +457,8 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
       // or it ended in error. An autonomous loop MUST halt on the Stop
       // affordance and must not hammer a failing turn — mirrors the desktop
       // `turnAborted` guard.
-      if (!closed && !turnOutcome.aborted && !turnOutcome.errored) {
-        input.onTurnComplete?.((text) => runAgentTurn(text));
+      if (!closed && turnOutcome?.kind === 'completed') {
+        input.onTurnComplete?.(turnOutcome.turnId, (text) => runAgentTurn(text));
       }
     });
   }

--- a/packages/runtime/src/__tests__/goal-continuation.test.ts
+++ b/packages/runtime/src/__tests__/goal-continuation.test.ts
@@ -36,24 +36,39 @@ function setup(opts?: {
   return { mgr, deps, injected };
 }
 
+function controlledCall<T>() {
+  let markStarted!: () => void;
+  let resolveResult!: (value: T | PromiseLike<T>) => void;
+  const started = new Promise<void>((resolve) => { markStarted = resolve; });
+  const result = new Promise<T>((resolve) => { resolveResult = resolve; });
+  return {
+    invoke: () => {
+      markStarted();
+      return result;
+    },
+    started,
+    resolve: resolveResult,
+  };
+}
+
 describe('handleGoalContinuation', () => {
   test('no active goal → no_goal', async () => {
     const { deps } = setup();
-    const out = await handleGoalContinuation(deps, SESSION);
+    const out = await handleGoalContinuation(deps, SESSION, 'turn-1');
     assert.equal(out.kind, 'no_goal');
   });
 
   test('session busy → cannot_continue', async () => {
     const { mgr, deps } = setup({ canContinue: false });
-    mgr.set(SESSION, 'x');
-    const out = await handleGoalContinuation(deps, SESSION);
+    mgr.create(SESSION, 'x');
+    const out = await handleGoalContinuation(deps, SESSION, 'turn-1');
     assert.equal(out.kind, 'cannot_continue');
   });
 
   test('met → achieved, no injection', async () => {
     const { mgr, deps, injected } = setup({ evaluation: { met: true, reason: 'all pass' } });
-    mgr.set(SESSION, 'x');
-    const out = await handleGoalContinuation(deps, SESSION);
+    mgr.create(SESSION, 'x');
+    const out = await handleGoalContinuation(deps, SESSION, 'turn-1');
     assert.equal(out.kind, 'achieved');
     assert.equal(mgr.get(SESSION)?.status, 'achieved');
     assert.equal(injected.length, 0);
@@ -61,8 +76,8 @@ describe('handleGoalContinuation', () => {
 
   test('impossible → impossible, no injection', async () => {
     const { mgr, deps, injected } = setup({ evaluation: { impossible: true, reason: 'cannot' } });
-    mgr.set(SESSION, 'x');
-    const out = await handleGoalContinuation(deps, SESSION);
+    mgr.create(SESSION, 'x');
+    const out = await handleGoalContinuation(deps, SESSION, 'turn-1');
     assert.equal(out.kind, 'impossible');
     assert.equal(mgr.get(SESSION)?.status, 'impossible');
     assert.equal(injected.length, 0);
@@ -70,8 +85,8 @@ describe('handleGoalContinuation', () => {
 
   test('not met + progress → continued, injects steering turn', async () => {
     const { mgr, deps, injected } = setup({ evaluation: { progress: true, reason: '1 of 3 done' } });
-    mgr.set(SESSION, 'x');
-    const out = await handleGoalContinuation(deps, SESSION);
+    mgr.create(SESSION, 'x');
+    const out = await handleGoalContinuation(deps, SESSION, 'turn-1');
     assert.equal(out.kind, 'continued');
     assert.equal(injected.length, 1);
     assert.ok(injected[0].includes('1 of 3 done'));
@@ -81,11 +96,11 @@ describe('handleGoalContinuation', () => {
 
   test('no progress accumulates and trips stalled at block cap', async () => {
     const { mgr, deps, injected } = setup({ evaluation: { progress: false, reason: 'stuck' } });
-    mgr.set(SESSION, 'x', { blockCap: 2 });
-    const first = await handleGoalContinuation(deps, SESSION);
+    mgr.create(SESSION, 'x', { blockCap: 2 });
+    const first = await handleGoalContinuation(deps, SESSION, 'turn-1');
     assert.equal(first.kind, 'continued');
     assert.equal(mgr.get(SESSION)?.consecutiveNoProgress, 1);
-    const second = await handleGoalContinuation(deps, SESSION);
+    const second = await handleGoalContinuation(deps, SESSION, 'turn-2');
     assert.equal(second.kind, 'stopped');
     assert.equal(mgr.get(SESSION)?.status, 'stalled');
     // Second call must not inject (goal stalled).
@@ -94,33 +109,41 @@ describe('handleGoalContinuation', () => {
 
   test('evaluate-first: a goal MET on its final permitted turn is achieved, not max_iterations', async () => {
     const { mgr, deps } = setup({ evaluation: { met: true, reason: 'all pass' } });
-    mgr.set(SESSION, 'x', { maxIterations: 1 });
-    const out = await handleGoalContinuation(deps, SESSION);
+    mgr.create(SESSION, 'x', { maxIterations: 1 });
+    const out = await handleGoalContinuation(deps, SESSION, 'turn-final');
     assert.equal(out.kind, 'achieved');
     assert.equal(mgr.get(SESSION)?.status, 'achieved');
   });
 
   test('not-met on the final permitted turn stops with max_iterations', async () => {
     const { mgr, deps } = setup({ evaluation: { met: false, progress: true } });
-    mgr.set(SESSION, 'x', { maxIterations: 1 });
-    const out = await handleGoalContinuation(deps, SESSION);
+    mgr.create(SESSION, 'x', { maxIterations: 1 });
+    const out = await handleGoalContinuation(deps, SESSION, 'turn-final');
     assert.equal(out.kind, 'stopped');
     assert.equal(mgr.get(SESSION)?.status, 'max_iterations');
   });
 
   test('evaluate-first: a goal MET on the budget-crossing turn is achieved, not budget_limited', async () => {
     const { mgr, deps } = setup({ tokenCount: 2000, evaluation: { met: true, reason: 'done' } });
-    mgr.set(SESSION, 'x', { tokenBudget: 1000, tokensAtStart: 500 });
-    const out = await handleGoalContinuation(deps, SESSION);
+    mgr.create(SESSION, 'x', { tokenBudget: 1000, tokensAtStart: 500 });
+    const out = await handleGoalContinuation(deps, SESSION, 'turn-final');
     assert.equal(out.kind, 'achieved');
     assert.equal(mgr.get(SESSION)?.status, 'achieved');
   });
 
   test('not-met budget crossing stops with budget_limited', async () => {
     const { mgr, deps } = setup({ tokenCount: 2000, evaluation: { met: false, progress: true } });
-    mgr.set(SESSION, 'x', { tokenBudget: 1000, tokensAtStart: 500 });
-    mgr.recordTokens(SESSION, 500); // establish baseline before the continuation
-    const out = await handleGoalContinuation(deps, SESSION);
+    const created = mgr.create(SESSION, 'x', { tokenBudget: 1000, tokensAtStart: 500 });
+    assert.equal(created.kind, 'created');
+    mgr.settleTurn(SESSION, {
+      checkpoint: { goalId: created.goal.id, revision: created.goal.revision },
+      turnId: 'turn-baseline',
+      verdict: 'continue',
+      reason: 'baseline',
+      madeProgress: true,
+      tokensNow: 500,
+    });
+    const out = await handleGoalContinuation(deps, SESSION, 'turn-final');
     assert.equal(out.kind, 'stopped');
     assert.equal(mgr.get(SESSION)?.status, 'budget_limited');
   });
@@ -136,8 +159,8 @@ describe('handleGoalContinuation', () => {
       injectTurn: () => {},
       canContinue: async () => true,
     };
-    mgr.set(SESSION, 'x', { blockCap: 2 });
-    await handleGoalContinuation(deps, SESSION);
+    mgr.create(SESSION, 'x', { blockCap: 2 });
+    await handleGoalContinuation(deps, SESSION, 'turn-1');
     // Neutral: streak neither advanced nor reset; goal still active (fail-open).
     assert.equal(mgr.get(SESSION)?.consecutiveNoProgress, 0);
     assert.equal(mgr.get(SESSION)?.status, 'active');
@@ -147,8 +170,8 @@ describe('handleGoalContinuation', () => {
     const { mgr, deps, injected } = setup({
       evaluation: { waiting: true, progress: false, reason: 'CI still running' },
     });
-    mgr.set(SESSION, 'deploy done', { blockCap: 2 });
-    const out = await handleGoalContinuation(deps, SESSION);
+    mgr.create(SESSION, 'deploy done', { blockCap: 2 });
+    const out = await handleGoalContinuation(deps, SESSION, 'turn-1');
     assert.equal(out.kind, 'continued');
     // Waiting must NOT accumulate toward stall (a wait is not being stuck).
     assert.equal(mgr.get(SESSION)?.consecutiveNoProgress, 0);
@@ -160,10 +183,10 @@ describe('handleGoalContinuation', () => {
     const { mgr, deps } = setup({
       evaluation: { waiting: true, progress: false, reason: 'CI running' },
     });
-    mgr.set(SESSION, 'x', { maxIterations: 3 });
-    await handleGoalContinuation(deps, SESSION); // turn 1
-    await handleGoalContinuation(deps, SESSION); // turn 2
-    const third = await handleGoalContinuation(deps, SESSION); // turn 3 hits cap
+    mgr.create(SESSION, 'x', { maxIterations: 3 });
+    await handleGoalContinuation(deps, SESSION, 'turn-1');
+    await handleGoalContinuation(deps, SESSION, 'turn-2');
+    const third = await handleGoalContinuation(deps, SESSION, 'turn-3');
     assert.equal(third.kind, 'stopped');
     assert.equal(mgr.get(SESSION)?.status, 'max_iterations');
   });
@@ -172,40 +195,157 @@ describe('handleGoalContinuation', () => {
     let id = 0;
     const mgr = new GoalManager({ generateId: () => `g-${++id}`, now: () => 1000 });
     const inFlight = new Set<string>();
-    let releaseEval: (() => void) | undefined;
+    const evaluation = controlledCall<string>();
     const deps: GoalContinuationDeps = {
       goalManager: mgr,
       inFlight,
-      evaluator: { evaluate: () => new Promise<string>((resolve) => { releaseEval = () => resolve('{"met": false, "progress": true, "reason": "x"}'); }) },
+      evaluator: { evaluate: evaluation.invoke },
       getRecentContext: async () => 'ctx',
       injectTurn: () => {},
       canContinue: async () => true,
     };
-    mgr.set(SESSION, 'x');
-    const first = handleGoalContinuation(deps, SESSION); // hangs on evaluate
-    await new Promise((r) => setTimeout(r, 0));
-    const second = await handleGoalContinuation(deps, SESSION); // should see inFlight
+    mgr.create(SESSION, 'x');
+    const first = handleGoalContinuation(deps, SESSION, 'turn-1'); // hangs on evaluate
+    await evaluation.started;
+    const second = await handleGoalContinuation(deps, SESSION, 'turn-2'); // should see inFlight
     assert.equal(second.kind, 'busy');
-    releaseEval?.();
+    evaluation.resolve('{"met": false, "progress": true, "reason": "x"}');
     await first;
+  });
+
+  test('a completed turn is settled once without re-running the evaluator', async () => {
+    const { mgr, deps, injected } = setup();
+    let evaluations = 0;
+    const evaluate = deps.evaluator.evaluate;
+    deps.evaluator.evaluate = (...args) => {
+      evaluations++;
+      return evaluate(...args);
+    };
+    mgr.create(SESSION, 'x');
+
+    const first = await handleGoalContinuation(deps, SESSION, 'turn-1');
+    const replay = await handleGoalContinuation(deps, SESSION, 'turn-1');
+
+    assert.equal(first.kind, 'continued');
+    assert.equal(replay.kind, 'duplicate');
+    assert.equal(evaluations, 1);
+    assert.equal(injected.length, 1);
+    assert.equal(mgr.get(SESSION)?.iterations, 1);
+  });
+
+  test('a settled turn remains duplicate after its terminal Goal is replaced', async () => {
+    const { mgr, deps, injected } = setup();
+    let evaluations = 0;
+    const evaluate = deps.evaluator.evaluate;
+    deps.evaluator.evaluate = (...args) => {
+      evaluations++;
+      return evaluate(...args);
+    };
+    mgr.create(SESSION, 'first', { maxIterations: 1 });
+
+    const first = await handleGoalContinuation(deps, SESSION, 'turn-shared');
+    assert.equal(first.kind, 'stopped');
+    const replacement = mgr.create(SESSION, 'replacement');
+    assert.equal(replacement.kind, 'created');
+    const replay = await handleGoalContinuation(deps, SESSION, 'turn-shared');
+
+    assert.equal(replay.kind, 'duplicate');
+    assert.equal(evaluations, 1);
+    assert.deepEqual(injected, []);
+    assert.equal(replacement.goal.iterations, 0);
+    assert.equal(replacement.goal.revision, 0);
+  });
+
+  test('an evaluator result cannot settle a replacement Goal', async () => {
+    const { mgr, deps, injected } = setup();
+    const evaluation = controlledCall<string>();
+    deps.evaluator.evaluate = evaluation.invoke;
+    const decisions: string[] = [];
+    deps.taskGate = {
+      listActionableTaskKeys: async () => [],
+      recordDecision: (trace) => { decisions.push(trace.decision); },
+    };
+    mgr.create(SESSION, 'old');
+    const pending = handleGoalContinuation(deps, SESSION, 'turn-old');
+    await evaluation.started;
+
+    mgr.clear(SESSION);
+    const replacement = mgr.create(SESSION, 'replacement');
+    assert.equal(replacement.kind, 'created');
+    evaluation.resolve('{"met":true,"impossible":false,"progress":true,"waiting":false,"reason":"old done"}');
+    const result = await pending;
+
+    assert.equal(result.kind, 'stale');
+    assert.equal(mgr.get(SESSION)?.condition, 'replacement');
+    assert.equal(mgr.get(SESSION)?.status, 'active');
+    assert.deepEqual(injected, []);
+    assert.deepEqual(decisions, []);
+  });
+
+  test('an evaluator result cannot cross clear, pause/resume, or removal', async (t) => {
+    for (const scenario of ['clear', 'pause-resume', 'remove'] as const) {
+      await t.test(scenario, async () => {
+        const { mgr, deps, injected } = setup();
+        const evaluation = controlledCall<string>();
+        deps.evaluator.evaluate = evaluation.invoke;
+        mgr.create(SESSION, 'x');
+        const pending = handleGoalContinuation(deps, SESSION, `turn-${scenario}`);
+        await evaluation.started;
+
+        if (scenario === 'clear') {
+          mgr.clear(SESSION);
+        } else if (scenario === 'pause-resume') {
+          mgr.pause(SESSION);
+          mgr.resume(SESSION);
+        } else {
+          mgr.remove(SESSION);
+        }
+        evaluation.resolve('{"met":false,"impossible":false,"progress":true,"waiting":false,"reason":"old progress"}');
+        const result = await pending;
+
+        assert.equal(result.kind, 'stale');
+        if (scenario === 'remove') assert.equal(mgr.get(SESSION), undefined);
+        else assert.equal(mgr.get(SESSION)?.iterations, 0);
+        assert.deepEqual(injected, []);
+      });
+    }
+  });
+
+  test('a post-settlement pause prevents stale continuation injection', async () => {
+    const { mgr, deps, injected } = setup();
+    const taskRead = controlledCall<string[]>();
+    deps.taskGate = {
+      listActionableTaskKeys: taskRead.invoke,
+    };
+    mgr.create(SESSION, 'x');
+    const pending = handleGoalContinuation(deps, SESSION, 'turn-1');
+    await taskRead.started;
+
+    mgr.pause(SESSION);
+    taskRead.resolve([]);
+    const result = await pending;
+
+    assert.equal(result.kind, 'stale');
+    assert.equal(mgr.get(SESSION)?.status, 'paused');
+    assert.deepEqual(injected, []);
   });
 
   test('paused goal is not continued', async () => {
     const { mgr, deps } = setup();
-    mgr.set(SESSION, 'x');
+    mgr.create(SESSION, 'x');
     mgr.pause(SESSION);
-    const out = await handleGoalContinuation(deps, SESSION);
+    const out = await handleGoalContinuation(deps, SESSION, 'turn-1');
     assert.equal(out.kind, 'no_goal');
   });
 
   test('task gate injects one reminder per goal and traces the reminder limit', async () => {
     const { mgr, deps, injected } = setup();
-    const traces: Array<{ decision: string; taskKeys: string[]; turnId?: string }> = [];
+    const traces: Array<{ decision: string; taskKeys: string[]; turnId: string }> = [];
     deps.taskGate = {
       listActionableTaskKeys: async () => ['T1', 'T1.1'],
       recordDecision: (trace) => { traces.push(trace); },
     };
-    mgr.set(SESSION, 'finish implementation');
+    mgr.create(SESSION, 'finish implementation');
     await handleGoalContinuation(deps, SESSION, 'turn-1');
     await handleGoalContinuation(deps, SESSION, 'turn-2');
     assert.equal(injected.length, 2);
@@ -222,7 +362,7 @@ describe('handleGoalContinuation', () => {
       listActionableTaskKeys: async () => [],
       recordDecision: (trace) => { decisions.push(trace.decision); },
     };
-    mgr.set(SESSION, 'wait for dependency');
+    mgr.create(SESSION, 'wait for dependency');
     await handleGoalContinuation(deps, SESSION, 'turn-1');
     assert.doesNotMatch(injected[0]!, /\[Task reminder\]/);
     assert.deepEqual(decisions, ['no_actionable_tasks']);
@@ -236,7 +376,7 @@ describe('handleGoalContinuation', () => {
       listActionableTaskKeys: async () => { listCalls += 1; return ['T1']; },
       recordDecision: (trace) => { decisions.push(trace.decision); },
     };
-    mgr.set(SESSION, 'done');
+    mgr.create(SESSION, 'done');
     await handleGoalContinuation(deps, SESSION, 'turn-final');
     assert.equal(listCalls, 0);
     assert.equal(injected.length, 0);
@@ -255,7 +395,7 @@ describe('handleGoalContinuation', () => {
       listActionableTaskKeys: async () => ['T1'],
       recordDecision: (trace) => { traces.push(trace.decision); },
     };
-    mgr.set(SESSION, 'finish implementation');
+    mgr.create(SESSION, 'finish implementation');
 
     const preempted = await handleGoalContinuation(deps, SESSION, 'turn-1');
     assert.equal(preempted.kind, 'cannot_continue');
@@ -275,7 +415,7 @@ describe('handleGoalContinuation', () => {
       listActionableTaskKeys: async () => ['T1', 'T2.1'],
       recordDecision: (trace) => { traces.push(trace); },
     };
-    mgr.set(SESSION, 'finish implementation', { maxIterations: 1 });
+    mgr.create(SESSION, 'finish implementation', { maxIterations: 1 });
     const result = await handleGoalContinuation(deps, SESSION, 'turn-final');
     assert.equal(result.kind, 'stopped');
     assert.deepEqual(traces, [{

--- a/packages/runtime/src/__tests__/goal-state.test.ts
+++ b/packages/runtime/src/__tests__/goal-state.test.ts
@@ -2,9 +2,11 @@ import { describe, test } from 'node:test';
 import assert from 'node:assert/strict';
 import {
   GoalManager,
-  TERMINAL_GOAL_STATUSES,
+  goalCheckpoint,
   DEFAULT_MAX_ITERATIONS,
   DEFAULT_BLOCK_CAP,
+  type GoalState,
+  type GoalTurnSettlementInput,
 } from '../goal-state.js';
 
 const SESSION = 'sess-1';
@@ -12,279 +14,304 @@ const SESSION = 'sess-1';
 function createManager(startTime = 1_700_000_000_000) {
   let id = 0;
   let time = startTime;
-  const mgr = new GoalManager({ generateId: () => `goal-${++id}`, now: () => time });
-  return { mgr, advance: (ms: number) => { time += ms; }, at: () => time };
+  const events: Array<{ goal: GoalState; previous?: string }> = [];
+  const mgr = new GoalManager({
+    generateId: () => `goal-${++id}`,
+    now: () => time,
+    onChange: (goal, previous) => events.push({ goal, previous }),
+  });
+  return { mgr, events, advance: (ms: number) => { time += ms; } };
 }
 
-describe('GoalManager — set / lifecycle', () => {
-  test('set creates an active goal with defaults', () => {
+function createGoal(
+  mgr: GoalManager,
+  condition = 'all tests pass',
+  opts?: Parameters<GoalManager['create']>[2],
+): GoalState {
+  const result = mgr.create(SESSION, condition, opts);
+  assert.equal(result.kind, 'created');
+  return result.goal;
+}
+
+function settle(
+  mgr: GoalManager,
+  turnId: string,
+  input: Partial<Omit<
+    Extract<GoalTurnSettlementInput, { verdict: 'continue' }>,
+    'checkpoint' | 'turnId' | 'verdict'
+  >> = {},
+) {
+  const goal = mgr.getActive(SESSION);
+  assert.ok(goal);
+  return mgr.settleTurn(SESSION, {
+    checkpoint: goalCheckpoint(goal),
+    turnId,
+    verdict: 'continue',
+    reason: 'keep going',
+    madeProgress: true,
+    ...input,
+  });
+}
+
+describe('GoalManager creation and lifecycle', () => {
+  test('creates an immutable active goal with defaults and custom limits', () => {
     const { mgr } = createManager();
-    const g = mgr.set(SESSION, 'all tests pass');
-    assert.equal(g.status, 'active');
-    assert.equal(g.iterations, 0);
-    assert.equal(g.maxIterations, DEFAULT_MAX_ITERATIONS);
-    assert.equal(g.blockCap, DEFAULT_BLOCK_CAP);
-    assert.equal(g.consecutiveNoProgress, 0);
-    assert.equal(g.tokenBudget, undefined);
+    const goal = createGoal(mgr, 'ship it', {
+      maxIterations: 10,
+      blockCap: 3,
+      tokenBudget: 5000,
+      tokensAtStart: 100,
+    });
+
+    assert.equal(goal.revision, 0);
+    assert.equal(goal.status, 'active');
+    assert.equal(goal.maxIterations, 10);
+    assert.equal(goal.blockCap, 3);
+    assert.equal(goal.tokenBudget, 5000);
+    assert.equal(goal.tokensAtStart, 100);
+    assert.ok(Object.isFrozen(goal));
+
+    const { mgr: defaults } = createManager();
+    const defaultGoal = createGoal(defaults);
+    assert.equal(defaultGoal.maxIterations, DEFAULT_MAX_ITERATIONS);
+    assert.equal(defaultGoal.blockCap, DEFAULT_BLOCK_CAP);
   });
 
-  test('set accepts custom limits', () => {
-    const { mgr } = createManager();
-    const g = mgr.set(SESSION, 'x', { maxIterations: 10, blockCap: 3, tokenBudget: 5000, tokensAtStart: 100 });
-    assert.equal(g.maxIterations, 10);
-    assert.equal(g.blockCap, 3);
-    assert.equal(g.tokenBudget, 5000);
-    assert.equal(g.tokensAtStart, 100);
-    assert.equal(g.tokensNow, 100);
-  });
+  test('rejects active and paused Goal replacement without mutating either snapshot', () => {
+    const { mgr, events } = createManager();
+    const original = createGoal(mgr, 'first');
 
-  test('set replaces an active goal (old marked cleared)', () => {
-    const { mgr } = createManager();
-    const first = mgr.set(SESSION, 'first');
-    mgr.set(SESSION, 'second');
-    assert.equal(first.status, 'cleared');
-    assert.equal(mgr.get(SESSION)?.condition, 'second');
-  });
+    const activeConflict = mgr.create(SESSION, 'second');
+    assert.equal(activeConflict.kind, 'unfinished');
+    assert.strictEqual(activeConflict.goal, original);
 
-  test('set after a terminal goal does not mutate the settled one', () => {
-    const { mgr } = createManager();
-    const first = mgr.set(SESSION, 'first');
-    mgr.markAchieved(SESSION, 'done');
-    assert.equal(first.status, 'achieved');
-    mgr.set(SESSION, 'second');
-    // The achieved goal object keeps its status; a new goal replaces the map entry.
-    assert.equal(first.status, 'achieved');
-    assert.equal(mgr.get(SESSION)?.condition, 'second');
-  });
-
-  test('getActive only returns active goals', () => {
-    const { mgr } = createManager();
-    mgr.set(SESSION, 'x');
-    assert.ok(mgr.getActive(SESSION));
-    mgr.pause(SESSION);
-    assert.equal(mgr.getActive(SESSION), undefined);
-  });
-});
-
-describe('GoalManager — iteration ceiling', () => {
-  test('incrementIteration trips max_iterations', () => {
-    const { mgr } = createManager();
-    mgr.set(SESSION, 'x', { maxIterations: 2 });
-    mgr.incrementIteration(SESSION);
-    const g = mgr.incrementIteration(SESSION);
-    assert.equal(g?.status, 'max_iterations');
-  });
-
-  test('incrementIteration on non-active returns undefined', () => {
-    const { mgr } = createManager();
-    mgr.set(SESSION, 'x');
-    mgr.pause(SESSION);
-    assert.equal(mgr.incrementIteration(SESSION), undefined);
-  });
-});
-
-describe('GoalManager — block cap (stall detection)', () => {
-  test('progress resets the no-progress streak', () => {
-    const { mgr } = createManager();
-    mgr.set(SESSION, 'x', { blockCap: 3 });
-    mgr.recordProgress(SESSION, false);
-    mgr.recordProgress(SESSION, false);
-    assert.equal(mgr.get(SESSION)?.consecutiveNoProgress, 2);
-    mgr.recordProgress(SESSION, true);
-    assert.equal(mgr.get(SESSION)?.consecutiveNoProgress, 0);
-    assert.equal(mgr.get(SESSION)?.status, 'active');
-  });
-
-  test('block cap trips stalled', () => {
-    const { mgr } = createManager();
-    mgr.set(SESSION, 'x', { blockCap: 3 });
-    mgr.recordProgress(SESSION, false);
-    mgr.recordProgress(SESSION, false);
-    const g = mgr.recordProgress(SESSION, false);
-    assert.equal(g?.status, 'stalled');
-    assert.ok(g?.lastReason?.includes('No progress'));
-  });
-
-  test('recordProgress on non-active is a no-op', () => {
-    const { mgr } = createManager();
-    mgr.set(SESSION, 'x');
-    mgr.markAchieved(SESSION, 'done');
-    assert.equal(mgr.recordProgress(SESSION, false), undefined);
-  });
-});
-
-describe('GoalManager — token budget', () => {
-  test('recordTokens trips budget_limited (after baseline established)', () => {
-    const { mgr } = createManager();
-    mgr.set(SESSION, 'x', { tokenBudget: 1000, tokensAtStart: 500 });
-    mgr.recordTokens(SESSION, 500);  // establishes baseline at 500
-    mgr.recordTokens(SESSION, 1200); // spent 700, under budget
-    assert.equal(mgr.get(SESSION)?.status, 'active');
-    mgr.recordTokens(SESSION, 1600); // spent 1100, over budget
-    assert.equal(mgr.get(SESSION)?.status, 'budget_limited');
-  });
-
-  test('tokensSpent computes delta from established baseline', () => {
-    const { mgr } = createManager();
-    mgr.set(SESSION, 'x', { tokensAtStart: 500 });
-    mgr.recordTokens(SESSION, 500); // baseline
-    mgr.recordTokens(SESSION, 800);
-    assert.equal(mgr.tokensSpent(SESSION), 300);
-  });
-
-  test('token count is monotonic (stale smaller read ignored)', () => {
-    const { mgr } = createManager();
-    mgr.set(SESSION, 'x', { tokensAtStart: 0 });
-    mgr.recordTokens(SESSION, 0);    // baseline
-    mgr.recordTokens(SESSION, 1000);
-    mgr.recordTokens(SESSION, 500);  // stale
-    assert.equal(mgr.get(SESSION)?.tokensNow, 1000);
-  });
-
-  test('no budget → recordTokens never trips budget_limited', () => {
-    const { mgr } = createManager();
-    mgr.set(SESSION, 'x');
-    mgr.recordTokens(SESSION, 0);
-    mgr.recordTokens(SESSION, 1_000_000);
-    assert.equal(mgr.get(SESSION)?.status, 'active');
-  });
-});
-
-describe('GoalManager — pause / resume', () => {
-  test('pause then resume', () => {
-    const { mgr } = createManager();
-    mgr.set(SESSION, 'x');
     const paused = mgr.pause(SESSION);
-    assert.equal(paused?.status, 'paused');
-    assert.ok(paused?.pausedAt);
+    assert.equal(paused?.revision, 1);
+    const pausedConflict = mgr.create(SESSION, 'third');
+    assert.equal(pausedConflict.kind, 'unfinished');
+    assert.strictEqual(pausedConflict.goal, paused);
+    assert.equal(events.length, 2);
+  });
+
+  test('a terminal Goal may be followed by a new Goal without rewriting its snapshot', () => {
+    const { mgr } = createManager();
+    const first = createGoal(mgr, 'first');
+    const cleared = mgr.clear(SESSION);
+    assert.equal(cleared?.status, 'cleared');
+    const second = mgr.create(SESSION, 'second');
+
+    assert.equal(second.kind, 'created');
+    assert.notEqual(second.goal.id, first.id);
+    assert.equal(first.status, 'active');
+    assert.equal(first.revision, 0);
+  });
+
+  test('pause, resume, and clear each produce a new revision', () => {
+    const { mgr, advance } = createManager();
+    const original = createGoal(mgr);
+    advance(10);
+    const paused = mgr.pause(SESSION);
     const resumed = mgr.resume(SESSION);
+    const cleared = mgr.clear(SESSION);
+
+    assert.equal(original.revision, 0);
+    assert.equal(paused?.revision, 1);
+    assert.equal(paused?.status, 'paused');
+    assert.equal(resumed?.revision, 2);
     assert.equal(resumed?.status, 'active');
     assert.equal(resumed?.pausedAt, undefined);
-  });
-
-  test('cannot pause a non-active goal', () => {
-    const { mgr } = createManager();
-    mgr.set(SESSION, 'x');
-    mgr.markAchieved(SESSION, 'done');
-    assert.equal(mgr.pause(SESSION), undefined);
-  });
-
-  test('cannot resume a non-paused goal', () => {
-    const { mgr } = createManager();
-    mgr.set(SESSION, 'x');
-    assert.equal(mgr.resume(SESSION), undefined);
+    assert.equal(cleared?.revision, 3);
+    assert.equal(cleared?.status, 'cleared');
+    assert.equal(mgr.clear(SESSION), undefined);
   });
 });
 
-describe('GoalManager — terminal transitions', () => {
-  test('markAchieved / markImpossible only from active', () => {
-    const { mgr } = createManager();
-    mgr.set(SESSION, 'x');
-    assert.equal(mgr.markAchieved(SESSION, 'done')?.status, 'achieved');
-    assert.equal(mgr.markImpossible(SESSION, 'no'), undefined);
-  });
-
-  test('clear from active → cleared; clear from terminal keeps outcome', () => {
-    const { mgr } = createManager();
-    mgr.set(SESSION, 'x');
-    assert.equal(mgr.clear(SESSION)?.status, 'cleared');
-
-    mgr.set(SESSION, 'y');
-    mgr.markAchieved(SESSION, 'done');
-    assert.equal(mgr.clear(SESSION)?.status, 'achieved');
-  });
-
-  test('TERMINAL_GOAL_STATUSES covers all stop states', () => {
-    for (const s of ['achieved', 'impossible', 'cleared', 'stalled', 'budget_limited', 'max_iterations'] as const) {
-      assert.ok(TERMINAL_GOAL_STATUSES.has(s), `${s} should be terminal`);
-    }
-    assert.ok(!TERMINAL_GOAL_STATUSES.has('active'));
-    assert.ok(!TERMINAL_GOAL_STATUSES.has('paused'));
-  });
-
-  test('remove and dispose', () => {
-    const { mgr } = createManager();
-    mgr.set(SESSION, 'x');
-    assert.equal(mgr.remove(SESSION), true);
-    assert.equal(mgr.get(SESSION), undefined);
-    mgr.set('a', '1');
-    mgr.set('b', '2');
-    mgr.dispose();
-    assert.equal(mgr.get('a'), undefined);
-    assert.equal(mgr.get('b'), undefined);
-  });
-
-  test('different sessions are independent', () => {
-    const { mgr } = createManager();
-    mgr.set('a', 'goal A');
-    mgr.set('b', 'goal B');
-    assert.equal(mgr.get('a')?.condition, 'goal A');
-    assert.equal(mgr.get('b')?.condition, 'goal B');
-  });
-});
-
-describe('GoalManager — token baseline', () => {
-  test('first recordTokens establishes the baseline (spend starts at 0)', () => {
-    const { mgr } = createManager();
-    // GoalSet captured a stale/0 baseline; the goal actually starts at 50k.
-    mgr.set(SESSION, 'x', { tokenBudget: 20000, tokensAtStart: 0 });
-    mgr.recordTokens(SESSION, 50000); // first real observation → re-baseline
-    assert.equal(mgr.tokensSpent(SESSION), 0);
-    assert.equal(mgr.get(SESSION)?.status, 'active'); // NOT budget_limited
-    mgr.recordTokens(SESSION, 71000); // spent 21000 > 20000
-    assert.equal(mgr.get(SESSION)?.status, 'budget_limited');
-  });
-});
-
-describe('GoalManager — onChange (kill-switch events)', () => {
-  function managerWithSpy() {
-    let id = 0;
-    const events: Array<{ status: string; previous?: string }> = [];
-    const mgr = new GoalManager({
-      generateId: () => `goal-${++id}`,
-      now: () => 1_700_000_000_000,
-      onChange: (goal, previous) => events.push({ status: goal.status, previous }),
+describe('GoalManager atomic turn settlement', () => {
+  test('commits token, iteration, progress, reason, revision, and one event atomically', () => {
+    const { mgr, events } = createManager();
+    const before = createGoal(mgr, 'x', { tokensAtStart: 0 });
+    const result = settle(mgr, 'turn-1', {
+      madeProgress: false,
+      tokensNow: 50_000,
+      reason: 'one check remains',
     });
-    return { mgr, events };
-  }
 
-  test('fires on set (goal armed)', () => {
-    const { mgr, events } = managerWithSpy();
-    mgr.set(SESSION, 'x');
-    assert.equal(events.length, 1);
-    assert.equal(events[0].status, 'active');
-    assert.equal(events[0].previous, undefined);
-  });
-
-  test('fires on each continuation and carries the previous status', () => {
-    const { mgr, events } = managerWithSpy();
-    mgr.set(SESSION, 'x');
-    mgr.incrementIteration(SESSION);
+    assert.equal(result.kind, 'applied');
+    assert.equal(result.goal.revision, 1);
+    assert.equal(result.goal.iterations, 1);
+    assert.equal(result.goal.consecutiveNoProgress, 1);
+    assert.equal(result.goal.tokensAtStart, 50_000);
+    assert.equal(result.goal.tokensNow, 50_000);
+    assert.equal(result.goal.lastReason, 'one check remains');
+    assert.equal(before.iterations, 0);
     assert.equal(events.length, 2);
-    assert.equal(events[1].status, 'active');
-    assert.equal(events[1].previous, 'active');
+    assert.equal(events[1]?.previous, 'active');
   });
 
-  test('fires on terminal transitions (achieved / cleared)', () => {
-    const { mgr, events } = managerWithSpy();
-    mgr.set(SESSION, 'x');
-    mgr.markAchieved(SESSION, 'done');
-    assert.equal(events.at(-1)?.status, 'achieved');
-    mgr.set('sess-2', 'y');
-    mgr.clear('sess-2');
-    assert.equal(events.at(-1)?.status, 'cleared');
+  test('terminal evaluator verdict settles without advancing turn counters', () => {
+    const { mgr } = createManager();
+    const goal = createGoal(mgr, 'x', { maxIterations: 1, tokenBudget: 1000 });
+    const result = mgr.settleTurn(SESSION, {
+      checkpoint: goalCheckpoint(goal),
+      turnId: 'turn-final',
+      verdict: 'achieved',
+      reason: 'verified',
+    });
+
+    assert.equal(result.kind, 'applied');
+    assert.equal(result.goal.status, 'achieved');
+    assert.equal(result.goal.iterations, 0);
+    assert.equal(result.goal.lastReason, 'verified');
   });
 
-  test('fires on remove so a badge can clear', () => {
-    const { mgr, events } = managerWithSpy();
-    mgr.set(SESSION, 'x');
-    const before = events.length;
-    mgr.remove(SESSION);
-    assert.equal(events.length, before + 1);
+  test('token budget stops settlement before iteration and stall updates', () => {
+    const { mgr } = createManager();
+    createGoal(mgr, 'x', { tokenBudget: 1000, maxIterations: 2, blockCap: 1 });
+    settle(mgr, 'turn-1', { tokensNow: 500, madeProgress: true });
+    const budget = settle(mgr, 'turn-2', { tokensNow: 1500, madeProgress: false });
+
+    assert.equal(budget.kind, 'applied');
+    assert.equal(budget.goal.status, 'budget_limited');
+    assert.equal(budget.goal.iterations, 1);
+    assert.equal(budget.goal.consecutiveNoProgress, 0);
   });
 
-  test('is optional — a manager without onChange still mutates', () => {
-    const mgr = new GoalManager({ generateId: () => 'g', now: () => 0 });
-    assert.doesNotThrow(() => { mgr.set(SESSION, 'x'); mgr.clear(SESSION); });
+  test('iteration cap stops settlement before the stall update', () => {
+    const { mgr } = createManager();
+    createGoal(mgr, 'x', { maxIterations: 1, blockCap: 1 });
+
+    const result = settle(mgr, 'turn-1', { madeProgress: false });
+
+    assert.equal(result.kind, 'applied');
+    assert.equal(result.goal.status, 'max_iterations');
+    assert.equal(result.goal.consecutiveNoProgress, 0);
+  });
+
+  test('progress resets the streak and no progress eventually stalls', () => {
+    const { mgr } = createManager();
+    createGoal(mgr, 'x', { blockCap: 2 });
+    settle(mgr, 'turn-1', { madeProgress: false });
+    settle(mgr, 'turn-2', { madeProgress: true });
+    settle(mgr, 'turn-3', { madeProgress: false });
+    const stopped = settle(mgr, 'turn-4', { madeProgress: false });
+
+    assert.equal(stopped.kind, 'applied');
+    assert.equal(stopped.goal.status, 'stalled');
+    assert.equal(stopped.goal.consecutiveNoProgress, 2);
+  });
+
+  test('token observations remain monotonic after the initial baseline', () => {
+    const { mgr } = createManager();
+    createGoal(mgr, 'x');
+    settle(mgr, 'turn-1', { tokensNow: 1000 });
+    settle(mgr, 'turn-2', { tokensNow: 1800 });
+    settle(mgr, 'turn-3', { tokensNow: 1200 });
+
+    assert.equal(mgr.get(SESSION)?.tokensNow, 1800);
+    assert.equal(mgr.tokensSpent(SESSION), 800);
+  });
+});
+
+describe('GoalManager stale and duplicate rejection', () => {
+  test('rejects an evaluator checkpoint invalidated by pause and resume', () => {
+    const { mgr, events } = createManager();
+    const goal = createGoal(mgr);
+    const checkpoint = goalCheckpoint(goal);
+    mgr.pause(SESSION);
+    const resumed = mgr.resume(SESSION);
+    const eventCount = events.length;
+
+    const result = mgr.settleTurn(SESSION, {
+      checkpoint,
+      turnId: 'turn-old',
+      verdict: 'achieved',
+      reason: 'stale verdict',
+    });
+
+    assert.equal(result.kind, 'stale');
+    assert.strictEqual(mgr.get(SESSION), resumed);
+    assert.equal(events.length, eventCount);
+  });
+
+  test('rejects an evaluator checkpoint after clear and replacement (ABA)', () => {
+    const { mgr } = createManager();
+    const first = createGoal(mgr, 'first');
+    const checkpoint = goalCheckpoint(first);
+    mgr.clear(SESSION);
+    const replacement = mgr.create(SESSION, 'replacement');
+    assert.equal(replacement.kind, 'created');
+
+    const result = mgr.settleTurn(SESSION, {
+      checkpoint,
+      turnId: 'turn-old',
+      verdict: 'impossible',
+      reason: 'stale verdict',
+    });
+
+    assert.equal(result.kind, 'stale');
+    assert.equal(mgr.get(SESSION)?.condition, 'replacement');
+    assert.equal(mgr.get(SESSION)?.status, 'active');
+  });
+
+  test('rejects sequential replay of any already-settled turn', () => {
+    const { mgr } = createManager();
+    const first = createGoal(mgr);
+    const turnOne = mgr.settleTurn(SESSION, {
+      checkpoint: goalCheckpoint(first),
+      turnId: 'turn-1',
+      verdict: 'continue',
+      reason: 'continue',
+      madeProgress: true,
+    });
+    assert.equal(turnOne.kind, 'applied');
+    const turnTwo = settle(mgr, 'turn-2');
+    assert.equal(turnTwo.kind, 'applied');
+
+    const replay = mgr.settleTurn(SESSION, {
+      checkpoint: goalCheckpoint(turnTwo.goal),
+      turnId: 'turn-1',
+      verdict: 'achieved',
+      reason: 'must not apply',
+    });
+
+    assert.equal(replay.kind, 'duplicate');
+    assert.equal(mgr.get(SESSION)?.iterations, 2);
+    assert.equal(mgr.get(SESSION)?.status, 'active');
+  });
+
+  test('retains turn idempotency when a terminal Goal is replaced', () => {
+    const { mgr } = createManager();
+    createGoal(mgr, 'first', { maxIterations: 1 });
+    const terminal = settle(mgr, 'turn-shared');
+    assert.equal(terminal.kind, 'applied');
+    assert.equal(terminal.goal.status, 'max_iterations');
+
+    const replacement = mgr.create(SESSION, 'replacement');
+    assert.equal(replacement.kind, 'created');
+    const replay = mgr.settleTurn(SESSION, {
+      checkpoint: goalCheckpoint(replacement.goal),
+      turnId: 'turn-shared',
+      verdict: 'continue',
+      reason: 'must not apply',
+      madeProgress: true,
+    });
+
+    assert.equal(replay.kind, 'duplicate');
+    assert.strictEqual(replay.goal, replacement.goal);
+    assert.equal(replacement.goal.revision, 0);
+    assert.equal(replacement.goal.iterations, 0);
+  });
+});
+
+describe('GoalManager ownership cleanup', () => {
+  test('sessions are independent and remove/dispose release their records', () => {
+    const { mgr } = createManager();
+    assert.equal(mgr.create('a', 'goal A').kind, 'created');
+    assert.equal(mgr.create('b', 'goal B').kind, 'created');
+    assert.equal(mgr.remove('a'), true);
+    assert.equal(mgr.get('a'), undefined);
+    assert.equal(mgr.get('b')?.condition, 'goal B');
+    mgr.dispose();
+    assert.equal(mgr.get('b'), undefined);
   });
 });

--- a/packages/runtime/src/__tests__/goal-tools.test.ts
+++ b/packages/runtime/src/__tests__/goal-tools.test.ts
@@ -1,6 +1,6 @@
 import { describe, test } from 'node:test';
 import assert from 'node:assert/strict';
-import { GoalManager } from '../goal-state.js';
+import { GoalManager, goalCheckpoint } from '../goal-state.js';
 import {
   buildGoalTools,
   GOAL_SET_TOOL_NAME,
@@ -65,6 +65,18 @@ describe('goal tools', () => {
     assert.equal(mgr.get(SESSION)?.tokensAtStart, 1234);
   });
 
+  test('GoalSet reports an unfinished Goal instead of replacing it', async () => {
+    const { mgr, tools } = makeTools();
+    const set = findTool(tools, GOAL_SET_TOOL_NAME);
+    await set.impl({ condition: 'first' }, ctx());
+    const first = mgr.get(SESSION);
+
+    const out = await set.impl({ condition: 'replacement' }, ctx()) as string;
+
+    assert.match(out, /unfinished goal/);
+    assert.strictEqual(mgr.get(SESSION), first);
+  });
+
   test('GoalPause / GoalResume lifecycle', async () => {
     const { mgr, tools } = makeTools();
     await findTool(tools, GOAL_SET_TOOL_NAME).impl({ condition: 'x' }, ctx());
@@ -102,8 +114,24 @@ describe('goal tools', () => {
   test('GoalStatus shows full lifecycle detail', async () => {
     const { mgr, tools } = makeTools();
     await findTool(tools, GOAL_SET_TOOL_NAME).impl({ condition: 'deploy', token_budget: 5000 }, ctx());
-    mgr.recordTokens(SESSION, 1000); // establishes baseline at 1000
-    mgr.recordTokens(SESSION, 2500); // spent 1500 since baseline
+    const first = mgr.getActive(SESSION)!;
+    mgr.settleTurn(SESSION, {
+      checkpoint: goalCheckpoint(first),
+      turnId: 'turn-1',
+      verdict: 'continue',
+      reason: 'continue',
+      madeProgress: true,
+      tokensNow: 1000,
+    });
+    const second = mgr.getActive(SESSION)!;
+    mgr.settleTurn(SESSION, {
+      checkpoint: goalCheckpoint(second),
+      turnId: 'turn-2',
+      verdict: 'continue',
+      reason: 'continue',
+      madeProgress: true,
+      tokensNow: 2500,
+    });
     const out = await findTool(tools, GOAL_STATUS_TOOL_NAME).impl({}, ctx()) as string;
     assert.ok(out.includes('deploy'));
     assert.ok(out.includes('Status: active'));

--- a/packages/runtime/src/goal-continuation.ts
+++ b/packages/runtime/src/goal-continuation.ts
@@ -19,12 +19,18 @@
  */
 
 import { evaluateGoal, type GoalEvaluation, type GoalEvaluatorDeps } from './goal-evaluator.js';
-import type { GoalManager } from './goal-state.js';
+import {
+  goalCheckpoint,
+  type GoalManager,
+  type GoalTurnSettlementResult,
+} from './goal-state.js';
 
 export type GoalContinuationOutcome =
   | { kind: 'no_goal' }
   | { kind: 'cannot_continue' }
   | { kind: 'busy' }
+  | { kind: 'duplicate' }
+  | { kind: 'stale' }
   | { kind: 'achieved'; evaluation: GoalEvaluation }
   | { kind: 'impossible'; evaluation: GoalEvaluation }
   | { kind: 'stopped'; reason: string; status: string }
@@ -39,7 +45,7 @@ export type GoalTaskGateDecision =
 
 export interface GoalTaskGateTrace {
   sessionId: string;
-  turnId?: string;
+  turnId: string;
   goalId: string;
   decision: GoalTaskGateDecision;
   taskKeys: string[];
@@ -86,51 +92,65 @@ const taskGateReminderState = new WeakMap<GoalTaskGateDeps, Set<string>>();
 export async function handleGoalContinuation(
   deps: GoalContinuationDeps,
   sessionId: string,
-  completedTurnId?: string,
+  completedTurnId: string,
 ): Promise<GoalContinuationOutcome> {
   const goal = deps.goalManager.getActive(sessionId);
   if (!goal) return { kind: 'no_goal' };
+  if (deps.goalManager.hasSettledTurn(sessionId, completedTurnId)) {
+    return { kind: 'duplicate' };
+  }
+  const checkpoint = goalCheckpoint(goal);
 
   // Re-entrancy guard: only one continuation in flight per session.
   if (deps.inFlight?.has(sessionId)) return { kind: 'busy' };
   deps.inFlight?.add(sessionId);
   try {
     if (!(await deps.canContinue(sessionId))) return { kind: 'cannot_continue' };
+    if (!deps.goalManager.matchesActive(sessionId, checkpoint)) return { kind: 'stale' };
 
     // Evaluate FIRST — a genuine completion on the final permitted turn must be
     // detected before any cap short-circuits the loop.
     const context = await deps.getRecentContext(sessionId);
+    if (!deps.goalManager.matchesActive(sessionId, checkpoint)) return { kind: 'stale' };
     const evaluation = await evaluateGoal(deps.evaluator, goal.condition, context, sessionId);
-
-    if (evaluation.met) {
-      await recordTaskGateDecision(deps.taskGate, {
-        sessionId, turnId: completedTurnId, goalId: goal.id, decision: 'evaluator_terminal', taskKeys: [],
+    const settlementBase = {
+      checkpoint,
+      turnId: completedTurnId,
+      reason: evaluation.reason,
+    };
+    let settlement: GoalTurnSettlementResult;
+    if (evaluation.met || evaluation.impossible) {
+      settlement = deps.goalManager.settleTurn(sessionId, {
+        ...settlementBase,
+        verdict: evaluation.met ? 'achieved' : 'impossible',
       });
-      deps.goalManager.markAchieved(sessionId, evaluation.reason);
-      return { kind: 'achieved', evaluation };
-    }
-    if (evaluation.impossible) {
-      await recordTaskGateDecision(deps.taskGate, {
-        sessionId, turnId: completedTurnId, goalId: goal.id, decision: 'evaluator_terminal', taskKeys: [],
+    } else {
+      settlement = deps.goalManager.settleTurn(sessionId, {
+        ...settlementBase,
+        verdict: 'continue',
+        ...(!evaluation.evaluatorFailed && !evaluation.waiting
+          ? { madeProgress: evaluation.progress }
+          : {}),
+        ...(deps.getTokenCount ? { tokensNow: deps.getTokenCount(sessionId) } : {}),
       });
-      deps.goalManager.markImpossible(sessionId, evaluation.reason);
-      return { kind: 'impossible', evaluation };
     }
+    if (settlement.kind === 'duplicate') return { kind: 'duplicate' };
+    if (settlement.kind !== 'applied') return { kind: 'stale' };
 
-    // Enforce caps AFTER evaluation. Each may flip the goal terminal.
-    if (deps.getTokenCount) {
-      deps.goalManager.recordTokens(sessionId, deps.getTokenCount(sessionId));
+    const settled = settlement.goal;
+    if (settled.status === 'achieved' || settled.status === 'impossible') {
+      await recordTaskGateDecision(deps.taskGate, {
+        sessionId,
+        turnId: completedTurnId,
+        goalId: goal.id,
+        decision: 'evaluator_terminal',
+        taskKeys: [],
+      });
+      return settled.status === 'achieved'
+        ? { kind: 'achieved', evaluation }
+        : { kind: 'impossible', evaluation };
     }
-    deps.goalManager.incrementIteration(sessionId);
-    // Progress signal drives the stall cap. Skip it (neutral) when the evaluator
-    // failed (transient outage must not defeat stall detection) OR when the
-    // agent is legitimately waiting on an external event (a wait is not a stall).
-    if (!evaluation.evaluatorFailed && !evaluation.waiting) {
-      deps.goalManager.recordProgress(sessionId, evaluation.progress);
-    }
-
-    const settled = deps.goalManager.get(sessionId);
-    if (!settled || settled.status !== 'active') {
+    if (settled.status !== 'active') {
       const taskKeys = await listActionableTaskKeys(deps.taskGate, sessionId);
       await recordTaskGateDecision(deps.taskGate, {
         sessionId,
@@ -139,9 +159,10 @@ export async function handleGoalContinuation(
         decision: 'goal_stopped',
         taskKeys,
       });
-      return { kind: 'stopped', reason: settled?.lastReason ?? 'Goal settled', status: settled?.status ?? 'unknown' };
+      return { kind: 'stopped', reason: settled.lastReason ?? 'Goal settled', status: settled.status };
     }
 
+    const settledCheckpoint = goalCheckpoint(settled);
     const taskKeys = await listActionableTaskKeys(deps.taskGate, sessionId);
     const remindedGoalIds = deps.taskGate
       ? deps.taskGate.remindedGoalIds ?? reminderStateFor(deps.taskGate)
@@ -154,9 +175,10 @@ export async function handleGoalContinuation(
         : 'reminder_limit_reached';
     // Re-check idle immediately before injecting — the evaluator call may have
     // spanned seconds during which a user send started a new turn.
+    if (!deps.goalManager.matchesActive(sessionId, settledCheckpoint)) return { kind: 'stale' };
     if (!(await deps.canContinue(sessionId))) return { kind: 'cannot_continue' };
+    if (!deps.goalManager.matchesActive(sessionId, settledCheckpoint)) return { kind: 'stale' };
 
-    settled.lastReason = evaluation.reason;
     const waitNote = evaluation.waiting ? ' (waiting on an external event — re-check, do not spin uselessly)' : '';
     if (shouldRemind) remindedGoalIds.add(goal.id);
     deps.injectTurn(

--- a/packages/runtime/src/goal-state.ts
+++ b/packages/runtime/src/goal-state.ts
@@ -39,44 +39,84 @@ export const TERMINAL_GOAL_STATUSES: ReadonlySet<GoalStatus> = new Set<GoalStatu
 ]);
 
 export interface GoalState {
-  id: string;
-  sessionId: string;
-  condition: string;
-  status: GoalStatus;
-  setAt: number;
-  iterations: number;
-  maxIterations: number;
+  readonly id: string;
+  readonly revision: number;
+  readonly sessionId: string;
+  readonly condition: string;
+  readonly status: GoalStatus;
+  readonly setAt: number;
+  readonly iterations: number;
+  readonly maxIterations: number;
   /** Consecutive turns with no progress (drives the block cap → stalled). */
-  consecutiveNoProgress: number;
+  readonly consecutiveNoProgress: number;
   /** Force-stop after this many consecutive no-progress turns (CC's 8). */
-  blockCap: number;
+  readonly blockCap: number;
   /** Optional token budget; goal → budget_limited when exceeded. */
-  tokenBudget?: number;
+  readonly tokenBudget?: number;
   /** Token count observed when the goal was set (baseline for spend). */
-  tokensAtStart: number;
+  readonly tokensAtStart: number;
   /** Latest observed token count (used to compute spend). */
-  tokensNow: number;
+  readonly tokensNow: number;
   /**
    * True until the first real token observation. The baseline captured at set
    * time can be stale/0 (the model calls GoalSet before any continuation has
-   * observed the session's token count), so the first recordTokens re-baselines
+   * observed the session's token count), so the first settlement re-baselines
    * to measure only tokens the goal itself spends.
    */
-  tokensBaselinePending: boolean;
-  lastReason?: string;
-  achievedAt?: number;
-  pausedAt?: number;
+  readonly tokensBaselinePending: boolean;
+  readonly lastReason?: string;
+  readonly achievedAt?: number;
+  readonly pausedAt?: number;
 }
+
+/** Immutable identity of the Goal snapshot an asynchronous operation observed. */
+export interface GoalCheckpoint {
+  readonly goalId: string;
+  readonly revision: number;
+}
+
+export function goalCheckpoint(goal: Pick<GoalState, 'id' | 'revision'>): GoalCheckpoint {
+  return Object.freeze({ goalId: goal.id, revision: goal.revision });
+}
+
+export type GoalCreateResult =
+  | { kind: 'created'; goal: GoalState }
+  | { kind: 'unfinished'; goal: GoalState };
+
+interface GoalTurnSettlementBase {
+  readonly checkpoint: GoalCheckpoint;
+  readonly turnId: string;
+  readonly reason: string;
+}
+
+export type GoalTurnSettlementInput =
+  | (GoalTurnSettlementBase & {
+      readonly verdict: 'achieved';
+    })
+  | (GoalTurnSettlementBase & {
+      readonly verdict: 'impossible';
+    })
+  | (GoalTurnSettlementBase & {
+      readonly verdict: 'continue';
+      /** Undefined is neutral: neither advances nor resets the no-progress streak. */
+      readonly madeProgress?: boolean;
+      readonly tokensNow?: number;
+    });
+
+export type GoalTurnSettlementResult =
+  | { kind: 'applied'; goal: GoalState }
+  | { kind: 'duplicate'; goal: GoalState }
+  | { kind: 'stale'; goal: GoalState }
+  | { kind: 'inactive'; goal: GoalState }
+  | { kind: 'not_found' };
 
 export interface GoalManagerDeps {
   generateId: () => string;
   now: () => number;
   /**
-   * Fired after every goal state transition (set / continue / pause / resume /
-   * terminal / clear / remove). Lets a host surface an autonomous loop to the
-   * UI — a token-burning goal must never run without a visible indicator and a
-   * clear affordance. `previous` is the status before the change (undefined on
-   * first set) so a host can detect entering/leaving the active state.
+   * Fired after every accepted goal state transition. Lets a host surface an
+   * autonomous loop to the UI — a token-burning goal must never run without a
+   * visible indicator and a clear affordance.
    */
   onChange?: (goal: GoalState, previous?: GoalStatus) => void;
 }
@@ -84,8 +124,19 @@ export interface GoalManagerDeps {
 export const DEFAULT_MAX_ITERATIONS = 50;
 export const DEFAULT_BLOCK_CAP = 8;
 
+interface GoalRecord {
+  state: GoalState;
+  /** Turn identity belongs to the session lifetime, not an individual Goal. */
+  readonly settledTurnIds: Set<string>;
+}
+
+type GoalStatePatch = Partial<Omit<
+  GoalState,
+  'id' | 'revision' | 'sessionId' | 'condition' | 'setAt'
+>>;
+
 export class GoalManager {
-  private goals = new Map<string, GoalState>();
+  private goals = new Map<string, GoalRecord>();
 
   constructor(private readonly deps: GoalManagerDeps) {}
 
@@ -93,20 +144,34 @@ export class GoalManager {
     this.deps.onChange?.(goal, previous);
   }
 
-  set(sessionId: string, condition: string, opts?: {
+  private commit(record: GoalRecord, patch: GoalStatePatch): GoalState {
+    const previous = record.state.status;
+    const committed = Object.freeze({
+      ...record.state,
+      ...patch,
+      revision: record.state.revision + 1,
+    });
+    record.state = committed;
+    this.emit(committed, previous);
+    return committed;
+  }
+
+  create(sessionId: string, condition: string, opts?: {
     maxIterations?: number;
     blockCap?: number;
     tokenBudget?: number;
     tokensAtStart?: number;
-  }): GoalState {
-    // Replacing an existing goal: settle the old one before overwriting.
-    const existing = this.goals.get(sessionId);
+  }): GoalCreateResult {
+    const record = this.goals.get(sessionId);
+    const existing = record?.state;
     if (existing && !TERMINAL_GOAL_STATUSES.has(existing.status)) {
-      existing.status = 'cleared';
+      return { kind: 'unfinished', goal: existing };
     }
+
     const start = opts?.tokensAtStart ?? 0;
-    const goal: GoalState = {
+    const goal: GoalState = Object.freeze({
       id: this.deps.generateId(),
+      revision: 0,
       sessionId,
       condition,
       status: 'active',
@@ -119,139 +184,143 @@ export class GoalManager {
       tokensAtStart: start,
       tokensNow: start,
       tokensBaselinePending: true,
-    };
-    this.goals.set(sessionId, goal);
+    });
+    if (record) {
+      record.state = goal;
+    } else {
+      this.goals.set(sessionId, { state: goal, settledTurnIds: new Set() });
+    }
     this.emit(goal);
-    return goal;
+    return { kind: 'created', goal };
   }
 
   get(sessionId: string): GoalState | undefined {
-    return this.goals.get(sessionId);
+    return this.goals.get(sessionId)?.state;
   }
 
   getActive(sessionId: string): GoalState | undefined {
-    const goal = this.goals.get(sessionId);
+    const goal = this.goals.get(sessionId)?.state;
     return goal?.status === 'active' ? goal : undefined;
   }
 
+  matchesActive(sessionId: string, checkpoint: GoalCheckpoint): boolean {
+    const goal = this.goals.get(sessionId)?.state;
+    return goal?.status === 'active'
+      && goal.id === checkpoint.goalId
+      && goal.revision === checkpoint.revision;
+  }
+
+  hasSettledTurn(sessionId: string, turnId: string): boolean {
+    return this.goals.get(sessionId)?.settledTurnIds.has(turnId) ?? false;
+  }
+
   tokensSpent(sessionId: string): number {
-    const goal = this.goals.get(sessionId);
+    const goal = this.goals.get(sessionId)?.state;
     if (!goal) return 0;
     return Math.max(0, goal.tokensNow - goal.tokensAtStart);
   }
 
-  incrementIteration(sessionId: string): GoalState | undefined {
-    const goal = this.goals.get(sessionId);
-    if (!goal || goal.status !== 'active') return undefined;
-    const previous = goal.status;
-    goal.iterations++;
-    if (goal.iterations >= goal.maxIterations) {
-      goal.status = 'max_iterations';
-      goal.lastReason = `Reached maximum iterations (${goal.maxIterations})`;
-    }
-    this.emit(goal, previous);
-    return goal;
-  }
+  settleTurn(sessionId: string, input: GoalTurnSettlementInput): GoalTurnSettlementResult {
+    const record = this.goals.get(sessionId);
+    if (!record) return { kind: 'not_found' };
+    const current = record.state;
+    if (record.settledTurnIds.has(input.turnId)) return { kind: 'duplicate', goal: current };
+    if (current.id !== input.checkpoint.goalId) return { kind: 'stale', goal: current };
+    if (current.revision !== input.checkpoint.revision) return { kind: 'stale', goal: current };
+    if (current.status !== 'active') return { kind: 'inactive', goal: current };
 
-  recordProgress(sessionId: string, madeProgress: boolean): GoalState | undefined {
-    const goal = this.goals.get(sessionId);
-    if (!goal || goal.status !== 'active') return undefined;
-    const previous = goal.status;
-    if (madeProgress) {
-      goal.consecutiveNoProgress = 0;
+    let patch: GoalStatePatch;
+    if (input.verdict === 'achieved') {
+      patch = {
+        status: 'achieved',
+        lastReason: input.reason,
+        achievedAt: this.deps.now(),
+      };
+    } else if (input.verdict === 'impossible') {
+      patch = { status: 'impossible', lastReason: input.reason };
     } else {
-      goal.consecutiveNoProgress++;
-      if (goal.consecutiveNoProgress >= goal.blockCap) {
-        goal.status = 'stalled';
-        goal.lastReason = `No progress for ${goal.blockCap} consecutive turns`;
+      let tokensAtStart = current.tokensAtStart;
+      let tokensNow = current.tokensNow;
+      let tokensBaselinePending = current.tokensBaselinePending;
+      let iterations = current.iterations;
+      let consecutiveNoProgress = current.consecutiveNoProgress;
+      let status: GoalStatus = current.status;
+      let lastReason = input.reason;
+
+      if (input.tokensNow !== undefined) {
+        if (tokensBaselinePending) {
+          tokensAtStart = input.tokensNow;
+          tokensNow = input.tokensNow;
+          tokensBaselinePending = false;
+        } else {
+          tokensNow = Math.max(tokensNow, input.tokensNow);
+          if (
+            current.tokenBudget !== undefined
+            && tokensNow - tokensAtStart >= current.tokenBudget
+          ) {
+            status = 'budget_limited';
+            lastReason = `Token budget exhausted (${current.tokenBudget} tokens)`;
+          }
+        }
       }
-    }
-    this.emit(goal, previous);
-    return goal;
-  }
 
-  recordTokens(sessionId: string, tokensNow: number): GoalState | undefined {
-    const goal = this.goals.get(sessionId);
-    if (!goal) return undefined;
-    const previous = goal.status;
-    // The first real observation establishes the baseline (see field doc).
-    if (goal.tokensBaselinePending) {
-      goal.tokensAtStart = tokensNow;
-      goal.tokensNow = tokensNow;
-      goal.tokensBaselinePending = false;
-      this.emit(goal, previous);
-      return goal;
-    }
-    // Token counts are monotonic; never let a stale/smaller read regress spend.
-    goal.tokensNow = Math.max(goal.tokensNow, tokensNow);
-    if (
-      goal.status === 'active' &&
-      goal.tokenBudget !== undefined &&
-      goal.tokensNow - goal.tokensAtStart >= goal.tokenBudget
-    ) {
-      goal.status = 'budget_limited';
-      goal.lastReason = `Token budget exhausted (${goal.tokenBudget} tokens)`;
-    }
-    this.emit(goal, previous);
-    return goal;
-  }
+      if (status === 'active') {
+        iterations++;
+        if (iterations >= current.maxIterations) {
+          status = 'max_iterations';
+          lastReason = `Reached maximum iterations (${current.maxIterations})`;
+        }
+      }
 
-  markAchieved(sessionId: string, reason: string): GoalState | undefined {
-    const goal = this.goals.get(sessionId);
-    if (!goal || goal.status !== 'active') return undefined;
-    const previous = goal.status;
-    goal.status = 'achieved';
-    goal.lastReason = reason;
-    goal.achievedAt = this.deps.now();
-    this.emit(goal, previous);
-    return goal;
-  }
+      if (status === 'active' && input.madeProgress !== undefined) {
+        if (input.madeProgress) {
+          consecutiveNoProgress = 0;
+        } else {
+          consecutiveNoProgress++;
+          if (consecutiveNoProgress >= current.blockCap) {
+            status = 'stalled';
+            lastReason = `No progress for ${current.blockCap} consecutive turns`;
+          }
+        }
+      }
 
-  markImpossible(sessionId: string, reason: string): GoalState | undefined {
-    const goal = this.goals.get(sessionId);
-    if (!goal || goal.status !== 'active') return undefined;
-    const previous = goal.status;
-    goal.status = 'impossible';
-    goal.lastReason = reason;
-    this.emit(goal, previous);
-    return goal;
+      patch = {
+        status,
+        iterations,
+        consecutiveNoProgress,
+        tokensAtStart,
+        tokensNow,
+        tokensBaselinePending,
+        lastReason,
+      };
+    }
+
+    record.settledTurnIds.add(input.turnId);
+    return { kind: 'applied', goal: this.commit(record, patch) };
   }
 
   pause(sessionId: string): GoalState | undefined {
-    const goal = this.goals.get(sessionId);
-    if (!goal || goal.status !== 'active') return undefined;
-    const previous = goal.status;
-    goal.status = 'paused';
-    goal.pausedAt = this.deps.now();
-    this.emit(goal, previous);
-    return goal;
+    const record = this.goals.get(sessionId);
+    if (!record || record.state.status !== 'active') return undefined;
+    return this.commit(record, { status: 'paused', pausedAt: this.deps.now() });
   }
 
   resume(sessionId: string): GoalState | undefined {
-    const goal = this.goals.get(sessionId);
-    if (!goal || goal.status !== 'paused') return undefined;
-    const previous = goal.status;
-    goal.status = 'active';
-    goal.pausedAt = undefined;
-    this.emit(goal, previous);
-    return goal;
+    const record = this.goals.get(sessionId);
+    if (!record || record.state.status !== 'paused') return undefined;
+    return this.commit(record, { status: 'active', pausedAt: undefined });
   }
 
   clear(sessionId: string): GoalState | undefined {
-    const goal = this.goals.get(sessionId);
-    if (!goal) return undefined;
-    const previous = goal.status;
-    if (!TERMINAL_GOAL_STATUSES.has(goal.status)) {
-      goal.status = 'cleared';
-    }
-    this.emit(goal, previous);
-    return goal;
+    const record = this.goals.get(sessionId);
+    if (!record || TERMINAL_GOAL_STATUSES.has(record.state.status)) return undefined;
+    return this.commit(record, { status: 'cleared' });
   }
 
   remove(sessionId: string): boolean {
-    const goal = this.goals.get(sessionId);
+    const record = this.goals.get(sessionId);
     const deleted = this.goals.delete(sessionId);
-    if (goal && deleted) this.emit(goal, goal.status);
+    if (record && deleted) this.emit(record.state, record.state.status);
     return deleted;
   }
 

--- a/packages/runtime/src/goal-tools.ts
+++ b/packages/runtime/src/goal-tools.ts
@@ -46,7 +46,7 @@ function buildGoalSetTool(deps: GoalToolsDeps): MakaTool<{
       'Set an autonomous execution goal. After each turn an evaluator judges progress; '
       + 'if the condition is not met the system continues working turn after turn until it is '
       + 'met, deemed impossible, stalls, or hits a limit. Only one goal is active per session; '
-      + 'setting a new one replaces the previous.',
+      + 'an unfinished goal must be cleared or completed before another can be set.',
     parameters: z.object({
       condition: z.string().trim().min(1).max(500)
         .describe('The objective to achieve. Should be observable and verifiable (e.g. "all tests in packages/runtime pass", "PR #522 review comments addressed").'),
@@ -60,12 +60,17 @@ function buildGoalSetTool(deps: GoalToolsDeps): MakaTool<{
     permissionRequired: false,
     impl: (input, ctx) => {
       const tokensAtStart = deps.getTokenCount?.(ctx.sessionId) ?? 0;
-      const goal = deps.goalManager.set(ctx.sessionId, input.condition, {
+      const result = deps.goalManager.create(ctx.sessionId, input.condition, {
         maxIterations: input.max_iterations,
         blockCap: input.block_cap,
         tokenBudget: input.token_budget,
         tokensAtStart,
       });
+      if (result.kind === 'unfinished') {
+        return `Goal not set: unfinished goal "${result.goal.condition}" is ${result.goal.status}. `
+          + 'Clear or complete it before setting another goal.';
+      }
+      const goal = result.goal;
       const limits = [
         `max ${goal.maxIterations} turns`,
         `stall after ${goal.blockCap} no-progress turns`,


### PR DESCRIPTION
<details open>
<summary><strong>English</strong></summary>

## Summary

- Replace mutable Goal state with immutable, revisioned snapshots.
- Settle each completed turn through one synchronous transition that validates the observed Goal identity and revision.
- Deduplicate completed turns across Goal replacement using their stable runtime `turnId`.
- Refuse to overwrite an active or paused Goal, and carry the real terminal turn identity through the TUI continuation path.

## Why

Goal evaluation crosses several asynchronous boundaries. While an evaluator is running, the current Goal may be paused, resumed, cleared, or followed by another Goal. The previous implementation located subsequent mutations only by `sessionId`, so an old evaluator result could update whichever Goal occupied that session when it returned.

A completed turn was also applied through separate token, iteration, progress, and terminal mutations. This allowed partial state transitions and gave repeated completion callbacks no stable idempotency boundary.

## Design

| Decision | Rationale |
| --- | --- |
| Represent Goal state as immutable snapshots with a monotonically increasing `revision`. | Callers cannot mutate shared state directly, and every accepted lifecycle change creates an explicit version boundary. |
| Capture `{ goalId, revision }` before asynchronous evaluation and validate it before settlement and continuation injection. | `goalId` rejects results from an earlier Goal; `revision` also rejects stale results after pause/resume or another transition on the same Goal. |
| Settle a turn through one `settleTurn` operation. | The evaluator result and, for a nonterminal turn, token observation, iteration, progress, limits, and reason are committed together and emit one state change. |
| Retain settled `turnId` values for the lifetime of the session Goal record, including across Goal replacement. | Replaying an old completion callback cannot settle a newer Goal. The set is released with the session record on `remove` or `dispose`; it is deliberately not evicted because eviction would re-enable old replays. |
| Reject `GoalSet` while the current Goal is active or paused. | An unfinished objective cannot be silently cleared and replaced by another model call. |
| Require a real runtime terminal `turnId` in TUI completion and task-gate traces. | Desktop and TUI use the same identity and idempotency contract; missing terminal events are treated as errors rather than inventing an identity. |

The existing evaluator-first behavior is preserved: an achieved or impossible verdict still wins on the final permitted turn. For a nonterminal verdict, limit precedence remains token budget, iteration ceiling, then stall detection.

## Scope

This PR is limited to Goal state-transition integrity.

It does not add persistence or restart recovery, redesign continuation scheduling, change the current immediate handling of `waiting`, alter evaluator evidence or model control authority, or modify Desktop/TUI presentation. Those concerns require separate lifecycle decisions rather than being folded into this state-machine change.

No compatibility layer, dependency, storage migration, or parallel mutation API is introduced.

## Verification

State and continuation coverage includes stale evaluator results across clear/replacement, pause/resume, and session removal; repeated turns on the same and replacement Goals; atomic limit precedence; immutable snapshots; unfinished Goal replacement; and propagation of the real TUI terminal turn ID.

The repository-wide typecheck, test suite, and build pass.

## Review focus

Two invariants are central:

1. An asynchronous result may commit only when both the Goal identity and exact observed revision still match.
2. A runtime turn belongs to the session lifecycle for settlement idempotency; replacing the Goal must not make an already settled turn reusable.

</details>

<details>
<summary><strong>简体中文</strong></summary>

## 摘要

- 将可变 Goal 状态改为带 revision 的不可变快照。
- 通过一次同步转换结算每个已完成 turn，并校验此前观测到的 Goal 身份和 revision。
- 使用稳定的 runtime `turnId` 在 Goal replacement 前后保持去重。
- 禁止覆盖 active 或 paused Goal，并让 TUI continuation 使用真实的终态 turn identity。

## 原因

Goal evaluator 会跨越多个异步边界。Evaluator 运行期间，当前 Goal 可能被暂停、恢复、清除，或在清除后创建新的 Goal。此前后续 mutation 仅通过 `sessionId` 定位，因此旧 evaluator 返回时可能修改当时占据该 session 的另一个 Goal。

一个已完成 turn 的 token、iteration、progress 和终态原先也通过多次独立 mutation 应用。这既可能产生部分状态转换，也无法为重复 completion callback 提供稳定的幂等边界。

## 设计

| 决策 | 理由 |
| --- | --- |
| 将 Goal 状态表示为带单调递增 `revision` 的不可变快照。 | 调用方无法直接修改共享状态，每次被接受的生命周期转换都有明确版本边界。 |
| 在异步 evaluation 前捕获 `{ goalId, revision }`，并在结算和注入 continuation 前重新校验。 | `goalId` 拒绝早期 Goal 的结果；`revision` 还能拒绝同一 Goal 在 pause/resume 或其它转换后的过期结果。 |
| 通过单个 `settleTurn` 操作结算 turn。 | Evaluator 结果以及非终态 turn 的 token observation、iteration、progress、限制和 reason 会一起提交，并只产生一次状态通知。 |
| 在 session Goal record 的整个生命周期内保留已结算 `turnId`，包括 Goal replacement 之后。 | 旧 completion callback 无法结算新的 Goal。该集合会在 `remove` 或 `dispose` 时随 session record 释放；不进行淘汰，因为淘汰会重新允许旧 turn 重放。 |
| 当前 Goal 为 active 或 paused 时拒绝 `GoalSet`。 | 未完成目标不会被另一个模型调用静默清除并覆盖。 |
| TUI completion 和 task-gate trace 必须携带真实 runtime 终态 `turnId`。 | Desktop 与 TUI 遵守相同的身份和幂等契约；缺少终态事件时按错误处理，而不是构造虚假身份。 |

现有 evaluator-first 行为保持不变：即使已经到达最后一个允许的 turn，achieved 或 impossible verdict 仍优先成立。对于非终态 verdict，限制优先级仍为 token budget、iteration ceiling、stall detection。

## 范围

本 PR 仅处理 Goal 状态转换完整性。

它不加入持久化或重启恢复，不重构 continuation scheduling，不改变当前对 `waiting` 的立即处理方式，不调整 evaluator 证据或模型控制权，也不修改 Desktop/TUI 展示。这些问题需要独立的生命周期设计，不应混入本次状态机修改。

本 PR 不增加兼容层、依赖、存储迁移或并行 mutation API。

## 验证

状态机与 continuation 测试覆盖 clear/replacement、pause/resume 和 session removal 期间的过期 evaluator；同一 Goal 与 replacement Goal 上的 turn 重放；原子限制优先级；不可变快照；未完成 Goal replacement；以及真实 TUI 终态 turn ID 的传递。

根级 typecheck、完整测试与 build 均通过。

## 审查重点

本次设计有两个核心不变量：

1. 异步结果只有在 Goal 身份与此前观测的精确 revision 都仍然匹配时才能提交。
2. 对 settlement 幂等性而言，runtime turn 属于 session 生命周期；替换 Goal 不能让已经结算的 turn 重新可用。

</details>
