### PR TITLE
feat(storage): compare-and-set credential writes

### DIFF
--- a/packages/storage/src/__tests__/credential-store.test.ts
+++ b/packages/storage/src/__tests__/credential-store.test.ts
@@ -7,7 +7,9 @@ import {
   CREDENTIAL_SCHEMA_VERSION,
   createFileCredentialStore,
   withCredentialFileLock,
+  type CredentialCasResult,
   type CredentialKind,
+  type CredentialStore,
 } from '../credential-store.js';
 
 const isPosix = process.platform !== 'win32';
@@ -207,6 +209,121 @@ describe('FileCredentialStore', () => {
           error.message.includes(`${path}.lock`)
           && /remove that directory and retry/.test(error.message),
       );
+    });
+  });
+});
+
+describe('FileCredentialStore compareAndSetSecret', () => {
+  // Optional capability: exercise it through a guarded helper so a store that
+  // does not expose CAS is a caller's own fallback problem, not a test crash.
+  function cas(
+    store: CredentialStore,
+    slug: string,
+    kind: CredentialKind,
+    expected: string | null,
+    value: string,
+  ): Promise<CredentialCasResult> {
+    assert.ok(store.compareAndSetSecret, 'file store exposes the CAS capability');
+    return store.compareAndSetSecret(slug, kind, expected, value);
+  }
+
+  test('the file store advertises the optional CAS capability', async () => {
+    await withTempDir(async (dir) => {
+      const store = createFileCredentialStore(dir);
+      assert.equal(typeof store.compareAndSetSecret, 'function');
+    });
+  });
+
+  test('commits when the basis still matches, and the write persists', async () => {
+    await withTempDir(async (dir) => {
+      const store = createFileCredentialStore(dir);
+      await store.setSecret('acct', 'oauth_token', 'tok-basis');
+
+      const result = await cas(store, 'acct', 'oauth_token', 'tok-basis', 'tok-next');
+      assert.deepEqual(result, { committed: true });
+      assert.equal(await store.getSecret('acct', 'oauth_token'), 'tok-next');
+    });
+  });
+
+  test('commits a write-if-absent (expected null) only while the entry is absent', async () => {
+    await withTempDir(async (dir) => {
+      // The one-shot legacy import: decide "store has no token" and write in one
+      // serialized step. A value written between the check and the write must
+      // make the import lose, not clobber.
+      const importer = createFileCredentialStore(dir);
+      const other = createFileCredentialStore(dir);
+
+      // Someone writes a token after the importer would have read "absent".
+      await other.setSecret('acct', 'oauth_token', 'tok-live');
+
+      const blocked = await cas(importer, 'acct', 'oauth_token', null, 'tok-import');
+      assert.deepEqual(blocked, { committed: false, current: 'tok-live' });
+      assert.equal(await other.getSecret('acct', 'oauth_token'), 'tok-live');
+
+      // With a genuinely absent entry the same write-if-absent commits.
+      const committed = await cas(importer, 'other-acct', 'oauth_token', null, 'tok-import');
+      assert.deepEqual(committed, { committed: true });
+      assert.equal(await importer.getSecret('other-acct', 'oauth_token'), 'tok-import');
+    });
+  });
+
+  test('two store instances racing on the same basis: loser sees the entry changed and adopts it', async () => {
+    await withTempDir(async (dir) => {
+      // Two separate instances share the file (a cross-process refresh). Both
+      // read the same basis; only the file lock decides the winner.
+      const a = createFileCredentialStore(dir);
+      const b = createFileCredentialStore(dir);
+      await a.setSecret('acct', 'oauth_token', 'tok-basis');
+
+      // A commits first, then B tries with the now-stale basis.
+      const winner = await cas(a, 'acct', 'oauth_token', 'tok-basis', 'tok-A');
+      const loser = await cas(b, 'acct', 'oauth_token', 'tok-basis', 'tok-B');
+
+      assert.deepEqual(winner, { committed: true });
+      // Entry changed (not gone): current is a string the loser adopts.
+      assert.deepEqual(loser, { committed: false, current: 'tok-A' });
+      const reader = createFileCredentialStore(dir);
+      assert.equal(await reader.getSecret('acct', 'oauth_token'), 'tok-A');
+    });
+  });
+
+  test('a basis whose entry was deleted (logout) is distinguishable from a changed one', async () => {
+    await withTempDir(async (dir) => {
+      const a = createFileCredentialStore(dir);
+      const b = createFileCredentialStore(dir);
+      await a.setSecret('acct', 'oauth_token', 'tok-basis');
+
+      // A terminal logout removes the entry after B read its basis.
+      await a.deleteSecret('acct', 'oauth_token');
+
+      const result = await cas(b, 'acct', 'oauth_token', 'tok-basis', 'tok-resurrect');
+      // Entry gone (current === null): the caller must NOT resurrect it, and the
+      // write did not commit.
+      assert.deepEqual(result, { committed: false, current: null });
+      const reader = createFileCredentialStore(dir);
+      assert.equal(await reader.getSecret('acct', 'oauth_token'), null);
+    });
+  });
+
+  test('concurrent CAS from the same basis: exactly one wins, the loser returns the winner value', async () => {
+    await withTempDir(async (dir) => {
+      const a = createFileCredentialStore(dir);
+      const b = createFileCredentialStore(dir);
+      await a.setSecret('acct', 'oauth_token', 'tok-basis');
+
+      const [ra, rb] = await Promise.all([
+        cas(a, 'acct', 'oauth_token', 'tok-basis', 'tok-A'),
+        cas(b, 'acct', 'oauth_token', 'tok-basis', 'tok-B'),
+      ]);
+
+      const winners = [ra, rb].filter((r) => r.committed);
+      assert.equal(winners.length, 1, 'exactly one CAS commits');
+      const winnerValue = ra.committed ? 'tok-A' : 'tok-B';
+      const loser = ra.committed ? rb : ra;
+      assert.deepEqual(loser, { committed: false, current: winnerValue });
+
+      const reader = createFileCredentialStore(dir);
+      assert.equal(await reader.getSecret('acct', 'oauth_token'), winnerValue);
     });
   });
 });

--- a/packages/storage/src/credential-store.ts
+++ b/packages/storage/src/credential-store.ts
@@ -49,12 +49,53 @@ interface CredentialFile {
   values: Record<string, string>;
 }
 
+/**
+ * Outcome of a compare-and-set write.
+ *
+ * `committed: true` — the basis was still the stored authority, so the new
+ * value was persisted (this caller is the winner).
+ *
+ * `committed: false` — the basis was stale; someone committed first. `current`
+ * is what the store holds instead, and it distinguishes the two loser cases the
+ * refresh lifecycle must tell apart:
+ *   - `current === null`: the entry is gone. A terminal delete (e.g. a logout)
+ *     happened after the caller read its basis; the caller must NOT resurrect it.
+ *   - `current` is a string: the entry was changed by a concurrent winner. The
+ *     caller adopts `current` instead of overwriting it.
+ */
+export type CredentialCasResult =
+  | { committed: true }
+  | { committed: false; current: string | null };
+
 export interface CredentialStore {
   getSecret(slug: string, kind: CredentialKind): Promise<string | null>;
   setSecret(slug: string, kind: CredentialKind, value: string): Promise<void>;
   /** Delete one kind, or — with no kind — every kind for the slug (e.g. a
    *  connection being removed). */
   deleteSecret(slug: string, kind?: CredentialKind): Promise<void>;
+  /**
+   * Optional compare-and-set write. Persist `value` for `(slug, kind)` only
+   * while the stored entry still equals `expected` — the basis the caller read
+   * before deciding to write. `expected: null` asserts the entry is absent, for
+   * a write-if-not-present (e.g. the one-shot legacy import deciding "store
+   * already has a token" and writing inside one serialized step).
+   *
+   * The basis check and the write run together under the same cross-process
+   * lock as `setSecret`, so no concurrent writer can slip in between them; the
+   * check is a specialization of the current read-modify-write, not a lease held
+   * across any external I/O.
+   *
+   * Optional capability: third-party `CredentialStore` implementations and the
+   * future `credential_provider` backends stay source-compatible without it.
+   * When it is absent, callers fall back to an unconditional `setSecret`
+   * (today's behavior).
+   */
+  compareAndSetSecret?(
+    slug: string,
+    kind: CredentialKind,
+    expected: string | null,
+    value: string,
+  ): Promise<CredentialCasResult>;
 }
 
 export function createFileCredentialStore(workspaceRoot: string): CredentialStore {
@@ -203,6 +244,33 @@ class FileCredentialStore implements CredentialStore {
   private set(slug: string, kind: StoredCredentialKind, value: string): Promise<void> {
     return this.mutate((values) => {
       values[this.key(slug, kind)] = value;
+    });
+  }
+
+  /**
+   * Compare-and-set specialization of the read-modify-write: read under the
+   * lock, verify the stored entry still equals the caller's basis, and only then
+   * write. A mismatch commits nothing and reports what the store holds so the
+   * loser can distinguish a terminal delete (`current === null`) from a
+   * concurrent winner it must adopt (`current` is a string).
+   */
+  compareAndSetSecret(
+    slug: string,
+    kind: CredentialKind,
+    expected: string | null,
+    value: string,
+  ): Promise<CredentialCasResult> {
+    const key = this.key(slug, toStoredKind(kind));
+    return withCredentialFileLock(this.path, async () => {
+      const file = await this.readUnlocked();
+      const stored = file.values[key];
+      const current = stored === undefined ? null : stored;
+      if (current !== expected) {
+        return { committed: false, current };
+      }
+      file.values[key] = value;
+      await this.write(file);
+      return { committed: true };
     });
   }
 

--- a/packages/storage/src/index.ts
+++ b/packages/storage/src/index.ts
@@ -11,6 +11,7 @@ export {
   migrateLegacyCredentialFile,
 } from './credential-store.js';
 export type {
+  CredentialCasResult,
   CredentialKind,
   CredentialStore,
   LegacyCredentialDecryptor,


### PR DESCRIPTION
## Summary

Step 1 of #1133. The shared `CredentialStore` is the single OAuth token authority, but its refresh lifecycle is still "read → network → unconditional write", so a cross-process interleaving can commit a result whose basis is no longer current. This adds the storage primitive that lets the runtime (step 2) commit only on a still-current basis.

`compareAndSetSecret` persists a value for `(slug, kind)` only while the stored entry still equals the caller's basis. It is a specialization of the existing read-modify-write: the basis check and the write run together inside the same never-stolen `withCredentialFileLock`, so no concurrent writer slips between them. No lease is held across any network I/O by design (the issue explicitly rejects that).

The result distinguishes the two loser cases the refresh lifecycle must tell apart:
- `committed: false, current: null` — the entry is gone (a terminal delete, e.g. a logout); the caller must not resurrect it.
- `committed: false, current: <string>` — a concurrent winner changed the entry; the caller adopts `current` instead of overwriting it.

It is an optional member of the structural `CredentialStore` type, so third-party implementations and the future `credential_provider` backends stay source-compatible; callers fall back to an unconditional `setSecret` when it is absent.

Scope is storage only. The runtime refresh transaction (step 2) and the desktop service migration (step 3) remain; this is not a `Fixes`.

## Verification

Run from `packages/storage`:
- `npm run typecheck` — clean.
- `npm test` (`clean && build && test:dist`) — 292 pass, 1 skipped (a Windows-only case), 0 fail; the new `FileCredentialStore compareAndSetSecret` block (6 tests) covers: capability presence, commit-on-matching-basis with persistence, write-if-absent (`expected: null`) for the import TOCTOU, two instances racing on one basis (loser sees the entry changed and adopts it), logout making the entry gone (`current: null`, distinguishable and not resurrected), and a concurrent `Promise.all` race where exactly one commits and the loser returns the winner value. All fake credential values.