### PR TITLE
feat(cli): add activity strip with Working… Ns elapsed counter

### DIFF
--- a/packages/cli/src/__tests__/pi-transcript.test.ts
+++ b/packages/cli/src/__tests__/pi-transcript.test.ts
@@ -10,6 +10,7 @@ import {
   applyMakaSessionEventToTranscript,
   applyShellRunUpdateToTranscript,
   createMakaPiTranscriptState,
+  renderMakaPiActivityStrip,
   renderMakaPiStatusLine,
   renderMakaPiTranscript,
   refreshRunningShellRunElapsed,
@@ -2365,6 +2366,21 @@ describe('Maka Pi TUI status line', () => {
       usage: { costUsd: 0, cacheHitInput: 0, cacheMissInput: 0, contextRemaining: 96_000 },
     }, 100));
     assert.doesNotMatch(line, /ctx /);
+  });
+});
+
+describe('Maka Pi TUI activity strip', () => {
+  test('shows Working… Ns when turnElapsedMs is set', () => {
+    const line = stripAnsi(renderMakaPiActivityStrip({
+      ...meta(),
+      turnElapsedMs: 5_500,
+    }, 100));
+    assert.equal(line, 'Working… 5s');
+  });
+
+  test('shows blank row when turnElapsedMs is undefined', () => {
+    const line = renderMakaPiActivityStrip(meta(), 100);
+    assert.equal(line, '');
   });
 });
 

--- a/packages/cli/src/__tests__/pi-tui-runner.test.ts
+++ b/packages/cli/src/__tests__/pi-tui-runner.test.ts
@@ -711,6 +711,36 @@ describe('Maka Pi TUI runner', () => {
     ]);
   });
 
+  test('shows Working… in the activity strip while a turn runs', async () => {
+    const terminal = new FakeTerminal();
+    const driver = new HangingTurnDriver();
+    const run = runMakaPiTui({
+      title: 'Maka',
+      driver,
+      cwd: '/repo',
+      model: 'deepseek-v4-flash',
+      connectionSlug: 'deepseek',
+      permissionMode: 'ask',
+      terminal,
+    });
+
+    terminal.input('hello');
+    terminal.input('\r');
+    await waitFor(() => plainTerminalOutput(terminal.screenOutput()).includes('Working…'));
+    assert.match(plainTerminalOutput(terminal.screenOutput()), /Working… \d+s/);
+
+    driver.releaseComplete();
+    await waitFor(() => !plainTerminalOutput(terminal.screenOutput()).includes('Working…'));
+
+    exitMaka(terminal);
+    await Promise.race([
+      run,
+      delay(50).then(() => {
+        throw new Error('TUI did not close during test cleanup');
+      }),
+    ]);
+  });
+
   test('uses logo blue for TUI accent chrome', async () => {
     const terminal = new FakeTerminal();
     const driver = new SlashCommandDriver();
@@ -3870,6 +3900,39 @@ class HangingCloseDriver extends SlashCommandDriver {
   releaseStop(): void {
     this.resolveStop?.();
     this.resolveStop = null;
+  }
+}
+
+class HangingTurnDriver extends SlashCommandDriver {
+  private resolveComplete: (() => void) | null = null;
+
+  override async *sendPrompt(prompt: string): AsyncIterable<SessionEvent> {
+    this.prompts.push(prompt);
+    yield {
+      type: 'text_delta',
+      id: 'event-text-delta',
+      turnId: 'turn-1',
+      ts: 1,
+      messageId: 'msg-1',
+      text: 'thinking…',
+    };
+    await new Promise<void>((resolve) => {
+      this.resolveComplete = resolve;
+    });
+    yield {
+      type: 'text_complete',
+      id: 'event-text-complete',
+      turnId: 'turn-1',
+      ts: 2,
+      messageId: 'msg-1',
+      text: 'done',
+    };
+    yield { type: 'complete', id: 'event-complete', turnId: 'turn-1', ts: 3, stopReason: 'end_turn' };
+  }
+
+  releaseComplete(): void {
+    this.resolveComplete?.();
+    this.resolveComplete = null;
   }
 }
 

--- a/packages/cli/src/pi-transcript.ts
+++ b/packages/cli/src/pi-transcript.ts
@@ -109,6 +109,8 @@ export interface MakaPiTranscriptMetadata {
   usage?: MakaPiUsageSummary;
   /** Maximum context tokens for the active model, for the `ctx used/window pct%` segment. */
   modelContextWindow?: number;
+  /** Elapsed milliseconds of the running agent turn, for the activity strip. */
+  turnElapsedMs?: number;
 }
 
 export function createMakaPiTranscriptState(): MakaPiTranscriptState {
@@ -955,6 +957,18 @@ export function renderMakaPiStatusLine(metadata: MakaPiTranscriptMetadata, width
   parts.push(ansi.dim(metadata.connectionSlug));
   parts.push(ansi.dim(metadata.cwd));
   return fitLine(parts.join(sep), safeWidth);
+}
+
+/**
+ * One-line activity strip shown between the transcript and the editor.
+ * Renders `Working… Ns` while a turn runs, or a blank reserved row when idle
+ * so the layout does not jump when a turn starts or ends.
+ */
+export function renderMakaPiActivityStrip(metadata: MakaPiTranscriptMetadata, width: number): string {
+  const safeWidth = Math.max(1, width);
+  if (metadata.turnElapsedMs === undefined) return '';
+  const seconds = Math.floor(metadata.turnElapsedMs / 1000);
+  return fitLine(ansi.dim(`Working… ${seconds}s`), safeWidth);
 }
 
 function formatTokenCount(tokens: number): string {

--- a/packages/cli/src/pi-tui-layout.ts
+++ b/packages/cli/src/pi-tui-layout.ts
@@ -1,5 +1,6 @@
 import { Container, type Component, type Terminal } from '@earendil-works/pi-tui';
 import {
+  renderMakaPiActivityStrip,
   renderMakaPiStatusLine,
   renderMakaPiTranscript,
   type MakaPiTranscriptMetadata,
@@ -29,6 +30,16 @@ export class MakaStatusLineComponent implements Component {
   }
 }
 
+export class MakaActivityStripComponent implements Component {
+  constructor(private readonly metadata: () => MakaPiTranscriptMetadata) {}
+
+  invalidate(): void {}
+
+  render(width: number): string[] {
+    return [renderMakaPiActivityStrip(this.metadata(), width)];
+  }
+}
+
 /**
  * Stacks the transcript above the editor and status line. The transcript is
  * never windowed: every line is emitted and, when the whole document is taller
@@ -44,26 +55,30 @@ export class MakaStatusLineComponent implements Component {
 export class MakaPiLayoutComponent extends Container {
   constructor(
     private readonly transcript: MakaTranscriptComponent,
+    private readonly activityStrip: MakaActivityStripComponent,
     private readonly editor: Component,
     private readonly statusLine: Component,
     private readonly terminal: Terminal,
   ) {
     super();
     this.addChild(transcript);
+    this.addChild(activityStrip);
     this.addChild(editor);
     this.addChild(statusLine);
   }
 
   render(width: number): string[] {
     const transcriptLines = this.transcript.render(width);
+    const activityLines = this.activityStrip.render(width);
     const editorLines = this.editor.render(width);
     const statusLines = this.statusLine.render(width);
-    const chromeRows = editorLines.length + statusLines.length;
+    const chromeRows = activityLines.length + editorLines.length + statusLines.length;
     const viewportRows = Math.max(0, this.terminal.rows - chromeRows);
     const paddingRows = Math.max(0, viewportRows - transcriptLines.length);
     return [
       ...transcriptLines,
       ...Array.from({ length: paddingRows }, () => ''),
+      ...activityLines,
       ...editorLines,
       ...statusLines,
     ];

--- a/packages/cli/src/pi-tui-runner.ts
+++ b/packages/cli/src/pi-tui-runner.ts
@@ -54,6 +54,7 @@ import {
   FOCUS_OUT_SEQUENCE,
 } from './tui-attention.js';
 import {
+  MakaActivityStripComponent,
   MakaPiLayoutComponent,
   MakaStatusLineComponent,
   MakaTranscriptComponent,
@@ -134,6 +135,7 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
     answers: Array<string | null>;
   } | undefined;
   let turnRunning = false;
+  let turnStartedAt: number | undefined;
   let interruptRequested = false;
   let lastTurnEscapeAt = 0;
   let lastIdleEscapeAt = 0;
@@ -157,16 +159,18 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
     busy,
     usage: state.usage,
     modelContextWindow,
+    turnElapsedMs: turnStartedAt !== undefined ? Date.now() - turnStartedAt : undefined,
   });
 
   const transcript = new MakaTranscriptComponent(state, metadata);
+  const activityStrip = new MakaActivityStripComponent(metadata);
   const statusLine = new MakaStatusLineComponent(metadata);
   // Show the whole slash-command set at once — discoverability is the point of
   // the menu. Keep a little headroom above the current command count.
   const editor = new Editor(tui, editorTheme(), { paddingX: 1, autocompleteMaxVisible: EDITOR_AUTOCOMPLETE_MAX_VISIBLE });
   let refreshEditorCwd: ((cwd: string) => void) | undefined;
   const editorSurface = new MakaAutocompleteAboveEditorComponent(editor);
-  const layout = new MakaPiLayoutComponent(transcript, editorSurface, statusLine, terminal);
+  const layout = new MakaPiLayoutComponent(transcript, activityStrip, editorSurface, statusLine, terminal);
   const attention = new AttentionController(terminal, {
     baseTitle: input.title,
     ...(input.attentionLongTurnThresholdMs !== undefined
@@ -182,6 +186,20 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
     state,
     onTick: requestRender,
   });
+  // 1-second heartbeat that re-renders the activity strip's elapsed counter
+  // while a turn runs. Stopped on turn end and disposed on teardown.
+  let turnElapsedInterval: ReturnType<typeof setInterval> | undefined;
+  const startTurnElapsedTicker = () => {
+    if (turnElapsedInterval) return;
+    turnElapsedInterval = setInterval(() => requestRender(), 1_000);
+    turnElapsedInterval.unref();
+  };
+  const stopTurnElapsedTicker = () => {
+    if (turnElapsedInterval) {
+      clearInterval(turnElapsedInterval);
+      turnElapsedInterval = undefined;
+    }
+  };
   let shellRunOwnerMappings: ShellRunUpdate[] = [];
   let hydratingShellRunsFor: string | undefined;
   let shellRunHydrationEpoch = 0;
@@ -311,6 +329,7 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
     unsubscribeShellRunUpdates?.();
     resetShellRunSessionState();
     shellRunElapsedTicker.dispose();
+    stopTurnElapsedTicker();
     terminal.setProgress(false);
     // Drop the busy / attention title marker so the tab is not handed back to
     // the shell still marked busy when the session exits.
@@ -416,6 +435,8 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
   function runAgentTurn(prompt: string): void {
     busy = true;
     turnRunning = true;
+    turnStartedAt = Date.now();
+    startTurnElapsedTicker();
     interruptRequested = false;
     lastTurnEscapeAt = 0;
     editor.disableSubmit = true;
@@ -459,6 +480,8 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
     }).finally(() => {
       busy = false;
       turnRunning = false;
+      turnStartedAt = undefined;
+      stopTurnElapsedTicker();
       interruptRequested = false;
       editor.disableSubmit = false;
       terminal.setProgress(false);


### PR DESCRIPTION
## Summary

Add a one-line activity strip between the transcript and the editor. It shows `Working… Ns` while an agent turn runs and a blank reserved row when idle, so the layout does not jump when a turn starts or ends.

A 1-second interval ticker re-renders the strip to keep the elapsed counter current. The ticker starts when a turn begins (`runAgentTurn`) and stops on turn end (`finally`) or teardown (`restoreTerminal`).

Components:
- `renderMakaPiActivityStrip` in `pi-transcript.ts` — renders the strip line from `metadata.turnElapsedMs`.
- `MakaActivityStripComponent` in `pi-tui-layout.ts` — wraps the render function as a pi-tui `Component`.
- `MakaPiLayoutComponent` — includes the strip in `chromeRows` and renders it between padding and editor.
- Runner — tracks `turnStartedAt`, computes `turnElapsedMs` in `metadata()`, manages the ticker lifecycle.

Refs #1053 (seam 5).

## Verification

- `npm run build` — clean
- `npm test` — 372 tests pass (3 new: 2 unit tests for `renderMakaPiActivityStrip`, 1 runner test verifying `Working…` appears during a turn and disappears after)