### PR TITLE
feat(cli): resume sessions across workspaces

### DIFF
--- a/packages/cli/src/__tests__/pi-tui-runner.test.ts
+++ b/packages/cli/src/__tests__/pi-tui-runner.test.ts
@@ -15,7 +15,13 @@ import {
   type UserQuestionResponse,
 } from '@maka/core';
 import type { ShellRunUpdate } from '@maka/runtime';
-import type { MakaSessionDriver, MakaSessionRewindResult, MakaSessionSwitchResult, RewindTarget } from '../session-driver.js';
+import type {
+  MakaSessionDriver,
+  MakaSessionRewindResult,
+  MakaSessionSwitchResult,
+  RewindTarget,
+  SessionResumeAvailability,
+} from '../session-driver.js';
 import { runMakaPiTui } from '../pi-tui-runner.js';
 import { BUSY_SPINNER_FRAMES } from '../tui-attention.js';
 import { arrangeAutocompleteAboveEditor } from '../tui-autocomplete-layout.js';
@@ -1985,6 +1991,7 @@ describe('Maka Pi TUI runner', () => {
       fakeSessionSummary('session-current', '/repo', 'Current chat'),
       { ...fakeSessionSummary('session-legacy', '/repo', 'Legacy chat'), cwd: undefined },
     ]);
+    Object.defineProperty(driver, 'getSessionResumeAvailability', { value: undefined });
     const run = runMakaPiTui({
       title: 'Maka', driver, cwd: '/repo', model: 'claude-sonnet-4-5',
       connectionSlug: 'claude-subscription', permissionMode: 'ask', terminal,
@@ -3658,6 +3665,12 @@ class SlashCommandDriver implements MakaSessionDriver {
 
   async listSessions(): Promise<SessionSummary[]> {
     return this.sessions;
+  }
+
+  async getSessionResumeAvailability(session: SessionSummary): Promise<SessionResumeAvailability> {
+    return session.cwd
+      ? { available: true }
+      : { available: false, reason: 'Missing working directory' };
   }
 
   async *sendPrompt(prompt: string): AsyncIterable<SessionEvent> {

--- a/packages/cli/src/__tests__/pi-tui-runner.test.ts
+++ b/packages/cli/src/__tests__/pi-tui-runner.test.ts
@@ -1758,15 +1758,15 @@ describe('Maka Pi TUI runner', () => {
     terminal.input('/session');
     terminal.input('\r');
 
-    await waitFor(() => terminal.output().includes('Resume Session (Current Folder)'));
+    await waitFor(() => plainTerminalOutput(terminal.output()).includes('Resume Session Current'));
     // The picker labels rows by human name, not the raw session id.
     await waitFor(() => terminal.output().includes('Existing chat'));
-    const titleLine = latestPlainLineContaining(terminal.output(), 'Resume Session (Current Folder)');
-    assert.equal(titleLine.startsWith('Resume Session (Current Folder)'), true);
+    const titleLine = latestPlainLineContaining(terminal.output(), 'Resume Session Current');
+    assert.equal(titleLine.startsWith('Resume Session Current'), true);
     assert.equal(visibleWidth(titleLine), terminal.columns);
     assertBottomPickerPlacement(
       terminal,
-      'Resume Session (Current Folder)',
+      'Resume Session Current',
       'Maka · ask · claude-sonnet-4-5 · claude-subscription · /repo',
     );
     terminal.input('\r');
@@ -1878,10 +1878,11 @@ describe('Maka Pi TUI runner', () => {
     await run;
   });
 
-  test('shows only current-cwd sessions in the session picker', async () => {
+  test('shows every connection in Current while hiding other cwd sessions', async () => {
     const terminal = new FakeTerminal();
     const driver = new SlashCommandDriver([
       fakeSessionSummary('session-current', '/repo', 'Current chat'),
+      { ...fakeSessionSummary('session-other-connection', '/repo', 'Other connection chat'), llmConnectionSlug: 'zai' },
       fakeSessionSummary('session-other', '/elsewhere', 'Other chat'),
     ]);
     const run = runMakaPiTui({
@@ -1899,6 +1900,7 @@ describe('Maka Pi TUI runner', () => {
 
     await waitFor(() => terminal.output().includes('Current chat'));
     const output = plainTerminalOutput(terminal.output());
+    assert.equal(output.includes('Other connection chat'), true);
     assert.equal(output.includes('Other chat'), false);
 
     terminal.input('\x1b');
@@ -1909,6 +1911,100 @@ describe('Maka Pi TUI runner', () => {
         throw new Error('TUI did not close during test cleanup');
       }),
     ]);
+  });
+
+  test('toggles the session picker from Current to All with Tab', async () => {
+    const terminal = new FakeTerminal();
+    const driver = new SlashCommandDriver([
+      fakeSessionSummary('session-current', '/repo', 'Current chat'),
+      fakeSessionSummary('session-other', '/elsewhere', 'Other chat'),
+    ]);
+    const run = runMakaPiTui({
+      title: 'Maka',
+      driver,
+      cwd: '/repo',
+      model: 'claude-sonnet-4-5',
+      connectionSlug: 'claude-subscription',
+      permissionMode: 'ask',
+      terminal,
+    });
+
+    terminal.input('/session');
+    terminal.input('\r');
+    await waitFor(() => terminal.output().includes('Current chat'));
+    assert.equal(plainTerminalOutput(terminal.screenOutput()).includes('Other chat'), false);
+
+    terminal.input('\t');
+    await waitFor(() => plainTerminalOutput(terminal.screenOutput()).includes('Other chat'));
+    assert.match(plainTerminalOutput(terminal.screenOutput()), /Resume Session.*All/);
+    assert.match(plainTerminalOutput(terminal.screenOutput()), /Other chat.*elsewhere/);
+
+    terminal.input('\x1b');
+    exitMaka(terminal);
+    await run;
+  });
+
+  test('adopts a resumed cwd and remembers the All scope for the TUI process', async () => {
+    const terminal = new FakeTerminal();
+    const driver = new SlashCommandDriver([
+      fakeSessionSummary('session-current', '/repo', 'Current chat'),
+      fakeSessionSummary('session-other', '/elsewhere', 'Other chat'),
+    ]);
+    const run = runMakaPiTui({
+      title: 'Maka', driver, cwd: '/repo', model: 'claude-sonnet-4-5',
+      connectionSlug: 'claude-subscription', permissionMode: 'ask', terminal,
+    });
+
+    terminal.input('/session');
+    terminal.input('\r');
+    await waitFor(() => terminal.output().includes('Current chat'));
+    terminal.input('\t');
+    await waitFor(() => plainTerminalOutput(terminal.screenOutput()).includes('Other chat'));
+    terminal.input('\x1b[B');
+    terminal.input('\r');
+    await waitFor(() => driver.sessionIds.includes('session-other'));
+    await waitFor(() => plainTerminalOutput(terminal.screenOutput()).includes('/elsewhere'));
+
+    terminal.input('/session');
+    terminal.input('\r');
+    await waitFor(() => plainTerminalOutput(terminal.screenOutput()).includes('Resume Session All'));
+    terminal.input('\t');
+    await waitFor(() => plainTerminalOutput(terminal.screenOutput()).includes('Resume Session Current'));
+    const currentOutput = plainTerminalOutput(terminal.screenOutput());
+    assert.equal(currentOutput.includes('Other chat'), true);
+    assert.equal(currentOutput.includes('Current chat'), false);
+
+    terminal.input('\x1b');
+    exitMaka(terminal);
+    await run;
+  });
+
+  test('shows a session without a cwd in All but prevents resuming it', async () => {
+    const terminal = new FakeTerminal();
+    const driver = new SlashCommandDriver([
+      fakeSessionSummary('session-current', '/repo', 'Current chat'),
+      { ...fakeSessionSummary('session-legacy', '/repo', 'Legacy chat'), cwd: undefined },
+    ]);
+    const run = runMakaPiTui({
+      title: 'Maka', driver, cwd: '/repo', model: 'claude-sonnet-4-5',
+      connectionSlug: 'claude-subscription', permissionMode: 'ask', terminal,
+    });
+
+    terminal.input('/session');
+    terminal.input('\r');
+    await waitFor(() => terminal.output().includes('Current chat'));
+    terminal.input('\t');
+    await waitFor(() => plainTerminalOutput(terminal.screenOutput()).includes('Missing working directory'));
+    terminal.input('\x1b[B');
+    terminal.input('\r');
+    await delay(10);
+
+    assert.deepEqual(driver.sessionIds, []);
+    assert.match(plainTerminalOutput(terminal.screenOutput()), /Legacy chat.*Missing working directory/);
+
+    terminal.input('\x1b');
+    exitMaka(terminal);
+    await run;
   });
 
   test('the session picker scrolls through every session rather than capping', async () => {
@@ -1928,7 +2024,7 @@ describe('Maka Pi TUI runner', () => {
     terminal.input('/session');
     terminal.input('\r');
 
-    await waitFor(() => terminal.output().includes('Resume Session (Current Folder)'));
+    await waitFor(() => plainTerminalOutput(terminal.output()).includes('Resume Session Current'));
     // All 12 are in the list (not sliced to 10): the scroll indicator counts the
     // full total, so the window shows "(1/12)".
     await waitFor(() => plainTerminalOutput(terminal.screenOutput()).includes('/12)'));
@@ -1967,7 +2063,7 @@ describe('Maka Pi TUI runner', () => {
     terminal.input('/session');
     terminal.input('\r');
 
-    await waitFor(() => terminal.output().includes('Resume Session (Current Folder)'));
+    await waitFor(() => plainTerminalOutput(terminal.output()).includes('Resume Session Current'));
     // Same label on both rows, but the short id in the description tells them apart.
     await waitFor(() => plainTerminalOutput(terminal.screenOutput()).includes('aaaa1111'));
     await waitFor(() => plainTerminalOutput(terminal.screenOutput()).includes('bbbb4444'));

--- a/packages/cli/src/__tests__/session-driver.test.ts
+++ b/packages/cli/src/__tests__/session-driver.test.ts
@@ -267,7 +267,7 @@ describe('Maka session driver', () => {
 
       await assert.rejects(
         driver.switchSession('no-cwd'),
-        /Session belongs to a different folder/,
+        /Session has no working directory/,
       );
 
       await collect(driver.sendPrompt('again'));
@@ -282,9 +282,8 @@ describe('Maka session driver', () => {
     const missingCwd = await mkdtemp(join(tmpdir(), 'maka-missing-session-cwd-'));
     await rm(missingCwd, { recursive: true, force: true });
     const runtime = new RecordingRuntime();
-    runtime.sessionSummaries = [
-      sessionSummary({ id: 'deleted-worktree', cwd: missingCwd }),
-    ];
+    const deleted = sessionSummary({ id: 'deleted-worktree', cwd: missingCwd });
+    runtime.sessionSummaries = [deleted];
     const driver = createMakaSessionDriver({
       runtime,
       cwd: '/repo',
@@ -292,6 +291,10 @@ describe('Maka session driver', () => {
       model: 'claude-sonnet-4-5',
     });
 
+    assert.deepEqual(await driver.getSessionResumeAvailability?.(deleted), {
+      available: false,
+      reason: 'Working directory no longer exists',
+    });
     await assert.rejects(
       driver.switchSession('deleted-worktree'),
       new RegExp(`Session cwd no longer exists: ${escapeRegExp(missingCwd)}`),
@@ -299,7 +302,7 @@ describe('Maka session driver', () => {
     assert.equal(driver.getSessionId(), null);
   });
 
-  test('refuses to switch across folders and leaves the active session unchanged', async () => {
+  test('switches across folders and uses the resumed cwd for the next new session', async () => {
     const repo = await mkdtemp(join(tmpdir(), 'maka-active-cwd-'));
     const elsewhere = await mkdtemp(join(tmpdir(), 'maka-other-cwd-'));
     try {
@@ -313,23 +316,20 @@ describe('Maka session driver', () => {
       });
       await collect(driver.sendPrompt('hi'));
 
-      await assert.rejects(
-        driver.switchSession('other-folder'),
-        /Session belongs to a different folder/,
-      );
+      const resumed = await driver.switchSession('other-folder');
+      driver.startNewSession();
+      await collect(driver.sendPrompt('new work here'));
 
-      // The rejected switch must not move the active session: the next prompt
-      // still lands on the original session.
-      await collect(driver.sendPrompt('again'));
+      assert.equal(resumed.summary.cwd, elsewhere);
       assert.equal(runtime.sent[0]?.sessionId, 'session-1');
-      assert.equal(runtime.sent[1]?.sessionId, 'session-1');
+      assert.equal(runtime.created[1]?.cwd, elsewhere);
     } finally {
       await rm(repo, { recursive: true, force: true });
       await rm(elsewhere, { recursive: true, force: true });
     }
   });
 
-  test('refuses to switch across connections and leaves the active session unchanged', async () => {
+  test('adopts the resumed connection and model for the next new session', async () => {
     const repo = await mkdtemp(join(tmpdir(), 'maka-active-cwd-'));
     try {
       const runtime = new RecordingRuntime();
@@ -344,14 +344,12 @@ describe('Maka session driver', () => {
       });
       await collect(driver.sendPrompt('hi'));
 
-      await assert.rejects(
-        driver.switchSession('other-conn'),
-        /Session uses a different connection/,
-      );
+      await driver.switchSession('other-conn');
+      driver.startNewSession();
+      await collect(driver.sendPrompt('new work here'));
 
-      await collect(driver.sendPrompt('again'));
-      assert.equal(runtime.sent[0]?.sessionId, 'session-1');
-      assert.equal(runtime.sent[1]?.sessionId, 'session-1');
+      assert.equal(runtime.created[1]?.llmConnectionSlug, 'other-connection');
+      assert.equal(runtime.created[1]?.model, 'claude-sonnet-4-5');
     } finally {
       await rm(repo, { recursive: true, force: true });
     }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,7 +1,5 @@
 export {
   createMakaSessionDriver,
-  MISSING_SESSION_CWD_REASON,
-  DELETED_SESSION_CWD_REASON,
   type MakaSessionDriver,
   type MakaSessionDriverInput,
   type MakaSessionRuntime,

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,8 +1,11 @@
 export {
   createMakaSessionDriver,
+  MISSING_SESSION_CWD_REASON,
+  DELETED_SESSION_CWD_REASON,
   type MakaSessionDriver,
   type MakaSessionDriverInput,
   type MakaSessionRuntime,
+  type SessionResumeAvailability,
 } from './session-driver.js';
 export {
   parseMakaCliArgs,

--- a/packages/cli/src/pi-tui-pickers.ts
+++ b/packages/cli/src/pi-tui-pickers.ts
@@ -92,7 +92,12 @@ function slashCommandPrefix(lines: string[], cursorLine: number, cursorCol: numb
 export class PickerOverlay implements Component {
   constructor(
     private readonly list: SelectList,
-    private readonly input: { title: string; rightLabel: string; hint?: string },
+    private readonly input: {
+      title: string;
+      rightLabel: string;
+      hint?: string;
+      onInput?: (data: string) => boolean;
+    },
   ) {}
 
   invalidate(): void {
@@ -100,6 +105,7 @@ export class PickerOverlay implements Component {
   }
 
   handleInput(data: string): void {
+    if (this.input.onInput?.(data)) return;
     this.list.handleInput(data);
   }
 

--- a/packages/cli/src/pi-tui-runner.ts
+++ b/packages/cli/src/pi-tui-runner.ts
@@ -1,3 +1,4 @@
+import { basename } from 'node:path';
 import {
   Editor,
   Key,
@@ -22,7 +23,11 @@ import {
   type ShellRunUpdate,
 } from '@maka/core';
 import type { ModelChoice } from './connection-target.js';
-import type { MakaSessionDriver, MakaSessionSwitchResult } from './session-driver.js';
+import {
+  MISSING_SESSION_CWD_REASON,
+  type MakaSessionDriver,
+  type MakaSessionSwitchResult,
+} from './session-driver.js';
 import {
   createMakaPiTranscriptState,
   activePermissionRequest,
@@ -113,6 +118,7 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
   let thinkingLevels: readonly ThinkingLevel[] = providerType
     ? thinkingVariantsForModel(providerType, input.model)
     : [];
+  let sessionListScope: 'current' | 'all' = 'current';
   let busy = false;
   let closed = false;
   let permissionResponseInFlightRequestId: string | null = null;
@@ -153,6 +159,7 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
   // Show the whole slash-command set at once — discoverability is the point of
   // the menu. Keep a little headroom above the current command count.
   const editor = new Editor(tui, editorTheme(), { paddingX: 1, autocompleteMaxVisible: EDITOR_AUTOCOMPLETE_MAX_VISIBLE });
+  let refreshEditorCwd: ((cwd: string) => void) | undefined;
   const editorSurface = new MakaAutocompleteAboveEditorComponent(editor);
   const layout = new MakaPiLayoutComponent(transcript, editorSurface, statusLine, terminal);
   const attention = new AttentionController(terminal, {
@@ -507,11 +514,17 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
   // `messages`. Shared by switchSession and rewindToTurn so both land the same
   // runner state (model/connection/thinking/transcript/scroll).
   const applySwitchResult = async ({ summary, messages }: MakaSessionSwitchResult): Promise<void> => {
+    cwd = summary.cwd ?? cwd;
     model = summary.model;
+    const previousConnectionSlug = connectionSlug;
     connectionSlug = summary.llmConnectionSlug;
+    providerType = input.modelChoices?.find((choice) => (
+      choice.connectionSlug === summary.llmConnectionSlug
+    ))?.providerType ?? (previousConnectionSlug === summary.llmConnectionSlug ? providerType : undefined);
     permissionMode = summary.permissionMode;
     thinkingLevel = summary.thinkingLevel;
     thinkingLevels = providerType ? thinkingVariantsForModel(providerType, summary.model) : [];
+    refreshEditorCwd?.(cwd);
     replaceTranscriptWithStoredMessages(state, messages);
     resetShellRunSessionState();
     if (input.listShellRunUpdates) {
@@ -524,9 +537,9 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
     shellRunElapsedTicker.sync();
   };
 
-  // Folder/connection safety is enforced inside driver.switchSession(),
-  // before it commits any internal state, so a rejected switch leaves the
-  // active session untouched and the next prompt still lands on the old one.
+  // The driver validates the durable cwd before adopting the resumed session.
+  // A failure leaves the active session untouched and the next prompt still
+  // lands on the old one.
   const switchSession = async (sessionId: string) => {
     const result = await input.driver.switchSession(sessionId);
     await applySwitchResult(result);
@@ -704,43 +717,53 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
 
   const showSessionList = async () => {
     const sessions = await input.driver.listSessions();
-    const currentSessions = sessions.filter(
-      (session) => session.cwd === cwd && session.llmConnectionSlug === connectionSlug,
-    );
-    if (currentSessions.length === 0) {
-      state.entries.push({
-        kind: 'notice',
-        level: 'info',
-        text: 'No sessions found for this folder.',
+    const availability = new Map(await Promise.all(sessions.map(async (session) => {
+      if (!session.cwd) return [session.id, { available: false, reason: MISSING_SESSION_CWD_REASON }] as const;
+      return [
+        session.id,
+        await input.driver.getSessionResumeAvailability?.(session) ?? { available: true },
+      ] as const;
+    })));
+    const renderScope = (): void => {
+      const visibleSessions = sessionListScope === 'current'
+        ? sessions.filter((session) => session.cwd === cwd)
+        : sessions;
+      const items: SelectItem[] = visibleSessions.map((session) => {
+        const state = availability.get(session.id);
+        const location = sessionListScope === 'all' && session.cwd ? ` ${basename(session.cwd)}` : '';
+        return {
+          value: session.id,
+          label: session.name || session.id,
+          description: state?.available === false
+            ? `${shortSessionId(session.id)} ${state.reason}`
+            : `${shortSessionId(session.id)}${location} ${session.llmConnectionSlug} ${session.model}`,
+        };
       });
-      requestRender();
-      return;
-    }
-
-    // Recency-sorted. Label each row by its human name (the id is the selection
-    // value, not something the user should have to read) and disambiguate
-    // same-named sessions with a short id in the description. The list scrolls,
-    // so every session stays reachable — nothing is capped or hidden.
-    const items: SelectItem[] = currentSessions.map((session) => ({
-      value: session.id,
-      label: session.name || session.id,
-      description: `${shortSessionId(session.id)} ${session.model}`,
-    }));
-    // Reserve enough columns for the description (short id + model) so long
-    // CJK names truncate instead of swallowing the disambiguation text.
-    // pi-tui's renderItem deducts 2 prefix + 2 gap + 2 safety = 6 columns
-    // beyond the primary column width, so reserve 30 to leave ~24 for the
-    // description (enough for "aaaa1111 claude-sonnet-4-5").
-    const maxNameWidth = Math.max(20, terminal.columns - 30);
-    showSelectPicker(
-      'Resume Session (Current Folder)',
-      'Current Folder',
-      items,
-      (item) => {
+      const list = new SelectList(items, 10, selectListTheme(), {
+        minPrimaryColumnWidth: 20,
+        maxPrimaryColumnWidth: Math.max(20, terminal.columns - 30),
+      });
+      let overlay: OverlayHandle | undefined;
+      list.onSelect = (item) => {
+        if (availability.get(item.value)?.available === false) return;
+        overlay?.hide();
         void runControl(() => switchSession(item.value));
-      },
-      { minPrimaryColumnWidth: 20, maxPrimaryColumnWidth: maxNameWidth },
-    );
+      };
+      list.onCancel = () => overlay?.hide();
+      overlay = showBottomPicker(new PickerOverlay(list, {
+        title: 'Resume Session',
+        rightLabel: sessionListScope === 'current' ? 'Current' : 'All',
+        hint: 'Tab scope · ↑↓ move · Enter select · Esc close',
+        onInput: (data) => {
+          if (!matchesKey(data, Key.tab) || isKeyRelease(data) || isKeyRepeat(data)) return false;
+          sessionListScope = sessionListScope === 'current' ? 'all' : 'current';
+          overlay?.hide();
+          renderScope();
+          return true;
+        },
+      }));
+    };
+    renderScope();
   };
 
   const showRewindPicker = async () => {
@@ -1071,7 +1094,10 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
     return true;
   };
 
-  editor.setAutocompleteProvider(new MakaAutocompleteProvider(input.cwd, slashCommands));
+  refreshEditorCwd = (nextCwd) => {
+    editor.setAutocompleteProvider(new MakaAutocompleteProvider(nextCwd, slashCommands));
+  };
+  refreshEditorCwd(cwd);
 
   tui.addInputListener((data) => {
     // Once closing has begun, swallow any buffered input that reaches the

--- a/packages/cli/src/pi-tui-runner.ts
+++ b/packages/cli/src/pi-tui-runner.ts
@@ -24,7 +24,7 @@ import {
 } from '@maka/core';
 import type { ModelChoice } from './connection-target.js';
 import {
-  MISSING_SESSION_CWD_REASON,
+  inspectSessionResumeAvailability,
   type MakaSessionDriver,
   type MakaSessionSwitchResult,
 } from './session-driver.js';
@@ -718,10 +718,10 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
   const showSessionList = async () => {
     const sessions = await input.driver.listSessions();
     const availability = new Map(await Promise.all(sessions.map(async (session) => {
-      if (!session.cwd) return [session.id, { available: false, reason: MISSING_SESSION_CWD_REASON }] as const;
       return [
         session.id,
-        await input.driver.getSessionResumeAvailability?.(session) ?? { available: true },
+        await input.driver.getSessionResumeAvailability?.(session)
+          ?? await inspectSessionResumeAvailability(session),
       ] as const;
     })));
     const renderScope = (): void => {

--- a/packages/cli/src/runtime-bootstrap.ts
+++ b/packages/cli/src/runtime-bootstrap.ts
@@ -218,8 +218,10 @@ export async function createMakaCliRuntimeContext(
   const host: HostCapabilities = {
     toolNames: new Set([...tools, automationTool, ...goalTools, ...surfaceTools].map((tool) => tool.name)),
   };
-  const skillSource = resolveSkillDiscoveryPaths(input.cwd, input.workspaceRoot);
-  const skillTool = buildSkillAgentTool(skillSource, host);
+  const skillTool = buildSkillAgentTool(
+    ({ cwd }) => resolveSkillDiscoveryPaths(cwd, input.workspaceRoot),
+    host,
+  );
   const allTools = [...tools, automationTool, ...goalTools, skillTool, ...surfaceTools];
 
   backends.register('ai-sdk', async (ctx) => {

--- a/packages/cli/src/session-driver.ts
+++ b/packages/cli/src/session-driver.ts
@@ -90,8 +90,24 @@ export type SessionResumeAvailability =
   | { available: true }
   | { available: false; reason: string };
 
-export const MISSING_SESSION_CWD_REASON = 'Missing working directory';
-export const DELETED_SESSION_CWD_REASON = 'Working directory no longer exists';
+const MISSING_SESSION_CWD_REASON = 'Missing working directory';
+const DELETED_SESSION_CWD_REASON = 'Working directory no longer exists';
+
+export async function inspectSessionResumeAvailability(
+  session: SessionSummary,
+): Promise<SessionResumeAvailability> {
+  if (!session.cwd) return { available: false, reason: MISSING_SESSION_CWD_REASON };
+  try {
+    await realpath(session.cwd);
+    return { available: true };
+  } catch (error) {
+    const code = (error as { code?: unknown }).code;
+    if (code === 'ENOENT' || code === 'ENOTDIR') {
+      return { available: false, reason: DELETED_SESSION_CWD_REASON };
+    }
+    throw error;
+  }
+}
 
 export function createMakaSessionDriver(input: MakaSessionDriverInput): MakaSessionDriver {
   return new RuntimeMakaSessionDriver(input);
@@ -140,17 +156,7 @@ class RuntimeMakaSessionDriver implements MakaSessionDriver {
   }
 
   async getSessionResumeAvailability(session: SessionSummary): Promise<SessionResumeAvailability> {
-    if (!session.cwd) return { available: false, reason: MISSING_SESSION_CWD_REASON };
-    try {
-      await realpath(session.cwd);
-      return { available: true };
-    } catch (error) {
-      const code = (error as { code?: unknown }).code;
-      if (code === 'ENOENT' || code === 'ENOTDIR') {
-        return { available: false, reason: DELETED_SESSION_CWD_REASON };
-      }
-      throw error;
-    }
+    return inspectSessionResumeAvailability(session);
   }
 
   async stop(): Promise<void> {
@@ -216,11 +222,15 @@ class RuntimeMakaSessionDriver implements MakaSessionDriver {
   async switchSession(sessionId: string): Promise<MakaSessionSwitchResult> {
     const summary = (await this.listSessions()).find((session) => session.id === sessionId);
     if (!summary) throw new Error(`Session not found: ${sessionId}`);
-    if (!summary.cwd) throw new Error('Session has no working directory and cannot be resumed.');
-    await assertSessionCwdExists(summary.cwd);
+    const availability = await inspectSessionResumeAvailability(summary);
+    if (!availability.available) {
+      if (!summary.cwd) throw new Error('Session has no working directory and cannot be resumed.');
+      throw new Error(`Session cwd no longer exists: ${summary.cwd}`);
+    }
+    const sessionCwd = summary.cwd!;
     const messages = await this.input.runtime.getMessages(summary.id);
     this.sessionId = summary.id;
-    this.cwd = summary.cwd;
+    this.cwd = sessionCwd;
     this.model = summary.model;
     this.llmConnectionSlug = summary.llmConnectionSlug;
     this.thinkingLevel = summary.thinkingLevel;
@@ -303,16 +313,4 @@ function cwdRank(session: SessionSummary, cwd: string): number {
 function firstLine(text: string): string {
   const line = text.split('\n').map((part) => part.trim()).find((part) => part.length > 0);
   return line ?? '(empty prompt)';
-}
-
-async function assertSessionCwdExists(cwd: string): Promise<void> {
-  try {
-    await realpath(cwd);
-  } catch (error) {
-    const code = (error as { code?: unknown }).code;
-    if (code === 'ENOENT' || code === 'ENOTDIR') {
-      throw new Error(`Session cwd no longer exists: ${cwd}`);
-    }
-    throw error;
-  }
 }

--- a/packages/cli/src/session-driver.ts
+++ b/packages/cli/src/session-driver.ts
@@ -57,6 +57,7 @@ export interface MakaSessionSwitchResult {
 
 export interface MakaSessionDriver {
   listSessions(): Promise<SessionSummary[]>;
+  getSessionResumeAvailability?(session: SessionSummary): Promise<SessionResumeAvailability>;
   sendPrompt(prompt: string): AsyncIterable<SessionEvent>;
   compactSession(): AsyncIterable<SessionEvent>;
   respondToPermission(response: PermissionResponse): Promise<void>;
@@ -85,12 +86,20 @@ export interface MakaSessionDriver {
   getSessionId(): string | null;
 }
 
+export type SessionResumeAvailability =
+  | { available: true }
+  | { available: false; reason: string };
+
+export const MISSING_SESSION_CWD_REASON = 'Missing working directory';
+export const DELETED_SESSION_CWD_REASON = 'Working directory no longer exists';
+
 export function createMakaSessionDriver(input: MakaSessionDriverInput): MakaSessionDriver {
   return new RuntimeMakaSessionDriver(input);
 }
 
 class RuntimeMakaSessionDriver implements MakaSessionDriver {
   private sessionId: string | null = null;
+  private cwd: string;
   private model: string;
   // The connection the active/next session runs on. Mutable so a cross-provider
   // /model switch can rebind it; new sessions are created on this connection.
@@ -101,6 +110,7 @@ class RuntimeMakaSessionDriver implements MakaSessionDriver {
 
   constructor(private readonly input: MakaSessionDriverInput) {
     this.newId = input.newId ?? randomUUID;
+    this.cwd = input.cwd;
     this.model = input.model;
     this.llmConnectionSlug = input.llmConnectionSlug;
     this.permissionMode = input.permissionMode ?? 'ask';
@@ -123,10 +133,24 @@ class RuntimeMakaSessionDriver implements MakaSessionDriver {
     return (await this.input.runtime.listSessions())
       .map((session, index) => ({ session, index }))
       .sort((left, right) => {
-        const cwdDelta = cwdRank(left.session, this.input.cwd) - cwdRank(right.session, this.input.cwd);
+        const cwdDelta = cwdRank(left.session, this.cwd) - cwdRank(right.session, this.cwd);
         return cwdDelta !== 0 ? cwdDelta : left.index - right.index;
       })
       .map(({ session }) => session);
+  }
+
+  async getSessionResumeAvailability(session: SessionSummary): Promise<SessionResumeAvailability> {
+    if (!session.cwd) return { available: false, reason: MISSING_SESSION_CWD_REASON };
+    try {
+      await realpath(session.cwd);
+      return { available: true };
+    } catch (error) {
+      const code = (error as { code?: unknown }).code;
+      if (code === 'ENOENT' || code === 'ENOTDIR') {
+        return { available: false, reason: DELETED_SESSION_CWD_REASON };
+      }
+      throw error;
+    }
   }
 
   async stop(): Promise<void> {
@@ -192,17 +216,11 @@ class RuntimeMakaSessionDriver implements MakaSessionDriver {
   async switchSession(sessionId: string): Promise<MakaSessionSwitchResult> {
     const summary = (await this.listSessions()).find((session) => session.id === sessionId);
     if (!summary) throw new Error(`Session not found: ${sessionId}`);
-    if (summary.cwd) await assertSessionCwdExists(summary.cwd);
-    // Enforce folder/connection before reading messages or committing any
-    // internal state, so a rejected switch leaves the active session untouched.
-    if (summary.cwd !== this.input.cwd) {
-      throw new Error('Session belongs to a different folder; run Maka in that folder to resume it.');
-    }
-    if (summary.llmConnectionSlug !== this.llmConnectionSlug) {
-      throw new Error('Session uses a different connection; run Maka with that connection to resume it.');
-    }
+    if (!summary.cwd) throw new Error('Session has no working directory and cannot be resumed.');
+    await assertSessionCwdExists(summary.cwd);
     const messages = await this.input.runtime.getMessages(summary.id);
     this.sessionId = summary.id;
+    this.cwd = summary.cwd;
     this.model = summary.model;
     this.llmConnectionSlug = summary.llmConnectionSlug;
     this.thinkingLevel = summary.thinkingLevel;
@@ -264,7 +282,7 @@ class RuntimeMakaSessionDriver implements MakaSessionDriver {
   private async ensureSession(prompt: string): Promise<string> {
     if (this.sessionId) return this.sessionId;
     const session = await this.input.runtime.createSession({
-      cwd: this.input.cwd,
+      cwd: this.cwd,
       name: prompt.slice(0, 42) || '新建对话',
       backend: 'ai-sdk',
       llmConnectionSlug: this.llmConnectionSlug,

--- a/packages/runtime/src/__tests__/skills.test.ts
+++ b/packages/runtime/src/__tests__/skills.test.ts
@@ -297,6 +297,36 @@ Make every slide carry one idea.`);
     });
   });
 
+  it('buildSkillAgentTool resolves project skills from each tool call cwd', async () => {
+    await withWorkspace(async (workspaceRoot) => {
+      const firstProject = join(workspaceRoot, 'first-project');
+      const secondProject = join(workspaceRoot, 'second-project');
+      await mkdir(join(firstProject, '.agents', 'skills', 'project-helper'), { recursive: true });
+      await mkdir(join(secondProject, '.agents', 'skills', 'project-helper'), { recursive: true });
+      await writeFile(join(firstProject, '.agents', 'skills', 'project-helper', 'SKILL.md'), `---
+name: Project Helper
+description: First project helper.
+---
+# First project`, 'utf8');
+      await writeFile(join(secondProject, '.agents', 'skills', 'project-helper', 'SKILL.md'), `---
+name: Project Helper
+description: Second project helper.
+---
+# Second project`, 'utf8');
+
+      const tool = buildSkillAgentTool((ctx) => resolveSkillDiscoveryPaths(ctx.cwd, workspaceRoot));
+      const result = await tool.impl({ name: 'Project Helper' }, {
+        sessionId: 's2', turnId: 't2', cwd: secondProject, toolCallId: 'tool-2',
+        abortSignal: new AbortController().signal, emitOutput: () => {},
+      });
+
+      assert.equal(result.ok, true);
+      if (!result.ok) return;
+      assert.match(result.skill.instructions, /# Second project/);
+      assert.doesNotMatch(result.skill.instructions, /# First project/);
+    });
+  });
+
   it('loadSkillInstructions bounds loaded instructions and returns available skills on miss', async () => {
     await withWorkspace(async (workspaceRoot) => {
       await writeSkill(workspaceRoot, 'huge', `---

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -975,5 +975,6 @@ export type {
   LoadSkillInstructionsResult,
   SkillRuntimeStateReadResult,
   SkillSource,
+  SkillSourceResolver,
   SkillDiscoveryEntry,
 } from './skills.js';

--- a/packages/runtime/src/skills.ts
+++ b/packages/runtime/src/skills.ts
@@ -3,7 +3,7 @@ import { homedir } from 'node:os';
 import { lstat, mkdir, readdir, readFile, realpath, rename, unlink, writeFile } from 'node:fs/promises';
 import { isAbsolute, join, relative } from 'node:path';
 import { z } from 'zod';
-import type { MakaTool } from './tool-runtime.js';
+import type { MakaTool, MakaToolContext } from './tool-runtime.js';
 
 /**
  * Workspace skill read path shared by the desktop app and the CLI.
@@ -124,6 +124,7 @@ export type SkillRuntimeStateReadResult =
  * reading/writing `skills-state.json`.
  */
 export type SkillSource = string | { dirs: string[]; stateRoot: string; entries?: SkillDiscoveryEntry[] };
+export type SkillSourceResolver = (context: Pick<MakaToolContext, 'sessionId' | 'cwd'>) => SkillSource;
 
 /**
  * Standard skill discovery paths per the Agent Skills spec
@@ -447,7 +448,10 @@ export async function loadSkillInstructions(source: SkillSource, name: string, h
   return { ok: false, reason: 'not_found', availableSkills };
 }
 
-export function buildSkillAgentTool(source: SkillSource, host?: HostCapabilities): MakaTool<{ name: string }, LoadSkillInstructionsResult> {
+export function buildSkillAgentTool(
+  source: SkillSource | SkillSourceResolver,
+  host?: HostCapabilities,
+): MakaTool<{ name: string }, LoadSkillInstructionsResult> {
   return {
     name: 'Skill',
     description:
@@ -457,7 +461,11 @@ export function buildSkillAgentTool(source: SkillSource, host?: HostCapabilities
     }),
     permissionRequired: false,
     displayName: 'Skill',
-    impl: async ({ name }) => loadSkillInstructions(source, name, host),
+    impl: async ({ name }, ctx) => loadSkillInstructions(
+      typeof source === 'function' ? source(ctx) : source,
+      name,
+      host,
+    ),
   };
 }
 


### PR DESCRIPTION
## Summary

- add a Current / All scope toggle to the TUI session picker, with Tab switching and process-local scope memory
- resume durable sessions across cwd and connection boundaries by adopting the session's stored cwd, connection, model, thinking level, and permission mode
- keep sessions with missing or deleted working directories discoverable but unavailable, with an explicit reason
- update file autocomplete and project skill loading to follow the active session cwd after a cross-workspace resume

This fixes durable-session discovery independently of #853. It does not add a Runtime Host or live Turn / PTY handoff between processes.

## Verification

- `npm test -w maka-agent`
- `npm test -w @maka/runtime`
- `npm run typecheck`
- targeted TUI tests cover Current / All switching, scope memory, cross-cwd resume, unavailable cwd handling, and session disambiguation
- targeted Runtime tests cover resolving project skills from each ToolCall's session cwd

## Review focus

The active cwd now changes when a session is resumed from another workspace. The same cwd is used by the status line, file autocomplete, new sessions, tool execution, system prompts, and project skill discovery so the resumed context does not split across directories.

This PR only resumes durable session state. Taking over work that is still owned by another Desktop or TUI process remains part of the broader Runtime Host work in #853.
