### PR TITLE
docs: put the language badge on the CI badge row and match its style

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
-<a href="./README.zh-CN.md"><img alt="简体中文" src="https://img.shields.io/badge/%E7%AE%80%E4%BD%93%E4%B8%AD%E6%96%87-2ea44f?style=for-the-badge&logo=googletranslate&logoColor=white"></a>
-
 # Maka
 
 [![CI](https://github.com/Maka-Agent/maka-agent/actions/workflows/ci.yml/badge.svg)](https://github.com/Maka-Agent/maka-agent/actions/workflows/ci.yml)
+[![docs](https://img.shields.io/badge/docs-%E7%AE%80%E4%BD%93%E4%B8%AD%E6%96%87-blue?logo=googletranslate&logoColor=white)](./README.zh-CN.md)
 
 ![Maka — Your work. Your agent.](./.github/assets/maka-hero.en.png)
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,8 +1,7 @@
-<a href="./README.md"><img alt="English" src="https://img.shields.io/badge/English-2ea44f?style=for-the-badge&logo=googletranslate&logoColor=white"></a>
-
 # Maka
 
 [![CI](https://github.com/Maka-Agent/maka-agent/actions/workflows/ci.yml/badge.svg)](https://github.com/Maka-Agent/maka-agent/actions/workflows/ci.yml)
+[![docs](https://img.shields.io/badge/docs-English-blue?logo=googletranslate&logoColor=white)](./README.md)
 
 ![Maka——你的工作，你的 Agent。](./.github/assets/maka-hero.zh-CN.png)
 


### PR DESCRIPTION
Follow-up to #1029. Two problems the badge still had:

1. **Wrong place** — it floated alone *above* the H1, while CI sat on its own row *below* it. Two separate badge rows for what is really one badge strip.
2. **Wrong style** — `style=for-the-badge` (a chunky all-caps slab) sitting next to CI's small flat badge, so they never read as the same kind of control.

Both READMEs now open with a single badge row under the title — CI first, then the language switch — in shields' default flat style to match the CI badge. Blue rather than green so it doesn't read as a second pass/fail signal beside CI.

```
# Maka

[![CI](…)](…) [![docs](…简体中文…)](./README.zh-CN.md)
```

Both badge URLs verified live (HTTP 200, `aria-label="docs: 简体中文"` / `"docs: English"`).