### PR TITLE
fix(runtime): emit contextRemaining in token_usage events

### DIFF
--- a/packages/runtime/src/ai-sdk-backend.ts
+++ b/packages/runtime/src/ai-sdk-backend.ts
@@ -1530,8 +1530,10 @@ export class AiSdkBackend implements AgentBackend {
                 runtimeSteps += 1;
                 const stepUsage = normalizeAiSdkUsage(chunk.usage, { rawFinishReason: chunk.finishReason });
                 if (!stepUsage) sawUnusableStepUsage = true;
+                // Fail closed: reset on every step boundary so a missing final
+                // step's usage does not leave a stale value from an earlier step.
+                lastStepInputTokens = stepUsage?.inputTokens;
                 if (stepUsage) {
-                  lastStepInputTokens = stepUsage.inputTokens;
                   completedStepUsage = mergeNormalizedUsage(completedStepUsage, stepUsage);
                   this.cumulativeUsageCheckpoint = mergeNormalizedUsage(this.cumulativeUsageCheckpoint, stepUsage);
                   await this.input.recordUsageCheckpoint?.({
@@ -1766,6 +1768,13 @@ export class AiSdkBackend implements AgentBackend {
               };
               await this.input.appendMessage(note).catch(() => {});
             }
+            const contextRemainingForUsage = (() => {
+              const contextWindow = resolveSelectedModelContextWindow(this.input.connection, this.input.modelId);
+              if (lastStepInputTokens !== undefined && contextWindow !== undefined) {
+                return Math.max(0, contextWindow - lastStepInputTokens);
+              }
+              return undefined;
+            })();
             queue.push({
               type: 'token_usage',
               id: this.newId(),
@@ -1791,13 +1800,7 @@ export class AiSdkBackend implements AgentBackend {
               requestShapeChangeReason: turnDiagnostics.requestShape.requestShapeChangeReason,
               promptSegments: turnDiagnostics.promptSegments,
               ...(contextBudgetForUsage ? { contextBudget: contextBudgetForUsage } : {}),
-              ...(() => {
-                const contextWindow = resolveSelectedModelContextWindow(this.input.connection, this.input.modelId);
-                if (lastStepInputTokens !== undefined && contextWindow !== undefined) {
-                  return { contextRemaining: Math.max(0, contextWindow - lastStepInputTokens) };
-                }
-                return {};
-              })(),
+              ...(contextRemainingForUsage !== undefined ? { contextRemaining: contextRemainingForUsage } : {}),
             } satisfies TokenUsageEvent);
           }
         } catch {

--- a/packages/runtime/src/ai-sdk-backend.ts
+++ b/packages/runtime/src/ai-sdk-backend.ts
@@ -1103,6 +1103,12 @@ export class AiSdkBackend implements AgentBackend {
     // fails the whole fallback closed (#972: incomplete usage is no usage).
     let completedStepUsage: NormalizedAiSdkUsage | undefined;
     let sawUnusableStepUsage = false;
+    // Input tokens from the last completed step — the actual prompt token count
+    // of the final API request. Used to compute contextRemaining for the TUI
+    // statusline ctx segment (#1067): contextRemaining = contextWindow - this.
+    // totalUsage.inputTokens is cumulative across steps and would produce
+    // misleading >100% percentages, so the per-step value is captured here.
+    let lastStepInputTokens: number | undefined;
     let streamStatus: LlmCallRecord['status'] = 'success';
     let streamErrorClass: string | undefined;
     let rawFinishReason: string | undefined;
@@ -1525,6 +1531,7 @@ export class AiSdkBackend implements AgentBackend {
                 const stepUsage = normalizeAiSdkUsage(chunk.usage, { rawFinishReason: chunk.finishReason });
                 if (!stepUsage) sawUnusableStepUsage = true;
                 if (stepUsage) {
+                  lastStepInputTokens = stepUsage.inputTokens;
                   completedStepUsage = mergeNormalizedUsage(completedStepUsage, stepUsage);
                   this.cumulativeUsageCheckpoint = mergeNormalizedUsage(this.cumulativeUsageCheckpoint, stepUsage);
                   await this.input.recordUsageCheckpoint?.({
@@ -1784,6 +1791,13 @@ export class AiSdkBackend implements AgentBackend {
               requestShapeChangeReason: turnDiagnostics.requestShape.requestShapeChangeReason,
               promptSegments: turnDiagnostics.promptSegments,
               ...(contextBudgetForUsage ? { contextBudget: contextBudgetForUsage } : {}),
+              ...(() => {
+                const contextWindow = resolveSelectedModelContextWindow(this.input.connection, this.input.modelId);
+                if (lastStepInputTokens !== undefined && contextWindow !== undefined) {
+                  return { contextRemaining: Math.max(0, contextWindow - lastStepInputTokens) };
+                }
+                return {};
+              })(),
             } satisfies TokenUsageEvent);
           }
         } catch {


### PR DESCRIPTION
## Summary

Closes #1067. The TUI statusline ctx segment (`ctx 32k/128k 25%`) never renders because `ai-sdk-backend.ts` never sets `contextRemaining` on the `TokenUsageEvent`. The entire downstream pipeline (event forwarding, TUI state, statusline rendering) already exists — this fills the source.

## Change

- Capture `lastStepInputTokens` from each `finish-step` chunk's `stepUsage.inputTokens` in the streaming handler.
- When constructing the `TokenUsageEvent`, compute `contextRemaining = max(0, contextWindow - lastStepInputTokens)` when both values are available.
- `contextWindow` comes from `resolveSelectedModelContextWindow(connection, modelId)` — already used for mid-turn capacity compaction.
- `lastStepInputTokens` is the per-step value, NOT the cumulative `totalUsage.inputTokens` which would produce misleading >100% percentages (#1064 correctly rejected that fallback).

## Verification

- `npx tsc --noEmit` — pass
- `npm test` — runtime 1952 pass, cli 393 pass, 0 fail

## Review focus

One file changed (`ai-sdk-backend.ts`), 14 lines added. The IIFE pattern `...(() => { ... })()` avoids a new `const` binding outside the object literal while keeping the computation co-located with the event construction. `lastStepInputTokens` is set at every `finish-step` boundary, so it always holds the last completed step's value.
