### PR TITLE
test: replace timing guesses with synchronization

### DIFF
--- a/apps/desktop/src/main/__tests__/cdp-bridge.test.ts
+++ b/apps/desktop/src/main/__tests__/cdp-bridge.test.ts
@@ -84,6 +84,10 @@ function nextMessage(ws: WebSocket): Promise<Record<string, unknown>> {
   return new Promise((resolve) => ws.once('message', (data) => resolve(JSON.parse(String(data)))));
 }
 
+function waitForCommand(debuggerEmitter: EventEmitter): Promise<unknown[]> {
+  return once(debuggerEmitter, 'command', { signal: AbortSignal.timeout(2_000) });
+}
+
 function withDifferentSecret(endpoint: string): string {
   return endpoint.replace(/\/[^/]+$/, '/0000000000000000');
 }
@@ -186,7 +190,7 @@ describe('CdpBridge', () => {
     const { bridge, cdpEndpoint } = await startBridge(asWebContents);
     const ws = await open(cdpEndpoint);
     const errored = nextMessage(ws);
-    const commandStarted = once(wc.debugger, 'command');
+    const commandStarted = waitForCommand(wc.debugger);
     ws.send(JSON.stringify({ id: 99, method: 'Page.navigate', params: {} }));
     await commandStarted;
     await bridge.stop();
@@ -203,7 +207,7 @@ describe('CdpBridge', () => {
     const { bridge, cdpEndpoint } = await startBridge(asWebContents);
     const ws = await open(cdpEndpoint);
     const errored = nextMessage(ws);
-    const commandStarted = once(wc.debugger, 'command');
+    const commandStarted = waitForCommand(wc.debugger);
     ws.send(JSON.stringify({ id: 5, method: 'Page.navigate', params: {}, sessionId: 'session-a' }));
     await commandStarted;
     await bridge.stop();
@@ -221,7 +225,7 @@ describe('CdpBridge', () => {
     const { cdpEndpoint } = await startBridge(asWebContents);
 
     const first = await open(cdpEndpoint);
-    const firstCommandStarted = once(wc.debugger, 'command');
+    const firstCommandStarted = waitForCommand(wc.debugger);
     first.send(JSON.stringify({ id: 1, method: 'Page.navigate', params: {} }));
     await firstCommandStarted;
     first.terminate();
@@ -235,7 +239,7 @@ describe('CdpBridge', () => {
     if (!second) throw new Error('could not reconnect after terminate');
 
     const answered = nextMessage(second);
-    const secondCommandStarted = once(wc.debugger, 'command');
+    const secondCommandStarted = waitForCommand(wc.debugger);
     second.send(JSON.stringify({ id: 1, method: 'Runtime.evaluate', params: {} }));
     await secondCommandStarted;
     resolvers[0]?.({ stale: true }); // the dead connection's command completes late

--- a/apps/desktop/src/main/__tests__/cdp-bridge.test.ts
+++ b/apps/desktop/src/main/__tests__/cdp-bridge.test.ts
@@ -6,7 +6,7 @@
 
 import { strict as assert } from 'node:assert';
 import { afterEach, describe, it } from 'node:test';
-import { EventEmitter } from 'node:events';
+import { EventEmitter, once } from 'node:events';
 import type { IncomingMessage } from 'node:http';
 import type { Duplex } from 'node:stream';
 import type { WebContents } from 'electron';
@@ -30,6 +30,7 @@ class MockDebugger extends EventEmitter {
   }
   sendCommand(method: string, params?: unknown, sessionId?: string) {
     this.calls.push({ method, params, sessionId });
+    this.emit('command');
     return this.impl(method, params, sessionId);
   }
 }
@@ -185,8 +186,9 @@ describe('CdpBridge', () => {
     const { bridge, cdpEndpoint } = await startBridge(asWebContents);
     const ws = await open(cdpEndpoint);
     const errored = nextMessage(ws);
+    const commandStarted = once(wc.debugger, 'command');
     ws.send(JSON.stringify({ id: 99, method: 'Page.navigate', params: {} }));
-    await new Promise((resolve) => setTimeout(resolve, 20)); // let the command register as pending
+    await commandStarted;
     await bridge.stop();
     const msg = (await errored) as { id: number; error?: { message: string } };
     assert.equal(msg.id, 99);
@@ -201,8 +203,9 @@ describe('CdpBridge', () => {
     const { bridge, cdpEndpoint } = await startBridge(asWebContents);
     const ws = await open(cdpEndpoint);
     const errored = nextMessage(ws);
+    const commandStarted = once(wc.debugger, 'command');
     ws.send(JSON.stringify({ id: 5, method: 'Page.navigate', params: {}, sessionId: 'session-a' }));
-    await new Promise((resolve) => setTimeout(resolve, 20)); // let the command register as pending
+    await commandStarted;
     await bridge.stop();
     const msg = (await errored) as { id: number; sessionId?: string; error?: { message: string } };
     assert.equal(msg.id, 5);
@@ -218,8 +221,9 @@ describe('CdpBridge', () => {
     const { cdpEndpoint } = await startBridge(asWebContents);
 
     const first = await open(cdpEndpoint);
+    const firstCommandStarted = once(wc.debugger, 'command');
     first.send(JSON.stringify({ id: 1, method: 'Page.navigate', params: {} }));
-    await new Promise((resolve) => setTimeout(resolve, 20)); // let id 1 register as pending
+    await firstCommandStarted;
     first.terminate();
 
     // The single slot frees only once the server has processed the close.
@@ -231,8 +235,9 @@ describe('CdpBridge', () => {
     if (!second) throw new Error('could not reconnect after terminate');
 
     const answered = nextMessage(second);
+    const secondCommandStarted = once(wc.debugger, 'command');
     second.send(JSON.stringify({ id: 1, method: 'Runtime.evaluate', params: {} }));
-    await new Promise((resolve) => setTimeout(resolve, 20));
+    await secondCommandStarted;
     resolvers[0]?.({ stale: true }); // the dead connection's command completes late
     resolvers[1]?.({ fresh: true });
     const msg = (await answered) as { id: number; result: Record<string, unknown> };

--- a/apps/desktop/src/main/__tests__/onboarding-service.test.ts
+++ b/apps/desktop/src/main/__tests__/onboarding-service.test.ts
@@ -89,24 +89,26 @@ describe('createOnboardingService.getSnapshot', () => {
   });
 
   it('resolves per-connection credentials in PARALLEL (@kenji perf gate)', async () => {
-    // Each hasCredential call sleeps 50ms. With 4 connections, serial =
-    // 200ms; parallel = ~50ms. Assert <= 150ms to leave a generous
-    // buffer for slow CI machines while still catching serialization.
     const conns = ['a', 'b', 'c', 'd'].map((slug) => realConnection({ slug }));
+    let started = 0;
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => { release = resolve; });
     const service = createOnboardingService(
       fakeDeps({
         listConnections: async () => conns,
         getDefaultSlug: async () => 'a',
         hasCredential: async () => {
-          await new Promise((resolve) => setTimeout(resolve, 50));
+          started += 1;
+          await gate;
           return true;
         },
       }),
     );
-    const start = Date.now();
-    await service.getSnapshot();
-    const elapsed = Date.now() - start;
-    assert.ok(elapsed < 150, `credential lookups must run in parallel; took ${elapsed}ms (serial would be ~200ms)`);
+    const snapshot = service.getSnapshot();
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    assert.equal(started, conns.length, 'every credential lookup must start before any lookup finishes');
+    release();
+    await snapshot;
   });
 
   it('credential-lookup error → treated as hasSecret=false, NEVER thrown to caller', async () => {

--- a/apps/desktop/src/main/__tests__/onboarding-service.test.ts
+++ b/apps/desktop/src/main/__tests__/onboarding-service.test.ts
@@ -106,9 +106,10 @@ describe('createOnboardingService.getSnapshot', () => {
     );
     const snapshot = service.getSnapshot();
     await new Promise<void>((resolve) => setImmediate(resolve));
-    assert.equal(started, conns.length, 'every credential lookup must start before any lookup finishes');
+    const startedBeforeRelease = started;
     release();
     await snapshot;
+    assert.equal(startedBeforeRelease, conns.length, 'every credential lookup must start before any lookup finishes');
   });
 
   it('credential-lookup error → treated as hasSecret=false, NEVER thrown to caller', async () => {

--- a/apps/desktop/src/main/__tests__/open-gateway.test.ts
+++ b/apps/desktop/src/main/__tests__/open-gateway.test.ts
@@ -586,11 +586,14 @@ describe('OpenGatewayService', () => {
     const status = await service.sync(createGatewaySettings({ enabled: true, port: 0, token: 'dev-token' }).openGateway);
     assert.ok(status.baseUrl);
 
-    const controllers: AbortController[] = [];
+    // Keep each unread response body reachable until cleanup. Undici closes an SSE
+    // connection when its response is garbage-collected, which would make the stream
+    // count depend on GC timing instead of the gateway limit under test.
+    const streams: Array<{ controller: AbortController; response: Response }> = [];
     try {
       for (let index = 0; index < 3; index += 1) {
         const opened = await openEventStream(status.baseUrl, 'same-session');
-        controllers.push(opened.controller);
+        streams.push(opened);
         assert.equal(opened.response.status, 200);
       }
       assert.equal(service.getStatus().activeEventStreams, 3);
@@ -603,7 +606,7 @@ describe('OpenGatewayService', () => {
 
       for (let index = 0; index < 7; index += 1) {
         const opened = await openEventStream(status.baseUrl, `other-${index}`);
-        controllers.push(opened.controller);
+        streams.push(opened);
         assert.equal(opened.response.status, 200);
       }
       assert.equal(service.getStatus().activeEventStreams, 10);
@@ -614,7 +617,7 @@ describe('OpenGatewayService', () => {
       assert.doesNotMatch(globalRejected.headers.get('content-type') ?? '', /^text\/event-stream/);
       assert.equal(service.getStatus().activeEventStreams, 10);
     } finally {
-      for (const controller of controllers) controller.abort();
+      for (const stream of streams) stream.controller.abort();
       await waitFor(() => service.getStatus().activeEventStreams === 0);
     }
   });

--- a/apps/desktop/src/main/__tests__/rive-workflow-tool.test.ts
+++ b/apps/desktop/src/main/__tests__/rive-workflow-tool.test.ts
@@ -137,6 +137,8 @@ describe('RiveWorkflow tool and CLI bridge', { concurrency: false }, () => {
     await withFakeRive('ignore-term', async (riveBin, cwd) => {
       const pidFile = join(cwd, 'pid');
       const controller = new AbortController();
+      let childReady!: () => void;
+      const childReadyPromise = new Promise<void>((resolve) => { childReady = resolve; });
       const promise = runRiveCli({
         action: 'workflow_status',
         workflowRunId: 'wfrun_ignore_term',
@@ -145,8 +147,21 @@ describe('RiveWorkflow tool and CLI bridge', { concurrency: false }, () => {
         riveBin,
         env: { ...process.env, PID_FILE: pidFile },
         abortSignal: controller.signal,
+        emitOutput: (stream, chunk) => {
+          if (stream === 'stdout' && chunk.includes('RIVE_CHILD_READY')) childReady();
+        },
       });
-      await waitForFile(pidFile);
+      let readyTimer: ReturnType<typeof setTimeout> | undefined;
+      try {
+        await Promise.race([
+          childReadyPromise,
+          new Promise<never>((_, reject) => {
+            readyTimer = setTimeout(() => reject(new Error('timed out waiting for the fake Rive child')), 2_000);
+          }),
+        ]);
+      } finally {
+        if (readyTimer) clearTimeout(readyTimer);
+      }
       const pid = Number((await readFile(pidFile, 'utf8')).trim());
       controller.abort();
       await assert.rejects(promise, (error) => {
@@ -282,6 +297,7 @@ function fakeRiveScript(mode: string): string {
       '#!/bin/sh',
       'trap "" TERM',
       'echo $$ > "$PID_FILE"',
+      'echo RIVE_CHILD_READY',
       'sleep 20',
       'echo \'{"protocol":{"state":"completed"},"display":{"summary":"late"}}\'',
       '',
@@ -327,19 +343,6 @@ function fakeRiveScript(mode: string): string {
     'JSON',
     '',
   ].join('\n');
-}
-
-async function waitForFile(path: string): Promise<void> {
-  const startedAt = Date.now();
-  while (Date.now() - startedAt < 1000) {
-    try {
-      await readFile(path, 'utf8');
-      return;
-    } catch {
-      await new Promise((resolve) => setTimeout(resolve, 10));
-    }
-  }
-  throw new Error(`timed out waiting for ${path}`);
 }
 
 async function repoRoot(): Promise<string> {

--- a/packages/headless/src/__tests__/ab-run.test.ts
+++ b/packages/headless/src/__tests__/ab-run.test.ts
@@ -139,13 +139,56 @@ describe('runAbComparison', () => {
     ]);
   });
 
-  test('drains every started pair and arm before propagating a rejection', async () => {
+  test('drains the sibling arm before propagating a pair rejection', async () => {
+    const started: string[] = [];
+    const finished: string[] = [];
+    let bothStarted!: () => void;
+    const bothStartedPromise = new Promise<void>((resolve) => { bothStarted = resolve; });
+    let releaseSibling!: () => void;
+    const siblingMayFinish = new Promise<void>((resolve) => { releaseSibling = resolve; });
+    const run = runAbComparison({
+      runId: 'ab-run',
+      arms: [
+        { id: 'maka', kind: 'harness', fingerprint: sha256('maka') },
+        { id: 'opencode', kind: 'harness', fingerprint: sha256('opencode') },
+      ],
+      evaluationTasks: [
+        { id: 't1', path: '/tasks/t1' },
+      ],
+      reps: 1,
+      maxConcurrency: 1,
+      runArm: async ({ arm, task }) => {
+        const id = `${task.id}:${arm.id}`;
+        started.push(id);
+        if (started.length === 2) bothStarted();
+        await bothStartedPromise;
+        if (id === 't1:maka') throw new Error('arm failed');
+        await siblingMayFinish;
+        finished.push(id);
+        return completed(task.id, true);
+      },
+    });
+
+    let rejectionObserved = false;
+    const rejection = assert.rejects(run, /arm failed/).then(() => { rejectionObserved = true; });
+    await bothStartedPromise;
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    const rejectedBeforeSiblingFinished = rejectionObserved;
+    releaseSibling();
+    await rejection;
+
+    assert.equal(rejectedBeforeSiblingFinished, false, 'the pair must keep draining its sibling arm before rejecting');
+    assert.deepEqual(started, ['t1:maka', 't1:opencode']);
+    assert.deepEqual(finished, ['t1:opencode']);
+  });
+
+  test('drains every started pair before propagating a rejection', async () => {
     const started: string[] = [];
     const finished: string[] = [];
     let allStarted!: () => void;
     const allStartedPromise = new Promise<void>((resolve) => { allStarted = resolve; });
-    let releaseSuccessful!: () => void;
-    const successfulMayFinish = new Promise<void>((resolve) => { releaseSuccessful = resolve; });
+    let releaseOtherPair!: () => void;
+    const otherPairMayFinish = new Promise<void>((resolve) => { releaseOtherPair = resolve; });
     const run = runAbComparison({
       runId: 'ab-run',
       arms: [
@@ -155,7 +198,6 @@ describe('runAbComparison', () => {
       evaluationTasks: [
         { id: 't1', path: '/tasks/t1' },
         { id: 't2', path: '/tasks/t2' },
-        { id: 't3', path: '/tasks/t3' },
       ],
       reps: 1,
       maxConcurrency: 2,
@@ -165,7 +207,7 @@ describe('runAbComparison', () => {
         if (started.length === 4) allStarted();
         await allStartedPromise;
         if (id === 't1:maka') throw new Error('arm failed');
-        await successfulMayFinish;
+        if (task.id === 't2') await otherPairMayFinish;
         finished.push(id);
         return completed(task.id, true);
       },
@@ -175,16 +217,13 @@ describe('runAbComparison', () => {
     const rejection = assert.rejects(run, /arm failed/).then(() => { rejectionObserved = true; });
     await allStartedPromise;
     await new Promise<void>((resolve) => setImmediate(resolve));
-    assert.equal(rejectionObserved, false, 'the comparison must keep draining active arms before rejecting');
-    releaseSuccessful();
+    const rejectedBeforeOtherPairFinished = rejectionObserved;
+    releaseOtherPair();
     await rejection;
 
-    assert.deepEqual(new Set(started), new Set([
-      't1:maka', 't1:opencode', 't2:maka', 't2:opencode',
-    ]));
-    assert.deepEqual(new Set(finished), new Set([
-      't1:opencode', 't2:maka', 't2:opencode',
-    ]));
+    assert.equal(rejectedBeforeOtherPairFinished, false, 'the comparison must keep draining every active pair before rejecting');
+    assert.deepEqual(new Set(started), new Set(['t1:maka', 't1:opencode', 't2:maka', 't2:opencode']));
+    assert.deepEqual(new Set(finished), new Set(['t1:opencode', 't2:maka', 't2:opencode']));
   });
 
   test('stops scheduling new pairs after the observed cost threshold is reached', async () => {

--- a/packages/headless/src/__tests__/ab-run.test.ts
+++ b/packages/headless/src/__tests__/ab-run.test.ts
@@ -144,6 +144,8 @@ describe('runAbComparison', () => {
     const finished: string[] = [];
     let allStarted!: () => void;
     const allStartedPromise = new Promise<void>((resolve) => { allStarted = resolve; });
+    let releaseSuccessful!: () => void;
+    const successfulMayFinish = new Promise<void>((resolve) => { releaseSuccessful = resolve; });
     const run = runAbComparison({
       runId: 'ab-run',
       arms: [
@@ -163,20 +165,24 @@ describe('runAbComparison', () => {
         if (started.length === 4) allStarted();
         await allStartedPromise;
         if (id === 't1:maka') throw new Error('arm failed');
-        await new Promise<void>((resolve) => setTimeout(resolve, 25));
+        await successfulMayFinish;
         finished.push(id);
         return completed(task.id, true);
       },
     });
 
-    await assert.rejects(run, /arm failed/);
-    const finishedAtReject = [...finished];
-    await new Promise<void>((resolve) => setTimeout(resolve, 40));
+    let rejectionObserved = false;
+    const rejection = assert.rejects(run, /arm failed/).then(() => { rejectionObserved = true; });
+    await allStartedPromise;
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    assert.equal(rejectionObserved, false, 'the comparison must keep draining active arms before rejecting');
+    releaseSuccessful();
+    await rejection;
 
     assert.deepEqual(new Set(started), new Set([
       't1:maka', 't1:opencode', 't2:maka', 't2:opencode',
     ]));
-    assert.deepEqual(new Set(finishedAtReject), new Set([
+    assert.deepEqual(new Set(finished), new Set([
       't1:opencode', 't2:maka', 't2:opencode',
     ]));
   });


### PR DESCRIPTION
## Summary

Remove fixed-delay timing assumptions from async tests and synchronize them with the events they actually depend on.

- Wait for CDP commands to enter the debugger, with a deadline used only to bound failure.
- Verify onboarding credential lookup concurrency with a controlled barrier instead of wall-clock duration.
- Verify sibling-arm draining and active-pair draining as two independent A/B contracts.
- Retain unread SSE responses so Undici garbage collection cannot change active stream counts; this restores the fix from #994 that #1005 accidentally reverted.
- Wait for the fake Rive child readiness signal instead of polling its PID file with a one-second timing budget.

Closes #1007
Refs #993

## Verification

- Desktop unit test suite: 2535/2535 passed
- Headless test suite: 955 passed, 1 skipped
- Changed async tests under repeated stress: 50/50 passed
- Rive abort/reap test stress: 10/10 passed
- SSE stream-limit test stress: 100/100 passed