### PR TITLE
feat(core+ui+desktop): add reactive locale foundation

### DIFF
--- a/apps/desktop/.storybook/preview.tsx
+++ b/apps/desktop/.storybook/preview.tsx
@@ -1,6 +1,7 @@
 import type { Decorator, Preview } from '@storybook/react-vite';
 import '../src/renderer/styles.css';
 import { THEME_PALETTES } from '../../../packages/core/src/settings.js';
+import { LocaleProvider } from '@maka/ui';
 
 const PALETTE_LABELS: Record<string, string> = {
   default: 'Default',
@@ -15,7 +16,6 @@ const withMakaRoot: Decorator = (Story, context) => {
 
   root.classList.toggle('dark', colorScheme === 'dark');
   root.style.colorScheme = colorScheme;
-  root.setAttribute('lang', 'zh');
 
   if (palette === 'default') {
     root.removeAttribute('data-maka-theme');
@@ -24,9 +24,11 @@ const withMakaRoot: Decorator = (Story, context) => {
   }
 
   return (
-    <div className="h-screen w-screen overflow-y-auto bg-background p-6 text-foreground antialiased">
-      <Story />
-    </div>
+    <LocaleProvider preference="zh">
+      <div className="h-screen w-screen overflow-y-auto bg-background p-6 text-foreground antialiased">
+        <Story />
+      </div>
+    </LocaleProvider>
   );
 };
 

--- a/apps/desktop/src/main/__tests__/attachment-frontend-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/attachment-frontend-contract.test.ts
@@ -2,14 +2,20 @@ import assert from 'node:assert/strict';
 import { readFile } from 'node:fs/promises';
 import { resolve } from 'node:path';
 import { describe, it } from 'node:test';
-import { createElement } from 'react';
+import { createElement, type ReactNode } from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
 import type { AttachmentRef, SessionSummary, StoredMessage } from '@maka/core';
-import { ChatView } from '@maka/ui';
+import { ChatView, LocaleProvider } from '@maka/ui';
 
 const REPO_ROOT = process.cwd().endsWith('apps/desktop')
   ? resolve(process.cwd(), '..', '..')
   : process.cwd();
+
+function renderWithLocale(child: ReactNode): string {
+  return renderToStaticMarkup(
+    createElement(LocaleProvider, { preference: 'zh', children: child }),
+  );
+}
 
 async function readRepo(relativePath: string): Promise<string> {
   return readFile(resolve(REPO_ROOT, relativePath), 'utf8');
@@ -123,7 +129,7 @@ describe('attachment frontend contract', () => {
       permissionMode: 'ask',
     };
 
-    const markup = renderToStaticMarkup(createElement(ChatView, {
+    const markup = renderWithLocale(createElement(ChatView, {
       messages,
       activeSession,
       onNew: () => {},

--- a/apps/desktop/src/main/__tests__/automation-result-preview-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/automation-result-preview-contract.test.ts
@@ -10,12 +10,18 @@
 
 import { strict as assert } from 'node:assert';
 import { describe, it } from 'node:test';
-import { createElement } from 'react';
+import { createElement, type ReactNode } from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
 import { AutomationManager, buildAutomationTool, AUTOMATION_TOOL_NAME } from '@maka/runtime';
-import { ToolActivity, type ToolActivityItem } from '@maka/ui';
+import { LocaleProvider, ToolActivity, type ToolActivityItem } from '@maka/ui';
 
 const SESSION = 'sess-preview-contract';
+
+function renderWithLocale(child: ReactNode): string {
+  return renderToStaticMarkup(
+    createElement(LocaleProvider, { preference: 'zh', children: child }),
+  );
+}
 
 function toolCtx() {
   return {
@@ -48,7 +54,7 @@ function renderAutomationResult(text: string): string {
     args: { mode: 'create' },
     result: { kind: 'text', text },
   };
-  return renderToStaticMarkup(createElement(ToolActivity, { items: [item], open: true }));
+  return renderWithLocale(createElement(ToolActivity, { items: [item], open: true }));
 }
 
 describe('Automation tool result preview contract', () => {

--- a/apps/desktop/src/main/__tests__/composer-mention-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/composer-mention-contract.test.ts
@@ -16,11 +16,17 @@ import { strict as assert } from 'node:assert';
 import { readFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { describe, it } from 'node:test';
-import { createElement } from 'react';
+import { createElement, type ReactNode } from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
-import { Composer } from '@maka/ui';
+import { Composer, LocaleProvider } from '@maka/ui';
 
 const COMPOSER_TSX = join(process.cwd(), '../../packages/ui/src/composer.tsx');
+
+function renderWithLocale(child: ReactNode): string {
+  return renderToStaticMarkup(
+    createElement(LocaleProvider, { preference: 'zh', children: child }),
+  );
+}
 
 function keydownBody(source: string): string {
   return source.match(/function onTextareaKeyDown\(event: KeyboardEvent<HTMLTextAreaElement>\) \{[\s\S]*?\n  \}/)?.[0] ?? '';
@@ -72,7 +78,7 @@ describe('composer mention popup contract', () => {
   });
 
   it('renders inert (no listbox) when mention props are absent (SSR minimal props)', () => {
-    const markup = renderToStaticMarkup(
+    const markup = renderWithLocale(
       createElement(Composer, { onSend: () => {}, onStop: () => {} }),
     );
     assert.doesNotMatch(markup, /role="listbox"/, 'no popup without mention props');

--- a/apps/desktop/src/main/__tests__/composer-processing-hint.test.ts
+++ b/apps/desktop/src/main/__tests__/composer-processing-hint.test.ts
@@ -8,12 +8,18 @@
 
 import { strict as assert } from 'node:assert';
 import { describe, it } from 'node:test';
-import { createElement } from 'react';
+import { createElement, type ReactNode } from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
-import { Composer } from '@maka/ui';
+import { Composer, LocaleProvider } from '@maka/ui';
+
+function renderWithLocale(child: ReactNode): string {
+  return renderToStaticMarkup(
+    createElement(LocaleProvider, { preference: 'zh', children: child }),
+  );
+}
 
 function render(props: Partial<Parameters<typeof Composer>[0]>): string {
-  return renderToStaticMarkup(
+  return renderWithLocale(
     createElement(Composer, {
       onSend: () => {},
       onStop: () => {},

--- a/apps/desktop/src/main/__tests__/personalization-sync-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/personalization-sync-contract.test.ts
@@ -207,12 +207,12 @@ describe('Personalization form state sync (PR-PERSONALIZATION-SYNC-0)', () => {
       /return \(\) => \{[\s\S]*persistTicketRef\.current \+= 1;[\s\S]*clearTimeout\(toneDebounceRef\.current\)/,
       'Personalization cleanup must invalidate in-flight saves and cancel the pending debounce',
     );
-    // A stale locale must not be applied after Settings closes: the mount +
-    // ticket guard gates the applyUiLocale side effect.
+    // A stale canonical locale must not be reconciled into the form after
+    // Settings closes: the mount + ticket guard gates the local state write.
     assert.match(
       page,
-      /if \(!personalizationMountedRef\.current \|\| ticket !== persistTicketRef\.current\) return;[\s\S]*applyUiLocale\(patch\.uiLocale\)/,
-      'Personalization save must not apply a stale UI locale after Settings is closed',
+      /if \(!personalizationMountedRef\.current \|\| ticket !== persistTicketRef\.current\) return;[\s\S]*setUiLocale\(result\.settings\.personalization\.uiLocale\)/,
+      'Personalization save must not reconcile a stale UI locale after Settings is closed',
     );
     assert.match(
       page,

--- a/apps/desktop/src/main/__tests__/reactive-locale-foundation-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/reactive-locale-foundation-contract.test.ts
@@ -9,6 +9,10 @@ function rendererSource(file: string): string {
   return readFileSync(resolve(REPO_ROOT, 'apps/desktop/src/renderer', file), 'utf8');
 }
 
+function repoSource(file: string): string {
+  return readFileSync(resolve(REPO_ROOT, file), 'utf8');
+}
+
 describe('reactive locale foundation', () => {
   it('owns one persisted preference and one test override in AppShell state', () => {
     const source = rendererSource('app-shell.tsx');
@@ -67,11 +71,14 @@ describe('reactive locale foundation', () => {
   it('uses the reactive locale for desktop copy and Intl formatting', () => {
     const onboarding = rendererSource('OnboardingHero.tsx');
     const artifact = rendererSource('artifact-pane.tsx');
+    const toolPreview = repoSource('packages/ui/src/tool-activity/builtin-preview.ts');
 
     assert.match(onboarding, /useUiLocale\(\)/);
     assert.match(artifact, /useUiLocale\(\)/);
     assert.match(artifact, /formatRelativeTimestamp\(record\.createdAt, Date\.now\(\), locale\)/);
     assert.doesNotMatch(onboarding, /detectUiLocale/);
+    assert.doesNotMatch(toolPreview, /detectUiLocale/);
+    assert.match(toolPreview, /locale: UiLocale/);
   });
 
   it('keeps provider catalog copy on the same reactive locale path', () => {

--- a/apps/desktop/src/main/__tests__/reactive-locale-foundation-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/reactive-locale-foundation-contract.test.ts
@@ -16,7 +16,7 @@ describe('reactive locale foundation', () => {
 
     assert.match(source, /useState<UiLocalePreference>\('auto'\)/);
     assert.match(source, /useState<UiLocale \| null>\(null\)/);
-    assert.match(source, /setUiLocalePreference\(uiLocale\)/);
+    assert.match(source, /setUiLocalePreference\(preference\)/);
     assert.match(source, /setUiLocaleOverride\(smoke\?\.locale \?\? null\)/);
     assert.match(
       source,
@@ -26,6 +26,7 @@ describe('reactive locale foundation', () => {
   });
 
   it('feeds the persisted settings result back into React without a DOM side channel', () => {
+    const appShell = rendererSource('app-shell.tsx');
     const overlays = rendererSource('app-shell-overlays.tsx');
     const modal = rendererSource('settings/SettingsModal.tsx');
     const surface = rendererSource('settings/settings-surface.tsx');
@@ -34,7 +35,12 @@ describe('reactive locale foundation', () => {
 
     assert.match(overlays, /setUiLocalePreference: \(preference: UiLocalePreference\) => void/);
     assert.match(modal, /onUiLocalePreferenceChange\(preference: UiLocalePreference\): void/);
-    assert.match(surface, /const \[uiLocaleUpdateGate\] = useState\(createUiLocaleUpdateGate\)/);
+    assert.match(appShell, /const \[uiLocaleUpdateGate\] = useState\(createUiLocaleUpdateGate\)/);
+    assert.match(appShell, /uiLocaleUpdateGate\.beginHydration\(\)/);
+    assert.match(appShell, /uiLocaleUpdateGate\.commitHydration\(/);
+    assert.match(appShell, /uiLocaleUpdateGate=\{uiLocaleUpdateGate\}/);
+    assert.match(surface, /uiLocaleUpdateGate: UiLocaleUpdateGate/);
+    assert.doesNotMatch(surface, /useState\(createUiLocaleUpdateGate\)/);
     assert.match(
       surface,
       /uiLocaleUpdateGate\.commit\([\s\S]*next\.personalization\.uiLocale,[\s\S]*props\.onUiLocalePreferenceChange,[\s\S]*\);[\s\S]*if \(settingsModalMountedRef\.current/,

--- a/apps/desktop/src/main/__tests__/reactive-locale-foundation-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/reactive-locale-foundation-contract.test.ts
@@ -61,4 +61,31 @@ describe('reactive locale foundation', () => {
     assert.match(artifact, /formatRelativeTimestamp\(record\.createdAt, Date\.now\(\), locale\)/);
     assert.doesNotMatch(onboarding, /detectUiLocale/);
   });
+
+  it('keeps provider catalog copy on the same reactive locale path', () => {
+    const display = rendererSource('settings/provider-display.tsx');
+    const copy = rendererSource('settings/provider-display-copy.ts');
+
+    assert.doesNotMatch(display, /detectUiLocale/);
+    assert.match(display, /locale: UiLocale/);
+    assert.doesNotMatch(display, /locale:\s*UiLocale\s*=/, 'providerDisplay must not infer a locale');
+    assert.match(copy, /satisfies Record<ProviderType, UiCatalog<ProviderCopy>>/);
+    assert.doesNotMatch(copy, /ProviderDisplayLocale/);
+
+    for (const file of [
+      'OnboardingHero.tsx',
+      'settings/provider-add-form.tsx',
+      'settings/provider-catalog.tsx',
+      'settings/provider-connection-detail.tsx',
+      'settings/ProvidersPanel.tsx',
+    ]) {
+      const source = rendererSource(file);
+      assert.match(source, /useUiLocale\(\)/, `${file} must consume the reactive locale`);
+      assert.doesNotMatch(
+        source,
+        /providerDisplay\([^,\n)]+\)/,
+        `${file} must pass the reactive locale to providerDisplay`,
+      );
+    }
+  });
 });

--- a/apps/desktop/src/main/__tests__/reactive-locale-foundation-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/reactive-locale-foundation-contract.test.ts
@@ -52,10 +52,16 @@ describe('reactive locale foundation', () => {
 
   it('keeps visual-smoke locale overrides in the same provider path', () => {
     const source = rendererSource('app-shell-visual-smoke.ts');
+    const appShell = rendererSource('app-shell.tsx');
 
     assert.match(source, /setUiLocaleOverride: Dispatch<SetStateAction<UiLocale \| null>>/);
     assert.match(source, /setUiLocaleOverride\(state\.locale \?\? null\)/);
     assert.doesNotMatch(source, /data-maka-visual-smoke-locale/);
+    assert.ok(
+      appShell.indexOf('setUiLocaleOverride(smoke?.locale ?? null)')
+        < appShell.indexOf('uiLocaleUpdateGate.commitHydration('),
+      'visual-smoke override hydration must not be gated by persisted preference hydration',
+    );
   });
 
   it('uses the reactive locale for desktop copy and Intl formatting', () => {

--- a/apps/desktop/src/main/__tests__/reactive-locale-foundation-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/reactive-locale-foundation-contract.test.ts
@@ -34,7 +34,12 @@ describe('reactive locale foundation', () => {
 
     assert.match(overlays, /setUiLocalePreference: \(preference: UiLocalePreference\) => void/);
     assert.match(modal, /onUiLocalePreferenceChange\(preference: UiLocalePreference\): void/);
-    assert.match(surface, /props\.onUiLocalePreferenceChange\(next\.personalization\.uiLocale\)/);
+    assert.match(surface, /const uiLocaleUpdateTicketRef = useRef\(0\)/);
+    assert.match(
+      surface,
+      /uiLocaleTicket !== null[\s\S]*uiLocaleTicket === uiLocaleUpdateTicketRef\.current[\s\S]*props\.onUiLocalePreferenceChange\(next\.personalization\.uiLocale\)/,
+      'an unrelated settings request must not suppress a successful locale update',
+    );
     assert.doesNotMatch(appearance, /applyUiLocale/);
     assert.doesNotMatch(theme, /applyUiLocale|UiLocalePreference/);
   });

--- a/apps/desktop/src/main/__tests__/reactive-locale-foundation-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/reactive-locale-foundation-contract.test.ts
@@ -34,11 +34,11 @@ describe('reactive locale foundation', () => {
 
     assert.match(overlays, /setUiLocalePreference: \(preference: UiLocalePreference\) => void/);
     assert.match(modal, /onUiLocalePreferenceChange\(preference: UiLocalePreference\): void/);
-    assert.match(surface, /const uiLocaleUpdateTicketRef = useRef\(0\)/);
+    assert.match(surface, /const \[uiLocaleUpdateGate\] = useState\(createUiLocaleUpdateGate\)/);
     assert.match(
       surface,
-      /uiLocaleTicket !== null[\s\S]*uiLocaleTicket === uiLocaleUpdateTicketRef\.current[\s\S]*props\.onUiLocalePreferenceChange\(next\.personalization\.uiLocale\)/,
-      'an unrelated settings request must not suppress a successful locale update',
+      /uiLocaleUpdateGate\.commit\([\s\S]*next\.personalization\.uiLocale,[\s\S]*props\.onUiLocalePreferenceChange,[\s\S]*\);[\s\S]*if \(settingsModalMountedRef\.current/,
+      'locale success must reach AppShell independently of local Settings ownership',
     );
     assert.doesNotMatch(appearance, /applyUiLocale/);
     assert.doesNotMatch(theme, /applyUiLocale|UiLocalePreference/);

--- a/apps/desktop/src/main/__tests__/reactive-locale-foundation-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/reactive-locale-foundation-contract.test.ts
@@ -1,0 +1,59 @@
+import { strict as assert } from 'node:assert';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, it } from 'node:test';
+
+const REPO_ROOT = resolve(import.meta.dirname, '../../../../..');
+
+function rendererSource(file: string): string {
+  return readFileSync(resolve(REPO_ROOT, 'apps/desktop/src/renderer', file), 'utf8');
+}
+
+describe('reactive locale foundation', () => {
+  it('owns one persisted preference and one test override in AppShell state', () => {
+    const source = rendererSource('app-shell.tsx');
+    const html = rendererSource('index.html');
+
+    assert.match(source, /useState<UiLocalePreference>\('auto'\)/);
+    assert.match(source, /useState<UiLocale \| null>\(null\)/);
+    assert.match(source, /setUiLocalePreference\(uiLocale\)/);
+    assert.match(source, /setUiLocaleOverride\(smoke\?\.locale \?\? null\)/);
+    assert.match(
+      source,
+      /<LocaleProvider preference=\{uiLocalePreference\} override=\{uiLocaleOverride\}>[\s\S]*?<AppShellOverlays/,
+    );
+    assert.match(html, /<html lang="zh">/, 'the pre-React document must match auto -> zh');
+  });
+
+  it('feeds the persisted settings result back into React without a DOM side channel', () => {
+    const overlays = rendererSource('app-shell-overlays.tsx');
+    const modal = rendererSource('settings/SettingsModal.tsx');
+    const surface = rendererSource('settings/settings-surface.tsx');
+    const appearance = rendererSource('settings/appearance-settings-page.tsx');
+    const theme = rendererSource('theme.ts');
+
+    assert.match(overlays, /setUiLocalePreference: \(preference: UiLocalePreference\) => void/);
+    assert.match(modal, /onUiLocalePreferenceChange\(preference: UiLocalePreference\): void/);
+    assert.match(surface, /props\.onUiLocalePreferenceChange\(next\.personalization\.uiLocale\)/);
+    assert.doesNotMatch(appearance, /applyUiLocale/);
+    assert.doesNotMatch(theme, /applyUiLocale|UiLocalePreference/);
+  });
+
+  it('keeps visual-smoke locale overrides in the same provider path', () => {
+    const source = rendererSource('app-shell-visual-smoke.ts');
+
+    assert.match(source, /setUiLocaleOverride: Dispatch<SetStateAction<UiLocale \| null>>/);
+    assert.match(source, /setUiLocaleOverride\(state\.locale \?\? null\)/);
+    assert.doesNotMatch(source, /data-maka-visual-smoke-locale/);
+  });
+
+  it('uses the reactive locale for desktop copy and Intl formatting', () => {
+    const onboarding = rendererSource('OnboardingHero.tsx');
+    const artifact = rendererSource('artifact-pane.tsx');
+
+    assert.match(onboarding, /useUiLocale\(\)/);
+    assert.match(artifact, /useUiLocale\(\)/);
+    assert.match(artifact, /formatRelativeTimestamp\(record\.createdAt, Date\.now\(\), locale\)/);
+    assert.doesNotMatch(onboarding, /detectUiLocale/);
+  });
+});

--- a/apps/desktop/src/main/__tests__/renderer-startup-fail-soft-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/renderer-startup-fail-soft-contract.test.ts
@@ -42,7 +42,7 @@ describe('renderer startup fail-soft contract', () => {
     assert.match(mountEffect, /void (?:options\.|latest\.)?refreshShellSettings\(\)/);
     assert.match(
       refreshShellSettings,
-      /try \{[\s\S]*window\.maka\.settings\.get\(\)[\s\S]*setUiLocalePreference\(uiLocale\)[\s\S]*setUiLocaleOverride\(smoke\?\.locale \?\? null\)[\s\S]*applyTheme\(pref\)[\s\S]*applyThemePalette\(palette\)[\s\S]*\} catch \(error\) \{[\s\S]*toastApi\.error\('载入外观设置失败', generalizedErrorMessageChinese\(error, '外观设置暂时无法载入，请稍后重试。'\)\)/,
+      /try \{[\s\S]*window\.maka\.settings\.get\(\)[\s\S]*uiLocaleUpdateGate\.commitHydration\([\s\S]*setUiLocalePreference\(preference\)[\s\S]*setUiLocaleOverride\(smoke\?\.locale \?\? null\)[\s\S]*applyTheme\(pref\)[\s\S]*applyThemePalette\(palette\)[\s\S]*\} catch \(error\) \{[\s\S]*toastApi\.error\('载入外观设置失败', generalizedErrorMessageChinese\(error, '外观设置暂时无法载入，请稍后重试。'\)\)/,
       'startup shell settings load failures must surface visibly without exposing raw storage/system details',
     );
     assert.doesNotMatch(refreshShellSettings, /toastApi\.error\('载入外观设置失败', cleanErrorMessage\(error\)\)/);

--- a/apps/desktop/src/main/__tests__/renderer-startup-fail-soft-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/renderer-startup-fail-soft-contract.test.ts
@@ -42,13 +42,13 @@ describe('renderer startup fail-soft contract', () => {
     assert.match(mountEffect, /void (?:options\.|latest\.)?refreshShellSettings\(\)/);
     assert.match(
       refreshShellSettings,
-      /try \{[\s\S]*window\.maka\.settings\.get\(\)[\s\S]*applyUiLocale\(uiLocale\)[\s\S]*applyTheme\(pref\)[\s\S]*applyThemePalette\(palette\)[\s\S]*\} catch \(error\) \{[\s\S]*toastApi\.error\('载入外观设置失败', generalizedErrorMessageChinese\(error, '外观设置暂时无法载入，请稍后重试。'\)\)/,
+      /try \{[\s\S]*window\.maka\.settings\.get\(\)[\s\S]*setUiLocalePreference\(uiLocale\)[\s\S]*setUiLocaleOverride\(smoke\?\.locale \?\? null\)[\s\S]*applyTheme\(pref\)[\s\S]*applyThemePalette\(palette\)[\s\S]*\} catch \(error\) \{[\s\S]*toastApi\.error\('载入外观设置失败', generalizedErrorMessageChinese\(error, '外观设置暂时无法载入，请稍后重试。'\)\)/,
       'startup shell settings load failures must surface visibly without exposing raw storage/system details',
     );
     assert.doesNotMatch(refreshShellSettings, /toastApi\.error\('载入外观设置失败', cleanErrorMessage\(error\)\)/);
     assert.doesNotMatch(
       refreshShellSettings,
-      /catch \(error\) \{[\s\S]*applyUiLocale\('auto'\)|catch \(error\) \{[\s\S]*applyTheme\('auto'\)|catch \(error\) \{[\s\S]*applyThemePalette\('default'\)/,
+      /catch \(error\) \{[\s\S]*setUiLocalePreference\('auto'\)|catch \(error\) \{[\s\S]*applyTheme\('auto'\)|catch \(error\) \{[\s\S]*applyThemePalette\('default'\)/,
       'startup shell settings failures must not force default language/theme/palette over unknown persisted settings',
     );
     assert.match(

--- a/apps/desktop/src/main/__tests__/renderer-startup-fail-soft-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/renderer-startup-fail-soft-contract.test.ts
@@ -42,7 +42,7 @@ describe('renderer startup fail-soft contract', () => {
     assert.match(mountEffect, /void (?:options\.|latest\.)?refreshShellSettings\(\)/);
     assert.match(
       refreshShellSettings,
-      /try \{[\s\S]*window\.maka\.settings\.get\(\)[\s\S]*uiLocaleUpdateGate\.commitHydration\([\s\S]*setUiLocalePreference\(preference\)[\s\S]*setUiLocaleOverride\(smoke\?\.locale \?\? null\)[\s\S]*applyTheme\(pref\)[\s\S]*applyThemePalette\(palette\)[\s\S]*\} catch \(error\) \{[\s\S]*toastApi\.error\('载入外观设置失败', generalizedErrorMessageChinese\(error, '外观设置暂时无法载入，请稍后重试。'\)\)/,
+      /try \{[\s\S]*window\.maka\.settings\.get\(\)[\s\S]*setUiLocaleOverride\(smoke\?\.locale \?\? null\)[\s\S]*uiLocaleUpdateGate\.commitHydration\([\s\S]*setUiLocalePreference\(preference\)[\s\S]*applyTheme\(pref\)[\s\S]*applyThemePalette\(palette\)[\s\S]*\} catch \(error\) \{[\s\S]*toastApi\.error\('载入外观设置失败', generalizedErrorMessageChinese\(error, '外观设置暂时无法载入，请稍后重试。'\)\)/,
       'startup shell settings load failures must surface visibly without exposing raw storage/system details',
     );
     assert.doesNotMatch(refreshShellSettings, /toastApi\.error\('载入外观设置失败', cleanErrorMessage\(error\)\)/);

--- a/apps/desktop/src/main/__tests__/session-list-render-helpers.ts
+++ b/apps/desktop/src/main/__tests__/session-list-render-helpers.ts
@@ -1,5 +1,5 @@
 import type { SessionSummary } from '@maka/core';
-import { SessionListPanel } from '@maka/ui';
+import { LocaleProvider, SessionListPanel } from '@maka/ui';
 import { createElement } from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
 
@@ -36,16 +36,19 @@ export function renderSessionListPanel(options: {
     onDelete() {},
   };
 
-  return renderToStaticMarkup(createElement(SessionListPanel, {
-    selection: { section: 'sessions', filter: 'chats' },
-    sessions: options.sessions ?? [makeSessionSummary(options.session)],
-    statusGroups: options.statusGroups,
-    viewMode: options.viewMode,
-    onViewModeChange: options.viewMode ? () => {} : undefined,
-    onSelectSession() {},
-    onSelect() {},
-    onOpenSettings() {},
-    onNew() {},
-    rowActions,
-  } satisfies Parameters<typeof SessionListPanel>[0]));
+  return renderToStaticMarkup(createElement(LocaleProvider, {
+    preference: 'zh',
+    children: createElement(SessionListPanel, {
+      selection: { section: 'sessions', filter: 'chats' },
+      sessions: options.sessions ?? [makeSessionSummary(options.session)],
+      statusGroups: options.statusGroups,
+      viewMode: options.viewMode,
+      onViewModeChange: options.viewMode ? () => {} : undefined,
+      onSelectSession() {},
+      onSelect() {},
+      onOpenSettings() {},
+      onNew() {},
+      rowActions,
+    } satisfies Parameters<typeof SessionListPanel>[0]),
+  }));
 }

--- a/apps/desktop/src/main/__tests__/streaming-handoff.test.ts
+++ b/apps/desktop/src/main/__tests__/streaming-handoff.test.ts
@@ -1,15 +1,22 @@
 import { strict as assert } from 'node:assert';
 import { describe, it } from 'node:test';
-import { createElement } from 'react';
+import { createElement, type ReactNode } from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
 import type { SessionEvent } from '@maka/core';
 import {
   armLiveTurn,
   ChatView,
+  LocaleProvider,
   type LiveTurnProjection,
   type InteractionQueues,
 } from '@maka/ui';
 import { createAppShellSessionEventHandlers } from '../../renderer/app-shell-session-events.js';
+
+function renderWithLocale(child: ReactNode): string {
+  return renderToStaticMarkup(
+    createElement(LocaleProvider, { preference: 'zh', children: child }),
+  );
+}
 
 function createStateSetter<T>(initial: T): {
   get(): T;
@@ -25,7 +32,7 @@ function createStateSetter<T>(initial: T): {
 }
 
 function renderLiveTurn(liveTurn: LiveTurnProjection): string {
-  return renderToStaticMarkup(createElement(ChatView, {
+  return renderWithLocale(createElement(ChatView, {
     activeSession: {
       id: 'session-1',
       name: 'streaming',
@@ -74,7 +81,7 @@ describe('single live-turn handoff', () => {
 
   it('keeps a completed live answer as the only visible owner until settle', () => {
     const finalText = 'one visible answer';
-    const markup = renderToStaticMarkup(createElement(ChatView, {
+    const markup = renderWithLocale(createElement(ChatView, {
       activeSession: {
         id: 'session-1', name: 'streaming', lastMessageAt: 1, status: 'active', backend: 'ai-sdk',
         labels: [], isFlagged: false, isArchived: false, hasUnread: false,
@@ -103,7 +110,7 @@ describe('single live-turn handoff', () => {
 
   it('keeps an incomplete live answer as the only owner after early persistence', () => {
     const text = 'persisted before a slow tool finishes';
-    const markup = renderToStaticMarkup(createElement(ChatView, {
+    const markup = renderWithLocale(createElement(ChatView, {
       activeSession: {
         id: 'session-1', name: 'streaming', lastMessageAt: 1, status: 'running', backend: 'pi-agent',
         labels: [], isFlagged: false, isArchived: false, hasUnread: false,

--- a/apps/desktop/src/main/__tests__/subagent-ui-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/subagent-ui-contract.test.ts
@@ -2,24 +2,27 @@ import { strict as assert } from 'node:assert';
 import { describe, it } from 'node:test';
 import { createElement } from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
-import { OverlayHost } from '@maka/ui';
+import { LocaleProvider, OverlayHost } from '@maka/ui';
 
 describe('subagent UI contract', () => {
   it('renders a compact subagent card without exposing internal ids', () => {
-    const markup = renderToStaticMarkup(createElement(OverlayHost, {
-      content: {
-        kind: 'subagent',
-        agentName: 'Research Agent',
-        turnId: 'turn-secret-123',
-        runId: 'run-secret-456',
-        status: 'completed',
-        permissionMode: 'explore',
-        summary: 'Mapped the runtime path.',
-        artifactIds: ['artifact-secret-1', 'artifact-secret-2'],
-        durationMs: 14_500,
-        eventCount: 42,
-      },
-      onClose: () => {},
+    const markup = renderToStaticMarkup(createElement(LocaleProvider, {
+      preference: 'zh',
+      children: createElement(OverlayHost, {
+        content: {
+          kind: 'subagent',
+          agentName: 'Research Agent',
+          turnId: 'turn-secret-123',
+          runId: 'run-secret-456',
+          status: 'completed',
+          permissionMode: 'explore',
+          summary: 'Mapped the runtime path.',
+          artifactIds: ['artifact-secret-1', 'artifact-secret-2'],
+          durationMs: 14_500,
+          eventCount: 42,
+        },
+        onClose: () => {},
+      }),
     }));
 
     assert.match(markup, /data-kind="subagent"/);

--- a/apps/desktop/src/main/__tests__/tool-activity-result-preview-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/tool-activity-result-preview-contract.test.ts
@@ -5,7 +5,7 @@ import { describe, it } from 'node:test';
 import { createElement } from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
 import type { ToolResultContent } from '@maka/core';
-import { OverlayHost } from '@maka/ui';
+import { LocaleProvider, OverlayHost } from '@maka/ui';
 
 const SECRET = 'sk-1234567890abcdefghi';
 
@@ -209,7 +209,10 @@ describe('ToolActivity result preview contract', () => {
 });
 
 function renderPreview(content: ToolResultContent): string {
-  return renderToStaticMarkup(createElement(OverlayHost, { content, onClose: () => {} }));
+  return renderToStaticMarkup(createElement(LocaleProvider, {
+    preference: 'zh',
+    children: createElement(OverlayHost, { content, onClose: () => {} }),
+  }));
 }
 
 function numberedLines(prefix: string, count: number): string {

--- a/apps/desktop/src/main/__tests__/tool-args-redaction-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/tool-args-redaction-contract.test.ts
@@ -27,7 +27,7 @@ describe('tool and permission args redaction', () => {
     const permissionPrompt = permissionSource.match(/export function PermissionPrompt[\s\S]*?function renderPermissionSummary/)?.[0] ?? '';
 
     // Quiet panel: never stringify args; use formatToolInvocationLine / formatQuietJsonValue.
-    assert.match(toolActivity, /formatToolInvocationLine\(item\)/);
+    assert.match(toolActivity, /formatToolInvocationLine\(item, locale\)/);
     assert.match(toolActivity, /formatQuietJsonValue/);
     assert.doesNotMatch(toolActivity, /JSON\.stringify\(item\.args/);
     assert.doesNotMatch(toolActivity, /formatRedactedJson\(item\.args\)/);

--- a/apps/desktop/src/main/__tests__/tool-error-collapse-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/tool-error-collapse-contract.test.ts
@@ -20,13 +20,19 @@
  */
 
 import { strict as assert } from 'node:assert';
-import { createElement } from 'react';
+import { createElement, type ReactNode } from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
 import { describe, it } from 'node:test';
 import type { ToolActivityItem } from '@maka/ui';
-import { ToolActivity, ToolErrorDetails } from '@maka/ui';
+import { LocaleProvider, ToolActivity, ToolErrorDetails } from '@maka/ui';
 
 const TAIL_MARKER = 'TAIL_MARKER_SCHEMA_DETAILS';
+
+function renderWithLocale(child: ReactNode): string {
+  return renderToStaticMarkup(
+    createElement(LocaleProvider, { preference: 'zh', children: child }),
+  );
+}
 
 // A long, natural-language error whose tail sits past the banner's 240px
 // truncation. Repeating varied prose (not a single-char run) so redactSecrets
@@ -44,11 +50,11 @@ function erroredItem(errorText: string): ToolActivityItem {
 }
 
 function renderErrored(errorText: string): string {
-  return renderToStaticMarkup(createElement(ToolActivity, { items: [erroredItem(errorText)] }));
+  return renderWithLocale(createElement(ToolActivity, { items: [erroredItem(errorText)] }));
 }
 
 function renderExpanded(errorText: string): string {
-  return renderToStaticMarkup(createElement(ToolActivity, { items: [erroredItem(errorText)], open: true }));
+  return renderWithLocale(createElement(ToolActivity, { items: [erroredItem(errorText)], open: true }));
 }
 
 describe('PR-TOOL-ERROR-COLLAPSE-0 contract (issue #741)', () => {
@@ -91,7 +97,7 @@ describe('PR-TOOL-ERROR-COLLAPSE-0 contract (issue #741)', () => {
     // #741 P2: args:{} + errored + non-owned used to leave an empty destructive
     // tool-output box (the raw moved to the disclosure, but showResult kept the
     // shared panel open with nothing in it).
-    const markup = renderToStaticMarkup(createElement(ToolActivity, { items: [{
+    const markup = renderWithLocale(createElement(ToolActivity, { items: [{
       toolUseId: 'tu_empty', toolName: 'unknown_tool', status: 'errored', args: {},
       result: { kind: 'text', text: 'validation failed' },
     }], open: true }));

--- a/apps/desktop/src/main/__tests__/ui-locale-update-gate.test.ts
+++ b/apps/desktop/src/main/__tests__/ui-locale-update-gate.test.ts
@@ -108,4 +108,32 @@ describe('UI locale settings update gate', () => {
     );
     assert.deepEqual(applied, ['zh']);
   });
+
+  it('accepts an older pending save after the newer save fails', () => {
+    const gate = createUiLocaleUpdateGate();
+    const firstSaveTicket = gate.begin(true);
+    const failedSaveTicket = gate.begin(true);
+    const applied: string[] = [];
+
+    gate.cancel(failedSaveTicket);
+    assert.equal(
+      gate.commit(firstSaveTicket, 'en', (next) => applied.push(next)),
+      true,
+    );
+    assert.deepEqual(applied, ['en']);
+  });
+
+  it('restores an older successful save when the newer save fails later', () => {
+    const gate = createUiLocaleUpdateGate();
+    const firstSaveTicket = gate.begin(true);
+    const failedSaveTicket = gate.begin(true);
+    const applied: string[] = [];
+
+    assert.equal(
+      gate.commit(firstSaveTicket, 'en', (next) => applied.push(next)),
+      false,
+    );
+    gate.cancel(failedSaveTicket);
+    assert.deepEqual(applied, ['en']);
+  });
 });

--- a/apps/desktop/src/main/__tests__/ui-locale-update-gate.test.ts
+++ b/apps/desktop/src/main/__tests__/ui-locale-update-gate.test.ts
@@ -1,0 +1,46 @@
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'node:test';
+
+import { createUiLocaleUpdateGate } from '../../renderer/settings/ui-locale-update-gate.js';
+
+describe('UI locale settings update gate', () => {
+  it('delivers a successful locale save after the Settings surface closes', async () => {
+    const gate = createUiLocaleUpdateGate();
+    const ticket = gate.begin(true);
+    const savedLocales: string[] = [];
+    const save = Promise.resolve('en' as const);
+
+    // Closing Settings invalidates local UI ownership, but AppShell remains
+    // mounted and still owns the locale callback.
+    const surfaceMounted = false;
+    await save.then((locale) => {
+      assert.equal(surfaceMounted, false);
+      assert.equal(gate.commit(ticket, locale, (next) => savedLocales.push(next)), true);
+    });
+
+    assert.deepEqual(savedLocales, ['en']);
+  });
+
+  it('ignores unrelated settings writes and rejects stale locale responses', () => {
+    const gate = createUiLocaleUpdateGate();
+    const firstLocaleTicket = gate.begin(true);
+    assert.equal(gate.begin(false), null);
+    const latestLocaleTicket = gate.begin(true);
+    const savedLocales: string[] = [];
+
+    assert.equal(gate.commit(firstLocaleTicket, 'en', (next) => savedLocales.push(next)), false);
+    assert.equal(gate.commit(latestLocaleTicket, 'zh', (next) => savedLocales.push(next)), true);
+    assert.deepEqual(savedLocales, ['zh']);
+  });
+
+  it('delivers the persisted auto preference without resolving it locally', () => {
+    const gate = createUiLocaleUpdateGate();
+    const savedPreferences: string[] = [];
+
+    assert.equal(
+      gate.commit(gate.begin(true), 'auto', (next) => savedPreferences.push(next)),
+      true,
+    );
+    assert.deepEqual(savedPreferences, ['auto']);
+  });
+});

--- a/apps/desktop/src/main/__tests__/ui-locale-update-gate.test.ts
+++ b/apps/desktop/src/main/__tests__/ui-locale-update-gate.test.ts
@@ -43,4 +43,69 @@ describe('UI locale settings update gate', () => {
     );
     assert.deepEqual(savedPreferences, ['auto']);
   });
+
+  it('rejects a stale hydration that started before a newer locale save', () => {
+    const gate = createUiLocaleUpdateGate();
+    const hydration = gate.beginHydration();
+    const saveTicket = gate.begin(true);
+    const applied: string[] = [];
+
+    assert.equal(gate.commit(saveTicket, 'en', (next) => applied.push(next)), true);
+    assert.equal(
+      gate.commitHydration(hydration, 'zh', (next) => applied.push(next)),
+      false,
+    );
+    assert.deepEqual(applied, ['en']);
+  });
+
+  it('rejects hydration started while a locale save is pending', () => {
+    const gate = createUiLocaleUpdateGate();
+    const saveTicket = gate.begin(true);
+    const hydration = gate.beginHydration();
+    const applied: string[] = [];
+
+    assert.equal(
+      gate.commitHydration(hydration, 'zh', (next) => applied.push(next)),
+      false,
+    );
+    assert.equal(gate.commit(saveTicket, 'en', (next) => applied.push(next)), true);
+    assert.deepEqual(applied, ['en']);
+  });
+
+  it('orders locale saves across Settings remounts with one AppShell gate', () => {
+    const appShellGate = createUiLocaleUpdateGate();
+    const firstSurfaceTicket = appShellGate.begin(true);
+    const secondSurfaceTicket = appShellGate.begin(true);
+    const applied: string[] = [];
+
+    assert.equal(
+      appShellGate.commit(secondSurfaceTicket, 'en', (next) => applied.push(next)),
+      true,
+    );
+    assert.equal(
+      appShellGate.commit(firstSurfaceTicket, 'zh', (next) => applied.push(next)),
+      false,
+    );
+    assert.deepEqual(applied, ['en']);
+  });
+
+  it('releases a failed save so a later hydration can apply', () => {
+    const gate = createUiLocaleUpdateGate();
+    const failedSaveTicket = gate.begin(true);
+    const blockedHydration = gate.beginHydration();
+    const applied: string[] = [];
+
+    gate.cancel(failedSaveTicket);
+    assert.equal(
+      gate.commitHydration(blockedHydration, 'zh', (next) => applied.push(next)),
+      false,
+    );
+
+    const retryHydration = gate.beginHydration();
+    assert.equal(
+      gate.commitHydration(retryHydration, 'zh', (next) => applied.push(next)),
+      true,
+    );
+    assert.deepEqual(applied, ['zh']);
+  });
 });

--- a/apps/desktop/src/main/__tests__/ui-locale-update-gate.test.ts
+++ b/apps/desktop/src/main/__tests__/ui-locale-update-gate.test.ts
@@ -89,7 +89,7 @@ describe('UI locale settings update gate', () => {
     assert.deepEqual(applied, ['en']);
   });
 
-  it('releases a failed save so a later hydration can apply', () => {
+  it('releases a failed save so an in-flight hydration can apply', () => {
     const gate = createUiLocaleUpdateGate();
     const failedSaveTicket = gate.begin(true);
     const blockedHydration = gate.beginHydration();
@@ -98,14 +98,24 @@ describe('UI locale settings update gate', () => {
     gate.cancel(failedSaveTicket);
     assert.equal(
       gate.commitHydration(blockedHydration, 'zh', (next) => applied.push(next)),
-      false,
-    );
-
-    const retryHydration = gate.beginHydration();
-    assert.equal(
-      gate.commitHydration(retryHydration, 'zh', (next) => applied.push(next)),
       true,
     );
+    assert.deepEqual(applied, ['zh']);
+  });
+
+  it('applies the latest blocked hydration when an intervening locale save fails', () => {
+    const gate = createUiLocaleUpdateGate();
+    const hydration = gate.beginHydration();
+    const failedSaveTicket = gate.begin(true);
+    const applied: string[] = [];
+
+    assert.equal(
+      gate.commitHydration(hydration, 'zh', (next) => applied.push(next)),
+      false,
+    );
+    assert.deepEqual(applied, []);
+
+    gate.cancel(failedSaveTicket);
     assert.deepEqual(applied, ['zh']);
   });
 

--- a/apps/desktop/src/main/__tests__/ui-render-memo-boundary-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/ui-render-memo-boundary-contract.test.ts
@@ -11,6 +11,7 @@ const REPO_ROOT = resolve(import.meta.dirname, '../../../../..');
 const LUCIDE_REACT_PACKAGE = ['lucide', 'react'].join('-');
 
 type SessionHistoryModule = {
+  LocaleProvider(props: { preference: 'zh'; children: ReactElement }): ReactElement;
   SessionHistoryList(props: {
     sessions: SessionSummary[];
     activeId?: string;
@@ -42,7 +43,7 @@ afterEach(() => {
 
 describe('UI render memo boundary contract', () => {
   it('keeps sidebar session rows from rendering on unrelated parent updates with row actions present', async () => {
-    const { SessionHistoryList } = await importSessionHistoryList();
+    const { LocaleProvider, SessionHistoryList } = await importSessionHistoryList();
     const root = installReactRenderer();
     let rowRenderCount = 0;
     const sessions = [
@@ -61,6 +62,7 @@ describe('UI render memo boundary contract', () => {
     resetTimestampCounters(sessions);
     await render(root, createElement(RenderHost, {
       SessionHistoryList,
+      LocaleProvider,
       label: 'first parent render',
       onSelectSession,
       rowActions,
@@ -73,6 +75,7 @@ describe('UI render memo boundary contract', () => {
     resetTimestampCounters(sessions);
     await render(root, createElement(RenderHost, {
       SessionHistoryList,
+      LocaleProvider,
       label: 'unrelated parent render',
       onSelectSession,
       rowActions,
@@ -91,6 +94,7 @@ describe('UI render memo boundary contract', () => {
     resetTimestampCounters(sessions);
     await render(root, createElement(RenderHost, {
       SessionHistoryList,
+      LocaleProvider,
       label: 'streaming session update',
       onSelectSession,
       rowActions,
@@ -108,6 +112,7 @@ describe('UI render memo boundary contract', () => {
 });
 
 function RenderHost(props: {
+  LocaleProvider: SessionHistoryModule['LocaleProvider'];
   SessionHistoryList: SessionHistoryModule['SessionHistoryList'];
   label: string;
   onSelectSession(sessionId: string): void;
@@ -116,19 +121,22 @@ function RenderHost(props: {
   staleSessionIds: Set<string>;
   streamingSessionIds: Set<string>;
 }) {
-  return createElement(
-    'div',
-    null,
-    createElement('p', null, props.label),
-    createElement(props.SessionHistoryList, {
-      sessions: props.sessions,
-      activeId: 'session-a',
-      streamingSessionIds: props.streamingSessionIds,
-      staleSessionIds: props.staleSessionIds,
-      onSelectSession: props.onSelectSession,
-      rowActions: props.rowActions,
-    }),
-  );
+  return createElement(props.LocaleProvider, {
+    preference: 'zh',
+    children: createElement(
+      'div',
+      null,
+      createElement('p', null, props.label),
+      createElement(props.SessionHistoryList, {
+        sessions: props.sessions,
+        activeId: 'session-a',
+        streamingSessionIds: props.streamingSessionIds,
+        staleSessionIds: props.staleSessionIds,
+        onSelectSession: props.onSelectSession,
+        rowActions: props.rowActions,
+      }),
+    ),
+  });
 }
 
 function createSession(id: string, name: string, onRender: () => void): SessionSummary {
@@ -189,7 +197,14 @@ function createRowActions(): NonNullable<Parameters<SessionHistoryModule['Sessio
 async function importSessionHistoryList(): Promise<SessionHistoryModule> {
   const outfile = resolve(REPO_ROOT, 'apps/desktop/dist/main/__tests__/session-history-list.memo-bundle.mjs');
   await build({
-    entryPoints: [resolve(REPO_ROOT, 'packages/ui/dist/session-history-list.js')],
+    stdin: {
+      contents: [
+        "export { SessionHistoryList } from './packages/ui/dist/session-history-list.js';",
+        "export { LocaleProvider } from './packages/ui/dist/locale-context.js';",
+      ].join('\n'),
+      resolveDir: REPO_ROOT,
+      sourcefile: 'session-history-list.memo-entry.mjs',
+    },
     outfile,
     bundle: true,
     external: ['@base-ui/react', '@maka/core', LUCIDE_REACT_PACKAGE, 'react', 'react-dom', 'react-dom/*', 'react/jsx-runtime'],

--- a/apps/desktop/src/main/visual-smoke-fixture.ts
+++ b/apps/desktop/src/main/visual-smoke-fixture.ts
@@ -8,6 +8,7 @@ import type {
   PlanReminder,
   SessionHeader,
   StoredMessage,
+  UiLocale,
   VisualSmokeScenario,
   VisualSmokeState,
 } from '@maka/core';
@@ -161,14 +162,14 @@ export interface VisualSmokeFixture {
   theme: 'light' | 'dark' | 'auto' | null;
   /**
    * PR-UI-VISUAL-SMOKE-LOCALE: UI locale override (zh | en). null
-   * means "let `detectUiLocale()` read `navigator.language`". When set,
-   * the renderer applies `data-maka-visual-smoke-locale=<value>` to
-   * `<html>` so `detectUiLocale()` returns the locked value
+   * means "use the persisted locale preference". When set,
+   * the renderer passes the value to LocaleProvider, which synchronizes
+   * document metadata and consumers to the locked value
    * deterministically — same fixture, same locale, same screenshot
    * across hosts. Driven by env var
    * `MAKA_VISUAL_SMOKE_LOCALE=zh|en`. Unknown values fail closed.
    */
-  locale: 'zh' | 'en' | null;
+  locale: UiLocale | null;
   /**
    * PR-UI-VISUAL-SMOKE-TIMEZONE: IANA timezone override. null means
    * "use the host system timezone" (current behavior). When set, the
@@ -231,9 +232,9 @@ function parseThemeFlag(raw: string | undefined): 'light' | 'dark' | 'auto' | nu
 /**
  * Validate the UI locale override. Accepts only the closed enum
  * `zh | en`; everything else fails closed to null (renderer falls
- * back to `navigator.language` detection). PR-UI-VISUAL-SMOKE-LOCALE.
+ * back to the persisted preference). PR-UI-VISUAL-SMOKE-LOCALE.
  */
-function parseLocaleFlag(raw: string | undefined): 'zh' | 'en' | null {
+function parseLocaleFlag(raw: string | undefined): UiLocale | null {
   if (raw === undefined) return null;
   const normalized = raw.trim().toLowerCase();
   if (normalized === 'zh' || normalized === 'en') return normalized;

--- a/apps/desktop/src/renderer/OnboardingHero.tsx
+++ b/apps/desktop/src/renderer/OnboardingHero.tsx
@@ -254,6 +254,7 @@ function NeedsConnectionHero(props: {
   refreshConnectionsPending?: boolean;
   onSkip?: () => Promise<void> | void;
 }) {
+  const locale = useUiLocale();
   const setupSteps = getOnboardingSetupSteps({ kind: 'needs_connection' });
   return (
     <section className="maka-onboarding maka-firstrun" aria-label="欢迎使用 Maka">
@@ -275,7 +276,7 @@ function NeedsConnectionHero(props: {
       <div className="maka-firstrun-list">
         <ul role="list">
           {RECOMMENDED_PROVIDER_TYPES.map((type) => {
-            const display = providerDisplay(type);
+            const display = providerDisplay(type, locale);
             return (
               <li key={type}>
                 <Item

--- a/apps/desktop/src/renderer/OnboardingHero.tsx
+++ b/apps/desktop/src/renderer/OnboardingHero.tsx
@@ -21,7 +21,7 @@
 
 import { ArrowRight, ArrowUp, ChevronRight, RotateCcw, Sparkles, KeyRound, Settings as SettingsIcon, Cpu, AlertCircle, FolderOpen, Paperclip, X } from '@maka/ui/icons';
 import { Fragment, useCallback, useEffect, useRef, useState, type ClipboardEvent, type DragEvent, type KeyboardEvent } from 'react';
-import { RECOMMENDED_PROVIDER_TYPES, type LlmConnection, type OnboardingState, type QuickChatMode, type SettingsSection } from '@maka/core';
+import { RECOMMENDED_PROVIDER_TYPES, type LlmConnection, type OnboardingState, type QuickChatMode, type SettingsSection, type UiCatalog } from '@maka/core';
 import {
   Button,
   Item,
@@ -33,13 +33,12 @@ import {
   Textarea,
   appendPromptContextDraft,
   createChatInputActionOwner,
-  detectUiLocale,
   fileTransferContainsFiles,
   focusTextInputAtEnd,
   isChatInputComposing,
   useMountedRef,
+  useUiLocale,
   type ChatInputActionOwner,
-  type UiLocale,
 } from '@maka/ui';
 import { ProviderLogo, providerDisplay } from './settings/provider-display';
 import { FIRST_RUN_TASK_SUGGESTIONS } from './first-run-task-suggestions';
@@ -53,7 +52,7 @@ import { getOnboardingSetupSteps, type OnboardingSetupStep } from './onboarding-
  * short placeholder, example sentence moved to a `<small>` hint
  * below the textarea so first-run users still know what to type.
  */
-const READY_HERO_COPY_BY_LOCALE: Record<UiLocale, {
+const READY_HERO_COPY_BY_LOCALE: UiCatalog<{
   ariaLabel: string;
   eyebrow: string;
   headline: string;
@@ -552,7 +551,8 @@ function ReadyEmptyHero(props: {
     };
   }, []);
 
-  const copy = READY_HERO_COPY_BY_LOCALE[detectUiLocale()];
+  const locale = useUiLocale();
+  const copy = READY_HERO_COPY_BY_LOCALE[locale];
   const quickChatBusy = props.quickChatPending || submitPending;
   const importStatusText = pendingImportAction === null
     ? null

--- a/apps/desktop/src/renderer/app-shell-overlays.tsx
+++ b/apps/desktop/src/renderer/app-shell-overlays.tsx
@@ -4,6 +4,7 @@ import type {
   SettingsSection,
   ThemePalette,
   ThemePreference,
+  UiLocalePreference,
 } from '@maka/core';
 import { SearchModal } from '@maka/ui';
 import { KeyboardHelpModal } from './keyboard-help';
@@ -43,6 +44,7 @@ export function AppShellOverlays(props: {
   setThemePref(themePref: ThemePreference): void;
   themePalette: ThemePalette;
   setThemePalette(themePalette: ThemePalette): void;
+  setUiLocalePreference: (preference: UiLocalePreference) => void;
   setUserLabel(userLabel: string): void;
   settingsRequestedSection: SettingsSection | undefined;
   settingsProviderCatalogOpen: boolean;
@@ -83,6 +85,7 @@ export function AppShellOverlays(props: {
     settingsProviderCatalogOpen,
     setThemePalette,
     setThemePref,
+    setUiLocalePreference,
     setUserLabel,
     themePalette,
     themePref,
@@ -101,6 +104,7 @@ export function AppShellOverlays(props: {
             onThemeChange={setThemePref}
             themePalette={themePalette}
             onThemePaletteChange={setThemePalette}
+            onUiLocalePreferenceChange={setUiLocalePreference}
             onUserLabelChange={setUserLabel}
             requestedSection={settingsRequestedSection}
             openProviderCatalog={settingsProviderCatalogOpen}

--- a/apps/desktop/src/renderer/app-shell-overlays.tsx
+++ b/apps/desktop/src/renderer/app-shell-overlays.tsx
@@ -10,6 +10,7 @@ import { SearchModal } from '@maka/ui';
 import { KeyboardHelpModal } from './keyboard-help';
 import { CommandPalette } from './command-palette';
 import { buildAppShellCommandList, type AppShellCommandListOptions } from './app-shell-command-actions';
+import type { UiLocaleUpdateGate } from './settings/ui-locale-update-gate';
 
 // Settings is a large surface (providers, OAuth, network, bots, daily-review,
 // usage, etc.) that is only needed once the user opens the Settings modal.
@@ -45,6 +46,7 @@ export function AppShellOverlays(props: {
   themePalette: ThemePalette;
   setThemePalette(themePalette: ThemePalette): void;
   setUiLocalePreference: (preference: UiLocalePreference) => void;
+  uiLocaleUpdateGate: UiLocaleUpdateGate;
   setUserLabel(userLabel: string): void;
   settingsRequestedSection: SettingsSection | undefined;
   settingsProviderCatalogOpen: boolean;
@@ -86,6 +88,7 @@ export function AppShellOverlays(props: {
     setThemePalette,
     setThemePref,
     setUiLocalePreference,
+    uiLocaleUpdateGate,
     setUserLabel,
     themePalette,
     themePref,
@@ -105,6 +108,7 @@ export function AppShellOverlays(props: {
             themePalette={themePalette}
             onThemePaletteChange={setThemePalette}
             onUiLocalePreferenceChange={setUiLocalePreference}
+            uiLocaleUpdateGate={uiLocaleUpdateGate}
             onUserLabelChange={setUserLabel}
             requestedSection={settingsRequestedSection}
             openProviderCatalog={settingsProviderCatalogOpen}

--- a/apps/desktop/src/renderer/app-shell-visual-smoke.ts
+++ b/apps/desktop/src/renderer/app-shell-visual-smoke.ts
@@ -1,5 +1,5 @@
 import type { Dispatch, SetStateAction } from 'react';
-import type { SettingsSection, ThemePreference } from '@maka/core';
+import type { SettingsSection, ThemePreference, UiLocale } from '@maka/core';
 import type { InteractionQueues, LiveTurnProjection } from '@maka/ui';
 import type { NavSelection } from '@maka/ui';
 import { applyTheme } from './theme';
@@ -25,6 +25,7 @@ export function createAppShellVisualSmokeActions(options: {
   setWorkbarCollapsed: Dispatch<SetStateAction<boolean>>;
   setWorkbarTab: Dispatch<SetStateAction<SessionWorkbarTab>>;
   setThemePref: Dispatch<SetStateAction<ThemePreference>>;
+  setUiLocaleOverride: Dispatch<SetStateAction<UiLocale | null>>;
 }): AppShellVisualSmokeActions {
   const {
     openPalette,
@@ -40,6 +41,7 @@ export function createAppShellVisualSmokeActions(options: {
     setWorkbarCollapsed,
     setWorkbarTab,
     setThemePref,
+    setUiLocaleOverride,
   } = options;
 
   async function applyVisualSmokeFixture() {
@@ -85,17 +87,15 @@ export function createAppShellVisualSmokeActions(options: {
     // `refreshSessions()` resolves and BEFORE any locale-dependent
     // content (EmptyChatHero / Composer / OnboardingHero quickChat)
     // enters the React tree — all of those gate on sessions /
-    // connection state which load inside this same effect. The
-    // attribute is attached to `<html>` so `detectUiLocale()` reads
-    // the deterministic value on every subsequent render. The
+    // connection state which load inside this same effect. The reactive
+    // override reaches every consumer before the fixture's
+    // session refresh exposes locale-dependent content.
     // AppShell initial mount already ran when this effect fires,
     // but that initial mount renders no locale-aware copy yet
     // (it's a loading shell), so there's no observable host-locale
     // leak in the captured baseline. See @kenji review
     // @msg 7b96e182.
-    if (state.locale) {
-      document.documentElement.setAttribute('data-maka-visual-smoke-locale', state.locale);
-    }
+    setUiLocaleOverride(state.locale ?? null);
     // PR-UI-VISUAL-SMOKE-TIMEZONE (@kenji msg 45486cdf): mirror the
     // locale attribute pattern. When `MAKA_VISUAL_SMOKE_TIMEZONE` is
     // set and validates against `Intl.DateTimeFormat`, the IANA name

--- a/apps/desktop/src/renderer/app-shell.tsx
+++ b/apps/desktop/src/renderer/app-shell.tsx
@@ -42,6 +42,7 @@ import { useOnboardingSnapshot } from './use-onboarding-snapshot';
 import type { OnboardingSnapshot } from '../global';
 import { ProviderLogo } from './settings/provider-display';
 import { ProviderBrandMark } from './settings/provider-brand-marks';
+import { createUiLocaleUpdateGate } from './settings/ui-locale-update-gate';
 // The session workbar owns the task ledger, embedded browser, and artifact
 // preview. Keep the combined auxiliary surface out of the first chat paint.
 const SessionWorkbar = lazy(() => import('./session-workbar').then((m) => ({ default: m.SessionWorkbar })));
@@ -218,6 +219,7 @@ export function AppShell({
   const [themePalette, setThemePalette] = useState<ThemePalette>('default');
   const [uiLocalePreference, setUiLocalePreference] = useState<UiLocalePreference>('auto');
   const [uiLocaleOverride, setUiLocaleOverride] = useState<UiLocale | null>(null);
+  const [uiLocaleUpdateGate] = useState(createUiLocaleUpdateGate);
   const [userLabel, setUserLabel] = useState<string>('');
   // Settings → 通用 → 默认权限模式 — DISPLAY-ONLY mirror. The composer's
   // picker shows it before the user makes a per-session choice; the actual
@@ -1014,6 +1016,7 @@ export function AppShell({
   }
 
   async function refreshShellSettings() {
+    const uiLocaleHydration = uiLocaleUpdateGate.beginHydration();
     try {
       const next = await window.maka.settings.get();
       const smoke = await window.maka.visualSmoke.getState();
@@ -1021,8 +1024,14 @@ export function AppShell({
       const palette = next.appearance?.palette ?? 'default';
       const name = next.personalization?.displayName ?? '';
       const uiLocale = next.personalization?.uiLocale ?? 'auto';
-      setUiLocalePreference(uiLocale);
-      setUiLocaleOverride(smoke?.locale ?? null);
+      uiLocaleUpdateGate.commitHydration(
+        uiLocaleHydration,
+        uiLocale,
+        (preference) => {
+          setUiLocalePreference(preference);
+          setUiLocaleOverride(smoke?.locale ?? null);
+        },
+      );
       setThemePref(pref);
       setThemePalette(palette);
       setUserLabel(name);
@@ -1628,6 +1637,7 @@ export function AppShell({
         themePalette={themePalette}
         setThemePalette={setThemePalette}
         setUiLocalePreference={setUiLocalePreference}
+        uiLocaleUpdateGate={uiLocaleUpdateGate}
         setUserLabel={setUserLabel}
         settingsRequestedSection={settingsRequestedSection}
         settingsProviderCatalogOpen={settingsProviderCatalogOpen}

--- a/apps/desktop/src/renderer/app-shell.tsx
+++ b/apps/desktop/src/renderer/app-shell.tsx
@@ -7,6 +7,8 @@ import type {
   SettingsSection,
   ThemePalette,
   ThemePreference,
+  UiLocale,
+  UiLocalePreference,
 } from '@maka/core';
 import { generalizedErrorMessageChinese, hasSettledInitialOnboarding } from '@maka/core';
 import {
@@ -23,6 +25,7 @@ import {
   type ComposerHandle,
   type MakaUriDest,
   MakaUriContext,
+  LocaleProvider,
   type NavSelection,
   SessionListPanel,
   SkillsPage,
@@ -57,7 +60,7 @@ import { deriveSessionStatusGroups } from './session-status-grouping';
 import { deriveAppShellTurnViewModel } from './app-shell-turn-view-model';
 import { readScrollMotionBehavior } from './scroll-motion-policy';
 import { deriveBranchBanner } from './branch-banner';
-import { applyTheme, applyThemePalette, applyUiLocale } from './theme';
+import { applyTheme, applyThemePalette } from './theme';
 import { safeLocalStorageSet } from './browser-storage';
 import { filterSessions, readNavSelection } from './nav-selection';
 import {
@@ -213,6 +216,8 @@ export function AppShell({
   const [settingsProviderCatalogOpen, setSettingsProviderCatalogOpen] = useState(false);
   const [themePref, setThemePref] = useState<ThemePreference>('auto');
   const [themePalette, setThemePalette] = useState<ThemePalette>('default');
+  const [uiLocalePreference, setUiLocalePreference] = useState<UiLocalePreference>('auto');
+  const [uiLocaleOverride, setUiLocaleOverride] = useState<UiLocale | null>(null);
   const [userLabel, setUserLabel] = useState<string>('');
   // Settings → 通用 → 默认权限模式 — DISPLAY-ONLY mirror. The composer's
   // picker shows it before the user makes a per-session choice; the actual
@@ -785,6 +790,7 @@ export function AppShell({
     setWorkbarCollapsed,
     setWorkbarTab,
     setThemePref,
+    setUiLocaleOverride,
   });
 
   const {
@@ -1014,12 +1020,9 @@ export function AppShell({
       const pref = smoke?.theme ?? next.appearance?.theme ?? 'auto';
       const palette = next.appearance?.palette ?? 'default';
       const name = next.personalization?.displayName ?? '';
-      // PR-LANG-PREF-0: apply persisted UI locale preference to
-      // `<html data-maka-locale>` BEFORE first paint of any
-      // locale-aware surface. `'auto'` clears the explicit attribute
-      // and uses the Chinese-first product fallback.
       const uiLocale = next.personalization?.uiLocale ?? 'auto';
-      applyUiLocale(uiLocale);
+      setUiLocalePreference(uiLocale);
+      setUiLocaleOverride(smoke?.locale ?? null);
       setThemePref(pref);
       setThemePalette(palette);
       setUserLabel(name);
@@ -1206,7 +1209,8 @@ export function AppShell({
   };
 
   return (
-    <div className="appFrame agents-layout-root" data-agents-page>
+    <LocaleProvider preference={uiLocalePreference} override={uiLocaleOverride}>
+      <div className="appFrame agents-layout-root" data-agents-page>
       <div
         className="app maka-shell-2col agents-layout-body"
         aria-hidden={hasModalOpen ? 'true' : undefined}
@@ -1623,6 +1627,7 @@ export function AppShell({
         setThemePref={setThemePref}
         themePalette={themePalette}
         setThemePalette={setThemePalette}
+        setUiLocalePreference={setUiLocalePreference}
         setUserLabel={setUserLabel}
         settingsRequestedSection={settingsRequestedSection}
         settingsProviderCatalogOpen={settingsProviderCatalogOpen}
@@ -1647,6 +1652,7 @@ export function AppShell({
         paletteOnOpenSearchModal={paletteOnOpenSearchModal}
         commandOptions={commandOptions}
       />
-    </div>
+      </div>
+    </LocaleProvider>
   );
 }

--- a/apps/desktop/src/renderer/app-shell.tsx
+++ b/apps/desktop/src/renderer/app-shell.tsx
@@ -1024,13 +1024,11 @@ export function AppShell({
       const palette = next.appearance?.palette ?? 'default';
       const name = next.personalization?.displayName ?? '';
       const uiLocale = next.personalization?.uiLocale ?? 'auto';
+      setUiLocaleOverride(smoke?.locale ?? null);
       uiLocaleUpdateGate.commitHydration(
         uiLocaleHydration,
         uiLocale,
-        (preference) => {
-          setUiLocalePreference(preference);
-          setUiLocaleOverride(smoke?.locale ?? null);
-        },
+        (preference) => setUiLocalePreference(preference),
       );
       setThemePref(pref);
       setThemePalette(palette);

--- a/apps/desktop/src/renderer/artifact-pane.tsx
+++ b/apps/desktop/src/renderer/artifact-pane.tsx
@@ -70,6 +70,7 @@ import {
   formatBytes,
   useMountedRef,
   useToast,
+  useUiLocale,
 } from '@maka/ui';
 import { ArtifactPreview } from './artifact-preview';
 import { nextArtifactListAction } from './artifact-list-keyboard';
@@ -83,6 +84,7 @@ export function ArtifactPane(props: {
 }) {
   const { sessionId } = props;
   const toast = useToast();
+  const locale = useUiLocale();
   const [records, setRecords] = useState<ArtifactRecord[]>([]);
   const [recordsSessionId, setRecordsSessionId] = useState<string | undefined>(undefined);
   const [selectedId, setSelectedId] = useState<string | null>(null);
@@ -420,7 +422,7 @@ export function ArtifactPane(props: {
                   <span className="maka-artifact-row-name">{record.name}</span>
                   <span className="maka-artifact-row-meta">
                     <span className="maka-artifact-row-size">{formatBytes(record.sizeBytes)}</span>
-                    <span className="maka-artifact-row-time">{formatRelativeTimestamp(record.createdAt)}</span>
+                    <span className="maka-artifact-row-time">{formatRelativeTimestamp(record.createdAt, Date.now(), locale)}</span>
                   </span>
                   {record.status === 'deleted' && (
                     <Badge variant="destructive" className="maka-artifact-row-badge">已删除</Badge>

--- a/apps/desktop/src/renderer/index.html
+++ b/apps/desktop/src/renderer/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="zh-CN">
+<html lang="zh">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />

--- a/apps/desktop/src/renderer/settings/ProvidersPanel.tsx
+++ b/apps/desktop/src/renderer/settings/ProvidersPanel.tsx
@@ -8,6 +8,7 @@ import {
   type LlmConnection,
   type ProviderCatalogGroup,
   type ProviderType,
+  type UiLocale,
 } from '@maka/core';
 import {
   Chip,
@@ -15,6 +16,7 @@ import {
   PrimitiveTabs, PrimitiveTabsList, PrimitiveTabsTrigger, PrimitiveTabsPanel,
   Item, ItemMedia, ItemContent, ItemTitle, ItemDescription, ItemActions,
   useMountedRef,
+  useUiLocale,
   useToast,
 } from '@maka/ui';
 import { connectionChipStatus } from './provider-connection-status';
@@ -61,6 +63,7 @@ export function ProvidersPanel({ bridge, initialPage = 'connections' }: {
   const providerDialogLifecycleRef = useRef(0);
   const providersPanelRef = useRef<HTMLDivElement>(null);
   const providerCatalogRef = useRef<HTMLElement>(null);
+  const locale = useUiLocale();
   const toast = useToast();
 
   function closeDialog() {
@@ -125,7 +128,7 @@ export function ProvidersPanel({ bridge, initialPage = 'connections' }: {
   }
 
   function chipAriaLabel(connection: LlmConnection): string {
-    const provider = providerDisplay(connection.providerType).name;
+    const provider = providerDisplay(connection.providerType, locale).name;
     const defaultSuffix = connection.slug === defaultSlug ? '，默认连接' : '';
     const status = connectionChipStatus(connection);
     const statusSuffix = status ? `，${status.label}` : '';
@@ -144,7 +147,7 @@ export function ProvidersPanel({ bridge, initialPage = 'connections' }: {
       if (PROVIDER_DEFAULTS[type].status !== 'ready') return false;
       if (category !== 'recommended' && PROVIDER_DEFAULTS[type].catalogGroup !== category) return false;
       if (!normalizedQuery) return true;
-      const display = providerDisplay(type);
+      const display = providerDisplay(type, locale);
       return [type, display.name, display.description, PROVIDER_DEFAULTS[type].label]
         .some((value) => value.toLocaleLowerCase().includes(normalizedQuery));
     });
@@ -208,7 +211,7 @@ export function ProvidersPanel({ bridge, initialPage = 'connections' }: {
                           {connection.name}
                           {connection.slug === defaultSlug && <Chip size="sm" variant="accent">默认</Chip>}
                         </ItemTitle>
-                        <ItemDescription>{providerDisplay(connection.providerType).name}</ItemDescription>
+                        <ItemDescription>{providerDisplay(connection.providerType, locale).name}</ItemDescription>
                       </ItemContent>
                       <ItemActions>
                         {status && <Chip dot size="sm" variant={status.tone}>{status.label}</Chip>}
@@ -282,7 +285,7 @@ export function ProvidersPanel({ bridge, initialPage = 'connections' }: {
 
       {createType && (
         <ProviderConnectionDialog
-          title={`连接 ${providerDisplay(createType).name}`}
+          title={`连接 ${providerDisplay(createType, locale).name}`}
           subtitle="完成必要配置后，连接会出现在模型页上方。"
           providerType={createType}
           onClose={closeDialog}
@@ -307,7 +310,7 @@ export function ProvidersPanel({ bridge, initialPage = 'connections' }: {
       {selected && (
         <ProviderConnectionDialog
           title={selected.name}
-          subtitle={connectionDialogSubtitle(selected, selected.slug === defaultSlug)}
+          subtitle={connectionDialogSubtitle(selected, selected.slug === defaultSlug, locale)}
           providerType={selected.providerType}
           onClose={closeDialog}
           finalFocus={() => providerFocusElement(providersPanelRef.current, { kind: 'connection', slug: selected.slug })}
@@ -331,8 +334,8 @@ export function ProvidersPanel({ bridge, initialPage = 'connections' }: {
   );
 }
 
-function connectionDialogSubtitle(connection: LlmConnection, isDefault: boolean): string {
-  const providerName = providerDisplay(connection.providerType).name;
+function connectionDialogSubtitle(connection: LlmConnection, isDefault: boolean, locale: UiLocale): string {
+  const providerName = providerDisplay(connection.providerType, locale).name;
   const parts = providerName === connection.name ? [] : [providerName];
   parts.push(isDefault ? '默认连接' : '模型连接');
   return parts.join(' · ');

--- a/apps/desktop/src/renderer/settings/SettingsModal.tsx
+++ b/apps/desktop/src/renderer/settings/SettingsModal.tsx
@@ -4,6 +4,7 @@ import type {
   SettingsSection,
   ThemePalette,
   ThemePreference,
+  UiLocalePreference,
 } from '@maka/core';
 import { SettingsSurface } from './settings-surface';
 
@@ -26,6 +27,7 @@ export function SettingsModal(props: {
    */
   themePalette: ThemePalette;
   onThemePaletteChange(palette: ThemePalette): void;
+  onUiLocalePreferenceChange(preference: UiLocalePreference): void;
   onUserLabelChange?(label: string): void;
   /**
    * Force the modal to a specific section when it (re-)mounts or when the
@@ -83,6 +85,7 @@ export function SettingsModal(props: {
         onThemeChange={props.onThemeChange}
         themePalette={props.themePalette}
         onThemePaletteChange={props.onThemePaletteChange}
+        onUiLocalePreferenceChange={props.onUiLocalePreferenceChange}
         onUserLabelChange={props.onUserLabelChange}
         requestedSection={props.requestedSection}
         openProviderCatalog={props.openProviderCatalog}

--- a/apps/desktop/src/renderer/settings/SettingsModal.tsx
+++ b/apps/desktop/src/renderer/settings/SettingsModal.tsx
@@ -7,6 +7,7 @@ import type {
   UiLocalePreference,
 } from '@maka/core';
 import { SettingsSurface } from './settings-surface';
+import type { UiLocaleUpdateGate } from './ui-locale-update-gate';
 
 export { SETTINGS_NAV } from './settings-nav';
 export type { SettingsNavGroup } from './settings-nav';
@@ -28,6 +29,7 @@ export function SettingsModal(props: {
   themePalette: ThemePalette;
   onThemePaletteChange(palette: ThemePalette): void;
   onUiLocalePreferenceChange(preference: UiLocalePreference): void;
+  uiLocaleUpdateGate: UiLocaleUpdateGate;
   onUserLabelChange?(label: string): void;
   /**
    * Force the modal to a specific section when it (re-)mounts or when the
@@ -86,6 +88,7 @@ export function SettingsModal(props: {
         themePalette={props.themePalette}
         onThemePaletteChange={props.onThemePaletteChange}
         onUiLocalePreferenceChange={props.onUiLocalePreferenceChange}
+        uiLocaleUpdateGate={props.uiLocaleUpdateGate}
         onUserLabelChange={props.onUserLabelChange}
         requestedSection={props.requestedSection}
         openProviderCatalog={props.openProviderCatalog}

--- a/apps/desktop/src/renderer/settings/appearance-settings-page.tsx
+++ b/apps/desktop/src/renderer/settings/appearance-settings-page.tsx
@@ -5,10 +5,10 @@ import type {
   PersonalizationSettings,
   ThemePalette,
   ThemePreference,
+  UiLocalePreference,
   UpdateAppSettingsResult,
 } from '@maka/core';
 import { ChoiceCard, ChoiceCardGroup, Input, SettingsSegmented as Segmented, Textarea, useMountedRef, useToast } from '@maka/ui';
-import { applyUiLocale, type UiLocalePreference } from '../theme';
 import { settingsActionErrorMessage } from './settings-error-copy';
 
 const THEME_OPTIONS: Array<{ value: ThemePreference; label: string; help: string }> = [
@@ -112,14 +112,10 @@ export function PersonalizationSettingsPage(props: {
     const ticket = ++persistTicketRef.current;
     persistPendingCountRef.current += 1;
     try {
-      await props.onUpdate({ personalization: patch });
+      const result = await props.onUpdate({ personalization: patch });
       if (!personalizationMountedRef.current || ticket !== persistTicketRef.current) return;
       if (patch.uiLocale !== undefined) {
-        // PR-LANG-PREF-0: apply the chosen locale to <html> right after save
-        // so the change takes effect immediately in the current window. The
-        // persisted value also drives next-boot detection (main.tsx applies
-        // it on settings load).
-        applyUiLocale(patch.uiLocale);
+        setUiLocale(result.settings.personalization.uiLocale);
       }
     } catch (error) {
       if (personalizationMountedRef.current && ticket === persistTicketRef.current) {
@@ -187,8 +183,8 @@ export function PersonalizationSettingsPage(props: {
         {/*
           PR-LANG-PREF-0 (WAWQAQ msg `edc9cb41` + kenji `7e532892`
           acceptance criteria): 自动 / 中文 / English. User explicit
-          choice wins over navigator.language; visual-smoke override
-          wins over both (deterministic baselines).
+          choice wins over the temporary auto -> zh fallback;
+          visual-smoke override wins over both (deterministic baselines).
         */}
         <div className="settingsFormRow">
           <div>

--- a/apps/desktop/src/renderer/settings/provider-add-form.tsx
+++ b/apps/desktop/src/renderer/settings/provider-add-form.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState, type FormEvent } from 'react';
 import { PROVIDER_DEFAULTS, validateSlug, type ProviderType } from '@maka/core';
 import { providerAuthRequiresSecret, providerAuthSupportsApiKey } from '@maka/core/llm-connections';
-import { Button, Chip, Input, useMountedRef } from '@maka/ui';
+import { Button, Chip, Input, useMountedRef, useUiLocale } from '@maka/ui';
 import { buildCatalogRecommendedDefaultModel } from '../model-catalog-choices';
 import { PasswordInput } from './password-input';
 import { providerDisplay } from './provider-display';
@@ -20,8 +20,9 @@ export function AddProviderForm(props: {
   onCancel(): void;
   onCreated(slug: string): Promise<void>;
 }) {
+  const locale = useUiLocale();
   const defaults = PROVIDER_DEFAULTS[props.providerType];
-  const display = providerDisplay(props.providerType);
+  const display = providerDisplay(props.providerType, locale);
   const recommendedDefaultModel = buildCatalogRecommendedDefaultModel(props.providerType);
   const [slug, setSlug] = useState(() => nextSlug(props.providerType, props.existingSlugs));
   const [name, setName] = useState(display.name);

--- a/apps/desktop/src/renderer/settings/provider-catalog.tsx
+++ b/apps/desktop/src/renderer/settings/provider-catalog.tsx
@@ -1,12 +1,13 @@
 import { ChevronRight } from '@maka/ui/icons';
 import { PROVIDER_DEFAULTS, type ProviderType } from '@maka/core';
-import { Chip, Item, ItemActions, ItemContent, ItemDescription, ItemMedia, ItemTitle } from '@maka/ui';
+import { Chip, Item, ItemActions, ItemContent, ItemDescription, ItemMedia, ItemTitle, useUiLocale } from '@maka/ui';
 import { ProviderLogo, providerDisplay } from './provider-display';
 import { isWiredOAuthProvider } from './provider-panel-shared';
 
 export function ProviderCatalogCard(props: { type: ProviderType; count: number; onSelect(): void }) {
+  const locale = useUiLocale();
   const defaults = PROVIDER_DEFAULTS[props.type];
-  const display = providerDisplay(props.type);
+  const display = providerDisplay(props.type, locale);
   const disabled = defaults.status !== 'ready';
   const disabledStatus = providerDisabledStatus(props.type);
   const title = disabled ? providerDisabledTitle(props.type) : `添加 ${display.name}`;

--- a/apps/desktop/src/renderer/settings/provider-connection-detail.tsx
+++ b/apps/desktop/src/renderer/settings/provider-connection-detail.tsx
@@ -25,6 +25,7 @@ import {
   RelativeTime,
   useMountedRef,
   useToast,
+  useUiLocale,
 } from '@maka/ui';
 import { Check } from '@maka/ui/icons';
 import { PasswordInput } from './password-input';
@@ -143,9 +144,10 @@ function UnknownConnectionDetail({ props }: { props: ConnectionDetailProps }) {
 }
 
 function ConnectionDetailInner(props: ConnectionDetailProps) {
+  const locale = useUiLocale();
   const { connection } = props;
   const defaults = PROVIDER_DEFAULTS[connection.providerType];
-  const display = providerDisplay(connection.providerType);
+  const display = providerDisplay(connection.providerType, locale);
   const [apiKey, setApiKey] = useState('');
   const [hasSecret, setHasSecret] = useState<CredentialPresenceStatus>(
     defaults.authKind === 'none' ? true : 'loading',

--- a/apps/desktop/src/renderer/settings/provider-display-copy.ts
+++ b/apps/desktop/src/renderer/settings/provider-display-copy.ts
@@ -1,4 +1,4 @@
-import type { ProviderType } from '@maka/core';
+import type { ProviderType, UiCatalog } from '@maka/core';
 
 /**
  * Pure-data provider introduction copy, localized zh / en.
@@ -6,9 +6,7 @@ import type { ProviderType } from '@maka/core';
  * No React / @maka/ui imports on purpose: the desktop main-process test
  * runner (node --test over dist/main) imports this module directly, so the
  * copy contract (provider-display-copy-contract.test.ts) asserts the real
- * data instead of regex-parsing TSX source. The locale type is declared
- * locally for the same reason; it is structurally identical to @maka/ui's
- * UiLocale ('zh' | 'en').
+ * data instead of regex-parsing TSX source.
  *
  * These stay in the display layer (not the registry) because they are
  * introduction prose tuned for the catalog, not the runtime provider facts.
@@ -22,8 +20,6 @@ import type { ProviderType } from '@maka/core';
  * Completeness is enforced at compile time: `satisfies Record<ProviderType,
  * …>` fails the build when a registered provider has no bilingual entry.
  */
-export type ProviderDisplayLocale = 'zh' | 'en';
-
 export interface ProviderCopy {
   name: string;
   description: string;
@@ -225,4 +221,4 @@ export const PROVIDER_DISPLAY_COPY = {
     zh: { name: 'Gemini CLI', description: 'Google 账号登录暂未接入聊天发送。' },
     en: { name: 'Gemini CLI', description: 'Google account sign-in is not yet wired to chat.' },
   },
-} satisfies Record<ProviderType, Record<ProviderDisplayLocale, ProviderCopy>>;
+} satisfies Record<ProviderType, UiCatalog<ProviderCopy>>;

--- a/apps/desktop/src/renderer/settings/provider-display.tsx
+++ b/apps/desktop/src/renderer/settings/provider-display.tsx
@@ -1,5 +1,4 @@
-import { PROVIDER_DEFAULTS, type ProviderType } from '@maka/core';
-import { detectUiLocale, type UiLocale } from '@maka/ui';
+import { PROVIDER_DEFAULTS, type ProviderType, type UiLocale } from '@maka/core';
 import { ProviderBrandMark } from './provider-brand-marks';
 import { PROVIDER_DISPLAY_COPY, type ProviderCopy } from './provider-display-copy';
 
@@ -18,7 +17,7 @@ export function ProviderLogo(props: { type: ProviderType; compact?: boolean }) {
 
 export function providerDisplay(
   type: ProviderType,
-  locale: UiLocale = detectUiLocale(),
+  locale: UiLocale,
 ): ProviderCopy {
   // The copy map covers every registered ProviderType at compile time
   // (`satisfies` in provider-display-copy.ts), but a connection persisted on

--- a/apps/desktop/src/renderer/settings/settings-surface.tsx
+++ b/apps/desktop/src/renderer/settings/settings-surface.tsx
@@ -34,7 +34,7 @@ import { settingsActionErrorMessage } from './settings-error-copy';
 import { UsageSettingsPage } from './usage-settings-page';
 import { VoiceModelsSettingsPage } from './voice-settings-page';
 import { WebSearchSettingsPage } from './web-search-settings-page';
-import { createUiLocaleUpdateGate } from './ui-locale-update-gate';
+import type { UiLocaleUpdateGate } from './ui-locale-update-gate';
 
 export function SettingsSurface(props: {
   connections: LlmConnection[];
@@ -46,6 +46,7 @@ export function SettingsSurface(props: {
   themePalette: ThemePalette;
   onThemePaletteChange(palette: ThemePalette): void;
   onUiLocalePreferenceChange(preference: UiLocalePreference): void;
+  uiLocaleUpdateGate: UiLocaleUpdateGate;
   onUserLabelChange?(label: string): void;
   requestedSection?: SettingsSection;
   openProviderCatalog?: boolean;
@@ -111,7 +112,6 @@ export function SettingsSurface(props: {
   const settingsModalMountedRef = useMountedRef();
   const settingsReloadTicketRef = useRef(0);
   const settingsUpdateTicketRef = useRef(0);
-  const [uiLocaleUpdateGate] = useState(createUiLocaleUpdateGate);
   const usageReloadTicketRef = useRef(0);
   const toast = useToast();
 
@@ -151,21 +151,26 @@ export function SettingsSurface(props: {
   async function updateSettings(patch: Parameters<typeof window.maka.settings.update>[0]) {
     const ticket = settingsUpdateTicketRef.current + 1;
     settingsUpdateTicketRef.current = ticket;
-    const uiLocaleTicket = uiLocaleUpdateGate.begin(
+    const uiLocaleTicket = props.uiLocaleUpdateGate.begin(
       patch.personalization?.uiLocale !== undefined,
     );
-    const result = await window.maka.settings.update(patch);
-    const next = result.settings;
-    uiLocaleUpdateGate.commit(
-      uiLocaleTicket,
-      next.personalization.uiLocale,
-      props.onUiLocalePreferenceChange,
-    );
-    if (settingsModalMountedRef.current && ticket === settingsUpdateTicketRef.current) {
-      setSettings(next);
-      props.onUserLabelChange?.(next.personalization.displayName);
+    try {
+      const result = await window.maka.settings.update(patch);
+      const next = result.settings;
+      props.uiLocaleUpdateGate.commit(
+        uiLocaleTicket,
+        next.personalization.uiLocale,
+        props.onUiLocalePreferenceChange,
+      );
+      if (settingsModalMountedRef.current && ticket === settingsUpdateTicketRef.current) {
+        setSettings(next);
+        props.onUserLabelChange?.(next.personalization.displayName);
+      }
+      return result;
+    } catch (error) {
+      props.uiLocaleUpdateGate.cancel(uiLocaleTicket);
+      throw error;
     }
-    return result;
   }
 
   async function reloadUsage(range: UsageRange = settings.usage.range) {

--- a/apps/desktop/src/renderer/settings/settings-surface.tsx
+++ b/apps/desktop/src/renderer/settings/settings-surface.tsx
@@ -34,6 +34,7 @@ import { settingsActionErrorMessage } from './settings-error-copy';
 import { UsageSettingsPage } from './usage-settings-page';
 import { VoiceModelsSettingsPage } from './voice-settings-page';
 import { WebSearchSettingsPage } from './web-search-settings-page';
+import { createUiLocaleUpdateGate } from './ui-locale-update-gate';
 
 export function SettingsSurface(props: {
   connections: LlmConnection[];
@@ -110,7 +111,7 @@ export function SettingsSurface(props: {
   const settingsModalMountedRef = useMountedRef();
   const settingsReloadTicketRef = useRef(0);
   const settingsUpdateTicketRef = useRef(0);
-  const uiLocaleUpdateTicketRef = useRef(0);
+  const [uiLocaleUpdateGate] = useState(createUiLocaleUpdateGate);
   const usageReloadTicketRef = useRef(0);
   const toast = useToast();
 
@@ -124,7 +125,6 @@ export function SettingsSurface(props: {
     return () => {
       settingsReloadTicketRef.current += 1;
       settingsUpdateTicketRef.current += 1;
-      uiLocaleUpdateTicketRef.current += 1;
       usageReloadTicketRef.current += 1;
     };
   }, []);
@@ -151,18 +151,16 @@ export function SettingsSurface(props: {
   async function updateSettings(patch: Parameters<typeof window.maka.settings.update>[0]) {
     const ticket = settingsUpdateTicketRef.current + 1;
     settingsUpdateTicketRef.current = ticket;
-    const uiLocaleTicket = patch.personalization?.uiLocale === undefined
-      ? null
-      : ++uiLocaleUpdateTicketRef.current;
+    const uiLocaleTicket = uiLocaleUpdateGate.begin(
+      patch.personalization?.uiLocale !== undefined,
+    );
     const result = await window.maka.settings.update(patch);
     const next = result.settings;
-    if (
-      settingsModalMountedRef.current
-      && uiLocaleTicket !== null
-      && uiLocaleTicket === uiLocaleUpdateTicketRef.current
-    ) {
-      props.onUiLocalePreferenceChange(next.personalization.uiLocale);
-    }
+    uiLocaleUpdateGate.commit(
+      uiLocaleTicket,
+      next.personalization.uiLocale,
+      props.onUiLocalePreferenceChange,
+    );
     if (settingsModalMountedRef.current && ticket === settingsUpdateTicketRef.current) {
       setSettings(next);
       props.onUserLabelChange?.(next.personalization.displayName);

--- a/apps/desktop/src/renderer/settings/settings-surface.tsx
+++ b/apps/desktop/src/renderer/settings/settings-surface.tsx
@@ -110,6 +110,7 @@ export function SettingsSurface(props: {
   const settingsModalMountedRef = useMountedRef();
   const settingsReloadTicketRef = useRef(0);
   const settingsUpdateTicketRef = useRef(0);
+  const uiLocaleUpdateTicketRef = useRef(0);
   const usageReloadTicketRef = useRef(0);
   const toast = useToast();
 
@@ -123,6 +124,7 @@ export function SettingsSurface(props: {
     return () => {
       settingsReloadTicketRef.current += 1;
       settingsUpdateTicketRef.current += 1;
+      uiLocaleUpdateTicketRef.current += 1;
       usageReloadTicketRef.current += 1;
     };
   }, []);
@@ -149,12 +151,21 @@ export function SettingsSurface(props: {
   async function updateSettings(patch: Parameters<typeof window.maka.settings.update>[0]) {
     const ticket = settingsUpdateTicketRef.current + 1;
     settingsUpdateTicketRef.current = ticket;
+    const uiLocaleTicket = patch.personalization?.uiLocale === undefined
+      ? null
+      : ++uiLocaleUpdateTicketRef.current;
     const result = await window.maka.settings.update(patch);
     const next = result.settings;
+    if (
+      settingsModalMountedRef.current
+      && uiLocaleTicket !== null
+      && uiLocaleTicket === uiLocaleUpdateTicketRef.current
+    ) {
+      props.onUiLocalePreferenceChange(next.personalization.uiLocale);
+    }
     if (settingsModalMountedRef.current && ticket === settingsUpdateTicketRef.current) {
       setSettings(next);
       props.onUserLabelChange?.(next.personalization.displayName);
-      props.onUiLocalePreferenceChange(next.personalization.uiLocale);
     }
     return result;
   }

--- a/apps/desktop/src/renderer/settings/settings-surface.tsx
+++ b/apps/desktop/src/renderer/settings/settings-surface.tsx
@@ -7,6 +7,7 @@ import type {
   SettingsSection,
   ThemePalette,
   ThemePreference,
+  UiLocalePreference,
   UpdateAppSettingsResult,
   UsageRange,
   UsageStats,
@@ -43,6 +44,7 @@ export function SettingsSurface(props: {
   onThemeChange(pref: ThemePreference): void;
   themePalette: ThemePalette;
   onThemePaletteChange(palette: ThemePalette): void;
+  onUiLocalePreferenceChange(preference: UiLocalePreference): void;
   onUserLabelChange?(label: string): void;
   requestedSection?: SettingsSection;
   openProviderCatalog?: boolean;
@@ -152,6 +154,7 @@ export function SettingsSurface(props: {
     if (settingsModalMountedRef.current && ticket === settingsUpdateTicketRef.current) {
       setSettings(next);
       props.onUserLabelChange?.(next.personalization.displayName);
+      props.onUiLocalePreferenceChange(next.personalization.uiLocale);
     }
     return result;
   }

--- a/apps/desktop/src/renderer/settings/ui-locale-update-gate.ts
+++ b/apps/desktop/src/renderer/settings/ui-locale-update-gate.ts
@@ -29,37 +29,73 @@ export interface UiLocaleHydrationTicket {
  * even when the modal closes before the IPC response arrives.
  */
 export function createUiLocaleUpdateGate(): UiLocaleUpdateGate {
+  let writeRevision = 0;
   let latestTicket = 0;
+  let appliedTicket = 0;
   let latestHydrationTicket = 0;
   const pendingTickets = new Set<number>();
+  const successfulWrites = new Map<number, {
+    preference: UiLocalePreference;
+    apply: (preference: UiLocalePreference) => void;
+  }>();
+
+  function latestUnsettledTicket(): number {
+    let latest = 0;
+    for (const ticket of pendingTickets) latest = Math.max(latest, ticket);
+    for (const ticket of successfulWrites.keys()) latest = Math.max(latest, ticket);
+    return latest;
+  }
+
+  function applySuccessfulWrite(ticket: number): boolean {
+    const successful = successfulWrites.get(ticket);
+    if (!successful) return false;
+    successfulWrites.delete(ticket);
+    appliedTicket = Math.max(appliedTicket, ticket);
+    for (const staleTicket of successfulWrites.keys()) {
+      if (staleTicket < appliedTicket) successfulWrites.delete(staleTicket);
+    }
+    successful.apply(successful.preference);
+    return true;
+  }
 
   return {
     begin(hasLocalePreference) {
       if (!hasLocalePreference) return null;
-      const ticket = ++latestTicket;
+      const ticket = ++writeRevision;
+      latestTicket = ticket;
       pendingTickets.add(ticket);
       return ticket;
     },
     cancel(ticket) {
-      if (ticket !== null) pendingTickets.delete(ticket);
+      if (ticket === null) return;
+      pendingTickets.delete(ticket);
+      successfulWrites.delete(ticket);
+      if (ticket !== latestTicket) return;
+      latestTicket = latestUnsettledTicket();
+      applySuccessfulWrite(latestTicket);
     },
     commit(ticket, preference, onUiLocalePreferenceChange) {
-      if (ticket !== null) pendingTickets.delete(ticket);
-      if (ticket === null || ticket !== latestTicket) return false;
-      onUiLocalePreferenceChange(preference);
-      return true;
+      if (ticket === null) return false;
+      pendingTickets.delete(ticket);
+      if (ticket < appliedTicket) return false;
+      successfulWrites.set(ticket, {
+        preference,
+        apply: onUiLocalePreferenceChange,
+      });
+      if (ticket !== latestTicket) return false;
+      return applySuccessfulWrite(ticket);
     },
     beginHydration() {
       return {
         id: ++latestHydrationTicket,
-        localeWriteRevision: latestTicket,
+        localeWriteRevision: writeRevision,
         startedWhileWritePending: pendingTickets.size > 0,
       };
     },
     commitHydration(ticket, preference, onUiLocalePreferenceChange) {
       if (
         ticket.id !== latestHydrationTicket
-        || ticket.localeWriteRevision !== latestTicket
+        || ticket.localeWriteRevision !== writeRevision
         || ticket.startedWhileWritePending
         || pendingTickets.size > 0
       ) {

--- a/apps/desktop/src/renderer/settings/ui-locale-update-gate.ts
+++ b/apps/desktop/src/renderer/settings/ui-locale-update-gate.ts
@@ -2,11 +2,24 @@ import type { UiLocalePreference } from '@maka/core';
 
 export interface UiLocaleUpdateGate {
   begin(hasLocalePreference: boolean): number | null;
+  cancel(ticket: number | null): void;
   commit(
     ticket: number | null,
     preference: UiLocalePreference,
     onUiLocalePreferenceChange: (preference: UiLocalePreference) => void,
   ): boolean;
+  beginHydration(): UiLocaleHydrationTicket;
+  commitHydration(
+    ticket: UiLocaleHydrationTicket,
+    preference: UiLocalePreference,
+    onUiLocalePreferenceChange: (preference: UiLocalePreference) => void,
+  ): boolean;
+}
+
+export interface UiLocaleHydrationTicket {
+  readonly id: number;
+  readonly localeWriteRevision: number;
+  readonly startedWhileWritePending: boolean;
 }
 
 /**
@@ -17,13 +30,41 @@ export interface UiLocaleUpdateGate {
  */
 export function createUiLocaleUpdateGate(): UiLocaleUpdateGate {
   let latestTicket = 0;
+  let latestHydrationTicket = 0;
+  const pendingTickets = new Set<number>();
 
   return {
     begin(hasLocalePreference) {
-      return hasLocalePreference ? ++latestTicket : null;
+      if (!hasLocalePreference) return null;
+      const ticket = ++latestTicket;
+      pendingTickets.add(ticket);
+      return ticket;
+    },
+    cancel(ticket) {
+      if (ticket !== null) pendingTickets.delete(ticket);
     },
     commit(ticket, preference, onUiLocalePreferenceChange) {
+      if (ticket !== null) pendingTickets.delete(ticket);
       if (ticket === null || ticket !== latestTicket) return false;
+      onUiLocalePreferenceChange(preference);
+      return true;
+    },
+    beginHydration() {
+      return {
+        id: ++latestHydrationTicket,
+        localeWriteRevision: latestTicket,
+        startedWhileWritePending: pendingTickets.size > 0,
+      };
+    },
+    commitHydration(ticket, preference, onUiLocalePreferenceChange) {
+      if (
+        ticket.id !== latestHydrationTicket
+        || ticket.localeWriteRevision !== latestTicket
+        || ticket.startedWhileWritePending
+        || pendingTickets.size > 0
+      ) {
+        return false;
+      }
       onUiLocalePreferenceChange(preference);
       return true;
     },

--- a/apps/desktop/src/renderer/settings/ui-locale-update-gate.ts
+++ b/apps/desktop/src/renderer/settings/ui-locale-update-gate.ts
@@ -1,0 +1,31 @@
+import type { UiLocalePreference } from '@maka/core';
+
+export interface UiLocaleUpdateGate {
+  begin(hasLocalePreference: boolean): number | null;
+  commit(
+    ticket: number | null,
+    preference: UiLocalePreference,
+    onUiLocalePreferenceChange: (preference: UiLocalePreference) => void,
+  ): boolean;
+}
+
+/**
+ * Keeps locale writes ordered independently from unrelated Settings writes.
+ * The gate deliberately outlives the Settings surface's mounted ownership:
+ * AppShell owns the callback and must receive a successful persisted value
+ * even when the modal closes before the IPC response arrives.
+ */
+export function createUiLocaleUpdateGate(): UiLocaleUpdateGate {
+  let latestTicket = 0;
+
+  return {
+    begin(hasLocalePreference) {
+      return hasLocalePreference ? ++latestTicket : null;
+    },
+    commit(ticket, preference, onUiLocalePreferenceChange) {
+      if (ticket === null || ticket !== latestTicket) return false;
+      onUiLocalePreferenceChange(preference);
+      return true;
+    },
+  };
+}

--- a/apps/desktop/src/renderer/settings/ui-locale-update-gate.ts
+++ b/apps/desktop/src/renderer/settings/ui-locale-update-gate.ts
@@ -38,6 +38,11 @@ export function createUiLocaleUpdateGate(): UiLocaleUpdateGate {
     preference: UiLocalePreference;
     apply: (preference: UiLocalePreference) => void;
   }>();
+  let blockedHydration: {
+    ticket: UiLocaleHydrationTicket;
+    preference: UiLocalePreference;
+    apply: (preference: UiLocalePreference) => void;
+  } | null = null;
 
   function latestUnsettledTicket(): number {
     let latest = 0;
@@ -50,11 +55,27 @@ export function createUiLocaleUpdateGate(): UiLocaleUpdateGate {
     const successful = successfulWrites.get(ticket);
     if (!successful) return false;
     successfulWrites.delete(ticket);
+    blockedHydration = null;
     appliedTicket = Math.max(appliedTicket, ticket);
     for (const staleTicket of successfulWrites.keys()) {
       if (staleTicket < appliedTicket) successfulWrites.delete(staleTicket);
     }
     successful.apply(successful.preference);
+    return true;
+  }
+
+  function applyBlockedHydration(): boolean {
+    if (
+      !blockedHydration
+      || blockedHydration.ticket.id !== latestHydrationTicket
+      || pendingTickets.size > 0
+      || successfulWrites.size > 0
+    ) {
+      return false;
+    }
+    const hydration = blockedHydration;
+    blockedHydration = null;
+    hydration.apply(hydration.preference);
     return true;
   }
 
@@ -72,7 +93,7 @@ export function createUiLocaleUpdateGate(): UiLocaleUpdateGate {
       successfulWrites.delete(ticket);
       if (ticket !== latestTicket) return;
       latestTicket = latestUnsettledTicket();
-      applySuccessfulWrite(latestTicket);
+      if (!applySuccessfulWrite(latestTicket)) applyBlockedHydration();
     },
     commit(ticket, preference, onUiLocalePreferenceChange) {
       if (ticket === null) return false;
@@ -93,16 +114,30 @@ export function createUiLocaleUpdateGate(): UiLocaleUpdateGate {
       };
     },
     commitHydration(ticket, preference, onUiLocalePreferenceChange) {
+      if (ticket.id !== latestHydrationTicket) {
+        return false;
+      }
       if (
-        ticket.id !== latestHydrationTicket
-        || ticket.localeWriteRevision !== writeRevision
-        || ticket.startedWhileWritePending
-        || pendingTickets.size > 0
+        appliedTicket > ticket.localeWriteRevision
+        || (ticket.startedWhileWritePending && appliedTicket >= ticket.localeWriteRevision)
       ) {
         return false;
       }
-      onUiLocalePreferenceChange(preference);
-      return true;
+      if (
+        ticket.localeWriteRevision === writeRevision
+        && !ticket.startedWhileWritePending
+        && pendingTickets.size === 0
+      ) {
+        blockedHydration = null;
+        onUiLocalePreferenceChange(preference);
+        return true;
+      }
+      blockedHydration = {
+        ticket,
+        preference,
+        apply: onUiLocalePreferenceChange,
+      };
+      return applyBlockedHydration();
     },
   };
 }

--- a/apps/desktop/src/renderer/theme.ts
+++ b/apps/desktop/src/renderer/theme.ts
@@ -82,32 +82,3 @@ export function applyThemePalette(palette: ThemePalette): void {
   }
   safeLocalStorageSet('maka-theme-palette-v1', palette);
 }
-
-/**
- * PR-LANG-PREF-0: apply persisted UI locale preference to `<html>`.
- *
- * - `'auto'`  → remove `data-maka-locale`; UI components fall back to
- *               the Chinese-first product default.
- * - `'zh'` / `'en'` → set `data-maka-locale=<value>` so
- *               `detectUiLocale()` returns the user choice synchronously
- *               on every read.
- *
- * Also updates `<html lang>` so screen readers and CSS `:lang()` rules
- * see the right language code. The visual-smoke override
- * (`data-maka-visual-smoke-locale`) still wins over this attribute
- * in `detectUiLocale()` so fixture screenshots stay deterministic.
- */
-export type UiLocalePreference = 'auto' | 'zh' | 'en';
-
-export function applyUiLocale(preference: UiLocalePreference): void {
-  const root = document.documentElement;
-  if (preference === 'auto') {
-    root.removeAttribute('data-maka-locale');
-    // Keep the default shell coherent for assistive tech. Explicit
-    // English still sets both `data-maka-locale` and `lang` below.
-    root.setAttribute('lang', 'zh');
-  } else {
-    root.setAttribute('data-maka-locale', preference);
-    root.setAttribute('lang', preference);
-  }
-}

--- a/apps/desktop/stories/settings/settings-pages.stories.tsx
+++ b/apps/desktop/stories/settings/settings-pages.stories.tsx
@@ -1,4 +1,4 @@
-import { useRef } from 'react';
+import { useRef, useState } from 'react';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { ToastProvider } from '@maka/ui';
 import type {
@@ -12,6 +12,7 @@ import type {
 } from '@maka/core';
 import { createDefaultSettings, DEFAULT_DAILY_REVIEW_CONFIG, mergeSettings } from '@maka/core';
 import { SettingsSurface } from '../../src/renderer/settings/settings-surface';
+import { createUiLocaleUpdateGate } from '../../src/renderer/settings/ui-locale-update-gate';
 import type { ConnectionsBridge } from '../../src/renderer/settings/ProvidersPanel';
 import { withScopedMakaBridge } from '../maka-bridge';
 
@@ -189,6 +190,7 @@ const withSettingsBridge = withScopedMakaBridge(makaBridge);
 
 function SettingsStory(props: { section: SettingsSection }) {
   const initialFocusRef = useRef<HTMLButtonElement>(null);
+  const [uiLocaleUpdateGate] = useState(createUiLocaleUpdateGate);
 
   return (
     <ToastProvider>
@@ -210,6 +212,7 @@ function SettingsStory(props: { section: SettingsSection }) {
           themePalette={'default' as ThemePalette}
           onThemePaletteChange={noop}
           onUiLocalePreferenceChange={noop}
+          uiLocaleUpdateGate={uiLocaleUpdateGate}
           requestedSection={props.section}
           initialFocusRef={initialFocusRef}
           onOpenDailyReview={noop}

--- a/apps/desktop/stories/settings/settings-pages.stories.tsx
+++ b/apps/desktop/stories/settings/settings-pages.stories.tsx
@@ -209,6 +209,7 @@ function SettingsStory(props: { section: SettingsSection }) {
           onThemeChange={noop}
           themePalette={'default' as ThemePalette}
           onThemePaletteChange={noop}
+          onUiLocalePreferenceChange={noop}
           requestedSection={props.section}
           initialFocusRef={initialFocusRef}
           onOpenDailyReview={noop}

--- a/docs/superpowers/plans/2026-07-16-reactive-locale-foundation.md
+++ b/docs/superpowers/plans/2026-07-16-reactive-locale-foundation.md
@@ -1,0 +1,376 @@
+# Reactive Locale Foundation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Establish one persisted locale preference and one reactive derived `zh | en` locale for `@maka/core`, `@maka/ui`, and the desktop renderer.
+
+**Architecture:** `@maka/core` owns closed locale types and the pure resolution/Intl mapping policy. `@maka/ui` owns a React provider and typed catalogs, while desktop owns the persisted-preference state and visual-test override state. All existing locale-aware renderers consume context; DOM attributes remain synchronized outputs rather than a second input path.
+
+**Tech Stack:** TypeScript 5.9, React 19, Node test runner, Electron desktop renderer, npm workspaces.
+
+---
+
+### Task 1: Canonicalize locale types and resolution in `@maka/core`
+
+**Files:**
+- Create: `packages/core/src/ui-locale.ts`
+- Create: `packages/core/src/__tests__/ui-locale.test.ts`
+- Modify: `packages/core/src/settings.ts`
+- Modify: `packages/core/src/index.ts`
+- Modify: `packages/core/src/__tests__/lang-pref.test.ts`
+
+- [ ] **Step 1: Write failing locale contract tests**
+
+Add tests that import the public core API and assert the exact supported arrays, both runtime guards, `auto -> zh`, explicit choices, override precedence, and Intl mapping:
+
+```ts
+assert.deepEqual([...UI_LOCALES], ['zh', 'en']);
+assert.deepEqual([...UI_LOCALE_PREFERENCES], ['auto', 'zh', 'en']);
+assert.equal(resolveUiLocale('auto'), 'zh');
+assert.equal(resolveUiLocale('en'), 'en');
+assert.equal(resolveUiLocale('en', 'zh'), 'zh');
+assert.equal(uiLocaleToIntlLocale('zh'), 'zh-CN');
+assert.equal(uiLocaleToIntlLocale('en'), 'en');
+```
+
+- [ ] **Step 2: Run the focused test and verify RED**
+
+Run: `npm --workspace @maka/core test`
+
+Expected: TypeScript build fails because `ui-locale.ts` and the public exports do not exist.
+
+- [ ] **Step 3: Add the canonical core implementation**
+
+Implement:
+
+```ts
+export const UI_LOCALES = ['zh', 'en'] as const;
+export type UiLocale = typeof UI_LOCALES[number];
+export type UiLocalePreference = 'auto' | UiLocale;
+export const UI_LOCALE_PREFERENCES = ['auto', ...UI_LOCALES] as const;
+export type UiCatalog<T> = Record<UiLocale, T>;
+
+export function isUiLocale(value: unknown): value is UiLocale {
+  return value === 'zh' || value === 'en';
+}
+
+export function isUiLocalePreference(value: unknown): value is UiLocalePreference {
+  return value === 'auto' || isUiLocale(value);
+}
+
+export function resolveUiLocale(
+  preference: UiLocalePreference,
+  override?: UiLocale | null,
+): UiLocale {
+  if (override) return override;
+  return preference === 'auto' ? 'zh' : preference;
+}
+
+export function uiLocaleToIntlLocale(locale: UiLocale): 'zh-CN' | 'en' {
+  return locale === 'zh' ? 'zh-CN' : 'en';
+}
+```
+
+Import the preference type/constants/guard into `settings.ts`, remove its duplicate declarations, and re-export the locale module from `index.ts`.
+
+- [ ] **Step 4: Run core tests and verify GREEN**
+
+Run: `npm --workspace @maka/core test`
+
+Expected: all core tests pass.
+
+- [ ] **Step 5: Commit**
+
+Commit message: `feat(core): centralize UI locale contract`
+
+### Task 2: Make core timestamp formatting explicitly locale-driven
+
+**Files:**
+- Modify: `packages/core/src/relative-time.ts`
+- Modify: `packages/core/src/__tests__/relative-time.test.ts`
+
+- [ ] **Step 1: Write failing zh/en formatter tests**
+
+Add English and Chinese assertions that pass the locale explicitly as the third argument:
+
+```ts
+assert.match(formatRelativeTimestamp(NOW - 5 * 60_000, NOW, 'en'), /5 minutes ago/i);
+assert.match(formatRelativeTimestamp(NOW - 5 * 60_000, NOW, 'zh'), /5.*分钟/);
+```
+
+Add a source assertion that `relative-time.ts` no longer reads `document.documentElement`.
+
+- [ ] **Step 2: Run focused core tests and verify RED**
+
+Run: `npm --workspace @maka/core test`
+
+Expected: the English call still uses the Chinese DOM/default resolver.
+
+- [ ] **Step 3: Thread `UiLocale` into formatter caches**
+
+Change relative and compact timestamp functions to accept `locale: UiLocale = 'zh'` after the existing `now` argument, map through `uiLocaleToIntlLocale()`, and key caches by that mapped value. Delete the DOM-reading `resolveLocale()` helper. Preserve every existing time bucket and default behavior.
+
+- [ ] **Step 4: Run core tests and verify GREEN**
+
+Run: `npm --workspace @maka/core test`
+
+Expected: all core tests pass, including explicit zh/en output.
+
+- [ ] **Step 5: Commit**
+
+Commit message: `refactor(core): make timestamp locale explicit`
+
+### Task 3: Add the reactive provider to `@maka/ui`
+
+**Files:**
+- Create: `packages/ui/src/locale-context.tsx`
+- Create: `packages/ui/src/__tests__/locale-context.test.tsx`
+- Modify: `packages/ui/src/index.ts`
+- Modify: `packages/ui/src/locale-helpers.ts`
+
+- [ ] **Step 1: Write failing provider/context tests**
+
+Test the provider API with a small server-rendered context probe. Test the provider's exported `syncUiLocaleDocument(locale, override)` helper separately with a fake `document.documentElement`; the provider layout effect must call this same helper:
+
+```tsx
+function Probe() {
+  return <span>{useUiLocale()}</span>;
+}
+
+assert.equal(renderToStaticMarkup(
+  <LocaleProvider preference="en"><Probe /></LocaleProvider>,
+), '<span>en</span>');
+```
+
+The tests also cover `auto -> zh`, override precedence, missing-provider failure, `lang`, `data-maka-locale`, and `data-maka-visual-smoke-locale` synchronization.
+
+- [ ] **Step 2: Run UI tests and verify RED**
+
+Run: `npm --workspace @maka/ui test`
+
+Expected: build fails because `LocaleProvider` and `useUiLocale` do not exist.
+
+- [ ] **Step 3: Implement provider and hook**
+
+Implement a context with an undefined default, derive through core `resolveUiLocale`, synchronize HTML through `syncUiLocaleDocument()` in a layout effect guarded for non-DOM environments, and throw `useUiLocale must be used within LocaleProvider` outside the provider. Export the module from `index.ts`.
+
+Keep prompt suggestions in `locale-helpers.ts`, import the canonical `UiLocale`/`UiCatalog` from core, require an explicit locale in `getPromptSuggestions(locale)`, and remove `detectUiLocale()`.
+
+- [ ] **Step 4: Run UI tests and verify GREEN**
+
+Run: `npm --workspace @maka/ui test`
+
+Expected: all UI tests pass.
+
+- [ ] **Step 5: Commit**
+
+Commit message: `feat(ui): add reactive locale provider`
+
+### Task 4: Migrate existing shared UI locale consumers
+
+**Files:**
+- Modify: `packages/ui/src/chat-empty-hero.tsx`
+- Modify: `packages/ui/src/composer.tsx`
+- Modify: `packages/ui/src/chat-display-helpers.ts`
+- Modify: `packages/ui/src/relative-time.tsx`
+- Modify: `packages/ui/src/session-history-list.tsx`
+- Modify: `packages/ui/src/tool-activity.tsx`
+- Modify: `packages/ui/src/tool-activity/presentation.ts`
+- Modify: `packages/ui/src/__tests__/tool-activity-presentation.test.ts`
+- Modify: affected component render tests to wrap `LocaleProvider`
+
+- [ ] **Step 1: Add failing locale-reactivity and pure-helper tests**
+
+Assert chat time helpers accept `UiLocale`, tool display helpers accept it explicitly, and source contains no `detectUiLocale` call:
+
+```ts
+assert.match(formatAbsoluteTimestamp(TS, 'en'), /2026|Jul/);
+assert.equal(resolveToolDisplayName(connectorItem, 'en'), 'Load tools');
+```
+
+- [ ] **Step 2: Run UI tests and verify RED**
+
+Run: `npm --workspace @maka/ui test`
+
+Expected: helpers do not accept/consume an explicit locale and source still imports `detectUiLocale`.
+
+- [ ] **Step 3: Replace detection with context/parameters**
+
+Use `useUiLocale()` at React component boundaries. Pass `UiLocale` into pure helpers. Convert existing catalog declarations to `UiCatalog<...>` so both keys are compile-time required. Pass locale into core timestamp functions and UI absolute/clock formatters. Update isolated component tests to render inside `LocaleProvider preference="auto"`.
+
+- [ ] **Step 4: Run UI tests and typecheck**
+
+Run: `npm --workspace @maka/ui test`
+
+Run: `npm --workspace @maka/ui run typecheck`
+
+Expected: both commands pass and `rg -n "detectUiLocale" packages/ui/src` returns no matches.
+
+- [ ] **Step 5: Commit**
+
+Commit message: `refactor(ui): consume locale from React context`
+
+### Task 5: Wire desktop persisted preference and visual override into React state
+
+**Files:**
+- Create: `apps/desktop/src/main/__tests__/reactive-locale-foundation-contract.test.ts`
+- Modify: `apps/desktop/src/renderer/app-shell.tsx`
+- Modify: `apps/desktop/src/renderer/app-shell-visual-smoke.ts`
+- Modify: `apps/desktop/src/renderer/app-shell-overlays.tsx`
+- Modify: `apps/desktop/src/renderer/settings/SettingsModal.tsx`
+- Modify: `apps/desktop/src/renderer/settings/settings-surface.tsx`
+- Modify: `apps/desktop/src/renderer/settings/appearance-settings-page.tsx`
+- Modify: `apps/desktop/src/renderer/OnboardingHero.tsx`
+- Modify: `apps/desktop/src/renderer/artifact-pane.tsx`
+- Modify: `apps/desktop/src/renderer/theme.ts`
+- Modify: existing desktop source-contract tests affected by the new state path
+
+- [ ] **Step 1: Write failing desktop wiring tests**
+
+Add contracts asserting:
+
+- `AppShell` owns `uiLocalePreference` and `uiLocaleOverride` state;
+- the whole renderer return is wrapped in `LocaleProvider`;
+- startup settings hydrate preference state;
+- visual smoke hydrates override state;
+- successful settings updates notify the shell with `result.settings.personalization.uiLocale`;
+- no settings path calls `applyUiLocale`;
+- `OnboardingHero` and `ArtifactPane` consume `useUiLocale()`;
+- the legacy duplicate type and `applyUiLocale()` implementation are removed from `theme.ts`.
+
+- [ ] **Step 2: Run the targeted desktop test and verify RED**
+
+Run: `npm --workspace @maka/desktop run build:main`
+
+Run: `node --test apps/desktop/dist/main/__tests__/reactive-locale-foundation-contract.test.js`
+
+Expected: source contract fails because locale is still applied only to DOM.
+
+- [ ] **Step 3: Implement desktop state and provider wiring**
+
+In `AppShell`:
+
+```tsx
+const [uiLocalePreference, setUiLocalePreference] = useState<UiLocalePreference>('auto');
+const [uiLocaleOverride, setUiLocaleOverride] = useState<UiLocale | null>(null);
+
+return (
+  <LocaleProvider preference={uiLocalePreference} override={uiLocaleOverride}>
+    {/* existing desktop tree */}
+  </LocaleProvider>
+);
+```
+
+Set both states in `refreshShellSettings()`. Pass `setUiLocaleOverride` into visual-smoke actions. Thread `onUiLocalePreferenceChange` alongside the existing theme callbacks through overlays, modal, and settings surface. Invoke it only after a current successful settings update and use the canonical value returned by the backend.
+
+Delete `applyUiLocale` and the duplicate desktop preference type. Migrate `OnboardingHero` and `ArtifactPane` to the hook and explicit timestamp locale.
+
+- [ ] **Step 4: Run desktop targeted tests and verify GREEN**
+
+Run: `npm --workspace @maka/desktop run build:main`
+
+Run: `node --test apps/desktop/dist/main/__tests__/reactive-locale-foundation-contract.test.js`
+
+Expected: all new desktop locale contracts pass.
+
+- [ ] **Step 5: Commit**
+
+Commit message: `feat(desktop): wire reactive UI locale state`
+
+### Task 6: Remove the parallel localization path and prove compile-time catalog coverage
+
+**Files:**
+- Modify: all remaining files reported by locale searches
+- Modify: `apps/desktop/src/main/__tests__/personalization-sync-contract.test.ts`
+- Modify: `apps/desktop/src/main/__tests__/renderer-startup-fail-soft-contract.test.ts`
+- Modify: `apps/desktop/src/main/visual-smoke-fixture.ts` comments/contracts as needed
+
+- [ ] **Step 1: Add failing absence/precedence assertions**
+
+The desktop contract must reject these source patterns:
+
+```ts
+assert.doesNotMatch(rendererSource, /detectUiLocale/);
+assert.doesNotMatch(rendererSource, /applyUiLocale/);
+assert.doesNotMatch(rendererSource, /document\.documentElement.*makaLocale/);
+```
+
+It must assert `UiCatalog` usage for current catalogs and test override precedence through the core resolver/provider inputs.
+
+- [ ] **Step 2: Run targeted tests and verify RED**
+
+Run the new desktop contract and existing personalization/startup contracts.
+
+Expected: stale contracts still expect `applyUiLocale` or remaining sources still reference DOM detection.
+
+- [ ] **Step 3: Update remaining consumers and stale contracts**
+
+Remove all remaining renderer/UI reads of locale DOM attributes, update comments to describe React state, and realign old source tests with the single preference -> state -> provider path. Keep visual-smoke DOM attributes only as provider-synchronized observable outputs.
+
+- [ ] **Step 4: Run searches and targeted tests**
+
+Run: `rg -n "detectUiLocale|applyUiLocale|type UiLocalePreference =" packages apps/desktop/src/renderer`
+
+Expected: no legacy implementation matches; only canonical core exports/tests/documentation may mention the names.
+
+Run the targeted core, UI, and desktop locale tests. Expected: all pass.
+
+- [ ] **Step 5: Commit**
+
+Commit message: `test(locale): enforce single reactive locale path`
+
+### Task 7: Final verification and delivery audit
+
+**Files:**
+- Modify only files needed to fix verification failures caused by this branch.
+
+- [ ] **Step 1: Run focused package tests**
+
+Run:
+
+```text
+npm --workspace @maka/core test
+npm --workspace @maka/ui test
+npm --workspace @maka/desktop test
+```
+
+Expected: core and UI are fully green. Desktop feature-related tests are green; separately record any reproduced Windows-only baseline failures established before implementation.
+
+- [ ] **Step 2: Run workspace typecheck and build**
+
+Run: `npm run typecheck`
+
+Run: `npm run build`
+
+Expected: both exit 0.
+
+- [ ] **Step 3: Run repository hygiene checks**
+
+Run: `git diff --check upstream/main...HEAD`
+
+Run: `git status --short`
+
+Expected: no whitespace errors and only intentional changes.
+
+- [ ] **Step 4: Audit every PR 1 requirement**
+
+Confirm with source/test evidence:
+
+- canonical core types and resolver;
+- provider/hook public API;
+- persisted preference enters React state;
+- runtime switching is reactive;
+- override > explicit > auto precedence;
+- `auto -> zh` remains;
+- `<html lang>` and Intl use the resolved locale;
+- catalogs require zh/en at compile time;
+- DOM detection and duplicate types are absent;
+- CLI and later translation slices are untouched.
+
+- [ ] **Step 5: Review branch diff and commit any verification-only fixes**
+
+Run: `git diff --stat upstream/main...HEAD`
+
+Run: `git log --oneline upstream/main..HEAD`
+
+Expected: a focused PR 1 diff with small, intentional commits and no generated artifacts.

--- a/docs/superpowers/specs/2026-07-16-reactive-locale-foundation-design.md
+++ b/docs/superpowers/specs/2026-07-16-reactive-locale-foundation-design.md
@@ -1,0 +1,120 @@
+# Reactive Locale Foundation Design
+
+## Scope
+
+This change implements only PR 1 from issue #1052. It establishes the reactive locale authority needed by later translation slices without translating the remaining desktop shell, settings, conversation, or tool copy.
+
+The foundation must provide:
+
+- one persisted preference: `personalization.uiLocale`;
+- one derived runtime locale: `zh | en`;
+- a temporary `auto -> zh` policy until desktop coverage is complete;
+- a test-only override that wins over the persisted preference;
+- reactive React rendering with no reload;
+- synchronized `<html lang>` and locale-sensitive `Intl` formatting;
+- compile-time-complete `zh` and `en` catalogs;
+- no DOM-reading localization path alongside React context.
+
+CLI localization, additional locales, translation infrastructure, and translation of user/model/generated content remain out of scope.
+
+## Architecture
+
+### `@maka/core`: canonical locale contract
+
+Create a focused `ui-locale.ts` module that owns:
+
+- `UiLocale = 'zh' | 'en'`;
+- `UiLocalePreference = 'auto' | UiLocale`;
+- the ordered supported locale and preference constants;
+- runtime guards for both closed unions;
+- `UiCatalog<T> = Record<UiLocale, T>`;
+- a pure `resolveUiLocale(preference, override?)` policy;
+- `uiLocaleToIntlLocale(locale)` for the `zh -> zh-CN`, `en -> en` mapping.
+
+The resolver precedence is:
+
+1. valid test override;
+2. explicit `zh` or `en` preference;
+3. `auto -> zh`.
+
+`settings.ts` imports these definitions instead of declaring a second preference union. `@maka/core` re-exports the complete locale contract from its public index.
+
+### `@maka/ui`: reactive provider and typed catalogs
+
+Replace `detectUiLocale()` with a React context:
+
+- `<LocaleProvider preference override>` derives the locale through `resolveUiLocale()`;
+- `useUiLocale()` returns that derived locale and fails clearly outside a provider;
+- the provider updates `<html lang>` whenever the resolved locale changes;
+- the provider exposes the locale through React state/context only, not by reading DOM attributes.
+
+Existing shared UI catalogs use `UiCatalog<T>` (or an equivalent `satisfies UiCatalog<T>` constraint), so omitting either locale is a type error. Existing components that currently call `detectUiLocale()` switch to `useUiLocale()`. Non-component presentation helpers receive `UiLocale` explicitly from their React owner.
+
+The legacy `detectUiLocale()` export is removed once all current consumers are migrated. This prevents a non-reactive DOM path from surviving beside the provider.
+
+### Desktop renderer: preference and override state
+
+`AppShell` owns two runtime inputs:
+
+- `uiLocalePreference`, initialized as `auto` and refreshed from persisted settings;
+- `uiLocaleOverride`, initialized as `null` and populated only by the visual-smoke fixture.
+
+The returned desktop tree is wrapped in `LocaleProvider`. Settings updates continue to persist through the existing `window.maka.settings.update()` path. After a locale patch is accepted, the settings surface notifies `AppShell`, which updates the preference state and triggers an immediate React rerender without reloading.
+
+The visual-smoke action updates `uiLocaleOverride` rather than only writing a DOM attribute. The provider resolves the override, rerenders consumers, and synchronizes `<html lang>`. Test attributes may remain as observable fixture markers, but no production copy or formatter reads them as locale authority.
+
+## Data flow
+
+Startup:
+
+1. Desktop starts with preference `auto` and no override, resolving to `zh`.
+2. `refreshShellSettings()` loads the persisted preference and visual-smoke state.
+3. React state receives both inputs.
+4. `LocaleProvider` derives one locale and publishes it.
+5. Consumers rerender; `<html lang>` and `Intl` receive the same locale.
+
+Runtime preference change:
+
+1. The user selects `auto`, `zh`, or `en`.
+2. The existing settings update path persists `personalization.uiLocale`.
+3. On success, the desktop preference state updates.
+4. The provider derives the new locale and React consumers rerender immediately.
+5. `<html lang>` changes in the same commit/effect cycle; no reload occurs.
+
+Test override:
+
+1. The visual-smoke fixture provides `zh` or `en`.
+2. Desktop stores it in override state.
+3. The override wins over every persisted preference.
+4. Clearing the override reveals the persisted preference again.
+
+## `Intl` behavior
+
+Locale-sensitive formatters must not inspect `document`. Pure formatter functions accept `UiLocale` explicitly (with a Chinese default only where a non-React compatibility call requires one). React formatter components call `useUiLocale()` and pass the resolved value. Formatter caches are keyed by the mapped `Intl` locale, so runtime switching selects a new formatter without reload.
+
+## Error handling
+
+- Persisted unknown preferences continue to normalize to `auto` at the settings boundary.
+- Invalid visual-smoke values continue to normalize to no override before reaching React.
+- `useUiLocale()` outside a provider throws an actionable error instead of silently selecting a language.
+- A failed settings write leaves the runtime authority unchanged and preserves the existing sanitized failure toast.
+
+## Testing
+
+Tests are added before implementation and cover:
+
+- core union guards, constants, `auto -> zh`, explicit preference resolution, override precedence, catalog completeness, and `Intl` mapping;
+- provider rendering in both locales, runtime prop switching, missing-provider failure, and `<html lang>` synchronization;
+- existing localized shared components consuming context rather than DOM detection;
+- desktop startup hydration from the persisted preference;
+- successful locale persistence updating desktop React state;
+- failed persistence not changing the runtime locale;
+- visual-smoke override precedence and synchronization;
+- relative/absolute time formatting using the resolved locale;
+- source/compile contracts proving the duplicate locale types and `detectUiLocale()` path are gone.
+
+Verification includes focused red/green tests, `@maka/core`, `@maka/ui`, and desktop tests, workspace typechecking, build checks, `git diff --check`, and a requirement-by-requirement audit against PR 1.
+
+## Delivery boundary
+
+PR 1 makes every already-localized surface reactive and establishes compile-time-safe catalogs. It does not claim that the entire English desktop renderer is translated; that issue-level completion condition depends on PRs 2–4. The temporary `auto -> zh` behavior is intentional in this slice even though the final issue outcome will later make “Follow system” inspect the supported system language.

--- a/packages/core/src/__tests__/relative-time.test.ts
+++ b/packages/core/src/__tests__/relative-time.test.ts
@@ -37,6 +37,18 @@ describe('formatRelativeTimestamp', () => {
     assert.match(out, /5.*minute|分钟/i);
   });
 
+  it('formats against the explicitly resolved English locale', () => {
+    const out = formatRelativeTimestamp(NOW - 5 * 60_000, NOW, 'en');
+    assert.match(out, /5 minutes ago/i);
+    assert.doesNotMatch(out, /分钟/);
+  });
+
+  it('formats against the explicitly resolved Chinese locale', () => {
+    const out = formatRelativeTimestamp(NOW - 5 * 60_000, NOW, 'zh');
+    assert.match(out, /5.*分钟/);
+    assert.doesNotMatch(out, /minutes ago/i);
+  });
+
   it('formats a 3-hour age in hours', () => {
     const out = formatRelativeTimestamp(NOW - 3 * 60 * 60_000, NOW);
     assert.match(out, /3.*hour|小时/i);

--- a/packages/core/src/__tests__/ui-locale.test.ts
+++ b/packages/core/src/__tests__/ui-locale.test.ts
@@ -1,0 +1,64 @@
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'node:test';
+
+import {
+  UI_LOCALES,
+  UI_LOCALE_PREFERENCES,
+  isUiLocale,
+  isUiLocalePreference,
+  resolveUiLocale,
+  uiLocaleToIntlLocale,
+  type UiCatalog,
+} from '../index.js';
+
+describe('UI locale contract', () => {
+  it('exposes the complete supported locale and preference sets', () => {
+    assert.deepEqual([...UI_LOCALES], ['zh', 'en']);
+    assert.deepEqual([...UI_LOCALE_PREFERENCES], ['auto', 'zh', 'en']);
+  });
+
+  it('accepts only supported resolved locales', () => {
+    assert.equal(isUiLocale('zh'), true);
+    assert.equal(isUiLocale('en'), true);
+    assert.equal(isUiLocale('auto'), false);
+    assert.equal(isUiLocale('ja'), false);
+    assert.equal(isUiLocale(null), false);
+  });
+
+  it('accepts only supported persisted preferences', () => {
+    assert.equal(isUiLocalePreference('auto'), true);
+    assert.equal(isUiLocalePreference('zh'), true);
+    assert.equal(isUiLocalePreference('en'), true);
+    assert.equal(isUiLocalePreference('ja'), false);
+    assert.equal(isUiLocalePreference(undefined), false);
+  });
+
+  it('temporarily resolves auto to Chinese', () => {
+    assert.equal(resolveUiLocale('auto'), 'zh');
+  });
+
+  it('preserves an explicit supported preference', () => {
+    assert.equal(resolveUiLocale('zh'), 'zh');
+    assert.equal(resolveUiLocale('en'), 'en');
+  });
+
+  it('gives a test override precedence over every persisted preference', () => {
+    assert.equal(resolveUiLocale('auto', 'en'), 'en');
+    assert.equal(resolveUiLocale('en', 'zh'), 'zh');
+    assert.equal(resolveUiLocale('zh', null), 'zh');
+  });
+
+  it('maps the resolved locale to the Intl locale used by formatters', () => {
+    assert.equal(uiLocaleToIntlLocale('zh'), 'zh-CN');
+    assert.equal(uiLocaleToIntlLocale('en'), 'en');
+  });
+
+  it('provides a compile-time complete catalog shape', () => {
+    const catalog = {
+      zh: { label: '中文' },
+      en: { label: 'English' },
+    } satisfies UiCatalog<{ label: string }>;
+
+    assert.deepEqual(Object.keys(catalog), ['zh', 'en']);
+  });
+});

--- a/packages/core/src/__tests__/ui-locale.test.ts
+++ b/packages/core/src/__tests__/ui-locale.test.ts
@@ -11,6 +11,10 @@ import {
   type UiCatalog,
 } from '../index.js';
 
+// @ts-expect-error Every catalog must include English; no implicit fallback.
+const missingEnglishCatalog: UiCatalog<string> = { zh: '中文' };
+void missingEnglishCatalog;
+
 describe('UI locale contract', () => {
   it('exposes the complete supported locale and preference sets', () => {
     assert.deepEqual([...UI_LOCALES], ['zh', 'en']);

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1109,6 +1109,21 @@ export {
 } from './settings.js';
 export type { BotDeliveryProvider } from './settings.js';
 
+// ui-locale.ts
+export type {
+  UiCatalog,
+  UiLocale,
+  UiLocalePreference,
+} from './ui-locale.js';
+export {
+  UI_LOCALES,
+  UI_LOCALE_PREFERENCES,
+  isUiLocale,
+  isUiLocalePreference,
+  resolveUiLocale,
+  uiLocaleToIntlLocale,
+} from './ui-locale.js';
+
 // bot-platform-hints.ts
 export type {
   BotFormattingProfile,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -245,7 +245,6 @@ export {
   formatToolInvocationLine,
   type QuietPreview,
   type ToolInvocationInput,
-  type UiLocale,
 } from './tool-quiet-preview.js';
 export { redactSecrets as displayRedactSecrets } from './display-redaction.js';
 export {

--- a/packages/core/src/relative-time.ts
+++ b/packages/core/src/relative-time.ts
@@ -19,6 +19,8 @@
  * the locale date string.
  */
 
+import { uiLocaleToIntlLocale, type UiLocale } from './ui-locale.js';
+
 /** Maximum age (ms) that still gets a relative bucket. Older → absolute. */
 const RELATIVE_HORIZON_MS = 7 * 24 * 60 * 60 * 1000;
 
@@ -26,20 +28,8 @@ let cachedRelativeFormat: Intl.RelativeTimeFormat | null = null;
 let cachedAbsoluteFormat: Intl.DateTimeFormat | null = null;
 let cachedLocale: string | null = null;
 
-function resolveLocale(): string {
-  if (typeof document !== 'undefined') {
-    const explicit = document.documentElement.getAttribute('data-maka-locale');
-    if (explicit === 'en') return 'en';
-    if (explicit === 'zh') return 'zh-CN';
-    const smoke = document.documentElement.getAttribute('data-maka-visual-smoke-locale');
-    if (smoke === 'en') return 'en';
-    if (smoke === 'zh') return 'zh-CN';
-  }
-  return 'zh-CN';
-}
-
-function getRelativeFormat(): Intl.RelativeTimeFormat {
-  const locale = resolveLocale();
+function getRelativeFormat(uiLocale: UiLocale): Intl.RelativeTimeFormat {
+  const locale = uiLocaleToIntlLocale(uiLocale);
   if (!cachedRelativeFormat || cachedLocale !== locale) {
     cachedRelativeFormat = new Intl.RelativeTimeFormat(locale, { numeric: 'auto' });
     cachedAbsoluteFormat = null;
@@ -48,8 +38,8 @@ function getRelativeFormat(): Intl.RelativeTimeFormat {
   return cachedRelativeFormat;
 }
 
-function getAbsoluteFormat(): Intl.DateTimeFormat {
-  const locale = resolveLocale();
+function getAbsoluteFormat(uiLocale: UiLocale): Intl.DateTimeFormat {
+  const locale = uiLocaleToIntlLocale(uiLocale);
   if (!cachedAbsoluteFormat || cachedLocale !== locale) {
     cachedAbsoluteFormat = new Intl.DateTimeFormat(locale, {
       dateStyle: 'medium',
@@ -70,34 +60,38 @@ function getAbsoluteFormat(): Intl.DateTimeFormat {
  * don't want sidebar rows showing "in 2 minutes" when a tab's clock
  * drifts.
  */
-export function formatRelativeTimestamp(ts: number, now: number = Date.now()): string {
+export function formatRelativeTimestamp(
+  ts: number,
+  now: number = Date.now(),
+  locale: UiLocale = 'zh',
+): string {
   const diffMs = now - ts;
   if (diffMs < 0) {
     // Clock skew or future-dated record. Snap to "刚刚".
-    return getRelativeFormat().format(-1, 'second');
+    return getRelativeFormat(locale).format(-1, 'second');
   }
   if (diffMs > RELATIVE_HORIZON_MS) {
-    return getAbsoluteFormat().format(new Date(ts));
+    return getAbsoluteFormat(locale).format(new Date(ts));
   }
   const diffSeconds = Math.round(diffMs / 1000);
   if (diffSeconds < 60) {
     // Clamp to >=1 so we never produce "0 seconds ago".
-    return getRelativeFormat().format(-Math.max(1, diffSeconds), 'second');
+    return getRelativeFormat(locale).format(-Math.max(1, diffSeconds), 'second');
   }
   const diffMinutes = Math.round(diffSeconds / 60);
-  if (diffMinutes < 60) return getRelativeFormat().format(-diffMinutes, 'minute');
+  if (diffMinutes < 60) return getRelativeFormat(locale).format(-diffMinutes, 'minute');
   const diffHours = Math.round(diffMinutes / 60);
-  if (diffHours < 24) return getRelativeFormat().format(-diffHours, 'hour');
+  if (diffHours < 24) return getRelativeFormat(locale).format(-diffHours, 'hour');
   const diffDays = Math.round(diffHours / 24);
-  return getRelativeFormat().format(-diffDays, 'day');
+  return getRelativeFormat(locale).format(-diffDays, 'day');
 }
 
 let cachedCompactSameYearFormat: Intl.DateTimeFormat | null = null;
 let cachedCompactOtherYearFormat: Intl.DateTimeFormat | null = null;
 let cachedCompactLocale: string | null = null;
 
-function getCompactFormats(): { sameYear: Intl.DateTimeFormat; otherYear: Intl.DateTimeFormat } {
-  const locale = resolveLocale();
+function getCompactFormats(uiLocale: UiLocale): { sameYear: Intl.DateTimeFormat; otherYear: Intl.DateTimeFormat } {
+  const locale = uiLocaleToIntlLocale(uiLocale);
   if (!cachedCompactSameYearFormat || !cachedCompactOtherYearFormat || cachedCompactLocale !== locale) {
     cachedCompactSameYearFormat = new Intl.DateTimeFormat(locale, { month: 'short', day: 'numeric' });
     cachedCompactOtherYearFormat = new Intl.DateTimeFormat(locale, {
@@ -119,13 +113,17 @@ function getCompactFormats(): { sameYear: Intl.DateTimeFormat; otherYear: Intl.D
  * session title next to it to ~2 characters. Minute precision belongs
  * in tooltips/detail surfaces, not scan-level list rows.
  */
-export function formatCompactTimestamp(ts: number, now: number = Date.now()): string {
+export function formatCompactTimestamp(
+  ts: number,
+  now: number = Date.now(),
+  locale: UiLocale = 'zh',
+): string {
   const diffMs = now - ts;
   if (diffMs >= 0 && diffMs <= RELATIVE_HORIZON_MS) {
-    return formatRelativeTimestamp(ts, now);
+    return formatRelativeTimestamp(ts, now, locale);
   }
-  if (diffMs < 0) return formatRelativeTimestamp(ts, now);
-  const { sameYear, otherYear } = getCompactFormats();
+  if (diffMs < 0) return formatRelativeTimestamp(ts, now, locale);
+  const { sameYear, otherYear } = getCompactFormats(locale);
   const date = new Date(ts);
   const nowDate = new Date(now);
   return date.getFullYear() === nowDate.getFullYear() ? sameYear.format(date) : otherYear.format(date);

--- a/packages/core/src/relative-time.ts
+++ b/packages/core/src/relative-time.ts
@@ -130,7 +130,7 @@ export function formatCompactTimestamp(
 }
 
 /**
- * Reset the cached formatters. Used by `applyUiLocale()` so a language
+ * Reset cached formatters for deterministic tests. Runtime locale
  * change takes effect without a full reload — the next call will
  * re-instantiate against the new locale.
  */

--- a/packages/core/src/relative-time.ts
+++ b/packages/core/src/relative-time.ts
@@ -130,9 +130,8 @@ export function formatCompactTimestamp(
 }
 
 /**
- * Reset cached formatters for deterministic tests. Runtime locale
- * change takes effect without a full reload — the next call will
- * re-instantiate against the new locale.
+ * Reset cached formatters for deterministic tests. Runtime calls select the
+ * cache with an explicit locale, so switching locale does not need a reset.
  */
 export function resetRelativeTimeFormatters(): void {
   cachedRelativeFormat = null;

--- a/packages/core/src/settings.ts
+++ b/packages/core/src/settings.ts
@@ -17,6 +17,14 @@ import {
 import { defaultLocalMemorySettings, normalizeLocalMemorySettings } from './local-memory.js';
 import type { PermissionMode } from './permission.js';
 import { PERMISSION_MODES } from './permission.js';
+import {
+  UI_LOCALE_PREFERENCES,
+  isUiLocalePreference,
+  type UiLocalePreference,
+} from './ui-locale.js';
+
+export { UI_LOCALE_PREFERENCES, isUiLocalePreference } from './ui-locale.js';
+export type { UiLocalePreference } from './ui-locale.js';
 
 /**
  * PR-SETTINGS-IA-CONSOLIDATE-0 + PR-SETTINGS-REVIEW-0 (WAWQAQ msg
@@ -209,14 +217,6 @@ export interface AppearanceSettings {
  * Closed union so adding a third locale is a deliberate
  * contract-level decision.
  */
-export type UiLocalePreference = 'auto' | 'zh' | 'en';
-
-export const UI_LOCALE_PREFERENCES: readonly UiLocalePreference[] = ['auto', 'zh', 'en'];
-
-export function isUiLocalePreference(value: unknown): value is UiLocalePreference {
-  return value === 'auto' || value === 'zh' || value === 'en';
-}
-
 export interface PersonalizationSettings {
   /** How the assistant addresses the user. Empty falls back to "你". */
   displayName: string;

--- a/packages/core/src/settings.ts
+++ b/packages/core/src/settings.ts
@@ -712,8 +712,8 @@ export function normalizeSettings(input: unknown): AppSettings {
     // PR-LANG-PREF-0: closed-enum fail-closed for the new
     // `personalization.uiLocale` preference. mergeSettings spreads
     // raw user values, so an unknown value would otherwise reach the
-    // renderer and produce a `data-maka-locale="xx"` attribute with
-    // no detector mapping. Fall back to 'auto' on any miss.
+    // renderer outside the closed reactive-locale contract. Fall back to
+    // 'auto' on any miss.
     personalization: {
       ...base.personalization,
       uiLocale: isUiLocalePreference(base.personalization.uiLocale)

--- a/packages/core/src/settings.ts
+++ b/packages/core/src/settings.ts
@@ -208,9 +208,9 @@ export interface AppearanceSettings {
  * PR-LANG-PREF-0 (WAWQAQ msg `edc9cb41` + xuan `b4f4f2a8`/`54b56858`
  * + kenji `7e532892`): closed UI-locale preference.
  *
- * `'auto'` — use `navigator.language` detection (today's behavior).
+ * `'auto'` — temporarily resolve to Chinese-first UI copy.
  * `'zh'` / `'en'` — user explicit override; takes precedence over
- *   navigator detection but is itself overridden by the visual-smoke
+ *   the temporary fallback but is itself overridden by the visual-smoke
  *   fixture locale (fixtures stay deterministic regardless of the
  *   persisted user preference).
  *
@@ -224,7 +224,7 @@ export interface PersonalizationSettings {
   assistantTone: string;
   /**
    * PR-LANG-PREF-0: UI locale preference (kenji `7e532892` acceptance):
-   * user explicit choice > navigator.language; visual-smoke override
+   * user explicit choice > temporary auto-to-Chinese fallback; visual-smoke override
    * stays for fixture tests. Defaults to `'auto'`.
    */
   uiLocale: UiLocalePreference;

--- a/packages/core/src/tool-quiet-preview.ts
+++ b/packages/core/src/tool-quiet-preview.ts
@@ -6,16 +6,17 @@
  * and `readWriteStdinInputPreview`, both already in `@maka/core`.
  *
  * Extracted from `packages/ui/src/tool-activity/builtin-preview.ts` (#1065)
- * so the CLI can consume the same path. Desktop passes `detectUiLocale()`;
- * the TUI passes `'en'`.
+ * so the CLI can consume the same path. Every caller passes its resolved
+ * locale explicitly.
  */
 
 import { redactSecrets } from './display-redaction.js';
 import { readWriteStdinInputPreview } from './tool-activity-args.js';
+import type { UiLocale } from './ui-locale.js';
 
 // ── Locale ───────────────────────────────────────────────────────────────
 
-export type UiLocale = 'zh' | 'en';
+export type { UiLocale } from './ui-locale.js';
 
 interface QuietPreviewStrings {
   backgroundTerminal: string;

--- a/packages/core/src/ui-locale.ts
+++ b/packages/core/src/ui-locale.ts
@@ -1,0 +1,39 @@
+/** Resolved locales supported by the desktop renderer. */
+export const UI_LOCALES = ['zh', 'en'] as const;
+
+export type UiLocale = typeof UI_LOCALES[number];
+
+/** The only persisted locale preference. The resolved locale is never stored. */
+export type UiLocalePreference = 'auto' | UiLocale;
+
+export const UI_LOCALE_PREFERENCES = ['auto', ...UI_LOCALES] as const;
+
+/** A catalog must carry copy for every supported resolved locale. */
+export type UiCatalog<T> = Record<UiLocale, T>;
+
+export function isUiLocale(value: unknown): value is UiLocale {
+  return value === 'zh' || value === 'en';
+}
+
+export function isUiLocalePreference(value: unknown): value is UiLocalePreference {
+  return value === 'auto' || isUiLocale(value);
+}
+
+/**
+ * Derive the single renderer locale.
+ *
+ * Visual/test overrides are deliberately highest priority. `auto` remains
+ * Chinese-first until the remaining desktop translation slices are complete.
+ */
+export function resolveUiLocale(
+  preference: UiLocalePreference,
+  override?: UiLocale | null,
+): UiLocale {
+  if (override) return override;
+  return preference === 'auto' ? 'zh' : preference;
+}
+
+/** Locale identifier used by every locale-sensitive Intl formatter. */
+export function uiLocaleToIntlLocale(locale: UiLocale): 'zh-CN' | 'en' {
+  return locale === 'zh' ? 'zh-CN' : 'en';
+}

--- a/packages/core/src/visual-smoke.ts
+++ b/packages/core/src/visual-smoke.ts
@@ -1,5 +1,6 @@
 import type { PermissionRequestEvent, ToolResultContent } from './events.js';
 import type { SettingsSection } from './settings.js';
+import type { UiLocale } from './ui-locale.js';
 
 export type VisualSmokeScenario =
   | 'all'
@@ -210,17 +211,13 @@ export interface VisualSmokeState {
   theme?: 'light' | 'dark' | 'auto';
   /**
    * PR-UI-VISUAL-SMOKE-LOCALE: UI locale override driven by
-   * `MAKA_VISUAL_SMOKE_LOCALE=zh|en`. PR-UI-14's `detectUiLocale()`
-   * reads `navigator.language` by default, which makes screenshot
-   * baselines drift between hosts (e.g. a CI machine on en-US vs a
-   * Mac mini on zh-CN renders different placeholder text in the
-   * same fixture). When set, the renderer applies
-   * `data-maka-visual-smoke-locale="zh|en"` to `<html>` and
-   * `detectUiLocale()` reads that BEFORE `navigator.language`.
-   * Unrecognized values fall back to undefined (renderer uses
-   * navigator detection as today).
+   * `MAKA_VISUAL_SMOKE_LOCALE=zh|en`. The reactive locale provider
+   * normally follows the persisted preference. When set, the renderer
+   * records `data-maka-visual-smoke-locale="zh|en"` on `<html>` and
+   * resolves that override before the persisted preference.
+   * Unrecognized values fall back to undefined.
    */
-  locale?: 'zh' | 'en';
+  locale?: UiLocale;
   /**
    * PR-UI-VISUAL-SMOKE-TIMEZONE: IANA timezone override driven by
    * `MAKA_VISUAL_SMOKE_TIMEZONE=<IANA name>`. Mirrors the locale

--- a/packages/ui/src/__tests__/locale-context.test.tsx
+++ b/packages/ui/src/__tests__/locale-context.test.tsx
@@ -1,0 +1,104 @@
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'node:test';
+import { renderToStaticMarkup } from 'react-dom/server';
+
+import {
+  LocaleProvider,
+  syncUiLocaleDocument,
+  useUiLocale,
+} from '../locale-context.js';
+
+function LocaleProbe() {
+  return <span>{useUiLocale()}</span>;
+}
+
+describe('LocaleProvider', () => {
+  it('renders an explicit preference through context', () => {
+    const markup = renderToStaticMarkup(
+      <LocaleProvider preference="en">
+        <LocaleProbe />
+      </LocaleProvider>,
+    );
+
+    assert.equal(markup, '<span>en</span>');
+  });
+
+  it('switches the resolved locale when the provider preference changes', () => {
+    const renderPreference = (preference: 'zh' | 'en') => renderToStaticMarkup(
+      <LocaleProvider preference={preference}>
+        <LocaleProbe />
+      </LocaleProvider>,
+    );
+
+    assert.equal(renderPreference('zh'), '<span>zh</span>');
+    assert.equal(renderPreference('en'), '<span>en</span>');
+  });
+
+  it('keeps auto Chinese-first until desktop translation is complete', () => {
+    const markup = renderToStaticMarkup(
+      <LocaleProvider preference="auto">
+        <LocaleProbe />
+      </LocaleProvider>,
+    );
+
+    assert.equal(markup, '<span>zh</span>');
+  });
+
+  it('gives the test override precedence over the persisted preference', () => {
+    const markup = renderToStaticMarkup(
+      <LocaleProvider preference="en" override="zh">
+        <LocaleProbe />
+      </LocaleProvider>,
+    );
+
+    assert.equal(markup, '<span>zh</span>');
+  });
+
+  it('fails clearly when a reactive consumer is outside the provider', () => {
+    assert.throws(
+      () => renderToStaticMarkup(<LocaleProbe />),
+      /useUiLocale must be used within LocaleProvider/,
+    );
+  });
+});
+
+describe('syncUiLocaleDocument', () => {
+  it('synchronizes html lang, the resolved locale, and the test override', () => {
+    const previousDocument = globalThis.document;
+    const attributes = new Map<string, string>();
+    globalThis.document = {
+      documentElement: {
+        setAttribute(name: string, value: string) {
+          attributes.set(name, value);
+        },
+        removeAttribute(name: string) {
+          attributes.delete(name);
+        },
+      },
+    } as unknown as Document;
+
+    try {
+      syncUiLocaleDocument('zh', 'zh');
+      assert.equal(attributes.get('lang'), 'zh');
+      assert.equal(attributes.get('data-maka-locale'), 'zh');
+      assert.equal(attributes.get('data-maka-visual-smoke-locale'), 'zh');
+
+      syncUiLocaleDocument('en', null);
+      assert.equal(attributes.get('lang'), 'en');
+      assert.equal(attributes.get('data-maka-locale'), 'en');
+      assert.equal(attributes.has('data-maka-visual-smoke-locale'), false);
+    } finally {
+      globalThis.document = previousDocument;
+    }
+  });
+
+  it('is a no-op in non-DOM environments', () => {
+    const previousDocument = globalThis.document;
+    globalThis.document = undefined as unknown as Document;
+    try {
+      assert.doesNotThrow(() => syncUiLocaleDocument('en', null));
+    } finally {
+      globalThis.document = previousDocument;
+    }
+  });
+});

--- a/packages/ui/src/__tests__/tool-activity-presentation.test.ts
+++ b/packages/ui/src/__tests__/tool-activity-presentation.test.ts
@@ -1,17 +1,29 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
-import { createElement } from 'react';
-import { renderToStaticMarkup } from 'react-dom/server';
+import { createElement, type ReactNode } from 'react';
+import { renderToStaticMarkup as renderReactToStaticMarkup } from 'react-dom/server';
 import type { StoredMessage, ToolResultContent } from '@maka/core';
 import { ToolActivity, ToolTrow } from '../tool-activity.js';
 import { ToolResultPreview } from '../tool-activity/tool-result-preview.js';
 import {
   createToolDisclosureState,
-  deriveToolActivityPresentation,
+  deriveToolActivityPresentation as derivePresentation,
   setToolDisclosureOpen,
   syncToolDisclosureState,
 } from '../tool-activity/presentation.js';
 import { materializeTools, type ToolActivityItem } from '../materialize.js';
+import { LocaleProvider } from '../locale-context.js';
+
+function renderToStaticMarkup(node: ReactNode): string {
+  return renderReactToStaticMarkup(createElement(LocaleProvider, {
+    preference: 'zh',
+    children: node,
+  }));
+}
+
+function deriveToolActivityPresentation(item: ToolActivityItem) {
+  return derivePresentation(item, 'zh');
+}
 
 function renderTool(item: ToolActivityItem): string {
   return renderToStaticMarkup(createElement(ToolTrow, { items: [item] }));

--- a/packages/ui/src/__tests__/tool-trow-stability.test.tsx
+++ b/packages/ui/src/__tests__/tool-trow-stability.test.tsx
@@ -1,12 +1,20 @@
 import { strict as assert } from 'node:assert';
 import { describe, it } from 'node:test';
-import { createElement } from 'react';
-import { renderToStaticMarkup } from 'react-dom/server';
+import { createElement, type ReactNode } from 'react';
+import { renderToStaticMarkup as renderReactToStaticMarkup } from 'react-dom/server';
+import { LocaleProvider } from '../locale-context.js';
 import type { ToolActivityItem } from '../materialize.js';
 import { ToolTrow } from '../tool-activity.js';
 
 function runningTool(id: string, name: string): ToolActivityItem {
   return { toolUseId: id, toolName: name, status: 'running', args: {} };
+}
+
+function renderToStaticMarkup(node: ReactNode): string {
+  return renderReactToStaticMarkup(createElement(LocaleProvider, {
+    preference: 'zh',
+    children: node,
+  }));
 }
 
 describe('ToolTrow stable structure', () => {

--- a/packages/ui/src/__tests__/tool-trow-summary.test.ts
+++ b/packages/ui/src/__tests__/tool-trow-summary.test.ts
@@ -3,8 +3,9 @@ import { readFileSync } from 'node:fs';
 import { describe, it } from 'node:test';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { createElement } from 'react';
-import { renderToStaticMarkup } from 'react-dom/server';
+import { createElement, type ReactNode } from 'react';
+import { renderToStaticMarkup as renderReactToStaticMarkup } from 'react-dom/server';
+import { LocaleProvider } from '../locale-context.js';
 import { ToolTrow } from '../tool-activity.js';
 import { summarizeTrowTools } from '../tool-activity/trow-summary.js';
 import type { ToolActivityItem } from '../materialize.js';
@@ -13,6 +14,13 @@ const toolActivitySource = readFileSync(
   join(dirname(fileURLToPath(import.meta.url)), '..', '..', 'src', 'tool-activity.tsx'),
   'utf8',
 );
+
+function renderToStaticMarkup(node: ReactNode): string {
+  return renderReactToStaticMarkup(createElement(LocaleProvider, {
+    preference: 'zh',
+    children: node,
+  }));
+}
 
 describe('tool trow summary aggregation', () => {
   it('multi-tool running summary shows aggregated bucket with 正在 prefix, not the active tool description', () => {

--- a/packages/ui/src/chat-display-helpers.ts
+++ b/packages/ui/src/chat-display-helpers.ts
@@ -5,8 +5,8 @@
  *
  * PR-UI-LIB-EXTRACT-4 (round 5/10) introduced this module with a
  * deliberate ESM circular import on `./components.js` for
- * `detectUiLocale`. PR-UI-LIB-EXTRACT-5 (round 6/10) broke the
- * cycle by lifting `detectUiLocale` into a new `locale-helpers`
+ * locale resolution. PR-UI-LIB-EXTRACT-5 (round 6/10) broke the
+ * cycle by lifting locale helpers into a new `locale-helpers`
  * leaf module; this file now depends on that leaf instead.
  *
  * Why this seam: duration formatting has ms→s→m bucket rules, and
@@ -21,35 +21,35 @@
  * sites.
  */
 
-import { detectUiLocale } from './locale-helpers.js';
+import { uiLocaleToIntlLocale, type UiLocale } from '@maka/core';
 
-function createAbsoluteTimeFormat(): Intl.DateTimeFormat {
+function createAbsoluteTimeFormat(locale: UiLocale): Intl.DateTimeFormat {
   if (typeof Intl === 'undefined' || typeof Intl.DateTimeFormat !== 'function') {
     return { format: (d: Date) => d.toISOString() } as unknown as Intl.DateTimeFormat;
   }
   return new Intl.DateTimeFormat(
-    detectUiLocale() === 'en' ? 'en' : 'zh-CN',
+    uiLocaleToIntlLocale(locale),
     { dateStyle: 'medium', timeStyle: 'short' },
   );
 }
 
-export function formatAbsoluteTimestamp(ts: number): string {
-  return createAbsoluteTimeFormat().format(new Date(ts));
+export function formatAbsoluteTimestamp(ts: number, locale: UiLocale): string {
+  return createAbsoluteTimeFormat(locale).format(new Date(ts));
 }
 
-function createClockTimeFormat(): Intl.DateTimeFormat {
+function createClockTimeFormat(locale: UiLocale): Intl.DateTimeFormat {
   if (typeof Intl === 'undefined' || typeof Intl.DateTimeFormat !== 'function') {
     return { format: (d: Date) => d.toISOString().slice(11, 16) } as unknown as Intl.DateTimeFormat;
   }
   return new Intl.DateTimeFormat(
-    detectUiLocale() === 'en' ? 'en' : 'zh-CN',
+    uiLocaleToIntlLocale(locale),
     { hour: '2-digit', minute: '2-digit', hour12: false },
   );
 }
 
 /** Wall-clock `HH:mm` (24-hour), for the always-absolute user-message time. */
-export function formatClockTime(ts: number): string {
-  return createClockTimeFormat().format(new Date(ts));
+export function formatClockTime(ts: number, locale: UiLocale): string {
+  return createClockTimeFormat(locale).format(new Date(ts));
 }
 
 export function formatTurnDuration(ms: number): string {

--- a/packages/ui/src/chat-empty-hero.tsx
+++ b/packages/ui/src/chat-empty-hero.tsx
@@ -31,10 +31,11 @@ import {
   DEEP_RESEARCH_SCOPE_OPTIONS,
   DEEP_RESEARCH_STARTER_PROMPTS,
   DEEP_RESEARCH_WORKFLOW_STEPS,
+  type UiCatalog,
 } from '@maka/core';
 import { Button as BaseButton } from '@base-ui/react/button';
 
-import { detectUiLocale, type UiLocale } from './locale-helpers.js';
+import { useUiLocale } from './locale-context.js';
 
 export type DayPeriod = 'morning' | 'noon' | 'afternoon' | 'evening';
 
@@ -62,7 +63,7 @@ export function detectDayPeriod(nowMs: number = Date.now()): DayPeriod {
   return 'evening';
 }
 
-const EMPTY_HERO_COPY_BY_LOCALE: Record<UiLocale, {
+const EMPTY_HERO_COPY_BY_LOCALE: UiCatalog<{
   ariaLabel: string;
   /** Time-of-day prefix: "早上好" / "Good morning" etc. */
   greeting: Record<DayPeriod, string>;
@@ -130,7 +131,7 @@ export function EmptyChatHero(props: { onPromptSuggestion?(prompt: string): void
   // that still pass it, but the generic empty-chat surface no longer
   // renders suggestions; Deep Research keeps its specialized starters.
   const label = props.userLabel?.trim();
-  const locale = detectUiLocale();
+  const locale = useUiLocale();
   const copy = EMPTY_HERO_COPY_BY_LOCALE[locale];
   // PR-UI-LAYOUT-4: time-of-day greeting prefix. `detectDayPeriod`
   // reads the user's local clock at render time; we don't memo

--- a/packages/ui/src/chat-turn.tsx
+++ b/packages/ui/src/chat-turn.tsx
@@ -15,6 +15,7 @@ import { Collapsible, CollapsibleTrigger, CollapsiblePanel } from './primitives/
 import { Bubble, Marker, markerVariants, Message, TextShimmer } from './primitives/chat.js';
 import { Tooltip, TooltipTrigger, TooltipContent } from './primitives/tooltip.js';
 import { ToolTrow } from './tool-activity.js';
+import { useUiLocale } from './locale-context.js';
 
 
 /**
@@ -85,6 +86,7 @@ function AttachmentImage(props: { attachment: AttachmentRef }) {
 }
 
 const MessageBody = memo(function MessageBody(props: { role: string; text: string; ts?: number; attachments?: readonly AttachmentRef[] }) {
+  const locale = useUiLocale();
   if (props.role === 'user') {
     // User turn: the message sits in a tinted, width-capped block aligned to
     // the right (so the right-anchor reads even for long messages), with an
@@ -125,9 +127,9 @@ const MessageBody = memo(function MessageBody(props: { role: string; text: strin
             <small
               className="maka-message-time-inline tabular-nums"
               aria-hidden="true"
-              title={formatAbsoluteTimestamp(props.ts)}
+              title={formatAbsoluteTimestamp(props.ts, locale)}
             >
-              {formatClockTime(props.ts)}
+              {formatClockTime(props.ts, locale)}
             </small>
           )}
           <MessageCopyButton text={props.text} footerStyle />
@@ -283,6 +285,7 @@ export const TurnView = memo(function TurnView(props: {
     continuingIndicator?: boolean;
   };
 }) {
+  const locale = useUiLocale();
   const { turn } = props;
   const forwardBadges = props.lineageBadges?.filter((b) => b.direction === 'forward') ?? [];
   const reverseBadges = props.lineageBadges?.filter((b) => b.direction === 'reverse') ?? [];
@@ -341,7 +344,7 @@ export const TurnView = memo(function TurnView(props: {
         <Message
           variant="user"
           aria-label="你发送的消息"
-          title={turn.user.ts ? formatAbsoluteTimestamp(turn.user.ts) : undefined}
+          title={turn.user.ts ? formatAbsoluteTimestamp(turn.user.ts, locale) : undefined}
           className="group/usermsg"
         >
           <MessageBody role="user" text={turn.user.text} ts={turn.user.ts} attachments={turn.user.attachments} />
@@ -351,7 +354,7 @@ export const TurnView = memo(function TurnView(props: {
         <Message
           key={note.id}
           variant="system"
-          title={note.ts ? formatAbsoluteTimestamp(note.ts) : undefined}
+          title={note.ts ? formatAbsoluteTimestamp(note.ts, locale) : undefined}
         >
           <MessageBody role="system" text={note.text} ts={note.ts} />
         </Message>

--- a/packages/ui/src/clipboard-feedback.ts
+++ b/packages/ui/src/clipboard-feedback.ts
@@ -26,7 +26,7 @@
  *      both `markdown.tsx` and `components.tsx` depend on it,
  *      with no edges between them in this dimension. Same cycle-
  *      breaking pattern PR-UI-LIB-EXTRACT-5 used for round 5's
- *      `detectUiLocale` cycle.
+ *      earlier locale-helper cycle.
  */
 
 import { useEffect, useRef, useState } from 'react';

--- a/packages/ui/src/composer.tsx
+++ b/packages/ui/src/composer.tsx
@@ -14,7 +14,8 @@ import {
 import { useMountedRef } from './use-mounted-ref.js';
 import { ArrowUp, Blocks, Check, ChevronDown, FileEdit, FolderOpen, GitBranch, History, Paperclip, Plus } from './icons.js';
 import { ChatModelSwitcher, ModelChipStatic, NewChatModelPicker } from './chat-model-switcher.js';
-import { type UiLocale, detectUiLocale } from './locale-helpers.js';
+import type { UiCatalog } from '@maka/core';
+import { useUiLocale } from './locale-context.js';
 import { type ChatModelChoice, modelChoiceValue } from './chat-model-helpers.js';
 import {
   type ComposerHistoryState,
@@ -57,7 +58,7 @@ const COMPOSER_MAX_HEIGHT = 240;
  * OnboardingHero gets a separate `<small>` example hint below the
  * textarea so first-run users still know what to type.
  */
-const COMPOSER_COPY_BY_LOCALE: Record<UiLocale, {
+const COMPOSER_COPY_BY_LOCALE: UiCatalog<{
   placeholder: string;
   textareaAriaLabel: string;
   awaitingPermission: string;
@@ -105,7 +106,7 @@ const COMPOSER_COPY_BY_LOCALE: Record<UiLocale, {
   },
 };
 
-const COMPOSER_BUTTON_COPY_BY_LOCALE: Record<UiLocale, { sendLabel: string; stopLabel: string }> = {
+const COMPOSER_BUTTON_COPY_BY_LOCALE: UiCatalog<{ sendLabel: string; stopLabel: string }> = {
   zh: { sendLabel: '发送', stopLabel: '停止' },
   en: { sendLabel: 'Send', stopLabel: 'Stop' },
 };
@@ -280,11 +281,7 @@ export const Composer = forwardRef<
   const recomputeMentionRef = useRef<() => void>(() => {});
   const mentionPopupOpen = mention !== null;
   // PR-UI-15: locale-aware copy for placeholder + toolbar states. We
-  // detect once per render (cheap) rather than memoizing — the locale
-  // is effectively constant for the lifetime of the renderer but the
-  // few ns of detection cost beats wiring up a context provider just
-  // for this bundle.
-  const locale = detectUiLocale();
+  const locale = useUiLocale();
   const copy = COMPOSER_COPY_BY_LOCALE[locale];
   const buttonCopy = COMPOSER_BUTTON_COPY_BY_LOCALE[locale];
 

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -12,6 +12,7 @@ export * from './chat-input-behavior.js';
 export * from './input-history.js';
 export * from './daily-review-helpers.js';
 export * from './locale-helpers.js';
+export * from './locale-context.js';
 export * from './markdown.js';
 export * from './maka-uri.js';
 export * from './materialize.js';

--- a/packages/ui/src/locale-context.tsx
+++ b/packages/ui/src/locale-context.tsx
@@ -1,0 +1,55 @@
+import {
+  createContext,
+  useContext,
+  useLayoutEffect,
+  type ReactNode,
+} from 'react';
+import {
+  resolveUiLocale,
+  type UiLocale,
+  type UiLocalePreference,
+} from '@maka/core';
+
+const UiLocaleContext = createContext<UiLocale | undefined>(undefined);
+
+export function syncUiLocaleDocument(
+  locale: UiLocale,
+  override?: UiLocale | null,
+): void {
+  if (typeof document === 'undefined') return;
+
+  const root = document.documentElement;
+  root.setAttribute('lang', locale);
+  root.setAttribute('data-maka-locale', locale);
+  if (override) {
+    root.setAttribute('data-maka-visual-smoke-locale', override);
+  } else {
+    root.removeAttribute('data-maka-visual-smoke-locale');
+  }
+}
+
+export function LocaleProvider(props: {
+  preference: UiLocalePreference;
+  override?: UiLocale | null;
+  children: ReactNode;
+}) {
+  const locale = resolveUiLocale(props.preference, props.override);
+
+  useLayoutEffect(() => {
+    syncUiLocaleDocument(locale, props.override);
+  }, [locale, props.override]);
+
+  return (
+    <UiLocaleContext.Provider value={locale}>
+      {props.children}
+    </UiLocaleContext.Provider>
+  );
+}
+
+export function useUiLocale(): UiLocale {
+  const locale = useContext(UiLocaleContext);
+  if (!locale) {
+    throw new Error('useUiLocale must be used within LocaleProvider');
+  }
+  return locale;
+}

--- a/packages/ui/src/locale-helpers.ts
+++ b/packages/ui/src/locale-helpers.ts
@@ -2,7 +2,7 @@
  * UI locale detection + prompt-suggestion copy.
  *
  * PR-UI-LIB-EXTRACT-5 (WAWQAQ msg `510fef52`, round 6/10): pulled
- * out of `components.tsx`. `detectUiLocale`, `UiLocale`, and
+ * out of `components.tsx`. Locale types and
  * `getPromptSuggestions` were already public exports from
  * `@maka/ui` (consumed by the renderer's main.tsx, OnboardingHero,
  * theme.ts, visual-smoke fixture, and the
@@ -18,21 +18,18 @@
  *      onboarding hero, Intl.DateTimeFormat language) that giving
  *      it its own home is the natural cut.
  *   2. Round 5 introduced a deliberate ESM circular import — the
- *      new `chat-display-helpers.ts` needed `detectUiLocale` from
+ *      new `chat-display-helpers.ts` needed locale state from
  *      `components.tsx`, while `components.tsx` imports its time
  *      formatters from `chat-display-helpers.ts`. Safe but ugly.
- *      Moving `detectUiLocale` here breaks the cycle: both
+ *      Moving locale helpers here broke the cycle: both
  *      `components.tsx` and `chat-display-helpers.ts` now depend on
  *      this leaf module, with no edges between them in this
  *      dimension.
  */
 
-/**
- * Internal locale family used by prompt-suggestion mapping. Kept
- * private to this module; consumers use the public `UiLocale`
- * alias below.
- */
-type PromptSuggestionLocale = 'zh' | 'en';
+import type { UiCatalog, UiLocale } from '@maka/core';
+
+export type { UiLocale } from '@maka/core';
 
 export type PromptSuggestion = { label: string; prompt: string };
 
@@ -46,14 +43,14 @@ export type PromptSuggestion = { label: string; prompt: string };
  *      universally relevant — the chips read as "Maka is only for
  *      programmers".
  *
- * Fix: detect locale family (zh / en) via `navigator.language` and
+ * Fix: select a complete catalog from the LocaleProvider value and
  * return a balanced mix of dev + general starting points. Each locale
  * keeps 3 dev chips (codebase summary / explain code / Code review)
  * for the power-user path and adds 3 general chips (read a long doc,
  * translate, draft a message) so the empty-chat surface reads as a
  * general assistant first, a coding assistant second.
  */
-const PROMPT_SUGGESTIONS_BY_LOCALE: Record<PromptSuggestionLocale, PromptSuggestion[]> = {
+const PROMPT_SUGGESTIONS_BY_LOCALE: UiCatalog<PromptSuggestion[]> = {
   zh: [
     { label: '总结代码库', prompt: '帮我总结当前代码库的目录结构和关键模块。' },
     { label: '解释这段代码', prompt: '我贴一段代码进来，请帮我逐行解释它做什么、有没有坑：\n\n```\n\n```' },
@@ -72,39 +69,6 @@ const PROMPT_SUGGESTIONS_BY_LOCALE: Record<PromptSuggestionLocale, PromptSuggest
   ],
 };
 
-/**
- * Detects the renderer-side UI locale family. Used by EmptyChatHero
- * chips + hero copy (PR-UI-14) and Composer / OnboardingHero quickChat
- * placeholders (PR-UI-15). Centralized here so all UI surfaces fall
- * onto the same `zh` / `en` split — there's no per-component drift.
- */
-export type UiLocale = PromptSuggestionLocale;
-
-export function detectUiLocale(): UiLocale {
-  if (typeof document !== 'undefined') {
-    // Precedence (highest to lowest), per kenji `7e532892` +
-    // xuan `54b56858` acceptance criteria:
-    //   1. visual-smoke fixture override (deterministic baselines).
-    //   2. user preference (PR-LANG-PREF-0): persisted in
-    //      `personalization.uiLocale`; the renderer mirrors a
-    //      resolved-value attribute (`data-maka-locale="zh|en"`)
-    //      to `<html>` on mount and on every settings save so we
-    //      can read it synchronously here without an async
-    //      settings round-trip.
-    //   3. Chinese-first product fallback. Most app chrome is already
-    //      Chinese, and Electron's `navigator.language` can be `en-US`
-    //      on this dev machine, which produced a visibly mixed shell.
-    //
-    // Real users can still choose English explicitly in Settings; `auto`
-    // should not make the default Chinese shell read half-English.
-    const smokeOverride = document.documentElement.dataset.makaVisualSmokeLocale;
-    if (smokeOverride === 'zh' || smokeOverride === 'en') return smokeOverride;
-    const userPref = document.documentElement.dataset.makaLocale;
-    if (userPref === 'zh' || userPref === 'en') return userPref;
-  }
-  return 'zh';
-}
-
-export function getPromptSuggestions(locale?: UiLocale): PromptSuggestion[] {
-  return PROMPT_SUGGESTIONS_BY_LOCALE[locale ?? detectUiLocale()];
+export function getPromptSuggestions(locale: UiLocale): PromptSuggestion[] {
+  return PROMPT_SUGGESTIONS_BY_LOCALE[locale];
 }

--- a/packages/ui/src/relative-time.tsx
+++ b/packages/ui/src/relative-time.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import { formatAbsoluteTimestamp } from './chat-display-helpers.js';
 import { formatRelativeTimestamp, nextRelativeRefreshDelay } from '@maka/core';
 import { cn } from './utils.js';
+import { useUiLocale } from './locale-context.js';
 
 /**
  * PR-RELATIVE-TIME-0: a self-refreshing relative-time label. Sidebar +
@@ -12,6 +13,7 @@ import { cn } from './utils.js';
  * past the 7-day horizon we stop ticking and show the absolute date.
  */
 export function RelativeTime(props: { ts: number; className?: string; suppressTitle?: boolean }) {
+  const locale = useUiLocale();
   const [, setTick] = useState(0);
   useEffect(() => {
     const delay = nextRelativeRefreshDelay(props.ts);
@@ -23,9 +25,9 @@ export function RelativeTime(props: { ts: number; className?: string; suppressTi
     <small
       className={cn('tabular-nums', props.className ?? 'maka-message-time')}
       aria-hidden="true"
-      title={props.suppressTitle ? undefined : formatAbsoluteTimestamp(props.ts)}
+      title={props.suppressTitle ? undefined : formatAbsoluteTimestamp(props.ts, locale)}
     >
-      {formatRelativeTimestamp(props.ts)}
+      {formatRelativeTimestamp(props.ts, Date.now(), locale)}
     </small>
   );
 }

--- a/packages/ui/src/session-history-list.tsx
+++ b/packages/ui/src/session-history-list.tsx
@@ -1,6 +1,6 @@
 import { memo, useEffect, useRef, useState, type FocusEvent, type KeyboardEvent } from 'react';
 import { useMountedRef } from './use-mounted-ref.js';
-import type { SessionSummary } from '@maka/core';
+import type { SessionSummary, UiLocale } from '@maka/core';
 import { formatCompactTimestamp } from '@maka/core';
 import {
   Archive,
@@ -26,6 +26,7 @@ import { Menu, MenuItem, MenuPopup, MenuSeparator, MenuTrigger } from './primiti
 import { Button as UiButton } from './ui.js';
 import { Button as BaseButton } from '@base-ui/react/button';
 import { describeBlockedReason, presentSessionStatus } from './session-status-presentation.js';
+import { useUiLocale } from './locale-context.js';
 
 type SessionRowActionId = 'flag' | 'archive' | 'rename' | 'delete';
 type SessionHistoryGroupVariant = 'status' | 'project';
@@ -473,6 +474,7 @@ const SessionRow = memo(function SessionRow(props: {
   actions?: SessionRowActions;
 }) {
   const { session, active, streaming, stale, actions, onSelect } = props;
+  const locale = useUiLocale();
   const [editing, setEditing] = useState(false);
   const [actionsVisible, setActionsVisible] = useState(false);
   const [menuOpen, setMenuOpen] = useState(false);
@@ -600,7 +602,7 @@ const SessionRow = memo(function SessionRow(props: {
               autoComplete="off"
               spellCheck={false}
             />
-            <div className="maka-list-row-meta">{formatSessionMeta(session)}</div>
+            <div className="maka-list-row-meta">{formatSessionMeta(session, locale)}</div>
           </div>
         </form>
       ) : (
@@ -688,7 +690,7 @@ const SessionRow = memo(function SessionRow(props: {
           {shouldShowSessionUnreadDot(session, Boolean(streaming), active) ? (
             <span className="maka-list-row-unread" aria-label="未读消息" />
           ) : (
-            <span className="maka-list-row-meta">{formatSessionMeta(session)}</span>
+            <span className="maka-list-row-meta">{formatSessionMeta(session, locale)}</span>
           )}
         </BaseButton>
       )}
@@ -808,7 +810,7 @@ function groupSessionsByTime(sessions: SessionSummary[]): SessionGroup[] {
   return buckets.filter((group) => group.sessions.length > 0);
 }
 
-function formatSessionMeta(session: SessionSummary): string {
+function formatSessionMeta(session: SessionSummary, locale: UiLocale): string {
   if (!session.lastMessageAt) return noMessagesYet;
-  return formatCompactTimestamp(session.lastMessageAt);
+  return formatCompactTimestamp(session.lastMessageAt, Date.now(), locale);
 }

--- a/packages/ui/src/tool-activity.tsx
+++ b/packages/ui/src/tool-activity.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState, type ComponentType, type ReactNode } from 'react';
-import { isShellOutput, type ToolResultContent } from '@maka/core';
+import { isShellOutput, type ToolResultContent, type UiLocale } from '@maka/core';
 import {
   AlertOctagon,
   Check,
@@ -178,14 +178,14 @@ function useToolDisclosure(presentation: ToolActivityPresentation) {
   };
 }
 
-function extractErrorText(result: ToolActivityItem['result']): string {
+function extractErrorText(result: ToolActivityItem['result'], locale: UiLocale): string {
   if (!result) return '';
   switch (result.kind) {
     case 'text':
       return result.text;
     case 'json': {
       // Same quiet formatter as the panel — never dump escaped JSON braces.
-      const quiet = formatQuietJsonValue(result.value);
+      const quiet = formatQuietJsonValue(result.value, locale);
       return quiet.headline ? `${quiet.headline}\n${quiet.body}` : quiet.body;
     }
     case 'terminal': {
@@ -383,6 +383,7 @@ function ToolActivityCard({ item, open: openProp }: { item: ToolActivityItem; op
  * quiet formatters (tool-args-redaction-contract / quiet-panel contracts).
  */
 function ToolCardBody({ item }: { item: ToolActivityItem }) {
+  const locale = useUiLocale();
   const cancelled = isCancelledToolResult(item.result);
   // Cancel maps to interrupted at materialize/live-projection; keep defensive
   // checks so a stale errored+cancelled item still does not look like failure.
@@ -396,7 +397,7 @@ function ToolCardBody({ item }: { item: ToolActivityItem }) {
   // Every tool: human invocation line from args — never pretty-printed JSON.
   // Skip when the result panel already prints the command (terminal/shell_run).
   const invocationLine = !permissionDenied && !ownsPanel
-    ? formatToolInvocationLine(item)
+    ? formatToolInvocationLine(item, locale)
     : undefined;
   // While running the live stream is the output; once a structured result
   // preview exists it is the single quiet output block — never render both.
@@ -414,7 +415,7 @@ function ToolCardBody({ item }: { item: ToolActivityItem }) {
     : undefined;
   const quietJson =
     displayResult?.kind === 'json'
-      ? formatQuietJsonValue(displayResult.value)
+      ? formatQuietJsonValue(displayResult.value, locale)
       : undefined;
   // Keep the invocation line whenever args yield one. Only add a result
   // headline when it says something different (avoids dropping Write/Edit paths
@@ -465,7 +466,7 @@ function ToolCardBody({ item }: { item: ToolActivityItem }) {
           {/* No formatRedactedJson dump — if invocation failed, quiet-format args. */}
           {!showInvocation && !resultHeadline && item.args !== undefined && !permissionDenied && !showResult && (
             <pre className={cn(TOOL_OUTPUT_BODY_CLASS, 'max-h-40')}>
-              {formatQuietJsonValue(item.args).body}
+              {formatQuietJsonValue(item.args, locale).body}
             </pre>
           )}
           {showLiveStream && (
@@ -733,11 +734,12 @@ function summarizeErrorText(text: string): string {
 // Alert owns the shell; these are the few declarations it doesn't set, kept arbitrary
 // so they map 1:1 to the old CSS (`[align-self:start]`, not Tailwind's `flex-start`).
 function ToolErrorBanner(props: { result: ToolActivityItem['result'] }) {
+  const locale = useUiLocale();
   // Tool stderr / raw provider errors occasionally slip credential paths,
   // bearer tokens, or API keys through main-side redaction. Apply a
   // defensive UI-level mask before display *and* before clipboard copy so
   // the user can't accidentally paste a credential into a bug report.
-  const errorText = formatUserVisibleToolText(redactSecrets(extractErrorText(props.result)));
+  const errorText = formatUserVisibleToolText(redactSecrets(extractErrorText(props.result, locale)));
   const copyFeedback = useClipboardCopyFeedback();
   const copyPhase = copyFeedback.phaseFor('tool-error');
   const copyPending = copyPhase === 'pending';

--- a/packages/ui/src/tool-activity.tsx
+++ b/packages/ui/src/tool-activity.tsx
@@ -17,7 +17,7 @@ import {
   type LucideProps,
 } from './icons.js';
 import { useClipboardCopyFeedback } from './clipboard-feedback.js';
-import { detectUiLocale } from './locale-helpers.js';
+import { useUiLocale } from './locale-context.js';
 import { type ToolActivityItem, type ToolOutputChunk } from './materialize.js';
 import {
   isTrowRunning,
@@ -56,7 +56,8 @@ import {
 
 /** Friendly card for a `load_tools` result; falls back to JSON on unexpected shapes. */
 function LoadToolResultPreview(props: { args: unknown; value: unknown }) {
-  const desc = describeLoadToolResult(props.args, props.value, detectUiLocale());
+  const locale = useUiLocale();
+  const desc = describeLoadToolResult(props.args, props.value, locale);
   if (!desc) {
     return <ToolResultPreview content={{ kind: 'json', value: props.value }} />;
   }
@@ -342,12 +343,13 @@ export function ToolActivity(props: {
 }
 
 function ToolActivityCard({ item, open: openProp }: { item: ToolActivityItem; open?: boolean }) {
+  const locale = useUiLocale();
   // Ordinary work stays summarized. A new permission prompt opens the
   // diagnostics (it is actionable); an errored tool stays collapsed — the
   // failure signal lives on the summary line. An explicit user toggle survives
   // later ordinary status changes. See disclosure-collapsible-contract:
   // defaultOpen is banned here.
-  const presentation = deriveToolActivityPresentation(item);
+  const presentation = deriveToolActivityPresentation(item, locale);
   const disclosure = useToolDisclosure(presentation);
   const open = openProp ?? disclosure.open;
   const duration = formatDuration(item.durationMs);
@@ -361,7 +363,7 @@ function ToolActivityCard({ item, open: openProp }: { item: ToolActivityItem; op
     >
       <CollapsibleTrigger className={toolVariants({ part: 'header' })}>
         <span className={toolVariants({ part: 'dot' })} data-status={item.status} aria-hidden="true" />
-        <span className={toolVariants({ part: 'name' })}>{resolveToolDisplayName(item)}</span>
+        <span className={toolVariants({ part: 'name' })}>{resolveToolDisplayName(item, locale)}</span>
         <span className={toolVariants({ part: 'meta' })}>
           {duration && <span className={toolVariants({ part: 'duration' })}>{duration}</span>}
           <span className={toolVariants({ part: 'status-label' })}>{toolStatusLabel(item)}</span>
@@ -533,6 +535,7 @@ export function ToolTrow({ items }: { items: ToolActivityItem[] }) {
 }
 
 function ToolTrowGroup({ items }: { items: ToolActivityItem[] }) {
+  const locale = useUiLocale();
   const running = isTrowRunning(items);
   const attention = trowNeedsAttention(items);
   // The group's presentation follows the first item (the first-seen bucket the
@@ -540,7 +543,7 @@ function ToolTrowGroup({ items }: { items: ToolActivityItem[] }) {
   // running group shows the whole-group aggregation, a single-tool group's
   // active tool is items[0] anyway, and disclosure attention is overridden by
   // the whole-group trowNeedsAttention below.
-  const firstPresentation = deriveToolActivityPresentation(items[0]!);
+  const firstPresentation = deriveToolActivityPresentation(items[0]!, locale);
   // Groups share the same disclosure state as a single row: ordinary work is
   // summarized; a new permission prompt opens diagnostics (errors stay
   // collapsed — the summary line carries the failure signal); manual choice
@@ -605,7 +608,8 @@ function ToolTrowGroup({ items }: { items: ToolActivityItem[] }) {
  * (`toolVariants({item})`), per the flat trow visual language.
  */
 function ToolTrowRow({ item }: { item: ToolActivityItem }) {
-  const presentation = deriveToolActivityPresentation(item);
+  const locale = useUiLocale();
+  const presentation = deriveToolActivityPresentation(item, locale);
   const disclosure = useToolDisclosure(presentation);
   const duration = formatDuration(item.durationMs);
   // #tool-jitter: a row settles by its shimmer stopping — the same seam as the
@@ -623,7 +627,7 @@ function ToolTrowRow({ item }: { item: ToolActivityItem }) {
   const summaryTone = errored ? 'text-[color:var(--destructive)]' : 'text-[color:var(--muted-foreground)]';
   // An errored row stays collapsed, so the destructive tint is not enough —
   // the failure is spelled out as a word on the row label.
-  const rowLabel = item.intent ? formatToolIntent(item.intent) : resolveToolDisplayName(item);
+  const rowLabel = item.intent ? formatToolIntent(item.intent) : resolveToolDisplayName(item, locale);
   return (
     <Collapsible className="flex flex-col" data-trow="row" data-status={item.status} data-settled={settled ? 'true' : undefined} open={disclosure.open} onOpenChange={disclosure.setOpen}>
       <CollapsibleTrigger className="group flex w-full items-center gap-2 py-0.5 text-left">

--- a/packages/ui/src/tool-activity/builtin-preview.ts
+++ b/packages/ui/src/tool-activity/builtin-preview.ts
@@ -3,8 +3,7 @@
  *
  * `formatToolInvocationLine` and `formatQuietJsonValue` are pure functions
  * extracted from this module into `@maka/core` so the CLI/TUI can consume
- * the same path. Desktop passes `detectUiLocale()` — the default `'zh'`
- * locale preserves byte-identical output to the previous inline implementation.
+ * the same path. Desktop passes the resolved locale from `LocaleProvider`.
  *
  * The desktop `ToolActivityItem`-typed signature is adapted here so existing
  * call sites (`tool-activity.tsx`, `tool-result-preview.tsx`) keep their
@@ -14,23 +13,27 @@
 import {
   formatQuietJsonValue as coreFormatQuietJsonValue,
   formatToolInvocationLine as coreFormatToolInvocationLine,
+  type UiLocale,
 } from '@maka/core';
-import { detectUiLocale } from '../locale-helpers.js';
 import type { ToolActivityItem } from '../materialize.js';
 
 export type { QuietPreview } from '@maka/core';
 
-/** Desktop-adapted wrapper that injects the detected UI locale. */
+/** Desktop-adapted wrapper with an explicit resolved locale. */
 export function formatToolInvocationLine(
   item: Pick<ToolActivityItem, 'toolName' | 'args' | 'activityKind'>,
+  locale: UiLocale,
 ): string | undefined {
   return coreFormatToolInvocationLine(
     { toolName: item.toolName, args: item.args },
-    detectUiLocale(),
+    locale,
   );
 }
 
-/** Desktop-adapted wrapper that injects the detected UI locale. */
-export function formatQuietJsonValue(value: unknown): import('@maka/core').QuietPreview {
-  return coreFormatQuietJsonValue(value, detectUiLocale());
+/** Desktop-adapted wrapper with an explicit resolved locale. */
+export function formatQuietJsonValue(
+  value: unknown,
+  locale: UiLocale,
+): import('@maka/core').QuietPreview {
+  return coreFormatQuietJsonValue(value, locale);
 }

--- a/packages/ui/src/tool-activity/presentation.ts
+++ b/packages/ui/src/tool-activity/presentation.ts
@@ -1,4 +1,4 @@
-import { detectUiLocale } from '../locale-helpers.js';
+import type { UiLocale } from '@maka/core';
 import type { ToolActivityItem } from '../materialize.js';
 import { loadToolDisplayName } from '../tool-format.js';
 import { formatUserVisibleToolText } from './preview-utils.js';
@@ -21,16 +21,19 @@ export function isConnectorTool(name: string): boolean {
   return CONNECTOR_TOOL_NAMES.has(name);
 }
 
-export function resolveToolDisplayName(item: ToolActivityItem): string {
+export function resolveToolDisplayName(item: ToolActivityItem, locale: UiLocale): string {
   if (item.displayName) return item.displayName;
-  if (isConnectorTool(item.toolName)) return loadToolDisplayName(detectUiLocale());
+  if (isConnectorTool(item.toolName)) return loadToolDisplayName(locale);
   return item.toolName;
 }
 
-export function deriveToolActivityPresentation(item: ToolActivityItem): ToolActivityPresentation {
+export function deriveToolActivityPresentation(
+  item: ToolActivityItem,
+  locale: UiLocale,
+): ToolActivityPresentation {
   return {
     kind: trowActivityKind(item.toolName, item.activityKind),
-    summary: formatUserVisibleToolText(item.intent ?? '') || resolveToolDisplayName(item),
+    summary: formatUserVisibleToolText(item.intent ?? '') || resolveToolDisplayName(item, locale),
     // Only a permission prompt is an attention state: it is actionable and a
     // collapsed row would hide it. An errored tool stays collapsed — the trow
     // summary line keeps the failure signal (「N 个失败」 in destructive

--- a/packages/ui/src/tool-activity/tool-result-preview.tsx
+++ b/packages/ui/src/tool-activity/tool-result-preview.tsx
@@ -10,6 +10,7 @@ import {
 import { AlertCircle, Ban, Check, Clock, GitBranch, Loader2, Plug } from '../icons.js';
 import { previewVariants } from '../primitives/chat.js';
 import { redactSecrets } from '../redact.js';
+import { useUiLocale } from '../locale-context.js';
 import { cn } from '../ui.js';
 import { ExploreAgentPreview, SubagentPreview } from './agent-preview.js';
 import { formatQuietJsonValue } from './builtin-preview.js';
@@ -40,6 +41,7 @@ export function ToolResultPreview(props: {
   shellRunSource?: 'owned' | 'unavailable';
 }) {
   const { content } = props;
+  const locale = useUiLocale();
 
   if (content.kind === 'file_diff') {
     return <FileDiffPreview diff={content.diff} paths={content.paths} />;
@@ -99,7 +101,7 @@ export function ToolResultPreview(props: {
 
   if (content.kind === 'json') {
     // Never pretty-print JSON with escaped newlines — quiet plain text only.
-    const quiet = formatQuietJsonValue(content.value);
+    const quiet = formatQuietJsonValue(content.value, locale);
     return (
       <div className="grid gap-1.5" data-kind="json">
         {quiet.headline ? (


### PR DESCRIPTION
## Summary

Implements PR 1 of #1052: the reactive locale foundation for the desktop renderer.

- centralize `UiLocale`, `UiLocalePreference`, locale guards, resolution, and Intl mappings in `@maka/core`
- add `LocaleProvider` and `useUiLocale()` to `@maka/ui`
- hydrate the persisted locale preference into desktop React state
- update localized UI immediately after a successful preference change, without reloading
- keep `<html lang>` and locale-sensitive `Intl` formatting synchronized
- make test overrides take precedence over persisted preferences
- preserve the temporary `auto -> zh` behavior
- remove the parallel DOM-reading locale detection path
- enforce complete `zh` and `en` catalog shapes at compile time

## Locale authority

There is now one locale flow:

`personalization.uiLocale` → desktop React state → `LocaleProvider` → UI consumers

Resolution precedence is:

1. test/visual-smoke override
2. explicit `zh` or `en` preference
3. `auto`, temporarily resolved to `zh`

Failed or superseded settings writes do not change the active runtime locale.

## Testing

Coverage includes:

- core locale guards, resolution precedence, and Intl mappings
- provider rendering and runtime switching
- missing-provider errors
- `<html lang>` synchronization
- persisted preference hydration and updates
- failed and out-of-order preference writes
- test override precedence
- relative-time formatting in both locales
- contracts preventing duplicate locale types and legacy DOM detection

## Scope

This PR intentionally implements only PR 1 from #1052.

It does not include:

- complete desktop copy translation
- CLI localization
- additional locales
- system-language detection for `auto`
- i18next, ICU, remote catalogs, or translation-platform integration
- translation of user content, model output, brands, code, commands, or generated content

Part of #1052.