### PR TITLE
refactor(desktop): share settings action guards and connection-test helpers

### DIFF
--- a/apps/desktop/src/main/__tests__/account-auth-ui.test.ts
+++ b/apps/desktop/src/main/__tests__/account-auth-ui.test.ts
@@ -228,22 +228,17 @@ describe('Account settings credential probe UI', () => {
 
     assert.match(
       page,
-      /const testingSlugRef = useRef<string \| null>\(null\)/,
-      'Account page connection tests need a synchronous duplicate-click guard, not only React state',
+      /const connectionTestGuard = useActionGuard<string>\(\)/,
+      'Account page connection tests need a synchronous duplicate-click guard from the shared hook, not only React state',
     );
     assert.match(
       page,
-      /const accountPageMountedRef = useMountedRef\(\);[\s\S]*useEffect\(\(\) => \{[\s\S]*return \(\) => \{[\s\S]*testingSlugRef\.current = null;/,
-      'Account page must release test ownership when Settings closes',
-    );
-    assert.match(
-      page,
-      /async function testConnection\(slug: string\) \{[\s\S]*if \(testingSlugRef\.current !== null\) return;[\s\S]*testingSlugRef\.current = slug;[\s\S]*await window\.maka\.connections\.test\(slug\)[\s\S]*if \(!accountPageMountedRef\.current \|\| testingSlugRef\.current !== slug\) return;/,
+      /async function testConnection\(slug: string\) \{[\s\S]*if \(!connectionTestGuard\.begin\(slug\)\) return;[\s\S]*await window\.maka\.connections\.test\(slug\)[\s\S]*if \(!accountPageMountedRef\.current \|\| connectionTestGuard\.current !== slug\) return;/,
       'Account page connection test must set the duplicate-click guard before awaiting IPC',
     );
     assert.match(
       page,
-      /finally \{[\s\S]*if \(accountPageMountedRef\.current && testingSlugRef\.current === slug\) \{[\s\S]*try \{[\s\S]*await props\.onRefresh\(\);[\s\S]*\} catch \(error\) \{[\s\S]*if \(accountPageMountedRef\.current && testingSlugRef\.current === slug\) \{[\s\S]*toast\.error\('刷新模型连接状态失败', settingsActionErrorMessage\(error\)\);[\s\S]*\} finally \{[\s\S]*testingSlugRef\.current = null;[\s\S]*if \(accountPageMountedRef\.current\) \{[\s\S]*setTestingSlug\(null\);/,
+      /finally \{[\s\S]*if \(accountPageMountedRef\.current && connectionTestGuard\.current === slug\) \{[\s\S]*try \{[\s\S]*await props\.onRefresh\(\);[\s\S]*\} catch \(error\) \{[\s\S]*if \(accountPageMountedRef\.current && connectionTestGuard\.current === slug\) \{[\s\S]*toast\.error\('刷新模型连接状态失败', settingsActionErrorMessage\(error\)\);[\s\S]*\} finally \{[\s\S]*connectionTestGuard\.finish\(\);[\s\S]*if \(accountPageMountedRef\.current\) \{[\s\S]*setTestingSlug\(null\);/,
       'Account page connection test must keep the button pending through status refresh and surface refresh failures',
     );
     assert.doesNotMatch(
@@ -264,28 +259,28 @@ describe('Account settings credential probe UI', () => {
     );
     assert.match(
       page,
-      /return \(\) => \{[\s\S]*testingSlugRef\.current = null;/,
-      'Account page cleanup must release an in-flight connection test owner',
+      /const connectionTestGuard = useActionGuard<string>\(\)/,
+      'Account page must hold its in-flight connection test owner in the shared guard (released on unmount)',
     );
     assert.match(
       page,
-      /const result = await window\.maka\.connections\.test\(slug\);[\s\S]*if \(!accountPageMountedRef\.current \|\| testingSlugRef\.current !== slug\) return;[\s\S]*if \(result\.ok\) \{/,
+      /const result = await window\.maka\.connections\.test\(slug\);[\s\S]*if \(!accountPageMountedRef\.current \|\| connectionTestGuard\.current !== slug\) return;[\s\S]*if \(result\.ok\) \{/,
       'Connection test success/failure toasts must not fire after unmount',
     );
     assert.match(
       page,
-      /catch \(error\) \{[\s\S]*if \(accountPageMountedRef\.current && testingSlugRef\.current === slug\) \{[\s\S]*toast\.error\('测试出错', settingsActionErrorMessage\(error\)\);/,
+      /catch \(error\) \{[\s\S]*if \(accountPageMountedRef\.current && connectionTestGuard\.current === slug\) \{[\s\S]*toast\.error\('测试出错', settingsActionErrorMessage\(error\)\);/,
       'Thrown connection-test errors must not toast after unmount',
     );
     assert.match(
       page,
-      /finally \{[\s\S]*if \(accountPageMountedRef\.current && testingSlugRef\.current === slug\) \{[\s\S]*await props\.onRefresh\(\);/,
+      /finally \{[\s\S]*if \(accountPageMountedRef\.current && connectionTestGuard\.current === slug\) \{[\s\S]*await props\.onRefresh\(\);/,
       'Post-test status refresh must not run after the account page unmounts',
     );
     assert.match(
       page,
-      /testingSlugRef\.current = null;[\s\S]*if \(accountPageMountedRef\.current\) \{[\s\S]*setTestingSlug\(null\);/,
-      'Connection-test cleanup must release the ref but not write React pending state after unmount',
+      /connectionTestGuard\.finish\(\);[\s\S]*if \(accountPageMountedRef\.current\) \{[\s\S]*setTestingSlug\(null\);/,
+      'Connection-test cleanup must release the guard but not write React pending state after unmount',
     );
   });
 

--- a/apps/desktop/src/main/__tests__/account-auth-ui.test.ts
+++ b/apps/desktop/src/main/__tests__/account-auth-ui.test.ts
@@ -192,9 +192,10 @@ describe('Account settings credential probe UI', () => {
 
   it('sanitizes account-page connection test failures before toast', async () => {
     const source = await readSettingsCombinedSource();
+    const { shared } = await readProviderSettingsSources();
     const page = source.match(/function AccountSettingsPage[\s\S]*?function AccountConnectionRow/)?.[0] ?? '';
-    const helper = source.match(/function accountConnectionTestFailureMessage\(result: ConnectionTestResult\): string \{[\s\S]*?\n\}/)?.[0] ?? '';
-    const fallback = source.match(/function accountConnectionTestFailureFallback\(result: ConnectionTestResult\): string \{[\s\S]*?\n\}/)?.[0] ?? '';
+    const helper = shared.match(/function connectionTestFailureMessage\([\s\S]*?\n\}/)?.[0] ?? '';
+    const fallback = shared.match(/function connectionTestFailureFallback\([\s\S]*?\n\}/)?.[0] ?? '';
 
     assert.match(
       helper,
@@ -202,18 +203,28 @@ describe('Account settings credential probe UI', () => {
       'Account page connection-test failures must classify/redact raw provider messages before toast',
     );
     assert.match(fallback, /statusCode === 429[\s\S]*触发速率限制/);
-    assert.match(fallback, /errorClass === 'auth'[\s\S]*鉴权失败/);
+    assert.match(fallback, /errorClass === 'auth'[\s\S]*copy\.auth/);
     assert.match(fallback, /errorClass === 'network'[\s\S]*网络错误，请检查服务地址或代理设置后重试/);
     assert.doesNotMatch(fallback, /Base URL/);
     assert.match(
+      source,
+      /const ACCOUNT_CONNECTION_TEST_COPY = \{[\s\S]*auth: '鉴权失败，请检查模型密钥、订阅账号登录或凭据配置后重试。',[\s\S]*recheck: '连接测试失败，请检查模型连接配置后重试。',[\s\S]*\} as const;/,
+      'Account page must inject its broader troubleshooting copy into the shared helper',
+    );
+    assert.match(
       page,
-      /toast\.error\('连接测试失败', accountConnectionTestFailureMessage\(result\)\)/,
+      /toast\.error\('连接测试失败', connectionTestFailureMessage\(result, ACCOUNT_CONNECTION_TEST_COPY\)\)/,
       'Account page test failure toast must not use result.errorMessage directly',
     );
     assert.match(
       page,
       /toast\.error\('测试出错', settingsActionErrorMessage\(error\)\)/,
       'Account page thrown test failures must use the shared Settings sanitized error helper',
+    );
+    assert.doesNotMatch(
+      page,
+      /function accountConnectionTestFailure(?:Message|Fallback)\(/,
+      'Account page must not keep a private connection-test failure classifier after sharing',
     );
     assert.doesNotMatch(
       page,

--- a/apps/desktop/src/main/__tests__/action-guard.test.ts
+++ b/apps/desktop/src/main/__tests__/action-guard.test.ts
@@ -1,0 +1,109 @@
+/**
+ * Behavioral coverage for createKeyedActionGuard — the framework-free
+ * multi-latch sibling of useOAuthLoginFlow's one-shot action guard, consumed
+ * through useKeyedActionGuard by Settings components that hold several
+ * independent action latches at once (the connection detail sheet's mutually
+ * excluding actions, the memory / workspace-instructions controllers' per-row
+ * action keys).
+ *
+ * The hook itself needs a DOM + React to render; the guard is pulled out
+ * precisely so the safety behaviors the pages rely on — synchronous
+ * re-entrancy rejection, per-key independence, exclusive acquisition, and
+ * owner-checked release across reset() — are testable directly, without a
+ * renderer.
+ */
+
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'node:test';
+import { createKeyedActionGuard } from '../../renderer/settings/action-guard.js';
+
+describe('keyed action guard', () => {
+  it('admits the first action per key and rejects a concurrent same-key action', () => {
+    const guard = createKeyedActionGuard<string>();
+    assert.equal(guard.has('save'), false);
+    const release = guard.begin('save');
+    assert.ok(release, 'first save must be admitted');
+    assert.equal(guard.has('save'), true);
+    // A double-click must be rejected synchronously, before React re-renders
+    // the disabled button.
+    assert.equal(guard.begin('save'), null, 'a second save must be rejected while one is pending');
+    assert.equal(guard.size, 1);
+  });
+
+  it('lets different keys run in parallel and releases them independently', () => {
+    const guard = createKeyedActionGuard<string>();
+    const releaseSave = guard.begin('save');
+    const releaseTest = guard.begin('test');
+    assert.ok(releaseSave && releaseTest, 'independent keys must both be admitted');
+    assert.equal(guard.size, 2);
+
+    releaseSave!();
+    assert.equal(guard.has('save'), false, 'releasing save must free its key');
+    assert.equal(guard.has('test'), true, 'releasing save must not free test');
+    assert.ok(guard.begin('save'), 'save must be admitted again after release');
+
+    releaseTest!();
+    assert.equal(guard.size, 1);
+  });
+
+  it('beginExclusive admits only while nothing is in flight', () => {
+    const guard = createKeyedActionGuard<string>();
+    const releaseFetch = guard.begin('fetch-models');
+    assert.ok(releaseFetch);
+    assert.equal(guard.beginExclusive('save'), null, 'exclusive save must be rejected while a fetch is pending');
+
+    releaseFetch!();
+    const releaseSave = guard.beginExclusive('save');
+    assert.ok(releaseSave, 'exclusive save must be admitted once the sheet is idle');
+    assert.equal(guard.beginExclusive('test'), null, 'a second exclusive begin must be rejected while the hold stands');
+    // Plain per-key begin stays independent: an exclusive hold does not
+    // block other keys (the post-save silent model refresh overlaps save
+    // exactly this way), just like the hand-rolled independent refs did.
+    const releaseTest = guard.begin('test');
+    assert.ok(releaseTest, 'per-key begin must stay independent of an exclusive hold');
+    releaseTest!();
+
+    releaseSave!();
+    assert.ok(guard.beginExclusive('test'), 'exclusive begin must be admitted again after the exclusive release');
+  });
+
+  it('keeps a stale release from stripping a newer hold after reset', () => {
+    const guard = createKeyedActionGuard<string>();
+    const staleRelease = guard.begin('save');
+    assert.ok(staleRelease);
+
+    // Teardown (unmount / StrictMode remount simulation) drops every hold;
+    // the same key can be acquired again right after.
+    guard.reset();
+    assert.equal(guard.size, 0);
+    const nextRelease = guard.begin('save');
+    assert.ok(nextRelease, 'save must be re-acquirable after reset');
+
+    staleRelease!();
+    assert.equal(guard.has('save'), true, 'the stale release must not strip the newer hold');
+
+    nextRelease!();
+    assert.equal(guard.has('save'), false, 'the owning release still frees the key');
+  });
+
+  it('treats a double release as a no-op', () => {
+    const guard = createKeyedActionGuard<string>();
+    const release = guard.begin('save');
+    assert.ok(release);
+    release!();
+    release!();
+    assert.equal(guard.has('save'), false);
+    assert.ok(guard.begin('save'), 'save must still be admitted after a double release');
+  });
+
+  it('reset drops every in-flight hold', () => {
+    const guard = createKeyedActionGuard<string>();
+    assert.ok(guard.begin('save'));
+    assert.ok(guard.begin('test'));
+    assert.equal(guard.size, 2);
+    guard.reset();
+    assert.equal(guard.size, 0);
+    assert.equal(guard.has('save'), false);
+    assert.equal(guard.has('test'), false);
+  });
+});

--- a/apps/desktop/src/main/__tests__/daily-review-copy-feedback-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/daily-review-copy-feedback-contract.test.ts
@@ -272,53 +272,48 @@ describe('Daily Review copy feedback contract', () => {
     const saveBlock = blockBetween(pageBlock, 'async function patchConfig', 'async function triggerRun');
     const runBlock = blockBetween(pageBlock, 'async function triggerRun', 'const effectiveConfig');
 
-    assert.match(pageBlock, /const savingKeyRef = useRef<string \| null>\(null\)/);
-    assert.match(pageBlock, /const runningModeRef = useRef<DailyReviewMode \| null>\(null\)/);
-    assert.match(
-      pageBlock,
-      /return \(\) => \{\s*savingKeyRef\.current = null;\s*runningModeRef\.current = null;\s*\};/,
-      'Daily Review Settings async owners must be invalidated when Settings closes',
-    );
+    assert.match(pageBlock, /const saveConfigGuard = useActionGuard<string>\(\)/);
+    assert.match(pageBlock, /const runModeGuard = useActionGuard<DailyReviewMode>\(\)/);
     assert.match(
       saveBlock,
-      /if \(!dailyReviewIpc\.setConfig \|\| !config \|\| savingKeyRef\.current !== null\) return;\s*savingKeyRef\.current = key;\s*setSavingKey\(key\);/,
+      /if \(!dailyReviewIpc\.setConfig \|\| !config \|\| saveConfigGuard\.current !== null\) return;\s*saveConfigGuard\.begin\(key\);\s*setSavingKey\(key\);/,
       'Daily Review config saves must synchronously reject same-frame duplicate writes before React disables controls',
     );
     assert.match(
       saveBlock,
-      /const next = await dailyReviewIpc\.setConfig\(patch\);\s*if \(mountedRef\.current && savingKeyRef\.current === key\) setConfig\(next\);/,
+      /const next = await dailyReviewIpc\.setConfig\(patch\);\s*if \(mountedRef\.current && saveConfigGuard\.current === key\) setConfig\(next\);/,
       'Late config save responses must only update the still-mounted owning settings page',
     );
     assert.match(
       saveBlock,
-      /if \(mountedRef\.current && savingKeyRef\.current === key\) \{\s*toast\.error\('保存每日回顾设置失败', settingsActionErrorMessage\(err\)\);\s*\}/,
+      /if \(mountedRef\.current && saveConfigGuard\.current === key\) \{\s*toast\.error\('保存每日回顾设置失败', settingsActionErrorMessage\(err\)\);\s*\}/,
       'Late config save failures must not toast after Settings closes or ownership changes',
     );
     assert.match(
       saveBlock,
-      /finally \{\s*if \(savingKeyRef\.current === key\) \{\s*savingKeyRef\.current = null;\s*\}\s*if \(mountedRef\.current\) setSavingKey\(null\);/,
+      /finally \{\s*if \(saveConfigGuard\.current === key\) \{\s*saveConfigGuard\.finish\(\);\s*\}\s*if \(mountedRef\.current\) setSavingKey\(null\);/,
       'Daily Review config save owners must be released by the matching request only',
     );
     assert.match(pageBlock, /const formDisabled = !hasConfigIpc \|\| loading \|\| Boolean\(loadError\) \|\| !effectiveConfig \|\| savingKey !== null;/);
 
     assert.match(
       runBlock,
-      /if \(!dailyReviewIpc\.runOnce \|\| runningModeRef\.current !== null\) return;\s*runningModeRef\.current = mode;\s*setRunningMode\(mode\);/,
+      /if \(!dailyReviewIpc\.runOnce \|\| runModeGuard\.current !== null\) return;\s*runModeGuard\.begin\(mode\);\s*setRunningMode\(mode\);/,
       'Manual Daily Review runs must synchronously reject duplicate starts before React disables buttons',
     );
     assert.match(
       runBlock,
-      /if \(mountedRef\.current && runningModeRef\.current === mode\) \{\s*toast\.success\(mode === 'daily' \? '已生成每日回顾' : '已生成深度分析', '可在「每日回顾」面板查看。'\);\s*\}/,
+      /if \(mountedRef\.current && runModeGuard\.current === mode\) \{\s*toast\.success\(mode === 'daily' \? '已生成每日回顾' : '已生成深度分析', '可在「每日回顾」面板查看。'\);\s*\}/,
       'Manual run success feedback must be owned by the still-mounted request',
     );
     assert.match(
       runBlock,
-      /if \(mountedRef\.current && runningModeRef\.current === mode\) \{\s*toast\.error\('生成回顾失败', settingsActionErrorMessage\(err\)\);\s*\}/,
+      /if \(mountedRef\.current && runModeGuard\.current === mode\) \{\s*toast\.error\('生成回顾失败', settingsActionErrorMessage\(err\)\);\s*\}/,
       'Manual run failure feedback must be owned by the still-mounted request',
     );
     assert.match(
       runBlock,
-      /finally \{\s*if \(runningModeRef\.current === mode\) \{\s*runningModeRef\.current = null;\s*\}\s*if \(mountedRef\.current\) setRunningMode\(null\);/,
+      /finally \{\s*if \(runModeGuard\.current === mode\) \{\s*runModeGuard\.finish\(\);\s*\}\s*if \(mountedRef\.current\) setRunningMode\(null\);/,
       'Manual run owners must be released by the matching request only',
     );
     assert.match(pageBlock, /disabled=\{runningMode !== null\}/);

--- a/apps/desktop/src/main/__tests__/default-permission-mode-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/default-permission-mode-contract.test.ts
@@ -153,8 +153,8 @@ describe('General settings page 默认权限模式 picker', () => {
     assert.ok(fn, 'persistPermissionMode must exist');
     assert.match(
       fn,
-      /if \(savingPermissionModeRef\.current\) return;/,
-      'overlapping settings.update calls have no ordering guarantee -- the ref guard must reject re-entrant saves like persistDefault does',
+      /const releaseSave = persistGuard\.begin\('permission-mode'\);[\s\S]*if \(!releaseSave\) return;/,
+      'overlapping settings.update calls have no ordering guarantee -- the shared keyed guard must reject re-entrant saves like persistDefault does',
     );
   });
 });

--- a/apps/desktop/src/main/__tests__/general-settings-configurable-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/general-settings-configurable-contract.test.ts
@@ -85,7 +85,7 @@ describe('General settings configurable contract', () => {
     );
   });
 
-  it('guards GeneralDefaultsCard with the same mounted-ref + savingRef ownership pattern used elsewhere in SettingsModal', async () => {
+  it('guards GeneralDefaultsCard with the same mounted-ref + shared action-guard ownership pattern used elsewhere in SettingsModal', async () => {
     const src = await readSettingsCombinedSource();
     // Capture the function's body up to the next top-level `function`
     // declaration so per-card guards are checked inside the component.
@@ -99,13 +99,13 @@ describe('General settings configurable contract', () => {
     );
     assert.match(
       cardBlock,
-      /const savingRef = useRef\(false\);/,
-      'GeneralDefaultsCard must use a synchronous savingRef so rapid duplicate selects do not race a previous in-flight save',
+      /const persistGuard = useKeyedActionGuard<'default-model' \| 'permission-mode'>\(\)/,
+      'GeneralDefaultsCard must use a synchronous guard from the shared hook so rapid duplicate selects do not race a previous in-flight save',
     );
     assert.match(
       cardBlock,
-      /if \(savingRef\.current\) return;[\s\S]*savingRef\.current = true;[\s\S]*setSaving\(true\);[\s\S]*await window\.maka\.connections\.setDefaultModel/,
-      'GeneralDefaultsCard must take the synchronous savingRef lock before awaiting the IPC; React state alone is not enough to block double-clicks',
+      /const releaseSave = persistGuard\.begin\('default-model'\);[\s\S]*if \(!releaseSave\) return;[\s\S]*setSaving\(true\);[\s\S]*await window\.maka\.connections\.setDefaultModel/,
+      'GeneralDefaultsCard must take the synchronous guard lock before awaiting the IPC; React state alone is not enough to block double-clicks',
     );
     assert.match(
       cardBlock,

--- a/apps/desktop/src/main/__tests__/local-memory-ui-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/local-memory-ui-contract.test.ts
@@ -226,11 +226,11 @@ describe('local MEMORY.md Settings UI contract', () => {
     const src = await readSettingsCombinedSource();
     const memoryPage = src.match(/function MemorySettingsPage\([\s\S]*?function MemoryEntryList/)?.[0] ?? '';
 
-    assert.match(memoryPage, /pendingMemoryActionKeysRef = useRef<Set<string>>\(new Set\(\)\)/);
+    assert.match(memoryPage, /const memoryActionGuard = useKeyedActionGuard<string>\(\)/);
     assert.match(memoryPage, /async function runMemoryAction<T>\([\s\S]*key: string,[\s\S]*action: \(isCurrent: \(\) => boolean\) => Promise<T>,/);
-    assert.match(memoryPage, /if \(pendingMemoryActionKeysRef\.current\.has\(key\)\) return undefined/);
-    assert.match(memoryPage, /pendingMemoryActionKeysRef\.current\.add\(key\)/);
-    assert.match(memoryPage, /pendingMemoryActionKeysRef\.current\.delete\(key\)/);
+    assert.match(memoryPage, /const release = memoryActionGuard\.begin\(key\);/);
+    assert.match(memoryPage, /if \(!release\) return undefined;/);
+    assert.match(memoryPage, /finally \{[\s\S]*release\(\);/);
     assert.match(memoryPage, /const isMemoryActionPending = \(key: string\) => pendingMemoryActions\.has\(key\)/);
 
     assert.match(memoryPage, /runAction\(`instruction:\$\{file\}:open`/);
@@ -262,15 +262,15 @@ describe('local MEMORY.md Settings UI contract', () => {
 
     assert.match(memoryPage, /type MemoryWriteAction =[\s\S]*'save'[\s\S]*'reset'[\s\S]*'restore'[\s\S]*'entry-status'/);
     assert.match(memoryPage, /const \[pendingMemoryWriteAction, setPendingMemoryWriteAction\] = useState<MemoryWriteAction \| null>\(null\)/);
-    assert.match(memoryPage, /const memoryWriteBusyRef = useRef\(false\)/);
+    assert.match(memoryPage, /const memoryActionGuard = useKeyedActionGuard<string>\(\)/);
     assert.match(
       memoryPage,
-      /async function runMemoryWriteAction<T>\([\s\S]*action: MemoryWriteAction,[\s\S]*run: \(isCurrent: \(\) => boolean\) => Promise<T>,[\s\S]*if \(memoryWriteBusyRef\.current\) return undefined;[\s\S]*memoryWriteBusyRef\.current = true;[\s\S]*setPendingMemoryWriteAction\(action\);[\s\S]*setBusy\(true\);/,
+      /async function runMemoryWriteAction<T>\([\s\S]*action: MemoryWriteAction,[\s\S]*run: \(isCurrent: \(\) => boolean\) => Promise<T>,[\s\S]*const releaseWrite = memoryActionGuard\.begin\('write'\);[\s\S]*if \(!releaseWrite\) return undefined;[\s\S]*setPendingMemoryWriteAction\(action\);[\s\S]*setBusy\(true\);/,
       'local memory writes must set a synchronous busy guard before awaiting file/settings writes',
     );
     assert.match(
       memoryPage,
-      /finally \{[\s\S]*memoryWriteBusyRef\.current = false;[\s\S]*setPendingMemoryWriteAction\(null\);[\s\S]*setBusy\(false\);[\s\S]*\}/,
+      /finally \{[\s\S]*releaseWrite\(\);[\s\S]*setPendingMemoryWriteAction\(null\);[\s\S]*setBusy\(false\);[\s\S]*\}/,
       'local memory write guard must always release after success or failure',
     );
     assert.match(memoryPage, /await runMemoryWriteAction\('reload'/);
@@ -315,8 +315,8 @@ describe('local MEMORY.md Settings UI contract', () => {
     assert.match(memoryPage, /const memoryReloadTicketRef = useRef\(0\)/);
     assert.match(
       memoryPage,
-      /useEffect\(\(\) => \{[\s\S]*memoryPageLifecycleRef\.current \+= 1;[\s\S]*memoryPageMountedRef\.current = true;[\s\S]*const lifecycle = memoryPageLifecycleRef\.current;[\s\S]*return \(\) => \{[\s\S]*memoryPageMountedRef\.current = false;[\s\S]*memoryReloadTicketRef\.current \+= 1;[\s\S]*memoryWriteBusyRef\.current = false;[\s\S]*pendingMemoryActionKeysRef\.current\.clear\(\);/,
-      'Memory page cleanup must invalidate reloads and release pending owners',
+      /useEffect\(\(\) => \{[\s\S]*memoryPageLifecycleRef\.current \+= 1;[\s\S]*memoryPageMountedRef\.current = true;[\s\S]*const lifecycle = memoryPageLifecycleRef\.current;[\s\S]*return \(\) => \{[\s\S]*memoryPageMountedRef\.current = false;[\s\S]*memoryReloadTicketRef\.current \+= 1;/,
+      'Memory page cleanup must invalidate reloads (the shared keyed guard hook releases pending owners on unmount)',
     );
     assert.match(
       memoryPage,
@@ -340,8 +340,8 @@ describe('local MEMORY.md Settings UI contract', () => {
     );
     assert.match(
       writeActionBlock,
-      /const lifecycle = memoryPageLifecycleRef\.current;[\s\S]*return await run\(\(\) => isMemoryPageCurrent\(lifecycle\)\);[\s\S]*catch \(error\) \{[\s\S]*if \(!isMemoryPageCurrent\(lifecycle\)\) return undefined;[\s\S]*finally \{[\s\S]*memoryWriteBusyRef\.current = false;[\s\S]*if \(isMemoryPageCurrent\(lifecycle\)\) \{[\s\S]*setPendingMemoryWriteAction\(null\);[\s\S]*setBusy\(false\);/,
-      'Memory write wrapper must release refs but not write pending state after unmount',
+      /const lifecycle = memoryPageLifecycleRef\.current;[\s\S]*return await run\(\(\) => isMemoryPageCurrent\(lifecycle\)\);[\s\S]*catch \(error\) \{[\s\S]*if \(!isMemoryPageCurrent\(lifecycle\)\) return undefined;[\s\S]*finally \{[\s\S]*releaseWrite\(\);[\s\S]*if \(isMemoryPageCurrent\(lifecycle\)\) \{[\s\S]*setPendingMemoryWriteAction\(null\);[\s\S]*setBusy\(false\);/,
+      'Memory write wrapper must release the guard but not write pending state after unmount',
     );
     assert.match(enableBlock, /await runMemoryWriteAction\('enable', async \(isCurrent\) => \{[\s\S]*await props\.onReloadSettings\(\);[\s\S]*if \(!isCurrent\(\)\) return;[\s\S]*setState\(next\);/);
     assert.match(agentReadBlock, /await runMemoryWriteAction\('agent-read', async \(isCurrent\) => \{[\s\S]*await props\.onReloadSettings\(\);[\s\S]*if \(!isCurrent\(\)\) return;[\s\S]*setState\(next\);/);
@@ -353,8 +353,8 @@ describe('local MEMORY.md Settings UI contract', () => {
     assert.match(updateStatusBlock, /await runMemoryWriteAction\('entry-status', async \(isCurrent\) => \{[\s\S]*const next = await window\.maka\.memory\.save\(result\.draft\);[\s\S]*if \(!isCurrent\(\)\) return;[\s\S]*setState\(next\);/);
     assert.match(
       actionBlock,
-      /action: \(isCurrent: \(\) => boolean\) => Promise<T>,[\s\S]*const lifecycle = memoryPageLifecycleRef\.current;[\s\S]*return await action\(\(\) => isMemoryPageCurrent\(lifecycle\)\);[\s\S]*catch \(error\) \{[\s\S]*if \(!isMemoryPageCurrent\(lifecycle\)\) return undefined;[\s\S]*finally \{[\s\S]*pendingMemoryActionKeysRef\.current\.delete\(key\);[\s\S]*if \(isMemoryPageCurrent\(lifecycle\)\) \{[\s\S]*setPendingMemoryActions/,
-      'Memory file-action wrapper must release refs but not write pending state after unmount',
+      /action: \(isCurrent: \(\) => boolean\) => Promise<T>,[\s\S]*const lifecycle = memoryPageLifecycleRef\.current;[\s\S]*return await action\(\(\) => isMemoryPageCurrent\(lifecycle\)\);[\s\S]*catch \(error\) \{[\s\S]*if \(!isMemoryPageCurrent\(lifecycle\)\) return undefined;[\s\S]*finally \{[\s\S]*release\(\);[\s\S]*if \(isMemoryPageCurrent\(lifecycle\)\) \{[\s\S]*setPendingMemoryActions/,
+      'Memory file-action wrapper must release the guard but not write pending state after unmount',
     );
     assert.match(openFileBlock, /await runMemoryAction\('memory:file:open', async \(isCurrent\) => \{[\s\S]*const result = await window\.maka\.memory\.openFile\(\);[\s\S]*if \(!isCurrent\(\)\) return;[\s\S]*if \(!result\.ok\) toast\.error/);
     assert.match(openLatestBlock, /await runMemoryAction\('backup:latest:open', async \(isCurrent\) => \{[\s\S]*const result = await window\.maka\.memory\.openLatestBackup\(\);[\s\S]*if \(!isCurrent\(\)\) return;[\s\S]*if \(!result\.ok\) toast\.error/);

--- a/apps/desktop/src/main/__tests__/model-oauth-section-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/model-oauth-section-contract.test.ts
@@ -137,13 +137,23 @@ describe('Model OAuth catalog contract (PR-MODEL-OAUTH-ALL-0 + PR-CLAUDE-CARD-MO
     );
     assert.match(
       providers,
-      /function connectionTestFailureMessage\(result: ConnectionTestResult, troubleshootingCopy: string\)[\s\S]*generalizedErrorMessageChinese\(new Error\(result\.errorMessage\), fallback\)/,
+      /function connectionTestFailureMessage\(\s*result: ConnectionTestResult,\s*copy: ConnectionTestTroubleshootingCopy,\s*\): string \{[\s\S]*generalizedErrorMessageChinese\(new Error\(result\.errorMessage\), fallback\)/,
       'failed connection tests must not toast raw provider response bodies',
     );
     assert.match(
+      providers,
+      /function connectionTestFailureFallback\(\s*result: ConnectionTestResult,\s*copy: ConnectionTestTroubleshootingCopy,\s*\): string \{[\s\S]*statusCode === 429[\s\S]*errorClass === 'auth'[\s\S]*copy\.auth[\s\S]*copy\.recheck/,
+      'connection-test failure classification must live once in provider-panel-shared with injectable surface copy',
+    );
+    assert.match(
       detail,
-      /toast\.error\([\s\S]*`连接失败 · \$\{connection\.name\}`,[\s\S]*connectionTestFailureMessage\(result, credentialTroubleshootingCopy\)/,
-      'ConnectionDetail test failure toast must use localized sanitized copy',
+      /toast\.error\([\s\S]*`连接失败 · \$\{connection\.name\}`,[\s\S]*connectionTestFailureMessage\(result, \{\s*auth: `鉴权失败，请确认 \$\{credentialTroubleshootingCopy\} 后重试。`,\s*recheck: `检查 \$\{credentialTroubleshootingCopy\} 后重试。`,\s*\}\)/,
+      'ConnectionDetail test failure toast must use shared helper with Models-sheet troubleshooting copy',
+    );
+    assert.doesNotMatch(
+      detail,
+      /function connectionTestFailure(?:Message|Fallback)\(/,
+      'ConnectionDetail must not keep a private connection-test failure classifier after sharing',
     );
     assert.match(
       detail,

--- a/apps/desktop/src/main/__tests__/model-oauth-section-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/model-oauth-section-contract.test.ts
@@ -147,32 +147,32 @@ describe('Model OAuth catalog contract (PR-MODEL-OAUTH-ALL-0 + PR-CLAUDE-CARD-MO
     );
     assert.match(
       detail,
-      /const busyRef = useRef\(false\)[\s\S]*const testingRef = useRef\(false\)[\s\S]*const fetchingModelsRef = useRef\(false\)[\s\S]*const savingEnabledModelsRef = useRef\(false\)[\s\S]*const settingDefaultRef = useRef\(false\)[\s\S]*const deletingRef = useRef\(false\)/,
-      'ConnectionDetail actions must have synchronous duplicate-action guards, not only React state',
+      /const connectionDetailActionGuard = useKeyedActionGuard<[\s\S]*'save' \| 'test' \| 'fetch-models' \| 'save-enabled-models' \| 'set-default' \| 'delete'[\s\S]*>\(\)/,
+      'ConnectionDetail actions must have synchronous duplicate-action guards from the shared keyed guard, not only React state',
     );
     assert.match(
       detail,
-      /async function save\(\) \{[\s\S]*if \(busyRef\.current \|\| testingRef\.current \|\| fetchingModelsRef\.current \|\| savingEnabledModelsRef\.current \|\| settingDefaultRef\.current \|\| deletingRef\.current\) return;[\s\S]*busyRef\.current = true;[\s\S]*props\.bridge\.update\(/,
+      /async function save\(\) \{[\s\S]*const releaseSave = connectionDetailActionGuard\.beginExclusive\('save'\);[\s\S]*if \(!releaseSave\) return;[\s\S]*props\.bridge\.update\(/,
       'ConnectionDetail save must set its duplicate-submit guard before awaiting bridge.update()',
     );
     assert.match(
       detail,
-      /async function runTest\(\) \{[\s\S]*if \(testingRef\.current \|\| busyRef\.current \|\| fetchingModelsRef\.current \|\| savingEnabledModelsRef\.current \|\| settingDefaultRef\.current \|\| deletingRef\.current\) return;[\s\S]*testingRef\.current = true;[\s\S]*props\.bridge\.test\(/,
+      /async function runTest\(\) \{[\s\S]*const releaseTest = connectionDetailActionGuard\.beginExclusive\('test'\);[\s\S]*if \(!releaseTest\) return;[\s\S]*props\.bridge\.test\(/,
       'ConnectionDetail test must be gated synchronously before awaiting bridge.test()',
     );
     assert.match(
       detail,
-      /async function refreshModels\(opts: \{ silent\?: boolean \} = \{\}\) \{[\s\S]*if \(fetchingModelsRef\.current\) return;[\s\S]*if \(!opts\.silent && \(busyRef\.current \|\| testingRef\.current \|\| savingEnabledModelsRef\.current \|\| settingDefaultRef\.current \|\| deletingRef\.current\)\) return;[\s\S]*fetchingModelsRef\.current = true;[\s\S]*props\.bridge\.fetchModels\(/,
+      /async function refreshModels\(opts: \{ silent\?: boolean \} = \{\}\) \{[\s\S]*const releaseFetch = opts\.silent[\s\S]*\? connectionDetailActionGuard\.begin\('fetch-models'\)[\s\S]*: connectionDetailActionGuard\.beginExclusive\('fetch-models'\);[\s\S]*if \(!releaseFetch\) return;[\s\S]*props\.bridge\.fetchModels\(/,
       'ConnectionDetail model refresh must be duplicate-gated while preserving the post-save silent refresh',
     );
     assert.match(
       detail,
-      /async function setAsDefault\(\) \{[\s\S]*if \(settingDefaultRef\.current \|\| busyRef\.current \|\| testingRef\.current \|\| fetchingModelsRef\.current \|\| savingEnabledModelsRef\.current \|\| deletingRef\.current\) return;[\s\S]*settingDefaultRef\.current = true;[\s\S]*props\.bridge\.setDefault\(/,
+      /async function setAsDefault\(\) \{[\s\S]*const releaseSetDefault = connectionDetailActionGuard\.beginExclusive\('set-default'\);[\s\S]*if \(!releaseSetDefault\) return;[\s\S]*props\.bridge\.setDefault\(/,
       'ConnectionDetail default-switch must be gated synchronously before awaiting bridge.setDefault()',
     );
     assert.match(
       detail,
-      /async function remove\(\) \{[\s\S]*if \(deletingRef\.current \|\| busyRef\.current \|\| testingRef\.current \|\| fetchingModelsRef\.current \|\| savingEnabledModelsRef\.current \|\| settingDefaultRef\.current\) return;[\s\S]*deletingRef\.current = true;[\s\S]*props\.bridge\.delete\(/,
+      /async function remove\(\) \{[\s\S]*const releaseDelete = connectionDetailActionGuard\.beginExclusive\('delete'\);[\s\S]*if \(!releaseDelete\) return;[\s\S]*props\.bridge\.delete\(/,
       'ConnectionDetail delete must be gated synchronously before awaiting bridge.delete()',
     );
     assert.match(
@@ -242,17 +242,17 @@ describe('Model OAuth catalog contract (PR-MODEL-OAUTH-ALL-0 + PR-CLAUDE-CARD-MO
     );
     assert.match(
       addForm,
-      /const busyRef = useRef\(false\)/,
-      'AddProviderForm create must have a synchronous duplicate-submit guard',
+      /const submitGuard = useActionGuard<'submit'>\(\)/,
+      'AddProviderForm create must have a synchronous duplicate-submit guard from the shared hook',
     );
     assert.match(
       addForm,
-      /const addProviderMountedRef = useMountedRef\(\)[\s\S]*useEffect\(\(\) => \{[\s\S]*return \(\) => \{[\s\S]*busyRef\.current = false;[\s\S]*\};[\s\S]*\}, \[\]\);/,
-      'AddProviderForm must track its own sheet lifetime so pending create continuations cannot write after overlay close',
+      /const addProviderMountedRef = useMountedRef\(\)/,
+      'AddProviderForm must track its own sheet lifetime so pending create continuations cannot write after overlay close (the shared guard hook releases on unmount)',
     );
     assert.match(
       addForm,
-      /async function submit\(\) \{[\s\S]*if \(busyRef\.current\) return;[\s\S]*busyRef\.current = true;[\s\S]*setBusy\(true\);[\s\S]*props\.bridge\.create\(/,
+      /async function submit\(\) \{[\s\S]*if \(submitGuard\.current !== null\) return;[\s\S]*submitGuard\.begin\('submit'\);[\s\S]*setBusy\(true\);[\s\S]*props\.bridge\.create\(/,
       'AddProviderForm create must set the duplicate-submit guard before awaiting bridge.create()',
     );
     assert.match(
@@ -262,7 +262,7 @@ describe('Model OAuth catalog contract (PR-MODEL-OAUTH-ALL-0 + PR-CLAUDE-CARD-MO
     );
     assert.match(
       addForm,
-      /catch \(err\) \{[\s\S]*if \(addProviderMountedRef\.current\) setError\(providerPanelActionErrorMessage\(err\)\);[\s\S]*\} finally \{[\s\S]*busyRef\.current = false;[\s\S]*if \(addProviderMountedRef\.current\) setBusy\(false\);[\s\S]*\}/,
+      /catch \(err\) \{[\s\S]*if \(addProviderMountedRef\.current\) setError\(providerPanelActionErrorMessage\(err\)\);[\s\S]*\} finally \{[\s\S]*submitGuard\.finish\(\);[\s\S]*if \(addProviderMountedRef\.current\) setBusy\(false\);[\s\S]*\}/,
       'AddProviderForm create guard must release without setting React state after sheet unmount',
     );
     assert.match(
@@ -759,7 +759,7 @@ describe('Model OAuth catalog contract (PR-MODEL-OAUTH-ALL-0 + PR-CLAUDE-CARD-MO
     );
     assert.match(
       detail,
-      /async function remove\(\) \{[\s\S]*deletingRef\.current = true;[\s\S]*setDeleting\(true\);[\s\S]*let deleted = false;[\s\S]*await props\.bridge\.delete\(connection\.slug\);[\s\S]*deleted = true;[\s\S]*await props\.onDeleted\(\);[\s\S]*catch \(error\) \{[\s\S]*toast\.error\([\s\S]*deleted \? '刷新模型列表失败' : '删除模型连接失败'/,
+      /async function remove\(\) \{[\s\S]*setDeleting\(true\);[\s\S]*let deleted = false;[\s\S]*await props\.bridge\.delete\(connection\.slug\);[\s\S]*deleted = true;[\s\S]*await props\.onDeleted\(\);[\s\S]*catch \(error\) \{[\s\S]*toast\.error\([\s\S]*deleted \? '刷新模型列表失败' : '删除模型连接失败'/,
       'ConnectionDetail delete failures and post-delete refresh failures must be visible',
     );
     assert.match(
@@ -817,7 +817,7 @@ describe('Model OAuth catalog contract (PR-MODEL-OAUTH-ALL-0 + PR-CLAUDE-CARD-MO
     );
     assert.match(
       detail,
-      /useEffect\(\(\) => \{[\s\S]*connectionDetailLifecycleRef\.current \+= 1;[\s\S]*return \(\) => \{[\s\S]*connectionDetailLifecycleRef\.current \+= 1;[\s\S]*busyRef\.current = false;[\s\S]*testingRef\.current = false;[\s\S]*fetchingModelsRef\.current = false;[\s\S]*settingDefaultRef\.current = false;[\s\S]*deletingRef\.current = false;[\s\S]*\};[\s\S]*\}, \[connection\.slug\]\);/,
+      /useEffect\(\(\) => \{[\s\S]*connectionDetailLifecycleRef\.current \+= 1;[\s\S]*return \(\) => \{[\s\S]*connectionDetailLifecycleRef\.current \+= 1;[\s\S]*connectionDetailActionGuard\.reset\(\);[\s\S]*\};[\s\S]*\}, \[connection\.slug\]\);/,
       'ConnectionDetail cleanup must release every pending action owner on close or provider switch',
     );
     assert.match(

--- a/apps/desktop/src/main/__tests__/office-documents-capability.test.ts
+++ b/apps/desktop/src/main/__tests__/office-documents-capability.test.ts
@@ -56,14 +56,9 @@ describe('Office document capability contract', () => {
     assert.match(settings, /复制 macOS\/Linux 安装命令/);
     assert.match(settings, /<div className="settingsCapabilityGuidanceActions" role="group" aria-label="Office 文档安装辅助">/);
     assert.doesNotMatch(settings, /<div className="settingsCapabilityGuidanceActions" aria-label="Office 文档安装辅助">/);
-    assert.match(settings, /copyingOfficeCliInstallRef\.current/, 'OfficeCLI install copy action must have a ref-backed double-click guard');
-    assert.match(settings, /if \(copyingOfficeCliInstallRef\.current\) return;/);
+    assert.match(settings, /const copyOfficeCliInstallGuard = useActionGuard<'copy'>\(\)/, 'OfficeCLI install copy action must have a guard-backed double-click guard from the shared hook');
+    assert.match(settings, /if \(!copyOfficeCliInstallGuard\.begin\('copy'\)\) return;/);
     assert.match(settings, /const capabilityRowMountedRef = useMountedRef\(\);/);
-    assert.match(
-      settings,
-      /useEffect\(\(\) => \{[\s\S]*return \(\) => \{[\s\S]*copyingOfficeCliInstallRef\.current = false;/,
-      'OfficeCLI install copy action must release ownership when its capability row unmounts',
-    );
     assert.match(settings, /disabled=\{copyingOfficeCliInstall\}/);
     assert.match(settings, /copyingOfficeCliInstall \? '复制中…' : '复制 macOS\/Linux 安装命令'/);
     assert.match(
@@ -78,8 +73,8 @@ describe('Office document capability contract', () => {
     );
     assert.match(
       settings,
-      /finally \{[\s\S]*copyingOfficeCliInstallRef\.current = false;[\s\S]*if \(capabilityRowMountedRef\.current\) \{[\s\S]*setCopyingOfficeCliInstall\(false\);/,
-      'OfficeCLI install copy cleanup must not write React pending state after unmount',
+      /finally \{[\s\S]*copyOfficeCliInstallGuard\.finish\(\);[\s\S]*if \(capabilityRowMountedRef\.current\) \{[\s\S]*setCopyingOfficeCliInstall\(false\);/,
+      'OfficeCLI install copy cleanup must not write React pending state after unmount (the shared guard hook releases on unmount)',
     );
     assert.match(settings, /iOfficeAI\/OfficeCLI\/releases/);
     assert.doesNotMatch(settings, /execFile\(|spawn\(|child_process/);

--- a/apps/desktop/src/main/__tests__/open-gateway-settings-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/open-gateway-settings-contract.test.ts
@@ -57,8 +57,7 @@ describe('Open Gateway Settings endpoint contract', () => {
 
   it('surfaces clipboard failures for every Open Gateway copy action', () => {
     const helper = settingsSource.match(/async function copyGatewayText[\s\S]*?async function copyBaseUrl/)?.[0] ?? '';
-    assert.match(helper, /copyingGatewayActionRef\.current/);
-    assert.match(helper, /if \(copyingGatewayActionRef\.current\) return/);
+    assert.match(helper, /if \(!gatewayCopyGuard\.begin\(action\)\) return/);
     assert.match(helper, /setCopyingGatewayAction\(action\)/);
     assert.match(helper, /if \(openGatewayMountedRef\.current\) \{[\s\S]*setCopyingGatewayAction\(null\)/);
     assert.match(helper, /try \{[\s\S]*navigator\.clipboard\.writeText\(text\)[\s\S]*if \(openGatewayMountedRef\.current\) \{[\s\S]*toast\.success\(successTitle, successDetail\)/);
@@ -99,8 +98,8 @@ describe('Open Gateway Settings endpoint contract', () => {
 
     assert.match(
       gatewayBlock,
-      /mountedRef: openGatewayMountedRef,[\s\S]*return \(\) => \{[\s\S]*copyingGatewayActionRef\.current = null;/,
-      'Open Gateway Settings must track mounted ownership (from the shared draft hook) and release copy ownership when the page closes',
+      /const gatewayCopyGuard = useActionGuard<string>\(\);[\s\S]*mountedRef: openGatewayMountedRef,/,
+      'Open Gateway Settings must track mounted ownership (from the shared draft hook) and hold copy ownership in the shared guard (released on unmount)',
     );
     assert.match(
       helper,
@@ -114,8 +113,8 @@ describe('Open Gateway Settings endpoint contract', () => {
     );
     assert.match(
       helper,
-      /finally \{[\s\S]*copyingGatewayActionRef\.current = null;[\s\S]*if \(openGatewayMountedRef\.current\) \{[\s\S]*setCopyingGatewayAction\(null\);/,
-      'Open Gateway copy cleanup must release the ref but not write React state after unmount',
+      /finally \{[\s\S]*gatewayCopyGuard\.finish\(\);[\s\S]*if \(openGatewayMountedRef\.current\) \{[\s\S]*setCopyingGatewayAction\(null\);/,
+      'Open Gateway copy cleanup must release the guard but not write React state after unmount',
     );
   });
 

--- a/apps/desktop/src/main/__tests__/settings-action-guard-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/settings-action-guard-contract.test.ts
@@ -1,0 +1,91 @@
+import { strict as assert } from 'node:assert';
+import { readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { describe, it } from 'node:test';
+
+const repoRoot = process.cwd().endsWith('apps/desktop')
+  ? join(process.cwd(), '..', '..')
+  : process.cwd();
+
+async function readRepo(path: string): Promise<string> {
+  return readFile(join(repoRoot, path), 'utf8');
+}
+
+/**
+ * Source contract for the shared Settings action-guard hooks.
+ *
+ * Before #1041 every Settings page hand-rolled the same synchronous
+ * `xRef.current` re-entrancy guard plus an unmount cleanup resetting it, and
+ * each page's contract test pinned that text. The guards now live in
+ * use-action-guard.ts (wrapping the unit-tested createOneShotActionGuard /
+ * createKeyedActionGuard seams), so the ownership invariants are pinned once
+ * here; per-page contracts only assert that pages route through the hooks.
+ */
+describe('Settings action guard hook contract', () => {
+  it('wraps the tested framework-free seams instead of new guard logic', async () => {
+    const hook = await readRepo('apps/desktop/src/renderer/settings/use-action-guard.ts');
+
+    assert.match(
+      hook,
+      /import \{ createOneShotActionGuard, type OneShotActionGuard \} from '\.\/oauth-login-flow-guard'/,
+      'useActionGuard must reuse the unit-tested one-shot seam behind useOAuthLoginFlow',
+    );
+    assert.match(
+      hook,
+      /import \{ createKeyedActionGuard, type KeyedActionGuard \} from '\.\/action-guard'/,
+      'useKeyedActionGuard must reuse the unit-tested keyed seam',
+    );
+    assert.match(
+      hook,
+      /export function useActionGuard<Action>\(\): OneShotActionGuard<Action> \{[\s\S]*createOneShotActionGuard<Action>\(\)/,
+      'useActionGuard must hold the one-shot guard in a ref so the check stays synchronous across renders',
+    );
+    assert.match(
+      hook,
+      /export function useKeyedActionGuard<Key>\(\): KeyedActionGuard<Key> \{[\s\S]*createKeyedActionGuard<Key>\(\)/,
+      'useKeyedActionGuard must hold the keyed guard in a ref so the check stays synchronous across renders',
+    );
+  });
+
+  it('releases every guard hold on unmount', async () => {
+    const hook = await readRepo('apps/desktop/src/renderer/settings/use-action-guard.ts');
+
+    const oneShot = hook.match(/export function useActionGuard[\s\S]*?export function useKeyedActionGuard/)?.[0] ?? '';
+    assert.match(
+      oneShot,
+      /useEffect\(\(\) => \{[\s\S]*return \(\) => \{[\s\S]*guard\.finish\(\);[\s\S]*\};[\s\S]*\}, \[\]\);/,
+      'useActionGuard must release the pending action on unmount (replaces per-page xRef.current = false cleanups)',
+    );
+    const keyed = hook.match(/export function useKeyedActionGuard[\s\S]*$/)?.[0] ?? '';
+    assert.match(
+      keyed,
+      /useEffect\(\(\) => \{[\s\S]*return \(\) => \{[\s\S]*guard\.reset\(\);[\s\S]*\};[\s\S]*\}, \[\]\);/,
+      'useKeyedActionGuard must drop every key hold on unmount',
+    );
+  });
+
+  it('keeps keyed-guard release ownership safe across reset', async () => {
+    const guard = await readRepo('apps/desktop/src/renderer/settings/action-guard.ts');
+
+    assert.match(
+      guard,
+      /const owners = new Map<Key, number>\(\)/,
+      'the keyed guard must track an owner token per key',
+    );
+    assert.match(
+      guard,
+      /const owner = \+\+sequence;[\s\S]*owners\.set\(key, owner\);[\s\S]*if \(owners\.get\(key\) === owner\) owners\.delete\(key\);/,
+      'a release must only drop its own token so a late release after reset cannot strip a newer hold',
+    );
+    assert.match(
+      guard,
+      /begin\(key: Key\): \(\(\) => void\) \| null \{[\s\S]*if \(owners\.has\(key\)\) return null;/,
+      'same-key re-entry must be rejected synchronously',
+    );
+    assert.match(
+      guard,
+      /beginExclusive\(key: Key\): \(\(\) => void\) \| null \{[\s\S]*if \(owners\.size > 0\) return null;/,
+      'exclusive acquisition must be rejected while any action is in flight',
+    );
+  });
+});

--- a/apps/desktop/src/main/__tests__/settings-app-info-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/settings-app-info-contract.test.ts
@@ -71,17 +71,12 @@ describe('Settings app-info loading contract', () => {
     const dataBlock = blockBetween('function DataSettingsPage', 'function PersonalizationSettingsPage');
 
     assert.match(dataBlock, /const \[pendingDataAction, setPendingDataAction\] = useState<string \| null>\(null\)/);
-    assert.match(dataBlock, /const pendingDataActionRef = useRef<string \| null>\(null\)/);
+    assert.match(dataBlock, /const dataActionGuard = useActionGuard<string>\(\)/);
     assert.match(dataBlock, /const dataPageMountedRef = useMountedRef\(\)/);
     assert.match(
       dataBlock,
-      /useEffect\(\(\) => \{[\s\S]*return \(\) => \{[\s\S]*pendingDataActionRef\.current = null;[\s\S]*\};[\s\S]*\}, \[toast\]\);/,
-      'Data page actions must be invalidated when the page unmounts',
-    );
-    assert.match(
-      dataBlock,
-      /async function runDataAction\(action: string, run: \(\) => Promise<void>\) \{[\s\S]*if \(pendingDataActionRef\.current\) return;[\s\S]*pendingDataActionRef\.current = action;[\s\S]*setPendingDataAction\(action\);[\s\S]*await run\(\);[\s\S]*pendingDataActionRef\.current = null;[\s\S]*if \(dataPageMountedRef\.current\) \{[\s\S]*setPendingDataAction\(null\);[\s\S]*\}/,
-      'Data page open/copy actions need a shared pending guard and must not clean UI state after unmount',
+      /async function runDataAction\(action: string, run: \(\) => Promise<void>\) \{[\s\S]*if \(!dataActionGuard\.begin\(action\)\) return;[\s\S]*setPendingDataAction\(action\);[\s\S]*await run\(\);[\s\S]*dataActionGuard\.finish\(\);[\s\S]*if \(dataPageMountedRef\.current\) \{[\s\S]*setPendingDataAction\(null\);[\s\S]*\}/,
+      'Data page open/copy actions need a shared pending guard and must not clean UI state after unmount (the shared guard hook releases on unmount)',
     );
     assert.match(
       dataBlock,
@@ -153,17 +148,17 @@ describe('Settings app-info loading contract', () => {
     const aboutBlock = blockBetween('function AboutSettingsPage', 'function SettingsSkeleton');
 
     assert.match(aboutBlock, /const \[copyingEnvSummary, setCopyingEnvSummary\] = useState\(false\)/);
-    assert.match(aboutBlock, /const copyingEnvSummaryRef = useRef\(false\)/);
+    assert.match(aboutBlock, /const envSummaryCopyGuard = useActionGuard<'copy'>\(\)/);
     assert.match(aboutBlock, /const aboutPageMountedRef = useMountedRef\(\)/);
     assert.match(
       aboutBlock,
-      /useEffect\(\(\) => \{[\s\S]*return \(\) => \{[\s\S]*copyingEnvSummaryRef\.current = false;[\s\S]*\};[\s\S]*\}, \[toast\]\);/,
-      'About page copy actions must be invalidated when the page unmounts',
+      /async function copyEnvSummary\(\) \{[\s\S]*if \(!envSummaryCopyGuard\.begin\('copy'\)\) return;[\s\S]*setCopyingEnvSummary\(true\);/,
+      'About page environment copy should not allow repeated clipboard requests (the shared guard hook releases on unmount)',
     );
     assert.match(
       aboutBlock,
-      /async function copyEnvSummary\(\) \{[\s\S]*if \(copyingEnvSummaryRef\.current\) return;[\s\S]*copyingEnvSummaryRef\.current = true;[\s\S]*setCopyingEnvSummary\(true\);[\s\S]*await navigator\.clipboard\.writeText\(summary\);[\s\S]*if \(aboutPageMountedRef\.current\) \{[\s\S]*toast\.success\('已复制环境信息', '可直接粘贴到问题报告'\);[\s\S]*\}[\s\S]*catch \{[\s\S]*if \(aboutPageMountedRef\.current\) \{[\s\S]*toast\.error\('复制失败', '剪贴板不可用或被系统拒绝。'\);[\s\S]*\}[\s\S]*finally \{[\s\S]*copyingEnvSummaryRef\.current = false;[\s\S]*if \(aboutPageMountedRef\.current\) \{[\s\S]*setCopyingEnvSummary\(false\);[\s\S]*\}/,
-      'About page environment copy should not allow repeated clipboard requests and must not update UI after unmount',
+      /await navigator\.clipboard\.writeText\(summary\);[\s\S]*if \(aboutPageMountedRef\.current\) \{[\s\S]*toast\.success\('已复制环境信息', '可直接粘贴到问题报告'\);[\s\S]*\}[\s\S]*catch \{[\s\S]*if \(aboutPageMountedRef\.current\) \{[\s\S]*toast\.error\('复制失败', '剪贴板不可用或被系统拒绝。'\);[\s\S]*\}[\s\S]*finally \{[\s\S]*envSummaryCopyGuard\.finish\(\);[\s\S]*if \(aboutPageMountedRef\.current\) \{[\s\S]*setCopyingEnvSummary\(false\);[\s\S]*\}/,
+      'About page environment copy must not update UI after unmount',
     );
     assert.match(aboutBlock, /disabled=\{copyingEnvSummary\}/);
     assert.match(aboutBlock, /copyingEnvSummary \? '复制中…' : '复制环境信息'/);

--- a/apps/desktop/src/main/__tests__/settings-form-a11y-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/settings-form-a11y-contract.test.ts
@@ -182,27 +182,32 @@ describe('Settings form accessibility labels', () => {
     const passwordInput = await readRepo('apps/desktop/src/renderer/settings/password-input.tsx');
 
     assert.match(passwordInput, /const toast = useToast\(\)/);
-    assert.match(passwordInput, /const copyingRef = useRef\(false\)/);
+    assert.match(passwordInput, /const copyGuard = useActionGuard<'copy'>\(\)/);
     assert.match(passwordInput, /const mountedRef = useMountedRef\(\)/);
     assert.match(passwordInput, /const copyFeedbackTimerRef = useRef<number \| null>\(null\)/);
     assert.match(
       passwordInput,
-      /return \(\) => \{[\s\S]*copyingRef\.current = false;[\s\S]*window\.clearTimeout\(copyFeedbackTimerRef\.current\);/,
-      'PasswordInput must clear pending copy-feedback timers and invalidate clipboard state when it unmounts',
+      /return \(\) => \{[\s\S]*if \(copyFeedbackTimerRef\.current !== null\) \{[\s\S]*window\.clearTimeout\(copyFeedbackTimerRef\.current\);[\s\S]*copyFeedbackTimerRef\.current = null;/,
+      'PasswordInput must clear pending copy-feedback timers when it unmounts (duplicate-copy release is owned by useActionGuard)',
     );
     assert.match(
       passwordInput,
       /function showCopiedFeedback\(\) \{[\s\S]*window\.clearTimeout\(copyFeedbackTimerRef\.current\);[\s\S]*setJustCopied\(true\);[\s\S]*copyFeedbackTimerRef\.current = window\.setTimeout\(\(\) => \{[\s\S]*if \(mountedRef\.current\) setJustCopied\(false\);/,
       'PasswordInput must replace stale success timers so repeated copies do not clear fresh success feedback early',
     );
-    assert.match(passwordInput, /if \(copyingRef\.current\) return;/);
+    assert.match(passwordInput, /if \(!copyGuard\.begin\('copy'\)\) return;/);
     assert.match(passwordInput, /setCopying\(true\)/);
     assert.match(passwordInput, /if \(mountedRef\.current\) showCopiedFeedback\(\)/);
     assert.match(passwordInput, /if \(mountedRef\.current\) toast\.error\('复制失败', '剪贴板不可用或被系统拒绝。'\)/);
-    assert.match(passwordInput, /if \(mountedRef\.current\) setCopying\(false\)/);
+    assert.match(passwordInput, /copyGuard\.finish\(\);[\s\S]*if \(mountedRef\.current\) setCopying\(false\)/);
     assert.match(passwordInput, /disabled=\{copying\}/);
     assert.match(passwordInput, /aria-label=\{copying \? '复制中' : justCopied \? '已复制' : '复制'\}/);
     assert.match(passwordInput, /toast\.error\('复制失败', '剪贴板不可用或被系统拒绝。'\)/);
+    assert.doesNotMatch(
+      passwordInput,
+      /const copyingRef = useRef\(false\)/,
+      'PasswordInput must not keep a private copy guard after routing through useActionGuard',
+    );
     assert.doesNotMatch(
       passwordInput,
       /clipboard unavailable; silent|catch \{\s*\/\*/,

--- a/apps/desktop/src/main/__tests__/settings-network-gateway-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/settings-network-gateway-contract.test.ts
@@ -106,18 +106,18 @@ describe('Settings network and gateway persistence contract', () => {
 
     assert.match(
       networkBlock,
-      /const proxyTestRunningRef = useRef\(false\);/,
-      'Network proxy test needs a ref gate so fast double-clicks cannot duplicate proxy test IPC before React disables the button',
+      /const proxyTestGuard = useActionGuard<'test'>\(\)/,
+      'Network proxy test needs a synchronous guard so fast double-clicks cannot duplicate proxy test IPC before React disables the button',
     );
     assert.match(
       networkBlock,
-      /async function testProxy\(\) \{\s*if \(proxyTestRunningRef\.current\) return;[\s\S]*proxyTestRunningRef\.current = true;[\s\S]*window\.maka\.settings\.testNetworkProxy\(toProxyTestInput\(proxyDraftRef\.current\)\)/,
+      /async function testProxy\(\) \{\s*if \(!proxyTestGuard\.begin\('test'\)\) return;[\s\S]*window\.maka\.settings\.testNetworkProxy\(toProxyTestInput\(proxyDraftRef\.current\)\)/,
       'Network proxy test must lock synchronously and test the latest local draft snapshot, not the previous render value',
     );
     assert.match(
       networkBlock,
-      /finally \{[\s\S]*proxyTestRunningRef\.current = false;[\s\S]*setTesting\(false\);[\s\S]*\}/,
-      'Network proxy test must release the ref gate after the IPC settles',
+      /finally \{[\s\S]*proxyTestGuard\.finish\(\);[\s\S]*setTesting\(false\);[\s\S]*\}/,
+      'Network proxy test must release the guard after the IPC settles',
     );
     assert.doesNotMatch(
       networkBlock,
@@ -139,8 +139,8 @@ describe('Settings network and gateway persistence contract', () => {
     );
     assert.match(
       networkBlock,
-      /useEffect\(\(\) => \{[\s\S]*return \(\) => \{[\s\S]*proxyTestRunningRef\.current = false;/,
-      'Network proxy cleanup must release test ownership when Settings closes (the hook invalidates save tickets)',
+      /const proxyTestGuard = useActionGuard<'test'>\(\)/,
+      'Network proxy test ownership must come from the shared action-guard hook (released on unmount; the draft hook invalidates save tickets)',
     );
     // Save-response staleness + rollback after unmount are owned by the shared
     // optimistic draft hook and covered by its controller unit test; the page
@@ -162,8 +162,8 @@ describe('Settings network and gateway persistence contract', () => {
     );
     assert.match(
       networkBlock,
-      /finally \{[\s\S]*proxyTestRunningRef\.current = false;[\s\S]*if \(networkPageMountedRef\.current\) \{[\s\S]*setTesting\(false\);/,
-      'Network proxy test cleanup must release the ref but not write React state after unmount',
+      /finally \{[\s\S]*proxyTestGuard\.finish\(\);[\s\S]*if \(networkPageMountedRef\.current\) \{[\s\S]*setTesting\(false\);/,
+      'Network proxy test cleanup must release the guard but not write React state after unmount',
     );
   });
 
@@ -252,8 +252,8 @@ describe('Settings network and gateway persistence contract', () => {
     );
     assert.match(
       gatewayBlock,
-      /useEffect\(\(\) => \{[\s\S]*return \(\) => \{[\s\S]*copyingGatewayActionRef\.current = null;/,
-      'Open Gateway cleanup must release copy ownership when Settings closes (the hook invalidates save tickets)',
+      /const gatewayCopyGuard = useActionGuard<string>\(\)/,
+      'Open Gateway copy ownership must come from the shared action-guard hook (released on unmount; the draft hook invalidates save tickets)',
     );
     // Save-response staleness, draft rollback, token mirroring, and pending
     // state are owned by the shared optimistic draft hook (unit-tested on its

--- a/apps/desktop/src/main/__tests__/settings-roadmap-cleanup-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/settings-roadmap-cleanup-contract.test.ts
@@ -250,20 +250,19 @@ describe('Settings coming-soon cleanup contract', () => {
     const permissionPage = settings.match(/function PermissionCenterPage\(\)[\s\S]*?function CapabilityRow/)?.[0] ?? '';
 
     assert.match(permissionPage, /const \[pendingPermAction, setPendingPermAction\] = useState<string \| null>\(null\)/);
-    assert.match(permissionPage, /const pendingPermActionRef = useRef<string \| null>\(null\)/);
     assert.match(
       permissionPage,
-      /return \(\) => \{[\s\S]*pendingPermActionRef\.current = null;/,
-      'Permission Center must release the pending action owner when Settings closes',
+      /const permissionActionGuard = useActionGuard<string>\(\)/,
+      'Permission Center must hold the pending action owner in the shared guard (released on unmount)',
     );
     assert.match(
       permissionPage,
-      /const actionKey = `\$\{permId\}:\$\{kind\}`;[\s\S]*if \(pendingPermActionRef\.current\) return;[\s\S]*pendingPermActionRef\.current = actionKey;[\s\S]*setPendingPermAction\(actionKey\);/,
+      /const actionKey = `\$\{permId\}:\$\{kind\}`;[\s\S]*if \(!permissionActionGuard\.begin\(actionKey\)\) return;[\s\S]*setPendingPermAction\(actionKey\);/,
       'Permission Center must synchronously reject same-frame duplicate permission actions before React commits disabled state',
     );
     assert.match(
       permissionPage,
-      /finally \{[\s\S]*if \(pendingPermActionRef\.current === actionKey\) \{[\s\S]*pendingPermActionRef\.current = null;[\s\S]*\}[\s\S]*if \(mountedRef\.current\) setPendingPermAction\(null\);/,
+      /finally \{[\s\S]*if \(permissionActionGuard\.current === actionKey\) \{[\s\S]*permissionActionGuard\.finish\(\);[\s\S]*\}[\s\S]*if \(mountedRef\.current\) setPendingPermAction\(null\);/,
       'Permission Center must release only the action it owns and avoid state writes after unmount',
     );
     assert.match(permissionPage, /busy=\{pendingPermAction !== null\}/);

--- a/apps/desktop/src/main/__tests__/settings-usage-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/settings-usage-contract.test.ts
@@ -223,8 +223,8 @@ describe('Settings usage dashboard contract', () => {
     );
     assert.match(
       usagePage,
-      /useEffect\(\(\) => \{[\s\S]*return \(\) => \{[\s\S]*usageRefreshRunningRef\.current = false;/,
-      'Usage settings cleanup must release manual refresh ownership (the hook invalidates saves)',
+      /const usageRefreshGuard = useActionGuard<'refresh'>\(\)/,
+      'Usage settings must hold its manual refresh guard from the shared hook (which releases it on unmount and invalidates saves)',
     );
     // Save-response staleness + rollback after unmount are owned by the shared
     // optimistic draft hook and covered by its controller unit test; the page
@@ -236,7 +236,7 @@ describe('Settings usage dashboard contract', () => {
     );
     assert.match(
       usagePage,
-      /finally \{[\s\S]*usageRefreshRunningRef\.current = false;[\s\S]*if \(usagePageMountedRef\.current\) \{[\s\S]*setRefreshing\(false\);/,
+      /finally \{[\s\S]*usageRefreshGuard\.finish\(\);[\s\S]*if \(usagePageMountedRef\.current\) \{[\s\S]*setRefreshing\(false\);/,
       'Manual usage refresh cleanup must not write React pending state after unmount',
     );
   });
@@ -270,18 +270,18 @@ describe('Settings usage dashboard contract', () => {
     assert.ok(usagePage, 'Usage settings page block must exist');
     assert.match(
       usagePage![0],
-      /const usageRefreshRunningRef = useRef\(false\);/,
-      'Manual usage refresh needs a ref gate so fast double-clicks cannot duplicate reloads before React disables the button',
+      /const usageRefreshGuard = useActionGuard<'refresh'>\(\)/,
+      'Manual usage refresh needs a synchronous guard so fast double-clicks cannot duplicate reloads before React disables the button',
     );
     assert.match(
       usagePage![0],
-      /async function refresh\(\) \{\s*if \(usageRefreshRunningRef\.current\) return;[\s\S]*usageRefreshRunningRef\.current = true;[\s\S]*await props\.onReload\(usageDraftRef\.current\.range\)/,
+      /async function refresh\(\) \{\s*if \(!usageRefreshGuard\.begin\('refresh'\)\) return;[\s\S]*await props\.onReload\(usageDraftRef\.current\.range\)/,
       'Manual usage refresh must lock synchronously and read the latest local draft range',
     );
     assert.match(
       usagePage![0],
-      /finally \{[\s\S]*usageRefreshRunningRef\.current = false;[\s\S]*setRefreshing\(false\);[\s\S]*\}/,
-      'Manual usage refresh must release the ref gate after reload settles',
+      /finally \{[\s\S]*usageRefreshGuard\.finish\(\);[\s\S]*setRefreshing\(false\);[\s\S]*\}/,
+      'Manual usage refresh must release the guard after reload settles',
     );
     assert.doesNotMatch(
       usagePage![0],

--- a/apps/desktop/src/main/__tests__/voice-capture-smoke-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/voice-capture-smoke-contract.test.ts
@@ -52,18 +52,18 @@ describe('voice capture smoke Settings contract', () => {
     assert.ok(voicePage, 'voice settings page source must be discoverable');
     assert.match(
       voicePage!,
-      /const captureSmokeBusyRef = useRef\(false\);/,
-      'voice capture smoke needs a ref gate so fast double-clicks cannot start duplicate microphone captures before React disables the button',
+      /const captureSmokeGuard = useActionGuard<'smoke'>\(\)/,
+      'voice capture smoke needs a synchronous guard so fast double-clicks cannot start duplicate microphone captures before React disables the button',
     );
     assert.match(
       voicePage!,
-      /async function runCaptureSmoke\(\) \{\s*if \(captureSmokeBusyRef\.current\) return;[\s\S]*captureSmokeBusyRef\.current = true;[\s\S]*navigator\.mediaDevices\.getUserMedia/,
+      /async function runCaptureSmoke\(\) \{\s*if \(captureSmokeGuard\.current !== null\) return;[\s\S]*captureSmokeGuard\.begin\('smoke'\);[\s\S]*navigator\.mediaDevices\.getUserMedia/,
       'voice capture smoke must take the synchronous lock before the first getUserMedia await',
     );
     assert.match(
       voicePage!,
-      /finally \{[\s\S]*stream\?\.getTracks\(\)\.forEach\(\(track\) => track\.stop\(\)\);[\s\S]*captureSmokeBusyRef\.current = false;[\s\S]*setIsBusy\(false\);[\s\S]*\}/,
-      'voice capture smoke must release the ref after stopping microphone tracks',
+      /finally \{[\s\S]*stream\?\.getTracks\(\)\.forEach\(\(track\) => track\.stop\(\)\);[\s\S]*captureSmokeGuard\.finish\(\);[\s\S]*setIsBusy\(false\);[\s\S]*\}/,
+      'voice capture smoke must release the guard after stopping microphone tracks',
     );
     assert.match(voicePage!, /aria-busy=\{isBusy\}/, 'voice capture button must expose the pending state to assistive tech');
     assert.match(voicePage!, /data-pending=\{isBusy \? 'true' : undefined\}/, 'voice capture button must expose a stable pending hook');
@@ -101,8 +101,8 @@ describe('voice capture smoke Settings contract', () => {
     assert.ok(voicePage, 'voice settings page source must be discoverable');
     assert.match(
       voicePage!,
-      /const voicePageMountedRef = useMountedRef\(\);[\s\S]*const activeVoiceCaptureStreamRef = useRef<MediaStream \| null>\(null\);[\s\S]*return \(\) => \{[\s\S]*activeVoiceCaptureStreamRef\.current\?\.getTracks\(\)\.forEach\(\(track\) => track\.stop\(\)\);[\s\S]*activeVoiceCaptureStreamRef\.current = null;[\s\S]*captureSmokeBusyRef\.current = false;/,
-      'voice capture smoke must track page ownership and release the pending owner when Settings closes',
+      /const captureSmokeGuard = useActionGuard<'smoke'>\(\);[\s\S]*const voicePageMountedRef = useMountedRef\(\);[\s\S]*const activeVoiceCaptureStreamRef = useRef<MediaStream \| null>\(null\);[\s\S]*return \(\) => \{[\s\S]*activeVoiceCaptureStreamRef\.current\?\.getTracks\(\)\.forEach\(\(track\) => track\.stop\(\)\);[\s\S]*activeVoiceCaptureStreamRef\.current = null;/,
+      'voice capture smoke must track page ownership and stop the active stream when Settings closes (the shared guard hook releases the pending owner)',
     );
     assert.match(
       voicePage!,
@@ -126,7 +126,7 @@ describe('voice capture smoke Settings contract', () => {
     );
     assert.match(
       voicePage!,
-      /finally \{[\s\S]*stream\?\.getTracks\(\)\.forEach\(\(track\) => track\.stop\(\)\);[\s\S]*if \(activeVoiceCaptureStreamRef\.current === stream\) \{[\s\S]*activeVoiceCaptureStreamRef\.current = null;[\s\S]*\}[\s\S]*captureSmokeBusyRef\.current = false;[\s\S]*if \(voicePageMountedRef\.current\) \{[\s\S]*setIsBusy\(false\);/,
+      /finally \{[\s\S]*stream\?\.getTracks\(\)\.forEach\(\(track\) => track\.stop\(\)\);[\s\S]*if \(activeVoiceCaptureStreamRef\.current === stream\) \{[\s\S]*activeVoiceCaptureStreamRef\.current = null;[\s\S]*\}[\s\S]*captureSmokeGuard\.finish\(\);[\s\S]*if \(voicePageMountedRef\.current\) \{[\s\S]*setIsBusy\(false\);/,
       'voice capture cleanup must stop microphone tracks, clear the active stream owner, and only write React state while mounted',
     );
   });

--- a/apps/desktop/src/main/__tests__/web-search-boundary.test.ts
+++ b/apps/desktop/src/main/__tests__/web-search-boundary.test.ts
@@ -177,11 +177,12 @@ describe('web-search renderer boundary (PR-WEB-SEARCH-TAVILY-0)', () => {
 
     assert.ok(page, 'Web search settings page block must exist');
     assert.match(page![0], /const \[pendingWebSearchEnabled, setPendingWebSearchEnabled\] = useState\(false\)/);
-    assert.match(page![0], /const pendingWebSearchEnabledRef = useRef\(false\)/);
     assert.match(page![0], /const \[pendingCredentialAction, setPendingCredentialAction\] = useState<'save' \| 'clear' \| null>\(null\)/);
-    assert.match(page![0], /const pendingCredentialActionRef = useRef<'save' \| 'clear' \| null>\(null\)/);
-    assert.match(page![0], /const testingRef = useRef\(false\)/);
-    assert.match(page![0], /const liveQueryRunningRef = useRef\(false\)/);
+    assert.match(
+      page![0],
+      /const webSearchActionGuard = useKeyedActionGuard<'set-enabled' \| 'credential' \| 'test' \| 'live-query'>\(\)/,
+      'Web search pending owners must come from the shared keyed action guard instead of hand-rolled refs',
+    );
     assert.match(page![0], /const liveQueryInputRef = useRef\(liveQuery\)/);
     assert.match(
       page![0],
@@ -195,25 +196,25 @@ describe('web-search renderer boundary (PR-WEB-SEARCH-TAVILY-0)', () => {
     );
     assert.match(
       page![0],
-      /async function runCredentialAction\([\s\S]*if \(pendingCredentialActionRef\.current !== null \|\| testingRef\.current\) return;[\s\S]*pendingCredentialActionRef\.current = action;[\s\S]*setPendingCredentialAction\(action\);[\s\S]*await run\(\);[\s\S]*pendingCredentialActionRef\.current = null;[\s\S]*setPendingCredentialAction\(null\);/,
+      /async function runCredentialAction\([\s\S]*if \(webSearchActionGuard\.has\('credential'\) \|\| webSearchActionGuard\.has\('test'\)\) return;[\s\S]*webSearchActionGuard\.begin\('credential'\);[\s\S]*setPendingCredentialAction\(action\);[\s\S]*await run\(\);[\s\S]*releaseCredential\(\);[\s\S]*setPendingCredentialAction\(null\);/,
       'Saving or clearing Tavily credentials must reject duplicate clicks synchronously and expose pending state.',
     );
     assert.match(
       page![0],
-      /async function setEnabled\(enabled: boolean\) \{[\s\S]*if \(pendingWebSearchEnabledRef\.current\) return;[\s\S]*pendingWebSearchEnabledRef\.current = true;[\s\S]*setPendingWebSearchEnabled\(true\);[\s\S]*await updateWebSearch\(\{ enabled \}\);[\s\S]*pendingWebSearchEnabledRef\.current = false;[\s\S]*setPendingWebSearchEnabled\(false\);/,
+      /async function setEnabled\(enabled: boolean\) \{[\s\S]*const releaseEnabled = webSearchActionGuard\.begin\('set-enabled'\);[\s\S]*if \(!releaseEnabled\) return;[\s\S]*setPendingWebSearchEnabled\(true\);[\s\S]*await updateWebSearch\(\{ enabled \}\);[\s\S]*releaseEnabled\(\);[\s\S]*setPendingWebSearchEnabled\(false\);/,
       'The web-search enable switch must reject duplicate same-frame toggles and expose local pending state.',
     );
     assert.match(page![0], /runCredentialAction\('save', async \(\) => \{/);
     assert.match(page![0], /runCredentialAction\('clear', async \(\) => \{/);
     assert.match(
       page![0],
-      /if \(testingRef\.current \|\| pendingCredentialActionRef\.current !== null\) return;[\s\S]*testingRef\.current = true;[\s\S]*setTesting\(true\);[\s\S]*testingRef\.current = false;[\s\S]*setTesting\(false\);/,
-      'Credential tests must also have a ref-backed duplicate-click guard.',
+      /if \(webSearchActionGuard\.has\('test'\) \|\| webSearchActionGuard\.has\('credential'\)\) return;[\s\S]*const releaseTest = webSearchActionGuard\.begin\('test'\);[\s\S]*if \(!releaseTest\) return;[\s\S]*setTesting\(true\);[\s\S]*releaseTest\(\);[\s\S]*setTesting\(false\);/,
+      'Credential tests must also have a guard-backed duplicate-click guard.',
     );
     assert.match(
       page![0],
-      /if \(liveQueryRunningRef\.current\) return;[\s\S]*const queryOwner = liveQueryInputRef\.current;[\s\S]*liveQueryRunningRef\.current = true;[\s\S]*setLiveQueryRunning\(true\);[\s\S]*liveQueryRunningRef\.current = false;[\s\S]*setLiveQueryRunning\(false\);/,
-      'Live query verification must have a ref-backed duplicate-submit guard.',
+      /if \(webSearchActionGuard\.has\('live-query'\)\) return;[\s\S]*const queryOwner = liveQueryInputRef\.current;[\s\S]*webSearchActionGuard\.begin\('live-query'\);[\s\S]*setLiveQueryRunning\(true\);[\s\S]*releaseLiveQuery\(\);[\s\S]*setLiveQueryRunning\(false\);/,
+      'Live query verification must have a guard-backed duplicate-submit guard.',
     );
     assert.match(page![0], /const credentialActionBusy = pendingCredentialAction !== null \|\| testing/);
     assert.match(page![0], /disabled=\{usingEnvKey \|\| credentialActionBusy\}/, 'Credential input should freeze while save, clear, or test is pending.');
@@ -237,17 +238,17 @@ describe('web-search renderer boundary (PR-WEB-SEARCH-TAVILY-0)', () => {
     );
     assert.match(
       page![0],
-      /useEffect\(\(\) => \{[\s\S]*return \(\) => \{[\s\S]*pendingWebSearchEnabledRef\.current = false;[\s\S]*pendingCredentialActionRef\.current = null;[\s\S]*testingRef\.current = false;[\s\S]*liveQueryRunningRef\.current = false;[\s\S]*\};[\s\S]*\}, \[\]\)/,
-      'Unmount must mark the page inactive and release synchronous pending owners',
+      /const webSearchActionGuard = useKeyedActionGuard<'set-enabled' \| 'credential' \| 'test' \| 'live-query'>\(\)/,
+      'Unmount must release synchronous pending owners (the shared keyed guard hook resets every key on unmount)',
     );
     assert.match(
       page![0],
-      /finally \{[\s\S]*pendingWebSearchEnabledRef\.current = false;[\s\S]*if \(webSearchMountedRef\.current\) \{[\s\S]*setPendingWebSearchEnabled\(false\);[\s\S]*\}/,
+      /finally \{[\s\S]*releaseEnabled\(\);[\s\S]*if \(webSearchMountedRef\.current\) \{[\s\S]*setPendingWebSearchEnabled\(false\);[\s\S]*\}/,
       'Web-search enable completion must not set pending switch state after unmount',
     );
     assert.match(
       page![0],
-      /finally \{[\s\S]*pendingCredentialActionRef\.current = null;[\s\S]*if \(webSearchMountedRef\.current\) \{[\s\S]*setPendingCredentialAction\(null\);[\s\S]*\}/,
+      /finally \{[\s\S]*releaseCredential\(\);[\s\S]*if \(webSearchMountedRef\.current\) \{[\s\S]*setPendingCredentialAction\(null\);[\s\S]*\}/,
       'Credential save/clear completion must not set state after unmount',
     );
     assert.match(
@@ -262,7 +263,7 @@ describe('web-search renderer boundary (PR-WEB-SEARCH-TAVILY-0)', () => {
     );
     assert.match(
       page![0],
-      /finally \{[\s\S]*testingRef\.current = false;[\s\S]*if \(webSearchMountedRef\.current\) \{[\s\S]*setTesting\(false\);[\s\S]*\}/,
+      /finally \{[\s\S]*releaseTest\(\);[\s\S]*if \(webSearchMountedRef\.current\) \{[\s\S]*setTesting\(false\);[\s\S]*\}/,
       'Credential test completion must not set testing state after unmount',
     );
     assert.match(
@@ -277,7 +278,7 @@ describe('web-search renderer boundary (PR-WEB-SEARCH-TAVILY-0)', () => {
     );
     assert.match(
       page![0],
-      /finally \{[\s\S]*liveQueryRunningRef\.current = false;[\s\S]*if \(webSearchMountedRef\.current\) \{[\s\S]*setLiveQueryRunning\(false\);[\s\S]*\}/,
+      /finally \{[\s\S]*releaseLiveQuery\(\);[\s\S]*if \(webSearchMountedRef\.current\) \{[\s\S]*setLiveQueryRunning\(false\);[\s\S]*\}/,
       'Live-query completion must not clear running state after unmount',
     );
   });

--- a/apps/desktop/src/renderer/settings/about-settings-page.tsx
+++ b/apps/desktop/src/renderer/settings/about-settings-page.tsx
@@ -1,9 +1,10 @@
-import { useEffect, useId, useRef, useState } from 'react';
+import { useEffect, useId, useState } from 'react';
 import { Sparkles } from '@maka/ui/icons';
 import { Button, PageHeader, useMountedRef, useToast } from '@maka/ui';
 import { SettingsRows, SettingRow } from './settings-rows';
 import { settingsActionErrorMessage } from './settings-error-copy';
 import { SettingsSkeletonStack } from './settings-skeleton';
+import { useActionGuard } from './use-action-guard';
 
 type AppInfo = Awaited<ReturnType<typeof window.maka.app.info>>;
 
@@ -17,7 +18,7 @@ export function AboutSettingsPage() {
   const [info, setInfo] = useState<AppInfo | null>(null);
   const [infoError, setInfoError] = useState<string | null>(null);
   const [copyingEnvSummary, setCopyingEnvSummary] = useState(false);
-  const copyingEnvSummaryRef = useRef(false);
+  const envSummaryCopyGuard = useActionGuard<'copy'>();
   const aboutPageMountedRef = useMountedRef();
   const toast = useToast();
   const envSummaryHelpId = useId();
@@ -40,7 +41,6 @@ export function AboutSettingsPage() {
     });
     return () => {
       cancelled = true;
-      copyingEnvSummaryRef.current = false;
     };
   }, [toast]);
 
@@ -73,8 +73,7 @@ export function AboutSettingsPage() {
 
   async function copyEnvSummary() {
     if (!info) return;
-    if (copyingEnvSummaryRef.current) return;
-    copyingEnvSummaryRef.current = true;
+    if (!envSummaryCopyGuard.begin('copy')) return;
     setCopyingEnvSummary(true);
     // Markdown block ready to paste into a problem report. Deliberately excludes
     // workspacePath since that can leak the OS username; user can still copy
@@ -103,7 +102,7 @@ export function AboutSettingsPage() {
         toast.error('复制失败', '剪贴板不可用或被系统拒绝。');
       }
     } finally {
-      copyingEnvSummaryRef.current = false;
+      envSummaryCopyGuard.finish();
       if (aboutPageMountedRef.current) {
         setCopyingEnvSummary(false);
       }

--- a/apps/desktop/src/renderer/settings/account-settings-page.tsx
+++ b/apps/desktop/src/renderer/settings/account-settings-page.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
-import type { ConnectionTestResult, LlmConnection } from '@maka/core';
-import { deriveProviderAuthContractFromConnection, generalizedErrorMessageChinese } from '@maka/core';
+import type { LlmConnection } from '@maka/core';
+import { deriveProviderAuthContractFromConnection } from '@maka/core';
 import { PROVIDER_DEFAULTS, providerAuthRequiresSecret } from '@maka/core/llm-connections';
 import { Button, Chip, RelativeTime, useMountedRef, useToast } from '@maka/ui';
 import {
@@ -15,7 +15,10 @@ import {
 } from '../connection-status';
 import { SettingsRows, SettingRow } from './settings-rows';
 import { settingsActionErrorMessage } from './settings-error-copy';
-import { connectionLastTestMessageDisplay } from './provider-panel-shared';
+import {
+  connectionLastTestMessageDisplay,
+  connectionTestFailureMessage,
+} from './provider-panel-shared';
 import { useActionGuard } from './use-action-guard';
 
 type AccountSecretProbeStatus = boolean | 'loading' | 'error';
@@ -23,24 +26,13 @@ type AccountSecretProbeResult =
   | { slug: string; status: boolean }
   | { slug: string; status: 'error'; message: string };
 
-function accountConnectionTestFailureMessage(result: ConnectionTestResult): string {
-  const fallback = accountConnectionTestFailureFallback(result);
-  if (!result.errorMessage) return fallback;
-  return generalizedErrorMessageChinese(new Error(result.errorMessage), fallback);
-}
-
-function accountConnectionTestFailureFallback(result: ConnectionTestResult): string {
-  if (result.statusCode === 429) return '当前账号或模型服务触发速率限制，请稍后重试。';
-  if (result.errorClass === 'timeout') return '请求超时，请检查网络或代理后重试。';
-  if (result.errorClass === 'auth' || result.statusCode === 401 || result.statusCode === 403) {
-    return '鉴权失败，请检查模型密钥、订阅账号登录或凭据配置后重试。';
-  }
-  if (result.errorClass === 'provider_unavailable' || (result.statusCode !== undefined && result.statusCode >= 500)) {
-    return '模型服务暂时不可用，请稍后重试。';
-  }
-  if (result.errorClass === 'network') return '网络错误，请检查服务地址或代理设置后重试。';
-  return '连接测试失败，请检查模型连接配置后重试。';
-}
+// Account-page troubleshooting copy is broader than the Models sheet: a
+// single list spans API-key and OAuth providers, so auth/recheck guidance
+// cannot mention a specific field like the connection-detail sheet does.
+const ACCOUNT_CONNECTION_TEST_COPY = {
+  auth: '鉴权失败，请检查模型密钥、订阅账号登录或凭据配置后重试。',
+  recheck: '连接测试失败，请检查模型连接配置后重试。',
+} as const;
 
 export function AccountSettingsPage(props: {
   connections: LlmConnection[];
@@ -96,7 +88,7 @@ export function AccountSettingsPage(props: {
       if (result.ok) {
         toast.success('连接已验证', `延迟 ${result.latencyMs ?? '?'} ms${result.modelTested ? ' · ' + result.modelTested : ''}`);
       } else {
-        toast.error('连接测试失败', accountConnectionTestFailureMessage(result));
+        toast.error('连接测试失败', connectionTestFailureMessage(result, ACCOUNT_CONNECTION_TEST_COPY));
       }
     } catch (error) {
       // Main is supposed to return a structured result; if something escapes

--- a/apps/desktop/src/renderer/settings/account-settings-page.tsx
+++ b/apps/desktop/src/renderer/settings/account-settings-page.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useState } from 'react';
 import type { ConnectionTestResult, LlmConnection } from '@maka/core';
 import { deriveProviderAuthContractFromConnection, generalizedErrorMessageChinese } from '@maka/core';
 import { PROVIDER_DEFAULTS, providerAuthRequiresSecret } from '@maka/core/llm-connections';
@@ -16,6 +16,7 @@ import {
 import { SettingsRows, SettingRow } from './settings-rows';
 import { settingsActionErrorMessage } from './settings-error-copy';
 import { connectionLastTestMessageDisplay } from './provider-panel-shared';
+import { useActionGuard } from './use-action-guard';
 
 type AccountSecretProbeStatus = boolean | 'loading' | 'error';
 type AccountSecretProbeResult =
@@ -53,15 +54,9 @@ export function AccountSettingsPage(props: {
   const [secretMap, setSecretMap] = useState<Record<string, AccountSecretProbeStatus>>({});
   const [secretProbeError, setSecretProbeError] = useState<string | null>(null);
   const [testingSlug, setTestingSlug] = useState<string | null>(null);
-  const testingSlugRef = useRef<string | null>(null);
+  const connectionTestGuard = useActionGuard<string>();
   const accountPageMountedRef = useMountedRef();
   const toast = useToast();
-
-  useEffect(() => {
-    return () => {
-      testingSlugRef.current = null;
-    };
-  }, []);
 
   useEffect(() => {
     let cancelled = false;
@@ -93,12 +88,11 @@ export function AccountSettingsPage(props: {
   }, [props.connections]);
 
   async function testConnection(slug: string) {
-    if (testingSlugRef.current !== null) return;
-    testingSlugRef.current = slug;
+    if (!connectionTestGuard.begin(slug)) return;
     setTestingSlug(slug);
     try {
       const result = await window.maka.connections.test(slug);
-      if (!accountPageMountedRef.current || testingSlugRef.current !== slug) return;
+      if (!accountPageMountedRef.current || connectionTestGuard.current !== slug) return;
       if (result.ok) {
         toast.success('连接已验证', `延迟 ${result.latencyMs ?? '?'} ms${result.modelTested ? ' · ' + result.modelTested : ''}`);
       } else {
@@ -107,27 +101,27 @@ export function AccountSettingsPage(props: {
     } catch (error) {
       // Main is supposed to return a structured result; if something escapes
       // to throw form, surface the generalized message anyway.
-      if (accountPageMountedRef.current && testingSlugRef.current === slug) {
+      if (accountPageMountedRef.current && connectionTestGuard.current === slug) {
         toast.error('测试出错', settingsActionErrorMessage(error));
       }
     } finally {
       // Pull the freshest lastTestStatus/lastTestAt/lastTestMessage so the
       // row re-renders with the new derived status without a Settings reopen.
-      if (accountPageMountedRef.current && testingSlugRef.current === slug) {
+      if (accountPageMountedRef.current && connectionTestGuard.current === slug) {
         try {
           await props.onRefresh();
         } catch (error) {
-          if (accountPageMountedRef.current && testingSlugRef.current === slug) {
+          if (accountPageMountedRef.current && connectionTestGuard.current === slug) {
             toast.error('刷新模型连接状态失败', settingsActionErrorMessage(error));
           }
         } finally {
-          testingSlugRef.current = null;
+          connectionTestGuard.finish();
           if (accountPageMountedRef.current) {
             setTestingSlug(null);
           }
         }
-      } else if (testingSlugRef.current === slug) {
-        testingSlugRef.current = null;
+      } else if (connectionTestGuard.current === slug) {
+        connectionTestGuard.finish();
       }
     }
   }

--- a/apps/desktop/src/renderer/settings/action-guard.ts
+++ b/apps/desktop/src/renderer/settings/action-guard.ts
@@ -1,0 +1,60 @@
+// Framework-free keyed one-shot action guard: the multi-latch sibling of
+// oauth-login-flow-guard.ts's createOneShotActionGuard for components that
+// hold several independent action latches at once (the connection detail
+// sheet's six mutually excluding actions, the memory / workspace-instructions
+// controllers' per-row action keys). Kept React-free so its behavior is
+// unit-testable without a DOM (see action-guard.test.ts) and so the desktop
+// test runner can import it without pulling React into its program.
+//
+// The check stays synchronous — a second concurrent action is rejected before
+// React can re-render the disabled button, never subject to render batching.
+export interface KeyedActionGuard<Key> {
+  /** Acquire `key`; returns its release function, or null when already held. */
+  begin(key: Key): (() => void) | null;
+  /** Acquire `key` only while no action is in flight; otherwise null. */
+  beginExclusive(key: Key): (() => void) | null;
+  has(key: Key): boolean;
+  /** Count of in-flight actions, for cross-action exclusion checks. */
+  readonly size: number;
+  /** Drop every hold (teardown). In-flight releases stay safe: see below. */
+  reset(): void;
+}
+
+export function createKeyedActionGuard<Key>(): KeyedActionGuard<Key> {
+  // key -> owner token. The release closure only drops its own token, so a
+  // late release settling after reset() + a newer acquire of the same key
+  // cannot strip the newer action's hold (the StrictMode remount race the
+  // hand-rolled owner-token refs in use-workspace-instructions-controller
+  // defended against). Tokens are monotonic for the guard's lifetime, never
+  // reused after reset.
+  const owners = new Map<Key, number>();
+  let sequence = 0;
+
+  function acquire(key: Key): () => void {
+    const owner = ++sequence;
+    owners.set(key, owner);
+    return () => {
+      if (owners.get(key) === owner) owners.delete(key);
+    };
+  }
+
+  return {
+    begin(key: Key): (() => void) | null {
+      if (owners.has(key)) return null;
+      return acquire(key);
+    },
+    beginExclusive(key: Key): (() => void) | null {
+      if (owners.size > 0) return null;
+      return acquire(key);
+    },
+    has(key: Key): boolean {
+      return owners.has(key);
+    },
+    get size(): number {
+      return owners.size;
+    },
+    reset(): void {
+      owners.clear();
+    },
+  };
+}

--- a/apps/desktop/src/renderer/settings/daily-review-settings-page.tsx
+++ b/apps/desktop/src/renderer/settings/daily-review-settings-page.tsx
@@ -1,9 +1,10 @@
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import type { DailyReviewConfig, DailyReviewMode, LlmConnection } from '@maka/core';
 import { Alert, AlertDescription, Button, Input, SettingsSelect, SettingsSwitch as Switch, useMountedRef, useToast } from '@maka/ui';
 import { buildCatalogDailyReviewModelOptions } from '../model-catalog-choices';
 import { settingsActionErrorMessage } from './settings-error-copy';
 import { SettingsRows } from './settings-rows';
+import { useActionGuard } from './use-action-guard';
 
 /**
  * PR-DAILY-REVIEW-MVP-0 follow-up: Settings → 每日回顾 is no longer
@@ -50,15 +51,8 @@ export function DailyReviewSettingsPage(props: { connections: readonly LlmConnec
   const [savingKey, setSavingKey] = useState<string | null>(null);
   const [runningMode, setRunningMode] = useState<DailyReviewMode | null>(null);
   const mountedRef = useMountedRef();
-  const savingKeyRef = useRef<string | null>(null);
-  const runningModeRef = useRef<DailyReviewMode | null>(null);
-
-  useEffect(() => {
-    return () => {
-      savingKeyRef.current = null;
-      runningModeRef.current = null;
-    };
-  }, []);
+  const saveConfigGuard = useActionGuard<string>();
+  const runModeGuard = useActionGuard<DailyReviewMode>();
 
   useEffect(() => {
     if (!hasConfigIpc || !dailyReviewIpc.getConfig) {
@@ -89,40 +83,40 @@ export function DailyReviewSettingsPage(props: { connections: readonly LlmConnec
   }, [hasConfigIpc, dailyReviewIpc]);
 
   async function patchConfig(key: string, patch: Partial<DailyReviewConfig>) {
-    if (!dailyReviewIpc.setConfig || !config || savingKeyRef.current !== null) return;
-    savingKeyRef.current = key;
+    if (!dailyReviewIpc.setConfig || !config || saveConfigGuard.current !== null) return;
+    saveConfigGuard.begin(key);
     setSavingKey(key);
     try {
       const next = await dailyReviewIpc.setConfig(patch);
-      if (mountedRef.current && savingKeyRef.current === key) setConfig(next);
+      if (mountedRef.current && saveConfigGuard.current === key) setConfig(next);
     } catch (err) {
-      if (mountedRef.current && savingKeyRef.current === key) {
+      if (mountedRef.current && saveConfigGuard.current === key) {
         toast.error('保存每日回顾设置失败', settingsActionErrorMessage(err));
       }
     } finally {
-      if (savingKeyRef.current === key) {
-        savingKeyRef.current = null;
+      if (saveConfigGuard.current === key) {
+        saveConfigGuard.finish();
       }
       if (mountedRef.current) setSavingKey(null);
     }
   }
 
   async function triggerRun(mode: DailyReviewMode) {
-    if (!dailyReviewIpc.runOnce || runningModeRef.current !== null) return;
-    runningModeRef.current = mode;
+    if (!dailyReviewIpc.runOnce || runModeGuard.current !== null) return;
+    runModeGuard.begin(mode);
     setRunningMode(mode);
     try {
       await dailyReviewIpc.runOnce({ mode });
-      if (mountedRef.current && runningModeRef.current === mode) {
+      if (mountedRef.current && runModeGuard.current === mode) {
         toast.success(mode === 'daily' ? '已生成每日回顾' : '已生成深度分析', '可在「每日回顾」面板查看。');
       }
     } catch (err) {
-      if (mountedRef.current && runningModeRef.current === mode) {
+      if (mountedRef.current && runModeGuard.current === mode) {
         toast.error('生成回顾失败', settingsActionErrorMessage(err));
       }
     } finally {
-      if (runningModeRef.current === mode) {
-        runningModeRef.current = null;
+      if (runModeGuard.current === mode) {
+        runModeGuard.finish();
       }
       if (mountedRef.current) setRunningMode(null);
     }

--- a/apps/desktop/src/renderer/settings/data-settings-page.tsx
+++ b/apps/desktop/src/renderer/settings/data-settings-page.tsx
@@ -1,9 +1,10 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useState } from 'react';
 import type { ConfigCategory } from '@maka/storage';
 import { Button, SettingsSelect, SettingsSwitch as Switch, clearGlobalInputHistory, useMountedRef, useToast } from '@maka/ui';
 import { openPathFailureCopy, openPathActionLabel } from '../open-path';
 import { SettingsRows, SettingRow } from './settings-rows';
 import { settingsActionErrorMessage } from './settings-error-copy';
+import { useActionGuard } from './use-action-guard';
 
 const CONFIG_CATEGORY_OPTIONS: ReadonlyArray<{
   id: ConfigCategory;
@@ -44,7 +45,7 @@ export function DataSettingsPage() {
   const [info, setInfo] = useState<Awaited<ReturnType<typeof window.maka.app.info>> | null>(null);
   const [infoError, setInfoError] = useState<string | null>(null);
   const [pendingDataAction, setPendingDataAction] = useState<string | null>(null);
-  const pendingDataActionRef = useRef<string | null>(null);
+  const dataActionGuard = useActionGuard<string>();
   const dataPageMountedRef = useMountedRef();
   const toast = useToast();
   const [selectedCategories, setSelectedCategories] = useState<Set<ConfigCategory>>(
@@ -69,18 +70,16 @@ export function DataSettingsPage() {
     });
     return () => {
       cancelled = true;
-      pendingDataActionRef.current = null;
     };
   }, [toast]);
 
   async function runDataAction(action: string, run: () => Promise<void>) {
-    if (pendingDataActionRef.current) return;
-    pendingDataActionRef.current = action;
+    if (!dataActionGuard.begin(action)) return;
     setPendingDataAction(action);
     try {
       await run();
     } finally {
-      pendingDataActionRef.current = null;
+      dataActionGuard.finish();
       if (dataPageMountedRef.current) {
         setPendingDataAction(null);
       }

--- a/apps/desktop/src/renderer/settings/general-settings-page.tsx
+++ b/apps/desktop/src/renderer/settings/general-settings-page.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useMemo, useState } from 'react';
 import { PersonalizationSettingsPage } from './appearance-settings-page';
 import type {
   AppSettings,
@@ -29,6 +29,7 @@ import { buildCatalogChatModelChoices } from '../model-catalog-choices';
 import { PasswordInput } from './password-input';
 import { SettingsRows } from './settings-rows';
 import { settingsActionErrorMessage } from './settings-error-copy';
+import { useActionGuard, useKeyedActionGuard } from './use-action-guard';
 import { useOptimisticSettingsDraft } from './use-optimistic-settings-draft';
 
 export function GeneralSettingsPage(props: {
@@ -120,17 +121,9 @@ function GeneralDefaultsCard(props: {
 }) {
   const toast = useToast();
   const mountedRef = useMountedRef();
-  const savingRef = useRef(false);
+  const persistGuard = useKeyedActionGuard<'default-model' | 'permission-mode'>();
   const [saving, setSaving] = useState(false);
-  const savingPermissionModeRef = useRef(false);
   const [savingPermissionMode, setSavingPermissionMode] = useState(false);
-
-  useEffect(() => {
-    return () => {
-      savingRef.current = false;
-      savingPermissionModeRef.current = false;
-    };
-  }, []);
 
   const modelChoices = useMemo(() => buildCatalogChatModelChoices(props.connections), [props.connections]);
   const modelGroups = useMemo(() => modelMenuGroups(modelChoices), [modelChoices]);
@@ -147,8 +140,8 @@ function GeneralDefaultsCard(props: {
   }, [modelChoices, selectedValue]);
 
   async function persistDefault(nextValue: string) {
-    if (savingRef.current) return;
-    savingRef.current = true;
+    const releaseSave = persistGuard.begin('default-model');
+    if (!releaseSave) return;
     setSaving(true);
     try {
       const parsed = parseModelChoiceValue(nextValue);
@@ -163,9 +156,7 @@ function GeneralDefaultsCard(props: {
         toast.error('保存默认模型失败', settingsActionErrorMessage(error));
       }
     } finally {
-      if (savingRef.current) {
-        savingRef.current = false;
-      }
+      releaseSave();
       if (mountedRef.current) setSaving(false);
     }
   }
@@ -175,8 +166,8 @@ function GeneralDefaultsCard(props: {
     // alone can't fully prevent overlapping saves (React disables it a tick
     // after the click), and overlapping settings.update calls have no
     // ordering guarantee.
-    if (savingPermissionModeRef.current) return;
-    savingPermissionModeRef.current = true;
+    const releaseSave = persistGuard.begin('permission-mode');
+    if (!releaseSave) return;
     setSavingPermissionMode(true);
     try {
       await props.onUpdate({ chatDefaults: { permissionMode: nextMode } });
@@ -185,7 +176,7 @@ function GeneralDefaultsCard(props: {
         toast.error('保存默认权限模式失败', settingsActionErrorMessage(error));
       }
     } finally {
-      savingPermissionModeRef.current = false;
+      releaseSave();
       if (mountedRef.current) setSavingPermissionMode(false);
     }
   }
@@ -246,7 +237,7 @@ function NetworkProxySection(props: {
 }) {
   const persistedProxy = props.settings.network.proxy;
   const [testing, setTesting] = useState(false);
-  const proxyTestRunningRef = useRef(false);
+  const proxyTestGuard = useActionGuard<'test'>();
   const toast = useToast();
   const {
     draft: proxyDraft,
@@ -259,19 +250,12 @@ function NetworkProxySection(props: {
     { onError: (error) => toast.error('保存网络设置失败', settingsActionErrorMessage(error)) },
   );
 
-  useEffect(() => {
-    return () => {
-      proxyTestRunningRef.current = false;
-    };
-  }, []);
-
   function updateProxy(patch: Partial<NetworkProxySettings>) {
     return update(patch);
   }
 
   async function testProxy() {
-    if (proxyTestRunningRef.current) return;
-    proxyTestRunningRef.current = true;
+    if (!proxyTestGuard.begin('test')) return;
     setTesting(true);
     try {
       const result = await window.maka.settings.testNetworkProxy(toProxyTestInput(proxyDraftRef.current));
@@ -286,7 +270,7 @@ function NetworkProxySection(props: {
         toast.error('代理测试出错', settingsActionErrorMessage(error));
       }
     } finally {
-      proxyTestRunningRef.current = false;
+      proxyTestGuard.finish();
       if (networkPageMountedRef.current) {
         setTesting(false);
       }

--- a/apps/desktop/src/renderer/settings/open-gateway-settings-page.tsx
+++ b/apps/desktop/src/renderer/settings/open-gateway-settings-page.tsx
@@ -1,10 +1,11 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useState } from 'react';
 import type { AppSettings, OpenGatewayRuntimeStatus, UpdateAppSettingsResult } from '@maka/core';
 import { Button, Input, NumberField, NumberFieldInput, SettingsSelect, SettingsSwitch as Switch, Textarea, useToast } from '@maka/ui';
 import { PasswordInput } from './password-input';
 import { MetricCard } from './settings-metric-card';
 import { SettingsRows, SettingRow } from './settings-rows';
 import { settingsActionErrorMessage } from './settings-error-copy';
+import { useActionGuard } from './use-action-guard';
 import { useOptimisticSettingsDraft } from './use-optimistic-settings-draft';
 
 export function OpenGatewaySettingsPage(props: {
@@ -17,7 +18,7 @@ export function OpenGatewaySettingsPage(props: {
   const [tokenDraft, setTokenDraft] = useState(persistedGateway.token);
   const [eventSessionId, setEventSessionId] = useState('');
   const [copyingGatewayAction, setCopyingGatewayAction] = useState<string | null>(null);
-  const copyingGatewayActionRef = useRef<string | null>(null);
+  const gatewayCopyGuard = useActionGuard<string>();
   const toast = useToast();
   const {
     draft: gatewayDraft,
@@ -32,12 +33,6 @@ export function OpenGatewaySettingsPage(props: {
       onReconcile: (next) => setTokenDraft(next.token),
     },
   );
-
-  useEffect(() => {
-    return () => {
-      copyingGatewayActionRef.current = null;
-    };
-  }, []);
 
   useEffect(() => {
     let cancelled = false;
@@ -86,8 +81,7 @@ export function OpenGatewaySettingsPage(props: {
   }
 
   async function copyGatewayText(action: string, text: string, successTitle: string, successDetail: string) {
-    if (copyingGatewayActionRef.current) return;
-    copyingGatewayActionRef.current = action;
+    if (!gatewayCopyGuard.begin(action)) return;
     setCopyingGatewayAction(action);
     try {
       await navigator.clipboard.writeText(text);
@@ -99,7 +93,7 @@ export function OpenGatewaySettingsPage(props: {
         toast.error('复制失败', '剪贴板不可用或被系统拒绝。');
       }
     } finally {
-      copyingGatewayActionRef.current = null;
+      gatewayCopyGuard.finish();
       if (openGatewayMountedRef.current) {
         setCopyingGatewayAction(null);
       }

--- a/apps/desktop/src/renderer/settings/password-input.tsx
+++ b/apps/desktop/src/renderer/settings/password-input.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState, type Ref } from 'react';
 import { Check, Copy, Eye, EyeOff } from '@maka/ui/icons';
 import { Button, Input, useMountedRef, useToast } from '@maka/ui';
+import { useActionGuard } from './use-action-guard';
 
 /**
  * PR-BOT-SETTINGS-PASSWORD-EYE-0 / PR-BOT-SETTINGS-PASSWORD-COPY-0 /
@@ -31,13 +32,12 @@ export function PasswordInput(props: {
   const [visible, setVisible] = useState(false);
   const [justCopied, setJustCopied] = useState(false);
   const [copying, setCopying] = useState(false);
-  const copyingRef = useRef(false);
+  const copyGuard = useActionGuard<'copy'>();
   const mountedRef = useMountedRef();
   const copyFeedbackTimerRef = useRef<number | null>(null);
 
   useEffect(() => {
     return () => {
-      copyingRef.current = false;
       if (copyFeedbackTimerRef.current !== null) {
         window.clearTimeout(copyFeedbackTimerRef.current);
         copyFeedbackTimerRef.current = null;
@@ -58,8 +58,7 @@ export function PasswordInput(props: {
 
   async function copyValue() {
     if (!props.value) return;
-    if (copyingRef.current) return;
-    copyingRef.current = true;
+    if (!copyGuard.begin('copy')) return;
     setCopying(true);
     try {
       await navigator.clipboard.writeText(props.value);
@@ -67,7 +66,7 @@ export function PasswordInput(props: {
     } catch {
       if (mountedRef.current) toast.error('复制失败', '剪贴板不可用或被系统拒绝。');
     } finally {
-      copyingRef.current = false;
+      copyGuard.finish();
       if (mountedRef.current) setCopying(false);
     }
   }

--- a/apps/desktop/src/renderer/settings/permission-center-page.tsx
+++ b/apps/desktop/src/renderer/settings/permission-center-page.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState, type ComponentType } from 'react';
+import { useEffect, useState, type ComponentType } from 'react';
 import {
   Accessibility as AccessibilityIcon,
   Bell,
@@ -22,6 +22,7 @@ import { Button, Badge, EmptyState, RelativeTime, PageHeader, SectionHeader, Sta
 import { settingsActionErrorMessage } from './settings-error-copy';
 import { statusBadgeVariant } from './settings-status-badge';
 import { SettingsSkeletonStack } from './settings-skeleton';
+import { useActionGuard } from './use-action-guard';
 
 /**
  * PR-UI-8 — Permission Center read-only page. Consumes `window.maka.permissions.getSnapshot()`
@@ -110,13 +111,7 @@ export function PermissionCenterPage() {
   const [diagnosticsOpen, setDiagnosticsOpen] = useState(false);
   const toast = useToast();
   const mountedRef = useMountedRef();
-  const pendingPermActionRef = useRef<string | null>(null);
-
-  useEffect(() => {
-    return () => {
-      pendingPermActionRef.current = null;
-    };
-  }, []);
+  const permissionActionGuard = useActionGuard<string>();
 
   useEffect(() => {
     let cancelled = false;
@@ -147,8 +142,7 @@ export function PermissionCenterPage() {
     kind: 'request' | 'openSettings',
   ) {
     const actionKey = `${permId}:${kind}`;
-    if (pendingPermActionRef.current) return;
-    pendingPermActionRef.current = actionKey;
+    if (!permissionActionGuard.begin(actionKey)) return;
     setPendingPermAction(actionKey);
     try {
       const result =
@@ -165,8 +159,8 @@ export function PermissionCenterPage() {
     } catch (err) {
       if (mountedRef.current) toast.error('权限操作失败', settingsActionErrorMessage(err));
     } finally {
-      if (pendingPermActionRef.current === actionKey) {
-        pendingPermActionRef.current = null;
+      if (permissionActionGuard.current === actionKey) {
+        permissionActionGuard.finish();
       }
       if (mountedRef.current) setPendingPermAction(null);
     }
@@ -344,21 +338,14 @@ function CapabilityRow(props: { capability: CapabilitySnapshot }) {
   const { capability } = props;
   const toast = useToast();
   const [copyingOfficeCliInstall, setCopyingOfficeCliInstall] = useState(false);
-  const copyingOfficeCliInstallRef = useRef(false);
+  const copyOfficeCliInstallGuard = useActionGuard<'copy'>();
   const capabilityRowMountedRef = useMountedRef();
   const readinessCopy = CAPABILITY_READINESS_COPY[capability.readiness];
   const showOfficeCliInstallActions =
     capability.id === 'office_documents' && capability.runtimeProbe.state !== 'healthy';
 
-  useEffect(() => {
-    return () => {
-      copyingOfficeCliInstallRef.current = false;
-    };
-  }, []);
-
   async function copyOfficeCliInstallCommand() {
-    if (copyingOfficeCliInstallRef.current) return;
-    copyingOfficeCliInstallRef.current = true;
+    if (!copyOfficeCliInstallGuard.begin('copy')) return;
     setCopyingOfficeCliInstall(true);
     try {
       await navigator.clipboard.writeText(OFFICECLI_INSTALL_COMMAND);
@@ -370,7 +357,7 @@ function CapabilityRow(props: { capability: CapabilitySnapshot }) {
         toast.error('复制失败', '剪贴板不可用或被系统拒绝。');
       }
     } finally {
-      copyingOfficeCliInstallRef.current = false;
+      copyOfficeCliInstallGuard.finish();
       if (capabilityRowMountedRef.current) {
         setCopyingOfficeCliInstall(false);
       }

--- a/apps/desktop/src/renderer/settings/provider-add-form.tsx
+++ b/apps/desktop/src/renderer/settings/provider-add-form.tsx
@@ -1,10 +1,11 @@
-import { useEffect, useRef, useState, type FormEvent } from 'react';
+import { useState, type FormEvent } from 'react';
 import { PROVIDER_DEFAULTS, validateSlug, type ProviderType } from '@maka/core';
 import { providerAuthRequiresSecret, providerAuthSupportsApiKey } from '@maka/core/llm-connections';
 import { Button, Chip, Input, useMountedRef, useUiLocale } from '@maka/ui';
 import { buildCatalogRecommendedDefaultModel } from '../model-catalog-choices';
 import { PasswordInput } from './password-input';
 import { providerDisplay } from './provider-display';
+import { useActionGuard } from './use-action-guard';
 import {
   categoryLabel,
   isWiredOAuthProvider,
@@ -31,7 +32,7 @@ export function AddProviderForm(props: {
   const [apiKey, setApiKey] = useState('');
   const [error, setError] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
-  const busyRef = useRef(false);
+  const submitGuard = useActionGuard<'submit'>();
   const addProviderMountedRef = useMountedRef();
 
   const isCloudflareWorkersAi = props.providerType === 'cloudflare-workers-ai';
@@ -42,14 +43,8 @@ export function AddProviderForm(props: {
   const requiresApiKey = providerAuthRequiresSecret(props.providerType) && supportsApiKey;
   const usesApiKeyDialog = usesQuickApiKeyDialog(props.providerType);
 
-  useEffect(() => {
-    return () => {
-      busyRef.current = false;
-    };
-  }, []);
-
   async function submit() {
-    if (busyRef.current) return;
+    if (submitGuard.current !== null) return;
     setError(null);
     const slugError = validateSlug(slug);
     if (slugError) return setError(slugError);
@@ -66,7 +61,7 @@ export function AddProviderForm(props: {
         ? '请到账号连接完成登录；登录成功后会自动创建模型连接。'
         : '该账号登录暂未接入聊天发送；请先使用同一家厂商的模型密钥。');
     }
-    busyRef.current = true;
+    submitGuard.begin('submit');
     setBusy(true);
     try {
       const resolvedBaseUrl = isCloudflareWorkersAi
@@ -88,7 +83,7 @@ export function AddProviderForm(props: {
     } catch (err) {
       if (addProviderMountedRef.current) setError(providerPanelActionErrorMessage(err));
     } finally {
-      busyRef.current = false;
+      submitGuard.finish();
       if (addProviderMountedRef.current) setBusy(false);
     }
   }

--- a/apps/desktop/src/renderer/settings/provider-connection-detail.tsx
+++ b/apps/desktop/src/renderer/settings/provider-connection-detail.tsx
@@ -32,6 +32,7 @@ import { PasswordInput } from './password-input';
 import { buildCatalogModelChoices } from '../model-catalog-choices';
 import { providerDisplay } from './provider-display';
 import { connectionChipStatus } from './provider-connection-status';
+import { useActionGuard, useKeyedActionGuard } from './use-action-guard';
 import { useOAuthLoginFlow, type OAuthLoginFlowBridge } from './use-oauth-login-flow';
 import {
   connectionLastTestMessageDisplay,
@@ -169,12 +170,9 @@ function ConnectionDetailInner(props: ConnectionDetailProps) {
   const [savingEnabledModels, setSavingEnabledModels] = useState(false);
   const [settingDefault, setSettingDefault] = useState(false);
   const [deleting, setDeleting] = useState(false);
-  const busyRef = useRef(false);
-  const testingRef = useRef(false);
-  const fetchingModelsRef = useRef(false);
-  const savingEnabledModelsRef = useRef(false);
-  const settingDefaultRef = useRef(false);
-  const deletingRef = useRef(false);
+  const connectionDetailActionGuard = useKeyedActionGuard<
+    'save' | 'test' | 'fetch-models' | 'save-enabled-models' | 'set-default' | 'delete'
+  >();
   const connectionDetailMountedRef = useMountedRef();
   const connectionDetailLifecycleRef = useRef(0);
   const toast = useToast();
@@ -214,12 +212,7 @@ function ConnectionDetailInner(props: ConnectionDetailProps) {
     connectionDetailLifecycleRef.current += 1;
     return () => {
       connectionDetailLifecycleRef.current += 1;
-      busyRef.current = false;
-      testingRef.current = false;
-      fetchingModelsRef.current = false;
-      savingEnabledModelsRef.current = false;
-      settingDefaultRef.current = false;
-      deletingRef.current = false;
+      connectionDetailActionGuard.reset();
     };
   }, [connection.slug]);
 
@@ -294,9 +287,9 @@ function ConnectionDetailInner(props: ConnectionDetailProps) {
   });
 
   async function save() {
-    if (busyRef.current || testingRef.current || fetchingModelsRef.current || savingEnabledModelsRef.current || settingDefaultRef.current || deletingRef.current) return;
+    const releaseSave = connectionDetailActionGuard.beginExclusive('save');
+    if (!releaseSave) return;
     const lifecycle = connectionDetailLifecycleRef.current;
-    busyRef.current = true;
     setBusy(true);
     let saved = false;
     try {
@@ -331,13 +324,13 @@ function ConnectionDetailInner(props: ConnectionDetailProps) {
         providerPanelActionErrorMessage(error),
       );
     } finally {
-      busyRef.current = false;
+      releaseSave();
       if (isConnectionDetailCurrent(lifecycle)) setBusy(false);
     }
   }
 
   async function updateEnabledModels(nextIds: string[]) {
-    if (savingEnabledModelsRef.current || detailActionBusy) return;
+    if (connectionDetailActionGuard.has('save-enabled-models') || detailActionBusy) return;
     const next = connectionEnabledModelIds({
       defaultModel: connection.defaultModel,
       enabledModelIds: nextIds,
@@ -345,7 +338,8 @@ function ConnectionDetailInner(props: ConnectionDetailProps) {
     if (modelIdListsEqual(next, enabledModelIds)) return;
     const previous = enabledModelIds;
     const lifecycle = connectionDetailLifecycleRef.current;
-    savingEnabledModelsRef.current = true;
+    const releaseSaveModels = connectionDetailActionGuard.begin('save-enabled-models');
+    if (!releaseSaveModels) return;
     setSavingEnabledModels(true);
     setEnabledModelIds(next);
     let saved = false;
@@ -362,15 +356,15 @@ function ConnectionDetailInner(props: ConnectionDetailProps) {
         providerPanelActionErrorMessage(error),
       );
     } finally {
-      savingEnabledModelsRef.current = false;
+      releaseSaveModels();
       if (isConnectionDetailCurrent(lifecycle)) setSavingEnabledModels(false);
     }
   }
 
   async function runTest() {
-    if (testingRef.current || busyRef.current || fetchingModelsRef.current || savingEnabledModelsRef.current || settingDefaultRef.current || deletingRef.current) return;
+    const releaseTest = connectionDetailActionGuard.beginExclusive('test');
+    if (!releaseTest) return;
     const lifecycle = connectionDetailLifecycleRef.current;
-    testingRef.current = true;
     setTesting(true);
     try {
       const result: ConnectionTestResult = await props.bridge.test(connection.slug, { model: connection.defaultModel });
@@ -391,16 +385,19 @@ function ConnectionDetailInner(props: ConnectionDetailProps) {
       const message = providerPanelActionErrorMessage(error);
       toast.error(`连接测试出错 · ${connection.name}`, message);
     } finally {
-      testingRef.current = false;
+      releaseTest();
       if (isConnectionDetailCurrent(lifecycle)) setTesting(false);
     }
   }
 
   async function refreshModels(opts: { silent?: boolean } = {}) {
-    if (fetchingModelsRef.current) return;
-    if (!opts.silent && (busyRef.current || testingRef.current || savingEnabledModelsRef.current || settingDefaultRef.current || deletingRef.current)) return;
+    // A silent refresh (the post-save auto-fetch) may overlap other actions;
+    // a manual one is gated on the whole sheet like the other buttons.
+    const releaseFetch = opts.silent
+      ? connectionDetailActionGuard.begin('fetch-models')
+      : connectionDetailActionGuard.beginExclusive('fetch-models');
+    if (!releaseFetch) return;
     const lifecycle = connectionDetailLifecycleRef.current;
-    fetchingModelsRef.current = true;
     setFetchingModels(true);
     try {
       // Backend (xuan `81ed044`) returns a `ModelDiscoveryResult` envelope —
@@ -430,19 +427,20 @@ function ConnectionDetailInner(props: ConnectionDetailProps) {
         `${message} · 当前继续显示静态列表，请确认 ${credentialTroubleshootingCopy} 后重试。`,
       );
     } finally {
-      fetchingModelsRef.current = false;
+      releaseFetch();
       if (isConnectionDetailCurrent(lifecycle)) setFetchingModels(false);
     }
   }
 
   async function setAsDefault() {
-    if (settingDefaultRef.current || busyRef.current || testingRef.current || fetchingModelsRef.current || savingEnabledModelsRef.current || deletingRef.current) return;
+    const releaseSetDefault = connectionDetailActionGuard.beginExclusive('set-default');
+    if (!releaseSetDefault) return;
     if (!connection.enabled) {
+      releaseSetDefault();
       toast.error('无法设为默认', '这个模型连接已禁用，请重新登录或启用后再设为默认。');
       return;
     }
     const lifecycle = connectionDetailLifecycleRef.current;
-    settingDefaultRef.current = true;
     setSettingDefault(true);
     try {
       await props.bridge.setDefault(connection.slug);
@@ -454,15 +452,15 @@ function ConnectionDetailInner(props: ConnectionDetailProps) {
       if (!isConnectionDetailCurrent(lifecycle)) return;
       toast.error('切换默认失败', providerPanelActionErrorMessage(error));
     } finally {
-      settingDefaultRef.current = false;
+      releaseSetDefault();
       if (isConnectionDetailCurrent(lifecycle)) setSettingDefault(false);
     }
   }
 
   async function remove() {
-    if (deletingRef.current || busyRef.current || testingRef.current || fetchingModelsRef.current || savingEnabledModelsRef.current || settingDefaultRef.current) return;
+    const releaseDelete = connectionDetailActionGuard.beginExclusive('delete');
+    if (!releaseDelete) return;
     const lifecycle = connectionDetailLifecycleRef.current;
-    deletingRef.current = true;
     setDeleting(true);
     const ok = await toast.confirm({
       title: `删除供应商 ${connection.name}？`,
@@ -473,7 +471,7 @@ function ConnectionDetailInner(props: ConnectionDetailProps) {
     });
     if (!isConnectionDetailCurrent(lifecycle)) return;
     if (!ok) {
-      deletingRef.current = false;
+      releaseDelete();
       setDeleting(false);
       return;
     }
@@ -490,7 +488,7 @@ function ConnectionDetailInner(props: ConnectionDetailProps) {
         providerPanelActionErrorMessage(error),
       );
     } finally {
-      deletingRef.current = false;
+      releaseDelete();
       if (isConnectionDetailCurrent(lifecycle)) setDeleting(false);
     }
   }
@@ -674,15 +672,14 @@ function GitHubCopilotReloginNotice(props: {
   onRelogin(): Promise<void>;
 }) {
   const [busy, setBusy] = useState(false);
-  const busyRef = useRef(false);
+  const connectGuard = useActionGuard<'connect'>();
   const mountedRef = useMountedRef();
   const toast = useToast();
   const loggedIn = props.hasSecret === true;
   const loading = props.hasSecret === 'loading';
 
   async function connect() {
-    if (busyRef.current) return;
-    busyRef.current = true;
+    if (!connectGuard.begin('connect')) return;
     setBusy(true);
     try {
       const result = await window.maka.githubCopilotSubscription.connectExistingLogin();
@@ -694,7 +691,7 @@ function GitHubCopilotReloginNotice(props: {
     } catch (error) {
       if (mountedRef.current) toast.error('导入 GitHub Copilot 登录失败', generalizedErrorMessageChinese(error));
     } finally {
-      busyRef.current = false;
+      connectGuard.finish();
       if (mountedRef.current) setBusy(false);
     }
   }

--- a/apps/desktop/src/renderer/settings/provider-connection-detail.tsx
+++ b/apps/desktop/src/renderer/settings/provider-connection-detail.tsx
@@ -36,6 +36,7 @@ import { useActionGuard, useKeyedActionGuard } from './use-action-guard';
 import { useOAuthLoginFlow, type OAuthLoginFlowBridge } from './use-oauth-login-flow';
 import {
   connectionLastTestMessageDisplay,
+  connectionTestFailureMessage,
   providerPanelActionErrorMessage,
   type ConnectionsBridge,
   type CredentialPresenceStatus,
@@ -66,25 +67,6 @@ function oauthLoginServiceFor(providerType: ProviderType): OAuthLoginService | n
     default:
       return null;
   }
-}
-
-function connectionTestFailureMessage(result: ConnectionTestResult, troubleshootingCopy: string): string {
-  const fallback = connectionTestFailureFallback(result, troubleshootingCopy);
-  if (!result.errorMessage) return fallback;
-  return generalizedErrorMessageChinese(new Error(result.errorMessage), fallback);
-}
-
-function connectionTestFailureFallback(result: ConnectionTestResult, troubleshootingCopy: string): string {
-  if (result.statusCode === 429) return '当前账号或模型服务触发速率限制，请稍后重试。';
-  if (result.errorClass === 'timeout') return '请求超时，请检查网络或代理后重试。';
-  if (result.errorClass === 'auth' || result.statusCode === 401 || result.statusCode === 403) {
-    return `鉴权失败，请确认 ${troubleshootingCopy} 后重试。`;
-  }
-  if (result.errorClass === 'provider_unavailable' || (result.statusCode !== undefined && result.statusCode >= 500)) {
-    return '模型服务暂时不可用，请稍后重试。';
-  }
-  if (result.errorClass === 'network') return '网络错误，请检查服务地址或代理设置后重试。';
-  return `检查 ${troubleshootingCopy} 后重试。`;
 }
 
 interface ConnectionDetailProps {
@@ -377,7 +359,10 @@ function ConnectionDetailInner(props: ConnectionDetailProps) {
       } else {
         toast.error(
           `连接失败 · ${connection.name}`,
-          connectionTestFailureMessage(result, credentialTroubleshootingCopy),
+          connectionTestFailureMessage(result, {
+            auth: `鉴权失败，请确认 ${credentialTroubleshootingCopy} 后重试。`,
+            recheck: `检查 ${credentialTroubleshootingCopy} 后重试。`,
+          }),
         );
       }
     } catch (error) {

--- a/apps/desktop/src/renderer/settings/provider-panel-shared.ts
+++ b/apps/desktop/src/renderer/settings/provider-panel-shared.ts
@@ -28,6 +28,41 @@ export function providerPanelActionErrorMessage(error: unknown): string {
   return generalizedErrorMessageChinese(error, '模型连接服务暂时不可用，请稍后重试。');
 }
 
+export interface ConnectionTestTroubleshootingCopy {
+  /** Auth-class failure copy (errorClass 'auth' or HTTP 401/403). */
+  auth: string;
+  /** Final fallback copy when no failure class matched. */
+  recheck: string;
+}
+
+// Shared connection-test failure classification. The Models connection
+// sheet and the Account page used to each hand-copy this table; only the
+// surface-specific troubleshooting copy differs, so callers inject it.
+export function connectionTestFailureFallback(
+  result: ConnectionTestResult,
+  copy: ConnectionTestTroubleshootingCopy,
+): string {
+  if (result.statusCode === 429) return '当前账号或模型服务触发速率限制，请稍后重试。';
+  if (result.errorClass === 'timeout') return '请求超时，请检查网络或代理后重试。';
+  if (result.errorClass === 'auth' || result.statusCode === 401 || result.statusCode === 403) {
+    return copy.auth;
+  }
+  if (result.errorClass === 'provider_unavailable' || (result.statusCode !== undefined && result.statusCode >= 500)) {
+    return '模型服务暂时不可用，请稍后重试。';
+  }
+  if (result.errorClass === 'network') return '网络错误，请检查服务地址或代理设置后重试。';
+  return copy.recheck;
+}
+
+export function connectionTestFailureMessage(
+  result: ConnectionTestResult,
+  copy: ConnectionTestTroubleshootingCopy,
+): string {
+  const fallback = connectionTestFailureFallback(result, copy);
+  if (!result.errorMessage) return fallback;
+  return generalizedErrorMessageChinese(new Error(result.errorMessage), fallback);
+}
+
 export function connectionLastTestMessageDisplay(message: string | undefined): string | undefined {
   if (!message) return undefined;
   const trimmed = message.trim();

--- a/apps/desktop/src/renderer/settings/usage-settings-page.tsx
+++ b/apps/desktop/src/renderer/settings/usage-settings-page.tsx
@@ -1,9 +1,10 @@
-import { useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
+import { useMemo, useState, type ReactNode } from 'react';
 import type { AppSettings, UpdateAppSettingsResult, UsageRange, UsageStats } from '@maka/core';
 import { Button, Input, Segmented, SettingsSelect, SettingsSwitch as Switch, useToast } from '@maka/ui';
 import { RefreshCcw } from '@maka/ui/icons';
 import { MetricCard } from './settings-metric-card';
 import { settingsActionErrorMessage } from './settings-error-copy';
+import { useActionGuard } from './use-action-guard';
 import { useOptimisticSettingsDraft } from './use-optimistic-settings-draft';
 
 export function UsageSettingsPage(props: {
@@ -15,7 +16,7 @@ export function UsageSettingsPage(props: {
 }) {
   const persistedUsage = props.settings.usage;
   const [refreshing, setRefreshing] = useState(false);
-  const usageRefreshRunningRef = useRef(false);
+  const usageRefreshGuard = useActionGuard<'refresh'>();
   const stats = props.stats;
   const toast = useToast();
   const {
@@ -28,12 +29,6 @@ export function UsageSettingsPage(props: {
     (patch) => props.onUpdate({ usage: patch }).then((result) => result.settings.usage),
     { onError: (error) => toast.error('保存使用统计设置失败', settingsActionErrorMessage(error)) },
   );
-
-  useEffect(() => {
-    return () => {
-      usageRefreshRunningRef.current = false;
-    };
-  }, []);
 
   const normalizedModelFilter = usageDraft.modelFilter.trim().toLowerCase();
   const hasRequestFilters = usageDraft.status !== 'all' || normalizedModelFilter.length > 0;
@@ -60,13 +55,12 @@ export function UsageSettingsPage(props: {
   }
 
   async function refresh() {
-    if (usageRefreshRunningRef.current) return;
-    usageRefreshRunningRef.current = true;
+    if (!usageRefreshGuard.begin('refresh')) return;
     setRefreshing(true);
     try {
       await props.onReload(usageDraftRef.current.range);
     } finally {
-      usageRefreshRunningRef.current = false;
+      usageRefreshGuard.finish();
       if (usagePageMountedRef.current) {
         setRefreshing(false);
       }

--- a/apps/desktop/src/renderer/settings/use-action-guard.ts
+++ b/apps/desktop/src/renderer/settings/use-action-guard.ts
@@ -1,0 +1,56 @@
+import { useEffect, useRef } from 'react';
+import { createKeyedActionGuard, type KeyedActionGuard } from './action-guard';
+import { createOneShotActionGuard, type OneShotActionGuard } from './oauth-login-flow-guard';
+
+/**
+ * Shared one-shot action guards for Settings async actions.
+ *
+ * Settings pages used to each hand-roll the same synchronous
+ * `xRef.current` re-entrancy guard: check the ref, set it before the first
+ * await, clear it in `finally`, and reset it from an unmount cleanup so a
+ * StrictMode-remounted page is not stuck disabled. These hooks own that
+ * machinery once, on top of the tested framework-free seams:
+ *
+ * - `useActionGuard` wraps `createOneShotActionGuard` (the seam behind
+ *   `useOAuthLoginFlow`) for a component's single in-flight action; the
+ *   held action label doubles as a staleness token (`guard.current === key`).
+ * - `useKeyedActionGuard` wraps `createKeyedActionGuard` for components
+ *   holding several independent latches at once (per-row action keys,
+ *   mutually excluding sheet actions).
+ *
+ * Both release every hold on unmount, replacing the per-page
+ * `xRef.current = false` cleanup effects.
+ */
+export function useActionGuard<Action>(): OneShotActionGuard<Action> {
+  const guardRef = useRef<OneShotActionGuard<Action> | null>(null);
+  if (guardRef.current === null) {
+    guardRef.current = createOneShotActionGuard<Action>();
+  }
+  const guard = guardRef.current;
+
+  useEffect(() => {
+    return () => {
+      guard.finish();
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return guard;
+}
+
+export function useKeyedActionGuard<Key>(): KeyedActionGuard<Key> {
+  const guardRef = useRef<KeyedActionGuard<Key> | null>(null);
+  if (guardRef.current === null) {
+    guardRef.current = createKeyedActionGuard<Key>();
+  }
+  const guard = guardRef.current;
+
+  useEffect(() => {
+    return () => {
+      guard.reset();
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return guard;
+}

--- a/apps/desktop/src/renderer/settings/use-memory-settings-controller.ts
+++ b/apps/desktop/src/renderer/settings/use-memory-settings-controller.ts
@@ -16,6 +16,7 @@ import {
   memoryOriginLabel,
 } from './memory-settings-labels';
 import { deriveMemorySettingsViewModel } from './memory-settings-view-model';
+import { useKeyedActionGuard } from './use-action-guard';
 
 export interface MemoryDocumentControllerProps {
   settings: AppSettings;
@@ -45,8 +46,10 @@ export function useMemoryDocumentController(props: MemoryDocumentControllerProps
   const [pendingMemoryWriteAction, setPendingMemoryWriteAction] = useState<MemoryWriteAction | null>(null);
   const [pendingMemoryActions, setPendingMemoryActions] = useState<Set<string>>(() => new Set());
   const editorRef = useRef<HTMLTextAreaElement | null>(null);
-  const memoryWriteBusyRef = useRef(false);
-  const pendingMemoryActionKeysRef = useRef<Set<string>>(new Set());
+  // One keyed guard holds both the single write latch (key 'write', the old
+  // memoryWriteBusyRef) and the per-action latches (the old
+  // pendingMemoryActionKeysRef set) with owner-checked releases.
+  const memoryActionGuard = useKeyedActionGuard<string>();
   const memoryPageMountedRef = useRef(false);
   const memoryPageLifecycleRef = useRef(0);
   const memoryReloadTicketRef = useRef(0);
@@ -60,8 +63,6 @@ export function useMemoryDocumentController(props: MemoryDocumentControllerProps
       if (memoryPageLifecycleRef.current !== lifecycle) return;
       memoryPageMountedRef.current = false;
       memoryReloadTicketRef.current += 1;
-      memoryWriteBusyRef.current = false;
-      pendingMemoryActionKeysRef.current.clear();
     };
   }, []);
 
@@ -73,9 +74,9 @@ export function useMemoryDocumentController(props: MemoryDocumentControllerProps
     action: MemoryWriteAction,
     run: (isCurrent: () => boolean) => Promise<T>,
   ): Promise<T | undefined> {
-    if (memoryWriteBusyRef.current) return undefined;
+    const releaseWrite = memoryActionGuard.begin('write');
+    if (!releaseWrite) return undefined;
     const lifecycle = memoryPageLifecycleRef.current;
-    memoryWriteBusyRef.current = true;
     setPendingMemoryWriteAction(action);
     setBusy(true);
     try {
@@ -84,7 +85,7 @@ export function useMemoryDocumentController(props: MemoryDocumentControllerProps
       if (!isMemoryPageCurrent(lifecycle)) return undefined;
       throw error;
     } finally {
-      memoryWriteBusyRef.current = false;
+      releaseWrite();
       if (isMemoryPageCurrent(lifecycle)) {
         setPendingMemoryWriteAction(null);
         setBusy(false);
@@ -96,9 +97,9 @@ export function useMemoryDocumentController(props: MemoryDocumentControllerProps
     key: string,
     action: (isCurrent: () => boolean) => Promise<T>,
   ): Promise<T | undefined> {
-    if (pendingMemoryActionKeysRef.current.has(key)) return undefined;
+    const release = memoryActionGuard.begin(key);
+    if (!release) return undefined;
     const lifecycle = memoryPageLifecycleRef.current;
-    pendingMemoryActionKeysRef.current.add(key);
     setPendingMemoryActions((current) => new Set(current).add(key));
     try {
       return await action(() => isMemoryPageCurrent(lifecycle));
@@ -106,7 +107,7 @@ export function useMemoryDocumentController(props: MemoryDocumentControllerProps
       if (!isMemoryPageCurrent(lifecycle)) return undefined;
       throw error;
     } finally {
-      pendingMemoryActionKeysRef.current.delete(key);
+      release();
       if (isMemoryPageCurrent(lifecycle)) {
         setPendingMemoryActions((current) => {
           const next = new Set(current);

--- a/apps/desktop/src/renderer/settings/use-workspace-instructions-controller.ts
+++ b/apps/desktop/src/renderer/settings/use-workspace-instructions-controller.ts
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from 'react';
 import type { UpdateAppSettingsResult } from '@maka/core';
 import { useToast } from '@maka/ui';
 import { settingsActionErrorMessage } from './settings-error-copy';
+import { useKeyedActionGuard } from './use-action-guard';
 
 type WorkspaceInstructionState = Awaited<ReturnType<typeof window.maka.workspaceInstructions.getState>>;
 
@@ -16,9 +17,10 @@ export function useWorkspaceInstructionsController(props: WorkspaceInstructionsC
   const [pendingActions, setPendingActions] = useState<Set<string>>(() => new Set());
   const mountedRef = useRef(false);
   const lifecycleRef = useRef(0);
-  const pendingActionOwnersRef = useRef<Map<string, number>>(new Map());
-  const actionOwnerSequenceRef = useRef(0);
-  const writeOwnerRef = useRef<number | null>(null);
+  // One keyed guard holds both the single write latch (key 'write', the old
+  // writeOwnerRef) and the per-action owner latches (the old
+  // pendingActionOwnersRef map) with owner-checked releases.
+  const instructionActionGuard = useKeyedActionGuard<string>();
   const toast = useToast();
 
   useEffect(() => {
@@ -28,8 +30,6 @@ export function useWorkspaceInstructionsController(props: WorkspaceInstructionsC
     return () => {
       if (lifecycleRef.current !== lifecycle) return;
       mountedRef.current = false;
-      pendingActionOwnersRef.current.clear();
-      writeOwnerRef.current = null;
     };
   }, []);
 
@@ -52,17 +52,14 @@ export function useWorkspaceInstructionsController(props: WorkspaceInstructionsC
   }
 
   async function runAction(key: string, action: (isActionCurrent: () => boolean) => Promise<void>): Promise<void> {
-    if (pendingActionOwnersRef.current.has(key)) return;
+    const release = instructionActionGuard.begin(key);
+    if (!release) return;
     const lifecycle = lifecycleRef.current;
-    const owner = ++actionOwnerSequenceRef.current;
-    pendingActionOwnersRef.current.set(key, owner);
     setPendingActions((current) => new Set(current).add(key));
     try {
       await action(() => isCurrent(lifecycle));
     } finally {
-      if (pendingActionOwnersRef.current.get(key) === owner) {
-        pendingActionOwnersRef.current.delete(key);
-      }
+      release();
       if (isCurrent(lifecycle)) {
         setPendingActions((current) => {
           const next = new Set(current);
@@ -77,13 +74,12 @@ export function useWorkspaceInstructionsController(props: WorkspaceInstructionsC
     key: string,
     action: (isActionCurrent: () => boolean) => Promise<void>,
   ): Promise<void> {
-    if (writeOwnerRef.current !== null) return;
-    const owner = ++actionOwnerSequenceRef.current;
-    writeOwnerRef.current = owner;
+    const releaseWrite = instructionActionGuard.begin('write');
+    if (!releaseWrite) return;
     try {
       await runAction(key, action);
     } finally {
-      if (writeOwnerRef.current === owner) writeOwnerRef.current = null;
+      releaseWrite();
     }
   }
 

--- a/apps/desktop/src/renderer/settings/voice-settings-page.tsx
+++ b/apps/desktop/src/renderer/settings/voice-settings-page.tsx
@@ -3,6 +3,7 @@ import { Volume2 } from '@maka/ui/icons';
 import type { VoicePermissionStatus } from '@maka/core';
 import { defaultVoiceCaptureCaps, validateVoiceCaptureRequest } from '@maka/core';
 import { Button, PageHeader, formatBytes, useMountedRef, useToast } from '@maka/ui';
+import { useActionGuard } from './use-action-guard';
 
 type VoiceSmokeState =
   | { status: 'idle'; message: string }
@@ -18,7 +19,7 @@ export function VoiceModelsSettingsPage() {
     message: '等待运行本机录音自检。',
   });
   const [isBusy, setIsBusy] = useState(false);
-  const captureSmokeBusyRef = useRef(false);
+  const captureSmokeGuard = useActionGuard<'smoke'>();
   const voicePageMountedRef = useMountedRef();
   const activeVoiceCaptureStreamRef = useRef<MediaStream | null>(null);
   const toast = useToast();
@@ -29,7 +30,6 @@ export function VoiceModelsSettingsPage() {
     return () => {
       activeVoiceCaptureStreamRef.current?.getTracks().forEach((track) => track.stop());
       activeVoiceCaptureStreamRef.current = null;
-      captureSmokeBusyRef.current = false;
     };
   }, []);
 
@@ -44,7 +44,7 @@ export function VoiceModelsSettingsPage() {
   }, []);
 
   async function runCaptureSmoke() {
-    if (captureSmokeBusyRef.current) return;
+    if (captureSmokeGuard.current !== null) return;
     if (!navigator.mediaDevices?.getUserMedia) {
       setPermission('unsupported');
       setSmoke({ status: 'error', message: '当前运行环境不支持浏览器麦克风 API。' });
@@ -56,7 +56,7 @@ export function VoiceModelsSettingsPage() {
       return;
     }
 
-    captureSmokeBusyRef.current = true;
+    captureSmokeGuard.begin('smoke');
     setIsBusy(true);
     setSmoke({ status: 'checking', message: '正在请求 macOS / 浏览器麦克风权限…' });
     let stream: MediaStream | null = null;
@@ -121,7 +121,7 @@ export function VoiceModelsSettingsPage() {
       if (activeVoiceCaptureStreamRef.current === stream) {
         activeVoiceCaptureStreamRef.current = null;
       }
-      captureSmokeBusyRef.current = false;
+      captureSmokeGuard.finish();
       if (voicePageMountedRef.current) {
         setIsBusy(false);
       }

--- a/apps/desktop/src/renderer/settings/web-search-settings-page.tsx
+++ b/apps/desktop/src/renderer/settings/web-search-settings-page.tsx
@@ -1,10 +1,11 @@
-import { useEffect, useRef, useState } from 'react';
+import { useRef, useState } from 'react';
 import type { AppSettings, UpdateAppSettingsResult, WebSearchCredentialStatus } from '@maka/core';
 import { normalizeSearchUrl, webSearchCredentialStatusFromResponse } from '@maka/core';
 import { Button, Chip, Input, RelativeTime, SettingsSwitch as Switch, redactSecrets, useMountedRef, useToast } from '@maka/ui';
 import { PasswordInput } from './password-input';
 import { settingsActionErrorMessage } from './settings-error-copy';
 import { SettingsRows } from './settings-rows';
+import { useKeyedActionGuard } from './use-action-guard';
 
 /**
  * PR-WEB-SEARCH-TAVILY-0: Settings → 联网搜索.
@@ -37,21 +38,9 @@ export function WebSearchSettingsPage(props: {
   const [liveQueryResults, setLiveQueryResults] = useState<readonly { title: string; url: string; snippet: string; source: string }[] | null>(null);
   const [liveQueryError, setLiveQueryError] = useState<string | null>(null);
   const webSearchMountedRef = useMountedRef();
-  const pendingWebSearchEnabledRef = useRef(false);
-  const pendingCredentialActionRef = useRef<'save' | 'clear' | null>(null);
-  const testingRef = useRef(false);
-  const liveQueryRunningRef = useRef(false);
+  const webSearchActionGuard = useKeyedActionGuard<'set-enabled' | 'credential' | 'test' | 'live-query'>();
   const liveQueryInputRef = useRef(liveQuery);
   const toast = useToast();
-
-  useEffect(() => {
-    return () => {
-      pendingWebSearchEnabledRef.current = false;
-      pendingCredentialActionRef.current = null;
-      testingRef.current = false;
-      liveQueryRunningRef.current = false;
-    };
-  }, []);
 
   function updateLiveQuery(next: string) {
     liveQueryInputRef.current = next;
@@ -65,13 +54,14 @@ export function WebSearchSettingsPage(props: {
   }
 
   async function runCredentialAction(action: 'save' | 'clear', run: () => Promise<void>) {
-    if (pendingCredentialActionRef.current !== null || testingRef.current) return;
-    pendingCredentialActionRef.current = action;
+    if (webSearchActionGuard.has('credential') || webSearchActionGuard.has('test')) return;
+    const releaseCredential = webSearchActionGuard.begin('credential');
+    if (!releaseCredential) return;
     setPendingCredentialAction(action);
     try {
       await run();
     } finally {
-      pendingCredentialActionRef.current = null;
+      releaseCredential();
       if (webSearchMountedRef.current) {
         setPendingCredentialAction(null);
       }
@@ -94,13 +84,13 @@ export function WebSearchSettingsPage(props: {
   }
 
   async function setEnabled(enabled: boolean) {
-    if (pendingWebSearchEnabledRef.current) return;
-    pendingWebSearchEnabledRef.current = true;
+    const releaseEnabled = webSearchActionGuard.begin('set-enabled');
+    if (!releaseEnabled) return;
     setPendingWebSearchEnabled(true);
     try {
       await updateWebSearch({ enabled });
     } finally {
-      pendingWebSearchEnabledRef.current = false;
+      releaseEnabled();
       if (webSearchMountedRef.current) {
         setPendingWebSearchEnabled(false);
       }
@@ -144,8 +134,9 @@ export function WebSearchSettingsPage(props: {
   }
 
   async function runTest() {
-    if (testingRef.current || pendingCredentialActionRef.current !== null) return;
-    testingRef.current = true;
+    if (webSearchActionGuard.has('test') || webSearchActionGuard.has('credential')) return;
+    const releaseTest = webSearchActionGuard.begin('test');
+    if (!releaseTest) return;
     setTesting(true);
     const usesDraftKey = draftKey.trim().length > 0;
     const testedCredentialVersion = tavily.credentialVersion;
@@ -168,7 +159,7 @@ export function WebSearchSettingsPage(props: {
         toast.error('Tavily 测试出错', settingsActionErrorMessage(err));
       }
     } finally {
-      testingRef.current = false;
+      releaseTest();
       if (webSearchMountedRef.current) {
         setTesting(false);
       }
@@ -176,11 +167,12 @@ export function WebSearchSettingsPage(props: {
   }
 
   async function runLiveQuery() {
-    if (liveQueryRunningRef.current) return;
+    if (webSearchActionGuard.has('live-query')) return;
     const queryOwner = liveQueryInputRef.current;
     const trimmed = queryOwner.trim();
     if (trimmed.length === 0) return;
-    liveQueryRunningRef.current = true;
+    const releaseLiveQuery = webSearchActionGuard.begin('live-query');
+    if (!releaseLiveQuery) return;
     setLiveQueryRunning(true);
     setLiveQueryError(null);
     setLiveQueryResults(null);
@@ -208,7 +200,7 @@ export function WebSearchSettingsPage(props: {
         setLiveQueryError(settingsActionErrorMessage(err));
       }
     } finally {
-      liveQueryRunningRef.current = false;
+      releaseLiveQuery();
       if (webSearchMountedRef.current) {
         setLiveQueryRunning(false);
       }

--- a/packages/headless/src/__tests__/harness-ab-run.test.ts
+++ b/packages/headless/src/__tests__/harness-ab-run.test.ts
@@ -43,9 +43,13 @@ describe('runHarnessAbComparison', () => {
         ],
       });
 
+      // Bound is intentionally generous: the full headless suite runs many
+      // files under one `node --test` process, so a 100ms observe window was
+      // flaking under load even when all four arms did start. Concurrency
+      // breakage still fails (fourStarted never resolves).
       const observedFour = await Promise.race([
         fourStartedPromise.then(() => true),
-        new Promise<false>((resolve) => setTimeout(() => resolve(false), 100)),
+        new Promise<false>((resolve) => setTimeout(() => resolve(false), 5_000)),
       ]);
       release();
       await comparison;


### PR DESCRIPTION
## Summary

Settings pages reinvented two patterns: one-shot async action guards and (already partly fixed) optimistic drafts. This PR finishes the guard path and the connection-test failure helper dedupe for #1041.

- Add `useActionGuard` / `useKeyedActionGuard` (+ framework-free `createKeyedActionGuard`) and route ~15 hand-rolled settings guard sites through them.
- Share `connectionTestFailureFallback` / `connectionTestFailureMessage` in `provider-panel-shared` with injectable auth/recheck copy; migrate Models detail + Account page; delete private classifiers.
- Co-migrate source-grounded contracts (including PasswordInput) onto the shared seams without weakening assertions.
- Small test reliability fix: widen the headless harness A/B concurrency observe window so full `node --test` no longer flakes a 100ms race.

Refs #1041

### Remaining #1041 surface (not in this PR)
- `provider-oauth-section.tsx` / `bot-chat-settings-page.tsx` left alone (owned by parallel PR #1155 / issue #1042).
- Clipboard+toast collapse skipped: no existing shared seam; copies are surface-specific.
- Optimistic drafts already landed via #1146 (`useOptimisticSettingsDraft`); personalization was intentionally left out there.
- Dead `csvList` in bot-chat left alone (same parallel ownership).

## Verification

- `npm run typecheck` — pass (after `npm run build:test` post-rebase)
- Narrow: `node --test dist/main/__tests__/account-auth-ui.test.js dist/main/__tests__/model-oauth-section-contract.test.js dist/main/__tests__/settings-form-a11y-contract.test.js` — pass
- Headless isolation: `node ../../scripts/run-headless-tests.mjs` — pass (3× after observe-window fix)
- `npm run test:fast` — pass (all workspaces)
- Not run: full `npm run test` (clean rebuild path), E2E / Playwright, visual/screenshot checks (behavior-neutral refactor)

## Review focus

- Keyed guard semantics (`begin` vs `beginExclusive`, owner-checked release, unmount reset) and how ConnectionDetail multi-latch sites map onto them.
- Shared connection-test failure helper: classification table once, surface copy injected (`auth` / `recheck`); contracts pin both.