### PR TITLE
fix(desktop): 修复命令面板关闭按钮布局与点击

### DIFF
--- a/apps/desktop/e2e/command-palette.spec.ts
+++ b/apps/desktop/e2e/command-palette.spec.ts
@@ -1,0 +1,38 @@
+import { test, expect } from './fixtures';
+import type { Locator } from '@playwright/test';
+
+async function expectPaletteHeaderGeometry(dialog: Locator): Promise<void> {
+  const searchInput = dialog.getByRole('combobox', { name: '搜索命令、设置项或会话' });
+  const closeButton = dialog.getByRole('button', { name: '关闭命令面板' });
+  const [inputBox, closeBox, paddingLeft] = await Promise.all([
+    searchInput.boundingBox(),
+    closeButton.boundingBox(),
+    searchInput.evaluate((element) => Number.parseFloat(getComputedStyle(element).paddingLeft)),
+  ]);
+  if (!inputBox || !closeBox) throw new Error('Command palette header controls must have rendered bounds');
+
+  const gap = closeBox.x - (inputBox.x + inputBox.width);
+  expect(gap).toBeGreaterThanOrEqual(8);
+  expect(paddingLeft).toBeGreaterThanOrEqual(10);
+}
+
+test('command palette header geometry and dismissal stay intact', async ({ window: page }) => {
+  const openButton = page.getByRole('button', { name: '打开命令面板' });
+  const dialog = page.getByRole('dialog', { name: '命令面板' });
+
+  await openButton.click();
+  await expect(dialog).toBeVisible();
+  await expectPaletteHeaderGeometry(dialog);
+
+  await page.setViewportSize({ width: 520, height: 700 });
+  await expect(dialog).toBeVisible();
+  await expectPaletteHeaderGeometry(dialog);
+
+  await dialog.getByRole('button', { name: '关闭命令面板' }).click();
+  await expect(dialog).toBeHidden();
+
+  await openButton.click();
+  await expect(dialog).toBeVisible();
+  await page.keyboard.press('Escape');
+  await expect(dialog).toBeHidden();
+});

--- a/apps/desktop/src/main/__tests__/command-palette-a11y-copy-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/command-palette-a11y-copy-contract.test.ts
@@ -104,14 +104,34 @@ describe('Command palette accessibility and visible copy', () => {
     );
     assert.match(
       inputWrapStyle,
-      /margin:\s*var\(--space-2\)\s*var\(--space-2-5\);/,
-      'Palette InputGroup should preserve the compact command-modal inset spacing',
+      /width:\s*100%;/,
+      'Palette InputGroup should fill the search column while the header owns outer spacing',
     );
     assert.doesNotMatch(
       styles,
       /maka-palette-input-hint/,
       'Input-addon hint CSS must stay deleted along with the duplicated hint markup',
     );
+  });
+
+  it('keeps the close action beside the input group so the search shell cannot cover its hit target', async () => {
+    const src = await readRepo('apps/desktop/src/renderer/command-palette.tsx');
+    const styles = await readRendererContractCss();
+    const headerStyle = styles.match(/\.maka-palette-header\s*\{[\s\S]*?\}/)?.[0] ?? '';
+    const inputStyle = styles.match(/\.maka-palette-input\s*\{[\s\S]*?\}/)?.[0] ?? '';
+    assert.match(
+      src,
+      /<DialogContent[\s\S]*?showClose=\{false\}/,
+      'the palette must disable DialogContent\'s absolute close button',
+    );
+    assert.match(
+      src,
+      /<div className="maka-palette-header">[\s\S]*?<InputGroup[\s\S]*?<\/InputGroup>[\s\S]*?<Button[\s\S]*?aria-label="关闭命令面板"[\s\S]*?onClick=\{props\.onClose\}[\s\S]*?<X aria-hidden="true" \/>[\s\S]*?<\/Button>[\s\S]*?<\/div>/,
+      'the close button must be a sibling immediately to the right of the input group',
+    );
+    assert.match(headerStyle, /grid-template-columns:\s*minmax\(0, 1fr\) var\(--h-control-md\);/);
+    assert.match(headerStyle, /gap:\s*var\(--space-2\);/);
+    assert.match(inputStyle, /padding-inline:\s*var\(--space-2-5\);/);
   });
 
   it('keeps command palette chrome compact, non-selectable, and tactile without blocking text entry', async () => {

--- a/apps/desktop/src/main/__tests__/renderer-utility-primitives-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/renderer-utility-primitives-contract.test.ts
@@ -121,9 +121,14 @@ describe('renderer utility surfaces use shared UI primitives', () => {
     assert.doesNotMatch(source, /<kbd\b/, 'Command palette shortcut glyphs must use shared primitive Kbd');
     assert.match(source, /<InputGroup[\s\S]*className="maka-palette-input-wrap"[\s\S]*aria-label="命令面板搜索"[\s\S]*onMouseDown=\{\(event\) => \{/);
     assert.match(source, /<InputGroupInput[\s\S]*className="maka-palette-input"/);
-    // Detail round 6: shortcut hints live in the palette footer only; the
-    // former inline-end addon duplicated ↵/Esc next to the input.
-    assert.doesNotMatch(source, /<InputGroupAddon\b/, 'Palette input must not regrow the duplicated shortcut-hint addon');
+    // Shortcut hints stay in the footer, and the close action stays outside
+    // the search InputGroup so neither can cover the other's hit target.
+    assert.doesNotMatch(source, /<InputGroupAddon\b/, 'Palette input must not regrow an inline addon');
+    assert.match(
+      source,
+      /<div className="maka-palette-header">[\s\S]*?<InputGroup[\s\S]*?<\/InputGroup>[\s\S]*?aria-label="关闭命令面板"/,
+      'Palette header must place the close action after the search InputGroup',
+    );
     assert.match(source, /<Autocomplete.Item[\s\S]*className="maka-palette-item"/, 'Command palette rows must be Autocomplete.Item (#520 PR8)');
     assert.match(source, /<KbdGroup className="maka-shortcut-group">[\s\S]*<Kbd className="maka-shortcut-kbd">↑<\/Kbd>[\s\S]*<Kbd className="maka-shortcut-kbd">↓<\/Kbd>/);
   });

--- a/apps/desktop/src/renderer/command-palette.tsx
+++ b/apps/desktop/src/renderer/command-palette.tsx
@@ -29,11 +29,13 @@ import {
   Sun,
   SunMoon,
   Wifi,
+  X,
   type LucideIcon,
 } from '@maka/ui/icons';
 import type { LlmConnection, PermissionMode, SessionSummary, SettingsSection, ThemePreference } from '@maka/core';
 import type { NavSelection } from '@maka/ui';
 import {
+  Button,
   DialogContent,
   DialogRoot,
   Empty,
@@ -667,6 +669,7 @@ export function CommandPalette(props: {
         className="maka-modal maka-palette-modal top-[12vh] -translate-y-0"
         aria-label="命令面板"
         initialFocus={inputRef}
+        showClose={false}
       >
         {/*
           #520 PR8: Autocomplete owns the listbox/option ARIA + ArrowUp/Down/
@@ -693,30 +696,41 @@ export function CommandPalette(props: {
           itemToStringValue={(cmd) => cmd.label}
           items={combined}
         >
-          <InputGroup
-            className="maka-palette-input-wrap"
-            aria-label="命令面板搜索"
-            onMouseDown={(event) => {
-              const target = event.target as HTMLElement;
-              if (target.closest('input')) return;
-              event.preventDefault();
-              inputRef.current?.focus();
-            }}
-          >
-            <Autocomplete.Input
-              render={
-                <InputGroupInput
-                  ref={inputRef}
-                  className="maka-palette-input"
-                  type="text"
-                  placeholder="搜索命令、设置项或会话…"
-                  aria-label="搜索命令、设置项或会话"
-                  autoComplete="off"
-                  spellCheck={false}
-                />
-              }
-            />
-          </InputGroup>
+          <div className="maka-palette-header">
+            <InputGroup
+              className="maka-palette-input-wrap"
+              aria-label="命令面板搜索"
+              onMouseDown={(event) => {
+                const target = event.target as HTMLElement;
+                if (target.closest('input')) return;
+                event.preventDefault();
+                inputRef.current?.focus();
+              }}
+            >
+              <Autocomplete.Input
+                render={
+                  <InputGroupInput
+                    ref={inputRef}
+                    className="maka-palette-input"
+                    type="text"
+                    placeholder="搜索命令、设置项或会话…"
+                    aria-label="搜索命令、设置项或会话"
+                    autoComplete="off"
+                    spellCheck={false}
+                  />
+                }
+              />
+            </InputGroup>
+            <Button
+              type="button"
+              variant="quiet"
+              size="icon-sm"
+              aria-label="关闭命令面板"
+              onClick={props.onClose}
+            >
+              <X aria-hidden="true" />
+            </Button>
+          </div>
           <Autocomplete.List className="maka-palette-list" id="maka-palette-list" aria-label="命令面板结果">
             {grouped.length === 0 ? (
               <Empty className="maka-palette-empty py-8 md:py-10 gap-3">

--- a/apps/desktop/src/renderer/styles/palette.css
+++ b/apps/desktop/src/renderer/styles/palette.css
@@ -21,6 +21,7 @@
 }
 
 .maka-palette-modal,
+.maka-palette-header,
 .maka-palette-list,
 .maka-palette-group-label,
 .maka-palette-item,
@@ -30,10 +31,17 @@
   user-select: none;
 }
 
+.maka-palette-header {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) var(--h-control-md);
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-2) var(--space-2-5);
+}
+
 .maka-palette-input-wrap {
-  width: auto;
+  width: 100%;
   min-height: var(--h-control-lg);
-  margin: var(--space-2) var(--space-2-5);
   /* Concentric radius formula: inner radius = outer
      radius − inset. Modal shell is 12px with an 8px inset, so the
      input's 6px control radius read "too round" against the shell
@@ -57,6 +65,7 @@
 }
 
 .maka-palette-input {
+  padding-inline: var(--space-2-5);
   color: var(--foreground);
   font-size: var(--font-size-ui);
   line-height: var(--leading-snug);


### PR DESCRIPTION
## Summary

- 将关闭按钮放到搜索框右侧，并移除弹窗默认关闭按钮
- 增加搜索框内边距，修复提示文字贴近左边框的问题
- 保持鼠标点击关闭和 Escape 关闭行为，并补充桌面与窄窗口 E2E 覆盖

## Testing

- npm --workspace @maka/desktop test
- npm --workspace @maka/desktop run build
- npx playwright test command-palette.spec.ts --config e2e/playwright.config.ts
- git diff --check

Related to #883