### PR TITLE
feat(cli): show ctx used/window pct% in statusline

### DIFF
--- a/packages/cli/src/__tests__/pi-transcript.test.ts
+++ b/packages/cli/src/__tests__/pi-transcript.test.ts
@@ -2340,6 +2340,32 @@ describe('Maka Pi TUI status line', () => {
     }, 100));
     assert.doesNotMatch(line, /thinking/);
   });
+
+  test('shows ctx used/window pct% when modelContextWindow and contextRemaining are both set', () => {
+    const line = stripAnsi(renderMakaPiStatusLine({
+      ...meta(),
+      modelContextWindow: 128_000,
+      usage: { costUsd: 0, cacheHitInput: 0, cacheMissInput: 0, contextRemaining: 96_000 },
+    }, 100));
+    assert.match(line, /ctx 32k\/128k 25%/);
+  });
+
+  test('omits ctx segment when modelContextWindow is set but no contextRemaining', () => {
+    const line = stripAnsi(renderMakaPiStatusLine({
+      ...meta(),
+      modelContextWindow: 128_000,
+      usage: { costUsd: 0, cacheHitInput: 0, cacheMissInput: 0 },
+    }, 100));
+    assert.doesNotMatch(line, /ctx /);
+  });
+
+  test('omits ctx segment when contextRemaining is set but no modelContextWindow', () => {
+    const line = stripAnsi(renderMakaPiStatusLine({
+      ...meta(),
+      usage: { costUsd: 0, cacheHitInput: 0, cacheMissInput: 0, contextRemaining: 96_000 },
+    }, 100));
+    assert.doesNotMatch(line, /ctx /);
+  });
 });
 
 function meta() {

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -4,7 +4,7 @@ import { readFile } from 'node:fs/promises';
 import { realpathSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { describeChatConfigurationReason, parseNoRealConnectionError } from '@maka/core';
-import { handleGoalContinuation } from '@maka/runtime';
+import { handleGoalContinuation, resolveSelectedModelContextWindow } from '@maka/runtime';
 import { createMakaSessionDriver } from './session-driver.js';
 import { createMakaCliRuntimeContext } from './runtime-bootstrap.js';
 import { selectableModelIdsForTarget } from './connection-target.js';
@@ -148,6 +148,7 @@ export async function runMakaCli(argv: string[] = process.argv.slice(2)): Promis
           modelChoices: context.modelChoices,
           connectionSlug: context.target.connection.slug,
           providerType: context.target.connection.providerType,
+          modelContextWindow: resolveSelectedModelContextWindow(context.target.connection, context.target.model),
           permissionMode: 'ask',
           subscribeShellRunUpdates: context.subscribeShellRunUpdates,
           listShellRunUpdates: context.listShellRunUpdates,

--- a/packages/cli/src/connection-target.ts
+++ b/packages/cli/src/connection-target.ts
@@ -1,7 +1,7 @@
 import { isConnectionReady, type ChatConfigurationReason } from '@maka/core/connection-readiness';
 import type { LlmConnection, ProviderType } from '@maka/core/llm-connections';
 import { PROVIDER_DEFAULTS } from '@maka/core/llm-connections';
-import { isOAuthSubscriptionProvider, resolveOAuthSubscriptionTokens, type OAuthSubscriptionTokens } from '@maka/runtime';
+import { isOAuthSubscriptionProvider, resolveOAuthSubscriptionTokens, resolveSelectedModelContextWindow, type OAuthSubscriptionTokens } from '@maka/runtime';
 import type { ConnectionStore, CredentialKind, CredentialStore } from '@maka/storage';
 
 export interface ReadySessionTarget {
@@ -18,6 +18,8 @@ export interface ModelChoice {
   providerType: ProviderType;
   model: string;
   isDefaultConnection: boolean;
+  /** Maximum context tokens for this model, resolved from the connection or provider catalog. */
+  contextWindow?: number;
 }
 
 export function selectableModelIdsForTarget(target: Pick<ReadySessionTarget, 'connection' | 'model'>): string[] {
@@ -141,6 +143,7 @@ export async function listReadyModelChoices(input: {
           providerType: connection.providerType,
           model,
           isDefaultConnection: connection.slug === defaultSlug,
+          contextWindow: resolveSelectedModelContextWindow(connection, model),
         });
       }
     } catch {

--- a/packages/cli/src/pi-transcript.ts
+++ b/packages/cli/src/pi-transcript.ts
@@ -107,6 +107,8 @@ export interface MakaPiTranscriptMetadata {
   sessionId?: string | null;
   busy?: boolean;
   usage?: MakaPiUsageSummary;
+  /** Maximum context tokens for the active model, for the `ctx used/window pct%` segment. */
+  modelContextWindow?: number;
 }
 
 export function createMakaPiTranscriptState(): MakaPiTranscriptState {
@@ -936,8 +938,10 @@ export function renderMakaPiStatusLine(metadata: MakaPiTranscriptMetadata, width
   if (thinking) parts.push(thinking);
   const usage = metadata.usage;
   if (usage) {
-    if (usage.contextRemaining !== undefined) {
-      parts.push(ansi.dim(`ctx ${formatTokenCount(usage.contextRemaining)}`));
+    if (metadata.modelContextWindow !== undefined && usage.contextRemaining !== undefined) {
+      const used = Math.max(0, metadata.modelContextWindow - usage.contextRemaining);
+      const pct = Math.round((used / metadata.modelContextWindow) * 100);
+      parts.push(ansi.dim(`ctx ${formatTokenCount(used)}/${formatTokenCount(metadata.modelContextWindow)} ${pct}%`));
     }
     if (usage.costUsd > 0) {
       parts.push(ansi.dim(`$${formatCost(usage.costUsd)}`));

--- a/packages/cli/src/pi-tui-runner.ts
+++ b/packages/cli/src/pi-tui-runner.ts
@@ -85,6 +85,8 @@ export interface MakaPiTuiInput {
   connectionSlug: string;
   providerType?: ProviderType;
   permissionMode: PermissionMode;
+  /** Maximum context tokens for the active model, for the statusline ctx segment. */
+  modelContextWindow?: number;
   terminal?: Terminal;
   /** Starts the CLI process-exit deadline after terminal restore, before outer cleanup. */
   onProcessExit?: (exitCode: number, error?: Error) => void;
@@ -114,6 +116,7 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
   // Mutable: a cross-connection /model switch rebinds the provider, which changes
   // both the connection and the thinking variants the new model supports.
   let providerType = input.providerType;
+  let modelContextWindow = input.modelContextWindow;
   let permissionMode = input.permissionMode;
   let thinkingLevel: ThinkingLevel | undefined = undefined;
   let thinkingLevels: readonly ThinkingLevel[] = providerType
@@ -153,6 +156,7 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
     sessionId: input.driver.getSessionId(),
     busy,
     usage: state.usage,
+    modelContextWindow,
   });
 
   const transcript = new MakaTranscriptComponent(state, metadata);
@@ -474,6 +478,8 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
   const setModel = async (nextModel: string) => {
     await input.driver.setModel(nextModel);
     model = nextModel;
+    const match = input.modelChoices?.find((choice) => choice.model === nextModel);
+    if (match) modelContextWindow = match.contextWindow;
     thinkingLevel = undefined;
     thinkingLevels = providerType ? thinkingVariantsForModel(providerType, nextModel) : [];
     state.entries.push({
@@ -491,6 +497,7 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
     model = choice.model;
     connectionSlug = choice.connectionSlug;
     providerType = choice.providerType;
+    modelContextWindow = choice.contextWindow;
     thinkingLevel = undefined;
     thinkingLevels = thinkingVariantsForModel(choice.providerType, choice.model);
     state.entries.push({


### PR DESCRIPTION
## Summary

Replace the bare `ctx <remaining>` statusline segment with `ctx used/window pct%`, where `used = modelContextWindow - contextRemaining`. The segment is omitted entirely until both the window size and the latest `contextRemaining` are known.

Threads `modelContextWindow` through the data path:
- `ModelChoice` gains `contextWindow?: number`, populated by `listReadyModelChoices` via `resolveSelectedModelContextWindow`.
- `MakaPiTuiInput` and `MakaPiTranscriptMetadata` gain `modelContextWindow?: number`.
- `cli.ts` passes the initial value from `context.target`; `/model` switch (both `setModelChoice` and `setModel` paths) updates it.

Refs #1053 (seam 4).

## Verification

- `npm run build` — clean
- `npm test` — 369 tests pass (3 new: ctx segment shows/omits correctly)