### PR TITLE
fix(desktop): restore API key quick connect

### DIFF
--- a/apps/desktop/e2e/providers.spec.ts
+++ b/apps/desktop/e2e/providers.spec.ts
@@ -47,13 +47,23 @@ test('adds a catalog provider through the canonical API-key dialog', async ({ wi
   await page.getByRole('button', { name: /添加模型供应商：Cerebras/ }).click();
   const dialog = page.getByRole('dialog', { name: '连接 Cerebras' });
   await expect(dialog).toBeVisible();
-  await expect(dialog.getByLabel('Cerebras API Key')).toBeFocused();
-  await expect(dialog.getByLabel('Cerebras API Key')).toHaveAttribute('type', 'password');
+  await expect(dialog.getByLabel('API Key')).toBeFocused();
+  await expect(dialog.getByLabel('API Key')).toHaveAttribute('type', 'password');
+  await expect(dialog.getByText('输入 Cerebras API Key 即可完成连接。')).toHaveCount(0);
+  await expect(dialog.getByText('粘贴服务商提供的 API Key，凭据仅保存在本机。')).toBeVisible();
+  await expect(dialog.getByText('Cerebras API Key', { exact: true })).toHaveCount(0);
   await expect(dialog.getByLabel('模型供应商连接标识')).toHaveCount(0);
   await expect(dialog.getByLabel('模型供应商服务地址')).toHaveCount(0);
   await expect(dialog.getByLabel('模型供应商默认模型')).toHaveCount(0);
-  await dialog.getByLabel('Cerebras API Key').fill('e2e-cerebras-key');
-  await dialog.getByRole('button', { name: '连接 Cerebras' }).click();
+  const dialogBox = await dialog.boundingBox();
+  expect(dialogBox?.width).toBeLessThanOrEqual(420);
+  expect(dialogBox?.height).toBeGreaterThanOrEqual(190);
+  expect(dialogBox?.height).toBeLessThanOrEqual(210);
+  await expect(dialog.locator('.providerLogo')).toHaveCSS('width', '24px');
+  await expect(dialog.locator('.providerLogo')).toHaveCSS('height', '24px');
+  expect((await dialog.getByRole('button', { name: '连接', exact: true }).boundingBox())?.width).toBeLessThan(96);
+  await dialog.getByLabel('API Key').fill('e2e-cerebras-key');
+  await dialog.getByRole('button', { name: '连接', exact: true }).click();
 
   await expect(dialog).toBeHidden();
   const connection = page.getByRole('button', { name: /模型连接：Cerebras/ });
@@ -142,7 +152,7 @@ test('restores keyboard focus across provider child pages', async ({ window: pag
   const siliconFlow = page.getByRole('button', { name: /添加模型供应商：SiliconFlow/ });
   await siliconFlow.focus();
   await page.keyboard.press('Enter');
-  await expect(page.getByLabel('SiliconFlow API Key')).toBeFocused();
+  await expect(page.getByLabel('API Key')).toBeFocused();
 
   await page.keyboard.press('Escape');
   await expect(siliconFlow).toBeFocused();

--- a/apps/desktop/e2e/providers.spec.ts
+++ b/apps/desktop/e2e/providers.spec.ts
@@ -50,20 +50,22 @@ test('adds a catalog provider through the canonical API-key dialog', async ({ wi
   await expect(dialog.getByLabel('API Key')).toBeFocused();
   await expect(dialog.getByLabel('API Key')).toHaveAttribute('type', 'password');
   await expect(dialog.getByText('输入 Cerebras API Key 即可完成连接。')).toHaveCount(0);
-  await expect(dialog.getByText('粘贴服务商提供的 API Key，凭据仅保存在本机。')).toBeVisible();
+  await expect(dialog.getByText('粘贴服务商提供的 API Key，凭据仅保存在本机。')).toHaveCount(0);
+  await expect(dialog.getByText('连接后即可使用模型；API Key 不会自动同步，由你掌控。')).toBeVisible();
   await expect(dialog.getByText('Cerebras API Key', { exact: true })).toHaveCount(0);
+  await expect(dialog.getByLabel('API Key')).toHaveAttribute('placeholder', '输入或粘贴 API Key');
   await expect(dialog.getByLabel('模型供应商连接标识')).toHaveCount(0);
   await expect(dialog.getByLabel('模型供应商服务地址')).toHaveCount(0);
   await expect(dialog.getByLabel('模型供应商默认模型')).toHaveCount(0);
   const dialogBox = await dialog.boundingBox();
   expect(dialogBox?.width).toBeLessThanOrEqual(420);
   expect(dialogBox?.height).toBeGreaterThanOrEqual(190);
-  expect(dialogBox?.height).toBeLessThanOrEqual(210);
+  expect(dialogBox?.height).toBeLessThanOrEqual(230);
   await expect(dialog.locator('.providerLogo')).toHaveCSS('width', '24px');
   await expect(dialog.locator('.providerLogo')).toHaveCSS('height', '24px');
-  expect((await dialog.getByRole('button', { name: '连接', exact: true }).boundingBox())?.width).toBeLessThan(96);
+  expect((await dialog.getByRole('button', { name: '连接并使用', exact: true }).boundingBox())?.width).toBeLessThan(96);
   await dialog.getByLabel('API Key').fill('e2e-cerebras-key');
-  await dialog.getByRole('button', { name: '连接', exact: true }).click();
+  await dialog.getByRole('button', { name: '连接并使用', exact: true }).click();
 
   await expect(dialog).toBeHidden();
   const connection = page.getByRole('button', { name: /模型连接：Cerebras/ });

--- a/apps/desktop/e2e/providers.spec.ts
+++ b/apps/desktop/e2e/providers.spec.ts
@@ -24,7 +24,7 @@ import { test, expect } from './fixtures';
 // upstream <img> mark that must stay untouched in BOTH light and dark themes);
 // the assertions below validate the *flow and the colorAssetRenderContract
 // mechanism*, not Cerebras's data — that lives in the registry contract tests.
-test('adds a catalog provider through the canonical API-key journey (search, tab, colored mark, form defaults)', async ({ window: page }) => {
+test('adds a catalog provider through the canonical API-key dialog', async ({ window: page }) => {
   await page.getByRole('button', { name: '展开侧边栏' }).click();
   await page.getByRole('button', { name: '设置' }).click();
   await expect(page.getByLabel('设置内容')).toBeVisible();
@@ -45,17 +45,25 @@ test('adds a catalog provider through the canonical API-key journey (search, tab
   expect(await catalogMark.evaluate(colorAssetRenderContract)).toEqual(COLOR_ASSET_RENDER_CONTRACT);
 
   await page.getByRole('button', { name: /添加模型供应商：Cerebras/ }).click();
-  await expect(page.getByLabel('模型供应商连接标识')).toHaveValue('cerebras');
-  await expect(page.getByLabel('模型供应商服务地址')).toHaveValue('https://api.cerebras.ai/v1');
-  await expect(page.getByLabel('模型供应商默认模型')).toHaveValue('gpt-oss-120b');
-  await page.getByRole('button', { name: '保存供应商' }).click();
+  const dialog = page.getByRole('dialog', { name: '连接 Cerebras' });
+  await expect(dialog).toBeVisible();
+  await expect(dialog.getByLabel('Cerebras API Key')).toBeFocused();
+  await expect(dialog.getByLabel('Cerebras API Key')).toHaveAttribute('type', 'password');
+  await expect(dialog.getByLabel('模型供应商连接标识')).toHaveCount(0);
+  await expect(dialog.getByLabel('模型供应商服务地址')).toHaveCount(0);
+  await expect(dialog.getByLabel('模型供应商默认模型')).toHaveCount(0);
+  await dialog.getByLabel('Cerebras API Key').fill('e2e-cerebras-key');
+  await dialog.getByRole('button', { name: '连接 Cerebras' }).click();
 
-  await expect(page.getByRole('heading', { name: 'Cerebras', exact: true }).first()).toBeVisible();
+  await expect(dialog).toBeHidden();
+  const connection = page.getByRole('button', { name: /模型连接：Cerebras/ });
+  await expect(connection).toBeFocused();
+  await connection.click();
   const detailMark = page.locator('.providerSubpageHeader .providerLogo[data-provider="cerebras"] img');
   await expect(detailMark).toBeVisible();
   expect(await detailMark.evaluate(colorAssetRenderContract)).toEqual(COLOR_ASSET_RENDER_CONTRACT);
   await expect(page.getByText('gpt-oss-120b', { exact: true }).first()).toBeVisible();
-  await expect(page.getByRole('textbox', { name: '模型密钥' })).toBeVisible();
+  await expect(page.getByRole('textbox', { name: '模型密钥' })).toHaveAttribute('placeholder', '••••••••');
 });
 
 // Distinct form behavior: an account-scoped provider has no fixed base URL —
@@ -134,9 +142,9 @@ test('restores keyboard focus across provider child pages', async ({ window: pag
   const siliconFlow = page.getByRole('button', { name: /添加模型供应商：SiliconFlow/ });
   await siliconFlow.focus();
   await page.keyboard.press('Enter');
-  await expect(page.getByRole('button', { name: '返回模型连接' })).toBeFocused();
+  await expect(page.getByLabel('SiliconFlow API Key')).toBeFocused();
 
-  await page.keyboard.press('Enter');
+  await page.keyboard.press('Escape');
   await expect(siliconFlow).toBeFocused();
 
   const catalogBack = page.getByRole('button', { name: '返回模型连接' });

--- a/apps/desktop/e2e/providers.spec.ts
+++ b/apps/desktop/e2e/providers.spec.ts
@@ -51,7 +51,10 @@ test('adds a catalog provider through the canonical API-key dialog', async ({ wi
   await expect(dialog.getByLabel('API Key')).toHaveAttribute('type', 'password');
   await expect(dialog.getByText('输入 Cerebras API Key 即可完成连接。')).toHaveCount(0);
   await expect(dialog.getByText('粘贴服务商提供的 API Key，凭据仅保存在本机。')).toHaveCount(0);
-  await expect(dialog.getByText('连接后即可使用模型；API Key 不会自动同步，由你掌控。')).toBeVisible();
+  const intro = dialog.getByText('输入 API Key 即可连接；密钥仅保存在本机。');
+  await expect(intro).toBeVisible();
+  await expect(intro).toHaveCSS('white-space', 'nowrap');
+  expect(await intro.evaluate((element) => element.scrollWidth <= element.clientWidth)).toBe(true);
   await expect(dialog.getByText('Cerebras API Key', { exact: true })).toHaveCount(0);
   await expect(dialog.getByLabel('API Key')).toHaveAttribute('placeholder', '输入或粘贴 API Key');
   await expect(dialog.getByLabel('模型供应商连接标识')).toHaveCount(0);
@@ -64,7 +67,21 @@ test('adds a catalog provider through the canonical API-key dialog', async ({ wi
   await expect(dialog.locator('.providerLogo')).toHaveCSS('width', '24px');
   await expect(dialog.locator('.providerLogo')).toHaveCSS('height', '24px');
   expect((await dialog.getByRole('button', { name: '连接并使用', exact: true }).boundingBox())?.width).toBeLessThan(96);
-  await dialog.getByLabel('API Key').fill('e2e-cerebras-key');
+  const keyInput = dialog.getByLabel('API Key');
+  const inputBox = await keyInput.boundingBox();
+  await keyInput.fill(`sk-${'a'.repeat(300)}`);
+  const longKeyLayout = await keyInput.evaluate((input) => ({
+    clientWidth: input.clientWidth,
+    scrollWidth: input.scrollWidth,
+    clientHeight: input.clientHeight,
+    scrollHeight: input.scrollHeight,
+  }));
+  expect(longKeyLayout.scrollWidth).toBeGreaterThan(longKeyLayout.clientWidth);
+  expect(longKeyLayout.scrollHeight).toBe(longKeyLayout.clientHeight);
+  expect((await keyInput.boundingBox())?.height).toBe(inputBox?.height);
+  expect((await dialog.boundingBox())?.width).toBe(dialogBox?.width);
+  expect((await dialog.boundingBox())?.height).toBe(dialogBox?.height);
+  await keyInput.fill('e2e-cerebras-key');
   await dialog.getByRole('button', { name: '连接并使用', exact: true }).click();
 
   await expect(dialog).toBeHidden();

--- a/apps/desktop/e2e/providers.spec.ts
+++ b/apps/desktop/e2e/providers.spec.ts
@@ -49,24 +49,18 @@ test('adds a catalog provider through the canonical API-key dialog', async ({ wi
   await expect(dialog).toBeVisible();
   await expect(dialog.getByLabel('API Key')).toBeFocused();
   await expect(dialog.getByLabel('API Key')).toHaveAttribute('type', 'password');
-  await expect(dialog.getByText('输入 Cerebras API Key 即可完成连接。')).toHaveCount(0);
-  await expect(dialog.getByText('粘贴服务商提供的 API Key，凭据仅保存在本机。')).toHaveCount(0);
   const intro = dialog.getByText('输入 API Key 即可连接；密钥仅保存在本机。');
   await expect(intro).toBeVisible();
   await expect(intro).toHaveCSS('white-space', 'nowrap');
   expect(await intro.evaluate((element) => element.scrollWidth <= element.clientWidth)).toBe(true);
-  await expect(dialog.getByText('Cerebras API Key', { exact: true })).toHaveCount(0);
   await expect(dialog.getByLabel('API Key')).toHaveAttribute('placeholder', '输入或粘贴 API Key');
   await expect(dialog.getByLabel('模型供应商连接标识')).toHaveCount(0);
   await expect(dialog.getByLabel('模型供应商服务地址')).toHaveCount(0);
   await expect(dialog.getByLabel('模型供应商默认模型')).toHaveCount(0);
   const dialogBox = await dialog.boundingBox();
   expect(dialogBox?.width).toBeLessThanOrEqual(420);
-  expect(dialogBox?.height).toBeGreaterThanOrEqual(190);
-  expect(dialogBox?.height).toBeLessThanOrEqual(230);
   await expect(dialog.locator('.providerLogo')).toHaveCSS('width', '24px');
   await expect(dialog.locator('.providerLogo')).toHaveCSS('height', '24px');
-  expect((await dialog.getByRole('button', { name: '连接并使用', exact: true }).boundingBox())?.width).toBeLessThan(96);
   const keyInput = dialog.getByLabel('API Key');
   const inputBox = await keyInput.boundingBox();
   await keyInput.fill(`sk-${'a'.repeat(300)}`);
@@ -115,13 +109,18 @@ test('derives an account-scoped endpoint from the Cloudflare account-id field', 
   // The plain base-URL input is replaced by the account-id field; the endpoint
   // is derived, not typed.
   await expect(page.getByLabel('Cloudflare 账户 ID')).toHaveValue('');
+  await expect(page.getByLabel('Cloudflare Workers AI API Key')).toBeVisible();
   await expect(page.getByLabel('模型供应商服务地址')).toHaveCount(0);
   await page.getByLabel('Cloudflare 账户 ID').fill(accountId);
+  await page.getByRole('button', { name: '保存供应商' }).click();
+  await expect(page.getByRole('alert')).toHaveText('请填写 Cloudflare Workers AI API Key');
+
+  await page.getByLabel('Cloudflare Workers AI API Key').fill('e2e-cloudflare-key');
   await page.getByRole('button', { name: '保存供应商' }).click();
 
   await expect(page.getByRole('heading', { name: 'Cloudflare Workers AI', exact: true }).first()).toBeVisible();
   await expect(page.getByRole('textbox', { name: '服务地址', exact: true })).toHaveValue(baseUrl);
-  await expect(page.getByRole('textbox', { name: '模型密钥' })).toBeVisible();
+  await expect(page.getByRole('textbox', { name: '模型密钥' })).toHaveAttribute('placeholder', '••••••••');
 });
 
 // Distinct form behavior: a no-auth local runtime shows no API-key field at all

--- a/apps/desktop/src/main/__tests__/connection-credential-ipc-hardening-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/connection-credential-ipc-hardening-contract.test.ts
@@ -55,8 +55,8 @@ describe('connection credential IPC hardening contract', () => {
     assert.match(helper, /normalizeConnectionSlugForIpc\(input\.slug, 'connection slug'\)/);
 
     const handler = handlerBlock('connections:create');
-    assert.match(handler, /const normalizedInput = normalizeCreateConnectionInput\(input\);[\s\S]*connectionStore\.create\(normalizedInput\);/);
-    assert.match(handler, /credentialStore\.setSecret\(connection\.slug, 'api_key', normalizedInput\.apiKey\)/);
+    assert.match(handler, /const normalizedInput = normalizeCreateConnectionInput\(input\);[\s\S]*createConnectionWithCredential\(\{ connectionStore, credentialStore \}, normalizedInput\)/);
+    assert.match(mainSource, /createConnectionWithCredential[\s\S]*connectionStore\.create\(input\)[\s\S]*credentialStore\.setSecret\(connection\.slug, 'api_key', input\.apiKey\)/);
   });
 
   it('caps and validates create apiKey before persistence without echoing the secret value', () => {
@@ -74,12 +74,12 @@ describe('connection credential IPC hardening contract', () => {
     );
     assert.ok(
       handler.indexOf('normalizeCreateConnectionInput(input)')
-        < handler.indexOf('connectionStore.create(normalizedInput)'),
+        < handler.indexOf('createConnectionWithCredential'),
       'create must normalize and cap apiKey before connection persistence',
     );
     assert.ok(
       handler.indexOf('normalizeCreateConnectionInput(input)')
-        < handler.indexOf('credentialStore.setSecret'),
+        < handler.indexOf('createConnectionWithCredential'),
       'create must normalize and cap apiKey before credential persistence',
     );
   });

--- a/apps/desktop/src/main/__tests__/create-connection-with-credential.test.ts
+++ b/apps/desktop/src/main/__tests__/create-connection-with-credential.test.ts
@@ -1,0 +1,40 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, it } from 'node:test';
+import { createConnectionStore } from '@maka/storage';
+import { createConnectionWithCredential } from '../create-connection-with-credential.js';
+
+describe('createConnectionWithCredential', () => {
+  it('removes the new connection when credential persistence fails', async () => {
+    const workspaceRoot = await mkdtemp(join(tmpdir(), 'maka-create-connection-'));
+    try {
+      const connectionStore = createConnectionStore(workspaceRoot);
+      await assert.rejects(
+        createConnectionWithCredential(
+          {
+            connectionStore,
+            credentialStore: {
+              async setSecret() {
+                throw new Error('credential write failed');
+              },
+            },
+          },
+          {
+            slug: 'openai',
+            name: 'OpenAI',
+            providerType: 'openai',
+            apiKey: 'test-key',
+          },
+        ),
+        /credential write failed/,
+      );
+
+      assert.deepEqual(await connectionStore.list(), []);
+      assert.equal(await connectionStore.getDefault(), null);
+    } finally {
+      await rm(workspaceRoot, { recursive: true, force: true });
+    }
+  });
+});

--- a/apps/desktop/src/main/__tests__/main-process-contract-source-helpers.ts
+++ b/apps/desktop/src/main/__tests__/main-process-contract-source-helpers.ts
@@ -9,6 +9,7 @@ export const MAIN_PROCESS_SOURCE_REPO_PATHS: readonly string[] = [
   'apps/desktop/src/main/bot-incoming-main.ts',
   'apps/desktop/src/main/browser-ipc-main.ts',
   'apps/desktop/src/main/config-ipc-main.ts',
+  'apps/desktop/src/main/create-connection-with-credential.ts',
   'apps/desktop/src/main/connections-ipc-main.ts',
   'apps/desktop/src/main/daily-review-ipc-main.ts',
   'apps/desktop/src/main/daily-review-main.ts',

--- a/apps/desktop/src/main/__tests__/model-oauth-section-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/model-oauth-section-contract.test.ts
@@ -287,10 +287,14 @@ describe('Model OAuth catalog contract (PR-MODEL-OAUTH-ALL-0 + PR-CLAUDE-CARD-MO
     );
   });
 
-  it('provider configuration uses an accessible in-pane child page, not a Sheet', async () => {
+  it('standard API providers use the shared key dialog while special configuration stays in-pane', async () => {
     const src = await readProviderSettingsCombinedSource();
     assert.match(src, /type ProviderPage =[\s\S]*kind: 'add'[\s\S]*kind: 'detail'/);
     assert.match(src, /function ProviderPageHeader[\s\S]*aria-label="返回模型连接"/);
+    assert.match(src, /usesQuickApiKeyDialog[\s\S]*defaults\.authKind === 'api_key' && Boolean\(defaults\.baseUrl\)/);
+    assert.match(src, /<DialogContent[\s\S]*initialFocus=\{apiKeyInputRef\}[\s\S]*finalFocus=\{props\.finalFocus\}/);
+    assert.match(src, /ariaLabel=\{`\$\{display\.name\} API Key`\}/);
+    assert.match(src, /\.\.\.\(normalizedApiKey \? \{ apiKey: normalizedApiKey \} : \{\}\)/);
     assert.match(src, /<div className="providerInlineEditor">[\s\S]*<AddProviderForm/);
     assert.doesNotMatch(src, /ProviderConfigSheetOverlay/, 'API provider configuration must not use the OAuth modal infrastructure');
   });

--- a/apps/desktop/src/main/__tests__/model-oauth-section-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/model-oauth-section-contract.test.ts
@@ -293,7 +293,7 @@ describe('Model OAuth catalog contract (PR-MODEL-OAUTH-ALL-0 + PR-CLAUDE-CARD-MO
     assert.match(src, /function ProviderPageHeader[\s\S]*aria-label="返回模型连接"/);
     assert.match(src, /usesQuickApiKeyDialog[\s\S]*defaults\.authKind === 'api_key' && Boolean\(defaults\.baseUrl\)/);
     assert.match(src, /<DialogContent[\s\S]*initialFocus=\{apiKeyInputRef\}[\s\S]*finalFocus=\{props\.finalFocus\}/);
-    assert.match(src, /ariaLabel=\{`\$\{display\.name\} API Key`\}/);
+    assert.match(src, /ariaLabel="API Key"/);
     assert.match(src, /\.\.\.\(normalizedApiKey \? \{ apiKey: normalizedApiKey \} : \{\}\)/);
     assert.match(src, /<div className="providerInlineEditor">[\s\S]*<AddProviderForm/);
     assert.doesNotMatch(src, /ProviderConfigSheetOverlay/, 'API provider configuration must not use the OAuth modal infrastructure');

--- a/apps/desktop/src/main/__tests__/model-oauth-section-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/model-oauth-section-contract.test.ts
@@ -292,6 +292,8 @@ describe('Model OAuth catalog contract (PR-MODEL-OAUTH-ALL-0 + PR-CLAUDE-CARD-MO
     assert.match(src, /type ProviderPage =[\s\S]*kind: 'add'[\s\S]*kind: 'detail'/);
     assert.match(src, /function ProviderPageHeader[\s\S]*aria-label="返回模型连接"/);
     assert.match(src, /usesQuickApiKeyDialog[\s\S]*defaults\.authKind === 'api_key' && Boolean\(defaults\.baseUrl\)/);
+    assert.match(src, /const supportsApiKey = providerAuthSupportsApiKey\(props\.providerType\)/);
+    assert.match(src, /const requiresApiKey = providerAuthRequiresSecret\(props\.providerType\) && supportsApiKey/);
     assert.match(src, /<DialogContent[\s\S]*initialFocus=\{apiKeyInputRef\}[\s\S]*finalFocus=\{props\.finalFocus\}/);
     assert.match(src, /ariaLabel="API Key"/);
     assert.match(src, /\.\.\.\(normalizedApiKey \? \{ apiKey: normalizedApiKey \} : \{\}\)/);

--- a/apps/desktop/src/main/__tests__/provider-navigation-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/provider-navigation-contract.test.ts
@@ -36,7 +36,7 @@ describe('Settings model provider page hierarchy', () => {
 
     assert.match(
       source,
-      /if \(page\.kind === 'catalog'\)[\s\S]*<ProviderPageHeader[\s\S]*title="添加服务商"[\s\S]*onBack=\{\(\) => navigate\(\{ kind: 'connections' \}, \{ kind: 'add-provider' \}\)\}/,
+      /if \(page\.kind === 'catalog' \|\| \(page\.kind === 'add' && usesQuickApiKeyDialog\(page\.providerType\)\)\)[\s\S]*<ProviderPageHeader[\s\S]*title="添加服务商"[\s\S]*onBack=\{\(\) => navigate\(\{ kind: 'connections' \}, \{ kind: 'add-provider' \}\)\}/,
       'the catalog must provide a way back to model connections',
     );
     assert.match(

--- a/apps/desktop/src/main/connections-ipc-main.ts
+++ b/apps/desktop/src/main/connections-ipc-main.ts
@@ -12,6 +12,7 @@ import { PROVIDER_DEFAULTS, providerAuthRequiresSecret } from '@maka/core/llm-co
 import { fetchProviderModels, testConnection } from '@maka/runtime';
 import { createConnectionStore } from '@maka/storage';
 import { createFileCredentialStore } from './credential-store.js';
+import { createConnectionWithCredential } from './create-connection-with-credential.js';
 import { connectionTestStatusPatch } from './connection-test-status.js';
 
 type ConnectionStore = ReturnType<typeof createConnectionStore>;
@@ -170,10 +171,7 @@ export function registerConnectionsIpc(deps: ConnectionsIpcDeps): void {
     // store or credential write; OAuth-token providers must keep their
     // canonical provider endpoint.
     const normalizedInput = normalizeCreateConnectionInput(input);
-    const connection = await connectionStore.create(normalizedInput);
-    if (normalizedInput.apiKey) {
-      await credentialStore.setSecret(connection.slug, 'api_key', normalizedInput.apiKey);
-    }
+    const connection = await createConnectionWithCredential({ connectionStore, credentialStore }, normalizedInput);
     emitConnectionListChanged();
     return connection;
   });

--- a/apps/desktop/src/main/create-connection-with-credential.ts
+++ b/apps/desktop/src/main/create-connection-with-credential.ts
@@ -1,0 +1,23 @@
+import type { CreateConnectionInput, LlmConnection } from '@maka/core/llm-connections';
+import type { ConnectionStore, CredentialStore } from '@maka/storage';
+
+interface CreateConnectionWithCredentialDeps {
+  connectionStore: Pick<ConnectionStore, 'create' | 'remove'>;
+  credentialStore: Pick<CredentialStore, 'setSecret'>;
+}
+
+export async function createConnectionWithCredential(
+  deps: CreateConnectionWithCredentialDeps,
+  input: CreateConnectionInput,
+): Promise<LlmConnection> {
+  const connection = await deps.connectionStore.create(input);
+  if (input.apiKey) {
+    try {
+      await deps.credentialStore.setSecret(connection.slug, 'api_key', input.apiKey);
+    } catch (error) {
+      await deps.connectionStore.remove(connection.slug);
+      throw error;
+    }
+  }
+  return connection;
+}

--- a/apps/desktop/src/renderer/settings/ProvidersPanel.tsx
+++ b/apps/desktop/src/renderer/settings/ProvidersPanel.tsx
@@ -18,7 +18,7 @@ import {
   useToast,
 } from '@maka/ui';
 import { connectionChipStatus } from './provider-connection-status';
-import { AddProviderForm } from './provider-add-form';
+import { AddProviderForm, usesQuickApiKeyDialog } from './provider-add-form';
 import { ProviderCatalogCard } from './provider-catalog';
 import { ConnectionDetail } from './provider-connection-detail';
 import { ProviderLogo, providerDisplay } from './provider-display';
@@ -167,7 +167,8 @@ export function ProvidersPanel({ bridge, initialPage = 'connections' }: {
     );
   }
 
-  if (page.kind === 'catalog') {
+  if (page.kind === 'catalog' || (page.kind === 'add' && usesQuickApiKeyDialog(page.providerType))) {
+    const quickAddType = page.kind === 'add' ? page.providerType : null;
     return (
       <div ref={providersPanelRef} className="providersPanel providerChildPage">
         <ProviderPageHeader
@@ -221,6 +222,24 @@ export function ProvidersPanel({ bridge, initialPage = 'connections' }: {
             );
           })}
         </PrimitiveTabs>
+        {quickAddType && (
+          <AddProviderForm
+            key={quickAddType}
+            bridge={bridge}
+            providerType={quickAddType}
+            existingSlugs={connections.map((connection) => connection.slug)}
+            finalFocus={() => providersPanelRef.current
+              ? providerFocusElement(providersPanelRef.current, { kind: 'catalog-provider', providerType: quickAddType }) ?? null
+              : null}
+            onCancel={() => navigate({ kind: 'catalog' }, { kind: 'catalog-provider', providerType: quickAddType })}
+            onCreated={async (slug) => {
+              const lifecycle = providerPageLifecycleRef.current;
+              const reloaded = await reload();
+              if (!reloaded || !providersPanelMountedRef.current || providerPageLifecycleRef.current !== lifecycle) return;
+              navigate({ kind: 'connections' }, { kind: 'connection', slug });
+            }}
+          />
+        )}
       </div>
     );
   }

--- a/apps/desktop/src/renderer/settings/password-input.tsx
+++ b/apps/desktop/src/renderer/settings/password-input.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useRef, useState, type Ref } from 'react';
 import { Check, Copy, Eye, EyeOff } from '@maka/ui/icons';
 import { Button, Input, useMountedRef, useToast } from '@maka/ui';
 
@@ -22,7 +22,9 @@ export function PasswordInput(props: {
   onChange(next: string): void;
   placeholder?: string;
   ariaLabel?: string;
+  ariaDescribedBy?: string;
   disabled?: boolean;
+  inputRef?: Ref<HTMLInputElement>;
   onBlur?(): void;
 }) {
   const toast = useToast();
@@ -72,12 +74,14 @@ export function PasswordInput(props: {
   return (
     <div className="settingsPasswordField">
       <Input
+        ref={props.inputRef}
         type={visible ? 'text' : 'password'}
         value={props.value}
         onChange={(event) => props.onChange(event.currentTarget.value)}
         onBlur={props.onBlur}
         placeholder={props.placeholder}
         aria-label={props.ariaLabel}
+        aria-describedby={props.ariaDescribedBy}
         autoComplete="off"
         spellCheck={false}
         disabled={props.disabled}

--- a/apps/desktop/src/renderer/settings/provider-add-form.tsx
+++ b/apps/desktop/src/renderer/settings/provider-add-form.tsx
@@ -118,7 +118,7 @@ export function AddProviderForm(props: {
             icon={<ProviderLogo type={props.providerType} compact />}
             title={`连接 ${display.name}`}
             titleId={titleId}
-            subtitle="连接后即可使用模型；API Key 不会自动同步，由你掌控。"
+            subtitle="输入 API Key 即可连接；密钥仅保存在本机。"
             onClose={() => {
               if (!busy) props.onCancel();
             }}

--- a/apps/desktop/src/renderer/settings/provider-add-form.tsx
+++ b/apps/desktop/src/renderer/settings/provider-add-form.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState, type FormEvent } from 'react';
 import { PROVIDER_DEFAULTS, validateSlug, type ProviderType } from '@maka/core';
+import { providerAuthRequiresSecret, providerAuthSupportsApiKey } from '@maka/core/llm-connections';
 import { Button, Chip, DialogContent, DialogHeader, DialogRoot, Input, useMountedRef } from '@maka/ui';
 import { buildCatalogRecommendedDefaultModel } from '../model-catalog-choices';
 import { PasswordInput } from './password-input';
@@ -39,6 +40,8 @@ export function AddProviderForm(props: {
   const requiresBaseUrl = !defaults.baseUrl && !isCloudflareWorkersAi;
   const isExperimental = defaults.status === 'phase3-experimental';
   const isWiredOAuth = isWiredOAuthProvider(props.providerType);
+  const supportsApiKey = providerAuthSupportsApiKey(props.providerType);
+  const requiresApiKey = providerAuthRequiresSecret(props.providerType) && supportsApiKey;
   const usesApiKeyDialog = usesQuickApiKeyDialog(props.providerType);
 
   useEffect(() => {
@@ -54,7 +57,7 @@ export function AddProviderForm(props: {
     if (slugError) return setError(slugError);
     if (props.existingSlugs.includes(slug)) return setError('连接标识已存在');
     const normalizedApiKey = apiKey.trim();
-    if (usesApiKeyDialog && !normalizedApiKey) return setError(`请填写 ${display.name} API Key`);
+    if (requiresApiKey && !normalizedApiKey) return setError(`请填写 ${display.name} API Key`);
     const normalizedCloudflareAccountId = cloudflareAccountId.trim();
     if (isCloudflareWorkersAi && !normalizedCloudflareAccountId) {
       return setError('请填写 Cloudflare Account ID');
@@ -171,6 +174,21 @@ export function AddProviderForm(props: {
             : '这类账号登录暂未接入聊天发送。当前请先使用同一家厂商的模型密钥。'}</span>
         </div>
       )}
+      {supportsApiKey && (
+        <label>
+          <span>API Key（{requiresApiKey ? '必填' : '可选'}）</span>
+          <PasswordInput
+            value={apiKey}
+            onChange={(next) => {
+              setApiKey(next);
+              if (error) setError(null);
+            }}
+            placeholder="输入或粘贴 API Key"
+            ariaLabel={`${display.name} API Key`}
+            disabled={isExperimental || busy}
+          />
+        </label>
+      )}
       <label>
         <span>连接标识</span>
         <Input value={slug} onChange={(event) => setSlug(event.currentTarget.value)} placeholder="my-provider" disabled={isExperimental || busy} aria-label="模型供应商连接标识" />
@@ -212,7 +230,7 @@ export function AddProviderForm(props: {
           aria-label="模型供应商默认模型"
         />
       </label>
-      {error && <p className="providerError">{error}</p>}
+      {error && <p className="providerError" role="alert">{error}</p>}
       <div className="providerActions">
         <Button variant="ghost" type="button" disabled={busy} onClick={props.onCancel}>取消</Button>
         <Button type="button" disabled={busy || isExperimental} onClick={submit}>

--- a/apps/desktop/src/renderer/settings/provider-add-form.tsx
+++ b/apps/desktop/src/renderer/settings/provider-add-form.tsx
@@ -1,8 +1,9 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useRef, useState, type FormEvent } from 'react';
 import { PROVIDER_DEFAULTS, validateSlug, type ProviderType } from '@maka/core';
-import { Button, Chip, Input, useMountedRef } from '@maka/ui';
+import { Button, Chip, DialogContent, DialogHeader, DialogRoot, Input, useMountedRef } from '@maka/ui';
 import { buildCatalogRecommendedDefaultModel } from '../model-catalog-choices';
-import { providerDisplay } from './provider-display';
+import { PasswordInput } from './password-input';
+import { ProviderLogo, providerDisplay } from './provider-display';
 import {
   categoryLabel,
   isWiredOAuthProvider,
@@ -15,6 +16,7 @@ export function AddProviderForm(props: {
   bridge: ConnectionsBridge;
   providerType: ProviderType;
   existingSlugs: string[];
+  finalFocus?(): HTMLElement | null;
   onCancel(): void;
   onCreated(slug: string): Promise<void>;
 }) {
@@ -26,15 +28,18 @@ export function AddProviderForm(props: {
   const [baseUrl, setBaseUrl] = useState(defaults.baseUrl);
   const [cloudflareAccountId, setCloudflareAccountId] = useState('');
   const [defaultModel, setDefaultModel] = useState(recommendedDefaultModel);
+  const [apiKey, setApiKey] = useState('');
   const [error, setError] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
   const busyRef = useRef(false);
   const addProviderMountedRef = useMountedRef();
+  const apiKeyInputRef = useRef<HTMLInputElement>(null);
 
   const isCloudflareWorkersAi = props.providerType === 'cloudflare-workers-ai';
   const requiresBaseUrl = !defaults.baseUrl && !isCloudflareWorkersAi;
   const isExperimental = defaults.status === 'phase3-experimental';
   const isWiredOAuth = isWiredOAuthProvider(props.providerType);
+  const usesApiKeyDialog = usesQuickApiKeyDialog(props.providerType);
 
   useEffect(() => {
     return () => {
@@ -48,6 +53,8 @@ export function AddProviderForm(props: {
     const slugError = validateSlug(slug);
     if (slugError) return setError(slugError);
     if (props.existingSlugs.includes(slug)) return setError('连接标识已存在');
+    const normalizedApiKey = apiKey.trim();
+    if (usesApiKeyDialog && !normalizedApiKey) return setError(`请填写 ${display.name} API Key`);
     const normalizedCloudflareAccountId = cloudflareAccountId.trim();
     if (isCloudflareWorkersAi && !normalizedCloudflareAccountId) {
       return setError('请填写 Cloudflare Account ID');
@@ -73,6 +80,7 @@ export function AddProviderForm(props: {
         providerType: props.providerType,
         baseUrl: resolvedBaseUrl,
         defaultModel,
+        ...(normalizedApiKey ? { apiKey: normalizedApiKey } : {}),
       });
       if (!addProviderMountedRef.current) return;
       await props.onCreated(connection.slug);
@@ -82,6 +90,66 @@ export function AddProviderForm(props: {
       busyRef.current = false;
       if (addProviderMountedRef.current) setBusy(false);
     }
+  }
+
+  function submitApiKey(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    void submit();
+  }
+
+  if (usesApiKeyDialog) {
+    const titleId = `provider-key-dialog-${props.providerType}`;
+    const errorId = `${titleId}-error`;
+    return (
+      <DialogRoot
+        open
+        onOpenChange={(open) => {
+          if (!open && !busy) props.onCancel();
+        }}
+      >
+        <DialogContent
+          className="maka-modal providerKeyDialog"
+          aria-labelledby={titleId}
+          initialFocus={apiKeyInputRef}
+          finalFocus={props.finalFocus}
+          showClose={false}
+        >
+          <DialogHeader
+            icon={<ProviderLogo type={props.providerType} compact />}
+            title={`连接 ${display.name}`}
+            titleId={titleId}
+            subtitle={`输入 ${display.name} API Key 即可完成连接。`}
+            onClose={() => {
+              if (!busy) props.onCancel();
+            }}
+          />
+          <form className="providerKeyDialogForm" onSubmit={submitApiKey}>
+            <label>
+              <span>{display.name} API Key</span>
+              <PasswordInput
+                value={apiKey}
+                onChange={(next) => {
+                  setApiKey(next);
+                  if (error) setError(null);
+                }}
+                placeholder="粘贴 API Key"
+                ariaLabel={`${display.name} API Key`}
+                ariaDescribedBy={error ? errorId : undefined}
+                inputRef={apiKeyInputRef}
+                disabled={busy}
+              />
+            </label>
+            {error && <p className="providerError" id={errorId} role="alert">{error}</p>}
+            <div className="providerKeyDialogActions">
+              <Button variant="ghost" type="button" disabled={busy} onClick={props.onCancel}>取消</Button>
+              <Button type="submit" disabled={busy}>
+                {busy ? '连接中…' : `连接 ${display.name}`}
+              </Button>
+            </div>
+          </form>
+        </DialogContent>
+      </DialogRoot>
+    );
   }
 
   return (
@@ -153,4 +221,9 @@ export function AddProviderForm(props: {
       </div>
     </div>
   );
+}
+
+export function usesQuickApiKeyDialog(providerType: ProviderType): boolean {
+  const defaults = PROVIDER_DEFAULTS[providerType];
+  return defaults.authKind === 'api_key' && Boolean(defaults.baseUrl);
 }

--- a/apps/desktop/src/renderer/settings/provider-add-form.tsx
+++ b/apps/desktop/src/renderer/settings/provider-add-form.tsx
@@ -118,7 +118,7 @@ export function AddProviderForm(props: {
             icon={<ProviderLogo type={props.providerType} compact />}
             title={`连接 ${display.name}`}
             titleId={titleId}
-            subtitle="粘贴服务商提供的 API Key，凭据仅保存在本机。"
+            subtitle="连接后即可使用模型；API Key 不会自动同步，由你掌控。"
             onClose={() => {
               if (!busy) props.onCancel();
             }}
@@ -132,7 +132,7 @@ export function AddProviderForm(props: {
                   setApiKey(next);
                   if (error) setError(null);
                 }}
-                placeholder="粘贴 API Key"
+                placeholder="输入或粘贴 API Key"
                 ariaLabel="API Key"
                 ariaDescribedBy={error ? errorId : undefined}
                 inputRef={apiKeyInputRef}
@@ -143,7 +143,7 @@ export function AddProviderForm(props: {
             <div className="providerKeyDialogActions">
               <Button variant="ghost" type="button" disabled={busy} onClick={props.onCancel}>取消</Button>
               <Button type="submit" disabled={busy}>
-                {busy ? '连接中…' : '连接'}
+                {busy ? '连接中…' : '连接并使用'}
               </Button>
             </div>
           </form>

--- a/apps/desktop/src/renderer/settings/provider-add-form.tsx
+++ b/apps/desktop/src/renderer/settings/provider-add-form.tsx
@@ -118,14 +118,14 @@ export function AddProviderForm(props: {
             icon={<ProviderLogo type={props.providerType} compact />}
             title={`连接 ${display.name}`}
             titleId={titleId}
-            subtitle={`输入 ${display.name} API Key 即可完成连接。`}
+            subtitle="粘贴服务商提供的 API Key，凭据仅保存在本机。"
             onClose={() => {
               if (!busy) props.onCancel();
             }}
           />
           <form className="providerKeyDialogForm" onSubmit={submitApiKey}>
             <label>
-              <span>{display.name} API Key</span>
+              <span>API Key</span>
               <PasswordInput
                 value={apiKey}
                 onChange={(next) => {
@@ -133,7 +133,7 @@ export function AddProviderForm(props: {
                   if (error) setError(null);
                 }}
                 placeholder="粘贴 API Key"
-                ariaLabel={`${display.name} API Key`}
+                ariaLabel="API Key"
                 ariaDescribedBy={error ? errorId : undefined}
                 inputRef={apiKeyInputRef}
                 disabled={busy}
@@ -143,7 +143,7 @@ export function AddProviderForm(props: {
             <div className="providerKeyDialogActions">
               <Button variant="ghost" type="button" disabled={busy} onClick={props.onCancel}>取消</Button>
               <Button type="submit" disabled={busy}>
-                {busy ? '连接中…' : `连接 ${display.name}`}
+                {busy ? '连接中…' : '连接'}
               </Button>
             </div>
           </form>

--- a/apps/desktop/src/renderer/styles/settings/provider-editor.css
+++ b/apps/desktop/src/renderer/styles/settings/provider-editor.css
@@ -91,7 +91,17 @@
 }
 
 .providerKeyDialog {
-  width: min(460px, calc(100vw - 48px));
+  width: min(420px, calc(100vw - 32px));
+}
+
+.providerKeyDialog [data-slot="dialog-header"] {
+  align-items: center;
+}
+
+.providerKeyDialog [data-slot="dialog-header-icon"],
+.providerKeyDialog .providerLogo[data-compact="true"] {
+  width: 24px;
+  height: 24px;
 }
 
 .providerKeyDialogForm {
@@ -112,7 +122,6 @@
   display: flex;
   justify-content: flex-end;
   gap: var(--space-2);
-  padding-top: var(--space-1);
 }
 
 .providerUnavailableNotice {

--- a/apps/desktop/src/renderer/styles/settings/provider-editor.css
+++ b/apps/desktop/src/renderer/styles/settings/provider-editor.css
@@ -98,6 +98,10 @@
   align-items: center;
 }
 
+.providerKeyDialog [data-slot="dialog-header-subtitle"] {
+  white-space: nowrap;
+}
+
 .providerKeyDialog [data-slot="dialog-header-icon"],
 .providerKeyDialog .providerLogo[data-compact="true"] {
   width: 24px;

--- a/apps/desktop/src/renderer/styles/settings/provider-editor.css
+++ b/apps/desktop/src/renderer/styles/settings/provider-editor.css
@@ -90,6 +90,31 @@
   gap: var(--space-3);
 }
 
+.providerKeyDialog {
+  width: min(460px, calc(100vw - 48px));
+}
+
+.providerKeyDialogForm {
+  display: grid;
+  gap: var(--space-3);
+  padding: var(--space-4);
+}
+
+.providerKeyDialogForm label {
+  display: grid;
+  gap: var(--space-1-5);
+  color: var(--foreground-secondary);
+  font-size: var(--font-size-ui);
+  font-weight: var(--font-weight-medium);
+}
+
+.providerKeyDialogActions {
+  display: flex;
+  justify-content: flex-end;
+  gap: var(--space-2);
+  padding-top: var(--space-1);
+}
+
 .providerUnavailableNotice {
   display: grid;
   gap: var(--space-1);


### PR DESCRIPTION
## Summary

- restore the missing API Key field for catalog providers that use a fixed endpoint
- replace the advanced provider form with a focused API Key dialog while preserving custom, local, OAuth, and account-scoped flows
- keep provider defaults in the catalog, preserve keyboard focus, and clarify the local-only credential handling
- keep long API keys on one horizontally scrolling input line without resizing the dialog

## Verification

- `npm run lint` — 1,583 files checked
- `npm --workspace @maka/desktop test` — 2,544 tests passed
- `npx playwright test --config e2e/playwright.config.ts e2e/providers.spec.ts` — 4 tests passed
- live Electron inspection via CDP: 420 × 200 dialog, 24 × 24 provider logo, single-line guidance, 300-character API Key overflow

## Visual evidence

<img width="3024" height="1004" alt="image" src="https://github.com/user-attachments/assets/00d37c4d-2554-4d95-9b94-f9d8de3b08f9" />