### PR TITLE
fix(cli): respect desktop-curated enabledModelIds in the /model picker

### DIFF
--- a/packages/cli/src/__tests__/connection-target.test.ts
+++ b/packages/cli/src/__tests__/connection-target.test.ts
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
 import { describe, test } from 'node:test';
 import type { LlmConnection } from '@maka/core/llm-connections';
-import { listReadyModelChoices, resolveDefaultSessionTarget } from '../connection-target.js';
+import { listReadyModelChoices, resolveDefaultSessionTarget, selectableModelIdsForTarget } from '../connection-target.js';
 
 describe('default session target resolver', () => {
   test('resolves OpenCode Go credentials without rewriting its exact model id', async () => {
@@ -979,13 +979,70 @@ describe('default session target resolver', () => {
   });
 });
 
+describe('selectableModelIdsForTarget', () => {
+  test('filters the picker to the connection enabledModelIds, keeping the current model selectable', () => {
+    const connection = makeConnection({
+      providerType: 'ollama',
+      defaultModel: 'glm-5.2',
+      enabledModelIds: ['glm-5.2'],
+      models: [{ id: 'glm-5.2' }, { id: 'glm-5-air' }, { id: 'glm-4.6' }],
+    });
+
+    // The session is currently on glm-5-air: it stays selectable even though
+    // the user curated it out; the rest of the catalog (glm-4.6) stays hidden.
+    assert.deepEqual(
+      selectableModelIdsForTarget({ connection, model: 'glm-5-air' }),
+      ['glm-5-air', 'glm-5.2'],
+    );
+  });
+
+  test('legacy connections without enabledModelIds collapse to the default model, never the full catalog', () => {
+    const connection = makeConnection({
+      providerType: 'ollama',
+      defaultModel: 'glm-5.2',
+      models: [{ id: 'glm-5.2' }, { id: 'glm-5-air' }],
+    });
+
+    assert.deepEqual(
+      selectableModelIdsForTarget({ connection, model: 'glm-5.2' }),
+      ['glm-5.2'],
+    );
+  });
+});
+
 describe('listReadyModelChoices', () => {
+  test('lists only enabledModelIds for connections with a curated model set', async () => {
+    const zai = makeConnection({
+      slug: 'zai',
+      name: 'Z.ai',
+      providerType: 'ollama', // authKind none → ready without a stored secret
+      defaultModel: 'glm-5.2',
+      enabledModelIds: ['glm-5.2'],
+      models: [{ id: 'glm-5.2' }, { id: 'glm-5-air' }],
+    });
+
+    const choices = await listReadyModelChoices({
+      connectionStore: {
+        list: async () => [zai],
+        getDefault: async () => 'zai',
+      },
+      credentialStore: {
+        getSecret: async () => null,
+      },
+    });
+
+    // glm-5-air is discovered but curated out on desktop, so the TUI picker
+    // must not offer it either.
+    assert.deepEqual(choices.map((choice) => choice.model), ['glm-5.2']);
+  });
+
   test('lists models across every ready connection and skips fake / not-ready', async () => {
     const zai = makeConnection({
       slug: 'zai',
       name: 'Z.ai',
       providerType: 'ollama', // authKind none → ready without a stored secret
       defaultModel: 'glm-5.2',
+      enabledModelIds: ['glm-5.2', 'glm-5-air'],
       models: [{ id: 'glm-5.2' }, { id: 'glm-5-air' }],
     });
     const openai = makeConnection({

--- a/packages/cli/src/connection-target.ts
+++ b/packages/cli/src/connection-target.ts
@@ -1,6 +1,6 @@
 import { isConnectionReady, type ChatConfigurationReason } from '@maka/core/connection-readiness';
 import type { LlmConnection, ProviderType } from '@maka/core/llm-connections';
-import { PROVIDER_DEFAULTS } from '@maka/core/llm-connections';
+import { connectionEnabledModelIds, PROVIDER_DEFAULTS } from '@maka/core/llm-connections';
 import { isOAuthSubscriptionProvider, resolveOAuthSubscriptionTokens, resolveSelectedModelContextWindow, type OAuthSubscriptionTokens } from '@maka/runtime';
 import type { ConnectionStore, CredentialKind, CredentialStore } from '@maka/storage';
 
@@ -23,11 +23,13 @@ export interface ModelChoice {
 }
 
 export function selectableModelIdsForTarget(target: Pick<ReadySessionTarget, 'connection' | 'model'>): string[] {
-  const defaults = PROVIDER_DEFAULTS[target.connection.providerType];
+  // The picker mirrors the desktop's curated visibility: only the connection's
+  // enabled models are offered (legacy connections collapse to their default
+  // model, never the full discovered catalog). The session's current model
+  // stays selectable even when the user curated it out.
   const candidates = [
     target.model,
-    target.connection.defaultModel,
-    ...(target.connection.models?.map((model) => model.id) ?? defaults?.fallbackModels ?? []),
+    ...connectionEnabledModelIds(target.connection),
   ];
   const ids: string[] = [];
   const seen = new Set<string>();


### PR DESCRIPTION
## Summary

Desktop connections now carry a user-curated visible model set (`enabledModelIds` — "Model ids shown in model pickers"), but the TUI `/model` picker built its choices from the connection's full discovered catalog (`connection.models`) and never filtered by it, so models the user hid on desktop still appeared in the TUI.

`selectableModelIdsForTarget` now builds candidates from `connectionEnabledModelIds()` — the same helper desktop pickers filter by — with the documented invariant that legacy connections without the field collapse to their default model, never the full catalog. The session's current model stays selectable even when the user curated it out, so an in-flight session never loses its active model.

Refs #1098 (the onboarding flow will write/respect the same curation).

## Verification

- `npm run typecheck` (packages/cli) — pass
- `npm test` (packages/cli, full suite incl. pretest rebuild of core/storage/runtime) — 415 pass, 0 fail
- New tests: curated connection lists only `enabledModelIds` while keeping the current model selectable; legacy connection (no `enabledModelIds`) collapses to the default model; `listReadyModelChoices` end-to-end with a curated connection. All three fail before the fix, pass after; the pre-existing fixtures were updated to include the field the store materializes in practice.
