### PR TITLE
fix(headless): mount a hermetic OpenCode toolchain

### DIFF
--- a/packages/headless/harbor/docker-compose-linux-amd64.yaml
+++ b/packages/headless/harbor/docker-compose-linux-amd64.yaml
@@ -1,0 +1,3 @@
+services:
+  main:
+    platform: linux/amd64

--- a/packages/headless/harbor/opencode_agent.py
+++ b/packages/headless/harbor/opencode_agent.py
@@ -16,18 +16,13 @@ from harbor.models.agent.context import AgentContext
 
 from trial_pricing import estimate_cost, pricing_from_env
 
-_UPSTREAM_CURL_INSTALL_COMMAND = "apt-get update && apt-get install -y curl"
-_RETRYING_CURL_INSTALL_COMMAND = (
-    "command -v curl >/dev/null 2>&1 && exit 0; "
-    "status=1; "
-    "for attempt in 1 2 3; do "
-    "apt-get -o Acquire::Retries=3 update && "
-    "apt-get -o Acquire::Retries=3 install -y curl && exit 0; "
-    "status=$?; "
-    '[ "$attempt" -eq 3 ] && exit "$status"; '
-    "sleep $((attempt * 5)); "
-    'done; exit "$status"'
-)
+_TOOLCHAIN_ROOT = Path("/opt/maka-opencode-toolchain")
+_TOOLCHAIN_NODE = _TOOLCHAIN_ROOT / "bin" / "node"
+_TOOLCHAIN_OPENCODE = _TOOLCHAIN_ROOT / "bin" / "opencode"
+_TOOLCHAIN_MANIFEST = _TOOLCHAIN_ROOT / "manifest.json"
+_TOOLCHAIN_CHECKSUMS = _TOOLCHAIN_ROOT / "checksums.sha256"
+_NODE_VERSION = "22.23.1"
+_OPENCODE_VERSION = "1.17.18"
 
 
 class MakaOpenCodeAgent(OpenCode):
@@ -37,22 +32,34 @@ class MakaOpenCodeAgent(OpenCode):
     def name() -> str:
         return "opencode"
 
-    async def exec_as_root(
-        self,
-        environment: BaseEnvironment,
-        command: str,
-        env: dict[str, str] | None = None,
-        cwd: str | None = None,
-        timeout_sec: int | None = None,
-    ) -> Any:
-        if command == _UPSTREAM_CURL_INSTALL_COMMAND:
-            command = _RETRYING_CURL_INSTALL_COMMAND
-        return await super().exec_as_root(
+    def get_version_command(self) -> str | None:
+        return f"{shlex.quote(str(_TOOLCHAIN_OPENCODE))} --version"
+
+    async def install(self, environment: BaseEnvironment) -> None:
+        expected_fingerprint = self._get_env("MAKA_OPENCODE_TOOLCHAIN_FINGERPRINT")
+        if not expected_fingerprint:
+            raise ValueError("MAKA_OPENCODE_TOOLCHAIN_FINGERPRINT is required")
+        manifest_check = (
+            "const fs = require('node:fs'); "
+            "const manifest = JSON.parse(fs.readFileSync(process.argv[1], 'utf8')); "
+            "if (manifest.fingerprint !== process.env.MAKA_EXPECTED_TOOLCHAIN_FINGERPRINT) "
+            "throw new Error('OpenCode toolchain fingerprint mismatch');"
+        )
+        command = (
+            "set -euo pipefail; "
+            'test "$(uname -s)" = Linux; '
+            'test "$(uname -m)" = x86_64; '
+            f"cd {shlex.quote(str(_TOOLCHAIN_ROOT))}; "
+            f"sha256sum --check {shlex.quote(_TOOLCHAIN_CHECKSUMS.name)}; "
+            f'test "$({shlex.quote(str(_TOOLCHAIN_NODE))} --version)" = v{_NODE_VERSION}; '
+            f'test "$({shlex.quote(str(_TOOLCHAIN_OPENCODE))} --version)" = {_OPENCODE_VERSION}; '
+            f"{shlex.quote(str(_TOOLCHAIN_NODE))} -e {shlex.quote(manifest_check)} "
+            f"{shlex.quote(str(_TOOLCHAIN_MANIFEST))}"
+        )
+        await self.exec_as_agent(
             environment,
             command=command,
-            env=env,
-            cwd=cwd,
-            timeout_sec=timeout_sec,
+            env={"MAKA_EXPECTED_TOOLCHAIN_FINGERPRINT": expected_fingerprint},
         )
 
     @with_prompt_template
@@ -167,12 +174,11 @@ class MakaOpenCodeAgent(OpenCode):
         runner_path = self._stop_runner_path()
         grace_ms = self._stop_grace_ms()
         command = (
-            ". ~/.nvm/nvm.sh; "
-            f"node {shlex.quote(runner_path)} "
+            f"{shlex.quote(str(_TOOLCHAIN_NODE))} {shlex.quote(runner_path)} "
             "--output /logs/agent/opencode.txt "
             f"--grace-ms {grace_ms} "
             "-- "
-            f"opencode --model={shlex.quote(self.model_name)} run --format=json --pure "
+            f"{shlex.quote(str(_TOOLCHAIN_OPENCODE))} --model={shlex.quote(self.model_name)} run --format=json --pure "
             f"{cli_flags_arg}{variant_arg}--thinking --auto -- "
             f"{escaped_instruction}"
         )

--- a/packages/headless/harbor/opencode_agent.py
+++ b/packages/headless/harbor/opencode_agent.py
@@ -21,8 +21,6 @@ _TOOLCHAIN_NODE = _TOOLCHAIN_ROOT / "bin" / "node"
 _TOOLCHAIN_OPENCODE = _TOOLCHAIN_ROOT / "bin" / "opencode"
 _TOOLCHAIN_MANIFEST = _TOOLCHAIN_ROOT / "manifest.json"
 _TOOLCHAIN_CHECKSUMS = _TOOLCHAIN_ROOT / "checksums.sha256"
-_NODE_VERSION = "22.23.1"
-_OPENCODE_VERSION = "1.17.18"
 
 
 class MakaOpenCodeAgent(OpenCode):
@@ -51,8 +49,6 @@ class MakaOpenCodeAgent(OpenCode):
             'test "$(uname -m)" = x86_64; '
             f"cd {shlex.quote(str(_TOOLCHAIN_ROOT))}; "
             f"sha256sum --check {shlex.quote(_TOOLCHAIN_CHECKSUMS.name)}; "
-            f'test "$({shlex.quote(str(_TOOLCHAIN_NODE))} --version)" = v{_NODE_VERSION}; '
-            f'test "$({shlex.quote(str(_TOOLCHAIN_OPENCODE))} --version)" = {_OPENCODE_VERSION}; '
             f"{shlex.quote(str(_TOOLCHAIN_NODE))} -e {shlex.quote(manifest_check)} "
             f"{shlex.quote(str(_TOOLCHAIN_MANIFEST))}"
         )

--- a/packages/headless/harbor/run-harness-ab.mjs
+++ b/packages/headless/harbor/run-harness-ab.mjs
@@ -98,6 +98,59 @@ export function harnessMakaContextBudgetEnv() {
   };
 }
 
+export function buildHarnessAbManifest({
+  subjectFingerprint,
+  taskSourceFingerprint,
+  toolchainFingerprint,
+}) {
+  return buildHarnessAbRunManifest({
+    benchmark: {
+      dataset: 'terminal-bench',
+      version: '2.1',
+      revision: TERMINAL_BENCH_2_1_REVISION,
+      timeoutPolicy: 'task-native',
+      timeoutMultiplier: 1,
+      outerTimeoutGraceSec: HARBOR_SETUP_TEARDOWN_GRACE_SEC,
+    },
+    taskIds: TERMINAL_BENCH_2_1_TASK_IDS,
+    orderSeed: ORDER_SEED,
+    pilotTaskCount: PILOT_TASKS,
+    model: { provider: PROVIDER, id: MODEL, reasoningEffort: REASONING_EFFORT },
+    pricing: PRICING,
+    arms: [
+      {
+        id: 'maka',
+        version: subjectFingerprint,
+        config: {
+          adapter: 'maka_agent:MakaAgent',
+          externalSystemPrompt: 'empty',
+          reasoningEffort: REASONING_EFFORT,
+          continuation: false,
+          attemptPolicy: 'single',
+          contextBudget: HARNESS_MAKA_CONTEXT_BUDGET,
+        },
+      },
+      {
+        id: 'opencode',
+        version: OPENCODE_TOOLCHAIN_SPEC.opencode.version,
+        config: {
+          adapter: 'opencode_agent:MakaOpenCodeAgent',
+          externalSystemPrompt: 'empty',
+          variant: REASONING_EFFORT,
+          pure: true,
+          permissions: 'auto',
+          attemptPolicy: 'single',
+        },
+      },
+    ],
+    taskBudgetSec: null,
+    harborTimeoutMs: null,
+    subjectFingerprint,
+    taskSourceFingerprint,
+    toolchainFingerprint,
+  });
+}
+
 export async function main() {
   const repoRoot = resolve(fileURLToPath(new URL('../../..', import.meta.url)));
   const makaRepoPath = process.env.MAKA_HARNESS_AB_MAKA_REPO
@@ -149,48 +202,7 @@ async function runLocked({ repoRoot, makaRepoPath, tasksRoot, runId, limit, runR
     hostToolchainFingerprint,
     opencodeToolchainFingerprint: OPENCODE_TOOLCHAIN_FINGERPRINT,
   })).digest('hex')}`;
-  const manifest = buildHarnessAbRunManifest({
-    benchmark: {
-      dataset: 'terminal-bench',
-      version: '2.1',
-      revision: TERMINAL_BENCH_2_1_REVISION,
-      timeoutPolicy: 'task-native',
-      timeoutMultiplier: 1,
-      outerTimeoutGraceSec: HARBOR_SETUP_TEARDOWN_GRACE_SEC,
-    },
-    taskIds: TERMINAL_BENCH_2_1_TASK_IDS,
-    orderSeed: ORDER_SEED,
-    pilotTaskCount: PILOT_TASKS,
-    model: { provider: PROVIDER, id: MODEL, reasoningEffort: REASONING_EFFORT },
-    pricing: PRICING,
-    arms: [
-      {
-        id: 'maka',
-        version: subjectFingerprint,
-        config: {
-          adapter: 'maka_agent:MakaAgent',
-          externalSystemPrompt: 'empty',
-          reasoningEffort: REASONING_EFFORT,
-          continuation: false,
-          attemptPolicy: 'single',
-          contextBudget: HARNESS_MAKA_CONTEXT_BUDGET,
-        },
-      },
-      {
-        id: 'opencode',
-        version: OPENCODE_VERSION,
-        config: {
-          adapter: 'opencode_agent:MakaOpenCodeAgent',
-          externalSystemPrompt: 'empty',
-          variant: REASONING_EFFORT,
-          pure: true,
-          permissions: 'auto',
-          attemptPolicy: 'single',
-        },
-      },
-    ],
-    taskBudgetSec: null,
-    harborTimeoutMs: null,
+  const manifest = buildHarnessAbManifest({
     subjectFingerprint,
     taskSourceFingerprint,
     toolchainFingerprint,

--- a/packages/headless/harbor/run-harness-ab.mjs
+++ b/packages/headless/harbor/run-harness-ab.mjs
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 import { mkdir, readFile, rename, writeFile } from 'node:fs/promises';
+import { createHash } from 'node:crypto';
 import { homedir } from 'node:os';
 import { join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -11,6 +12,11 @@ import {
   resolveFixedPromptRunRoot,
 } from '#fixed-prompt-task-source';
 import { createHarborTaskRunner } from '#harbor-task-runner';
+import {
+  OPENCODE_TOOLCHAIN_FINGERPRINT,
+  OPENCODE_TOOLCHAIN_SPEC,
+  prepareOpenCodeToolchain,
+} from '#opencode-toolchain';
 import {
   assertTerminalBench21TaskSet,
   assertTerminalBench21TaskTreeFingerprint,
@@ -135,11 +141,15 @@ async function runLocked({ repoRoot, makaRepoPath, tasksRoot, runId, limit, runR
     makaRepoPath,
     process.env.MAKA_HARNESS_AB_EXPLICIT_SUBJECT_FINGERPRINT,
   );
-  const toolchainFingerprint = await buildToolchainFingerprint(
+  const hostToolchainFingerprint = await buildToolchainFingerprint(
     process.env.MAKA_HARNESS_AB_TOOLCHAIN_FINGERPRINT,
     undefined,
     makaRepoPath,
   );
+  const toolchainFingerprint = `sha256:${createHash('sha256').update(JSON.stringify({
+    hostToolchainFingerprint,
+    opencodeToolchainFingerprint: OPENCODE_TOOLCHAIN_FINGERPRINT,
+  })).digest('hex')}`;
   const manifest = buildHarnessAbRunManifest({
     benchmark: {
       dataset: 'terminal-bench',
@@ -196,6 +206,11 @@ async function runLocked({ repoRoot, makaRepoPath, tasksRoot, runId, limit, runR
     console.log(`dry-run: ${limit}/${EXPECTED_TASKS} paired Pass@1 cells planned -> ${manifestPath}`);
     return;
   }
+
+  const opencodeToolchainPath = process.env.MAKA_HARNESS_AB_OPENCODE_TOOLCHAIN
+    ? resolve(process.env.MAKA_HARNESS_AB_OPENCODE_TOOLCHAIN)
+    : join(runRoot, 'toolchains', `opencode-${OPENCODE_TOOLCHAIN_SPEC.opencode.version}-linux-x64`);
+  await prepareOpenCodeToolchain(opencodeToolchainPath);
 
   const keyFile = envPath('MAKA_HARNESS_AB_KEY_FILE', join(repoRoot, '.local-secrets/zai-key'));
   if ((await readFile(keyFile, 'utf8')).trim().length === 0) throw new Error('MAKA_HARNESS_AB_KEY_FILE is empty');
@@ -259,6 +274,7 @@ async function runLocked({ repoRoot, makaRepoPath, tasksRoot, runId, limit, runR
           ...runnerOptions,
           agent: 'opencode',
           agentVersion: OPENCODE_VERSION,
+          opencodeToolchainPath,
         }),
       },
     ],

--- a/packages/headless/harbor/run-harness-ab.mjs
+++ b/packages/headless/harbor/run-harness-ab.mjs
@@ -48,7 +48,6 @@ const PROVIDER = 'zai-coding-plan';
 const MODEL = 'glm-5.2';
 const MODEL_SPEC = `${PROVIDER}/${MODEL}`;
 const REASONING_EFFORT = 'max';
-const OPENCODE_VERSION = '1.17.18';
 const BASE_URL = 'https://api.z.ai/api/coding/paas/v4';
 const ORDER_SEED = 'terminal-bench-2.1:glm-5.2:maka-vs-opencode:v1';
 const PRICING = {
@@ -239,6 +238,7 @@ async function runLocked({ repoRoot, makaRepoPath, tasksRoot, runId, limit, runR
     pricing,
     agentEnv: { ZAI_BASE_URL: BASE_URL },
     timeoutMultiplier: 1,
+    dockerPlatform: 'linux/amd64',
   };
   const makaContextBudgetEnv = harnessMakaContextBudgetEnv();
   const config = (id) => ({
@@ -273,7 +273,7 @@ async function runLocked({ repoRoot, makaRepoPath, tasksRoot, runId, limit, runR
         harborRunner: createHarborTaskRunner({
           ...runnerOptions,
           agent: 'opencode',
-          agentVersion: OPENCODE_VERSION,
+          agentVersion: OPENCODE_TOOLCHAIN_SPEC.opencode.version,
           opencodeToolchainPath,
         }),
       },

--- a/packages/headless/package.json
+++ b/packages/headless/package.json
@@ -36,6 +36,7 @@
     "#prompt-ab-run": "./dist/prompt-ab-run.js",
     "#harbor-task-runner": "./dist/harbor-task-runner.js",
     "#harbor-cell": "./dist/harbor-cell.js",
+    "#opencode-toolchain": "./dist/opencode-toolchain.js",
     "#runtime-policy-ab-profile": "./dist/runtime-policy-ab-profile.js",
     "#runtime-policy-ab-spec": "./dist/runtime-policy-ab-spec.js",
     "#runtime-policy-ab-run": "./dist/runtime-policy-ab-run.js",

--- a/packages/headless/src/__tests__/harbor-adapter.test.ts
+++ b/packages/headless/src/__tests__/harbor-adapter.test.ts
@@ -1494,7 +1494,6 @@ try:
         asyncio.run(agent.install(environment))
         install_command, install_env = environment.agent_commands[0]
         assert "/opt/maka-opencode-toolchain/bin/node" in install_command, install_command
-        assert "/opt/maka-opencode-toolchain/bin/opencode" in install_command, install_command
         assert "sha256sum --check" in install_command, install_command
         assert "MAKA_EXPECTED_TOOLCHAIN_FINGERPRINT" in install_command, install_command
         assert install_env["MAKA_EXPECTED_TOOLCHAIN_FINGERPRINT"] == "sha256:" + "a" * 64, install_env
@@ -1502,6 +1501,7 @@ try:
         assert "npm" not in install_command, install_command
         assert "nvm" not in install_command, install_command
         assert "apt-get" not in install_command, install_command
+        assert "--version" not in install_command, install_command
         assert environment.root_commands == [], environment.root_commands
 
         asyncio.run(agent.run("hi", environment, context))

--- a/packages/headless/src/__tests__/harbor-adapter.test.ts
+++ b/packages/headless/src/__tests__/harbor-adapter.test.ts
@@ -1472,6 +1472,7 @@ try:
             "MAKA_SYSTEM_PROMPT": "",
             "MAKA_REASONING_EFFORT": "max",
             "MAKA_OPENCODE_VARIANT": "max",
+            "MAKA_OPENCODE_TOOLCHAIN_FINGERPRINT": "sha256:" + "a" * 64,
             "MAKA_TRIAL_INPUT_USD_PER_1M": "2",
             "MAKA_TRIAL_OUTPUT_USD_PER_1M": "10",
             "MAKA_TRIAL_CACHE_READ_USD_PER_1M": "0.5",
@@ -1491,17 +1492,26 @@ try:
         agent.exec_as_agent = exec_as_agent
 
         asyncio.run(agent.install(environment))
-        install_command, install_kwargs = environment.root_commands[0]
-        assert "for attempt in 1 2 3" in install_command, install_command
-        assert "Acquire::Retries=3" in install_command, install_command
-        assert "sleep $((attempt * 5))" in install_command, install_command
-        assert install_kwargs["env"] == {"DEBIAN_FRONTEND": "noninteractive"}, install_kwargs
+        install_command, install_env = environment.agent_commands[0]
+        assert "/opt/maka-opencode-toolchain/bin/node" in install_command, install_command
+        assert "/opt/maka-opencode-toolchain/bin/opencode" in install_command, install_command
+        assert "sha256sum --check" in install_command, install_command
+        assert "MAKA_EXPECTED_TOOLCHAIN_FINGERPRINT" in install_command, install_command
+        assert install_env["MAKA_EXPECTED_TOOLCHAIN_FINGERPRINT"] == "sha256:" + "a" * 64, install_env
+        assert "curl" not in install_command, install_command
+        assert "npm" not in install_command, install_command
+        assert "nvm" not in install_command, install_command
+        assert "apt-get" not in install_command, install_command
+        assert environment.root_commands == [], environment.root_commands
 
         asyncio.run(agent.run("hi", environment, context))
         command, env = next(item for item in environment.agent_commands if "opencode --model=" in item[0])
         assert "opencode-stop-runner.mjs" in command, command
         assert "--output /logs/agent/opencode.txt" in command, command
         assert "opencode --model=zai-coding-plan/glm-5.2 run --format=json" in command, command
+        assert "/opt/maka-opencode-toolchain/bin/node" in command, command
+        assert "/opt/maka-opencode-toolchain/bin/opencode" in command, command
+        assert ".nvm" not in command, command
         assert "--pure" in command, command
         assert "--auto" in command, command
         assert "--dangerously-skip-permissions" not in command, command
@@ -1521,7 +1531,7 @@ try:
         assert 'cat --' not in command, command
         assert "test-zai-key" not in command, command
         assert "test-zai-key" not in json.dumps(env), env
-        assert len(environment.root_commands) == 1, environment.root_commands
+        assert environment.root_commands == [], environment.root_commands
         assert os.environ.get("ZAI_API_KEY") is None
         assert os.environ.get("ZAI_BASE_URL") is None
 

--- a/packages/headless/src/__tests__/harbor-task-runner.test.ts
+++ b/packages/headless/src/__tests__/harbor-task-runner.test.ts
@@ -868,7 +868,10 @@ describe('createHarborTaskRunner', () => {
 
 describe('buildHarborJobConfig', () => {
   test('pins the OpenCode adapter and max model variant without serializing credentials', () => {
-    const toolchain = { opencodeToolchainPath: '/cache/opencode-1.17.18-linux-x64' };
+    const toolchain = {
+      opencodeToolchainPath: '/cache/opencode-1.17.18-linux-x64',
+      dockerPlatform: 'linux/amd64',
+    } as const;
     const config = buildHarborJobConfig(runInput(), {
       makaRepoPath: '/repo',
       jobsDir: '/jobs/x',
@@ -884,6 +887,7 @@ describe('buildHarborJobConfig', () => {
     const agent = (config.agents as Array<Record<string, unknown>>)[0]!;
     const env = agent.env as Record<string, string>;
     const mounts = (config.environment as { mounts: Array<Record<string, unknown>> }).mounts;
+    const extraDockerCompose = (config.environment as { extra_docker_compose?: string[] }).extra_docker_compose;
 
     // Harbor resolves built-in names before import_path, so setting both would
     // silently bypass MakaOpenCodeAgent and its host-side auth proxy.
@@ -900,8 +904,26 @@ describe('buildHarborJobConfig', () => {
       && mount.target === '/opt/maka-opencode-toolchain'
       && mount.read_only === true
     )));
+    assert.deepEqual(extraDockerCompose, ['/repo/packages/headless/harbor/docker-compose-linux-amd64.yaml']);
     assert.equal(env.ZAI_API_KEY, undefined);
     assert.equal(env.ZAI_API_KEY_FILE, undefined);
+  });
+
+  test('pins the Maka arm to the same Docker platform as OpenCode', () => {
+    const config = buildHarborJobConfig(runInput(), {
+      makaRepoPath: '/repo',
+      jobsDir: '/jobs/x',
+      jobName: 'trial',
+      agent: 'maka',
+      model: 'zai-coding-plan/glm-5.2',
+      provider: 'zai-coding-plan',
+      dockerPlatform: 'linux/amd64',
+    } as Parameters<typeof buildHarborJobConfig>[1]);
+
+    assert.deepEqual(
+      (config.environment as { extra_docker_compose?: string[] }).extra_docker_compose,
+      ['/repo/packages/headless/harbor/docker-compose-linux-amd64.yaml'],
+    );
   });
 
   test('requires a prepared toolchain for OpenCode before Harbor starts', () => {

--- a/packages/headless/src/__tests__/harbor-task-runner.test.ts
+++ b/packages/headless/src/__tests__/harbor-task-runner.test.ts
@@ -311,6 +311,8 @@ describe('createHarborTaskRunner', () => {
         makaRepoPath: repo,
         jobsDir,
         agent: 'opencode',
+        opencodeToolchainPath: '/toolchain',
+        agentVersion: '1.17.18',
         model: 'github-copilot/gpt-5.4',
         provider: 'github-copilot',
         apiKeyFile: keyFile,
@@ -332,6 +334,7 @@ describe('createHarborTaskRunner', () => {
         makaRepoPath: repo,
         jobsDir,
         agent: 'opencode',
+        opencodeToolchainPath: '/toolchain',
         agentVersion: '1.17.18',
         model: 'zai-coding-plan/glm-5.2',
         provider: 'zai-coding-plan',
@@ -365,6 +368,8 @@ describe('createHarborTaskRunner', () => {
         makaRepoPath: repo,
         jobsDir,
         agent: 'opencode',
+        opencodeToolchainPath: '/toolchain',
+        agentVersion: '1.17.18',
         model: 'ollama/qwen2.5-coder:7b',
         provider: 'ollama',
         agentEnv: { MAKA_BASE_URL: 'http://host.docker.internal:11434/v1' },
@@ -863,6 +868,7 @@ describe('createHarborTaskRunner', () => {
 
 describe('buildHarborJobConfig', () => {
   test('pins the OpenCode adapter and max model variant without serializing credentials', () => {
+    const toolchain = { opencodeToolchainPath: '/cache/opencode-1.17.18-linux-x64' };
     const config = buildHarborJobConfig(runInput(), {
       makaRepoPath: '/repo',
       jobsDir: '/jobs/x',
@@ -873,9 +879,11 @@ describe('buildHarborJobConfig', () => {
       reasoningEffort: 'max',
       agentVersion: '1.17.18',
       pricing: { inputUsdPer1M: 1.4, cacheReadUsdPer1M: 0.26, outputUsdPer1M: 4.4 },
+      ...toolchain,
     });
     const agent = (config.agents as Array<Record<string, unknown>>)[0]!;
     const env = agent.env as Record<string, string>;
+    const mounts = (config.environment as { mounts: Array<Record<string, unknown>> }).mounts;
 
     // Harbor resolves built-in names before import_path, so setting both would
     // silently bypass MakaOpenCodeAgent and its host-side auth proxy.
@@ -886,8 +894,29 @@ describe('buildHarborJobConfig', () => {
     assert.equal(env.MAKA_OPENCODE_VARIANT, 'max');
     assert.equal(env.MAKA_LLM_CONNECTION_SLUG, 'zai-coding-plan');
     assert.equal(env.MAKA_REASONING_EFFORT, 'max');
+    assert.match(env.MAKA_OPENCODE_TOOLCHAIN_FINGERPRINT, /^sha256:[a-f0-9]{64}$/);
+    assert.ok(mounts.some((mount) => (
+      mount.source === '/cache/opencode-1.17.18-linux-x64'
+      && mount.target === '/opt/maka-opencode-toolchain'
+      && mount.read_only === true
+    )));
     assert.equal(env.ZAI_API_KEY, undefined);
     assert.equal(env.ZAI_API_KEY_FILE, undefined);
+  });
+
+  test('requires a prepared toolchain for OpenCode before Harbor starts', () => {
+    assert.throws(
+      () => buildHarborJobConfig(runInput(), {
+        makaRepoPath: '/repo',
+        jobsDir: '/jobs/x',
+        jobName: 'trial',
+        agent: 'opencode',
+        model: 'zai-coding-plan/glm-5.2',
+        provider: 'zai-coding-plan',
+        agentVersion: '1.17.18',
+      }),
+      /opencodeToolchainPath is required for the OpenCode adapter/,
+    );
   });
 
   test('rejects experiment identity overrides in extra agent env', () => {

--- a/packages/headless/src/__tests__/harness-ab-cli.test.ts
+++ b/packages/headless/src/__tests__/harness-ab-cli.test.ts
@@ -44,6 +44,23 @@ test('harness A/B runtime keeps pruning enabled and semantic compact disabled', 
   });
 });
 
+test('harness A/B manifest uses the pinned OpenCode toolchain version', async () => {
+  const { buildHarnessAbManifest } = await import(
+    new URL('../../harbor/run-harness-ab.mjs', import.meta.url).href
+  );
+
+  const manifest = buildHarnessAbManifest({
+    subjectFingerprint: 'subject',
+    taskSourceFingerprint: 'tasks',
+    toolchainFingerprint: 'tools',
+  });
+
+  assert.equal(
+    manifest.arms.find((arm: { id: string }) => arm.id === 'opencode')?.metadata.version,
+    '1.17.18',
+  );
+});
+
 test('detached harness launcher persists a terminal failed journal after the worker exits', async () => {
   const dir = await mkdtemp(join(tmpdir(), 'maka-harness-ab-detached-'));
   try {

--- a/packages/headless/src/__tests__/opencode-toolchain.test.ts
+++ b/packages/headless/src/__tests__/opencode-toolchain.test.ts
@@ -1,0 +1,63 @@
+import assert from 'node:assert/strict';
+import { createHash } from 'node:crypto';
+import { chmod, mkdtemp, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, test } from 'node:test';
+import {
+  OPENCODE_TOOLCHAIN_FINGERPRINT,
+  OPENCODE_TOOLCHAIN_SPEC,
+} from '../opencode-toolchain.js';
+
+describe('OpenCode toolchain', () => {
+  test('validates a prepared toolchain and rejects binary drift', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'maka-opencode-toolchain-'));
+    try {
+      const binDir = join(root, 'bin');
+      await mkdir(binDir);
+      await writeFile(join(binDir, 'node'), 'pinned node\n');
+      await writeFile(join(binDir, 'opencode'), 'pinned opencode\n');
+      await chmod(join(binDir, 'node'), 0o755);
+      await chmod(join(binDir, 'opencode'), 0o755);
+      const files = {
+        'bin/node': sha256('pinned node\n'),
+        'bin/opencode': sha256('pinned opencode\n'),
+      };
+      await writeFile(join(root, 'manifest.json'), `${JSON.stringify({
+        schemaVersion: 1,
+        fingerprint: OPENCODE_TOOLCHAIN_FINGERPRINT,
+        spec: OPENCODE_TOOLCHAIN_SPEC,
+        files,
+      }, null, 2)}\n`);
+      await writeFile(
+        join(root, 'checksums.sha256'),
+        Object.entries(files).map(([path, hash]) => `${hash}  ${path}\n`).join(''),
+      );
+
+      const module = await import('../opencode-toolchain.js') as Record<string, unknown>;
+      const validate = module.validatePreparedOpenCodeToolchain as ((path: string) => Promise<unknown>);
+      const prepare = module.prepareOpenCodeToolchain as ((
+        path: string,
+        options: { fetchFn: typeof fetch },
+      ) => Promise<{ path: string; fingerprint: string }>);
+      await validate(root);
+      const reused = await prepare(root, {
+        fetchFn: async () => {
+          throw new Error('a valid prepared toolchain must not access the network');
+        },
+      });
+      assert.equal(reused.path, root);
+      assert.equal(reused.fingerprint, OPENCODE_TOOLCHAIN_FINGERPRINT);
+
+      await writeFile(join(binDir, 'opencode'), 'drifted opencode\n');
+      await assert.rejects(validate(root), /bin\/opencode SHA-256 mismatch/);
+      assert.match(await readFile(join(root, 'manifest.json'), 'utf8'), /1\.17\.18/);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+});
+
+function sha256(value: string): string {
+  return createHash('sha256').update(value).digest('hex');
+}

--- a/packages/headless/src/__tests__/opencode-toolchain.test.ts
+++ b/packages/headless/src/__tests__/opencode-toolchain.test.ts
@@ -10,7 +10,15 @@ import {
 } from '../opencode-toolchain.js';
 
 describe('OpenCode toolchain', () => {
-  test('validates a prepared toolchain and rejects binary drift', async () => {
+  test('binds the fingerprint to the extracted binaries and rejects a self-signed cache', async () => {
+    assert.equal(
+      (OPENCODE_TOOLCHAIN_SPEC.node as { binarySha256?: string }).binarySha256,
+      '93956de2e59480474a7b46571da1651180b1a050cdf32641ebec4ce6e478e068',
+    );
+    assert.equal(
+      (OPENCODE_TOOLCHAIN_SPEC.opencode as { binarySha256?: string }).binarySha256,
+      '0cbfb6de55aa4ce3c74da12d8516376033693a88abca6238c5be32bf98130636',
+    );
     const root = await mkdtemp(join(tmpdir(), 'maka-opencode-toolchain-'));
     try {
       const binDir = join(root, 'bin');
@@ -34,23 +42,11 @@ describe('OpenCode toolchain', () => {
         Object.entries(files).map(([path, hash]) => `${hash}  ${path}\n`).join(''),
       );
 
-      const module = await import('../opencode-toolchain.js') as Record<string, unknown>;
-      const validate = module.validatePreparedOpenCodeToolchain as ((path: string) => Promise<unknown>);
-      const prepare = module.prepareOpenCodeToolchain as ((
-        path: string,
-        options: { fetchFn: typeof fetch },
-      ) => Promise<{ path: string; fingerprint: string }>);
-      await validate(root);
-      const reused = await prepare(root, {
-        fetchFn: async () => {
-          throw new Error('a valid prepared toolchain must not access the network');
-        },
-      });
-      assert.equal(reused.path, root);
-      assert.equal(reused.fingerprint, OPENCODE_TOOLCHAIN_FINGERPRINT);
-
-      await writeFile(join(binDir, 'opencode'), 'drifted opencode\n');
-      await assert.rejects(validate(root), /bin\/opencode SHA-256 mismatch/);
+      const { validatePreparedOpenCodeToolchain } = await import('../opencode-toolchain.js');
+      await assert.rejects(
+        validatePreparedOpenCodeToolchain(root),
+        /bin\/node SHA-256 mismatch/,
+      );
       assert.match(await readFile(join(root, 'manifest.json'), 'utf8'), /1\.17\.18/);
     } finally {
       await rm(root, { recursive: true, force: true });

--- a/packages/headless/src/harbor-task-runner.ts
+++ b/packages/headless/src/harbor-task-runner.ts
@@ -70,6 +70,8 @@ export interface HarborTaskRunnerOptions {
   agentVersion?: string;
   /** Prepared OpenCode toolchain mounted read-only into task containers. */
   opencodeToolchainPath?: string;
+  /** Explicit Docker target platform shared by comparison arms. */
+  dockerPlatform?: 'linux/amd64';
   /** Base directory under which each task gets an isolated per-task job dir. */
   jobsDir: string;
   /** MAKA_MODEL, e.g. "deepseek/deepseek-v4-flash". */
@@ -471,6 +473,9 @@ export function buildHarborJobConfig(
       force_build: false,
       delete: true,
       mounts,
+      ...(options.dockerPlatform === 'linux/amd64'
+        ? { extra_docker_compose: [join(options.makaRepoPath, 'packages/headless/harbor/docker-compose-linux-amd64.yaml')] }
+        : {}),
     },
     verifier: { env: {}, disable: false },
     metrics: [{ type: 'mean', kwargs: {} }],

--- a/packages/headless/src/harbor-task-runner.ts
+++ b/packages/headless/src/harbor-task-runner.ts
@@ -25,6 +25,11 @@ import {
   providerCredentialEnv,
   requireProviderCredentialEnv,
 } from './provider-env.js';
+import {
+  OPENCODE_TOOLCHAIN_CONTAINER_PATH,
+  OPENCODE_TOOLCHAIN_FINGERPRINT,
+  OPENCODE_TOOLCHAIN_SPEC,
+} from './opencode-toolchain.js';
 
 const execFileAsync = promisify(execFile);
 
@@ -63,6 +68,8 @@ export interface HarborTaskRunnerOptions {
   agent?: 'maka' | 'opencode';
   /** Version passed to Harbor's installed-agent adapter (used to pin OpenCode). */
   agentVersion?: string;
+  /** Prepared OpenCode toolchain mounted read-only into task containers. */
+  opencodeToolchainPath?: string;
   /** Base directory under which each task gets an isolated per-task job dir. */
   jobsDir: string;
   /** MAKA_MODEL, e.g. "deepseek/deepseek-v4-flash". */
@@ -404,8 +411,17 @@ export function buildHarborJobConfig(
   const makaModel = modelIdForProvider(options.model, provider);
   const adapter = options.agent ?? 'maka';
   const agentModel = adapter === 'opencode' ? modelForOpenCode(options.model, provider) : makaModel;
+  if (adapter === 'opencode' && !options.opencodeToolchainPath) {
+    throw new Error('opencodeToolchainPath is required for the OpenCode adapter');
+  }
+  if (adapter === 'opencode' && options.agentVersion !== OPENCODE_TOOLCHAIN_SPEC.opencode.version) {
+    throw new Error(`OpenCode adapter version must match toolchain version ${OPENCODE_TOOLCHAIN_SPEC.opencode.version}`);
+  }
   const mounts: Array<Record<string, unknown>> = [
     { type: 'bind', source: options.makaRepoPath, target: CONTAINER_MAKA_REPO, read_only: true },
+    ...(adapter === 'opencode'
+      ? [{ type: 'bind', source: options.opencodeToolchainPath!, target: OPENCODE_TOOLCHAIN_CONTAINER_PATH, read_only: true }]
+      : []),
   ];
 
   const agentEnv: Record<string, string> = {
@@ -419,6 +435,9 @@ export function buildHarborJobConfig(
   if (options.reasoningEffort) {
     agentEnv.MAKA_REASONING_EFFORT = options.reasoningEffort;
     if (adapter === 'opencode') agentEnv.MAKA_OPENCODE_VARIANT = options.reasoningEffort;
+  }
+  if (adapter === 'opencode') {
+    agentEnv.MAKA_OPENCODE_TOOLCHAIN_FINGERPRINT = OPENCODE_TOOLCHAIN_FINGERPRINT;
   }
 
   if (options.pricing) {

--- a/packages/headless/src/opencode-toolchain.ts
+++ b/packages/headless/src/opencode-toolchain.ts
@@ -26,11 +26,13 @@ export const OPENCODE_TOOLCHAIN_SPEC = {
     version: '22.23.1',
     archiveUrl: 'https://nodejs.org/dist/v22.23.1/node-v22.23.1-linux-x64.tar.gz',
     archiveSha256: '7a8cb04b4a1df4eaf432125324b81b29a088e73570a23259a8de1c65d07fc129',
+    binarySha256: '93956de2e59480474a7b46571da1651180b1a050cdf32641ebec4ce6e478e068',
   },
   opencode: {
     version: '1.17.18',
     archiveUrl: 'https://registry.npmjs.org/opencode-linux-x64/-/opencode-linux-x64-1.17.18.tgz',
     archiveIntegrity: 'sha512-8BmT22yp7pCXXu/HvAMaJsNNd6xhmlUrGs5YZSfU0neZfkSZg+Dkf9IGsuOugOtL0x2erDg2/6rRBpcJAGmTrA==',
+    binarySha256: '0cbfb6de55aa4ce3c74da12d8516376033693a88abca6238c5be32bf98130636',
   },
 } as const;
 
@@ -47,7 +49,6 @@ interface OpenCodeToolchainManifest {
   schemaVersion: 1;
   fingerprint: typeof OPENCODE_TOOLCHAIN_FINGERPRINT;
   spec: typeof OPENCODE_TOOLCHAIN_SPEC;
-  files: Record<'bin/node' | 'bin/opencode', string>;
 }
 
 export async function validatePreparedOpenCodeToolchain(path: string): Promise<PreparedOpenCodeToolchain> {
@@ -58,12 +59,13 @@ export async function validatePreparedOpenCodeToolchain(path: string): Promise<P
   if (JSON.stringify(manifest.spec) !== JSON.stringify(OPENCODE_TOOLCHAIN_SPEC)) {
     throw new Error('OpenCode toolchain spec does not match the pinned contract');
   }
+  const pinnedFiles = {
+    'bin/node': OPENCODE_TOOLCHAIN_SPEC.node.binarySha256,
+    'bin/opencode': OPENCODE_TOOLCHAIN_SPEC.opencode.binarySha256,
+  } as const;
   const checksums: string[] = [];
   for (const relativePath of ['bin/node', 'bin/opencode'] as const) {
-    const expected = manifest.files[relativePath];
-    if (!/^[a-f0-9]{64}$/.test(expected)) {
-      throw new Error(`OpenCode toolchain manifest is missing ${relativePath} SHA-256`);
-    }
+    const expected = pinnedFiles[relativePath];
     const actual = await sha256File(join(path, relativePath));
     if (actual !== expected) {
       throw new Error(`OpenCode toolchain ${relativePath} SHA-256 mismatch`);
@@ -122,14 +124,13 @@ export async function prepareOpenCodeToolchain(
     await chmod(join(binDir, 'opencode'), 0o755);
 
     const files = {
-      'bin/node': await sha256File(join(binDir, 'node')),
-      'bin/opencode': await sha256File(join(binDir, 'opencode')),
+      'bin/node': OPENCODE_TOOLCHAIN_SPEC.node.binarySha256,
+      'bin/opencode': OPENCODE_TOOLCHAIN_SPEC.opencode.binarySha256,
     };
     const manifest: OpenCodeToolchainManifest = {
       schemaVersion: 1,
       fingerprint: OPENCODE_TOOLCHAIN_FINGERPRINT,
       spec: OPENCODE_TOOLCHAIN_SPEC,
-      files,
     };
     await writeFile(join(temporaryPath, 'manifest.json'), `${JSON.stringify(manifest, null, 2)}\n`, 'utf8');
     await writeFile(
@@ -160,7 +161,7 @@ function parseManifest(raw: string): OpenCodeToolchainManifest {
   } catch (error) {
     throw new Error('OpenCode toolchain manifest is not valid JSON', { cause: error });
   }
-  if (!isRecord(value) || value.schemaVersion !== 1 || !isRecord(value.spec) || !isRecord(value.files)) {
+  if (!isRecord(value) || value.schemaVersion !== 1 || !isRecord(value.spec)) {
     throw new Error('OpenCode toolchain manifest has an invalid shape');
   }
   return value as unknown as OpenCodeToolchainManifest;

--- a/packages/headless/src/opencode-toolchain.ts
+++ b/packages/headless/src/opencode-toolchain.ts
@@ -1,0 +1,203 @@
+import { createHash } from 'node:crypto';
+import { execFile } from 'node:child_process';
+import { createReadStream } from 'node:fs';
+import {
+  access,
+  chmod,
+  mkdir,
+  mkdtemp,
+  readFile,
+  rename,
+  rm,
+  writeFile,
+} from 'node:fs/promises';
+import { basename, dirname, join } from 'node:path';
+import { promisify } from 'node:util';
+
+const execFileAsync = promisify(execFile);
+
+export const OPENCODE_TOOLCHAIN_CONTAINER_PATH = '/opt/maka-opencode-toolchain';
+
+export const OPENCODE_TOOLCHAIN_SPEC = {
+  schemaVersion: 1,
+  platform: 'linux',
+  arch: 'x64',
+  node: {
+    version: '22.23.1',
+    archiveUrl: 'https://nodejs.org/dist/v22.23.1/node-v22.23.1-linux-x64.tar.gz',
+    archiveSha256: '7a8cb04b4a1df4eaf432125324b81b29a088e73570a23259a8de1c65d07fc129',
+  },
+  opencode: {
+    version: '1.17.18',
+    archiveUrl: 'https://registry.npmjs.org/opencode-linux-x64/-/opencode-linux-x64-1.17.18.tgz',
+    archiveIntegrity: 'sha512-8BmT22yp7pCXXu/HvAMaJsNNd6xhmlUrGs5YZSfU0neZfkSZg+Dkf9IGsuOugOtL0x2erDg2/6rRBpcJAGmTrA==',
+  },
+} as const;
+
+export const OPENCODE_TOOLCHAIN_FINGERPRINT = `sha256:${createHash('sha256')
+  .update(JSON.stringify(OPENCODE_TOOLCHAIN_SPEC))
+  .digest('hex')}`;
+
+export interface PreparedOpenCodeToolchain {
+  path: string;
+  fingerprint: typeof OPENCODE_TOOLCHAIN_FINGERPRINT;
+}
+
+interface OpenCodeToolchainManifest {
+  schemaVersion: 1;
+  fingerprint: typeof OPENCODE_TOOLCHAIN_FINGERPRINT;
+  spec: typeof OPENCODE_TOOLCHAIN_SPEC;
+  files: Record<'bin/node' | 'bin/opencode', string>;
+}
+
+export async function validatePreparedOpenCodeToolchain(path: string): Promise<PreparedOpenCodeToolchain> {
+  const manifest = parseManifest(await readFile(join(path, 'manifest.json'), 'utf8'));
+  if (manifest.fingerprint !== OPENCODE_TOOLCHAIN_FINGERPRINT) {
+    throw new Error(`OpenCode toolchain fingerprint mismatch: ${manifest.fingerprint}`);
+  }
+  if (JSON.stringify(manifest.spec) !== JSON.stringify(OPENCODE_TOOLCHAIN_SPEC)) {
+    throw new Error('OpenCode toolchain spec does not match the pinned contract');
+  }
+  const checksums: string[] = [];
+  for (const relativePath of ['bin/node', 'bin/opencode'] as const) {
+    const expected = manifest.files[relativePath];
+    if (!/^[a-f0-9]{64}$/.test(expected)) {
+      throw new Error(`OpenCode toolchain manifest is missing ${relativePath} SHA-256`);
+    }
+    const actual = await sha256File(join(path, relativePath));
+    if (actual !== expected) {
+      throw new Error(`OpenCode toolchain ${relativePath} SHA-256 mismatch`);
+    }
+    checksums.push(`${expected}  ${relativePath}\n`);
+  }
+  if (await readFile(join(path, 'checksums.sha256'), 'utf8') !== checksums.join('')) {
+    throw new Error('OpenCode toolchain checksums.sha256 does not match its manifest');
+  }
+  return { path, fingerprint: OPENCODE_TOOLCHAIN_FINGERPRINT };
+}
+
+export async function prepareOpenCodeToolchain(
+  path: string,
+  options: { fetchFn?: typeof fetch } = {},
+): Promise<PreparedOpenCodeToolchain> {
+  if (await exists(join(path, 'manifest.json'))) {
+    return validatePreparedOpenCodeToolchain(path);
+  }
+  await mkdir(dirname(path), { recursive: true });
+  const temporaryPath = await mkdtemp(join(dirname(path), `.${basename(path)}-`));
+  try {
+    const nodeArchive = join(temporaryPath, 'node.tar.gz');
+    const opencodeArchive = join(temporaryPath, 'opencode.tgz');
+    await downloadVerified({
+      url: OPENCODE_TOOLCHAIN_SPEC.node.archiveUrl,
+      path: nodeArchive,
+      algorithm: 'sha256',
+      expected: OPENCODE_TOOLCHAIN_SPEC.node.archiveSha256,
+      fetchFn: options.fetchFn ?? fetch,
+    });
+    await downloadVerified({
+      url: OPENCODE_TOOLCHAIN_SPEC.opencode.archiveUrl,
+      path: opencodeArchive,
+      algorithm: 'sha512',
+      expected: OPENCODE_TOOLCHAIN_SPEC.opencode.archiveIntegrity.slice('sha512-'.length),
+      encoding: 'base64',
+      fetchFn: options.fetchFn ?? fetch,
+    });
+
+    const binDir = join(temporaryPath, 'bin');
+    await mkdir(binDir);
+    await execFileAsync('tar', [
+      '-xzf', nodeArchive,
+      '-C', binDir,
+      '--strip-components=2',
+      `node-v${OPENCODE_TOOLCHAIN_SPEC.node.version}-linux-x64/bin/node`,
+    ]);
+    await execFileAsync('tar', [
+      '-xzf', opencodeArchive,
+      '-C', binDir,
+      '--strip-components=2',
+      'package/bin/opencode',
+    ]);
+    await chmod(join(binDir, 'node'), 0o755);
+    await chmod(join(binDir, 'opencode'), 0o755);
+
+    const files = {
+      'bin/node': await sha256File(join(binDir, 'node')),
+      'bin/opencode': await sha256File(join(binDir, 'opencode')),
+    };
+    const manifest: OpenCodeToolchainManifest = {
+      schemaVersion: 1,
+      fingerprint: OPENCODE_TOOLCHAIN_FINGERPRINT,
+      spec: OPENCODE_TOOLCHAIN_SPEC,
+      files,
+    };
+    await writeFile(join(temporaryPath, 'manifest.json'), `${JSON.stringify(manifest, null, 2)}\n`, 'utf8');
+    await writeFile(
+      join(temporaryPath, 'checksums.sha256'),
+      Object.entries(files).map(([relativePath, hash]) => `${hash}  ${relativePath}\n`).join(''),
+      'utf8',
+    );
+    await rm(nodeArchive);
+    await rm(opencodeArchive);
+    await validatePreparedOpenCodeToolchain(temporaryPath);
+    try {
+      await rename(temporaryPath, path);
+    } catch (error) {
+      const code = (error as NodeJS.ErrnoException).code;
+      if (code !== 'EEXIST' && code !== 'ENOTEMPTY') throw error;
+      await validatePreparedOpenCodeToolchain(path);
+    }
+    return { path, fingerprint: OPENCODE_TOOLCHAIN_FINGERPRINT };
+  } finally {
+    await rm(temporaryPath, { recursive: true, force: true });
+  }
+}
+
+function parseManifest(raw: string): OpenCodeToolchainManifest {
+  let value: unknown;
+  try {
+    value = JSON.parse(raw);
+  } catch (error) {
+    throw new Error('OpenCode toolchain manifest is not valid JSON', { cause: error });
+  }
+  if (!isRecord(value) || value.schemaVersion !== 1 || !isRecord(value.spec) || !isRecord(value.files)) {
+    throw new Error('OpenCode toolchain manifest has an invalid shape');
+  }
+  return value as unknown as OpenCodeToolchainManifest;
+}
+
+async function downloadVerified(input: {
+  url: string;
+  path: string;
+  algorithm: 'sha256' | 'sha512';
+  expected: string;
+  encoding?: 'hex' | 'base64';
+  fetchFn: typeof fetch;
+}): Promise<void> {
+  const response = await input.fetchFn(input.url);
+  if (!response.ok) throw new Error(`failed to download ${input.url}: HTTP ${response.status}`);
+  const bytes = new Uint8Array(await response.arrayBuffer());
+  const actual = createHash(input.algorithm).update(bytes).digest(input.encoding ?? 'hex');
+  if (actual !== input.expected) throw new Error(`archive checksum mismatch for ${input.url}`);
+  await writeFile(input.path, bytes);
+}
+
+async function sha256File(path: string): Promise<string> {
+  const hash = createHash('sha256');
+  for await (const chunk of createReadStream(path)) hash.update(chunk);
+  return hash.digest('hex');
+}
+
+async function exists(path: string): Promise<boolean> {
+  try {
+    await access(path);
+    return true;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return false;
+    throw error;
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}


### PR DESCRIPTION
## Summary

- replace OpenCode's per-cell `apt`/NVM/npm installation with one host-prepared, checksum-verified toolchain
- pin both A/B arms to `linux/amd64` through Harbor's Docker Compose overlay seam
- bind the toolchain fingerprint to the published archives and the exact extracted Node 22.23.1/OpenCode 1.17.18 binary hashes
- mount the toolchain read-only and fail before model execution on platform, fingerprint, or binary drift
- keep the TypeScript toolchain spec as the version authority instead of copying versions into the harness and Python adapter

Refs #1021.

## Verification

- `npm test --workspace @maka/headless` — 965 passed, 0 failed, 1 existing conditional skip
- Harbor's base Compose file plus the checked-in overlay resolves to `platform: linux/amd64`
- prepared the pinned bundle from the published Node and OpenCode archives and verified both archive checksums and extracted binary hashes
- mounted the bundle read-only into `ubuntu:24.04` with `--platform linux/amd64 --network none`; both pinned binary checksums passed

A real-provider Harbor canary was not run; this slice validates the exact mounted artifact and task platform without using credentials.
