### PR TITLE
feat(cli): inline AskUserQuestion free-text row with options

### DIFF
--- a/packages/cli/src/__tests__/pi-tui-runner.test.ts
+++ b/packages/cli/src/__tests__/pi-tui-runner.test.ts
@@ -436,7 +436,7 @@ describe('Maka Pi TUI runner', () => {
     ]);
   });
 
-  test('answers sequential questions with a choice, Escape, and Other input', async () => {
+  test('answers sequential questions inline with a choice, Escape, and type-to-jump Other', async () => {
     const terminal = new FakeTerminal();
     const driver = new UserQuestionPromptDriver();
     const run = runMakaPiTui({
@@ -452,24 +452,152 @@ describe('Maka Pi TUI runner', () => {
       'Choose an approach',
       'Maka · ask · claude-sonnet-4-5 · claude-subscription · /repo',
     );
-    assert.ok(plainTerminalOutput(terminal.screenOutput()).includes('Ctrl+C stop'));
+    // The preset options and the free-text "Other" row are on screen together —
+    // the option list is no longer swapped out for a separate text overlay.
+    const firstScreen = plainTerminalOutput(terminal.screenOutput());
+    assert.ok(firstScreen.includes('Extend'));
+    assert.ok(firstScreen.includes('Separate'));
+    assert.ok(firstScreen.includes('Other: type your answer'));
+    assert.ok(firstScreen.includes('Ctrl+C stop'));
 
+    // Q1: Enter selects the highlighted first option (Extend).
     terminal.input('\r');
     await waitFor(() => plainTerminalOutput(terminal.screenOutput()).includes('Keep the default'));
+    // Q2: Escape leaves the question unanswered.
     terminal.input('\x1b');
     await waitFor(() => plainTerminalOutput(terminal.screenOutput()).includes('Anything else'));
-    terminal.input('\x1b[B');
-    terminal.input('\x1b[B');
-    terminal.input('\r');
-    await waitFor(() => plainTerminalOutput(terminal.screenOutput()).includes('Type another answer'));
-    assert.ok(plainTerminalOutput(terminal.screenOutput()).includes('Ctrl+C stop'));
+    // Q3: typing while an option is highlighted jumps straight into the Other
+    // row and seeds it with the typed text — options stay visible throughout.
     terminal.input('Use the existing seam');
+    await waitFor(() => plainTerminalOutput(terminal.screenOutput()).includes('Use the existing seam'));
+    assert.ok(plainTerminalOutput(terminal.screenOutput()).includes('Nothing'));
     terminal.input('\r');
 
     await waitFor(() => driver.responses.length === 1);
     assert.deepEqual(driver.responses, [{
       requestId: 'question-1',
       answers: ['Extend', null, 'Use the existing seam'],
+    }]);
+
+    exitMaka(terminal);
+    await run;
+  });
+
+  test('navigates the inline option list and Other row with the arrow keys', async () => {
+    const terminal = new FakeTerminal();
+    const driver = new UserQuestionPromptDriver();
+    const run = runMakaPiTui({
+      title: 'Maka', driver, cwd: '/repo', model: 'claude-sonnet-4-5',
+      connectionSlug: 'claude-subscription', permissionMode: 'ask', terminal,
+    });
+
+    terminal.input('choose');
+    terminal.input('\r');
+    await waitFor(() => plainTerminalOutput(terminal.screenOutput()).includes('Choose an approach'));
+
+    // Q1: ↓ moves the highlight to the second option, Enter selects it.
+    terminal.input('\x1b[B');
+    terminal.input('\r');
+    await waitFor(() => plainTerminalOutput(terminal.screenOutput()).includes('Keep the default'));
+
+    // Q2: ↓ past both options lands on the Other row; typed text submits on Enter.
+    terminal.input('\x1b[B');
+    terminal.input('\x1b[B');
+    terminal.input('typed answer');
+    await waitFor(() => plainTerminalOutput(terminal.screenOutput()).includes('typed answer'));
+    terminal.input('\r');
+    await waitFor(() => plainTerminalOutput(terminal.screenOutput()).includes('Anything else'));
+
+    // Q3: ↑ from the first option wraps to the (empty) Other row; Enter there is a
+    // no-op, so the question stays open until Escape leaves it unanswered.
+    terminal.input('\x1b[A');
+    terminal.input('\r');
+    await delay(20);
+    assert.equal(driver.responses.length, 0);
+    assert.ok(plainTerminalOutput(terminal.screenOutput()).includes('Anything else'));
+    terminal.input('\x1b');
+
+    await waitFor(() => driver.responses.length === 1);
+    assert.deepEqual(driver.responses, [{
+      requestId: 'question-1',
+      answers: ['Separate', 'typed answer', null],
+    }]);
+
+    exitMaka(terminal);
+    await run;
+  });
+
+  test('submits a large pasted Other answer expanded, not as a paste marker', async () => {
+    const terminal = new FakeTerminal();
+    const driver = new UserQuestionPromptDriver();
+    const run = runMakaPiTui({
+      title: 'Maka', driver, cwd: '/repo', model: 'claude-sonnet-4-5',
+      connectionSlug: 'claude-subscription', permissionMode: 'ask', terminal,
+    });
+
+    terminal.input('choose');
+    terminal.input('\r');
+    await waitFor(() => plainTerminalOutput(terminal.screenOutput()).includes('Choose an approach'));
+
+    // ↑ from the first option wraps onto the Other row; a >1000-char bracketed
+    // paste is stored as a `[paste #N …]` placeholder inside the editor.
+    const pasted = 'x'.repeat(1001);
+    terminal.input('\x1b[A');
+    terminal.input(`\x1b[200~${pasted}\x1b[201~`);
+    await waitFor(() => plainTerminalOutput(terminal.screenOutput()).includes('[paste #1 1001 chars]'));
+
+    // Enter must submit through the Editor's own path, which expands the
+    // placeholder back into the full pasted text before answering.
+    terminal.input('\r');
+    await waitFor(() => plainTerminalOutput(terminal.screenOutput()).includes('Keep the default'));
+    terminal.input('\x1b');
+    await waitFor(() => plainTerminalOutput(terminal.screenOutput()).includes('Anything else'));
+    terminal.input('\x1b');
+
+    await waitFor(() => driver.responses.length === 1);
+    assert.deepEqual(driver.responses, [{
+      requestId: 'question-1',
+      answers: [pasted, null, null],
+    }]);
+
+    exitMaka(terminal);
+    await run;
+  });
+
+  test('treats LF in the Other row as a newline, not a submit', async () => {
+    const terminal = new FakeTerminal();
+    const driver = new UserQuestionPromptDriver();
+    const run = runMakaPiTui({
+      title: 'Maka', driver, cwd: '/repo', model: 'claude-sonnet-4-5',
+      connectionSlug: 'claude-subscription', permissionMode: 'ask', terminal,
+    });
+
+    terminal.input('choose');
+    terminal.input('\r');
+    await waitFor(() => plainTerminalOutput(terminal.screenOutput()).includes('Choose an approach'));
+
+    // Type into the Other row, then send a legacy LF (Ctrl-J). The Editor owns
+    // Enter-key classification: LF is a newline, so the question must stay open
+    // with a second line started instead of submitting the answer.
+    terminal.input('line one');
+    await waitFor(() => plainTerminalOutput(terminal.screenOutput()).includes('line one'));
+    terminal.input('\n');
+    terminal.input('line two');
+    await waitFor(() => plainTerminalOutput(terminal.screenOutput()).includes('line two'));
+    assert.equal(driver.responses.length, 0);
+    assert.ok(plainTerminalOutput(terminal.screenOutput()).includes('Choose an approach'));
+
+    // CR submits: the answer carries the newline the LF inserted.
+    terminal.input('\r');
+    await waitFor(() => plainTerminalOutput(terminal.screenOutput()).includes('Keep the default'));
+    terminal.input('\x1b');
+    await waitFor(() => plainTerminalOutput(terminal.screenOutput()).includes('Anything else'));
+    terminal.input('\x1b');
+
+    await waitFor(() => driver.responses.length === 1);
+    assert.deepEqual(driver.responses, [{
+      requestId: 'question-1',
+      answers: ['line one\nline two', null, null],
     }]);
 
     exitMaka(terminal);

--- a/packages/cli/src/pi-tui-pickers.ts
+++ b/packages/cli/src/pi-tui-pickers.ts
@@ -3,6 +3,8 @@ import {
   Editor,
   Key,
   SelectList,
+  decodeKittyPrintable,
+  isKeyRepeat,
   matchesKey,
   truncateToWidth,
   visibleWidth,
@@ -13,6 +15,7 @@ import {
   type SelectItem,
   type TUI,
 } from '@earendil-works/pi-tui';
+import type { UserQuestionOption } from '@maka/core';
 import { PERMISSION_MODES, type PermissionMode } from '@maka/core/permission';
 import type { ThinkingLevel } from '@maka/core/model-thinking';
 import type { ModelChoice } from './connection-target.js';
@@ -121,23 +124,54 @@ export class PickerOverlay implements Component {
   }
 }
 
-export class UserQuestionTextOverlay implements Component {
+const USER_QUESTION_ROW_PREFIX_WIDTH = 2;
+
+/**
+ * A single question's overlay: the preset options and a free-text "Other" row on
+ * one screen. The free-text row is the list's last line — an inline {@link Editor}
+ * that activates when the highlight lands on it. ↑↓ move the highlight through the
+ * options and the input row as one ring; typing a printable character while on an
+ * option jumps to the input row and starts the answer there (gemini-cli's
+ * type-to-jump). Enter selects the highlighted option, or submits non-empty input
+ * text; Esc leaves the whole question unanswered. Replaces the old two-step design
+ * that swapped the option list out for a separate text overlay.
+ */
+export class UserQuestionOverlay implements Component {
   private readonly editor: Editor;
+  // Highlight index over [0, options.length]. `options.length` is the input row.
+  private activeIndex = 0;
 
   constructor(
     tui: TUI,
     private readonly input: {
       title: string;
       rightLabel: string;
-      onSubmit(value: string): void;
+      hint: string;
+      placeholder: string;
+      options: readonly UserQuestionOption[];
+      onSelectOption(index: number): void;
+      onSubmitText(value: string): void;
       onSkip(): void;
     },
   ) {
-    this.editor = new Editor(tui, editorTheme(), { paddingX: 1 });
+    // paddingX 0 so the inline row aligns under the `  `/`→ ` option prefix
+    // instead of the editor's own gutter.
+    this.editor = new Editor(tui, editorTheme(), { paddingX: 0 });
+    // Submit through the Editor's own submitValue() path: it expands paste
+    // markers (a large paste is stored as a `[paste #N …]` placeholder until
+    // then) and trims, so the answer is the real pasted/typed text. An empty
+    // submission is a no-op so Enter on the blank row can't send a blank answer.
     this.editor.onSubmit = (value) => {
-      const answer = value.trim();
-      if (answer) this.input.onSubmit(answer);
+      if (value) this.input.onSubmitText(value);
     };
+  }
+
+  private get inputRowIndex(): number {
+    return this.input.options.length;
+  }
+
+  private get onInputRow(): boolean {
+    return this.activeIndex === this.inputRowIndex;
   }
 
   invalidate(): void {
@@ -145,26 +179,91 @@ export class UserQuestionTextOverlay implements Component {
   }
 
   handleInput(data: string): void {
+    // Esc always abandons the whole question (advance unanswered), even with
+    // text typed — one Esc level, matching the pre-inline behavior.
     if (matchesKey(data, Key.escape)) {
       this.input.onSkip();
       return;
     }
-    this.editor.handleInput(data);
+    if (matchesKey(data, Key.up)) {
+      this.activeIndex = this.activeIndex === 0 ? this.inputRowIndex : this.activeIndex - 1;
+      return;
+    }
+    if (matchesKey(data, Key.down)) {
+      this.activeIndex = this.activeIndex === this.inputRowIndex ? 0 : this.activeIndex + 1;
+      return;
+    }
+    if (matchesKey(data, Key.enter) || matchesKey(data, Key.return)) {
+      // A held-key repeat must not double-advance onto the next question.
+      if (isKeyRepeat(data)) return;
+      if (!this.onInputRow) {
+        this.input.onSelectOption(this.activeIndex);
+        return;
+      }
+      // Fall through: on the input row even Enter goes to the Editor, whose own
+      // key classification decides newline (LF/Ctrl-J, Shift+Enter, `\`+Enter)
+      // vs submit — submitValue() then feeds the wired onSubmit above.
+    }
+    if (this.onInputRow) {
+      this.editor.handleInput(data);
+      return;
+    }
+    // Type-to-jump: a printable key (or an IME/legacy multi-byte sequence) while
+    // an option is highlighted moves to the input row and starts the answer with
+    // that key. Mirror the editor's own printable test — a Kitty CSI-u printable,
+    // or a legacy sequence whose first byte is a non-control character — so
+    // navigation/control keys (arrows, Enter, Esc, Ctrl/Alt combos) never trigger
+    // the jump. The raw sequence is handed to the editor so its IME and paste
+    // handling stay intact.
+    const printable = decodeKittyPrintable(data) ?? (data.charCodeAt(0) >= 32 ? data : undefined);
+    if (printable !== undefined) {
+      this.activeIndex = this.inputRowIndex;
+      this.editor.handleInput(data);
+    }
   }
 
   render(width: number): string[] {
     const safeWidth = Math.max(1, width);
-    // #1064: emit the hardware-cursor marker so IME candidate windows position
-    // correctly inside this overlay editor. Without this, CJK input methods
-    // anchor at the terminal bottom instead of the editor's cursor location.
-    // Reference: ~/.pi/agent/extensions/question.ts.
-    this.editor.focused = true;
-    return [
+    const lines: string[] = [
       padLine(`${this.input.title} ${ansi.accent(this.input.rightLabel)}`, safeWidth),
-      padLine(ansi.dim('Type another answer · Enter submit · Esc unanswered · Ctrl+C stop'), safeWidth),
-      ...this.editor.render(safeWidth).map((line) => padLine(line, safeWidth)),
-      padLine(ansi.accent('-'.repeat(safeWidth)), safeWidth),
+      padLine(ansi.dim(this.input.hint), safeWidth),
+      padLine('', safeWidth),
     ];
+    this.input.options.forEach((option, index) => {
+      lines.push(this.renderOptionRow(option, index === this.activeIndex, safeWidth));
+    });
+    lines.push(...this.renderInputRow(safeWidth));
+    lines.push(padLine(ansi.accent('-'.repeat(safeWidth)), safeWidth));
+    return lines;
+  }
+
+  private renderOptionRow(option: UserQuestionOption, active: boolean, width: number): string {
+    const prefix = active ? '→ ' : '  ';
+    const body = option.description
+      ? `${option.label}  ${active ? option.description : ansi.dim(option.description)}`
+      : option.label;
+    return formatPickerItemLine(`${prefix}${body}`, width);
+  }
+
+  private renderInputRow(width: number): string[] {
+    const prefix = this.onInputRow ? '→ ' : '  ';
+    const contentWidth = Math.max(1, width - USER_QUESTION_ROW_PREFIX_WIDTH);
+    // Focused only while the input row is highlighted: that both shows the block
+    // cursor and emits the hardware-cursor marker (#1064) so IME candidate windows
+    // anchor to the edited text instead of the terminal bottom.
+    this.editor.focused = this.onInputRow;
+    if (!this.onInputRow && this.editor.getText().length === 0) {
+      return [padLine(`${prefix}${ansi.dim(this.input.placeholder)}`, width)];
+    }
+    // Drop the editor's own top/bottom border rows; keep just its content lines
+    // so the answer reads as one row of the list.
+    const editorLines = this.editor.render(contentWidth).slice(1, -1);
+    if (editorLines.length === 0) {
+      return [padLine(`${prefix}${ansi.dim(this.input.placeholder)}`, width)];
+    }
+    return editorLines.map((line, index) => (
+      padLine(`${index === 0 ? prefix : '  '}${line}`, width)
+    ));
   }
 }
 

--- a/packages/cli/src/pi-tui-runner.ts
+++ b/packages/cli/src/pi-tui-runner.ts
@@ -62,7 +62,7 @@ import {
 import {
   MakaAutocompleteProvider,
   PickerOverlay,
-  UserQuestionTextOverlay,
+  UserQuestionOverlay,
   modelChoicePickerItems,
   modelPickerItems,
   permissionModePickerItems,
@@ -652,42 +652,20 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
       return;
     }
     closeUserQuestionOverlay();
-    const items: SelectItem[] = [
-      ...question.options.map((option, index) => ({
-        value: `option:${index}`,
-        label: option.label,
-        ...(option.description ? { description: option.description } : {}),
-      })),
-      { value: 'other', label: 'Other…', description: 'Type another answer.' },
-    ];
-    const list = new SelectList(items, 10, selectListTheme(), {
-      minPrimaryColumnWidth: 12,
-      maxPrimaryColumnWidth: 48,
-    });
     const advance = (answer: string | null): void => {
       progress.answers[progress.index] = answer;
       progress.index += 1;
       showUserQuestion();
     };
-    list.onSelect = (item) => {
-      if (item.value === 'other') {
-        closeUserQuestionOverlay();
-        userQuestionOverlay = showBottomPicker(new UserQuestionTextOverlay(tui, {
-          title: question.question,
-          rightLabel: `${progress.index + 1} / ${request.questions.length}`,
-          onSubmit: advance,
-          onSkip: () => advance(null),
-        }));
-        return;
-      }
-      const optionIndex = Number(item.value.slice('option:'.length));
-      advance(question.options[optionIndex]?.label ?? null);
-    };
-    list.onCancel = () => advance(null);
-    userQuestionOverlay = showBottomPicker(new PickerOverlay(list, {
+    userQuestionOverlay = showBottomPicker(new UserQuestionOverlay(tui, {
       title: question.question,
       rightLabel: `${progress.index + 1} / ${request.questions.length}`,
-      hint: '↑↓ move · Enter select · Esc unanswered · Ctrl+C stop',
+      hint: '↑↓ move · type to answer · Enter select · Esc unanswered · Ctrl+C stop',
+      placeholder: 'Other: type your answer…',
+      options: question.options,
+      onSelectOption: (index) => advance(question.options[index]?.label ?? null),
+      onSubmitText: (value) => advance(value),
+      onSkip: () => advance(null),
     }));
   };
 


### PR DESCRIPTION
## Summary

Selecting "Other…" in an AskUserQuestion overlay used to destroy the option list and swap in a standalone text overlay, so the presets disappeared the moment you started typing. This replaces the two-step design with a single `UserQuestionOverlay`: the free-text answer is the last row of the option list, backed by an inline editor that activates when the highlight lands on it.

- ↑↓ move through the presets and the input row as one ring, so options and free text stay on screen together and you can switch freely.
- Typing a printable character while an option is highlighted jumps to the input row and starts the answer there (the type-to-jump pattern gemini-cli, opencode, and grok-build converged on).
- Enter selects the highlighted option, or submits non-empty input text through the editor's own submit path (paste markers expand, LF/Ctrl-J stays a newline); Enter on the empty row is a no-op.
- Esc still skips the whole question; multi-question requests keep the sequential n / N flow.
- `UserQuestionTextOverlay` and its swap path are deleted.

## Verification

- `packages/cli` typecheck and Biome lint: clean.
- `node --test dist/__tests__/pi-tui-runner.test.js`: 98/98 pass, including new coverage for inline navigation, type-to-jump, a 1001-char bracketed paste submitting the full text (not the `[paste #N …]` placeholder), LF-as-newline in the Other row, and Ctrl-C interrupt with the overlay open.
- Full `maka-agent` workspace test run after rebasing onto latest main: fail 0.
- Externally reviewed (Codex): the one P1 finding — inline submission bypassing the editor's paste-expansion/submit path — is fixed here and covered by the two new tests; no other findings.

## Review focus

Keyboard-protocol edges: type-to-jump uses `decodeKittyPrintable` plus a legacy first-byte printable test, so kitty and standard legacy terminals work; xterm modifyOtherKeys sequences may not trigger the jump (arrow-key navigation still does).