### PR TITLE
refactor(runtime): centralize filesystem-containment guards

### DIFF
--- a/apps/desktop/src/main/explore-agent-tool.ts
+++ b/apps/desktop/src/main/explore-agent-tool.ts
@@ -1,7 +1,7 @@
 import { lstat, readdir, readFile, realpath, stat } from 'node:fs/promises';
-import { basename, extname, isAbsolute, join, relative, resolve, sep } from 'node:path';
+import { basename, extname, join, resolve } from 'node:path';
 import { z } from 'zod';
-import type { MakaTool } from '@maka/runtime';
+import { isInside, toRelative, type MakaTool } from '@maka/runtime';
 
 export const EXPLORE_AGENT_TOOL_NAME = 'ExploreAgent';
 
@@ -957,16 +957,6 @@ function capSnippet(line: string): string {
 
 function looksBinary(text: string): boolean {
   return text.includes('\u0000');
-}
-
-function isInside(root: string, target: string): boolean {
-  const rel = relative(root, target);
-  return rel === '' || (rel !== '..' && !rel.startsWith(`..${sep}`) && !isAbsolute(rel));
-}
-
-function toRelative(root: string, target: string): string {
-  const rel = relative(root, target);
-  return rel === '' ? '.' : rel.split(sep).join('/');
 }
 
 function failure(

--- a/apps/desktop/src/main/managed-skill-sources.ts
+++ b/apps/desktop/src/main/managed-skill-sources.ts
@@ -1,8 +1,8 @@
 import { createHash } from 'node:crypto';
 import { homedir } from 'node:os';
-import { basename, dirname, extname, isAbsolute, join, relative } from 'node:path';
+import { basename, dirname, extname, isAbsolute, join } from 'node:path';
 import { lstat, mkdir, readdir, readFile, realpath, rename, unlink, writeFile } from 'node:fs/promises';
-import { validateSkillMetadata, type SkillValidationIssue } from '@maka/runtime';
+import { isContainedPath, isSafeSkillId, validateSkillMetadata, type SkillValidationIssue } from '@maka/runtime';
 
 /**
  * Fixed marketplace taxonomy. A source's `category:` front-matter is
@@ -311,13 +311,4 @@ function parseSkillFrontMatterForSource(text: string): { name?: string; descript
 
 function sha256(bytes: Buffer): string {
   return createHash('sha256').update(bytes).digest('hex');
-}
-
-function isSafeSkillId(value: string): boolean {
-  return /^[A-Za-z0-9][A-Za-z0-9._-]{0,80}$/.test(value);
-}
-
-function isContainedPath(root: string, child: string): boolean {
-  const rel = relative(root, child);
-  return rel === '' || (!!rel && !rel.startsWith('..') && !isAbsolute(rel));
 }

--- a/apps/desktop/src/main/office-document-tool.ts
+++ b/apps/desktop/src/main/office-document-tool.ts
@@ -1,9 +1,9 @@
 import { execFile } from 'node:child_process';
 import { lstat, realpath } from 'node:fs/promises';
-import { dirname, extname, isAbsolute, relative, resolve, sep } from 'node:path';
+import { dirname, extname, isAbsolute, resolve } from 'node:path';
 import { z } from 'zod';
 import { redactSecrets } from '@maka/core/redaction';
-import type { MakaTool } from '@maka/runtime';
+import { isInside, toRelative, type MakaTool } from '@maka/runtime';
 import { buildOfficeCliEnv } from './officecli-env.js';
 
 export const OFFICE_DOCUMENT_TOOL_NAME = 'OfficeDocument';
@@ -659,14 +659,4 @@ function capOutput(text: string): { text: string; truncated: boolean } {
 
 function displayArgs(args: string[], abs: string, rel: string): string[] {
   return args.map((arg) => arg === abs ? rel : arg);
-}
-
-function isInside(root: string, target: string): boolean {
-  const rel = relative(root, target);
-  return rel === '' || (rel !== '..' && !rel.startsWith(`..${sep}`) && !isAbsolute(rel));
-}
-
-function toRelative(root: string, target: string): string {
-  const rel = relative(root, target);
-  return rel === '' ? '.' : rel.split(sep).join('/');
 }

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -1024,10 +1024,14 @@ export {
   readContainedRegularFile,
   readContainedRegularTextFile,
   writeContainedRegularTextFile,
-  isContainedPath,
-  isSafeSkillId,
   isRecord,
 } from './skills.js';
+export {
+  isContainedPath,
+  isSafeSkillId,
+  isInside,
+  toRelative,
+} from './path-containment.js';
 export type {
   SkillRuntimeStatus,
   SkillManifest,

--- a/packages/runtime/src/path-containment.ts
+++ b/packages/runtime/src/path-containment.ts
@@ -1,30 +1,27 @@
 import { isAbsolute, relative, sep } from 'node:path';
 
 /**
- * Shared filesystem-containment and identifier guards.
+ * Shared filesystem-containment and identifier guards, moved verbatim from
+ * previously duplicated private copies in the runtime skill reader and the
+ * desktop main process. This leaf module imports only `node:path`, so both the
+ * pure-Node runtime and the desktop main process (which already depends on
+ * `@maka/runtime`) can use it without reverse dependencies.
  *
- * This leaf module is the single home for the path-safety primitives that were
- * previously kept as private copies across the runtime skill reader and the
- * desktop main process. Centralizing them means a future fix to a containment
- * check lands in one place instead of drifting between byte-identical copies.
- * It imports only `node:path`, so it has no reverse dependency on any heavier
- * module and can be safely reused by both the pure-Node runtime and the desktop
- * main process (which already depends on `@maka/runtime`).
+ * Two behavior variants live here and are NOT interchangeable — their
+ * `..`-prefix handling diverges on a child entry whose own name begins with
+ * `..` (e.g. `root/..foo`): {@link isContainedPath} rejects it as an escape,
+ * while the separator-aware {@link isInside} correctly treats it as inside.
+ * Reconciling them is a behavior-changing decision, not a mechanical move;
+ * callers must keep the guard they used before.
  *
- * Two distinct containment families live here on purpose; they are NOT
- * interchangeable and were verified byte-for-byte before being moved verbatim:
- *
- * - {@link isContainedPath} treats any relative path whose string starts with
- *   `..` as an escape. It is the guard used by the skill reader
- *   (`skills.ts`) and the managed skill-source store.
- * - {@link isInside} is separator-aware: it rejects only an exact `..` or a
- *   `..<sep>`-prefixed relative path, so a sibling entry whose name literally
- *   begins with `..` (e.g. `..foo`) is correctly treated as inside. It is the
- *   guard used by the read-only explore worker.
- *
- * Their `..`-prefix handling differs, so reconciling the two is a deliberate,
- * behavior-changing decision that must not be folded into a mechanical move.
- * Callers must keep using the same guard they used before.
+ * This module is not yet the single home of containment logic, and function
+ * names elsewhere do not reliably indicate which variant they implement.
+ * Known remaining variants pending a follow-up consolidation:
+ * - `workspace-executor.ts`, `filesystem-worker/operations.ts`, and
+ *   `additional-permissions.ts` each define a local `isInside`-style check
+ *   with bare-`startsWith('..')` ({@link isContainedPath}) semantics.
+ * - `system-prompt/workspace-instructions.ts` exports `isPathInside`, a
+ *   cross-platform-tested equivalent of {@link isInside} under default args.
  */
 
 /**
@@ -45,9 +42,8 @@ export function isSafeSkillId(value: string): boolean {
 /**
  * Separator-aware containment check: true when `target` is inside (or equal to)
  * `root`. Rejects only an exact `..` or a `..<sep>`-prefixed relative path, so
- * a sibling whose name starts with `..` stays inside. Used by the read-only
- * explore worker. See the module note on why this differs from
- * {@link isContainedPath}.
+ * a child entry whose own name starts with `..` stays inside. See the module
+ * note on why this differs from {@link isContainedPath}.
  */
 export function isInside(root: string, target: string): boolean {
   const rel = relative(root, target);

--- a/packages/runtime/src/path-containment.ts
+++ b/packages/runtime/src/path-containment.ts
@@ -1,0 +1,61 @@
+import { isAbsolute, relative, sep } from 'node:path';
+
+/**
+ * Shared filesystem-containment and identifier guards.
+ *
+ * This leaf module is the single home for the path-safety primitives that were
+ * previously kept as private copies across the runtime skill reader and the
+ * desktop main process. Centralizing them means a future fix to a containment
+ * check lands in one place instead of drifting between byte-identical copies.
+ * It imports only `node:path`, so it has no reverse dependency on any heavier
+ * module and can be safely reused by both the pure-Node runtime and the desktop
+ * main process (which already depends on `@maka/runtime`).
+ *
+ * Two distinct containment families live here on purpose; they are NOT
+ * interchangeable and were verified byte-for-byte before being moved verbatim:
+ *
+ * - {@link isContainedPath} treats any relative path whose string starts with
+ *   `..` as an escape. It is the guard used by the skill reader
+ *   (`skills.ts`) and the managed skill-source store.
+ * - {@link isInside} is separator-aware: it rejects only an exact `..` or a
+ *   `..<sep>`-prefixed relative path, so a sibling entry whose name literally
+ *   begins with `..` (e.g. `..foo`) is correctly treated as inside. It is the
+ *   guard used by the read-only explore worker.
+ *
+ * Their `..`-prefix handling differs, so reconciling the two is a deliberate,
+ * behavior-changing decision that must not be folded into a mechanical move.
+ * Callers must keep using the same guard they used before.
+ */
+
+/**
+ * True when `child` resolves inside (or equal to) `root`. Any relative path
+ * that begins with `..` is rejected as an escape. Used by the skill reader and
+ * the managed skill-source store.
+ */
+export function isContainedPath(root: string, child: string): boolean {
+  const rel = relative(root, child);
+  return rel === '' || (!!rel && !rel.startsWith('..') && !isAbsolute(rel));
+}
+
+/** True when `value` is a safe skill/source identifier (no path or control chars). */
+export function isSafeSkillId(value: string): boolean {
+  return /^[A-Za-z0-9][A-Za-z0-9._-]{0,80}$/.test(value);
+}
+
+/**
+ * Separator-aware containment check: true when `target` is inside (or equal to)
+ * `root`. Rejects only an exact `..` or a `..<sep>`-prefixed relative path, so
+ * a sibling whose name starts with `..` stays inside. Used by the read-only
+ * explore worker. See the module note on why this differs from
+ * {@link isContainedPath}.
+ */
+export function isInside(root: string, target: string): boolean {
+  const rel = relative(root, target);
+  return rel === '' || (rel !== '..' && !rel.startsWith(`..${sep}`) && !isAbsolute(rel));
+}
+
+/** Relative POSIX path from `root` to `target`, or `.` when they are equal. */
+export function toRelative(root: string, target: string): string {
+  const rel = relative(root, target);
+  return rel === '' ? '.' : rel.split(sep).join('/');
+}

--- a/packages/runtime/src/skills.ts
+++ b/packages/runtime/src/skills.ts
@@ -1,9 +1,10 @@
 import { createHash } from 'node:crypto';
 import { homedir } from 'node:os';
 import { lstat, mkdir, readdir, readFile, realpath, rename, unlink, writeFile } from 'node:fs/promises';
-import { isAbsolute, join, relative } from 'node:path';
+import { join, relative } from 'node:path';
 import { parseDocument } from 'yaml';
 import { z } from 'zod';
+import { isContainedPath, isSafeSkillId } from './path-containment.js';
 import type { MakaTool, MakaToolContext } from './tool-runtime.js';
 
 /**
@@ -907,15 +908,6 @@ export async function writeContainedRegularTextFile(rootDir: string, filePath: s
     await unlink(tempPath).catch(() => {});
     return false;
   }
-}
-
-export function isContainedPath(root: string, child: string): boolean {
-  const rel = relative(root, child);
-  return rel === '' || (!!rel && !rel.startsWith('..') && !isAbsolute(rel));
-}
-
-export function isSafeSkillId(value: string): boolean {
-  return /^[A-Za-z0-9][A-Za-z0-9._-]{0,80}$/.test(value);
 }
 
 export function isRecord(value: unknown): value is Record<string, unknown> {


### PR DESCRIPTION
## Summary

Third High slice of #1084. The filesystem-containment guards existed as private copies across the runtime skill reader and the desktop main process. This centralizes them so a future fix to a containment check lands in one place instead of drifting between copies.

New shared leaf `packages/runtime/src/path-containment.ts` (imports only `node:path`, no reverse deps), re-exported from `@maka/runtime`. Desktop main already depends on `@maka/runtime` and `apps/desktop/src/main/skills.ts` already imported these guards from it, so the shared home is an existing seam, not a new package.

Verification of the issue's "byte-identical in three places" premise found **two distinct guard variants**, documented in the module header and moved verbatim:

- `isContainedPath` / `isSafeSkillId` — byte-identical in `packages/runtime/src/skills.ts` (public export) and `apps/desktop/src/main/managed-skill-sources.ts` (private copy). Both now import the shared home.
- `isInside` / `toRelative` — used by `apps/desktop/src/main/explore-agent-tool.ts` and (byte-identically) `apps/desktop/src/main/office-document-tool.ts`; both now import the shared home. `isInside` is separator-aware (`rel !== '..' && !rel.startsWith('..' + sep)`) and is **not** byte-identical to `isContainedPath` (`!rel.startsWith('..')`); they diverge on a child entry whose own name literally starts with `..` (e.g. `root/..foo`): `isContainedPath` rejects it, `isInside` accepts it. Reconciling them is a deliberate, behavior-changing decision for a later PR, not a mechanical move.

Behavior-neutral: guards moved verbatim, no logic changed. `@maka/runtime` public exports stay stable (guards re-exported from the index, sourced from the new leaf) so the later non-High `skills.ts`-split slice composes. No tests directly named these guards; the symlink/escape behavioral tests stay with their modules and pass unchanged.

Review follow-up (second commit): the module header no longer claims a repo-complete taxonomy or single-home status — runtime still holds local `isInside`-named checks with `isContainedPath` semantics (`workspace-executor.ts`, `filesystem-worker/operations.ts`, `additional-permissions.ts`) and a tested separator-aware `isPathInside` (`system-prompt/workspace-instructions.ts`), now listed in the header as pending consolidation; and `office-document-tool.ts`'s byte-identical private `isInside`/`toRelative` copies were deduped the same way as `explore-agent-tool.ts`.

Deferred to a follow-up: reconciling `isInside` with the existing tested `isPathInside`, migrating the bare-`startsWith('..')` variants listed above, and a contract test forbidding new private containment predicates.

This checks the third High checkbox of #1084 (containment-guard dedup).

## Verification

- `npm --workspace @maka/runtime run typecheck` — pass
- `npm --workspace @maka/runtime run build` — pass
- `tsc -p tsconfig.main.json --noEmit` (desktop main) + `build:main` — pass
- `node --test packages/runtime/dist/__tests__/skills.test.js` — 31/31 pass
- `node --test` on desktop `managed-skill-sources`, `explore-agent-tool`, `skills`, `bundled-skill-catalog`, `office-document-tool`, `office-documents-capability` tests — 80/80 pass
- `biome lint` on all changed files — no findings

Refs #1084

## Security

Security-relevant path-containment code moved verbatim with no logic change. The two guard variants are documented as non-interchangeable so a future consolidation is a conscious, reviewed decision.