### PR TITLE
fix: enable thinking for Kimi Coding Plan

### DIFF
--- a/packages/runtime/src/__tests__/computer-use-provider-protocol.test.ts
+++ b/packages/runtime/src/__tests__/computer-use-provider-protocol.test.ts
@@ -13,7 +13,7 @@ import {
   type CuDispatchBackend,
   type CuObservation,
 } from '../computer-use-tools.js';
-import { getAIModel } from '../model-factory.js';
+import { buildProviderOptions, getAIModel } from '../model-factory.js';
 import { PermissionEngine } from '../permission-engine.js';
 
 const servers: Array<{ close(): Promise<void> }> = [];
@@ -73,15 +73,16 @@ describe('Anthropic-compatible Computer Use product loops', () => {
       });
       const events: SessionEvent[] = [];
       const toolResults: Array<{ isError: boolean }> = [];
+      const providerConnection = connection(
+        provider.providerType,
+        `${server.url}${provider.baseSuffix}`,
+        provider.modelId,
+      );
       const runtime = new AiSdkBackend({
         sessionId: `session-${provider.providerType}`,
         header: header(provider.providerType, provider.modelId),
         appendMessage: async () => {},
-        connection: connection(
-          provider.providerType,
-          `${server.url}${provider.baseSuffix}`,
-          provider.modelId,
-        ),
+        connection: providerConnection,
         apiKey: 'test-key',
         modelId: provider.modelId,
         permissionEngine: new PermissionEngine({
@@ -89,6 +90,7 @@ describe('Anthropic-compatible Computer Use product loops', () => {
           now: () => 1,
         }),
         modelFactory: (input) => getAIModel(input),
+        providerOptions: buildProviderOptions(providerConnection, provider.modelId),
         tools: [computerTool],
         maxSteps: 6,
         newId: idGenerator(),
@@ -121,6 +123,16 @@ describe('Anthropic-compatible Computer Use product loops', () => {
         (requestBodies[0].tools as Array<{ name: string }>).map((tool) => tool.name),
         ['maka_computer'],
       );
+      if (provider.providerType === 'kimi-coding-plan') {
+        for (const body of requestBodies) {
+          assert.equal(
+            (body.thinking as { type?: string } | undefined)?.type,
+            'enabled',
+            'Kimi Coding Plan must enable thinking on every turn',
+          );
+          assert.deepEqual(body.output_config, { effort: 'max' });
+        }
+      }
     });
   }
 });

--- a/packages/runtime/src/model-factory.ts
+++ b/packages/runtime/src/model-factory.ts
@@ -264,11 +264,22 @@ export function buildProviderOptions(
   const variants = thinkingVariantsForModel(connection.providerType, modelId);
   const level = thinkingLevel && variants.includes(thinkingLevel) ? thinkingLevel : undefined;
   switch (connection.providerType) {
+    case 'kimi-coding-plan':
+      return {
+        anthropic: modelId === 'kimi-for-coding'
+          ? {
+              // Kimi's managed coding route requires enabled thinking and max
+              // effort. The Anthropic AI SDK also requires a compatibility
+              // budget and otherwise injects the same value with a warning.
+              thinking: { type: 'enabled' as const, budgetTokens: 1_024 },
+              effort: 'max',
+            }
+          : {},
+      };
     // Anthropic-protocol: effort enum models send `effort`; toggle/budget
     // models send `thinking.disabled` for off. No budget-token mapping — the
     // provider's native effort values pass through unchanged.
     case 'anthropic':
-    case 'kimi-coding-plan':
     case 'MiniMax':
     case 'MiniMax-cn':
     case 'claude-subscription':


### PR DESCRIPTION
## Summary

Enable the standard `kimi-for-coding` route with Thinking and max effort by default, matching Kimi Code’s documented managed-route behavior. Keep the HighSpeed route and other Anthropic-compatible providers unchanged.

Add a provider-loop regression assertion so every Kimi tool-loop step carries the required Thinking wire.

## Verification

- `node --test packages/runtime/dist/__tests__/computer-use-provider-protocol.test.js packages/runtime/dist/__tests__/model-factory-thinking.test.js` — 46 passed
- `npm --workspace @maka/runtime test` — 1,939 passed, 7 skipped
- Live `kimi-for-coding` probe through `getAIModel` + default `buildProviderOptions` returned the expected response with non-empty reasoning output; the stored credential was read in memory and never printed.