### PR TITLE
fix: restore green CI on main (runtime prune regression + non-hermetic CLI color tests)

### DIFF
--- a/packages/cli/src/__tests__/pi-transcript.test.ts
+++ b/packages/cli/src/__tests__/pi-transcript.test.ts
@@ -1,6 +1,7 @@
 import assert from 'node:assert/strict';
-import { describe, test } from 'node:test';
+import { before, describe, test } from 'node:test';
 import { visibleWidth } from '@earendil-works/pi-tui';
+import { _setColorLevelForTesting } from '../tui-ansi.js';
 import type { PipeShellOutput, PtyShellOutput, ShellRunToolResult } from '@maka/core';
 import type { SessionEvent, ToolResultContent } from '@maka/core/events';
 import type { StoredMessage } from '@maka/core/session';
@@ -21,6 +22,13 @@ import {
   toggleAllToolExpansion,
   togglePendingPermissionDetails,
 } from '../pi-transcript.js';
+
+// Pin the color level so ANSI-escape assertions are hermetic. Detection reads
+// process.env.TERM/COLORTERM at module load, so ambient terminal capability
+// (truecolor locally, unset/dumb on CI runners) would otherwise decide whether
+// color escapes appear. Level 3 (truecolor) is the development default these
+// tests lock (#1064/#1066); matches tui-ansi.test.ts's reset convention.
+before(() => _setColorLevelForTesting(3));
 
 describe('Maka Pi TUI transcript', () => {
   test('greets on a fresh empty session and drops the welcome once a prompt lands', () => {

--- a/packages/cli/src/__tests__/pi-tui-runner.test.ts
+++ b/packages/cli/src/__tests__/pi-tui-runner.test.ts
@@ -2,7 +2,7 @@ import assert from 'node:assert/strict';
 import { spawn } from 'node:child_process';
 import { once } from 'node:events';
 import { setTimeout as delay } from 'node:timers/promises';
-import { describe, test } from 'node:test';
+import { before, describe, test } from 'node:test';
 import { visibleWidth } from '@earendil-works/pi-tui';
 import {
   SHELL_RUN_UPDATE_BUFFER_MAX_ENTRIES,
@@ -23,6 +23,7 @@ import type {
   SessionResumeAvailability,
 } from '../session-driver.js';
 import { runMakaPiTui } from '../pi-tui-runner.js';
+import { _setColorLevelForTesting } from '../tui-ansi.js';
 import { BUSY_SPINNER_FRAMES } from '../tui-attention.js';
 import { arrangeAutocompleteAboveEditor } from '../tui-autocomplete-layout.js';
 import {
@@ -33,6 +34,11 @@ import {
   plainTerminalOutput,
   waitFor,
 } from './tui-terminal-mock.js';
+
+// Pin truecolor so the accent-chrome escape assertion ("uses logo blue") is
+// hermetic. Color level is detected from process.env.TERM/COLORTERM at module
+// load, which varies between local (truecolor) and CI (unset/dumb) terminals.
+before(() => _setColorLevelForTesting(3));
 
 describe('Maka Pi TUI runner', () => {
   test('restores the terminal before exiting on SIGTERM', async () => {

--- a/packages/runtime/src/ai-sdk-backend.ts
+++ b/packages/runtime/src/ai-sdk-backend.ts
@@ -316,13 +316,23 @@ function activeToolResultArchiveKey(
 /**
  * Tool results from the newest completed step have not crossed the provider
  * boundary yet: prepareStep is invoked immediately before the first request
- * that could show those results to the model. Active pruning may archive only
- * calls from older completed steps, after the model has had one request in
- * which to consume their exact output.
+ * that could show those results to the model. By default active pruning defers
+ * the newest step and archives only older completed steps, after the model has
+ * had one request in which to consume their exact output.
+ *
+ * `includeNewestStep` widens eligibility to every completed step, including the
+ * newest. The caller sets it when mid-turn capacity compaction is active: the
+ * final-payload verdict may need an oversized newest result pruned to a
+ * placeholder before declaring exhaustion, and capacity/recovery rebuilds
+ * re-materialize raw bodies from the ledger that must be re-archived.
  */
-function collectPrunablePrepareStepToolCallIds(steps: PrepareStepLike['steps']): Set<string> {
+function collectPrunablePrepareStepToolCallIds(
+  steps: PrepareStepLike['steps'],
+  includeNewestStep: boolean,
+): Set<string> {
   const out = new Set<string>();
-  for (const step of steps.slice(0, -1)) {
+  const prunableSteps = includeNewestStep ? steps : steps.slice(0, -1);
+  for (const step of prunableSteps) {
     for (const call of step.toolCalls ?? []) {
       if (typeof call.toolCallId === 'string' && call.toolCallId.length > 0) {
         out.add(call.toolCallId);
@@ -1447,12 +1457,19 @@ export class AiSdkBackend implements AgentBackend {
           midTurnSystemPromptChars,
           onMidTurnDiagnosticPatch,
         );
-        const activeToolResultPruneHook = this.buildActiveToolResultPrunePrepareStep(turnId, (patch) => {
-          activeToolResultPruneDiagnosticPatch = mergeActiveToolResultPruneDiagnosticPatches(
-            activeToolResultPruneDiagnosticPatch,
-            patch,
-          );
-        });
+        // When mid-turn capacity compaction is active, the prune must also cover
+        // the newest completed step; see collectPrunablePrepareStepToolCallIds.
+        const activeToolResultPruneIncludesNewestStep = midTurnState !== undefined;
+        const activeToolResultPruneHook = this.buildActiveToolResultPrunePrepareStep(
+          turnId,
+          activeToolResultPruneIncludesNewestStep,
+          (patch) => {
+            activeToolResultPruneDiagnosticPatch = mergeActiveToolResultPruneDiagnosticPatches(
+              activeToolResultPruneDiagnosticPatch,
+              patch,
+            );
+          },
+        );
         const shapedPrepareStep = composePrepareStep(
           plan.prepareStep,
           midTurnCapacityHook,
@@ -2408,6 +2425,7 @@ export class AiSdkBackend implements AgentBackend {
 
   private buildActiveToolResultPrunePrepareStep(
     turnId: string,
+    includeNewestStep: boolean,
     onDiagnosticPatch?: (patch: ActiveToolResultPruneDiagnosticPatch) => void,
   ): PrepareStepFunctionLike | undefined {
     const policy = this.input.contextBudget?.activeToolResultPrune;
@@ -2415,7 +2433,7 @@ export class AiSdkBackend implements AgentBackend {
 
     const archivedPlaceholders = new Map<string, ActiveArchivedToolResultPlaceholder>();
     return async (options) => {
-      const eligibleToolCallIds = collectPrunablePrepareStepToolCallIds(options.steps);
+      const eligibleToolCallIds = collectPrunablePrepareStepToolCallIds(options.steps, includeNewestStep);
       if (eligibleToolCallIds.size === 0) return undefined;
       const rewritten = await rewriteActiveToolResultsInMessages({
         messages: options.messages,


### PR DESCRIPTION
## Summary

CI on `main` has been red since #1066/#986 landed. Two independent breakages were masking each other — the runtime failure halted the sequential workspace chain before the CLI suite ran, so the CLI failure only surfaced once the runtime one was fixed. Neither fix can go CI-green alone, so both land here as two independently revertable commits.

**1. `fix(runtime)`: mid-turn capacity prune regression (#986)**

#986 changed `collectPrunablePrepareStepToolCallIds` to unconditionally exclude the newest completed step from active tool-result pruning, so a freshly fetched result stays raw for one request. That default is right for the proactive token-saving path, but applied unconditionally it broke three pre-existing reviewed invariants that all require pruning the newest step when mid-turn capacity compaction is active:

- the final-payload verdict must be able to rescue an oversized newest result to a placeholder instead of declaring `context_budget_exhausted` (mid-turn review finding C)
- capacity/recovery rebuilds re-materialize raw bodies from the ledger, and the prune must re-archive them (capacity-replacement re-convergence)
- an actively pruned tool result must stay a placeholder in the overflow retry request (overflow review round-3 P1)

The fix makes the newest-step exclusion conditional: the prune covers every completed step exactly when mid-turn capacity compaction is wired (`midTurnState !== undefined`), keeping #986's keep-newest-raw default for every other configuration. #986's semantic/attention compaction feature and its new tests are untouched; no test expectations changed. Isolation evidence: the two failing test files were not modified by #986, `steps.slice(0, -1)` was the only behavioral change on this path, and toggling that condition alone flips all 5 failures. #986's own newest-kept-raw tests only cover configurations without mid-turn capacity, which is why the conditional satisfies both contracts.

**2. `test(cli)`: non-hermetic ANSI color assertions (#1064/#1066)**

`tui-ansi.ts` detects color capability from `TERM`/`COLORTERM` at module load and caches it. The `pi-transcript` and `pi-tui-runner` ANSI assertions never pinned the level, so they inherited ambient terminal capability: truecolor locally (macOS shells set `COLORTERM=truecolor` even with piped stdout), level 0 on Actions runners (no `TERM`/`COLORTERM`), where every color function is a no-op and the color assertions fail deterministically. The fix pins level 3 in both test files via the existing `_setColorLevelForTesting` seam, matching `tui-ansi.test.ts`'s convention. Product detection is untouched and no assertion is weakened.

## Verification

- `packages/runtime` `npm test`: 1963 pass, 0 fail, 7 skipped (was 5 fail); `npm run typecheck` clean
- `packages/cli` `npm test`: 393 pass, 0 fail; `npm run typecheck` clean
- CLI cluster under the reproducing condition: `env -u COLORTERM TERM=dumb CI=true node --test` → 0 fail across 10/10 iterations (pre-fix: 8 fail, proven by stashing the fix)
- Repo-root `npm run test:dist` under CI-like env (`env -u TERM -u COLORTERM CI=true`): exit 0, 0 failures across all workspaces

## Root cause of the masking

Runs 29477460801/29478404301 "passed" the CLI suite only because `test:dist`'s sequential `&&` chain halted at the runtime workspace; grep for the CLI suite names in those logs returns nothing. Every CI run that actually reached `packages/cli` since #1066 failed the color cluster.