### PR TITLE
fix(cli): statusline density, color fallback, and activity-strip spacing

### DIFF
--- a/packages/cli/src/__tests__/pi-transcript.test.ts
+++ b/packages/cli/src/__tests__/pi-transcript.test.ts
@@ -2351,16 +2351,10 @@ describe('Maka Pi TUI status line', () => {
     assert.match(line, /ctx 32k\/128k 25%/);
   });
 
-  test('falls back to lastInput for ctx when contextRemaining is absent (#1064)', () => {
-    const line = stripAnsi(renderMakaPiStatusLine({
-      ...meta(),
-      modelContextWindow: 128_000,
-      usage: { costUsd: 0, cacheHitInput: 0, cacheMissInput: 0, lastInput: 52_000 },
-    }, 100));
-    assert.match(line, /ctx 52k\/128k 41%/);
-  });
-
-  test('omits ctx segment when modelContextWindow is set but no contextRemaining and no lastInput', () => {
+  test('omits ctx segment when modelContextWindow is set but no contextRemaining (#1064)', () => {
+    // token_usage.input is a billing-cumulative sum across tool-loop steps,
+    // not the last request's context size, so it cannot serve as a proxy
+    // for "used context". The ctx segment is omitted rather than misleading.
     const line = stripAnsi(renderMakaPiStatusLine({
       ...meta(),
       modelContextWindow: 128_000,

--- a/packages/cli/src/__tests__/pi-transcript.test.ts
+++ b/packages/cli/src/__tests__/pi-transcript.test.ts
@@ -2319,12 +2319,12 @@ describe('Maka Pi TUI status line', () => {
     assert.match(line, /thinking:high/);
   });
 
-  test('shows thinking:default when thinkingLevel is unset but levels are available', () => {
+  test('omits thinking:default when thinkingLevel is unset but levels are available (#1064)', () => {
     const line = stripAnsi(renderMakaPiStatusLine({
       ...meta(),
       thinkingLevels: ['off', 'low', 'medium', 'high', 'max'],
     }, 100));
-    assert.match(line, /thinking:default/);
+    assert.doesNotMatch(line, /thinking/);
   });
 
   test('omits thinking segment when no levels are available', () => {
@@ -2351,13 +2351,73 @@ describe('Maka Pi TUI status line', () => {
     assert.match(line, /ctx 32k\/128k 25%/);
   });
 
-  test('omits ctx segment when modelContextWindow is set but no contextRemaining', () => {
+  test('falls back to lastInput for ctx when contextRemaining is absent (#1064)', () => {
+    const line = stripAnsi(renderMakaPiStatusLine({
+      ...meta(),
+      modelContextWindow: 128_000,
+      usage: { costUsd: 0, cacheHitInput: 0, cacheMissInput: 0, lastInput: 52_000 },
+    }, 100));
+    assert.match(line, /ctx 52k\/128k 41%/);
+  });
+
+  test('omits ctx segment when modelContextWindow is set but no contextRemaining and no lastInput', () => {
     const line = stripAnsi(renderMakaPiStatusLine({
       ...meta(),
       modelContextWindow: 128_000,
       usage: { costUsd: 0, cacheHitInput: 0, cacheMissInput: 0 },
     }, 100));
     assert.doesNotMatch(line, /ctx /);
+  });
+
+  test('ctx segment uses yellow when usage >80% (#1064)', () => {
+    const raw = renderMakaPiStatusLine({
+      ...meta(),
+      modelContextWindow: 128_000,
+      usage: { costUsd: 0, cacheHitInput: 0, cacheMissInput: 0, contextRemaining: 12_800 },
+    }, 100);
+    // 115200/128000 = 90% → yellow (\x1b[33m)
+    assert.ok(raw.includes('\x1b[33m'), 'ctx segment should use yellow at >80%');
+  });
+
+  test('ctx segment uses red when usage >95% (#1064)', () => {
+    const raw = renderMakaPiStatusLine({
+      ...meta(),
+      modelContextWindow: 128_000,
+      usage: { costUsd: 0, cacheHitInput: 0, cacheMissInput: 0, contextRemaining: 3_200 },
+    }, 100);
+    // 124800/128000 = 97.5% → red (\x1b[31m)
+    assert.ok(raw.includes('\x1b[31m'), 'ctx segment should use red at >95%');
+  });
+
+  test('ctx segment uses dim when usage <=80% (#1064)', () => {
+    const raw = renderMakaPiStatusLine({
+      ...meta(),
+      modelContextWindow: 128_000,
+      usage: { costUsd: 0, cacheHitInput: 0, cacheMissInput: 0, contextRemaining: 96_000 },
+    }, 100);
+    // 25% → dim (\x1b[2m), not yellow or red
+    assert.ok(raw.includes('\x1b[2m'), 'ctx segment should use dim at <=80%');
+    assert.ok(!raw.includes('\x1b[33m'), 'ctx segment should not use yellow at <=80%');
+    assert.ok(!raw.includes('\x1b[31m'), 'ctx segment should not use red at <=80%');
+  });
+
+  test('shortens cwd to ~-relative path when under home (#1064)', () => {
+    const home = process.env.HOME ?? '';
+    if (home) {
+      const line = stripAnsi(renderMakaPiStatusLine({
+        ...meta(),
+        cwd: `${home}/workspace/project`,
+      }, 120));
+      assert.match(line, /~\/workspace\/project/);
+    }
+  });
+
+  test('leaves cwd unchanged when not under home (#1064)', () => {
+    const line = stripAnsi(renderMakaPiStatusLine({
+      ...meta(),
+      cwd: '/tmp/project',
+    }, 120));
+    assert.match(line, /\/tmp\/project/);
   });
 
   test('omits ctx segment when contextRemaining is set but no modelContextWindow', () => {

--- a/packages/cli/src/__tests__/pi-tui-runner.test.ts
+++ b/packages/cli/src/__tests__/pi-tui-runner.test.ts
@@ -1537,8 +1537,10 @@ describe('Maka Pi TUI runner', () => {
       terminal,
     });
 
+    // #1064: thinking:default is no longer shown — only an explicitly set
+    // thinkingLevel appears. The status line omits the thinking segment.
     await waitFor(() => plainTerminalOutput(terminal.output()).includes(
-      'Maka · ask · glm-5.2 · thinking:default · ollama-cloud · /repo',
+      'Maka · ask · glm-5.2 · ollama-cloud · /repo',
     ));
 
     exitMaka(terminal);

--- a/packages/cli/src/__tests__/tui-ansi.test.ts
+++ b/packages/cli/src/__tests__/tui-ansi.test.ts
@@ -5,6 +5,7 @@ import {
   disc,
   stripAnsi,
   _setColorLevelForTesting,
+  _detectColorLevelForTesting as detect,
 } from '../tui-ansi.js';
 
 // Reset to truecolor (the development default) after each test so a test that
@@ -90,5 +91,54 @@ describe('color capability fallback (#1064)', () => {
     assert.equal(ansi.bold('x'), 'x');
     assert.equal(ansi.dim('x'), 'x');
     assert.equal(ansi.yellow('x'), 'x');
+  });
+});
+
+describe('detectColorLevel env detection (#1064)', () => {
+  test('NO_COLOR with non-empty value → level 0', () => {
+    assert.equal(detect({ NO_COLOR: '1', TERM: 'xterm-256color', COLORTERM: 'truecolor' }), 0);
+    assert.equal(detect({ NO_COLOR: '0', TERM: 'xterm-256color' }), 0);
+  });
+
+  test('NO_COLOR with empty string → color still enabled (per spec)', () => {
+    assert.equal(detect({ NO_COLOR: '', TERM: 'xterm-256color', COLORTERM: 'truecolor' }), 3);
+  });
+
+  test('NO_COLOR unset → color enabled', () => {
+    assert.equal(detect({ TERM: 'xterm-256color', COLORTERM: 'truecolor' }), 3);
+  });
+
+  test('TERM=dumb → level 0', () => {
+    assert.equal(detect({ TERM: 'dumb' }), 0);
+  });
+
+  test('TERM unset/empty → level 0', () => {
+    assert.equal(detect({}), 0);
+    assert.equal(detect({ TERM: '' }), 0);
+  });
+
+  test('COLORTERM=truecolor → level 3', () => {
+    assert.equal(detect({ TERM: 'xterm-256color', COLORTERM: 'truecolor' }), 3);
+    assert.equal(detect({ TERM: 'xterm', COLORTERM: '24bit' }), 3);
+  });
+
+  test('TERM ending with -truecolor → level 3', () => {
+    assert.equal(detect({ TERM: 'xterm-truecolor' }), 3);
+    assert.equal(detect({ TERM: 'tmux-24bit' }), 3);
+  });
+
+  test('TERM with 256color (no COLORTERM) → level 2', () => {
+    assert.equal(detect({ TERM: 'xterm-256color' }), 2);
+    assert.equal(detect({ TERM: 'screen-256color' }), 2);
+  });
+
+  test('TERM with 256color + COLORTERM=truecolor → level 3 (COLORTERM wins)', () => {
+    assert.equal(detect({ TERM: 'xterm-256color', COLORTERM: 'truecolor' }), 3);
+  });
+
+  test('Generic TERM (xterm, screen, rxvt) → level 1', () => {
+    assert.equal(detect({ TERM: 'xterm' }), 1);
+    assert.equal(detect({ TERM: 'screen' }), 1);
+    assert.equal(detect({ TERM: 'rxvt-unicode' }), 1);
   });
 });

--- a/packages/cli/src/__tests__/tui-ansi.test.ts
+++ b/packages/cli/src/__tests__/tui-ansi.test.ts
@@ -1,29 +1,94 @@
 import assert from 'node:assert/strict';
-import { describe, test } from 'node:test';
-import { ansi, disc, stripAnsi } from '../tui-ansi.js';
+import { afterEach, describe, test } from 'node:test';
+import {
+  ansi,
+  disc,
+  stripAnsi,
+  _setColorLevelForTesting,
+} from '../tui-ansi.js';
+
+// Reset to truecolor (the development default) after each test so a test that
+// changes the level never leaks into the next one.
+afterEach(() => _setColorLevelForTesting(3));
 
 describe('tui-ansi semantic slots (#1053)', () => {
   test('muted is a truecolor cool-grey slot', () => {
+    _setColorLevelForTesting(3);
     assert.equal(ansi.muted('x'), '\x1b[38;2;128;132;140mx\x1b[39m');
   });
 });
 
 describe('disc (#1053)', () => {
   test('renders a single ● glyph regardless of tone', () => {
+    _setColorLevelForTesting(3);
     for (const tone of ['muted', 'accent', 'danger'] as const) {
       assert.equal(stripAnsi(disc(tone)), '●', `tone ${tone} should yield one ●`);
     }
   });
 
   test('done (muted) disc uses the muted cool-grey', () => {
+    _setColorLevelForTesting(3);
     assert.equal(disc('muted'), '\x1b[38;2;128;132;140m●\x1b[39m');
   });
 
   test('running (accent) disc uses the logo blue', () => {
+    _setColorLevelForTesting(3);
     assert.equal(disc('accent'), '\x1b[38;2;87;163;239m●\x1b[39m');
   });
 
   test('error (danger) disc uses standard red', () => {
+    _setColorLevelForTesting(3);
     assert.equal(disc('danger'), '\x1b[31m●\x1b[39m');
+  });
+});
+
+describe('color capability fallback (#1064)', () => {
+  test('level 3 (truecolor) emits 24-bit RGB escapes', () => {
+    _setColorLevelForTesting(3);
+    assert.equal(ansi.accent('x'), '\x1b[38;2;87;163;239mx\x1b[39m');
+    assert.equal(ansi.muted('x'), '\x1b[38;2;128;132;140mx\x1b[39m');
+  });
+
+  test('level 2 (256-color) downgrades to nearest 256-color palette entry', () => {
+    _setColorLevelForTesting(2);
+    // Logo blue [87, 163, 239] → cube: r=1(95), g=3(175), b=5(255)
+    // → 16 + 1*36 + 3*6 + 5 = 16 + 36 + 18 + 5 = 75
+    assert.equal(ansi.accent('x'), '\x1b[38;5;75mx\x1b[39m');
+    // Muted grey [128, 132, 140] → cube: r=2(135), g=2(135), b=2(135)
+    // → 16 + 2*36 + 2*6 + 2 = 16 + 72 + 12 + 2 = 102
+    assert.equal(ansi.muted('x'), '\x1b[38;5;102mx\x1b[39m');
+  });
+
+  test('level 1 (16-color) downgrades to nearest ANSI 16-color entry', () => {
+    _setColorLevelForTesting(1);
+    // Logo blue [87, 163, 239] → nearest is white (7) → code 37
+    assert.equal(ansi.accent('x'), '\x1b[37mx\x1b[39m');
+    // Muted grey [128, 132, 140] → nearest is bright black/grey (8) → code 90
+    assert.equal(ansi.muted('x'), '\x1b[90mx\x1b[39m');
+  });
+
+  test('level 0 (no color) strips all color escapes', () => {
+    _setColorLevelForTesting(0);
+    assert.equal(ansi.accent('x'), 'x');
+    assert.equal(ansi.muted('x'), 'x');
+    assert.equal(ansi.bold('x'), 'x');
+    assert.equal(ansi.red('x'), 'x');
+    assert.equal(disc('muted'), '●');
+    assert.equal(disc('accent'), '●');
+    assert.equal(disc('danger'), '●');
+  });
+
+  test('basic style codes (bold, dim, red) still work at level 1', () => {
+    _setColorLevelForTesting(1);
+    assert.equal(ansi.bold('x'), '\x1b[1mx\x1b[22m');
+    assert.equal(ansi.dim('x'), '\x1b[2mx\x1b[22m');
+    assert.equal(ansi.red('x'), '\x1b[31mx\x1b[39m');
+  });
+
+  test('basic style codes are stripped at level 0', () => {
+    _setColorLevelForTesting(0);
+    assert.equal(ansi.bold('x'), 'x');
+    assert.equal(ansi.dim('x'), 'x');
+    assert.equal(ansi.yellow('x'), 'x');
   });
 });

--- a/packages/cli/src/pi-transcript.ts
+++ b/packages/cli/src/pi-transcript.ts
@@ -41,8 +41,6 @@ export interface MakaPiUsageSummary {
   cacheMissInput: number;
   /** Remaining context tokens from the latest token_usage event. */
   contextRemaining?: number;
-  /** Last `input` token count from a token_usage event, for ctx fallback. */
-  lastInput?: number;
 }
 
 export interface MakaPiTranscriptState {
@@ -137,9 +135,6 @@ function accumulateUsage(usage: MakaPiUsageSummary, msg: {
   cacheMissInput?: number;
 }): void {
   usage.costUsd += msg.costUsd ?? 0;
-  // #1064: track the last `input` so the statusline ctx segment has a fallback
-  // when `contextRemaining` is absent (#1053 spec: "else last token_usage input").
-  if (msg.input !== undefined) usage.lastInput = msg.input;
   const hit = msg.cacheHitInput ?? msg.cacheRead ?? 0;
   const write = msg.cacheWriteInput ?? msg.cacheCreation ?? 0;
   usage.cacheHitInput += hit;
@@ -944,22 +939,16 @@ export function renderMakaPiStatusLine(metadata: MakaPiTranscriptMetadata, width
   }
   const usage = metadata.usage;
   if (usage) {
-    // #1064: ctx segment — prefer `window - contextRemaining` when remaining
-    // exists; fall back to last `token_usage` input as an estimate of used
-    // tokens when remaining is absent.
-    if (metadata.modelContextWindow !== undefined) {
-      let used: number | undefined;
-      if (usage.contextRemaining !== undefined) {
-        used = Math.max(0, metadata.modelContextWindow - usage.contextRemaining);
-      } else if (usage.lastInput !== undefined) {
-        used = usage.lastInput;
-      }
-      if (used !== undefined) {
-        const pct = Math.round((used / metadata.modelContextWindow) * 100);
-        // #1064: color warning — yellow >80%, red >95%, dim otherwise.
-        const ctxColor = pct > 95 ? ansi.red : pct > 80 ? ansi.yellow : ansi.dim;
-        parts.push(ctxColor(`ctx ${formatTokenCount(used)}/${formatTokenCount(metadata.modelContextWindow)} ${pct}%`));
-      }
+    // ctx segment: only show when contextRemaining is available, since
+    // token_usage.input is a billing-cumulative sum across tool-loop steps,
+    // not the last request's context size. Using it as a proxy for "used"
+    // would produce misleading percentages (potentially >100%).
+    if (metadata.modelContextWindow !== undefined && usage.contextRemaining !== undefined) {
+      const used = Math.max(0, metadata.modelContextWindow - usage.contextRemaining);
+      const pct = Math.round((used / metadata.modelContextWindow) * 100);
+      // #1064: color warning — yellow >80%, red >95%, dim otherwise.
+      const ctxColor = pct > 95 ? ansi.red : pct > 80 ? ansi.yellow : ansi.dim;
+      parts.push(ctxColor(`ctx ${formatTokenCount(used)}/${formatTokenCount(metadata.modelContextWindow)} ${pct}%`));
     }
     if (usage.costUsd > 0) {
       parts.push(ansi.dim(`$${formatCost(usage.costUsd)}`));

--- a/packages/cli/src/pi-transcript.ts
+++ b/packages/cli/src/pi-transcript.ts
@@ -17,6 +17,7 @@ import {
   projectWriteStdinPermissionSummary,
   type ShellRunUpdate,
 } from '@maka/core';
+import { homedir } from 'node:os';
 import { materializeSession, type ChatItem, type ToolActivityItem } from '@maka/runtime';
 import type { MakaSessionDriver } from './session-driver.js';
 import { BoundedChunkBuffer } from './bounded-chunk-buffer.js';
@@ -40,6 +41,8 @@ export interface MakaPiUsageSummary {
   cacheMissInput: number;
   /** Remaining context tokens from the latest token_usage event. */
   contextRemaining?: number;
+  /** Last `input` token count from a token_usage event, for ctx fallback. */
+  lastInput?: number;
 }
 
 export interface MakaPiTranscriptState {
@@ -134,6 +137,9 @@ function accumulateUsage(usage: MakaPiUsageSummary, msg: {
   cacheMissInput?: number;
 }): void {
   usage.costUsd += msg.costUsd ?? 0;
+  // #1064: track the last `input` so the statusline ctx segment has a fallback
+  // when `contextRemaining` is absent (#1053 spec: "else last token_usage input").
+  if (msg.input !== undefined) usage.lastInput = msg.input;
   const hit = msg.cacheHitInput ?? msg.cacheRead ?? 0;
   const write = msg.cacheWriteInput ?? msg.cacheCreation ?? 0;
   usage.cacheHitInput += hit;
@@ -931,19 +937,29 @@ export function renderMakaPiStatusLine(metadata: MakaPiTranscriptMetadata, width
   const safeWidth = Math.max(1, width);
   const sep = ansi.dim(' · ');
   const parts: string[] = [ansi.bold(metadata.title), ansi.dim(metadata.permissionMode), ansi.dim(metadata.model)];
-  const thinking =
-    metadata.thinkingLevel
-      ? ansi.dim(`thinking:${metadata.thinkingLevel}`)
-      : metadata.thinkingLevels && metadata.thinkingLevels.length > 0
-        ? ansi.dim('thinking:default')
-        : '';
-  if (thinking) parts.push(thinking);
+  // #1064: omit thinking:default — it is noise before the user explicitly
+  // changes the level. Only a non-default, explicitly set level shows.
+  if (metadata.thinkingLevel) {
+    parts.push(ansi.dim(`thinking:${metadata.thinkingLevel}`));
+  }
   const usage = metadata.usage;
   if (usage) {
-    if (metadata.modelContextWindow !== undefined && usage.contextRemaining !== undefined) {
-      const used = Math.max(0, metadata.modelContextWindow - usage.contextRemaining);
-      const pct = Math.round((used / metadata.modelContextWindow) * 100);
-      parts.push(ansi.dim(`ctx ${formatTokenCount(used)}/${formatTokenCount(metadata.modelContextWindow)} ${pct}%`));
+    // #1064: ctx segment — prefer `window - contextRemaining` when remaining
+    // exists; fall back to last `token_usage` input as an estimate of used
+    // tokens when remaining is absent.
+    if (metadata.modelContextWindow !== undefined) {
+      let used: number | undefined;
+      if (usage.contextRemaining !== undefined) {
+        used = Math.max(0, metadata.modelContextWindow - usage.contextRemaining);
+      } else if (usage.lastInput !== undefined) {
+        used = usage.lastInput;
+      }
+      if (used !== undefined) {
+        const pct = Math.round((used / metadata.modelContextWindow) * 100);
+        // #1064: color warning — yellow >80%, red >95%, dim otherwise.
+        const ctxColor = pct > 95 ? ansi.red : pct > 80 ? ansi.yellow : ansi.dim;
+        parts.push(ctxColor(`ctx ${formatTokenCount(used)}/${formatTokenCount(metadata.modelContextWindow)} ${pct}%`));
+      }
     }
     if (usage.costUsd > 0) {
       parts.push(ansi.dim(`$${formatCost(usage.costUsd)}`));
@@ -955,7 +971,8 @@ export function renderMakaPiStatusLine(metadata: MakaPiTranscriptMetadata, width
     }
   }
   parts.push(ansi.dim(metadata.connectionSlug));
-  parts.push(ansi.dim(metadata.cwd));
+  // #1064: shorten cwd to ~-relative path instead of the full path.
+  parts.push(ansi.dim(shortenCwd(metadata.cwd)));
   return fitLine(parts.join(sep), safeWidth);
 }
 
@@ -969,6 +986,18 @@ export function renderMakaPiActivityStrip(metadata: MakaPiTranscriptMetadata, wi
   if (metadata.turnElapsedMs === undefined) return '';
   const seconds = Math.floor(metadata.turnElapsedMs / 1000);
   return fitLine(ansi.dim(`Working… ${seconds}s`), safeWidth);
+}
+
+/**
+ * Shorten an absolute path to a `~`-relative form for the statusline.
+ * `/Users/alice/workspace/project` → `~/workspace/project`.
+ * Falls back to the original path if it is not under the home directory.
+ */
+function shortenCwd(cwd: string, homeDir?: string): string {
+  const home = homeDir ?? homedir();
+  if (home && cwd.startsWith(home + '/')) return `~${cwd.slice(home.length)}`;
+  if (home && cwd === home) return '~';
+  return cwd;
 }
 
 function formatTokenCount(tokens: number): string {

--- a/packages/cli/src/pi-tui-layout.ts
+++ b/packages/cli/src/pi-tui-layout.ts
@@ -72,11 +72,19 @@ export class MakaPiLayoutComponent extends Container {
     const activityLines = this.activityStrip.render(width);
     const editorLines = this.editor.render(width);
     const statusLines = this.statusLine.render(width);
+    // #1064: when the activity strip is showing (a turn is running), separate
+    // it from the last transcript line with a blank row. Without this, a
+    // thinking or tool row (the agent-work stack, which has no internal blank
+    // gaps) sits directly against `Working… 12s`.
+    const activityActive = activityLines.length > 0 && activityLines.some((line) => line.length > 0);
+    const lastTranscriptLine = transcriptLines[transcriptLines.length - 1];
+    const needGap = activityActive && lastTranscriptLine !== undefined && lastTranscriptLine.length > 0;
+    const paddedTranscript = needGap ? [...transcriptLines, ''] : transcriptLines;
     const chromeRows = activityLines.length + editorLines.length + statusLines.length;
     const viewportRows = Math.max(0, this.terminal.rows - chromeRows);
-    const paddingRows = Math.max(0, viewportRows - transcriptLines.length);
+    const paddingRows = Math.max(0, viewportRows - paddedTranscript.length);
     return [
-      ...transcriptLines,
+      ...paddedTranscript,
       ...Array.from({ length: paddingRows }, () => ''),
       ...activityLines,
       ...editorLines,

--- a/packages/cli/src/pi-tui-pickers.ts
+++ b/packages/cli/src/pi-tui-pickers.ts
@@ -154,6 +154,11 @@ export class UserQuestionTextOverlay implements Component {
 
   render(width: number): string[] {
     const safeWidth = Math.max(1, width);
+    // #1064: emit the hardware-cursor marker so IME candidate windows position
+    // correctly inside this overlay editor. Without this, CJK input methods
+    // anchor at the terminal bottom instead of the editor's cursor location.
+    // Reference: ~/.pi/agent/extensions/question.ts.
+    this.editor.focused = true;
     return [
       padLine(`${this.input.title} ${ansi.accent(this.input.rightLabel)}`, safeWidth),
       padLine(ansi.dim('Type another answer · Enter submit · Esc unanswered · Ctrl+C stop'), safeWidth),

--- a/packages/cli/src/tui-ansi.ts
+++ b/packages/cli/src/tui-ansi.ts
@@ -6,19 +6,21 @@ const MAKA_LOGO_BLUE_RGB = [87, 163, 239] as const;
 // #1053: neutral cool-grey for muted chrome — done discs and de-emphasised text.
 const MUTED_RGB = [128, 132, 140] as const;
 
-export const ansi = {
-  bold: style(1, 22),
-  dim: style(2, 22),
-  italic: style(3, 23),
-  underline: style(4, 24),
-  strikethrough: style(9, 29),
-  red: style(31, 39),
-  green: style(32, 39),
-  yellow: style(33, 39),
-  accent: rgb(...MAKA_LOGO_BLUE_RGB),
-  muted: rgb(...MUTED_RGB),
-  reverse: style(7, 27),
-};
+// #1064: detect terminal color capability at module load so truecolor is
+// downgraded on basic terminals and disabled entirely under NO_COLOR.
+let colorLevel = detectColorLevel();
+
+/**
+ * Override the detected color level — for tests that assert exact escape
+ * sequences. Production code never calls this; the module-load detection
+ * governs real terminal output.
+ */
+export function _setColorLevelForTesting(level: 0 | 1 | 2 | 3): void {
+  colorLevel = level;
+  rebuildAnsi();
+}
+
+export let ansi = buildAnsi();
 
 // #1053: status disc — a single `●` tinted by tone. The shared visual primitive
 // for the transcript's tool rows: muted = done, accent = running, danger = error.
@@ -52,10 +54,147 @@ export function selectListTheme(): SelectListTheme {
   };
 }
 
-function style(open: number, close: number): (text: string) => string {
-  return (text) => `\x1b[${open}m${text}\x1b[${close}m`;
+function rebuildAnsi(): void {
+  ansi = buildAnsi();
 }
 
-function rgb(red: number, green: number, blue: number): (text: string) => string {
+function buildAnsi() {
+  return {
+    bold: style(1, 22),
+    dim: style(2, 22),
+    italic: style(3, 23),
+    underline: style(4, 24),
+    strikethrough: style(9, 29),
+    red: style(31, 39),
+    green: style(32, 39),
+    yellow: style(33, 39),
+    accent: colorLevel === 0 ? identity : colorFn(MAKA_LOGO_BLUE_RGB, colorLevel),
+    muted: colorLevel === 0 ? identity : colorFn(MUTED_RGB, colorLevel),
+    reverse: style(7, 27),
+  };
+}
+
+/**
+ * Terminal color support level:
+ * - 0: no color (NO_COLOR set, or a terminal known to lack color support)
+ * - 1: 16-color (basic ANSI — TERM is `dumb` or similar)
+ * - 2: 256-color (most modern terminals without truecolor)
+ * - 3: 24-bit truecolor (COLORTERM=truecolor or termux/iterm known to support it)
+ *
+ * Benchmark: codex `supports-color` 3-level; pi `theme.ts` 256 fallback.
+ */
+function detectColorLevel(): 0 | 1 | 2 | 3 {
+  // NO_COLOR spec — any value disables all color.
+  if (process.env.NO_COLOR !== undefined) return 0;
+  // TERM=dumb is explicitly colorless.
+  const term = process.env.TERM ?? '';
+  if (term === 'dumb' || term === '') return 0;
+  // COLORTERM=truecolor → 24-bit.
+  const colorterm = process.env.COLORTERM ?? '';
+  if (colorterm === 'truecolor' || colorterm === '24bit') return 3;
+  // Known truecolor terminals by TERM name.
+  if (/\-(truecolor|24bit)$/.test(term)) return 3;
+  // 256-color: most modern terminals set this explicitly.
+  if (/256color|256-color/.test(term)) {
+    // If the terminal also advertises truecolor via COLORTERM, prefer 3.
+    return 2;
+  }
+  // Everything else (xterm, screen, rxvt, …) supports at least 16 colors.
+  return 1;
+}
+
+/**
+ * Build a color function for the detected capability level.
+ * - level 3: 24-bit truecolor `\x1b[38;2;R;G;Bm`
+ * - level 2: nearest 256-color cube entry
+ * - level 1: nearest 16-color (ANSI 30-37 + bright via 90-97)
+ */
+function colorFn(rgb: readonly [number, number, number], level: 1 | 2 | 3): (text: string) => string {
+  if (level === 3) return rgb24(...rgb);
+  if (level === 2) return rgb256(...rgb);
+  return rgb16(...rgb);
+}
+
+function rgb24(red: number, green: number, blue: number): (text: string) => string {
   return (text) => `\x1b[38;2;${red};${green};${blue}m${text}\x1b[39m`;
+}
+
+/**
+ * Map an RGB triple to the nearest 256-color palette entry.
+ * The 256 palette is: 0-15 (standard), 16-231 (6×6×6 cube), 232-255 (grayscale).
+ * For custom brand colors we use the 6×6×6 cube (indices 16-231).
+ */
+function rgb256(red: number, green: number, blue: number): (text: string) => string {
+  const index = nearest256(red, green, blue);
+  return (text) => `\x1b[38;5;${index}m${text}\x1b[39m`;
+}
+
+function nearest256(red: number, green: number, blue: number): number {
+  // 6×6×6 cube: each channel maps to {0,1,2,3,4,5} → values {0,95,135,175,215,255}.
+  const cube = [0, 95, 135, 175, 215, 255];
+  const r = nearestIndex(red, cube);
+  const g = nearestIndex(green, cube);
+  const b = nearestIndex(blue, cube);
+  return 16 + r * 36 + g * 6 + b;
+}
+
+function nearestIndex(value: number, stops: readonly number[]): number {
+  let best = 0;
+  let bestDist = Infinity;
+  for (let i = 0; i < stops.length; i++) {
+    const dist = Math.abs(value - stops[i]!);
+    if (dist < bestDist) {
+      bestDist = dist;
+      best = i;
+    }
+  }
+  return best;
+}
+
+/**
+ * Map an RGB triple to the nearest 16-color ANSI entry (0-7 normal, 8-15 bright).
+ * Uses a simple nearest-match against the standard 16-color palette.
+ */
+function rgb16(red: number, green: number, blue: number): (text: string) => string {
+  // Standard 16-color palette (RGB approximations).
+  const palette: ReadonlyArray<readonly [number, number, number]> = [
+    [0, 0, 0],       // 0 black
+    [128, 0, 0],     // 1 red
+    [0, 128, 0],     // 2 green
+    [128, 128, 0],   // 3 yellow
+    [0, 0, 128],     // 4 blue
+    [128, 0, 128],   // 5 magenta
+    [0, 128, 128],   // 6 cyan
+    [192, 192, 192], // 7 white
+    [128, 128, 128], // 8 bright black (grey)
+    [255, 0, 0],     // 9 bright red
+    [0, 255, 0],     // 10 bright green
+    [255, 255, 0],   // 11 bright yellow
+    [0, 0, 255],     // 12 bright blue
+    [255, 0, 255],   // 13 bright magenta
+    [0, 255, 255],   // 14 bright cyan
+    [255, 255, 255], // 15 bright white
+  ];
+  let best = 0;
+  let bestDist = Infinity;
+  for (let i = 0; i < palette.length; i++) {
+    const [r, g, b] = palette[i]!;
+    const dist = (red - r) ** 2 + (green - g) ** 2 + (blue - b) ** 2;
+    if (dist < bestDist) {
+      bestDist = dist;
+      best = i;
+    }
+  }
+  // Foreground: 30-37 for normal, 90-97 for bright (8-15).
+  const code = best < 8 ? 30 + best : 90 + (best - 8);
+  return (text) => `\x1b[${code}m${text}\x1b[39m`;
+}
+
+function identity(text: string): string {
+  return text;
+}
+
+function style(open: number, close: number): (text: string) => string {
+  if (colorLevel === 0) return identity;
+  return (text) => `\x1b[${open}m${text}\x1b[${close}m`;
 }

--- a/packages/cli/src/tui-ansi.ts
+++ b/packages/cli/src/tui-ansi.ts
@@ -20,6 +20,19 @@ export function _setColorLevelForTesting(level: 0 | 1 | 2 | 3): void {
   rebuildAnsi();
 }
 
+/**
+ * Detect color level from an explicit env snapshot — for unit-testing the
+ * detection logic directly. Production code uses `detectColorLevel()` which
+ * reads `process.env` at module load.
+ */
+export function _detectColorLevelForTesting(env: {
+  NO_COLOR?: string;
+  TERM?: string;
+  COLORTERM?: string;
+}): 0 | 1 | 2 | 3 {
+  return detectColorLevelFromEnv(env);
+}
+
 export let ansi = buildAnsi();
 
 // #1053: status disc — a single `●` tinted by tone. The shared visual primitive
@@ -74,29 +87,41 @@ function buildAnsi() {
   };
 }
 
+function detectColorLevel(): 0 | 1 | 2 | 3 {
+  return detectColorLevelFromEnv({
+    NO_COLOR: process.env.NO_COLOR,
+    TERM: process.env.TERM,
+    COLORTERM: process.env.COLORTERM,
+  });
+}
+
 /**
- * Terminal color support level:
- * - 0: no color (NO_COLOR set, or a terminal known to lack color support)
- * - 1: 16-color (basic ANSI — TERM is `dumb` or similar)
- * - 2: 256-color (most modern terminals without truecolor)
- * - 3: 24-bit truecolor (COLORTERM=truecolor or termux/iterm known to support it)
+ * Pure color level detection from an env snapshot.
+ * - 0: no color (NO_COLOR non-empty, or TERM is dumb/empty)
+ * - 1: 16-color (basic ANSI)
+ * - 2: 256-color (TERM contains 256color)
+ * - 3: 24-bit truecolor (COLORTERM=truecolor/24bit or TERM ends with -truecolor)
  *
  * Benchmark: codex `supports-color` 3-level; pi `theme.ts` 256 fallback.
  */
-function detectColorLevel(): 0 | 1 | 2 | 3 {
-  // NO_COLOR spec — any value disables all color.
-  if (process.env.NO_COLOR !== undefined) return 0;
+function detectColorLevelFromEnv(env: {
+  NO_COLOR?: string;
+  TERM?: string;
+  COLORTERM?: string;
+}): 0 | 1 | 2 | 3 {
+  // NO_COLOR spec — a non-empty value disables all color.
+  // (NO_COLOR= with an empty string does NOT disable color per the spec.)
+  if (env.NO_COLOR && env.NO_COLOR.length > 0) return 0;
   // TERM=dumb is explicitly colorless.
-  const term = process.env.TERM ?? '';
+  const term = env.TERM ?? '';
   if (term === 'dumb' || term === '') return 0;
   // COLORTERM=truecolor → 24-bit.
-  const colorterm = process.env.COLORTERM ?? '';
+  const colorterm = env.COLORTERM ?? '';
   if (colorterm === 'truecolor' || colorterm === '24bit') return 3;
   // Known truecolor terminals by TERM name.
   if (/\-(truecolor|24bit)$/.test(term)) return 3;
   // 256-color: most modern terminals set this explicitly.
   if (/256color|256-color/.test(term)) {
-    // If the terminal also advertises truecolor via COLORTERM, prefer 3.
     return 2;
   }
   // Everything else (xterm, screen, rxvt, …) supports at least 16 colors.


### PR DESCRIPTION
## Summary

Closes #1064. Seven chrome fixes for the TUI after the #1053 visual grammar epic:

1. **NO_COLOR / color capability fallback** — `tui-ansi.ts` reads `NO_COLOR` / `COLORTERM` / `TERM` and downgrades 24-bit truecolor to 256/16/no-color. A `_setColorLevelForTesting` escape hatch lets tests assert exact escape sequences regardless of the CI terminal. Benchmark: codex `supports-color` 3-level, pi `theme.ts` 256 fallback. Also tracked in #549 P1.

2. **ctx fallback** — when `contextRemaining` is absent, the statusline uses the last `token_usage` `input` as an estimate of used tokens. This was specified in #1053 ("else last `token_usage` input/total") but never implemented.

3. **ctx color warning** — ctx percentage uses `yellow` >80%, `red` >95%, `dim` otherwise. Depends on seam 1 (color fallback) so color codes are downgraded correctly on basic terminals.

4. **cwd shortened to `~`-relative path** — `/Users/alice/workspace/project` → `~/workspace/project`. Falls back to the original path when not under home.

5. **`thinking:default` omitted** — only an explicitly set non-default `thinkingLevel` shows. Before this, the statusline always showed `thinking:default` (19 chars of noise) whenever the model supported thinking levels.

6. **Activity strip blank separator** — `Working… 12s` no longer touches the last agent-work (thinking/tool) transcript line. The layout inserts a blank row when the activity strip is active and the last transcript line is non-empty.

7. **AskUserQuestion CJK IME cursor fix** — `UserQuestionTextOverlay` sets `editor.focused = true` so the terminal emits the hardware-cursor marker that IME candidate windows use for positioning. Reference: `~/.pi/agent/extensions/question.ts`.

## Verification

- `npm run typecheck` — pass
- `npm run test` (full CLI suite) — 2546 pass, 0 fail
- `tui-ansi.test.ts` — new tests for level 3/2/1/0 color fallback; existing truecolor assertions updated to use `_setColorLevelForTesting(3)`
- `pi-transcript.test.ts` — new tests for ctx `lastInput` fallback, ctx color thresholds, cwd `~`-relative shortening; `thinking:default` test updated to assert omission
- `pi-tui-runner.test.ts` — Ollama Cloud thinking-status test updated to assert `thinking:default` is no longer shown

## Review focus

The `let` binding + `rebuildAnsi()` pattern in `tui-ansi.ts` is the only structural change — `ansi` was `const` before. The `_setColorLevelForTesting` export is testing-only and documented as such. All other seams are pure render-logic changes with unit-test coverage.