### PR TITLE
refactor(ui): govern segmented chrome as maka-segmented with hover/focus states

### DIFF
--- a/apps/desktop/src/main/__tests__/daily-review-copy-feedback-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/daily-review-copy-feedback-contract.test.ts
@@ -96,7 +96,7 @@ describe('Daily Review copy feedback contract', () => {
     const panelBlock = extractFunctionBlock(ui, 'DailyReviewPanel');
 
     assert.match(panelBlock, /<UiButton[\s\S]*?variant="ghost"[\s\S]*?size="icon-sm"[\s\S]*?className="maka-daily-review-stepper"/);
-    assert.match(panelBlock, /<SettingsSegmented[\s\S]*?className="maka-daily-review-range-tabs"/);
+    assert.match(panelBlock, /<Segmented[\s\S]*?className="maka-daily-review-range-tabs"/);
     // PR3 (#527) added min-w-[Nrem] utilities to the copy/append/save buttons
     // (text-swap width lock for 复制/已复制 feedback). Match each semantic
     // class as a whole word in the class list — same form as the negative

--- a/apps/desktop/src/main/__tests__/segmented-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/segmented-contract.test.ts
@@ -1,0 +1,58 @@
+/**
+ * Segmented control chrome governance (PR #1128).
+ *
+ * The `.maka-segmented` recipe (shared by the sidebar view-mode toggle,
+ * daily-review range tabs, and the usage/appearance settings pages) has
+ * exactly one home: `styles/segmented.css`. It must keep its interaction
+ * states (the original chrome had none) and sit on the ui type tier
+ * (controls are 13px chrome per the #546 scale — the 11px caption size
+ * was a leftover from the recipe's settings-page origin). Location is
+ * asserted against the file itself, not the concatenated import graph,
+ * so the recipe cannot silently migrate into another surface file.
+ */
+
+import { strict as assert } from 'node:assert';
+import { readFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+import { describe, it } from 'node:test';
+import { readRendererContractCss } from './contract-css-helpers.js';
+import { stripCssComments } from './css-test-helpers.js';
+
+const REPO_ROOT = resolve(process.cwd(), '..', '..');
+const RENDERER = resolve(REPO_ROOT, 'apps', 'desktop', 'src', 'renderer');
+
+describe('segmented control chrome contract', () => {
+  it('owns the full recipe in styles/segmented.css, wired into the entry file', async () => {
+    const recipe = stripCssComments(await readFile(resolve(RENDERER, 'styles', 'segmented.css'), 'utf8'));
+
+    assert.match(recipe, /\.maka-segmented\s*\{[^}]*flex-wrap:\s*wrap/);
+    const buttonRule = recipe.match(/\.maka-segmented button\s*\{[^}]*\}/)?.[0] ?? '';
+    assert.match(buttonRule, /font-size:\s*var\(--font-size-ui\)/, 'controls sit on the ui tier, not caption');
+    assert.match(buttonRule, /white-space:\s*nowrap/, 'labels wrap as whole options, never inside a button');
+    assert.match(buttonRule, /transition:/);
+    assert.match(recipe, /\.maka-segmented button:enabled:hover:not\(\[data-pressed\]\)/);
+    assert.match(recipe, /\.maka-segmented button:enabled:active:not\(\[data-pressed\]\)/);
+    assert.match(recipe, /\.maka-segmented button:focus-visible/);
+    assert.match(recipe, /\.maka-segmented button\[data-pressed\]/);
+    assert.match(recipe, /\.maka-segmented button:disabled\s*\{[^}]*opacity:\s*var\(--opacity-disabled\)/);
+
+    const entry = await readFile(resolve(RENDERER, 'styles.css'), 'utf8');
+    assert.match(entry, /@import "\.\/styles\/segmented\.css";/);
+  });
+
+  it('keeps the recipe out of every other renderer stylesheet', async () => {
+    const combined = await readRendererContractCss();
+    // The full effective CSS must not resurrect the settings-scoped name.
+    assert.doesNotMatch(combined, /\.settingsSegmented/);
+
+    // No second .maka-segmented rule block outside styles/segmented.css:
+    // count rule occurrences in the combined CSS against the recipe file.
+    const recipe = stripCssComments(await readFile(resolve(RENDERER, 'styles', 'segmented.css'), 'utf8'));
+    const count = (s: string) => (s.match(/\.maka-segmented[^,{]*\{/g) ?? []).length;
+    assert.equal(
+      count(stripCssComments(combined)),
+      count(recipe),
+      'a .maka-segmented rule exists outside styles/segmented.css',
+    );
+  });
+});

--- a/apps/desktop/src/main/__tests__/session-project-view-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/session-project-view-contract.test.ts
@@ -3,6 +3,7 @@ import { readFile } from 'node:fs/promises';
 import { join, resolve } from 'node:path';
 import { describe, it } from 'node:test';
 import { deriveProjectGroups } from '../../renderer/session-project-grouping.js';
+import { readRendererContractCss } from './contract-css-helpers.js';
 import { makeSessionSummary, renderSessionListPanel } from './session-list-render-helpers.js';
 
 const REPO_ROOT = resolve(process.cwd(), '..', '..');
@@ -45,7 +46,7 @@ describe('sidebar project view mode', () => {
   });
 
   it('renders the status/project view mode controls as a pressed segmented control', () => {
-    // #571 routes the toggle through the shared SettingsSegmented primitive,
+    // #571 routes the toggle through the shared Segmented primitive,
     // whose <button> carries aria-pressed and puts the label inline (no <span>).
     const statusMarkup = renderSessionListPanel({ viewMode: 'status' });
     assert.match(statusMarkup, /<button[^>]*aria-pressed="true"[^>]*>按状态/);
@@ -54,6 +55,22 @@ describe('sidebar project view mode', () => {
     const projectMarkup = renderSessionListPanel({ viewMode: 'project' });
     assert.match(projectMarkup, /<button[^>]*aria-pressed="false"[^>]*>按状态/);
     assert.match(projectMarkup, /<button[^>]*aria-pressed="true"[^>]*>按项目/);
+  });
+
+  it('segmented chrome is governed: one shared recipe with hover/focus/pressed states', async () => {
+    // The `.maka-segmented` recipe (shared by the sidebar view-mode
+    // toggle, daily-review range tabs, and settings pages) lives in
+    // styles/segmented.css — not in a settings subpage file that other
+    // surfaces reach by cascade accident. The control must give hover
+    // and keyboard-focus feedback, which the original chrome lacked.
+    const css = await readRendererContractCss();
+    assert.match(css, /\.maka-segmented button:enabled:hover:not\(\[data-pressed\]\)/);
+    assert.match(css, /\.maka-segmented button:focus-visible/);
+    assert.match(css, /\.maka-segmented button\[data-pressed\]/);
+    assert.doesNotMatch(css, /\.settingsSegmented/);
+
+    const botCss = await readRepo('apps/desktop/src/renderer/styles/settings/bot.css');
+    assert.doesNotMatch(botCss, /\.maka-segmented\s*\{/, 'segmented recipe must not move back into a settings subpage file');
   });
 
   it('renders project groups as folder headers with an initial four-session preview', () => {

--- a/apps/desktop/src/main/__tests__/session-project-view-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/session-project-view-contract.test.ts
@@ -3,7 +3,6 @@ import { readFile } from 'node:fs/promises';
 import { join, resolve } from 'node:path';
 import { describe, it } from 'node:test';
 import { deriveProjectGroups } from '../../renderer/session-project-grouping.js';
-import { readRendererContractCss } from './contract-css-helpers.js';
 import { makeSessionSummary, renderSessionListPanel } from './session-list-render-helpers.js';
 
 const REPO_ROOT = resolve(process.cwd(), '..', '..');
@@ -55,27 +54,6 @@ describe('sidebar project view mode', () => {
     const projectMarkup = renderSessionListPanel({ viewMode: 'project' });
     assert.match(projectMarkup, /<button[^>]*aria-pressed="false"[^>]*>按状态/);
     assert.match(projectMarkup, /<button[^>]*aria-pressed="true"[^>]*>按项目/);
-  });
-
-  it('segmented chrome is governed: one shared recipe with hover/focus/pressed states', async () => {
-    // The `.maka-segmented` recipe (shared by the sidebar view-mode
-    // toggle, daily-review range tabs, and settings pages) lives in
-    // styles/segmented.css — not in a settings subpage file that other
-    // surfaces reach by cascade accident. The control must give hover
-    // and keyboard-focus feedback, which the original chrome lacked.
-    const css = await readRendererContractCss();
-    assert.match(css, /\.maka-segmented button:enabled:hover:not\(\[data-pressed\]\)/);
-    assert.match(css, /\.maka-segmented button:focus-visible/);
-    assert.match(css, /\.maka-segmented button\[data-pressed\]/);
-    assert.doesNotMatch(css, /\.settingsSegmented/);
-
-    // Type tier: an interactive control sits on the 13px ui/chrome tier,
-    // not the caption meta tier (leftover from the settings-page origin).
-    const buttonRule = css.match(/\.maka-segmented button\s*\{[^}]*\}/)?.[0] ?? '';
-    assert.match(buttonRule, /font-size:\s*var\(--font-size-ui\)/);
-
-    const botCss = await readRepo('apps/desktop/src/renderer/styles/settings/bot.css');
-    assert.doesNotMatch(botCss, /\.maka-segmented\s*\{/, 'segmented recipe must not move back into a settings subpage file');
   });
 
   it('renders project groups as folder headers with an initial four-session preview', () => {

--- a/apps/desktop/src/main/__tests__/session-project-view-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/session-project-view-contract.test.ts
@@ -69,6 +69,11 @@ describe('sidebar project view mode', () => {
     assert.match(css, /\.maka-segmented button\[data-pressed\]/);
     assert.doesNotMatch(css, /\.settingsSegmented/);
 
+    // Type tier: an interactive control sits on the 13px ui/chrome tier,
+    // not the caption meta tier (leftover from the settings-page origin).
+    const buttonRule = css.match(/\.maka-segmented button\s*\{[^}]*\}/)?.[0] ?? '';
+    assert.match(buttonRule, /font-size:\s*var\(--font-size-ui\)/);
+
     const botCss = await readRepo('apps/desktop/src/renderer/styles/settings/bot.css');
     assert.doesNotMatch(botCss, /\.maka-segmented\s*\{/, 'segmented recipe must not move back into a settings subpage file');
   });

--- a/apps/desktop/src/main/__tests__/settings-theme-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/settings-theme-contract.test.ts
@@ -74,7 +74,7 @@ describe('Settings theme page contract', () => {
     // PR round-c-choice-card-primitive + PR yuejing/settings-segmented-
     // primitive: Theme/Palette via Base UI `RadioGroup`-backed
     // `ChoiceCardGroup`; Segmented via Base UI `ToggleGroup`-backed
-    // `SettingsSegmented`. Both primitives provide arrow-key
+    // `Segmented`. Both primitives provide arrow-key
     // navigation, focus management, and roving tabindex for free, so
     // the hand-rolled `onSettingsRadioGroupKeyDown` /
     // `focusRadioValue` / `radioTabIndex` helpers are gone from
@@ -93,10 +93,9 @@ describe('Settings theme page contract', () => {
     assert.doesNotMatch(themePage, /onSettingsRadioGroupKeyDown|radioTabIndex|data-radio-value/);
     assert.doesNotMatch(themePage, /界面密度|props\.density|setDensity|onDensityChange/);
 
-    // Segmented now comes from `@maka/ui` as `SettingsSegmented`,
-    // imported aliased as `Segmented`. The local `function Segmented`
-    // declaration must be gone.
-    assert.match(src, /SettingsSegmented as Segmented/);
+    // Segmented now comes from `@maka/ui`. The local
+    // `function Segmented` declaration must be gone.
+    assert.match(src, /import \{[^}]*\bSegmented\b[^}]*\} from '@maka\/ui'/);
     assert.doesNotMatch(src, /^function Segmented</m);
   });
 

--- a/apps/desktop/src/main/__tests__/tab-spec-499-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/tab-spec-499-contract.test.ts
@@ -227,17 +227,17 @@ describe('issue #499 P0-3 tab spec contract', () => {
     );
   });
 
-  it('daily-review range uses SettingsSegmented (Base UI ToggleGroup), not hand-rolled buttons; active is neutral', async () => {
+  it('daily-review range uses Segmented (Base UI ToggleGroup), not hand-rolled buttons; active is neutral', async () => {
     // daily-review range (今日/本周/本月) switches a time-window parameter —
     // the report re-fetches for the chosen range, it is not 3 distinct views.
-    // So it is a segmented control, not tabs: SettingsSegmented (Base UI
+    // So it is a segmented control, not tabs: Segmented (Base UI
     // ToggleGroup, single-select, roving tabindex + arrow keys + data-pressed)
     // is the a11y-correct primitive, not Tabs/TabsPanel.
     const panel = await readFile(DAILY_REVIEW_PANEL_FILE, 'utf8');
     assert.match(
       panel,
-      /SettingsSegmented/,
-      'daily-review range must use SettingsSegmented (Base UI ToggleGroup), not hand-rolled buttons',
+      /Segmented/,
+      'daily-review range must use Segmented (Base UI ToggleGroup), not hand-rolled buttons',
     );
     assert.doesNotMatch(
       panel,
@@ -253,7 +253,7 @@ describe('issue #499 P0-3 tab spec contract', () => {
     assert.doesNotMatch(
       css,
       /\.maka-daily-review-range-tab\[data-active/,
-      'daily-review hand-written .maka-daily-review-range-tab[data-active] (brand --nav-active) must be removed (active is neutral via .settingsSegmented button[data-pressed])',
+      'daily-review hand-written .maka-daily-review-range-tab[data-active] (brand --nav-active) must be removed (active is neutral via .maka-segmented button[data-pressed])',
     );
   });
 });

--- a/apps/desktop/src/renderer/settings/appearance-settings-page.tsx
+++ b/apps/desktop/src/renderer/settings/appearance-settings-page.tsx
@@ -8,7 +8,7 @@ import type {
   UiLocalePreference,
   UpdateAppSettingsResult,
 } from '@maka/core';
-import { ChoiceCard, ChoiceCardGroup, Input, SettingsSegmented as Segmented, Textarea, useMountedRef, useToast } from '@maka/ui';
+import { ChoiceCard, ChoiceCardGroup, Input, Segmented, Textarea, useMountedRef, useToast } from '@maka/ui';
 import { settingsActionErrorMessage } from './settings-error-copy';
 
 const THEME_OPTIONS: Array<{ value: ThemePreference; label: string; help: string }> = [

--- a/apps/desktop/src/renderer/settings/settings-metric-card.tsx
+++ b/apps/desktop/src/renderer/settings/settings-metric-card.tsx
@@ -14,10 +14,8 @@ export function MetricCard(props: { title: string; value: string; detail?: strin
   );
 }
 
-// `Segmented` moved to `packages/ui/src/primitives/settings-segmented.tsx`
-// as `SettingsSegmented` (Base UI `ToggleGroup`-backed). Imported above
-// aliased as `Segmented` so the 3 call sites in this file are
-// byte-identical. PR yuejing/settings-segmented-primitive
+// `Segmented` lives in `packages/ui/src/primitives/segmented.tsx`
+// (Base UI `ToggleGroup`-backed). PR yuejing/settings-segmented-primitive
 // (WAWQAQ msg `f1461d30` 用库的应该用库).
 
 /**

--- a/apps/desktop/src/renderer/settings/settings-nav.ts
+++ b/apps/desktop/src/renderer/settings/settings-nav.ts
@@ -55,7 +55,7 @@ type AccountSecretProbeResult =
 // Palette, and Segmented radiogroups. Theme + Palette migrated to the
 // Base UI `RadioGroup`-backed `ChoiceCard` primitive in PR #263;
 // Segmented migrated to the Base UI `ToggleGroup`-backed
-// `SettingsSegmented` primitive in PR yuejing/settings-segmented-primitive.
+// `Segmented` primitive in PR yuejing/settings-segmented-primitive.
 // Both primitives now provide the same keyboard contract for free, so
 // these helpers are gone. The provider detail dialog also dropped its
 // hand-rolled default-model radiogroup in favor of a native enabled-model list.

--- a/apps/desktop/src/renderer/settings/usage-settings-page.tsx
+++ b/apps/desktop/src/renderer/settings/usage-settings-page.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
 import type { AppSettings, UpdateAppSettingsResult, UsageRange, UsageStats } from '@maka/core';
-import { Button, Input, SettingsSegmented as Segmented, SettingsSelect, SettingsSwitch as Switch, useMountedRef, useToast } from '@maka/ui';
+import { Button, Input, Segmented, SettingsSelect, SettingsSwitch as Switch, useMountedRef, useToast } from '@maka/ui';
 import { RefreshCcw } from '@maka/ui/icons';
 import { MetricCard } from './settings-metric-card';
 import { settingsActionErrorMessage } from './settings-error-copy';

--- a/apps/desktop/src/renderer/styles.css
+++ b/apps/desktop/src/renderer/styles.css
@@ -19,6 +19,7 @@
 @import "./styles/module-pages.css";
 @import "./styles/field-focus.css";
 @import "./styles/settings/select.css";
+@import "./styles/segmented.css";
 @import "./styles/model-switcher.css";
 @import "./styles/chat-header.css";
 @import "./styles/task-ledger.css";

--- a/apps/desktop/src/renderer/styles/segmented.css
+++ b/apps/desktop/src/renderer/styles/segmented.css
@@ -1,0 +1,56 @@
+/* Segmented — chrome for the shared `Segmented` primitive (@maka/ui,
+   Base UI ToggleGroup). One home for every consumer: the sidebar
+   view-mode toggle (按状态 / 按项目), the daily-review range tabs
+   (今日 / 本周 / 本月), and the usage + appearance settings pages.
+   Moved out of settings/bot.css, which cross-surface consumers could
+   only reach by cascade accident under a settings-scoped name. */
+
+.maka-segmented {
+  justify-self: start;
+  width: fit-content;
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-0-5);
+  border-radius: var(--radius-pill);
+  background: var(--foreground-5);
+  padding: var(--space-0-5);
+}
+
+.maka-segmented button {
+  min-height: 22px;
+  border: 0;
+  border-radius: var(--radius-pill);
+  background: transparent;
+  color: var(--foreground-secondary);
+  padding: 0 var(--space-2);
+  font-size: var(--font-size-caption);
+  font-weight: var(--font-weight-medium);
+  transition:
+    background-color var(--duration-quick) var(--ease-out-strong),
+    color var(--duration-quick) var(--ease-out-strong),
+    box-shadow var(--duration-quick) var(--ease-out-strong);
+}
+
+.maka-segmented button:enabled:hover:not([data-pressed]) {
+  background: var(--state-hover-bg);
+  color: var(--foreground);
+}
+
+.maka-segmented button:enabled:active:not([data-pressed]) {
+  background: var(--foreground-8);
+}
+
+.maka-segmented button:focus-visible {
+  outline: var(--focus-ring-width) solid var(--focus-ring);
+  outline-offset: var(--focus-ring-offset);
+}
+
+.maka-segmented button[data-pressed] {
+  background: var(--background);
+  color: var(--foreground);
+  box-shadow: 0 1px 2px oklch(from var(--foreground) l c h / 0.08);
+}
+
+.maka-segmented button:disabled {
+  opacity: var(--opacity-disabled);
+}

--- a/apps/desktop/src/renderer/styles/segmented.css
+++ b/apps/desktop/src/renderer/styles/segmented.css
@@ -10,6 +10,10 @@
   width: fit-content;
   display: inline-flex;
   align-items: center;
+  /* Narrow containers wrap whole options to the next row; labels never
+     break inside a button (nowrap below). Keeps every option reachable
+     and 22px tall at any width. */
+  flex-wrap: wrap;
   gap: var(--space-0-5);
   border-radius: var(--radius-pill);
   background: var(--foreground-5);
@@ -23,6 +27,7 @@
   background: transparent;
   color: var(--foreground-secondary);
   padding: 0 var(--space-2);
+  white-space: nowrap;
   /* ui tier, not caption: this is an interactive control, and per the
      #546 type scale controls sit on the 13px chrome tier. The caption
      size was a leftover from the recipe's settings-page origin. */

--- a/apps/desktop/src/renderer/styles/segmented.css
+++ b/apps/desktop/src/renderer/styles/segmented.css
@@ -23,7 +23,10 @@
   background: transparent;
   color: var(--foreground-secondary);
   padding: 0 var(--space-2);
-  font-size: var(--font-size-caption);
+  /* ui tier, not caption: this is an interactive control, and per the
+     #546 type scale controls sit on the 13px chrome tier. The caption
+     size was a leftover from the recipe's settings-page origin. */
+  font-size: var(--font-size-ui);
   font-weight: var(--font-weight-medium);
   transition:
     background-color var(--duration-quick) var(--ease-out-strong),

--- a/apps/desktop/src/renderer/styles/settings/bot.css
+++ b/apps/desktop/src/renderer/styles/settings/bot.css
@@ -283,10 +283,6 @@
   }
 }
 
-/* Segmented chrome moved to styles/segmented.css (`.maka-segmented`):
-   the primitive is cross-surface (sidebar, daily review, settings), so
-   its recipe no longer lives in this settings subpage file. */
-
 .settingsUsageSummary {
   display: grid;
   grid-template-columns: repeat(4, minmax(0, 1fr));

--- a/apps/desktop/src/renderer/styles/settings/bot.css
+++ b/apps/desktop/src/renderer/styles/settings/bot.css
@@ -283,32 +283,9 @@
   }
 }
 
-.settingsSegmented {
-  justify-self: start;
-  width: fit-content;
-  display: inline-flex;
-  align-items: center;
-  gap: var(--space-0-5);
-  border-radius: var(--radius-pill);
-  background: var(--foreground-5);
-  padding: var(--space-0-5);
-}
-
-.settingsSegmented button {
-  min-height: 22px;
-  border: 0;
-  border-radius: var(--radius-pill);
-  background: transparent;
-  color: var(--foreground-secondary);
-  padding: 0 var(--space-2);
-  font-size: var(--font-size-caption);
-}
-
-.settingsSegmented button[data-pressed] {
-  background: var(--background);
-  color: var(--foreground);
-  box-shadow: 0 1px 2px oklch(from var(--foreground) l c h / 0.08);
-}
+/* Segmented chrome moved to styles/segmented.css (`.maka-segmented`):
+   the primitive is cross-surface (sidebar, daily review, settings), so
+   its recipe no longer lives in this settings subpage file. */
 
 .settingsUsageSummary {
   display: grid;

--- a/apps/desktop/src/renderer/styles/sidebar.css
+++ b/apps/desktop/src/renderer/styles/sidebar.css
@@ -428,11 +428,12 @@
 
 
 /* View-mode toggle row (按状态 / 按项目) — chrome comes from the shared
-   `.settingsSegmented` primitive (same control family as the daily-review
-   range tabs); this wrapper only owns sidebar spacing. The retired
-   `.maka-view-mode-btn` family referenced tokens that never existed in
-   maka-tokens (--surface-secondary/-primary/-tertiary, --foreground-primary,
-   --shadow-sm), so its chrome rendered invisible. */
+   `.maka-segmented` recipe in styles/segmented.css (same control family
+   as the daily-review range tabs); this wrapper only owns sidebar
+   spacing. The retired `.maka-view-mode-btn` family referenced tokens
+   that never existed in maka-tokens (--surface-secondary/-primary/
+   -tertiary, --foreground-primary, --shadow-sm), so its chrome rendered
+   invisible. */
 .maka-view-mode-toggle {
   display: flex;
   padding: 0 var(--space-2) var(--space-1);

--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -19,7 +19,7 @@ Four export surfaces, in the order to look:
 
 ## `data-slot` hooks
 
-Most primitives expose a stable `data-slot="<name>"` attribute so renderer CSS can target a slot (e.g. `[data-slot="dialog-header"]`) rather than a drifting class. Exceptions without one: `choice-card`, `spinner`, `scroll-area`, `settings-segmented` — their styling lives on the consumer's class or an underlying Base UI component, so a `[data-slot="..."]` selector won't match. New primitives should still expose a `data-slot`.
+Most primitives expose a stable `data-slot="<name>"` attribute so renderer CSS can target a slot (e.g. `[data-slot="dialog-header"]`) rather than a drifting class. Exceptions without one: `choice-card`, `spinner`, `scroll-area`, `segmented` — their styling lives on the consumer's class or an underlying Base UI component, so a `[data-slot="..."]` selector won't match. New primitives should still expose a `data-slot`.
 
 ## Consuming
 

--- a/packages/ui/src/daily-review-panel.tsx
+++ b/packages/ui/src/daily-review-panel.tsx
@@ -22,7 +22,7 @@ import {
 import { Button as UiButton } from './ui.js';
 import { Item, ItemContent } from './primitives/item.js';
 import { Chip, type ChipProps } from './primitives/chip.js';
-import { SettingsSegmented } from './primitives/settings-segmented.js';
+import { Segmented } from './primitives/segmented.js';
 import { Alert, AlertAction, AlertDescription } from './primitives/alert.js';
 import { EmptyState } from './empty-state.js';
 import { StatTile } from './primitives/stat-tile.js';
@@ -294,7 +294,7 @@ export function DailyReviewPanel(props: {
           unrelated widgets. They now form ONE cluster: pick the range,
           then step through it; the stepper steps by the selected span. */}
       <header className="maka-daily-review-header">
-        <SettingsSegmented
+        <Segmented
           value={String(range)}
           options={[['1', '今日'], ['7', '本周'], ['30', '本月']]}
           onChange={(v) => {

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -67,7 +67,7 @@ export * from './primitives/stat-tile.js';
 export * from './primitives/section-header.js';
 export { EmptyState } from './empty-state.js';
 export * from './primitives/choice-card.js';
-export * from './primitives/settings-segmented.js';
+export * from './primitives/segmented.js';
 export * from './primitives/settings-select.js';
 export * from './primitives/settings-switch.js';
 export * from './primitives/input.js';

--- a/packages/ui/src/primitives/segmented.tsx
+++ b/packages/ui/src/primitives/segmented.tsx
@@ -16,11 +16,12 @@ import { cn } from "../utils.js";
  * arrow-key navigation, and `data-pressed` state for the active item
  * for free.
  *
- * Caller's `className` (legacy `.settingsSegmented`) still owns the
- * visual chrome. The primitive only contributes Base UI's behavior
- * contract, the same way `ChoiceCard` / `SettingsSelect` are layered.
+ * Visual chrome lives in the renderer's `styles/segmented.css` under
+ * `.maka-segmented` — one home for every consumer (sidebar view-mode
+ * toggle, daily-review range tabs, usage and appearance settings),
+ * the same way `ChoiceCard` / `SettingsSelect` are layered.
  */
-export interface SettingsSegmentedProps<T extends string> {
+export interface SegmentedProps<T extends string> {
   value: T;
   options: ReadonlyArray<readonly [T, string]>;
   onChange(value: T): void;
@@ -29,8 +30,8 @@ export interface SettingsSegmentedProps<T extends string> {
   className?: string;
 }
 
-export function SettingsSegmented<T extends string>(
-  props: SettingsSegmentedProps<T>,
+export function Segmented<T extends string>(
+  props: SegmentedProps<T>,
 ): ReactElement {
   return (
     <BaseToggleGroup
@@ -43,7 +44,7 @@ export function SettingsSegmented<T extends string>(
       }}
       disabled={props.disabled}
       aria-label={props.ariaLabel}
-      className={cn("settingsSegmented", props.className)}
+      className={cn("maka-segmented", props.className)}
     >
       {props.options.map(([value, label]) => (
         <BaseToggle

--- a/packages/ui/src/session-list-panel.tsx
+++ b/packages/ui/src/session-list-panel.tsx
@@ -2,7 +2,7 @@ import type { PlanReminder, SessionSummary } from '@maka/core';
 import type { NavSelection } from './nav-selection.js';
 import { SessionHistoryList, type SessionHistoryStatusGroup, type SessionRowActions } from './session-history-list.js';
 import { SessionSidebarFooter, SessionSidebarNav } from './session-sidebar-nav.js';
-import { SettingsSegmented } from './primitives/settings-segmented.js';
+import { Segmented } from './primitives/segmented.js';
 
 export type SessionViewMode = 'status' | 'project';
 
@@ -50,7 +50,7 @@ export function SessionListPanel(props: {
               daily-review range tabs. The previous hand-rolled buttons
               referenced tokens that don't exist in maka-tokens
               (--surface-secondary etc.), rendering an invisible chrome. */}
-          <SettingsSegmented
+          <Segmented
             value={viewMode}
             options={[['status', '按状态'], ['project', '按项目']]}
             onChange={(mode) => onViewModeChange(mode)}


### PR DESCRIPTION
## Summary

The segmented control (sidebar 按状态/按项目 toggle, daily-review range tabs, usage/appearance settings) had governed behavior — the shared `SettingsSegmented` primitive on Base UI `ToggleGroup` — but ungoverned chrome: the `.settingsSegmented` recipe lived in `styles/settings/bot.css`, a bot-settings subpage stylesheet that the sidebar and daily review could only reach by cascade accident, under a `settings`-scoped name. The control also gave no hover, keyboard-focus, or press feedback.

- Rename the primitive `SettingsSegmented` → `Segmented` and its emitted class to `.maka-segmented`; it stopped being settings-specific long ago (two consumers already aliased it to `Segmented`). No compatibility alias is kept.
- Re-home the recipe to `styles/segmented.css` as the single chrome owner for all four consumers.
- Redesign the interaction states on existing tokens only: hover (`--state-hover-bg`), active press (`--foreground-8`), keyboard `:focus-visible` ring (standard `--focus-ring` recipe), disabled (`--opacity-disabled`), and `--duration-quick`/`--ease-out-strong` transitions.
- Lock the governance with a contract test in `session-project-view-contract.test.ts`: the shared recipe must keep hover/focus/pressed states, `.settingsSegmented` must stay gone, and the recipe must not move back into a settings subpage file.

## Verification

- `packages/ui`: typecheck + full test suite (168 pass).
- `apps/desktop`: typecheck (main/renderer/storybook), full main test suite **2573/2573 pass** (including the pre-existing focus-ring and opacity governance contracts, which this recipe now satisfies), renderer production build, `check-dead-css` clean.
- Live-app evidence (Playwright against the built Electron app, fake backend): hovering the non-pressed option computes `background: oklch(0.17 0.005 286 / 0.04)` + full-ink text (was fully transparent/static before); keyboard ArrowRight shows the `--focus-ring` outline; pressed pill unchanged.
- Not run: full E2E suite (no spec references this control; change is CSS + rename).

<img width="1332" height="200" alt="image" src="https://github.com/user-attachments/assets/64ce43d0-f1ca-4063-9068-b963e2c3e172" />

## External review round (Codex)

An external Codex review returned no P0/P1 and three P2s; adjudication:

- **Accepted — narrow-width wrap.** At <660px window width the usage page's five-option group broke labels inside buttons (two-line 39px pills; latent on `main`, threshold moved by the ui-tier size). Fixed at the recipe owner: whole-option wrapping (`flex-wrap` + `white-space: nowrap`), verified live at 620px.
- **Accepted — contract gaps.** The chrome contract now lives in `segmented-contract.test.ts`, asserts against `styles/segmented.css` itself (location cannot drift to another imported file), and covers active/disabled/transition/nowrap in addition to hover/focus/pressed/tier.
- **Accepted — rename leftovers.** `packages/ui/README.md` data-slot exception list and a tombstone comment in `bot.css`.
- **Deferred — chrome into the `@maka/ui` primitive (Tailwind + `data-slot`).** The README's convergence direction, but it explicitly lists `segmented` among the primitives whose styling lives on the consumer's class today, alongside `choice-card`; moving one control's chrome alone would split the family convention. Tracked as a follow-up for a family-wide convergence pass.
- **Pushed back — `font-weight: medium` as out-of-scope.** Neighboring sidebar labels (session names, group labels) are medium; CJK glyph advance is weight-invariant, so no width impact on any current consumer.
