### PR TITLE
refactor(providers): land the three Phase 8 conformance preconditions

### DIFF
--- a/packages/core/src/__tests__/model-metadata.test.ts
+++ b/packages/core/src/__tests__/model-metadata.test.ts
@@ -1,6 +1,6 @@
 import { strict as assert } from 'node:assert';
 import { describe, it } from 'node:test';
-import { lookupModelMetadata, resolveModelVisionSupport } from '../model-metadata.js';
+import { lookupModelMetadata, openAiAdapterApiProtocol, resolveModelVisionSupport } from '../model-metadata.js';
 import { PROVIDER_DEFAULTS, type ModelInfo, type ProviderType } from '../llm-connections.js';
 
 describe('model-metadata vision capability', () => {
@@ -91,5 +91,19 @@ describe('resolveModelVisionSupport', () => {
   it('falls back to metadata when the model list is empty or missing', () => {
     assert.equal(resolveModelVisionSupport('zai-coding-plan' as ProviderType, [], 'glm-5v-turbo'), true);
     assert.equal(resolveModelVisionSupport('zai-coding-plan' as ProviderType, undefined, 'glm-5.2'), false);
+  });
+});
+
+describe('openAiAdapterApiProtocol', () => {
+  it('routes every gpt-5* family to the Responses wire', () => {
+    for (const modelId of ['gpt-5', 'gpt-5-codex', 'gpt-5.5', 'gpt-5.6-sol', 'GPT-5', ' gpt-5.4 ']) {
+      assert.equal(openAiAdapterApiProtocol(modelId), 'openai-responses', modelId);
+    }
+  });
+
+  it('keeps every other OpenAI-adapter model on the Chat Completions wire', () => {
+    for (const modelId of ['gpt-4o', 'gpt-4.1', 'o3', 'o4-mini', 'chatgpt-4o-latest']) {
+      assert.equal(openAiAdapterApiProtocol(modelId), 'openai-chat', modelId);
+    }
   });
 });

--- a/packages/core/src/__tests__/provider-contract-matrix.test.ts
+++ b/packages/core/src/__tests__/provider-contract-matrix.test.ts
@@ -107,6 +107,12 @@ describe('provider contract matrix — discovery derivation', () => {
     assert.equal(lmStudio.state === 'generated' && lmStudio.discovery?.auth, 'none');
   });
 
+  it('derives auth optional when the provider credential is user-optional', () => {
+    const localai = cellFor('localai', 'discovery');
+    assert.equal(localai.state, 'generated');
+    assert.equal(localai.state === 'generated' && localai.discovery?.auth, 'optional');
+  });
+
   it('marks fireworks / cohere / ollama discovery as override', () => {
     for (const providerType of ['fireworks-ai', 'cohere', 'ollama'] as const) {
       const cell = cellFor(providerType, 'discovery');

--- a/packages/core/src/model-metadata.ts
+++ b/packages/core/src/model-metadata.ts
@@ -45,6 +45,23 @@ export function lookupModelProviderOverride(
 }
 
 /**
+ * The request wire a model served over the OpenAI adapter must use.
+ *
+ * OpenAI's `gpt-5*` families are served only over the Responses API; every other
+ * model on the OpenAI adapter uses Chat Completions. This is the single declared
+ * source of that protocol split, expressed through the {@link ModelInfo.apiProtocol}
+ * seam. It is consumed by the runtime model factory (to pick `.responses()` vs
+ * `.chat()`) and by the conformance matrix (to keep `gpt-5*` off the generated
+ * default-Chat wire), replacing the `/^gpt-5/i` routing regex that was previously
+ * hard-coded in both places.
+ */
+export function openAiAdapterApiProtocol(
+  modelId: string,
+): 'openai-responses' | 'openai-chat' {
+  return /^gpt-5/i.test(modelId.trim()) ? 'openai-responses' : 'openai-chat';
+}
+
+/**
  * Resolve whether a model accepts image input for the send path.
  *
  * Stored `connection.models` win when they declare `vision` explicitly

--- a/packages/core/src/provider-contract-matrix.ts
+++ b/packages/core/src/provider-contract-matrix.ts
@@ -24,7 +24,7 @@
  * Pure: no IO, no network, no clock. Given the registry it is a total function.
  */
 
-import { lookupModelProviderOverride } from './model-metadata.js';
+import { lookupModelProviderOverride, openAiAdapterApiProtocol } from './model-metadata.js';
 import {
   PROVIDER_REGISTRY,
   type ProviderDefaults,
@@ -59,9 +59,16 @@ export const SUBSCRIPTION_WIRE_ADAPTER_KINDS: ReadonlySet<ProviderRuntimeAdapter
 /** Derived expectation for a generated `discovery` cell. */
 export interface ProviderContractDiscoveryPlan {
   protocol: ProviderDefaults['protocol'];
-  /** `none` when the request must carry no credential — a public model list, or a
-   * provider with no credential to send; `default` when it carries provider auth. */
-  auth: 'default' | 'none';
+  /**
+   * How the discovery request carries (or omits) a credential:
+   *   - `none`     the request must carry no credential — a public model list, or
+   *                a provider with no credential to send (`authKind: 'none'`).
+   *   - `default`  the request must carry the provider's credential (`api_key`).
+   *   - `optional` the credential is user-optional (`authKind: 'optional_api_key'`):
+   *                the request carries it when a key is configured and omits it
+   *                entirely when none is, so both branches must be exercised.
+   */
+  auth: 'default' | 'none' | 'optional';
   path?: string;
   query?: Readonly<Record<string, string>>;
   responseShape?: 'array-or-data';
@@ -163,7 +170,7 @@ function wireForProtocol(protocol: ProviderDefaults['protocol']): ProviderContra
 function sampleModelIdFor(providerType: ProviderType, def: ProviderDefaults): string {
   const usesDefaultWire = (id: string): boolean => {
     if (lookupModelProviderOverride(providerType, id)) return false;
-    if (def.runtimeAdapter.kind === 'openai' && /^gpt-5/i.test(id)) return false;
+    if (def.runtimeAdapter.kind === 'openai' && openAiAdapterApiProtocol(id) === 'openai-responses') return false;
     return true;
   };
   return def.fallbackModels.find(usesDefaultWire) ?? SYNTHETIC_SAMPLE_MODEL_ID;
@@ -214,7 +221,11 @@ function discoveryCell(providerType: ProviderType, def: ProviderDefaults): Provi
         dimension: 'discovery',
         discovery: {
           protocol: def.protocol,
-          auth: discovery.auth === 'none' || def.authKind === 'none' ? 'none' : 'default',
+          auth: discovery.auth === 'none' || def.authKind === 'none'
+            ? 'none'
+            : def.authKind === 'optional_api_key'
+              ? 'optional'
+              : 'default',
           ...(discovery.path !== undefined ? { path: discovery.path } : {}),
           ...(discovery.query !== undefined ? { query: discovery.query } : {}),
           ...(discovery.responseShape !== undefined ? { responseShape: discovery.responseShape } : {}),

--- a/packages/runtime/src/__tests__/conformance-harness.ts
+++ b/packages/runtime/src/__tests__/conformance-harness.ts
@@ -1,0 +1,62 @@
+/**
+ * Shared scripted-HTTP harness for the provider conformance suites.
+ *
+ * Not a test file: node --test only picks up `*.test.js`, so this module can be
+ * imported by the generated matrix suite, the executable override bindings, and
+ * the hand-written conformance suite without registering anything itself.
+ *
+ * Servers are tracked per process; each suite that starts servers must call
+ * {@link closeAllJsonServers} from an `after` hook.
+ */
+
+import assert from 'node:assert/strict';
+import { createServer, type IncomingMessage, type ServerResponse } from 'node:http';
+
+const servers: Array<{ close(): Promise<void> }> = [];
+
+export async function startJsonServer(
+  handler: (request: IncomingMessage, response: ServerResponse) => void | Promise<void>,
+): Promise<{ url: string; close(): Promise<void> }> {
+  const server = createServer((request, response) => {
+    void Promise.resolve(handler(request, response)).catch((error) => {
+      response.destroy(error as Error);
+    });
+  });
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const address = server.address();
+  assert.ok(address && typeof address === 'object');
+  const control = {
+    url: `http://127.0.0.1:${address.port}`,
+    close: () => new Promise<void>((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    }),
+  };
+  servers.push(control);
+  return control;
+}
+
+export async function closeAllJsonServers(): Promise<void> {
+  const open = servers.splice(0, servers.length);
+  await Promise.all(open.map((server) => server.close()));
+}
+
+export function readBody(request: IncomingMessage): Promise<string> {
+  return new Promise((resolve, reject) => {
+    let body = '';
+    request.setEncoding('utf8');
+    request.on('data', (chunk) => { body += chunk; });
+    request.on('end', () => resolve(body));
+    request.on('error', reject);
+  });
+}
+
+export function respondJson(response: ServerResponse, status: number, body: unknown): void {
+  response.writeHead(status, { 'content-type': 'application/json' });
+  response.end(JSON.stringify(body));
+}
+
+export function respondOpenAIStream(response: ServerResponse, chunks: readonly unknown[]): void {
+  response.writeHead(200, { 'content-type': 'text/event-stream' });
+  for (const chunk of chunks) response.write(`data: ${JSON.stringify(chunk)}\n\n`);
+  response.end('data: [DONE]\n\n');
+}

--- a/packages/runtime/src/__tests__/model-fetcher.test.ts
+++ b/packages/runtime/src/__tests__/model-fetcher.test.ts
@@ -436,68 +436,6 @@ describe('fetchProviderModels', () => {
     assert.deepEqual(models, [{ id: 'claude-haiku-4-5-20251001' }]);
   });
 
-  test('GitHub Copilot discovers only account-enabled tool models and preserves each exact endpoint wire', async () => {
-    const server = await startJsonServer((request, response) => {
-      assert.equal(request.method, 'GET');
-      assert.equal(request.url, '/models');
-      assert.equal(request.headers.authorization, 'Bearer github-account-token');
-      assert.equal(request.headers['user-agent'], 'GitHubCopilotChat/0.35.0');
-      assert.equal(request.headers['editor-version'], 'vscode/1.107.0');
-      assert.equal(request.headers['editor-plugin-version'], 'copilot-chat/0.35.0');
-      assert.equal(request.headers['copilot-integration-id'], 'vscode-chat');
-      assert.equal(request.headers['x-github-api-version'], '2026-06-01');
-      respondJson(response, 200, {
-        data: [
-          copilotModel('gpt-5.4', ['/responses']),
-          copilotModel('claude-sonnet-4.6', ['/v1/messages']),
-          copilotModel('gemini-3.1-pro-preview', ['/chat/completions']),
-          { ...copilotModel('disabled-by-policy', ['/chat/completions']), policy: { state: 'disabled' } },
-          { ...copilotModel('hidden-from-picker', ['/chat/completions']), model_picker_enabled: false },
-          { ...copilotModel('no-tools', ['/chat/completions']), capabilities: { supports: { tool_calls: false } } },
-          copilotModel('unsupported-wire', ['/embeddings']),
-        ],
-      });
-    });
-
-    const models = await fetchProviderModels({
-      slug: 'github-copilot',
-      name: 'GitHub Copilot',
-      providerType: 'github-copilot',
-      baseUrl: server.url,
-      defaultModel: 'gpt-5.4',
-      enabled: true,
-      createdAt: 1,
-      updatedAt: 1,
-    }, 'github-account-token');
-
-    assert.deepEqual(models, [
-      {
-        id: 'gpt-5.4',
-        displayName: 'gpt-5.4 display',
-        contextWindow: 400_000,
-        maxOutputTokens: 128_000,
-        apiProtocol: 'openai-responses',
-        capabilities: { vision: true, reasoning: true, functionCalling: true },
-      },
-      {
-        id: 'claude-sonnet-4.6',
-        displayName: 'claude-sonnet-4.6 display',
-        contextWindow: 400_000,
-        maxOutputTokens: 128_000,
-        apiProtocol: 'anthropic-messages',
-        capabilities: { vision: true, reasoning: true, functionCalling: true },
-      },
-      {
-        id: 'gemini-3.1-pro-preview',
-        displayName: 'gemini-3.1-pro-preview display',
-        contextWindow: 400_000,
-        maxOutputTokens: 128_000,
-        apiProtocol: 'openai-chat',
-        capabilities: { vision: true, reasoning: true, functionCalling: true },
-      },
-    ]);
-  });
-
   test('MiniMax Coding Plan discovers exact model ids with Anthropic API-key authentication', async () => {
     let observedAuthorization = '';
     let observedApiKey = '';
@@ -642,27 +580,6 @@ async function startJsonServer(
 function respondJson(response: ServerResponse, status: number, body: unknown): void {
   response.writeHead(status, { 'content-type': 'application/json' });
   response.end(JSON.stringify(body));
-}
-
-function copilotModel(id: string, supportedEndpoints: string[]): Record<string, unknown> {
-  return {
-    id,
-    name: `${id} display`,
-    model_picker_enabled: true,
-    supported_endpoints: supportedEndpoints,
-    policy: { state: 'enabled' },
-    capabilities: {
-      limits: {
-        max_prompt_tokens: 400_000,
-        max_output_tokens: 128_000,
-      },
-      supports: {
-        tool_calls: true,
-        vision: true,
-        reasoning_effort: ['low', 'medium', 'high'],
-      },
-    },
-  };
 }
 
 function zaiConnection(): LlmConnection {

--- a/packages/runtime/src/__tests__/provider-conformance.test.ts
+++ b/packages/runtime/src/__tests__/provider-conformance.test.ts
@@ -2,12 +2,11 @@ import assert from 'node:assert/strict';
 import { createServer, type IncomingMessage, type ServerResponse } from 'node:http';
 import { after, describe, test } from 'node:test';
 import type { LlmConnection } from '@maka/core';
-import { generateText, stepCountIs, streamText, tool } from 'ai';
+import { generateText, stepCountIs, tool } from 'ai';
 import { z } from 'zod';
 import { fetchProviderModels } from '../model-fetcher.js';
 import { buildProviderOptions, getAIModel } from '../model-factory.js';
 import { testConnection } from '../test-connection.js';
-import { buildSubscriptionModelFetch } from '../subscription-model-fetch.js';
 
 const servers: Array<{ close(): Promise<void> }> = [];
 
@@ -61,140 +60,68 @@ describe('models.dev provider conformance', () => {
     assert.equal(result.ok, false);
   });
 
-  test('GitHub Copilot discovers the account model and completes a reasoning tool loop on its exact wire', async () => {
-    const modelId = 'gemini-3.1-pro-preview';
-    const requestBodies: Array<Record<string, unknown>> = [];
-    const initiators: string[] = [];
+  test('OpenAI routes gpt-5* through the Responses wire and other models through Chat Completions by declaration', async () => {
+    const requests: string[] = [];
     const server = await startJsonServer(async (request, response) => {
-      assert.equal(request.headers.authorization, 'Bearer github-account-token');
-      if (request.method === 'GET' && request.url === '/models') {
-        respondJson(response, 200, {
-          data: [{
-            id: modelId,
-            name: 'Gemini 3.1 Pro Preview',
-            model_picker_enabled: true,
-            supported_endpoints: ['/chat/completions'],
-            policy: { state: 'enabled' },
-            capabilities: {
-              limits: { max_prompt_tokens: 400_000, max_output_tokens: 64_000 },
-              supports: { tool_calls: true, reasoning_effort: ['low', 'medium', 'high'] },
-            },
-          }],
-        });
-        return;
-      }
       assert.equal(request.method, 'POST');
-      assert.equal(request.url, '/chat/completions');
-      assert.equal(request.headers['openai-intent'], 'conversation-edits');
-      assert.equal(request.headers['x-github-api-version'], '2026-06-01');
-      initiators.push(String(request.headers['x-initiator']));
-      requestBodies.push(JSON.parse(await readBody(request)) as Record<string, unknown>);
-      if (requestBodies.length === 1) {
+      assert.equal(request.headers.authorization, 'Bearer openai-test-key');
+      requests.push(request.url ?? '');
+      await readBody(request);
+      if (request.url === '/v1/responses') {
         respondJson(response, 200, {
-          id: 'copilot-tool',
-          object: 'chat.completion',
-          created: 1,
-          model: modelId,
-          choices: [{
-            index: 0,
-            message: {
-              role: 'assistant',
-              content: null,
-              reasoning_content: 'I should use the echo tool.',
-              tool_calls: [{
-                id: 'call-copilot-echo',
-                type: 'function',
-                function: { name: 'echo', arguments: '{"text":"hello"}' },
-              }],
-            },
-            finish_reason: 'tool_calls',
+          id: 'resp_gpt5',
+          object: 'response',
+          created_at: 1,
+          status: 'completed',
+          model: 'gpt-5.5',
+          output: [{
+            type: 'message',
+            id: 'msg_gpt5',
+            status: 'completed',
+            role: 'assistant',
+            content: [{ type: 'output_text', text: 'Responses wire.', annotations: [], logprobs: [] }],
           }],
-          usage: { prompt_tokens: 8, completion_tokens: 4, total_tokens: 12 },
+          usage: { input_tokens: 8, output_tokens: 3, total_tokens: 11 },
         });
         return;
       }
+      assert.equal(request.url, '/v1/chat/completions');
       respondJson(response, 200, {
-        id: 'copilot-final',
+        id: 'chatcmpl-gpt4o',
         object: 'chat.completion',
         created: 2,
-        model: modelId,
+        model: 'gpt-4o',
         choices: [{
           index: 0,
-          message: { role: 'assistant', content: 'Echoed hello.' },
+          message: { role: 'assistant', content: 'Chat wire.' },
           finish_reason: 'stop',
         }],
-        usage: { prompt_tokens: 12, completion_tokens: 3, total_tokens: 15 },
+        usage: { prompt_tokens: 8, completion_tokens: 3, total_tokens: 11 },
       });
     });
     const connection: LlmConnection = {
-      slug: 'github-copilot',
-      name: 'GitHub Copilot',
-      providerType: 'github-copilot',
-      baseUrl: server.url,
-      defaultModel: modelId,
+      slug: 'openai',
+      name: 'OpenAI',
+      providerType: 'openai',
+      baseUrl: `${server.url}/v1`,
+      defaultModel: 'gpt-5.5',
       enabled: true,
       createdAt: 1,
       updatedAt: 1,
     };
-    const models = await fetchProviderModels(connection, 'github-account-token');
-    connection.models = models;
-    const modelFetch = buildSubscriptionModelFetch({
-      connection,
-      sessionId: 'session-copilot',
-      modelId,
-      fetchFn: fetch,
-    });
-    assert.ok(modelFetch);
 
-    const result = await generateText({
-      model: getAIModel({
-        connection,
-        apiKey: 'github-account-token',
-        modelId,
-        fetch: modelFetch,
-      }),
-      prompt: 'Call echo with hello.',
-      stopWhen: stepCountIs(2),
-      tools: {
-        echo: tool({
-          description: 'Echo text',
-          inputSchema: z.object({ text: z.string() }),
-          execute: async ({ text }) => ({ echoed: text }),
-        }),
-      },
+    const gpt5 = await generateText({
+      model: getAIModel({ connection, apiKey: 'openai-test-key', modelId: 'gpt-5.5' }),
+      prompt: 'Say hi.',
+    });
+    const gpt4o = await generateText({
+      model: getAIModel({ connection, apiKey: 'openai-test-key', modelId: 'gpt-4o' }),
+      prompt: 'Say hi.',
     });
 
-    assert.deepEqual(models.map((model) => [model.id, model.apiProtocol]), [[modelId, 'openai-chat']]);
-    assert.deepEqual(initiators, ['user', 'agent']);
-    assert.equal(requestBodies[0]?.model, modelId);
-    assert.equal(result.steps[0]?.reasoningText, 'I should use the echo tool.');
-    assert.deepEqual(result.steps[0]?.toolResults[0]?.output, { echoed: 'hello' });
-    // Turn two must carry the exact model id, replay the assistant tool-call
-    // turn (original tool_calls id + reasoning_content verbatim), and link the
-    // tool result back through tool_call_id.
-    assert.equal(requestBodies[1]?.model, modelId);
-    const secondMessages = requestBodies[1]?.messages as Array<Record<string, unknown>>;
-    const assistant = secondMessages.find((message) => message.role === 'assistant');
-    assert.ok(assistant, 'turn two must replay the assistant tool-call turn');
-    assert.deepEqual(
-      (assistant.tool_calls as Array<{ id: string }>).map(({ id }) => id),
-      ['call-copilot-echo'],
-      'turn two must replay the original tool_calls id',
-    );
-    assert.equal(
-      assistant.reasoning_content,
-      'I should use the echo tool.',
-      'turn two must replay the first-turn reasoning verbatim as reasoning_content',
-    );
-    const toolMessage = secondMessages.find((message) => message.role === 'tool');
-    assert.ok(toolMessage, 'turn two must carry a tool message with the echo result');
-    assert.equal(toolMessage.tool_call_id, 'call-copilot-echo');
-    const toolMessageContent = JSON.stringify(toolMessage.content);
-    assert.ok(
-      toolMessageContent.includes('echoed') && toolMessageContent.includes('hello'),
-      `turn two tool message must carry the echo output, got ${toolMessageContent}`,
-    );
-    assert.equal(result.text, 'Echoed hello.');
+    assert.deepEqual(requests, ['/v1/responses', '/v1/chat/completions']);
+    assert.equal(gpt5.text, 'Responses wire.');
+    assert.equal(gpt4o.text, 'Chat wire.');
   });
 
   test('OpenCode Go preserves exact discovery ids and reasoning through a two-stage tool loop', async () => {
@@ -460,107 +387,6 @@ describe('models.dev provider conformance', () => {
       { role: 'tool', content: '{"echoed":"hello"}', tool_call_id: 'call_zenmux_echo' },
     );
     assert.equal(result.text, 'Echoed hello.');
-  });
-
-  test('ZenMux replays signed reasoning details in the streamed runtime tool loop', async () => {
-    const modelId = 'moonshotai/kimi-k2.5';
-    const reasoningDetails = [{
-      type: 'reasoning.text',
-      text: 'Use echo.',
-      signature: 'deterministic-stream-signature',
-      format: 'anthropic-claude-v1',
-    }];
-    const requestBodies: Array<Record<string, unknown>> = [];
-    const server = await startJsonServer(async (request, response) => {
-      const body = JSON.parse(await readBody(request)) as Record<string, unknown>;
-      requestBodies.push(body);
-      assert.equal(body.stream, true);
-      if (requestBodies.length === 1) {
-        respondOpenAIStream(response, [{
-          id: 'chatcmpl-zenmux-stream-tool',
-          object: 'chat.completion.chunk',
-          created: 1,
-          model: modelId,
-          choices: [{
-            index: 0,
-            delta: {
-              role: 'assistant',
-              reasoning: 'Use echo.',
-              reasoning_details: reasoningDetails,
-              tool_calls: [{
-                index: 0,
-                id: 'call_zenmux_stream_echo',
-                type: 'function',
-                function: { name: 'echo', arguments: '{"text":"hello"}' },
-              }],
-            },
-            finish_reason: null,
-          }],
-        }, {
-          id: 'chatcmpl-zenmux-stream-tool',
-          object: 'chat.completion.chunk',
-          created: 1,
-          model: modelId,
-          choices: [{ index: 0, delta: {}, finish_reason: 'tool_calls' }],
-          usage: { prompt_tokens: 8, completion_tokens: 4, total_tokens: 12 },
-        }]);
-        return;
-      }
-      respondOpenAIStream(response, [{
-        id: 'chatcmpl-zenmux-stream-final',
-        object: 'chat.completion.chunk',
-        created: 2,
-        model: modelId,
-        choices: [{ index: 0, delta: { role: 'assistant', content: 'Echoed hello.' }, finish_reason: null }],
-      }, {
-        id: 'chatcmpl-zenmux-stream-final',
-        object: 'chat.completion.chunk',
-        created: 2,
-        model: modelId,
-        choices: [{ index: 0, delta: {}, finish_reason: 'stop' }],
-        usage: { prompt_tokens: 14, completion_tokens: 3, total_tokens: 17 },
-      }]);
-    });
-    const connection: LlmConnection = {
-      slug: 'zenmux',
-      name: 'ZenMux',
-      providerType: 'zenmux',
-      baseUrl: `${server.url}/v1`,
-      defaultModel: modelId,
-      enabled: true,
-      createdAt: 1,
-      updatedAt: 1,
-    };
-
-    const result = streamText({
-      model: getAIModel({ connection, apiKey: 'zenmux-test-key', modelId }),
-      prompt: 'Call echo with hello.',
-      stopWhen: stepCountIs(2),
-      tools: {
-        echo: tool({
-          description: 'Echo text',
-          inputSchema: z.object({ text: z.string() }),
-          execute: async ({ text }) => ({ echoed: text }),
-        }),
-      },
-    });
-
-    assert.equal(await result.text, 'Echoed hello.');
-    assert.equal(requestBodies.length, 2);
-    assert.deepEqual(
-      (requestBodies[1].messages as Array<Record<string, unknown>>).find(({ role }) => role === 'assistant'),
-      {
-        role: 'assistant',
-        content: null,
-        reasoning: 'Use echo.',
-        reasoning_details: reasoningDetails,
-        tool_calls: [{
-          id: 'call_zenmux_stream_echo',
-          type: 'function',
-          function: { name: 'echo', arguments: '{"text":"hello"}' },
-        }],
-      },
-    );
   });
 
   test('OpenCode connection probes follow each selected model protocol', async () => {
@@ -2069,325 +1895,6 @@ describe('models.dev provider conformance', () => {
     assert.equal(result.text, 'Echoed hello.');
   });
 
-  test('Fireworks discovers exact serverless model paths and completes a two-stage tool-call loop', async () => {
-    const modelId = 'accounts/fireworks/models/kimi-k2p6';
-    const requestBodies: Array<Record<string, unknown>> = [];
-    const server = await startJsonServer(async (request, response) => {
-      assert.equal(request.headers.authorization, 'Bearer fireworks-test-key');
-      if (request.method === 'GET' && request.url === '/v1/accounts?pageSize=200') {
-        respondJson(response, 200, {
-          accounts: [{ name: 'accounts/acme' }],
-          nextPageToken: 'accounts-next',
-        });
-        return;
-      }
-      if (request.method === 'GET' && request.url === '/v1/accounts?pageSize=200&pageToken=accounts-next') {
-        respondJson(response, 200, { accounts: [{ name: 'accounts/team' }] });
-        return;
-      }
-      if (
-        request.method === 'GET'
-        && request.url === '/v1/accounts/acme/models?filter=supports_serverless%3Dtrue&pageSize=200'
-      ) {
-        respondJson(response, 200, {
-          models: [{
-            name: 'accounts/acme/models/custom-agent',
-            displayName: 'Custom Agent',
-            supportsTools: true,
-            supportsServerless: true,
-          }],
-          nextPageToken: 'models-next',
-        });
-        return;
-      }
-      if (
-        request.method === 'GET'
-        && request.url === '/v1/accounts/acme/models?filter=supports_serverless%3Dtrue&pageSize=200&pageToken=models-next'
-      ) {
-        respondJson(response, 200, {
-          models: [{
-            name: 'accounts/acme/models/custom-agent-v2',
-            displayName: 'Custom Agent V2',
-            supportsTools: true,
-            supportsServerless: true,
-          }],
-        });
-        return;
-      }
-      if (
-        request.method === 'GET'
-        && request.url === '/v1/accounts/team/models?filter=supports_serverless%3Dtrue&pageSize=200'
-      ) {
-        respondJson(response, 200, {
-          models: [{
-            name: 'accounts/team/models/team-agent',
-            displayName: 'Team Agent',
-            supportsTools: true,
-            supportsServerless: true,
-          }],
-        });
-        return;
-      }
-      if (
-        request.method === 'GET'
-        && request.url === '/v1/accounts/fireworks/models?filter=supports_serverless%3Dtrue&pageSize=200'
-      ) {
-        respondJson(response, 200, {
-          models: [{
-            name: modelId,
-            displayName: 'Kimi K2.6',
-            contextLength: 262_000,
-            supportsImageInput: true,
-            supportsTools: true,
-            supportsServerless: true,
-          }],
-        });
-        return;
-      }
-
-      assert.equal(request.method, 'POST');
-      assert.equal(request.url, '/inference/v1/chat/completions');
-      requestBodies.push(JSON.parse(await readBody(request)) as Record<string, unknown>);
-      if (requestBodies.length === 1) {
-        respondJson(response, 200, {
-          id: 'chatcmpl-fireworks-tool',
-          object: 'chat.completion',
-          created: 1,
-          model: modelId,
-          choices: [{
-            index: 0,
-            message: {
-              role: 'assistant',
-              content: null,
-              tool_calls: [{
-                id: 'call_echo',
-                type: 'function',
-                function: { name: 'echo', arguments: '{"text":"hello"}' },
-              }],
-            },
-            finish_reason: 'tool_calls',
-          }],
-          usage: { prompt_tokens: 8, completion_tokens: 4, total_tokens: 12 },
-        });
-        return;
-      }
-
-      respondJson(response, 200, {
-        id: 'chatcmpl-fireworks-final',
-        object: 'chat.completion',
-        created: 2,
-        model: modelId,
-        choices: [{
-          index: 0,
-          message: { role: 'assistant', content: 'Echoed hello.' },
-          finish_reason: 'stop',
-        }],
-        usage: { prompt_tokens: 12, completion_tokens: 3, total_tokens: 15 },
-      });
-    });
-    const connection: LlmConnection = {
-      slug: 'fireworks-ai',
-      name: 'Fireworks AI',
-      providerType: 'fireworks-ai',
-      baseUrl: `${server.url}/inference/v1`,
-      defaultModel: modelId,
-      enabled: true,
-      createdAt: 1,
-      updatedAt: 1,
-    };
-
-    const models = await fetchProviderModels(connection, 'fireworks-test-key');
-    assert.deepEqual(models, [
-      {
-        id: 'accounts/acme/models/custom-agent',
-        displayName: 'Custom Agent',
-        capabilities: { functionCalling: true },
-      },
-      {
-        id: 'accounts/acme/models/custom-agent-v2',
-        displayName: 'Custom Agent V2',
-        capabilities: { functionCalling: true },
-      },
-      {
-        id: 'accounts/team/models/team-agent',
-        displayName: 'Team Agent',
-        capabilities: { functionCalling: true },
-      },
-      {
-        id: modelId,
-        displayName: 'Kimi K2.6',
-        contextWindow: 262_000,
-        capabilities: { vision: true, functionCalling: true },
-      },
-    ]);
-
-    const result = await generateText({
-      model: getAIModel({ connection, apiKey: 'fireworks-test-key', modelId }),
-      prompt: 'Call echo with hello.',
-      stopWhen: stepCountIs(2),
-      tools: {
-        echo: tool({
-          description: 'Echo text',
-          inputSchema: z.object({ text: z.string() }),
-          execute: async ({ text }) => ({ echoed: text }),
-        }),
-      },
-    });
-
-    assert.deepEqual(requestBodies.map((body) => body.model), [modelId, modelId]);
-    assert.deepEqual(
-      (requestBodies[1].messages as Array<{ role: string; content: string }>).find(({ role }) => role === 'tool'),
-      { role: 'tool', content: '{"echoed":"hello"}', tool_call_id: 'call_echo' },
-    );
-    assert.equal(result.text, 'Echoed hello.');
-  });
-
-  for (const testCase of [
-    {
-      label: 'complex local model id',
-      discoveredModelIds: ['hf.co/bartowski/Qwen2.5-Coder-7B-Instruct-GGUF:Q4_K_M'],
-      modelId: 'hf.co/bartowski/Qwen2.5-Coder-7B-Instruct-GGUF:Q4_K_M',
-    },
-    {
-      label: 'cloud alias distinct from its local model id',
-      discoveredModelIds: ['qwen3.5', 'qwen3.5:cloud'],
-      modelId: 'qwen3.5:cloud',
-    },
-  ] as const) {
-    test(`Ollama preserves an exact ${testCase.label} through local discovery and a no-secret tool-call loop`, async () => {
-      await assertOllamaModelContract(testCase.discoveredModelIds, testCase.modelId);
-    });
-  }
-
-  test('Cohere paginates account models and completes its native V2 tool-call loop', async () => {
-    const modelId = 'command-a-plus-05-2026';
-    const requestBodies: Array<Record<string, unknown>> = [];
-    const modelListUrls: string[] = [];
-    const server = await startJsonServer(async (request, response) => {
-      assert.equal(request.headers.authorization, 'Bearer cohere-test-key');
-      if (request.method === 'GET' && request.url?.startsWith('/v1/models?')) {
-        modelListUrls.push(request.url);
-        const url = new URL(request.url, 'http://localhost');
-        assert.equal(url.searchParams.get('endpoint'), 'chat');
-        assert.equal(url.searchParams.get('page_size'), '1000');
-        if (!url.searchParams.has('page_token')) {
-          respondJson(response, 200, {
-            models: [
-              { name: modelId, is_deprecated: false, endpoints: ['chat'], context_length: 128_000 },
-              { name: 'retired-command', is_deprecated: true, endpoints: ['chat'], context_length: 4_000 },
-            ],
-            next_page_token: 'page-2',
-          });
-          return;
-        }
-        assert.equal(url.searchParams.get('page_token'), 'page-2');
-        respondJson(response, 200, {
-          models: [{
-            name: 'command-a-reasoning-08-2025',
-            is_deprecated: false,
-            endpoints: ['chat'],
-            context_length: 256_000,
-          }],
-          next_page_token: '',
-        });
-        return;
-      }
-
-      assert.equal(request.method, 'POST');
-      assert.equal(request.url, '/v2/chat');
-      const body = JSON.parse(await readBody(request)) as Record<string, unknown>;
-      requestBodies.push(body);
-      if (requestBodies.length === 1) {
-        respondJson(response, 200, {
-          generation_id: 'cohere-tool-turn',
-          finish_reason: 'TOOL_CALL',
-          message: {
-            role: 'assistant',
-            content: [],
-            tool_plan: 'Call echo.',
-            tool_calls: [{
-              id: 'call_echo',
-              type: 'function',
-              function: { name: 'echo', arguments: '{"text":"hello"}' },
-            }],
-          },
-          usage: {
-            billed_units: { input_tokens: 8, output_tokens: 4 },
-            tokens: { input_tokens: 8, output_tokens: 4 },
-          },
-        });
-        return;
-      }
-
-      respondJson(response, 200, {
-        generation_id: 'cohere-final-turn',
-        finish_reason: 'COMPLETE',
-        message: {
-          role: 'assistant',
-          content: [{ type: 'text', text: 'Echoed hello.' }],
-        },
-        usage: {
-          billed_units: { input_tokens: 12, output_tokens: 3 },
-          tokens: { input_tokens: 12, output_tokens: 3 },
-        },
-      });
-    });
-    const connection: LlmConnection = {
-      slug: 'cohere',
-      name: 'Cohere',
-      providerType: 'cohere',
-      baseUrl: `${server.url}/v2`,
-      defaultModel: modelId,
-      enabled: true,
-      createdAt: 1,
-      updatedAt: 1,
-    };
-
-    const models = await fetchProviderModels(connection, 'cohere-test-key');
-    assert.deepEqual(models, [
-      { id: modelId, contextWindow: 128_000 },
-      { id: 'command-a-reasoning-08-2025', contextWindow: 256_000 },
-    ]);
-    assert.equal(modelListUrls.length, 2);
-
-    const result = await generateText({
-      model: getAIModel({ connection, apiKey: 'cohere-test-key', modelId: models[0]!.id }),
-      prompt: 'Call echo with hello.',
-      stopWhen: stepCountIs(2),
-      tools: {
-        echo: tool({
-          description: 'Echo text',
-          inputSchema: z.object({ text: z.string() }),
-          execute: async ({ text }) => ({ echoed: text }),
-        }),
-      },
-    });
-
-    assert.equal(requestBodies.length, 2);
-    assert.deepEqual(requestBodies.map((body) => body.model), [modelId, modelId]);
-    assert.deepEqual(
-      (requestBodies[0].tools as Array<{ function: { name: string } }>).map((entry) => entry.function.name),
-      ['echo'],
-    );
-    const secondMessages = requestBodies[1]?.messages as Array<Record<string, unknown>>;
-    assert.deepEqual(secondMessages.find(({ role }) => role === 'assistant'), {
-      role: 'assistant',
-      tool_calls: [{
-        id: 'call_echo',
-        type: 'function',
-        function: { name: 'echo', arguments: '{"text":"hello"}' },
-      }],
-    });
-    assert.deepEqual(secondMessages.find(({ role }) => role === 'tool'), {
-      role: 'tool',
-      content: '{"echoed":"hello"}',
-      tool_call_id: 'call_echo',
-    });
-    assert.equal(result.steps[0]?.toolCalls[0]?.toolName, 'echo');
-    assert.deepEqual(result.steps[0]?.toolResults[0]?.output, { echoed: 'hello' });
-    assert.equal(result.text, 'Echoed hello.');
-  });
-
   test('Mistral discovers exact account model ids and completes its documented tool-call loop', async () => {
     const requestBodies: Array<Record<string, unknown>> = [];
     let modelListRequests = 0;
@@ -3346,99 +2853,6 @@ describe('models.dev provider conformance', () => {
   }
 });
 
-async function assertOllamaModelContract(
-  discoveredModelIds: readonly string[],
-  modelId: string,
-): Promise<void> {
-  const requestBodies: Array<Record<string, unknown>> = [];
-  const server = await startJsonServer(async (request, response) => {
-    if (request.method === 'GET' && request.url === '/api/tags') {
-      assert.equal(request.headers.authorization, undefined);
-      respondJson(response, 200, {
-        models: discoveredModelIds.map((id) => ({ name: id, model: id })),
-      });
-      return;
-    }
-    assert.equal(request.method, 'POST');
-    assert.equal(request.url, '/v1/chat/completions');
-    assert.equal(request.headers.authorization, undefined);
-    const body = JSON.parse(await readBody(request)) as Record<string, unknown>;
-    requestBodies.push(body);
-    if (requestBodies.length === 1) {
-      respondJson(response, 200, {
-        id: 'chatcmpl-ollama-tool',
-        object: 'chat.completion',
-        created: 1,
-        model: modelId,
-        choices: [{
-          index: 0,
-          message: {
-            role: 'assistant',
-            content: null,
-            tool_calls: [{
-              id: 'call_echo',
-              type: 'function',
-              function: { name: 'echo', arguments: '{"text":"hello"}' },
-            }],
-          },
-          finish_reason: 'tool_calls',
-        }],
-        usage: { prompt_tokens: 8, completion_tokens: 4, total_tokens: 12 },
-      });
-      return;
-    }
-    respondJson(response, 200, {
-      id: 'chatcmpl-ollama-final',
-      object: 'chat.completion',
-      created: 2,
-      model: modelId,
-      choices: [{
-        index: 0,
-        message: { role: 'assistant', content: 'Echoed hello.' },
-        finish_reason: 'stop',
-      }],
-      usage: { prompt_tokens: 12, completion_tokens: 3, total_tokens: 15 },
-    });
-  });
-  const connection: LlmConnection = {
-    slug: 'ollama-local',
-    name: 'Ollama',
-    providerType: 'ollama',
-    baseUrl: `${server.url}/v1`,
-    defaultModel: modelId,
-    enabled: true,
-    createdAt: 1,
-    updatedAt: 1,
-  };
-
-  assert.deepEqual(await fetchProviderModels(connection, ''), discoveredModelIds.map((id) => ({ id })));
-
-  const result = await generateText({
-    model: getAIModel({ connection, apiKey: '', modelId }),
-    prompt: 'Call echo with hello, then report the result.',
-    tools: {
-      echo: tool({
-        description: 'Echo text',
-        inputSchema: z.object({ text: z.string() }),
-        execute: async ({ text }) => ({ text }),
-      }),
-    },
-    stopWhen: stepCountIs(2),
-  });
-
-  assert.equal(result.text, 'Echoed hello.');
-  assert.equal(requestBodies.length, 2);
-  assert.deepEqual(requestBodies.map((body) => body.model), [modelId, modelId]);
-  assert.deepEqual(
-    (requestBodies[0].tools as Array<{ function: { name: string } }>).map((entry) => entry.function.name),
-    ['echo'],
-  );
-  const secondMessages = requestBodies[1]?.messages as Array<{ role: string; content: string }>;
-  const toolMessage = secondMessages.find((message) => message.role === 'tool');
-  assert.ok(toolMessage);
-  assert.deepEqual(JSON.parse(toolMessage.content), { text: 'hello' });
-}
-
 async function startJsonServer(
   handler: (request: IncomingMessage, response: ServerResponse) => void | Promise<void>,
 ): Promise<{ url: string; close(): Promise<void> }> {
@@ -3473,10 +2887,4 @@ function readBody(request: IncomingMessage): Promise<string> {
 function respondJson(response: ServerResponse, status: number, body: unknown): void {
   response.writeHead(status, { 'content-type': 'application/json' });
   response.end(JSON.stringify(body));
-}
-
-function respondOpenAIStream(response: ServerResponse, chunks: readonly unknown[]): void {
-  response.writeHead(200, { 'content-type': 'text/event-stream' });
-  for (const chunk of chunks) response.write(`data: ${JSON.stringify(chunk)}\n\n`);
-  response.end('data: [DONE]\n\n');
 }

--- a/packages/runtime/src/__tests__/provider-contract-matrix.test.ts
+++ b/packages/runtime/src/__tests__/provider-contract-matrix.test.ts
@@ -8,10 +8,12 @@
  *   - `generated`      a parametric wire test is executed against a scripted
  *                      local HTTP server (discovery, exact-model-id, tool-loop,
  *                      reasoning-replay), driven entirely by the derived cell.
- *   - `override`       the cell is asserted to have a named entry in
- *                      {@link OVERRIDE_REGISTRY}, each pointing at the
- *                      hand-written test (in `provider-conformance.test.ts` by
- *                      default) that owns the provider-specific contract.
+ *   - `override`       the cell binds to an executable entry in
+ *                      {@link PROVIDER_CONTRACT_OVERRIDE_BINDINGS}
+ *                      (`provider-contract-overrides.ts`), and this suite runs
+ *                      the bound provider-specific contract directly — deleting
+ *                      or breaking an override fails here, with no reliance on
+ *                      test titles in another source file.
  *   - `not-applicable` the machine-readable reason is asserted, and any reverse
  *                      assertion (e.g. fallback discovery must not call /models)
  *                      is executed.
@@ -19,16 +21,11 @@
  * The gap report (`test('no contract gaps ...')`) fails loudly, listing
  * provider + dimension + what is missing, whenever a ready provider's dimension
  * satisfies none of the three states — this is Phase 7's gap reporting.
- *
- * This file is purely additive. It does not modify or replace the hand-written
- * `provider-conformance.test.ts`; overlapping coverage is intentional.
  */
 
 import assert from 'node:assert/strict';
-import { readFileSync } from 'node:fs';
-import { createServer, type IncomingMessage, type ServerResponse } from 'node:http';
+import type { IncomingMessage } from 'node:http';
 import { after, describe, test } from 'node:test';
-import { fileURLToPath } from 'node:url';
 import type { LlmConnection } from '@maka/core';
 import {
   PROVIDER_CONTRACT_MATRIX_PLAN,
@@ -42,6 +39,11 @@ import { generateText, stepCountIs, tool } from 'ai';
 import { z } from 'zod';
 import { fetchProviderModels } from '../model-fetcher.js';
 import { getAIModel } from '../model-factory.js';
+import { closeAllJsonServers, readBody, respondJson, startJsonServer } from './conformance-harness.js';
+import {
+  PROVIDER_CONTRACT_OVERRIDE_BINDINGS,
+  type ProviderContractOverrideBinding,
+} from './provider-contract-overrides.js';
 
 const REASONING_TEXT = 'I should call echo with the requested text.';
 const FINAL_TEXT = 'Echoed hello.';
@@ -49,111 +51,12 @@ const API_KEY = 'contract-matrix-test-key';
 
 const plan = PROVIDER_CONTRACT_MATRIX_PLAN;
 
-const servers: Array<{ close(): Promise<void> }> = [];
+after(closeAllJsonServers);
 
-after(async () => {
-  await Promise.all(servers.map((server) => server.close()));
-});
-
-/** A named override binding a plan cell to a hand-written conformance test. */
-interface OverrideBinding {
-  /**
-   * Exact test title as it appears verbatim in the bound test source (for
-   * parametric tests, the literal template text including any `${...}`
-   * placeholder). The binding test below asserts the source still contains an
-   * enabled `test(` call whose complete quoted title equals this text, so
-   * deleting, renaming (even by suffix), or skipping the hand-written test
-   * breaks the matrix instead of leaving a silent gap.
-   */
-  test: string;
-  /**
-   * Source file (sibling of this suite) that owns the bound test.
-   * Defaults to {@link DEFAULT_OVERRIDE_TEST_FILE}.
-   */
-  file?: string;
-  /** Human-readable statement of the provider-specific contract the override owns. */
-  contract: string;
-}
-
-const DEFAULT_OVERRIDE_TEST_FILE = 'provider-conformance.test.ts';
-
-const GITHUB_COPILOT_OVERRIDE_TEST =
-  'GitHub Copilot discovers the account model and completes a reasoning tool loop on its exact wire';
-
-/**
- * Named overrides. Each key is a plan `overrideKey` (`${providerType}:${dimension}`)
- * and each value binds the hand-written test that owns the provider-specific
- * contract the plan cannot generate. A missing key here surfaces as a contract
- * gap; a stale or disabled `test` title fails the source binding test.
- */
-const OVERRIDE_REGISTRY: Readonly<Record<string, OverrideBinding>> = {
-  'cohere:discovery': {
-    test: 'Cohere paginates account models and completes its native V2 tool-call loop',
-    contract: 'Cohere native V2 paginated /v1/models discovery (endpoint=chat)',
-  },
-  'fireworks-ai:discovery': {
-    test: 'Fireworks discovers exact serverless model paths and completes a two-stage tool-call loop',
-    contract: 'Fireworks account pagination discovery over /v1/accounts + per-account /models',
-  },
-  'ollama:discovery': {
-    // eslint-disable-next-line no-template-curly-in-string -- literal source text of a parametric title
-    test: 'Ollama preserves an exact ${testCase.label} through local discovery and a no-secret tool-call loop',
-    contract: 'Ollama native /api/tags discovery',
-  },
-  'github-copilot:discovery': {
-    test: 'GitHub Copilot discovers only account-enabled tool models and preserves each exact endpoint wire',
-    file: 'model-fetcher.test.ts',
-    contract: 'GitHub Copilot subscription /models discovery (picker + endpoint gating)',
-  },
-  'github-copilot:exact-model-id': {
-    test: GITHUB_COPILOT_OVERRIDE_TEST,
-    contract: 'GitHub Copilot preserves the exact account model id on its subscription wire',
-  },
-  'github-copilot:tool-loop': {
-    test: GITHUB_COPILOT_OVERRIDE_TEST,
-    contract: 'GitHub Copilot completes a two-stage tool loop on its subscription wire',
-  },
-  'github-copilot:reasoning-replay': {
-    test: GITHUB_COPILOT_OVERRIDE_TEST,
-    contract: 'GitHub Copilot replays reasoning on its provider-specific per-model wire',
-  },
-  'zenmux:reasoning-replay': {
-    test: 'ZenMux replays signed reasoning details in the streamed runtime tool loop',
-    contract: 'Signed reasoning_details are replayed byte-for-byte, beyond a plain field rename',
-  },
-};
-
-/**
- * The suite runs compiled from `dist/` (sibling `.js`) but can also run straight
- * from `src/` (sibling `.ts`). Test titles survive compilation verbatim, so read
- * whichever sibling exists, resolved relative to this test file.
- */
-function readOverrideTestSource(file: string): string {
-  const errors: string[] = [];
-  for (const candidate of [`./${file}`, `./${file.replace(/\.ts$/, '.js')}`]) {
-    try {
-      return readFileSync(fileURLToPath(new URL(candidate, import.meta.url)), 'utf8');
-    } catch (error) {
-      errors.push(`${candidate}: ${(error as Error).message}`);
-    }
-  }
-  throw new Error(`override test source "${file}" not found next to the matrix suite:\n${errors.join('\n')}`);
-}
-
-/**
- * True when the source contains an *enabled* `test(` call whose complete quoted
- * title equals the bound title — `test('title'`, `test("title"`, or
- * `` test(`title` `` (the backtick form covers parametric template-literal
- * titles, whose bound text includes the `${...}` placeholder verbatim).
- * Requiring the closing quote means renaming the test — even by appending a
- * suffix — breaks the binding. `test.skip(` / `test.todo(` never match because
- * their call prefix differs. Known residual: this is a textual check, so a
- * fully commented-out `test(...)` line still matches; the Phase 8 executable
- * override binding removes that class.
- */
-function hasEnabledTestCall(source: string, title: string): boolean {
-  return ["'", '"', '`'].some((quote) => source.includes(`test(${quote}${title}${quote}`));
-}
+/** Executable override lookup: plan `overrideKey` → its runnable binding. */
+const OVERRIDE_BINDING_BY_KEY: ReadonlyMap<string, ProviderContractOverrideBinding> = new Map(
+  PROVIDER_CONTRACT_OVERRIDE_BINDINGS.flatMap((binding) => binding.keys.map((key) => [key, binding])),
+);
 
 const KNOWN_WIRES: ReadonlySet<ProviderContractWire> = new Set([
   'openai-chat',
@@ -176,8 +79,8 @@ describe('provider conformance matrix — gap report', () => {
           }
           break;
         case 'override':
-          if (!OVERRIDE_REGISTRY[cell.overrideKey]) {
-            gaps.push(`${where}: no named override registered for key "${cell.overrideKey}"`);
+          if (!OVERRIDE_BINDING_BY_KEY.has(cell.overrideKey)) {
+            gaps.push(`${where}: no executable override binding registered for key "${cell.overrideKey}"`);
           }
           break;
         case 'not-applicable':
@@ -190,47 +93,28 @@ describe('provider conformance matrix — gap report', () => {
     assert.deepEqual(gaps, [], `provider contract gaps found:\n  ${gaps.join('\n  ')}`);
   });
 
-  test('every registered override maps to a real override cell in the plan', () => {
+  test('every registered override binding maps to a real override cell in the plan', () => {
     const overrideKeys = new Set(
       listProviderContractCells(plan)
         .filter((entry) => entry.cell.state === 'override')
         .map((entry) => (entry.cell.state === 'override' ? entry.cell.overrideKey : '')),
     );
-    for (const key of Object.keys(OVERRIDE_REGISTRY)) {
-      assert.ok(overrideKeys.has(key), `override registry key "${key}" has no matching override cell`);
-    }
-  });
-
-  test('every registered override title is an enabled test call in its bound source file', () => {
-    const sources = new Map<string, string>();
-    for (const [key, binding] of Object.entries(OVERRIDE_REGISTRY)) {
-      const file = binding.file ?? DEFAULT_OVERRIDE_TEST_FILE;
-      let source = sources.get(file);
-      if (source === undefined) {
-        source = readOverrideTestSource(file);
-        sources.set(file, source);
+    const seen = new Set<string>();
+    for (const binding of PROVIDER_CONTRACT_OVERRIDE_BINDINGS) {
+      assert.ok(binding.keys.length > 0, `override binding "${binding.title}" must own at least one key`);
+      for (const key of binding.keys) {
+        assert.ok(!seen.has(key), `override key "${key}" is bound by more than one executable binding`);
+        seen.add(key);
+        assert.ok(overrideKeys.has(key), `override binding key "${key}" has no matching override cell`);
       }
-      if (hasEnabledTestCall(source, binding.test)) continue;
-      assert.fail(
-        source.includes(binding.test)
-          ? `override "${key}": the bound title exists in ${file} but is not an enabled test call `
-            + `(is it test.skip/test.todo, or referenced outside a test(...)?): "${binding.test}" `
-            + '— re-enable the hand-written test or update the binding'
-          : `override "${key}" is bound to a test title that no longer exists in ${file}: `
-            + `"${binding.test}" — update the binding or restore the hand-written test`,
-      );
     }
   });
 });
 
-describe('provider conformance matrix — override cells reference a named hand-written test', () => {
-  for (const { providerType, dimension, cell } of listProviderContractCells(plan)) {
-    if (cell.state !== 'override') continue;
-    test(`${providerType} · ${dimension} · override → ${cell.overrideKey}`, () => {
-      const reference = OVERRIDE_REGISTRY[cell.overrideKey];
-      assert.ok(reference, `expected a named override for ${cell.overrideKey}`);
-      assert.ok(reference.test.length > 0, `override for ${cell.overrideKey} must name its hand-written test title`);
-      assert.ok(reference.contract.length > 0, `override for ${cell.overrideKey} must describe its contract`);
+describe('provider conformance matrix — override cells execute their bound contract', () => {
+  for (const binding of PROVIDER_CONTRACT_OVERRIDE_BINDINGS) {
+    test(`${binding.keys.join(' + ')} · ${binding.title}`, async () => {
+      await binding.run();
     });
   }
 });
@@ -266,6 +150,33 @@ describe('provider conformance matrix — wire (exact-model-id + tool-loop + rea
 // Generated discovery execution
 // ---------------------------------------------------------------------------
 
+/**
+ * The per-run credential expectation a generated discovery cell expands into.
+ * `default` runs once with the provider credential; `none` runs once with no
+ * credential on the wire; `optional` (optional_api_key providers such as
+ * LocalAI) runs twice — a configured key must reach the wire, and an absent key
+ * must leave the request credential-free rather than sending a dummy value.
+ */
+interface DiscoveryCredentialCase {
+  label: 'provider-auth' | 'no-auth' | 'optional-with-key' | 'optional-without-key';
+  apiKey: string;
+  expectCredential: boolean;
+}
+
+function discoveryCredentialCases(auth: ProviderContractDiscoveryPlan['auth']): DiscoveryCredentialCase[] {
+  switch (auth) {
+    case 'default':
+      return [{ label: 'provider-auth', apiKey: API_KEY, expectCredential: true }];
+    case 'none':
+      return [{ label: 'no-auth', apiKey: API_KEY, expectCredential: false }];
+    case 'optional':
+      return [
+        { label: 'optional-with-key', apiKey: API_KEY, expectCredential: true },
+        { label: 'optional-without-key', apiKey: '', expectCredential: false },
+      ];
+  }
+}
+
 async function runGeneratedDiscovery(
   row: ProviderContractRow,
   cell: ProviderContractGeneratedCell & { discovery: NonNullable<ProviderContractGeneratedCell['discovery']> },
@@ -277,30 +188,32 @@ async function runGeneratedDiscovery(
   const payloadShapes: ReadonlyArray<'data-object' | 'bare-array'> =
     discovery.responseShape === 'array-or-data' ? ['data-object', 'bare-array'] : ['data-object'];
   for (const shape of payloadShapes) {
-    const where = `${row.providerType} discovery (${shape} payload)`;
-    // Handler assertion failures are recorded and rethrown after the fetch so
-    // the test fails with the request-contract message instead of a generic
-    // "failed to fetch models" wrapper.
-    const handlerErrors: unknown[] = [];
-    let requestCount = 0;
-    const server = await startJsonServer((request, response) => {
-      requestCount += 1;
-      try {
-        assertDiscoveryRequest(row, discovery, request);
-      } catch (error) {
-        handlerErrors.push(error);
-      }
-      respondJson(response, 200, discoveryPayload(discovery.protocol, sample, discovery.filter, shape));
-    });
-    const connection = baseConnection(row, server.url);
-    const models = await fetchProviderModels(connection, API_KEY);
-    if (handlerErrors.length > 0) throw handlerErrors[0];
-    assert.ok(requestCount >= 1, `${where} must request the model list`);
-    assert.deepEqual(
-      models.map((model) => model.id),
-      [sample],
-      `${where} should return exactly the scripted exact id`,
-    );
+    for (const credentialCase of discoveryCredentialCases(discovery.auth)) {
+      const where = `${row.providerType} discovery (${shape} payload, ${credentialCase.label})`;
+      // Handler assertion failures are recorded and rethrown after the fetch so
+      // the test fails with the request-contract message instead of a generic
+      // "failed to fetch models" wrapper.
+      const handlerErrors: unknown[] = [];
+      let requestCount = 0;
+      const server = await startJsonServer((request, response) => {
+        requestCount += 1;
+        try {
+          assertDiscoveryRequest(row, discovery, credentialCase, request);
+        } catch (error) {
+          handlerErrors.push(error);
+        }
+        respondJson(response, 200, discoveryPayload(discovery.protocol, sample, discovery.filter, shape));
+      });
+      const connection = baseConnection(row, server.url);
+      const models = await fetchProviderModels(connection, credentialCase.apiKey);
+      if (handlerErrors.length > 0) throw handlerErrors[0];
+      assert.ok(requestCount >= 1, `${where} must request the model list`);
+      assert.deepEqual(
+        models.map((model) => model.id),
+        [sample],
+        `${where} should return exactly the scripted exact id`,
+      );
+    }
   }
 }
 
@@ -309,9 +222,9 @@ async function runGeneratedDiscovery(
  * auth — mirroring `model-fetcher.ts`'s real URL/header construction:
  *
  *   - openai:    `{baseUrl}{path ?? '/models'}?{query}` with a Bearer credential
- *                when the cell declares provider auth *and* the provider's
- *                authKind actually supports an API key (lm-studio declares
- *                `authKind: 'none'`, so its wire carries no credential).
+ *                when the credential case expects one (lm-studio declares
+ *                `authKind: 'none'` and LocalAI without a configured key sends
+ *                nothing, so those wires carry no credential).
  *   - anthropic: `{baseUrl}/v1/models` with the `x-api-key` credential header.
  *   - google:    `{baseUrl}/v1beta/models?key={apiKey}` — the credential rides
  *                the `key` query parameter, never a header.
@@ -319,9 +232,10 @@ async function runGeneratedDiscovery(
 function assertDiscoveryRequest(
   row: ProviderContractRow,
   discovery: ProviderContractDiscoveryPlan,
+  credentialCase: DiscoveryCredentialCase,
   request: IncomingMessage,
 ): void {
-  const where = `${row.providerType} discovery`;
+  const where = `${row.providerType} discovery (${credentialCase.label})`;
   assert.equal(request.method, 'GET', `${where} must GET the model list`);
   const url = new URL(request.url ?? '', 'http://contract.test');
 
@@ -334,22 +248,24 @@ function assertDiscoveryRequest(
 
   // Query: exactly the declared parameters (google adds its key-query credential).
   const expectedQuery: Record<string, string> = { ...(discovery.query ?? {}) };
-  if (discovery.protocol === 'google' && discovery.auth !== 'none') expectedQuery.key = API_KEY;
+  if (discovery.protocol === 'google' && credentialCase.expectCredential) expectedQuery.key = API_KEY;
   assert.deepEqual(
     Object.fromEntries(url.searchParams),
     expectedQuery,
     `${where} must send exactly the declared query parameters`,
   );
 
-  // Auth: public cells must carry no credential; default cells must carry the
-  // protocol's credential exactly as model-fetcher constructs it.
+  // Auth: credential-free cases (public lists, `authKind: 'none'`, and
+  // optional_api_key with no configured key) must not inject any credential —
+  // not even a dummy value; credentialed cases must carry the protocol's
+  // credential exactly as model-fetcher constructs it.
   const authorization = request.headers.authorization;
   const xApiKey = request.headers['x-api-key'];
   const xGoogApiKey = request.headers['x-goog-api-key'];
-  if (discovery.auth === 'none') {
-    assert.equal(authorization, undefined, `${where} is public: it must not send an Authorization header`);
-    assert.equal(xApiKey, undefined, `${where} is public: it must not send an x-api-key header`);
-    assert.equal(xGoogApiKey, undefined, `${where} is public: it must not send an x-goog-api-key header`);
+  if (!credentialCase.expectCredential) {
+    assert.equal(authorization, undefined, `${where} must not send an Authorization header`);
+    assert.equal(xApiKey, undefined, `${where} must not send an x-api-key header`);
+    assert.equal(xGoogApiKey, undefined, `${where} must not send an x-goog-api-key header`);
     return;
   }
   switch (discovery.protocol) {
@@ -807,40 +723,4 @@ function baseConnection(row: ProviderContractRow, baseUrl: string): LlmConnectio
     createdAt: 1,
     updatedAt: 1,
   };
-}
-
-async function startJsonServer(
-  handler: (request: IncomingMessage, response: ServerResponse) => void | Promise<void>,
-): Promise<{ url: string; close(): Promise<void> }> {
-  const server = createServer((request, response) => {
-    void Promise.resolve(handler(request, response)).catch((error) => {
-      response.destroy(error as Error);
-    });
-  });
-  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
-  const address = server.address();
-  assert.ok(address && typeof address === 'object');
-  const control = {
-    url: `http://127.0.0.1:${address.port}`,
-    close: () => new Promise<void>((resolve, reject) => {
-      server.close((error) => (error ? reject(error) : resolve()));
-    }),
-  };
-  servers.push(control);
-  return control;
-}
-
-function readBody(request: IncomingMessage): Promise<string> {
-  return new Promise((resolve, reject) => {
-    let body = '';
-    request.setEncoding('utf8');
-    request.on('data', (chunk) => { body += chunk; });
-    request.on('end', () => resolve(body));
-    request.on('error', reject);
-  });
-}
-
-function respondJson(response: ServerResponse, status: number, body: unknown): void {
-  response.writeHead(status, { 'content-type': 'application/json' });
-  response.end(JSON.stringify(body));
 }

--- a/packages/runtime/src/__tests__/provider-contract-overrides.ts
+++ b/packages/runtime/src/__tests__/provider-contract-overrides.ts
@@ -1,0 +1,787 @@
+/**
+ * Executable override bindings for the provider conformance matrix.
+ *
+ * Every matrix cell the plan marks `override` binds here to a real, runnable
+ * assertion instead of a hand-written test title. The matrix suite executes
+ * each binding directly, so deleting, breaking, or orphaning an override
+ * fails the matrix — there is no textual source check that a commented-out
+ * test could satisfy. A plan override cell without a binding (or a binding
+ * without a plan cell) fails the gap report in the matrix suite.
+ *
+ * Not a test file itself: node --test only runs `*.test.js`, so these bodies
+ * execute exactly once, from `provider-contract-matrix.test.ts`.
+ */
+
+import assert from 'node:assert/strict';
+import type { LlmConnection } from '@maka/core';
+import { generateText, stepCountIs, streamText, tool } from 'ai';
+import { z } from 'zod';
+import { fetchProviderModels } from '../model-fetcher.js';
+import { getAIModel } from '../model-factory.js';
+import { buildSubscriptionModelFetch } from '../subscription-model-fetch.js';
+import { readBody, respondJson, respondOpenAIStream, startJsonServer } from './conformance-harness.js';
+
+export interface ProviderContractOverrideBinding {
+  /** Plan override keys (`${providerType}:${dimension}`) this executable owns. */
+  keys: readonly string[];
+  /** Human-readable statement of the provider-specific contract, used as the test title. */
+  title: string;
+  run(): Promise<void>;
+}
+
+export const PROVIDER_CONTRACT_OVERRIDE_BINDINGS: readonly ProviderContractOverrideBinding[] = [
+  {
+    keys: ['github-copilot:discovery'],
+    title: 'GitHub Copilot discovers only account-enabled tool models and preserves each exact endpoint wire',
+    run: runGitHubCopilotDiscovery,
+  },
+  {
+    keys: ['github-copilot:exact-model-id', 'github-copilot:tool-loop', 'github-copilot:reasoning-replay'],
+    title: 'GitHub Copilot discovers the account model and completes a reasoning tool loop on its exact wire',
+    run: runGitHubCopilotWire,
+  },
+  {
+    keys: ['fireworks-ai:discovery'],
+    title: 'Fireworks discovers exact serverless model paths and completes a two-stage tool-call loop',
+    run: runFireworksDiscovery,
+  },
+  {
+    keys: ['ollama:discovery'],
+    title: 'Ollama preserves exact local model ids (complex ids and cloud aliases) through /api/tags discovery and a no-secret tool-call loop',
+    run: runOllamaDiscovery,
+  },
+  {
+    keys: ['cohere:discovery'],
+    title: 'Cohere paginates account models and completes its native V2 tool-call loop',
+    run: runCohereDiscovery,
+  },
+  {
+    keys: ['zenmux:reasoning-replay'],
+    title: 'ZenMux replays signed reasoning details in the streamed runtime tool loop',
+    run: runZenMuxSignedReasoningReplay,
+  },
+];
+
+async function runGitHubCopilotDiscovery(): Promise<void> {
+  const server = await startJsonServer((request, response) => {
+    assert.equal(request.method, 'GET');
+    assert.equal(request.url, '/models');
+    assert.equal(request.headers.authorization, 'Bearer github-account-token');
+    assert.equal(request.headers['user-agent'], 'GitHubCopilotChat/0.35.0');
+    assert.equal(request.headers['editor-version'], 'vscode/1.107.0');
+    assert.equal(request.headers['editor-plugin-version'], 'copilot-chat/0.35.0');
+    assert.equal(request.headers['copilot-integration-id'], 'vscode-chat');
+    assert.equal(request.headers['x-github-api-version'], '2026-06-01');
+    respondJson(response, 200, {
+      data: [
+        copilotModel('gpt-5.4', ['/responses']),
+        copilotModel('claude-sonnet-4.6', ['/v1/messages']),
+        copilotModel('gemini-3.1-pro-preview', ['/chat/completions']),
+        { ...copilotModel('disabled-by-policy', ['/chat/completions']), policy: { state: 'disabled' } },
+        { ...copilotModel('hidden-from-picker', ['/chat/completions']), model_picker_enabled: false },
+        { ...copilotModel('no-tools', ['/chat/completions']), capabilities: { supports: { tool_calls: false } } },
+        copilotModel('unsupported-wire', ['/embeddings']),
+      ],
+    });
+  });
+
+  const models = await fetchProviderModels({
+    slug: 'github-copilot',
+    name: 'GitHub Copilot',
+    providerType: 'github-copilot',
+    baseUrl: server.url,
+    defaultModel: 'gpt-5.4',
+    enabled: true,
+    createdAt: 1,
+    updatedAt: 1,
+  }, 'github-account-token');
+
+  assert.deepEqual(models, [
+    {
+      id: 'gpt-5.4',
+      displayName: 'gpt-5.4 display',
+      contextWindow: 400_000,
+      maxOutputTokens: 128_000,
+      apiProtocol: 'openai-responses',
+      capabilities: { vision: true, reasoning: true, functionCalling: true },
+    },
+    {
+      id: 'claude-sonnet-4.6',
+      displayName: 'claude-sonnet-4.6 display',
+      contextWindow: 400_000,
+      maxOutputTokens: 128_000,
+      apiProtocol: 'anthropic-messages',
+      capabilities: { vision: true, reasoning: true, functionCalling: true },
+    },
+    {
+      id: 'gemini-3.1-pro-preview',
+      displayName: 'gemini-3.1-pro-preview display',
+      contextWindow: 400_000,
+      maxOutputTokens: 128_000,
+      apiProtocol: 'openai-chat',
+      capabilities: { vision: true, reasoning: true, functionCalling: true },
+    },
+  ]);
+}
+
+function copilotModel(id: string, supportedEndpoints: string[]): Record<string, unknown> {
+  return {
+    id,
+    name: `${id} display`,
+    model_picker_enabled: true,
+    supported_endpoints: supportedEndpoints,
+    policy: { state: 'enabled' },
+    capabilities: {
+      limits: {
+        max_prompt_tokens: 400_000,
+        max_output_tokens: 128_000,
+      },
+      supports: {
+        tool_calls: true,
+        vision: true,
+        reasoning_effort: ['low', 'medium', 'high'],
+      },
+    },
+  };
+}
+
+async function runGitHubCopilotWire(): Promise<void> {
+  const modelId = 'gemini-3.1-pro-preview';
+  const requestBodies: Array<Record<string, unknown>> = [];
+  const initiators: string[] = [];
+  const server = await startJsonServer(async (request, response) => {
+    assert.equal(request.headers.authorization, 'Bearer github-account-token');
+    if (request.method === 'GET' && request.url === '/models') {
+      respondJson(response, 200, {
+        data: [{
+          id: modelId,
+          name: 'Gemini 3.1 Pro Preview',
+          model_picker_enabled: true,
+          supported_endpoints: ['/chat/completions'],
+          policy: { state: 'enabled' },
+          capabilities: {
+            limits: { max_prompt_tokens: 400_000, max_output_tokens: 64_000 },
+            supports: { tool_calls: true, reasoning_effort: ['low', 'medium', 'high'] },
+          },
+        }],
+      });
+      return;
+    }
+    assert.equal(request.method, 'POST');
+    assert.equal(request.url, '/chat/completions');
+    assert.equal(request.headers['openai-intent'], 'conversation-edits');
+    assert.equal(request.headers['x-github-api-version'], '2026-06-01');
+    initiators.push(String(request.headers['x-initiator']));
+    requestBodies.push(JSON.parse(await readBody(request)) as Record<string, unknown>);
+    if (requestBodies.length === 1) {
+      respondJson(response, 200, {
+        id: 'copilot-tool',
+        object: 'chat.completion',
+        created: 1,
+        model: modelId,
+        choices: [{
+          index: 0,
+          message: {
+            role: 'assistant',
+            content: null,
+            reasoning_content: 'I should use the echo tool.',
+            tool_calls: [{
+              id: 'call-copilot-echo',
+              type: 'function',
+              function: { name: 'echo', arguments: '{"text":"hello"}' },
+            }],
+          },
+          finish_reason: 'tool_calls',
+        }],
+        usage: { prompt_tokens: 8, completion_tokens: 4, total_tokens: 12 },
+      });
+      return;
+    }
+    respondJson(response, 200, {
+      id: 'copilot-final',
+      object: 'chat.completion',
+      created: 2,
+      model: modelId,
+      choices: [{
+        index: 0,
+        message: { role: 'assistant', content: 'Echoed hello.' },
+        finish_reason: 'stop',
+      }],
+      usage: { prompt_tokens: 12, completion_tokens: 3, total_tokens: 15 },
+    });
+  });
+  const connection: LlmConnection = {
+    slug: 'github-copilot',
+    name: 'GitHub Copilot',
+    providerType: 'github-copilot',
+    baseUrl: server.url,
+    defaultModel: modelId,
+    enabled: true,
+    createdAt: 1,
+    updatedAt: 1,
+  };
+  const models = await fetchProviderModels(connection, 'github-account-token');
+  connection.models = models;
+  const modelFetch = buildSubscriptionModelFetch({
+    connection,
+    sessionId: 'session-copilot',
+    modelId,
+    fetchFn: fetch,
+  });
+  assert.ok(modelFetch);
+
+  const result = await generateText({
+    model: getAIModel({
+      connection,
+      apiKey: 'github-account-token',
+      modelId,
+      fetch: modelFetch,
+    }),
+    prompt: 'Call echo with hello.',
+    stopWhen: stepCountIs(2),
+    tools: {
+      echo: tool({
+        description: 'Echo text',
+        inputSchema: z.object({ text: z.string() }),
+        execute: async ({ text }) => ({ echoed: text }),
+      }),
+    },
+  });
+
+  assert.deepEqual(models.map((model) => [model.id, model.apiProtocol]), [[modelId, 'openai-chat']]);
+  assert.deepEqual(initiators, ['user', 'agent']);
+  assert.equal(requestBodies[0]?.model, modelId);
+  assert.equal(result.steps[0]?.reasoningText, 'I should use the echo tool.');
+  assert.deepEqual(result.steps[0]?.toolResults[0]?.output, { echoed: 'hello' });
+  // Turn two must carry the exact model id, replay the assistant tool-call
+  // turn (original tool_calls id + reasoning_content verbatim), and link the
+  // tool result back through tool_call_id.
+  assert.equal(requestBodies[1]?.model, modelId);
+  const secondMessages = requestBodies[1]?.messages as Array<Record<string, unknown>>;
+  const assistant = secondMessages.find((message) => message.role === 'assistant');
+  assert.ok(assistant, 'turn two must replay the assistant tool-call turn');
+  assert.deepEqual(
+    (assistant.tool_calls as Array<{ id: string }>).map(({ id }) => id),
+    ['call-copilot-echo'],
+    'turn two must replay the original tool_calls id',
+  );
+  assert.equal(
+    assistant.reasoning_content,
+    'I should use the echo tool.',
+    'turn two must replay the first-turn reasoning verbatim as reasoning_content',
+  );
+  const toolMessage = secondMessages.find((message) => message.role === 'tool');
+  assert.ok(toolMessage, 'turn two must carry a tool message with the echo result');
+  assert.equal(toolMessage.tool_call_id, 'call-copilot-echo');
+  const toolMessageContent = JSON.stringify(toolMessage.content);
+  assert.ok(
+    toolMessageContent.includes('echoed') && toolMessageContent.includes('hello'),
+    `turn two tool message must carry the echo output, got ${toolMessageContent}`,
+  );
+  assert.equal(result.text, 'Echoed hello.');
+}
+
+async function runFireworksDiscovery(): Promise<void> {
+  const modelId = 'accounts/fireworks/models/kimi-k2p6';
+  const requestBodies: Array<Record<string, unknown>> = [];
+  const server = await startJsonServer(async (request, response) => {
+    assert.equal(request.headers.authorization, 'Bearer fireworks-test-key');
+    if (request.method === 'GET' && request.url === '/v1/accounts?pageSize=200') {
+      respondJson(response, 200, {
+        accounts: [{ name: 'accounts/acme' }],
+        nextPageToken: 'accounts-next',
+      });
+      return;
+    }
+    if (request.method === 'GET' && request.url === '/v1/accounts?pageSize=200&pageToken=accounts-next') {
+      respondJson(response, 200, { accounts: [{ name: 'accounts/team' }] });
+      return;
+    }
+    if (
+      request.method === 'GET'
+      && request.url === '/v1/accounts/acme/models?filter=supports_serverless%3Dtrue&pageSize=200'
+    ) {
+      respondJson(response, 200, {
+        models: [{
+          name: 'accounts/acme/models/custom-agent',
+          displayName: 'Custom Agent',
+          supportsTools: true,
+          supportsServerless: true,
+        }],
+        nextPageToken: 'models-next',
+      });
+      return;
+    }
+    if (
+      request.method === 'GET'
+      && request.url === '/v1/accounts/acme/models?filter=supports_serverless%3Dtrue&pageSize=200&pageToken=models-next'
+    ) {
+      respondJson(response, 200, {
+        models: [{
+          name: 'accounts/acme/models/custom-agent-v2',
+          displayName: 'Custom Agent V2',
+          supportsTools: true,
+          supportsServerless: true,
+        }],
+      });
+      return;
+    }
+    if (
+      request.method === 'GET'
+      && request.url === '/v1/accounts/team/models?filter=supports_serverless%3Dtrue&pageSize=200'
+    ) {
+      respondJson(response, 200, {
+        models: [{
+          name: 'accounts/team/models/team-agent',
+          displayName: 'Team Agent',
+          supportsTools: true,
+          supportsServerless: true,
+        }],
+      });
+      return;
+    }
+    if (
+      request.method === 'GET'
+      && request.url === '/v1/accounts/fireworks/models?filter=supports_serverless%3Dtrue&pageSize=200'
+    ) {
+      respondJson(response, 200, {
+        models: [{
+          name: modelId,
+          displayName: 'Kimi K2.6',
+          contextLength: 262_000,
+          supportsImageInput: true,
+          supportsTools: true,
+          supportsServerless: true,
+        }],
+      });
+      return;
+    }
+
+    assert.equal(request.method, 'POST');
+    assert.equal(request.url, '/inference/v1/chat/completions');
+    requestBodies.push(JSON.parse(await readBody(request)) as Record<string, unknown>);
+    if (requestBodies.length === 1) {
+      respondJson(response, 200, {
+        id: 'chatcmpl-fireworks-tool',
+        object: 'chat.completion',
+        created: 1,
+        model: modelId,
+        choices: [{
+          index: 0,
+          message: {
+            role: 'assistant',
+            content: null,
+            tool_calls: [{
+              id: 'call_echo',
+              type: 'function',
+              function: { name: 'echo', arguments: '{"text":"hello"}' },
+            }],
+          },
+          finish_reason: 'tool_calls',
+        }],
+        usage: { prompt_tokens: 8, completion_tokens: 4, total_tokens: 12 },
+      });
+      return;
+    }
+
+    respondJson(response, 200, {
+      id: 'chatcmpl-fireworks-final',
+      object: 'chat.completion',
+      created: 2,
+      model: modelId,
+      choices: [{
+        index: 0,
+        message: { role: 'assistant', content: 'Echoed hello.' },
+        finish_reason: 'stop',
+      }],
+      usage: { prompt_tokens: 12, completion_tokens: 3, total_tokens: 15 },
+    });
+  });
+  const connection: LlmConnection = {
+    slug: 'fireworks-ai',
+    name: 'Fireworks AI',
+    providerType: 'fireworks-ai',
+    baseUrl: `${server.url}/inference/v1`,
+    defaultModel: modelId,
+    enabled: true,
+    createdAt: 1,
+    updatedAt: 1,
+  };
+
+  const models = await fetchProviderModels(connection, 'fireworks-test-key');
+  assert.deepEqual(models, [
+    {
+      id: 'accounts/acme/models/custom-agent',
+      displayName: 'Custom Agent',
+      capabilities: { functionCalling: true },
+    },
+    {
+      id: 'accounts/acme/models/custom-agent-v2',
+      displayName: 'Custom Agent V2',
+      capabilities: { functionCalling: true },
+    },
+    {
+      id: 'accounts/team/models/team-agent',
+      displayName: 'Team Agent',
+      capabilities: { functionCalling: true },
+    },
+    {
+      id: modelId,
+      displayName: 'Kimi K2.6',
+      contextWindow: 262_000,
+      capabilities: { vision: true, functionCalling: true },
+    },
+  ]);
+
+  const result = await generateText({
+    model: getAIModel({ connection, apiKey: 'fireworks-test-key', modelId }),
+    prompt: 'Call echo with hello.',
+    stopWhen: stepCountIs(2),
+    tools: {
+      echo: tool({
+        description: 'Echo text',
+        inputSchema: z.object({ text: z.string() }),
+        execute: async ({ text }) => ({ echoed: text }),
+      }),
+    },
+  });
+
+  assert.deepEqual(requestBodies.map((body) => body.model), [modelId, modelId]);
+  assert.deepEqual(
+    (requestBodies[1].messages as Array<{ role: string; content: string }>).find(({ role }) => role === 'tool'),
+    { role: 'tool', content: '{"echoed":"hello"}', tool_call_id: 'call_echo' },
+  );
+  assert.equal(result.text, 'Echoed hello.');
+}
+
+async function runOllamaDiscovery(): Promise<void> {
+  // Complex local model id, then a cloud alias distinct from its local model id.
+  await assertOllamaModelContract(
+    ['hf.co/bartowski/Qwen2.5-Coder-7B-Instruct-GGUF:Q4_K_M'],
+    'hf.co/bartowski/Qwen2.5-Coder-7B-Instruct-GGUF:Q4_K_M',
+  );
+  await assertOllamaModelContract(['qwen3.5', 'qwen3.5:cloud'], 'qwen3.5:cloud');
+}
+
+async function assertOllamaModelContract(
+  discoveredModelIds: readonly string[],
+  modelId: string,
+): Promise<void> {
+  const requestBodies: Array<Record<string, unknown>> = [];
+  const server = await startJsonServer(async (request, response) => {
+    if (request.method === 'GET' && request.url === '/api/tags') {
+      assert.equal(request.headers.authorization, undefined);
+      respondJson(response, 200, {
+        models: discoveredModelIds.map((id) => ({ name: id, model: id })),
+      });
+      return;
+    }
+    assert.equal(request.method, 'POST');
+    assert.equal(request.url, '/v1/chat/completions');
+    assert.equal(request.headers.authorization, undefined);
+    const body = JSON.parse(await readBody(request)) as Record<string, unknown>;
+    requestBodies.push(body);
+    if (requestBodies.length === 1) {
+      respondJson(response, 200, {
+        id: 'chatcmpl-ollama-tool',
+        object: 'chat.completion',
+        created: 1,
+        model: modelId,
+        choices: [{
+          index: 0,
+          message: {
+            role: 'assistant',
+            content: null,
+            tool_calls: [{
+              id: 'call_echo',
+              type: 'function',
+              function: { name: 'echo', arguments: '{"text":"hello"}' },
+            }],
+          },
+          finish_reason: 'tool_calls',
+        }],
+        usage: { prompt_tokens: 8, completion_tokens: 4, total_tokens: 12 },
+      });
+      return;
+    }
+    respondJson(response, 200, {
+      id: 'chatcmpl-ollama-final',
+      object: 'chat.completion',
+      created: 2,
+      model: modelId,
+      choices: [{
+        index: 0,
+        message: { role: 'assistant', content: 'Echoed hello.' },
+        finish_reason: 'stop',
+      }],
+      usage: { prompt_tokens: 12, completion_tokens: 3, total_tokens: 15 },
+    });
+  });
+  const connection: LlmConnection = {
+    slug: 'ollama-local',
+    name: 'Ollama',
+    providerType: 'ollama',
+    baseUrl: `${server.url}/v1`,
+    defaultModel: modelId,
+    enabled: true,
+    createdAt: 1,
+    updatedAt: 1,
+  };
+
+  assert.deepEqual(await fetchProviderModels(connection, ''), discoveredModelIds.map((id) => ({ id })));
+
+  const result = await generateText({
+    model: getAIModel({ connection, apiKey: '', modelId }),
+    prompt: 'Call echo with hello, then report the result.',
+    tools: {
+      echo: tool({
+        description: 'Echo text',
+        inputSchema: z.object({ text: z.string() }),
+        execute: async ({ text }) => ({ text }),
+      }),
+    },
+    stopWhen: stepCountIs(2),
+  });
+
+  assert.equal(result.text, 'Echoed hello.');
+  assert.equal(requestBodies.length, 2);
+  assert.deepEqual(requestBodies.map((body) => body.model), [modelId, modelId]);
+  assert.deepEqual(
+    (requestBodies[0].tools as Array<{ function: { name: string } }>).map((entry) => entry.function.name),
+    ['echo'],
+  );
+  const secondMessages = requestBodies[1]?.messages as Array<{ role: string; content: string }>;
+  const toolMessage = secondMessages.find((message) => message.role === 'tool');
+  assert.ok(toolMessage);
+  assert.deepEqual(JSON.parse(toolMessage.content), { text: 'hello' });
+}
+
+async function runCohereDiscovery(): Promise<void> {
+  const modelId = 'command-a-plus-05-2026';
+  const requestBodies: Array<Record<string, unknown>> = [];
+  const modelListUrls: string[] = [];
+  const server = await startJsonServer(async (request, response) => {
+    assert.equal(request.headers.authorization, 'Bearer cohere-test-key');
+    if (request.method === 'GET' && request.url?.startsWith('/v1/models?')) {
+      modelListUrls.push(request.url);
+      const url = new URL(request.url, 'http://localhost');
+      assert.equal(url.searchParams.get('endpoint'), 'chat');
+      assert.equal(url.searchParams.get('page_size'), '1000');
+      if (!url.searchParams.has('page_token')) {
+        respondJson(response, 200, {
+          models: [
+            { name: modelId, is_deprecated: false, endpoints: ['chat'], context_length: 128_000 },
+            { name: 'retired-command', is_deprecated: true, endpoints: ['chat'], context_length: 4_000 },
+          ],
+          next_page_token: 'page-2',
+        });
+        return;
+      }
+      assert.equal(url.searchParams.get('page_token'), 'page-2');
+      respondJson(response, 200, {
+        models: [{
+          name: 'command-a-reasoning-08-2025',
+          is_deprecated: false,
+          endpoints: ['chat'],
+          context_length: 256_000,
+        }],
+        next_page_token: '',
+      });
+      return;
+    }
+
+    assert.equal(request.method, 'POST');
+    assert.equal(request.url, '/v2/chat');
+    const body = JSON.parse(await readBody(request)) as Record<string, unknown>;
+    requestBodies.push(body);
+    if (requestBodies.length === 1) {
+      respondJson(response, 200, {
+        generation_id: 'cohere-tool-turn',
+        finish_reason: 'TOOL_CALL',
+        message: {
+          role: 'assistant',
+          content: [],
+          tool_plan: 'Call echo.',
+          tool_calls: [{
+            id: 'call_echo',
+            type: 'function',
+            function: { name: 'echo', arguments: '{"text":"hello"}' },
+          }],
+        },
+        usage: {
+          billed_units: { input_tokens: 8, output_tokens: 4 },
+          tokens: { input_tokens: 8, output_tokens: 4 },
+        },
+      });
+      return;
+    }
+
+    respondJson(response, 200, {
+      generation_id: 'cohere-final-turn',
+      finish_reason: 'COMPLETE',
+      message: {
+        role: 'assistant',
+        content: [{ type: 'text', text: 'Echoed hello.' }],
+      },
+      usage: {
+        billed_units: { input_tokens: 12, output_tokens: 3 },
+        tokens: { input_tokens: 12, output_tokens: 3 },
+      },
+    });
+  });
+  const connection: LlmConnection = {
+    slug: 'cohere',
+    name: 'Cohere',
+    providerType: 'cohere',
+    baseUrl: `${server.url}/v2`,
+    defaultModel: modelId,
+    enabled: true,
+    createdAt: 1,
+    updatedAt: 1,
+  };
+
+  const models = await fetchProviderModels(connection, 'cohere-test-key');
+  assert.deepEqual(models, [
+    { id: modelId, contextWindow: 128_000 },
+    { id: 'command-a-reasoning-08-2025', contextWindow: 256_000 },
+  ]);
+  assert.equal(modelListUrls.length, 2);
+
+  const result = await generateText({
+    model: getAIModel({ connection, apiKey: 'cohere-test-key', modelId: models[0]!.id }),
+    prompt: 'Call echo with hello.',
+    stopWhen: stepCountIs(2),
+    tools: {
+      echo: tool({
+        description: 'Echo text',
+        inputSchema: z.object({ text: z.string() }),
+        execute: async ({ text }) => ({ echoed: text }),
+      }),
+    },
+  });
+
+  assert.equal(requestBodies.length, 2);
+  assert.deepEqual(requestBodies.map((body) => body.model), [modelId, modelId]);
+  assert.deepEqual(
+    (requestBodies[0].tools as Array<{ function: { name: string } }>).map((entry) => entry.function.name),
+    ['echo'],
+  );
+  const secondMessages = requestBodies[1]?.messages as Array<Record<string, unknown>>;
+  assert.deepEqual(secondMessages.find(({ role }) => role === 'assistant'), {
+    role: 'assistant',
+    tool_calls: [{
+      id: 'call_echo',
+      type: 'function',
+      function: { name: 'echo', arguments: '{"text":"hello"}' },
+    }],
+  });
+  assert.deepEqual(secondMessages.find(({ role }) => role === 'tool'), {
+    role: 'tool',
+    content: '{"echoed":"hello"}',
+    tool_call_id: 'call_echo',
+  });
+  assert.equal(result.steps[0]?.toolCalls[0]?.toolName, 'echo');
+  assert.deepEqual(result.steps[0]?.toolResults[0]?.output, { echoed: 'hello' });
+  assert.equal(result.text, 'Echoed hello.');
+}
+
+async function runZenMuxSignedReasoningReplay(): Promise<void> {
+  const modelId = 'moonshotai/kimi-k2.5';
+  const reasoningDetails = [{
+    type: 'reasoning.text',
+    text: 'Use echo.',
+    signature: 'deterministic-stream-signature',
+    format: 'anthropic-claude-v1',
+  }];
+  const requestBodies: Array<Record<string, unknown>> = [];
+  const server = await startJsonServer(async (request, response) => {
+    const body = JSON.parse(await readBody(request)) as Record<string, unknown>;
+    requestBodies.push(body);
+    assert.equal(body.stream, true);
+    if (requestBodies.length === 1) {
+      respondOpenAIStream(response, [{
+        id: 'chatcmpl-zenmux-stream-tool',
+        object: 'chat.completion.chunk',
+        created: 1,
+        model: modelId,
+        choices: [{
+          index: 0,
+          delta: {
+            role: 'assistant',
+            reasoning: 'Use echo.',
+            reasoning_details: reasoningDetails,
+            tool_calls: [{
+              index: 0,
+              id: 'call_zenmux_stream_echo',
+              type: 'function',
+              function: { name: 'echo', arguments: '{"text":"hello"}' },
+            }],
+          },
+          finish_reason: null,
+        }],
+      }, {
+        id: 'chatcmpl-zenmux-stream-tool',
+        object: 'chat.completion.chunk',
+        created: 1,
+        model: modelId,
+        choices: [{ index: 0, delta: {}, finish_reason: 'tool_calls' }],
+        usage: { prompt_tokens: 8, completion_tokens: 4, total_tokens: 12 },
+      }]);
+      return;
+    }
+    respondOpenAIStream(response, [{
+      id: 'chatcmpl-zenmux-stream-final',
+      object: 'chat.completion.chunk',
+      created: 2,
+      model: modelId,
+      choices: [{ index: 0, delta: { role: 'assistant', content: 'Echoed hello.' }, finish_reason: null }],
+    }, {
+      id: 'chatcmpl-zenmux-stream-final',
+      object: 'chat.completion.chunk',
+      created: 2,
+      model: modelId,
+      choices: [{ index: 0, delta: {}, finish_reason: 'stop' }],
+      usage: { prompt_tokens: 14, completion_tokens: 3, total_tokens: 17 },
+    }]);
+  });
+  const connection: LlmConnection = {
+    slug: 'zenmux',
+    name: 'ZenMux',
+    providerType: 'zenmux',
+    baseUrl: `${server.url}/v1`,
+    defaultModel: modelId,
+    enabled: true,
+    createdAt: 1,
+    updatedAt: 1,
+  };
+
+  const result = streamText({
+    model: getAIModel({ connection, apiKey: 'zenmux-test-key', modelId }),
+    prompt: 'Call echo with hello.',
+    stopWhen: stepCountIs(2),
+    tools: {
+      echo: tool({
+        description: 'Echo text',
+        inputSchema: z.object({ text: z.string() }),
+        execute: async ({ text }) => ({ echoed: text }),
+      }),
+    },
+  });
+
+  assert.equal(await result.text, 'Echoed hello.');
+  assert.equal(requestBodies.length, 2);
+  assert.deepEqual(
+    (requestBodies[1].messages as Array<Record<string, unknown>>).find(({ role }) => role === 'assistant'),
+    {
+      role: 'assistant',
+      content: null,
+      reasoning: 'Use echo.',
+      reasoning_details: reasoningDetails,
+      tool_calls: [{
+        id: 'call_zenmux_stream_echo',
+        type: 'function',
+        function: { name: 'echo', arguments: '{"text":"hello"}' },
+      }],
+    },
+  );
+}

--- a/packages/runtime/src/model-factory.ts
+++ b/packages/runtime/src/model-factory.ts
@@ -5,6 +5,7 @@ import { createOpenAI } from '@ai-sdk/openai';
 import { createOpenAICompatible, type MetadataExtractor } from '@ai-sdk/openai-compatible';
 import { isJSONArray, type JSONArray, type LanguageModelV3, type SharedV3ProviderOptions } from '@ai-sdk/provider';
 import { type LlmConnection, type ProviderType } from '@maka/core/llm-connections';
+import { openAiAdapterApiProtocol } from '@maka/core/model-metadata';
 import type { ThinkingLevel } from '@maka/core/model-thinking';
 import { thinkingOptionsForModel, thinkingVariantsForModel } from '@maka/core/model-thinking';
 import { anthropicV1BaseUrl, googleV1BetaBaseUrl } from './provider-urls.js';
@@ -80,8 +81,13 @@ export function getAIModel(input: ModelFactoryInput): LanguageModelV3 {
 
     case 'openai': {
       const openai = createOpenAI({ apiKey, baseURL });
-      if (/^gpt-5/i.test(modelId)) return openai.responses(modelId);
-      return openai.chat(modelId);
+      // Routing is declaration-driven via the ModelInfo.apiProtocol seam: an
+      // account-declared protocol wins (mirrors the github-copilot case above);
+      // otherwise the model's declared OpenAI-adapter protocol decides. gpt-5*
+      // families are Responses-only; everything else uses Chat Completions.
+      const apiProtocol = connection.models?.find((model) => model.id === modelId)?.apiProtocol
+        ?? openAiAdapterApiProtocol(modelId);
+      return apiProtocol === 'openai-responses' ? openai.responses(modelId) : openai.chat(modelId);
     }
 
     case 'google':


### PR DESCRIPTION
## Summary

Part of #860 (Phase 8). Lands the three Phase 8 preconditions recorded when #974 merged, so the overlapping hand-written conformance coverage can be consolidated in a follow-up without losing any contract:

1. **Per-cell credential cases for `optional_api_key` discovery.** The matrix plan now derives `auth: 'optional'` for `optional_api_key` providers (LocalAI), alongside `'default'` and `'none'`. The generated discovery executor expands `optional` into two executed branches: a configured key must reach the wire as `Authorization: Bearer …`, and an absent key must leave the request completely credential-free (no dummy value). `'none'` (Ollama, LM Studio, public lists) keeps asserting that no credential header is ever sent.

2. **Executable override bindings replace the textual title check.** Override cells now bind to runnable entries in `packages/runtime/src/__tests__/provider-contract-overrides.ts`, and the matrix suite executes each binding directly as a test. The previous mechanism asserted that a bound test *title* existed as an enabled `test(...)` call in another source file — a textual check that a fully commented-out test could still satisfy. The bound hand-written tests (GitHub Copilot discovery + subscription wire, Fireworks pagination discovery, Ollama `/api/tags` discovery, Cohere native V2 pagination, ZenMux streamed signed-reasoning replay) moved verbatim out of `provider-conformance.test.ts` / `model-fetcher.test.ts` into the bindings module, so each contract executes exactly once and deleting or breaking an override fails the matrix instead of leaving a silent gap. Shared scripted-HTTP plumbing moved to `conformance-harness.ts`.

3. **`apiProtocol` declaration lift retires the `/^gpt-5/i` routing regex in runtime.** The OpenAI-adapter protocol split is now declared once in core as `openAiAdapterApiProtocol()` (documented against the existing `ModelInfo.apiProtocol` seam). `model-factory` routes by the connection's stored per-model `apiProtocol` when present (account-advertised wire, same as the GitHub Copilot case) and otherwise by the core declaration; the matrix's sample-model-id derivation consumes the same declaration instead of duplicating the regex. Behavior is unchanged: `gpt-5*` still goes to the Responses API, everything else to Chat Completions, now locked by a wire test.

## Verification

- `npm run typecheck` — all workspaces pass.
- `npm run test:scripts` — 109/109 pass.
- Workspace tests: `@maka/core` 1066 pass, `@maka/storage` 286 pass (1 skipped), `@maka/runtime` 1973 pass (7 skipped/todo), `@maka/headless` 1022 pass (1 skipped), `maka-agent` (CLI) 412 pass, `@maka/desktop` 2571 pass — 0 failures everywhere.
- `npm run check:stale` — dist is fresh; `git diff --check` clean.
- Matrix gap report stays green: every ready-provider dimension is generated, bound to an executed override, or justified N/A; new targeted tests cover `optional` derivation (`localai`), both LocalAI credential branches, and OpenAI gpt-5*/other wire routing.

## Review focus

- The override binding bodies are verbatim moves (imports adjusted to the shared harness); reviewing them as moves keeps the diff small.
- `getAIModel`'s `openai` case now consults `connection.models[].apiProtocol` first. No current discovery path stores `apiProtocol` for the `openai` provider type, so this is behavior-preserving today; it exists so an account-advertised wire wins over the static declaration, mirroring the GitHub Copilot case.
