### PR TITLE
chore(ci): run GitHub Actions on Node 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '22'
+          node-version: '24'
           cache: npm
       - run: npm ci
       - run: npm run lint
@@ -36,7 +36,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '22'
+          node-version: '24'
           cache: npm
       - name: Install Linux runtime dependencies
         run: sudo apt-get update && sudo apt-get install -y ripgrep bubblewrap
@@ -70,7 +70,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '22'
+          node-version: '24'
           cache: npm
       - run: npm ci
       # Electron is a GUI app; on a headless Linux runner it needs a virtual

--- a/.github/workflows/oracle-evidence-audit.yml
+++ b/.github/workflows/oracle-evidence-audit.yml
@@ -29,7 +29,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '22'
+          node-version: '24'
           cache: npm
       - uses: astral-sh/setup-uv@v6
       - uses: docker/setup-buildx-action@v3
@@ -92,7 +92,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '22'
+          node-version: '24'
           cache: npm
       - uses: astral-sh/setup-uv@v6
       - uses: docker/setup-buildx-action@v3
@@ -134,7 +134,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '22'
+          node-version: '24'
           cache: npm
       - run: npm ci
       - run: npm run build:test


### PR DESCRIPTION
## Summary

Bump GitHub Actions `setup-node` from Node **22** to **24** so CI host Node matches Electron 40+ main-process Node (24.x). Desktop unit tests run under host Node via `node --test`; after the Electron 43 upgrade they otherwise exercise Node 22 while production main runs Node 24.

Refs #1118 / #1123 (Electron upgrade). Independent of that PR — safe to land before or after.

## Changes

- `.github/workflows/ci.yml` — `typecheck`, `test`, `e2e` jobs: `node-version: '24'`
- `.github/workflows/oracle-evidence-audit.yml` — all three jobs: `node-version: '24'`

No application code or package engines changes.

## Verification

- Diff is workflow-only (6 pin sites).
- Relies on Actions `setup-node` + this PR’s CI green for real validation.