### PR TITLE
test(runtime): wait for PTY readiness before SIGTERM

### DIFF
--- a/packages/runtime/src/__tests__/shell-run-manager.test.ts
+++ b/packages/runtime/src/__tests__/shell-run-manager.test.ts
@@ -1503,6 +1503,7 @@ describe('ShellRunProcessManager', () => {
       timeoutMs: 5_000,
     }));
     assert.equal(gracefulRun.kind, 'shell_run');
+    await waitForPtyText(graceful, gracefulRun.ref, /ready/);
     const stopped = await graceful.stopBackgroundTask('session-1', gracefulRun.ref, NO_ABORT);
     assertShellRun(stopped);
     assert.equal(stopped.output?.mode, 'pty');
@@ -1518,6 +1519,7 @@ describe('ShellRunProcessManager', () => {
       timeoutMs: 5_000,
     }));
     assert.equal(forcedRun.kind, 'shell_run');
+    await waitForPtyText(forced, forcedRun.ref, /ready/);
     const forcedStop = await forced.stopBackgroundTask('session-1', forcedRun.ref, NO_ABORT);
     assertShellRun(forcedStop);
     assert.equal(forcedStop.status, 'cancelled');


### PR DESCRIPTION
## Summary

- wait for the graceful PTY fixture to report `ready` before sending SIGTERM
- wait for the ignored-SIGTERM fixture to report `ready` so the test genuinely covers forced escalation
- remove the startup race that leaves the Runtime suite red on macOS

Closes #1095.

## Verification

Rebased onto `fd6bd9e3` (`origin/main`) and validated from a clean dependency install:

- current-main baseline focused test — failed because the expected final sentinel was empty
- rebased fixed focused test — passed 5/5 consecutive runs
- `npm run lint` — passed (1619 files)
- `npm run build` — passed
- `npm run typecheck` — passed
- `npm --workspace @maka/runtime test` — passed (1976 passed, 0 failed, 7 skipped)

## Root cause

`runBackgroundBash()` confirms that the background run was created, but it does not guarantee the spawned shell has installed its signal trap. The test stopped both PTY fixtures immediately, so the graceful fixture could exit before printing its final sentinel and the forced fixture could pass without actually ignoring SIGTERM. Waiting for each command's existing `ready` marker makes both assertions test the intended lifecycle behavior.
