### PR TITLE
fix(headless): force durable deadline settlement

### DIFF
--- a/packages/headless/harbor/run-host-cell.mjs
+++ b/packages/headless/harbor/run-host-cell.mjs
@@ -9,6 +9,7 @@ import {
   buildHarborCellContextBudgetPolicySnapshot,
   buildHarborCellContinuationPolicy,
   buildHarborCellTaskLedgerExperimentPolicy,
+  createHarborHttpToolExecutor,
   harborCellMaxStepsFromEnv,
   harborCellSoftTimeoutMsFromEnv,
   normalizeHarborCellContextEnv,
@@ -79,7 +80,7 @@ export async function main(options = {}) {
     realBackendIsolation: {
       kind: 'external',
       label: 'Harbor task container via host adapter',
-      toolExecutor: httpToolExecutor(env),
+      toolExecutor: createHarborHttpToolExecutor(env),
     },
     now,
     newId,
@@ -126,33 +127,6 @@ async function hostApiKey(env) {
   throw new Error('MAKA_HOST_API_KEY_FILE is required for host-side Harbor cells');
 }
 
-function httpToolExecutor(env) {
-  const baseUrl = requiredEnv(env, 'MAKA_HARBOR_TOOL_EXECUTOR_URL');
-  const token = requiredEnv(env, 'MAKA_HARBOR_TOOL_EXECUTOR_TOKEN');
-  return {
-    exec: async (input) => {
-      const response = await fetch(new URL('/exec', baseUrl), {
-        method: 'POST',
-        headers: {
-          authorization: `Bearer ${token}`,
-          'content-type': 'application/json',
-        },
-        body: JSON.stringify(input),
-      });
-      const body = await response.text();
-      if (!response.ok) {
-        return { exitCode: 1, stdout: '', stderr: body };
-      }
-      const parsed = JSON.parse(body);
-      return {
-        exitCode: Number.isInteger(parsed.exitCode) ? parsed.exitCode : 1,
-        stdout: typeof parsed.stdout === 'string' ? parsed.stdout : '',
-        stderr: typeof parsed.stderr === 'string' ? parsed.stderr : '',
-      };
-    },
-  };
-}
-
 async function instructionFromEnv(env) {
   if (env.MAKA_INSTRUCTION !== undefined) return env.MAKA_INSTRUCTION;
   if (env.MAKA_INSTRUCTION_FILE) return await readFile(env.MAKA_INSTRUCTION_FILE, 'utf8');
@@ -167,12 +141,6 @@ function providerFromModel(rawModel) {
 function stripProvider(rawModel, provider) {
   const prefix = `${provider}/`;
   return rawModel.startsWith(prefix) ? rawModel.slice(prefix.length) : rawModel;
-}
-
-function requiredEnv(env, name) {
-  const value = env[name];
-  if (!value) throw new Error(`${name} is required`);
-  return value;
 }
 
 function randomId() {

--- a/packages/headless/src/__tests__/harbor-cell.test.ts
+++ b/packages/headless/src/__tests__/harbor-cell.test.ts
@@ -682,14 +682,14 @@ describe('runHarborCell', () => {
         cwd: workspaceDir,
         outputDir,
         storageRoot,
-        settleAfterMs: 20,
         registerBackends: (registry) => {
           registry.register('fake', (ctx) => {
-            backend = new NonCooperativeDeadlineBackend(ctx.sessionId);
+            backend = new NonCooperativeDeadlineBackend(ctx.sessionId, 'fake', 5_000);
             return backend;
           });
         },
-      }), 250, 'Harbor cell did not force-stop before the hard deadline');
+        settleAfterMs: 1_000,
+      }), 3_000, 'Harbor cell did not force-stop before the hard deadline');
 
       assert.equal(result.settledByDeadline, true);
       assert.deepEqual(backend?.stopModes, ['immediate']);
@@ -708,7 +708,7 @@ describe('runHarborCell', () => {
       const fallback = new Promise<IsolatedCommandResult>((resolve) => {
         releaseFallback = () => resolve({ exitCode: 0, stdout: '', stderr: '' });
       });
-      const fallbackTimer = setTimeout(releaseFallback, 500);
+      const fallbackTimer = setTimeout(releaseFallback, 5_000);
       const executor: IsolatedToolExecutor = {
         exec: async (_input, control) => {
           const signal = control?.abortSignal;
@@ -724,7 +724,7 @@ describe('runHarborCell', () => {
         cwd: workspaceDir,
         outputDir,
         storageRoot,
-        settleAfterMs: 20,
+        settleAfterMs: 1_000,
         realBackendIsolation: {
           kind: 'external',
           label: 'cancellable test executor',
@@ -737,7 +737,7 @@ describe('runHarborCell', () => {
             return backend;
           });
         },
-      }), 250, 'Harbor cell did not cancel its active isolated tool');
+      }), 3_000, 'Harbor cell did not cancel its active isolated tool');
       clearTimeout(fallbackTimer);
 
       assert.equal(result.settledByDeadline, true);

--- a/packages/headless/src/__tests__/harbor-cell.test.ts
+++ b/packages/headless/src/__tests__/harbor-cell.test.ts
@@ -164,6 +164,48 @@ class DeadlineSettlingBackend implements AgentBackend {
   async dispose(): Promise<void> {}
 }
 
+class NonCooperativeDeadlineBackend implements AgentBackend {
+  readonly sessionId: string;
+  readonly stopModes: BackendStopMode[] = [];
+  private releaseStop!: () => void;
+  private readonly stopped = new Promise<void>((resolve) => {
+    this.releaseStop = resolve;
+  });
+  private readonly fallback: NodeJS.Timeout;
+
+  constructor(sessionId: string, readonly kind: BackendKind = 'fake', fallbackAfterMs = 500) {
+    this.sessionId = sessionId;
+    this.fallback = setTimeout(() => this.releaseStop(), fallbackAfterMs);
+  }
+
+  async *send(input: BackendSendInput): AsyncIterable<SessionEvent> {
+    const ts = Date.now();
+    yield {
+      type: 'token_usage',
+      id: 'usage-before-forced-deadline',
+      turnId: input.turnId,
+      ts,
+      input: 13,
+      output: 5,
+      total: 18,
+      costUsd: 0.004,
+    };
+    await this.stopped;
+    yield { type: 'abort', id: 'forced-deadline-abort', turnId: input.turnId, ts: Date.now(), reason: 'user_stop' };
+    yield { type: 'complete', id: 'forced-deadline-complete', turnId: input.turnId, ts: Date.now(), stopReason: 'user_stop' };
+  }
+
+  async stop(_reason: 'user_stop' | 'redirect', mode: BackendStopMode = 'immediate'): Promise<void> {
+    this.stopModes.push(mode);
+    if (mode !== 'immediate') return;
+    clearTimeout(this.fallback);
+    this.releaseStop();
+  }
+
+  async respondToPermission(_decision: PermissionDecision): Promise<void> {}
+  async dispose(): Promise<void> {}
+}
+
 class TerminalClaimBeforeDeadlineBackend implements AgentBackend {
   readonly kind = 'fake' as const;
   readonly sessionId: string;
@@ -568,7 +610,39 @@ describe('runHarborCell', () => {
       }), 10_000, 'Harbor cell did not settle before the hard deadline');
 
       assert.equal(result.settledByDeadline, true);
-      assert.deepEqual(backend?.stopModes, ['after_step']);
+      assert.deepEqual(backend?.stopModes, ['immediate']);
+      assert.equal(result.output.tokenSummary?.total, 18);
+      assert.deepEqual(result.output.deadlineSettlement, {
+        source: 'benchmark.deadline',
+        mode: 'immediate',
+      });
+      assert.deepEqual(
+        JSON.parse(await readFile(join(outputDir, HARBOR_CELL_OUTPUT_FILENAME), 'utf8')),
+        result.output,
+      );
+    });
+  });
+
+  test('force-stops a non-cooperative active step and writes final usage before the hard deadline', async () => {
+    await withDirs(async ({ workspaceDir, outputDir, storageRoot }) => {
+      let backend: NonCooperativeDeadlineBackend | undefined;
+      const result = await withTimeout(runHarborCell({
+        config,
+        instruction: 'keep working until force-stopped',
+        cwd: workspaceDir,
+        outputDir,
+        storageRoot,
+        settleAfterMs: 20,
+        registerBackends: (registry) => {
+          registry.register('fake', (ctx) => {
+            backend = new NonCooperativeDeadlineBackend(ctx.sessionId);
+            return backend;
+          });
+        },
+      }), 250, 'Harbor cell did not force-stop before the hard deadline');
+
+      assert.equal(result.settledByDeadline, true);
+      assert.deepEqual(backend?.stopModes, ['immediate']);
       assert.equal(result.output.tokenSummary?.total, 18);
       assert.deepEqual(
         JSON.parse(await readFile(join(outputDir, HARBOR_CELL_OUTPUT_FILENAME), 'utf8')),
@@ -1310,7 +1384,7 @@ describe('runHarborCell', () => {
     });
   });
 
-  test('host-side Harbor cell returns after settling at its soft deadline', async () => {
+  test('host-side Harbor cell force-stops a non-cooperative step at its soft deadline', async () => {
     const { main } = await import(new URL('../../harbor/run-host-cell.mjs', import.meta.url).href) as {
       main: (options?: { registerBackends?: (registry: BackendRegistry) => void }) => Promise<unknown>;
     };
@@ -1329,13 +1403,17 @@ describe('runHarborCell', () => {
         process.env.MAKA_CELL_SOFT_TIMEOUT_MS = '1000';
         const result = await withTimeout(main({
           registerBackends: (registry) => {
-            registry.register('ai-sdk', (ctx) => new DeadlineSettlingBackend(ctx.sessionId, 'ai-sdk'));
+            registry.register('ai-sdk', (ctx) => new NonCooperativeDeadlineBackend(ctx.sessionId, 'ai-sdk', 2_000));
           },
         }), 10_000, 'host cell did not honor its soft deadline');
 
         assert.equal(Reflect.get(result as object, 'settledByDeadline'), true);
         const output = JSON.parse(await readFile(join(outputDir, HARBOR_CELL_OUTPUT_FILENAME), 'utf8'));
         assert.equal(output.tokenSummary.total, 18);
+        assert.deepEqual(output.deadlineSettlement, {
+          source: 'benchmark.deadline',
+          mode: 'immediate',
+        });
       } finally {
         process.env = previousEnv;
       }

--- a/packages/headless/src/__tests__/harbor-cell.test.ts
+++ b/packages/headless/src/__tests__/harbor-cell.test.ts
@@ -19,7 +19,7 @@ import {
 } from '@maka/runtime';
 import { createArtifactStore } from '@maka/storage';
 import type { Config } from '../contracts.js';
-import type { HeadlessBackendContext, IsolatedToolExecutor } from '../isolation.js';
+import type { HeadlessBackendContext, IsolatedCommandResult, IsolatedToolExecutor } from '../isolation.js';
 import {
   buildAiSdkCellBackendRegistration,
   buildHarborCellContextBudgetBackendOptions,
@@ -28,6 +28,7 @@ import {
   buildHarborCellTaskLedgerExperimentPolicy,
   harborCellMaxStepsFromEnv,
   createHarborCellLocalToolExecutor,
+  createHarborHttpToolExecutor,
   HARBOR_CELL_CONTEXT_ENV_KEYS,
   HARBOR_CELL_OUTPUT_FILENAME,
   HARBOR_CELL_RUNTIME_EVENTS_FILENAME,
@@ -37,6 +38,7 @@ import {
   runHarborCell,
   writeHarborCellUsageCheckpoint,
 } from '../harbor-cell.js';
+import { buildIsolatedBashTool } from '../tools.js';
 
 const config: Config = {
   id: 'cell-cfg',
@@ -200,6 +202,54 @@ class NonCooperativeDeadlineBackend implements AgentBackend {
     if (mode !== 'immediate') return;
     clearTimeout(this.fallback);
     this.releaseStop();
+  }
+
+  async respondToPermission(_decision: PermissionDecision): Promise<void> {}
+  async dispose(): Promise<void> {}
+}
+
+class ActiveIsolatedToolDeadlineBackend implements AgentBackend {
+  readonly kind: BackendKind = 'ai-sdk';
+  readonly stopModes: BackendStopMode[] = [];
+  private readonly controller = new AbortController();
+
+  constructor(
+    readonly sessionId: string,
+    private readonly executor: IsolatedToolExecutor,
+  ) {}
+
+  async *send(input: BackendSendInput): AsyncIterable<SessionEvent> {
+    const ts = Date.now();
+    yield {
+      type: 'token_usage',
+      id: 'usage-before-active-tool-deadline',
+      turnId: input.turnId,
+      ts,
+      input: 13,
+      output: 5,
+      total: 18,
+      costUsd: 0.004,
+    };
+    const tool = buildIsolatedBashTool(this.executor);
+    try {
+      await tool.impl({ command: 'sleep until cancelled' }, {
+        sessionId: this.sessionId,
+        turnId: input.turnId,
+        cwd: '/workspace',
+        toolCallId: 'active-bash-call',
+        abortSignal: this.controller.signal,
+        emitOutput: () => {},
+      });
+    } catch (error) {
+      if (!this.controller.signal.aborted) throw error;
+    }
+    yield { type: 'abort', id: 'active-tool-deadline-abort', turnId: input.turnId, ts: Date.now(), reason: 'user_stop' };
+    yield { type: 'complete', id: 'active-tool-deadline-complete', turnId: input.turnId, ts: Date.now(), stopReason: 'user_stop' };
+  }
+
+  async stop(_reason: 'user_stop' | 'redirect', mode: BackendStopMode = 'immediate'): Promise<void> {
+    this.stopModes.push(mode);
+    if (mode === 'immediate') this.controller.abort();
   }
 
   async respondToPermission(_decision: PermissionDecision): Promise<void> {}
@@ -648,6 +698,55 @@ describe('runHarborCell', () => {
         JSON.parse(await readFile(join(outputDir, HARBOR_CELL_OUTPUT_FILENAME), 'utf8')),
         result.output,
       );
+    });
+  });
+
+  test('force-stops an active isolated tool and writes final artifacts before the hard deadline', async () => {
+    await withDirs(async ({ workspaceDir, outputDir, storageRoot }) => {
+      let backend: ActiveIsolatedToolDeadlineBackend | undefined;
+      let releaseFallback!: () => void;
+      const fallback = new Promise<IsolatedCommandResult>((resolve) => {
+        releaseFallback = () => resolve({ exitCode: 0, stdout: '', stderr: '' });
+      });
+      const fallbackTimer = setTimeout(releaseFallback, 500);
+      const executor: IsolatedToolExecutor = {
+        exec: async (_input, control) => {
+          const signal = control?.abortSignal;
+          if (!signal) return await fallback;
+          return await new Promise<IsolatedCommandResult>((_resolve, reject) => {
+            signal.addEventListener('abort', () => reject(signal.reason), { once: true });
+          });
+        },
+      };
+      const result = await withTimeout(runHarborCell({
+        config: { ...config, backend: 'ai-sdk' },
+        instruction: 'run a tool until force-stopped',
+        cwd: workspaceDir,
+        outputDir,
+        storageRoot,
+        settleAfterMs: 20,
+        realBackendIsolation: {
+          kind: 'external',
+          label: 'cancellable test executor',
+          toolExecutor: executor,
+        },
+        registerBackends: (registry, context) => {
+          if (!context.toolExecutor) throw new Error('missing isolated tool executor');
+          registry.register('ai-sdk', (ctx) => {
+            backend = new ActiveIsolatedToolDeadlineBackend(ctx.sessionId, context.toolExecutor!);
+            return backend;
+          });
+        },
+      }), 250, 'Harbor cell did not cancel its active isolated tool');
+      clearTimeout(fallbackTimer);
+
+      assert.equal(result.settledByDeadline, true);
+      assert.deepEqual(backend?.stopModes, ['immediate']);
+      assert.equal(result.output.tokenSummary?.total, 18);
+      assert.deepEqual(result.output.deadlineSettlement, {
+        source: 'benchmark.deadline',
+        mode: 'immediate',
+      });
     });
   });
 
@@ -3508,7 +3607,66 @@ setTimeout(() => {
 
 });
 
+describe('createHarborHttpToolExecutor', () => {
+  test('forwards active-tool cancellation to fetch without serializing execution control', async () => {
+    const previousFetch = globalThis.fetch;
+    const controller = new AbortController();
+    let observedSignal: AbortSignal | null | undefined;
+    let observedBody: unknown;
+    try {
+      globalThis.fetch = async (_input, init) => {
+        observedSignal = init?.signal;
+        observedBody = JSON.parse(String(init?.body));
+        return new Response(JSON.stringify({ exitCode: 0, stdout: 'ok', stderr: '' }), { status: 200 });
+      };
+      const executor = createHarborHttpToolExecutor({
+        MAKA_HARBOR_TOOL_EXECUTOR_URL: 'http://127.0.0.1:1',
+        MAKA_HARBOR_TOOL_EXECUTOR_TOKEN: 'test-token',
+      });
+
+      await executor.exec(
+        { command: 'sleep until cancelled', cwd: '/workspace' },
+        { abortSignal: controller.signal },
+      );
+
+      assert.equal(observedSignal, controller.signal);
+      assert.deepEqual(observedBody, {
+        command: 'sleep until cancelled',
+        cwd: '/workspace',
+      });
+    } finally {
+      globalThis.fetch = previousFetch;
+    }
+  });
+});
+
 describe('createHarborCellLocalToolExecutor', () => {
+  test('cancels a bounded-tail Bash command when the active tool is aborted', async () => {
+    const executor = createHarborCellLocalToolExecutor({ MAKA_CELL_COMMAND_TIMEOUT_MS: '10000' });
+    const controller = new AbortController();
+    const run = executor.exec(
+      { command: 'sleep 1', cwd: process.cwd(), boundedTail: true },
+      { abortSignal: controller.signal },
+    );
+    setTimeout(() => controller.abort(), 20);
+
+    const result = await withTimeout(run, 250, 'local isolated command ignored tool cancellation');
+    assert.notEqual(result.exitCode, 0);
+  });
+
+  test('cancels a full-output file command when the active tool is aborted', async () => {
+    const executor = createHarborCellLocalToolExecutor({ MAKA_CELL_COMMAND_TIMEOUT_MS: '10000' });
+    const controller = new AbortController();
+    const run = executor.exec(
+      { command: 'sleep 1', cwd: process.cwd() },
+      { abortSignal: controller.signal },
+    );
+    setTimeout(() => controller.abort(), 20);
+
+    const result = await withTimeout(run, 250, 'local isolated file command ignored tool cancellation');
+    assert.notEqual(result.exitCode, 0);
+  });
+
   test('lets MAKA_CELL_COMMAND_TIMEOUT_MS lower the default per-command timeout', async () => {
     const executor = createHarborCellLocalToolExecutor({ MAKA_CELL_COMMAND_TIMEOUT_MS: '50' });
     const result = await executor.exec({ command: 'sleep 1', cwd: process.cwd() });

--- a/packages/headless/src/__tests__/tools.test.ts
+++ b/packages/headless/src/__tests__/tools.test.ts
@@ -210,6 +210,23 @@ describe('isolated headless tools', () => {
     );
   });
 
+  test('command-backed file tools forward active-turn cancellation to the isolated executor', async () => {
+    const seenSignals: Array<AbortSignal | undefined> = [];
+    const tools = buildIsolatedHeadlessTools({
+      async exec(_input, control) {
+        seenSignals.push(control?.abortSignal);
+        return { exitCode: 0, stdout: '', stderr: '' };
+      },
+    });
+    const ctx = toolCtx('/workspace');
+
+    await tool(tools, 'Read').impl({ path: 'src/f.txt' }, ctx);
+    await tool(tools, 'Glob').impl({ pattern: '**/*.txt' }, ctx);
+    await tool(tools, 'Grep').impl({ pattern: 'hello' }, ctx);
+
+    assert.deepEqual(seenSignals, [ctx.abortSignal, ctx.abortSignal, ctx.abortSignal]);
+  });
+
   test('standard isolated tool surface exposes externalized file tools to local-read children', () => {
     const tools = buildIsolatedHeadlessTools({
       async exec() {
@@ -341,19 +358,23 @@ describe('isolated headless tools', () => {
     const cwd = await mkdtemp(join(tmpdir(), 'maka-headless-tools-host-'));
     await writeFile(join(cwd, 'target.txt'), 'host\n', 'utf8');
     const calls: Array<{ name: string; input: unknown }> = [];
+    const nativeSignals: Array<AbortSignal | undefined> = [];
     const tools = buildIsolatedHeadlessTools({
       async exec() {
         throw new Error('file tools must use native isolated methods when available');
       },
-      async writeFile(input) {
+      async writeFile(input, control) {
+        nativeSignals.push(control?.abortSignal);
         calls.push({ name: 'Write', input });
         return { ok: true, path: input.path, bytes: Buffer.byteLength(input.content, 'utf8') };
       },
-      async globFiles(input) {
+      async globFiles(input, control) {
+        nativeSignals.push(control?.abortSignal);
         calls.push({ name: 'Glob', input });
         return { files: ['container.txt'] };
       },
-      async grepFiles(input) {
+      async grepFiles(input, control) {
+        nativeSignals.push(control?.abortSignal);
         calls.push({ name: 'Grep', input });
         return { matches: ['container.txt:1:needle'] };
       },
@@ -381,6 +402,8 @@ describe('isolated headless tools', () => {
       { name: 'Glob', input: { cwd, pattern: '*.txt', searchCwd: 'src' } },
       { name: 'Grep', input: { cwd, pattern: 'needle', path: 'src', glob: '*.txt' } },
     ]);
+    assert.equal(nativeSignals.length, 3);
+    assert.ok(nativeSignals.every((signal) => signal instanceof AbortSignal));
   });
 
   test('Read ignores any native readFile hook and always formats via READ_SCRIPT', async () => {

--- a/packages/headless/src/cell-output.ts
+++ b/packages/headless/src/cell-output.ts
@@ -65,6 +65,11 @@ export interface HarborCellExecutionIdentity {
   pricingProfile: string;
 }
 
+export interface HarborCellDeadlineSettlement {
+  source: 'benchmark.deadline';
+  mode: 'immediate';
+}
+
 export interface HarborCellContinuationSummary {
   enabled: boolean;
   maxTurns: number;
@@ -102,6 +107,7 @@ export interface HarborCellOutput {
   runtimeEventsPath: string;
   promptHash?: string;
   executionIdentity?: HarborCellExecutionIdentity;
+  deadlineSettlement?: HarborCellDeadlineSettlement;
   tokenSummary?: HarborCellTokenSummary;
   contextBudgetPolicy?: HarborCellContextBudgetPolicySnapshot;
   contextBudgetSummary?: HarborCellContextBudgetSummary;
@@ -119,6 +125,7 @@ export function buildHarborCellOutput(input: {
   invocation: InvocationResult;
   runtimeEventsPath: string;
   executionIdentity?: HarborCellExecutionIdentity;
+  deadlineSettlement?: HarborCellDeadlineSettlement;
   contextBudgetPolicy?: HarborCellContextBudgetPolicySnapshot;
   continuationSummary?: HarborCellContinuationSummary;
   taskToolSummaryEnabled?: boolean;
@@ -132,6 +139,7 @@ export function buildHarborCellOutput(input: {
     runtimeEventsPath: input.runtimeEventsPath,
     ...promptHashField(invocation.events),
     ...(input.executionIdentity ? { executionIdentity: input.executionIdentity } : {}),
+    ...(input.deadlineSettlement ? { deadlineSettlement: input.deadlineSettlement } : {}),
     ...(tokenSummary ? { tokenSummary } : {}),
     ...(input.contextBudgetPolicy ? { contextBudgetPolicy: input.contextBudgetPolicy } : {}),
     ...contextBudgetSummaryField(invocation.events),
@@ -190,6 +198,9 @@ export function validateHarborCellOutput(value: unknown): HarborCellOutput {
   const executionIdentity = 'executionIdentity' in value
     ? validateHarborCellExecutionIdentity(value.executionIdentity)
     : undefined;
+  const deadlineSettlement = 'deadlineSettlement' in value
+    ? validateHarborCellDeadlineSettlement(value.deadlineSettlement)
+    : undefined;
   const tokenSummary = 'tokenSummary' in value
     ? validateHarborCellTokenSummary(value.tokenSummary)
     : undefined;
@@ -218,6 +229,7 @@ export function validateHarborCellOutput(value: unknown): HarborCellOutput {
     runtimeEventsPath,
     ...(promptHash !== undefined ? { promptHash } : {}),
     ...(executionIdentity !== undefined ? { executionIdentity } : {}),
+    ...(deadlineSettlement !== undefined ? { deadlineSettlement } : {}),
     ...(tokenSummary ? { tokenSummary } : {}),
     ...(contextBudgetPolicy !== undefined ? { contextBudgetPolicy } : {}),
     ...(contextBudgetSummary !== undefined ? { contextBudgetSummary } : {}),
@@ -231,6 +243,14 @@ export function validateHarborCellOutput(value: unknown): HarborCellOutput {
     runtimeRefs,
   };
   return output;
+}
+
+function validateHarborCellDeadlineSettlement(value: unknown): HarborCellDeadlineSettlement {
+  if (!isRecord(value)) throw new Error('deadlineSettlement must be a JSON object');
+  return {
+    source: requireStringUnion(value.source, 'deadlineSettlement.source', ['benchmark.deadline'] as const),
+    mode: requireStringUnion(value.mode, 'deadlineSettlement.mode', ['immediate'] as const),
+  };
 }
 
 export function validateHarborCellExecutionIdentity(value: unknown): HarborCellExecutionIdentity {

--- a/packages/headless/src/harbor-cell.ts
+++ b/packages/headless/src/harbor-cell.ts
@@ -1,7 +1,7 @@
-import { mkdir, readFile, rename, writeFile } from 'node:fs/promises';
+import { mkdir, readFile, rename, rm, writeFile } from 'node:fs/promises';
 import { readFileSync } from 'node:fs';
 import { exec as nodeExec } from 'node:child_process';
-import { createHash } from 'node:crypto';
+import { createHash, randomUUID } from 'node:crypto';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
 import { promisify } from 'node:util';
@@ -390,7 +390,7 @@ export async function runHarborCell(input: RunHarborCellInput): Promise<RunHarbo
         deadlineReached = true;
         settlementAttempt = manager.stopSession(session.id, {
           source: 'benchmark_deadline',
-          mode: 'after_step',
+          mode: 'immediate',
         }).catch((error) => {
           settlementError = error;
         });
@@ -458,16 +458,19 @@ export async function runHarborCell(input: RunHarborCellInput): Promise<RunHarbo
   await mkdir(input.outputDir, { recursive: true });
   const runtimeEventsPath = join(input.outputDir, HARBOR_CELL_RUNTIME_EVENTS_FILENAME);
   const outputPath = join(input.outputDir, HARBOR_CELL_OUTPUT_FILENAME);
-  await writeFile(runtimeEventsPath, runtimeEventsJsonl(combinedInvocation), 'utf8');
+  await writeHarborCellArtifact(runtimeEventsPath, runtimeEventsJsonl(combinedInvocation));
   const output = validateHarborCellOutput(buildHarborCellOutput({
     invocation: combinedInvocation,
     runtimeEventsPath,
     executionIdentity,
+    ...(settledByDeadline
+      ? { deadlineSettlement: { source: 'benchmark.deadline' as const, mode: 'immediate' as const } }
+      : {}),
     ...(input.contextBudgetPolicy ? { contextBudgetPolicy: input.contextBudgetPolicy } : {}),
     ...(continuationSummary ? { continuationSummary } : {}),
     ...(input.taskToolSummaryEnabled !== undefined ? { taskToolSummaryEnabled: input.taskToolSummaryEnabled } : {}),
   }));
-  await writeFile(outputPath, `${JSON.stringify(output, null, 2)}\n`, 'utf8');
+  await writeHarborCellArtifact(outputPath, `${JSON.stringify(output, null, 2)}\n`);
 
   return { invocation: combinedInvocation, output, outputPath, runtimeEventsPath, settledByDeadline };
 }
@@ -823,9 +826,17 @@ export async function writeHarborCellUsageCheckpoint(
   };
   await mkdir(outputDir, { recursive: true });
   const path = join(outputDir, HARBOR_CELL_USAGE_CHECKPOINT_FILENAME);
-  const pendingPath = `${path}.${process.pid}.tmp`;
-  await writeFile(pendingPath, `${JSON.stringify(tokenSummary, null, 2)}\n`, 'utf8');
-  await rename(pendingPath, path);
+  await writeHarborCellArtifact(path, `${JSON.stringify(tokenSummary, null, 2)}\n`);
+}
+
+async function writeHarborCellArtifact(path: string, contents: string): Promise<void> {
+  const pendingPath = `${path}.${process.pid}.${randomUUID()}.tmp`;
+  try {
+    await writeFile(pendingPath, contents, { encoding: 'utf8', flush: true });
+    await rename(pendingPath, path);
+  } finally {
+    await rm(pendingPath, { force: true });
+  }
 }
 
 export function buildHarborCellAiSdkTools(

--- a/packages/headless/src/harbor-cell.ts
+++ b/packages/headless/src/harbor-cell.ts
@@ -1361,7 +1361,7 @@ export function createHarborHttpToolExecutor(env: RunHarborCellEnv = process.env
   const baseUrl = requiredHarborEnv(env, 'MAKA_HARBOR_TOOL_EXECUTOR_URL');
   const token = requiredHarborEnv(env, 'MAKA_HARBOR_TOOL_EXECUTOR_TOKEN');
   return {
-    exec: async (input) => {
+    exec: async (input, control) => {
       const timeoutSec = input.timeoutMs === undefined
         ? undefined
         : Math.max(1, Math.ceil(input.timeoutMs / 1000));
@@ -1375,6 +1375,7 @@ export function createHarborHttpToolExecutor(env: RunHarborCellEnv = process.env
           ...input,
           ...(timeoutSec !== undefined ? { timeoutSec } : {}),
         }),
+        signal: control?.abortSignal,
       });
       const body = await response.text();
       if (!response.ok) return { exitCode: 1, stdout: '', stderr: body };
@@ -1403,7 +1404,7 @@ export function createHarborCellLocalToolExecutor(env: RunHarborCellEnv = proces
   const shell = defaultShellPlan();
   return {
     shell,
-    exec: async ({ command, cwd, timeoutMs, boundedTail }) => {
+    exec: async ({ command, cwd, timeoutMs, boundedTail }, control) => {
       if (boundedTail) {
         // Bash opted in: stream into a bounded tail (shared with the in-process
         // builtin Bash) instead of execAsync({ maxBuffer }). A command whose
@@ -1414,6 +1415,7 @@ export function createHarborCellLocalToolExecutor(env: RunHarborCellEnv = proces
             cwd,
             env: childEnv,
             timeoutMs: timeoutMs ?? defaultTimeoutMs,
+            abortSignal: control?.abortSignal,
             shell,
           });
           return {
@@ -1443,6 +1445,7 @@ export function createHarborCellLocalToolExecutor(env: RunHarborCellEnv = proces
           env: childEnv,
           timeout: timeoutMs ?? defaultTimeoutMs,
           maxBuffer: HARBOR_CELL_TOOL_MAX_BUFFER_BYTES,
+          signal: control?.abortSignal,
         });
         return { exitCode: 0, stdout: result.stdout, stderr: result.stderr };
       } catch (error) {

--- a/packages/headless/src/index.ts
+++ b/packages/headless/src/index.ts
@@ -396,6 +396,7 @@ export type {
   IsolatedReadFileInput,
   IsolatedReadFileResult,
   IsolatedToolExecutor,
+  IsolatedToolExecutionControl,
   IsolatedWriteFileInput,
   IsolatedWriteFileResult,
   RealBackendIsolation,

--- a/packages/headless/src/isolation.ts
+++ b/packages/headless/src/isolation.ts
@@ -32,6 +32,10 @@ export interface IsolatedCommandResult {
   stderrTruncated?: boolean;
 }
 
+export interface IsolatedToolExecutionControl {
+  abortSignal?: AbortSignal;
+}
+
 export interface IsolatedReadFileInput {
   cwd: string;
   path: string;
@@ -104,7 +108,7 @@ export const ISOLATED_HEADLESS_TOOL_NAMES = ['Bash', 'Read', 'Write', 'Edit', 'G
  * model-backed backend is allowed.
  */
 export interface IsolatedToolExecutor {
-  exec(input: IsolatedCommandInput): Promise<IsolatedCommandResult>;
+  exec(input: IsolatedCommandInput, control?: IsolatedToolExecutionControl): Promise<IsolatedCommandResult>;
   /**
    * Shell dialect this executor's Bash commands run in, surfaced so
    * buildIsolatedBashTool can DECLARE it in the tool description. Selection
@@ -128,9 +132,9 @@ export interface IsolatedToolExecutor {
    * in the headless process, and writes bytes back through the executor. Both
    * hold regardless of which native ops an executor provides.
    */
-  writeFile?(input: IsolatedWriteFileInput): Promise<IsolatedWriteFileResult>;
-  globFiles?(input: IsolatedGlobInput): Promise<IsolatedGlobResult>;
-  grepFiles?(input: IsolatedGrepInput): Promise<IsolatedGrepResult>;
+  writeFile?(input: IsolatedWriteFileInput, control?: IsolatedToolExecutionControl): Promise<IsolatedWriteFileResult>;
+  globFiles?(input: IsolatedGlobInput, control?: IsolatedToolExecutionControl): Promise<IsolatedGlobResult>;
+  grepFiles?(input: IsolatedGrepInput, control?: IsolatedToolExecutionControl): Promise<IsolatedGrepResult>;
 }
 
 export interface ExternalRealBackendIsolation {

--- a/packages/headless/src/tools.ts
+++ b/packages/headless/src/tools.ts
@@ -91,16 +91,19 @@ export function buildIsolatedBashTool(
       + (guidance ? ` ${guidance}` : ''),
     defaultTimeoutMs: cleanupCommandTimeoutMs,
     emitReturnedOutput: true,
-    execute: async ({ command, cwd, timeoutMs }) => {
+    execute: async ({ command, cwd, timeoutMs, ctx }) => {
       // boundedTail: Bash is the one caller that wants a recoverable tail of a
       // huge, never-killed output. Read/Glob/Grep deliberately omit it so they
       // get full, head-first content from the executor.
-      return await executor.exec({
-        command,
-        cwd,
-        ...(timeoutMs !== undefined ? { timeoutMs } : {}),
-        boundedTail: true,
-      });
+      return await executor.exec(
+        {
+          command,
+          cwd,
+          ...(timeoutMs !== undefined ? { timeoutMs } : {}),
+          boundedTail: true,
+        },
+        { abortSignal: ctx.abortSignal },
+      );
     },
     afterResult: async (input, result, ctx) => {
       await options.heavyTaskEvidence?.recordToolEvidence({ name: 'Bash', input, result }, ctx);
@@ -137,7 +140,7 @@ export function buildIsolatedReadTool(
         normalizedPath,
         numberArg(offset),
         numberArg(limit),
-      ]));
+      ]), ctx.abortSignal);
       const result = { content: stdout };
       await options.heavyTaskEvidence?.recordToolEvidence({ name: 'Read', input, result }, ctx);
       return result;
@@ -160,14 +163,14 @@ export function buildIsolatedWriteTool(
       const input = { cwd, path: normalizedPath, content };
       return await withFileWriteLock(fileWriteKey(cwd, normalizedPath), async () => {
         if (executor.writeFile) {
-          const result = await executor.writeFile(input);
+          const result = await executor.writeFile(input, { abortSignal: ctx.abortSignal });
           await options.heavyTaskEvidence?.recordToolEvidence({ name: 'Write', input, result }, ctx);
           return result;
         }
         await execFileCommand(executor, cwd, shellFileCommand(WRITE_SCRIPT, [
           normalizedPath,
           content,
-        ]));
+        ]), ctx.abortSignal);
         const result = { ok: true, path: normalizedPath, bytes: Buffer.byteLength(content, 'utf8') };
         await options.heavyTaskEvidence?.recordToolEvidence({ name: 'Write', input, result }, ctx);
         return result;
@@ -199,9 +202,9 @@ export function buildIsolatedEditTool(
       const normalizedPath = normalizeWorkspacePath(path, cwd, 'Edit path');
       const input = { cwd, path: normalizedPath, oldString: old_string, newString: new_string };
       return await withFileWriteLock(fileWriteKey(cwd, normalizedPath), async () => {
-        const raw = await readIsolatedFileBytes(executor, cwd, normalizedPath);
+        const raw = await readIsolatedFileBytes(executor, cwd, normalizedPath, ctx.abortSignal);
         const { content, ...metadata } = computeEditBytes(raw, old_string, new_string, normalizedPath);
-        await writeIsolatedFileBytes(executor, cwd, normalizedPath, content);
+        await writeIsolatedFileBytes(executor, cwd, normalizedPath, content, ctx.abortSignal);
         const result = { ok: true, path: normalizedPath, replacements: 1, ...metadata };
         await options.heavyTaskEvidence?.recordToolEvidence({ name: 'Edit', input, result }, ctx);
         return result;
@@ -228,7 +231,7 @@ export function buildIsolatedGlobTool(
       const normalizedRelCwd = relCwd === undefined ? undefined : normalizeWorkspacePath(relCwd, cwd, 'Glob cwd');
       const input = { cwd, pattern: normalizedPattern, searchCwd: normalizedRelCwd };
       if (executor.globFiles) {
-        const result = await executor.globFiles(input);
+        const result = await executor.globFiles(input, { abortSignal: ctx.abortSignal });
         await options.heavyTaskEvidence?.recordToolEvidence({ name: 'Glob', input, result }, ctx);
         return result;
       }
@@ -236,7 +239,7 @@ export function buildIsolatedGlobTool(
         normalizedPattern,
         globPatternToEre(normalizedPattern),
         normalizedRelCwd ?? '',
-      ]));
+      ]), ctx.abortSignal);
       const result = { files: parseLineArray(stdout) };
       await options.heavyTaskEvidence?.recordToolEvidence({ name: 'Glob', input, result }, ctx);
       return result;
@@ -268,7 +271,7 @@ export function buildIsolatedGrepTool(
         glob: normalizedGlob,
       };
       if (executor.grepFiles) {
-        const result = await executor.grepFiles(input);
+        const result = await executor.grepFiles(input, { abortSignal: ctx.abortSignal });
         await options.heavyTaskEvidence?.recordToolEvidence({ name: 'Grep', input, result }, ctx);
         return result;
       }
@@ -277,7 +280,7 @@ export function buildIsolatedGrepTool(
         normalizedPath ?? '',
         normalizedGlob ?? '',
         normalizedGlob === undefined ? '' : globPatternToEre(normalizedGlob),
-      ]));
+      ]), ctx.abortSignal);
       const result = { matches: parseLineArray(stdout) };
       await options.heavyTaskEvidence?.recordToolEvidence({ name: 'Grep', input, result }, ctx);
       return result;
@@ -285,16 +288,29 @@ export function buildIsolatedGrepTool(
   };
 }
 
-async function execFileCommand(executor: IsolatedToolExecutor, cwd: string, command: string): Promise<string> {
-  const result = await executor.exec({ command, cwd, timeoutMs: 120_000 });
+async function execFileCommand(
+  executor: IsolatedToolExecutor,
+  cwd: string,
+  command: string,
+  abortSignal: AbortSignal,
+): Promise<string> {
+  const result = await executor.exec(
+    { command, cwd, timeoutMs: 120_000 },
+    { abortSignal },
+  );
   if (result.exitCode !== 0) {
     throw new Error(result.stderr.trim() || `isolated file command failed with exit code ${result.exitCode}`);
   }
   return result.stdout;
 }
 
-async function readIsolatedFileBytes(executor: IsolatedToolExecutor, cwd: string, path: string): Promise<Buffer> {
-  const stdout = await execFileCommand(executor, cwd, shellFileCommand(EDIT_READ_BYTES_SCRIPT, [path]));
+async function readIsolatedFileBytes(
+  executor: IsolatedToolExecutor,
+  cwd: string,
+  path: string,
+  abortSignal: AbortSignal,
+): Promise<Buffer> {
+  const stdout = await execFileCommand(executor, cwd, shellFileCommand(EDIT_READ_BYTES_SCRIPT, [path]), abortSignal);
   return Buffer.from(stdout.replace(/\s+/g, ''), 'base64');
 }
 
@@ -303,11 +319,12 @@ async function writeIsolatedFileBytes(
   cwd: string,
   path: string,
   content: Buffer,
+  abortSignal: AbortSignal,
 ): Promise<void> {
   await execFileCommand(executor, cwd, shellFileCommand(EDIT_WRITE_BYTES_SCRIPT, [
     path,
     content.toString('base64'),
-  ]));
+  ]), abortSignal);
 }
 
 function computeEditBytes(


### PR DESCRIPTION
## Summary

- force-stop an active Harbor provider/tool step with `immediate` at the soft deadline instead of waiting indefinitely for `after_step`
- atomically publish durable runtime events before using `maka-cell-output.json` as the final commit marker
- persist explicit `benchmark.deadline` / `immediate` settlement provenance in the final cell output
- cover non-cooperative steps through both the shared cell API and the host-side Harbor entrypoint

Closes #1078.

## Verification

- `env -u OLLAMA_API_KEY -u ZAI_API_KEY HOME=/tmp/maka-headless-isolated-home npm --workspace @maka/headless test` — 1005 passed, 0 failed, 1 existing clean-checkout-only skip
- focused deadline, normal-completion race, continuation suppression, usage provenance, and host adapter tests passed
- `npm --workspace @maka/headless run typecheck` passed
- no live provider, Oracle, or benchmark rerun was performed

## Root cause

The cell's only deadline action used `after_step`. That mode deliberately lets the active provider/tool step continue, so a non-cooperative step could outlive the entire Harbor settlement grace and be hard-killed before final artifacts were written.
