### PR TITLE
feat(headless): filter unaddressable RSI tasks

### DIFF
--- a/packages/headless/harbor/run-prompt-optimization.mjs
+++ b/packages/headless/harbor/run-prompt-optimization.mjs
@@ -411,6 +411,15 @@ async function main() {
   if (result.droppedHeldInTaskIds.length > 0 || result.droppedHeldOutTaskIds.length > 0) {
     console.log(`dropped (unstable in baseline): held-in [${result.droppedHeldInTaskIds.join(', ')}], held-out [${result.droppedHeldOutTaskIds.join(', ')}]`);
   }
+  const excludedHeldIn = result.addressability.heldIn.taskStats
+    .filter((stat) => !stat.addressable)
+    .map((stat) => `${stat.taskId}:${stat.rejectionReason}`);
+  const excludedHeldOut = result.addressability.heldOut.taskStats
+    .filter((stat) => !stat.addressable)
+    .map((stat) => `${stat.taskId}:${stat.rejectionReason}`);
+  if (excludedHeldIn.length > 0 || excludedHeldOut.length > 0) {
+    console.log(`excluded (proposal/decision only): held-in [${excludedHeldIn.join(', ')}], held-out [${excludedHeldOut.join(', ')}]`);
+  }
   console.log(`decisions: ${result.decisions.length} (kept ${result.keptCount})`);
   console.log(`totalCostUsd: ${result.totalCostUsd.toFixed(4)}`);
   console.log(`smoke: ${result.smoke.status} (rounds ${result.smoke.observedRounds}/${result.smoke.minimumRounds})`);

--- a/packages/headless/src/__tests__/helpers/prompt-optimization-loop-harness.ts
+++ b/packages/headless/src/__tests__/helpers/prompt-optimization-loop-harness.ts
@@ -36,6 +36,7 @@ export interface RunLoopOptions {
   rewardFor: (roundId: string, taskId: string) => number;
   rounds: number;
   baselineRuns: number;
+  zScore?: number;
   costCeilingUsd?: number;
   maxInfraFailureRate?: number;
   heldOutResultsTsvPath?: string;
@@ -65,6 +66,7 @@ export async function runLoop(harness: Harness, options: RunLoopOptions) {
     runId: options.runId ?? 'run-1',
     rounds: options.rounds,
     baselineRuns: options.baselineRuns,
+    ...(options.zScore !== undefined ? { zScore: options.zScore } : {}),
     agentCwdPath: harness.agentCwdPath,
     programPath: harness.programPath,
     systemPromptPath: harness.systemPromptPath,

--- a/packages/headless/src/__tests__/prompt-acceptance-policy.test.ts
+++ b/packages/headless/src/__tests__/prompt-acceptance-policy.test.ts
@@ -9,6 +9,7 @@ import {
   decidePromptAcceptance,
   promptAcceptanceNoiseBand,
   promptAcceptanceStateFromWal,
+  selectAddressablePromptTasks,
   selectStablePromptTasks,
   summarizePromptAcceptancePartition,
 } from '../prompt-acceptance-policy.js';
@@ -198,6 +199,74 @@ describe('prompt acceptance policy', () => {
         { taskId: 'task-b', reason: 'incomplete' },
       ],
     });
+  });
+
+  test('classifies capability-limit and high-flip tasks from kept-prompt history', () => {
+    const keptPromptEvents = [
+      completed('stable', true, { id: 'stable-0', roundId: 'round-0', promptHash: 'prompt-0', ts: 1 }),
+      completed('capability', false, { id: 'capability-0', roundId: 'round-0', promptHash: 'prompt-0', ts: 2 }),
+      completed('flaky', true, { id: 'flaky-0', roundId: 'round-0', promptHash: 'prompt-0', ts: 3 }),
+      completed('stable', true, { id: 'stable-1', roundId: 'round-1', promptHash: 'prompt-1', ts: 4 }),
+      completed('capability', false, { id: 'capability-1', roundId: 'round-1', promptHash: 'prompt-1', ts: 5 }),
+      completed('flaky', false, { id: 'flaky-1', roundId: 'round-1', promptHash: 'prompt-1', ts: 6 }),
+      completed('stable', false, { id: 'stable-2', roundId: 'round-2', promptHash: 'prompt-2', ts: 7 }),
+      completed('capability', false, { id: 'capability-2', roundId: 'round-2', promptHash: 'prompt-2', ts: 8 }),
+      completed('flaky', true, { id: 'flaky-2', roundId: 'round-2', promptHash: 'prompt-2', ts: 9 }),
+    ];
+
+    const result = selectAddressablePromptTasks({
+      taskIds: ['stable', 'capability', 'flaky'],
+      keptPromptEvents,
+    });
+
+    assert.deepEqual(result, {
+      selectedTaskIds: ['stable'],
+      taskStats: [
+        {
+          taskId: 'stable',
+          observations: 3,
+          keptPrompts: 3,
+          passes: 2,
+          flips: 1,
+          flipRate: 0.5,
+          addressable: true,
+        },
+        {
+          taskId: 'capability',
+          observations: 3,
+          keptPrompts: 3,
+          passes: 0,
+          flips: 0,
+          flipRate: 0,
+          addressable: false,
+          rejectionReason: 'capability_limit',
+        },
+        {
+          taskId: 'flaky',
+          observations: 3,
+          keptPrompts: 3,
+          passes: 2,
+          flips: 2,
+          flipRate: 1,
+          addressable: false,
+          rejectionReason: 'flaky',
+        },
+      ],
+    });
+  });
+
+  test('does not infer multiple retained prompts from legacy events without prompt hashes', () => {
+    const result = selectAddressablePromptTasks({
+      taskIds: ['legacy-failure'],
+      keptPromptEvents: [
+        completed('legacy-failure', false, { id: 'legacy-0', roundId: 'baseline-0', ts: 1 }),
+        completed('legacy-failure', false, { id: 'legacy-1', roundId: 'baseline-1', ts: 2 }),
+      ],
+    });
+
+    assert.deepEqual(result.selectedTaskIds, ['legacy-failure']);
+    assert.equal(result.taskStats[0]?.keptPrompts, 1);
+    assert.equal(result.taskStats[0]?.rejectionReason, undefined);
   });
 
   test('keeps candidates that improve held-in beyond noise without falling below the held-out original floor', () => {

--- a/packages/headless/src/__tests__/prompt-optimization-loop.test.ts
+++ b/packages/headless/src/__tests__/prompt-optimization-loop.test.ts
@@ -4,7 +4,7 @@ import { join } from 'node:path';
 import { describe, test } from 'node:test';
 import { readFixedPromptWal } from '../fixed-prompt-controller.js';
 import { promptAcceptanceNoiseBand } from '../prompt-acceptance-policy.js';
-import { execFileAsync, evidenceRefsFor, makeTasks, runLoop, taskIndex, withHarness, type MetaAgentPromptInput } from './helpers/prompt-optimization-loop-harness.js';
+import { execFileAsync, evidenceRefsFor, fakeMetaAgent, makeTasks, runLoop, taskIndex, withHarness, type MetaAgentPromptInput } from './helpers/prompt-optimization-loop-harness.js';
 
 describe('runPromptOptimizationLoop', () => {
   test('defaults the acceptance noise band to a 1.96 z-score', async () => {
@@ -640,6 +640,133 @@ describe('runPromptOptimizationLoop', () => {
         .filter((event) => event.roundId === 'round-0' && event.type === 'task_completed' && (event.taskId ?? '').startsWith('hin-'))
         .map((event) => event.taskId);
       assert.deepEqual([...new Set(roundHeldInTaskIds)].sort(), ['hin-0', 'hin-1']);
+    });
+  });
+
+  test('runs flaky tasks but excludes them from proposal evidence and decisions', async () => {
+    await withHarness(async (harness) => {
+      const heldInTasks = makeTasks('hin', 3);
+      const heldOutTasks = makeTasks('hout', 2);
+      const roundTaskIds: string[] = [];
+      let proposalInput: MetaAgentPromptInput | undefined;
+      const rewardFor = (roundId: string, taskId: string): number => {
+        if (taskId === 'hin-0' || taskId === 'hout-0') return 1;
+        if (taskId === 'hin-2' && roundId !== 'baseline-1') return 1;
+        return roundId === 'round-0' ? 1 : 0;
+      };
+
+      const result = await runLoop(harness, {
+        heldInTasks,
+        heldOutTasks,
+        rewardFor,
+        rounds: 1,
+        baselineRuns: 3,
+        onTaskRun: (roundId, taskId) => {
+          if (roundId === 'round-0' && taskId.startsWith('hin-')) roundTaskIds.push(taskId);
+        },
+        metaAgent: async (input) => {
+          proposalInput = input;
+          return {
+            systemPrompt: 'addressability candidate\n',
+            summary: 'use only addressable evidence',
+            candidateRationale: {
+              failurePattern: 'coverage_regression',
+              evidenceRefs: evidenceRefsFor(input),
+              hypothesis: 'addressable evidence supports a bounded prompt improvement',
+              targetedFix: 'clarify the general success criteria',
+              predictedFixes: [],
+              riskTasks: [],
+            },
+          };
+        },
+      });
+
+      assert.ok(proposalInput);
+      assert.deepEqual(proposalInput.heldInDigests.map((digest) => digest.taskId), ['hin-0', 'hin-1']);
+      assert.match(proposalInput.resultsTsv, /hin-0/);
+      assert.match(proposalInput.resultsTsv, /hin-1/);
+      assert.doesNotMatch(proposalInput.resultsTsv, /hin-2/);
+      assert.deepEqual([...new Set(roundTaskIds)].sort(), ['hin-0', 'hin-1', 'hin-2']);
+      assert.equal(result.baseline.heldIn.taskCount, 2);
+      assert.equal(result.baseline.heldOut.taskCount, 2);
+      assert.deepEqual(result.addressability.heldIn.taskStats.map((stat) => ({
+        taskId: stat.taskId,
+        addressable: stat.addressable,
+        rejectionReason: stat.rejectionReason,
+      })), [
+        { taskId: 'hin-0', addressable: true, rejectionReason: undefined },
+        { taskId: 'hin-1', addressable: true, rejectionReason: undefined },
+        { taskId: 'hin-2', addressable: false, rejectionReason: 'flaky' },
+      ]);
+      assert.deepEqual(result.addressability.heldOut.selectedTaskIds, ['hout-0', 'hout-1']);
+      assert.deepEqual(result.droppedHeldInTaskIds, []);
+    });
+  });
+
+  test('excludes a capability-limit task after two retained prompts but keeps executing it', async () => {
+    await withHarness(async (harness) => {
+      const heldInTasks = makeTasks('hin', 20);
+      const heldOutTasks = makeTasks('hout', 4);
+      const proposalInputs: MetaAgentPromptInput[] = [];
+      const roundOneTaskIds: string[] = [];
+      const propose = fakeMetaAgent();
+      const rewardFor = (roundId: string, taskId: string): number => {
+        if (taskId.startsWith('hout-')) return 1;
+        const index = taskIndex(taskId);
+        if (roundId.startsWith('baseline-')) return index < 10 ? 1 : 0;
+        if (roundId === 'round-0') return index < 19 ? 1 : 0;
+        return 1;
+      };
+
+      const first = await runLoop(harness, {
+        heldInTasks,
+        heldOutTasks,
+        rewardFor,
+        rounds: 1,
+        baselineRuns: 2,
+        metaAgent: async (input) => {
+          proposalInputs.push(input);
+          return propose(input);
+        },
+      });
+      assert.equal(first.decisions[0]?.decision, 'keep');
+      assert.equal(proposalInputs.length, 1);
+      assert.match(proposalInputs[0]!.resultsTsv, /hin-19/);
+      proposalInputs.length = 0;
+
+      const result = await runLoop(harness, {
+        heldInTasks,
+        heldOutTasks,
+        rewardFor,
+        rounds: 2,
+        baselineRuns: 2,
+        metaAgent: async (input) => {
+          proposalInputs.push(input);
+          return propose(input);
+        },
+        onTaskRun: (roundId, taskId) => {
+          if (roundId === 'round-1' && taskId.startsWith('hin-')) roundOneTaskIds.push(taskId);
+        },
+      });
+
+      assert.equal(result.decisions[0]?.decision, 'keep');
+      assert.equal(proposalInputs.length, 1);
+      assert.doesNotMatch(proposalInputs[0]!.resultsTsv, /hin-19/);
+      assert.equal(proposalInputs[0]!.heldInDigests.some((digest) => digest.taskId === 'hin-19'), false);
+      assert.ok(roundOneTaskIds.includes('hin-19'));
+      assert.deepEqual(
+        result.addressability.heldIn.taskStats.find((stat) => stat.taskId === 'hin-19'),
+        {
+          taskId: 'hin-19',
+          observations: 3,
+          keptPrompts: 2,
+          passes: 0,
+          flips: 0,
+          flipRate: 0,
+          addressable: false,
+          rejectionReason: 'capability_limit',
+        },
+      );
     });
   });
 

--- a/packages/headless/src/__tests__/prompt-optimization-loop.test.ts
+++ b/packages/headless/src/__tests__/prompt-optimization-loop.test.ts
@@ -304,6 +304,64 @@ describe('runPromptOptimizationLoop', () => {
     });
   });
 
+  test('keeps the calibrated baseline reference after a discard before the first keep', async () => {
+    await withHarness(async (harness) => {
+      const rewardFor = (roundId: string, taskId: string): number => {
+        if (taskId.startsWith('hout-')) return 1;
+        const index = taskIndex(taskId);
+        if (roundId === 'baseline-0') return index < 10 ? 1 : 0;
+        if (roundId === 'baseline-1') return index < 14 ? 1 : 0;
+        return index < 12 ? 1 : 0;
+      };
+
+      const result = await runLoop(harness, {
+        heldInTasks: makeTasks('hin', 20),
+        heldOutTasks: makeTasks('hout', 2),
+        rewardFor,
+        rounds: 2,
+        baselineRuns: 2,
+      });
+
+      assert.equal(result.decisions[0]?.decision, 'discard');
+      assert.equal(result.baseline.heldIn.referencePassEligibleRate, 0.6);
+      assert.equal(
+        result.decisions[1]?.previousHeldInReferencePassEligibleRate,
+        result.baseline.heldIn.referencePassEligibleRate,
+      );
+    });
+  });
+
+  test('carries the banked reference after a keep instead of the raw kept sweep rate', async () => {
+    await withHarness(async (harness) => {
+      const rewardFor = (roundId: string, taskId: string): number => {
+        const index = taskIndex(taskId);
+        if (taskId.startsWith('hout-')) return index < 2 ? 1 : 0;
+        if (roundId.startsWith('baseline-')) return index < 10 ? 1 : 0;
+        if (roundId === 'round-0') return index < 6 || index >= 10 ? 1 : 0;
+        return index < 17 ? 1 : 0;
+      };
+
+      const result = await runLoop(harness, {
+        heldInTasks: makeTasks('hin', 20),
+        heldOutTasks: makeTasks('hout', 4),
+        rewardFor,
+        rounds: 2,
+        baselineRuns: 2,
+        zScore: 0.5,
+      });
+
+      assert.deepEqual(result.decisions.map((decision) => decision.decision), ['keep', 'keep']);
+      assert.equal(
+        result.decisions[1]?.previousHeldInReferencePassEligibleRate,
+        result.decisions[0]?.heldInReferencePassEligibleRate,
+      );
+      assert.notEqual(
+        result.decisions[0]?.heldInReferencePassEligibleRate,
+        result.decisions[0]?.metrics.candidate.heldIn.passEligibleRate,
+      );
+    });
+  });
+
   test('skips the held-out sweep for a candidate that does not clear the held-in gate', async () => {
     await withHarness(async (harness) => {
       const heldInTasks = makeTasks('hin', 2);
@@ -732,7 +790,34 @@ describe('runPromptOptimizationLoop', () => {
       assert.equal(first.decisions[0]?.decision, 'keep');
       assert.equal(proposalInputs.length, 1);
       assert.match(proposalInputs[0]!.resultsTsv, /hin-19/);
+      assert.deepEqual(
+        first.addressability.heldIn.taskStats.find((stat) => stat.taskId === 'hin-19'),
+        {
+          taskId: 'hin-19',
+          observations: 3,
+          keptPrompts: 2,
+          passes: 0,
+          flips: 0,
+          flipRate: 0,
+          addressable: false,
+          rejectionReason: 'capability_limit',
+        },
+      );
       proposalInputs.length = 0;
+
+      const replayedFirst = await runLoop(harness, {
+        heldInTasks,
+        heldOutTasks,
+        rewardFor,
+        rounds: 1,
+        baselineRuns: 2,
+        metaAgent: async (input) => {
+          proposalInputs.push(input);
+          return propose(input);
+        },
+      });
+      assert.deepEqual(replayedFirst.addressability, first.addressability);
+      assert.equal(proposalInputs.length, 0);
 
       const result = await runLoop(harness, {
         heldInTasks,
@@ -754,18 +839,28 @@ describe('runPromptOptimizationLoop', () => {
       assert.doesNotMatch(proposalInputs[0]!.resultsTsv, /hin-19/);
       assert.equal(proposalInputs[0]!.heldInDigests.some((digest) => digest.taskId === 'hin-19'), false);
       assert.ok(roundOneTaskIds.includes('hin-19'));
-      assert.deepEqual(
-        result.addressability.heldIn.taskStats.find((stat) => stat.taskId === 'hin-19'),
-        {
-          taskId: 'hin-19',
-          observations: 3,
-          keptPrompts: 2,
-          passes: 0,
-          flips: 0,
-          flipRate: 0,
-          addressable: false,
-          rejectionReason: 'capability_limit',
-        },
+      const terminalStat = result.addressability.heldIn.taskStats.find((stat) => stat.taskId === 'hin-19');
+      assert.equal(terminalStat?.observations, 4);
+      assert.equal(terminalStat?.keptPrompts, 3);
+      assert.equal(terminalStat?.passes, 1);
+    });
+  });
+
+  test('fails loud when a terminal keep makes the whole held-out partition unaddressable', async () => {
+    await withHarness(async (harness) => {
+      await assert.rejects(
+        runLoop(harness, {
+          heldInTasks: makeTasks('hin', 20),
+          heldOutTasks: makeTasks('hout', 1),
+          rewardFor: (roundId, taskId) => {
+            if (taskId.startsWith('hout-')) return 0;
+            if (roundId.startsWith('baseline-')) return taskIndex(taskId) < 10 ? 1 : 0;
+            return 1;
+          },
+          rounds: 1,
+          baselineRuns: 2,
+        }),
+        /held-out addressable task count is 0 after kept-prompt history filtering/,
       );
     });
   });

--- a/packages/headless/src/prompt-acceptance-policy.ts
+++ b/packages/headless/src/prompt-acceptance-policy.ts
@@ -157,6 +157,35 @@ export interface StablePromptTaskSelectionResult {
   }>;
 }
 
+export type PromptTaskAddressabilityRejectionReason = 'capability_limit' | 'flaky';
+
+export interface PromptTaskAddressabilityStat {
+  taskId: string;
+  observations: number;
+  keptPrompts: number;
+  passes: number;
+  flips: number;
+  flipRate: number;
+  addressable: boolean;
+  rejectionReason?: PromptTaskAddressabilityRejectionReason;
+}
+
+export interface SelectAddressablePromptTasksInput {
+  taskIds: readonly string[];
+  /** Completed evaluations produced by prompts that were retained. The loop
+   * grows this replay-stable prefix only after each KEEP decision; excluded
+   * tasks continue to execute in candidate rounds. */
+  keptPromptEvents: readonly FixedPromptTaskWalEvent[];
+}
+
+export interface PromptTaskAddressabilitySelectionResult {
+  selectedTaskIds: string[];
+  taskStats: PromptTaskAddressabilityStat[];
+}
+
+const MIN_FLAKY_TASK_OBSERVATIONS = 3;
+const MAX_ADDRESSABLE_TASK_FLIP_RATE = 0.5;
+
 export function calibratePromptAcceptanceBaseline(
   input: CalibratePromptAcceptanceBaselineInput,
 ): PromptAcceptanceBaseline {
@@ -251,6 +280,73 @@ export function selectStablePromptTasks(
     selectedTaskIds.push(taskId);
   }
   return { selectedTaskIds, rejectedTaskIds };
+}
+
+/**
+ * Separate prompt-addressability from execution stability. A task can be
+ * perfectly runnable yet provide no useful prompt-optimization signal because
+ * the retained prompt history never solved it (capability ceiling) or because
+ * its result oscillates too often. Those tasks remain in the execution/WAL set;
+ * this selector only defines proposal evidence and acceptance/noise-band input.
+ */
+export function selectAddressablePromptTasks(
+  input: SelectAddressablePromptTasksInput,
+): PromptTaskAddressabilitySelectionResult {
+  const taskIdSet = new Set(input.taskIds);
+  const historyByTask = new Map<string, Array<{ passed: boolean; promptHash: string }>>();
+  const orderedEvents = input.keptPromptEvents
+    .filter((event): event is FixedPromptTaskCompletedEvent => (
+      event.type === 'task_completed'
+      && event.eligible
+      && event.scored
+      && taskIdSet.has(event.taskId)
+    ))
+    .map((event, index) => ({ event, index }))
+    .sort((a, b) => a.event.ts - b.event.ts || a.index - b.index);
+  for (const { event } of orderedEvents) {
+    const history = historyByTask.get(event.taskId) ?? [];
+    history.push({
+      passed: event.passed,
+      // A legacy event without prompt identity cannot prove that two distinct
+      // retained prompts hit the same ceiling, so group all such evidence into
+      // one conservative unknown prompt instead of guessing from round ids.
+      promptHash: event.promptHash ?? 'legacy-unknown',
+    });
+    historyByTask.set(event.taskId, history);
+  }
+
+  const taskStats = input.taskIds.map((taskId): PromptTaskAddressabilityStat => {
+    const history = historyByTask.get(taskId) ?? [];
+    const outcomes = history.map((item) => item.passed);
+    const observations = outcomes.length;
+    const keptPrompts = new Set(history.map((item) => item.promptHash)).size;
+    const passes = outcomes.filter(Boolean).length;
+    let flips = 0;
+    for (let index = 1; index < outcomes.length; index += 1) {
+      if (outcomes[index] !== outcomes[index - 1]) flips += 1;
+    }
+    const flipRate = observations > 1 ? flips / (observations - 1) : 0;
+    const rejectionReason: PromptTaskAddressabilityRejectionReason | undefined = keptPrompts >= 2 && passes === 0
+      ? 'capability_limit'
+      : observations >= MIN_FLAKY_TASK_OBSERVATIONS && flipRate > MAX_ADDRESSABLE_TASK_FLIP_RATE
+        ? 'flaky'
+        : undefined;
+    return {
+      taskId,
+      observations,
+      keptPrompts,
+      passes,
+      flips,
+      flipRate,
+      addressable: rejectionReason === undefined,
+      ...(rejectionReason ? { rejectionReason } : {}),
+    };
+  });
+
+  return {
+    selectedTaskIds: taskStats.filter((stat) => stat.addressable).map((stat) => stat.taskId),
+    taskStats,
+  };
 }
 
 function isStableBaselineEvent(

--- a/packages/headless/src/prompt-optimization-loop.ts
+++ b/packages/headless/src/prompt-optimization-loop.ts
@@ -28,10 +28,13 @@ import {
   calibratePromptAcceptanceBaseline,
   decidePromptAcceptance,
   heldInGateReason,
+  selectAddressablePromptTasks,
   selectStablePromptTasks,
+  summarizePromptAcceptancePartition,
   type PromptAcceptanceBaseline,
   type PromptAcceptanceBaselineRun,
   type PromptAcceptanceResult,
+  type PromptTaskAddressabilitySelectionResult,
 } from './prompt-acceptance-policy.js';
 import {
   promptStructuralSmokeReport,
@@ -158,6 +161,12 @@ export interface PromptOptimizationLoopResult {
   droppedHeldInTaskIds: string[];
   /** Held-out task ids dropped before calibration, same criterion. */
   droppedHeldOutTaskIds: string[];
+  /** Historical kept-prompt addressability used only for proposal evidence and
+   * acceptance. Rejected tasks still execute and remain recorded in the WAL. */
+  addressability: {
+    heldIn: PromptTaskAddressabilitySelectionResult;
+    heldOut: PromptTaskAddressabilitySelectionResult;
+  };
 }
 
 export async function runPromptOptimizationLoop(
@@ -396,28 +405,40 @@ export async function runPromptOptimizationLoop(
   const droppedHeldOutTaskIds = heldOutStable.rejectedTaskIds.map((rejected) => rejected.taskId);
   const stableHeldInSet = new Set(stableHeldInTaskIds);
   const stableHeldOutSet = new Set(stableHeldOutTaskIds);
-  const roundHeldInTasks = input.heldInTasks.filter((task) => stableHeldInSet.has(task.id));
-  const roundHeldOutTasks = input.heldOutTasks.filter((task) => stableHeldOutSet.has(task.id));
   const stableHeldIn = (events: readonly FixedPromptTaskWalEvent[]): FixedPromptTaskWalEvent[] =>
     events.filter((event) => stableHeldInSet.has(event.taskId));
   const stableHeldOut = (events: readonly FixedPromptTaskWalEvent[]): FixedPromptTaskWalEvent[] =>
     events.filter((event) => stableHeldOutSet.has(event.taskId));
-
+  let keptHeldInHistory = baselineRunsData.flatMap((run) => stableHeldIn(run.heldInEvents));
+  let keptHeldOutHistory = baselineRunsData.flatMap((run) => stableHeldOut(run.heldOutEvents));
+  const initialAddressability = {
+    heldIn: selectAddressablePromptTasks({
+      taskIds: stableHeldInTaskIds,
+      keptPromptEvents: keptHeldInHistory,
+    }),
+    heldOut: selectAddressablePromptTasks({
+      taskIds: stableHeldOutTaskIds,
+      keptPromptEvents: keptHeldOutHistory,
+    }),
+  };
+  const roundHeldInTasks = input.heldInTasks.filter((task) => stableHeldInSet.has(task.id));
+  const roundHeldOutTasks = input.heldOutTasks.filter((task) => stableHeldOutSet.has(task.id));
   const baseline = calibratePromptAcceptanceBaseline({
-    heldInTaskIds: stableHeldInTaskIds,
-    heldOutTaskIds: stableHeldOutTaskIds,
+    heldInTaskIds: initialAddressability.heldIn.selectedTaskIds,
+    heldOutTaskIds: initialAddressability.heldOut.selectedTaskIds,
     baselineRuns: baselineRunsData,
     zScore,
   });
 
-  const originalHeldOutEvents = stableHeldOut(baselineRunsData[0]!.heldOutEvents);
   let lastKeptCommitSha = replayState.seedCommitSha;
-  let heldInReference = baseline.heldIn.referencePassEligibleRate;
-  let lastKeptHeldInEvents: readonly FixedPromptTaskWalEvent[] = stableHeldIn(baselineRunsData[0]!.heldInEvents);
-  let previousCandidateHeldInEvents: readonly FixedPromptTaskWalEvent[] | undefined;
-  let latestHeldInFeedbackEvents: readonly FixedPromptTaskWalEvent[] = stableHeldIn(baselineRunsData[baselineRunsData.length - 1]!.heldInEvents);
+  let finalHeldInReference = baseline.heldIn.referencePassEligibleRate;
+  let lastKeptHeldInExecutionEvents: readonly FixedPromptTaskWalEvent[] = stableHeldIn(baselineRunsData[0]!.heldInEvents);
+  let previousCandidateHeldInExecutionEvents: readonly FixedPromptTaskWalEvent[] | undefined;
+  let latestHeldInFeedbackExecutionEvents: readonly FixedPromptTaskWalEvent[] = stableHeldIn(
+    baselineRunsData[baselineRunsData.length - 1]!.heldInEvents,
+  );
+  let finalAddressability = initialAddressability;
   let nextPromptAttribution: RsiPromptAttribution | undefined;
-  let nextHeldInDigests = await digestsFor(stableHeldIn(baselineRunsData[baselineRunsData.length - 1]!.heldInEvents));
 
   // 2. Candidate rounds.
   const decisions: PromptAcceptanceResult[] = [];
@@ -431,8 +452,54 @@ export async function runPromptOptimizationLoop(
       break;
     }
     const roundId = `round-${round}`;
+    const addressability = {
+      heldIn: selectAddressablePromptTasks({
+        taskIds: stableHeldInTaskIds,
+        keptPromptEvents: keptHeldInHistory,
+      }),
+      heldOut: selectAddressablePromptTasks({
+        taskIds: stableHeldOutTaskIds,
+        keptPromptEvents: keptHeldOutHistory,
+      }),
+    };
+    if (addressability.heldIn.selectedTaskIds.length === 0) {
+      throw new Error('held-in addressable task count is 0 after kept-prompt history filtering');
+    }
+    if (addressability.heldOut.selectedTaskIds.length === 0) {
+      throw new Error('held-out addressable task count is 0 after kept-prompt history filtering');
+    }
+    finalAddressability = addressability;
+    const decisionHeldInTaskIds = addressability.heldIn.selectedTaskIds;
+    const decisionHeldOutTaskIds = addressability.heldOut.selectedTaskIds;
+    const decisionHeldInSet = new Set(decisionHeldInTaskIds);
+    const decisionHeldOutSet = new Set(decisionHeldOutTaskIds);
+    const decisionHeldIn = (events: readonly FixedPromptTaskWalEvent[]): FixedPromptTaskWalEvent[] =>
+      events.filter((event) => decisionHeldInSet.has(event.taskId));
+    const decisionHeldOut = (events: readonly FixedPromptTaskWalEvent[]): FixedPromptTaskWalEvent[] =>
+      events.filter((event) => decisionHeldOutSet.has(event.taskId));
+    const activeBaseline = calibratePromptAcceptanceBaseline({
+      heldInTaskIds: decisionHeldInTaskIds,
+      heldOutTaskIds: decisionHeldOutTaskIds,
+      baselineRuns: baselineRunsData,
+      zScore,
+    });
+    const originalHeldOutEvents = decisionHeldOut(baselineRunsData[0]!.heldOutEvents);
+    const lastKeptHeldInEvents = decisionHeldIn(lastKeptHeldInExecutionEvents);
+    const previousCandidateHeldInEvents = previousCandidateHeldInExecutionEvents
+      ? decisionHeldIn(previousCandidateHeldInExecutionEvents)
+      : undefined;
+    const latestHeldInFeedbackEvents = decisionHeldIn(latestHeldInFeedbackExecutionEvents);
+    const heldInReference = decisions.length === 0
+      ? activeBaseline.heldIn.referencePassEligibleRate
+      : summarizePromptAcceptancePartition(
+        lastKeptHeldInExecutionEvents,
+        decisionHeldInTaskIds,
+      ).passEligibleRate;
+    finalHeldInReference = heldInReference;
+    const nextHeldInDigests = await digestsFor(latestHeldInFeedbackEvents);
+    await writeFixedPromptResultsTsv(input.heldInResultsTsvPath, latestHeldInFeedbackEvents);
     const promptAnalysis = await analyzeRsiRound({
-      heldInTaskIds: stableHeldInTaskIds,
+      heldInTaskIds: decisionHeldInTaskIds,
       lastKeptEvents: lastKeptHeldInEvents,
       ...(previousCandidateHeldInEvents ? { previousCandidateEvents: previousCandidateHeldInEvents } : {}),
       candidateEvents: latestHeldInFeedbackEvents,
@@ -442,8 +509,10 @@ export async function runPromptOptimizationLoop(
       state: replayState,
       runId: input.runId,
       roundId,
-      heldInTaskIds: stableHeldInTaskIds,
-      heldOutTaskIds: stableHeldOutTaskIds,
+      heldInTaskIds: decisionHeldInTaskIds,
+      heldOutTaskIds: decisionHeldOutTaskIds,
+      executedHeldInTaskIds: stableHeldInTaskIds,
+      executedHeldOutTaskIds: stableHeldOutTaskIds,
       ...(input.resumeFingerprint ? { resumeFingerprint: input.resumeFingerprint } : {}),
       heldInResultsTsvPath: input.heldInResultsTsvPath,
       heldOutResultsTsvPath: input.heldOutResultsTsvPath,
@@ -454,17 +523,17 @@ export async function runPromptOptimizationLoop(
         await writeFixedPromptResultsTsv(input.heldOutResultsTsvPath, existingDecisionRound.heldOut.events);
       }
       const existingHeldInEvents = existingDecisionRound.heldIn.events;
-      accumulate(existingDecisionRound.heldIn);
-      if (existingDecisionRound.heldOut) accumulate(existingDecisionRound.heldOut);
-      const replayedRewardHackScan = await scanHeldIn(existingHeldInEvents);
+      accumulate(existingDecisionRound.executedHeldIn);
+      if (existingDecisionRound.executedHeldOut) accumulate(existingDecisionRound.executedHeldOut);
+      const replayedRewardHackScan = await scanHeldIn(existingDecisionRound.executedHeldIn.events);
       if (
         !existingDecisionRound.heldOut
         && heldInGateReason({
-          heldInTaskIds: stableHeldInTaskIds,
+          heldInTaskIds: decisionHeldInTaskIds,
           lastKeptHeldInEvents,
           candidateHeldInEvents: existingHeldInEvents,
           previousHeldInReferencePassEligibleRate: heldInReference,
-          heldInPassRateNoiseBand: baseline.heldIn.noiseBand,
+          heldInPassRateNoiseBand: activeBaseline.heldIn.noiseBand,
           rewardHackScan: replayedRewardHackScan,
         }) === null
       ) {
@@ -476,12 +545,12 @@ export async function runPromptOptimizationLoop(
         candidateCommitSha: existingDecisionRound.decision.candidateCommitSha,
         previousLastKeptCommitSha: lastKeptCommitSha,
         originalCommitSha: replayState.seedCommitSha,
-        heldInTaskIds: stableHeldInTaskIds,
-        heldOutTaskIds: stableHeldOutTaskIds,
+        heldInTaskIds: decisionHeldInTaskIds,
+        heldOutTaskIds: decisionHeldOutTaskIds,
         previousHeldInReferencePassEligibleRate: heldInReference,
-        originalHeldOutPassEligibleRate: baseline.heldOut.originalPassEligibleRate,
-        heldInPassRateNoiseBand: baseline.heldIn.noiseBand,
-        heldOutPassRateNoiseBand: baseline.heldOut.noiseBand,
+        originalHeldOutPassEligibleRate: activeBaseline.heldOut.originalPassEligibleRate,
+        heldInPassRateNoiseBand: activeBaseline.heldIn.noiseBand,
+        heldOutPassRateNoiseBand: activeBaseline.heldOut.noiseBand,
         originalEvents: originalHeldOutEvents,
         lastKeptEvents: lastKeptHeldInEvents,
         candidateEvents: [...existingHeldInEvents, ...(existingDecisionRound.heldOut?.events ?? [])],
@@ -500,33 +569,36 @@ export async function runPromptOptimizationLoop(
         candidateRationale: replayedCandidate.candidateRationale,
         promptTimeAnalysis: promptAnalysis,
         analysis: await analyzeRsiRound({
-          heldInTaskIds: stableHeldInTaskIds,
+          heldInTaskIds: decisionHeldInTaskIds,
           lastKeptEvents: lastKeptHeldInEvents,
           ...(previousCandidateHeldInEvents ? { previousCandidateEvents: previousCandidateHeldInEvents } : {}),
           candidateEvents: existingHeldInEvents,
         }),
-        heldInTaskIds: stableHeldInTaskIds,
+        heldInTaskIds: decisionHeldInTaskIds,
         lastKeptEvents: lastKeptHeldInEvents,
         candidateEvents: existingHeldInEvents,
         decision: replayedResult,
       });
       assertReplayedAttributionMatchesResult(existingDecisionRound.attribution, replayedAttribution);
       decisions.push(replayedResult);
+      finalHeldInReference = replayedResult.heldInReferencePassEligibleRate;
       if (replayedResult.decision === 'keep') {
         lastKeptCommitSha = replayedResult.lastKeptCommitSha;
-        heldInReference = replayedResult.heldInReferencePassEligibleRate;
-        lastKeptHeldInEvents = existingHeldInEvents;
+        lastKeptHeldInExecutionEvents = existingDecisionRound.executedHeldIn.events;
+        keptHeldInHistory = [...keptHeldInHistory, ...existingDecisionRound.executedHeldIn.events];
+        if (existingDecisionRound.executedHeldOut) {
+          keptHeldOutHistory = [...keptHeldOutHistory, ...existingDecisionRound.executedHeldOut.events];
+        }
       }
-      previousCandidateHeldInEvents = existingHeldInEvents;
-      latestHeldInFeedbackEvents = existingHeldInEvents;
-      nextHeldInDigests = await digestsFor(existingHeldInEvents);
+      previousCandidateHeldInExecutionEvents = existingDecisionRound.executedHeldIn.events;
+      latestHeldInFeedbackExecutionEvents = existingDecisionRound.executedHeldIn.events;
       nextPromptAttribution = projectRsiPromptAttribution(existingDecisionRound.attribution);
       continue;
     }
 
     const existingCandidate = replayState.candidateByRoundId.get(roundId);
     if (existingCandidate) {
-      assertCandidateMatchesStableTaskSet(existingCandidate, stableHeldInTaskIds);
+      assertCandidateMatchesStableTaskSet(existingCandidate, decisionHeldInTaskIds);
     }
     const candidate = existingCandidate ?? await runPromptCandidateRound({
       runId: input.runId,
@@ -536,7 +608,7 @@ export async function runPromptOptimizationLoop(
       systemPromptPath: input.systemPromptPath,
       resultsTsvPath: input.heldInResultsTsvPath,
       resultsJsonlPath: input.resultsJsonlPath,
-      heldInTaskIds: stableHeldInTaskIds,
+      heldInTaskIds: decisionHeldInTaskIds,
       heldInDigests: nextHeldInDigests,
       rsiAnalysis: promptAnalysis,
       ...(nextPromptAttribution ? { promptAttribution: nextPromptAttribution } : {}),
@@ -552,20 +624,23 @@ export async function runPromptOptimizationLoop(
     const heldIn = await sweep(roundId, roundHeldInTasks, input.heldInResultsTsvPath);
     accumulate(heldIn);
     const rewardHackScan = await scanHeldIn(heldIn.events);
+    const heldInDecisionEvents = decisionHeldIn(heldIn.events);
+    await writeFixedPromptResultsTsv(input.heldInResultsTsvPath, heldInDecisionEvents);
 
     // #64 LOOP steps 8-10: only spend the held-out sweep when held-in clears the
     // gate (improved beyond noise, coverage intact, no reward-hack quarantine). A
     // candidate that cannot KEEP on held-in evidence is discarded without ever
     // running held-out — saving cost, time, and infra exposure.
     const heldInGate = heldInGateReason({
-      heldInTaskIds: stableHeldInTaskIds,
+      heldInTaskIds: decisionHeldInTaskIds,
       lastKeptHeldInEvents,
-      candidateHeldInEvents: heldIn.events,
+      candidateHeldInEvents: heldInDecisionEvents,
       previousHeldInReferencePassEligibleRate: heldInReference,
-      heldInPassRateNoiseBand: baseline.heldIn.noiseBand,
+      heldInPassRateNoiseBand: activeBaseline.heldIn.noiseBand,
       rewardHackScan,
     });
-    let heldOutEvents: readonly FixedPromptTaskWalEvent[] = [];
+    let heldOutExecutionEvents: readonly FixedPromptTaskWalEvent[] = [];
+    let heldOutDecisionEvents: readonly FixedPromptTaskWalEvent[] = [];
     if (heldInGate === null) {
       // Held-in cleared, but the held-in sweep itself can have exhausted the
       // budget. Do not start the held-out sweep if a guard already trips: the
@@ -580,7 +655,8 @@ export async function runPromptOptimizationLoop(
       }
       const heldOut = await sweep(roundId, roundHeldOutTasks, input.heldOutResultsTsvPath);
       accumulate(heldOut);
-      heldOutEvents = heldOut.events;
+      heldOutExecutionEvents = heldOut.events;
+      heldOutDecisionEvents = decisionHeldOut(heldOut.events);
     }
 
     const result = decidePromptAcceptance({
@@ -589,15 +665,15 @@ export async function runPromptOptimizationLoop(
       candidateCommitSha: candidate.commitSha,
       previousLastKeptCommitSha: lastKeptCommitSha,
       originalCommitSha: replayState.seedCommitSha,
-      heldInTaskIds: stableHeldInTaskIds,
-      heldOutTaskIds: stableHeldOutTaskIds,
+      heldInTaskIds: decisionHeldInTaskIds,
+      heldOutTaskIds: decisionHeldOutTaskIds,
       previousHeldInReferencePassEligibleRate: heldInReference,
-      originalHeldOutPassEligibleRate: baseline.heldOut.originalPassEligibleRate,
-      heldInPassRateNoiseBand: baseline.heldIn.noiseBand,
-      heldOutPassRateNoiseBand: baseline.heldOut.noiseBand,
+      originalHeldOutPassEligibleRate: activeBaseline.heldOut.originalPassEligibleRate,
+      heldInPassRateNoiseBand: activeBaseline.heldIn.noiseBand,
+      heldOutPassRateNoiseBand: activeBaseline.heldOut.noiseBand,
       originalEvents: originalHeldOutEvents,
       lastKeptEvents: lastKeptHeldInEvents,
-      candidateEvents: [...heldIn.events, ...heldOutEvents],
+      candidateEvents: [...heldInDecisionEvents, ...heldOutDecisionEvents],
       rewardHackScan,
     });
     if (result.decision === 'discard') {
@@ -620,14 +696,14 @@ export async function runPromptOptimizationLoop(
       candidateRationale: candidate.candidateRationale,
       promptTimeAnalysis: promptAnalysis,
       analysis: await analyzeRsiRound({
-        heldInTaskIds: stableHeldInTaskIds,
+        heldInTaskIds: decisionHeldInTaskIds,
         lastKeptEvents: lastKeptHeldInEvents,
         ...(previousCandidateHeldInEvents ? { previousCandidateEvents: previousCandidateHeldInEvents } : {}),
-        candidateEvents: heldIn.events,
+        candidateEvents: heldInDecisionEvents,
       }),
-      heldInTaskIds: stableHeldInTaskIds,
+      heldInTaskIds: decisionHeldInTaskIds,
       lastKeptEvents: lastKeptHeldInEvents,
-      candidateEvents: heldIn.events,
+      candidateEvents: heldInDecisionEvents,
       decision: result,
     });
     const attributionEvent: RsiControllerAttributionEvent = {
@@ -640,18 +716,19 @@ export async function runPromptOptimizationLoop(
     await appendFixedPromptWalEvent(input.resultsJsonlPath, attributionEvent);
     nextPromptAttribution = projectRsiPromptAttribution(controllerAttribution);
     decisions.push(result);
+    finalHeldInReference = result.heldInReferencePassEligibleRate;
 
     if (result.decision === 'keep') {
       lastKeptCommitSha = result.lastKeptCommitSha;
-      heldInReference = result.heldInReferencePassEligibleRate;
-      lastKeptHeldInEvents = heldIn.events;
+      lastKeptHeldInExecutionEvents = heldIn.events;
+      keptHeldInHistory = [...keptHeldInHistory, ...heldIn.events];
+      keptHeldOutHistory = [...keptHeldOutHistory, ...heldOutExecutionEvents];
     }
 
     // The most recent attempt seeds the next round's meta-agent feedback, even
     // when discarded — "this change did not help" is useful signal.
-    previousCandidateHeldInEvents = heldIn.events;
-    latestHeldInFeedbackEvents = heldIn.events;
-    nextHeldInDigests = await digestsFor(heldIn.events);
+    previousCandidateHeldInExecutionEvents = heldIn.events;
+    latestHeldInFeedbackExecutionEvents = heldIn.events;
   }
 
   // 3. Structural smoke report over the full WAL.
@@ -669,12 +746,13 @@ export async function runPromptOptimizationLoop(
     decisions,
     keptCount: decisions.filter((decision) => decision.decision === 'keep').length,
     lastKeptCommitSha,
-    heldInReferencePassEligibleRate: heldInReference,
+    heldInReferencePassEligibleRate: finalHeldInReference,
     totalCostUsd,
     stopReason,
     smoke,
     droppedHeldInTaskIds,
     droppedHeldOutTaskIds,
+    addressability: finalAddressability,
   };
 }
 

--- a/packages/headless/src/prompt-optimization-loop.ts
+++ b/packages/headless/src/prompt-optimization-loop.ts
@@ -30,7 +30,6 @@ import {
   heldInGateReason,
   selectAddressablePromptTasks,
   selectStablePromptTasks,
-  summarizePromptAcceptancePartition,
   type PromptAcceptanceBaseline,
   type PromptAcceptanceBaselineRun,
   type PromptAcceptanceResult,
@@ -411,7 +410,7 @@ export async function runPromptOptimizationLoop(
     events.filter((event) => stableHeldOutSet.has(event.taskId));
   let keptHeldInHistory = baselineRunsData.flatMap((run) => stableHeldIn(run.heldInEvents));
   let keptHeldOutHistory = baselineRunsData.flatMap((run) => stableHeldOut(run.heldOutEvents));
-  const initialAddressability = {
+  const selectCurrentAddressability = (): PromptOptimizationLoopResult['addressability'] => ({
     heldIn: selectAddressablePromptTasks({
       taskIds: stableHeldInTaskIds,
       keptPromptEvents: keptHeldInHistory,
@@ -420,7 +419,18 @@ export async function runPromptOptimizationLoop(
       taskIds: stableHeldOutTaskIds,
       keptPromptEvents: keptHeldOutHistory,
     }),
+  });
+  const assertAddressablePartitions = (
+    addressability: PromptOptimizationLoopResult['addressability'],
+  ): void => {
+    if (addressability.heldIn.selectedTaskIds.length === 0) {
+      throw new Error('held-in addressable task count is 0 after kept-prompt history filtering');
+    }
+    if (addressability.heldOut.selectedTaskIds.length === 0) {
+      throw new Error('held-out addressable task count is 0 after kept-prompt history filtering');
+    }
   };
+  const initialAddressability = selectCurrentAddressability();
   const roundHeldInTasks = input.heldInTasks.filter((task) => stableHeldInSet.has(task.id));
   const roundHeldOutTasks = input.heldOutTasks.filter((task) => stableHeldOutSet.has(task.id));
   const baseline = calibratePromptAcceptanceBaseline({
@@ -438,6 +448,7 @@ export async function runPromptOptimizationLoop(
     baselineRunsData[baselineRunsData.length - 1]!.heldInEvents,
   );
   let finalAddressability = initialAddressability;
+  let hasKeptCandidate = false;
   let nextPromptAttribution: RsiPromptAttribution | undefined;
 
   // 2. Candidate rounds.
@@ -452,22 +463,8 @@ export async function runPromptOptimizationLoop(
       break;
     }
     const roundId = `round-${round}`;
-    const addressability = {
-      heldIn: selectAddressablePromptTasks({
-        taskIds: stableHeldInTaskIds,
-        keptPromptEvents: keptHeldInHistory,
-      }),
-      heldOut: selectAddressablePromptTasks({
-        taskIds: stableHeldOutTaskIds,
-        keptPromptEvents: keptHeldOutHistory,
-      }),
-    };
-    if (addressability.heldIn.selectedTaskIds.length === 0) {
-      throw new Error('held-in addressable task count is 0 after kept-prompt history filtering');
-    }
-    if (addressability.heldOut.selectedTaskIds.length === 0) {
-      throw new Error('held-out addressable task count is 0 after kept-prompt history filtering');
-    }
+    const addressability = selectCurrentAddressability();
+    assertAddressablePartitions(addressability);
     finalAddressability = addressability;
     const decisionHeldInTaskIds = addressability.heldIn.selectedTaskIds;
     const decisionHeldOutTaskIds = addressability.heldOut.selectedTaskIds;
@@ -489,12 +486,9 @@ export async function runPromptOptimizationLoop(
       ? decisionHeldIn(previousCandidateHeldInExecutionEvents)
       : undefined;
     const latestHeldInFeedbackEvents = decisionHeldIn(latestHeldInFeedbackExecutionEvents);
-    const heldInReference = decisions.length === 0
-      ? activeBaseline.heldIn.referencePassEligibleRate
-      : summarizePromptAcceptancePartition(
-        lastKeptHeldInExecutionEvents,
-        decisionHeldInTaskIds,
-      ).passEligibleRate;
+    const heldInReference = hasKeptCandidate
+      ? finalHeldInReference
+      : activeBaseline.heldIn.referencePassEligibleRate;
     finalHeldInReference = heldInReference;
     const nextHeldInDigests = await digestsFor(latestHeldInFeedbackEvents);
     await writeFixedPromptResultsTsv(input.heldInResultsTsvPath, latestHeldInFeedbackEvents);
@@ -583,6 +577,7 @@ export async function runPromptOptimizationLoop(
       decisions.push(replayedResult);
       finalHeldInReference = replayedResult.heldInReferencePassEligibleRate;
       if (replayedResult.decision === 'keep') {
+        hasKeptCandidate = true;
         lastKeptCommitSha = replayedResult.lastKeptCommitSha;
         lastKeptHeldInExecutionEvents = existingDecisionRound.executedHeldIn.events;
         keptHeldInHistory = [...keptHeldInHistory, ...existingDecisionRound.executedHeldIn.events];
@@ -719,6 +714,7 @@ export async function runPromptOptimizationLoop(
     finalHeldInReference = result.heldInReferencePassEligibleRate;
 
     if (result.decision === 'keep') {
+      hasKeptCandidate = true;
       lastKeptCommitSha = result.lastKeptCommitSha;
       lastKeptHeldInExecutionEvents = heldIn.events;
       keptHeldInHistory = [...keptHeldInHistory, ...heldIn.events];
@@ -730,6 +726,13 @@ export async function runPromptOptimizationLoop(
     previousCandidateHeldInExecutionEvents = heldIn.events;
     latestHeldInFeedbackExecutionEvents = heldIn.events;
   }
+
+  // A terminal KEEP changes retained-prompt history after the final round's
+  // decision set was selected. Refresh once more so the returned profile and
+  // fail-loud empty-partition invariant describe the committed final state,
+  // including replay of a terminal keep.
+  finalAddressability = selectCurrentAddressability();
+  assertAddressablePartitions(finalAddressability);
 
   // 3. Structural smoke report over the full WAL.
   const events = await readFixedPromptWal(input.resultsJsonlPath);

--- a/packages/headless/src/prompt-optimization-replay-evidence.ts
+++ b/packages/headless/src/prompt-optimization-replay-evidence.ts
@@ -17,6 +17,8 @@ import { validateRsiControllerAttribution } from './rsi-controller-attribution.j
 
 export interface ReplayedPromptDecisionRound {
   decision: PromptCandidateDecisionEvent;
+  executedHeldIn: FixedPromptControllerResult;
+  executedHeldOut: FixedPromptControllerResult | undefined;
   heldIn: FixedPromptControllerResult;
   heldOut: FixedPromptControllerResult | undefined;
   attribution: RsiControllerAttributionEvent;
@@ -94,6 +96,8 @@ export function replayPromptDecisionRound(input: {
   roundId: string;
   heldInTaskIds: readonly string[];
   heldOutTaskIds: readonly string[];
+  executedHeldInTaskIds?: readonly string[];
+  executedHeldOutTaskIds?: readonly string[];
   resumeFingerprint?: string;
   heldInResultsTsvPath: string;
   heldOutResultsTsvPath: string;
@@ -134,8 +138,29 @@ export function replayPromptDecisionRound(input: {
     ...(input.resumeFingerprint ? { resumeFingerprint: input.resumeFingerprint } : {}),
     resultsTsvPath: input.heldOutResultsTsvPath,
   });
+  const executedHeldIn = replayRequiredControllerSweep({
+    events: input.events,
+    runId: input.runId,
+    roundId: input.roundId,
+    taskIds: input.executedHeldInTaskIds ?? input.heldInTaskIds,
+    expectedPromptHash: candidate.promptHash,
+    ...(input.resumeFingerprint ? { resumeFingerprint: input.resumeFingerprint } : {}),
+    resultsTsvPath: input.heldInResultsTsvPath,
+    missingEvidenceMessage: `RSI WAL replay missing executed held-in task evidence for ${input.roundId}`,
+  });
+  const executedHeldOut = replayControllerSweep({
+    events: input.events,
+    runId: input.runId,
+    roundId: input.roundId,
+    taskIds: input.executedHeldOutTaskIds ?? input.heldOutTaskIds,
+    expectedPromptHash: candidate.promptHash,
+    ...(input.resumeFingerprint ? { resumeFingerprint: input.resumeFingerprint } : {}),
+    resultsTsvPath: input.heldOutResultsTsvPath,
+  });
   return {
     decision,
+    executedHeldIn,
+    executedHeldOut,
     heldIn,
     heldOut,
     attribution,


### PR DESCRIPTION
## Summary

Implements the independent **addressability filtering** slice from #619.

- derive deterministic per-task retained-prompt statistics (`passes`, `flips`, `flipRate`, distinct kept prompt count) from the RSI WAL prefix;
- exclude tasks as `capability_limit` only after at least two distinct retained prompt hashes have never passed, avoiding the false conclusion that one weak seed prompt defines the model ceiling;
- exclude sufficiently observed high-flip tasks as `flaky`;
- keep excluded tasks in every execution sweep and in the WAL, while removing them from meta-agent TSV/digests/analysis and held-in/held-out acceptance + noise-band sets;
- recompute the addressability profile after each KEEP and preserve the same prefix semantics during WAL replay/resume;
- retain full executed sweeps during replay for cost accounting and reward-hack scanning, separately from the filtered decision view;
- expose final addressability stats in the result JSON and CLI summary.

This intentionally does **not** include #619's failure-signature clustering or audit-schema merge.

## Safety / compatibility

- Legacy task events without `promptHash` are grouped into one unknown prompt and cannot by themselves prove `capability_limit`.
- Reward-hack scanning still covers the full executed task set.
- If an entire held-in or held-out decision partition becomes unaddressable, the loop fails loud instead of producing a meaningless decision.
- Candidate task-set hashes continue to make replay drift fail closed.

## Validation

- `npm --workspace @maka/headless test` — 966 passed, 0 failed, 1 skipped (967 total)
- `npm --workspace @maka/headless run typecheck`
- `node --check packages/headless/harbor/run-prompt-optimization.mjs`
- `git diff --check`

The integration coverage includes a two-stage run/resume: a task fails under the seed and first retained candidate, becomes `capability_limit` in round 2, remains executed, and is absent from proposal evidence and acceptance.

Refs #619
