### PR TITLE
fix(runtime): silence AI SDK default onError that dumps raw stream errors to the terminal

### DIFF
--- a/packages/runtime/src/__tests__/model-adapter-onerror.test.ts
+++ b/packages/runtime/src/__tests__/model-adapter-onerror.test.ts
@@ -1,0 +1,53 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+import { MockLanguageModelV3 } from 'ai/test';
+
+import { ModelAdapter } from '../model-adapter.js';
+
+function newAdapter(): ModelAdapter {
+  return new ModelAdapter({
+    connection: { providerType: 'openai' } as never,
+    apiKey: 'test',
+    modelId: 'mock',
+    modelFactory: () => ({}),
+    newId: () => 'id',
+    now: () => 0,
+  });
+}
+
+describe('ModelAdapter.startStream onError', () => {
+  // streamText's default onError is `console.error(error)`, which dumps the
+  // raw error object (stack + request bodies) straight onto the terminal,
+  // bypassing the TUI transcript. Stream failures already reach the user via
+  // the fullStream `error` chunk → ErrorEvent path, so nothing may leak to
+  // console.error.
+  test('a provider stream failure never reaches console.error', async () => {
+    const logged: unknown[] = [];
+    const original = console.error;
+    console.error = (...args: unknown[]) => { logged.push(args); };
+    try {
+      const model = new MockLanguageModelV3({
+        doStream: async () => {
+          throw new Error('Client network socket disconnected before secure TLS connection was established');
+        },
+      });
+      const result = await newAdapter().startStream({
+        model,
+        messages: [{ role: 'user', content: 'hi' }],
+        tools: {},
+        activeTools: [],
+        system: 'sys',
+        abortSignal: new AbortController().signal,
+        repairToolCall: async () => null,
+      });
+      for await (const chunk of result.fullStream) {
+        if ((chunk as { type?: unknown }).type === 'error') break;
+      }
+      // Let any post-chunk callback settle before asserting.
+      await new Promise((resolve) => setImmediate(resolve));
+    } finally {
+      console.error = original;
+    }
+    assert.deepEqual(logged, [], 'stream errors must surface via the error chunk, not console.error');
+  });
+});

--- a/packages/runtime/src/model-adapter.ts
+++ b/packages/runtime/src/model-adapter.ts
@@ -193,6 +193,11 @@ export class ModelAdapter {
         ? [configuredStop, () => stopAfterStep()]
         : configuredStop,
       abortSignal: input.abortSignal,
+      // The SDK default onError console.errors the raw error object (stack,
+      // request bodies), which lands on the terminal outside the TUI
+      // transcript. Stream failures already surface through the fullStream
+      // `error` chunk → ErrorEvent path, so silence the default.
+      onError: () => {},
     });
   }
 


### PR DESCRIPTION
## Summary

On a provider stream failure (e.g. network disconnect), the TUI painted the raw `AI_RetryError` object — a full `util.inspect` dump with stack frames, nested per-attempt errors, and request bodies — directly onto the terminal, bypassing the transcript.

Root cause: AI SDK `streamText` defaults `onError` to `({ error }) => console.error(error)` (`ai/dist/index.mjs`), and `ModelAdapter.startStream` — the repo's only `streamText` call site — did not pass one. The SDK's default handler writes to stderr outside the TUI's rendering pipeline.

The application already surfaces the same failure properly: the `fullStream` `error` chunk is captured, converted via `makeErrorEvent` → `generalizedErrorMessage`, and rendered as a short classified notice in the transcript (e.g. "Network error"). This PR passes an explicit no-op `onError` so the SDK default no longer leaks; no error information is lost.

## Verification

- New regression test `model-adapter-onerror.test.ts` drives `ModelAdapter.startStream` with a failing mock model and asserts `console.error` is never called; it fails before the fix (raw error logged) and passes after.
- Full `@maka/runtime` suite: 1960 tests, 1953 pass, 0 fail (7 skipped).

## Root cause

`streamText`'s default `onError` handler is `console.error(error)`. Without an explicit override, every stream failure was written to stderr as a raw object dump in addition to — and visually instead of — the classified transcript notice.