### PR TITLE
fix(desktop): render provider-editor dividers via defined --border token

### DIFF
--- a/apps/desktop/src/renderer/styles/settings/provider-editor.css
+++ b/apps/desktop/src/renderer/styles/settings/provider-editor.css
@@ -606,7 +606,7 @@
   display: grid;
   gap: var(--space-4);
   padding-bottom: var(--space-4);
-  border-bottom: var(--border-width-hairline) solid var(--border-subtle);
+  border-bottom: var(--border-width-hairline) solid var(--border);
 }
 
 .providerSubpageBack {
@@ -641,7 +641,7 @@
   display: grid;
   gap: var(--space-3);
   padding-top: var(--space-5);
-  border-top: var(--border-width-hairline) solid var(--border-subtle);
+  border-top: var(--border-width-hairline) solid var(--border);
 }
 
 @media (max-width: 620px) {
@@ -723,7 +723,7 @@
   flex-direction: column;
   align-items: flex-start;
   gap: var(--space-1-5);
-  border: var(--border-width-hairline) solid var(--border-subtle);
+  border: var(--border-width-hairline) solid var(--border);
   border-radius: var(--radius-control);
   background: var(--background-elevated);
   color: var(--foreground);


### PR DESCRIPTION
## Summary

The provider-editor section header, account section, and empty-state chip drew their hairline borders with `var(--border-subtle)` — a token defined nowhere in the repo. An undefined custom property with no fallback makes the whole `border` shorthand invalid at computed-value time, so `border-style` fell back to `none` and all three dividers/outlines rendered with no border at all.

Point them at `--border`, the token the rest of this file already uses for hairline dividers (`:174`, `:248`, `:300`), rather than inventing a new one.

Closes #1040

## Verification

- `grep -rn border-subtle apps/desktop/src packages/*/src` → no remaining references.
- Reviewed the 3-line diff; each site now matches the file's `solid var(--border)` convention.
- CI green (test / e2e / typecheck) after a re-run cleared an unrelated harbor-cell flake tracked in #1048.
- CSS-only change with no typecheck/test surface of its own; not visually confirmed in the running app.
