### PR TITLE
refactor(desktop): split registerIpc into per-domain register*Ipc modules

### DIFF
--- a/apps/desktop/src/main/__tests__/bot-settings-ui-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/bot-settings-ui-contract.test.ts
@@ -4,12 +4,14 @@ import { describe, it } from 'node:test';
 import { join } from 'node:path';
 import { readRendererContractCss } from './contract-css-helpers.js';
 import { readSettingsCombinedSource } from './settings-contract-source-helpers.js';
+import { readMainProcessCombinedSource } from './main-process-contract-source-helpers.js';
 
 const repoRoot = process.cwd().endsWith('apps/desktop')
   ? join(process.cwd(), '..', '..')
   : process.cwd();
 
 async function readRepo(path: string): Promise<string> {
+  if (path === 'apps/desktop/src/main/main.ts') return readMainProcessCombinedSource();
   return readFile(join(repoRoot, path), 'utf8');
 }
 

--- a/apps/desktop/src/main/__tests__/compact-routing-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/compact-routing-contract.test.ts
@@ -3,6 +3,7 @@ import { readFile } from 'node:fs/promises';
 import { resolve } from 'node:path';
 import { describe, it } from 'node:test';
 import { readRendererShellSource } from './renderer-shell-source-helpers.js';
+import { readMainProcessCombinedSource } from './main-process-contract-source-helpers.js';
 
 const REPO_ROOT = resolve(import.meta.dirname, '../../../../..');
 
@@ -26,7 +27,7 @@ describe('/compact routing contract', () => {
   });
 
   it('main sessions:compact IPC drives runtime.compactSession via streamEvents', async () => {
-    const main = await readFile(resolve(REPO_ROOT, 'apps/desktop/src/main/main.ts'), 'utf8');
+    const main = await readMainProcessCombinedSource();
     const handler = main.match(/ipcMain\.handle\('sessions:compact'[\s\S]*?\n  \}\);/)?.[0] ?? '';
 
     assert.match(handler, /await ensureSessionCanSend\(sessionId\);/);

--- a/apps/desktop/src/main/__tests__/computer-use-capability.test.ts
+++ b/apps/desktop/src/main/__tests__/computer-use-capability.test.ts
@@ -2,15 +2,13 @@ import assert from 'node:assert/strict';
 import { readFile } from 'node:fs/promises';
 import { resolve } from 'node:path';
 import { describe, it } from 'node:test';
+import { readMainProcessCombinedSource } from './main-process-contract-source-helpers.js';
 
 const ROOT = resolve(process.cwd(), '..', '..');
 
 describe('Desktop Computer Use production wiring', () => {
   it('registers the function harness without presentation or provider adapters', async () => {
-    const main = await readFile(
-      resolve(ROOT, 'apps/desktop/src/main/main.ts'),
-      'utf8',
-    );
+    const main = await readMainProcessCombinedSource();
     assert.match(main, /createComputerUseHost/);
     assert.match(main, /createCursorOverlayController/);
     assert.match(main, /createComputerUseOverlayHook/);
@@ -20,10 +18,7 @@ describe('Desktop Computer Use production wiring', () => {
   });
 
   it('clears Runtime and executor ownership at every turn/session boundary', async () => {
-    const main = await readFile(
-      resolve(ROOT, 'apps/desktop/src/main/main.ts'),
-      'utf8',
-    );
+    const main = await readMainProcessCombinedSource();
     assert.match(main, /sessions:stop[\s\S]*computerUseTools\.clearSession/);
     assert.match(main, /sessions:stop[\s\S]*computerUseOverlay\.clearForSession/);
     assert.match(main, /sessions:archive[\s\S]*computerUseTools\.clearSession/);
@@ -41,7 +36,7 @@ describe('Desktop Computer Use production wiring', () => {
   it('reports scoped approval and live service health instead of binary-only healthy', async () => {
     const [snapshot, main] = await Promise.all([
       readFile(resolve(ROOT, 'apps/desktop/src/main/capability-snapshot.ts'), 'utf8'),
-      readFile(resolve(ROOT, 'apps/desktop/src/main/main.ts'), 'utf8'),
+      readMainProcessCombinedSource(),
     ]);
     const capability = snapshot.match(
       /function computerUseCapability[\s\S]*?(?=function officeDocumentsCapability)/,
@@ -60,7 +55,7 @@ describe('Desktop Computer Use production wiring', () => {
 
   it('does not expose screenshot-returning Computer Use tools to non-visual models', async () => {
     const [main, packageJson] = await Promise.all([
-      readFile(resolve(ROOT, 'apps/desktop/src/main/main.ts'), 'utf8'),
+      readMainProcessCombinedSource(),
       readFile(resolve(ROOT, 'apps/desktop/package.json'), 'utf8'),
     ]);
     assert.match(main, /computerUseToolsForModel\([\s\S]*supportsVision/);
@@ -72,10 +67,7 @@ describe('Desktop Computer Use production wiring', () => {
   });
 
   it('wires a conservative physical-input quiet window', async () => {
-    const main = await readFile(
-      resolve(ROOT, 'apps/desktop/src/main/main.ts'),
-      'utf8',
-    );
+    const main = await readMainProcessCombinedSource();
     assert.match(main, /powerMonitor\.getSystemIdleTime\(\) < 1/);
     assert.match(main, /physicalInputRecentlyActive/);
   });

--- a/apps/desktop/src/main/__tests__/computer-use-host.test.ts
+++ b/apps/desktop/src/main/__tests__/computer-use-host.test.ts
@@ -4,6 +4,7 @@ import { chmod, mkdtemp, readFile, rm, symlink, writeFile } from 'node:fs/promis
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, it } from 'node:test';
+import { readMainProcessCombinedSource } from './main-process-contract-source-helpers.js';
 import {
   createComputerUseHost,
   computerUseServiceHealth,
@@ -148,7 +149,7 @@ describe('Computer Use host health', () => {
 
   it('wires a one-second physical-input quiet window', async () => {
     const source = await import('node:fs/promises').then(({ readFile }) =>
-      readFile(join(process.cwd(), 'src/main/main.ts'), 'utf8'));
+      readMainProcessCombinedSource());
     assert.match(source, /physicalInputRecentlyActive/);
     assert.match(source, /powerMonitor\.getSystemIdleTime\(\) < 1/);
   });

--- a/apps/desktop/src/main/__tests__/credential-store-secret-kinds-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/credential-store-secret-kinds-contract.test.ts
@@ -3,12 +3,14 @@ import { readFile } from 'node:fs/promises';
 import { join, resolve } from 'node:path';
 import { describe, it } from 'node:test';
 import type { CredentialKind, CredentialStore } from '../credential-store.js';
+import { readMainProcessCombinedSource } from './main-process-contract-source-helpers.js';
 
 const repoRoot = process.cwd().endsWith(join('apps', 'desktop'))
   ? resolve(process.cwd(), '..', '..')
   : process.cwd();
 
 async function readRepo(relativePath: string): Promise<string> {
+  if (relativePath === 'apps/desktop/src/main/main.ts') return readMainProcessCombinedSource();
   return readFile(join(repoRoot, relativePath), 'utf8');
 }
 

--- a/apps/desktop/src/main/__tests__/default-permission-mode-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/default-permission-mode-contract.test.ts
@@ -22,7 +22,7 @@ import { strict as assert } from 'node:assert';
 import { describe, it } from 'node:test';
 import { readRendererShellSources } from './renderer-shell-source-helpers.js';
 import { readSettingsCombinedSource } from './settings-contract-source-helpers.js';
-import { readMainTsSource } from './main-process-contract-source-helpers.js';
+import { readMainProcessCombinedSource, readMainTsSource } from './main-process-contract-source-helpers.js';
 
 describe('default permission mode contract', () => {
   it('renderer always omits permissionMode when creating sessions', async () => {
@@ -63,10 +63,13 @@ describe('default permission mode contract', () => {
       'the resolver must live in ./permission-mode-default.ts, not inline in main.ts (so its never-rejects fallback is unit-testable)',
     );
 
-    // Both sessions:create branches (fake + ai-sdk) + quick chat must inject
-    // settingsStore.get into the resolver — proving they route through the
-    // single authority instead of reading settings inline.
-    const routedCalls = src.match(/resolveDefaultPermissionMode\(\(\) => settingsStore\.get\(\)\)/g) ?? [];
+    // Both sessions:create branches (fake + ai-sdk) live in sessions-ipc-main.ts
+    // and quick chat stays in main.ts — but all must inject settingsStore.get
+    // into the resolver, proving they route through the single authority
+    // instead of reading settings inline. Count across the combined main-process
+    // source so the split does not weaken the invariant.
+    const combined = await readMainProcessCombinedSource();
+    const routedCalls = combined.match(/resolveDefaultPermissionMode\(\(\) => settingsStore\.get\(\)\)/g) ?? [];
     assert.ok(
       routedCalls.length >= 3, // fake branch + ai-sdk branch + quick chat
       `all session-creation fallbacks must route through resolveDefaultPermissionMode(() => settingsStore.get()) (found ${routedCalls.length}, expected >= 3)`,

--- a/apps/desktop/src/main/__tests__/main-process-contract-source-helpers.ts
+++ b/apps/desktop/src/main/__tests__/main-process-contract-source-helpers.ts
@@ -6,6 +6,7 @@ const REPO_ROOT = resolve(import.meta.dirname, '../../../../..');
 
 export const MAIN_PROCESS_SOURCE_REPO_PATHS: readonly string[] = [
   'apps/desktop/src/main/main.ts',
+  'apps/desktop/src/main/app-ipc-main.ts',
   'apps/desktop/src/main/bot-incoming-main.ts',
   'apps/desktop/src/main/browser-ipc-main.ts',
   'apps/desktop/src/main/config-ipc-main.ts',
@@ -13,19 +14,29 @@ export const MAIN_PROCESS_SOURCE_REPO_PATHS: readonly string[] = [
   'apps/desktop/src/main/connections-ipc-main.ts',
   'apps/desktop/src/main/daily-review-ipc-main.ts',
   'apps/desktop/src/main/daily-review-main.ts',
+  'apps/desktop/src/main/gateway-ipc-main.ts',
+  'apps/desktop/src/main/git-ipc-main.ts',
   'apps/desktop/src/main/main-window.ts',
   'apps/desktop/src/main/memory-ipc-main.ts',
   'apps/desktop/src/main/notifications-ipc-main.ts',
   'apps/desktop/src/main/oauth-model-connections-main.ts',
+  'apps/desktop/src/main/onboarding-ipc-main.ts',
   'apps/desktop/src/main/permission-mode-default.ts',
+  'apps/desktop/src/main/permissions-ipc-main.ts',
   'apps/desktop/src/main/plan-reminders-ipc-main.ts',
   'apps/desktop/src/main/plan-reminders-main.ts',
+  'apps/desktop/src/main/project-root-controller.ts',
+  'apps/desktop/src/main/session-entry-ipc-main.ts',
+  'apps/desktop/src/main/sessions-ipc-main.ts',
+  'apps/desktop/src/main/settings-ipc-main.ts',
   'apps/desktop/src/main/subscription-model-fetch.ts',
   'apps/desktop/src/main/subscription-ipc-main.ts',
   'apps/desktop/src/main/system-prompt-main.ts',
   'apps/desktop/src/main/usage-ipc-main.ts',
   'apps/desktop/src/main/web-search-ipc-main.ts',
+  'apps/desktop/src/main/workspace-instructions-ipc-main.ts',
   'apps/desktop/src/main/workspace-resources-ipc-main.ts',
+  'apps/desktop/src/main/workspace-search-ipc-main.ts',
 ];
 
 export async function readMainProcessCombinedSource(): Promise<string> {

--- a/apps/desktop/src/main/__tests__/main-process-wiring-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/main-process-wiring-contract.test.ts
@@ -14,11 +14,23 @@ const extractedIpcRegistrars = [
   ['registerSubscriptionIpc', './subscription-ipc-main'],
   ['registerBrowserIpc', './browser-ipc-main'],
   ['registerConnectionsIpc', './connections-ipc-main'],
+  ['registerConfigIpc', './config-ipc-main'],
+  ['registerNotificationsIpc', './notifications-ipc-main'],
   ['registerPlanReminderIpc', './plan-reminders-ipc-main'],
   ['registerWorkspaceResourcesIpc', './workspace-resources-ipc-main'],
   ['registerDailyReviewIpc', './daily-review-ipc-main'],
   ['registerUsageIpc', './usage-ipc-main'],
   ['registerWebSearchIpc', './web-search-ipc-main'],
+  ['registerAppIpc', './app-ipc-main'],
+  ['registerGitIpc', './git-ipc-main'],
+  ['registerWorkspaceSearchIpc', './workspace-search-ipc-main'],
+  ['registerWorkspaceInstructionsIpc', './workspace-instructions-ipc-main'],
+  ['registerOnboardingIpc', './onboarding-ipc-main'],
+  ['registerSessionEntryIpc', './session-entry-ipc-main'],
+  ['registerSessionsIpc', './sessions-ipc-main'],
+  ['registerPermissionsIpc', './permissions-ipc-main'],
+  ['registerSettingsIpc', './settings-ipc-main'],
+  ['registerGatewayIpc', './gateway-ipc-main'],
 ] as const;
 
 function escapeRegExp(value: string): string {

--- a/apps/desktop/src/main/__tests__/office-documents-capability.test.ts
+++ b/apps/desktop/src/main/__tests__/office-documents-capability.test.ts
@@ -4,6 +4,7 @@ import { describe, it } from 'node:test';
 import { join, resolve } from 'node:path';
 import { readAllRendererCss } from './css-test-helpers.js';
 import { readSettingsCombinedSource } from './settings-contract-source-helpers.js';
+import { readMainProcessCombinedSource } from './main-process-contract-source-helpers.js';
 
 const REPO_ROOT = resolve(process.cwd(), '..', '..');
 const CAPABILITY_SNAPSHOT = join(REPO_ROOT, 'apps', 'desktop', 'src', 'main', 'capability-snapshot.ts');
@@ -24,7 +25,7 @@ describe('Office document capability contract', () => {
   it('surfaces Office 文档 as a capability backed by officecli probe', async () => {
     const [snapshot, main] = await Promise.all([
       readFile(CAPABILITY_SNAPSHOT, 'utf8'),
-      readFile(MAIN, 'utf8'),
+      readMainProcessCombinedSource(),
     ]);
 
     assert.match(snapshot, /officeDocumentsCapability\(input\.officeCliProbe, now\)/);

--- a/apps/desktop/src/main/__tests__/permission-response-ipc-boundary.test.ts
+++ b/apps/desktop/src/main/__tests__/permission-response-ipc-boundary.test.ts
@@ -7,6 +7,7 @@ import {
   readRendererShellSource,
   readRendererShellSources,
 } from './renderer-shell-source-helpers.js';
+import { readMainProcessCombinedSource } from './main-process-contract-source-helpers.js';
 
 import {
   normalizeBranchFromTurnInput,
@@ -31,7 +32,7 @@ describe('permission response IPC boundary', () => {
 
   it('registers AskUserQuestion only on the Desktop root tool surface and routes its response', async () => {
     const mainPath = fileURLToPath(new URL('../../../src/main/main.ts', import.meta.url));
-    const main = await readFile(mainPath, 'utf8');
+    const main = await readMainProcessCombinedSource();
     const rootTools = main.match(/const builtinTools: MakaTool\[\] = \[[\s\S]*?\n\];/)?.[0] ?? '';
     const childTools = main.match(/const childAgentTools = buildChildAgentTools\([\s\S]*?\n\]\);/)?.[0] ?? '';
     const handler = main.match(/ipcMain\.handle\('sessions:respondToUserQuestion'[\s\S]*?\n  \);/)?.[0] ?? '';
@@ -85,7 +86,7 @@ describe('permission response IPC boundary', () => {
 
   it('routes sessions:respondToPermission through the main-process normalizer', async () => {
     const mainPath = fileURLToPath(new URL('../../../src/main/main.ts', import.meta.url));
-    const main = await readFile(mainPath, 'utf8');
+    const main = await readMainProcessCombinedSource();
     const handler = main.match(/ipcMain\.handle\('sessions:respondToPermission'[\s\S]*?\n  \);/)?.[0] ?? '';
 
     assert.match(handler, /normalizePermissionResponse\(response\)/);
@@ -110,7 +111,7 @@ describe('permission response IPC boundary', () => {
 
   it('routes turn actions through main-process normalizers', async () => {
     const mainPath = fileURLToPath(new URL('../../../src/main/main.ts', import.meta.url));
-    const main = await readFile(mainPath, 'utf8');
+    const main = await readMainProcessCombinedSource();
     const regenerateHandler = main.match(/ipcMain\.handle\('sessions:regenerateTurn'[\s\S]*?\n  \);/)?.[0] ?? '';
     const branchHandler = main.match(/ipcMain\.handle\('sessions:branchFromTurn'[\s\S]*?\n  \);/)?.[0] ?? '';
 
@@ -155,7 +156,7 @@ describe('permission response IPC boundary', () => {
 
   it('routes send and stop IPC payloads through main-process normalizers', async () => {
     const mainPath = fileURLToPath(new URL('../../../src/main/main.ts', import.meta.url));
-    const main = await readFile(mainPath, 'utf8');
+    const main = await readMainProcessCombinedSource();
     const stopHandler = main.match(/ipcMain\.handle\('sessions:stop'[\s\S]*?\n  \);/)?.[0] ?? '';
     const sendHandler = main.match(/ipcMain\.handle\('sessions:send'[\s\S]*?\n  \);/)?.[0] ?? '';
 
@@ -310,7 +311,7 @@ describe('permission response IPC boundary', () => {
 
   it('broadcasts the final message-appended refresh only after the runtime iterator drains', async () => {
     const mainPath = fileURLToPath(new URL('../../../src/main/main.ts', import.meta.url));
-    const main = await readFile(mainPath, 'utf8');
+    const main = await readMainProcessCombinedSource();
     const streamEvents = main.match(/async function streamEvents\([\s\S]*?\n\}/)?.[0] ?? '';
     const collectBotReply = main.match(/async function collectBotReply\([\s\S]*?\n\}/)?.[0] ?? '';
 

--- a/apps/desktop/src/main/__tests__/project-context-badge.test.ts
+++ b/apps/desktop/src/main/__tests__/project-context-badge.test.ts
@@ -5,7 +5,6 @@ import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { resolveProjectGitInfo, resolveProjectRoot } from '@maka/runtime';
 import { readRendererContractCss } from './contract-css-helpers.js';
-import { readMainProcessCombinedSource } from './main-process-contract-source-helpers.js';
 import { readRendererShellCombinedSource } from './renderer-shell-source-helpers.js';
 
 const repoRoot = process.cwd().endsWith('apps/desktop')
@@ -13,9 +12,19 @@ const repoRoot = process.cwd().endsWith('apps/desktop')
   : process.cwd();
 
 async function readRepo(path: string): Promise<string> {
-  if (path === 'apps/desktop/src/main/main.ts') return readMainProcessCombinedSource();
   return readFile(join(repoRoot, path), 'utf8');
 }
+
+// Main-process sources are read per owning file (not the combined blob), so
+// each assertion locks the file that actually implements the behavior — a
+// regression in one module can neither hide behind matching text in another
+// nor be masked by the shared project-root controller's internals.
+const MAIN = 'apps/desktop/src/main/main.ts';
+const APP_IPC = 'apps/desktop/src/main/app-ipc-main.ts';
+const CONTROLLER = 'apps/desktop/src/main/project-root-controller.ts';
+const SESSIONS_IPC = 'apps/desktop/src/main/sessions-ipc-main.ts';
+const WORKSPACE_INSTRUCTIONS_IPC = 'apps/desktop/src/main/workspace-instructions-ipc-main.ts';
+const MAIN_WINDOW = 'apps/desktop/src/main/main-window.ts';
 
 describe('project context workspace picker', () => {
   it('resolves git branch from normal and worktree-style .git metadata', async () => {
@@ -55,14 +64,16 @@ describe('project context workspace picker', () => {
   });
 
   it('exposes the main-owned project path through app info', async () => {
-    const main = await readRepo('apps/desktop/src/main/main.ts');
+    const main = await readRepo(MAIN);
+    const appIpc = await readRepo(APP_IPC);
+    const controller = await readRepo(CONTROLLER);
     const preload = await readRepo('apps/desktop/src/preload/preload.ts');
     const globalTypes = await readRepo('apps/desktop/src/global.d.ts');
 
     assert.match(main, /fallbackRoots: \(\) => \[process\.cwd\(\), app\.getAppPath\(\)\]/);
-    assert.match(main, /projectGit:\s*await resolveProjectGitInfo\(projectPath\)/);
+    assert.match(appIpc, /projectGit:\s*await resolveProjectGitInfo\(projectPath\)/);
     assert.match(main, /function registerIpc\(\): void/);
-    assert.match(main, /const persistedProjectRootPromise = loadPersistedProjectRoot\(\)/);
+    assert.match(controller, /const persistedProjectRootPromise = loadPersistedProjectRoot\(\)/);
     assert.doesNotMatch(main, /async function registerIpc\(\): Promise<void>/);
     assert.doesNotMatch(main, /void registerIpc\(\);/);
     assert.match(preload, /projectPath:\s*string;/);
@@ -72,35 +83,57 @@ describe('project context workspace picker', () => {
   });
 
   it('lets the composer picker choose a new project directory instead of only opening Finder', async () => {
-    const main = await readRepo('apps/desktop/src/main/main.ts');
+    const appIpc = await readRepo(APP_IPC);
+    const controller = await readRepo(CONTROLLER);
+    const mainWindow = await readRepo(MAIN_WINDOW);
     const preload = await readRepo('apps/desktop/src/preload/preload.ts');
     const globalTypes = await readRepo('apps/desktop/src/global.d.ts');
     const renderer = await readRendererShellCombinedSource();
     const workspacePickerBlock = renderer.match(/workspacePicker=\{\{[\s\S]*?\n\s*\}\}/)?.[0] ?? '';
 
-    assert.match(main, /let selectedProjectRoot: string \| null = null;/);
-    assert.match(main, /if \(selectedProjectRoot\) return selectedProjectRoot;/);
-    assert.match(main, /async function resolveExplicit\(projectPath: unknown\): Promise</);
-    assert.match(main, /ipcMain\.handle\(\s*'app:selectProjectDirectory'/);
-    assert.match(main, /mainWindowController\.showOpenDialog\(\{[\s\S]*title:\s*'选择工作目录'[\s\S]*properties:\s*\['openDirectory'\]/);
-    assert.match(main, /dialog\.showOpenDialog\(mainWindow,\s*options\)/);
-    assert.match(main, /const projectPath = await resolveProjectRoot\(\[selectedPath\]\)/);
-    assert.match(main, /selectedProjectRoot = projectPath;/);
-    assert.match(main, /projectGit:\s*await resolveProjectGitInfo\(projectPath\)/);
+    assert.match(controller, /let selectedProjectRoot: string \| null = null;/);
+    assert.match(controller, /if \(selectedProjectRoot\) return selectedProjectRoot;/);
+    assert.match(controller, /async function resolveExplicit\(projectPath: unknown\): Promise</);
+    assert.match(appIpc, /ipcMain\.handle\(\s*'app:selectProjectDirectory'/);
+    assert.match(appIpc, /mainWindowController\.showOpenDialog\(\{[\s\S]*?title:\s*'选择工作目录'[\s\S]*?properties:\s*\['openDirectory'\]/);
+    assert.match(mainWindow, /dialog\.showOpenDialog\(mainWindow,\s*options\)/);
+    assert.match(appIpc, /const projectPath = await resolveProjectRoot\(\[selectedPath\]\)/);
+    // Both picker handlers must adopt the chosen root through the shared
+    // controller — the only writer of the selection state. Extract each
+    // handler so a dropped setSelected call cannot pass on the other
+    // handler's (or the controller's internal) matching text.
+    const selectDirectoryHandler = appIpc.match(/'app:selectProjectDirectory'[\s\S]*?\n  \);/)?.[0] ?? '';
+    const selectRootHandler = appIpc.match(/'app:selectProjectRoot'[\s\S]*?\n  \);/)?.[0] ?? '';
     assert.match(
-      main,
-      /'app:resolveProjectGitInfo'[\s\S]*const explicitRoot = await resolveExplicitProjectRoot\(projectPath\);[\s\S]*if \(!explicitRoot\.ok\) return explicitRoot;/,
+      selectDirectoryHandler,
+      /projectRoot\.setSelected\(projectPath\);/,
+      'the directory picker must adopt the chosen root through the shared project-root controller',
+    );
+    assert.match(
+      selectRootHandler,
+      /projectRoot\.setSelected\(resolved\);/,
+      'the explicit project-root selection must adopt the validated root through the shared project-root controller',
+    );
+    assert.match(
+      controller,
+      /function setSelected\(projectPath: string\): void \{\s*selectedProjectRoot = projectPath;\s*void saveLastProjectPath\(projectPath\);/,
+      'the controller must both select and persist an adopted project root',
+    );
+    assert.match(appIpc, /projectGit:\s*await resolveProjectGitInfo\(projectPath\)/);
+    assert.match(
+      appIpc,
+      /'app:resolveProjectGitInfo'[\s\S]*?const explicitRoot = await projectRoot\.resolveExplicit\(projectPath\);[\s\S]*?if \(!explicitRoot\.ok\) return explicitRoot;/,
       'explicit project git lookups must validate the supplied path instead of falling back to process.cwd()',
     );
     assert.match(
-      main,
-      /async function loadPersistedProjectRoot\(\): Promise<string \| null> \{[\s\S]*await stat\(parsed\.projectPath\)[\s\S]*return await resolveProjectRoot\(\[parsed\.projectPath\]\)/,
-      'restored last-project-path must be validated before it becomes currentProjectRoot',
+      controller,
+      /async function loadPersistedProjectRoot\(\): Promise<string \| null> \{[\s\S]*?await stat\(parsed\.projectPath\)[\s\S]*?return await resolveProjectRoot\(\[parsed\.projectPath\]\)/,
+      'restored last-project-path must be validated before it becomes the current project root',
     );
     assert.match(
-      main,
-      /if \(selectedProjectRoot\) return selectedProjectRoot;[\s\S]*const persistedProjectRoot = await persistedProjectRootPromise;[\s\S]*if \(persistedProjectRoot\) \{[\s\S]*selectedProjectRoot = persistedProjectRoot;[\s\S]*return persistedProjectRoot;/,
-      'currentProjectRoot must await the validated persisted project before falling back',
+      controller,
+      /if \(selectedProjectRoot\) return selectedProjectRoot;[\s\S]*?const persistedProjectRoot = await persistedProjectRootPromise;[\s\S]*?if \(persistedProjectRoot\) \{[\s\S]*?selectedProjectRoot = persistedProjectRoot;[\s\S]*?return persistedProjectRoot;/,
+      'the current project root must await the validated persisted project before falling back',
     );
     assert.match(preload, /selectProjectDirectory\(\): Promise</);
     assert.match(preload, /ipcRenderer\.invoke\('app:selectProjectDirectory'\)/);
@@ -139,32 +172,36 @@ describe('project context workspace picker', () => {
   });
 
   it('defaults new sessions to the main-owned current project root', async () => {
-    const main = await readRepo('apps/desktop/src/main/main.ts');
+    const main = await readRepo(MAIN);
+    const sessionsIpc = await readRepo(SESSIONS_IPC);
     const chatActions = await readRepo('apps/desktop/src/renderer/app-shell-chat-actions.ts');
 
-    assert.match(main, /const cwd = input\?\.cwd \?\? \(await currentProjectRoot\(\)\)/);
+    assert.match(sessionsIpc, /const cwd = input\?\.cwd \?\? \(await currentProjectRoot\(\)\)/);
     assert.match(main, /handleQuickChatStart\(input, currentProjectRoot\)/);
     assert.match(main, /cwd:\s*await getCurrentProjectRoot\(\)/);
-    assert.doesNotMatch(main, /const cwd = input\?\.cwd \?\? process\.cwd\(\)/);
+    assert.doesNotMatch(sessionsIpc, /const cwd = input\?\.cwd \?\? process\.cwd\(\)/);
+    assert.doesNotMatch(sessionsIpc, /cwd:\s*process\.cwd\(\)/);
     assert.doesNotMatch(main, /cwd:\s*process\.cwd\(\)/);
     assert.doesNotMatch(chatActions, /\.\.\.\(projectPath \? \{ cwd: projectPath \} : \{\}\)/);
   });
 
   it('resolves workspace instruction files under the selected project root', async () => {
-    const main = await readRepo('apps/desktop/src/main/main.ts');
+    const main = await readRepo(MAIN);
+    const wsIpc = await readRepo(WORKSPACE_INSTRUCTIONS_IPC);
 
-    assert.match(main, /ipcMain\.handle\('workspaceInstructions:getState', async \(\) => getWorkspaceInstructionsState\(await currentProjectRoot\(\)\)\)/);
-    assert.match(main, /resolveWorkspaceInstructionFileForOpen\(await currentProjectRoot\(\), typeof file === 'string' \? file : ''\)/);
-    assert.match(main, /createWorkspaceInstructionFile\(await currentProjectRoot\(\), typeof file === 'string' \? file : ''\)/);
-    assert.doesNotMatch(main, /workspaceInstructions:getState', \(\) => getWorkspaceInstructionsState\(process\.cwd\(\)\)/);
+    assert.match(main, /registerWorkspaceInstructionsIpc\(\{ getCurrentProjectRoot: currentProjectRoot \}\)/);
+    assert.match(wsIpc, /ipcMain\.handle\('workspaceInstructions:getState', async \(\) => getWorkspaceInstructionsState\(await currentProjectRoot\(\)\)\)/);
+    assert.match(wsIpc, /resolveWorkspaceInstructionFileForOpen\(await currentProjectRoot\(\), typeof file === 'string' \? file : ''\)/);
+    assert.match(wsIpc, /createWorkspaceInstructionFile\(await currentProjectRoot\(\), typeof file === 'string' \? file : ''\)/);
+    assert.doesNotMatch(wsIpc, /getWorkspaceInstructionsState\(process\.cwd\(\)\)/);
   });
 
   it('opens project directory by allowlisted key, not renderer-supplied path', async () => {
-    const main = await readRepo('apps/desktop/src/main/main.ts');
+    const appIpc = await readRepo(APP_IPC);
     const guard = await readRepo('apps/desktop/src/main/open-path-guard.ts');
     const renderer = await readRendererShellCombinedSource();
 
-    assert.match(main, /resolveOpenPath\(\{ key, workspaceRoot, projectRoot:\s*await currentProjectRoot\(\) \}\)/);
+    assert.match(appIpc, /resolveOpenPath\(\{ key, workspaceRoot, projectRoot:\s*await currentProjectRoot\(\) \}\)/);
     assert.match(guard, /value === 'project'/);
     assert.match(renderer, /window\.maka\.app\.openPath\('project'\)/);
     assert.doesNotMatch(renderer, /openPath\(appInfo\.projectPath\)/);

--- a/apps/desktop/src/main/__tests__/project-context-badge.test.ts
+++ b/apps/desktop/src/main/__tests__/project-context-badge.test.ts
@@ -59,7 +59,7 @@ describe('project context workspace picker', () => {
     const preload = await readRepo('apps/desktop/src/preload/preload.ts');
     const globalTypes = await readRepo('apps/desktop/src/global.d.ts');
 
-    assert.match(main, /resolveProjectRoot\(\[process\.cwd\(\), app\.getAppPath\(\)\]\)/);
+    assert.match(main, /fallbackRoots: \(\) => \[process\.cwd\(\), app\.getAppPath\(\)\]/);
     assert.match(main, /projectGit:\s*await resolveProjectGitInfo\(projectPath\)/);
     assert.match(main, /function registerIpc\(\): void/);
     assert.match(main, /const persistedProjectRootPromise = loadPersistedProjectRoot\(\)/);
@@ -80,7 +80,7 @@ describe('project context workspace picker', () => {
 
     assert.match(main, /let selectedProjectRoot: string \| null = null;/);
     assert.match(main, /if \(selectedProjectRoot\) return selectedProjectRoot;/);
-    assert.match(main, /async function resolveExplicitProjectRoot\(projectPath: unknown\): Promise</);
+    assert.match(main, /async function resolveExplicit\(projectPath: unknown\): Promise</);
     assert.match(main, /ipcMain\.handle\(\s*'app:selectProjectDirectory'/);
     assert.match(main, /mainWindowController\.showOpenDialog\(\{[\s\S]*title:\s*'选择工作目录'[\s\S]*properties:\s*\['openDirectory'\]/);
     assert.match(main, /dialog\.showOpenDialog\(mainWindow,\s*options\)/);

--- a/apps/desktop/src/main/__tests__/project-root-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/project-root-controller.test.ts
@@ -1,0 +1,165 @@
+import assert from 'node:assert/strict';
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, it } from 'node:test';
+import { createProjectRootController } from '../project-root-controller.js';
+
+/**
+ * Behavioral coverage for the shared project-root selection authority
+ * (issue #1084 review follow-up): selected > persisted > fallback
+ * precedence, explicit-path validation, and persistence on adoption.
+ * The IPC modules only forward to this controller, so these unit tests
+ * lock the state machine without needing an Electron ipcMain.
+ */
+
+interface Fixture {
+  base: string;
+  lastProjectPathFile: string;
+  fallbackDir: string;
+  persistedDir: string;
+  selectedDir: string;
+}
+
+async function withFixture(fn: (fixture: Fixture) => Promise<void>): Promise<void> {
+  const base = await mkdtemp(join(tmpdir(), 'maka-project-root-controller-'));
+  try {
+    const fixture: Fixture = {
+      base,
+      lastProjectPathFile: join(base, 'last-project-path.json'),
+      fallbackDir: join(base, 'fallback'),
+      persistedDir: join(base, 'persisted'),
+      selectedDir: join(base, 'selected'),
+    };
+    await mkdir(fixture.fallbackDir, { recursive: true });
+    await mkdir(fixture.persistedDir, { recursive: true });
+    await mkdir(fixture.selectedDir, { recursive: true });
+    await fn(fixture);
+  } finally {
+    await rm(base, { recursive: true, force: true });
+  }
+}
+
+async function waitForPersistedPath(file: string, expected: string): Promise<void> {
+  for (let attempt = 0; attempt < 100; attempt++) {
+    try {
+      const parsed = JSON.parse(await readFile(file, 'utf8')) as { projectPath?: string };
+      if (parsed.projectPath === expected) return;
+    } catch {
+      // Not written yet (setSelected persists fire-and-forget).
+    }
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  assert.fail(`setSelected must persist ${expected} to ${file}`);
+}
+
+describe('project-root controller', () => {
+  it('falls back to the first resolvable fallback root when nothing is selected or persisted', async () => {
+    await withFixture(async (fixture) => {
+      const controller = createProjectRootController({
+        lastProjectPathFile: fixture.lastProjectPathFile,
+        fallbackRoots: () => [fixture.fallbackDir],
+      });
+      assert.equal(await controller.current(), fixture.fallbackDir);
+    });
+  });
+
+  it('prefers a validated persisted project over the fallback roots', async () => {
+    await withFixture(async (fixture) => {
+      await writeFile(
+        fixture.lastProjectPathFile,
+        JSON.stringify({ projectPath: fixture.persistedDir }),
+        'utf8',
+      );
+      const controller = createProjectRootController({
+        lastProjectPathFile: fixture.lastProjectPathFile,
+        fallbackRoots: () => [fixture.fallbackDir],
+      });
+      assert.equal(await controller.current(), fixture.persistedDir);
+    });
+  });
+
+  it('ignores a persisted project that no longer exists and falls back', async () => {
+    await withFixture(async (fixture) => {
+      await writeFile(
+        fixture.lastProjectPathFile,
+        JSON.stringify({ projectPath: join(fixture.base, 'deleted') }),
+        'utf8',
+      );
+      const controller = createProjectRootController({
+        lastProjectPathFile: fixture.lastProjectPathFile,
+        fallbackRoots: () => [fixture.fallbackDir],
+      });
+      assert.equal(await controller.current(), fixture.fallbackDir);
+    });
+  });
+
+  it('prefers the in-session selection over both persisted and fallback roots', async () => {
+    await withFixture(async (fixture) => {
+      await writeFile(
+        fixture.lastProjectPathFile,
+        JSON.stringify({ projectPath: fixture.persistedDir }),
+        'utf8',
+      );
+      const controller = createProjectRootController({
+        lastProjectPathFile: fixture.lastProjectPathFile,
+        fallbackRoots: () => [fixture.fallbackDir],
+      });
+      controller.setSelected(fixture.selectedDir);
+      assert.equal(await controller.current(), fixture.selectedDir);
+    });
+  });
+
+  it('persists an adopted selection so a fresh controller restores it', async () => {
+    await withFixture(async (fixture) => {
+      const controller = createProjectRootController({
+        lastProjectPathFile: fixture.lastProjectPathFile,
+        fallbackRoots: () => [fixture.fallbackDir],
+      });
+      controller.setSelected(fixture.selectedDir);
+      await waitForPersistedPath(fixture.lastProjectPathFile, fixture.selectedDir);
+
+      const restored = createProjectRootController({
+        lastProjectPathFile: fixture.lastProjectPathFile,
+        fallbackRoots: () => [fixture.fallbackDir],
+      });
+      assert.equal(await restored.current(), fixture.selectedDir);
+    });
+  });
+
+  it('validates explicit paths: rejects non-strings and missing directories, resolves real ones', async () => {
+    await withFixture(async (fixture) => {
+      const controller = createProjectRootController({
+        lastProjectPathFile: fixture.lastProjectPathFile,
+        fallbackRoots: () => [fixture.fallbackDir],
+      });
+
+      assert.deepEqual(await controller.resolveExplicit(undefined), { ok: false, reason: 'invalid-path' });
+      assert.deepEqual(await controller.resolveExplicit(''), { ok: false, reason: 'invalid-path' });
+      assert.deepEqual(await controller.resolveExplicit(42), { ok: false, reason: 'invalid-path' });
+      assert.deepEqual(
+        await controller.resolveExplicit(join(fixture.base, 'missing')),
+        { ok: false, reason: 'not-found' },
+      );
+      assert.deepEqual(
+        await controller.resolveExplicit(fixture.selectedDir),
+        { ok: true, projectPath: fixture.selectedDir },
+      );
+
+      // A nested path inside a git repo resolves to the repo root, matching
+      // the project-root walk the picker handlers rely on.
+      const repoRoot = join(fixture.base, 'repo');
+      const nested = join(repoRoot, 'apps', 'desktop');
+      await mkdir(join(repoRoot, '.git'), { recursive: true });
+      await writeFile(join(repoRoot, '.git', 'HEAD'), 'ref: refs/heads/main\n', 'utf8');
+      await mkdir(nested, { recursive: true });
+      assert.deepEqual(
+        await controller.resolveExplicit(nested),
+        { ok: true, projectPath: repoRoot },
+      );
+
+      // Validation must not adopt: the current root is untouched.
+      assert.equal(await controller.current(), fixture.fallbackDir);
+    });
+  });
+});

--- a/apps/desktop/src/main/__tests__/session-open-routing-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/session-open-routing-contract.test.ts
@@ -3,6 +3,7 @@ import { readFile } from 'node:fs/promises';
 import { resolve } from 'node:path';
 import { describe, it } from 'node:test';
 import { readRendererShellSource, readRendererShellSources } from './renderer-shell-source-helpers.js';
+import { readMainProcessCombinedSource } from './main-process-contract-source-helpers.js';
 
 const REPO_ROOT = resolve(import.meta.dirname, '../../../../..');
 
@@ -96,7 +97,7 @@ describe('session open routing contract', () => {
   });
 
   it('keeps persisted mark-read at the renderer message-read IPC boundary', async () => {
-    const main = await readFile(resolve(REPO_ROOT, 'apps/desktop/src/main/main.ts'), 'utf8');
+    const main = await readMainProcessCombinedSource();
     const readMessagesHandler = main.match(/ipcMain\.handle\('sessions:readMessages'[\s\S]*?\n  \}\);/)?.[0] ?? '';
     const searchHandler = main.match(/ipcMain\.handle\('search:thread'[\s\S]*?\n  \}\);/)?.[0] ?? '';
     const gatewayDeps = main.match(/const openGateway = new OpenGatewayService\(\{[\s\S]*?\n\}\);/)?.[0] ?? '';

--- a/apps/desktop/src/main/__tests__/session-sticky-model-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/session-sticky-model-contract.test.ts
@@ -5,6 +5,7 @@ import { readProviderSettingsCombinedSource } from './provider-contract-source-h
 import { describe, it } from 'node:test';
 import { readRendererContractCss } from './contract-css-helpers.js';
 import { readRendererShellCombinedSource } from './renderer-shell-source-helpers.js';
+import { readMainProcessCombinedSource } from './main-process-contract-source-helpers.js';
 
 const REPO_ROOT = resolve(import.meta.dirname, '../../../../..');
 
@@ -24,7 +25,7 @@ async function readModelSwitcherUiSource(): Promise<string> {
 
 describe('PR-SESSION-STICKY-MODEL-0 contract', () => {
   it('captures the ready model when creating a desktop session', async () => {
-    const main = await readFile(resolve(REPO_ROOT, 'apps/desktop/src/main/main.ts'), 'utf8');
+    const main = await readMainProcessCombinedSource();
 
     assert.match(main, /const requestedSlug = input\?\.llmConnectionSlug \?\? \(await connectionStore\.getDefault\(\)\)/);
     assert.match(main, /const \{ connection, model \} = await getReadyConnection\(requestedSlug, input\?\.model\)/);
@@ -35,7 +36,7 @@ describe('PR-SESSION-STICKY-MODEL-0 contract', () => {
     const readiness = await readFile(resolve(REPO_ROOT, 'apps/desktop/src/main/chat-readiness.ts'), 'utf8');
     const coreReadiness = await readFile(resolve(REPO_ROOT, 'packages/core/src/connection-readiness.ts'), 'utf8');
     const projection = await readFile(resolve(REPO_ROOT, 'packages/core/src/session-send-projection.ts'), 'utf8');
-    const main = await readFile(resolve(REPO_ROOT, 'apps/desktop/src/main/main.ts'), 'utf8');
+    const main = await readMainProcessCombinedSource();
 
     assert.match(readiness, /assertSessionCanSend\([\s\S]*header: Pick<SessionHeader, 'backend' \| 'llmConnectionSlug' \| 'model'>/);
     assert.match(readiness, /requireReadyConnection\(header\.llmConnectionSlug, deps, header\.model\)/);
@@ -76,7 +77,7 @@ describe('PR-SESSION-STICKY-MODEL-0 contract', () => {
   });
 
   it('lets the user explicitly switch the current session model from the chat header', async () => {
-    const main = await readFile(resolve(REPO_ROOT, 'apps/desktop/src/main/main.ts'), 'utf8');
+    const main = await readMainProcessCombinedSource();
     const preload = await readFile(resolve(REPO_ROOT, 'apps/desktop/src/preload/preload.ts'), 'utf8');
     const globalTypes = await readFile(resolve(REPO_ROOT, 'apps/desktop/src/global.d.ts'), 'utf8');
     const renderer = await readRendererShellCombinedSource();

--- a/apps/desktop/src/main/__tests__/session-thinking-level-main-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/session-thinking-level-main-contract.test.ts
@@ -2,11 +2,12 @@ import { strict as assert } from 'node:assert';
 import { readFile } from 'node:fs/promises';
 import { resolve } from 'node:path';
 import { describe, it } from 'node:test';
+import { readMainProcessCombinedSource } from './main-process-contract-source-helpers.js';
 
 const REPO_ROOT = resolve(import.meta.dirname, '../../../../..');
 
 async function readMainSource(): Promise<string> {
-  return readFile(resolve(REPO_ROOT, 'apps/desktop/src/main/main.ts'), 'utf8');
+  return readMainProcessCombinedSource();
 }
 
 function extractIpcHandler(source: string, channel: string): string {

--- a/apps/desktop/src/main/__tests__/settings-network-gateway-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/settings-network-gateway-contract.test.ts
@@ -3,12 +3,10 @@ import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { describe, it } from 'node:test';
 import { readSettingsCombinedSourceSync } from './settings-contract-source-helpers.js';
+import { readMainProcessCombinedSourceSync } from './main-process-contract-source-helpers.js';
 
 const settingsSource = readSettingsCombinedSourceSync();
-const mainSource = readFileSync(
-  join(process.cwd(), 'src/main/main.ts'),
-  'utf8',
-);
+const mainSource = readMainProcessCombinedSourceSync();
 
 function blockBetween(start: string, end: string): string {
   return settingsSource.match(new RegExp(`${start}[\\s\\S]*?${end}`))?.[0] ?? '';

--- a/apps/desktop/src/main/__tests__/task-ledger-desktop-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/task-ledger-desktop-contract.test.ts
@@ -3,8 +3,10 @@ import { readFile } from 'node:fs/promises';
 import { resolve } from 'node:path';
 import { describe, it } from 'node:test';
 import { REPO_ROOT } from './css-test-helpers.js';
+import { readMainProcessCombinedSource } from './main-process-contract-source-helpers.js';
 
 async function source(relativePath: string): Promise<string> {
+  if (relativePath === 'apps/desktop/src/main/main.ts') return readMainProcessCombinedSource();
   return readFile(resolve(REPO_ROOT, relativePath), 'utf8');
 }
 

--- a/apps/desktop/src/main/__tests__/theme-source.test.ts
+++ b/apps/desktop/src/main/__tests__/theme-source.test.ts
@@ -11,6 +11,7 @@ import { describe, it } from 'node:test';
 import { readFile } from 'node:fs/promises';
 import { resolve } from 'node:path';
 import { isThemePreference, toNativeThemeSource } from '../theme-source.js';
+import { readMainProcessCombinedSource } from './main-process-contract-source-helpers.js';
 
 // Anchored at the repo root, not relative to this test file's own location --
 // `npm test` runs the compiled dist/main/__tests__/*.test.js, so a plain
@@ -128,7 +129,7 @@ describe('theme-source', () => {
     });
 
     it('window:setTitleBarOverlayTheme forwards the sender to the guarded main-window controller', async () => {
-      const src = await readFile(MAIN_TS, 'utf8');
+      const src = await readMainProcessCombinedSource();
       assert.match(
         src,
         /ipcMain\.handle\('window:setTitleBarOverlayTheme', \(event, theme: unknown\): void => \{\s*mainWindowController\.setTitleBarOverlayTheme\(event\.sender, theme\);\s*\}\);/,

--- a/apps/desktop/src/main/__tests__/workspace-instructions.test.ts
+++ b/apps/desktop/src/main/__tests__/workspace-instructions.test.ts
@@ -4,6 +4,7 @@ import { mkdir, mkdtemp, readFile, rm, symlink, writeFile } from 'node:fs/promis
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { readSettingsCombinedSource } from './settings-contract-source-helpers.js';
+import { readMainProcessCombinedSource } from './main-process-contract-source-helpers.js';
 import {
   MAX_WORKSPACE_INSTRUCTION_FILE_CHARS,
   buildWorkspaceInstructionsPromptFragment,
@@ -140,7 +141,7 @@ describe('workspace instructions prompt fragment', () => {
   });
 
   it('wires instruction actions through the selected project root without arbitrary paths', async () => {
-    const main = await readFile(join(process.cwd(), 'src/main/main.ts'), 'utf8');
+    const main = await readMainProcessCombinedSource();
     const preload = await readFile(join(process.cwd(), 'src/preload/preload.ts'), 'utf8');
     const settings = await readSettingsCombinedSource();
 

--- a/apps/desktop/src/main/app-ipc-main.ts
+++ b/apps/desktop/src/main/app-ipc-main.ts
@@ -1,0 +1,204 @@
+import { mkdir } from 'node:fs/promises';
+import { join } from 'node:path';
+import { arch as osArch, release as osRelease } from 'node:os';
+import { app, ipcMain, shell } from 'electron';
+import { resolveProjectGitInfo, resolveProjectRoot } from '@maka/runtime';
+import type { createMainWindowController } from './main-window.js';
+import type { ProjectRootController } from './project-root-controller.js';
+import { resolveOpenPath, type OpenPathResult } from './open-path-guard.js';
+import { getVisualSmokeState, type resolveVisualSmokeFixture } from './visual-smoke-fixture.js';
+import type { resolveBuildInfo } from './build-info.js';
+
+type MainWindowController = ReturnType<typeof createMainWindowController>;
+type VisualSmokeFixture = ReturnType<typeof resolveVisualSmokeFixture>;
+type BuildInfo = ReturnType<typeof resolveBuildInfo>;
+
+export interface AppIpcDeps {
+  mainWindowController: MainWindowController;
+  projectRoot: ProjectRootController;
+  workspaceRoot: string;
+  buildInfo: BuildInfo;
+  visualSmokeFixture: VisualSmokeFixture;
+}
+
+/**
+ * Sanitize a single path segment for use under `screenshots/`. Allows
+ * only `[a-zA-Z0-9._-]`; rejects everything else (slashes, `..`, NUL,
+ * UTF-8 letters). Returns null when the input is empty after sanitization
+ * so the capture IPC can fail-closed rather than write to an attacker-
+ * controlled relative path.
+ */
+function sanitizeSegment(value: unknown): string | null {
+  if (typeof value !== 'string') return null;
+  const trimmed = value.trim();
+  if (trimmed.length === 0 || trimmed.length > 128) return null;
+  if (!/^[a-zA-Z0-9._-]+$/.test(trimmed)) return null;
+  if (trimmed === '.' || trimmed === '..') return null;
+  return trimmed;
+}
+
+export function registerAppIpc(deps: AppIpcDeps): void {
+  const { mainWindowController, projectRoot, workspaceRoot, buildInfo, visualSmokeFixture } = deps;
+  // Local bindings to the shared project-root authority, keeping the read/
+  // resolve call sites identical to the pre-split inline closures.
+  const currentProjectRoot = (): Promise<string> => projectRoot.current();
+  const resolveExplicitProjectRoot = projectRoot.resolveExplicit;
+
+  ipcMain.handle('window:setTitlebarControlsVisible', (event, visible: unknown): void => {
+    mainWindowController.setTitlebarControlsVisible(event.sender, visible);
+  });
+  // PR-SHOW-AFTER-FIRST-COMMIT: the renderer signals its first React commit so
+  // the hidden window (main-window.ts show: false) is revealed only once real
+  // content can paint. Idempotent + visual-smoke-safe inside the controller.
+  ipcMain.handle('window:notifyRendererReady', (): void => {
+    mainWindowController.notifyRendererReady();
+  });
+  ipcMain.handle('window:setThemeSource', (event, themePref: unknown): void => {
+    mainWindowController.setThemeSource(event.sender, themePref);
+  });
+  // PR-WINDOW-TITLEBAR-0: re-sync the native titleBarOverlay color when the
+  // renderer resolves a new light/dark mode or palette. No-op outside Windows.
+  ipcMain.handle('window:setTitleBarOverlayTheme', (event, theme: unknown): void => {
+    mainWindowController.setTitleBarOverlayTheme(event.sender, theme);
+  });
+  ipcMain.handle('app:info', async () => {
+    const projectPath = await currentProjectRoot();
+    return {
+      appVersion: app.getVersion(),
+      electronVersion: process.versions.electron ?? '',
+      nodeVersion: process.versions.node ?? '',
+      chromeVersion: process.versions.chrome ?? '',
+      platform: process.platform,
+      arch: osArch(),
+      osRelease: osRelease(),
+      workspacePath: workspaceRoot,
+      projectPath,
+      projectGit: await resolveProjectGitInfo(projectPath),
+      buildMode: buildInfo.mode,
+      buildCommit: buildInfo.commit,
+    };
+  });
+  ipcMain.handle('app:openPath', async (_event, key: string): Promise<OpenPathResult> => {
+    const resolved = await resolveOpenPath({ key, workspaceRoot, projectRoot: await currentProjectRoot() });
+    if (!resolved.ok) return resolved;
+    const error = await shell.openPath(resolved.path);
+    if (error) return { ok: false, reason: 'open-failed' };
+    return { ok: true, opened: resolved.key };
+  });
+  ipcMain.handle(
+    'app:selectProjectDirectory',
+    async (): Promise<
+      | { ok: true; projectPath: string; projectGit: Awaited<ReturnType<typeof resolveProjectGitInfo>> }
+      | { ok: false; reason: 'cancelled' | 'missing-selection' }
+    > => {
+      const result = await mainWindowController.showOpenDialog({
+        title: '选择工作目录',
+        properties: ['openDirectory'],
+      });
+      const selectedPath = result.filePaths[0];
+      if (result.canceled) return { ok: false, reason: 'cancelled' };
+      if (!selectedPath) return { ok: false, reason: 'missing-selection' };
+      const projectPath = await resolveProjectRoot([selectedPath]);
+      projectRoot.setSelected(projectPath);
+      return {
+        ok: true,
+        projectPath,
+        projectGit: await resolveProjectGitInfo(projectPath),
+      };
+    },
+  );
+  ipcMain.handle(
+    'app:selectProjectRoot',
+    async (_event, projectPath: unknown): Promise<
+      | { ok: true; projectPath: string; projectGit: Awaited<ReturnType<typeof resolveProjectGitInfo>> }
+      | { ok: false; reason: 'invalid-path' | 'not-found' }
+    > => {
+      const explicitRoot = await resolveExplicitProjectRoot(projectPath);
+      if (!explicitRoot.ok) return explicitRoot;
+      const resolved = explicitRoot.projectPath;
+      projectRoot.setSelected(resolved);
+      return {
+        ok: true,
+        projectPath: resolved,
+        projectGit: await resolveProjectGitInfo(resolved),
+      };
+    },
+  );
+  ipcMain.handle(
+    'app:resolveProjectGitInfo',
+    async (
+      _event,
+      projectPath: unknown,
+    ): Promise<
+      | { ok: true; projectPath: string; projectGit: Awaited<ReturnType<typeof resolveProjectGitInfo>> }
+      | { ok: false; reason: 'invalid-path' | 'not-found' }
+    > => {
+      if (projectPath !== undefined) {
+        const explicitRoot = await resolveExplicitProjectRoot(projectPath);
+        if (!explicitRoot.ok) return explicitRoot;
+        const resolved = explicitRoot.projectPath;
+        return { ok: true, projectPath: resolved, projectGit: await resolveProjectGitInfo(resolved) };
+      }
+      const resolved = await currentProjectRoot();
+      return { ok: true, projectPath: resolved, projectGit: await resolveProjectGitInfo(resolved) };
+    },
+  );
+  ipcMain.handle('visualSmoke:getState', () => getVisualSmokeState(visualSmokeFixture));
+  /**
+   * PR-IR-01 screenshot capture (dev/test-only).
+   *
+   * Available only when `MAKA_VISUAL_SMOKE_FIXTURE` is set — refuses
+   * otherwise so real users / packaged builds can't be coerced into
+   * dumping the renderer to disk. The capture script
+   * (`scripts/capture-screenshots.mjs`) drives this IPC after the
+   * fixture finishes settling.
+   *
+   * Returns the absolute path of the written file or a structured
+   * failure reason. The renderer never sees absolute paths (per the
+   * filesystem-boundary contract); the script reads the result back
+   * over IPC because it owns the screenshot directory.
+   */
+  ipcMain.handle(
+    'visualSmoke:capture',
+    async (
+      _event,
+      input: { scenario: string; variant: string },
+    ): Promise<
+      | { ok: true; path: string }
+      | { ok: false; reason: 'not_in_fixture_mode' | 'invalid_input' | 'capture_failed' | 'write_failed' }
+    > => {
+      if (!visualSmokeFixture) return { ok: false, reason: 'not_in_fixture_mode' };
+      const scenario = sanitizeSegment(input?.scenario);
+      const variant = sanitizeSegment(input?.variant);
+      if (!scenario || !variant) return { ok: false, reason: 'invalid_input' };
+      let image: Electron.NativeImage;
+      try {
+        const capture = await mainWindowController.capturePage();
+        if (!capture) return { ok: false, reason: 'capture_failed' };
+        image = capture;
+      } catch {
+        return { ok: false, reason: 'capture_failed' };
+      }
+      const dir = join(workspaceRoot, 'screenshots', scenario);
+      try {
+        await mkdir(dir, { recursive: true });
+      } catch {
+        return { ok: false, reason: 'write_failed' };
+      }
+      const filePath = join(dir, `${variant}.png`);
+      try {
+        const { writeFile } = await import('node:fs/promises');
+        await writeFile(filePath, image.toPNG());
+      } catch {
+        return { ok: false, reason: 'write_failed' };
+      }
+      // Deterministic stdout marker so the driver script
+      // (`scripts/capture-screenshots.mjs`) can match on the line and
+      // know the capture completed without polling the filesystem.
+      // The line is single-token whitespace-separated so it's easy to
+      // parse by regex.
+      console.log(`[visual-smoke] captured scenario=${scenario} variant=${variant} path=${filePath}`);
+      return { ok: true, path: filePath };
+    },
+  );
+}

--- a/apps/desktop/src/main/app-ipc-main.ts
+++ b/apps/desktop/src/main/app-ipc-main.ts
@@ -39,10 +39,9 @@ function sanitizeSegment(value: unknown): string | null {
 
 export function registerAppIpc(deps: AppIpcDeps): void {
   const { mainWindowController, projectRoot, workspaceRoot, buildInfo, visualSmokeFixture } = deps;
-  // Local bindings to the shared project-root authority, keeping the read/
-  // resolve call sites identical to the pre-split inline closures.
+  // Call-time read of the shared project-root authority: every handler must
+  // observe the latest selection, not a snapshot taken at registration.
   const currentProjectRoot = (): Promise<string> => projectRoot.current();
-  const resolveExplicitProjectRoot = projectRoot.resolveExplicit;
 
   ipcMain.handle('window:setTitlebarControlsVisible', (event, visible: unknown): void => {
     mainWindowController.setTitlebarControlsVisible(event.sender, visible);
@@ -113,7 +112,7 @@ export function registerAppIpc(deps: AppIpcDeps): void {
       | { ok: true; projectPath: string; projectGit: Awaited<ReturnType<typeof resolveProjectGitInfo>> }
       | { ok: false; reason: 'invalid-path' | 'not-found' }
     > => {
-      const explicitRoot = await resolveExplicitProjectRoot(projectPath);
+      const explicitRoot = await projectRoot.resolveExplicit(projectPath);
       if (!explicitRoot.ok) return explicitRoot;
       const resolved = explicitRoot.projectPath;
       projectRoot.setSelected(resolved);
@@ -134,7 +133,7 @@ export function registerAppIpc(deps: AppIpcDeps): void {
       | { ok: false; reason: 'invalid-path' | 'not-found' }
     > => {
       if (projectPath !== undefined) {
-        const explicitRoot = await resolveExplicitProjectRoot(projectPath);
+        const explicitRoot = await projectRoot.resolveExplicit(projectPath);
         if (!explicitRoot.ok) return explicitRoot;
         const resolved = explicitRoot.projectPath;
         return { ok: true, projectPath: resolved, projectGit: await resolveProjectGitInfo(resolved) };

--- a/apps/desktop/src/main/gateway-ipc-main.ts
+++ b/apps/desktop/src/main/gateway-ipc-main.ts
@@ -1,0 +1,10 @@
+import { ipcMain } from 'electron';
+import type { OpenGatewayService } from './open-gateway.js';
+
+export interface GatewayIpcDeps {
+  openGateway: OpenGatewayService;
+}
+
+export function registerGatewayIpc(deps: GatewayIpcDeps): void {
+  ipcMain.handle('gateway:status', async () => deps.openGateway.getStatus());
+}

--- a/apps/desktop/src/main/git-ipc-main.ts
+++ b/apps/desktop/src/main/git-ipc-main.ts
@@ -1,0 +1,23 @@
+import { ipcMain } from 'electron';
+import { checkoutBranch, listLocalBranches } from './git-branch.js';
+
+export interface GitIpcDeps {
+  getCurrentProjectRoot: () => Promise<string>;
+}
+
+export function registerGitIpc(deps: GitIpcDeps): void {
+  ipcMain.handle('app:listGitBranches', async () => {
+    const projectPath = await deps.getCurrentProjectRoot();
+    return listLocalBranches(projectPath);
+  });
+  ipcMain.handle(
+    'app:checkoutGitBranch',
+    async (_event, branch: unknown): Promise<{ ok: boolean; branch?: string; reason?: string; message?: string }> => {
+      if (typeof branch !== 'string' || !branch) {
+        return { ok: false, reason: 'failed', message: '无效的分支名' };
+      }
+      const projectPath = await deps.getCurrentProjectRoot();
+      return checkoutBranch(projectPath, branch);
+    },
+  );
+}

--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -1,44 +1,23 @@
-import { app, ipcMain, nativeImage, powerMonitor, safeStorage, shell } from 'electron';
+import { app, nativeImage, powerMonitor, safeStorage, shell } from 'electron';
 import { randomUUID } from 'node:crypto';
-import { mkdir, readFile, realpath, stat, writeFile } from 'node:fs/promises';
-import { basename, isAbsolute, join, relative, resolve, sep } from 'node:path';
+import { mkdir, readFile, realpath } from 'node:fs/promises';
+import { isAbsolute, join, relative, resolve, sep } from 'node:path';
 import { startConfigFileWatcher, type ConfigFileWatcher } from './config-file-watcher.js';
-import { release as osRelease, arch as osArch } from 'node:os';
 import {
-  generalizedErrorMessage,
-  generalizedErrorMessageChinese,
-  redactSecrets,
   filterModelVisibleTaskLedgerTasks,
-  sanitizeTaskLedgerTask,
-  buildHealthSnapshot,
-  healthSignalFromCapability,
-  healthSignalFromConnection,
-  healthSignalFromConnectionRuntime,
-  isPermissionMode,
   isDeepResearchSession,
-  isThinkingLevel,
-  thinkingVariantsForModel,
   resolveModelVisionSupport,
   DEEP_RESEARCH_SESSION_LABEL,
   expertTeamIdFromLabels,
-  expertTeamLabel,
-  botDisplayLabel,
 } from '@maka/core';
 import type {
   AppSettings,
   BotProvider,
   ConnectionEvent,
-  CreateSessionInput,
   PermissionMode,
   SessionChangedEvent,
   SessionChangedReason,
   SessionEvent,
-  SessionHeader,
-  SessionListFilter,
-  ThinkingLevel,
-  StoredMessage,
-  SettingsTestResult,
-  UpdateAppSettingsResult,
   UpdateAppSettingsInput,
 } from '@maka/core';
 import { deriveBotStatusPersistenceUpdate } from './bot-status-persistence.js';
@@ -49,14 +28,6 @@ import {
   persistArchivedToolResultToArtifacts,
   readArchivedToolResultFromArtifacts,
 } from './tool-result-archive-artifacts.js';
-import {
-  normalizeBranchFromTurnInput,
-  normalizePermissionResponse,
-  normalizeRegenerateTurnInput,
-  normalizeSessionSendCommand,
-  normalizeStopSessionInput,
-  normalizeUserQuestionResponse,
-} from './permission-response-guard.js';
 import { turnFailureMessageFromSessionEvent } from './turn-stream-outcome.js';
 import { ClaudeSubscriptionService } from './oauth/claude-subscription-service.js';
 import { OpenAiCodexService } from './oauth/openai-codex-service.js';
@@ -65,13 +36,8 @@ import { CursorSubscriptionService } from './oauth/cursor-subscription-service.j
 import { AntigravitySubscriptionService } from './oauth/antigravity-subscription-service.js';
 import { importLegacyOAuthTokenFiles } from './oauth/shared-credential-bridge.js';
 import type { WorkspacePrivacyContext } from '@maka/core/incognito';
-import type { LlmCallRecord, PricingConfig, ToolInvocationRecord } from '@maka/core/usage-stats/types';
-import type {
-  TestProxyInput,
-  TestProxyResult,
-} from '@maka/core/settings/network-settings';
-import { SENSITIVE_PLACEHOLDER } from '@maka/core/settings/network-settings';
-import { err, ok, tryResult, type Result } from '@maka/core/settings/result';
+import type { LlmCallRecord, ToolInvocationRecord } from '@maka/core/usage-stats/types';
+import { ok } from '@maka/core/settings/result';
 import {
   AiSdkBackend,
   BackendRegistry,
@@ -89,15 +55,11 @@ import {
   buildSubagentSpawnTool,
   buildSubagentToolGroup,
   getAIModel,
-  getExpertTeam,
-  listExpertTeams,
   buildProviderOptions,
   recordLlmCall,
   recordToolInvocation,
   buildPricingLookup,
   BotRegistry,
-  getWechatBridgeQrCode,
-  testBotChannel as testRuntimeBotChannel,
   setActiveProxy,
   ShellRunProcessManager,
 } from '@maka/runtime';
@@ -111,9 +73,7 @@ import type {
   ToolResultArchiveReadResult,
   ToolResultArchiveRecorderInput,
 } from '@maka/runtime';
-import { testProxyConnection } from '@maka/runtime/network/proxy-test';
-import { fetchWeChatQrcode, pollWeChatQrcodeStatus } from './wechat-scan-login.js';
-import type { LlmConnection, ProviderType } from '@maka/core/llm-connections';
+import type { LlmConnection } from '@maka/core/llm-connections';
 import {
   createAgentRunStore,
   createArtifactStore,
@@ -132,35 +92,17 @@ import {
   errorReason,
   requireReadyConnection,
 } from './chat-readiness.js';
-import {
-  sessionReadMessagesFailureMessage,
-} from './session-read-error-copy.js';
 import { createFileCredentialStore, migrateLegacyCredentials } from './credential-store.js';
 import { bindOnboardingDeps, createOnboardingService } from './onboarding-service.js';
 import { handleQuickChatStart as runQuickChatStart, type QuickChatResult } from './quick-chat.js';
-import { handleExpertTeamStart as runExpertTeamStart } from './expert-team-start.js';
-import { probeOfficeCli } from './officecli-probe.js';
-import { resolveOpenPath, type OpenPathResult } from './open-path-guard.js';
-import { resolveProjectGitInfo, resolveProjectRoot, resolveSkillDiscoveryPaths } from '@maka/runtime';
-import { listLocalBranches, checkoutBranch } from './git-branch.js';
-import { searchWorkspaceFiles } from './workspace-file-search.js';
+import { resolveSkillDiscoveryPaths } from '@maka/runtime';
 import { createDailyReviewArchiveStore } from './daily-review-archive-store.js';
-import { botTestErrorMessage, buildSettingsUpdateResult, maskAppSettings, preserveSensitivePlaceholders, toSettingsTestResult } from './settings-ipc-helpers.js';
+import { preserveSensitivePlaceholders } from './settings-ipc-helpers.js';
 import {
   buildSkillAgentTool,
 } from './skills.js';
-import {
-  createWorkspaceInstructionFile,
-  getWorkspaceInstructionsState,
-  resolveWorkspaceInstructionFileForOpen,
-  type WorkspaceInstructionCreateFailureReason,
-  type WorkspaceInstructionOpenFailureReason,
-} from './workspace-instructions.js';
-import { buildCapabilitySnapshotCollection, buildPermissionSnapshot } from './capability-snapshot.js';
-import { openSystemPermissionPane, requestPermissionAccess } from './permissions-actions.js';
 import { resolveDefaultPermissionMode } from './permission-mode-default.js';
 import {
-  getVisualSmokeState,
   resolveVisualSmokeFixture,
   seedVisualSmokeFixture,
 } from './visual-smoke-fixture.js';
@@ -169,8 +111,6 @@ import { OpenGatewayService } from './open-gateway.js';
 import { LocalMemoryService } from './local-memory-service.js';
 import { createAttachmentApprovalRegistry } from './attachment-approval.js';
 import { createAttachmentByteReader } from './attachment-reader.js';
-import { resizeImageForAttachment } from './attachment-resize-native.js';
-import { resolveSessionSend } from './session-send-resolve.js';
 import { buildExploreAgentTool } from './explore-agent-tool.js';
 import { buildOfficeDocumentEditTool, buildOfficeDocumentTool } from './office-document-tool.js';
 import {
@@ -195,7 +135,6 @@ import {
   computerUseToolsForModel,
 } from './computer-use-model-tools.js';
 import { createComputerUseOverlayHook } from '@maka/computer-use';
-import { releaseBrowserSession } from './browser/session.js';
 import { createMainWindowController } from './main-window.js';
 import { createDailyReviewMainService } from './daily-review-main.js';
 import { createPlanReminderMainService } from './plan-reminders-main.js';
@@ -209,9 +148,7 @@ import { createMainGoalWiring } from './goal-wiring.js';
 import { handleGoalContinuation } from '@maka/runtime';
 import { createOAuthModelConnectionsMainService } from './oauth-model-connections-main.js';
 import {
-  applyNetworkPatch,
   maskNetworkSettings,
-  toAppNetworkPatch,
   toContractNetworkSettings,
 } from './network-settings-main.js';
 import { registerMemoryIpc } from './memory-ipc-main.js';
@@ -225,6 +162,17 @@ import { registerDailyReviewIpc } from './daily-review-ipc-main.js';
 import { registerUsageIpc } from './usage-ipc-main.js';
 import { registerWebSearchIpc } from './web-search-ipc-main.js';
 import { registerNotificationsIpc } from './notifications-ipc-main.js';
+import { registerAppIpc } from './app-ipc-main.js';
+import { registerGitIpc } from './git-ipc-main.js';
+import { registerWorkspaceSearchIpc } from './workspace-search-ipc-main.js';
+import { registerWorkspaceInstructionsIpc } from './workspace-instructions-ipc-main.js';
+import { registerOnboardingIpc } from './onboarding-ipc-main.js';
+import { registerSessionEntryIpc } from './session-entry-ipc-main.js';
+import { registerPermissionsIpc } from './permissions-ipc-main.js';
+import { registerSettingsIpc } from './settings-ipc-main.js';
+import { registerGatewayIpc } from './gateway-ipc-main.js';
+import { registerSessionsIpc } from './sessions-ipc-main.js';
+import { createProjectRootController } from './project-root-controller.js';
 
 // E2E switches must never fire in a packaged build, and must never run against
 // the real user data: a stray MAKA_E2E on a build/dev machine would otherwise
@@ -759,11 +707,15 @@ let lookupPricing = buildPricingLookup();
 // newer, more useful failure replaces the previous one.
 const previousBotStatus = new Map<BotProvider, Pick<BotStatus, 'readiness' | 'reason'>>();
 let botIncoming: ReturnType<typeof createBotIncomingMainService>;
-// botIncoming is wired at module load, before registerIpc() defines the
-// current-project-root resolver. registerIpc reassigns this once the resolver
-// exists; until then the launch directory is the safe fallback. Unifying
-// project-root resolution is tracked as a follow-up.
-let resolveCurrentProjectRoot: () => Promise<string> = async () => process.cwd();
+// Single authority for the "current project root" selection, shared across the
+// app/window, git, workspace-search, workspace-instructions, and session-entry
+// IPC surfaces. botIncoming, automation cron runs, and quick-chat read the
+// current selection through the thin `resolveCurrentProjectRoot` adapter below.
+const projectRootController = createProjectRootController({
+  lastProjectPathFile: join(workspaceRoot, 'last-project-path.json'),
+  fallbackRoots: () => [process.cwd(), app.getAppPath()],
+});
+const resolveCurrentProjectRoot: () => Promise<string> = () => projectRootController.current();
 const botRegistry = new BotRegistry({
   onIncomingMessage: (message: BotIncomingMessage) => {
     // Only log incoming bot messages in dev — production stdout leaking
@@ -874,22 +826,6 @@ async function resolveToolArtifactSourcePath(cwd: string, sourcePath: string): P
     return null;
   }
   return isInsideOrSamePath(root, target) ? target : null;
-}
-
-/**
- * Sanitize a single path segment for use under `screenshots/`. Allows
- * only `[a-zA-Z0-9._-]`; rejects everything else (slashes, `..`, NUL,
- * UTF-8 letters). Returns null when the input is empty after sanitization
- * so the capture IPC can fail-closed rather than write to an attacker-
- * controlled relative path.
- */
-function sanitizeSegment(value: unknown): string | null {
-  if (typeof value !== 'string') return null;
-  const trimmed = value.trim();
-  if (trimmed.length === 0 || trimmed.length > 128) return null;
-  if (!/^[a-zA-Z0-9._-]+$/.test(trimmed)) return null;
-  if (trimmed === '.' || trimmed === '..') return null;
-  return trimmed;
 }
 
 function isInsideOrSamePath(root: string, target: string): boolean {
@@ -1003,18 +939,6 @@ backends.register('ai-sdk', async (ctx) => {
   });
 });
 
-async function tryWeChatQrResult<T>(fn: () => Promise<T>, errorCode: string): Promise<Result<T>> {
-  try {
-    return ok(await fn());
-  } catch (error) {
-    return err(errorCode, weChatQrFailureMessage(error));
-  }
-}
-
-function weChatQrFailureMessage(error: unknown): string {
-  return generalizedErrorMessageChinese(error, '微信扫码登录暂时不可用，请稍后重试。');
-}
-
 backends.register('fake', (ctx) =>
   new FakeBackend({ sessionId: ctx.sessionId, header: ctx.header, store: ctx.store, appendMessage: ctx.appendMessage }),
 );
@@ -1090,411 +1014,51 @@ const onboardingService = createOnboardingService(
   }),
 );
 
-function workspaceInstructionOpenFailureCopy(reason: WorkspaceInstructionOpenFailureReason | 'open-failed'): string {
-  switch (reason) {
-    case 'unknown-file':
-      return '只能打开 AGENTS.md / CLAUDE.md / GEMINI.md。';
-    case 'missing':
-      return '项目指令文件不存在。';
-    case 'blocked':
-      return '项目指令文件不在当前工作区范围内。';
-    case 'not-a-file':
-      return '项目指令路径不是普通文件。';
-    case 'open-failed':
-      return '系统未能打开这个文件。';
-  }
-}
-
-function workspaceInstructionCreateFailureCopy(reason: WorkspaceInstructionCreateFailureReason): string {
-  switch (reason) {
-    case 'unknown-file':
-      return '只能创建 AGENTS.md / CLAUDE.md / GEMINI.md。';
-    case 'exists':
-      return '项目指令文件已经存在。';
-    case 'blocked':
-      return '当前工作区路径不可写或不在允许范围内。';
-    case 'write-failed':
-      return '写入项目指令文件失败。';
-  }
-}
-
-
-
-function proxyTestFailureMessage(result: TestProxyResult): string {
-  const raw = redactSecrets(result.error ?? '').trim();
-  const lower = raw.toLowerCase();
-  if (lower.includes('proxy disabled')) return '代理未启用，请先打开代理开关。';
-  if (lower.includes('proxy host/port required')) return '请填写代理服务器地址和端口后再测试。';
-  if (lower.includes('proxy test timeout') || lower.includes('timeout')) return '代理测试超时，请检查代理服务是否可达。';
-  if (result.status) return `代理测试返回 HTTP ${result.status}，请检查代理服务或测试地址。`;
-  const classified = generalizedErrorMessageChinese(raw, '');
-  if (classified) return classified;
-  if (raw && /[\u4E00-\u9FFF]/.test(raw)) return raw;
-  return '代理不可达，请检查代理服务器地址、端口或认证信息。';
-}
-
 function registerIpc(): void {
-  const LAST_PROJECT_PATH_FILE = join(workspaceRoot, 'last-project-path.json');
+  const currentProjectRoot = resolveCurrentProjectRoot;
 
-  let selectedProjectRoot: string | null = null;
-
-  async function loadPersistedProjectRoot(): Promise<string | null> {
-    try {
-      const raw = await readFile(LAST_PROJECT_PATH_FILE, 'utf8');
-      const parsed = JSON.parse(raw) as Record<string, unknown>;
-      if (typeof parsed.projectPath === 'string' && parsed.projectPath) {
-        await stat(parsed.projectPath);
-        return await resolveProjectRoot([parsed.projectPath]);
-      }
-    } catch {
-      // File missing, invalid, or points at a deleted directory.
-    }
-    return null;
-  }
-  const persistedProjectRootPromise = loadPersistedProjectRoot();
-
-  async function saveLastProjectPath(projectPath: string): Promise<void> {
-    try {
-      await writeFile(LAST_PROJECT_PATH_FILE, JSON.stringify({ projectPath }), 'utf8');
-    } catch {
-      // Best-effort; failure should not block the selection.
-    }
-  }
-
-  async function currentProjectRoot(): Promise<string> {
-    if (selectedProjectRoot) return selectedProjectRoot;
-    const persistedProjectRoot = await persistedProjectRootPromise;
-    if (persistedProjectRoot) {
-      selectedProjectRoot = persistedProjectRoot;
-      return persistedProjectRoot;
-    }
-    return resolveProjectRoot([process.cwd(), app.getAppPath()]);
-  }
-  resolveCurrentProjectRoot = currentProjectRoot;
-
-  async function resolveExplicitProjectRoot(projectPath: unknown): Promise<
-    | { ok: true; projectPath: string }
-    | { ok: false; reason: 'invalid-path' | 'not-found' }
-  > {
-    if (typeof projectPath !== 'string' || !projectPath) {
-      return { ok: false, reason: 'invalid-path' };
-    }
-    try {
-      await stat(projectPath);
-    } catch {
-      return { ok: false, reason: 'not-found' };
-    }
-    return { ok: true, projectPath: await resolveProjectRoot([projectPath]) };
-  }
-
-  ipcMain.handle('window:setTitlebarControlsVisible', (event, visible: unknown): void => {
-    mainWindowController.setTitlebarControlsVisible(event.sender, visible);
+  registerAppIpc({
+    mainWindowController,
+    projectRoot: projectRootController,
+    workspaceRoot,
+    buildInfo,
+    visualSmokeFixture,
   });
-  // PR-SHOW-AFTER-FIRST-COMMIT: the renderer signals its first React commit so
-  // the hidden window (main-window.ts show: false) is revealed only once real
-  // content can paint. Idempotent + visual-smoke-safe inside the controller.
-  ipcMain.handle('window:notifyRendererReady', (): void => {
-    mainWindowController.notifyRendererReady();
-  });
-  ipcMain.handle('window:setThemeSource', (event, themePref: unknown): void => {
-    mainWindowController.setThemeSource(event.sender, themePref);
-  });
-  // PR-WINDOW-TITLEBAR-0: re-sync the native titleBarOverlay color when the
-  // renderer resolves a new light/dark mode or palette. No-op outside Windows.
-  ipcMain.handle('window:setTitleBarOverlayTheme', (event, theme: unknown): void => {
-    mainWindowController.setTitleBarOverlayTheme(event.sender, theme);
-  });
-  ipcMain.handle('app:info', async () => {
-    const projectPath = await currentProjectRoot();
-    return {
-      appVersion: app.getVersion(),
-      electronVersion: process.versions.electron ?? '',
-      nodeVersion: process.versions.node ?? '',
-      chromeVersion: process.versions.chrome ?? '',
-      platform: process.platform,
-      arch: osArch(),
-      osRelease: osRelease(),
-      workspacePath: workspaceRoot,
-      projectPath,
-      projectGit: await resolveProjectGitInfo(projectPath),
-      buildMode: buildInfo.mode,
-      buildCommit: buildInfo.commit,
-    };
-  });
-  ipcMain.handle('app:openPath', async (_event, key: string): Promise<OpenPathResult> => {
-    const resolved = await resolveOpenPath({ key, workspaceRoot, projectRoot: await currentProjectRoot() });
-    if (!resolved.ok) return resolved;
-    const error = await shell.openPath(resolved.path);
-    if (error) return { ok: false, reason: 'open-failed' };
-    return { ok: true, opened: resolved.key };
-  });
-  ipcMain.handle(
-    'app:selectProjectDirectory',
-    async (): Promise<
-      | { ok: true; projectPath: string; projectGit: Awaited<ReturnType<typeof resolveProjectGitInfo>> }
-      | { ok: false; reason: 'cancelled' | 'missing-selection' }
-    > => {
-      const result = await mainWindowController.showOpenDialog({
-        title: '选择工作目录',
-        properties: ['openDirectory'],
-      });
-      const selectedPath = result.filePaths[0];
-      if (result.canceled) return { ok: false, reason: 'cancelled' };
-      if (!selectedPath) return { ok: false, reason: 'missing-selection' };
-      const projectPath = await resolveProjectRoot([selectedPath]);
-      selectedProjectRoot = projectPath;
-      void saveLastProjectPath(projectPath);
-      return {
-        ok: true,
-        projectPath,
-        projectGit: await resolveProjectGitInfo(projectPath),
-      };
-    },
-  );
-  ipcMain.handle(
-    'app:selectProjectRoot',
-    async (_event, projectPath: unknown): Promise<
-      | { ok: true; projectPath: string; projectGit: Awaited<ReturnType<typeof resolveProjectGitInfo>> }
-      | { ok: false; reason: 'invalid-path' | 'not-found' }
-    > => {
-      const explicitRoot = await resolveExplicitProjectRoot(projectPath);
-      if (!explicitRoot.ok) return explicitRoot;
-      const resolved = explicitRoot.projectPath;
-      selectedProjectRoot = resolved;
-      void saveLastProjectPath(resolved);
-      return {
-        ok: true,
-        projectPath: resolved,
-        projectGit: await resolveProjectGitInfo(resolved),
-      };
-    },
-  );
-  ipcMain.handle(
-    'app:resolveProjectGitInfo',
-    async (
-      _event,
-      projectPath: unknown,
-    ): Promise<
-      | { ok: true; projectPath: string; projectGit: Awaited<ReturnType<typeof resolveProjectGitInfo>> }
-      | { ok: false; reason: 'invalid-path' | 'not-found' }
-    > => {
-      if (projectPath !== undefined) {
-        const explicitRoot = await resolveExplicitProjectRoot(projectPath);
-        if (!explicitRoot.ok) return explicitRoot;
-        const resolved = explicitRoot.projectPath;
-        return { ok: true, projectPath: resolved, projectGit: await resolveProjectGitInfo(resolved) };
-      }
-      const resolved = await currentProjectRoot();
-      return { ok: true, projectPath: resolved, projectGit: await resolveProjectGitInfo(resolved) };
-    },
-  );
-  ipcMain.handle('app:listGitBranches', async () => {
-    const projectPath = await currentProjectRoot();
-    return listLocalBranches(projectPath);
-  });
-  ipcMain.handle(
-    'app:checkoutGitBranch',
-    async (_event, branch: unknown): Promise<{ ok: boolean; branch?: string; reason?: string; message?: string }> => {
-      if (typeof branch !== 'string' || !branch) {
-        return { ok: false, reason: 'failed', message: '无效的分支名' };
-      }
-      const projectPath = await currentProjectRoot();
-      return checkoutBranch(projectPath, branch);
-    },
-  );
-  // Composer `@` mention popup: list workspace files under the same project
-  // root that app:info reports. Git repos honor .gitignore + untracked via
-  // `git ls-files`; other trees fall back to a bounded walk. See
-  // workspace-file-search.ts.
-  ipcMain.handle(
-    'workspace:searchFiles',
-    async (_event, input: unknown) => {
-      const request = (input ?? {}) as { query?: unknown; limit?: unknown };
-      const projectPath = await currentProjectRoot();
-      return searchWorkspaceFiles(projectPath, { query: request.query, limit: request.limit });
-    },
-  );
   registerMemoryIpc({ localMemory });
   registerConfigIpc({ connectionStore, settingsStore, credentialStore, workspaceRoot });
   registerNotificationsIpc({ settingsStore, mainWindowController, e2e: isE2e });
-  ipcMain.handle('workspaceInstructions:getState', async () => getWorkspaceInstructionsState(await currentProjectRoot()));
-  ipcMain.handle(
-    'workspaceInstructions:openFile',
-    async (_event, file: unknown): Promise<{ ok: true } | { ok: false; message: string }> => {
-      const resolved = await resolveWorkspaceInstructionFileForOpen(await currentProjectRoot(), typeof file === 'string' ? file : '');
-      if (!resolved.ok) return { ok: false, message: workspaceInstructionOpenFailureCopy(resolved.reason) };
-      const error = await shell.openPath(resolved.path);
-      return error ? { ok: false, message: workspaceInstructionOpenFailureCopy('open-failed') } : { ok: true };
-    },
-  );
-  ipcMain.handle(
-    'workspaceInstructions:createFile',
-    async (_event, file: unknown): Promise<{ ok: true } | { ok: false; message: string }> => {
-      const created = await createWorkspaceInstructionFile(await currentProjectRoot(), typeof file === 'string' ? file : '');
-      if (!created.ok) return { ok: false, message: workspaceInstructionCreateFailureCopy(created.reason) };
-      return { ok: true };
-    },
-  );
+  registerWorkspaceInstructionsIpc({ getCurrentProjectRoot: currentProjectRoot });
   registerWorkspaceResourcesIpc({
     workspaceRoot,
     artifactStore,
     mainWindowController,
     sendToRenderer: safeSendToRenderer,
   });
-  ipcMain.handle('visualSmoke:getState', () => getVisualSmokeState(visualSmokeFixture));
-  /**
-   * PR-IR-01 screenshot capture (dev/test-only).
-   *
-   * Available only when `MAKA_VISUAL_SMOKE_FIXTURE` is set — refuses
-   * otherwise so real users / packaged builds can't be coerced into
-   * dumping the renderer to disk. The capture script
-   * (`scripts/capture-screenshots.mjs`) drives this IPC after the
-   * fixture finishes settling.
-   *
-   * Returns the absolute path of the written file or a structured
-   * failure reason. The renderer never sees absolute paths (per the
-   * filesystem-boundary contract); the script reads the result back
-   * over IPC because it owns the screenshot directory.
-   */
-  ipcMain.handle(
-    'visualSmoke:capture',
-    async (
-      _event,
-      input: { scenario: string; variant: string },
-    ): Promise<
-      | { ok: true; path: string }
-      | { ok: false; reason: 'not_in_fixture_mode' | 'invalid_input' | 'capture_failed' | 'write_failed' }
-    > => {
-      if (!visualSmokeFixture) return { ok: false, reason: 'not_in_fixture_mode' };
-      const scenario = sanitizeSegment(input?.scenario);
-      const variant = sanitizeSegment(input?.variant);
-      if (!scenario || !variant) return { ok: false, reason: 'invalid_input' };
-      let image: Electron.NativeImage;
-      try {
-        const capture = await mainWindowController.capturePage();
-        if (!capture) return { ok: false, reason: 'capture_failed' };
-        image = capture;
-      } catch {
-        return { ok: false, reason: 'capture_failed' };
-      }
-      const dir = join(workspaceRoot, 'screenshots', scenario);
-      try {
-        await mkdir(dir, { recursive: true });
-      } catch {
-        return { ok: false, reason: 'write_failed' };
-      }
-      const filePath = join(dir, `${variant}.png`);
-      try {
-        const { writeFile } = await import('node:fs/promises');
-        await writeFile(filePath, image.toPNG());
-      } catch {
-        return { ok: false, reason: 'write_failed' };
-      }
-      // Deterministic stdout marker so the driver script
-      // (`scripts/capture-screenshots.mjs`) can match on the line and
-      // know the capture completed without polling the filesystem.
-      // The line is single-token whitespace-separated so it's easy to
-      // parse by regex.
-      console.log(`[visual-smoke] captured scenario=${scenario} variant=${variant} path=${filePath}`);
-      return { ok: true, path: filePath };
-    },
-  );
+  registerWorkspaceSearchIpc({ getCurrentProjectRoot: currentProjectRoot });
+  registerGitIpc({ getCurrentProjectRoot: currentProjectRoot });
   registerPlanReminderIpc({ planReminders, getWorkspacePrivacyContext });
-  ipcMain.handle('shell-runs:list', (_event, sessionId: string) => runtime.listShellRunUpdates(sessionId));
-  ipcMain.handle('tasks:list', async (_event, sessionId: string) => {
-    const tasks = await taskLedgerStore.list(sessionId, {
-      includeTerminal: true,
-      includeArchived: false,
-      classifyResumeTrust: true,
-      ...(visualSmokeFixture ? { now: getVisualSmokeState(visualSmokeFixture)?.now ?? Date.now() } : {}),
-    });
-    return tasks.map(sanitizeTaskLedgerTask);
+  registerSessionsIpc({
+    runtime,
+    store,
+    taskLedgerStore,
+    goalManager: goalWiring.manager,
+    automationManager: automationWiring.manager,
+    computerUseOverlay,
+    computerUseTools,
+    artifactStore,
+    attachmentApprovals,
+    settingsStore,
+    connectionStore,
+    mainWindowController,
+    visualSmokeFixture,
+    emitSessionsChanged,
+    ensureSessionCanSend,
+    getReadyConnection,
+    streamEvents,
+    getCurrentProjectRoot: currentProjectRoot,
+    getWorkspacePrivacyContext,
+    canCreateFakeSession: canCreateFakeSessionFromRenderer,
   });
-  ipcMain.handle('sessions:list', (_event, filter?: SessionListFilter) => runtime.listSessions(filter));
-  ipcMain.handle('sessions:create', async (_event, input?: Partial<CreateSessionInput>) => {
-    const cwd = input?.cwd ?? (await currentProjectRoot());
-    if (input?.backend === 'fake') {
-      if (!canCreateFakeSessionFromRenderer()) {
-        throw new Error('FakeBackend sessions are only available in development.');
-      }
-      const session = await runtime.createSession({
-        cwd,
-        backend: 'fake',
-        llmConnectionSlug: input.llmConnectionSlug ?? 'fake',
-        model: input.model ?? 'fake-model',
-        permissionMode: input.permissionMode ?? (await resolveDefaultPermissionMode(() => settingsStore.get())),
-        name: input.name ?? 'New Chat',
-        labels: input.labels,
-      });
-      emitSessionsChanged('created', session.id);
-      return session;
-    }
-
-    const requestedSlug = input?.llmConnectionSlug ?? (await connectionStore.getDefault());
-    const { connection, model } = await getReadyConnection(requestedSlug, input?.model);
-    const thinkingLevel = normalizeSupportedSessionThinkingLevel(input?.thinkingLevel, connection.providerType, model);
-
-    const session = await runtime.createSession({
-      cwd,
-      backend: 'ai-sdk',
-      llmConnectionSlug: connection.slug,
-      model,
-      ...(thinkingLevel !== undefined ? { thinkingLevel } : {}),
-      permissionMode: input?.permissionMode ?? (await resolveDefaultPermissionMode(() => settingsStore.get())),
-      name: input?.name ?? 'New Chat',
-      labels: input?.labels,
-    });
-    emitSessionsChanged('created', session.id);
-    return session;
-  });
-  ipcMain.handle('sessions:readMessages', async (_event, sessionId: string) => {
-    if (visualSmokeFixture) return store.readMessages(sessionId);
-    let messages: StoredMessage[];
-    try {
-      messages = await runtime.getMessages(sessionId);
-    } catch (error) {
-      throw new Error(sessionReadMessagesFailureMessage(error));
-    }
-    try {
-      await runtime.markSessionRead(sessionId, latestStoredMessageTs(messages));
-    } catch {
-      // Reading the content already succeeded. Leave the persisted unread
-      // state for a later refresh instead of turning this into a load error.
-    }
-    return messages;
-  });
-  ipcMain.handle('sessions:listTurns', (_event, sessionId: string) => runtime.listTurns(sessionId));
-  // Goal kill-switch surface: the renderer reads the active goal to badge a
-  // session running an autonomous loop, and clears it to stop the loop. `get`
-  // returns null when no goal is set; `clear` settles it (continuation stops
-  // after the current turn). Both are pure local state, so no permission gate.
-  ipcMain.handle('goal:get', (_event, sessionId: string) => goalWiring.manager.get(sessionId) ?? null);
-  ipcMain.handle('goal:clear', (_event, sessionId: string) => {
-    goalWiring.manager.clear(sessionId);
-  });
-  // PR-SEARCH-2: local thread search. Renderer-facing channel; the pure
-  // helper in `./search/thread-search.ts` enforces all gates (G1 snippet
-  // redaction, G2 fake-backend exclude, G4 caps, G5 case-fold + NFC,
-  // G9 tool_result scan cap, G10 system/meta exclusion). The helper
-  // receives the runtime via DI so unit tests stay Electron-agnostic.
-  // We deliberately do NOT log the request body — query text never enters
-  // telemetry.
-  // ===========================================================
-  // PR-OAUTH-SUBSCRIPTION-0: Claude subscription OAuth IPC.
-  // All handlers return either `SubscriptionAccountState` or
-  // `SubscriptionActionResult` — never raw tokens (xuan G-X3).
-  //
-  // kenji `1da909d5` blocking concern: Anthropic does not permit
-  // third-party developers to offer Claude.ai login on behalf of
-  // users. Until product/legal sign-off, the entire feature is
-  // gated behind `MAKA_CLAUDE_SUBSCRIPTION_EXPERIMENTAL=1`. The
-  // Settings UI also hides the card; this guard is the second line
-  // of defense (a DevTools-triggered call to `window.maka` still
-  // hits the experimental gate).
-  // ===========================================================
-  // kenji `45b31e16`: use the dedicated `experimental_disabled`
-  // reason so the user-visible state is clearly "this feature is
-  // not enabled by Maka" — NOT "Anthropic rejected my account".
   registerSubscriptionIpc({
     connectionStore,
     claudeSubscription,
@@ -1509,205 +1073,8 @@ function registerIpc(): void {
     syncGitHubCopilotConnection,
     emitConnectionListChanged,
   });
-
   registerWebSearchIpc({ settingsStore, getWorkspacePrivacyContext });
-
-  ipcMain.handle('search:thread', async (_event, request: unknown) => {
-    // PR-SEARCH-2 review fixup (@xuan `2f1aba55`): pass `unknown`
-    // through to the helper, which runs an object-shape guard and
-    // returns an `invalid_query` error envelope for null / non-object
-    // / missing-field payloads. Never throws across the IPC boundary.
-    //
-    // PR-SEARCH-2.5 (@xuan `2c55b975`): wire `getPrivacyContext` to
-    // the main-authority workspace privacy state.
-    //
-    // This is the main-owned workspace privacy source, not a renderer
-    // self-attestation. The helper validates whatever shape is returned
-    // via `validateWorkspacePrivacyContext`, so a future drift in
-    // authority source is automatically fail-closed.
-    return runThreadSearch(request, {
-      listSessions: () => runtime.listSessions(),
-      readMessages: (sessionId: string) => runtime.getMessages(sessionId),
-      getPrivacyContext: getWorkspacePrivacyContext,
-    });
-  });
-  ipcMain.handle('sessions:stop', async (_event, sessionId: string, input?: { source?: 'stop_button' }) => {
-    computerUseOverlay.clearForSession(sessionId);
-    computerUseTools.clearSession(sessionId);
-    await runtime.stopSession(sessionId, normalizeStopSessionInput(input));
-    emitSessionsChanged('status-change', sessionId);
-    emitSessionsChanged('turn-status-change', sessionId);
-    emitSessionsChanged('message-appended', sessionId);
-  });
-  ipcMain.handle('sessions:respondToPermission', (_event, sessionId: string, response) =>
-    runtime.respondToPermission(sessionId, normalizePermissionResponse(response)),
-  );
-  ipcMain.handle('sessions:respondToUserQuestion', (_event, sessionId: string, response) =>
-    runtime.respondToUserQuestion(sessionId, normalizeUserQuestionResponse(response)),
-  );
-  ipcMain.handle('sessions:send', async (event, sessionId: string, command: unknown) => {
-    const sendCommand = normalizeSessionSendCommand(command);
-    if (!sendCommand) return;
-    const { turnId, attachments } = await resolveSessionSend({
-      sessionId,
-      senderId: event.sender.id,
-      command: sendCommand,
-      ensureCanSend: ensureSessionCanSend,
-      readHeader: (id) => store.readHeader(id),
-      approvals: attachmentApprovals,
-      stat: async (path) => ({ size: (await stat(path)).size }),
-      artifactStore,
-      resizeImage: resizeImageForAttachment,
-    });
-    const iterator = runtime.sendMessage(sessionId, {
-      turnId,
-      text: sendCommand.text,
-      ...(attachments.length > 0 ? { attachments } : {}),
-    });
-    void streamEvents(sessionId, iterator, turnId);
-    return { turnId, attachments };
-  });
-  ipcMain.handle(
-    'attachments:pickFiles',
-    async (event): Promise<
-      | { ok: true; files: { approvalId: string; name: string; mimeType?: string; size: number }[] }
-      | { ok: false; reason: 'cancelled' }
-    > => {
-      const result = await mainWindowController.showOpenDialog({
-        title: '添加附件',
-        properties: ['openFile', 'multiSelections'],
-      });
-      if (result.canceled || !result.filePaths[0]) return { ok: false, reason: 'cancelled' };
-      const chosen = await Promise.all(
-        result.filePaths.map(async (path) => ({ path, name: basename(path), size: (await stat(path)).size })),
-      );
-      // Paths stay in main; the renderer only gets one-shot opaque tokens.
-      return { ok: true, files: attachmentApprovals.issueApprovals(event.sender.id, chosen) };
-    },
-  );
-  ipcMain.handle(
-    'attachments:readBytes',
-    async (_event, sessionId: string, relativePath: string): Promise<
-      | { ok: true; base64: string; mimeType: string }
-      | { ok: false; reason: string }
-    > => {
-      // Session-scoped read: only attachments filed under this session.
-      const record = await artifactStore.get(relativePath).catch(() => null);
-      if (!record || record.sessionId !== sessionId) return { ok: false, reason: 'not_found' };
-      const result = await artifactStore.readBinary(relativePath);
-      if (!result.ok) return result;
-      return { ok: true, base64: result.base64, mimeType: result.mimeType };
-    },
-  );
-  ipcMain.handle('sessions:compact', async (_event, sessionId: string) => {
-    await ensureSessionCanSend(sessionId);
-    const turnId = randomUUID();
-    void streamEvents(sessionId, runtime.compactSession(sessionId, { turnId }), turnId);
-  });
-  ipcMain.handle('sessions:regenerateTurn', async (_event, sessionId: string, input: unknown) => {
-    await ensureSessionCanSend(sessionId);
-    const normalized = normalizeRegenerateTurnInput(input);
-    const turnId = normalized.turnId ?? randomUUID();
-    void streamEvents(sessionId, runtime.regenerateTurn(sessionId, { ...normalized, turnId }), turnId);
-  });
-  ipcMain.handle('sessions:branchFromTurn', async (_event, sessionId: string, input: unknown) => {
-    const session = await runtime.branchFromTurn(sessionId, normalizeBranchFromTurnInput(input));
-    emitSessionsChanged('created', session.id);
-    return session;
-  });
-  ipcMain.handle('sessions:archive', async (_event, sessionId: string) => {
-    computerUseOverlay.clearForSession(sessionId);
-    computerUseTools.clearSession(sessionId);
-    await runtime.archive(sessionId);
-    // An archived conversation is no longer shown: drop its browser connection
-    // and view so it does not keep a live Chromium page in the background.
-    await releaseBrowserSession(sessionId);
-    // Stop any autonomous loops tied to the session (goal + polling heartbeats).
-    goalWiring.manager.remove(sessionId);
-    automationWiring.manager.removeAllForSession(sessionId);
-    emitSessionsChanged('archived', sessionId);
-  });
-  ipcMain.handle('sessions:unarchive', async (_event, sessionId: string) => {
-    await runtime.unarchive(sessionId);
-    emitSessionsChanged('updated', sessionId);
-  });
-  ipcMain.handle('sessions:setFlagged', async (_event, sessionId: string, isFlagged: boolean) => {
-    await runtime.setFlagged(sessionId, isFlagged);
-    emitSessionsChanged('pinned', sessionId);
-  });
-  ipcMain.handle('sessions:rename', async (_event, sessionId: string, name: string) => {
-    await runtime.renameSession(sessionId, name);
-    emitSessionsChanged('renamed', sessionId);
-  });
-  ipcMain.handle('sessions:setPermissionMode', (_event, sessionId: string, mode: unknown) => {
-    if (!isPermissionMode(mode)) {
-      throw new Error(`Invalid permission mode: ${String(mode)}`);
-    }
-    return runtime.setPermissionMode(sessionId, mode).then((session) => {
-      emitSessionsChanged('mode-change', sessionId);
-      return session;
-    });
-  });
-  ipcMain.handle('sessions:setModel', async (_event, sessionId: string, input: unknown) => {
-    const { llmConnectionSlug, model } = normalizeSessionModelSelection(input);
-    const header = await store.readHeader(sessionId);
-    if (header.status === 'running') {
-      throw new Error('当前对话正在运行，等结束后再切换模型。');
-    }
-    if (header.status === 'waiting_for_user') {
-      throw new Error('当前有工具调用正在等待确认，处理后再切换模型。');
-    }
-    const ready = await getReadyConnection(llmConnectionSlug, model);
-    const next = await runtime.updateSession(sessionId, {
-      backend: 'ai-sdk',
-      llmConnectionSlug: ready.connection.slug,
-      model: ready.model,
-      // Switching model clears the per-model thinking variant (see model-thinking.ts).
-      thinkingLevel: undefined,
-      connectionLocked: true,
-      status: 'active',
-      blockedReason: undefined,
-      statusUpdatedAt: Date.now(),
-    });
-    emitSessionsChanged('updated', sessionId, {
-      connectionSlug: ready.connection.slug,
-      modelId: ready.model,
-    });
-    return next;
-  });
-  ipcMain.handle('sessions:setThinkingLevel', async (_event, sessionId: string, input: unknown) => {
-    const header = await store.readHeader(sessionId);
-    if (header.status === 'running') {
-      throw new Error('当前对话正在运行，等结束后再切换思考级别。');
-    }
-    if (header.status === 'waiting_for_user') {
-      throw new Error('当前有工具调用正在等待确认，处理后再切换思考级别。');
-    }
-    const connection = await connectionStore.get(header.llmConnectionSlug);
-    if (!connection) {
-      throw new Error(`Unknown connection: ${header.llmConnectionSlug}`);
-    }
-    const nextThinkingLevel = normalizeSupportedSessionThinkingLevel(input, connection.providerType, header.model);
-    const next = await runtime.updateSession(sessionId, nextThinkingLevel === undefined ? { thinkingLevel: undefined } : { thinkingLevel: nextThinkingLevel });
-    emitSessionsChanged('updated', sessionId);
-    return next;
-  });
-  ipcMain.handle('sessions:remove', async (_event, sessionId: string) => {
-    computerUseOverlay.clearForSession(sessionId);
-    computerUseTools.clearSession(sessionId);
-    await runtime.remove(sessionId);
-    // Drop the conversation's browser connection and destroy its view (no-op
-    // if it never opened one). releaseBrowserSession disposes the view via the
-    // host, covering both agent-driven and hand-opened views.
-    await releaseBrowserSession(sessionId);
-    // Stop any autonomous loops tied to the session (goal + polling heartbeats).
-    goalWiring.manager.remove(sessionId);
-    automationWiring.manager.removeAllForSession(sessionId);
-    emitSessionsChanged('deleted', sessionId);
-  });
-
   registerBrowserIpc({ mainWindowController });
-
   registerConnectionsIpc({
     connectionStore,
     credentialStore,
@@ -1716,214 +1083,31 @@ function registerIpc(): void {
     hasConnectionSecret,
     emitConnectionListChanged,
   });
-
-  // PR110b: Onboarding snapshot + milestone IPCs. Renderer polls via
-  // these on app load and whenever `sessions:changed` /
-  // `connections:changed` / settings change events fire. No push from
-  // main.
-  ipcMain.handle('onboarding:getSnapshot', async () => onboardingService.getSnapshot());
-  ipcMain.handle('onboarding:setMilestone', async (_event, id: unknown, status: unknown) => {
-    // Service throws INVALID_MILESTONE_ID / INVALID_MILESTONE_STATUS
-    // for bad inputs; let the error propagate so the renderer sees
-    // it as a typed reject rather than silently swallowing.
-    return onboardingService.setMilestone(id, status);
+  registerOnboardingIpc({ onboardingService });
+  registerSessionEntryIpc({
+    runtime,
+    getReadyConnection,
+    getCurrentProjectRoot: currentProjectRoot,
+    getOnboardingState: async () => (await onboardingService.getSnapshot()).state,
+    emitSessionsChanged,
+    ensureSessionCanSend,
+    streamEvents,
+    quickChatStart: (input) => handleQuickChatStart(input, currentProjectRoot),
   });
-  ipcMain.handle('onboarding:clearMilestone', async (_event, id: unknown) => {
-    return onboardingService.clearMilestone(id);
+  registerPermissionsIpc({
+    settingsStore,
+    connectionStore,
+    telemetryRepo,
+    botRegistry,
+    getComputerUseCapabilityInput: computerUseCapabilityInput,
   });
-  // PR110b: Quick Chat entry. Input shape is intentionally minimal —
-  // `{ prompt?: string }` — to keep readiness gating airtight. Override
-  // surfaces (connectionSlug / model) will land in PR110c/d when the
-  // model-picker UI is ready.
-  ipcMain.handle('quickChat:start', async (_event, input: unknown) => {
-    return handleQuickChatStart(input, currentProjectRoot);
+  registerSettingsIpc({
+    settingsStore,
+    botRegistry,
+    normalizeSettingsPatch,
+    applySettingsRuntimeEffects,
   });
-
-  // Expert teams: list the built-in teams and start a labeled team session.
-  // A team session is a normal session tagged `mode:expert-team:<teamId>`; the
-  // label activates the lead persona + expert_dispatch tool (see the backend
-  // factory). The lead runs read-only (explore) and dispatches read-only members.
-  ipcMain.handle('expertTeam:list', async () => ({
-    teams: listExpertTeams().map((team) => ({
-      id: team.id,
-      name: team.name,
-      description: team.description,
-      members: team.members.map((member) => ({
-        id: member.id,
-        name: member.name,
-        description: member.description,
-        ...(member.whenToUse ? { whenToUse: member.whenToUse } : {}),
-      })),
-    })),
-  }));
-  ipcMain.handle('expertTeam:start', async (_event, input: unknown) => {
-    return runExpertTeamStart(input, {
-      isKnownTeam: (teamId) => getExpertTeam(teamId) !== undefined,
-      getOnboardingState: async () => (await onboardingService.getSnapshot()).state,
-      createSession: async ({ teamId, defaultConnectionSlug, defaultModel }) => {
-        const ready = await getReadyConnection(defaultConnectionSlug, defaultModel);
-        const team = getExpertTeam(teamId);
-        return runtime.createSession({
-          cwd: await currentProjectRoot(),
-          backend: 'ai-sdk',
-          llmConnectionSlug: ready.connection.slug,
-          model: ready.model,
-          // Shipped teams are read-only review crews: the lead reads + dispatches
-          // read-only members, so the whole session stays in explore mode.
-          permissionMode: 'explore',
-          name: team ? team.name : 'Expert Team',
-          labels: [expertTeamLabel(teamId)],
-        });
-      },
-      emitCreated: (sessionId) => emitSessionsChanged('created', sessionId),
-      ensureCanSend: (sessionId) => ensureSessionCanSend(sessionId),
-      sendFirstMessage: async (sessionId, text) => {
-        const turnId = randomUUID();
-        const iterator = runtime.sendMessage(sessionId, { turnId, text });
-        void streamEvents(sessionId, iterator, turnId);
-      },
-    });
-  });
-
-  ipcMain.handle('permissions:getSnapshot', () => buildPermissionSnapshot());
-  ipcMain.handle('permissions:openSystemSettings', async (_event, permId: unknown) => {
-    return openSystemPermissionPane(permId);
-  });
-  ipcMain.handle('permissions:requestAccess', async (_event, permId: unknown) => {
-    return requestPermissionAccess(permId);
-  });
-  ipcMain.handle('capabilities:getSnapshot', async () => {
-    const permissions = buildPermissionSnapshot();
-    const settings = await settingsStore.get();
-    const officeCliProbe = await probeOfficeCli({ now: permissions.checkedAt });
-    return buildCapabilitySnapshotCollection({
-      settings,
-      permissions,
-      botStatuses: botRegistry.allStatuses(),
-      officeCliProbe,
-      computerUse: computerUseCapabilityInput(),
-      now: permissions.checkedAt,
-    });
-  });
-  ipcMain.handle('health:getSnapshot', async () => {
-    const now = Date.now();
-    const permissions = buildPermissionSnapshot(now);
-    const settings = await settingsStore.get();
-    const officeCliProbe = await probeOfficeCli({ now });
-    const capabilitySnapshot = buildCapabilitySnapshotCollection({
-      settings,
-      permissions,
-      botStatuses: botRegistry.allStatuses(),
-      officeCliProbe,
-      computerUse: computerUseCapabilityInput(),
-      now,
-    });
-    const connections = await connectionStore.list();
-    const connectionSignals = connections.flatMap((connection) => [
-      healthSignalFromConnection(connection, now),
-      healthSignalFromConnectionRuntime(
-        connection,
-        telemetryRepo.latestLlmRuntimeProbe(connection.slug, connection.defaultModel),
-        now,
-      ),
-    ].filter((signal): signal is NonNullable<typeof signal> => Boolean(signal)));
-    return buildHealthSnapshot(now, [
-      ...connectionSignals,
-      ...capabilitySnapshot.capabilities.map(healthSignalFromCapability),
-    ]);
-  });
-
-  ipcMain.handle('settings:get', async () => maskAppSettings(await settingsStore.get()));
-  ipcMain.handle('settings:update', async (_event, patch: UpdateAppSettingsInput): Promise<UpdateAppSettingsResult> => {
-    const normalizedPatch = await normalizeSettingsPatch(patch);
-    const next = await settingsStore.update(normalizedPatch);
-    await applySettingsRuntimeEffects(next, patch);
-    return buildSettingsUpdateResult(next, patch);
-  });
-  ipcMain.handle('gateway:status', async () => openGateway.getStatus());
-  ipcMain.handle('settings:testNetworkProxy', async (_event, input: TestProxyInput = {}) => {
-    const started = Date.now();
-    const stored = toContractNetworkSettings((await settingsStore.get()).network).proxy;
-    const proxy = input.proxy?.password === SENSITIVE_PLACEHOLDER
-      ? { ...input.proxy, password: stored.password }
-      : input.proxy;
-    const testedProxy = proxy ?? stored;
-    const result = await testProxyConnection({ ...input, proxy }, stored);
-    const latencyMs = result.latencyMs ?? (Date.now() - started);
-    if (!result.ok) {
-      return {
-        ok: false,
-        message: proxyTestFailureMessage(result),
-        latencyMs,
-      } satisfies SettingsTestResult;
-    }
-    return {
-      ok: true,
-      message: result.ip
-        ? `代理配置有效：${testedProxy.type}://${testedProxy.host}:${testedProxy.port} · ${result.countryFlag ?? ''} ${result.ip}`.trim()
-        : `代理配置有效：${testedProxy.type}://${testedProxy.host}:${testedProxy.port}`,
-      latencyMs,
-      details: {
-        status: result.status,
-        ip: result.ip,
-        countryCode: result.countryCode,
-        countryFlag: result.countryFlag,
-        bypassList: testedProxy.bypassList,
-      },
-    } satisfies SettingsTestResult;
-  });
-  ipcMain.handle('settings:testBotChannel', async (_event, provider: BotProvider) => {
-    const settings = await settingsStore.get();
-    const result = await testRuntimeBotChannel(provider, settings.botChat.channels[provider]);
-    await settingsStore.update({
-      botChat: {
-        channels: {
-          [provider]: {
-            connected: result.ok,
-            readiness: result.ok ? 'credentials_valid' : 'configured',
-            readinessReason: result.ok ? undefined : botTestErrorMessage(provider, result.error),
-            readinessUpdatedAt: Date.now(),
-            lastTestAt: Date.now(),
-            lastError: result.ok ? undefined : botTestErrorMessage(provider, result.error),
-          },
-        },
-      },
-    });
-    const next = await settingsStore.get();
-    await applySettingsRuntimeEffects(next, { botChat: { channels: { [provider]: {} } } });
-    return toSettingsTestResult(provider, result);
-  });
-  ipcMain.handle('settings:bots:listStatuses', () =>
-    tryResult(async () => botRegistry.allStatuses(), 'BOTS_STATUS_FAILED'),
-  );
-  ipcMain.handle('settings:bots:restart', (_event, provider: BotProvider) =>
-    tryResult(async () => {
-      const settings = await settingsStore.get();
-      await botRegistry.applySettings(settings.botChat);
-      return botRegistry.getStatus(provider);
-    }, 'BOTS_RESTART_FAILED'),
-  );
-
-  // PR-BOT-WECHAT-QR-MODAL-0 (WAWQAQ msg `10ec1fbe`): WeChat ClawBot
-  // scan-login. Renderer triggers the QR fetch from the modal, then
-  // polls the status endpoint until 'confirmed' or 'expired'. Main
-  // process owns the actual HTTP calls so the renderer never sees
-  // raw response bodies.
-  ipcMain.handle('settings:bots:wechat:fetchQrcode', () =>
-    tryWeChatQrResult(async () => fetchWeChatQrcode(), 'WECHAT_QR_FETCH_FAILED'),
-  );
-  ipcMain.handle('settings:bots:wechat:pollQrcodeStatus', (_event, qrToken: unknown) =>
-    tryWeChatQrResult(async () => {
-      if (typeof qrToken !== 'string' || !qrToken) {
-        throw new Error('qrToken must be a non-empty string');
-      }
-      return pollWeChatQrcodeStatus(qrToken);
-    }, 'WECHAT_QR_STATUS_FAILED'),
-  );
-  ipcMain.handle('settings:bots:wechatQrCode', async () => {
-    const settings = await settingsStore.get();
-    return getWechatBridgeQrCode(settings.botChat.channels.wechat);
-  });
+  registerGatewayIpc({ openGateway });
   registerDailyReviewIpc({ dailyReview, dailyReviewArchiveStore, mainWindowController });
   registerUsageIpc({
     settingsStore,
@@ -1933,7 +1117,6 @@ function registerIpc(): void {
     },
     sendToRenderer: safeSendToRenderer,
   });
-
 }
 
 function canCreateFakeSessionFromRenderer(): boolean {
@@ -2076,14 +1259,6 @@ function isStatusChangingSessionEvent(event: SessionEvent): boolean {
     event.type === 'error';
 }
 
-function latestStoredMessageTs(messages: readonly StoredMessage[]): number | undefined {
-  let latest: number | undefined;
-  for (const message of messages) {
-    if (Number.isFinite(message.ts)) latest = latest === undefined ? message.ts : Math.max(latest, message.ts);
-  }
-  return latest;
-}
-
 function isTurnStatusChangingSessionEvent(event: SessionEvent): boolean {
   return event.type === 'complete' || event.type === 'abort' || event.type === 'error';
 }
@@ -2123,22 +1298,6 @@ const readyConnectionDeps = {
 
 function getReadyConnection(slug: string | null | undefined, model?: string) {
   return requireReadyConnection(slug, readyConnectionDeps, model);
-}
-
-function normalizeSupportedSessionThinkingLevel(
-  input: unknown,
-  providerType: ProviderType,
-  model: string,
-): ThinkingLevel | undefined {
-  const thinkingLevel = input === undefined || input === null ? undefined : input;
-  if (thinkingLevel === undefined) return undefined;
-  if (!isThinkingLevel(thinkingLevel)) {
-    throw new Error(`Invalid thinking level: ${String(input)}`);
-  }
-  if (!thinkingVariantsForModel(providerType, model).includes(thinkingLevel)) {
-    throw new Error(`当前模型不支持思考级别：${thinkingLevel}`);
-  }
-  return thinkingLevel;
 }
 
 /**
@@ -2215,22 +1374,6 @@ function emitSessionsChanged(
   if (extra?.connectionSlug) event.connectionSlug = extra.connectionSlug;
   if (extra?.modelId) event.modelId = extra.modelId;
   safeSendToRenderer('sessions:changed', event);
-}
-
-function normalizeSessionModelSelection(input: unknown): { llmConnectionSlug: string; model: string } {
-  if (!input || typeof input !== 'object') {
-    throw new Error('Invalid model selection');
-  }
-  const record = input as Record<string, unknown>;
-  const llmConnectionSlug = typeof record.llmConnectionSlug === 'string' ? record.llmConnectionSlug.trim() : '';
-  const model = typeof record.model === 'string' ? record.model.trim() : '';
-  if (!llmConnectionSlug) {
-    throw new Error('Missing model connection');
-  }
-  if (!model) {
-    throw new Error('Missing model');
-  }
-  return { llmConnectionSlug, model };
 }
 
 async function recoverInterruptedSessionsOnStartup(): Promise<void> {

--- a/apps/desktop/src/main/network-settings-main.ts
+++ b/apps/desktop/src/main/network-settings-main.ts
@@ -1,10 +1,8 @@
-import type { AppSettings, UpdateAppSettingsInput } from '@maka/core';
+import type { AppSettings } from '@maka/core';
 import {
   NETWORK_DEFAULTS,
-  applySensitivePatch,
   maskSensitive,
   type NetworkSettings as ContractNetworkSettings,
-  type ProxySettings,
 } from '@maka/core/settings/network-settings';
 
 type StoredNetworkSettings = AppSettings['network'];
@@ -26,41 +24,7 @@ export function toContractNetworkSettings(network: StoredNetworkSettings): Contr
   };
 }
 
-export function toAppNetworkPatch(network: ContractNetworkSettings): NonNullable<UpdateAppSettingsInput['network']> {
-  return {
-    proxy: {
-      enabled: network.proxy.enabled,
-      protocol: network.proxy.type,
-      host: network.proxy.host,
-      port: network.proxy.port,
-      authEnabled: Boolean(network.proxy.username || network.proxy.password),
-      username: network.proxy.username ?? '',
-      password: typeof network.proxy.password === 'string' ? network.proxy.password : '',
-      bypassList: network.proxy.bypassList,
-    },
-  };
-}
 
-export function applyNetworkPatch(
-  prev: ContractNetworkSettings,
-  patch: Partial<ContractNetworkSettings>,
-): ContractNetworkSettings {
-  const proxyPatch: Partial<ProxySettings> = patch.proxy ?? {};
-  const nextProxy: ProxySettings = {
-    ...prev.proxy,
-    ...stripUndefined(proxyPatch),
-    password: applySensitivePatch(
-      typeof prev.proxy.password === 'string' ? prev.proxy.password : undefined,
-      proxyPatch.password,
-    ),
-    bypassList: Array.isArray(proxyPatch.bypassList) ? proxyPatch.bypassList : prev.proxy.bypassList,
-  };
-  return {
-    ...prev,
-    ...stripUndefined(patch),
-    proxy: nextProxy,
-  };
-}
 
 export function maskNetworkSettings(settings: ContractNetworkSettings): ContractNetworkSettings {
   return {
@@ -72,6 +36,3 @@ export function maskNetworkSettings(settings: ContractNetworkSettings): Contract
   };
 }
 
-function stripUndefined<T extends Record<string, unknown>>(value: T): Partial<T> {
-  return Object.fromEntries(Object.entries(value).filter(([, entry]) => entry !== undefined)) as Partial<T>;
-}

--- a/apps/desktop/src/main/onboarding-ipc-main.ts
+++ b/apps/desktop/src/main/onboarding-ipc-main.ts
@@ -1,0 +1,23 @@
+import { ipcMain } from 'electron';
+import type { createOnboardingService } from './onboarding-service.js';
+
+export interface OnboardingIpcDeps {
+  onboardingService: ReturnType<typeof createOnboardingService>;
+}
+
+export function registerOnboardingIpc(deps: OnboardingIpcDeps): void {
+  // PR110b: Onboarding snapshot + milestone IPCs. Renderer polls via
+  // these on app load and whenever `sessions:changed` /
+  // `connections:changed` / settings change events fire. No push from
+  // main.
+  ipcMain.handle('onboarding:getSnapshot', async () => deps.onboardingService.getSnapshot());
+  ipcMain.handle('onboarding:setMilestone', async (_event, id: unknown, status: unknown) => {
+    // Service throws INVALID_MILESTONE_ID / INVALID_MILESTONE_STATUS
+    // for bad inputs; let the error propagate so the renderer sees
+    // it as a typed reject rather than silently swallowing.
+    return deps.onboardingService.setMilestone(id, status);
+  });
+  ipcMain.handle('onboarding:clearMilestone', async (_event, id: unknown) => {
+    return deps.onboardingService.clearMilestone(id);
+  });
+}

--- a/apps/desktop/src/main/permissions-ipc-main.ts
+++ b/apps/desktop/src/main/permissions-ipc-main.ts
@@ -1,0 +1,78 @@
+import { ipcMain } from 'electron';
+import {
+  buildHealthSnapshot,
+  healthSignalFromCapability,
+  healthSignalFromConnection,
+  healthSignalFromConnectionRuntime,
+} from '@maka/core';
+import type { BotRegistry } from '@maka/runtime';
+import type { ConnectionStore, SettingsStore } from '@maka/storage';
+import type { createTelemetryRepo } from '@maka/storage';
+import { buildCapabilitySnapshotCollection, buildPermissionSnapshot } from './capability-snapshot.js';
+import { openSystemPermissionPane, requestPermissionAccess } from './permissions-actions.js';
+import { probeOfficeCli } from './officecli-probe.js';
+
+type TelemetryRepo = ReturnType<typeof createTelemetryRepo>;
+type ComputerUseCapabilityInput = NonNullable<
+  Parameters<typeof buildCapabilitySnapshotCollection>[0]['computerUse']
+>;
+
+export interface PermissionsIpcDeps {
+  settingsStore: SettingsStore;
+  connectionStore: ConnectionStore;
+  telemetryRepo: TelemetryRepo;
+  botRegistry: BotRegistry;
+  getComputerUseCapabilityInput: () => ComputerUseCapabilityInput;
+}
+
+export function registerPermissionsIpc(deps: PermissionsIpcDeps): void {
+  const { settingsStore, connectionStore, telemetryRepo, botRegistry, getComputerUseCapabilityInput } = deps;
+
+  ipcMain.handle('permissions:getSnapshot', () => buildPermissionSnapshot());
+  ipcMain.handle('permissions:openSystemSettings', async (_event, permId: unknown) => {
+    return openSystemPermissionPane(permId);
+  });
+  ipcMain.handle('permissions:requestAccess', async (_event, permId: unknown) => {
+    return requestPermissionAccess(permId);
+  });
+  ipcMain.handle('capabilities:getSnapshot', async () => {
+    const permissions = buildPermissionSnapshot();
+    const settings = await settingsStore.get();
+    const officeCliProbe = await probeOfficeCli({ now: permissions.checkedAt });
+    return buildCapabilitySnapshotCollection({
+      settings,
+      permissions,
+      botStatuses: botRegistry.allStatuses(),
+      officeCliProbe,
+      computerUse: getComputerUseCapabilityInput(),
+      now: permissions.checkedAt,
+    });
+  });
+  ipcMain.handle('health:getSnapshot', async () => {
+    const now = Date.now();
+    const permissions = buildPermissionSnapshot(now);
+    const settings = await settingsStore.get();
+    const officeCliProbe = await probeOfficeCli({ now });
+    const capabilitySnapshot = buildCapabilitySnapshotCollection({
+      settings,
+      permissions,
+      botStatuses: botRegistry.allStatuses(),
+      officeCliProbe,
+      computerUse: getComputerUseCapabilityInput(),
+      now,
+    });
+    const connections = await connectionStore.list();
+    const connectionSignals = connections.flatMap((connection) => [
+      healthSignalFromConnection(connection, now),
+      healthSignalFromConnectionRuntime(
+        connection,
+        telemetryRepo.latestLlmRuntimeProbe(connection.slug, connection.defaultModel),
+        now,
+      ),
+    ].filter((signal): signal is NonNullable<typeof signal> => Boolean(signal)));
+    return buildHealthSnapshot(now, [
+      ...connectionSignals,
+      ...capabilitySnapshot.capabilities.map(healthSignalFromCapability),
+    ]);
+  });
+}

--- a/apps/desktop/src/main/project-root-controller.ts
+++ b/apps/desktop/src/main/project-root-controller.ts
@@ -1,0 +1,94 @@
+import { readFile, stat, writeFile } from 'node:fs/promises';
+import { resolveProjectRoot } from '@maka/runtime';
+
+/**
+ * Owns the "current project root" selection shared across the app/window,
+ * git, workspace-search, workspace-instructions, and session-entry IPC
+ * surfaces. The selection is a single mutable authority: the app IPC module
+ * updates it through `setSelected` when the user picks a directory, and every
+ * other surface reads it through `current`.
+ *
+ * Extracted verbatim from the former `registerIpc()` closures so the state has
+ * one owner once the handlers are split across modules; behavior is unchanged.
+ */
+export interface ProjectRootController {
+  /** Resolve the effective project root (selected → persisted → fallback). */
+  current(): Promise<string>;
+  /** Validate + resolve an explicit renderer-supplied path without selecting it. */
+  resolveExplicit(
+    projectPath: unknown,
+  ): Promise<
+    | { ok: true; projectPath: string }
+    | { ok: false; reason: 'invalid-path' | 'not-found' }
+  >;
+  /** Adopt a resolved project root as the active selection and persist it. */
+  setSelected(projectPath: string): void;
+}
+
+export interface ProjectRootControllerDeps {
+  /** Absolute path of the JSON file that persists the last selected project. */
+  lastProjectPathFile: string;
+  /** Roots probed (in order) when nothing is selected or persisted. */
+  fallbackRoots: () => string[];
+}
+
+export function createProjectRootController(
+  deps: ProjectRootControllerDeps,
+): ProjectRootController {
+  let selectedProjectRoot: string | null = null;
+
+  async function loadPersistedProjectRoot(): Promise<string | null> {
+    try {
+      const raw = await readFile(deps.lastProjectPathFile, 'utf8');
+      const parsed = JSON.parse(raw) as Record<string, unknown>;
+      if (typeof parsed.projectPath === 'string' && parsed.projectPath) {
+        await stat(parsed.projectPath);
+        return await resolveProjectRoot([parsed.projectPath]);
+      }
+    } catch {
+      // File missing, invalid, or points at a deleted directory.
+    }
+    return null;
+  }
+  const persistedProjectRootPromise = loadPersistedProjectRoot();
+
+  async function saveLastProjectPath(projectPath: string): Promise<void> {
+    try {
+      await writeFile(deps.lastProjectPathFile, JSON.stringify({ projectPath }), 'utf8');
+    } catch {
+      // Best-effort; failure should not block the selection.
+    }
+  }
+
+  async function current(): Promise<string> {
+    if (selectedProjectRoot) return selectedProjectRoot;
+    const persistedProjectRoot = await persistedProjectRootPromise;
+    if (persistedProjectRoot) {
+      selectedProjectRoot = persistedProjectRoot;
+      return persistedProjectRoot;
+    }
+    return resolveProjectRoot(deps.fallbackRoots());
+  }
+
+  async function resolveExplicit(projectPath: unknown): Promise<
+    | { ok: true; projectPath: string }
+    | { ok: false; reason: 'invalid-path' | 'not-found' }
+  > {
+    if (typeof projectPath !== 'string' || !projectPath) {
+      return { ok: false, reason: 'invalid-path' };
+    }
+    try {
+      await stat(projectPath);
+    } catch {
+      return { ok: false, reason: 'not-found' };
+    }
+    return { ok: true, projectPath: await resolveProjectRoot([projectPath]) };
+  }
+
+  function setSelected(projectPath: string): void {
+    selectedProjectRoot = projectPath;
+    void saveLastProjectPath(projectPath);
+  }
+
+  return { current, resolveExplicit, setSelected };
+}

--- a/apps/desktop/src/main/session-entry-ipc-main.ts
+++ b/apps/desktop/src/main/session-entry-ipc-main.ts
@@ -1,0 +1,87 @@
+import { randomUUID } from 'node:crypto';
+import { ipcMain } from 'electron';
+import {
+  getExpertTeam,
+  listExpertTeams,
+} from '@maka/runtime';
+import type { SessionManager } from '@maka/runtime';
+import { expertTeamLabel } from '@maka/core';
+import type { OnboardingState, SessionEvent } from '@maka/core';
+import { handleExpertTeamStart as runExpertTeamStart } from './expert-team-start.js';
+import type { QuickChatResult } from './quick-chat.js';
+import type { requireReadyConnection } from './chat-readiness.js';
+
+export interface SessionEntryIpcDeps {
+  runtime: SessionManager;
+  getReadyConnection: (
+    slug: string | null | undefined,
+    model?: string,
+  ) => ReturnType<typeof requireReadyConnection>;
+  getCurrentProjectRoot: () => Promise<string>;
+  getOnboardingState: () => Promise<OnboardingState>;
+  emitSessionsChanged: (reason: 'created', sessionId: string) => void;
+  ensureSessionCanSend: (sessionId: string) => Promise<void>;
+  streamEvents: (
+    sessionId: string,
+    iterator: AsyncIterable<SessionEvent>,
+    fallbackTurnId?: string,
+  ) => Promise<{ turnId: string; ok: boolean; error?: string }>;
+  /** Quick Chat entry — thin adapter over the extracted `quick-chat.ts` helper. */
+  quickChatStart: (rawInput: unknown) => Promise<QuickChatResult>;
+}
+
+export function registerSessionEntryIpc(deps: SessionEntryIpcDeps): void {
+  // PR110b: Quick Chat entry. Input shape is intentionally minimal —
+  // `{ prompt?: string }` — to keep readiness gating airtight. Override
+  // surfaces (connectionSlug / model) will land in PR110c/d when the
+  // model-picker UI is ready.
+  ipcMain.handle('quickChat:start', async (_event, input: unknown) => {
+    return deps.quickChatStart(input);
+  });
+
+  // Expert teams: list the built-in teams and start a labeled team session.
+  // A team session is a normal session tagged `mode:expert-team:<teamId>`; the
+  // label activates the lead persona + expert_dispatch tool (see the backend
+  // factory). The lead runs read-only (explore) and dispatches read-only members.
+  ipcMain.handle('expertTeam:list', async () => ({
+    teams: listExpertTeams().map((team) => ({
+      id: team.id,
+      name: team.name,
+      description: team.description,
+      members: team.members.map((member) => ({
+        id: member.id,
+        name: member.name,
+        description: member.description,
+        ...(member.whenToUse ? { whenToUse: member.whenToUse } : {}),
+      })),
+    })),
+  }));
+  ipcMain.handle('expertTeam:start', async (_event, input: unknown) => {
+    return runExpertTeamStart(input, {
+      isKnownTeam: (teamId) => getExpertTeam(teamId) !== undefined,
+      getOnboardingState: () => deps.getOnboardingState(),
+      createSession: async ({ teamId, defaultConnectionSlug, defaultModel }) => {
+        const ready = await deps.getReadyConnection(defaultConnectionSlug, defaultModel);
+        const team = getExpertTeam(teamId);
+        return deps.runtime.createSession({
+          cwd: await deps.getCurrentProjectRoot(),
+          backend: 'ai-sdk',
+          llmConnectionSlug: ready.connection.slug,
+          model: ready.model,
+          // Shipped teams are read-only review crews: the lead reads + dispatches
+          // read-only members, so the whole session stays in explore mode.
+          permissionMode: 'explore',
+          name: team ? team.name : 'Expert Team',
+          labels: [expertTeamLabel(teamId)],
+        });
+      },
+      emitCreated: (sessionId) => deps.emitSessionsChanged('created', sessionId),
+      ensureCanSend: (sessionId) => deps.ensureSessionCanSend(sessionId),
+      sendFirstMessage: async (sessionId, text) => {
+        const turnId = randomUUID();
+        const iterator = deps.runtime.sendMessage(sessionId, { turnId, text });
+        void deps.streamEvents(sessionId, iterator, turnId);
+      },
+    });
+  });
+}

--- a/apps/desktop/src/main/sessions-ipc-main.ts
+++ b/apps/desktop/src/main/sessions-ipc-main.ts
@@ -1,0 +1,431 @@
+import { randomUUID } from 'node:crypto';
+import { basename } from 'node:path';
+import { stat } from 'node:fs/promises';
+import { ipcMain } from 'electron';
+import {
+  isPermissionMode,
+  isThinkingLevel,
+  sanitizeTaskLedgerTask,
+  thinkingVariantsForModel,
+} from '@maka/core';
+import type {
+  CreateSessionInput,
+  SessionEvent,
+  SessionChangedEvent,
+  SessionChangedReason,
+  SessionListFilter,
+  StoredMessage,
+  ThinkingLevel,
+} from '@maka/core';
+import type { ProviderType } from '@maka/core/llm-connections';
+import type { WorkspacePrivacyContext } from '@maka/core/incognito';
+import type { SessionManager } from '@maka/runtime';
+import type { createArtifactStore, createSessionStore } from '@maka/storage';
+import type { ConnectionStore, SettingsStore } from '@maka/storage';
+import { runThreadSearch } from './search/thread-search.js';
+import { resolveSessionSend } from './session-send-resolve.js';
+import { resizeImageForAttachment } from './attachment-resize-native.js';
+import { releaseBrowserSession } from './browser/session.js';
+import { sessionReadMessagesFailureMessage } from './session-read-error-copy.js';
+import { resolveDefaultPermissionMode } from './permission-mode-default.js';
+import {
+  normalizeBranchFromTurnInput,
+  normalizePermissionResponse,
+  normalizeRegenerateTurnInput,
+  normalizeSessionSendCommand,
+  normalizeStopSessionInput,
+  normalizeUserQuestionResponse,
+} from './permission-response-guard.js';
+import { getVisualSmokeState, type resolveVisualSmokeFixture } from './visual-smoke-fixture.js';
+import type { requireReadyConnection } from './chat-readiness.js';
+import type { MainTaskLedgerWiring } from './task-ledger-wiring.js';
+import type { MainGoalWiring } from './goal-wiring.js';
+import type { MainAutomationWiring } from './automation-wiring.js';
+import type { AttachmentApprovalRegistry } from './attachment-approval.js';
+import type { createMainWindowController } from './main-window.js';
+
+type SessionStore = ReturnType<typeof createSessionStore>;
+type ArtifactStore = ReturnType<typeof createArtifactStore>;
+type MainWindowController = ReturnType<typeof createMainWindowController>;
+type VisualSmokeFixture = ReturnType<typeof resolveVisualSmokeFixture>;
+
+/** The per-session cleanup subset of the cursor-overlay controller. */
+interface SessionOverlayCleanup {
+  clearForSession(sessionId: string): void;
+}
+/** The per-session cleanup subset of the computer-use tool group. */
+interface SessionToolCleanup {
+  clearSession(sessionId: string): void;
+}
+
+export interface SessionsIpcDeps {
+  runtime: SessionManager;
+  store: SessionStore;
+  taskLedgerStore: MainTaskLedgerWiring['store'];
+  goalManager: MainGoalWiring['manager'];
+  automationManager: MainAutomationWiring['manager'];
+  computerUseOverlay: SessionOverlayCleanup;
+  computerUseTools: SessionToolCleanup;
+  artifactStore: ArtifactStore;
+  attachmentApprovals: AttachmentApprovalRegistry;
+  settingsStore: SettingsStore;
+  connectionStore: ConnectionStore;
+  mainWindowController: MainWindowController;
+  visualSmokeFixture: VisualSmokeFixture;
+  emitSessionsChanged: (
+    reason: SessionChangedReason,
+    sessionId?: string,
+    extra?: Pick<SessionChangedEvent, 'connectionSlug' | 'modelId'>,
+  ) => void;
+  ensureSessionCanSend: (sessionId: string) => Promise<void>;
+  getReadyConnection: (
+    slug: string | null | undefined,
+    model?: string,
+  ) => ReturnType<typeof requireReadyConnection>;
+  streamEvents: (
+    sessionId: string,
+    iterator: AsyncIterable<SessionEvent>,
+    fallbackTurnId?: string,
+  ) => Promise<{ turnId: string; ok: boolean; error?: string }>;
+  getCurrentProjectRoot: () => Promise<string>;
+  getWorkspacePrivacyContext: () => Promise<WorkspacePrivacyContext>;
+  canCreateFakeSession: () => boolean;
+}
+
+function latestStoredMessageTs(messages: readonly StoredMessage[]): number | undefined {
+  let latest: number | undefined;
+  for (const message of messages) {
+    if (Number.isFinite(message.ts)) latest = latest === undefined ? message.ts : Math.max(latest, message.ts);
+  }
+  return latest;
+}
+
+function normalizeSessionModelSelection(input: unknown): { llmConnectionSlug: string; model: string } {
+  if (!input || typeof input !== 'object') {
+    throw new Error('Invalid model selection');
+  }
+  const record = input as Record<string, unknown>;
+  const llmConnectionSlug = typeof record.llmConnectionSlug === 'string' ? record.llmConnectionSlug.trim() : '';
+  const model = typeof record.model === 'string' ? record.model.trim() : '';
+  if (!llmConnectionSlug) {
+    throw new Error('Missing model connection');
+  }
+  if (!model) {
+    throw new Error('Missing model');
+  }
+  return { llmConnectionSlug, model };
+}
+
+function normalizeSupportedSessionThinkingLevel(
+  input: unknown,
+  providerType: ProviderType,
+  model: string,
+): ThinkingLevel | undefined {
+  const thinkingLevel = input === undefined || input === null ? undefined : input;
+  if (thinkingLevel === undefined) return undefined;
+  if (!isThinkingLevel(thinkingLevel)) {
+    throw new Error(`Invalid thinking level: ${String(input)}`);
+  }
+  if (!thinkingVariantsForModel(providerType, model).includes(thinkingLevel)) {
+    throw new Error(`当前模型不支持思考级别：${thinkingLevel}`);
+  }
+  return thinkingLevel;
+}
+
+export function registerSessionsIpc(deps: SessionsIpcDeps): void {
+  const {
+    runtime,
+    store,
+    taskLedgerStore,
+    goalManager,
+    automationManager,
+    computerUseOverlay,
+    computerUseTools,
+    artifactStore,
+    attachmentApprovals,
+    settingsStore,
+    connectionStore,
+    mainWindowController,
+    visualSmokeFixture,
+    emitSessionsChanged,
+    ensureSessionCanSend,
+    getReadyConnection,
+    streamEvents,
+    getWorkspacePrivacyContext,
+    canCreateFakeSession,
+  } = deps;
+  const currentProjectRoot = deps.getCurrentProjectRoot;
+
+  ipcMain.handle('shell-runs:list', (_event, sessionId: string) => runtime.listShellRunUpdates(sessionId));
+  ipcMain.handle('tasks:list', async (_event, sessionId: string) => {
+    const tasks = await taskLedgerStore.list(sessionId, {
+      includeTerminal: true,
+      includeArchived: false,
+      classifyResumeTrust: true,
+      ...(visualSmokeFixture ? { now: getVisualSmokeState(visualSmokeFixture)?.now ?? Date.now() } : {}),
+    });
+    return tasks.map(sanitizeTaskLedgerTask);
+  });
+  ipcMain.handle('sessions:list', (_event, filter?: SessionListFilter) => runtime.listSessions(filter));
+  ipcMain.handle('sessions:create', async (_event, input?: Partial<CreateSessionInput>) => {
+    const cwd = input?.cwd ?? (await currentProjectRoot());
+    if (input?.backend === 'fake') {
+      if (!canCreateFakeSession()) {
+        throw new Error('FakeBackend sessions are only available in development.');
+      }
+      const session = await runtime.createSession({
+        cwd,
+        backend: 'fake',
+        llmConnectionSlug: input.llmConnectionSlug ?? 'fake',
+        model: input.model ?? 'fake-model',
+        permissionMode: input.permissionMode ?? (await resolveDefaultPermissionMode(() => settingsStore.get())),
+        name: input.name ?? 'New Chat',
+        labels: input.labels,
+      });
+      emitSessionsChanged('created', session.id);
+      return session;
+    }
+
+    const requestedSlug = input?.llmConnectionSlug ?? (await connectionStore.getDefault());
+    const { connection, model } = await getReadyConnection(requestedSlug, input?.model);
+    const thinkingLevel = normalizeSupportedSessionThinkingLevel(input?.thinkingLevel, connection.providerType, model);
+
+    const session = await runtime.createSession({
+      cwd,
+      backend: 'ai-sdk',
+      llmConnectionSlug: connection.slug,
+      model,
+      ...(thinkingLevel !== undefined ? { thinkingLevel } : {}),
+      permissionMode: input?.permissionMode ?? (await resolveDefaultPermissionMode(() => settingsStore.get())),
+      name: input?.name ?? 'New Chat',
+      labels: input?.labels,
+    });
+    emitSessionsChanged('created', session.id);
+    return session;
+  });
+  ipcMain.handle('sessions:readMessages', async (_event, sessionId: string) => {
+    if (visualSmokeFixture) return store.readMessages(sessionId);
+    let messages: StoredMessage[];
+    try {
+      messages = await runtime.getMessages(sessionId);
+    } catch (error) {
+      throw new Error(sessionReadMessagesFailureMessage(error));
+    }
+    try {
+      await runtime.markSessionRead(sessionId, latestStoredMessageTs(messages));
+    } catch {
+      // Reading the content already succeeded. Leave the persisted unread
+      // state for a later refresh instead of turning this into a load error.
+    }
+    return messages;
+  });
+  ipcMain.handle('sessions:listTurns', (_event, sessionId: string) => runtime.listTurns(sessionId));
+  // Goal kill-switch surface: the renderer reads the active goal to badge a
+  // session running an autonomous loop, and clears it to stop the loop. `get`
+  // returns null when no goal is set; `clear` settles it (continuation stops
+  // after the current turn). Both are pure local state, so no permission gate.
+  ipcMain.handle('goal:get', (_event, sessionId: string) => goalManager.get(sessionId) ?? null);
+  ipcMain.handle('goal:clear', (_event, sessionId: string) => {
+    goalManager.clear(sessionId);
+  });
+  // PR-SEARCH-2: local thread search. Renderer-facing channel; the pure
+  // helper in `./search/thread-search.ts` enforces all gates (G1 snippet
+  // redaction, G2 fake-backend exclude, G4 caps, G5 case-fold + NFC,
+  // G9 tool_result scan cap, G10 system/meta exclusion). The helper
+  // receives the runtime via DI so unit tests stay Electron-agnostic.
+  // We deliberately do NOT log the request body — query text never enters
+  // telemetry.
+  ipcMain.handle('search:thread', async (_event, request: unknown) => {
+    // PR-SEARCH-2 review fixup (@xuan `2f1aba55`): pass `unknown`
+    // through to the helper, which runs an object-shape guard and
+    // returns an `invalid_query` error envelope for null / non-object
+    // / missing-field payloads. Never throws across the IPC boundary.
+    //
+    // PR-SEARCH-2.5 (@xuan `2c55b975`): wire `getPrivacyContext` to
+    // the main-authority workspace privacy state.
+    //
+    // This is the main-owned workspace privacy source, not a renderer
+    // self-attestation. The helper validates whatever shape is returned
+    // via `validateWorkspacePrivacyContext`, so a future drift in
+    // authority source is automatically fail-closed.
+    return runThreadSearch(request, {
+      listSessions: () => runtime.listSessions(),
+      readMessages: (sessionId: string) => runtime.getMessages(sessionId),
+      getPrivacyContext: getWorkspacePrivacyContext,
+    });
+  });
+  ipcMain.handle('sessions:stop', async (_event, sessionId: string, input?: { source?: 'stop_button' }) => {
+    computerUseOverlay.clearForSession(sessionId);
+    computerUseTools.clearSession(sessionId);
+    await runtime.stopSession(sessionId, normalizeStopSessionInput(input));
+    emitSessionsChanged('status-change', sessionId);
+    emitSessionsChanged('turn-status-change', sessionId);
+    emitSessionsChanged('message-appended', sessionId);
+  });
+  ipcMain.handle('sessions:respondToPermission', (_event, sessionId: string, response) =>
+    runtime.respondToPermission(sessionId, normalizePermissionResponse(response)),
+  );
+  ipcMain.handle('sessions:respondToUserQuestion', (_event, sessionId: string, response) =>
+    runtime.respondToUserQuestion(sessionId, normalizeUserQuestionResponse(response)),
+  );
+  ipcMain.handle('sessions:send', async (event, sessionId: string, command: unknown) => {
+    const sendCommand = normalizeSessionSendCommand(command);
+    if (!sendCommand) return;
+    const { turnId, attachments } = await resolveSessionSend({
+      sessionId,
+      senderId: event.sender.id,
+      command: sendCommand,
+      ensureCanSend: ensureSessionCanSend,
+      readHeader: (id) => store.readHeader(id),
+      approvals: attachmentApprovals,
+      stat: async (path) => ({ size: (await stat(path)).size }),
+      artifactStore,
+      resizeImage: resizeImageForAttachment,
+    });
+    const iterator = runtime.sendMessage(sessionId, {
+      turnId,
+      text: sendCommand.text,
+      ...(attachments.length > 0 ? { attachments } : {}),
+    });
+    void streamEvents(sessionId, iterator, turnId);
+    return { turnId, attachments };
+  });
+  ipcMain.handle(
+    'attachments:pickFiles',
+    async (event): Promise<
+      | { ok: true; files: { approvalId: string; name: string; mimeType?: string; size: number }[] }
+      | { ok: false; reason: 'cancelled' }
+    > => {
+      const result = await mainWindowController.showOpenDialog({
+        title: '添加附件',
+        properties: ['openFile', 'multiSelections'],
+      });
+      if (result.canceled || !result.filePaths[0]) return { ok: false, reason: 'cancelled' };
+      const chosen = await Promise.all(
+        result.filePaths.map(async (path) => ({ path, name: basename(path), size: (await stat(path)).size })),
+      );
+      // Paths stay in main; the renderer only gets one-shot opaque tokens.
+      return { ok: true, files: attachmentApprovals.issueApprovals(event.sender.id, chosen) };
+    },
+  );
+  ipcMain.handle(
+    'attachments:readBytes',
+    async (_event, sessionId: string, relativePath: string): Promise<
+      | { ok: true; base64: string; mimeType: string }
+      | { ok: false; reason: string }
+    > => {
+      // Session-scoped read: only attachments filed under this session.
+      const record = await artifactStore.get(relativePath).catch(() => null);
+      if (!record || record.sessionId !== sessionId) return { ok: false, reason: 'not_found' };
+      const result = await artifactStore.readBinary(relativePath);
+      if (!result.ok) return result;
+      return { ok: true, base64: result.base64, mimeType: result.mimeType };
+    },
+  );
+  ipcMain.handle('sessions:compact', async (_event, sessionId: string) => {
+    await ensureSessionCanSend(sessionId);
+    const turnId = randomUUID();
+    void streamEvents(sessionId, runtime.compactSession(sessionId, { turnId }), turnId);
+  });
+  ipcMain.handle('sessions:regenerateTurn', async (_event, sessionId: string, input: unknown) => {
+    await ensureSessionCanSend(sessionId);
+    const normalized = normalizeRegenerateTurnInput(input);
+    const turnId = normalized.turnId ?? randomUUID();
+    void streamEvents(sessionId, runtime.regenerateTurn(sessionId, { ...normalized, turnId }), turnId);
+  });
+  ipcMain.handle('sessions:branchFromTurn', async (_event, sessionId: string, input: unknown) => {
+    const session = await runtime.branchFromTurn(sessionId, normalizeBranchFromTurnInput(input));
+    emitSessionsChanged('created', session.id);
+    return session;
+  });
+  ipcMain.handle('sessions:archive', async (_event, sessionId: string) => {
+    computerUseOverlay.clearForSession(sessionId);
+    computerUseTools.clearSession(sessionId);
+    await runtime.archive(sessionId);
+    // An archived conversation is no longer shown: drop its browser connection
+    // and view so it does not keep a live Chromium page in the background.
+    await releaseBrowserSession(sessionId);
+    // Stop any autonomous loops tied to the session (goal + polling heartbeats).
+    goalManager.remove(sessionId);
+    automationManager.removeAllForSession(sessionId);
+    emitSessionsChanged('archived', sessionId);
+  });
+  ipcMain.handle('sessions:unarchive', async (_event, sessionId: string) => {
+    await runtime.unarchive(sessionId);
+    emitSessionsChanged('updated', sessionId);
+  });
+  ipcMain.handle('sessions:setFlagged', async (_event, sessionId: string, isFlagged: boolean) => {
+    await runtime.setFlagged(sessionId, isFlagged);
+    emitSessionsChanged('pinned', sessionId);
+  });
+  ipcMain.handle('sessions:rename', async (_event, sessionId: string, name: string) => {
+    await runtime.renameSession(sessionId, name);
+    emitSessionsChanged('renamed', sessionId);
+  });
+  ipcMain.handle('sessions:setPermissionMode', (_event, sessionId: string, mode: unknown) => {
+    if (!isPermissionMode(mode)) {
+      throw new Error(`Invalid permission mode: ${String(mode)}`);
+    }
+    return runtime.setPermissionMode(sessionId, mode).then((session) => {
+      emitSessionsChanged('mode-change', sessionId);
+      return session;
+    });
+  });
+  ipcMain.handle('sessions:setModel', async (_event, sessionId: string, input: unknown) => {
+    const { llmConnectionSlug, model } = normalizeSessionModelSelection(input);
+    const header = await store.readHeader(sessionId);
+    if (header.status === 'running') {
+      throw new Error('当前对话正在运行，等结束后再切换模型。');
+    }
+    if (header.status === 'waiting_for_user') {
+      throw new Error('当前有工具调用正在等待确认，处理后再切换模型。');
+    }
+    const ready = await getReadyConnection(llmConnectionSlug, model);
+    const next = await runtime.updateSession(sessionId, {
+      backend: 'ai-sdk',
+      llmConnectionSlug: ready.connection.slug,
+      model: ready.model,
+      // Switching model clears the per-model thinking variant (see model-thinking.ts).
+      thinkingLevel: undefined,
+      connectionLocked: true,
+      status: 'active',
+      blockedReason: undefined,
+      statusUpdatedAt: Date.now(),
+    });
+    emitSessionsChanged('updated', sessionId, {
+      connectionSlug: ready.connection.slug,
+      modelId: ready.model,
+    });
+    return next;
+  });
+  ipcMain.handle('sessions:setThinkingLevel', async (_event, sessionId: string, input: unknown) => {
+    const header = await store.readHeader(sessionId);
+    if (header.status === 'running') {
+      throw new Error('当前对话正在运行，等结束后再切换思考级别。');
+    }
+    if (header.status === 'waiting_for_user') {
+      throw new Error('当前有工具调用正在等待确认，处理后再切换思考级别。');
+    }
+    const connection = await connectionStore.get(header.llmConnectionSlug);
+    if (!connection) {
+      throw new Error(`Unknown connection: ${header.llmConnectionSlug}`);
+    }
+    const nextThinkingLevel = normalizeSupportedSessionThinkingLevel(input, connection.providerType, header.model);
+    const next = await runtime.updateSession(sessionId, nextThinkingLevel === undefined ? { thinkingLevel: undefined } : { thinkingLevel: nextThinkingLevel });
+    emitSessionsChanged('updated', sessionId);
+    return next;
+  });
+  ipcMain.handle('sessions:remove', async (_event, sessionId: string) => {
+    computerUseOverlay.clearForSession(sessionId);
+    computerUseTools.clearSession(sessionId);
+    await runtime.remove(sessionId);
+    // Drop the conversation's browser connection and destroy its view (no-op
+    // if it never opened one). releaseBrowserSession disposes the view via the
+    // host, covering both agent-driven and hand-opened views.
+    await releaseBrowserSession(sessionId);
+    // Stop any autonomous loops tied to the session (goal + polling heartbeats).
+    goalManager.remove(sessionId);
+    automationManager.removeAllForSession(sessionId);
+    emitSessionsChanged('deleted', sessionId);
+  });
+}

--- a/apps/desktop/src/main/settings-ipc-main.ts
+++ b/apps/desktop/src/main/settings-ipc-main.ts
@@ -1,0 +1,160 @@
+import { ipcMain } from 'electron';
+import {
+  generalizedErrorMessageChinese,
+  redactSecrets,
+} from '@maka/core';
+import type {
+  AppSettings,
+  BotProvider,
+  SettingsTestResult,
+  UpdateAppSettingsInput,
+  UpdateAppSettingsResult,
+} from '@maka/core';
+import {
+  SENSITIVE_PLACEHOLDER,
+  type TestProxyInput,
+  type TestProxyResult,
+} from '@maka/core/settings/network-settings';
+import { err, ok, tryResult, type Result } from '@maka/core/settings/result';
+import {
+  getWechatBridgeQrCode,
+  testBotChannel as testRuntimeBotChannel,
+} from '@maka/runtime';
+import type { BotRegistry } from '@maka/runtime';
+import { testProxyConnection } from '@maka/runtime/network/proxy-test';
+import type { SettingsStore } from '@maka/storage';
+import { fetchWeChatQrcode, pollWeChatQrcodeStatus } from './wechat-scan-login.js';
+import { toContractNetworkSettings } from './network-settings-main.js';
+import {
+  botTestErrorMessage,
+  buildSettingsUpdateResult,
+  maskAppSettings,
+  toSettingsTestResult,
+} from './settings-ipc-helpers.js';
+
+export interface SettingsIpcDeps {
+  settingsStore: SettingsStore;
+  botRegistry: BotRegistry;
+  normalizeSettingsPatch: (patch: UpdateAppSettingsInput) => Promise<UpdateAppSettingsInput>;
+  applySettingsRuntimeEffects: (settings: AppSettings, patch: UpdateAppSettingsInput) => Promise<void>;
+}
+
+function proxyTestFailureMessage(result: TestProxyResult): string {
+  const raw = redactSecrets(result.error ?? '').trim();
+  const lower = raw.toLowerCase();
+  if (lower.includes('proxy disabled')) return '代理未启用，请先打开代理开关。';
+  if (lower.includes('proxy host/port required')) return '请填写代理服务器地址和端口后再测试。';
+  if (lower.includes('proxy test timeout') || lower.includes('timeout')) return '代理测试超时，请检查代理服务是否可达。';
+  if (result.status) return `代理测试返回 HTTP ${result.status}，请检查代理服务或测试地址。`;
+  const classified = generalizedErrorMessageChinese(raw, '');
+  if (classified) return classified;
+  if (raw && /[\u4E00-\u9FFF]/.test(raw)) return raw;
+  return '代理不可达，请检查代理服务器地址、端口或认证信息。';
+}
+
+function weChatQrFailureMessage(error: unknown): string {
+  return generalizedErrorMessageChinese(error, '微信扫码登录暂时不可用，请稍后重试。');
+}
+
+async function tryWeChatQrResult<T>(fn: () => Promise<T>, errorCode: string): Promise<Result<T>> {
+  try {
+    return ok(await fn());
+  } catch (error) {
+    return err(errorCode, weChatQrFailureMessage(error));
+  }
+}
+
+export function registerSettingsIpc(deps: SettingsIpcDeps): void {
+  const { settingsStore, botRegistry, normalizeSettingsPatch, applySettingsRuntimeEffects } = deps;
+
+  ipcMain.handle('settings:get', async () => maskAppSettings(await settingsStore.get()));
+  ipcMain.handle('settings:update', async (_event, patch: UpdateAppSettingsInput): Promise<UpdateAppSettingsResult> => {
+    const normalizedPatch = await normalizeSettingsPatch(patch);
+    const next = await settingsStore.update(normalizedPatch);
+    await applySettingsRuntimeEffects(next, patch);
+    return buildSettingsUpdateResult(next, patch);
+  });
+  ipcMain.handle('settings:testNetworkProxy', async (_event, input: TestProxyInput = {}) => {
+    const started = Date.now();
+    const stored = toContractNetworkSettings((await settingsStore.get()).network).proxy;
+    const proxy = input.proxy?.password === SENSITIVE_PLACEHOLDER
+      ? { ...input.proxy, password: stored.password }
+      : input.proxy;
+    const testedProxy = proxy ?? stored;
+    const result = await testProxyConnection({ ...input, proxy }, stored);
+    const latencyMs = result.latencyMs ?? (Date.now() - started);
+    if (!result.ok) {
+      return {
+        ok: false,
+        message: proxyTestFailureMessage(result),
+        latencyMs,
+      } satisfies SettingsTestResult;
+    }
+    return {
+      ok: true,
+      message: result.ip
+        ? `代理配置有效：${testedProxy.type}://${testedProxy.host}:${testedProxy.port} · ${result.countryFlag ?? ''} ${result.ip}`.trim()
+        : `代理配置有效：${testedProxy.type}://${testedProxy.host}:${testedProxy.port}`,
+      latencyMs,
+      details: {
+        status: result.status,
+        ip: result.ip,
+        countryCode: result.countryCode,
+        countryFlag: result.countryFlag,
+        bypassList: testedProxy.bypassList,
+      },
+    } satisfies SettingsTestResult;
+  });
+  ipcMain.handle('settings:testBotChannel', async (_event, provider: BotProvider) => {
+    const settings = await settingsStore.get();
+    const result = await testRuntimeBotChannel(provider, settings.botChat.channels[provider]);
+    await settingsStore.update({
+      botChat: {
+        channels: {
+          [provider]: {
+            connected: result.ok,
+            readiness: result.ok ? 'credentials_valid' : 'configured',
+            readinessReason: result.ok ? undefined : botTestErrorMessage(provider, result.error),
+            readinessUpdatedAt: Date.now(),
+            lastTestAt: Date.now(),
+            lastError: result.ok ? undefined : botTestErrorMessage(provider, result.error),
+          },
+        },
+      },
+    });
+    const next = await settingsStore.get();
+    await applySettingsRuntimeEffects(next, { botChat: { channels: { [provider]: {} } } });
+    return toSettingsTestResult(provider, result);
+  });
+  ipcMain.handle('settings:bots:listStatuses', () =>
+    tryResult(async () => botRegistry.allStatuses(), 'BOTS_STATUS_FAILED'),
+  );
+  ipcMain.handle('settings:bots:restart', (_event, provider: BotProvider) =>
+    tryResult(async () => {
+      const settings = await settingsStore.get();
+      await botRegistry.applySettings(settings.botChat);
+      return botRegistry.getStatus(provider);
+    }, 'BOTS_RESTART_FAILED'),
+  );
+
+  // PR-BOT-WECHAT-QR-MODAL-0 (WAWQAQ msg `10ec1fbe`): WeChat ClawBot
+  // scan-login. Renderer triggers the QR fetch from the modal, then
+  // polls the status endpoint until 'confirmed' or 'expired'. Main
+  // process owns the actual HTTP calls so the renderer never sees
+  // raw response bodies.
+  ipcMain.handle('settings:bots:wechat:fetchQrcode', () =>
+    tryWeChatQrResult(async () => fetchWeChatQrcode(), 'WECHAT_QR_FETCH_FAILED'),
+  );
+  ipcMain.handle('settings:bots:wechat:pollQrcodeStatus', (_event, qrToken: unknown) =>
+    tryWeChatQrResult(async () => {
+      if (typeof qrToken !== 'string' || !qrToken) {
+        throw new Error('qrToken must be a non-empty string');
+      }
+      return pollWeChatQrcodeStatus(qrToken);
+    }, 'WECHAT_QR_STATUS_FAILED'),
+  );
+  ipcMain.handle('settings:bots:wechatQrCode', async () => {
+    const settings = await settingsStore.get();
+    return getWechatBridgeQrCode(settings.botChat.channels.wechat);
+  });
+}

--- a/apps/desktop/src/main/workspace-instructions-ipc-main.ts
+++ b/apps/desktop/src/main/workspace-instructions-ipc-main.ts
@@ -1,0 +1,65 @@
+import { ipcMain, shell } from 'electron';
+import {
+  createWorkspaceInstructionFile,
+  getWorkspaceInstructionsState,
+  resolveWorkspaceInstructionFileForOpen,
+  type WorkspaceInstructionCreateFailureReason,
+  type WorkspaceInstructionOpenFailureReason,
+} from './workspace-instructions.js';
+
+export interface WorkspaceInstructionsIpcDeps {
+  getCurrentProjectRoot: () => Promise<string>;
+}
+
+function workspaceInstructionOpenFailureCopy(
+  reason: WorkspaceInstructionOpenFailureReason | 'open-failed',
+): string {
+  switch (reason) {
+    case 'unknown-file':
+      return '只能打开 AGENTS.md / CLAUDE.md / GEMINI.md。';
+    case 'missing':
+      return '项目指令文件不存在。';
+    case 'blocked':
+      return '项目指令文件不在当前工作区范围内。';
+    case 'not-a-file':
+      return '项目指令路径不是普通文件。';
+    case 'open-failed':
+      return '系统未能打开这个文件。';
+  }
+}
+
+function workspaceInstructionCreateFailureCopy(reason: WorkspaceInstructionCreateFailureReason): string {
+  switch (reason) {
+    case 'unknown-file':
+      return '只能创建 AGENTS.md / CLAUDE.md / GEMINI.md。';
+    case 'exists':
+      return '项目指令文件已经存在。';
+    case 'blocked':
+      return '当前工作区路径不可写或不在允许范围内。';
+    case 'write-failed':
+      return '写入项目指令文件失败。';
+  }
+}
+
+export function registerWorkspaceInstructionsIpc(deps: WorkspaceInstructionsIpcDeps): void {
+  const currentProjectRoot = deps.getCurrentProjectRoot;
+
+  ipcMain.handle('workspaceInstructions:getState', async () => getWorkspaceInstructionsState(await currentProjectRoot()));
+  ipcMain.handle(
+    'workspaceInstructions:openFile',
+    async (_event, file: unknown): Promise<{ ok: true } | { ok: false; message: string }> => {
+      const resolved = await resolveWorkspaceInstructionFileForOpen(await currentProjectRoot(), typeof file === 'string' ? file : '');
+      if (!resolved.ok) return { ok: false, message: workspaceInstructionOpenFailureCopy(resolved.reason) };
+      const error = await shell.openPath(resolved.path);
+      return error ? { ok: false, message: workspaceInstructionOpenFailureCopy('open-failed') } : { ok: true };
+    },
+  );
+  ipcMain.handle(
+    'workspaceInstructions:createFile',
+    async (_event, file: unknown): Promise<{ ok: true } | { ok: false; message: string }> => {
+      const created = await createWorkspaceInstructionFile(await currentProjectRoot(), typeof file === 'string' ? file : '');
+      if (!created.ok) return { ok: false, message: workspaceInstructionCreateFailureCopy(created.reason) };
+      return { ok: true };
+    },
+  );
+}

--- a/apps/desktop/src/main/workspace-search-ipc-main.ts
+++ b/apps/desktop/src/main/workspace-search-ipc-main.ts
@@ -1,0 +1,18 @@
+import { ipcMain } from 'electron';
+import { searchWorkspaceFiles } from './workspace-file-search.js';
+
+export interface WorkspaceSearchIpcDeps {
+  getCurrentProjectRoot: () => Promise<string>;
+}
+
+export function registerWorkspaceSearchIpc(deps: WorkspaceSearchIpcDeps): void {
+  // Composer `@` mention popup: list workspace files under the same project
+  // root that app:info reports. Git repos honor .gitignore + untracked via
+  // `git ls-files`; other trees fall back to a bounded walk. See
+  // workspace-file-search.ts.
+  ipcMain.handle('workspace:searchFiles', async (_event, input: unknown) => {
+    const request = (input ?? {}) as { query?: unknown; limit?: unknown };
+    const projectPath = await deps.getCurrentProjectRoot();
+    return searchWorkspaceFiles(projectPath, { query: request.query, limit: request.limit });
+  });
+}

--- a/scripts/check-console.mjs
+++ b/scripts/check-console.mjs
@@ -39,6 +39,10 @@ const ALLOW = new Map([
     'dev-gated by VITE_DEV_SERVER_URL / NODE_ENV (PR100).',
   ],
   [
+    'apps/desktop/src/main/app-ipc-main.ts',
+    'visual-smoke capture marker is fixture-gated and stdout-parsed by capture tooling (moved from main.ts, #1084).',
+  ],
+  [
     'apps/desktop/src/main/daily-review-main.ts',
     'scheduler failures are main-process diagnostics and do not expose secrets.',
   ],


### PR DESCRIPTION
## Summary

First **High** slice of #1084: `apps/desktop/src/main/main.ts` had regrown to 2412 lines with `registerIpc()` inlining ≥8 feature domains, even though 11 sibling `*-ipc-main.ts` files already followed a `register*Ipc(deps)` pattern — the seam existed but was applied inconsistently, and its contract test could only regex-match raw source because `registerIpc` runs as a module side effect.

This migrates the un-migrated domains into dedicated `register*Ipc(deps)` modules so `registerIpc` becomes pure composition and each domain is independently testable:

- `app-ipc-main.ts` — window + `app:info`/`app:openPath` + project-directory selection + `visualSmoke:*`
- `git-ipc-main.ts` — `app:listGitBranches` / `app:checkoutGitBranch`
- `workspace-search-ipc-main.ts` — `workspace:searchFiles`
- `workspace-instructions-ipc-main.ts` — `workspaceInstructions:*`
- `onboarding-ipc-main.ts` — `onboarding:*`
- `session-entry-ipc-main.ts` — `quickChat:start` + `expertTeam:*`
- `sessions-ipc-main.ts` — `sessions:*`, `tasks:list`, `shell-runs:list`, `goal:*`, `search:thread`, `attachments:*`
- `permissions-ipc-main.ts` — `permissions:*` + `capabilities:getSnapshot` + `health:getSnapshot`
- `settings-ipc-main.ts` — `settings:*` / bots / network / WeChat QR
- `gateway-ipc-main.ts` — `gateway:status`

The shared "current project root" selection moves into `project-root-controller.ts` so a single authority owns the mutable state now that its readers (git, workspace-search, workspace-instructions, session-entry, app-info) and the picker handlers live in separate modules. The controller now has direct behavioral unit tests (selection precedence, explicit-path validation, persistence).

This is a behavior-neutral pure move with one intentional delta: bot-incoming and automation fires that land before `registerIpc()` previously hit the documented temporary `process.cwd()` fallback and now resolve through the controller (persisted last-project-path → `resolveProjectRoot` fallback) — the intended fix of that temporary hack, with a negligible module-load-only window. Handler bodies are otherwise unchanged, and the shared wiring (`streamEvents`, `emitSessionsChanged`, `ensureSessionCanSend`, `getReadyConnection`, `applySettingsRuntimeEffects`, ...) stays in `main.ts` as the composition root and is injected as deps. `main.ts` drops from 2447 to 1590 lines.

Per the issue's note on the broken verification boundary: this PR structurally enables it — every domain is an exported DI registrar invocable in isolation — while the co-migrated contract tests remain source-scoped (the wiring contract now enumerates every extracted registrar, the combined main-process source helper lists the new modules, direct `main.ts` readers switch to that combined source, and the project-root assertions are scoped to their owning files); behavioral wiring tests that drive each registrar against a fake `ipcMain` are deferred to a follow-up.

Checks the first **High** checkbox in #1084 (the `main.ts` slice). Refs #1084.

## Verification

- `npm run typecheck` (main + renderer + storybook) — pass
- `npm run build:main` — pass
- `node --test dist/main/**/*.test.js` — 2599 pass / 0 fail (includes the co-migrated wiring, IPC-surface, and per-domain contract tests, plus the new `project-root-controller` behavioral unit tests)
- `npm run test:checks` (check-console / check-a11y / check-copy) — pass
- Mutation check on the re-scoped project-root contract: temporarily deleting the directory picker's `projectRoot.setSelected(...)` call makes `project-context-badge.test.ts` fail with the intended assertion; restored and green.

## Review focus

Behavior neutrality of the move: each `register*Ipc` receives its collaborators as deps and preserves the original handler bodies verbatim; `registerIpc` is now only `register*Ipc({...})` calls. Contract-test edits redirect source-reading assertions to the combined main-process source or, for the project-root selection, to the narrowest owning file, following the two intentional text changes (`resolveExplicitProjectRoot` → controller `resolveExplicit`, inline fallback → `fallbackRoots`).