### PR TITLE
fix: settle Harbor cells before hard timeout

### DIFF
--- a/packages/core/src/backend-types.ts
+++ b/packages/core/src/backend-types.ts
@@ -55,12 +55,14 @@ export interface BackendCompactHistoryResult {
   contextBudget?: ContextBudgetDiagnostic;
 }
 
+export type BackendStopMode = 'immediate' | 'after_step';
+
 export interface AgentBackend {
   readonly kind: BackendKind;
   readonly sessionId: string;
   send(input: BackendSendInput): AsyncIterable<SessionEvent>;
   compactHistory?(input: BackendCompactHistoryInput): Promise<BackendCompactHistoryResult>;
-  stop(reason: 'user_stop' | 'redirect'): Promise<void>;
+  stop(reason: 'user_stop' | 'redirect', mode?: BackendStopMode): Promise<void>;
   respondToPermission(decision: PermissionDecision): Promise<void>;
   respondToUserQuestion?(response: UserQuestionResponse): Promise<void>;
   dispose(): Promise<void>;

--- a/packages/headless/harbor/maka_agent.py
+++ b/packages/headless/harbor/maka_agent.py
@@ -202,6 +202,7 @@ class MakaAgent(BaseInstalledAgent):
         return (Path(maka_repo) / "packages" / "headless" / "harbor" / "run-host-cell.mjs").as_posix()
 
     _DEFAULT_CELL_TIMEOUT_SEC = 900
+    _DEFAULT_CELL_SETTLEMENT_GRACE_SEC = 30
 
     def _cell_timeout_sec(self) -> int:
         """Wall-clock budget for the in-container cell. A hard-coded value turns
@@ -215,6 +216,25 @@ class MakaAgent(BaseInstalledAgent):
         except (TypeError, ValueError):
             return self._DEFAULT_CELL_TIMEOUT_SEC
         return value if value > 0 else self._DEFAULT_CELL_TIMEOUT_SEC
+
+    def _cell_settlement_grace_sec(self) -> int:
+        raw = self._get_env("MAKA_CELL_SETTLEMENT_GRACE_SEC")
+        if not raw:
+            return self._DEFAULT_CELL_SETTLEMENT_GRACE_SEC
+        try:
+            value = int(raw)
+        except (TypeError, ValueError):
+            return self._DEFAULT_CELL_SETTLEMENT_GRACE_SEC
+        return value if value > 0 else self._DEFAULT_CELL_SETTLEMENT_GRACE_SEC
+
+    def _cell_soft_timeout_ms(self) -> int:
+        timeout_sec = self._cell_timeout_sec()
+        grace_sec = self._cell_settlement_grace_sec()
+        if grace_sec >= timeout_sec:
+            raise RuntimeError(
+                "MAKA_CELL_SETTLEMENT_GRACE_SEC must be smaller than MAKA_CELL_TIMEOUT_SEC"
+            )
+        return (timeout_sec - grace_sec) * 1000
 
     def _host_side_llm_enabled(self) -> bool:
         return bool(
@@ -253,6 +273,8 @@ class MakaAgent(BaseInstalledAgent):
                     raise RuntimeError(f"Maka host cell exceeded {self._cell_timeout_sec()}s") from error
                 raise
             run_log_path.write_bytes(stdout + stderr)
+            if process.returncode == 124:
+                raise RuntimeError(f"Maka host cell exceeded {self._cell_timeout_sec()}s")
             if process.returncode != 0:
                 message = (stderr or stdout).decode("utf-8", errors="replace").strip()
                 raise RuntimeError(f"Maka host cell exited {process.returncode}: {message}")
@@ -270,6 +292,7 @@ class MakaAgent(BaseInstalledAgent):
         env["MAKA_WORKDIR"] = container_cwd
         env["MAKA_HARBOR_TOOL_EXECUTOR_URL"] = executor.url
         env["MAKA_HARBOR_TOOL_EXECUTOR_TOKEN"] = executor.token
+        env["MAKA_CELL_SOFT_TIMEOUT_MS"] = str(self._cell_soft_timeout_ms())
         for key in ("MAKA_HOST_API_KEY", "MAKA_HOST_API_KEY_FILE", "MAKA_HOST_API_KEY_ENV_NAME", "MAKA_HOST_BASE_URL"):
             value = self._get_env(key)
             if value:

--- a/packages/headless/harbor/run-host-cell.mjs
+++ b/packages/headless/harbor/run-host-cell.mjs
@@ -10,6 +10,7 @@ import {
   buildHarborCellContinuationPolicy,
   buildHarborCellTaskLedgerExperimentPolicy,
   harborCellMaxStepsFromEnv,
+  harborCellSoftTimeoutMsFromEnv,
   normalizeHarborCellContextEnv,
   providerApiKeyEnvName,
   reasoningEffortFromEnv,
@@ -42,6 +43,7 @@ export async function main(options = {}) {
   const economyTaskMode = economyTaskModeFromEnv(env.MAKA_ECONOMY_TASK_MODE);
   const taskLedgerExperimentPolicy = buildHarborCellTaskLedgerExperimentPolicy(env);
   const maxSteps = harborCellMaxStepsFromEnv(env);
+  const settleAfterMs = harborCellSoftTimeoutMsFromEnv(env);
   const reasoningEffort = reasoningEffortFromEnv(env.MAKA_REASONING_EFFORT);
   const now = Date.now;
   const newId = randomId;
@@ -64,6 +66,7 @@ export async function main(options = {}) {
     ...(contextBudgetPolicy ? { contextBudgetPolicy } : {}),
     ...(continuationPolicy ? { continuationPolicy } : {}),
     ...(taskLedgerExperimentPolicy ? { taskToolSummaryEnabled: true } : {}),
+    ...(settleAfterMs !== undefined ? { settleAfterMs } : {}),
     registerBackends: options.registerBackends ?? buildAiSdkCellBackendRegistration({
       provider,
       model,
@@ -87,7 +90,9 @@ export async function main(options = {}) {
     errorClass: result.output.errorClass,
     outputPath: result.outputPath,
     runtimeEventsPath: result.runtimeEventsPath,
+    settledByDeadline: result.settledByDeadline,
   }));
+  return result;
 }
 
 function economyTaskModeFromEnv(value) {
@@ -174,10 +179,18 @@ function randomId() {
   return globalThis.crypto?.randomUUID?.() ?? `host_cell_${Date.now().toString(36)}_${Math.random().toString(36).slice(2)}`;
 }
 
+export function hostCellExitCode(result) {
+  return result.settledByDeadline ? 124 : 0;
+}
+
 if (process.argv[1] && pathToFileURL(process.argv[1]).href === import.meta.url) {
-  main().catch((error) => {
-    const message = error instanceof Error ? error.message : String(error);
-    console.error(`maka run-host-cell failed: ${message}`);
-    process.exitCode = 1;
-  });
+  main()
+    .then((result) => {
+      process.exitCode = hostCellExitCode(result);
+    })
+    .catch((error) => {
+      const message = error instanceof Error ? error.message : String(error);
+      console.error(`maka run-host-cell failed: ${message}`);
+      process.exitCode = 1;
+    });
 }

--- a/packages/headless/src/__tests__/harbor-adapter.test.ts
+++ b/packages/headless/src/__tests__/harbor-adapter.test.ts
@@ -61,7 +61,10 @@ describe('Harbor adapter contract', () => {
     assert.match(source, /Maka cell output is not valid JSON/);
     assert.match(source, /_read_cell_output\(required=True\)/);
     assert.match(source, /MAKA_CELL_TIMEOUT_SEC/);
+    assert.match(source, /MAKA_CELL_SETTLEMENT_GRACE_SEC/);
+    assert.match(source, /MAKA_CELL_SOFT_TIMEOUT_MS/);
     assert.match(source, /timeout_sec=self\._cell_timeout_sec\(\)/);
+    assert.match(source, /process\.returncode == 124/);
     assert.match(source, /deepseek\/deepseek-v4-flash/);
     assert.doesNotMatch(source, /deepseek\/deepseek-chat/);
     assert.match(source, /economy_task_flag = self\._resolved_flags\.get\("economy_task_mode"\)/);
@@ -1169,6 +1172,20 @@ with tempfile.TemporaryDirectory() as tmp:
     assert MakaAgent(Path(tmp), extra_env={"MAKA_CELL_TIMEOUT_SEC": "1800"})._cell_timeout_sec() == 1800
     assert MakaAgent(Path(tmp), extra_env={"MAKA_CELL_TIMEOUT_SEC": "oops"})._cell_timeout_sec() == 900
     assert MakaAgent(Path(tmp), extra_env={"MAKA_CELL_TIMEOUT_SEC": "0"})._cell_timeout_sec() == 900
+    assert MakaAgent(Path(tmp))._cell_soft_timeout_ms() == 870000
+    assert MakaAgent(Path(tmp), extra_env={
+        "MAKA_CELL_TIMEOUT_SEC": "1800",
+        "MAKA_CELL_SETTLEMENT_GRACE_SEC": "60",
+    })._cell_soft_timeout_ms() == 1740000
+
+    host_deadline_env = MakaAgent(Path(tmp), extra_env={
+        "MAKA_BACKEND": "fake",
+        "MAKA_HOST_NO_AUTH": "true",
+    })._host_cell_env(Path("/tmp/instruction.txt"), "/workspace", types.SimpleNamespace(
+        url="http://127.0.0.1:1",
+        token="test-token",
+    ))
+    assert host_deadline_env["MAKA_CELL_SOFT_TIMEOUT_MS"] == "870000", host_deadline_env
 
     # The default model must not be the deprecated deepseek-chat alias.
     default_model_env = MakaAgent(Path(tmp), extra_env={"MAKA_HOST_API_KEY_FILE": "/host/deepseek-key"})._cell_env(Path("/logs/agent/instruction.txt"))

--- a/packages/headless/src/__tests__/harbor-cell.test.ts
+++ b/packages/headless/src/__tests__/harbor-cell.test.ts
@@ -5,7 +5,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, test } from 'node:test';
 import type { BackendKind, LlmConnection, SessionEvent, SessionHeader } from '@maka/core';
-import type { BackendSendInput, PermissionDecision } from '@maka/core/backend-types';
+import type { BackendSendInput, BackendStopMode, PermissionDecision } from '@maka/core/backend-types';
 import {
   BackendRegistry,
   PermissionEngine,
@@ -123,6 +123,7 @@ const registerThrowingBackend = (registry: BackendRegistry): void => {
 
 class DeadlineSettlingBackend implements AgentBackend {
   readonly sessionId: string;
+  readonly stopModes: BackendStopMode[] = [];
   private releaseStop!: () => void;
   private readonly stopped = new Promise<void>((resolve) => {
     this.releaseStop = resolve;
@@ -133,6 +134,7 @@ class DeadlineSettlingBackend implements AgentBackend {
   }
 
   async *send(input: BackendSendInput): AsyncIterable<SessionEvent> {
+    await this.stopped;
     const ts = Date.now();
     yield {
       type: 'token_usage',
@@ -144,17 +146,17 @@ class DeadlineSettlingBackend implements AgentBackend {
       total: 18,
       costUsd: 0.004,
     };
-    await this.stopped;
     yield {
-      type: 'abort',
-      id: 'deadline-abort',
+      type: 'complete',
+      id: 'deadline-complete',
       turnId: input.turnId,
       ts: Date.now(),
-      reason: 'user_stop',
+      stopReason: 'end_turn',
     };
   }
 
-  async stop(): Promise<void> {
+  async stop(_reason: 'user_stop' | 'redirect', mode: BackendStopMode = 'immediate'): Promise<void> {
+    this.stopModes.push(mode);
     this.releaseStop();
   }
 
@@ -212,6 +214,41 @@ class StepCapThenCompleteBackend implements AgentBackend {
   async stop(): Promise<void> {}
   async respondToPermission(_decision: PermissionDecision): Promise<void> {}
   async dispose(): Promise<void> {}
+}
+
+class DeadlineStepCapBackend extends StepCapThenCompleteBackend {
+  private releaseStop!: () => void;
+  private readonly stopped = new Promise<void>((resolve) => {
+    this.releaseStop = resolve;
+  });
+
+  override async *send(input: BackendSendInput): AsyncIterable<SessionEvent> {
+    if (this.prompts.length > 0) {
+      yield* super.send(input);
+      return;
+    }
+    this.prompts.push(input.text);
+    this.cwds.push(this.ctx.header.cwd);
+    await this.stopped;
+    const ts = Date.now();
+    yield {
+      type: 'token_usage',
+      id: 'usage-deadline-step-cap',
+      turnId: input.turnId,
+      ts,
+      input: 10,
+      output: 1,
+      total: 11,
+      costUsd: 0.01,
+      rawFinishReason: 'tool-calls',
+      runtimeSteps: 50,
+    };
+    yield { type: 'complete', id: 'complete-deadline-step-cap', turnId: input.turnId, ts, stopReason: 'end_turn' };
+  }
+
+  override async stop(): Promise<void> {
+    this.releaseStop();
+  }
 }
 
 function registerStepCapThenCompleteBackend(seen: { backend?: StepCapThenCompleteBackend }) {
@@ -476,6 +513,7 @@ describe('runHarborCell', () => {
   test('settles the active session before its hard deadline and writes final usage', async () => {
     await withDirs(async ({ workspaceDir, outputDir, storageRoot }) => {
       const deadline = { settleAfterMs: 1_000 };
+      let backend: DeadlineSettlingBackend | undefined;
       const result = await withTimeout(runHarborCell({
         config,
         instruction: 'keep working until stopped',
@@ -484,16 +522,49 @@ describe('runHarborCell', () => {
         storageRoot,
         ...deadline,
         registerBackends: (registry) => {
-          registry.register('fake', (ctx) => new DeadlineSettlingBackend(ctx.sessionId));
+          registry.register('fake', (ctx) => {
+            backend = new DeadlineSettlingBackend(ctx.sessionId);
+            return backend;
+          });
         },
       }), 10_000, 'Harbor cell did not settle before the hard deadline');
 
       assert.equal(result.settledByDeadline, true);
+      assert.deepEqual(backend?.stopModes, ['after_step']);
       assert.equal(result.output.tokenSummary?.total, 18);
       assert.deepEqual(
         JSON.parse(await readFile(join(outputDir, HARBOR_CELL_OUTPUT_FILENAME), 'utf8')),
         result.output,
       );
+    });
+  });
+
+  test('does not start a continuation turn after the settlement deadline latches', async () => {
+    await withDirs(async ({ workspaceDir, outputDir, storageRoot }) => {
+      let backend: DeadlineStepCapBackend | undefined;
+      const result = await withTimeout(runHarborCell({
+        config,
+        instruction: 'stop at the deadline',
+        cwd: workspaceDir,
+        outputDir,
+        storageRoot,
+        settleAfterMs: 25,
+        continuationPolicy: {
+          enabled: true,
+          maxTurns: 2,
+          maxTotalRuntimeSteps: 100,
+          prompt: 'continue after the deadline',
+        },
+        registerBackends: (registry) => {
+          registry.register('fake', (ctx) => {
+            backend = new DeadlineStepCapBackend({ sessionId: ctx.sessionId, header: ctx.header });
+            return backend;
+          });
+        },
+      }), 5_000, 'Harbor cell did not settle its capped turn');
+
+      assert.equal(result.settledByDeadline, true);
+      assert.deepEqual(backend?.prompts, ['stop at the deadline']);
     });
   });
 

--- a/packages/headless/src/__tests__/harbor-cell.test.ts
+++ b/packages/headless/src/__tests__/harbor-cell.test.ts
@@ -164,6 +164,44 @@ class DeadlineSettlingBackend implements AgentBackend {
   async dispose(): Promise<void> {}
 }
 
+class TerminalClaimBeforeDeadlineBackend implements AgentBackend {
+  readonly kind = 'fake' as const;
+  readonly sessionId: string;
+  stopCalls = 0;
+
+  constructor(sessionId: string) {
+    this.sessionId = sessionId;
+  }
+
+  async *send(input: BackendSendInput): AsyncIterable<SessionEvent> {
+    yield {
+      type: 'token_usage',
+      id: 'usage-before-normal-completion',
+      turnId: input.turnId,
+      ts: Date.now(),
+      input: 2,
+      output: 1,
+      total: 3,
+      costUsd: 0.001,
+    };
+    yield {
+      type: 'complete',
+      id: 'completed-before-deadline',
+      turnId: input.turnId,
+      ts: Date.now(),
+      stopReason: 'end_turn',
+    };
+    await new Promise((resolve) => setTimeout(resolve, 1_100));
+  }
+
+  async stop(): Promise<void> {
+    this.stopCalls += 1;
+  }
+
+  async respondToPermission(_decision: PermissionDecision): Promise<void> {}
+  async dispose(): Promise<void> {}
+}
+
 class StepCapThenCompleteBackend implements AgentBackend {
   readonly kind: BackendKind = 'fake';
   readonly sessionId: string;
@@ -536,6 +574,29 @@ describe('runHarborCell', () => {
         JSON.parse(await readFile(join(outputDir, HARBOR_CELL_OUTPUT_FILENAME), 'utf8')),
         result.output,
       );
+    });
+  });
+
+  test('does not report deadline settlement after normal completion already claimed the terminal state', async () => {
+    await withDirs(async ({ workspaceDir, outputDir, storageRoot }) => {
+      let backend: TerminalClaimBeforeDeadlineBackend | undefined;
+      const result = await runHarborCell({
+        config,
+        instruction: 'finish before the deadline',
+        cwd: workspaceDir,
+        outputDir,
+        storageRoot,
+        settleAfterMs: 1_000,
+        registerBackends: (registry) => {
+          registry.register('fake', (ctx) => {
+            backend = new TerminalClaimBeforeDeadlineBackend(ctx.sessionId);
+            return backend;
+          });
+        },
+      });
+
+      assert.equal(result.settledByDeadline, false);
+      assert.equal(backend?.stopCalls, 0);
     });
   });
 

--- a/packages/headless/src/__tests__/harbor-cell.test.ts
+++ b/packages/headless/src/__tests__/harbor-cell.test.ts
@@ -121,6 +121,47 @@ const registerThrowingBackend = (registry: BackendRegistry): void => {
   registry.register('fake', (ctx) => new ThrowingBackend({ sessionId: ctx.sessionId }));
 };
 
+class DeadlineSettlingBackend implements AgentBackend {
+  readonly sessionId: string;
+  private releaseStop!: () => void;
+  private readonly stopped = new Promise<void>((resolve) => {
+    this.releaseStop = resolve;
+  });
+
+  constructor(sessionId: string, readonly kind: BackendKind = 'fake') {
+    this.sessionId = sessionId;
+  }
+
+  async *send(input: BackendSendInput): AsyncIterable<SessionEvent> {
+    const ts = Date.now();
+    yield {
+      type: 'token_usage',
+      id: 'usage-before-deadline',
+      turnId: input.turnId,
+      ts,
+      input: 13,
+      output: 5,
+      total: 18,
+      costUsd: 0.004,
+    };
+    await this.stopped;
+    yield {
+      type: 'abort',
+      id: 'deadline-abort',
+      turnId: input.turnId,
+      ts: Date.now(),
+      reason: 'user_stop',
+    };
+  }
+
+  async stop(): Promise<void> {
+    this.releaseStop();
+  }
+
+  async respondToPermission(_decision: PermissionDecision): Promise<void> {}
+  async dispose(): Promise<void> {}
+}
+
 class StepCapThenCompleteBackend implements AgentBackend {
   readonly kind: BackendKind = 'fake';
   readonly sessionId: string;
@@ -432,6 +473,30 @@ describe('runHarborCell', () => {
     });
   });
 
+  test('settles the active session before its hard deadline and writes final usage', async () => {
+    await withDirs(async ({ workspaceDir, outputDir, storageRoot }) => {
+      const deadline = { settleAfterMs: 1_000 };
+      const result = await withTimeout(runHarborCell({
+        config,
+        instruction: 'keep working until stopped',
+        cwd: workspaceDir,
+        outputDir,
+        storageRoot,
+        ...deadline,
+        registerBackends: (registry) => {
+          registry.register('fake', (ctx) => new DeadlineSettlingBackend(ctx.sessionId));
+        },
+      }), 10_000, 'Harbor cell did not settle before the hard deadline');
+
+      assert.equal(result.settledByDeadline, true);
+      assert.equal(result.output.tokenSummary?.total, 18);
+      assert.deepEqual(
+        JSON.parse(await readFile(join(outputDir, HARBOR_CELL_OUTPUT_FILENAME), 'utf8')),
+        result.output,
+      );
+    });
+  });
+
   test('writes execution identity before the first model call', async () => {
     await withDirs(async ({ workspaceDir, outputDir, storageRoot }) => {
       let observedIdentity: unknown;
@@ -505,6 +570,27 @@ describe('runHarborCell', () => {
         JSON.parse(await readFile(join(outputDir, HARBOR_CELL_OUTPUT_FILENAME), 'utf8')),
         result.output,
       );
+    });
+  });
+
+  test('env entrypoint settles at the configured soft deadline', async () => {
+    await withDirs(async ({ workspaceDir, outputDir, storageRoot }) => {
+      const result = await withTimeout(runHarborCellFromEnv({
+        MAKA_BACKEND: 'fake',
+        MAKA_INSTRUCTION: 'keep working until stopped',
+        MAKA_MODEL: 'fake-model',
+        MAKA_WORKDIR: workspaceDir,
+        MAKA_OUTPUT_DIR: outputDir,
+        MAKA_STORAGE_ROOT: storageRoot,
+        MAKA_CELL_SOFT_TIMEOUT_MS: '1000',
+      }, {
+        registerBackends: (registry) => {
+          registry.register('fake', (ctx) => new DeadlineSettlingBackend(ctx.sessionId));
+        },
+      }), 10_000, 'Harbor env cell did not honor its soft deadline');
+
+      assert.equal(result.settledByDeadline, true);
+      assert.equal(result.output.tokenSummary?.total, 18);
     });
   });
 
@@ -1090,6 +1176,46 @@ describe('runHarborCell', () => {
       const output = JSON.parse(await readFile(join(outputDir, 'maka-cell-output.json'), 'utf8'));
       assert.equal(output.executionIdentity.pricingProfile, 'frozen-pricing-profile');
     });
+  });
+
+  test('host-side Harbor cell returns after settling at its soft deadline', async () => {
+    const { main } = await import(new URL('../../harbor/run-host-cell.mjs', import.meta.url).href) as {
+      main: (options?: { registerBackends?: (registry: BackendRegistry) => void }) => Promise<unknown>;
+    };
+    await withDirs(async ({ workspaceDir, outputDir, storageRoot }) => {
+      const previousEnv = { ...process.env };
+      try {
+        process.env.MAKA_PROVIDER = 'openai';
+        process.env.MAKA_MODEL = 'openai/gpt-4o-mini';
+        process.env.MAKA_HOST_API_KEY = 'test-key';
+        process.env.MAKA_HARBOR_TOOL_EXECUTOR_URL = 'http://127.0.0.1:1';
+        process.env.MAKA_HARBOR_TOOL_EXECUTOR_TOKEN = 'token';
+        process.env.MAKA_INSTRUCTION = 'Keep working until stopped.';
+        process.env.MAKA_WORKDIR = workspaceDir;
+        process.env.MAKA_OUTPUT_DIR = outputDir;
+        process.env.MAKA_STORAGE_ROOT = storageRoot;
+        process.env.MAKA_CELL_SOFT_TIMEOUT_MS = '1000';
+        const result = await withTimeout(main({
+          registerBackends: (registry) => {
+            registry.register('ai-sdk', (ctx) => new DeadlineSettlingBackend(ctx.sessionId, 'ai-sdk'));
+          },
+        }), 10_000, 'host cell did not honor its soft deadline');
+
+        assert.equal(Reflect.get(result as object, 'settledByDeadline'), true);
+        const output = JSON.parse(await readFile(join(outputDir, HARBOR_CELL_OUTPUT_FILENAME), 'utf8'));
+        assert.equal(output.tokenSummary.total, 18);
+      } finally {
+        process.env = previousEnv;
+      }
+    });
+  });
+
+  test('host-side deadline settlement exits with the conventional timeout status', async () => {
+    const module = await import(new URL('../../harbor/run-host-cell.mjs', import.meta.url).href) as Record<string, unknown>;
+    const hostCellExitCode = module.hostCellExitCode as ((result: { settledByDeadline: boolean }) => number);
+
+    assert.equal(hostCellExitCode({ settledByDeadline: true }), 124);
+    assert.equal(hostCellExitCode({ settledByDeadline: false }), 0);
   });
 
   test('host-side Harbor cell config treats MAKA_ECONOMY_TASK_MODE=false as explicit disable', async () => {
@@ -3266,6 +3392,17 @@ async function withDirs<T>(
     await rm(workspaceDir, { recursive: true, force: true });
     await rm(outputDir, { recursive: true, force: true });
     await rm(storageRoot, { recursive: true, force: true });
+  }
+}
+
+async function withTimeout<T>(promise: Promise<T>, timeoutMs: number, message: string): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([promise, new Promise<never>((_resolve, reject) => {
+      timer = setTimeout(() => reject(new Error(message)), timeoutMs);
+    })]);
+  } finally {
+    if (timer) clearTimeout(timer);
   }
 }
 

--- a/packages/headless/src/harbor-cell.ts
+++ b/packages/headless/src/harbor-cell.ts
@@ -386,7 +386,10 @@ export async function runHarborCell(input: RunHarborCellInput): Promise<RunHarbo
     ? undefined
     : setTimeout(() => {
         settledByDeadline = true;
-        settlementAttempt = manager.stopSession(session.id, { source: 'benchmark_deadline' }).catch((error) => {
+        settlementAttempt = manager.stopSession(session.id, {
+          source: 'benchmark_deadline',
+          mode: 'after_step',
+        }).catch((error) => {
           settlementError = error;
         });
       }, input.settleAfterMs);
@@ -404,6 +407,7 @@ export async function runHarborCell(input: RunHarborCellInput): Promise<RunHarbo
   let attemptedTurnId: string | undefined;
   try {
     for (let turnIndex = 0; turnIndex < continuationPolicy.maxTurns; turnIndex += 1) {
+      if (settledByDeadline) break;
       const turnId = newId();
       attemptedTurnId = turnId;
       invocation = undefined;
@@ -415,6 +419,7 @@ export async function runHarborCell(input: RunHarborCellInput): Promise<RunHarbo
       }
       if (!invocation) throw new Error('Harbor cell turn finished without a runtime invocation result');
       invocations.push(invocation);
+      if (settledByDeadline) break;
       if (!isToolCallStepCap(invocation)) break;
       stepCapHits += 1;
       if (totalRuntimeSteps(invocations) >= continuationPolicy.maxTotalRuntimeSteps) break;

--- a/packages/headless/src/harbor-cell.ts
+++ b/packages/headless/src/harbor-cell.ts
@@ -92,6 +92,7 @@ export interface RunHarborCellInput {
   contextBudgetPolicy?: HarborCellContextBudgetPolicySnapshot;
   continuationPolicy?: HarborCellContinuationPolicy;
   taskToolSummaryEnabled?: boolean;
+  settleAfterMs?: number;
   now?: () => number;
   newId?: () => string;
 }
@@ -127,6 +128,7 @@ export interface RunHarborCellResult {
   output: HarborCellOutput;
   outputPath: string;
   runtimeEventsPath: string;
+  settledByDeadline: boolean;
 }
 
 export type RunHarborCellEnv = Record<string, string | undefined>;
@@ -302,6 +304,9 @@ const PI_PROVIDER_ENV_RULES = [
 ] satisfies Array<{ includes: string[]; keys?: string[]; prefixes?: string[] }>;
 
 export async function runHarborCell(input: RunHarborCellInput): Promise<RunHarborCellResult> {
+  if (input.settleAfterMs !== undefined && (!Number.isFinite(input.settleAfterMs) || input.settleAfterMs <= 0)) {
+    throw new Error('settleAfterMs must be a finite positive number');
+  }
   if (backendNeedsIsolation(input.config.backend)) {
     validateRealBackendIsolation(input.realBackendIsolation);
     if (!input.registerBackends) {
@@ -374,6 +379,18 @@ export async function runHarborCell(input: RunHarborCellInput): Promise<RunHarbo
     name: `harbor-cell:${input.config.id}`,
   });
 
+  let settledByDeadline = false;
+  let settlementError: unknown;
+  let settlementAttempt: Promise<void> | undefined;
+  const settlementTimer = input.settleAfterMs === undefined
+    ? undefined
+    : setTimeout(() => {
+        settledByDeadline = true;
+        settlementAttempt = manager.stopSession(session.id, { source: 'benchmark_deadline' }).catch((error) => {
+          settlementError = error;
+        });
+      }, input.settleAfterMs);
+
   const continuationPolicy = input.continuationPolicy ?? {
     enabled: false,
     maxTurns: 1,
@@ -406,7 +423,11 @@ export async function runHarborCell(input: RunHarborCellInput): Promise<RunHarbo
     }
   } catch (error) {
     sendMessageError = error;
+  } finally {
+    if (settlementTimer) clearTimeout(settlementTimer);
   }
+  await settlementAttempt;
+  if (settlementError) throw settlementError;
   if (sendMessageError) {
     invocations.push(failedInvocationFromError(sendMessageError, {
       newId,
@@ -436,7 +457,7 @@ export async function runHarborCell(input: RunHarborCellInput): Promise<RunHarbo
   }));
   await writeFile(outputPath, `${JSON.stringify(output, null, 2)}\n`, 'utf8');
 
-  return { invocation: combinedInvocation, output, outputPath, runtimeEventsPath };
+  return { invocation: combinedInvocation, output, outputPath, runtimeEventsPath, settledByDeadline };
 }
 
 export async function runHarborCellFromEnv(
@@ -454,6 +475,7 @@ export async function runHarborCellFromEnv(
   const economyTaskMode = economyTaskModeFromEnv(resolvedEnv.MAKA_ECONOMY_TASK_MODE);
   const taskLedgerExperimentPolicy = buildHarborCellTaskLedgerExperimentPolicy(resolvedEnv);
   const maxSteps = harborCellMaxStepsFromEnv(resolvedEnv);
+  const settleAfterMs = harborCellSoftTimeoutMsFromEnv(resolvedEnv);
   const reasoningEffort = reasoningEffortFromEnv(resolvedEnv.MAKA_REASONING_EFFORT);
   const baseConfig = {
     id: resolvedEnv.MAKA_CONFIG_ID ?? 'harbor-cell',
@@ -536,6 +558,7 @@ export async function runHarborCellFromEnv(
     ...(contextBudgetPolicy ? { contextBudgetPolicy } : {}),
     ...(continuationPolicy ? { continuationPolicy } : {}),
     ...(taskLedgerExperimentPolicy ? { taskToolSummaryEnabled: true } : {}),
+    ...(settleAfterMs !== undefined ? { settleAfterMs } : {}),
     ...(registerBackends ? { registerBackends } : {}),
     ...(backendNeedsIsolation(backend)
       ? {
@@ -582,6 +605,10 @@ export function buildHarborCellContinuationPolicy(
 
 export function harborCellMaxStepsFromEnv(env: RunHarborCellEnv = process.env): number | undefined {
   return positiveIntEnv(env.MAKA_MAX_STEPS, 'MAKA_MAX_STEPS');
+}
+
+export function harborCellSoftTimeoutMsFromEnv(env: RunHarborCellEnv = process.env): number | undefined {
+  return positiveIntEnv(env.MAKA_CELL_SOFT_TIMEOUT_MS, 'MAKA_CELL_SOFT_TIMEOUT_MS');
 }
 
 function isToolCallStepCap(invocation: InvocationResult): boolean {

--- a/packages/headless/src/harbor-cell.ts
+++ b/packages/headless/src/harbor-cell.ts
@@ -379,13 +379,13 @@ export async function runHarborCell(input: RunHarborCellInput): Promise<RunHarbo
     name: `harbor-cell:${input.config.id}`,
   });
 
-  let settledByDeadline = false;
+  let deadlineReached = false;
   let settlementError: unknown;
   let settlementAttempt: Promise<void> | undefined;
   const settlementTimer = input.settleAfterMs === undefined
     ? undefined
     : setTimeout(() => {
-        settledByDeadline = true;
+        deadlineReached = true;
         settlementAttempt = manager.stopSession(session.id, {
           source: 'benchmark_deadline',
           mode: 'after_step',
@@ -407,7 +407,7 @@ export async function runHarborCell(input: RunHarborCellInput): Promise<RunHarbo
   let attemptedTurnId: string | undefined;
   try {
     for (let turnIndex = 0; turnIndex < continuationPolicy.maxTurns; turnIndex += 1) {
-      if (settledByDeadline) break;
+      if (deadlineReached) break;
       const turnId = newId();
       attemptedTurnId = turnId;
       invocation = undefined;
@@ -419,7 +419,7 @@ export async function runHarborCell(input: RunHarborCellInput): Promise<RunHarbo
       }
       if (!invocation) throw new Error('Harbor cell turn finished without a runtime invocation result');
       invocations.push(invocation);
-      if (settledByDeadline) break;
+      if (deadlineReached) break;
       if (!isToolCallStepCap(invocation)) break;
       stepCapHits += 1;
       if (totalRuntimeSteps(invocations) >= continuationPolicy.maxTotalRuntimeSteps) break;
@@ -444,6 +444,11 @@ export async function runHarborCell(input: RunHarborCellInput): Promise<RunHarbo
     throw new Error('Harbor cell finished without a runtime invocation result');
   }
   const combinedInvocation = combineInvocations(invocations);
+  const terminalRun = deadlineReached
+    ? await agentRunStore.readRun(session.id, combinedInvocation.runId).catch(() => undefined)
+    : undefined;
+  const settledByDeadline = terminalRun?.status === 'cancelled'
+    && terminalRun.abortSource === 'benchmark.deadline';
   const continuationSummary = continuationPolicy.enabled
     ? buildContinuationSummary(continuationPolicy, invocations, stepCapHits)
     : undefined;

--- a/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
+++ b/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
@@ -2473,6 +2473,50 @@ describe('AiSdkBackend model history', () => {
     );
   });
 
+  test('after-step stop preserves the current provider step usage and prevents another step', async () => {
+    const loop = countingToolLoopModel();
+    let backend!: AiSdkBackend;
+    let stopRequested = false;
+    const stoppingTool: MakaTool = {
+      name: 'Read',
+      description: 'Read description',
+      parameters: z.object({ path: z.string() }),
+      permissionRequired: false,
+      impl: async () => {
+        stopRequested = true;
+        await (backend.stop as unknown as (
+          reason: 'user_stop',
+          mode: 'after_step',
+        ) => Promise<void>)('user_stop', 'after_step');
+        return { ok: true };
+      },
+    };
+    backend = new AiSdkBackend({
+      sessionId: 'session-1',
+      header: header(),
+      appendMessage: async () => {},
+      connection: connection(),
+      apiKey: 'sk-test',
+      modelId: 'mock-model-id',
+      permissionEngine: new PermissionEngine({ newId: () => 'permission-id', now: () => 1 }),
+      modelFactory: () => loop.model,
+      tools: [stoppingTool],
+      newId: idGenerator(),
+      now: monotonicClock(),
+    });
+    const events: SessionEvent[] = [];
+
+    for await (const event of backend.send({ turnId: 'turn-1', text: 'hi', context: [] })) {
+      events.push(event);
+    }
+
+    assert.equal(stopRequested, true);
+    assert.equal(loop.callCount(), 1);
+    assert.equal(events.some((event) => event.type === 'abort'), false);
+    const usage = events.find((event) => event.type === 'token_usage');
+    assert.equal(usage?.type === 'token_usage' ? usage.total : undefined, 2);
+  });
+
   test('aborting during post-stream persistence wins over step-limit completion', async () => {
     const loop = countingToolLoopModel();
     const gate = makeGate();

--- a/packages/runtime/src/__tests__/overflow-reactive-recovery.test.ts
+++ b/packages/runtime/src/__tests__/overflow-reactive-recovery.test.ts
@@ -74,6 +74,8 @@ interface ReactiveFixtureOptions {
   slowAppendMessage?: boolean;
   /** Enable the active tool-result prune with a small threshold + archive seam. */
   activeToolResultPrune?: boolean;
+  /** Test-only gate before a numbered provider request starts. */
+  beforeStream?: (call: number) => Promise<void>;
 }
 
 interface ReactiveLlmCall {
@@ -191,6 +193,7 @@ function buildReactiveFixture(options: ReactiveFixtureOptions): ReactiveFixture 
     doStream: async (
       streamOptions: { abortSignal?: AbortSignal },
     ): Promise<{ stream: ReadableStream<LanguageModelV3StreamPart> }> => {
+      await options.beforeStream?.(model.doStreamCalls.length);
       if (streamOptions.abortSignal?.aborted) {
         throw Object.assign(new Error('aborted'), { name: 'AbortError' });
       }
@@ -413,6 +416,31 @@ describe('reactive overflow recovery in the streaming backend', () => {
     assert.equal(lastCall?.inputTokens, 220);
     assert.equal(lastCall?.outputTokens, 30);
     assert.equal(lastCall?.totalTokens, 250);
+  });
+
+  test('does not retry an overflow after an after-step stop is requested', async () => {
+    let signalSecondStream!: () => void;
+    let releaseSecondStream!: () => void;
+    const secondStreamStarted = new Promise<void>((resolve) => { signalSecondStream = resolve; });
+    const secondStreamGate = new Promise<void>((resolve) => { releaseSecondStream = resolve; });
+    const fixture = buildReactiveFixture({
+      script: ['tool', 'overflow', 'done'],
+      bigPriors: true,
+      beforeStream: async (call) => {
+        if (call !== 2) return;
+        signalSecondStream();
+        await secondStreamGate;
+      },
+    });
+
+    const turn = runTurn(fixture);
+    await secondStreamStarted;
+    await fixture.backend.stop('user_stop', 'after_step');
+    releaseSecondStream();
+    await turn;
+
+    assert.equal(fixture.model.doStreamCalls.length, 2);
+    assert.equal(fixture.recorded.length, 0);
   });
 
   test('recovers from a plain-object in-stream error part, not just Error instances (review round-8 P1-1)', async () => {

--- a/packages/runtime/src/__tests__/session-manager.test.ts
+++ b/packages/runtime/src/__tests__/session-manager.test.ts
@@ -3350,6 +3350,7 @@ describe('SessionManager permission mode updates', () => {
 
     expect(backend?.stopCalls).toBe(1);
     expect(backend?.stopModes).toEqual(['after_step']);
+    expect(backend?.sendInputs).toHaveLength(0);
   });
 
   test('stopSession retries only backends that failed in a multi-session stop', async () => {

--- a/packages/runtime/src/__tests__/session-manager.test.ts
+++ b/packages/runtime/src/__tests__/session-manager.test.ts
@@ -17,7 +17,7 @@ import type {
   StoredMessage,
   TurnRecord,
 } from '@maka/core';
-import type { BackendSendInput, PermissionDecision } from '@maka/core/backend-types';
+import type { BackendSendInput, BackendStopMode, PermissionDecision } from '@maka/core/backend-types';
 import { expect } from '../test-helpers.js';
 import {
   BackendRegistry,
@@ -3308,6 +3308,50 @@ describe('SessionManager permission mode updates', () => {
     )).toHaveLength(1);
   });
 
+  test('stopSession waits for a turn that is still registering', async () => {
+    const store = new MemorySessionStore();
+    const runStore = new MemoryAgentRunStore();
+    const backends = new BackendRegistry();
+    let backend: TestBackend | undefined;
+    backends.register('fake', (ctx) => {
+      backend = new TestBackend(ctx);
+      return backend;
+    });
+    const manager = new SessionManager({
+      store,
+      runStore,
+      runtimeEventStore: runStore,
+      backends,
+      newId: nextId(),
+      now: nextNow(6_847),
+      runtimeSource: 'test',
+    });
+    const session = await manager.createSession(makeInput());
+    const readStarted = makeGate();
+    const releaseRead = makeGate();
+    store.nextReadHeaderGate = { started: readStarted, release: releaseRead };
+    const turn = manager.sendMessage(session.id, { turnId: 'turn-registering', text: 'hello' })[Symbol.asyncIterator]();
+    const firstEvent = turn.next();
+    await readStarted.promise;
+
+    let stopSettled = false;
+    const stop = manager.stopSession(session.id, {
+      source: 'benchmark_deadline',
+      mode: 'after_step',
+    }).finally(() => {
+      stopSettled = true;
+    });
+    await Promise.resolve();
+    expect(stopSettled).toBe(false);
+    releaseRead.release();
+    await stop;
+    await firstEvent;
+    while (!(await turn.next()).done) {}
+
+    expect(backend?.stopCalls).toBe(1);
+    expect(backend?.stopModes).toEqual(['after_step']);
+  });
+
   test('stopSession retries only backends that failed in a multi-session stop', async () => {
     const store = new MemorySessionStore();
     const runStore = new MemoryAgentRunStore();
@@ -5773,6 +5817,7 @@ class TestBackend implements AgentBackend {
   readonly sessionId: string;
   readonly sendInputs: BackendSendInput[] = [];
   stopCalls = 0;
+  readonly stopModes: BackendStopMode[] = [];
 
   constructor(private readonly ctx: BackendFactoryContext, private readonly gate?: Gate) {
     this.sessionId = ctx.sessionId;
@@ -5785,8 +5830,9 @@ class TestBackend implements AgentBackend {
     yield { type: 'complete', id: `${input.turnId}-complete`, turnId: input.turnId, ts: 2, stopReason: 'end_turn' };
   }
 
-  async stop(): Promise<void> {
+  async stop(_reason: 'user_stop' | 'redirect', mode: BackendStopMode = 'immediate'): Promise<void> {
     this.stopCalls += 1;
+    this.stopModes.push(mode);
   }
   async respondToPermission(_decision: PermissionDecision): Promise<void> {}
 
@@ -6691,6 +6737,7 @@ class MemorySessionStore implements SessionStore {
   failNextAppendMessage: ((message: StoredMessage) => boolean) | undefined;
   failAfterNextAppendMessage: ((message: StoredMessage) => boolean) | undefined;
   disposeCount = 0;
+  nextReadHeaderGate: { started: Gate; release: Gate } | undefined;
 
   async create(input: CreateSessionInput): Promise<SessionHeader> {
     const header: SessionHeader = {
@@ -6727,6 +6774,12 @@ class MemorySessionStore implements SessionStore {
   }
 
   async readHeader(sessionId: string): Promise<SessionHeader> {
+    const gate = this.nextReadHeaderGate;
+    if (gate) {
+      this.nextReadHeaderGate = undefined;
+      gate.started.release();
+      await gate.release.promise;
+    }
     const header = this.headers.get(sessionId);
     if (!header) {
       const error = new Error(`Unknown session ${sessionId}`) as NodeJS.ErrnoException;

--- a/packages/runtime/src/__tests__/session-projection-helpers.test.ts
+++ b/packages/runtime/src/__tests__/session-projection-helpers.test.ts
@@ -94,4 +94,8 @@ describe('session projection helpers', () => {
     expect(normalizeStopSessionSource('stop_button')).toBe('renderer.stop_button');
     expect(normalizeStopSessionSource(undefined)).toBeUndefined();
   });
+
+  test('normalizeStopSessionSource preserves benchmark deadline provenance', () => {
+    expect(normalizeStopSessionSource('benchmark_deadline')).toBe('benchmark.deadline');
+  });
 });

--- a/packages/runtime/src/ai-sdk-backend.ts
+++ b/packages/runtime/src/ai-sdk-backend.ts
@@ -793,6 +793,7 @@ export class AiSdkBackend implements AgentBackend {
   private abortController: AbortController | null = null;
   private historyCompactAbortController: AbortController | null = null;
   private currentTurnId: string | null = null;
+  private stopAfterStepRequested = false;
   private currentRunId: string | null = null;
   /** Side-channel for tool.execute() callbacks to push events into the iterator. */
   private currentQueue: AsyncEventQueue<SessionEvent> | null = null;
@@ -1473,6 +1474,7 @@ export class AiSdkBackend implements AgentBackend {
             },
             system: systemPrompt,
             abortSignal: this.abortController!.signal,
+            stopAfterStep: () => this.stopAfterStepRequested,
             ...(sendScopedPrepareStep ? { prepareStep: sendScopedPrepareStep } : {}),
             ...(remainingStepBudget !== undefined ? { maxSteps: remainingStepBudget } : {}),
           });
@@ -1894,7 +1896,12 @@ export class AiSdkBackend implements AgentBackend {
   // Helpers
   // --------------------------------------------------------------------------
 
-  async stop(_reason: 'user_stop' | 'redirect'): Promise<void> {
+  async stop(_reason: 'user_stop' | 'redirect', mode: 'immediate' | 'after_step' = 'immediate'): Promise<void> {
+    if (mode === 'after_step') {
+      this.stopAfterStepRequested = true;
+      this.currentRunTrace?.abortRequested(_reason);
+      return;
+    }
     this.aborted = true;
     this.abortController?.abort();
     this.historyCompactAbortController?.abort();
@@ -3981,6 +3988,7 @@ export class AiSdkBackend implements AgentBackend {
     this.currentRunTrace = null;
     this.currentUserIntent = undefined;
     this.currentStepMessageId = null;
+    this.stopAfterStepRequested = false;
     this.toolRuntime.endTurn(turnId, this.aborted ? 'aborted' : 'completed');
     this.aborted = false;
   }

--- a/packages/runtime/src/ai-sdk-backend.ts
+++ b/packages/runtime/src/ai-sdk-backend.ts
@@ -1542,6 +1542,7 @@ export class AiSdkBackend implements AgentBackend {
           }
 
           if (sawStreamError && !this.aborted) {
+            if (this.stopAfterStepRequested) throw streamErrorChunk;
             // A retry is a fresh provider request that would run at least one
             // more step; with the send-level budget already spent there is
             // nothing left to grant it, so the error is terminal.

--- a/packages/runtime/src/model-adapter.ts
+++ b/packages/runtime/src/model-adapter.ts
@@ -121,6 +121,8 @@ export interface ModelAdapterStreamInput {
    * to the adapter's configured maxSteps.
    */
   maxSteps?: number;
+  /** Stop the SDK tool loop after the current provider step completes. */
+  stopAfterStep?: () => boolean;
 }
 
 export interface ModelAdapterStreamCallbacks {
@@ -172,6 +174,10 @@ export class ModelAdapter {
     };
 
     const maxSteps = input.maxSteps ?? this.input.maxSteps;
+    const configuredStop = maxSteps === undefined
+      ? isLoopFinished()
+      : stepCountIs(maxSteps);
+    const stopAfterStep = input.stopAfterStep;
     return streamText({
       model: input.model,
       messages: input.messages,
@@ -183,9 +189,9 @@ export class ModelAdapter {
       providerOptions: this.input.providerOptions,
       // streamText defaults to one step when stopWhen is omitted. Its exported
       // non-stopping condition is required for an unbounded tool loop.
-      stopWhen: maxSteps === undefined
-        ? isLoopFinished()
-        : stepCountIs(maxSteps),
+      stopWhen: stopAfterStep
+        ? [configuredStop, () => stopAfterStep()]
+        : configuredStop,
       abortSignal: input.abortSignal,
     });
   }

--- a/packages/runtime/src/runtime-kernel.ts
+++ b/packages/runtime/src/runtime-kernel.ts
@@ -369,6 +369,7 @@ export class RuntimeKernel implements RuntimeKernelLike {
       providers: { newId: this.deps.newId, now: this.deps.now },
       stopOnTerminal: false,
     });
+    if (run.isStopped()) abortController.abort();
     const runnerResult = runner.run({
       sessionId,
       invocationId: begin.initialRuntimeEvent.invocationId,
@@ -383,6 +384,11 @@ export class RuntimeKernel implements RuntimeKernelLike {
       lineage: run.lineage,
       abortSignal: abortController.signal,
     }).then(async (result) => {
+      if (!flowDone) {
+        flowDone = true;
+        await run.finalize();
+        sessionEvents.close();
+      }
       await this.deps.runtimeInvocationObserver?.(result);
       return result;
     }, (error) => {

--- a/packages/runtime/src/runtime-kernel.ts
+++ b/packages/runtime/src/runtime-kernel.ts
@@ -96,11 +96,21 @@ interface StopOperation {
   targets: Map<ActiveSession, StopTarget>;
 }
 
+interface PendingStopAttempt {
+  input: StopSessionInput;
+  promise: Promise<void>;
+  resolve: () => void;
+  reject: (error: unknown) => void;
+  delivery: Promise<void>;
+}
+
 export class RuntimeKernel implements RuntimeKernelLike {
   private readonly active = new Map<string, ActiveSession>();
   private readonly childActive = new Map<string, ActiveSession>();
   private readonly stopOperations = new Map<string, StopOperation>();
   private readonly stopAttempts = new Map<string, Promise<void>>();
+  private readonly pendingTurnStarts = new Map<string, number>();
+  private readonly pendingStops = new Map<string, PendingStopAttempt>();
   private readonly historyCompactCheckpoints = new Map<string, HistoryCompactCheckpoint | undefined>();
   private readonly historyCompactCheckpointLoads = new Map<string, Promise<HistoryCompactCheckpoint | undefined>>();
   private readonly historyCompactCheckpointWrites = new Map<string, Promise<void>>();
@@ -116,30 +126,42 @@ export class RuntimeKernel implements RuntimeKernelLike {
     sessionId: string,
     input: UserMessageInput,
   ): AsyncIterable<SessionEvent> {
-    const header = await this.deps.store.readHeader(sessionId);
-    const run = new AgentRun({
-      sessionId,
-      header,
-      userInput: input,
-      store: this.deps.store,
-      runStore: this.deps.runStore,
-      runtimeEventStore: this.deps.runtimeEventStore,
-      repairRunRuntimeLedger: this.deps.repairRunRuntimeLedger,
-      newId: this.deps.newId,
-      now: this.deps.now,
-      hooks: {
-        ensureActive: (targetSessionId, nextHeader) => this.ensureActive(targetSessionId, nextHeader),
-        registerRun: (active, activeRun) => this.registerRun(active, activeRun),
-        unregisterRun: (active, activeRun) => this.unregisterRun(active, activeRun),
-        updateHeader: (targetSessionId, patch) => this.updateHeader(targetSessionId, patch),
-        updateStatus: (targetSessionId, status, blockedReason, ts) =>
-          this.updateStatus(targetSessionId, status, blockedReason, ts),
-        appendTurnState: (targetSessionId, turnId, status, lineage, options) =>
-          this.appendTurnState(targetSessionId, turnId, status, lineage, options),
-      },
-    });
+    this.pendingTurnStarts.set(sessionId, (this.pendingTurnStarts.get(sessionId) ?? 0) + 1);
+    let pending = true;
+    try {
+      const header = await this.deps.store.readHeader(sessionId);
+      const run = new AgentRun({
+        sessionId,
+        header,
+        userInput: input,
+        store: this.deps.store,
+        runStore: this.deps.runStore,
+        runtimeEventStore: this.deps.runtimeEventStore,
+        repairRunRuntimeLedger: this.deps.repairRunRuntimeLedger,
+        newId: this.deps.newId,
+        now: this.deps.now,
+        hooks: {
+          ensureActive: (targetSessionId, nextHeader) => this.ensureActive(targetSessionId, nextHeader),
+          registerRun: (active, activeRun) => {
+            this.registerRun(active, activeRun);
+            if (pending) {
+              pending = false;
+              this.finishPendingTurnStart(sessionId, true);
+            }
+          },
+          unregisterRun: (active, activeRun) => this.unregisterRun(active, activeRun),
+          updateHeader: (targetSessionId, patch) => this.updateHeader(targetSessionId, patch),
+          updateStatus: (targetSessionId, status, blockedReason, ts) =>
+            this.updateStatus(targetSessionId, status, blockedReason, ts),
+          appendTurnState: (targetSessionId, turnId, status, lineage, options) =>
+            this.appendTurnState(targetSessionId, turnId, status, lineage, options),
+        },
+      });
 
-    yield* this.runAgentTurn(sessionId, input, run);
+      yield* this.runAgentTurn(sessionId, input, run);
+    } finally {
+      if (pending) this.finishPendingTurnStart(sessionId, false);
+    }
   }
 
   async *compactSession(
@@ -422,6 +444,10 @@ export class RuntimeKernel implements RuntimeKernelLike {
 
   private async stopSessionAttempt(sessionId: string, input: StopSessionInput): Promise<void> {
     const activeSessions = this.activeSessionsFor(sessionId);
+    if (activeSessions.length === 0 && (this.pendingTurnStarts.get(sessionId) ?? 0) > 0) {
+      await this.waitForPendingStop(sessionId, input);
+      return;
+    }
     let operation = this.stopOperations.get(sessionId);
     if (!operation) {
       const abortSource = normalizeStopSessionSource(input.source);
@@ -461,7 +487,7 @@ export class RuntimeKernel implements RuntimeKernelLike {
     this.stopOperations.set(sessionId, operation);
 
     const undelivered = [...operation.targets.values()].filter((target) => !target.delivered);
-    const results = await Promise.allSettled(undelivered.map((target) => target.active.backend.stop('user_stop')));
+    const results = await Promise.allSettled(undelivered.map((target) => target.active.backend.stop('user_stop', input.mode)));
     let stopError: unknown;
     results.forEach((result, index) => {
       if (result.status === 'fulfilled') undelivered[index]!.delivered = true;
@@ -494,6 +520,39 @@ export class RuntimeKernel implements RuntimeKernelLike {
     }
     for (const run of stoppedRuns) run.completeStop();
     this.stopOperations.delete(sessionId);
+  }
+
+  private waitForPendingStop(sessionId: string, input: StopSessionInput): Promise<void> {
+    const existing = this.pendingStops.get(sessionId);
+    if (existing) return existing.promise;
+    let resolve!: () => void;
+    let reject!: (error: unknown) => void;
+    const promise = new Promise<void>((resolvePromise, rejectPromise) => {
+      resolve = resolvePromise;
+      reject = rejectPromise;
+    });
+    this.pendingStops.set(sessionId, {
+      input,
+      promise,
+      resolve,
+      reject,
+      delivery: Promise.resolve(),
+    });
+    return promise;
+  }
+
+  private finishPendingTurnStart(sessionId: string, registered: boolean): void {
+    const remaining = Math.max(0, (this.pendingTurnStarts.get(sessionId) ?? 1) - 1);
+    if (remaining === 0) this.pendingTurnStarts.delete(sessionId);
+    else this.pendingTurnStarts.set(sessionId, remaining);
+    const pendingStop = this.pendingStops.get(sessionId);
+    if (!pendingStop) return;
+    if (registered) {
+      pendingStop.delivery = pendingStop.delivery.then(() => this.stopSessionAttempt(sessionId, pendingStop.input));
+    }
+    if (remaining > 0) return;
+    this.pendingStops.delete(sessionId);
+    pendingStop.delivery.then(pendingStop.resolve, pendingStop.reject);
   }
 
   private async appendStopProjection(sessionId: string, message: StoredMessage): Promise<void> {

--- a/packages/runtime/src/session-manager.ts
+++ b/packages/runtime/src/session-manager.ts
@@ -64,7 +64,7 @@ import {
   terminalRunStatusFromRuntimeEvent,
 } from './terminal-run-commit.js';
 
-import type { AgentBackend } from '@maka/core/backend-types';
+import type { AgentBackend, BackendStopMode } from '@maka/core/backend-types';
 import type { MakaTool } from './tool-runtime.js';
 import type { RunTraceRecorder } from './run-trace.js';
 import type { ShellRunProcessManager } from './shell-run-manager.js';
@@ -92,6 +92,7 @@ import { requireResolvedAgentDefinition } from './expert-catalog.js';
 
 export interface StopSessionInput {
   source?: 'stop_button' | 'benchmark_deadline';
+  mode?: BackendStopMode;
 }
 
 export interface CompactSessionInput {

--- a/packages/runtime/src/session-manager.ts
+++ b/packages/runtime/src/session-manager.ts
@@ -91,7 +91,7 @@ import {
 import { requireResolvedAgentDefinition } from './expert-catalog.js';
 
 export interface StopSessionInput {
-  source?: 'stop_button';
+  source?: 'stop_button' | 'benchmark_deadline';
 }
 
 export interface CompactSessionInput {

--- a/packages/runtime/src/session-projection-helpers.ts
+++ b/packages/runtime/src/session-projection-helpers.ts
@@ -66,10 +66,11 @@ export function turnHasRetainedOutput(
 }
 
 export function normalizeStopSessionSource(
-  source: 'stop_button' | undefined,
+  source: 'stop_button' | 'benchmark_deadline' | undefined,
 ): string | undefined {
   switch (source) {
     case 'stop_button': return 'renderer.stop_button';
+    case 'benchmark_deadline': return 'benchmark.deadline';
     case undefined: return undefined;
   }
 }


### PR DESCRIPTION
## Summary

- request cooperative after-step settlement at a soft deadline so the active provider step can finish and report authoritative usage
- latch the deadline so no continuation turn starts afterward, and preserve stop delivery while a turn is still registering
- write final cell output before returning timeout status; retain the existing hard timeout only as a kill fallback
- record benchmark deadline provenance separately from renderer stop actions
- derive the soft deadline from the existing cell timeout with a configurable 30-second settlement grace

Refs #1021.

## Verification

- `npm test --workspace @maka/core` — 1003 passed
- `npm test --workspace @maka/runtime` — 1938 passed, 0 failed, 7 conditional skips
- `npm test --workspace @maka/headless` — 967 passed, 0 failed, 1 existing conditional skip
- regression tests cover after-step usage, a stop during turn registration, deadline-latched continuation, final cell output, host exit status 124, and adapter timeout classification

## Remaining work

- OpenCode hermetic toolchain: #1024
- [ ] add same-session transient provider stream recovery
- [ ] add verifier-only infrastructure recovery and verifier health qualification
- [ ] run a real-provider canary after the harness stability slices land
