### PR TITLE
fix: reland merges reverted by #1005's snapshot squash

### DIFF
--- a/apps/desktop/src/main/__tests__/composer-picker-trigger-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/composer-picker-trigger-contract.test.ts
@@ -1,0 +1,41 @@
+import { strict as assert } from 'node:assert';
+import { readFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+import { test } from 'node:test';
+
+const REPO_ROOT = resolve(import.meta.dirname, '../../../../..');
+
+async function read(relativePath: string): Promise<string> {
+  return readFile(resolve(REPO_ROOT, relativePath), 'utf8');
+}
+
+test('composer permission and model pickers opt into quiet trigger chrome', async () => {
+  const [composer, permissionMode, chatModelSwitcher, modelPicker] = await Promise.all([
+    read('packages/ui/src/composer.tsx'),
+    read('packages/ui/src/permission-mode-menu.tsx'),
+    read('packages/ui/src/chat-model-switcher.tsx'),
+    read('packages/ui/src/model-picker.tsx'),
+  ]);
+
+  assert.match(
+    composer,
+    /<PermissionModeSelect[\s\S]*?appearance="quiet"[\s\S]*?activeMode=/,
+    'the composer permission picker must opt out of field chrome',
+  );
+  assert.match(
+    permissionMode,
+    /<SelectTrigger[\s\S]*?appearance=\{props\.appearance\}/,
+    'PermissionModeSelect must forward its trigger appearance',
+  );
+
+  const composerModelPickers = chatModelSwitcher.match(/<ModelPicker[\s\S]*?>/g) ?? [];
+  assert.equal(composerModelPickers.length, 2, 'both composer model picker variants must remain on the shared ModelPicker');
+  for (const picker of composerModelPickers) {
+    assert.match(picker, /triggerAppearance="quiet"/, 'each composer model picker must opt out of field chrome');
+  }
+  assert.match(
+    modelPicker,
+    /<ModelPickerTrigger[\s\S]*?appearance=\{props\.triggerAppearance\}/,
+    'ModelPicker must forward its requested trigger appearance',
+  );
+});

--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -989,6 +989,7 @@ backends.register('ai-sdk', async (ctx) => {
     }),
     recordRunTrace: ctx.recordRunTrace,
     recordHistoryCompactCheckpoint: ctx.recordHistoryCompactCheckpoint,
+    loadTurnRuntimeEvents: ctx.loadTurnRuntimeEvents,
     recordActiveFullCompactBlock: ctx.recordActiveFullCompactBlock,
     recordSemanticCompactBlock: ctx.recordSemanticCompactBlock,
     newId: randomUUID,

--- a/packages/cli/src/runtime-bootstrap.ts
+++ b/packages/cli/src/runtime-bootstrap.ts
@@ -275,6 +275,7 @@ export async function createMakaCliRuntimeContext(
         maxOutputTokens: 4096,
       }),
       recordHistoryCompactCheckpoint: ctx.recordHistoryCompactCheckpoint,
+      loadTurnRuntimeEvents: ctx.loadTurnRuntimeEvents,
       systemPrompt: async ({ cwd }) => {
         const settings = await settingsStore.get();
         return buildCliSystemPrompt({

--- a/packages/core/src/__tests__/events.test.ts
+++ b/packages/core/src/__tests__/events.test.ts
@@ -45,5 +45,6 @@ describe('failureClassFromCompleteStopReason', () => {
     expect(failureClassFromCompleteStopReason('plan_handoff')).toBe(undefined);
     expect(failureClassFromCompleteStopReason('permission_handoff')).toBe(undefined);
     expect(failureClassFromCompleteStopReason('user_stop')).toBe(undefined);
+    expect(failureClassFromCompleteStopReason('context_budget_exhausted')).toBe('context_budget_exhausted');
   });
 });

--- a/packages/core/src/backend-types.ts
+++ b/packages/core/src/backend-types.ts
@@ -20,6 +20,12 @@ export interface BackendSendInput {
   runId?: string;
   /** Caller-generated turn id shared by the persisted UserMessage and every emitted event. */
   turnId: string;
+  /**
+   * The persisted initial user RuntimeEvent for this turn (the head anchor).
+   * Mid-turn capacity compaction keeps this event verbatim in every projection
+   * and needs its exact ledger identity for replay-checkable coverage.
+   */
+  headAnchorRuntimeEvent?: RuntimeEvent;
   text: string;
   attachments?: AttachmentRef[];
   /**

--- a/packages/core/src/events.ts
+++ b/packages/core/src/events.ts
@@ -492,17 +492,30 @@ export interface CompleteEvent extends BaseEvent {
     | 'plan_handoff'
     | 'permission_handoff'
     | 'step_limit'
-    | 'max_tokens';
+    | 'max_tokens'
+    | 'context_budget_exhausted';
+  /**
+   * Detail for `stopReason: 'context_budget_exhausted'` — the runtime could not
+   * produce a provider-safe request even after mid-turn compaction. A first-class
+   * outcome, not a provider context-length error.
+   */
+  contextBudgetExhaustedDetail?: ContextBudgetExhaustedDetail;
 }
+
+export type ContextBudgetExhaustedDetail =
+  | 'no_safe_completed_span'
+  | 'summarizer_failed'
+  | 'head_anchor_exceeds_capacity';
 
 export type CompleteStopReason = CompleteEvent['stopReason'];
 
 /** Stable failure taxonomy for complete events that did not finish the turn. */
 export function failureClassFromCompleteStopReason(
   reason: CompleteStopReason,
-): 'runtime_error' | 'tool_step_cap_reached' | undefined {
+): 'runtime_error' | 'tool_step_cap_reached' | 'context_budget_exhausted' | undefined {
   if (reason === 'error') return 'runtime_error';
   if (reason === 'step_limit') return 'tool_step_cap_reached';
+  if (reason === 'context_budget_exhausted') return 'context_budget_exhausted';
   return undefined;
 }
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -42,6 +42,7 @@ export type {
   AttachmentRef,
   AttachmentIngestItem,
   CompleteStopReason,
+  ContextBudgetExhaustedDetail,
 } from './events.js';
 export type {
   UserQuestion,

--- a/packages/core/src/usage-stats/types.ts
+++ b/packages/core/src/usage-stats/types.ts
@@ -213,6 +213,8 @@ export interface CompactionDecisionDiagnostic {
   stage: CompactionStageDiagnostic;
   sourceKind: CompactionSourceDiagnosticKind;
   decision: CompactionDecisionDiagnosticKind;
+  /** Compaction phase; absent on legacy data = pre_turn. */
+  phase?: 'pre_turn' | 'mid_turn';
   boundaryKind?: string;
   boundaryIds?: string[];
   coveredTurns?: number;

--- a/packages/headless/harbor/opencode_agent.py
+++ b/packages/headless/harbor/opencode_agent.py
@@ -16,6 +16,19 @@ from harbor.models.agent.context import AgentContext
 
 from trial_pricing import estimate_cost, pricing_from_env
 
+_UPSTREAM_CURL_INSTALL_COMMAND = "apt-get update && apt-get install -y curl"
+_RETRYING_CURL_INSTALL_COMMAND = (
+    "command -v curl >/dev/null 2>&1 && exit 0; "
+    "status=1; "
+    "for attempt in 1 2 3; do "
+    "apt-get -o Acquire::Retries=3 update && "
+    "apt-get -o Acquire::Retries=3 install -y curl && exit 0; "
+    "status=$?; "
+    '[ "$attempt" -eq 3 ] && exit "$status"; '
+    "sleep $((attempt * 5)); "
+    'done; exit "$status"'
+)
+
 
 class MakaOpenCodeAgent(OpenCode):
     """Run Harbor's OpenCode agent while normalizing trial cost fields."""
@@ -23,6 +36,24 @@ class MakaOpenCodeAgent(OpenCode):
     @staticmethod
     def name() -> str:
         return "opencode"
+
+    async def exec_as_root(
+        self,
+        environment: BaseEnvironment,
+        command: str,
+        env: dict[str, str] | None = None,
+        cwd: str | None = None,
+        timeout_sec: int | None = None,
+    ) -> Any:
+        if command == _UPSTREAM_CURL_INSTALL_COMMAND:
+            command = _RETRYING_CURL_INSTALL_COMMAND
+        return await super().exec_as_root(
+            environment,
+            command=command,
+            env=env,
+            cwd=cwd,
+            timeout_sec=timeout_sec,
+        )
 
     @with_prompt_template
     async def run(

--- a/packages/headless/src/__tests__/cell-output.test.ts
+++ b/packages/headless/src/__tests__/cell-output.test.ts
@@ -24,6 +24,7 @@ describe('Harbor cell output contract', () => {
             cacheMissInputSource: 'explicit',
             reasoning: 2,
             total: 17,
+            runtimeSteps: 1,
             costUsd: 0.00123,
             systemPromptHash: 'sha256:prompt-a',
             promptSegments: [
@@ -49,6 +50,7 @@ describe('Harbor cell output contract', () => {
             cacheRead: 2,
             cacheCreation: 1,
             total: 10,
+            runtimeSteps: 1,
             costUsd: 0.004,
             systemPromptHash: 'sha256:prompt-a',
           },
@@ -96,7 +98,7 @@ describe('Harbor cell output contract', () => {
         actualToolNames: ['Bash', 'Read'],
         actualToolCallCounts: { Bash: 1, Read: 1 },
       },
-      steps: 5,
+      steps: 2,
       durationMs: 150,
       startedAt: 100,
       finishedAt: 250,
@@ -132,6 +134,34 @@ describe('Harbor cell output contract', () => {
       systemPromptHash: 'sha256:prompt-a',
       pricingProfile: 'deepseek-v4-flash-tbench-v1',
     });
+  });
+
+  test('persists a real-provider failure when token usage is unavailable', () => {
+    const output = buildHarborCellOutput({
+      invocation: {
+        invocationId: 'inv-missing-usage',
+        runId: 'run-missing-usage',
+        sessionId: 'session-1',
+        turnId: 'turn-1',
+        status: 'failed',
+        failure: { class: 'network' },
+        events: [runtimeEvent({ id: 'user-event', role: 'user', author: 'user' })],
+        startedAt: 100,
+        finishedAt: 250,
+      },
+      runtimeEventsPath: '/logs/agent/runtime-events.jsonl',
+      executionIdentity: {
+        llmConnectionSlug: 'zai-coding-plan',
+        model: 'glm-5.2',
+        systemPromptHash: 'sha256:prompt-a',
+        pricingProfile: 'zai-public',
+      },
+    });
+
+    assert.equal(output.status, 'failed');
+    assert.equal(output.errorClass, 'network');
+    assert.equal('tokenSummary' in output, false);
+    assert.deepEqual(validateHarborCellOutput(output), output);
   });
 
   test('keeps output when runtime emits more than one prompt hash', () => {
@@ -185,10 +215,99 @@ describe('Harbor cell output contract', () => {
       runtimeEventsPath: '/logs/agent/runtime-events.jsonl',
     });
 
+    assert.ok(output.tokenSummary);
     assert.equal(output.tokenSummary.input, 13);
     assert.equal(output.tokenSummary.output, 12);
     assert.equal(output.tokenSummary.reasoning, 2);
     assert.equal(output.tokenSummary.total, 27);
+  });
+
+  test('counts completed model steps instead of streaming event chunks', () => {
+    const partialChunks = Array.from({ length: 100 }, (_, index) => runtimeEvent({
+      id: `partial-${index}`,
+      partial: true,
+      content: { kind: 'text', text: 'x' },
+    }));
+    const output = buildHarborCellOutput({
+      invocation: {
+        invocationId: 'inv-stream-steps',
+        runId: 'run-stream-steps',
+        sessionId: 'session-1',
+        turnId: 'turn-1',
+        status: 'failed',
+        failure: { class: 'network' },
+        events: [
+          ...partialChunks,
+          runtimeEvent({ id: 'final-thinking', content: { kind: 'thinking', text: 'done' } }),
+          runtimeEvent({ id: 'final-text', content: { kind: 'text', text: '' } }),
+        ],
+        startedAt: 100,
+        finishedAt: 250,
+      },
+      runtimeEventsPath: '/logs/agent/runtime-events.jsonl',
+    });
+
+    assert.equal(output.steps, 1);
+  });
+
+  test('counts a pure-tool step when runtime usage does not report steps', () => {
+    const output = buildHarborCellOutput({
+      invocation: {
+        invocationId: 'inv-tool-steps',
+        runId: 'run-tool-steps',
+        sessionId: 'session-1',
+        turnId: 'turn-1',
+        status: 'completed',
+        events: [
+          runtimeEvent({
+            id: 'tool-step',
+            content: { kind: 'function_call', id: 'call-1', name: 'Read', args: {} },
+            refs: { toolCallId: 'call-1', stepId: 'step-1' },
+          }),
+          runtimeEvent({
+            id: 'final-text',
+            content: { kind: 'text', text: 'done' },
+            refs: { providerEventId: 'step-2' },
+          }),
+        ],
+        startedAt: 100,
+        finishedAt: 250,
+      },
+      runtimeEventsPath: '/logs/agent/runtime-events.jsonl',
+    });
+
+    assert.equal(output.steps, 2);
+  });
+
+  test('uses step identity only for turns whose runtime step usage is unavailable', () => {
+    const output = buildHarborCellOutput({
+      invocation: {
+        invocationId: 'inv-mixed-steps',
+        runId: 'run-mixed-steps',
+        sessionId: 'session-1',
+        turnId: 'turn-2',
+        status: 'failed',
+        failure: { class: 'tool_step_cap_reached' },
+        events: [
+          runtimeEvent({
+            id: 'reported-turn',
+            turnId: 'turn-1',
+            actions: { tokenUsage: { input: 1, output: 1, runtimeSteps: 1 } },
+          }),
+          runtimeEvent({
+            id: 'unmetered-tool-step',
+            turnId: 'turn-2',
+            content: { kind: 'function_call', id: 'call-2', name: 'Read', args: {} },
+            refs: { toolCallId: 'call-2', stepId: 'step-2' },
+          }),
+        ],
+        startedAt: 100,
+        finishedAt: 250,
+      },
+      runtimeEventsPath: '/logs/agent/runtime-events.jsonl',
+    });
+
+    assert.equal(output.steps, 2);
   });
 
   test('summarizes context budget diagnostics from token usage events', () => {

--- a/packages/headless/src/__tests__/fixed-prompt-controller.test.ts
+++ b/packages/headless/src/__tests__/fixed-prompt-controller.test.ts
@@ -751,7 +751,7 @@ describe('fixed prompt controller', () => {
     });
   });
 
-  test('uses early execution identity to attribute a timeout before cell output', async () => {
+  test('excludes an early-attested timeout without a usage checkpoint', async () => {
     await withDir(async (dir) => {
       const systemPromptPath = join(dir, 'system_prompt.md');
       await writeFile(systemPromptPath, 'fixed prompt\n', 'utf8');
@@ -781,8 +781,8 @@ describe('fixed prompt controller', () => {
       const event = result.events[0];
       assert.equal(event?.type, 'task_budget_exhausted');
       if (event?.type !== 'task_budget_exhausted') assert.fail('expected budget exhaustion event');
-      assert.equal(event.eligible, true);
-      assert.equal(event.evidenceErrorClass, undefined);
+      assert.equal(event.eligible, false);
+      assert.equal(event.evidenceErrorClass, 'missing_token_usage');
       assert.deepEqual(
         (event as { executionIdentity?: typeof executionIdentity }).executionIdentity,
         executionIdentity,
@@ -1743,6 +1743,83 @@ describe('fixed prompt controller', () => {
     });
   });
 
+  test('records missing real-provider usage as a plumbing failure', async () => {
+    await withDir(async (dir) => {
+      const systemPromptPath = join(dir, 'system_prompt.md');
+      await writeFile(systemPromptPath, 'fixed prompt\n', 'utf8');
+
+      const result = await runFixedPromptController({
+        runId: 'run-1',
+        roundId: 'round-1',
+        config,
+        systemPromptPath,
+        resultsJsonlPath: join(dir, 'results.jsonl'),
+        resultsTsvPath: join(dir, 'results.tsv'),
+        tasks: [{ id: 'task-a', path: '/bench/task-a' }],
+        requireExecutionIdentity: true,
+        expectedPricingProfile: 'test-profile',
+        harborRunner: async () => harborOutput({
+          taskId: 'task-a',
+          omitTokenSummary: true,
+          executionIdentity: {
+            llmConnectionSlug: 'fake',
+            model: 'fake-model',
+            systemPromptHash: hashSystemPrompt('fixed prompt\n'),
+            pricingProfile: 'test-profile',
+          },
+        }),
+        now: () => 100,
+        newId: idFactory(),
+      });
+
+      assert.equal(result.events[0]?.type, 'task_plumbing_failed');
+      assert.equal(result.events[0]?.eligible, false);
+      assert.equal(result.events[0]?.errorClass, 'missing_token_usage');
+    });
+  });
+
+  test('excludes an attested failed cell when usage is unavailable', async () => {
+    await withDir(async (dir) => {
+      const systemPromptPath = join(dir, 'system_prompt.md');
+      const resultsTsvPath = join(dir, 'results.tsv');
+      await writeFile(systemPromptPath, 'fixed prompt\n', 'utf8');
+
+      const result = await runFixedPromptController({
+        runId: 'run-1',
+        roundId: 'round-1',
+        config,
+        systemPromptPath,
+        resultsJsonlPath: join(dir, 'results.jsonl'),
+        resultsTsvPath,
+        tasks: [{ id: 'task-a', path: '/bench/task-a' }],
+        requireExecutionIdentity: true,
+        expectedPricingProfile: 'test-profile',
+        harborRunner: async () => harborOutput({
+          taskId: 'task-a',
+          status: 'failed',
+          errorClass: 'tool_step_cap_reached',
+          omitTokenSummary: true,
+          executionIdentity: {
+            llmConnectionSlug: 'fake',
+            model: 'fake-model',
+            systemPromptHash: hashSystemPrompt('fixed prompt\n'),
+            pricingProfile: 'test-profile',
+          },
+        }),
+        now: () => 100,
+        newId: idFactory(),
+      });
+
+      assert.equal(result.events[0]?.type, 'task_plumbing_failed');
+      assert.equal(result.events[0]?.eligible, false);
+      assert.equal(result.events[0]?.errorClass, 'missing_token_usage');
+      assert.equal('tokenSummary' in result.events[0]!, false);
+      const [, row] = (await readFile(resultsTsvPath, 'utf8')).trimEnd().split('\n');
+      assert.equal(row?.split('\t')[7], '');
+      assert.equal(row?.split('\t')[8], '');
+    });
+  });
+
   test('records prompt hash mismatches as plumbing failures', async () => {
     await withDir(async (dir) => {
       const systemPromptPath = join(dir, 'system_prompt.md');
@@ -1901,6 +1978,7 @@ function harborOutput(input: {
   promptHash?: string;
   omitPromptHash?: boolean;
   tokenSummary?: HarborTaskRunOutput['cell']['tokenSummary'];
+  omitTokenSummary?: boolean;
   contextBudgetPolicy?: HarborTaskRunOutput['cell']['contextBudgetPolicy'];
   contextBudgetSummary?: HarborTaskRunOutput['cell']['contextBudgetSummary'];
   continuationSummary?: HarborTaskRunOutput['cell']['continuationSummary'];
@@ -1919,7 +1997,9 @@ function harborOutput(input: {
       traceEventsPath: `/logs/${input.taskId}/events.jsonl`,
       ...(input.omitPromptHash ? {} : { promptHash: input.promptHash ?? hashSystemPrompt('fixed prompt\n') }),
       ...(input.executionIdentity ? { executionIdentity: input.executionIdentity } : {}),
-      tokenSummary: input.tokenSummary ?? tokenSummary({ input: 1, output: 2, reasoning: 0, total: 3, costUsd: 0.02 }),
+      ...(input.omitTokenSummary
+        ? {}
+        : { tokenSummary: input.tokenSummary ?? tokenSummary({ input: 1, output: 2, reasoning: 0, total: 3, costUsd: 0.02 }) }),
       ...(input.contextBudgetPolicy ? { contextBudgetPolicy: input.contextBudgetPolicy } : {}),
       ...(input.contextBudgetSummary ? { contextBudgetSummary: input.contextBudgetSummary } : {}),
       ...(input.continuationSummary ? { continuationSummary: input.continuationSummary } : {}),

--- a/packages/headless/src/__tests__/harbor-adapter.test.ts
+++ b/packages/headless/src/__tests__/harbor-adapter.test.ts
@@ -1419,6 +1419,16 @@ class OpenCode:
     def _error_messages(self):
         return []
 
+    async def exec_as_root(self, environment, command, **kwargs):
+        return await environment.exec(command, **kwargs)
+
+    async def install(self, environment):
+        await self.exec_as_root(
+            environment,
+            command="apt-get update && apt-get install -y curl",
+            env={"DEBIAN_FRONTEND": "noninteractive"},
+        )
+
     async def run(self, instruction, environment, context):
         raise AssertionError("MakaOpenCodeAgent should use its stop-sentinel run path")
 
@@ -1480,6 +1490,13 @@ try:
             environment.agent_commands.append((command, env or {}))
         agent.exec_as_agent = exec_as_agent
 
+        asyncio.run(agent.install(environment))
+        install_command, install_kwargs = environment.root_commands[0]
+        assert "for attempt in 1 2 3" in install_command, install_command
+        assert "Acquire::Retries=3" in install_command, install_command
+        assert "sleep $((attempt * 5))" in install_command, install_command
+        assert install_kwargs["env"] == {"DEBIAN_FRONTEND": "noninteractive"}, install_kwargs
+
         asyncio.run(agent.run("hi", environment, context))
         command, env = next(item for item in environment.agent_commands if "opencode --model=" in item[0])
         assert "opencode-stop-runner.mjs" in command, command
@@ -1504,7 +1521,7 @@ try:
         assert 'cat --' not in command, command
         assert "test-zai-key" not in command, command
         assert "test-zai-key" not in json.dumps(env), env
-        assert environment.root_commands == [], environment.root_commands
+        assert len(environment.root_commands) == 1, environment.root_commands
         assert os.environ.get("ZAI_API_KEY") is None
         assert os.environ.get("ZAI_BASE_URL") is None
 

--- a/packages/headless/src/__tests__/harbor-cell.test.ts
+++ b/packages/headless/src/__tests__/harbor-cell.test.ts
@@ -183,6 +183,39 @@ function registerStepCapThenCompleteBackend(seen: { backend?: StepCapThenComplet
   };
 }
 
+class UnmeteredStepCapThenCompleteBackend extends StepCapThenCompleteBackend {
+  async *send(input: BackendSendInput): AsyncIterable<SessionEvent> {
+    if (this.prompts.length > 0) {
+      yield* super.send(input);
+      return;
+    }
+    const ts = Date.now();
+    this.prompts.push(input.text);
+    this.cwds.push(this.ctx.header.cwd);
+    yield {
+      type: 'tool_start',
+      id: 'unmetered-tool-step',
+      turnId: input.turnId,
+      ts,
+      toolUseId: 'call-1',
+      toolName: 'Read',
+      args: { path: 'README.md' },
+      stepId: 'step-1',
+    };
+    yield { type: 'complete', id: 'unmetered-step-cap', turnId: input.turnId, ts, stopReason: 'step_limit' };
+  }
+}
+
+function registerUnmeteredStepCapThenCompleteBackend(seen: { backend?: UnmeteredStepCapThenCompleteBackend }) {
+  return (registry: BackendRegistry): void => {
+    registry.register('fake', (ctx) => {
+      const backend = new UnmeteredStepCapThenCompleteBackend({ sessionId: ctx.sessionId, header: ctx.header });
+      seen.backend = backend;
+      return backend;
+    });
+  };
+}
+
 class StepCapThenThrowBackend extends StepCapThenCompleteBackend {
   async *send(input: BackendSendInput): AsyncIterable<SessionEvent> {
     if (this.prompts.length > 0) {
@@ -382,6 +415,7 @@ describe('runHarborCell', () => {
       assert.equal(result.output.status, 'completed');
       assert.equal(result.output.promptHash, 'sha256:cell-prompt');
       assert.equal(result.output.runtimeEventsPath, join(outputDir, HARBOR_CELL_RUNTIME_EVENTS_FILENAME));
+      assert.ok(result.output.tokenSummary);
       assert.equal(result.output.tokenSummary.costUsd, 0.0042);
       assert.deepEqual(result.output.executionIdentity, {
         llmConnectionSlug: 'fake',
@@ -507,12 +541,13 @@ describe('runHarborCell', () => {
         continuedTurns: 1,
         stepCapHits: 1,
         capExhausted: false,
-        totalRuntimeSteps: 50,
+        totalRuntimeSteps: 51,
         turns: [
           { turnIndex: 0, status: 'failed', stepCapHit: true, runtimeSteps: 50 },
-          { turnIndex: 1, status: 'completed', stepCapHit: false, runtimeSteps: 0 },
+          { turnIndex: 1, status: 'completed', stepCapHit: false, runtimeSteps: 1 },
         ],
       });
+      assert.ok(result.output.tokenSummary);
       assert.equal(result.output.tokenSummary.input, 13);
       assert.equal(result.output.tokenSummary.costUsd, 0.03);
       const runtimeEvents = await readFile(join(outputDir, HARBOR_CELL_RUNTIME_EVENTS_FILENAME), 'utf8');
@@ -601,6 +636,32 @@ describe('runHarborCell', () => {
     });
   });
 
+  test('stops continuation at the step budget when the capped turn has no usage', async () => {
+    await withDirs(async ({ workspaceDir, outputDir, storageRoot }) => {
+      const seen: { backend?: UnmeteredStepCapThenCompleteBackend } = {};
+      const result = await runHarborCell({
+        config,
+        instruction: 'solve the benchmark task',
+        cwd: workspaceDir,
+        outputDir,
+        storageRoot,
+        registerBackends: registerUnmeteredStepCapThenCompleteBackend(seen),
+        continuationPolicy: {
+          enabled: true,
+          maxTurns: 3,
+          maxTotalRuntimeSteps: 1,
+          prompt: 'Continue neutrally from current workspace.',
+        },
+      });
+
+      assert.equal(result.output.status, 'failed');
+      assert.equal(result.output.errorClass, 'tool_step_cap_reached');
+      assert.deepEqual(seen.backend?.prompts, ['solve the benchmark task']);
+      assert.equal(result.output.continuationSummary?.totalRuntimeSteps, 1);
+      assert.equal('tokenSummary' in result.output, false);
+    });
+  });
+
   test('does not spend continuation step budget from diagnostic event count', async () => {
     await withDirs(async ({ workspaceDir, outputDir, storageRoot }) => {
       const seen: { backend?: NoisyStepCapThenCompleteBackend } = {};
@@ -632,10 +693,10 @@ describe('runHarborCell', () => {
         continuedTurns: 1,
         stepCapHits: 1,
         capExhausted: false,
-        totalRuntimeSteps: 50,
+        totalRuntimeSteps: 51,
         turns: [
           { turnIndex: 0, status: 'failed', stepCapHit: true, runtimeSteps: 50 },
-          { turnIndex: 1, status: 'completed', stepCapHit: false, runtimeSteps: 0 },
+          { turnIndex: 1, status: 'completed', stepCapHit: false, runtimeSteps: 1 },
         ],
       });
     });
@@ -674,11 +735,11 @@ describe('runHarborCell', () => {
         continuedTurns: 2,
         stepCapHits: 2,
         capExhausted: false,
-        totalRuntimeSteps: 100,
+        totalRuntimeSteps: 101,
         turns: [
           { turnIndex: 0, status: 'failed', stepCapHit: true, runtimeSteps: 50 },
           { turnIndex: 1, status: 'failed', stepCapHit: true, runtimeSteps: 50 },
-          { turnIndex: 2, status: 'completed', stepCapHit: false, runtimeSteps: 0 },
+          { turnIndex: 2, status: 'completed', stepCapHit: false, runtimeSteps: 1 },
         ],
       });
     });
@@ -2081,6 +2142,7 @@ console.log(JSON.stringify({ type: 'agent_end', messages: [{ role: 'assistant', 
       assert.equal(argv.at(-1), '-p');
       assert.equal(argv.includes('solve through default pi transport'), false);
       assert.equal(await readFile(join(workspaceDir, 'pi-default-stdin.txt'), 'utf8'), 'solve through default pi transport');
+      assert.ok(result.output.tokenSummary);
       assert.equal(result.output.tokenSummary.input, 5);
       assert.equal(result.output.tokenSummary.output, 2);
       assert.equal(result.output.tokenSummary.costUsd, 0.0003);

--- a/packages/headless/src/__tests__/runtime-policy-ab-lifecycle.test.ts
+++ b/packages/headless/src/__tests__/runtime-policy-ab-lifecycle.test.ts
@@ -246,6 +246,7 @@ test('pilot candidate pass against an attested baseline timeout can launch full 
               systemPromptHash: hashSystemPrompt(runInput.systemPrompt),
               pricingProfile: 'test-profile',
             },
+            tokenSummary: tokenSummary({ input: 4, output: 6, reasoning: 0, total: 10, costUsd: 0.01 }),
           });
         }
         return output(runInput, candidate);

--- a/packages/headless/src/cell-output.ts
+++ b/packages/headless/src/cell-output.ts
@@ -102,7 +102,7 @@ export interface HarborCellOutput {
   runtimeEventsPath: string;
   promptHash?: string;
   executionIdentity?: HarborCellExecutionIdentity;
-  tokenSummary: HarborCellTokenSummary;
+  tokenSummary?: HarborCellTokenSummary;
   contextBudgetPolicy?: HarborCellContextBudgetPolicySnapshot;
   contextBudgetSummary?: HarborCellContextBudgetSummary;
   continuationSummary?: HarborCellContinuationSummary;
@@ -124,6 +124,7 @@ export function buildHarborCellOutput(input: {
   taskToolSummaryEnabled?: boolean;
 }): HarborCellOutput {
   const { invocation } = input;
+  const tokenSummary = summarizeCellTokens(invocation.events);
   return {
     schemaVersion: HARBOR_CELL_OUTPUT_SCHEMA_VERSION,
     status: invocation.status,
@@ -131,13 +132,13 @@ export function buildHarborCellOutput(input: {
     runtimeEventsPath: input.runtimeEventsPath,
     ...promptHashField(invocation.events),
     ...(input.executionIdentity ? { executionIdentity: input.executionIdentity } : {}),
-    tokenSummary: summarizeCellTokens(invocation.events),
+    ...(tokenSummary ? { tokenSummary } : {}),
     ...(input.contextBudgetPolicy ? { contextBudgetPolicy: input.contextBudgetPolicy } : {}),
     ...contextBudgetSummaryField(invocation.events),
     ...(input.continuationSummary ? { continuationSummary: input.continuationSummary } : {}),
     toolSummary: summarizeCellTools(invocation.events),
     ...taskToolSummaryField(invocation.events, input.taskToolSummaryEnabled ?? false),
-    steps: invocation.events.length,
+    steps: countRuntimeSteps(invocation.events),
     durationMs: invocation.finishedAt - invocation.startedAt,
     startedAt: invocation.startedAt,
     finishedAt: invocation.finishedAt,
@@ -148,6 +149,26 @@ export function buildHarborCellOutput(input: {
       turnId: invocation.turnId,
     },
   };
+}
+
+export function countRuntimeSteps(events: readonly RuntimeEvent[]): number {
+  const turns = new Map<string, { reported: number; stepIds: Set<string>; legacyTextSteps: number }>();
+  for (const event of events) {
+    const turn = turns.get(event.turnId) ?? { reported: 0, stepIds: new Set<string>(), legacyTextSteps: 0 };
+    turn.reported += event.actions?.tokenUsage?.runtimeSteps ?? 0;
+    turns.set(event.turnId, turn);
+    if (event.role !== 'model' || event.partial === true) continue;
+    const stepId = event.refs?.stepId ?? event.refs?.providerEventId;
+    if (stepId) {
+      turn.stepIds.add(stepId);
+    } else if (event.content?.kind === 'text') {
+      turn.legacyTextSteps += 1;
+    }
+  }
+  return [...turns.values()].reduce(
+    (sum, turn) => sum + (turn.reported > 0 ? turn.reported : turn.stepIds.size + turn.legacyTextSteps),
+    0,
+  );
 }
 
 export function hashHarborSystemPrompt(systemPrompt: string): string {
@@ -169,7 +190,9 @@ export function validateHarborCellOutput(value: unknown): HarborCellOutput {
   const executionIdentity = 'executionIdentity' in value
     ? validateHarborCellExecutionIdentity(value.executionIdentity)
     : undefined;
-  const tokenSummary = validateHarborCellTokenSummary(value.tokenSummary);
+  const tokenSummary = 'tokenSummary' in value
+    ? validateHarborCellTokenSummary(value.tokenSummary)
+    : undefined;
   const contextBudgetPolicy = 'contextBudgetPolicy' in value
     ? validateContextBudgetPolicySnapshot(value.contextBudgetPolicy)
     : undefined;
@@ -195,7 +218,7 @@ export function validateHarborCellOutput(value: unknown): HarborCellOutput {
     runtimeEventsPath,
     ...(promptHash !== undefined ? { promptHash } : {}),
     ...(executionIdentity !== undefined ? { executionIdentity } : {}),
-    tokenSummary,
+    ...(tokenSummary ? { tokenSummary } : {}),
     ...(contextBudgetPolicy !== undefined ? { contextBudgetPolicy } : {}),
     ...(contextBudgetSummary !== undefined ? { contextBudgetSummary } : {}),
     ...(continuationSummary !== undefined ? { continuationSummary } : {}),
@@ -271,7 +294,7 @@ function requireContinuationTurns(value: unknown): HarborCellContinuationTurnSum
   });
 }
 
-export function summarizeCellTokens(events: readonly RuntimeEvent[]): HarborCellTokenSummary {
+export function summarizeCellTokens(events: readonly RuntimeEvent[]): HarborCellTokenSummary | undefined {
   const summary: HarborCellTokenSummary = {
     input: 0,
     output: 0,
@@ -286,9 +309,11 @@ export function summarizeCellTokens(events: readonly RuntimeEvent[]): HarborCell
   };
   let sawExplicitCacheMiss = false;
   let sawDerivedCacheMiss = false;
+  let sawUsage = false;
   for (const event of events) {
     const usage = event.actions?.tokenUsage;
     if (!usage) continue;
+    sawUsage = true;
     summary.input += usage.input ?? 0;
     summary.output += usage.output ?? 0;
     const cacheHitInput = usage.cacheHitInput ?? usage.cacheRead ?? 0;
@@ -312,6 +337,7 @@ export function summarizeCellTokens(events: readonly RuntimeEvent[]): HarborCell
     summary.total += usage.total ?? (usage.input ?? 0) + (usage.output ?? 0) + (usage.reasoning ?? 0);
     summary.costUsd += usage.costUsd ?? 0;
   }
+  if (!sawUsage) return undefined;
   if (sawExplicitCacheMiss) {
     summary.cacheMissInputSource = 'explicit';
   } else if (sawDerivedCacheMiss) {

--- a/packages/headless/src/fixed-prompt-controller.ts
+++ b/packages/headless/src/fixed-prompt-controller.ts
@@ -98,7 +98,7 @@ export interface FixedPromptTaskCompletedEvent {
   errorClass?: string;
   promptHash?: string;
   executionIdentity?: HarborCellExecutionIdentity;
-  tokenSummary: HarborCellTokenSummary;
+  tokenSummary?: HarborCellTokenSummary;
   contextBudgetPolicy?: HarborCellContextBudgetPolicySnapshot;
   contextBudgetSummary?: HarborCellContextBudgetSummary;
   continuationSummary?: HarborCellContinuationSummary;
@@ -175,7 +175,7 @@ export interface FixedPromptTaskPlumbingFailedEvent {
   passed: false;
   scored: false;
   eligible: false;
-  errorClass: 'zero_cost_with_tokens' | 'prompt_hash_mismatch' | 'missing_prompt_hash' | 'missing_execution_identity' | 'execution_identity_mismatch';
+  errorClass: 'missing_token_usage' | 'zero_cost_with_tokens' | 'prompt_hash_mismatch' | 'missing_prompt_hash' | 'missing_execution_identity' | 'execution_identity_mismatch';
   error: string;
   promptHash?: string;
   expectedPromptHash?: string;
@@ -520,18 +520,21 @@ export async function writeFixedPromptResultsTsv(
     'cost_usd',
     'runtime_events_path',
   ];
-  const rows = events.map((event) => [
-    event.taskId,
-    event.status,
-    String(event.passed),
-    String(event.scored),
-    String(event.eligible),
-    event.errorClass ?? '',
-    'promptHash' in event ? event.promptHash ?? '' : '',
-    String(eventTokenSummary(event)?.total ?? 0),
-    String(eventTokenSummary(event)?.costUsd ?? 0),
-    'runtimeEventsPath' in event ? event.runtimeEventsPath ?? '' : '',
-  ]);
+  const rows = events.map((event) => {
+    const tokenSummary = eventTokenSummary(event);
+    return [
+      event.taskId,
+      event.status,
+      String(event.passed),
+      String(event.scored),
+      String(event.eligible),
+      event.errorClass ?? '',
+      'promptHash' in event ? event.promptHash ?? '' : '',
+      tokenSummary ? String(tokenSummary.total) : '',
+      tokenSummary ? String(tokenSummary.costUsd) : '',
+      'runtimeEventsPath' in event ? event.runtimeEventsPath ?? '' : '',
+    ];
+  });
   const body = [header, ...rows].map((row) => row.map(tsvCell).join('\t')).join('\n');
   await writeFile(path, `${body}\n`, 'utf8');
 }
@@ -717,7 +720,7 @@ function taskCompletedEvent(input: {
     ...(errorClass ? { errorClass } : {}),
     ...(output.cell.promptHash ? { promptHash: output.cell.promptHash } : {}),
     ...(output.cell.executionIdentity ? { executionIdentity: output.cell.executionIdentity } : {}),
-    tokenSummary: output.cell.tokenSummary,
+    ...(output.cell.tokenSummary ? { tokenSummary: output.cell.tokenSummary } : {}),
     ...(output.cell.contextBudgetPolicy ? { contextBudgetPolicy: output.cell.contextBudgetPolicy } : {}),
     ...(output.cell.contextBudgetSummary ? { contextBudgetSummary: output.cell.contextBudgetSummary } : {}),
     ...(output.cell.continuationSummary ? { continuationSummary: output.cell.continuationSummary } : {}),
@@ -766,7 +769,7 @@ function taskPlumbingFailedEvent(input: {
     error: input.error,
     ...(input.output.cell.promptHash ? { promptHash: input.output.cell.promptHash } : {}),
     expectedPromptHash: input.expectedPromptHash,
-    tokenSummary: input.output.cell.tokenSummary,
+    ...(input.output.cell.tokenSummary ? { tokenSummary: input.output.cell.tokenSummary } : {}),
     ...(input.output.cell.contextBudgetPolicy
       ? { contextBudgetPolicy: input.output.cell.contextBudgetPolicy }
       : {}),
@@ -813,7 +816,17 @@ function classifyPlumbingFailure(output: HarborTaskRunOutput, expectedPromptHash
       error: `Harbor cell prompt hash ${output.cell.promptHash} did not match ${expectedPromptHash}`,
     };
   }
-  if (output.cell.tokenSummary.total > 0 && output.cell.tokenSummary.costUsd === 0) {
+  if (
+    (output.cell.status === 'completed' || output.cell.errorClass === 'tool_step_cap_reached')
+    && output.cell.executionIdentity
+    && (!output.cell.tokenSummary || output.cell.tokenSummary.total <= 0)
+  ) {
+    return {
+      errorClass: 'missing_token_usage',
+      error: 'Harbor cell did not report token usage for the attested real-provider execution',
+    };
+  }
+  if (output.cell.tokenSummary && output.cell.tokenSummary.total > 0 && output.cell.tokenSummary.costUsd === 0) {
     return {
       errorClass: 'zero_cost_with_tokens',
       error: 'Harbor cell reported token usage but zero costUsd',
@@ -953,6 +966,16 @@ function taskBudgetExhaustedEvent(input: {
     );
     if (evidenceFailure?.errorClass === 'missing_execution_identity') {
       evidenceFailure = { ...evidenceFailure, error: LEGACY_TIMEOUT_MISSING_EXECUTION_IDENTITY_ERROR };
+    }
+    if (
+      evidenceFailure === undefined
+      && artifactRefs.executionIdentity
+      && (!artifactRefs.tokenSummary || artifactRefs.tokenSummary.total <= 0)
+    ) {
+      evidenceFailure = {
+        errorClass: 'missing_token_usage',
+        error: 'Harbor cell did not report token usage for the attested real-provider execution',
+      };
     }
   }
   const tokenSummary = artifactRefs.cellOutput?.tokenSummary ?? artifactRefs.tokenSummary;

--- a/packages/headless/src/harbor-cell.ts
+++ b/packages/headless/src/harbor-cell.ts
@@ -46,6 +46,7 @@ import {
 import { registerFakeBackend } from './backends.js';
 import {
   buildHarborCellOutput,
+  countRuntimeSteps,
   hashHarborSystemPrompt,
   validateHarborCellOutput,
   type HarborCellContextBudgetPolicySnapshot,
@@ -644,10 +645,7 @@ function continuationTurnSummary(
 }
 
 function invocationRuntimeSteps(invocation: InvocationResult): number {
-  return invocation.events.reduce((sum, event) => {
-    const runtimeSteps = event.actions?.tokenUsage?.runtimeSteps;
-    return sum + (runtimeSteps ?? 0);
-  }, 0);
+  return countRuntimeSteps(invocation.events);
 }
 
 function failedInvocationFromError(error: unknown, input: {

--- a/packages/headless/src/harbor-task-runner.ts
+++ b/packages/headless/src/harbor-task-runner.ts
@@ -289,7 +289,7 @@ function cellArtifactRefs(cell: HarborCellOutput, hostEventsPath: string, trialD
   return {
     runtimeEventsPath: hostEventsPath,
     traceEventsPath,
-    tokenSummary: cell.tokenSummary,
+    ...(cell.tokenSummary ? { tokenSummary: cell.tokenSummary } : {}),
     cellOutput: { ...cell, runtimeEventsPath: hostEventsPath, traceEventsPath },
   };
 }

--- a/packages/runtime/src/__tests__/active-tool-result-prune.test.ts
+++ b/packages/runtime/src/__tests__/active-tool-result-prune.test.ts
@@ -53,6 +53,7 @@ describe('active current-turn tool-result pruning', () => {
     };
     const composed = composePrepareStep(
       () => ({ activeTools: ['Read', LOAD_TOOLS_NAME] }),
+      undefined,
       activePrune,
     );
 
@@ -385,7 +386,7 @@ describe('active current-turn tool-result pruning', () => {
       messages: [{ role: 'user', content: 'load rive' }],
       tools: aiSdkTools,
       activeTools: plan.activeTools,
-      prepareStep: composePrepareStep(plan.prepareStep, activePrune),
+      prepareStep: composePrepareStep(plan.prepareStep, undefined, activePrune),
       abortSignal: new AbortController().signal,
       repairToolCall: async () => null,
     });

--- a/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
+++ b/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
@@ -3898,6 +3898,47 @@ describe('AiSdkBackend usage telemetry', () => {
     ]);
   });
 
+  test('does not record fabricated zero telemetry when provider usage is unavailable', async () => {
+    const llmRecords: LlmCallRecord[] = [];
+    const model = new MockLanguageModelV3({
+      doStream: {
+        stream: simulateReadableStream({
+          chunks: [
+            { type: 'stream-start', warnings: [] },
+            {
+              type: 'finish',
+              finishReason: { unified: 'stop', raw: 'stop' },
+              usage: {
+                inputTokens: { total: undefined, noCache: undefined, cacheRead: undefined, cacheWrite: undefined },
+                outputTokens: { total: undefined, text: undefined, reasoning: undefined },
+              } as never,
+            },
+          ],
+          initialDelayInMs: null,
+          chunkDelayInMs: null,
+        }),
+      },
+    });
+    const backend = new AiSdkBackend({
+      sessionId: 'session-1',
+      header: header(),
+      appendMessage: async () => {},
+      connection: connection(),
+      apiKey: 'sk-test',
+      modelId: 'mock-model-id',
+      permissionEngine: new PermissionEngine({ newId: () => 'permission-id', now: () => 1 }),
+      modelFactory: () => model,
+      tools: [],
+      newId: idGenerator(),
+      now: monotonicClock(),
+      recordLlmCall: (record) => { llmRecords.push(record); },
+    });
+
+    await drain(backend.send({ turnId: 'turn-1', text: 'hi', context: [] }));
+
+    assert.deepEqual(llmRecords, []);
+  });
+
   test('keeps checkpoint cost unknown when model pricing is unavailable', async () => {
     const usageCheckpoints: Array<{ costUsd?: number }> = [];
     const model = new MockLanguageModelV3({
@@ -4175,6 +4216,44 @@ describe('AiSdkBackend usage telemetry', () => {
 
     assert.equal(recordedBlocks.length, 1);
     assert.equal(recordedBlocks[0]?.blockId, 'afcompact-sync-test');
+  });
+
+  test('does not record semantic compact usage when provider usage is unavailable', () => {
+    const llmRecords: LlmCallRecord[] = [];
+    const backend = new AiSdkBackend({
+      sessionId: 'session-1',
+      header: header(),
+      appendMessage: async () => {},
+      connection: connection(),
+      apiKey: 'sk-test',
+      modelId: 'mock-model-id',
+      permissionEngine: new PermissionEngine({ newId: () => 'permission-id', now: () => 1 }),
+      modelFactory: () => completionModel(),
+      tools: [],
+      newId: idGenerator(),
+      now: monotonicClock(),
+      recordLlmCall: (record) => { llmRecords.push(record); },
+    });
+
+    (backend as unknown as {
+      recordSemanticCompactSummaryCall(input: {
+        callId: string;
+        turnId: string;
+        modelId: string;
+        startedAt: number;
+        latencyMs: number;
+        status: LlmCallRecord['status'];
+      }): void;
+    }).recordSemanticCompactSummaryCall({
+      callId: 'semantic-1',
+      turnId: 'turn-1',
+      modelId: 'mock-model-id',
+      startedAt: 1,
+      latencyMs: 2,
+      status: 'error',
+    });
+
+    assert.deepEqual(llmRecords, []);
   });
 
   test('semantic compact records a separate no-tools summarizer LLM call', async () => {

--- a/packages/runtime/src/__tests__/ai-sdk-flow.test.ts
+++ b/packages/runtime/src/__tests__/ai-sdk-flow.test.ts
@@ -701,6 +701,25 @@ describe('mapSessionEventToRuntimeEvent (pure)', () => {
     });
   });
 
+  test('context_budget_exhausted keeps its detail in the durable terminal state', () => {
+    const mapped = mapSessionEventToRuntimeEvent(
+      ev({
+        type: 'complete',
+        stopReason: 'context_budget_exhausted',
+        contextBudgetExhaustedDetail: 'head_anchor_exceeds_capacity',
+      }),
+      ctx,
+      createSessionEventMapMemory(),
+    );
+
+    assert.equal(mapped.status, 'failed');
+    assert.deepEqual(mapped.actions?.stateDelta, {
+      stopReason: 'context_budget_exhausted',
+      failureClass: 'context_budget_exhausted',
+      contextBudgetExhaustedDetail: 'head_anchor_exceeds_capacity',
+    });
+  });
+
   test('tool_output_delta and tool_progress map to partial tool-role heartbeats', () => {
     const mem = createSessionEventMapMemory();
     const a = mapSessionEventToRuntimeEvent(

--- a/packages/runtime/src/__tests__/async-queue.test.ts
+++ b/packages/runtime/src/__tests__/async-queue.test.ts
@@ -108,3 +108,96 @@ describe('AsyncEventQueue', () => {
     expect(out).toEqual([10, 20, 30]);
   });
 });
+
+describe('AsyncEventQueue seq-ack counters', () => {
+  test('pushedCount stamps enqueues; ackConsumed counts processed events', () => {
+    const q = new AsyncEventQueue<number>();
+    expect(q.pushedCount).toBe(0);
+    q.push(1);
+    q.push(2);
+    expect(q.pushedCount).toBe(2);
+    expect(q.consumedCount).toBe(0);
+    q.ackConsumed();
+    expect(q.consumedCount).toBe(1);
+    // A dropped push (after close) is not stamped: the counter tracks events
+    // a consumer can ever receive, or the boundary would be unreachable.
+    q.close();
+    q.push(3);
+    expect(q.pushedCount).toBe(2);
+  });
+
+  test('waitForProgress resolves on push, ack, close, and detach — condition-variable, not a poll', async () => {
+    const q = new AsyncEventQueue<number>();
+    let wakes = 0;
+    const arm = (): void => {
+      void q.waitForProgress().then(() => { wakes += 1; });
+    };
+
+    arm();
+    q.push(1);
+    await Promise.resolve();
+    expect(wakes).toBe(1);
+
+    arm();
+    q.ackConsumed();
+    await Promise.resolve();
+    expect(wakes).toBe(2);
+
+    arm();
+    q.noteConsumerDetached();
+    await Promise.resolve();
+    expect(wakes).toBe(3);
+    expect(q.consumerDetached).toBe(true);
+
+    arm();
+    q.close();
+    await Promise.resolve();
+    expect(wakes).toBe(4);
+  });
+
+  test('a seq-ack boundary wait observes consumed >= pushed exactly when the consumer has processed everything', async () => {
+    const q = new AsyncEventQueue<number>();
+    const processed: number[] = [];
+
+    // Producer-side boundary waiter: everything pushed so far must be processed.
+    const boundary = q.pushedCount; // 0 — then push 3 events
+    q.push(1);
+    q.push(2);
+    q.push(3);
+    q.close();
+    expect(boundary).toBe(0);
+
+    const waiter = (async () => {
+      while (q.consumedCount < q.pushedCount) {
+        await q.waitForProgress();
+      }
+      return [q.pushedCount, q.consumedCount];
+    })();
+
+    // Consumer acks after fully processing each event (the drain() pattern).
+    for await (const v of q) {
+      processed.push(v);
+      q.ackConsumed();
+    }
+    expect(await waiter).toEqual([3, 3]);
+    expect(processed).toEqual([1, 2, 3]);
+  });
+
+  test('a detached consumer wakes boundary waiters instead of deadlocking them', async () => {
+    const q = new AsyncEventQueue<number>();
+    q.push(1);
+    q.push(2);
+    const waiter = (async () => {
+      while (q.consumedCount < q.pushedCount) {
+        if (q.consumerDetached) return 'detached';
+        await q.waitForProgress();
+      }
+      return 'acked';
+    })();
+    // The consumer abandons the stream after one event without acking the rest.
+    const iter = q[Symbol.asyncIterator]();
+    await iter.next();
+    q.noteConsumerDetached();
+    expect(await waiter).toBe('detached');
+  });
+});

--- a/packages/runtime/src/__tests__/context-budget-mid-turn-policy.test.ts
+++ b/packages/runtime/src/__tests__/context-budget-mid-turn-policy.test.ts
@@ -1,0 +1,62 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+import type { LlmConnection } from '@maka/core';
+import { buildDefaultContextBudgetPolicy } from '../context-budget-policy.js';
+
+describe('mid-turn history compact policy env plumbing', () => {
+  test('defaults off: no midTurn subconfig without an explicit opt-in', () => {
+    const policy = buildDefaultContextBudgetPolicy(connection(), {
+      env: { MAKA_CONTEXT_HISTORY_COMPACT: 'on' },
+    });
+    assert.equal(policy?.historyCompact?.enabled, true);
+    assert.equal(policy?.historyCompact?.midTurn, undefined);
+  });
+
+  test('opts in with MAKA_CONTEXT_HISTORY_COMPACT_MID_TURN=on and the shared reserve', () => {
+    const policy = buildDefaultContextBudgetPolicy(connection(), {
+      env: {
+        MAKA_CONTEXT_HISTORY_COMPACT: 'on',
+        MAKA_CONTEXT_HISTORY_COMPACT_MID_TURN: 'on',
+      },
+    });
+    assert.deepEqual(policy?.historyCompact?.midTurn, { enabled: true, reserveTokens: 16_384 });
+  });
+
+  test('honors explicit reserve and tail-event overrides', () => {
+    const policy = buildDefaultContextBudgetPolicy(connection(), {
+      env: {
+        MAKA_CONTEXT_HISTORY_COMPACT: 'on',
+        MAKA_CONTEXT_HISTORY_COMPACT_MID_TURN: 'on',
+        MAKA_CONTEXT_HISTORY_COMPACT_RESERVE_TOKENS: '8000',
+        MAKA_CONTEXT_HISTORY_COMPACT_MID_TURN_TAIL_EVENTS: '2',
+      },
+    });
+    assert.deepEqual(policy?.historyCompact?.midTurn, {
+      enabled: true,
+      reserveTokens: 8_000,
+      reserveTailEvents: 2,
+    });
+  });
+
+  test('mid_turn=off keeps it disabled even with history compact on', () => {
+    const policy = buildDefaultContextBudgetPolicy(connection(), {
+      env: {
+        MAKA_CONTEXT_HISTORY_COMPACT: 'on',
+        MAKA_CONTEXT_HISTORY_COMPACT_MID_TURN: 'off',
+      },
+    });
+    assert.equal(policy?.historyCompact?.midTurn, undefined);
+  });
+});
+
+function connection(): LlmConnection {
+  return {
+    slug: 'anthropic-main',
+    name: 'Anthropic',
+    providerType: 'anthropic',
+    defaultModel: 'claude-sonnet-4-5-20250929',
+    enabled: true,
+    createdAt: 1,
+    updatedAt: 1,
+  };
+}

--- a/packages/runtime/src/__tests__/history-compact-mid-turn-checkpoint.test.ts
+++ b/packages/runtime/src/__tests__/history-compact-mid-turn-checkpoint.test.ts
@@ -1,0 +1,230 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+import type { RuntimeEvent } from '@maka/core/runtime-event';
+import {
+  buildHistoryCompactCheckpoint,
+  matchHistoryCompactCheckpointPrefix,
+  midTurnHeadAnchorEvent,
+  projectHistoryCompactCheckpointReplay,
+  validateHistoryCompactCheckpointShape,
+} from '../history-compact-checkpoint.js';
+import { applyRuntimeEventHistoryCompact } from '../context-budget.js';
+
+describe('mid-turn history compact checkpoint', () => {
+  test('builds a mid_turn checkpoint that re-renders the covered head anchor verbatim', () => {
+    // [prior turn user, prior turn model, head anchor user, current step model]
+    const events = [
+      textEvent('prior-user', 'turn-0', 'user'),
+      textEvent('prior-model', 'turn-0', 'model'),
+      textEvent('anchor', 'turn-1', 'user'),
+      textEvent('step-model', 'turn-1', 'model'),
+    ];
+    const checkpoint = buildHistoryCompactCheckpoint({
+      sessionId: 'session-1',
+      coveredRuntimeEvents: events,
+      summary: 'Prior work plus the current turn opening.',
+      phase: 'mid_turn',
+      headAnchor: { runtimeEventId: 'anchor', turnId: 'turn-1' },
+      now: 1_800_000_010_000,
+    });
+
+    assert.equal(checkpoint.phase, 'mid_turn');
+    assert.deepEqual(checkpoint.headAnchor, { runtimeEventId: 'anchor', turnId: 'turn-1' });
+    assert.equal(validateHistoryCompactCheckpointShape(checkpoint, 'session-1'), true);
+    // Coverage remains a contiguous prefix whose digest matches the raw events.
+    const match = matchHistoryCompactCheckpointPrefix(checkpoint, [...events, textEvent('tail', 'turn-1', 'model')]);
+    assert.equal(match.coveredEventCount, 4);
+    assert.deepEqual(match.successorRuntimeEvents.map((event) => event.id), ['tail']);
+
+    const anchor = midTurnHeadAnchorEvent(checkpoint, match.coveredRuntimeEvents);
+    assert.equal(anchor?.id, 'anchor');
+    const projected = projectHistoryCompactCheckpointReplay(
+      checkpoint,
+      match.coveredRuntimeEvents,
+      match.successorRuntimeEvents,
+    );
+    assert.deepEqual(projected.map((event) => event.id), [
+      `history-compact:${checkpoint.checkpointId}`,
+      'anchor',
+      'tail',
+    ]);
+    // Head anchor is byte-identical to the covered raw event.
+    assert.deepEqual(projected[1], events[2]);
+  });
+
+  test('rejects a mid_turn checkpoint without a covered head anchor', () => {
+    const events = [textEvent('a', 'turn-1', 'user'), textEvent('b', 'turn-1', 'model')];
+    assert.throws(() => buildHistoryCompactCheckpoint({
+      sessionId: 'session-1', coveredRuntimeEvents: events, summary: 'x', phase: 'mid_turn',
+    }), /requires a head anchor/);
+    assert.throws(() => buildHistoryCompactCheckpoint({
+      sessionId: 'session-1', coveredRuntimeEvents: events, summary: 'x', phase: 'mid_turn',
+      headAnchor: { runtimeEventId: 'missing', turnId: 'turn-1' },
+    }), /must be a covered RuntimeEvent/);
+  });
+
+  test('rejects a head anchor that is not the compacted turn\'s user event', () => {
+    const events = [textEvent('a', 'turn-1', 'user'), textEvent('b', 'turn-1', 'model')];
+    // Anchor turnId disagrees with the covered event.
+    assert.throws(() => buildHistoryCompactCheckpoint({
+      sessionId: 'session-1', coveredRuntimeEvents: events, summary: 'x', phase: 'mid_turn',
+      headAnchor: { runtimeEventId: 'a', turnId: 'turn-9' },
+    }), /must be the compacted turn's user event/);
+    // Anchor references a model event, not the turn's user message.
+    assert.throws(() => buildHistoryCompactCheckpoint({
+      sessionId: 'session-1', coveredRuntimeEvents: events, summary: 'x', phase: 'mid_turn',
+      headAnchor: { runtimeEventId: 'b', turnId: 'turn-1' },
+    }), /must be the compacted turn's user event/);
+  });
+
+  test('rejects a head anchor pointing at another covered turn\'s user event', () => {
+    // A self-consistent anchor (role user, matching self-reported turnId) that
+    // resolves to a PRIOR turn's prompt would silently drop the real current
+    // prompt from the replay — the compacted turn is the last covered event's
+    // turn, and the anchor must belong to it.
+    const events = [
+      textEvent('prior-user', 'turn-0', 'user'),
+      textEvent('prior-model', 'turn-0', 'model'),
+      textEvent('anchor', 'turn-1', 'user'),
+      textEvent('step-model', 'turn-1', 'model'),
+    ];
+    assert.throws(() => buildHistoryCompactCheckpoint({
+      sessionId: 'session-1', coveredRuntimeEvents: events, summary: 'x', phase: 'mid_turn',
+      headAnchor: { runtimeEventId: 'prior-user', turnId: 'turn-0' },
+    }), /must be the compacted turn's user event/);
+
+    // Matcher: a persisted checkpoint whose anchor was tampered to the prior
+    // turn's user event must fail closed as coverage_miss.
+    const checkpoint = buildHistoryCompactCheckpoint({
+      sessionId: 'session-1', coveredRuntimeEvents: events, summary: 'mid turn summary',
+      phase: 'mid_turn', headAnchor: { runtimeEventId: 'anchor', turnId: 'turn-1' },
+    });
+    const priorUserAnchor = {
+      ...checkpoint,
+      headAnchor: { runtimeEventId: 'prior-user', turnId: 'turn-0' },
+    };
+    assert.equal(matchHistoryCompactCheckpointPrefix(priorUserAnchor, events).reason, 'coverage_miss');
+    assert.equal(matchHistoryCompactCheckpointPrefix(checkpoint, events).reason, undefined);
+  });
+
+  test('rejects coverage that includes a partial streaming snapshot', () => {
+    const events = [
+      textEvent('a', 'turn-1', 'user'),
+      { ...textEvent('b-partial', 'turn-1', 'model'), partial: true },
+      textEvent('c', 'turn-1', 'model'),
+    ];
+    assert.throws(() => buildHistoryCompactCheckpoint({
+      sessionId: 'session-1', coveredRuntimeEvents: events, summary: 'x', phase: 'mid_turn',
+      headAnchor: { runtimeEventId: 'a', turnId: 'turn-1' },
+    }), /must not include partial events/);
+  });
+
+  test('fails the prefix match closed when the head anchor reference is corrupted', () => {
+    const events = [
+      textEvent('anchor', 'turn-1', 'user'),
+      textEvent('step-model', 'turn-1', 'model'),
+      textEvent('tail', 'turn-1', 'model'),
+    ];
+    const checkpoint = buildHistoryCompactCheckpoint({
+      sessionId: 'session-1',
+      coveredRuntimeEvents: events.slice(0, 2),
+      summary: 'mid turn summary',
+      phase: 'mid_turn',
+      headAnchor: { runtimeEventId: 'anchor', turnId: 'turn-1' },
+    });
+
+    // Anchor id pointing outside the coverage: the replay would silently drop
+    // the turn's user message, so the match must fail closed instead.
+    const missingAnchor = {
+      ...checkpoint,
+      headAnchor: { runtimeEventId: 'tail', turnId: 'turn-1' },
+    };
+    assert.equal(matchHistoryCompactCheckpointPrefix(missingAnchor, events).reason, 'coverage_miss');
+
+    // Anchor resolving to a covered non-user event fails the same way.
+    const modelAnchor = {
+      ...checkpoint,
+      headAnchor: { runtimeEventId: 'step-model', turnId: 'turn-1' },
+    };
+    assert.equal(matchHistoryCompactCheckpointPrefix(modelAnchor, events).reason, 'coverage_miss');
+
+    // Anchor turnId disagreeing with the covered event fails too.
+    const wrongTurnAnchor = {
+      ...checkpoint,
+      headAnchor: { runtimeEventId: 'anchor', turnId: 'turn-9' },
+    };
+    assert.equal(matchHistoryCompactCheckpointPrefix(wrongTurnAnchor, events).reason, 'coverage_miss');
+
+    // The intact checkpoint still matches.
+    assert.equal(matchHistoryCompactCheckpointPrefix(checkpoint, events).reason, undefined);
+  });
+
+  test('keeps pre_turn checkpoint ids stable when phase is absent or explicit', () => {
+    const events = [textEvent('a', 'turn-0', 'user'), textEvent('b', 'turn-0', 'model')];
+    const implicit = buildHistoryCompactCheckpoint({
+      sessionId: 'session-1', coveredRuntimeEvents: events, summary: 'same', now: 5,
+    });
+    const explicit = buildHistoryCompactCheckpoint({
+      sessionId: 'session-1', coveredRuntimeEvents: events, summary: 'same', phase: 'pre_turn', now: 5,
+    });
+    assert.equal(implicit.phase, undefined);
+    assert.equal(explicit.checkpointId, implicit.checkpointId);
+    // A mid_turn checkpoint over the same coverage is a distinct id.
+    const mid = buildHistoryCompactCheckpoint({
+      sessionId: 'session-1', coveredRuntimeEvents: events, summary: 'same', now: 5,
+      phase: 'mid_turn', headAnchor: { runtimeEventId: 'a', turnId: 'turn-0' },
+    });
+    assert.notEqual(mid.checkpointId, implicit.checkpointId);
+  });
+
+  test('replays a mid_turn checkpoint as [block, verbatim head anchor, uncovered tail]', () => {
+    const events = [
+      textEvent('prior-user', 'turn-0', 'user'),
+      textEvent('prior-model', 'turn-0', 'model'),
+      textEvent('anchor', 'turn-1', 'user'),
+      textEvent('step-model', 'turn-1', 'model'),
+      textEvent('step-tool', 'turn-1', 'model'),
+    ];
+    const checkpoint = buildHistoryCompactCheckpoint({
+      sessionId: 'session-1',
+      coveredRuntimeEvents: events.slice(0, 4),
+      summary: 'mid turn summary',
+      phase: 'mid_turn',
+      headAnchor: { runtimeEventId: 'anchor', turnId: 'turn-1' },
+    });
+
+    // Normal thresholds: the raw projection is far below the default high
+    // water, and the accepted mid_turn checkpoint must STILL replay — the
+    // covered raw span may never be re-injected on recovery.
+    const replay = applyRuntimeEventHistoryCompact(events, {
+      maxHistoryEstimatedTokens: 1_000,
+      charsPerToken: 1,
+      historyCompact: { enabled: true, mode: 'read_write', checkpoint },
+    });
+
+    assert.equal(replay.checkpoint?.checkpointId, checkpoint.checkpointId);
+    assert.deepEqual(replay.events.map((event) => event.id), [
+      `history-compact:${checkpoint.checkpointId}`,
+      'anchor',
+      'step-tool',
+    ]);
+    // The head anchor renders verbatim and is not duplicated in the tail.
+    const anchorCount = replay.events.filter((event) => event.id === 'anchor').length;
+    assert.equal(anchorCount, 1);
+  });
+});
+
+function textEvent(id: string, turnId: string, role: 'user' | 'model'): RuntimeEvent {
+  return {
+    id,
+    sessionId: 'session-1',
+    runId: 'run-1',
+    turnId,
+    invocationId: 'run-1',
+    ts: 1_800_000_000_000,
+    partial: false,
+    role,
+    author: role === 'user' ? 'user' : 'agent',
+    content: { kind: 'text', text: `payload-${id}` },
+  };
+}

--- a/packages/runtime/src/__tests__/mid-turn-capacity-backend.test.ts
+++ b/packages/runtime/src/__tests__/mid-turn-capacity-backend.test.ts
@@ -1,0 +1,1106 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+import { setImmediate as flushMacrotask } from 'node:timers/promises';
+import { MockLanguageModelV3, simulateReadableStream } from 'ai/test';
+import type { LanguageModelV3StreamPart } from '@ai-sdk/provider';
+import type { LlmConnection, SessionHeader } from '@maka/core';
+import type { SessionEvent } from '@maka/core/events';
+import type { RuntimeEvent } from '@maka/core/runtime-event';
+import type { AgentBackend, BackendSendInput } from '@maka/core/backend-types';
+import { z } from 'zod';
+import { AiSdkBackend } from '../ai-sdk-backend.js';
+import { AiSdkFlow, createSessionEventMapMemory, mapSessionEventToRuntimeEvent } from '../ai-sdk-flow.js';
+import type { InvocationContext } from '../invocation-context.js';
+import { PermissionEngine } from '../permission-engine.js';
+import { applyRuntimeEventContextBudget, evaluateHistoryCompactCheckpointReplay } from '../context-budget.js';
+import type { HistoryCompactCheckpoint } from '../history-compact-checkpoint.js';
+import type { ContextBudgetDiagnostic } from '@maka/core/usage-stats/types';
+
+const RAW_SPAN_ONE = 'RAW_SPAN_ONE_'.repeat(24);
+const RAW_SPAN_TWO = 'RAW_SPAN_TWO_'.repeat(160);
+/** Third-step result big enough that even the rolled-forward fold cannot fit. */
+const ROLLING_TAIL = 'ROLLING_TAIL_'.repeat(740);
+const HUGE_RESULT = 'HUGE_RESULT_'.repeat(670);
+const ANCHOR_TEXT = 'compact this very long turn but keep my exact words';
+
+interface MidTurnFixture {
+  backend: AiSdkBackend;
+  model: MockLanguageModelV3;
+  recorded: HistoryCompactCheckpoint[];
+  recordedBeforeThirdRequest: () => boolean;
+  toolExecutions: string[];
+  summarizerCalls: number;
+  priorEvents: RuntimeEvent[];
+  anchor: RuntimeEvent;
+  /** The fixture's durable RuntimeEvent ledger for the current turn/run. */
+  ledger: RuntimeEvent[];
+  ledgerReads: number;
+  events: SessionEvent[];
+  messages: unknown[];
+  llmCalls: Array<{
+    inputTokens?: number;
+    outputTokens?: number;
+    totalTokens?: number;
+    status?: string;
+    errorClass?: string;
+    contextBudget?: ContextBudgetDiagnostic;
+  }>;
+  /** JSON of each summarizer call's folded runtime events (coverage evidence). */
+  summarizedSources: string[];
+  persist: (event: SessionEvent) => void;
+}
+
+interface MidTurnFixtureOptions {
+  contextWindow?: number;
+  reserveTokens?: number;
+  summarize?: () => Promise<string | undefined> | string | undefined;
+  branch?: string;
+  /** Omit the prior turns so the compaction pool has no safe completed span. */
+  withoutPriorTurns?: boolean;
+  /** Enable the default-on active tool-result prune with a tiny threshold. */
+  activeToolResultPrune?: boolean;
+  /** Enable semantic compaction so it competes with the capacity hook. */
+  semanticCompact?: boolean;
+  /** Override the checkpoint recorder (e.g. to simulate a write failure). */
+  record?: (checkpoint: HistoryCompactCheckpoint) => void;
+  /** Make the prior turns large so folding them rescues an over-window turn. */
+  bigPriors?: boolean;
+  /** First tool result is huge (finding C: prune must be able to rescue it). */
+  hugeFirstResult?: boolean;
+  /** The model finishes on the second request instead of running three steps. */
+  finalAtSecondCall?: boolean;
+  /** Add a third tool step whose result outgrows even a rolled-forward fold (finding A). */
+  rollingOverflow?: boolean;
+  /** Economy tool availability with a huge-schema group behind load_tools (finding D). */
+  bigToolGroup?: boolean;
+  /** The first step emits assistant text before its tool call (finding B). */
+  assistantTextInFirstStep?: boolean;
+  /** Override the first step's reported usage; 'missing' = empty usage object. */
+  firstStepUsage?: { input: number; output: number } | 'missing';
+  /** Volatile per-request turn tail (cwd/task state) appended to the user message. */
+  volatileTurnTail?: boolean;
+  /** Very large prior turns (~20k chars) so a large summary still shrinks the fold. */
+  giantPriors?: boolean;
+  /** Large system prompt sent via the separate `system` field (finding: cold start). */
+  bigSystemPrompt?: boolean;
+}
+
+/**
+ * Consumer scheduling mode for a fixture turn. `slow` reproduces the review's
+ * scheduling perturbation: the event consumer (which persists to the durable
+ * ledger) yields several macrotasks before persisting each event, so the
+ * ledger genuinely lags the SDK's step progression and the trigger's seq-ack
+ * durability boundary is exercised for real.
+ */
+type ConsumerMode = 'immediate' | 'slow';
+
+function buildFixture(options: MidTurnFixtureOptions = {}): MidTurnFixture {
+  const contextWindow = options.contextWindow ?? 2_000;
+  const reserveTokens = options.reserveTokens ?? 1_500;
+  const recorded: HistoryCompactCheckpoint[] = [];
+  const toolExecutions: string[] = [];
+  const events: SessionEvent[] = [];
+  const messages: unknown[] = [];
+  const llmCalls: Array<{
+    inputTokens?: number;
+    outputTokens?: number;
+    totalTokens?: number;
+    status?: string;
+    errorClass?: string;
+    contextBudget?: ContextBudgetDiagnostic;
+  }> = [];
+  const summarizedSources: string[] = [];
+  let recordedAtThirdRequest = false;
+  const fixture = { summarizerCalls: 0, ledgerReads: 0 };
+  const usage = (input: number, output: number) => ({
+    inputTokens: { total: input, noCache: input, cacheRead: 0, cacheWrite: 0 },
+    outputTokens: { total: output, text: output, reasoning: 0 },
+  });
+  const firstStepUsage = (): ReturnType<typeof usage> => {
+    // A usage object the SDK accepts but whose token counts are absent — the
+    // adapter's normalization fails closed (undefined) and the capacity hook's
+    // usability check must fall back to cold start (the finding-1 shape).
+    if (options.firstStepUsage === 'missing') return { inputTokens: {}, outputTokens: {} } as ReturnType<typeof usage>;
+    if (options.firstStepUsage) return usage(options.firstStepUsage.input, options.firstStepUsage.output);
+    return usage(100, 20);
+  };
+  const toolCallChunks = (id: string, name: string, args: object): LanguageModelV3StreamPart[] => [
+    { type: 'stream-start', warnings: [] },
+    { type: 'tool-call', toolCallId: id, toolName: name, input: JSON.stringify(args) },
+    {
+      type: 'finish',
+      finishReason: { unified: 'tool-calls', raw: 'tool_calls' },
+      usage: id === 'tool-1' ? firstStepUsage() : usage(150, 30),
+    },
+  ];
+  const doneChunks = (): LanguageModelV3StreamPart[] => [
+    { type: 'stream-start', warnings: [] },
+    { type: 'text-start', id: 'text-1' },
+    { type: 'text-delta', id: 'text-1', delta: 'done' },
+    { type: 'text-end', id: 'text-1' },
+    { type: 'finish', finishReason: { unified: 'stop', raw: 'stop' }, usage: usage(120, 10) },
+  ];
+  const chunksForCall = (call: number): LanguageModelV3StreamPart[] => {
+    if (options.bigToolGroup) {
+      return call === 1 ? toolCallChunks('tool-1', 'load_tools', { group: 'big' }) : doneChunks();
+    }
+    if (call === 1) {
+      const first = toolCallChunks('tool-1', 'Read', { path: 'one.md' });
+      if (!options.assistantTextInFirstStep) return first;
+      return [
+        first[0]!,
+        { type: 'text-start', id: 'step1-text' },
+        { type: 'text-delta', id: 'step1-text', delta: 'ASSISTANT_SENTINEL step one reasoning' },
+        { type: 'text-end', id: 'step1-text' },
+        ...first.slice(1),
+      ];
+    }
+    if (options.finalAtSecondCall) return doneChunks();
+    if (call === 2) return toolCallChunks('tool-2', 'Read', { path: 'two.md' });
+    if (options.rollingOverflow && call === 3) return toolCallChunks('tool-3', 'Read', { path: 'three.md' });
+    return doneChunks();
+  };
+  const model = new MockLanguageModelV3({
+    doStream: async (streamOptions: { abortSignal?: AbortSignal }) => {
+      // A real transport rejects immediately on an already-aborted signal; the
+      // mock must mirror that so an exhausted turn never streams the
+      // over-budget request.
+      if (streamOptions.abortSignal?.aborted) {
+        throw Object.assign(new Error('aborted'), { name: 'AbortError' });
+      }
+      const call = model.doStreamCalls.length;
+      if (call === 3) recordedAtThirdRequest = recorded.length > 0;
+      const chunks = chunksForCall(call);
+      return { stream: simulateReadableStream({ chunks, initialDelayInMs: null, chunkDelayInMs: null }) };
+    },
+  });
+  const priorChars = options.giantPriors ? 10_000 : options.bigPriors ? 2_000 : 120;
+  const priorEvents: RuntimeEvent[] = options.withoutPriorTurns ? [] : [
+    runtimeTextEvent('prior-user', 'turn-0', 'user', `PRIOR_FACT question ${'p'.repeat(priorChars)}`),
+    runtimeTextEvent('prior-model', 'turn-0', 'model', `PRIOR_FACT answer ${'q'.repeat(priorChars)}`),
+  ];
+  const anchor: RuntimeEvent = {
+    ...runtimeTextEvent('anchor-1', 'turn-1', 'user', ANCHOR_TEXT),
+    ...(options.branch !== undefined ? { branch: options.branch } : {}),
+  };
+
+  // The fixture's durable run ledger: the consumer persists every non-partial
+  // mapped RuntimeEvent exactly the way AgentRun.acceptMappedEvent does (same
+  // mapper, same InvocationContext incl. branch), and the durable-read seam
+  // serves it back after pending consumer work has flushed.
+  const ledger: RuntimeEvent[] = [anchor];
+  const ledgerCtx: InvocationContext = {
+    sessionId: 'session-1',
+    invocationId: 'run-1',
+    runId: 'run-1',
+    turnId: 'turn-1',
+    ...(options.branch !== undefined ? { branch: options.branch } : {}),
+    source: 'desktop',
+    startedAt: 1,
+    request: { sessionId: 'session-1', turnId: 'turn-1', text: ANCHOR_TEXT, source: 'desktop' },
+    newId: idGenerator(),
+    now: monotonicClock(),
+  };
+  const ledgerMemory = createSessionEventMapMemory();
+  const persist = (event: SessionEvent): void => {
+    const mapped = mapSessionEventToRuntimeEvent(event, ledgerCtx, ledgerMemory);
+    // Partial snapshots live in side files and non-terminal errors are never
+    // persisted; the immutable ledger holds everything else.
+    if (mapped.partial === true) return;
+    if (mapped.content?.kind === 'error') return;
+    ledger.push(mapped);
+  };
+
+  const backend = new AiSdkBackend({
+    sessionId: 'session-1',
+    header: header(),
+    appendMessage: async (message) => { messages.push(message); },
+    connection: { ...connection(), models: [{ id: 'mock-model-id', contextWindow }] },
+    apiKey: 'sk-test',
+    modelId: 'mock-model-id',
+    permissionEngine: new PermissionEngine({ newId: () => 'permission-id', now: () => 1 }),
+    modelFactory: () => model,
+    tools: [
+      {
+        name: 'Read',
+        description: 'Read description',
+        parameters: z.object({ path: z.string() }),
+        permissionRequired: false,
+        impl: async (args: { path: string }) => {
+          toolExecutions.push(args.path);
+          if (args.path === 'one.md') return { body: options.hugeFirstResult ? HUGE_RESULT : RAW_SPAN_ONE };
+          if (args.path === 'three.md') return { body: ROLLING_TAIL };
+          return { body: RAW_SPAN_TWO };
+        },
+      },
+      ...(options.bigToolGroup
+        ? [{
+            name: 'Big',
+            // A same-turn load_tools activation adds this schema to every later
+            // request; the trigger must count it (finding D).
+            description: `BIG_SCHEMA ${'D'.repeat(12_000)}`,
+            parameters: z.object({ q: z.string() }),
+            permissionRequired: false,
+            impl: async () => ({ ok: true }),
+          }]
+        : []),
+    ],
+    ...(options.bigToolGroup
+      ? { toolAvailability: { economy: true, groups: [{ id: 'big', toolNames: ['Big'] }] } }
+      : {}),
+    ...(options.volatileTurnTail
+      ? { turnTailPrompt: 'VOLATILE_TAIL_SENTINEL cwd=/tmp/maka task=keep-going' }
+      : {}),
+    ...(options.bigSystemPrompt
+      ? { systemPrompt: 'SYSTEM_CONTEXT '.repeat(400) }
+      : {}),
+    contextBudget: {
+      name: 'mid-turn-test',
+      maxHistoryEstimatedTokens: 100_000,
+      minRecentTurns: 1,
+      historyCompact: {
+        enabled: true,
+        mode: 'read_write',
+        midTurn: { enabled: true, reserveTokens },
+      },
+      ...(options.activeToolResultPrune
+        ? { activeToolResultPrune: { enabled: true, maxCurrentResultEstimatedTokens: 30 } }
+        : {}),
+      ...(options.semanticCompact
+        ? {
+            semanticCompact: {
+              enabled: true,
+              mode: 'replace' as const,
+              minStepNumber: 2,
+              maxActiveEstimatedTokens: 1,
+            },
+          }
+        : {}),
+    },
+    ...(options.activeToolResultPrune
+      ? { archiveToolResult: () => ({ artifactId: 'artifact-archived-1' }) }
+      : {}),
+    summarizeHistoryCompact: async (input) => {
+      fixture.summarizerCalls += 1;
+      summarizedSources.push(JSON.stringify(input.source.foldedRuntimeEvents));
+      const summary = options.summarize ? await options.summarize() : 'MID_TURN_SUMMARY_SENTINEL';
+      return summary;
+    },
+    recordHistoryCompactCheckpoint: (checkpoint) => {
+      if (options.record) return options.record(checkpoint);
+      recorded.push(checkpoint);
+    },
+    loadTurnRuntimeEvents: async (turnId) => {
+      fixture.ledgerReads += 1;
+      // Emulate the durable read: let the event consumer's pending microtask
+      // work flush (the real seam awaits the run's serialized write queue).
+      await flushMacrotask();
+      return ledger.filter((event) => event.turnId === turnId);
+    },
+    recordLlmCall: (record) => { llmCalls.push(record as (typeof llmCalls)[number]); },
+    newId: idGenerator(),
+    now: monotonicClock(),
+  });
+  return {
+    backend,
+    model,
+    recorded,
+    recordedBeforeThirdRequest: () => recordedAtThirdRequest,
+    toolExecutions,
+    get summarizerCalls() { return fixture.summarizerCalls; },
+    get ledgerReads() { return fixture.ledgerReads; },
+    priorEvents,
+    anchor,
+    ledger,
+    events,
+    messages,
+    llmCalls,
+    summarizedSources,
+    persist,
+  };
+}
+
+async function runFixtureTurn(fixture: MidTurnFixture, consumer: ConsumerMode = 'immediate'): Promise<void> {
+  for await (const event of fixture.backend.send({
+    runId: 'run-1',
+    turnId: 'turn-1',
+    headAnchorRuntimeEvent: fixture.anchor,
+    text: ANCHOR_TEXT,
+    context: [],
+    runtimeContext: [...fixture.priorEvents],
+  })) {
+    if (consumer === 'slow') {
+      // Scheduling perturbation: hold the durable write back across several
+      // macrotasks so the ledger lags the SDK between steps.
+      await flushMacrotask();
+      await flushMacrotask();
+      await flushMacrotask();
+    }
+    // The consumer persists before continuing, exactly like AgentRun.
+    fixture.persist(event);
+    fixture.events.push(event);
+  }
+}
+
+function promptJson(fixture: MidTurnFixture, call: number): string {
+  return JSON.stringify(fixture.model.doStreamCalls[call]?.prompt.map((message) => ({
+    role: message.role,
+    content: message.content,
+  })));
+}
+
+function compactionDecisions(
+  fixture: MidTurnFixture,
+): NonNullable<ContextBudgetDiagnostic['compactionDecisions']> {
+  const usageEvent = fixture.events.find((event) => event.type === 'token_usage') as
+    | { contextBudget?: ContextBudgetDiagnostic }
+    | undefined;
+  return usageEvent?.contextBudget?.compactionDecisions ?? [];
+}
+
+function defineMidTurnSuite(consumer: ConsumerMode): void {
+  test('compacts over the high water, persists first, and continues the same turn', async () => {
+    const fixture = buildFixture();
+    await runFixtureTurn(fixture, consumer);
+
+    // The turn ran three steps and completed normally.
+    assert.equal(fixture.model.doStreamCalls.length, 3);
+    const complete = fixture.events.find((event) => event.type === 'complete');
+    assert.equal(complete?.type === 'complete' ? complete.stopReason : undefined, 'end_turn');
+
+    // Coverage came from the durable ledger read, not a mirrored stream.
+    assert.equal(fixture.ledgerReads > 0, true);
+
+    // A mid_turn checkpoint was durably recorded before the third request.
+    assert.equal(fixture.recorded.length, 1);
+    assert.equal(fixture.recordedBeforeThirdRequest(), true);
+    const checkpoint = fixture.recorded[0]!;
+    assert.equal(checkpoint.phase, 'mid_turn');
+    assert.deepEqual(checkpoint.headAnchor, { runtimeEventId: 'anchor-1', turnId: 'turn-1' });
+    // Coverage: [prior-user, prior-model, anchor, call-1, result-1] — all of
+    // them durable in the ledger before the checkpoint was recorded.
+    assert.equal(checkpoint.coverage.eventCount, 5);
+
+    // The next step's prompt is [compact block, verbatim head anchor, preserved tail].
+    const thirdPrompt = promptJson(fixture, 2);
+    assert.match(thirdPrompt, /maka_history_compact_checkpoint/);
+    assert.match(thirdPrompt, /MID_TURN_SUMMARY_SENTINEL/);
+    assert.equal(thirdPrompt.includes(ANCHOR_TEXT), true);
+    // The replaced raw span (first tool result and prior turns) is gone...
+    assert.equal(thirdPrompt.includes('RAW_SPAN_ONE_'), false);
+    assert.equal(thirdPrompt.includes('PRIOR_FACT'), false);
+    // ...while the reserved tail (second tool call/result pair) stays verbatim.
+    assert.equal(thirdPrompt.includes('RAW_SPAN_TWO_'), true);
+    assert.match(thirdPrompt, /tool-2/);
+
+    // Completed tool calls are not executed again.
+    assert.deepEqual(fixture.toolExecutions, ['one.md', 'two.md']);
+
+    // The compaction decision lands in the usage diagnostics with phase mid_turn.
+    const midTurnDecision = compactionDecisions(fixture).find((decision) => decision.phase === 'mid_turn');
+    assert.equal(midTurnDecision?.decision, 'replaced');
+    assert.equal(midTurnDecision?.reason, 'context_limit');
+    assert.deepEqual(midTurnDecision?.boundaryIds, [checkpoint.checkpointId]);
+
+    // Invariant: a persisted checkpoint always passes the single replay gate
+    // under the same policy the backend replays with — the next projection
+    // selects it (no coverage_miss, no size rejection).
+    const fit = evaluateHistoryCompactCheckpointReplay(checkpoint, fixture.ledger, {
+      maxHistoryEstimatedTokens: 100_000,
+      minRecentTurns: 1,
+      historyCompact: { enabled: true, mode: 'read_write' },
+    });
+    assert.equal(fit.fits, true);
+  });
+
+  test('recovery re-projection with ctx.branch replays the checkpoint without the raw span', async () => {
+    const fixture = buildFixture({ branch: 'lane-7' });
+    await runFixtureTurn(fixture, consumer);
+    assert.equal(fixture.recorded.length, 1);
+    const checkpoint = fixture.recorded[0]!;
+
+    // The durable ledger the coverage was computed over carries the branch on
+    // every current-turn event, because the fixture consumer maps with the
+    // same InvocationContext (incl. branch) as AiSdkFlow.
+    for (const event of fixture.ledger) {
+      assert.equal(event.branch, 'lane-7');
+    }
+
+    // Recovery: re-project prior turns + the durable current-turn ledger with
+    // normal thresholds — the checkpoint replays and the covered raw span is
+    // never re-injected, even though the raw history is below the high water.
+    const replay = applyRuntimeEventContextBudget([...fixture.priorEvents, ...fixture.ledger], {
+      maxHistoryEstimatedTokens: 100_000,
+      minRecentTurns: 1,
+      historyCompact: { enabled: true, mode: 'read_write', checkpoint },
+    });
+
+    assert.ok(replay);
+    const replayIds = replay.events.map((event) => event.id);
+    assert.equal(replayIds[0], `history-compact:${checkpoint.checkpointId}`);
+    assert.equal(replayIds.includes('anchor-1'), true);
+    assert.deepEqual(replay.events[1], fixture.anchor);
+    assert.equal(replayIds.includes('prior-user'), false);
+    assert.equal(replayIds.includes('prior-model'), false);
+    const replayJson = JSON.stringify(replay.events);
+    assert.equal(replayJson.includes('RAW_SPAN_ONE_'), false);
+    assert.equal(replayJson.includes('RAW_SPAN_TWO_'), true);
+  });
+
+  test('ends the turn with context_budget_exhausted when over the window with no safe span', async () => {
+    // No prior turns and a window the first step's usage already exceeds: the
+    // pool is [anchor, one open call/result pair], so no safe completed span.
+    const fixture = buildFixture({ contextWindow: 120, reserveTokens: 100, withoutPriorTurns: true });
+    await runFixtureTurn(fixture, consumer);
+
+    const complete = fixture.events.find((event) => event.type === 'complete');
+    assert.equal(complete?.type, 'complete');
+    if (complete?.type !== 'complete') return;
+    assert.equal(complete.stopReason, 'context_budget_exhausted');
+    assert.equal(complete.contextBudgetExhaustedDetail, 'no_safe_completed_span');
+    // Explicit outcome, not a raw provider error.
+    assert.equal(fixture.events.some((event) => event.type === 'error'), false);
+    // The over-budget request was aborted before it could stream (the second
+    // doStream attempt sees an already-aborted signal and rejects).
+    assert.equal(fixture.model.doStreamCalls.length <= 2, true);
+    assert.equal(fixture.events.some((event) => event.type === 'tool_start' && event.toolName === 'Read' && JSON.stringify(event.args).includes('two.md')), false);
+  });
+
+  test('ends the turn with summarizer_failed detail when over the window and the summary fails', async () => {
+    // Estimate at the first boundary ≈ 120 real usage + result chars/4 ≈ 200;
+    // window 150 puts it over the hard cap while priors leave a safe span.
+    const fixture = buildFixture({
+      contextWindow: 150,
+      reserveTokens: 100,
+      summarize: () => { throw new Error('summarizer down'); },
+    });
+    await runFixtureTurn(fixture, consumer);
+
+    const complete = fixture.events.find((event) => event.type === 'complete');
+    assert.equal(complete?.type, 'complete');
+    if (complete?.type !== 'complete') return;
+    assert.equal(complete.stopReason, 'context_budget_exhausted');
+    assert.equal(complete.contextBudgetExhaustedDetail, 'summarizer_failed');
+  });
+
+  test('ends the turn with head_anchor_exceeds_capacity when even the minimal projection cannot fit', async () => {
+    // Big priors leave a safe span, the summary succeeds, and the fold
+    // GENUINELY shrinks the payload — but the last request's real input
+    // (1400 tokens) is so large that even the [block, anchor, open pair]
+    // projection stays over the 150-token window: the irreducible remainder
+    // exceeds capacity. (A non-shrinking fold is a different failure —
+    // summarizer_failed via replacement_not_smaller.)
+    const fixture = buildFixture({
+      contextWindow: 150,
+      reserveTokens: 100,
+      bigPriors: true,
+      firstStepUsage: { input: 1_400, output: 20 },
+    });
+    await runFixtureTurn(fixture, consumer);
+
+    const complete = fixture.events.find((event) => event.type === 'complete');
+    assert.equal(complete?.type, 'complete');
+    if (complete?.type !== 'complete') return;
+    assert.equal(complete.stopReason, 'context_budget_exhausted');
+    assert.equal(complete.contextBudgetExhaustedDetail, 'head_anchor_exceeds_capacity');
+    // The fold itself was valid and durable; it just could not rescue.
+    assert.equal(fixture.recorded.length, 1);
+  });
+
+  test('fails open under the window when the summarizer fails, with a diagnostic', async () => {
+    const fixture = buildFixture({ summarize: () => undefined });
+    await runFixtureTurn(fixture, consumer);
+
+    // The turn still completes; the third request keeps the raw span.
+    assert.equal(fixture.model.doStreamCalls.length, 3);
+    const complete = fixture.events.find((event) => event.type === 'complete');
+    assert.equal(complete?.type === 'complete' ? complete.stopReason : undefined, 'end_turn');
+    assert.equal(fixture.recorded.length, 0);
+    const thirdPrompt = promptJson(fixture, 2);
+    assert.equal(thirdPrompt.includes('RAW_SPAN_ONE_'), true);
+    assert.equal(thirdPrompt.includes('maka_history_compact_checkpoint'), false);
+
+    const failedOpen = compactionDecisions(fixture).find(
+      (decision) => decision.phase === 'mid_turn' && decision.decision === 'failedOpen',
+    );
+    assert.equal(failedOpen?.failOpenReason, 'summarizer_failed');
+    // The recorder was never reached, so the diagnostics claim no write.
+    const usageEvent = fixture.events.find((event) => event.type === 'token_usage') as
+      | { contextBudget?: ContextBudgetDiagnostic }
+      | undefined;
+    assert.equal(usageEvent?.contextBudget?.historyCompactWritesAttempted, undefined);
+    assert.equal(usageEvent?.contextBudget?.historyCompactWriteFailures, undefined);
+  });
+
+  test('fails open with write_failed diagnostics when the checkpoint write fails under the window', async () => {
+    const fixture = buildFixture({ record: () => { throw new Error('disk full'); } });
+    await runFixtureTurn(fixture, consumer);
+
+    // The turn still completes on the raw projection; nothing durable claims
+    // a successful write.
+    assert.equal(fixture.model.doStreamCalls.length, 3);
+    const complete = fixture.events.find((event) => event.type === 'complete');
+    assert.equal(complete?.type === 'complete' ? complete.stopReason : undefined, 'end_turn');
+    assert.equal(fixture.recorded.length, 0);
+    assert.equal(promptJson(fixture, 2).includes('RAW_SPAN_ONE_'), true);
+
+    const failedOpen = compactionDecisions(fixture).find(
+      (decision) => decision.phase === 'mid_turn' && decision.decision === 'failedOpen',
+    );
+    assert.equal(failedOpen?.failOpenReason, 'write_failed');
+    // The recorder WAS invoked and failed: exactly that is what the counters say.
+    const usageEvent = fixture.events.find((event) => event.type === 'token_usage') as
+      | { contextBudget?: ContextBudgetDiagnostic }
+      | undefined;
+    assert.equal(usageEvent?.contextBudget?.historyCompactWritesAttempted, 1);
+    assert.equal(usageEvent?.contextBudget?.historyCompactWriteFailures, 1);
+  });
+
+  test('exhausts with write_failed in the durable diagnostics when the write fails over the window', async () => {
+    // Big priors make folding rescue the over-window estimate, so the plan
+    // compacts and the failure happens AT the recorder — over the window that
+    // is the explicit exhausted outcome, and the durable diagnostics must
+    // carry write_failed even though the terminal enum has no write member.
+    const fixture = buildFixture({
+      contextWindow: 150,
+      reserveTokens: 100,
+      bigPriors: true,
+      record: () => { throw new Error('disk full'); },
+    });
+    await runFixtureTurn(fixture, consumer);
+
+    const complete = fixture.events.find((event) => event.type === 'complete');
+    assert.equal(complete?.type, 'complete');
+    if (complete?.type !== 'complete') return;
+    assert.equal(complete.stopReason, 'context_budget_exhausted');
+    assert.equal(complete.contextBudgetExhaustedDetail, 'summarizer_failed');
+
+    const lastCall = fixture.llmCalls.at(-1);
+    const exhaustedDecision = (lastCall?.contextBudget?.compactionDecisions ?? []).find(
+      (decision) => decision.phase === 'mid_turn' && decision.reason === 'context_budget_exhausted',
+    );
+    assert.equal(exhaustedDecision?.skippedReasonCounts?.write_failed, 1);
+    assert.equal(lastCall?.contextBudget?.historyCompactWritesAttempted, 1);
+    assert.equal(lastCall?.contextBudget?.historyCompactWriteFailures, 1);
+  });
+
+  test('fails open with a diagnostic when the durable ledger read fails (never a silent skip)', async () => {
+    const fixture = buildFixture();
+    // Break the seam after construction: every trigger read now rejects.
+    (fixture.backend as unknown as {
+      input: { loadTurnRuntimeEvents: () => Promise<RuntimeEvent[]> };
+    }).input.loadTurnRuntimeEvents = () => Promise.reject(new Error('ledger offline'));
+    await runFixtureTurn(fixture, consumer);
+
+    // The turn still completes on the raw projection; nothing was recorded.
+    assert.equal(fixture.model.doStreamCalls.length, 3);
+    const complete = fixture.events.find((event) => event.type === 'complete');
+    assert.equal(complete?.type === 'complete' ? complete.stopReason : undefined, 'end_turn');
+    assert.equal(fixture.recorded.length, 0);
+    assert.equal(promptJson(fixture, 2).includes('RAW_SPAN_ONE_'), true);
+
+    const failedOpen = compactionDecisions(fixture).find(
+      (decision) => decision.phase === 'mid_turn' && decision.decision === 'failedOpen',
+    );
+    assert.equal(failedOpen?.failOpenReason, 'ledger_read_failed');
+  });
+
+  test('active tool-result prune re-converges the rebuilt tail after a capacity replacement', async () => {
+    const fixture = buildFixture({ activeToolResultPrune: true });
+    await runFixtureTurn(fixture, consumer);
+
+    assert.equal(fixture.model.doStreamCalls.length, 3);
+    assert.equal(fixture.recorded.length, 1);
+    const thirdPrompt = promptJson(fixture, 2);
+    // Capacity compaction owns the projection: compact block + verbatim anchor.
+    assert.match(thirdPrompt, /maka_history_compact_checkpoint/);
+    assert.equal(thirdPrompt.includes(ANCHOR_TEXT), true);
+    assert.equal(thirdPrompt.includes('RAW_SPAN_ONE_'), false);
+    // The large tool result in the rebuilt tail is re-archived to a
+    // placeholder by the prune hook running AFTER the capacity hook — the
+    // capacity replacement must not resurrect the raw body.
+    assert.equal(thirdPrompt.includes('RAW_SPAN_TWO_'), false);
+    assert.match(thirdPrompt, /artifact-archived-1/);
+    assert.match(thirdPrompt, /active_current_turn_tool_result_pruned_before_next_step/);
+  });
+
+  test('semantic compaction yields on the step the capacity hook replaced', async () => {
+    const fixture = buildFixture({ semanticCompact: true });
+    await runFixtureTurn(fixture, consumer);
+
+    // The capacity projection won the replaced step.
+    assert.equal(fixture.model.doStreamCalls.length, 3);
+    assert.equal(fixture.recorded.length, 1);
+    assert.match(promptJson(fixture, 2), /maka_history_compact_checkpoint/);
+
+    // Deterministic priority: semantic compaction was skipped for that step
+    // with an explicit decision — one step never runs two summarizers.
+    const yielded = compactionDecisions(fixture).find(
+      (decision) => decision.reason === 'mid_turn_capacity_precedence',
+    );
+    assert.equal(yielded?.decision, 'unchanged');
+    assert.equal(fixture.summarizerCalls, 1);
+    // No semantic summary model call was ever made.
+    assert.equal(fixture.events.some((event) => event.type === 'error'), false);
+  });
+
+  test('a rolling second compaction that still exceeds the window ends explicitly (review finding A)', async () => {
+    // Review round-3 finding A: the old post-fold re-estimate subtracted the
+    // RAW covered span from a usage estimate anchored to the ALREADY-compacted
+    // previous request, over-crediting the second fold and letting a
+    // still-over-window request stream. The final-payload owner measures the
+    // real replacement projection instead: the third step's huge result makes
+    // even [second block, anchor, tail] exceed the window, so the turn must
+    // end with the explicit outcome — never send the over-window request.
+    const fixture = buildFixture({ bigPriors: true, rollingOverflow: true });
+    await runFixtureTurn(fixture, consumer);
+
+    // The first fold happened and its projection was used (three requests ran).
+    assert.equal(fixture.recorded.length, 2);
+    assert.equal(fixture.recorded[0]?.phase, 'mid_turn');
+    // The second fold rolled forward from the first checkpoint...
+    assert.equal(fixture.recorded[1]?.previousCheckpointId, fixture.recorded[0]?.checkpointId);
+    // ...but its replacement still exceeds the window: explicit outcome.
+    const complete = fixture.events.find((event) => event.type === 'complete');
+    assert.equal(complete?.type, 'complete');
+    if (complete?.type !== 'complete') return;
+    assert.equal(complete.stopReason, 'context_budget_exhausted');
+    assert.equal(complete.contextBudgetExhaustedDetail, 'head_anchor_exceeds_capacity');
+    // The over-window fourth request never streamed.
+    assert.equal(fixture.events.some((event) => event.type === 'text_complete' && event.text === 'done'), false);
+  });
+
+  test('an aborted multi-step send records the accumulated usage of the completed steps', async () => {
+    // The terminal LLM-call record is fail-closed on usage evidence (#972),
+    // and an aborted send never resolves the SDK's totalUsage promise. But
+    // every COMPLETED step reported real usage at its finish-step boundary,
+    // so the terminal record must carry that accumulated sum — the capacity
+    // verdict diagnostics ride this record and the completed steps' cost is
+    // real. Three steps stream (100/20 + 150/30 + 150/30) before the step-4
+    // verdict aborts the send.
+    const fixture = buildFixture({ bigPriors: true, rollingOverflow: true });
+    await runFixtureTurn(fixture, consumer);
+
+    const complete = fixture.events.find((event) => event.type === 'complete');
+    assert.equal(complete?.type === 'complete' ? complete.stopReason : undefined, 'context_budget_exhausted');
+    // Three requests streamed; the fourth doStream call rejects immediately on
+    // the already-aborted signal and never reports usage.
+    assert.equal(fixture.model.doStreamCalls.length, 4);
+    const lastCall = fixture.llmCalls.at(-1);
+    assert.equal(lastCall?.status, 'error');
+    assert.equal(lastCall?.errorClass, 'ContextBudgetExhausted');
+    assert.equal(lastCall?.inputTokens, 400);
+    assert.equal(lastCall?.outputTokens, 80);
+    assert.equal(lastCall?.totalTokens, 480);
+  });
+
+  test('an unusable completed-step usage sample fails the whole record closed — no partial sum (review round-7)', async () => {
+    // #972 semantics: incomplete usage evidence fails closed. The first
+    // completed step's usage is unusable (normalization returns undefined),
+    // so the sum of the remaining steps (150/30 + 150/30) is a PARTIAL cost.
+    // LlmCallRecord has no partial marker — downstream reads any record as
+    // the whole call — so the truthful outcome is no record at all; the
+    // terminal result stays observable on the durable CompleteEvent.
+    const fixture = buildFixture({ bigPriors: true, rollingOverflow: true, firstStepUsage: 'missing' });
+    await runFixtureTurn(fixture, consumer);
+
+    const complete = fixture.events.find((event) => event.type === 'complete');
+    assert.equal(complete?.type === 'complete' ? complete.stopReason : undefined, 'context_budget_exhausted');
+    assert.equal(fixture.llmCalls.length, 0);
+  });
+
+  test('the verdict is issued after pruning — a prune-rescuable step is not exhausted (review finding C)', async () => {
+    // Review round-3 finding C repro: one huge tool result, no safe completed
+    // span for the capacity hook, but the active tool-result prune (which runs
+    // AFTER the capacity hook) archives the result down to a placeholder that
+    // fits the window. A verdict inside the capacity hook would have declared
+    // context_budget_exhausted before the rescue could run.
+    const fixture = buildFixture({
+      contextWindow: 500,
+      reserveTokens: 100,
+      withoutPriorTurns: true,
+      hugeFirstResult: true,
+      finalAtSecondCall: true,
+      activeToolResultPrune: true,
+    });
+    await runFixtureTurn(fixture, consumer);
+
+    const complete = fixture.events.find((event) => event.type === 'complete');
+    assert.equal(complete?.type === 'complete' ? complete.stopReason : undefined, 'end_turn');
+    assert.equal(fixture.model.doStreamCalls.length, 2);
+    // The second request carries the archive placeholder, not the raw body.
+    const secondPrompt = promptJson(fixture, 1);
+    assert.equal(secondPrompt.includes('HUGE_RESULT_'), false);
+    assert.match(secondPrompt, /artifact-archived-1/);
+    // The capacity hook's failure is a diagnostic, not a terminal outcome.
+    const failedOpen = compactionDecisions(fixture).find(
+      (decision) => decision.phase === 'mid_turn' && decision.decision === 'failedOpen',
+    );
+    assert.equal(failedOpen?.failOpenReason, 'no_safe_completed_span');
+  });
+
+  test('the trigger counts same-turn tool-schema growth from load_tools (review finding D)', async () => {
+    // Review round-3 finding D repro: the model activates a ~12.7k-char tool
+    // group mid-turn. The schema lands in every later request, so the payload
+    // estimate must count it: the next request cannot fit the 500-token window
+    // and the pool has no safe completed span, so the turn ends explicitly
+    // instead of streaming a ~3k-token request into a 500-token window.
+    const fixture = buildFixture({
+      contextWindow: 500,
+      reserveTokens: 100,
+      withoutPriorTurns: true,
+      bigToolGroup: true,
+    });
+    await runFixtureTurn(fixture, consumer);
+
+    const complete = fixture.events.find((event) => event.type === 'complete');
+    assert.equal(complete?.type, 'complete');
+    if (complete?.type !== 'complete') return;
+    assert.equal(complete.stopReason, 'context_budget_exhausted');
+    assert.equal(complete.contextBudgetExhaustedDetail, 'no_safe_completed_span');
+    // The over-window second request never streamed the expanded schema.
+    assert.equal(fixture.events.some((event) => event.type === 'text_complete' && event.text === 'done'), false);
+  });
+
+  test('a fold that cannot shrink the real payload is refused, not applied (runaway summary)', async () => {
+    // The summarizer returns a block far larger than the span it replaces.
+    // Applying it would hand the verdict owner a WORSE request than the raw
+    // projection; the hook measures the materialized payload and keeps the raw
+    // messages instead. Validation runs before the recorder, so the rejected
+    // checkpoint is never persisted (asserted below).
+    const fixture = buildFixture({ summarize: () => 'GIANT_SUMMARY_'.repeat(600) });
+    await runFixtureTurn(fixture, consumer);
+
+    assert.equal(fixture.model.doStreamCalls.length, 3);
+    const complete = fixture.events.find((event) => event.type === 'complete');
+    assert.equal(complete?.type === 'complete' ? complete.stopReason : undefined, 'end_turn');
+    // The raw span stayed; the giant block was never sent.
+    const thirdPrompt = promptJson(fixture, 2);
+    assert.equal(thirdPrompt.includes('RAW_SPAN_ONE_'), true);
+    assert.equal(thirdPrompt.includes('GIANT_SUMMARY_'), false);
+    const failedOpen = compactionDecisions(fixture).find(
+      (decision) => decision.phase === 'mid_turn' && decision.decision === 'failedOpen',
+    );
+    assert.equal(failedOpen?.failOpenReason, 'replacement_not_smaller');
+    // Review round-4 finding 3: a checkpoint whose replacement was REJECTED
+    // must never be persisted — replay applies the session's latest checkpoint
+    // before any high-water check, so a persisted runaway block would poison
+    // every later projection even though this step correctly refused it.
+    assert.equal(fixture.recorded.length, 0);
+    // The recorder was never reached, so the diagnostics claim no write.
+    const usageEvent = fixture.events.find((event) => event.type === 'token_usage') as
+      | { contextBudget?: ContextBudgetDiagnostic }
+      | undefined;
+    assert.equal(usageEvent?.contextBudget?.historyCompactWritesAttempted, undefined);
+  });
+
+  test('the usage baseline is the last request\'s INPUT tokens — output is not double-counted (review finding 1)', async () => {
+    // Review round-4 finding 1 repro shape: a step with heavy output. The
+    // signed payload delta already carries the freshly generated assistant
+    // output and tool results, so a baseline of input+output counts the
+    // output twice (~500 real tokens estimated as ~900) and terminates a
+    // turn that actually fits the window.
+    const fixture = buildFixture({
+      contextWindow: 500,
+      reserveTokens: 100,
+      withoutPriorTurns: true,
+      finalAtSecondCall: true,
+      firstStepUsage: { input: 300, output: 380 },
+    });
+    await runFixtureTurn(fixture, consumer);
+
+    // input(300) + payload delta (~hundred tokens) fits the 500 window; the
+    // double-counting baseline (680 + delta) would have exhausted it.
+    const complete = fixture.events.find((event) => event.type === 'complete');
+    assert.equal(complete?.type === 'complete' ? complete.stopReason : undefined, 'end_turn');
+    assert.equal(fixture.model.doStreamCalls.length, 2);
+  });
+
+  test('a usage object without usable input tokens falls back to cold start, never to zero (review finding 1)', async () => {
+    // Reverse direction: the adapter normalizes missing token fields to 0. A
+    // zero baseline plus a small delta estimates a huge request as tiny and
+    // lets it stream over the window; an unusable usage sample must instead
+    // fall back to the whole-payload cold-start estimate, which triggers the
+    // fold here (big priors leave a safe span, so compaction rescues).
+    const fixture = buildFixture({
+      contextWindow: 1_000,
+      reserveTokens: 100,
+      bigPriors: true,
+      finalAtSecondCall: true,
+      firstStepUsage: 'missing',
+    });
+    await runFixtureTurn(fixture, consumer);
+
+    assert.equal(fixture.recorded.length, 1);
+    const secondPrompt = promptJson(fixture, 1);
+    assert.match(secondPrompt, /maka_history_compact_checkpoint/);
+    assert.equal(secondPrompt.includes('PRIOR_FACT'), false);
+    const complete = fixture.events.find((event) => event.type === 'complete');
+    assert.equal(complete?.type === 'complete' ? complete.stopReason : undefined, 'end_turn');
+  });
+
+  test('the volatile turn tail survives a capacity replacement (review finding 2)', async () => {
+    // The initial provider user message decorates the durable anchor text
+    // with a volatile turn tail (cwd, shell context, task state). The
+    // replacement projection is materialized from the ledger, where the
+    // anchor holds only the raw user text — the rendering must go through
+    // the same decoration owner or compaction silently drops that context
+    // (and even counts the drop as shrinkage).
+    const fixture = buildFixture({ volatileTurnTail: true });
+    await runFixtureTurn(fixture, consumer);
+
+    assert.equal(fixture.recorded.length, 1);
+    const thirdPrompt = promptJson(fixture, 2);
+    assert.match(thirdPrompt, /maka_history_compact_checkpoint/);
+    assert.equal(thirdPrompt.includes(ANCHOR_TEXT), true);
+    assert.equal(thirdPrompt.includes('VOLATILE_TAIL_SENTINEL'), true);
+    const complete = fixture.events.find((event) => event.type === 'complete');
+    assert.equal(complete?.type === 'complete' ? complete.stopReason : undefined, 'end_turn');
+  });
+
+  test('an over-window runaway summary terminates as summarizer_failed, not head_anchor_exceeds_capacity (review finding 4)', async () => {
+    // A non-shrinking replacement proves the summarizer's output is unusable,
+    // not that the irreducible remainder (anchor + tail + overhead) exceeds
+    // capacity — the terminal detail must say so; the diagnostic reason keeps
+    // the precise replacement_not_smaller cause.
+    const fixture = buildFixture({
+      contextWindow: 150,
+      reserveTokens: 100,
+      summarize: () => 'GIANT_SUMMARY_'.repeat(600),
+    });
+    await runFixtureTurn(fixture, consumer);
+
+    const complete = fixture.events.find((event) => event.type === 'complete');
+    assert.equal(complete?.type, 'complete');
+    if (complete?.type !== 'complete') return;
+    assert.equal(complete.stopReason, 'context_budget_exhausted');
+    assert.equal(complete.contextBudgetExhaustedDetail, 'summarizer_failed');
+    const lastCall = fixture.llmCalls.at(-1);
+    const exhaustedDecision = (lastCall?.contextBudget?.compactionDecisions ?? []).find(
+      (decision) => decision.phase === 'mid_turn' && decision.reason === 'context_budget_exhausted',
+    );
+    assert.equal(exhaustedDecision?.skippedReasonCounts?.replacement_not_smaller, 1);
+    // The rejected checkpoint was never persisted.
+    assert.equal(fixture.recorded.length, 0);
+  });
+
+  test('a checkpoint the next replay would reject is never persisted (review round-5 finding 1)', async () => {
+    // Review round-5 repro: maxSummaryEstimatedTokens defaults to 1024, and a
+    // 5000-char summary yields a ~1133-token checkpoint envelope. The fold
+    // clearly SHRINKS the giant covered span, so materialize+smaller alone
+    // accept and persist it — but the recovery path's single replay gate
+    // (max_block_tokens) rejects it next round and re-projects the covered
+    // raw span, violating the never-re-injected invariant. Validation must
+    // therefore include replay admissibility, through the same gate function
+    // with the same policy — one acceptance standard, not two.
+    const fixture = buildFixture({
+      giantPriors: true,
+      summarize: () => 'S'.repeat(5_000),
+    });
+    await runFixtureTurn(fixture, consumer);
+
+    // The inadmissible checkpoint was never persisted...
+    assert.equal(fixture.recorded.length, 0);
+    // ...the step failed open on the raw projection...
+    assert.equal(fixture.model.doStreamCalls.length, 3);
+    const complete = fixture.events.find((event) => event.type === 'complete');
+    assert.equal(complete?.type === 'complete' ? complete.stopReason : undefined, 'end_turn');
+    const thirdPrompt = promptJson(fixture, 2);
+    assert.equal(thirdPrompt.includes('PRIOR_FACT'), true);
+    assert.equal(thirdPrompt.includes('maka_history_compact_checkpoint'), false);
+    // ...with the precise gate reason in the diagnostics.
+    const failedOpen = compactionDecisions(fixture).find(
+      (decision) => decision.phase === 'mid_turn' && decision.decision === 'failedOpen',
+    );
+    assert.equal(failedOpen?.failOpenReason, 'replay_rejected_max_block_tokens');
+  });
+
+  test('the cold-start estimate covers the FULL provider input including the system prompt (review round-5 finding 2)', async () => {
+    // The system prompt travels in the separate `system` field, not in
+    // messages. With usage missing, a cold-start estimate over messages+tools
+    // alone (~2150 tokens) stays under the 2900 high water and lets a real
+    // ~3650-token request stream into a 3000-token window. The single payload
+    // measure must include the system prompt: constant between adjacent
+    // requests (signed deltas unaffected), decisive for cold start.
+    const fixture = buildFixture({
+      contextWindow: 3_000,
+      reserveTokens: 100,
+      withoutPriorTurns: true,
+      hugeFirstResult: true,
+      finalAtSecondCall: true,
+      firstStepUsage: 'missing',
+      bigSystemPrompt: true,
+    });
+    await runFixtureTurn(fixture, consumer);
+
+    const complete = fixture.events.find((event) => event.type === 'complete');
+    assert.equal(complete?.type, 'complete');
+    if (complete?.type !== 'complete') return;
+    assert.equal(complete.stopReason, 'context_budget_exhausted');
+    assert.equal(complete.contextBudgetExhaustedDetail, 'no_safe_completed_span');
+    // The over-window second request never streamed.
+    assert.equal(fixture.events.some((event) => event.type === 'text_complete' && event.text === 'done'), false);
+    // Every completed step's usage was unusable, so there is no usage
+    // evidence at all: the fail-closed terminal record is skipped and the
+    // exhausted outcome is observable only through the CompleteEvent above.
+    assert.equal(fixture.llmCalls.length, 0);
+  });
+
+  test('a completed step\'s assistant text is never dropped from the replacement (review finding B)', async () => {
+    // Review round-3 finding B repro: the FIRST step emits assistant text AND
+    // a tool call, and the trigger fires at that step's own boundary. The old
+    // durable watermark waited only for the tool call/response pair — which
+    // are enqueued DURING the step, before the pump flushes the step's
+    // text_complete — so under a slow consumer the ledger could satisfy the
+    // watermark while the already-emitted assistant text was still missing.
+    // Because the replacement projection replaces the WHOLE message list,
+    // that text silently vanished from the next request. The seq-ack boundary
+    // counts the event stream itself (pump flush of the step boundary + the
+    // consumer's processed ack), so the durable pool must contain the step's
+    // text before any coverage is computed.
+    const fixture = buildFixture({
+      // High water at 200 tokens: the first step's usage (120) plus its tool
+      // result delta crosses it, so the trigger fires at the step-1 boundary.
+      reserveTokens: 1_800,
+      assistantTextInFirstStep: true,
+      finalAtSecondCall: true,
+    });
+    await runFixtureTurn(fixture, consumer);
+
+    // The text was emitted to the user...
+    assert.equal(
+      fixture.events.some((event) => event.type === 'text_complete' && event.text.includes('ASSISTANT_SENTINEL')),
+      true,
+    );
+    // ...and the projection accounts for it: the step-1 text event is in the
+    // durable pool when coverage is computed, so it survives either verbatim
+    // in the preserved tail of the second request or inside the summarized
+    // covered span — never silently dropped from both.
+    assert.equal(fixture.recorded.length, 1);
+    const secondPrompt = promptJson(fixture, 1);
+    assert.match(secondPrompt, /maka_history_compact_checkpoint/);
+    const inTail = secondPrompt.includes('ASSISTANT_SENTINEL');
+    const inCoveredSpan = fixture.summarizedSources.join('\n').includes('ASSISTANT_SENTINEL');
+    assert.equal(inTail || inCoveredSpan, true);
+    // The turn still completes normally on the compacted projection.
+    const complete = fixture.events.find((event) => event.type === 'complete');
+    assert.equal(complete?.type === 'complete' ? complete.stopReason : undefined, 'end_turn');
+  });
+
+}
+
+describe('mid-turn capacity compaction in the streaming backend', () => {
+  defineMidTurnSuite('immediate');
+});
+
+describe('mid-turn capacity compaction with a slow ledger consumer', () => {
+  // Review round-2/3 repro: the consumer that persists to the durable ledger
+  // yields several macrotasks per event, so the ledger genuinely lags the
+  // SDK's step progression. The seq-ack durability boundary must make every
+  // behavior above hold identically — no over-window request slipping out,
+  // and no completed-step content silently dropped from a replacement.
+  defineMidTurnSuite('slow');
+});
+
+describe('mid-turn capacity compaction flow plumbing', () => {
+  test('AiSdkFlow forwards the persisted head anchor to backend.send', async () => {
+    const sendInputs: BackendSendInput[] = [];
+    const anchor = runtimeTextEvent('anchor-1', 'turn-1', 'user', ANCHOR_TEXT);
+    const fakeBackend: AgentBackend = {
+      kind: 'ai-sdk',
+      sessionId: 'session-1',
+      // eslint-disable-next-line @typescript-eslint/require-await
+      async *send(input: BackendSendInput): AsyncIterable<SessionEvent> {
+        sendInputs.push(input);
+        yield { type: 'complete', id: 'complete-1', turnId: input.turnId, ts: 2, stopReason: 'end_turn' };
+      },
+      stop: async () => {},
+      respondToPermission: async () => {},
+      dispose: async () => {},
+    };
+    const flow = new AiSdkFlow({ backend: fakeBackend });
+    const ctx: InvocationContext = {
+      sessionId: 'session-1',
+      invocationId: 'run-1',
+      runId: 'run-1',
+      turnId: 'turn-1',
+      branch: 'lane-7',
+      source: 'desktop',
+      startedAt: 1,
+      request: {
+        sessionId: 'session-1',
+        turnId: 'turn-1',
+        text: 'hello',
+        source: 'desktop',
+        initialRuntimeEvent: anchor,
+      },
+      newId: idGenerator(),
+      now: monotonicClock(),
+    };
+    for await (const _event of flow.run(ctx, { text: 'hello', context: [] })) {
+      // drain
+    }
+    assert.equal(sendInputs.length, 1);
+    assert.equal(sendInputs[0]?.headAnchorRuntimeEvent, anchor);
+  });
+});
+
+function runtimeTextEvent(id: string, turnId: string, role: 'user' | 'model', text: string): RuntimeEvent {
+  return {
+    id,
+    sessionId: 'session-1',
+    runId: 'run-1',
+    turnId,
+    invocationId: 'run-1',
+    ts: 1_800_000_000_000,
+    partial: false,
+    role,
+    author: role === 'user' ? 'user' : 'agent',
+    content: { kind: 'text', text },
+  };
+}
+
+function header(): SessionHeader {
+  return {
+    id: 'session-1',
+    workspaceRoot: '/tmp/maka',
+    cwd: '/tmp/maka',
+    createdAt: 1,
+    lastUsedAt: 1,
+    name: 'Test',
+    isFlagged: false,
+    labels: [],
+    isArchived: false,
+    status: 'active',
+    statusUpdatedAt: 1,
+    hasUnread: false,
+    backend: 'ai-sdk',
+    llmConnectionSlug: 'anthropic-main',
+    connectionLocked: true,
+    model: 'mock-model-id',
+    permissionMode: 'ask',
+    schemaVersion: 1,
+  };
+}
+
+function connection(): LlmConnection {
+  return {
+    slug: 'anthropic-main',
+    name: 'Anthropic',
+    providerType: 'anthropic',
+    defaultModel: 'mock-model-id',
+    enabled: true,
+    createdAt: 1,
+    updatedAt: 1,
+  };
+}
+
+function idGenerator(): () => string {
+  let index = 0;
+  return () => `id-${++index}`;
+}
+
+function monotonicClock(): () => number {
+  let value = 1_000;
+  return () => ++value;
+}

--- a/packages/runtime/src/__tests__/mid-turn-capacity-compact.test.ts
+++ b/packages/runtime/src/__tests__/mid-turn-capacity-compact.test.ts
@@ -1,0 +1,311 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+import type { RuntimeEvent } from '@maka/core/runtime-event';
+import {
+  estimateNextRequestTokens,
+  exceedsContextWindow,
+  exceedsHighWater,
+  planMidTurnCapacityCompaction,
+  selectMidTurnSafeBoundary,
+  type PlanMidTurnCapacityCompactionInput,
+} from '../mid-turn-capacity-compact.js';
+import { applyRuntimeEventHistoryCompact } from '../context-budget.js';
+import { matchHistoryCompactCheckpointPrefix } from '../history-compact-checkpoint.js';
+
+describe('mid-turn capacity trigger measurement', () => {
+  test('anchors on real provider usage plus a tail char/4 delta', () => {
+    // last step: 100 input + 40 output real tokens, then 400 chars of new tool results
+    assert.equal(
+      estimateNextRequestTokens({ priorUsageTokens: 140, appendedChars: 400, charsPerToken: 4 }),
+      140 + 100,
+    );
+  });
+
+  test('credits a SIGNED negative payload delta after a compaction shrank the projection', () => {
+    // The last usage sample measured the PRE-compaction request; the payload
+    // delta is negative after the fold, so the estimate must shrink with it —
+    // clamping the delta at zero would judge the compacted request by the
+    // pre-compaction usage and wrongly exhaust a rescued turn.
+    assert.equal(
+      estimateNextRequestTokens({ priorUsageTokens: 700, appendedChars: -1_200, charsPerToken: 4 }),
+      400,
+    );
+    // The estimate never goes below zero even when the shrink exceeds usage.
+    assert.equal(
+      estimateNextRequestTokens({ priorUsageTokens: 100, appendedChars: -4_000, charsPerToken: 4 }),
+      0,
+    );
+  });
+
+  test('falls back to whole-projection char/4 on cold start (no usage)', () => {
+    assert.equal(
+      estimateNextRequestTokens({ appendedChars: 40, charsPerToken: 4, coldStartChars: 800 }),
+      200,
+    );
+  });
+
+  test('high-water crosses at contextWindow minus reserve; hard cap at the window', () => {
+    assert.equal(exceedsHighWater(100_000, 128_000, 16_384), false);
+    assert.equal(exceedsHighWater(120_000, 128_000, 16_384), true);
+    assert.equal(exceedsContextWindow(120_000, 128_000), false);
+    assert.equal(exceedsContextWindow(130_000, 128_000), true);
+  });
+});
+
+describe('mid-turn safe boundary selection', () => {
+  test('folds the largest immutable non-partial prefix, leaving the reserved tail', () => {
+    const events = [
+      user('anchor', 'turn-1'),
+      model('m1', 'turn-1'),
+      model('m2', 'turn-1'),
+      model('m3', 'turn-1'),
+    ];
+    const boundary = selectMidTurnSafeBoundary(events, { reserveTailEvents: 1 });
+    assert.deepEqual(boundary, { ok: true, coveredCount: 3 });
+  });
+
+  test('never cuts on a partial (streaming) event', () => {
+    const events = [
+      user('anchor', 'turn-1'),
+      model('m1', 'turn-1'),
+      { ...model('m2-partial', 'turn-1'), partial: true },
+    ];
+    // Reserving 0 tail would cut after the partial; it must retreat to m1.
+    const boundary = selectMidTurnSafeBoundary(events, { reserveTailEvents: 0 });
+    assert.deepEqual(boundary, { ok: true, coveredCount: 2 });
+  });
+
+  test('never splits a tool call/result pair', () => {
+    const events = [
+      user('anchor', 'turn-1'),
+      call('c1', 'call-1', 'turn-1'),
+      result('r1', 'call-1', 'turn-1'),
+      call('c2', 'call-2', 'turn-1'),
+      result('r2', 'call-2', 'turn-1'),
+    ];
+    // reserveTail=2 would cut at index 3, between call-2 and its result → retreat to 3? No:
+    // index 3 straddles call-2(3)/result-2(4)? call at 3 >= 3, result at 4 >= 3, both outside → safe.
+    // Force a straddle: reserveTail=1 → maxCut=4 straddles nothing (call-2 at 3<4, result-2 at 4>=4) → straddle, retreat to 3.
+    const boundary = selectMidTurnSafeBoundary(events, { reserveTailEvents: 1 });
+    assert.deepEqual(boundary, { ok: true, coveredCount: 3 });
+  });
+
+  test('retreats before a partial in the middle of the prefix, not just at the cut', () => {
+    const events = [
+      user('anchor', 'turn-1'),
+      { ...model('m-partial', 'turn-1'), partial: true },
+      model('m-final', 'turn-1'),
+    ];
+    // With no reserved tail the largest cut ends on the immutable m-final, but
+    // the prefix would still span the partial snapshot — coverage must stop
+    // strictly before the first partial.
+    const boundary = selectMidTurnSafeBoundary(events, { reserveTailEvents: 0 });
+    assert.deepEqual(boundary, { ok: true, coveredCount: 1 });
+  });
+
+  test('never covers an open tool call whose response has not arrived', () => {
+    const events = [
+      model('prior', 'turn-0'),
+      user('anchor', 'turn-1'),
+      call('open-call', 'call-open', 'turn-1'),
+    ];
+    // Even with no reserved tail, covering the open call would orphan the
+    // response that lands after compaction — the cut must stop before it.
+    const boundary = selectMidTurnSafeBoundary(events, { reserveTailEvents: 0 });
+    assert.deepEqual(boundary, { ok: true, coveredCount: 2 });
+  });
+
+  test('reports no safe completed span when the whole pool is one atomic pair', () => {
+    const events = [
+      call('c1', 'call-1', 'turn-1'),
+      result('r1', 'call-1', 'turn-1'),
+    ];
+    // Reserving 1 tail forces maxCut=1, which straddles the only pair → no safe span.
+    const boundary = selectMidTurnSafeBoundary(events, { reserveTailEvents: 1 });
+    assert.deepEqual(boundary, { ok: false, reason: 'no_safe_completed_span' });
+  });
+});
+
+describe('plan mid-turn capacity compaction', () => {
+  // A long turn: two prior turns folded already conceptually, plus the current
+  // turn's head anchor and several completed steps.
+  function longTurnEvents(): RuntimeEvent[] {
+    return [
+      model('prior-0', 'turn-0'),
+      model('prior-1', 'turn-0'),
+      user('anchor', 'turn-1'),
+      call('call-a', 'ca', 'turn-1'),
+      result('res-a', 'ca', 'turn-1'),
+      call('call-b', 'cb', 'turn-1'),
+      result('res-b', 'cb', 'turn-1'),
+    ];
+  }
+  function planInput(over: Partial<PlanMidTurnCapacityCompactionInput> = {}): PlanMidTurnCapacityCompactionInput {
+    return {
+      sessionId: 'session-1',
+      orderedEvents: longTurnEvents(),
+      headAnchor: { runtimeEventId: 'anchor', turnId: 'turn-1' },
+      estimatedNextRequestTokens: 120_000,
+      contextWindow: 128_000,
+      reserveTokens: 16_384,
+      reserveTailEvents: 1,
+      charsPerToken: 4,
+      now: 1_800_000_010_000,
+      summarize: () => 'A faithful mid-turn summary.',
+      ...over,
+    };
+  }
+
+  test('skips below the high-water threshold', async () => {
+    const result = await planMidTurnCapacityCompaction(planInput({ estimatedNextRequestTokens: 100_000 }));
+    assert.deepEqual(result, { decision: 'skip', reason: 'below_high_water' });
+  });
+
+  test('compacts a safe prefix, keeps the head anchor verbatim, and continues with the tail', async () => {
+    const result = await planMidTurnCapacityCompaction(planInput());
+    assert.equal(result.decision, 'compacted');
+    if (result.decision !== 'compacted') return;
+    assert.equal(result.checkpoint.phase, 'mid_turn');
+    // Replacement is [block, verbatim head anchor, ...tail]; completed tool
+    // calls/results before the boundary are folded, not replayed raw.
+    const ids = result.replacementEvents.map((event) => event.id);
+    assert.equal(ids[0], `history-compact:${result.checkpoint.checkpointId}`);
+    assert.equal(ids[1], 'anchor');
+    // Head anchor byte-identical to the raw event.
+    assert.deepEqual(result.replacementEvents[1], longTurnEvents()[2]);
+    // No folded raw event re-appears in the replacement.
+    assert.equal(ids.includes('call-a'), false);
+    assert.equal(ids.includes('res-a'), false);
+    // The reserved tail (last event) is preserved verbatim.
+    assert.equal(ids.at(-1), 'res-b');
+  });
+
+  test('persisted checkpoint replay-validates against the same ledger prefix (recovery)', async () => {
+    const events = longTurnEvents();
+    const result = await planMidTurnCapacityCompaction(planInput({ orderedEvents: events }));
+    assert.equal(result.decision, 'compacted');
+    if (result.decision !== 'compacted') return;
+
+    // Re-projecting the ledger with the persisted checkpoint must match the exact
+    // covered prefix and not re-inject any raw covered event.
+    const match = matchHistoryCompactCheckpointPrefix(result.checkpoint, events);
+    assert.equal(match.reason, undefined);
+    assert.equal(match.coveredEventCount, result.coveredRuntimeEvents.length);
+
+    // Normal thresholds: even though the raw ledger is far below the default
+    // high water, the accepted mid_turn checkpoint replays — recovery never
+    // re-injects the replaced raw span.
+    const replay = applyRuntimeEventHistoryCompact(events, {
+      maxHistoryEstimatedTokens: 1_000_000,
+      charsPerToken: 4,
+      historyCompact: { enabled: true, mode: 'read_write', checkpoint: result.checkpoint },
+    });
+    assert.equal(replay.checkpoint?.checkpointId, result.checkpoint.checkpointId);
+    const replayIds = replay.events.map((event) => event.id);
+    assert.equal(replayIds[0], `history-compact:${result.checkpoint.checkpointId}`);
+    assert.equal(replayIds.includes('anchor'), true);
+    assert.equal(replayIds.includes('call-a'), false);
+  });
+
+  test('fails open below the window when the summarizer fails', async () => {
+    const result = await planMidTurnCapacityCompaction(planInput({
+      estimatedNextRequestTokens: 120_000, // over high-water, under window
+      summarize: () => { throw new Error('summarizer down'); },
+    }));
+    assert.deepEqual(result, { decision: 'fail_open', reason: 'summarizer_failed' });
+  });
+
+  test('fails open (never terminates) above the window when the summarizer fails', async () => {
+    // The engine is a pure shaper: the over-window pass/terminate verdict is
+    // issued by the backend's final-request estimate owner, never here.
+    const result = await planMidTurnCapacityCompaction(planInput({
+      estimatedNextRequestTokens: 130_000, // over the window itself
+      summarize: () => '',
+    }));
+    assert.deepEqual(result, { decision: 'fail_open', reason: 'summarizer_failed' });
+  });
+
+  test('fails open with no_safe_completed_span when the pool has no safe cut past the anchor', async () => {
+    // Only the head anchor and one open call/result pair; reserving the tail
+    // leaves no safe completed span that also covers a step past the anchor.
+    const events = [user('anchor', 'turn-1'), call('c', 'c1', 'turn-1'), result('r', 'c1', 'turn-1')];
+    const outcome = await planMidTurnCapacityCompaction(planInput({
+      orderedEvents: events,
+      estimatedNextRequestTokens: 130_000,
+      reserveTailEvents: 1,
+    }));
+    assert.deepEqual(outcome, { decision: 'fail_open', reason: 'no_safe_completed_span' });
+  });
+
+  test('still shapes when the estimate exceeds the window — no post-fold window verdict here', async () => {
+    // Review round-3 finding A: a post-fold re-estimate that subtracts the
+    // RAW covered span is wrong on a rolling (second) compaction — the
+    // previous request was already `[block, anchor, tail]` and never carried
+    // that raw prefix, so the subtraction over-credits the fold and passes a
+    // still-over-window request. The engine therefore makes NO window claim
+    // after folding: it returns the shape and the backend owner re-measures
+    // the actual replacement payload.
+    const outcome = await planMidTurnCapacityCompaction(planInput({
+      estimatedNextRequestTokens: 10_000,
+      contextWindow: 1_000,
+      reserveTokens: 100,
+    }));
+    assert.equal(outcome.decision, 'compacted');
+  });
+
+  // Note: a fold whose materialized replacement does not SHRINK the request
+  // (e.g. a runaway summary block) is refused at the backend hook, which
+  // measures the real payload bytes — see the mid-turn backend suite. The
+  // engine works on runtime-event char estimates and makes no such claim.
+
+  test('rolls forward from a matching previous checkpoint (only the new span is summarized)', async () => {
+    const events = longTurnEvents();
+    const first = await planMidTurnCapacityCompaction(planInput({
+      orderedEvents: events.slice(0, 5), // fold through res-a
+    }));
+    assert.equal(first.decision, 'compacted');
+    if (first.decision !== 'compacted') return;
+
+    let seenNewlyFolded: string[] = [];
+    const second = await planMidTurnCapacityCompaction(planInput({
+      orderedEvents: events,
+      previousCheckpoint: first.checkpoint,
+      summarize: ({ newlyFoldedRuntimeEvents, previousCheckpoint }) => {
+        seenNewlyFolded = newlyFoldedRuntimeEvents.map((event) => event.id);
+        assert.equal(previousCheckpoint?.checkpointId, first.checkpoint.checkpointId);
+        return 'rolled-forward summary';
+      },
+    }));
+    assert.equal(second.decision, 'compacted');
+    if (second.decision !== 'compacted') return;
+    // First folded through `anchor`; the second folds through `res-a`, so only
+    // the span after the previous checkpoint's coverage is re-summarized.
+    assert.deepEqual(seenNewlyFolded, ['call-a', 'res-a']);
+    assert.equal(second.checkpoint.previousCheckpointId, first.checkpoint.checkpointId);
+  });
+});
+
+function base(id: string, turnId: string): Omit<RuntimeEvent, 'role' | 'author' | 'content'> {
+  return {
+    id, sessionId: 'session-1', runId: 'run-1', turnId, invocationId: 'run-1',
+    ts: 1_800_000_000_000, partial: false,
+  };
+}
+function user(id: string, turnId: string): RuntimeEvent {
+  return { ...base(id, turnId), role: 'user', author: 'user', content: { kind: 'text', text: id } };
+}
+function model(id: string, turnId: string, text: string = id): RuntimeEvent {
+  return { ...base(id, turnId), role: 'model', author: 'agent', content: { kind: 'text', text } };
+}
+function call(id: string, callId: string, turnId: string): RuntimeEvent {
+  return {
+    ...base(id, turnId), role: 'model', author: 'agent',
+    content: { kind: 'function_call', id: callId, name: 'tool', args: {} },
+  };
+}
+function result(id: string, callId: string, turnId: string, payload: string = 'ok'): RuntimeEvent {
+  return {
+    ...base(id, turnId), role: 'tool', author: 'tool',
+    content: { kind: 'function_response', id: callId, name: 'tool', result: payload },
+  };
+}

--- a/packages/runtime/src/__tests__/model-adapter.test.ts
+++ b/packages/runtime/src/__tests__/model-adapter.test.ts
@@ -237,6 +237,112 @@ describe('ModelAdapter stream and error normalization', () => {
     );
   });
 
+  test('treats provider usage without token values as unavailable', () => {
+    assert.equal(normalizeAiSdkUsage({
+      inputTokens: undefined,
+      outputTokens: undefined,
+      totalTokens: undefined,
+    }), undefined);
+  });
+
+  test('treats incomplete provider usage as unavailable unless total can supply the missing side', () => {
+    assert.equal(normalizeAiSdkUsage({ inputTokens: 12 }), undefined);
+    assert.equal(normalizeAiSdkUsage({ outputTokens: 3 }), undefined);
+    assert.equal(normalizeAiSdkUsage({ totalTokens: 15 }), undefined);
+
+    assert.deepEqual(normalizeAiSdkUsage({ inputTokens: 12, totalTokens: 15 }), {
+      inputTokens: 12,
+      outputTokens: 3,
+      cacheHitInputTokens: 0,
+      cacheMissInputTokens: 12,
+      cacheMissInputSource: 'derived',
+      cachedInputTokens: 0,
+      cacheWriteInputTokens: 0,
+      reasoningTokens: 0,
+      totalTokens: 15,
+    });
+    assert.deepEqual(normalizeAiSdkUsage({ outputTokens: 3, totalTokens: 15 }), {
+      inputTokens: 12,
+      outputTokens: 3,
+      cacheHitInputTokens: 0,
+      cacheMissInputTokens: 12,
+      cacheMissInputSource: 'derived',
+      cachedInputTokens: 0,
+      cacheWriteInputTokens: 0,
+      reasoningTokens: 0,
+      totalTokens: 15,
+    });
+    assert.deepEqual(normalizeAiSdkUsage({ inputTokens: 0, outputTokens: 0 }), {
+      inputTokens: 0,
+      outputTokens: 0,
+      cacheHitInputTokens: 0,
+      cacheMissInputTokens: 0,
+      cacheMissInputSource: 'derived',
+      cachedInputTokens: 0,
+      cacheWriteInputTokens: 0,
+      reasoningTokens: 0,
+      totalTokens: 0,
+    });
+  });
+
+  test('derives totals from detail-only AI SDK usage', () => {
+    assert.deepEqual(
+      normalizeAiSdkUsage({
+        inputTokens: {
+          total: undefined,
+          noCache: 10,
+          cacheRead: 5,
+          cacheWrite: 2,
+        },
+        outputTokens: {
+          total: undefined,
+          text: 4,
+          reasoning: 3,
+        },
+      }),
+      {
+        inputTokens: 17,
+        outputTokens: 7,
+        cacheHitInputTokens: 5,
+        cacheMissInputTokens: 10,
+        cacheMissInputSource: 'explicit',
+        cachedInputTokens: 5,
+        cacheWriteInputTokens: 2,
+        reasoningTokens: 3,
+        totalTokens: 24,
+      },
+    );
+  });
+
+  test('derives totals from the public AI SDK 6 detail shape', () => {
+    const usage = {
+      inputTokens: undefined,
+      outputTokens: undefined,
+      totalTokens: undefined,
+      inputTokenDetails: {
+        noCacheTokens: 10,
+        cacheReadTokens: 5,
+        cacheWriteTokens: 2,
+      },
+      outputTokenDetails: {
+        textTokens: 4,
+        reasoningTokens: 3,
+      },
+    } as unknown as Parameters<typeof normalizeAiSdkUsage>[0];
+
+    assert.deepEqual(normalizeAiSdkUsage(usage), {
+      inputTokens: 17,
+      outputTokens: 7,
+      cacheHitInputTokens: 5,
+      cacheMissInputTokens: 10,
+      cacheMissInputSource: 'explicit',
+      cachedInputTokens: 5,
+      cacheWriteInputTokens: 2,
+      reasoningTokens: 3,
+      totalTokens: 24,
+    });
+  });
+
   test('preserves DeepSeek and OpenAI-compatible raw usage fields', () => {
     assert.deepEqual(
       normalizeAiSdkUsage(

--- a/packages/runtime/src/__tests__/session-manager.test.ts
+++ b/packages/runtime/src/__tests__/session-manager.test.ts
@@ -3011,6 +3011,67 @@ describe('SessionManager permission mode updates', () => {
     expect(result.artifactIds).toEqual(['artifact-1']);
   });
 
+  test('the durable turn-ledger seam reaches parent runs but is withheld from child sessions', async () => {
+    const store = new MemorySessionStore();
+    const runStore = new MemoryAgentRunStore();
+    const backends = new BackendRegistry();
+    const contexts: BackendFactoryContext[] = [];
+    const seamReads: Array<{ turnId: string; eventIds: string[] } | undefined> = [];
+    class SeamProbeBackend extends TestBackend {
+      constructor(private readonly probeCtx: BackendFactoryContext) {
+        super(probeCtx);
+      }
+
+      override async *send(input: BackendSendInput): AsyncIterable<SessionEvent> {
+        seamReads.push(this.probeCtx.loadTurnRuntimeEvents
+          ? {
+              turnId: input.turnId,
+              eventIds: (await this.probeCtx.loadTurnRuntimeEvents(input.turnId)).map((event) => event.id),
+            }
+          : undefined);
+        yield* super.send(input);
+      }
+    }
+    backends.register('fake', (ctx) => {
+      contexts.push(ctx);
+      return new SeamProbeBackend(ctx);
+    });
+    const manager = new SessionManager({
+      store,
+      runStore, runtimeEventStore: runStore, backends,
+      childTools: [testTool('Read'), testTool('Glob'), testTool('Grep')],
+      newId: nextId(),
+      now: nextNow(6_850),
+      runtimeSource: 'test',
+    });
+    const session = await manager.createSession(makeInput({ permissionMode: 'ask' }));
+    await drain(manager.sendMessage(session.id, { turnId: 'parent-turn', text: 'parent context' }));
+    const [parentRun] = await runStore.listSessionRuns(session.id);
+    if (!parentRun) throw new Error('parent run was not recorded');
+    await manager.spawnChildAgent(session.id, {
+      turnId: 'child-turn',
+      parentRunId: parentRun.runId,
+      spec: { id: LOCAL_READ_AGENT_ID, name: 'Reader', systemPrompt: 'read only' },
+      prompt: 'inspect',
+    });
+
+    // The parent (main-session) backend can read its turn's durable ledger —
+    // the seam resolves the active run and returns the persisted events.
+    expect(seamReads.length).toBe(2);
+    expect(seamReads[0]?.turnId).toBe('parent-turn');
+    expect((seamReads[0]?.eventIds.length ?? 0) > 0).toBe(true);
+
+    // The child factory context is NOT given the seam: a child run has no
+    // top-level prior context, so a mid-turn checkpoint built from its
+    // child-only ledger would claim session-prefix coverage and poison the
+    // session-global checkpoint stream for the parent projection. Without
+    // the seam, child mid-turn capacity compaction cannot arm.
+    expect(contexts.length).toBe(2);
+    expect(typeof contexts[0]?.loadTurnRuntimeEvents).toBe('function');
+    expect(contexts[1]?.loadTurnRuntimeEvents).toBe(undefined);
+    expect(seamReads[1]).toBe(undefined);
+  });
+
   test('spawnChildAgent returns the terminal RuntimeEvent status when the child header commit fails', async () => {
     const store = new MemorySessionStore();
     const runStore = new MemoryAgentRunStore({ failUpdateRunStatusOnce: 'completed' });

--- a/packages/runtime/src/agent-run.ts
+++ b/packages/runtime/src/agent-run.ts
@@ -221,6 +221,26 @@ export class AgentRun {
     }, { rethrow: true });
   }
 
+  /**
+   * Durable read of this run's RuntimeEvent ledger for the mid-turn capacity
+   * invariant: waits for every write enqueued so far, then reads the store, so
+   * a caller-derived coverage prefix can only ever span events that are
+   * already persisted. Rejects when the store is unavailable — coverage must
+   * never be computed over a projection the ledger cannot replay.
+   */
+  async loadTurnRuntimeEvents(): Promise<RuntimeEvent[]> {
+    if (!this.input.runtimeEventStore || !this.runtimeEventStoreAvailable) {
+      throw new Error('RuntimeEvent store is unavailable for turn runtime events');
+    }
+    await this.runtimeEventQueue.catch(() => {});
+    // A write may have failed while we waited; a snapshot from a store that
+    // just went unavailable must not be treated as a complete durable read.
+    if (!this.runtimeEventStoreAvailable) {
+      throw new Error('RuntimeEvent store became unavailable for turn runtime events');
+    }
+    return await this.input.runtimeEventStore.readRuntimeEvents(this.sessionId, this.runId);
+  }
+
   recordSemanticCompactBlock(block: SemanticCompactBlock): void {
     if (!this.input.runStore || !this.runStoreAvailable) return;
     this.enqueueRunStore('append semantic compact block', async () => {

--- a/packages/runtime/src/ai-sdk-backend.ts
+++ b/packages/runtime/src/ai-sdk-backend.ts
@@ -35,6 +35,7 @@
 import type {
   SessionEvent,
   CompleteEvent,
+  ContextBudgetExhaustedDetail,
   AbortEvent,
   ErrorEvent,
   TextCompleteEvent,
@@ -145,11 +146,13 @@ import {
   ARCHIVED_TOOL_RESULT_REWRITE_VERSION,
   applyRuntimeEventContextBudget,
   buildContextBudgetDiagnosticShell,
+  buildHistoryCompactBlockFromSummary,
   buildHistorySearchSource,
   buildPromptSegmentEstimates,
   collectStaleToolResultArchiveCandidates,
   evaluateHistoryCompactCheckpointReplay,
   estimateRuntimeEventsTokens,
+  isHistoryCompactContentEvent,
   mergeContextBudgetDiagnostic,
   mergeContextBudgetDiagnosticPatches,
   mergeRuntimeEventsInOriginalOrder,
@@ -180,7 +183,12 @@ import {
   matchHistoryCompactCheckpointPrefix,
   type HistoryCompactCheckpoint,
 } from './history-compact-checkpoint.js';
-
+import { resolveSelectedModelContextWindow } from './context-budget-policy.js';
+import {
+  estimateNextRequestTokens,
+  exceedsHighWater,
+  planMidTurnCapacityCompaction,
+} from './mid-turn-capacity-compact.js';
 export {
   DEFAULT_PERMISSION_TIMEOUT_MS,
   MAX_ACTIVE_SUBAGENT_TOOLS_PER_TURN,
@@ -204,12 +212,34 @@ export type {
 
 export const INVALID_TOOL_NAME = 'invalid';
 
+/**
+ * Deterministic prepareStep pipeline over ONE provider-visible projection.
+ * Order is a contract: mid-turn capacity compaction runs first among the
+ * message-shaping hooks so every later mechanism operates on (and re-converges
+ * onto) its projection — active tool-result pruning re-archives large tool
+ * results in the rebuilt tail, and semantic/active-full compaction sees the
+ * already-compacted messages. On a step where the capacity hook replaced the
+ * request, semantic/active-full compaction yields (see send()) so two
+ * summarizers never run for one step.
+ *
+ * Every hook here only SHAPES the projection. The pass/terminate capacity
+ * verdict is issued once, after the whole pipeline, by the final-request
+ * estimate owner (buildMidTurnFinalRequestVerdict) over the actual outgoing
+ * (messages, tools) payload — never by an individual hook over an intermediate
+ * projection that a later hook could still rescue.
+ */
 export function composePrepareStep(
   toolAvailability: PrepareStepFunctionLike | undefined,
+  midTurnCapacityCompact: PrepareStepFunctionLike | undefined,
   activeToolResultPrune: PrepareStepFunctionLike | undefined,
   activeFullCompact?: PrepareStepFunctionLike | undefined,
 ): PrepareStepFunctionLike | undefined {
-  const hooks = [toolAvailability, activeToolResultPrune, activeFullCompact].filter(Boolean) as PrepareStepFunctionLike[];
+  const hooks = [
+    toolAvailability,
+    midTurnCapacityCompact,
+    activeToolResultPrune,
+    activeFullCompact,
+  ].filter(Boolean) as PrepareStepFunctionLike[];
   if (hooks.length === 0) return undefined;
   return async (options: PrepareStepLike): Promise<PrepareStepResultLike | undefined> => {
     let result: PrepareStepResultLike | undefined;
@@ -271,6 +301,126 @@ function projectAcceptedActiveFullCompactMessages(
     ...acceptedProjection.projectedMessages,
     ...incomingMessages.slice(acceptedProjection.sourceSignatures.length),
   ];
+}
+
+// ============================================================================
+// Mid-turn capacity compaction — per-send trigger state
+// ============================================================================
+
+/**
+ * Per-send() state for the mid-turn capacity invariant. The coverage pool is
+ * NOT mirrored here: every trigger reads the current turn's persisted
+ * RuntimeEvents through the injected durable-read seam, so coverage can only
+ * span events the ledger already replays. This class keeps only the trigger's
+ * cursor state between steps.
+ */
+class MidTurnCapacityCompactState {
+  /**
+   * Chars of the final (system prompt + messages + active tool schema)
+   * payload of the LAST prepared request, recorded by the final-request
+   * estimate owner at the end of every prepareStep pipeline run. All capacity estimates are signed
+   * deltas against this number, so they are anchored to the request the
+   * provider actually saw — a compacted projection, a pruned tail, or a
+   * same-turn tool-schema expansion all move the delta the same way.
+   */
+  lastRequestPayloadChars: number | undefined;
+  /**
+   * The last request's REAL input size: the inputTokens the provider reported
+   * for the last finished step. Never input+output — the signed payload delta
+   * already carries the step's freshly generated output (assistant text/tool
+   * calls) and its tool results, so an output-inclusive baseline would count
+   * them twice. Undefined when the last step's usage is missing or unusable
+   * (no positive input count); estimates then fall back to the whole-payload
+   * cold-start path — an unusable sample is unknown, never zero.
+   */
+  lastRequestInputTokens: number | undefined;
+  /** Latest durable checkpoint (loaded or written) for roll-forward summaries. */
+  previousCheckpoint: HistoryCompactCheckpoint | undefined;
+  /** Set when the turn must end with a context_budget_exhausted outcome. */
+  exhaustedDetail: ContextBudgetExhaustedDetail | undefined;
+  /**
+   * Step whose request the capacity hook replaced. Semantic/active-full
+   * compaction yields on that exact step so one step never runs two
+   * summarizers or double-projects.
+   */
+  replacedStepNumber: number | undefined;
+  /**
+   * finish-step boundaries the event pump has flushed into the session-event
+   * queue. The capacity hook's durability wait needs it: only after the pump
+   * has flushed step N's boundary are that step's thinking/text completion
+   * events enqueued at all.
+   */
+  flushedSteps = 0;
+  /**
+   * Set by the final-request estimate owner to force one capacity re-entry on
+   * the current step, bypassing the (deliberately approximate) high-water
+   * trigger. Consumed by the capacity hook on its next invocation.
+   */
+  forcedTriggerEstimate: number | undefined;
+  /**
+   * The capacity hook's most recent shaping failure. The owner reads it (for
+   * the same step only) to pick the terminal detail and diagnostic reason
+   * when the final payload is over the window, and to avoid re-entering a
+   * shaper that already attempted and failed this step.
+   */
+  lastShapeFailure: {
+    stepNumber: number;
+    detail: ContextBudgetExhaustedDetail;
+    diagnosticReason: string;
+  } | undefined;
+
+  constructor(
+    readonly headAnchor: RuntimeEvent,
+    readonly priorContentEvents: readonly RuntimeEvent[],
+    readonly contextWindow: number,
+  ) {}
+}
+
+/**
+ * Char measure of the FULL provider-visible request input: the system prompt
+ * (sent through the separate `system` field), the (projected) messages, and
+ * the serialized schemas of the active tool subset. The capacity trigger and
+ * the final-request estimate owner both measure with this ONE function, so
+ * their deltas against `lastRequestPayloadChars` are commensurable and
+ * same-turn tool-schema growth (a `load_tools` activation) is counted like
+ * any other payload growth. The system prompt is constant between adjacent
+ * requests — signed deltas cancel it — but the cold-start estimate (no usable
+ * usage sample) is the whole payload, so omitting it would under-estimate by
+ * exactly the system prompt and let an over-window request stream.
+ */
+function midTurnRequestPayloadChars(
+  messages: readonly ModelMessage[],
+  providerTools: readonly MakaTool[],
+  activeTools: readonly string[],
+  systemPromptChars: number,
+): number {
+  return (
+    Math.max(0, Math.floor(systemPromptChars))
+    + JSON.stringify(messages).length
+    + toolSchemaCharsForDiagnostics(providerTools, activeTools)
+  );
+}
+
+/**
+ * Event-driven wait for seq-ack progress: resolves when the queue reports any
+ * push/ack/close/wake, or immediately on abort. The caller loops and re-checks
+ * its condition — a condition variable, not a poll.
+ */
+function waitForQueueProgressOrAbort(
+  queue: AsyncEventQueue<SessionEvent>,
+  abortSignal: AbortSignal | undefined,
+): Promise<void> {
+  return new Promise<void>((resolve) => {
+    let settled = false;
+    const settle = (): void => {
+      if (settled) return;
+      settled = true;
+      abortSignal?.removeEventListener('abort', settle);
+      resolve();
+    };
+    abortSignal?.addEventListener('abort', settle, { once: true });
+    void queue.waitForProgress().then(settle);
+  });
 }
 
 function joinPromptFragments(fragments: readonly (string | undefined)[]): string | undefined {
@@ -520,6 +670,19 @@ export interface AiSdkBackendInput {
   summarizeHistoryCompact?: HistoryCompactSummarizer;
   /** Best-effort durable recorder for accepted V2 checkpoints. */
   recordHistoryCompactCheckpoint?: HistoryCompactCheckpointRecorder;
+  /**
+   * Durable read of the given turn's persisted RuntimeEvents from the
+   * authoritative run ledger (same injection seam as the checkpoint
+   * loader/recorder). Mid-turn capacity compaction derives its coverage pool
+   * from this read: covered events are persisted by construction before the
+   * checkpoint that folds them, and their bytes are exactly what recovery
+   * replays. A lagging read is NOT fail-safe here — the replacement
+   * projection replaces the whole message list, so a missing completed-step
+   * event would be silently dropped from the next request; the capacity hook
+   * therefore reads only after its seq-ack durability boundary (all enqueued
+   * session events processed by the consumer) is satisfied.
+   */
+  loadTurnRuntimeEvents?: (turnId: string) => Promise<RuntimeEvent[]>;
   /** Optional best-effort durable recorder for accepted active full compact blocks. */
   recordActiveFullCompactBlock?: ActiveFullCompactBlockRecorder;
   /** Optional best-effort durable recorder for accepted semantic compact blocks. */
@@ -750,6 +913,7 @@ export class AiSdkBackend implements AgentBackend {
     this.toolRuntime.beginTurn(turnId);
     this.abortController = new AbortController();
 
+    const midTurnState = this.buildMidTurnCapacityCompactState(input);
     const queue = new AsyncEventQueue<SessionEvent>();
     this.currentQueue = queue;
 
@@ -819,6 +983,15 @@ export class AiSdkBackend implements AgentBackend {
     };
     let tokenUsage: NormalizedAiSdkUsage | undefined;
     let tokenUsageCostUsd: number | undefined;
+    // Per-send sum of every COMPLETED step's usage, merged at each finish-step
+    // boundary. When the send aborts (mid-turn exhaust, user stop, stream
+    // error) the SDK's `totalUsage` promise never resolves, but this sum is
+    // real provider-reported evidence for the steps that did finish — IF every
+    // completed step produced a usable sample. One unusable sample makes the
+    // sum a partial cost, and LlmCallRecord has no partial marker, so the flag
+    // fails the whole fallback closed (#972: incomplete usage is no usage).
+    let completedStepUsage: NormalizedAiSdkUsage | undefined;
+    let sawUnusableStepUsage = false;
     let streamStatus: LlmCallRecord['status'] = 'success';
     let streamErrorClass: string | undefined;
     let rawFinishReason: string | undefined;
@@ -900,6 +1073,11 @@ export class AiSdkBackend implements AgentBackend {
 
     // --- Build messages from RuntimeEvent history and its compatibility projection. ---
     const priorReplay = await this.buildPriorMessages(input);
+    if (midTurnState) {
+      // Roll-forward seed: the latest durable checkpoint (loaded or written at
+      // turn start) so a mid-turn summary only re-reads the newly folded span.
+      midTurnState.previousCheckpoint = priorReplay.latestHistoryCompactCheckpoint;
+    }
 
     // --- Background pump: streamText → fullStream → normalize → queue ---
     const pumpDone: Promise<void> = (async () => {
@@ -1018,37 +1196,94 @@ export class AiSdkBackend implements AgentBackend {
           activeTools: activeToolsForStep ?? plan.activeTools,
           priorMessages: stepMessages,
         }, priorShapeBaseline).requestShapeHash;
-        const prepareStep = composePrepareStep(
-          plan.prepareStep,
-          this.buildActiveToolResultPrunePrepareStep(turnId, (patch) => {
-            activeToolResultPruneDiagnosticPatch = mergeActiveToolResultPruneDiagnosticPatches(
-              activeToolResultPruneDiagnosticPatch,
+        const activeCompactHook = this.buildSemanticCompactPrepareStep(
+          turnId,
+          model,
+          input.runtimeContext,
+          (messagesForStep, activeToolsForStep) => stepRequestShapeHash(messagesForStep, activeToolsForStep),
+          (patch) => {
+            activeCompactDiagnosticPatch = mergeContextBudgetDiagnosticPatches(
+              activeCompactDiagnosticPatch,
               patch,
             );
-          }),
-          this.buildSemanticCompactPrepareStep(
-            turnId,
-            model,
-            input.runtimeContext,
-            (messagesForStep, activeToolsForStep) => stepRequestShapeHash(messagesForStep, activeToolsForStep),
-            (patch) => {
-              activeCompactDiagnosticPatch = mergeContextBudgetDiagnosticPatches(
-                activeCompactDiagnosticPatch,
-                patch,
-              );
-            },
-          ) ?? this.buildActiveFullCompactPrepareStep(
-            turnId,
-            input.runtimeContext,
-            (messagesForStep, activeToolsForStep) => stepRequestShapeHash(messagesForStep, activeToolsForStep),
-            (patch) => {
-              activeCompactDiagnosticPatch = mergeContextBudgetDiagnosticPatches(
-                activeCompactDiagnosticPatch,
-                patch,
-              );
-            },
-          ),
+          },
+        ) ?? this.buildActiveFullCompactPrepareStep(
+          turnId,
+          input.runtimeContext,
+          (messagesForStep, activeToolsForStep) => stepRequestShapeHash(messagesForStep, activeToolsForStep),
+          (patch) => {
+            activeCompactDiagnosticPatch = mergeContextBudgetDiagnosticPatches(
+              activeCompactDiagnosticPatch,
+              patch,
+            );
+          },
         );
+        // Deterministic priority on a capacity-replaced step: the hard window
+        // invariant owns the projection, so semantic/active-full compaction
+        // yields for that step (recorded as a decision) instead of running a
+        // second summarizer over the same request.
+        const activeCompactAfterMidTurn = activeCompactHook && midTurnState
+          ? (options: PrepareStepLike) => {
+              if (midTurnState.replacedStepNumber === options.stepNumber) {
+                activeCompactDiagnosticPatch = mergeContextBudgetDiagnosticPatches(
+                  activeCompactDiagnosticPatch,
+                  compactionDecisionDiagnosticPatch({
+                    stage: 'activeStep',
+                    sourceKind: 'providerMessages',
+                    decision: 'unchanged',
+                    boundaryKind: 'historyCompact',
+                    reason: 'mid_turn_capacity_precedence',
+                    skippedReasonCounts: { mid_turn_capacity_precedence: 1 },
+                  }),
+                );
+                return undefined;
+              }
+              return activeCompactHook(options);
+            }
+          : activeCompactHook;
+        const onMidTurnDiagnosticPatch = (patch: Partial<ContextBudgetDiagnostic>): void => {
+          activeCompactDiagnosticPatch = mergeContextBudgetDiagnosticPatches(
+            activeCompactDiagnosticPatch,
+            patch,
+          );
+        };
+        const midTurnSystemPromptChars = systemPrompt?.length ?? 0;
+        const midTurnCapacityHook = this.buildMidTurnCapacityCompactPrepareStep(
+          turnId,
+          midTurnState,
+          queue,
+          providerTools,
+          () => currentRepairToolNames(),
+          turnTailPrompt,
+          midTurnSystemPromptChars,
+          onMidTurnDiagnosticPatch,
+        );
+        const activeToolResultPruneHook = this.buildActiveToolResultPrunePrepareStep(turnId, (patch) => {
+          activeToolResultPruneDiagnosticPatch = mergeActiveToolResultPruneDiagnosticPatches(
+            activeToolResultPruneDiagnosticPatch,
+            patch,
+          );
+        });
+        const shapedPrepareStep = composePrepareStep(
+          plan.prepareStep,
+          midTurnCapacityHook,
+          activeToolResultPruneHook,
+          activeCompactAfterMidTurn,
+        );
+        // The verdict owner wraps the WHOLE shaping pipeline: hooks shape, one
+        // owner measures the final payload and decides pass/terminate.
+        const prepareStep = midTurnState && midTurnCapacityHook && shapedPrepareStep
+          ? this.buildMidTurnFinalRequestVerdict({
+              shaped: shapedPrepareStep,
+              reentry: composePrepareStep(undefined, midTurnCapacityHook, activeToolResultPruneHook)!,
+              state: midTurnState,
+              providerTools,
+              fallbackActiveTools: () => currentRepairToolNames(),
+              charsPerToken: this.input.contextBudget?.charsPerToken ?? 4,
+              systemPromptChars: midTurnSystemPromptChars,
+              onDiagnosticPatch: onMidTurnDiagnosticPatch,
+            })
+          : shapedPrepareStep;
 
         const result = await this.modelAdapter.startStream({
           model,
@@ -1082,7 +1317,9 @@ export class AiSdkBackend implements AgentBackend {
           if (isStepFinishChunk) {
             runtimeSteps += 1;
             const stepUsage = normalizeAiSdkUsage(chunk.usage, { rawFinishReason: chunk.finishReason });
+            if (!stepUsage) sawUnusableStepUsage = true;
             if (stepUsage) {
+              completedStepUsage = mergeNormalizedUsage(completedStepUsage, stepUsage);
               this.cumulativeUsageCheckpoint = mergeNormalizedUsage(this.cumulativeUsageCheckpoint, stepUsage);
               await this.input.recordUsageCheckpoint?.({
                 ...this.cumulativeUsageCheckpoint,
@@ -1108,6 +1345,14 @@ export class AiSdkBackend implements AgentBackend {
           if (isStepFinishChunk) {
             await flushStep();
             this.currentStepMessageId = this.newId();
+            if (midTurnState) {
+              // Durability clock: step N's thinking/text completion events are
+              // enqueued by flushStep just above, so only after this boundary
+              // can a seq-ack wait for step N mean anything. Wake waiters AFTER
+              // the increment or they would re-check a stale count and sleep.
+              midTurnState.flushedSteps += 1;
+              queue.wake();
+            }
           }
         }
 
@@ -1117,6 +1362,16 @@ export class AiSdkBackend implements AgentBackend {
         // persist a partial assistant turn and emit a false end_turn completion.
         if (this.aborted) {
           throw Object.assign(new Error('aborted'), { name: 'AbortError' });
+        }
+
+        // Mid-turn exhaustion aborts the SDK stream, but streamText ends
+        // gracefully on abort instead of throwing; route to the explicit
+        // outcome regardless of how the stream wound down.
+        if (midTurnState?.exhaustedDetail) {
+          throw Object.assign(
+            new Error(`mid-turn context budget exhausted: ${midTurnState.exhaustedDetail}`),
+            { name: 'MidTurnContextBudgetExhaustedError' },
+          );
         }
 
         // Catch-all: flush any residual step content if the provider closed the
@@ -1277,7 +1532,20 @@ export class AiSdkBackend implements AgentBackend {
         // BOTH exits — user stop and provider error / watchdog timeout — so
         // partialOutputRetained reflects what the user actually saw.
         await flushStep().catch(() => {});
-        if (this.aborted) {
+        if (!this.aborted && midTurnState?.exhaustedDetail) {
+          // Mid-turn compaction could not produce a provider-safe request: end
+          // the turn with the explicit first-class outcome, not a raw error.
+          streamErrorClass = 'ContextBudgetExhausted';
+          trace.modelStreamCompleted('context_budget_exhausted');
+          queue.push({
+            type: 'complete',
+            id: this.newId(),
+            turnId,
+            ts: this.now(),
+            stopReason: 'context_budget_exhausted',
+            contextBudgetExhaustedDetail: midTurnState.exhaustedDetail,
+          } satisfies CompleteEvent);
+        } else if (this.aborted) {
           queue.push({
             type: 'abort',
             id: this.newId(),
@@ -1313,6 +1581,20 @@ export class AiSdkBackend implements AgentBackend {
           activeToolResultPruneDiagnosticPatch,
           activeCompactDiagnosticPatch,
         );
+        // The terminal record is fail-closed on usage evidence: no evidence,
+        // no record. An aborted send has no `totalUsage`, but when EVERY
+        // completed step produced a usable sample their accumulated usage IS
+        // the complete evidence — record it, carrying the real cost of the
+        // steps that ran plus the diagnostics riding this record. Otherwise
+        // (no finish-step at all, or any unusable sample) the record is
+        // skipped: a partial sum posed as the whole call would violate the
+        // #972 no-fabrication invariant. The terminal outcome itself does not
+        // depend on this record — stopReason and the exhausted detail are
+        // durable on the CompleteEvent either way.
+        if (!tokenUsage && completedStepUsage && !sawUnusableStepUsage) {
+          tokenUsage = completedStepUsage;
+          tokenUsageCostUsd = this.computeTokenUsageCostUsd(tokenUsage);
+        }
         if (tokenUsage) this.input.recordLlmCall?.({
           sessionId: this.sessionId,
           turnId,
@@ -1358,7 +1640,9 @@ export class AiSdkBackend implements AgentBackend {
     })();
 
     try {
-      for await (const ev of queue) yield ev;
+      // drain() carries the seq-ack semantics (consumer pull = processed ack);
+      // every consumer-facing path must go through it.
+      yield* this.drain(queue);
     } finally {
       await pumpDone.catch(() => {});
       this.cleanupAfterTurn(turnId);
@@ -1457,6 +1741,8 @@ export class AiSdkBackend implements AgentBackend {
     diagnostics: RuntimeEventModelReplayPlan['diagnostics'];
     runtimeEventCount?: number;
     contextBudget?: ContextBudgetDiagnostic;
+    /** Latest durable checkpoint (loaded or written this turn) for mid-turn roll-forward. */
+    latestHistoryCompactCheckpoint?: HistoryCompactCheckpoint;
   }> {
     const projectedMessages = await this.materializePriorMessages(
       input.context.filter((message) => message.turnId !== input.turnId),
@@ -1471,6 +1757,7 @@ export class AiSdkBackend implements AgentBackend {
     let runtimeContext = budgeted?.events
       ?? priorRuntimeContext;
     let contextBudgetDiagnostic = budgeted?.diagnostic;
+    let latestHistoryCompactCheckpoint = contextBudget?.historyCompact?.checkpoint;
     if (preparedContextBudget.diagnosticPatch) {
       contextBudgetDiagnostic = mergeContextBudgetDiagnostic(
         contextBudgetDiagnostic ?? buildContextBudgetDiagnosticShell(priorRuntimeContext, runtimeContext, contextBudget),
@@ -1494,6 +1781,7 @@ export class AiSdkBackend implements AgentBackend {
             abortSignal: this.abortController?.signal,
           });
           if (writePatch.replacementCheckpoint) {
+            latestHistoryCompactCheckpoint = writePatch.replacementCheckpoint;
             runtimeContext = [
               historyCompactCheckpointToRuntimeEvent(writePatch.replacementCheckpoint),
               ...runtimeContext.filter((event) => !event.id.startsWith('history-compact:')),
@@ -1660,6 +1948,7 @@ export class AiSdkBackend implements AgentBackend {
         diagnostics: plan.diagnostics,
         runtimeEventCount: runtimeContext.length,
         ...(contextBudgetDiagnostic ? { contextBudget: contextBudgetDiagnostic } : {}),
+        ...(latestHistoryCompactCheckpoint ? { latestHistoryCompactCheckpoint } : {}),
       };
     }
 
@@ -1670,6 +1959,7 @@ export class AiSdkBackend implements AgentBackend {
         diagnostics: plan.diagnostics,
         runtimeEventCount: runtimeContext.length,
         ...(contextBudgetDiagnostic ? { contextBudget: contextBudgetDiagnostic } : {}),
+        ...(latestHistoryCompactCheckpoint ? { latestHistoryCompactCheckpoint } : {}),
       };
     }
 
@@ -1680,6 +1970,7 @@ export class AiSdkBackend implements AgentBackend {
         diagnostics: plan.diagnostics,
         runtimeEventCount: runtimeContext.length,
         ...(contextBudgetDiagnostic ? { contextBudget: contextBudgetDiagnostic } : {}),
+        ...(latestHistoryCompactCheckpoint ? { latestHistoryCompactCheckpoint } : {}),
       };
     }
 
@@ -1690,6 +1981,7 @@ export class AiSdkBackend implements AgentBackend {
         diagnostics: plan.diagnostics,
         runtimeEventCount: runtimeContext.length,
         ...(contextBudgetDiagnostic ? { contextBudget: contextBudgetDiagnostic } : {}),
+        ...(latestHistoryCompactCheckpoint ? { latestHistoryCompactCheckpoint } : {}),
       };
     }
 
@@ -1699,6 +1991,7 @@ export class AiSdkBackend implements AgentBackend {
       diagnostics: plan.diagnostics,
       runtimeEventCount: runtimeContext.length,
       ...(contextBudgetDiagnostic ? { contextBudget: contextBudgetDiagnostic } : {}),
+      ...(latestHistoryCompactCheckpoint ? { latestHistoryCompactCheckpoint } : {}),
     };
   }
 
@@ -1944,6 +2237,514 @@ export class AiSdkBackend implements AgentBackend {
         return { messages: rewritten.messages };
       }
       return !dryRun && projectedMessages ? { messages: projectedMessages } : undefined;
+    };
+  }
+
+  /**
+   * Mid-turn capacity compaction eligibility (issue #882 PR 1). Explicit
+   * opt-in via `historyCompact.midTurn.enabled`; requires the checkpoint
+   * writer seams plus the durable turn-ledger read, the persisted head anchor
+   * for this turn, and a known model context window.
+   */
+  private buildMidTurnCapacityCompactState(input: BackendSendInput): MidTurnCapacityCompactState | undefined {
+    const policy = this.input.contextBudget;
+    if (policy?.historyCompact?.enabled !== true || policy.historyCompact.midTurn?.enabled !== true) {
+      return undefined;
+    }
+    if (
+      !this.input.summarizeHistoryCompact
+      || !this.input.recordHistoryCompactCheckpoint
+      || !this.input.loadTurnRuntimeEvents
+    ) {
+      return undefined;
+    }
+    const headAnchor = input.headAnchorRuntimeEvent;
+    if (
+      !headAnchor
+      || headAnchor.sessionId !== this.sessionId
+      || headAnchor.turnId !== input.turnId
+      || headAnchor.role !== 'user'
+      || headAnchor.author !== 'user'
+      || !isHistoryCompactContentEvent(headAnchor)
+    ) {
+      return undefined;
+    }
+    const contextWindow = resolveSelectedModelContextWindow(this.input.connection, this.input.modelId);
+    if (contextWindow === undefined) return undefined;
+    const priorContentEvents = (input.runtimeContext ?? [])
+      .filter((event) => event.turnId !== input.turnId)
+      .filter(isHistoryCompactContentEvent);
+    return new MidTurnCapacityCompactState(headAnchor, priorContentEvents, contextWindow);
+  }
+
+  /**
+   * prepareStep SHAPING hook for the mid-turn capacity invariant: between
+   * steps of one turn, estimate the next provider request (last step's real
+   * usage + a signed char/4 payload delta, tool schemas included) against
+   * `contextWindow - reserve`; over the high-water, fold a safe completed
+   * prefix into a durable mid_turn checkpoint and continue the same turn on
+   * `[compact block, verbatim head anchor, preserved tail]`.
+   *
+   * This hook never terminates the turn: every failure fails open with a
+   * diagnostic and records itself for the final-request estimate owner, which
+   * re-measures the payload after ALL shaping (including active tool-result
+   * pruning, which runs later and can still rescue the step) and issues the
+   * context_budget_exhausted verdict only when the request that would really
+   * go out exceeds the window. The trigger threshold here is deliberately
+   * approximate — a missed or spurious trigger is recoverable; the verdict is
+   * not, so it does not live here.
+   */
+  private buildMidTurnCapacityCompactPrepareStep(
+    turnId: string,
+    state: MidTurnCapacityCompactState | undefined,
+    queue: AsyncEventQueue<SessionEvent>,
+    providerTools: readonly MakaTool[],
+    fallbackActiveTools: () => readonly string[],
+    turnTailPrompt: string | undefined,
+    systemPromptChars: number,
+    onDiagnosticPatch: (patch: Partial<ContextBudgetDiagnostic>) => void,
+  ): PrepareStepFunctionLike | undefined {
+    if (!state) return undefined;
+    const summarizer = this.input.summarizeHistoryCompact!;
+    const recorder = this.input.recordHistoryCompactCheckpoint!;
+    const loadTurnRuntimeEvents = this.input.loadTurnRuntimeEvents!;
+    const policy = this.input.contextBudget!;
+    const compactPolicy = policy.historyCompact!;
+    const midTurn = compactPolicy.midTurn!;
+    const charsPerToken = policy.charsPerToken ?? 4;
+    const reserveTokens = midTurn.reserveTokens ?? 16_384;
+    const maxSummaryEstimatedTokens = compactPolicy.maxBlockEstimatedTokens
+      ?? compactPolicy.maxSummaryEstimatedTokens
+      ?? 1_024;
+    let acceptedProjection: ActiveFullCompactPrepareStepProjection | undefined;
+
+    return async (options) => {
+      const incomingMessages = options.messages;
+      const projectedMessages = projectAcceptedActiveFullCompactMessages(incomingMessages, acceptedProjection);
+      const keepProjection = (): PrepareStepResultLike | undefined =>
+        projectedMessages ? { messages: projectedMessages } : undefined;
+      // Step 0 is shaped by the pre_turn path; the mid-turn trigger only runs
+      // between steps, once completed-step usage and events exist.
+      if (options.stepNumber < 1 || state.exhaustedDetail) return keepProjection();
+
+      // Real usage for the last finished step, read synchronously from the
+      // SDK's own step results (the same numbers the finish-step chunk
+      // carries) — no coupling to how far the stream consumer has advanced.
+      // Baseline = the last request's INPUT tokens only (see the state field
+      // doc: the payload delta already carries the step's output). The
+      // adapter fails closed on missing token counts (undefined, #972), and a
+      // provider can still report a zero input outright — either way a
+      // non-positive input count is unusable for estimation, so clear the
+      // baseline and let the estimate fall back to the whole-payload cold
+      // start instead of "0 + delta".
+      const lastStepInputTokens = normalizeAiSdkUsage(options.steps.at(-1)?.usage)?.inputTokens;
+      state.lastRequestInputTokens =
+        lastStepInputTokens !== undefined && Number.isFinite(lastStepInputTokens) && lastStepInputTokens > 0
+          ? lastStepInputTokens
+          : undefined;
+
+      // A skipped trigger is never silent: every failure-driven skip records a
+      // failedOpen decision. Recorder counters are attached ONLY on the tiers
+      // where the recorder was actually invoked — the diagnostics must never
+      // claim a write that did not happen.
+      const failOpen = (
+        failOpenReason: string,
+        recorderCounters: Partial<ContextBudgetDiagnostic> = {},
+      ): PrepareStepResultLike | undefined => {
+        onDiagnosticPatch({
+          historyCompactEnabled: true,
+          historyCompactMode: 'read_write',
+          ...recorderCounters,
+          ...compactionDecisionDiagnosticPatch({
+            stage: 'activeStep',
+            sourceKind: 'runtimeEvents',
+            decision: 'failedOpen',
+            phase: 'mid_turn',
+            boundaryKind: 'historyCompact',
+            reason: 'context_limit',
+            failOpenReason,
+          }),
+        });
+        return keepProjection();
+      };
+      // A shaping failure additionally records itself for the final-request
+      // estimate owner: when the final payload is still over the window, the
+      // owner turns this step's failure into the terminal detail instead of
+      // re-entering a shaper that already attempted and failed.
+      const shapeFailure = (
+        detail: ContextBudgetExhaustedDetail,
+        diagnosticReason: string,
+        recorderCounters: Partial<ContextBudgetDiagnostic> = {},
+      ): PrepareStepResultLike | undefined => {
+        state.lastShapeFailure = { stepNumber: options.stepNumber, detail, diagnosticReason };
+        return failOpen(diagnosticReason, recorderCounters);
+      };
+
+      // Trigger estimate: the last request's input tokens plus a SIGNED char/4 delta of
+      // this step's payload (system prompt + projected messages + active tool
+      // schemas) against the previous request's measured payload. Measured synchronously from
+      // the SDK's own projection — no ledger dependency — so a same-turn
+      // `load_tools` schema expansion or a large tool result both count. This
+      // position measures BEFORE later shapers (prune) run, so it can
+      // over-trigger; that is the recoverable direction, and the verdict owner
+      // re-measures the post-shaping payload.
+      const measuredMessages = projectedMessages ?? incomingMessages;
+      const activeToolsForStep = options.activeTools ?? fallbackActiveTools();
+      const payloadChars = midTurnRequestPayloadChars(
+        measuredMessages,
+        providerTools,
+        activeToolsForStep,
+        systemPromptChars,
+      );
+      const forcedEstimate = state.forcedTriggerEstimate;
+      state.forcedTriggerEstimate = undefined;
+      const estimate = forcedEstimate ?? estimateNextRequestTokens({
+        ...(state.lastRequestInputTokens !== undefined ? { priorUsageTokens: state.lastRequestInputTokens } : {}),
+        appendedChars: payloadChars - (state.lastRequestPayloadChars ?? payloadChars),
+        charsPerToken,
+        coldStartChars: payloadChars,
+      });
+      if (forcedEstimate === undefined && !exceedsHighWater(estimate, state.contextWindow, reserveTokens)) {
+        return keepProjection();
+      }
+
+      // Coverage pool = the durable run ledger, read through the injected
+      // seam. Covered events are persisted by construction (no crash window
+      // between checkpoint and source), and their bytes are exactly what a
+      // recovery re-projection replays.
+      //
+      // Seq-ack durability boundary. The replacement projection REPLACES the
+      // whole message list, so any completed-step content event missing from
+      // the durable pool is silently dropped from the next request — a
+      // lagging ledger here is content loss (e.g. a step's already-emitted
+      // assistant text), not a conservative under-count. No event-kind
+      // predicate can close that: the wait counts the event stream itself.
+      //  1. The pump has flushed every finish-step boundary the SDK reports
+      //     completed (state.flushedSteps), so ALL of the completed steps'
+      //     session events — tool pairs AND thinking/text completions — are
+      //     enqueued with producer-stamped sequence numbers.
+      //  2. The consumer has fully processed everything enqueued
+      //     (consumedCount >= pushedCount). The consumer's pull is the ack
+      //     (see drain()): it fires after processing, not after persisting,
+      //     so deliberately-unpersisted events (non-terminal errors,
+      //     partials) can never deadlock the wait.
+      // After both, ONE durable read (which itself re-awaits the run's
+      // serialized write queue) sees every event the projection may carry.
+      // Exits: the boundary, an abort, a detached consumer, or a read failure.
+      const abortSignal = this.abortController?.signal;
+      for (;;) {
+        if (abortSignal?.aborted) return shapeFailure('no_safe_completed_span', 'ledger_wait_aborted');
+        if (queue.consumerDetached) return shapeFailure('no_safe_completed_span', 'ledger_wait_aborted');
+        if (state.flushedSteps >= options.stepNumber && queue.consumedCount >= queue.pushedCount) break;
+        await waitForQueueProgressOrAbort(queue, abortSignal);
+      }
+      let turnLedger: RuntimeEvent[];
+      try {
+        turnLedger = await loadTurnRuntimeEvents(turnId);
+      } catch {
+        return shapeFailure('no_safe_completed_span', 'ledger_read_failed');
+      }
+      const currentTurnEvents = turnLedger
+        .filter((event) => event.turnId === turnId)
+        .filter(isHistoryCompactContentEvent);
+      // The head anchor is persisted before backend.send() is invoked, so
+      // its absence is a wiring error, not replication lag — fail open now.
+      if (!currentTurnEvents.some((event) => event.id === state.headAnchor.id)) {
+        return shapeFailure('no_safe_completed_span', 'head_anchor_not_durable');
+      }
+      const orderedEvents = [...state.priorContentEvents, ...currentTurnEvents];
+
+      const plan = await planMidTurnCapacityCompaction({
+        sessionId: this.sessionId,
+        orderedEvents,
+        headAnchor: { runtimeEventId: state.headAnchor.id, turnId },
+        estimatedNextRequestTokens: estimate,
+        contextWindow: state.contextWindow,
+        reserveTokens,
+        reserveTailEvents: midTurn.reserveTailEvents ?? 1,
+        charsPerToken,
+        now: this.now(),
+        ...(compactPolicy.highWaterName !== undefined ? { highWaterName: compactPolicy.highWaterName } : {}),
+        maxSummaryEstimatedTokens,
+        ...(state.previousCheckpoint ? { previousCheckpoint: state.previousCheckpoint } : {}),
+        summarize: async ({ coveredRuntimeEvents, newlyFoldedRuntimeEvents, previousCheckpoint }) => {
+          const draftBlock = buildHistoryCompactBlockFromSummary({
+            sessionId: this.sessionId,
+            foldedRuntimeEvents: coveredRuntimeEvents,
+            summary: 'Mid-turn capacity compaction draft.',
+            ...(compactPolicy.highWaterName !== undefined ? { highWaterName: compactPolicy.highWaterName } : {}),
+            maxSummaryEstimatedTokens,
+            charsPerToken,
+            now: this.now(),
+          });
+          return await Promise.resolve(summarizer({
+            sessionId: this.sessionId,
+            turnId,
+            source: { draftBlock, foldedRuntimeEvents: [...coveredRuntimeEvents] },
+            limits: {
+              maxBlocks: 1,
+              maxBlockEstimatedTokens: maxSummaryEstimatedTokens,
+              maxEstimatedTokens: compactPolicy.maxEstimatedTokens ?? 2_048,
+              charsPerToken,
+            },
+            ...(previousCheckpoint ? { previousCheckpoint } : {}),
+            newlyFoldedRuntimeEvents: [...newlyFoldedRuntimeEvents],
+            ...(this.abortController?.signal ? { abortSignal: this.abortController.signal } : {}),
+          }));
+        },
+      });
+
+      if (plan.decision === 'skip') return keepProjection();
+      if (plan.decision === 'fail_open') return shapeFailure(plan.reason, plan.reason);
+
+      // Lifecycle order is validate → persist → apply, where validate =
+      // materializable ∧ smaller ∧ replay-admissible. Replay applies the
+      // session's latest checkpoint BEFORE any high-water check, so a
+      // checkpoint that fails ANY of the three must never be persisted — it
+      // would poison every later projection even though this step correctly
+      // refused it.
+      // Persistence still precedes application, so the crash-window property
+      // (never apply an unpersisted fold) is unchanged, and the recorder
+      // counters stay truthful: validation failures never reached the
+      // recorder, so they attach no write counters.
+      const replayPlan = buildRuntimeEventModelReplayPlan(plan.replacementEvents, {
+        toolActivityTurnIds: collectToolActivityTurnIds(orderedEvents),
+      });
+      if (
+        replayPlan.items.length === 0
+        || hasBlockingReplayDiagnostics(replayPlan)
+        || (replayPlan.hasProviderNativeSemantics && !this.canReplayProviderNative(replayPlan))
+      ) {
+        return shapeFailure('no_safe_completed_span', 'replacement_unmaterializable');
+      }
+      // The head anchor must render exactly like the raw projection's current
+      // user message: the initial request decorates it with the volatile turn
+      // tail (cwd, shell context, task state — see send()), which is not part
+      // of the durable anchor bytes. Reuse the same decoration owner
+      // (appendTurnTailPrompt) on the anchor's replay item so a replacement
+      // never silently drops that context — and never counts the drop as
+      // shrinkage in the guard below.
+      const replayItemsWithAnchorTail = replayPlan.items.map((item) =>
+        item.kind === 'text' && item.role === 'user' && item.eventId === state.headAnchor.id
+          ? { ...item, content: this.appendTurnTailPrompt(item.content, turnTailPrompt) as string }
+          : item,
+      );
+      const replacementMessages = await this.materializeRuntimeReplayPlan({
+        ...replayPlan,
+        items: replayItemsWithAnchorTail,
+      });
+      // Apply the shape only when it actually shrinks the request: a
+      // materialized replacement that is not smaller than the current payload
+      // (e.g. a runaway summary block) would hand the verdict owner a WORSE
+      // request than the raw projection it just refused to improve. A
+      // non-shrinking fold proves the summarizer's OUTPUT is unusable — not
+      // that the irreducible remainder exceeds capacity — so over the window
+      // the owner reports it as summarizer_failed, with the precise
+      // replacement_not_smaller diagnostic reason.
+      const replacedPayloadChars = midTurnRequestPayloadChars(
+        replacementMessages,
+        providerTools,
+        activeToolsForStep,
+        systemPromptChars,
+      );
+      if (replacedPayloadChars >= payloadChars) {
+        return shapeFailure('summarizer_failed', 'replacement_not_smaller');
+      }
+      // Replay admissibility, through the SAME single gate the recovery path
+      // runs (max block / max total / prefix budget) with the same policy —
+      // one acceptance standard, not two. A checkpoint accepted here but
+      // rejected at replay would still become the session's latest checkpoint
+      // and poison recovery: the next projection would refuse it and
+      // re-inject the covered raw span. Block-size rejections mean the
+      // summarizer's output is unusable (summarizer_failed); a prefix over
+      // the history budget means the irreducible remainder is too large.
+      const replayFit = evaluateHistoryCompactCheckpointReplay(
+        plan.checkpoint,
+        plan.replacementEvents.slice(1),
+        policy,
+      );
+      if (!replayFit.fits) {
+        return shapeFailure(
+          replayFit.reason === 'prefix_over_budget' ? 'head_anchor_exceeds_capacity' : 'summarizer_failed',
+          `replay_rejected_${replayFit.reason}`,
+        );
+      }
+
+      // The replacement is valid: durably persist the checkpoint BEFORE
+      // applying the projection — the same order as the pre_turn path — so a
+      // recovery re-projection never re-injects the replaced raw span. A
+      // persistence failure keeps raw messages and records write_failed in
+      // the durable diagnostics; if the final payload is then over the
+      // window, the verdict owner maps this failure to the terminal
+      // summarizer_failed detail.
+      const writeFailedCounters: Partial<ContextBudgetDiagnostic> = {
+        historyCompactWritesAttempted: 1,
+        historyCompactWriteFailures: 1,
+      };
+      try {
+        await Promise.resolve(recorder(plan.checkpoint, turnId));
+      } catch {
+        return shapeFailure('summarizer_failed', 'write_failed', writeFailedCounters);
+      }
+      state.previousCheckpoint = plan.checkpoint;
+      acceptedProjection = {
+        sourceSignatures: incomingMessages.map(modelMessageSignature),
+        projectedMessages: replacementMessages,
+      };
+      state.replacedStepNumber = options.stepNumber;
+      onDiagnosticPatch({
+        historyCompactEnabled: true,
+        historyCompactMode: 'read_write',
+        historyCompactWritesAttempted: 1,
+        historyCompactBlocksWritten: 1,
+        historyCompactWrittenBlockIds: [plan.checkpoint.checkpointId],
+        historyCompactWriteEstimatedTokens: plan.checkpoint.estimatedTokens,
+        historyCompactBlockIds: [plan.checkpoint.checkpointId],
+        historyCompactedTurns: plan.checkpoint.coverage.turnCount,
+        historyCompactedEvents: plan.checkpoint.coverage.eventCount,
+        historyCompactedEstimatedTokensBefore: plan.estimatedTokensBefore,
+        historyCompactedEstimatedTokensAfter: plan.estimatedTokensAfter,
+        highWaterName: plan.checkpoint.highWaterName,
+        highWaterSeq: plan.checkpoint.highWaterSeq,
+        highWaterReason: 'history_compact',
+        ...compactionDecisionDiagnosticPatch({
+          stage: 'activeStep',
+          sourceKind: 'runtimeEvents',
+          decision: 'replaced',
+          phase: 'mid_turn',
+          boundaryKind: 'historyCompact',
+          boundaryIds: [plan.checkpoint.checkpointId],
+          coverage: { bodySha256: [plan.checkpoint.coverage.sourceDigest] },
+          reason: 'context_limit',
+          estimatedTokensBefore: plan.estimatedTokensBefore,
+          estimatedTokensAfter: plan.estimatedTokensAfter,
+        }),
+      });
+      return { messages: replacementMessages };
+    };
+  }
+
+  /**
+   * The single end-of-pipeline estimate owner for the mid-turn capacity
+   * invariant. Every prepareStep hook only shapes; this wrapper measures the
+   * FINAL outgoing (messages, tools) payload — the bytes the provider will
+   * actually see, after capacity compaction, active tool-result pruning, and
+   * semantic/active-full compaction have all run — and issues the one
+   * safety-critical verdict:
+   *
+   *  - estimate = the last request's real INPUT tokens + signed char/4 delta
+   *    against the previous request's measured payload (recorded here on
+   *    every step, including step 0's baseline); the delta already carries
+   *    the step's fresh output, so an output-inclusive baseline would count
+   *    it twice, and an unusable usage sample falls back to the whole-payload
+   *    cold start rather than a zero baseline;
+   *  - over the window with no capacity attempt this step (the approximate
+   *    trigger missed, e.g. growth the trigger under-weighted), force ONE
+   *    capacity re-entry — the verdict must not terminate a turn a shaper can
+   *    still rescue, and one bounded re-entry preserves termination;
+   *  - still over the window → context_budget_exhausted, with the terminal
+   *    detail taken from this step's capacity outcome: a replacement that
+   *    remains too large is head_anchor_exceeds_capacity (the irreducible
+   *    remainder exceeds capacity); a recorded shaping failure keeps its own
+   *    detail and diagnostic reason.
+   *
+   * Step 0 is shaped by the pre_turn path and only records the baseline here.
+   */
+  private buildMidTurnFinalRequestVerdict(input: {
+    shaped: PrepareStepFunctionLike;
+    reentry: PrepareStepFunctionLike;
+    state: MidTurnCapacityCompactState;
+    providerTools: readonly MakaTool[];
+    fallbackActiveTools: () => readonly string[];
+    charsPerToken: number;
+    systemPromptChars: number;
+    onDiagnosticPatch: (patch: Partial<ContextBudgetDiagnostic>) => void;
+  }): PrepareStepFunctionLike {
+    const {
+      shaped,
+      reentry,
+      state,
+      providerTools,
+      fallbackActiveTools,
+      charsPerToken,
+      systemPromptChars,
+      onDiagnosticPatch,
+    } = input;
+    return async (options) => {
+      let result = await Promise.resolve(shaped(options));
+      const finalPayloadChars = (): number => midTurnRequestPayloadChars(
+        result?.messages ?? options.messages,
+        providerTools,
+        result?.activeTools ?? options.activeTools ?? fallbackActiveTools(),
+        systemPromptChars,
+      );
+      let payloadChars = finalPayloadChars();
+      if (options.stepNumber >= 1 && !state.exhaustedDetail) {
+        const estimateFinal = (): number => estimateNextRequestTokens({
+          ...(state.lastRequestInputTokens !== undefined ? { priorUsageTokens: state.lastRequestInputTokens } : {}),
+          appendedChars: payloadChars - (state.lastRequestPayloadChars ?? payloadChars),
+          charsPerToken,
+          coldStartChars: payloadChars,
+        });
+        let estimate = estimateFinal();
+        const capacityAttemptedThisStep = state.replacedStepNumber === options.stepNumber
+          || state.lastShapeFailure?.stepNumber === options.stepNumber;
+        if (estimate > state.contextWindow && !capacityAttemptedThisStep) {
+          // One bounded capacity re-entry: the trigger threshold is
+          // approximate on purpose (recoverable), so a miss must become a
+          // rescue attempt before it can become a terminal verdict. Re-run
+          // only the capacity + prune shapers over the already-shaped
+          // projection; a second attempt after a same-step failure is
+          // pointless (the failure was not a trigger miss) and would double
+          // recorder counters and summarizer calls.
+          state.forcedTriggerEstimate = estimate;
+          const reshaped = await Promise.resolve(reentry({
+            ...options,
+            messages: result?.messages ?? options.messages,
+            ...(result?.activeTools ? { activeTools: result.activeTools } : {}),
+          }));
+          state.forcedTriggerEstimate = undefined;
+          if (reshaped) {
+            result = {
+              ...(result ?? {}),
+              ...reshaped,
+              activeTools: reshaped.activeTools ?? result?.activeTools,
+            };
+          }
+          payloadChars = finalPayloadChars();
+          estimate = estimateFinal();
+        }
+        if (estimate > state.contextWindow) {
+          const failure = state.lastShapeFailure?.stepNumber === options.stepNumber
+            ? state.lastShapeFailure
+            : undefined;
+          const replacedThisStep = state.replacedStepNumber === options.stepNumber;
+          const detail: ContextBudgetExhaustedDetail = replacedThisStep
+            ? 'head_anchor_exceeds_capacity'
+            : failure?.detail ?? 'no_safe_completed_span';
+          const diagnosticReason = replacedThisStep
+            ? 'head_anchor_exceeds_capacity'
+            : failure?.diagnosticReason ?? 'no_safe_completed_span';
+          state.exhaustedDetail = detail;
+          onDiagnosticPatch({
+            historyCompactEnabled: true,
+            historyCompactMode: 'read_write',
+            ...compactionDecisionDiagnosticPatch({
+              stage: 'activeStep',
+              sourceKind: 'runtimeEvents',
+              decision: 'unchanged',
+              phase: 'mid_turn',
+              boundaryKind: 'historyCompact',
+              reason: 'context_budget_exhausted',
+              skippedReasonCounts: { [diagnosticReason]: 1 },
+            }),
+          });
+          this.abortController?.abort(new Error(`mid-turn context budget exhausted: ${detail}`));
+          return result;
+        }
+      }
+      state.lastRequestPayloadChars = payloadChars;
+      return result;
     };
   }
 
@@ -2788,7 +3589,22 @@ export class AiSdkBackend implements AgentBackend {
   }
 
   private async *drain(queue: AsyncEventQueue<SessionEvent>): AsyncIterable<SessionEvent> {
-    for await (const ev of queue) yield ev;
+    try {
+      for await (const ev of queue) {
+        yield ev;
+        // Generator backpressure IS the consumer's ack: this line runs only
+        // when the consumer's loop body finished for `ev` and pulled the next
+        // event, so `consumedCount` counts fully PROCESSED events. AgentRun
+        // persists each mapped event before continuing, so an acked event is
+        // either durable or deliberately skipped (partials, non-terminal
+        // errors) — exactly the set a durable read can ever return.
+        queue.ackConsumed();
+      }
+    } finally {
+      // The consumer abandoned or finished the stream; wake any seq-ack waiter
+      // so it observes `consumerDetached` instead of blocking forever.
+      queue.noteConsumerDetached();
+    }
   }
 
   private cleanupAfterTurn(turnId: string): void {

--- a/packages/runtime/src/ai-sdk-backend.ts
+++ b/packages/runtime/src/ai-sdk-backend.ts
@@ -1313,25 +1313,25 @@ export class AiSdkBackend implements AgentBackend {
           activeToolResultPruneDiagnosticPatch,
           activeCompactDiagnosticPatch,
         );
-        this.input.recordLlmCall?.({
+        if (tokenUsage) this.input.recordLlmCall?.({
           sessionId: this.sessionId,
           turnId,
           connectionSlug: this.input.connection.slug,
           providerId: this.input.connection.providerType,
           modelId: this.input.modelId,
-          inputTokens: tokenUsage?.inputTokens ?? 0,
-          outputTokens: tokenUsage?.outputTokens ?? 0,
-          cacheHitInputTokens: tokenUsage?.cacheHitInputTokens ?? 0,
-          cacheMissInputTokens: tokenUsage?.cacheMissInputTokens ?? 0,
-          ...(tokenUsage?.cacheMissInputSource !== undefined
+          inputTokens: tokenUsage.inputTokens,
+          outputTokens: tokenUsage.outputTokens,
+          cacheHitInputTokens: tokenUsage.cacheHitInputTokens,
+          cacheMissInputTokens: tokenUsage.cacheMissInputTokens,
+          ...(tokenUsage.cacheMissInputSource !== undefined
             ? { cacheMissInputSource: tokenUsage.cacheMissInputSource }
             : {}),
-          cachedInputTokens: tokenUsage?.cachedInputTokens ?? 0,
-          cacheWriteInputTokens: tokenUsage?.cacheWriteInputTokens ?? 0,
-          reasoningTokens: tokenUsage?.reasoningTokens ?? 0,
-          totalTokens: tokenUsage?.totalTokens,
-          ...(tokenUsage?.rawFinishReason !== undefined ? { rawFinishReason: tokenUsage.rawFinishReason } : {}),
-          ...(tokenUsage?.raw !== undefined ? { rawUsage: tokenUsage.raw } : {}),
+          cachedInputTokens: tokenUsage.cachedInputTokens,
+          cacheWriteInputTokens: tokenUsage.cacheWriteInputTokens,
+          reasoningTokens: tokenUsage.reasoningTokens,
+          totalTokens: tokenUsage.totalTokens,
+          ...(tokenUsage.rawFinishReason !== undefined ? { rawFinishReason: tokenUsage.rawFinishReason } : {}),
+          ...(tokenUsage.raw !== undefined ? { rawUsage: tokenUsage.raw } : {}),
           latencyMs: Math.max(0, this.now() - startedAt),
           status: streamStatus,
           ...(streamErrorClass ? { errorClass: streamErrorClass } : {}),
@@ -1958,7 +1958,8 @@ export class AiSdkBackend implements AgentBackend {
     status: LlmCallRecord['status'];
     errorClass?: string;
   }): void {
-    const costUsd = input.usage ? this.computeTokenUsageCostUsd(input.usage) : 0;
+    if (!input.usage) return;
+    const costUsd = this.computeTokenUsageCostUsd(input.usage);
     this.input.recordLlmCall?.({
       sessionId: this.sessionId,
       turnId: input.turnId,
@@ -1967,19 +1968,19 @@ export class AiSdkBackend implements AgentBackend {
       connectionSlug: this.input.connection.slug,
       providerId: this.input.connection.providerType,
       modelId: input.modelId,
-      inputTokens: input.usage?.inputTokens ?? 0,
-      outputTokens: input.usage?.outputTokens ?? 0,
-      cacheHitInputTokens: input.usage?.cacheHitInputTokens ?? 0,
-      cacheMissInputTokens: input.usage?.cacheMissInputTokens ?? 0,
-      ...(input.usage?.cacheMissInputSource !== undefined
+      inputTokens: input.usage.inputTokens,
+      outputTokens: input.usage.outputTokens,
+      cacheHitInputTokens: input.usage.cacheHitInputTokens,
+      cacheMissInputTokens: input.usage.cacheMissInputTokens,
+      ...(input.usage.cacheMissInputSource !== undefined
         ? { cacheMissInputSource: input.usage.cacheMissInputSource }
         : {}),
-      cachedInputTokens: input.usage?.cachedInputTokens ?? 0,
-      cacheWriteInputTokens: input.usage?.cacheWriteInputTokens ?? 0,
-      reasoningTokens: input.usage?.reasoningTokens ?? 0,
-      totalTokens: input.usage?.totalTokens,
+      cachedInputTokens: input.usage.cachedInputTokens,
+      cacheWriteInputTokens: input.usage.cacheWriteInputTokens,
+      reasoningTokens: input.usage.reasoningTokens,
+      totalTokens: input.usage.totalTokens,
       ...(input.finishReason !== undefined ? { rawFinishReason: input.finishReason } : {}),
-      ...(input.usage?.raw !== undefined ? { rawUsage: input.usage.raw } : {}),
+      ...(input.usage.raw !== undefined ? { rawUsage: input.usage.raw } : {}),
       latencyMs: input.latencyMs,
       status: input.status,
       ...(input.errorClass ? { errorClass: input.errorClass } : {}),

--- a/packages/runtime/src/ai-sdk-flow.ts
+++ b/packages/runtime/src/ai-sdk-flow.ts
@@ -455,7 +455,7 @@ export function mapSessionEventToRuntimeEvent(
         actions: { endInvocation: true, stateDelta: { abortSource: event.reason } },
       };
     case 'complete':
-      return completeRuntimeEvent(base, event.stopReason, memory);
+      return completeRuntimeEvent(base, event, memory);
     default: {
       // Exhaustiveness guard: if SessionEvent grows a new variant, the
       // mapping falls through to a diagnostic event instead of dropping it.
@@ -475,9 +475,10 @@ export function mapSessionEventToRuntimeEvent(
 
 function completeRuntimeEvent(
   base: ReturnType<typeof resolveBase>,
-  stopReason: CompleteStopReason,
+  event: CompleteEvent,
   memory: SessionEventMapMemory,
 ): RuntimeEvent {
+  const stopReason = event.stopReason;
   const status = memory.failureClass && stopReason !== 'user_stop'
     ? 'failed'
     : mapCompleteStopReason(stopReason);
@@ -486,6 +487,12 @@ function completeRuntimeEvent(
     stateDelta.failureClass = memory.failureClass
       ?? failureClassFromCompleteStopReason(stopReason)
       ?? 'runtime_error';
+  }
+  // The context_budget_exhausted outcome carries which invariant made the turn
+  // unrecoverable; the durable terminal state must not collapse it to a bare
+  // failure class.
+  if (event.contextBudgetExhaustedDetail !== undefined) {
+    stateDelta.contextBudgetExhaustedDetail = event.contextBudgetExhaustedDetail;
   }
   if (status === 'aborted') stateDelta.abortSource = stopReason;
   return {
@@ -590,6 +597,11 @@ export class AiSdkFlow implements AgentFlow, AgentFlowControl {
       for await (const sessionEvent of this.backend.send({
         runId: ctx.runId,
         turnId: ctx.turnId,
+        // The persisted head anchor: mid-turn capacity compaction keeps this
+        // event verbatim and needs its exact ledger identity for coverage.
+        ...(ctx.request.initialRuntimeEvent !== undefined
+          ? { headAnchorRuntimeEvent: ctx.request.initialRuntimeEvent }
+          : {}),
         text: input.text,
         ...(input.attachments !== undefined ? { attachments: input.attachments } : {}),
         context: input.context,

--- a/packages/runtime/src/async-queue.ts
+++ b/packages/runtime/src/async-queue.ts
@@ -14,6 +14,14 @@
  * - `error(err)` rejects the next/current waiter and marks the queue errored;
  *   subsequent `next()` calls re-throw.
  * - One consumer only. Multiple consumers will race on `next()`.
+ *
+ * Seq-ack counters: `pushedCount` stamps a monotonic sequence on the producer
+ * side at enqueue; the consumer loop acks each event AFTER fully processing it
+ * via `ackConsumed()` (see AiSdkBackend.drain — the generator's pull IS the
+ * ack). A producer-side waiter can then await "everything enqueued before this
+ * boundary has been processed" with `consumedCount >= pushedCount`, using
+ * `waitForProgress()` as the condition-variable wake — no polling, and immune
+ * to event-kind predicate drift because it counts the stream itself.
  */
 
 export class AsyncEventQueue<T> implements AsyncIterable<T> {
@@ -24,15 +32,51 @@ export class AsyncEventQueue<T> implements AsyncIterable<T> {
   }> = [];
   private closed = false;
   private err: Error | null = null;
+  /** Monotonic count of events accepted by push(). */
+  pushedCount = 0;
+  /** Monotonic count of events the consumer has fully processed. */
+  consumedCount = 0;
+  /** Set when the consumer abandoned the stream; progress waiters must not block on it. */
+  consumerDetached = false;
+  private progressWaiters: Array<() => void> = [];
 
   push(item: T): void {
     if (this.closed || this.err) return;
+    this.pushedCount += 1;
     const w = this.waiters.shift();
     if (w) {
       w.resolve({ value: item, done: false });
     } else {
       this.buf.push(item);
     }
+    this.wake();
+  }
+
+  /** Consumer-side ack: one event has been fully processed (not just received). */
+  ackConsumed(): void {
+    this.consumedCount += 1;
+    this.wake();
+  }
+
+  /** The consumer stopped pulling; wake waiters so they can observe it. */
+  noteConsumerDetached(): void {
+    this.consumerDetached = true;
+    this.wake();
+  }
+
+  /** Resolves on the next push/ack/close/error/wake — a condition-variable wait. */
+  waitForProgress(): Promise<void> {
+    return new Promise<void>((resolve) => {
+      this.progressWaiters.push(resolve);
+    });
+  }
+
+  /** Wake all progress waiters so they re-check their condition. */
+  wake(): void {
+    if (this.progressWaiters.length === 0) return;
+    const waiters = this.progressWaiters;
+    this.progressWaiters = [];
+    for (const resolve of waiters) resolve();
   }
 
   close(): void {
@@ -42,6 +86,7 @@ export class AsyncEventQueue<T> implements AsyncIterable<T> {
       const w = this.waiters.shift()!;
       w.resolve({ value: undefined as unknown as T, done: true });
     }
+    this.wake();
   }
 
   error(err: Error): void {
@@ -52,6 +97,7 @@ export class AsyncEventQueue<T> implements AsyncIterable<T> {
       const w = this.waiters.shift()!;
       w.reject(err);
     }
+    this.wake();
   }
 
   [Symbol.asyncIterator](): AsyncIterator<T> {

--- a/packages/runtime/src/compaction-boundary.ts
+++ b/packages/runtime/src/compaction-boundary.ts
@@ -63,6 +63,8 @@ export interface CompactionDecision {
   stage: CompactionStage;
   sourceKind: CompactionSourceKind;
   decision: CompactionDecisionKind;
+  /** Compaction phase; absent = pre_turn. */
+  phase?: 'pre_turn' | 'mid_turn';
   boundaryKind?: CompactionBoundaryKind;
   boundaryIds?: readonly string[];
   coverage?: CompactionCoverage;
@@ -165,6 +167,7 @@ export function compactionDecisionToDiagnostic(
     stage: decision.stage,
     sourceKind: decision.sourceKind,
     decision: decision.decision,
+    ...(decision.phase ? { phase: decision.phase } : {}),
     ...(decision.boundaryKind ? { boundaryKind: decision.boundaryKind } : {}),
     ...(decision.boundaryIds ? { boundaryIds: [...decision.boundaryIds] } : {}),
     ...(decision.coverage?.turnIds ? { coveredTurns: decision.coverage.turnIds.length } : {}),

--- a/packages/runtime/src/context-budget-policy.ts
+++ b/packages/runtime/src/context-budget-policy.ts
@@ -185,6 +185,7 @@ function buildHistoryCompactPolicy(
   const tailEstimatedTokens = parseOptionalPositiveInt(env.MAKA_CONTEXT_HISTORY_COMPACT_TAIL_TOKENS);
   const minRecentTurns = parseOptionalPositiveInt(env.MAKA_CONTEXT_HISTORY_COMPACT_MIN_RECENT_TURNS);
   const maxSummaryEstimatedTokens = parseOptionalPositiveInt(env.MAKA_CONTEXT_HISTORY_COMPACT_MAX_SUMMARY_TOKENS);
+  const midTurn = buildHistoryCompactMidTurnPolicy(env);
   return {
     enabled: true,
     mode: parseHistoryCompactMode(env.MAKA_CONTEXT_HISTORY_COMPACT_MODE),
@@ -198,6 +199,27 @@ function buildHistoryCompactPolicy(
     maxEstimatedTokens: parsePositiveInt(env.MAKA_CONTEXT_HISTORY_COMPACT_MAX_TOKENS, 2048),
     maxBlockEstimatedTokens: parsePositiveInt(env.MAKA_CONTEXT_HISTORY_COMPACT_MAX_BLOCK_TOKENS, 1024),
     highWaterName: env.MAKA_CONTEXT_HISTORY_COMPACT_HIGH_WATER_NAME ?? defaultHighWaterName,
+    ...(midTurn !== undefined ? { midTurn } : {}),
+  };
+}
+
+// Mid-turn capacity compaction defaults OFF this PR: only an explicit
+// MAKA_CONTEXT_HISTORY_COMPACT_MID_TURN=on opts in, so a standalone revert of
+// this line leaves every surface's behavior unchanged. PR 3 sinks the default on.
+function buildHistoryCompactMidTurnPolicy(
+  env: Record<string, string | undefined>,
+): NonNullable<NonNullable<ContextBudgetPolicy['historyCompact']>['midTurn']> | undefined {
+  const enabled = parseOptionalBoolean(
+    env.MAKA_CONTEXT_HISTORY_COMPACT_MID_TURN,
+    'MAKA_CONTEXT_HISTORY_COMPACT_MID_TURN',
+  );
+  if (enabled !== true) return undefined;
+  const reserveTokens = parseOptionalPositiveInt(env.MAKA_CONTEXT_HISTORY_COMPACT_RESERVE_TOKENS) ?? 16_384;
+  const reserveTailEvents = parseOptionalNonNegativeInt(env.MAKA_CONTEXT_HISTORY_COMPACT_MID_TURN_TAIL_EVENTS);
+  return {
+    enabled: true,
+    reserveTokens,
+    ...(reserveTailEvents !== undefined ? { reserveTailEvents } : {}),
   };
 }
 

--- a/packages/runtime/src/context-budget.ts
+++ b/packages/runtime/src/context-budget.ts
@@ -17,6 +17,7 @@ import type { CompactionDecisionKind } from './compaction-boundary.js';
 import {
   historyCompactCheckpointToRuntimeEvent,
   matchHistoryCompactCheckpointPrefix,
+  midTurnHeadAnchorEvent,
   renderHistoryCompactCheckpoint,
   type HistoryCompactCheckpoint,
 } from './history-compact-checkpoint.js';
@@ -305,6 +306,25 @@ export interface HistoryCompactPolicy {
   /** Optional archive refs keyed by RuntimeEvent id for archive-before-project validation. */
   sourceArchiveRefs?: readonly HistoryCompactSourceArchiveRef[] | Readonly<Record<string, HistoryCompactSourceArchiveRef>>;
   highWaterName?: string;
+  /**
+   * Optional mid-turn capacity compaction, layered on the same V2 checkpoint
+   * protocol. Defaults off (explicit opt-in this PR); when enabled the backend
+   * measures the next provider request between steps and folds a safe completed
+   * prefix before crossing the model context window.
+   */
+  midTurn?: HistoryCompactMidTurnPolicy;
+}
+
+export interface HistoryCompactMidTurnPolicy {
+  enabled: boolean;
+  /**
+   * Tokens kept free below the selected model context window. The proactive
+   * high-water threshold is `contextWindow - reserveTokens`. Defaults to the
+   * shared history-compact reserve (16384).
+   */
+  reserveTokens?: number;
+  /** Trailing events kept verbatim as the continuation tail. Defaults to 1. */
+  reserveTailEvents?: number;
 }
 
 export interface HistoryCompactSourceArchiveRef {
@@ -652,6 +672,66 @@ export function applyRuntimeEventHistoryCompact(
   }
 
   const compactableEvents = events.filter(isHistoryCompactContentEvent);
+
+  // A mid_turn checkpoint's coverage reaches into the compacted turn's own
+  // completed steps, so it can extend past what tail selection would retain
+  // and must not require multiple prior turns. Match it against the full
+  // content projection BEFORE every size-based guard — including the
+  // below-high-water skip: replaying an accepted mid_turn checkpoint is a
+  // correctness invariant (the covered raw span must never be re-injected),
+  // not a capacity optimization, so a small raw projection does not bypass
+  // it. Replay is the deterministic [block, verbatim head anchor, tail].
+  const midTurnCheckpoint = compactPolicy.checkpoint?.phase === 'mid_turn' ? compactPolicy.checkpoint : undefined;
+  if (midTurnCheckpoint) {
+    const match = matchHistoryCompactCheckpointPrefix(midTurnCheckpoint, compactableEvents);
+    if (match.reason) {
+      increment(skippedReasonCounts, match.reason);
+    } else {
+      const headAnchor = midTurnHeadAnchorEvent(midTurnCheckpoint, match.coveredRuntimeEvents);
+      const replayTail = headAnchor
+        ? [headAnchor, ...match.successorRuntimeEvents]
+        : [...match.successorRuntimeEvents];
+      const fit = evaluateHistoryCompactCheckpointReplay(midTurnCheckpoint, replayTail, policy!, {
+        charsPerToken,
+        maxHistoryEstimatedTokens: maxTokens,
+      });
+      if (!fit.fits) {
+        increment(skippedReasonCounts, fit.reason);
+      } else {
+        return {
+          events: [historyCompactCheckpointToRuntimeEvent(midTurnCheckpoint), ...replayTail],
+          blocks: [],
+          checkpoint: midTurnCheckpoint,
+          diagnosticPatch: {
+            ...basePatch,
+            historyCompactBlocksAvailable: 1,
+            historyCompactBlocksSelected: 1,
+            historyCompactBlockIds: [midTurnCheckpoint.checkpointId],
+            historyCompactedTurns: midTurnCheckpoint.coverage.turnCount,
+            historyCompactedEvents: midTurnCheckpoint.coverage.eventCount,
+            historyCompactedEstimatedTokensBefore: estimateRuntimeEventsTokens(match.coveredRuntimeEvents, charsPerToken),
+            historyCompactedEstimatedTokensAfter: fit.checkpointTokens,
+            historyCompactCoverageHashes: [midTurnCheckpoint.coverage.sourceDigest],
+            highWaterName: midTurnCheckpoint.highWaterName,
+            highWaterSeq: midTurnCheckpoint.highWaterSeq,
+            highWaterReason: 'history_compact',
+            ...compactionDecisionDiagnosticPatch({
+              stage: 'priorReplay',
+              sourceKind: 'runtimeEvents',
+              decision: 'replaced',
+              phase: 'mid_turn',
+              boundaryKind: 'historyCompact',
+              boundaryIds: [midTurnCheckpoint.checkpointId],
+              coverage: { bodySha256: [midTurnCheckpoint.coverage.sourceDigest] },
+              estimatedTokensBefore: estimateRuntimeEventsTokens(match.coveredRuntimeEvents, charsPerToken),
+              estimatedTokensAfter: fit.checkpointTokens,
+            }),
+          },
+        };
+      }
+    }
+  }
+
   const estimatedTokensBefore = estimateRuntimeEventsTokens(compactableEvents, charsPerToken);
   const highWaterRatio = finiteRatio(compactPolicy.highWaterRatio, 0.8);
   const highWaterThreshold = Math.max(1, Math.floor(maxTokens * highWaterRatio));
@@ -723,7 +803,8 @@ export function applyRuntimeEventHistoryCompact(
     };
   }
 
-  const checkpoint = compactPolicy.checkpoint;
+  // mid_turn checkpoints were handled above against the full content projection.
+  const checkpoint = compactPolicy.checkpoint?.phase === 'mid_turn' ? undefined : compactPolicy.checkpoint;
   if (checkpoint) {
     const match = matchHistoryCompactCheckpointPrefix(checkpoint, foldedEvents);
     if (match.reason) {
@@ -2120,7 +2201,8 @@ function turnKey(event: RuntimeEvent): string {
   return event.turnId || '<unknown-turn>';
 }
 
-function isHistoryCompactContentEvent(event: RuntimeEvent): boolean {
+/** True when the event carries model-visible content the compact projection counts. */
+export function isHistoryCompactContentEvent(event: RuntimeEvent): boolean {
   return estimateRuntimeEventChars(event) > 0;
 }
 

--- a/packages/runtime/src/history-compact-checkpoint.ts
+++ b/packages/runtime/src/history-compact-checkpoint.ts
@@ -25,6 +25,26 @@ export interface HistoryCompactCheckpointCoverage {
   sourceDigest: string;
 }
 
+/**
+ * Compaction phase. Absent on legacy data and defaults to `pre_turn`, the
+ * turn-boundary compaction the V2 checkpoint protocol was introduced for. A
+ * `mid_turn` checkpoint folds a prefix that reaches into the current turn's
+ * completed steps, so its projection re-renders the covered head anchor (the
+ * current turn's user message) verbatim after the compact block.
+ */
+export type HistoryCompactCheckpointPhase = 'pre_turn' | 'mid_turn';
+
+/**
+ * Reference to a covered RuntimeEvent that a `mid_turn` checkpoint re-renders
+ * verbatim in the replay projection. Coverage still spans this event so the
+ * digest math stays a contiguous prefix; the projection deterministically
+ * rebuilds `[compact block, verbatim head anchor, tail]` from it.
+ */
+export interface HistoryCompactCheckpointHeadAnchor {
+  runtimeEventId: string;
+  turnId: string;
+}
+
 export interface HistoryCompactCheckpoint {
   kind: 'maka.history_compact_checkpoint';
   version: 2;
@@ -36,6 +56,10 @@ export interface HistoryCompactCheckpoint {
   /** Present on evidence-spine checkpoints; omitted only on legacy V2 data. */
   source?: HistoryCompactCheckpointSource;
   coverage: HistoryCompactCheckpointCoverage;
+  /** Absent = `pre_turn`. `mid_turn` checkpoints carry a `headAnchor`. */
+  phase?: HistoryCompactCheckpointPhase;
+  /** Present only on `mid_turn` checkpoints; the covered head anchor re-rendered verbatim. */
+  headAnchor?: HistoryCompactCheckpointHeadAnchor;
   summary: string;
   limitations: string[];
   estimatedTokens: number;
@@ -52,6 +76,10 @@ export interface BuildHistoryCompactCheckpointInput {
   previousCheckpointId?: string;
   now?: number;
   charsPerToken?: number;
+  /** Defaults to `pre_turn`. `mid_turn` requires a `headAnchor` inside coverage. */
+  phase?: HistoryCompactCheckpointPhase;
+  /** Required when `phase` is `mid_turn`; must reference a covered RuntimeEvent. */
+  headAnchor?: HistoryCompactCheckpointHeadAnchor;
 }
 
 export type HistoryCompactCheckpointPrefixMatch =
@@ -77,9 +105,44 @@ export function buildHistoryCompactCheckpoint(
   if (input.coveredRuntimeEvents.some((event) => event.sessionId !== input.sessionId)) {
     throw new Error('History compact checkpoint source events must belong to one session');
   }
+  // A partial streaming snapshot is later replaced or deleted in the durable
+  // ledger, so a digest over it can never replay: coverage must be immutable.
+  if (input.coveredRuntimeEvents.some((event) => event.partial === true)) {
+    throw new Error('History compact checkpoint coverage must not include partial events');
+  }
   const summary = input.summary.trim();
   if (summary.length === 0) {
     throw new Error('History compact checkpoint requires a non-empty summary');
+  }
+  // A mid_turn checkpoint folds a prefix that reaches into the current turn, so
+  // its head anchor MUST be one of the covered events — the projection re-renders
+  // that exact event verbatim after the block, and coverage stays contiguous.
+  const phase = input.phase === 'mid_turn' ? 'mid_turn' : undefined;
+  let headAnchor: HistoryCompactCheckpointHeadAnchor | undefined;
+  if (phase === 'mid_turn') {
+    if (!input.headAnchor) {
+      throw new Error('Mid-turn history compact checkpoint requires a head anchor');
+    }
+    const anchored = input.coveredRuntimeEvents.find((event) => event.id === input.headAnchor!.runtimeEventId);
+    if (!anchored) {
+      throw new Error('Mid-turn history compact checkpoint head anchor must be a covered RuntimeEvent');
+    }
+    // The anchor is re-rendered verbatim as the compacted turn's user message.
+    // The compacted turn is the one the coverage reaches into — the LAST
+    // covered event's turn — so the anchor must be that turn's user event. A
+    // self-consistent anchor resolving to some other covered user event (e.g.
+    // a prior turn's prompt) would silently drop the real current prompt from
+    // the replay, so the protocol fails closed at build time.
+    const lastCovered = input.coveredRuntimeEvents.at(-1)!;
+    if (
+      anchored.turnId !== input.headAnchor.turnId
+      || anchored.turnId !== lastCovered.turnId
+      || anchored.role !== 'user'
+      || anchored.author !== 'user'
+    ) {
+      throw new Error('Mid-turn history compact checkpoint head anchor must be the compacted turn\'s user event');
+    }
+    headAnchor = { runtimeEventId: input.headAnchor.runtimeEventId, turnId: input.headAnchor.turnId };
   }
   const charsPerToken = input.charsPerToken ?? 4;
   const maxSummaryChars = Math.max(80, (input.maxSummaryEstimatedTokens ?? 1_024) * Math.max(1, charsPerToken));
@@ -113,6 +176,8 @@ export function buildHistoryCompactCheckpoint(
     coverage,
     summary: boundedSummary,
     previousCheckpointId: input.previousCheckpointId,
+    // Only hash the phase/anchor when set so pre_turn checkpoint ids stay stable.
+    ...(phase ? { phase, headAnchor } : {}),
   })).slice(0, 32)}`;
   const checkpoint: HistoryCompactCheckpoint = {
     kind: 'maka.history_compact_checkpoint',
@@ -124,6 +189,8 @@ export function buildHistoryCompactCheckpoint(
     highWaterSeq,
     source,
     coverage,
+    ...(phase ? { phase } : {}),
+    ...(headAnchor ? { headAnchor } : {}),
     summary: boundedSummary,
     limitations: [
       'Replay-time summary of the covered RuntimeEvent prefix.',
@@ -193,6 +260,13 @@ export function validateHistoryCompactCheckpointShape(
       checkpoint.sessionId,
       coverage,
     ))
+    && (checkpoint.phase === undefined || checkpoint.phase === 'pre_turn' || checkpoint.phase === 'mid_turn')
+    && (checkpoint.phase !== 'mid_turn'
+      || (!!checkpoint.headAnchor
+        && nonEmpty(checkpoint.headAnchor.runtimeEventId)
+        && nonEmpty(checkpoint.headAnchor.turnId)))
+    && (checkpoint.headAnchor === undefined
+      || (nonEmpty(checkpoint.headAnchor.runtimeEventId) && nonEmpty(checkpoint.headAnchor.turnId)))
     && typeof checkpoint.summary === 'string'
     && checkpoint.summary.trim().length > 0
     && Array.isArray(checkpoint.limitations)
@@ -257,10 +331,56 @@ export function matchHistoryCompactCheckpointPrefix(
   ) {
     return { coveredEventCount: 0, coveredRuntimeEvents: [], successorRuntimeEvents: [], reason: 'coverage_miss' };
   }
+  // A mid_turn checkpoint's replay re-renders the head anchor verbatim, so a
+  // corrupted anchor reference must fail the match closed here — otherwise the
+  // projection would silently drop the compacted turn's user message.
+  // The compacted turn is the coverage's `through` turn, so the anchor must be
+  // THAT turn's user event — not merely any self-consistent covered user event
+  // (e.g. a prior turn's prompt).
+  if (checkpoint.phase === 'mid_turn') {
+    const anchor = coveredRuntimeEvents.find(
+      (event) => event.id === checkpoint.headAnchor!.runtimeEventId,
+    );
+    if (
+      !anchor
+      || anchor.turnId !== checkpoint.headAnchor!.turnId
+      || anchor.turnId !== checkpoint.coverage.through.turnId
+      || anchor.role !== 'user'
+      || anchor.author !== 'user'
+    ) {
+      return { coveredEventCount: 0, coveredRuntimeEvents: [], successorRuntimeEvents: [], reason: 'coverage_miss' };
+    }
+  }
   if (historyCompactSourceDigest(coveredRuntimeEvents) !== checkpoint.coverage.sourceDigest) {
     return { coveredEventCount: 0, coveredRuntimeEvents: [], successorRuntimeEvents: [], reason: 'source_hash_mismatch' };
   }
   return { coveredEventCount: coveredRuntimeEvents.length, coveredRuntimeEvents, successorRuntimeEvents };
+}
+
+/**
+ * Deterministic replay projection for a checkpoint. `pre_turn` yields
+ * `[compact block, ...tail]`; `mid_turn` re-inserts the covered head anchor
+ * verbatim as `[compact block, head anchor, ...tail]` so the current turn's
+ * user message stays exact even though coverage folded it. `coveredRuntimeEvents`
+ * are the raw events the checkpoint covers (from `matchHistoryCompactCheckpointPrefix`).
+ */
+export function projectHistoryCompactCheckpointReplay(
+  checkpoint: HistoryCompactCheckpoint,
+  coveredRuntimeEvents: readonly RuntimeEvent[],
+  replayTail: readonly RuntimeEvent[],
+): RuntimeEvent[] {
+  const block = historyCompactCheckpointToRuntimeEvent(checkpoint);
+  const anchor = midTurnHeadAnchorEvent(checkpoint, coveredRuntimeEvents);
+  return anchor ? [block, anchor, ...replayTail] : [block, ...replayTail];
+}
+
+/** The covered head anchor event for a mid_turn checkpoint, or undefined. */
+export function midTurnHeadAnchorEvent(
+  checkpoint: HistoryCompactCheckpoint,
+  coveredRuntimeEvents: readonly RuntimeEvent[],
+): RuntimeEvent | undefined {
+  if (checkpoint.phase !== 'mid_turn' || !checkpoint.headAnchor) return undefined;
+  return coveredRuntimeEvents.find((event) => event.id === checkpoint.headAnchor!.runtimeEventId);
 }
 
 function historyCompactCheckpointSource(

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -503,6 +503,8 @@ export {
   canReplaceHistoryCompactCheckpoint,
   historyCompactCheckpointToRuntimeEvent,
   matchHistoryCompactCheckpointPrefix,
+  midTurnHeadAnchorEvent,
+  projectHistoryCompactCheckpointReplay,
   renderHistoryCompactCheckpoint,
   validateHistoryCompactCheckpointShape,
 } from './history-compact-checkpoint.js';
@@ -510,9 +512,27 @@ export type {
   BuildHistoryCompactCheckpointInput,
   HistoryCompactCheckpoint,
   HistoryCompactCheckpointCoverage,
+  HistoryCompactCheckpointHeadAnchor,
+  HistoryCompactCheckpointPhase,
   HistoryCompactCheckpointPrefixMatch,
   HistoryCompactCheckpointSource,
 } from './history-compact-checkpoint.js';
+export {
+  estimateNextRequestTokens,
+  exceedsContextWindow,
+  exceedsHighWater,
+  planMidTurnCapacityCompaction,
+  selectMidTurnSafeBoundary,
+} from './mid-turn-capacity-compact.js';
+export type {
+  EstimateNextRequestTokensInput,
+  MidTurnBoundary,
+  MidTurnBoundaryOptions,
+  MidTurnFailReason,
+  MidTurnSummarizer,
+  PlanMidTurnCapacityCompactionInput,
+  PlanMidTurnCapacityCompactionResult,
+} from './mid-turn-capacity-compact.js';
 export { cleanupLegacyHistoryCompactArtifacts } from './history-compact-cleanup.js';
 export type {
   HistoryCompactCleanupDiagnostic,
@@ -559,6 +579,7 @@ export type {
   ArchiveRetrievalResult,
   HistoryCompactBlock,
   HistoryCompactCoverage,
+  HistoryCompactMidTurnPolicy,
   HistoryCompactPolicy,
   HistoryCompactReplayResult,
   HistoryCompactSourceArchiveRef,

--- a/packages/runtime/src/mid-turn-capacity-compact.ts
+++ b/packages/runtime/src/mid-turn-capacity-compact.ts
@@ -1,0 +1,329 @@
+import type { RuntimeEvent } from '@maka/core/runtime-event';
+import { estimateRuntimeEventsTokens } from './context-budget.js';
+import {
+  buildHistoryCompactCheckpoint,
+  historyCompactCheckpointToRuntimeEvent,
+  matchHistoryCompactCheckpointPrefix,
+  projectHistoryCompactCheckpointReplay,
+  type HistoryCompactCheckpoint,
+} from './history-compact-checkpoint.js';
+
+/**
+ * Mid-turn capacity compaction: the pure measurement + safe-boundary engine.
+ *
+ * The runtime owns one active-turn context invariant — a long single turn must
+ * compact a safe completed prefix before the next provider request crosses the
+ * selected model's context window. This module is turn-agnostic and side-effect
+ * free, and it only SHAPES: it selects the largest safe covered prefix and
+ * builds the checkpoint + replacement projection, failing open when it cannot.
+ * The safety-critical pass/terminate verdict is NOT issued here — the backend's
+ * final-request estimate owner measures the actual outgoing (messages, tools)
+ * payload after every shaping hook has run and decides `context_budget_exhausted`
+ * there, so the verdict is always about the request that really goes out.
+ */
+
+export interface EstimateNextRequestTokensInput {
+  /**
+   * The last request's real INPUT tokens as reported by the provider — never
+   * input+output, because `appendedChars` is a delta against that request's
+   * payload and already carries the step's freshly generated output.
+   * Undefined on cold start or when the sample is unusable (no positive
+   * input count), which falls back to a whole-payload char estimate.
+   */
+  priorUsageTokens?: number;
+  /**
+   * SIGNED char delta of the next request's payload versus the last measured
+   * request payload. Negative after compaction/pruning shrank the projection —
+   * the estimate must credit the shrink, or a compacted request would still be
+   * judged by the pre-compaction usage sample.
+   */
+  appendedChars: number;
+  /** Estimate conversion; defaults to 4 chars/token. */
+  charsPerToken?: number;
+  /** Whole-payload chars, used only when `priorUsageTokens` is undefined. */
+  coldStartChars?: number;
+}
+
+/**
+ * Estimate the token size of the next provider request. Anchors on the last
+ * step's real usage plus a signed char/4 payload delta for content the provider
+ * has not yet counted (or no longer carries); cold-start (no usage) is a pure
+ * char/4 estimate of the whole payload. This mirrors how surveyed peers avoid
+ * pure character guessing.
+ */
+export function estimateNextRequestTokens(input: EstimateNextRequestTokensInput): number {
+  const charsPerToken = Math.max(1, input.charsPerToken ?? 4);
+  if (input.priorUsageTokens !== undefined && Number.isFinite(input.priorUsageTokens)) {
+    return Math.max(
+      0,
+      Math.max(0, Math.floor(input.priorUsageTokens)) + estimateSignedChars(input.appendedChars, charsPerToken),
+    );
+  }
+  return Math.max(0, estimateSignedChars(input.coldStartChars ?? input.appendedChars, charsPerToken));
+}
+
+/** Proactive threshold: the next request would cross `contextWindow - reserve`. */
+export function exceedsHighWater(
+  estimatedTokens: number,
+  contextWindow: number,
+  reserveTokens: number,
+): boolean {
+  const highWater = Math.max(1, contextWindow - Math.max(0, reserveTokens));
+  return estimatedTokens > highWater;
+}
+
+/** Hard cap: the estimate exceeds the raw context window even before the reserve. */
+export function exceedsContextWindow(estimatedTokens: number, contextWindow: number): boolean {
+  return estimatedTokens > contextWindow;
+}
+
+export interface MidTurnBoundaryOptions {
+  /** Keep at least this many trailing events uncovered as the verbatim tail. */
+  reserveTailEvents?: number;
+}
+
+export type MidTurnBoundary =
+  | { ok: true; coveredCount: number }
+  | { ok: false; reason: 'no_safe_completed_span' };
+
+/**
+ * Select the largest contiguous covered prefix that is safe to fold:
+ *
+ *  - it ends on an immutable, non-partial event (a partial streaming snapshot is
+ *    later replaced/deleted, so a digest over it can never replay);
+ *  - it never straddles a tool call/result pair (a provider protocol unit);
+ *  - it leaves at least `reserveTailEvents` trailing events as the verbatim tail.
+ *
+ * Returns `no_safe_completed_span` when no such cut exists (e.g. the remaining
+ * pool is a single atomic call/result pair), which the caller surfaces as an
+ * explicit `context_budget_exhausted` outcome rather than a provider error.
+ */
+export function selectMidTurnSafeBoundary(
+  events: readonly RuntimeEvent[],
+  options: MidTurnBoundaryOptions = {},
+): MidTurnBoundary {
+  const reserveTail = Math.max(0, Math.floor(options.reserveTailEvents ?? 0));
+  // A partial anywhere in the covered prefix (not just at the cut) poisons the
+  // digest — its snapshot is later replaced or deleted — so the boundary
+  // retreats to strictly before the first partial in the pool.
+  const firstPartialIndex = events.findIndex((event) => event.partial === true);
+  const maxCut = Math.min(
+    events.length - reserveTail,
+    firstPartialIndex === -1 ? events.length : firstPartialIndex,
+  );
+  const pairSpans = toolPairSpans(events);
+  for (let cut = maxCut; cut >= 1; cut -= 1) {
+    if (straddlesToolPair(pairSpans, cut)) continue;
+    return { ok: true, coveredCount: cut };
+  }
+  return { ok: false, reason: 'no_safe_completed_span' };
+}
+
+interface ToolPairSpan {
+  callIndex?: number;
+  responseIndex?: number;
+}
+
+function toolPairSpans(events: readonly RuntimeEvent[]): ToolPairSpan[] {
+  const byCallId = new Map<string, ToolPairSpan>();
+  events.forEach((event, index) => {
+    const content = event.content;
+    if (content?.kind === 'function_call') {
+      const span = byCallId.get(content.id) ?? {};
+      span.callIndex = index;
+      byCallId.set(content.id, span);
+    } else if (content?.kind === 'function_response') {
+      const span = byCallId.get(content.id) ?? {};
+      span.responseIndex = index;
+      byCallId.set(content.id, span);
+    }
+  });
+  return [...byCallId.values()];
+}
+
+/**
+ * A cut at exclusive index `cut` straddles a pair if exactly one side is
+ * covered. A call whose response is not in the pool yet is an OPEN span:
+ * covering it would orphan the response that arrives later (a result with no
+ * call in the projection), so any cut past the call is unsafe. A response
+ * without a call is inert — its call lives before the pool, so no cut inside
+ * the pool can split that pair.
+ */
+function straddlesToolPair(spans: readonly ToolPairSpan[], cut: number): boolean {
+  for (const span of spans) {
+    if (span.callIndex !== undefined && span.responseIndex === undefined) {
+      if (span.callIndex < cut) return true;
+      continue;
+    }
+    if (span.callIndex === undefined || span.responseIndex === undefined) continue;
+    const callCovered = span.callIndex < cut;
+    const responseCovered = span.responseIndex < cut;
+    if (callCovered !== responseCovered) return true;
+  }
+  return false;
+}
+
+function estimateSignedChars(chars: number | undefined, charsPerToken: number): number {
+  const value = Math.trunc(chars ?? 0);
+  if (!Number.isFinite(value) || value === 0) return 0;
+  const magnitude = Math.ceil(Math.abs(value) / charsPerToken);
+  return value > 0 ? magnitude : -magnitude;
+}
+
+// ============================================================================
+// Orchestration: engine + checkpoint protocol + injected summarizer → decision
+// ============================================================================
+
+export type MidTurnSummarizer = (input: {
+  coveredRuntimeEvents: readonly RuntimeEvent[];
+  newlyFoldedRuntimeEvents: readonly RuntimeEvent[];
+  previousCheckpoint?: HistoryCompactCheckpoint;
+}) => Promise<string | undefined> | string | undefined;
+
+export interface PlanMidTurnCapacityCompactionInput {
+  sessionId: string;
+  /**
+   * Full ordered content-event projection for the compaction pool:
+   * `[...prior turns, head anchor, ...current-turn completed steps]`.
+   */
+  orderedEvents: readonly RuntimeEvent[];
+  /** The current turn's user message; must be one of `orderedEvents`. */
+  headAnchor: { runtimeEventId: string; turnId: string };
+  /** Estimated size of the next provider request (see estimateNextRequestTokens). */
+  estimatedNextRequestTokens: number;
+  contextWindow: number;
+  reserveTokens: number;
+  reserveTailEvents?: number;
+  charsPerToken?: number;
+  now?: number;
+  highWaterName?: string;
+  highWaterSeq?: number;
+  maxSummaryEstimatedTokens?: number;
+  previousCheckpoint?: HistoryCompactCheckpoint;
+  summarize: MidTurnSummarizer;
+}
+
+export type PlanMidTurnCapacityCompactionResult =
+  | { decision: 'skip'; reason: 'below_high_water' }
+  | { decision: 'fail_open'; reason: MidTurnFailReason }
+  | {
+      decision: 'compacted';
+      checkpoint: HistoryCompactCheckpoint;
+      /** Deterministic `[block, head anchor, tail]` replacement projection. */
+      replacementEvents: RuntimeEvent[];
+      coveredRuntimeEvents: RuntimeEvent[];
+      tailRuntimeEvents: RuntimeEvent[];
+      estimatedTokensBefore: number;
+      estimatedTokensAfter: number;
+    };
+
+export type MidTurnFailReason =
+  | 'no_safe_completed_span'
+  | 'summarizer_failed';
+
+/**
+ * Decide, deterministically, how a long active turn compacts before the next
+ * provider request. This plan is a pure shaper: when it cannot fold a safe
+ * completed prefix it FAILS OPEN (keep the raw projection + diagnostic) and
+ * never terminates the turn itself. The two failure tiers — fail open under
+ * the window, explicit `context_budget_exhausted` over it — are applied by the
+ * backend's final-request estimate owner, which re-measures the actual outgoing
+ * payload after all shaping (including this fold) has been applied.
+ */
+export async function planMidTurnCapacityCompaction(
+  input: PlanMidTurnCapacityCompactionInput,
+): Promise<PlanMidTurnCapacityCompactionResult> {
+  const charsPerToken = Math.max(1, input.charsPerToken ?? 4);
+  const highWater = Math.max(1, input.contextWindow - Math.max(0, input.reserveTokens));
+  if (input.estimatedNextRequestTokens <= highWater) {
+    return { decision: 'skip', reason: 'below_high_water' };
+  }
+
+  const boundary = selectMidTurnSafeBoundary(input.orderedEvents, {
+    reserveTailEvents: input.reserveTailEvents ?? 1,
+  });
+  const headAnchorIndex = input.orderedEvents.findIndex(
+    (event) => event.id === input.headAnchor.runtimeEventId,
+  );
+  // Coverage must include the head anchor and at least one other event, since the
+  // anchor is re-rendered verbatim — folding only the anchor saves nothing.
+  if (
+    !boundary.ok
+    || headAnchorIndex < 0
+    || boundary.coveredCount <= headAnchorIndex
+    || boundary.coveredCount < 2
+  ) {
+    return { decision: 'fail_open', reason: 'no_safe_completed_span' };
+  }
+
+  const coveredRuntimeEvents = input.orderedEvents.slice(0, boundary.coveredCount);
+  const tailRuntimeEvents = input.orderedEvents.slice(boundary.coveredCount);
+
+  // Roll forward from a previous checkpoint when it is an exact prefix of the
+  // covered events, so the summary only re-reads the newly folded span.
+  const checkpointMatch = input.previousCheckpoint
+    ? matchHistoryCompactCheckpointPrefix(input.previousCheckpoint, coveredRuntimeEvents)
+    : undefined;
+  const previousCheckpoint = checkpointMatch && !checkpointMatch.reason ? input.previousCheckpoint : undefined;
+  const newlyFoldedRuntimeEvents = previousCheckpoint
+    ? checkpointMatch!.successorRuntimeEvents
+    : coveredRuntimeEvents;
+
+  let summary: string | undefined;
+  try {
+    summary = (await Promise.resolve(input.summarize({
+      coveredRuntimeEvents,
+      newlyFoldedRuntimeEvents,
+      ...(previousCheckpoint ? { previousCheckpoint } : {}),
+    })))?.trim();
+  } catch {
+    summary = undefined;
+  }
+  if (!summary) {
+    return { decision: 'fail_open', reason: 'summarizer_failed' };
+  }
+
+  const checkpoint = buildHistoryCompactCheckpoint({
+    sessionId: input.sessionId,
+    coveredRuntimeEvents,
+    summary,
+    phase: 'mid_turn',
+    headAnchor: input.headAnchor,
+    ...(input.highWaterName !== undefined ? { highWaterName: input.highWaterName } : {}),
+    ...(input.highWaterSeq !== undefined ? { highWaterSeq: input.highWaterSeq } : {}),
+    ...(input.maxSummaryEstimatedTokens !== undefined
+      ? { maxSummaryEstimatedTokens: input.maxSummaryEstimatedTokens }
+      : {}),
+    ...(previousCheckpoint ? { previousCheckpointId: previousCheckpoint.checkpointId } : {}),
+    charsPerToken,
+    ...(input.now !== undefined ? { now: input.now } : {}),
+  });
+
+  const replacementEvents = projectHistoryCompactCheckpointReplay(
+    checkpoint,
+    coveredRuntimeEvents,
+    tailRuntimeEvents,
+  );
+  const estimatedTokensBefore = estimateRuntimeEventsTokens(coveredRuntimeEvents, charsPerToken);
+  const estimatedTokensAfter = estimateRuntimeEventsTokens(
+    [historyCompactCheckpointToRuntimeEvent(checkpoint)],
+    charsPerToken,
+  );
+
+  // No post-fold verdict here: any re-estimate over the raw ledger span is
+  // wrong once the previous request was itself a compacted projection (the
+  // raw covered span was never in that request, so subtracting it
+  // over-credits the fold). The backend applies the shape only when the
+  // materialized replacement payload actually shrinks the request, and its
+  // final-request estimate owner measures the outgoing payload for the
+  // window verdict.
+  return {
+    decision: 'compacted',
+    checkpoint,
+    replacementEvents,
+    coveredRuntimeEvents,
+    tailRuntimeEvents,
+    estimatedTokensBefore,
+    estimatedTokensAfter,
+  };
+}

--- a/packages/runtime/src/model-adapter.ts
+++ b/packages/runtime/src/model-adapter.ts
@@ -51,10 +51,19 @@ export interface ModelAdapterInput {
 export interface PrepareStepLike {
   steps: ReadonlyArray<{
     toolCalls?: ReadonlyArray<{ toolCallId?: string; toolName: string; input?: unknown }>;
+    /** Real provider usage the SDK recorded for this finished step. */
+    usage?: AiSdkUsageLike;
   }>;
   stepNumber: number;
   model: unknown;
   messages: ModelMessage[];
+  /**
+   * Active tool subset for this step. The SDK does not pass it; the composed
+   * prepareStep pipeline threads an earlier hook's `activeTools` result through
+   * so later hooks (and the final-request estimate owner) can measure the
+   * provider-visible tool schema for the step.
+   */
+  activeTools?: readonly string[];
   experimental_context: unknown;
 }
 

--- a/packages/runtime/src/model-adapter.ts
+++ b/packages/runtime/src/model-adapter.ts
@@ -409,6 +409,7 @@ export interface AiSdkUsageLike {
     reasoningTokens?: number;
   };
   outputTokenDetails?: {
+    textTokens?: number;
     reasoningTokens?: number;
   };
   raw?: AiSdkRawUsageFields;
@@ -434,19 +435,28 @@ export function normalizeAiSdkUsage(
   options: { rawFinishReason?: unknown } = {},
 ): NormalizedAiSdkUsage | undefined {
   if (!usage) return undefined;
-  const inputTokens =
+  const reportedInputTokens =
     finiteTokenFromValueOrBreakdown(usage.inputTokens, 'total')
+    ?? finiteTokenBreakdownSum(usage.inputTokens, ['noCache', 'cacheRead', 'cacheWrite'])
     ?? finiteToken(usage.promptTokens)
     ?? finiteToken(usage.raw?.prompt_tokens)
     ?? finiteToken(usage.prompt_tokens)
-    ?? 0;
-  const outputTokens =
+    ?? finiteTokenSum([
+      usage.inputTokenDetails?.noCacheTokens,
+      usage.inputTokenDetails?.cacheReadTokens,
+      usage.inputTokenDetails?.cacheWriteTokens,
+    ]);
+  const reportedOutputTokens =
     finiteTokenFromValueOrBreakdown(usage.outputTokens, 'total')
+    ?? finiteTokenBreakdownSum(usage.outputTokens, ['text', 'reasoning'])
     ?? finiteToken(usage.completionTokens)
     ?? finiteToken(usage.raw?.completion_tokens)
     ?? finiteToken(usage.completion_tokens)
-    ?? 0;
-  const cacheHitInputTokens =
+    ?? finiteTokenSum([
+      usage.outputTokenDetails?.textTokens,
+      usage.outputTokenDetails?.reasoningTokens,
+    ]);
+  const reportedCacheHitInputTokens =
     finiteToken(usage.cacheHitInputTokens)
     ?? finiteToken(usage.cachedInputTokens)
     ?? finiteToken(usage.cacheReadInputTokens)
@@ -456,14 +466,12 @@ export function normalizeAiSdkUsage(
     ?? finiteToken(usage.prompt_tokens_details?.cached_tokens)
     ?? finiteTokenFromBreakdown(usage.inputTokens, 'cacheRead')
     ?? finiteToken(usage.inputTokenDetails?.cacheReadTokens)
-    ?? finiteToken(usage.inputTokenDetails?.cachedTokens)
-    ?? 0;
-  const cacheWriteInputTokens =
+    ?? finiteToken(usage.inputTokenDetails?.cachedTokens);
+  const reportedCacheWriteInputTokens =
     finiteToken(usage.cacheWriteInputTokens)
     ?? finiteToken(usage.cacheCreationInputTokens)
     ?? finiteTokenFromBreakdown(usage.inputTokens, 'cacheWrite')
-    ?? finiteToken(usage.inputTokenDetails?.cacheWriteTokens)
-    ?? 0;
+    ?? finiteToken(usage.inputTokenDetails?.cacheWriteTokens);
   const explicitCacheMissInputTokens =
     finiteToken(usage.cacheMissInputTokens)
     ?? finiteToken(usage.raw?.prompt_cache_miss_tokens)
@@ -471,24 +479,42 @@ export function normalizeAiSdkUsage(
     ?? finiteTokenFromBreakdown(usage.inputTokens, 'noCache')
     ?? finiteToken(usage.inputTokenDetails?.noCacheTokens)
     ?? finiteToken(usage.inputTokenDetails?.cacheMissTokens);
-  const cacheMissInputTokens =
-    explicitCacheMissInputTokens
-    ?? Math.max(0, inputTokens - cacheHitInputTokens - cacheWriteInputTokens);
-  const cacheMissInputSource: CacheMissInputSource =
-    explicitCacheMissInputTokens !== undefined ? 'explicit' : 'derived';
-  const reasoningTokens =
+  const reportedReasoningTokens =
     finiteToken(usage.reasoningTokens)
     ?? finiteTokenFromBreakdown(usage.outputTokens, 'reasoning')
     ?? finiteToken(usage.outputTokenDetails?.reasoningTokens)
     ?? finiteToken(usage.raw?.completion_tokens_details?.reasoning_tokens)
     ?? finiteToken(usage.completion_tokens_details?.reasoning_tokens)
-    ?? finiteToken(usage.inputTokenDetails?.reasoningTokens)
-    ?? 0;
-  const totalTokens =
+    ?? finiteToken(usage.inputTokenDetails?.reasoningTokens);
+  const reportedTotalTokens =
     finiteToken(usage.totalTokens)
     ?? finiteToken(usage.raw?.total_tokens)
-    ?? finiteToken(usage.total_tokens)
-    ?? inputTokens + outputTokens;
+    ?? finiteToken(usage.total_tokens);
+  const inputTokens = reportedInputTokens ?? (
+    reportedTotalTokens !== undefined
+    && reportedOutputTokens !== undefined
+    && reportedTotalTokens >= reportedOutputTokens
+      ? reportedTotalTokens - reportedOutputTokens
+      : undefined
+  );
+  const outputTokens = reportedOutputTokens ?? (
+    reportedTotalTokens !== undefined
+    && reportedInputTokens !== undefined
+    && reportedTotalTokens >= reportedInputTokens
+      ? reportedTotalTokens - reportedInputTokens
+      : undefined
+  );
+  if (inputTokens === undefined || outputTokens === undefined) return undefined;
+  const cacheHitInputTokens = reportedCacheHitInputTokens ?? 0;
+  const cacheWriteInputTokens = reportedCacheWriteInputTokens ?? 0;
+  const cacheMissInputTokens =
+    explicitCacheMissInputTokens
+    ?? Math.max(0, inputTokens - cacheHitInputTokens - cacheWriteInputTokens);
+  const cacheMissInputSource: CacheMissInputSource =
+    explicitCacheMissInputTokens !== undefined ? 'explicit' : 'derived';
+  const reasoningTokens = reportedReasoningTokens ?? 0;
+  const totalTokens =
+    reportedTotalTokens ?? inputTokens + outputTokens;
   const raw = rawUsageFields(usage);
   const rawFinishReason = rawFinishReasonString(options.rawFinishReason);
   return {
@@ -523,6 +549,24 @@ function finiteTokenFromValueOrBreakdown(
   key: keyof TokenCountBreakdown,
 ): number | undefined {
   return finiteToken(value) ?? finiteTokenFromBreakdown(value, key);
+}
+
+function finiteTokenBreakdownSum(
+  value: number | TokenCountBreakdown | undefined,
+  keys: readonly (keyof TokenCountBreakdown)[],
+): number | undefined {
+  if (!value || typeof value !== 'object') return undefined;
+  const parts = keys.map((key) => finiteToken(value[key]));
+  return parts.every((part) => part === undefined)
+    ? undefined
+    : parts.reduce<number>((sum, part) => sum + (part ?? 0), 0);
+}
+
+function finiteTokenSum(values: readonly unknown[]): number | undefined {
+  const tokens = values.map(finiteToken);
+  return tokens.every((token) => token === undefined)
+    ? undefined
+    : tokens.reduce<number>((sum, token) => sum + (token ?? 0), 0);
 }
 
 function rawUsageFields(usage: AiSdkUsageLike): AiSdkRawUsageFields | undefined {

--- a/packages/runtime/src/runtime-kernel.ts
+++ b/packages/runtime/src/runtime-kernel.ts
@@ -677,6 +677,13 @@ export class RuntimeKernel implements RuntimeKernelLike {
           const run = runId ? active?.activeRuns.get(runId) : undefined;
           return this.recordHistoryCompactCheckpoint(sessionId, checkpoint, run);
         },
+        loadTurnRuntimeEvents: (turnId: string) => {
+          const active = this.active.get(sessionId);
+          const runId = active?.turnToRunId.get(turnId);
+          const run = runId ? active?.activeRuns.get(runId) : undefined;
+          if (!run) return Promise.reject(new Error('No active AgentRun for turn runtime events'));
+          return run.loadTurnRuntimeEvents();
+        },
       } : {}),
       recordActiveFullCompactBlock: (block) => {
         const active = this.active.get(sessionId);
@@ -737,6 +744,13 @@ export class RuntimeKernel implements RuntimeKernelLike {
           const run = runId ? active?.activeRuns.get(runId) : undefined;
           return this.recordHistoryCompactCheckpoint(sessionId, checkpoint, run);
         },
+        // loadTurnRuntimeEvents is deliberately NOT injected for child
+        // sessions: a child run has no top-level prior context, so a mid-turn
+        // checkpoint built from its child-only ledger would claim to cover a
+        // session-scoped projection prefix and poison the session-global
+        // checkpoint cache/CAS for the parent projection. Child mid-turn
+        // compaction stays disabled (the backend requires this seam) until
+        // checkpoint streams are partitioned by lineage.
       } : {}),
       recordActiveFullCompactBlock: (block) => {
         const active = this.childActive.get(activeKey);

--- a/packages/runtime/src/session-manager.ts
+++ b/packages/runtime/src/session-manager.ts
@@ -213,6 +213,13 @@ export interface BackendFactoryContext {
   recordRunTrace?: RunTraceRecorder;
   loadHistoryCompactCheckpoint?: () => Promise<HistoryCompactCheckpoint | undefined>;
   recordHistoryCompactCheckpoint?: (checkpoint: HistoryCompactCheckpoint, turnId: string) => Promise<void>;
+  /**
+   * Durable read of the given turn's persisted RuntimeEvents from the
+   * authoritative run ledger. Mid-turn capacity compaction derives its
+   * coverage pool from this read, so covered events are persisted by
+   * construction before any checkpoint that folds them.
+   */
+  loadTurnRuntimeEvents?: (turnId: string) => Promise<RuntimeEvent[]>;
   recordActiveFullCompactBlock?: (block: ActiveFullCompactBlock) => void;
   recordSemanticCompactBlock?: (block: SemanticCompactBlock) => void;
   shellRunContextSummary?: () => Promise<string | undefined>;

--- a/packages/ui/src/__tests__/live-turn-projection.test.ts
+++ b/packages/ui/src/__tests__/live-turn-projection.test.ts
@@ -538,6 +538,18 @@ describe('reconcileTerminalLiveTurn', () => {
     ]), undefined);
   });
 
+  it('keeps a non-terminal projection armed once persisted history covers all steps', () => {
+    const inFlight: LiveTurnProjection = {
+      turnId: 'turn-1',
+      phase: 'streamed',
+      steps: toolOnly.steps,
+    };
+    assert.deepEqual(reconcileTerminalLiveTurn(inFlight, [
+      { type: 'tool_call', id: 'tool-1', turnId: 'turn-1', stepId: 'step-1', ts: 1, toolName: 'Bash', args: {} },
+      { type: 'tool_result', id: 'result-1', turnId: 'turn-1', ts: 2, toolUseId: 'tool-1', isError: false, content: { kind: 'text', text: 'ok' } },
+    ]), { turnId: 'turn-1', phase: 'streamed', steps: [] });
+  });
+
   it('retains terminal evidence while persisted history does not cover it', () => {
     assert.equal(reconcileTerminalLiveTurn(toolOnly, []), toolOnly);
   });

--- a/packages/ui/src/__tests__/picker-trigger.test.ts
+++ b/packages/ui/src/__tests__/picker-trigger.test.ts
@@ -1,0 +1,19 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { pickerTriggerClasses } from '../ui.js';
+
+test('picker triggers separate field chrome from quiet toolbar chrome', () => {
+  const field = pickerTriggerClasses('field');
+  const quiet = pickerTriggerClasses('quiet');
+
+  assert.match(field, /\bmin-h-9\b/);
+  assert.match(field, /\bw-full\b/);
+  assert.match(field, /\bshadow-sm\b/);
+
+  assert.doesNotMatch(quiet, /\bmin-h-9\b/);
+  assert.doesNotMatch(quiet, /\bw-full\b/);
+  assert.doesNotMatch(quiet, /\bshadow-/);
+  assert.doesNotMatch(quiet, /\bborder-input\b/);
+  assert.match(quiet, /focus-visible:ring-2/);
+  assert.match(quiet, /disabled:pointer-events-none/);
+});

--- a/packages/ui/src/chat-model-switcher.tsx
+++ b/packages/ui/src/chat-model-switcher.tsx
@@ -179,6 +179,7 @@ export function ChatModelSwitcher(props: {
       aria-busy={pending ? 'true' : undefined}
     >
       <ModelPicker
+        triggerAppearance="quiet"
         groups={grouped}
         value={currentValue}
         disabled={disabled}
@@ -267,6 +268,7 @@ export function NewChatModelPicker(props: {
   const grouped = modelMenuGroups(props.choices);
   return (
     <ModelPicker
+      triggerAppearance="quiet"
       groups={grouped}
       value={props.currentValue ?? ''}
       renderProviderMark={props.renderProviderMark}

--- a/packages/ui/src/composer.tsx
+++ b/packages/ui/src/composer.tsx
@@ -880,6 +880,7 @@ export const Composer = forwardRef<
                 normal chat. */}
             {props.onPermissionModeChange ? (
               <PermissionModeSelect
+                appearance="quiet"
                 activeMode={props.permissionMode ?? 'ask'}
                 onSelect={(mode) => {
                   void props.onPermissionModeChange?.(mode);

--- a/packages/ui/src/live-turn-projection.ts
+++ b/packages/ui/src/live-turn-projection.ts
@@ -384,6 +384,6 @@ export function reconcileTerminalLiveTurn(
     return !toolsCovered;
   });
   if (steps.length === current.steps.length) return current;
-  if (steps.length === 0) return undefined;
+  if (steps.length === 0 && current.terminal) return undefined;
   return { ...current, steps };
 }

--- a/packages/ui/src/model-picker.tsx
+++ b/packages/ui/src/model-picker.tsx
@@ -18,7 +18,7 @@ import {
   type ModelPickerPinnedItem,
 } from './model-picker-internals.js';
 import { cn } from './utils.js';
-import { inputClasses } from './primitives/input.js';
+import { pickerTriggerClasses, type PickerTriggerAppearance } from './ui.js';
 
 export interface ModelPickerProps {
   groups: ModelMenuGroup[];
@@ -31,6 +31,7 @@ export interface ModelPickerProps {
   searchPlaceholder?: string;
   emptyMessage?: string;
   triggerClassName?: string;
+  triggerAppearance?: PickerTriggerAppearance;
   popupClassName?: string;
   ariaLabel: string;
   title?: string;
@@ -40,14 +41,17 @@ export interface ModelPickerProps {
   children: ReactNode;
 }
 
-const ModelPickerTrigger = forwardRef<HTMLButtonElement, React.ComponentPropsWithoutRef<typeof BaseCombobox.Trigger>>(function ModelPickerTrigger(
-  { className, children, ...props },
+const ModelPickerTrigger = forwardRef<
+  HTMLButtonElement,
+  React.ComponentPropsWithoutRef<typeof BaseCombobox.Trigger> & { appearance?: PickerTriggerAppearance }
+>(function ModelPickerTrigger(
+  { appearance = 'field', className, children, ...props },
   ref,
 ) {
   return (
     <BaseCombobox.Trigger
       ref={ref}
-      className={cn(inputClasses, 'justify-between', className)}
+      className={cn(pickerTriggerClasses(appearance), 'justify-between', className)}
       {...props}
     >
       {children}
@@ -200,6 +204,7 @@ export function ModelPicker(props: ModelPickerProps) {
       disabled={props.disabled}
     >
       <ModelPickerTrigger
+        appearance={props.triggerAppearance}
         className={props.triggerClassName}
         aria-label={props.ariaLabel}
         title={props.title}

--- a/packages/ui/src/permission-mode-menu.tsx
+++ b/packages/ui/src/permission-mode-menu.tsx
@@ -8,6 +8,7 @@ import {
   SelectRoot,
   SelectTrigger,
   SelectValue,
+  type PickerTriggerAppearance,
 } from './ui.js';
 
 export interface PermissionModeMeta {
@@ -80,6 +81,7 @@ export function PermissionModeSelect(props: {
   disabledReason?: string;
   ariaLabel?: string;
   className?: string;
+  appearance?: PickerTriggerAppearance;
 }) {
   const displayMode: PermissionMode = props.activeMode === 'explore' ? 'ask' : props.activeMode;
   const meta = PERMISSION_MODE_META[displayMode];
@@ -93,6 +95,7 @@ export function PermissionModeSelect(props: {
       }}
     >
       <SelectTrigger
+        appearance={props.appearance}
         aria-label={props.ariaLabel ?? `权限模式：${meta.label}`}
         title={props.disabledReason ?? meta.hint}
         className={props.className}

--- a/packages/ui/src/ui.tsx
+++ b/packages/ui/src/ui.tsx
@@ -19,6 +19,23 @@ import { inputClasses } from './primitives/input.js';
 
 export { cn } from './utils.js';
 
+export type PickerTriggerAppearance = 'field' | 'quiet';
+
+const quietPickerTriggerClasses = [
+  'inline-flex shrink-0 items-center',
+  'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
+  'disabled:pointer-events-none disabled:opacity-50',
+].join(' ');
+
+/**
+ * Picker triggers appear either as form fields or as quiet toolbar controls.
+ * The quiet variant intentionally carries only interaction states: its owning
+ * surface remains the single source of geometry and visual chrome.
+ */
+export function pickerTriggerClasses(appearance: PickerTriggerAppearance = 'field'): string {
+  return appearance === 'field' ? inputClasses : quietPickerTriggerClasses;
+}
+
 // === Base UI style-hook convention (#520 PR5 item 23) =========================
 // Every Base UI wrapper in this file exposes `data-slot="<name>"` so CSS can
 // target `[data-slot="..."]` (a stable hook that survives className drift);
@@ -257,14 +274,17 @@ export const AlertDialogContent = createModalContent({
 export { Tabs as TabsRoot, TabsList, TabsTab as TabsTrigger, TabsPanel } from './primitives/tabs.js';
 
 export const SelectRoot = BaseSelect.Root;
-export const SelectTrigger = forwardRef<HTMLButtonElement, React.ComponentPropsWithoutRef<typeof BaseSelect.Trigger>>(function SelectTrigger(
-  { className, children, ...props },
+export const SelectTrigger = forwardRef<
+  HTMLButtonElement,
+  React.ComponentPropsWithoutRef<typeof BaseSelect.Trigger> & { appearance?: PickerTriggerAppearance }
+>(function SelectTrigger(
+  { appearance = 'field', className, children, ...props },
   ref,
 ) {
   return (
     <BaseSelect.Trigger
       ref={ref}
-      className={cn(inputClasses, 'justify-between', className)}
+      className={cn(pickerTriggerClasses(appearance), 'justify-between', className)}
       data-slot="select-trigger"
       {...props}
     >


### PR DESCRIPTION
## Summary

PR #1005 was squash-merged from a branch that had been "rebased" onto the then-latest `main` (8153519a) by transplanting whole-tree snapshots instead of replaying its diffs: its first rebased commit (f99a4db5) already differs from its parent by 104 files / −4518 lines that have nothing to do with its subject. The linear history gave GitHub no conflict to block on, and CI stayed green because the stale tree is self-consistent — the reverted features' tests were reverted along with their code.

The squash therefore silently reverted every merge that landed between the branch point (0915cbe9) and 8153519a:

- #972 follow-up `4b736dc2` — fix(headless): harden real-provider smoke reliability (14 files)
- #996 `8ef9373f` — feat(runtime): mid-turn capacity compaction (28 files, code and tests)
- #999 `ecf515da` — fix(ui): restore quiet composer picker triggers (7 files)
- #1000 `8153519a` — fix(ui): keep in-flight live turn armed (2 files)
- #994 `b7460c2f` — test(desktop): SSE stream-count race fix (1 file; independently re-fixed on main by #1012, so it is not re-landed here)
- #995 `465c2cd3` — Ollama Cloud thinking options (masked inside #1005's intended files; already restored by #1010 — verified hunk-by-hunk, no residual loss)

The symptom-level "restore" commits that have been appearing on main (#1010, #1012) are earlier pieces of this same damage being rediscovered one at a time; this PR re-lands the remainder at the root.

This PR is exactly `git cherry-pick` of the four still-missing already-reviewed, already-merged commits, in their original order, with original messages and authorship preserved. No new content.

## Verification

- Classification of #1005's diff against its true branch point: 47 files were pure reverts (its content identical to the branch point, no intended change) and 6 files mixed intended provider changes with clobbered content; every restored file was verified against that inventory.
- Strong invariants, each checked file-by-file:
  - For every pure-revert file, `git diff 8153519a HEAD -- <file>` is empty — byte-identical restoration.
  - `packages/cli/src/runtime-bootstrap.ts` (also touched by #1009 after the accident): the delta vs `main` is exactly #996's one seam line; #1009's changes are fully preserved.
  - `git diff main HEAD --name-only` contains no file outside the restoration inventory.
- 465c2cd3: all three files diffed hunk-by-hunk against HEAD; every semantic of that commit is present (remaining differences are #1010's equivalent rewording and #1005's intended provider renames).
- Full suites on the branch (rebased onto `main` at d75fba9d): runtime 1880/0 fail (7 pre-existing skips), headless 963/0, cli 358/0, ui 154/0, desktop 2537/0; repo-wide `npm run typecheck` and `npm run build` clean. The restored #996 tests (mid-turn capacity suite), #999/#1000 ui tests all pass.

## Root cause

A PR branch must be updated onto new `main` by replaying its own diffs (`git rebase`, or merge from main), never by transplanting old tree snapshots onto a new parent — a snapshot transplant makes the branch silently carry a revert of everything merged since the snapshot, and neither GitHub's conflict check (linear history, nothing to conflict) nor CI (tests reverted together with code) can catch it. Reviewing the merge diff's file list against the PR's stated scope is the cheap guard: #1005's diff touched 929 lines of `ai-sdk-backend.ts` that its description never mentions.
