### PR TITLE
refactor(ui): decompose composer and plan-reminder panels into focused hooks (#1044)

### DIFF
--- a/apps/desktop/src/main/__tests__/command-palette-plan-reminder-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/command-palette-plan-reminder-contract.test.ts
@@ -19,12 +19,14 @@ describe('command palette plan reminder contract', () => {
 
   it('wires the action to the shipped plan panel and focuses the title field', async () => {
     const main = await readRendererShellCombinedSource();
-    const ui = await readFile(resolve(REPO_ROOT, 'packages/ui/src/plan-reminder-panel.tsx'), 'utf8');
+    // Issue #1044: the form (and its title input) lives in the extracted
+    // PlanReminderFormDialog; the focus hook marker moved with it.
+    const dialog = await readFile(resolve(REPO_ROOT, 'packages/ui/src/plan-reminder-form-dialog.tsx'), 'utf8');
 
     assert.match(main, /function\s+openPlanReminderForm\(\)/);
     assert.match(main, /setNavSelection\(\{\s*section:\s*'automations'\s*\}\)/);
     assert.match(main, /onStartPlanReminder:\s*openPlanReminderForm/);
     assert.match(main, /querySelector<HTMLInputElement>\('\[data-maka-plan-title-input="true"\]'\)/);
-    assert.match(ui, /data-maka-plan-title-input="true"/);
+    assert.match(dialog, /data-maka-plan-title-input="true"/);
   });
 });

--- a/apps/desktop/src/main/__tests__/composer-send-guard.test.ts
+++ b/apps/desktop/src/main/__tests__/composer-send-guard.test.ts
@@ -20,6 +20,9 @@ describe('composer send guard', () => {
 
   it('keeps follow-up submits single-flight until the current send settles', async () => {
     const source = await readFile(join(process.cwd(), '../../packages/ui/src/composer.tsx'), 'utf8');
+    // Issue #1044: draft persistence moved into useComposerDraft; the draft
+    // assertions read the hook, the send/toolbar assertions stay on Composer.
+    const draftHook = await readFile(join(process.cwd(), '../../packages/ui/src/use-composer-draft.ts'), 'utf8');
     const sendCurrent = source.match(/async function sendCurrent\(\) \{[\s\S]*?\n  \}/)?.[0] ?? '';
     const toolbar = source.match(/<div className="maka-composer-toolbar[\s\S]*?<\/div>\n        <\/div>/)?.[0] ?? '';
 
@@ -28,9 +31,9 @@ describe('composer send guard', () => {
     assert.match(sendCurrent, /sendPendingRef\.current = true;[\s\S]*setSendPending\(true\);/);
     assert.match(sendCurrent, /finally \{[\s\S]*sendPendingRef\.current = false;[\s\S]*if \(composerMountedRef\.current\) setSendPending\(false\);[\s\S]*\}/);
     assert.match(toolbar, /sendPending \? \(\s*copy\.sending\s*\)/, 'toolbar must surface the transient sending state');
-    assert.match(source, /const \[hasDraftText, setHasDraftText\] = useState\(false\);/);
+    assert.match(draftHook, /const \[hasDraftText, setHasDraftText\] = useState\(false\);/);
     assert.match(
-      source,
+      draftHook,
       /rememberComposerDraft\(draftStoreRef\.current, activeDraftKeyRef\.current, nextValue\);[\s\S]*setHasDraftText\(Boolean\(nextValue\.trim\(\)\)\);/,
       'draft text state must follow the actual textarea draft value',
     );
@@ -41,12 +44,18 @@ describe('composer send guard', () => {
 
   it('clears the submitted draft key when first send switches into a new session', async () => {
     const source = await readFile(join(process.cwd(), '../../packages/ui/src/composer.tsx'), 'utf8');
+    const draftHook = await readFile(join(process.cwd(), '../../packages/ui/src/use-composer-draft.ts'), 'utf8');
     const sendCurrent = source.match(/async function sendCurrent\(\) \{[\s\S]*?\n  \}/)?.[0] ?? '';
 
     assert.match(
       sendCurrent,
-      /const submittedDraftKey = activeDraftKeyRef\.current;[\s\S]*sent = await props\.onSend\(text\);[\s\S]*if \(sent === false\) return;[\s\S]*rememberComposerDraft\(draftStoreRef\.current, submittedDraftKey, ''\);[\s\S]*saveCurrentDraft\(''\);/,
+      /const submittedDraftKey = activeDraftKey\(\);[\s\S]*sent = await props\.onSend\(text\);[\s\S]*if \(sent === false\) return;[\s\S]*clearDraft\(submittedDraftKey\);[\s\S]*saveCurrentDraft\(''\);/,
       'successful sends must clear both the original draft key and the current key after a new-session send changes draftKey',
+    );
+    assert.match(
+      draftHook,
+      /function clearDraft\(key: string \| undefined\) \{\s*rememberComposerDraft\(draftStoreRef\.current, key, ''\);/,
+      'clearDraft must remove the stored draft under the submitted key',
     );
   });
 

--- a/apps/desktop/src/main/__tests__/plan-reminder-panel-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/plan-reminder-panel-contract.test.ts
@@ -11,26 +11,37 @@ function blockBetween(source: string, start: string, end: string): string {
 }
 
 describe('Plan Reminder panel async action contract', () => {
+  // Issue #1044: the create/edit form (all field state + the submit owner)
+  // moved into PlanReminderFormDialog; the panel keeps list/runs/query state
+  // plus the per-action pending + refresh owners. Each invariant below is
+  // asserted against the component that now owns it.
   it('gates form submit and refresh before React commits disabled state', async () => {
     const ui = await readFile(resolve(REPO_ROOT, 'packages/ui/src/plan-reminder-panel.tsx'), 'utf8');
+    const dialog = await readFile(resolve(REPO_ROOT, 'packages/ui/src/plan-reminder-form-dialog.tsx'), 'utf8');
     const panelBlock = extractFunctionBlock(ui, 'PlanReminderPanel');
-    const submitBlock = blockBetween(panelBlock, 'async function submit', 'async function runPlanReminderAction');
+    const dialogBlock = extractFunctionBlock(dialog, 'PlanReminderFormDialog');
+    const submitBlock = blockBetween(dialogBlock, 'async function submit', 'return \\(');
     const refreshBlock = blockBetween(panelBlock, 'async function refreshFromPanel', 'return \\(');
 
-    assert.match(panelBlock, /const \[submitPending, setSubmitPending\] = useState\(false\)/);
+    assert.match(dialogBlock, /const \[submitPending, setSubmitPending\] = useState\(false\)/);
     assert.match(panelBlock, /const \[refreshPending, setRefreshPending\] = useState\(false\)/);
-    assert.match(panelBlock, /const submitPendingRef = useRef\(false\)/);
+    assert.match(dialogBlock, /const submitPendingRef = useRef\(false\)/);
     assert.match(panelBlock, /const refreshPendingRef = useRef\(false\)/);
     assert.match(
+      dialogBlock,
+      /return \(\) => \{\s*submitPendingRef\.current = false;\s*\};\s*\}, \[\]\)/,
+      'Plan Reminder pending form owner must be released when the dialog unmounts',
+    );
+    assert.match(
       panelBlock,
-      /return \(\) => \{\s*submitPendingRef\.current = false;\s*refreshPendingRef\.current = false;\s*pendingActionKeysRef\.current = new Set\(\);/,
-      'Plan Reminder pending form/refresh owners must be released when the panel unmounts',
+      /return \(\) => \{\s*refreshPendingRef\.current = false;\s*pendingActionKeysRef\.current = new Set\(\);/,
+      'Plan Reminder refresh/action pending owners must be released when the panel unmounts',
     );
 
     assert.match(
-      panelBlock,
-      /function closeReminderDialog\(\) \{\s*if \(submitPendingRef\.current\) return;\s*setFormDialogOpen\(false\);/,
-      'The form dialog must not close while a submit is still owned by the panel',
+      dialogBlock,
+      /function closeReminderDialog\(\) \{\s*if \(submitPendingRef\.current\) return;\s*props\.onOpenChange\(false\);/,
+      'The form dialog must not close while a submit is still owned by the dialog',
     );
     assert.match(
       submitBlock,
@@ -43,9 +54,9 @@ describe('Plan Reminder panel async action contract', () => {
       /finally \{\s*submitPendingRef\.current = false;\s*if \(planReminderMountedRef\.current\) setSubmitPending\(false\);/,
       'Plan Reminder submit owner must release without writing React state after unmount',
     );
-    assert.match(panelBlock, /const submitDisabled = !canCreate \|\| submitPending;/);
-    assert.match(panelBlock, /<form className="maka-plan-form" onSubmit=\{submit\} aria-busy=\{submitPending \? 'true' : undefined\}>/);
-    assert.match(panelBlock, /<UiButton type="submit" disabled=\{submitDisabled\}>/);
+    assert.match(dialogBlock, /const submitDisabled = !canCreate \|\| submitPending;/);
+    assert.match(dialogBlock, /<form className="maka-plan-form" onSubmit=\{submit\} aria-busy=\{submitPending \? 'true' : undefined\}>/);
+    assert.match(dialogBlock, /<UiButton type="submit" disabled=\{submitDisabled\}>/);
 
     assert.match(
       refreshBlock,

--- a/apps/desktop/src/main/__tests__/project-context-badge.test.ts
+++ b/apps/desktop/src/main/__tests__/project-context-badge.test.ts
@@ -209,21 +209,26 @@ describe('project context workspace picker', () => {
 
   it('renders the guarded project picker below the composer', async () => {
     const ui = await readRepo('packages/ui/src/composer.tsx');
+    // Issue #1044: the workspace row JSX + its picker prop shapes moved into
+    // ComposerWorkspaceRow; Composer forwards the props. The picker-contract
+    // assertions read the row component, the prop wiring stays on Composer.
+    const workspaceRow = await readRepo('packages/ui/src/composer-workspace-row.tsx');
     const styles = await readRendererContractCss();
     const renderer = await readRendererShellCombinedSource();
 
-    assert.match(ui, /workspacePicker\?:\s*\{/);
-    assert.match(ui, /className="maka-composer-workspace-picker"/);
-    assert.match(ui, /branch\?: string \| null;/);
-    assert.match(ui, /pending\?: boolean;/);
-    assert.match(ui, /disabled=\{wp\.pending === true\}/);
-    assert.match(ui, /aria-busy=\{wp\.pending === true \? 'true' : undefined\}/);
+    assert.match(ui, /workspacePicker\?: ComposerWorkspacePicker;/);
+    assert.match(ui, /<ComposerWorkspaceRow workspacePicker=\{props\.workspacePicker\} branchPicker=\{props\.branchPicker\} \/>/);
+    assert.match(workspaceRow, /className="maka-composer-workspace-picker"/);
+    assert.match(workspaceRow, /branch\?: string \| null;/);
+    assert.match(workspaceRow, /pending\?: boolean;/);
+    assert.match(workspaceRow, /disabled=\{wp\.pending === true\}/);
+    assert.match(workspaceRow, /aria-busy=\{wp\.pending === true \? 'true' : undefined\}/);
     // WAWQAQ msg `28128c9e` (2026-06-20): the "选择工作目录" placeholder
     // is only rendered when no directory has been selected yet. Once
     // a label is set, the picker renders `.maka-composer-workspace-current`
     // alone — no more "选择工作目录 ai ▾" doubled string.
-    assert.match(ui, /\? <span className="maka-composer-workspace-current">\{wp\.label\}<\/span>[\s\S]*?: <span>选择工作目录<\/span>/);
-    assert.match(ui, /当前分支 \$\{wp\.branch\}/);
+    assert.match(workspaceRow, /\? <span className="maka-composer-workspace-current">\{wp\.label\}<\/span>[\s\S]*?: <span>选择工作目录<\/span>/);
+    assert.match(workspaceRow, /当前分支 \$\{wp\.branch\}/);
     // Workspace picker must track the shared chat/composer measure token,
     // not a bespoke hard-coded width, so future measure updates keep the
     // row aligned with the composer card automatically.

--- a/apps/desktop/src/main/__tests__/renderer-utility-primitives-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/renderer-utility-primitives-contract.test.ts
@@ -311,7 +311,9 @@ describe('renderer utility surfaces use shared UI primitives', () => {
       readFile(join(repoRoot, 'packages/ui/src/search-modal.tsx'), 'utf8'),
       readFile(join(process.cwd(), 'src/renderer/app-shell-chrome-actions.tsx'), 'utf8'),
       readFile(join(process.cwd(), 'src/renderer/browser-panel.tsx'), 'utf8'),
-      readFile(join(repoRoot, 'packages/ui/src/plan-reminder-panel.tsx'), 'utf8'),
+      // Issue #1044: the preset buttons live in the extracted
+      // PlanReminderFormDialog; the governed-variant assertion follows them.
+      readFile(join(repoRoot, 'packages/ui/src/plan-reminder-form-dialog.tsx'), 'utf8'),
       readFile(join(repoRoot, 'packages/ui/stories/interaction-states.stories.tsx'), 'utf8'),
       readRendererContractCss(),
     ]);

--- a/apps/desktop/src/main/__tests__/settings-roadmap-cleanup-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/settings-roadmap-cleanup-contract.test.ts
@@ -352,6 +352,9 @@ describe('Settings coming-soon cleanup contract', () => {
         readRepo('packages/ui/src/skills-panel.tsx'),
         readRepo('packages/ui/src/daily-review-panel.tsx'),
         readRepo('packages/ui/src/plan-reminder-panel.tsx'),
+        // Issue #1044: keep the stub-vocabulary gate on the extracted
+        // plan-reminder form dialog (moved out of plan-reminder-panel.tsx).
+        readRepo('packages/ui/src/plan-reminder-form-dialog.tsx'),
         readRepo('packages/ui/src/relative-time.tsx'),
       ])
     ).join('\n');

--- a/apps/desktop/src/main/__tests__/settings-roadmap-cleanup-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/settings-roadmap-cleanup-contract.test.ts
@@ -346,6 +346,9 @@ describe('Settings coming-soon cleanup contract', () => {
         readRepo('packages/ui/src/components.tsx'),
         readRepo('packages/ui/src/chat-view.tsx'),
         readRepo('packages/ui/src/composer.tsx'),
+        // Issue #1044: keep the stub-vocabulary gate on the extracted
+        // composer workspace row (moved out of composer.tsx).
+        readRepo('packages/ui/src/composer-workspace-row.tsx'),
         readRepo('packages/ui/src/skills-panel.tsx'),
         readRepo('packages/ui/src/daily-review-panel.tsx'),
         readRepo('packages/ui/src/plan-reminder-panel.tsx'),

--- a/apps/desktop/src/main/__tests__/visible-copy-hygiene-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/visible-copy-hygiene-contract.test.ts
@@ -37,6 +37,9 @@ const FILES_TO_SCAN = [
   resolve(process.cwd(), '..', '..', 'packages', 'ui', 'src', 'chat-view.tsx'),
   resolve(process.cwd(), '..', '..', 'packages', 'ui', 'src', 'chat-turn.tsx'),
   resolve(process.cwd(), '..', '..', 'packages', 'ui', 'src', 'composer.tsx'),
+  // Issue #1044: visible copy that moved out of the two decomposed panels
+  // keeps the same hygiene coverage in its new home.
+  resolve(process.cwd(), '..', '..', 'packages', 'ui', 'src', 'composer-workspace-row.tsx'),
   resolve(process.cwd(), '..', '..', 'packages', 'ui', 'src', 'skills-panel.tsx'),
   resolve(process.cwd(), '..', '..', 'packages', 'ui', 'src', 'daily-review-panel.tsx'),
   resolve(process.cwd(), '..', '..', 'packages', 'ui', 'src', 'plan-reminder-panel.tsx'),

--- a/apps/desktop/src/main/__tests__/visible-copy-hygiene-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/visible-copy-hygiene-contract.test.ts
@@ -43,6 +43,7 @@ const FILES_TO_SCAN = [
   resolve(process.cwd(), '..', '..', 'packages', 'ui', 'src', 'skills-panel.tsx'),
   resolve(process.cwd(), '..', '..', 'packages', 'ui', 'src', 'daily-review-panel.tsx'),
   resolve(process.cwd(), '..', '..', 'packages', 'ui', 'src', 'plan-reminder-panel.tsx'),
+  resolve(process.cwd(), '..', '..', 'packages', 'ui', 'src', 'plan-reminder-form-dialog.tsx'),
   resolve(process.cwd(), '..', '..', 'packages', 'ui', 'src', 'chat-empty-hero.tsx'),
   ...RENDERER_SHELL_SOURCE_REPO_PATHS.map((repoPath) => resolve(process.cwd(), '..', '..', repoPath)),
   join(process.cwd(), 'src', 'renderer', 'OnboardingHero.tsx'),

--- a/packages/ui/src/composer-workspace-row.tsx
+++ b/packages/ui/src/composer-workspace-row.tsx
@@ -1,0 +1,162 @@
+/**
+ * Composer workspace row (issue #1044) — the workspace picker + git branch
+ * picker rendered below the composer card. Extracted from `composer.tsx`;
+ * purely presentational: both pickers are standard compact menu triggers fed
+ * by host-injected props. Shared Button owns their visual and interaction
+ * states; local classes only constrain layout and label truncation.
+ */
+
+import { Check, ChevronDown, FolderOpen, GitBranch, History } from './icons.js';
+import { Button as UiButton } from './ui.js';
+import { Menu, MenuItem, MenuPopup, MenuSeparator, MenuTrigger } from './primitives/menu.js';
+
+export interface ComposerWorkspacePicker {
+  label?: string;
+  branch?: string | null;
+  pending?: boolean;
+  recentWorkspaces?: string[];
+  onOpen(): void;
+  onSelect(path: string): void;
+}
+
+/**
+ * Git branch picker for the workspace row, shown to the right of
+ * the folder indicator when the workspace is a git repository.
+ * Clicking the trigger opens a Menu listing local branches; selecting
+ * one fires `onSelect` to switch branches (handled in the shell).
+ */
+export interface ComposerBranchPicker {
+  branch: string | null;
+  pending?: boolean;
+  branches: string[];
+  onOpen(): void;
+  onSelect(branch: string): void;
+}
+
+export function ComposerWorkspaceRow(props: {
+  workspacePicker: ComposerWorkspacePicker;
+  branchPicker?: ComposerBranchPicker;
+}) {
+  const wp = props.workspacePicker;
+  return (
+    <div className="maka-composer-workspace-row">
+      {/* The workspace and branch pickers are standard compact menu
+          triggers. Shared Button owns their visual and interaction states;
+          local classes only constrain layout and label truncation. */}
+      <Menu>
+        <MenuTrigger
+          render={({ onClick: menuToggleClick, ...triggerRest }) => (
+            <UiButton
+              {...triggerRest}
+              onClick={(e) => {
+                menuToggleClick?.(e);
+              }}
+              type="button"
+              variant="quiet"
+              size="sm"
+              className="maka-composer-workspace-picker"
+              disabled={wp.pending === true}
+              aria-busy={wp.pending === true ? 'true' : undefined}
+              title={wp.branch ? `选择工作目录 · ${wp.branch}` : '选择工作目录'}
+              aria-label={wp.branch
+                ? `选择工作目录：${wp.label ?? '当前工作目录'}，当前分支 ${wp.branch}`
+                : `选择工作目录：${wp.label ?? '当前工作目录'}`}
+            >
+              <FolderOpen size={13} aria-hidden="true" />
+              {wp.label
+                ? <span className="maka-composer-workspace-current">{wp.label}</span>
+                : <span>选择工作目录</span>}
+              <ChevronDown size={12} aria-hidden="true" />
+            </UiButton>
+          )}
+        />
+        <MenuPopup className="maka-composer-workspace-menu" align="start" side="top" sideOffset={6}>
+          {wp.recentWorkspaces && wp.recentWorkspaces.length > 0
+            ? (
+              <>
+                {wp.recentWorkspaces.map((wsp) => (
+                  <MenuItem key={wsp} onClick={() => { wp.onSelect(wsp); }}>
+                    <History size={13} aria-hidden="true" />
+                    <span>{basenameFromPath(wsp)}</span>
+                  </MenuItem>
+                ))}
+                <MenuSeparator />
+                <MenuItem onClick={() => { wp.onOpen(); }}>
+                  <FolderOpen size={13} aria-hidden="true" />
+                  <span>选择其他目录...</span>
+                </MenuItem>
+              </>
+            )
+            : (
+              <MenuItem onClick={() => { wp.onOpen(); }}>
+                <FolderOpen size={13} aria-hidden="true" />
+                <span>选择工作目录...</span>
+              </MenuItem>
+            )}
+        </MenuPopup>
+      </Menu>
+      {props.branchPicker && (() => {
+        const bp = props.branchPicker!;
+        const triggerDisabled = bp.pending === true;
+        return (
+          <Menu>
+            <MenuTrigger
+              render={({ onClick: menuToggleClick, ...triggerRest }) => (
+                <UiButton
+                  {...triggerRest}
+                  onClick={(e) => {
+                    bp.onOpen();
+                    menuToggleClick?.(e);
+                  }}
+                  type="button"
+                  variant="quiet"
+                  size="sm"
+                  className="maka-composer-branch-picker"
+                  disabled={triggerDisabled}
+                  aria-busy={triggerDisabled ? 'true' : undefined}
+                  title={bp.branch ? `分支：${bp.branch}` : '选择分支'}
+                  aria-label={bp.branch
+                    ? `切换分支：${bp.branch}`
+                    : '选择分支'}
+                >
+                  <GitBranch size={13} aria-hidden="true" />
+                  <span className="maka-composer-branch-current">{bp.branch ?? '—'}</span>
+                  <ChevronDown size={12} aria-hidden="true" />
+                </UiButton>
+              )}
+            />
+            <MenuPopup className="maka-composer-branch-menu" align="start" side="top" sideOffset={6}>
+              {bp.branches.length === 0 ? (
+                <div className="maka-composer-branch-empty">无本地分支</div>
+              ) : (
+                bp.branches.map((b) => (
+                  <MenuItem
+                    key={b}
+                    data-active={b === bp.branch}
+                    onClick={() => {
+                      if (b === bp.branch) return;
+                      void bp.onSelect(b);
+                    }}
+                  >
+                    <GitBranch size={13} aria-hidden="true" />
+                    <span>{b}</span>
+                    {b === bp.branch && (
+                      <Check size={12} aria-hidden="true" className="maka-composer-branch-check" />
+                    )}
+                  </MenuItem>
+                ))
+              )}
+            </MenuPopup>
+          </Menu>
+        );
+      })()}
+    </div>
+  );
+}
+
+/** Extract the last path segment from a file system path (win32 / posix). */
+function basenameFromPath(value: string): string {
+  const trimmed = value.replace(/[\\/]+$/, '');
+  const name = trimmed.split(/[\\/]/).filter(Boolean).pop();
+  return name || trimmed || '当前项目';
+}

--- a/packages/ui/src/composer.tsx
+++ b/packages/ui/src/composer.tsx
@@ -1,7 +1,6 @@
 import {
   forwardRef,
   useEffect,
-  useId,
   useImperativeHandle,
   useRef,
   useState,
@@ -12,7 +11,7 @@ import {
   type ReactNode,
 } from 'react';
 import { useMountedRef } from './use-mounted-ref.js';
-import { ArrowUp, Blocks, Check, ChevronDown, FileEdit, FolderOpen, GitBranch, History, Paperclip, Plus } from './icons.js';
+import { ArrowUp, Blocks, Paperclip, Plus } from './icons.js';
 import { ChatModelSwitcher, ModelChipStatic, NewChatModelPicker } from './chat-model-switcher.js';
 import type { UiCatalog } from '@maka/core';
 import { useUiLocale } from './locale-context.js';
@@ -22,22 +21,21 @@ import { useComposerDraft } from './use-composer-draft.js';
 import { useComposerHistory } from './use-composer-history.js';
 import {
   createChatInputActionOwner,
-  detectMentionTrigger,
   fileTransferContainsFiles,
   focusTextInputAtEnd,
   isChatInputComposing,
-  mentionQueryMatches,
   type ChatInputActionOwner,
-  type MentionTrigger,
 } from './chat-input-behavior.js';
-import { ComposerMentionPopup, mentionOptionId, type MentionItem } from './composer-mention-popup.js';
+import { ComposerMentionPopup, mentionOptionId } from './composer-mention-popup.js';
+import { useMentionPopup } from './use-mention-popup.js';
+import { ComposerWorkspaceRow, type ComposerBranchPicker, type ComposerWorkspacePicker } from './composer-workspace-row.js';
 import type { AttachmentRef, PermissionMode, ProviderType, SessionSummary } from '@maka/core';
 import { Button as UiButton } from './ui.js';
 import { Textarea as UiTextarea } from './primitives/textarea.js';
 import { AttachmentFileCard } from './attachment-file-card.js';
 import { Kbd } from './primitives/kbd.js';
 import { PermissionModeSelect } from './permission-mode-menu.js';
-import { Menu, MenuItem, MenuPopup, MenuSeparator, MenuSub, MenuSubPopup, MenuSubTrigger, MenuTrigger } from './primitives/menu.js';
+import { Menu, MenuItem, MenuPopup, MenuSub, MenuSubPopup, MenuSubTrigger, MenuTrigger } from './primitives/menu.js';
 
 const COMPOSER_MAX_HEIGHT = 240;
 
@@ -189,27 +187,14 @@ export const Composer = forwardRef<
      * Settings · 模型 instead of wearing a dropdown chevron it cannot honor.
      */
     onOpenModelSettings?(): void;
-    workspacePicker?: {
-      label?: string;
-      branch?: string | null;
-      pending?: boolean;
-      recentWorkspaces?: string[];
-      onOpen(): void;
-      onSelect(path: string): void;
-    };
+    workspacePicker?: ComposerWorkspacePicker;
     /**
      * Git branch picker for the workspace row, shown to the right of
      * the folder indicator when the workspace is a git repository.
      * Clicking the trigger opens a Menu listing local branches; selecting
      * one fires `onSelect` to switch branches (handled in the shell).
      */
-    branchPicker?: {
-      branch: string | null;
-      pending?: boolean;
-      branches: string[];
-      onOpen(): void;
-      onSelect(branch: string): void;
-    };
+    branchPicker?: ComposerBranchPicker;
     /**
      * PR-MOVE-PERMISSION-MODE (WAWQAQ 47fe0d0e + a667cf6c): the
      * permission mode picker lives inside the composer left-controls
@@ -268,22 +253,29 @@ export const Composer = forwardRef<
     autoResize,
     saveCurrentDraft,
   });
-  // Mention popup state (@ file / skill). `mention` holds the active trigger +
-  // query + trigger-char index; items/loading/activeIndex drive the popup. The
-  // whole block stays inert unless the matching provider prop is present, so
-  // the SSR contracts (minimal props) render nothing here.
-  const [mention, setMention] = useState<MentionTrigger | null>(null);
-  const [mentionItems, setMentionItems] = useState<readonly MentionItem[]>([]);
-  const [mentionActiveIndex, setMentionActiveIndex] = useState(0);
-  const [mentionLoading, setMentionLoading] = useState(false);
-  const mentionListboxId = useId();
-  // Exact post-insertion snapshot: after we splice in a token the value can
-  // still parse as a valid trigger (e.g. `@file.txt ` — one trailing space),
-  // which would immediately re-open the popup. Suppress detection for that one
-  // state only; any further edit or caret move clears it and detection resumes.
-  const mentionSuppressRef = useRef<{ value: string; caret: number } | null>(null);
-  const recomputeMentionRef = useRef<() => void>(() => {});
-  const mentionPopupOpen = mention !== null;
+  // Mention popup state (@ file / skill) lives in useMentionPopup (issue
+  // #1044); the identifiers below keep their names so the keydown routing
+  // (arrows / Enter / Tab / Esc, pinned by the composer-mention contract)
+  // reads exactly as before.
+  const {
+    mention,
+    mentionItems,
+    mentionActiveIndex,
+    setMentionActiveIndex,
+    mentionLoading,
+    mentionListboxId,
+    mentionPopupOpen,
+    recomputeMention,
+    closeMention,
+    selectMention,
+  } = useMentionPopup({
+    textareaRef,
+    mentionSkills: props.mentionSkills,
+    onSearchMentionFiles: props.onSearchMentionFiles,
+    saveCurrentDraft,
+    autoResize,
+    resetPromptHistoryNavigation,
+  });
   // PR-UI-15: locale-aware copy for placeholder + toolbar states. We
   const locale = useUiLocale();
   const copy = COMPOSER_COPY_BY_LOCALE[locale];
@@ -457,135 +449,6 @@ export const Composer = forwardRef<
     saveCurrentDraft();
     recomputeMention();
   }
-
-  function closeMention() {
-    setMention(null);
-    setMentionItems([]);
-    setMentionActiveIndex(0);
-    setMentionLoading(false);
-  }
-
-  // Re-detect the active mention trigger from the live textarea value + caret.
-  // Called on input, keyup, and document selectionchange so clicking elsewhere
-  // (or moving the caret out of a trigger) closes the popup.
-  function recomputeMention() {
-    const el = textareaRef.current;
-    if (!el) return;
-    // Only the focused textarea drives the popup — a selectionchange from
-    // another field, or a blur, should close it.
-    if (typeof document !== 'undefined' && document.activeElement !== el) {
-      if (mentionPopupOpen) closeMention();
-      return;
-    }
-    const caret = el.selectionEnd ?? el.value.length;
-    const suppress = mentionSuppressRef.current;
-    if (suppress && suppress.value === el.value && suppress.caret === caret) {
-      if (mentionPopupOpen) closeMention();
-      return;
-    }
-    mentionSuppressRef.current = null;
-    const result = detectMentionTrigger(el.value, caret);
-    // Gate on provider presence so the feature no-ops when a popup has nothing
-    // to render (keeps the SSR/minimal-props path inert).
-    if (!result
-      || (result.trigger === '@' && !props.onSearchMentionFiles)
-      || (result.trigger === '/' && props.mentionSkills === undefined)) {
-      if (mentionPopupOpen) closeMention();
-      return;
-    }
-    setMention((prev) =>
-      prev && prev.trigger === result.trigger && prev.query === result.query && prev.start === result.start
-        ? prev
-        : result,
-    );
-  }
-  recomputeMentionRef.current = recomputeMention;
-
-  function selectMention(index: number) {
-    const el = textareaRef.current;
-    const current = mention;
-    if (!el || !current) return;
-    const item = mentionItems[index];
-    if (!item) return;
-    const insertion = item.type === 'file'
-      ? `@${item.relativePath} `
-      : `使用 ${item.name} 技能：`;
-    const value = el.value;
-    const caret = el.selectionEnd ?? value.length;
-    // Replace [start, caret): the trigger char (at `start`) through the caret,
-    // i.e. the `@query` / `/query` the user typed, with the plain-text token.
-    const nextValue = value.slice(0, current.start) + insertion + value.slice(caret);
-    const nextCaret = current.start + insertion.length;
-    resetPromptHistoryNavigation();
-    el.value = nextValue;
-    el.setSelectionRange(nextCaret, nextCaret);
-    mentionSuppressRef.current = { value: nextValue, caret: nextCaret };
-    closeMention();
-    saveCurrentDraft(nextValue);
-    autoResize();
-    el.focus();
-  }
-
-  // Populate the popup for the active trigger: skills filter synchronously from
-  // props; files search through the (debounced) IPC-backed callback.
-  useEffect(() => {
-    if (!mention) {
-      setMentionItems([]);
-      setMentionLoading(false);
-      return;
-    }
-    if (mention.trigger === '/') {
-      const skills = props.mentionSkills ?? [];
-      const items: MentionItem[] = skills
-        .filter((skill) => mentionQueryMatches(mention.query, `${skill.name} ${skill.description ?? ''}`))
-        .slice(0, 50)
-        .map((skill) => ({ type: 'skill', id: skill.id, name: skill.name, description: skill.description }));
-      setMentionItems(items);
-      setMentionActiveIndex(0);
-      setMentionLoading(false);
-      return undefined;
-    }
-    const search = props.onSearchMentionFiles;
-    if (!search) {
-      setMentionItems([]);
-      setMentionLoading(false);
-      return undefined;
-    }
-    let cancelled = false;
-    setMentionLoading(true);
-    setMentionActiveIndex(0);
-    const timer = setTimeout(() => {
-      void (async () => {
-        try {
-          const files = await search(mention.query);
-          if (cancelled) return;
-          const items: MentionItem[] = files
-            .filter((file) => mentionQueryMatches(mention.query, file.relativePath))
-            .slice(0, 50)
-            .map((file) => ({ type: 'file', relativePath: file.relativePath }));
-          setMentionItems(items);
-        } catch {
-          // Fail soft: an IPC error just yields an empty list (未找到文件).
-          if (!cancelled) setMentionItems([]);
-        } finally {
-          if (!cancelled) setMentionLoading(false);
-        }
-      })();
-    }, 150);
-    return () => {
-      cancelled = true;
-      clearTimeout(timer);
-    };
-  }, [mention, props.mentionSkills, props.onSearchMentionFiles]);
-
-  // Caret-move detection: a plain click or arrow that moves the caret out of a
-  // trigger fires selectionchange (not input), so listen for it while mounted.
-  useEffect(() => {
-    if (typeof document === 'undefined') return undefined;
-    const onSelectionChange = () => recomputeMentionRef.current();
-    document.addEventListener('selectionchange', onSelectionChange);
-    return () => document.removeEventListener('selectionchange', onSelectionChange);
-  }, []);
 
   function canAcceptDroppedFiles(): boolean {
     return Boolean(props.onAttachFilePaths && !props.disabled && !props.streaming && !importActionOwnerRef.current?.pending);
@@ -916,130 +779,9 @@ export const Composer = forwardRef<
           </div>
         </div>
       </div>
-      {props.workspacePicker && (() => {
-        const wp = props.workspacePicker!;
-        return (
-        <div className="maka-composer-workspace-row">
-          {/* The workspace and branch pickers are standard compact menu
-              triggers. Shared Button owns their visual and interaction states;
-              local classes only constrain layout and label truncation. */}
-          <Menu>
-            <MenuTrigger
-              render={({ onClick: menuToggleClick, ...triggerRest }) => (
-                <UiButton
-                  {...triggerRest}
-                  onClick={(e) => {
-                    menuToggleClick?.(e);
-                  }}
-                  type="button"
-                  variant="quiet"
-                  size="sm"
-                  className="maka-composer-workspace-picker"
-                  disabled={wp.pending === true}
-                  aria-busy={wp.pending === true ? 'true' : undefined}
-                  title={wp.branch ? `选择工作目录 · ${wp.branch}` : '选择工作目录'}
-                  aria-label={wp.branch
-                    ? `选择工作目录：${wp.label ?? '当前工作目录'}，当前分支 ${wp.branch}`
-                    : `选择工作目录：${wp.label ?? '当前工作目录'}`}
-                >
-                  <FolderOpen size={13} aria-hidden="true" />
-                  {wp.label
-                    ? <span className="maka-composer-workspace-current">{wp.label}</span>
-                    : <span>选择工作目录</span>}
-                  <ChevronDown size={12} aria-hidden="true" />
-                </UiButton>
-              )}
-            />
-            <MenuPopup className="maka-composer-workspace-menu" align="start" side="top" sideOffset={6}>
-              {wp.recentWorkspaces && wp.recentWorkspaces.length > 0
-                ? (
-                  <>
-                    {wp.recentWorkspaces.map((wsp) => (
-                      <MenuItem key={wsp} onClick={() => { wp.onSelect(wsp); }}>
-                        <History size={13} aria-hidden="true" />
-                        <span>{basenameFromPath(wsp)}</span>
-                      </MenuItem>
-                    ))}
-                    <MenuSeparator />
-                    <MenuItem onClick={() => { wp.onOpen(); }}>
-                      <FolderOpen size={13} aria-hidden="true" />
-                      <span>选择其他目录...</span>
-                    </MenuItem>
-                  </>
-                )
-                : (
-                  <MenuItem onClick={() => { wp.onOpen(); }}>
-                    <FolderOpen size={13} aria-hidden="true" />
-                    <span>选择工作目录...</span>
-                  </MenuItem>
-                )}
-            </MenuPopup>
-          </Menu>
-          {props.branchPicker && (() => {
-            const bp = props.branchPicker!;
-            const triggerDisabled = bp.pending === true;
-            return (
-              <Menu>
-                <MenuTrigger
-                  render={({ onClick: menuToggleClick, ...triggerRest }) => (
-                    <UiButton
-                      {...triggerRest}
-                      onClick={(e) => {
-                        bp.onOpen();
-                        menuToggleClick?.(e);
-                      }}
-                      type="button"
-                      variant="quiet"
-                      size="sm"
-                      className="maka-composer-branch-picker"
-                      disabled={triggerDisabled}
-                      aria-busy={triggerDisabled ? 'true' : undefined}
-                      title={bp.branch ? `分支：${bp.branch}` : '选择分支'}
-                      aria-label={bp.branch
-                        ? `切换分支：${bp.branch}`
-                        : '选择分支'}
-                    >
-                      <GitBranch size={13} aria-hidden="true" />
-                      <span className="maka-composer-branch-current">{bp.branch ?? '—'}</span>
-                      <ChevronDown size={12} aria-hidden="true" />
-                    </UiButton>
-                  )}
-                />
-                <MenuPopup className="maka-composer-branch-menu" align="start" side="top" sideOffset={6}>
-                  {bp.branches.length === 0 ? (
-                    <div className="maka-composer-branch-empty">无本地分支</div>
-                  ) : (
-                    bp.branches.map((b) => (
-                      <MenuItem
-                        key={b}
-                        data-active={b === bp.branch}
-                        onClick={() => {
-                          if (b === bp.branch) return;
-                          void bp.onSelect(b);
-                        }}
-                      >
-                        <GitBranch size={13} aria-hidden="true" />
-                        <span>{b}</span>
-                        {b === bp.branch && (
-                          <Check size={12} aria-hidden="true" className="maka-composer-branch-check" />
-                        )}
-                      </MenuItem>
-                    ))
-                  )}
-                </MenuPopup>
-              </Menu>
-            );
-          })()}
-        </div>
-      );
-    })()}
+      {props.workspacePicker ? (
+        <ComposerWorkspaceRow workspacePicker={props.workspacePicker} branchPicker={props.branchPicker} />
+      ) : null}
     </form>
   );
 });
-
-/** Extract the last path segment from a file system path (win32 / posix). */
-function basenameFromPath(value: string): string {
-  const trimmed = value.replace(/[\\/]+$/, '');
-  const name = trimmed.split(/[\\/]/).filter(Boolean).pop();
-  return name || trimmed || '当前项目';
-}

--- a/packages/ui/src/composer.tsx
+++ b/packages/ui/src/composer.tsx
@@ -17,16 +17,9 @@ import { ChatModelSwitcher, ModelChipStatic, NewChatModelPicker } from './chat-m
 import type { UiCatalog } from '@maka/core';
 import { useUiLocale } from './locale-context.js';
 import { type ChatModelChoice, modelChoiceValue } from './chat-model-helpers.js';
-import {
-  type ComposerHistoryState,
-  appendPromptContextDraft,
-  navigateComposerHistory,
-  readComposerDraft,
-  reconcileHistorySync,
-  rememberComposerDraft,
-  rememberComposerHistoryEntry,
-} from './composer-helpers.js';
-import { readGlobalInputHistory, saveGlobalInputHistoryEntry } from './input-history.js';
+import { appendPromptContextDraft } from './composer-helpers.js';
+import { useComposerDraft } from './use-composer-draft.js';
+import { useComposerHistory } from './use-composer-history.js';
 import {
   createChatInputActionOwner,
   detectMentionTrigger,
@@ -251,9 +244,6 @@ export const Composer = forwardRef<
   const [dragActive, setDragActive] = useState(false);
   const [sendPending, setSendPending] = useState(false);
   const [pendingImportAction, setPendingImportAction] = useState<ComposerImportActionId | null>(null);
-  const [hasDraftText, setHasDraftText] = useState(false);
-  const draftStoreRef = useRef<Map<string, string>>(new Map());
-  const activeDraftKeyRef = useRef<string | undefined>(props.draftKey);
   const composerMountedRef = useMountedRef();
   const sendPendingRef = useRef(false);
   const compositionActiveRef = useRef(false);
@@ -263,7 +253,21 @@ export const Composer = forwardRef<
       if (composerMountedRef.current) setPendingImportAction(action);
     });
   }
-  const promptHistoryRef = useRef<ComposerHistoryState>({ entries: readGlobalInputHistory() ?? [], index: -1, savedDraft: '' });
+  // Draft persistence + prompt-history navigation live in dedicated hooks
+  // (issue #1044). `resetPromptHistoryNavigation` is a hoisted wrapper so the
+  // draft hook's swap effect can reset history navigation even though the
+  // history hook is created one line below it.
+  const { hasDraftText, saveCurrentDraft, clearDraft, activeDraftKey } = useComposerDraft({
+    textareaRef,
+    draftKey: props.draftKey,
+    autoResize,
+    onDraftKeyChange: resetPromptHistoryNavigation,
+  });
+  const { resetNavigation, rememberSentEntry, handleArrowKey } = useComposerHistory({
+    textareaRef,
+    autoResize,
+    saveCurrentDraft,
+  });
   // Mention popup state (@ file / skill). `mention` holds the active trigger +
   // query + trigger-char index; items/loading/activeIndex drive the popup. The
   // whole block stays inert unless the matching provider prop is present, so
@@ -303,39 +307,9 @@ export const Composer = forwardRef<
     el.style.height = `${Math.min(el.scrollHeight, COMPOSER_MAX_HEIGHT)}px`;
   }
 
-  function saveCurrentDraft(value?: string) {
-    const nextValue = value ?? textareaRef.current?.value ?? '';
-    rememberComposerDraft(draftStoreRef.current, activeDraftKeyRef.current, nextValue);
-    setHasDraftText(Boolean(nextValue.trim()));
-  }
-
   function resetPromptHistoryNavigation() {
-    promptHistoryRef.current = {
-      entries: promptHistoryRef.current.entries,
-      index: -1,
-      savedDraft: '',
-    };
+    resetNavigation();
   }
-
-  useEffect(() => {
-    const el = textareaRef.current;
-    const previousKey = activeDraftKeyRef.current;
-    const nextKey = props.draftKey;
-
-    if (previousKey !== nextKey) {
-      rememberComposerDraft(draftStoreRef.current, previousKey, el?.value ?? '');
-      activeDraftKeyRef.current = nextKey;
-      resetPromptHistoryNavigation();
-      if (el) {
-        const nextDraft = readComposerDraft(draftStoreRef.current, nextKey);
-        el.value = nextDraft;
-        setHasDraftText(Boolean(nextDraft.trim()));
-        autoResize();
-        const length = el.value.length;
-        el.setSelectionRange(length, length);
-      }
-    }
-  }, [props.draftKey]);
 
   useImperativeHandle(
     ref,
@@ -372,7 +346,7 @@ export const Composer = forwardRef<
     const form = formRef.current;
     const text = (textarea?.value ?? '').trim();
     if (!text) return;
-    const submittedDraftKey = activeDraftKeyRef.current;
+    const submittedDraftKey = activeDraftKey();
     sendPendingRef.current = true;
     setSendPending(true);
     let sent: boolean | void;
@@ -386,13 +360,8 @@ export const Composer = forwardRef<
     if (sent === false) return;
     // Save to both local ref and global persistence so the history
     // survives page reloads and is shared across all input surfaces.
-    saveGlobalInputHistoryEntry(text);
-    promptHistoryRef.current = {
-      entries: rememberComposerHistoryEntry(promptHistoryRef.current.entries, text),
-      index: -1,
-      savedDraft: '',
-    };
-    rememberComposerDraft(draftStoreRef.current, submittedDraftKey, '');
+    rememberSentEntry(text);
+    clearDraft(submittedDraftKey);
     saveCurrentDraft('');
     form?.reset();
     // form.reset() empties the textarea but doesn't fire input — collapse
@@ -470,56 +439,11 @@ export const Composer = forwardRef<
       return;
     }
     // PR-GLOBAL-INPUT-HISTORY: up/down arrow navigates the global input
-    // history. Bare arrow keys only start navigation when the textarea is
-    // empty, or when the user is already mid-navigation (index >= 0); in a
-    // multi-line draft the caret keeps moving so editing isn't hijacked.
-    // Ctrl/Cmd + ArrowUp/ArrowDown is an explicit shortcut that always
-    // navigates history regardless of the current draft.
+    // history; the state machine + textarea application live in
+    // useComposerHistory (issue #1044). A consumed keystroke stops here so it
+    // can't fall through to send.
     if (event.key === 'ArrowUp' || event.key === 'ArrowDown') {
-      const explicit = Boolean(event.ctrlKey || event.metaKey);
-      const plainArrow = !event.shiftKey && !event.altKey && !event.ctrlKey && !event.metaKey;
-      if (plainArrow || explicit) {
-        const el = textareaRef.current;
-        const isNavigatingHistory = promptHistoryRef.current.index >= 0;
-        const canStartHistory = Boolean(el && !el.value.trim());
-        if (el && (explicit || isNavigatingHistory || canStartHistory)) {
-          // Re-read global history from localStorage on every navigation so
-          // a clear from Settings (an overlay that keeps the Composer
-          // mounted) is picked up immediately, and a transient storage
-          // failure does not clobber the in-memory history.
-          // reconcileHistorySync restores the saved draft if a clear happened
-          // mid-navigation (so the user doesn't lose what they were typing).
-          const synced = readGlobalInputHistory();
-          const { state, restoreDraft } = reconcileHistorySync(promptHistoryRef.current, synced);
-          promptHistoryRef.current = state;
-          if (restoreDraft && el) {
-            el.value = state.savedDraft;
-            saveCurrentDraft(state.savedDraft);
-            autoResize();
-            const length = el.value.length;
-            el.setSelectionRange(length, length);
-          }
-          // Nothing to navigate when history was cleared (synced empty).
-          // When the storage read failed (synced === null), keep navigating
-          // with the in-memory entries.
-          if (synced !== null && synced.length === 0) return;
-          const next = navigateComposerHistory(
-            promptHistoryRef.current,
-            event.key === 'ArrowUp' ? 'previous' : 'next',
-            el.value,
-          );
-          if (next.changed) {
-            event.preventDefault();
-            promptHistoryRef.current = next.state;
-            el.value = next.value;
-            saveCurrentDraft(next.value);
-            autoResize();
-            const length = el.value.length;
-            el.setSelectionRange(length, length);
-            return;
-          }
-        }
-      }
+      if (handleArrowKey(event)) return;
     }
     if (event.key !== 'Enter') return;
     if (event.shiftKey || event.altKey) return; // Shift+Enter / Alt+Enter inserts a newline.

--- a/packages/ui/src/plan-reminder-form-dialog.tsx
+++ b/packages/ui/src/plan-reminder-form-dialog.tsx
@@ -1,0 +1,418 @@
+/**
+ * Plan-reminder create/edit form dialog (issue #1044).
+ *
+ * Owns ALL form state + the submit pipeline that used to live inline in
+ * `plan-reminder-panel.tsx`: the nine field states, editingId, the
+ * submitPending single-flight owner, validation, and the close guard. The
+ * panel keeps only list/runs/query state and opens this dialog with a
+ * `PlanReminderFormSeed` (remounting per open via `key`, so fields always
+ * initialize from the seed — same outcome as the old open-handler setters).
+ *
+ * Async-owner invariants (pinned by plan-reminder-panel-contract):
+ *   - submit rejects re-entry synchronously via submitPendingRef before
+ *     React commits the disabled state;
+ *   - the dialog refuses to close while a submit is in flight;
+ *   - the pending owner is released on unmount without writing React state.
+ */
+
+import { useEffect, useRef, useState, type FormEvent } from 'react';
+import { useMountedRef } from './use-mounted-ref.js';
+import { Check, Plus, X } from './icons.js';
+import { BotBrandLogo } from './bot-brand-logo.js';
+import type {
+  BotProvider,
+  PlanReminder,
+  PlanReminderDeliveryTarget,
+  PlanReminderRecurrence,
+} from '@maka/core';
+import { BOT_DELIVERY_PROVIDERS, botDisplayLabel } from '@maka/core';
+import {
+  type PlanReminderExampleTemplate,
+  duplicatePlanReminderTitle,
+  formatPlanDeliveryProviderList,
+  planReminderEditableRunAt,
+  planReminderFormValidationMessage,
+  planReminderPresetRunAt,
+  planReminderRecurrenceValue,
+  planReminderTemplateNextRunAt,
+  toPlanReminderDateTimeInputValue,
+} from './plan-reminder-helpers.js';
+import { PlanReminderSelect } from './plan-reminder-select.js';
+import {
+  Button as UiButton,
+  DialogClose,
+  DialogContent,
+  DialogRoot,
+} from './ui.js';
+import { Input } from './primitives/input.js';
+import { Textarea as UiTextarea } from './primitives/textarea.js';
+import type {
+  PlanReminderDraftInput,
+  PlanReminderUpdatePatch,
+} from './module-panel-types.js';
+
+/** Initial field values the dialog mounts with (one per open). */
+export interface PlanReminderFormSeed {
+  editingId: string | null;
+  title: string;
+  note: string;
+  runAtLocal: string;
+  recurrence: PlanReminderRecurrence;
+  cronExpression: string;
+  deliveryChannel: PlanReminderDeliveryTarget['channel'];
+  deliveryPlatform: BotProvider;
+  deliveryChatId: string;
+}
+
+/** Blank create-mode seed (one hour from now, no recurrence, local delivery). */
+export function createPlanReminderFormSeed(): PlanReminderFormSeed {
+  return {
+    editingId: null,
+    title: '',
+    note: '',
+    runAtLocal: toPlanReminderDateTimeInputValue(Date.now() + 60 * 60 * 1000),
+    recurrence: 'none',
+    cronExpression: '0 9 * * 1-5',
+    deliveryChannel: 'local',
+    deliveryPlatform: 'telegram',
+    deliveryChatId: '',
+  };
+}
+
+/** Create-mode seed prefilled from an example template. */
+export function planReminderTemplateSeed(template: PlanReminderExampleTemplate): PlanReminderFormSeed {
+  return {
+    ...createPlanReminderFormSeed(),
+    title: template.title,
+    note: template.note,
+    recurrence: template.recurrence,
+    cronExpression: template.cronExpression,
+    runAtLocal: toPlanReminderDateTimeInputValue(planReminderTemplateNextRunAt(template)),
+  };
+}
+
+function planReminderReminderSeed(reminder: PlanReminder): PlanReminderFormSeed {
+  return {
+    editingId: reminder.id,
+    title: reminder.title,
+    note: reminder.note,
+    runAtLocal: toPlanReminderDateTimeInputValue(planReminderEditableRunAt(reminder)),
+    recurrence: planReminderRecurrenceValue(reminder),
+    cronExpression: reminder.schedule.kind === 'cron' ? reminder.schedule.expression : '0 9 * * 1-5',
+    deliveryChannel: reminder.delivery.channel,
+    ...(reminder.delivery.channel === 'bot'
+      ? { deliveryPlatform: reminder.delivery.platform, deliveryChatId: reminder.delivery.chatId }
+      : { deliveryPlatform: 'telegram' as BotProvider, deliveryChatId: '' }),
+  };
+}
+
+/** Edit-mode seed prefilled from an existing reminder. */
+export function planReminderEditSeed(reminder: PlanReminder): PlanReminderFormSeed {
+  return planReminderReminderSeed(reminder);
+}
+
+/** Create-mode seed copying an existing reminder under a 副本 title. */
+export function planReminderDuplicateSeed(reminder: PlanReminder): PlanReminderFormSeed {
+  return {
+    ...planReminderReminderSeed(reminder),
+    editingId: null,
+    title: duplicatePlanReminderTitle(reminder.title),
+  };
+}
+
+export function PlanReminderFormDialog(props: {
+  open: boolean;
+  seed: PlanReminderFormSeed;
+  /** Current reminders, so an open edit form resets if its reminder vanishes. */
+  reminders: PlanReminder[];
+  onOpenChange(open: boolean): void;
+  onCreate?(input: PlanReminderDraftInput): boolean | Promise<boolean> | void | Promise<void>;
+  onUpdate?(id: string, patch: PlanReminderUpdatePatch): boolean | Promise<boolean> | void | Promise<void>;
+}) {
+  const [title, setTitle] = useState(props.seed.title);
+  const [note, setNote] = useState(props.seed.note);
+  const [runAtLocal, setRunAtLocal] = useState(props.seed.runAtLocal);
+  const [recurrence, setRecurrence] = useState<PlanReminderRecurrence>(props.seed.recurrence);
+  const [cronExpression, setCronExpression] = useState(props.seed.cronExpression);
+  const [deliveryChannel, setDeliveryChannel] = useState<PlanReminderDeliveryTarget['channel']>(props.seed.deliveryChannel);
+  const [deliveryPlatform, setDeliveryPlatform] = useState<BotProvider>(props.seed.deliveryPlatform);
+  const [deliveryChatId, setDeliveryChatId] = useState(props.seed.deliveryChatId);
+  const [editingId, setEditingId] = useState<string | null>(props.seed.editingId);
+  const [submitPending, setSubmitPending] = useState(false);
+  const planReminderMountedRef = useMountedRef();
+  const submitPendingRef = useRef(false);
+  const parsedRunAt = Date.parse(runAtLocal);
+  const delivery: PlanReminderDeliveryTarget = deliveryChannel === 'bot'
+    ? { channel: 'bot', platform: deliveryPlatform, chatId: deliveryChatId.trim() }
+    : { channel: 'local' };
+  const validationMessage = planReminderFormValidationMessage({
+    title,
+    parsedRunAt,
+    recurrence,
+    cronExpression,
+    delivery,
+    now: Date.now(),
+  });
+  const canCreate = validationMessage === null;
+  const submitDisabled = !canCreate || submitPending;
+  const formInteractionDisabled = submitPending;
+  const isEditing = editingId !== null;
+
+  useEffect(() => {
+    return () => {
+      submitPendingRef.current = false;
+    };
+  }, []);
+
+  useEffect(() => {
+    if (editingId && !props.reminders.some((reminder) => reminder.id === editingId)) resetForm();
+  }, [editingId, props.reminders]);
+
+  function resetForm() {
+    setTitle('');
+    setNote('');
+    setRecurrence('none');
+    setCronExpression('0 9 * * 1-5');
+    setDeliveryChannel('local');
+    setDeliveryPlatform('telegram');
+    setDeliveryChatId('');
+    setRunAtLocal(toPlanReminderDateTimeInputValue(Date.now() + 60 * 60 * 1000));
+    setEditingId(null);
+  }
+
+  function closeReminderDialog() {
+    if (submitPendingRef.current) return;
+    props.onOpenChange(false);
+    resetForm();
+  }
+
+  function applyRunAtPreset(preset: 'ten-minutes' | 'one-hour' | 'tomorrow-morning' | 'next-monday') {
+    setRunAtLocal(toPlanReminderDateTimeInputValue(planReminderPresetRunAt(preset)));
+  }
+
+  async function submit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    if (submitDisabled || submitPendingRef.current) return;
+    submitPendingRef.current = true;
+    const input = {
+      title: title.trim(),
+      note: note.trim(),
+      runAt: parsedRunAt,
+      recurrence,
+      ...(recurrence === 'cron' ? { cronExpression: cronExpression.trim() } : {}),
+      delivery,
+    };
+    setSubmitPending(true);
+    try {
+      const result = editingId
+        ? await props.onUpdate?.(editingId, input)
+        : await props.onCreate?.({
+          ...input,
+          ...(input.note ? { note: input.note } : {}),
+        });
+      if (result !== false && planReminderMountedRef.current) {
+        resetForm();
+        props.onOpenChange(false);
+      }
+    } finally {
+      submitPendingRef.current = false;
+      if (planReminderMountedRef.current) setSubmitPending(false);
+    }
+  }
+
+  return (
+    <DialogRoot
+      open={props.open}
+      onOpenChange={(open) => {
+        if (open) {
+          props.onOpenChange(true);
+        } else {
+          closeReminderDialog();
+        }
+      }}
+    >
+      <DialogContent
+        className="maka-plan-dialog w-[min(92vw,680px)] p-0"
+        aria-labelledby="maka-plan-dialog-title"
+        showClose={false}
+      >
+        <form className="maka-plan-form" onSubmit={submit} aria-busy={submitPending ? 'true' : undefined}>
+          <header className="maka-plan-form-header">
+            <div>
+              <p className="maka-plan-eyebrow">计划提示词</p>
+              <h3 id="maka-plan-dialog-title" className="maka-plan-form-title">{isEditing ? '编辑提醒' : '新建提醒'}</h3>
+            </div>
+            <DialogClose
+              render={<UiButton variant="quiet" size="icon-sm" />}
+              type="button"
+              onClick={closeReminderDialog}
+              disabled={formInteractionDisabled}
+              aria-label="关闭计划提醒表单"
+            >
+              <X size={16} aria-hidden="true" />
+            </DialogClose>
+          </header>
+          <div className="maka-plan-form-grid">
+            <label className="maka-plan-field">
+              <span>标题</span>
+              <Input
+                value={title}
+                onChange={(event) => setTitle(event.currentTarget.value)}
+                maxLength={120}
+                data-maka-plan-title-input="true"
+                placeholder="例如：明天复盘项目进度"
+                disabled={formInteractionDisabled}
+              />
+            </label>
+            <label className="maka-plan-field">
+              <span>时间</span>
+              <Input
+                value={runAtLocal}
+                onChange={(event) => setRunAtLocal(event.currentTarget.value)}
+                type="text"
+                inputMode="numeric"
+                autoComplete="off"
+                spellCheck={false}
+                placeholder="2026-06-05 13:44"
+                aria-label="提醒时间"
+                disabled={formInteractionDisabled}
+              />
+            </label>
+          </div>
+          <div className="maka-plan-presets" aria-label="快速设置提醒时间">
+            {[
+              ['ten-minutes', '10 分钟后'],
+              ['one-hour', '1 小时后'],
+              ['tomorrow-morning', '明天 9 点'],
+              ['next-monday', '下周一 9 点'],
+            ].map(([preset, label]) => (
+              <UiButton
+                key={preset}
+                type="button"
+                variant="secondary"
+                size="sm"
+                className="maka-plan-preset"
+                onClick={() => applyRunAtPreset(preset as 'ten-minutes' | 'one-hour' | 'tomorrow-morning' | 'next-monday')}
+                disabled={formInteractionDisabled}
+              >
+                {label}
+              </UiButton>
+            ))}
+          </div>
+          <div className="maka-plan-form-grid">
+            <label className="maka-plan-field">
+              <span>重复</span>
+              <PlanReminderSelect
+                value={recurrence}
+                onChange={(value) => setRecurrence(value)}
+                disabled={formInteractionDisabled}
+                ariaLabel="重复"
+                options={[
+                  ['none', '不重复'],
+                  ['daily', '每天'],
+                  ['weekly', '每周'],
+                  ['monthly', '每月'],
+                  ['cron', 'Cron'],
+                ] satisfies ReadonlyArray<readonly [PlanReminderRecurrence, string]>}
+              />
+            </label>
+            <label className="maka-plan-field">
+              <span>投递</span>
+              <PlanReminderSelect
+                value={deliveryChannel}
+                onChange={(value) => setDeliveryChannel(value)}
+                disabled={formInteractionDisabled}
+                ariaLabel="投递"
+                options={[
+                  ['local', '本地提醒'],
+                  ['bot', '机器人聊天'],
+                ] satisfies ReadonlyArray<readonly [PlanReminderDeliveryTarget['channel'], string]>}
+              />
+            </label>
+          </div>
+          {recurrence === 'cron' && (
+            <label className="maka-plan-field">
+              <span>Cron</span>
+              <Input
+                value={cronExpression}
+                onChange={(event) => setCronExpression(event.currentTarget.value)}
+                maxLength={80}
+                placeholder="例如 0 9 * * 1-5"
+                disabled={formInteractionDisabled}
+              />
+            </label>
+          )}
+          {deliveryChannel === 'bot' && (
+            <>
+              <div className="maka-plan-delivery-grid">
+                <label className="maka-plan-field">
+                  <span>平台</span>
+                  <PlanReminderSelect
+                    value={deliveryPlatform}
+                    onChange={(value) => setDeliveryPlatform(value)}
+                    disabled={formInteractionDisabled}
+                    ariaLabel="平台"
+                    options={BOT_DELIVERY_PROVIDERS.map((provider) => {
+                      const icon = (
+                        <BotBrandLogo
+                          provider={provider}
+                          width="100%"
+                          height="100%"
+                          aria-hidden="true"
+                        />
+                      );
+                      return [provider, botDisplayLabel(provider), icon] as const;
+                    })}
+                  />
+                </label>
+                <label className="maka-plan-field">
+                  <span>Chat ID</span>
+                  <Input
+                    value={deliveryChatId}
+                    onChange={(event) => setDeliveryChatId(event.currentTarget.value)}
+                    maxLength={160}
+                    placeholder="例如 Telegram chat_id"
+                    disabled={formInteractionDisabled}
+                  />
+                </label>
+              </div>
+              <p className="maka-plan-delivery-help">
+                当前可投递到 {formatPlanDeliveryProviderList()}；其它机器人平台不会出现在投递目标里。
+              </p>
+            </>
+          )}
+          <label className="maka-plan-field maka-plan-prompt-field">
+            <span>备注</span>
+            <UiTextarea
+              value={note}
+              onChange={(event) => setNote(event.currentTarget.value)}
+              maxLength={1000}
+              rows={5}
+              placeholder="可选：补充需要提醒的上下文"
+              disabled={formInteractionDisabled}
+            />
+          </label>
+          {validationMessage && (
+            <p className="maka-plan-validation" role="status" aria-live="polite">
+              {validationMessage}
+            </p>
+          )}
+          <footer className="maka-plan-form-footer">
+            <UiButton
+              variant="secondary"
+              type="button"
+              onClick={closeReminderDialog}
+              disabled={formInteractionDisabled}
+            >
+              取消
+            </UiButton>
+            <UiButton type="submit" disabled={submitDisabled}>
+              {isEditing ? <Check size={14} aria-hidden="true" /> : <Plus size={14} aria-hidden="true" />}
+              <span>{submitPending ? (isEditing ? '保存中…' : '创建中…') : (isEditing ? '保存提醒' : '创建提醒')}</span>
+            </UiButton>
+          </footer>
+        </form>
+      </DialogContent>
+    </DialogRoot>
+  );
+}

--- a/packages/ui/src/plan-reminder-panel.tsx
+++ b/packages/ui/src/plan-reminder-panel.tsx
@@ -1,9 +1,8 @@
-import { useEffect, useRef, useState, type FormEvent } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { Button as BaseButton } from '@base-ui/react/button';
 import { useMountedRef } from './use-mounted-ref.js';
 import {
   ArchiveRestore,
-  Check,
   Clock,
   Copy,
   Info,
@@ -13,21 +12,13 @@ import {
   RefreshCcw,
   Repeat,
   Trash2,
-  X,
 } from './icons.js';
-import { BotBrandLogo } from './bot-brand-logo.js';
-import { SettingsSelect, type SettingsSelectOption } from './primitives/settings-select.js';
 import type {
-  BotProvider,
   CapabilityAuditReport,
   PlanReminder,
-  PlanReminderDeliveryTarget,
-  PlanReminderRecurrence,
   PlanReminderStatus,
 } from '@maka/core';
 import {
-  BOT_DELIVERY_PROVIDERS,
-  botDisplayLabel,
   deriveCapabilityAuditReport,
   formatPlanReminderDeliveryTarget,
 } from '@maka/core';
@@ -35,28 +26,26 @@ import {
   PLAN_REMINDER_EXAMPLE_TEMPLATES,
   type PlanReminderExampleTemplate,
   comparePlanReminderBySort,
-  duplicatePlanReminderTitle,
-  formatPlanDeliveryProviderList,
   formatPlanRecurrence,
   formatReminderCountdown,
   formatReminderTime,
   normalizePlanReminderSearchQuery,
-  planReminderEditableRunAt,
-  planReminderFormValidationMessage,
   planReminderMatchesSearch,
-  planReminderPresetRunAt,
-  planReminderRecurrenceValue,
   planReminderRunRangeStart,
   planReminderStatusLabel,
-  planReminderTemplateNextRunAt,
   runStatusLabel,
-  toPlanReminderDateTimeInputValue,
 } from './plan-reminder-helpers.js';
 import {
+  PlanReminderFormDialog,
+  createPlanReminderFormSeed,
+  planReminderDuplicateSeed,
+  planReminderEditSeed,
+  planReminderTemplateSeed,
+  type PlanReminderFormSeed,
+} from './plan-reminder-form-dialog.js';
+import { PlanReminderSelect } from './plan-reminder-select.js';
+import {
   Button as UiButton,
-  DialogClose,
-  DialogContent,
-  DialogRoot,
   Switch,
   TabsList,
   TabsPanel,
@@ -67,7 +56,6 @@ import { Badge } from './primitives/badge.js';
 import { Chip, type ChipProps } from './primitives/chip.js';
 import { PageHeader } from './primitives/page-header.js';
 import { Input } from './primitives/input.js';
-import { Textarea as UiTextarea } from './primitives/textarea.js';
 import { Alert, AlertTitle } from './primitives/alert.js';
 import { Menu, MenuItem, MenuPopup, MenuTrigger } from './primitives/menu.js';
 import { EmptyState } from './empty-state.js';
@@ -76,23 +64,6 @@ import type {
   PlanReminderDraftInput,
   PlanReminderUpdatePatch,
 } from './module-panel-types.js';
-
-// PR round-AB-shared-select (yuejing 2026-06-25, kenji styles inventory
-// task #128): `PlanReminderSelect` is now a thin specialization of the
-// shared `SettingsSelect` primitive — `width="full"` to preserve the
-// existing edge-to-edge sizing inside `.maka-plan-delivery-grid`.
-// Plan Reminder and Settings selects share one component so option
-// shape, trigger/popup chrome, and the selected-trigger icon contract
-// can't drift apart again.
-function PlanReminderSelect<T extends string>(props: {
-  value: T;
-  options: ReadonlyArray<SettingsSelectOption<T>>;
-  onChange(value: T): void;
-  ariaLabel: string;
-  disabled?: boolean;
-}) {
-  return <SettingsSelect width="full" {...props} />;
-}
 
 // Run-history status Chip tone. triggered = it fired (info, informational,
 // not a health signal), blocked = intentionally skipped (warning), failed =
@@ -124,29 +95,23 @@ export function PlanReminderPanel(props: {
   type PlanReminderView = 'tasks' | 'runs';
   type PlanReminderRunRange = 'day' | 'week' | 'month' | 'all';
   type PlanReminderSort = 'created-desc' | 'next-run-asc' | 'updated-desc';
-  const [title, setTitle] = useState('');
-  const [note, setNote] = useState('');
-  const [runAtLocal, setRunAtLocal] = useState(() => toPlanReminderDateTimeInputValue(Date.now() + 60 * 60 * 1000));
-  const [recurrence, setRecurrence] = useState<PlanReminderRecurrence>('none');
-  const [cronExpression, setCronExpression] = useState('0 9 * * 1-5');
-  const [deliveryChannel, setDeliveryChannel] = useState<PlanReminderDeliveryTarget['channel']>('local');
-  const [deliveryPlatform, setDeliveryPlatform] = useState<BotProvider>('telegram');
-  const [deliveryChatId, setDeliveryChatId] = useState('');
-  const [editingId, setEditingId] = useState<string | null>(null);
-  const [submitPending, setSubmitPending] = useState(false);
   const [pendingActionKeys, setPendingActionKeys] = useState<ReadonlySet<string>>(() => new Set());
   const planReminderMountedRef = useMountedRef();
-  const submitPendingRef = useRef(false);
   const refreshPendingRef = useRef(false);
   const pendingActionKeysRef = useRef<Set<string>>(new Set());
+  // Issue #1044: all create/edit form fields + submit moved into
+  // PlanReminderFormDialog. The panel only tracks whether the dialog is
+  // open and which seed it mounts with; `formNonce` remounts the dialog per
+  // open so the form initializes from the seed.
   const [formDialogOpen, setFormDialogOpen] = useState(false);
+  const [formSeed, setFormSeed] = useState<PlanReminderFormSeed>(() => createPlanReminderFormSeed());
+  const [formNonce, setFormNonce] = useState(0);
   const [planView, setPlanView] = useState<PlanReminderView>('tasks');
   const [runRange, setRunRange] = useState<PlanReminderRunRange>('week');
   const [listFilter, setListFilter] = useState<PlanReminderListFilter>('active');
   const [listSort, setListSort] = useState<PlanReminderSort>('created-desc');
   const [listQuery, setListQuery] = useState('');
   const [refreshPending, setRefreshPending] = useState(false);
-  const parsedRunAt = Date.parse(runAtLocal);
   const normalizedListQuery = normalizePlanReminderSearchQuery(listQuery);
   const searchMatchedReminders = normalizedListQuery
     ? props.reminders.filter((reminder) => planReminderMatchesSearch(reminder, normalizedListQuery))
@@ -169,139 +134,35 @@ export function PlanReminderPanel(props: {
     paused: searchMatchedReminders.filter((reminder) => reminder.status === 'paused').length,
     completed: searchMatchedReminders.filter((reminder) => reminder.status === 'completed').length,
   };
-  const delivery: PlanReminderDeliveryTarget = deliveryChannel === 'bot'
-    ? { channel: 'bot', platform: deliveryPlatform, chatId: deliveryChatId.trim() }
-    : { channel: 'local' };
-  const validationMessage = planReminderFormValidationMessage({
-    title,
-    parsedRunAt,
-    recurrence,
-    cronExpression,
-    delivery,
-    now: Date.now(),
-  });
-  const canCreate = validationMessage === null;
-  const submitDisabled = !canCreate || submitPending;
-  const formInteractionDisabled = submitPending;
-  const isEditing = editingId !== null;
   const auditReport = props.auditReport ?? deriveCapabilityAuditReport({ planReminders: props.reminders });
 
   useEffect(() => {
     return () => {
-      submitPendingRef.current = false;
       refreshPendingRef.current = false;
       pendingActionKeysRef.current = new Set();
     };
   }, []);
 
-  useEffect(() => {
-    if (editingId && !props.reminders.some((reminder) => reminder.id === editingId)) resetForm();
-  }, [editingId, props.reminders]);
-
-  function resetForm() {
-    setTitle('');
-    setNote('');
-    setRecurrence('none');
-    setCronExpression('0 9 * * 1-5');
-    setDeliveryChannel('local');
-    setDeliveryPlatform('telegram');
-    setDeliveryChatId('');
-    setRunAtLocal(toPlanReminderDateTimeInputValue(Date.now() + 60 * 60 * 1000));
-    setEditingId(null);
+  function openReminderDialog(seed: PlanReminderFormSeed) {
+    setFormSeed(seed);
+    setFormNonce((nonce) => nonce + 1);
+    setFormDialogOpen(true);
   }
 
   function openCreateReminderDialog() {
-    resetForm();
-    setFormDialogOpen(true);
+    openReminderDialog(createPlanReminderFormSeed());
   }
 
   function openPlanReminderTemplate(template: PlanReminderExampleTemplate) {
-    setEditingId(null);
-    setTitle(template.title);
-    setNote(template.note);
-    setRecurrence(template.recurrence);
-    setCronExpression(template.cronExpression);
-    setDeliveryChannel('local');
-    setDeliveryPlatform('telegram');
-    setDeliveryChatId('');
-    setRunAtLocal(toPlanReminderDateTimeInputValue(planReminderTemplateNextRunAt(template)));
-    setFormDialogOpen(true);
-  }
-
-  function closeReminderDialog() {
-    if (submitPendingRef.current) return;
-    setFormDialogOpen(false);
-    resetForm();
+    openReminderDialog(planReminderTemplateSeed(template));
   }
 
   function editReminder(reminder: PlanReminder) {
-    setEditingId(reminder.id);
-    setTitle(reminder.title);
-    setNote(reminder.note);
-    setRunAtLocal(toPlanReminderDateTimeInputValue(planReminderEditableRunAt(reminder)));
-    setRecurrence(planReminderRecurrenceValue(reminder));
-    setCronExpression(reminder.schedule.kind === 'cron' ? reminder.schedule.expression : '0 9 * * 1-5');
-    setDeliveryChannel(reminder.delivery.channel);
-    if (reminder.delivery.channel === 'bot') {
-      setDeliveryPlatform(reminder.delivery.platform);
-      setDeliveryChatId(reminder.delivery.chatId);
-    } else {
-      setDeliveryPlatform('telegram');
-      setDeliveryChatId('');
-    }
-    setFormDialogOpen(true);
+    openReminderDialog(planReminderEditSeed(reminder));
   }
 
   function duplicateReminder(reminder: PlanReminder) {
-    setEditingId(null);
-    setTitle(duplicatePlanReminderTitle(reminder.title));
-    setNote(reminder.note);
-    setRunAtLocal(toPlanReminderDateTimeInputValue(planReminderEditableRunAt(reminder)));
-    setRecurrence(planReminderRecurrenceValue(reminder));
-    setCronExpression(reminder.schedule.kind === 'cron' ? reminder.schedule.expression : '0 9 * * 1-5');
-    setDeliveryChannel(reminder.delivery.channel);
-    if (reminder.delivery.channel === 'bot') {
-      setDeliveryPlatform(reminder.delivery.platform);
-      setDeliveryChatId(reminder.delivery.chatId);
-    } else {
-      setDeliveryPlatform('telegram');
-      setDeliveryChatId('');
-    }
-    setFormDialogOpen(true);
-  }
-
-  function applyRunAtPreset(preset: 'ten-minutes' | 'one-hour' | 'tomorrow-morning' | 'next-monday') {
-    setRunAtLocal(toPlanReminderDateTimeInputValue(planReminderPresetRunAt(preset)));
-  }
-
-  async function submit(event: FormEvent<HTMLFormElement>) {
-    event.preventDefault();
-    if (submitDisabled || submitPendingRef.current) return;
-    submitPendingRef.current = true;
-    const input = {
-      title: title.trim(),
-      note: note.trim(),
-      runAt: parsedRunAt,
-      recurrence,
-      ...(recurrence === 'cron' ? { cronExpression: cronExpression.trim() } : {}),
-      delivery,
-    };
-    setSubmitPending(true);
-    try {
-      const result = editingId
-        ? await props.onUpdate?.(editingId, input)
-        : await props.onCreate?.({
-          ...input,
-          ...(input.note ? { note: input.note } : {}),
-        });
-      if (result !== false && planReminderMountedRef.current) {
-        resetForm();
-        setFormDialogOpen(false);
-      }
-    } finally {
-      submitPendingRef.current = false;
-      if (planReminderMountedRef.current) setSubmitPending(false);
-    }
+    openReminderDialog(planReminderDuplicateSeed(reminder));
   }
 
   async function runPlanReminderAction(
@@ -546,14 +407,14 @@ export function PlanReminderPanel(props: {
                           <MenuPopup className="maka-plan-card-menu" align="end">
                             <MenuItem
                               onClick={() => editReminder(reminder)}
-                              disabled={submitPending || reminderActionPending || reminder.status === 'completed'}
+                              disabled={reminderActionPending || reminder.status === 'completed'}
                             >
                               <Pencil size={14} aria-hidden="true" />
                               编辑
                             </MenuItem>
                             <MenuItem
                               onClick={() => duplicateReminder(reminder)}
-                              disabled={submitPending || reminderActionPending}
+                              disabled={reminderActionPending}
                             >
                               <Copy size={14} aria-hidden="true" />
                               复制
@@ -665,199 +526,15 @@ export function PlanReminderPanel(props: {
         </TabsRoot>
       </div>
 
-      <DialogRoot
+      <PlanReminderFormDialog
+        key={formNonce}
         open={formDialogOpen}
-        onOpenChange={(open) => {
-          if (open) {
-            setFormDialogOpen(true);
-          } else {
-            closeReminderDialog();
-          }
-        }}
-      >
-        <DialogContent
-          className="maka-plan-dialog w-[min(92vw,680px)] p-0"
-          aria-labelledby="maka-plan-dialog-title"
-          showClose={false}
-        >
-          <form className="maka-plan-form" onSubmit={submit} aria-busy={submitPending ? 'true' : undefined}>
-            <header className="maka-plan-form-header">
-              <div>
-                <p className="maka-plan-eyebrow">计划提示词</p>
-                <h3 id="maka-plan-dialog-title" className="maka-plan-form-title">{isEditing ? '编辑提醒' : '新建提醒'}</h3>
-              </div>
-              <DialogClose
-                render={<UiButton variant="quiet" size="icon-sm" />}
-                type="button"
-                onClick={closeReminderDialog}
-                disabled={formInteractionDisabled}
-                aria-label="关闭计划提醒表单"
-              >
-                <X size={16} aria-hidden="true" />
-              </DialogClose>
-            </header>
-            <div className="maka-plan-form-grid">
-              <label className="maka-plan-field">
-                <span>标题</span>
-                <Input
-                  value={title}
-                  onChange={(event) => setTitle(event.currentTarget.value)}
-                  maxLength={120}
-                  data-maka-plan-title-input="true"
-                  placeholder="例如：明天复盘项目进度"
-                  disabled={formInteractionDisabled}
-                />
-              </label>
-              <label className="maka-plan-field">
-                <span>时间</span>
-                <Input
-                  value={runAtLocal}
-                  onChange={(event) => setRunAtLocal(event.currentTarget.value)}
-                  type="text"
-                  inputMode="numeric"
-                  autoComplete="off"
-                  spellCheck={false}
-                  placeholder="2026-06-05 13:44"
-                  aria-label="提醒时间"
-                  disabled={formInteractionDisabled}
-                />
-              </label>
-            </div>
-            <div className="maka-plan-presets" aria-label="快速设置提醒时间">
-              {[
-                ['ten-minutes', '10 分钟后'],
-                ['one-hour', '1 小时后'],
-                ['tomorrow-morning', '明天 9 点'],
-                ['next-monday', '下周一 9 点'],
-              ].map(([preset, label]) => (
-                <UiButton
-                  key={preset}
-                  type="button"
-                  variant="secondary"
-                  size="sm"
-                  className="maka-plan-preset"
-                  onClick={() => applyRunAtPreset(preset as 'ten-minutes' | 'one-hour' | 'tomorrow-morning' | 'next-monday')}
-                  disabled={formInteractionDisabled}
-                >
-                  {label}
-                </UiButton>
-              ))}
-            </div>
-            <div className="maka-plan-form-grid">
-              <label className="maka-plan-field">
-                <span>重复</span>
-                <PlanReminderSelect
-                  value={recurrence}
-                  onChange={(value) => setRecurrence(value)}
-                  disabled={formInteractionDisabled}
-                  ariaLabel="重复"
-                  options={[
-                    ['none', '不重复'],
-                    ['daily', '每天'],
-                    ['weekly', '每周'],
-                    ['monthly', '每月'],
-                    ['cron', 'Cron'],
-                  ] satisfies ReadonlyArray<readonly [PlanReminderRecurrence, string]>}
-                />
-              </label>
-              <label className="maka-plan-field">
-                <span>投递</span>
-                <PlanReminderSelect
-                  value={deliveryChannel}
-                  onChange={(value) => setDeliveryChannel(value)}
-                  disabled={formInteractionDisabled}
-                  ariaLabel="投递"
-                  options={[
-                    ['local', '本地提醒'],
-                    ['bot', '机器人聊天'],
-                  ] satisfies ReadonlyArray<readonly [PlanReminderDeliveryTarget['channel'], string]>}
-                />
-              </label>
-            </div>
-            {recurrence === 'cron' && (
-              <label className="maka-plan-field">
-                <span>Cron</span>
-                <Input
-                  value={cronExpression}
-                  onChange={(event) => setCronExpression(event.currentTarget.value)}
-                  maxLength={80}
-                  placeholder="例如 0 9 * * 1-5"
-                  disabled={formInteractionDisabled}
-                />
-              </label>
-            )}
-            {deliveryChannel === 'bot' && (
-              <>
-                <div className="maka-plan-delivery-grid">
-                  <label className="maka-plan-field">
-                    <span>平台</span>
-                    <PlanReminderSelect
-                      value={deliveryPlatform}
-                      onChange={(value) => setDeliveryPlatform(value)}
-                      disabled={formInteractionDisabled}
-                      ariaLabel="平台"
-                      options={BOT_DELIVERY_PROVIDERS.map((provider) => {
-                        const icon = (
-                          <BotBrandLogo
-                            provider={provider}
-                            width="100%"
-                            height="100%"
-                            aria-hidden="true"
-                          />
-                        );
-                        return [provider, botDisplayLabel(provider), icon] as const;
-                      })}
-                    />
-                  </label>
-                  <label className="maka-plan-field">
-                    <span>Chat ID</span>
-                    <Input
-                      value={deliveryChatId}
-                      onChange={(event) => setDeliveryChatId(event.currentTarget.value)}
-                      maxLength={160}
-                      placeholder="例如 Telegram chat_id"
-                      disabled={formInteractionDisabled}
-                    />
-                  </label>
-                </div>
-                <p className="maka-plan-delivery-help">
-                  当前可投递到 {formatPlanDeliveryProviderList()}；其它机器人平台不会出现在投递目标里。
-                </p>
-              </>
-            )}
-            <label className="maka-plan-field maka-plan-prompt-field">
-              <span>备注</span>
-              <UiTextarea
-                value={note}
-                onChange={(event) => setNote(event.currentTarget.value)}
-                maxLength={1000}
-                rows={5}
-                placeholder="可选：补充需要提醒的上下文"
-                disabled={formInteractionDisabled}
-              />
-            </label>
-            {validationMessage && (
-              <p className="maka-plan-validation" role="status" aria-live="polite">
-                {validationMessage}
-              </p>
-            )}
-            <footer className="maka-plan-form-footer">
-              <UiButton
-                variant="secondary"
-                type="button"
-                onClick={closeReminderDialog}
-                disabled={formInteractionDisabled}
-              >
-                取消
-              </UiButton>
-              <UiButton type="submit" disabled={submitDisabled}>
-                {isEditing ? <Check size={14} aria-hidden="true" /> : <Plus size={14} aria-hidden="true" />}
-                <span>{submitPending ? (isEditing ? '保存中…' : '创建中…') : (isEditing ? '保存提醒' : '创建提醒')}</span>
-              </UiButton>
-            </footer>
-          </form>
-        </DialogContent>
-      </DialogRoot>
+        seed={formSeed}
+        reminders={props.reminders}
+        onOpenChange={setFormDialogOpen}
+        onCreate={props.onCreate}
+        onUpdate={props.onUpdate}
+      />
     </div>
   );
 }

--- a/packages/ui/src/plan-reminder-select.tsx
+++ b/packages/ui/src/plan-reminder-select.tsx
@@ -1,0 +1,21 @@
+import { SettingsSelect, type SettingsSelectOption } from './primitives/settings-select.js';
+
+// PR round-AB-shared-select (yuejing 2026-06-25, kenji styles inventory
+// task #128): `PlanReminderSelect` is now a thin specialization of the
+// shared `SettingsSelect` primitive — `width="full"` to preserve the
+// existing edge-to-edge sizing inside `.maka-plan-delivery-grid`.
+// Plan Reminder and Settings selects share one component so option
+// shape, trigger/popup chrome, and the selected-trigger icon contract
+// can't drift apart again.
+//
+// Issue #1044: shared by the panel (list filter/sort/range toolbars) and
+// the extracted form dialog, so it lives in its own leaf module.
+export function PlanReminderSelect<T extends string>(props: {
+  value: T;
+  options: ReadonlyArray<SettingsSelectOption<T>>;
+  onChange(value: T): void;
+  ariaLabel: string;
+  disabled?: boolean;
+}) {
+  return <SettingsSelect width="full" {...props} />;
+}

--- a/packages/ui/src/use-composer-draft.ts
+++ b/packages/ui/src/use-composer-draft.ts
@@ -1,0 +1,89 @@
+/**
+ * Composer draft-persistence hook (issue #1044).
+ *
+ * Owns the per-session unsent-draft store that used to live inline in
+ * `composer.tsx`: a bounded Map keyed by `draftKey`, the active key, and the
+ * `hasDraftText` flag that gates the send button. The pure store operations
+ * (remember / read, with the 120k-char and 32-entry bounds) stay in
+ * `composer-helpers.ts` — this hook is the React seam that wires them to the
+ * uncontrolled textarea.
+ *
+ * The swap effect preserves the exact pre-extraction semantics: when the host
+ * switches `draftKey` (e.g. the first send in the home composer creates a
+ * session and the surface re-keys), the textarea value is remembered under
+ * the OLD key, the draft for the NEW key is swapped in, and the caret lands
+ * at the end. `onDraftKeyChange` lets the composer reset sibling state
+ * machines (prompt-history navigation) at the same moment without this hook
+ * depending on them.
+ */
+
+import { useEffect, useRef, useState, type RefObject } from 'react';
+import { readComposerDraft, rememberComposerDraft } from './composer-helpers.js';
+
+export interface ComposerDraftApi {
+  /** True while the active draft holds non-whitespace text (gates Send). */
+  hasDraftText: boolean;
+  /**
+   * Persist the current (or given) textarea value under the active draft key
+   * and refresh `hasDraftText`.
+   */
+  saveCurrentDraft(value?: string): void;
+  /**
+   * Clear the draft stored under an explicit key. A successful send clears
+   * the key it was submitted from (which may no longer be the active key
+   * after a new-session swap) in addition to the active draft.
+   */
+  clearDraft(key: string | undefined): void;
+  /** The key the current textarea content is persisted under. */
+  activeDraftKey(): string | undefined;
+}
+
+export function useComposerDraft(input: {
+  textareaRef: RefObject<HTMLTextAreaElement | null>;
+  /** Runtime-only key used to keep unsent drafts isolated per session. */
+  draftKey: string | undefined;
+  /** Re-measure the textarea after a programmatic value swap. */
+  autoResize(): void;
+  /** Fired after the active key swaps so sibling state machines can reset. */
+  onDraftKeyChange(): void;
+}): ComposerDraftApi {
+  const [hasDraftText, setHasDraftText] = useState(false);
+  const draftStoreRef = useRef<Map<string, string>>(new Map());
+  const activeDraftKeyRef = useRef<string | undefined>(input.draftKey);
+
+  function saveCurrentDraft(value?: string) {
+    const nextValue = value ?? input.textareaRef.current?.value ?? '';
+    rememberComposerDraft(draftStoreRef.current, activeDraftKeyRef.current, nextValue);
+    setHasDraftText(Boolean(nextValue.trim()));
+  }
+
+  function clearDraft(key: string | undefined) {
+    rememberComposerDraft(draftStoreRef.current, key, '');
+  }
+
+  function activeDraftKey() {
+    return activeDraftKeyRef.current;
+  }
+
+  useEffect(() => {
+    const el = input.textareaRef.current;
+    const previousKey = activeDraftKeyRef.current;
+    const nextKey = input.draftKey;
+
+    if (previousKey !== nextKey) {
+      rememberComposerDraft(draftStoreRef.current, previousKey, el?.value ?? '');
+      activeDraftKeyRef.current = nextKey;
+      input.onDraftKeyChange();
+      if (el) {
+        const nextDraft = readComposerDraft(draftStoreRef.current, nextKey);
+        el.value = nextDraft;
+        setHasDraftText(Boolean(nextDraft.trim()));
+        input.autoResize();
+        const length = el.value.length;
+        el.setSelectionRange(length, length);
+      }
+    }
+  }, [input.draftKey]);
+
+  return { hasDraftText, saveCurrentDraft, clearDraft, activeDraftKey };
+}

--- a/packages/ui/src/use-composer-history.ts
+++ b/packages/ui/src/use-composer-history.ts
@@ -1,0 +1,124 @@
+/**
+ * Composer prompt-history navigation hook (issue #1044).
+ *
+ * Owns the up/down-arrow recall state that used to live inline in
+ * `composer.tsx`: the in-memory mirror of the global input history plus the
+ * "mid-navigation" index/savedDraft pair. The pure state machine
+ * (`navigateComposerHistory`, `reconcileHistorySync`,
+ * `rememberComposerHistoryEntry`) stays in `composer-helpers.ts` and the
+ * localStorage seam in `input-history.ts` — both unit-tested there. This
+ * hook is the React/DOM seam that applies navigation results to the
+ * uncontrolled textarea (value + caret + draft persistence + resize).
+ */
+
+import { useRef, type KeyboardEvent, type RefObject } from 'react';
+import {
+  type ComposerHistoryState,
+  navigateComposerHistory,
+  reconcileHistorySync,
+  rememberComposerHistoryEntry,
+} from './composer-helpers.js';
+import { readGlobalInputHistory, saveGlobalInputHistoryEntry } from './input-history.js';
+
+export interface ComposerHistoryApi {
+  /**
+   * Drop back to "not navigating" (index -1, no saved draft). Any real edit,
+   * send, or programmatic text set calls this so the next arrow-up starts
+   * from the newest entry again.
+   */
+  resetNavigation(): void;
+  /**
+   * Record a successfully-sent prompt into both the in-memory list and the
+   * persisted global history (shared across input surfaces, survives reloads).
+   */
+  rememberSentEntry(text: string): void;
+  /**
+   * PR-GLOBAL-INPUT-HISTORY: up/down arrow navigates the global input
+   * history. Bare arrow keys only start navigation when the textarea is
+   * empty, or when the user is already mid-navigation (index >= 0); in a
+   * multi-line draft the caret keeps moving so editing isn't hijacked.
+   * Ctrl/Cmd + ArrowUp/ArrowDown is an explicit shortcut that always
+   * navigates history regardless of the current draft.
+   *
+   * Returns true when the keystroke was consumed (a navigation applied, or
+   * deliberately swallowed because history is empty) and the caller must
+   * stop further key handling.
+   */
+  handleArrowKey(event: KeyboardEvent<HTMLTextAreaElement>): boolean;
+}
+
+export function useComposerHistory(input: {
+  textareaRef: RefObject<HTMLTextAreaElement | null>;
+  /** Re-measure the textarea after a programmatic value swap. */
+  autoResize(): void;
+  /** Persist the applied value under the active draft key. */
+  saveCurrentDraft(value?: string): void;
+}): ComposerHistoryApi {
+  const promptHistoryRef = useRef<ComposerHistoryState>({ entries: readGlobalInputHistory() ?? [], index: -1, savedDraft: '' });
+
+  function resetNavigation() {
+    promptHistoryRef.current = {
+      entries: promptHistoryRef.current.entries,
+      index: -1,
+      savedDraft: '',
+    };
+  }
+
+  function rememberSentEntry(text: string) {
+    // Save to both local ref and global persistence so the history
+    // survives page reloads and is shared across all input surfaces.
+    saveGlobalInputHistoryEntry(text);
+    promptHistoryRef.current = {
+      entries: rememberComposerHistoryEntry(promptHistoryRef.current.entries, text),
+      index: -1,
+      savedDraft: '',
+    };
+  }
+
+  function applyValue(el: HTMLTextAreaElement, value: string) {
+    el.value = value;
+    input.saveCurrentDraft(value);
+    input.autoResize();
+    const length = el.value.length;
+    el.setSelectionRange(length, length);
+  }
+
+  function handleArrowKey(event: KeyboardEvent<HTMLTextAreaElement>): boolean {
+    const explicit = Boolean(event.ctrlKey || event.metaKey);
+    const plainArrow = !event.shiftKey && !event.altKey && !event.ctrlKey && !event.metaKey;
+    if (!plainArrow && !explicit) return false;
+    const el = input.textareaRef.current;
+    const isNavigatingHistory = promptHistoryRef.current.index >= 0;
+    const canStartHistory = Boolean(el && !el.value.trim());
+    if (!el || !(explicit || isNavigatingHistory || canStartHistory)) return false;
+    // Re-read global history from localStorage on every navigation so
+    // a clear from Settings (an overlay that keeps the Composer
+    // mounted) is picked up immediately, and a transient storage
+    // failure does not clobber the in-memory history.
+    // reconcileHistorySync restores the saved draft if a clear happened
+    // mid-navigation (so the user doesn't lose what they were typing).
+    const synced = readGlobalInputHistory();
+    const { state, restoreDraft } = reconcileHistorySync(promptHistoryRef.current, synced);
+    promptHistoryRef.current = state;
+    if (restoreDraft) {
+      applyValue(el, state.savedDraft);
+    }
+    // Nothing to navigate when history was cleared (synced empty) — the
+    // keystroke is swallowed so it can't fall through to other handlers.
+    // When the storage read failed (synced === null), keep navigating
+    // with the in-memory entries.
+    if (synced !== null && synced.length === 0) return true;
+    const next = navigateComposerHistory(
+      promptHistoryRef.current,
+      event.key === 'ArrowUp' ? 'previous' : 'next',
+      el.value,
+    );
+    if (!next.changed) return false;
+    event.preventDefault();
+    promptHistoryRef.current = next.state;
+    applyValue(el, next.value);
+    return true;
+  }
+
+  return { resetNavigation, rememberSentEntry, handleArrowKey };
+}

--- a/packages/ui/src/use-mention-popup.ts
+++ b/packages/ui/src/use-mention-popup.ts
@@ -1,0 +1,217 @@
+/**
+ * Composer `@` file / `/` skill mention-popup state machine (issue #1044).
+ *
+ * Owns the trigger detection + popup state that used to live inline in
+ * `composer.tsx`: the active trigger + query, the filtered items, the
+ * highlighted index, and the post-insertion suppression snapshot. The popup
+ * overlay itself stays presentational (`composer-mention-popup.tsx`); the
+ * keyboard routing (arrows / Enter / Tab / Esc) stays in Composer's
+ * onTextareaKeyDown, which drives this hook's API — that ordering is pinned
+ * by the composer-mention contract.
+ *
+ * The whole hook stays inert unless the matching provider prop is present
+ * (`onSearchMentionFiles` for `@`, `mentionSkills` for `/`), so the SSR
+ * contracts (minimal props) render nothing here. See
+ * docs/archive/composer-mentions-spec-2026-07-14.md for the v1 plain-text
+ * model.
+ */
+
+import { useEffect, useId, useRef, useState, type Dispatch, type RefObject, type SetStateAction } from 'react';
+import { detectMentionTrigger, mentionQueryMatches, type MentionTrigger } from './chat-input-behavior.js';
+import type { MentionItem } from './composer-mention-popup.js';
+
+export interface ComposerMentionApi {
+  /** The active trigger + query + trigger-char index; null when closed. */
+  mention: MentionTrigger | null;
+  /** Items shown in the popup for the active trigger. */
+  mentionItems: readonly MentionItem[];
+  /** Highlighted row; wrap-around navigation lives in Composer's keydown. */
+  mentionActiveIndex: number;
+  setMentionActiveIndex: Dispatch<SetStateAction<number>>;
+  /** True while the debounced `@` file search is in flight. */
+  mentionLoading: boolean;
+  /** Listbox id the textarea's aria-controls / aria-activedescendant point at. */
+  mentionListboxId: string;
+  /** Derived: a trigger is active and the popup is rendered. */
+  mentionPopupOpen: boolean;
+  /**
+   * Re-detect the active mention trigger from the live textarea value +
+   * caret. Called on input, keyup, and document selectionchange so clicking
+   * elsewhere (or moving the caret out of a trigger) closes the popup.
+   */
+  recomputeMention(): void;
+  /** Close the popup and clear its transient state. */
+  closeMention(): void;
+  /** Splice the chosen item's plain-text token into the textarea. */
+  selectMention(index: number): void;
+}
+
+export function useMentionPopup(input: {
+  textareaRef: RefObject<HTMLTextAreaElement | null>;
+  /** ENABLED skills offered by the `/` popup; undefined disables that popup. */
+  mentionSkills?: ReadonlyArray<{ id: string; name: string; description?: string }>;
+  /** Workspace-file search backing the `@` popup; undefined disables it. */
+  onSearchMentionFiles?(query: string): Promise<ReadonlyArray<{ relativePath: string }>>;
+  /** Persist the post-insertion value under the active draft key. */
+  saveCurrentDraft(value?: string): void;
+  /** Re-measure the textarea after the insertion changes its height. */
+  autoResize(): void;
+  /** Inserting a mention is an edit: history navigation restarts. */
+  resetPromptHistoryNavigation(): void;
+}): ComposerMentionApi {
+  // Mention popup state (@ file / skill). `mention` holds the active trigger +
+  // query + trigger-char index; items/loading/activeIndex drive the popup. The
+  // whole block stays inert unless the matching provider prop is present, so
+  // the SSR contracts (minimal props) render nothing here.
+  const [mention, setMention] = useState<MentionTrigger | null>(null);
+  const [mentionItems, setMentionItems] = useState<readonly MentionItem[]>([]);
+  const [mentionActiveIndex, setMentionActiveIndex] = useState(0);
+  const [mentionLoading, setMentionLoading] = useState(false);
+  const mentionListboxId = useId();
+  // Exact post-insertion snapshot: after we splice in a token the value can
+  // still parse as a valid trigger (e.g. `@file.txt ` — one trailing space),
+  // which would immediately re-open the popup. Suppress detection for that one
+  // state only; any further edit or caret move clears it and detection resumes.
+  const mentionSuppressRef = useRef<{ value: string; caret: number } | null>(null);
+  const recomputeMentionRef = useRef<() => void>(() => {});
+  const mentionPopupOpen = mention !== null;
+
+  function closeMention() {
+    setMention(null);
+    setMentionItems([]);
+    setMentionActiveIndex(0);
+    setMentionLoading(false);
+  }
+
+  function recomputeMention() {
+    const el = input.textareaRef.current;
+    if (!el) return;
+    // Only the focused textarea drives the popup — a selectionchange from
+    // another field, or a blur, should close it.
+    if (typeof document !== 'undefined' && document.activeElement !== el) {
+      if (mentionPopupOpen) closeMention();
+      return;
+    }
+    const caret = el.selectionEnd ?? el.value.length;
+    const suppress = mentionSuppressRef.current;
+    if (suppress && suppress.value === el.value && suppress.caret === caret) {
+      if (mentionPopupOpen) closeMention();
+      return;
+    }
+    mentionSuppressRef.current = null;
+    const result = detectMentionTrigger(el.value, caret);
+    // Gate on provider presence so the feature no-ops when a popup has nothing
+    // to render (keeps the SSR/minimal-props path inert).
+    if (!result
+      || (result.trigger === '@' && !input.onSearchMentionFiles)
+      || (result.trigger === '/' && input.mentionSkills === undefined)) {
+      if (mentionPopupOpen) closeMention();
+      return;
+    }
+    setMention((prev) =>
+      prev && prev.trigger === result.trigger && prev.query === result.query && prev.start === result.start
+        ? prev
+        : result,
+    );
+  }
+  recomputeMentionRef.current = recomputeMention;
+
+  function selectMention(index: number) {
+    const el = input.textareaRef.current;
+    const current = mention;
+    if (!el || !current) return;
+    const item = mentionItems[index];
+    if (!item) return;
+    const insertion = item.type === 'file'
+      ? `@${item.relativePath} `
+      : `使用 ${item.name} 技能：`;
+    const value = el.value;
+    const caret = el.selectionEnd ?? value.length;
+    // Replace [start, caret): the trigger char (at `start`) through the caret,
+    // i.e. the `@query` / `/query` the user typed, with the plain-text token.
+    const nextValue = value.slice(0, current.start) + insertion + value.slice(caret);
+    const nextCaret = current.start + insertion.length;
+    input.resetPromptHistoryNavigation();
+    el.value = nextValue;
+    el.setSelectionRange(nextCaret, nextCaret);
+    mentionSuppressRef.current = { value: nextValue, caret: nextCaret };
+    closeMention();
+    input.saveCurrentDraft(nextValue);
+    input.autoResize();
+    el.focus();
+  }
+
+  // Populate the popup for the active trigger: skills filter synchronously from
+  // props; files search through the (debounced) IPC-backed callback.
+  useEffect(() => {
+    if (!mention) {
+      setMentionItems([]);
+      setMentionLoading(false);
+      return;
+    }
+    if (mention.trigger === '/') {
+      const skills = input.mentionSkills ?? [];
+      const items: MentionItem[] = skills
+        .filter((skill) => mentionQueryMatches(mention.query, `${skill.name} ${skill.description ?? ''}`))
+        .slice(0, 50)
+        .map((skill) => ({ type: 'skill', id: skill.id, name: skill.name, description: skill.description }));
+      setMentionItems(items);
+      setMentionActiveIndex(0);
+      setMentionLoading(false);
+      return undefined;
+    }
+    const search = input.onSearchMentionFiles;
+    if (!search) {
+      setMentionItems([]);
+      setMentionLoading(false);
+      return undefined;
+    }
+    let cancelled = false;
+    setMentionLoading(true);
+    setMentionActiveIndex(0);
+    const timer = setTimeout(() => {
+      void (async () => {
+        try {
+          const files = await search(mention.query);
+          if (cancelled) return;
+          const items: MentionItem[] = files
+            .filter((file) => mentionQueryMatches(mention.query, file.relativePath))
+            .slice(0, 50)
+            .map((file) => ({ type: 'file', relativePath: file.relativePath }));
+          setMentionItems(items);
+        } catch {
+          // Fail soft: an IPC error just yields an empty list (未找到文件).
+          if (!cancelled) setMentionItems([]);
+        } finally {
+          if (!cancelled) setMentionLoading(false);
+        }
+      })();
+    }, 150);
+    return () => {
+      cancelled = true;
+      clearTimeout(timer);
+    };
+  }, [mention, input.mentionSkills, input.onSearchMentionFiles]);
+
+  // Caret-move detection: a plain click or arrow that moves the caret out of a
+  // trigger fires selectionchange (not input), so listen for it while mounted.
+  useEffect(() => {
+    if (typeof document === 'undefined') return undefined;
+    const onSelectionChange = () => recomputeMentionRef.current();
+    document.addEventListener('selectionchange', onSelectionChange);
+    return () => document.removeEventListener('selectionchange', onSelectionChange);
+  }, []);
+
+  return {
+    mention,
+    mentionItems,
+    mentionActiveIndex,
+    setMentionActiveIndex,
+    mentionLoading,
+    mentionListboxId,
+    mentionPopupOpen,
+    recomputeMention,
+    closeMention,
+    selectMention,
+  };
+}


### PR DESCRIPTION
## Summary

Closes #1044.

Behavior- and visually-neutral decomposition of the two shared-UI panels so each hook/component owns one concern:

**Composer** (`composer.tsx` 1121 → 787 lines) — now orchestrates only:
- `use-composer-draft.ts` — per-session draft persistence: the bounded draft Map, active key, `hasDraftText`, `saveCurrentDraft`/`clearDraft`, and the `draftKey` swap effect (pure store ops stay in `composer-helpers.ts`).
- `use-composer-history.ts` — up/down prompt-history navigation: the in-memory history mirror, `resetNavigation`/`rememberSentEntry`, and the arrow-key handler that applies navigation to the uncontrolled textarea.
- `use-mention-popup.ts` — the `@`/`/` mention state machine: trigger detection, items, active index, post-insertion suppression, `selectionchange` listener. Composer keeps only the keydown routing, driving the hook through identically-named bindings.
- `composer-workspace-row.tsx` — the workspace + branch picker row, with named `ComposerWorkspacePicker`/`ComposerBranchPicker` prop types.

**Plan reminder** (`plan-reminder-panel.tsx` 863 → 540 lines) — the panel keeps only list/runs/query state, per-action pending, and refresh:
- `plan-reminder-form-dialog.tsx` — `PlanReminderFormDialog` owns ALL create/edit form state (nine fields, `editingId`), the `submitPending` single-flight owner, validation, and the submit/close pipeline. The panel opens it with a `PlanReminderFormSeed` and remounts per open (`key={formNonce}`), so fields initialize from the seed exactly where the old open-handler setters put them.
- `plan-reminder-select.tsx` — the shared `PlanReminderSelect` used by both surfaces.

Public export surface is unchanged (`Composer`/`ComposerHandle` via `components.tsx`, `PlanReminderPanel` via `plan-reminder-panel.tsx`); `@maka/ui` stays host-agnostic (no new props, no `window.maka`).

Contract tests that regex-match raw source were co-migrated to pin the same invariants across the new seams — none weakened: `composer-send-guard` (draft internals now asserted on the hook; send path unchanged), `project-context-badge` (workspace-row assertions on the row component), `plan-reminder-panel-contract` (submit owner/close guard asserted on the dialog), `command-palette-plan-reminder` (title-input marker), `renderer-utility-primitives` (preset button variants), and the copy-hygiene / stub-vocabulary scans now include the new files.

One deliberate simplification: the card-menu edit/duplicate items drop their `submitPending ||` disabled guard — unreachable, since the menu lives behind the modal dialog whenever a submit can be in flight. Also dropped two imports in `composer.tsx` that the move made dead (`MenuSeparator`, `FileEdit`).

## Verification

- Post-merge polish (pure draft/history helper unit tests + plan-reminder form-seed move into helpers) lands in follow-up #1157.
- `npm run test:fast` from the worktree root — all workspace tests pass (includes `build:test`; ui + desktop suites green end to end).
- Narrow sweeps during development: all composer contract tests (157 tests incl. `composer-send-guard`, `composer-mention`, `composer-esc-drag-clear`, `composer-constant-footprint`, `permission-composer-takeover`, SSR hint tests) and all plan-reminder tests (95 tests incl. `plan-reminder-panel-contract`, `tab-spec-499`, `badge/chip-converge`) — green after each commit.
- `npm run typecheck` (all workspaces, incl. desktop renderer + storybook tsconfigs) — clean.
- `npm run lint` — clean.
- Not run: e2e / visual smoke / screenshots (no visual or behavior change intended; DOM structure, classes, and aria attributes are preserved verbatim).

## Review focus

The riskiest extraction is the draft-persistence hook (`use-composer-draft.ts`): the `draftKey` swap effect must remember the outgoing value under the OLD key, swap in the NEW key's draft, and reset history navigation in one pass — including the first-send-new-session re-key, where `sendCurrent` clears the submitted key via `clearDraft(submittedDraftKey)` + `saveCurrentDraft('')`. The send-guard contract pins this path; worth a manual read of the hook's effect against the old inline code.
