### PR TITLE
fix(cli): show default thinking status in TUI

### DIFF
--- a/packages/cli/src/__tests__/pi-transcript.test.ts
+++ b/packages/cli/src/__tests__/pi-transcript.test.ts
@@ -10,6 +10,7 @@ import {
   applyMakaSessionEventToTranscript,
   applyShellRunUpdateToTranscript,
   createMakaPiTranscriptState,
+  renderMakaPiStatusLine,
   renderMakaPiTranscript,
   refreshRunningShellRunElapsed,
   replaceTranscriptWithStoredMessages,
@@ -2186,6 +2187,40 @@ describe('transcript entry render memoization', () => {
     const after = renderMakaPiTranscript(state, meta(), 100).map(stripAnsi).join('\n');
     assert.match(after, /BBBB/);
     assert.doesNotMatch(after, /AAAA/);
+  });
+});
+
+describe('Maka Pi TUI status line', () => {
+  test('shows thinking:high when thinkingLevel is set', () => {
+    const line = stripAnsi(renderMakaPiStatusLine({
+      ...meta(),
+      thinkingLevel: 'high',
+      thinkingLevels: ['off', 'low', 'medium', 'high', 'max'],
+    }, 100));
+    assert.match(line, /thinking:high/);
+  });
+
+  test('shows thinking:default when thinkingLevel is unset but levels are available', () => {
+    const line = stripAnsi(renderMakaPiStatusLine({
+      ...meta(),
+      thinkingLevels: ['off', 'low', 'medium', 'high', 'max'],
+    }, 100));
+    assert.match(line, /thinking:default/);
+  });
+
+  test('omits thinking segment when no levels are available', () => {
+    const line = stripAnsi(renderMakaPiStatusLine({
+      ...meta(),
+    }, 100));
+    assert.doesNotMatch(line, /thinking/);
+  });
+
+  test('omits thinking segment when thinkingLevels is empty', () => {
+    const line = stripAnsi(renderMakaPiStatusLine({
+      ...meta(),
+      thinkingLevels: [],
+    }, 100));
+    assert.doesNotMatch(line, /thinking/);
   });
 });
 

--- a/packages/cli/src/__tests__/pi-tui-runner.test.ts
+++ b/packages/cli/src/__tests__/pi-tui-runner.test.ts
@@ -1408,33 +1408,6 @@ describe('Maka Pi TUI runner', () => {
     ]);
   });
 
-  test('shows the default thinking status for Ollama Cloud GLM-5.2', async () => {
-    const terminal = new FakeTerminal();
-    const driver = new SlashCommandDriver();
-    const run = runMakaPiTui({
-      title: 'Maka',
-      driver,
-      cwd: '/repo',
-      model: 'glm-5.2',
-      connectionSlug: 'ollama-cloud',
-      providerType: 'ollama-cloud',
-      permissionMode: 'ask',
-      terminal,
-    });
-
-    await waitFor(() => plainTerminalOutput(terminal.output()).includes(
-      'Maka · ask · glm-5.2 · thinking:default · ollama-cloud · /repo',
-    ));
-
-    exitMaka(terminal);
-    await Promise.race([
-      run,
-      delay(50).then(() => {
-        throw new Error('TUI did not close during test cleanup');
-      }),
-    ]);
-  });
-
   test('handles /thinking off when the current model exposes a real off wire', async () => {
     const terminal = new FakeTerminal();
     const driver = new SlashCommandDriver();

--- a/packages/cli/src/__tests__/pi-tui-runner.test.ts
+++ b/packages/cli/src/__tests__/pi-tui-runner.test.ts
@@ -1408,6 +1408,33 @@ describe('Maka Pi TUI runner', () => {
     ]);
   });
 
+  test('shows the default thinking status for Ollama Cloud GLM-5.2', async () => {
+    const terminal = new FakeTerminal();
+    const driver = new SlashCommandDriver();
+    const run = runMakaPiTui({
+      title: 'Maka',
+      driver,
+      cwd: '/repo',
+      model: 'glm-5.2',
+      connectionSlug: 'ollama-cloud',
+      providerType: 'ollama-cloud',
+      permissionMode: 'ask',
+      terminal,
+    });
+
+    await waitFor(() => plainTerminalOutput(terminal.output()).includes(
+      'Maka · ask · glm-5.2 · thinking:default · ollama-cloud · /repo',
+    ));
+
+    exitMaka(terminal);
+    await Promise.race([
+      run,
+      delay(50).then(() => {
+        throw new Error('TUI did not close during test cleanup');
+      }),
+    ]);
+  });
+
   test('handles /thinking off when the current model exposes a real off wire', async () => {
     const terminal = new FakeTerminal();
     const driver = new SlashCommandDriver();

--- a/packages/cli/src/pi-transcript.ts
+++ b/packages/cli/src/pi-transcript.ts
@@ -920,7 +920,12 @@ export function renderMakaPiStatusLine(metadata: MakaPiTranscriptMetadata, width
   const safeWidth = Math.max(1, width);
   const sep = ansi.dim(' · ');
   const parts: string[] = [ansi.bold(metadata.title), ansi.dim(metadata.permissionMode), ansi.dim(metadata.model)];
-  const thinking = metadata.thinkingLevel ? ansi.dim(`thinking:${metadata.thinkingLevel}`) : '';
+  const thinking =
+    metadata.thinkingLevel
+      ? ansi.dim(`thinking:${metadata.thinkingLevel}`)
+      : metadata.thinkingLevels && metadata.thinkingLevels.length > 0
+        ? ansi.dim('thinking:default')
+        : '';
   if (thinking) parts.push(thinking);
   const usage = metadata.usage;
   if (usage) {


### PR DESCRIPTION
## Summary

Show `thinking:default` in the TUI status line when the current model exposes thinking levels but the user has not selected an explicit override.

This keeps unsupported models unchanged and continues to show explicit values such as `thinking:high`. It fixes Ollama Cloud GLM-5.2 appearing without any thinking status despite supporting configurable reasoning effort.

## Verification

- `npm --workspace maka-agent test`
- 351 tests passed
- Added status-line contract tests for explicit, default, unavailable, and empty thinking levels
- CI: typecheck, test, and e2e passed
