### PR TITLE
feat(cli): fold background-task polls at tool_start and announce settles

### DIFF
--- a/packages/cli/src/__tests__/pi-transcript.test.ts
+++ b/packages/cli/src/__tests__/pi-transcript.test.ts
@@ -1234,6 +1234,276 @@ describe('Maka Pi TUI transcript', () => {
     assert.doesNotMatch(unavailable, /Ask Maka to stop this task/);
   });
 
+  test('never renders a background-task Read card while a poll is in flight', () => {
+    const state = createMakaPiTranscriptState();
+    const ref = 'maka://runtime/background-tasks/bg-1';
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_start', toolUseId: 'bash-bg', toolName: 'Bash',
+      args: { command: 'npm test' },
+    }));
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_result', toolUseId: 'bash-bg', isError: false,
+      content: shellRun({ ref, status: 'running', stdout: 'starting\n', updatedAt: 2_000 }),
+    }));
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_start', toolUseId: 'read-bg', toolName: 'Read', args: { ref },
+    }));
+
+    // The poll is in flight, but no Read row ever appears — the parent card is
+    // the only tool entry throughout.
+    assert.deepEqual(
+      state.entries.filter((entry) => entry.kind === 'tool').map((tool) => tool.toolUseId),
+      ['bash-bg'],
+    );
+    const inFlight = renderMakaPiTranscript(state, meta(), 100).map(stripAnsi).join('\n');
+    assert.doesNotMatch(inFlight, /● Read/);
+
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_result', toolUseId: 'read-bg', isError: false,
+      content: shellRun({ ref, status: 'running', stdout: 'starting\nstill running\n', updatedAt: 5_000 }),
+    }));
+
+    const tools = state.entries.filter((entry) => entry.kind === 'tool');
+    assert.deepEqual(tools.map((tool) => tool.toolUseId), ['bash-bg']);
+    assert.equal(
+      tools[0]?.result?.kind === 'shell_run' && tools[0].result.output?.mode === 'pipes'
+        ? tools[0].result.output.stdout
+        : '',
+      'starting\nstill running\n',
+    );
+    const settled = renderMakaPiTranscript(state, meta(), 100).map(stripAnsi).join('\n');
+    assert.doesNotMatch(settled, /● Read/);
+  });
+
+  test('surfaces an errored background-task poll as a card instead of swallowing it', () => {
+    const state = createMakaPiTranscriptState();
+    const ref = 'maka://runtime/background-tasks/bg-1';
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_start', toolUseId: 'bash-bg', toolName: 'Bash',
+      args: { command: 'npm test' },
+    }));
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_result', toolUseId: 'bash-bg', isError: false,
+      content: shellRun({ ref, status: 'running', stdout: 'starting\n', updatedAt: 2_000 }),
+    }));
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_start', toolUseId: 'read-bg', toolName: 'Read', args: { ref },
+    }));
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_result', toolUseId: 'read-bg', isError: true,
+      content: { kind: 'text', text: 'background task no longer exists' },
+    }));
+
+    const tools = state.entries.filter((entry) => entry.kind === 'tool');
+    assert.equal(tools.length, 2);
+    const poll = tools[1];
+    assert.equal(poll?.toolUseId, 'read-bg');
+    assert.equal(poll?.toolName, 'Read');
+    assert.equal(poll?.status, 'error');
+    const rendered = renderMakaPiTranscript(state, meta(), 100).map(stripAnsi).join('\n');
+    assert.match(rendered, /● Read/);
+    assert.match(rendered, /background task no longer exists/);
+  });
+
+  test('never renders a StopBackgroundTask card while the stop is in flight', () => {
+    const state = createMakaPiTranscriptState();
+    const ref = 'maka://runtime/background-tasks/bg-1';
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_start', toolUseId: 'bash-bg', toolName: 'Bash', args: { command: 'sleep 30' },
+    }));
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_result', toolUseId: 'bash-bg', isError: false,
+      content: shellRun({ ref, status: 'running' }),
+    }));
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_start', toolUseId: 'stop-bg', toolName: 'StopBackgroundTask', args: { ref },
+    }));
+
+    // No transient stop row while the stop call is in flight.
+    assert.deepEqual(
+      state.entries.filter((entry) => entry.kind === 'tool').map((tool) => tool.toolUseId),
+      ['bash-bg'],
+    );
+
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_result', toolUseId: 'stop-bg', isError: false,
+      content: shellRun({ ref, status: 'cancelled', completedAt: 8_000, exitCode: 130 }),
+    }));
+
+    const tools = state.entries.filter((entry) => entry.kind === 'tool');
+    assert.deepEqual(tools.map((tool) => tool.toolUseId), ['bash-bg']);
+    assert.equal(tools[0]?.status, 'aborted');
+    const rendered = renderMakaPiTranscript(state, meta(), 100).map(stripAnsi).join('\n');
+    assert.doesNotMatch(rendered, /● StopBackgroundTask/);
+  });
+
+  test('never folds a WriteStdin aimed at a background-task ref', () => {
+    const state = createMakaPiTranscriptState();
+    const ref = 'maka://runtime/background-tasks/bg-1';
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_start', toolUseId: 'bash-bg', toolName: 'Bash', args: { command: 'top' },
+    }));
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_result', toolUseId: 'bash-bg', isError: false,
+      content: shellRun({ ref, status: 'running' }),
+    }));
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_start', toolUseId: 'stdin-bg', toolName: 'WriteStdin',
+      args: { ref, input: 'q' },
+    }));
+
+    // WriteStdin is a real interaction with the process, not polling: its card
+    // renders from tool_start on.
+    const tools = state.entries.filter((entry) => entry.kind === 'tool');
+    assert.deepEqual(tools.map((tool) => tool.toolUseId), ['bash-bg', 'stdin-bg']);
+    assert.equal(tools[1]?.status, 'running');
+  });
+
+  test('announces at the transcript tail when a running background task completes', () => {
+    const state = createMakaPiTranscriptState();
+    const ref = 'maka://runtime/background-tasks/bg-1';
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_start', toolUseId: 'bash-bg', toolName: 'Bash',
+      args: { command: 'npm test' },
+    }));
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_result', toolUseId: 'bash-bg', isError: false,
+      content: shellRun({ ref, status: 'running', stdout: 'starting\n', updatedAt: 2_000 }),
+    }));
+
+    applyShellRunViewUpdateToTranscript(state, {
+      sessionId: 'session-1',
+      ownership: { kind: 'local' },
+      sourceTurnId: 'turn-1',
+      sourceToolCallId: 'bash-bg',
+      result: shellRun({ ref, status: 'completed', stdout: 'starting\ndone\n', completedAt: 48_000, exitCode: 0 }),
+    });
+
+    const notice = state.entries[state.entries.length - 1];
+    assert.equal(notice?.kind, 'notice');
+    assert.equal(notice?.kind === 'notice' ? notice.level : '', 'info');
+    const text = notice?.kind === 'notice' ? notice.text : '';
+    assert.match(text, /Background task completed: npm test/);
+    assert.match(text, /exit 0/);
+    assert.match(text, /47s/);
+  });
+
+  test('notifies a settle exactly once across a folded poll and the live update', () => {
+    const state = createMakaPiTranscriptState();
+    const ref = 'maka://runtime/background-tasks/bg-1';
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_start', toolUseId: 'bash-bg', toolName: 'Bash',
+      args: { command: 'npm test' },
+    }));
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_result', toolUseId: 'bash-bg', isError: false,
+      content: shellRun({ ref, status: 'running', stdout: 'starting\n', updatedAt: 2_000 }),
+    }));
+
+    // The model's poll observes the settle first: exactly one notice.
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_start', toolUseId: 'read-bg', toolName: 'Read', args: { ref },
+    }));
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_result', toolUseId: 'read-bg', isError: false,
+      content: shellRun({ ref, status: 'completed', stdout: 'starting\ndone\n', completedAt: 48_000, exitCode: 0 }),
+    }));
+    let notices = state.entries.filter((entry) => entry.kind === 'notice');
+    assert.equal(notices.length, 1);
+    assert.equal(notices[0]?.kind === 'notice' ? notices[0].level : '', 'info');
+    assert.match(notices[0]?.kind === 'notice' ? notices[0].text : '', /Background task completed: npm test/);
+
+    // The event-driven update reporting the same settle must not re-notify.
+    applyShellRunViewUpdateToTranscript(state, {
+      sessionId: 'session-1',
+      ownership: { kind: 'local' },
+      sourceTurnId: 'turn-1',
+      sourceToolCallId: 'bash-bg',
+      result: shellRun({ ref, status: 'completed', stdout: 'starting\ndone\n', completedAt: 48_000, exitCode: 0 }),
+    });
+    notices = state.entries.filter((entry) => entry.kind === 'notice');
+    assert.equal(notices.length, 1);
+  });
+
+  test('announces a failed background task as an error with its exit and message', () => {
+    const state = createMakaPiTranscriptState();
+    const ref = 'maka://runtime/background-tasks/bg-1';
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_start', toolUseId: 'bash-bg', toolName: 'Bash',
+      args: { command: 'npm run build' },
+    }));
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_result', toolUseId: 'bash-bg', isError: false,
+      content: shellRun({ ref, status: 'running', cmd: 'npm run build' }),
+    }));
+
+    applyShellRunViewUpdateToTranscript(state, {
+      sessionId: 'session-1',
+      ownership: { kind: 'local' },
+      sourceTurnId: 'turn-1',
+      sourceToolCallId: 'bash-bg',
+      result: shellRun({
+        ref, status: 'failed', cmd: 'npm run build',
+        completedAt: 13_000, exitCode: 1, failureMessage: 'compiler exited\nwith diagnostics',
+      }),
+    });
+
+    const notice = state.entries[state.entries.length - 1];
+    assert.equal(notice?.kind, 'notice');
+    assert.equal(notice?.kind === 'notice' ? notice.level : '', 'error');
+    const text = notice?.kind === 'notice' ? notice.text : '';
+    assert.match(text, /Background task failed: npm run build/);
+    assert.match(text, /exit 1/);
+    assert.match(text, /12s/);
+    // Only the first line of a multi-line failure message joins the notice.
+    assert.match(text, /compiler exited/);
+    assert.doesNotMatch(text, /with diagnostics/);
+  });
+
+  test('announces a stopped background task as a plain note', () => {
+    const state = createMakaPiTranscriptState();
+    const ref = 'maka://runtime/background-tasks/bg-1';
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_start', toolUseId: 'bash-bg', toolName: 'Bash', args: { command: 'sleep 30' },
+    }));
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_result', toolUseId: 'bash-bg', isError: false,
+      content: shellRun({ ref, status: 'running', cmd: 'sleep 30' }),
+    }));
+
+    applyShellRunViewUpdateToTranscript(state, {
+      sessionId: 'session-1',
+      ownership: { kind: 'local' },
+      sourceTurnId: 'turn-1',
+      sourceToolCallId: 'bash-bg',
+      result: shellRun({ ref, status: 'cancelled', cmd: 'sleep 30', completedAt: 8_000, exitCode: 130 }),
+    });
+
+    const notice = state.entries[state.entries.length - 1];
+    assert.equal(notice?.kind, 'notice');
+    assert.equal(notice?.kind === 'notice' ? notice.level : '', 'info');
+    assert.match(notice?.kind === 'notice' ? notice.text : '', /Background task stopped: sleep 30/);
+  });
+
+  test('stays silent for a background task already settled in stored history', () => {
+    const state = createMakaPiTranscriptState();
+    const ref = 'maka://runtime/background-tasks/bg-1';
+
+    replaceTranscriptWithStoredMessages(state, [
+      {
+        type: 'tool_call', id: 'bash-bg', turnId: 'turn-1', ts: 1,
+        toolName: 'Bash', args: { command: 'npm test' },
+      },
+      {
+        type: 'tool_result', id: 'bash-result', turnId: 'turn-1', ts: 2,
+        toolUseId: 'bash-bg', isError: false,
+        content: shellRun({ ref, status: 'completed', stdout: 'done\n', completedAt: 5_000, updatedAt: 5_000, exitCode: 0 }),
+      },
+    ] satisfies StoredMessage[]);
+
+    assert.equal(state.entries.some((entry) => entry.kind === 'notice'), false);
+  });
+
   test('folds a background-task Read result into its parent Bash card', () => {
     const state = createMakaPiTranscriptState();
     const ref = 'maka://runtime/background-tasks/bg-1';

--- a/packages/cli/src/__tests__/pi-transcript.test.ts
+++ b/packages/cli/src/__tests__/pi-transcript.test.ts
@@ -399,6 +399,85 @@ describe('Maka Pi TUI transcript', () => {
     );
   });
 
+  test('keeps a stored errored Read poll as a card without folding it into the parent Bash card', () => {
+    const state = createMakaPiTranscriptState();
+    const ref = 'maka://runtime/background-tasks/bg-1';
+
+    replaceTranscriptWithStoredMessages(state, [
+      {
+        type: 'tool_call', id: 'bash-bg', turnId: 'turn-1', ts: 1,
+        toolName: 'Bash', args: { command: 'npm test' },
+      },
+      {
+        type: 'tool_result', id: 'bash-result', turnId: 'turn-1', ts: 2,
+        toolUseId: 'bash-bg', isError: false,
+        content: shellRun({ ref, status: 'running', stdout: 'starting\n', revision: 1, updatedAt: 2_000 }),
+      },
+      {
+        type: 'tool_call', id: 'read-bg', turnId: 'turn-1', ts: 3,
+        toolName: 'Read', args: { ref },
+      },
+      // isError is the call-level authoritative status: even with a well-formed
+      // shell_run payload, a failed poll must survive replay as its own error
+      // card and must not mutate the parent.
+      {
+        type: 'tool_result', id: 'read-result', turnId: 'turn-1', ts: 4,
+        toolUseId: 'read-bg', isError: true,
+        content: shellRun({ ref, status: 'running', stdout: 'starting\nnewer\n', revision: 2, updatedAt: 5_000 }),
+      },
+    ] satisfies StoredMessage[]);
+
+    const tools = state.entries.filter((entry) => entry.kind === 'tool');
+    assert.deepEqual(tools.map((tool) => tool.toolUseId), ['bash-bg', 'read-bg']);
+    assert.equal(tools[1]?.status, 'error');
+    // The parent keeps its own revision, output, and status — the failed poll
+    // changes nothing.
+    assert.equal(tools[0]?.status, 'running');
+    assert.equal(tools[0]?.result?.kind === 'shell_run' ? tools[0].result.revision : undefined, 1);
+    assert.equal(
+      tools[0]?.result?.kind === 'shell_run' && tools[0].result.output?.mode === 'pipes'
+        ? tools[0].result.output.stdout
+        : '',
+      'starting\n',
+    );
+    const rendered = renderMakaPiTranscript(state, meta(), 100).map(stripAnsi).join('\n');
+    assert.match(rendered, /● Read/);
+  });
+
+  test('keeps a stored errored StopBackgroundTask poll as a card without folding it into the parent', () => {
+    const state = createMakaPiTranscriptState();
+    const ref = 'maka://runtime/background-tasks/bg-1';
+
+    replaceTranscriptWithStoredMessages(state, [
+      {
+        type: 'tool_call', id: 'bash-bg', turnId: 'turn-1', ts: 1,
+        toolName: 'Bash', args: { command: 'sleep 30' },
+      },
+      {
+        type: 'tool_result', id: 'bash-result', turnId: 'turn-1', ts: 2,
+        toolUseId: 'bash-bg', isError: false,
+        content: shellRun({ ref, status: 'running', stdout: 'starting\n', revision: 1, updatedAt: 2_000 }),
+      },
+      {
+        type: 'tool_call', id: 'stop-bg', turnId: 'turn-1', ts: 3,
+        toolName: 'StopBackgroundTask', args: { ref },
+      },
+      {
+        type: 'tool_result', id: 'stop-result', turnId: 'turn-1', ts: 4,
+        toolUseId: 'stop-bg', isError: true,
+        content: shellRun({ ref, status: 'cancelled', stdout: 'starting\n', revision: 2, completedAt: 5_000, exitCode: 130 }),
+      },
+    ] satisfies StoredMessage[]);
+
+    const tools = state.entries.filter((entry) => entry.kind === 'tool');
+    assert.deepEqual(tools.map((tool) => tool.toolUseId), ['bash-bg', 'stop-bg']);
+    assert.equal(tools[1]?.status, 'error');
+    assert.equal(tools[0]?.status, 'running');
+    assert.equal(tools[0]?.result?.kind === 'shell_run' ? tools[0].result.revision : undefined, 1);
+    const rendered = renderMakaPiTranscript(state, meta(), 100).map(stripAnsi).join('\n');
+    assert.match(rendered, /● StopBackgroundTask/);
+  });
+
   test('renders a PTY around the cursor when compact and as three head plus three tail rows when expanded', () => {
     const state = createMakaPiTranscriptState();
     const screen = Array.from({ length: 8 }, (_, index) => `pty-row-${index + 1}`).join('\n');

--- a/packages/cli/src/__tests__/pi-transcript.test.ts
+++ b/packages/cli/src/__tests__/pi-transcript.test.ts
@@ -1275,6 +1275,73 @@ describe('Maka Pi TUI transcript', () => {
     assert.doesNotMatch(settled, /● Read/);
   });
 
+  test('surfaces an errored poll carrying shell_run content instead of folding it', () => {
+    const state = createMakaPiTranscriptState();
+    const ref = 'maka://runtime/background-tasks/bg-1';
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_start', toolUseId: 'bash-bg', toolName: 'Bash',
+      args: { command: 'npm test' },
+    }));
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_result', toolUseId: 'bash-bg', isError: false,
+      content: shellRun({ ref, status: 'running', stdout: 'starting\n', updatedAt: 2_000 }),
+    }));
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_start', toolUseId: 'read-bg', toolName: 'Read', args: { ref },
+    }));
+    // isError is the call-level authoritative status: even with a well-formed
+    // shell_run payload, the failed call must not fold into the parent.
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_result', toolUseId: 'read-bg', isError: true,
+      content: shellRun({ ref, status: 'running', stdout: 'starting\nnewer\n', updatedAt: 5_000 }),
+    }));
+
+    const tools = state.entries.filter((entry) => entry.kind === 'tool');
+    assert.deepEqual(tools.map((tool) => tool.toolUseId), ['bash-bg', 'read-bg']);
+    assert.equal(tools[1]?.status, 'error');
+    // The parent keeps its pre-error revision — the failed call changes nothing.
+    assert.equal(
+      tools[0]?.result?.kind === 'shell_run' && tools[0].result.output?.mode === 'pipes'
+        ? tools[0].result.output.stdout
+        : '',
+      'starting\n',
+    );
+    const rendered = renderMakaPiTranscript(state, meta(), 100).map(stripAnsi).join('\n');
+    assert.match(rendered, /● Read/);
+  });
+
+  test('keeps an errored non-folded poll card instead of splicing it into the parent', () => {
+    const state = createMakaPiTranscriptState();
+    const ref = 'maka://runtime/background-tasks/bg-1';
+    // The Read starts before the parent carries its shell_run result, so it is
+    // not folded at tool_start.
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_start', toolUseId: 'bash-bg', toolName: 'Bash',
+      args: { command: 'npm test' },
+    }));
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_start', toolUseId: 'read-bg', toolName: 'Read', args: { ref },
+    }));
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_result', toolUseId: 'bash-bg', isError: false,
+      content: shellRun({ ref, status: 'running', stdout: 'starting\n', updatedAt: 2_000 }),
+    }));
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_result', toolUseId: 'read-bg', isError: true,
+      content: shellRun({ ref, status: 'running', stdout: 'starting\nnewer\n', updatedAt: 5_000 }),
+    }));
+
+    const tools = state.entries.filter((entry) => entry.kind === 'tool');
+    assert.deepEqual(tools.map((tool) => tool.toolUseId), ['bash-bg', 'read-bg']);
+    assert.equal(tools[1]?.status, 'error');
+    assert.equal(
+      tools[0]?.result?.kind === 'shell_run' && tools[0].result.output?.mode === 'pipes'
+        ? tools[0].result.output.stdout
+        : '',
+      'starting\n',
+    );
+  });
+
   test('surfaces an errored background-task poll as a card instead of swallowing it', () => {
     const state = createMakaPiTranscriptState();
     const ref = 'maka://runtime/background-tasks/bg-1';
@@ -1357,6 +1424,39 @@ describe('Maka Pi TUI transcript', () => {
     const tools = state.entries.filter((entry) => entry.kind === 'tool');
     assert.deepEqual(tools.map((tool) => tool.toolUseId), ['bash-bg', 'stdin-bg']);
     assert.equal(tools[1]?.status, 'running');
+  });
+
+  test('stays silent for a hydration catch-up update that settles a resumed card', () => {
+    const state = createMakaPiTranscriptState();
+    const ref = 'maka://runtime/background-tasks/bg-1';
+
+    // A resumed session: stored history still records the run as running.
+    replaceTranscriptWithStoredMessages(state, [
+      {
+        type: 'tool_call', id: 'bash-bg', turnId: 'turn-1', ts: 1,
+        toolName: 'Bash', args: { command: 'npm test' },
+      },
+      {
+        type: 'tool_result', id: 'bash-result', turnId: 'turn-1', ts: 2,
+        toolUseId: 'bash-bg', isError: false,
+        content: shellRun({ ref, status: 'running', stdout: 'starting\n', updatedAt: 2_000 }),
+      },
+    ] satisfies StoredMessage[]);
+
+    // Durable state says the run settled while away: the card flips, but
+    // catch-up replay is not a live event, so no notice fires.
+    const applied = applyShellRunViewUpdateToTranscript(state, {
+      sessionId: 'session-1',
+      ownership: { kind: 'local' },
+      sourceTurnId: 'turn-1',
+      sourceToolCallId: 'bash-bg',
+      result: shellRun({ ref, status: 'completed', stdout: 'starting\ndone\n', completedAt: 48_000, exitCode: 0 }),
+    }, { announceSettle: false });
+
+    assert.equal(applied, true);
+    const tools = state.entries.filter((entry) => entry.kind === 'tool');
+    assert.equal(tools[0]?.status, 'done');
+    assert.equal(state.entries.some((entry) => entry.kind === 'notice'), false);
   });
 
   test('announces at the transcript tail when a running background task completes', () => {
@@ -1502,6 +1602,55 @@ describe('Maka Pi TUI transcript', () => {
     ] satisfies StoredMessage[]);
 
     assert.equal(state.entries.some((entry) => entry.kind === 'notice'), false);
+  });
+
+  test('announces a timed-out background task with human-readable text', () => {
+    const state = createMakaPiTranscriptState();
+    const ref = 'maka://runtime/background-tasks/bg-1';
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_start', toolUseId: 'bash-bg', toolName: 'Bash',
+      args: { command: 'npm test' },
+    }));
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_result', toolUseId: 'bash-bg', isError: false,
+      content: shellRun({ ref, status: 'running' }),
+    }));
+
+    applyShellRunViewUpdateToTranscript(state, {
+      sessionId: 'session-1',
+      ownership: { kind: 'local' },
+      sourceTurnId: 'turn-1',
+      sourceToolCallId: 'bash-bg',
+      result: shellRun({ ref, status: 'timed_out', completedAt: 60_000 }),
+    });
+
+    const notice = state.entries[state.entries.length - 1];
+    assert.equal(notice?.kind, 'notice');
+    assert.equal(notice?.kind === 'notice' ? notice.level : '', 'error');
+    const text = notice?.kind === 'notice' ? notice.text : '';
+    assert.match(text, /Background task timed out: npm test/);
+    assert.doesNotMatch(text, /timed_out/);
+  });
+
+  test('drops a folded poll when the turn aborts mid-flight', () => {
+    const state = createMakaPiTranscriptState();
+    const ref = 'maka://runtime/background-tasks/bg-1';
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_start', toolUseId: 'bash-bg', toolName: 'Bash',
+      args: { command: 'npm test' },
+    }));
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_result', toolUseId: 'bash-bg', isError: false,
+      content: shellRun({ ref, status: 'running' }),
+    }));
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_start', toolUseId: 'read-bg', toolName: 'Read', args: { ref },
+    }));
+    assert.equal(state.pendingShellRunPolls.size, 1);
+
+    applyMakaSessionEventToTranscript(state, event({ type: 'abort', reason: 'user_stop' }));
+
+    assert.equal(state.pendingShellRunPolls.size, 0);
   });
 
   test('folds a background-task Read result into its parent Bash card', () => {

--- a/packages/cli/src/__tests__/pi-transcript.test.ts
+++ b/packages/cli/src/__tests__/pi-transcript.test.ts
@@ -1604,6 +1604,114 @@ describe('Maka Pi TUI transcript', () => {
     assert.equal(notices.length, 1);
   });
 
+  test('announces a detached background task settle exactly once when its owner completes it', () => {
+    const state = createMakaPiTranscriptState();
+    const ref = 'maka://runtime/background-tasks/bg-1';
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_start', toolUseId: 'bash-bg', toolName: 'Bash', args: { command: 'build' },
+    }));
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_result', toolUseId: 'bash-bg', isError: false,
+      content: shellRun({ ref, status: 'running', cmd: 'build', stdout: 'starting\n', updatedAt: 2_000 }),
+    }));
+
+    // An inherited run is presented as `detached` while its resource keeps
+    // running; this must not silence its later settle.
+    applyShellRunViewUpdateToTranscript(state, {
+      sessionId: 'session-branch',
+      ownership: { kind: 'source_owned', sourceSessionId: 'session-1', ownerSessionId: 'session-1' },
+      sourceTurnId: 'turn-1',
+      sourceToolCallId: 'bash-bg',
+      result: shellRun({ ref, status: 'running', cmd: 'build', stdout: 'starting\n', updatedAt: 3_000, revision: 3_000 }),
+    });
+    const detached = state.entries.find((entry) => entry.kind === 'tool');
+    assert.equal(detached?.kind === 'tool' ? detached.status : '', 'detached');
+    assert.equal(state.entries.some((entry) => entry.kind === 'notice'), false);
+
+    // The owner's live subscription settles the run: the detached card still
+    // announces exactly once.
+    applyShellRunViewUpdateToTranscript(state, {
+      sessionId: 'session-1',
+      ownership: { kind: 'local' },
+      sourceTurnId: 'turn-1',
+      sourceToolCallId: 'bash-bg',
+      result: shellRun({ ref, status: 'completed', cmd: 'build', stdout: 'starting\ndone\n', completedAt: 48_000, exitCode: 0, revision: 48_000 }),
+    });
+    const notices = state.entries.filter((entry) => entry.kind === 'notice');
+    assert.equal(notices.length, 1);
+    assert.equal(notices[0]?.kind === 'notice' ? notices[0].level : '', 'info');
+    assert.match(notices[0]?.kind === 'notice' ? notices[0].text : '', /Background task completed: build/);
+  });
+
+  test('announces a detached background task orphaned settle as an error exactly once', () => {
+    const state = createMakaPiTranscriptState();
+    const ref = 'maka://runtime/background-tasks/bg-1';
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_start', toolUseId: 'bash-bg', toolName: 'Bash', args: { command: 'build' },
+    }));
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_result', toolUseId: 'bash-bg', isError: false,
+      content: shellRun({ ref, status: 'running', cmd: 'build', stdout: 'starting\n', updatedAt: 2_000 }),
+    }));
+    applyShellRunViewUpdateToTranscript(state, {
+      sessionId: 'session-branch',
+      ownership: { kind: 'source_owned', sourceSessionId: 'session-1', ownerSessionId: 'session-1' },
+      sourceTurnId: 'turn-1',
+      sourceToolCallId: 'bash-bg',
+      result: shellRun({ ref, status: 'running', cmd: 'build', stdout: 'starting\n', updatedAt: 3_000, revision: 3_000 }),
+    });
+    assert.equal(state.entries.some((entry) => entry.kind === 'notice'), false);
+
+    // The owner reports the run orphaned: an error-level notice with the
+    // `orphaned` verb, fired exactly once from the detached card.
+    applyShellRunViewUpdateToTranscript(state, {
+      sessionId: 'session-1',
+      ownership: { kind: 'local' },
+      sourceTurnId: 'turn-1',
+      sourceToolCallId: 'bash-bg',
+      result: shellRun({ ref, status: 'orphaned', cmd: 'build', completedAt: 20_000, exitCode: 1, revision: 20_000 }),
+    });
+    const notices = state.entries.filter((entry) => entry.kind === 'notice');
+    assert.equal(notices.length, 1);
+    assert.equal(notices[0]?.kind === 'notice' ? notices[0].level : '', 'error');
+    assert.match(notices[0]?.kind === 'notice' ? notices[0].text : '', /Background task orphaned: build/);
+  });
+
+  test('notifies a settle exactly once when the live update precedes the folded poll', () => {
+    const state = createMakaPiTranscriptState();
+    const ref = 'maka://runtime/background-tasks/bg-1';
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_start', toolUseId: 'bash-bg', toolName: 'Bash', args: { command: 'npm test' },
+    }));
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_result', toolUseId: 'bash-bg', isError: false,
+      content: shellRun({ ref, status: 'running', stdout: 'starting\n', updatedAt: 2_000 }),
+    }));
+
+    // The event-driven update reports the settle first: exactly one notice.
+    applyShellRunViewUpdateToTranscript(state, {
+      sessionId: 'session-1',
+      ownership: { kind: 'local' },
+      sourceTurnId: 'turn-1',
+      sourceToolCallId: 'bash-bg',
+      result: shellRun({ ref, status: 'completed', stdout: 'starting\ndone\n', completedAt: 48_000, exitCode: 0 }),
+    });
+    let notices = state.entries.filter((entry) => entry.kind === 'notice');
+    assert.equal(notices.length, 1);
+    assert.match(notices[0]?.kind === 'notice' ? notices[0].text : '', /Background task completed: npm test/);
+
+    // A folded poll observing the same settle afterward must not re-notify.
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_start', toolUseId: 'read-bg', toolName: 'Read', args: { ref },
+    }));
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_result', toolUseId: 'read-bg', isError: false,
+      content: shellRun({ ref, status: 'completed', stdout: 'starting\ndone\n', completedAt: 48_000, exitCode: 0 }),
+    }));
+    notices = state.entries.filter((entry) => entry.kind === 'notice');
+    assert.equal(notices.length, 1);
+  });
+
   test('announces a failed background task as an error with its exit and message', () => {
     const state = createMakaPiTranscriptState();
     const ref = 'maka://runtime/background-tasks/bg-1';

--- a/packages/cli/src/__tests__/pi-tui-runner.test.ts
+++ b/packages/cli/src/__tests__/pi-tui-runner.test.ts
@@ -2151,6 +2151,88 @@ describe('Maka Pi TUI runner', () => {
 
     await waitFor(() => plainTerminalOutput(terminal.screenOutput()).includes('(4s · 2 lines)'));
     assert.deepEqual(reads, ['session-2']);
+    // Hydration is catch-up replay of durable state, not a live settle: the
+    // card flips silently, with no Background task notice at the tail.
+    assert.equal(plainTerminalOutput(terminal.output()).includes('Background task'), false);
+
+    exitMaka(terminal);
+    await run;
+  });
+
+  test('announces a live settle that arrives after hydration completes', async () => {
+    const terminal = new FakeTerminal();
+    const ref = 'maka://runtime/background-tasks/bg-1';
+    const driver = new SlashCommandDriver(
+      [fakeSessionSummary('session-2', '/repo')],
+      new Map([
+        ['session-2', [
+          {
+            type: 'tool_call', id: 'tool-bg', turnId: 'turn-1', ts: 1,
+            toolName: 'Bash', args: { command: 'build' },
+          },
+          {
+            type: 'tool_result', id: 'result-bg', turnId: 'turn-1', ts: 2,
+            toolUseId: 'tool-bg', isError: false,
+            content: {
+              kind: 'shell_run', ref, mode: 'pipes', status: 'running', cwd: '/repo', cmd: 'build',
+              startedAt: 1_000, updatedAt: 2_000,
+              revision: 2_000,
+              output: pipeOutput('starting\n'),
+            },
+          },
+        ] satisfies StoredMessage[]],
+      ]),
+    );
+    let listener: ((update: ShellRunUpdate) => void) | undefined;
+    const run = runMakaPiTui({
+      title: 'Maka', driver, cwd: '/repo', model: 'claude-sonnet-4-5',
+      connectionSlug: 'claude-subscription', permissionMode: 'ask', terminal,
+      subscribeShellRunUpdates: (next) => {
+        listener = next;
+        return () => { listener = undefined; };
+      },
+      // The run is still live at attach time, so catch-up only refreshes output.
+      listShellRunUpdates: async (sessionId) => [{
+        sessionId,
+        ownership: { kind: 'local' },
+        sourceTurnId: 'turn-1',
+        sourceToolCallId: 'tool-bg',
+        result: {
+          kind: 'shell_run', ref, mode: 'pipes', status: 'running', cwd: '/repo', cmd: 'build',
+          startedAt: 1_000, updatedAt: 3_000,
+          revision: 3_000,
+          output: pipeOutput('starting\nstill running\n'),
+        },
+      }],
+    });
+
+    terminal.input('/session session-2');
+    terminal.input('\r');
+
+    await waitFor(() => plainTerminalOutput(terminal.screenOutput()).includes('running'));
+    assert.equal(plainTerminalOutput(terminal.output()).includes('Background task'), false);
+
+    // The settle lands through the live subscription after hydration: exactly
+    // one notice fires.
+    await waitFor(() => listener !== undefined);
+    assert.ok(listener);
+    listener({
+      sessionId: 'session-2',
+      ownership: { kind: 'local' },
+      sourceTurnId: 'turn-1',
+      sourceToolCallId: 'tool-bg',
+      result: {
+        kind: 'shell_run', ref, mode: 'pipes', status: 'completed', cwd: '/repo', cmd: 'build',
+        startedAt: 1_000, updatedAt: 5_000, completedAt: 5_000, exitCode: 0,
+        revision: 5_000,
+        output: pipeOutput('starting\nstill running\ndone\n'),
+      },
+    });
+
+    await waitFor(() => plainTerminalOutput(terminal.output()).includes('Background task completed: build'));
+    await delay(50);
+    const announcements = plainTerminalOutput(terminal.output()).split('Background task completed').length - 1;
+    assert.equal(announcements, 1);
 
     exitMaka(terminal);
     await run;

--- a/packages/cli/src/__tests__/pi-tui-runner.test.ts
+++ b/packages/cli/src/__tests__/pi-tui-runner.test.ts
@@ -2853,6 +2853,15 @@ describe('Maka Pi TUI runner', () => {
     await waitFor(() => plainTerminalOutput(terminal.screenOutput()).includes('3 lines'));
     assert.equal(plainTerminalOutput(terminal.screenOutput()).includes('detached'), false);
 
+    // The detached card's run resource was still `running`, so the owner's live
+    // settle announces exactly once at the transcript tail — the `detached`
+    // presentation status must not swallow the transition.
+    await waitFor(() => plainTerminalOutput(terminal.screenOutput()).includes('Background task completed: build'));
+    assert.equal(
+      plainTerminalOutput(terminal.screenOutput()).split('Background task completed: build').length - 1,
+      1,
+    );
+
     exitMaka(terminal);
     await run;
   });

--- a/packages/cli/src/pi-transcript.ts
+++ b/packages/cli/src/pi-transcript.ts
@@ -652,14 +652,22 @@ function toolActivityToTranscriptEntry(item: ToolActivityItem): MakaPiToolEntry 
     ...(item.durationMs !== undefined ? { durationMs: item.durationMs } : {}),
     status: transcriptToolStatus(item.status),
   };
-  if (item.result?.kind === 'shell_run') applyOwnShellRunResult(entry, item.result);
+  // A failed call keeps its error status and raw payload: applying the shell_run
+  // as the card's own result would let a still-running or settled payload
+  // overwrite the error and swallow the failure on replay. This mirrors the live
+  // tool_result path, which forces `error` for any errored shell_run result, and
+  // is what lets the stored fold below recognize an errored poll by its status.
+  if (item.result?.kind === 'shell_run' && !item.isError) applyOwnShellRunResult(entry, item.result);
   return entry;
 }
 
 function foldStoredShellRunChildren(entries: MakaPiTranscriptEntry[]): MakaPiTranscriptEntry[] {
   const folded: MakaPiTranscriptEntry[] = [];
   for (const entry of entries) {
-    if (entry.kind === 'tool' && entry.result?.kind === 'shell_run') {
+    // An errored poll never folds: its failed payload must not mutate the parent
+    // and its error card must survive replay, mirroring the live path's "failure
+    // is never swallowed" invariant.
+    if (entry.kind === 'tool' && entry.result?.kind === 'shell_run' && entry.status !== 'error') {
       const shellRun = entry.result;
       const parent = [...folded]
         .reverse()

--- a/packages/cli/src/pi-transcript.ts
+++ b/packages/cli/src/pi-transcript.ts
@@ -1190,10 +1190,15 @@ function readArgsRef(args: unknown): string | undefined {
   return typeof ref === 'string' && ref.length > 0 ? ref : undefined;
 }
 
-/** A card tracking a live local run: still `running` with a running shell_run result. */
+/**
+ * A card whose run resource is still `running`. The transition is keyed on the
+ * resource status, not the presentation status: an inherited run is shown as
+ * `detached` while its resource keeps running, and its settle must still
+ * announce. Replay stays silent via the `announceSettle: false` hydration option
+ * and because stored replay never routes through the notice path.
+ */
 function isLiveShellRunCard(entry: MakaPiToolEntry | undefined): boolean {
-  return entry?.status === 'running'
-    && entry.result?.kind === 'shell_run'
+  return entry?.result?.kind === 'shell_run'
     && entry.result.status === 'running';
 }
 

--- a/packages/cli/src/pi-transcript.ts
+++ b/packages/cli/src/pi-transcript.ts
@@ -177,11 +177,21 @@ export function refreshRunningShellRunElapsed(
 export function applyShellRunViewUpdateToTranscript(
   state: MakaPiTranscriptState,
   update: ShellRunUpdate,
+  options?: {
+    /**
+     * Whether a running → settled flip appends a transcript-tail notice.
+     * Default true for live updates. Hydration catch-up (`listShellRunUpdates`)
+     * passes false: replaying durable state is not a live event, and the notice
+     * is never persisted, so announcing catch-up would re-announce on every
+     * session attach.
+     */
+    announceSettle?: boolean;
+  },
 ): boolean {
   const tool = findToolEntry(state, update.sourceToolCallId);
   const wasLive = isLiveShellRunCard(tool);
   const applied = applyShellRunUpdateToTranscript(state, update.sourceToolCallId, update.result);
-  if (tool && wasLive && isSettledShellRunCard(tool)) {
+  if (tool && wasLive && isSettledShellRunCard(tool) && options?.announceSettle !== false) {
     pushShellRunSettledNotice(state, tool);
   }
   if (!tool
@@ -417,7 +427,9 @@ export function applyMakaSessionEventToTranscript(
         const parent = shellRun
           ? findShellRunParent(state, shellRun.ref, event.toolUseId)
           : undefined;
-        if (parent && shellRun) {
+        // isError is the call-level authoritative status: a failed call never
+        // folds, even when it carries a well-formed shell_run payload.
+        if (parent && shellRun && !event.isError) {
           applyLiveShellRunResultToParent(state, parent, shellRun);
           break;
         }
@@ -437,7 +449,7 @@ export function applyMakaSessionEventToTranscript(
           durationMs: event.durationMs,
           status: event.isError ? 'error' : 'done',
         };
-        if (shellRun) applyOwnShellRunResult(entry, shellRun, event.durationMs);
+        if (shellRun && !event.isError) applyOwnShellRunResult(entry, shellRun, event.durationMs);
         state.entries.push(entry);
         break;
       }
@@ -446,7 +458,7 @@ export function applyMakaSessionEventToTranscript(
       const parent = shellRun
         ? findShellRunParent(state, shellRun.ref, event.toolUseId)
         : undefined;
-      if (tool && parent && shellRun) {
+      if (tool && parent && shellRun && !event.isError) {
         applyLiveShellRunResultToParent(state, parent, shellRun);
         if (tool.toolName === 'Read' || tool.toolName === 'StopBackgroundTask') {
           state.entries.splice(state.entries.indexOf(tool), 1);
@@ -462,6 +474,9 @@ export function applyMakaSessionEventToTranscript(
           } else {
             applyOwnShellRunResult(tool, shellRun, event.durationMs);
           }
+          // isError is the call-level authoritative status: a failed call shows
+          // error even when its payload is a well-formed (still running) run.
+          if (event.isError) tool.status = 'error';
         } else {
           tool.status = event.isError ? 'error' : 'done';
           tool.result = event.content;
@@ -559,6 +574,7 @@ export function applyMakaSessionEventToTranscript(
 
     case 'error':
       clearPendingInteractions(state);
+      state.pendingShellRunPolls.clear();
       state.entries.push({
         kind: 'notice',
         level: 'error',
@@ -568,6 +584,7 @@ export function applyMakaSessionEventToTranscript(
 
     case 'abort':
       clearPendingInteractions(state);
+      state.pendingShellRunPolls.clear();
       state.entries.push({
         kind: 'notice',
         level: 'info',
@@ -1206,7 +1223,8 @@ function pushShellRunSettledNotice(state: MakaPiTranscriptState, entry: MakaPiTo
     || result.status === 'timed_out'
     || result.status === 'orphaned';
   const verb = result.status === 'completed' ? 'completed'
-    : result.status === 'cancelled' ? 'stopped' : result.status;
+    : result.status === 'cancelled' ? 'stopped'
+      : result.status === 'timed_out' ? 'timed out' : result.status;
   const parts: string[] = [];
   if (result.exitCode !== undefined) parts.push(`exit ${result.exitCode}`);
   const secs = Math.round((entry.durationMs ?? 0) / 1000);

--- a/packages/cli/src/pi-transcript.ts
+++ b/packages/cli/src/pi-transcript.ts
@@ -57,11 +57,26 @@ export interface MakaPiTranscriptState {
    */
   expandAllTools: boolean;
   expandAllThinking: boolean;
+  /**
+   * Ref polls folded at `tool_start`, childToolUseId → card facts. A Read /
+   * StopBackgroundTask aimed at a ref a visible Bash card owns is internal
+   * polling: it never renders a row, and its result folds straight into the
+   * parent. The facts survive only so an errored poll can surface as a normal
+   * card instead of being swallowed.
+   */
+  pendingShellRunPolls: Map<string, MakaPiPendingShellRunPoll>;
   /** Aggregated token usage for statusline display; reset on session switch. */
   usage: MakaPiUsageSummary;
 }
 
 export type MakaPiPendingInteraction = AnyPermissionRequestEvent | UserQuestionRequestEvent;
+
+/** Facts kept from a folded poll's `tool_start` so an errored result can still materialize a proper card. */
+export interface MakaPiPendingShellRunPoll {
+  toolName: string;
+  title?: string;
+  input: unknown;
+}
 
 /** A single live output chunk from a `tool_output_delta` event. */
 export interface MakaPiToolOutputDelta {
@@ -121,6 +136,7 @@ export function createMakaPiTranscriptState(): MakaPiTranscriptState {
     queuedInteractions: [],
     expandAllTools: false,
     expandAllThinking: false,
+    pendingShellRunPolls: new Map(),
     usage: { costUsd: 0, cacheHitInput: 0, cacheMissInput: 0 },
   };
 }
@@ -162,8 +178,12 @@ export function applyShellRunViewUpdateToTranscript(
   state: MakaPiTranscriptState,
   update: ShellRunUpdate,
 ): boolean {
-  const applied = applyShellRunUpdateToTranscript(state, update.sourceToolCallId, update.result);
   const tool = findToolEntry(state, update.sourceToolCallId);
+  const wasLive = isLiveShellRunCard(tool);
+  const applied = applyShellRunUpdateToTranscript(state, update.sourceToolCallId, update.result);
+  if (tool && wasLive && isSettledShellRunCard(tool)) {
+    pushShellRunSettledNotice(state, tool);
+  }
   if (!tool
     || tool.toolName !== 'Bash'
     || tool.result?.kind !== 'shell_run'
@@ -200,6 +220,7 @@ export function replaceTranscriptWithStoredMessages(
       .map((entry) => entry.messageId),
   );
   clearPendingInteractions(state);
+  state.pendingShellRunPolls.clear();
   state.expandAllTools = false;
   state.expandAllThinking = false;
   state.usage = { costUsd: 0, cacheHitInput: 0, cacheMissInput: 0 };
@@ -355,7 +376,24 @@ export function applyMakaSessionEventToTranscript(
       if (event.text) setThinking(state, event.messageId, event.text);
       break;
 
-    case 'tool_start':
+    case 'tool_start': {
+      // A Read / StopBackgroundTask aimed at a ref a visible Bash card owns is
+      // internal polling of that run: it never gets a row, so an active polling
+      // loop cannot flicker cards in and out of the transcript. The result
+      // folds into the parent at tool_result. A poll is folded only when its
+      // parent card already carries the run's shell_run result — otherwise it
+      // renders normally and the tool_result fold below still applies.
+      if (event.toolName === 'Read' || event.toolName === 'StopBackgroundTask') {
+        const ref = readArgsRef(event.args);
+        if (ref && findShellRunParent(state, ref, event.toolUseId)) {
+          state.pendingShellRunPolls.set(event.toolUseId, {
+            toolName: event.toolName,
+            ...(event.displayName ? { title: event.displayName } : {}),
+            input: projectToolActivityArgs(event.toolName, event.args),
+          });
+          break;
+        }
+      }
       state.entries.push({
         kind: 'tool',
         toolUseId: event.toolUseId,
@@ -368,16 +406,48 @@ export function applyMakaSessionEventToTranscript(
         status: 'running',
       });
       break;
+    }
 
     case 'tool_result': {
       completePendingPermissionsForToolUseId(state, event.toolUseId);
+      const foldedPoll = state.pendingShellRunPolls.get(event.toolUseId);
+      if (foldedPoll) {
+        state.pendingShellRunPolls.delete(event.toolUseId);
+        const shellRun = event.content.kind === 'shell_run' ? event.content : undefined;
+        const parent = shellRun
+          ? findShellRunParent(state, shellRun.ref, event.toolUseId)
+          : undefined;
+        if (parent && shellRun) {
+          applyLiveShellRunResultToParent(state, parent, shellRun);
+          break;
+        }
+        // The poll failed (or lost its parent): surface a normal card so the
+        // failure is never swallowed by the fold.
+        const entry: MakaPiToolEntry = {
+          kind: 'tool',
+          toolUseId: event.toolUseId,
+          toolName: foldedPoll.toolName,
+          ...(foldedPoll.title ? { title: foldedPoll.title } : {}),
+          input: foldedPoll.input,
+          progress: createProgressBuffer(),
+          outputDeltas: createOutputBuffer(),
+          result: event.content,
+          output: formatToolResultContent(event.content),
+          resultVersion: 1,
+          durationMs: event.durationMs,
+          status: event.isError ? 'error' : 'done',
+        };
+        if (shellRun) applyOwnShellRunResult(entry, shellRun, event.durationMs);
+        state.entries.push(entry);
+        break;
+      }
       const tool = findToolEntry(state, event.toolUseId);
       const shellRun = event.content.kind === 'shell_run' ? event.content : undefined;
       const parent = shellRun
         ? findShellRunParent(state, shellRun.ref, event.toolUseId)
         : undefined;
       if (tool && parent && shellRun) {
-        applyShellRunResult(parent, shellRun);
+        applyLiveShellRunResultToParent(state, parent, shellRun);
         if (tool.toolName === 'Read' || tool.toolName === 'StopBackgroundTask') {
           state.entries.splice(state.entries.indexOf(tool), 1);
         } else {
@@ -1085,6 +1155,71 @@ function findShellRunParent(
       && entry.toolUseId !== childToolUseId
       && entry.result?.kind === 'shell_run'
       && entry.result.ref === ref);
+}
+
+/** The runtime-resource ref a tool call is aimed at, when the args carry one. */
+function readArgsRef(args: unknown): string | undefined {
+  const ref = args !== null && typeof args === 'object'
+    ? (args as { ref?: unknown }).ref
+    : undefined;
+  return typeof ref === 'string' && ref.length > 0 ? ref : undefined;
+}
+
+/** A card tracking a live local run: still `running` with a running shell_run result. */
+function isLiveShellRunCard(entry: MakaPiToolEntry | undefined): boolean {
+  return entry?.status === 'running'
+    && entry.result?.kind === 'shell_run'
+    && entry.result.status === 'running';
+}
+
+/**
+ * Apply a live result to a parent Bash card, announcing a running → settled
+ * transition exactly once. Shared by both poll paths (folded at tool_start and
+ * the tool_result fold) so a settle observed through the model's polling
+ * notifies the same way as the event-driven update.
+ */
+function applyLiveShellRunResultToParent(
+  state: MakaPiTranscriptState,
+  parent: MakaPiToolEntry,
+  result: Extract<ToolResultContent, { kind: 'shell_run' }>,
+): void {
+  const wasLive = isLiveShellRunCard(parent);
+  applyShellRunResult(parent, result);
+  if (wasLive && isSettledShellRunCard(parent)) pushShellRunSettledNotice(state, parent);
+}
+
+function isSettledShellRunCard(entry: MakaPiToolEntry): boolean {
+  return entry.result?.kind === 'shell_run' && entry.result.status !== 'running';
+}
+
+/**
+ * Announce a live running → settled transition at the transcript tail: the
+ * card flip itself happens wherever the card sits in the scrollback, which is
+ * usually off-screen by the time a long task ends. Only live transitions fire
+ * — a run first seen settled (own result, stored replay) stays silent, so a
+ * settle reported twice (event + folded poll) notifies exactly once.
+ */
+function pushShellRunSettledNotice(state: MakaPiTranscriptState, entry: MakaPiToolEntry): void {
+  const result = entry.result?.kind === 'shell_run' ? entry.result : undefined;
+  if (!result) return;
+  const failed = result.status === 'failed'
+    || result.status === 'timed_out'
+    || result.status === 'orphaned';
+  const verb = result.status === 'completed' ? 'completed'
+    : result.status === 'cancelled' ? 'stopped' : result.status;
+  const parts: string[] = [];
+  if (result.exitCode !== undefined) parts.push(`exit ${result.exitCode}`);
+  const secs = Math.round((entry.durationMs ?? 0) / 1000);
+  if (secs >= 1) parts.push(`${secs}s`);
+  const suffix = parts.length > 0 ? ` (${parts.join(' · ')})` : '';
+  const failure = failed && result.failureMessage
+    ? ` — ${result.failureMessage.split('\n', 1)[0]}`
+    : '';
+  state.entries.push({
+    kind: 'notice',
+    level: failed ? 'error' : 'info',
+    text: `Background task ${verb}: ${result.cmd.split('\n', 1)[0]}${suffix}${failure}`,
+  });
 }
 
 /** A user turn: a dim `>` quote prefix per line, no speaker label. */

--- a/packages/cli/src/pi-tui-runner.ts
+++ b/packages/cli/src/pi-tui-runner.ts
@@ -205,7 +205,10 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
   let shellRunHydrationEpoch = 0;
   let shellRunHydrationRetryTimer: ReturnType<typeof setTimeout> | undefined;
   const pendingShellRunUpdates = new ShellRunUpdateBuffer('cli.pi-tui-hydration-buffer');
-  const applyShellRunViewUpdate = (candidate: ShellRunUpdate): boolean => {
+  const applyShellRunViewUpdate = (
+    candidate: ShellRunUpdate,
+    options?: { announceSettle?: boolean },
+  ): boolean => {
     const index = shellRunOwnerMappings.findIndex((update) => (
       update.sessionId === candidate.sessionId
       && update.sourceToolCallId === candidate.sourceToolCallId
@@ -220,7 +223,7 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
     if (index >= 0 && retainOwnerMapping) shellRunOwnerMappings[index] = merged.update;
     else if (index >= 0) shellRunOwnerMappings.splice(index, 1);
     else if (retainOwnerMapping) shellRunOwnerMappings.push(merged.update);
-    return applyShellRunViewUpdateToTranscript(state, merged.update);
+    return applyShellRunViewUpdateToTranscript(state, merged.update, options);
   };
   const replayPendingShellRunUpdates = (sessionId: string): boolean => {
     const buffered = pendingShellRunUpdates.drain();
@@ -246,7 +249,10 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
     try {
       const updates = await input.listShellRunUpdates?.(sessionId);
       if (closed || epoch !== shellRunHydrationEpoch || input.driver.getSessionId() !== sessionId) return;
-      for (const update of updates ?? []) applyShellRunViewUpdate(update);
+      // Catch-up replays durable state, not a live event: flip cards silently.
+      // Updates buffered from the live subscription during the await are
+      // genuinely live and stay announceable in the drain below.
+      for (const update of updates ?? []) applyShellRunViewUpdate(update, { announceSettle: false });
       const overflowed = replayPendingShellRunUpdates(sessionId);
       shellRunElapsedTicker.sync();
       requestRender();


### PR DESCRIPTION
## Summary

#1096's remaining gap on main: background-task ref polling only folded into the parent Bash card at `tool_result`, so every poll rendered a transient `● Read maka://… (running)` row that vanished a beat later — an active polling loop flickered rows in and out of the transcript.

- **Fold at `tool_start`**: a Read / StopBackgroundTask whose ref is owned by a visible Bash card never renders a row; the result folds straight into the parent. An errored poll still materializes a normal card (failure is never swallowed) — on stored replay too: a failed poll keeps its error card and never mutates the parent, matching the live path. A poll with no parent renders as before; WriteStdin is never folded.
- **Settle notice**: a live running → settled transition appends one transcript-tail notice — `Note: Background task completed: sleep 15 && echo BG_TASK_DONE (exit 0 · 15s)`, with failed / timed_out / orphaned as red errors and cancelled as a plain note. The transition is keyed on the run's resource status, so an inherited run shown as `detached` announces when its owner settles it. Fires exactly once whether the settle arrives via the event-driven ShellRunUpdate channel or a folded poll, in either order (transition detection dedups); stored replay and hydration catch-up stay silent.

The settle notice is the one addition beyond the issue text, aligned in the issue discussion: the card flip itself happens off-screen in the scrollback, so a settle was previously invisible. Out-of-scope items from the issue (statusline indicator, task focusing, `/background`) remain excluded.

Reviewed pre-merge (Opus + Codex, findings adjudicated): the stored-replay error preservation and the detached settle announcement above landed as review fixes. Known accepted edges, deliberately unchanged: a settle landing inside the hydration `listShellRunUpdates` await is applied silently as catch-up, and a folded poll's `tool_result` arriving after an abort falls back to a raw card.

Closes #1096

## Verification

- `npm test` in `packages/cli`: 435/435 pass (20 new tests pin the tool_start fold, error surfacing live and on stored replay, parent-missing fallback, WriteStdin exclusion, settle notice levels including orphaned, once-only dedup in both arrival orders, detached-settle announcement, and stored-replay/hydration silence).
- Each fix was revert-verified: temporarily undoing it makes its new tests fail.
- `npx biome lint` on changed files: clean. `tsc --noEmit` in `packages/cli`: clean.
- Full-repo suite not run (cli-only surface, no cross-package API changes).
- Live TUI run against a real provider (background `sleep 15 && echo BG_TASK_DONE`, model polling via Read): the card stayed `(running Ns)`, no Read rows ever appeared, and at settle the transcript showed:

```
● Bash  $ sleep 15 && echo BG_TASK_DONE (15s · 1 line)
Note: Background task completed: sleep 15 && echo BG_TASK_DONE (exit 0 · 15s)
```
