### PR TITLE
feat(cli): trigger slash-command completion for any /-token, not just line start

### DIFF
--- a/packages/cli/src/__tests__/pi-tui-runner.test.ts
+++ b/packages/cli/src/__tests__/pi-tui-runner.test.ts
@@ -1,8 +1,11 @@
 import assert from 'node:assert/strict';
 import { spawn } from 'node:child_process';
 import { once } from 'node:events';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { setTimeout as delay } from 'node:timers/promises';
-import { before, describe, test } from 'node:test';
+import { after, before, describe, test } from 'node:test';
 import { visibleWidth } from '@earendil-works/pi-tui';
 import {
   SHELL_RUN_UPDATE_BUFFER_MAX_ENTRIES,
@@ -23,6 +26,7 @@ import type {
   RewindTarget,
   SessionResumeAvailability,
 } from '../session-driver.js';
+import { MakaAutocompleteProvider } from '../pi-tui-pickers.js';
 import { runMakaPiTui } from '../pi-tui-runner.js';
 import { _setColorLevelForTesting } from '../tui-ansi.js';
 import { BUSY_SPINNER_FRAMES } from '../tui-attention.js';
@@ -3951,6 +3955,81 @@ describe('Maka Pi TUI runner', () => {
     assert.equal(terminal.titles.at(-1), 'Maka');
   });
 
+});
+
+describe('MakaAutocompleteProvider slash-token completion', () => {
+  const commands = [
+    { name: 'compact', description: 'compact the transcript' },
+    { name: 'config', description: 'open config' },
+    { name: 'model', description: 'switch model' },
+  ];
+  const signal = new AbortController().signal;
+
+  // A hermetic base path with one known file so the file-provider fall-through
+  // is deterministic instead of reading the machine's real /Users tree.
+  let baseDir: string;
+  before(() => {
+    baseDir = mkdtempSync(join(tmpdir(), 'maka-slash-'));
+    writeFileSync(join(baseDir, 'findings.txt'), '');
+  });
+  after(() => rmSync(baseDir, { recursive: true, force: true }));
+
+  function suggest(line: string) {
+    const provider = new MakaAutocompleteProvider(baseDir, commands);
+    return provider.getSuggestions([line], 0, line.length, { signal });
+  }
+
+  const values = (result: { items: { value: string }[] } | null) =>
+    (result?.items ?? []).map((item) => item.value);
+
+  test('completes a `/` token that begins mid-message', async () => {
+    const result = await suggest('see /co');
+    assert.equal(result?.prefix, '/co');
+    assert.deepEqual(values(result), ['compact', 'config']);
+  });
+
+  test('leaves line-start command completion unchanged', async () => {
+    const bare = await suggest('/');
+    assert.equal(bare?.prefix, '/');
+    assert.deepEqual(values(bare), ['compact', 'config', 'model']);
+
+    const filtered = await suggest('/co');
+    assert.equal(filtered?.prefix, '/co');
+    assert.deepEqual(values(filtered), ['compact', 'config']);
+  });
+
+  test('does not treat an absolute path token as a command (falls through to files)', async () => {
+    const result = await suggest(`see ${baseDir}/fi`);
+    // The token is a path, no command matches, so the file provider answers with
+    // the path prefix and the matching file — never the command items.
+    assert.equal(result?.prefix, `${baseDir}/fi`);
+    assert.deepEqual(values(result), [`${baseDir}/findings.txt`]);
+    assert.equal(values(result).some((value) => commands.some((c) => c.name === value)), false);
+  });
+
+  test('applies a mid-message command completion as a `/name ` token', () => {
+    const provider = new MakaAutocompleteProvider(baseDir, commands);
+    const line = 'see /co';
+    const applied = provider.applyCompletion([line], 0, line.length, { value: 'compact', label: '/compact' }, '/co');
+    assert.deepEqual(applied.lines, ['see /compact ']);
+    assert.equal(applied.cursorLine, 0);
+    assert.equal(applied.cursorCol, 'see /compact '.length);
+  });
+
+  test('applies a path completion through the file provider, not as a command', () => {
+    const provider = new MakaAutocompleteProvider(baseDir, commands);
+    const prefix = `${baseDir}/fi`;
+    const line = `see ${prefix}`;
+    const applied = provider.applyCompletion(
+      [line],
+      0,
+      line.length,
+      { value: `${baseDir}/findings.txt`, label: 'findings.txt' },
+      prefix,
+    );
+    // The chosen path is inserted verbatim; it is never rewritten to `/findings.txt `.
+    assert.deepEqual(applied.lines, [`see ${baseDir}/findings.txt`]);
+  });
 });
 
 /** Count the standalone BEL bytes the attention layer wrote. */

--- a/packages/cli/src/pi-tui-pickers.ts
+++ b/packages/cli/src/pi-tui-pickers.ts
@@ -46,7 +46,10 @@ export class MakaAutocompleteProvider implements AutocompleteProvider {
           label: `/${command.name}`,
           description: command.description,
         }));
-      return items.length > 0 ? { items, prefix: slashPrefix } : null;
+      // Only claim the token when a command actually matches; otherwise fall
+      // through so a `/`-token that is really a path (e.g. `/Users/…`) still
+      // reaches the file provider instead of being swallowed as a dead command.
+      if (items.length > 0) return { items, prefix: slashPrefix };
     }
     return this.fileProvider.getSuggestions(lines, cursorLine, cursorCol, options);
   }
@@ -60,7 +63,13 @@ export class MakaAutocompleteProvider implements AutocompleteProvider {
   ): { lines: string[]; cursorLine: number; cursorCol: number } {
     const currentLine = lines[cursorLine] || '';
     const beforePrefix = currentLine.slice(0, cursorCol - prefix.length);
-    if (prefix.startsWith('/') && beforePrefix.trim() === '') {
+    // Identify a command completion by the chosen item being a real command
+    // rather than by position: the token can now start mid-message, and a
+    // path item (value = a filesystem path) never equals a bare command name,
+    // so a `/Users/…` completion still routes to the file provider below.
+    const isSlashCommand =
+      prefix.startsWith('/') && this.slashCommands.some((command) => command.name === item.value);
+    if (isSlashCommand) {
       const nextLines = [...lines];
       nextLines[cursorLine] = `${beforePrefix}/${item.value} ${currentLine.slice(cursorCol)}`;
       return {
@@ -86,10 +95,17 @@ export interface MakaSlashCommand extends MakaSlashCommandMetadata {
   run(parts: string[]): void;
 }
 
+// The `/`-token under the cursor: a `/` that begins a token — at line start or
+// immediately after whitespace — followed by the run of non-whitespace up to the
+// cursor. This lets command completion fire mid-message, not only at column 0.
+// A non-command token (e.g. `/Users/x`) is returned too; the caller falls back
+// to the file provider when no command matches, so paths are never hijacked.
+const SLASH_TOKEN = /(?:^|\s)(\/\S*)$/;
+
 function slashCommandPrefix(lines: string[], cursorLine: number, cursorCol: number): string | null {
   const currentLine = lines[cursorLine] || '';
   const textBeforeCursor = currentLine.slice(0, cursorCol);
-  return textBeforeCursor.startsWith('/') && !textBeforeCursor.includes(' ') ? textBeforeCursor : null;
+  return SLASH_TOKEN.exec(textBeforeCursor)?.[1] ?? null;
 }
 
 export class PickerOverlay implements Component {


### PR DESCRIPTION
## Summary

Gap 2 of #1100: `/` now triggers command completion wherever it begins a token — at line start **or** immediately after whitespace — instead of only at column 0. Typing `/co` mid-message now surfaces the matching commands, while a `/`-token that is really a path (e.g. `/Users/…`) still falls through to the file provider and is never hijacked.

`slashCommandPrefix` (`packages/cli/src/pi-tui-pickers.ts`) now returns the whitespace-delimited `/`-token under the cursor. `getSuggestions` claims that token only when a command actually matches; otherwise it falls through to the file provider, so both mid-message and line-start path tokens keep completing as paths. `applyCompletion` now identifies a command by the chosen item being a real command (rather than by cursor position), so a mid-message command inserts as `/name ` and a `/Users/…` completion is applied verbatim as a path.

Completion-only — execution semantics are unchanged: a message runs as a command solely when the whole message starts with `/`. The `/skills` picker (gap 1) is intentionally out of scope, so this references rather than closes the issue.

## Verification

- `npm run typecheck` (packages/cli) — clean.
- `npm test` (packages/cli) — 467 pass / 0 fail, including 5 new unit tests in `pi-tui-runner.test.ts` covering: mid-message `/co` → command items; line-start `/` and `/co` unchanged; an absolute-path token → file provider, not command items; mid-message command application inserts `/name `; path completion applied verbatim, not as a command.

Refs #1100



## Closure note

Closed after adversarial review reproduced the feature against the real `pi-tui` Editor. The provider is never invoked for a mid-message `/` token, and selecting a slash-prefixed completion would submit the whole message. `pi-tui` 0.80.9 still excludes `/` from provider-defined trigger characters and retains the slash-prefix submit behavior. Without an accepted upstream change or a maintained dependency fork/patch, this repository-only change cannot deliver the stated behavior. We are therefore closing the slice rather than merging unreachable code; #1100 remains open.
