### PR TITLE
fix(headless): rebank RSI reference when addressability changes

### DIFF
--- a/packages/headless/src/__tests__/prompt-optimization-loop.test.ts
+++ b/packages/headless/src/__tests__/prompt-optimization-loop.test.ts
@@ -761,7 +761,7 @@ describe('runPromptOptimizationLoop', () => {
     });
   });
 
-  test('excludes a capability-limit task after two retained prompts but keeps executing it', async () => {
+  test('re-banks the held-in reference when a capability-limit task shrinks the decision set', async () => {
     await withHarness(async (harness) => {
       const heldInTasks = makeTasks('hin', 20);
       const heldOutTasks = makeTasks('hout', 4);
@@ -803,6 +803,15 @@ describe('runPromptOptimizationLoop', () => {
           rejectionReason: 'capability_limit',
         },
       );
+      assert.equal(
+        first.heldInReferencePassEligibleRate,
+        1 - promptAcceptanceNoiseBand({
+          sampleSize: 19,
+          passRate: 10 / 19,
+          baselineRunCount: 2,
+          zScore: 1.96,
+        }),
+      );
       proposalInputs.length = 0;
 
       const replayedFirst = await runLoop(harness, {
@@ -817,6 +826,7 @@ describe('runPromptOptimizationLoop', () => {
         },
       });
       assert.deepEqual(replayedFirst.addressability, first.addressability);
+      assert.equal(replayedFirst.heldInReferencePassEligibleRate, first.heldInReferencePassEligibleRate);
       assert.equal(proposalInputs.length, 0);
 
       const result = await runLoop(harness, {
@@ -835,14 +845,129 @@ describe('runPromptOptimizationLoop', () => {
       });
 
       assert.equal(result.decisions[0]?.decision, 'keep');
+      assert.equal(result.decisions[1]?.decision, 'discard');
+      assert.equal(result.decisions[1]?.reason, 'held_in_within_noise');
+      assert.equal(result.decisions[1]?.metrics.lastKept.heldIn.passEligibleRate, 1);
+      assert.equal(
+        result.decisions[1]?.previousHeldInReferencePassEligibleRate,
+        1 - result.decisions[1]!.heldInPassRateNoiseBand,
+      );
+      assert.equal(
+        result.heldInReferencePassEligibleRate,
+        result.decisions[1]?.previousHeldInReferencePassEligibleRate,
+      );
       assert.equal(proposalInputs.length, 1);
       assert.doesNotMatch(proposalInputs[0]!.resultsTsv, /hin-19/);
       assert.equal(proposalInputs[0]!.heldInDigests.some((digest) => digest.taskId === 'hin-19'), false);
       assert.ok(roundOneTaskIds.includes('hin-19'));
       const terminalStat = result.addressability.heldIn.taskStats.find((stat) => stat.taskId === 'hin-19');
-      assert.equal(terminalStat?.observations, 4);
-      assert.equal(terminalStat?.keptPrompts, 3);
-      assert.equal(terminalStat?.passes, 1);
+      assert.equal(terminalStat?.observations, 3);
+      assert.equal(terminalStat?.keptPrompts, 2);
+      assert.equal(terminalStat?.passes, 0);
+      assert.equal(terminalStat?.rejectionReason, 'capability_limit');
+
+      proposalInputs.length = 0;
+      const replayed = await runLoop(harness, {
+        heldInTasks,
+        heldOutTasks,
+        rewardFor,
+        rounds: 2,
+        baselineRuns: 2,
+        metaAgent: async (input) => {
+          proposalInputs.push(input);
+          return propose(input);
+        },
+      });
+      assert.equal(proposalInputs.length, 0);
+      assert.deepEqual(replayed.decisions, result.decisions);
+      assert.equal(replayed.heldInReferencePassEligibleRate, result.heldInReferencePassEligibleRate);
+      assert.deepEqual(replayed.addressability, result.addressability);
+    });
+  });
+
+  test('reward-hack scanning includes capability-limited tasks outside the decision set', async () => {
+    await withHarness(async (harness) => {
+      const heldInTasks = makeTasks('hin', 20);
+      const heldOutTasks = makeTasks('hout', 4);
+      const roundOneTaskIds: string[] = [];
+      const rewardFor = (roundId: string, taskId: string): number => {
+        if (taskId.startsWith('hout-')) return 1;
+        const index = taskIndex(taskId);
+        if (roundId.startsWith('baseline-')) return index < 10 ? 1 : 0;
+        if (roundId === 'round-0') return index < 19 ? 1 : 0;
+        return 1;
+      };
+
+      const result = await runLoop(harness, {
+        heldInTasks,
+        heldOutTasks,
+        rewardFor,
+        rounds: 2,
+        baselineRuns: 2,
+        rewardHackVerifierPatternsByTaskId: {
+          ...Object.fromEntries(heldInTasks.map((task) => [task.id, ['ZZZ_NO_VERIFIER_MATCH']])),
+          'hin-19': ['EXPECTED_SECRET'],
+        },
+        runtimeEventCommandFor: (roundId, taskId) => (
+          roundId === 'round-1' && taskId === 'hin-19' ? 'echo EXPECTED_SECRET' : undefined
+        ),
+        onTaskRun: (roundId, taskId) => {
+          if (roundId === 'round-1' && taskId.startsWith('hin-')) roundOneTaskIds.push(taskId);
+        },
+      });
+
+      assert.equal(result.decisions[0]?.decision, 'keep');
+      assert.equal(result.decisions[1]?.decision, 'discard');
+      assert.equal(result.decisions[1]?.reason, 'reward_hack_quarantined');
+      assert.deepEqual(result.decisions[1]?.rewardHackScan, {
+        decision: 'quarantine',
+        reason: 'verifier_pattern',
+        matchedPatterns: ['EXPECTED_SECRET'],
+      });
+      assert.ok(roundOneTaskIds.includes('hin-19'));
+      assert.equal(result.decisions[1]?.metrics.candidate.heldIn.taskCount, 19);
+    });
+  });
+
+  test('re-banks again when retained evidence expands the decision set', async () => {
+    await withHarness(async (harness) => {
+      const heldInTasks = makeTasks('hin', 20);
+      const heldOutTasks = makeTasks('hout', 4);
+      const proposalInputs: MetaAgentPromptInput[] = [];
+      const propose = fakeMetaAgent();
+      const rewardFor = (roundId: string, taskId: string): number => {
+        if (taskId.startsWith('hout-')) return 1;
+        const index = taskIndex(taskId);
+        if (roundId.startsWith('baseline-')) return index < 10 ? 1 : 0;
+        if (roundId === 'round-0') return index > 0 && index < 18 ? 1 : 0;
+        return 1;
+      };
+
+      const result = await runLoop(harness, {
+        heldInTasks,
+        heldOutTasks,
+        rewardFor,
+        rounds: 3,
+        baselineRuns: 2,
+        metaAgent: async (input) => {
+          proposalInputs.push(input);
+          return propose(input);
+        },
+      });
+
+      assert.deepEqual(result.decisions.map((decision) => decision.decision), ['keep', 'keep', 'discard']);
+      assert.deepEqual(proposalInputs.map((input) => input.heldInDigests.length), [20, 18, 19]);
+      assert.equal(proposalInputs[1]?.heldInDigests.some((digest) => digest.taskId === 'hin-18'), false);
+      assert.equal(proposalInputs[1]?.heldInDigests.some((digest) => digest.taskId === 'hin-19'), false);
+      assert.equal(proposalInputs[2]?.heldInDigests.some((digest) => digest.taskId === 'hin-18'), true);
+      assert.equal(proposalInputs[2]?.heldInDigests.some((digest) => digest.taskId === 'hin-19'), true);
+      assert.equal(proposalInputs[2]?.heldInDigests.some((digest) => digest.taskId === 'hin-0'), false);
+      assert.equal(result.decisions[2]?.metrics.lastKept.heldIn.passEligibleRate, 1);
+      assert.equal(
+        result.decisions[2]?.previousHeldInReferencePassEligibleRate,
+        1 - result.decisions[2]!.heldInPassRateNoiseBand,
+      );
+      assert.equal(result.decisions[2]?.reason, 'held_in_within_noise');
     });
   });
 

--- a/packages/headless/src/prompt-acceptance-policy.ts
+++ b/packages/headless/src/prompt-acceptance-policy.ts
@@ -642,6 +642,13 @@ function rewardHackGateReason(scan: PromptCandidateRewardHackScan): PromptAccept
   return scan.decision === 'clean' ? null : PROMPT_REWARD_HACK_QUARANTINE_REASON;
 }
 
+export function bankPromptAcceptanceReference(
+  passEligibleRate: number,
+  noiseBand: number,
+): number {
+  return passEligibleRate - noiseBand;
+}
+
 function nextHeldInReferencePassEligibleRate(input: {
   decision: PromptAcceptanceDecision;
   previousReference: number | null;
@@ -651,7 +658,7 @@ function nextHeldInReferencePassEligibleRate(input: {
   if (input.decision !== 'keep' || input.candidatePassEligibleRate === null) {
     return input.previousReference;
   }
-  const bankedReference = input.candidatePassEligibleRate - input.noiseBand;
+  const bankedReference = bankPromptAcceptanceReference(input.candidatePassEligibleRate, input.noiseBand);
   return input.previousReference === null
     ? bankedReference
     : Math.max(input.previousReference, bankedReference);

--- a/packages/headless/src/prompt-optimization-loop.ts
+++ b/packages/headless/src/prompt-optimization-loop.ts
@@ -25,11 +25,13 @@ import {
 } from './prompt-candidate-loop.js';
 import {
   appendPromptAcceptanceDecision,
+  bankPromptAcceptanceReference,
   calibratePromptAcceptanceBaseline,
   decidePromptAcceptance,
   heldInGateReason,
   selectAddressablePromptTasks,
   selectStablePromptTasks,
+  summarizePromptAcceptancePartition,
   type PromptAcceptanceBaseline,
   type PromptAcceptanceBaselineRun,
   type PromptAcceptanceResult,
@@ -268,8 +270,10 @@ export async function runPromptOptimizationLoop(
       })),
   );
 
-  // Reward-hacking guard over the held-in trajectories the meta-agent optimizes
-  // against. First non-clean task decides the round (deterministic by order).
+  // Reward-hacking is a safety gate over the full executed held-in sweep, not
+  // only the addressable decision subset. A flaky or capability-limited task
+  // cannot exempt a candidate from quarantine. First non-clean task decides
+  // the round (deterministic by execution order).
   const scanHeldIn = async (
     events: readonly FixedPromptTaskWalEvent[],
   ): Promise<PromptCandidateRewardHackScan> => {
@@ -447,7 +451,7 @@ export async function runPromptOptimizationLoop(
   let latestHeldInFeedbackExecutionEvents: readonly FixedPromptTaskWalEvent[] = stableHeldIn(
     baselineRunsData[baselineRunsData.length - 1]!.heldInEvents,
   );
-  let finalAddressability = initialAddressability;
+  let heldInReferenceTaskIds = initialAddressability.heldIn.selectedTaskIds;
   let hasKeptCandidate = false;
   let nextPromptAttribution: RsiPromptAttribution | undefined;
 
@@ -465,7 +469,6 @@ export async function runPromptOptimizationLoop(
     const roundId = `round-${round}`;
     const addressability = selectCurrentAddressability();
     assertAddressablePartitions(addressability);
-    finalAddressability = addressability;
     const decisionHeldInTaskIds = addressability.heldIn.selectedTaskIds;
     const decisionHeldOutTaskIds = addressability.heldOut.selectedTaskIds;
     const decisionHeldInSet = new Set(decisionHeldInTaskIds);
@@ -486,10 +489,18 @@ export async function runPromptOptimizationLoop(
       ? decisionHeldIn(previousCandidateHeldInExecutionEvents)
       : undefined;
     const latestHeldInFeedbackEvents = decisionHeldIn(latestHeldInFeedbackExecutionEvents);
+    const heldInReferenceTaskSetChanged = !sameTaskIdSet(heldInReferenceTaskIds, decisionHeldInTaskIds);
     const heldInReference = hasKeptCandidate
-      ? finalHeldInReference
+      ? heldInReferenceTaskSetChanged
+        ? bankedReferenceForTaskSet(
+            lastKeptHeldInEvents,
+            decisionHeldInTaskIds,
+            activeBaseline.heldIn.noiseBand,
+          )
+        : finalHeldInReference
       : activeBaseline.heldIn.referencePassEligibleRate;
     finalHeldInReference = heldInReference;
+    heldInReferenceTaskIds = decisionHeldInTaskIds;
     const nextHeldInDigests = await digestsFor(latestHeldInFeedbackEvents);
     await writeFixedPromptResultsTsv(input.heldInResultsTsvPath, latestHeldInFeedbackEvents);
     const promptAnalysis = await analyzeRsiRound({
@@ -731,8 +742,23 @@ export async function runPromptOptimizationLoop(
   // decision set was selected. Refresh once more so the returned profile and
   // fail-loud empty-partition invariant describe the committed final state,
   // including replay of a terminal keep.
-  finalAddressability = selectCurrentAddressability();
+  const finalAddressability = selectCurrentAddressability();
   assertAddressablePartitions(finalAddressability);
+  const finalHeldInTaskIds = finalAddressability.heldIn.selectedTaskIds;
+  if (hasKeptCandidate && !sameTaskIdSet(heldInReferenceTaskIds, finalHeldInTaskIds)) {
+    const finalHeldInSet = new Set(finalHeldInTaskIds);
+    const finalBaseline = calibratePromptAcceptanceBaseline({
+      heldInTaskIds: finalHeldInTaskIds,
+      heldOutTaskIds: finalAddressability.heldOut.selectedTaskIds,
+      baselineRuns: baselineRunsData,
+      zScore,
+    });
+    finalHeldInReference = bankedReferenceForTaskSet(
+      lastKeptHeldInExecutionEvents.filter((event) => finalHeldInSet.has(event.taskId)),
+      finalHeldInTaskIds,
+      finalBaseline.heldIn.noiseBand,
+    );
+  }
 
   // 3. Structural smoke report over the full WAL.
   const events = await readFixedPromptWal(input.resultsJsonlPath);
@@ -757,6 +783,21 @@ export async function runPromptOptimizationLoop(
     droppedHeldOutTaskIds,
     addressability: finalAddressability,
   };
+}
+
+function sameTaskIdSet(left: readonly string[], right: readonly string[]): boolean {
+  if (left.length !== right.length) return false;
+  const rightSet = new Set(right);
+  return left.every((taskId) => rightSet.has(taskId));
+}
+
+function bankedReferenceForTaskSet(
+  lastKeptEvents: readonly FixedPromptTaskWalEvent[],
+  taskIds: readonly string[],
+  noiseBand: number,
+): number | null {
+  const passEligibleRate = summarizePromptAcceptancePartition(lastKeptEvents, taskIds).passEligibleRate;
+  return passEligibleRate === null ? null : bankPromptAcceptanceReference(passEligibleRate, noiseBand);
 }
 
 function assertUniqueTaskIds(label: string, taskIds: readonly string[]): void {


### PR DESCRIPTION
## Summary

Follow-up to #1015 and the post-merge review observation about a shrinking decision-set denominator.

- track the held-in task set that owns the banked acceptance reference;
- when addressability changes, recompute the last-kept pass rate on the new set and re-bank it with that set's calibrated noise band;
- apply the same rebasing after a terminal KEEP so the returned reference and final addressability profile share one denominator;
- preserve deterministic fresh/replay behavior when the set shrinks, expands, or swaps members;
- make the existing safety intent explicit: reward-hack scanning still covers the full executed held-in sweep, including tasks excluded from the decision set;
- remove the round-local `finalAddressability` writes that were overwritten by the final recomputation.

Without the re-bank, dropping an always-failing task could leave a 20-task reference below the true last-kept bar for the new 19-task set, biasing later decisions toward KEEP. The regression test covers the concrete 19/20 -> 19/19 case: a flat candidate is now discarded instead of being treated as an improvement.

## Replay and compatibility

- Fresh execution and WAL replay are asserted to produce identical decisions, final reference, and addressability.
- Existing task-set hash checks remain fail-closed. This PR does not relax cross-version WAL replay; a pre-change decision whose acceptance semantics differ should still be rejected rather than silently reinterpreted.
- Reward-hack scans deliberately use the full executed set on both fresh and replay paths.

## Self-review coverage

- decision set shrinks after a KEEP;
- terminal KEEP changes final addressability;
- retained evidence later expands/swaps the decision set;
- excluded task still triggers reward-hack quarantine;
- fresh/replay parity;
- empty-partition invariant remains fail-loud.

## Validation

- `npx --yes @biomejs/biome@2.5.4 lint packages/headless/src/prompt-acceptance-policy.ts packages/headless/src/prompt-optimization-loop.ts packages/headless/src/__tests__/prompt-optimization-loop.test.ts`
- `npm --workspace @maka/headless run typecheck`
- focused acceptance/replay/resume suites: 89 passed, 0 failed
- `npm --workspace @maka/headless test`: 971 passed, 0 failed, 1 skipped
- `git diff --check`

Follow-up to #1015.