### PR TITLE
fix(desktop): scan all skill discovery paths, not just {workspaceRoot}/skills/

### DIFF
--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -140,7 +140,7 @@ import { handleQuickChatStart as runQuickChatStart, type QuickChatResult } from 
 import { handleExpertTeamStart as runExpertTeamStart } from './expert-team-start.js';
 import { probeOfficeCli } from './officecli-probe.js';
 import { resolveOpenPath, type OpenPathResult } from './open-path-guard.js';
-import { resolveProjectGitInfo, resolveProjectRoot } from '@maka/runtime';
+import { resolveProjectGitInfo, resolveProjectRoot, resolveSkillDiscoveryPaths } from '@maka/runtime';
 import { listLocalBranches, checkoutBranch } from './git-branch.js';
 import { searchWorkspaceFiles } from './workspace-file-search.js';
 import { createDailyReviewArchiveStore } from './daily-review-archive-store.js';
@@ -712,7 +712,10 @@ const builtinTools: MakaTool[] = [
   }).filter((tool: MakaTool) => tool.name !== 'Edit'),
   // External reference lazy-skill pattern: the prompt lists available skills,
   // and this read-only tool loads the full SKILL.md only when the task matches.
-  buildSkillAgentTool(workspaceRoot),
+  // Resolve per-call from the session cwd so skills at all 5 standard paths
+  // (cwd/.maka, cwd/.agents, workspaceRoot/skills, ~/.maka, ~/.agents) are
+  // discovered — matching the CLI and the Agent Skills spec (#1068).
+  buildSkillAgentTool(({ cwd }) => resolveSkillDiscoveryPaths(cwd, workspaceRoot)),
   // External reference plan-mode borrow: a bounded read-only local worker for
   // self-contained code/repo investigations. The tool advertises the
   // `subagent` category; explore mode allows it, but the implementation

--- a/apps/desktop/src/main/system-prompt-main.ts
+++ b/apps/desktop/src/main/system-prompt-main.ts
@@ -18,6 +18,7 @@ import {
   buildPersonalizationPromptFragment,
   resolveProjectGitInfo,
   buildSessionEnvironmentPromptFragment,
+  resolveSkillDiscoveryPaths,
   type GoalManager,
 } from '@maka/runtime';
 import { buildSkillsPromptFragment } from './skills.js';
@@ -51,7 +52,8 @@ export function createSystemPromptMainService(deps: SystemPromptMainDeps) {
     const personalization = includePersonalization
       ? buildPersonalizationPromptFragment(settings.personalization)
       : { text: undefined };
-    const skills = await buildSkillsPromptFragment(deps.workspaceRoot, undefined, options?.skillBudget);
+    const skillSource = resolveSkillDiscoveryPaths(cwd ?? deps.workspaceRoot, deps.workspaceRoot);
+    const skills = await buildSkillsPromptFragment(skillSource, undefined, options?.skillBudget);
     const workspaceInstructions = settings.workspaceInstructions.enabled && cwd
       ? await buildWorkspaceInstructionsPromptFragment(cwd)
       : undefined;


### PR DESCRIPTION
## Summary

Closes #1068. The desktop app only discovered skills from `{workspaceRoot}/skills/`. Skills at the standard cross-client paths (`~/.agents/skills/`, `~/.maka/skills/`, `{cwd}/.agents/skills/`, `{cwd}/.maka/skills/`) were invisible to the model.

## Change

Two call sites switched from a bare `workspaceRoot` string to `resolveSkillDiscoveryPaths`:

- `system-prompt-main.ts:55` — `resolveSkillDiscoveryPaths(cwd ?? workspaceRoot, workspaceRoot)` for the prompt catalog
- `main.ts:715` — `buildSkillAgentTool(({ cwd }) => resolveSkillDiscoveryPaths(cwd, workspaceRoot))` for the Skill tool's per-call resolver

This matches the CLI wiring (`packages/cli/src/cli-system-prompt.ts:62` and `packages/cli/src/runtime-bootstrap.ts:221`) and the Agent Skills spec.

## Verification

- `npx tsc --noEmit` — pass (desktop main + renderer)
- `npm test` — desktop 2556 pass, 0 fail

## Non-goals

- Governance UI (`listInstalledSkills` / skill management panel) still scans only `{workspaceRoot}/skills/`. Multi-path skills are model-visible and loadable but not manageable from the UI — tracked in #424.
