### PR TITLE
fix(headless): report resilient Harness schedules by evidence axis

### DIFF
--- a/packages/headless/README.md
+++ b/packages/headless/README.md
@@ -180,7 +180,7 @@ For a live run, remove `MAKA_HARNESS_AB_DRY_RUN` and set `MAKA_HARNESS_AB_KEY_FI
 
 For an unattended run, invoke `node packages/headless/harbor/run-harness-ab-detached.mjs` with the same environment. It detaches the worker from the terminal and atomically journals `running`, `completed`, or `failed` in `background-run.json`; stdout and stderr go to `background-run.log`.
 
-Outputs are `harness-ab-report.json`, `.csv`, and `.md`. Report schema v2 records scheduled, attempted, model-scored, infrastructure-failed, unscored, and missing-final-usage cell coverage while keeping paired Pass@1 and fully metered cache-aware API-equivalent cost on separate denominators. A fully attempted schedule with honest evidence gaps finishes as `completed_with_gaps`; an unattempted suffix remains `incomplete`. Reports do not claim fixed-plan spend or publish results.
+Outputs are `harness-ab-report.json`, `.csv`, and `.md`. Report schema v2 records scheduled, attempted, model-scored, unscored (including the infrastructure-failed subset), and missing-final-usage cell coverage while keeping paired Pass@1 and fully metered cache-aware API-equivalent cost on separate denominators. A fully attempted schedule with honest evidence gaps finishes as `completed_with_gaps`; an unattempted suffix remains `incomplete`. Reports do not claim fixed-plan spend or publish results.
 
 ## Attention semantic-compaction A/B
 

--- a/packages/headless/README.md
+++ b/packages/headless/README.md
@@ -180,7 +180,7 @@ For a live run, remove `MAKA_HARNESS_AB_DRY_RUN` and set `MAKA_HARNESS_AB_KEY_FI
 
 For an unattended run, invoke `node packages/headless/harbor/run-harness-ab-detached.mjs` with the same environment. It detaches the worker from the terminal and atomically journals `running`, `completed`, or `failed` in `background-run.json`; stdout and stderr go to `background-run.log`.
 
-Outputs are `harness-ab-report.json`, `.csv`, and `.md`. They report Pass@1 and cache-aware API-equivalent cost separately; they do not claim fixed-plan spend or publish results.
+Outputs are `harness-ab-report.json`, `.csv`, and `.md`. Report schema v2 records scheduled, attempted, model-scored, infrastructure-failed, unscored, and missing-final-usage cell coverage while keeping paired Pass@1 and fully metered cache-aware API-equivalent cost on separate denominators. A fully attempted schedule with honest evidence gaps finishes as `completed_with_gaps`; an unattempted suffix remains `incomplete`. Reports do not claim fixed-plan spend or publish results.
 
 ## Attention semantic-compaction A/B
 

--- a/packages/headless/harbor/run-harness-ab.mjs
+++ b/packages/headless/harbor/run-harness-ab.mjs
@@ -340,7 +340,7 @@ async function runLocked({ repoRoot, makaRepoPath, tasksRoot, runId, limit, runR
   await writeFile(join(runRoot, 'harness-ab-report.csv'), renderHarnessAbReportCsv(report), 'utf8');
   await writeFile(join(runRoot, 'harness-ab-report.md'), renderHarnessAbReportMarkdown(report), 'utf8');
   assertHarnessAbReportCompleted(report);
-  console.log(`completed: ${report.effectiveness.pairedEvaluated}/${report.completeness.expectedPerArm} paired Pass@1 cells -> ${runRoot}`);
+  console.log(`completed: ${report.coverage.attemptedCells}/${report.coverage.scheduledCells} cells attempted; ${report.effectiveness.pairedEvaluated} paired Pass@1 outcomes -> ${runRoot}`);
 }
 
 function backgroundJournal(runRoot) {

--- a/packages/headless/harbor/run-harness-ab.mjs
+++ b/packages/headless/harbor/run-harness-ab.mjs
@@ -340,7 +340,7 @@ async function runLocked({ repoRoot, makaRepoPath, tasksRoot, runId, limit, runR
   await writeFile(join(runRoot, 'harness-ab-report.csv'), renderHarnessAbReportCsv(report), 'utf8');
   await writeFile(join(runRoot, 'harness-ab-report.md'), renderHarnessAbReportMarkdown(report), 'utf8');
   assertHarnessAbReportCompleted(report);
-  console.log(`completed: ${report.coverage.attemptedCells}/${report.coverage.scheduledCells} cells attempted; ${report.effectiveness.pairedEvaluated} paired Pass@1 outcomes -> ${runRoot}`);
+  console.log(`${report.runStatus}: ${report.coverage.attemptedCells}/${report.coverage.scheduledCells} cells attempted; ${report.effectiveness.pairedEvaluated} paired Pass@1 outcomes -> ${runRoot}`);
 }
 
 function backgroundJournal(runRoot) {

--- a/packages/headless/src/__tests__/ab-run.test.ts
+++ b/packages/headless/src/__tests__/ab-run.test.ts
@@ -251,6 +251,49 @@ describe('runAbComparison', () => {
     assert.equal(result.stopReason, 'observed_cost_stop_reached');
   });
 
+  test('closes pair admission as soon as one arm reaches the observed cost threshold', async () => {
+    const calls: string[] = [];
+    let releaseSibling!: () => void;
+    const siblingMayFinish = new Promise<void>((resolve) => { releaseSibling = resolve; });
+    let secondPairFinished!: () => void;
+    const secondPairFinishedPromise = new Promise<void>((resolve) => { secondPairFinished = resolve; });
+    let secondPairArms = 0;
+    const comparison = runAbComparison({
+      runId: 'ab-run',
+      arms: [
+        { id: 'off', kind: 'runtime', fingerprint: sha256('off') },
+        { id: 'on', kind: 'runtime', fingerprint: sha256('on') },
+      ],
+      evaluationTasks: [
+        { id: 't1', path: '/tasks/t1' },
+        { id: 't2', path: '/tasks/t2' },
+        { id: 't3', path: '/tasks/t3' },
+      ],
+      reps: 1,
+      maxConcurrency: 2,
+      observedCostStopUsd: 0.01,
+      runArm: async ({ arm, task }) => {
+        calls.push(`${task.id}:${arm.id}`);
+        if (task.id === 't1' && arm.id === 'on') await siblingMayFinish;
+        if (task.id === 't2') {
+          secondPairArms += 1;
+          if (secondPairArms === 2) secondPairFinished();
+        }
+        return completed(task.id, true);
+      },
+    });
+
+    await secondPairFinishedPromise;
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    const suffixStartedBeforeDrain = calls.some((call) => call.startsWith('t3:'));
+    releaseSibling();
+    const result = await comparison;
+
+    assert.equal(suffixStartedBeforeDrain, false);
+    assert.deepEqual(new Set(calls), new Set(['t1:off', 't1:on', 't2:off', 't2:on']));
+    assert.equal(result.stopReason, 'observed_cost_stop_reached');
+  });
+
   test('stops scheduling new pairs after a systemic provider failure', async () => {
     const calls: string[] = [];
     const result = await runAbComparison({
@@ -273,6 +316,52 @@ describe('runAbComparison', () => {
     });
 
     assert.deepEqual(calls, ['ab-off-r0-t1', 'ab-on-r0-t1']);
+    assert.equal(result.stopReason, 'systemic_provider_failure');
+  });
+
+  test('closes pair admission as soon as one arm reports a systemic provider failure', async () => {
+    const calls: string[] = [];
+    let releaseSibling!: () => void;
+    const siblingMayFinish = new Promise<void>((resolve) => { releaseSibling = resolve; });
+    let secondPairFinished!: () => void;
+    const secondPairFinishedPromise = new Promise<void>((resolve) => { secondPairFinished = resolve; });
+    let secondPairArms = 0;
+    const comparison = runAbComparison({
+      runId: 'ab-run',
+      arms: [
+        { id: 'off', kind: 'runtime', fingerprint: sha256('off') },
+        { id: 'on', kind: 'runtime', fingerprint: sha256('on') },
+      ],
+      evaluationTasks: [
+        { id: 't1', path: '/tasks/t1' },
+        { id: 't2', path: '/tasks/t2' },
+        { id: 't3', path: '/tasks/t3' },
+      ],
+      reps: 1,
+      maxConcurrency: 2,
+      runArm: async ({ arm, task }) => {
+        calls.push(`${task.id}:${arm.id}`);
+        if (task.id === 't1' && arm.id === 'off') return providerBilling(task.id);
+        if (task.id === 't1') {
+          await siblingMayFinish;
+          return completed(task.id, true);
+        }
+        if (task.id === 't2') {
+          secondPairArms += 1;
+          if (secondPairArms === 2) secondPairFinished();
+        }
+        return completed(task.id, true);
+      },
+    });
+
+    await secondPairFinishedPromise;
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    const suffixStartedBeforeDrain = calls.some((call) => call.startsWith('t3:'));
+    releaseSibling();
+    const result = await comparison;
+
+    assert.equal(suffixStartedBeforeDrain, false);
+    assert.deepEqual(new Set(calls), new Set(['t1:off', 't1:on', 't2:off', 't2:on']));
     assert.equal(result.stopReason, 'systemic_provider_failure');
   });
 

--- a/packages/headless/src/__tests__/fixed-prompt-controller.test.ts
+++ b/packages/headless/src/__tests__/fixed-prompt-controller.test.ts
@@ -553,6 +553,51 @@ describe('fixed prompt controller', () => {
     });
   });
 
+  test('fails loud when durable Pass@1 admission cannot be persisted', async () => {
+    await withDir(async (dir) => {
+      const systemPromptPath = join(dir, 'system_prompt.md');
+      const resultsJsonlPath = join(dir, 'results.jsonl');
+      await writeFile(systemPromptPath, 'fixed prompt\n', 'utf8');
+      const originalAppendFile = fs.promises.appendFile;
+      fs.promises.appendFile = async (...args) => {
+        if (String(args[0]).endsWith('.attempts.jsonl')) {
+          throw new Error('attempt WAL unavailable');
+        }
+        return originalAppendFile(...args);
+      };
+      syncBuiltinESMExports();
+      let harborCalls = 0;
+
+      try {
+        await assert.rejects(
+          runFixedPromptController({
+            runId: 'run-1',
+            roundId: 'round-1',
+            config,
+            systemPromptPath,
+            resultsJsonlPath,
+            tasks: [{ id: 'task-a', path: '/bench/task-a' }],
+            infraFailurePolicy: 'terminal',
+            protectPassAtOne: true,
+            harborRunner: async ({ task }) => {
+              harborCalls += 1;
+              return harborOutput({ taskId: task.id });
+            },
+            now: () => 100,
+            newId: idFactory(),
+          }),
+          /attempt WAL unavailable/,
+        );
+      } finally {
+        fs.promises.appendFile = originalAppendFile;
+        syncBuiltinESMExports();
+      }
+
+      assert.equal(harborCalls, 0);
+      await assert.rejects(readFile(resultsJsonlPath, 'utf8'), { code: 'ENOENT' });
+    });
+  });
+
   test('protectPassAtOne never retries a full Harbor attempt after runner failure', async () => {
     await withDir(async (dir) => {
       const systemPromptPath = join(dir, 'system_prompt.md');

--- a/packages/headless/src/__tests__/harness-ab-cli.test.ts
+++ b/packages/headless/src/__tests__/harness-ab-cli.test.ts
@@ -61,6 +61,13 @@ test('harness A/B manifest uses the pinned OpenCode toolchain version', async ()
   );
 });
 
+test('harness A/B completion log preserves the report status', async () => {
+  const scriptPath = new URL('../../harbor/run-harness-ab.mjs', import.meta.url);
+  const source = await readFile(scriptPath, 'utf8');
+
+  assert.match(source, /console\.log\(`\$\{report\.runStatus\}:/);
+});
+
 test('detached harness launcher persists a terminal failed journal after the worker exits', async () => {
   const dir = await mkdtemp(join(tmpdir(), 'maka-harness-ab-detached-'));
   try {

--- a/packages/headless/src/__tests__/harness-ab-report.test.ts
+++ b/packages/headless/src/__tests__/harness-ab-report.test.ts
@@ -103,6 +103,35 @@ describe('harness A/B report', () => {
     assert.equal(report.effectiveness.candidateMinusBaseline, -1);
   });
 
+  test('reports a budget-exhausted cell with final usage as unscored', () => {
+    const meteredTimeout = {
+      ...budgetExhausted('a'),
+      tokenSummary: usage('a', false, 100, 40, 20, 0.00018).tokenSummary,
+      tokenSummarySource: 'final' as const,
+    };
+    const summary = summarizeAbComparison({
+      runId: 'glm-harness-ab',
+      roundId: 'ab-summary',
+      baselineArmId: 'maka',
+      candidateArmId: 'opencode',
+      evaluationTaskIds: ['a'],
+      baselineRuns: [[meteredTimeout]],
+      candidateRuns: [[usage('a', true, 100, 40, 20, 0.00018)]],
+    });
+
+    const report = buildHarnessAbReport(summary);
+
+    assert.equal(report.runStatus, 'completed_with_gaps');
+    assert.deepEqual(report.coverage, {
+      scheduledCells: 2,
+      attemptedCells: 2,
+      modelScoredCells: 1,
+      infraFailedCells: 0,
+      unscoredCells: 1,
+      missingFinalUsageCells: 0,
+    });
+  });
+
   test('stays incomplete when scheduled cells were never attempted', () => {
     const summary = summarizeAbComparison({
       runId: 'glm-harness-ab',

--- a/packages/headless/src/__tests__/harness-ab-report.test.ts
+++ b/packages/headless/src/__tests__/harness-ab-report.test.ts
@@ -58,7 +58,7 @@ describe('harness A/B report', () => {
     assert.match(markdown, /# Maka vs OpenCode — GLM-5\.2 Harness Comparison/);
     assert.match(markdown, /Pass@1/);
     assert.match(markdown, /API-equivalent cost/);
-    assert.match(markdown, /Cell coverage: 4\/4 attempted; 4 model-scored; 0 infra-failed; 0 unscored; 0 missing final usage\./);
+    assert.match(markdown, /Cell coverage: 4\/4 attempted; 4 model-scored; 0 unscored \(including 0 infra-failed\); 0 missing final usage\./);
     assert.match(markdown, /No composite score/);
   });
 

--- a/packages/headless/src/__tests__/harness-ab-report.test.ts
+++ b/packages/headless/src/__tests__/harness-ab-report.test.ts
@@ -30,7 +30,7 @@ describe('harness A/B report', () => {
 
     const report = buildHarnessAbReport(summary);
 
-    assert.equal(report.schemaVersion, 'maka.harness_ab.report.v1');
+    assert.equal(report.schemaVersion, 'maka.harness_ab.report.v2');
     assert.deepEqual(report.effectiveness, {
       metric: 'pass@1',
       pairedEvaluated: 2,
@@ -50,18 +50,19 @@ describe('harness A/B report', () => {
     assert.equal('score' in report, false);
 
     const csv = renderHarnessAbReportCsv(report);
-    assert.match(csv, /^run_status,stop_reason,paired_expected,paired_evaluated,excluded_pairs,missing_pairs,paired_metered,missing_usage_pairs,axis,metric,baseline_arm,baseline_value,candidate_arm,candidate_value,candidate_minus_baseline\n/);
-    assert.match(csv, /completed,,2,2,0,0,2,0,effectiveness,pass_rate,maka,1,opencode,0.5,-0.5/);
-    assert.match(csv, /completed,,2,2,0,0,2,0,economy,total_tokens,maka,240,opencode,360,120/);
+    assert.match(csv, /^run_status,stop_reason,scheduled_cells,attempted_cells,model_scored_cells,infra_failed_cells,unscored_cells,missing_final_usage_cells,paired_evaluated,paired_metered,missing_usage_pairs,axis,metric,baseline_arm,baseline_value,candidate_arm,candidate_value,candidate_minus_baseline\n/);
+    assert.match(csv, /completed,,4,4,4,0,0,0,2,2,0,effectiveness,pass_rate,maka,1,opencode,0.5,-0.5/);
+    assert.match(csv, /completed,,4,4,4,0,0,0,2,2,0,economy,total_tokens,maka,240,opencode,360,120/);
 
     const markdown = renderHarnessAbReportMarkdown(report);
     assert.match(markdown, /# Maka vs OpenCode — GLM-5\.2 Harness Comparison/);
     assert.match(markdown, /Pass@1/);
     assert.match(markdown, /API-equivalent cost/);
+    assert.match(markdown, /Cell coverage: 4\/4 attempted; 4 model-scored; 0 infra-failed; 0 unscored; 0 missing final usage\./);
     assert.match(markdown, /No composite score/);
   });
 
-  test('stays incomplete when an infrastructure pair is excluded', () => {
+  test('completes with explicit cell coverage when every cell is attempted but one fails in infrastructure', () => {
     const summary = summarizeAbComparison({
       runId: 'glm-harness-ab',
       roundId: 'ab-summary',
@@ -69,13 +70,24 @@ describe('harness A/B report', () => {
       candidateArmId: 'opencode',
       evaluationTaskIds: ['a', 'b'],
       baselineRuns: [[completed('a', true), completed('b', true)]],
-      candidateRuns: [[completed('a', false), providerBilling('b')]],
+      candidateRuns: [[completed('a', false), infraFailure('b')]],
     });
 
     const report = buildHarnessAbReport(summary);
 
-    assert.equal(report.runStatus, 'incomplete');
-    assert.throws(() => assertHarnessAbReportCompleted(report), /1 excluded/);
+    assert.equal(report.schemaVersion, 'maka.harness_ab.report.v2');
+    assert.equal(report.runStatus, 'completed_with_gaps');
+    assert.deepEqual(report.coverage, {
+      scheduledCells: 4,
+      attemptedCells: 4,
+      modelScoredCells: 3,
+      infraFailedCells: 1,
+      unscoredCells: 1,
+      missingFinalUsageCells: 0,
+    });
+    assert.doesNotThrow(() => assertHarnessAbReportCompleted(report));
+    assert.match(renderHarnessAbReportCsv(report), /completed_with_gaps,,4,4,3,1,1,0,1,1,0,effectiveness,pass_rate/);
+    assert.match(renderHarnessAbReportMarkdown(report), /Status: completed_with_gaps\./);
     assert.deepEqual(report.effectiveness.baseline, {
       armId: 'maka',
       passed: 1,
@@ -89,6 +101,31 @@ describe('harness A/B report', () => {
       passRate: 0,
     });
     assert.equal(report.effectiveness.candidateMinusBaseline, -1);
+  });
+
+  test('stays incomplete when scheduled cells were never attempted', () => {
+    const summary = summarizeAbComparison({
+      runId: 'glm-harness-ab',
+      roundId: 'ab-summary',
+      baselineArmId: 'maka',
+      candidateArmId: 'opencode',
+      evaluationTaskIds: ['a', 'b'],
+      baselineRuns: [[usage('a', true, 100, 40, 20, 0.1)]],
+      candidateRuns: [[usage('a', false, 120, 50, 30, 0.2)]],
+    });
+
+    const report = buildHarnessAbReport(summary);
+
+    assert.equal(report.runStatus, 'incomplete');
+    assert.deepEqual(report.coverage, {
+      scheduledCells: 4,
+      attemptedCells: 2,
+      modelScoredCells: 2,
+      infraFailedCells: 0,
+      unscoredCells: 0,
+      missingFinalUsageCells: 0,
+    });
+    assert.throws(() => assertHarnessAbReportCompleted(report), /2\/4 scheduled cells attempted/);
   });
 
   test('reports economy over the same evaluated pairs as effectiveness', () => {
@@ -141,7 +178,8 @@ describe('harness A/B report', () => {
     };
 
     assert.equal(report.effectiveness.pairedEvaluated, 2);
-    assert.equal(report.runStatus, 'incomplete');
+    assert.equal(report.runStatus, 'completed_with_gaps');
+    assert.equal(report.coverage.missingFinalUsageCells, 1);
     assert.equal(economy.pairedMetered, 1);
     assert.equal(economy.missingUsagePairs, 1);
     assert.equal(report.economy.baseline.totalTokens, 120);
@@ -149,10 +187,10 @@ describe('harness A/B report', () => {
     assert.equal(report.economy.baseline.costPerPassUsd, 0.1);
     assert.equal(report.economy.candidate.costPerPassUsd, 0.2);
     assert.match(renderHarnessAbReportMarkdown(report), /fully metered pairs: 1; missing usage: 1/);
-    assert.throws(() => assertHarnessAbReportCompleted(report), /missing usage for 1 pair/);
+    assert.doesNotThrow(() => assertHarnessAbReportCompleted(report));
   });
 
-  test('treats timeout usage checkpoints as incomplete metering', () => {
+  test('keeps timeout usage checkpoints out of final metering without making execution incomplete', () => {
     const checkpointOnlyTimeout = {
       ...budgetExhausted('a'),
       tokenSummary: usage('checkpoint', false, 100, 40, 20, 0.1).tokenSummary,
@@ -172,7 +210,8 @@ describe('harness A/B report', () => {
 
     assert.equal(summary.pairedAttempts.fullyMeteredPairs, 0);
     assert.deepEqual(summary.pairedAttempts.missingUsagePairIds, ['a#r0']);
-    assert.equal(report.runStatus, 'incomplete');
+    assert.equal(report.runStatus, 'completed_with_gaps');
+    assert.equal(report.coverage.missingFinalUsageCells, 1);
   });
 
   test('preserves an early stop in every report format and rejects completion', () => {
@@ -192,8 +231,8 @@ describe('harness A/B report', () => {
 
     assert.equal(report.runStatus, 'stopped');
     assert.equal(report.stopReason, 'systemic_provider_failure');
-    assert.match(renderHarnessAbReportCsv(report), /^run_status,stop_reason,paired_expected,paired_evaluated,excluded_pairs,missing_pairs,paired_metered,missing_usage_pairs,axis,metric,/);
-    assert.match(renderHarnessAbReportCsv(report), /stopped,systemic_provider_failure,1,0,1,0,0,0,effectiveness,pass_rate/);
+    assert.match(renderHarnessAbReportCsv(report), /^run_status,stop_reason,scheduled_cells,attempted_cells,model_scored_cells,infra_failed_cells,unscored_cells,missing_final_usage_cells,paired_evaluated,paired_metered,missing_usage_pairs,axis,metric,/);
+    assert.match(renderHarnessAbReportCsv(report), /stopped,systemic_provider_failure,2,2,1,1,1,0,0,0,0,effectiveness,pass_rate/);
     assert.match(renderHarnessAbReportMarkdown(report), /Status: stopped \(systemic_provider_failure\)\./);
     assert.throws(
       () => assertHarnessAbReportCompleted(report),
@@ -238,5 +277,13 @@ function providerBilling(taskId: string): FixedPromptTaskInfraFailedEvent {
     eligible: false,
     errorClass: 'provider_billing',
     error: 'provider billing failure',
+  };
+}
+
+function infraFailure(taskId: string): FixedPromptTaskInfraFailedEvent {
+  return {
+    ...providerBilling(taskId),
+    errorClass: 'network',
+    error: 'provider network failure',
   };
 }

--- a/packages/headless/src/__tests__/harness-ab-run.test.ts
+++ b/packages/headless/src/__tests__/harness-ab-run.test.ts
@@ -222,7 +222,7 @@ describe('runHarnessAbComparison', () => {
     }
   });
 
-  test('keeps the report incomplete when OpenCode usage output is missing', async () => {
+  test('completes with gaps when one attempted cell has no usable output', async () => {
     const dir = await mkdtemp(join(tmpdir(), 'maka-harness-ab-missing-usage-'));
     try {
       const promptPath = join(dir, 'empty-system-prompt.txt');
@@ -245,7 +245,15 @@ describe('runHarnessAbComparison', () => {
       const report = buildHarnessAbReport(summary);
 
       assert.equal(summary.pairedAttempts.excludedPairIds.length, 1);
-      assert.equal(report.runStatus, 'incomplete');
+      assert.equal(report.runStatus, 'completed_with_gaps');
+      assert.deepEqual(report.coverage, {
+        scheduledCells: 2,
+        attemptedCells: 2,
+        modelScoredCells: 1,
+        infraFailedCells: 1,
+        unscoredCells: 1,
+        missingFinalUsageCells: 0,
+      });
     } finally {
       await rm(dir, { recursive: true, force: true });
     }

--- a/packages/headless/src/__tests__/harness-ab-run.test.ts
+++ b/packages/headless/src/__tests__/harness-ab-run.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { mkdtemp, readdir, rm, writeFile } from 'node:fs/promises';
+import { mkdtemp, readFile, readdir, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, test } from 'node:test';
@@ -162,6 +162,61 @@ describe('runHarnessAbComparison', () => {
 
       await runHarnessAbComparison(input);
       assert.equal(failingAttempts, 1);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  test('continues the frozen schedule after a terminal cell infrastructure failure', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'maka-harness-ab-resilient-schedule-'));
+    try {
+      const promptPath = join(dir, 'empty-system-prompt.txt');
+      const resultsPath = join(dir, 'results.jsonl');
+      await writeFile(promptPath, '', 'utf8');
+      const calls: string[] = [];
+      let failingAttempts = 0;
+      const maka = harnessArm('maka', calls);
+      const successfulMakaRunner = maka.harborRunner;
+      maka.harborRunner = async (input) => {
+        calls.push(`${input.task.id}:maka`);
+        if (input.task.id === 'b') {
+          failingAttempts += 1;
+          throw new HarborInfraError('provider network failed after launch');
+        }
+        calls.pop();
+        return successfulMakaRunner(input);
+      };
+      const input = {
+        runId: 'glm-harness-ab',
+        runRoot: dir,
+        resultsJsonlPath: resultsPath,
+        systemPromptPath: promptPath,
+        resumeFingerprint: 'sha256:manifest',
+        evaluationTasks: ['a', 'b', 'c'].map((id) => ({ id, path: `/tasks/${id}` })),
+        arms: [maka, harnessArm('opencode', calls)] as const,
+      };
+
+      const first = await runHarnessAbComparison(input);
+
+      assert.equal(first.baseline.observed, 3);
+      assert.equal(first.candidate.observed, 3);
+      assert.equal(first.baseline.infraFailed, 1);
+      assert.equal(failingAttempts, 1);
+      assert.deepEqual(
+        new Set(calls),
+        new Set(['a:maka', 'a:opencode', 'b:maka', 'b:opencode', 'c:maka', 'c:opencode']),
+      );
+      const terminalEvents = (await readFile(resultsPath, 'utf8')).trim().split('\n').map((line) => JSON.parse(line) as {
+        taskId: string;
+        type: string;
+      });
+      assert.equal(terminalEvents.find((event) => event.taskId === 'b' && event.type === 'task_infra_failed')?.type, 'task_infra_failed');
+      assert.equal(terminalEvents.filter((event) => event.taskId === 'c' && event.type === 'task_completed').length, 2);
+      assert.equal((await readFile(`${resultsPath}.attempts.jsonl`, 'utf8')).trim().split('\n').length, 6);
+
+      await runHarnessAbComparison(input);
+      assert.equal(failingAttempts, 1);
+      assert.equal(calls.length, 6);
     } finally {
       await rm(dir, { recursive: true, force: true });
     }

--- a/packages/headless/src/ab-run.ts
+++ b/packages/headless/src/ab-run.ts
@@ -34,11 +34,19 @@ export async function runAbComparison(input: RunAbComparisonInput): Promise<AbCo
   let observedCostUsd = 0;
   let stopReason: AbComparisonSummary['stopReason'];
   const active = new Map<number, Promise<ActivePairResult>>();
+  const observeArmEvent = (event: FixedPromptTaskWalEvent) => {
+    observedCostUsd += eventCostUsd(event);
+    if (isSystemicProviderFailure(event)) {
+      stopReason = 'systemic_provider_failure';
+    } else if (!stopReason && input.observedCostStopUsd !== undefined && observedCostUsd >= input.observedCostStopUsd) {
+      stopReason = 'observed_cost_stop_reached';
+    }
+  };
   const launchReadyPairs = () => {
     while (!stopReason && active.size < maxConcurrency && nextPairIndex < pairs.length) {
       const pairIndex = nextPairIndex;
       const pair = pairs[nextPairIndex++]!;
-      active.set(pairIndex, runComparisonPair(input, pair).then((result) => ({ pairIndex, ...result })));
+      active.set(pairIndex, runComparisonPair(input, pair, observeArmEvent).then((result) => ({ pairIndex, ...result })));
     }
   };
 
@@ -54,12 +62,6 @@ export async function runAbComparison(input: RunAbComparisonInput): Promise<AbCo
     active.delete(result.pairIndex);
     baselineRuns[result.rep]!.push(result.baseline);
     candidateRuns[result.rep]!.push(result.candidate);
-    observedCostUsd += eventCostUsd(result.baseline) + eventCostUsd(result.candidate);
-    if (isSystemicProviderFailure(result.baseline) || isSystemicProviderFailure(result.candidate)) {
-      stopReason = 'systemic_provider_failure';
-    } else if (input.observedCostStopUsd !== undefined && observedCostUsd >= input.observedCostStopUsd) {
-      stopReason = 'observed_cost_stop_reached';
-    }
     launchReadyPairs();
   }
   const taskOrder = new Map(input.evaluationTasks.map((task, index) => [task.id, index]));
@@ -97,27 +99,28 @@ function isSystemicProviderFailure(event: FixedPromptTaskWalEvent): boolean {
 async function runComparisonPair(
   input: RunAbComparisonInput,
   pair: { rep: number; taskIndex: number; task: FixedPromptTask },
+  onArmEvent: (event: FixedPromptTaskWalEvent) => void,
 ): Promise<{ rep: number; baseline: FixedPromptTaskWalEvent; candidate: FixedPromptTaskWalEvent }> {
   if (input.armExecution === 'sequential') {
     if ((pair.rep + pair.taskIndex) % 2 === 0) {
-      const baseline = await runComparisonTaskArm(input, input.arms[0], pair);
-      const candidate = await runComparisonTaskArm(input, input.arms[1], pair);
+      const baseline = await runComparisonTaskArm(input, input.arms[0], pair, onArmEvent);
+      const candidate = await runComparisonTaskArm(input, input.arms[1], pair, onArmEvent);
       return { rep: pair.rep, baseline, candidate };
     }
-    const candidate = await runComparisonTaskArm(input, input.arms[1], pair);
-    const baseline = await runComparisonTaskArm(input, input.arms[0], pair);
+    const candidate = await runComparisonTaskArm(input, input.arms[1], pair, onArmEvent);
+    const baseline = await runComparisonTaskArm(input, input.arms[0], pair, onArmEvent);
     return { rep: pair.rep, baseline, candidate };
   }
   if ((pair.rep + pair.taskIndex) % 2 === 0) {
     const [baseline, candidate] = await drainParallelArmRuns([
-      runComparisonTaskArm(input, input.arms[0], pair),
-      runComparisonTaskArm(input, input.arms[1], pair),
+      runComparisonTaskArm(input, input.arms[0], pair, onArmEvent),
+      runComparisonTaskArm(input, input.arms[1], pair, onArmEvent),
     ]);
     return { rep: pair.rep, baseline, candidate };
   }
   const [candidate, baseline] = await drainParallelArmRuns([
-    runComparisonTaskArm(input, input.arms[1], pair),
-    runComparisonTaskArm(input, input.arms[0], pair),
+    runComparisonTaskArm(input, input.arms[1], pair, onArmEvent),
+    runComparisonTaskArm(input, input.arms[0], pair, onArmEvent),
   ]);
   return { rep: pair.rep, baseline, candidate };
 }
@@ -146,6 +149,7 @@ async function runComparisonTaskArm(
   input: RunAbComparisonInput,
   arm: AbArmSpec,
   pair: { rep: number; task: FixedPromptTask },
+  onArmEvent: (event: FixedPromptTaskWalEvent) => void,
 ): Promise<FixedPromptTaskWalEvent> {
   const roundId = buildAbRoundId(input.roundIdPrefix, arm.id, pair.rep, pair.task.id);
   const event = await input.runArm({
@@ -156,6 +160,7 @@ async function runComparisonTaskArm(
     rep: pair.rep,
   });
   if (event.taskId !== pair.task.id) throw new Error(`A/B arm ${roundId} produced event for ${event.taskId}, expected ${pair.task.id}`);
+  onArmEvent(event);
   return event;
 }
 

--- a/packages/headless/src/ab-summary.ts
+++ b/packages/headless/src/ab-summary.ts
@@ -114,6 +114,7 @@ function summarizeArm(
     budgetExhausted: observed.filter((event) => abOutcomeCategory(event) === 'budget').length,
     infraFailed: observed.filter((event) => abOutcomeCategory(event) === 'infra').length,
     plumbingFailed: observed.filter((event) => abOutcomeCategory(event) === 'plumbing').length,
+    missingFinalUsage: valid.filter((event) => !hasCompleteTokenSummary(event)).length,
     attestationWarnings: observed.filter(isMissingExecutionIdentityTimeout).length,
     missing: attempts - observed.length,
     coverageRate: attempts > 0 ? valid.length / attempts : 1,

--- a/packages/headless/src/ab-types.ts
+++ b/packages/headless/src/ab-types.ts
@@ -63,6 +63,7 @@ export interface AbArmSummary {
   budgetExhausted: number;
   infraFailed: number;
   plumbingFailed: number;
+  missingFinalUsage: number;
   attestationWarnings: number;
   missing: number;
   coverageRate: number;

--- a/packages/headless/src/fixed-prompt-controller.ts
+++ b/packages/headless/src/fixed-prompt-controller.ts
@@ -623,33 +623,31 @@ async function runTaskAndBuildEvent(input: {
   newId: () => string;
   now: () => number;
 }): Promise<FixedPromptTaskWalEvent> {
-  const runHarbor = async () => {
-    if (input.input.protectPassAtOne) {
-      const attemptStarted: FixedPromptTaskAttemptStartedEvent = {
-        schemaVersion: FIXED_PROMPT_WAL_SCHEMA_VERSION,
-        type: 'task_attempt_started',
-        id: input.newId(),
-        ts: input.now(),
-        runId: input.input.runId,
-        roundId: input.input.roundId,
-        ...(input.resumeFingerprint ? { resumeFingerprint: input.resumeFingerprint } : {}),
-        taskId: input.task.id,
-        promptHash: input.expectedPromptHash,
-      };
-      await appendFixedPromptWalEvent(
-        attemptWalPath(input.input.resultsJsonlPath),
-        attemptStarted,
-        { flush: true },
-      );
-    }
-    return input.input.harborRunner({
+  if (input.input.protectPassAtOne) {
+    const attemptStarted: FixedPromptTaskAttemptStartedEvent = {
+      schemaVersion: FIXED_PROMPT_WAL_SCHEMA_VERSION,
+      type: 'task_attempt_started',
+      id: input.newId(),
+      ts: input.now(),
       runId: input.input.runId,
       roundId: input.input.roundId,
-      task: input.task,
-      config: input.config,
-      systemPrompt: input.systemPrompt,
-    });
-  };
+      ...(input.resumeFingerprint ? { resumeFingerprint: input.resumeFingerprint } : {}),
+      taskId: input.task.id,
+      promptHash: input.expectedPromptHash,
+    };
+    await appendFixedPromptWalEvent(
+      attemptWalPath(input.input.resultsJsonlPath),
+      attemptStarted,
+      { flush: true },
+    );
+  }
+  const runHarbor = () => input.input.harborRunner({
+    runId: input.input.runId,
+    roundId: input.input.roundId,
+    task: input.task,
+    config: input.config,
+    systemPrompt: input.systemPrompt,
+  });
   let output;
   try {
     output = await runHarbor();

--- a/packages/headless/src/harness-ab-report.ts
+++ b/packages/headless/src/harness-ab-report.ts
@@ -161,7 +161,7 @@ export function renderHarnessAbReportMarkdown(report: HarnessAbReport): string {
     `Status: ${report.runStatus}${report.stopReason ? ` (${report.stopReason})` : ''}.`,
     '',
     `Run: ${report.runId}; tasks: ${report.taskCount}; paired evaluated: ${report.effectiveness.pairedEvaluated}.`,
-    `Cell coverage: ${report.coverage.attemptedCells}/${report.coverage.scheduledCells} attempted; ${report.coverage.modelScoredCells} model-scored; ${report.coverage.infraFailedCells} infra-failed; ${report.coverage.unscoredCells} unscored; ${report.coverage.missingFinalUsageCells} missing final usage.`,
+    `Cell coverage: ${report.coverage.attemptedCells}/${report.coverage.scheduledCells} attempted; ${report.coverage.modelScoredCells} model-scored; ${report.coverage.unscoredCells} unscored (including ${report.coverage.infraFailedCells} infra-failed); ${report.coverage.missingFinalUsageCells} missing final usage.`,
     `Economy coverage: fully metered pairs: ${report.economy.pairedMetered}; missing usage: ${report.economy.missingUsagePairs}.`,
     '',
     '## Effectiveness',

--- a/packages/headless/src/harness-ab-report.ts
+++ b/packages/headless/src/harness-ab-report.ts
@@ -57,10 +57,10 @@ export function buildHarnessAbReport(summary: AbComparisonSummary): HarnessAbRep
   const coverage = {
     scheduledCells: summary.baseline.attempts + summary.candidate.attempts,
     attemptedCells: summary.baseline.observed + summary.candidate.observed,
-    modelScoredCells: summary.baseline.valid + summary.candidate.valid,
+    modelScoredCells: summary.baseline.completed + summary.candidate.completed,
     infraFailedCells: summary.baseline.infraFailed + summary.candidate.infraFailed,
     unscoredCells: summary.baseline.observed + summary.candidate.observed
-      - summary.baseline.valid - summary.candidate.valid,
+      - summary.baseline.completed - summary.candidate.completed,
     missingFinalUsageCells: summary.baseline.missingFinalUsage + summary.candidate.missingFinalUsage,
   };
   const runStatus = summary.stopReason

--- a/packages/headless/src/harness-ab-report.ts
+++ b/packages/headless/src/harness-ab-report.ts
@@ -21,17 +21,18 @@ export interface HarnessAbArmEconomy {
 }
 
 export interface HarnessAbReport {
-  schemaVersion: 'maka.harness_ab.report.v1';
+  schemaVersion: 'maka.harness_ab.report.v2';
   runId: string;
-  runStatus: 'completed' | 'incomplete' | 'stopped';
+  runStatus: 'completed' | 'completed_with_gaps' | 'incomplete' | 'stopped';
   stopReason?: NonNullable<AbComparisonSummary['stopReason']>;
   taskCount: number;
-  completeness: {
-    baselineObserved: number;
-    candidateObserved: number;
-    expectedPerArm: number;
-    excludedPairs: number;
-    missingPairs: number;
+  coverage: {
+    scheduledCells: number;
+    attemptedCells: number;
+    modelScoredCells: number;
+    infraFailedCells: number;
+    unscoredCells: number;
+    missingFinalUsageCells: number;
   };
   effectiveness: {
     metric: 'pass@1';
@@ -53,26 +54,29 @@ export interface HarnessAbReport {
 }
 
 export function buildHarnessAbReport(summary: AbComparisonSummary): HarnessAbReport {
+  const coverage = {
+    scheduledCells: summary.baseline.attempts + summary.candidate.attempts,
+    attemptedCells: summary.baseline.observed + summary.candidate.observed,
+    modelScoredCells: summary.baseline.valid + summary.candidate.valid,
+    infraFailedCells: summary.baseline.infraFailed + summary.candidate.infraFailed,
+    unscoredCells: summary.baseline.observed + summary.candidate.observed
+      - summary.baseline.valid - summary.candidate.valid,
+    missingFinalUsageCells: summary.baseline.missingFinalUsage + summary.candidate.missingFinalUsage,
+  };
   const runStatus = summary.stopReason
     ? 'stopped'
-    : summary.pairedAttempts.missingPairIds.length === 0
-        && summary.pairedAttempts.missingUsagePairIds.length === 0
-        && summary.pairedAttempts.excludedPairIds.length === 0
-      ? 'completed'
-      : 'incomplete';
+    : coverage.attemptedCells < coverage.scheduledCells
+      ? 'incomplete'
+      : coverage.unscoredCells > 0 || coverage.missingFinalUsageCells > 0
+        ? 'completed_with_gaps'
+        : 'completed';
   return {
-    schemaVersion: 'maka.harness_ab.report.v1',
+    schemaVersion: 'maka.harness_ab.report.v2',
     runId: summary.runId,
     runStatus,
     ...(summary.stopReason ? { stopReason: summary.stopReason } : {}),
     taskCount: summary.taskCount,
-    completeness: {
-      baselineObserved: summary.baseline.observed,
-      candidateObserved: summary.candidate.observed,
-      expectedPerArm: summary.baseline.attempts,
-      excludedPairs: summary.pairedAttempts.excludedPairIds.length,
-      missingPairs: summary.pairedAttempts.missingPairIds.length,
-    },
+    coverage,
     effectiveness: {
       metric: 'pass@1',
       pairedEvaluated: summary.pairedAttempts.evaluatedPairs,
@@ -130,14 +134,17 @@ export function renderHarnessAbReportCsv(report: HarnessAbReport): string {
     ['economy', 'cost_per_pass_usd', baselineEconomy.armId, baselineEconomy.costPerPassUsd, candidateEconomy.armId, candidateEconomy.costPerPassUsd, nullableDelta(candidateEconomy.costPerPassUsd, baselineEconomy.costPerPassUsd)],
   ];
   return [
-    'run_status,stop_reason,paired_expected,paired_evaluated,excluded_pairs,missing_pairs,paired_metered,missing_usage_pairs,axis,metric,baseline_arm,baseline_value,candidate_arm,candidate_value,candidate_minus_baseline',
+    'run_status,stop_reason,scheduled_cells,attempted_cells,model_scored_cells,infra_failed_cells,unscored_cells,missing_final_usage_cells,paired_evaluated,paired_metered,missing_usage_pairs,axis,metric,baseline_arm,baseline_value,candidate_arm,candidate_value,candidate_minus_baseline',
     ...rows.map((row) => [
       report.runStatus,
       report.stopReason ?? '',
-      report.completeness.expectedPerArm,
+      report.coverage.scheduledCells,
+      report.coverage.attemptedCells,
+      report.coverage.modelScoredCells,
+      report.coverage.infraFailedCells,
+      report.coverage.unscoredCells,
+      report.coverage.missingFinalUsageCells,
       report.effectiveness.pairedEvaluated,
-      report.completeness.excludedPairs,
-      report.completeness.missingPairs,
       report.economy.pairedMetered,
       report.economy.missingUsagePairs,
       ...row,
@@ -153,7 +160,8 @@ export function renderHarnessAbReportMarkdown(report: HarnessAbReport): string {
     '',
     `Status: ${report.runStatus}${report.stopReason ? ` (${report.stopReason})` : ''}.`,
     '',
-    `Run: ${report.runId}; tasks: ${report.taskCount}; paired evaluated: ${report.effectiveness.pairedEvaluated}; excluded: ${report.completeness.excludedPairs}; missing: ${report.completeness.missingPairs}.`,
+    `Run: ${report.runId}; tasks: ${report.taskCount}; paired evaluated: ${report.effectiveness.pairedEvaluated}.`,
+    `Cell coverage: ${report.coverage.attemptedCells}/${report.coverage.scheduledCells} attempted; ${report.coverage.modelScoredCells} model-scored; ${report.coverage.infraFailedCells} infra-failed; ${report.coverage.unscoredCells} unscored; ${report.coverage.missingFinalUsageCells} missing final usage.`,
     `Economy coverage: fully metered pairs: ${report.economy.pairedMetered}; missing usage: ${report.economy.missingUsagePairs}.`,
     '',
     '## Effectiveness',
@@ -187,14 +195,7 @@ export function assertHarnessAbReportCompleted(report: HarnessAbReport): void {
     throw new Error(`harness A/B stopped: ${report.stopReason ?? 'unknown_reason'}`);
   }
   if (report.runStatus === 'incomplete') {
-    if (report.economy.missingUsagePairs > 0) {
-      throw new Error(
-        `harness A/B incomplete: missing usage for ${report.economy.missingUsagePairs} pair(s)`,
-      );
-    }
-    throw new Error(
-      `harness A/B incomplete: ${report.effectiveness.pairedEvaluated}/${report.completeness.expectedPerArm} paired attempts evaluated (${report.completeness.excludedPairs} excluded, ${report.completeness.missingPairs} missing)`,
-    );
+    throw new Error(`harness A/B incomplete: ${report.coverage.attemptedCells}/${report.coverage.scheduledCells} scheduled cells attempted`);
   }
 }
 


### PR DESCRIPTION
## Summary

- lock the existing Harness behavior that persists one terminal infrastructure outcome, continues the frozen suffix, and never reruns the admitted Pass@1 cell on resume
- publish `maka.harness_ab.report.v2` with cell-level scheduled, attempted, model-scored, infrastructure-failed, unscored, and missing-final-usage coverage while retaining paired effectiveness and economy denominators
- treat a fully attempted schedule with honest evidence gaps as the successful `completed_with_gaps` terminal state while keeping unattempted suffixes and systemic stops unsuccessful

Closes #1080.

## Verification

- `npm --workspace @maka/headless test` — 1025 tests passed
- `npm --workspace @maka/headless run typecheck`
- Live provider and Oracle benchmark runs were not run; deterministic Harness/controller coverage exercises the contract without provider traffic.

## Diagnosis

Current `main` already converts recoverable Harbor failures into durable terminal cell events before they reach the generic pair scheduler. The new Harness regression passes without a scheduler production change and proves later cells run while resume preserves the single admitted sample. Raw scheduler, persistence, manifest, and lock rejections remain fail-loud rather than being fabricated as cell outcomes.