### PR TITLE
fix: restore Ollama Cloud thinking options

### DIFF
--- a/packages/cli/src/__tests__/pi-tui-runner.test.ts
+++ b/packages/cli/src/__tests__/pi-tui-runner.test.ts
@@ -1408,6 +1408,33 @@ describe('Maka Pi TUI runner', () => {
     ]);
   });
 
+  test('shows the default thinking status for Ollama Cloud GLM-5.2', async () => {
+    const terminal = new FakeTerminal();
+    const driver = new SlashCommandDriver();
+    const run = runMakaPiTui({
+      title: 'Maka',
+      driver,
+      cwd: '/repo',
+      model: 'glm-5.2',
+      connectionSlug: 'ollama-cloud',
+      providerType: 'ollama-cloud',
+      permissionMode: 'ask',
+      terminal,
+    });
+
+    await waitFor(() => plainTerminalOutput(terminal.output()).includes(
+      'Maka · ask · glm-5.2 · thinking:default · ollama-cloud · /repo',
+    ));
+
+    exitMaka(terminal);
+    await Promise.race([
+      run,
+      delay(50).then(() => {
+        throw new Error('TUI did not close during test cleanup');
+      }),
+    ]);
+  });
+
   test('handles /thinking off when the current model exposes a real off wire', async () => {
     const terminal = new FakeTerminal();
     const driver = new SlashCommandDriver();

--- a/packages/core/src/__tests__/model-thinking.test.ts
+++ b/packages/core/src/__tests__/model-thinking.test.ts
@@ -149,15 +149,30 @@ describe('thinkingOptionsForModel', () => {
     );
   });
 
-  test('Ollama Cloud exposes the documented OpenAI-compatible reasoning effort values', () => {
+  test('Ollama Cloud reasoning models expose off/low/medium/high/max; GPT-OSS low/medium/high only; deprecated excluded', () => {
     assert.deepEqual(
       thinkingOptionsForModel('ollama-cloud', 'qwen3.5:397b'),
-      { efforts: ['none', 'low', 'medium', 'high'], toggle: true },
+      { efforts: ['none', 'low', 'medium', 'high', 'max'], toggle: true },
     );
     assert.deepEqual(
       [...thinkingVariantsForModel('ollama-cloud', 'qwen3.5:397b')],
-      ['off', 'low', 'medium', 'high'],
+      ['off', 'low', 'medium', 'high', 'max'],
     );
+    assert.deepEqual(
+      [...thinkingVariantsForModel('ollama-cloud', 'glm-5.2')],
+      ['off', 'low', 'medium', 'high', 'max'],
+    );
+    assert.deepEqual(
+      thinkingOptionsForModel('ollama-cloud', 'gpt-oss:120b'),
+      { efforts: ['low', 'medium', 'high'] },
+    );
+    assert.deepEqual(
+      [...thinkingVariantsForModel('ollama-cloud', 'gpt-oss:120b')],
+      ['low', 'medium', 'high'],
+    );
+    assert.deepEqual([...thinkingVariantsForModel('ollama-cloud', 'devstral-2:123b')], []);
+    assert.deepEqual([...thinkingVariantsForModel('ollama-cloud', 'cogito-2.1:671b')], []);
+    assert.deepEqual([...thinkingVariantsForModel('ollama-cloud', 'kimi-k2-thinking')], []);
   });
 
   test('claude-subscription inherits anthropic thinking options (displayMetadataOnly preserves them)', () => {

--- a/packages/core/src/model-metadata.ts
+++ b/packages/core/src/model-metadata.ts
@@ -133,6 +133,27 @@ const VOLCENGINE_CODING_PLAN_MODEL_METADATA: Record<string, ModelMetadata> = {
   'kimi-k2.7-code': planModel('Kimi-K2.7-Code', true, 256_000, 32_000),
 };
 
+// Ollama Cloud accepts reasoning_effort for every active reasoning model in its
+// generated catalog. GPT-OSS is the narrower exception and cannot be disabled.
+const OLLAMA_CLOUD_STANDARD_THINKING_OPTIONS: ThinkingOptions = {
+  efforts: ['none', 'low', 'medium', 'high', 'max'],
+  toggle: true,
+};
+
+const OLLAMA_CLOUD_GPT_OSS_THINKING_OPTIONS: ThinkingOptions = {
+  efforts: ['low', 'medium', 'high'],
+};
+
+const ollamaCloudThinkingModels: Record<string, ModelMetadata> = Object.fromEntries(
+  Object.entries(GENERATED_MODELS_DEV_METADATA['ollama-cloud'])
+    .filter(([, metadata]) => metadata.capabilities?.reasoning && metadata.lifecycle !== 'deprecated')
+    .map(([id]) => [id, {
+      thinkingOptions: id.startsWith('gpt-oss')
+        ? OLLAMA_CLOUD_GPT_OSS_THINKING_OPTIONS
+        : OLLAMA_CLOUD_STANDARD_THINKING_OPTIONS,
+    }]),
+);
+
 // Facts that models.dev cannot express: provider wire controls and
 // access-path-specific aliases/limits. Standard model facts stay generated.
 const STATIC_MODEL_METADATA: Partial<Record<ProviderType, Record<string, ModelMetadata>>> = {
@@ -225,11 +246,7 @@ const STATIC_MODEL_METADATA: Partial<Record<ProviderType, Record<string, ModelMe
       },
     },
   },
-  'ollama-cloud': {
-    'qwen3.5:397b': {
-      thinkingOptions: { efforts: ['none', 'low', 'medium', 'high'], toggle: true },
-    },
-  },
+  'ollama-cloud': ollamaCloudThinkingModels,
   deepseek: {
     'deepseek-v4-flash': { thinkingOptions: { efforts: ['high', 'max'], toggle: true } },
   },

--- a/packages/runtime/src/__tests__/model-factory-thinking.test.ts
+++ b/packages/runtime/src/__tests__/model-factory-thinking.test.ts
@@ -174,6 +174,21 @@ describe('buildProviderOptions: thinking level', () => {
     assert.deepEqual(buildProviderOptions(conn('vercel'), 'grok-4.3', 'high'), {});
   });
 
+  test('Ollama Cloud sends reasoning effort under its namespace; standard models expose off, GPT-OSS does not', () => {
+    assert.deepEqual([...thinkingVariantsForModel('ollama-cloud', 'glm-5.2')], ['off', 'low', 'medium', 'high', 'max']);
+    assert.deepEqual(buildProviderOptions(conn('ollama-cloud'), 'glm-5.2', 'high'), {
+      'ollama-cloud': { reasoningEffort: 'high' },
+    });
+    assert.deepEqual(buildProviderOptions(conn('ollama-cloud'), 'glm-5.2', 'off'), {
+      'ollama-cloud': { reasoningEffort: 'none' },
+    });
+    assert.deepEqual([...thinkingVariantsForModel('ollama-cloud', 'gpt-oss:120b')], ['low', 'medium', 'high']);
+    assert.deepEqual(buildProviderOptions(conn('ollama-cloud'), 'gpt-oss:120b', 'high'), {
+      'ollama-cloud': { reasoningEffort: 'high' },
+    });
+    assert.deepEqual(buildProviderOptions(conn('ollama-cloud'), 'gpt-oss:120b', 'off'), {});
+  });
+
   test('a level the model does not support is dropped (defensive)', () => {
     assert.deepEqual(buildProviderOptions(conn('openai'), 'gpt-4o', 'high'), { openai: { store: false } });
     assert.deepEqual(buildProviderOptions(conn('anthropic'), 'claude-haiku-4-5', 'max'), { anthropic: {} });
@@ -258,6 +273,8 @@ describe('buildProviderOptions: resolver/options drift guard', () => {
     { providerType: 'groq', model: 'openai/gpt-oss-120b' },
     { providerType: 'openrouter', model: 'openai/gpt-5.6-sol' },
     { providerType: 'vercel', model: 'xai/grok-4.3' },
+    { providerType: 'ollama-cloud', model: 'glm-5.2' },
+    { providerType: 'ollama-cloud', model: 'gpt-oss:120b' },
     { providerType: 'cloudflare-workers-ai', model: '@cf/moonshotai/kimi-k2.6' },
     { providerType: 'zai-coding-plan', model: 'glm-5.2', slug: 'zai-coding-plan' },
     { providerType: 'volcengine-ark', model: 'doubao-seed-2-0-pro-260215' },


### PR DESCRIPTION
## Summary

Restore the Ollama Cloud thinking-option derivation accidentally reverted by #1005. Active reasoning models again expose the provider-supported effort values; GPT-OSS remains limited to low/medium/high, while deprecated and non-reasoning models remain excluded.

This restores GLM-5.2's `/thinking` controls and `thinking:default` TUI status. The failures recorded in #1008 were not render-timing flakes: the merge ref included #1005, so GLM-5.2 had no thinking variants and the expected status could never render.

Closes #1008.

## Verification

- `npm --workspace @maka/core test`
- `npm --workspace @maka/runtime test`
- `npm --workspace maka-agent test`
- `npm run typecheck`