### PR TITLE
refactor(desktop): fold Copilot modal guard onto shared one-shot action guard

### DIFF
--- a/apps/desktop/src/renderer/settings/provider-oauth-section.tsx
+++ b/apps/desktop/src/renderer/settings/provider-oauth-section.tsx
@@ -21,6 +21,7 @@ import {
 import { type StatusTone } from './settings-status-badge';
 import { ProviderLogo } from './provider-display';
 import { ProviderConnectionDialog } from './provider-connection-dialog';
+import { createOneShotActionGuard } from './oauth-login-flow-guard';
 import {
   useOAuthLoginFlow,
   subscriptionActionErrorMessage,
@@ -331,10 +332,15 @@ async function getSubscriptionSnapshot(serviceId: OAuthServiceId): Promise<Subsc
   return (await window.maka.openAiCodex.getAccountState()) as SubscriptionSnapshot;
 }
 
+type GitHubCopilotPendingAction = 'connect' | 'refresh' | 'logout';
+
 function GitHubCopilotSubscriptionModal(props: { onClose(): void }) {
   const [state, setState] = useState<SubscriptionSnapshot | null>(null);
-  const [pendingAction, setPendingAction] = useState<'connect' | 'refresh' | 'logout' | null>(null);
-  const pendingRef = useRef<typeof pendingAction>(null);
+  const [pendingAction, setPendingAction] = useState<GitHubCopilotPendingAction | null>(null);
+  // Same synchronous one-shot guard useOAuthLoginFlow relies on: reject a
+  // second concurrent action before React can re-render the disabled button,
+  // instead of hand-rolling a parallel pendingRef lifecycle here.
+  const pendingGuard = useRef(createOneShotActionGuard<GitHubCopilotPendingAction>()).current;
   const mountedRef = useMountedRef();
   const toast = useToast();
 
@@ -345,9 +351,8 @@ function GitHubCopilotSubscriptionModal(props: { onClose(): void }) {
 
   useEffect(() => { void refreshState(); }, []);
 
-  async function runAction(action: NonNullable<typeof pendingAction>) {
-    if (pendingRef.current) return;
-    pendingRef.current = action;
+  async function runAction(action: GitHubCopilotPendingAction) {
+    if (!pendingGuard.begin(action)) return;
     setPendingAction(action);
     try {
       const result = action === 'connect'
@@ -360,7 +365,7 @@ function GitHubCopilotSubscriptionModal(props: { onClose(): void }) {
     } catch (error) {
       if (mountedRef.current) toast.error('GitHub Copilot 账号操作失败', subscriptionActionErrorMessage(error));
     } finally {
-      pendingRef.current = null;
+      pendingGuard.finish();
       if (mountedRef.current) setPendingAction(null);
     }
   }


### PR DESCRIPTION
## Summary

`GitHubCopilotSubscriptionModal` in `provider-oauth-section.tsx` hand-rolled its own
duplicate-action guard — a local `pendingRef` (`useRef`) plus a `setPendingAction`
lifecycle — that re-implemented the exact synchronous one-shot guard the shared OAuth
seam already provides. This folds the modal onto that shared, unit-tested primitive:
`createOneShotActionGuard` from `oauth-login-flow-guard.ts` (the same guard
`useOAuthLoginFlow` holds in a ref). `runAction` now gates through
`pendingGuard.begin(action)` / `pendingGuard.finish()` instead of a parallel `pendingRef`.

Behavior is preserved exactly: a second concurrent connect/refresh/logout is still
rejected synchronously before React re-renders the disabled buttons, and the pending
label state still clears only when the component is still mounted. Copilot's flow is
connect/refresh/logout IPC round-trips (not the browser-loopback login/logout that
`useOAuthLoginFlow` drives), so this reuses the guard seam rather than routing the modal
through the browser-handoff hook, which would change behavior.

This is the OAuth guard slice of #1042; extracting `ClaudeSubscriptionCard` and the
bot-chat split remain open under that issue. Renderer-only — no main-process subscription
service changes.

Refs #1042

## Verification

Ran from `apps/desktop` in the feature worktree:

- `npm run typecheck` — passed (main + renderer + storybook projects).
- `npm test` — 2594 pass / 0 fail, including `oauth-login-flow-guard.test.ts` and the
  `model-oauth-section-contract` source-invariant tests.
- `npx playwright test e2e/settings.spec.ts e2e/providers.spec.ts` — 10 passed
  (fake backend, deterministic).
