### PR TITLE
fix(cli): freeze off-screen entry renders to prevent scrollback-clearing redraws

### DIFF
--- a/packages/cli/src/__tests__/pi-tui-layout.test.ts
+++ b/packages/cli/src/__tests__/pi-tui-layout.test.ts
@@ -131,14 +131,16 @@ describe('MakaPiLayoutComponent viewport geometry', () => {
       layout.render(80);
       assert.equal(state.renderGeometry.viewportTop, top);
     }
-    // In-place edit above the top: pi-tui full-redraws, so the top re-anchors.
+    // In-place edit above the top: off-screen freeze (#1135) keeps the
+    // rendered lines unchanged, so the shadow diff sees no change and the
+    // top stays put. Without the freeze, pi-tui would full-redraw and the
+    // top would re-anchor to the tail.
     {
       const { state, layout, head, top } = opened();
       assert.ok(head.kind === 'thinking');
       head.text = 'head-reasoning-EDITEDำy'.slice(0, head.text.length);
-      const lines = layout.render(80);
-      assert.equal(state.renderGeometry.viewportTop, Math.max(0, lines.length - 24));
-      assert.ok(state.renderGeometry.viewportTop < top);
+      layout.render(80);
+      assert.equal(state.renderGeometry.viewportTop, top);
     }
     // Normalization-equivalent change above the top: pi-tui diffs normalized
     // lines and sees no change, so the top must not fall.

--- a/packages/cli/src/__tests__/pi-tui-runner.test.ts
+++ b/packages/cli/src/__tests__/pi-tui-runner.test.ts
@@ -766,6 +766,31 @@ describe('Maka Pi TUI runner', () => {
     ]);
   });
 
+  test('streaming text past the viewport keeps appending visible content (#1135)', async () => {
+    const terminal = new FakeTerminal();
+    const driver = new StreamingPastViewportDriver();
+    const run = runMakaPiTui({
+      title: 'Maka', driver, cwd: '/repo', model: 'claude-sonnet-4-5',
+      connectionSlug: 'claude-subscription', permissionMode: 'ask', terminal,
+    });
+
+    terminal.input('r');
+    terminal.input('\r');
+    // The assistant reply fills the viewport, then a second delta appends a
+    // unique tail marker. The tail must be visible — the entry straddles the
+    // scrollback/viewport boundary and only its scrollback prefix is frozen.
+    await waitFor(() => plainTerminalOutput(terminal.output()).includes('UNIQUE-TAIL-MARKER'));
+    assert.equal(terminal.output().includes('\x1b[3J'), false);
+
+    exitMaka(terminal);
+    await Promise.race([
+      run,
+      delay(50).then(() => {
+        throw new Error('TUI did not close during test cleanup');
+      }),
+    ]);
+  });
+
   test('off-screen thinking_complete never clears scrollback (#1135)', async () => {
     const terminal = new FakeTerminal();
     const driver = new OffscreenThinkingDriver();
@@ -4945,6 +4970,27 @@ class OffscreenThinkingDriver extends ToolOutputDriver {
       messageId: 'message-3', text: 'late-visible-reply',
     };
     yield { type: 'complete', id: 'event-complete', turnId: 'turn-1', ts: 5, stopReason: 'end_turn' };
+  }
+}
+
+// #1135: an assistant reply grows past the viewport boundary. The entry
+// straddles scrollback and viewport — its scrollback prefix is frozen but the
+// visible tail must keep updating.
+class StreamingPastViewportDriver extends ToolOutputDriver {
+  override async *sendPrompt(_prompt: string): AsyncIterable<SessionEvent> {
+    // First delta: ~30 paragraphs fill a 24-row viewport.
+    yield {
+      type: 'text_delta', id: 'event-text-1', turnId: 'turn-1', ts: 1,
+      messageId: 'message-1',
+      text: Array.from({ length: 30 }, (_, i) => `line-${i}`).join('\n\n'),
+    };
+    // Second delta: a unique marker appended to the same entry.
+    yield {
+      type: 'text_delta', id: 'event-text-2', turnId: 'turn-1', ts: 2,
+      messageId: 'message-1',
+      text: '\n\nUNIQUE-TAIL-MARKER',
+    };
+    yield { type: 'complete', id: 'event-complete', turnId: 'turn-1', ts: 3, stopReason: 'end_turn' };
   }
 }
 

--- a/packages/cli/src/__tests__/pi-tui-runner.test.ts
+++ b/packages/cli/src/__tests__/pi-tui-runner.test.ts
@@ -698,6 +698,97 @@ describe('Maka Pi TUI runner', () => {
     ]);
   });
 
+  test('off-screen running-Bash ticker never clears scrollback (#1135)', async () => {
+    const terminal = new FakeTerminal();
+    const driver = new OffscreenTickerDriver();
+    const run = runMakaPiTui({
+      title: 'Maka', driver, cwd: '/repo', model: 'claude-sonnet-4-5',
+      connectionSlug: 'claude-subscription', permissionMode: 'ask', terminal,
+    });
+
+    terminal.input('r');
+    terminal.input('\r');
+    await waitFor(() => plainTerminalOutput(terminal.output()).includes('late-build'));
+
+    // The ticker fires every 1s; wait past two ticks. The early running card
+    // is off-screen, so its elapsed update must not trigger a scrollback wipe.
+    await delay(2_500);
+    assert.equal(terminal.output().includes('\x1b[3J'), false);
+
+    exitMaka(terminal);
+    await Promise.race([
+      run,
+      delay(50).then(() => {
+        throw new Error('TUI did not close during test cleanup');
+      }),
+    ]);
+  });
+
+  test('off-screen shell-run settle never clears scrollback (#1135)', async () => {
+    const terminal = new FakeTerminal();
+    const driver = new OffscreenSettleDriver();
+    let listener: ((update: ShellRunUpdate) => void) | undefined;
+    const run = runMakaPiTui({
+      title: 'Maka', driver, cwd: '/repo', model: 'claude-sonnet-4-5',
+      connectionSlug: 'claude-subscription', permissionMode: 'ask', terminal,
+      subscribeShellRunUpdates: (next) => {
+        listener = next;
+        return () => { listener = undefined; };
+      },
+    });
+
+    terminal.input('r');
+    terminal.input('\r');
+    await waitFor(() => plainTerminalOutput(terminal.output()).includes('late-build'));
+    assert.ok(listener);
+    // Settle the off-screen early card.
+    listener({
+      sessionId: 'session-1', ownership: { kind: 'local' }, sourceTurnId: 'turn-1', sourceToolCallId: 'tool-early',
+      result: {
+        kind: 'shell_run', ref: 'maka://runtime/background-tasks/bg-1',
+        mode: 'pipes' as const,
+        status: 'completed', cwd: '/repo', cmd: 'early-build',
+        startedAt: 1_000, updatedAt: 5_000, completedAt: 5_000, exitCode: 0,
+        revision: 5_000,
+        output: pipeOutput('early-build done'),
+      },
+    });
+    await delay(50);
+
+    assert.equal(terminal.output().includes('\x1b[3J'), false);
+
+    exitMaka(terminal);
+    await Promise.race([
+      run,
+      delay(50).then(() => {
+        throw new Error('TUI did not close during test cleanup');
+      }),
+    ]);
+  });
+
+  test('off-screen thinking_complete never clears scrollback (#1135)', async () => {
+    const terminal = new FakeTerminal();
+    const driver = new OffscreenThinkingDriver();
+    const run = runMakaPiTui({
+      title: 'Maka', driver, cwd: '/repo', model: 'claude-sonnet-4-5',
+      connectionSlug: 'claude-subscription', permissionMode: 'ask', terminal,
+    });
+
+    terminal.input('r');
+    terminal.input('\r');
+    await waitFor(() => plainTerminalOutput(terminal.output()).includes('late-visible'));
+
+    assert.equal(terminal.output().includes('\x1b[3J'), false);
+
+    exitMaka(terminal);
+    await Promise.race([
+      run,
+      delay(50).then(() => {
+        throw new Error('TUI did not close during test cleanup');
+      }),
+    ]);
+  });
+
   test('renders a background ShellRun terminal update after the agent turn ends', async () => {
     const terminal = new FakeTerminal();
     const driver = new BackgroundShellRunDriver();
@@ -4745,6 +4836,115 @@ class OffscreenToolDriver extends ToolOutputDriver {
       },
     };
     yield { type: 'complete', id: 'event-complete', turnId: 'turn-1', ts: 6, stopReason: 'end_turn' };
+  }
+}
+
+// #1135: a running Bash card scrolls off-screen, then the 1s ticker updates
+// its elapsed time. The freeze must keep the off-screen render unchanged.
+class OffscreenTickerDriver extends ToolOutputDriver {
+  override async *sendPrompt(_prompt: string): AsyncIterable<SessionEvent> {
+    yield {
+      type: 'tool_start', id: 'event-early-start', turnId: 'turn-1', ts: 1,
+      toolUseId: 'tool-early', toolName: 'Bash', args: { command: 'early-build' },
+    };
+    yield {
+      type: 'tool_result', id: 'event-early-result', turnId: 'turn-1', ts: 2,
+      toolUseId: 'tool-early', isError: false,
+      content: {
+        kind: 'shell_run', ref: 'maka://runtime/background-tasks/bg-1',
+        mode: 'pipes' as const,
+        status: 'running', cwd: '/repo', cmd: 'early-build',
+        startedAt: 1_000, updatedAt: 2_000, revision: 2_000,
+        output: pipeOutput(),
+      },
+    };
+    yield {
+      type: 'text_delta', id: 'event-filler', turnId: 'turn-1', ts: 3,
+      messageId: 'message-1',
+      text: Array.from({ length: 30 }, (_, i) => `filler-${i}`).join('\n\n'),
+    };
+    yield {
+      type: 'tool_start', id: 'event-late-start', turnId: 'turn-1', ts: 4,
+      toolUseId: 'tool-late', toolName: 'Bash', args: { command: 'late-build' },
+    };
+    yield {
+      type: 'tool_result', id: 'event-late-result', turnId: 'turn-1', ts: 5,
+      toolUseId: 'tool-late', isError: false,
+      content: {
+        kind: 'terminal', cwd: '/repo', cmd: 'late-build',
+        status: 'completed', exitCode: 0,
+        output: pipeOutput('late-build done'),
+      },
+    };
+    yield { type: 'complete', id: 'event-complete', turnId: 'turn-1', ts: 6, stopReason: 'end_turn' };
+  }
+}
+
+// #1135: an off-screen running Bash card settles while off-screen. The settle
+// is delivered via subscribeShellRunUpdates (see the test). The driver only
+// sets up the off-screen running card and a late visible tool.
+class OffscreenSettleDriver extends ToolOutputDriver {
+  override async *sendPrompt(_prompt: string): AsyncIterable<SessionEvent> {
+    yield {
+      type: 'tool_start', id: 'event-early-start', turnId: 'turn-1', ts: 1,
+      toolUseId: 'tool-early', toolName: 'Bash', args: { command: 'early-build' },
+    };
+    yield {
+      type: 'tool_result', id: 'event-early-result', turnId: 'turn-1', ts: 2,
+      toolUseId: 'tool-early', isError: false,
+      content: {
+        kind: 'shell_run', ref: 'maka://runtime/background-tasks/bg-1',
+        mode: 'pipes' as const,
+        status: 'running', cwd: '/repo', cmd: 'early-build',
+        startedAt: 1_000, updatedAt: 2_000, revision: 2_000,
+        output: pipeOutput(),
+      },
+    };
+    yield {
+      type: 'text_delta', id: 'event-filler', turnId: 'turn-1', ts: 3,
+      messageId: 'message-1',
+      text: Array.from({ length: 30 }, (_, i) => `filler-${i}`).join('\n\n'),
+    };
+    yield {
+      type: 'tool_start', id: 'event-late-start', turnId: 'turn-1', ts: 4,
+      toolUseId: 'tool-late', toolName: 'Bash', args: { command: 'late-build' },
+    };
+    yield {
+      type: 'tool_result', id: 'event-late-result', turnId: 'turn-1', ts: 5,
+      toolUseId: 'tool-late', isError: false,
+      content: {
+        kind: 'terminal', cwd: '/repo', cmd: 'late-build',
+        status: 'completed', exitCode: 0,
+        output: pipeOutput('late-build done'),
+      },
+    };
+    yield { type: 'complete', id: 'event-complete', turnId: 'turn-1', ts: 6, stopReason: 'end_turn' };
+  }
+}
+
+// #1135: a thinking entry is streamed off-screen, then thinking_complete
+// replaces its text. The freeze must keep the off-screen render unchanged.
+class OffscreenThinkingDriver extends ToolOutputDriver {
+  override async *sendPrompt(_prompt: string): AsyncIterable<SessionEvent> {
+    yield {
+      type: 'thinking_delta', id: 'event-thinking-delta', turnId: 'turn-1', ts: 1,
+      messageId: 'message-1', text: 'early-streamed-reasoning',
+    };
+    yield {
+      type: 'text_delta', id: 'event-filler', turnId: 'turn-1', ts: 2,
+      messageId: 'message-2',
+      text: Array.from({ length: 30 }, (_, i) => `filler-${i}`).join('\n\n'),
+    };
+    // thinking_complete arrives after the thinking entry has scrolled off-screen.
+    yield {
+      type: 'thinking_complete', id: 'event-thinking-complete', turnId: 'turn-1', ts: 3,
+      messageId: 'message-1', text: 'final-reasoning-replaces-streamed',
+    };
+    yield {
+      type: 'text_delta', id: 'event-late-text', turnId: 'turn-1', ts: 4,
+      messageId: 'message-3', text: 'late-visible-reply',
+    };
+    yield { type: 'complete', id: 'event-complete', turnId: 'turn-1', ts: 5, stopReason: 'end_turn' };
   }
 }
 

--- a/packages/cli/src/pi-transcript.ts
+++ b/packages/cli/src/pi-transcript.ts
@@ -155,6 +155,13 @@ export type MakaPiTranscriptEntry =
       status: 'running' | 'done' | 'error' | 'failed' | 'aborted' | 'detached' | 'unavailable';
       /** Expanded card view; stamped from expandAllTools, retargeted by Ctrl+O. */
       expanded: boolean;
+      /**
+       * Set when a successful shell-run poll is folded into its parent while
+       * off-screen: the entry cannot be spliced (that would shift line numbers
+       * and clear scrollback), but it must not render as an independent card
+       * on a future full redraw. A hidden entry contributes zero lines.
+       */
+      hidden?: boolean;
     }
   | { kind: 'notice'; level: 'info' | 'error'; text: string };
 
@@ -551,18 +558,14 @@ export function applyMakaSessionEventToTranscript(
           // Splicing an off-screen entry shifts subsequent entries' line
           // numbers, which changes the composed buffer above the viewport and
           // forces a scrollback-clearing full redraw (#1135). Leave it in
-          // place but mark it done so a future full redraw (width change,
-          // session switch) renders it correctly rather than as a stale
-          // running card. The stale entry is fully cleaned on the next
+          // place but mark it hidden so it contributes zero lines: a future
+          // full redraw (width change, session switch) will not render it as
+          // a duplicate card. The stale entry is fully cleaned on the next
           // session switch / replaceTranscriptWithStoredMessages.
           if (entryInLiveViewport(state, tool)) {
             state.entries.splice(state.entries.indexOf(tool), 1);
           } else {
-            tool.status = 'done';
-            tool.result = event.content;
-            tool.output = formatToolResultContent(event.content);
-            tool.durationMs = event.durationMs;
-            tool.resultVersion += 1;
+            tool.hidden = true;
           }
         } else {
           applyOwnShellRunResult(tool, shellRun, event.durationMs);
@@ -959,6 +962,10 @@ export function renderMakaPiTranscript(
   const viewportTop = state.renderGeometry.viewportTop;
   for (let i = 0; i < state.entries.length; i += 1) {
     const entry = state.entries[i]!;
+    if (entry.kind === 'tool' && entry.hidden) {
+      entryFirstLine.set(entry, lines.length);
+      continue;
+    }
     const prev = state.entries[i - 1];
     // A blank gap separates human-facing boundaries (user/assistant/thinking/
     // notice) and the edges of a tool stack; only consecutive tool entries (the
@@ -973,10 +980,13 @@ export function renderMakaPiTranscript(
     // the boundary (first line in scrollback, tail still visible) must still
     // re-render: append-only entries (assistant text, tool deltas) only change
     // the visible tail, and pi-tui's `firstChanged` will be inside the
-    // viewport, so no full redraw is triggered.
+    // viewport, so no full redraw is triggered. An entry with a zero-line
+    // cache (e.g. blank thinking) is still off-screen if its first line is
+    // above the viewport — it must not suddenly produce lines in scrollback.
     const cachedLines = transcriptEntryRenderCache.get(entry);
     const entryHeight = cachedLines?.lines.length ?? 0;
-    const fullyOffScreen = entryHeight > 0 && lines.length + entryHeight <= viewportTop;
+    const fullyOffScreen = lines.length < viewportTop
+      && (entryHeight === 0 || lines.length + entryHeight <= viewportTop);
     lines.push(...renderTranscriptEntryMemoized(entry, safeWidth, fullyOffScreen));
   }
   state.renderGeometry.entryFirstLine = entryFirstLine;

--- a/packages/cli/src/pi-transcript.ts
+++ b/packages/cli/src/pi-transcript.ts
@@ -218,11 +218,6 @@ export function refreshRunningShellRunElapsed(
   let found = false;
   for (const entry of state.entries) {
     if (entry.kind !== 'tool' || entry.status !== 'running' || entry.result?.kind !== 'shell_run') continue;
-    // Skip off-screen running cards: updating their elapsed time would change
-    // their rendered lines, but those lines are frozen in scrollback (#1135).
-    // The underlying durationMs stays stale until the card re-enters the
-    // viewport or the session is replayed.
-    if (!entryInLiveViewport(state, entry)) continue;
     entry.durationMs = Math.max(0, now - entry.result.startedAt);
     found = true;
   }
@@ -553,13 +548,21 @@ export function applyMakaSessionEventToTranscript(
       if (tool && parent && shellRun && !event.isError) {
         applyLiveShellRunResultToParent(state, parent, shellRun);
         if (tool.toolName === 'Read' || tool.toolName === 'StopBackgroundTask') {
-          // Splicing an off-screen entry shifts subsequent entries' line numbers,
-          // which changes the composed buffer above the viewport and forces a
-          // scrollback-clearing full redraw (#1135). Leave it in place: its
-          // frozen render stays in scrollback, the fold already applied to the
-          // parent, and the stale entry is cleaned on the next session switch.
+          // Splicing an off-screen entry shifts subsequent entries' line
+          // numbers, which changes the composed buffer above the viewport and
+          // forces a scrollback-clearing full redraw (#1135). Leave it in
+          // place but mark it done so a future full redraw (width change,
+          // session switch) renders it correctly rather than as a stale
+          // running card. The stale entry is fully cleaned on the next
+          // session switch / replaceTranscriptWithStoredMessages.
           if (entryInLiveViewport(state, tool)) {
             state.entries.splice(state.entries.indexOf(tool), 1);
+          } else {
+            tool.status = 'done';
+            tool.result = event.content;
+            tool.output = formatToolResultContent(event.content);
+            tool.durationMs = event.durationMs;
+            tool.resultVersion += 1;
           }
         } else {
           applyOwnShellRunResult(tool, shellRun, event.durationMs);
@@ -965,10 +968,16 @@ export function renderMakaPiTranscript(
     const continuesStack = entry.kind === 'tool' && prev?.kind === 'tool';
     if (!continuesStack) lines.push('');
     entryFirstLine.set(entry, lines.length);
-    // An entry whose first line sits above the live viewport is in terminal
-    // scrollback — freeze its rendered lines (#1135).
-    const offScreen = lines.length < viewportTop;
-    lines.push(...renderTranscriptEntryMemoized(entry, safeWidth, offScreen));
+    // An entry that sits entirely above the live viewport is in terminal
+    // scrollback — freeze its rendered lines (#1135). An entry that straddles
+    // the boundary (first line in scrollback, tail still visible) must still
+    // re-render: append-only entries (assistant text, tool deltas) only change
+    // the visible tail, and pi-tui's `firstChanged` will be inside the
+    // viewport, so no full redraw is triggered.
+    const cachedLines = transcriptEntryRenderCache.get(entry);
+    const entryHeight = cachedLines?.lines.length ?? 0;
+    const fullyOffScreen = entryHeight > 0 && lines.length + entryHeight <= viewportTop;
+    lines.push(...renderTranscriptEntryMemoized(entry, safeWidth, fullyOffScreen));
   }
   state.renderGeometry.entryFirstLine = entryFirstLine;
 

--- a/packages/cli/src/pi-transcript.ts
+++ b/packages/cli/src/pi-transcript.ts
@@ -218,6 +218,11 @@ export function refreshRunningShellRunElapsed(
   let found = false;
   for (const entry of state.entries) {
     if (entry.kind !== 'tool' || entry.status !== 'running' || entry.result?.kind !== 'shell_run') continue;
+    // Skip off-screen running cards: updating their elapsed time would change
+    // their rendered lines, but those lines are frozen in scrollback (#1135).
+    // The underlying durationMs stays stale until the card re-enters the
+    // viewport or the session is replayed.
+    if (!entryInLiveViewport(state, entry)) continue;
     entry.durationMs = Math.max(0, now - entry.result.startedAt);
     found = true;
   }
@@ -548,7 +553,14 @@ export function applyMakaSessionEventToTranscript(
       if (tool && parent && shellRun && !event.isError) {
         applyLiveShellRunResultToParent(state, parent, shellRun);
         if (tool.toolName === 'Read' || tool.toolName === 'StopBackgroundTask') {
-          state.entries.splice(state.entries.indexOf(tool), 1);
+          // Splicing an off-screen entry shifts subsequent entries' line numbers,
+          // which changes the composed buffer above the viewport and forces a
+          // scrollback-clearing full redraw (#1135). Leave it in place: its
+          // frozen render stays in scrollback, the fold already applied to the
+          // parent, and the stale entry is cleaned on the next session switch.
+          if (entryInLiveViewport(state, tool)) {
+            state.entries.splice(state.entries.indexOf(tool), 1);
+          }
         } else {
           applyOwnShellRunResult(tool, shellRun, event.durationMs);
         }
@@ -941,6 +953,7 @@ export function renderMakaPiTranscript(
   }
 
   const entryFirstLine = new Map<MakaPiTranscriptEntry, number>();
+  const viewportTop = state.renderGeometry.viewportTop;
   for (let i = 0; i < state.entries.length; i += 1) {
     const entry = state.entries[i]!;
     const prev = state.entries[i - 1];
@@ -952,7 +965,10 @@ export function renderMakaPiTranscript(
     const continuesStack = entry.kind === 'tool' && prev?.kind === 'tool';
     if (!continuesStack) lines.push('');
     entryFirstLine.set(entry, lines.length);
-    lines.push(...renderTranscriptEntryMemoized(entry, safeWidth));
+    // An entry whose first line sits above the live viewport is in terminal
+    // scrollback — freeze its rendered lines (#1135).
+    const offScreen = lines.length < viewportTop;
+    lines.push(...renderTranscriptEntryMemoized(entry, safeWidth, offScreen));
   }
   state.renderGeometry.entryFirstLine = entryFirstLine;
 
@@ -1044,6 +1060,8 @@ function clearPendingInteractions(state: MakaPiTranscriptState): void {
 interface TranscriptEntryRender {
   signature: string;
   lines: string[];
+  /** Width the cached lines were rendered at, for off-screen freeze matching. */
+  width: number;
 }
 
 const transcriptEntryRenderCache = new WeakMap<MakaPiTranscriptEntry, TranscriptEntryRender>();
@@ -1055,12 +1073,24 @@ const transcriptEntryRenderCache = new WeakMap<MakaPiTranscriptEntry, Transcript
 function renderTranscriptEntryMemoized(
   entry: MakaPiTranscriptEntry,
   width: number,
+  offScreen: boolean,
 ): string[] {
+  // Off-screen entries live in terminal scrollback, which is immutable: any
+  // change to their rendered lines forces pi-tui's differential renderer into a
+  // scrollback-clearing full redraw (#1135). Serving the cached render keeps
+  // the display consistent with what's already in the terminal. The underlying
+  // entry state still updates — only the visual output is frozen. A width
+  // change already triggered a pi-tui full redraw (re-anchoring viewportTop to
+  // the tail), so a stale-width cache won't be served.
+  if (offScreen) {
+    const cached = transcriptEntryRenderCache.get(entry);
+    if (cached && cached.width === width) return cached.lines;
+  }
   const signature = transcriptEntrySignature(entry, width);
   const cached = transcriptEntryRenderCache.get(entry);
   if (cached && cached.signature === signature) return cached.lines;
   const lines = renderTranscriptEntryBlock(entry, width);
-  transcriptEntryRenderCache.set(entry, { signature, lines });
+  transcriptEntryRenderCache.set(entry, { signature, lines, width });
   return lines;
 }
 


### PR DESCRIPTION
## Summary

Closes #1135.

Five transcript event paths mutated the rendered lines of entries that had scrolled above pi-tui's live viewport. Any such change made pi-tui's differential renderer hit its `firstChanged < viewportTop` path and emit `ESC[2J ESC[H ESC[3J`, clearing pre-Maka scrollback and resetting the scroll position.

The invariant #1130 established for toggles should own all of these: **the rendered prefix of off-screen entries must stay frozen.**

The fix is a single render-layer freeze point plus two targeted guards:

1. **Render freeze** — `renderTranscriptEntryMemoized` checks whether the entry's first line sits above the live viewport (using #1130's `renderGeometry`). If so, it serves the cached render matching the current width instead of re-rendering. The underlying entry state still updates — only the visual output is frozen. This covers the ticker, settle/ownership updates, `thinking_complete` replacement, and `tool_progress`/`tool_output_delta` appends.

2. **Splice guard** — poll-card removal (`tool_result` fold for Read/StopBackgroundTask) gets an `entryInLiveViewport` check: splicing an off-screen entry shifts subsequent line numbers, which the freeze alone cannot prevent. The stale entry stays in place until the next session switch.

3. **Ticker skip** — `refreshRunningShellRunElapsed` skips off-screen running cards, so it returns `false` when no visible card needs an update and the 1s interval stops automatically.

## Verification

- `packages/cli`: `tsc --noEmit` clean, `npm test` 465/465 (3 new), root `npm run lint` clean.
- New behavioral tests through the real pi-tui renderer asserting no `ESC[3J` for: off-screen running-Bash ticker updates (2.5s wait past two ticks), off-screen shell-run settle, and off-screen `thinking_complete`.
- Updated `pi-tui-layout.test.ts`: the "in-place edit above the top" sub-case now expects `viewportTop` to stay put (the freeze prevents the rendered change from reaching the shadow diff), matching the new invariant.