### PR TITLE
docs: one language badge per README — drop the self-referential one

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-<a href="./README.md"><img alt="English" src="https://img.shields.io/badge/English-2ea44f?style=for-the-badge&logo=googletranslate&logoColor=white"></a>
-<a href="./README.zh-CN.md"><img alt="简体中文" src="https://img.shields.io/badge/%E7%AE%80%E4%BD%93%E4%B8%AD%E6%96%87-555?style=for-the-badge&logo=googletranslate&logoColor=white"></a>
+<a href="./README.zh-CN.md"><img alt="简体中文" src="https://img.shields.io/badge/%E7%AE%80%E4%BD%93%E4%B8%AD%E6%96%87-2ea44f?style=for-the-badge&logo=googletranslate&logoColor=white"></a>
 
 # Maka
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,5 +1,4 @@
-<a href="./README.md"><img alt="English" src="https://img.shields.io/badge/English-555?style=for-the-badge&logo=googletranslate&logoColor=white"></a>
-<a href="./README.zh-CN.md"><img alt="简体中文" src="https://img.shields.io/badge/%E7%AE%80%E4%BD%93%E4%B8%AD%E6%96%87-2ea44f?style=for-the-badge&logo=googletranslate&logoColor=white"></a>
+<a href="./README.md"><img alt="English" src="https://img.shields.io/badge/English-2ea44f?style=for-the-badge&logo=googletranslate&logoColor=white"></a>
 
 # Maka
 


### PR DESCRIPTION
Both READMEs shipped a full language switcher (current language green + other language gray), so **each page carried a badge pointing at itself** — README.md's green `English` badge linked to README.md. A dead control: reads as an affordance, does nothing.

Each README now carries exactly one badge, linking to the other language:

| File | Badge | Links to |
|---|---|---|
| `README.md` | 简体中文 | `README.zh-CN.md` |
| `README.zh-CN.md` | English | `README.md` |

The active/inactive gray goes away with it — a single badge *is* the action, so there's no current-vs-other state left to encode. No tests or contracts pinned these; `docs/README.md` has no badges.