### PR TITLE
refactor(security): reconcile containment guards and cell-timeout parsing

### DIFF
--- a/apps/desktop/src/main/explore-agent-tool.ts
+++ b/apps/desktop/src/main/explore-agent-tool.ts
@@ -1,7 +1,7 @@
 import { lstat, readdir, readFile, realpath, stat } from 'node:fs/promises';
 import { basename, extname, join, resolve } from 'node:path';
 import { z } from 'zod';
-import { isInside, toRelative, type MakaTool } from '@maka/runtime';
+import { isPathInside, toRelative, type MakaTool } from '@maka/runtime';
 
 export const EXPLORE_AGENT_TOOL_NAME = 'ExploreAgent';
 
@@ -266,12 +266,12 @@ export async function runReadOnlyExplore(input: {
       return abortFailure(objective, roots, queryTerms, ignoredPaths, stoppingCondition, progress, startedAt);
     }
     const resolved = resolve(workspaceRoot, root);
-    if (!isInside(workspaceRoot, resolved)) {
+    if (!isPathInside(workspaceRoot, resolved)) {
       return failure('invalid_root', objective, roots, queryTerms, ignoredPaths, stoppingCondition, `root 必须位于会话工作目录内：${root}`, progress, startedAt);
     }
     try {
       const actual = await realpath(resolved);
-      if (!isInside(workspaceRoot, actual)) {
+      if (!isPathInside(workspaceRoot, actual)) {
         return failure('invalid_root', objective, roots, queryTerms, ignoredPaths, stoppingCondition, `root 不能穿过符号链接离开工作目录：${root}`, progress, startedAt);
       }
       const rootStat = await stat(actual);
@@ -637,7 +637,7 @@ async function listTextFiles(
         return;
       }
       const child = join(abs, entry.name);
-      if (!isInside(workspaceRoot, child)) {
+      if (!isPathInside(workspaceRoot, child)) {
         skipped++;
         continue;
       }

--- a/apps/desktop/src/main/managed-skill-sources.ts
+++ b/apps/desktop/src/main/managed-skill-sources.ts
@@ -2,7 +2,7 @@ import { createHash } from 'node:crypto';
 import { homedir } from 'node:os';
 import { basename, dirname, extname, isAbsolute, join } from 'node:path';
 import { lstat, mkdir, readdir, readFile, realpath, rename, unlink, writeFile } from 'node:fs/promises';
-import { isContainedPath, isSafeSkillId, validateSkillMetadata, type SkillValidationIssue } from '@maka/runtime';
+import { isPathInside, isSafeSkillId, validateSkillMetadata, type SkillValidationIssue } from '@maka/runtime';
 
 /**
  * Fixed marketplace taxonomy. A source's `category:` front-matter is
@@ -183,7 +183,7 @@ export async function readManagedSkillSource(
     const sourceStat = await lstat(sourcePath);
     if (!sourceStat.isFile() || sourceStat.isSymbolicLink()) return { ok: false, reason: 'blocked_path' };
     const sourceReal = await realpath(sourcePath);
-    if (!isContainedPath(sourceDirReal.path, sourceReal)) return { ok: false, reason: 'blocked_path' };
+    if (!isPathInside(sourceDirReal.path, sourceReal)) return { ok: false, reason: 'blocked_path' };
     const bytes = await readFile(sourcePath);
     const contentSha256 = `sha256:${sha256(bytes)}`;
     const content = bytes.toString('utf8');
@@ -236,7 +236,7 @@ async function resolveContainedDirectory(rootReal: string, directory: string): P
     const directoryStat = await lstat(directory);
     if (!directoryStat.isDirectory() || directoryStat.isSymbolicLink()) return { ok: false, reason: 'blocked_path' };
     const directoryReal = await realpath(directory);
-    if (!isContainedPath(rootReal, directoryReal)) return { ok: false, reason: 'blocked_path' };
+    if (!isPathInside(rootReal, directoryReal)) return { ok: false, reason: 'blocked_path' };
     return { ok: true, path: directoryReal };
   } catch {
     return { ok: false, reason: 'not_found' };
@@ -260,7 +260,7 @@ async function writeContainedBufferFile(
       if (options.failIfExists) return false;
       if (!existing.isFile() || existing.isSymbolicLink()) return false;
       const fileReal = await realpath(filePath);
-      if (!isContainedPath(rootReal, fileReal)) return false;
+      if (!isPathInside(rootReal, fileReal)) return false;
     }
     await writeFile(tempPath, bytes, { flag: 'wx', mode: 0o600 });
     const tempStat = await lstat(tempPath);
@@ -269,7 +269,7 @@ async function writeContainedBufferFile(
       return false;
     }
     const tempReal = await realpath(tempPath);
-    if (!isContainedPath(rootReal, tempReal)) {
+    if (!isPathInside(rootReal, tempReal)) {
       await unlink(tempPath).catch(() => {});
       return false;
     }

--- a/apps/desktop/src/main/office-document-tool.ts
+++ b/apps/desktop/src/main/office-document-tool.ts
@@ -3,7 +3,7 @@ import { lstat, realpath } from 'node:fs/promises';
 import { dirname, extname, isAbsolute, resolve } from 'node:path';
 import { z } from 'zod';
 import { redactSecrets } from '@maka/core/redaction';
-import { isInside, toRelative, type MakaTool } from '@maka/runtime';
+import { isPathInside, toRelative, type MakaTool } from '@maka/runtime';
 import { buildOfficeCliEnv } from './officecli-env.js';
 
 export const OFFICE_DOCUMENT_TOOL_NAME = 'OfficeDocument';
@@ -409,7 +409,7 @@ async function resolveOfficeDocumentPath(cwd: string, inputPath: unknown): Promi
 
   const workspaceRoot = await realpath(cwd);
   const abs = resolve(workspaceRoot, inputPath);
-  if (!isInside(workspaceRoot, abs)) {
+  if (!isPathInside(workspaceRoot, abs)) {
     return { ok: false, reason: 'invalid_path', message: 'Office 文档路径不能离开工作目录。' };
   }
   const ext = extname(abs).toLowerCase();
@@ -431,7 +431,7 @@ async function resolveOfficeDocumentPath(cwd: string, inputPath: unknown): Promi
   }
 
   const actual = await realpath(abs);
-  if (!isInside(workspaceRoot, actual)) {
+  if (!isPathInside(workspaceRoot, actual)) {
     return { ok: false, reason: 'symlink_escape', message: 'Office 文档路径不能通过符号链接离开工作目录。' };
   }
   return { ok: true, workspaceRoot, abs: actual, rel: toRelative(workspaceRoot, actual) };
@@ -451,7 +451,7 @@ async function resolveNewOfficeDocumentPath(cwd: string, inputPath: unknown): Pr
 
   const workspaceRoot = await realpath(cwd);
   const abs = resolve(workspaceRoot, inputPath);
-  if (!isInside(workspaceRoot, abs)) {
+  if (!isPathInside(workspaceRoot, abs)) {
     return { ok: false, reason: 'invalid_path', message: 'Office 文档路径不能离开工作目录。' };
   }
   const ext = extname(abs).toLowerCase();
@@ -481,7 +481,7 @@ async function resolveNewOfficeDocumentPath(cwd: string, inputPath: unknown): Pr
     return { ok: false, reason: 'not_file', message: 'Office 文档所在路径必须是文件夹。' };
   }
   const actualParent = await realpath(parent);
-  if (!isInside(workspaceRoot, actualParent)) {
+  if (!isPathInside(workspaceRoot, actualParent)) {
     return { ok: false, reason: 'symlink_escape', message: 'Office 文档路径不能通过符号链接离开工作目录。' };
   }
   return { ok: true, workspaceRoot, abs, rel: toRelative(workspaceRoot, abs) };

--- a/apps/desktop/src/main/skills.ts
+++ b/apps/desktop/src/main/skills.ts
@@ -2,7 +2,7 @@ import { createHash } from 'node:crypto';
 import { lstat, mkdir, readFile, realpath, rename, rm, stat, unlink, writeFile } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
 import {
-  isContainedPath,
+  isPathInside,
   isRecord,
   isSafeSkillId,
   parseSkillFrontMatter,
@@ -258,7 +258,7 @@ export async function ensureBundledOfficeSkills(root: string): Promise<{ created
       return { created, updated, skipped, failed: BUNDLED_OFFICE_SKILLS.map((skill) => skill.id) };
     }
     [rootReal, skillsReal] = await Promise.all([realpath(root), realpath(skillsDir)]);
-    if (!isContainedPath(rootReal, skillsReal)) {
+    if (!isPathInside(rootReal, skillsReal)) {
       return { created, updated, skipped, failed: BUNDLED_OFFICE_SKILLS.map((skill) => skill.id) };
     }
   } catch {
@@ -273,7 +273,7 @@ export async function ensureBundledOfficeSkills(root: string): Promise<{ created
         if (error.code !== 'EEXIST') throw error;
       });
       const skillReal = await realpath(skillDir);
-      if (!isContainedPath(skillsReal, skillReal)) {
+      if (!isPathInside(skillsReal, skillReal)) {
         failed.push(skill.id);
         continue;
       }
@@ -453,7 +453,7 @@ export async function createStarterSkill(root: string): Promise<CreateStarterSki
 
     try {
       const skillReal = await realpath(skillDir);
-      if (!isContainedPath(skillsReal, skillReal)) {
+      if (!isPathInside(skillsReal, skillReal)) {
         return { ok: false, reason: 'blocked_path' };
       }
 
@@ -504,7 +504,7 @@ export async function deleteSkill(root: string, id: string): Promise<DeleteSkill
     const [rootReal, skillsStat] = await Promise.all([realpath(root), lstat(skillsDir)]);
     if (!skillsStat.isDirectory() || skillsStat.isSymbolicLink()) return { ok: false, reason: 'blocked_path' };
     skillsReal = await realpath(skillsDir);
-    if (!isContainedPath(rootReal, skillsReal)) return { ok: false, reason: 'blocked_path' };
+    if (!isPathInside(rootReal, skillsReal)) return { ok: false, reason: 'blocked_path' };
   } catch {
     return { ok: false, reason: 'not_found' };
   }
@@ -519,7 +519,7 @@ export async function deleteSkill(root: string, id: string): Promise<DeleteSkill
     if ((error as NodeJS.ErrnoException).code === 'ENOENT') return { ok: false, reason: 'not_found' };
     return { ok: false, reason: 'blocked_path' };
   }
-  if (!isContainedPath(skillsReal, skillReal)) return { ok: false, reason: 'blocked_path' };
+  if (!isPathInside(skillsReal, skillReal)) return { ok: false, reason: 'blocked_path' };
 
   try {
     await rm(skillReal, { recursive: true });
@@ -552,7 +552,7 @@ export async function installManagedSkill(
     if (!skillsStat.isDirectory() || skillsStat.isSymbolicLink()) return { ok: false, reason: 'blocked_path' };
     const rootReal = await realpath(root);
     skillsReal = await realpath(skillsDir);
-    if (!isContainedPath(rootReal, skillsReal)) return { ok: false, reason: 'blocked_path' };
+    if (!isPathInside(rootReal, skillsReal)) return { ok: false, reason: 'blocked_path' };
   } catch {
     return { ok: false, reason: 'write_failed' };
   }
@@ -564,7 +564,7 @@ export async function installManagedSkill(
     await mkdir(skillDir, { mode: 0o700 });
     createdSkillDir = true;
     const skillReal = await realpath(skillDir);
-    if (!isContainedPath(skillsReal, skillReal)) {
+    if (!isPathInside(skillsReal, skillReal)) {
       if (createdSkillDir) await rm(skillDir, { recursive: true, force: true }).catch(() => {});
       return { ok: false, reason: 'blocked_path' };
     }
@@ -675,7 +675,7 @@ export async function installBundledSkill(root: string, id: string): Promise<Ins
     if (!skillsStat.isDirectory() || skillsStat.isSymbolicLink()) return { ok: false, reason: 'blocked_path' };
     const rootReal = await realpath(root);
     skillsReal = await realpath(skillsDir);
-    if (!isContainedPath(rootReal, skillsReal)) return { ok: false, reason: 'blocked_path' };
+    if (!isPathInside(rootReal, skillsReal)) return { ok: false, reason: 'blocked_path' };
   } catch {
     return { ok: false, reason: 'write_failed' };
   }
@@ -687,7 +687,7 @@ export async function installBundledSkill(root: string, id: string): Promise<Ins
     await mkdir(skillDir, { mode: 0o700 });
     createdSkillDir = true;
     const skillReal = await realpath(skillDir);
-    if (!isContainedPath(skillsReal, skillReal)) {
+    if (!isPathInside(skillsReal, skillReal)) {
       await rm(skillDir, { recursive: true, force: true }).catch(() => {});
       return { ok: false, reason: 'blocked_path' };
     }
@@ -751,7 +751,7 @@ export async function updateManagedSkill(
       readContainedRegularTextFile(skillDir, skillFile),
       readContainedRegularTextFile(skillDir, lockFile),
     ]);
-    if (!isContainedPath(skillsReal, skillReal)) return { ok: false, reason: 'blocked_path' };
+    if (!isPathInside(skillsReal, skillReal)) return { ok: false, reason: 'blocked_path' };
     if (!current.ok) return { ok: false, reason: current.reason === 'blocked_path' ? 'blocked_path' : 'write_failed' };
     if (!currentLock.ok) return { ok: false, reason: currentLock.reason === 'blocked_path' ? 'blocked_path' : 'write_failed' };
 
@@ -811,17 +811,17 @@ async function resolveSkillFileUpdateTarget(root: string, skillId: string): Prom
     const [rootReal, skillsStat] = await Promise.all([realpath(root), lstat(skillsDir)]);
     if (!skillsStat.isDirectory() || skillsStat.isSymbolicLink()) return { ok: false, reason: 'blocked_path' };
     const skillsReal = await realpath(skillsDir);
-    if (!isContainedPath(rootReal, skillsReal)) return { ok: false, reason: 'blocked_path' };
+    if (!isPathInside(rootReal, skillsReal)) return { ok: false, reason: 'blocked_path' };
 
     const skillStat = await lstat(skillDir);
     if (!skillStat.isDirectory() || skillStat.isSymbolicLink()) return { ok: false, reason: 'blocked_path' };
     const skillReal = await realpath(skillDir);
-    if (!isContainedPath(skillsReal, skillReal)) return { ok: false, reason: 'blocked_path' };
+    if (!isPathInside(skillsReal, skillReal)) return { ok: false, reason: 'blocked_path' };
 
     const fileStat = await lstat(skillFile);
     if (!fileStat.isFile() || fileStat.isSymbolicLink()) return { ok: false, reason: 'blocked_path' };
     const fileReal = await realpath(skillFile);
-    if (!isContainedPath(skillReal, fileReal)) return { ok: false, reason: 'blocked_path' };
+    if (!isPathInside(skillReal, fileReal)) return { ok: false, reason: 'blocked_path' };
     return { ok: true };
   } catch {
     return { ok: false, reason: 'missing' };
@@ -876,7 +876,7 @@ export async function previewManagedSkillUpdate(
       realpath(skillDir),
       readContainedRegularTextFile(skillDir, skillFile),
     ]);
-    if (!isContainedPath(skillsReal, skillReal)) return { ok: false, reason: 'blocked_path' };
+    if (!isPathInside(skillsReal, skillReal)) return { ok: false, reason: 'blocked_path' };
     if (!current.ok) return { ok: false, reason: current.reason === 'blocked_path' ? 'blocked_path' : 'read_failed' };
     const baselineContent = await readManagedSkillBaseline(skillDir);
     return {
@@ -971,7 +971,7 @@ async function removeManagedSkillBaseline(skillDir: string): Promise<void> {
   if (fileStat === null) return;
   if (!fileStat.isFile() || fileStat.isSymbolicLink()) return;
   const fileReal = await realpath(baselineFile);
-  if (!isContainedPath(baselineReal, fileReal)) return;
+  if (!isPathInside(baselineReal, fileReal)) return;
   await unlink(baselineFile);
 }
 
@@ -996,7 +996,7 @@ async function resolveManagedSkillBaselineDir(skillDir: string): Promise<
       return { ok: false };
     }
     const [metadataReal, baselineReal] = await Promise.all([realpath(metadataDir), realpath(baselineDir)]);
-    if (!isContainedPath(skillReal, metadataReal) || !isContainedPath(metadataReal, baselineReal)) return { ok: false };
+    if (!isPathInside(skillReal, metadataReal) || !isPathInside(metadataReal, baselineReal)) return { ok: false };
     return { ok: true, baselineDir };
   } catch {
     return { ok: false };
@@ -1083,7 +1083,7 @@ export async function resolveSkillOpenPath(
   } catch {
     return { ok: false, reason: 'missing' };
   }
-  if (!isContainedPath(rootReal, skillsReal)) return { ok: false, reason: 'blocked_path' };
+  if (!isPathInside(rootReal, skillsReal)) return { ok: false, reason: 'blocked_path' };
 
   const skillDir = join(skillsDir, id);
   const candidate = target === 'file' ? join(skillDir, 'SKILL.md') : skillDir;
@@ -1093,7 +1093,7 @@ export async function resolveSkillOpenPath(
   } catch {
     return { ok: false, reason: 'missing' };
   }
-  if (!isContainedPath(skillsReal, openedPath)) return { ok: false, reason: 'blocked_path' };
+  if (!isPathInside(skillsReal, openedPath)) return { ok: false, reason: 'blocked_path' };
 
   const openedStat = await stat(openedPath).catch(() => null);
   if (!openedStat) return { ok: false, reason: 'missing' };

--- a/packages/headless/harbor/maka_agent.py
+++ b/packages/headless/harbor/maka_agent.py
@@ -77,6 +77,15 @@ def _host_node_process_env(cell_env: dict[str, str]) -> dict[str, str]:
     return env
 
 
+# 2^53 - 1, matches JS Number.MAX_SAFE_INTEGER so the TS host and this adapter
+# agree on the upper bound for MAKA_CELL_TIMEOUT_SEC; an over-long digit string
+# is malformed, not a giant timeout.
+_MAX_SAFE_INTEGER = 9007199254740991
+# ASCII decimal positive integer literal only; [0-9] (not \d) rejects Unicode
+# digits on both sides. Matches the TS host's lenientPositiveIntEnv.
+_POSITIVE_INT_RE = re.compile(r"[1-9][0-9]*")
+
+
 class MakaAgent(BaseInstalledAgent):
     """Run Maka inside the Harbor task container and expose the shared cell output."""
 
@@ -267,17 +276,26 @@ class MakaAgent(BaseInstalledAgent):
         slow-but-healthy tasks into infra failures, so the operator can raise it
         via MAKA_CELL_TIMEOUT_SEC; a malformed value falls back to the default.
 
-        Accepted syntax is a decimal positive integer literal (no sign, no
-        leading zero, no exponent or decimal form), matching the TS host's
-        lenientPositiveIntEnv so both sides agree on exactly which strings are
-        valid: "1e3", "1.0", "+1800", "01800" all fall back to the default.
+        Accepted syntax is an ASCII decimal positive integer literal (no sign,
+        no leading zero, no exponent/decimal form, no Unicode digits), and the
+        value is capped at 2^53 - 1 (JS Number.MAX_SAFE_INTEGER). This matches
+        the TS host's lenientPositiveIntEnv so both sides agree on exactly which
+        strings are valid: "1e3", "1.0", "+1800", "01800", "1٢", and over-long
+        digit strings all fall back to the default.
         """
         raw = self._get_env("MAKA_CELL_TIMEOUT_SEC")
         if not raw:
             return self._DEFAULT_CELL_TIMEOUT_SEC
-        if re.fullmatch(r"[1-9]\d*", raw.strip()) is None:
+        stripped = raw.strip()
+        if _POSITIVE_INT_RE.fullmatch(stripped) is None:
             return self._DEFAULT_CELL_TIMEOUT_SEC
-        return int(raw.strip())
+        try:
+            value = int(stripped)
+        except ValueError:
+            # CPython caps integer-string conversion length; an over-long value
+            # is malformed, not a giant timeout.
+            return self._DEFAULT_CELL_TIMEOUT_SEC
+        return value if value <= _MAX_SAFE_INTEGER else self._DEFAULT_CELL_TIMEOUT_SEC
 
     def _cell_settlement_grace_sec(self) -> int:
         raw = self._get_env("MAKA_CELL_SETTLEMENT_GRACE_SEC")

--- a/packages/headless/harbor/maka_agent.py
+++ b/packages/headless/harbor/maka_agent.py
@@ -7,6 +7,7 @@ import concurrent.futures
 import contextlib
 import json
 import os
+import re
 import secrets
 import shlex
 import threading
@@ -264,15 +265,19 @@ class MakaAgent(BaseInstalledAgent):
     def _cell_timeout_sec(self) -> int:
         """Wall-clock budget for the in-container cell. A hard-coded value turns
         slow-but-healthy tasks into infra failures, so the operator can raise it
-        via MAKA_CELL_TIMEOUT_SEC; a malformed value falls back to the default."""
+        via MAKA_CELL_TIMEOUT_SEC; a malformed value falls back to the default.
+
+        Accepted syntax is a decimal positive integer literal (no sign, no
+        leading zero, no exponent or decimal form), matching the TS host's
+        lenientPositiveIntEnv so both sides agree on exactly which strings are
+        valid: "1e3", "1.0", "+1800", "01800" all fall back to the default.
+        """
         raw = self._get_env("MAKA_CELL_TIMEOUT_SEC")
         if not raw:
             return self._DEFAULT_CELL_TIMEOUT_SEC
-        try:
-            value = int(raw)
-        except (TypeError, ValueError):
+        if re.fullmatch(r"[1-9]\d*", raw.strip()) is None:
             return self._DEFAULT_CELL_TIMEOUT_SEC
-        return value if value > 0 else self._DEFAULT_CELL_TIMEOUT_SEC
+        return int(raw.strip())
 
     def _cell_settlement_grace_sec(self) -> int:
         raw = self._get_env("MAKA_CELL_SETTLEMENT_GRACE_SEC")

--- a/packages/headless/src/__tests__/harbor-adapter.test.ts
+++ b/packages/headless/src/__tests__/harbor-adapter.test.ts
@@ -1421,14 +1421,17 @@ with tempfile.TemporaryDirectory() as tmp:
     assert gateway_env["MAKA_CONTEXT_FOO"] == "1", gateway_env
 
     # Cell wall-clock timeout is operator-configurable with a safe default and a
-    # fallback for malformed or non-positive values. Both sides accept a decimal
-    # positive integer literal only (regex [1-9]\d*), so "+1800"/"01800" miss.
+    # fallback for malformed or non-positive values. Both sides accept an ASCII
+    # decimal positive integer literal only (regex [1-9][0-9]*) capped at 2^53-1,
+    # so "+1800"/"01800"/"1٢"/over-long digit strings all miss.
     assert MakaAgent(Path(tmp))._cell_timeout_sec() == 900
     assert MakaAgent(Path(tmp), extra_env={"MAKA_CELL_TIMEOUT_SEC": "1800"})._cell_timeout_sec() == 1800
     assert MakaAgent(Path(tmp), extra_env={"MAKA_CELL_TIMEOUT_SEC": "oops"})._cell_timeout_sec() == 900
     assert MakaAgent(Path(tmp), extra_env={"MAKA_CELL_TIMEOUT_SEC": "0"})._cell_timeout_sec() == 900
     assert MakaAgent(Path(tmp), extra_env={"MAKA_CELL_TIMEOUT_SEC": "+1800"})._cell_timeout_sec() == 900
     assert MakaAgent(Path(tmp), extra_env={"MAKA_CELL_TIMEOUT_SEC": "01800"})._cell_timeout_sec() == 900
+    assert MakaAgent(Path(tmp), extra_env={"MAKA_CELL_TIMEOUT_SEC": "1٢"})._cell_timeout_sec() == 900
+    assert MakaAgent(Path(tmp), extra_env={"MAKA_CELL_TIMEOUT_SEC": "9" * 5000})._cell_timeout_sec() == 900
     assert MakaAgent(Path(tmp))._cell_soft_timeout_ms() == 870000
     assert MakaAgent(Path(tmp), extra_env={
         "MAKA_CELL_TIMEOUT_SEC": "1800",

--- a/packages/headless/src/__tests__/harbor-adapter.test.ts
+++ b/packages/headless/src/__tests__/harbor-adapter.test.ts
@@ -1421,11 +1421,14 @@ with tempfile.TemporaryDirectory() as tmp:
     assert gateway_env["MAKA_CONTEXT_FOO"] == "1", gateway_env
 
     # Cell wall-clock timeout is operator-configurable with a safe default and a
-    # fallback for malformed or non-positive values.
+    # fallback for malformed or non-positive values. Both sides accept a decimal
+    # positive integer literal only (regex [1-9]\d*), so "+1800"/"01800" miss.
     assert MakaAgent(Path(tmp))._cell_timeout_sec() == 900
     assert MakaAgent(Path(tmp), extra_env={"MAKA_CELL_TIMEOUT_SEC": "1800"})._cell_timeout_sec() == 1800
     assert MakaAgent(Path(tmp), extra_env={"MAKA_CELL_TIMEOUT_SEC": "oops"})._cell_timeout_sec() == 900
     assert MakaAgent(Path(tmp), extra_env={"MAKA_CELL_TIMEOUT_SEC": "0"})._cell_timeout_sec() == 900
+    assert MakaAgent(Path(tmp), extra_env={"MAKA_CELL_TIMEOUT_SEC": "+1800"})._cell_timeout_sec() == 900
+    assert MakaAgent(Path(tmp), extra_env={"MAKA_CELL_TIMEOUT_SEC": "01800"})._cell_timeout_sec() == 900
     assert MakaAgent(Path(tmp))._cell_soft_timeout_ms() == 870000
     assert MakaAgent(Path(tmp), extra_env={
         "MAKA_CELL_TIMEOUT_SEC": "1800",

--- a/packages/headless/src/__tests__/harbor-task-runner.test.ts
+++ b/packages/headless/src/__tests__/harbor-task-runner.test.ts
@@ -1215,10 +1215,8 @@ describe('buildHarborJobConfig', () => {
     // Shared contract with the Python adapter (maka_agent.py _cell_timeout_sec):
     // an unparseable or non-positive MAKA_CELL_TIMEOUT_SEC falls back to the task
     // metadata timeout, or passes through for the adapter to apply its default.
-    // The "1e3" / "1.0" rows lock a known divergence from Python int() syntax:
-    // Number(raw) accepts them and the host rewrites the env to the parsed
-    // integer before the container sees it; unifying the accepted syntax is
-    // deferred to the fail-loud follow-up noted in PR #1137.
+    // Accepted syntax matches Python int(): a decimal positive integer literal
+    // only, so "1e3" / "1.0" are treated as a miss (unified in #1145).
     const cases: Array<{ raw: string | undefined; parsed: number | undefined }> = [
       { raw: undefined, parsed: undefined },
       { raw: '', parsed: undefined },
@@ -1226,8 +1224,8 @@ describe('buildHarborJobConfig', () => {
       { raw: 'oops', parsed: undefined },
       { raw: '0', parsed: undefined },
       { raw: '-5', parsed: undefined },
-      { raw: '1e3', parsed: 1000 },
-      { raw: '1.0', parsed: 1 },
+      { raw: '1e3', parsed: undefined },
+      { raw: '1.0', parsed: undefined },
       { raw: '1800', parsed: 1800 },
     ];
     for (const { raw, parsed } of cases) {

--- a/packages/headless/src/__tests__/harbor-task-runner.test.ts
+++ b/packages/headless/src/__tests__/harbor-task-runner.test.ts
@@ -1215,9 +1215,10 @@ describe('buildHarborJobConfig', () => {
     // Shared contract with the Python adapter (maka_agent.py _cell_timeout_sec):
     // an unparseable or non-positive MAKA_CELL_TIMEOUT_SEC falls back to the task
     // metadata timeout, or passes through for the adapter to apply its default.
-    // Both sides accept a decimal positive integer literal only (regex [1-9]\d*),
-    // so "1e3" / "1.0" / "+1800" / "01800" are a miss; the over-long row locks
-    // the JS guard that keeps Number() overflow (Infinity) out (unified in #1145).
+    // Both sides accept an ASCII decimal positive integer literal only
+    // (regex [1-9][0-9]*) capped at 2^53-1, so "1e3"/"1.0"/"+1800"/"01800"/"1٢"
+    // are a miss; the over-long row locks the JS guard against Number() overflow
+    // (unified in #1145).
     const cases: Array<{ raw: string | undefined; parsed: number | undefined }> = [
       { raw: undefined, parsed: undefined },
       { raw: '', parsed: undefined },
@@ -1230,6 +1231,7 @@ describe('buildHarborJobConfig', () => {
       { raw: '1800', parsed: 1800 },
       { raw: '+1800', parsed: undefined },
       { raw: '01800', parsed: undefined },
+      { raw: '1٢', parsed: undefined },
       { raw: '9'.repeat(400), parsed: undefined },
     ];
     for (const { raw, parsed } of cases) {

--- a/packages/headless/src/__tests__/harbor-task-runner.test.ts
+++ b/packages/headless/src/__tests__/harbor-task-runner.test.ts
@@ -1215,8 +1215,9 @@ describe('buildHarborJobConfig', () => {
     // Shared contract with the Python adapter (maka_agent.py _cell_timeout_sec):
     // an unparseable or non-positive MAKA_CELL_TIMEOUT_SEC falls back to the task
     // metadata timeout, or passes through for the adapter to apply its default.
-    // Accepted syntax matches Python int(): a decimal positive integer literal
-    // only, so "1e3" / "1.0" are treated as a miss (unified in #1145).
+    // Both sides accept a decimal positive integer literal only (regex [1-9]\d*),
+    // so "1e3" / "1.0" / "+1800" / "01800" are a miss; the over-long row locks
+    // the JS guard that keeps Number() overflow (Infinity) out (unified in #1145).
     const cases: Array<{ raw: string | undefined; parsed: number | undefined }> = [
       { raw: undefined, parsed: undefined },
       { raw: '', parsed: undefined },
@@ -1227,6 +1228,9 @@ describe('buildHarborJobConfig', () => {
       { raw: '1e3', parsed: undefined },
       { raw: '1.0', parsed: undefined },
       { raw: '1800', parsed: 1800 },
+      { raw: '+1800', parsed: undefined },
+      { raw: '01800', parsed: undefined },
+      { raw: '9'.repeat(400), parsed: undefined },
     ];
     for (const { raw, parsed } of cases) {
       const agentEnv: Record<string, string> = raw === undefined ? {} : { MAKA_CELL_TIMEOUT_SEC: raw };

--- a/packages/headless/src/headless-run-env.ts
+++ b/packages/headless/src/headless-run-env.ts
@@ -121,15 +121,20 @@ export function positiveIntEnv(raw: string | undefined, name: string): number | 
  * Python adapter recovers from a malformed `MAKA_CELL_TIMEOUT_SEC`
  * (`maka_agent.py` `_cell_timeout_sec`: "a malformed value falls back to the
  * default") and the TS runner must not fail loudly where the adapter would
- * recover. Accepted syntax matches Python `int()` on this variable: a decimal
- * positive integer literal only (`"1800"`), so `"1e3"` / `"1.0"` / non-numeric
- * forms are all a parse miss. New TS-only env vars should use the throwing
+ * recover. Accepted syntax is a decimal positive integer literal (`"1800"`)
+ * only — the same `[1-9]\d*` form the Python adapter enforces, so `"1e3"`,
+ * `"1.0"`, `"+1800"`, `"01800"`, and non-numeric forms are all a parse miss on
+ * both sides. Values are capped at `Number.isSafeInteger`, so an over-long
+ * digit string (which `Number()` would coerce to `Infinity`) still falls back
+ * rather than slipping through. New TS-only env vars should use the throwing
  * `positiveIntEnv` instead.
  */
 export function lenientPositiveIntEnv(raw: string | undefined): number | undefined {
   if (raw === undefined) return undefined;
   const value = raw.trim();
-  return /^[1-9]\d*$/.test(value) ? Number(value) : undefined;
+  if (!/^[1-9]\d*$/.test(value)) return undefined;
+  const parsed = Number(value);
+  return Number.isSafeInteger(parsed) ? parsed : undefined;
 }
 
 /**

--- a/packages/headless/src/headless-run-env.ts
+++ b/packages/headless/src/headless-run-env.ts
@@ -117,22 +117,19 @@ export function positiveIntEnv(raw: string | undefined, name: string): number | 
 
 /**
  * Lenient positive-integer parse: returns `undefined` for unset, malformed, or
- * non-positive values instead of throwing. Byte-equivalent to the pre-split
- * private parser in `harbor-task-runner.ts`, kept lenient because the Harbor
+ * non-positive values instead of throwing. Kept lenient because the Harbor
  * Python adapter recovers from a malformed `MAKA_CELL_TIMEOUT_SEC`
  * (`maka_agent.py` `_cell_timeout_sec`: "a malformed value falls back to the
  * default") and the TS runner must not fail loudly where the adapter would
- * recover. Accepted syntax is wider than Python's `int()`: `Number(raw)` also
- * takes exponent/decimal-looking forms (`"1e3"` → 1000, `"1.0"` → 1) that the
- * adapter would reject — harmless today because the host rewrites the env to
- * the parsed integer before the container sees it; unifying the accepted syntax
- * is deferred to the same fail-loud follow-up noted in PR #1137. New TS-only
- * env vars should use the throwing `positiveIntEnv` instead.
+ * recover. Accepted syntax matches Python `int()` on this variable: a decimal
+ * positive integer literal only (`"1800"`), so `"1e3"` / `"1.0"` / non-numeric
+ * forms are all a parse miss. New TS-only env vars should use the throwing
+ * `positiveIntEnv` instead.
  */
 export function lenientPositiveIntEnv(raw: string | undefined): number | undefined {
   if (raw === undefined) return undefined;
-  const value = Number(raw);
-  return Number.isInteger(value) && value > 0 ? value : undefined;
+  const value = raw.trim();
+  return /^[1-9]\d*$/.test(value) ? Number(value) : undefined;
 }
 
 /**

--- a/packages/headless/src/workspace-executor-adapter.ts
+++ b/packages/headless/src/workspace-executor-adapter.ts
@@ -18,6 +18,7 @@ import type {
   WorkspaceWriteLockKeyResult,
 } from '@maka/runtime/workspace-executor';
 import { posix as pathPosix } from 'node:path';
+import { isPathInside } from '@maka/runtime';
 import type { IsolatedToolExecutor } from './isolation.js';
 
 export const ISOLATED_WORKSPACE_EXECUTOR_FACTS: WorkspaceExecutorFacts = {
@@ -115,13 +116,8 @@ function resolveIsolatedWorkspacePath(cwd: string, inputPath: string, label: str
   const target = inputPath.startsWith('/')
     ? pathPosix.normalize(inputPath)
     : pathPosix.resolve(root, inputPath);
-  if (!isInsidePosix(root, target)) {
+  if (!isPathInside(root, target, { relative: pathPosix.relative, isAbsolute: pathPosix.isAbsolute, sep: pathPosix.sep })) {
     throw new Error(`${label} must stay inside workspace`);
   }
   return target;
-}
-
-function isInsidePosix(root: string, target: string): boolean {
-  const rel = pathPosix.relative(root, target);
-  return rel === '' || (!rel.startsWith('..') && !pathPosix.isAbsolute(rel));
 }

--- a/packages/runtime/src/__tests__/containment-guard-contract.test.ts
+++ b/packages/runtime/src/__tests__/containment-guard-contract.test.ts
@@ -15,8 +15,9 @@ const SCAN_ROOTS = ['packages', 'apps'];
 // var — re-introduces a parallel containment implementation; new callers must
 // import `isPathInside` from `@maka/runtime` (or `./path-containment.js` inside
 // the runtime package). The strict-interior family (`isInsideOrSamePath` /
-// `isInsideCwd`, where the target may not equal root) is a deliberately
-// different semantic and stays allowed. `pathWithinRoot` is intentionally NOT
+// `isInsideCwd`) is a deliberately different semantic and stays allowed;
+// unifying it with `isPathInside` is tracked separately (out of scope for #1145).
+// `pathWithinRoot` is intentionally NOT
 // retired: `packages/core` has same-named helpers that do POSIX policy-string
 // prefix matching (`trimTrailingSlashes` + `startsWith`), not `node:path`
 // relative containment, so the name is not a reliable signal across packages.

--- a/packages/runtime/src/__tests__/containment-guard-contract.test.ts
+++ b/packages/runtime/src/__tests__/containment-guard-contract.test.ts
@@ -1,0 +1,58 @@
+import { strict as assert } from 'node:assert';
+import { readdir, readFile } from 'node:fs/promises';
+import { relative, resolve } from 'node:path';
+import { describe, it } from 'node:test';
+
+const REPO_ROOT = resolve(import.meta.dirname, '../../../..');
+const PATH_CONTAINMENT_HOME = resolve(REPO_ROOT, 'packages/runtime/src/path-containment.ts');
+
+// Production source roots that may define path-containment predicates.
+const SCAN_ROOTS = ['packages/runtime/src', 'packages/headless/src', 'packages/storage/src', 'apps/desktop/src/main'];
+
+// Names retired in #1145 when every "inside or equal to root" caller moved to
+// the shared `isPathInside`. Defining one again re-introduces a parallel
+// containment implementation; new callers must import `isPathInside` from
+// `@maka/runtime` (or `./path-containment.js` inside the runtime package). The
+// strict-interior family (`isInsideOrSamePath` / `isInsideCwd`, where the target
+// may not equal root) is a deliberately different semantic and stays allowed.
+const RETIRED = ['isInside', 'isContainedPath', 'isInsidePosix', 'pathWithinRoot'];
+const RETIRED_RE = new RegExp(`(?:export\\s+)?function\\s+(${RETIRED.join('|')})\\b`);
+
+async function* walk(dir: string): AsyncGenerator<string> {
+  let entries;
+  try {
+    entries = await readdir(dir, { withFileTypes: true });
+  } catch {
+    return;
+  }
+  for (const entry of entries) {
+    if (['node_modules', '__tests__', 'dist', '.worktree', '.pi'].includes(entry.name)) continue;
+    const full = resolve(dir, entry.name);
+    if (entry.isDirectory()) yield* walk(full);
+    else if (entry.name.endsWith('.ts')) yield full;
+  }
+}
+
+describe('containment-guard contract', () => {
+  it('the shared isPathInside home exists and exports isPathInside', async () => {
+    const home = await readFile(PATH_CONTAINMENT_HOME, 'utf8');
+    assert.match(home, /export function isPathInside\b/, 'path-containment.ts must export isPathInside');
+  });
+
+  it('no retired private containment predicate is redefined outside the shared home', async () => {
+    const offenders: string[] = [];
+    for (const root of SCAN_ROOTS) {
+      for await (const file of walk(resolve(REPO_ROOT, root))) {
+        if (file === PATH_CONTAINMENT_HOME) continue;
+        const text = await readFile(file, 'utf8');
+        const match = text.match(RETIRED_RE);
+        if (match) offenders.push(`${relative(REPO_ROOT, file)} redefines retired "${match[1]}"`);
+      }
+    }
+    assert.deepEqual(
+      offenders,
+      [],
+      'Retired containment predicates must not be redefined; import isPathInside from @maka/runtime instead.',
+    );
+  });
+});

--- a/packages/runtime/src/__tests__/containment-guard-contract.test.ts
+++ b/packages/runtime/src/__tests__/containment-guard-contract.test.ts
@@ -6,17 +6,22 @@ import { describe, it } from 'node:test';
 const REPO_ROOT = resolve(import.meta.dirname, '../../../..');
 const PATH_CONTAINMENT_HOME = resolve(REPO_ROOT, 'packages/runtime/src/path-containment.ts');
 
-// Production source roots that may define path-containment predicates.
-const SCAN_ROOTS = ['packages/runtime/src', 'packages/headless/src', 'packages/storage/src', 'apps/desktop/src/main'];
+// Scan every TypeScript source tree under the monorepo; `walk` prunes tests,
+// build output, deps, worktrees, and Playwright e2e.
+const SCAN_ROOTS = ['packages', 'apps'];
 
 // Names retired in #1145 when every "inside or equal to root" caller moved to
-// the shared `isPathInside`. Defining one again re-introduces a parallel
-// containment implementation; new callers must import `isPathInside` from
-// `@maka/runtime` (or `./path-containment.js` inside the runtime package). The
-// strict-interior family (`isInsideOrSamePath` / `isInsideCwd`, where the target
-// may not equal root) is a deliberately different semantic and stays allowed.
-const RETIRED = ['isInside', 'isContainedPath', 'isInsidePosix', 'pathWithinRoot'];
-const RETIRED_RE = new RegExp(`(?:export\\s+)?function\\s+(${RETIRED.join('|')})\\b`);
+// the shared `isPathInside`. Defining one again — as a function, const, let, or
+// var — re-introduces a parallel containment implementation; new callers must
+// import `isPathInside` from `@maka/runtime` (or `./path-containment.js` inside
+// the runtime package). The strict-interior family (`isInsideOrSamePath` /
+// `isInsideCwd`, where the target may not equal root) is a deliberately
+// different semantic and stays allowed. `pathWithinRoot` is intentionally NOT
+// retired: `packages/core` has same-named helpers that do POSIX policy-string
+// prefix matching (`trimTrailingSlashes` + `startsWith`), not `node:path`
+// relative containment, so the name is not a reliable signal across packages.
+const RETIRED = ['isInside', 'isContainedPath', 'isInsidePosix'];
+const RETIRED_RE = new RegExp(`(?:export\\s+)?(?:function|(?:const|let|var))\\s+(${RETIRED.join('|')})\\b`);
 
 async function* walk(dir: string): AsyncGenerator<string> {
   let entries;
@@ -26,10 +31,10 @@ async function* walk(dir: string): AsyncGenerator<string> {
     return;
   }
   for (const entry of entries) {
-    if (['node_modules', '__tests__', 'dist', '.worktree', '.pi'].includes(entry.name)) continue;
+    if (['node_modules', '__tests__', 'dist', '.worktree', '.pi', 'e2e'].includes(entry.name)) continue;
     const full = resolve(dir, entry.name);
     if (entry.isDirectory()) yield* walk(full);
-    else if (entry.name.endsWith('.ts')) yield full;
+    else if (entry.name.endsWith('.ts') || entry.name.endsWith('.tsx')) yield full;
   }
 }
 

--- a/packages/runtime/src/__tests__/path-containment.test.ts
+++ b/packages/runtime/src/__tests__/path-containment.test.ts
@@ -1,7 +1,7 @@
 import { strict as assert } from 'node:assert';
 import { win32, posix } from 'node:path';
 import { describe, test } from 'node:test';
-import { isPathInside } from '../system-prompt/workspace-instructions.js';
+import { isPathInside } from '../path-containment.js';
 
 describe('isPathInside', () => {
   test('rejects cross-drive Windows targets (different drive is not inside root)', () => {

--- a/packages/runtime/src/additional-permissions.ts
+++ b/packages/runtime/src/additional-permissions.ts
@@ -1,5 +1,6 @@
 import { promises as fs } from 'node:fs';
-import { dirname, isAbsolute, relative, resolve } from 'node:path';
+import { dirname, isAbsolute, resolve } from 'node:path';
+import { isPathInside } from './path-containment.js';
 import {
   MAX_ADDITIONAL_FILESYSTEM_ENTRIES,
   MAX_ADDITIONAL_PERMISSION_PATH_CHARS,
@@ -516,7 +517,7 @@ export function buildAdditionalPermissionProposal(input: {
     isProtectedMetadataPath(entry.path, input.workspaceRoots)
   )) ?? false;
   const outsideWorkspace = input.profile.fileSystem?.entries.some((entry) => (
-    !input.workspaceRoots.some((root) => pathWithinRoot(entry.path, root))
+    !input.workspaceRoots.some((root) => isPathInside(root, entry.path))
   )) ?? false;
   return freezeAdditionalPermissionProposal({
     profile: input.profile,
@@ -642,11 +643,6 @@ function permissionPathKey(entry: NormalizedAdditionalPermissionPath): string {
 
 function permissionProfileHasNetwork(profile: PermissionProfile): boolean {
   return profile.type !== 'disabled' && profile.network.kind === 'enabled';
-}
-
-function pathWithinRoot(path: string, root: string): boolean {
-  const rel = relative(root, path);
-  return rel === '' || (!rel.startsWith('..') && !isAbsolute(rel));
 }
 
 function isMissingPathError(error: unknown): boolean {

--- a/packages/runtime/src/filesystem-worker/operations.ts
+++ b/packages/runtime/src/filesystem-worker/operations.ts
@@ -1,7 +1,8 @@
 import { spawn } from 'node:child_process';
 import { promises as fs } from 'node:fs';
 import { glob as nodeGlob } from 'node:fs/promises';
-import { dirname, isAbsolute, relative, resolve } from 'node:path';
+import { dirname, isAbsolute, resolve } from 'node:path';
+import { isPathInside } from '../path-containment.js';
 import { additionalPermissionAllowsPath } from '@maka/core/additional-permissions';
 
 import { hashAdditionalPermissionProfile } from '../additional-permission-hash.js';
@@ -228,7 +229,7 @@ async function resolveWritableAllowed(
   }
   const parent = await fs.realpath(dirname(candidate));
   assertAllowed(root, candidate, label, 'write', permission);
-  if (!isInside(root, parent) && !exactWriteCoversParent(permission, candidate, parent)) {
+  if (!isPathInside(root, parent) && !exactWriteCoversParent(permission, candidate, parent)) {
     throw operationError('path_denied', `${label} parent was not covered by the one-call permission.`);
   }
   return candidate;
@@ -256,7 +257,7 @@ async function resolveCandidate(
 ): Promise<{ root: string; candidate: string }> {
   const root = await fs.realpath(cwd);
   const candidate = resolve(root, inputPath);
-  if (!isInside(root, candidate) && !additionalPermissionAllowsPath(permission, candidate, access)) {
+  if (!isPathInside(root, candidate) && !additionalPermissionAllowsPath(permission, candidate, access)) {
     throw operationError('path_denied', `${label} path was not covered by the one-call permission.`);
   }
   return { root, candidate };
@@ -269,13 +270,8 @@ function assertAllowed(
   access: 'read' | 'write',
   permission: FilesystemWorkerRequest['operationPermission'],
 ): void {
-  if (isInside(root, target) || additionalPermissionAllowsPath(permission, target, access)) return;
+  if (isPathInside(root, target) || additionalPermissionAllowsPath(permission, target, access)) return;
   throw operationError('path_denied', `${label} path escaped its approved target.`);
-}
-
-function isInside(root: string, target: string): boolean {
-  const rel = relative(root, target);
-  return rel === '' || (!rel.startsWith('..') && !isAbsolute(rel));
 }
 
 function exactWriteCoversParent(

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -1040,10 +1040,8 @@ export type {
   SkillInvocationResolution,
 } from './skill-invocation.js';
 export {
-  isContainedPath,
-  isSafeSkillId,
-  isInside,
   isPathInside,
+  isSafeSkillId,
   toRelative,
 } from './path-containment.js';
 export type { PathInsideApi } from './path-containment.js';

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -932,7 +932,6 @@ export type {
 export {
   buildWorkspaceInstructionsPromptFragment,
   getWorkspaceInstructionsState,
-  isPathInside,
   WORKSPACE_INSTRUCTION_FILES,
   MAX_WORKSPACE_INSTRUCTION_FILE_CHARS,
   MAX_WORKSPACE_INSTRUCTIONS_PROMPT_CHARS,
@@ -941,7 +940,6 @@ export type {
   WorkspaceInstructionFileStatus,
   WorkspaceInstructionFileState,
   WorkspaceInstructionsState,
-  PathInsideApi,
 } from './system-prompt/workspace-instructions.js';
 export {
   buildPersonalizationPromptFragment,
@@ -1045,8 +1043,10 @@ export {
   isContainedPath,
   isSafeSkillId,
   isInside,
+  isPathInside,
   toRelative,
 } from './path-containment.js';
+export type { PathInsideApi } from './path-containment.js';
 export type {
   SkillRuntimeStatus,
   SkillManifest,

--- a/packages/runtime/src/path-containment.ts
+++ b/packages/runtime/src/path-containment.ts
@@ -20,8 +20,10 @@ import { isAbsolute, relative, sep } from 'node:path';
  * - `workspace-executor.ts`, `filesystem-worker/operations.ts`, and
  *   `additional-permissions.ts` each define a local `isInside`-style check
  *   with bare-`startsWith('..')` ({@link isContainedPath}) semantics.
- * - `system-prompt/workspace-instructions.ts` exports `isPathInside`, a
- *   cross-platform-tested equivalent of {@link isInside} under default args.
+ * - {@link isPathInside} (moved here from `system-prompt/workspace-instructions.ts`)
+ *   is the cross-platform-tested, `pathApi`-injectable form of this check and
+ *   the intended single home for the separator-aware family once the bare-
+ *   `startsWith('..')` variants below migrate to it.
  */
 
 /**
@@ -44,10 +46,41 @@ export function isSafeSkillId(value: string): boolean {
  * `root`. Rejects only an exact `..` or a `..<sep>`-prefixed relative path, so
  * a child entry whose own name starts with `..` stays inside. See the module
  * note on why this differs from {@link isContainedPath}.
+ *
+ * Prefer {@link isPathInside} for new code: it is the same check with an
+ * injectable `pathApi` and an explicit cross-drive guard, and is intended to
+ * replace both this and {@link isContainedPath} once callers migrate.
  */
 export function isInside(root: string, target: string): boolean {
   const rel = relative(root, target);
   return rel === '' || (rel !== '..' && !rel.startsWith(`..${sep}`) && !isAbsolute(rel));
+}
+
+/** Path primitives {@link isPathInside} uses, injectable for cross-platform tests. */
+export interface PathInsideApi {
+  relative: typeof relative;
+  isAbsolute: typeof isAbsolute;
+  sep: string;
+}
+
+/**
+ * Separator-aware containment check with an injectable `pathApi`: true when
+ * `target` is inside (or equal to) `root`. Moved here from
+ * `system-prompt/workspace-instructions.ts` so the separator-aware family has
+ * one home; defaults use the host `node:path`. The injectable primitives make
+ * the Windows cross-drive case and POSIX sandbox paths testable.
+ */
+export function isPathInside(root: string, target: string, pathApi: PathInsideApi = { relative, isAbsolute, sep }): boolean {
+  const rel = pathApi.relative(root, target);
+  // path.relative returns the target path unchanged (absolute) when root and
+  // target are on different drives on Windows. An absolute result means the
+  // target is not reachable from root via a relative path, so reject it before
+  // the `..` escape check.
+  if (pathApi.isAbsolute(rel)) return false;
+  // Reject only a real parent-reference segment: the exact ".." or a path
+  // starting with `..${sep}`. A leading ".." followed by anything else (e.g.
+  // "..rules") is a legitimate directory name, not an escape.
+  return rel === '' || (rel !== '..' && !rel.startsWith(`..${pathApi.sep}`));
 }
 
 /** Relative POSIX path from `root` to `target`, or `.` when they are equal. */

--- a/packages/runtime/src/path-containment.ts
+++ b/packages/runtime/src/path-containment.ts
@@ -1,74 +1,25 @@
 import { isAbsolute, relative, sep } from 'node:path';
 
 /**
- * Shared filesystem-containment and identifier guards, moved verbatim from
- * previously duplicated private copies in the runtime skill reader and the
- * desktop main process. This leaf module imports only `node:path`, so both the
- * pure-Node runtime and the desktop main process (which already depends on
- * `@maka/runtime`) can use it without reverse dependencies.
+ * Shared filesystem-containment and identifier guards. This is the single
+ * authority for path-containment checks across the runtime, the desktop main
+ * process, and headless: both the pure-Node runtime and the desktop main (which
+ * already depends on `@maka/runtime`) reach it here without reverse
+ * dependencies. The leaf imports only `node:path`.
  *
- * Two behavior variants live here and are NOT interchangeable — their
- * `..`-prefix handling diverges on a child entry whose own name begins with
- * `..` (e.g. `root/..foo`): {@link isContainedPath} rejects it as an escape,
- * while the separator-aware {@link isInside} correctly treats it as inside.
- * Reconciling them is a behavior-changing decision, not a mechanical move;
- * callers must keep the guard they used before.
- *
- * This module is not yet the single home of containment logic, and function
- * names elsewhere do not reliably indicate which variant they implement.
- * Known remaining variants pending a follow-up consolidation:
- * - `workspace-executor.ts`, `filesystem-worker/operations.ts`, and
- *   `additional-permissions.ts` each define a local `isInside`-style check
- *   with bare-`startsWith('..')` ({@link isContainedPath}) semantics.
- * - {@link isPathInside} (moved here from `system-prompt/workspace-instructions.ts`)
- *   is the cross-platform-tested, `pathApi`-injectable form of this check and
- *   the intended single home for the separator-aware family once the bare-
- *   `startsWith('..')` variants below migrate to it.
+ * {@link isPathInside} is separator-aware: it rejects only a real
+ * parent-reference segment (`..` exactly, or `..${sep}`-prefixed), so a child
+ * entry whose own name begins with `..` (e.g. `root/..foo`) is correctly
+ * treated as inside. Its `pathApi` parameter makes the Windows cross-drive case
+ * and POSIX sandbox paths testable. The bare-`startsWith('..')` variant that
+ * preceded it was retired in #1145 because it misclassified such names as
+ * escapes; identifier safety is handled separately by {@link isSafeSkillId}.
  */
 
 /**
- * True when `child` resolves inside (or equal to) `root`. Any relative path
- * that begins with `..` is rejected as an escape. Used by the skill reader and
- * the managed skill-source store.
- */
-export function isContainedPath(root: string, child: string): boolean {
-  const rel = relative(root, child);
-  return rel === '' || (!!rel && !rel.startsWith('..') && !isAbsolute(rel));
-}
-
-/** True when `value` is a safe skill/source identifier (no path or control chars). */
-export function isSafeSkillId(value: string): boolean {
-  return /^[A-Za-z0-9][A-Za-z0-9._-]{0,80}$/.test(value);
-}
-
-/**
- * Separator-aware containment check: true when `target` is inside (or equal to)
- * `root`. Rejects only an exact `..` or a `..<sep>`-prefixed relative path, so
- * a child entry whose own name starts with `..` stays inside. See the module
- * note on why this differs from {@link isContainedPath}.
- *
- * Prefer {@link isPathInside} for new code: it is the same check with an
- * injectable `pathApi` and an explicit cross-drive guard, and is intended to
- * replace both this and {@link isContainedPath} once callers migrate.
- */
-export function isInside(root: string, target: string): boolean {
-  const rel = relative(root, target);
-  return rel === '' || (rel !== '..' && !rel.startsWith(`..${sep}`) && !isAbsolute(rel));
-}
-
-/** Path primitives {@link isPathInside} uses, injectable for cross-platform tests. */
-export interface PathInsideApi {
-  relative: typeof relative;
-  isAbsolute: typeof isAbsolute;
-  sep: string;
-}
-
-/**
- * Separator-aware containment check with an injectable `pathApi`: true when
- * `target` is inside (or equal to) `root`. Moved here from
- * `system-prompt/workspace-instructions.ts` so the separator-aware family has
- * one home; defaults use the host `node:path`. The injectable primitives make
- * the Windows cross-drive case and POSIX sandbox paths testable.
+ * True when `target` is inside (or equal to) `root`. Used by the skill reader,
+ * the managed skill-source store, the filesystem worker, and the workspace
+ * executor to keep resolved paths inside their approved root.
  */
 export function isPathInside(root: string, target: string, pathApi: PathInsideApi = { relative, isAbsolute, sep }): boolean {
   const rel = pathApi.relative(root, target);
@@ -81,6 +32,18 @@ export function isPathInside(root: string, target: string, pathApi: PathInsideAp
   // starting with `..${sep}`. A leading ".." followed by anything else (e.g.
   // "..rules") is a legitimate directory name, not an escape.
   return rel === '' || (rel !== '..' && !rel.startsWith(`..${pathApi.sep}`));
+}
+
+/** Path primitives {@link isPathInside} uses, injectable for cross-platform tests. */
+export interface PathInsideApi {
+  relative: typeof relative;
+  isAbsolute: typeof isAbsolute;
+  sep: string;
+}
+
+/** True when `value` is a safe skill/source identifier (no path or control chars). */
+export function isSafeSkillId(value: string): boolean {
+  return /^[A-Za-z0-9][A-Za-z0-9._-]{0,80}$/.test(value);
 }
 
 /** Relative POSIX path from `root` to `target`, or `.` when they are equal. */

--- a/packages/runtime/src/skills.ts
+++ b/packages/runtime/src/skills.ts
@@ -4,7 +4,7 @@ import { lstat, mkdir, readdir, readFile, realpath, rename, unlink, writeFile } 
 import { join, relative } from 'node:path';
 import { parseDocument } from 'yaml';
 import { z } from 'zod';
-import { isContainedPath, isSafeSkillId } from './path-containment.js';
+import { isPathInside, isSafeSkillId } from './path-containment.js';
 import type { MakaTool, MakaToolContext } from './tool-runtime.js';
 
 /**
@@ -353,7 +353,7 @@ async function scanSkillDir(
     // Verify the resolved directory has not escaped its containment root via
     // an ancestor symlink (e.g. `repo/.agents -> /outside`).
     const [rootReal, dirReal] = await Promise.all([realpath(containmentRoot), realpath(dir)]);
-    if (!isContainedPath(rootReal, dirReal)) return { skills: [], diagnostics: [] };
+    if (!isPathInside(rootReal, dirReal)) return { skills: [], diagnostics: [] };
     entries = await readdir(dir, { withFileTypes: true });
     entries.sort((a, b) => a.name.localeCompare(b.name));
   } catch {
@@ -810,7 +810,7 @@ export async function readSkillRuntimeState(root: string): Promise<SkillRuntimeS
     if (metadataStat === null) return { ok: true, states: new Map() };
     if (!metadataStat.isDirectory() || metadataStat.isSymbolicLink()) return { ok: false, reason: 'blocked_path' };
     const metadataReal = await realpath(metadataDir);
-    if (!isContainedPath(rootReal, metadataReal)) return { ok: false, reason: 'blocked_path' };
+    if (!isPathInside(rootReal, metadataReal)) return { ok: false, reason: 'blocked_path' };
 
     const stateStat = await lstat(stateFile).catch((error: NodeJS.ErrnoException) => {
       if (error.code === 'ENOENT') return null;
@@ -819,7 +819,7 @@ export async function readSkillRuntimeState(root: string): Promise<SkillRuntimeS
     if (stateStat === null) return { ok: true, states: new Map() };
     if (!stateStat.isFile() || stateStat.isSymbolicLink()) return { ok: false, reason: 'blocked_path' };
     const stateReal = await realpath(stateFile);
-    if (!isContainedPath(metadataReal, stateReal)) return { ok: false, reason: 'blocked_path' };
+    if (!isPathInside(metadataReal, stateReal)) return { ok: false, reason: 'blocked_path' };
 
     const parsed = JSON.parse(await readFile(stateFile, 'utf8')) as unknown;
     if (!isRecord(parsed) || parsed.schemaVersion !== 1 || !isRecord(parsed.skills)) {
@@ -865,7 +865,7 @@ export async function readContainedRegularFile(rootDir: string, filePath: string
     const [rootReal, fileStat] = await Promise.all([realpath(rootDir), lstat(filePath)]);
     if (!fileStat.isFile() || fileStat.isSymbolicLink()) return { ok: false };
     const fileReal = await realpath(filePath);
-    if (!isContainedPath(rootReal, fileReal)) return { ok: false };
+    if (!isPathInside(rootReal, fileReal)) return { ok: false };
     return { ok: true, bytes: await readFile(filePath) };
   } catch {
     return { ok: false };
@@ -880,7 +880,7 @@ export async function readContainedRegularTextFile(rootDir: string, filePath: st
     const [rootReal, fileStat] = await Promise.all([realpath(rootDir), lstat(filePath)]);
     if (!fileStat.isFile() || fileStat.isSymbolicLink()) return { ok: false, reason: 'blocked_path' };
     const fileReal = await realpath(filePath);
-    if (!isContainedPath(rootReal, fileReal)) return { ok: false, reason: 'blocked_path' };
+    if (!isPathInside(rootReal, fileReal)) return { ok: false, reason: 'blocked_path' };
     const content = await readFile(filePath, 'utf8');
     return { ok: true, content, sha256: `sha256:${sha256(content)}` };
   } catch {
@@ -899,7 +899,7 @@ export async function writeContainedRegularTextFile(rootDir: string, filePath: s
     if (existing !== null && (!existing.isFile() || existing.isSymbolicLink())) return false;
     if (existing !== null) {
       const fileReal = await realpath(filePath);
-      if (!isContainedPath(rootReal, fileReal)) return false;
+      if (!isPathInside(rootReal, fileReal)) return false;
     }
     await writeFile(tempPath, content, { encoding: 'utf8', flag: 'wx', mode: 0o600 });
     const tempStat = await lstat(tempPath);
@@ -908,7 +908,7 @@ export async function writeContainedRegularTextFile(rootDir: string, filePath: s
       return false;
     }
     const tempReal = await realpath(tempPath);
-    if (!isContainedPath(rootReal, tempReal)) {
+    if (!isPathInside(rootReal, tempReal)) {
       await unlink(tempPath).catch(() => {});
       return false;
     }
@@ -1182,7 +1182,7 @@ async function resolveSkillRuntimeStateDirForWrite(root: string): Promise<
     const metadataStat = await lstat(metadataDir);
     if (!metadataStat.isDirectory() || metadataStat.isSymbolicLink()) return { ok: false, reason: 'blocked_path' };
     const metadataReal = await realpath(metadataDir);
-    if (!isContainedPath(rootReal, metadataReal)) return { ok: false, reason: 'blocked_path' };
+    if (!isPathInside(rootReal, metadataReal)) return { ok: false, reason: 'blocked_path' };
     return { ok: true, metadataDir };
   } catch {
     return { ok: false, reason: 'write_failed' };

--- a/packages/runtime/src/system-prompt/workspace-instructions.ts
+++ b/packages/runtime/src/system-prompt/workspace-instructions.ts
@@ -1,5 +1,6 @@
 import { readFile, realpath } from 'node:fs/promises';
-import { isAbsolute, join, relative, sep } from 'node:path';
+import { join } from 'node:path';
+import { isPathInside } from '../path-containment.js';
 
 /**
  * Read-only workspace-instruction prompt fragment.
@@ -166,23 +167,4 @@ function truncateCodepoints(text: string, max: number): string {
   const chars = Array.from(text);
   if (chars.length <= max) return text;
   return chars.slice(0, Math.max(0, max)).join('');
-}
-
-export interface PathInsideApi {
-  relative: typeof relative;
-  isAbsolute: typeof isAbsolute;
-  sep: string;
-}
-
-export function isPathInside(root: string, target: string, pathApi: PathInsideApi = { relative, isAbsolute, sep }): boolean {
-  const rel = pathApi.relative(root, target);
-  // path.relative returns the target path unchanged (absolute) when root and
-  // target are on different drives on Windows. An absolute result means the
-  // target is not reachable from root via a relative path, so reject it before
-  // the `..` escape check.
-  if (pathApi.isAbsolute(rel)) return false;
-  // Reject only a real parent-reference segment: the exact ".." or a path
-  // starting with `..${sep}`. A leading ".." followed by anything else (e.g.
-  // "..rules") is a legitimate directory name, not an escape.
-  return rel === '' || (rel !== '..' && !rel.startsWith(`..${pathApi.sep}`));
 }

--- a/packages/runtime/src/workspace-executor.ts
+++ b/packages/runtime/src/workspace-executor.ts
@@ -1,7 +1,8 @@
 import { promises as fs } from 'node:fs';
 import { exec } from 'node:child_process';
 import { glob as nodeGlob } from 'node:fs/promises';
-import { dirname, isAbsolute, relative, resolve } from 'node:path';
+import { dirname, isAbsolute, resolve } from 'node:path';
+import { isPathInside } from './path-containment.js';
 import { promisify } from 'node:util';
 import type { ToolExecutionFacts } from '@maka/core/permission';
 import { runProcessWithBoundedTail, runShellWithBoundedTail } from './shell-exec.js';
@@ -292,11 +293,11 @@ async function resolveWritableInsideCwd(cwd: string, inputPath: string, label: s
   }
   const root = await fs.realpath(cwd);
   const candidate = resolve(root, inputPath);
-  if (!isInside(root, candidate)) {
+  if (!isPathInside(root, candidate)) {
     throw new Error(`${label} path must stay inside session cwd`);
   }
   const parent = await fs.realpath(dirname(candidate));
-  if (!isInside(root, parent)) {
+  if (!isPathInside(root, parent)) {
     throw new Error(`${label} path must stay inside session cwd`);
   }
   return candidate;
@@ -308,17 +309,12 @@ async function resolveExistingInsideCwd(cwd: string, inputPath: string, label: s
   }
   const root = await fs.realpath(cwd);
   const candidate = resolve(root, inputPath);
-  if (!isInside(root, candidate)) {
+  if (!isPathInside(root, candidate)) {
     throw new Error(`${label} path must stay inside session cwd`);
   }
   const target = await fs.realpath(candidate);
-  if (!isInside(root, target)) {
+  if (!isPathInside(root, target)) {
     throw new Error(`${label} path must stay inside session cwd`);
   }
   return target;
-}
-
-function isInside(root: string, target: string): boolean {
-  const rel = relative(root, target);
-  return rel === '' || (!rel.startsWith('..') && !isAbsolute(rel));
 }


### PR DESCRIPTION
## Summary

Closes #1145. Two reconciliations deferred from #1084's High slices (#1136, #1137).

**Containment guards → single authority.** The repo carried three "inside or equal to root" containment semantics across five owners. This PR retires the duplicates and makes `path-containment.ts::isPathInside` (separator-aware, `pathApi`-injectable, cross-platform-tested) the single authority:

- `isContainedPath` (skill reader, managed sources) and the private `isInside` in `workspace-executor.ts` / `filesystem-worker/operations.ts`, plus `pathWithinRoot` in `additional-permissions.ts`, now call `isPathInside`.
- `isInside` (the non-injectable separator-aware copy) is removed; `isPathInside` itself moves into `path-containment.ts` from `system-prompt/workspace-instructions.ts`, which now imports it from there.
- headless `isInsidePosix` becomes `isPathInside(root, target, <posix pathApi>)`, reusing the injectable primitives for POSIX sandbox paths.
- desktop main (`skills.ts`, `managed-skill-sources.ts`, `explore-agent-tool.ts`, `office-document-tool.ts`) switches from `isContainedPath` / `isInside` to `isPathInside`.
- A repo-wide contract test forbids re-introducing the retired names (`isInside`, `isContainedPath`, `isInsidePosix`, `pathWithinRoot`) outside `path-containment.ts`.

**`..foo` edge decided.** A child entry whose own name begins with `..` (e.g. `root/..foo`) is now correctly treated as inside, where the bare-`startsWith('..')` variant rejected it as an escape. `..foo` is a legitimate directory name, not a parent reference; skill-id safety is enforced separately by `isSafeSkillId`. The `..rules` case is locked by `path-containment.test.ts`.

**`MAKA_CELL_TIMEOUT_SEC` syntax unified.** `lenientPositiveIntEnv` narrows to a decimal positive integer literal, matching what the Harbor adapter's Python `int()` accepts. `"1e3"` / `"1.0"` are now a parse miss (fall back to task timeout, then adapter default) on both sides, closing the divergence deferred from #1137. Still lenient (no throw), aligned with the adapter's "malformed → default" contract.

**Strict-interior family left as-is.** `isInsideOrSamePath` / `isInsideCwd` (`rel !== ''`, target may not equal root) are a deliberately different semantic and out of scope; the contract test allows them by name.

## Verification

- `npm --workspace @maka/runtime run test` — 2039 pass (incl. new `containment-guard-contract`), 7 skipped
- `npm --workspace @maka/headless run test:dist` — 1080 pass, 1 skipped
- desktop main `skills` / `managed-skill-sources` / `explore-agent-tool` / `office-document-tool` / `office-documents-capability` / `bundled-skill-catalog` tests — 80 pass
- typecheck: `@maka/runtime`, `@maka/headless`, desktop main — pass
- `biome lint` on all 16 changed files — clean
- `npm run check:stale` — dist is fresh
- Python adapter `_cell_timeout_sec` behavior unchanged (no `maka_agent.py` edit); the table test now mirrors it on the TS side.

## Security

Security-relevant path-containment code converges on the single tested `isPathInside` (cross-drive guard + separator-aware `..` handling). The one behavior change (`..foo` now inside) tightens correctness, not the escape boundary: a real `..` parent reference is still rejected, and identifier safety stays with `isSafeSkillId`.

## Breaking change

`@maka/runtime` public surface drops `isContainedPath` and `isInside`. All in-repo callers migrate in the same PR; the four commits are each independently buildable (move `isPathInside` → migrate callers + drop retired variants → contract test → cell-timeout narrowing).
