### PR TITLE
feat: runtime-owned context compaction defaults across surfaces

### DIFF
--- a/apps/desktop/src/main/__tests__/context-budget-policy.test.ts
+++ b/apps/desktop/src/main/__tests__/context-budget-policy.test.ts
@@ -10,6 +10,7 @@ const ACTIVE_PRUNE_ENV_KEYS = [
   'MAKA_CONTEXT_ACTIVE_TOOL_RESULT_MIN_STEP_NUMBER',
   'MAKA_CONTEXT_HISTORY_COMPACT',
   'MAKA_CONTEXT_HISTORY_COMPACT_RESERVE_TOKENS',
+  'MAKA_CONTEXT_HISTORY_COMPACT_MID_TURN',
 ] as const;
 
 const savedEnv: Record<string, string | undefined> = {};
@@ -81,6 +82,18 @@ describe('desktop activeToolResultPrune policy', () => {
     assert.equal(policy?.historyCompact?.highWaterRatio, 1);
     assert.equal(policy?.historyCompact?.minRecentTurns, 3);
     assert.equal(policy?.historyCompact?.tailEstimatedTokens, 16_384);
+  });
+
+  test('enables mid-turn capacity compaction by default with the shared reserve (runtime-owned)', () => {
+    const policy = buildDefaultContextBudgetPolicy(openaiConnection(), { name: 'desktop-default-history-budget' });
+    assert.deepEqual(policy?.historyCompact?.midTurn, { enabled: true, reserveTokens: 16_384 });
+  });
+
+  test('honors MAKA_CONTEXT_HISTORY_COMPACT_MID_TURN=off as the explicit escape hatch', () => {
+    process.env.MAKA_CONTEXT_HISTORY_COMPACT_MID_TURN = 'off';
+    const policy = buildDefaultContextBudgetPolicy(openaiConnection(), { name: 'desktop-default-history-budget' });
+    assert.equal(policy?.historyCompact?.enabled, true);
+    assert.equal(policy?.historyCompact?.midTurn, undefined);
   });
 
   test('uses the selected model context window minus the default reserve as the history budget', () => {

--- a/apps/desktop/src/main/__tests__/context-budget-policy.test.ts
+++ b/apps/desktop/src/main/__tests__/context-budget-policy.test.ts
@@ -11,6 +11,8 @@ const ACTIVE_PRUNE_ENV_KEYS = [
   'MAKA_CONTEXT_HISTORY_COMPACT',
   'MAKA_CONTEXT_HISTORY_COMPACT_RESERVE_TOKENS',
   'MAKA_CONTEXT_HISTORY_COMPACT_MID_TURN',
+  'MAKA_CONTEXT_SEMANTIC_COMPACT',
+  'MAKA_CONTEXT_SEMANTIC_COMPACT_MODE',
 ] as const;
 
 const savedEnv: Record<string, string | undefined> = {};
@@ -94,6 +96,17 @@ describe('desktop activeToolResultPrune policy', () => {
     const policy = buildDefaultContextBudgetPolicy(openaiConnection(), { name: 'desktop-default-history-budget' });
     assert.equal(policy?.historyCompact?.enabled, true);
     assert.equal(policy?.historyCompact?.midTurn, undefined);
+  });
+
+  test('keeps semantic compaction (the #986 experiment) off by default', () => {
+    const policy = buildDefaultContextBudgetPolicy(openaiConnection(), { name: 'desktop-default-history-budget' });
+    assert.equal(policy?.semanticCompact, undefined);
+  });
+
+  test('honors an explicit MAKA_CONTEXT_SEMANTIC_COMPACT=on opt-in', () => {
+    process.env.MAKA_CONTEXT_SEMANTIC_COMPACT = 'on';
+    const policy = buildDefaultContextBudgetPolicy(openaiConnection(), { name: 'desktop-default-history-budget' });
+    assert.equal(policy?.semanticCompact?.enabled, true);
   });
 
   test('uses the selected model context window minus the default reserve as the history budget', () => {

--- a/packages/cli/src/__tests__/runtime-bootstrap.test.ts
+++ b/packages/cli/src/__tests__/runtime-bootstrap.test.ts
@@ -473,9 +473,9 @@ describe('Maka CLI runtime bootstrap', () => {
         assert.equal(backendInput.contextBudget?.name, 'cli-default-history-budget');
         assert.equal(backendInput.contextBudget?.maxHistoryEstimatedTokens, 32_000);
         assert.equal(backendInput.contextBudget?.activeToolResultPrune?.enabled, true);
-        // In-turn semantic compaction is stripped for the CLI: it interrupts the
-        // live reply with a compaction notice for small savings. History/turn
-        // compaction stays.
+        // In-turn semantic compaction (the #986 experiment) is off by default in
+        // the runtime, so the CLI inherits it absent without a local strip.
+        // History/turn compaction stays.
         assert.equal(backendInput.contextBudget?.semanticCompact, undefined);
         assert.equal(backendInput.contextBudget?.historyCompact?.enabled, true);
         assert.equal(backendInput.contextBudget?.historyCompact?.mode, 'read_write');
@@ -519,8 +519,8 @@ describe('Maka CLI runtime bootstrap', () => {
           });
           const backendInput = (backend as unknown as { input: AiSdkBackendInput }).input;
 
-          // The CLI default strips semantic compaction, but an explicit env
-          // opt-in must reach the backend so the path stays exercisable.
+          // Semantic compaction is off by default, but an explicit env opt-in
+          // must reach the backend so the path stays exercisable.
           assert.equal(backendInput.contextBudget?.semanticCompact?.enabled, true);
         });
       } finally {

--- a/packages/cli/src/runtime-bootstrap.ts
+++ b/packages/cli/src/runtime-bootstrap.ts
@@ -259,7 +259,10 @@ export async function createMakaCliRuntimeContext(
       modelFactory: (modelInput) => getAIModel({ ...modelInput, fetch: modelFetch }),
       tools: allTools,
       providerOptions: buildProviderOptions(ready.connection, ready.model, header.thinkingLevel),
-      contextBudget: buildCliContextBudgetPolicy(ready.connection, ready.model),
+      contextBudget: buildDefaultContextBudgetPolicy(ready.connection, {
+        name: 'cli-default-history-budget',
+        modelId: ready.model,
+      }),
       loadHistoryCompact: (event) => loadHistoryCompactBlocksFromArtifacts(artifactStore, event),
       loadHistoryCompactCheckpoint: ctx.loadHistoryCompactCheckpoint,
       summarizeHistoryCompact: buildLlmHistorySummarizer({
@@ -463,48 +466,6 @@ export async function createMakaCliRuntimeContext(
       shellRunListeners.clear();
     },
   };
-}
-
-// The CLI keeps turn-boundary history compaction but disables *in-turn* semantic
-// compaction by default. Firing mid-turn, it interrupts the live reply with a
-// `Context compacted: semanticCompact` notice for small savings, which reads as
-// noise in an interactive session. So we drop it from the default policy rather
-// than setting an env override, leaving the rest of the budget (history compact,
-// tool-result pruning) untouched.
-//
-// But only the *default* is off: if the user explicitly opts in via
-// `MAKA_CONTEXT_SEMANTIC_COMPACT` or `MAKA_CONTEXT_SEMANTIC_COMPACT_MODE`, honor
-// it so the path can still be exercised and debugged from the CLI.
-function buildCliContextBudgetPolicy(
-  connection: Parameters<typeof buildDefaultContextBudgetPolicy>[0],
-  modelId: string,
-  env: Record<string, string | undefined> = process.env,
-): ReturnType<typeof buildDefaultContextBudgetPolicy> {
-  const policy = buildDefaultContextBudgetPolicy(connection, {
-    name: 'cli-default-history-budget',
-    modelId,
-  });
-  if (!policy?.semanticCompact) return policy;
-  // buildDefaultContextBudgetPolicy already reflects env-off (policy would have
-  // no semanticCompact), so reaching here means default-on or an explicit opt-in.
-  // Keep it only for the explicit opt-in; otherwise apply the CLI default (off).
-  if (userOptedIntoSemanticCompact(env)) return policy;
-  const { semanticCompact: _omitted, ...rest } = policy;
-  return rest;
-}
-
-// True when the environment explicitly turns semantic compaction on — either a
-// truthy `MAKA_CONTEXT_SEMANTIC_COMPACT`, or a `MAKA_CONTEXT_SEMANTIC_COMPACT_MODE`
-// set to a mode other than `off`. Mirrors the spellings the runtime policy
-// accepts. An invalid boolean would already have thrown inside the default
-// policy build above, so this only classifies well-formed values.
-function userOptedIntoSemanticCompact(env: Record<string, string | undefined>): boolean {
-  const enable = env.MAKA_CONTEXT_SEMANTIC_COMPACT?.trim().toLowerCase();
-  if (enable === '1' || enable === 'true' || enable === 'yes' || enable === 'on' || enable === 'enabled') {
-    return true;
-  }
-  const mode = env.MAKA_CONTEXT_SEMANTIC_COMPACT_MODE?.trim().toLowerCase();
-  return mode === 'validate_only' || mode === 'prepare_step_dry_run' || mode === 'replace';
 }
 
 export async function getOrCreateCliClaudeDeviceId(

--- a/packages/runtime/src/__tests__/context-budget-mid-turn-policy.test.ts
+++ b/packages/runtime/src/__tests__/context-budget-mid-turn-policy.test.ts
@@ -51,6 +51,60 @@ describe('mid-turn history compact policy env plumbing', () => {
   });
 });
 
+describe('window-bounded reserve derivation (issue #882 PR 3 review P2)', () => {
+  test('caps the derived reserve on a small-window model instead of degrading to a 1-token budget', () => {
+    // gpt-4 has an 8192-token window. A flat 16384 reserve used to derive
+    // maxHistoryEstimatedTokens = max(1, 8192 - 16384) = 1, and a mid_turn
+    // high water clamped to 1 token — every multi-step turn ran the
+    // summarizer for a checkpoint that could never pass the replay gate.
+    // The default reserve must be bounded by the KNOWN window: a quarter of
+    // the window, capped at the classic 16384.
+    const policy = buildDefaultContextBudgetPolicy(gpt4Connection(), { env: {}, modelId: 'gpt-4' });
+    assert.equal(policy?.maxHistoryEstimatedTokens, 8192 - 2048);
+    assert.deepEqual(policy?.historyCompact?.midTurn, { enabled: true, reserveTokens: 2048 });
+  });
+
+  test('keeps the classic 16384 reserve for large windows (>= 64K unchanged)', () => {
+    const policy = buildDefaultContextBudgetPolicy(connection(), { env: {} });
+    // claude-sonnet-4-5 metadata window is 200_000: 200_000 / 4 caps at 16_384.
+    assert.equal(policy?.maxHistoryEstimatedTokens, 200_000 - 16_384);
+    assert.deepEqual(policy?.historyCompact?.midTurn, { enabled: true, reserveTokens: 16_384 });
+  });
+
+  test('keeps the classic 16384 reserve when the window is unknown (metadata-less model)', () => {
+    const policy = buildDefaultContextBudgetPolicy({
+      ...gpt4Connection(),
+      defaultModel: 'custom-model',
+      models: [{ id: 'custom-model' }],
+    } as LlmConnection, { env: {}, modelId: 'custom-model' });
+    // No window: the flat 32_000 fallback budget and the classic reserve.
+    assert.equal(policy?.maxHistoryEstimatedTokens, 32_000);
+    assert.deepEqual(policy?.historyCompact?.midTurn, { enabled: true, reserveTokens: 16_384 });
+  });
+
+  test('respects an explicit reserve override verbatim even on a small window', () => {
+    const policy = buildDefaultContextBudgetPolicy(gpt4Connection(), {
+      env: { MAKA_CONTEXT_HISTORY_COMPACT_RESERVE_TOKENS: '6000' },
+      modelId: 'gpt-4',
+    });
+    assert.equal(policy?.maxHistoryEstimatedTokens, 8192 - 6000);
+    assert.deepEqual(policy?.historyCompact?.midTurn, { enabled: true, reserveTokens: 6000 });
+  });
+});
+
+function gpt4Connection(): LlmConnection {
+  return {
+    slug: 'openai-main',
+    name: 'OpenAI',
+    providerType: 'openai',
+    defaultModel: 'gpt-4',
+    models: [{ id: 'gpt-4' }],
+    enabled: true,
+    createdAt: 1,
+    updatedAt: 1,
+  } as LlmConnection;
+}
+
 function connection(): LlmConnection {
   return {
     slug: 'anthropic-main',

--- a/packages/runtime/src/__tests__/context-budget-mid-turn-policy.test.ts
+++ b/packages/runtime/src/__tests__/context-budget-mid-turn-policy.test.ts
@@ -4,29 +4,23 @@ import type { LlmConnection } from '@maka/core';
 import { buildDefaultContextBudgetPolicy } from '../context-budget-policy.js';
 
 describe('mid-turn history compact policy env plumbing', () => {
-  test('defaults off: no midTurn subconfig without an explicit opt-in', () => {
+  test('defaults on: the runtime derives midTurn with the shared reserve when history compaction is enabled', () => {
     const policy = buildDefaultContextBudgetPolicy(connection(), {
       env: { MAKA_CONTEXT_HISTORY_COMPACT: 'on' },
     });
     assert.equal(policy?.historyCompact?.enabled, true);
-    assert.equal(policy?.historyCompact?.midTurn, undefined);
+    assert.deepEqual(policy?.historyCompact?.midTurn, { enabled: true, reserveTokens: 16_384 });
   });
 
-  test('opts in with MAKA_CONTEXT_HISTORY_COMPACT_MID_TURN=on and the shared reserve', () => {
-    const policy = buildDefaultContextBudgetPolicy(connection(), {
-      env: {
-        MAKA_CONTEXT_HISTORY_COMPACT: 'on',
-        MAKA_CONTEXT_HISTORY_COMPACT_MID_TURN: 'on',
-      },
-    });
+  test('defaults on with no compaction env at all (the runtime, not the surface, owns it)', () => {
+    const policy = buildDefaultContextBudgetPolicy(connection(), { env: {} });
+    assert.equal(policy?.historyCompact?.enabled, true);
     assert.deepEqual(policy?.historyCompact?.midTurn, { enabled: true, reserveTokens: 16_384 });
   });
 
   test('honors explicit reserve and tail-event overrides', () => {
     const policy = buildDefaultContextBudgetPolicy(connection(), {
       env: {
-        MAKA_CONTEXT_HISTORY_COMPACT: 'on',
-        MAKA_CONTEXT_HISTORY_COMPACT_MID_TURN: 'on',
         MAKA_CONTEXT_HISTORY_COMPACT_RESERVE_TOKENS: '8000',
         MAKA_CONTEXT_HISTORY_COMPACT_MID_TURN_TAIL_EVENTS: '2',
       },
@@ -38,14 +32,22 @@ describe('mid-turn history compact policy env plumbing', () => {
     });
   });
 
-  test('mid_turn=off keeps it disabled even with history compact on', () => {
+  test('MAKA_CONTEXT_HISTORY_COMPACT_MID_TURN=off is the escape hatch even with history compact on', () => {
     const policy = buildDefaultContextBudgetPolicy(connection(), {
       env: {
         MAKA_CONTEXT_HISTORY_COMPACT: 'on',
         MAKA_CONTEXT_HISTORY_COMPACT_MID_TURN: 'off',
       },
     });
+    assert.equal(policy?.historyCompact?.enabled, true);
     assert.equal(policy?.historyCompact?.midTurn, undefined);
+  });
+
+  test('an explicit MAKA_CONTEXT_HISTORY_COMPACT=off disables history compaction and midTurn with it', () => {
+    const policy = buildDefaultContextBudgetPolicy(connection(), {
+      env: { MAKA_CONTEXT_HISTORY_COMPACT: 'off' },
+    });
+    assert.equal(policy?.historyCompact, undefined);
   });
 });
 

--- a/packages/runtime/src/__tests__/context-budget-semantic-compact-policy.test.ts
+++ b/packages/runtime/src/__tests__/context-budget-semantic-compact-policy.test.ts
@@ -1,0 +1,56 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+import type { LlmConnection } from '@maka/core';
+import { buildDefaultContextBudgetPolicy } from '../context-budget-policy.js';
+
+describe('semantic compaction policy env plumbing (issue #882 PR 3)', () => {
+  test('defaults off: the #986 experiment is opt-in, not part of the runtime default', () => {
+    const policy = buildDefaultContextBudgetPolicy(connection(), { env: {} });
+    // The rest of the default budget still exists (history compaction stays on),
+    // proving the policy is built but simply omits the experiment.
+    assert.equal(policy?.historyCompact?.enabled, true);
+    assert.equal(policy?.semanticCompact, undefined);
+  });
+
+  test('honors an explicit MAKA_CONTEXT_SEMANTIC_COMPACT=on opt-in', () => {
+    const policy = buildDefaultContextBudgetPolicy(connection(), {
+      env: { MAKA_CONTEXT_SEMANTIC_COMPACT: 'on' },
+    });
+    assert.equal(policy?.semanticCompact?.enabled, true);
+    assert.equal(policy?.semanticCompact?.mode, 'replace');
+  });
+
+  test('honors an explicit mode as an opt-in even without the boolean flag', () => {
+    const policy = buildDefaultContextBudgetPolicy(connection(), {
+      env: { MAKA_CONTEXT_SEMANTIC_COMPACT_MODE: 'validate_only' },
+    });
+    assert.equal(policy?.semanticCompact?.enabled, true);
+    assert.equal(policy?.semanticCompact?.mode, 'validate_only');
+  });
+
+  test('an explicit mode of off keeps it disabled', () => {
+    const policy = buildDefaultContextBudgetPolicy(connection(), {
+      env: { MAKA_CONTEXT_SEMANTIC_COMPACT_MODE: 'off' },
+    });
+    assert.equal(policy?.semanticCompact, undefined);
+  });
+
+  test('an explicit MAKA_CONTEXT_SEMANTIC_COMPACT=off keeps it disabled', () => {
+    const policy = buildDefaultContextBudgetPolicy(connection(), {
+      env: { MAKA_CONTEXT_SEMANTIC_COMPACT: 'off' },
+    });
+    assert.equal(policy?.semanticCompact, undefined);
+  });
+});
+
+function connection(): LlmConnection {
+  return {
+    slug: 'anthropic-main',
+    name: 'Anthropic',
+    providerType: 'anthropic',
+    defaultModel: 'claude-sonnet-4-5-20250929',
+    enabled: true,
+    createdAt: 1,
+    updatedAt: 1,
+  };
+}

--- a/packages/runtime/src/__tests__/mid-turn-capacity-backend.test.ts
+++ b/packages/runtime/src/__tests__/mid-turn-capacity-backend.test.ts
@@ -52,6 +52,8 @@ interface MidTurnFixture {
 
 interface MidTurnFixtureOptions {
   contextWindow?: number;
+  /** Omit the model's context window entirely (unknown model metadata). */
+  withoutContextWindow?: boolean;
   reserveTokens?: number;
   summarize?: () => Promise<string | undefined> | string | undefined;
   branch?: string;
@@ -215,7 +217,10 @@ function buildFixture(options: MidTurnFixtureOptions = {}): MidTurnFixture {
     sessionId: 'session-1',
     header: header(),
     appendMessage: async (message) => { messages.push(message); },
-    connection: { ...connection(), models: [{ id: 'mock-model-id', contextWindow }] },
+    connection: {
+      ...connection(),
+      models: [{ id: 'mock-model-id', ...(options.withoutContextWindow ? {} : { contextWindow }) }],
+    },
     apiKey: 'sk-test',
     modelId: 'mock-model-id',
     permissionEngine: new PermissionEngine({ newId: () => 'permission-id', now: () => 1 }),
@@ -1042,6 +1047,48 @@ describe('mid-turn capacity compaction flow plumbing', () => {
     }
     assert.equal(sendInputs.length, 1);
     assert.equal(sendInputs[0]?.headAnchorRuntimeEvent, anchor);
+  });
+});
+
+describe('mid-turn capacity default-on safety guards (issue #882 PR 3)', () => {
+  test('does not fire when the selected model has no known context window (conservative default)', async () => {
+    // PR 3 sinks midTurn on by default, but the backend only activates it when
+    // resolveSelectedModelContextWindow yields a window. An unknown model (no
+    // metadata, no models[].contextWindow) must fall back to never compacting
+    // rather than guessing a window — the turn runs raw and completes normally.
+    const fixture = buildFixture({ withoutContextWindow: true });
+    await runFixtureTurn(fixture);
+
+    assert.equal(fixture.recorded.length, 0);
+    assert.equal(fixture.summarizerCalls, 0);
+    assert.equal(fixture.ledgerReads, 0);
+    const complete = fixture.events.find((event) => event.type === 'complete');
+    assert.equal(complete?.type === 'complete' ? complete.stopReason : undefined, 'end_turn');
+    // The raw span is never folded away, proving no compaction ran.
+    assert.equal(promptJson(fixture, 2).includes('RAW_SPAN_ONE_'), true);
+  });
+
+  test('does not fire for a session without a persisted head anchor (child sessions have no seam)', async () => {
+    // PR 1's decision: child sessions are structurally without the head-anchor
+    // seam, so even with midTurn on by default the trigger must never activate.
+    // Sending without a headAnchorRuntimeEvent reproduces that shape.
+    const fixture = buildFixture();
+    const events: SessionEvent[] = [];
+    for await (const event of fixture.backend.send({
+      runId: 'run-1',
+      turnId: 'turn-1',
+      text: ANCHOR_TEXT,
+      context: [],
+      runtimeContext: [...fixture.priorEvents],
+    })) {
+      fixture.persist(event);
+      events.push(event);
+    }
+
+    assert.equal(fixture.recorded.length, 0);
+    assert.equal(fixture.summarizerCalls, 0);
+    const complete = events.find((event) => event.type === 'complete');
+    assert.equal(complete?.type === 'complete' ? complete.stopReason : undefined, 'end_turn');
   });
 });
 

--- a/packages/runtime/src/__tests__/mid-turn-capacity-backend.test.ts
+++ b/packages/runtime/src/__tests__/mid-turn-capacity-backend.test.ts
@@ -271,10 +271,13 @@ function buildFixture(options: MidTurnFixtureOptions = {}): MidTurnFixture {
           {
             name: 'runtime-default-mid-turn',
             modelId: 'mock-model-id',
-            // Only the reserve is sized to the toy window (a first-class knob);
-            // every other value is the shipped runtime default, including the
-            // default-on midTurn derivation under test.
-            env: { MAKA_CONTEXT_HISTORY_COMPACT_RESERVE_TOKENS: String(reserveTokens) },
+            // Every value is the shipped runtime default (including the
+            // default-on midTurn derivation and the window-bounded reserve
+            // under test); a test may still size the reserve to its toy window
+            // through the first-class env knob by passing reserveTokens.
+            env: options.reserveTokens !== undefined
+              ? { MAKA_CONTEXT_HISTORY_COMPACT_RESERVE_TOKENS: String(options.reserveTokens) }
+              : {},
           },
         )
       : {
@@ -1108,26 +1111,79 @@ describe('mid-turn capacity default-on safety guards (issue #882 PR 3)', () => {
     const complete = events.find((event) => event.type === 'complete');
     assert.equal(complete?.type === 'complete' ? complete.stopReason : undefined, 'end_turn');
   });
+
+  test('never runs a pointless summarizer on a small-window model under the shipped defaults (review P2)', async () => {
+    // gpt-4 shape: an 8192-token window under the runtime-derived defaults.
+    // A flat 16384 reserve used to clamp the mid_turn high water to 1 token —
+    // every boundary triggered, the summarizer ran, and the checkpoint could
+    // never pass the 1-token replay gate: pure waste. With the window-bounded
+    // reserve the payload sits far below the high water, so the default must
+    // be completely inert here: no summarizer call, no checkpoint, and the
+    // turn completes on the raw projection.
+    const fixture = buildFixture({ useRuntimeDefaultPolicy: true, contextWindow: 8_192 });
+    await runFixtureTurn(fixture);
+
+    assert.equal(fixture.summarizerCalls, 0);
+    assert.equal(fixture.recorded.length, 0);
+    assert.equal(fixture.model.doStreamCalls.length, 3);
+    const complete = fixture.events.find((event) => event.type === 'complete');
+    assert.equal(complete?.type === 'complete' ? complete.stopReason : undefined, 'end_turn');
+    assert.equal(promptJson(fixture, 2).includes('RAW_SPAN_ONE_'), true);
+  });
 });
 
 describe('the shipped runtime default drives the proactive long-turn journey (issue #882 PR 3)', () => {
-  test('a long turn near the window compacts mid-turn and continues instead of truncating', async () => {
-    // No hand-built policy: this wires buildDefaultContextBudgetPolicy — the
-    // exact default every surface now inherits — into the backend. A long turn
-    // whose growing payload crosses `contextWindow - reserve` must fold a safe
-    // completed prefix and continue the SAME turn to normal completion, never
+  test('a long turn near the window compacts mid-turn, persists the checkpoint, and continues instead of truncating', async () => {
+    // No hand-built policy and no env override: this wires
+    // buildDefaultContextBudgetPolicy — the exact default every surface now
+    // inherits — into the backend. A long turn whose real usage crosses
+    // `contextWindow - derivedReserve` (window 1000 → reserve 250, high water
+    // 750) must fold a safe completed prefix into a DURABLE mid_turn
+    // checkpoint and continue the SAME turn to normal completion, never
     // truncate it or surface a raw provider error.
-    const fixture = buildFixture({ useRuntimeDefaultPolicy: true });
+    const fixture = buildFixture({
+      useRuntimeDefaultPolicy: true,
+      contextWindow: 1_000,
+      bigPriors: true,
+      firstStepUsage: { input: 900, output: 20 },
+    });
     await runFixtureTurn(fixture);
 
-    // The default's midTurn config actually engaged mid-turn: the summarizer
-    // seam was invoked between steps as the payload crossed the high water.
-    assert.equal(fixture.summarizerCalls >= 1, true);
+    // The checkpoint was durably persisted (not a fail-open raw continuation).
+    assert.equal(fixture.recorded.length, 1);
+    assert.equal(fixture.recorded[0]?.phase, 'mid_turn');
+    // The continued request rides the compacted projection: the compact block
+    // is present and the replaced raw span is gone.
+    const continuedPrompt = promptJson(fixture, 1);
+    assert.match(continuedPrompt, /maka_history_compact_checkpoint/);
+    assert.match(continuedPrompt, /MID_TURN_SUMMARY_SENTINEL/);
+    assert.equal(continuedPrompt.includes('PRIOR_FACT'), false);
+    assert.equal(continuedPrompt.includes(ANCHOR_TEXT), true);
     // ...and the turn continued through all three steps to a clean end — no
     // truncation, no raw provider error surfaced to the user.
     assert.equal(fixture.model.doStreamCalls.length, 3);
     const complete = fixture.events.find((event) => event.type === 'complete');
     assert.equal(complete?.type === 'complete' ? complete.stopReason : undefined, 'end_turn');
+    assert.equal(fixture.events.some((event) => event.type === 'error'), false);
+  });
+
+  test('an unrescuable turn under the shipped default ends with the explicit context_budget_exhausted outcome', async () => {
+    // Same runtime-derived default (window 120 → reserve 30, high water 90):
+    // no prior turns leaves no safe completed span, and the request genuinely
+    // exceeds the window — the turn must end with the first-class outcome, not
+    // a raw provider error.
+    const fixture = buildFixture({
+      useRuntimeDefaultPolicy: true,
+      contextWindow: 120,
+      withoutPriorTurns: true,
+    });
+    await runFixtureTurn(fixture);
+
+    const complete = fixture.events.find((event) => event.type === 'complete');
+    assert.equal(complete?.type, 'complete');
+    if (complete?.type !== 'complete') return;
+    assert.equal(complete.stopReason, 'context_budget_exhausted');
+    assert.equal(complete.contextBudgetExhaustedDetail, 'no_safe_completed_span');
     assert.equal(fixture.events.some((event) => event.type === 'error'), false);
   });
 });

--- a/packages/runtime/src/__tests__/mid-turn-capacity-backend.test.ts
+++ b/packages/runtime/src/__tests__/mid-turn-capacity-backend.test.ts
@@ -9,6 +9,7 @@ import type { RuntimeEvent } from '@maka/core/runtime-event';
 import type { AgentBackend, BackendSendInput } from '@maka/core/backend-types';
 import { z } from 'zod';
 import { AiSdkBackend } from '../ai-sdk-backend.js';
+import { buildDefaultContextBudgetPolicy } from '../context-budget-policy.js';
 import { AiSdkFlow, createSessionEventMapMemory, mapSessionEventToRuntimeEvent } from '../ai-sdk-flow.js';
 import type { InvocationContext } from '../invocation-context.js';
 import { PermissionEngine } from '../permission-engine.js';
@@ -54,6 +55,11 @@ interface MidTurnFixtureOptions {
   contextWindow?: number;
   /** Omit the model's context window entirely (unknown model metadata). */
   withoutContextWindow?: boolean;
+  /**
+   * Derive the policy from the runtime default (buildDefaultContextBudgetPolicy)
+   * instead of the hand-built one, so a test can exercise the shipped default.
+   */
+  useRuntimeDefaultPolicy?: boolean;
   reserveTokens?: number;
   summarize?: () => Promise<string | undefined> | string | undefined;
   branch?: string;
@@ -259,7 +265,19 @@ function buildFixture(options: MidTurnFixtureOptions = {}): MidTurnFixture {
     ...(options.bigSystemPrompt
       ? { systemPrompt: 'SYSTEM_CONTEXT '.repeat(400) }
       : {}),
-    contextBudget: {
+    contextBudget: options.useRuntimeDefaultPolicy
+      ? buildDefaultContextBudgetPolicy(
+          { ...connection(), models: [{ id: 'mock-model-id', contextWindow }] },
+          {
+            name: 'runtime-default-mid-turn',
+            modelId: 'mock-model-id',
+            // Only the reserve is sized to the toy window (a first-class knob);
+            // every other value is the shipped runtime default, including the
+            // default-on midTurn derivation under test.
+            env: { MAKA_CONTEXT_HISTORY_COMPACT_RESERVE_TOKENS: String(reserveTokens) },
+          },
+        )
+      : {
       name: 'mid-turn-test',
       maxHistoryEstimatedTokens: 100_000,
       minRecentTurns: 1,
@@ -1089,6 +1107,28 @@ describe('mid-turn capacity default-on safety guards (issue #882 PR 3)', () => {
     assert.equal(fixture.summarizerCalls, 0);
     const complete = events.find((event) => event.type === 'complete');
     assert.equal(complete?.type === 'complete' ? complete.stopReason : undefined, 'end_turn');
+  });
+});
+
+describe('the shipped runtime default drives the proactive long-turn journey (issue #882 PR 3)', () => {
+  test('a long turn near the window compacts mid-turn and continues instead of truncating', async () => {
+    // No hand-built policy: this wires buildDefaultContextBudgetPolicy — the
+    // exact default every surface now inherits — into the backend. A long turn
+    // whose growing payload crosses `contextWindow - reserve` must fold a safe
+    // completed prefix and continue the SAME turn to normal completion, never
+    // truncate it or surface a raw provider error.
+    const fixture = buildFixture({ useRuntimeDefaultPolicy: true });
+    await runFixtureTurn(fixture);
+
+    // The default's midTurn config actually engaged mid-turn: the summarizer
+    // seam was invoked between steps as the payload crossed the high water.
+    assert.equal(fixture.summarizerCalls >= 1, true);
+    // ...and the turn continued through all three steps to a clean end — no
+    // truncation, no raw provider error surfaced to the user.
+    assert.equal(fixture.model.doStreamCalls.length, 3);
+    const complete = fixture.events.find((event) => event.type === 'complete');
+    assert.equal(complete?.type === 'complete' ? complete.stopReason : undefined, 'end_turn');
+    assert.equal(fixture.events.some((event) => event.type === 'error'), false);
   });
 });
 

--- a/packages/runtime/src/context-budget-policy.ts
+++ b/packages/runtime/src/context-budget-policy.ts
@@ -14,9 +14,11 @@ export function buildDefaultContextBudgetPolicy(
 ): ContextBudgetPolicy | undefined {
   const env = options.env ?? process.env;
   if (env.MAKA_CONTEXT_BUDGET === 'off') return undefined;
+  const contextWindow = resolveSelectedModelContextWindow(connection, options.modelId);
+  const reserveTokens = defaultCompactReserveTokens(env, contextWindow);
   const maxHistoryEstimatedTokens =
     parseOptionalPositiveInt(env.MAKA_CONTEXT_HISTORY_BUDGET_TOKENS) ??
-    defaultHistoryBudgetTokens(connection, env, options.modelId);
+    defaultHistoryBudgetTokens(connection, contextWindow, reserveTokens);
   const maxHistoryTurns = parseOptionalPositiveInt(env.MAKA_CONTEXT_HISTORY_BUDGET_TURNS);
   const minRecentTurns = parsePositiveInt(env.MAKA_CONTEXT_MIN_RECENT_TURNS, 2);
   const surfaceName = (options.name ?? 'default-history-budget').replace(/-default-history-budget$/, '');
@@ -24,7 +26,7 @@ export function buildDefaultContextBudgetPolicy(
   const archiveRetrieval = buildArchiveRetrievalPolicy(env);
   const historySearch = buildHistorySearchPolicy(env);
   const synthesisCache = buildSynthesisCachePolicy(env);
-  const historyCompact = buildHistoryCompactPolicy(env, `${surfaceName}-history-compact`);
+  const historyCompact = buildHistoryCompactPolicy(env, `${surfaceName}-history-compact`, reserveTokens);
   const historyRewrite = buildHistoryRewriteGatePolicy(env, `${surfaceName}-history-rewrite`);
   const semanticCompact = buildSemanticCompactPolicy(env, `${surfaceName}-semantic-compact`);
   const activeToolResultPrune = buildActiveToolResultPrunePolicy(env);
@@ -176,6 +178,7 @@ function buildSynthesisCachePolicy(
 function buildHistoryCompactPolicy(
   env: Record<string, string | undefined>,
   defaultHighWaterName: string,
+  reserveTokens: number,
 ): NonNullable<ContextBudgetPolicy['historyCompact']> | undefined {
   const enabled = parseOptionalBoolean(env.MAKA_CONTEXT_HISTORY_COMPACT, 'MAKA_CONTEXT_HISTORY_COMPACT');
   if (enabled === false) return undefined;
@@ -185,7 +188,7 @@ function buildHistoryCompactPolicy(
   const tailEstimatedTokens = parseOptionalPositiveInt(env.MAKA_CONTEXT_HISTORY_COMPACT_TAIL_TOKENS);
   const minRecentTurns = parseOptionalPositiveInt(env.MAKA_CONTEXT_HISTORY_COMPACT_MIN_RECENT_TURNS);
   const maxSummaryEstimatedTokens = parseOptionalPositiveInt(env.MAKA_CONTEXT_HISTORY_COMPACT_MAX_SUMMARY_TOKENS);
-  const midTurn = buildHistoryCompactMidTurnPolicy(env);
+  const midTurn = buildHistoryCompactMidTurnPolicy(env, reserveTokens);
   return {
     enabled: true,
     mode: parseHistoryCompactMode(env.MAKA_CONTEXT_HISTORY_COMPACT_MODE),
@@ -214,13 +217,13 @@ function buildHistoryCompactPolicy(
 // though the default is on.
 function buildHistoryCompactMidTurnPolicy(
   env: Record<string, string | undefined>,
+  reserveTokens: number,
 ): NonNullable<NonNullable<ContextBudgetPolicy['historyCompact']>['midTurn']> | undefined {
   const enabled = parseOptionalBoolean(
     env.MAKA_CONTEXT_HISTORY_COMPACT_MID_TURN,
     'MAKA_CONTEXT_HISTORY_COMPACT_MID_TURN',
   );
   if (enabled === false) return undefined;
-  const reserveTokens = parseOptionalPositiveInt(env.MAKA_CONTEXT_HISTORY_COMPACT_RESERVE_TOKENS) ?? 16_384;
   const reserveTailEvents = parseOptionalNonNegativeInt(env.MAKA_CONTEXT_HISTORY_COMPACT_MID_TURN_TAIL_EVENTS);
   return {
     enabled: true,
@@ -313,14 +316,31 @@ function buildSemanticCompactPolicy(
   };
 }
 
+// Single owner of the compaction reserve default. The classic 16384 reserve
+// assumed large-window models; on an 8K window it derived a 1-token history
+// budget and a 1-token mid_turn high water — every multi-step turn ran the
+// summarizer for a checkpoint the replay gate could never admit. The default
+// is therefore bounded by the KNOWN window (a quarter of it, capped at 16384;
+// peers bound the same way: opencode caps its buffer by the model's output
+// limit, gemini-cli triggers at a window fraction). An explicit
+// MAKA_CONTEXT_HISTORY_COMPACT_RESERVE_TOKENS is respected verbatim, and an
+// unknown window keeps the classic constant.
+function defaultCompactReserveTokens(
+  env: Record<string, string | undefined>,
+  contextWindow: number | undefined,
+): number {
+  const explicit = parseOptionalPositiveInt(env.MAKA_CONTEXT_HISTORY_COMPACT_RESERVE_TOKENS);
+  if (explicit !== undefined) return explicit;
+  if (contextWindow === undefined) return 16_384;
+  return Math.min(16_384, Math.max(1, Math.floor(contextWindow / 4)));
+}
+
 function defaultHistoryBudgetTokens(
   connection: LlmConnection,
-  env: Record<string, string | undefined>,
-  modelId: string | undefined,
+  contextWindow: number | undefined,
+  reserveTokens: number,
 ): number | undefined {
-  const contextWindow = resolveSelectedModelContextWindow(connection, modelId);
   if (contextWindow !== undefined) {
-    const reserveTokens = parsePositiveInt(env.MAKA_CONTEXT_HISTORY_COMPACT_RESERVE_TOKENS, 16_384);
     return Math.max(1, contextWindow - reserveTokens);
   }
   if (connection.providerType === 'deepseek') return undefined;

--- a/packages/runtime/src/context-budget-policy.ts
+++ b/packages/runtime/src/context-budget-policy.ts
@@ -242,6 +242,12 @@ function buildHistoryRewriteGatePolicy(
   };
 }
 
+// Semantic compaction is the #981/#986 attention-first experiment, distinct
+// from the standard historyCompact mechanism. It defaults OFF and is opt-in per
+// surface (issue #882 PR 3): an explicit MAKA_CONTEXT_SEMANTIC_COMPACT truthy
+// value, or a MAKA_CONTEXT_SEMANTIC_COMPACT_MODE other than `off`, turns it on.
+// This keeps the experiment out of every surface's default budget without each
+// surface stripping it locally.
 function buildSemanticCompactPolicy(
   env: Record<string, string | undefined>,
   defaultHighWaterName: string,
@@ -250,6 +256,9 @@ function buildSemanticCompactPolicy(
   if (enabled === false) return undefined;
   const mode = parseSemanticCompactMode(env.MAKA_CONTEXT_SEMANTIC_COMPACT_MODE);
   if (mode === 'off') return undefined;
+  // Default off: require an explicit opt-in (the boolean flag or an explicit
+  // non-off mode). Neither present means the experiment stays out of the budget.
+  if (enabled !== true && mode === undefined) return undefined;
   const rejectInvalidSummaries = parseOptionalBoolean(
     env.MAKA_CONTEXT_SEMANTIC_COMPACT_REJECT_INVALID_SUMMARIES,
     'MAKA_CONTEXT_SEMANTIC_COMPACT_REJECT_INVALID_SUMMARIES',

--- a/packages/runtime/src/context-budget-policy.ts
+++ b/packages/runtime/src/context-budget-policy.ts
@@ -203,9 +203,15 @@ function buildHistoryCompactPolicy(
   };
 }
 
-// Mid-turn capacity compaction defaults OFF this PR: only an explicit
-// MAKA_CONTEXT_HISTORY_COMPACT_MID_TURN=on opts in, so a standalone revert of
-// this line leaves every surface's behavior unchanged. PR 3 sinks the default on.
+// Mid-turn capacity compaction is a runtime-owned default (issue #882 PR 3):
+// whenever history compaction is enabled, the runtime derives midTurn from the
+// selected model's window (`contextWindow - reserveTokens`, the same reserve as
+// the turn-boundary budget) so every surface inherits the invariant without
+// copying config. `MAKA_CONTEXT_HISTORY_COMPACT_MID_TURN=off` stays as the
+// explicit escape hatch. The backend still gates activation on the checkpoint
+// seams, the persisted head anchor, and a KNOWN context window, so a session
+// without model metadata (or a child with no anchor seam) never misfires even
+// though the default is on.
 function buildHistoryCompactMidTurnPolicy(
   env: Record<string, string | undefined>,
 ): NonNullable<NonNullable<ContextBudgetPolicy['historyCompact']>['midTurn']> | undefined {
@@ -213,7 +219,7 @@ function buildHistoryCompactMidTurnPolicy(
     env.MAKA_CONTEXT_HISTORY_COMPACT_MID_TURN,
     'MAKA_CONTEXT_HISTORY_COMPACT_MID_TURN',
   );
-  if (enabled !== true) return undefined;
+  if (enabled === false) return undefined;
   const reserveTokens = parseOptionalPositiveInt(env.MAKA_CONTEXT_HISTORY_COMPACT_RESERVE_TOKENS) ?? 16_384;
   const reserveTailEvents = parseOptionalNonNegativeInt(env.MAKA_CONTEXT_HISTORY_COMPACT_MID_TURN_TAIL_EVENTS);
   return {

--- a/packages/runtime/src/context-budget.ts
+++ b/packages/runtime/src/context-budget.ts
@@ -308,9 +308,12 @@ export interface HistoryCompactPolicy {
   highWaterName?: string;
   /**
    * Optional mid-turn capacity compaction, layered on the same V2 checkpoint
-   * protocol. Defaults off (explicit opt-in this PR); when enabled the backend
-   * measures the next provider request between steps and folds a safe completed
-   * prefix before crossing the model context window.
+   * protocol. Omitting the field in a handwritten policy leaves it off; the
+   * shared runtime default (buildDefaultContextBudgetPolicy) enables it
+   * whenever history compaction is on, unless MAKA_CONTEXT_HISTORY_COMPACT_MID_TURN
+   * opts out. When enabled the backend measures the next provider request
+   * between steps and folds a safe completed prefix before crossing the model
+   * context window.
    */
   midTurn?: HistoryCompactMidTurnPolicy;
 }
@@ -319,8 +322,9 @@ export interface HistoryCompactMidTurnPolicy {
   enabled: boolean;
   /**
    * Tokens kept free below the selected model context window. The proactive
-   * high-water threshold is `contextWindow - reserveTokens`. Defaults to the
-   * shared history-compact reserve (16384).
+   * high-water threshold is `contextWindow - reserveTokens`. Defaults to 16384
+   * when omitted in a handwritten policy; the shared runtime default always
+   * supplies a window-bounded value.
    */
   reserveTokens?: number;
   /** Trailing events kept verbatim as the continuation tail. Defaults to 1. */


### PR DESCRIPTION
## Summary

Refs #882 (PR 3 of 3, per the split in https://github.com/maka-agent/maka-agent/issues/882#issuecomment-4971348873; #996 landed the proactive machinery, #1017 the reactive recovery).

Context-budget defaults were owned per surface: the CLI carried its own policy builder, desktop shipped semantic compaction on by default while the CLI required an opt-in, and mid-turn capacity compaction was dark everywhere. This PR sinks the defaults into the runtime's `buildDefaultContextBudgetPolicy` so every surface ships the same behavior:

- **Mid-turn capacity compaction defaults ON** whenever history compaction is enabled (`MAKA_CONTEXT_HISTORY_COMPACT_MID_TURN=off` opts out).
- **Semantic compaction defaults OFF** (`MAKA_CONTEXT_SEMANTIC_COMPACT=on` opts in) — the runtime default is the owner, so desktop's previous on-by-default flips without a desktop change.
- **The compaction reserve is derived, window-bounded, with a single owner** (`defaultCompactReserveTokens`): `min(16384, window/4)`, feeding both the turn-boundary history budget and the mid-turn high water. This also fixes a pre-existing pathology on main: the flat 16384 reserve on an 8K-window model derived `maxHistoryEstimatedTokens = 1`, and with mid-turn on it would have run the summarizer every multi-step turn for a checkpoint the replay gate could never admit. On an 8K model the default is now completely inert below the high water — never a pointless summarizer call. ≥64K windows are byte-identical to before; an explicit `MAKA_CONTEXT_HISTORY_COMPACT_RESERVE_TOKENS` is respected verbatim; an unknown window keeps the classic constants. Peers bound the same way (opencode caps its buffer by the model's output limit, gemini-cli triggers at a window fraction).
- **The CLI deletes its local policy builder** and consumes the shared derivation; **headless keeps explicit per-field policies** and never engages history compaction, so benchmark runs stay deterministic.

## Verification

- `npm --workspace @maka/runtime test`: 1936 tests, 0 fail (7 pre-existing skips). New coverage: policy derivation matrix (8K → 2048/6144, ≥64K unchanged, unknown window, explicit override), semantic-compact default-off policy tests, a small-window guard (default never runs a pointless summarizer on an 8K model), and a shipped-defaults journey with no env overrides — a long turn under the derived default persists a `mid_turn` checkpoint, the continued request carries the compact block without the replaced raw span, the anchor stays verbatim, and the unrescuable path ends with the explicit `context_budget_exhausted` outcome.
- CLI (359, locking the deleted builder's env behaviors against the shared derivation) and desktop (2542) suites, repo-wide `npm run typecheck` and `npm run build`: clean.
- External review: 2 codex review rounds. Round 1 found the small-window degradation (fixed at the single derivation owner, red-first) and asked for the journey's durable-persistence assertions; round 2 confirmed both closed and passed with one comment-drift note, fixed in the last commit.
- Not run: a Playwright E2E for the default flip — deliberately. The desktop E2E fake backend bypasses `prepareStep`, so a renderer-level test would fake the machinery under test; the runtime-level journey with the real shipped policy is the honest seam. A reactive-path (provider overflow) cross-surface E2E needs a real-backend harness and is tracked as follow-up in #882.

## Review focus

`buildDefaultContextBudgetPolicy` is the single owner of shipped context-budget defaults: surfaces consume it and may only override with explicit user-facing configuration. If a surface needs different behavior, the knob belongs in the shared derivation, not in a surface-local builder.
