### PR TITLE
test(headless): deflake harbor-cell settlement-deadline continuation test

### DIFF
--- a/packages/headless/src/__tests__/harbor-cell.test.ts
+++ b/packages/headless/src/__tests__/harbor-cell.test.ts
@@ -609,7 +609,7 @@ describe('runHarborCell', () => {
         cwd: workspaceDir,
         outputDir,
         storageRoot,
-        settleAfterMs: 25,
+        settleAfterMs: 1_000,
         continuationPolicy: {
           enabled: true,
           maxTurns: 2,


### PR DESCRIPTION
## Summary

`does not start a continuation turn after the settlement deadline latches` (packages/headless/src/__tests__/harbor-cell.test.ts) was intermittently failing in CI, seeing an empty action list instead of `['stop at the deadline']`.

Root cause is a test-timing race, not a headless/harbor regression. The test used `settleAfterMs: 25`, so on a busy runner the settlement timer fired during `run.begin()` — before the backend's `send` was dispatched. That lands on the runtime-runner `abort signal already set before dispatch` early return (`packages/runtime/src/runtime-runner.ts`), which skips `backend.send` entirely, so the prompt is never recorded, while the run is still cancelled by the deadline (`settledByDeadline` stays true). The assertion then reads `[]`.

Fix: raise `settleAfterMs` to `1_000`, matching every other reliable deadline test in the file, so the first `send` always starts and records its prompt before the deadline latches. Injecting a fake clock would require a product-side timer seam only for this test's timing; the 1s wall-clock margin is the pattern the rest of the suite already trusts.

Closes #1048

## Verification

- Target test run 5× locally: all pass (~1019ms each, i.e. ≈ settleAfterMs, as expected).
- Isolated CI-equivalent runner `node scripts/run-headless-tests.mjs` over the full headless suite: 981 pass / 0 fail / 1 skipped.