### PR TITLE
feat(cli): add muted color slot and disc primitive for TUI grammar

### DIFF
--- a/packages/cli/src/__tests__/tui-ansi.test.ts
+++ b/packages/cli/src/__tests__/tui-ansi.test.ts
@@ -1,0 +1,29 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+import { ansi, disc, stripAnsi } from '../tui-ansi.js';
+
+describe('tui-ansi semantic slots (#1053)', () => {
+  test('muted is a truecolor cool-grey slot', () => {
+    assert.equal(ansi.muted('x'), '\x1b[38;2;128;132;140mx\x1b[39m');
+  });
+});
+
+describe('disc (#1053)', () => {
+  test('renders a single ● glyph regardless of tone', () => {
+    for (const tone of ['muted', 'accent', 'danger'] as const) {
+      assert.equal(stripAnsi(disc(tone)), '●', `tone ${tone} should yield one ●`);
+    }
+  });
+
+  test('done (muted) disc uses the muted cool-grey', () => {
+    assert.equal(disc('muted'), '\x1b[38;2;128;132;140m●\x1b[39m');
+  });
+
+  test('running (accent) disc uses the logo blue', () => {
+    assert.equal(disc('accent'), '\x1b[38;2;87;163;239m●\x1b[39m');
+  });
+
+  test('error (danger) disc uses standard red', () => {
+    assert.equal(disc('danger'), '\x1b[31m●\x1b[39m');
+  });
+});

--- a/packages/cli/src/tui-ansi.ts
+++ b/packages/cli/src/tui-ansi.ts
@@ -3,6 +3,9 @@ import type { EditorTheme, SelectListTheme } from '@earendil-works/pi-tui';
 // PR #496: desktop --accent = oklch(0.70 0.135 250), rendered here as truecolor ANSI.
 const MAKA_LOGO_BLUE_RGB = [87, 163, 239] as const;
 
+// #1053: neutral cool-grey for muted chrome — done discs and de-emphasised text.
+const MUTED_RGB = [128, 132, 140] as const;
+
 export const ansi = {
   bold: style(1, 22),
   dim: style(2, 22),
@@ -13,8 +16,20 @@ export const ansi = {
   green: style(32, 39),
   yellow: style(33, 39),
   accent: rgb(...MAKA_LOGO_BLUE_RGB),
+  muted: rgb(...MUTED_RGB),
   reverse: style(7, 27),
 };
+
+// #1053: status disc — a single `●` tinted by tone. The shared visual primitive
+// for the transcript's tool rows: muted = done, accent = running, danger = error.
+export type DiscTone = 'muted' | 'accent' | 'danger';
+
+const DISC_GLYPH = '●';
+
+export function disc(tone: DiscTone): string {
+  const color = tone === 'muted' ? ansi.muted : tone === 'accent' ? ansi.accent : ansi.red;
+  return color(DISC_GLYPH);
+}
 
 export function stripAnsi(text: string): string {
   return text.replace(/\x1b\[[0-9;?]*[ -/]*[@-~]/g, '');


### PR DESCRIPTION
## Summary

Foundation layer (seam 1) for #1053 — semantic color slots in `packages/cli/src/tui-ansi.ts`. Adds:

- `ansi.muted` — a truecolor neutral cool-grey slot for de-emphasised chrome.
- `disc(tone)` — a status disc primitive (a single `●` tinted by tone: `muted` = done, `accent` = running, `danger` = error), the shared visual primitive that the tool-row and chrome seams (#1053 seams 2/3/5) will consume.

Pure addition, no call-site changes, no behavior change — this lands the contract so the consumer seams can reference it directly. The first visible consumer is seam 2 (tool cards).

## Verification

- `npm test --workspace maka-agent` — 364 tests pass, including 5 new string-contract tests for `muted` and `disc` (glyph is always a single `●`; each tone maps to the exact ANSI sequence).
- No existing renderer changed; zero regressions.

No visible TUI change in this PR by design.

Refs #1053.

<img width="1204" height="1048" alt="image" src="https://github.com/user-attachments/assets/df991cae-cdcc-4083-a182-b5a4e2285a75" />
