### PR TITLE
fix(cli): flip the expansion default and explain when Ctrl+O/Ctrl+T finds no block in view

### DIFF
--- a/packages/cli/src/__tests__/pi-transcript.test.ts
+++ b/packages/cli/src/__tests__/pi-transcript.test.ts
@@ -558,20 +558,60 @@ describe('Maka Pi TUI transcript', () => {
     assert.doesNotMatch(afterText, /early-head/);
   });
 
-  test('Ctrl+O reports nothing to toggle when every tool card sits above the viewport', () => {
+  test('Ctrl+O with a head-scrolled expanded card flips the default back and leaves a notice (#1134)', () => {
     const state = createMakaPiTranscriptState();
     applyMakaSessionEventToTranscript(state, event({
-      type: 'tool_start', toolUseId: 'tool-1', toolName: 'Bash', args: { command: 'npm test' },
+      type: 'tool_start', toolUseId: 'tool-big', toolName: 'Bash', args: { command: 'big-diff' },
     }));
     applyMakaSessionEventToTranscript(state, event({
-      type: 'tool_result', toolUseId: 'tool-1', isError: false, content: terminalResult('ok\n'),
+      type: 'tool_result', toolUseId: 'tool-big', isError: false,
+      content: terminalResult(`big-head\n${Array.from({ length: 80 }, (_, i) => `big-row-${i}`).join('\n')}`),
     }));
 
-    const lines = renderMakaPiTranscript(state, meta(), 100);
-    state.renderGeometry.viewportTop = lines.length;
+    assert.equal(toggleAllToolExpansion(state), true);
+    assert.equal(state.expandAllTools, true);
+    const entry = state.entries.find(
+      (candidate): candidate is Extract<typeof candidate, { kind: 'tool' }> => candidate.kind === 'tool',
+    );
+    assert.ok(entry);
+    assert.equal(entry.expanded, true);
 
+    // Expanding grew the document past the terminal: the card's head is now
+    // terminal scrollback and only its tail is inside the live viewport.
+    const before = renderMakaPiTranscript(state, meta(), 100);
+    const firstLine = state.renderGeometry.entryFirstLine?.get(entry);
+    assert.ok(firstLine !== undefined);
+    const viewportTop = firstLine + 5;
+    assert.ok(viewportTop < before.length);
+    state.renderGeometry.viewportTop = viewportTop;
+
+    // The second Ctrl+O cannot collapse the card (its head is in scrollback),
+    // but it must still flip the default back and say why nothing moved.
+    assert.equal(toggleAllToolExpansion(state), true);
+    assert.equal(state.expandAllTools, false);
+    assert.equal(entry.expanded, true);
+
+    const notice = state.entries[state.entries.length - 1];
+    assert.equal(notice.kind, 'notice');
+    assert.equal(notice.kind === 'notice' && notice.level, 'info');
+    assert.match(notice.kind === 'notice' ? notice.text : '', /starts collapsed/);
+
+    const after = renderMakaPiTranscript(state, meta(), 100);
+    assert.deepEqual(after.slice(0, viewportTop), before.slice(0, viewportTop));
+    assert.match(after.map(stripAnsi).join('\n'), /Note: /);
+
+    // A third Ctrl+O keeps flipping the default and keeps saying so.
+    assert.equal(toggleAllToolExpansion(state), true);
+    assert.equal(state.expandAllTools, true);
+    const third = state.entries[state.entries.length - 1];
+    assert.match(third.kind === 'notice' ? third.text : '', /starts expanded/);
+  });
+
+  test('Ctrl+O reports nothing to toggle when the session has no tool card at all', () => {
+    const state = createMakaPiTranscriptState();
     assert.equal(toggleAllToolExpansion(state), false);
     assert.equal(state.expandAllTools, false);
+    assert.equal(state.entries.some((entry) => entry.kind === 'notice'), false);
   });
 
   test('tool cards born after an expand-all start expanded', () => {
@@ -625,6 +665,38 @@ describe('Maka Pi TUI transcript', () => {
     const afterText = after.map(stripAnsi).join('\n');
     assert.match(afterText, /late-visible-reasoning/);
     assert.doesNotMatch(afterText, /early-secret-reasoning/);
+  });
+
+  test('Ctrl+T with only head-scrolled thinking flips the default back and leaves a notice (#1134)', () => {
+    const state = createMakaPiTranscriptState();
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'thinking_delta', messageId: 'message-1',
+      text: Array.from({ length: 80 }, (_, i) => `reasoning-row-${i}`).join('\n'),
+    }));
+
+    assert.equal(toggleAllThinkingExpansion(state), true);
+    assert.equal(state.expandAllThinking, true);
+
+    const before = renderMakaPiTranscript(state, meta(), 100);
+    const entry = state.entries.find(
+      (candidate): candidate is Extract<typeof candidate, { kind: 'thinking' }> => candidate.kind === 'thinking',
+    );
+    assert.ok(entry);
+    const firstLine = state.renderGeometry.entryFirstLine?.get(entry);
+    assert.ok(firstLine !== undefined);
+    const viewportTop = firstLine + 10;
+    state.renderGeometry.viewportTop = viewportTop;
+
+    assert.equal(toggleAllThinkingExpansion(state), true);
+    assert.equal(state.expandAllThinking, false);
+    assert.equal(entry.expanded, true);
+
+    const notice = state.entries[state.entries.length - 1];
+    assert.equal(notice.kind, 'notice');
+    assert.match(notice.kind === 'notice' ? notice.text : '', /starts collapsed/);
+
+    const after = renderMakaPiTranscript(state, meta(), 100);
+    assert.deepEqual(after.slice(0, viewportTop), before.slice(0, viewportTop));
   });
 
   test('replays WriteStdin as a human-readable operation row while merging its PTY revision into Bash', () => {

--- a/packages/cli/src/__tests__/pi-tui-runner.test.ts
+++ b/packages/cli/src/__tests__/pi-tui-runner.test.ts
@@ -844,6 +844,40 @@ describe('Maka Pi TUI runner', () => {
     ]);
   });
 
+  test('Ctrl-T on a block expanded past the viewport flips the default and explains, without clearing scrollback (#1134)', async () => {
+    const terminal = new FakeTerminal();
+    const driver = new TallThinkingOutputDriver();
+    const run = runMakaPiTui({
+      title: 'Maka', driver, cwd: '/repo', model: 'claude-sonnet-4-5',
+      connectionSlug: 'claude-subscription', permissionMode: 'ask', terminal,
+    });
+
+    terminal.input('run');
+    terminal.input('\r');
+    await waitFor(() => plainTerminalOutput(terminal.output()).includes('Thinking…'));
+
+    // Expanding writes all 80 reasoning rows; the block's own head scrolls
+    // above the 24-row viewport into terminal scrollback.
+    terminal.input('\x14');
+    await waitFor(() => plainTerminalOutput(terminal.output()).includes('reason-row-79'));
+
+    // The second Ctrl+T finds no thinking head inside the viewport. It must
+    // not clear scrollback, must keep the frozen expansion, and must say what
+    // happened instead of silently doing nothing.
+    terminal.input('\x14');
+    await waitFor(() => plainTerminalOutput(terminal.screenOutput()).includes('No thinking in view to toggle'));
+    assert.match(plainTerminalOutput(terminal.screenOutput()), /New thinking starts collapsed/);
+    assert.equal(terminal.output().includes('\x1b[3J'), false);
+
+    exitMaka(terminal);
+    await Promise.race([
+      run,
+      delay(50).then(() => {
+        throw new Error('TUI did not close during test cleanup');
+      }),
+    ]);
+  });
+
   test('renders the statusline below the input editor', async () => {
     const terminal = new FakeTerminal();
     const driver = new SlashCommandDriver();
@@ -4618,6 +4652,27 @@ class ThinkingOutputDriver implements MakaSessionDriver {
   startNewSession(): void {}
   getSessionId(): string {
     return 'session-1';
+  }
+}
+
+/** 80 reasoning rows: expanding pushes the block's head into scrollback (#1134). */
+class TallThinkingOutputDriver extends ThinkingOutputDriver {
+  override async *sendPrompt(_prompt: string): AsyncIterable<SessionEvent> {
+    yield {
+      type: 'thinking_delta',
+      id: 'event-thinking',
+      turnId: 'turn-1',
+      ts: 1,
+      messageId: 'message-1',
+      text: Array.from({ length: 80 }, (_, i) => `reason-row-${i}`).join('\n'),
+    };
+    yield {
+      type: 'complete',
+      id: 'event-complete',
+      turnId: 'turn-1',
+      ts: 2,
+      stopReason: 'end_turn',
+    };
   }
 }
 

--- a/packages/cli/src/pi-transcript.ts
+++ b/packages/cli/src/pi-transcript.ts
@@ -322,6 +322,12 @@ function entryInLiveViewport(state: MakaPiTranscriptState, entry: MakaPiTranscri
  * True while entry positions are unknown but the viewport has scrolled (a
  * wholesale replacement not yet re-rendered): a toggle could rewrite lines
  * above pi-tui's real viewport, so it must do nothing until the next render.
+ *
+ * Unknown positions with viewportTop === 0 are deliberately NOT inert: while
+ * the viewport has never scrolled, no line sits in scrollback and pi-tui's
+ * differential render (`firstChanged < viewportTop`) can never full-redraw,
+ * so toggling everything — including entries awaiting their first render —
+ * is physically safe.
  */
 function togglesInert(state: MakaPiTranscriptState): boolean {
   return state.renderGeometry.entryFirstLine === undefined && state.renderGeometry.viewportTop > 0;

--- a/packages/cli/src/pi-transcript.ts
+++ b/packages/cli/src/pi-transcript.ts
@@ -318,27 +318,66 @@ function entryInLiveViewport(state: MakaPiTranscriptState, entry: MakaPiTranscri
   return firstLine === undefined || firstLine >= geometry.viewportTop;
 }
 
-/** Toggle every tool card in the live viewport at once; false when there is none. */
+/**
+ * True while entry positions are unknown but the viewport has scrolled (a
+ * wholesale replacement not yet re-rendered): a toggle could rewrite lines
+ * above pi-tui's real viewport, so it must do nothing until the next render.
+ */
+function togglesInert(state: MakaPiTranscriptState): boolean {
+  return state.renderGeometry.entryFirstLine === undefined && state.renderGeometry.viewportTop > 0;
+}
+
+/**
+ * Toggle every tool card in the live viewport at once and flip the default for
+ * future cards; false when the session has no tool card at all or the toggles
+ * are inert pending a render.
+ *
+ * When every card sits above the viewport (e.g. a block whose own expansion
+ * pushed its head into scrollback, #1134), nothing visible can change — those
+ * lines are immutable short of a scrollback-clearing full redraw — so the
+ * toggle still flips the default and appends a notice saying why.
+ */
 export function toggleAllToolExpansion(state: MakaPiTranscriptState): boolean {
-  const targets = state.entries.filter(
-    (entry): entry is MakaPiToolEntry => entry.kind === 'tool' && entryInLiveViewport(state, entry),
+  if (togglesInert(state)) return false;
+  const candidates = state.entries.filter(
+    (entry): entry is MakaPiToolEntry => entry.kind === 'tool',
   );
-  if (targets.length === 0) return false;
+  if (candidates.length === 0) return false;
   state.expandAllTools = !state.expandAllTools;
+  const targets = candidates.filter((entry) => entryInLiveViewport(state, entry));
   for (const entry of targets) entry.expanded = state.expandAllTools;
+  if (targets.length === 0) {
+    state.entries.push({
+      kind: 'notice',
+      level: 'info',
+      text: `No tool card in view to toggle — cards above stay as rendered in scrollback. New tool output starts ${state.expandAllTools ? 'expanded' : 'collapsed'}.`,
+    });
+  }
   return true;
 }
 
-/** Toggle every thinking entry in the live viewport at once; false when there is none. */
+/**
+ * Toggle every thinking entry in the live viewport at once and flip the
+ * default for future entries; false when there is no thinking at all or the
+ * toggles are inert pending a render. Same head-scrolled contract as
+ * toggleAllToolExpansion (#1134).
+ */
 export function toggleAllThinkingExpansion(state: MakaPiTranscriptState): boolean {
-  const targets = state.entries.filter(
-    (entry): entry is MakaPiThinkingEntry => entry.kind === 'thinking'
-      && Boolean(entry.text.trim())
-      && entryInLiveViewport(state, entry),
+  if (togglesInert(state)) return false;
+  const candidates = state.entries.filter(
+    (entry): entry is MakaPiThinkingEntry => entry.kind === 'thinking' && Boolean(entry.text.trim()),
   );
-  if (targets.length === 0) return false;
+  if (candidates.length === 0) return false;
   state.expandAllThinking = !state.expandAllThinking;
+  const targets = candidates.filter((entry) => entryInLiveViewport(state, entry));
   for (const entry of targets) entry.expanded = state.expandAllThinking;
+  if (targets.length === 0) {
+    state.entries.push({
+      kind: 'notice',
+      level: 'info',
+      text: `No thinking in view to toggle — thinking above stays as rendered in scrollback. New thinking starts ${state.expandAllThinking ? 'expanded' : 'collapsed'}.`,
+    });
+  }
   return true;
 }
 

--- a/packages/cli/src/pi-tui-runner.ts
+++ b/packages/cli/src/pi-tui-runner.ts
@@ -1463,7 +1463,10 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
   // be rewritten, so resizing it would push pi-tui's differential renderer
   // into a scrollback-clearing full redraw (its `firstChanged < viewportTop`
   // path). The toggles therefore retarget only entries inside the viewport;
-  // see entryInLiveViewport in pi-transcript.ts (#1097).
+  // see entryInLiveViewport in pi-transcript.ts (#1097). A block whose own
+  // expansion pushed its head above the viewport can consequently never be
+  // collapsed in place (#1134): the toggles still flip the default and append
+  // a notice, and the expanded content stays readable in scrollback.
   tui.setClearOnShrink(false);
   tui.addChild(layout);
   tui.setFocus(editorSurface);


### PR DESCRIPTION
## Summary

Closes #1134. Follow-up to #1097 / #1130.

Expanding a block taller than the terminal pushes the block's own head above the live viewport into terminal scrollback. Scrollback is append-only, so collapsing that block in place is physically impossible without the scrollback-clearing full redraw the #1097 contract forbids — the second Ctrl+O/Ctrl+T found no in-viewport target, returned false, and silently left both the block and the expansion default stuck.

Per the decision on #1134, this accepts the physical limitation instead of "fixing" it (option 3), and removes the two real defects around it:

- `toggleAllToolExpansion` / `toggleAllThinkingExpansion` now always flip the expansion default when any candidate entry exists and entry positions are known, so a stuck default no longer leaks into future entries.
- When every candidate sits above the viewport, the toggle appends an info notice — the keypress is no longer silent — saying the content above stays readable in scrollback and which state new output starts in.
- Toggles stay fully inert while entry positions are unknown after a wholesale replacement (unchanged #1130 contract), and entries above the viewport stay byte-identical across a toggle (unchanged #1097 contract).

Not done, deliberately: clamping expanded rendering (regresses full-content-into-scrollback), letting toggles touch head-scrolled blocks (reintroduces the #1097 wipe), or an explicit scrollback-clearing redraw command (possible orthogonal follow-up).

## Verification

- `packages/cli`: `npm test` 465/465 (3 new/updated unit tests, 1 new integration test), root `npm run lint` clean.
- New unit tests lock: head-scrolled second toggle flips the default back, freezes the entry, keeps scrollback lines byte-identical, and appends the notice; a session with no candidate still reports nothing to toggle; the post-replacement inert window is preserved.
- New integration test drives the real pi-tui renderer through `runMakaPiTui` with a 24-row terminal: an 80-line thinking block is expanded past the viewport, the second Ctrl+T renders the notice, and the whole output stream contains no `ESC[3J`.
- Manually drove the built TUI in a real tmux TTY (100×24): expanded an 80-line thinking block (head scrolled into tmux scrollback), pressed Ctrl+T again → notice rendered, expansion frozen, all 80 rows still present in tmux scrollback with no screen clear; Ctrl+O on the in-viewport tool card still round-trips expand/collapse.

```
  reason-row-78
  reason-row-79
● Bash  $ npm test (41 lines)
done answering
Note: No thinking in view to toggle — thinking above stays as rendered in scrollback. New thinking
starts collapsed.
```
