### PR TITLE
feat(cli): status-colored tool rows with parenthesized outcome annotations

### DIFF
--- a/packages/cli/src/__tests__/pi-transcript.test.ts
+++ b/packages/cli/src/__tests__/pi-transcript.test.ts
@@ -411,7 +411,7 @@ describe('Maka Pi TUI transcript', () => {
     // Compact: a running PTY Bash shows only the disc row; the PTY screen
     // lives in the expanded card.
     const compact = renderMakaPiTranscript(state, meta(), 100).map(stripAnsi).join('\n');
-    assert.match(compact, /● Bash  \$ interactive  ·  running/);
+    assert.match(compact, /● Bash  \$ interactive \(running\)/);
     assert.doesNotMatch(compact, /pty-row-1/);
 
     assert.equal(toggleAllToolExpansion(state), true);
@@ -510,7 +510,7 @@ describe('Maka Pi TUI transcript', () => {
     ] satisfies StoredMessage[]);
 
     const rendered = renderMakaPiTranscript(state, meta(), 100).map(stripAnsi).join('\n');
-    assert.match(rendered, /● Bash  \$ npm test  ·  5s/);
+    assert.match(rendered, /● Bash  \$ npm test \(5s\)/);
   });
 
   test('rebuilds automatic context compaction notes from stored session messages', () => {
@@ -950,8 +950,8 @@ describe('Maka Pi TUI transcript', () => {
 
   test('keeps tool cards compact until the latest tool is expanded', () => {
     const state = createMakaPiTranscriptState();
-    // `head-line` is first; the compact one-line summary shows only the last
-    // non-empty line, and expanding reveals the full stdout.
+    // `head-line` is first; the compact one-line summary shows only the output
+    // size, never output content, and expanding reveals the full stdout.
     const stdout = `head-line\n${Array.from({ length: 30 }, (_, i) => `row-${i}`).join('\n')}`;
 
     applyMakaSessionEventToTranscript(state, event({
@@ -973,8 +973,11 @@ describe('Maka Pi TUI transcript', () => {
     // Compact cards are a single line (plus the leading blank separator).
     assert.equal(compactLines.length, 2);
     assert.match(compact, /● Bash  \$ npm test/);
-    assert.match(compact, /\(31 lines\) row-29 ›/);
+    assert.match(compact, /\(31 lines\)/);
     assert.doesNotMatch(compact, /head-line/);
+    assert.doesNotMatch(compact, /row-29/);
+    // The annotation's shapes carry the affordance; no expand marker remains.
+    assert.doesNotMatch(compact, /›/);
 
     assert.equal(toggleAllToolExpansion(state), true);
     const expanded = renderMakaPiTranscript(state, meta(), 120).map(stripAnsi).join('\n');
@@ -983,7 +986,7 @@ describe('Maka Pi TUI transcript', () => {
     assert.match(expanded, /row-29/);
   });
 
-  test('summarizes a failing Bash tool with exit code and last stderr line', () => {
+  test('summarizes a failing Bash tool with a red exit code, not the error text', () => {
     const state = createMakaPiTranscriptState();
     applyMakaSessionEventToTranscript(state, event({
       type: 'tool_start',
@@ -1005,9 +1008,52 @@ describe('Maka Pi TUI transcript', () => {
     const lines = renderMakaPiTranscript(state, meta(), 120);
     assert.equal(lines.length, 2);
     const compact = lines.map(stripAnsi).join('\n');
-    assert.match(compact, /exit 1 final error line ›/);
+    assert.match(compact, /\(exit 1\)/);
+    // The error text itself lives only in the expanded card.
+    assert.doesNotMatch(compact, /final error line/);
     // The exit code is red.
     assert.match(lines.join('\n'), /\x1b\[31mexit 1\x1b\[39m/);
+  });
+
+  test('marks a completed tool with a green disc', () => {
+    const state = createMakaPiTranscriptState();
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_start', toolUseId: 'tool-1', toolName: 'Bash', args: { command: 'true' },
+    }));
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_result', toolUseId: 'tool-1', isError: false,
+      content: terminalResult('', '', { cmd: 'true' }),
+    }));
+
+    const lines = renderMakaPiTranscript(state, meta(), 100);
+    assert.match(lines.join('\n'), /\x1b\[32m●\x1b\[39m/);
+  });
+
+  test('hides a sub-second duration on a settled compact row', () => {
+    const state = createMakaPiTranscriptState();
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_start', toolUseId: 'bash-fast', toolName: 'Bash', args: { command: 'true' },
+    }));
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_result', toolUseId: 'bash-fast', isError: false,
+      content: shellRun({ status: 'completed', startedAt: 1_000, updatedAt: 1_300, completedAt: 1_300, exitCode: 0 }),
+    }));
+
+    const rendered = renderMakaPiTranscript(state, meta(), 100).map(stripAnsi).join('\n');
+    assert.match(rendered, /● Bash  \$ true \(no output\)/);
+    assert.doesNotMatch(rendered, /0s/);
+  });
+
+  test('shows the first real command line when a Bash command leads with comments', () => {
+    const state = createMakaPiTranscriptState();
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_start', toolUseId: 'tool-1', toolName: 'Bash',
+      args: { command: '# look for the setting\ngrep -n "setting" src/config.ts' },
+    }));
+
+    const compact = renderMakaPiTranscript(state, meta(), 100).map(stripAnsi).join('\n');
+    assert.match(compact, /\$ grep -n "setting" src\/config\.ts/);
+    assert.doesNotMatch(compact, /look for the setting/);
   });
 
   test('summarizes a silent successful command as (no output)', () => {
@@ -1049,7 +1095,7 @@ describe('Maka Pi TUI transcript', () => {
     const lines = renderMakaPiTranscript(state, meta(), 120).map(stripAnsi);
     assert.equal(lines.length, 2);
     const compact = lines.join('\n');
-    assert.match(compact, /● Bash  \$ npm run build  ·  running/);
+    assert.match(compact, /● Bash  \$ npm run build \(running\)/);
     assert.doesNotMatch(compact, /step one/);
     assert.doesNotMatch(compact, /step two/);
 
@@ -1078,7 +1124,7 @@ describe('Maka Pi TUI transcript', () => {
     const tool = state.entries.find((entry) => entry.kind === 'tool');
     assert.equal(tool?.kind === 'tool' ? tool.status : undefined, 'running');
     const rendered = renderMakaPiTranscript(state, meta(), 100).map(stripAnsi).join('\n');
-    assert.match(rendered, /● Bash  \$ sleep 30  ·  running 10s/);
+    assert.match(rendered, /● Bash  \$ sleep 30 \(running 10s\)/);
     assert.doesNotMatch(rendered, /done/);
     assert.equal(rendered.split('$ sleep 30').length - 1, 1);
   });
@@ -1124,7 +1170,7 @@ describe('Maka Pi TUI transcript', () => {
     });
 
     const rendered = renderMakaPiTranscript(state, meta(), 100).map(stripAnsi).join('\n');
-    assert.match(rendered, /owned by source session/);
+    assert.match(rendered, /\(detached\)/);
     assert.doesNotMatch(rendered, /continues in source session/);
 
     applyShellRunViewUpdateToTranscript(state, {
@@ -1135,7 +1181,7 @@ describe('Maka Pi TUI transcript', () => {
       result: shellRun({ stdout: '', stderr: '' }),
     });
     const unavailable = renderMakaPiTranscript(state, meta(), 100).map(stripAnsi).join('\n');
-    assert.match(unavailable, /source session unavailable/);
+    assert.match(unavailable, /\(source unavailable\)/);
     assert.doesNotMatch(unavailable, /Ask Maka to stop this task/);
   });
 
@@ -1293,7 +1339,7 @@ describe('Maka Pi TUI transcript', () => {
     assert.equal(tools[0]?.status, 'aborted');
     const lines = renderMakaPiTranscript(state, meta(), 100);
     const rendered = lines.map(stripAnsi).join('\n');
-    assert.match(rendered, /● Bash  \$ sleep 30  ·  7s/);
+    assert.match(rendered, /● Bash  \$ sleep 30 \(7s · cancelled · exit 130\)/);
     assert.doesNotMatch(rendered, /● StopBackgroundTask/);
     // An aborted background task uses the danger disc (red).
     assert.match(lines.join('\n'), /\x1b\[31m●\x1b\[39m/);
@@ -1332,10 +1378,117 @@ describe('Maka Pi TUI transcript', () => {
     const lines = renderMakaPiTranscript(state, meta(), 60).map(stripAnsi);
     assert.equal(lines.length, 2); // one card line plus the leading blank separator
     const row = lines[1]!;
-    // A long command must not hide the elapsed time or the expand marker.
-    assert.match(row, /·  5s/);
-    assert.match(row, /›$/);
+    // A long command must not hide the elapsed time or the outcome.
+    assert.match(row, /\(5s · 2 lines\)$/);
     assert.ok(visibleWidth(row) <= 60, `row width ${visibleWidth(row)} exceeds 60`);
+  });
+
+  test('reserves an annotation exactly at the 30-column cap when a row overflows', () => {
+    const state = createMakaPiTranscriptState();
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_start', toolUseId: 'bash-cap', toolName: 'Bash',
+      args: { command: 'npm run build ' + 'x'.repeat(60) },
+    }));
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_result', toolUseId: 'bash-cap', isError: false,
+      content: shellRun({ status: 'timed_out', startedAt: 0, updatedAt: 1_234_000, completedAt: 1_234_000, exitCode: 124 }),
+    }));
+
+    const lines = renderMakaPiTranscript(state, meta(), 60).map(stripAnsi);
+    const row = lines[1]!;
+    // `(1234s · timed_out · exit 124)` is exactly 30 columns. The cap is
+    // measured on the annotation alone (the joining space is budgeted
+    // separately), so an at-cap annotation is still reserved whole.
+    assert.match(row, /\(1234s · timed_out · exit 124\)$/);
+    assert.ok(visibleWidth(row) <= 60, `row width ${visibleWidth(row)} exceeds 60`);
+  });
+
+  test('drops an unprotected generic annotation before truncating the target', () => {
+    const state = createMakaPiTranscriptState();
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_start', toolUseId: 'frob-1', toolName: 'Frobnicate',
+      args: { alpha: 'x'.repeat(50), beta: 'two' },
+    }));
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_result', toolUseId: 'frob-1', isError: false,
+      content: { kind: 'json', value: { gamma: 3 } },
+    }));
+
+    const lines = renderMakaPiTranscript(state, meta(), 40).map(stripAnsi);
+    const row = lines[1]!;
+    // The generic first-line annotation is free text: it yields to the target
+    // instead of being reserved like a fixed-shape outcome.
+    assert.match(row, /alpha/);
+    assert.doesNotMatch(row, /gamma/);
+    assert.ok(visibleWidth(row) <= 40, `row width ${visibleWidth(row)} exceeds 40`);
+  });
+
+  test('hides a sub-second duration instead of rounding it up to 1s', () => {
+    const state = createMakaPiTranscriptState();
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_start', toolUseId: 'bash-fast', toolName: 'Bash', args: { command: 'true' },
+    }));
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_result', toolUseId: 'bash-fast', isError: false,
+      content: shellRun({ status: 'completed', startedAt: 1_000, updatedAt: 1_999, completedAt: 1_999, exitCode: 0, stdout: 'ok\n' }),
+    }));
+
+    const rendered = renderMakaPiTranscript(state, meta(), 100).map(stripAnsi).join('\n');
+    // 999ms rounds to 1, but the gate is on raw milliseconds: no `1s`.
+    assert.match(rendered, /● Bash  \$ true \(1 line\)/);
+  });
+
+  test('shows 1s once a full second has elapsed', () => {
+    const state = createMakaPiTranscriptState();
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_start', toolUseId: 'bash-1s', toolName: 'Bash', args: { command: 'true' },
+    }));
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_result', toolUseId: 'bash-1s', isError: false,
+      content: shellRun({ status: 'completed', startedAt: 1_000, updatedAt: 2_000, completedAt: 2_000, exitCode: 0, stdout: 'ok\n' }),
+    }));
+
+    const rendered = renderMakaPiTranscript(state, meta(), 100).map(stripAnsi).join('\n');
+    assert.match(rendered, /● Bash  \$ true \(1s · 1 line\)/);
+  });
+
+  test('a running row stays bare `running` for a sub-second duration', () => {
+    const state = createMakaPiTranscriptState();
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_start', toolUseId: 'bash-bg', toolName: 'Bash', args: { command: 'sleep 30' },
+    }));
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_result', toolUseId: 'bash-bg', isError: false,
+      content: shellRun({ status: 'running', startedAt: 1_000, updatedAt: 1_400 }),
+      durationMs: 400,
+    }));
+
+    const rendered = renderMakaPiTranscript(state, meta(), 100).map(stripAnsi).join('\n');
+    assert.match(rendered, /● Bash  \$ sleep 30 \(running\)/);
+  });
+
+  test('counts stdout and stderr lines per stream, not at the join boundary', () => {
+    const state = createMakaPiTranscriptState();
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_start', toolUseId: 'bash-fg', toolName: 'Bash', args: { command: 'fg' },
+    }));
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_result', toolUseId: 'bash-fg', isError: false,
+      content: terminalResult('out\n', 'err\n'),
+    }));
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_start', toolUseId: 'bash-bg', toolName: 'Bash', args: { command: 'bg' },
+    }));
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_result', toolUseId: 'bash-bg', isError: false,
+      content: shellRun({ status: 'completed', startedAt: 0, updatedAt: 2_000, completedAt: 2_000, exitCode: 0, stdout: 'out\n', stderr: 'err\n' }),
+    }));
+
+    const rendered = renderMakaPiTranscript(state, meta(), 100).map(stripAnsi).join('\n');
+    // `out\n` + `err\n` is two lines — joining before counting would invent a
+    // third line at the stream boundary.
+    assert.match(rendered, /● Bash  \$ fg \(2 lines\)/);
+    assert.match(rendered, /● Bash  \$ bg \(2s · 2 lines\)/);
   });
 
   test('applies a runtime-published terminal update directly to its parent Bash card', () => {
@@ -1354,8 +1507,9 @@ describe('Maka Pi TUI transcript', () => {
 
     assert.equal(applied, true);
     const rendered = renderMakaPiTranscript(state, meta(), 100).map(stripAnsi).join('\n');
-    assert.match(rendered, /● Bash  \$ build  ·  4s/);
-    assert.match(rendered, /done/);
+    assert.match(rendered, /● Bash  \$ build \(4s · 1 line\)/);
+    // Compact shows the output size, not the output content.
+    assert.doesNotMatch(rendered, /done/);
   });
 
   test('does not erase a runtime-published output update with an equal-time handoff result', () => {
@@ -1399,7 +1553,7 @@ describe('Maka Pi TUI transcript', () => {
     assert.equal(compactLines.length, 2);
     const compact = compactLines.join('\n');
     assert.match(compact, /src\/app\.ts offset 10 limit 20/);
-    assert.match(compact, /4 lines, 59 bytes ›/);
+    assert.match(compact, /\(4 lines\)/);
     assert.doesNotMatch(compact, /content-line-0/);
 
     // A successful Read pulled the file into the model's context; expanding the
@@ -1492,7 +1646,7 @@ describe('Maka Pi TUI transcript', () => {
     // Collapsed and expanded must agree: both drop the trailing newline, so the
     // same card cannot flip from "4 lines" to "3 lines" when toggled with Ctrl+O.
     const compact = renderMakaPiTranscript(state, meta(), 100).map(stripAnsi).join('\n');
-    assert.match(compact, /3 lines, 6 bytes/);
+    assert.match(compact, /\(3 lines\)/);
     assert.equal(toggleAllToolExpansion(state), true);
     const expanded = renderMakaPiTranscript(state, meta(), 100).map(stripAnsi).join('\n');
     assert.match(expanded, /Read 3 lines, 6 bytes/);
@@ -1638,7 +1792,7 @@ describe('Maka Pi TUI transcript', () => {
     assert.equal(compactLines.length, 2);
     const compact = compactLines.join('\n');
     assert.match(compact, /TODO in packages glob \*\.ts/);
-    assert.match(compact, /12 matches ›/);
+    assert.match(compact, /\(12 matches\)/);
     assert.doesNotMatch(compact, /match-0/);
 
     // Expanding a Grep card shows every match — a structured list the user
@@ -1671,7 +1825,7 @@ describe('Maka Pi TUI transcript', () => {
     assert.equal(compactLines.length, 2);
     const compact = compactLines.join('\n');
     assert.match(compact, /● Glob  \*\*\/\*\.ts in packages/);
-    assert.match(compact, /3 files ›/);
+    assert.match(compact, /\(3 files\)/);
     assert.doesNotMatch(compact, /src\/a\.ts/);
 
     assert.equal(toggleAllToolExpansion(state), true);
@@ -1759,7 +1913,7 @@ describe('Maka Pi TUI transcript', () => {
     // custom case extracts headline key:value lines, never JSON braces.
     // The multi-line key:value input is collapsed to a single line by
     // collapseToSingleLine so the compact card stays one line.
-    assert.match(lines[1] ?? '', /● Frobnicate  alpha: 1 beta: two  ·  gamma: 3 ›/);
+    assert.match(lines[1] ?? '', /● Frobnicate  alpha: 1 beta: two \(gamma: 3\)/);
     assert.doesNotMatch(lines[1] ?? '', /\{"alpha"/);
     assert.doesNotMatch(lines[1] ?? '', /\{"gamma"/);
   });
@@ -1784,8 +1938,10 @@ describe('Maka Pi TUI transcript', () => {
     const compactLines = renderMakaPiTranscript(state, meta(), 100);
     assert.equal(compactLines.length, 2);
     const compactRaw = compactLines.join('\n');
-    // Compact: `+1 -1 file.ts` with green add count and red delete count.
-    assert.match(compactLines.map(stripAnsi).join('\n'), /\+1 -1 file\.ts ›/);
+    // Compact: `+1 -1` with green add count and red delete count; the path is
+    // already the card's input summary, so the diff summary does not repeat it.
+    assert.match(compactLines.map(stripAnsi).join('\n'), /\(\+1 -1\)/);
+    assert.doesNotMatch(compactLines.map(stripAnsi).join('\n'), /\+1 -1 file\.ts/);
     assert.match(compactRaw, /\x1b\[32m\+1\x1b\[39m/);
     assert.match(compactRaw, /\x1b\[31m-1\x1b\[39m/);
     assert.doesNotMatch(compactLines.map(stripAnsi).join('\n'), /added line/);
@@ -1902,7 +2058,9 @@ describe('Maka Pi TUI transcript', () => {
 
     const lines = renderMakaPiTranscript(state, meta(), 100).map(stripAnsi);
     assert.equal(lines.length, 2);
-    assert.match(lines.join('\n'), /Wrote 42 bytes to out\.txt/);
+    // The path is already the card's input summary; the result adds only size.
+    assert.match(lines.join('\n'), /● Write  out\.txt \(42 bytes\)/);
+    assert.doesNotMatch(lines.join('\n'), /Wrote 42 bytes to/);
     assert.doesNotMatch(lines.join('\n'), /\(Ctrl\+O\)/);
   });
 
@@ -2270,7 +2428,7 @@ describe('transcript entry render memoization', () => {
     assert.doesNotMatch(finalized, /AAAA/);
   });
 
-  test('re-renders a ShellRun when only the latest output stream changes', () => {
+  test('merges a latestStream-only ShellRun update into the card result', () => {
     const state = createMakaPiTranscriptState();
     applyMakaSessionEventToTranscript(state, event({
       type: 'tool_start', toolUseId: 'bash-bg', toolName: 'Bash', args: { command: 'build' },
@@ -2282,17 +2440,25 @@ describe('transcript entry render memoization', () => {
         status: 'completed', completedAt: 3_000, exitCode: 0,
       }),
     }));
-    const before = renderMakaPiTranscript(state, meta(), 100).map(stripAnsi).join('\n');
-    assert.match(before, /BBBB/);
+    // The compact row carries only the line count and the expanded card shows
+    // both streams, so a latestStream flip is observable only on the result
+    // itself — the render must still re-run from a fresh memo entry.
+    const latestStream = () => {
+      const tool = state.entries.find((entry) => entry.kind === 'tool');
+      return tool?.kind === 'tool' && tool.result?.kind === 'shell_run' && tool.result.output?.mode === 'pipes'
+        ? tool.result.output.latestStream
+        : undefined;
+    };
+    assert.equal(latestStream(), 'stderr');
 
     applyShellRunUpdateToTranscript(state, 'bash-bg', shellRun({
       stdout: 'AAAA', stderr: 'BBBB', updatedAt: 3_000, revision: 3_001,
       latestStream: 'stdout',
       status: 'completed', completedAt: 3_000, exitCode: 0,
     }));
-    const after = renderMakaPiTranscript(state, meta(), 100).map(stripAnsi).join('\n');
-    assert.match(after, /AAAA/);
-    assert.doesNotMatch(after, /BBBB/);
+    assert.equal(latestStream(), 'stdout');
+    const rendered = renderMakaPiTranscript(state, meta(), 100).map(stripAnsi).join('\n');
+    assert.match(rendered, /\(2s · 2 lines\)/);
   });
 
   test('re-renders equal-length ShellRun output only when revision advances', () => {

--- a/packages/cli/src/__tests__/pi-tui-runner.test.ts
+++ b/packages/cli/src/__tests__/pi-tui-runner.test.ts
@@ -641,7 +641,7 @@ describe('Maka Pi TUI runner', () => {
     terminal.input('n');
     terminal.input('\r');
 
-    await waitFor(() => terminal.output().includes('›'));
+    await waitFor(() => terminal.output().includes('(31 lines)'));
     assert.equal(terminal.output().includes('expanded-tail'), false);
 
     terminal.input('\x0f');
@@ -689,7 +689,7 @@ describe('Maka Pi TUI runner', () => {
         output: pipeOutput('done\n'),
       },
     });
-    await waitFor(() => plainTerminalOutput(terminal.screenOutput()).includes('·  4s'));
+    await waitFor(() => plainTerminalOutput(terminal.screenOutput()).includes('(4s · 1 line)'));
 
     exitMaka(terminal);
     await run;
@@ -711,7 +711,7 @@ describe('Maka Pi TUI runner', () => {
 
     terminal.input('run');
     terminal.input('\r');
-    await waitFor(() => terminal.output().includes('›'));
+    await waitFor(() => terminal.output().includes('(31 lines)'));
 
     // Kitty keyboard protocol terminals (Ghostty/Kitty) send one event for the
     // key press and another for the release. The release must not undo the
@@ -719,11 +719,11 @@ describe('Maka Pi TUI runner', () => {
     terminal.input('\x1b[111;5u');
     terminal.input('\x1b[111;5:3u');
 
-    // The compact-only › hint leaving the screen proves the card is
+    // The compact-only annotation leaving the screen proves the card is
     // still expanded after the release event.
-    await waitFor(() => !plainTerminalOutput(terminal.screenOutput()).includes('›'));
+    await waitFor(() => !plainTerminalOutput(terminal.screenOutput()).includes('(31 lines)'));
     await delay(20);
-    assert.equal(plainTerminalOutput(terminal.screenOutput()).includes('›'), false);
+    assert.equal(plainTerminalOutput(terminal.screenOutput()).includes('(31 lines)'), false);
 
     exitMaka(terminal);
     await Promise.race([
@@ -2143,7 +2143,7 @@ describe('Maka Pi TUI runner', () => {
     terminal.input('/session session-2');
     terminal.input('\r');
 
-    await waitFor(() => plainTerminalOutput(terminal.screenOutput()).includes('·  4s'));
+    await waitFor(() => plainTerminalOutput(terminal.screenOutput()).includes('(4s · 2 lines)'));
     assert.deepEqual(reads, ['session-2']);
 
     exitMaka(terminal);
@@ -2743,7 +2743,10 @@ describe('Maka Pi TUI runner', () => {
     }]);
 
     await waitFor(() => plainTerminalOutput(terminal.screenOutput()).includes('detached'));
-    await waitFor(() => plainTerminalOutput(terminal.screenOutput()).includes('buffered owner revision'));
+    // The stale one-line hydration must not clobber the newer two-line local
+    // output: the compact row reports the merged output's line count.
+    await waitFor(() => plainTerminalOutput(terminal.screenOutput()).includes('2 lines'));
+    assert.equal(plainTerminalOutput(terminal.screenOutput()).includes('1 line'), false);
     assert.equal(plainTerminalOutput(terminal.screenOutput()).includes('Ask Maka to stop this task'), false);
 
     assert.ok(listener);
@@ -2759,7 +2762,7 @@ describe('Maka Pi TUI runner', () => {
         output: pipeOutput('still running\nbuffered owner revision\ndone\n'),
       },
     });
-    await waitFor(() => plainTerminalOutput(terminal.screenOutput()).includes('done'));
+    await waitFor(() => plainTerminalOutput(terminal.screenOutput()).includes('3 lines'));
     assert.equal(plainTerminalOutput(terminal.screenOutput()).includes('detached'), false);
 
     exitMaka(terminal);
@@ -2877,7 +2880,9 @@ describe('Maka Pi TUI runner', () => {
       },
     }]);
 
-    await waitFor(() => plainTerminalOutput(terminal.screenOutput()).includes('authoritative terminal state'));
+    // The authoritative settled card is the one that shows its 4s elapsed
+    // time; the intermediate detached snapshot only carries a line count.
+    await waitFor(() => plainTerminalOutput(terminal.screenOutput()).includes('(4s · 1 line)'));
     assert.equal(plainTerminalOutput(terminal.screenOutput()).includes('detached'), false);
     assert.equal(hydrationAttempts, 2);
 

--- a/packages/cli/src/__tests__/tui-ansi.test.ts
+++ b/packages/cli/src/__tests__/tui-ansi.test.ts
@@ -22,12 +22,17 @@ describe('tui-ansi semantic slots (#1053)', () => {
 describe('disc (#1053)', () => {
   test('renders a single ● glyph regardless of tone', () => {
     _setColorLevelForTesting(3);
-    for (const tone of ['muted', 'accent', 'danger'] as const) {
+    for (const tone of ['ok', 'muted', 'accent', 'danger'] as const) {
       assert.equal(stripAnsi(disc(tone)), '●', `tone ${tone} should yield one ●`);
     }
   });
 
-  test('done (muted) disc uses the muted cool-grey', () => {
+  test('done (ok) disc uses standard green', () => {
+    _setColorLevelForTesting(3);
+    assert.equal(disc('ok'), '\x1b[32m●\x1b[39m');
+  });
+
+  test('detached/unavailable (muted) disc uses the muted cool-grey', () => {
     _setColorLevelForTesting(3);
     assert.equal(disc('muted'), '\x1b[38;2;128;132;140m●\x1b[39m');
   });
@@ -74,6 +79,7 @@ describe('color capability fallback (#1064)', () => {
     assert.equal(ansi.muted('x'), 'x');
     assert.equal(ansi.bold('x'), 'x');
     assert.equal(ansi.red('x'), 'x');
+    assert.equal(disc('ok'), '●');
     assert.equal(disc('muted'), '●');
     assert.equal(disc('accent'), '●');
     assert.equal(disc('danger'), '●');

--- a/packages/cli/src/pi-transcript-tools.ts
+++ b/packages/cli/src/pi-transcript-tools.ts
@@ -2,7 +2,6 @@ import type { ToolOutputStream, ToolResultContent } from '@maka/core/events';
 import {
   formatQuietJsonValue,
   formatToolInvocationLine,
-  ptyCompactTerminalLine,
   ptyTuiTerminalRows,
   ptyTuiTerminalView,
   readWriteStdinInputPreview,
@@ -28,88 +27,111 @@ export function renderToolBlock(entry: MakaPiToolEntry, width: number, expanded:
   return expanded ? renderExpandedToolBlock(entry, width) : renderCompactToolBlock(entry, width);
 }
 
-/** Status disc for a tool row: muted = done, accent = running, danger = error/aborted/failed. */
+/** Status disc for a tool row: green = done, accent = running, danger = error/aborted/failed, muted = detached/unavailable. */
 function toolDisc(entry: MakaPiToolEntry): string {
   if (entry.status === 'running') return disc('accent');
   if (entry.status === 'error' || entry.status === 'aborted' || entry.status === 'failed') return disc('danger');
-  return disc('muted');
+  if (entry.status === 'detached' || entry.status === 'unavailable') return disc('muted');
+  return disc('ok');
 }
 
-/** Duration/status segment in integer seconds (#1053): `5s`, `running 12s`, `detached`. */
+/**
+ * Duration/status part of the annotation, in integer seconds (#1053): `5s`,
+ * `running 12s`. Sub-second durations are noise and never shown — the gate is
+ * on the raw milliseconds, not the rounded value, so 999ms does not surface
+ * as `1s`. Status words for rows without a live process (`detached`,
+ * `source unavailable`) are dimmed like the other placeholders.
+ */
 function toolDurationText(entry: MakaPiToolEntry): string {
+  const subSecond = entry.durationMs !== undefined && entry.durationMs < 1000;
   const secs = entry.durationMs === undefined ? undefined : Math.max(0, Math.round(entry.durationMs / 1000));
   if (entry.status === 'running') {
-    return secs === undefined ? ansi.dim('running') : ansi.dim(`running ${secs}s`);
+    return secs === undefined || subSecond ? 'running' : `running ${secs}s`;
   }
   if (entry.status === 'detached') return ansi.dim('detached');
   if (entry.status === 'unavailable') return ansi.dim('source unavailable');
-  return secs === undefined ? '' : ansi.dim(`${secs}s`);
+  return secs === undefined || subSecond ? '' : `${secs}s`;
 }
 
 /**
- * Compact tool card: a single line in the #1053 disc grammar -
- * `● Name  primary  ·  duration  ·  summary ›`. The disc carries status, the
- * duration is integer seconds, and a dim trailing `›` marks an expandable
- * card. Live output and stop hints live only in the expanded card, so collapse
- * never grows a second line (no height jitter). The disc, name, duration, and
- * `›` are always preserved; only the input and summary text truncate, so a
- * long command or result never hides elapsed time or the expand marker.
+ * Compact tool card: a single line — `● Name  target (annotation)`. The disc
+ * carries the status color (green done / blue running / red failed / grey
+ * detached); the parenthesized annotation carries the outcome in short fixed
+ * shapes: counts (`5 matches`, `3 lines`), sizes (`42 bytes`), a diff tally
+ * (`+1 -3`), durations (`5s`, sharing the parens as `5s · 3 lines`), red exit
+ * codes, or the dim `no output` placeholder. Output content never appears on
+ * the row — it lives in the expanded card, and the annotation's shapes
+ * already say whether there is anything to expand, so the row needs neither
+ * a separator glyph nor an expand marker. Short annotations are reserved
+ * whole during truncation: a long command can never hide an `exit 1`.
  */
 function renderCompactToolBlock(entry: MakaPiToolEntry, width: number): string[] {
   const inputSummary = collapseToSingleLine(toolInputSummary(entry));
-  const duration = toolDurationText(entry);
-  const summary = compactToolSummary(entry, width);
-  const summaryText = summary && entry.status !== 'running' ? collapseToSingleLine(summary.text) : '';
-  const sep = `  ${ansi.dim('·')}  `;
-  const chevron = summary?.expandable ? ` ${ansi.dim('›')}` : '';
   const head = `${toolDisc(entry)} ${entry.title ?? entry.toolName}`;
-  return [fitLine(assembleCompactToolRow(head, inputSummary, duration, summaryText, sep, chevron, width), width)];
+  const annotation = compactAnnotation(entry);
+  return [fitLine(assembleCompactToolRow(head, inputSummary, annotation.text, width, annotation.protect), width)];
 }
 
 /**
- * Lay out `head  input  ·  duration  ·  summary chevron` on one line, keeping
- * the head, duration segment, and chevron (the status-carrying parts) intact
- * and truncating only the flexible input/summary text when the row overflows.
- * Input is truncated before summary so a long command keeps its elapsed time.
+ * Build the `(part · part)` annotation for a compact row: duration/status
+ * first, then the outcome. While running only the duration part shows
+ * (`(running 12s)`). A placeholder outcome (`no output`) appears only when it
+ * would be the annotation's sole content — `(5s)` needs no silence disclaimer.
+ * `protect` reports whether every part is a fixed shape (durations always
+ * are): only protected annotations are reserved whole during truncation.
  */
-function assembleCompactToolRow(
-  head: string,
-  input: string,
-  duration: string,
-  summary: string,
-  sep: string,
-  chevron: string,
-  width: number,
-): string {
+function compactAnnotation(entry: MakaPiToolEntry): { text: string; protect: boolean } {
+  const parts: string[] = [];
+  const duration = toolDurationText(entry);
+  if (duration) parts.push(duration);
+  let protect = true;
+  if (entry.status !== 'running') {
+    const summary = compactToolSummary(entry);
+    if (summary && !(summary.placeholder && parts.length > 0)) {
+      parts.push(collapseToSingleLine(summary.text));
+      protect = summary.protect === true;
+    }
+  }
+  return { text: parts.length > 0 ? `(${parts.join(' · ')})` : '', protect };
+}
+
+/** A protected annotation at or below this visible width is reserved whole when the row overflows. */
+const COMPACT_ANNOTATION_RESERVE = 30;
+
+/**
+ * Lay out `head  target (annotation)` on one line. The head and a short
+ * protected annotation are preserved whole; the free-text target truncates
+ * first, so a long command can never hide an exit code. An unprotected
+ * annotation (a generic first result line) is never reserved — it takes
+ * whatever the target leaves.
+ */
+function assembleCompactToolRow(head: string, input: string, annotation: string, width: number, protect: boolean): string {
   const inputSeg = input ? `  ${input}` : '';
-  const durSeg = duration ? `${sep}${duration}` : '';
-  const sumSeg = summary ? `${sep}${summary}` : '';
-  const full = `${head}${inputSeg}${durSeg}${sumSeg}${chevron}`;
+  const annSeg = annotation ? ` ${annotation}` : '';
+  const full = `${head}${inputSeg}${annSeg}`;
   if (visibleWidth(full) <= width) return full;
-  // Overflow: reserve head + duration + chevron, then fit input before summary.
-  // Input joins the name with two spaces; duration and summary join with `·`.
-  let budget = Math.max(0, width - visibleWidth(`${head}${durSeg}${chevron}`));
+  // The cap is measured on the annotation alone; the joining space is still
+  // budgeted below, so an annotation exactly at the cap is kept whole.
+  const reserved = protect && visibleWidth(annotation) <= COMPACT_ANNOTATION_RESERVE;
+  const budget = Math.max(0, width - visibleWidth(head) - (reserved ? visibleWidth(annSeg) : 0));
   let builtInput = '';
-  let builtSummary = '';
   if (input && budget > 3) {
     const room = budget - 2;
-    const text = visibleWidth(input) > room ? truncateToWidth(input, room, '…') : input;
-    builtInput = `  ${text}`;
-    budget -= visibleWidth(builtInput);
+    builtInput = `  ${visibleWidth(input) > room ? truncateToWidth(input, room, '…') : input}`;
   }
-  const sepW = visibleWidth(sep);
-  if (summary && budget > sepW + 1) {
-    const room = budget - sepW;
-    const text = visibleWidth(summary) > room ? truncateToWidth(summary, room, '…') : summary;
-    builtSummary = `${sep}${text}`;
+  if (reserved) return `${head}${builtInput}${annSeg}`;
+  let builtAnnotation = '';
+  const leftover = budget - visibleWidth(builtInput);
+  if (annotation && leftover > 1) {
+    builtAnnotation = ` ${visibleWidth(annotation) > leftover ? truncateToWidth(annotation, leftover, '…') : annotation}`;
   }
-  return `${head}${builtInput}${durSeg}${builtSummary}${chevron}`;
+  return `${head}${builtInput}${builtAnnotation}`;
 }
 
 function renderExpandedToolBlock(entry: MakaPiToolEntry, width: number): string[] {
   const duration = toolDurationText(entry);
   let header = `${toolDisc(entry)} ${entry.title ?? entry.toolName}`;
-  if (duration) header += `  ${ansi.dim('·')}  ${duration}`;
+  if (duration) header += ` (${duration})`;
   const lines = [fitLine(header, width)];
 
   const inputSummary = toolInputSummary(entry);
@@ -143,124 +165,112 @@ function renderExpandedToolBlock(entry: MakaPiToolEntry, width: number): string[
 
 interface CompactToolSummary {
   text: string;
-  /** True when expanding would reveal more than this one-line summary. */
-  expandable: boolean;
+  /** Placeholder shown only when the annotation would otherwise be empty (`no output`). */
+  placeholder?: boolean;
+  /**
+   * Fixed-shape outcome (a count, size, diff tally, or exit status) eligible
+   * for whole-annotation reservation when the row overflows. Free text — the
+   * generic first-line fallback or a WriteStdin operation echo — is never
+   * reserved, so it cannot push the command off the row.
+   */
+  protect?: boolean;
 }
 
-function compactToolSummary(entry: MakaPiToolEntry, width: number): CompactToolSummary | undefined {
-  const hasLiveOutput = entry.outputDeltas.length > 0 || entry.progress.length > 0;
+function noOutput(): CompactToolSummary {
+  return { text: ansi.dim('no output'), placeholder: true, protect: true };
+}
+
+function linesText(count: number): string {
+  return `${count} line${count === 1 ? '' : 's'}`;
+}
+
+/**
+ * Combined line count for a pipes result. Each stream is counted after
+ * trimming its own trailing newlines and the counts are summed — joining the
+ * streams first would invent a line at the boundary (`out\n` + `err\n` is
+ * two lines, not three).
+ */
+function pipeOutputLineCount(output: { stdout?: string; stderr?: string }): number {
+  let count = 0;
+  for (const stream of [output.stdout, output.stderr]) {
+    const trimmed = stream?.replace(/\n+$/, '');
+    if (trimmed) count += trimmed.split('\n').length;
+  }
+  return count;
+}
+
+function compactToolSummary(entry: MakaPiToolEntry): CompactToolSummary | undefined {
   const result = entry.result;
   if (result?.kind === 'shell_run') {
     if (entry.toolName === 'WriteStdin') {
-      return {
-        text: formatPtyControlOperation(result.operation, entry.input),
-        expandable: result.operation?.kind === 'pty_control' && result.operation.failed,
-      };
+      return { text: formatPtyControlOperation(result.operation, entry.input) };
     }
-    const latest = result.output?.mode === 'pty'
-      ? ptyCompactTerminalLine(result.output)
-      : result.output?.mode === 'pipes'
-        ? result.output.latestStream
-          ? lastNonEmptyLine(result.output[result.output.latestStream])
-          : lastNonEmptyLine([result.output.stdout, result.output.stderr].filter(Boolean).join('\n'))
-        : '';
-    if (latest) return { text: latest, expandable: true };
-    return {
-      text: entry.status === 'detached'
-        ? ansi.dim('(owned by source session)')
-        : entry.status === 'unavailable'
-          ? ansi.dim('(source session unavailable)')
-        : result.status === 'running'
-          ? ansi.dim('(waiting for output)')
-          : ansi.dim('(no output)'),
-      expandable: true,
-    };
-  }
-  if (entry.status === 'running' && hasLiveOutput) {
-    const live = latestLiveOutputLine(entry);
-    if (live) return { text: live, expandable: true };
+    // A settled background run reports its outcome, not its output: the status
+    // and exit code are the signal, the stream body lives in the expanded card.
+    if (result.status !== 'running' && result.status !== 'completed') {
+      const parts: string[] = [result.status];
+      if (result.exitCode !== undefined) parts.push(`exit ${result.exitCode}`);
+      return { text: ansi.red(parts.join(' · ')), protect: true };
+    }
+    if (result.output?.mode === 'pty') {
+      const rows = ptyTuiTerminalRows(result.output).length;
+      return rows > 0 ? { text: linesText(rows), protect: true } : noOutput();
+    }
+    if (result.output?.mode === 'pipes') {
+      const lines = pipeOutputLineCount(result.output);
+      if (lines > 0) return { text: linesText(lines), protect: true };
+    }
+    return noOutput();
   }
 
-  if (result?.kind === 'terminal') return compactTerminalSummary(result, hasLiveOutput);
+  if (result?.kind === 'terminal') return compactTerminalSummary(result);
   if (result?.kind === 'file_diff') return compactDiffSummary(result);
   if (result?.kind === 'file_write') {
-    return { text: `Wrote ${result.bytes} bytes to ${result.path}`, expandable: hasLiveOutput };
+    // The path is already the card's input summary; the result adds only size.
+    return { text: `${result.bytes} bytes`, protect: true };
   }
 
   if (entry.toolName === 'Grep') {
     const count = jsonArrayCount(entry, 'matches');
-    if (count !== undefined) {
-      return {
-        text: `${count} match${count === 1 ? '' : 'es'}`,
-        expandable: count > 0 || hasLiveOutput,
-      };
-    }
+    if (count !== undefined) return { text: `${count} match${count === 1 ? '' : 'es'}`, protect: true };
   }
 
   if (entry.toolName === 'Glob') {
     const count = jsonArrayCount(entry, 'files');
-    if (count !== undefined) {
-      return {
-        text: `${count} file${count === 1 ? '' : 's'}`,
-        expandable: count > 0 || hasLiveOutput,
-      };
-    }
+    if (count !== undefined) return { text: `${count} file${count === 1 ? '' : 's'}`, protect: true };
   }
 
   const text = plainResultText(entry);
   if (!text) return undefined;
   // Only a successful filesystem Read that carries real file content gets the
-  // line/byte summary — the same guard the expanded card uses. A runtime
+  // line summary — the same guard the expanded card uses. A runtime
   // resource, errored, or archived Read falls through to the generic first-line
   // summary so its status shows instead of a fabricated count.
   if (entry.toolName === 'Read'
     && entry.status !== 'error'
     && isFilesystemReadPath(entry)
     && isReadBodyResult(result)) {
-    const lineCount = readBodyLineCount(text);
-    return {
-      text: `${lineCount} line${lineCount === 1 ? '' : 's'}, ${byteLength(text)} bytes`,
-      expandable: true,
-    };
+    return { text: linesText(readBodyLineCount(text)), protect: true };
   }
-  const firstLine = text.split('\n', 1)[0] ?? '';
-  return {
-    text: firstLine,
-    expandable: text.includes('\n') || hasLiveOutput || firstLine.length + 2 > width,
-  };
+  // The generic first-line fallback is free text, never reserved: the command
+  // a user ran says more than one truncated line of what came back.
+  return { text: text.split('\n', 1)[0] ?? '' };
 }
 
 function compactTerminalSummary(
   content: Extract<ToolResultContent, { kind: 'terminal' }>,
-  hasLiveOutput: boolean,
 ): CompactToolSummary {
-  const hasOutput = content.output.mode === 'pty'
-    ? Boolean(ptyCompactTerminalLine(content.output))
-    : Boolean(content.output.stdout || content.output.stderr);
   if (content.status !== 'completed') {
-    const detail = content.output.mode === 'pipes'
-      ? lastNonEmptyLine(content.output.stderr)
-      : ptyCompactTerminalLine(content.output);
-    const status = ansi.red(content.exitCode === undefined ? content.status : `exit ${content.exitCode}`);
-    return {
-      text: detail ? `${status} ${detail}` : status,
-      expandable: hasOutput || hasLiveOutput,
-    };
+    // The exit code is the whole signal on a failed row; the error text lives
+    // in the expanded card.
+    return { text: ansi.red(content.exitCode === undefined ? content.status : `exit ${content.exitCode}`), protect: true };
   }
   if (content.output.mode === 'pty') {
-    const latest = ptyCompactTerminalLine(content.output);
-    return latest
-      ? { text: latest, expandable: true }
-      : { text: ansi.dim('(no output)'), expandable: hasLiveOutput };
+    const rows = ptyTuiTerminalRows(content.output).length;
+    return rows > 0 ? { text: linesText(rows), protect: true } : noOutput();
   }
-  const combined = [content.output.stdout, content.output.stderr].filter(Boolean).join('\n').replace(/\n+$/, '');
-  if (!combined) return { text: ansi.dim('(no output)'), expandable: hasLiveOutput };
-  const totalLines = combined.split('\n').length;
-  const prefix = totalLines > 1 ? ansi.dim(`(${totalLines} lines) `) : '';
-  return {
-    text: `${prefix}${lastNonEmptyLine(combined)}`,
-    expandable: totalLines > 1 || hasLiveOutput,
-  };
+  const lines = pipeOutputLineCount(content.output);
+  return lines > 0 ? { text: linesText(lines), protect: true } : noOutput();
 }
 
 function compactDiffSummary(
@@ -273,11 +283,8 @@ function compactDiffSummary(
     if (kind === 'add') adds += 1;
     else if (kind === 'del') dels += 1;
   }
-  const path = content.paths[0];
-  return {
-    text: `${ansi.green(`+${adds}`)} ${ansi.red(`-${dels}`)}${path ? ` ${path}` : ''}`,
-    expandable: true,
-  };
+  // The path is already the card's input summary; the tally is the outcome.
+  return { text: `${ansi.green(`+${adds}`)} ${ansi.red(`-${dels}`)}`, protect: true };
 }
 
 /**
@@ -294,25 +301,6 @@ function jsonArrayCount(entry: MakaPiToolEntry, key: string): number | undefined
     if (Array.isArray(rows)) return rows.length;
   }
   return undefined;
-}
-
-/** Latest non-empty output line from live deltas (redaction-aware), else progress. */
-function latestLiveOutputLine(entry: MakaPiToolEntry): string {
-  const groups = groupOutputDeltas(entry.outputDeltas.values());
-  if (groups.length > 0) {
-    const fromDeltas = lastNonEmptyLine(groups.map((group) => group.text).join('\n'));
-    if (fromDeltas) return fromDeltas;
-  }
-  return lastNonEmptyLine(entry.progress.values().join(''));
-}
-
-function lastNonEmptyLine(text: string): string {
-  const lines = text.split('\n');
-  for (let i = lines.length - 1; i >= 0; i -= 1) {
-    const line = lines[i];
-    if (line && line.trim()) return line;
-  }
-  return '';
 }
 
 function renderToolText(text: string, width: number): string[] {
@@ -676,7 +664,12 @@ function toolInputSummary(entry: MakaPiToolEntry): string {
     case 'Bash': {
       const command = obj?.command;
       if (typeof command === 'string' && command.trim()) {
-        return `$ ${command.split('\n')[0]}`;
+        // Agents often lead with `#` comment lines; the row names what the
+        // command does, so show the first real command line when one exists.
+        const firstRealLine = command.split('\n')
+          .map((line) => line.trim())
+          .find((line) => line !== '' && !line.startsWith('#'));
+        return `$ ${firstRealLine ?? command.split('\n')[0]!.trim()}`;
       }
       break;
     }

--- a/packages/cli/src/tui-ansi.ts
+++ b/packages/cli/src/tui-ansi.ts
@@ -36,13 +36,20 @@ export function _detectColorLevelForTesting(env: {
 export let ansi = buildAnsi();
 
 // #1053: status disc — a single `●` tinted by tone. The shared visual primitive
-// for the transcript's tool rows: muted = done, accent = running, danger = error.
-export type DiscTone = 'muted' | 'accent' | 'danger';
+// for the transcript's tool rows: ok = done, accent = running, danger = error,
+// muted = detached/unavailable (neither a success nor a failure of this session).
+export type DiscTone = 'ok' | 'muted' | 'accent' | 'danger';
 
 const DISC_GLYPH = '●';
 
 export function disc(tone: DiscTone): string {
-  const color = tone === 'muted' ? ansi.muted : tone === 'accent' ? ansi.accent : ansi.red;
+  const color = tone === 'ok'
+    ? ansi.green
+    : tone === 'muted'
+      ? ansi.muted
+      : tone === 'accent'
+        ? ansi.accent
+        : ansi.red;
   return color(DISC_GLYPH);
 }
 


### PR DESCRIPTION
## Summary

The TUI's compact tool rows were hard to scan: status lived only on a tiny grey disc (so failures hid in a wall of identical rows), and every row carried long variable content — the command's last output line, `0s` durations, `#` comment lines — that overflowed the terminal width.

The compact row is now a single fixed grammar: `● Tool  target (annotation)`.

```
● Grep  contextRemaining in packages/runtime/src (5 matches)
● Read  packages/runtime/src/runtime-kernel.ts offset 210 limit 60 (60 lines)
● Bash  $ grep -n "contextRemaining" packages/core/src/events.ts (3 lines)
● Bash  $ npm test (running 12s)
● Edit  packages/core/src/events.ts (+12 -3)
● Bash  $ grep -rn "x" src/ (exit 1)
```

- **Status color on the disc**: green = done, blue = running, red = failed/aborted, grey = detached/unavailable. Done was grey before, indistinguishable from chrome.
- **No separator or expand marker**: the parenthesized annotation's fixed shapes (counts, sizes, `+A -D`, `exit N`, `running Ns`, `no output`) already delimit the outcome and say whether there is anything to expand — the same convention opencode uses (`Glob "**/*db*" in src (6 matches)`).
- **No output content on the row**: successful Bash shows a line count, failures show a red `(exit N)`; output lives in the expanded card. Bash rows also show the first real command line instead of a leading `#` comment.
- **No `0s`**: sub-second durations are omitted.
- **No duplication**: Read drops bytes (still in the expanded card), Write/Edit drop the path already shown as the target.
- **Truncation protects the outcome**: short annotations are reserved whole when a row overflows, so a long command can never hide an exit code.

Expanded cards are unchanged except the header follows the same grammar (`● Bash (5s)`).

## Verification

- `npm run build && node --test "dist/**/*.test.js"` in `packages/cli`: 406 pass, 0 fail (updated the assertions that locked the old grammar, including two runner tests that observed output content on the compact row; intent re-locked on the new observables).
- `biome lint` on the changed files: clean.
- Rendered a representative transcript through `renderMakaPiTranscript` and inspected raw ANSI: green/blue/red discs per status, `(+12 -3)` keeps its green/red counts, and a long failing command truncates to `…` while the red `(exit 1)` survives at the end of the row.
- One external review round (codex): four findings fixed with regression tests — an annotation exactly at the 30-column reserve cap is now kept whole (the cap is measured without the joining space), sub-second durations are gated on raw milliseconds so 999ms no longer renders as `1s`, stdout/stderr line counts are summed per stream instead of inventing a boundary line, and only fixed-shape annotations are reserved (a generic first-line outcome now yields to the target instead of pushing it off the row). One finding deferred: below roughly `head + annotation` width the row can still clip the annotation — that needs a product policy for pathological widths, not a code guess.

Did not run: desktop E2E (TUI-only change; `packages/cli` is not exercised by `apps/desktop`).

<img width="2037" height="1119" alt="image" src="https://github.com/user-attachments/assets/c8b6d907-6803-4528-a9e6-d544629206c7" />
