### PR TITLE
test(ui): pin draft/history helpers and relocate form seeds (#1044 follow-up)

### DIFF
--- a/packages/ui/src/__tests__/composer-helpers.test.ts
+++ b/packages/ui/src/__tests__/composer-helpers.test.ts
@@ -1,6 +1,13 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { reconcileHistorySync, type ComposerHistoryState } from '../composer-helpers.js';
+import {
+  navigateComposerHistory,
+  readComposerDraft,
+  reconcileHistorySync,
+  rememberComposerDraft,
+  rememberComposerHistoryEntry,
+  type ComposerHistoryState,
+} from '../composer-helpers.js';
 
 // reconcileHistorySync reconciles the Composer's in-memory history state
 // with what localStorage reports, right before a history-navigation keystroke
@@ -53,5 +60,148 @@ describe('reconcileHistorySync', () => {
     const current: ComposerHistoryState = { entries: [], index: -1, savedDraft: '保留的草稿' };
     const result = reconcileHistorySync(current, ['a']);
     assert.equal(result.state.savedDraft, '保留的草稿');
+  });
+});
+
+// The draft store backs useComposerDraft (issue #1044): the hook's
+// save/clear/swap paths all delegate here, so pin the store semantics the
+// hook relies on — no-op without a key, blank-means-delete, overwrite keeps
+// one entry, and both caps (120k chars, 32 keys) bound the Map.
+describe('rememberComposerDraft / readComposerDraft', () => {
+  it('is a no-op when the draft key is undefined', () => {
+    const store = new Map<string, string>();
+    rememberComposerDraft(store, undefined, 'hello');
+    assert.equal(store.size, 0);
+    assert.equal(readComposerDraft(store, undefined), '');
+  });
+
+  it('stores and reads back the draft under its key', () => {
+    const store = new Map<string, string>();
+    rememberComposerDraft(store, 'session-a', '草稿内容');
+    assert.equal(readComposerDraft(store, 'session-a'), '草稿内容');
+    assert.equal(readComposerDraft(store, 'session-b'), '');
+  });
+
+  it('deletes the entry when the remembered value is blank', () => {
+    const store = new Map<string, string>();
+    rememberComposerDraft(store, 'session-a', '草稿内容');
+    rememberComposerDraft(store, 'session-a', '   ');
+    assert.equal(store.has('session-a'), false);
+    assert.equal(readComposerDraft(store, 'session-a'), '');
+  });
+
+  it('overwrites an existing key without growing the store', () => {
+    const store = new Map<string, string>();
+    rememberComposerDraft(store, 'session-a', 'first');
+    rememberComposerDraft(store, 'session-a', 'second');
+    assert.equal(store.size, 1);
+    assert.equal(readComposerDraft(store, 'session-a'), 'second');
+  });
+
+  it('keeps only the trailing 120k characters of an over-long draft', () => {
+    const store = new Map<string, string>();
+    const head = 'H'.repeat(100);
+    const tail = 'T'.repeat(120_000);
+    rememberComposerDraft(store, 'session-a', head + tail);
+    const stored = readComposerDraft(store, 'session-a');
+    assert.equal(stored.length, 120_000);
+    assert.equal(stored, tail);
+  });
+
+  it('evicts the oldest key past 32 entries, and re-remembering refreshes recency', () => {
+    const store = new Map<string, string>();
+    for (let i = 0; i < 32; i++) rememberComposerDraft(store, `key-${i}`, `draft-${i}`);
+    assert.equal(store.size, 32);
+    // Refresh key-0 so key-1 becomes the oldest.
+    rememberComposerDraft(store, 'key-0', 'draft-0-fresh');
+    rememberComposerDraft(store, 'key-32', 'draft-32');
+    assert.equal(store.size, 32);
+    assert.equal(store.has('key-0'), true, 'refreshed key survives eviction');
+    assert.equal(store.has('key-1'), false, 'oldest untouched key is evicted first');
+    assert.equal(readComposerDraft(store, 'key-32'), 'draft-32');
+  });
+});
+
+// rememberComposerHistoryEntry backs useComposerHistory.rememberSentEntry —
+// the in-memory list mirrors the persisted global history (dedup + cap).
+describe('rememberComposerHistoryEntry', () => {
+  it('appends a trimmed new entry', () => {
+    assert.deepEqual(rememberComposerHistoryEntry(['a'], '  b  '), ['a', 'b']);
+  });
+
+  it('leaves the list unchanged for blank input', () => {
+    assert.deepEqual(rememberComposerHistoryEntry(['a'], '   '), ['a']);
+  });
+
+  it('dedups an existing entry by moving it to the newest position', () => {
+    assert.deepEqual(rememberComposerHistoryEntry(['a', 'b', 'c'], 'a'), ['b', 'c', 'a']);
+  });
+
+  it('evicts the oldest entry past 50 entries', () => {
+    const entries = Array.from({ length: 50 }, (_, i) => `entry-${i}`);
+    const next = rememberComposerHistoryEntry(entries, 'entry-50');
+    assert.equal(next.length, 50);
+    assert.equal(next[0], 'entry-1');
+    assert.equal(next[49], 'entry-50');
+  });
+});
+
+// navigateComposerHistory backs useComposerHistory.handleArrowKey — the
+// up/down recall transitions, including the saved-draft round trip the
+// textarea applies verbatim.
+describe('navigateComposerHistory', () => {
+  it('does nothing when history is empty', () => {
+    const state: ComposerHistoryState = { entries: [], index: -1, savedDraft: '' };
+    assert.deepEqual(navigateComposerHistory(state, 'previous', 'draft'), { state, value: 'draft', changed: false });
+  });
+
+  it('previous from idle recalls the newest entry and saves the current draft', () => {
+    const state: ComposerHistoryState = { entries: ['old', 'new'], index: -1, savedDraft: '' };
+    const result = navigateComposerHistory(state, 'previous', '正在输入');
+    assert.equal(result.changed, true);
+    assert.equal(result.value, 'new');
+    assert.deepEqual(result.state, { entries: ['old', 'new'], index: 1, savedDraft: '正在输入' });
+  });
+
+  it('previous walks older and clamps at the oldest entry', () => {
+    let state: ComposerHistoryState = { entries: ['old', 'new'], index: 1, savedDraft: 'draft' };
+    const first = navigateComposerHistory(state, 'previous', 'new');
+    assert.equal(first.value, 'old');
+    assert.equal(first.state.index, 0);
+    const clamped = navigateComposerHistory(first.state, 'previous', 'old');
+    assert.equal(clamped.value, 'old', 'stays on the oldest entry instead of wrapping');
+    assert.equal(clamped.state.index, 0);
+    assert.equal(clamped.changed, true);
+    state = clamped.state;
+    assert.equal(state.savedDraft, 'draft', 'the saved draft survives repeated previous');
+  });
+
+  it('next from idle is a no-op', () => {
+    const state: ComposerHistoryState = { entries: ['a'], index: -1, savedDraft: '' };
+    assert.deepEqual(navigateComposerHistory(state, 'next', 'draft'), { state, value: 'draft', changed: false });
+  });
+
+  it('next walks newer and restores the saved draft past the newest entry', () => {
+    const navigating: ComposerHistoryState = { entries: ['old', 'new'], index: 0, savedDraft: '我的草稿' };
+    const newer = navigateComposerHistory(navigating, 'next', 'old');
+    assert.equal(newer.value, 'new');
+    assert.equal(newer.state.index, 1);
+    const restored = navigateComposerHistory(newer.state, 'next', 'new');
+    assert.equal(restored.changed, true);
+    assert.equal(restored.value, '我的草稿');
+    assert.deepEqual(restored.state, { entries: ['old', 'new'], index: -1, savedDraft: '' });
+  });
+
+  it('round-trips a full up-up-down-down cycle back to the original draft', () => {
+    let state: ComposerHistoryState = { entries: ['one', 'two'], index: -1, savedDraft: '' };
+    let value = '原始输入';
+    for (const direction of ['previous', 'previous', 'next', 'next'] as const) {
+      const result = navigateComposerHistory(state, direction, value);
+      assert.equal(result.changed, true);
+      state = result.state;
+      value = result.value;
+    }
+    assert.equal(value, '原始输入');
+    assert.deepEqual(state, { entries: ['one', 'two'], index: -1, savedDraft: '' });
   });
 });

--- a/packages/ui/src/plan-reminder-form-dialog.tsx
+++ b/packages/ui/src/plan-reminder-form-dialog.tsx
@@ -27,14 +27,10 @@ import type {
 } from '@maka/core';
 import { BOT_DELIVERY_PROVIDERS, botDisplayLabel } from '@maka/core';
 import {
-  type PlanReminderExampleTemplate,
-  duplicatePlanReminderTitle,
+  type PlanReminderFormSeed,
   formatPlanDeliveryProviderList,
-  planReminderEditableRunAt,
   planReminderFormValidationMessage,
   planReminderPresetRunAt,
-  planReminderRecurrenceValue,
-  planReminderTemplateNextRunAt,
   toPlanReminderDateTimeInputValue,
 } from './plan-reminder-helpers.js';
 import { PlanReminderSelect } from './plan-reminder-select.js';
@@ -50,75 +46,6 @@ import type {
   PlanReminderDraftInput,
   PlanReminderUpdatePatch,
 } from './module-panel-types.js';
-
-/** Initial field values the dialog mounts with (one per open). */
-export interface PlanReminderFormSeed {
-  editingId: string | null;
-  title: string;
-  note: string;
-  runAtLocal: string;
-  recurrence: PlanReminderRecurrence;
-  cronExpression: string;
-  deliveryChannel: PlanReminderDeliveryTarget['channel'];
-  deliveryPlatform: BotProvider;
-  deliveryChatId: string;
-}
-
-/** Blank create-mode seed (one hour from now, no recurrence, local delivery). */
-export function createPlanReminderFormSeed(): PlanReminderFormSeed {
-  return {
-    editingId: null,
-    title: '',
-    note: '',
-    runAtLocal: toPlanReminderDateTimeInputValue(Date.now() + 60 * 60 * 1000),
-    recurrence: 'none',
-    cronExpression: '0 9 * * 1-5',
-    deliveryChannel: 'local',
-    deliveryPlatform: 'telegram',
-    deliveryChatId: '',
-  };
-}
-
-/** Create-mode seed prefilled from an example template. */
-export function planReminderTemplateSeed(template: PlanReminderExampleTemplate): PlanReminderFormSeed {
-  return {
-    ...createPlanReminderFormSeed(),
-    title: template.title,
-    note: template.note,
-    recurrence: template.recurrence,
-    cronExpression: template.cronExpression,
-    runAtLocal: toPlanReminderDateTimeInputValue(planReminderTemplateNextRunAt(template)),
-  };
-}
-
-function planReminderReminderSeed(reminder: PlanReminder): PlanReminderFormSeed {
-  return {
-    editingId: reminder.id,
-    title: reminder.title,
-    note: reminder.note,
-    runAtLocal: toPlanReminderDateTimeInputValue(planReminderEditableRunAt(reminder)),
-    recurrence: planReminderRecurrenceValue(reminder),
-    cronExpression: reminder.schedule.kind === 'cron' ? reminder.schedule.expression : '0 9 * * 1-5',
-    deliveryChannel: reminder.delivery.channel,
-    ...(reminder.delivery.channel === 'bot'
-      ? { deliveryPlatform: reminder.delivery.platform, deliveryChatId: reminder.delivery.chatId }
-      : { deliveryPlatform: 'telegram' as BotProvider, deliveryChatId: '' }),
-  };
-}
-
-/** Edit-mode seed prefilled from an existing reminder. */
-export function planReminderEditSeed(reminder: PlanReminder): PlanReminderFormSeed {
-  return planReminderReminderSeed(reminder);
-}
-
-/** Create-mode seed copying an existing reminder under a 副本 title. */
-export function planReminderDuplicateSeed(reminder: PlanReminder): PlanReminderFormSeed {
-  return {
-    ...planReminderReminderSeed(reminder),
-    editingId: null,
-    title: duplicatePlanReminderTitle(reminder.title),
-  };
-}
 
 export function PlanReminderFormDialog(props: {
   open: boolean;

--- a/packages/ui/src/plan-reminder-helpers.ts
+++ b/packages/ui/src/plan-reminder-helpers.ts
@@ -17,6 +17,7 @@
  */
 
 import type {
+  BotProvider,
   PlanReminder,
   PlanReminderDeliveryTarget,
   PlanReminderRecurrence,
@@ -296,4 +297,79 @@ export function runStatusLabel(status: NonNullable<PlanReminder['lastRun']>['sta
   if (status === 'triggered') return '已触发';
   if (status === 'blocked') return '已阻止';
   return '失败';
+}
+
+/**
+ * Initial field values for the plan-reminder form dialog
+ * (PlanReminderFormDialog, issue #1044). The panel builds one seed per open
+ * (create / template / edit / duplicate) and the dialog mounts with it, so
+ * the seeds are pure mappings — they live here with the other form helpers,
+ * not in the component file.
+ */
+export interface PlanReminderFormSeed {
+  editingId: string | null;
+  title: string;
+  note: string;
+  runAtLocal: string;
+  recurrence: PlanReminderRecurrence;
+  cronExpression: string;
+  deliveryChannel: PlanReminderDeliveryTarget['channel'];
+  deliveryPlatform: BotProvider;
+  deliveryChatId: string;
+}
+
+/** Blank create-mode seed (one hour from now, no recurrence, local delivery). */
+export function createPlanReminderFormSeed(): PlanReminderFormSeed {
+  return {
+    editingId: null,
+    title: '',
+    note: '',
+    runAtLocal: toPlanReminderDateTimeInputValue(Date.now() + 60 * 60 * 1000),
+    recurrence: 'none',
+    cronExpression: '0 9 * * 1-5',
+    deliveryChannel: 'local',
+    deliveryPlatform: 'telegram',
+    deliveryChatId: '',
+  };
+}
+
+/** Create-mode seed prefilled from an example template. */
+export function planReminderTemplateSeed(template: PlanReminderExampleTemplate): PlanReminderFormSeed {
+  return {
+    ...createPlanReminderFormSeed(),
+    title: template.title,
+    note: template.note,
+    recurrence: template.recurrence,
+    cronExpression: template.cronExpression,
+    runAtLocal: toPlanReminderDateTimeInputValue(planReminderTemplateNextRunAt(template)),
+  };
+}
+
+function planReminderReminderSeed(reminder: PlanReminder): PlanReminderFormSeed {
+  return {
+    editingId: reminder.id,
+    title: reminder.title,
+    note: reminder.note,
+    runAtLocal: toPlanReminderDateTimeInputValue(planReminderEditableRunAt(reminder)),
+    recurrence: planReminderRecurrenceValue(reminder),
+    cronExpression: reminder.schedule.kind === 'cron' ? reminder.schedule.expression : '0 9 * * 1-5',
+    deliveryChannel: reminder.delivery.channel,
+    ...(reminder.delivery.channel === 'bot'
+      ? { deliveryPlatform: reminder.delivery.platform, deliveryChatId: reminder.delivery.chatId }
+      : { deliveryPlatform: 'telegram' as BotProvider, deliveryChatId: '' }),
+  };
+}
+
+/** Edit-mode seed prefilled from an existing reminder. */
+export function planReminderEditSeed(reminder: PlanReminder): PlanReminderFormSeed {
+  return planReminderReminderSeed(reminder);
+}
+
+/** Create-mode seed copying an existing reminder under a 副本 title. */
+export function planReminderDuplicateSeed(reminder: PlanReminder): PlanReminderFormSeed {
+  return {
+    ...planReminderReminderSeed(reminder),
+    editingId: null,
+    title: duplicatePlanReminderTitle(reminder.title),
+  };
 }

--- a/packages/ui/src/plan-reminder-panel.tsx
+++ b/packages/ui/src/plan-reminder-panel.tsx
@@ -25,24 +25,22 @@ import {
 import {
   PLAN_REMINDER_EXAMPLE_TEMPLATES,
   type PlanReminderExampleTemplate,
+  type PlanReminderFormSeed,
   comparePlanReminderBySort,
+  createPlanReminderFormSeed,
   formatPlanRecurrence,
   formatReminderCountdown,
   formatReminderTime,
   normalizePlanReminderSearchQuery,
+  planReminderDuplicateSeed,
+  planReminderEditSeed,
   planReminderMatchesSearch,
   planReminderRunRangeStart,
   planReminderStatusLabel,
+  planReminderTemplateSeed,
   runStatusLabel,
 } from './plan-reminder-helpers.js';
-import {
-  PlanReminderFormDialog,
-  createPlanReminderFormSeed,
-  planReminderDuplicateSeed,
-  planReminderEditSeed,
-  planReminderTemplateSeed,
-  type PlanReminderFormSeed,
-} from './plan-reminder-form-dialog.js';
+import { PlanReminderFormDialog } from './plan-reminder-form-dialog.js';
 import { PlanReminderSelect } from './plan-reminder-select.js';
 import {
   Button as UiButton,


### PR DESCRIPTION
## Summary

Follow-up polish to #1153 (Closes #1044 already shipped). Behavior-neutral only:

1. **Pure unit coverage** for the composer draft/history helpers that back `useComposerDraft` / `useComposerHistory` (`rememberComposerDraft`/`readComposerDraft`, `rememberComposerHistoryEntry`, `navigateComposerHistory`) — closes the untested-gap note from the #1153 review.
2. **Move** `PlanReminderFormSeed` + create/template/edit/duplicate seed builders from `plan-reminder-form-dialog.tsx` into `plan-reminder-helpers.ts` (pure mappings). Panel imports seeds from helpers; dialog stays the React owner of field state + submit.

No behavior or visual change; no contract weakening.

## Verification

- `npm --workspace @maka/ui run build` + `typecheck` — clean.
- `node --test packages/ui/dist/__tests__/composer-helpers.test.js` — 22/22 pass (includes the new draft/history suites).
- `npm --workspace @maka/ui run test:dist` — 184/184 pass.
- `npm --workspace @maka/desktop run typecheck` — clean.
- Related desktop contracts (plan-reminder-panel, command-palette-plan-reminder, renderer-utility-primitives, visible-copy-hygiene, settings-roadmap-cleanup, composer-send-guard) — 63/63 pass.
- Not run: e2e / visual smoke (no DOM/behavior change).

## Review focus

Seed move is mechanical (same functions, new module). Prefer reading the new pure tests against `composer-helpers.ts` for the draft Map caps and history navigation round trip.