### PR TITLE
fix: stabilize Electron E2E startup

### DIFF
--- a/apps/desktop/e2e/electron-lifecycle.spec.ts
+++ b/apps/desktop/e2e/electron-lifecycle.spec.ts
@@ -36,11 +36,20 @@ test('force-kills Electron when graceful E2E teardown does not settle', async ()
     process: () => child,
   };
 
+  let terminatedTree = false;
   const settled = await Promise.race([
-    closeElectronApplication(app, 0).then(() => true),
+    closeElectronApplication(app, 0, async (target, signal) => {
+      expect(target).toBe(child);
+      expect(signal).toBe('SIGKILL');
+      terminatedTree = true;
+      child.signalCode = signal;
+      child.emit('exit');
+      return true;
+    }).then(() => true),
     new Promise<false>((resolve) => setTimeout(() => resolve(false), 25)),
   ]);
 
   expect(settled).toBe(true);
-  expect(child.killedWith).toBe('SIGKILL');
+  expect(terminatedTree).toBe(true);
+  expect(child.killedWith).toBeUndefined();
 });

--- a/apps/desktop/e2e/electron-lifecycle.spec.ts
+++ b/apps/desktop/e2e/electron-lifecycle.spec.ts
@@ -1,0 +1,46 @@
+import { EventEmitter } from 'node:events';
+import { test, expect } from '@playwright/test';
+import {
+  closeElectronApplication,
+  type ClosableElectronApplication,
+  type ElectronProcessHandle,
+} from './electron-lifecycle.js';
+
+class FakeElectronProcess extends EventEmitter implements ElectronProcessHandle {
+  exitCode: number | null = null;
+  signalCode: NodeJS.Signals | null = null;
+  killedWith: NodeJS.Signals | undefined;
+
+  kill(signal: NodeJS.Signals): boolean {
+    this.killedWith = signal;
+    queueMicrotask(() => {
+      this.signalCode = signal;
+      this.emit('exit');
+    });
+    return true;
+  }
+
+  override once(event: 'exit', listener: () => void): this {
+    return super.once(event, listener);
+  }
+
+  override off(event: 'exit', listener: () => void): this {
+    return super.off(event, listener);
+  }
+}
+
+test('force-kills Electron when graceful E2E teardown does not settle', async () => {
+  const child = new FakeElectronProcess();
+  const app: ClosableElectronApplication = {
+    close: () => new Promise<void>(() => {}),
+    process: () => child,
+  };
+
+  const settled = await Promise.race([
+    closeElectronApplication(app, 0).then(() => true),
+    new Promise<false>((resolve) => setTimeout(() => resolve(false), 25)),
+  ]);
+
+  expect(settled).toBe(true);
+  expect(child.killedWith).toBe('SIGKILL');
+});

--- a/apps/desktop/e2e/electron-lifecycle.ts
+++ b/apps/desktop/e2e/electron-lifecycle.ts
@@ -1,3 +1,6 @@
+import type { ChildProcess } from 'node:child_process';
+import { terminateChildProcessTree } from '@maka/runtime';
+
 export interface ElectronProcessHandle {
   exitCode: number | null;
   signalCode: NodeJS.Signals | null;
@@ -5,6 +8,14 @@ export interface ElectronProcessHandle {
   once(event: 'exit', listener: () => void): unknown;
   off(event: 'exit', listener: () => void): unknown;
 }
+
+type ProcessTreeTerminator = (
+  child: ElectronProcessHandle,
+  signal: 'SIGKILL',
+) => Promise<boolean>;
+
+const terminateElectronProcessTree: ProcessTreeTerminator = (child, signal) =>
+  terminateChildProcessTree(child as ChildProcess, signal);
 
 export interface ClosableElectronApplication {
   close(): Promise<void>;
@@ -14,6 +25,7 @@ export interface ClosableElectronApplication {
 export async function closeElectronApplication(
   app: ClosableElectronApplication,
   graceMs: number,
+  terminateTree: ProcessTreeTerminator = terminateElectronProcessTree,
 ): Promise<void> {
   const child = app.process();
   const gracefulClose = app.close().then(
@@ -23,7 +35,7 @@ export async function closeElectronApplication(
   if (await settlesWithin(gracefulClose, graceMs)) return;
 
   if (child.exitCode === null && child.signalCode === null) {
-    child.kill('SIGKILL');
+    await terminateTree(child, 'SIGKILL');
   }
   if (!await waitForExit(child, 2_000)) {
     throw new Error('Electron process did not exit after SIGKILL');

--- a/apps/desktop/e2e/electron-lifecycle.ts
+++ b/apps/desktop/e2e/electron-lifecycle.ts
@@ -1,0 +1,65 @@
+export interface ElectronProcessHandle {
+  exitCode: number | null;
+  signalCode: NodeJS.Signals | null;
+  kill(signal: NodeJS.Signals): boolean;
+  once(event: 'exit', listener: () => void): unknown;
+  off(event: 'exit', listener: () => void): unknown;
+}
+
+export interface ClosableElectronApplication {
+  close(): Promise<void>;
+  process(): ElectronProcessHandle;
+}
+
+export async function closeElectronApplication(
+  app: ClosableElectronApplication,
+  graceMs: number,
+): Promise<void> {
+  const child = app.process();
+  const gracefulClose = app.close().then(
+    () => true,
+    () => false,
+  );
+  if (await settlesWithin(gracefulClose, graceMs)) return;
+
+  if (child.exitCode === null && child.signalCode === null) {
+    child.kill('SIGKILL');
+  }
+  if (!await waitForExit(child, 2_000)) {
+    throw new Error('Electron process did not exit after SIGKILL');
+  }
+}
+
+async function settlesWithin(promise: Promise<boolean>, timeoutMs: number): Promise<boolean> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<false>((resolve) => {
+        timer = setTimeout(() => resolve(false), timeoutMs);
+      }),
+    ]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
+async function waitForExit(child: ElectronProcessHandle, timeoutMs: number): Promise<boolean> {
+  if (child.exitCode !== null || child.signalCode !== null) return true;
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  let onExit: (() => void) | undefined;
+  try {
+    return await Promise.race([
+      new Promise<true>((resolve) => {
+        onExit = () => resolve(true);
+        child.once('exit', onExit);
+      }),
+      new Promise<false>((resolve) => {
+        timer = setTimeout(() => resolve(false), timeoutMs);
+      }),
+    ]);
+  } finally {
+    if (timer) clearTimeout(timer);
+    if (onExit) child.off('exit', onExit);
+  }
+}

--- a/apps/desktop/e2e/fixtures.ts
+++ b/apps/desktop/e2e/fixtures.ts
@@ -4,6 +4,7 @@ import { mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { createConnectionStore, createFileCredentialStore } from '@maka/storage';
+import { closeElectronApplication } from './electron-lifecycle.js';
 
 const DESKTOP_ROOT = process.cwd();
 
@@ -65,33 +66,6 @@ function buildE2eEnv(userDataDir: string, visualSmokeScenario?: string): NodeJS.
 }
 
 /**
- * Launch the desktop app against a throwaway userData dir and wait for a
- * readiness selector. MAKA_E2E=1 forces every session onto the deterministic
- * fake backend, so tests run without real provider keys or network. `seed`
- * controls whether a connection is pre-staged: chat/session/settings/attachment
- * need it to clear onboarding; first-run must boot without it.
- */
-async function launchE2eApp(
-  userDataDir: string,
-  { seed, readinessSelector, visualSmokeScenario }: {
-    seed: boolean;
-    readinessSelector: string;
-    visualSmokeScenario?: string;
-  },
-): Promise<{ app: ElectronApplication; page: Page }> {
-  if (seed) await seedE2eConnection(userDataDir);
-  const app = await electron.launch({
-    args: ['.'],
-    cwd: DESKTOP_ROOT,
-    env: buildE2eEnv(userDataDir, visualSmokeScenario),
-  });
-  const page = await app.firstWindow();
-  // Centralize the cold-start wait so test bodies are flake-free under retries:0.
-  await page.waitForSelector(readinessSelector, { timeout: 20_000 });
-  return { app, page };
-}
-
-/**
  * Own the full launch lifecycle so a failure anywhere — seeding, Electron
  * launch, firstWindow, or the readiness wait — still tears down the Electron
  * process and the throwaway userData dir. The previous shape ran `mkdtemp`
@@ -108,13 +82,35 @@ async function withE2eWindow(
 ): Promise<void> {
   const userDataDir = await mkdtemp(path.join(tmpdir(), 'maka-e2e-'));
   let app: ElectronApplication | undefined;
+  const mainLogs: string[] = [];
   try {
-    const launched = await launchE2eApp(userDataDir, { seed, readinessSelector, visualSmokeScenario });
-    app = launched.app;
-    await use(launched.page);
+    if (seed) await seedE2eConnection(userDataDir);
+    app = await electron.launch({
+      args: ['.'],
+      cwd: DESKTOP_ROOT,
+      env: buildE2eEnv(userDataDir, visualSmokeScenario),
+    });
+    app.on('console', (message) => {
+      mainLogs.push(message.text());
+      if (mainLogs.length > 20) mainLogs.shift();
+    });
+    let page: Page;
+    try {
+      page = await app.firstWindow();
+    } catch (error) {
+      const detail = error instanceof Error ? error.message : String(error);
+      const logs = mainLogs.length > 0 ? `\nElectron main console:\n${mainLogs.join('\n')}` : '';
+      throw new Error(`${detail}${logs}`, { cause: error });
+    }
+    // Centralize the cold-start wait so test bodies are flake-free under retries:0.
+    await page.waitForSelector(readinessSelector, { timeout: 20_000 });
+    await use(page);
   } finally {
-    await app?.close().catch(() => {});
-    await rm(userDataDir, { recursive: true, force: true });
+    try {
+      if (app) await closeElectronApplication(app, 5_000);
+    } finally {
+      await rm(userDataDir, { recursive: true, force: true });
+    }
   }
 }
 

--- a/apps/desktop/src/main/__tests__/window-reveal-after-first-commit-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/window-reveal-after-first-commit-contract.test.ts
@@ -238,6 +238,20 @@ describe('window reveal wiring (PR-SHOW-AFTER-FIRST-COMMIT)', () => {
     );
   });
 
+  it('owns Electron launch before waiting for the first E2E window so startup failures can be cleaned up', async () => {
+    const src = await readRepoFile('apps/desktop/e2e/fixtures.ts');
+    const helperStart = src.indexOf('async function withE2eWindow(');
+    const helperEnd = src.indexOf('\nexport const test =', helperStart);
+    assert.notEqual(helperStart, -1);
+    assert.notEqual(helperEnd, -1);
+    const helper = src.slice(helperStart, helperEnd);
+    const tryIndex = helper.indexOf('try {');
+    const launchIndex = helper.indexOf('app = await electron.launch(');
+    const firstWindowIndex = helper.indexOf('await app.firstWindow(');
+    assert.ok(tryIndex !== -1 && launchIndex > tryIndex, 'Electron must be assigned inside the lifecycle try block');
+    assert.ok(firstWindowIndex > launchIndex, 'the app handle must be retained before firstWindow can time out');
+  });
+
   it('main-window creates the window hidden and wires the reveal fallback timer', async () => {
     const src = await readRepoFile('apps/desktop/src/main/main-window.ts');
     // Every run now creates hidden — no `!app.isPackaged && startHidden` gate.

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -69,6 +69,7 @@ export type {
 export { AiSdkBackend } from './ai-sdk-backend.js';
 export type { MakaTool, MakaToolContext } from './tool-runtime.js';
 export { buildAskUserQuestionTool } from './ask-user-question-tool.js';
+export { terminateChildProcessTree } from './process-tree-terminator.js';
 export type {
   AgentBackend,
   BackendCompactHistoryInput,

--- a/packages/storage/src/__tests__/settings-store-onboarding.test.ts
+++ b/packages/storage/src/__tests__/settings-store-onboarding.test.ts
@@ -206,6 +206,24 @@ describe('SettingsStore.clearOnboardingMilestone', () => {
 });
 
 describe('SettingsStore.get file recovery', () => {
+  it('serializes concurrent first reads while creating default settings', async () => {
+    const workspaceRoot = await mkdtemp(join(tmpdir(), 'maka-settings-concurrent-defaults-'));
+    const originalNow = Date.now;
+    try {
+      Date.now = () => 1_000;
+      const store = createSettingsStore(workspaceRoot);
+
+      const settings = await Promise.all(Array.from({ length: 16 }, () => store.get()));
+
+      assert.equal(settings.every((value) => value.schemaVersion === 1), true);
+      const raw = await readFile(join(workspaceRoot, 'settings.json'), 'utf8');
+      assert.equal(JSON.parse(raw).schemaVersion, 1);
+    } finally {
+      Date.now = originalNow;
+      await rm(workspaceRoot, { recursive: true, force: true });
+    }
+  });
+
   it('creates defaults only when settings.json is missing', async () => {
     const workspaceRoot = await mkdtemp(join(tmpdir(), 'maka-settings-defaults-'));
     try {

--- a/packages/storage/src/settings-store.ts
+++ b/packages/storage/src/settings-store.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from 'node:crypto';
 import { mkdir, readFile, rename, writeFile } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
 import type {
@@ -105,6 +106,15 @@ class FileSettingsStore implements SettingsStore {
   }
 
   async get(): Promise<AppSettings> {
+    let settings: AppSettings | undefined;
+    await this.withQueue(async () => {
+      settings = await this.readOrCreate();
+    });
+    if (!settings) throw new Error('Failed to read settings');
+    return settings;
+  }
+
+  private async readOrCreate(): Promise<AppSettings> {
     try {
       const text = await readFile(this.settingsPath, 'utf8');
       return normalizeSettings(JSON.parse(text));
@@ -119,7 +129,7 @@ class FileSettingsStore implements SettingsStore {
   async update(patch: UpdateAppSettingsInput): Promise<AppSettings> {
     let next: AppSettings | undefined;
     await this.withQueue(async () => {
-      const current = await this.get();
+      const current = await this.readOrCreate();
       next = mergeSettings(current, patch);
       await this.write(next);
     });
@@ -141,7 +151,7 @@ class FileSettingsStore implements SettingsStore {
         : { id, skippedAt: timestamp };
     let result: OnboardingMilestone[] | undefined;
     await this.withQueue(async () => {
-      const current = await this.get();
+      const current = await this.readOrCreate();
       // Append the new entry; sanitize() applies last-valid-entry-wins
       // dedup with stable first-seen position. ID validity is enforced
       // by the sanitizer (closed enum).
@@ -165,7 +175,7 @@ class FileSettingsStore implements SettingsStore {
   async clearOnboardingMilestone(id: OnboardingMilestoneId): Promise<OnboardingMilestone[]> {
     let result: OnboardingMilestone[] | undefined;
     await this.withQueue(async () => {
-      const current = await this.get();
+      const current = await this.readOrCreate();
       const knownId = sanitizeOnboardingMilestones([{ id }]).some((entry) => entry.id === id);
       if (!knownId) {
         throw new Error(`invalid onboarding milestone id: ${String(id)}`);
@@ -267,7 +277,7 @@ class FileSettingsStore implements SettingsStore {
 
   private async write(settings: AppSettings): Promise<void> {
     await mkdir(dirname(this.settingsPath), { recursive: true });
-    const tempPath = `${this.settingsPath}.${process.pid}.${Date.now()}.tmp`;
+    const tempPath = `${this.settingsPath}.${process.pid}.${randomUUID()}.tmp`;
     await writeFile(tempPath, JSON.stringify(settings, null, 2) + '\n', 'utf8');
     await rename(tempPath, this.settingsPath);
   }

--- a/packages/storage/src/settings-store.ts
+++ b/packages/storage/src/settings-store.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from 'node:crypto';
 import { mkdir, readFile, rename, writeFile } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
 import type {
@@ -277,7 +276,7 @@ class FileSettingsStore implements SettingsStore {
 
   private async write(settings: AppSettings): Promise<void> {
     await mkdir(dirname(this.settingsPath), { recursive: true });
-    const tempPath = `${this.settingsPath}.${process.pid}.${randomUUID()}.tmp`;
+    const tempPath = `${this.settingsPath}.${process.pid}.${Date.now()}.tmp`;
     await writeFile(tempPath, JSON.stringify(settings, null, 2) + '\n', 'utf8');
     await rename(tempPath, this.settingsPath);
   }


### PR DESCRIPTION
## Summary

Fix the underlying race that intermittently prevented the Electron main window from opening during E2E startup.

Concurrent first reads of a missing settings file could generate the same temporary path because the path only included the process ID and current millisecond. One caller renamed the shared temporary file first, causing the other caller to fail with `ENOENT` and preventing window creation.

Serialize public settings reads through the existing store queue. Retain the Electron application handle before waiting for the first window, include recent main-process console output in startup failures, and bound teardown. If graceful Playwright shutdown stalls, reuse the runtime process-tree terminator so Electron renderer and GPU descendants are also reaped.

Refs #1007

## Verification

- Settings concurrent-first-read regression test: 16 simultaneous reads with a frozen clock
- Storage test suite: 275 passed, 1 skipped
- Electron cold-start E2E stress: 20/20 passed
- Desktop E2E suite after process-tree review fix: 18/18 passed
- Desktop typecheck passed
- Electron lifecycle helper tests passed