### PR TITLE
fix(runtime): unblock session resume after a run ends with an error event

### DIFF
--- a/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
+++ b/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
@@ -191,6 +191,43 @@ describe('AiSdkBackend model history', () => {
     ]);
   });
 
+  test('stored-message fallback skips empty assistant texts', async () => {
+    // A thinking/tool-only step projects an assistant row with empty text.
+    // The degraded stored-message path must not replay it: an empty text
+    // content block is a hard 400 on Anthropic-protocol providers, which
+    // permanently blocks every later turn of the session.
+    const model = completionModel();
+    const backend = new AiSdkBackend({
+      sessionId: 'session-1',
+      header: header(),
+      appendMessage: async () => {},
+      connection: connection(),
+      apiKey: 'sk-test',
+      modelId: 'mock-model-id',
+      permissionEngine: new PermissionEngine({ newId: () => 'permission-id', now: () => 1 }),
+      modelFactory: () => model,
+      tools: [],
+      newId: idGenerator(),
+      now: monotonicClock(),
+    });
+
+    await drain(backend.send({
+      turnId: 'turn-current',
+      text: 'current user',
+      context: [
+        { type: 'user', id: 'projection-u', turnId: 'turn-prev', ts: 1, text: 'projection user' },
+        { type: 'assistant', id: 'projection-empty', turnId: 'turn-prev', ts: 2, text: '', modelId: 'm' },
+        { type: 'assistant', id: 'projection-a', turnId: 'turn-prev', ts: 3, text: 'projection assistant', modelId: 'm' },
+      ],
+    }));
+
+    assert.deepEqual(compactPrompt(model), [
+      { role: 'user', content: [{ type: 'text', text: 'projection user' }] },
+      { role: 'assistant', content: [{ type: 'text', text: 'projection assistant' }] },
+      { role: 'user', content: [{ type: 'text', text: 'current user' }] },
+    ]);
+  });
+
   test('stored-message fallback keeps placeholder text when no reader is wired', async () => {
     const model = completionModel();
     const backend = new AiSdkBackend({

--- a/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
+++ b/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
@@ -144,6 +144,64 @@ describe('AiSdkBackend model history', () => {
     ]);
   });
 
+  test('drops a dangling tool call from replay after a crash during tool execution', async () => {
+    // The app died between persisting the function_call and its
+    // function_response; recovery appended the terminal error event. Replaying
+    // the dangling tool_use without a tool_result is a provider 400, so the
+    // request must carry the surviving history without the orphan call.
+    const model = completionModel();
+    const backend = new AiSdkBackend({
+      sessionId: 'session-1',
+      header: header(),
+      appendMessage: async () => {},
+      connection: connection(),
+      apiKey: 'sk-test',
+      modelId: 'mock-model-id',
+      permissionEngine: new PermissionEngine({ newId: () => 'permission-id', now: () => 1 }),
+      modelFactory: () => model,
+      tools: [],
+      newId: idGenerator(),
+      now: monotonicClock(),
+    });
+
+    await drain(backend.send({
+      turnId: 'turn-current',
+      text: 'current user',
+      context: [
+        { type: 'user', id: 'projection-u', turnId: 'turn-prev', ts: 1, text: 'runtime user' },
+      ],
+      runtimeContext: [
+        runtimeTextEvent({ id: 'rt-u', turnId: 'turn-prev', role: 'user', author: 'user', text: 'runtime user' }),
+        runtimeEvent({
+          id: 'rt-dangling-call',
+          turnId: 'turn-prev',
+          role: 'model',
+          author: 'agent',
+          content: { kind: 'function_call', id: 'tool-1', name: 'Bash', args: { command: 'sleep 999' } },
+        }),
+        {
+          id: 'rt-terminal-error',
+          invocationId: 'inv-1',
+          runId: 'run-prev',
+          sessionId: 'session-1',
+          turnId: 'turn-prev',
+          ts: 3,
+          partial: false,
+          role: 'system',
+          author: 'system',
+          status: 'failed',
+          content: { kind: 'error', code: 'app_restarted', reason: 'app_restarted', message: 'app_restarted' },
+          actions: { endInvocation: true },
+        },
+      ],
+    }));
+
+    assert.deepEqual(compactPrompt(model), [
+      { role: 'user', content: [{ type: 'text', text: 'runtime user' }] },
+      { role: 'user', content: [{ type: 'text', text: 'current user' }] },
+    ]);
+  });
+
   test('uses StoredMessage projection when RuntimeEvent replay is empty', async () => {
     const model = completionModel();
     const backend = new AiSdkBackend({

--- a/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
+++ b/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
@@ -90,6 +90,60 @@ describe('AiSdkBackend model history', () => {
     ]);
   });
 
+  test('keeps RuntimeEvent replay when the prior run ended with a terminal error event', async () => {
+    // Regression: a run recovered after an app restart commits a terminal
+    // error-content event to the ledger. That event must not degrade the next
+    // turn to the stored-message projection — the session would be stuck on the
+    // degraded path for every later turn.
+    const model = completionModel();
+    const backend = new AiSdkBackend({
+      sessionId: 'session-1',
+      header: header(),
+      appendMessage: async () => {},
+      connection: connection(),
+      apiKey: 'sk-test',
+      modelId: 'mock-model-id',
+      permissionEngine: new PermissionEngine({ newId: () => 'permission-id', now: () => 1 }),
+      modelFactory: () => model,
+      tools: [],
+      newId: idGenerator(),
+      now: monotonicClock(),
+    });
+
+    await drain(backend.send({
+      turnId: 'turn-current',
+      text: 'current user',
+      context: [
+        { type: 'user', id: 'projection-u', turnId: 'turn-prev', ts: 1, text: 'projection user' },
+        { type: 'assistant', id: 'projection-a', turnId: 'turn-prev', ts: 2, text: 'projection assistant', modelId: 'm' },
+      ],
+      runtimeContext: [
+        runtimeTextEvent({ id: 'rt-u', turnId: 'turn-prev', role: 'user', author: 'user', text: 'runtime user' }),
+        runtimeTextEvent({ id: 'rt-a', turnId: 'turn-prev', role: 'model', author: 'agent', text: 'runtime assistant' }),
+        {
+          id: 'rt-terminal-error',
+          invocationId: 'inv-1',
+          runId: 'run-prev',
+          sessionId: 'session-1',
+          turnId: 'turn-prev',
+          ts: 3,
+          partial: false,
+          role: 'system',
+          author: 'system',
+          status: 'failed',
+          content: { kind: 'error', code: 'app_restarted', reason: 'app_restarted', message: 'app_restarted' },
+          actions: { endInvocation: true },
+        },
+      ],
+    }));
+
+    assert.deepEqual(compactPrompt(model), [
+      { role: 'user', content: [{ type: 'text', text: 'runtime user' }] },
+      { role: 'assistant', content: [{ type: 'text', text: 'runtime assistant' }] },
+      { role: 'user', content: [{ type: 'text', text: 'current user' }] },
+    ]);
+  });
+
   test('uses StoredMessage projection when RuntimeEvent replay is empty', async () => {
     const model = completionModel();
     const backend = new AiSdkBackend({
@@ -3495,11 +3549,25 @@ describe('AiSdkBackend model history', () => {
       runtimeContext: [
         runtimeTextEvent({ id: 'rt-u', turnId: 'turn-prev', role: 'user', author: 'user', text: 'runtime user' }),
         runtimeEvent({
-          id: 'rt-error',
+          id: 'rt-call',
           turnId: 'turn-prev',
-          role: 'system',
-          author: 'system',
-          content: { kind: 'error', reason: 'tool_failed', message: 'Tool failed' },
+          role: 'model',
+          author: 'agent',
+          content: { kind: 'function_call', id: 'tool-1', name: 'Bash', args: { command: 'ls' } },
+        }),
+        runtimeEvent({
+          id: 'rt-invalid-shell',
+          turnId: 'turn-prev',
+          role: 'tool',
+          author: 'tool',
+          content: {
+            kind: 'function_response',
+            id: 'tool-1',
+            name: 'Bash',
+            // Unrecognizable shell result shape: neither current nor legacy.
+            result: { kind: 'terminal', garbage: true },
+            isError: false,
+          },
         }),
       ],
     }));

--- a/packages/runtime/src/__tests__/runtime-event-adapters.test.ts
+++ b/packages/runtime/src/__tests__/runtime-event-adapters.test.ts
@@ -1233,6 +1233,38 @@ describe('buildModelHistoryFromRuntimeEvents', () => {
     expect(plan.items.map((item) => item.kind)).toEqual(['text', 'tool_call', 'tool_result']);
     expect(plan.hasProviderNativeSemantics).toBe(true);
   });
+
+  test('drops a tool call whose result never landed in the ledger', () => {
+    // A crash during tool execution persists the function_call but never its
+    // function_response (recovery then appends a terminal error event). A
+    // replayed tool_use with no tool_result is a provider 400, so the planner
+    // must drop the dangling call — mirroring the deliberately non-blocking
+    // unmatched_tool_result handling — instead of replaying or blocking.
+    const events: RuntimeEvent[] = [
+      ev({ role: 'user', author: 'user', content: { kind: 'text', text: 'q' } }),
+      ev({
+        role: 'model',
+        author: 'agent',
+        content: { kind: 'function_call', id: 'tool-1', name: 'Bash', args: { command: 'sleep 999' } },
+      }),
+      ev({
+        role: 'system',
+        author: 'system',
+        status: 'failed',
+        content: { kind: 'error', code: 'app_restarted', reason: 'app_restarted', message: 'app_restarted' },
+        actions: { endInvocation: true },
+      }),
+    ];
+
+    const plan = buildRuntimeEventModelReplayPlan(events);
+
+    expect(plan.items.map((item) => item.kind)).toEqual(['text']);
+    expect(plan.semanticKinds).not.toContain('tool_call');
+    expect(plan.hasProviderNativeSemantics).toBe(false);
+    const codes = plan.diagnostics.map((diagnostic) => diagnostic.code);
+    expect(codes).toContain('unmatched_tool_call');
+    expect(codes).not.toContain('unsupported_content');
+  });
 });
 
 // ============================================================================

--- a/packages/runtime/src/__tests__/runtime-event-adapters.test.ts
+++ b/packages/runtime/src/__tests__/runtime-event-adapters.test.ts
@@ -1189,6 +1189,50 @@ describe('buildModelHistoryFromRuntimeEvents', () => {
     expect(plan.items).toHaveLength(1);
     expect(plan.diagnostics.map((diagnostic) => diagnostic.code)).toContain('terminal_fact_diagnostic_only');
   });
+
+  test('error-content RuntimeEvents are diagnostic-only, never blocking', () => {
+    // A run that errored (or was recovered after an app restart) lands error
+    // events in the ledger: a non-terminal error fact from the flow, and a
+    // terminal commit carrying the failure as error content. Neither is model
+    // conversation — flagging them `unsupported_content` (a blocking
+    // diagnostic) would degrade every later turn of the session to the
+    // stored-message projection.
+    const events: RuntimeEvent[] = [
+      ev({ role: 'user', author: 'user', content: { kind: 'text', text: 'q' } }),
+      ev({
+        role: 'model',
+        author: 'agent',
+        content: { kind: 'function_call', id: 'tool-1', name: 'Bash', args: { command: 'ls' } },
+      }),
+      ev({
+        role: 'tool',
+        author: 'tool',
+        content: { kind: 'function_response', id: 'tool-1', name: 'Bash', result: { ok: true }, isError: false },
+      }),
+      // Non-terminal error fact (ai-sdk-flow: the terminal complete follows).
+      ev({
+        role: 'system',
+        author: 'system',
+        content: { kind: 'error', code: 'api_error', reason: 'api_error', message: 'boom' },
+      }),
+      // Terminal recovery commit (terminal-run-commit after an app restart).
+      ev({
+        role: 'system',
+        author: 'system',
+        status: 'failed',
+        content: { kind: 'error', code: 'app_restarted', reason: 'app_restarted', message: 'app_restarted' },
+        actions: { endInvocation: true },
+      }),
+    ];
+
+    const plan = buildRuntimeEventModelReplayPlan(events);
+
+    const codes = plan.diagnostics.map((diagnostic) => diagnostic.code);
+    expect(codes).not.toContain('unsupported_content');
+    expect(codes.filter((code) => code === 'error_content_diagnostic_only')).toHaveLength(2);
+    expect(plan.items.map((item) => item.kind)).toEqual(['text', 'tool_call', 'tool_result']);
+    expect(plan.hasProviderNativeSemantics).toBe(true);
+  });
 });
 
 // ============================================================================

--- a/packages/runtime/src/ai-sdk-backend.ts
+++ b/packages/runtime/src/ai-sdk-backend.ts
@@ -4139,8 +4139,11 @@ export class AiSdkBackend implements AgentBackend {
         }
         out.push({ role: 'user', content: await this.appendImageParts(formatTextWithAttachmentRefs(m.text, m.attachments), m.attachments) } as ModelMessage);
       }
-      else if (m.type === 'assistant') out.push({ role: 'assistant', content: m.text });
-      // tool_call / tool_result / permission_decision / token_usage / system_note skipped
+      // A thinking/tool-only step projects an assistant row with empty text;
+      // replaying it as an empty text block is a hard 400 on Anthropic-protocol
+      // providers.
+      else if (m.type === 'assistant' && m.text.length > 0) out.push({ role: 'assistant', content: m.text });
+      // empty assistant / tool_call / tool_result / permission_decision / token_usage / system_note skipped
     }
     return out;
   }

--- a/packages/runtime/src/model-history.ts
+++ b/packages/runtime/src/model-history.ts
@@ -89,6 +89,7 @@ export type RuntimeEventReplayDiagnosticCode =
   | 'unsigned_thinking_skipped'
   | 'signed_thinking_in_tool_turn_skipped'
   | 'unmatched_tool_result'
+  | 'unmatched_tool_call'
   | 'tool_id_mismatch';
 
 export interface RuntimeEventReplayDiagnostic {
@@ -559,6 +560,22 @@ export function buildRuntimeEventModelReplayPlan(
         ));
         break;
     }
+  }
+
+  // A call whose result never landed (the app died during tool execution;
+  // recovery appends the terminal error but cannot invent the result) must not
+  // replay: a tool_use with no tool_result is a provider 400. Drop it — the
+  // deliberately non-blocking mirror of unmatched_tool_result — so consumers
+  // that read `items` directly (materializer, compact summarizer) stay valid.
+  for (const [toolCallId, call] of callsById) {
+    const index = items.indexOf(call.item);
+    if (index >= 0) items.splice(index, 1);
+    diagnostics.push({
+      code: 'unmatched_tool_call',
+      message: 'function_call has no matching function_response; dropped from model replay',
+      eventId: call.eventId,
+      detail: { toolCallId },
+    });
   }
 
   const textMessages = items

--- a/packages/runtime/src/model-history.ts
+++ b/packages/runtime/src/model-history.ts
@@ -84,6 +84,7 @@ export type RuntimeEventReplayDiagnosticCode =
   | 'unsupported_content'
   | 'system_runtime_fact_diagnostic_only'
   | 'terminal_fact_diagnostic_only'
+  | 'error_content_diagnostic_only'
   | 'empty_text_skipped'
   | 'unsigned_thinking_skipped'
   | 'signed_thinking_in_tool_turn_skipped'
@@ -369,6 +370,20 @@ export function buildRuntimeEventModelReplayPlan(
           event,
           'empty_text_skipped',
           'empty model text RuntimeEvent (thinking/tool-only step closer) skipped for model replay',
+        ));
+        continue;
+      }
+      // Error content is a run/turn failure fact (a flow error event or a
+      // terminal recovery commit), not model conversation. It must stay
+      // diagnostic-only: `unsupported_content` is a BLOCKING diagnostic (see
+      // hasBlockingReplayDiagnostics), and one persisted failure would
+      // otherwise degrade every later turn of the session to the
+      // stored-message projection.
+      if (event.content.kind === 'error') {
+        diagnostics.push(diagnostic(
+          event,
+          'error_content_diagnostic_only',
+          'error RuntimeEvent content is diagnostic-only for model replay',
         ));
         continue;
       }


### PR DESCRIPTION
## Summary

A session whose previous run ended with a persisted error event — an app-restart recovery commit (`terminal-run-commit.ts`) or a mid-run provider error fact (`ai-sdk-flow.ts`) — could never complete another turn: every retry failed in ~400ms with `errorClass: "unknown"` and the session stayed `blocked`.

Three defects compose into the dead loop:

1. **The replay planner treated error-content events as blocking.** `buildRuntimeEventModelReplayPlan` classified `kind: 'error'` content as `unsupported_content`, a blocking diagnostic, so the whole ledger degraded from provider-native replay to the stored-message projection. Error content is a failure fact, not model conversation (core already defines it as non-model-visible); it is now the non-blocking `error_content_diagnostic_only`.
2. **The degraded projection built invalid requests.** `materializePriorMessages` replayed every stored assistant row verbatim. Thinking/tool-only steps project assistant rows with empty text, and an empty text content block is a hard 400 on Anthropic-protocol providers. Empty assistant rows are now skipped.
3. **Dangling tool calls replayed as provider-invalid history.** A crash during tool execution persists the `function_call` but never its `function_response`; a replayed `tool_use` with no `tool_result` is a provider 400. Previously masked by defect 1's blanket degradation, exposed by fix 1. The planner now drops unmatched calls with the non-blocking `unmatched_tool_call` diagnostic — the mirror of the existing `unmatched_tool_result` handling — which also keeps items-only consumers (materializer, compact summarizer) provider-valid.

Fix 1 keeps recovered sessions on the provider-native path; fixes 2 and 3 make both replay paths produce valid requests for every ledger shape a crash can leave behind.

## Verification

- TDD: each fix has a regression test that reproduced the symptom before the change (`runtime-event-adapters.test.ts` planner classification and dangling-call drop; `ai-sdk-backend.test.ts` replay-gate, fallback-projection, and dangling-call request shapes via the mock model prompt).
- Full `@maka/runtime` suite passes (0 fail).
- Replayed the real broken session ledger (126 events, interrupted by an app restart mid-run) through the fixed planner: 0 blocking diagnostics, provider-native replay engages, and the interrupted step's dangling signed thinking is claimed by its step's buffered tool call.
- External review (Codex) over the diff: found the dangling-call gap (fix 3); its remaining assessment confirmed fixes 1–2 sit at the responsible layer with no other affected consumers of the diagnostic union or the fallback projection.

Not run: a live resume against a real Anthropic-protocol provider (needs real credentials; the request shapes exercised are the same ones the mock-model tests assert).

## Root cause

Diagnosed from a stuck production session: app restart mid-run → recovery writes a terminal error event → next turn's replay degrades (defect 1) → degraded projection emits 23 empty assistant messages from thinking-only steps → Anthropic-protocol 400 on every retry (defect 2), surfaced only as `errorClass: "unknown"`. Defect 3 is the adjacent crash shape (mid-tool instead of post-tool) that fix 1 would otherwise have exposed.