### PR TITLE
feat(desktop): retire Electron safeStorage as OAuth credential authority

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ Current boundaries that matter:
 
 - Sessions and connection metadata live in the local filesystem;
 - Runtime credentials such as API keys, bot tokens, and proxy passwords currently live in local plaintext `credentials.json`, behind the OS account boundary, with POSIX directory mode `0700` and file mode `0600` enforced;
-- Claude and Codex keep an Electron `safeStorage` desktop copy and also export a best-effort plaintext `oauth_token` copy to `credentials.json` for the pure-Node runtime; Cursor and Antigravity remain non-operational preview integrations;
+- Subscription OAuth tokens (Claude, Codex, GitHub Copilot, and the Cursor/Antigravity previews) live in the same `credentials.json` — the single authority for desktop, TUI, and headless; Electron `safeStorage` only decrypts pre-existing legacy token files once at desktop startup (#1125);
 - Renderer does not receive plaintext credentials. File writes, Shell, and dangerous tool calls pass through the permission engine;
 - Headless real-model evaluation fails closed by default and requires an explicit external isolation boundary.
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -160,7 +160,7 @@ Maka 默认把 workspace 数据放在 Electron `userData` 下：
 
 - 会话和连接元数据保存在本地文件系统；
 - API key、bot token、proxy password 等运行凭据当前保存在本地 plaintext `credentials.json`，依赖 OS 账号边界，并在 POSIX 上强制目录 `0700`、文件 `0600`；
-- Claude 和 Codex 在 Electron `safeStorage` 中保留桌面副本，同时为纯 Node runtime best-effort 导出一份 plaintext `oauth_token` 到 `credentials.json`；Cursor 和 Antigravity 仍是不可用的 preview integration；
+- 订阅 OAuth token（Claude、Codex、GitHub Copilot 以及 Cursor/Antigravity preview）统一存放在同一份 `credentials.json`，它是 desktop、TUI、headless 的唯一凭据权威；Electron `safeStorage` 仅在 desktop 启动时一次性解密迁移历史遗留 token 文件（#1125）；
 - Renderer 不接收明文凭据；文件写入、Shell 和危险工具调用需要经过 permission engine；
 - Headless real-model eval 默认 fail closed，要求调用方显式提供外部隔离边界。
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -92,12 +92,14 @@ supply their own boundary. See
    user's workspace directory. Its load-bearing boundary is the OS
    user account plus filesystem controls: directory mode 0o700,
    file mode 0o600, atomic writes, and no symlink/traversal escape.
-   Claude and Codex subscription services keep their Desktop token copy
-   behind Electron safeStorage, but also export a best-effort plaintext
-   `oauth_token` JSON copy to `credentials.json` so the pure-Node runtime
-   can use the account. That shared copy has the same OS-account and
-   0o700/0o600 boundary as other runtime credentials. Cursor and
-   Antigravity are currently non-operational preview integrations.
+   Subscription OAuth tokens (Claude, Codex, GitHub Copilot, and the
+   Cursor/Antigravity previews) live in the same store: `credentials.json`
+   is the single authority every surface — Desktop, TUI, headless —
+   reads and writes, under the same OS-account and 0o700/0o600 boundary
+   as other runtime credentials. Electron safeStorage is not part of
+   this boundary anymore; Desktop startup imports pre-existing
+   safeStorage-encrypted token files into the store once and removes
+   them (#1125).
 3. **Renderer process sandbox + preload IPC bridge.** The
    renderer cannot reach files, network, or shell directly. Every
    IPC handler in `apps/desktop/src/main/main.ts` is the trust
@@ -175,9 +177,10 @@ boundary in §2.3 was crossed. Examples:
 - `credentials.json` is written outside the workspace credential
   path, through a symlink/traversal escape, or with POSIX permissions
   looser than the 0o700/0o600 boundary.
-- safeStorage encryption is bypassed for a Desktop subscription-token
-  store that is implemented to require safeStorage. The documented
-  plaintext CLI shared copy is not such a bypass.
+- A production OAuth path writes or requires a safeStorage-encrypted
+  token copy again. `credentials.json` is the single documented token
+  authority; safeStorage exists only inside the one-shot legacy import
+  (#1125).
 - A cleartext secret crosses main→renderer IPC under any
   circumstance (including error paths, settings preview, IPC
   result envelopes, log lines).

--- a/apps/desktop/src/main/__tests__/antigravity-subscription-service.test.ts
+++ b/apps/desktop/src/main/__tests__/antigravity-subscription-service.test.ts
@@ -12,7 +12,7 @@
  *
  * The tests import from `antigravity-subscription-helpers.ts`
  * directly so they don't pull in the `electron` ESM module —
- * the service class file imports `safeStorage` from electron,
+ * the service class file imports `shell` from electron,
  * which is unavailable under plain `node --test`.
  */
 
@@ -126,15 +126,18 @@ describe('Antigravity service source-grep contract', () => {
     );
   });
 
-  it('declares the safeStorage-encrypted token path under userData', async () => {
+  it('persists tokens through the shared credential store, not safeStorage (#1125)', async () => {
     const src = await readFile(SERVICE_SOURCE, 'utf8');
     assert.match(
       src,
-      /\.antigravity_subscription_token/,
-      'token file path must mirror the Claude / Codex pattern',
+      /saveSharedOAuthTokens\(this\.credentialStore, 'antigravity-subscription'/,
+      'tokens must be written to the shared CredentialStore (the cross-surface authority)',
     );
-    assert.match(src, /safeStorage\.encryptString/, 'tokens must be encrypted via safeStorage');
-    assert.match(src, /mode:\s*0o600/, 'persisted token file must be written with mode 0o600');
+    assert.doesNotMatch(
+      src,
+      /encryptString|decryptString|isEncryptionAvailable/,
+      'no safeStorage-encrypted token path may remain',
+    );
   });
 
   it('exports the preview status constant for the renderer-side scan', async () => {

--- a/apps/desktop/src/main/__tests__/claude-subscription-cloak-flag.test.ts
+++ b/apps/desktop/src/main/__tests__/claude-subscription-cloak-flag.test.ts
@@ -202,28 +202,26 @@ describe('cloaked request module isolation (xuan G-X4)', () => {
       /'maka-desktop\/[^']*\(oauth-subscription\)'/,
       'OAuth UA must NOT advertise maka-desktop — Anthropic rejects non-claude-cli UAs',
     );
-    // Every OAuth-related fetch (token exchange, refresh, usage,
-    // profile) must reference the OAUTH_USER_AGENT constant, not
-    // any inline literal.
+    // Every OAuth-related fetch (token exchange, usage, profile)
+    // must reference the OAUTH_USER_AGENT constant, not any inline
+    // literal. Refresh lives in the runtime's shared refresher
+    // (subscription-credentials.ts), which pins the same UA.
     const uaUses = src.match(/'User-Agent':\s*\w+/g) ?? [];
-    assert.ok(uaUses.length >= 4,
-      `expected at least 4 OAuth fetches to set User-Agent (token / refresh / usage / profile), got ${uaUses.length}`);
+    assert.ok(uaUses.length >= 3,
+      `expected at least 3 OAuth fetches to set User-Agent (token / usage / profile), got ${uaUses.length}`);
     for (const u of uaUses) {
       assert.match(u, /OAUTH_USER_AGENT/, `${u} must reference the OAUTH_USER_AGENT constant`);
     }
   });
 
-  it('token storage fails closed when safeStorage encryption is unavailable', async () => {
+  it('token storage fails closed when the shared credential store rejects the write', async () => {
     const src = await readFile(SERVICE_SOURCE, 'utf8');
+    // saveTokens must record storage_failed AND rethrow — a token that
+    // could not be persisted for every surface is not a partial success.
     assert.match(
       src,
-      /safeStorage\.isEncryptionAvailable\(\)\)\s*\{\s*throw new Error\('safeStorage encryption is unavailable\.'\);/s,
-      'saveTokens must fail closed instead of writing plaintext when safeStorage is unavailable',
-    );
-    assert.doesNotMatch(
-      src,
-      /Buffer\.from\(serialized,\s*['"]utf8['"]\)/,
-      'token persistence must not fall back to plaintext Buffer.from(serialized)',
+      /saveSharedOAuthTokens\(this\.credentialStore, 'claude-subscription'[\s\S]{0,400}lastStorageFailedMessage[\s\S]{0,200}throw err;/,
+      'saveTokens must set storage_failed detail and rethrow when the store write fails',
     );
   });
 });

--- a/apps/desktop/src/main/__tests__/cursor-subscription-service.test.ts
+++ b/apps/desktop/src/main/__tests__/cursor-subscription-service.test.ts
@@ -102,15 +102,18 @@ describe('Cursor subscription OAuth config (upstream cursor-auth pattern)', () =
 });
 
 describe('Cursor service source-grep contract', () => {
-  it('declares the safeStorage-encrypted token path under userData', async () => {
+  it('persists tokens through the shared credential store, not safeStorage (#1125)', async () => {
     const src = await readFile(SERVICE_SOURCE, 'utf8');
     assert.match(
       src,
-      /\.cursor_subscription_token/,
-      'token file path must mirror the Claude service pattern',
+      /saveSharedOAuthTokens\(this\.credentialStore, 'cursor-subscription'/,
+      'tokens must be written to the shared CredentialStore (the cross-surface authority)',
     );
-    assert.match(src, /safeStorage\.encryptString/, 'tokens must be encrypted via safeStorage');
-    assert.match(src, /mode:\s*0o600/, 'persisted token file must be written with mode 0o600');
+    assert.doesNotMatch(
+      src,
+      /encryptString|decryptString|isEncryptionAvailable/,
+      'no safeStorage-encrypted token path may remain',
+    );
   });
 
   it('uses globalThis.fetch by default so Electron session proxy applies', async () => {

--- a/apps/desktop/src/main/__tests__/oauth-bug-sweep-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/oauth-bug-sweep-contract.test.ts
@@ -18,15 +18,6 @@ const SERVICES_WITH_LOOPBACK_SERVER = [
   'antigravity-subscription-service.ts',
 ];
 
-// Services still on the legacy per-service encrypted token file.
-// Claude / Codex moved to the shared CredentialStore authority
-// (#1125); their corrupt-entry cleanup lives in the shared bridge and
-// is asserted in the storage-failure contract below.
-const SERVICES_WITH_LEGACY_TOKEN_FILE = [
-  'cursor-subscription-service.ts',
-  'antigravity-subscription-service.ts',
-];
-
 const WIRED_OAUTH_SEND_SERVICES = [
   'claude-subscription-service.ts',
   'openai-codex-service.ts',
@@ -60,26 +51,10 @@ describe('OAuth callback server: drains sockets + timeout (B-SWEEP-1, B-SWEEP-2)
   }
 });
 
-describe('OAuth loadTokens: unlinks corrupt files (B-SWEEP-3)', () => {
-  for (const file of SERVICES_WITH_LEGACY_TOKEN_FILE) {
-    it(`${file} deletes the token file when decryptString / JSON.parse throws`, async () => {
-      const source = await readFile(resolve(OAUTH_DIR, file), 'utf8');
-      // After PR-BUG-SWEEP-2026-06-02 the catch block around
-      // decryptString + JSON.parse must call fs.unlink so a
-      // corrupt token blob doesn't pin the user to a stuck
-      // "not logged in" state. Best-effort — we don't bubble the
-      // unlink error.
-      // Find the loadTokens method, ensure it contains an unlink.
-      const loadTokensStart = source.indexOf('private async loadTokens(');
-      assert.ok(loadTokensStart > 0, `loadTokens not found in ${file}`);
-      // Limit to the method body — find the next top-level
-      // 'private ' or 'public ' or 'async ' declaration after it.
-      const tail = source.slice(loadTokensStart, loadTokensStart + 1500);
-      assert.match(tail, /fs\.unlink\(this\.tokenFilePath\)/,
-        `loadTokens in ${file} must unlink the token file on decrypt failure`);
-    });
-  }
-});
+// B-SWEEP-3 (unlink corrupt token files) is retired: every service
+// now persists through the shared CredentialStore (#1125), and the
+// bridge deletes a corrupt entry — covered by
+// shared-oauth-token-persistence.test.ts.
 
 describe('OAuth loadTokens: storage failures are not shown as logged out', () => {
   for (const file of WIRED_OAUTH_SEND_SERVICES) {

--- a/apps/desktop/src/main/__tests__/oauth-bug-sweep-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/oauth-bug-sweep-contract.test.ts
@@ -18,9 +18,11 @@ const SERVICES_WITH_LOOPBACK_SERVER = [
   'antigravity-subscription-service.ts',
 ];
 
-const SERVICES_WITH_LOAD_TOKENS = [
-  'claude-subscription-service.ts',
-  'openai-codex-service.ts',
+// Services still on the legacy per-service encrypted token file.
+// Claude / Codex moved to the shared CredentialStore authority
+// (#1125); their corrupt-entry cleanup lives in the shared bridge and
+// is asserted in the storage-failure contract below.
+const SERVICES_WITH_LEGACY_TOKEN_FILE = [
   'cursor-subscription-service.ts',
   'antigravity-subscription-service.ts',
 ];
@@ -59,7 +61,7 @@ describe('OAuth callback server: drains sockets + timeout (B-SWEEP-1, B-SWEEP-2)
 });
 
 describe('OAuth loadTokens: unlinks corrupt files (B-SWEEP-3)', () => {
-  for (const file of SERVICES_WITH_LOAD_TOKENS) {
+  for (const file of SERVICES_WITH_LEGACY_TOKEN_FILE) {
     it(`${file} deletes the token file when decryptString / JSON.parse throws`, async () => {
       const source = await readFile(resolve(OAUTH_DIR, file), 'utf8');
       // After PR-BUG-SWEEP-2026-06-02 the catch block around
@@ -102,18 +104,18 @@ describe('OAuth loadTokens: storage failures are not shown as logged out', () =>
       );
       assert.match(
         loadTokens,
-        /safeStorage\.isEncryptionAvailable\(\)[\s\S]*lastStorageFailedMessage[\s\S]*return null/,
-        `${file} safeStorage-unavailable reads must set storage_failed detail`,
+        /loadSharedOAuthTokens\(this\.credentialStore/,
+        `${file} must load tokens from the shared credential store (the authority, #1125)`,
       );
       assert.match(
         loadTokens,
-        /catch \(error\)[\s\S]*code !== 'ENOENT'[\s\S]*lastStorageFailedMessage[\s\S]*return null/,
-        `${file} token-file read errors other than ENOENT must set storage_failed detail`,
+        /catch \{[\s\S]*lastStorageFailedMessage[\s\S]*return null/,
+        `${file} store read failures must set storage_failed detail instead of reading as logged out`,
       );
       assert.match(
         loadTokens,
-        /decryptString[\s\S]*JSON\.parse[\s\S]*catch \{[\s\S]*lastStorageFailedMessage[\s\S]*fs\.unlink\(this\.tokenFilePath\)/,
-        `${file} decrypt/parse failures must set storage_failed detail before corrupt-token cleanup`,
+        /status === 'corrupt'[\s\S]*lastStorageFailedMessage[\s\S]*return null/,
+        `${file} corrupt shared entries (deleted by the bridge) must surface storage_failed detail`,
       );
     });
   }

--- a/apps/desktop/src/main/__tests__/openai-codex-service.test.ts
+++ b/apps/desktop/src/main/__tests__/openai-codex-service.test.ts
@@ -155,15 +155,18 @@ describe('Codex JWT account-id extraction', () => {
 });
 
 describe('Codex service source-grep contract', () => {
-  it('declares the safeStorage-encrypted token path under userData', async () => {
+  it('persists tokens through the shared credential store, not safeStorage (#1125)', async () => {
     const src = await readFile(SERVICE_SOURCE, 'utf8');
     assert.match(
       src,
-      /\.codex_subscription_token/,
-      'token file path must mirror the Claude service pattern',
+      /saveSharedOAuthTokens\(this\.credentialStore, 'codex-subscription'/,
+      'tokens must be written to the shared CredentialStore (the cross-surface authority)',
     );
-    assert.match(src, /safeStorage\.encryptString/, 'tokens must be encrypted via safeStorage');
-    assert.match(src, /mode:\s*0o600/, 'persisted token file must be written with mode 0o600');
+    assert.doesNotMatch(
+      src,
+      /encryptString|decryptString|isEncryptionAvailable/,
+      'no safeStorage-encrypted token path may remain',
+    );
   });
 
   it('uses globalThis.fetch by default so Electron session proxy applies', async () => {

--- a/apps/desktop/src/main/__tests__/shared-oauth-token-persistence.test.ts
+++ b/apps/desktop/src/main/__tests__/shared-oauth-token-persistence.test.ts
@@ -1,0 +1,245 @@
+/**
+ * Unit tests for the authoritative OAuth token persistence layer
+ * (#1125): CredentialStore-backed save/load/delete plus the one-shot
+ * import of legacy safeStorage-encrypted token files. Exercised
+ * against the real pure-Node FileCredentialStore in a tmpdir so the
+ * on-disk contract (v1 schema, 0600 perms) is covered end to end.
+ */
+
+import { strict as assert } from 'node:assert';
+import { mkdtemp, readFile, rm, stat, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { after, describe, it } from 'node:test';
+import { createFileCredentialStore } from '@maka/storage';
+import {
+  deleteSharedOAuthTokens,
+  importLegacyOAuthTokenFiles,
+  loadSharedOAuthTokens,
+  saveSharedOAuthTokens,
+  type LegacySafeStorageDecryptor,
+} from '../oauth/shared-credential-bridge.js';
+
+const TOKENS = {
+  access_token: 'access-1',
+  refresh_token: 'refresh-1',
+  expires_at: 1_800_000_000_000,
+  account_uuid: 'uuid-1',
+};
+
+const tempRoots: string[] = [];
+async function makeWorkspace(): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), 'maka-oauth-bridge-'));
+  tempRoots.push(root);
+  return root;
+}
+after(async () => {
+  await Promise.all(tempRoots.map((root) => rm(root, { recursive: true, force: true })));
+});
+
+/** Reversible stand-in for safeStorage: "encryption" is base64. */
+function fakeDecryptor(overrides: Partial<LegacySafeStorageDecryptor> = {}): LegacySafeStorageDecryptor {
+  return {
+    isEncryptionAvailable: () => true,
+    decryptString: (encrypted: Buffer) => Buffer.from(encrypted.toString('utf8'), 'base64').toString('utf8'),
+    ...overrides,
+  };
+}
+
+function encryptedTokenFileContents(payload: unknown): string {
+  return Buffer.from(JSON.stringify(payload), 'utf8').toString('base64');
+}
+
+describe('shared OAuth token persistence (store authority)', () => {
+  it('round-trips tokens through the credential store', async () => {
+    const store = createFileCredentialStore(await makeWorkspace());
+    await saveSharedOAuthTokens(store, 'claude-subscription', TOKENS);
+    const result = await loadSharedOAuthTokens(store, 'claude-subscription');
+    assert.equal(result.status, 'ok');
+    assert.deepEqual(result.status === 'ok' && result.tokens, TOKENS);
+  });
+
+  it('reports missing tokens as missing', async () => {
+    const store = createFileCredentialStore(await makeWorkspace());
+    assert.deepEqual(await loadSharedOAuthTokens(store, 'claude-subscription'), { status: 'missing' });
+  });
+
+  it('save propagates store failures instead of swallowing them', async () => {
+    await assert.rejects(
+      saveSharedOAuthTokens(
+        { setSecret: async () => { throw new Error('store down'); } },
+        'claude-subscription',
+        TOKENS,
+      ),
+      /store down/,
+    );
+  });
+
+  it('load propagates store read failures (fail closed, not logged out)', async () => {
+    const workspaceRoot = await makeWorkspace();
+    await writeFile(join(workspaceRoot, 'credentials.json'), '{"version":999,"values":{}}');
+    const store = createFileCredentialStore(workspaceRoot);
+    await assert.rejects(loadSharedOAuthTokens(store, 'claude-subscription'), /schema version/);
+  });
+
+  it('deletes an unparseable entry and reports corrupt', async () => {
+    const store = createFileCredentialStore(await makeWorkspace());
+    await store.setSecret('claude-subscription', 'oauth_token', 'not-a-token-payload');
+    assert.deepEqual(await loadSharedOAuthTokens(store, 'claude-subscription'), { status: 'corrupt' });
+    assert.equal(await store.getSecret('claude-subscription', 'oauth_token'), null);
+  });
+
+  it('delete removes the entry and leaves other kinds intact', async () => {
+    const store = createFileCredentialStore(await makeWorkspace());
+    await store.setSecret('claude-subscription', 'api_key', 'sk-keep');
+    await saveSharedOAuthTokens(store, 'claude-subscription', TOKENS);
+    await deleteSharedOAuthTokens(store, 'claude-subscription');
+    assert.equal(await store.getSecret('claude-subscription', 'oauth_token'), null);
+    assert.equal(await store.getSecret('claude-subscription', 'api_key'), 'sk-keep');
+  });
+});
+
+describe('legacy safeStorage token file import (one-shot)', () => {
+  it('imports a decryptable token file into the store and removes the file', async () => {
+    const workspaceRoot = await makeWorkspace();
+    const store = createFileCredentialStore(workspaceRoot);
+    const filePath = join(workspaceRoot, '.claude_subscription_token');
+    await writeFile(filePath, encryptedTokenFileContents(TOKENS));
+
+    const reports = await importLegacyOAuthTokenFiles({
+      credentialStore: store,
+      decryptor: fakeDecryptor(),
+      files: [{ slug: 'claude-subscription', filePath }],
+    });
+
+    assert.deepEqual(reports.map((r) => r.outcome), ['imported']);
+    const result = await loadSharedOAuthTokens(store, 'claude-subscription');
+    assert.equal(result.status === 'ok' && result.tokens.access_token, TOKENS.access_token);
+    await assert.rejects(stat(filePath), { code: 'ENOENT' });
+  });
+
+  it('is a no-op for missing files and reports nothing', async () => {
+    const workspaceRoot = await makeWorkspace();
+    const reports = await importLegacyOAuthTokenFiles({
+      credentialStore: createFileCredentialStore(workspaceRoot),
+      decryptor: fakeDecryptor(),
+      files: [{ slug: 'claude-subscription', filePath: join(workspaceRoot, '.absent') }],
+    });
+    assert.deepEqual(reports, []);
+  });
+
+  it('never clobbers an existing store token; removes the stale file as superseded', async () => {
+    const workspaceRoot = await makeWorkspace();
+    const store = createFileCredentialStore(workspaceRoot);
+    const fresher = { ...TOKENS, access_token: 'fresher-from-cli-refresh' };
+    await saveSharedOAuthTokens(store, 'claude-subscription', fresher);
+    const filePath = join(workspaceRoot, '.claude_subscription_token');
+    await writeFile(filePath, encryptedTokenFileContents(TOKENS));
+
+    const reports = await importLegacyOAuthTokenFiles({
+      credentialStore: store,
+      decryptor: fakeDecryptor(),
+      files: [{ slug: 'claude-subscription', filePath }],
+    });
+
+    assert.deepEqual(reports.map((r) => r.outcome), ['superseded']);
+    const result = await loadSharedOAuthTokens(store, 'claude-subscription');
+    assert.equal(result.status === 'ok' && result.tokens.access_token, 'fresher-from-cli-refresh');
+    await assert.rejects(stat(filePath), { code: 'ENOENT' });
+  });
+
+  it('leaves the file intact when decryption is unavailable', async () => {
+    const workspaceRoot = await makeWorkspace();
+    const store = createFileCredentialStore(workspaceRoot);
+    const filePath = join(workspaceRoot, '.claude_subscription_token');
+    await writeFile(filePath, encryptedTokenFileContents(TOKENS));
+
+    const reports = await importLegacyOAuthTokenFiles({
+      credentialStore: store,
+      decryptor: fakeDecryptor({ isEncryptionAvailable: () => false }),
+      files: [{ slug: 'claude-subscription', filePath }],
+    });
+
+    assert.deepEqual(reports.map((r) => r.outcome), ['left-encrypted']);
+    assert.equal(await store.getSecret('claude-subscription', 'oauth_token'), null);
+    await stat(filePath); // still present
+  });
+
+  it('leaves the file intact when decryption throws (keychain denied)', async () => {
+    const workspaceRoot = await makeWorkspace();
+    const filePath = join(workspaceRoot, '.claude_subscription_token');
+    await writeFile(filePath, encryptedTokenFileContents(TOKENS));
+
+    const reports = await importLegacyOAuthTokenFiles({
+      credentialStore: createFileCredentialStore(workspaceRoot),
+      decryptor: fakeDecryptor({ decryptString: () => { throw new Error('denied'); } }),
+      files: [{ slug: 'claude-subscription', filePath }],
+    });
+
+    assert.deepEqual(reports.map((r) => r.outcome), ['left-encrypted']);
+    await stat(filePath); // still present, retried next start
+  });
+
+  it('removes a file whose decrypted payload is not a token', async () => {
+    const workspaceRoot = await makeWorkspace();
+    const store = createFileCredentialStore(workspaceRoot);
+    const filePath = join(workspaceRoot, '.claude_subscription_token');
+    await writeFile(filePath, Buffer.from('{"not":"a token"}', 'utf8').toString('base64'));
+
+    const reports = await importLegacyOAuthTokenFiles({
+      credentialStore: store,
+      decryptor: fakeDecryptor(),
+      files: [{ slug: 'claude-subscription', filePath }],
+    });
+
+    assert.deepEqual(reports.map((r) => r.outcome), ['removed-corrupt']);
+    assert.equal(await store.getSecret('claude-subscription', 'oauth_token'), null);
+    await assert.rejects(stat(filePath), { code: 'ENOENT' });
+  });
+
+  it('reports per-file failures without throwing and continues with the rest', async () => {
+    const workspaceRoot = await makeWorkspace();
+    const store = createFileCredentialStore(workspaceRoot);
+    const failingPath = join(workspaceRoot, '.claude_subscription_token');
+    const okPath = join(workspaceRoot, '.codex_subscription_token');
+    await writeFile(failingPath, encryptedTokenFileContents(TOKENS));
+    await writeFile(okPath, encryptedTokenFileContents({ ...TOKENS, account_id: 'acct-1' }));
+
+    const reports = await importLegacyOAuthTokenFiles({
+      credentialStore: {
+        getSecret: async (slug) => {
+          if (slug === 'claude-subscription') throw new Error('store exploded');
+          return store.getSecret(slug, 'oauth_token');
+        },
+        setSecret: (slug, kind, value) => store.setSecret(slug, kind, value),
+      },
+      decryptor: fakeDecryptor(),
+      files: [
+        { slug: 'claude-subscription', filePath: failingPath },
+        { slug: 'codex-subscription', filePath: okPath },
+      ],
+    });
+
+    assert.deepEqual(reports.map((r) => r.outcome), ['failed', 'imported']);
+    await stat(failingPath); // failed file left intact
+    assert.equal((await loadSharedOAuthTokens(store, 'codex-subscription')).status, 'ok');
+  });
+
+  it('keeps credentials.json owner-only after an import', async () => {
+    const workspaceRoot = await makeWorkspace();
+    const store = createFileCredentialStore(workspaceRoot);
+    const filePath = join(workspaceRoot, '.claude_subscription_token');
+    await writeFile(filePath, encryptedTokenFileContents(TOKENS));
+    await importLegacyOAuthTokenFiles({
+      credentialStore: store,
+      decryptor: fakeDecryptor(),
+      files: [{ slug: 'claude-subscription', filePath }],
+    });
+    if (process.platform !== 'win32') {
+      const mode = (await stat(join(workspaceRoot, 'credentials.json'))).mode & 0o777;
+      assert.equal(mode, 0o600);
+    }
+    const raw = await readFile(join(workspaceRoot, 'credentials.json'), 'utf8');
+    assert.match(raw, /"version": 1/);
+  });
+});

--- a/apps/desktop/src/main/__tests__/shared-oauth-token-persistence.test.ts
+++ b/apps/desktop/src/main/__tests__/shared-oauth-token-persistence.test.ts
@@ -82,11 +82,14 @@ describe('shared OAuth token persistence (store authority)', () => {
     await assert.rejects(loadSharedOAuthTokens(store, 'claude-subscription'), /schema version/);
   });
 
-  it('deletes an unparseable entry and reports corrupt', async () => {
+  it('keeps an unparseable entry intact and reports corrupt (reads never destroy secrets)', async () => {
     const store = createFileCredentialStore(await makeWorkspace());
     await store.setSecret('claude-subscription', 'oauth_token', 'not-a-token-payload');
     assert.deepEqual(await loadSharedOAuthTokens(store, 'claude-subscription'), { status: 'corrupt' });
-    assert.equal(await store.getSecret('claude-subscription', 'oauth_token'), null);
+    assert.equal(await store.getSecret('claude-subscription', 'oauth_token'), 'not-a-token-payload');
+    // A fresh login overwrites the corrupt entry — no delete needed to unstick.
+    await saveSharedOAuthTokens(store, 'claude-subscription', TOKENS);
+    assert.equal((await loadSharedOAuthTokens(store, 'claude-subscription')).status, 'ok');
   });
 
   it('delete removes the entry and leaves other kinds intact', async () => {
@@ -148,6 +151,25 @@ describe('legacy safeStorage token file import (one-shot)', () => {
     await assert.rejects(stat(filePath), { code: 'ENOENT' });
   });
 
+  it('a garbage store entry does not supersede a valid legacy file', async () => {
+    const workspaceRoot = await makeWorkspace();
+    const store = createFileCredentialStore(workspaceRoot);
+    await store.setSecret('claude-subscription', 'oauth_token', 'stored-garbage');
+    const filePath = join(workspaceRoot, '.claude_subscription_token');
+    await writeFile(filePath, encryptedTokenFileContents(TOKENS));
+
+    const reports = await importLegacyOAuthTokenFiles({
+      credentialStore: store,
+      decryptor: fakeDecryptor(),
+      files: [{ slug: 'claude-subscription', filePath }],
+    });
+
+    assert.deepEqual(reports.map((r) => r.outcome), ['imported']);
+    const result = await loadSharedOAuthTokens(store, 'claude-subscription');
+    assert.equal(result.status === 'ok' && result.tokens.access_token, TOKENS.access_token);
+    await assert.rejects(stat(filePath), { code: 'ENOENT' });
+  });
+
   it('leaves the file intact when decryption is unavailable', async () => {
     const workspaceRoot = await makeWorkspace();
     const store = createFileCredentialStore(workspaceRoot);
@@ -180,7 +202,7 @@ describe('legacy safeStorage token file import (one-shot)', () => {
     await stat(filePath); // still present, retried next start
   });
 
-  it('removes a file whose decrypted payload is not a token', async () => {
+  it('keeps a file whose decrypted payload is not a token this build can parse', async () => {
     const workspaceRoot = await makeWorkspace();
     const store = createFileCredentialStore(workspaceRoot);
     const filePath = join(workspaceRoot, '.claude_subscription_token');
@@ -192,9 +214,9 @@ describe('legacy safeStorage token file import (one-shot)', () => {
       files: [{ slug: 'claude-subscription', filePath }],
     });
 
-    assert.deepEqual(reports.map((r) => r.outcome), ['removed-corrupt']);
+    assert.deepEqual(reports.map((r) => r.outcome), ['left-unparseable']);
     assert.equal(await store.getSecret('claude-subscription', 'oauth_token'), null);
-    await assert.rejects(stat(filePath), { code: 'ENOENT' });
+    await stat(filePath); // kept — only an explicit logout destroys it
   });
 
   it('reports per-file failures without throwing and continues with the rest', async () => {

--- a/apps/desktop/src/main/__tests__/subscription-shared-credential-store.test.ts
+++ b/apps/desktop/src/main/__tests__/subscription-shared-credential-store.test.ts
@@ -1,82 +1,99 @@
+/**
+ * Source-grounded contract: the shared CredentialStore (workspace
+ * credentials.json) is the single OAuth token authority for the
+ * desktop subscription services (#1125). Desktop persists through the
+ * shared-credential-bridge helpers and never through Electron
+ * safeStorage; the runtime-usable token a pure-Node surface reads is
+ * the same one the desktop wrote. Unit coverage of the bridge itself
+ * lives in shared-oauth-token-persistence.test.ts.
+ */
+
 import { strict as assert } from 'node:assert';
 import { readFile } from 'node:fs/promises';
 import { dirname, resolve } from 'node:path';
 import { describe, it } from 'node:test';
 import { fileURLToPath } from 'node:url';
-import {
-  tryDeleteSharedOAuthToken,
-  trySaveSharedOAuthToken,
-} from '../oauth/shared-credential-bridge.js';
 
 const DESKTOP_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..', '..');
-const CLAUDE_SOURCE = resolve(DESKTOP_ROOT, 'src', 'main', 'oauth', 'claude-subscription-service.ts');
-const CODEX_SOURCE = resolve(DESKTOP_ROOT, 'src', 'main', 'oauth', 'openai-codex-service.ts');
+const OAUTH_DIR = resolve(DESKTOP_ROOT, 'src', 'main', 'oauth');
 
-describe('OAuth subscription shared credential store bridge', () => {
-  it('writes OAuth tokens to the shared credential store when available', async () => {
-    const writes: Array<{ slug: string; kind: string; value: string }> = [];
+const STORE_AUTHORITY_SERVICES = [
+  ['Claude', 'claude-subscription-service.ts', 'claude-subscription'],
+  ['Codex', 'openai-codex-service.ts', 'codex-subscription'],
+] as const;
 
-    const saved = await trySaveSharedOAuthToken({
-      credentialStore: {
-        setSecret: async (slug, kind, value) => {
-          writes.push({ slug, kind, value });
-        },
-      },
-      slug: 'claude-subscription',
-      value: '{"access_token":"token"}',
-    });
-
-    assert.equal(saved, true);
-    assert.deepEqual(writes, [{
-      slug: 'claude-subscription',
-      kind: 'oauth_token',
-      value: '{"access_token":"token"}',
-    }]);
-  });
-
-  it('keeps desktop OAuth usable when the shared credential write fails', async () => {
-    const saved = await trySaveSharedOAuthToken({
-      credentialStore: {
-        setSecret: async () => {
-          throw new Error('shared store unavailable');
-        },
-      },
-      slug: 'codex-subscription',
-      value: '{"access_token":"token"}',
-    });
-
-    assert.equal(saved, false);
-  });
-
-  it('reports shared credential delete failures without throwing', async () => {
-    const deleted = await tryDeleteSharedOAuthToken({
-      credentialStore: {
-        deleteSecret: async () => {
-          throw new Error('shared store unavailable');
-        },
-      },
-      slug: 'claude-subscription',
-    });
-
-    assert.equal(deleted, false);
-  });
-
-  it('desktop services export tokens to shared credentials but never restore login state from them', async () => {
-    for (const [name, source, slug] of [
-      ['Claude', CLAUDE_SOURCE, 'claude-subscription'],
-      ['Codex', CODEX_SOURCE, 'codex-subscription'],
-    ] as const) {
-      const src = await readFile(source, 'utf8');
-      assert.doesNotMatch(src, /loadSharedTokens/, `${name} service must not read CLI shared tokens back into desktop state`);
-      assert.doesNotMatch(
+describe('OAuth subscription token authority (shared CredentialStore)', () => {
+  for (const [name, file, slug] of STORE_AUTHORITY_SERVICES) {
+    it(`${name} service persists tokens only through the shared credential store`, async () => {
+      const src = await readFile(resolve(OAUTH_DIR, file), 'utf8');
+      assert.match(
         src,
-        new RegExp(`getSecret\\(\\s*'${slug}',\\s*'oauth_token'`),
-        `${name} service must not restore desktop login from shared CLI credentials`,
+        new RegExp(`saveSharedOAuthTokens\\(this\\.credentialStore, '${slug}'`),
+        `${name} service must write tokens to the shared store (the authority)`,
       );
       assert.match(
         src,
-        new RegExp(`tryDeleteSharedOAuthToken\\(\\{[\\s\\S]*slug:\\s*'${slug}'`),
-        `${name} logout should still attempt to clean the exported CLI token`,
+        new RegExp(`loadSharedOAuthTokens\\(this\\.credentialStore, '${slug}'`),
+        `${name} service must read tokens back from the shared store`,
+      );
+      assert.match(
+        src,
+        new RegExp(`deleteSharedOAuthTokens\\(this\\.credentialStore, '${slug}'`),
+        `${name} logout must delete the authoritative shared token`,
+      );
+    });
+
+    it(`${name} service has no safeStorage / encrypted-file token path left`, async () => {
+      const src = await readFile(resolve(OAUTH_DIR, file), 'utf8');
+      assert.doesNotMatch(
+        src,
+        /from 'electron'.*safeStorage|safeStorage.*from 'electron'/,
+        `${name} service must not import safeStorage — the store is the only authority (#1125)`,
+      );
+      assert.doesNotMatch(
+        src,
+        /encryptString|decryptString|isEncryptionAvailable/,
+        `${name} service must not encrypt/decrypt token files`,
+      );
+      assert.doesNotMatch(
+        src,
+        /fs\.writeFile\(this\.legacyTokenFilePath/,
+        `${name} service must never write the legacy token file`,
+      );
+      assert.match(
+        src,
+        /fs\.unlink\(this\.legacyTokenFilePath\)/,
+        `${name} logout must still clear a legacy token file the startup import could not process`,
+      );
+    });
+
+    it(`${name} service refreshes through the runtime's shared refresher`, async () => {
+      const src = await readFile(resolve(OAUTH_DIR, file), 'utf8');
+      assert.match(
+        src,
+        /refreshOAuthSubscriptionTokens\(\{/,
+        `${name} service must reuse the runtime refresh implementation, not a private duplicate`,
+      );
+      assert.doesNotMatch(
+        src,
+        /private async requestRefresh/,
+        `${name} service must not keep a parallel refresh implementation`,
+      );
+    });
+  }
+
+  it('main.ts runs the one-shot legacy token import at startup, non-fatally', async () => {
+    const src = await readFile(resolve(DESKTOP_ROOT, 'src', 'main', 'main.ts'), 'utf8');
+    assert.match(
+      src,
+      /try\s*\{[\s\S]{0,600}importLegacyOAuthTokenFiles\(\{[\s\S]*?\}\);?[\s\S]{0,600}catch/,
+      'legacy OAuth token import must be wrapped so a failure cannot break startup',
+    );
+    for (const slug of ['claude-subscription', 'codex-subscription']) {
+      assert.match(
+        src,
+        new RegExp(`slug: '${slug}', filePath: join\\(userDataDir, '\\.\\w+_subscription_token'\\)`),
+        `startup import must cover the legacy ${slug} token file`,
       );
     }
   });

--- a/apps/desktop/src/main/__tests__/subscription-shared-credential-store.test.ts
+++ b/apps/desktop/src/main/__tests__/subscription-shared-credential-store.test.ts
@@ -67,6 +67,33 @@ describe('OAuth subscription token authority (shared CredentialStore)', () => {
       );
     });
 
+    it(`${name} service maps store write failures to storage_failed, not exchange/refresh failures`, async () => {
+      const src = await readFile(resolve(OAUTH_DIR, file), 'utf8');
+      // Both the login save and the refresh save must have their own
+      // catch that surfaces storage_failed: a consumed one-time code or
+      // a successfully rotated token with a failed write is a storage
+      // problem, not a provider problem.
+      const saveCatches = src.match(/await this\.saveTokens\([\s\S]{0,500}?reason: 'storage_failed'/g) ?? [];
+      assert.ok(
+        saveCatches.length >= 2,
+        `${name} must map save failures to storage_failed in both completeAuthorization and refreshTokens; found ${saveCatches.length}`,
+      );
+    });
+
+    it(`${name} logout stays terminal against an in-flight refresh`, async () => {
+      const src = await readFile(resolve(OAUTH_DIR, file), 'utf8');
+      assert.match(
+        src,
+        /this\.credentialEpoch \+= 1/,
+        `${name} logout must bump the credential epoch`,
+      );
+      assert.match(
+        src,
+        /epoch !== this\.credentialEpoch/,
+        `${name} refresh must discard its result when the epoch moved (logout during the network window)`,
+      );
+    });
+
     it(`${name} service refreshes through the runtime's shared refresher`, async () => {
       const src = await readFile(resolve(OAUTH_DIR, file), 'utf8');
       assert.match(

--- a/apps/desktop/src/main/__tests__/subscription-shared-credential-store.test.ts
+++ b/apps/desktop/src/main/__tests__/subscription-shared-credential-store.test.ts
@@ -9,7 +9,7 @@
  */
 
 import { strict as assert } from 'node:assert';
-import { readFile } from 'node:fs/promises';
+import { readdir, readFile } from 'node:fs/promises';
 import { dirname, resolve } from 'node:path';
 import { describe, it } from 'node:test';
 import { fileURLToPath } from 'node:url';
@@ -81,6 +81,34 @@ describe('OAuth subscription token authority (shared CredentialStore)', () => {
       );
     });
   }
+
+  it('no production OAuth path invokes safeStorage (#1125 acceptance)', async () => {
+    // The acceptance bar for #1125: saving or loading a runtime-usable
+    // token must never require safeStorage. No module under oauth/ may
+    // import or call safeStorage (the bridge's legacy import takes an
+    // injected decryptor instead); main.ts may only pass the object
+    // into the legacy importers, never call it.
+    for (const file of await readdir(OAUTH_DIR)) {
+      if (!file.endsWith('.ts')) continue;
+      const src = await readFile(resolve(OAUTH_DIR, file), 'utf8');
+      assert.doesNotMatch(
+        src,
+        /import\s*\{[^}]*\bsafeStorage\b[^}]*\}\s*from 'electron'/,
+        `oauth/${file} must not import safeStorage from electron`,
+      );
+      assert.doesNotMatch(
+        src,
+        /\bsafeStorage\s*[.(]/,
+        `oauth/${file} must not invoke safeStorage`,
+      );
+    }
+    const mainSrc = await readFile(resolve(DESKTOP_ROOT, 'src', 'main', 'main.ts'), 'utf8');
+    assert.doesNotMatch(
+      mainSrc,
+      /safeStorage\s*\./,
+      'main.ts must only hand safeStorage to the legacy importers, never call it',
+    );
+  });
 
   it('main.ts runs the one-shot legacy token import at startup, non-fatally', async () => {
     const src = await readFile(resolve(DESKTOP_ROOT, 'src', 'main', 'main.ts'), 'utf8');

--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -367,9 +367,11 @@ function hasConnectionSecret(connection: LlmConnection): Promise<boolean> {
 }
 const cursorSubscription = new CursorSubscriptionService({
   userDataDir: app.getPath('userData'),
+  credentialStore,
 });
 const antigravitySubscription = new AntigravitySubscriptionService({
   userDataDir: app.getPath('userData'),
+  credentialStore,
 });
 
 const planReminderStore = createPlanReminderStore(workspaceRoot);
@@ -2353,6 +2355,8 @@ async function runBackgroundStartup(): Promise<void> {
       files: [
         { slug: 'claude-subscription', filePath: join(userDataDir, '.claude_subscription_token') },
         { slug: 'codex-subscription', filePath: join(userDataDir, '.codex_subscription_token') },
+        { slug: 'cursor-subscription', filePath: join(userDataDir, '.cursor_subscription_token') },
+        { slug: 'antigravity-subscription', filePath: join(userDataDir, '.antigravity_subscription_token') },
       ],
     });
     for (const report of reports) {

--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -2315,6 +2315,17 @@ app.whenReady().then(async () => {
   // settled. Any state that background startup mutates is pushed to the
   // renderer via the existing `sessions:changed` / `connections:event`
   // / `settings:bots:statusChanged` channels, so the UI converges lazily.
+  // Visual-smoke fixture mode wipes and reseeds the whole workspace
+  // (`rm -rf` first). That wipe must finish BEFORE the window opens and
+  // before background startup touches the workspace: createWindow reads
+  // the settings store, and a concurrent wipe lands inside the store's
+  // read-or-create write (mkdir → tmp → rename), rejecting createWindow
+  // so the window never appears. Fixture runs trade first-paint latency
+  // for determinism by definition; production launches skip this await.
+  if (visualSmokeFixture) {
+    console.log(`[visual-smoke] scenario=${visualSmokeFixture.scenario} workspace=${workspaceRoot}`);
+    await seedVisualSmokeFixture({ workspaceRoot, fixture: visualSmokeFixture, credentialStore });
+  }
   const backgroundStartup = runBackgroundStartup();
   await mainWindowController.createWindow();
   // Keep the process alive until background work settles so schedulers
@@ -2366,10 +2377,9 @@ async function runBackgroundStartup(): Promise<void> {
   } catch (error) {
     console.error('[credentials] legacy OAuth token import failed; files left intact:', error);
   }
-  if (visualSmokeFixture) {
-    console.log(`[visual-smoke] scenario=${visualSmokeFixture.scenario} workspace=${workspaceRoot}`);
-    await seedVisualSmokeFixture({ workspaceRoot, fixture: visualSmokeFixture, credentialStore });
-  } else {
+  // Visual-smoke seeding happens synchronously in `whenReady` before the
+  // window opens (see there for why); only the real bootstrap runs here.
+  if (!visualSmokeFixture) {
     await ensureBootstrapConnection();
   }
   const settings = await settingsStore.get();

--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -63,6 +63,7 @@ import { OpenAiCodexService } from './oauth/openai-codex-service.js';
 import { GitHubCopilotSubscriptionService } from './oauth/github-copilot-subscription-service.js';
 import { CursorSubscriptionService } from './oauth/cursor-subscription-service.js';
 import { AntigravitySubscriptionService } from './oauth/antigravity-subscription-service.js';
+import { importLegacyOAuthTokenFiles } from './oauth/shared-credential-bridge.js';
 import type { WorkspacePrivacyContext } from '@maka/core/incognito';
 import type { LlmCallRecord, PricingConfig, ToolInvocationRecord } from '@maka/core/usage-stats/types';
 import type {
@@ -2339,6 +2340,27 @@ async function runBackgroundStartup(): Promise<void> {
     await migrateLegacyCredentials(workspaceRoot, safeStorage);
   } catch (error) {
     console.error('[credentials] migration off safeStorage failed; legacy file left intact:', error);
+  }
+  // One-shot import of pre-#1125 safeStorage-encrypted OAuth token
+  // files into the shared CredentialStore, which is the only token
+  // authority from here on. Best-effort like the migration above:
+  // files that cannot be decrypted are left intact for a later start.
+  try {
+    const userDataDir = app.getPath('userData');
+    const reports = await importLegacyOAuthTokenFiles({
+      credentialStore,
+      decryptor: safeStorage,
+      files: [
+        { slug: 'claude-subscription', filePath: join(userDataDir, '.claude_subscription_token') },
+        { slug: 'codex-subscription', filePath: join(userDataDir, '.codex_subscription_token') },
+      ],
+    });
+    for (const report of reports) {
+      const log = report.outcome === 'failed' ? console.error : console.log;
+      log(`[credentials] legacy OAuth token file for ${report.slug}: ${report.outcome}`, report.error ?? '');
+    }
+  } catch (error) {
+    console.error('[credentials] legacy OAuth token import failed; files left intact:', error);
   }
   if (visualSmokeFixture) {
     console.log(`[visual-smoke] scenario=${visualSmokeFixture.scenario} workspace=${workspaceRoot}`);

--- a/apps/desktop/src/main/oauth/antigravity-subscription-service.ts
+++ b/apps/desktop/src/main/oauth/antigravity-subscription-service.ts
@@ -3,7 +3,8 @@
  * preview-only placeholder.
  *
  * Structurally mirrors the Claude / Codex services (loopback PKCE,
- * Google OAuth endpoints, safeStorage-encrypted persistence). The
+ * Google OAuth endpoints, tokens persisted in the shared
+ * CredentialStore — the cross-surface authority, #1125). The
  * preview remains fail-closed because no Google client id is bundled.
  *
  * Status: 'preview'. The card is visible in Settings → 模型, but
@@ -21,11 +22,11 @@
  *     advances to a real implementation.
  */
 
-import { safeStorage, shell } from 'electron';
+import { shell } from 'electron';
 import { randomBytes, randomUUID } from 'node:crypto';
 import { promises as fs } from 'node:fs';
 import { createServer, type IncomingMessage, type Server, type ServerResponse } from 'node:http';
-import { dirname, join } from 'node:path';
+import { join } from 'node:path';
 import {
   PENDING_AUTHORIZATION_TTL_MS,
   PKCE_VERIFIER_LENGTH_BYTES,
@@ -44,6 +45,12 @@ import {
   buildAntigravityAuthorizationUrl,
   pkceChallengeFromVerifier,
 } from './antigravity-subscription-helpers.js';
+import {
+  deleteSharedOAuthTokens,
+  loadSharedOAuthTokens,
+  saveSharedOAuthTokens,
+  type SharedOAuthCredentialStore,
+} from './shared-credential-bridge.js';
 
 const GOOGLE_AUTHORIZE_ENDPOINT = ANTIGRAVITY_OAUTH_CONFIG.authUrl;
 const GOOGLE_TOKEN_ENDPOINT = ANTIGRAVITY_OAUTH_CONFIG.tokenUrl;
@@ -90,14 +97,19 @@ export interface AntigravitySubscriptionServiceDeps {
   now?: () => number;
   /** fetch implementation. Defaults to global fetch (Node 18+). */
   fetchFn?: typeof fetch;
+  /** Shared workspace credential store — the authoritative token store for every surface (#1125). */
+  credentialStore: SharedOAuthCredentialStore;
 }
 
 export class AntigravitySubscriptionService {
-  private readonly tokenFilePath: string;
+  /** Pre-#1125 safeStorage-encrypted token file. Never written or read
+   *  anymore; unlinked on logout in case the startup import could not
+   *  run, so logout still means "no credential survives anywhere". */
+  private readonly legacyTokenFilePath: string;
   private readonly now: () => number;
   private readonly fetchFn: typeof fetch;
+  private readonly credentialStore: SharedOAuthCredentialStore;
 
-  private cachedTokens: PersistedTokens | null = null;
   private pending: Map<string, PendingAuthorization> = new Map();
 
   private lastRefreshFailedMessage: string | null = null;
@@ -105,9 +117,10 @@ export class AntigravitySubscriptionService {
   private refreshing = false;
 
   constructor(deps: AntigravitySubscriptionServiceDeps) {
-    this.tokenFilePath = join(deps.userDataDir, '.antigravity_subscription_token');
+    this.legacyTokenFilePath = join(deps.userDataDir, '.antigravity_subscription_token');
     this.now = deps.now ?? (() => Date.now());
     this.fetchFn = deps.fetchFn ?? (globalThis.fetch as typeof fetch);
+    this.credentialStore = deps.credentialStore;
   }
 
   // -----------------------------------------------------------
@@ -214,7 +227,6 @@ export class AntigravitySubscriptionService {
       }
       const tokens = await this.exchangeCodeForTokens(code, pending.verifier);
       await this.saveTokens(tokens);
-      this.cachedTokens = tokens;
       this.disposePending(authRequestId);
       this.authorizing = false;
       return { ok: true };
@@ -259,7 +271,6 @@ export class AntigravitySubscriptionService {
     try {
       const next = await this.requestRefresh(tokens.refresh_token);
       await this.saveTokens(next);
-      this.cachedTokens = next;
       this.lastRefreshFailedMessage = null;
       this.refreshing = false;
       return { ok: true };
@@ -272,18 +283,24 @@ export class AntigravitySubscriptionService {
   }
 
   async logout(): Promise<SubscriptionActionResult> {
-    this.cachedTokens = null;
     this.lastRefreshFailedMessage = null;
     for (const id of [...this.pending.keys()]) this.disposePending(id);
     this.authorizing = false;
+    let legacyDeleteFailed = false;
     try {
-      await fs.unlink(this.tokenFilePath);
+      await fs.unlink(this.legacyTokenFilePath);
     } catch (err) {
       const code = (err as NodeJS.ErrnoException).code;
       if (code !== 'ENOENT') {
-        return { ok: false, reason: 'storage_failed', message: '删除本地凭据失败，请手动清理。' };
+        legacyDeleteFailed = true;
       }
     }
+    try {
+      await deleteSharedOAuthTokens(this.credentialStore, 'antigravity-subscription');
+    } catch {
+      return { ok: false, reason: 'storage_failed', message: '删除共享凭据失败，请手动清理。' };
+    }
+    if (legacyDeleteFailed) return { ok: false, reason: 'storage_failed', message: '删除本地遗留凭据失败，请手动清理。' };
     return { ok: true };
   }
 
@@ -461,37 +478,30 @@ export class AntigravitySubscriptionService {
   }
 
   private async saveTokens(tokens: PersistedTokens): Promise<void> {
-    const serialized = JSON.stringify(tokens);
-    const dir = dirname(this.tokenFilePath);
-    await fs.mkdir(dir, { recursive: true });
-    if (!safeStorage.isEncryptionAvailable()) {
-      throw new Error('safeStorage encryption is unavailable.');
-    }
-    const buffer = safeStorage.encryptString(serialized);
-    await fs.writeFile(this.tokenFilePath, buffer, { mode: 0o600 });
-    await fs.chmod(this.tokenFilePath, 0o600);
+    // Fail closed: a store write failure propagates to the caller's
+    // failure envelope instead of pretending the login stuck.
+    await saveSharedOAuthTokens(this.credentialStore, 'antigravity-subscription', tokens);
   }
 
+  /**
+   * Always reads the shared store — no in-memory copy; the store is
+   * the cross-surface authority (#1125). A corrupt entry is deleted by
+   * the bridge so the next login isn't stuck.
+   */
   private async loadTokens(): Promise<PersistedTokens | null> {
-    if (this.cachedTokens) return this.cachedTokens;
-    let buffer: Buffer;
+    let result: Awaited<ReturnType<typeof loadSharedOAuthTokens>>;
     try {
-      buffer = await fs.readFile(this.tokenFilePath);
+      result = await loadSharedOAuthTokens(this.credentialStore, 'antigravity-subscription');
     } catch {
       return null;
     }
-    if (!safeStorage.isEncryptionAvailable()) return null;
-    try {
-      const decoded = safeStorage.decryptString(buffer);
-      const parsed = JSON.parse(decoded) as PersistedTokens;
-      this.cachedTokens = parsed;
-      return parsed;
-    } catch {
-      // Token file exists but is unreadable. Delete to avoid a
-      // stuck-corrupt state on the next login attempt.
-      try { await fs.unlink(this.tokenFilePath); } catch { /* best-effort */ }
-      return null;
-    }
+    if (result.status !== 'ok') return null;
+    return {
+      access_token: result.tokens.access_token,
+      refresh_token: result.tokens.refresh_token,
+      id_token: result.tokens.id_token,
+      expires_at: result.tokens.expires_at,
+    };
   }
 
   private failureFromError(

--- a/apps/desktop/src/main/oauth/claude-subscription-service.ts
+++ b/apps/desktop/src/main/oauth/claude-subscription-service.ts
@@ -656,9 +656,9 @@ export class ClaudeSubscriptionService {
       return null;
     }
     if (result.status === 'corrupt') {
-      // Entry existed but was not a token payload; the bridge deleted
-      // it so the next login doesn't observe a stuck-corrupt state.
-      this.lastStorageFailedMessage = 'Claude OAuth 共享凭据无法解析，已清理损坏条目，请重新登录。';
+      // Entry exists but is not a token payload; it is kept as-is
+      // (reads never destroy secrets) and a fresh login overwrites it.
+      this.lastStorageFailedMessage = 'Claude OAuth 共享凭据无法解析，请重新登录。';
       return null;
     }
     if (result.status === 'missing') return null;

--- a/apps/desktop/src/main/oauth/claude-subscription-service.ts
+++ b/apps/desktop/src/main/oauth/claude-subscription-service.ts
@@ -191,6 +191,13 @@ export class ClaudeSubscriptionService {
   private lastStorageFailedMessage: string | null = null;
   private authorizing = false;
   private refreshing = false;
+  /**
+   * Bumped by logout. A refresh that started before the bump discards
+   * its result instead of writing tokens back after the user logged
+   * out — in this process, logout is terminal even against an
+   * in-flight refresh's read→network→write window.
+   */
+  private credentialEpoch = 0;
 
   constructor(deps: ClaudeSubscriptionServiceDeps) {
     this.legacyTokenFilePath = join(deps.userDataDir, '.claude_subscription_token');
@@ -326,7 +333,15 @@ export class ClaudeSubscriptionService {
 
     try {
       const tokens = await this.exchangeCodeForTokens(parsed.code, verifier, parsed.state);
-      await this.saveTokens(tokens);
+      // Storage failures are not exchange failures: the one-time code
+      // was consumed successfully, so tell the user to fix the store
+      // instead of implying the code was bad.
+      try {
+        await this.saveTokens(tokens);
+      } catch {
+        this.authorizing = false;
+        return { ok: false, reason: 'storage_failed', message: this.lastStorageFailedMessage ?? '写入共享凭据失败，请检查 credentials.json 权限后重试。' };
+      }
       this.pending.delete(authRequestId);
       this.authorizing = false;
       // Kick a profile fetch in the background; failure is non-fatal
@@ -374,7 +389,12 @@ export class ClaudeSubscriptionService {
     return {
       provider: 'claude-subscription',
       runtimeState,
-      profile: this.cachedProfile ?? { accountUuid: tokens.account_uuid },
+      // The cached profile is only valid for the account the shared
+      // store currently holds — another surface may have re-logged in
+      // with a different account since the profile was fetched.
+      profile: this.cachedProfile?.accountUuid === tokens.account_uuid
+        ? this.cachedProfile
+        : { accountUuid: tokens.account_uuid },
       quota: this.cachedQuota ?? undefined,
       errorMessage: this.errorForState(runtimeState),
     };
@@ -390,6 +410,7 @@ export class ClaudeSubscriptionService {
   async refreshTokens(): Promise<SubscriptionActionResult> {
     const tokens = await this.loadTokens();
     if (!tokens) return { ok: false, reason: 'refresh_failed', message: '当前未登录。' };
+    const epoch = this.credentialEpoch;
     this.refreshing = true;
     try {
       const next = await refreshOAuthSubscriptionTokens({
@@ -398,14 +419,25 @@ export class ClaudeSubscriptionService {
         now: this.now,
         fetchFn: this.fetchFn,
       });
-      await this.saveTokens({
-        access_token: next.access_token,
-        refresh_token: next.refresh_token,
-        expires_at: next.expires_at,
-        token_type: next.token_type ?? tokens.token_type,
-        scope: next.scope ?? tokens.scope,
-        account_uuid: next.account_uuid ?? tokens.account_uuid,
-      });
+      if (epoch !== this.credentialEpoch) {
+        // Logout landed while the refresh was in flight: drop the
+        // result instead of resurrecting the deleted credential.
+        this.refreshing = false;
+        return { ok: false, reason: 'refresh_failed', message: '登录状态已变更，本次刷新结果已丢弃。' };
+      }
+      try {
+        await this.saveTokens({
+          access_token: next.access_token,
+          refresh_token: next.refresh_token,
+          expires_at: next.expires_at,
+          token_type: next.token_type ?? tokens.token_type,
+          scope: next.scope ?? tokens.scope,
+          account_uuid: next.account_uuid ?? tokens.account_uuid,
+        });
+      } catch {
+        this.refreshing = false;
+        return { ok: false, reason: 'storage_failed', message: this.lastStorageFailedMessage ?? '写入共享凭据失败，请检查 credentials.json 权限后重试。' };
+      }
       this.lastRefreshFailedMessage = null;
       this.refreshing = false;
       return { ok: true };
@@ -483,6 +515,7 @@ export class ClaudeSubscriptionService {
    *   - Clear runtime diagnostic flags.
    */
   async logout(): Promise<SubscriptionActionResult> {
+    this.credentialEpoch += 1;
     this.cachedQuota = null;
     this.cachedProfile = null;
     this.lastRefreshFailedMessage = null;

--- a/apps/desktop/src/main/oauth/claude-subscription-service.ts
+++ b/apps/desktop/src/main/oauth/claude-subscription-service.ts
@@ -4,8 +4,11 @@
  * Responsibilities:
  *   1. PKCE authorize URL generation + pending state (G-X1).
  *   2. Paste-code parsing + state validation (G-X2).
- *   3. Token exchange + refresh + persistence via safeStorage with
- *      explicit mode 0o600 (G-X1 + kenji hard gates).
+ *   3. Token exchange + refresh + persistence via the shared
+ *      CredentialStore (workspace credentials.json) — the single
+ *      cross-surface token authority (#1125). Refresh goes through
+ *      the runtime's provider refresher so desktop and pure-Node
+ *      surfaces share one refresh implementation.
  *   4. Usage quota fetch (caches with QUOTA_CACHE_TTL_MS).
  *   5. Logout: clears in-memory + deletes token file.
  *   6. Account state snapshot for renderer (no token-shaped fields).
@@ -20,7 +23,7 @@
  *   - PKCE state matched with constant-time equality (G-X1).
  */
 
-import { safeStorage, shell } from 'electron';
+import { shell } from 'electron';
 import { createHash, randomBytes, randomUUID } from 'node:crypto';
 import { promises as fs } from 'node:fs';
 import { dirname, join } from 'node:path';
@@ -42,12 +45,13 @@ import {
   type SubscriptionActionResult,
 } from '@maka/core';
 import {
-  serializeOAuthSubscriptionTokens,
+  refreshOAuthSubscriptionTokens,
 } from '@maka/runtime';
-import type { CredentialStore } from '@maka/storage';
 import {
-  tryDeleteSharedOAuthToken,
-  trySaveSharedOAuthToken,
+  deleteSharedOAuthTokens,
+  loadSharedOAuthTokens,
+  saveSharedOAuthTokens,
+  type SharedOAuthCredentialStore,
 } from './shared-credential-bridge.js';
 
 // =============================================================
@@ -79,12 +83,13 @@ export const CLAUDE_SUBSCRIPTION_PRODUCT_VERSION = '2.1.153';
 const OAUTH_USER_AGENT = `claude-cli/${CLAUDE_SUBSCRIPTION_PRODUCT_VERSION} (external, cli)`;
 
 // =============================================================
-// Token storage — encrypted via safeStorage, mode 0o600.
+// Token storage — shared CredentialStore (workspace
+// credentials.json), the cross-surface authority (#1125).
 // =============================================================
 
 /**
- * Tokens persisted to disk. INTERNAL TO THIS MODULE — never crosses
- * the IPC boundary. The renderer only sees the public
+ * Tokens persisted to the shared store. INTERNAL TO THIS MODULE —
+ * never crosses the IPC boundary. The renderer only sees the public
  * `SubscriptionAccountState` shape, which omits these fields.
  *
  * Field names use snake_case to match Anthropic's token response;
@@ -160,18 +165,21 @@ export interface ClaudeSubscriptionServiceDeps {
   now?: () => number;
   /** fetch implementation. Defaults to global fetch (Node 18+). */
   fetchFn?: typeof fetch;
-  /** Shared workspace credential store used as a one-way export for pure-Node callers such as the CLI. */
-  credentialStore?: Pick<CredentialStore, 'setSecret' | 'deleteSecret'>;
+  /** Shared workspace credential store — the authoritative token store for every surface (#1125). */
+  credentialStore: SharedOAuthCredentialStore;
 }
 
 export class ClaudeSubscriptionService {
-  private readonly tokenFilePath: string;
+  /** Pre-#1125 safeStorage-encrypted token file. Never written or read
+   *  anymore; unlinked on logout in case the startup import could not
+   *  run (e.g. keychain unavailable) so logout still means "no
+   *  credential survives anywhere". */
+  private readonly legacyTokenFilePath: string;
   private readonly deviceIdFilePath: string;
   private readonly now: () => number;
   private readonly fetchFn: typeof fetch;
-  private readonly credentialStore?: Pick<CredentialStore, 'setSecret' | 'deleteSecret'>;
+  private readonly credentialStore: SharedOAuthCredentialStore;
 
-  private cachedTokens: PersistedTokens | null = null;
   private cachedQuota: QuotaSnapshot | null = null;
   private cachedProfile: SubscriptionAccountProfile | null = null;
   private pending: Map<string, PendingAuthorization> = new Map();
@@ -185,7 +193,7 @@ export class ClaudeSubscriptionService {
   private refreshing = false;
 
   constructor(deps: ClaudeSubscriptionServiceDeps) {
-    this.tokenFilePath = join(deps.userDataDir, '.claude_subscription_token');
+    this.legacyTokenFilePath = join(deps.userDataDir, '.claude_subscription_token');
     this.deviceIdFilePath = join(deps.userDataDir, '.claude_subscription_device_id');
     this.now = deps.now ?? (() => Date.now());
     this.fetchFn = deps.fetchFn ?? (globalThis.fetch as typeof fetch);
@@ -319,7 +327,6 @@ export class ClaudeSubscriptionService {
     try {
       const tokens = await this.exchangeCodeForTokens(parsed.code, verifier, parsed.state);
       await this.saveTokens(tokens);
-      this.cachedTokens = tokens;
       this.pending.delete(authRequestId);
       this.authorizing = false;
       // Kick a profile fetch in the background; failure is non-fatal
@@ -385,9 +392,20 @@ export class ClaudeSubscriptionService {
     if (!tokens) return { ok: false, reason: 'refresh_failed', message: '当前未登录。' };
     this.refreshing = true;
     try {
-      const next = await this.requestRefresh(tokens.refresh_token, tokens.account_uuid);
-      await this.saveTokens(next);
-      this.cachedTokens = next;
+      const next = await refreshOAuthSubscriptionTokens({
+        providerType: 'claude-subscription',
+        tokens,
+        now: this.now,
+        fetchFn: this.fetchFn,
+      });
+      await this.saveTokens({
+        access_token: next.access_token,
+        refresh_token: next.refresh_token,
+        expires_at: next.expires_at,
+        token_type: next.token_type ?? tokens.token_type,
+        scope: next.scope ?? tokens.scope,
+        account_uuid: next.account_uuid ?? tokens.account_uuid,
+      });
       this.lastRefreshFailedMessage = null;
       this.refreshing = false;
       return { ok: true };
@@ -458,13 +476,13 @@ export class ClaudeSubscriptionService {
    * the claude.ai account-side UI.
    *
    * What this method DOES:
-   *   - Delete token file (ENOENT is treated as success — already gone).
-   *   - Clear `cachedTokens`, `cachedProfile`, `cachedQuota`.
+   *   - Delete the shared-store token (the authority) and any legacy
+   *     safeStorage token file the startup import could not process.
+   *   - Clear `cachedProfile`, `cachedQuota`.
    *   - Clear in-flight pending authorizations.
    *   - Clear runtime diagnostic flags.
    */
   async logout(): Promise<SubscriptionActionResult> {
-    this.cachedTokens = null;
     this.cachedQuota = null;
     this.cachedProfile = null;
     this.lastRefreshFailedMessage = null;
@@ -473,22 +491,22 @@ export class ClaudeSubscriptionService {
     this.lastStorageFailedMessage = null;
     this.pending.clear();
     this.authorizing = false;
-    let localDeleteFailed = false;
+    let legacyDeleteFailed = false;
     try {
-      await fs.unlink(this.tokenFilePath);
+      await fs.unlink(this.legacyTokenFilePath);
     } catch (err) {
       // ENOENT is fine; anything else is suspicious but not fatal.
       const code = (err as NodeJS.ErrnoException).code;
       if (code !== 'ENOENT') {
-        localDeleteFailed = true;
+        legacyDeleteFailed = true;
       }
     }
-    const sharedDeleted = await tryDeleteSharedOAuthToken({
-      credentialStore: this.credentialStore,
-      slug: 'claude-subscription',
-    });
-    if (localDeleteFailed) return { ok: false, reason: 'storage_failed', message: '删除本地凭据失败，请手动清理。' };
-    if (!sharedDeleted) return { ok: false, reason: 'storage_failed', message: '删除共享凭据失败，请手动清理。' };
+    try {
+      await deleteSharedOAuthTokens(this.credentialStore, 'claude-subscription');
+    } catch {
+      return { ok: false, reason: 'storage_failed', message: '删除共享凭据失败，请手动清理。' };
+    }
+    if (legacyDeleteFailed) return { ok: false, reason: 'storage_failed', message: '删除本地遗留凭据失败，请手动清理。' };
     return { ok: true };
   }
 
@@ -612,93 +630,48 @@ export class ClaudeSubscriptionService {
     };
   }
 
-  private async requestRefresh(refreshToken: string, prevAccountUuid: string): Promise<PersistedTokens> {
-    const response = await this.fetchFn(CLAUDE_TOKEN_ENDPOINT, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        'User-Agent': OAUTH_USER_AGENT,
-      },
-      body: JSON.stringify({
-        grant_type: 'refresh_token',
-        refresh_token: refreshToken,
-        client_id: CLAUDE_CLIENT_ID,
-      }),
-    });
-    if (!response.ok) throw new Error(`Token refresh failed (${response.status}).`);
-    const payload = (await response.json()) as {
-      access_token: string;
-      refresh_token: string;
-      expires_in: number;
-      token_type: string;
-      scope: string;
-      account?: { uuid?: string };
-    };
-    return {
-      access_token: payload.access_token,
-      refresh_token: payload.refresh_token,
-      expires_at: this.now() + 1000 * payload.expires_in,
-      token_type: payload.token_type,
-      scope: payload.scope,
-      account_uuid: payload.account?.uuid ?? prevAccountUuid,
-    };
-  }
-
   private async saveTokens(tokens: PersistedTokens): Promise<void> {
-    const serialized = JSON.stringify(tokens);
-    const dir = dirname(this.tokenFilePath);
-    await fs.mkdir(dir, { recursive: true });
-    if (!safeStorage.isEncryptionAvailable()) {
-      throw new Error('safeStorage encryption is unavailable.');
+    try {
+      await saveSharedOAuthTokens(this.credentialStore, 'claude-subscription', tokens);
+    } catch (err) {
+      // Fail closed: a token we cannot persist for every surface is a
+      // storage failure, not a partial success.
+      this.lastStorageFailedMessage = '写入 Claude OAuth 共享凭据失败，请检查 credentials.json 权限后重试。';
+      throw err;
     }
-    const buffer = safeStorage.encryptString(serialized);
-    await fs.writeFile(this.tokenFilePath, buffer, { mode: 0o600 });
-    // Re-apply mode explicitly in case the existing file had a
-    // different mode (writeFile only sets it on create).
-    await fs.chmod(this.tokenFilePath, 0o600);
-    await this.trySaveSharedTokens(tokens);
     this.lastStorageFailedMessage = null;
   }
 
+  /**
+   * Always reads the shared store — no in-memory copy. Pure-Node
+   * surfaces refresh and rewrite the same entry, so caching here could
+   * hold a rotated-out refresh token.
+   */
   private async loadTokens(): Promise<PersistedTokens | null> {
-    if (this.cachedTokens) return this.cachedTokens;
-    let buffer: Buffer;
+    let result: Awaited<ReturnType<typeof loadSharedOAuthTokens>>;
     try {
-      buffer = await fs.readFile(this.tokenFilePath);
-    } catch (error) {
-      const code = (error as NodeJS.ErrnoException).code;
-      if (code !== 'ENOENT') {
-        this.lastStorageFailedMessage = '读取 Claude OAuth 本地凭据失败，请检查文件权限或重新登录。';
-      }
-      return null;
-    }
-    if (!safeStorage.isEncryptionAvailable()) {
-      this.lastStorageFailedMessage = '系统 safeStorage 当前不可用，无法读取 Claude OAuth 本地凭据。';
-      return null;
-    }
-    try {
-      const decoded = safeStorage.decryptString(buffer);
-      const parsed = JSON.parse(decoded) as PersistedTokens;
-      this.cachedTokens = parsed;
-      this.lastStorageFailedMessage = null;
-      await this.trySaveSharedTokens(parsed);
-      return parsed;
+      result = await loadSharedOAuthTokens(this.credentialStore, 'claude-subscription');
     } catch {
-      // Token file exists but is unreadable (keychain rolled, file
-      // corrupted, JSON shape drifted). Delete it so the next
-      // login attempt doesn't observe a stuck-corrupt state.
-      this.lastStorageFailedMessage = 'Claude OAuth 本地凭据无法解密，已清理损坏文件，请重新登录。';
-      try { await fs.unlink(this.tokenFilePath); } catch { /* best-effort */ }
+      this.lastStorageFailedMessage = '读取 Claude OAuth 共享凭据失败，请检查 credentials.json 或重新登录。';
       return null;
     }
-  }
-
-  private async trySaveSharedTokens(tokens: PersistedTokens): Promise<void> {
-    await trySaveSharedOAuthToken({
-      credentialStore: this.credentialStore,
-      slug: 'claude-subscription',
-      value: serializeOAuthSubscriptionTokens(tokens),
-    });
+    if (result.status === 'corrupt') {
+      // Entry existed but was not a token payload; the bridge deleted
+      // it so the next login doesn't observe a stuck-corrupt state.
+      this.lastStorageFailedMessage = 'Claude OAuth 共享凭据无法解析，已清理损坏条目，请重新登录。';
+      return null;
+    }
+    if (result.status === 'missing') return null;
+    this.lastStorageFailedMessage = null;
+    const tokens = result.tokens;
+    return {
+      access_token: tokens.access_token,
+      refresh_token: tokens.refresh_token,
+      expires_at: tokens.expires_at,
+      token_type: tokens.token_type ?? 'Bearer',
+      scope: tokens.scope ?? '',
+      account_uuid: tokens.account_uuid ?? '',
+    };
   }
 
   private async refreshProfile(): Promise<void> {
@@ -717,7 +690,7 @@ export class ClaudeSubscriptionService {
       };
       if (data.account) {
         this.cachedProfile = {
-          accountUuid: data.account.uuid ?? (this.cachedTokens?.account_uuid ?? ''),
+          accountUuid: data.account.uuid ?? ((await this.loadTokens())?.account_uuid ?? ''),
           email: data.account.email ?? data.account.email_address,
           displayName: data.account.display_name,
         };

--- a/apps/desktop/src/main/oauth/cursor-subscription-service.ts
+++ b/apps/desktop/src/main/oauth/cursor-subscription-service.ts
@@ -14,14 +14,16 @@
  *   - Refresh failure does NOT auto-logout.
  *   - The login URL is held in-process; the renderer only
  *     receives an opaque `authRequestId`.
+ *   - Tokens persist in the shared CredentialStore (workspace
+ *     credentials.json), the cross-surface authority (#1125).
  *
  * Reference: cursor-auth plugin pattern (external reference).
  */
 
-import { safeStorage, shell } from 'electron';
+import { shell } from 'electron';
 import { randomBytes, randomUUID } from 'node:crypto';
 import { promises as fs } from 'node:fs';
-import { dirname, join } from 'node:path';
+import { join } from 'node:path';
 import {
   PENDING_AUTHORIZATION_TTL_MS,
   PKCE_VERIFIER_LENGTH_BYTES,
@@ -36,6 +38,12 @@ import {
   getTokenExpiry,
   pkceChallengeFromVerifier,
 } from './cursor-subscription-helpers.js';
+import {
+  deleteSharedOAuthTokens,
+  loadSharedOAuthTokens,
+  saveSharedOAuthTokens,
+  type SharedOAuthCredentialStore,
+} from './shared-credential-bridge.js';
 
 // Endpoint shortcuts so the existing class body reads like the
 // Claude / Codex services (constants at the top, lookups inline).
@@ -89,15 +97,20 @@ export interface CursorSubscriptionServiceDeps {
   /** Sleep function. Injectable for tests so poll loops don't
    *  actually wait. */
   sleepFn?: (ms: number) => Promise<void>;
+  /** Shared workspace credential store — the authoritative token store for every surface (#1125). */
+  credentialStore: SharedOAuthCredentialStore;
 }
 
 export class CursorSubscriptionService {
-  private readonly tokenFilePath: string;
+  /** Pre-#1125 safeStorage-encrypted token file. Never written or read
+   *  anymore; unlinked on logout in case the startup import could not
+   *  run, so logout still means "no credential survives anywhere". */
+  private readonly legacyTokenFilePath: string;
   private readonly now: () => number;
   private readonly fetchFn: typeof fetch;
   private readonly sleepFn: (ms: number) => Promise<void>;
+  private readonly credentialStore: SharedOAuthCredentialStore;
 
-  private cachedTokens: PersistedTokens | null = null;
   private pending: Map<string, PendingAuthorization> = new Map();
 
   private lastRefreshFailedMessage: string | null = null;
@@ -105,11 +118,12 @@ export class CursorSubscriptionService {
   private refreshing = false;
 
   constructor(deps: CursorSubscriptionServiceDeps) {
-    this.tokenFilePath = join(deps.userDataDir, '.cursor_subscription_token');
+    this.legacyTokenFilePath = join(deps.userDataDir, '.cursor_subscription_token');
     this.now = deps.now ?? (() => Date.now());
     this.fetchFn = deps.fetchFn ?? (globalThis.fetch as typeof fetch);
     this.sleepFn =
       deps.sleepFn ?? ((ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms)));
+    this.credentialStore = deps.credentialStore;
   }
 
   // -----------------------------------------------------------
@@ -199,7 +213,6 @@ export class CursorSubscriptionService {
     try {
       const tokens = await pending.pollPromise;
       await this.saveTokens(tokens);
-      this.cachedTokens = tokens;
       this.disposePending(authRequestId);
       this.authorizing = false;
       return { ok: true };
@@ -257,7 +270,6 @@ export class CursorSubscriptionService {
     try {
       const next = await this.requestRefresh(tokens.refresh_token);
       await this.saveTokens(next);
-      this.cachedTokens = next;
       this.lastRefreshFailedMessage = null;
       this.refreshing = false;
       return { ok: true };
@@ -270,21 +282,29 @@ export class CursorSubscriptionService {
   }
 
   /**
-   * Logout: clear in-memory + delete token file. Local clear only.
+   * Logout: clear in-memory state, delete the shared-store token (the
+   * authority) and any legacy safeStorage token file the startup
+   * import could not process. Local clear only.
    */
   async logout(): Promise<SubscriptionActionResult> {
-    this.cachedTokens = null;
     this.lastRefreshFailedMessage = null;
     for (const id of [...this.pending.keys()]) this.disposePending(id);
     this.authorizing = false;
+    let legacyDeleteFailed = false;
     try {
-      await fs.unlink(this.tokenFilePath);
+      await fs.unlink(this.legacyTokenFilePath);
     } catch (err) {
       const code = (err as NodeJS.ErrnoException).code;
       if (code !== 'ENOENT') {
-        return { ok: false, reason: 'storage_failed', message: '删除本地凭据失败，请手动清理。' };
+        legacyDeleteFailed = true;
       }
     }
+    try {
+      await deleteSharedOAuthTokens(this.credentialStore, 'cursor-subscription');
+    } catch {
+      return { ok: false, reason: 'storage_failed', message: '删除共享凭据失败，请手动清理。' };
+    }
+    if (legacyDeleteFailed) return { ok: false, reason: 'storage_failed', message: '删除本地遗留凭据失败，请手动清理。' };
     return { ok: true };
   }
 
@@ -408,37 +428,29 @@ export class CursorSubscriptionService {
   }
 
   private async saveTokens(tokens: PersistedTokens): Promise<void> {
-    const serialized = JSON.stringify(tokens);
-    const dir = dirname(this.tokenFilePath);
-    await fs.mkdir(dir, { recursive: true });
-    if (!safeStorage.isEncryptionAvailable()) {
-      throw new Error('safeStorage encryption is unavailable.');
-    }
-    const buffer = safeStorage.encryptString(serialized);
-    await fs.writeFile(this.tokenFilePath, buffer, { mode: 0o600 });
-    await fs.chmod(this.tokenFilePath, 0o600);
+    // Fail closed: a store write failure propagates to the caller's
+    // failure envelope instead of pretending the login stuck.
+    await saveSharedOAuthTokens(this.credentialStore, 'cursor-subscription', tokens);
   }
 
+  /**
+   * Always reads the shared store — no in-memory copy; the store is
+   * the cross-surface authority (#1125). A corrupt entry is deleted by
+   * the bridge so the next login isn't stuck.
+   */
   private async loadTokens(): Promise<PersistedTokens | null> {
-    if (this.cachedTokens) return this.cachedTokens;
-    let buffer: Buffer;
+    let result: Awaited<ReturnType<typeof loadSharedOAuthTokens>>;
     try {
-      buffer = await fs.readFile(this.tokenFilePath);
+      result = await loadSharedOAuthTokens(this.credentialStore, 'cursor-subscription');
     } catch {
       return null;
     }
-    if (!safeStorage.isEncryptionAvailable()) return null;
-    try {
-      const decoded = safeStorage.decryptString(buffer);
-      const parsed = JSON.parse(decoded) as PersistedTokens;
-      this.cachedTokens = parsed;
-      return parsed;
-    } catch {
-      // Token file exists but is unreadable. Delete to avoid a
-      // stuck-corrupt state on the next login attempt.
-      try { await fs.unlink(this.tokenFilePath); } catch { /* best-effort */ }
-      return null;
-    }
+    if (result.status !== 'ok') return null;
+    return {
+      access_token: result.tokens.access_token,
+      refresh_token: result.tokens.refresh_token,
+      expires_at: result.tokens.expires_at,
+    };
   }
 
   private failureFromError(

--- a/apps/desktop/src/main/oauth/openai-codex-service.ts
+++ b/apps/desktop/src/main/oauth/openai-codex-service.ts
@@ -5,8 +5,9 @@
  * mirrors its shape:
  *   - PKCE authorize URL generation + pending state.
  *   - Loopback callback server (port 1455) captures the redirect.
- *   - Token exchange + refresh + safeStorage-encrypted persistence
- *     under `app.getPath('userData')` with mode 0o600.
+ *   - Token exchange + refresh + persistence via the shared
+ *     CredentialStore (workspace credentials.json), the single
+ *     cross-surface token authority (#1125).
  *   - Account state snapshot for renderer — never exposes tokens.
  *
  * Hard gates (shared with the Claude service):
@@ -21,11 +22,11 @@
  * endpoint constants pinned to that file's values.
  */
 
-import { safeStorage, shell } from 'electron';
+import { shell } from 'electron';
 import { randomBytes, randomUUID } from 'node:crypto';
 import { promises as fs } from 'node:fs';
 import { createServer, type IncomingMessage, type Server, type ServerResponse } from 'node:http';
-import { dirname, join } from 'node:path';
+import { join } from 'node:path';
 import {
   PENDING_AUTHORIZATION_TTL_MS,
   PKCE_VERIFIER_LENGTH_BYTES,
@@ -37,12 +38,13 @@ import {
   type SubscriptionActionResult,
 } from '@maka/core';
 import {
-  serializeOAuthSubscriptionTokens,
+  refreshOAuthSubscriptionTokens,
 } from '@maka/runtime';
-import type { CredentialStore } from '@maka/storage';
 import {
-  tryDeleteSharedOAuthToken,
-  trySaveSharedOAuthToken,
+  deleteSharedOAuthTokens,
+  loadSharedOAuthTokens,
+  saveSharedOAuthTokens,
+  type SharedOAuthCredentialStore,
 } from './shared-credential-bridge.js';
 import {
   CODEX_OAUTH_CONFIG,
@@ -115,17 +117,19 @@ export interface OpenAiCodexServiceDeps {
   now?: () => number;
   /** fetch implementation. Defaults to global fetch (Node 18+). */
   fetchFn?: typeof fetch;
-  /** Shared workspace credential store used as a one-way export for pure-Node callers such as the CLI. */
-  credentialStore?: Pick<CredentialStore, 'setSecret' | 'deleteSecret'>;
+  /** Shared workspace credential store — the authoritative token store for every surface (#1125). */
+  credentialStore: SharedOAuthCredentialStore;
 }
 
 export class OpenAiCodexService {
-  private readonly tokenFilePath: string;
+  /** Pre-#1125 safeStorage-encrypted token file. Never written or read
+   *  anymore; unlinked on logout in case the startup import could not
+   *  run, so logout still means "no credential survives anywhere". */
+  private readonly legacyTokenFilePath: string;
   private readonly now: () => number;
   private readonly fetchFn: typeof fetch;
-  private readonly credentialStore?: Pick<CredentialStore, 'setSecret' | 'deleteSecret'>;
+  private readonly credentialStore: SharedOAuthCredentialStore;
 
-  private cachedTokens: PersistedTokens | null = null;
   private cachedClaims: AccountClaims | null = null;
   private pending: Map<string, PendingAuthorization> = new Map();
 
@@ -135,7 +139,7 @@ export class OpenAiCodexService {
   private refreshing = false;
 
   constructor(deps: OpenAiCodexServiceDeps) {
-    this.tokenFilePath = join(deps.userDataDir, '.codex_subscription_token');
+    this.legacyTokenFilePath = join(deps.userDataDir, '.codex_subscription_token');
     this.now = deps.now ?? (() => Date.now());
     this.fetchFn = deps.fetchFn ?? (globalThis.fetch as typeof fetch);
     this.credentialStore = deps.credentialStore;
@@ -254,7 +258,6 @@ export class OpenAiCodexService {
       }
       const tokens = await this.exchangeCodeForTokens(code, pending.verifier);
       await this.saveTokens(tokens);
-      this.cachedTokens = tokens;
       this.cachedClaims = extractAccountClaims(tokens.access_token, tokens.id_token);
       this.disposePending(authRequestId);
       this.authorizing = false;
@@ -321,10 +324,21 @@ export class OpenAiCodexService {
     if (!tokens) return { ok: false, reason: 'refresh_failed', message: '当前未登录。' };
     this.refreshing = true;
     try {
-      const next = await this.requestRefresh(tokens);
-      await this.saveTokens(next);
-      this.cachedTokens = next;
-      this.cachedClaims = extractAccountClaims(next.access_token, next.id_token);
+      const next = await refreshOAuthSubscriptionTokens({
+        providerType: 'openai-codex',
+        tokens,
+        now: this.now,
+        fetchFn: this.fetchFn,
+      });
+      const claims = extractAccountClaims(next.access_token, next.id_token);
+      await this.saveTokens({
+        access_token: next.access_token,
+        refresh_token: next.refresh_token,
+        id_token: next.id_token,
+        expires_at: next.expires_at,
+        account_id: claims.accountId || tokens.account_id,
+      });
+      this.cachedClaims = claims;
       this.lastRefreshFailedMessage = null;
       this.refreshing = false;
       return { ok: true };
@@ -337,32 +351,33 @@ export class OpenAiCodexService {
   }
 
   /**
-   * Logout: clear in-memory + delete token file. Local clear only;
-   * no remote revocation (auth.openai.com does not publicly expose
-   * an RFC 7009 endpoint we can rely on).
+   * Logout: clear in-memory state, delete the shared-store token (the
+   * authority) and any legacy safeStorage token file the startup
+   * import could not process. Local clear only; no remote revocation
+   * (auth.openai.com does not publicly expose an RFC 7009 endpoint we
+   * can rely on).
    */
   async logout(): Promise<SubscriptionActionResult> {
-    this.cachedTokens = null;
     this.cachedClaims = null;
     this.lastRefreshFailedMessage = null;
     this.lastStorageFailedMessage = null;
     for (const id of [...this.pending.keys()]) this.disposePending(id);
     this.authorizing = false;
-    let localDeleteFailed = false;
+    let legacyDeleteFailed = false;
     try {
-      await fs.unlink(this.tokenFilePath);
+      await fs.unlink(this.legacyTokenFilePath);
     } catch (err) {
       const code = (err as NodeJS.ErrnoException).code;
       if (code !== 'ENOENT') {
-        localDeleteFailed = true;
+        legacyDeleteFailed = true;
       }
     }
-    const sharedDeleted = await tryDeleteSharedOAuthToken({
-      credentialStore: this.credentialStore,
-      slug: 'codex-subscription',
-    });
-    if (localDeleteFailed) return { ok: false, reason: 'storage_failed', message: '删除本地凭据失败，请手动清理。' };
-    if (!sharedDeleted) return { ok: false, reason: 'storage_failed', message: '删除共享凭据失败，请手动清理。' };
+    try {
+      await deleteSharedOAuthTokens(this.credentialStore, 'codex-subscription');
+    } catch {
+      return { ok: false, reason: 'storage_failed', message: '删除共享凭据失败，请手动清理。' };
+    }
+    if (legacyDeleteFailed) return { ok: false, reason: 'storage_failed', message: '删除本地遗留凭据失败，请手动清理。' };
     return { ok: true };
   }
 
@@ -537,91 +552,47 @@ export class OpenAiCodexService {
     };
   }
 
-  private async requestRefresh(tokens: PersistedTokens): Promise<PersistedTokens> {
-    const body = new URLSearchParams({
-      grant_type: 'refresh_token',
-      client_id: CODEX_CLIENT_ID,
-      refresh_token: tokens.refresh_token,
-    });
-    const response = await this.fetchFn(CODEX_TOKEN_ENDPOINT, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/x-www-form-urlencoded',
-        'User-Agent': PLAIN_USER_AGENT,
-      },
-      body: body.toString(),
-    });
-    if (!response.ok) throw new Error(`Token refresh failed (${response.status}).`);
-    const payload = (await response.json()) as {
-      access_token: string;
-      refresh_token?: string;
-      id_token?: string;
-      expires_in: number;
-    };
-    const nextIdToken = payload.id_token ?? tokens.id_token;
-    const claims = extractAccountClaims(payload.access_token, nextIdToken);
-    return {
-      access_token: payload.access_token,
-      refresh_token: payload.refresh_token ?? tokens.refresh_token,
-      id_token: nextIdToken,
-      expires_at: this.now() + 1000 * payload.expires_in,
-      account_id: claims.accountId || tokens.account_id,
-    };
-  }
-
   private async saveTokens(tokens: PersistedTokens): Promise<void> {
-    const serialized = JSON.stringify(tokens);
-    const dir = dirname(this.tokenFilePath);
-    await fs.mkdir(dir, { recursive: true });
-    if (!safeStorage.isEncryptionAvailable()) {
-      throw new Error('safeStorage encryption is unavailable.');
+    try {
+      await saveSharedOAuthTokens(this.credentialStore, 'codex-subscription', tokens);
+    } catch (err) {
+      // Fail closed: a token we cannot persist for every surface is a
+      // storage failure, not a partial success.
+      this.lastStorageFailedMessage = '写入 Codex OAuth 共享凭据失败，请检查 credentials.json 权限后重试。';
+      throw err;
     }
-    const buffer = safeStorage.encryptString(serialized);
-    await fs.writeFile(this.tokenFilePath, buffer, { mode: 0o600 });
-    await fs.chmod(this.tokenFilePath, 0o600);
-    await this.trySaveSharedTokens(tokens);
     this.lastStorageFailedMessage = null;
   }
 
+  /**
+   * Always reads the shared store — no in-memory copy. Pure-Node
+   * surfaces refresh and rewrite the same entry, so caching here could
+   * hold a rotated-out refresh token.
+   */
   private async loadTokens(): Promise<PersistedTokens | null> {
-    if (this.cachedTokens) return this.cachedTokens;
-    let buffer: Buffer;
+    let result: Awaited<ReturnType<typeof loadSharedOAuthTokens>>;
     try {
-      buffer = await fs.readFile(this.tokenFilePath);
-    } catch (error) {
-      const code = (error as NodeJS.ErrnoException).code;
-      if (code !== 'ENOENT') {
-        this.lastStorageFailedMessage = '读取 Codex OAuth 本地凭据失败，请检查文件权限或重新登录。';
-      }
-      return null;
-    }
-    if (!safeStorage.isEncryptionAvailable()) {
-      this.lastStorageFailedMessage = '系统 safeStorage 当前不可用，无法读取 Codex OAuth 本地凭据。';
-      return null;
-    }
-    try {
-      const decoded = safeStorage.decryptString(buffer);
-      const parsed = JSON.parse(decoded) as PersistedTokens;
-      this.cachedTokens = parsed;
-      this.lastStorageFailedMessage = null;
-      await this.trySaveSharedTokens(parsed);
-      return parsed;
+      result = await loadSharedOAuthTokens(this.credentialStore, 'codex-subscription');
     } catch {
-      // Token file exists but is unreadable (keychain rolled, file
-      // corrupted, JSON shape drifted). Delete it so the next login
-      // flow doesn't observe a stuck-corrupt state. Best-effort.
-      this.lastStorageFailedMessage = 'Codex OAuth 本地凭据无法解密，已清理损坏文件，请重新登录。';
-      try { await fs.unlink(this.tokenFilePath); } catch { /* best-effort */ }
+      this.lastStorageFailedMessage = '读取 Codex OAuth 共享凭据失败，请检查 credentials.json 或重新登录。';
       return null;
     }
-  }
-
-  private async trySaveSharedTokens(tokens: PersistedTokens): Promise<void> {
-    await trySaveSharedOAuthToken({
-      credentialStore: this.credentialStore,
-      slug: 'codex-subscription',
-      value: serializeOAuthSubscriptionTokens(tokens),
-    });
+    if (result.status === 'corrupt') {
+      // Entry existed but was not a token payload; the bridge deleted
+      // it so the next login doesn't observe a stuck-corrupt state.
+      this.lastStorageFailedMessage = 'Codex OAuth 共享凭据无法解析，已清理损坏条目，请重新登录。';
+      return null;
+    }
+    if (result.status === 'missing') return null;
+    this.lastStorageFailedMessage = null;
+    const tokens = result.tokens;
+    return {
+      access_token: tokens.access_token,
+      refresh_token: tokens.refresh_token,
+      id_token: tokens.id_token,
+      expires_at: tokens.expires_at,
+      account_id: tokens.account_id ?? '',
+    };
   }
 
   private failureFromError(

--- a/apps/desktop/src/main/oauth/openai-codex-service.ts
+++ b/apps/desktop/src/main/oauth/openai-codex-service.ts
@@ -578,9 +578,9 @@ export class OpenAiCodexService {
       return null;
     }
     if (result.status === 'corrupt') {
-      // Entry existed but was not a token payload; the bridge deleted
-      // it so the next login doesn't observe a stuck-corrupt state.
-      this.lastStorageFailedMessage = 'Codex OAuth 共享凭据无法解析，已清理损坏条目，请重新登录。';
+      // Entry exists but is not a token payload; it is kept as-is
+      // (reads never destroy secrets) and a fresh login overwrites it.
+      this.lastStorageFailedMessage = 'Codex OAuth 共享凭据无法解析，请重新登录。';
       return null;
     }
     if (result.status === 'missing') return null;

--- a/apps/desktop/src/main/oauth/openai-codex-service.ts
+++ b/apps/desktop/src/main/oauth/openai-codex-service.ts
@@ -52,7 +52,6 @@ import {
   extractAccountClaims,
   pkceChallengeFromVerifier,
   safeExtractAccountClaims,
-  type CodexAccountClaims,
 } from './openai-codex-helpers.js';
 
 // Endpoint shortcuts so the existing class body keeps reading
@@ -81,8 +80,6 @@ interface PersistedTokens {
   account_id: string;
   /* eslint-enable */
 }
-
-type AccountClaims = CodexAccountClaims;
 
 interface PendingAuthorization {
   verifier: string;
@@ -130,13 +127,19 @@ export class OpenAiCodexService {
   private readonly fetchFn: typeof fetch;
   private readonly credentialStore: SharedOAuthCredentialStore;
 
-  private cachedClaims: AccountClaims | null = null;
   private pending: Map<string, PendingAuthorization> = new Map();
 
   private lastRefreshFailedMessage: string | null = null;
   private lastStorageFailedMessage: string | null = null;
   private authorizing = false;
   private refreshing = false;
+  /**
+   * Bumped by logout. A refresh that started before the bump discards
+   * its result instead of writing tokens back after the user logged
+   * out — in this process, logout is terminal even against an
+   * in-flight refresh's read→network→write window.
+   */
+  private credentialEpoch = 0;
 
   constructor(deps: OpenAiCodexServiceDeps) {
     this.legacyTokenFilePath = join(deps.userDataDir, '.codex_subscription_token');
@@ -257,8 +260,16 @@ export class OpenAiCodexService {
         return { ok: false, reason: 'invalid_paste_code', message: '回调 state 校验失败，请重新登录。' };
       }
       const tokens = await this.exchangeCodeForTokens(code, pending.verifier);
-      await this.saveTokens(tokens);
-      this.cachedClaims = extractAccountClaims(tokens.access_token, tokens.id_token);
+      // Storage failures are not exchange failures: the one-time code
+      // was consumed successfully, so tell the user to fix the store
+      // instead of implying the code was bad.
+      try {
+        await this.saveTokens(tokens);
+      } catch {
+        this.disposePending(authRequestId);
+        this.authorizing = false;
+        return { ok: false, reason: 'storage_failed', message: this.lastStorageFailedMessage ?? '写入共享凭据失败，请检查 credentials.json 权限后重试。' };
+      }
       this.disposePending(authRequestId);
       this.authorizing = false;
       return { ok: true };
@@ -301,7 +312,10 @@ export class OpenAiCodexService {
         runtimeState: this.authorizing ? 'authorizing' : 'not_logged_in',
       };
     }
-    const claims = this.cachedClaims ?? safeExtractAccountClaims(tokens.access_token, tokens.id_token);
+    // Claims are always derived from the CURRENT tokens rather than
+    // cached: another surface may have re-logged in with a different
+    // account since this process last saw a login or refresh.
+    const claims = safeExtractAccountClaims(tokens.access_token, tokens.id_token);
     const runtimeState = this.deriveRuntimeState();
     return {
       provider: 'openai-codex',
@@ -322,6 +336,7 @@ export class OpenAiCodexService {
   async refreshTokens(): Promise<SubscriptionActionResult> {
     const tokens = await this.loadTokens();
     if (!tokens) return { ok: false, reason: 'refresh_failed', message: '当前未登录。' };
+    const epoch = this.credentialEpoch;
     this.refreshing = true;
     try {
       const next = await refreshOAuthSubscriptionTokens({
@@ -330,15 +345,25 @@ export class OpenAiCodexService {
         now: this.now,
         fetchFn: this.fetchFn,
       });
+      if (epoch !== this.credentialEpoch) {
+        // Logout landed while the refresh was in flight: drop the
+        // result instead of resurrecting the deleted credential.
+        this.refreshing = false;
+        return { ok: false, reason: 'refresh_failed', message: '登录状态已变更，本次刷新结果已丢弃。' };
+      }
       const claims = extractAccountClaims(next.access_token, next.id_token);
-      await this.saveTokens({
-        access_token: next.access_token,
-        refresh_token: next.refresh_token,
-        id_token: next.id_token,
-        expires_at: next.expires_at,
-        account_id: claims.accountId || tokens.account_id,
-      });
-      this.cachedClaims = claims;
+      try {
+        await this.saveTokens({
+          access_token: next.access_token,
+          refresh_token: next.refresh_token,
+          id_token: next.id_token,
+          expires_at: next.expires_at,
+          account_id: claims.accountId || tokens.account_id,
+        });
+      } catch {
+        this.refreshing = false;
+        return { ok: false, reason: 'storage_failed', message: this.lastStorageFailedMessage ?? '写入共享凭据失败，请检查 credentials.json 权限后重试。' };
+      }
       this.lastRefreshFailedMessage = null;
       this.refreshing = false;
       return { ok: true };
@@ -358,7 +383,7 @@ export class OpenAiCodexService {
    * can rely on).
    */
   async logout(): Promise<SubscriptionActionResult> {
-    this.cachedClaims = null;
+    this.credentialEpoch += 1;
     this.lastRefreshFailedMessage = null;
     this.lastStorageFailedMessage = null;
     for (const id of [...this.pending.keys()]) this.disposePending(id);

--- a/apps/desktop/src/main/oauth/shared-credential-bridge.ts
+++ b/apps/desktop/src/main/oauth/shared-credential-bridge.ts
@@ -1,7 +1,184 @@
+/**
+ * OAuth token persistence for the desktop subscription services.
+ *
+ * The pure-Node `CredentialStore` (workspace `credentials.json`) is the
+ * single authority for runtime-usable OAuth tokens (#1125): desktop,
+ * TUI, and headless all read and write the same store, so a desktop
+ * login is immediately usable from pure-Node surfaces and vice versa.
+ * Electron `safeStorage` no longer stores tokens; it only decrypts
+ * legacy per-service token files once via
+ * `importLegacyOAuthTokenFiles`, after which those files are removed.
+ *
+ * Read/write failures are the caller's to surface (`storage_failed`),
+ * so unlike the historical best-effort export, these helpers do not
+ * swallow store errors.
+ */
+
+import { promises as fs } from 'node:fs';
+import {
+  parseOAuthSubscriptionTokens,
+  serializeOAuthSubscriptionTokens,
+  type OAuthSubscriptionTokens,
+} from '@maka/runtime';
 import type { CredentialStore } from '@maka/storage';
 
+export type SharedOAuthCredentialStore = Pick<CredentialStore, 'getSecret' | 'setSecret' | 'deleteSecret'>;
+
+/** @deprecated Transitional alias while services migrate to the store-authority API. */
 export type SharedOAuthCredentialSaveStore = Pick<CredentialStore, 'setSecret'>;
+/** @deprecated Transitional alias while services migrate to the store-authority API. */
 export type SharedOAuthCredentialDeleteStore = Pick<CredentialStore, 'deleteSecret'>;
+
+export type SharedOAuthTokensReadResult =
+  | { status: 'ok'; tokens: OAuthSubscriptionTokens }
+  | { status: 'missing' }
+  /** Entry existed but was not a valid token payload; it has been deleted
+   *  so the next login does not observe a stuck-corrupt state. */
+  | { status: 'corrupt' };
+
+/** Persist tokens as the authoritative copy. Throws on store failure. */
+export async function saveSharedOAuthTokens(
+  store: Pick<CredentialStore, 'setSecret'>,
+  slug: string,
+  tokens: OAuthSubscriptionTokens,
+): Promise<void> {
+  await store.setSecret(slug, 'oauth_token', serializeOAuthSubscriptionTokens(tokens));
+}
+
+/**
+ * Load the authoritative tokens. Store read errors (corrupt file,
+ * schema mismatch, stale lock) propagate to the caller; an entry that
+ * exists but does not parse as a token payload is deleted (best-effort)
+ * and reported as `corrupt`.
+ */
+export async function loadSharedOAuthTokens(
+  store: SharedOAuthCredentialStore,
+  slug: string,
+): Promise<SharedOAuthTokensReadResult> {
+  const raw = await store.getSecret(slug, 'oauth_token');
+  if (raw === null) return { status: 'missing' };
+  const tokens = parseOAuthSubscriptionTokens(raw);
+  if (!tokens) {
+    await store.deleteSecret(slug, 'oauth_token').catch(() => {});
+    return { status: 'corrupt' };
+  }
+  return { status: 'ok', tokens };
+}
+
+/** Delete the authoritative tokens. Throws on store failure. */
+export async function deleteSharedOAuthTokens(
+  store: Pick<CredentialStore, 'deleteSecret'>,
+  slug: string,
+): Promise<void> {
+  await store.deleteSecret(slug, 'oauth_token');
+}
+
+// =============================================================
+// One-shot import of legacy safeStorage-encrypted token files.
+// =============================================================
+
+/**
+ * Shape-compatible with Electron's `safeStorage` so main.ts can pass it
+ * straight through; injected so this module never imports `electron`
+ * and the import stays testable in pure Node.
+ */
+export interface LegacySafeStorageDecryptor {
+  isEncryptionAvailable(): boolean;
+  decryptString(encrypted: Buffer): string;
+}
+
+export interface LegacyOAuthTokenFile {
+  slug: string;
+  filePath: string;
+}
+
+export type LegacyOAuthTokenImportOutcome =
+  /** Decrypted and written to the store; file removed. */
+  | 'imported'
+  /** The store already held a token for the slug (it is at least as
+   *  fresh — every legacy write dual-wrote the store, and pure-Node
+   *  refreshes write only the store); file removed as a stale duplicate. */
+  | 'superseded'
+  /** Decryption unavailable or denied; file left intact for a later
+   *  start (never destroy a possibly recoverable secret). */
+  | 'left-encrypted'
+  /** Decrypted fine but the payload is not a token; file removed. */
+  | 'removed-corrupt'
+  /** Unexpected I/O or store error; file left intact. */
+  | 'failed';
+
+export interface LegacyOAuthTokenImportReport {
+  slug: string;
+  filePath: string;
+  outcome: LegacyOAuthTokenImportOutcome;
+  error?: unknown;
+}
+
+/**
+ * Import legacy safeStorage-encrypted token files into the shared
+ * store, once per file. Idempotent: a missing file is a no-op, and
+ * every terminal outcome except `left-encrypted`/`failed` removes the
+ * file so no decryptable copy survives (tombstone, matching
+ * `migrateLegacyCredentialFile`). Never throws — desktop startup treats
+ * migration as best-effort; returns a report per file that existed.
+ */
+export async function importLegacyOAuthTokenFiles(input: {
+  credentialStore: Pick<CredentialStore, 'getSecret' | 'setSecret'>;
+  decryptor: LegacySafeStorageDecryptor;
+  files: LegacyOAuthTokenFile[];
+}): Promise<LegacyOAuthTokenImportReport[]> {
+  const reports: LegacyOAuthTokenImportReport[] = [];
+  for (const { slug, filePath } of input.files) {
+    const report = (outcome: LegacyOAuthTokenImportOutcome, error?: unknown): void => {
+      reports.push({ slug, filePath, outcome, ...(error === undefined ? {} : { error }) });
+    };
+    let encrypted: Buffer;
+    try {
+      encrypted = await fs.readFile(filePath);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'ENOENT') report('failed', error);
+      continue;
+    }
+    try {
+      if (await input.credentialStore.getSecret(slug, 'oauth_token') !== null) {
+        await fs.unlink(filePath);
+        report('superseded');
+        continue;
+      }
+      if (!input.decryptor.isEncryptionAvailable()) {
+        report('left-encrypted');
+        continue;
+      }
+      let decoded: string;
+      try {
+        decoded = input.decryptor.decryptString(encrypted);
+      } catch (error) {
+        // Keychain denied / rolled: possibly recoverable on a later
+        // start, so keep the file. Only a successful decrypt that
+        // yields garbage proves the file is dead.
+        report('left-encrypted', error);
+        continue;
+      }
+      const tokens = parseOAuthSubscriptionTokens(decoded);
+      if (!tokens) {
+        await fs.unlink(filePath);
+        report('removed-corrupt');
+        continue;
+      }
+      await input.credentialStore.setSecret(slug, 'oauth_token', serializeOAuthSubscriptionTokens(tokens));
+      await fs.unlink(filePath);
+      report('imported');
+    } catch (error) {
+      report('failed', error);
+    }
+  }
+  return reports;
+}
+
+// =============================================================
+// Transitional best-effort export helpers — deleted once every
+// service persists through the authoritative API above.
+// =============================================================
 
 export interface TrySaveSharedOAuthTokenInput {
   credentialStore?: SharedOAuthCredentialSaveStore;

--- a/apps/desktop/src/main/oauth/shared-credential-bridge.ts
+++ b/apps/desktop/src/main/oauth/shared-credential-bridge.ts
@@ -24,11 +24,6 @@ import type { CredentialStore } from '@maka/storage';
 
 export type SharedOAuthCredentialStore = Pick<CredentialStore, 'getSecret' | 'setSecret' | 'deleteSecret'>;
 
-/** @deprecated Transitional alias while services migrate to the store-authority API. */
-export type SharedOAuthCredentialSaveStore = Pick<CredentialStore, 'setSecret'>;
-/** @deprecated Transitional alias while services migrate to the store-authority API. */
-export type SharedOAuthCredentialDeleteStore = Pick<CredentialStore, 'deleteSecret'>;
-
 export type SharedOAuthTokensReadResult =
   | { status: 'ok'; tokens: OAuthSubscriptionTokens }
   | { status: 'missing' }
@@ -173,39 +168,4 @@ export async function importLegacyOAuthTokenFiles(input: {
     }
   }
   return reports;
-}
-
-// =============================================================
-// Transitional best-effort export helpers — deleted once every
-// service persists through the authoritative API above.
-// =============================================================
-
-export interface TrySaveSharedOAuthTokenInput {
-  credentialStore?: SharedOAuthCredentialSaveStore;
-  slug: string;
-  value: string;
-}
-
-export interface TryDeleteSharedOAuthTokenInput {
-  credentialStore?: SharedOAuthCredentialDeleteStore;
-  slug: string;
-}
-
-export async function trySaveSharedOAuthToken(input: TrySaveSharedOAuthTokenInput): Promise<boolean> {
-  try {
-    await input.credentialStore?.setSecret(input.slug, 'oauth_token', input.value);
-    return Boolean(input.credentialStore);
-  } catch {
-    return false;
-  }
-}
-
-export async function tryDeleteSharedOAuthToken(input: TryDeleteSharedOAuthTokenInput): Promise<boolean> {
-  if (!input.credentialStore) return true;
-  try {
-    await input.credentialStore.deleteSecret(input.slug, 'oauth_token');
-    return true;
-  } catch {
-    return false;
-  }
 }

--- a/apps/desktop/src/main/oauth/shared-credential-bridge.ts
+++ b/apps/desktop/src/main/oauth/shared-credential-bridge.ts
@@ -27,8 +27,10 @@ export type SharedOAuthCredentialStore = Pick<CredentialStore, 'getSecret' | 'se
 export type SharedOAuthTokensReadResult =
   | { status: 'ok'; tokens: OAuthSubscriptionTokens }
   | { status: 'missing' }
-  /** Entry existed but was not a valid token payload; it has been deleted
-   *  so the next login does not observe a stuck-corrupt state. */
+  /** Entry exists but is not a valid token payload. The entry is kept
+   *  as-is: reads never destroy a secret (it may be readable by a
+   *  newer schema or repairable by hand), and a fresh login simply
+   *  overwrites it — there is no stuck state a delete would unstick. */
   | { status: 'corrupt' };
 
 /** Persist tokens as the authoritative copy. Throws on store failure. */
@@ -43,8 +45,8 @@ export async function saveSharedOAuthTokens(
 /**
  * Load the authoritative tokens. Store read errors (corrupt file,
  * schema mismatch, stale lock) propagate to the caller; an entry that
- * exists but does not parse as a token payload is deleted (best-effort)
- * and reported as `corrupt`.
+ * exists but does not parse as a token payload is reported as
+ * `corrupt` and left untouched.
  */
 export async function loadSharedOAuthTokens(
   store: SharedOAuthCredentialStore,
@@ -53,10 +55,7 @@ export async function loadSharedOAuthTokens(
   const raw = await store.getSecret(slug, 'oauth_token');
   if (raw === null) return { status: 'missing' };
   const tokens = parseOAuthSubscriptionTokens(raw);
-  if (!tokens) {
-    await store.deleteSecret(slug, 'oauth_token').catch(() => {});
-    return { status: 'corrupt' };
-  }
+  if (!tokens) return { status: 'corrupt' };
   return { status: 'ok', tokens };
 }
 
@@ -90,15 +89,18 @@ export interface LegacyOAuthTokenFile {
 export type LegacyOAuthTokenImportOutcome =
   /** Decrypted and written to the store; file removed. */
   | 'imported'
-  /** The store already held a token for the slug (it is at least as
-   *  fresh — every legacy write dual-wrote the store, and pure-Node
-   *  refreshes write only the store); file removed as a stale duplicate. */
+  /** The store already held a PARSEABLE token for the slug (it is at
+   *  least as fresh — every legacy write dual-wrote the store, and
+   *  pure-Node refreshes write only the store); file removed as a
+   *  stale duplicate. An unparseable store entry does not supersede:
+   *  a valid legacy token must win over stored garbage. */
   | 'superseded'
   /** Decryption unavailable or denied; file left intact for a later
    *  start (never destroy a possibly recoverable secret). */
   | 'left-encrypted'
-  /** Decrypted fine but the payload is not a token; file removed. */
-  | 'removed-corrupt'
+  /** Decrypted fine but the payload is not a token this build can
+   *  parse; file kept — only an explicit logout destroys it. */
+  | 'left-unparseable'
   /** Unexpected I/O or store error; file left intact. */
   | 'failed';
 
@@ -111,11 +113,14 @@ export interface LegacyOAuthTokenImportReport {
 
 /**
  * Import legacy safeStorage-encrypted token files into the shared
- * store, once per file. Idempotent: a missing file is a no-op, and
- * every terminal outcome except `left-encrypted`/`failed` removes the
- * file so no decryptable copy survives (tombstone, matching
- * `migrateLegacyCredentialFile`). Never throws — desktop startup treats
- * migration as best-effort; returns a report per file that existed.
+ * store, once per file. Idempotent: a missing file is a no-op. The
+ * file is removed only when its secret provably survives elsewhere —
+ * written into the store (`imported`) or superseded by a parseable
+ * store token; every other outcome keeps the file for a later start
+ * (or manual recovery), because the import must never be the step
+ * that destroys the last copy of a credential. Never throws — desktop
+ * startup treats migration as best-effort; returns a report per file
+ * that existed.
  */
 export async function importLegacyOAuthTokenFiles(input: {
   credentialStore: Pick<CredentialStore, 'getSecret' | 'setSecret'>;
@@ -135,7 +140,8 @@ export async function importLegacyOAuthTokenFiles(input: {
       continue;
     }
     try {
-      if (await input.credentialStore.getSecret(slug, 'oauth_token') !== null) {
+      const existing = await input.credentialStore.getSecret(slug, 'oauth_token');
+      if (existing !== null && parseOAuthSubscriptionTokens(existing)) {
         await fs.unlink(filePath);
         report('superseded');
         continue;
@@ -149,15 +155,13 @@ export async function importLegacyOAuthTokenFiles(input: {
         decoded = input.decryptor.decryptString(encrypted);
       } catch (error) {
         // Keychain denied / rolled: possibly recoverable on a later
-        // start, so keep the file. Only a successful decrypt that
-        // yields garbage proves the file is dead.
+        // start, so keep the file.
         report('left-encrypted', error);
         continue;
       }
       const tokens = parseOAuthSubscriptionTokens(decoded);
       if (!tokens) {
-        await fs.unlink(filePath);
-        report('removed-corrupt');
+        report('left-unparseable');
         continue;
       }
       await input.credentialStore.setSecret(slug, 'oauth_token', serializeOAuthSubscriptionTokens(tokens));

--- a/apps/desktop/src/main/onboarding-service.ts
+++ b/apps/desktop/src/main/onboarding-service.ts
@@ -98,7 +98,7 @@ export function createOnboardingService(deps: OnboardingServiceDeps): Onboarding
 
       // @kenji PR110b perf gate: per-connection credential lookup must
       // run in parallel, NOT serialized. Even with 4-5 connections,
-      // async safeStorage reads can add up to noticeable startup
+      // async credential-store reads can add up to noticeable startup
       // latency on cold open.
       const secretEntries = await Promise.all(
         connections.map(async (connection) => {

--- a/packages/core/src/oauth-subscription.ts
+++ b/packages/core/src/oauth-subscription.ts
@@ -39,7 +39,7 @@ export type OAuthSubscriptionRuntimeState =
   | 'authenticated'        // tokens valid; not yet proven operational
   | 'refreshing'           // refresh attempt in flight
   | 'refresh_failed'       // refresh errored; user must re-login (token file NOT auto-deleted per kenji)
-  | 'storage_failed'       // token file / safeStorage read failed; do not present as logged out
+  | 'storage_failed'       // shared credential store read failed; do not present as logged out
   | 'quota_unavailable'    // tokens valid but /oauth/usage failed
   | 'provider_rejected';   // last send rejected by provider (likely policy / cloak needed)
 
@@ -120,7 +120,7 @@ export type SubscriptionActionFailureReason =
   | 'authorization_expired'    // verifier TTL passed before paste
   | 'token_exchange_failed'    // /oauth/token returned non-200
   | 'refresh_failed'           // refresh attempt errored
-  | 'storage_failed'           // safeStorage / file write failed
+  | 'storage_failed'           // shared credential store write failed
   // PR-OAUTH-SUBSCRIPTION-0 (kenji `45b31e16`): the experimental
   // env flag is OFF. Distinct from `provider_rejected` so the user
   // doesn't think Anthropic rejected their account — this is

--- a/packages/runtime/src/__tests__/subscription-credentials.test.ts
+++ b/packages/runtime/src/__tests__/subscription-credentials.test.ts
@@ -57,3 +57,61 @@ describe('GitHub Copilot subscription credentials', () => {
     assert.equal(tokens?.base_url, 'https://api.githubcopilot.com');
   });
 });
+
+describe('OAuth refresh response validation', () => {
+  const nearExpiryStored = JSON.stringify({
+    access_token: 'old-access',
+    refresh_token: 'old-refresh',
+    expires_at: 1_000, // already past `now` below → refresh path runs
+  });
+
+  const okResponse = (body: unknown): Response =>
+    ({ ok: true, status: 200, json: async () => body }) as unknown as Response;
+
+  for (const [name, body] of [
+    ['empty object', {}],
+    ['empty access token', { access_token: '', expires_in: 3600 }],
+    ['missing expiry', { access_token: 'new-access' }],
+    ['non-numeric expiry', { access_token: 'new-access', expires_in: 'soon' }],
+    ['non-positive expiry', { access_token: 'new-access', expires_in: 0 }],
+  ] as const) {
+    test(`a 200 refresh with ${name} never replaces the stored token`, async () => {
+      const writes: string[] = [];
+      const tokens = await resolveOAuthSubscriptionTokens({
+        providerType: 'claude-subscription',
+        slug: 'claude-subscription',
+        credentialStore: {
+          getSecret: async () => nearExpiryStored,
+          setSecret: async (_slug, _kind, value) => {
+            writes.push(value);
+          },
+        },
+        now: () => 10_000_000,
+        fetchFn: async () => okResponse(body),
+      });
+
+      assert.equal(tokens, null, 'an invalid refresh payload must surface as a refresh failure');
+      assert.deepEqual(writes, [], 'the still-working stored record must not be overwritten with garbage');
+    });
+  }
+
+  test('a rotated refresh token that is an empty string keeps the previous refresh token', async () => {
+    const writes: string[] = [];
+    const tokens = await resolveOAuthSubscriptionTokens({
+      providerType: 'claude-subscription',
+      slug: 'claude-subscription',
+      credentialStore: {
+        getSecret: async () => nearExpiryStored,
+        setSecret: async (_slug, _kind, value) => {
+          writes.push(value);
+        },
+      },
+      now: () => 10_000_000,
+      fetchFn: async () => okResponse({ access_token: 'new-access', refresh_token: '', expires_in: 3600 }),
+    });
+
+    assert.equal(tokens?.access_token, 'new-access');
+    assert.equal(tokens?.refresh_token, 'old-refresh');
+    assert.equal(writes.length, 1);
+  });
+});

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -485,6 +485,7 @@ export {
   extractOAuthSubscriptionAccessToken,
   isOAuthSubscriptionProvider,
   parseOAuthSubscriptionTokens,
+  refreshOAuthSubscriptionTokens,
   resolveOAuthSubscriptionAccessToken,
   resolveOAuthSubscriptionTokens,
   createGitHubCopilotAccountTokens,

--- a/packages/runtime/src/subscription-credentials.ts
+++ b/packages/runtime/src/subscription-credentials.ts
@@ -105,17 +105,25 @@ export async function resolveOAuthSubscriptionTokens(
   return refreshed;
 }
 
-async function refreshOAuthSubscriptionTokens(input: {
+/**
+ * Provider-specific refresh request. Exported so the desktop services
+ * force-refresh through the same HTTP contract the pure-Node resolve
+ * path uses — one refresh implementation per provider, not two.
+ * Throws on a failed refresh; persistence is the caller's concern.
+ */
+export async function refreshOAuthSubscriptionTokens(input: {
   providerType: OAuthSubscriptionProvider;
   tokens: OAuthSubscriptionTokens;
-  now: () => number;
-  fetchFn: typeof fetch;
+  now?: () => number;
+  fetchFn?: typeof fetch;
 }): Promise<OAuthSubscriptionTokens> {
+  const now = input.now ?? (() => Date.now());
+  const fetchFn = input.fetchFn ?? fetch;
   switch (input.providerType) {
     case 'claude-subscription':
-      return refreshClaudeSubscriptionTokens(input.tokens, input.now, input.fetchFn);
+      return refreshClaudeSubscriptionTokens(input.tokens, now, fetchFn);
     case 'openai-codex':
-      return refreshOpenAiCodexTokens(input.tokens, input.now, input.fetchFn);
+      return refreshOpenAiCodexTokens(input.tokens, now, fetchFn);
     case 'github-copilot':
       return input.tokens;
   }

--- a/packages/runtime/src/subscription-credentials.ts
+++ b/packages/runtime/src/subscription-credentials.ts
@@ -153,6 +153,30 @@ export function isSupportedGitHubCopilotAccountToken(token: string): boolean {
 }
 
 
+/**
+ * Guard a refresh response before it may replace the stored authority:
+ * a 200 with a missing/empty access token or a non-positive expiry must
+ * surface as a refresh failure, never overwrite a still-working record
+ * with garbage. Returns the validated required fields.
+ */
+function requireRefreshedTokenFields(
+  provider: string,
+  payload: { access_token?: unknown; expires_in?: unknown },
+): { accessToken: string; expiresInMs: number } {
+  const accessToken = payload.access_token;
+  const expiresIn = payload.expires_in;
+  if (typeof accessToken !== 'string' || accessToken.length === 0
+    || typeof expiresIn !== 'number' || !Number.isFinite(expiresIn) || expiresIn <= 0) {
+    throw new Error(`${provider} OAuth token refresh returned an invalid token payload.`);
+  }
+  return { accessToken, expiresInMs: 1000 * expiresIn };
+}
+
+/** A rotated refresh token must be a non-empty string; otherwise keep the previous one. */
+function nextRefreshToken(candidate: unknown, previous: string): string {
+  return typeof candidate === 'string' && candidate.length > 0 ? candidate : previous;
+}
+
 async function refreshClaudeSubscriptionTokens(
   tokens: OAuthSubscriptionTokens,
   now: () => number,
@@ -172,17 +196,18 @@ async function refreshClaudeSubscriptionTokens(
   });
   if (!response.ok) throw new Error(`Claude OAuth token refresh failed (${response.status}).`);
   const payload = await response.json() as {
-    access_token: string;
+    access_token?: string;
     refresh_token?: string;
-    expires_in: number;
+    expires_in?: number;
     token_type?: string;
     scope?: string;
     account?: { uuid?: string };
   };
+  const { accessToken, expiresInMs } = requireRefreshedTokenFields('Claude', payload);
   return {
-    access_token: payload.access_token,
-    refresh_token: payload.refresh_token ?? tokens.refresh_token,
-    expires_at: now() + 1000 * payload.expires_in,
+    access_token: accessToken,
+    refresh_token: nextRefreshToken(payload.refresh_token, tokens.refresh_token),
+    expires_at: now() + expiresInMs,
     token_type: payload.token_type ?? tokens.token_type,
     scope: payload.scope ?? tokens.scope,
     account_uuid: payload.account?.uuid ?? tokens.account_uuid,
@@ -209,16 +234,17 @@ async function refreshOpenAiCodexTokens(
   });
   if (!response.ok) throw new Error(`Codex OAuth token refresh failed (${response.status}).`);
   const payload = await response.json() as {
-    access_token: string;
+    access_token?: string;
     refresh_token?: string;
     id_token?: string;
-    expires_in: number;
+    expires_in?: number;
   };
+  const { accessToken, expiresInMs } = requireRefreshedTokenFields('Codex', payload);
   return {
-    access_token: payload.access_token,
-    refresh_token: payload.refresh_token ?? tokens.refresh_token,
+    access_token: accessToken,
+    refresh_token: nextRefreshToken(payload.refresh_token, tokens.refresh_token),
     id_token: payload.id_token ?? tokens.id_token,
-    expires_at: now() + 1000 * payload.expires_in,
+    expires_at: now() + expiresInMs,
     account_id: tokens.account_id,
   };
 }


### PR DESCRIPTION
## Summary

Closes #1125. Retires Electron `safeStorage` as the OAuth token authority: the pure-Node `CredentialStore` (workspace `credentials.json`) is now the single store every surface — desktop, TUI, headless — reads and writes, so a desktop login is immediately usable from pure-Node callers and vice versa, and macOS keychain prompts for "Maka Safe Storage" disappear from OAuth hot paths.

- The shared credential bridge becomes the real persistence layer: store-backed save/load/delete that fail closed (`storage_failed`), plus a one-shot startup import that decrypts pre-existing safeStorage token files into the store and tombstones them. Files that cannot be decrypted (keychain unavailable/denied) are left intact for a later start; only a payload that decrypts to garbage is removed.
- Claude and Codex services drop the safeStorage file and the best-effort dual-write; force-refresh reuses the runtime's provider refresher (`refreshOAuthSubscriptionTokens`, newly exported) instead of a private duplicate, and the in-memory token cache is gone so a pure-Node refresh can't be shadowed by a stale rotated-out refresh token.
- Cursor and Antigravity (previews) gain the `credentialStore` dependency and follow the same model; GitHub Copilot already did.
- Logout deletes the authoritative store entry plus any legacy file the import could not process, so logout still means "no credential survives anywhere".
- Docs (SECURITY.md, README, README.zh-CN) now describe one model, and a contract test pins the acceptance bar: no module under `oauth/` imports or invokes safeStorage; `main.ts` only passes it to the legacy importers.

Sequenced as four commits (persistence layer → Claude/Codex → Cursor/Antigravity → docs + contract), each independently revertable.

## Verification

- `apps/desktop`: `npm run build:main && node --test "dist/main/**/*.test.js"` — 2586 pass, 0 fail. Includes new unit coverage of the bridge against the real `FileCredentialStore` in a tmpdir (round-trip, fail-closed store errors, corrupt-entry cleanup, and every legacy-import outcome: imported / superseded / left-encrypted / removed-corrupt / failed / 0600 perms preserved).
- `packages/runtime`: `npm test` — 2011 pass.
- Repo root: `npm run test:fast` (all workspaces) and `npm run typecheck` — clean.
- Not run: Playwright E2E (OAuth flows are main-process only and not covered there) and a live provider login; the login/exchange HTTP paths are unchanged, only persistence moved.

## Migration

Legacy `userData/.{claude,codex,cursor,antigravity}_subscription_token` files import automatically on desktop start (logged as `[credentials] legacy OAuth token file for <slug>: <outcome>`). If the store already holds a token for the slug, the file is removed as a stale duplicate — the store copy is at least as fresh because every legacy write dual-wrote it and pure-Node refreshes write only the store. Users whose keychain denies decryption keep their file and can simply re-login; nothing is destroyed.

## Review focus

- Failure-surface parity in `loadTokens`/`saveTokens` rewrites: store read errors and corrupt entries must keep reporting `storage_failed` rather than `not_logged_in` (pinned by `oauth-bug-sweep-contract.test.ts`).
- The Codex refresh now persists `account_id` from freshly extracted claims with fallback to the previous value — same as the old private refresher, but worth a second pair of eyes.


## Post-review hardening

An external review pass (adjudicated finding-by-finding) drove three follow-up commits:

- `fix(desktop): seed visual-smoke fixtures before the window opens` — CI E2E failure; the fixture workspace wipe raced `createWindow`'s settings read. Latent on main; the legacy-token import shifted the interleaving into the failure window.
- `fix(desktop): never destroy OAuth secrets on read or import; validate refresh payloads` — reads and the one-shot import no longer delete anything they cannot prove is superseded; a 200 refresh response without a usable token can no longer overwrite a working record.
- `fix(desktop): honest storage_failed mapping, logout epoch guard, and store-derived account identity` — store write failures stop masquerading as provider failures; logout stays terminal against an in-flight refresh; account identity is derived from the store instead of per-process caches.

Deferred with reasons (tracked in a follow-up issue): cross-process refresh commit races (pre-existing; needs a storage compare-and-set primitive), the import's microsecond get/set window (transitional code), and `storage_failed` states for the non-operational Cursor/Antigravity previews.
