### PR TITLE
feat(desktop): polish provider settings — bilingual copy, stable dialog height, full model checklist

### DIFF
--- a/apps/desktop/e2e/providers.spec.ts
+++ b/apps/desktop/e2e/providers.spec.ts
@@ -98,12 +98,24 @@ test('adds a catalog provider through the canonical API-key dialog', async ({ wi
 
   await expect(detailDialog.getByText('GPT OSS 120B', { exact: true })).toBeHidden();
   await detailDialog.getByText('高级设置', { exact: true }).click();
-  await expect(detailDialog.getByText('GPT OSS 120B', { exact: true }).first()).toBeVisible();
-  const enabledModels = detailDialog.getByRole('list', { name: '已启用模型' });
-  await expect(enabledModels.getByRole('button')).toHaveCount(0);
-  await detailDialog.getByLabel('搜索并添加模型').fill('gemma-4-31b');
-  await detailDialog.getByRole('list', { name: '可添加模型' }).getByRole('button', { name: '添加' }).click();
-  await expect(enabledModels).toContainText('Gemma');
+
+  // The full candidate catalog is shown persistently as one checkbox list; the
+  // default model is checked and locked, and toggling a candidate flows through
+  // the shared enabledModelIds path (no search-only "add" surface).
+  const modelList = detailDialog.getByRole('list', { name: '模型列表' });
+  await expect(modelList).toBeVisible();
+  const defaultRow = modelList.getByRole('checkbox', { name: /GPT OSS 120B/ });
+  await expect(defaultRow).toBeChecked();
+  await expect(defaultRow).toBeDisabled();
+
+  const gemmaRow = modelList.getByRole('checkbox', { name: /Gemma/ }).first();
+  await expect(gemmaRow).not.toBeChecked();
+  // Dialog height stays fixed as the list is filtered to a subset.
+  const advancedHeightBefore = (await detailDialog.boundingBox())?.height;
+  await detailDialog.getByLabel('搜索模型').fill('gemma');
+  expect((await detailDialog.boundingBox())?.height).toBe(advancedHeightBefore);
+  await gemmaRow.click();
+  await expect(gemmaRow).toBeChecked();
   await expect(detailDialog.getByRole('textbox', { name: /模型密钥/ })).toHaveAttribute('placeholder', '••••••••');
 });
 

--- a/apps/desktop/e2e/providers.spec.ts
+++ b/apps/desktop/e2e/providers.spec.ts
@@ -116,6 +116,39 @@ test('adds a catalog provider through the canonical API-key dialog', async ({ wi
   expect((await detailDialog.boundingBox())?.height).toBe(advancedHeightBefore);
   await gemmaRow.click();
   await expect(gemmaRow).toBeChecked();
+
+  // Roving tabindex: the whole model list is ONE Tab stop. Tab from the search
+  // field lands on the active row, a second Tab leaves the list entirely (no
+  // per-row Tab stops even with hundreds of rows), and ArrowDown + Space move
+  // activity and toggle the focused row.
+  await detailDialog.getByLabel('搜索模型').fill('');
+  await detailDialog.getByLabel('搜索模型').click();
+  await page.keyboard.press('Tab');
+  const firstStop = await page.evaluate(() => ({
+    role: document.activeElement?.getAttribute('role') ?? null,
+    inList: Boolean(document.activeElement?.closest('.providerModelChoiceList')),
+  }));
+  expect(firstStop).toEqual({ role: 'checkbox', inList: true });
+  await page.keyboard.press('Tab');
+  expect(await page.evaluate(() => Boolean(document.activeElement?.closest('.providerModelChoiceList')))).toBe(false);
+  await page.keyboard.press('Shift+Tab');
+  const beforeArrow = await page.evaluate(() => document.activeElement?.getAttribute('data-model-id') ?? null);
+  await page.keyboard.press('ArrowDown');
+  const afterArrow = await page.evaluate(() => ({
+    id: document.activeElement?.getAttribute('data-model-id') ?? null,
+    checked: document.activeElement?.getAttribute('aria-checked') ?? null,
+  }));
+  expect(afterArrow.id).not.toBeNull();
+  expect(afterArrow.id).not.toBe(beforeArrow);
+  await page.keyboard.press('Space');
+  const toggledRow = detailDialog.locator(`[data-model-id="${afterArrow.id}"]`);
+  await expect(toggledRow).toHaveAttribute('aria-checked', afterArrow.checked === 'true' ? 'false' : 'true');
+  // Restore the row's original state (rows freeze while the save is in
+  // flight — the existing busy-freeze contract — so wait until re-enabled).
+  await expect(toggledRow).toBeEnabled();
+  await toggledRow.click();
+  await expect(toggledRow).toHaveAttribute('aria-checked', afterArrow.checked!);
+
   await expect(detailDialog.getByRole('textbox', { name: /模型密钥/ })).toHaveAttribute('placeholder', '••••••••');
 
   // Short-viewport invariant: when the expanded detail content outgrows the

--- a/apps/desktop/e2e/providers.spec.ts
+++ b/apps/desktop/e2e/providers.spec.ts
@@ -84,6 +84,18 @@ test('adds a catalog provider through the canonical API-key dialog', async ({ wi
   const detailMark = detailDialog.locator('.providerLogo[data-provider="cerebras"] img');
   await expect(detailMark).toBeVisible();
   expect(await detailMark.evaluate(colorAssetRenderContract)).toEqual(COLOR_ASSET_RENDER_CONTRACT);
+
+  // Dialog height must stay fixed while an API key is typed: the credential
+  // hint is a single persistent line and the 更新密钥 button is always present
+  // (disabled until a new key is entered), so nothing is added or removed.
+  const detailKeyField = detailDialog.getByRole('textbox', { name: /模型密钥/ });
+  await expect(detailKeyField).toHaveAttribute('placeholder', '••••••••');
+  const detailHeightBefore = (await detailDialog.boundingBox())?.height;
+  await detailKeyField.fill('sk-e2e-replacement-key');
+  await expect(detailDialog.getByRole('button', { name: '更新密钥', exact: true })).toBeEnabled();
+  expect((await detailDialog.boundingBox())?.height).toBe(detailHeightBefore);
+  await detailKeyField.fill('');
+
   await expect(detailDialog.getByText('GPT OSS 120B', { exact: true })).toBeHidden();
   await detailDialog.getByText('高级设置', { exact: true }).click();
   await expect(detailDialog.getByText('GPT OSS 120B', { exact: true }).first()).toBeVisible();

--- a/apps/desktop/e2e/providers.spec.ts
+++ b/apps/desktop/e2e/providers.spec.ts
@@ -117,6 +117,39 @@ test('adds a catalog provider through the canonical API-key dialog', async ({ wi
   await gemmaRow.click();
   await expect(gemmaRow).toBeChecked();
   await expect(detailDialog.getByRole('textbox', { name: /模型密钥/ })).toHaveAttribute('placeholder', '••••••••');
+
+  // Short-viewport invariant: when the expanded detail content outgrows the
+  // popup's 85dvh cap, the dialog must stay within the viewport and the BODY
+  // must take over scrolling (grid-template-rows: auto minmax(0, 1fr)),
+  // keeping the bottom actions reachable. Without the row constraint the body
+  // row sizes to content, overflows the popup box under overflow-hidden, and
+  // its own overflow-y:auto never engages — 删除连接 sits unreachable below
+  // the viewport.
+  const cdp = await page.context().newCDPSession(page);
+  await cdp.send('Emulation.setDeviceMetricsOverride', {
+    width: 1000,
+    height: 500,
+    deviceScaleFactor: 1,
+    mobile: false,
+  });
+  const shortViewportBox = await detailDialog.boundingBox();
+  expect(shortViewportBox!.height).toBeLessThanOrEqual(500 * 0.85);
+  expect(shortViewportBox!.y + shortViewportBox!.height).toBeLessThanOrEqual(500);
+  const dialogBody = detailDialog.locator('.providerConnectionDialogBody');
+  const scrollable = await dialogBody.evaluate((body) => body.scrollHeight > body.clientHeight);
+  expect(scrollable).toBe(true);
+  const deleteButton = detailDialog.getByRole('button', { name: '删除连接', exact: true });
+  // Scrolling the body must bring the bottom action into the viewport, and the
+  // click's actionability check (visible, stable, hit-testable) must pass —
+  // a clipped/unreachable button fails both.
+  await deleteButton.scrollIntoViewIfNeeded();
+  await expect(deleteButton).toBeInViewport();
+  await deleteButton.click();
+  const confirm = page.getByRole('alertdialog');
+  await expect(confirm).toBeVisible();
+  await confirm.getByRole('button', { name: '取消', exact: true }).click();
+  await expect(confirm).toBeHidden();
+  await cdp.send('Emulation.clearDeviceMetricsOverride');
 });
 
 // Distinct form behavior: an account-scoped provider has no fixed base URL —

--- a/apps/desktop/src/main/__tests__/model-oauth-section-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/model-oauth-section-contract.test.ts
@@ -392,15 +392,23 @@ describe('Model OAuth catalog contract (PR-MODEL-OAUTH-ALL-0 + PR-CLAUDE-CARD-MO
     assert.match(src, /自定义 OpenAI 兼容接口/);
     assert.match(src, /添加模型供应商：\$\{display\.name\}/);
     assert.match(src, /智谱 · OpenAI 兼容/);
+    // Provider introduction copy is localized zh / en in the display layer
+    // (PROVIDER_DISPLAY_COPY). The OpenAI OAuth account path must still name the
+    // account login, not a Codex subscription, in its Chinese copy.
     assert.match(
       src,
-      /case 'openai-codex':\s*return \{ name: 'OpenAI OAuth', description: 'ChatGPT \/ Codex 账号登录；登录后自动成为可用模型连接。' \}/,
+      /'openai-codex':\s*\{\s*zh:\s*\{ name: 'OpenAI OAuth', description: 'ChatGPT \/ Codex 账号登录；登录后自动成为可用模型连接。' \}/,
       'OpenAI OAuth account path should not be presented as a Codex subscription in provider settings',
     );
+    // Both locales ship explicit copy for the custom provider, so the Chinese
+    // UI never falls through to the raw English registry fallback
+    // ("Custom OpenAI-compatible endpoint or gateway.").
+    assert.match(src, /zh: \{ name: '自定义 OpenAI 兼容接口'/);
+    assert.match(src, /en: \{ name: 'Custom OpenAI-compatible'/);
     assert.doesNotMatch(
       src,
-      /OpenAI-compatible|endpoint/,
-      'model provider settings visible copy must not mix English technical fallback such as OpenAI-compatible endpoint',
+      /OpenAI-compatible endpoint or gateway/,
+      'localized display copy must not leak the raw English registry fallback into UI',
     );
   });
 

--- a/apps/desktop/src/main/__tests__/model-oauth-section-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/model-oauth-section-contract.test.ts
@@ -673,6 +673,13 @@ describe('Model OAuth catalog contract (PR-MODEL-OAUTH-ALL-0 + PR-CLAUDE-CARD-MO
       /<Button type="button" disabled=\{detailActionBusy \|\| !hasApiKeyChange\} onClick=\{save\}>[\s\S]*<Button type="button" disabled=\{detailActionBusy \|\| !hasBaseUrlChange\} onClick=\{save\}>/,
       'each Save action stays beside its field and disabled (not unmounted) until that field changes',
     );
+    // An OAuth-fixed endpoint is readOnly with no dirty path (no jitter risk),
+    // so it must not render a permanently-disabled 保存服务地址 button.
+    assert.match(
+      detail,
+      /\{!hasFixedOAuthBaseUrl && \(\s*<div className="providerEndpointActions">/,
+      'OAuth-fixed endpoints render no endpoint Save action instead of a forever-disabled one',
+    );
   });
 
   it('forwards an empty service-address draft so the stored override can be cleared', async () => {
@@ -699,13 +706,19 @@ describe('Model OAuth catalog contract (PR-MODEL-OAUTH-ALL-0 + PR-CLAUDE-CARD-MO
     // reflecting `enabledModelIds`, not a separate search-only "add" surface.
     assert.match(
       enabledModels,
-      /<ul className="providerModelChoiceList" aria-label="模型列表">/,
-      'the model catalog must use a single named native list',
+      /<ul\s+ref=\{modelListRef\}\s+className="providerModelChoiceList"\s+aria-label="模型列表"\s+onKeyDown=\{onModelListKeyDown\}\s*>/,
+      'the model catalog must use a single named native list with the roving-tabindex keyboard handler',
     );
     assert.match(
       enabledModels,
       /role="checkbox"\s+aria-checked=\{isEnabled\}/,
       'each model row is a checkbox reflecting its enabled state',
+    );
+    // Roving tabindex: exactly one row is a Tab stop; the rest are -1.
+    assert.match(
+      enabledModels,
+      /tabIndex=\{row\.id === resolvedActiveRowId \? 0 : -1\}/,
+      'model rows must rove a single tabIndex=0 so the list is one Tab stop',
     );
     assert.match(
       enabledModels,

--- a/apps/desktop/src/main/__tests__/model-oauth-section-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/model-oauth-section-contract.test.ts
@@ -197,13 +197,13 @@ describe('Model OAuth catalog contract (PR-MODEL-OAUTH-ALL-0 + PR-CLAUDE-CARD-MO
     );
     assert.match(
       detail,
-      /\{hasApiKeyChange && \([\s\S]*disabled=\{detailActionBusy\} onClick=\{save\}[\s\S]*\{busy \? '保存中…' : '更新密钥'\}/,
-      'ConnectionDetail key save button must appear only when the key draft is dirty',
+      /<Button type="button" disabled=\{detailActionBusy \|\| !hasApiKeyChange\} onClick=\{save\}>[\s\S]*\{busy \? '保存中…' : '更新密钥'\}/,
+      'ConnectionDetail key save button stays present but disabled until the key draft is dirty (constant dialog height)',
     );
     assert.match(
       detail,
-      /\{hasBaseUrlChange && \([\s\S]*className="providerEndpointActions"[\s\S]*disabled=\{detailActionBusy\} onClick=\{save\}[\s\S]*\{busy \? '保存中…' : '保存服务地址'\}/,
-      'ConnectionDetail endpoint save button must remain available to providers without API keys',
+      /className="providerEndpointActions"[\s\S]*<Button type="button" disabled=\{detailActionBusy \|\| !hasBaseUrlChange\} onClick=\{save\}>[\s\S]*\{busy \? '保存中…' : '保存服务地址'\}/,
+      'ConnectionDetail endpoint save button stays present but disabled until the endpoint draft is dirty',
     );
     assert.match(
       detail,
@@ -434,7 +434,10 @@ describe('Model OAuth catalog contract (PR-MODEL-OAUTH-ALL-0 + PR-CLAUDE-CARD-MO
     assert.match(detail, /<Label[^>]*>服务地址<\/Label>/);
     assert.match(detail, /props\.fixedOAuth && <FieldDescription>OAuth 固定<\/FieldDescription>/);
     assert.match(detail, /<Label[^>]*>模型密钥<\/Label>/);
-    assert.match(detail, /hasSecret === true && <FieldDescription>已设置，粘贴新值可替换<\/FieldDescription>/);
+    // The credential hint is a single persistent line (constant dialog height);
+    // its text still covers the "已设置，粘贴新值可替换" state.
+    assert.match(detail, /<FieldDescription>\{apiKeyStatusHint\}<\/FieldDescription>/);
+    assert.match(detail, /hasSecret === true\s*\?\s*'已设置，粘贴新值可替换'/);
     assert.match(detail, /placeholder=\{hasSecret === true \? '••••••••' : '粘贴模型密钥'\}/);
     assert.match(detail, /ariaLabel=\{`\$\{display\.name\} 模型密钥`\}/);
     assert.match(detail, /获取模型密钥/);
@@ -653,7 +656,7 @@ describe('Model OAuth catalog contract (PR-MODEL-OAUTH-ALL-0 + PR-CLAUDE-CARD-MO
     );
   });
 
-  it('does not render Save when an existing connection has no draft changes', async () => {
+  it('keeps each Save action beside its field, disabled until that field is dirty', async () => {
     const src = await readProviderSettingsCombinedSource();
     const detail = src.match(/function ConnectionDetail[\s\S]*?function GitHubCopilotReloginNotice/)?.[0] ?? '';
 
@@ -662,10 +665,13 @@ describe('Model OAuth catalog contract (PR-MODEL-OAUTH-ALL-0 + PR-CLAUDE-CARD-MO
       /const hasApiKeyChange = apiKey\.length > 0;[\s\S]*const hasBaseUrlChange = draftBaseUrl !== savedBaseUrl;/,
       'ConnectionDetail must compute dirty state separately for each field it writes',
     );
+    // The Save buttons stay mounted (disabled while the field is clean) so the
+    // dialog does not add or drop a row — and thus does not jitter in height —
+    // the moment the user starts typing a key or editing the endpoint.
     assert.match(
       detail,
-      /\{hasApiKeyChange && \([\s\S]*<Button type="button" disabled=\{detailActionBusy\} onClick=\{save\}>[\s\S]*\{hasBaseUrlChange && \([\s\S]*<Button type="button" disabled=\{detailActionBusy\} onClick=\{save\}>/,
-      'each Save action must stay beside its field and out of the default visual hierarchy until that field changes',
+      /<Button type="button" disabled=\{detailActionBusy \|\| !hasApiKeyChange\} onClick=\{save\}>[\s\S]*<Button type="button" disabled=\{detailActionBusy \|\| !hasBaseUrlChange\} onClick=\{save\}>/,
+      'each Save action stays beside its field and disabled (not unmounted) until that field changes',
     );
   });
 

--- a/apps/desktop/src/main/__tests__/model-oauth-section-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/model-oauth-section-contract.test.ts
@@ -444,8 +444,8 @@ describe('Model OAuth catalog contract (PR-MODEL-OAUTH-ALL-0 + PR-CLAUDE-CARD-MO
     assert.match(detail, /模型密钥 \/ 服务地址 \/ 代理设置/);
 
     assert.match(enabledModels, /启用模型/);
-    assert.match(enabledModels, /仅这些模型会出现在模型选择器中/);
-    assert.match(enabledModels, /搜索并添加模型/);
+    assert.match(enabledModels, /勾选的模型会出现在模型选择器中/);
+    assert.match(enabledModels, /搜索模型/);
     assert.match(src, /网络错误，请检查服务地址或代理设置后重试。/);
     // Provider descriptions are version-agnostic (provider + access path,
     // never a model generation that goes stale).
@@ -691,19 +691,26 @@ describe('Model OAuth catalog contract (PR-MODEL-OAUTH-ALL-0 + PR-CLAUDE-CARD-MO
     );
   });
 
-  it('uses native list semantics for enabled and searchable models', async () => {
+  it('renders the full model catalog as one named checkbox list', async () => {
     const src = await readProviderSettingsCombinedSource();
     const enabledModels = src.match(/function EnabledModelManager[\s\S]*?function modelDisplayLabel/)?.[0] ?? '';
 
+    // One persistent list of every candidate model; enabled state is a checkbox
+    // reflecting `enabledModelIds`, not a separate search-only "add" surface.
     assert.match(
       enabledModels,
-      /<ul className="providerModelSearchResults" aria-label="可添加模型">/,
-      'search results must use a named native list',
+      /<ul className="providerModelChoiceList" aria-label="模型列表">/,
+      'the model catalog must use a single named native list',
     );
     assert.match(
       enabledModels,
-      /<ul className="providerEnabledModelList" aria-label="已启用模型">/,
-      'enabled models must use a named native list',
+      /role="checkbox"\s+aria-checked=\{isEnabled\}/,
+      'each model row is a checkbox reflecting its enabled state',
+    );
+    assert.match(
+      enabledModels,
+      /<OverlayScrollArea className="providerModelChoiceScroll">/,
+      'the list scrolls inside a fixed-height region so filtering never resizes the dialog',
     );
     assert.doesNotMatch(
       enabledModels,
@@ -721,7 +728,10 @@ describe('Model OAuth catalog contract (PR-MODEL-OAUTH-ALL-0 + PR-CLAUDE-CARD-MO
       detail,
       /async function updateEnabledModels\(nextIds: string\[\]\)[\s\S]*connectionEnabledModelIds\([\s\S]*props\.bridge\.update\(connection\.slug, \{ enabledModelIds: next \}\)[\s\S]*await props\.onChanged\(\)/,
     );
-    assert.match(enabledModels, /isDefault \? \([\s\S]*providerEnabledModelMeta">默认<[\s\S]*\) : \([\s\S]*aria-label=\{`移除/);
+    // The default model row is checked and locked (disabled), never toggled off,
+    // and there is no second Save action inside the editor.
+    assert.match(enabledModels, /disabled=\{props\.disabled \|\| isDefault\}/);
+    assert.match(enabledModels, /isDefault && \([\s\S]*providerEnabledModelMeta">默认</);
     assert.doesNotMatch(enabledModels, /保存/);
   });
 

--- a/apps/desktop/src/main/__tests__/provider-contract-source-helpers.ts
+++ b/apps/desktop/src/main/__tests__/provider-contract-source-helpers.ts
@@ -10,6 +10,7 @@ export interface ProviderSettingsSources {
   catalog: string;
   oauth: string;
   display: string;
+  displayCopy: string;
   addForm: string;
   detail: string;
   shared: string;
@@ -22,18 +23,20 @@ const sourcePaths = {
   catalog: resolve(SETTINGS_ROOT, 'provider-catalog.tsx'),
   oauth: resolve(SETTINGS_ROOT, 'provider-oauth-section.tsx'),
   display: resolve(SETTINGS_ROOT, 'provider-display.tsx'),
+  displayCopy: resolve(SETTINGS_ROOT, 'provider-display-copy.ts'),
   addForm: resolve(SETTINGS_ROOT, 'provider-add-form.tsx'),
   detail: resolve(SETTINGS_ROOT, 'provider-connection-detail.tsx'),
   shared: resolve(SETTINGS_ROOT, 'provider-panel-shared.ts'),
 } as const;
 
 export async function readProviderSettingsSources(): Promise<ProviderSettingsSources> {
-  const [panel, dialog, catalog, oauth, display, addForm, detail, shared] = await Promise.all([
+  const [panel, dialog, catalog, oauth, display, displayCopy, addForm, detail, shared] = await Promise.all([
     readFile(sourcePaths.panel, 'utf8'),
     readFile(sourcePaths.dialog, 'utf8'),
     readFile(sourcePaths.catalog, 'utf8'),
     readFile(sourcePaths.oauth, 'utf8'),
     readFile(sourcePaths.display, 'utf8'),
+    readFile(sourcePaths.displayCopy, 'utf8'),
     readFile(sourcePaths.addForm, 'utf8'),
     readFile(sourcePaths.detail, 'utf8'),
     readFile(sourcePaths.shared, 'utf8'),
@@ -45,6 +48,7 @@ export async function readProviderSettingsSources(): Promise<ProviderSettingsSou
     catalog,
     oauth,
     display,
+    displayCopy,
     addForm,
     detail,
     shared,
@@ -54,6 +58,7 @@ export async function readProviderSettingsSources(): Promise<ProviderSettingsSou
       catalog,
       oauth,
       display,
+      displayCopy,
       addForm,
       detail,
       shared,

--- a/apps/desktop/src/main/__tests__/provider-display-copy-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/provider-display-copy-contract.test.ts
@@ -1,0 +1,84 @@
+/**
+ * Provider display-copy completeness contract.
+ *
+ * providerDisplay() localizes provider introduction copy zh / en through the
+ * PROVIDER_DISPLAY_COPY map in provider-display.tsx. Any catalog provider
+ * missing from that map silently falls back to the registry's English
+ * description — which is exactly the "no Chinese introduction on a Chinese
+ * UI" gap this contract exists to prevent.
+ *
+ * Data-driven over CATALOG_PROVIDER_TYPES (like the brand-mark completeness
+ * check in icon-governance-contract.test.ts) so a newly registered catalog
+ * provider is caught automatically: every type must carry a non-empty zh AND
+ * en description, the zh copy must actually be Chinese (contains CJK), and
+ * the en copy must not contain CJK. The registry fallback path in
+ * providerDisplay() remains only for unknown persisted provider types.
+ *
+ * This is a source-grep contract, not a DOM render — we don't pull React
+ * into the desktop test runner.
+ */
+
+import { strict as assert } from 'node:assert';
+import { readFile } from 'node:fs/promises';
+import { describe, it } from 'node:test';
+import { resolve } from 'node:path';
+import { CATALOG_PROVIDER_TYPES } from '@maka/core';
+
+const REPO_ROOT = resolve(import.meta.dirname, '../../../../..');
+const PROVIDER_DISPLAY_FILE = resolve(
+  REPO_ROOT,
+  'apps/desktop/src/renderer/settings/provider-display.tsx',
+);
+
+const CJK = /[一-鿿]/;
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/** Matches one `type: { zh: {...}, en: {...} }` entry (quoted or bare key). */
+function copyEntry(src: string, type: string): { zh: string; en: string } | null {
+  const key = escapeRegExp(type);
+  const entry = new RegExp(
+    `\\n  (?:'${key}'|${key}): \\{\\n`
+    + `    zh: \\{ name: '[^']+', description: '([^']+)'(?:, badge: '[^']+')? \\},\\n`
+    + `    en: \\{ name: '[^']+', description: '([^']+)'(?:, badge: '[^']+')? \\},\\n`
+    + `  \\},`,
+  ).exec(src);
+  if (!entry) return null;
+  return { zh: entry[1]!, en: entry[2]! };
+}
+
+describe('provider display copy contract', () => {
+  it('ships non-empty zh and en introduction copy for every catalog provider', async () => {
+    const src = await readFile(PROVIDER_DISPLAY_FILE, 'utf8');
+    const missing: string[] = [];
+    for (const type of CATALOG_PROVIDER_TYPES) {
+      const copy = copyEntry(src, type);
+      if (!copy || !copy.zh.trim() || !copy.en.trim()) missing.push(type);
+    }
+    assert.deepEqual(
+      missing,
+      [],
+      'every catalog provider must carry bilingual introduction copy in PROVIDER_DISPLAY_COPY '
+        + '(the registry fallback is English-only, which ships an untranslated card on the '
+        + `Chinese UI) — add zh + en entries for:\n  ${missing.join('\n  ')}`,
+    );
+  });
+
+  it('keeps zh copy Chinese and en copy free of CJK for every catalog provider', async () => {
+    const src = await readFile(PROVIDER_DISPLAY_FILE, 'utf8');
+    const wrongLocale: string[] = [];
+    for (const type of CATALOG_PROVIDER_TYPES) {
+      const copy = copyEntry(src, type);
+      if (!copy) continue; // completeness is the previous test's finding
+      if (!CJK.test(copy.zh) || CJK.test(copy.en)) wrongLocale.push(type);
+    }
+    assert.deepEqual(
+      wrongLocale,
+      [],
+      'zh descriptions must contain Chinese text and en descriptions must not — '
+        + `swapped or copied-through entries:\n  ${wrongLocale.join('\n  ')}`,
+    );
+  });
+});

--- a/apps/desktop/src/main/__tests__/provider-display-copy-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/provider-display-copy-contract.test.ts
@@ -1,78 +1,29 @@
 /**
- * Provider display-copy completeness contract.
+ * Provider display-copy locale contract.
  *
  * providerDisplay() localizes provider introduction copy zh / en through the
- * PROVIDER_DISPLAY_COPY map in provider-display.tsx. Any catalog provider
- * missing from that map silently falls back to the registry's English
- * description — which is exactly the "no Chinese introduction on a Chinese
- * UI" gap this contract exists to prevent.
- *
- * Data-driven over CATALOG_PROVIDER_TYPES (like the brand-mark completeness
- * check in icon-governance-contract.test.ts) so a newly registered catalog
- * provider is caught automatically: every type must carry a non-empty zh AND
- * en description, the zh copy must actually be Chinese (contains CJK), and
- * the en copy must not contain CJK. The registry fallback path in
- * providerDisplay() remains only for unknown persisted provider types.
- *
- * This is a source-grep contract, not a DOM render — we don't pull React
- * into the desktop test runner.
+ * pure-data PROVIDER_DISPLAY_COPY map. COMPLETENESS is enforced at compile
+ * time — the map `satisfies Record<ProviderType, …>`, so a newly registered
+ * provider without a bilingual entry fails the build. What the type system
+ * cannot see is whether an entry is actually bilingual: a zh description
+ * pasted from the English registry text type-checks fine but ships an
+ * untranslated card on the Chinese UI — exactly the gap this contract
+ * prevents. Asserted over the imported data itself (the module is
+ * React-free, so the main-process test runner loads it directly), not a
+ * regex parse of TSX source.
  */
 
 import { strict as assert } from 'node:assert';
-import { readFile } from 'node:fs/promises';
 import { describe, it } from 'node:test';
-import { resolve } from 'node:path';
-import { CATALOG_PROVIDER_TYPES } from '@maka/core';
-
-const REPO_ROOT = resolve(import.meta.dirname, '../../../../..');
-const PROVIDER_DISPLAY_FILE = resolve(
-  REPO_ROOT,
-  'apps/desktop/src/renderer/settings/provider-display.tsx',
-);
+import { PROVIDER_DISPLAY_COPY } from '../../renderer/settings/provider-display-copy.js';
 
 const CJK = /[一-鿿]/;
 
-function escapeRegExp(value: string): string {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-}
-
-/** Matches one `type: { zh: {...}, en: {...} }` entry (quoted or bare key). */
-function copyEntry(src: string, type: string): { zh: string; en: string } | null {
-  const key = escapeRegExp(type);
-  const entry = new RegExp(
-    `\\n  (?:'${key}'|${key}): \\{\\n`
-    + `    zh: \\{ name: '[^']+', description: '([^']+)'(?:, badge: '[^']+')? \\},\\n`
-    + `    en: \\{ name: '[^']+', description: '([^']+)'(?:, badge: '[^']+')? \\},\\n`
-    + `  \\},`,
-  ).exec(src);
-  if (!entry) return null;
-  return { zh: entry[1]!, en: entry[2]! };
-}
-
 describe('provider display copy contract', () => {
-  it('ships non-empty zh and en introduction copy for every catalog provider', async () => {
-    const src = await readFile(PROVIDER_DISPLAY_FILE, 'utf8');
-    const missing: string[] = [];
-    for (const type of CATALOG_PROVIDER_TYPES) {
-      const copy = copyEntry(src, type);
-      if (!copy || !copy.zh.trim() || !copy.en.trim()) missing.push(type);
-    }
-    assert.deepEqual(
-      missing,
-      [],
-      'every catalog provider must carry bilingual introduction copy in PROVIDER_DISPLAY_COPY '
-        + '(the registry fallback is English-only, which ships an untranslated card on the '
-        + `Chinese UI) — add zh + en entries for:\n  ${missing.join('\n  ')}`,
-    );
-  });
-
-  it('keeps zh copy Chinese and en copy free of CJK for every catalog provider', async () => {
-    const src = await readFile(PROVIDER_DISPLAY_FILE, 'utf8');
+  it('keeps zh copy Chinese and en copy free of CJK for every provider', () => {
     const wrongLocale: string[] = [];
-    for (const type of CATALOG_PROVIDER_TYPES) {
-      const copy = copyEntry(src, type);
-      if (!copy) continue; // completeness is the previous test's finding
-      if (!CJK.test(copy.zh) || CJK.test(copy.en)) wrongLocale.push(type);
+    for (const [type, copy] of Object.entries(PROVIDER_DISPLAY_COPY)) {
+      if (!CJK.test(copy.zh.description) || CJK.test(copy.en.description)) wrongLocale.push(type);
     }
     assert.deepEqual(
       wrongLocale,
@@ -80,5 +31,15 @@ describe('provider display copy contract', () => {
       'zh descriptions must contain Chinese text and en descriptions must not — '
         + `swapped or copied-through entries:\n  ${wrongLocale.join('\n  ')}`,
     );
+  });
+
+  it('ships non-empty names and descriptions in both locales', () => {
+    const empty: string[] = [];
+    for (const [type, copy] of Object.entries(PROVIDER_DISPLAY_COPY)) {
+      for (const locale of ['zh', 'en'] as const) {
+        if (!copy[locale].name.trim() || !copy[locale].description.trim()) empty.push(`${type} (${locale})`);
+      }
+    }
+    assert.deepEqual(empty, [], `blank copy entries:\n  ${empty.join('\n  ')}`);
   });
 });

--- a/apps/desktop/src/main/__tests__/renderer-utility-primitives-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/renderer-utility-primitives-contract.test.ts
@@ -298,7 +298,7 @@ describe('renderer utility surfaces use shared UI primitives', () => {
     assert.doesNotMatch(rendererCss, /\.settingsWechatQrSecondary\b/);
 
     const providerDetail = await readFile(join(process.cwd(), 'src/renderer/settings/provider-connection-detail.tsx'), 'utf8');
-    assert.match(providerDetail, /<Button[\s\S]*variant="ghost"[\s\S]*aria-label=\{`移除/);
+    assert.match(providerDetail, /<Button variant="secondary" type="button" disabled=\{detailActionBusy \|\| !hasUsableCredential\} onClick=\{runTest\}>/);
     assert.doesNotMatch(providerDetail, /<BaseButton|modelTableRow/);
   });
 

--- a/apps/desktop/src/main/__tests__/session-sticky-model-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/session-sticky-model-contract.test.ts
@@ -65,7 +65,7 @@ describe('PR-SESSION-STICKY-MODEL-0 contract', () => {
     assert.match(renderer, /normalizeActiveChatModel\(activeSession, activeConnection, chatModelChoices\)/);
     assert.match(ui, /本会话固定模型：\$\{props\.activeConnectionLabel\} · \$\{props\.activeModelLabel\}/);
     assert.match(ui, /设置里的默认模型只影响新建会话/);
-    assert.match(providers, /仅这些模型会出现在模型选择器中/);
+    assert.match(providers, /勾选的模型会出现在模型选择器中/);
   });
 
   it('lets the user explicitly switch the current session model from the chat header', async () => {

--- a/apps/desktop/src/main/__tests__/settings-form-a11y-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/settings-form-a11y-contract.test.ts
@@ -169,7 +169,7 @@ describe('Settings form accessibility labels', () => {
     assert.doesNotMatch(providersPanel, /<select\b/, 'ProvidersPanel must use the Base UI Select primitive for Settings selects');
     assert.doesNotMatch(providersPanel, /className="maka-button/, 'ProvidersPanel governed Buttons must not layer the legacy maka-button class (inert under the @maka/ui Button utilities, so it is dead weight)');
     assert.match(providersPanel, /aria-label="搜索模型"/);
-    assert.match(providersPanel, /<ul className="providerModelChoiceList" aria-label="模型列表">/);
+    assert.match(providersPanel, /className="providerModelChoiceList"\s+aria-label="模型列表"/);
     // `Item` rows become real buttons through Base UI's polymorphic
     // `render={<button .../>}` prop, which is a primitive render target rather
     // than a hand-rolled control. Strip those before asserting no raw <button>

--- a/apps/desktop/src/main/__tests__/settings-form-a11y-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/settings-form-a11y-contract.test.ts
@@ -67,8 +67,8 @@ describe('Settings form accessibility labels', () => {
     // table cells which carry the same border-radius family.
     const providerIcon = '';
     const providerCatalogBadge = styles.match(/\.providerCatalogBadge\s*\{[\s\S]*?\}/)?.[0] ?? '';
-    const enabledModelList = styles.match(/\.providerEnabledModelList\s*\{[\s\S]*?\}/)?.[0] ?? '';
-    const modelSearchResults = styles.match(/\.providerModelSearchResults\s*\{[\s\S]*?\}/)?.[0] ?? '';
+    const modelChoiceList = styles.match(/\.providerModelChoiceList\s*\{[\s\S]*?\}/)?.[0] ?? '';
+    const modelChoiceScroll = styles.match(/\.providerModelChoiceScroll\s*\{[\s\S]*?\}/)?.[0] ?? '';
     const settingsRow = styles.match(/\.settingsRow\s*\{[\s\S]*?\}/g)?.at(-1) ?? '';
     const settingsRowValue = styles.match(/\.settingsRow > span\s*\{[\s\S]*?\}/)?.[0] ?? '';
     const settingsRowTitle = styles.match(/\.settingsRow strong\s*\{[\s\S]*?\}/)?.[0] ?? '';
@@ -84,15 +84,16 @@ describe('Settings form accessibility labels', () => {
     assert.match(providerMarketGridRule, /grid-template-columns:\s*1fr;/, 'Settings provider catalog should render as a seamless single-column row list, not a card grid');
     assert.ok(providerCatalogRow, 'Settings provider catalog rows should be governed by the shared .providerCatalogRow (Item) class');
     // PR-DELETE-ORPHAN-CSS: providerIcon assertion removed (orphan).
-    assert.match(enabledModelList, /display:\s*grid;/, 'Enabled models should group plain rows with layout, not container chrome');
-    assert.match(enabledModelList, /gap:\s*var\(--space-1\);/, 'Enabled model rows should use whitespace as their persistent grouping cue');
-    assert.doesNotMatch(enabledModelList, /border-(?:top|bottom):/, 'Enabled models should not add separators around an already-bordered search field');
-    assert.match(modelSearchResults, /border-radius:\s*var\(--radius-surface\);/, 'Search results may use the standard secondary-surface radius');
+    assert.match(modelChoiceList, /display:\s*grid;/, 'The model list should group plain rows with layout, not per-row container chrome');
+    assert.match(modelChoiceList, /gap:\s*var\(--space-0-5\);/, 'Model rows should use whitespace as their persistent grouping cue');
+    assert.doesNotMatch(modelChoiceList, /border-(?:top|bottom):/, 'Model rows should not add separators inside the already-bordered scroll region');
+    assert.match(modelChoiceScroll, /border-radius:\s*var\(--radius-surface\);/, 'The model scroll region uses the standard secondary-surface radius');
+    assert.match(modelChoiceScroll, /height:\s*\d+px;/, 'The model scroll region is a fixed height so filtering never resizes the dialog');
     assert.match(providerCatalogBadge, /border-radius:\s*var\(--radius-control\);/, 'Provider catalog badges (category / preview / login) should use compact squared target-layout style corners, not pills');
     assert.match(connectionBadge, /rounded-\[var\(--radius-control\)\]/, 'Settings status badges (Chip primitive) should use compact squared target-layout style corners, not pills');
     assert.match(settingsBadge, /rounded-\[var\(--radius-control\)\]/, 'Generic Settings badges (Chip primitive) should use compact squared target-layout style corners, not pills');
     assert.doesNotMatch(providerCatalogBadge, /border-radius:\s*var\(--radius-pill\);/, 'Provider catalog badges must not regress to pill-shaped chrome');
-    assert.doesNotMatch(enabledModelList, /border-radius|box-shadow|background:/, 'Enabled model rows must stay visually flat');
+    assert.doesNotMatch(modelChoiceList, /border-radius|box-shadow|background:/, 'Model rows must stay visually flat inside the bordered scroll region');
     assert.doesNotMatch(connectionBadge, /rounded-\[var\(--radius-pill\)\]/, 'Settings connection badges (Chip primitive) must not regress to pill-shaped chrome');
     assert.doesNotMatch(settingsBadge, /rounded-\[var\(--radius-pill\)\]/, 'Generic Settings badges (Chip primitive) must not regress to pill-shaped chrome');
     assert.match(settingsRow, /display:\s*grid;/, 'Settings rows should use a stable label/value grid instead of flex auto sizing');
@@ -167,8 +168,8 @@ describe('Settings form accessibility labels', () => {
     assert.doesNotMatch(providersPanel, /<textarea\b/, 'ProvidersPanel must use the shared Textarea primitive for Settings text areas');
     assert.doesNotMatch(providersPanel, /<select\b/, 'ProvidersPanel must use the Base UI Select primitive for Settings selects');
     assert.doesNotMatch(providersPanel, /className="maka-button/, 'ProvidersPanel governed Buttons must not layer the legacy maka-button class (inert under the @maka/ui Button utilities, so it is dead weight)');
-    assert.match(providersPanel, /aria-label="搜索并添加模型"/);
-    assert.match(providersPanel, /<ul className="providerEnabledModelList" aria-label="已启用模型">/);
+    assert.match(providersPanel, /aria-label="搜索模型"/);
+    assert.match(providersPanel, /<ul className="providerModelChoiceList" aria-label="模型列表">/);
     // `Item` rows become real buttons through Base UI's polymorphic
     // `render={<button .../>}` prop, which is a primitive render target rather
     // than a hand-rolled control. Strip those before asserting no raw <button>
@@ -254,7 +255,7 @@ describe('Settings form accessibility labels', () => {
       '模型供应商连接标识',
       '模型供应商显示名称',
       '模型供应商服务地址',
-      '搜索并添加模型',
+      '搜索模型',
     ]) {
       assert.ok(providers.includes(`aria-label="${label}"`), `ProvidersPanel must label ${label}`);
     }

--- a/apps/desktop/src/renderer/settings/provider-connection-detail.tsx
+++ b/apps/desktop/src/renderer/settings/provider-connection-detail.tsx
@@ -10,7 +10,23 @@ import {
   type ProviderType,
 } from '@maka/core';
 import { providerAuthRequiresSecret, providerAuthSupportsApiKey } from '@maka/core/llm-connections';
-import { Button, FieldDescription, FieldRoot, Input, Label, RelativeTime, useMountedRef, useToast } from '@maka/ui';
+import {
+  Button,
+  FieldDescription,
+  FieldRoot,
+  Input,
+  Item,
+  ItemActions,
+  ItemContent,
+  ItemMedia,
+  ItemTitle,
+  Label,
+  OverlayScrollArea,
+  RelativeTime,
+  useMountedRef,
+  useToast,
+} from '@maka/ui';
+import { Check } from '@maka/ui/icons';
 import { PasswordInput } from './password-input';
 import { buildCatalogModelChoices } from '../model-catalog-choices';
 import { providerDisplay } from './provider-display';
@@ -792,8 +808,14 @@ function modelListsEqual(left: ModelInfo[], right: ModelInfo[]): boolean {
 }
 
 /**
- * Compact allowlist editor. The complete provider catalog appears only after
- * the user searches; the persistent rows are the short enabled list.
+ * Enabled-model editor. The full candidate catalog (live-fetched merged with
+ * the static fallback, via buildCatalogModelChoices) is shown persistently
+ * inside a fixed-height scroll region; enabled models read as checked. Clicking
+ * a row toggles it through the shared `enabledModelIds` path, so a newly
+ * enabled model reaches the chat model picker with no side state. The default
+ * model stays checked and locked (`connectionEnabledModelIds` always keeps it
+ * enabled). Search filters the same list in place, so neither the provider's
+ * model count nor an active filter changes the dialog height.
  */
 function EnabledModelManager(props: {
   modelChoices: ModelCatalogEntry[];
@@ -804,82 +826,103 @@ function EnabledModelManager(props: {
 }) {
   const [query, setQuery] = useState('');
   const enabled = useMemo(() => new Set(props.enabledModelIds), [props.enabledModelIds]);
-  const matches = useMemo(() => {
+  const rows = useMemo(() => {
+    const byId = new Map(props.modelChoices.map((model) => [model.id, model] as const));
+    const seen = new Set<string>();
+    const list: Array<{ id: string; label: string }> = [];
+    for (const model of props.modelChoices) {
+      if (!model.canUseAsChatDefault) continue;
+      seen.add(model.id);
+      list.push({ id: model.id, label: modelDisplayLabel(model) });
+    }
+    // Always surface an already-enabled model even if it is not a current
+    // chat-default candidate (a stale id, or a model dropped from the latest
+    // catalog), so the user can still toggle it off.
+    for (const id of props.enabledModelIds) {
+      if (seen.has(id)) continue;
+      seen.add(id);
+      const model = byId.get(id);
+      list.push({ id, label: model ? modelDisplayLabel(model) : id });
+    }
+    return list;
+  }, [props.modelChoices, props.enabledModelIds]);
+
+  const visibleRows = useMemo(() => {
     const normalizedQuery = query.trim().toLowerCase();
-    if (!normalizedQuery) return [];
-    return props.modelChoices
-      .filter((model) => {
-        if (enabled.has(model.id) || !model.canUseAsChatDefault) return false;
-        const label = modelDisplayLabel(model).toLowerCase();
-        return model.id.toLowerCase().includes(normalizedQuery) || label.includes(normalizedQuery);
-      })
-      .slice(0, 20);
-  }, [enabled, props.modelChoices, query]);
+    if (!normalizedQuery) return rows;
+    return rows.filter(
+      (row) => row.id.toLowerCase().includes(normalizedQuery) || row.label.toLowerCase().includes(normalizedQuery),
+    );
+  }, [rows, query]);
+
+  function toggle(id: string) {
+    if (props.disabled || id === props.defaultModel) return;
+    const next = enabled.has(id)
+      ? props.enabledModelIds.filter((candidate) => candidate !== id)
+      : [...props.enabledModelIds, id];
+    props.onChange(next);
+  }
 
   return (
     <section className="providerEnabledModels" aria-labelledby="provider-enabled-models-title">
       <div className="providerEnabledModelsHeader">
         <strong id="provider-enabled-models-title">启用模型 {props.enabledModelIds.length}</strong>
-        <span>仅这些模型会出现在模型选择器中。</span>
+        <span>勾选的模型会出现在模型选择器中。</span>
       </div>
       <Input
         type="search"
         value={query}
         onChange={(event) => setQuery(event.currentTarget.value)}
-        placeholder="搜索并添加模型"
+        placeholder="搜索模型"
         autoComplete="off"
         spellCheck={false}
         disabled={props.disabled}
-        aria-label="搜索并添加模型"
+        aria-label="搜索模型"
       />
-      {query.trim() && (
-        <ul className="providerModelSearchResults" aria-label="可添加模型">
-          {matches.length === 0 ? (
-            <li className="providerModelSearchEmpty">没有可添加的匹配模型。</li>
-          ) : matches.map((model) => (
-            <li className="providerModelSearchRow" key={model.id}>
-              <span>{modelDisplayLabel(model)}</span>
-              <Button
-                type="button"
-                variant="ghost"
-                size="sm"
-                disabled={props.disabled}
-                onClick={() => {
-                  props.onChange([...props.enabledModelIds, model.id]);
-                  setQuery('');
-                }}
-              >
-                添加
-              </Button>
+      <OverlayScrollArea className="providerModelChoiceScroll">
+        <ul className="providerModelChoiceList" aria-label="模型列表">
+          {visibleRows.length === 0 ? (
+            <li className="providerModelChoiceEmpty">
+              {rows.length === 0 ? '暂无可选模型，请先更新模型目录。' : '没有匹配的模型。'}
             </li>
-          ))}
+          ) : (
+            visibleRows.map((row) => {
+              const isEnabled = enabled.has(row.id);
+              const isDefault = row.id === props.defaultModel;
+              return (
+                <li key={row.id}>
+                  <Item
+                    className="providerModelChoiceRow"
+                    size="sm"
+                    data-enabled={isEnabled ? 'true' : undefined}
+                    render={
+                      <button
+                        type="button"
+                        role="checkbox"
+                        aria-checked={isEnabled}
+                        disabled={props.disabled || isDefault}
+                        onClick={() => toggle(row.id)}
+                      />
+                    }
+                  >
+                    <ItemMedia className="providerModelChoiceCheck" aria-hidden="true">
+                      {isEnabled ? <Check size={14} /> : null}
+                    </ItemMedia>
+                    <ItemContent>
+                      <ItemTitle className="providerModelChoiceLabel">{row.label}</ItemTitle>
+                    </ItemContent>
+                    {isDefault && (
+                      <ItemActions>
+                        <span className="providerEnabledModelMeta">默认</span>
+                      </ItemActions>
+                    )}
+                  </Item>
+                </li>
+              );
+            })
+          )}
         </ul>
-      )}
-      <ul className="providerEnabledModelList" aria-label="已启用模型">
-        {props.enabledModelIds.map((id) => {
-          const model = props.modelChoices.find((candidate) => candidate.id === id);
-          const isDefault = id === props.defaultModel;
-          return (
-            <li key={id}>
-              <span>{model ? modelDisplayLabel(model) : id}</span>
-              {isDefault ? (
-                <span className="providerEnabledModelMeta">默认</span>
-              ) : (
-                <Button
-                  type="button"
-                  variant="ghost"
-                  size="icon"
-                  disabled={props.disabled}
-                  aria-label={`移除 ${model ? modelDisplayLabel(model) : id}`}
-                  onClick={() => props.onChange(props.enabledModelIds.filter((candidate) => candidate !== id))}
-                >
-                  ×
-                </Button>
-              )}
-            </li>
-          );
-        })}
-      </ul>
+      </OverlayScrollArea>
     </section>
   );
 }

--- a/apps/desktop/src/renderer/settings/provider-connection-detail.tsx
+++ b/apps/desktop/src/renderer/settings/provider-connection-detail.tsx
@@ -610,12 +610,16 @@ function ConnectionDetailInner(props: ConnectionDetailProps) {
               onChange={setBaseUrl}
             />
             {/* Persistent button (disabled until the endpoint is edited) so the
-                advanced settings body height stays constant while typing. */}
-            <div className="providerEndpointActions">
-              <Button type="button" disabled={detailActionBusy || !hasBaseUrlChange} onClick={save}>
-                {busy ? '保存中…' : '保存服务地址'}
-              </Button>
-            </div>
+                advanced settings body height stays constant while typing. An
+                OAuth-fixed endpoint is readOnly with no dirty path — no jitter
+                risk — so it renders no permanently-disabled Save at all. */}
+            {!hasFixedOAuthBaseUrl && (
+              <div className="providerEndpointActions">
+                <Button type="button" disabled={detailActionBusy || !hasBaseUrlChange} onClick={save}>
+                  {busy ? '保存中…' : '保存服务地址'}
+                </Button>
+              </div>
+            )}
           </div>
           <div className="providerAdvancedActions">
             <Button variant="secondary" type="button" disabled={detailActionBusy || !hasUsableCredential} onClick={runTest}>

--- a/apps/desktop/src/renderer/settings/provider-connection-detail.tsx
+++ b/apps/desktop/src/renderer/settings/provider-connection-detail.tsx
@@ -176,6 +176,17 @@ function ConnectionDetailInner(props: ConnectionDetailProps) {
   const draftBaseUrl = baseUrl;
   const hasApiKeyChange = apiKey.length > 0;
   const hasBaseUrlChange = draftBaseUrl !== savedBaseUrl;
+  // Persistent single-line credential hint. Rendered in every hasSecret state
+  // (including `false`) so the description row never adds or drops a line as the
+  // async secret probe resolves — the dialog height stays constant.
+  const apiKeyStatusHint =
+    hasSecret === true
+      ? '已设置，粘贴新值可替换'
+      : hasSecret === 'loading'
+        ? '正在读取状态'
+        : hasSecret === 'error'
+          ? '凭据状态未知'
+          : '尚未设置密钥';
   const detailActionBusy = busy || testing || fetchingModels || savingEnabledModels || settingDefault || deleting;
   const issue = connectionChipStatus(connection);
   const lastTestMessage = connectionLastTestMessageDisplay(connection.lastTestMessage);
@@ -489,9 +500,7 @@ function ConnectionDetailInner(props: ConnectionDetailProps) {
         <div className="providerCredentialTask">
           <FieldRoot className="grid gap-1.5">
             <Label className="text-xs text-foreground-secondary">模型密钥</Label>
-            {hasSecret === true && <FieldDescription>已设置，粘贴新值可替换</FieldDescription>}
-            {hasSecret === 'loading' && <FieldDescription>正在读取状态</FieldDescription>}
-            {hasSecret === 'error' && <FieldDescription>凭据状态未知</FieldDescription>}
+            <FieldDescription>{apiKeyStatusHint}</FieldDescription>
             <PasswordInput
               value={apiKey}
               onChange={setApiKey}
@@ -506,11 +515,12 @@ function ConnectionDetailInner(props: ConnectionDetailProps) {
                 获取模型密钥
               </a>
             )}
-            {hasApiKeyChange && (
-              <Button type="button" disabled={detailActionBusy} onClick={save}>
-                {busy ? '保存中…' : '更新密钥'}
-              </Button>
-            )}
+            {/* Persistent button (disabled until a new key is typed) so the
+                credential actions row keeps a fixed height — no jitter when the
+                user starts pasting a key. */}
+            <Button type="button" disabled={detailActionBusy || !hasApiKeyChange} onClick={save}>
+              {busy ? '保存中…' : '更新密钥'}
+            </Button>
           </div>
         </div>
       )}
@@ -583,13 +593,13 @@ function ConnectionDetailInner(props: ConnectionDetailProps) {
               disabled={detailActionBusy}
               onChange={setBaseUrl}
             />
-            {hasBaseUrlChange && (
-              <div className="providerEndpointActions">
-                <Button type="button" disabled={detailActionBusy} onClick={save}>
-                  {busy ? '保存中…' : '保存服务地址'}
-                </Button>
-              </div>
-            )}
+            {/* Persistent button (disabled until the endpoint is edited) so the
+                advanced settings body height stays constant while typing. */}
+            <div className="providerEndpointActions">
+              <Button type="button" disabled={detailActionBusy || !hasBaseUrlChange} onClick={save}>
+                {busy ? '保存中…' : '保存服务地址'}
+              </Button>
+            </div>
           </div>
           <div className="providerAdvancedActions">
             <Button variant="secondary" type="button" disabled={detailActionBusy || !hasUsableCredential} onClick={runTest}>

--- a/apps/desktop/src/renderer/settings/provider-connection-detail.tsx
+++ b/apps/desktop/src/renderer/settings/provider-connection-detail.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState, type KeyboardEvent } from 'react';
 import {
   PROVIDER_DEFAULTS,
   connectionEnabledModelIds,
@@ -825,6 +825,14 @@ function EnabledModelManager(props: {
   onChange(ids: string[]): void;
 }) {
   const [query, setQuery] = useState('');
+  // Roving tabindex (composite-widget keyboard pattern): the whole list is ONE
+  // Tab stop. Without this every row button is a Tab stop, and a large catalog
+  // (OpenRouter's fallback list is 260+ rows) walls off everything below the
+  // list for keyboard users. Only the active row has tabIndex=0; ArrowUp/Down
+  // + Home/End move activity (focus scrolls the row into view), Space/Enter
+  // toggle via the button's native activation.
+  const [activeRowId, setActiveRowId] = useState<string | null>(null);
+  const modelListRef = useRef<HTMLUListElement>(null);
   const enabled = useMemo(() => new Set(props.enabledModelIds), [props.enabledModelIds]);
   const rows = useMemo(() => {
     const byId = new Map(props.modelChoices.map((model) => [model.id, model] as const));
@@ -863,6 +871,42 @@ function EnabledModelManager(props: {
     props.onChange(next);
   }
 
+  // The default-model row is disabled (natively unfocusable), so arrow-key
+  // traversal skips it — consistent with Tab behavior.
+  const focusableRows = visibleRows.filter((row) => row.id !== props.defaultModel);
+  const resolvedActiveRowId = activeRowId !== null && focusableRows.some((row) => row.id === activeRowId)
+    ? activeRowId
+    : focusableRows[0]?.id ?? null;
+
+  function onModelListKeyDown(event: KeyboardEvent<HTMLUListElement>) {
+    if (focusableRows.length === 0) return;
+    const currentIndex = Math.max(0, focusableRows.findIndex((row) => row.id === resolvedActiveRowId));
+    let nextIndex: number;
+    switch (event.key) {
+      case 'ArrowDown':
+        nextIndex = Math.min(currentIndex + 1, focusableRows.length - 1);
+        break;
+      case 'ArrowUp':
+        nextIndex = Math.max(currentIndex - 1, 0);
+        break;
+      case 'Home':
+        nextIndex = 0;
+        break;
+      case 'End':
+        nextIndex = focusableRows.length - 1;
+        break;
+      default:
+        return;
+    }
+    event.preventDefault();
+    const next = focusableRows[nextIndex];
+    setActiveRowId(next.id);
+    // Focus scrolls the row into view inside the fixed-height scroll region.
+    modelListRef.current
+      ?.querySelector<HTMLElement>(`[data-model-id="${CSS.escape(next.id)}"]`)
+      ?.focus();
+  }
+
   return (
     <section className="providerEnabledModels" aria-labelledby="provider-enabled-models-title">
       <div className="providerEnabledModelsHeader">
@@ -880,7 +924,12 @@ function EnabledModelManager(props: {
         aria-label="搜索模型"
       />
       <OverlayScrollArea className="providerModelChoiceScroll">
-        <ul className="providerModelChoiceList" aria-label="模型列表">
+        <ul
+          ref={modelListRef}
+          className="providerModelChoiceList"
+          aria-label="模型列表"
+          onKeyDown={onModelListKeyDown}
+        >
           {visibleRows.length === 0 ? (
             <li className="providerModelChoiceEmpty">
               {rows.length === 0 ? '暂无可选模型，请先更新模型目录。' : '没有匹配的模型。'}
@@ -894,14 +943,16 @@ function EnabledModelManager(props: {
                   <Item
                     className="providerModelChoiceRow"
                     size="sm"
-                    data-enabled={isEnabled ? 'true' : undefined}
                     render={
                       <button
                         type="button"
                         role="checkbox"
                         aria-checked={isEnabled}
+                        data-model-id={row.id}
+                        tabIndex={row.id === resolvedActiveRowId ? 0 : -1}
                         disabled={props.disabled || isDefault}
                         onClick={() => toggle(row.id)}
+                        onFocus={() => setActiveRowId(row.id)}
                       />
                     }
                   >

--- a/apps/desktop/src/renderer/settings/provider-display-copy.ts
+++ b/apps/desktop/src/renderer/settings/provider-display-copy.ts
@@ -1,0 +1,228 @@
+import type { ProviderType } from '@maka/core';
+
+/**
+ * Pure-data provider introduction copy, localized zh / en.
+ *
+ * No React / @maka/ui imports on purpose: the desktop main-process test
+ * runner (node --test over dist/main) imports this module directly, so the
+ * copy contract (provider-display-copy-contract.test.ts) asserts the real
+ * data instead of regex-parsing TSX source. The locale type is declared
+ * locally for the same reason; it is structurally identical to @maka/ui's
+ * UiLocale ('zh' | 'en').
+ *
+ * These stay in the display layer (not the registry) because they are
+ * introduction prose tuned for the catalog, not the runtime provider facts.
+ * Descriptions stay version-agnostic on purpose: they name the PROVIDER and
+ * how you connect (official key / plan / protocol-compatible / gateway /
+ * local), never a specific model generation — model names go stale (GPT-4o,
+ * DeepSeek-V3, …) but the provider and access path do not. Brand names
+ * (Anthropic, OpenAI, …) are never translated. Entries follow
+ * CATALOG_PROVIDER_TYPES order, with the OAuth account providers at the end.
+ *
+ * Completeness is enforced at compile time: `satisfies Record<ProviderType,
+ * …>` fails the build when a registered provider has no bilingual entry.
+ */
+export type ProviderDisplayLocale = 'zh' | 'en';
+
+export interface ProviderCopy {
+  name: string;
+  description: string;
+  badge?: string;
+}
+
+export const PROVIDER_DISPLAY_COPY = {
+  'kimi-coding-plan': {
+    zh: { name: 'Kimi Coding Plan', description: '月之暗面 · Anthropic 兼容', badge: 'Coding' },
+    en: { name: 'Kimi Coding Plan', description: 'Moonshot · Anthropic-compatible', badge: 'Coding' },
+  },
+  'minimax-coding-plan': {
+    zh: { name: 'MiniMax Coding Plan', description: 'MiniMax Coding 套餐 · Anthropic 兼容', badge: 'Coding' },
+    en: { name: 'MiniMax Coding Plan', description: 'MiniMax coding plan · Anthropic-compatible', badge: 'Coding' },
+  },
+  deepseek: {
+    zh: { name: 'DeepSeek', description: 'DeepSeek 官方接入', badge: 'API' },
+    en: { name: 'DeepSeek', description: 'Official DeepSeek API access.', badge: 'API' },
+  },
+  moonshot: {
+    zh: { name: 'Moonshot', description: 'Moonshot 官方接入', badge: 'API' },
+    en: { name: 'Moonshot', description: 'Official Moonshot API access.', badge: 'API' },
+  },
+  'zai-coding-plan': {
+    zh: { name: 'Z.AI Coding Plan', description: '智谱 · OpenAI 兼容', badge: 'Coding' },
+    en: { name: 'Z.AI Coding Plan', description: 'Zhipu · OpenAI-compatible', badge: 'Coding' },
+  },
+  MiniMax: {
+    zh: { name: 'MiniMax', description: 'MiniMax · Anthropic 兼容', badge: 'API' },
+    en: { name: 'MiniMax', description: 'MiniMax · Anthropic-compatible', badge: 'API' },
+  },
+  'MiniMax-cn': {
+    zh: { name: 'MiniMax 中国站', description: 'MiniMax 中国站 · Anthropic 兼容', badge: 'API' },
+    en: { name: 'MiniMax China', description: 'MiniMax China · Anthropic-compatible', badge: 'API' },
+  },
+  siliconflow: {
+    zh: { name: 'SiliconFlow', description: '硅基流动多模型 API，支持精确模型 ID。', badge: '聚合' },
+    en: { name: 'SiliconFlow', description: 'Hosted multi-model API with exact upstream model ids.', badge: 'Aggregator' },
+  },
+  anthropic: {
+    zh: { name: 'Anthropic', description: 'Anthropic 官方接入', badge: 'API' },
+    en: { name: 'Anthropic', description: 'Official Anthropic API access.', badge: 'API' },
+  },
+  openai: {
+    zh: { name: 'OpenAI', description: 'OpenAI 官方接入', badge: 'API' },
+    en: { name: 'OpenAI', description: 'Official OpenAI API access.', badge: 'API' },
+  },
+  google: {
+    zh: { name: 'Google Gemini', description: 'Google AI Studio 接入', badge: 'API' },
+    en: { name: 'Google Gemini', description: 'Google AI Studio API access.', badge: 'API' },
+  },
+  xai: {
+    zh: { name: 'xAI', description: 'xAI 官方接入，Grok 系列模型', badge: 'API' },
+    en: { name: 'xAI', description: 'Official xAI API access for Grok models.', badge: 'API' },
+  },
+  zai: {
+    zh: { name: 'Z.AI', description: '智谱官方接入，GLM 系列模型', badge: 'API' },
+    en: { name: 'Z.AI', description: 'Official Z.AI API access for GLM models.', badge: 'API' },
+  },
+  xiaomi: {
+    zh: { name: 'Xiaomi', description: '小米官方接入，MiMo 系列模型', badge: 'API' },
+    en: { name: 'Xiaomi', description: 'Official Xiaomi API access for MiMo models.', badge: 'API' },
+  },
+  cerebras: {
+    zh: { name: 'Cerebras', description: '高速推理托管开源模型', badge: 'API' },
+    en: { name: 'Cerebras', description: 'Fast hosted open-model inference.', badge: 'API' },
+  },
+  mistral: {
+    zh: { name: 'Mistral', description: 'Mistral 官方接入', badge: 'API' },
+    en: { name: 'Mistral', description: 'Official Mistral API access.', badge: 'API' },
+  },
+  togetherai: {
+    zh: { name: 'Together AI', description: '托管开源模型 API', badge: 'API' },
+    en: { name: 'Together AI', description: 'Hosted open models over one API.', badge: 'API' },
+  },
+  ollama: {
+    zh: { name: 'Ollama', description: '本机运行 · 离线可用', badge: 'Local' },
+    en: { name: 'Ollama', description: 'Runs locally · works offline', badge: 'Local' },
+  },
+  'lm-studio': {
+    zh: { name: 'LM Studio', description: '本机 LM Studio 服务 · 离线可用', badge: 'Local' },
+    en: { name: 'LM Studio', description: 'Local models served by LM Studio.', badge: 'Local' },
+  },
+  localai: {
+    zh: { name: 'LocalAI', description: '本机 LocalAI 服务，可选密钥保护', badge: 'Local' },
+    en: { name: 'LocalAI', description: 'Local models served by LocalAI, with optional API key.', badge: 'Local' },
+  },
+  'openai-compatible': {
+    zh: { name: '自定义 OpenAI 兼容接口', description: '中转站、代理服务或自部署网关。', badge: 'Custom' },
+    en: { name: 'Custom OpenAI-compatible', description: 'Relay, proxy, or self-hosted gateway.', badge: 'Custom' },
+  },
+  'fireworks-ai': {
+    zh: { name: 'Fireworks AI', description: 'Serverless 开源模型托管', badge: 'API' },
+    en: { name: 'Fireworks AI', description: 'Serverless open models with exact Fireworks model paths.', badge: 'API' },
+  },
+  nvidia: {
+    zh: { name: 'NVIDIA', description: 'NVIDIA 官方托管模型接入', badge: 'API' },
+    en: { name: 'NVIDIA', description: 'NVIDIA-hosted models API access.', badge: 'API' },
+  },
+  'tencent-tokenhub': {
+    zh: { name: 'Tencent TokenHub', description: '腾讯云 TokenHub 按量接入，混元等模型', badge: 'API' },
+    en: { name: 'Tencent TokenHub', description: 'Tencent Cloud TokenHub pay-as-you-go access.', badge: 'API' },
+  },
+  stepfun: {
+    zh: { name: 'StepFun 中国站', description: '阶跃星辰官方接入 · 中国站', badge: 'API' },
+    en: { name: 'StepFun (China)', description: 'Official StepFun China API access.', badge: 'API' },
+  },
+  'tencent-coding-plan': {
+    zh: { name: 'Tencent Coding Plan', description: '腾讯云 Coding 套餐 · OpenAI 兼容', badge: 'Coding' },
+    en: { name: 'Tencent Coding Plan', description: 'Tencent Cloud coding plan · OpenAI-compatible', badge: 'Coding' },
+  },
+  'stepfun-ai': {
+    zh: { name: 'StepFun 国际站', description: '阶跃星辰官方接入 · 国际站', badge: 'API' },
+    en: { name: 'StepFun (Global)', description: 'Official StepFun Global API access.', badge: 'API' },
+  },
+  'volcengine-ark': {
+    zh: { name: '火山方舟', description: '火山引擎官方接入，豆包等模型', badge: 'API' },
+    en: { name: 'Volcengine Ark (China)', description: 'Volcengine Ark direct API access in China.', badge: 'API' },
+  },
+  'volcengine-coding-plan': {
+    zh: { name: '火山方舟 Coding Plan', description: '火山引擎 Coding 订阅 · OpenAI 兼容', badge: 'Coding' },
+    en: { name: 'Volcengine Ark Coding Plan (China)', description: 'Volcengine Ark coding subscription · OpenAI-compatible', badge: 'Coding' },
+  },
+  'tencent-token-plan': {
+    zh: { name: 'Tencent Token Plan', description: '腾讯云 Token 套餐，个人智能体与编码工具', badge: 'Token' },
+    en: { name: 'Tencent Token Plan', description: 'Tencent Cloud token plan for personal agents and coding tools.', badge: 'Token' },
+  },
+  'stepfun-step-plan': {
+    zh: { name: 'StepFun Step Plan 中国站', description: '阶跃星辰订阅套餐 · 中国站', badge: 'Plan' },
+    en: { name: 'StepFun Step Plan (China)', description: 'StepFun China subscription for coding and agent tools.', badge: 'Plan' },
+  },
+  deepinfra: {
+    zh: { name: 'DeepInfra', description: '开源模型托管推理 · OpenAI 兼容', badge: 'API' },
+    en: { name: 'DeepInfra', description: 'Hosted open-model inference · OpenAI-compatible', badge: 'API' },
+  },
+  cohere: {
+    zh: { name: 'Cohere', description: 'Cohere 官方接入', badge: 'API' },
+    en: { name: 'Cohere', description: 'Official Cohere Chat API access.', badge: 'API' },
+  },
+  vercel: {
+    zh: { name: 'Vercel AI Gateway', description: '一个密钥接入多家托管模型', badge: '网关' },
+    en: { name: 'Vercel AI Gateway', description: 'One API key for hosted models with exact creator/model ids.', badge: 'Gateway' },
+  },
+  'stepfun-ai-step-plan': {
+    zh: { name: 'StepFun Step Plan 国际站', description: '阶跃星辰订阅套餐 · 国际站', badge: 'Plan' },
+    en: { name: 'StepFun Step Plan (Global)', description: 'StepFun Global subscription for coding and agent tools.', badge: 'Plan' },
+  },
+  'cloudflare-workers-ai': {
+    zh: { name: 'Cloudflare Workers AI', description: 'Cloudflare 托管模型，账户级接入', badge: 'API' },
+    en: { name: 'Cloudflare Workers AI', description: 'Cloudflare-hosted models over the account-scoped API.', badge: 'API' },
+  },
+  huggingface: {
+    zh: { name: 'Hugging Face', description: 'Inference Providers 路由，聚合多家托管模型', badge: '路由' },
+    en: { name: 'Hugging Face', description: 'Inference Providers router across hosted models.', badge: 'Router' },
+  },
+  'ollama-cloud': {
+    zh: { name: 'Ollama Cloud', description: 'Ollama 官方云端托管模型', badge: 'API' },
+    en: { name: 'Ollama Cloud', description: 'Ollama-hosted cloud models over the official remote API.', badge: 'API' },
+  },
+  zenmux: {
+    zh: { name: 'ZenMux', description: '模型路由网关，一个密钥接入多家模型', badge: '网关' },
+    en: { name: 'ZenMux', description: 'One API key for routed models with exact creator/model ids.', badge: 'Gateway' },
+  },
+  opencode: {
+    zh: { name: 'OpenCode Zen', description: '面向编码智能体的按量模型精选', badge: 'Plan' },
+    en: { name: 'OpenCode Zen', description: 'Curated pay-as-you-go models for coding agents.', badge: 'Plan' },
+  },
+  'opencode-go': {
+    zh: { name: 'OpenCode Go', description: '低价订阅制的开源编码模型精选', badge: 'Plan' },
+    en: { name: 'OpenCode Go', description: 'Low-cost subscription to curated open coding models.', badge: 'Plan' },
+  },
+  groq: {
+    zh: { name: 'Groq', description: 'LPU 高速推理托管开源模型', badge: 'API' },
+    en: { name: 'Groq', description: 'Ultra-fast LPU-hosted open models.', badge: 'API' },
+  },
+  openrouter: {
+    zh: { name: 'OpenRouter', description: '一个密钥接入各大模型厂商 · OpenAI 兼容', badge: '聚合' },
+    en: { name: 'OpenRouter', description: 'One API key across all major model labs · OpenAI-compatible', badge: 'Aggregator' },
+  },
+  alibaba: {
+    zh: { name: 'Alibaba', description: '阿里云百炼接入，通义千问 Qwen 模型', badge: 'API' },
+    en: { name: 'Alibaba', description: 'Alibaba Cloud API access for Qwen models.', badge: 'API' },
+  },
+  // OAuth account providers (not in CATALOG_PROVIDER_TYPES; shown in the
+  // accounts section and on connection rows).
+  'github-copilot': {
+    zh: { name: 'GitHub Copilot', description: 'GitHub Copilot 订阅接入，复用本机 GitHub 登录', badge: 'Account' },
+    en: { name: 'GitHub Copilot', description: 'GitHub Copilot subscription access using an existing GitHub login.', badge: 'Account' },
+  },
+  'claude-subscription': {
+    zh: { name: 'Claude Subscription', description: 'Claude Pro / Max 订阅账号登录；登录后自动成为可用模型连接。' },
+    en: { name: 'Claude Subscription', description: 'Sign in with a Claude Pro / Max subscription; it becomes an available model connection once signed in.' },
+  },
+  'openai-codex': {
+    zh: { name: 'OpenAI OAuth', description: 'ChatGPT / Codex 账号登录；登录后自动成为可用模型连接。' },
+    en: { name: 'OpenAI OAuth', description: 'Sign in with a ChatGPT / Codex account; it becomes an available model connection once signed in.' },
+  },
+  'gemini-cli': {
+    zh: { name: 'Gemini CLI', description: 'Google 账号登录暂未接入聊天发送。' },
+    en: { name: 'Gemini CLI', description: 'Google account sign-in is not yet wired to chat.' },
+  },
+} satisfies Record<ProviderType, Record<ProviderDisplayLocale, ProviderCopy>>;

--- a/apps/desktop/src/renderer/settings/provider-display.tsx
+++ b/apps/desktop/src/renderer/settings/provider-display.tsx
@@ -22,33 +22,27 @@ interface ProviderCopy {
 }
 
 // UI-layer provider introduction copy, localized zh / en. These stay in the
-// display layer (not the registry) because they are marketing/introduction
-// prose tuned for the catalog, not the runtime provider facts. Descriptions
-// stay version-agnostic on purpose: they name the PROVIDER and how you connect
-// (official key / protocol-compatible / local), never a specific model
-// generation — model names go stale (GPT-4o, DeepSeek-V3, …) but the provider
-// and access path do not. Brand names (Anthropic, OpenAI, …) are never
-// translated.
+// display layer (not the registry) because they are introduction prose tuned
+// for the catalog, not the runtime provider facts. Descriptions stay
+// version-agnostic on purpose: they name the PROVIDER and how you connect
+// (official key / plan / protocol-compatible / gateway / local), never a
+// specific model generation — model names go stale (GPT-4o, DeepSeek-V3, …)
+// but the provider and access path do not. Brand names (Anthropic, OpenAI, …)
+// are never translated. Entries follow CATALOG_PROVIDER_TYPES order, with the
+// OAuth account providers at the end.
+//
+// Completeness is pinned by
+// apps/desktop/src/main/__tests__/provider-display-copy-contract.test.ts:
+// every CATALOG_PROVIDER_TYPES entry must carry non-empty zh AND en
+// descriptions, so a new catalog provider cannot ship without bilingual copy.
 const PROVIDER_DISPLAY_COPY: Partial<Record<ProviderType, Record<UiLocale, ProviderCopy>>> = {
-  siliconflow: {
-    zh: { name: 'SiliconFlow', description: '硅基流动多模型 API，支持精确模型 ID。', badge: '聚合' },
-    en: { name: 'SiliconFlow', description: 'Hosted multi-model API with exact upstream model ids.', badge: 'Aggregator' },
-  },
-  anthropic: {
-    zh: { name: 'Anthropic', description: 'Anthropic 官方接入', badge: 'API' },
-    en: { name: 'Anthropic', description: 'Official Anthropic API access.', badge: 'API' },
-  },
   'kimi-coding-plan': {
     zh: { name: 'Kimi Coding Plan', description: '月之暗面 · Anthropic 兼容', badge: 'Coding' },
     en: { name: 'Kimi Coding Plan', description: 'Moonshot · Anthropic-compatible', badge: 'Coding' },
   },
-  openai: {
-    zh: { name: 'OpenAI', description: 'OpenAI 官方接入', badge: 'API' },
-    en: { name: 'OpenAI', description: 'Official OpenAI API access.', badge: 'API' },
-  },
-  google: {
-    zh: { name: 'Google Gemini', description: 'Google AI Studio 接入', badge: 'API' },
-    en: { name: 'Google Gemini', description: 'Google AI Studio API access.', badge: 'API' },
+  'minimax-coding-plan': {
+    zh: { name: 'MiniMax Coding Plan', description: 'MiniMax Coding 套餐 · Anthropic 兼容', badge: 'Coding' },
+    en: { name: 'MiniMax Coding Plan', description: 'MiniMax coding plan · Anthropic-compatible', badge: 'Coding' },
   },
   deepseek: {
     zh: { name: 'DeepSeek', description: 'DeepSeek 官方接入', badge: 'API' },
@@ -70,13 +64,159 @@ const PROVIDER_DISPLAY_COPY: Partial<Record<ProviderType, Record<UiLocale, Provi
     zh: { name: 'MiniMax 中国站', description: 'MiniMax 中国站 · Anthropic 兼容', badge: 'API' },
     en: { name: 'MiniMax China', description: 'MiniMax China · Anthropic-compatible', badge: 'API' },
   },
+  siliconflow: {
+    zh: { name: 'SiliconFlow', description: '硅基流动多模型 API，支持精确模型 ID。', badge: '聚合' },
+    en: { name: 'SiliconFlow', description: 'Hosted multi-model API with exact upstream model ids.', badge: 'Aggregator' },
+  },
+  anthropic: {
+    zh: { name: 'Anthropic', description: 'Anthropic 官方接入', badge: 'API' },
+    en: { name: 'Anthropic', description: 'Official Anthropic API access.', badge: 'API' },
+  },
+  openai: {
+    zh: { name: 'OpenAI', description: 'OpenAI 官方接入', badge: 'API' },
+    en: { name: 'OpenAI', description: 'Official OpenAI API access.', badge: 'API' },
+  },
+  google: {
+    zh: { name: 'Google Gemini', description: 'Google AI Studio 接入', badge: 'API' },
+    en: { name: 'Google Gemini', description: 'Google AI Studio API access.', badge: 'API' },
+  },
+  xai: {
+    zh: { name: 'xAI', description: 'xAI 官方接入，Grok 系列模型', badge: 'API' },
+    en: { name: 'xAI', description: 'Official xAI API access for Grok models.', badge: 'API' },
+  },
+  zai: {
+    zh: { name: 'Z.AI', description: '智谱官方接入，GLM 系列模型', badge: 'API' },
+    en: { name: 'Z.AI', description: 'Official Z.AI API access for GLM models.', badge: 'API' },
+  },
+  xiaomi: {
+    zh: { name: 'Xiaomi', description: '小米官方接入，MiMo 系列模型', badge: 'API' },
+    en: { name: 'Xiaomi', description: 'Official Xiaomi API access for MiMo models.', badge: 'API' },
+  },
+  cerebras: {
+    zh: { name: 'Cerebras', description: '高速推理托管开源模型', badge: 'API' },
+    en: { name: 'Cerebras', description: 'Fast hosted open-model inference.', badge: 'API' },
+  },
+  mistral: {
+    zh: { name: 'Mistral', description: 'Mistral 官方接入', badge: 'API' },
+    en: { name: 'Mistral', description: 'Official Mistral API access.', badge: 'API' },
+  },
+  togetherai: {
+    zh: { name: 'Together AI', description: '托管开源模型 API', badge: 'API' },
+    en: { name: 'Together AI', description: 'Hosted open models over one API.', badge: 'API' },
+  },
   ollama: {
     zh: { name: 'Ollama', description: '本机运行 · 离线可用', badge: 'Local' },
     en: { name: 'Ollama', description: 'Runs locally · works offline', badge: 'Local' },
   },
+  'lm-studio': {
+    zh: { name: 'LM Studio', description: '本机 LM Studio 服务 · 离线可用', badge: 'Local' },
+    en: { name: 'LM Studio', description: 'Local models served by LM Studio.', badge: 'Local' },
+  },
+  localai: {
+    zh: { name: 'LocalAI', description: '本机 LocalAI 服务，可选密钥保护', badge: 'Local' },
+    en: { name: 'LocalAI', description: 'Local models served by LocalAI, with optional API key.', badge: 'Local' },
+  },
   'openai-compatible': {
     zh: { name: '自定义 OpenAI 兼容接口', description: '中转站、代理服务或自部署网关。', badge: 'Custom' },
     en: { name: 'Custom OpenAI-compatible', description: 'Relay, proxy, or self-hosted gateway.', badge: 'Custom' },
+  },
+  'fireworks-ai': {
+    zh: { name: 'Fireworks AI', description: 'Serverless 开源模型托管', badge: 'API' },
+    en: { name: 'Fireworks AI', description: 'Serverless open models with exact Fireworks model paths.', badge: 'API' },
+  },
+  nvidia: {
+    zh: { name: 'NVIDIA', description: 'NVIDIA 官方托管模型接入', badge: 'API' },
+    en: { name: 'NVIDIA', description: 'NVIDIA-hosted models API access.', badge: 'API' },
+  },
+  'tencent-tokenhub': {
+    zh: { name: 'Tencent TokenHub', description: '腾讯云 TokenHub 按量接入，混元等模型', badge: 'API' },
+    en: { name: 'Tencent TokenHub', description: 'Tencent Cloud TokenHub pay-as-you-go access.', badge: 'API' },
+  },
+  stepfun: {
+    zh: { name: 'StepFun 中国站', description: '阶跃星辰官方接入 · 中国站', badge: 'API' },
+    en: { name: 'StepFun (China)', description: 'Official StepFun China API access.', badge: 'API' },
+  },
+  'tencent-coding-plan': {
+    zh: { name: 'Tencent Coding Plan', description: '腾讯云 Coding 套餐 · OpenAI 兼容', badge: 'Coding' },
+    en: { name: 'Tencent Coding Plan', description: 'Tencent Cloud coding plan · OpenAI-compatible', badge: 'Coding' },
+  },
+  'stepfun-ai': {
+    zh: { name: 'StepFun 国际站', description: '阶跃星辰官方接入 · 国际站', badge: 'API' },
+    en: { name: 'StepFun (Global)', description: 'Official StepFun Global API access.', badge: 'API' },
+  },
+  'volcengine-ark': {
+    zh: { name: '火山方舟', description: '火山引擎官方接入，豆包等模型', badge: 'API' },
+    en: { name: 'Volcengine Ark (China)', description: 'Volcengine Ark direct API access in China.', badge: 'API' },
+  },
+  'volcengine-coding-plan': {
+    zh: { name: '火山方舟 Coding Plan', description: '火山引擎 Coding 订阅 · OpenAI 兼容', badge: 'Coding' },
+    en: { name: 'Volcengine Ark Coding Plan (China)', description: 'Volcengine Ark coding subscription · OpenAI-compatible', badge: 'Coding' },
+  },
+  'tencent-token-plan': {
+    zh: { name: 'Tencent Token Plan', description: '腾讯云 Token 套餐，个人智能体与编码工具', badge: 'Token' },
+    en: { name: 'Tencent Token Plan', description: 'Tencent Cloud token plan for personal agents and coding tools.', badge: 'Token' },
+  },
+  'stepfun-step-plan': {
+    zh: { name: 'StepFun Step Plan 中国站', description: '阶跃星辰订阅套餐 · 中国站', badge: 'Plan' },
+    en: { name: 'StepFun Step Plan (China)', description: 'StepFun China subscription for coding and agent tools.', badge: 'Plan' },
+  },
+  deepinfra: {
+    zh: { name: 'DeepInfra', description: '开源模型托管推理 · OpenAI 兼容', badge: 'API' },
+    en: { name: 'DeepInfra', description: 'Hosted open-model inference · OpenAI-compatible', badge: 'API' },
+  },
+  cohere: {
+    zh: { name: 'Cohere', description: 'Cohere 官方接入', badge: 'API' },
+    en: { name: 'Cohere', description: 'Official Cohere Chat API access.', badge: 'API' },
+  },
+  vercel: {
+    zh: { name: 'Vercel AI Gateway', description: '一个密钥接入多家托管模型', badge: '网关' },
+    en: { name: 'Vercel AI Gateway', description: 'One API key for hosted models with exact creator/model ids.', badge: 'Gateway' },
+  },
+  'stepfun-ai-step-plan': {
+    zh: { name: 'StepFun Step Plan 国际站', description: '阶跃星辰订阅套餐 · 国际站', badge: 'Plan' },
+    en: { name: 'StepFun Step Plan (Global)', description: 'StepFun Global subscription for coding and agent tools.', badge: 'Plan' },
+  },
+  'cloudflare-workers-ai': {
+    zh: { name: 'Cloudflare Workers AI', description: 'Cloudflare 托管模型，账户级接入', badge: 'API' },
+    en: { name: 'Cloudflare Workers AI', description: 'Cloudflare-hosted models over the account-scoped API.', badge: 'API' },
+  },
+  huggingface: {
+    zh: { name: 'Hugging Face', description: 'Inference Providers 路由，聚合多家托管模型', badge: '路由' },
+    en: { name: 'Hugging Face', description: 'Inference Providers router across hosted models.', badge: 'Router' },
+  },
+  'ollama-cloud': {
+    zh: { name: 'Ollama Cloud', description: 'Ollama 官方云端托管模型', badge: 'API' },
+    en: { name: 'Ollama Cloud', description: 'Ollama-hosted cloud models over the official remote API.', badge: 'API' },
+  },
+  zenmux: {
+    zh: { name: 'ZenMux', description: '模型路由网关，一个密钥接入多家模型', badge: '网关' },
+    en: { name: 'ZenMux', description: 'One API key for routed models with exact creator/model ids.', badge: 'Gateway' },
+  },
+  opencode: {
+    zh: { name: 'OpenCode Zen', description: '面向编码智能体的按量模型精选', badge: 'Plan' },
+    en: { name: 'OpenCode Zen', description: 'Curated pay-as-you-go models for coding agents.', badge: 'Plan' },
+  },
+  'opencode-go': {
+    zh: { name: 'OpenCode Go', description: '低价订阅制的开源编码模型精选', badge: 'Plan' },
+    en: { name: 'OpenCode Go', description: 'Low-cost subscription to curated open coding models.', badge: 'Plan' },
+  },
+  groq: {
+    zh: { name: 'Groq', description: 'LPU 高速推理托管开源模型', badge: 'API' },
+    en: { name: 'Groq', description: 'Ultra-fast LPU-hosted open models.', badge: 'API' },
+  },
+  openrouter: {
+    zh: { name: 'OpenRouter', description: '一个密钥接入各大模型厂商 · OpenAI 兼容', badge: '聚合' },
+    en: { name: 'OpenRouter', description: 'One API key across all major model labs · OpenAI-compatible', badge: 'Aggregator' },
+  },
+  alibaba: {
+    zh: { name: 'Alibaba', description: '阿里云百炼接入，通义千问 Qwen 模型', badge: 'API' },
+    en: { name: 'Alibaba', description: 'Alibaba Cloud API access for Qwen models.', badge: 'API' },
+  },
+  // OAuth account providers (not in CATALOG_PROVIDER_TYPES; shown in the
+  // accounts section and on connection rows).
+  'github-copilot': {
+    zh: { name: 'GitHub Copilot', description: 'GitHub Copilot 订阅接入，复用本机 GitHub 登录', badge: 'Account' },
+    en: { name: 'GitHub Copilot', description: 'GitHub Copilot subscription access using an existing GitHub login.', badge: 'Account' },
   },
   'claude-subscription': {
     zh: { name: 'Claude Subscription', description: 'Claude Pro / Max 订阅账号登录；登录后自动成为可用模型连接。' },

--- a/apps/desktop/src/renderer/settings/provider-display.tsx
+++ b/apps/desktop/src/renderer/settings/provider-display.tsx
@@ -1,6 +1,7 @@
 import { PROVIDER_DEFAULTS, type ProviderType } from '@maka/core';
 import { detectUiLocale, type UiLocale } from '@maka/ui';
 import { ProviderBrandMark } from './provider-brand-marks';
+import { PROVIDER_DISPLAY_COPY, type ProviderCopy } from './provider-display-copy';
 
 // Kept as a thin wrapper so the many `ProviderLogo` call sites stay put.
 function ProviderLogoMark({ type }: { type: ProviderType }) {
@@ -15,232 +16,18 @@ export function ProviderLogo(props: { type: ProviderType; compact?: boolean }) {
   );
 }
 
-interface ProviderCopy {
-  name: string;
-  description: string;
-  badge?: string;
-}
-
-// UI-layer provider introduction copy, localized zh / en. These stay in the
-// display layer (not the registry) because they are introduction prose tuned
-// for the catalog, not the runtime provider facts. Descriptions stay
-// version-agnostic on purpose: they name the PROVIDER and how you connect
-// (official key / plan / protocol-compatible / gateway / local), never a
-// specific model generation — model names go stale (GPT-4o, DeepSeek-V3, …)
-// but the provider and access path do not. Brand names (Anthropic, OpenAI, …)
-// are never translated. Entries follow CATALOG_PROVIDER_TYPES order, with the
-// OAuth account providers at the end.
-//
-// Completeness is pinned by
-// apps/desktop/src/main/__tests__/provider-display-copy-contract.test.ts:
-// every CATALOG_PROVIDER_TYPES entry must carry non-empty zh AND en
-// descriptions, so a new catalog provider cannot ship without bilingual copy.
-const PROVIDER_DISPLAY_COPY: Partial<Record<ProviderType, Record<UiLocale, ProviderCopy>>> = {
-  'kimi-coding-plan': {
-    zh: { name: 'Kimi Coding Plan', description: '月之暗面 · Anthropic 兼容', badge: 'Coding' },
-    en: { name: 'Kimi Coding Plan', description: 'Moonshot · Anthropic-compatible', badge: 'Coding' },
-  },
-  'minimax-coding-plan': {
-    zh: { name: 'MiniMax Coding Plan', description: 'MiniMax Coding 套餐 · Anthropic 兼容', badge: 'Coding' },
-    en: { name: 'MiniMax Coding Plan', description: 'MiniMax coding plan · Anthropic-compatible', badge: 'Coding' },
-  },
-  deepseek: {
-    zh: { name: 'DeepSeek', description: 'DeepSeek 官方接入', badge: 'API' },
-    en: { name: 'DeepSeek', description: 'Official DeepSeek API access.', badge: 'API' },
-  },
-  moonshot: {
-    zh: { name: 'Moonshot', description: 'Moonshot 官方接入', badge: 'API' },
-    en: { name: 'Moonshot', description: 'Official Moonshot API access.', badge: 'API' },
-  },
-  'zai-coding-plan': {
-    zh: { name: 'Z.AI Coding Plan', description: '智谱 · OpenAI 兼容', badge: 'Coding' },
-    en: { name: 'Z.AI Coding Plan', description: 'Zhipu · OpenAI-compatible', badge: 'Coding' },
-  },
-  MiniMax: {
-    zh: { name: 'MiniMax', description: 'MiniMax · Anthropic 兼容', badge: 'API' },
-    en: { name: 'MiniMax', description: 'MiniMax · Anthropic-compatible', badge: 'API' },
-  },
-  'MiniMax-cn': {
-    zh: { name: 'MiniMax 中国站', description: 'MiniMax 中国站 · Anthropic 兼容', badge: 'API' },
-    en: { name: 'MiniMax China', description: 'MiniMax China · Anthropic-compatible', badge: 'API' },
-  },
-  siliconflow: {
-    zh: { name: 'SiliconFlow', description: '硅基流动多模型 API，支持精确模型 ID。', badge: '聚合' },
-    en: { name: 'SiliconFlow', description: 'Hosted multi-model API with exact upstream model ids.', badge: 'Aggregator' },
-  },
-  anthropic: {
-    zh: { name: 'Anthropic', description: 'Anthropic 官方接入', badge: 'API' },
-    en: { name: 'Anthropic', description: 'Official Anthropic API access.', badge: 'API' },
-  },
-  openai: {
-    zh: { name: 'OpenAI', description: 'OpenAI 官方接入', badge: 'API' },
-    en: { name: 'OpenAI', description: 'Official OpenAI API access.', badge: 'API' },
-  },
-  google: {
-    zh: { name: 'Google Gemini', description: 'Google AI Studio 接入', badge: 'API' },
-    en: { name: 'Google Gemini', description: 'Google AI Studio API access.', badge: 'API' },
-  },
-  xai: {
-    zh: { name: 'xAI', description: 'xAI 官方接入，Grok 系列模型', badge: 'API' },
-    en: { name: 'xAI', description: 'Official xAI API access for Grok models.', badge: 'API' },
-  },
-  zai: {
-    zh: { name: 'Z.AI', description: '智谱官方接入，GLM 系列模型', badge: 'API' },
-    en: { name: 'Z.AI', description: 'Official Z.AI API access for GLM models.', badge: 'API' },
-  },
-  xiaomi: {
-    zh: { name: 'Xiaomi', description: '小米官方接入，MiMo 系列模型', badge: 'API' },
-    en: { name: 'Xiaomi', description: 'Official Xiaomi API access for MiMo models.', badge: 'API' },
-  },
-  cerebras: {
-    zh: { name: 'Cerebras', description: '高速推理托管开源模型', badge: 'API' },
-    en: { name: 'Cerebras', description: 'Fast hosted open-model inference.', badge: 'API' },
-  },
-  mistral: {
-    zh: { name: 'Mistral', description: 'Mistral 官方接入', badge: 'API' },
-    en: { name: 'Mistral', description: 'Official Mistral API access.', badge: 'API' },
-  },
-  togetherai: {
-    zh: { name: 'Together AI', description: '托管开源模型 API', badge: 'API' },
-    en: { name: 'Together AI', description: 'Hosted open models over one API.', badge: 'API' },
-  },
-  ollama: {
-    zh: { name: 'Ollama', description: '本机运行 · 离线可用', badge: 'Local' },
-    en: { name: 'Ollama', description: 'Runs locally · works offline', badge: 'Local' },
-  },
-  'lm-studio': {
-    zh: { name: 'LM Studio', description: '本机 LM Studio 服务 · 离线可用', badge: 'Local' },
-    en: { name: 'LM Studio', description: 'Local models served by LM Studio.', badge: 'Local' },
-  },
-  localai: {
-    zh: { name: 'LocalAI', description: '本机 LocalAI 服务，可选密钥保护', badge: 'Local' },
-    en: { name: 'LocalAI', description: 'Local models served by LocalAI, with optional API key.', badge: 'Local' },
-  },
-  'openai-compatible': {
-    zh: { name: '自定义 OpenAI 兼容接口', description: '中转站、代理服务或自部署网关。', badge: 'Custom' },
-    en: { name: 'Custom OpenAI-compatible', description: 'Relay, proxy, or self-hosted gateway.', badge: 'Custom' },
-  },
-  'fireworks-ai': {
-    zh: { name: 'Fireworks AI', description: 'Serverless 开源模型托管', badge: 'API' },
-    en: { name: 'Fireworks AI', description: 'Serverless open models with exact Fireworks model paths.', badge: 'API' },
-  },
-  nvidia: {
-    zh: { name: 'NVIDIA', description: 'NVIDIA 官方托管模型接入', badge: 'API' },
-    en: { name: 'NVIDIA', description: 'NVIDIA-hosted models API access.', badge: 'API' },
-  },
-  'tencent-tokenhub': {
-    zh: { name: 'Tencent TokenHub', description: '腾讯云 TokenHub 按量接入，混元等模型', badge: 'API' },
-    en: { name: 'Tencent TokenHub', description: 'Tencent Cloud TokenHub pay-as-you-go access.', badge: 'API' },
-  },
-  stepfun: {
-    zh: { name: 'StepFun 中国站', description: '阶跃星辰官方接入 · 中国站', badge: 'API' },
-    en: { name: 'StepFun (China)', description: 'Official StepFun China API access.', badge: 'API' },
-  },
-  'tencent-coding-plan': {
-    zh: { name: 'Tencent Coding Plan', description: '腾讯云 Coding 套餐 · OpenAI 兼容', badge: 'Coding' },
-    en: { name: 'Tencent Coding Plan', description: 'Tencent Cloud coding plan · OpenAI-compatible', badge: 'Coding' },
-  },
-  'stepfun-ai': {
-    zh: { name: 'StepFun 国际站', description: '阶跃星辰官方接入 · 国际站', badge: 'API' },
-    en: { name: 'StepFun (Global)', description: 'Official StepFun Global API access.', badge: 'API' },
-  },
-  'volcengine-ark': {
-    zh: { name: '火山方舟', description: '火山引擎官方接入，豆包等模型', badge: 'API' },
-    en: { name: 'Volcengine Ark (China)', description: 'Volcengine Ark direct API access in China.', badge: 'API' },
-  },
-  'volcengine-coding-plan': {
-    zh: { name: '火山方舟 Coding Plan', description: '火山引擎 Coding 订阅 · OpenAI 兼容', badge: 'Coding' },
-    en: { name: 'Volcengine Ark Coding Plan (China)', description: 'Volcengine Ark coding subscription · OpenAI-compatible', badge: 'Coding' },
-  },
-  'tencent-token-plan': {
-    zh: { name: 'Tencent Token Plan', description: '腾讯云 Token 套餐，个人智能体与编码工具', badge: 'Token' },
-    en: { name: 'Tencent Token Plan', description: 'Tencent Cloud token plan for personal agents and coding tools.', badge: 'Token' },
-  },
-  'stepfun-step-plan': {
-    zh: { name: 'StepFun Step Plan 中国站', description: '阶跃星辰订阅套餐 · 中国站', badge: 'Plan' },
-    en: { name: 'StepFun Step Plan (China)', description: 'StepFun China subscription for coding and agent tools.', badge: 'Plan' },
-  },
-  deepinfra: {
-    zh: { name: 'DeepInfra', description: '开源模型托管推理 · OpenAI 兼容', badge: 'API' },
-    en: { name: 'DeepInfra', description: 'Hosted open-model inference · OpenAI-compatible', badge: 'API' },
-  },
-  cohere: {
-    zh: { name: 'Cohere', description: 'Cohere 官方接入', badge: 'API' },
-    en: { name: 'Cohere', description: 'Official Cohere Chat API access.', badge: 'API' },
-  },
-  vercel: {
-    zh: { name: 'Vercel AI Gateway', description: '一个密钥接入多家托管模型', badge: '网关' },
-    en: { name: 'Vercel AI Gateway', description: 'One API key for hosted models with exact creator/model ids.', badge: 'Gateway' },
-  },
-  'stepfun-ai-step-plan': {
-    zh: { name: 'StepFun Step Plan 国际站', description: '阶跃星辰订阅套餐 · 国际站', badge: 'Plan' },
-    en: { name: 'StepFun Step Plan (Global)', description: 'StepFun Global subscription for coding and agent tools.', badge: 'Plan' },
-  },
-  'cloudflare-workers-ai': {
-    zh: { name: 'Cloudflare Workers AI', description: 'Cloudflare 托管模型，账户级接入', badge: 'API' },
-    en: { name: 'Cloudflare Workers AI', description: 'Cloudflare-hosted models over the account-scoped API.', badge: 'API' },
-  },
-  huggingface: {
-    zh: { name: 'Hugging Face', description: 'Inference Providers 路由，聚合多家托管模型', badge: '路由' },
-    en: { name: 'Hugging Face', description: 'Inference Providers router across hosted models.', badge: 'Router' },
-  },
-  'ollama-cloud': {
-    zh: { name: 'Ollama Cloud', description: 'Ollama 官方云端托管模型', badge: 'API' },
-    en: { name: 'Ollama Cloud', description: 'Ollama-hosted cloud models over the official remote API.', badge: 'API' },
-  },
-  zenmux: {
-    zh: { name: 'ZenMux', description: '模型路由网关，一个密钥接入多家模型', badge: '网关' },
-    en: { name: 'ZenMux', description: 'One API key for routed models with exact creator/model ids.', badge: 'Gateway' },
-  },
-  opencode: {
-    zh: { name: 'OpenCode Zen', description: '面向编码智能体的按量模型精选', badge: 'Plan' },
-    en: { name: 'OpenCode Zen', description: 'Curated pay-as-you-go models for coding agents.', badge: 'Plan' },
-  },
-  'opencode-go': {
-    zh: { name: 'OpenCode Go', description: '低价订阅制的开源编码模型精选', badge: 'Plan' },
-    en: { name: 'OpenCode Go', description: 'Low-cost subscription to curated open coding models.', badge: 'Plan' },
-  },
-  groq: {
-    zh: { name: 'Groq', description: 'LPU 高速推理托管开源模型', badge: 'API' },
-    en: { name: 'Groq', description: 'Ultra-fast LPU-hosted open models.', badge: 'API' },
-  },
-  openrouter: {
-    zh: { name: 'OpenRouter', description: '一个密钥接入各大模型厂商 · OpenAI 兼容', badge: '聚合' },
-    en: { name: 'OpenRouter', description: 'One API key across all major model labs · OpenAI-compatible', badge: 'Aggregator' },
-  },
-  alibaba: {
-    zh: { name: 'Alibaba', description: '阿里云百炼接入，通义千问 Qwen 模型', badge: 'API' },
-    en: { name: 'Alibaba', description: 'Alibaba Cloud API access for Qwen models.', badge: 'API' },
-  },
-  // OAuth account providers (not in CATALOG_PROVIDER_TYPES; shown in the
-  // accounts section and on connection rows).
-  'github-copilot': {
-    zh: { name: 'GitHub Copilot', description: 'GitHub Copilot 订阅接入，复用本机 GitHub 登录', badge: 'Account' },
-    en: { name: 'GitHub Copilot', description: 'GitHub Copilot subscription access using an existing GitHub login.', badge: 'Account' },
-  },
-  'claude-subscription': {
-    zh: { name: 'Claude Subscription', description: 'Claude Pro / Max 订阅账号登录；登录后自动成为可用模型连接。' },
-    en: { name: 'Claude Subscription', description: 'Sign in with a Claude Pro / Max subscription; it becomes an available model connection once signed in.' },
-  },
-  'openai-codex': {
-    zh: { name: 'OpenAI OAuth', description: 'ChatGPT / Codex 账号登录；登录后自动成为可用模型连接。' },
-    en: { name: 'OpenAI OAuth', description: 'Sign in with a ChatGPT / Codex account; it becomes an available model connection once signed in.' },
-  },
-  'gemini-cli': {
-    zh: { name: 'Gemini CLI', description: 'Google 账号登录暂未接入聊天发送。' },
-    en: { name: 'Gemini CLI', description: 'Google account sign-in is not yet wired to chat.' },
-  },
-};
-
 export function providerDisplay(
   type: ProviderType,
   locale: UiLocale = detectUiLocale(),
 ): ProviderCopy {
-  const copy = PROVIDER_DISPLAY_COPY[type]?.[locale];
+  // The copy map covers every registered ProviderType at compile time
+  // (`satisfies` in provider-display-copy.ts), but a connection persisted on
+  // a branch that registers a provider this build doesn't know reaches here
+  // with an unknown type at runtime — hence the widened view and the registry
+  // fallback below. Mirrors `isFakeBackend`.
+  const copyByType = PROVIDER_DISPLAY_COPY as Partial<Record<ProviderType, Record<UiLocale, ProviderCopy>>>;
+  const copy = copyByType[type]?.[locale];
   if (copy) return copy;
-  // Unknown providerType (a connection persisted on a branch that registers a
-  // provider this build doesn't know) → fall back to the registry facts
-  // instead of crashing. Mirrors `isFakeBackend`.
   const definition = PROVIDER_DEFAULTS[type];
   return {
     name: definition?.label ?? type,

--- a/apps/desktop/src/renderer/settings/provider-display.tsx
+++ b/apps/desktop/src/renderer/settings/provider-display.tsx
@@ -1,4 +1,5 @@
 import { PROVIDER_DEFAULTS, type ProviderType } from '@maka/core';
+import { detectUiLocale, type UiLocale } from '@maka/ui';
 import { ProviderBrandMark } from './provider-brand-marks';
 
 // Kept as a thin wrapper so the many `ProviderLogo` call sites stay put.
@@ -14,52 +15,96 @@ export function ProviderLogo(props: { type: ProviderType; compact?: boolean }) {
   );
 }
 
-export function providerDisplay(type: ProviderType): { name: string; description: string; badge?: string } {
+interface ProviderCopy {
+  name: string;
+  description: string;
+  badge?: string;
+}
+
+// UI-layer provider introduction copy, localized zh / en. These stay in the
+// display layer (not the registry) because they are marketing/introduction
+// prose tuned for the catalog, not the runtime provider facts. Descriptions
+// stay version-agnostic on purpose: they name the PROVIDER and how you connect
+// (official key / protocol-compatible / local), never a specific model
+// generation — model names go stale (GPT-4o, DeepSeek-V3, …) but the provider
+// and access path do not. Brand names (Anthropic, OpenAI, …) are never
+// translated.
+const PROVIDER_DISPLAY_COPY: Partial<Record<ProviderType, Record<UiLocale, ProviderCopy>>> = {
+  siliconflow: {
+    zh: { name: 'SiliconFlow', description: '硅基流动多模型 API，支持精确模型 ID。', badge: '聚合' },
+    en: { name: 'SiliconFlow', description: 'Hosted multi-model API with exact upstream model ids.', badge: 'Aggregator' },
+  },
+  anthropic: {
+    zh: { name: 'Anthropic', description: 'Anthropic 官方接入', badge: 'API' },
+    en: { name: 'Anthropic', description: 'Official Anthropic API access.', badge: 'API' },
+  },
+  'kimi-coding-plan': {
+    zh: { name: 'Kimi Coding Plan', description: '月之暗面 · Anthropic 兼容', badge: 'Coding' },
+    en: { name: 'Kimi Coding Plan', description: 'Moonshot · Anthropic-compatible', badge: 'Coding' },
+  },
+  openai: {
+    zh: { name: 'OpenAI', description: 'OpenAI 官方接入', badge: 'API' },
+    en: { name: 'OpenAI', description: 'Official OpenAI API access.', badge: 'API' },
+  },
+  google: {
+    zh: { name: 'Google Gemini', description: 'Google AI Studio 接入', badge: 'API' },
+    en: { name: 'Google Gemini', description: 'Google AI Studio API access.', badge: 'API' },
+  },
+  deepseek: {
+    zh: { name: 'DeepSeek', description: 'DeepSeek 官方接入', badge: 'API' },
+    en: { name: 'DeepSeek', description: 'Official DeepSeek API access.', badge: 'API' },
+  },
+  moonshot: {
+    zh: { name: 'Moonshot', description: 'Moonshot 官方接入', badge: 'API' },
+    en: { name: 'Moonshot', description: 'Official Moonshot API access.', badge: 'API' },
+  },
+  'zai-coding-plan': {
+    zh: { name: 'Z.AI Coding Plan', description: '智谱 · OpenAI 兼容', badge: 'Coding' },
+    en: { name: 'Z.AI Coding Plan', description: 'Zhipu · OpenAI-compatible', badge: 'Coding' },
+  },
+  MiniMax: {
+    zh: { name: 'MiniMax', description: 'MiniMax · Anthropic 兼容', badge: 'API' },
+    en: { name: 'MiniMax', description: 'MiniMax · Anthropic-compatible', badge: 'API' },
+  },
+  'MiniMax-cn': {
+    zh: { name: 'MiniMax 中国站', description: 'MiniMax 中国站 · Anthropic 兼容', badge: 'API' },
+    en: { name: 'MiniMax China', description: 'MiniMax China · Anthropic-compatible', badge: 'API' },
+  },
+  ollama: {
+    zh: { name: 'Ollama', description: '本机运行 · 离线可用', badge: 'Local' },
+    en: { name: 'Ollama', description: 'Runs locally · works offline', badge: 'Local' },
+  },
+  'openai-compatible': {
+    zh: { name: '自定义 OpenAI 兼容接口', description: '中转站、代理服务或自部署网关。', badge: 'Custom' },
+    en: { name: 'Custom OpenAI-compatible', description: 'Relay, proxy, or self-hosted gateway.', badge: 'Custom' },
+  },
+  'claude-subscription': {
+    zh: { name: 'Claude Subscription', description: 'Claude Pro / Max 订阅账号登录；登录后自动成为可用模型连接。' },
+    en: { name: 'Claude Subscription', description: 'Sign in with a Claude Pro / Max subscription; it becomes an available model connection once signed in.' },
+  },
+  'openai-codex': {
+    zh: { name: 'OpenAI OAuth', description: 'ChatGPT / Codex 账号登录；登录后自动成为可用模型连接。' },
+    en: { name: 'OpenAI OAuth', description: 'Sign in with a ChatGPT / Codex account; it becomes an available model connection once signed in.' },
+  },
+  'gemini-cli': {
+    zh: { name: 'Gemini CLI', description: 'Google 账号登录暂未接入聊天发送。' },
+    en: { name: 'Gemini CLI', description: 'Google account sign-in is not yet wired to chat.' },
+  },
+};
+
+export function providerDisplay(
+  type: ProviderType,
+  locale: UiLocale = detectUiLocale(),
+): ProviderCopy {
+  const copy = PROVIDER_DISPLAY_COPY[type]?.[locale];
+  if (copy) return copy;
+  // Unknown providerType (a connection persisted on a branch that registers a
+  // provider this build doesn't know) → fall back to the registry facts
+  // instead of crashing. Mirrors `isFakeBackend`.
   const definition = PROVIDER_DEFAULTS[type];
-  switch (type) {
-    // Descriptions stay version-agnostic on purpose: they name the
-    // PROVIDER and how you connect (official key / protocol-compatible /
-    // local), never a specific model generation — model names go stale
-    // (GPT-4o, DeepSeek-V3, …) but the provider and access path do not.
-    case 'siliconflow':
-      return { name: 'SiliconFlow', description: '硅基流动多模型 API，支持精确模型 ID。', badge: '聚合' };
-    case 'anthropic':
-      return { name: 'Anthropic', description: 'Anthropic 官方接入', badge: 'API' };
-    case 'kimi-coding-plan':
-      return { name: 'Kimi Coding Plan', description: '月之暗面 · Anthropic 兼容', badge: 'Coding' };
-    case 'openai':
-      return { name: 'OpenAI', description: 'OpenAI 官方接入', badge: 'API' };
-    case 'google':
-      return { name: 'Google Gemini', description: 'Google AI Studio 接入', badge: 'API' };
-    case 'deepseek':
-      return { name: 'DeepSeek', description: 'DeepSeek 官方接入', badge: 'API' };
-    case 'moonshot':
-      return { name: 'Moonshot', description: 'Moonshot 官方接入', badge: 'API' };
-    case 'zai-coding-plan':
-      return { name: 'Z.AI Coding Plan', description: '智谱 · OpenAI 兼容', badge: 'Coding' };
-    case 'MiniMax':
-      return { name: 'MiniMax', description: 'MiniMax · Anthropic 兼容', badge: 'API' };
-    case 'MiniMax-cn':
-      return { name: 'MiniMax 中国站', description: 'MiniMax 中国站 · Anthropic 兼容', badge: 'API' };
-    case 'ollama':
-      return { name: 'Ollama', description: '本机运行 · 离线可用', badge: 'Local' };
-    case 'openai-compatible':
-      return { name: '自定义 OpenAI 兼容接口', description: '中转站、代理服务或自部署网关。', badge: 'Custom' };
-    case 'claude-subscription':
-      return { name: 'Claude Subscription', description: 'Claude Pro / Max 订阅账号登录；登录后自动成为可用模型连接。' };
-    case 'openai-codex':
-      return { name: 'OpenAI OAuth', description: 'ChatGPT / Codex 账号登录；登录后自动成为可用模型连接。' };
-    case 'gemini-cli':
-      return { name: 'Gemini CLI', description: 'Google 账号登录暂未接入聊天发送。' };
-    default: {
-      // Unknown providerType (a connection persisted on a branch that
-      // registers a provider this build doesn't know) → fall back to the
-      // raw type string instead of crashing. Mirrors `isFakeBackend`.
-      return {
-        name: definition?.label ?? type,
-        description: definition?.description ?? '该 provider 在当前版本未注册。',
-        ...(definition?.catalogBadge ? { badge: definition.catalogBadge } : {}),
-      };
-    }
-  }
+  return {
+    name: definition?.label ?? type,
+    description: definition?.description ?? (locale === 'en' ? 'This provider is not registered in the current build.' : '该 provider 在当前版本未注册。'),
+    ...(definition?.catalogBadge ? { badge: definition.catalogBadge } : {}),
+  };
 }

--- a/apps/desktop/src/renderer/styles/settings/provider-editor.css
+++ b/apps/desktop/src/renderer/styles/settings/provider-editor.css
@@ -92,6 +92,14 @@
 
 .providerConnectionDialog {
   width: min(520px, calc(100vw - 32px));
+  /* The shared modal popup is `grid max-h-[85dvh] overflow-hidden` with no row
+     constraint, so header/body rows size to content: when the detail content
+     outgrows 85dvh the body row overflows the popup box and is clipped, and
+     the body's own overflow-y:auto never engages (clientHeight==scrollHeight)
+     — bottom actions become unreachable. Pin the rows to header + shrinkable
+     body so the body takes over scrolling at max height. The close button is
+     absolutely positioned and stays out of grid flow. */
+  grid-template-rows: auto minmax(0, 1fr);
 }
 
 .providerConnectionDialog [data-slot="dialog-header"] {

--- a/apps/desktop/src/renderer/styles/settings/provider-editor.css
+++ b/apps/desktop/src/renderer/styles/settings/provider-editor.css
@@ -367,7 +367,6 @@
 }
 
 .providerModelChoiceRow {
-  width: 100%;
   min-height: 32px;
 }
 

--- a/apps/desktop/src/renderer/styles/settings/provider-editor.css
+++ b/apps/desktop/src/renderer/styles/settings/provider-editor.css
@@ -335,65 +335,52 @@
 
 .providerEnabledModelsHeader span,
 .providerEnabledModelMeta,
-.providerModelSearchEmpty {
+.providerModelChoiceEmpty {
   color: var(--foreground-secondary);
   font-size: var(--font-size-caption);
 }
 
-.providerModelSearchResults {
-  margin: 0;
-  padding: 0;
+/* Fixed-height scroll region: the full candidate list scrolls internally, so
+   neither the provider's model count nor an active search filter changes the
+   dialog height. */
+.providerModelChoiceScroll {
+  height: 280px;
   border: var(--border-width-hairline) solid var(--border);
   border-radius: var(--radius-surface);
   background: var(--background-elevated);
-  overflow: hidden;
+}
+
+.providerModelChoiceList {
+  display: grid;
+  gap: var(--space-0-5);
+  margin: 0;
+  padding: var(--space-1);
   list-style: none;
 }
 
-.providerModelSearchRow {
-  display: flex;
-  align-items: center;
-  min-height: 40px;
-  gap: var(--space-2);
-  border-top: var(--border-width-hairline) solid var(--border);
+.providerModelChoiceRow {
+  width: 100%;
+  min-height: 32px;
 }
 
-.providerModelSearchRow:first-child {
-  border-top: 0;
+/* Fixed check column so enabled (checkmark) and disabled (empty) rows keep
+   their labels aligned. The checkmark itself signals the enabled state and
+   inherits the crisp foreground tint (matching the model-picker selected mark). */
+.providerModelChoiceCheck {
+  width: 16px;
+  color: var(--foreground);
 }
 
-.providerModelSearchRow {
-  padding: 0 var(--space-2);
-}
-
-.providerModelSearchRow > span,
-.providerEnabledModelList > li > span:first-child {
+.providerModelChoiceLabel {
   min-width: 0;
-  flex: 1;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 
-.providerModelSearchEmpty {
+.providerModelChoiceEmpty {
   display: block;
   padding: var(--space-3);
-}
-
-.providerEnabledModelList {
-  display: grid;
-  gap: var(--space-1);
-  margin: 0;
-  padding: 0;
-  list-style: none;
-}
-
-.providerEnabledModelList > li {
-  display: flex;
-  align-items: center;
-  min-height: 32px;
-  gap: var(--space-2);
-  padding: 0 var(--space-0-5);
 }
 
 

--- a/apps/desktop/src/renderer/styles/settings/provider-editor.css
+++ b/apps/desktop/src/renderer/styles/settings/provider-editor.css
@@ -477,7 +477,7 @@
   display: grid;
   gap: var(--space-3);
   padding-top: var(--space-5);
-  border-top: var(--border-width-hairline) solid var(--border-subtle);
+  border-top: var(--border-width-hairline) solid var(--border);
 }
 
 .providerRootHeader h3 {


### PR DESCRIPTION
## Summary

Three polish items for Settings → 模型, plus one token regression fix:

- **Bilingual provider introductions.** Provider catalog copy previously mixed hardcoded Chinese (15 providers) with English registry fallbacks (the other 32). `providerDisplay()` now serves zh/en copy for every catalog provider via the existing `uiLocale` preference (`detectUiLocale()`), same pattern as the other localized surfaces. A new completeness contract (`provider-display-copy-contract.test.ts`, modeled on the icon-governance brand-mark check) fails if a new catalog provider ships without non-empty zh + en descriptions, or if an entry's locale content is swapped.
- **Stable connection-dialog height while typing an API key.** The 更新密钥 / 保存服务地址 buttons are now always mounted and disabled until dirty, and the credential status hint is a persistent single line that only swaps text across `hasSecret` states (including a new "尚未设置密钥" state). Genuine status content (connection issues, OAuth notices) may still resize.
- **Enabled-model manager shows the full catalog.** `EnabledModelManager` now persistently renders every candidate model (live-fetched merged with fallback via `buildCatalogModelChoices`, plus enabled-but-uncatalogued ids so they stay removable) as a checkbox list inside a fixed-height (280px) `OverlayScrollArea`. Enabled models read as checked, clicking toggles through the existing `enabledModelIds` path so newly enabled models reach the chat model picker immediately, the default model is checked + locked, and search filters the same list in place — so neither catalog size nor filtering changes the dialog height.
- **Token fix.** `.providerCatalogSection` referenced the undefined `--border-subtle` (same class of bug as #1047); now `var(--border)`.

Out of scope, deliberately: the connection dialog's form copy (模型密钥, 测试连接, …) stays Chinese-first as pinned by the existing a11y/copy contracts; localizing the whole dialog is a separate effort.

## Verification

- `@maka/desktop` typecheck (main + renderer + storybook): clean
- `@maka/desktop` unit tests: 2542 pass / 0 fail (includes the new display-copy contract and updated model-oauth / settings-form-a11y / session-sticky-model / renderer-utility-primitives contracts)
- `@maka/core` build + provider-catalog contract: pass
- `check-copy` / `check-a11y` / `check-console`: OK
- providers E2E (Playwright, fake backend): 4/4 pass — the canonical journey now also asserts the dialog's bounding-box height is unchanged while a key is typed and while the model list is filtered, and exercises the checkbox list (default row checked + disabled, toggling a candidate persists)

<img width="2976" height="626" alt="image" src="https://github.com/user-attachments/assets/1c866833-cf21-44a4-ba49-99d04965ea88" />

<img width="2176" height="1656" alt="image" src="https://github.com/user-attachments/assets/1af36250-ed07-4663-8ad6-ce6320335ca7" />

<img width="4256" height="1124" alt="image" src="https://github.com/user-attachments/assets/62bdacdb-eb57-4be3-b30a-fb34ea03d2cb" />
