### PR TITLE
refactor(desktop): stabilize app-shell action factory identities

### DIFF
--- a/apps/desktop/src/main/__tests__/app-shell-stable-actions-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/app-shell-stable-actions-contract.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Contract for the app-shell action-factory stabilization (issue #1043).
+ *
+ * The 9 `createAppShell*Actions` factories run in the AppShell render body, so
+ * every render allocates fresh handler identities. That churn is observable:
+ * the streaming-settle fallback effect lists `settleAssistantStreaming` in its
+ * deps and therefore tears down/re-arms its 1s timer on every render while the
+ * fallback is armed.
+ *
+ * The fix wraps every factory in `useStableActions`, which returns a facade
+ * created once per component instance. The facade delegates each call to the
+ * latest committed render's factory result, so handlers are both
+ * identity-stable and always see fresh deps. These tests pin the delegation behavior (pure seam)
+ * and the wiring contract (source seam, the repo's renderer-test idiom).
+ */
+
+import { strict as assert } from 'node:assert';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, it } from 'node:test';
+import { createDelegatingActions } from '../../renderer/stable-actions.js';
+
+const REPO_ROOT = resolve(import.meta.dirname, '../../../../..');
+
+function rendererSource(file: string): string {
+  return readFileSync(resolve(REPO_ROOT, 'apps/desktop/src/renderer', file), 'utf8');
+}
+
+describe('createDelegatingActions', () => {
+  it('keeps facade identity stable while delegating to the latest actions', () => {
+    const latest = { current: { greet: (name: string) => `hello ${name}` } };
+    const facade = createDelegatingActions(latest);
+    const stableGreet = facade.greet;
+
+    // A later render re-runs the factory and swaps the ref contents.
+    latest.current = { greet: (name: string) => `hi ${name}` };
+
+    assert.equal(facade.greet, stableGreet, 'facade method identity must not change');
+    assert.equal(facade.greet('maka'), 'hi maka', 'calls must reach the latest closure');
+  });
+
+  it('forwards all arguments and the return value', () => {
+    const latest = { current: { add: (a: number, b: number) => a + b } };
+    const facade = createDelegatingActions(latest);
+    assert.equal(facade.add(2, 3), 5);
+    latest.current = { add: () => 42 };
+    assert.equal(facade.add(2, 3), 42);
+  });
+
+  it('fixes the key set at creation even if a later result changes shape', () => {
+    const latest = { current: { a: () => 'a', b: () => 'b' } as Record<string, () => string> };
+    const facade = createDelegatingActions(latest);
+    latest.current = { a: () => 'A2', c: () => 'c' };
+    assert.deepEqual(Object.keys(facade), ['a', 'b'], 'facade keys are fixed at creation');
+    assert.equal(facade.a(), 'A2', 'surviving keys still delegate to the latest result');
+  });
+});
+
+describe('AppShell action-factory stabilization', () => {
+  it('runs every object-returning factory through useStableActions', () => {
+    const shell = rendererSource('app-shell.tsx');
+    assert.doesNotMatch(
+      shell,
+      /= createAppShell\w+(Actions|Handlers)\(\{/,
+      'no object-returning factory may run unwrapped in the render body',
+    );
+    const wrapped =
+      shell.match(/useStableActions\(createAppShell\w+, \{/g) ?? [];
+    assert.equal(
+      wrapped.length,
+      9,
+      `expected 9 useStableActions-wrapped factories, found ${wrapped.length}`,
+    );
+  });
+
+  it('stabilizes the session-event handlers that feed effect deps', () => {
+    const shell = rendererSource('app-shell.tsx');
+    assert.match(
+      shell,
+      /\} = useStableActions\(createAppShellSessionEventHandlers, \{/,
+      'settleAssistantStreaming must be identity-stable so the settle fallback timer arms once',
+    );
+  });
+
+  it('removes the manual sessionRowActionHandlers ref-mirror superseded by the facade', () => {
+    const shell = rendererSource('app-shell.tsx');
+    assert.doesNotMatch(shell, /sessionRowActionHandlersRef/);
+  });
+
+  it('publishes the latest actions at commit time, never during render', () => {
+    const hook = rendererSource('use-stable-actions.ts');
+    // Lazy initialization is the only render-phase ref write React permits;
+    // on updates the ref is already populated and only the layout effect
+    // publishes, so an interrupted render cannot leak uncommitted closures.
+    assert.match(hook, /if \(latestRef\.current === null\) latestRef\.current = actions;/);
+    assert.match(hook, /useLayoutEffect\(\(\) => \{\s*latestRef\.current = actions;\s*\}\)/);
+    assert.doesNotMatch(hook, /^ {2}latestRef\.current = factory\(deps\);/m);
+    assert.match(hook, /useState\(\(\) => createDelegatingActions\(latestRef/);
+  });
+});

--- a/apps/desktop/src/main/__tests__/session-row-actions-fail-soft-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/session-row-actions-fail-soft-contract.test.ts
@@ -33,14 +33,14 @@ describe('session row actions fail soft', () => {
     assert.match(main, /const sessionPrefix = `\$\{sessionId\}:`;/);
     assert.match(main, /Array\.from\(pendingSessionRowActionsRef\.current\)\.some\(\(key\) => key\.startsWith\(sessionPrefix\)\)/);
     assert.match(main, /pendingSessionRowActionsRef\.current\.add\(key\);[\s\S]*catch \(error\) \{[\s\S]*toastApi\.error\(errorTitle, generalizedErrorMessageChinese\(error, '会话操作失败，请稍后重试。'\)\)[\s\S]*finally \{[\s\S]*pendingSessionRowActionsRef\.current\.delete\(key\);/);
-    assert.match(main, /const sessionRowActions = useMemo<NonNullable<Parameters<typeof SessionListPanel>\[0\]\['rowActions'\]>>\([\s\S]*onToggleFlag: \(sessionId, next\) => sessionRowActionHandlersRef\.current\.flagSession\(sessionId, next\),[\s\S]*onArchive: \(sessionId\) => sessionRowActionHandlersRef\.current\.archiveSession\(sessionId\),[\s\S]*onUnarchive: \(sessionId\) => sessionRowActionHandlersRef\.current\.unarchiveSession\(sessionId\),[\s\S]*onRename: \(sessionId, name\) => sessionRowActionHandlersRef\.current\.renameSession\(sessionId, name\),[\s\S]*onDelete: \(sessionId\) => sessionRowActionHandlersRef\.current\.deleteSession\(sessionId\),/);
+    assert.match(main, /const sessionRowActions = useMemo<NonNullable<Parameters<typeof SessionListPanel>\[0\]\['rowActions'\]>>\([\s\S]*onToggleFlag: \(sessionId, next\) => sessionRowActionHandlers.flagSession\(sessionId, next\),[\s\S]*onArchive: \(sessionId\) => sessionRowActionHandlers.archiveSession\(sessionId\),[\s\S]*onUnarchive: \(sessionId\) => sessionRowActionHandlers.unarchiveSession\(sessionId\),[\s\S]*onRename: \(sessionId, name\) => sessionRowActionHandlers.renameSession\(sessionId, name\),[\s\S]*onDelete: \(sessionId\) => sessionRowActionHandlers.deleteSession\(sessionId\),/);
     assert.match(main, /rowActions=\{sessionRowActions\}/);
     assert.match(sessionListBlock, /onSelectSession=\{[^}]+\}/);
     assert.match(sessionListBlock, /rowActions=\{[^}]+\}/);
     assert.doesNotMatch(sessionListBlock, /onSelectSession=\{\(sessionId\)/);
     assert.doesNotMatch(sessionListBlock, /rowActions=\{\{/);
-    assert.doesNotMatch(main, /onDelete: \(sessionId\) => void sessionRowActionHandlersRef\.current\.deleteSession\(sessionId\)/);
-    assert.doesNotMatch(main, /onToggleFlag: \(sessionId, next\) => void sessionRowActionHandlersRef\.current\.flagSession\(sessionId, next\)/);
+    assert.doesNotMatch(main, /onDelete: \(sessionId\) => void sessionRowActionHandlers.deleteSession\(sessionId\)/);
+    assert.doesNotMatch(main, /onToggleFlag: \(sessionId, next\) => void sessionRowActionHandlers.flagSession\(sessionId, next\)/);
   });
 
   it('cleans active session renderer state consistently after archive or delete', async () => {

--- a/apps/desktop/src/renderer/app-shell.tsx
+++ b/apps/desktop/src/renderer/app-shell.tsx
@@ -98,6 +98,7 @@ import { createAppShellDailyReviewActions } from './app-shell-daily-review-actio
 import { createAppShellSessionRowActions } from './app-shell-session-row-actions';
 import { createAppShellSessionSettingsActions } from './app-shell-session-settings-actions';
 import { createAppShellStopAction } from './app-shell-stop-action';
+import { useStableActions } from './use-stable-actions';
 import {
   useActiveSessionEvents,
   useAppShellBootstrapSubscriptions,
@@ -299,7 +300,7 @@ export function AppShell({
     appendDailyReviewMarkdown,
     copyDailyReviewMarkdown,
     saveDailyReviewMarkdown,
-  } = createAppShellDailyReviewActions({
+  } = useStableActions(createAppShellDailyReviewActions, {
     composerRef,
     toastApi,
   });
@@ -428,7 +429,7 @@ export function AppShell({
     sessionModelChangeRegistry.keysRef.current.delete(sessionId);
   }
 
-  const sessionRowActionHandlers = createAppShellSessionRowActions({
+  const sessionRowActionHandlers = useStableActions(createAppShellSessionRowActions, {
     activeIdRef,
     clearSessionRendererState,
     pendingSessionRowActionsRef: sessionRowActionRegistry.keysRef,
@@ -438,15 +439,13 @@ export function AppShell({
     setMessages,
     toastApi,
   });
-  const sessionRowActionHandlersRef = useRef(sessionRowActionHandlers);
-  sessionRowActionHandlersRef.current = sessionRowActionHandlers;
   const sessionRowActions = useMemo<NonNullable<Parameters<typeof SessionListPanel>[0]['rowActions']>>(
     () => ({
-      onToggleFlag: (sessionId, next) => sessionRowActionHandlersRef.current.flagSession(sessionId, next),
-      onArchive: (sessionId) => sessionRowActionHandlersRef.current.archiveSession(sessionId),
-      onUnarchive: (sessionId) => sessionRowActionHandlersRef.current.unarchiveSession(sessionId),
-      onRename: (sessionId, name) => sessionRowActionHandlersRef.current.renameSession(sessionId, name),
-      onDelete: (sessionId) => sessionRowActionHandlersRef.current.deleteSession(sessionId),
+      onToggleFlag: (sessionId, next) => sessionRowActionHandlers.flagSession(sessionId, next),
+      onArchive: (sessionId) => sessionRowActionHandlers.archiveSession(sessionId),
+      onUnarchive: (sessionId) => sessionRowActionHandlers.unarchiveSession(sessionId),
+      onRename: (sessionId, name) => sessionRowActionHandlers.renameSession(sessionId, name),
+      onDelete: (sessionId) => sessionRowActionHandlers.deleteSession(sessionId),
     }),
     [],
   );
@@ -455,7 +454,7 @@ export function AppShell({
     setPermissionMode,
     setSessionModel,
     setSessionThinkingLevel,
-  } = createAppShellSessionSettingsActions({
+  } = useStableActions(createAppShellSessionSettingsActions, {
     activeIdRef,
     connections,
     pendingPermissionModeChangesRef: permissionModeChangeRegistry.keysRef,
@@ -612,7 +611,7 @@ export function AppShell({
   const onboarding = useOnboardingSnapshot(initialOnboardingSnapshot);
   const [quickChatPending, setQuickChatPending] = useState(false);
   const quickChatPendingRef = useRef(false);
-  const { handleQuickChatSubmit, handleExpertTeamStart } = createAppShellQuickChatActions({
+  const { handleQuickChatSubmit, handleExpertTeamStart } = useStableActions(createAppShellQuickChatActions, {
     activeIdRef,
     captureComposerImportOwner,
     composerRef,
@@ -703,7 +702,7 @@ export function AppShell({
   const [workbarCollapsed, setWorkbarCollapsed] = useState(() => readSessionWorkbarCollapsed());
   const [workbarWidth, setWorkbarWidth] = useState(() => readSessionWorkbarWidth());
   const [workbarTab, setWorkbarTab] = useState(() => readSessionWorkbarTab());
-  const { startColumnResize, onResizeHandleKeyDown, startWorkbarResize, onWorkbarResizeHandleKeyDown } = createAppShellLayoutActions({
+  const { startColumnResize, onResizeHandleKeyDown, startWorkbarResize, onWorkbarResizeHandleKeyDown } = useStableActions(createAppShellLayoutActions, {
     sessionListCollapsed,
     sessionListWidth,
     setSessionListWidth,
@@ -787,7 +786,7 @@ export function AppShell({
     toastApi,
   });
 
-  const { applyVisualSmokeFixture } = createAppShellVisualSmokeActions({
+  const { applyVisualSmokeFixture } = useStableActions(createAppShellVisualSmokeActions, {
     openPalette,
     openSettingsSection,
     refreshSessions,
@@ -810,7 +809,7 @@ export function AppShell({
     respondToUserQuestion,
     refreshMessages,
     retryMessages,
-  } = createAppShellChatActions({
+  } = useStableActions(createAppShellChatActions, {
     activeIdRef,
     addPendingSessionAction,
     captureComposerImportOwner,
@@ -834,7 +833,7 @@ export function AppShell({
     pendingNewChatThinkingLevel: newChatThinkingLevel ?? null,
   });
 
-  const { handleTurnFooterAction } = createAppShellTurnActions({
+  const { handleTurnFooterAction } = useStableActions(createAppShellTurnActions, {
     activeIdRef,
     addPendingTurnAction: turnActionRegistry.addKey,
     clearPendingTurnAction: turnActionRegistry.clearKey,
@@ -879,7 +878,7 @@ export function AppShell({
     toastApi,
   });
 
-  const { handleEvent, reconcilePersistedMessages, settleAssistantStreaming } = createAppShellSessionEventHandlers({
+  const { handleEvent, reconcilePersistedMessages, settleAssistantStreaming } = useStableActions(createAppShellSessionEventHandlers, {
     activeIdRef,
     liveTurnBySessionRef,
     refreshMessages,

--- a/apps/desktop/src/renderer/stable-actions.ts
+++ b/apps/desktop/src/renderer/stable-actions.ts
@@ -1,0 +1,25 @@
+/**
+ * Delegating-actions facade behind `useStableActions` (issue #1043).
+ *
+ * App-shell action factories run in the render body, so every render allocates
+ * fresh handler identities. Any consumer that lists a handler in an effect dep
+ * array (the streaming-settle fallback timer did) tears down and re-arms on
+ * every render. The facade fixes the identity without freezing the closures:
+ * each method delegates to the latest committed render's factory result through
+ * `latestRef`, so calls always see fresh deps while consumers see one stable
+ * identity for the component's lifetime.
+ *
+ * Factories must return a constant key shape of function values — the
+ * facade's key set is fixed at creation. Kept React-free so the behavior is
+ * testable from `node:test`.
+ */
+export function createDelegatingActions<A extends object>(latestRef: { current: A }): A {
+  const facade: Record<string, (...args: unknown[]) => unknown> = {};
+  for (const key of Object.keys(latestRef.current)) {
+    facade[key] = (...args: unknown[]) => {
+      const action = Reflect.get(latestRef.current, key) as unknown as (...args: unknown[]) => unknown;
+      return action(...args);
+    };
+  }
+  return facade as unknown as A;
+}

--- a/apps/desktop/src/renderer/use-stable-actions.ts
+++ b/apps/desktop/src/renderer/use-stable-actions.ts
@@ -1,0 +1,31 @@
+import { useLayoutEffect, useRef, useState } from 'react';
+import { createDelegatingActions } from './stable-actions';
+
+/**
+ * Runs an app-shell action factory in the render body but returns a stable
+ * identity (issue #1043).
+ *
+ * The factory still runs every render, so its closures always capture the
+ * latest deps — identical to calling it bare. What consumers receive is a
+ * once-created delegating facade whose method identities never change, and it
+ * delegates only to the latest COMMITTED render's actions: publication happens
+ * in useLayoutEffect, so an interrupted or discarded concurrent render never
+ * leaks its closures to event handlers, timers, or subscriptions. This
+ * supersedes hand-rolled `handlersRef.current = handlers` mirrors, which
+ * published during render.
+ *
+ * `createAppShellStopAction` is deliberately NOT wrapped: it returns a bare
+ * function (no object to facade) and only feeds JSX props, never effect deps.
+ */
+export function useStableActions<D, A extends object>(factory: (deps: D) => A, deps: D): A {
+  const actions = factory(deps);
+  const latestRef = useRef<A | null>(null);
+  // Lazy initialization is the one render-phase ref write React permits; on
+  // updates the ref is already populated and only the layout effect publishes.
+  if (latestRef.current === null) latestRef.current = actions;
+  useLayoutEffect(() => {
+    latestRef.current = actions;
+  });
+  const [facade] = useState(() => createDelegatingActions(latestRef as { current: A }));
+  return facade;
+}


### PR DESCRIPTION
## Summary

Refs #1043 (step 1 of the plan documented there).

The 9 `createAppShell*Actions` factories ran unmemoized in the AppShell render body, so every render allocated fresh handler identities. The one observable harm: the streaming-settle fallback effect lists `settleAssistantStreaming` in its deps, so its 1s timer tore down and re-armed on every render while armed — under continuous render churn the fallback could be postponed indefinitely.

Rather than patching the one effect, this fixes the defect class. The new `useStableActions` still runs the factory every render (closures always capture the latest deps, identical to calling it bare), but returns a once-created **delegating facade** whose method identities never change. Publication to the facade happens in `useLayoutEffect`, so only the latest **committed** render's actions are reachable — an interrupted or discarded concurrent render cannot leak its closures to event handlers, timers, or subscriptions. The settle timer now arms once by construction, and any future effect-dep or memoized-child consumer is safe by the same mechanism.

- `createDelegatingActions` is pure and React-free so the behavior is testable through the repo's `node:test` chain; source contracts pin the wiring at all 9 call sites and forbid the render-phase publication this design rejected.
- The hand-rolled `sessionRowActionHandlersRef` mirror is removed — superseded by the facade. The fail-soft contract moves to the facade pattern with unchanged semantics (dedup registry, no fire-and-forget `void`).
- `createAppShellStopAction` deliberately stays unwrapped: it returns a bare function (no object to facade) and only feeds JSX props, never effect deps.

Not TDD for the timer behavior itself — the repo has no React-rendering test harness; identity stability is pinned by unit + source contracts and the streaming journey by the existing E2E below.

## Verification

- `tsc -p tsconfig.main.json` and `tsconfig.renderer.json` — clean.
- `node --test dist/main/**/*.test.js` — 2650/2651. The one failure (`menu-highlight-recipe-contract`) fails identically on clean `main`; unrelated, not touched here.
- Contract: `app-shell-stable-actions-contract.test.ts` (7 tests — facade delegation/identity, constant key set under shape change, wiring, commit-time publication).
- `npm run test:checks` (console / a11y / copy) — clean; `biome lint` on changed files — clean.
- Playwright `e2e/send-message.spec.ts` (fake-backend streaming journey through the settle path) — passes.

## Review focus

An external review round (Codex) flagged that the first iteration published `latestRef.current` during render, which under concurrent React can expose closures from an uncommitted render. Fixed at the owner: publication moved to `useLayoutEffect`, render-phase writes limited to lazy initialization, and a source contract now forbids the rejected pattern. One known pre-existing instance of the old pattern remains at `openSessionInChatRef` (single-function mirror, not a factory) — out of scope here, candidate for a follow-up sweep.
