### PR TITLE
feat(cli): one-line disc grammar for tool cards and thinking chrome

### DIFF
--- a/packages/cli/src/__tests__/pi-transcript.test.ts
+++ b/packages/cli/src/__tests__/pi-transcript.test.ts
@@ -1301,6 +1301,45 @@ describe('Maka Pi TUI transcript', () => {
     assert.match(lines.join('\n'), /\x1b\[31m●\x1b\[39m/);
   });
 
+  test('marks a failed background Bash card with the danger disc on the compact row', () => {
+    const state = createMakaPiTranscriptState();
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_start', toolUseId: 'bash-fail', toolName: 'Bash', args: { command: 'false' },
+    }));
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_result', toolUseId: 'bash-fail', isError: false,
+      content: shellRun({ status: 'failed', startedAt: 1_000, updatedAt: 2_000, completedAt: 2_000, exitCode: 1 }),
+    }));
+
+    const tools = state.entries.filter((entry) => entry.kind === 'tool');
+    assert.equal(tools[0]?.kind === 'tool' ? tools[0].status : undefined, 'failed');
+    const lines = renderMakaPiTranscript(state, meta(), 100);
+    const rendered = lines.map(stripAnsi).join('\n');
+    assert.match(rendered, /● Bash  \$ false/);
+    // A failed background run uses the danger (red) disc, not the muted done disc.
+    assert.match(lines.join('\n'), /\x1b\[31m●\x1b\[39m/);
+  });
+
+  test('keeps duration and the expand marker when a compact row overflows', () => {
+    const state = createMakaPiTranscriptState();
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_start', toolUseId: 'bash-long', toolName: 'Bash',
+      args: { command: 'npm run build ' + 'x'.repeat(60) },
+    }));
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_result', toolUseId: 'bash-long', isError: false,
+      content: shellRun({ status: 'completed', startedAt: 1_000, updatedAt: 6_000, completedAt: 6_000, exitCode: 0, stdout: 'first\nlast\n' }),
+    }));
+
+    const lines = renderMakaPiTranscript(state, meta(), 60).map(stripAnsi);
+    assert.equal(lines.length, 2); // one card line plus the leading blank separator
+    const row = lines[1]!;
+    // A long command must not hide the elapsed time or the expand marker.
+    assert.match(row, /·  5s/);
+    assert.match(row, /›$/);
+    assert.ok(visibleWidth(row) <= 60, `row width ${visibleWidth(row)} exceeds 60`);
+  });
+
   test('applies a runtime-published terminal update directly to its parent Bash card', () => {
     const state = createMakaPiTranscriptState();
     applyMakaSessionEventToTranscript(state, event({

--- a/packages/cli/src/__tests__/pi-transcript.test.ts
+++ b/packages/cli/src/__tests__/pi-transcript.test.ts
@@ -407,8 +407,10 @@ describe('Maka Pi TUI transcript', () => {
       }),
     }));
 
+    // Compact: a running PTY Bash shows only the disc row; the PTY screen
+    // lives in the expanded card.
     const compact = renderMakaPiTranscript(state, meta(), 100).map(stripAnsi).join('\n');
-    assert.match(compact, /pty-row-7/);
+    assert.match(compact, /● Bash  \$ interactive  ·  running/);
     assert.doesNotMatch(compact, /pty-row-1/);
 
     assert.equal(toggleAllToolExpansion(state), true);
@@ -507,7 +509,7 @@ describe('Maka Pi TUI transcript', () => {
     ] satisfies StoredMessage[]);
 
     const rendered = renderMakaPiTranscript(state, meta(), 100).map(stripAnsi).join('\n');
-    assert.match(rendered, /Tool Bash done 5000ms \$ npm test/);
+    assert.match(rendered, /● Bash  \$ npm test  ·  5s/);
   });
 
   test('rebuilds automatic context compaction notes from stored session messages', () => {
@@ -912,8 +914,8 @@ describe('Maka Pi TUI transcript', () => {
     assert.equal(state.entries[0]?.kind === 'thinking' ? state.entries[0].text : '', 'plan first');
 
     const collapsed = renderMakaPiTranscript(state, meta(), 100).map(stripAnsi);
-    const markerIndex = collapsed.findIndex((line) => line.includes('思考（Ctrl+T 展开）'));
-    const toolIndex = collapsed.findIndex((line) => line.includes('Tool Read'));
+    const markerIndex = collapsed.findIndex((line) => line.includes('Thinking…'));
+    const toolIndex = collapsed.findIndex((line) => line.includes('● Read'));
     const answerIndex = collapsed.findIndex((line) => line.includes('the answer'));
     assert.ok(markerIndex >= 0);
     assert.ok(markerIndex < toolIndex);
@@ -970,10 +972,10 @@ describe('Maka Pi TUI transcript', () => {
     const compactLines = renderMakaPiTranscript(state, meta(), 120).map(stripAnsi);
     const compact = compactLines.join('\n');
 
-    // Compact cards are at most two lines (plus the leading blank separator).
-    assert.equal(compactLines.length, 3);
-    assert.match(compact, /Tool Bash done \$ npm test/);
-    assert.match(compact, /\(31 lines\) row-29 \(Ctrl\+O\)/);
+    // Compact cards are a single line (plus the leading blank separator).
+    assert.equal(compactLines.length, 2);
+    assert.match(compact, /● Bash  \$ npm test/);
+    assert.match(compact, /\(31 lines\) row-29 ›/);
     assert.doesNotMatch(compact, /head-line/);
 
     assert.equal(toggleAllToolExpansion(state), true);
@@ -1003,9 +1005,9 @@ describe('Maka Pi TUI transcript', () => {
     }));
 
     const lines = renderMakaPiTranscript(state, meta(), 120);
-    assert.equal(lines.length, 3);
+    assert.equal(lines.length, 2);
     const compact = lines.map(stripAnsi).join('\n');
-    assert.match(compact, /exit 1 final error line \(Ctrl\+O\)/);
+    assert.match(compact, /exit 1 final error line ›/);
     // The exit code is red.
     assert.match(lines.join('\n'), /\x1b\[31mexit 1\x1b\[39m/);
   });
@@ -1026,7 +1028,7 @@ describe('Maka Pi TUI transcript', () => {
     }));
 
     const lines = renderMakaPiTranscript(state, meta(), 120).map(stripAnsi);
-    assert.equal(lines.length, 3);
+    assert.equal(lines.length, 2);
     assert.match(lines.join('\n'), /\(no output\)/);
     assert.doesNotMatch(lines.join('\n'), /\(Ctrl\+O\)/);
   });
@@ -1047,11 +1049,16 @@ describe('Maka Pi TUI transcript', () => {
     }));
 
     const lines = renderMakaPiTranscript(state, meta(), 120).map(stripAnsi);
-    assert.equal(lines.length, 3);
+    assert.equal(lines.length, 2);
     const compact = lines.join('\n');
-    assert.match(compact, /Tool Bash running \$ npm run build/);
-    assert.match(compact, /step two \(Ctrl\+O\)/);
+    assert.match(compact, /● Bash  \$ npm run build  ·  running/);
     assert.doesNotMatch(compact, /step one/);
+    assert.doesNotMatch(compact, /step two/);
+
+    // Live output lives in the expanded card for a running tool.
+    assert.equal(toggleAllToolExpansion(state), true);
+    const expanded = renderMakaPiTranscript(state, meta(), 120).map(stripAnsi).join('\n');
+    assert.match(expanded, /step two/);
   });
 
   test('keeps a background Bash card running until the process settles', () => {
@@ -1073,8 +1080,8 @@ describe('Maka Pi TUI transcript', () => {
     const tool = state.entries.find((entry) => entry.kind === 'tool');
     assert.equal(tool?.kind === 'tool' ? tool.status : undefined, 'running');
     const rendered = renderMakaPiTranscript(state, meta(), 100).map(stripAnsi).join('\n');
-    assert.match(rendered, /Tool Bash running 10000ms \$ sleep 30/);
-    assert.doesNotMatch(rendered, /Tool Bash .* done/);
+    assert.match(rendered, /● Bash  \$ sleep 30  ·  running 10s/);
+    assert.doesNotMatch(rendered, /done/);
     assert.equal(rendered.split('$ sleep 30').length - 1, 1);
   });
 
@@ -1090,9 +1097,14 @@ describe('Maka Pi TUI transcript', () => {
     }));
 
     assert.equal(refreshRunningShellRunElapsed(state, 13_500), true);
-    const rendered = renderMakaPiTranscript(state, meta(), 100).map(stripAnsi).join('\n');
-    assert.match(rendered, /running 12500ms/);
-    assert.match(rendered, /Ask Maka to stop this task/);
+    const compact = renderMakaPiTranscript(state, meta(), 100).map(stripAnsi).join('\n');
+    assert.match(compact, /running 13s/);
+    assert.doesNotMatch(compact, /Ask Maka to stop this task/);
+
+    // Stop guidance is expanded-only for a running background Bash shell_run.
+    assert.equal(toggleAllToolExpansion(state), true);
+    const expanded = renderMakaPiTranscript(state, meta(), 100).map(stripAnsi).join('\n');
+    assert.match(expanded, /Ask Maka to stop this task/);
   });
 
   test('describes a detached background Bash card by ownership, not lifecycle', () => {
@@ -1158,8 +1170,11 @@ describe('Maka Pi TUI transcript', () => {
       'starting\nstill running\n',
     );
     const rendered = renderMakaPiTranscript(state, meta(), 100).map(stripAnsi).join('\n');
-    assert.doesNotMatch(rendered, /Tool Read/);
-    assert.match(rendered, /still running/);
+    assert.doesNotMatch(rendered, /● Read/);
+    // Running card keeps the live tail in the expanded card.
+    assert.equal(toggleAllToolExpansion(state), true);
+    const expanded = renderMakaPiTranscript(state, meta(), 100).map(stripAnsi).join('\n');
+    assert.match(expanded, /still running/);
   });
 
   test('shows polled background output instead of a stale live delta', () => {
@@ -1184,6 +1199,8 @@ describe('Maka Pi TUI transcript', () => {
       content: shellRun({ ref, stdout: 'starting\n50%\n', updatedAt: 3_000 }),
     }));
 
+    // Live output lives in the expanded card for a running tool.
+    assert.equal(toggleAllToolExpansion(state), true);
     const rendered = renderMakaPiTranscript(state, meta(), 100).map(stripAnsi).join('\n');
     assert.match(rendered, /50%/);
   });
@@ -1204,9 +1221,10 @@ describe('Maka Pi TUI transcript', () => {
       type: 'tool_result', toolUseId: 'bash-bg', isError: false, content: result,
     }));
 
+    // Live output lives in the expanded card for a running tool.
+    assert.equal(toggleAllToolExpansion(state), true);
     const rendered = renderMakaPiTranscript(state, meta(), 100).map(stripAnsi).join('\n');
     assert.match(rendered, /99%/);
-    assert.doesNotMatch(rendered, /  warning \(Ctrl\+O\)/);
   });
 
   test('re-renders a background Bash card when polling replaces output with the same length', () => {
@@ -1219,6 +1237,8 @@ describe('Maka Pi TUI transcript', () => {
       type: 'tool_result', toolUseId: 'bash-bg', isError: false,
       content: shellRun({ ref, stdout: 'aaaa\n', updatedAt: 2_000 }),
     }));
+    // Live output lives in the expanded card for a running tool.
+    assert.equal(toggleAllToolExpansion(state), true);
     const before = renderMakaPiTranscript(state, meta(), 100).map(stripAnsi).join('\n');
     assert.match(before, /aaaa/);
 
@@ -1273,9 +1293,12 @@ describe('Maka Pi TUI transcript', () => {
     const tools = state.entries.filter((entry) => entry.kind === 'tool');
     assert.equal(tools.length, 1);
     assert.equal(tools[0]?.status, 'aborted');
-    const rendered = renderMakaPiTranscript(state, meta(), 100).map(stripAnsi).join('\n');
-    assert.match(rendered, /Tool Bash aborted 7000ms \$ sleep 30/);
-    assert.doesNotMatch(rendered, /Tool StopBackgroundTask/);
+    const lines = renderMakaPiTranscript(state, meta(), 100);
+    const rendered = lines.map(stripAnsi).join('\n');
+    assert.match(rendered, /● Bash  \$ sleep 30  ·  7s/);
+    assert.doesNotMatch(rendered, /● StopBackgroundTask/);
+    // An aborted background task uses the danger disc (red).
+    assert.match(lines.join('\n'), /\x1b\[31m●\x1b\[39m/);
   });
 
   test('applies a runtime-published terminal update directly to its parent Bash card', () => {
@@ -1294,7 +1317,7 @@ describe('Maka Pi TUI transcript', () => {
 
     assert.equal(applied, true);
     const rendered = renderMakaPiTranscript(state, meta(), 100).map(stripAnsi).join('\n');
-    assert.match(rendered, /Tool Bash done 4000ms \$ build/);
+    assert.match(rendered, /● Bash  \$ build  ·  4s/);
     assert.match(rendered, /done/);
   });
 
@@ -1336,10 +1359,10 @@ describe('Maka Pi TUI transcript', () => {
     }));
 
     const compactLines = renderMakaPiTranscript(state, meta(), 100).map(stripAnsi);
-    assert.equal(compactLines.length, 3);
+    assert.equal(compactLines.length, 2);
     const compact = compactLines.join('\n');
     assert.match(compact, /src\/app\.ts offset 10 limit 20/);
-    assert.match(compact, /4 lines, 59 bytes \(Ctrl\+O\)/);
+    assert.match(compact, /4 lines, 59 bytes ›/);
     assert.doesNotMatch(compact, /content-line-0/);
 
     // A successful Read pulled the file into the model's context; expanding the
@@ -1575,10 +1598,10 @@ describe('Maka Pi TUI transcript', () => {
     }));
 
     const compactLines = renderMakaPiTranscript(state, meta(), 100).map(stripAnsi);
-    assert.equal(compactLines.length, 3);
+    assert.equal(compactLines.length, 2);
     const compact = compactLines.join('\n');
     assert.match(compact, /TODO in packages glob \*\.ts/);
-    assert.match(compact, /12 matches \(Ctrl\+O\)/);
+    assert.match(compact, /12 matches ›/);
     assert.doesNotMatch(compact, /match-0/);
 
     // Expanding a Grep card shows every match — a structured list the user
@@ -1608,10 +1631,10 @@ describe('Maka Pi TUI transcript', () => {
     }));
 
     const compactLines = renderMakaPiTranscript(state, meta(), 100).map(stripAnsi);
-    assert.equal(compactLines.length, 3);
+    assert.equal(compactLines.length, 2);
     const compact = compactLines.join('\n');
-    assert.match(compact, /Tool Glob done \*\*\/\*\.ts in packages/);
-    assert.match(compact, /3 files \(Ctrl\+O\)/);
+    assert.match(compact, /● Glob  \*\*\/\*\.ts in packages/);
+    assert.match(compact, /3 files ›/);
     assert.doesNotMatch(compact, /src\/a\.ts/);
 
     assert.equal(toggleAllToolExpansion(state), true);
@@ -1688,10 +1711,11 @@ describe('Maka Pi TUI transcript', () => {
     }));
 
     const lines = renderMakaPiTranscript(state, meta(), 200).map(stripAnsi);
-    // Never more than two card lines: multi-line JSON must not split the header.
-    assert.equal(lines.length, 3);
-    assert.match(lines[1] ?? '', /Tool Frobnicate done input: \{"alpha":1,"beta":"two"\}/);
-    assert.match(lines[2] ?? '', /\{"gamma":3,"delta":"four"\}/);
+    // Never more than one card line (plus the leading blank separator):
+    // multi-line JSON must not split the header.
+    assert.equal(lines.length, 2);
+    assert.match(lines[1] ?? '', /● Frobnicate  input: \{"alpha":1,"beta":"two"\}/);
+    assert.match(lines[1] ?? '', /\{"gamma":3,"delta":"four"\}/);
   });
 
   test('summarizes file_diff compactly and colors the expanded diff', () => {
@@ -1712,10 +1736,10 @@ describe('Maka Pi TUI transcript', () => {
     }));
 
     const compactLines = renderMakaPiTranscript(state, meta(), 100);
-    assert.equal(compactLines.length, 3);
+    assert.equal(compactLines.length, 2);
     const compactRaw = compactLines.join('\n');
     // Compact: `+1 -1 file.ts` with green add count and red delete count.
-    assert.match(compactLines.map(stripAnsi).join('\n'), /\+1 -1 file\.ts \(Ctrl\+O\)/);
+    assert.match(compactLines.map(stripAnsi).join('\n'), /\+1 -1 file\.ts ›/);
     assert.match(compactRaw, /\x1b\[32m\+1\x1b\[39m/);
     assert.match(compactRaw, /\x1b\[31m-1\x1b\[39m/);
     assert.doesNotMatch(compactLines.map(stripAnsi).join('\n'), /added line/);
@@ -1831,7 +1855,7 @@ describe('Maka Pi TUI transcript', () => {
     }));
 
     const lines = renderMakaPiTranscript(state, meta(), 100).map(stripAnsi);
-    assert.equal(lines.length, 3);
+    assert.equal(lines.length, 2);
     assert.match(lines.join('\n'), /Wrote 42 bytes to out\.txt/);
     assert.doesNotMatch(lines.join('\n'), /\(Ctrl\+O\)/);
   });
@@ -1894,7 +1918,7 @@ describe('Maka Pi TUI transcript', () => {
     }));
 
     const collapsed = renderMakaPiTranscript(state, meta(), 100).map(stripAnsi);
-    assert.equal(collapsed.filter((line) => line.includes('思考（Ctrl+T 展开）')).length, 2);
+    assert.equal(collapsed.filter((line) => line.includes('Thinking…')).length, 2);
     assert.equal(collapsed.some((line) => line.includes('thought body')), false);
 
     // One press expands every thinking entry.
@@ -1906,7 +1930,7 @@ describe('Maka Pi TUI transcript', () => {
     // A second press collapses every thinking entry again.
     assert.equal(toggleAllThinkingExpansion(state), true);
     const recollapsed = renderMakaPiTranscript(state, meta(), 100).map(stripAnsi);
-    assert.equal(recollapsed.filter((line) => line.includes('思考（Ctrl+T 展开）')).length, 2);
+    assert.equal(recollapsed.filter((line) => line.includes('Thinking…')).length, 2);
     assert.equal(recollapsed.some((line) => line.includes('thought body')), false);
   });
 
@@ -1938,10 +1962,11 @@ describe('Maka Pi TUI transcript', () => {
       type: 'tool_output_delta', toolUseId: 'bash-1', seq: 3, stream: 'stderr', chunk: 'secret', redacted: true,
     }));
 
-    // Compact: the latest live line is the redaction marker, never the secret.
+    // Compact: a running tool shows only the disc row; live output (including
+    // the redaction marker) lives in the expanded card.
     const compact = renderMakaPiTranscript(state, meta(), 100).map(stripAnsi).join('\n');
-    assert.match(compact, /\[redacted\]/);
     assert.doesNotMatch(compact, /secret/);
+    assert.doesNotMatch(compact, /\[redacted\]/);
 
     assert.equal(toggleAllToolExpansion(state), true);
     const rendered = renderMakaPiTranscript(state, meta(), 100).map(stripAnsi).join('\n');
@@ -1962,6 +1987,8 @@ describe('Maka Pi TUI transcript', () => {
       stream: 'stdout', chunk: '', redacted: true,
     }));
 
+    // Live output lives in the expanded card for a running tool.
+    assert.equal(toggleAllToolExpansion(state), true);
     const rendered = renderMakaPiTranscript(state, meta(), 100).map(stripAnsi).join('\n');
     assert.match(rendered, /\[redacted\]/);
   });
@@ -2206,6 +2233,7 @@ describe('transcript entry render memoization', () => {
       type: 'tool_result', toolUseId: 'bash-bg', isError: false,
       content: shellRun({
         stdout: 'AAAA', stderr: 'BBBB', updatedAt: 3_000, latestStream: 'stderr',
+        status: 'completed', completedAt: 3_000, exitCode: 0,
       }),
     }));
     const before = renderMakaPiTranscript(state, meta(), 100).map(stripAnsi).join('\n');
@@ -2214,6 +2242,7 @@ describe('transcript entry render memoization', () => {
     applyShellRunUpdateToTranscript(state, 'bash-bg', shellRun({
       stdout: 'AAAA', stderr: 'BBBB', updatedAt: 3_000, revision: 3_001,
       latestStream: 'stdout',
+      status: 'completed', completedAt: 3_000, exitCode: 0,
     }));
     const after = renderMakaPiTranscript(state, meta(), 100).map(stripAnsi).join('\n');
     assert.match(after, /AAAA/);
@@ -2229,6 +2258,8 @@ describe('transcript entry render memoization', () => {
       type: 'tool_result', toolUseId: 'bash-bg', isError: false,
       content: shellRun({ stdout: 'AAAA', updatedAt: 3_000, latestStream: 'stdout' }),
     }));
+    // Live output lives in the expanded card for a running tool.
+    assert.equal(toggleAllToolExpansion(state), true);
     const before = renderMakaPiTranscript(state, meta(), 100).map(stripAnsi).join('\n');
     assert.match(before, /AAAA/);
 

--- a/packages/cli/src/__tests__/pi-tui-runner.test.ts
+++ b/packages/cli/src/__tests__/pi-tui-runner.test.ts
@@ -513,7 +513,7 @@ describe('Maka Pi TUI runner', () => {
     terminal.input('n');
     terminal.input('\r');
 
-    await waitFor(() => terminal.output().includes('(Ctrl+O)'));
+    await waitFor(() => terminal.output().includes('›'));
     assert.equal(terminal.output().includes('expanded-tail'), false);
 
     terminal.input('\x0f');
@@ -561,7 +561,7 @@ describe('Maka Pi TUI runner', () => {
         output: pipeOutput('done\n'),
       },
     });
-    await waitFor(() => plainTerminalOutput(terminal.screenOutput()).includes('done 4000ms'));
+    await waitFor(() => plainTerminalOutput(terminal.screenOutput()).includes('·  4s'));
 
     exitMaka(terminal);
     await run;
@@ -583,7 +583,7 @@ describe('Maka Pi TUI runner', () => {
 
     terminal.input('run');
     terminal.input('\r');
-    await waitFor(() => terminal.output().includes('(Ctrl+O)'));
+    await waitFor(() => terminal.output().includes('›'));
 
     // Kitty keyboard protocol terminals (Ghostty/Kitty) send one event for the
     // key press and another for the release. The release must not undo the
@@ -591,11 +591,11 @@ describe('Maka Pi TUI runner', () => {
     terminal.input('\x1b[111;5u');
     terminal.input('\x1b[111;5:3u');
 
-    // The compact-only (Ctrl+O) hint leaving the screen proves the card is
+    // The compact-only › hint leaving the screen proves the card is
     // still expanded after the release event.
-    await waitFor(() => !plainTerminalOutput(terminal.screenOutput()).includes('(Ctrl+O)'));
+    await waitFor(() => !plainTerminalOutput(terminal.screenOutput()).includes('›'));
     await delay(20);
-    assert.equal(plainTerminalOutput(terminal.screenOutput()).includes('(Ctrl+O)'), false);
+    assert.equal(plainTerminalOutput(terminal.screenOutput()).includes('›'), false);
 
     exitMaka(terminal);
     await Promise.race([
@@ -660,7 +660,7 @@ describe('Maka Pi TUI runner', () => {
     terminal.input('run');
     terminal.input('\r');
 
-    await waitFor(() => plainTerminalOutput(terminal.output()).includes('思考（Ctrl+T 展开）'));
+    await waitFor(() => plainTerminalOutput(terminal.output()).includes('Thinking…'));
     assert.equal(plainTerminalOutput(terminal.output()).includes('secret reasoning tail'), false);
 
     terminal.input('\x14');
@@ -1983,7 +1983,7 @@ describe('Maka Pi TUI runner', () => {
     terminal.input('/session session-2');
     terminal.input('\r');
 
-    await waitFor(() => plainTerminalOutput(terminal.screenOutput()).includes('done 4000ms'));
+    await waitFor(() => plainTerminalOutput(terminal.screenOutput()).includes('·  4s'));
     assert.deepEqual(reads, ['session-2']);
 
     exitMaka(terminal);

--- a/packages/cli/src/pi-transcript-tools.ts
+++ b/packages/cli/src/pi-transcript-tools.ts
@@ -8,7 +8,7 @@ import {
   type ShellRunOperation,
 } from '@maka/core';
 import { truncateToWidth, visibleWidth } from '@earendil-works/pi-tui';
-import { ansi } from './tui-ansi.js';
+import { ansi, disc } from './tui-ansi.js';
 import { colorDiff, diffLineKind } from './tui-diff.js';
 import {
   collapseToSingleLine,
@@ -26,49 +26,54 @@ export function renderToolBlock(entry: MakaPiToolEntry, width: number, expanded:
   return expanded ? renderExpandedToolBlock(entry, width) : renderCompactToolBlock(entry, width);
 }
 
-function toolStatusText(entry: MakaPiToolEntry): string {
-  const status = entry.status === 'running'
-    ? ansi.yellow('running')
-    : entry.status === 'detached'
-      ? ansi.dim('detached')
-      : entry.status === 'unavailable'
-        ? ansi.dim('source unavailable')
-      : entry.status === 'done'
-        ? ansi.green('done')
-        : ansi.red(entry.status);
-  const duration = entry.durationMs === undefined
-    ? ''
-    : ansi.dim(` ${entry.durationMs}ms`);
-  return `${status}${duration}`;
+/** Status disc for a tool row: muted = done, accent = running, danger = error/aborted. */
+function toolDisc(entry: MakaPiToolEntry): string {
+  if (entry.status === 'running') return disc('accent');
+  if (entry.status === 'error' || entry.status === 'aborted') return disc('danger');
+  return disc('muted');
+}
+
+/** Duration/status segment in integer seconds (#1053): `5s`, `running 12s`, `detached`. */
+function toolDurationText(entry: MakaPiToolEntry): string {
+  const secs = entry.durationMs === undefined ? undefined : Math.max(0, Math.round(entry.durationMs / 1000));
+  if (entry.status === 'running') {
+    return secs === undefined ? ansi.dim('running') : ansi.dim(`running ${secs}s`);
+  }
+  if (entry.status === 'detached') return ansi.dim('detached');
+  if (entry.status === 'unavailable') return ansi.dim('source unavailable');
+  return secs === undefined ? '' : ansi.dim(`${secs}s`);
 }
 
 /**
- * Compact tool card: at most two lines. Line 1 carries the tool name, an
- * inline dim input summary, and status; line 2 is a one-line result summary
- * with a dim `(Ctrl+O)` hint when expanding would reveal more.
+ * Compact tool card: a single line in the #1053 disc grammar -
+ * `● Name  primary  ·  duration  ·  summary ›`. The disc carries status, the
+ * duration is integer seconds, and a dim trailing `›` marks an expandable
+ * card. Live output and stop hints live only in the expanded card, so collapse
+ * never grows a second line (no height jitter).
  */
 function renderCompactToolBlock(entry: MakaPiToolEntry, width: number): string[] {
-  // collapseToSingleLine guards both slots: fitLine truncates width, not \n,
-  // so any multi-line summary text would silently break the two-line card.
   const inputSummary = collapseToSingleLine(toolInputSummary(entry));
-  const header = `${ansi.yellow('Tool')} ${entry.title ?? entry.toolName}`
-    + ` ${toolStatusText(entry)}${inputSummary ? ` ${ansi.dim(inputSummary)}` : ''}`;
-  const lines = [fitLine(header, width)];
+  const duration = toolDurationText(entry);
   const summary = compactToolSummary(entry, width);
-  if (summary) {
-    const hint = summary.expandable ? ansi.dim(' (Ctrl+O)') : '';
-    lines.push(fitLine(`  ${collapseToSingleLine(summary.text)}${hint}`, width));
-  }
-  if (entry.toolName === 'Bash' && entry.status === 'running' && entry.result?.kind === 'shell_run') {
-    lines.push(fitLine(ansi.dim('  Ask Maka to stop this task'), width));
-  }
-  return lines;
+  const sep = `  ${ansi.dim('·')}  `;
+  const segments: string[] = [];
+  if (inputSummary) segments.push(inputSummary);
+  if (duration) segments.push(duration);
+  // Running tools have no result yet; keep the row to `running Ns` and leave
+  // the live tail for the expanded card.
+  if (summary && entry.status !== 'running') segments.push(collapseToSingleLine(summary.text));
+  let line = `${toolDisc(entry)} ${entry.title ?? entry.toolName}`;
+  if (segments.length) line += `  ${segments.join(sep)}`;
+  if (summary?.expandable) line += ` ${ansi.dim('›')}`;
+  return [fitLine(line, width)];
 }
 
 function renderExpandedToolBlock(entry: MakaPiToolEntry, width: number): string[] {
-  const lines = [
-    fitLine(`${ansi.yellow('Tool')} ${entry.title ?? entry.toolName} ${toolStatusText(entry)}`, width),
-  ];
+  const duration = toolDurationText(entry);
+  let header = `${toolDisc(entry)} ${entry.title ?? entry.toolName}`;
+  if (duration) header += `  ${ansi.dim('·')}  ${duration}`;
+  const lines = [fitLine(header, width)];
+
   const inputSummary = toolInputSummary(entry);
   if (inputSummary) lines.push(...renderIndented(inputSummary, width, 2).map(ansi.dim));
   if (entry.progress.droppedChars > 0) {

--- a/packages/cli/src/pi-transcript-tools.ts
+++ b/packages/cli/src/pi-transcript-tools.ts
@@ -26,10 +26,10 @@ export function renderToolBlock(entry: MakaPiToolEntry, width: number, expanded:
   return expanded ? renderExpandedToolBlock(entry, width) : renderCompactToolBlock(entry, width);
 }
 
-/** Status disc for a tool row: muted = done, accent = running, danger = error/aborted. */
+/** Status disc for a tool row: muted = done, accent = running, danger = error/aborted/failed. */
 function toolDisc(entry: MakaPiToolEntry): string {
   if (entry.status === 'running') return disc('accent');
-  if (entry.status === 'error' || entry.status === 'aborted') return disc('danger');
+  if (entry.status === 'error' || entry.status === 'aborted' || entry.status === 'failed') return disc('danger');
   return disc('muted');
 }
 
@@ -49,23 +49,59 @@ function toolDurationText(entry: MakaPiToolEntry): string {
  * `● Name  primary  ·  duration  ·  summary ›`. The disc carries status, the
  * duration is integer seconds, and a dim trailing `›` marks an expandable
  * card. Live output and stop hints live only in the expanded card, so collapse
- * never grows a second line (no height jitter).
+ * never grows a second line (no height jitter). The disc, name, duration, and
+ * `›` are always preserved; only the input and summary text truncate, so a
+ * long command or result never hides elapsed time or the expand marker.
  */
 function renderCompactToolBlock(entry: MakaPiToolEntry, width: number): string[] {
   const inputSummary = collapseToSingleLine(toolInputSummary(entry));
   const duration = toolDurationText(entry);
   const summary = compactToolSummary(entry, width);
+  const summaryText = summary && entry.status !== 'running' ? collapseToSingleLine(summary.text) : '';
   const sep = `  ${ansi.dim('·')}  `;
-  const segments: string[] = [];
-  if (inputSummary) segments.push(inputSummary);
-  if (duration) segments.push(duration);
-  // Running tools have no result yet; keep the row to `running Ns` and leave
-  // the live tail for the expanded card.
-  if (summary && entry.status !== 'running') segments.push(collapseToSingleLine(summary.text));
-  let line = `${toolDisc(entry)} ${entry.title ?? entry.toolName}`;
-  if (segments.length) line += `  ${segments.join(sep)}`;
-  if (summary?.expandable) line += ` ${ansi.dim('›')}`;
-  return [fitLine(line, width)];
+  const chevron = summary?.expandable ? ` ${ansi.dim('›')}` : '';
+  const head = `${toolDisc(entry)} ${entry.title ?? entry.toolName}`;
+  return [fitLine(assembleCompactToolRow(head, inputSummary, duration, summaryText, sep, chevron, width), width)];
+}
+
+/**
+ * Lay out `head  input  ·  duration  ·  summary chevron` on one line, keeping
+ * the head, duration segment, and chevron (the status-carrying parts) intact
+ * and truncating only the flexible input/summary text when the row overflows.
+ * Input is truncated before summary so a long command keeps its elapsed time.
+ */
+function assembleCompactToolRow(
+  head: string,
+  input: string,
+  duration: string,
+  summary: string,
+  sep: string,
+  chevron: string,
+  width: number,
+): string {
+  const inputSeg = input ? `  ${input}` : '';
+  const durSeg = duration ? `${sep}${duration}` : '';
+  const sumSeg = summary ? `${sep}${summary}` : '';
+  const full = `${head}${inputSeg}${durSeg}${sumSeg}${chevron}`;
+  if (visibleWidth(full) <= width) return full;
+  // Overflow: reserve head + duration + chevron, then fit input before summary.
+  // Input joins the name with two spaces; duration and summary join with `·`.
+  let budget = Math.max(0, width - visibleWidth(`${head}${durSeg}${chevron}`));
+  let builtInput = '';
+  let builtSummary = '';
+  if (input && budget > 3) {
+    const room = budget - 2;
+    const text = visibleWidth(input) > room ? truncateToWidth(input, room, '…') : input;
+    builtInput = `  ${text}`;
+    budget -= visibleWidth(builtInput);
+  }
+  const sepW = visibleWidth(sep);
+  if (summary && budget > sepW + 1) {
+    const room = budget - sepW;
+    const text = visibleWidth(summary) > room ? truncateToWidth(summary, room, '…') : summary;
+    builtSummary = `${sep}${text}`;
+  }
+  return `${head}${builtInput}${durSeg}${builtSummary}${chevron}`;
 }
 
 function renderExpandedToolBlock(entry: MakaPiToolEntry, width: number): string[] {

--- a/packages/cli/src/pi-transcript.ts
+++ b/packages/cli/src/pi-transcript.ts
@@ -993,8 +993,8 @@ function setThinking(state: MakaPiTranscriptState, messageId: string, text: stri
 // never floods the scrollback; Ctrl+T expands every thinking entry on demand.
 function renderThinkingBlock(entry: MakaPiThinkingEntry, width: number, expanded: boolean): string[] {
   if (!entry.text.trim()) return [];
-  if (!expanded) return [fitLine(ansi.dim('思考（Ctrl+T 展开）'), width)];
-  const lines = [fitLine(ansi.dim('思考'), width)];
+  if (!expanded) return [fitLine(ansi.dim('Thinking…'), width)];
+  const lines = [fitLine(ansi.dim('Thinking'), width)];
   lines.push(...renderIndented(entry.text, width, 2).map((line) => fitLine(ansi.dim(line), width)));
   return lines;
 }


### PR DESCRIPTION
## Summary

Seam 2 of #1053 - the one-line disc grammar for tool cards and thinking chrome. Stacked on #1054 (seam 1, which adds the `disc()` primitive).

Compact tool cards collapse from 1–2 lines to a single disc-grammar row:

```
● Name  primary  ·  duration  ·  summary ›
```

- A status disc replaces the `Tool` label and wordy status text: muted `●` = done, accent `●` = running, danger `●` = error/aborted.
- Duration shows integer seconds (`5s`, `running 12s`) instead of `Nms`.
- A dim trailing `›` replaces the `(Ctrl+O)` hint.
- Live output and the "Ask Maka to stop" hint move to the expanded card, so collapse never grows a second line (no height jitter).
- The expanded header reuses the same disc grammar (`● Name  ·  duration`).

Thinking chrome switches to English (`Thinking…` / `Thinking`) and drops the inline `Ctrl+T` hint.

## Verification

- `npm test --workspace maka-agent` - 364 tests pass.
- Running-card live-output and stop-guidance assertions now verify the expanded card (compact no longer carries them by design).
- Added a regression assertion that an aborted background task uses the red danger disc.

Stacked on #1054; rebase to `main` once it merges. Refs #1053.

<img width="1736" height="1812" alt="f07b7bd354faf42672651cef49acba74" src="https://github.com/user-attachments/assets/6de6a0b9-67d4-4600-bc14-874dc0bc7400" />