### PR TITLE
fix(ui): restore circular composer icon buttons via governed Button pill shape

### DIFF
--- a/apps/desktop/src/main/__tests__/radius-converge-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/radius-converge-contract.test.ts
@@ -24,7 +24,10 @@
  *   5. Components must use the correct tier: control→rounded-sm, surface→rounded-md,
  *      modal→rounded-xl, pill→rounded-full/rounded-[var(--radius-pill)].
  *      Every --radius-* reference inside a component block must belong to the
- *      expected tier's alias set.
+ *      expected tier's alias set. A component that legitimately serves more
+ *      than one tier declares `alsoTiers` (e.g. buttonVariants is a control
+ *      that also offers the governed pill shape via shape="pill"); every
+ *      declared tier must then be present, and other tiers stay forbidden.
  *   6. Token values are pinned: control=6px, surface=8px, modal=12px, pill=999px.
  *   7. `--radius-button` is deleted; no stale references may remain.
  */
@@ -143,6 +146,8 @@ interface ComponentRadiusCheck {
   file: string;
   name: string;
   tier: Tier;
+  /** Additional tiers the component legitimately serves (see rule 5). */
+  alsoTiers?: Tier[];
 }
 
 /** The expected radius class for each tier. */
@@ -162,15 +167,14 @@ const TIER_TOKENS: Record<Tier, Set<string>> = {
   pill: new Set(['--radius-pill']),
 };
 
-/** Classes that belong to a *different* tier — must not appear. */
+/** Every tier-attributed class — a component block must only contain classes
+ *  from its declared tier(s); anything else from this list is forbidden. */
 const ALL_TIER_CLASSES = ['rounded-sm', 'rounded-md', 'rounded-lg', 'rounded-xl', 'rounded-full', 'rounded-[var(--radius-pill)]', 'rounded-[var(--radius-control)]', 'rounded-[var(--radius-surface)]', 'rounded-[var(--radius-modal)]'];
 
-function classesForOtherTiers(tier: Tier): string[] {
-  return ALL_TIER_CLASSES.filter((c) => !TIER_CLASS[tier].includes(c));
-}
-
 const COMPONENT_RADIUS: ComponentRadiusCheck[] = [
-  { file: 'packages/ui/src/ui.tsx', name: 'buttonVariants', tier: 'control' },
+  // shape="pill" (the composer "+" / send affordance) is a governed pill-tier
+  // shape on the control-tier Button — both tiers must stay present.
+  { file: 'packages/ui/src/ui.tsx', name: 'buttonVariants', tier: 'control', alsoTiers: ['pill'] },
   { file: 'packages/ui/src/primitives/input.tsx', name: 'inputClasses', tier: 'control' },
   { file: 'packages/ui/src/ui.tsx', name: 'SelectItem', tier: 'control' },
   { file: 'packages/ui/src/ui.tsx', name: 'Toggle', tier: 'control' },
@@ -294,25 +298,27 @@ function checkComponentTier(src: string, check: ComponentRadiusCheck): string[] 
     offenders.push(`${check.file}: ${check.name} not found in source — stale contract entry or renamed component`);
     return offenders;
   }
-  const expected = TIER_CLASS[check.tier];
-  const expectedTokens = TIER_TOKENS[check.tier];
-  const forbidden = classesForOtherTiers(check.tier);
-  const hasExpected = expected.some((c) => block.includes(c));
-  if (!hasExpected) {
-    offenders.push(`${check.file}: ${check.name} must use ${expected.join(' or ')} (${check.tier}), found none`);
+  const tiers: Tier[] = [check.tier, ...(check.alsoTiers ?? [])];
+  for (const tier of tiers) {
+    const expected = TIER_CLASS[tier];
+    if (!expected.some((c) => block.includes(c))) {
+      offenders.push(`${check.file}: ${check.name} must use ${expected.join(' or ')} (${tier}), found none`);
+    }
   }
+  const forbidden = ALL_TIER_CLASSES.filter((c) => !tiers.some((tier) => TIER_CLASS[tier].includes(c)));
   for (const bad of forbidden) {
     if (block.includes(bad)) {
-      offenders.push(`${check.file}: ${check.name} must not use ${bad} (wrong tier for ${check.tier})`);
+      offenders.push(`${check.file}: ${check.name} must not use ${bad} (wrong tier for ${tiers.join(' + ')})`);
     }
   }
   // Extract every --radius-* reference in the block and verify it belongs
   // to the expected tier. Catches calc() and arbitrary value paths that
   // the class-based check misses.
+  const expectedTokens = new Set(tiers.flatMap((tier) => [...TIER_TOKENS[tier]]));
   const blockTokens = [...block.matchAll(/--radius-[\w-]+/g)].map((t) => t[0]);
   for (const tok of blockTokens) {
     if (!expectedTokens.has(tok)) {
-      offenders.push(`${check.file}: ${check.name} references ${tok} which is not a ${check.tier} tier token`);
+      offenders.push(`${check.file}: ${check.name} references ${tok} which is not a ${tiers.join(' + ')} tier token`);
     }
   }
   return offenders;

--- a/apps/desktop/src/main/__tests__/renderer-utility-primitives-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/renderer-utility-primitives-contract.test.ts
@@ -340,8 +340,8 @@ describe('renderer utility surfaces use shared UI primitives', () => {
     assert.match(onboarding, /variant="secondary"\s+size="sm"\s+onClick=\{\(\) => prefillSuggestion/);
     assert.match(checklist, /import \{ Button as BaseButton \} from '@base-ui\/react\/button';/);
     assert.match(checklist, /<BaseButton[^>]*onClick=\{item\.onClick\}/);
-    assert.match(composer, /variant="quiet"\s+size="icon-sm"[\s\S]*aria-label=\{pendingImportAction/);
-    assert.match(composer, /variant="default"\s+size="icon"[\s\S]*aria-label=\{buttonCopy\.sendLabel\}/);
+    assert.match(composer, /variant="quiet"\s+size="icon-sm"\s+shape="pill"[\s\S]*aria-label=\{pendingImportAction/);
+    assert.match(composer, /variant="default"\s+size="icon"\s+shape="pill"[\s\S]*aria-label=\{buttonCopy\.sendLabel\}/);
     assert.match(plan, /variant="secondary"\s+size="sm"[\s\S]*onClick=\{\(\) => applyRunAtPreset/);
 
     assert.match(story, /import \{ SessionListPanel \} from '\.\.\/src\/session-list-panel\.js';/);

--- a/packages/ui/src/__tests__/button.test.ts
+++ b/packages/ui/src/__tests__/button.test.ts
@@ -1,6 +1,7 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { buttonVariants } from '../ui.js';
+import { cn } from '../utils.js';
 
 test('Button exposes only the governed 32px and 28px geometry tiers', () => {
   const medium = buttonVariants({ size: 'md' });
@@ -53,4 +54,16 @@ test('aria-disabled Button variants keep their resting tone during hover and act
   assert.match(quiet, /aria-disabled:hover:text-foreground-secondary/);
   assert.match(primary, /aria-disabled:hover:bg-primary/);
   assert.match(primary, /aria-disabled:active:bg-primary/);
+});
+
+test('Button pill shape lands on the governed pill radius tier', () => {
+  const pill = cn(buttonVariants({ size: 'icon', shape: 'pill' }));
+  const resting = cn(buttonVariants({ size: 'icon' }));
+
+  // rounded-full resolves to --radius-pill (999px) per the radius-converge
+  // contract; tailwind-merge must drop the base rounded-sm so the pill wins.
+  assert.match(pill, /\brounded-full\b/);
+  assert.ok(!pill.includes('rounded-sm'), 'pill shape must override the base rounded-sm');
+  assert.match(resting, /\brounded-sm\b/);
+  assert.ok(!resting.includes('rounded-full'));
 });

--- a/packages/ui/src/composer.tsx
+++ b/packages/ui/src/composer.tsx
@@ -828,6 +828,7 @@ export const Composer = forwardRef<
                       {...triggerRest}
                       variant="quiet"
                       size="icon-sm"
+                      shape="pill"
                       type="button"
                       disabled={props.disabled || importActionBusy}
                       onClick={(e) => { menuToggleClick?.(e); }}
@@ -980,6 +981,7 @@ export const Composer = forwardRef<
               <UiButton
                 variant="default"
                 size="icon"
+                shape="pill"
                 type="submit"
                 disabled={sendDisabled}
                 aria-label={buttonCopy.sendLabel}

--- a/packages/ui/src/ui.tsx
+++ b/packages/ui/src/ui.tsx
@@ -89,6 +89,17 @@ export const buttonVariants = cva(
         icon: 'h-8 w-8 px-0 text-sm',
         'icon-sm': 'h-7 w-7 px-0 text-sm',
       },
+      // #901 follow-up: circular affordance for round icon actions (composer
+      // "+" / send). #901 retired the consumer-layer pill CSS
+      // (maka-composer-send-button & friends) onto the shared Button but
+      // offered no governed replacement for the circle, silently squaring
+      // those buttons. The `shape` axis keeps the pill tier on the governed
+      // primitive instead of in per-surface CSS. `rounded-full` resolves to
+      // --radius-pill per the radius-converge contract.
+      shape: {
+        default: '',
+        pill: 'rounded-full',
+      },
     },
     compoundVariants: [
       {
@@ -111,6 +122,7 @@ export const buttonVariants = cva(
     defaultVariants: {
       variant: 'default',
       size: 'md',
+      shape: 'default',
     },
   },
 );
@@ -122,13 +134,13 @@ interface ButtonProps
 }
 
 export const Button = forwardRef<HTMLElement, ButtonProps>(function Button(
-  { className, variant, size, ...props },
+  { className, variant, size, shape, ...props },
   ref,
 ) {
   return (
     <BaseButton
       ref={ref}
-      className={cn(buttonVariants({ variant, size }), className)}
+      className={cn(buttonVariants({ variant, size, shape }), className)}
       data-slot="button"
       {...props}
     />


### PR DESCRIPTION
## Summary

#901 retired the composer's consumer-layer button CSS (`maka-composer-tool-button` / `maka-composer-context-plus` / `maka-composer-send-button`) onto the shared `Button`, but the shared primitive had no governed replacement for the circle — its only radius is the control-tier `rounded-sm`. The "+" affordance (including its hover) and the send button silently went square.

This restores the circle on the governed primitive instead of consumer CSS:

- `buttonVariants` gains a `shape` axis (`default` / `pill` → `rounded-full`, the `--radius-pill` tier); `Button` forwards the new prop.
- The composer "+" (`quiet`/`icon-sm`) and send (`default`/`icon`) buttons opt into `shape="pill"`.
- The radius-converge contract gains `alsoTiers` so a component can legitimately serve more than one radius tier (`buttonVariants`: control + pill — both must stay present, other tiers remain forbidden), closing the gap that let #901 drop the shape undetected.
- The utility-primitives contract now asserts the composer buttons carry `shape="pill"`; `button.test.ts` locks that tailwind-merge resolves `rounded-full` over the base `rounded-sm`.

Refs #901.

## Verification

- `npm --workspace @maka/ui run test` — 159/159 pass (includes the new pill-shape test).
- `node --test "dist/main/**/*.test.js"` (desktop main) — 2547/2547 pass (includes the strengthened radius-converge and utility-primitives contracts).
- `npm run typecheck` (main + renderer + storybook) — pass.
- `npm run test:checks` (check-console / check-a11y / check-copy) — pass.
- Not run: Playwright E2E and the screenshot harness — class-only restoration onto an already-used governed utility (`rounded-full` is used by Switch/Radio/Progress), with the shape now locked by unit + contract tests.

<img width="2476" height="1644" alt="image" src="https://github.com/user-attachments/assets/400d890c-5015-4f4b-acd2-845edf302883" />
