### PR TITLE
fix desktop titlebar control colors

### DIFF
--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -468,8 +468,8 @@ declare global {
         setTitlebarControlsVisible(visible: boolean): Promise<void>;
         setThemeSource(themePref: ThemePreference): Promise<void>;
         // PR-WINDOW-TITLEBAR-0: re-sync the native Windows titleBarOverlay
-        // color/symbolColor to the current app theme. No-op on non-Windows.
-        setTitleBarOverlayTheme(isDark: boolean): Promise<void>;
+        // color/symbolColor to the resolved app surface. No-op on non-Windows.
+        setTitleBarOverlayTheme(theme: { isDark: boolean; backgroundColor: string }): Promise<void>;
         // PR-SHOW-AFTER-FIRST-COMMIT: signal main after the first React commit
         // so the hidden window is revealed (see main-window.ts).
         notifyRendererReady(): Promise<void>;

--- a/apps/desktop/src/main/__tests__/theme-source.test.ts
+++ b/apps/desktop/src/main/__tests__/theme-source.test.ts
@@ -19,6 +19,7 @@ import { isThemePreference, toNativeThemeSource } from '../theme-source.js';
 const REPO_ROOT = resolve(import.meta.dirname, '../../../../..');
 const MAIN_TS = resolve(REPO_ROOT, 'apps/desktop/src/main/main.ts');
 const MAIN_WINDOW_TS = resolve(REPO_ROOT, 'apps/desktop/src/main/main-window.ts');
+const RENDERER_THEME_TS = resolve(REPO_ROOT, 'apps/desktop/src/renderer/theme.ts');
 
 describe('theme-source', () => {
   describe('toNativeThemeSource', () => {
@@ -86,7 +87,7 @@ describe('theme-source', () => {
 
       assert.match(
         src,
-        /const titleBarOverlayOptions = \(isDark: boolean\): \{ color: string; symbolColor: string; height: number \} => \(\{[\s\S]*height: TITLEBAR_OVERLAY_HEIGHT,[\s\S]*\}\);/,
+        /const titleBarOverlayOptions = \([\s\S]*?isDark: boolean,[\s\S]*?color = isDark \? '#1c1d21' : '#ffffff',[\s\S]*?\): \{ color: string; symbolColor: string; height: number \} => \(\{[\s\S]*height: TITLEBAR_OVERLAY_HEIGHT,[\s\S]*\}\);/,
         'one helper should include color, symbolColor, and height',
       );
       assert.match(
@@ -95,15 +96,34 @@ describe('theme-source', () => {
         'window creation should use the shared titleBarOverlay options helper',
       );
 
-      const methodMatch = src.match(/setTitleBarOverlayTheme\(sender, isDark\) \{([\s\S]*?)\n {4}\},/);
+      const methodMatch = src.match(/setTitleBarOverlayTheme\(sender, theme\) \{([\s\S]*?)\n {4}\},/);
       assert.ok(methodMatch, 'setTitleBarOverlayTheme method must exist on the controller');
       const body = methodMatch![1];
       assert.match(body, /target !== mainWindow/, 'must reject senders that are not the tracked main window');
-      assert.match(body, /typeof isDark !== 'boolean'/, 'must reject non-boolean theme values');
+      assert.match(body, /isTitleBarOverlayTheme\(theme\)/, 'must validate the renderer-provided theme payload');
       assert.match(
         body,
-        /mainWindow\.setTitleBarOverlay\(titleBarOverlayOptions\(isDark\)\)/,
-        'runtime theme sync should preserve the same overlay height as window creation',
+        /mainWindow\.setTitleBarOverlay\(titleBarOverlayOptions\(theme\.isDark, theme\.backgroundColor\)\)/,
+        'runtime theme sync should preserve the height and use the renderer surface color',
+      );
+    });
+
+    it('samples the resolved renderer background again after light/dark and palette changes', async () => {
+      const src = await readFile(RENDERER_THEME_TS, 'utf8');
+      assert.match(
+        src,
+        /getComputedStyle\(root\)\.getPropertyValue\('--background'\)/,
+        'the native controls should use the actual rendered content-surface color',
+      );
+      assert.match(
+        src,
+        /function setDarkClass[\s\S]*?syncTitleBarOverlay\(root\);/,
+        'light/dark changes should update the native controls',
+      );
+      assert.match(
+        src,
+        /function applyThemePalette[\s\S]*?syncTitleBarOverlay\(root\);/,
+        'palette changes should update the native controls',
       );
     });
 
@@ -111,7 +131,7 @@ describe('theme-source', () => {
       const src = await readFile(MAIN_TS, 'utf8');
       assert.match(
         src,
-        /ipcMain\.handle\('window:setTitleBarOverlayTheme', \(event, isDark: unknown\): void => \{\s*mainWindowController\.setTitleBarOverlayTheme\(event\.sender, isDark\);\s*\}\);/,
+        /ipcMain\.handle\('window:setTitleBarOverlayTheme', \(event, theme: unknown\): void => \{\s*mainWindowController\.setTitleBarOverlayTheme\(event\.sender, theme\);\s*\}\);/,
         'the IPC handler should let main-window.ts validate both sender and payload',
       );
     });

--- a/apps/desktop/src/main/main-window.ts
+++ b/apps/desktop/src/main/main-window.ts
@@ -23,7 +23,7 @@ export interface MainWindowController {
   notifyRendererReady(): void;
   setTitlebarControlsVisible(sender: Electron.WebContents, visible: unknown): void;
   setThemeSource(sender: Electron.WebContents, themePref: unknown): void;
-  setTitleBarOverlayTheme(sender: Electron.WebContents, isDark: unknown): void;
+  setTitleBarOverlayTheme(sender: Electron.WebContents, theme: unknown): void;
   showOpenDialog(options: Electron.OpenDialogOptions): Promise<Electron.OpenDialogReturnValue>;
   showSaveDialog(options: Electron.SaveDialogOptions): Promise<Electron.SaveDialogReturnValue>;
   capturePage(): Promise<Electron.NativeImage | null>;
@@ -84,11 +84,19 @@ const SHOW_FALLBACK_TIMEOUT_MS = 4000;
 // renderer `--h-titlebar: 36px` token so the native control strip and the
 // in-app top chrome share a baseline. The overlay color/symbolColor are
 // reused both at window creation (to avoid a first-frame flash against the
-// window `backgroundColor`) and on runtime theme changes via
+// window `backgroundColor`) and on runtime mode/palette changes via
 // `setTitleBarOverlayTheme`.
 const TITLEBAR_OVERLAY_HEIGHT = 36;
-const titleBarOverlayOptions = (isDark: boolean): { color: string; symbolColor: string; height: number } => ({
-  color: isDark ? '#1c1d21' : '#f3f3f5',
+const titleBarOverlayOptions = (
+  isDark: boolean,
+  color = isDark ? '#1c1d21' : '#ffffff',
+): { color: string; symbolColor: string; height: number } => ({
+  // The light overlay color must match the renderer's `--background`
+  // (maka-tokens.css :root, oklch(1 0 0) == #ffffff) so the top-right
+  // action buttons sit on the same surface as the OS-drawn window control
+  // strip — otherwise a visible color seam splits the titlebar. The dark
+  // value mirrors the dark-mode `--background` anchor.
+  color,
   symbolColor: isDark ? '#e6e6e8' : '#1c1d21',
   height: TITLEBAR_OVERLAY_HEIGHT,
 });
@@ -164,7 +172,7 @@ export function createMainWindowController(deps: MainWindowControllerDeps): Main
     const isDark =
       themePref === 'dark' ||
       (themePref === 'auto' && nativeTheme.shouldUseDarkColors);
-    const initialBg = isDark ? '#1c1d21' : '#f3f3f5';
+    const initialBg = isDark ? '#1c1d21' : '#ffffff';
     // Astro-Han review (#493): sync nativeTheme here too, not only via the
     // renderer's later setThemeSource() IPC call -- otherwise the vibrancy
     // material behind the sidebar can still flash the *system* theme's tint
@@ -405,11 +413,11 @@ export function createMainWindowController(deps: MainWindowControllerDeps): Main
       if (!isThemePreference(themePref)) return;
       nativeTheme.themeSource = toNativeThemeSource(themePref);
     },
-    setTitleBarOverlayTheme(sender, isDark) {
+    setTitleBarOverlayTheme(sender, theme) {
       const target = BrowserWindow.fromWebContents(sender);
       if (!target || target !== mainWindow || process.platform !== 'win32') return;
-      if (typeof isDark !== 'boolean') return;
-      mainWindow.setTitleBarOverlay(titleBarOverlayOptions(isDark));
+      if (!isTitleBarOverlayTheme(theme)) return;
+      mainWindow.setTitleBarOverlay(titleBarOverlayOptions(theme.isDark, theme.backgroundColor));
     },
     showOpenDialog(options) {
       return mainWindow
@@ -442,6 +450,16 @@ export function createMainWindowController(deps: MainWindowControllerDeps): Main
       return !!mainWindow && !mainWindow.isDestroyed() && mainWindow.isFocused();
     },
   };
+}
+
+function isTitleBarOverlayTheme(value: unknown): value is { isDark: boolean; backgroundColor: string } {
+  if (!value || typeof value !== 'object') return false;
+  const candidate = value as { isDark?: unknown; backgroundColor?: unknown };
+  return (
+    typeof candidate.isDark === 'boolean' &&
+    typeof candidate.backgroundColor === 'string' &&
+    /^#[0-9a-f]{6}$/i.test(candidate.backgroundColor)
+  );
 }
 
 /**

--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -1197,10 +1197,9 @@ function registerIpc(): void {
     mainWindowController.setThemeSource(event.sender, themePref);
   });
   // PR-WINDOW-TITLEBAR-0: re-sync the native titleBarOverlay color when the
-  // renderer resolves a new light/dark theme (user toggle or `auto` following
-  // the system). No-op outside Windows.
-  ipcMain.handle('window:setTitleBarOverlayTheme', (event, isDark: unknown): void => {
-    mainWindowController.setTitleBarOverlayTheme(event.sender, isDark);
+  // renderer resolves a new light/dark mode or palette. No-op outside Windows.
+  ipcMain.handle('window:setTitleBarOverlayTheme', (event, theme: unknown): void => {
+    mainWindowController.setTitleBarOverlayTheme(event.sender, theme);
   });
   ipcMain.handle('app:info', async () => {
     const projectPath = await currentProjectRoot();

--- a/apps/desktop/src/preload/preload.ts
+++ b/apps/desktop/src/preload/preload.ts
@@ -838,9 +838,9 @@ contextBridge.exposeInMainWorld('maka', {
       return ipcRenderer.invoke('window:setThemeSource', themePref);
     },
     // PR-WINDOW-TITLEBAR-0: re-sync the native Windows titleBarOverlay
-    // color/symbolColor to the current app theme. No-op on non-Windows.
-    setTitleBarOverlayTheme(isDark: boolean): Promise<void> {
-      return ipcRenderer.invoke('window:setTitleBarOverlayTheme', isDark);
+    // color/symbolColor to the resolved app surface. No-op on non-Windows.
+    setTitleBarOverlayTheme(theme: { isDark: boolean; backgroundColor: string }): Promise<void> {
+      return ipcRenderer.invoke('window:setTitleBarOverlayTheme', theme);
     },
     // PR-SHOW-AFTER-FIRST-COMMIT: tell main the renderer finished its first
     // React commit so the hidden window can be revealed. Fire-and-forget.

--- a/apps/desktop/src/renderer/theme.ts
+++ b/apps/desktop/src/renderer/theme.ts
@@ -56,12 +56,7 @@ function setDarkClass(isDark: boolean): void {
   // Lets native form controls and scrollbars pick up the right base colors per
   // the Vercel Web Interface Guidelines dark-mode rule.
   root.style.colorScheme = isDark ? 'dark' : 'light';
-  // PR-WINDOW-TITLEBAR-0: keep the native Windows titleBarOverlay color in
-  // sync with the resolved theme. The IPC handler is a no-op on non-Windows,
-  // and `window.maka` is only defined in the Electron renderer, so guard for
-  // both. Swallowed errors (window torn down mid-toggle, etc.) never block
-  // the in-app `.dark` toggle above.
-  void window.maka?.appWindow?.setTitleBarOverlayTheme?.(isDark).catch(() => {});
+  syncTitleBarOverlay(root);
 }
 
 /**
@@ -81,4 +76,41 @@ export function applyThemePalette(palette: ThemePalette): void {
     root.setAttribute('data-maka-theme', palette);
   }
   safeLocalStorageSet('maka-theme-palette-v1', palette);
+  // Palette variants override --background independently of light/dark mode.
+  // Re-sync after changing the attribute so the native Windows controls never
+  // retain the previous palette's titlebar color.
+  syncTitleBarOverlay(root);
+}
+
+function syncTitleBarOverlay(root: HTMLElement): void {
+  // The native Windows overlay sits on top of the renderer's content surface.
+  // Sample the actual resolved --background color instead of approximating it
+  // with one hard-coded light and dark pair; this also follows every palette.
+  const backgroundColor = cssColorToHex(
+    getComputedStyle(root).getPropertyValue('--background'),
+    root.classList.contains(DARK_CLASS) ? '#1c1d21' : '#ffffff',
+  );
+  void window.maka?.appWindow
+    ?.setTitleBarOverlayTheme?.({
+      isDark: root.classList.contains(DARK_CLASS),
+      backgroundColor,
+    })
+    .catch(() => {});
+}
+
+function cssColorToHex(value: string, fallback: string): string {
+  const color = value.trim();
+  if (!color || !CSS.supports('color', color)) return fallback;
+
+  const canvas = document.createElement('canvas');
+  canvas.width = 1;
+  canvas.height = 1;
+  const context = canvas.getContext('2d', { willReadFrequently: true });
+  if (!context) return fallback;
+
+  context.fillStyle = color;
+  context.fillRect(0, 0, 1, 1);
+  const [red, green, blue, alpha] = context.getImageData(0, 0, 1, 1).data;
+  if (alpha !== 255) return fallback;
+  return `#${[red, green, blue].map((channel) => channel.toString(16).padStart(2, '0')).join('')}`;
 }


### PR DESCRIPTION
## Summary

- make the native Windows titlebar controls use the renderer's resolved `--background` color
- re-sync the overlay after both light/dark mode and palette changes
- validate the renderer-provided color payload before applying it in the main process

## Why

The Window Controls Overlay used one hard-coded light color and one hard-coded dark color. That could differ from the actual window-bar surface, especially after selecting a non-default palette, leaving a visible color seam around the top-right minimize, maximize, and close buttons.

## Impact

The native window-control strip now stays visually continuous with the app titlebar across the default theme, dark mode, automatic system-theme changes, and custom palettes.

## Validation

- `npm --workspace @maka/desktop run build:main`
- `npx tsc -p apps/desktop/tsconfig.renderer.json --noEmit`
- `node --test apps/desktop/dist/main/__tests__/theme-source.test.js` (10 passing)
- `npx biome check` on the six changed files
- `git diff --check`
