### PR TITLE
fix(cli): give the thinking marker blank-line separation from tool rows

### DIFF
--- a/packages/cli/src/__tests__/pi-transcript.test.ts
+++ b/packages/cli/src/__tests__/pi-transcript.test.ts
@@ -935,6 +935,47 @@ describe('Maka Pi TUI transcript', () => {
     assert.ok(bodyIndex < expanded.findIndex((line) => line.includes('the answer')));
   });
 
+  test('separates the thinking marker from tool rows with blank lines', () => {
+    const state = createMakaPiTranscriptState();
+
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_start', toolUseId: 'tool-1', toolName: 'Bash', args: { command: 'ls' },
+    }));
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_result', toolUseId: 'tool-1', isError: false, content: { kind: 'text', text: 'ok' },
+    }));
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'thinking_delta', messageId: 'message-1', text: 'plan the next step',
+    }));
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_start', toolUseId: 'tool-2', toolName: 'Bash', args: { command: 'pwd' },
+    }));
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_result', toolUseId: 'tool-2', isError: false, content: { kind: 'text', text: 'ok' },
+    }));
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_start', toolUseId: 'tool-3', toolName: 'Bash', args: { command: 'whoami' },
+    }));
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_result', toolUseId: 'tool-3', isError: false, content: { kind: 'text', text: 'ok' },
+    }));
+
+    const lines = renderMakaPiTranscript(state, meta(), 100).map(stripAnsi);
+    const markerIndex = lines.findIndex((line) => line.includes('Thinking…'));
+    assert.ok(markerIndex > 0);
+
+    // Thinking reads as model output: a blank line sets it apart from the
+    // tool rows on both sides.
+    assert.equal(lines[markerIndex - 1], '');
+    assert.equal(lines[markerIndex + 1], '');
+
+    // Consecutive tool rows stay compact — no blank line between them.
+    const toolIndices = lines
+      .map((line, index) => (line.includes('● Bash') ? index : -1))
+      .filter((index) => index >= 0);
+    assert.deepEqual(toolIndices, [markerIndex - 2, markerIndex + 2, markerIndex + 3]);
+  });
+
   test('replaces the streamed thinking entry when thinking_complete arrives after the reply', () => {
     const state = createMakaPiTranscriptState();
 

--- a/packages/cli/src/pi-transcript.ts
+++ b/packages/cli/src/pi-transcript.ts
@@ -746,11 +746,12 @@ export function renderMakaPiTranscript(
   for (let i = 0; i < state.entries.length; i += 1) {
     const entry = state.entries[i]!;
     const prev = state.entries[i - 1];
-    // A blank gap separates human-facing boundaries (user/assistant/notice)
-    // and the edges of an agent-work stack; consecutive thinking/tool entries
-    // (the agent-work stack) have no blank line between them.
-    const continuesStack = (entry.kind === 'thinking' || entry.kind === 'tool')
-      && (prev?.kind === 'thinking' || prev?.kind === 'tool');
+    // A blank gap separates human-facing boundaries (user/assistant/thinking/
+    // notice) and the edges of a tool stack; only consecutive tool entries (the
+    // agent-work stack) have no blank line between them. Thinking reads as
+    // model output, so it gets the same blank-line breathing room as assistant
+    // text rather than packing against the tool rows.
+    const continuesStack = entry.kind === 'tool' && prev?.kind === 'tool';
     if (!continuesStack) lines.push('');
     lines.push(...renderTranscriptEntryMemoized(entry, safeWidth, state.expandAllTools, state.expandAllThinking));
   }


### PR DESCRIPTION
## Summary

In a dense agent-work run the transcript packed `Thinking…` directly against adjacent tool rows with no blank line, so long stretches read as one undifferentiated block:

```
● Bash  $ gh issue list --state open --limit 50 2>&1 | head -60 (50 lines)
● Bash  $ ls packages/cli/src/ && git log --oneline -5 -- packages/cli (28 lines)
Thinking…
● Bash  $ gh issue list --state open --limit 100 … (5 lines)
```

Thinking is model output, so it now gets the same blank-line breathing room as assistant text instead of joining the compact stack. The no-gap packing is reserved for consecutive tool rows only:

```
● Bash  $ gh issue list --state open --limit 50 2>&1 | head -60 (50 lines)
● Bash  $ ls packages/cli/src/ && git log --oneline -5 -- packages/cli (28 lines)

Thinking…

● Bash  $ gh issue list --state open --limit 100 … (5 lines)
```

The change is one condition in `renderMakaPiTranscript`'s entry loop: `continuesStack` now requires both neighbours to be tool entries (previously thinking counted as part of the stack on either side).

## Verification

- New regression test `separates the thinking marker from tool rows with blank lines` in `pi-transcript.test.ts` pins both sides: blank line before and after `Thinking…`, and no blank between consecutive tool rows. Watched it fail before the fix (`'● Bash  $ ls (ok)'` where `''` was expected), pass after.
- `npm --workspace maka-agent test` — 407/407 pass.
- `biome lint` and `tsc --noEmit` clean on the touched files.
- Rendered a tool→tool→thinking→tool→thinking→text sequence through the built `dist` and confirmed the output matches the layout above (blank lines around each `Thinking…`, tool rows still packed).