### PR TITLE
feat(runtime): add durable expert-team collaboration

### DIFF
--- a/apps/desktop/src/main/__tests__/agent-team-collaboration-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/agent-team-collaboration-contract.test.ts
@@ -1,0 +1,28 @@
+import { strict as assert } from 'node:assert';
+import { readFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import { describe, it } from 'node:test';
+
+describe('desktop agent-team collaboration wiring', () => {
+  it('shares one durable mailbox/task ledger across lead and child tools', async () => {
+    const mainPath = fileURLToPath(new URL('../../../src/main/main.ts', import.meta.url));
+    const main = await readFile(mainPath, 'utf8');
+
+    assert.match(main, /const agentMailboxStore = createAgentMailboxStore\(workspaceRoot\)/);
+    assert.match(
+      main,
+      /buildAgentTeamLeadTools\(\{[\s\S]*?mailbox: agentMailboxStore,[\s\S]*?taskLedger: taskLedgerStore/,
+    );
+    assert.match(
+      main,
+      /buildAgentTeamChildTools\(\{[\s\S]*?mailbox: agentMailboxStore,[\s\S]*?taskLedger: taskLedgerStore/,
+    );
+    assert.match(main, /const childAgentTools = buildChildAgentTools\([\s\S]*?\.\.\.agentTeamChildTools/);
+    assert.match(
+      main,
+      /buildExpertDispatchToolForTeamId\(expertTeamId, \{ taskLedger: taskLedgerStore \}\)/,
+    );
+    assert.match(main, /tools: expertDispatchTool[\s\S]*?\.\.\.agentTeamLeadTools/);
+    assert.match(main, /agentTeam,/);
+  });
+});

--- a/apps/desktop/src/main/__tests__/task-ledger-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/task-ledger-contract.test.ts
@@ -206,6 +206,7 @@ describe('task ledger contract', () => {
         create: async () => ({ created: [], total: 0 }),
         update: async () => ({ updated: {} as Task, total: 0 }),
         claim: async () => ({ updated: {} as Task, total: 0 }),
+        claimAvailable: async () => ({ updated: {} as Task, total: 0 }),
         settleAgentOutcome: async () => ({ updated: {} as Task, total: 0 }),
         subscribe: () => () => {},
       },

--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -51,6 +51,8 @@ import {
   createFilesystemWorkerLaunchSpecProvider,
   FilesystemWorkerClient,
   buildChildAgentTools,
+  buildAgentTeamChildTools,
+  buildAgentTeamLeadTools,
   buildExpertDispatchToolForTeamId,
   buildSubagentProjectionTools,
   buildSubagentSpawnTool,
@@ -77,6 +79,7 @@ import type {
 import type { LlmConnection } from '@maka/core/llm-connections';
 import {
   createAgentRunStore,
+  createAgentMailboxStore,
   createArtifactStore,
   createConnectionStore,
   createPlanReminderStore,
@@ -330,6 +333,7 @@ const antigravitySubscription = new AntigravitySubscriptionService({
 const planReminderStore = createPlanReminderStore(workspaceRoot);
 const taskLedgerWiring = createMainTaskLedgerWiring(workspaceRoot);
 const taskLedgerStore = taskLedgerWiring.store;
+const agentMailboxStore = createAgentMailboxStore(workspaceRoot);
 
 // Unified Automation — single "Automation" tool for heartbeat + cron.
 // Deps are resolved lazily since runtime/store aren't ready at this point.
@@ -630,6 +634,14 @@ const agentTools: MakaTool[] = [
   buildSubagentSpawnTool({ taskLedger: taskLedgerStore }),
   ...buildSubagentProjectionTools(),
 ];
+const agentTeamLeadTools = buildAgentTeamLeadTools({
+  mailbox: agentMailboxStore,
+  taskLedger: taskLedgerStore,
+});
+const agentTeamChildTools = buildAgentTeamChildTools({
+  mailbox: agentMailboxStore,
+  taskLedger: taskLedgerStore,
+});
 const deferredTools: MakaTool[] = [
   ...riveTools,
   ...officeTools,
@@ -711,6 +723,7 @@ const childAgentTools = buildChildAgentTools([
     } : {}),
   }).filter((tool: MakaTool) => tool.name !== 'Edit'),
   webSearchTool,
+  ...agentTeamChildTools,
 ]);
 let lookupPricing = buildPricingLookup();
 // Track the last status fields that affect persisted diagnostics. The reason
@@ -870,7 +883,12 @@ backends.register('ai-sdk', async (ctx) => {
   // Child turns receive scoped `ctx.tools` and inherit the label, but must NOT
   // get expert_dispatch — members cannot spawn nested teams.
   const expertTeamId = ctx.tools ? undefined : expertTeamIdFromLabels(ctx.header.labels);
-  const expertDispatchTool = expertTeamId ? buildExpertDispatchToolForTeamId(expertTeamId) : undefined;
+  const expertDispatchTool = expertTeamId
+    ? buildExpertDispatchToolForTeamId(expertTeamId, { taskLedger: taskLedgerStore })
+    : undefined;
+  const agentTeam = ctx.agentTeam ?? (expertTeamId
+    ? { role: 'lead' as const, teamId: expertTeamId, agentId: 'lead' }
+    : undefined);
   const backendTools = computerUseToolsForModel(
     candidateTools,
     computerUseTools,
@@ -890,7 +908,10 @@ backends.register('ai-sdk', async (ctx) => {
     modelId: model,
     permissionEngine,
     modelFactory: (input) => getAIModel({ ...input, fetch: modelFetch }),
-    tools: expertDispatchTool ? [...backendTools, expertDispatchTool] : backendTools,
+    tools: expertDispatchTool
+      ? [...backendTools, expertDispatchTool, ...agentTeamLeadTools]
+      : backendTools,
+    agentTeam,
     toolAvailability: backendToolAvailability,
     spawnChildAgent: (input) => runtime.spawnChildAgent(ctx.sessionId, input),
     listChildAgents: () => runtime.listChildAgents(ctx.sessionId),

--- a/docs/expert-team-runtime.md
+++ b/docs/expert-team-runtime.md
@@ -44,8 +44,9 @@ statelessly from the id alone.
    scoped capability tools plus `team_message`, `team_inbox`, `team_task_list`, and
    `team_task_claim`; a read-only archetype still cannot write files or use the network.
 4. Messages are appended to `sessions/<sessionId>/agent-mailbox.jsonl`, scoped by team
-   and parent lead `AgentRun`. Sender/recipient identities come from trusted runtime
-   context, not model arguments. Cursor reads make polling bounded and deterministic.
+   and parent lead `AgentRun`. Sender `AgentRun`/turn attribution comes from trusted
+   runtime context; named recipients resolve through the trusted team roster to stable
+   role addresses. Cursor reads make polling bounded and deterministic.
 5. A member may use `team_task_claim` to atomically claim one pending/blocked task
    owned by the current parent lead `AgentRun`. Tasks from ordinary or older lead runs
    are not discoverable or claimable. Conflicting claims fail closed; members receive
@@ -58,6 +59,21 @@ statelessly from the id alone.
 
 Members never receive `expert_dispatch` (child turns are gated in the backend factory),
 so there are no nested teams.
+
+### Role mailbox and cursor semantics
+
+Direct-message recipients are role addresses within one parent lead `AgentRun`, not
+individual child invocations. The lead uses the stable `lead` address; each member uses
+its deterministic `expert:<teamId>:<memberId>` agent id. Repeated or concurrent
+dispatches of the same member therefore share one role mailbox. This supports durable
+handoff between invocations, but it is not an invocation-private channel.
+
+`team_inbox` cursors are caller-owned. The store does not persist a read cursor for a
+role or child invocation: callers pass the last observed `nextSeq` back as `after_seq`.
+A fresh invocation that omits `after_seq` reads the role's available history from the
+start of the current lead run, including direct messages observed by an earlier
+invocation of that member. A new parent lead `AgentRun` starts a separate mailbox scope.
+Use distinct expert member roles when work requires separate direct-message inboxes.
 
 ## Definition resolution
 
@@ -101,7 +117,8 @@ prompt + tool wiring, the start/list IPC + preload + typings, and unit tests acr
 core / runtime / desktop-main.
 
 Shipped in the collaboration slice: a durable per-session/team-run mailbox, bounded
-direct messages and broadcasts, trusted AgentRun/Turn attribution, and atomic
+role-addressed direct messages and broadcasts, trusted sender AgentRun/Turn
+attribution, caller-owned inbox cursors, and atomic
 self-claim of one eligible shared Task Ledger item per child turn. Mailbox history is
 reloaded from its append-only log after process restart; corruption fails closed, and
 new lead runs do not silently inherit messages from an older run.

--- a/docs/expert-team-runtime.md
+++ b/docs/expert-team-runtime.md
@@ -1,11 +1,11 @@
-# Expert Teams (star orchestrator→worker)
+# Expert Teams (lead/member collaboration)
 
 Expert teams let a **lead** persona fan a task out to specialist **member** experts,
-each running as a tool-scoped child agent, then synthesize their results. It is the
-star topology reverse-engineered from WorkBuddy's `team` experts and QoderWork's
-sub-agent pipelines (see [expert-team-implementation.md](archive/expert-team-implementation.md)),
-rebuilt entirely on Maka's existing child-agent machinery — no new orchestration
-engine, no mesh mailbox, no shared task board.
+each running as a tool-scoped child agent, then synthesize their results. The runtime
+keeps the lead as the final adjudicator while adding a bounded, durable mailbox and
+atomic self-claim over Maka's existing Task Ledger. It is rebuilt on Maka's existing
+child-agent machinery rather than introducing a second orchestration engine (see
+[expert-team-implementation.md](archive/expert-team-implementation.md)).
 
 ## Model
 
@@ -17,8 +17,9 @@ engine, no mesh mailbox, no shared task board.
   exceed the policy of the archetype it runs under — this is stricter than either
   competitor and keeps Maka's permission-safety invariant.
 - **Expert team** (`ExpertTeamDefinition`) — a lead persona (runs as the main session)
-  plus N dispatchable members. Members never talk to each other; all coordination goes
-  through the lead.
+  plus N dispatchable members. Members can exchange bounded direct messages and
+  broadcasts within one team run. They may claim one eligible shared Task Ledger item
+  atomically, but the lead retains completion and result-adjudication authority.
 
 Definitions live in [`expert-catalog.ts`](../packages/runtime/src/expert-catalog.ts).
 Each member materializes into an ordinary `AgentDefinition` with a deterministic id
@@ -40,10 +41,20 @@ statelessly from the id alone.
    (distinct child turns, no shared mutex; bounded by `MAX_ACTIVE_SUBAGENT_TOOLS_PER_TURN`).
 3. Each dispatch resolves the member's materialized `AgentDefinition` and spawns it via
    the same `spawnChildAgent` capability `agent_spawn` uses. The child gets the member's
-   scoped tools + composed system prompt; a read-only archetype means the member
-   physically cannot write.
-4. **Fan-in** is the child result's bounded `summary` plus `artifactIds` pointers —
+   scoped capability tools plus `team_message`, `team_inbox`, `team_task_list`, and
+   `team_task_claim`; a read-only archetype still cannot write files or use the network.
+4. Messages are appended to `sessions/<sessionId>/agent-mailbox.jsonl`, scoped by team
+   and parent lead `AgentRun`. Sender/recipient identities come from trusted runtime
+   context, not model arguments. Cursor reads make polling bounded and deterministic.
+5. A member may use `team_task_claim` to atomically claim one pending/blocked task
+   owned by the current parent lead `AgentRun`. Tasks from ordinary or older lead runs
+   are not discoverable or claimable. Conflicting claims fail closed; members receive
+   no general task mutation or completion tool.
+6. **Fan-in** is the child result's bounded `summary` plus `artifactIds` pointers —
    members return digests, not raw payloads. The lead synthesizes one ranked result.
+   A completed child outcome leaves its claimed task `in_progress` as evidence for lead
+   review; failed, cancelled, and permission-waiting outcomes settle through the existing
+   Task Ledger outcome contract.
 
 Members never receive `expert_dispatch` (child turns are gated in the backend factory),
 so there are no nested teams.
@@ -89,7 +100,13 @@ Shipped: the runtime engine (catalog, resolver, dispatch tool, lead fragment), d
 prompt + tool wiring, the start/list IPC + preload + typings, and unit tests across
 core / runtime / desktop-main.
 
-Deliberately deferred (documented, not built): a renderer team-picker panel; mesh
-"Agent Teams" (member↔member `SendMessage`, shared self-claiming task board);
-worktree-isolated writing members (fail-closed today); a remote expert marketplace;
+Shipped in the collaboration slice: a durable per-session/team-run mailbox, bounded
+direct messages and broadcasts, trusted AgentRun/Turn attribution, and atomic
+self-claim of one eligible shared Task Ledger item per child turn. Mailbox history is
+reloaded from its append-only log after process restart; corruption fails closed, and
+new lead runs do not silently inherit messages from an older run.
+
+Deliberately deferred (documented, not built): automatic message wake/injection (members
+poll `team_inbox`); detached or cross-machine member lifecycles; a renderer team-picker
+panel; worktree-isolated writing members (fail-closed today); a remote expert marketplace;
 and the digital-colleague / IM / cloud layer.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -34,6 +34,7 @@
     "./bot-events": "./dist/bot-events.js",
     "./bot-platform-hints": "./dist/bot-platform-hints.js",
     "./plan-reminders": "./dist/plan-reminders.js",
+    "./agent-mailbox": "./dist/agent-mailbox.js",
     "./task-ledger": "./dist/task-ledger.js",
     "./memory": "./dist/memory.js",
     "./voice": "./dist/voice.js",

--- a/packages/core/src/__tests__/agent-mailbox.test.ts
+++ b/packages/core/src/__tests__/agent-mailbox.test.ts
@@ -47,5 +47,10 @@ describe('agent mailbox contract', () => {
     assert.equal(isAgentMailboxMessage({ ...base, kind: 'broadcast', to: { role: 'lead', agentId: 'lead' } }), false);
     assert.equal(isAgentMailboxMessage({ ...base, kind: 'message', to: { role: 'member', agentId: base.from.agentId } }), false);
     assert.equal(isAgentMailboxMessage({ ...base, kind: 'message', to: { role: 'member', agentId: 'lead' } }), false);
+    assert.equal(isAgentMailboxMessage({
+      ...base,
+      kind: 'broadcast',
+      from: { role: 'lead', agentId: 'lead', runId: 'another-parent-run', turnId: 'lead-turn' },
+    }), false);
   });
 });

--- a/packages/core/src/__tests__/agent-mailbox.test.ts
+++ b/packages/core/src/__tests__/agent-mailbox.test.ts
@@ -1,0 +1,51 @@
+import { strict as assert } from 'node:assert';
+import { describe, test } from 'node:test';
+import {
+  AGENT_MAILBOX_CONTENT_MAX_CHARS,
+  isAgentMailboxMessage,
+  isSafeAgentMailboxToken,
+  normalizeAgentMailboxContent,
+} from '../agent-mailbox.js';
+
+describe('agent mailbox contract', () => {
+  test('normalizes bounded content and redacts secrets before persistence', () => {
+    assert.deepEqual(normalizeAgentMailboxContent('  first\r\nsecond  '), {
+      ok: true,
+      value: 'first\nsecond',
+    });
+    const redacted = normalizeAgentMailboxContent('token ghp_abcdefghijklmnopqrstuvwxyz1234567890');
+    assert.equal(redacted.ok, true);
+    assert.match(redacted.ok ? redacted.value : '', /\[redacted\]/);
+  });
+
+  test('rejects empty and overlong mailbox content', () => {
+    assert.equal(normalizeAgentMailboxContent('  ').ok, false);
+    assert.equal(normalizeAgentMailboxContent('x'.repeat(AGENT_MAILBOX_CONTENT_MAX_CHARS + 1)).ok, false);
+  });
+
+  test('uses redaction-stable bounded tokens for durable identities', () => {
+    assert.equal(isSafeAgentMailboxToken('expert:code-review:correctness-reviewer'), true);
+    assert.equal(isSafeAgentMailboxToken('bad id'), false);
+    assert.equal(isSafeAgentMailboxToken('ghp_abcdefghijklmnopqrstuvwxyz1234567890'), false);
+  });
+
+  test('validates direct and broadcast persisted messages', () => {
+    const base = {
+      schemaVersion: 1,
+      id: 'message-1',
+      sessionId: 'session-1',
+      teamId: 'code-review',
+      parentRunId: 'parent-run',
+      seq: 1,
+      from: { role: 'member', agentId: 'expert:code-review:correctness-reviewer', runId: 'run-1', turnId: 'turn-1' },
+      content: 'Found an invariant violation.',
+      createdAt: 123,
+    } as const;
+    assert.equal(isAgentMailboxMessage({ ...base, kind: 'message', to: { role: 'lead', agentId: 'lead' } }), true);
+    assert.equal(isAgentMailboxMessage({ ...base, kind: 'broadcast' }), true);
+    assert.equal(isAgentMailboxMessage({ ...base, kind: 'message' }), false);
+    assert.equal(isAgentMailboxMessage({ ...base, kind: 'broadcast', to: { role: 'lead', agentId: 'lead' } }), false);
+    assert.equal(isAgentMailboxMessage({ ...base, kind: 'message', to: { role: 'member', agentId: base.from.agentId } }), false);
+    assert.equal(isAgentMailboxMessage({ ...base, kind: 'message', to: { role: 'member', agentId: 'lead' } }), false);
+  });
+});

--- a/packages/core/src/agent-mailbox.ts
+++ b/packages/core/src/agent-mailbox.ts
@@ -1,0 +1,128 @@
+import { redactSecrets } from './redaction.js';
+
+export const AGENT_MAILBOX_SCHEMA_VERSION = 1 as const;
+export const AGENT_MAILBOX_CONTENT_MAX_CHARS = 2_000;
+export const AGENT_MAILBOX_MAX_MESSAGES_PER_TEAM_RUN = 500;
+export const AGENT_MAILBOX_LIST_MAX = 50;
+
+export type AgentMailboxRole = 'lead' | 'member';
+export type AgentMailboxMessageKind = 'message' | 'broadcast';
+
+export interface AgentMailboxParticipantRef {
+  role: AgentMailboxRole;
+  agentId: string;
+  runId: string;
+  turnId: string;
+}
+
+export interface AgentMailboxMessage {
+  schemaVersion: typeof AGENT_MAILBOX_SCHEMA_VERSION;
+  id: string;
+  sessionId: string;
+  teamId: string;
+  parentRunId: string;
+  seq: number;
+  kind: AgentMailboxMessageKind;
+  from: AgentMailboxParticipantRef;
+  to?: { role: AgentMailboxRole; agentId: string };
+  content: string;
+  createdAt: number;
+}
+
+export interface AgentMailboxSendInput {
+  teamId: string;
+  parentRunId: string;
+  kind: AgentMailboxMessageKind;
+  from: AgentMailboxParticipantRef;
+  to?: { role: AgentMailboxRole; agentId: string };
+  content: unknown;
+}
+
+export interface AgentMailboxListOptions {
+  teamId: string;
+  parentRunId: string;
+  recipientAgentId: string;
+  afterSeq?: number;
+  limit?: number;
+}
+
+export interface AgentMailboxStore {
+  send(
+    sessionId: string,
+    input: AgentMailboxSendInput,
+  ): Promise<{ message: AgentMailboxMessage; total: number }>;
+  list(
+    sessionId: string,
+    options: AgentMailboxListOptions,
+  ): Promise<{ messages: AgentMailboxMessage[]; nextSeq: number; total: number }>;
+}
+
+export type AgentMailboxNormalizeResult<T> =
+  | { ok: true; value: T }
+  | { ok: false; message: string };
+
+export function isSafeAgentMailboxToken(value: unknown): value is string {
+  return typeof value === 'string'
+    && /^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/.test(value)
+    && redactSecrets(value) === value;
+}
+
+export function isAgentTeamId(value: unknown): value is string {
+  return typeof value === 'string'
+    && value.length <= 64
+    && /^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(value);
+}
+
+export function normalizeAgentMailboxContent(input: unknown): AgentMailboxNormalizeResult<string> {
+  if (typeof input !== 'string') return { ok: false, message: 'Agent mailbox content must be a string' };
+  const value = redactSecrets(input.normalize('NFC').replace(/\r\n?/g, '\n')).trim();
+  if (value.length === 0) return { ok: false, message: 'Agent mailbox content cannot be empty' };
+  if (Array.from(value).length > AGENT_MAILBOX_CONTENT_MAX_CHARS) {
+    return {
+      ok: false,
+      message: `Agent mailbox content must be ${AGENT_MAILBOX_CONTENT_MAX_CHARS} characters or fewer`,
+    };
+  }
+  return { ok: true, value };
+}
+
+export function isAgentMailboxParticipantRef(value: unknown): value is AgentMailboxParticipantRef {
+  if (!isRecord(value)) return false;
+  return (value.role === 'lead' || value.role === 'member')
+    && isAgentMailboxAddress(value)
+    && isSafeAgentMailboxToken(value.runId)
+    && isSafeAgentMailboxToken(value.turnId);
+}
+
+export function isAgentMailboxMessage(value: unknown): value is AgentMailboxMessage {
+  if (!isRecord(value)) return false;
+  if (
+    value.schemaVersion !== AGENT_MAILBOX_SCHEMA_VERSION
+    || !isSafeAgentMailboxToken(value.id)
+    || !isSafeAgentMailboxToken(value.sessionId)
+    || !isAgentTeamId(value.teamId)
+    || !isSafeAgentMailboxToken(value.parentRunId)
+    || !Number.isSafeInteger(value.seq)
+    || (value.seq as number) < 1
+    || (value.kind !== 'message' && value.kind !== 'broadcast')
+    || !isAgentMailboxParticipantRef(value.from)
+    || typeof value.createdAt !== 'number'
+    || !Number.isFinite(value.createdAt)
+  ) return false;
+  const content = normalizeAgentMailboxContent(value.content);
+  if (!content.ok || content.value !== value.content) return false;
+  if (value.kind === 'broadcast') return value.to === undefined;
+  return isRecord(value.to)
+    && isAgentMailboxAddress(value.to)
+    && value.to.agentId !== value.from.agentId;
+}
+
+function isAgentMailboxAddress(value: Record<string, unknown>): boolean {
+  return (value.role === 'lead' || value.role === 'member')
+    && isSafeAgentMailboxToken(value.agentId)
+    && (value.role === 'lead' ? value.agentId === 'lead' : value.agentId !== 'lead');
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}

--- a/packages/core/src/agent-mailbox.ts
+++ b/packages/core/src/agent-mailbox.ts
@@ -24,6 +24,7 @@ export interface AgentMailboxMessage {
   seq: number;
   kind: AgentMailboxMessageKind;
   from: AgentMailboxParticipantRef;
+  /** Stable role address within one parent lead run; it does not identify a child invocation. */
   to?: { role: AgentMailboxRole; agentId: string };
   content: string;
   createdAt: number;
@@ -34,6 +35,7 @@ export interface AgentMailboxSendInput {
   parentRunId: string;
   kind: AgentMailboxMessageKind;
   from: AgentMailboxParticipantRef;
+  /** Stable role address within one parent lead run; it does not identify a child invocation. */
   to?: { role: AgentMailboxRole; agentId: string };
   content: unknown;
 }
@@ -41,7 +43,9 @@ export interface AgentMailboxSendInput {
 export interface AgentMailboxListOptions {
   teamId: string;
   parentRunId: string;
+  /** Stable role address shared by repeated or concurrent invocations of that member. */
   recipientAgentId: string;
+  /** Caller-owned role-mailbox cursor; the store does not persist a cursor per invocation. */
   afterSeq?: number;
   limit?: number;
 }
@@ -109,6 +113,7 @@ export function isAgentMailboxMessage(value: unknown): value is AgentMailboxMess
     || typeof value.createdAt !== 'number'
     || !Number.isFinite(value.createdAt)
   ) return false;
+  if (value.from.role === 'lead' && value.from.runId !== value.parentRunId) return false;
   const content = normalizeAgentMailboxContent(value.content);
   if (!content.ok || content.value !== value.content) return false;
   if (value.kind === 'broadcast') return value.to === undefined;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -701,12 +701,35 @@ export {
   normalizePlanReminderTitle,
   normalizeUpdatePlanReminderInput,
 } from './plan-reminders.js';
+// agent-mailbox.ts (durable expert-team communication)
+export type {
+  AgentMailboxListOptions,
+  AgentMailboxMessage,
+  AgentMailboxMessageKind,
+  AgentMailboxNormalizeResult,
+  AgentMailboxParticipantRef,
+  AgentMailboxRole,
+  AgentMailboxSendInput,
+  AgentMailboxStore,
+} from './agent-mailbox.js';
+export {
+  AGENT_MAILBOX_CONTENT_MAX_CHARS,
+  AGENT_MAILBOX_LIST_MAX,
+  AGENT_MAILBOX_MAX_MESSAGES_PER_TEAM_RUN,
+  AGENT_MAILBOX_SCHEMA_VERSION,
+  isAgentMailboxMessage,
+  isAgentMailboxParticipantRef,
+  isAgentTeamId,
+  isSafeAgentMailboxToken,
+  normalizeAgentMailboxContent,
+} from './agent-mailbox.js';
 // task-ledger.ts (main agent session task tracking)
 export type {
   CreateTaskInput,
   ResumeTrust,
   Task,
   TaskAgentOutcome,
+  TaskAvailableClaimScope,
   TaskLedgerChangedEvent,
   TaskLedgerEvent,
   TaskLedgerEventTaskSnapshot,

--- a/packages/core/src/task-ledger.ts
+++ b/packages/core/src/task-ledger.ts
@@ -84,6 +84,11 @@ export interface TaskAgentOutcome {
   reason?: string;
 }
 
+export interface TaskAvailableClaimScope {
+  /** Main AgentRun that made this task available to its child team. */
+  parentRunId: string;
+}
+
 /**
  * Store contract shared by the storage implementation and the runtime tools.
  * Mutations return the changed task(s) and the new total, computed inside the
@@ -97,6 +102,7 @@ export interface TaskLedgerStore {
   create(sessionId: string, drafts: unknown, context?: TaskLedgerMutationContext): Promise<{ created: Task[]; total: number }>;
   update(sessionId: string, id: string, patch: unknown, context?: TaskLedgerMutationContext): Promise<{ updated: Task; total: number }>;
   claim(sessionId: string, id: string, owner: TaskOwner, context?: TaskLedgerMutationContext): Promise<{ updated: Task; total: number }>;
+  claimAvailable(sessionId: string, id: string, owner: TaskOwner, scope: TaskAvailableClaimScope, context?: TaskLedgerMutationContext): Promise<{ updated: Task; total: number }>;
   settleAgentOutcome(sessionId: string, id: string, outcome: TaskAgentOutcome, context?: TaskLedgerMutationContext): Promise<{ updated: Task; total: number }>;
   subscribe(listener: (event: TaskLedgerChangedEvent) => void): () => void;
 }

--- a/packages/runtime/src/__tests__/agent-team-tools.test.ts
+++ b/packages/runtime/src/__tests__/agent-team-tools.test.ts
@@ -174,6 +174,35 @@ describe('agent team collaboration tools', () => {
     });
   });
 
+  test('uses one role mailbox with caller-owned cursors across repeated member invocations', async () => {
+    const mailbox = new MemoryMailbox();
+    const tools = buildAgentTeamChildTools({ mailbox, taskLedger: new MemoryTaskLedger() });
+    const inbox = findTool(tools, TEAM_INBOX_TOOL_NAME);
+
+    await inbox.impl({ after_seq: 7 }, memberContext({
+      runId: 'child-run-a',
+      turnId: 'child-turn-a',
+    }));
+    await inbox.impl({}, memberContext({
+      runId: 'child-run-b',
+      turnId: 'child-turn-b',
+    }));
+
+    assert.deepEqual(mailbox.lists.map(({ options }) => options), [
+      {
+        teamId: 'code-review',
+        parentRunId: 'lead-run',
+        recipientAgentId: 'expert:code-review:correctness-reviewer',
+        afterSeq: 7,
+      },
+      {
+        teamId: 'code-review',
+        parentRunId: 'lead-run',
+        recipientAgentId: 'expert:code-review:correctness-reviewer',
+      },
+    ]);
+  });
+
   test('lists only available shared tasks and claims with durable child refs', async () => {
     const taskLedger = new MemoryTaskLedger();
     taskLedger.tasks = [

--- a/packages/runtime/src/__tests__/agent-team-tools.test.ts
+++ b/packages/runtime/src/__tests__/agent-team-tools.test.ts
@@ -1,0 +1,224 @@
+import { strict as assert } from 'node:assert';
+import { describe, test } from 'node:test';
+import type {
+  AgentMailboxListOptions,
+  AgentMailboxMessage,
+  AgentMailboxSendInput,
+  AgentMailboxStore,
+  Task,
+  TaskAgentOutcome,
+  TaskLedgerListOptions,
+  TaskLedgerMutationContext,
+  TaskLedgerStore,
+  TaskOwner,
+} from '@maka/core';
+import {
+  buildAgentTeamChildTools,
+  buildAgentTeamLeadTools,
+} from '../agent-team-tools.js';
+import {
+  TEAM_INBOX_TOOL_NAME,
+  TEAM_MESSAGE_TOOL_NAME,
+  TEAM_TASK_CLAIM_TOOL_NAME,
+  TEAM_TASK_LIST_TOOL_NAME,
+} from '../agent-team-tool-names.js';
+import type { MakaTool, MakaToolContext } from '../tool-runtime.js';
+
+class MemoryMailbox implements AgentMailboxStore {
+  sends: Array<{ sessionId: string; input: AgentMailboxSendInput }> = [];
+  lists: Array<{ sessionId: string; options: AgentMailboxListOptions }> = [];
+
+  async send(sessionId: string, input: AgentMailboxSendInput) {
+    this.sends.push({ sessionId, input });
+    const message = {
+      schemaVersion: 1,
+      id: 'message-1',
+      sessionId,
+      seq: 1,
+      createdAt: 1,
+      ...input,
+      content: String(input.content),
+    } as AgentMailboxMessage;
+    return { message, total: this.sends.length };
+  }
+
+  async list(sessionId: string, options: AgentMailboxListOptions) {
+    this.lists.push({ sessionId, options });
+    return { messages: [], nextSeq: options.afterSeq ?? 0, total: 0 };
+  }
+}
+
+class MemoryTaskLedger implements TaskLedgerStore {
+  tasks: Task[] = [];
+  claims: Array<{
+    sessionId: string;
+    id: string;
+    owner: TaskOwner;
+    scope: { parentRunId: string };
+    context?: TaskLedgerMutationContext;
+  }> = [];
+
+  async list(_sessionId: string, options?: TaskLedgerListOptions): Promise<Task[]> {
+    return this.tasks.filter((task) => options?.includeTerminal !== false || !['completed', 'failed', 'cancelled'].includes(task.status));
+  }
+  async get(_sessionId: string, id: string): Promise<Task | undefined> {
+    return this.tasks.find((task) => task.id === id || task.key === id);
+  }
+  async create(): Promise<{ created: Task[]; total: number }> { return { created: [], total: this.tasks.length }; }
+  async update(): Promise<{ updated: Task; total: number }> { throw new Error('not used'); }
+  async claim(): Promise<{ updated: Task; total: number }> { throw new Error('not used'); }
+  async claimAvailable(
+    sessionId: string,
+    id: string,
+    owner: TaskOwner,
+    scope: { parentRunId: string },
+    context?: TaskLedgerMutationContext,
+  ) {
+    const task = await this.get(sessionId, id);
+    if (!task) throw new Error(`No such task: ${id}`);
+    this.claims.push({ sessionId, id, owner, scope, context });
+    task.status = 'in_progress';
+    task.owner = owner;
+    return { updated: task, total: this.tasks.length };
+  }
+  async settleAgentOutcome(_sessionId: string, _id: string, _outcome: TaskAgentOutcome): Promise<{ updated: Task; total: number }> {
+    throw new Error('not used');
+  }
+  subscribe(): () => void { return () => {}; }
+}
+
+function task(id: string, key: string, status: Task['status'], owner?: TaskOwner): Task {
+  return { id, key, subject: `subject ${key}`, status, owner, createdAt: 1, updatedAt: 1 };
+}
+
+function memberContext(overrides: Partial<MakaToolContext> = {}): MakaToolContext {
+  return {
+    sessionId: 'session-1',
+    runId: 'child-run',
+    turnId: 'child-turn',
+    cwd: '/tmp',
+    toolCallId: 'tool-call',
+    abortSignal: new AbortController().signal,
+    emitOutput: () => {},
+    agentTeam: {
+      role: 'member',
+      teamId: 'code-review',
+      agentId: 'expert:code-review:correctness-reviewer',
+      parentRunId: 'lead-run',
+    },
+    ...overrides,
+  };
+}
+
+function leadContext(): MakaToolContext {
+  return {
+    ...memberContext(),
+    runId: 'lead-run',
+    turnId: 'lead-turn',
+    agentTeam: { role: 'lead', teamId: 'code-review', agentId: 'lead' },
+  };
+}
+
+function findTool(tools: MakaTool[], name: string): MakaTool {
+  const found = tools.find((tool) => tool.name === name);
+  assert.ok(found, `expected ${name}`);
+  return found;
+}
+
+describe('agent team collaboration tools', () => {
+  test('exposes the narrow lead and child surfaces', () => {
+    const deps = { mailbox: new MemoryMailbox(), taskLedger: new MemoryTaskLedger() };
+    assert.deepEqual(buildAgentTeamLeadTools(deps).map((tool) => tool.name), [TEAM_MESSAGE_TOOL_NAME, TEAM_INBOX_TOOL_NAME]);
+    assert.deepEqual(buildAgentTeamChildTools(deps).map((tool) => tool.name), [
+      TEAM_MESSAGE_TOOL_NAME,
+      TEAM_INBOX_TOOL_NAME,
+      TEAM_TASK_LIST_TOOL_NAME,
+      TEAM_TASK_CLAIM_TOOL_NAME,
+    ]);
+  });
+
+  test('derives sender and recipient identities from trusted team context', async () => {
+    const mailbox = new MemoryMailbox();
+    const tools = buildAgentTeamChildTools({ mailbox, taskLedger: new MemoryTaskLedger() });
+    await findTool(tools, TEAM_MESSAGE_TOOL_NAME).impl({
+      type: 'message', recipient: 'test-coverage-reviewer', content: 'Please cover the ownership race.',
+    }, memberContext());
+    assert.deepEqual(mailbox.sends[0], {
+      sessionId: 'session-1',
+      input: {
+        teamId: 'code-review',
+        parentRunId: 'lead-run',
+        kind: 'message',
+        from: {
+          role: 'member',
+          agentId: 'expert:code-review:correctness-reviewer',
+          runId: 'child-run',
+          turnId: 'child-turn',
+        },
+        to: { role: 'member', agentId: 'expert:code-review:test-coverage-reviewer' },
+        content: 'Please cover the ownership race.',
+      },
+    });
+  });
+
+  test('scopes inbox reads to the owning lead run and current agent identity', async () => {
+    const mailbox = new MemoryMailbox();
+    const tools = buildAgentTeamChildTools({ mailbox, taskLedger: new MemoryTaskLedger() });
+    await findTool(tools, TEAM_INBOX_TOOL_NAME).impl({ after_seq: 4, limit: 3 }, memberContext());
+    assert.deepEqual(mailbox.lists[0]?.options, {
+      teamId: 'code-review',
+      parentRunId: 'lead-run',
+      recipientAgentId: 'expert:code-review:correctness-reviewer',
+      afterSeq: 4,
+      limit: 3,
+    });
+  });
+
+  test('lists only available shared tasks and claims with durable child refs', async () => {
+    const taskLedger = new MemoryTaskLedger();
+    taskLedger.tasks = [
+      task('task-1', 'T1', 'pending', { actor: 'main_agent', runId: 'lead-run' }),
+      task('task-2', 'T2', 'blocked', { actor: 'main_agent', runId: 'lead-run' }),
+      task('task-3', 'T3', 'in_progress', { actor: 'main_agent', runId: 'lead-run' }),
+      task('task-4', 'T4', 'blocked', { actor: 'child_agent', agentId: 'other', turnId: 'other-turn' }),
+      task('task-5', 'T5', 'completed'),
+      task('task-6', 'T6', 'pending', { actor: 'main_agent', runId: 'older-lead-run' }),
+    ];
+    const tools = buildAgentTeamChildTools({ mailbox: new MemoryMailbox(), taskLedger });
+    const listed = await findTool(tools, TEAM_TASK_LIST_TOOL_NAME).impl({}, memberContext()) as { tasks: Task[] };
+    assert.deepEqual(listed.tasks.map((candidate) => candidate.key), ['T1', 'T2']);
+
+    await findTool(tools, TEAM_TASK_CLAIM_TOOL_NAME).impl({ task_id: 'T1' }, memberContext());
+    assert.deepEqual(taskLedger.claims[0], {
+      sessionId: 'session-1',
+      id: 'T1',
+      owner: {
+        actor: 'child_agent',
+        agentId: 'expert:code-review:correctness-reviewer',
+        runId: 'child-run',
+        turnId: 'child-turn',
+      },
+      scope: { parentRunId: 'lead-run' },
+      context: {
+        runId: 'child-run',
+        turnId: 'child-turn',
+        toolCallId: 'tool-call',
+        source: 'tool',
+        actor: 'child_agent',
+        reason: 'self-claimed by expert team member expert:code-review:correctness-reviewer',
+      },
+    });
+  });
+
+  test('fails closed without trusted team/run identity and denies lead self-claim', async () => {
+    const tools = buildAgentTeamChildTools({ mailbox: new MemoryMailbox(), taskLedger: new MemoryTaskLedger() });
+    await assert.rejects(
+      async () => await findTool(tools, TEAM_MESSAGE_TOOL_NAME).impl({ type: 'broadcast', content: 'x' }, memberContext({ agentTeam: undefined })),
+      /unavailable outside an expert-team run/,
+    );
+    await assert.rejects(
+      async () => await findTool(tools, TEAM_TASK_CLAIM_TOOL_NAME).impl({ task_id: 'T1' }, leadContext()),
+      /only to expert-team members/,
+    );
+  });
+});

--- a/packages/runtime/src/__tests__/expert-catalog.test.ts
+++ b/packages/runtime/src/__tests__/expert-catalog.test.ts
@@ -15,6 +15,7 @@ import {
   resolveAgentDefinition,
   type ExpertTeamDefinition,
 } from '../expert-catalog.js';
+import { AGENT_TEAM_CHILD_TOOL_NAMES } from '../agent-team-tool-names.js';
 
 const CODE_REVIEW = getExpertTeam('code-review');
 
@@ -63,7 +64,7 @@ describe('materialization inherits + narrows the archetype', () => {
     const archetype = getBuiltinAgentDefinition('local-read')!;
     const member = CODE_REVIEW!.members[0]!;
     const def = materializeExpertAgentDefinition(CODE_REVIEW!, member);
-    assert.deepEqual(def.tools, [...archetype.tools]);
+    assert.deepEqual(def.tools, [...archetype.tools, ...AGENT_TEAM_CHILD_TOOL_NAMES]);
     assert.equal(def.permissionMode, archetype.permissionMode);
     assert.deepEqual(def.categoryPolicy, archetype.categoryPolicy);
     assert.equal(def.profile, archetype.profile);
@@ -75,7 +76,8 @@ describe('materialization inherits + narrows the archetype', () => {
     const def = materializeExpertAgentDefinition(CODE_REVIEW!, member);
     assert.ok(def.systemPrompt.startsWith(archetype.systemPrompt));
     assert.match(def.systemPrompt, /member of the "Code Review Team"/);
-    assert.match(def.systemPrompt, /star topology/);
+    assert.match(def.systemPrompt, /team_task_list/);
+    assert.match(def.systemPrompt, /team_message/);
   });
 
   test('allows narrowing tools to a subset of the archetype', () => {
@@ -96,7 +98,7 @@ describe('materialization inherits + narrows the archetype', () => {
       ],
     };
     const def = materializeExpertAgentDefinition(team, team.members[0]!);
-    assert.deepEqual(def.tools, ['Read']);
+    assert.deepEqual(def.tools, ['Read', ...AGENT_TEAM_CHILD_TOOL_NAMES]);
   });
 
   test('rejects widening tools beyond the archetype', () => {

--- a/packages/runtime/src/__tests__/expert-tools.test.ts
+++ b/packages/runtime/src/__tests__/expert-tools.test.ts
@@ -8,6 +8,7 @@ import {
   buildExpertDispatchToolForTeamId,
 } from '../expert-tools.js';
 import { expect } from '../test-helpers.js';
+import type { Task, TaskAgentOutcome, TaskLedgerStore, TaskOwner } from '@maka/core';
 
 const CODE_REVIEW = getExpertTeam('code-review')!;
 
@@ -35,6 +36,25 @@ function fakeCtx(calls: unknown[], result?: Record<string, unknown>) {
       };
     },
   };
+}
+
+function recordingTaskLedger(task: Task): { taskLedger: TaskLedgerStore; outcomes: TaskAgentOutcome[] } {
+  const outcomes: TaskAgentOutcome[] = [];
+  const taskLedger = {
+    list: async () => [task],
+    get: async () => task,
+    create: async () => ({ created: [], total: 1 }),
+    update: async () => ({ updated: task, total: 1 }),
+    claim: async (_sessionId: string, _id: string, owner: TaskOwner) => ({ updated: { ...task, owner }, total: 1 }),
+    claimAvailable: async (_sessionId: string, _id: string, owner: TaskOwner) => ({ updated: { ...task, owner }, total: 1 }),
+    settleAgentOutcome: async (_sessionId: string, _id: string, outcome: TaskAgentOutcome) => {
+      outcomes.push(outcome);
+      task.owner = outcome.owner;
+      return { updated: task, total: 1 };
+    },
+    subscribe: () => () => {},
+  } satisfies TaskLedgerStore;
+  return { taskLedger, outcomes };
 }
 
 describe('expert_dispatch tool', () => {
@@ -100,6 +120,132 @@ describe('expert_dispatch tool', () => {
       'expert:code-review:simplification-reviewer',
       'expert:code-review:test-coverage-reviewer',
     ]);
+  });
+
+  test('settles a member self-claimed task with the real child run refs without auto-completing it', async () => {
+    const task: Task = {
+      id: 'task-1', key: 'T1', subject: 'review correctness', status: 'in_progress',
+      owner: {
+        actor: 'child_agent', agentId: 'expert:code-review:correctness-reviewer',
+        runId: 'claimed-child-run', turnId: 'child-turn',
+      },
+      createdAt: 1, updatedAt: 1,
+    };
+    const { taskLedger, outcomes } = recordingTaskLedger(task);
+    const tool = buildExpertDispatchTool(CODE_REVIEW, { taskLedger });
+    const base = fakeCtx([]) as ReturnType<typeof fakeCtx>;
+    base.spawnChildAgent = async (raw: unknown) => {
+      const input = raw as {
+        onReady?: (value: { turnId: string; agentId: string; agentName: string }) => void | Promise<void>;
+      };
+      await input.onReady?.({
+        turnId: 'child-turn',
+        agentId: 'expert:code-review:correctness-reviewer',
+        agentName: 'Correctness Reviewer',
+      });
+      return {
+        agentId: 'expert:code-review:correctness-reviewer', agentName: 'Correctness Reviewer',
+        turnId: 'child-turn', runId: 'child-run', status: 'completed', permissionMode: 'explore',
+        summary: 'evidence only', artifactIds: [],
+      };
+    };
+    await tool.impl({ member: 'correctness-reviewer', task: 'review' }, base as never);
+    assert.deepEqual(outcomes, [{
+      status: 'completed',
+      owner: {
+        actor: 'child_agent',
+        agentId: 'expert:code-review:correctness-reviewer',
+        runId: 'child-run',
+        turnId: 'child-turn',
+      },
+      reason: 'evidence only',
+    }]);
+    assert.equal(task.status, 'in_progress');
+  });
+
+  test('settles cancellation, timeout failure, and permission-waiting outcomes through the Task Ledger', async () => {
+    const cases = [
+      { status: 'cancelled', failureClass: 'parent_cancelled' },
+      { status: 'failed', failureClass: 'timeout' },
+      { status: 'waiting_permission', failureClass: 'permission_required' },
+    ] as const;
+    for (const { status, failureClass } of cases) {
+      const task: Task = {
+        id: `task-${status}`, key: `T-${status}`, subject: status, status: 'in_progress',
+        owner: {
+          actor: 'child_agent', agentId: 'expert:code-review:correctness-reviewer',
+          runId: 'claimed-child-run', turnId: 'child-turn',
+        },
+        createdAt: 1, updatedAt: 1,
+      };
+      const { taskLedger, outcomes } = recordingTaskLedger(task);
+      const tool = buildExpertDispatchTool(CODE_REVIEW, { taskLedger });
+      const ctx = fakeCtx([], { status, failureClass });
+      const spawn = ctx.spawnChildAgent;
+      ctx.spawnChildAgent = async (raw: unknown) => {
+        const input = raw as {
+          onReady?: (value: { turnId: string; agentId: string; agentName: string }) => void | Promise<void>;
+        };
+        await input.onReady?.({
+          turnId: 'child-turn',
+          agentId: 'expert:code-review:correctness-reviewer',
+          agentName: 'Correctness Reviewer',
+        });
+        return await spawn(raw);
+      };
+
+      await tool.impl({ member: 'correctness-reviewer', task: 'review' }, ctx as never);
+      assert.deepEqual(outcomes, [{
+        status,
+        owner: {
+          actor: 'child_agent',
+          agentId: 'expert:code-review:correctness-reviewer',
+          runId: 'claimed-child-run',
+          turnId: 'child-turn',
+        },
+        reason: failureClass,
+      }]);
+    }
+  });
+
+  test('records a startup failure for a task claimed before the child throws', async () => {
+    const task: Task = {
+      id: 'task-failed', key: 'T-failed', subject: 'failed', status: 'in_progress',
+      owner: {
+        actor: 'child_agent', agentId: 'expert:code-review:correctness-reviewer',
+        runId: 'claimed-child-run', turnId: 'child-turn',
+      },
+      createdAt: 1, updatedAt: 1,
+    };
+    const { taskLedger, outcomes } = recordingTaskLedger(task);
+    const tool = buildExpertDispatchTool(CODE_REVIEW, { taskLedger });
+    const ctx = fakeCtx([]);
+    ctx.spawnChildAgent = async (raw: unknown) => {
+      const input = raw as {
+        onReady?: (value: { turnId: string; agentId: string; agentName: string }) => void | Promise<void>;
+      };
+      await input.onReady?.({
+        turnId: 'child-turn',
+        agentId: 'expert:code-review:correctness-reviewer',
+        agentName: 'Correctness Reviewer',
+      });
+      throw new Error('child startup failed');
+    };
+
+    await assert.rejects(
+      async () => await tool.impl({ member: 'correctness-reviewer', task: 'review' }, ctx as never),
+      /child startup failed/,
+    );
+    assert.deepEqual(outcomes, [{
+      status: 'failed',
+      owner: {
+        actor: 'child_agent',
+        agentId: 'expert:code-review:correctness-reviewer',
+        runId: 'claimed-child-run',
+        turnId: 'child-turn',
+      },
+      reason: 'child startup failed',
+    }]);
   });
 
   test('fails clearly when the runtime lacks the spawnChildAgent capability', async () => {

--- a/packages/runtime/src/__tests__/session-manager.test.ts
+++ b/packages/runtime/src/__tests__/session-manager.test.ts
@@ -55,6 +55,7 @@ import {
   getExpertTeam,
   materializeExpertAgentDefinition,
 } from '../expert-catalog.js';
+import { AGENT_TEAM_CHILD_TOOL_NAMES } from '../agent-team-tool-names.js';
 
 describe('SessionManager manual compaction', () => {
   test('runs backend history compaction as a runtime turn and persists diagnostics', async () => {
@@ -2890,6 +2891,10 @@ describe('SessionManager permission mode updates', () => {
         testTool('Glob'),
         testTool('WebSearch'),
         testTool('Grep'),
+        ...AGENT_TEAM_CHILD_TOOL_NAMES.map((name) => ({
+          ...testTool(name),
+          categoryHint: 'read' as const,
+        })),
       ],
       newId: nextId(),
       now: nextNow(7_200),
@@ -2917,8 +2922,16 @@ describe('SessionManager permission mode updates', () => {
     // The resolver flowed the materialized expert definition through the child
     // turn: read-only archetype scope + composed persona + explore permission.
     expect(contexts.map((ctx) => ctx.header.permissionMode)).toEqual(['ask', 'explore']);
-    expect(contexts[1]?.tools?.map((tool) => tool.name)).toEqual(['Read', 'Glob', 'Grep']);
+    expect(contexts[1]?.tools?.map((tool) => tool.name)).toEqual([
+      'Read', 'Glob', 'Grep', ...AGENT_TEAM_CHILD_TOOL_NAMES,
+    ]);
     expect(contexts[1]?.systemPrompt).toBe(expected.systemPrompt);
+    expect(contexts[1]?.agentTeam).toEqual({
+      role: 'member',
+      teamId: team.id,
+      agentId: expertId,
+      parentRunId: parentRun.runId,
+    });
 
     const childRun = (await runStore.listSessionRuns(session.id)).find((run) => run.turnId === 'child-turn');
     expect(childRun?.agentId).toBe(expertId);

--- a/packages/runtime/src/__tests__/subagent-tools.test.ts
+++ b/packages/runtime/src/__tests__/subagent-tools.test.ts
@@ -904,6 +904,13 @@ function taskLedgerStub(task: Task | undefined, calls: string[]): TaskLedgerStor
       task.owner = owner;
       return { updated: task, total: 1 };
     },
+    claimAvailable: async (_sessionId, _id, owner: TaskOwner) => {
+      if (!task) throw new Error('No such task');
+      calls.push(`claimAvailable:${owner.turnId}`);
+      task.status = 'in_progress';
+      task.owner = owner;
+      return { updated: task, total: 1 };
+    },
     settleAgentOutcome: async (_sessionId, _id, outcome: TaskAgentOutcome) => {
       if (!task) throw new Error('No such task');
       calls.push(`settle:${outcome.status}:${outcome.owner.runId}`);

--- a/packages/runtime/src/__tests__/task-ledger-tools.test.ts
+++ b/packages/runtime/src/__tests__/task-ledger-tools.test.ts
@@ -87,6 +87,10 @@ class FakeTaskLedgerStore implements TaskLedgerStore {
     return { updated: { ...task }, total: this.tasks.length };
   }
 
+  async claimAvailable(sessionId: string, id: string, owner: TaskOwner): Promise<{ updated: Task; total: number }> {
+    return this.claim(sessionId, id, owner);
+  }
+
   async settleAgentOutcome(_sessionId: string, id: string, outcome: TaskAgentOutcome): Promise<{ updated: Task; total: number }> {
     const task = this.tasks.find((item) => item.id === id || item.key === id);
     if (!task) throw new Error(`No such task: ${id}`);

--- a/packages/runtime/src/agent-team-tool-names.ts
+++ b/packages/runtime/src/agent-team-tool-names.ts
@@ -1,0 +1,15 @@
+export const TEAM_MESSAGE_TOOL_NAME = 'team_message';
+export const TEAM_INBOX_TOOL_NAME = 'team_inbox';
+export const TEAM_TASK_LIST_TOOL_NAME = 'team_task_list';
+export const TEAM_TASK_CLAIM_TOOL_NAME = 'team_task_claim';
+
+export const AGENT_TEAM_LEAD_TOOL_NAMES = [
+  TEAM_MESSAGE_TOOL_NAME,
+  TEAM_INBOX_TOOL_NAME,
+] as const;
+
+export const AGENT_TEAM_CHILD_TOOL_NAMES = [
+  ...AGENT_TEAM_LEAD_TOOL_NAMES,
+  TEAM_TASK_LIST_TOOL_NAME,
+  TEAM_TASK_CLAIM_TOOL_NAME,
+] as const;

--- a/packages/runtime/src/agent-team-tools.ts
+++ b/packages/runtime/src/agent-team-tools.ts
@@ -51,11 +51,12 @@ function buildTeamMessageTool(mailbox: AgentMailboxStore): MakaTool {
   return {
     name: TEAM_MESSAGE_TOOL_NAME,
     displayName: 'Team Message',
-    description: 'Send one bounded, durable message to the team lead, a named teammate, or the whole current expert-team run.',
+    description: 'Send one bounded, durable message to the team lead role, a member role mailbox, or the whole current expert-team run.',
     parameters: z.discriminatedUnion('type', [
       z.object({
         type: z.literal('message'),
-        recipient: z.string().min(1).max(128).describe('Use "lead" or a member id from the team roster.'),
+        recipient: z.string().min(1).max(128)
+          .describe('Use "lead" or a member id from the team roster. A member id addresses its shared role mailbox.'),
         content: z.string().min(1).max(AGENT_MAILBOX_CONTENT_MAX_CHARS),
       }),
       z.object({
@@ -88,7 +89,9 @@ function buildTeamInboxTool(mailbox: AgentMailboxStore): MakaTool {
   return {
     name: TEAM_INBOX_TOOL_NAME,
     displayName: 'Team Inbox',
-    description: 'Read durable direct messages and teammate broadcasts for the current expert-team run. Use after_seq to poll without replaying earlier messages.',
+    description:
+      'Read durable direct messages and teammate broadcasts for this role in the current expert-team run. '
+      + 'Repeated or concurrent invocations of one member share this history; each caller must pass its own after_seq cursor.',
     parameters: z.object({
       after_seq: z.number().int().min(0).optional(),
       limit: z.number().int().min(1).max(AGENT_MAILBOX_LIST_MAX).optional(),

--- a/packages/runtime/src/agent-team-tools.ts
+++ b/packages/runtime/src/agent-team-tools.ts
@@ -1,0 +1,235 @@
+import { z } from 'zod';
+import {
+  AGENT_MAILBOX_CONTENT_MAX_CHARS,
+  AGENT_MAILBOX_LIST_MAX,
+  TASK_ID_MAX_CHARS,
+  filterModelVisibleTaskLedgerTasks,
+  isSafeTaskId,
+  sanitizeTaskLedgerTask,
+  type AgentMailboxParticipantRef,
+  type AgentMailboxStore,
+  type TaskLedgerStore,
+} from '@maka/core';
+import { buildExpertAgentId, getExpertTeam } from './expert-catalog.js';
+import type { AgentTeamExecutionContext, MakaTool, MakaToolContext } from './tool-runtime.js';
+import {
+  AGENT_TEAM_CHILD_TOOL_NAMES,
+  AGENT_TEAM_LEAD_TOOL_NAMES,
+  TEAM_INBOX_TOOL_NAME,
+  TEAM_MESSAGE_TOOL_NAME,
+  TEAM_TASK_CLAIM_TOOL_NAME,
+  TEAM_TASK_LIST_TOOL_NAME,
+} from './agent-team-tool-names.js';
+
+export interface AgentTeamToolDeps {
+  mailbox: AgentMailboxStore;
+  taskLedger: TaskLedgerStore;
+}
+
+export function buildAgentTeamLeadTools(deps: AgentTeamToolDeps): MakaTool[] {
+  const all = buildAgentTeamTools(deps);
+  const names = new Set<string>(AGENT_TEAM_LEAD_TOOL_NAMES);
+  return all.filter((tool) => names.has(tool.name));
+}
+
+export function buildAgentTeamChildTools(deps: AgentTeamToolDeps): MakaTool[] {
+  const all = buildAgentTeamTools(deps);
+  const names = new Set<string>(AGENT_TEAM_CHILD_TOOL_NAMES);
+  return all.filter((tool) => names.has(tool.name));
+}
+
+export function buildAgentTeamTools(deps: AgentTeamToolDeps): MakaTool[] {
+  return [
+    buildTeamMessageTool(deps.mailbox),
+    buildTeamInboxTool(deps.mailbox),
+    buildTeamTaskListTool(deps.taskLedger),
+    buildTeamTaskClaimTool(deps.taskLedger),
+  ];
+}
+
+function buildTeamMessageTool(mailbox: AgentMailboxStore): MakaTool {
+  return {
+    name: TEAM_MESSAGE_TOOL_NAME,
+    displayName: 'Team Message',
+    description: 'Send one bounded, durable message to the team lead, a named teammate, or the whole current expert-team run.',
+    parameters: z.discriminatedUnion('type', [
+      z.object({
+        type: z.literal('message'),
+        recipient: z.string().min(1).max(128).describe('Use "lead" or a member id from the team roster.'),
+        content: z.string().min(1).max(AGENT_MAILBOX_CONTENT_MAX_CHARS),
+      }),
+      z.object({
+        type: z.literal('broadcast'),
+        content: z.string().min(1).max(AGENT_MAILBOX_CONTENT_MAX_CHARS),
+      }),
+    ]),
+    permissionRequired: false,
+    categoryHint: 'read',
+    impl: async (input: unknown, ctx) => {
+      const execution = requireAgentTeamExecution(ctx);
+      const parsed = input as { type: 'message' | 'broadcast'; recipient?: string; content: string };
+      const from = participantFromContext(execution, ctx);
+      const to = parsed.type === 'message'
+        ? resolveRecipient(execution, parsed.recipient)
+        : undefined;
+      return await mailbox.send(ctx.sessionId, {
+        teamId: execution.teamId,
+        parentRunId: parentRunIdFor(execution, ctx),
+        kind: parsed.type,
+        from,
+        ...(to ? { to } : {}),
+        content: parsed.content,
+      });
+    },
+  };
+}
+
+function buildTeamInboxTool(mailbox: AgentMailboxStore): MakaTool {
+  return {
+    name: TEAM_INBOX_TOOL_NAME,
+    displayName: 'Team Inbox',
+    description: 'Read durable direct messages and teammate broadcasts for the current expert-team run. Use after_seq to poll without replaying earlier messages.',
+    parameters: z.object({
+      after_seq: z.number().int().min(0).optional(),
+      limit: z.number().int().min(1).max(AGENT_MAILBOX_LIST_MAX).optional(),
+    }),
+    permissionRequired: false,
+    categoryHint: 'read',
+    impl: async (input: unknown, ctx) => {
+      const execution = requireAgentTeamExecution(ctx);
+      const parsed = input as { after_seq?: number; limit?: number };
+      return await mailbox.list(ctx.sessionId, {
+        teamId: execution.teamId,
+        parentRunId: parentRunIdFor(execution, ctx),
+        recipientAgentId: execution.agentId,
+        ...(parsed.after_seq !== undefined ? { afterSeq: parsed.after_seq } : {}),
+        ...(parsed.limit !== undefined ? { limit: parsed.limit } : {}),
+      });
+    },
+  };
+}
+
+function buildTeamTaskListTool(taskLedger: TaskLedgerStore): MakaTool {
+  return {
+    name: TEAM_TASK_LIST_TOOL_NAME,
+    displayName: 'Team Tasks',
+    description: 'List Task Ledger items shared by the current lead AgentRun and eligible for atomic child self-claim.',
+    parameters: z.object({}),
+    permissionRequired: false,
+    categoryHint: 'read',
+    impl: async (_input, ctx) => {
+      const execution = requireMemberExecution(ctx);
+      const tasks = filterModelVisibleTaskLedgerTasks(await taskLedger.list(ctx.sessionId, {
+        includeTerminal: false,
+        classifyResumeTrust: true,
+      }))
+        .filter((task) =>
+          (task.status === 'pending' || task.status === 'blocked')
+          && task.owner?.actor === 'main_agent'
+          && task.owner.runId === execution.parentRunId
+        )
+        .map((task) => {
+          const safe = sanitizeTaskLedgerTask(task);
+          return {
+            id: safe.id,
+            key: safe.key,
+            subject: safe.subject,
+            status: safe.status,
+            ...(safe.parentId ? { parentId: safe.parentId } : {}),
+            ...(safe.blockedReason ? { blockedReason: safe.blockedReason } : {}),
+          };
+        });
+      return { tasks, total: tasks.length };
+    },
+  };
+}
+
+function buildTeamTaskClaimTool(taskLedger: TaskLedgerStore): MakaTool {
+  return {
+    name: TEAM_TASK_CLAIM_TOOL_NAME,
+    displayName: 'Claim Team Task',
+    description: 'Atomically claim one available shared Task Ledger item for this child turn. This grants work ownership, never completion authority.',
+    parameters: z.object({
+      task_id: z.string().min(1).max(TASK_ID_MAX_CHARS).refine(isSafeTaskId)
+        .describe('Task UUID or short key from team_task_list.'),
+    }),
+    permissionRequired: false,
+    categoryHint: 'read',
+    impl: async (input: unknown, ctx) => {
+      const execution = requireMemberExecution(ctx);
+      const parsed = input as { task_id: string };
+      const owner = {
+        actor: 'child_agent' as const,
+        agentId: execution.agentId,
+        runId: requireRunId(ctx),
+        turnId: ctx.turnId,
+      };
+      const result = await taskLedger.claimAvailable(ctx.sessionId, parsed.task_id, owner, {
+        parentRunId: execution.parentRunId,
+      }, {
+        runId: owner.runId,
+        turnId: owner.turnId,
+        toolCallId: ctx.toolCallId,
+        source: 'tool',
+        actor: 'child_agent',
+        reason: `self-claimed by expert team member ${execution.agentId}`,
+      });
+      return { task: sanitizeTaskLedgerTask(result.updated), total: result.total };
+    },
+  };
+}
+
+function requireAgentTeamExecution(ctx: MakaToolContext): AgentTeamExecutionContext {
+  if (!ctx.agentTeam) throw new Error('Agent team capability is unavailable outside an expert-team run');
+  requireRunId(ctx);
+  if (ctx.agentTeam.role === 'member' && !ctx.agentTeam.parentRunId) {
+    throw new Error('Expert-team member is missing its parent AgentRun identity');
+  }
+  return ctx.agentTeam;
+}
+
+function requireMemberExecution(ctx: MakaToolContext): AgentTeamExecutionContext & { role: 'member'; parentRunId: string } {
+  const execution = requireAgentTeamExecution(ctx);
+  if (execution.role !== 'member' || !execution.parentRunId) {
+    throw new Error('Shared task self-claim is available only to expert-team members');
+  }
+  return execution as AgentTeamExecutionContext & { role: 'member'; parentRunId: string };
+}
+
+function requireRunId(ctx: MakaToolContext): string {
+  if (!ctx.runId) throw new Error('Agent team tool requires a durable AgentRun identity');
+  return ctx.runId;
+}
+
+function parentRunIdFor(execution: AgentTeamExecutionContext, ctx: MakaToolContext): string {
+  return execution.role === 'lead' ? requireRunId(ctx) : execution.parentRunId!;
+}
+
+function participantFromContext(
+  execution: AgentTeamExecutionContext,
+  ctx: MakaToolContext,
+): AgentMailboxParticipantRef {
+  return {
+    role: execution.role,
+    agentId: execution.agentId,
+    runId: requireRunId(ctx),
+    turnId: ctx.turnId,
+  };
+}
+
+function resolveRecipient(
+  execution: AgentTeamExecutionContext,
+  recipient: string | undefined,
+): { role: 'lead' | 'member'; agentId: string } {
+  if (!recipient) throw new Error('Direct team messages require a recipient');
+  if (recipient === 'lead') {
+    if (execution.role === 'lead') throw new Error('Team messages cannot target the sender');
+    return { role: 'lead', agentId: 'lead' };
+  }
+  const team = getExpertTeam(execution.teamId);
+  const member = team?.members.find((candidate) => candidate.id === recipient);
+  if (!team || !member) throw new Error(`Unknown member "${recipient}" for expert team "${execution.teamId}"`);
+  const agentId = buildExpertAgentId(team.id, member.id);
+  if (agentId === execution.agentId) throw new Error('Team messages cannot target the sender');
+  return { role: 'member', agentId };
+}

--- a/packages/runtime/src/ai-sdk-backend.ts
+++ b/packages/runtime/src/ai-sdk-backend.ts
@@ -95,6 +95,7 @@ import {
   formatSyntheticToolErrorText,
   type MakaTool,
   type MakaToolContext,
+  type AgentTeamExecutionContext,
 } from './tool-runtime.js';
 import {
   ModelAdapter,
@@ -719,6 +720,8 @@ export interface AiSdkBackendInput {
   /** Canonical-named tools available this session. Backend wraps each with
    *  permission gating before passing to ai-sdk. */
   tools: MakaTool[];
+  /** Trusted identity for expert-team lead/member collaboration tools. */
+  agentTeam?: AgentTeamExecutionContext;
   /**
    * Optional unified tool-availability config (issue #37). With `economy: true`,
    * only core + ungrouped tools are advertised each turn; each group's tools are
@@ -933,6 +936,7 @@ export class AiSdkBackend implements AgentBackend {
       now: this.now,
       getPermissionPauseTarget: () => this.currentWatchdog,
       getCurrentRunId: () => this.currentRunId ?? undefined,
+      agentTeam: input.agentTeam,
       getCurrentStepId: () => this.currentStepMessageId ?? undefined,
       permissionRules: input.permissionRules,
       spawnChildAgent: input.spawnChildAgent,

--- a/packages/runtime/src/expert-catalog.ts
+++ b/packages/runtime/src/expert-catalog.ts
@@ -1,10 +1,12 @@
 /**
- * Expert teams — data-driven star orchestrator→worker personas.
+ * Expert teams — data-driven lead/member personas with bounded collaboration.
  *
  * An expert team is a lead persona (runs as the main session) plus a set of
  * member "experts" the lead dispatches as read/tool-scoped child agents. This
- * is the star topology: the lead fans work out to members and synthesizes their
- * results; members never talk to each other.
+ * keeps the lead responsible for fan-out, final synthesis, and task completion.
+ * Members may exchange bounded, durable messages and atomically self-claim one
+ * eligible shared task, but they cannot widen their capabilities or complete
+ * shared work without lead review.
  *
  * Experts do not invent new tool scopes. Every expert declares a capability
  * `archetype` — one of the built-in {@link AgentProfile}s — and inherits that
@@ -26,6 +28,7 @@ import {
   requireBuiltinAgentDefinition,
   requireBuiltinAgentDefinitionByProfile,
 } from './agent-catalog.js';
+import { AGENT_TEAM_CHILD_TOOL_NAMES } from './agent-team-tool-names.js';
 
 export const EXPERT_AGENT_ID_PREFIX = 'expert';
 
@@ -98,7 +101,7 @@ export function isExpertAgentId(id: string): boolean {
 /**
  * Compose a member's full system prompt: the archetype's base guardrails
  * (e.g. read-only discipline) followed by the expert's identity, lens, and the
- * shared worker protocol (star topology + pointer fan-in).
+ * shared worker protocol (bounded mailbox + shared task ownership + pointer fan-in).
  */
 function composeExpertSystemPrompt(
   archetype: AgentDefinition,
@@ -112,9 +115,11 @@ function composeExpertSystemPrompt(
     expert.persona,
     '',
     'Worker protocol:',
-    '- You are a spawned worker in a star topology. You do not talk to other members; you report only to the lead.',
+    '- You are a spawned member of one expert-team run. Your context and tool permissions remain isolated from every other member.',
+    '- Use team_task_list and atomically claim at most one eligible shared task when it matches your assignment. A claim grants ownership, never completion authority.',
+    '- Use team_message for a concrete cross-lens finding or blocker and team_inbox to poll for replies before your final answer. Keep messages bounded and evidence-backed; do not create acknowledgement loops.',
     '- Do exactly the task the lead assigned and stay within your lens. Do not expand scope.',
-    '- Persist any large output as an artifact and return a concise, structured summary the lead can merge. Do not dump raw file contents into your reply.',
+    '- Persist any large output as an artifact and return a concise, structured summary the lead can merge. The lead alone decides whether a shared task is complete.',
     '- Ground every finding in concrete evidence: name files, symbols, and line references.',
   ].join('\n');
 }
@@ -130,8 +135,8 @@ export function materializeExpertAgentDefinition(
 ): AgentDefinition {
   const archetype = requireBuiltinAgentDefinitionByProfile(expert.archetype);
   const archetypeTools = new Set(archetype.tools);
-  const tools = expert.tools ?? archetype.tools;
-  const widened = tools.filter((name) => !archetypeTools.has(name));
+  const capabilityTools = expert.tools ?? archetype.tools;
+  const widened = capabilityTools.filter((name) => !archetypeTools.has(name));
   if (widened.length > 0) {
     throw new Error(
       `Expert "${team.id}:${expert.id}" cannot use tools outside its "${expert.archetype}" archetype: ${widened.join(', ')}. ` +
@@ -145,7 +150,10 @@ export function materializeExpertAgentDefinition(
     description: expert.description,
     contract: archetype.contract,
     permissionMode: archetype.permissionMode,
-    tools: [...tools],
+    // Collaboration controls do not widen filesystem/network capability. They
+    // are runtime-owned, session/team-scoped tools whose trusted identity is
+    // injected by RuntimeKernel and whose durable stores enforce ownership.
+    tools: [...capabilityTools, ...AGENT_TEAM_CHILD_TOOL_NAMES],
     categoryPolicy: archetype.categoryPolicy,
     systemPrompt: composeExpertSystemPrompt(archetype, team, expert),
   };
@@ -329,8 +337,9 @@ export function buildExpertTeamLeadSystemPromptFragment(teamId: string): string 
     '- To run members concurrently, emit several expert_dispatch calls in a single turn. Independent members should always be dispatched together, not one after another.',
     '- Never ask a member to work outside its lens, and never dispatch the same task to two members.',
     '',
-    'Fan-in discipline:',
-    '- Each member returns a concise summary (and artifact ids for anything large). Members never talk to each other; all coordination goes through you.',
+    'Shared work + fan-in discipline:',
+    '- For work that benefits from shared ownership, create bounded Task Ledger items before dispatch and tell members to inspect team_task_list. Claims are atomic; child success remains evidence until you review and complete the task.',
+    '- Each member returns a concise summary (and artifact ids for anything large). Members may exchange bounded, durable messages; use team_inbox after fan-in to inspect messages addressed to the lead.',
     "- After members return, synthesize a single result: dedupe overlapping points, drop anything a member could not ground in evidence, and rank by importance. Speak as the lead — do not attribute output to \"the members\".",
     '- If a member fails or returns nothing useful, say so plainly rather than inventing its result.',
   ].join('\n');

--- a/packages/runtime/src/expert-tools.ts
+++ b/packages/runtime/src/expert-tools.ts
@@ -15,7 +15,7 @@
  */
 
 import { z } from 'zod';
-import type { ToolResultContent } from '@maka/core';
+import type { TaskAgentOutcome, TaskLedgerStore, TaskOwner, ToolResultContent } from '@maka/core';
 import type { MakaTool } from './tool-runtime.js';
 import {
   type ExpertTeamDefinition,
@@ -29,6 +29,10 @@ export const EXPERT_DISPATCH_TOOL_NAME = 'expert_dispatch';
 
 type SubagentToolResult = Extract<ToolResultContent, { kind: 'subagent' }>;
 
+export interface ExpertDispatchToolDeps {
+  taskLedger?: TaskLedgerStore;
+}
+
 function memberEnum(team: ExpertTeamDefinition): [string, ...string[]] {
   const ids = team.members.map((member) => member.id);
   return [ids[0]!, ...ids.slice(1)];
@@ -39,7 +43,7 @@ function memberEnum(team: ExpertTeamDefinition): [string, ...string[]] {
  * the roster embedded in the description are the team's members, so the model
  * can only dispatch valid members and sees each member's lens and tool scope.
  */
-export function buildExpertDispatchTool(team: ExpertTeamDefinition): MakaTool<
+export function buildExpertDispatchTool(team: ExpertTeamDefinition, deps: ExpertDispatchToolDeps = {}): MakaTool<
   {
     member: string;
     task: string;
@@ -53,7 +57,7 @@ export function buildExpertDispatchTool(team: ExpertTeamDefinition): MakaTool<
     description: [
       `Dispatch a member of the "${team.name}" to a bounded task and return its result.`,
       'The member runs as a tool-scoped child agent with its own fresh context — it sees only the task you pass, so make each task self-contained (exact files/scope + what to look for).',
-      'Run members concurrently by emitting several expert_dispatch calls in a single turn. Members do not talk to each other; synthesize their results yourself.',
+      'Run members concurrently by emitting several expert_dispatch calls in a single turn. Members may exchange bounded mailbox messages, but you remain responsible for synthesis and final task completion.',
       '',
       'Members:',
       roster,
@@ -78,14 +82,38 @@ export function buildExpertDispatchTool(team: ExpertTeamDefinition): MakaTool<
         throw new Error('spawnChildAgent capability is unavailable in this runtime context');
       }
       const definition = materializeExpertAgentDefinition(team, member);
-      const result = (await ctx.spawnChildAgent({
-        spec: {
-          id: buildExpertAgentId(team.id, member.id),
-          name: definition.name,
-          systemPrompt: definition.systemPrompt,
-        },
-        prompt: input.task,
-      })) as Omit<SubagentToolResult, 'kind'>;
+      let ready: { turnId: string; agentId: string } | undefined;
+      let result: Omit<SubagentToolResult, 'kind'>;
+      try {
+        result = (await ctx.spawnChildAgent({
+          spec: {
+            id: buildExpertAgentId(team.id, member.id),
+            name: definition.name,
+            systemPrompt: definition.systemPrompt,
+          },
+          prompt: input.task,
+          ...(deps.taskLedger ? {
+            onReady: ({ turnId, agentId }) => {
+              ready = { turnId, agentId };
+            },
+          } : {}),
+        })) as Omit<SubagentToolResult, 'kind'>;
+      } catch (error) {
+        if (deps.taskLedger && ready) {
+          await settleSelfClaimedTasks(deps.taskLedger, ctx.sessionId, ready, {
+            status: 'failed',
+            reason: error instanceof Error ? error.message : 'Expert-team member failed before returning a result',
+          }, ctx.toolCallId);
+        }
+        throw error;
+      }
+      if (deps.taskLedger && ready) {
+        await settleSelfClaimedTasks(deps.taskLedger, ctx.sessionId, ready, {
+          status: result.status,
+          ...(result.runId ? { runId: result.runId } : {}),
+          reason: result.failureClass ?? result.summary,
+        }, ctx.toolCallId);
+      }
       return {
         kind: 'subagent',
         ...result,
@@ -95,7 +123,46 @@ export function buildExpertDispatchTool(team: ExpertTeamDefinition): MakaTool<
 }
 
 /** Build the dispatch tool for a team id, or `undefined` if the team is unknown. */
-export function buildExpertDispatchToolForTeamId(teamId: string): MakaTool | undefined {
+export function buildExpertDispatchToolForTeamId(
+  teamId: string,
+  deps: ExpertDispatchToolDeps = {},
+): MakaTool | undefined {
   const team = getExpertTeam(teamId);
-  return team ? (buildExpertDispatchTool(team) as MakaTool) : undefined;
+  return team ? (buildExpertDispatchTool(team, deps) as MakaTool) : undefined;
+}
+
+async function settleSelfClaimedTasks(
+  taskLedger: TaskLedgerStore,
+  sessionId: string,
+  ready: { turnId: string; agentId: string },
+  result: { status: TaskAgentOutcome['status']; runId?: string; reason?: string },
+  toolCallId: string,
+): Promise<void> {
+  const claimed = (await taskLedger.list(sessionId, { includeTerminal: false }))
+    .filter((task) =>
+      task.owner?.actor === 'child_agent'
+      && task.owner.agentId === ready.agentId
+      && task.owner.turnId === ready.turnId
+    );
+  for (const task of claimed) {
+    const runId = result.runId ?? task.owner?.runId;
+    const owner: TaskOwner = {
+      actor: 'child_agent',
+      agentId: ready.agentId,
+      ...(runId ? { runId } : {}),
+      turnId: ready.turnId,
+    };
+    await taskLedger.settleAgentOutcome(sessionId, task.id, {
+      status: result.status,
+      owner,
+      reason: result.reason,
+    }, {
+      runId,
+      turnId: ready.turnId,
+      toolCallId,
+      source: 'system',
+      actor: 'child_agent',
+      reason: result.reason,
+    });
+  }
 }

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -448,6 +448,21 @@ export {
   buildExpertDispatchTool,
   buildExpertDispatchToolForTeamId,
 } from './expert-tools.js';
+export type { ExpertDispatchToolDeps } from './expert-tools.js';
+export {
+  AGENT_TEAM_CHILD_TOOL_NAMES,
+  AGENT_TEAM_LEAD_TOOL_NAMES,
+  TEAM_INBOX_TOOL_NAME,
+  TEAM_MESSAGE_TOOL_NAME,
+  TEAM_TASK_CLAIM_TOOL_NAME,
+  TEAM_TASK_LIST_TOOL_NAME,
+} from './agent-team-tool-names.js';
+export {
+  buildAgentTeamChildTools,
+  buildAgentTeamLeadTools,
+  buildAgentTeamTools,
+} from './agent-team-tools.js';
+export type { AgentTeamToolDeps } from './agent-team-tools.js';
 export {
   LEGACY_TASK_CREATE_TOOL_NAME,
   LEGACY_TASK_UPDATE_TOOL_NAME,

--- a/packages/runtime/src/runtime-kernel.ts
+++ b/packages/runtime/src/runtime-kernel.ts
@@ -22,7 +22,7 @@ import type { UserQuestionResponse } from '@maka/core/user-question';
 import { AgentRun, type AgentRunActiveSession, type AgentRunBeginResult, type AgentRunLineage } from './agent-run.js';
 import { AiSdkFlow, mapSessionEventToRuntimeEvent } from './ai-sdk-flow.js';
 import type { AgentBackend, SteeringLease } from '@maka/core/backend-types';
-import type { MakaTool } from './tool-runtime.js';
+import type { AgentTeamExecutionContext, MakaTool } from './tool-runtime.js';
 import type { InvocationContext, InvocationResult, InvocationSource } from './invocation-context.js';
 import { RuntimeRunner } from './runtime-runner.js';
 import type { BackendRegistry, CompactSessionInput, SessionStore, StopSessionInput } from './session-manager.js';
@@ -37,7 +37,7 @@ import {
   assertAgentDefinitionRunnable,
   buildToolsForAgentDefinition,
 } from './agent-catalog.js';
-import { requireResolvedAgentDefinition } from './expert-catalog.js';
+import { parseExpertAgentId, requireResolvedAgentDefinition } from './expert-catalog.js';
 import { loadLatestHistoryCompactCheckpointFromRunLedger } from './history-compact-ledger.js';
 import {
   canReplaceHistoryCompactCheckpoint,
@@ -341,6 +341,15 @@ export class RuntimeKernel implements RuntimeKernelLike {
       tools: availableChildTools,
     });
     const childTools = buildToolsForAgentDefinition(availableChildTools, definition);
+    const expertIdentity = parseExpertAgentId(definition.id);
+    const agentTeam: AgentTeamExecutionContext | undefined = expertIdentity
+      ? {
+          role: 'member',
+          teamId: expertIdentity.teamId,
+          agentId: definition.id,
+          parentRunId: input.parentRunId,
+        }
+      : undefined;
     const childHeader: SessionHeader = {
       ...parentHeader,
       permissionMode: definition.permissionMode,
@@ -367,7 +376,14 @@ export class RuntimeKernel implements RuntimeKernelLike {
       recordSessionMessages: false,
       hooks: {
         ensureActive: (targetSessionId, nextHeader) =>
-          this.ensureChildActive(activeKey, targetSessionId, nextHeader, definition.systemPrompt, childTools),
+          this.ensureChildActive(
+            activeKey,
+            targetSessionId,
+            nextHeader,
+            definition.systemPrompt,
+            childTools,
+            agentTeam,
+          ),
         registerRun: (active, activeRun) => this.registerRun(active, activeRun),
         unregisterRun: (active, activeRun) => this.unregisterChildRun(activeKey, active, activeRun),
         updateHeader: async (_targetSessionId, patch) => ({ ...childHeader, ...patch }),
@@ -1057,6 +1073,7 @@ export class RuntimeKernel implements RuntimeKernelLike {
     header: SessionHeader,
     systemPrompt: string,
     tools: readonly MakaTool[],
+    agentTeam?: AgentTeamExecutionContext,
   ): Promise<ActiveSession> {
     const existing = this.childActive.get(activeKey);
     if (existing) {
@@ -1071,6 +1088,7 @@ export class RuntimeKernel implements RuntimeKernelLike {
       appendMessage: async () => {},
       systemPrompt,
       tools,
+      ...(agentTeam ? { agentTeam } : {}),
       recordRunTrace: (event) => {
         const active = this.childActive.get(activeKey);
         const runId = active?.turnToRunId.get(event.turnId);

--- a/packages/runtime/src/session-manager.ts
+++ b/packages/runtime/src/session-manager.ts
@@ -66,7 +66,7 @@ import {
 } from './terminal-run-commit.js';
 
 import type { AgentBackend, BackendStopMode } from '@maka/core/backend-types';
-import type { MakaTool } from './tool-runtime.js';
+import type { AgentTeamExecutionContext, MakaTool } from './tool-runtime.js';
 import type { RunTraceRecorder } from './run-trace.js';
 import type { ShellRunProcessManager } from './shell-run-manager.js';
 import type { ActiveFullCompactBlock } from './active-full-compact.js';
@@ -212,6 +212,8 @@ export interface BackendFactoryContext {
    */
   systemPrompt?: string;
   tools?: readonly MakaTool[];
+  /** Trusted child expert-team identity. Main-session factories leave this undefined. */
+  agentTeam?: AgentTeamExecutionContext;
   recordRunTrace?: RunTraceRecorder;
   loadHistoryCompactCheckpoint?: () => Promise<HistoryCompactCheckpoint | undefined>;
   recordHistoryCompactCheckpoint?: (checkpoint: HistoryCompactCheckpoint, turnId: string) => Promise<void>;

--- a/packages/runtime/src/subagent-tools.ts
+++ b/packages/runtime/src/subagent-tools.ts
@@ -12,6 +12,7 @@ import {
   requireBuiltinAgentDefinitionByProfile,
 } from './agent-catalog.js';
 import type { ToolGroup } from './tool-availability.js';
+import { AGENT_TEAM_CHILD_TOOL_NAMES } from './agent-team-tool-names.js';
 
 export const AGENT_SPAWN_TOOL_NAME = 'agent_spawn';
 export const AGENT_LIST_TOOL_NAME = 'agent_list';
@@ -44,6 +45,12 @@ export function buildChildAgentTools(tools: readonly MakaTool[]): MakaTool[] {
       seen.add(tool.name);
       out.push(tool);
     }
+  }
+  for (const name of AGENT_TEAM_CHILD_TOOL_NAMES) {
+    const tool = tools.find((candidate) => candidate.name === name);
+    if (!tool || seen.has(name)) continue;
+    seen.add(name);
+    out.push(tool);
   }
   return out;
 }

--- a/packages/runtime/src/tool-runtime.ts
+++ b/packages/runtime/src/tool-runtime.ts
@@ -130,6 +130,8 @@ export interface MakaToolContext {
   toolCallId: string;
   abortSignal: AbortSignal;
   emitOutput: (stream: ToolOutputStream, chunk: string) => void;
+  /** Trusted expert-team identity supplied by RuntimeKernel/backend wiring. */
+  agentTeam?: AgentTeamExecutionContext;
   /** One-call grants already approved and consumed by ToolRuntime. */
   permissionContext?: ToolExecutionPermissionContext;
   spawnChildAgent?: (input: {
@@ -140,6 +142,14 @@ export interface MakaToolContext {
   listChildAgents?: () => Promise<unknown>;
   readChildAgentOutput?: (input: { runId?: string; turnId?: string; maxEvents?: number }) => Promise<unknown>;
   askUserQuestion?: (questions: UserQuestion[]) => Promise<UserQuestionResult>;
+}
+
+export interface AgentTeamExecutionContext {
+  role: 'lead' | 'member';
+  teamId: string;
+  agentId: string;
+  /** Lead AgentRun that owns this team execution. Required for members. */
+  parentRunId?: string;
 }
 
 export type AppendMessageFn = (m: ToolCallMessage | ToolResultMessage | PermissionDecisionMessage) => Promise<void>;
@@ -186,6 +196,7 @@ export interface ToolRuntimeInput {
   now: () => number;
   getPermissionPauseTarget: () => { pause(): void; resume(): void } | null;
   getCurrentRunId?: () => string | undefined;
+  agentTeam?: AgentTeamExecutionContext;
   /**
    * Id of the assistant step currently streaming, stamped onto each tool call's
    * `tool_start` event so model replay can group a step's reasoning + tool calls
@@ -1022,6 +1033,7 @@ export class ToolRuntime {
           toolCallId: toolUseId,
           abortSignal: ctx.abortSignal,
           emitOutput: output.emit,
+          ...(this.input.agentTeam ? { agentTeam: this.input.agentTeam } : {}),
           ...(permissionContext ? { permissionContext } : {}),
           ...(this.input.listChildAgents ? { listChildAgents: this.input.listChildAgents } : {}),
           ...(this.input.readChildAgentOutput ? { readChildAgentOutput: this.input.readChildAgentOutput } : {}),

--- a/packages/storage/src/__tests__/agent-mailbox-store.test.ts
+++ b/packages/storage/src/__tests__/agent-mailbox-store.test.ts
@@ -1,0 +1,122 @@
+import { strict as assert } from 'node:assert';
+import { describe, test } from 'node:test';
+import { mkdtemp, readFile, writeFile, mkdir } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { createAgentMailboxStore } from '../agent-mailbox-store.js';
+
+const SESSION_ID = 'session-1';
+const TEAM_ID = 'code-review';
+const PARENT_RUN_ID = 'parent-run';
+
+async function tempRoot(): Promise<string> {
+  return mkdtemp(join(tmpdir(), 'maka-agent-mailbox-'));
+}
+
+function member(agentId: string, runId: string, turnId: string) {
+  return { role: 'member' as const, agentId, runId, turnId };
+}
+
+describe('AgentMailboxStore', () => {
+  test('persists direct and broadcast messages with a monotonic scope cursor', async () => {
+    const root = await tempRoot();
+    let id = 0;
+    const store = createAgentMailboxStore(root, { newId: () => `message-${++id}`, now: () => 100 + id });
+    const correctness = member('expert:code-review:correctness-reviewer', 'run-a', 'turn-a');
+    const tests = member('expert:code-review:test-coverage-reviewer', 'run-b', 'turn-b');
+
+    const first = await store.send(SESSION_ID, {
+      teamId: TEAM_ID, parentRunId: PARENT_RUN_ID, kind: 'message', from: correctness,
+      to: { role: 'member', agentId: tests.agentId }, content: 'Please verify the race.',
+    });
+    const second = await store.send(SESSION_ID, {
+      teamId: TEAM_ID, parentRunId: PARENT_RUN_ID, kind: 'broadcast', from: correctness,
+      content: 'The ownership invariant is in task-ledger-store.ts.',
+    });
+    assert.equal(first.message.seq, 1);
+    assert.equal(second.message.seq, 2);
+    assert.equal(second.total, 2);
+
+    const inbox = await createAgentMailboxStore(root).list(SESSION_ID, {
+      teamId: TEAM_ID, parentRunId: PARENT_RUN_ID, recipientAgentId: tests.agentId,
+    });
+    assert.deepEqual(inbox.messages.map((message) => message.seq), [1, 2]);
+    assert.equal(inbox.nextSeq, 2);
+    assert.equal(inbox.total, 2);
+  });
+
+  test('isolates team runs and supports bounded cursor reads', async () => {
+    const root = await tempRoot();
+    let id = 0;
+    const store = createAgentMailboxStore(root, { newId: () => `m-${++id}`, now: () => id });
+    const sender = member('expert:code-review:correctness-reviewer', 'run-a', 'turn-a');
+    const recipient = 'expert:code-review:test-coverage-reviewer';
+    for (const content of ['one', 'two', 'three']) {
+      await store.send(SESSION_ID, {
+        teamId: TEAM_ID, parentRunId: PARENT_RUN_ID, kind: 'message', from: sender,
+        to: { role: 'member', agentId: recipient }, content,
+      });
+    }
+    await store.send(SESSION_ID, {
+      teamId: TEAM_ID, parentRunId: 'another-parent-run', kind: 'message', from: sender,
+      to: { role: 'member', agentId: recipient }, content: 'other run',
+    });
+    const page = await store.list(SESSION_ID, {
+      teamId: TEAM_ID, parentRunId: PARENT_RUN_ID, recipientAgentId: recipient, afterSeq: 1, limit: 1,
+    });
+    assert.deepEqual(page.messages.map((message) => message.content), ['two']);
+    assert.equal(page.nextSeq, 2);
+    assert.equal(page.total, 3);
+  });
+
+  test('serializes concurrent sends without duplicate sequence numbers', async () => {
+    const root = await tempRoot();
+    let id = 0;
+    const store = createAgentMailboxStore(root, { newId: () => `m-${++id}`, now: () => id });
+    const sender = member('expert:code-review:correctness-reviewer', 'run-a', 'turn-a');
+    const recipient = 'expert:code-review:test-coverage-reviewer';
+    await Promise.all(Array.from({ length: 20 }, (_, index) => store.send(SESSION_ID, {
+      teamId: TEAM_ID, parentRunId: PARENT_RUN_ID, kind: 'message', from: sender,
+      to: { role: 'member', agentId: recipient }, content: `message ${index}`,
+    })));
+    const inbox = await store.list(SESSION_ID, {
+      teamId: TEAM_ID, parentRunId: PARENT_RUN_ID, recipientAgentId: recipient, limit: 50,
+    });
+    assert.deepEqual(inbox.messages.map((message) => message.seq), Array.from({ length: 20 }, (_, index) => index + 1));
+  });
+
+  test('fails closed over corrupt durable data instead of appending a new history', async () => {
+    const root = await tempRoot();
+    const directory = join(root, 'sessions', SESSION_ID);
+    await mkdir(directory, { recursive: true });
+    const path = join(directory, 'agent-mailbox.jsonl');
+    await writeFile(path, '{not-json}\n', 'utf8');
+    const before = await readFile(path, 'utf8');
+    const store = createAgentMailboxStore(root);
+    await assert.rejects(() => store.send(SESSION_ID, {
+      teamId: TEAM_ID, parentRunId: PARENT_RUN_ID, kind: 'broadcast',
+      from: member('expert:code-review:correctness-reviewer', 'run-a', 'turn-a'), content: 'new',
+    }), /Invalid agent mailbox JSONL/);
+    assert.equal(await readFile(path, 'utf8'), before);
+  });
+
+  test('rejects replay histories with duplicate message identities', async () => {
+    const root = await tempRoot();
+    let id = 0;
+    const store = createAgentMailboxStore(root, { newId: () => `message-${++id}`, now: () => id });
+    const sender = member('expert:code-review:correctness-reviewer', 'run-a', 'turn-a');
+    const recipient = 'expert:code-review:test-coverage-reviewer';
+    const { message } = await store.send(SESSION_ID, {
+      teamId: TEAM_ID, parentRunId: PARENT_RUN_ID, kind: 'message', from: sender,
+      to: { role: 'member', agentId: recipient }, content: 'first',
+    });
+    const path = join(root, 'sessions', SESSION_ID, 'agent-mailbox.jsonl');
+    await writeFile(path, `${JSON.stringify(message)}\n${JSON.stringify({ ...message, seq: 2, content: 'duplicate' })}\n`, 'utf8');
+    await assert.rejects(
+      () => createAgentMailboxStore(root).list(SESSION_ID, {
+        teamId: TEAM_ID, parentRunId: PARENT_RUN_ID, recipientAgentId: recipient,
+      }),
+      /duplicate message id/,
+    );
+  });
+});

--- a/packages/storage/src/__tests__/agent-mailbox-store.test.ts
+++ b/packages/storage/src/__tests__/agent-mailbox-store.test.ts
@@ -69,6 +69,53 @@ describe('AgentMailboxStore', () => {
     assert.equal(page.total, 3);
   });
 
+  test('shares direct-message history by role while each invocation owns its cursor', async () => {
+    const root = await tempRoot();
+    let id = 0;
+    const store = createAgentMailboxStore(root, { newId: () => `m-${++id}`, now: () => id });
+    const sender = member('expert:code-review:correctness-reviewer', 'sender-run', 'sender-turn');
+    const recipientAgentId = 'expert:code-review:test-coverage-reviewer';
+    const options = {
+      teamId: TEAM_ID,
+      parentRunId: PARENT_RUN_ID,
+      recipientAgentId,
+    };
+
+    await store.send(SESSION_ID, {
+      teamId: TEAM_ID,
+      parentRunId: PARENT_RUN_ID,
+      kind: 'message',
+      from: sender,
+      to: { role: 'member', agentId: recipientAgentId },
+      content: 'first role message',
+    });
+    const [firstInvocation, concurrentInvocation] = await Promise.all([
+      store.list(SESSION_ID, options),
+      store.list(SESSION_ID, options),
+    ]);
+    assert.deepEqual(firstInvocation.messages.map((message) => message.content), ['first role message']);
+    assert.deepEqual(concurrentInvocation.messages.map((message) => message.content), ['first role message']);
+
+    await store.send(SESSION_ID, {
+      teamId: TEAM_ID,
+      parentRunId: PARENT_RUN_ID,
+      kind: 'message',
+      from: sender,
+      to: { role: 'member', agentId: recipientAgentId },
+      content: 'second role message',
+    });
+    const resumedInvocation = await store.list(SESSION_ID, {
+      ...options,
+      afterSeq: firstInvocation.nextSeq,
+    });
+    const freshInvocation = await store.list(SESSION_ID, options);
+    assert.deepEqual(resumedInvocation.messages.map((message) => message.content), ['second role message']);
+    assert.deepEqual(freshInvocation.messages.map((message) => message.content), [
+      'first role message',
+      'second role message',
+    ]);
+  });
+
   test('serializes concurrent sends without duplicate sequence numbers', async () => {
     const root = await tempRoot();
     let id = 0;

--- a/packages/storage/src/__tests__/task-ledger-store.test.ts
+++ b/packages/storage/src/__tests__/task-ledger-store.test.ts
@@ -656,6 +656,70 @@ describe('TaskLedgerStore', () => {
     );
   });
 
+  it('atomically self-claims only available tasks and limits one task per child turn', async () => {
+    const root = await tempRoot();
+    const store = createTaskLedgerStore(root);
+    const { created: [first, second] } = await store.create(SESSION_ID, [
+      { subject: 'first shared task' },
+      { subject: 'second shared task' },
+    ], { actor: 'main_agent', runId: 'lead-run', turnId: 'lead-turn' });
+    assert.ok(first && second);
+    const owner = { actor: 'child_agent' as const, agentId: 'expert:code-review:correctness-reviewer', turnId: 'child-turn' };
+    const scope = { parentRunId: 'lead-run' };
+    const claimed = await store.claimAvailable(SESSION_ID, first.id, owner, scope, { actor: 'child_agent', source: 'tool' });
+    assert.equal(claimed.updated.status, 'in_progress');
+    assert.deepEqual(claimed.updated.owner, owner);
+    assert.equal((await store.claimAvailable(SESSION_ID, first.id, owner, scope)).updated.id, first.id);
+    await assert.rejects(
+      () => store.claimAvailable(SESSION_ID, second.id, owner, scope),
+      /already owns task T1/,
+    );
+  });
+
+  it('refuses self-claim of unowned tasks or tasks shared by another lead run', async () => {
+    const root = await tempRoot();
+    const store = createTaskLedgerStore(root);
+    const { created: [unowned] } = await store.create(SESSION_ID, [{ subject: 'ordinary task' }]);
+    const { created: [olderRun] } = await store.create(
+      SESSION_ID,
+      [{ subject: 'older team task' }],
+      { actor: 'main_agent', runId: 'older-lead-run', turnId: 'older-lead-turn' },
+    );
+    assert.ok(unowned && olderRun);
+    const owner = { actor: 'child_agent' as const, agentId: 'agent-a', turnId: 'turn-a' };
+    const scope = { parentRunId: 'lead-run' };
+    await assert.rejects(() => store.claimAvailable(SESSION_ID, unowned.id, owner, scope), /not shared by parent run/);
+    await assert.rejects(() => store.claimAvailable(SESSION_ID, olderRun.id, owner, scope), /not shared by parent run/);
+  });
+
+  it('resolves concurrent self-claim races inside the write queue', async () => {
+    const root = await tempRoot();
+    const store = createTaskLedgerStore(root);
+    const { created: [task] } = await store.create(
+      SESSION_ID,
+      [{ subject: 'shared' }],
+      { actor: 'main_agent', runId: 'lead-run', turnId: 'lead-turn' },
+    );
+    assert.ok(task);
+    const outcomes = await Promise.allSettled([
+      store.claimAvailable(
+        SESSION_ID,
+        task.id,
+        { actor: 'child_agent', agentId: 'agent-a', turnId: 'turn-a' },
+        { parentRunId: 'lead-run' },
+      ),
+      store.claimAvailable(
+        SESSION_ID,
+        task.id,
+        { actor: 'child_agent', agentId: 'agent-b', turnId: 'turn-b' },
+        { parentRunId: 'lead-run' },
+      ),
+    ]);
+    assert.equal(outcomes.filter((outcome) => outcome.status === 'fulfilled').length, 1);
+    assert.equal(outcomes.filter((outcome) => outcome.status === 'rejected').length, 1);
+    assert.equal((await store.get(SESSION_ID, task.id))?.status, 'in_progress');
+  });
+
   it('backfills old JSONL fields and persists compatibility events on the next write', async () => {
     const root = await tempRoot();
     await mkdir(join(root, 'sessions', SESSION_ID), { recursive: true });

--- a/packages/storage/src/agent-mailbox-store.ts
+++ b/packages/storage/src/agent-mailbox-store.ts
@@ -1,0 +1,190 @@
+import { appendFile, mkdir, readFile } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+import { randomUUID } from 'node:crypto';
+import {
+  AGENT_MAILBOX_LIST_MAX,
+  AGENT_MAILBOX_MAX_MESSAGES_PER_TEAM_RUN,
+  AGENT_MAILBOX_SCHEMA_VERSION,
+  isAgentMailboxMessage,
+  isAgentMailboxParticipantRef,
+  isAgentTeamId,
+  isSafeAgentMailboxToken,
+  normalizeAgentMailboxContent,
+  type AgentMailboxListOptions,
+  type AgentMailboxMessage,
+  type AgentMailboxSendInput,
+  type AgentMailboxStore,
+} from '@maka/core/agent-mailbox';
+import { assertSafeSessionId } from './session-store.js';
+import { chainWrite } from './write-queue.js';
+
+export interface AgentMailboxStoreDeps {
+  newId?: () => string;
+  now?: () => number;
+}
+
+export function createAgentMailboxStore(
+  workspaceRoot: string,
+  deps: AgentMailboxStoreDeps = {},
+): AgentMailboxStore {
+  return new FileAgentMailboxStore(workspaceRoot, deps);
+}
+
+class FileAgentMailboxStore implements AgentMailboxStore {
+  private readonly sessionsRoot: string;
+  private readonly writeQueues = new Map<string, Promise<void>>();
+  private readonly newId: () => string;
+  private readonly now: () => number;
+
+  constructor(workspaceRoot: string, deps: AgentMailboxStoreDeps) {
+    this.sessionsRoot = join(workspaceRoot, 'sessions');
+    this.newId = deps.newId ?? randomUUID;
+    this.now = deps.now ?? Date.now;
+  }
+
+  async send(
+    sessionId: string,
+    input: AgentMailboxSendInput,
+  ): Promise<{ message: AgentMailboxMessage; total: number }> {
+    assertSafeSessionId(sessionId);
+    validateSendInput(input);
+    const normalized = normalizeAgentMailboxContent(input.content);
+    if (!normalized.ok) throw new Error(normalized.message);
+
+    let message: AgentMailboxMessage | undefined;
+    let total = 0;
+    await chainWrite(this.writeQueues, sessionId, async () => {
+      const messages = await this.readAll(sessionId);
+      const scope = messages.filter((candidate) =>
+        candidate.teamId === input.teamId && candidate.parentRunId === input.parentRunId
+      );
+      if (scope.length >= AGENT_MAILBOX_MAX_MESSAGES_PER_TEAM_RUN) {
+        throw new Error(
+          `Agent mailbox is limited to ${AGENT_MAILBOX_MAX_MESSAGES_PER_TEAM_RUN} messages per team run`,
+        );
+      }
+      const seq = scope.reduce((max, candidate) => Math.max(max, candidate.seq), 0) + 1;
+      const id = this.newId();
+      if (messages.some((candidate) => candidate.id === id)) {
+        throw new Error('Generated agent mailbox message id already exists');
+      }
+      message = {
+        schemaVersion: AGENT_MAILBOX_SCHEMA_VERSION,
+        id,
+        sessionId,
+        teamId: input.teamId,
+        parentRunId: input.parentRunId,
+        seq,
+        kind: input.kind,
+        from: input.from,
+        ...(input.to ? { to: input.to } : {}),
+        content: normalized.value,
+        createdAt: this.now(),
+      };
+      if (!isAgentMailboxMessage(message)) throw new Error('Generated agent mailbox message is invalid');
+      const path = this.filePath(sessionId);
+      await mkdir(dirname(path), { recursive: true });
+      await appendFile(path, `${JSON.stringify(message)}\n`, 'utf8');
+      total = scope.length + 1;
+    });
+    if (!message) throw new Error('Agent mailbox write did not produce a message');
+    return { message, total };
+  }
+
+  async list(
+    sessionId: string,
+    options: AgentMailboxListOptions,
+  ): Promise<{ messages: AgentMailboxMessage[]; nextSeq: number; total: number }> {
+    assertSafeSessionId(sessionId);
+    validateListOptions(options);
+    const afterSeq = options.afterSeq ?? 0;
+    const limit = options.limit ?? AGENT_MAILBOX_LIST_MAX;
+    const addressed = (await this.readAll(sessionId)).filter((message) =>
+      message.teamId === options.teamId
+      && message.parentRunId === options.parentRunId
+      && (
+        (message.kind === 'message' && message.to?.agentId === options.recipientAgentId)
+        || (message.kind === 'broadcast' && message.from.agentId !== options.recipientAgentId)
+      )
+    );
+    const messages = addressed.filter((message) => message.seq > afterSeq).slice(0, limit);
+    return {
+      messages,
+      nextSeq: messages.at(-1)?.seq ?? afterSeq,
+      total: addressed.length,
+    };
+  }
+
+  private filePath(sessionId: string): string {
+    return join(this.sessionsRoot, sessionId, 'agent-mailbox.jsonl');
+  }
+
+  private async readAll(sessionId: string): Promise<AgentMailboxMessage[]> {
+    let text: string;
+    try {
+      text = await readFile(this.filePath(sessionId), 'utf8');
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') return [];
+      throw error;
+    }
+    const messages: AgentMailboxMessage[] = [];
+    const seenMessageIds = new Set<string>();
+    const lastSeqByScope = new Map<string, number>();
+    for (const [index, line] of text.split(/\n/).entries()) {
+      if (line.trim().length === 0) continue;
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(line);
+      } catch (error) {
+        throw new Error(`Invalid agent mailbox JSONL line ${index + 1}: ${String(error)}`);
+      }
+      if (!isAgentMailboxMessage(parsed) || parsed.sessionId !== sessionId) {
+        throw new Error(`Invalid agent mailbox JSONL line ${index + 1}: unexpected message shape`);
+      }
+      if (seenMessageIds.has(parsed.id)) {
+        throw new Error(`Invalid agent mailbox JSONL line ${index + 1}: duplicate message id`);
+      }
+      seenMessageIds.add(parsed.id);
+      const scope = `${parsed.teamId}\u0000${parsed.parentRunId}`;
+      const prior = lastSeqByScope.get(scope) ?? 0;
+      if (parsed.seq <= prior) {
+        throw new Error(`Invalid agent mailbox JSONL line ${index + 1}: non-monotonic sequence`);
+      }
+      lastSeqByScope.set(scope, parsed.seq);
+      messages.push(parsed);
+    }
+    return messages;
+  }
+}
+
+function validateSendInput(input: AgentMailboxSendInput): void {
+  if (!isAgentTeamId(input.teamId)) throw new Error('Invalid agent team id');
+  if (!isSafeAgentMailboxToken(input.parentRunId)) throw new Error('Invalid parent AgentRun id');
+  if (!isAgentMailboxParticipantRef(input.from)) throw new Error('Invalid agent mailbox sender');
+  if (input.from.role === 'lead' && input.from.runId !== input.parentRunId) {
+    throw new Error('Lead mailbox messages must be scoped to the lead AgentRun');
+  }
+  if (input.kind === 'broadcast') {
+    if (input.to !== undefined) throw new Error('Broadcast messages cannot have a direct recipient');
+    return;
+  }
+  if (
+    input.kind !== 'message'
+    || !input.to
+    || (input.to.role !== 'lead' && input.to.role !== 'member')
+    || !isSafeAgentMailboxToken(input.to.agentId)
+  ) throw new Error('Direct agent mailbox messages require a valid recipient');
+  if (input.to.agentId === input.from.agentId) throw new Error('Agent mailbox messages cannot target the sender');
+}
+
+function validateListOptions(options: AgentMailboxListOptions): void {
+  if (!isAgentTeamId(options.teamId)) throw new Error('Invalid agent team id');
+  if (!isSafeAgentMailboxToken(options.parentRunId)) throw new Error('Invalid parent AgentRun id');
+  if (!isSafeAgentMailboxToken(options.recipientAgentId)) throw new Error('Invalid recipient agent id');
+  if (options.afterSeq !== undefined && (!Number.isSafeInteger(options.afterSeq) || options.afterSeq < 0)) {
+    throw new Error('afterSeq must be a non-negative safe integer');
+  }
+  if (options.limit !== undefined && (!Number.isSafeInteger(options.limit) || options.limit < 1 || options.limit > AGENT_MAILBOX_LIST_MAX)) {
+    throw new Error(`Agent mailbox list limit must be between 1 and ${AGENT_MAILBOX_LIST_MAX}`);
+  }
+}

--- a/packages/storage/src/index.ts
+++ b/packages/storage/src/index.ts
@@ -21,5 +21,6 @@ export * from './telemetry-repo.js';
 export * from './artifact-store.js';
 export * from './plan-reminder-store.js';
 export * from './task-ledger-store.js';
+export * from './agent-mailbox-store.js';
 export * from './config-transfer.js';
 export * from './automation-store.js';

--- a/packages/storage/src/task-ledger-store.ts
+++ b/packages/storage/src/task-ledger-store.ts
@@ -23,6 +23,7 @@ import {
   classifyTaskResumeTrust,
   type Task,
   type TaskAgentOutcome,
+  type TaskAvailableClaimScope,
   type TaskLedgerChangedEvent,
   type TaskLedgerEvent,
   type TaskLedgerEventTaskSnapshot,
@@ -216,6 +217,62 @@ class FileTaskLedgerStore implements TaskLedgerStore {
       updated = clearStaleTaskEvidence({ ...current, status: 'in_progress', owner, updatedAt: Date.now() });
       return tasks.map((task) => task.id === current.id ? updated! : task);
     }, () => previous && updated ? [buildTaskLedgerEvent({
+      type: taskLedgerEventTypeForUpdate(previous, updated), sessionId, task: updated, previous, context,
+    })] : []);
+    if (!updated) throw new Error(`No such task: ${id}`);
+    return { updated, total: all.length };
+  }
+
+  async claimAvailable(
+    sessionId: string,
+    id: string,
+    owner: TaskOwner,
+    scope: TaskAvailableClaimScope,
+    context: TaskLedgerMutationContext = {},
+  ): Promise<{ updated: Task; total: number }> {
+    assertSafeSessionId(sessionId);
+    assertChildTaskOwner(owner);
+    if (!isSafeTaskId(scope.parentRunId)) throw new Error('Available task claim requires a stable parent AgentRun id');
+    let updated: Task | undefined;
+    let previous: Task | undefined;
+    const all = await this.mutate(sessionId, (tasks) => {
+      const current = findTaskByRef(tasks, id);
+      if (!current) throw new Error(`No such task: ${id}`);
+      if (isTerminalTaskStatus(current.status)) throw new Error(`Cannot claim terminal task ${current.key}`);
+
+      const alreadyClaimed = tasks.find((task) =>
+        task.id !== current.id
+        && !isTerminalTaskStatus(task.status)
+        && task.owner?.actor === 'child_agent'
+        && task.owner.turnId === owner.turnId
+      );
+      if (alreadyClaimed) {
+        throw new Error(`Child agent already owns task ${alreadyClaimed.key}; one shared task may be claimed per child turn`);
+      }
+
+      const sameOwner = current.owner?.actor === 'child_agent'
+        && current.owner.turnId === owner.turnId;
+      if (
+        !sameOwner
+        && (current.owner?.actor !== 'main_agent' || current.owner.runId !== scope.parentRunId)
+      ) {
+        throw new Error(`Task ${current.key} is not shared by parent run ${scope.parentRunId}`);
+      }
+      if (current.status === 'in_progress' && !sameOwner) {
+        throw new Error(`Task ${current.key} is already in progress and is not available for self-claim`);
+      }
+      if (current.owner?.actor === 'child_agent' && !sameOwner) {
+        throw new Error(`Task ${current.key} is already claimed by another child agent`);
+      }
+
+      previous = current;
+      updated = sameOwner && current.status === 'in_progress'
+        ? current
+        : clearStaleTaskEvidence({ ...current, status: 'in_progress', owner, updatedAt: Date.now() });
+      return updated === current
+        ? tasks
+        : tasks.map((task) => task.id === current.id ? updated! : task);
+    }, () => previous && updated && previous !== updated ? [buildTaskLedgerEvent({
       type: taskLedgerEventTypeForUpdate(previous, updated), sessionId, task: updated, previous, context,
     })] : []);
     if (!updated) throw new Error(`No such task: ${id}`);


### PR DESCRIPTION
## Summary

This adds the first backend-only collaboration slice for Maka expert teams, building on the existing expert fan-out/fan-in runtime and Task Ledger ownership model.

- add a durable, append-only mailbox scoped by session, team, and parent lead AgentRun
- support bounded role-addressed direct messages and broadcasts with trusted sender AgentRun/Turn attribution
- expose trusted-context `team_message` / `team_inbox` tools to leads and members
- let child agents discover tasks owned by the current lead run and atomically claim one available Task Ledger item
- settle claimed task evidence across success, failure, cancellation, waiting-permission, timeout, and startup-error paths without auto-completing successful work
- document replay/restart boundaries and wire one shared mailbox/task ledger through the desktop runtime

## Safety and ownership semantics

- The parent/lead remains the final adjudicator; child messages and successful results are evidence, not completion authority.
- A child cannot steal an in-progress task, claim work from another lead run, or claim more than one task per child turn.
- Agent/team/run identity comes from trusted runtime context rather than model-controlled arguments.
- Direct recipients are stable role addresses within one parent lead run. Repeated or concurrent invocations of the same member share that role mailbox, while each caller owns its `after_seq` cursor.
- Mailbox histories fail closed on corruption, non-monotonic cursors, duplicate message IDs, invalid identities, or lead attribution outside the parent run.
- This PR does not add invocation-private inboxes, renderer UI, automatic message wakeups, remote/cross-machine workers, marketplace behavior, or worktree writes.

## Verification

- `npm run build:test`
- `npm run lint`
- `npm run typecheck`
- `npm run test:dist` — all workspace tests passed
- focused core/runtime/storage mailbox and team-tool tests — 16 passed

Related to #544.

Builds on the expert dispatch work in #971 and Task Ledger child ownership/review semantics in #956; it does not duplicate those slices.
