### PR TITLE
fix(ui): keep errored tools collapsed instead of force-expanding

### DIFF
--- a/apps/desktop/src/main/__tests__/automation-result-preview-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/automation-result-preview-contract.test.ts
@@ -42,15 +42,13 @@ function renderAutomationResult(text: string): string {
   const item: ToolActivityItem = {
     toolUseId: 'tu-1',
     toolName: AUTOMATION_TOOL_NAME,
-    // This test exercises the result parser, not disclosure defaults. Use an
-    // attention state so Base UI mounts the panel in static markup; ordinary
-    // running tools — and now errored tools too — stay collapsed until the
-    // user asks for diagnostics.
-    status: 'waiting_permission',
+    // This test exercises the result parser, not disclosure defaults; the
+    // open prop mounts the panel in static markup.
+    status: 'completed',
     args: { mode: 'create' },
     result: { kind: 'text', text },
   };
-  return renderToStaticMarkup(createElement(ToolActivity, { items: [item] }));
+  return renderToStaticMarkup(createElement(ToolActivity, { items: [item], open: true }));
 }
 
 describe('Automation tool result preview contract', () => {

--- a/apps/desktop/src/main/__tests__/automation-result-preview-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/automation-result-preview-contract.test.ts
@@ -44,8 +44,9 @@ function renderAutomationResult(text: string): string {
     toolName: AUTOMATION_TOOL_NAME,
     // This test exercises the result parser, not disclosure defaults. Use an
     // attention state so Base UI mounts the panel in static markup; ordinary
-    // running tools now stay collapsed until the user asks for diagnostics.
-    status: 'errored',
+    // running tools — and now errored tools too — stay collapsed until the
+    // user asks for diagnostics.
+    status: 'waiting_permission',
     args: { mode: 'create' },
     result: { kind: 'text', text },
   };

--- a/apps/desktop/src/main/__tests__/chat-stream-cascade-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/chat-stream-cascade-contract.test.ts
@@ -42,7 +42,7 @@ describe('chat tool-output stream migration contract (#332 PR3)', () => {
 
     assert.match(
       harness,
-      /const openByDefault = \(s\) => s === 'waiting_permission' \|\| s === 'errored';/,
+      /const openByDefault = \(s\) => s === 'waiting_permission';/,
     );
   });
 

--- a/apps/desktop/src/main/__tests__/tool-args-redaction-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/tool-args-redaction-contract.test.ts
@@ -50,7 +50,9 @@ describe('tool and permission args redaction', () => {
 
     const source = await readFile(join(process.cwd(), '../../packages/ui/src/tool-activity.tsx'), 'utf8');
     const toolActivity = source.match(/export function ToolActivity[\s\S]*?function ToolOutputStream/)?.[0] ?? '';
-    assert.match(toolActivity, /\{formatToolIntent\(item\.intent\)\}/);
+    // The rendered row label routes intent through formatToolIntent (redaction
+    // + 240 cap) — raw `{item.intent}` never reaches JSX.
+    assert.match(toolActivity, /formatToolIntent\(item\.intent\)/);
     assert.doesNotMatch(toolActivity, /\{item\.intent\}/);
   });
 

--- a/apps/desktop/src/main/__tests__/tool-error-collapse-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/tool-error-collapse-contract.test.ts
@@ -11,9 +11,12 @@
  *
  * These tests render the public ToolActivity surface (boxed card path) with
  * a single errored item whose error text is long enough that its tail sits
- * past the banner's 240px truncation. The tail marker must NOT appear in the
- * default (collapsed) markup — it only renders inside the CollapsiblePanel,
- * which Base UI leaves unmounted while closed.
+ * past the banner's 240px truncation. The errored card itself now stays
+ * collapsed by default (the failure signal lives on the row's status label),
+ * so the body-level assertions render the expanded card via the `open` prop.
+ * The tail marker must NOT appear even in the expanded markup — it only
+ * renders inside the inner CollapsiblePanel, which Base UI leaves unmounted
+ * while closed.
  */
 
 import { strict as assert } from 'node:assert';
@@ -44,15 +47,26 @@ function renderErrored(errorText: string): string {
   return renderToStaticMarkup(createElement(ToolActivity, { items: [erroredItem(errorText)] }));
 }
 
+function renderExpanded(errorText: string): string {
+  return renderToStaticMarkup(createElement(ToolActivity, { items: [erroredItem(errorText)], open: true }));
+}
+
 describe('PR-TOOL-ERROR-COLLAPSE-0 contract (issue #741)', () => {
-  it('renders the concise failure banner by default for an errored tool', () => {
+  it('keeps the errored card collapsed by default, with the failure signal on the row', () => {
     const markup = renderErrored(LONG_ERROR);
-    assert.match(markup, /工具调用失败/, 'errored tool must show the ToolErrorBanner summary');
+    assert.doesNotMatch(markup, /工具调用失败/, 'a collapsed errored tool must not mount the banner');
+    assert.doesNotMatch(markup, new RegExp(TAIL_MARKER), 'a collapsed errored tool must not mount the raw payload');
+    assert.match(markup, />失败</, 'the collapsed row still carries the failure status label');
+  });
+
+  it('renders the concise failure banner when an errored tool is expanded', () => {
+    const markup = renderExpanded(LONG_ERROR);
+    assert.match(markup, /工具调用失败/, 'expanded errored tool must show the ToolErrorBanner summary');
     assert.match(markup, /Validation failed:/, 'banner must show the start of the error text');
   });
 
-  it('collapses the raw diagnostic payload by default (tail marker not rendered alongside the banner)', () => {
-    const markup = renderErrored(LONG_ERROR);
+  it('collapses the raw diagnostic payload behind the inner disclosure (tail marker not rendered alongside the banner)', () => {
+    const markup = renderExpanded(LONG_ERROR);
     assert.doesNotMatch(
       markup,
       new RegExp(TAIL_MARKER),
@@ -61,14 +75,14 @@ describe('PR-TOOL-ERROR-COLLAPSE-0 contract (issue #741)', () => {
   });
 
   it('exposes a keyboard-reachable trigger to expand the raw diagnostics', () => {
-    const markup = renderErrored(LONG_ERROR);
+    const markup = renderExpanded(LONG_ERROR);
     assert.match(markup, /显示原始诊断/, 'errored tool must label the raw-details disclosure trigger');
   });
 
   it('does not collapse the banner summary itself — the first 240px stays visible', () => {
     // A short error (under the 240px banner truncation) still renders its text
     // in the banner; only the raw payload (which would duplicate it) collapses.
-    const markup = renderErrored('short failure reason');
+    const markup = renderExpanded('short failure reason');
     assert.match(markup, /short failure reason/, 'a short error must still appear in the banner');
     assert.match(markup, /显示原始诊断/, '...and still offers the raw-details disclosure');
   });
@@ -80,7 +94,7 @@ describe('PR-TOOL-ERROR-COLLAPSE-0 contract (issue #741)', () => {
     const markup = renderToStaticMarkup(createElement(ToolActivity, { items: [{
       toolUseId: 'tu_empty', toolName: 'unknown_tool', status: 'errored', args: {},
       result: { kind: 'text', text: 'validation failed' },
-    }] }));
+    }], open: true }));
     assert.doesNotMatch(markup, /data-slot="tool-output"/, 'an errored tool whose raw lives in the disclosure must not also render an empty shared output panel');
   });
 
@@ -101,7 +115,7 @@ describe('PR-TOOL-ERROR-COLLAPSE-0 contract (issue #741)', () => {
     // #741 P2: a 240-char slice kept newlines, so a 180-line error still
     // rendered ~161 lines (~2656px). The summary now caps both chars and lines.
     const multiLine = Array.from({ length: 180 }, (_, i) => `line ${i}`).join('\n');
-    const markup = renderErrored(multiLine);
+    const markup = renderExpanded(multiLine);
     const m = markup.match(/data-slot="alert-description"[^>]*>([\s\S]*?)<\/div>/);
     const summary = m?.[1] ?? '';
     assert.ok(summary.split('\n').length <= 4, `banner summary must cap at 4 lines, got ${summary.split('\n').length}`);

--- a/apps/desktop/src/main/__tests__/trow-summary.test.ts
+++ b/apps/desktop/src/main/__tests__/trow-summary.test.ts
@@ -84,14 +84,17 @@ describe('isTrowRunning', () => {
 });
 
 describe('trowNeedsAttention', () => {
-  it('forces the group open for a permission prompt or an errored tool', () => {
+  it('forces the group open only for a permission prompt', () => {
+    // A permission prompt is actionable: a collapsed summary line would hide
+    // it, so the group still force-opens for it.
     assert.equal(trowNeedsAttention([tool('Read'), tool('Bash', 'waiting_permission')]), true);
-    // An errored tool must keep the group expanded so the error banner and
-    // output stay diagnosable (parity with the old boxed cards).
-    assert.equal(trowNeedsAttention([tool('Read'), tool('Bash', 'errored')]), true);
   });
 
-  it('stays collapsed for settled or merely running groups', () => {
+  it('stays collapsed for errored, settled, or merely running groups', () => {
+    // An errored tool no longer force-opens the group: the settled summary
+    // line keeps the failure signal (「N 个失败」 in destructive color), and
+    // the error banner + output stay one click away.
+    assert.equal(trowNeedsAttention([tool('Read'), tool('Bash', 'errored')]), false);
     assert.equal(trowNeedsAttention([tool('Read'), tool('Grep')]), false);
     assert.equal(trowNeedsAttention([tool('Read', 'running'), tool('Grep', 'pending')]), false);
     assert.equal(trowNeedsAttention([tool('Read', 'interrupted')]), false);

--- a/packages/ui/src/__tests__/tool-activity-presentation.test.ts
+++ b/packages/ui/src/__tests__/tool-activity-presentation.test.ts
@@ -165,9 +165,7 @@ describe('tool activity presentation', () => {
       items: [{
         toolUseId: 'tool-output',
         toolName: 'Bash',
-        // waiting_permission mounts the panel in static markup; errored no
-        // longer force-opens it.
-        status: 'waiting_permission',
+        status: 'errored',
         args: { command: 'npm test' },
         outputChunks: [
           { seq: 1, stream: 'stdout', text: 'one\n', redacted: false, createdAt: 1 },
@@ -176,6 +174,7 @@ describe('tool activity presentation', () => {
         ],
         outputTruncated: true,
       } satisfies ToolActivityItem],
+      open: true,
     }));
 
     assert.doesNotMatch(markup, /stdout\s+2/i);
@@ -192,9 +191,7 @@ describe('tool activity presentation', () => {
         toolUseId: 'tool-terminal-panel',
         toolName: 'Bash',
         intent: '跑测试',
-        // waiting_permission mounts the panel in static markup; errored no
-        // longer force-opens it.
-        status: 'waiting_permission',
+        status: 'errored',
         args: { command: 'npm run -w @maka/ui test' },
         result: {
           kind: 'terminal',
@@ -205,6 +202,7 @@ describe('tool activity presentation', () => {
           output: pipeOutput('packages/ui ok\n', 'Error: boom\n'),
         },
       } satisfies ToolActivityItem],
+      open: true,
     }));
 
     // Command without shell prompt; no cwd / success-style exit badge bar.
@@ -235,12 +233,11 @@ describe('tool activity presentation', () => {
       items: [{
         toolUseId: 'tool-malformed-terminal',
         toolName: 'Bash',
-        // waiting_permission mounts the panel in static markup; errored no
-        // longer force-opens it.
-        status: 'waiting_permission',
+        status: 'errored',
         args: { command: 'npm test' },
         result: malformed,
       } satisfies ToolActivityItem],
+      open: true,
     }));
 
     assert.match(markup, /npm test/);
@@ -442,15 +439,14 @@ describe('tool activity presentation', () => {
       items: [{
         toolUseId: 'tool-mixed',
         toolName: 'CustomInspect',
-        // waiting_permission mounts the panel in static markup; errored no
-        // longer force-opens it.
-        status: 'waiting_permission',
+        status: 'errored',
         args: {},
         result: {
           kind: 'json',
           value: { results: [], error: 'permission denied', ok: false },
         },
       } satisfies ToolActivityItem],
+      open: true,
     }));
 
     assert.match(markup, /permission denied/);
@@ -616,9 +612,7 @@ describe('tool activity presentation', () => {
         toolUseId: 'tool-pty-control',
         toolName: 'WriteStdin',
         activityKind: 'command',
-        // waiting_permission mounts the panel in static markup; errored no
-        // longer force-opens it.
-        status: 'waiting_permission',
+        status: 'errored',
         args: {
           ref: 'maka://runtime/background-tasks/pty-1',
           inputPreview: { text: 'echo x\\n', bytes: 7, truncated: false },
@@ -655,6 +649,7 @@ describe('tool activity presentation', () => {
           },
         },
       } satisfies ToolActivityItem],
+      open: true,
     }));
 
     assert.match(markup, /未排队：echo x\\n/);

--- a/packages/ui/src/__tests__/tool-activity-presentation.test.ts
+++ b/packages/ui/src/__tests__/tool-activity-presentation.test.ts
@@ -107,7 +107,7 @@ describe('tool activity presentation', () => {
     );
   });
 
-  it('opens a newly errored tool even after an earlier manual collapse', () => {
+  it('keeps a tool collapsed when it errors, even after an earlier manual collapse', () => {
     const running: ToolActivityItem = {
       toolUseId: 'tool-error',
       toolName: 'Bash',
@@ -118,15 +118,46 @@ describe('tool activity presentation', () => {
       ...running,
       status: 'errored',
     };
+
+    // An error is not an attention state: the initial disclosure stays closed…
+    assert.deepEqual(
+      createToolDisclosureState(deriveToolActivityPresentation(errored)),
+      { open: false, manuallySet: false },
+    );
+
+    // …and an earlier manual collapse is not overridden when the tool errors.
     const collapsed = setToolDisclosureOpen(
       createToolDisclosureState(deriveToolActivityPresentation(running)),
       false,
     );
-
     assert.deepEqual(
       syncToolDisclosureState(collapsed, deriveToolActivityPresentation(errored)),
-      { open: true, manuallySet: false },
+      { open: false, manuallySet: true },
     );
+  });
+
+  it('keeps a settled errored tool collapsed while the summary carries the failure signal', () => {
+    const markup = renderTool({
+      toolUseId: 'tool-errored-collapsed',
+      toolName: 'Bash',
+      activityKind: 'command',
+      intent: '跑测试',
+      status: 'errored',
+      args: { command: 'npm test' },
+      result: {
+        kind: 'terminal',
+        cwd: '/tmp/maka',
+        cmd: 'npm test',
+        status: 'failed',
+        exitCode: 1,
+        output: pipeOutput('', 'Error: boom\n'),
+      },
+    });
+
+    // Collapsed: the diagnostic body is not mounted…
+    assert.doesNotMatch(markup, /Error: boom/);
+    // …but the failure stays visible on the summary line.
+    assert.match(markup, /1 个失败/);
   });
 
   it('shows diagnostic flags without exposing transport chunk counts', () => {
@@ -134,7 +165,9 @@ describe('tool activity presentation', () => {
       items: [{
         toolUseId: 'tool-output',
         toolName: 'Bash',
-        status: 'errored',
+        // waiting_permission mounts the panel in static markup; errored no
+        // longer force-opens it.
+        status: 'waiting_permission',
         args: { command: 'npm test' },
         outputChunks: [
           { seq: 1, stream: 'stdout', text: 'one\n', redacted: false, createdAt: 1 },
@@ -159,7 +192,9 @@ describe('tool activity presentation', () => {
         toolUseId: 'tool-terminal-panel',
         toolName: 'Bash',
         intent: '跑测试',
-        status: 'errored',
+        // waiting_permission mounts the panel in static markup; errored no
+        // longer force-opens it.
+        status: 'waiting_permission',
         args: { command: 'npm run -w @maka/ui test' },
         result: {
           kind: 'terminal',
@@ -200,7 +235,9 @@ describe('tool activity presentation', () => {
       items: [{
         toolUseId: 'tool-malformed-terminal',
         toolName: 'Bash',
-        status: 'errored',
+        // waiting_permission mounts the panel in static markup; errored no
+        // longer force-opens it.
+        status: 'waiting_permission',
         args: { command: 'npm test' },
         result: malformed,
       } satisfies ToolActivityItem],
@@ -405,7 +442,9 @@ describe('tool activity presentation', () => {
       items: [{
         toolUseId: 'tool-mixed',
         toolName: 'CustomInspect',
-        status: 'errored',
+        // waiting_permission mounts the panel in static markup; errored no
+        // longer force-opens it.
+        status: 'waiting_permission',
         args: {},
         result: {
           kind: 'json',
@@ -577,7 +616,9 @@ describe('tool activity presentation', () => {
         toolUseId: 'tool-pty-control',
         toolName: 'WriteStdin',
         activityKind: 'command',
-        status: 'errored',
+        // waiting_permission mounts the panel in static markup; errored no
+        // longer force-opens it.
+        status: 'waiting_permission',
         args: {
           ref: 'maka://runtime/background-tasks/pty-1',
           inputPreview: { text: 'echo x\\n', bytes: 7, truncated: false },

--- a/packages/ui/src/__tests__/tool-trow-summary.test.ts
+++ b/packages/ui/src/__tests__/tool-trow-summary.test.ts
@@ -55,13 +55,29 @@ describe('tool trow summary aggregation', () => {
     assert.doesNotMatch(markup, /lucide-search/);
   });
 
-  it('live summary omits the failed count (it changes mid-group); settled includes it', () => {
+  it('keeps the failed count visible in the live summary (the group no longer force-opens on error)', () => {
     const items: ToolActivityItem[] = [
       { toolUseId: 'r1', toolName: 'Read', activityKind: 'read', status: 'completed', args: {} },
       { toolUseId: 'g1', toolName: 'Grep', activityKind: 'search', status: 'errored', args: {} },
     ];
-    assert.equal(summarizeTrowTools(items, { live: true }), '正在读取 1 个文件，搜索 1 次');
+    // Errored tools stay collapsed now, so the summary line is the failure
+    // signal and must carry the count live, not only once settled.
+    assert.equal(summarizeTrowTools(items, { live: true }), '正在读取 1 个文件，搜索 1 次，1 个失败');
     assert.equal(summarizeTrowTools(items), '读取 1 个文件，搜索 1 次，1 个失败');
+  });
+
+  it('marks an errored row with a visible 失败 word inside an expanded group', () => {
+    const markup = renderToStaticMarkup(createElement(ToolTrow, {
+      items: [
+        // waiting_permission mounts the group panel in static markup, so the
+        // per-row headers render.
+        { toolUseId: 'w1', toolName: 'Write', activityKind: 'edit', status: 'waiting_permission', args: {}, intent: '写入配置' },
+        { toolUseId: 'e1', toolName: 'Bash', activityKind: 'command', status: 'errored', args: {}, intent: '运行测试' },
+      ] satisfies ToolActivityItem[],
+    }));
+    // A collapsed errored row must not rely on the destructive tint alone —
+    // the failure is a word, not just a color.
+    assert.match(markup, /运行测试 · 失败/);
   });
 
   it('ToolTrowRow never reintroduces the per-row settle fade or the motion abstraction', () => {

--- a/packages/ui/src/tool-activity.tsx
+++ b/packages/ui/src/tool-activity.tsx
@@ -320,7 +320,14 @@ function toolStatusLabel(item: ToolActivityItem): string {
   return STATUS_LABEL[item.status];
 }
 
-export function ToolActivity(props: { items: ToolActivityItem[] }) {
+export function ToolActivity(props: {
+  items: ToolActivityItem[];
+  /** Controlled open state applied to every card. When omitted each card
+   *  manages its own disclosure (permission prompts open; errored tools stay
+   *  collapsed). Passed by tests to render the expanded state in static
+   *  markup; production callers leave it uncontrolled. */
+  open?: boolean;
+}) {
   return (
     <section className={toolVariants({ part: 'container' })} aria-label="工具调用记录">
       <header className={toolVariants({ part: 'container-header' })}>
@@ -328,25 +335,28 @@ export function ToolActivity(props: { items: ToolActivityItem[] }) {
         <span className={toolVariants({ part: 'count' })} aria-label={`${props.items.length} 次调用`}>{props.items.length}</span>
       </header>
       {props.items.map((item) => (
-        <ToolActivityCard key={item.toolUseId} item={item} />
+        <ToolActivityCard key={item.toolUseId} item={item} open={props.open} />
       ))}
     </section>
   );
 }
 
-function ToolActivityCard({ item }: { item: ToolActivityItem }) {
-  // Ordinary work stays summarized. A new permission/error state opens the
-  // diagnostics, while an explicit user toggle survives later ordinary status
-  // changes. See disclosure-collapsible-contract: defaultOpen is banned here.
+function ToolActivityCard({ item, open: openProp }: { item: ToolActivityItem; open?: boolean }) {
+  // Ordinary work stays summarized. A new permission prompt opens the
+  // diagnostics (it is actionable); an errored tool stays collapsed — the
+  // failure signal lives on the summary line. An explicit user toggle survives
+  // later ordinary status changes. See disclosure-collapsible-contract:
+  // defaultOpen is banned here.
   const presentation = deriveToolActivityPresentation(item);
   const disclosure = useToolDisclosure(presentation);
+  const open = openProp ?? disclosure.open;
   const duration = formatDuration(item.durationMs);
   return (
     <Collapsible
       data-slot="tool"
       className={toolVariants({ part: 'item' })}
       data-status={item.status}
-      open={disclosure.open}
+      open={open}
       onOpenChange={disclosure.setOpen}
     >
       <CollapsibleTrigger className={toolVariants({ part: 'header' })}>
@@ -532,7 +542,8 @@ function ToolTrowGroup({ items }: { items: ToolActivityItem[] }) {
   // the whole-group trowNeedsAttention below.
   const firstPresentation = deriveToolActivityPresentation(items[0]!);
   // Groups share the same disclosure state as a single row: ordinary work is
-  // summarized; a new permission/error state opens diagnostics; manual choice
+  // summarized; a new permission prompt opens diagnostics (errors stay
+  // collapsed — the summary line carries the failure signal); manual choice
   // survives ordinary status changes.
   const disclosure = useToolDisclosure({ ...firstPresentation, needsAttention: attention });
   // #646: a group settles when all its tools do; the settle fade plays only if
@@ -588,8 +599,9 @@ function ToolTrowGroup({ items }: { items: ToolActivityItem[] }) {
 
 /**
  * A single flat, borderless tool row inside a multi-tool trow. Ordinary work
- * is collapsed; permission prompts and errors open for attention, and a user's
- * manual choice survives later ordinary status changes. No card frame
+ * is collapsed; permission prompts open for attention (errors stay collapsed —
+ * the summary line carries the failure signal), and a user's manual choice
+ * survives later ordinary status changes. No card frame
  * (`toolVariants({item})`), per the flat trow visual language.
  */
 function ToolTrowRow({ item }: { item: ToolActivityItem }) {

--- a/packages/ui/src/tool-activity.tsx
+++ b/packages/ui/src/tool-activity.tsx
@@ -621,6 +621,9 @@ function ToolTrowRow({ item }: { item: ToolActivityItem }) {
   // word. Running shimmers the model's intent (or the friendly tool name);
   // settled prefers the intent, falls back to the display name.
   const summaryTone = errored ? 'text-[color:var(--destructive)]' : 'text-[color:var(--muted-foreground)]';
+  // An errored row stays collapsed, so the destructive tint is not enough —
+  // the failure is spelled out as a word on the row label.
+  const rowLabel = item.intent ? formatToolIntent(item.intent) : resolveToolDisplayName(item);
   return (
     <Collapsible className="flex flex-col" data-trow="row" data-status={item.status} data-settled={settled ? 'true' : undefined} open={disclosure.open} onOpenChange={disclosure.setOpen}>
       <CollapsibleTrigger className="group flex w-full items-center gap-2 py-0.5 text-left">
@@ -631,10 +634,8 @@ function ToolTrowRow({ item }: { item: ToolActivityItem }) {
         />
         {running ? (
           <TextShimmer active delayed className="min-w-0 truncate text-[length:var(--font-size-base)]">{presentation.summary}</TextShimmer>
-        ) : item.intent ? (
-          <span className={cn('min-w-0 truncate text-[length:var(--font-size-base)]', summaryTone)}>{formatToolIntent(item.intent)}</span>
         ) : (
-          <span className={cn('min-w-0 truncate text-[length:var(--font-size-base)]', summaryTone)}>{resolveToolDisplayName(item)}</span>
+          <span className={cn('min-w-0 truncate text-[length:var(--font-size-base)]', summaryTone)}>{errored ? `${rowLabel} · 失败` : rowLabel}</span>
         )}
         {/* Quiet meta sits right after the label (near the text, not pinned to
             the far edge): duration + chevron ride in on hover / open, matching

--- a/packages/ui/src/tool-activity/presentation.ts
+++ b/packages/ui/src/tool-activity/presentation.ts
@@ -31,7 +31,11 @@ export function deriveToolActivityPresentation(item: ToolActivityItem): ToolActi
   return {
     kind: trowActivityKind(item.toolName, item.activityKind),
     summary: formatUserVisibleToolText(item.intent ?? '') || resolveToolDisplayName(item),
-    needsAttention: item.status === 'waiting_permission' || item.status === 'errored',
+    // Only a permission prompt is an attention state: it is actionable and a
+    // collapsed row would hide it. An errored tool stays collapsed — the trow
+    // summary line keeps the failure signal (「N 个失败」 in destructive
+    // color), and the diagnostics stay one click away.
+    needsAttention: item.status === 'waiting_permission',
   };
 }
 

--- a/packages/ui/src/tool-activity/trow-summary.ts
+++ b/packages/ui/src/tool-activity/trow-summary.ts
@@ -92,12 +92,11 @@ function isFailed(status: ToolActivityItem['status']): boolean {
 /**
  * Build the summary line for a trow: one clause per distinct activity kind in
  * first-seen order, joined with "，". With `{ live: true }` (a multi-tool
- * running group) the line is prefixed with "正在" and the trailing "N 个失败"
- * clause is suppressed — the failed count changes mid-group, so the failure
- * signal is kept off the jittering summary line and arrives with the settled
- * summary. Settled (default) includes the "N 个失败" clause when any tool
- * errored. A failed tool still
- * counts toward its type bucket (a failed read is "读取 1 个文件" + "1 个失败").
+ * running group) the line is prefixed with "正在". The "N 个失败" clause is
+ * included whenever any tool errored — errored tools stay collapsed, so the
+ * summary line is the failure signal and must carry the count live, not only
+ * once settled. A failed tool still counts toward its type bucket (a failed
+ * read is "读取 1 个文件" + "1 个失败").
  */
 export function summarizeTrowTools(
   items: readonly ToolActivityItem[],
@@ -113,9 +112,7 @@ export function summarizeTrowTools(
     if (isFailed(item.status)) failed += 1;
   }
   const clauses = order.map((kind) => KIND_CLAUSE[kind](counts.get(kind) ?? 0));
-  // Running summary prioritizes stability: the failed count changes as tools
-  // error mid-group, so it is shown only once the group settles.
-  if (!options?.live && failed > 0) clauses.push(`${failed} 个失败`);
+  if (failed > 0) clauses.push(`${failed} 个失败`);
   const base = clauses.join('，');
   return options?.live ? `正在${base}` : base;
 }

--- a/packages/ui/src/tool-activity/trow-summary.ts
+++ b/packages/ui/src/tool-activity/trow-summary.ts
@@ -93,10 +93,10 @@ function isFailed(status: ToolActivityItem['status']): boolean {
  * Build the summary line for a trow: one clause per distinct activity kind in
  * first-seen order, joined with "，". With `{ live: true }` (a multi-tool
  * running group) the line is prefixed with "正在" and the trailing "N 个失败"
- * clause is suppressed — the failed count changes mid-group, and errored tools
- * still force-open their disclosure (trowNeedsAttention), so the failure signal
- * is not lost, just kept off the jittering summary line. Settled (default)
- * includes the "N 个失败" clause when any tool errored. A failed tool still
+ * clause is suppressed — the failed count changes mid-group, so the failure
+ * signal is kept off the jittering summary line and arrives with the settled
+ * summary. Settled (default) includes the "N 个失败" clause when any tool
+ * errored. A failed tool still
  * counts toward its type bucket (a failed read is "读取 1 个文件" + "1 个失败").
  */
 export function summarizeTrowTools(
@@ -114,9 +114,7 @@ export function summarizeTrowTools(
   }
   const clauses = order.map((kind) => KIND_CLAUSE[kind](counts.get(kind) ?? 0));
   // Running summary prioritizes stability: the failed count changes as tools
-  // error mid-group, so it is shown only once the group settles. Errored tools
-  // still force-open their disclosure (trowNeedsAttention), so the failure
-  // signal is not lost — it just doesn't jitter the summary line mid-run.
+  // error mid-group, so it is shown only once the group settles.
   if (!options?.live && failed > 0) clauses.push(`${failed} 个失败`);
   const base = clauses.join('，');
   return options?.live ? `正在${base}` : base;
@@ -131,13 +129,12 @@ export function isTrowRunning(items: readonly ToolActivityItem[]): boolean {
 }
 
 /**
- * True when the group must force itself open: a permission prompt or an error
- * banner is inside. Both are actionable/diagnostic content that a collapsed
- * summary line would hide — the old boxed cards kept errored tools expanded,
- * and the trow keeps that behavior.
+ * True when the group must force itself open: a permission prompt is inside.
+ * A prompt is actionable content that a collapsed summary line would hide. An
+ * errored tool no longer force-opens the group — the settled summary line
+ * keeps the failure signal (「N 个失败」 in destructive color), and the error
+ * banner + output stay one click away behind the disclosure.
  */
 export function trowNeedsAttention(items: readonly ToolActivityItem[]): boolean {
-  return items.some(
-    (item) => item.status === 'waiting_permission' || item.status === 'errored',
-  );
+  return items.some((item) => item.status === 'waiting_permission');
 }

--- a/scripts/check-chat-marker-computed-style.mjs
+++ b/scripts/check-chat-marker-computed-style.mjs
@@ -129,17 +129,18 @@ const toolOutputPanel = (el, id) =>
 // body / intent, and the args `<pre>` override over the shared `.maka-code` base
 // — is static and diffed in full.
 //
-// Each card carries the production disclosure default: waiting_permission /
-// errored render OPEN; ordinary pending / running / completed / interrupted
-// states render COLLAPSED. The rich inner parts ride the open `errored` card,
-// and a collapsed `completed` card is diffed too. The non-vacuous collapsed
-// signal is the summary's
+// Each card carries the production disclosure default: waiting_permission
+// renders OPEN (a permission prompt is actionable); errored now renders
+// COLLAPSED like the other settled states (the failure signal lives on the
+// summary text). The rich inner parts ride the open `waiting_permission`
+// card, and collapsed `completed` + `errored` cards are diffed too. The
+// non-vacuous collapsed signal is the summary's
 // border-bottom: 1px on the open card, 0px on the collapsed one (the `[open]`
 // gate), so the rows genuinely exercise both states. (The body is hidden via
 // Chromium's `::details-content` pseudo, so its child `display` stays `block`
 // either way — the collapsed body row still diffs its box / typography parity.)
 const tv = (part) => toolVariants({ part });
-const openByDefault = (s) => s === 'waiting_permission' || s === 'errored';
+const openByDefault = (s) => s === 'waiting_permission';
 // The SINGLE source of truth for the tool-card fixture: every production
 // `ToolActivityItem['status']` (the keys of components.tsx's STATUS_LABEL). The
 // cards, the header count, and the diffed IDS all derive from this one list, so
@@ -155,19 +156,21 @@ const toolCardSection = (el) => {
   const body = pair('maka-tool-body', tv('body'));
   const dotEl = (s, id) => el('span', id, dot, `data-status="${s}" aria-hidden="true"`);
   // The status-invariant inner parts (name / meta / duration / status-label /
-  // body / intent / args) ride the OPEN `errored` card so they're each measured
-  // once in their visible state — including the `[open]>summary` divider.
-  const erroredInner =
+  // body / intent / args) ride the OPEN `waiting_permission` card so they're
+  // each measured once in their visible state — including the `[open]>summary`
+  // divider.
+  const waitingInner =
     el('summary', 'tool-summary', hdr, '',
-        dotEl('errored', 'tool-dot-errored')
+        dotEl('waiting_permission', 'tool-dot-waiting_permission')
         + el('span', 'tool-name', pair('maka-tool-name', tv('name')), '', 'Bash')
         + el('span', 'tool-meta', pair('maka-tool-meta', tv('meta')), '',
             el('span', 'tool-duration', pair('maka-tool-duration', tv('duration')), '', '1.2s')
-            + el('span', 'tool-statuslabel', pair('maka-tool-status-label', tv('status-label')), '', '失败')))
+            + el('span', 'tool-statuslabel', pair('maka-tool-status-label', tv('status-label')), '', '等待权限')))
       + el('div', 'tool-body', body, '',
           el('p', 'tool-intent', pair('maka-tool-intent', tv('intent')), '', 'run a command')
           + el('pre', 'tool-args', pair('maka-code toolArgs', cn('maka-code', tv('args'))), '', '{ "cmd": "ls" }'));
-  // The COLLAPSED `completed` card — the default history state. The summary loses
+  // The COLLAPSED `completed` card — the default history state (the collapsed
+  // `errored` card shares the same default branch now). The summary loses
   // its `[open]>summary` divider (border-bottom 0px vs the open card's 1px — the
   // non-vacuous proof the collapsed branch is really exercised); the body's box /
   // typography parity is diffed too. Both read identical across main/head.
@@ -177,7 +180,7 @@ const toolCardSection = (el) => {
         + el('span', 'tool-name-collapsed', pair('maka-tool-name', tv('name')), '', 'Read'))
       + el('div', 'tool-body-collapsed', body, '', 'hidden while collapsed');
   const inner = (s) =>
-    s === 'errored' ? erroredInner
+    s === 'waiting_permission' ? waitingInner
     : s === 'completed' ? completedInner
     // running dot excluded from IDS (animated); other open/collapsed dots diffed.
     : el('summary', `tool-sum-${s}`, hdr, '', dotEl(s, `tool-dot-${s}`));
@@ -257,8 +260,9 @@ const IDS = ['footer', 'footer-rest', 'footer-pending', 'footer-copy-pending', '
   // PR3b tool-card shell: section + count, all six `[data-status]` card
   // containers at their production default open/collapsed state, the summary header
   // grid, the static dot colors (running dot excluded — animated ring), the
-  // status-invariant inner parts (on the open `errored` card), and the COLLAPSED
-  // `completed` default — its summary (no `[open]` divider) + UA-hidden body.
+  // status-invariant inner parts (on the open `waiting_permission` card), and
+  // the COLLAPSED `completed` / `errored` defaults — the collapsed summary (no
+  // `[open]` divider) + UA-hidden body.
   'tool-section', 'tool-section-header', 'tool-count',
   // Derived from the same STAT as the cards (no second hand-kept list to drift):
   // every status' `[data-status]` container is diffed…


### PR DESCRIPTION
## Summary

In Desktop sessions, a failed tool force-expanded its trow group (and the legacy boxed card), spreading the error banner and raw output across the conversation. This PR keeps failed tools collapsed:

- The attention checks in `deriveToolActivityPresentation` and `trowNeedsAttention` narrow from `waiting_permission || errored` to `waiting_permission` only. Permission prompts keep the force-open behavior — they are actionable and a collapsed summary would hide them. Errors are no longer an attention state.
- The failure signal is not lost: the collapsed summary line still shows "N 个失败" in destructive color with a red kind icon (the boxed card shows the 「失败」status label), and the error banner + raw diagnostics stay one click away behind the disclosure.
- A manual collapse is no longer overridden when the tool later errors (`manuallySet` semantics unchanged).
- `ToolActivity` gains a controlled `open` prop (the existing `ToolErrorDetails` test pattern) so tests can render the expanded body in static markup; production callers never pass it and are unaffected.

The #741 error-collapse contract's goal (a verbose failure must not dominate the conversation) still holds under the collapsed default; its tests now pin the collapsed default and the expanded banner/inner-diagnostics behavior separately.

## Verification

- `@maka/ui` full suite: 160/160 pass, including a new trow-level regression test (errored tool stays collapsed, summary keeps "1 个失败").
- `@maka/desktop` full main suite: 2549/2549 pass (including the `test:checks` console/a11y/copy checks).
- `typecheck` (ui + desktop, incl. the storybook tsconfig) and `biome lint` on changed files pass.
- E2E / screenshot runs skipped: no e2e spec or visual-smoke fixture relies on errored tools auto-expanding (verified by repo-wide search).

<img width="2562" height="874" alt="image" src="https://github.com/user-attachments/assets/b6bd3983-215a-42fc-8898-c2c92f121eb0" />

## Review focus

A Codex review round on the initial commit found three P2 gaps created by removing the force-open fallback; all are fixed in follow-up commits on this branch:

- **Live groups hid the failed count, and errored rows inside an expanded group were tint-only.** The live-summary suppression was justified by the force-open fallback that this PR removes, so `summarizeTrowTools(live)` now keeps the "N 个失败" clause (the count is monotonic mid-group — no jitter), and an errored `ToolTrowRow` carries a visible "· 失败" word.
- **Five body-rendering tests had moved to `waiting_permission`, silently leaving the errored branches they pin.** They now keep `status: 'errored'` and mount the panel via the `open` prop (byte-identical to the old auto-open renders); the automation contract uses the honest `completed` + `open`.
- **The computed-style zero-visual fixture still mirrored `waiting_permission || errored` open-by-default.** It now matches production (`waiting_permission` only), with the rich inner parts on the open permission card and the errored card joining the collapsed set; the cascade contract regex is updated in lockstep. A fourth commit aligns the intent-redaction contract's source pin with the row-label refactor.

Follow-up verification: `@maka/ui` 161/161, `@maka/desktop` 2549/2549 (incl. checks), typecheck + biome lint clean, and a headless `check:chat-visual` smoke run confirming every rewritten fixture id resolves and computes.
