### PR TITLE
fix(runtime): preserve Read alternatives in provider schema

### DIFF
--- a/packages/runtime/src/__tests__/builtin-tools.test.ts
+++ b/packages/runtime/src/__tests__/builtin-tools.test.ts
@@ -640,19 +640,25 @@ describe('builtin Bash streaming output', () => {
     } satisfies RuntimeResourceReader;
     const read = buildBuiltinTools({ runtimeResources }).find((tool) => tool.name === 'Read');
     if (!read) throw new Error('Read tool missing');
-    const parameters = read.parameters as z.ZodTypeAny;
-    expect(zodSchema(parameters).jsonSchema.type).toBe('object');
-    expect(parameters.safeParse({ path: 'README.md', offset: 2, limit: 10 }).success).toBe(true);
-    expect(parameters.safeParse({ ref: 'maka://runtime/background-tasks/shell-run-1' }).success).toBe(true);
-    expect(parameters.safeParse({}).success).toBe(false);
-    expect(parameters.safeParse({
+    const parameters = read.parameters as {
+      jsonSchema: PromiseLike<Record<string, unknown>> | Record<string, unknown>;
+      validate(value: unknown): PromiseLike<{ success: boolean }> | { success: boolean };
+    };
+    const providerSchema = await parameters.jsonSchema;
+    expect(providerSchema.type).toBe('object');
+    expect(Array.isArray(providerSchema.anyOf)).toBe(true);
+    expect((providerSchema.anyOf as unknown[]).length).toBe(2);
+    expect((await parameters.validate({ path: 'README.md', offset: 2, limit: 10 })).success).toBe(true);
+    expect((await parameters.validate({ ref: 'maka://runtime/background-tasks/shell-run-1' })).success).toBe(true);
+    expect((await parameters.validate({})).success).toBe(false);
+    expect((await parameters.validate({
       ref: 'maka://runtime/background-tasks/shell-run-1',
       offset: 2,
-    }).success).toBe(false);
-    expect(parameters.safeParse({
+    })).success).toBe(false);
+    expect((await parameters.validate({
       path: 'README.md',
       ref: 'maka://runtime/background-tasks/shell-run-1',
-    }).success).toBe(false);
+    })).success).toBe(false);
     const context = {
       sessionId: 'session-1',
       runId: 'run-1',

--- a/packages/runtime/src/builtin-tools.ts
+++ b/packages/runtime/src/builtin-tools.ts
@@ -6,6 +6,7 @@
 // Bash / Write / Edit go through PermissionEngine.
 
 import { z } from 'zod';
+import { jsonSchema, zodSchema } from 'ai';
 import { realpathSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { isAbsolute } from 'node:path';
@@ -106,13 +107,24 @@ export function buildBuiltinTools(options: BuildBuiltinToolsOptions = {}): MakaT
   const runtimeResourceReadParameters = z.object({
     ref: z.string().describe('A runtime resource ref returned by another tool'),
   }).strict();
+  const strictReadParameters = z.union([fileReadParameters, runtimeResourceReadParameters])
+    .describe('Read a file with path, or a whole runtime resource with ref; provide exactly one');
+  const strictReadProviderSchema = zodSchema(strictReadParameters);
   const readParameters = options.runtimeResources
-    ? z.object({
-        ...fileReadParameters.shape,
-        ...runtimeResourceReadParameters.shape,
-      }).partial().strict()
-        .describe('Read a file with path, or a whole runtime resource with ref; provide exactly one')
-        .pipe(z.union([fileReadParameters, runtimeResourceReadParameters]))
+    ? jsonSchema(
+        async () => ({
+          ...await strictReadProviderSchema.jsonSchema,
+          type: 'object',
+        }),
+        {
+          validate: async (value) => {
+            const result = await strictReadParameters.safeParseAsync(value);
+            return result.success
+              ? { success: true, value: result.data }
+              : { success: false, error: result.error };
+          },
+        },
+      )
     : fileReadParameters;
   const shell = options.shell ?? defaultShellPlan();
   const sandboxPlatform = options.sandboxPlatform ?? process.platform;


### PR DESCRIPTION
## Summary

`Read` accepts exactly one of two input forms:

- `{ path, offset?, limit? }` for files
- `{ ref }` for runtime resources

The runtime validator already enforced this contract, but the provider-facing JSON Schema exposed `path`, `offset`, `limit`, and `ref` as four unrelated optional properties. Some models therefore generated file placeholders alongside `ref`, producing calls that were rejected by the stricter runtime validation.

This change keeps the strict Zod union as the canonical schema, exposes its generated alternatives to providers, and adds the root-level `type: "object"` required by stricter OpenAI-compatible providers such as DeepSeek.

The provider and runtime now receive the same effective contract without maintaining a second handwritten schema.

## Verification

- Manual Desktop test confirmed that runtime-resource reads use `{ ref }` without unrelated file arguments
- Runtime suite: 2011 passed, 7 skipped
- Root typecheck passed
- Biome lint passed for the changed files

<details>
<summary>中文</summary>

## 摘要

`Read` 只接受以下两种输入形式之一：

- 使用 `{ path, offset?, limit? }` 读取文件
- 使用 `{ ref }` 读取 runtime resource

运行时校验原本已经严格执行该契约，但 provider 可见的 JSON Schema 将 `path`、`offset`、`limit` 和 `ref` 暴露为四个彼此无关的可选属性。部分模型因此会在使用 `ref` 时同时生成文件参数占位值，随后被更严格的运行时校验拒绝。

本次修改继续以严格的 Zod union 作为唯一权威 schema，将其生成的分支约束直接暴露给 provider，并补充 DeepSeek 等严格 OpenAI-compatible provider 所要求的根级 `type: "object"`。

这样 provider 和 runtime 获得一致的有效契约，同时不需要维护第二份手写 schema。

## 验证

- Desktop 人工测试确认 runtime resource 读取只生成 `{ ref }`，不再携带无关文件参数
- Runtime 测试：2011 项通过，7 项跳过
- 根级 typecheck 通过
- 修改文件通过 Biome lint

</details>
