### PR TITLE
fix(cli): anchor Ctrl+O/Ctrl+T expansion to the live viewport so toggles never clear scrollback

### DIFF
--- a/packages/cli/src/__tests__/pi-transcript.test.ts
+++ b/packages/cli/src/__tests__/pi-transcript.test.ts
@@ -507,6 +507,126 @@ describe('Maka Pi TUI transcript', () => {
     assert.doesNotMatch(expanded, /pty-row-[45]/);
   });
 
+  test('Ctrl+O leaves tool cards above the live viewport untouched (#1097)', () => {
+    const state = createMakaPiTranscriptState();
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_start', toolUseId: 'tool-early', toolName: 'Bash', args: { command: 'early-build' },
+    }));
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_result', toolUseId: 'tool-early', isError: false,
+      content: terminalResult(`early-head\n${Array.from({ length: 30 }, (_, i) => `early-row-${i}`).join('\n')}`),
+    }));
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'text_delta', messageId: 'message-1',
+      text: Array.from({ length: 20 }, (_, i) => `filler-${i}`).join('\n\n'),
+    }));
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_start', toolUseId: 'tool-late', toolName: 'Bash', args: { command: 'late-build' },
+    }));
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_result', toolUseId: 'tool-late', isError: false,
+      content: terminalResult(`late-head\n${Array.from({ length: 30 }, (_, i) => `late-row-${i}`).join('\n')}`),
+    }));
+
+    const before = renderMakaPiTranscript(state, meta(), 100);
+    const early = state.entries.find(
+      (entry): entry is Extract<typeof entry, { kind: 'tool' }> => entry.kind === 'tool' && entry.toolUseId === 'tool-early',
+    );
+    const late = state.entries.find(
+      (entry): entry is Extract<typeof entry, { kind: 'tool' }> => entry.kind === 'tool' && entry.toolUseId === 'tool-late',
+    );
+    assert.ok(early && late);
+    // Scroll state as MakaPiLayoutComponent records it: the live viewport
+    // starts exactly where the late card begins, leaving the early card in
+    // scrollback above it.
+    const viewportTop = state.renderGeometry.entryFirstLine.get(late);
+    assert.ok(viewportTop !== undefined && viewportTop > 0);
+    state.renderGeometry.viewportTop = viewportTop;
+
+    assert.equal(toggleAllToolExpansion(state), true);
+    assert.equal(state.expandAllTools, true);
+    assert.equal(early.expanded, false);
+    assert.equal(late.expanded, true);
+
+    const after = renderMakaPiTranscript(state, meta(), 100);
+    // Everything above the viewport is terminal scrollback pi-tui cannot
+    // rewrite without a scrollback-clearing full redraw; those lines must
+    // stay byte-identical.
+    assert.deepEqual(after.slice(0, viewportTop), before.slice(0, viewportTop));
+    const afterText = after.map(stripAnsi).join('\n');
+    assert.match(afterText, /late-head/);
+    assert.doesNotMatch(afterText, /early-head/);
+  });
+
+  test('Ctrl+O reports nothing to toggle when every tool card sits above the viewport', () => {
+    const state = createMakaPiTranscriptState();
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_start', toolUseId: 'tool-1', toolName: 'Bash', args: { command: 'npm test' },
+    }));
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_result', toolUseId: 'tool-1', isError: false, content: terminalResult('ok\n'),
+    }));
+
+    const lines = renderMakaPiTranscript(state, meta(), 100);
+    state.renderGeometry.viewportTop = lines.length;
+
+    assert.equal(toggleAllToolExpansion(state), false);
+    assert.equal(state.expandAllTools, false);
+  });
+
+  test('tool cards born after an expand-all start expanded', () => {
+    const state = createMakaPiTranscriptState();
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_start', toolUseId: 'tool-1', toolName: 'Bash', args: { command: 'first' },
+    }));
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_result', toolUseId: 'tool-1', isError: false, content: terminalResult('ok\n'),
+    }));
+    assert.equal(toggleAllToolExpansion(state), true);
+
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_start', toolUseId: 'tool-2', toolName: 'Bash', args: { command: 'second' },
+    }));
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_result', toolUseId: 'tool-2', isError: false,
+      content: terminalResult(`second-head\n${Array.from({ length: 10 }, (_, i) => `second-row-${i}`).join('\n')}`),
+    }));
+
+    const rendered = renderMakaPiTranscript(state, meta(), 100).map(stripAnsi).join('\n');
+    assert.match(rendered, /second-head/);
+  });
+
+  test('Ctrl+T leaves thinking entries above the live viewport untouched (#1097)', () => {
+    const state = createMakaPiTranscriptState();
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'thinking_delta', messageId: 'message-1', text: 'early-secret-reasoning',
+    }));
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'text_delta', messageId: 'message-1',
+      text: Array.from({ length: 20 }, (_, i) => `filler-${i}`).join('\n\n'),
+    }));
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'thinking_delta', messageId: 'message-2', text: 'late-visible-reasoning',
+    }));
+
+    const before = renderMakaPiTranscript(state, meta(), 100);
+    const late = state.entries.find(
+      (entry): entry is Extract<typeof entry, { kind: 'thinking' }> => entry.kind === 'thinking' && entry.messageId === 'message-2',
+    );
+    assert.ok(late);
+    const viewportTop = state.renderGeometry.entryFirstLine.get(late);
+    assert.ok(viewportTop !== undefined && viewportTop > 0);
+    state.renderGeometry.viewportTop = viewportTop;
+
+    assert.equal(toggleAllThinkingExpansion(state), true);
+
+    const after = renderMakaPiTranscript(state, meta(), 100);
+    assert.deepEqual(after.slice(0, viewportTop), before.slice(0, viewportTop));
+    const afterText = after.map(stripAnsi).join('\n');
+    assert.match(afterText, /late-visible-reasoning/);
+    assert.doesNotMatch(afterText, /early-secret-reasoning/);
+  });
+
   test('replays WriteStdin as a human-readable operation row while merging its PTY revision into Bash', () => {
     const state = createMakaPiTranscriptState();
     const ref = 'maka://runtime/background-tasks/pty-1';

--- a/packages/cli/src/__tests__/pi-transcript.test.ts
+++ b/packages/cli/src/__tests__/pi-transcript.test.ts
@@ -539,7 +539,7 @@ describe('Maka Pi TUI transcript', () => {
     // Scroll state as MakaPiLayoutComponent records it: the live viewport
     // starts exactly where the late card begins, leaving the early card in
     // scrollback above it.
-    const viewportTop = state.renderGeometry.entryFirstLine.get(late);
+    const viewportTop = state.renderGeometry.entryFirstLine?.get(late);
     assert.ok(viewportTop !== undefined && viewportTop > 0);
     state.renderGeometry.viewportTop = viewportTop;
 
@@ -614,7 +614,7 @@ describe('Maka Pi TUI transcript', () => {
       (entry): entry is Extract<typeof entry, { kind: 'thinking' }> => entry.kind === 'thinking' && entry.messageId === 'message-2',
     );
     assert.ok(late);
-    const viewportTop = state.renderGeometry.entryFirstLine.get(late);
+    const viewportTop = state.renderGeometry.entryFirstLine?.get(late);
     assert.ok(viewportTop !== undefined && viewportTop > 0);
     state.renderGeometry.viewportTop = viewportTop;
 

--- a/packages/cli/src/__tests__/pi-tui-layout.test.ts
+++ b/packages/cli/src/__tests__/pi-tui-layout.test.ts
@@ -3,6 +3,7 @@ import { before, describe, test } from 'node:test';
 import type { Component, Terminal } from '@earendil-works/pi-tui';
 import { _setColorLevelForTesting } from '../tui-ansi.js';
 import {
+  appendUserPrompt,
   applyMakaSessionEventToTranscript,
   createMakaPiTranscriptState,
   replaceTranscriptWithStoredMessages,
@@ -94,6 +95,115 @@ describe('MakaPiLayoutComponent viewport geometry', () => {
     const grown = layout.render(80);
     assert.equal(state.renderGeometry.viewportTop, grown.length - 24);
     assert.ok(state.renderGeometry.viewportTop >= top);
+  });
+
+  // The remaining branches only differ from "reset to the tail on anything"
+  // once the estimate sits above the tail, so each case first shallow-truncates
+  // to open that gap, then exercises exactly one rule.
+  test('with the top above the tail, each shadow-diff rule acts independently', () => {
+    const opened = () => {
+      const { state, layout } = harness();
+      // First entry: an expanded thinking block (full-text cache key), so an
+      // in-place edit above the viewport top really changes rendered lines.
+      applyMakaSessionEventToTranscript(state, event({
+        type: 'thinking_delta', messageId: 'message-head', text: 'head-reasoning-xำy',
+      }));
+      const head = state.entries[0];
+      assert.ok(head?.kind === 'thinking');
+      head.expanded = true;
+      growTranscript(state, 60, 'message-1');
+      growTranscript(state, 10, 'message-2');
+      layout.render(80);
+      const top = state.renderGeometry.viewportTop;
+      // Shallow truncation: drop the m2 filler; the top stays put and now
+      // sits above the document tail.
+      state.entries.pop();
+      const lines = layout.render(80);
+      assert.equal(state.renderGeometry.viewportTop, top);
+      assert.ok(top > lines.length - 24);
+      return { state, layout, head, top };
+    };
+
+    // Append: keeps the top (an unconditional reset would drop it to the tail).
+    {
+      const { state, layout, top } = opened();
+      addTool(state, 'tool-small', 'echo hi');
+      layout.render(80);
+      assert.equal(state.renderGeometry.viewportTop, top);
+    }
+    // In-place edit above the top: pi-tui full-redraws, so the top re-anchors.
+    {
+      const { state, layout, head, top } = opened();
+      assert.ok(head.kind === 'thinking');
+      head.text = 'head-reasoning-EDITEDำy'.slice(0, head.text.length);
+      const lines = layout.render(80);
+      assert.equal(state.renderGeometry.viewportTop, Math.max(0, lines.length - 24));
+      assert.ok(state.renderGeometry.viewportTop < top);
+    }
+    // Normalization-equivalent change above the top: pi-tui diffs normalized
+    // lines and sees no change, so the top must not fall.
+    {
+      const { state, layout, head, top } = opened();
+      assert.ok(head.kind === 'thinking');
+      head.text = head.text.replace('ำ', 'ํา');
+      layout.render(80);
+      assert.equal(state.renderGeometry.viewportTop, top);
+    }
+  });
+
+  test('truncating to exactly the viewport top re-anchors (pi-tui redraws at that boundary)', () => {
+    const { state, layout } = harness();
+    for (let i = 0; i < 100; i += 1) appendUserPrompt(state, `prompt-${i}`);
+    const lines = layout.render(80);
+    const top = state.renderGeometry.viewportTop;
+    assert.equal(top, lines.length - 24);
+
+    // Each user entry is two composed lines (blank + prompt); chrome is five.
+    // Truncate so the composed document ends exactly at the old top.
+    const keep = (top - 5) / 2;
+    assert.equal(keep, Math.floor(keep));
+    state.entries.length = keep;
+    const shrunk = layout.render(80);
+    assert.equal(shrunk.length, top);
+    assert.equal(state.renderGeometry.viewportTop, Math.max(0, top - 24));
+  });
+
+  test('a Termux height change keeps the buffer-derived top instead of re-anchoring', () => {
+    process.env.TERMUX_VERSION = '0.118';
+    try {
+      const { state, layout, terminal } = harness();
+      growTranscript(state, 60, 'message-1');
+      growTranscript(state, 10, 'message-2');
+      layout.render(80);
+      const top = state.renderGeometry.viewportTop;
+      state.entries.pop();
+      layout.render(80);
+      assert.equal(state.renderGeometry.viewportTop, top);
+
+      // pi-tui keeps the buffer under Termux and recomputes the top from it;
+      // re-anchoring to the shorter document tail would fall below it.
+      terminal.rows = 30;
+      layout.render(80);
+      assert.equal(state.renderGeometry.viewportTop, top + 24 - 30);
+    } finally {
+      delete process.env.TERMUX_VERSION;
+    }
+  });
+
+  test('after a wholesale replacement the toggles stay inert until the next render', () => {
+    const { state, layout } = harness();
+    growTranscript(state, 60);
+    layout.render(80);
+    assert.ok(state.renderGeometry.viewportTop > 0);
+
+    replaceTranscriptWithStoredMessages(state, []);
+    addTool(state, 'tool-hydrated', 'echo hi');
+    // Entry positions are unknown and the viewport has scrolled: a toggle here
+    // could rewrite lines above pi-tui's real viewport, so it must do nothing.
+    assert.equal(toggleAllToolExpansion(state), false);
+
+    layout.render(80);
+    assert.equal(toggleAllToolExpansion(state), true);
   });
 });
 

--- a/packages/cli/src/__tests__/pi-tui-layout.test.ts
+++ b/packages/cli/src/__tests__/pi-tui-layout.test.ts
@@ -1,0 +1,154 @@
+import assert from 'node:assert/strict';
+import { before, describe, test } from 'node:test';
+import type { Component, Terminal } from '@earendil-works/pi-tui';
+import { _setColorLevelForTesting } from '../tui-ansi.js';
+import {
+  applyMakaSessionEventToTranscript,
+  createMakaPiTranscriptState,
+  replaceTranscriptWithStoredMessages,
+  toggleAllToolExpansion,
+  type MakaPiTranscriptMetadata,
+  type MakaPiTranscriptState,
+} from '../pi-transcript.js';
+import {
+  MakaActivityStripComponent,
+  MakaPendingQueueComponent,
+  MakaPiLayoutComponent,
+  MakaStatusLineComponent,
+  MakaTranscriptComponent,
+} from '../pi-tui-layout.js';
+import type { SessionEvent } from '@maka/core';
+
+before(() => _setColorLevelForTesting(3));
+
+// The viewport-top estimate must shadow pi-tui's real viewport (#1097): reset
+// to the document tail exactly when pi-tui would full-redraw (size change,
+// change above the top, shrink below the top), stay monotonic otherwise.
+describe('MakaPiLayoutComponent viewport geometry', () => {
+  test('a wholesale replacement (/new) re-anchors the viewport and keeps toggles alive', () => {
+    const { state, layout } = harness();
+    growTranscript(state, 60);
+    layout.render(80);
+    assert.ok(state.renderGeometry.viewportTop > 0);
+
+    replaceTranscriptWithStoredMessages(state, []);
+    layout.render(80);
+    assert.equal(state.renderGeometry.viewportTop, 0);
+
+    addTool(state, 'tool-new', 'echo hi');
+    layout.render(80);
+    assert.equal(toggleAllToolExpansion(state), true);
+  });
+
+  test('a terminal size change re-anchors the viewport to the document tail', () => {
+    const { state, layout, terminal } = harness();
+    growTranscript(state, 60);
+    const lines = layout.render(80);
+    assert.equal(state.renderGeometry.viewportTop, lines.length - 24);
+
+    terminal.rows = 50;
+    const taller = layout.render(80);
+    assert.equal(state.renderGeometry.viewportTop, Math.max(0, taller.length - 50));
+
+    // pi-tui full-redraws on any width change, even without a wrap difference.
+    terminal.rows = 24;
+    layout.render(80);
+    const before = state.renderGeometry.viewportTop;
+    terminal.columns = 120;
+    const wider = layout.render(120);
+    assert.equal(state.renderGeometry.viewportTop, Math.max(0, wider.length - 24));
+    assert.ok(state.renderGeometry.viewportTop <= before);
+  });
+
+  test('a shallow truncation keeps the viewport top, a deep one re-anchors it', () => {
+    const { state, layout } = harness();
+    growTranscript(state, 60, 'message-1');
+    growTranscript(state, 60, 'message-2');
+    addTool(state, 'tool-tail', 'echo tail');
+    layout.render(80);
+    const top = state.renderGeometry.viewportTop;
+    assert.ok(top > 0);
+
+    // Shallow: dropping the tail entry keeps the document longer than the
+    // viewport top; pi-tui clears the vacated rows without a full redraw and
+    // its viewport stays put, so the estimate must too.
+    state.entries.pop();
+    layout.render(80);
+    assert.equal(state.renderGeometry.viewportTop, top);
+
+    // Deep: truncating below the viewport top forces pi-tui's full redraw,
+    // which re-anchors its viewport to the new document tail.
+    state.entries.length = 1;
+    const shrunk = layout.render(80);
+    assert.equal(state.renderGeometry.viewportTop, Math.max(0, shrunk.length - 24));
+    assert.ok(state.renderGeometry.viewportTop < top);
+  });
+
+  test('appends and in-viewport edits keep the viewport top monotonic', () => {
+    const { state, layout } = harness();
+    growTranscript(state, 60);
+    layout.render(80);
+    const top = state.renderGeometry.viewportTop;
+
+    addTool(state, 'tool-append', 'echo more');
+    const grown = layout.render(80);
+    assert.equal(state.renderGeometry.viewportTop, grown.length - 24);
+    assert.ok(state.renderGeometry.viewportTop >= top);
+  });
+});
+
+interface StubTerminal {
+  rows: number;
+  columns: number;
+}
+
+function harness(): { state: MakaPiTranscriptState; layout: MakaPiLayoutComponent; terminal: StubTerminal } {
+  const state = createMakaPiTranscriptState();
+  const metadata = (): MakaPiTranscriptMetadata => ({
+    title: 'Maka',
+    cwd: '/repo',
+    model: 'deepseek-v4-flash',
+    connectionSlug: 'deepseek',
+    permissionMode: 'ask',
+    usage: state.usage,
+  });
+  const terminal: StubTerminal = { rows: 24, columns: 80 };
+  const stubComponent = (lines: string[]): Component => ({ render: () => lines, invalidate: () => {} });
+  const layout = new MakaPiLayoutComponent(
+    state,
+    new MakaTranscriptComponent(state, metadata),
+    new MakaActivityStripComponent(metadata),
+    new MakaPendingQueueComponent(state),
+    stubComponent(['editor-1', 'editor-2', 'editor-3']),
+    new MakaStatusLineComponent(metadata),
+    terminal as unknown as Terminal,
+  );
+  return { state, layout, terminal };
+}
+
+function growTranscript(state: MakaPiTranscriptState, paragraphs: number, messageId = 'message-filler'): void {
+  applyMakaSessionEventToTranscript(state, event({
+    type: 'text_delta',
+    messageId,
+    text: Array.from({ length: paragraphs }, (_, i) => `${messageId}-filler-${i}`).join('\n\n'),
+  }));
+}
+
+function addTool(state: MakaPiTranscriptState, toolUseId: string, command: string): void {
+  applyMakaSessionEventToTranscript(state, event({
+    type: 'tool_start', toolUseId, toolName: 'Bash', args: { command },
+  }));
+  applyMakaSessionEventToTranscript(state, event({
+    type: 'tool_result', toolUseId, isError: false,
+    content: { kind: 'text', text: 'ok' },
+  }));
+}
+
+function event(input: { type: SessionEvent['type'] } & Record<string, unknown>): SessionEvent {
+  return {
+    id: `${input.type}-id`,
+    turnId: 'turn-1',
+    ts: 1,
+    ...input,
+  } as SessionEvent;
+}

--- a/packages/cli/src/__tests__/pi-tui-runner.test.ts
+++ b/packages/cli/src/__tests__/pi-tui-runner.test.ts
@@ -667,6 +667,37 @@ describe('Maka Pi TUI runner', () => {
     ]);
   });
 
+  test('Ctrl-O with tool cards above the viewport never clears terminal scrollback (#1097)', async () => {
+    const terminal = new FakeTerminal();
+    const driver = new OffscreenToolDriver();
+    const run = runMakaPiTui({
+      title: 'Maka', driver, cwd: '/repo', model: 'claude-sonnet-4-5',
+      connectionSlug: 'claude-subscription', permissionMode: 'ask', terminal,
+    });
+
+    terminal.input('r');
+    terminal.input('\r');
+    await waitFor(() => plainTerminalOutput(terminal.output()).includes('late-build'));
+
+    terminal.input('\x0f');
+    // The late card sits inside the 24-row viewport, so Ctrl+O expands it.
+    await waitFor(() => plainTerminalOutput(terminal.output()).includes('late-head'));
+
+    // The early card scrolled above the viewport before the toggle: its lines
+    // are terminal scrollback now, so it must not be re-rendered expanded, and
+    // nothing in the whole run may emit the scrollback-erase sequence.
+    assert.equal(plainTerminalOutput(terminal.output()).includes('early-head'), false);
+    assert.equal(terminal.output().includes('\x1b[3J'), false);
+
+    exitMaka(terminal);
+    await Promise.race([
+      run,
+      delay(50).then(() => {
+        throw new Error('TUI did not close during test cleanup');
+      }),
+    ]);
+  });
+
   test('renders a background ShellRun terminal update after the agent turn ends', async () => {
     const terminal = new FakeTerminal();
     const driver = new BackgroundShellRunDriver();
@@ -4674,6 +4705,46 @@ class BackgroundShellRunDriver extends ToolOutputDriver {
       },
     };
     yield { type: 'complete', id: 'event-complete', turnId: 'turn-1', ts: 3, stopReason: 'end_turn' };
+  }
+}
+
+class OffscreenToolDriver extends ToolOutputDriver {
+  override async *sendPrompt(_prompt: string): AsyncIterable<SessionEvent> {
+    yield {
+      type: 'tool_start', id: 'event-early-start', turnId: 'turn-1', ts: 1,
+      toolUseId: 'tool-early', toolName: 'Bash', args: { command: 'early-build' },
+    };
+    yield {
+      type: 'tool_result', id: 'event-early-result', turnId: 'turn-1', ts: 2,
+      toolUseId: 'tool-early', isError: false,
+      content: {
+        kind: 'terminal', cwd: '/repo', cmd: 'early-build',
+        status: 'completed', exitCode: 0,
+        // `early-head` is hidden by the compact tail; it can only ever be
+        // written if the card is re-rendered expanded.
+        output: pipeOutput(`early-head\n${Array.from({ length: 30 }, (_, i) => `early-row-${i}`).join('\n')}`),
+      },
+    };
+    yield {
+      type: 'text_delta', id: 'event-filler', turnId: 'turn-1', ts: 3,
+      messageId: 'message-1',
+      // 30 paragraphs (~60 rows) push the early card above a 24-row viewport.
+      text: Array.from({ length: 30 }, (_, i) => `filler-${i}`).join('\n\n'),
+    };
+    yield {
+      type: 'tool_start', id: 'event-late-start', turnId: 'turn-1', ts: 4,
+      toolUseId: 'tool-late', toolName: 'Bash', args: { command: 'late-build' },
+    };
+    yield {
+      type: 'tool_result', id: 'event-late-result', turnId: 'turn-1', ts: 5,
+      toolUseId: 'tool-late', isError: false,
+      content: {
+        kind: 'terminal', cwd: '/repo', cmd: 'late-build',
+        status: 'completed', exitCode: 0,
+        output: pipeOutput(`late-head\n${Array.from({ length: 30 }, (_, i) => `late-row-${i}`).join('\n')}`),
+      },
+    };
+    yield { type: 'complete', id: 'event-complete', turnId: 'turn-1', ts: 6, stopReason: 'end_turn' };
   }
 }
 

--- a/packages/cli/src/pi-transcript.ts
+++ b/packages/cli/src/pi-transcript.ts
@@ -98,8 +98,13 @@ export interface MakaPiTranscriptState {
 export type MakaPiPendingInteraction = AnyPermissionRequestEvent | UserQuestionRequestEvent;
 
 export interface MakaPiRenderGeometry {
-  /** First rendered transcript-line index per entry, from the latest render. */
-  entryFirstLine: Map<MakaPiTranscriptEntry, number>;
+  /**
+   * First rendered transcript-line index per entry, from the latest render.
+   * `undefined` means no entry position is known — the transcript was just
+   * replaced wholesale and has not rendered since — which the toggles must
+   * treat as "nothing safely reachable" while the viewport has scrolled.
+   */
+  entryFirstLine: Map<MakaPiTranscriptEntry, number> | undefined;
   /**
    * pi-tui's live-viewport top in transcript-line coordinates (the transcript
    * is the first layout child, so transcript line i is composed line i). Held
@@ -177,7 +182,7 @@ export function createMakaPiTranscriptState(): MakaPiTranscriptState {
     queuedInteractions: [],
     expandAllTools: false,
     expandAllThinking: false,
-    renderGeometry: { entryFirstLine: new Map(), viewportTop: 0 },
+    renderGeometry: { entryFirstLine: undefined, viewportTop: 0 },
     pendingShellRunPolls: new Map(),
     usage: { costUsd: 0, cacheHitInput: 0, cacheMissInput: 0 },
     steering: [],
@@ -278,12 +283,14 @@ export function replaceTranscriptWithStoredMessages(
   state.pendingShellRunPolls.clear();
   state.expandAllTools = false;
   state.expandAllThinking = false;
-  // The old entries are gone; drop their recorded positions. viewportTop is
-  // left to the next layout render: when the replacement changes lines above
-  // it, pi-tui full-redraws and the layout's shadow diff resets the estimate
-  // to match; when the replacement is a pure truncation or identical content,
-  // pi-tui keeps its viewport and so does the estimate.
-  state.renderGeometry.entryFirstLine = new Map();
+  // The old entries are gone; no position is known until the next render, and
+  // until then the toggles must not touch anything (a replacement entry could
+  // render above the still-scrolled viewport). viewportTop is left to the next
+  // layout render: when the replacement changes lines above it, pi-tui
+  // full-redraws and the layout's shadow diff resets the estimate to match;
+  // when the replacement is a pure truncation or identical content, pi-tui
+  // keeps its viewport and so does the estimate.
+  state.renderGeometry.entryFirstLine = undefined;
   state.usage = { costUsd: 0, cacheHitInput: 0, cacheMissInput: 0 };
   // Queues are per-active-run; a switched/reset session has none pending.
   state.steering = [];
@@ -303,8 +310,12 @@ export function replaceTranscriptWithStoredMessages(
  * position (#1097), so the global toggles leave them untouched.
  */
 function entryInLiveViewport(state: MakaPiTranscriptState, entry: MakaPiTranscriptEntry): boolean {
-  const firstLine = state.renderGeometry.entryFirstLine.get(entry);
-  return firstLine === undefined || firstLine >= state.renderGeometry.viewportTop;
+  const geometry = state.renderGeometry;
+  // No positions at all (fresh state, or replaced and not yet rendered): safe
+  // only while the viewport has never scrolled.
+  if (geometry.entryFirstLine === undefined) return geometry.viewportTop === 0;
+  const firstLine = geometry.entryFirstLine.get(entry);
+  return firstLine === undefined || firstLine >= geometry.viewportTop;
 }
 
 /** Toggle every tool card in the live viewport at once; false when there is none. */

--- a/packages/cli/src/pi-transcript.ts
+++ b/packages/cli/src/pi-transcript.ts
@@ -50,13 +50,24 @@ export interface MakaPiTranscriptState {
   queuedInteractions: MakaPiPendingInteraction[];
   expandedPermissionRequestId?: string;
   /**
-   * Global expansion toggles: one Ctrl+O press expands every tool card in the
-   * transcript, one Ctrl+T press expands every thinking entry; pressing again
-   * collapses all. In-memory only; never persisted to storage. Resume resets
-   * both to collapsed.
+   * Expansion defaults: entries stamp `expanded` from these at creation, and
+   * one Ctrl+O / Ctrl+T press retargets every tool / thinking entry inside the
+   * live viewport and flips the default for entries created later. Entries
+   * above the viewport keep their state — their rendered lines sit in terminal
+   * scrollback, which cannot be rewritten, so resizing one would force pi-tui
+   * into a scrollback-clearing full redraw (#1097). In-memory only; never
+   * persisted to storage. Resume resets both to collapsed.
    */
   expandAllTools: boolean;
   expandAllThinking: boolean;
+  /**
+   * Geometry of the transcript render pi-tui last diffed against:
+   * renderMakaPiTranscript records each entry's first line and
+   * MakaPiLayoutComponent records the live-viewport top. The expansion toggles
+   * read it to leave entries above the viewport untouched (#1097); see
+   * entryInLiveViewport.
+   */
+  renderGeometry: MakaPiRenderGeometry;
   /**
    * Ref polls folded at `tool_start`, childToolUseId → card facts. A Read /
    * StopBackgroundTask aimed at a ref a visible Bash card owns is internal
@@ -86,6 +97,19 @@ export interface MakaPiTranscriptState {
 
 export type MakaPiPendingInteraction = AnyPermissionRequestEvent | UserQuestionRequestEvent;
 
+export interface MakaPiRenderGeometry {
+  /** First rendered transcript-line index per entry, from the latest render. */
+  entryFirstLine: Map<MakaPiTranscriptEntry, number>;
+  /**
+   * pi-tui's live-viewport top in transcript-line coordinates (the transcript
+   * is the first layout child, so transcript line i is composed line i). Held
+   * as a monotonic max: pi-tui's viewport never scrolls back up short of a
+   * full redraw, and a full redraw has already cleared scrollback, so
+   * overestimating only makes the toggles more conservative.
+   */
+  viewportTop: number;
+}
+
 /** Facts kept from a folded poll's `tool_start` so an errored result can still materialize a proper card. */
 export interface MakaPiPendingShellRunPoll {
   toolName: string;
@@ -107,7 +131,7 @@ const LIVE_TOOL_BUFFER_MAX_CHUNKS = 512;
 export type MakaPiTranscriptEntry =
   | { kind: 'user'; text: string }
   | { kind: 'assistant'; messageId: string; text: string }
-  | { kind: 'thinking'; messageId: string; text: string }
+  | { kind: 'thinking'; messageId: string; text: string; expanded: boolean }
   | {
       kind: 'tool';
       toolUseId: string;
@@ -124,6 +148,8 @@ export type MakaPiTranscriptEntry =
       outputDeltas: BoundedChunkBuffer<MakaPiToolOutputDelta>;
       durationMs?: number;
       status: 'running' | 'done' | 'error' | 'failed' | 'aborted' | 'detached' | 'unavailable';
+      /** Expanded card view; stamped from expandAllTools, retargeted by Ctrl+O. */
+      expanded: boolean;
     }
   | { kind: 'notice'; level: 'info' | 'error'; text: string };
 
@@ -151,6 +177,7 @@ export function createMakaPiTranscriptState(): MakaPiTranscriptState {
     queuedInteractions: [],
     expandAllTools: false,
     expandAllThinking: false,
+    renderGeometry: { entryFirstLine: new Map(), viewportTop: 0 },
     pendingShellRunPolls: new Map(),
     usage: { costUsd: 0, cacheHitInput: 0, cacheMissInput: 0 },
     steering: [],
@@ -251,6 +278,10 @@ export function replaceTranscriptWithStoredMessages(
   state.pendingShellRunPolls.clear();
   state.expandAllTools = false;
   state.expandAllThinking = false;
+  // The old entries are gone; drop their recorded positions. viewportTop stays:
+  // whatever is on screen still came from the previous render until the next
+  // render replaces it.
+  state.renderGeometry.entryFirstLine = new Map();
   state.usage = { costUsd: 0, cacheHitInput: 0, cacheMissInput: 0 };
   // Queues are per-active-run; a switched/reset session has none pending.
   state.steering = [];
@@ -261,21 +292,40 @@ export function replaceTranscriptWithStoredMessages(
   }
 }
 
-/** Toggle expansion of every tool card at once; false when there is none. */
+/**
+ * True when the entry will render inside the live viewport, or has not been
+ * rendered yet (a fresh entry first appears at the tail, inside the viewport).
+ * Entries above the viewport sit in terminal scrollback, which ANSI terminals
+ * cannot rewrite: resizing one forces pi-tui's differential renderer into a
+ * full redraw that clears pre-Maka scrollback and resets the user's scroll
+ * position (#1097), so the global toggles leave them untouched.
+ */
+function entryInLiveViewport(state: MakaPiTranscriptState, entry: MakaPiTranscriptEntry): boolean {
+  const firstLine = state.renderGeometry.entryFirstLine.get(entry);
+  return firstLine === undefined || firstLine >= state.renderGeometry.viewportTop;
+}
+
+/** Toggle every tool card in the live viewport at once; false when there is none. */
 export function toggleAllToolExpansion(state: MakaPiTranscriptState): boolean {
-  const hasTool = state.entries.some((entry) => entry.kind === 'tool');
-  if (!hasTool) return false;
+  const targets = state.entries.filter(
+    (entry): entry is MakaPiToolEntry => entry.kind === 'tool' && entryInLiveViewport(state, entry),
+  );
+  if (targets.length === 0) return false;
   state.expandAllTools = !state.expandAllTools;
+  for (const entry of targets) entry.expanded = state.expandAllTools;
   return true;
 }
 
-/** Toggle expansion of every thinking entry at once; false when there is none. */
+/** Toggle every thinking entry in the live viewport at once; false when there is none. */
 export function toggleAllThinkingExpansion(state: MakaPiTranscriptState): boolean {
-  const hasThinking = state.entries.some(
-    (entry) => entry.kind === 'thinking' && Boolean(entry.text.trim()),
+  const targets = state.entries.filter(
+    (entry): entry is MakaPiThinkingEntry => entry.kind === 'thinking'
+      && Boolean(entry.text.trim())
+      && entryInLiveViewport(state, entry),
   );
-  if (!hasThinking) return false;
+  if (targets.length === 0) return false;
   state.expandAllThinking = !state.expandAllThinking;
+  for (const entry of targets) entry.expanded = state.expandAllThinking;
   return true;
 }
 
@@ -436,6 +486,7 @@ export function applyMakaSessionEventToTranscript(
         progress: createProgressBuffer(),
         outputDeltas: createOutputBuffer(),
         status: 'running',
+        expanded: state.expandAllTools,
       });
       break;
     }
@@ -470,6 +521,7 @@ export function applyMakaSessionEventToTranscript(
           resultVersion: 1,
           durationMs: event.durationMs,
           status: event.isError ? 'error' : 'done',
+          expanded: state.expandAllTools,
         };
         if (shellRun && !event.isError) applyOwnShellRunResult(entry, shellRun, event.durationMs);
         state.entries.push(entry);
@@ -519,6 +571,7 @@ export function applyMakaSessionEventToTranscript(
           resultVersion: 1,
           durationMs: event.durationMs,
           status: event.isError ? 'error' : 'done',
+          expanded: state.expandAllTools,
         });
       }
       break;
@@ -651,7 +704,9 @@ function chatItemToTranscriptEntries(item: ChatItem): MakaPiTranscriptEntry[] {
       // Stored thinking happened before the reply text, so it resumes above it.
       const thinking = item.message.thinking?.text;
       if (thinking?.trim()) {
-        entries.push({ kind: 'thinking', messageId: item.message.id, text: thinking });
+        // Replay resets the expansion defaults to collapsed, so replayed
+        // entries start collapsed too.
+        entries.push({ kind: 'thinking', messageId: item.message.id, text: thinking, expanded: false });
       }
       entries.push({ kind: 'assistant', messageId: item.message.id, text: item.message.text });
       return entries;
@@ -684,6 +739,7 @@ function toolActivityToTranscriptEntry(item: ToolActivityItem): MakaPiToolEntry 
     resultVersion: item.result ? 1 : 0,
     ...(item.durationMs !== undefined ? { durationMs: item.durationMs } : {}),
     status: transcriptToolStatus(item.status),
+    expanded: false,
   };
   // A failed call keeps its error status and raw payload: applying the shell_run
   // as the card's own result would let a still-running or settled payload
@@ -871,6 +927,7 @@ export function renderMakaPiTranscript(
     return renderWelcomeBlock(metadata, safeWidth);
   }
 
+  const entryFirstLine = new Map<MakaPiTranscriptEntry, number>();
   for (let i = 0; i < state.entries.length; i += 1) {
     const entry = state.entries[i]!;
     const prev = state.entries[i - 1];
@@ -881,8 +938,10 @@ export function renderMakaPiTranscript(
     // text rather than packing against the tool rows.
     const continuesStack = entry.kind === 'tool' && prev?.kind === 'tool';
     if (!continuesStack) lines.push('');
-    lines.push(...renderTranscriptEntryMemoized(entry, safeWidth, state.expandAllTools, state.expandAllThinking));
+    entryFirstLine.set(entry, lines.length);
+    lines.push(...renderTranscriptEntryMemoized(entry, safeWidth));
   }
+  state.renderGeometry.entryFirstLine = entryFirstLine;
 
   if (state.pendingInteraction?.type === 'permission_request') {
     lines.push('');
@@ -983,13 +1042,11 @@ const transcriptEntryRenderCache = new WeakMap<MakaPiTranscriptEntry, Transcript
 function renderTranscriptEntryMemoized(
   entry: MakaPiTranscriptEntry,
   width: number,
-  expandAllTools: boolean,
-  expandAllThinking: boolean,
 ): string[] {
-  const signature = transcriptEntrySignature(entry, width, expandAllTools, expandAllThinking);
+  const signature = transcriptEntrySignature(entry, width);
   const cached = transcriptEntryRenderCache.get(entry);
   if (cached && cached.signature === signature) return cached.lines;
-  const lines = renderTranscriptEntryBlock(entry, width, expandAllTools, expandAllThinking);
+  const lines = renderTranscriptEntryBlock(entry, width);
   transcriptEntryRenderCache.set(entry, { signature, lines });
   return lines;
 }
@@ -997,8 +1054,6 @@ function renderTranscriptEntryMemoized(
 function renderTranscriptEntryBlock(
   entry: MakaPiTranscriptEntry,
   width: number,
-  expandAllTools: boolean,
-  expandAllThinking: boolean,
 ): string[] {
   switch (entry.kind) {
     case 'user':
@@ -1006,9 +1061,9 @@ function renderTranscriptEntryBlock(
     case 'assistant':
       return renderAssistantBlock(entry.text, width);
     case 'thinking':
-      return renderThinkingBlock(entry, width, expandAllThinking);
+      return renderThinkingBlock(entry, width, entry.expanded);
     case 'tool':
-      return renderToolBlock(entry, width, expandAllTools);
+      return renderToolBlock(entry, width, entry.expanded);
     case 'notice':
       return renderNotice(entry, width);
   }
@@ -1017,8 +1072,6 @@ function renderTranscriptEntryBlock(
 function transcriptEntrySignature(
   entry: MakaPiTranscriptEntry,
   width: number,
-  expandAllTools: boolean,
-  expandAllThinking: boolean,
 ): string {
   switch (entry.kind) {
     // user and assistant text is append-only (user is immutable; assistant only
@@ -1033,7 +1086,7 @@ function transcriptEntrySignature(
       // Not just the length: `thinking_complete` can replace the streamed text
       // in place with a same-length final, which a length-only key would miss and
       // then serve stale reasoning from the cache. Key on the full text.
-      return `thinking|${width}|${expandAllThinking ? 1 : 0}|${entry.text}`;
+      return `thinking|${width}|${entry.expanded ? 1 : 0}|${entry.text}`;
     case 'notice':
       return `notice|${width}|${entry.level}|${entry.text.length}`;
     case 'tool':
@@ -1046,7 +1099,7 @@ function transcriptEntrySignature(
       return [
         'tool',
         width,
-        expandAllTools ? 1 : 0,
+        entry.expanded ? 1 : 0,
         entry.status,
         entry.durationMs ?? '',
         entry.title ?? entry.toolName,
@@ -1181,7 +1234,7 @@ function appendThinking(state: MakaPiTranscriptState, messageId: string, text: s
     last.text += text;
     return;
   }
-  state.entries.push({ kind: 'thinking', messageId, text });
+  state.entries.push({ kind: 'thinking', messageId, text, expanded: state.expandAllThinking });
 }
 
 function setThinking(state: MakaPiTranscriptState, messageId: string, text: string): void {
@@ -1194,7 +1247,7 @@ function setThinking(state: MakaPiTranscriptState, messageId: string, text: stri
       return;
     }
   }
-  state.entries.push({ kind: 'thinking', messageId, text });
+  state.entries.push({ kind: 'thinking', messageId, text, expanded: state.expandAllThinking });
 }
 
 // Thinking stays collapsed to a one-line marker by default so reasoning

--- a/packages/cli/src/pi-transcript.ts
+++ b/packages/cli/src/pi-transcript.ts
@@ -278,9 +278,11 @@ export function replaceTranscriptWithStoredMessages(
   state.pendingShellRunPolls.clear();
   state.expandAllTools = false;
   state.expandAllThinking = false;
-  // The old entries are gone; drop their recorded positions. viewportTop stays:
-  // whatever is on screen still came from the previous render until the next
-  // render replaces it.
+  // The old entries are gone; drop their recorded positions. viewportTop is
+  // left to the next layout render: when the replacement changes lines above
+  // it, pi-tui full-redraws and the layout's shadow diff resets the estimate
+  // to match; when the replacement is a pure truncation or identical content,
+  // pi-tui keeps its viewport and so does the estimate.
   state.renderGeometry.entryFirstLine = new Map();
   state.usage = { costUsd: 0, cacheHitInput: 0, cacheMissInput: 0 };
   // Queues are per-active-run; a switched/reset session has none pending.

--- a/packages/cli/src/pi-tui-layout.ts
+++ b/packages/cli/src/pi-tui-layout.ts
@@ -1,4 +1,8 @@
 import { Container, type Component, type Terminal } from '@earendil-works/pi-tui';
+// Deep import (pi-tui does not re-export it): the viewport shadow diff must
+// compare the same canonical lines pi-tui diffs, and pi-tui normalizes Thai/Lao
+// AM sequences before its diff. Pinned to pi-tui 0.80.3.
+import { normalizeTerminalOutput } from '@earendil-works/pi-tui/dist/utils.js';
 import {
   renderMakaPiActivityStrip,
   renderMakaPiPendingQueue,
@@ -120,33 +124,54 @@ export class MakaPiLayoutComponent extends Container {
     //
     // Shadow pi-tui's own viewport rule rather than guessing: its viewport
     // never scrolls back up (monotonic max) except when it full-redraws and
-    // re-anchors to the document tail. It full-redraws exactly when the
-    // terminal width or height changed, when a line above the current
-    // viewport top changed (wholesale replacement), or when the document
-    // shrank below the viewport top (deep rewind) — those cases reset the
-    // estimate; anything else (appends, in-viewport edits, shallow
-    // truncation) keeps it monotonic.
-    this.state.renderGeometry.viewportTop = this.nextViewportTop(lines, width);
-    this.previousLines = lines;
+    // re-anchors to the document tail. Each branch of nextViewportTop mirrors
+    // one decision in pi-tui's doRender (tui.js, pinned 0.80.3); the estimate
+    // may exceed the real viewport top (which only makes the toggles more
+    // conservative) but must never fall below it. An upstream viewport getter
+    // would collapse all of this to one line.
+    const normalized = lines.map(normalizeTerminalOutput);
+    this.state.renderGeometry.viewportTop = this.nextViewportTop(normalized, width);
+    this.previousLines = normalized;
     this.previousRows = this.terminal.rows;
     this.previousWidth = width;
     return lines;
   }
 
+  /** `lines` are normalized, matching what pi-tui's differential renderer diffs. */
   private nextViewportTop(lines: string[], width: number): number {
-    const tailTop = Math.max(0, lines.length - this.terminal.rows);
-    if (
-      this.previousLines === undefined
-      || this.previousRows !== this.terminal.rows
-      || this.previousWidth !== width
-    ) {
-      return tailTop;
-    }
+    const rows = this.terminal.rows;
+    const tailTop = Math.max(0, lines.length - rows);
+    const previous = this.previousLines;
+    // First render; width changes full-redraw unconditionally (tui.js ~1061),
+    // even when no line ends up wrapping differently.
+    if (previous === undefined || this.previousWidth !== width) return tailTop;
     const current = this.state.renderGeometry.viewportTop;
-    if (lines.length < current) return tailTop;
-    const overlap = Math.min(this.previousLines.length, lines.length, current);
-    for (let i = 0; i < overlap; i += 1) {
-      if (this.previousLines[i] !== lines[i]) return tailTop;
+    if (this.previousRows !== rows) {
+      // Height changes full-redraw (tui.js ~1069) except under Termux, where
+      // the software keyboard resizes constantly and pi-tui instead keeps the
+      // buffer and recomputes its top from it (tui.js ~983).
+      return Boolean(process.env.TERMUX_VERSION)
+        ? Math.max(tailTop, current + (this.previousRows ?? rows) - rows)
+        : tailTop;
+    }
+    // Any change above the viewport top forces a full redraw (tui.js ~1169).
+    const scan = Math.min(previous.length, lines.length);
+    let firstChanged = -1;
+    for (let i = 0; i < scan; i += 1) {
+      if (previous[i] !== lines[i]) {
+        firstChanged = i;
+        break;
+      }
+    }
+    if (firstChanged !== -1 && firstChanged < current) return tailTop;
+    if (lines.length < previous.length) {
+      // Pure truncation: pi-tui's deleted-lines path full-redraws when the
+      // new document ends at or above the viewport top (tui.js ~1122,
+      // `targetRow < prevViewportTop`) or when more than a screenful of rows
+      // must be cleared (tui.js ~1136); a shallower truncation keeps the
+      // viewport where it was.
+      if (lines.length <= current) return tailTop;
+      if (firstChanged === -1 && previous.length - lines.length > rows) return tailTop;
     }
     return Math.max(current, tailTop);
   }

--- a/packages/cli/src/pi-tui-layout.ts
+++ b/packages/cli/src/pi-tui-layout.ts
@@ -66,6 +66,7 @@ export class MakaPendingQueueComponent implements Component {
  */
 export class MakaPiLayoutComponent extends Container {
   constructor(
+    private readonly state: MakaPiTranscriptState,
     private readonly transcript: MakaTranscriptComponent,
     private readonly activityStrip: MakaActivityStripComponent,
     private readonly pendingQueue: MakaPendingQueueComponent,
@@ -98,7 +99,7 @@ export class MakaPiLayoutComponent extends Container {
     const chromeRows = activityLines.length + pendingLines.length + editorLines.length + statusLines.length;
     const viewportRows = Math.max(0, this.terminal.rows - chromeRows);
     const paddingRows = Math.max(0, viewportRows - paddedTranscript.length);
-    return [
+    const lines = [
       ...paddedTranscript,
       ...Array.from({ length: paddingRows }, () => ''),
       ...activityLines,
@@ -106,5 +107,17 @@ export class MakaPiLayoutComponent extends Container {
       ...editorLines,
       ...statusLines,
     ];
+    // #1097: record where pi-tui's live viewport starts for this render, in
+    // transcript-line coordinates (valid because the transcript opens this
+    // composed list at line 0). Monotonic max mirrors pi-tui, whose viewport
+    // never scrolls back up short of a full redraw. The expansion toggles use
+    // it to leave entries above the viewport untouched — their lines sit in
+    // scrollback, which cannot be rewritten without a scrollback-clearing
+    // full redraw.
+    this.state.renderGeometry.viewportTop = Math.max(
+      this.state.renderGeometry.viewportTop,
+      lines.length - this.terminal.rows,
+    );
+    return lines;
   }
 }

--- a/packages/cli/src/pi-tui-layout.ts
+++ b/packages/cli/src/pi-tui-layout.ts
@@ -65,6 +65,11 @@ export class MakaPendingQueueComponent implements Component {
  * Once it overflows the padding is gone and the buffer grows past the viewport.
  */
 export class MakaPiLayoutComponent extends Container {
+  /** Composed lines of the previous render, for the viewport-top shadow diff. */
+  private previousLines: string[] | undefined;
+  private previousRows: number | undefined;
+  private previousWidth: number | undefined;
+
   constructor(
     private readonly state: MakaPiTranscriptState,
     private readonly transcript: MakaTranscriptComponent,
@@ -109,15 +114,40 @@ export class MakaPiLayoutComponent extends Container {
     ];
     // #1097: record where pi-tui's live viewport starts for this render, in
     // transcript-line coordinates (valid because the transcript opens this
-    // composed list at line 0). Monotonic max mirrors pi-tui, whose viewport
-    // never scrolls back up short of a full redraw. The expansion toggles use
-    // it to leave entries above the viewport untouched — their lines sit in
-    // scrollback, which cannot be rewritten without a scrollback-clearing
-    // full redraw.
-    this.state.renderGeometry.viewportTop = Math.max(
-      this.state.renderGeometry.viewportTop,
-      lines.length - this.terminal.rows,
-    );
+    // composed list at line 0). The expansion toggles use it to leave entries
+    // above the viewport untouched — their lines sit in scrollback, which
+    // cannot be rewritten without a scrollback-clearing full redraw.
+    //
+    // Shadow pi-tui's own viewport rule rather than guessing: its viewport
+    // never scrolls back up (monotonic max) except when it full-redraws and
+    // re-anchors to the document tail. It full-redraws exactly when the
+    // terminal width or height changed, when a line above the current
+    // viewport top changed (wholesale replacement), or when the document
+    // shrank below the viewport top (deep rewind) — those cases reset the
+    // estimate; anything else (appends, in-viewport edits, shallow
+    // truncation) keeps it monotonic.
+    this.state.renderGeometry.viewportTop = this.nextViewportTop(lines, width);
+    this.previousLines = lines;
+    this.previousRows = this.terminal.rows;
+    this.previousWidth = width;
     return lines;
+  }
+
+  private nextViewportTop(lines: string[], width: number): number {
+    const tailTop = Math.max(0, lines.length - this.terminal.rows);
+    if (
+      this.previousLines === undefined
+      || this.previousRows !== this.terminal.rows
+      || this.previousWidth !== width
+    ) {
+      return tailTop;
+    }
+    const current = this.state.renderGeometry.viewportTop;
+    if (lines.length < current) return tailTop;
+    const overlap = Math.min(this.previousLines.length, lines.length, current);
+    for (let i = 0; i < overlap; i += 1) {
+      if (this.previousLines[i] !== lines[i]) return tailTop;
+    }
+    return Math.max(current, tailTop);
   }
 }

--- a/packages/cli/src/pi-tui-runner.ts
+++ b/packages/cli/src/pi-tui-runner.ts
@@ -172,7 +172,7 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
   const editor = new Editor(tui, editorTheme(), { paddingX: 1, autocompleteMaxVisible: EDITOR_AUTOCOMPLETE_MAX_VISIBLE });
   let refreshEditorCwd: ((cwd: string) => void) | undefined;
   const editorSurface = new MakaAutocompleteAboveEditorComponent(editor);
-  const layout = new MakaPiLayoutComponent(transcript, activityStrip, pendingQueue, editorSurface, statusLine, terminal);
+  const layout = new MakaPiLayoutComponent(state, transcript, activityStrip, pendingQueue, editorSurface, statusLine, terminal);
   const attention = new AttentionController(terminal, {
     baseTitle: input.title,
     ...(input.attentionLongTurnThresholdMs !== undefined
@@ -1458,14 +1458,12 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
   // re-wrapping) a full clear would wipe the scrollback the user scrolls through.
   // Differential rendering clears the vacated rows without the wipe.
   //
-  // Known limit: a global Ctrl+O / Ctrl+T toggle that resizes a block sitting
-  // *above* the live viewport top makes pi-tui's differential renderer fall back
-  // to a full redraw (its `firstChanged < viewportTop` path), which does emit a
-  // scrollback-clearing sequence. That path re-emits the whole transcript, so no
-  // transcript content is lost — the tail is rebuilt into fresh scrollback — but
-  // the scroll position resets and any pre-Maka scrollback is cleared. Fully
-  // avoiding it would require a preserve-scrollback render path inside pi-tui,
-  // which we do not own; setClearOnShrink only governs the shrink path above.
+  // The Ctrl+O / Ctrl+T toggles are viewport-anchored for the same reason: an
+  // entry above the live viewport lives in terminal scrollback, which cannot
+  // be rewritten, so resizing it would push pi-tui's differential renderer
+  // into a scrollback-clearing full redraw (its `firstChanged < viewportTop`
+  // path). The toggles therefore retarget only entries inside the viewport;
+  // see entryInLiveViewport in pi-transcript.ts (#1097).
   tui.setClearOnShrink(false);
   tui.addChild(layout);
   tui.setFocus(editorSurface);


### PR DESCRIPTION
## Summary

Closes #1097.

A global Ctrl+O / Ctrl+T toggle resized every tool/thinking block, including ones scrolled above the live viewport. Terminal scrollback cannot be rewritten, so pi-tui's differential renderer fell back to a full redraw (`firstChanged < viewportTop`) that emits `ESC[2J ESC[H ESC[3J`, clearing pre-Maka scrollback and resetting the user's scroll position.

Since scrollback is immutable, the only correct behaviors for an off-screen block are "clear and re-emit" (the bug), "append a duplicate transcript" (worse), or "leave it untouched". This PR implements the third:

- Expansion becomes per-entry state (`entry.expanded`), stamped from the `expandAllTools` / `expandAllThinking` defaults at creation; render and the memo cache read only the entry.
- The toggles retarget entries whose first rendered line sits inside the live viewport and flip the default for future entries; entries above the viewport keep their frozen rendering.
- `renderMakaPiTranscript` records each entry's first line; `MakaPiLayoutComponent` records the viewport top in transcript coordinates (the transcript is the first composed child). The viewport top is a monotonic max, mirroring pi-tui's private `previousViewportTop`, which never scrolls back up short of a full redraw — overestimating only makes the toggles more conservative. `compositeOverlays` never lengthens an over-viewport buffer, so overlays cannot break the estimate.

The runner's "Known limit" comment is replaced by the new invariant. A follow-up upstream PR to pi-tui exposing a viewport getter can later replace the local computation with the exact value; it is not on this fix's critical path.

## Verification

- `packages/cli`: `tsc --noEmit` clean, `npm test` 458/458 (9 new), root `npm run lint` clean.
- New unit tests assert the lines above the viewport stay byte-identical across a toggle, off-screen entries keep their state, all-off-screen toggles report nothing to do, and entries created after an expand-all start expanded.
- New integration test drives the real pi-tui renderer through `runMakaPiTui` with a 24-row fake terminal: an early tool card scrolled above the viewport, Ctrl+O expands the visible card, and the whole output stream contains no `ESC[3J`. Reverting the viewport anchoring makes this test fail, confirming it locks the regression.


### Review hardening

An external review pass surfaced a real regression in the first commit: the viewport-top estimate was a pure monotonic max, but pi-tui re-anchors its real viewport whenever it full-redraws, so after `/new`, a session switch, a deep rewind, or a terminal resize the estimate stayed high and the toggles found nothing to target. `MakaPiLayoutComponent` now shadows pi-tui's exact full-redraw rule (size change, changed line above the top, shrink below the top → re-anchor to the document tail; anything else → monotonic), with `pi-tui-layout.test.ts` locking all four geometry behaviors including the shallow-truncation case where pi-tui keeps its viewport and the estimate must too.
