### PR TITLE
fix(runtime): unify provider error projection

### DIFF
--- a/packages/runtime/src/__tests__/model-adapter.test.ts
+++ b/packages/runtime/src/__tests__/model-adapter.test.ts
@@ -214,6 +214,38 @@ describe('ModelAdapter stream and error normalization', () => {
     assert.equal(adapter.mapFinishReason('provider-new-reason'), 'end_turn');
   });
 
+  test('projects a structured network error to a consistent reason and safe message', () => {
+    const event = newAdapter().makeErrorEvent('turn-1', {
+      message: 'fetch failed',
+      detail: 'token=sk-live-secret-token-value',
+    });
+
+    assert.equal(event.reason, 'network');
+    assert.equal(event.message, 'Network error');
+    assert.equal(JSON.stringify(event).includes('sk-live-secret-token-value'), false);
+  });
+
+  test('retains network classification for Node connection errors', () => {
+    const event = newAdapter().makeErrorEvent('turn-1', new Error('connect ECONNREFUSED 127.0.0.1:443'));
+
+    assert.equal(event.reason, 'network');
+    assert.equal(event.message, 'Network error');
+  });
+
+  test('projects string provider errors through the same classification', () => {
+    const event = newAdapter().makeErrorEvent('turn-1', 'fetch failed');
+
+    assert.equal(event.reason, 'network');
+    assert.equal(event.message, 'Network error');
+  });
+
+  test('keeps an unknown structured provider error generic', () => {
+    const event = newAdapter().makeErrorEvent('turn-1', { message: 'provider exploded' });
+
+    assert.equal(event.reason, undefined);
+    assert.equal(event.message, 'Operation failed');
+  });
+
   test('classifies provider context-length overflow errors as ContextLength', () => {
     const adapter = newAdapter();
     const overflow = (message: string, extra: Record<string, unknown> = {}) =>

--- a/packages/runtime/src/__tests__/model-adapter.test.ts
+++ b/packages/runtime/src/__tests__/model-adapter.test.ts
@@ -225,10 +225,13 @@ describe('ModelAdapter stream and error normalization', () => {
     assert.equal(JSON.stringify(event).includes('sk-live-secret-token-value'), false);
   });
 
-  test('retains network classification for Node connection errors', () => {
-    const event = newAdapter().makeErrorEvent('turn-1', new Error('connect ECONNREFUSED 127.0.0.1:443'));
+  test('retains Node connection copy without promoting retry classification', () => {
+    const adapter = newAdapter();
+    const error = new Error('connect ECONNREFUSED 127.0.0.1:443');
+    const event = adapter.makeErrorEvent('turn-1', error);
 
-    assert.equal(event.reason, 'network');
+    assert.equal(adapter.classifyError(error), 'Error');
+    assert.equal(event.reason, undefined);
     assert.equal(event.message, 'Network error');
   });
 

--- a/packages/runtime/src/model-adapter.ts
+++ b/packages/runtime/src/model-adapter.ts
@@ -6,12 +6,13 @@ import type {
   CompleteEvent,
 } from '@maka/core/events';
 import { providerAuthRequiresSecret, type LlmConnection } from '@maka/core/llm-connections';
+import { generalizedErrorMessage } from '@maka/core/redaction';
 import type { CacheMissInputSource } from '@maka/core/usage-stats/types';
 import type { ModelMessage } from 'ai';
 
 import type { AsyncEventQueue } from './async-queue.js';
 import { resolveModelRuntime } from './model-runtime.js';
-import { classifyError, errorMessageFromClass, errorReasonFromClass } from './tool-runtime.js';
+import { classifyError, errorPresentationFromClass } from './tool-runtime.js';
 
 /**
  * Build an ai-sdk LanguageModel from a single input object.
@@ -301,8 +302,8 @@ export class ModelAdapter {
 
   makeErrorEvent(turnId: string, err: unknown): ErrorEvent {
     const errorClass = classifyError(err);
-    const message = errorMessageFromClass(errorClass);
-    const reason = errorReasonFromClass(errorClass);
+    const presentation = errorPresentationFromClass(errorClass);
+    const message = presentation.message ?? generalizedErrorMessage(err);
     const code = err instanceof Error && 'code' in err
       ? String((err as { code?: unknown }).code)
       : undefined;
@@ -313,7 +314,7 @@ export class ModelAdapter {
       ts: this.input.now(),
       recoverable: false,
       ...(code !== undefined ? { code } : {}),
-      ...(reason !== undefined ? { reason } : {}),
+      ...(presentation.reason !== undefined ? { reason: presentation.reason } : {}),
       message,
     };
   }

--- a/packages/runtime/src/model-adapter.ts
+++ b/packages/runtime/src/model-adapter.ts
@@ -6,13 +6,12 @@ import type {
   CompleteEvent,
 } from '@maka/core/events';
 import { providerAuthRequiresSecret, type LlmConnection } from '@maka/core/llm-connections';
-import { generalizedErrorMessage } from '@maka/core/redaction';
 import type { CacheMissInputSource } from '@maka/core/usage-stats/types';
 import type { ModelMessage } from 'ai';
 
 import type { AsyncEventQueue } from './async-queue.js';
 import { resolveModelRuntime } from './model-runtime.js';
-import { classifyError, errorReasonFromClass } from './tool-runtime.js';
+import { classifyError, errorMessageFromClass, errorReasonFromClass } from './tool-runtime.js';
 
 /**
  * Build an ai-sdk LanguageModel from a single input object.
@@ -301,8 +300,9 @@ export class ModelAdapter {
   }
 
   makeErrorEvent(turnId: string, err: unknown): ErrorEvent {
-    const message = generalizedErrorMessage(err);
-    const reason = errorReasonFromClass(classifyError(err));
+    const errorClass = classifyError(err);
+    const message = errorMessageFromClass(errorClass);
+    const reason = errorReasonFromClass(errorClass);
     const code = err instanceof Error && 'code' in err
       ? String((err as { code?: unknown }).code)
       : undefined;

--- a/packages/runtime/src/tool-runtime.ts
+++ b/packages/runtime/src/tool-runtime.ts
@@ -1642,52 +1642,32 @@ export function classifyError(error: unknown): string {
   if (
     text.includes('network')
     || text.includes('fetch')
-    || text.includes('econn')
-    || text.includes('enotfound')
     || /\btypeerror\b.*\bterminated\b/.test(text)
   ) return 'Network';
   return error instanceof Error ? (error.name || 'Other') : 'Other';
 }
 
-export function errorReasonFromClass(errorClass: string): string | undefined {
+export function errorPresentationFromClass(errorClass: string): {
+  reason?: string;
+  message?: string;
+} {
   switch (errorClass) {
     case 'ContextLength':
-      return 'context_overflow';
+      return { reason: 'context_overflow', message: 'Context window exceeded' };
     case 'Timeout':
-      return 'timeout';
+      return { reason: 'timeout', message: 'Request timed out' };
     case 'Auth':
-      return 'auth';
+      return { reason: 'auth', message: 'Authentication failed' };
     case 'ProviderBilling':
-      return 'provider_billing';
+      return { reason: 'provider_billing', message: 'Provider billing required' };
     case 'ProviderUnavailable':
-      return 'provider_unavailable';
+      return { reason: 'provider_unavailable', message: 'Provider returned an error' };
     case 'RateLimit':
-      return 'rate_limit';
+      return { reason: 'rate_limit', message: 'Rate limit exceeded' };
     case 'Network':
-      return 'network';
+      return { reason: 'network', message: 'Network error' };
     default:
-      return undefined;
-  }
-}
-
-export function errorMessageFromClass(errorClass: string): string {
-  switch (errorClass) {
-    case 'ContextLength':
-      return 'Context window exceeded';
-    case 'Timeout':
-      return 'Request timed out';
-    case 'Auth':
-      return 'Authentication failed';
-    case 'ProviderBilling':
-      return 'Provider billing required';
-    case 'ProviderUnavailable':
-      return 'Provider returned an error';
-    case 'RateLimit':
-      return 'Rate limit exceeded';
-    case 'Network':
-      return 'Network error';
-    default:
-      return 'Operation failed';
+      return {};
   }
 }
 

--- a/packages/runtime/src/tool-runtime.ts
+++ b/packages/runtime/src/tool-runtime.ts
@@ -1642,6 +1642,8 @@ export function classifyError(error: unknown): string {
   if (
     text.includes('network')
     || text.includes('fetch')
+    || text.includes('econn')
+    || text.includes('enotfound')
     || /\btypeerror\b.*\bterminated\b/.test(text)
   ) return 'Network';
   return error instanceof Error ? (error.name || 'Other') : 'Other';
@@ -1665,6 +1667,27 @@ export function errorReasonFromClass(errorClass: string): string | undefined {
       return 'network';
     default:
       return undefined;
+  }
+}
+
+export function errorMessageFromClass(errorClass: string): string {
+  switch (errorClass) {
+    case 'ContextLength':
+      return 'Context window exceeded';
+    case 'Timeout':
+      return 'Request timed out';
+    case 'Auth':
+      return 'Authentication failed';
+    case 'ProviderBilling':
+      return 'Provider billing required';
+    case 'ProviderUnavailable':
+      return 'Provider returned an error';
+    case 'RateLimit':
+      return 'Rate limit exceeded';
+    case 'Network':
+      return 'Network error';
+    default:
+      return 'Operation failed';
   }
 }
 


### PR DESCRIPTION
## Summary

Closes #1074.

Provider error events now classify the raw provider value once and derive both the machine-readable reason and safe visible message from one presentation mapping. Structured network errors therefore emit `reason: network` with `message: Network error` instead of falling through to `Operation failed`.

For errors outside the authoritative provider taxonomy, the existing generalized safe copy remains the presentation fallback. This preserves `ECONN*` / `ENOTFOUND` user feedback without promoting those values into the `Network` machine class that controls transport retry. Retry behavior is unchanged.

## Verification

- TDD regression: structured `{ message: "fetch failed" }` changed from `Operation failed` to `Network error`.
- Review regression: `ECONNREFUSED` retains `Network error` copy while its machine classification remains unchanged, so the retry boundary does not expand.
- `npm run build --prefix packages/runtime` — pass.
- `node --test packages/runtime/dist/__tests__/model-adapter.test.js packages/runtime/dist/__tests__/ai-sdk-backend.test.js` — 132 pass, 0 fail.
- `npm test --prefix packages/runtime` — five active-prune/context-capacity failures remain. The same five failures reproduce on the clean `main` checkout and are unrelated to this PR.
