### PR TITLE
feat(headless): unify RSI and AHE audit schemas

### DIFF
--- a/packages/headless/src/__tests__/ahe-target-protocol.fixtures.ts
+++ b/packages/headless/src/__tests__/ahe-target-protocol.fixtures.ts
@@ -10,8 +10,8 @@ export const VALID_MAKA_AHE_CHANGE_MANIFEST: MakaAheChangeManifest = {
   sourceLabel: MAKA_AHE_TARGET_SOURCE_LABEL,
   targetSnapshotId: 'snap-baseline',
   createdAt: '2026-07-01T00:00:00.000Z',
-  changedComponents: ['maka-system-prompt', 'maka-tool-contracts'],
-  editedSurface: 'system_prompt',
+  changedComponents: ['maka-tool-contracts'],
+  editedSurface: 'tool_contract',
   evidenceRefs: [
     {
       taskId: 'terminal-bench/sqlite-with-gcov',
@@ -42,7 +42,6 @@ export const VALID_MAKA_AHE_CHANGE_MANIFEST: MakaAheChangeManifest = {
   patch: {
     applyMode: 'staged_patch',
     changedFiles: [
-      'apps/desktop/src/main/system-prompt-main.ts',
       'packages/runtime/src/tool-runtime.ts',
     ],
   },

--- a/packages/headless/src/__tests__/ahe-target-protocol.fixtures.ts
+++ b/packages/headless/src/__tests__/ahe-target-protocol.fixtures.ts
@@ -11,7 +11,8 @@ export const VALID_MAKA_AHE_CHANGE_MANIFEST: MakaAheChangeManifest = {
   targetSnapshotId: 'snap-baseline',
   createdAt: '2026-07-01T00:00:00.000Z',
   changedComponents: ['maka-system-prompt', 'maka-tool-contracts'],
-  failureEvidence: [
+  editedSurface: 'system_prompt',
+  evidenceRefs: [
     {
       taskId: 'terminal-bench/sqlite-with-gcov',
       runId: 'run-baseline',
@@ -19,7 +20,7 @@ export const VALID_MAKA_AHE_CHANGE_MANIFEST: MakaAheChangeManifest = {
       summary: 'Official verifier failed after the trace showed a missing gcov artifact.',
     },
   ],
-  rootCause: 'Tool contract omitted the expected artifact path, so the task plan never verified coverage output.',
+  hypothesis: 'Tool contract omitted the expected artifact path, so the task plan never verified coverage output.',
   targetedFix: 'Clarify the artifact contract in the tool description and prompt policy.',
   predictedFixes: [
     {
@@ -27,7 +28,7 @@ export const VALID_MAKA_AHE_CHANGE_MANIFEST: MakaAheChangeManifest = {
       summary: 'Candidate should create the gcov artifact before finalizing.',
     },
   ],
-  riskCases: [
+  riskTasks: [
     {
       taskId: 'terminal-bench/qemu-startup',
       summary: 'Prompt/tool changes must not add extra setup work to unrelated heavy tasks.',

--- a/packages/headless/src/__tests__/ahe-target-protocol.test.ts
+++ b/packages/headless/src/__tests__/ahe-target-protocol.test.ts
@@ -96,11 +96,11 @@ describe('AHE target protocol', () => {
     assert.equal(result.ok, true);
   });
 
-  it('uses the same audit field names and requires the edited surface to be changed', () => {
+  it('uses the same audit field names and binds every changed component to the edited surface', () => {
     const result = validateMakaAheChangeManifest({
       ...VALID_MAKA_AHE_CHANGE_MANIFEST,
       editedSurface: 'tool_contract',
-      changedComponents: ['maka-system-prompt'],
+      changedComponents: ['maka-tool-contracts', 'maka-system-prompt'],
     });
 
     assert.equal(result.ok, false);
@@ -137,6 +137,7 @@ describe('AHE target protocol', () => {
   it('rejects manifests that try to patch evidence-only components', () => {
     const result = validateMakaAheChangeManifest({
       ...VALID_MAKA_AHE_CHANGE_MANIFEST,
+      editedSurface: 'runtime_evidence',
       changedComponents: ['maka-runtime-evidence'],
       patch: {
         applyMode: 'staged_patch',
@@ -153,6 +154,7 @@ describe('AHE target protocol', () => {
   it('rejects patch paths outside changed editable component source refs', () => {
     const result = validateMakaAheChangeManifest({
       ...VALID_MAKA_AHE_CHANGE_MANIFEST,
+      editedSurface: 'system_prompt',
       changedComponents: ['maka-system-prompt'],
       patch: {
         applyMode: 'staged_patch',

--- a/packages/headless/src/__tests__/ahe-target-protocol.test.ts
+++ b/packages/headless/src/__tests__/ahe-target-protocol.test.ts
@@ -96,9 +96,23 @@ describe('AHE target protocol', () => {
     assert.equal(result.ok, true);
   });
 
+  it('uses the same audit field names and requires the edited surface to be changed', () => {
+    const result = validateMakaAheChangeManifest({
+      ...VALID_MAKA_AHE_CHANGE_MANIFEST,
+      editedSurface: 'tool_contract',
+      changedComponents: ['maka-system-prompt'],
+    });
+
+    assert.equal(result.ok, false);
+    if (!result.ok) {
+      assert(result.errors.some((error) => error.path === 'editedSurface'));
+    }
+  });
+
   it('lets the heavy-task component patch its policy owner', () => {
     const result = validateMakaAheChangeManifest({
       ...VALID_MAKA_AHE_CHANGE_MANIFEST,
+      editedSurface: 'heavy_task_policy',
       changedComponents: ['maka-heavy-task-policy'],
       patch: {
         applyMode: 'staged_patch',

--- a/packages/headless/src/__tests__/helpers/prompt-optimization-loop-harness.ts
+++ b/packages/headless/src/__tests__/helpers/prompt-optimization-loop-harness.ts
@@ -103,19 +103,22 @@ export async function runLoop(harness: Harness, options: RunLoopOptions) {
 
 /** A meta-agent that proposes a unique, valid prompt per round (no model). */
 export function fakeMetaAgent(): MetaAgent {
-  return async (promptInput) => ({
-    systemPrompt: `candidate prompt ${promptInput.roundId}\n`,
-    summary: `tuned for ${promptInput.roundId}`,
-    candidateRationale: {
-      editedSurface: 'system_prompt',
-      failurePattern: 'coverage_regression',
-      evidenceRefs: evidenceRefsFor(promptInput),
-      hypothesis: 'stable held-in coverage can improve with a clearer prompt',
-      targetedFix: 'make the success criteria explicit without adding task-specific answers',
-      predictedFixes: [],
-      riskTasks: [],
-    },
-  });
+  return async (promptInput) => {
+    const evidenceRefs = evidenceRefsFor(promptInput);
+    return {
+      systemPrompt: `candidate prompt ${promptInput.roundId}\n`,
+      summary: `tuned for ${promptInput.roundId}`,
+      candidateRationale: {
+        editedSurface: 'system_prompt',
+        evidenceRefs,
+        hypothesis: 'stable held-in coverage can improve with a clearer prompt',
+        targetedFix: 'make the success criteria explicit without adding task-specific answers',
+        predictedFixes: [],
+        riskTasks: [],
+        ...(evidenceRefs.length === 0 ? { failurePattern: 'coverage_regression' as const } : {}),
+      },
+    };
+  };
 }
 
 export function evidenceRefsFor(promptInput: MetaAgentPromptInput): string[] {

--- a/packages/headless/src/__tests__/helpers/prompt-optimization-loop-harness.ts
+++ b/packages/headless/src/__tests__/helpers/prompt-optimization-loop-harness.ts
@@ -107,6 +107,7 @@ export function fakeMetaAgent(): MetaAgent {
     systemPrompt: `candidate prompt ${promptInput.roundId}\n`,
     summary: `tuned for ${promptInput.roundId}`,
     candidateRationale: {
+      editedSurface: 'system_prompt',
       failurePattern: 'coverage_regression',
       evidenceRefs: evidenceRefsFor(promptInput),
       hypothesis: 'stable held-in coverage can improve with a clearer prompt',

--- a/packages/headless/src/__tests__/meta-agent-completion.test.ts
+++ b/packages/headless/src/__tests__/meta-agent-completion.test.ts
@@ -21,6 +21,7 @@ const connection: LlmConnection = {
 
 const base = { connection, apiKey: 'unused', modelId: 'deepseek-v4-flash' } as const;
 const candidateRationale = {
+  editedSurface: 'system_prompt',
   failurePattern: 'coverage_regression',
   evidenceRefs: [],
   hypothesis: 'coverage fell after the previous prompt change',
@@ -74,6 +75,9 @@ describe('createAiSdkMetaAgentCompletion', () => {
     });
     await complete({ prompt: 'render' });
     assert.match(seenSystem ?? '', /JSON object/);
+    assert.match(seenSystem ?? '', /"editedSurface":"system_prompt"/);
+    assert.match(seenSystem ?? '', /"evidenceRefs":/);
+    assert.match(seenSystem ?? '', /failurePattern only as a coarse fallback/);
   });
 });
 

--- a/packages/headless/src/__tests__/prompt-candidate-loop.test.ts
+++ b/packages/headless/src/__tests__/prompt-candidate-loop.test.ts
@@ -373,6 +373,13 @@ describe('prompt candidate loop', () => {
     );
   });
 
+  test('rejects candidateRationale for a non-prompt edited surface', async () => {
+    await assertRejectsCandidateRationale(
+      validCandidateRationale({ editedSurface: 'tool_contract' }),
+      /candidateRationale.editedSurface must be "system_prompt"/,
+    );
+  });
+
   test('rejects candidateRationale evidence refs outside the current RSI analysis', async () => {
     await withDir(async (dir) => {
       const programPath = join(dir, 'program.md');
@@ -416,7 +423,7 @@ describe('prompt candidate loop', () => {
     });
   });
 
-  test('requires evidence refs when current RSI analysis has signals for a typed failure pattern', async () => {
+  test('requires direct evidence when signals exist and otherwise requires a coarse fallback', async () => {
     await withDir(async (dir) => {
       const programPath = join(dir, 'program.md');
       const systemPromptPath = join(dir, 'system_prompt.md');
@@ -461,6 +468,26 @@ describe('prompt candidate loop', () => {
 
       await runPromptCandidateRound({
         ...baseInput,
+        resultsJsonlPath: join(dir, 'signal-ref-without-fallback.jsonl'),
+        rsiAnalysis: {
+          heldInTaskSetHash: 'sha256:held-in',
+          transitionVsLastKept: [],
+          transitionVsPreviousCandidate: [],
+          coverageRegressionTaskIds: [],
+          errorClassDistribution: [],
+          toolFailureClusters: [],
+          signals: [{ id: 'rsi-sig:known', kind: 'coverage_regression', taskIds: ['task-a'] }],
+        },
+        metaAgent: async () => candidatePromptResult({
+          candidateRationale: validCandidateRationale({
+            evidenceRefs: ['rsi-sig:known'],
+            failurePattern: undefined,
+          }),
+        }),
+      });
+
+      await runPromptCandidateRound({
+        ...baseInput,
         resultsJsonlPath: join(dir, 'allowed-empty-refs.jsonl'),
         rsiAnalysis: {
           heldInTaskSetHash: 'sha256:held-in',
@@ -475,6 +502,20 @@ describe('prompt candidate loop', () => {
           candidateRationale: validCandidateRationale({ evidenceRefs: [] }),
         }),
       });
+
+      await assert.rejects(
+        runPromptCandidateRound({
+          ...baseInput,
+          resultsJsonlPath: join(dir, 'missing-fallback.jsonl'),
+          metaAgent: async () => candidatePromptResult({
+            candidateRationale: validCandidateRationale({
+              evidenceRefs: [],
+              failurePattern: undefined,
+            }),
+          }),
+        }),
+        /candidateRationale.failurePattern fallback is required when evidenceRefs is empty/,
+      );
     });
   });
 
@@ -2104,12 +2145,13 @@ function candidatePromptResult(input: {
 
 function validCandidateRationale(overrides: Record<string, unknown> = {}): Record<string, unknown> {
   return {
-    failurePattern: 'coverage_regression',
+    editedSurface: 'system_prompt',
     evidenceRefs: [],
     hypothesis: 'coverage fell after the previous prompt change',
     targetedFix: 'keep the completion criteria explicit and conservative',
     predictedFixes: [],
     riskTasks: [],
+    failurePattern: 'coverage_regression',
     ...overrides,
   };
 }

--- a/packages/headless/src/__tests__/prompt-candidate-loop.test.ts
+++ b/packages/headless/src/__tests__/prompt-candidate-loop.test.ts
@@ -410,7 +410,10 @@ describe('prompt candidate loop', () => {
             signals: [{ id: 'rsi-sig:known', kind: 'coverage_regression', taskIds: ['task-a'] }],
           },
           metaAgent: async () => candidatePromptResult({
-            candidateRationale: validCandidateRationale({ evidenceRefs: ['rsi-sig:unknown'] }),
+            candidateRationale: validCandidateRationale({
+              evidenceRefs: ['rsi-sig:unknown'],
+              failurePattern: undefined,
+            }),
           }),
           git: gitNoop(dir),
           now: () => 100,
@@ -485,6 +488,26 @@ describe('prompt candidate loop', () => {
           }),
         }),
       });
+
+      await assert.rejects(
+        runPromptCandidateRound({
+          ...baseInput,
+          resultsJsonlPath: join(dir, 'redundant-fallback.jsonl'),
+          rsiAnalysis: {
+            heldInTaskSetHash: 'sha256:held-in',
+            transitionVsLastKept: [],
+            transitionVsPreviousCandidate: [],
+            coverageRegressionTaskIds: [],
+            errorClassDistribution: [],
+            toolFailureClusters: [],
+            signals: [{ id: 'rsi-sig:known', kind: 'coverage_regression', taskIds: ['task-a'] }],
+          },
+          metaAgent: async () => candidatePromptResult({
+            candidateRationale: validCandidateRationale({ evidenceRefs: ['rsi-sig:known'] }),
+          }),
+        }),
+        /candidateRationale.failurePattern must be omitted when evidenceRefs cites current analysis/,
+      );
 
       await runPromptCandidateRound({
         ...baseInput,

--- a/packages/headless/src/__tests__/prompt-control-run.test.ts
+++ b/packages/headless/src/__tests__/prompt-control-run.test.ts
@@ -23,6 +23,7 @@ describe('runPromptControlExperiment', () => {
             : input.currentSystemPrompt,
           summary: learnedFromHeldIn ? 'added the missing control rule' : 'no control signal found',
           candidateRationale: {
+            editedSurface: 'system_prompt',
             failurePattern: signal ? 'verification_failed' : 'other',
             evidenceRefs: signal ? [signal.id] : [],
             hypothesis: 'held-in failures share one missing prompt rule',

--- a/packages/headless/src/__tests__/prompt-control-run.test.ts
+++ b/packages/headless/src/__tests__/prompt-control-run.test.ts
@@ -24,12 +24,12 @@ describe('runPromptControlExperiment', () => {
           summary: learnedFromHeldIn ? 'added the missing control rule' : 'no control signal found',
           candidateRationale: {
             editedSurface: 'system_prompt',
-            failurePattern: signal ? 'verification_failed' : 'other',
             evidenceRefs: signal ? [signal.id] : [],
             hypothesis: 'held-in failures share one missing prompt rule',
             targetedFix: 'add the shared rule without task-specific answers',
             predictedFixes: ['control-held-in-a', 'control-held-in-b'],
             riskTasks: [],
+            ...(!signal ? { failurePattern: 'other' as const } : {}),
           },
         };
       };

--- a/packages/headless/src/__tests__/prompt-optimization-bootstrap.test.ts
+++ b/packages/headless/src/__tests__/prompt-optimization-bootstrap.test.ts
@@ -213,6 +213,7 @@ describe('ensurePromptOptimizationPromptRepo', () => {
           commitSha: candidateSha,
           promptHash,
           candidateRationale: {
+            editedSurface: 'system_prompt',
             failurePattern: 'coverage_regression',
             evidenceRefs: [],
             hypothesis: 'hypothesis',

--- a/packages/headless/src/__tests__/prompt-optimization-loop-replay-attribution.test.ts
+++ b/packages/headless/src/__tests__/prompt-optimization-loop-replay-attribution.test.ts
@@ -303,6 +303,7 @@ describe('runPromptOptimizationLoop replay attribution guards', () => {
           systemPrompt: `candidate prompt ${promptInput.roundId}\n`,
           summary: `tuned for ${promptInput.roundId}`,
           candidateRationale: {
+            editedSurface: 'system_prompt' as const,
             failurePattern: 'coverage_regression' as const,
             evidenceRefs: signal ? [signal.id] : [],
             hypothesis: 'make hin-0 pass reliably',

--- a/packages/headless/src/__tests__/prompt-optimization-loop-replay-attribution.test.ts
+++ b/packages/headless/src/__tests__/prompt-optimization-loop-replay-attribution.test.ts
@@ -304,12 +304,12 @@ describe('runPromptOptimizationLoop replay attribution guards', () => {
           summary: `tuned for ${promptInput.roundId}`,
           candidateRationale: {
             editedSurface: 'system_prompt' as const,
-            failurePattern: 'coverage_regression' as const,
             evidenceRefs: signal ? [signal.id] : [],
             hypothesis: 'make hin-0 pass reliably',
             targetedFix: 'clarify the success criteria',
             predictedFixes: ['hin-0'],
             riskTasks: [],
+            ...(!signal ? { failurePattern: 'coverage_regression' as const } : {}),
           },
         };
       };

--- a/packages/headless/src/__tests__/prompt-optimization-loop.test.ts
+++ b/packages/headless/src/__tests__/prompt-optimization-loop.test.ts
@@ -98,12 +98,14 @@ describe('runPromptOptimizationLoop', () => {
             summary: `tuned for ${promptInput.roundId}`,
             candidateRationale: {
               editedSurface: 'system_prompt',
-              failurePattern: 'coverage_regression',
               evidenceRefs: evidenceRefsFor(promptInput),
               hypothesis: 'avoid losing held-in scored artifacts',
               targetedFix: 'state artifact completion constraints plainly',
               predictedFixes: ['hin-1'],
               riskTasks: ['hin-0'],
+              ...(evidenceRefsFor(promptInput).length === 0
+                ? { failurePattern: 'coverage_regression' as const }
+                : {}),
             },
           };
         },
@@ -162,12 +164,14 @@ describe('runPromptOptimizationLoop', () => {
             summary: `tuned for ${promptInput.roundId}`,
             candidateRationale: {
               editedSurface: 'system_prompt',
-              failurePattern: 'verification_failed',
               evidenceRefs: evidenceRefsFor(promptInput),
               hypothesis: 'integer output selection can be made less ambiguous',
               targetedFix: 'prefer the task requested count when multiple totals appear',
               predictedFixes: ['hin-0'],
               riskTasks: ['hin-1'],
+              ...(evidenceRefsFor(promptInput).length === 0
+                ? { failurePattern: 'verification_failed' as const }
+                : {}),
             },
           };
         },
@@ -207,12 +211,14 @@ describe('runPromptOptimizationLoop', () => {
             summary: `tuned for ${promptInput.roundId}`,
             candidateRationale: {
               editedSurface: 'system_prompt',
-              failurePattern: 'coverage_regression',
               evidenceRefs: evidenceRefsFor(promptInput),
               hypothesis: 'restore coverage for held-in tasks',
               targetedFix: 'make artifact completion constraints explicit',
               predictedFixes: ['hin-0'],
               riskTasks: [],
+              ...(evidenceRefsFor(promptInput).length === 0
+                ? { failurePattern: 'coverage_regression' as const }
+                : {}),
             },
           };
         },
@@ -256,12 +262,14 @@ describe('runPromptOptimizationLoop', () => {
             summary: `tuned for ${promptInput.roundId}`,
             candidateRationale: {
               editedSurface: 'system_prompt',
-              failurePattern: 'coverage_regression',
               evidenceRefs: evidenceRefsFor(promptInput),
               hypothesis: 'avoid losing held-in scored artifacts',
               targetedFix: 'state artifact completion constraints plainly',
               predictedFixes: ['hin-19'],
               riskTasks: [],
+              ...(evidenceRefsFor(promptInput).length === 0
+                ? { failurePattern: 'coverage_regression' as const }
+                : {}),
             },
           };
         },
@@ -733,12 +741,14 @@ describe('runPromptOptimizationLoop', () => {
             summary: 'use only addressable evidence',
             candidateRationale: {
               editedSurface: 'system_prompt',
-              failurePattern: 'coverage_regression',
               evidenceRefs: evidenceRefsFor(input),
               hypothesis: 'addressable evidence supports a bounded prompt improvement',
               targetedFix: 'clarify the general success criteria',
               predictedFixes: [],
               riskTasks: [],
+              ...(evidenceRefsFor(input).length === 0
+                ? { failurePattern: 'coverage_regression' as const }
+                : {}),
             },
           };
         },

--- a/packages/headless/src/__tests__/prompt-optimization-loop.test.ts
+++ b/packages/headless/src/__tests__/prompt-optimization-loop.test.ts
@@ -97,6 +97,7 @@ describe('runPromptOptimizationLoop', () => {
             systemPrompt: `candidate prompt ${promptInput.roundId}\n`,
             summary: `tuned for ${promptInput.roundId}`,
             candidateRationale: {
+              editedSurface: 'system_prompt',
               failurePattern: 'coverage_regression',
               evidenceRefs: evidenceRefsFor(promptInput),
               hypothesis: 'avoid losing held-in scored artifacts',
@@ -160,6 +161,7 @@ describe('runPromptOptimizationLoop', () => {
             systemPrompt: `candidate prompt ${promptInput.roundId}\n`,
             summary: `tuned for ${promptInput.roundId}`,
             candidateRationale: {
+              editedSurface: 'system_prompt',
               failurePattern: 'verification_failed',
               evidenceRefs: evidenceRefsFor(promptInput),
               hypothesis: 'integer output selection can be made less ambiguous',
@@ -204,6 +206,7 @@ describe('runPromptOptimizationLoop', () => {
             systemPrompt: `candidate prompt ${promptInput.roundId}\n`,
             summary: `tuned for ${promptInput.roundId}`,
             candidateRationale: {
+              editedSurface: 'system_prompt',
               failurePattern: 'coverage_regression',
               evidenceRefs: evidenceRefsFor(promptInput),
               hypothesis: 'restore coverage for held-in tasks',
@@ -252,6 +255,7 @@ describe('runPromptOptimizationLoop', () => {
             systemPrompt: `candidate prompt ${promptInput.roundId}\n`,
             summary: `tuned for ${promptInput.roundId}`,
             candidateRationale: {
+              editedSurface: 'system_prompt',
               failurePattern: 'coverage_regression',
               evidenceRefs: evidenceRefsFor(promptInput),
               hypothesis: 'avoid losing held-in scored artifacts',
@@ -728,6 +732,7 @@ describe('runPromptOptimizationLoop', () => {
             systemPrompt: 'addressability candidate\n',
             summary: 'use only addressable evidence',
             candidateRationale: {
+              editedSurface: 'system_prompt',
               failurePattern: 'coverage_regression',
               evidenceRefs: evidenceRefsFor(input),
               hypothesis: 'addressable evidence supports a bounded prompt improvement',

--- a/packages/headless/src/__tests__/prompt-optimization-run.test.ts
+++ b/packages/headless/src/__tests__/prompt-optimization-run.test.ts
@@ -434,12 +434,12 @@ describe('runPromptOptimizationRun', () => {
             summary: `tuned for ${promptInput.roundId}`,
             candidateRationale: {
               editedSurface: 'system_prompt',
-              failurePattern: 'coverage_regression',
               evidenceRefs: signal ? [signal.id] : [],
               hypothesis: 'make the success criteria explicit',
               targetedFix: 'clarify the prompt without task-specific answers',
               predictedFixes: [],
               riskTasks: [],
+              ...(!signal ? { failurePattern: 'coverage_regression' as const } : {}),
             },
           };
         },
@@ -536,12 +536,12 @@ describe('runPromptOptimizationRun', () => {
             summary: `tuned for ${promptInput.roundId}`,
             candidateRationale: {
               editedSurface: 'system_prompt',
-              failurePattern: 'coverage_regression',
               evidenceRefs: signal ? [signal.id] : [],
               hypothesis: 'make the success criteria explicit',
               targetedFix: 'clarify the prompt without task-specific answers',
               predictedFixes: [],
               riskTasks: [],
+              ...(!signal ? { failurePattern: 'coverage_regression' as const } : {}),
             },
           };
         },

--- a/packages/headless/src/__tests__/prompt-optimization-run.test.ts
+++ b/packages/headless/src/__tests__/prompt-optimization-run.test.ts
@@ -433,6 +433,7 @@ describe('runPromptOptimizationRun', () => {
             systemPrompt: `candidate prompt ${promptInput.roundId}\n`,
             summary: `tuned for ${promptInput.roundId}`,
             candidateRationale: {
+              editedSurface: 'system_prompt',
               failurePattern: 'coverage_regression',
               evidenceRefs: signal ? [signal.id] : [],
               hypothesis: 'make the success criteria explicit',
@@ -534,6 +535,7 @@ describe('runPromptOptimizationRun', () => {
             systemPrompt: `candidate prompt ${promptInput.roundId}\n`,
             summary: `tuned for ${promptInput.roundId}`,
             candidateRationale: {
+              editedSurface: 'system_prompt',
               failurePattern: 'coverage_regression',
               evidenceRefs: signal ? [signal.id] : [],
               hypothesis: 'make the success criteria explicit',
@@ -577,6 +579,7 @@ describe('runPromptOptimizationRun', () => {
 
       const resultsJsonlPath = join(controllerDir, 'results.jsonl');
       const candidateRationale = {
+        editedSurface: 'system_prompt' as const,
         failurePattern: 'coverage_regression' as const,
         evidenceRefs: [],
         hypothesis: 'restore held-in coverage',

--- a/packages/headless/src/__tests__/prompt-structural-smoke.test.ts
+++ b/packages/headless/src/__tests__/prompt-structural-smoke.test.ts
@@ -687,6 +687,7 @@ function committedEvent(
 
 function candidateRationale(overrides: Partial<PromptCandidateRationale> = {}): PromptCandidateRationale {
   return {
+    editedSurface: 'system_prompt',
     failurePattern: 'coverage_regression' as const,
     evidenceRefs: [],
     hypothesis: 'held-in coverage can improve with a clearer prompt',

--- a/packages/headless/src/__tests__/rsi-controller-attribution.test.ts
+++ b/packages/headless/src/__tests__/rsi-controller-attribution.test.ts
@@ -7,8 +7,43 @@ import type { PromptAcceptanceResult } from '../prompt-acceptance-policy.js';
 import { tokenSummary } from './helpers/cell-output-fixtures.js';
 
 describe('RSI controller attribution', () => {
+  test('treats a direct signal reference as authoritative without a coarse fallback', () => {
+    const analysis: RsiRoundAnalysis = {
+      heldInTaskSetHash: 'sha256:held-in',
+      transitionVsLastKept: [],
+      transitionVsPreviousCandidate: [],
+      coverageRegressionTaskIds: ['task-a'],
+      errorClassDistribution: [],
+      toolFailureClusters: [],
+      signals: [{ id: 'rsi-sig:coverage', kind: 'coverage_regression', taskIds: ['task-a'] }],
+    };
+
+    const attribution = buildRsiControllerAttribution({
+      runId: 'run-1',
+      roundId: 'round-1',
+      candidateCommitSha: 'candidate-sha',
+      candidateRationaleHash: 'sha256:rationale',
+      candidateRationale: {
+        editedSurface: 'system_prompt',
+        evidenceRefs: ['rsi-sig:coverage'],
+        hypothesis: 'restore coverage for the unstable held-in task',
+        targetedFix: 'make the required artifact explicit',
+        predictedFixes: ['task-a'],
+        riskTasks: [],
+      },
+      analysis,
+      heldInTaskIds: ['task-a'],
+      lastKeptEvents: [completed({ taskId: 'task-a', passed: false })],
+      candidateEvents: [completed({ taskId: 'task-a', passed: true })],
+      decision: acceptanceResult({ decision: 'keep', reason: 'held_in_improved' }),
+    });
+
+    assert.equal(attribution.rootCauseSignalMatch, 'matched');
+  });
+
   test('compares candidate rationale predictions to held-in outcomes', () => {
     const rationale: PromptCandidateRationale = {
+      editedSurface: 'system_prompt',
       failurePattern: 'coverage_regression',
       evidenceRefs: ['rsi-sig:coverage'],
       hypothesis: 'restore coverage for the unstable held-in task',
@@ -79,6 +114,7 @@ describe('RSI controller attribution', () => {
       candidateCommitSha: 'commit-1',
       candidateRationaleHash: 'sha256:rationale',
       candidateRationale: {
+        editedSurface: 'system_prompt',
         failurePattern: 'other',
         evidenceRefs: [],
         hypothesis: 'unknown held-in behavior changed',
@@ -120,6 +156,7 @@ describe('RSI controller attribution', () => {
       candidateCommitSha: 'commit-1',
       candidateRationaleHash: 'sha256:rationale',
       candidateRationale: {
+        editedSurface: 'system_prompt',
         failurePattern: 'coverage_regression',
         evidenceRefs: [],
         hypothesis: 'coverage fell after the previous prompt change',
@@ -165,6 +202,7 @@ describe('RSI controller attribution', () => {
       candidateCommitSha: 'commit-1',
       candidateRationaleHash: 'sha256:rationale',
       candidateRationale: {
+        editedSurface: 'system_prompt',
         failurePattern: 'coverage_regression',
         evidenceRefs: ['rsi-sig:coverage'],
         hypothesis: 'coverage fell after the previous prompt change',
@@ -185,6 +223,7 @@ describe('RSI controller attribution', () => {
       candidateCommitSha: 'commit-1',
       candidateRationaleHash: 'sha256:rationale',
       candidateRationale: {
+        editedSurface: 'system_prompt',
         failurePattern: 'coverage_regression',
         evidenceRefs: ['rsi-sig:tool'],
         hypothesis: 'coverage fell after the previous prompt change',
@@ -223,6 +262,7 @@ describe('RSI controller attribution', () => {
       candidateCommitSha: 'commit-1',
       candidateRationaleHash: 'sha256:rationale',
       candidateRationale: {
+        editedSurface: 'system_prompt',
         failurePattern: 'runtime_error',
         evidenceRefs: ['rsi-sig:runtime'],
         hypothesis: 'runtime errors block held-in progress',
@@ -243,6 +283,7 @@ describe('RSI controller attribution', () => {
       candidateCommitSha: 'commit-1',
       candidateRationaleHash: 'sha256:rationale',
       candidateRationale: {
+        editedSurface: 'system_prompt',
         failurePattern: 'runtime_error',
         evidenceRefs: ['rsi-sig:max-tokens'],
         hypothesis: 'runtime errors block held-in progress',
@@ -268,6 +309,7 @@ describe('RSI controller attribution', () => {
       candidateCommitSha: 'commit-1',
       candidateRationaleHash: 'sha256:rationale',
       candidateRationale: {
+        editedSurface: 'system_prompt',
         failurePattern: 'coverage_regression',
         evidenceRefs: ['rsi-sig:coverage'],
         hypothesis: 'coverage fell before this candidate',

--- a/packages/headless/src/ahe-target-protocol.ts
+++ b/packages/headless/src/ahe-target-protocol.ts
@@ -6,6 +6,7 @@ import {
   type ExecutionLogCoverage,
   type TargetSnapshotRef,
 } from '@maka/core/execution-evidence';
+import type { MakaChangeAuditRecord } from './change-audit.js';
 
 export const MAKA_AHE_TARGET_PROTOCOL_VERSION_V1 = 'maka.ahe-target.v1' as const;
 export const MAKA_AHE_TARGET_PROTOCOL_VERSION = 'maka.ahe-target.v2' as const;
@@ -259,18 +260,18 @@ export interface MakaAheEvidenceCase {
   summary: string;
 }
 
-export interface MakaAheChangeManifest {
+export interface MakaAheChangeManifest extends MakaChangeAuditRecord<
+  MakaAheComponentCategory,
+  MakaAheEvidenceCase,
+  MakaAheEvidenceCase,
+  MakaAheEvidenceCase
+> {
   protocolVersion: MakaAheTargetProtocolVersion;
   manifestId: string;
   sourceLabel: MakaAheTargetSourceLabel | string;
   targetSnapshotId: string;
   createdAt: string;
   changedComponents: readonly string[];
-  failureEvidence: readonly MakaAheEvidenceCase[];
-  rootCause: string;
-  targetedFix: string;
-  predictedFixes: readonly MakaAheEvidenceCase[];
-  riskCases: readonly MakaAheEvidenceCase[];
   validationDataset: {
     datasetId: string;
     taskIds: readonly string[];
@@ -611,12 +612,24 @@ export function validateMakaAheChangeManifest(
   requireNonEmptyString(value.sourceLabel, 'sourceLabel', errors);
   requireNonEmptyString(value.targetSnapshotId, 'targetSnapshotId', errors);
   requireNonEmptyString(value.createdAt, 'createdAt', errors);
-  requireNonEmptyString(value.rootCause, 'rootCause', errors);
+  if (!isOneOf(value.editedSurface, MAKA_AHE_COMPONENT_CATEGORIES)) {
+    errors.push({ path: 'editedSurface', message: 'expected a known editable surface' });
+  }
+  requireNonEmptyString(value.hypothesis, 'hypothesis', errors);
   requireNonEmptyString(value.targetedFix, 'targetedFix', errors);
+  if (typeof value.failurePattern !== 'undefined') {
+    requireNonEmptyString(value.failurePattern, 'failurePattern', errors);
+  }
 
   const componentIds = new Set(components.map((component) => component.id));
   validateStringArray(value.changedComponents, 'changedComponents', errors, { minItems: 1, allowedValues: componentIds });
   const changedComponentIds = stringArray(value.changedComponents);
+  if (
+    isOneOf(value.editedSurface, MAKA_AHE_COMPONENT_CATEGORIES)
+    && !components.some((component) => changedComponentIds.includes(component.id) && component.category === value.editedSurface)
+  ) {
+    errors.push({ path: 'editedSurface', message: 'expected a surface represented by changedComponents' });
+  }
   for (const componentId of changedComponentIds) {
     const component = components.find((candidate) => candidate.id === componentId);
     if (component && !component.editable) {
@@ -626,9 +639,9 @@ export function validateMakaAheChangeManifest(
       });
     }
   }
-  validateEvidenceCases(value.failureEvidence, 'failureEvidence', errors, { minItems: 1 });
+  validateEvidenceCases(value.evidenceRefs, 'evidenceRefs', errors, { minItems: 1 });
   validateEvidenceCases(value.predictedFixes, 'predictedFixes', errors, { minItems: 1 });
-  validateEvidenceCases(value.riskCases, 'riskCases', errors, { minItems: 1 });
+  validateEvidenceCases(value.riskTasks, 'riskTasks', errors, { minItems: 1 });
   validateValidationDataset(value.validationDataset, errors);
   validatePatch(value.patch, errors, components.filter((component) => changedComponentIds.includes(component.id)));
   validateStringArray(value.rollbackCriteria, 'rollbackCriteria', errors, { minItems: 1 });

--- a/packages/headless/src/ahe-target-protocol.ts
+++ b/packages/headless/src/ahe-target-protocol.ts
@@ -613,7 +613,7 @@ export function validateMakaAheChangeManifest(
   requireNonEmptyString(value.targetSnapshotId, 'targetSnapshotId', errors);
   requireNonEmptyString(value.createdAt, 'createdAt', errors);
   if (!isOneOf(value.editedSurface, MAKA_AHE_COMPONENT_CATEGORIES)) {
-    errors.push({ path: 'editedSurface', message: 'expected a known editable surface' });
+    errors.push({ path: 'editedSurface', message: 'expected a known component category' });
   }
   requireNonEmptyString(value.hypothesis, 'hypothesis', errors);
   requireNonEmptyString(value.targetedFix, 'targetedFix', errors);
@@ -624,11 +624,12 @@ export function validateMakaAheChangeManifest(
   const componentIds = new Set(components.map((component) => component.id));
   validateStringArray(value.changedComponents, 'changedComponents', errors, { minItems: 1, allowedValues: componentIds });
   const changedComponentIds = stringArray(value.changedComponents);
+  const changedComponents = components.filter((component) => changedComponentIds.includes(component.id));
   if (
     isOneOf(value.editedSurface, MAKA_AHE_COMPONENT_CATEGORIES)
-    && !components.some((component) => changedComponentIds.includes(component.id) && component.category === value.editedSurface)
+    && changedComponents.some((component) => component.category !== value.editedSurface)
   ) {
-    errors.push({ path: 'editedSurface', message: 'expected a surface represented by changedComponents' });
+    errors.push({ path: 'editedSurface', message: 'expected every changed component to match the declared surface' });
   }
   for (const componentId of changedComponentIds) {
     const component = components.find((candidate) => candidate.id === componentId);
@@ -643,7 +644,7 @@ export function validateMakaAheChangeManifest(
   validateEvidenceCases(value.predictedFixes, 'predictedFixes', errors, { minItems: 1 });
   validateEvidenceCases(value.riskTasks, 'riskTasks', errors, { minItems: 1 });
   validateValidationDataset(value.validationDataset, errors);
-  validatePatch(value.patch, errors, components.filter((component) => changedComponentIds.includes(component.id)));
+  validatePatch(value.patch, errors, changedComponents);
   validateStringArray(value.rollbackCriteria, 'rollbackCriteria', errors, { minItems: 1 });
 
   return errors.length === 0 ? { ok: true, value: value as unknown as MakaAheChangeManifest } : { ok: false, errors };

--- a/packages/headless/src/change-audit.ts
+++ b/packages/headless/src/change-audit.ts
@@ -1,0 +1,22 @@
+/**
+ * Audit fields shared by RSI prompt candidates and AHE change manifests.
+ *
+ * The value types are generic because RSI stores compact signal/task ids in
+ * its WAL, while AHE manifests carry source-backed evidence case objects.
+ */
+export interface MakaChangeAuditRecord<
+  TEditedSurface extends string = string,
+  TEvidenceRef = string,
+  TPredictedFix = string,
+  TRiskTask = string,
+  TFallbackFailurePattern extends string = string,
+> {
+  editedSurface: TEditedSurface;
+  evidenceRefs: readonly TEvidenceRef[];
+  hypothesis: string;
+  targetedFix: string;
+  predictedFixes: readonly TPredictedFix[];
+  riskTasks: readonly TRiskTask[];
+  /** Coarse fallback for records that cannot cite a mined signature or signal. */
+  failurePattern?: TFallbackFailurePattern;
+}

--- a/packages/headless/src/fixed-prompt-controller.ts
+++ b/packages/headless/src/fixed-prompt-controller.ts
@@ -14,6 +14,7 @@ import {
 } from './cell-output.js';
 import type { Config } from './contracts.js';
 import { syncParentDirectory } from './immutable-file.js';
+import type { MakaChangeAuditRecord } from './change-audit.js';
 import { assertFinitePositive, assertPositiveInt, assertRatio } from './numeric-guards.js';
 
 export const FIXED_PROMPT_WAL_SCHEMA_VERSION = 1;
@@ -249,14 +250,13 @@ export const PROMPT_CANDIDATE_FAILURE_PATTERNS = [
 
 export type PromptCandidateFailurePattern = typeof PROMPT_CANDIDATE_FAILURE_PATTERNS[number];
 
-export interface PromptCandidateRationale {
-  failurePattern: PromptCandidateFailurePattern;
-  evidenceRefs: readonly string[];
-  hypothesis: string;
-  targetedFix: string;
-  predictedFixes: readonly string[];
-  riskTasks: readonly string[];
-}
+export interface PromptCandidateRationale extends MakaChangeAuditRecord<
+  'system_prompt',
+  string,
+  string,
+  string,
+  PromptCandidateFailurePattern
+> {}
 
 export type PromptCandidateRewardHackScan =
   | { decision: 'clean' }

--- a/packages/headless/src/index.ts
+++ b/packages/headless/src/index.ts
@@ -4,6 +4,7 @@
 // package-local entrypoints, not the root API. Minimal usage is
 // `runExperiment(config, task, { storageRoot })`.
 export { runPromptOptimizationRun } from './prompt-optimization-run.js';
+export type { MakaChangeAuditRecord } from './change-audit.js';
 export type {
   PromptOptimizationRunInput,
   PromptOptimizationRunResult,

--- a/packages/headless/src/meta-agent-completion.ts
+++ b/packages/headless/src/meta-agent-completion.ts
@@ -4,8 +4,9 @@ import { runOneShotCompletion } from './one-shot-completion.js';
 
 const META_AGENT_SYSTEM =
   'You optimize a single benchmark system prompt. Reply with exactly one JSON object '
-  + '{"systemPrompt":"...","summary":"...","candidateRationale":{"failurePattern":"coverage_regression|tool_failed|max_tokens|runtime_error|verification_failed|other","hypothesis":"short plain text","targetedFix":"short plain text","predictedFixes":["held-in-task-id"],"riskTasks":["held-in-task-id"]}} '
-  + 'and nothing else - no markdown fences, no prose.';
+  + '{"systemPrompt":"...","summary":"...","candidateRationale":{"editedSurface":"system_prompt","evidenceRefs":["rsi-sig:id"],"hypothesis":"short plain text","targetedFix":"short plain text","predictedFixes":["held-in-task-id"],"riskTasks":["held-in-task-id"]}} '
+  + 'and nothing else - no markdown fences, no prose. '
+  + 'Use failurePattern only as a coarse fallback when no evidence id is available.';
 
 export interface CreateAiSdkMetaAgentInput {
   connection: LlmConnection;

--- a/packages/headless/src/prompt-candidate-loop.ts
+++ b/packages/headless/src/prompt-candidate-loop.ts
@@ -542,6 +542,9 @@ function parseCandidateRationaleShape(value: unknown): CandidateRationale {
   if (evidenceRefs.length === 0 && typeof failurePattern === 'undefined') {
     throw new Error('candidateRationale.failurePattern fallback is required when evidenceRefs is empty');
   }
+  if (evidenceRefs.length > 0 && typeof failurePattern !== 'undefined') {
+    throw new Error('candidateRationale.failurePattern must be omitted when evidenceRefs cites current analysis');
+  }
   return {
     editedSurface: 'system_prompt',
     evidenceRefs,

--- a/packages/headless/src/prompt-candidate-loop.ts
+++ b/packages/headless/src/prompt-candidate-loop.ts
@@ -428,8 +428,9 @@ function formatMetaAgentParseError(error: unknown): string {
 export function renderMetaAgentPrompt(input: MetaAgentPromptInput): string {
   return [
     'You are improving one system prompt for benchmark tasks.',
-    'Return JSON only: {"systemPrompt":"...","summary":"...","candidateRationale":{"failurePattern":"coverage_regression|tool_failed|max_tokens|runtime_error|verification_failed|other","evidenceRefs":["rsi-sig:id"],"hypothesis":"short plain text","targetedFix":"short plain text","predictedFixes":["held-in-task-id"],"riskTasks":["held-in-task-id"]}}.',
-    'candidateRationale.evidenceRefs may only reference RSI R2 Held-In Analysis signal ids from the prompt; when signals exist and failurePattern is not "other", cite at least one signal. candidateRationale.predictedFixes and riskTasks may only reference held-in task ids from the prompt.',
+    'Return JSON only: {"systemPrompt":"...","summary":"...","candidateRationale":{"editedSurface":"system_prompt","evidenceRefs":["rsi-sig:id"],"hypothesis":"short plain text","targetedFix":"short plain text","predictedFixes":["held-in-task-id"],"riskTasks":["held-in-task-id"]}}.',
+    'candidateRationale.evidenceRefs may only reference RSI R2 Held-In Analysis signature or signal ids from the prompt. Cite those ids directly when available. Only when no evidence id is available, add failurePattern as a coarse fallback: "coverage_regression|tool_failed|max_tokens|runtime_error|verification_failed|other".',
+    'candidateRationale.predictedFixes and riskTasks may only reference held-in task ids from the prompt.',
     'Prefer pass/fail transitions and verifier failure summaries over tool_failure_cluster. Treat tool_failure_cluster as root cause only when it is unrecovered or aligns with the final task outcome.',
     'Do not include held-out tasks, verifier internals, expected outputs, raw traces, file paths, code fences, or multiline text in candidateRationale.',
     '',
@@ -523,7 +524,13 @@ function parseCandidateRationaleShape(value: unknown): CandidateRationale {
   if (serialized.length > CANDIDATE_RATIONALE_MAX_SERIALIZED_CHARS) {
     throw new Error(`candidateRationale must serialize to at most ${CANDIDATE_RATIONALE_MAX_SERIALIZED_CHARS} characters`);
   }
-  if (!PROMPT_CANDIDATE_FAILURE_PATTERNS.includes(value.failurePattern as PromptCandidateFailurePattern)) {
+  if (value.editedSurface !== 'system_prompt') {
+    throw new Error('candidateRationale.editedSurface must be "system_prompt"');
+  }
+  if (
+    typeof value.failurePattern !== 'undefined'
+    && !PROMPT_CANDIDATE_FAILURE_PATTERNS.includes(value.failurePattern as PromptCandidateFailurePattern)
+  ) {
     throw new Error(`candidateRationale.failurePattern must be one of: ${PROMPT_CANDIDATE_FAILURE_PATTERNS.join(', ')}`);
   }
   const hypothesis = parseRationaleTextShape(value.hypothesis, 'hypothesis');
@@ -531,13 +538,18 @@ function parseCandidateRationaleShape(value: unknown): CandidateRationale {
   const evidenceRefs = parseTaskIdArrayShape(value.evidenceRefs, 'evidenceRefs');
   const predictedFixes = parseTaskIdArrayShape(value.predictedFixes, 'predictedFixes');
   const riskTasks = parseTaskIdArrayShape(value.riskTasks, 'riskTasks');
+  const failurePattern = value.failurePattern as CandidateFailurePattern | undefined;
+  if (evidenceRefs.length === 0 && typeof failurePattern === 'undefined') {
+    throw new Error('candidateRationale.failurePattern fallback is required when evidenceRefs is empty');
+  }
   return {
-    failurePattern: value.failurePattern as CandidateFailurePattern,
+    editedSurface: 'system_prompt',
     evidenceRefs,
     hypothesis,
     targetedFix,
     predictedFixes,
     riskTasks,
+    ...(failurePattern ? { failurePattern } : {}),
   };
 }
 
@@ -549,7 +561,7 @@ function validateEvidenceRefs(candidateRationale: CandidateRationale, rsiAnalysi
     }
     return;
   }
-  if (rsiAnalysis.signals.length > 0 && candidateRationale.failurePattern !== 'other' && evidenceRefs.length === 0) {
+  if (rsiAnalysis.signals.length > 0 && evidenceRefs.length === 0) {
     throw new Error('candidateRationale.evidenceRefs must cite at least one current analysis signal');
   }
   const known = new Set(rsiAnalysis.signals.map((signal) => signal.id));

--- a/packages/headless/src/rsi-controller-attribution.ts
+++ b/packages/headless/src/rsi-controller-attribution.ts
@@ -1,5 +1,6 @@
 import type {
   FixedPromptTaskWalEvent,
+  PromptCandidateFailurePattern,
   PromptCandidateRationale,
   RsiPredictedFixOutcome,
   RsiRiskTaskOutcome,
@@ -211,6 +212,9 @@ function rootCauseSignalMatch(
   if (rationale.evidenceRefs.length === 0) return 'unknown';
   const referenced = new Set(rationale.evidenceRefs);
   const referencedSignals = analysis.signals.filter((signal) => referenced.has(signal.id));
+  if (typeof rationale.failurePattern === 'undefined') {
+    return referencedSignals.length > 0 ? 'matched' : 'unknown';
+  }
   const signalKinds = new Set(referencedSignals.map((signal) => signal.kind));
   if (rationale.failurePattern === 'coverage_regression') {
     return signalKinds.has('coverage_regression') ? 'matched' : 'contradicted';
@@ -226,7 +230,7 @@ function rootCauseSignalMatch(
   return 'unknown';
 }
 
-function isErrorClassBackedFailurePattern(failurePattern: PromptCandidateRationale['failurePattern']): boolean {
+function isErrorClassBackedFailurePattern(failurePattern: PromptCandidateFailurePattern): boolean {
   return failurePattern === 'max_tokens'
     || failurePattern === 'runtime_error'
     || failurePattern === 'verification_failed';


### PR DESCRIPTION
## Summary

- add a shared `MakaChangeAuditRecord` for RSI prompt candidates and AHE change manifests
- align both records on `editedSurface`, `evidenceRefs`, `hypothesis`, `targetedFix`, `predictedFixes`, and `riskTasks`
- demote the coarse RSI `failurePattern` enum to a fallback when no current analysis evidence id is available
- require prompt candidates to declare the bounded `system_prompt` mutation surface

## Implementation

- make `PromptCandidateRationale` and `MakaAheChangeManifest` specialize the same generic audit record
- rename the AHE manifest's parallel audit fields to the canonical shared names and validate that `editedSurface` is represented by `changedComponents`
- prefer direct RSI signal references, while preserving the coarse failure-pattern path when analysis exposes no evidence ids
- keep attribution deterministic when a candidate cites a signal directly without a coarse fallback
- update both the rendered round prompt and the real model system instruction to the same schema

## Verification

- `git diff --check`
- `npm --workspace @maka/headless run typecheck`
- focused audit-schema / candidate / attribution tests: 84 passed
- `npm --workspace @maka/headless test`: 985 tests, 984 passed, 1 skipped, 0 failed

Refs #619 (item 3).
