### PR TITLE
fix(headless): frame isolated Edit file reads

### DIFF
--- a/packages/headless/src/__tests__/harbor-cell-file-tools.test.ts
+++ b/packages/headless/src/__tests__/harbor-cell-file-tools.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { mkdtemp, writeFile } from 'node:fs/promises';
+import { mkdtemp, readFile, writeFile } from 'node:fs/promises';
 import { describe, test } from 'node:test';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -56,5 +56,64 @@ describe('Harbor local executor file tools (real spawn)', () => {
     // (Glob/Grep share the same command-backed executor.exec with no boundedTail
     //  flag — see the "only Bash opts into bounded-tail" contract test — so this
     //  head-first guarantee covers them too without generating MBs of matches.)
+  });
+
+  test('Edit fails closed when the real executor boundary appends job-control output', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'maka-harbor-edit-noise-'));
+    const file = join(cwd, 'data.txt');
+    const original = Buffer.from('alpha marker\n', 'utf8');
+    await writeFile(file, original);
+    const realExecutor = createHarborCellLocalToolExecutor();
+    const tools = buildIsolatedHeadlessTools({
+      ...realExecutor,
+      async exec(input, control) {
+        const result = await realExecutor.exec(input, control);
+        if (input.command.includes('MAKA_EDIT_BYTES_V1') && result.exitCode === 0) {
+          return {
+            ...result,
+            stdout: `${result.stdout}[1]+ Done env MAKA_HARBOR_COMMAND_SCOPE=test\n`,
+          };
+        }
+        return result;
+      },
+    });
+
+    await assert.rejects(
+      async () => await tool(tools, 'Edit').impl(
+        { path: 'data.txt', old_string: 'alpha', new_string: 'beta' },
+        toolCtx(cwd),
+      ),
+      /Edit read transport integrity check failed/,
+    );
+    assert.deepEqual(await readFile(file), original, 'a contaminated read must not reach the write boundary');
+  });
+
+  test('Edit preserves unrelated non-UTF-8 bytes across shorter and longer replacements', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'maka-harbor-edit-bytes-'));
+    const file = join(cwd, 'data.bin');
+    await writeFile(file, Buffer.concat([
+      Buffer.from([0xff]),
+      Buffer.from('alpha marker tail', 'utf8'),
+      Buffer.from([0xfe]),
+    ]));
+    const tools = buildIsolatedHeadlessTools(createHarborCellLocalToolExecutor());
+
+    await tool(tools, 'Edit').impl(
+      { path: 'data.bin', old_string: 'alpha marker', new_string: 'x' },
+      toolCtx(cwd),
+    );
+    assert.deepEqual(
+      await readFile(file),
+      Buffer.concat([Buffer.from([0xff]), Buffer.from('x tail', 'utf8'), Buffer.from([0xfe])]),
+    );
+
+    await tool(tools, 'Edit').impl(
+      { path: 'data.bin', old_string: 'x', new_string: 'a much longer marker' },
+      toolCtx(cwd),
+    );
+    assert.deepEqual(
+      await readFile(file),
+      Buffer.concat([Buffer.from([0xff]), Buffer.from('a much longer marker tail', 'utf8'), Buffer.from([0xfe])]),
+    );
   });
 });

--- a/packages/headless/src/__tests__/tools.test.ts
+++ b/packages/headless/src/__tests__/tools.test.ts
@@ -1,5 +1,6 @@
 import assert from 'node:assert/strict';
 import { exec as childExec } from 'node:child_process';
+import { createHash } from 'node:crypto';
 import { chmod, mkdir, mkdtemp, readFile, stat, symlink, writeFile } from 'node:fs/promises';
 import { describe, test } from 'node:test';
 import { tmpdir } from 'node:os';
@@ -474,6 +475,92 @@ describe('isolated headless tools', () => {
     assert.deepEqual(nativeCalls, []);
   });
 
+  test('Edit rejects unframed file bytes mixed with executor stdout noise before writing', async () => {
+    const source = Buffer.from('alpha marker', 'utf8');
+    let execCalls = 0;
+    const tools = buildIsolatedHeadlessTools({
+      async exec() {
+        execCalls += 1;
+        if (execCalls === 1) {
+          return {
+            exitCode: 0,
+            stdout: `${source.toString('base64')}\n[1]+ Done env MAKA_HARBOR_COMMAND_SCOPE=test\n`,
+            stderr: '',
+          };
+        }
+        return { exitCode: 0, stdout: '', stderr: '' };
+      },
+    });
+
+    await assert.rejects(
+      async () => await tool(tools, 'Edit').impl(
+        { path: 'data.txt', old_string: 'alpha', new_string: 'beta' },
+        toolCtx('/workspace'),
+      ),
+      /Edit read transport integrity check failed/,
+    );
+    assert.equal(execCalls, 1, 'a rejected read must not reach the write command');
+  });
+
+  test('Edit rejects ambiguous or corrupted read frames before writing', async (t) => {
+    const source = Buffer.from('alpha', 'utf8');
+    const valid = editReadFrame(source);
+    const cases = [
+      { name: 'output before the frame', stdout: `job started\n${valid}` },
+      { name: 'output after the frame', stdout: `${valid}[1]+ Done env MAKA_HARBOR_COMMAND_SCOPE=test\n` },
+      { name: 'duplicate frame', stdout: `${valid}${valid}` },
+      { name: 'truncated frame', stdout: valid.replace('MAKA_EDIT_BYTES_END\n', '') },
+      { name: 'unsupported frame version', stdout: valid.replace('MAKA_EDIT_BYTES_V1', 'MAKA_EDIT_BYTES_V2') },
+      { name: 'non-canonical Base64', stdout: valid.replace('YWxwaGE=', 'YWxwaGE') },
+      { name: 'byte length mismatch', stdout: valid.replace('length=5', 'length=6') },
+      { name: 'SHA-256 mismatch', stdout: valid.replace(/sha256=./, 'sha256=0') },
+    ];
+
+    for (const scenario of cases) {
+      await t.test(scenario.name, async () => {
+        let execCalls = 0;
+        const tools = buildIsolatedHeadlessTools({
+          async exec() {
+            execCalls += 1;
+            return execCalls === 1
+              ? { exitCode: 0, stdout: scenario.stdout, stderr: '' }
+              : { exitCode: 0, stdout: '', stderr: '' };
+          },
+        });
+
+        await assert.rejects(
+          async () => await tool(tools, 'Edit').impl(
+            { path: 'data.txt', old_string: 'alpha', new_string: 'beta' },
+            toolCtx('/workspace'),
+          ),
+          /Edit read transport integrity check failed/,
+        );
+        assert.equal(execCalls, 1, 'a rejected frame must not reach the write command');
+      });
+    }
+  });
+
+  test('Edit rejects a successful write result when the stored bytes do not match', async () => {
+    const source = Buffer.from('alpha marker', 'utf8');
+    let execCalls = 0;
+    const tools = buildIsolatedHeadlessTools({
+      async exec() {
+        execCalls += 1;
+        if (execCalls === 2) return { exitCode: 0, stdout: '', stderr: '' };
+        return { exitCode: 0, stdout: editReadFrame(source), stderr: '' };
+      },
+    });
+
+    await assert.rejects(
+      async () => await tool(tools, 'Edit').impl(
+        { path: 'data.txt', old_string: 'alpha', new_string: 'beta' },
+        toolCtx('/workspace'),
+      ),
+      /Edit post-write verification failed/,
+    );
+    assert.equal(execCalls, 3, 'Edit must read the stored bytes after the write reports success');
+  });
+
   test('enabled heavy-task evidence recorder captures Bash, Read, Grep, Write, and Edit results', async () => {
     const store = createInMemoryTaskRunStore();
     let id = 0;
@@ -484,12 +571,14 @@ describe('isolated headless tools', () => {
       now: () => 100 + id,
       newId: () => `id-${++id}`,
     });
+    let editBytes = Buffer.from('old payload', 'utf8');
     const tools = buildIsolatedHeadlessTools({
       async exec(input) {
         if (input.command.includes('Edit path') && input.command.includes('base64 < "$target"')) {
-          return { exitCode: 0, stdout: `${Buffer.from('old payload', 'utf8').toString('base64')}\n`, stderr: '' };
+          return { exitCode: 0, stdout: editReadFrame(editBytes), stderr: '' };
         }
         if (input.command.includes('Edit path')) {
+          editBytes = Buffer.from('new payload', 'utf8');
           return { exitCode: 0, stdout: '', stderr: '' };
         }
         // Read now runs through READ_SCRIPT (no native fast path); the script
@@ -1096,6 +1185,7 @@ describe('isolated headless tools', () => {
     // setImmediate yields force an overlap window when serialization is absent.
     let active = 0;
     let maxActive = 0;
+    let editBytes = Buffer.from('alpha marker', 'utf8');
     const tools = buildIsolatedHeadlessTools({
       async exec(input) {
         active += 1;
@@ -1104,8 +1194,9 @@ describe('isolated headless tools', () => {
         await new Promise((r) => setImmediate(r));
         active -= 1;
         if (input.command.includes('base64 < "$target"')) {
-          return { exitCode: 0, stdout: `${Buffer.from('alpha marker', 'utf8').toString('base64')}\n`, stderr: '' };
+          return { exitCode: 0, stdout: editReadFrame(editBytes), stderr: '' };
         }
+        if (input.command.includes('Edit path')) editBytes = Buffer.from('beta marker', 'utf8');
         return { exitCode: 0, stdout: '', stderr: '' };
       },
     });
@@ -1260,4 +1351,9 @@ function toolCtx(cwd: string) {
     abortSignal: new AbortController().signal,
     emitOutput: () => {},
   };
+}
+
+function editReadFrame(content: Buffer): string {
+  const digest = createHash('sha256').update(content).digest('hex');
+  return `MAKA_EDIT_BYTES_V1 length=${content.length} sha256=${digest}\n${content.toString('base64')}\nMAKA_EDIT_BYTES_END\n`;
 }

--- a/packages/headless/src/tools.ts
+++ b/packages/headless/src/tools.ts
@@ -7,6 +7,7 @@ import {
   computeEditedSource,
 } from '@maka/runtime';
 import { withFileWriteLock } from '@maka/runtime/file-write-lock';
+import { createHash } from 'node:crypto';
 import { posix as pathPosix } from 'node:path';
 import { z } from 'zod';
 import type { HeavyTaskEvidenceRecorder } from './heavy-task-evidence.js';
@@ -37,6 +38,10 @@ export interface BuildIsolatedHeadlessToolsOptions {
 // so the executor — not this layer — owns canonicalization.
 const fileWriteKey = (cwd: string, normalizedPath: string) =>
   JSON.stringify([pathPosix.normalize(cwd), pathPosix.normalize(normalizedPath)]);
+
+const EDIT_READ_FRAME_END = 'MAKA_EDIT_BYTES_END';
+const EDIT_READ_FRAME_HEADER_PATTERN = /^MAKA_EDIT_BYTES_V1 length=(0|[1-9]\d*) sha256=([a-f0-9]{64})$/;
+const CANONICAL_BASE64_PATTERN = /^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/;
 /**
  * Build Maka's standard headless tool surface with shell and file operations
  * routed through the isolated executor boundary.
@@ -205,6 +210,10 @@ export function buildIsolatedEditTool(
         const raw = await readIsolatedFileBytes(executor, cwd, normalizedPath, ctx.abortSignal);
         const { content, ...metadata } = computeEditBytes(raw, old_string, new_string, normalizedPath);
         await writeIsolatedFileBytes(executor, cwd, normalizedPath, content, ctx.abortSignal);
+        const stored = await readIsolatedFileBytes(executor, cwd, normalizedPath, ctx.abortSignal);
+        if (!stored.equals(content)) {
+          throw new Error(`Edit post-write verification failed for ${normalizedPath}: stored bytes differ from the replacement result`);
+        }
         const result = { ok: true, path: normalizedPath, replacements: 1, ...metadata };
         await options.heavyTaskEvidence?.recordToolEvidence({ name: 'Edit', input, result }, ctx);
         return result;
@@ -311,7 +320,38 @@ async function readIsolatedFileBytes(
   abortSignal: AbortSignal,
 ): Promise<Buffer> {
   const stdout = await execFileCommand(executor, cwd, shellFileCommand(EDIT_READ_BYTES_SCRIPT, [path]), abortSignal);
-  return Buffer.from(stdout.replace(/\s+/g, ''), 'base64');
+  return parseEditReadFrame(stdout);
+}
+
+function parseEditReadFrame(stdout: string): Buffer {
+  const lines = stdout.split('\n');
+  if (lines.length !== 4 || lines[3] !== '' || lines[2] !== EDIT_READ_FRAME_END) {
+    throw editReadIntegrityError('expected exactly one complete frame with no surrounding output');
+  }
+
+  const header = lines[0]?.match(EDIT_READ_FRAME_HEADER_PATTERN);
+  if (!header) throw editReadIntegrityError('frame header is missing or malformed');
+  const expectedLength = Number(header[1]);
+  if (!Number.isSafeInteger(expectedLength)) throw editReadIntegrityError('declared byte length is not safe');
+
+  const payload = lines[1] ?? '';
+  if (!CANONICAL_BASE64_PATTERN.test(payload)) {
+    throw editReadIntegrityError('payload is not canonical Base64');
+  }
+  const decoded = Buffer.from(payload, 'base64');
+  if (decoded.toString('base64') !== payload) {
+    throw editReadIntegrityError('payload is not canonical Base64');
+  }
+  if (decoded.length !== expectedLength) {
+    throw editReadIntegrityError(`declared ${expectedLength} bytes but decoded ${decoded.length}`);
+  }
+  const actualDigest = createHash('sha256').update(decoded).digest('hex');
+  if (actualDigest !== header[2]) throw editReadIntegrityError('SHA-256 digest mismatch');
+  return decoded;
+}
+
+function editReadIntegrityError(reason: string): Error {
+  return new Error(`Edit read transport integrity check failed: ${reason}`);
 }
 
 async function writeIsolatedFileBytes(
@@ -558,7 +598,17 @@ printf '%s' "$2" > "$target"
 const EDIT_READ_BYTES_SCRIPT = `${COMMON_SHELL_HELPERS}
 root=$(pwd -P) || exit 1
 target=$(existing_target "$1" 'Edit path') || exit 1
-base64 < "$target"
+size=$(wc -c < "$target" | tr -d '[:space:]') || exit 1
+if command -v sha256sum >/dev/null 2>&1; then
+  digest=$(sha256sum "$target" | awk '{print $1}') || exit 1
+elif command -v shasum >/dev/null 2>&1; then
+  digest=$(shasum -a 256 "$target" | awk '{print $1}') || exit 1
+else
+  fail 'SHA-256 utility is required for Edit transport'
+fi
+printf 'MAKA_EDIT_BYTES_V1 length=%s sha256=%s\n' "$size" "$digest"
+base64 < "$target" | LC_ALL=C tr -d '\\r\\n'
+printf '\nMAKA_EDIT_BYTES_END\n'
 `;
 
 const EDIT_WRITE_BYTES_SCRIPT = `${COMMON_SHELL_HELPERS}


### PR DESCRIPTION
## Summary

- replace the unframed isolated Edit Base64 stdout contract with a versioned frame containing byte length and SHA-256
- reject missing, duplicate, malformed, non-canonical, truncated, contaminated, length-mismatched, and digest-mismatched frames before writing
- read back the stored bytes after an atomic write and fail closed if they differ from the computed replacement
- preserve byte-exact non-UTF-8 edits and existing per-file serialization

## Regression coverage

- reproduces the observed Base64 plus job-control notification corruption
- covers surrounding output, duplicate/truncated frames, unsupported versions, Base64 canonicality, length, and digest validation
- exercises shortening and lengthening edits around non-UTF-8 bytes
- verifies contamination through the real Harbor local executor boundary
- retains the existing concurrent Edit serialization tests

## Verification

- `npm run lint`
- `npm run typecheck`
- `npm --workspace @maka/headless test` (`1080` passed, `0` failed, `1` skipped)
- focused Edit and Harbor boundary tests (`50` passed)

Closes #1111