### PR TITLE
feat(runtime): add durable Runtime Host execution slice

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9723,6 +9723,8 @@
       "name": "@maka/runtime-host",
       "version": "0.1.0",
       "dependencies": {
+        "@maka/core": "0.1.0",
+        "@maka/runtime": "0.1.0",
         "@maka/storage": "0.1.0"
       },
       "devDependencies": {

--- a/packages/core/src/agent-run.ts
+++ b/packages/core/src/agent-run.ts
@@ -1,5 +1,6 @@
-import type { PermissionMode } from './permission.js';
+import { isPermissionMode, type PermissionMode } from './permission.js';
 import type { BackendKind } from './session.js';
+import { defineObjectShape, hasExactShape, isFiniteNumber, isOptionalString, isRecord } from './record-schema.js';
 
 export const AGENT_RUN_STATUSES = [
   'created',
@@ -48,43 +49,46 @@ export interface AgentRunInputSummary {
   attachmentCount: number;
 }
 
-export type AgentRunEventType =
-  | 'run_created'
-  | 'run_started'
-  | 'turn_started'
-  | 'run_status_changed'
-  | 'model_resolved'
-  | 'model_resolve_failed'
-  | 'model_stream_started'
-  | 'model_stream_completed'
-  | 'model_stream_failed'
-  | 'tool_started'
-  | 'tool_completed'
-  | 'tool_failed'
-  | 'permission_requested'
-  | 'permission_decided'
-  | 'permission_failed'
-  | 'approval_routed'
-  | 'auto_review_started'
-  | 'auto_review_decided'
-  | 'auto_review_failed'
-  | 'sandbox_escalation_requested'
-  | 'sandbox_escalation_granted'
-  | 'sandbox_escalation_denied'
-  | 'sandbox_escalation_applied'
-  | 'sandbox_escalation_failed'
-  | 'sandbox_denial_detected'
-  | 'usage_recorded'
-  | 'history_compact_checkpoint_recorded'
-  | 'active_full_compact_block_recorded'
-  | 'semantic_compact_block_recorded'
-  | 'task_gate_decided'
-  | 'abort_requested'
-  | 'run_completed'
-  | 'run_failed'
-  | 'run_cancelled'
-  | 'trace_write_failed'
-  | 'event_corrupt';
+export const AGENT_RUN_EVENT_TYPES = [
+  'run_created',
+  'run_started',
+  'turn_started',
+  'run_status_changed',
+  'model_resolved',
+  'model_resolve_failed',
+  'model_stream_started',
+  'model_stream_completed',
+  'model_stream_failed',
+  'tool_started',
+  'tool_completed',
+  'tool_failed',
+  'permission_requested',
+  'permission_decided',
+  'permission_failed',
+  'approval_routed',
+  'auto_review_started',
+  'auto_review_decided',
+  'auto_review_failed',
+  'sandbox_escalation_requested',
+  'sandbox_escalation_granted',
+  'sandbox_escalation_denied',
+  'sandbox_escalation_applied',
+  'sandbox_escalation_failed',
+  'sandbox_denial_detected',
+  'usage_recorded',
+  'history_compact_checkpoint_recorded',
+  'active_full_compact_block_recorded',
+  'semantic_compact_block_recorded',
+  'task_gate_decided',
+  'abort_requested',
+  'run_completed',
+  'run_failed',
+  'run_cancelled',
+  'trace_write_failed',
+  'event_corrupt',
+] as const;
+
+export type AgentRunEventType = (typeof AGENT_RUN_EVENT_TYPES)[number];
 
 export interface AgentRunEvent {
   type: AgentRunEventType;
@@ -97,12 +101,114 @@ export interface AgentRunEvent {
   data?: Record<string, unknown>;
 }
 
+const AGENT_RUN_HEADER_SHAPE = defineObjectShape<AgentRunHeader>()(
+  [
+    'runId',
+    'sessionId',
+    'turnId',
+    'status',
+    'backendKind',
+    'llmConnectionSlug',
+    'modelId',
+    'cwd',
+    'permissionMode',
+    'createdAt',
+    'updatedAt',
+  ],
+  [
+    'invocationId',
+    'completedAt',
+    'parentRunId',
+    'agentId',
+    'agentName',
+    'parentTurnId',
+    'retriedFromTurnId',
+    'regeneratedFromTurnId',
+    'branchOfTurnId',
+    'parentSessionId',
+    'automationId',
+    'failureClass',
+    'failureMessage',
+    'abortSource',
+    'traceWriteError',
+  ],
+);
+
+const AGENT_RUN_EVENT_SHAPE = defineObjectShape<AgentRunEvent>()(
+  ['type', 'id', 'runId', 'sessionId', 'turnId', 'ts'],
+  ['message', 'data'],
+);
+
+export function decodeAgentRunHeader(value: unknown): AgentRunHeader {
+  if (!isRecord(value) || !hasExactShape(value, AGENT_RUN_HEADER_SHAPE)) {
+    throw new Error('Invalid AgentRun header schema');
+  }
+  const valid =
+    typeof value.runId === 'string' &&
+    typeof value.sessionId === 'string' &&
+    typeof value.turnId === 'string' &&
+    (AGENT_RUN_STATUSES as readonly unknown[]).includes(value.status) &&
+    isBackendKind(value.backendKind) &&
+    typeof value.llmConnectionSlug === 'string' &&
+    typeof value.modelId === 'string' &&
+    typeof value.cwd === 'string' &&
+    isPermissionMode(value.permissionMode) &&
+    isFiniteNumber(value.createdAt) &&
+    isFiniteNumber(value.updatedAt) &&
+    isOptionalString(value.invocationId) &&
+    (value.completedAt === undefined || isFiniteNumber(value.completedAt)) &&
+    [
+      value.parentRunId,
+      value.agentId,
+      value.agentName,
+      value.parentTurnId,
+      value.retriedFromTurnId,
+      value.regeneratedFromTurnId,
+      value.branchOfTurnId,
+      value.parentSessionId,
+      value.automationId,
+      value.failureClass,
+      value.failureMessage,
+      value.abortSource,
+      value.traceWriteError,
+    ].every(isOptionalString);
+  if (!valid) throw new Error('Invalid AgentRun header schema');
+  return value as unknown as AgentRunHeader;
+}
+
+export function decodeAgentRunEvent(value: unknown): AgentRunEvent {
+  if (
+    !isRecord(value) ||
+    !hasExactShape(value, AGENT_RUN_EVENT_SHAPE) ||
+    !(AGENT_RUN_EVENT_TYPES as readonly unknown[]).includes(value.type) ||
+    typeof value.id !== 'string' ||
+    typeof value.runId !== 'string' ||
+    typeof value.sessionId !== 'string' ||
+    typeof value.turnId !== 'string' ||
+    !isFiniteNumber(value.ts) ||
+    !isOptionalString(value.message) ||
+    (value.data !== undefined && !isRecord(value.data))
+  ) {
+    throw new Error('Invalid AgentRun event schema');
+  }
+  return value as unknown as AgentRunEvent;
+}
+
+function isBackendKind(value: unknown): value is BackendKind {
+  return value === 'ai-sdk' || value === 'fake' || value === 'pi-agent';
+}
+
 export interface AgentRunStore {
-  createRun(header: AgentRunHeader): Promise<AgentRunHeader>;
-  updateRun(sessionId: string, runId: string, patch: Partial<AgentRunHeader>): Promise<AgentRunHeader>;
+  createRun(header: AgentRunHeader, options?: { durable?: boolean }): Promise<AgentRunHeader>;
+  updateRun(
+    sessionId: string,
+    runId: string,
+    patch: Partial<AgentRunHeader>,
+    options?: { durable?: boolean },
+  ): Promise<AgentRunHeader>;
   readRun(sessionId: string, runId: string): Promise<AgentRunHeader>;
   listSessionRuns(sessionId: string): Promise<AgentRunHeader[]>;
-  appendEvent(sessionId: string, runId: string, event: AgentRunEvent): Promise<void>;
+  appendEvent(sessionId: string, runId: string, event: AgentRunEvent, options?: { durable?: boolean }): Promise<void>;
   readEvents(sessionId: string, runId: string): Promise<AgentRunEvent[]>;
   /** `undefined` means uninitialized; `null` is an initialized empty projection. */
   readEventProjection?(

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -99,6 +99,7 @@ export {
   isRuntimeEventRole,
   isRuntimeEventAuthor,
   isRuntimeEventStatus,
+  decodeRuntimeEvent,
   isTerminalRuntimeEventStatus,
   isTerminalRuntimeEvent,
   isPartialRuntimeEvent,
@@ -137,6 +138,7 @@ export {
 export type {
   RuntimeEventStore,
 } from './runtime-event-store.js';
+export { DurableStoreWriteError } from './runtime-event-store.js';
 
 // session.ts
 export type {
@@ -169,8 +171,11 @@ export {
   isSessionStatus,
   isSessionBlockedReason,
   isTurnStatus,
+  decodeStoredMessageForRead,
+  decodeStoredMessageForRecovery,
   userFacingText,
 } from './session.js';
+export { decodeCanonicalToolResultContent } from './tool-result-record-schema.js';
 
 // model-thinking.ts
 export type { ThinkingLevel } from './model-thinking.js';
@@ -189,7 +194,11 @@ export type {
   AgentRunStatus,
   AgentRunStore,
 } from './agent-run.js';
-export { AGENT_RUN_STATUSES } from './agent-run.js';
+export {
+  AGENT_RUN_STATUSES,
+  decodeAgentRunEvent,
+  decodeAgentRunHeader,
+} from './agent-run.js';
 
 // shell-run.ts
 export type {

--- a/packages/core/src/interaction-record-schema.ts
+++ b/packages/core/src/interaction-record-schema.ts
@@ -1,0 +1,299 @@
+import {
+  APPROVALS_REVIEWERS,
+  APPROVAL_RISK_LEVELS,
+  isToolCategory,
+  type AdditionalPermissionRequest,
+  type PermissionRequest,
+  type PermissionRequestPayload,
+  type PermissionResponse,
+  type SandboxEscalationRequest,
+  type SandboxEscalationRiskSummary,
+} from './permission.js';
+import {
+  validateAdditionalPermissionProfile,
+  type AdditionalPermissionRiskSummary,
+} from './additional-permissions.js';
+import type { AttachmentRef, StorageRef } from './events.js';
+import type { UserQuestion, UserQuestionOption, UserQuestionRequest } from './user-question.js';
+import {
+  defineObjectShape,
+  hasExactShape,
+  isFiniteNumber,
+  isOptionalString,
+  isRecord,
+} from './record-schema.js';
+
+const TOOL_PERMISSION_SHAPE = defineObjectShape<PermissionRequest>()(
+  [
+    'kind',
+    'requestId',
+    'toolUseId',
+    'toolName',
+    'category',
+    'reason',
+    'args',
+    'rememberForTurnAllowed',
+  ],
+  ['hint'],
+);
+
+const ADDITIONAL_PERMISSION_SHAPE = defineObjectShape<AdditionalPermissionRequest>()(
+  [
+    'kind',
+    'requestId',
+    'toolUseId',
+    'toolName',
+    'category',
+    'reason',
+    'additionalPermissions',
+    'cwd',
+    'justification',
+    'intentHash',
+    'permissionsHash',
+    'risk',
+    'alsoApprovesToolExecution',
+    'availableDecisions',
+  ],
+  ['hint'],
+);
+
+const SANDBOX_ESCALATION_SHAPE = defineObjectShape<SandboxEscalationRequest>()(
+  [
+    'kind',
+    'requestId',
+    'toolUseId',
+    'toolName',
+    'category',
+    'reason',
+    'command',
+    'cwd',
+    'justification',
+    'intentHash',
+    'commandHash',
+    'trigger',
+    'risk',
+    'alsoApprovesToolExecution',
+    'availableDecisions',
+  ],
+  ['hint'],
+);
+
+const PERMISSION_RESPONSE_SHAPE = defineObjectShape<PermissionResponse>()(
+  ['requestId', 'decision'],
+  ['rememberForTurn', 'reviewer', 'rationale', 'riskLevel'],
+);
+
+const ADDITIONAL_PERMISSION_RISK_SHAPE = defineObjectShape<AdditionalPermissionRiskSummary>()(
+  ['outsideWorkspace', 'protectedMetadata', 'networkEnabled'],
+  [],
+);
+const SANDBOX_ESCALATION_RISK_SHAPE = defineObjectShape<SandboxEscalationRiskSummary>()(
+  [
+    'unsandboxedExecution',
+    'unrestrictedFileSystem',
+    'unrestrictedNetwork',
+    'protectedMetadataExposed',
+  ],
+  [],
+);
+
+const QUESTION_REQUEST_SHAPE = defineObjectShape<UserQuestionRequest>()(
+  ['requestId', 'toolUseId', 'questions'],
+  [],
+);
+const QUESTION_SHAPE = defineObjectShape<UserQuestion>()(['question', 'options'], []);
+const QUESTION_OPTION_SHAPE = defineObjectShape<UserQuestionOption>()(['label'], ['description']);
+
+const ATTACHMENT_SHAPE = defineObjectShape<AttachmentRef>()(
+  ['kind', 'name', 'mimeType', 'bytes', 'ref'],
+  [],
+);
+type SessionFileRef = Extract<StorageRef, { kind: 'session_file' }>;
+type WorkspaceFileRef = Extract<StorageRef, { kind: 'workspace_file' }>;
+type ExternalFileRef = Extract<StorageRef, { kind: 'external_file' }>;
+const SESSION_FILE_REF_SHAPE = defineObjectShape<SessionFileRef>()(
+  ['kind', 'sessionId', 'relativePath'],
+  [],
+);
+const WORKSPACE_FILE_REF_SHAPE = defineObjectShape<WorkspaceFileRef>()(
+  ['kind', 'relativePath'],
+  [],
+);
+const EXTERNAL_FILE_REF_SHAPE = defineObjectShape<ExternalFileRef>()(['kind', 'absolutePath'], []);
+
+const TOOL_PERMISSION_REASONS = new Set([
+  'shell_dangerous',
+  'file_write',
+  'fs_destructive',
+  'network',
+  'git_destructive',
+  'privileged',
+  'browser',
+  'computer_use',
+  'custom',
+]);
+
+export function isPermissionRequestPayload(value: unknown): value is PermissionRequestPayload {
+  if (!isRecord(value)) return false;
+  const common =
+    typeof value.requestId === 'string' &&
+    typeof value.toolUseId === 'string' &&
+    typeof value.toolName === 'string' &&
+    isToolCategory(value.category);
+  if (!common) return false;
+
+  if (value.kind === 'tool_permission') {
+    return (
+      hasExactShape(value, TOOL_PERMISSION_SHAPE) &&
+      TOOL_PERMISSION_REASONS.has(value.reason as string) &&
+      Object.hasOwn(value, 'args') &&
+      typeof value.rememberForTurnAllowed === 'boolean' &&
+      isOptionalString(value.hint)
+    );
+  }
+  if (value.kind === 'additional_permissions') {
+    return (
+      hasExactShape(value, ADDITIONAL_PERMISSION_SHAPE) &&
+      value.reason === 'additional_permissions' &&
+      validateAdditionalPermissionProfile(value.additionalPermissions).ok &&
+      isAdditionalPermissionRisk(value.risk) &&
+      typeof value.cwd === 'string' &&
+      typeof value.justification === 'string' &&
+      typeof value.intentHash === 'string' &&
+      typeof value.permissionsHash === 'string' &&
+      typeof value.alsoApprovesToolExecution === 'boolean' &&
+      isAllowOnceDenyTuple(value.availableDecisions) &&
+      isOptionalString(value.hint)
+    );
+  }
+  return (
+    value.kind === 'sandbox_escalation' &&
+    hasExactShape(value, SANDBOX_ESCALATION_SHAPE) &&
+    value.toolName === 'Bash' &&
+    value.reason === 'sandbox_escalation' &&
+    typeof value.command === 'string' &&
+    typeof value.cwd === 'string' &&
+    typeof value.justification === 'string' &&
+    typeof value.intentHash === 'string' &&
+    typeof value.commandHash === 'string' &&
+    (value.trigger === 'proactive' || value.trigger === 'sandbox_denial') &&
+    isSandboxEscalationRisk(value.risk) &&
+    typeof value.alsoApprovesToolExecution === 'boolean' &&
+    isAllowOnceDenyTuple(value.availableDecisions) &&
+    isOptionalString(value.hint)
+  );
+}
+
+export function isPermissionResponse(value: unknown): value is PermissionResponse {
+  return (
+    isRecord(value) &&
+    hasExactShape(value, PERMISSION_RESPONSE_SHAPE) &&
+    typeof value.requestId === 'string' &&
+    isPermissionDecisionFields(value)
+  );
+}
+
+export function isPermissionDecisionFields(
+  value: Record<string, unknown>,
+  options: { allowHint?: boolean } = {},
+): boolean {
+  return (
+    (value.decision === 'allow' || value.decision === 'deny') &&
+    (value.rememberForTurn === undefined || typeof value.rememberForTurn === 'boolean') &&
+    (value.reviewer === undefined ||
+      (APPROVALS_REVIEWERS as readonly unknown[]).includes(value.reviewer)) &&
+    isOptionalString(value.rationale) &&
+    (value.riskLevel === undefined ||
+      (APPROVAL_RISK_LEVELS as readonly unknown[]).includes(value.riskLevel)) &&
+    (!options.allowHint || isOptionalString(value.hint))
+  );
+}
+
+export function isUserQuestionRequest(value: unknown): value is UserQuestionRequest {
+  return (
+    isRecord(value) &&
+    hasExactShape(value, QUESTION_REQUEST_SHAPE) &&
+    typeof value.requestId === 'string' &&
+    typeof value.toolUseId === 'string' &&
+    Array.isArray(value.questions) &&
+    value.questions.every(isUserQuestion)
+  );
+}
+
+export function isAttachmentRef(value: unknown): value is AttachmentRef {
+  return (
+    isRecord(value) &&
+    hasExactShape(value, ATTACHMENT_SHAPE) &&
+    ['image', 'pdf', 'doc', 'code', 'other'].includes(value.kind as string) &&
+    typeof value.name === 'string' &&
+    typeof value.mimeType === 'string' &&
+    isFiniteNumber(value.bytes) &&
+    value.bytes >= 0 &&
+    isStorageRef(value.ref)
+  );
+}
+
+export function isStorageRef(value: unknown): value is StorageRef {
+  if (!isRecord(value)) return false;
+  if (value.kind === 'session_file') {
+    return (
+      hasExactShape(value, SESSION_FILE_REF_SHAPE) &&
+      typeof value.sessionId === 'string' &&
+      typeof value.relativePath === 'string'
+    );
+  }
+  if (value.kind === 'workspace_file') {
+    return hasExactShape(value, WORKSPACE_FILE_REF_SHAPE) && typeof value.relativePath === 'string';
+  }
+  return (
+    value.kind === 'external_file' &&
+    hasExactShape(value, EXTERNAL_FILE_REF_SHAPE) &&
+    typeof value.absolutePath === 'string'
+  );
+}
+
+function isUserQuestion(value: unknown): value is UserQuestion {
+  return (
+    isRecord(value) &&
+    hasExactShape(value, QUESTION_SHAPE) &&
+    typeof value.question === 'string' &&
+    Array.isArray(value.options) &&
+    value.options.every(isUserQuestionOption)
+  );
+}
+
+function isUserQuestionOption(value: unknown): value is UserQuestionOption {
+  return (
+    isRecord(value) &&
+    hasExactShape(value, QUESTION_OPTION_SHAPE) &&
+    typeof value.label === 'string' &&
+    isOptionalString(value.description)
+  );
+}
+
+function isAdditionalPermissionRisk(value: unknown): value is AdditionalPermissionRiskSummary {
+  return (
+    isRecord(value) &&
+    hasExactShape(value, ADDITIONAL_PERMISSION_RISK_SHAPE) &&
+    typeof value.outsideWorkspace === 'boolean' &&
+    typeof value.protectedMetadata === 'boolean' &&
+    typeof value.networkEnabled === 'boolean'
+  );
+}
+
+function isSandboxEscalationRisk(value: unknown): value is SandboxEscalationRiskSummary {
+  return (
+    isRecord(value) &&
+    hasExactShape(value, SANDBOX_ESCALATION_RISK_SHAPE) &&
+    value.unsandboxedExecution === true &&
+    value.unrestrictedFileSystem === true &&
+    value.unrestrictedNetwork === true &&
+    value.protectedMetadataExposed === true
+  );
+}
+
+function isAllowOnceDenyTuple(value: unknown): boolean {
+  return (
+    Array.isArray(value) && value.length === 2 && value[0] === 'allow_once' && value[1] === 'deny'
+  );
+}

--- a/packages/core/src/record-schema.ts
+++ b/packages/core/src/record-schema.ts
@@ -1,0 +1,70 @@
+type IsOptionalInAnyMember<T extends object, K extends keyof T> = T extends unknown
+  ? {} extends Pick<T, K>
+    ? true
+    : false
+  : never;
+
+type RequiredKey<T extends object> = {
+  [K in keyof T]-?: true extends IsOptionalInAnyMember<T, K> ? never : K;
+}[keyof T] &
+  string;
+
+type OptionalKey<T extends object> = Exclude<keyof T & string, RequiredKey<T>>;
+
+type Covers<Expected extends string, Actual extends string> =
+  Exclude<Expected, Actual> extends never
+    ? unknown
+    : { readonly __missingKeys__: Exclude<Expected, Actual> };
+
+export interface ExactObjectShape {
+  readonly required: readonly string[];
+  readonly allowed: ReadonlySet<string>;
+}
+
+/**
+ * Defines a JSON object shape while making schema additions a type error until
+ * both the required and optional key lists are updated.
+ */
+export function defineObjectShape<T extends object>() {
+  return <
+    const Required extends readonly RequiredKey<T>[],
+    const Optional extends readonly OptionalKey<T>[],
+  >(
+    required: Required & Covers<RequiredKey<T>, Required[number]>,
+    optional: Optional & Covers<OptionalKey<T>, Optional[number]>,
+  ): ExactObjectShape => ({
+    required,
+    allowed: new Set([...required, ...optional]),
+  });
+}
+
+export function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+export function hasExactShape(value: Record<string, unknown>, shape: ExactObjectShape): boolean {
+  return (
+    shape.required.every((key) => Object.hasOwn(value, key)) &&
+    Object.keys(value).every((key) => shape.allowed.has(key))
+  );
+}
+
+export function isFiniteNumber(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value);
+}
+
+export function isOptionalFiniteNumber(value: unknown): boolean {
+  return value === undefined || isFiniteNumber(value);
+}
+
+export function isOptionalString(value: unknown): boolean {
+  return value === undefined || typeof value === 'string';
+}
+
+export function isStringArray(value: unknown): value is string[] {
+  return Array.isArray(value) && value.every((item) => typeof item === 'string');
+}
+
+export function isStringNumberRecord(value: unknown): boolean {
+  return isRecord(value) && Object.values(value).every(isFiniteNumber);
+}

--- a/packages/core/src/runtime-event-store.ts
+++ b/packages/core/src/runtime-event-store.ts
@@ -1,7 +1,27 @@
 import type { RuntimeEvent } from './runtime-event.js';
 
+/** A requested stable-storage barrier failed; read-back cannot upgrade it to success. */
+export class DurableStoreWriteError extends Error {
+  readonly name = 'DurableStoreWriteError';
+
+  constructor(message: string, readonly storeCause: unknown) {
+    super(message);
+  }
+}
+
 export interface RuntimeEventStore {
-  appendRuntimeEvent(sessionId: string, runId: string, event: RuntimeEvent): Promise<void>;
+  appendRuntimeEvent(
+    sessionId: string,
+    runId: string,
+    event: RuntimeEvent,
+    options?: { durable?: boolean },
+  ): Promise<void>;
+  /** Append the terminal event if absent, or re-establish its stable-storage barrier if present. */
+  ensureTerminalRuntimeEventDurable(
+    sessionId: string,
+    runId: string,
+    event: RuntimeEvent,
+  ): Promise<void>;
   readRuntimeEvents(sessionId: string, runId: string): Promise<RuntimeEvent[]>;
   /** Physical append-log rows only; excludes mutable partial snapshots. */
   readImmutableRuntimeEvents?(sessionId: string, runId: string): Promise<RuntimeEvent[]>;

--- a/packages/core/src/runtime-event.ts
+++ b/packages/core/src/runtime-event.ts
@@ -23,6 +23,21 @@ import type {
   PrefixChangeReason,
   PromptSegmentEstimate,
 } from './usage-stats/types.js';
+import {
+  defineObjectShape,
+  hasExactShape,
+  isFiniteNumber,
+  isOptionalString,
+  isRecord,
+  isStringArray,
+} from './record-schema.js';
+import {
+  isAttachmentRef,
+  isPermissionRequestPayload,
+  isPermissionResponse,
+  isUserQuestionRequest,
+} from './interaction-record-schema.js';
+import { isTokenUsageFields } from './usage-record-schema.js';
 
 // ============================================================================
 // Role / Author / Status
@@ -310,6 +325,169 @@ export interface RuntimeEvent {
   content?: RuntimeEventContent;
   actions?: RuntimeEventActions;
   refs?: RuntimeEventRefs;
+}
+
+const RUNTIME_EVENT_SHAPE = defineObjectShape<RuntimeEvent>()(
+  ['id', 'invocationId', 'runId', 'sessionId', 'turnId', 'ts', 'partial', 'role', 'author'],
+  ['branch', 'status', 'content', 'actions', 'refs'],
+);
+const TEXT_CONTENT_SHAPE = defineObjectShape<RuntimeEventTextContent>()(
+  ['kind', 'text'],
+  ['displayText', 'attachments', 'steering'],
+);
+const THINKING_CONTENT_SHAPE = defineObjectShape<RuntimeEventThinkingContent>()(['kind', 'text'], ['signature']);
+const FUNCTION_CALL_CONTENT_SHAPE = defineObjectShape<RuntimeEventFunctionCallContent>()(
+  ['kind', 'id', 'name', 'args'],
+  [],
+);
+const FUNCTION_RESPONSE_CONTENT_SHAPE = defineObjectShape<RuntimeEventFunctionResponseContent>()(
+  ['kind', 'id', 'name', 'result'],
+  ['isError'],
+);
+const ERROR_CONTENT_SHAPE = defineObjectShape<RuntimeEventErrorContent>()(
+  ['kind', 'message'],
+  ['code', 'reason', 'details'],
+);
+const RUNTIME_ACTIONS_SHAPE = defineObjectShape<RuntimeEventActions>()(
+  [],
+  [
+    'stateDelta',
+    'artifactDelta',
+    'permissionRequest',
+    'permissionDecision',
+    'userQuestionRequest',
+    'transferToAgent',
+    'endInvocation',
+    'tokenUsage',
+  ],
+);
+const RUNTIME_TOKEN_USAGE_SHAPE = defineObjectShape<RuntimeEventTokenUsage>()(
+  ['input', 'output'],
+  [
+    'cacheHitInput',
+    'cacheMissInput',
+    'cacheWriteInput',
+    'cacheMissInputSource',
+    'reasoning',
+    'total',
+    'rawFinishReason',
+    'runtimeSteps',
+    'cacheRead',
+    'cacheCreation',
+    'costUsd',
+    'systemPromptHash',
+    'contextRemaining',
+    'prefixHash',
+    'prefixChangeReason',
+    'requestShapeHash',
+    'requestShapeChangeReason',
+    'promptSegments',
+    'contextBudget',
+  ],
+);
+const RUNTIME_REFS_SHAPE = defineObjectShape<RuntimeEventRefs>()(
+  [],
+  ['storedMessageId', 'traceEventId', 'toolCallId', 'providerEventId', 'artifactId', 'stepId'],
+);
+
+export function decodeRuntimeEvent(value: unknown): RuntimeEvent {
+  if (
+    !isRecord(value) ||
+    !hasExactShape(value, RUNTIME_EVENT_SHAPE) ||
+    typeof value.id !== 'string' ||
+    typeof value.invocationId !== 'string' ||
+    typeof value.runId !== 'string' ||
+    typeof value.sessionId !== 'string' ||
+    typeof value.turnId !== 'string' ||
+    !isFiniteNumber(value.ts) ||
+    !isOptionalString(value.branch) ||
+    typeof value.partial !== 'boolean' ||
+    !isRuntimeEventRole(value.role) ||
+    !isRuntimeEventAuthor(value.author) ||
+    (value.status !== undefined && !isRuntimeEventStatus(value.status)) ||
+    (value.content !== undefined && !isRuntimeEventContent(value.content)) ||
+    (value.actions !== undefined && !isRuntimeEventActions(value.actions)) ||
+    (value.refs !== undefined && !isRuntimeEventRefs(value.refs))
+  ) {
+    throw new Error('Invalid RuntimeEvent schema');
+  }
+  return value as unknown as RuntimeEvent;
+}
+
+function isRuntimeEventContent(value: unknown): value is RuntimeEventContent {
+  if (!isRecord(value)) return false;
+  switch (value.kind) {
+    case 'text':
+      return (
+        hasExactShape(value, TEXT_CONTENT_SHAPE) &&
+        typeof value.text === 'string' &&
+        isOptionalString(value.displayText) &&
+        (value.attachments === undefined ||
+          (Array.isArray(value.attachments) && value.attachments.every(isAttachmentRef))) &&
+        (value.steering === undefined || value.steering === true)
+      );
+    case 'thinking':
+      return (
+        hasExactShape(value, THINKING_CONTENT_SHAPE) &&
+        typeof value.text === 'string' &&
+        isOptionalString(value.signature)
+      );
+    case 'function_call':
+      return (
+        hasExactShape(value, FUNCTION_CALL_CONTENT_SHAPE) &&
+        typeof value.id === 'string' &&
+        typeof value.name === 'string' &&
+        Object.hasOwn(value, 'args')
+      );
+    case 'function_response':
+      return (
+        hasExactShape(value, FUNCTION_RESPONSE_CONTENT_SHAPE) &&
+        typeof value.id === 'string' &&
+        typeof value.name === 'string' &&
+        Object.hasOwn(value, 'result') &&
+        (value.isError === undefined || typeof value.isError === 'boolean')
+      );
+    case 'error':
+      return (
+        hasExactShape(value, ERROR_CONTENT_SHAPE) &&
+        isOptionalString(value.code) &&
+        isOptionalString(value.reason) &&
+        typeof value.message === 'string' &&
+        (value.details === undefined || isStringArray(value.details) || isRecord(value.details))
+      );
+    default:
+      return false;
+  }
+}
+
+function isRuntimeEventActions(value: unknown): value is RuntimeEventActions {
+  if (!isRecord(value) || !hasExactShape(value, RUNTIME_ACTIONS_SHAPE)) return false;
+  return (
+    (value.stateDelta === undefined || isRecord(value.stateDelta)) &&
+    (value.artifactDelta === undefined ||
+      (isRecord(value.artifactDelta) &&
+        Object.values(value.artifactDelta).every(
+          (item) => typeof item === 'string' || typeof item === 'boolean' || isFiniteNumber(item),
+        ))) &&
+    (value.permissionRequest === undefined || isPermissionRequestPayload(value.permissionRequest)) &&
+    (value.permissionDecision === undefined || isPermissionResponse(value.permissionDecision)) &&
+    (value.userQuestionRequest === undefined || isUserQuestionRequest(value.userQuestionRequest)) &&
+    isOptionalString(value.transferToAgent) &&
+    (value.endInvocation === undefined || typeof value.endInvocation === 'boolean') &&
+    (value.tokenUsage === undefined || isRuntimeTokenUsage(value.tokenUsage))
+  );
+}
+
+function isRuntimeTokenUsage(value: unknown): value is RuntimeEventTokenUsage {
+  return isRecord(value) && hasExactShape(value, RUNTIME_TOKEN_USAGE_SHAPE) && isTokenUsageFields(value);
+}
+
+function isRuntimeEventRefs(value: unknown): value is RuntimeEventRefs {
+  return (
+    isRecord(value) &&
+    hasExactShape(value, RUNTIME_REFS_SHAPE) &&
+    Object.values(value).every((item) => typeof item === 'string')
+  );
 }
 
 // ============================================================================

--- a/packages/core/src/session.ts
+++ b/packages/core/src/session.ts
@@ -6,7 +6,7 @@
  * is enforced by the storage implementation.
  */
 
-import type { AttachmentRef, ToolActivityKind, ToolResultContent } from './events.js';
+import { TOOL_ACTIVITY_KINDS, type AttachmentRef, type ToolActivityKind, type ToolResultContent } from './events.js';
 import type { PermissionMode } from './permission.js';
 import type {
   CacheMissInputSource,
@@ -14,6 +14,13 @@ import type {
   PrefixChangeReason,
   PromptSegmentEstimate,
 } from './usage-stats/types.js';
+import { defineObjectShape, hasExactShape, isFiniteNumber, isOptionalString, isRecord } from './record-schema.js';
+import { isAttachmentRef, isPermissionDecisionFields } from './interaction-record-schema.js';
+import { isTokenUsageFields } from './usage-record-schema.js';
+import {
+  decodeCanonicalToolResultContent,
+  normalizeToolResultContentForRead,
+} from './tool-result-record-schema.js';
 
 export const SESSION_STATUSES = [
   'active',
@@ -361,6 +368,234 @@ export interface SystemNoteMessage {
     | 'abort';
   /** Shape depends on `kind`. */
   data?: unknown;
+}
+
+const USER_MESSAGE_SHAPE = defineObjectShape<UserMessage>()(
+  ['type', 'id', 'turnId', 'ts', 'text'],
+  ['displayText', 'attachments', 'origin'],
+);
+const ASSISTANT_MESSAGE_SHAPE = defineObjectShape<AssistantMessage>()(
+  ['type', 'id', 'turnId', 'ts', 'text', 'modelId'],
+  ['thinking', 'contentOrder'],
+);
+const TOOL_CALL_MESSAGE_SHAPE = defineObjectShape<ToolCallMessage>()(
+  ['type', 'id', 'turnId', 'ts', 'toolName', 'args'],
+  ['activityKind', 'displayName', 'intent', 'stepId'],
+);
+const TOOL_RESULT_MESSAGE_SHAPE = defineObjectShape<ToolResultMessage>()(
+  ['type', 'id', 'turnId', 'ts', 'toolUseId', 'isError', 'content'],
+  ['durationMs'],
+);
+const PERMISSION_DECISION_MESSAGE_SHAPE = defineObjectShape<PermissionDecisionMessage>()(
+  ['type', 'id', 'turnId', 'ts', 'toolUseId', 'toolName', 'decision'],
+  ['rememberForTurn', 'reviewer', 'rationale', 'riskLevel', 'hint'],
+);
+const TOKEN_USAGE_MESSAGE_SHAPE = defineObjectShape<TokenUsageMessage>()(
+  ['type', 'id', 'turnId', 'ts', 'input', 'output'],
+  [
+    'cacheHitInput',
+    'cacheMissInput',
+    'cacheWriteInput',
+    'cacheMissInputSource',
+    'reasoning',
+    'total',
+    'rawFinishReason',
+    'runtimeSteps',
+    'cacheRead',
+    'cacheCreation',
+    'costUsd',
+    'systemPromptHash',
+    'prefixHash',
+    'prefixChangeReason',
+    'requestShapeHash',
+    'requestShapeChangeReason',
+    'promptSegments',
+    'contextBudget',
+  ],
+);
+const TURN_STATE_MESSAGE_SHAPE = defineObjectShape<TurnStateMessage>()(
+  ['type', 'id', 'turnId', 'ts', 'status', 'partialOutputRetained'],
+  [
+    'parentTurnId',
+    'retriedFromTurnId',
+    'regeneratedFromTurnId',
+    'branchOfTurnId',
+    'parentSessionId',
+    'abortedAt',
+    'abortSource',
+    'errorClass',
+  ],
+);
+const SYSTEM_NOTE_MESSAGE_SHAPE = defineObjectShape<SystemNoteMessage>()(
+  ['type', 'id', 'ts', 'kind'],
+  ['turnId', 'data'],
+);
+type AssistantThinking = NonNullable<AssistantMessage['thinking']>;
+const ASSISTANT_THINKING_SHAPE = defineObjectShape<AssistantThinking>()(['text'], ['signature']);
+type AutomationOrigin = NonNullable<UserMessage['origin']>;
+const AUTOMATION_ORIGIN_SHAPE = defineObjectShape<AutomationOrigin>()(['kind', 'automationId'], []);
+
+const SYSTEM_NOTE_KINDS = new Set([
+  'session_start',
+  'session_resume',
+  'mode_change',
+  'model_change',
+  'context_compacted',
+  'context_compaction_failed_open',
+  'step_limit',
+  'error',
+  'abort',
+]);
+
+export function decodeStoredMessageForRead(value: unknown): StoredMessage {
+  return decodeStoredMessage(value, normalizeToolResultContentForRead);
+}
+
+export function decodeStoredMessageForRecovery(value: unknown): StoredMessage {
+  return decodeStoredMessage(value, decodeCanonicalToolResultContent);
+}
+
+function decodeStoredMessage(
+  value: unknown,
+  decodeToolResultContent: (content: unknown) => ToolResultContent,
+): StoredMessage {
+  const message = decodeStoredMessageContent(value, decodeToolResultContent);
+  if (!isRecord(message)) throw new Error('Invalid stored message schema');
+  switch (message.type) {
+    case 'user':
+      if (
+        hasExactShape(message, USER_MESSAGE_SHAPE) &&
+        hasMessageEnvelope(message, true) &&
+        typeof message.text === 'string' &&
+        isOptionalString(message.displayText) &&
+        (message.attachments === undefined ||
+          (Array.isArray(message.attachments) && message.attachments.every(isAttachmentRef))) &&
+        (message.origin === undefined || isAutomationOrigin(message.origin))
+      )
+        return message as unknown as UserMessage;
+      break;
+    case 'assistant':
+      if (
+        hasExactShape(message, ASSISTANT_MESSAGE_SHAPE) &&
+        hasMessageEnvelope(message, true) &&
+        typeof message.text === 'string' &&
+        typeof message.modelId === 'string' &&
+        (message.thinking === undefined || isAssistantThinking(message.thinking)) &&
+        (message.contentOrder === undefined ||
+          (Array.isArray(message.contentOrder) &&
+            message.contentOrder.every((item) => item === 'thinking' || item === 'text' || item === 'tools')))
+      )
+        return message as unknown as AssistantMessage;
+      break;
+    case 'tool_call':
+      if (
+        hasExactShape(message, TOOL_CALL_MESSAGE_SHAPE) &&
+        hasMessageEnvelope(message, true) &&
+        typeof message.toolName === 'string' &&
+        Object.hasOwn(message, 'args') &&
+        (message.activityKind === undefined ||
+          (TOOL_ACTIVITY_KINDS as readonly unknown[]).includes(message.activityKind)) &&
+        isOptionalString(message.displayName) &&
+        isOptionalString(message.intent) &&
+        isOptionalString(message.stepId)
+      )
+        return message as unknown as ToolCallMessage;
+      break;
+    case 'tool_result':
+      if (
+        hasExactShape(message, TOOL_RESULT_MESSAGE_SHAPE) &&
+        hasMessageEnvelope(message, true) &&
+        typeof message.toolUseId === 'string' &&
+        typeof message.isError === 'boolean' &&
+        isOptionalFiniteDuration(message.durationMs)
+      )
+        return message as unknown as ToolResultMessage;
+      break;
+    case 'permission_decision':
+      if (
+        hasExactShape(message, PERMISSION_DECISION_MESSAGE_SHAPE) &&
+        hasMessageEnvelope(message, true) &&
+        typeof message.toolUseId === 'string' &&
+        typeof message.toolName === 'string' &&
+        isPermissionDecisionFields(message, { allowHint: true })
+      )
+        return message as unknown as PermissionDecisionMessage;
+      break;
+    case 'token_usage':
+      if (
+        hasExactShape(message, TOKEN_USAGE_MESSAGE_SHAPE) &&
+        hasMessageEnvelope(message, true) &&
+        isTokenUsageFields(message)
+      )
+        return message as unknown as TokenUsageMessage;
+      break;
+    case 'turn_state':
+      if (
+        hasExactShape(message, TURN_STATE_MESSAGE_SHAPE) &&
+        hasMessageEnvelope(message, true) &&
+        isTurnStatus(message.status) &&
+        typeof message.partialOutputRetained === 'boolean' &&
+        isOptionalString(message.parentTurnId) &&
+        isOptionalString(message.retriedFromTurnId) &&
+        isOptionalString(message.regeneratedFromTurnId) &&
+        isOptionalString(message.branchOfTurnId) &&
+        isOptionalString(message.parentSessionId) &&
+        (message.abortedAt === undefined || isFiniteNumber(message.abortedAt)) &&
+        isOptionalString(message.abortSource) &&
+        isOptionalString(message.errorClass)
+      )
+        return message as unknown as TurnStateMessage;
+      break;
+    case 'system_note':
+      if (
+        hasExactShape(message, SYSTEM_NOTE_MESSAGE_SHAPE) &&
+        hasMessageEnvelope(message, false) &&
+        isOptionalString(message.turnId) &&
+        SYSTEM_NOTE_KINDS.has(message.kind as string)
+      )
+        return message as unknown as SystemNoteMessage;
+      break;
+  }
+  throw new Error('Invalid stored message schema');
+}
+
+function decodeStoredMessageContent(
+  value: unknown,
+  decodeToolResultContent: (content: unknown) => ToolResultContent,
+): unknown {
+  if (!isRecord(value) || value.type !== 'tool_result') return value;
+  return {
+    ...value,
+    content: decodeToolResultContent(value.content),
+  };
+}
+
+function hasMessageEnvelope(value: Record<string, unknown>, turnRequired: boolean): boolean {
+  return (
+    typeof value.id === 'string' && isFiniteNumber(value.ts) && (turnRequired ? typeof value.turnId === 'string' : true)
+  );
+}
+
+function isAssistantThinking(value: unknown): value is AssistantThinking {
+  return (
+    isRecord(value) &&
+    hasExactShape(value, ASSISTANT_THINKING_SHAPE) &&
+    typeof value.text === 'string' &&
+    isOptionalString(value.signature)
+  );
+}
+
+function isAutomationOrigin(value: unknown): value is AutomationOrigin {
+  return (
+    isRecord(value) &&
+    hasExactShape(value, AUTOMATION_ORIGIN_SHAPE) &&
+    value.kind === 'automation' &&
+    typeof value.automationId === 'string'
+  );
+}
+
+function isOptionalFiniteDuration(value: unknown): boolean {
+  return value === undefined || isFiniteNumber(value);
 }
 
 export const STEP_LIMIT_NOTICE_TEXT =

--- a/packages/core/src/shell-run-result.ts
+++ b/packages/core/src/shell-run-result.ts
@@ -2,8 +2,10 @@ import type {
   ShellRunSnapshotResult,
   ShellRunStateResult,
   ShellRunUpdate,
+  SandboxDenialRecovery,
   ToolResultContent,
 } from './events.js';
+import { defineObjectShape, hasExactShape } from './record-schema.js';
 import {
   isShellOutput,
   isShellRunStatus,
@@ -15,6 +17,12 @@ import {
 export type ShellRunToolResult = Extract<ToolResultContent, { kind: 'shell_run' }>;
 type TerminalToolResult = Extract<ToolResultContent, { kind: 'terminal' }>;
 type ShellToolResult = TerminalToolResult | ShellRunToolResult;
+type ShellRunToolResultRecord = Omit<ShellRunToolResult, 'output' | 'operation'> & {
+  output?: ShellOutput;
+  operation?: ShellRunToolResult extends { operation?: infer Operation }
+    ? Operation
+    : never;
+};
 
 /** Bounds observer updates retained while a durable ShellRun view is hydrating. */
 export const SHELL_RUN_UPDATE_BUFFER_MAX_ENTRIES = 256;
@@ -77,33 +85,20 @@ export type ShellToolResultNormalization =
   | { state: 'invalid' }
   | { state: 'valid'; content: ShellToolResult };
 
-const CURRENT_TERMINAL_RESULT_KEYS = new Set([
-  'kind',
-  'cwd',
-  'cmd',
-  'status',
-  'exitCode',
-  'failureMessage',
-  'output',
-]);
+const CURRENT_TERMINAL_RESULT_SHAPE = defineObjectShape<TerminalToolResult>()(
+  ['kind', 'cwd', 'cmd', 'status', 'output'],
+  ['exitCode', 'failureMessage', 'sandboxDenial'],
+);
 
-const CURRENT_SHELL_RUN_RESULT_KEYS = new Set([
-  'kind',
-  'ref',
-  'mode',
-  'status',
-  'cwd',
-  'cmd',
-  'startedAt',
-  'updatedAt',
-  'completedAt',
-  'exitCode',
-  'failureMessage',
-  'revision',
-  'timeoutMs',
-  'output',
-  'operation',
-]);
+const CURRENT_SHELL_RUN_RESULT_SHAPE = defineObjectShape<ShellRunToolResultRecord>()(
+  ['kind', 'ref', 'mode', 'status', 'cwd', 'cmd', 'startedAt', 'updatedAt', 'revision'],
+  ['completedAt', 'exitCode', 'failureMessage', 'timeoutMs', 'output', 'operation', 'sandboxDenial'],
+);
+
+const SANDBOX_DENIAL_SHAPE = defineObjectShape<SandboxDenialRecovery>()(
+  ['likely', 'recovery'],
+  ['backend'],
+);
 
 const STOP_OPERATION_KEYS = new Set(['kind', 'applied']);
 const PTY_CONTROL_OPERATION_KEYS = new Set(['kind', 'failed', 'input', 'resize']);
@@ -155,19 +150,25 @@ const LEGACY_SHELL_RUN_RESULT_KEYS = new Set([
 
 /** Validate current shell results and normalize only the exact preceding shape. */
 export function normalizeShellToolResultContent(value: unknown): ShellToolResultNormalization {
-  if (!isRecord(value) || (value.kind !== 'terminal' && value.kind !== 'shell_run')) {
-    return { state: 'not_shell' };
-  }
-  const current = value.kind === 'terminal'
-    ? currentTerminalResult(value)
-    : currentShellRunResult(value);
-  if (current) return { state: 'valid', content: current };
+  const canonical = decodeCanonicalShellToolResultContent(value);
+  if (canonical.state !== 'invalid') return canonical;
+  if (!isRecord(value)) return canonical;
   const legacy = value.kind === 'terminal'
     ? normalizeLegacyTerminalResult(value) ?? normalizePreStatusTerminalResult(value)
     : normalizeLegacyShellRunResult(value);
   return legacy
     ? { state: 'valid', content: legacy }
     : { state: 'invalid' };
+}
+
+export function decodeCanonicalShellToolResultContent(value: unknown): ShellToolResultNormalization {
+  if (!isRecord(value) || (value.kind !== 'terminal' && value.kind !== 'shell_run')) {
+    return { state: 'not_shell' };
+  }
+  const current = value.kind === 'terminal'
+    ? currentTerminalResult(value)
+    : currentShellRunResult(value);
+  return current ? { state: 'valid', content: current } : { state: 'invalid' };
 }
 
 function normalizePreStatusTerminalResult(
@@ -205,12 +206,13 @@ function hasLegacyTruncationMarker(value: string): boolean {
 
 function currentTerminalResult(value: Record<string, unknown>): TerminalToolResult | undefined {
   if (
-    !hasOnlyKeys(value, CURRENT_TERMINAL_RESULT_KEYS)
+    !hasExactShape(value, CURRENT_TERMINAL_RESULT_SHAPE)
     || typeof value.cwd !== 'string'
     || typeof value.cmd !== 'string'
     || !isLegacyTerminalStatus(value.status)
     || !isOptionalFiniteNumber(value.exitCode)
     || !isOptionalString(value.failureMessage)
+    || !isOptionalSandboxDenial(value.sandboxDenial)
     || !isShellOutput(value.output)
     || !isValidTerminalState(value)
   ) return undefined;
@@ -237,7 +239,7 @@ function isValidTerminalState(value: Record<string, unknown>): boolean {
 
 function currentShellRunResult(value: Record<string, unknown>): ShellRunToolResult | undefined {
   if (
-    !hasOnlyKeys(value, CURRENT_SHELL_RUN_RESULT_KEYS)
+    !hasExactShape(value, CURRENT_SHELL_RUN_RESULT_SHAPE)
     || typeof value.ref !== 'string'
     || (value.mode !== 'pipes' && value.mode !== 'pty')
     || !isShellRunStatus(value.status)
@@ -250,6 +252,7 @@ function currentShellRunResult(value: Record<string, unknown>): ShellRunToolResu
     || !isOptionalFiniteNumber(value.exitCode)
     || !isOptionalFiniteNumber(value.timeoutMs)
     || !isOptionalString(value.failureMessage)
+    || !isOptionalSandboxDenial(value.sandboxDenial)
     || (value.output !== undefined
       && (!isShellOutput(value.output) || value.output.mode !== value.mode))
     || !isCurrentShellRunOperation(value.operation, value.mode, value.output !== undefined)
@@ -448,6 +451,16 @@ function isOptionalFiniteNumber(value: unknown): boolean {
 
 function isOptionalString(value: unknown): boolean {
   return value === undefined || typeof value === 'string';
+}
+
+function isOptionalSandboxDenial(value: unknown): boolean {
+  return value === undefined || (
+    isRecord(value) &&
+    hasExactShape(value, SANDBOX_DENIAL_SHAPE) &&
+    value.likely === true &&
+    (value.backend === undefined || value.backend === 'macos-seatbelt' || value.backend === 'linux') &&
+    value.recovery === 'require_escalated'
+  );
 }
 
 function isOptionalBoolean(value: unknown): boolean {

--- a/packages/core/src/tool-result-record-schema.ts
+++ b/packages/core/src/tool-result-record-schema.ts
@@ -1,0 +1,446 @@
+import {
+  decodeCanonicalShellToolResultContent,
+  normalizeShellToolResultContent,
+} from './shell-run-result.js';
+import { isPermissionMode } from './permission.js';
+import type { ToolResultContent } from './events.js';
+import {
+  defineObjectShape,
+  hasExactShape,
+  isFiniteNumber,
+  isOptionalFiniteNumber,
+  isOptionalString,
+  isRecord,
+  isStringArray,
+} from './record-schema.js';
+import { isStorageRef } from './interaction-record-schema.js';
+
+type Result<K extends ToolResultContent['kind']> = Extract<ToolResultContent, { kind: K }>;
+type ExploreResult = Result<'explore_agent'>;
+type RiveResult = Result<'rive_workflow'>;
+
+const TEXT_SHAPE = defineObjectShape<Result<'text'>>()(['kind', 'text'], []);
+const JSON_SHAPE = defineObjectShape<Result<'json'>>()(['kind', 'value'], []);
+const FILE_DIFF_SHAPE = defineObjectShape<Result<'file_diff'>>()(['kind', 'paths', 'diff'], []);
+const FILE_WRITE_SHAPE = defineObjectShape<Result<'file_write'>>()(['kind', 'path', 'bytes'], []);
+const ARCHIVED_SHAPE = defineObjectShape<Result<'archived_tool_result'>>()(
+  [
+    'kind',
+    'status',
+    'runtimeEventId',
+    'toolCallId',
+    'toolName',
+    'originalEstimatedTokens',
+    'originalBytes',
+    'rewriteVersion',
+    'reason',
+  ],
+  ['artifactId', 'bodySha256'],
+);
+const IMAGE_SHAPE = defineObjectShape<Result<'image'>>()(['kind', 'mimeType', 'ref'], []);
+const SUMMARY_SHAPE = defineObjectShape<Result<'summary'>>()(
+  ['kind', 'original', 'summarized', 'reason'],
+  [],
+);
+const WEB_SEARCH_SHAPE = defineObjectShape<Result<'web_search'>>()(
+  ['kind', 'provider', 'query', 'rows'],
+  [],
+);
+type WebSearchRow = Result<'web_search'>['rows'][number];
+const WEB_SEARCH_ROW_SHAPE = defineObjectShape<WebSearchRow>()(
+  ['title', 'url', 'snippet', 'source'],
+  [],
+);
+const WEB_SEARCH_ERROR_SHAPE = defineObjectShape<Result<'web_search_error'>>()(
+  ['kind', 'ok', 'provider', 'reason', 'message'],
+  ['query', 'credentialSource'],
+);
+const OFFICE_DOCUMENT_SHAPE = defineObjectShape<Result<'office_document'>>()(
+  ['kind', 'ok'],
+  ['operation', 'path', 'args', 'stdout', 'stderr', 'truncated', 'reason', 'message'],
+);
+const EXPLORE_SHAPE = defineObjectShape<ExploreResult>()(
+  [
+    'kind',
+    'ok',
+    'mode',
+    'objective',
+    'roots',
+    'queries',
+    'filesInspected',
+    'filesSkipped',
+    'bytesRead',
+    'progress',
+    'candidateFiles',
+    'matches',
+    'notes',
+  ],
+  [
+    'partial',
+    'terminalStatus',
+    'ignoredPaths',
+    'stoppingCondition',
+    'limitReasons',
+    'filesDiscovered',
+    'sensitiveFilesSkipped',
+    'startedAt',
+    'completedAt',
+    'durationMs',
+    'recentEvents',
+    'evidence',
+    'summary',
+    'report',
+    'reason',
+    'message',
+  ],
+);
+type ExploreRecentEvent = NonNullable<ExploreResult['recentEvents']>[number];
+type ExploreEvidence = NonNullable<ExploreResult['evidence']>[number];
+type ExploreCandidate = ExploreResult['candidateFiles'][number];
+type ExploreMatch = ExploreResult['matches'][number];
+const EXPLORE_RECENT_EVENT_SHAPE = defineObjectShape<ExploreRecentEvent>()(
+  ['type', 'at', 'message'],
+  [],
+);
+const EXPLORE_EVIDENCE_SHAPE = defineObjectShape<ExploreEvidence>()(
+  ['type', 'path', 'label'],
+  ['line', 'score'],
+);
+const EXPLORE_CANDIDATE_SHAPE = defineObjectShape<ExploreCandidate>()(
+  ['path', 'score', 'reasons'],
+  [],
+);
+const EXPLORE_MATCH_SHAPE = defineObjectShape<ExploreMatch>()(
+  ['path', 'line', 'query', 'snippet'],
+  [],
+);
+const SUBAGENT_SHAPE = defineObjectShape<Result<'subagent'>>()(
+  ['kind', 'agentName', 'turnId', 'status', 'permissionMode', 'summary', 'artifactIds'],
+  ['agentId', 'runId', 'startedAt', 'completedAt', 'durationMs', 'eventCount', 'failureClass'],
+);
+const RIVE_SHAPE = defineObjectShape<RiveResult>()(
+  ['kind', 'ok', 'action', 'command', 'ids', 'summary'],
+  ['state', 'projection', 'nodes', 'stdoutTail', 'stderrTail', 'error'],
+);
+const RIVE_IDS_SHAPE = defineObjectShape<RiveResult['ids']>()(
+  [],
+  ['workflowRunId', 'schedulerRunId', 'rootWorkNodeId'],
+);
+type RiveProjection = NonNullable<RiveResult['projection']>;
+const RIVE_PROJECTION_SHAPE = defineObjectShape<RiveProjection>()(
+  [],
+  [
+    'templateId',
+    'version',
+    'templateHash',
+    'idempotencyStatus',
+    'workflowRunId',
+    'schedulerRunId',
+    'rootWorkNodeId',
+    'state',
+    'schedulerState',
+    'rootState',
+  ],
+);
+type RiveNode = NonNullable<RiveResult['nodes']>[number];
+const RIVE_NODE_SHAPE = defineObjectShape<RiveNode>()(
+  [],
+  ['id', 'templateId', 'title', 'state', 'runner', 'worker'],
+);
+type RiveError = NonNullable<RiveResult['error']>;
+const RIVE_ERROR_SHAPE = defineObjectShape<RiveError>()(
+  ['reason', 'message'],
+  ['code', 'suggestedAction'],
+);
+
+export function normalizeToolResultContentForRead(value: unknown): ToolResultContent {
+  const shell = normalizeShellToolResultContent(value);
+  if (shell.state === 'invalid') throw new Error('Invalid shell tool result content');
+  const normalized = shell.state === 'valid' ? shell.content : value;
+  return decodeCanonicalToolResultContent(normalized);
+}
+
+export function decodeCanonicalToolResultContent(value: unknown): ToolResultContent {
+  const shell = decodeCanonicalShellToolResultContent(value);
+  if (shell.state === 'invalid') throw new Error('Invalid shell tool result content');
+  if (shell.state === 'valid') return shell.content;
+  if (!isNonShellToolResultContent(value)) {
+    throw new Error('Invalid tool result content');
+  }
+  return value;
+}
+
+function isNonShellToolResultContent(value: unknown): value is ToolResultContent {
+  if (!isRecord(value) || typeof value.kind !== 'string') return false;
+  switch (value.kind) {
+    case 'text':
+      return hasExactShape(value, TEXT_SHAPE) && typeof value.text === 'string';
+    case 'json':
+      return hasExactShape(value, JSON_SHAPE) && Object.hasOwn(value, 'value');
+    case 'file_diff':
+      return (
+        hasExactShape(value, FILE_DIFF_SHAPE) &&
+        isStringArray(value.paths) &&
+        typeof value.diff === 'string'
+      );
+    case 'file_write':
+      return (
+        hasExactShape(value, FILE_WRITE_SHAPE) &&
+        typeof value.path === 'string' &&
+        isFiniteNumber(value.bytes)
+      );
+    case 'archived_tool_result':
+      return (
+        hasExactShape(value, ARCHIVED_SHAPE) &&
+        ['not_loaded', 'missing', 'corrupt'].includes(value.status as string) &&
+        typeof value.runtimeEventId === 'string' &&
+        typeof value.toolCallId === 'string' &&
+        typeof value.toolName === 'string' &&
+        isOptionalString(value.artifactId) &&
+        isOptionalString(value.bodySha256) &&
+        isFiniteNumber(value.originalEstimatedTokens) &&
+        isFiniteNumber(value.originalBytes) &&
+        isFiniteNumber(value.rewriteVersion) &&
+        value.reason === 'stale_tool_result_pruned_before_compact'
+      );
+    case 'image':
+      return (
+        hasExactShape(value, IMAGE_SHAPE) &&
+        typeof value.mimeType === 'string' &&
+        isStorageRef(value.ref)
+      );
+    case 'summary':
+      return (
+        hasExactShape(value, SUMMARY_SHAPE) &&
+        typeof value.original === 'string' &&
+        typeof value.summarized === 'string' &&
+        value.reason === 'too_large'
+      );
+    case 'web_search':
+      return (
+        hasExactShape(value, WEB_SEARCH_SHAPE) &&
+        typeof value.provider === 'string' &&
+        typeof value.query === 'string' &&
+        Array.isArray(value.rows) &&
+        value.rows.every(isWebSearchRow)
+      );
+    case 'web_search_error':
+      return (
+        hasExactShape(value, WEB_SEARCH_ERROR_SHAPE) &&
+        value.ok === false &&
+        typeof value.provider === 'string' &&
+        isOptionalString(value.query) &&
+        typeof value.reason === 'string' &&
+        typeof value.message === 'string' &&
+        isOptionalString(value.credentialSource)
+      );
+    case 'office_document':
+      return (
+        hasExactShape(value, OFFICE_DOCUMENT_SHAPE) &&
+        typeof value.ok === 'boolean' &&
+        isOptionalString(value.operation) &&
+        isOptionalString(value.path) &&
+        (value.args === undefined || isStringArray(value.args)) &&
+        isOptionalString(value.stdout) &&
+        isOptionalString(value.stderr) &&
+        (value.truncated === undefined || typeof value.truncated === 'boolean') &&
+        isOptionalString(value.reason) &&
+        isOptionalString(value.message)
+      );
+    case 'explore_agent':
+      return isExploreResult(value);
+    case 'subagent':
+      return (
+        hasExactShape(value, SUBAGENT_SHAPE) &&
+        isOptionalString(value.agentId) &&
+        typeof value.agentName === 'string' &&
+        typeof value.turnId === 'string' &&
+        isOptionalString(value.runId) &&
+        ['completed', 'failed', 'cancelled', 'running', 'waiting_permission'].includes(
+          value.status as string,
+        ) &&
+        isPermissionMode(value.permissionMode) &&
+        typeof value.summary === 'string' &&
+        isStringArray(value.artifactIds) &&
+        isOptionalFiniteNumber(value.startedAt) &&
+        isOptionalFiniteNumber(value.completedAt) &&
+        isOptionalFiniteNumber(value.durationMs) &&
+        isOptionalFiniteNumber(value.eventCount) &&
+        isOptionalString(value.failureClass)
+      );
+    case 'rive_workflow':
+      return isRiveResult(value);
+    default:
+      return false;
+  }
+}
+
+function isExploreResult(value: Record<string, unknown>): value is ExploreResult {
+  return (
+    hasExactShape(value, EXPLORE_SHAPE) &&
+    typeof value.ok === 'boolean' &&
+    (value.partial === undefined || typeof value.partial === 'boolean') &&
+    (value.terminalStatus === undefined ||
+      ['completed', 'completed_empty', 'failed', 'canceled', 'canceled_partial'].includes(
+        value.terminalStatus as string,
+      )) &&
+    value.mode === 'read_only' &&
+    typeof value.objective === 'string' &&
+    isStringArray(value.roots) &&
+    isStringArray(value.queries) &&
+    (value.ignoredPaths === undefined || isStringArray(value.ignoredPaths)) &&
+    isOptionalString(value.stoppingCondition) &&
+    (value.limitReasons === undefined ||
+      (Array.isArray(value.limitReasons) &&
+        value.limitReasons.every((reason) =>
+          ['candidate_budget', 'file_budget', 'match_budget', 'byte_budget'].includes(reason),
+        ))) &&
+    isOptionalFiniteNumber(value.filesDiscovered) &&
+    isFiniteNumber(value.filesInspected) &&
+    isFiniteNumber(value.filesSkipped) &&
+    isOptionalFiniteNumber(value.sensitiveFilesSkipped) &&
+    isFiniteNumber(value.bytesRead) &&
+    isOptionalFiniteNumber(value.startedAt) &&
+    isOptionalFiniteNumber(value.completedAt) &&
+    isOptionalFiniteNumber(value.durationMs) &&
+    isStringArray(value.progress) &&
+    (value.recentEvents === undefined ||
+      (Array.isArray(value.recentEvents) && value.recentEvents.every(isExploreRecentEvent))) &&
+    (value.evidence === undefined ||
+      (Array.isArray(value.evidence) && value.evidence.every(isExploreEvidence))) &&
+    isOptionalString(value.summary) &&
+    isOptionalString(value.report) &&
+    Array.isArray(value.candidateFiles) &&
+    value.candidateFiles.every(isExploreCandidate) &&
+    Array.isArray(value.matches) &&
+    value.matches.every(isExploreMatch) &&
+    isStringArray(value.notes) &&
+    (value.reason === undefined ||
+      ['invalid_objective', 'invalid_root', 'no_readable_roots', 'aborted'].includes(
+        value.reason as string,
+      )) &&
+    isOptionalString(value.message)
+  );
+}
+
+function isExploreRecentEvent(value: unknown): value is ExploreRecentEvent {
+  return (
+    isRecord(value) &&
+    hasExactShape(value, EXPLORE_RECENT_EVENT_SHAPE) &&
+    typeof value.type === 'string' &&
+    isFiniteNumber(value.at) &&
+    typeof value.message === 'string'
+  );
+}
+
+function isExploreEvidence(value: unknown): value is ExploreEvidence {
+  return (
+    isRecord(value) &&
+    hasExactShape(value, EXPLORE_EVIDENCE_SHAPE) &&
+    (value.type === 'match' || value.type === 'candidate') &&
+    typeof value.path === 'string' &&
+    isOptionalFiniteNumber(value.line) &&
+    typeof value.label === 'string' &&
+    isOptionalFiniteNumber(value.score)
+  );
+}
+
+function isExploreCandidate(value: unknown): value is ExploreCandidate {
+  return (
+    isRecord(value) &&
+    hasExactShape(value, EXPLORE_CANDIDATE_SHAPE) &&
+    typeof value.path === 'string' &&
+    isFiniteNumber(value.score) &&
+    isStringArray(value.reasons)
+  );
+}
+
+function isExploreMatch(value: unknown): value is ExploreMatch {
+  return (
+    isRecord(value) &&
+    hasExactShape(value, EXPLORE_MATCH_SHAPE) &&
+    typeof value.path === 'string' &&
+    isFiniteNumber(value.line) &&
+    typeof value.query === 'string' &&
+    typeof value.snippet === 'string'
+  );
+}
+
+function isWebSearchRow(value: unknown): value is WebSearchRow {
+  return (
+    isRecord(value) &&
+    hasExactShape(value, WEB_SEARCH_ROW_SHAPE) &&
+    typeof value.title === 'string' &&
+    typeof value.url === 'string' &&
+    typeof value.snippet === 'string' &&
+    typeof value.source === 'string'
+  );
+}
+
+function isRiveResult(value: Record<string, unknown>): value is RiveResult {
+  return (
+    hasExactShape(value, RIVE_SHAPE) &&
+    typeof value.ok === 'boolean' &&
+    typeof value.action === 'string' &&
+    isStringArray(value.command) &&
+    isOptionalString(value.state) &&
+    isRiveIds(value.ids) &&
+    typeof value.summary === 'string' &&
+    (value.projection === undefined || isRiveProjection(value.projection)) &&
+    (value.nodes === undefined || (Array.isArray(value.nodes) && value.nodes.every(isRiveNode))) &&
+    isOptionalString(value.stdoutTail) &&
+    isOptionalString(value.stderrTail) &&
+    (value.error === undefined || isRiveError(value.error))
+  );
+}
+
+function isRiveIds(value: unknown): value is RiveResult['ids'] {
+  return (
+    isRecord(value) &&
+    hasExactShape(value, RIVE_IDS_SHAPE) &&
+    isOptionalString(value.workflowRunId) &&
+    isOptionalString(value.schedulerRunId) &&
+    isOptionalString(value.rootWorkNodeId)
+  );
+}
+
+function isRiveProjection(value: unknown): value is RiveProjection {
+  return (
+    isRecord(value) &&
+    hasExactShape(value, RIVE_PROJECTION_SHAPE) &&
+    isOptionalString(value.templateId) &&
+    isOptionalFiniteNumber(value.version) &&
+    isOptionalString(value.templateHash) &&
+    isOptionalString(value.idempotencyStatus) &&
+    isOptionalString(value.workflowRunId) &&
+    isOptionalString(value.schedulerRunId) &&
+    isOptionalString(value.rootWorkNodeId) &&
+    isOptionalString(value.state) &&
+    isOptionalString(value.schedulerState) &&
+    isOptionalString(value.rootState)
+  );
+}
+
+function isRiveNode(value: unknown): value is RiveNode {
+  return (
+    isRecord(value) &&
+    hasExactShape(value, RIVE_NODE_SHAPE) &&
+    isOptionalString(value.id) &&
+    isOptionalString(value.templateId) &&
+    isOptionalString(value.title) &&
+    isOptionalString(value.state) &&
+    isOptionalString(value.runner) &&
+    isOptionalString(value.worker)
+  );
+}
+
+function isRiveError(value: unknown): value is RiveError {
+  return (
+    isRecord(value) &&
+    hasExactShape(value, RIVE_ERROR_SHAPE) &&
+    typeof value.reason === 'string' &&
+    typeof value.message === 'string' &&
+    isOptionalString(value.code) &&
+    isOptionalString(value.suggestedAction)
+  );
+}

--- a/packages/core/src/usage-record-schema.ts
+++ b/packages/core/src/usage-record-schema.ts
@@ -1,0 +1,395 @@
+import type {
+  CompactionDecisionDiagnostic,
+  ContextBudgetDiagnostic,
+  PromptSegmentEstimate,
+} from './usage-stats/types.js';
+import {
+  defineObjectShape,
+  hasExactShape,
+  isFiniteNumber,
+  isOptionalFiniteNumber,
+  isOptionalString,
+  isRecord,
+  isStringArray,
+  isStringNumberRecord,
+} from './record-schema.js';
+
+const PROMPT_SEGMENT_SHAPE = defineObjectShape<PromptSegmentEstimate>()(
+  ['kind', 'chars', 'estimatedTokens'],
+  ['messageCount', 'eventCount', 'toolCount'],
+);
+
+const COMPACTION_DECISION_SHAPE = defineObjectShape<CompactionDecisionDiagnostic>()(
+  ['stage', 'sourceKind', 'decision'],
+  [
+    'phase',
+    'boundaryKind',
+    'boundaryIds',
+    'coveredTurns',
+    'coveredRuntimeEvents',
+    'coveredToolCalls',
+    'coveredProviderMessages',
+    'coverageHashes',
+    'estimatedTokensBefore',
+    'estimatedTokensAfter',
+    'estimatedTokensSaved',
+    'candidateEstimatedTokens',
+    'preservedHeadEstimatedTokens',
+    'preservedTailEstimatedTokens',
+    'acceptedProjectionEstimatedTokens',
+    'compactCallInputTokens',
+    'compactCallOutputTokens',
+    'compactCallCacheReadInputTokens',
+    'compactCallCacheWriteInputTokens',
+    'compactCallTotalTokens',
+    'reason',
+    'failOpenReason',
+    'skippedReasonCounts',
+    'validationReasonCounts',
+  ],
+);
+
+const CONTEXT_BUDGET_SHAPE = defineObjectShape<ContextBudgetDiagnostic>()(
+  [
+    'enabled',
+    'estimatedTokensBefore',
+    'estimatedTokensAfter',
+    'keptTurns',
+    'droppedTurns',
+    'keptEvents',
+    'droppedEvents',
+  ],
+  [
+    'policyName',
+    'maxHistoryEstimatedTokens',
+    'maxHistoryTurns',
+    'prunedToolResults',
+    'prunedToolResultEstimatedTokensBefore',
+    'prunedToolResultEstimatedTokensAfter',
+    'archivePlaceholders',
+    'archiveWriteFailures',
+    'unarchivedToolResults',
+    'archivePlaceholderReasonCounts',
+    'activePrunedToolResults',
+    'activeArchiveFailures',
+    'activeEstimatedTokensSaved',
+    'semanticCompactEnabled',
+    'semanticCompactMode',
+    'compactionDecisions',
+    'archiveRetrievalMode',
+    'archiveRetrievalEligibleTurns',
+    'retrievedArchiveToolResults',
+    'retrievedArchiveEstimatedTokens',
+    'archiveRetrievalSkipped',
+    'archiveRetrievalFailures',
+    'archiveRetrievalSkippedReasonCounts',
+    'archiveRetrievalFailureReasonCounts',
+    'historySearchMatches',
+    'historyAroundRetrievedEvents',
+    'historyAroundEstimatedTokens',
+    'historyAroundSkippedEvents',
+    'synthesisCacheEnabled',
+    'synthesisCacheMode',
+    'synthesisCacheBlocksLoaded',
+    'synthesisCacheLoadSkipped',
+    'synthesisCacheLoadSkippedReasonCounts',
+    'synthesisCacheLoadFailures',
+    'synthesisCacheBlocksAvailable',
+    'synthesisCacheBlocksSelected',
+    'synthesisCacheBlockIds',
+    'synthesisCacheEstimatedTokens',
+    'synthesisCacheSkipped',
+    'synthesisCacheSkippedReasonCounts',
+    'synthesisCacheInvalidated',
+    'synthesisCacheInvalidationReasonCounts',
+    'synthesisCacheWritesAttempted',
+    'synthesisCacheBlocksWritten',
+    'synthesisCacheWrittenBlockIds',
+    'synthesisCacheWriteEstimatedTokens',
+    'synthesisCacheWriteSkipped',
+    'synthesisCacheWriteSkippedReasonCounts',
+    'synthesisCacheWriteFailures',
+    'synthesisCacheEvicted',
+    'synthesisCacheEvictionReasonCounts',
+    'historyCompactEnabled',
+    'historyCompactMode',
+    'historyCompactBlocksLoaded',
+    'historyCompactLoadSkipped',
+    'historyCompactLoadSkippedReasonCounts',
+    'historyCompactLoadFailures',
+    'historyCompactBlocksAvailable',
+    'historyCompactBlocksSelected',
+    'historyCompactBlockIds',
+    'historyCompactedTurns',
+    'historyCompactedEvents',
+    'historyCompactedEstimatedTokensBefore',
+    'historyCompactedEstimatedTokensAfter',
+    'historyCompactSkipped',
+    'historyCompactSkippedReasonCounts',
+    'historyCompactCoverageHashes',
+    'historyCompactWritesAttempted',
+    'historyCompactBlocksWritten',
+    'historyCompactWrittenBlockIds',
+    'historyCompactWriteEstimatedTokens',
+    'historyCompactWriteSkipped',
+    'historyCompactWriteSkippedReasonCounts',
+    'historyCompactWriteFailures',
+    'highWaterName',
+    'highWaterSeq',
+    'highWaterReason',
+    'highWaterRequestShapeHashBefore',
+    'highWaterRequestShapeHashAfter',
+    'historyRewriteVersion',
+    'historyRewriteResetReason',
+    'historyRewriteGate',
+  ],
+);
+
+const PROMPT_SEGMENT_KINDS = new Set([
+  'system_prompt',
+  'tool_schema',
+  'prior_history',
+  'current_user',
+  'turn_tail',
+]);
+
+const PREFIX_CHANGE_REASONS = new Set([
+  'first_turn',
+  'system_prompt_changed',
+  'tool_schema_changed',
+  'provider_options_changed',
+  'model_or_provider_changed',
+  'history_projection_changed',
+  'stable',
+  'unknown',
+]);
+
+const OPTIONAL_TOKEN_NUMBERS = [
+  'cacheHitInput',
+  'cacheMissInput',
+  'cacheWriteInput',
+  'reasoning',
+  'total',
+  'runtimeSteps',
+  'cacheRead',
+  'cacheCreation',
+  'costUsd',
+  'contextRemaining',
+] as const;
+
+const COMPACTION_NUMBERS = [
+  'coveredTurns',
+  'coveredRuntimeEvents',
+  'coveredToolCalls',
+  'coveredProviderMessages',
+  'estimatedTokensBefore',
+  'estimatedTokensAfter',
+  'estimatedTokensSaved',
+  'candidateEstimatedTokens',
+  'preservedHeadEstimatedTokens',
+  'preservedTailEstimatedTokens',
+  'acceptedProjectionEstimatedTokens',
+  'compactCallInputTokens',
+  'compactCallOutputTokens',
+  'compactCallCacheReadInputTokens',
+  'compactCallCacheWriteInputTokens',
+  'compactCallTotalTokens',
+] as const;
+
+const CONTEXT_NUMBERS = [
+  'maxHistoryEstimatedTokens',
+  'maxHistoryTurns',
+  'prunedToolResults',
+  'prunedToolResultEstimatedTokensBefore',
+  'prunedToolResultEstimatedTokensAfter',
+  'archivePlaceholders',
+  'archiveWriteFailures',
+  'unarchivedToolResults',
+  'activePrunedToolResults',
+  'activeArchiveFailures',
+  'activeEstimatedTokensSaved',
+  'archiveRetrievalEligibleTurns',
+  'retrievedArchiveToolResults',
+  'retrievedArchiveEstimatedTokens',
+  'archiveRetrievalSkipped',
+  'archiveRetrievalFailures',
+  'historySearchMatches',
+  'historyAroundRetrievedEvents',
+  'historyAroundEstimatedTokens',
+  'historyAroundSkippedEvents',
+  'synthesisCacheBlocksLoaded',
+  'synthesisCacheLoadSkipped',
+  'synthesisCacheLoadFailures',
+  'synthesisCacheBlocksAvailable',
+  'synthesisCacheBlocksSelected',
+  'synthesisCacheEstimatedTokens',
+  'synthesisCacheSkipped',
+  'synthesisCacheInvalidated',
+  'synthesisCacheWritesAttempted',
+  'synthesisCacheBlocksWritten',
+  'synthesisCacheWriteEstimatedTokens',
+  'synthesisCacheWriteSkipped',
+  'synthesisCacheWriteFailures',
+  'synthesisCacheEvicted',
+  'historyCompactBlocksLoaded',
+  'historyCompactLoadSkipped',
+  'historyCompactLoadFailures',
+  'historyCompactBlocksAvailable',
+  'historyCompactBlocksSelected',
+  'historyCompactedTurns',
+  'historyCompactedEvents',
+  'historyCompactedEstimatedTokensBefore',
+  'historyCompactedEstimatedTokensAfter',
+  'historyCompactSkipped',
+  'historyCompactWritesAttempted',
+  'historyCompactBlocksWritten',
+  'historyCompactWriteEstimatedTokens',
+  'historyCompactWriteSkipped',
+  'historyCompactWriteFailures',
+  'highWaterSeq',
+] as const;
+
+const CONTEXT_REASON_COUNTS = [
+  'archivePlaceholderReasonCounts',
+  'archiveRetrievalSkippedReasonCounts',
+  'archiveRetrievalFailureReasonCounts',
+  'synthesisCacheLoadSkippedReasonCounts',
+  'synthesisCacheSkippedReasonCounts',
+  'synthesisCacheInvalidationReasonCounts',
+  'synthesisCacheWriteSkippedReasonCounts',
+  'synthesisCacheEvictionReasonCounts',
+  'historyCompactLoadSkippedReasonCounts',
+  'historyCompactSkippedReasonCounts',
+  'historyCompactWriteSkippedReasonCounts',
+] as const;
+
+export function isTokenUsageFields(value: Record<string, unknown>): boolean {
+  if (!isFiniteNumber(value.input) || !isFiniteNumber(value.output)) return false;
+  if (OPTIONAL_TOKEN_NUMBERS.some((key) => !isOptionalFiniteNumber(value[key]))) return false;
+  return (
+    (value.cacheMissInputSource === undefined ||
+      value.cacheMissInputSource === 'explicit' ||
+      value.cacheMissInputSource === 'derived') &&
+    isOptionalString(value.rawFinishReason) &&
+    isOptionalString(value.systemPromptHash) &&
+    isOptionalString(value.prefixHash) &&
+    isOptionalPrefixChangeReason(value.prefixChangeReason) &&
+    isOptionalString(value.requestShapeHash) &&
+    isOptionalPrefixChangeReason(value.requestShapeChangeReason) &&
+    (value.promptSegments === undefined ||
+      (Array.isArray(value.promptSegments) &&
+        value.promptSegments.every(isPromptSegmentEstimate))) &&
+    (value.contextBudget === undefined || isContextBudgetDiagnostic(value.contextBudget))
+  );
+}
+
+export function isPromptSegmentEstimate(value: unknown): value is PromptSegmentEstimate {
+  return (
+    isRecord(value) &&
+    hasExactShape(value, PROMPT_SEGMENT_SHAPE) &&
+    PROMPT_SEGMENT_KINDS.has(value.kind as string) &&
+    isFiniteNumber(value.chars) &&
+    isFiniteNumber(value.estimatedTokens) &&
+    isOptionalFiniteNumber(value.messageCount) &&
+    isOptionalFiniteNumber(value.eventCount) &&
+    isOptionalFiniteNumber(value.toolCount)
+  );
+}
+
+export function isContextBudgetDiagnostic(value: unknown): value is ContextBudgetDiagnostic {
+  if (!isRecord(value) || !hasExactShape(value, CONTEXT_BUDGET_SHAPE)) return false;
+  if (
+    typeof value.enabled !== 'boolean' ||
+    !isFiniteNumber(value.estimatedTokensBefore) ||
+    !isFiniteNumber(value.estimatedTokensAfter) ||
+    !isFiniteNumber(value.keptTurns) ||
+    !isFiniteNumber(value.droppedTurns) ||
+    !isFiniteNumber(value.keptEvents) ||
+    !isFiniteNumber(value.droppedEvents) ||
+    CONTEXT_NUMBERS.some((key) => !isOptionalFiniteNumber(value[key])) ||
+    CONTEXT_REASON_COUNTS.some(
+      (key) => value[key] !== undefined && !isStringNumberRecord(value[key]),
+    )
+  ) {
+    return false;
+  }
+  return (
+    isOptionalString(value.policyName) &&
+    (value.semanticCompactEnabled === undefined ||
+      typeof value.semanticCompactEnabled === 'boolean') &&
+    (value.semanticCompactMode === undefined ||
+      ['off', 'validate_only', 'prepare_step_dry_run', 'replace'].includes(
+        value.semanticCompactMode as string,
+      )) &&
+    (value.compactionDecisions === undefined ||
+      (Array.isArray(value.compactionDecisions) &&
+        value.compactionDecisions.every(isCompactionDecisionDiagnostic))) &&
+    (value.archiveRetrievalMode === undefined ||
+      value.archiveRetrievalMode === 'eager' ||
+      value.archiveRetrievalMode === 'history_search_gated') &&
+    (value.synthesisCacheEnabled === undefined ||
+      typeof value.synthesisCacheEnabled === 'boolean') &&
+    (value.synthesisCacheMode === undefined ||
+      ['off', 'lookup', 'read_write', 'write_only', 'fallback_archive_retrieval'].includes(
+        value.synthesisCacheMode as string,
+      )) &&
+    optionalStringArray(value.synthesisCacheBlockIds) &&
+    optionalStringArray(value.synthesisCacheWrittenBlockIds) &&
+    (value.historyCompactEnabled === undefined ||
+      typeof value.historyCompactEnabled === 'boolean') &&
+    (value.historyCompactMode === undefined ||
+      ['off', 'deterministic', 'lookup', 'read_write'].includes(
+        value.historyCompactMode as string,
+      )) &&
+    optionalStringArray(value.historyCompactBlockIds) &&
+    optionalStringArray(value.historyCompactCoverageHashes) &&
+    optionalStringArray(value.historyCompactWrittenBlockIds) &&
+    isOptionalString(value.highWaterName) &&
+    (value.highWaterReason === undefined ||
+      [
+        'archive_prune',
+        'history_search_gated_retrieval',
+        'synthesis_cache_write',
+        'synthesis_cache_select',
+        'history_compact',
+        'manual_reset',
+        'system_change',
+        'tools_change',
+        'log_rewrite',
+      ].includes(value.highWaterReason as string)) &&
+    isOptionalString(value.highWaterRequestShapeHashBefore) &&
+    isOptionalString(value.highWaterRequestShapeHashAfter) &&
+    isOptionalString(value.historyRewriteVersion) &&
+    isOptionalString(value.historyRewriteResetReason) &&
+    isOptionalString(value.historyRewriteGate)
+  );
+}
+
+function isCompactionDecisionDiagnostic(value: unknown): value is CompactionDecisionDiagnostic {
+  if (!isRecord(value) || !hasExactShape(value, COMPACTION_DECISION_SHAPE)) return false;
+  return (
+    (value.stage === 'priorReplay' || value.stage === 'activeStep') &&
+    (value.sourceKind === 'runtimeEvents' || value.sourceKind === 'providerMessages') &&
+    (value.decision === 'unchanged' ||
+      value.decision === 'replaced' ||
+      value.decision === 'failedOpen') &&
+    (value.phase === undefined || value.phase === 'pre_turn' || value.phase === 'mid_turn') &&
+    isOptionalString(value.boundaryKind) &&
+    optionalStringArray(value.boundaryIds) &&
+    COMPACTION_NUMBERS.every((key) => isOptionalFiniteNumber(value[key])) &&
+    optionalStringArray(value.coverageHashes) &&
+    isOptionalString(value.reason) &&
+    isOptionalString(value.failOpenReason) &&
+    (value.skippedReasonCounts === undefined || isStringNumberRecord(value.skippedReasonCounts)) &&
+    (value.validationReasonCounts === undefined ||
+      isStringNumberRecord(value.validationReasonCounts))
+  );
+}
+
+function isOptionalPrefixChangeReason(value: unknown): boolean {
+  return value === undefined || PREFIX_CHANGE_REASONS.has(value as string);
+}
+
+function optionalStringArray(value: unknown): boolean {
+  return value === undefined || isStringArray(value);
+}

--- a/packages/headless/src/__tests__/task-agent-controller.test.ts
+++ b/packages/headless/src/__tests__/task-agent-controller.test.ts
@@ -86,7 +86,16 @@ class ReportingBackend implements AgentBackend {
       reasoning: 2,
       total: 17,
       costUsd: 0.123,
-      contextBudget: { policyName: 'unit-budget', droppedTurns: 1 } as never,
+      contextBudget: {
+        enabled: true,
+        policyName: 'unit-budget',
+        estimatedTokensBefore: 20,
+        estimatedTokensAfter: 10,
+        keptTurns: 1,
+        droppedTurns: 1,
+        keptEvents: 2,
+        droppedEvents: 1,
+      },
     };
     yield { type: 'complete', id: 'report-complete', turnId, ts, stopReason: 'end_turn' };
   }
@@ -1233,6 +1242,9 @@ describe('runTaskOnce', () => {
             throw new Error('terminal append failed');
           }
           return backingRuntimeEventStore.appendRuntimeEvent(sessionId, runId, event);
+        },
+        ensureTerminalRuntimeEventDurable() {
+          throw new Error('terminal append failed');
         },
         readRuntimeEvents: (sessionId, runId) => backingRuntimeEventStore.readRuntimeEvents(sessionId, runId),
         readSessionRuntimeEvents: (sessionId) => backingRuntimeEventStore.readSessionRuntimeEvents(sessionId),

--- a/packages/runtime-host/package.json
+++ b/packages/runtime-host/package.json
@@ -17,6 +17,8 @@
     "test:dist": "node --test \"dist/**/*.test.js\""
   },
   "dependencies": {
+    "@maka/core": "0.1.0",
+    "@maka/runtime": "0.1.0",
     "@maka/storage": "0.1.0"
   },
   "devDependencies": {

--- a/packages/runtime-host/src/__tests__/dependency-boundary.test.ts
+++ b/packages/runtime-host/src/__tests__/dependency-boundary.test.ts
@@ -129,6 +129,24 @@ test('the production Candidate dependency graph remains non-serving', () => {
   assert.deepEqual(violations, []);
 });
 
+test('the public server entrypoint does not expose the test execution composition', async () => {
+  const publicEntrypoints = await readPublicEntrypoints();
+  const serverEntrypoint = publicEntrypoints.get('server');
+  assert.ok(serverEntrypoint, 'missing public server entrypoint');
+  const forbidden = new Set([
+    'server/execution-candidate.ts',
+    'server/execution-composition.ts',
+    'server/root-turn-coordinator.ts',
+  ]);
+  assert.deepEqual(
+    reachableModules(serverEntrypoint, publicEntrypoints)
+      .map((path) => relative(sourceRoot, path))
+      .filter((path) => forbidden.has(path))
+      .sort(),
+    [],
+  );
+});
+
 test('dependency scanning fails closed on computed loads, loader aliases, and unapproved packages', () => {
   const scan = scanModuleReferences(join(sourceRoot, '__tests__', 'dependency-boundary.test.ts'));
   assert.ok(scan.specifiers.includes('node:url'));

--- a/packages/runtime-host/src/__tests__/dependency-boundary.test.ts
+++ b/packages/runtime-host/src/__tests__/dependency-boundary.test.ts
@@ -22,6 +22,14 @@ const allowedHostExternalImports = new Set([
   'node:url',
   'node:util',
 ]);
+const allowedServerExternalImports = new Set([
+  ...allowedHostExternalImports,
+  '@maka/core/agent-run',
+  '@maka/core/runtime-event',
+  '@maka/core/session',
+  '@maka/runtime',
+  '@maka/storage/execution-stores',
+]);
 const allowedExternalImports = {
   client: allowedHostExternalImports,
   protocol: new Set(['node:util']),
@@ -79,17 +87,43 @@ test('protocol and client stay within their subpaths and the root-authority boun
   assert.deepEqual(violations, []);
 });
 
-test('M1 Host source cannot reach Runtime or bypass package storage boundaries', async () => {
+test('only the server subgraph can reach the M2 Runtime composition', async () => {
   const violations: string[] = [];
   for (const path of await listTypeScriptFiles(sourceRoot)) {
-    if (relative(sourceRoot, path).split(sep)[0] === '__tests__') continue;
+    const localPath = relative(sourceRoot, path);
+    const topLevelArea = localPath.split(sep)[0];
+    if (topLevelArea === '__tests__') continue;
+    const allowedImports = topLevelArea === 'server' || localPath === 'candidate-main.ts'
+      ? allowedServerExternalImports
+      : allowedHostExternalImports;
     for (const specifier of moduleSpecifiers(path)) {
       if (isRelativeSpecifier(specifier)) {
         const target = sourcePathForSpecifier(path, specifier);
         if (!isInside(sourceRoot, target)) violations.push(`${path}: ${specifier}`);
         continue;
       }
-      if (!allowedHostExternalImports.has(specifier)) violations.push(`${path}: ${specifier}`);
+      if (!allowedImports.has(specifier)) violations.push(`${path}: ${specifier}`);
+    }
+  }
+  assert.deepEqual(violations, []);
+});
+
+test('the production Candidate dependency graph remains non-serving', () => {
+  const publicEntrypoints = new Map<string, string>();
+  const reached = reachableModules(join(sourceRoot, 'candidate-main.ts'), publicEntrypoints);
+  const forbiddenLocalModules = new Set([
+    'server/execution-candidate.ts',
+    'server/execution-composition.ts',
+    'server/root-turn-coordinator.ts',
+  ]);
+  const violations: string[] = [];
+  for (const path of reached) {
+    const localPath = relative(sourceRoot, path);
+    if (forbiddenLocalModules.has(localPath)) violations.push(localPath);
+    for (const specifier of moduleSpecifiers(path)) {
+      if (specifier === '@maka/runtime' || specifier === '@maka/storage/execution-stores') {
+        violations.push(`${localPath}: ${specifier}`);
+      }
     }
   }
   assert.deepEqual(violations, []);

--- a/packages/runtime-host/src/__tests__/execution-host.test.ts
+++ b/packages/runtime-host/src/__tests__/execution-host.test.ts
@@ -38,10 +38,17 @@ import {
 	RuntimeHostOperationError,
 	type RuntimeHostConnection,
 } from "../client/index.js";
-import { decodeHostFrame, type TurnSnapshot } from "../protocol/index.js";
+import {
+	decodeHostFrame,
+	RUNTIME_HOST_PROTOCOL_VERSION,
+	type TurnSnapshot,
+} from "../protocol/index.js";
 import { FramedTransport } from "../transport/framed-transport.js";
 
-const PROTOCOL_1 = { min: 1, max: 1 } as const;
+const CURRENT_PROTOCOL = {
+	min: RUNTIME_HOST_PROTOCOL_VERSION,
+	max: RUNTIME_HOST_PROTOCOL_VERSION,
+} as const;
 const PROCESS_TIMEOUT_MS = 10_000;
 
 test("two Clients share one execution after the starting Client disconnects", async () => {
@@ -809,7 +816,7 @@ async function connectClient(
 	const result = await connectRuntimeHost({
 		rootPath,
 		surface,
-		protocol: PROTOCOL_1,
+		protocol: CURRENT_PROTOCOL,
 	});
 	assert.equal(result.kind, "connected");
 	return result.connection;
@@ -824,8 +831,8 @@ async function sendStartWithoutReadingResponse(
 		kind: "hello",
 		clientInstanceId: randomUUID(),
 		surface: "desktop",
-		protocolMin: 1,
-		protocolMax: 1,
+		protocolMin: CURRENT_PROTOCOL.min,
+		protocolMax: CURRENT_PROTOCOL.max,
 	});
 	const handshake = decodeHostFrame(await transport.read(2_000));
 	assert.ok("kind" in handshake);

--- a/packages/runtime-host/src/__tests__/execution-host.test.ts
+++ b/packages/runtime-host/src/__tests__/execution-host.test.ts
@@ -1,0 +1,1013 @@
+import assert from "node:assert/strict";
+import { fork, type ChildProcess } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import {
+	appendFile,
+	chmod,
+	mkdtemp,
+	readFile,
+	readdir,
+	rm,
+	writeFile,
+} from "node:fs/promises";
+import { connect, type Socket } from "node:net";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test } from "node:test";
+import type { AgentRunHeader } from "@maka/core/agent-run";
+import type { StoredMessage } from "@maka/core/session";
+import { isTerminalRuntimeEvent } from "@maka/core/runtime-event";
+import type { RuntimeEvent } from "@maka/core/runtime-event";
+import {
+	classifyTerminalRuntimeLedger,
+	FAKE_ASK_USER_QUESTION_PROMPT,
+} from "@maka/runtime";
+import {
+	openInteractiveExecutionStoresForRead,
+	openInteractiveExecutionStoresForWrite,
+} from "@maka/storage/execution-stores";
+import {
+	resolveRootControlNamespace,
+	resolveStorageRoot,
+	tryAcquireInteractiveRootOwner,
+	tryAcquireInteractiveRootReader,
+	type StorageRootCapability,
+} from "@maka/storage/root-authority";
+import {
+	connectRuntimeHost,
+	RuntimeHostOperationError,
+	type RuntimeHostConnection,
+} from "../client/index.js";
+import { decodeHostFrame, type TurnSnapshot } from "../protocol/index.js";
+import { FramedTransport } from "../transport/framed-transport.js";
+
+const PROTOCOL_1 = { min: 1, max: 1 } as const;
+const PROCESS_TIMEOUT_MS = 10_000;
+
+test("two Clients share one execution after the starting Client disconnects", async () => {
+	await withExecutionRoot(async (fixture) => {
+		const host = await fixture.startHost();
+		const first = await connectClient(fixture.root, "desktop");
+		const second = await connectClient(fixture.root, "tui");
+		const turnId = randomUUID();
+
+		const started = await first.startTurn({
+			sessionId: fixture.sessionId,
+			turnId,
+			text: FAKE_ASK_USER_QUESTION_PROMPT,
+		});
+		assert.equal(started.turnId, turnId);
+		await assert.rejects(
+			() =>
+				second.startTurn({
+					sessionId: fixture.sessionId,
+					turnId: randomUUID(),
+					text: "must stay busy",
+				}),
+			operationError("session_busy"),
+		);
+
+		await first.close();
+		const observed = await second.queryTurn({
+			sessionId: fixture.sessionId,
+			turnId,
+		});
+		assert.equal(observed.runId, started.runId);
+		assert.ok(
+			observed.status === "running" || observed.status === "waiting_permission",
+		);
+		const stopped = await second.stopTurn(
+			{
+				sessionId: fixture.sessionId,
+				turnId,
+				runId: started.runId,
+			},
+			PROCESS_TIMEOUT_MS,
+		);
+		assert.equal(stopped.status, "cancelled");
+
+		const nextTurnId = randomUUID();
+		const next = await second.startTurn({
+			sessionId: fixture.sessionId,
+			turnId: nextTurnId,
+			text: FAKE_ASK_USER_QUESTION_PROMPT,
+		});
+		assert.deepEqual(
+			await second.startTurn({
+				sessionId: fixture.sessionId,
+				turnId,
+				text: FAKE_ASK_USER_QUESTION_PROMPT,
+			}),
+			stopped,
+		);
+		assert.deepEqual(
+			await second.stopTurn({
+				sessionId: fixture.sessionId,
+				turnId,
+				runId: started.runId,
+			}),
+			stopped,
+		);
+		const nextObserved = await second.queryTurn({
+			sessionId: fixture.sessionId,
+			turnId: nextTurnId,
+		});
+		assert.equal(nextObserved.runId, next.runId);
+		assert.ok(
+			nextObserved.status === "running" ||
+				nextObserved.status === "waiting_permission",
+		);
+		await second.stopTurn(
+			{
+				sessionId: fixture.sessionId,
+				turnId: nextTurnId,
+				runId: next.runId,
+			},
+			PROCESS_TIMEOUT_MS,
+		);
+		await second.close();
+		await fixture.stopHost(host);
+
+		const ledger = await fixture.readTurn(turnId);
+		assert.equal(ledger.runs.length, 1);
+		assert.equal(ledger.userMessages.length, 1);
+		assert.equal(ledger.terminalEvents.length, 1);
+		assert.equal(ledger.classification.kind, "fact");
+		if (ledger.classification.kind === "fact") {
+			assert.equal(ledger.classification.fact.runStatus, "cancelled");
+			assert.notEqual(ledger.classification.fact.failureClass, "app_restarted");
+		}
+	});
+});
+
+test("an archived Session rejects a new Turn before durable admission", async () => {
+	await withExecutionRoot(async (fixture) => {
+		await fixture.archiveSession();
+		const host = await fixture.startHost();
+		const client = await connectClient(fixture.root, "desktop");
+		const turnId = randomUUID();
+
+		await assert.rejects(
+			() =>
+				client.startTurn({
+					sessionId: fixture.sessionId,
+					turnId,
+					text: "must not execute",
+				}),
+			operationError("session_archived"),
+		);
+		assert.equal((await client.status()).state, "ready");
+		await client.close();
+		await fixture.stopHost(host);
+
+		assert.deepEqual(await fixture.readTurnFootprint(turnId), {
+			admitted: false,
+			runCount: 0,
+			userMessageCount: 0,
+		});
+	});
+});
+
+test("a killed Host is recovered exactly once before its successor becomes ready", {
+	skip: process.platform === "win32" ? "POSIX process death gate" : false,
+}, async () => {
+	await withExecutionRoot(async (fixture) => {
+		const firstHost = await fixture.startHost();
+		const first = await connectClient(fixture.root, "desktop");
+		const turnId = randomUUID();
+		const started = await first.startTurn({
+			sessionId: fixture.sessionId,
+			turnId,
+			text: FAKE_ASK_USER_QUESTION_PROMPT,
+		});
+
+		await fixture.killHost(firstHost);
+		await first.closed;
+		const secondHost = await fixture.startHost();
+		const second = await connectClient(fixture.root, "tui");
+		const recovered = await second.queryTurn({
+			sessionId: fixture.sessionId,
+			turnId,
+		});
+		assert.equal(recovered.status, "failed");
+		if (recovered.status === "failed")
+			assert.equal(recovered.failureClass, "app_restarted");
+		await second.close();
+		await fixture.stopHost(secondHost);
+
+		const thirdHost = await fixture.startHost();
+		const third = await connectClient(fixture.root, "run");
+		const stable = await third.queryTurn({
+			sessionId: fixture.sessionId,
+			turnId,
+		});
+		assert.deepEqual(stable, recovered);
+		assert.equal(stable.runId, started.runId);
+		await third.close();
+		await fixture.stopHost(thirdHost);
+
+		const ledger = await fixture.readTurn(turnId);
+		assert.equal(ledger.terminalEvents.length, 1);
+		assert.equal(ledger.classification.kind, "fact");
+		if (ledger.classification.kind === "fact") {
+			assert.equal(ledger.classification.fact.failureClass, "app_restarted");
+		}
+	});
+});
+
+test("graceful Host shutdown stops and drains an active Turn before releasing ownership", async () => {
+	await withExecutionRoot(async (fixture) => {
+		const host = await fixture.startHost();
+		const client = await connectClient(fixture.root, "desktop");
+		const turnId = randomUUID();
+		const started = await client.startTurn({
+			sessionId: fixture.sessionId,
+			turnId,
+			text: FAKE_ASK_USER_QUESTION_PROMPT,
+		});
+
+		await fixture.stopHost(host);
+		await client.closed;
+
+		const successor = await fixture.startHost();
+		const observer = await connectClient(fixture.root, "tui");
+		const stable = await observer.queryTurn({
+			sessionId: fixture.sessionId,
+			turnId,
+		});
+		assert.equal(stable.runId, started.runId);
+		assert.equal(stable.status, "cancelled");
+		await observer.close();
+		await fixture.stopHost(successor);
+
+		const ledger = await fixture.readTurn(turnId);
+		assert.equal(ledger.terminalEvents.length, 1);
+		assert.equal(ledger.classification.kind, "fact");
+		if (ledger.classification.kind === "fact") {
+			assert.equal(ledger.classification.fact.runStatus, "cancelled");
+			assert.notEqual(ledger.classification.fact.failureClass, "app_restarted");
+		}
+	});
+});
+
+test("a durable admission without a Run resumes before the Host becomes ready", async () => {
+	await withExecutionRoot(async (fixture) => {
+		const turnId = randomUUID();
+		const { runId } = await fixture.seedAdmission(
+			turnId,
+			FAKE_ASK_USER_QUESTION_PROMPT,
+		);
+		const host = await fixture.startHost();
+		const client = await connectClient(fixture.root, "tui");
+
+		const recovered = await client.queryTurn({
+			sessionId: fixture.sessionId,
+			turnId,
+		});
+		assert.equal(recovered.runId, runId);
+		assert.ok(
+			recovered.status === "running" ||
+				recovered.status === "waiting_permission",
+		);
+		await assert.rejects(
+			() =>
+				client.startTurn({
+					sessionId: fixture.sessionId,
+					turnId: randomUUID(),
+					text: "must remain behind the recovered admission",
+				}),
+			operationError("session_busy"),
+		);
+		const stopped = await client.stopTurn(
+			{
+				sessionId: fixture.sessionId,
+				turnId,
+				runId,
+			},
+			PROCESS_TIMEOUT_MS,
+		);
+		assert.equal(stopped.status, "cancelled");
+		await client.close();
+		await fixture.stopHost(host);
+
+		const ledger = await fixture.readTurn(turnId);
+		assert.equal(ledger.runs.length, 1);
+		assert.equal(ledger.userMessages.length, 1);
+		assert.equal(ledger.terminalEvents.length, 1);
+		assert.equal(ledger.classification.kind, "fact");
+		if (ledger.classification.kind === "fact") {
+			assert.notEqual(ledger.classification.fact.failureClass, "app_restarted");
+		}
+	});
+});
+
+test("startup recovery restores the admitted UserMessage before terminalizing its Run", async () => {
+	await withExecutionRoot(async (fixture) => {
+		const turnId = randomUUID();
+		const { runId, userMessageId } = await fixture.seedRunWithoutUserMessage(
+			turnId,
+			"recover the admitted message",
+		);
+		const host = await fixture.startHost();
+		const client = await connectClient(fixture.root, "tui");
+
+		const recovered = await client.queryTurn({
+			sessionId: fixture.sessionId,
+			turnId,
+		});
+		assert.equal(recovered.runId, runId);
+		assert.equal(recovered.status, "failed");
+		if (recovered.status === "failed") {
+			assert.equal(recovered.failureClass, "app_restarted");
+		}
+		await client.close();
+		await fixture.stopHost(host);
+
+		const ledger = await fixture.readTurn(turnId);
+		assert.equal(ledger.runs.length, 1);
+		assert.equal(ledger.userMessages.length, 1);
+		assert.equal(ledger.userMessages[0]?.id, userMessageId);
+		assert.equal(ledger.terminalEvents.length, 1);
+	});
+});
+
+test("startup recovery repairs a truncated RuntimeEvent tail before terminalizing the Run", async () => {
+	await withExecutionRoot(async (fixture) => {
+		const turnId = randomUUID();
+		const { runId } = await fixture.seedRunWithoutUserMessage(
+			turnId,
+			"recover after a partial RuntimeEvent write",
+		);
+		const runtimeEventsPath = fixture.runtimeEventsPath(runId);
+		await writeFile(runtimeEventsPath, '{"id":"truncated"', "utf8");
+
+		const host = await fixture.startHost();
+		const client = await connectClient(fixture.root, "tui");
+		const recovered = await client.queryTurn({
+			sessionId: fixture.sessionId,
+			turnId,
+		});
+		assert.equal(recovered.status, "failed");
+		if (recovered.status === "failed") {
+			assert.equal(recovered.failureClass, "app_restarted");
+		}
+		await client.close();
+		await fixture.stopHost(host);
+
+		const bytes = await readFile(runtimeEventsPath, "utf8");
+		assert.doesNotMatch(bytes, /truncated/);
+		assertJsonLines(bytes);
+		const ledger = await fixture.readTurn(turnId);
+		assert.equal(ledger.terminalEvents.length, 1);
+	});
+});
+
+test("startup recovery fails closed on a complete malformed RuntimeEvent record", async () => {
+	await withExecutionRoot(async (fixture) => {
+		const turnId = randomUUID();
+		const { runId } = await fixture.seedRunWithoutUserMessage(
+			turnId,
+			"do not recover across durable corruption",
+		);
+		const runtimeEventsPath = fixture.runtimeEventsPath(runId);
+		const malformed = '{"id":"malformed"\n';
+		await writeFile(runtimeEventsPath, malformed, "utf8");
+
+		await fixture.expectHostStartupFailure();
+		assert.equal(await readFile(runtimeEventsPath, "utf8"), malformed);
+		await fixture.assertOwnerAvailable();
+	});
+});
+
+test("startup recovery fails closed on a complete malformed Session record", async () => {
+	await withExecutionRoot(async (fixture) => {
+		await fixture.seedRunWithoutUserMessage(
+			randomUUID(),
+			"do not rewrite durable Session corruption",
+		);
+		const sessionPath = fixture.sessionPath();
+		const malformed = '{"type":"user"\n';
+		await appendFile(sessionPath, malformed, "utf8");
+		const expected = await readFile(sessionPath, "utf8");
+
+		await fixture.expectHostStartupFailure();
+		assert.equal(await readFile(sessionPath, "utf8"), expected);
+		await fixture.assertOwnerAvailable();
+	});
+});
+
+test("startup recovery fails closed on a complete malformed AgentRun record", async () => {
+	await withExecutionRoot(async (fixture) => {
+		const { runId } = await fixture.seedRunWithoutUserMessage(
+			randomUUID(),
+			"do not recover across durable AgentRun corruption",
+		);
+		const eventsPath = fixture.eventsPath(runId);
+		const malformed = '{"type":"run_started"\n';
+		await writeFile(eventsPath, malformed, "utf8");
+
+		await fixture.expectHostStartupFailure();
+		assert.equal(await readFile(eventsPath, "utf8"), malformed);
+		await fixture.assertOwnerAvailable();
+	});
+});
+
+test("a pre-start durability failure rejects turn.start and drains the Host", {
+	skip:
+		process.platform === "win32" || process.getuid?.() === 0
+			? "POSIX file-permission gate"
+			: false,
+}, async () => {
+	await withExecutionRoot(async (fixture) => {
+		const host = await fixture.startHost();
+		const client = await connectClient(fixture.root, "desktop");
+		const turnId = randomUUID();
+		const sessionPath = fixture.sessionPath();
+		await chmod(sessionPath, 0o400);
+		try {
+			await assert.rejects(
+				() =>
+					client.startTurn({
+						sessionId: fixture.sessionId,
+						turnId,
+						text: "fail before the durable start barrier",
+					}),
+				operationError("internal_failure"),
+			);
+			await client.closed;
+			await fixture.waitForHostExit(host);
+		} finally {
+			await chmod(sessionPath, 0o600);
+		}
+
+		const successor = await fixture.startHost();
+		const observer = await connectClient(fixture.root, "tui");
+		const recovered = await observer.queryTurn({
+			sessionId: fixture.sessionId,
+			turnId,
+		});
+		assert.equal(recovered.status, "failed");
+		await observer.close();
+		await fixture.stopHost(successor);
+
+		const ledger = await fixture.readTurn(turnId);
+		assert.equal(ledger.runs.length, 1);
+		assert.equal(ledger.userMessages.length, 1);
+		assert.equal(ledger.terminalEvents.length, 1);
+	});
+});
+
+test("retry after a discarded turn.start response reuses the durable semantic admission", async () => {
+	await withExecutionRoot(async (fixture) => {
+		const host = await fixture.startHost();
+		const turnId = randomUUID();
+		const text = "response loss must not duplicate this Turn";
+		const dropped = await sendStartWithoutReadingResponse(host.endpoint, {
+			sessionId: fixture.sessionId,
+			turnId,
+			text,
+		});
+		const observer = await connectClient(fixture.root, "tui");
+		const committed = await waitForTurn(observer, fixture.sessionId, turnId);
+		dropped.destroy();
+
+		const retried = await observer.startTurn({
+			sessionId: fixture.sessionId,
+			turnId,
+			text,
+		});
+		assert.equal(retried.runId, committed.runId);
+		await assert.rejects(
+			() =>
+				observer.startTurn({
+					sessionId: fixture.sessionId,
+					turnId,
+					text: `${text} changed`,
+				}),
+			operationError("operation_conflict"),
+		);
+		const terminal = await waitForTerminalTurn(
+			observer,
+			fixture.sessionId,
+			turnId,
+		);
+		assert.equal(terminal.status, "completed");
+		await observer.close();
+		await fixture.stopHost(host);
+
+		const ledger = await fixture.readTurn(turnId);
+		assert.equal(ledger.runs.length, 1);
+		assert.equal(ledger.userMessages.length, 1);
+		assert.equal(ledger.terminalEvents.length, 1);
+	});
+});
+
+interface ExecutionHostHandle {
+	child: ChildProcess;
+	hostEpoch: string;
+	endpoint: string;
+}
+
+interface TurnLedger {
+	runs: AgentRunHeader[];
+	userMessages: StoredMessage[];
+	terminalEvents: RuntimeEvent[];
+	classification: ReturnType<typeof classifyTerminalRuntimeLedger>;
+}
+
+class ExecutionFixture {
+	readonly #children = new Set<ChildProcess>();
+
+	constructor(
+		readonly base: string,
+		readonly root: string,
+		readonly capability: StorageRootCapability<"interactive">,
+		readonly sessionId: string,
+	) {}
+
+	sessionPath(): string {
+		return join(this.root, "sessions", this.sessionId, "session.jsonl");
+	}
+
+	runtimeEventsPath(runId: string): string {
+		return join(
+			this.root,
+			"sessions",
+			this.sessionId,
+			"runs",
+			runId,
+			"runtime-events.jsonl",
+		);
+	}
+
+	eventsPath(runId: string): string {
+		return join(
+			this.root,
+			"sessions",
+			this.sessionId,
+			"runs",
+			runId,
+			"events.jsonl",
+		);
+	}
+
+	seedAdmission(
+		turnId: string,
+		text: string,
+	): Promise<{ runId: string; userMessageId: string }> {
+		return this.seedTurnState(turnId, text, false);
+	}
+
+	async archiveSession(): Promise<void> {
+		const owner = await tryAcquireInteractiveRootOwner(this.capability);
+		assert.ok(owner);
+		if (!owner) throw new Error("Unable to acquire execution root for archive");
+		try {
+			const stores = await openInteractiveExecutionStoresForWrite(owner.lease);
+			await stores.sessionStore.archive(this.sessionId);
+		} finally {
+			await owner.close();
+		}
+	}
+
+	seedRunWithoutUserMessage(
+		turnId: string,
+		text: string,
+	): Promise<{ runId: string; userMessageId: string }> {
+		return this.seedTurnState(turnId, text, true);
+	}
+
+	private async seedTurnState(
+		turnId: string,
+		text: string,
+		createRun: boolean,
+	): Promise<{ runId: string; userMessageId: string }> {
+		const owner = await tryAcquireInteractiveRootOwner(this.capability);
+		assert.ok(owner);
+		if (!owner)
+			throw new Error("Unable to acquire execution root for admission setup");
+		try {
+			const stores = await openInteractiveExecutionStoresForWrite(owner.lease);
+			const admittedAt = Date.now();
+			const result = await stores.agentRunStore.admitRootTurn({
+				sessionId: this.sessionId,
+				turnId,
+				proposedRunId: randomUUID(),
+				proposedUserMessageId: randomUUID(),
+				normalizedInput: { text },
+				admittedAt,
+			});
+			assert.equal(result.kind, "admitted");
+			if (createRun) {
+				await stores.agentRunStore.createRun({
+					runId: result.admission.runId,
+					invocationId: result.admission.runId,
+					sessionId: this.sessionId,
+					turnId,
+					status: "created",
+					backendKind: "fake",
+					llmConnectionSlug: "fake",
+					modelId: "fake-model",
+					cwd: this.root,
+					permissionMode: "ask",
+					createdAt: admittedAt,
+					updatedAt: admittedAt,
+				});
+			}
+			return {
+				runId: result.admission.runId,
+				userMessageId: result.admission.userMessageId,
+			};
+		} finally {
+			await owner.close();
+		}
+	}
+
+	async startHost(): Promise<ExecutionHostHandle> {
+		const child = this.spawnHost("inherit");
+		const ready = await waitForHostReady(child);
+		return { child, ...ready };
+	}
+
+	async expectHostStartupFailure(): Promise<void> {
+		const child = this.spawnHost("ignore");
+		await assert.rejects(
+			() => waitForHostReady(child),
+			/execution Host exited before readiness/,
+		);
+		await withTimeout(
+			waitForExit(child),
+			PROCESS_TIMEOUT_MS,
+			"failed execution Host did not exit",
+		);
+		this.#children.delete(child);
+	}
+
+	async assertOwnerAvailable(): Promise<void> {
+		const owner = await tryAcquireInteractiveRootOwner(this.capability);
+		assert.ok(owner);
+		await owner?.close();
+	}
+
+	async stopHost(host: ExecutionHostHandle): Promise<void> {
+		if (host.child.exitCode === null && host.child.signalCode === null) {
+			host.child.kill("SIGTERM");
+		}
+		await withTimeout(
+			waitForExit(host.child),
+			PROCESS_TIMEOUT_MS,
+			"execution Host did not stop",
+		);
+		this.#children.delete(host.child);
+	}
+
+	async killHost(host: ExecutionHostHandle): Promise<void> {
+		host.child.kill("SIGKILL");
+		await withTimeout(
+			waitForExit(host.child),
+			PROCESS_TIMEOUT_MS,
+			"execution Host survived SIGKILL",
+		);
+		this.#children.delete(host.child);
+	}
+
+	async waitForHostExit(host: ExecutionHostHandle): Promise<void> {
+		await withTimeout(
+			waitForExit(host.child),
+			PROCESS_TIMEOUT_MS,
+			"draining execution Host did not exit",
+		);
+		this.#children.delete(host.child);
+	}
+
+	async readTurn(turnId: string): Promise<TurnLedger> {
+		const reader = await acquireReader(this.capability);
+		try {
+			const stores = await openInteractiveExecutionStoresForRead(reader.lease);
+			const admission = await stores.agentRunStore.readRootTurnAdmission(
+				this.sessionId,
+				turnId,
+			);
+			assert.ok(admission);
+			const runs = (
+				await stores.agentRunStore.listSessionRuns(this.sessionId)
+			).filter((candidate) => candidate.turnId === turnId);
+			const run = await stores.agentRunStore.readRun(
+				this.sessionId,
+				admission.runId,
+			);
+			const messages = await stores.sessionStore.readMessages(this.sessionId);
+			const runtimeEvents =
+				await stores.runtimeEventStore.readImmutableRuntimeEvents(
+					this.sessionId,
+					admission.runId,
+				);
+			return {
+				runs,
+				userMessages: messages.filter(
+					(message) => message.type === "user" && message.turnId === turnId,
+				),
+				terminalEvents: runtimeEvents.filter(isTerminalRuntimeEvent),
+				classification: classifyTerminalRuntimeLedger(run, runtimeEvents),
+			};
+		} finally {
+			await reader.close();
+		}
+	}
+
+	async readTurnFootprint(turnId: string): Promise<{
+		admitted: boolean;
+		runCount: number;
+		userMessageCount: number;
+	}> {
+		const reader = await acquireReader(this.capability);
+		try {
+			const stores = await openInteractiveExecutionStoresForRead(reader.lease);
+			const [admission, runs, messages] = await Promise.all([
+				stores.agentRunStore.readRootTurnAdmission(this.sessionId, turnId),
+				stores.agentRunStore.listSessionRuns(this.sessionId),
+				stores.sessionStore.readMessages(this.sessionId),
+			]);
+			return {
+				admitted: admission !== undefined,
+				runCount: runs.filter((run) => run.turnId === turnId).length,
+				userMessageCount: messages.filter(
+					(message) => message.type === "user" && message.turnId === turnId,
+				).length,
+			};
+		} finally {
+			await reader.close();
+		}
+	}
+
+	async close(): Promise<void> {
+		for (const child of this.#children) {
+			if (child.exitCode === null && child.signalCode === null)
+				child.kill("SIGKILL");
+			await withTimeout(
+				waitForExit(child),
+				1_000,
+				"cleanup Host did not exit",
+			).catch(() => undefined);
+		}
+		await rm(join(resolveRootControlNamespace(), this.capability.rootId), {
+			recursive: true,
+			force: true,
+		});
+		await removePosixEndpointDirectories(this.capability.rootId);
+		await rm(this.base, { recursive: true, force: true });
+	}
+
+	private spawnHost(stderr: "inherit" | "ignore"): ChildProcess {
+		const child = fork(
+			new URL("./fixtures/execution-host.js", import.meta.url),
+			[this.root, this.capability.rootId, "60000"],
+			{ stdio: ["ignore", "ignore", stderr, "ipc"] },
+		);
+		this.#children.add(child);
+		return child;
+	}
+}
+
+async function withExecutionRoot(
+	run: (fixture: ExecutionFixture) => Promise<void>,
+): Promise<void> {
+	const base = await mkdtemp(join(tmpdir(), "maka-runtime-host-execution-"));
+	const root = join(base, "root");
+	const capability = await resolveStorageRoot({
+		path: root,
+		kind: "interactive",
+	});
+	const owner = await tryAcquireInteractiveRootOwner(capability);
+	assert.ok(owner);
+	let sessionId: string;
+	try {
+		const stores = await openInteractiveExecutionStoresForWrite(owner.lease);
+		const session = await stores.sessionStore.create({
+			cwd: root,
+			backend: "fake",
+			llmConnectionSlug: "fake",
+			model: "fake-model",
+			permissionMode: "ask",
+		});
+		sessionId = session.id;
+	} finally {
+		await owner.close();
+	}
+	const fixture = new ExecutionFixture(base, root, capability, sessionId);
+	try {
+		await run(fixture);
+	} finally {
+		await fixture.close();
+	}
+}
+
+async function connectClient(
+	rootPath: string,
+	surface: "desktop" | "tui" | "run",
+): Promise<RuntimeHostConnection> {
+	const result = await connectRuntimeHost({
+		rootPath,
+		surface,
+		protocol: PROTOCOL_1,
+	});
+	assert.equal(result.kind, "connected");
+	return result.connection;
+}
+
+async function sendStartWithoutReadingResponse(
+	endpoint: string,
+	input: { sessionId: string; turnId: string; text: string },
+): Promise<FramedTransport> {
+	const transport = new FramedTransport(await openSocket(endpoint));
+	await transport.write({
+		kind: "hello",
+		clientInstanceId: randomUUID(),
+		surface: "desktop",
+		protocolMin: 1,
+		protocolMax: 1,
+	});
+	const handshake = decodeHostFrame(await transport.read(2_000));
+	assert.ok("kind" in handshake);
+	assert.equal(handshake.kind, "accepted");
+	await transport.write({
+		requestId: randomUUID(),
+		operation: "turn.start",
+		input,
+	});
+	return transport;
+}
+
+function openSocket(path: string): Promise<Socket> {
+	return new Promise((resolve, reject) => {
+		const socket = connect(path);
+		const onError = (error: Error) => {
+			socket.off("connect", onConnect);
+			reject(error);
+		};
+		const onConnect = () => {
+			socket.off("error", onError);
+			resolve(socket);
+		};
+		socket.once("error", onError);
+		socket.once("connect", onConnect);
+	});
+}
+
+async function waitForTurn(
+	connection: RuntimeHostConnection,
+	sessionId: string,
+	turnId: string,
+): Promise<TurnSnapshot> {
+	const deadline = Date.now() + PROCESS_TIMEOUT_MS;
+	while (true) {
+		try {
+			return await connection.queryTurn({ sessionId, turnId });
+		} catch (error) {
+			if (
+				!(error instanceof RuntimeHostOperationError) ||
+				error.code !== "not_found"
+			)
+				throw error;
+			if (Date.now() >= deadline)
+				throw new Error("Turn admission was not observed");
+			await sleep(20);
+		}
+	}
+}
+
+async function waitForTerminalTurn(
+	connection: RuntimeHostConnection,
+	sessionId: string,
+	turnId: string,
+): Promise<TurnSnapshot> {
+	const deadline = Date.now() + PROCESS_TIMEOUT_MS;
+	while (true) {
+		const snapshot = await connection.queryTurn({ sessionId, turnId });
+		if (
+			snapshot.status === "completed" ||
+			snapshot.status === "failed" ||
+			snapshot.status === "cancelled"
+		) {
+			return snapshot;
+		}
+		if (Date.now() >= deadline)
+			throw new Error("Turn did not reach a terminal fact");
+		await sleep(20);
+	}
+}
+
+function operationError(code: RuntimeHostOperationError["code"]) {
+	return (error: unknown): boolean =>
+		error instanceof RuntimeHostOperationError && error.code === code;
+}
+
+function assertJsonLines(bytes: string): void {
+	for (const line of bytes.split("\n").filter(Boolean)) {
+		assert.doesNotThrow(() => JSON.parse(line));
+	}
+}
+
+function waitForHostReady(
+	child: ChildProcess,
+): Promise<{ hostEpoch: string; endpoint: string }> {
+	return withTimeout(
+		new Promise((resolve, reject) => {
+			const cleanup = () => {
+				child.off("error", onError);
+				child.off("exit", onExit);
+				child.off("message", onMessage);
+			};
+			const onError = (error: Error) => {
+				cleanup();
+				reject(error);
+			};
+			const onExit = (code: number | null, signal: NodeJS.Signals | null) => {
+				cleanup();
+				reject(
+					new Error(
+						`execution Host exited before readiness: ${code ?? signal}`,
+					),
+				);
+			};
+			const onMessage = (message: unknown) => {
+				if (!isHostReadyMessage(message)) return;
+				cleanup();
+				resolve({ hostEpoch: message.hostEpoch, endpoint: message.endpoint });
+			};
+			child.once("error", onError);
+			child.once("exit", onExit);
+			child.on("message", onMessage);
+		}),
+		PROCESS_TIMEOUT_MS,
+		"execution Host did not become ready",
+	);
+}
+
+function isHostReadyMessage(
+	value: unknown,
+): value is { type: "ready"; hostEpoch: string; endpoint: string } {
+	if (!value || typeof value !== "object") return false;
+	const message = value as Record<string, unknown>;
+	return (
+		message.type === "ready" &&
+		typeof message.hostEpoch === "string" &&
+		typeof message.endpoint === "string"
+	);
+}
+
+function waitForExit(child: ChildProcess): Promise<void> {
+	if (child.exitCode !== null || child.signalCode !== null)
+		return Promise.resolve();
+	return new Promise((resolve, reject) => {
+		child.once("error", reject);
+		child.once("exit", () => resolve());
+	});
+}
+
+async function acquireReader(capability: StorageRootCapability<"interactive">) {
+	const deadline = Date.now() + PROCESS_TIMEOUT_MS;
+	while (true) {
+		const reader = await tryAcquireInteractiveRootReader(capability);
+		if (reader) return reader;
+		if (Date.now() >= deadline)
+			throw new Error(
+				"Interactive root reader could not acquire the released root",
+			);
+		await sleep(20);
+	}
+}
+
+async function removePosixEndpointDirectories(rootId: string): Promise<void> {
+	if (process.platform === "win32" || typeof process.getuid !== "function")
+		return;
+	const prefix = `m-${process.getuid()}-${Buffer.from(rootId, "hex").toString("base64url")}-`;
+	const entries = await readdir("/tmp", { withFileTypes: true });
+	await Promise.all(
+		entries.map(async (entry) => {
+			if (entry.isDirectory() && entry.name.startsWith(prefix)) {
+				await rm(join("/tmp", entry.name), { recursive: true, force: true });
+			}
+		}),
+	);
+}
+
+function withTimeout<T>(
+	promise: Promise<T>,
+	timeoutMs: number,
+	message: string,
+): Promise<T> {
+	let timer: NodeJS.Timeout | undefined;
+	return Promise.race([
+		promise,
+		new Promise<T>((_resolve, reject) => {
+			timer = setTimeout(() => reject(new Error(message)), timeoutMs);
+		}),
+	]).finally(() => {
+		if (timer) clearTimeout(timer);
+	});
+}
+
+function sleep(ms: number): Promise<void> {
+	return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/packages/runtime-host/src/__tests__/fixtures/connect-client.ts
+++ b/packages/runtime-host/src/__tests__/fixtures/connect-client.ts
@@ -1,6 +1,9 @@
 import { connectOrSpawnRuntimeHostWithDependencies } from '../../client/connect-or-spawn.js';
 import { launchDetachedRuntimeHostCandidate } from '../../client/launcher.js';
-import type { ClientSurface } from '../../protocol/index.js';
+import {
+  RUNTIME_HOST_PROTOCOL_VERSION,
+  type ClientSurface,
+} from '../../protocol/index.js';
 
 const [rootPath, surface] = process.argv.slice(2);
 if (!rootPath || !isClientSurface(surface)) {
@@ -12,7 +15,10 @@ const result = await connectOrSpawnRuntimeHostWithDependencies(
   {
     rootPath,
     surface,
-    protocol: { min: 1, max: 1 },
+    protocol: {
+      min: RUNTIME_HOST_PROTOCOL_VERSION,
+      max: RUNTIME_HOST_PROTOCOL_VERSION,
+    },
     electionDeadlineMs: 5_000,
   },
   {

--- a/packages/runtime-host/src/__tests__/fixtures/electron-connect-parent.ts
+++ b/packages/runtime-host/src/__tests__/fixtures/electron-connect-parent.ts
@@ -4,6 +4,7 @@ import {
 } from '@maka/storage/root-authority';
 import { connectOrSpawnRuntimeHost } from '../../client/index.js';
 import { readHostRegistration } from '../../control/registration.js';
+import { RUNTIME_HOST_PROTOCOL_VERSION } from '../../protocol/index.js';
 
 const [rootPath] = process.argv.slice(2);
 if (!rootPath) throw new Error('usage: electron-connect-parent <root>');
@@ -12,7 +13,10 @@ if (!process.versions.electron) throw new Error('electron-connect-parent require
 const result = await connectOrSpawnRuntimeHost({
   rootPath,
   surface: 'desktop',
-  protocol: { min: 1, max: 1 },
+  protocol: {
+    min: RUNTIME_HOST_PROTOCOL_VERSION,
+    max: RUNTIME_HOST_PROTOCOL_VERSION,
+  },
   electionDeadlineMs: 5_000,
 });
 if (result.kind !== 'connected') {

--- a/packages/runtime-host/src/__tests__/fixtures/execution-host.ts
+++ b/packages/runtime-host/src/__tests__/fixtures/execution-host.ts
@@ -1,0 +1,42 @@
+import { startExecutionRuntimeHostCandidate } from "../../server/execution-candidate.js";
+
+const [rootPath, expectedRootId, idleGraceRaw] = process.argv.slice(2);
+if (!rootPath || !expectedRootId || !/^[a-f0-9]{64}$/.test(expectedRootId)) {
+	throw new Error(
+		"usage: execution-host <root> <expected-root-id> [idle-grace-ms]",
+	);
+}
+const idleGraceMs = idleGraceRaw === undefined ? 30_000 : Number(idleGraceRaw);
+if (!Number.isSafeInteger(idleGraceMs) || idleGraceMs < 0) {
+	throw new Error("execution-host requires a non-negative idle grace");
+}
+
+const result = await startExecutionRuntimeHostCandidate({
+	rootPath,
+	expectedRootId,
+	idleGraceMs,
+});
+if (result.kind === "loser") process.exit(2);
+
+process.send?.({
+	type: "ready",
+	hostEpoch: result.host.hostEpoch,
+	endpoint: result.host.endpoint,
+});
+
+let closing = false;
+const close = () => {
+	if (closing) return;
+	closing = true;
+	void result.host.close();
+};
+process.once("SIGINT", close);
+process.once("SIGTERM", close);
+process.once("disconnect", close);
+try {
+	await result.host.closed;
+} catch {
+	process.exitCode = 1;
+} finally {
+	if (process.connected) process.disconnect?.();
+}

--- a/packages/runtime-host/src/__tests__/host-kernel.test.ts
+++ b/packages/runtime-host/src/__tests__/host-kernel.test.ts
@@ -24,7 +24,7 @@ import {
   RuntimeHostProtocolError,
 } from '../protocol/index.js';
 import {
-  NonServingRuntimeHost,
+  RuntimeHostKernel,
   startRuntimeHostCandidate,
   type RuntimeHostCandidateOptions,
   type RuntimeHostCandidateResult,
@@ -60,10 +60,15 @@ describe('non-serving Runtime Host kernel', () => {
       const connected = await connectRuntimeHost({ ...paths, rootPath: paths.root, surface: 'tui', protocol: PROTOCOL_1 });
       assert.equal(connected.kind, 'connected');
       if (connected.kind !== 'connected') return;
-      const status = await connected.connection.status();
-      assert.equal(status.hostEpoch, winner.host.hostEpoch);
-      assert.equal(status.state, 'ready');
-      assert.equal(status.connections, 1);
+      const statuses = await Promise.all([
+        connected.connection.status(),
+        connected.connection.status(),
+      ]);
+      for (const status of statuses) {
+        assert.equal(status.hostEpoch, winner.host.hostEpoch);
+        assert.equal(status.state, 'ready');
+        assert.equal(status.connections, 1);
+      }
       await connected.connection.close();
       await winner.host.closed;
 
@@ -422,7 +427,7 @@ describe('non-serving Runtime Host kernel', () => {
       };
 
       await assert.rejects(
-        () => NonServingRuntimeHost.start({ owner: copiedOwner }),
+        () => RuntimeHostKernel.start({ owner: copiedOwner }),
         (error: unknown) => error instanceof StorageRootAuthorityError
           && error.code === 'invalid_owner',
       );
@@ -449,7 +454,7 @@ describe('non-serving Runtime Host kernel', () => {
       await rename(paths.root, movedRoot);
       await mkdir(paths.root);
       await assert.rejects(
-        () => NonServingRuntimeHost.start({ owner }),
+        () => RuntimeHostKernel.start({ owner }),
         (error: unknown) => error instanceof StorageRootAuthorityError
           && error.code === 'root_identity_changed',
       );
@@ -555,6 +560,7 @@ describe('non-serving Runtime Host kernel', () => {
           protocolMax: 1,
         });
         const handshake = decodeHostFrame(await transport.read(2_000));
+        assert.ok('kind' in handshake);
         assert.equal(handshake.kind, 'accepted');
         incompleteSocket.write('{"kind":"hello"');
         await new Promise<void>((resolve) => setImmediate(resolve));
@@ -595,8 +601,9 @@ describe('non-serving Runtime Host kernel', () => {
         let blockedResponseObserved = false;
         for (let index = 0; index < 10_000 && !nonReadingSocket.destroyed; index += 1) {
           nonReadingSocket.write(`${JSON.stringify({
-            kind: 'status',
             requestId: `non-reading-${index}`,
+            operation: 'host.status',
+            input: {},
           })}\n`);
           const status = await observer.connection.status(2_000);
           if (status.activeOperations <= 1) continue;
@@ -1217,6 +1224,7 @@ async function openNonReadingStatusSocket(path: string): Promise<Socket> {
       protocolMax: 1,
     })}\n`);
   });
+  assert.ok('kind' in handshake);
   assert.equal(handshake.kind, 'accepted');
   socket.on('error', () => undefined);
   return socket;

--- a/packages/runtime-host/src/__tests__/host-kernel.test.ts
+++ b/packages/runtime-host/src/__tests__/host-kernel.test.ts
@@ -21,6 +21,7 @@ import { readHostRegistration } from '../control/registration.js';
 import {
   decodeHostFrame,
   RUNTIME_HOST_MAX_FRAME_BYTES,
+  RUNTIME_HOST_PROTOCOL_VERSION,
   RuntimeHostProtocolError,
 } from '../protocol/index.js';
 import {
@@ -40,8 +41,11 @@ import {
   type StorageRootCapability,
 } from '@maka/storage/root-authority';
 
-const PROTOCOL_1 = { min: 1, max: 1 } as const;
-const PROTOCOL_2 = { min: 2, max: 2 } as const;
+const CURRENT_PROTOCOL = {
+  min: RUNTIME_HOST_PROTOCOL_VERSION,
+  max: RUNTIME_HOST_PROTOCOL_VERSION,
+} as const;
+const LEGACY_PROTOCOL = { min: 1, max: 1 } as const;
 const require = createRequire(import.meta.url);
 
 describe('non-serving Runtime Host kernel', () => {
@@ -57,7 +61,7 @@ describe('non-serving Runtime Host kernel', () => {
         rootPath: paths.root,
       }), { kind: 'loser' });
 
-      const connected = await connectRuntimeHost({ ...paths, rootPath: paths.root, surface: 'tui', protocol: PROTOCOL_1 });
+      const connected = await connectRuntimeHost({ ...paths, rootPath: paths.root, surface: 'tui', protocol: CURRENT_PROTOCOL });
       assert.equal(connected.kind, 'connected');
       if (connected.kind !== 'connected') return;
       const statuses = await Promise.all([
@@ -89,7 +93,7 @@ describe('non-serving Runtime Host kernel', () => {
       });
       assert.equal(candidate.kind, 'winner');
       if (candidate.kind !== 'winner') return;
-      const resident = await connectRuntimeHost({ ...paths, rootPath: paths.root, surface: 'desktop', protocol: PROTOCOL_1 });
+      const resident = await connectRuntimeHost({ ...paths, rootPath: paths.root, surface: 'desktop', protocol: CURRENT_PROTOCOL });
       assert.equal(resident.kind, 'connected');
       if (resident.kind !== 'connected') return;
 
@@ -97,7 +101,7 @@ describe('non-serving Runtime Host kernel', () => {
         ...paths,
         rootPath: paths.root,
         surface: 'tui',
-        protocol: PROTOCOL_2,
+        protocol: LEGACY_PROTOCOL,
         electionDeadlineMs: 2_000,
       });
       assert.equal(blocked.kind, 'incompatible');
@@ -105,8 +109,8 @@ describe('non-serving Runtime Host kernel', () => {
       await resident.connection.close();
 
       const replaceable = await Promise.all([
-        connectRuntimeHost({ ...paths, rootPath: paths.root, surface: 'tui', protocol: PROTOCOL_2 }),
-        connectRuntimeHost({ ...paths, rootPath: paths.root, surface: 'run', protocol: PROTOCOL_2 }),
+        connectRuntimeHost({ ...paths, rootPath: paths.root, surface: 'tui', protocol: LEGACY_PROTOCOL }),
+        connectRuntimeHost({ ...paths, rootPath: paths.root, surface: 'run', protocol: LEGACY_PROTOCOL }),
       ]);
       for (const result of replaceable) {
         assert.equal(result.kind, 'incompatible');
@@ -126,7 +130,7 @@ describe('non-serving Runtime Host kernel', () => {
         ...paths,
         rootPath: paths.root,
         surface: 'tui',
-        protocol: PROTOCOL_1,
+        protocol: CURRENT_PROTOCOL,
       });
       assert.equal(attached.kind, 'connected');
       if (attached.kind !== 'connected') return;
@@ -185,7 +189,7 @@ describe('non-serving Runtime Host kernel', () => {
             idleGraceMs: 10_000,
           });
           holderPid = holder.pid;
-          const connected = await retryConnect(paths, PROTOCOL_1);
+          const connected = await retryConnect(paths, CURRENT_PROTOCOL);
           assert.equal(connected.kind, 'connected');
           if (connected.kind !== 'connected') return;
           assert.equal(connected.registration.pid, holderPid);
@@ -205,7 +209,7 @@ describe('non-serving Runtime Host kernel', () => {
             ...paths,
             rootPath: paths.root,
             surface: 'run',
-            protocol: PROTOCOL_1,
+            protocol: CURRENT_PROTOCOL,
           });
           assert.equal(stillConnected.kind, 'connected');
           if (stillConnected.kind !== 'connected') return;
@@ -229,7 +233,7 @@ describe('non-serving Runtime Host kernel', () => {
             {
               rootPath: paths.root,
               surface: 'inspect',
-              protocol: PROTOCOL_1,
+              protocol: CURRENT_PROTOCOL,
               electionDeadlineMs: 100,
             },
             {
@@ -247,7 +251,7 @@ describe('non-serving Runtime Host kernel', () => {
             {
               rootPath: paths.root,
               surface: 'inspect',
-              protocol: PROTOCOL_1,
+              protocol: CURRENT_PROTOCOL,
               electionDeadlineMs: 5_000,
             },
             {
@@ -304,7 +308,7 @@ describe('non-serving Runtime Host kernel', () => {
       paths.resources.trackPid(launchedPid);
       await waitForExit(launcher);
 
-      const connected = await retryConnect(paths, PROTOCOL_1);
+      const connected = await retryConnect(paths, CURRENT_PROTOCOL);
       assert.equal(connected.kind, 'connected');
       if (connected.kind !== 'connected') return;
       assert.equal(connected.registration.pid, launchedPid);
@@ -332,7 +336,7 @@ describe('non-serving Runtime Host kernel', () => {
       paths.resources.trackPid(launched.pid);
       await waitForSuccessfulExit(parent, 'Electron connect parent');
 
-      const connected = await retryConnect(paths, PROTOCOL_1);
+      const connected = await retryConnect(paths, CURRENT_PROTOCOL);
       assert.equal(connected.kind, 'connected');
       if (connected.kind !== 'connected') return;
       assert.equal(connected.connection.hostEpoch, launched.hostEpoch);
@@ -356,7 +360,7 @@ describe('non-serving Runtime Host kernel', () => {
       });
       let stopped = false;
       try {
-        const connected = await retryConnect(paths, PROTOCOL_1);
+        const connected = await retryConnect(paths, CURRENT_PROTOCOL);
         assert.equal(connected.kind, 'connected');
         if (connected.kind !== 'connected') return;
 
@@ -372,7 +376,7 @@ describe('non-serving Runtime Host kernel', () => {
 
         process.kill(attempt.pid, 'SIGCONT');
         stopped = false;
-        const reconnected = await retryConnect(paths, PROTOCOL_1);
+        const reconnected = await retryConnect(paths, CURRENT_PROTOCOL);
         assert.equal(reconnected.kind, 'connected');
         if (reconnected.kind !== 'connected') return;
         assert.equal((await reconnected.connection.status()).hostEpoch, connected.connection.hostEpoch);
@@ -398,7 +402,7 @@ describe('non-serving Runtime Host kernel', () => {
       const result = await connectOrSpawnRuntimeHost({
         rootPath: paths.root,
         surface: 'tui',
-        protocol: PROTOCOL_1,
+        protocol: CURRENT_PROTOCOL,
         electionDeadlineMs: 100,
       });
       assert.deepEqual(result, { kind: 'failed', reason: 'startup_timeout' });
@@ -478,7 +482,7 @@ describe('non-serving Runtime Host kernel', () => {
       });
       let stopped = false;
       try {
-        const connected = await retryConnect(paths, PROTOCOL_1);
+        const connected = await retryConnect(paths, CURRENT_PROTOCOL);
         assert.equal(connected.kind, 'connected');
         if (connected.kind !== 'connected') return;
         await connected.connection.close();
@@ -491,7 +495,7 @@ describe('non-serving Runtime Host kernel', () => {
           {
             rootPath: paths.root,
             surface: 'tui',
-            protocol: PROTOCOL_1,
+            protocol: CURRENT_PROTOCOL,
             electionDeadlineMs: 50,
             handshakeTimeoutMs: 5_000,
           },
@@ -529,8 +533,8 @@ describe('non-serving Runtime Host kernel', () => {
         kind: 'hello',
         clientInstanceId: 'draining-client',
         surface: 'tui',
-        protocolMin: 1,
-        protocolMax: 1,
+        protocolMin: CURRENT_PROTOCOL.min,
+        protocolMax: CURRENT_PROTOCOL.max,
       });
       const response = decodeHostFrame(await transport.read(2_000));
       assert.deepEqual(response, { kind: 'draining', hostEpoch: candidate.host.hostEpoch });
@@ -556,8 +560,8 @@ describe('non-serving Runtime Host kernel', () => {
           kind: 'hello',
           clientInstanceId: 'half-open-client',
           surface: 'tui',
-          protocolMin: 1,
-          protocolMax: 1,
+          protocolMin: CURRENT_PROTOCOL.min,
+          protocolMax: CURRENT_PROTOCOL.max,
         });
         const handshake = decodeHostFrame(await transport.read(2_000));
         assert.ok('kind' in handshake);
@@ -593,7 +597,7 @@ describe('non-serving Runtime Host kernel', () => {
         ...paths,
         rootPath: paths.root,
         surface: 'inspect',
-        protocol: PROTOCOL_1,
+        protocol: CURRENT_PROTOCOL,
       });
       assert.equal(observer.kind, 'connected');
       if (observer.kind !== 'connected') return;
@@ -684,7 +688,7 @@ describe('non-serving Runtime Host kernel', () => {
         () => connectRuntimeHost({
           rootPath: paths.root,
           surface: 'tui',
-          protocol: PROTOCOL_1,
+          protocol: CURRENT_PROTOCOL,
           connectTimeoutMs: 0,
         }),
         RangeError,
@@ -693,7 +697,7 @@ describe('non-serving Runtime Host kernel', () => {
         () => connectRuntimeHost({
           rootPath: paths.root,
           surface: 'tui',
-          protocol: PROTOCOL_1,
+          protocol: CURRENT_PROTOCOL,
           handshakeTimeoutMs: 0,
         }),
         RangeError,
@@ -702,7 +706,7 @@ describe('non-serving Runtime Host kernel', () => {
         () => connectRuntimeHost({
           rootPath: paths.root,
           surface: 'tui',
-          protocol: PROTOCOL_1,
+          protocol: CURRENT_PROTOCOL,
           clientInstanceId: '',
         }),
         RuntimeHostProtocolError,
@@ -719,7 +723,7 @@ describe('non-serving Runtime Host kernel', () => {
         () => connectOrSpawnRuntimeHost({
           rootPath: paths.root,
           surface: 'tui',
-          protocol: PROTOCOL_1,
+          protocol: CURRENT_PROTOCOL,
           clientInstanceId: 'x'.repeat(129),
           electionDeadlineMs: 100,
         }),
@@ -775,7 +779,7 @@ describe('non-serving Runtime Host kernel', () => {
       await writeFile(join(controlDirectory, 'registration.json'), '{"endpoint":"/tmp/not-authority"}\n', {
         mode: 0o600,
       });
-      const result = await connectRuntimeHost({ ...paths, rootPath: paths.root, surface: 'inspect', protocol: PROTOCOL_1 });
+      const result = await connectRuntimeHost({ ...paths, rootPath: paths.root, surface: 'inspect', protocol: CURRENT_PROTOCOL });
       assert.deepEqual(result, { kind: 'unavailable', reason: 'invalid_registration' });
     });
   });
@@ -796,7 +800,7 @@ describe('non-serving Runtime Host kernel', () => {
         ...paths,
         rootPath: paths.root,
         surface: 'tui',
-        protocol: PROTOCOL_1,
+        protocol: CURRENT_PROTOCOL,
       });
       assert.equal(connected.kind, 'connected');
       if (connected.kind !== 'connected') return;
@@ -817,7 +821,7 @@ describe('non-serving Runtime Host kernel', () => {
       const connected = await connectRuntimeHost({
         rootPath: paths.root,
         surface: 'tui',
-        protocol: PROTOCOL_1,
+        protocol: CURRENT_PROTOCOL,
       });
       assert.equal(connected.kind, 'connected');
       if (connected.kind !== 'connected') return;
@@ -1220,8 +1224,8 @@ async function openNonReadingStatusSocket(path: string): Promise<Socket> {
       kind: 'hello',
       clientInstanceId: 'non-reading-client',
       surface: 'tui',
-      protocolMin: 1,
-      protocolMax: 1,
+      protocolMin: CURRENT_PROTOCOL.min,
+      protocolMax: CURRENT_PROTOCOL.max,
     })}\n`);
   });
   assert.ok('kind' in handshake);

--- a/packages/runtime-host/src/__tests__/protocol.test.ts
+++ b/packages/runtime-host/src/__tests__/protocol.test.ts
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict';
 import { describe, test } from 'node:test';
 import {
   decodeClientFrame,
+  decodeHostFrame,
   negotiateProtocol,
   ProtocolFrameDecoder,
   RUNTIME_HOST_MAX_FRAME_BYTES,
@@ -18,15 +19,68 @@ describe('Runtime Host bootstrap protocol', () => {
     const decoder = new ProtocolFrameDecoder();
     const wire = Buffer.from(
       `${JSON.stringify({ kind: 'hello', clientInstanceId: '客户端', surface: 'tui', protocolMin: 1, protocolMax: 1 })}\n`
-      + `${JSON.stringify({ kind: 'status', requestId: 'status-1' })}\n`,
+      + `${JSON.stringify({ requestId: 'status-1', operation: 'host.status', input: {} })}\n`,
     );
     const split = wire.indexOf(Buffer.from('端')) + 1;
     assert.deepEqual(decoder.push(wire.subarray(0, split)), []);
     const frames = decoder.push(wire.subarray(split));
     assert.equal(frames.length, 2);
-    assert.equal(decodeClientFrame(frames[0]).kind, 'hello');
-    assert.deepEqual(decodeClientFrame(frames[1]), { kind: 'status', requestId: 'status-1' });
+    assert.deepEqual(decodeClientFrame(frames[0]), {
+      kind: 'hello',
+      clientInstanceId: '客户端',
+      surface: 'tui',
+      protocolMin: 1,
+      protocolMax: 1,
+    });
+    assert.deepEqual(decodeClientFrame(frames[1]), {
+      requestId: 'status-1',
+      operation: 'host.status',
+      input: {},
+    });
     decoder.end();
+  });
+
+  test('keeps the operation registry closed at request and response boundaries', () => {
+    assert.throws(
+      () => decodeClientFrame({ requestId: 'request-1', operation: 'store.read', input: {} }),
+      isInvalidFrame,
+    );
+    assert.throws(
+      () => decodeClientFrame({
+        requestId: 'request-2',
+        operation: 'turn.query',
+        input: { sessionId: 'session-1', turnId: 'turn-1', path: '/tmp/private' },
+      }),
+      isInvalidFrame,
+    );
+    assert.throws(
+      () => decodeHostFrame({
+        requestId: 'request-3',
+        operation: 'turn.query',
+        ok: false,
+        error: { code: 'session_busy', message: 'busy' },
+      }),
+      isInvalidFrame,
+    );
+  });
+
+  test('rejects terminal snapshots with fields from another terminal variant', () => {
+    assert.throws(
+      () => decodeHostFrame({
+        requestId: 'request-4',
+        operation: 'turn.query',
+        ok: true,
+        result: {
+          sessionId: 'session-1',
+          turnId: 'turn-1',
+          runId: 'run-1',
+          status: 'completed',
+          terminalEventId: 'event-1',
+          abortSource: 'user',
+        },
+      }),
+      isInvalidFrame,
+    );
   });
 
   test('rejects a frame before buffering more than the byte cap', () => {
@@ -37,3 +91,7 @@ describe('Runtime Host bootstrap protocol', () => {
     );
   });
 });
+
+function isInvalidFrame(error: unknown): boolean {
+  return error instanceof RuntimeHostProtocolError && error.code === 'invalid_frame';
+}

--- a/packages/runtime-host/src/client/connection.ts
+++ b/packages/runtime-host/src/client/connection.ts
@@ -10,14 +10,24 @@ import { readHostRegistration, RuntimeHostRegistrationError } from '../control/r
 import {
   decodeHostFrame,
   type ClientSurface,
+  type HostOperationErrorCode,
   type HostIncompatible,
   type HostRegistration,
-  type HostStatusResponse,
+  type HostStatusResult,
+  type OperationInput,
+  type OperationKey,
+  type OperationOutput,
   type ProtocolRange,
+  type RequestFrame,
+  type ResponseFrame,
+  type TurnQueryInput,
+  type TurnSnapshot,
+  type TurnStartInput,
+  type TurnStopInput,
   requireClientInstanceId,
   validateProtocolRange,
 } from '../protocol/index.js';
-import { FramedTransport } from '../transport/framed-transport.js';
+import { FramedTransport, RuntimeHostTransportError } from '../transport/framed-transport.js';
 
 const DEFAULT_CONNECT_TIMEOUT_MS = 500;
 const DEFAULT_HANDSHAKE_TIMEOUT_MS = 2_000;
@@ -69,8 +79,34 @@ export interface RuntimeHostConnection {
   readonly connectionId: string;
   readonly selectedProtocol: number;
   readonly closed: Promise<void>;
-  status(timeoutMs?: number): Promise<HostStatusResponse>;
+  request<K extends OperationKey>(
+    operation: K,
+    input: OperationInput<K>,
+    timeoutMs?: number,
+  ): Promise<OperationOutput<K>>;
+  status(timeoutMs?: number): Promise<HostStatusResult>;
+  startTurn(input: TurnStartInput, timeoutMs?: number): Promise<TurnSnapshot>;
+  queryTurn(input: TurnQueryInput, timeoutMs?: number): Promise<TurnSnapshot>;
+  stopTurn(input: TurnStopInput, timeoutMs?: number): Promise<TurnSnapshot>;
   close(): Promise<void>;
+}
+
+export class RuntimeHostOperationError extends Error {
+  constructor(
+    readonly operation: OperationKey,
+    readonly code: HostOperationErrorCode,
+    message: string,
+  ) {
+    super(message);
+    this.name = 'RuntimeHostOperationError';
+  }
+}
+
+interface PendingRequest {
+  operation: OperationKey;
+  resolve(value: unknown): void;
+  reject(error: Error): void;
+  timer: NodeJS.Timeout;
 }
 
 class RuntimeHostConnectionImpl implements RuntimeHostConnection {
@@ -79,7 +115,7 @@ class RuntimeHostConnectionImpl implements RuntimeHostConnection {
   readonly selectedProtocol: number;
   readonly closed: Promise<void>;
   readonly #transport: FramedTransport;
-  #requestTail: Promise<void> = Promise.resolve();
+  readonly #pendingRequests = new Map<string, PendingRequest>();
   #terminalError: Error | undefined;
 
   constructor(
@@ -95,34 +131,103 @@ class RuntimeHostConnectionImpl implements RuntimeHostConnection {
     this.connectionId = accepted.connectionId;
     this.selectedProtocol = accepted.selectedProtocol;
     this.closed = this.#transport.closed;
+    void this.#readResponses();
   }
 
-  status(timeoutMs = DEFAULT_HANDSHAKE_TIMEOUT_MS): Promise<HostStatusResponse> {
+  request<K extends OperationKey>(
+    operation: K,
+    input: OperationInput<K>,
+    timeoutMs = DEFAULT_HANDSHAKE_TIMEOUT_MS,
+  ): Promise<OperationOutput<K>> {
     const boundedTimeoutMs = requireTimeout(timeoutMs, 'timeoutMs');
-    const request = async () => {
-      if (this.#terminalError) throw this.#terminalError;
-      const requestId = randomUUID();
-      try {
-        await this.#transport.write({ kind: 'status', requestId });
-        const frame = decodeHostFrame(await this.#transport.read(boundedTimeoutMs));
-        if (frame.kind !== 'status' || frame.requestId !== requestId || frame.hostEpoch !== this.hostEpoch) {
-          throw new Error('Runtime Host returned a mismatched status response');
-        }
-        return frame;
-      } catch (error) {
-        this.#terminalError = error instanceof Error ? error : new Error(String(error));
-        this.#transport.destroy();
-        throw this.#terminalError;
-      }
-    };
-    const result = this.#requestTail.then(request, request);
-    this.#requestTail = result.then(() => undefined, () => undefined);
+    if (this.#terminalError) return Promise.reject(this.#terminalError);
+    const requestId = randomUUID();
+    const result = new Promise<OperationOutput<K>>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.#fail(new RuntimeHostTransportError(
+          'read_timeout',
+          `Timed out waiting for Runtime Host ${operation} response`,
+        ));
+      }, boundedTimeoutMs);
+      this.#pendingRequests.set(requestId, {
+        operation,
+        resolve: (value) => resolve(value as OperationOutput<K>),
+        reject,
+        timer,
+      });
+    });
+    const frame = { requestId, operation, input } as RequestFrame;
+    void this.#transport.write(frame).catch((error: unknown) => this.#fail(asError(error)));
     return result;
+  }
+
+  async status(timeoutMs?: number): Promise<HostStatusResult> {
+    const status = await this.request('host.status', {}, timeoutMs);
+    if (status.hostEpoch !== this.hostEpoch) {
+      const error = new Error('Runtime Host returned status for a different Host Epoch');
+      this.#fail(error);
+      throw error;
+    }
+    return status;
+  }
+
+  startTurn(input: TurnStartInput, timeoutMs?: number): Promise<TurnSnapshot> {
+    return this.request('turn.start', input, timeoutMs);
+  }
+
+  queryTurn(input: TurnQueryInput, timeoutMs?: number): Promise<TurnSnapshot> {
+    return this.request('turn.query', input, timeoutMs);
+  }
+
+  stopTurn(input: TurnStopInput, timeoutMs?: number): Promise<TurnSnapshot> {
+    return this.request('turn.stop', input, timeoutMs);
   }
 
   async close(): Promise<void> {
     this.#transport.destroy();
     await this.#transport.closed;
+  }
+
+  async #readResponses(): Promise<void> {
+    try {
+      while (true) {
+        const frame = decodeHostFrame(await this.#transport.read(0));
+        if ('kind' in frame) throw new Error('Runtime Host returned a handshake frame after acceptance');
+        this.#acceptResponse(frame);
+      }
+    } catch (error) {
+      this.#fail(asError(error));
+    }
+  }
+
+  #acceptResponse(frame: ResponseFrame): void {
+    const pending = this.#pendingRequests.get(frame.requestId);
+    if (!pending || pending.operation !== frame.operation) {
+      this.#fail(new Error('Runtime Host returned an unmatched operation response'));
+      return;
+    }
+    this.#pendingRequests.delete(frame.requestId);
+    clearTimeout(pending.timer);
+    if (frame.ok) {
+      pending.resolve(frame.result);
+      return;
+    }
+    pending.reject(new RuntimeHostOperationError(
+      frame.operation,
+      frame.error.code,
+      frame.error.message,
+    ));
+  }
+
+  #fail(error: Error): void {
+    if (this.#terminalError) return;
+    this.#terminalError = error;
+    for (const pending of this.#pendingRequests.values()) {
+      clearTimeout(pending.timer);
+      pending.reject(error);
+    }
+    this.#pendingRequests.clear();
+    this.#transport.destroy();
   }
 }
 
@@ -239,7 +344,7 @@ export async function connectResolvedRuntimeHost(
     const handshake = decodeHostFrame(
       await transport.read(0),
     );
-    if (handshake.kind === 'status') throw new Error('Runtime Host returned status before handshake');
+    if (!('kind' in handshake)) throw new Error('Runtime Host returned an operation response before handshake');
     if (handshake.hostEpoch !== registration.hostEpoch) {
       transport.destroy();
       return { kind: 'unavailable', reason: 'epoch_mismatch', registration };
@@ -359,4 +464,8 @@ function readRegistrationBeforeDeadline(
       },
     );
   });
+}
+
+function asError(error: unknown): Error {
+  return error instanceof Error ? error : new Error(String(error));
 }

--- a/packages/runtime-host/src/client/index.ts
+++ b/packages/runtime-host/src/client/index.ts
@@ -1,5 +1,6 @@
 export {
   connectRuntimeHost,
+  RuntimeHostOperationError,
   type ConnectRuntimeHostInput,
   type ConnectRuntimeHostResult,
   type RuntimeHostConnection,

--- a/packages/runtime-host/src/protocol/errors.ts
+++ b/packages/runtime-host/src/protocol/errors.ts
@@ -1,0 +1,19 @@
+export class RuntimeHostProtocolError extends Error {
+	constructor(
+		readonly code:
+			| "invalid_frame"
+			| "frame_too_large"
+			| "invalid_utf8"
+			| "invalid_json",
+		message: string,
+	) {
+		super(message);
+		this.name = "RuntimeHostProtocolError";
+	}
+}
+
+export function invalidProtocolFrame(
+	message: string,
+): RuntimeHostProtocolError {
+	return new RuntimeHostProtocolError("invalid_frame", message);
+}

--- a/packages/runtime-host/src/protocol/index.ts
+++ b/packages/runtime-host/src/protocol/index.ts
@@ -1,11 +1,21 @@
 import { TextDecoder } from 'node:util';
+import { invalidProtocolFrame, RuntimeHostProtocolError } from './errors.js';
+import {
+  decodeRequestFrame,
+  decodeResponseFrame,
+  type HostLifecycleState,
+  type RequestFrame,
+  type ResponseFrame,
+} from './operations.js';
+
+export { RuntimeHostProtocolError } from './errors.js';
+export * from './operations.js';
 
 export const RUNTIME_HOST_REGISTRATION_SCHEMA_VERSION = 1 as const;
 export const RUNTIME_HOST_PROTOCOL_VERSION = 1 as const;
 export const RUNTIME_HOST_MAX_FRAME_BYTES = 64 * 1024;
 
 export type ClientSurface = 'desktop' | 'tui' | 'run' | 'bot' | 'open_gateway' | 'inspect';
-export type HostLifecycleState = 'starting' | 'containing' | 'recovering' | 'ready' | 'draining';
 
 export interface ProtocolRange {
   min: number;
@@ -44,22 +54,8 @@ export interface HostDraining {
 
 export type HostHandshakeResult = HostAccepted | HostIncompatible | HostDraining;
 
-export interface HostStatusRequest {
-  kind: 'status';
-  requestId: string;
-}
-
-export interface HostStatusResponse {
-  kind: 'status';
-  requestId: string;
-  hostEpoch: string;
-  state: HostLifecycleState;
-  connections: number;
-  activeOperations: number;
-}
-
-export type ClientFrame = ClientHello | HostStatusRequest;
-export type HostFrame = HostHandshakeResult | HostStatusResponse;
+export type ClientFrame = ClientHello | RequestFrame;
+export type HostFrame = HostHandshakeResult | ResponseFrame;
 
 export interface HostRegistration {
   kind: 'maka-runtime-host';
@@ -72,16 +68,6 @@ export interface HostRegistration {
   state: HostLifecycleState;
   pid: number;
   createdAt: string;
-}
-
-export class RuntimeHostProtocolError extends Error {
-  constructor(
-    readonly code: 'invalid_frame' | 'frame_too_large' | 'invalid_utf8' | 'invalid_json',
-    message: string,
-  ) {
-    super(message);
-    this.name = 'RuntimeHostProtocolError';
-  }
 }
 
 export function negotiateProtocol(client: ProtocolRange, host: ProtocolRange): number | undefined {
@@ -115,10 +101,7 @@ export function decodeClientFrame(value: unknown): ClientFrame {
       protocolMax,
     } satisfies ClientHello;
   }
-  if (frame.kind === 'status') {
-    return { kind: 'status', requestId: requireId(frame.requestId, 'requestId') };
-  }
-  throw invalidFrame('Unknown client frame kind');
+  return decodeRequestFrame(frame);
 }
 
 export function decodeHostFrame(value: unknown): HostFrame {
@@ -148,17 +131,7 @@ export function decodeHostFrame(value: unknown): HostFrame {
   if (frame.kind === 'draining') {
     return { kind: 'draining', hostEpoch: requireId(frame.hostEpoch, 'hostEpoch') };
   }
-  if (frame.kind === 'status') {
-    return {
-      kind: 'status',
-      requestId: requireId(frame.requestId, 'requestId'),
-      hostEpoch: requireId(frame.hostEpoch, 'hostEpoch'),
-      state: requireHostState(frame.state),
-      connections: requireCount(frame.connections, 'connections'),
-      activeOperations: requireCount(frame.activeOperations, 'activeOperations'),
-    } satisfies HostStatusResponse;
-  }
-  throw invalidFrame('Unknown host frame kind');
+  return decodeResponseFrame(frame);
 }
 
 export function decodeHostRegistration(value: unknown): HostRegistration {
@@ -293,5 +266,5 @@ function requireReplacement(value: unknown): HostIncompatible['replacement'] {
 }
 
 function invalidFrame(message: string): RuntimeHostProtocolError {
-  return new RuntimeHostProtocolError('invalid_frame', message);
+  return invalidProtocolFrame(message);
 }

--- a/packages/runtime-host/src/protocol/index.ts
+++ b/packages/runtime-host/src/protocol/index.ts
@@ -12,7 +12,7 @@ export { RuntimeHostProtocolError } from './errors.js';
 export * from './operations.js';
 
 export const RUNTIME_HOST_REGISTRATION_SCHEMA_VERSION = 1 as const;
-export const RUNTIME_HOST_PROTOCOL_VERSION = 1 as const;
+export const RUNTIME_HOST_PROTOCOL_VERSION = 2 as const;
 export const RUNTIME_HOST_MAX_FRAME_BYTES = 64 * 1024;
 
 export type ClientSurface = 'desktop' | 'tui' | 'run' | 'bot' | 'open_gateway' | 'inspect';

--- a/packages/runtime-host/src/protocol/operations.ts
+++ b/packages/runtime-host/src/protocol/operations.ts
@@ -1,0 +1,516 @@
+import { invalidProtocolFrame } from "./errors.js";
+
+export type HostLifecycleState =
+	| "starting"
+	| "containing"
+	| "recovering"
+	| "ready"
+	| "draining";
+export type OperationMode = "command" | "query" | "control";
+export type RetryPolicy = "none" | "safe" | "semantic";
+export type AdmissionClass = "bootstrap" | "ready" | "session";
+
+export type HostOperationErrorCode =
+	| "host_not_ready"
+	| "host_draining"
+	| "operation_unavailable"
+	| "not_found"
+	| "session_archived"
+	| "session_busy"
+	| "operation_conflict"
+	| "internal_failure";
+
+export interface HostOperationError<
+	C extends HostOperationErrorCode = HostOperationErrorCode,
+> {
+	code: C;
+	message: string;
+}
+
+export interface OperationSpec<
+	Input,
+	Output,
+	ErrorCode extends HostOperationErrorCode,
+> {
+	mode: OperationMode;
+	decodeInput(value: unknown): Input;
+	decodeOutput(value: unknown): Output;
+	errors: readonly ErrorCode[];
+	retry: RetryPolicy;
+	admission: AdmissionClass;
+}
+
+export type HostStatusInput = Record<string, never>;
+
+export interface HostStatusResult {
+	hostEpoch: string;
+	state: HostLifecycleState;
+	connections: number;
+	activeOperations: number;
+	activeResidencies: number;
+}
+
+export interface TurnStartInput {
+	sessionId: string;
+	turnId: string;
+	text: string;
+}
+
+export interface TurnQueryInput {
+	sessionId: string;
+	turnId: string;
+}
+
+export interface TurnStopInput {
+	sessionId: string;
+	turnId: string;
+	runId: string;
+}
+
+export type TurnRunStatus =
+	| "admitted"
+	| "created"
+	| "running"
+	| "waiting_permission"
+	| "completed"
+	| "failed"
+	| "cancelled";
+
+interface TurnSnapshotBase {
+	sessionId: string;
+	turnId: string;
+	runId: string;
+}
+
+export type TurnSnapshot =
+	| (TurnSnapshotBase & {
+			status: Exclude<TurnRunStatus, "completed" | "failed" | "cancelled">;
+	  })
+	| (TurnSnapshotBase & { status: "completed"; terminalEventId: string })
+	| (TurnSnapshotBase & {
+			status: "failed";
+			terminalEventId: string;
+			failureClass: string;
+	  })
+	| (TurnSnapshotBase & {
+			status: "cancelled";
+			terminalEventId: string;
+			abortSource: string;
+	  });
+
+function defineOperation<
+	Input,
+	Output,
+	ErrorCode extends HostOperationErrorCode,
+>(
+	spec: OperationSpec<Input, Output, ErrorCode>,
+): OperationSpec<Input, Output, ErrorCode> {
+	return spec;
+}
+
+export const HOST_OPERATION_SPECS = {
+	"host.status": defineOperation({
+		mode: "query",
+		decodeInput: decodeHostStatusInput,
+		decodeOutput: decodeHostStatusResult,
+		errors: ["host_draining", "internal_failure"] as const,
+		retry: "safe",
+		admission: "bootstrap",
+	}),
+	"turn.start": defineOperation({
+		mode: "command",
+		decodeInput: decodeTurnStartInput,
+		decodeOutput: decodeTurnSnapshot,
+		errors: [
+			"host_not_ready",
+			"host_draining",
+			"operation_unavailable",
+			"not_found",
+			"session_archived",
+			"session_busy",
+			"operation_conflict",
+			"internal_failure",
+		] as const,
+		retry: "semantic",
+		admission: "session",
+	}),
+	"turn.query": defineOperation({
+		mode: "query",
+		decodeInput: decodeTurnQueryInput,
+		decodeOutput: decodeTurnSnapshot,
+		errors: [
+			"host_not_ready",
+			"host_draining",
+			"operation_unavailable",
+			"not_found",
+			"internal_failure",
+		] as const,
+		retry: "safe",
+		admission: "ready",
+	}),
+	"turn.stop": defineOperation({
+		mode: "control",
+		decodeInput: decodeTurnStopInput,
+		decodeOutput: decodeTurnSnapshot,
+		errors: [
+			"host_not_ready",
+			"host_draining",
+			"operation_unavailable",
+			"not_found",
+			"operation_conflict",
+			"internal_failure",
+		] as const,
+		retry: "semantic",
+		admission: "session",
+	}),
+} as const;
+
+export type OperationSpecMap = typeof HOST_OPERATION_SPECS;
+export type OperationKey = keyof OperationSpecMap;
+
+type InferInput<Spec> =
+	Spec extends OperationSpec<infer Input, unknown, HostOperationErrorCode>
+		? Input
+		: never;
+type InferOutput<Spec> =
+	Spec extends OperationSpec<unknown, infer Output, HostOperationErrorCode>
+		? Output
+		: never;
+type InferErrorCode<Spec> =
+	Spec extends OperationSpec<unknown, unknown, infer ErrorCode>
+		? ErrorCode
+		: never;
+
+export type OperationInput<K extends OperationKey> = InferInput<
+	OperationSpecMap[K]
+>;
+export type OperationOutput<K extends OperationKey> = InferOutput<
+	OperationSpecMap[K]
+>;
+export type OperationError<K extends OperationKey> = HostOperationError<
+	InferErrorCode<OperationSpecMap[K]>
+>;
+
+export type RequestFrameFor<K extends OperationKey> = {
+	requestId: string;
+	operation: K;
+	input: OperationInput<K>;
+};
+
+export type ResponseFrameFor<K extends OperationKey> =
+	| { requestId: string; operation: K; ok: true; result: OperationOutput<K> }
+	| { requestId: string; operation: K; ok: false; error: OperationError<K> };
+
+export type OperationOutcome<K extends OperationKey> =
+	| { ok: true; result: OperationOutput<K> }
+	| { ok: false; error: OperationError<K> };
+
+export type RequestFrame = {
+	[K in OperationKey]: RequestFrameFor<K>;
+}[OperationKey];
+export type ResponseFrame = {
+	[K in OperationKey]: ResponseFrameFor<K>;
+}[OperationKey];
+
+export function decodeRequestFrame(value: unknown): RequestFrame {
+	const frame = requireExactRecord(value, "operation request", [
+		"requestId",
+		"operation",
+		"input",
+	]);
+	const requestId = requireId(frame.requestId, "requestId");
+	const operation = requireOperationKey(frame.operation);
+	const spec = HOST_OPERATION_SPECS[operation];
+	const input = spec.decodeInput(frame.input);
+	return { requestId, operation, input } as RequestFrame;
+}
+
+export function decodeResponseFrame(value: unknown): ResponseFrame {
+	const record = requireRecord(value, "operation response");
+	if (record.ok === true) {
+		assertExactKeys(record, "operation response", [
+			"requestId",
+			"operation",
+			"ok",
+			"result",
+		]);
+		const requestId = requireId(record.requestId, "requestId");
+		const operation = requireOperationKey(record.operation);
+		const result = HOST_OPERATION_SPECS[operation].decodeOutput(record.result);
+		return { requestId, operation, ok: true, result } as ResponseFrame;
+	}
+	if (record.ok === false) {
+		assertExactKeys(record, "operation response", [
+			"requestId",
+			"operation",
+			"ok",
+			"error",
+		]);
+		const requestId = requireId(record.requestId, "requestId");
+		const operation = requireOperationKey(record.operation);
+		const error = decodeOperationError(
+			record.error,
+			HOST_OPERATION_SPECS[operation].errors,
+		);
+		return { requestId, operation, ok: false, error } as ResponseFrame;
+	}
+	throw invalidProtocolFrame("Invalid operation response outcome");
+}
+
+export function isOperationKey(value: unknown): value is OperationKey {
+	return (
+		typeof value === "string" && Object.hasOwn(HOST_OPERATION_SPECS, value)
+	);
+}
+
+function decodeHostStatusInput(value: unknown): HostStatusInput {
+	requireExactRecord(value, "host.status input", []);
+	return {};
+}
+
+function decodeHostStatusResult(value: unknown): HostStatusResult {
+	const record = requireExactRecord(value, "host.status result", [
+		"hostEpoch",
+		"state",
+		"connections",
+		"activeOperations",
+		"activeResidencies",
+	]);
+	return {
+		hostEpoch: requireId(record.hostEpoch, "hostEpoch"),
+		state: requireHostState(record.state),
+		connections: requireCount(record.connections, "connections"),
+		activeOperations: requireCount(record.activeOperations, "activeOperations"),
+		activeResidencies: requireCount(
+			record.activeResidencies,
+			"activeResidencies",
+		),
+	};
+}
+
+function decodeTurnStartInput(value: unknown): TurnStartInput {
+	const record = requireExactRecord(value, "turn.start input", [
+		"sessionId",
+		"turnId",
+		"text",
+	]);
+	return {
+		sessionId: requireEntityId(record.sessionId, "sessionId"),
+		turnId: requireEntityId(record.turnId, "turnId"),
+		text: requireString(record.text, "text", 48 * 1024),
+	};
+}
+
+function decodeTurnQueryInput(value: unknown): TurnQueryInput {
+	const record = requireExactRecord(value, "turn.query input", [
+		"sessionId",
+		"turnId",
+	]);
+	return {
+		sessionId: requireEntityId(record.sessionId, "sessionId"),
+		turnId: requireEntityId(record.turnId, "turnId"),
+	};
+}
+
+function decodeTurnStopInput(value: unknown): TurnStopInput {
+	const record = requireExactRecord(value, "turn.stop input", [
+		"sessionId",
+		"turnId",
+		"runId",
+	]);
+	return {
+		sessionId: requireEntityId(record.sessionId, "sessionId"),
+		turnId: requireEntityId(record.turnId, "turnId"),
+		runId: requireEntityId(record.runId, "runId"),
+	};
+}
+
+function decodeTurnSnapshot(value: unknown): TurnSnapshot {
+	const record = requireRecord(value, "Turn snapshot");
+	const base = {
+		sessionId: requireEntityId(record.sessionId, "sessionId"),
+		turnId: requireEntityId(record.turnId, "turnId"),
+		runId: requireEntityId(record.runId, "runId"),
+	};
+	const status = requireTurnRunStatus(record.status);
+	if (status === "completed") {
+		assertExactKeys(record, "completed Turn snapshot", [
+			"sessionId",
+			"turnId",
+			"runId",
+			"status",
+			"terminalEventId",
+		]);
+		return {
+			...base,
+			status,
+			terminalEventId: requireId(record.terminalEventId, "terminalEventId"),
+		};
+	}
+	if (status === "failed") {
+		assertExactKeys(record, "failed Turn snapshot", [
+			"sessionId",
+			"turnId",
+			"runId",
+			"status",
+			"terminalEventId",
+			"failureClass",
+		]);
+		return {
+			...base,
+			status,
+			terminalEventId: requireId(record.terminalEventId, "terminalEventId"),
+			failureClass: requireString(record.failureClass, "failureClass", 128),
+		};
+	}
+	if (status === "cancelled") {
+		assertExactKeys(record, "cancelled Turn snapshot", [
+			"sessionId",
+			"turnId",
+			"runId",
+			"status",
+			"terminalEventId",
+			"abortSource",
+		]);
+		return {
+			...base,
+			status,
+			terminalEventId: requireId(record.terminalEventId, "terminalEventId"),
+			abortSource: requireString(record.abortSource, "abortSource", 128),
+		};
+	}
+	assertExactKeys(record, "non-terminal Turn snapshot", [
+		"sessionId",
+		"turnId",
+		"runId",
+		"status",
+	]);
+	return { ...base, status };
+}
+
+function decodeOperationError<C extends HostOperationErrorCode>(
+	value: unknown,
+	allowedCodes: readonly C[],
+): HostOperationError<C> {
+	const record = requireExactRecord(value, "operation error", [
+		"code",
+		"message",
+	]);
+	if (
+		typeof record.code !== "string" ||
+		!allowedCodes.includes(record.code as C)
+	) {
+		throw invalidProtocolFrame("Operation returned an undeclared error code");
+	}
+	return {
+		code: record.code as C,
+		message: requireString(record.message, "operation error message", 1024),
+	};
+}
+
+function requireOperationKey(value: unknown): OperationKey {
+	if (!isOperationKey(value))
+		throw invalidProtocolFrame("Unknown operation key");
+	return value;
+}
+
+function requireHostState(value: unknown): HostLifecycleState {
+	if (
+		value === "starting" ||
+		value === "containing" ||
+		value === "recovering" ||
+		value === "ready" ||
+		value === "draining"
+	)
+		return value;
+	throw invalidProtocolFrame("Invalid Host state");
+}
+
+function requireTurnRunStatus(value: unknown): TurnRunStatus {
+	if (
+		value === "admitted" ||
+		value === "created" ||
+		value === "running" ||
+		value === "waiting_permission" ||
+		value === "completed" ||
+		value === "failed" ||
+		value === "cancelled"
+	)
+		return value;
+	throw invalidProtocolFrame("Invalid Turn run status");
+}
+
+function requireRecord(value: unknown, label: string): Record<string, unknown> {
+	if (!value || typeof value !== "object" || Array.isArray(value)) {
+		throw invalidProtocolFrame(`Invalid ${label}`);
+	}
+	return value as Record<string, unknown>;
+}
+
+function requireExactRecord(
+	value: unknown,
+	label: string,
+	keys: readonly string[],
+): Record<string, unknown> {
+	const record = requireRecord(value, label);
+	assertExactKeys(record, label, keys);
+	return record;
+}
+
+function assertExactKeys(
+	record: Record<string, unknown>,
+	label: string,
+	keys: readonly string[],
+): void {
+	assertAllowedKeys(record, label, keys);
+	if (
+		Object.keys(record).length !== keys.length ||
+		keys.some((key) => !Object.hasOwn(record, key))
+	) {
+		throw invalidProtocolFrame(`Invalid ${label} fields`);
+	}
+}
+
+function assertAllowedKeys(
+	record: Record<string, unknown>,
+	label: string,
+	keys: readonly string[],
+): void {
+	const allowed = new Set(keys);
+	if (Object.keys(record).some((key) => !allowed.has(key))) {
+		throw invalidProtocolFrame(`Unknown ${label} field`);
+	}
+}
+
+function requireString(
+	value: unknown,
+	label: string,
+	maxLength: number,
+): string {
+	if (
+		typeof value !== "string" ||
+		value.length === 0 ||
+		value.length > maxLength
+	) {
+		throw invalidProtocolFrame(`Invalid ${label}`);
+	}
+	return value;
+}
+
+function requireId(value: unknown, label: string): string {
+	return requireString(value, label, 128);
+}
+
+function requireEntityId(value: unknown, label: string): string {
+	const id = requireId(value, label);
+	if (!/^[A-Za-z0-9_-]{1,128}$/.test(id))
+		throw invalidProtocolFrame(`Invalid ${label}`);
+	return id;
+}
+
+function requireCount(value: unknown, label: string): number {
+	if (!Number.isSafeInteger(value) || (value as number) < 0) {
+		throw invalidProtocolFrame(`Invalid ${label}`);
+	}
+	return value as number;
+}

--- a/packages/runtime-host/src/server/candidate.ts
+++ b/packages/runtime-host/src/server/candidate.ts
@@ -2,7 +2,7 @@ import {
   resolveExistingStorageRoot,
   tryAcquireInteractiveRootOwner,
 } from '@maka/storage/root-authority';
-import { NonServingRuntimeHost } from './host-kernel.js';
+import { RuntimeHostKernel } from './host-kernel.js';
 
 export interface RuntimeHostCandidateOptions {
   rootPath: string;
@@ -13,7 +13,7 @@ export interface RuntimeHostCandidateOptions {
 
 export type RuntimeHostCandidateResult =
   | { kind: 'loser' }
-  | { kind: 'winner'; host: NonServingRuntimeHost };
+  | { kind: 'winner'; host: RuntimeHostKernel };
 
 export async function startRuntimeHostCandidate(
   options: RuntimeHostCandidateOptions,
@@ -25,7 +25,7 @@ export async function startRuntimeHostCandidate(
   });
   const owner = await tryAcquireInteractiveRootOwner(capability);
   if (!owner) return { kind: 'loser' };
-  const host = await NonServingRuntimeHost.start({
+  const host = await RuntimeHostKernel.start({
     owner,
     idleGraceMs: options.idleGraceMs,
     handshakeTimeoutMs: options.handshakeTimeoutMs,

--- a/packages/runtime-host/src/server/execution-candidate.ts
+++ b/packages/runtime-host/src/server/execution-candidate.ts
@@ -1,0 +1,30 @@
+import {
+	resolveExistingStorageRoot,
+	tryAcquireInteractiveRootOwner,
+} from "@maka/storage/root-authority";
+import type { RuntimeHostCandidateOptions } from "./candidate.js";
+import { createExecutionRuntimeHostComposition } from "./execution-composition.js";
+import { RuntimeHostKernel } from "./host-kernel.js";
+
+export type ExecutionRuntimeHostCandidateResult =
+	| { kind: "loser" }
+	| { kind: "winner"; host: RuntimeHostKernel };
+
+export async function startExecutionRuntimeHostCandidate(
+	options: RuntimeHostCandidateOptions,
+): Promise<ExecutionRuntimeHostCandidateResult> {
+	const capability = await resolveExistingStorageRoot({
+		path: options.rootPath,
+		kind: "interactive",
+		expectedRootId: options.expectedRootId,
+	});
+	const owner = await tryAcquireInteractiveRootOwner(capability);
+	if (!owner) return { kind: "loser" };
+	const host = await RuntimeHostKernel.start({
+		owner,
+		idleGraceMs: options.idleGraceMs,
+		handshakeTimeoutMs: options.handshakeTimeoutMs,
+		compositionFactory: createExecutionRuntimeHostComposition,
+	});
+	return { kind: "winner", host };
+}

--- a/packages/runtime-host/src/server/execution-composition.ts
+++ b/packages/runtime-host/src/server/execution-composition.ts
@@ -1,0 +1,44 @@
+import { randomUUID } from "node:crypto";
+import { BackendRegistry, FakeBackend, SessionManager } from "@maka/runtime";
+import { openInteractiveExecutionStoresForWrite } from "@maka/storage/execution-stores";
+import type {
+	RuntimeHostComposition,
+	RuntimeHostCompositionContext,
+} from "./host-kernel.js";
+import { RootTurnCoordinator } from "./root-turn-coordinator.js";
+
+export async function createExecutionRuntimeHostComposition(
+	context: RuntimeHostCompositionContext,
+): Promise<RuntimeHostComposition> {
+	const stores = await openInteractiveExecutionStoresForWrite(
+		context.owner.lease,
+	);
+	const backends = new BackendRegistry();
+	backends.register(
+		"fake",
+		(backendContext) => new FakeBackend(backendContext),
+	);
+	const manager = new SessionManager({
+		store: stores.sessionStore,
+		runStore: stores.agentRunStore,
+		runtimeEventStore: stores.runtimeEventStore,
+		backends,
+		newId: randomUUID,
+		now: Date.now,
+	});
+	const coordinator = new RootTurnCoordinator(
+		manager,
+		stores,
+		context.acquireResidency,
+		context.requestDrain,
+	);
+	return {
+		handlers: coordinator.handlers,
+		recover: async () => {
+			await coordinator.prepareRecovery();
+			await manager.recoverInterruptedSessionsStrict(stores);
+			await coordinator.recover();
+		},
+		close: () => coordinator.close(),
+	};
+}

--- a/packages/runtime-host/src/server/host-kernel.ts
+++ b/packages/runtime-host/src/server/host-kernel.ts
@@ -12,16 +12,26 @@ import {
 } from '../control/registration.js';
 import {
   decodeClientFrame,
+  HOST_OPERATION_SPECS,
   negotiateProtocol,
   RUNTIME_HOST_PROTOCOL_VERSION,
   RUNTIME_HOST_REGISTRATION_SCHEMA_VERSION,
   type ClientHello,
+  type HostOperationErrorCode,
   type HostHandshakeResult,
   type HostLifecycleState,
   type HostRegistration,
-  type HostStatusResponse,
+  type RequestFrame,
 } from '../protocol/index.js';
 import { FramedTransport } from '../transport/framed-transport.js';
+import {
+  dispatchOperation,
+  operationFailureResponse,
+  type ConnectionContext,
+  type DomainOperationHandlerMap,
+  type OperationResidency,
+  type OperationHandlerMap,
+} from './operation-dispatcher.js';
 
 const DEFAULT_IDLE_GRACE_MS = 30_000;
 const DEFAULT_HANDSHAKE_TIMEOUT_MS = 5_000;
@@ -32,37 +42,71 @@ const HOST_PROTOCOL = {
   max: RUNTIME_HOST_PROTOCOL_VERSION,
 } as const;
 
-export interface NonServingRuntimeHostOptions {
+export type RuntimeHostResidency = OperationResidency;
+
+export interface RuntimeHostCompositionContext {
+  owner: InteractiveRootOwner;
+  acquireResidency(): RuntimeHostResidency;
+  requestDrain(): void;
+}
+
+export interface RuntimeHostComposition {
+  readonly handlers: DomainOperationHandlerMap;
+  recover(): Promise<void>;
+  close(): Promise<void>;
+}
+
+export type RuntimeHostCompositionFactory = (
+  context: RuntimeHostCompositionContext,
+) => Promise<RuntimeHostComposition>;
+
+export interface RuntimeHostKernelOptions {
   owner: InteractiveRootOwner;
   idleGraceMs?: number;
   handshakeTimeoutMs?: number;
+  compositionFactory?: RuntimeHostCompositionFactory;
 }
 
-export class NonServingRuntimeHost {
+type AcceptedConnectionContext = Omit<ConnectionContext, 'acquireResidency'>;
+
+interface OperationLease {
+  acquireResidency(): RuntimeHostResidency;
+  seal(): void;
+  finish(): void;
+}
+
+export class RuntimeHostKernel {
   readonly hostEpoch = randomUUID();
   readonly closed: Promise<void>;
-  readonly #options: NonServingRuntimeHostOptions;
+  readonly #options: RuntimeHostKernelOptions;
   readonly #createdAt = new Date().toISOString();
   readonly #server: Server;
   readonly #handshakingTransports = new Set<FramedTransport>();
   readonly #acceptedTransports = new Set<FramedTransport>();
   readonly #operationDrainWaiters = new Set<() => void>();
+  readonly #residencyDrainWaiters = new Set<() => void>();
   readonly #idleGraceMs: number;
   readonly #handshakeTimeoutMs: number;
   #endpoint: RuntimeHostEndpoint | undefined;
   #state: HostLifecycleState = 'starting';
   #activeOperations = 0;
+  #activeCommandOperations = 0;
+  #activeResidencies = 0;
+  #composition: RuntimeHostComposition | undefined;
+  #operationHandlers: OperationHandlerMap;
   #idleTimer: NodeJS.Timeout | undefined;
+  #shutdownRequested = false;
   #shutdownTask: Promise<void> | undefined;
   #resolveClosed!: () => void;
   #rejectClosed!: (error: unknown) => void;
 
-  private constructor(options: NonServingRuntimeHostOptions) {
+  private constructor(options: RuntimeHostKernelOptions) {
     assertDuration(options.idleGraceMs ?? DEFAULT_IDLE_GRACE_MS, 'idleGraceMs', 0);
     assertDuration(options.handshakeTimeoutMs ?? DEFAULT_HANDSHAKE_TIMEOUT_MS, 'handshakeTimeoutMs', 1);
     this.#idleGraceMs = options.idleGraceMs ?? DEFAULT_IDLE_GRACE_MS;
     this.#handshakeTimeoutMs = options.handshakeTimeoutMs ?? DEFAULT_HANDSHAKE_TIMEOUT_MS;
     this.#options = options;
+    this.#operationHandlers = this.#createOperationHandlers(unavailableDomainHandlers());
     this.closed = new Promise((resolve, reject) => {
       this.#resolveClosed = resolve;
       this.#rejectClosed = reject;
@@ -70,14 +114,15 @@ export class NonServingRuntimeHost {
     this.#server = createServer((socket) => this.#accept(socket));
   }
 
-  static async start(options: NonServingRuntimeHostOptions): Promise<NonServingRuntimeHost> {
+  static async start(options: RuntimeHostKernelOptions): Promise<RuntimeHostKernel> {
     const owner = authenticateInteractiveRootOwner(options.owner);
-    let host: NonServingRuntimeHost | undefined;
+    let host: RuntimeHostKernel | undefined;
     try {
-      host = new NonServingRuntimeHost({
+      host = new RuntimeHostKernel({
         owner,
         idleGraceMs: options.idleGraceMs,
         handshakeTimeoutMs: options.handshakeTimeoutMs,
+        compositionFactory: options.compositionFactory,
       });
       await host.#start();
       return host;
@@ -102,7 +147,14 @@ export class NonServingRuntimeHost {
   }
 
   close(): Promise<void> {
-    return this.#commitShutdown();
+    this.#requestDrain();
+    return this.closed;
+  }
+
+  #requestDrain(): void {
+    this.#shutdownRequested = true;
+    this.#cancelIdle();
+    this.#commitRequestedShutdownIfQuiescent();
   }
 
   async #start(): Promise<void> {
@@ -114,6 +166,17 @@ export class NonServingRuntimeHost {
     await listen(this.#server, this.#endpoint.path);
     await this.#endpoint.prepareAfterListen();
     await this.#publishRegistration();
+    if (this.#options.compositionFactory) {
+      this.#state = 'recovering';
+      await this.#publishRegistration();
+      this.#composition = await this.#options.compositionFactory({
+        owner: this.#options.owner,
+        acquireResidency: () => this.#acquireResidency(),
+        requestDrain: () => this.#requestDrain(),
+      });
+      this.#operationHandlers = this.#createOperationHandlers(this.#composition.handlers);
+      await this.#composition.recover();
+    }
     this.#state = 'ready';
     await this.#publishRegistration();
     this.#scheduleIdleIfNeeded();
@@ -131,15 +194,22 @@ export class NonServingRuntimeHost {
     let connectionAccepted = false;
     try {
       const frame = decodeClientFrame(await transport.read(this.#handshakeTimeoutMs));
-      if (frame.kind !== 'hello') throw new Error('First Runtime Host frame must be a hello');
+      if (!('kind' in frame) || frame.kind !== 'hello') {
+        throw new Error('First Runtime Host frame must be a hello');
+      }
       const result = await this.#admitHandshake(frame, transport);
-      connectionAccepted = result.kind === 'accepted';
       await transport.write(result);
-      if (!connectionAccepted) {
+      if (result.kind !== 'accepted') {
         transport.destroyAfterFlush();
         return;
       }
-      await this.#serveAcceptedConnection(transport);
+      connectionAccepted = true;
+      await this.#serveAcceptedConnection(transport, {
+        hostEpoch: this.hostEpoch,
+        connectionId: result.connectionId,
+        surface: frame.surface,
+        principal: 'local_os_user',
+      });
     } catch {
       transport.destroy();
     } finally {
@@ -147,27 +217,33 @@ export class NonServingRuntimeHost {
     }
   }
 
-  async #serveAcceptedConnection(transport: FramedTransport): Promise<void> {
+  async #serveAcceptedConnection(
+    transport: FramedTransport,
+    connection: AcceptedConnectionContext,
+  ): Promise<void> {
     while (true) {
       const frame = decodeClientFrame(await transport.read(0));
-      if (frame.kind !== 'status') throw new Error('Unexpected bootstrap frame after handshake');
-      if (!await this.#beginStatusOperation()) {
-        transport.destroy();
-        return;
+      if ('kind' in frame) throw new Error('Unexpected handshake frame after acceptance');
+      const admission = await this.#beginOperation(frame);
+      if (typeof admission === 'string') {
+        await transport.write(operationFailureResponse(
+          frame,
+          admission,
+          admission === 'host_draining'
+            ? 'Runtime Host is draining'
+            : 'Runtime Host is not ready',
+        ));
+        continue;
       }
-      let response: HostStatusResponse;
       try {
-        response = {
-          kind: 'status',
-          requestId: frame.requestId,
-          hostEpoch: this.hostEpoch,
-          state: this.#state,
-          connections: this.#acceptedTransports.size,
-          activeOperations: this.#activeOperations,
-        };
+        const response = await dispatchOperation(frame, this.#operationHandlers, {
+          ...connection,
+          acquireResidency: () => admission.acquireResidency(),
+        });
+        admission.seal();
         await transport.write(response);
       } finally {
-        this.#finishOperation();
+        admission.finish();
       }
     }
   }
@@ -212,14 +288,47 @@ export class NonServingRuntimeHost {
     if (!this.#acceptedTransports.delete(transport)) {
       throw new Error('Runtime Host connection residency underflow');
     }
-    this.#scheduleIdleIfNeeded();
+    this.#settleLifecycleAfterWork();
   }
 
-  async #beginStatusOperation(): Promise<boolean> {
-    if (!await this.#hasLiveOwnerOrDrain() || this.#state === 'draining') return false;
+  async #beginOperation(frame: RequestFrame): Promise<OperationLease | HostOperationErrorCode> {
+    if (!await this.#hasLiveOwnerOrDrain() || this.#state === 'draining') return 'host_draining';
+    if (this.#shutdownRequested && HOST_OPERATION_SPECS[frame.operation].mode === 'command') {
+      return 'host_draining';
+    }
+    if (HOST_OPERATION_SPECS[frame.operation].admission !== 'bootstrap' && this.#state !== 'ready') {
+      return 'host_not_ready';
+    }
     this.#activeOperations += 1;
+    const command = HOST_OPERATION_SPECS[frame.operation].mode === 'command';
+    if (command) this.#activeCommandOperations += 1;
     this.#cancelIdle();
-    return true;
+    let sealed = false;
+    let finished = false;
+    const seal = () => {
+      if (sealed) return;
+      sealed = true;
+      if (command) {
+        if (this.#activeCommandOperations === 0) {
+          throw new Error('Runtime Host command operation residency underflow');
+        }
+        this.#activeCommandOperations -= 1;
+        this.#settleLifecycleAfterWork();
+      }
+    };
+    return {
+      acquireResidency: () => {
+        if (sealed || finished) throw new Error('Runtime Host operation lease has ended');
+        return this.#acquireResidency();
+      },
+      seal,
+      finish: () => {
+        if (finished) throw new Error('Runtime Host operation lease already ended');
+        finished = true;
+        seal();
+        this.#finishOperation();
+      },
+    };
   }
 
   async #hasLiveOwnerOrDrain(): Promise<boolean> {
@@ -244,7 +353,42 @@ export class NonServingRuntimeHost {
       for (const resolve of this.#operationDrainWaiters) resolve();
       this.#operationDrainWaiters.clear();
     }
-    this.#scheduleIdleIfNeeded();
+    this.#settleLifecycleAfterWork();
+  }
+
+  #acquireResidency(): RuntimeHostResidency {
+    this.#activeResidencies += 1;
+    this.#cancelIdle();
+    let active = true;
+    return {
+      release: () => {
+        if (!active) return;
+        active = false;
+        if (this.#activeResidencies === 0) throw new Error('Runtime Host residency underflow');
+        this.#activeResidencies -= 1;
+        if (this.#activeResidencies === 0) {
+          for (const resolve of this.#residencyDrainWaiters) resolve();
+          this.#residencyDrainWaiters.clear();
+        }
+        this.#settleLifecycleAfterWork();
+      },
+    };
+  }
+
+  #createOperationHandlers(domainHandlers: DomainOperationHandlerMap): OperationHandlerMap {
+    return {
+      'host.status': async () => ({
+        ok: true,
+        result: {
+          hostEpoch: this.hostEpoch,
+          state: this.#state,
+          connections: this.#acceptedTransports.size,
+          activeOperations: this.#activeOperations,
+          activeResidencies: this.#activeResidencies,
+        },
+      }),
+      ...domainHandlers,
+    };
   }
 
   #waitForOperations(): Promise<void> {
@@ -252,7 +396,13 @@ export class NonServingRuntimeHost {
     return new Promise((resolve) => this.#operationDrainWaiters.add(resolve));
   }
 
+  #waitForResidencies(): Promise<void> {
+    if (this.#activeResidencies === 0) return Promise.resolve();
+    return new Promise((resolve) => this.#residencyDrainWaiters.add(resolve));
+  }
+
   #scheduleIdleIfNeeded(): void {
+    if (this.#shutdownRequested) return;
     if (!this.#isTrueIdle() || this.#idleTimer) return;
     this.#idleTimer = setTimeout(() => {
       this.#idleTimer = undefined;
@@ -264,7 +414,8 @@ export class NonServingRuntimeHost {
   #isTrueIdle(): boolean {
     return this.#state === 'ready'
       && this.#acceptedTransports.size === 0
-      && this.#activeOperations === 0;
+      && this.#activeOperations === 0
+      && this.#activeResidencies === 0;
   }
 
   #cancelIdle(): void {
@@ -273,8 +424,22 @@ export class NonServingRuntimeHost {
     this.#idleTimer = undefined;
   }
 
+  #settleLifecycleAfterWork(): void {
+    if (this.#shutdownRequested) {
+      this.#commitRequestedShutdownIfQuiescent();
+      return;
+    }
+    this.#scheduleIdleIfNeeded();
+  }
+
+  #commitRequestedShutdownIfQuiescent(): void {
+    if (this.#activeCommandOperations !== 0) return;
+    void this.#commitShutdown().catch(() => undefined);
+  }
+
   #commitShutdown(): Promise<void> {
     if (!this.#shutdownTask) {
+      this.#shutdownRequested = true;
       this.#state = 'draining';
       this.#cancelIdle();
       this.#shutdownTask = this.#closeResources();
@@ -299,6 +464,8 @@ export class NonServingRuntimeHost {
     }
     for (const transport of handshaking) transport.destroy();
     await operationDrain;
+    await this.#composition?.close().catch((error: unknown) => errors.push(error));
+    await this.#waitForResidencies();
     for (const transport of accepted) transport.destroy();
     await serverClosed;
     await this.#endpoint?.cleanup().catch((error: unknown) => errors.push(error));
@@ -313,6 +480,7 @@ export class NonServingRuntimeHost {
     for (const transport of this.#handshakingTransports) transport.destroy();
     for (const transport of this.#acceptedTransports) transport.destroy();
     await closeServer(this.#server).catch(() => undefined);
+    await this.#composition?.close().catch(() => undefined);
     await this.#endpoint?.cleanup().catch(() => undefined);
     await removeHostRegistration(this.#options.owner.controlDirectory, this.hostEpoch).catch(() => undefined);
     await this.#options.owner.close();
@@ -394,4 +562,19 @@ function assertDuration(value: number, label: string, minimum: 0 | 1): void {
   if (!Number.isSafeInteger(value) || value < minimum || value > 120_000) {
     throw new RangeError(`${label} must be an integer between ${minimum} and 120000`);
   }
+}
+
+function unavailableDomainHandlers(): DomainOperationHandlerMap {
+  const unavailable = {
+    ok: false,
+    error: {
+      code: 'operation_unavailable',
+      message: 'Runtime Host operation is unavailable in this composition',
+    },
+  } as const;
+  return {
+    'turn.start': async () => unavailable,
+    'turn.query': async () => unavailable,
+    'turn.stop': async () => unavailable,
+  };
 }

--- a/packages/runtime-host/src/server/index.ts
+++ b/packages/runtime-host/src/server/index.ts
@@ -1,8 +1,3 @@
-export { createExecutionRuntimeHostComposition } from './execution-composition.js';
-export {
-  startExecutionRuntimeHostCandidate,
-  type ExecutionRuntimeHostCandidateResult,
-} from './execution-candidate.js';
 export {
   RuntimeHostKernel,
   type RuntimeHostComposition,

--- a/packages/runtime-host/src/server/index.ts
+++ b/packages/runtime-host/src/server/index.ts
@@ -1,6 +1,15 @@
+export { createExecutionRuntimeHostComposition } from './execution-composition.js';
 export {
-  NonServingRuntimeHost,
-  type NonServingRuntimeHostOptions,
+  startExecutionRuntimeHostCandidate,
+  type ExecutionRuntimeHostCandidateResult,
+} from './execution-candidate.js';
+export {
+  RuntimeHostKernel,
+  type RuntimeHostComposition,
+  type RuntimeHostCompositionContext,
+  type RuntimeHostCompositionFactory,
+  type RuntimeHostKernelOptions,
+  type RuntimeHostResidency,
 } from './host-kernel.js';
 export {
   startRuntimeHostCandidate,

--- a/packages/runtime-host/src/server/operation-dispatcher.ts
+++ b/packages/runtime-host/src/server/operation-dispatcher.ts
@@ -1,0 +1,100 @@
+import {
+	HOST_OPERATION_SPECS,
+	type ClientSurface,
+	type HostOperationErrorCode,
+	type OperationInput,
+	type OperationKey,
+	type OperationOutcome,
+	type RequestFrame,
+	type RequestFrameFor,
+	type ResponseFrame,
+	type ResponseFrameFor,
+} from "../protocol/index.js";
+
+export interface ConnectionContext {
+	hostEpoch: string;
+	connectionId: string;
+	surface: ClientSurface;
+	principal: "local_os_user";
+	acquireResidency(): OperationResidency;
+}
+
+export interface OperationResidency {
+	release(): void;
+}
+
+export type OperationHandler<K extends OperationKey> = (
+	input: OperationInput<K>,
+	context: ConnectionContext,
+) => Promise<OperationOutcome<K>>;
+
+export type OperationHandlerMap = {
+	[K in OperationKey]: OperationHandler<K>;
+};
+
+export type DomainOperationKey = Exclude<OperationKey, "host.status">;
+export type DomainOperationHandlerMap = Pick<
+	OperationHandlerMap,
+	DomainOperationKey
+>;
+
+export async function dispatchOperation(
+	request: RequestFrame,
+	handlers: OperationHandlerMap,
+	context: ConnectionContext,
+): Promise<ResponseFrame> {
+	return dispatchTypedOperation(
+		request as RequestFrameFor<OperationKey>,
+		handlers,
+		context,
+	) as Promise<ResponseFrame>;
+}
+
+export function operationFailureResponse(
+	request: RequestFrame,
+	code: HostOperationErrorCode,
+	message: string,
+): ResponseFrame {
+	const declaredErrors = HOST_OPERATION_SPECS[request.operation]
+		.errors as readonly HostOperationErrorCode[];
+	if (!declaredErrors.includes(code)) {
+		throw new Error(`${request.operation} does not declare ${code}`);
+	}
+	return {
+		requestId: request.requestId,
+		operation: request.operation,
+		ok: false,
+		error: { code, message },
+	} as ResponseFrame;
+}
+
+async function dispatchTypedOperation<K extends OperationKey>(
+	request: RequestFrameFor<K>,
+	handlers: OperationHandlerMap,
+	context: ConnectionContext,
+): Promise<ResponseFrameFor<K>> {
+	const handler = handlers[request.operation] as OperationHandler<K>;
+	let outcome: OperationOutcome<K>;
+	try {
+		outcome = await handler(request.input, context);
+	} catch {
+		return operationFailureResponse(
+			request as RequestFrame,
+			"internal_failure",
+			"Runtime Host operation failed",
+		) as ResponseFrameFor<K>;
+	}
+	return outcome.ok
+		? {
+				requestId: request.requestId,
+				operation: request.operation,
+				ok: true,
+				result: outcome.result,
+			}
+		: {
+				requestId: request.requestId,
+				operation: request.operation,
+				ok: false,
+				error: outcome.error,
+			};
+}

--- a/packages/runtime-host/src/server/root-turn-coordinator.ts
+++ b/packages/runtime-host/src/server/root-turn-coordinator.ts
@@ -1,0 +1,753 @@
+import { randomUUID } from "node:crypto";
+import type { AgentRunHeader } from "@maka/core/agent-run";
+import type { SessionHeader, StoredMessage } from "@maka/core/session";
+import {
+	classifyTerminalRuntimeLedger,
+	type SessionManager,
+} from "@maka/runtime";
+import type {
+	InteractiveExecutionStoresWriter,
+	RootTurnAdmission,
+} from "@maka/storage/execution-stores";
+import type {
+	OperationOutcome,
+	TurnQueryInput,
+	TurnSnapshot,
+	TurnStartInput,
+	TurnStopInput,
+} from "../protocol/index.js";
+import type { RuntimeHostResidency } from "./host-kernel.js";
+import type {
+	ConnectionContext,
+	DomainOperationHandlerMap,
+} from "./operation-dispatcher.js";
+
+interface ActiveRootTurn {
+	turnId: string;
+	runId: string;
+	userMessageId: string;
+	started: Promise<void>;
+	done: Promise<void>;
+	residency: RuntimeHostResidency;
+}
+
+type TurnStartOutcome = OperationOutcome<"turn.start">;
+
+type TurnStartDisposition =
+	| { kind: "complete"; outcome: TurnStartOutcome }
+	| { kind: "await_start"; active: ActiveRootTurn };
+
+interface Deferred {
+	readonly promise: Promise<void>;
+	readonly settled: boolean;
+	resolve(): void;
+	reject(error: unknown): void;
+}
+
+interface RecoverySessionPlan {
+	sessionId: string;
+	admissions: readonly RootTurnAdmission[];
+	missingMessages: readonly RecoveryUserMessage[];
+}
+
+export class RootTurnCoordinator {
+	readonly handlers: DomainOperationHandlerMap = {
+		"turn.start": (input, context) => this.startTurn(input, context),
+		"turn.query": (input) => this.queryTurn(input),
+		"turn.stop": (input) => this.stopTurn(input),
+	};
+
+	readonly #activeBySession = new Map<string, ActiveRootTurn>();
+	readonly #sessionGateTails = new Map<string, Promise<void>>();
+	readonly #recoveryAdmissionsBySession = new Map<
+		string,
+		readonly RootTurnAdmission[]
+	>();
+
+	constructor(
+		private readonly manager: SessionManager,
+		private readonly stores: InteractiveExecutionStoresWriter,
+		private readonly acquireRecoveryResidency: () => RuntimeHostResidency,
+		private readonly requestHostDrain: () => void,
+	) {}
+
+	async prepareRecovery(): Promise<void> {
+		const sessions = await this.stores.sessionStore.listForRecovery();
+		const plans: RecoverySessionPlan[] = [];
+		for (const session of sessions) {
+			const admissions =
+				await this.stores.agentRunStore.listRootTurnAdmissionsForRecovery(
+					session.id,
+				);
+			const messages = await this.stores.sessionStore.readMessagesForRecovery(
+				session.id,
+			);
+			const runs = await this.stores.agentRunStore.listSessionRunsForRecovery(
+				session.id,
+			);
+			const runsById = new Map(runs.map((run) => [run.runId, run]));
+			for (const run of runs) {
+				await this.stores.agentRunStore.readEventsForRecovery(
+					session.id,
+					run.runId,
+				);
+				await this.stores.runtimeEventStore.readRuntimeEvents(
+					session.id,
+					run.runId,
+				);
+			}
+			const messageIndex = indexRecoveryMessages(messages);
+			const pending: RootTurnAdmission[] = [];
+			const missingMessages: RecoveryUserMessage[] = [];
+			for (const admission of admissions) {
+				const run = runsById.get(admission.runId);
+				const userMessages =
+					messageIndex.userMessagesByTurnId.get(admission.turnId) ?? [];
+				const messageIdOwners =
+					messageIndex.messagesById.get(admission.userMessageId) ?? [];
+				if (messageIdOwners.length > 1) {
+					throw new Error(
+						`Admitted Turn ${admission.turnId} has a duplicated UserMessage identity`,
+					);
+				}
+				const messageIdOwner = messageIdOwners[0];
+				if (!run) {
+					if (userMessages.length > 0 || messageIdOwner) {
+						throw new Error(
+							`Admitted Turn ${admission.turnId} has a UserMessage but no Run`,
+						);
+					}
+					pending.push(admission);
+					continue;
+				}
+				if (run.turnId !== admission.turnId) {
+					throw new Error(
+						`Admitted Turn ${admission.turnId} does not match Run ${admission.runId}`,
+					);
+				}
+				if (userMessages.length > 1) {
+					throw new Error(
+						`Admitted Turn ${admission.turnId} has multiple UserMessages`,
+					);
+				}
+				const userMessage = userMessages[0];
+				if (userMessage) {
+					if (
+						messageIdOwner !== userMessage ||
+						userMessage.id !== admission.userMessageId ||
+						userMessage.text !== admission.normalizedInput.text
+					) {
+						throw new Error(
+							`Admitted Turn ${admission.turnId} does not match its UserMessage`,
+						);
+					}
+					continue;
+				}
+				if (messageIdOwner) {
+					throw new Error(
+						`Admitted Turn ${admission.turnId} reuses another message identity`,
+					);
+				}
+				const recoveredMessage = {
+					type: "user",
+					id: admission.userMessageId,
+					turnId: admission.turnId,
+					ts: admission.admittedAt,
+					text: admission.normalizedInput.text,
+				} satisfies RecoveryUserMessage;
+				missingMessages.push(recoveredMessage);
+				indexRecoveryMessage(messageIndex, recoveredMessage);
+			}
+			if (pending.length > 1) {
+				throw new Error(
+					`Session ${session.id} has multiple admitted Turns without Runs`,
+				);
+			}
+			const admission = pending[0];
+			if (admission && session.status === "archived") {
+				throw new Error(
+					`Archived Session ${session.id} has an admitted Turn without a Run`,
+				);
+			}
+			plans.push({
+				sessionId: session.id,
+				admissions,
+				missingMessages,
+			});
+		}
+
+		for (const plan of plans) {
+			for (const message of plan.missingMessages) {
+				await this.stores.sessionStore.appendMessage(plan.sessionId, message);
+			}
+			this.#recoveryAdmissionsBySession.set(plan.sessionId, plan.admissions);
+		}
+	}
+
+	async recover(): Promise<void> {
+		for (const [sessionId, admissions] of this.#recoveryAdmissionsBySession) {
+			let pending: RootTurnAdmission | undefined;
+			for (const admission of admissions) {
+				const run = await this.readRunIfPresent(sessionId, admission.runId);
+				if (!run) {
+					pending = admission;
+					continue;
+				}
+				const snapshot = await this.readCanonicalSnapshot(
+					sessionId,
+					admission.turnId,
+					admission.runId,
+					run,
+				);
+				if (!isTerminalSnapshot(snapshot)) {
+					throw new Error(
+						`Startup recovery left Turn ${admission.turnId} non-terminal`,
+					);
+				}
+			}
+			const admission = pending;
+			if (!admission) continue;
+			const input = {
+				sessionId,
+				turnId: admission.turnId,
+				text: admission.normalizedInput.text,
+			};
+			const disposition = await this.withSessionGate(sessionId, () =>
+				this.prepareAdmittedTurn(
+					input,
+					admission,
+					this.acquireRecoveryResidency,
+				),
+			);
+			const outcome = await this.resolveStartDisposition(input, disposition);
+			if (!outcome.ok) {
+				throw new Error(
+					`Unable to recover admitted Turn ${admission.turnId}: ${outcome.error.code}`,
+				);
+			}
+		}
+		this.#recoveryAdmissionsBySession.clear();
+	}
+
+	async close(): Promise<void> {
+		const active = [...this.#activeBySession.entries()];
+		const stopResults = await Promise.allSettled(
+			active.map(([sessionId]) =>
+				this.manager.stopSession(sessionId, { source: "stop_button" }),
+			),
+		);
+		const drainResults = await Promise.allSettled(
+			active.map(([, turn]) => turn.done),
+		);
+		const errors = [...stopResults, ...drainResults]
+			.filter(
+				(result): result is PromiseRejectedResult =>
+					result.status === "rejected",
+			)
+			.map((result) => result.reason);
+		if (this.#activeBySession.size !== 0) {
+			errors.push(
+				new Error(
+					"Runtime Host execution composition closed with active Turns",
+				),
+			);
+		}
+		if (errors.length > 0)
+			throw new AggregateError(
+				errors,
+				"Unable to close Runtime Host execution composition",
+			);
+	}
+
+	private startTurn(
+		input: TurnStartInput,
+		context: ConnectionContext,
+	): Promise<TurnStartOutcome> {
+		return this.runCommand(async () => {
+			const disposition = await this.withSessionGate(
+				input.sessionId,
+				async () => {
+					const existing =
+						await this.stores.agentRunStore.readRootTurnAdmission(
+							input.sessionId,
+							input.turnId,
+						);
+					if (existing) {
+						if (existing.normalizedInput.text !== input.text) {
+							return completedStart(
+								operationConflict(
+									"Turn identity was already admitted with a different payload",
+								),
+							);
+						}
+						return this.prepareAdmittedTurn(
+							input,
+							existing,
+							context.acquireResidency,
+						);
+					}
+
+					let header: SessionHeader;
+					try {
+						header = await this.stores.sessionStore.readHeaderSnapshot(
+							input.sessionId,
+						);
+					} catch (error) {
+						if (isMissingFile(error))
+							return completedStart(notFound("Session does not exist"));
+						throw error;
+					}
+					if (header.status === "archived") {
+						return completedStart(
+							sessionArchived("Cannot start a new Turn in an archived Session"),
+						);
+					}
+
+					if (this.#activeBySession.has(input.sessionId)) {
+						return completedStart(
+							sessionBusy("Session already has an active root Turn"),
+						);
+					}
+
+					const admission = await this.stores.agentRunStore.admitRootTurn({
+						sessionId: input.sessionId,
+						turnId: input.turnId,
+						proposedRunId: randomUUID(),
+						proposedUserMessageId: randomUUID(),
+						normalizedInput: { text: input.text },
+						admittedAt: Date.now(),
+					});
+					if (admission.admission.normalizedInput.text !== input.text) {
+						return completedStart(
+							operationConflict(
+								"Turn identity was already admitted with a different payload",
+							),
+						);
+					}
+					return this.prepareAdmittedTurn(
+						input,
+						admission.admission,
+						context.acquireResidency,
+					);
+				},
+			);
+			return this.resolveStartDisposition(input, disposition);
+		});
+	}
+
+	private queryTurn(
+		input: TurnQueryInput,
+	): Promise<OperationOutcome<"turn.query">> {
+		return this.withSessionGate(input.sessionId, async () => {
+			const admission = await this.stores.agentRunStore.readRootTurnAdmission(
+				input.sessionId,
+				input.turnId,
+			);
+			if (!admission) return notFound("Turn was not admitted");
+			return {
+				ok: true,
+				result: await this.readCanonicalSnapshot(
+					input.sessionId,
+					input.turnId,
+					admission.runId,
+				),
+			};
+		});
+	}
+
+	private stopTurn(
+		input: TurnStopInput,
+	): Promise<OperationOutcome<"turn.stop">> {
+		return this.runCommand(() =>
+			this.withSessionGate(input.sessionId, async () => {
+				const admission = await this.stores.agentRunStore.readRootTurnAdmission(
+					input.sessionId,
+					input.turnId,
+				);
+				if (!admission) return notFound("Turn was not admitted");
+				if (admission.runId !== input.runId) {
+					return operationConflict(
+						"Run identity does not match the admitted Turn",
+					);
+				}
+
+				const snapshot = await this.readCanonicalSnapshot(
+					input.sessionId,
+					input.turnId,
+					input.runId,
+				);
+				if (isTerminalSnapshot(snapshot)) return { ok: true, result: snapshot };
+				const active = this.#activeBySession.get(input.sessionId);
+				if (!active) {
+					throw new Error(
+						"Admitted non-terminal Turn has no active Runtime Host execution",
+					);
+				}
+				if (active.turnId !== input.turnId || active.runId !== input.runId) {
+					return operationConflict(
+						"A different root Turn owns the active Session execution",
+					);
+				}
+
+				await this.manager.stopSession(input.sessionId, {
+					source: "stop_button",
+				});
+				await active.done;
+				return {
+					ok: true,
+					result: await this.readCanonicalSnapshot(
+						input.sessionId,
+						input.turnId,
+						input.runId,
+					),
+				};
+			}),
+		);
+	}
+
+	private async prepareAdmittedTurn(
+		input: TurnStartInput,
+		admission: RootTurnAdmission,
+		acquireResidency: () => RuntimeHostResidency,
+	): Promise<TurnStartDisposition> {
+		if (
+			admission.sessionId !== input.sessionId ||
+			admission.turnId !== input.turnId
+		) {
+			throw new Error("Root Turn admission identity does not match its input");
+		}
+		const { runId } = admission;
+		const existingRun = await this.readRunIfPresent(input.sessionId, runId);
+		if (existingRun) {
+			const snapshot = await this.readCanonicalSnapshot(
+				input.sessionId,
+				input.turnId,
+				runId,
+				existingRun,
+			);
+			if (isTerminalSnapshot(snapshot))
+				return completedStart({ ok: true, result: snapshot });
+			const active = this.#activeBySession.get(input.sessionId);
+			if (active?.turnId === input.turnId && active.runId === runId) {
+				return { kind: "await_start", active };
+			}
+			if (active)
+				return completedStart(
+					sessionBusy("Session already has an active root Turn"),
+				);
+			throw new Error(
+				"Admitted non-terminal Turn has no active Runtime Host execution",
+			);
+		}
+
+		const active = this.#activeBySession.get(input.sessionId);
+		if (active) {
+			if (active.turnId !== input.turnId || active.runId !== runId) {
+				return completedStart(
+					sessionBusy("Session already has an active root Turn"),
+				);
+			}
+			return { kind: "await_start", active };
+		}
+
+		const residency = acquireResidency();
+		const started = deferred();
+		const entry: ActiveRootTurn = {
+			turnId: input.turnId,
+			runId,
+			userMessageId: admission.userMessageId,
+			started: started.promise,
+			done: Promise.resolve(),
+			residency,
+		};
+		this.#activeBySession.set(input.sessionId, entry);
+		entry.done = this.drainTurn(input, entry, started);
+		return { kind: "await_start", active: entry };
+	}
+
+	private async resolveStartDisposition(
+		input: TurnStartInput,
+		disposition: TurnStartDisposition,
+	): Promise<TurnStartOutcome> {
+		if (disposition.kind === "complete") return disposition.outcome;
+		await disposition.active.started;
+		return {
+			ok: true,
+			result: await this.readCanonicalSnapshot(
+				input.sessionId,
+				input.turnId,
+				disposition.active.runId,
+			),
+		};
+	}
+
+	private async drainTurn(
+		input: TurnStartInput,
+		active: ActiveRootTurn,
+		started: Deferred,
+	): Promise<void> {
+		try {
+			for await (const _event of this.manager.sendMessage(
+				input.sessionId,
+				{ turnId: input.turnId, text: input.text },
+				{
+					runId: active.runId,
+					userMessageId: active.userMessageId,
+					durability: "required",
+					onRunStarted: (startedRunId) => {
+						if (startedRunId !== active.runId) {
+							throw new Error(
+								"Runtime started a different Run than the admitted identity",
+							);
+						}
+						started.resolve();
+					},
+				},
+			)) {
+				// The Host must consume the complete stream so Runtime finalization can commit.
+			}
+			const snapshot = await this.readCanonicalSnapshot(
+				input.sessionId,
+				input.turnId,
+				active.runId,
+			);
+			if (!isTerminalSnapshot(snapshot)) {
+				throw new Error(
+					"Runtime Turn drained without a canonical terminal fact",
+				);
+			}
+		} catch (error) {
+			if (started.settled) {
+				try {
+					const snapshot = await this.readCanonicalSnapshot(
+						input.sessionId,
+						input.turnId,
+						active.runId,
+					);
+					if (isTerminalSnapshot(snapshot)) return;
+				} catch {
+					// The original execution error remains the command failure.
+				}
+			}
+			started.reject(error);
+			this.requestHostDrain();
+		} finally {
+			if (this.#activeBySession.get(input.sessionId) === active) {
+				this.#activeBySession.delete(input.sessionId);
+			}
+			active.residency.release();
+		}
+	}
+
+	private async readCanonicalSnapshot(
+		sessionId: string,
+		turnId: string,
+		runId: string,
+		knownRun?: AgentRunHeader,
+	): Promise<TurnSnapshot> {
+		const run = knownRun ?? (await this.readRunIfPresent(sessionId, runId));
+		if (!run) return { sessionId, turnId, runId, status: "admitted" };
+		if (run.turnId !== turnId) {
+			throw new Error("Admitted Turn identity does not match its Run header");
+		}
+
+		const [runEvents, runtimeEvents] = await Promise.all([
+			this.stores.agentRunStore.readEvents(sessionId, runId),
+			this.stores.runtimeEventStore.readImmutableRuntimeEvents(
+				sessionId,
+				runId,
+			),
+		]);
+		const terminal = classifyTerminalRuntimeLedger(run, runtimeEvents);
+		if (terminal.kind === "fact") {
+			const fact = terminal.fact;
+			if (fact.runStatus === "completed") {
+				return {
+					sessionId,
+					turnId,
+					runId,
+					status: "completed",
+					terminalEventId: fact.terminalEvent.id,
+				};
+			}
+			if (fact.runStatus === "failed") {
+				if (!fact.failureClass)
+					throw new Error("Failed terminal fact has no failure class");
+				return {
+					sessionId,
+					turnId,
+					runId,
+					status: "failed",
+					terminalEventId: fact.terminalEvent.id,
+					failureClass: fact.failureClass,
+				};
+			}
+			if (!fact.abortSource)
+				throw new Error("Cancelled terminal fact has no abort source");
+			return {
+				sessionId,
+				turnId,
+				runId,
+				status: "cancelled",
+				terminalEventId: fact.terminalEvent.id,
+				abortSource: fact.abortSource,
+			};
+		}
+		if (terminal.kind !== "none") {
+			throw new Error(
+				"Runtime ledger does not contain one canonical terminal fact",
+			);
+		}
+		if (
+			run.status === "completed" ||
+			run.status === "failed" ||
+			run.status === "cancelled"
+		) {
+			throw new Error(
+				"Terminal Run header has no canonical terminal RuntimeEvent",
+			);
+		}
+		if (
+			run.status !== "created" &&
+			!runEvents.some((event) => event.type === "run_started")
+		) {
+			throw new Error("Non-created Run has no durable start fact");
+		}
+		return { sessionId, turnId, runId, status: run.status };
+	}
+
+	private async readRunIfPresent(
+		sessionId: string,
+		runId: string,
+	): Promise<AgentRunHeader | undefined> {
+		try {
+			return await this.stores.agentRunStore.readRun(sessionId, runId);
+		} catch (error) {
+			if (isMissingFile(error)) return undefined;
+			throw error;
+		}
+	}
+
+	private async withSessionGate<T>(
+		sessionId: string,
+		operation: () => Promise<T>,
+	): Promise<T> {
+		const previous = this.#sessionGateTails.get(sessionId) ?? Promise.resolve();
+		let release!: () => void;
+		const current = new Promise<void>((resolve) => {
+			release = resolve;
+		});
+		const tail = previous.then(() => current);
+		this.#sessionGateTails.set(sessionId, tail);
+		await previous;
+		try {
+			return await operation();
+		} finally {
+			release();
+			if (this.#sessionGateTails.get(sessionId) === tail) {
+				this.#sessionGateTails.delete(sessionId);
+			}
+		}
+	}
+
+	private async runCommand<T>(operation: () => Promise<T>): Promise<T> {
+		try {
+			return await operation();
+		} catch (error) {
+			this.requestHostDrain();
+			throw error;
+		}
+	}
+}
+
+type RecoveryUserMessage = Extract<StoredMessage, { type: "user" }>;
+
+interface RecoveryMessageIndex {
+	userMessagesByTurnId: Map<string, RecoveryUserMessage[]>;
+	messagesById: Map<string, StoredMessage[]>;
+}
+
+function indexRecoveryMessages(
+	messages: readonly StoredMessage[],
+): RecoveryMessageIndex {
+	const index: RecoveryMessageIndex = {
+		userMessagesByTurnId: new Map(),
+		messagesById: new Map(),
+	};
+	for (const message of messages) indexRecoveryMessage(index, message);
+	return index;
+}
+
+function indexRecoveryMessage(
+	index: RecoveryMessageIndex,
+	message: StoredMessage,
+): void {
+	appendIndexed(index.messagesById, message.id, message);
+	if (message.type === "user") {
+		appendIndexed(index.userMessagesByTurnId, message.turnId, message);
+	}
+}
+
+function appendIndexed<K, V>(index: Map<K, V[]>, key: K, value: V): void {
+	const values = index.get(key);
+	if (values) values.push(value);
+	else index.set(key, [value]);
+}
+
+function deferred(): Deferred {
+	let settled = false;
+	let resolvePromise!: () => void;
+	let rejectPromise!: (error: unknown) => void;
+	const promise = new Promise<void>((resolve, reject) => {
+		resolvePromise = resolve;
+		rejectPromise = reject;
+	});
+	return {
+		promise,
+		get settled() {
+			return settled;
+		},
+		resolve: () => {
+			if (settled) return;
+			settled = true;
+			resolvePromise();
+		},
+		reject: (error) => {
+			if (settled) return;
+			settled = true;
+			rejectPromise(error);
+		},
+	};
+}
+
+function isMissingFile(error: unknown): boolean {
+	return (error as NodeJS.ErrnoException | undefined)?.code === "ENOENT";
+}
+
+function isTerminalSnapshot(snapshot: TurnSnapshot): boolean {
+	return (
+		snapshot.status === "completed" ||
+		snapshot.status === "failed" ||
+		snapshot.status === "cancelled"
+	);
+}
+
+function completedStart(outcome: TurnStartOutcome): TurnStartDisposition {
+	return { kind: "complete", outcome };
+}
+
+function notFound(message: string) {
+	return { ok: false, error: { code: "not_found", message } } as const;
+}
+
+function sessionBusy(message: string) {
+	return { ok: false, error: { code: "session_busy", message } } as const;
+}
+
+function sessionArchived(message: string) {
+	return { ok: false, error: { code: "session_archived", message } } as const;
+}
+
+function operationConflict(message: string) {
+	return { ok: false, error: { code: "operation_conflict", message } } as const;
+}

--- a/packages/runtime-host/tsconfig.json
+++ b/packages/runtime-host/tsconfig.json
@@ -8,5 +8,9 @@
     "composite": true
   },
   "include": ["src"],
-  "references": [{ "path": "../storage" }]
+  "references": [
+    { "path": "../core" },
+    { "path": "../storage" },
+    { "path": "../runtime" }
+  ]
 }

--- a/packages/runtime/src/__tests__/agent-run-inspect.test.ts
+++ b/packages/runtime/src/__tests__/agent-run-inspect.test.ts
@@ -143,6 +143,21 @@ class MemoryAgentRunStore implements AgentRunStore, RuntimeEventStore {
     this.runtimeEvents.set(eventKey, [...(this.runtimeEvents.get(eventKey) ?? []), copyRuntimeEvent(event)]);
   }
 
+  async ensureTerminalRuntimeEventDurable(
+    sessionId: string,
+    runId: string,
+    event: RuntimeEvent,
+  ): Promise<void> {
+    const existing = (this.runtimeEvents.get(key(sessionId, runId)) ?? []).find((candidate) => candidate.id === event.id);
+    if (!existing) {
+      await this.appendRuntimeEvent(sessionId, runId, event);
+      return;
+    }
+    if (JSON.stringify(existing) !== JSON.stringify(event)) {
+      throw new Error(`RuntimeEvent ${event.id} does not match the durable ledger record`);
+    }
+  }
+
   async readRuntimeEvents(sessionId: string, runId: string): Promise<RuntimeEvent[]> {
     if (this.options.failRuntimeEventReads) throw new Error('runtime ledger is corrupt');
     return (this.runtimeEvents.get(key(sessionId, runId)) ?? []).map(copyRuntimeEvent);

--- a/packages/runtime/src/__tests__/pi-agent-backend.test.ts
+++ b/packages/runtime/src/__tests__/pi-agent-backend.test.ts
@@ -1,6 +1,10 @@
 import assert from 'node:assert/strict';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { describe, test } from 'node:test';
 import type { BackendKind, SessionEvent, SessionHeader, StoredMessage } from '@maka/core';
+import { createSessionStore } from '@maka/storage';
 
 import { PermissionEngine } from '../permission-engine.js';
 import {
@@ -48,6 +52,61 @@ describe('PiAgentBackend skeleton', () => {
     );
     assert.equal(messages.some((message) => message.type === 'tool_call' && message.toolName === 'Read'), true);
     assert.equal(messages.some((message) => message.type === 'tool_result' && message.toolUseId === 'tool-1'), true);
+  });
+
+  test('normalizes noncanonical tool payloads before strict storage recovery', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'maka-pi-canonical-'));
+    try {
+      const store = createSessionStore(root);
+      const session = await store.create({
+        cwd: root,
+        backend: 'pi-agent',
+        llmConnectionSlug: 'pi-agent',
+        model: 'pi-test',
+        permissionMode: 'execute',
+      });
+      const backend = new PiAgentBackend({
+        sessionId: session.id,
+        header: session,
+        appendMessage: (message) => store.appendMessage(session.id, message),
+        permissionEngine: new PermissionEngine({ newId: nextId('perm'), now: nextNow(1_250) }),
+        transport: frames([
+          { type: 'tool_start', toolUseId: 'tool-1', toolName: 'Read' },
+          { type: 'tool_result', toolUseId: 'tool-1' },
+          {
+            type: 'tool_start',
+            toolUseId: 'tool-2',
+            toolName: 'Weather',
+            args: { city: 'Singapore' },
+          },
+          {
+            type: 'tool_result',
+            toolUseId: 'tool-2',
+            content: { kind: 'weather', temperature: 20 },
+          },
+          { type: 'complete' },
+        ]),
+        newId: nextId('id'),
+        now: nextNow(2_250),
+      });
+
+      await drain(backend.send({ turnId: 'turn-1', text: 'inspect', context: [] }));
+
+      const messages = await store.readMessagesForRecovery(session.id);
+      const toolCalls = messages.filter((message) => message.type === 'tool_call');
+      const toolResults = messages.filter((message) => message.type === 'tool_result');
+      assert.equal(toolCalls[0]?.args, null);
+      assert.deepEqual(
+        toolResults[0]?.content,
+        { kind: 'json', value: null },
+      );
+      assert.deepEqual(toolResults[1]?.content, {
+        kind: 'json',
+        value: { kind: 'weather', temperature: 20 },
+      });
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
   });
 
   test('persists Pi text-tool-text as two stable assistant steps', async () => {

--- a/packages/runtime/src/__tests__/runtime-event-backfill.test.ts
+++ b/packages/runtime/src/__tests__/runtime-event-backfill.test.ts
@@ -34,6 +34,29 @@ function recoveryMarker(event: RuntimeEvent): Record<string, unknown> | undefine
 }
 
 describe('runtime event backfill', () => {
+  test('prefers the persisted Run invocation identity over a caller fallback', () => {
+    const result = backfillRuntimeEventsFromStoredMessages({
+      run: { ...run, invocationId: 'persisted-invocation' },
+      invocationId: 'caller-fallback',
+      messages: [
+        {
+          type: 'turn_state',
+          id: 'legacy-state',
+          turnId: 'turn-1',
+          ts: 180,
+          status: 'completed',
+          partialOutputRetained: false,
+        },
+      ],
+      newId: nextIds(),
+      now: () => 999,
+    });
+
+    expect(result.events.map((event) => event.invocationId)).toEqual([
+      'persisted-invocation',
+    ]);
+  });
+
   test('backfills only low-risk RuntimeEvents from legacy StoredMessage rows', () => {
     const messages: StoredMessage[] = [
       {

--- a/packages/runtime/src/__tests__/session-manager-terminal-ledger.test.ts
+++ b/packages/runtime/src/__tests__/session-manager-terminal-ledger.test.ts
@@ -1,6 +1,6 @@
 import { describe, test } from 'node:test';
 import assert from 'node:assert/strict';
-import { deriveTurnRecords, isTerminalRuntimeEvent } from '@maka/core';
+import { deriveTurnRecords, DurableStoreWriteError, isTerminalRuntimeEvent } from '@maka/core';
 import type {
   AgentRunEvent,
   AgentRunHeader,
@@ -263,7 +263,6 @@ describe('SessionManager terminal ledger invariants', () => {
         status: 'failed',
         ts: 3,
         terminalEvent: completedTerminal,
-        terminalEventAlreadyPersisted: true,
         failureClass: 'tool_failed',
       }),
       /terminal RuntimeEvent status completed cannot commit failed run header/,
@@ -352,6 +351,35 @@ describe('SessionManager terminal ledger invariants', () => {
     expect(terminalEvents[0]?.status).toBe('aborted');
     expect(terminalEvents[0]?.actions?.stateDelta?.abortSource).toBe('user_stop');
     expect(terminalEvents[0]?.actions?.stateDelta?.recovered).toBeUndefined();
+  });
+
+  test('synthetic terminal durability failures are not tolerated as header failures', async () => {
+    const runStore = new TinyAgentRunStore({
+      failTerminalRuntimeEventDurabilityAfterAppend: true,
+    });
+    const run = makeRunHeader({ status: 'running' });
+    await runStore.createRun(run);
+
+    await assert.rejects(
+      commitOrCreateTerminalRunFact({
+        runStore,
+        runtimeEventStore: runStore,
+        newId: nextId(),
+        sessionId: run.sessionId,
+        runId: run.runId,
+        turnId: run.turnId,
+        ts: 3,
+        fallbackStatus: 'failed',
+        fallbackInvocationId: run.runId,
+        fallbackFailureClass: 'missing_terminal_event',
+        allowHeaderCommitFailure: true,
+      }),
+      DurableStoreWriteError,
+    );
+
+    expect((await runStore.readRun(run.sessionId, run.runId)).status).toBe('running');
+    expect(await runStore.readRuntimeEvents(run.sessionId, run.runId)).toHaveLength(1);
+    expect(await runStore.readEvents(run.sessionId, run.runId)).toHaveLength(0);
   });
 
   test('synthetic terminal builder keeps live and recovered metadata distinct', () => {
@@ -1376,6 +1404,7 @@ class TinyAgentRunStore implements AgentRunStore, RuntimeEventStore {
 
   constructor(private readonly options: {
     failTerminalRuntimeEventAppends?: boolean;
+    failTerminalRuntimeEventDurabilityAfterAppend?: boolean;
     beforeTerminalRuntimeEventAppend?: () => Promise<void>;
   } = {}) {}
 
@@ -1420,6 +1449,25 @@ class TinyAgentRunStore implements AgentRunStore, RuntimeEventStore {
     if (isTerminalRuntimeEvent(event)) await this.options.beforeTerminalRuntimeEventAppend?.();
     const eventKey = key(sessionId, runId);
     this.runtimeEvents.set(eventKey, [...(this.runtimeEvents.get(eventKey) ?? []), clone(event)]);
+  }
+
+  async ensureTerminalRuntimeEventDurable(
+    sessionId: string,
+    runId: string,
+    event: RuntimeEvent,
+  ): Promise<void> {
+    const existing = (this.runtimeEvents.get(key(sessionId, runId)) ?? []).find((candidate) => candidate.id === event.id);
+    if (!existing) {
+      await this.appendRuntimeEvent(sessionId, runId, event);
+    } else if (JSON.stringify(existing) !== JSON.stringify(event)) {
+      throw new Error(`RuntimeEvent ${event.id} does not match the durable ledger record`);
+    }
+    if (this.options.failTerminalRuntimeEventDurabilityAfterAppend) {
+      throw new DurableStoreWriteError(
+        'terminal runtime event did not reach stable storage',
+        new Error('simulated fsync failure'),
+      );
+    }
   }
 
   async readRuntimeEvents(sessionId: string, runId: string): Promise<RuntimeEvent[]> {

--- a/packages/runtime/src/__tests__/session-manager.test.ts
+++ b/packages/runtime/src/__tests__/session-manager.test.ts
@@ -7752,6 +7752,21 @@ class MemoryAgentRunStore implements AgentRunStore, RuntimeEventStore {
     this.runtimeEvents.set(eventKey, [...(this.runtimeEvents.get(eventKey) ?? []), copyRuntimeEvent(event)]);
   }
 
+  async ensureTerminalRuntimeEventDurable(
+    sessionId: string,
+    runId: string,
+    event: RuntimeEvent,
+  ): Promise<void> {
+    const existing = (this.runtimeEvents.get(key(sessionId, runId)) ?? []).find((candidate) => candidate.id === event.id);
+    if (!existing) {
+      await this.appendRuntimeEvent(sessionId, runId, event);
+      return;
+    }
+    if (JSON.stringify(existing) !== JSON.stringify(event)) {
+      throw new Error(`RuntimeEvent ${event.id} does not match the durable ledger record`);
+    }
+  }
+
   async readRuntimeEvents(sessionId: string, runId: string): Promise<RuntimeEvent[]> {
     if (this.options.failRuntimeEventReads) throw new Error('runtime event read failed');
     await this.options.beforeRuntimeEventRead?.(sessionId, runId);
@@ -7858,6 +7873,21 @@ class MemoryRuntimeEventStore implements RuntimeEventStore {
     if (this.options.failRuntimeEventAppends) throw new Error('runtime event append failed');
     const eventKey = key(sessionId, runId);
     this.runtimeEvents.set(eventKey, [...(this.runtimeEvents.get(eventKey) ?? []), copyRuntimeEvent(event)]);
+  }
+
+  async ensureTerminalRuntimeEventDurable(
+    sessionId: string,
+    runId: string,
+    event: RuntimeEvent,
+  ): Promise<void> {
+    const existing = (this.runtimeEvents.get(key(sessionId, runId)) ?? []).find((candidate) => candidate.id === event.id);
+    if (!existing) {
+      await this.appendRuntimeEvent(sessionId, runId, event);
+      return;
+    }
+    if (JSON.stringify(existing) !== JSON.stringify(event)) {
+      throw new Error(`RuntimeEvent ${event.id} does not match the durable ledger record`);
+    }
   }
 
   async readRuntimeEvents(sessionId: string, runId: string): Promise<RuntimeEvent[]> {

--- a/packages/runtime/src/__tests__/shell-run-tool-result.test.ts
+++ b/packages/runtime/src/__tests__/shell-run-tool-result.test.ts
@@ -1,6 +1,10 @@
 import assert from 'node:assert/strict';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { describe, test } from 'node:test';
 import type { PtyShellOutput, ShellRunRecord } from '@maka/core';
+import { createSessionStore } from '@maka/storage';
 
 import { projectPtyOutputForModel, terminalContent } from '../shell-run-tool-result.js';
 
@@ -33,16 +37,7 @@ describe('PTY model output projection', () => {
 
 describe('shell run sandbox denial projection', () => {
   test('offers escalation recovery only for a failed sandboxed process', () => {
-    const base: ShellRunRecord = {
-      shellRunId: 'shell-1', sessionId: 'session-1', sourceTurnId: 'turn-1',
-      sourceToolCallId: 'tool-1', cwd: '/workspace', command: 'write outside',
-      status: 'failed', startedAt: 1, updatedAt: 2, completedAt: 2, exitCode: 1,
-      revision: 2,
-      output: {
-        mode: 'pipes', stdout: '', stderr: 'Operation not permitted',
-        stdoutTruncated: false, stderrTruncated: false, redacted: false,
-      },
-    };
+    const base = failedShellRun();
 
     assert.equal(terminalContent(base).sandboxDenial, undefined);
     assert.deepEqual(terminalContent({
@@ -58,7 +53,66 @@ describe('shell run sandbox denial projection', () => {
       sandboxExecution: { type: 'none', enforced: false },
     }).sandboxDenial, undefined);
   });
+
+  test('round-trips the producer sandbox denial through strict FileSessionStore recovery', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'maka-shell-result-recovery-'));
+    try {
+      const store = createSessionStore(root);
+      const session = await store.create({
+        cwd: '/workspace',
+        backend: 'fake',
+        llmConnectionSlug: 'fake',
+        model: 'fake-model',
+        permissionMode: 'ask',
+      });
+      const content = terminalContent({
+        ...failedShellRun(),
+        sessionId: session.id,
+        sandboxExecution: { type: 'macos-seatbelt', enforced: true },
+      });
+      await store.appendMessage(session.id, {
+        type: 'tool_result',
+        id: 'tool-result-1',
+        turnId: 'turn-1',
+        ts: 2,
+        toolUseId: 'tool-1',
+        isError: true,
+        content,
+      });
+
+      const messages = await store.readMessagesForRecovery(session.id);
+      const result = messages.find((message) => message.id === 'tool-result-1');
+      assert.deepEqual(result?.type === 'tool_result' ? result.content : undefined, content);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
 });
+
+function failedShellRun(): ShellRunRecord {
+  return {
+    shellRunId: 'shell-1',
+    sessionId: 'session-1',
+    sourceTurnId: 'turn-1',
+    sourceToolCallId: 'tool-1',
+    cwd: '/workspace',
+    command: 'write outside',
+    status: 'failed',
+    startedAt: 1,
+    updatedAt: 2,
+    completedAt: 2,
+    exitCode: 1,
+    revision: 2,
+    output: {
+      mode: 'pipes',
+      stdout: '',
+      stderr: 'Operation not permitted',
+      stdoutTruncated: false,
+      stderrTruncated: false,
+      redacted: false,
+    },
+  };
+}
 
 function ptyOutput(overrides: Partial<PtyShellOutput>): PtyShellOutput {
   return {

--- a/packages/runtime/src/agent-run.ts
+++ b/packages/runtime/src/agent-run.ts
@@ -67,10 +67,15 @@ export type AgentRunLineage = Partial<Pick<
   'parentRunId' | 'parentTurnId' | 'retriedFromTurnId' | 'regeneratedFromTurnId' | 'branchOfTurnId' | 'parentSessionId'
 >>;
 
+export type AgentRunDurability = 'best_effort' | 'required';
+
 export interface AgentRunInput {
   sessionId: string;
   header: SessionHeader;
   userInput: UserMessageInput;
+  runId?: string;
+  userMessageId?: string;
+  durability?: AgentRunDurability;
   store: SessionStore;
   runStore?: AgentRunStore;
   runtimeEventStore?: RuntimeEventStore;
@@ -137,7 +142,10 @@ export class AgentRun {
     if (input.runStore && !input.runtimeEventStore) {
       throw new Error('RuntimeEventStore is required when AgentRunStore is configured');
     }
-    this.runId = input.newId();
+    if (input.durability === 'required' && (!input.runStore || !input.runtimeEventStore)) {
+      throw new Error('Required AgentRun durability needs AgentRunStore and RuntimeEventStore');
+    }
+    this.runId = input.runId ?? input.newId();
     this.sessionId = input.sessionId;
     this.turnId = input.userInput.turnId;
     this.header = input.header;
@@ -349,7 +357,7 @@ export class AgentRun {
 
     let initialRuntimeEventId: string;
     if (this.recordsSessionMessages()) {
-      const userMessageId = this.input.newId();
+      const userMessageId = this.input.userMessageId ?? this.input.newId();
       const userMessageTs = this.input.now();
       initialRuntimeEventId = userMessageId;
       const userMsg: UserMessage = {
@@ -373,7 +381,9 @@ export class AgentRun {
     }
 
     const initialRuntimeEvent = this.buildInitialRuntimeEvent(initialRuntimeEventId, this.lastTs);
-    await this.recordRuntimeEvents([initialRuntimeEvent]);
+    await this.recordRuntimeEvents([initialRuntimeEvent], {
+      requireDurableWrite: this.requiresDurablePersistence(),
+    });
 
     if (!this.header.connectionLocked) {
       this.header = await this.input.hooks.updateHeader(this.sessionId, { connectionLocked: true });
@@ -683,8 +693,13 @@ export class AgentRun {
       });
     } catch (error) {
       this.runStoreAvailable = false;
+      if (this.requiresDurablePersistence()) throw error;
       this.enqueueTraceWriteFailure(error);
     }
+  }
+
+  private requiresDurablePersistence(): boolean {
+    return this.input.durability === 'required';
   }
 
   private async buildPriorRuntimeContext(): Promise<PriorRuntimeContext | undefined> {
@@ -785,8 +800,7 @@ export class AgentRun {
 
   private async markRunStarted(ts: number): Promise<void> {
     if (!this.input.runStore || !this.runStoreAvailable) return;
-    this.enqueueRunStore('mark run started', async () => {
-      await this.input.runStore?.updateRun(this.sessionId, this.runId, { status: 'running', updatedAt: ts });
+    const write = this.enqueueRunStore('mark run started', async () => {
       await this.input.runStore?.appendEvent(this.sessionId, this.runId, {
         type: 'run_started',
         id: this.input.newId(),
@@ -795,7 +809,9 @@ export class AgentRun {
         turnId: this.turnId,
         ts,
       });
-    });
+      await this.input.runStore?.updateRun(this.sessionId, this.runId, { status: 'running', updatedAt: ts });
+    }, { rethrow: this.requiresDurablePersistence() });
+    if (this.requiresDurablePersistence()) await write;
   }
 
   private recordStatusFromTransition(

--- a/packages/runtime/src/agent-run.ts
+++ b/packages/runtime/src/agent-run.ts
@@ -1,5 +1,5 @@
 import type { AgentRunEvent, AgentRunHeader, AgentRunStore, RuntimeEvent, RuntimeEventStore } from '@maka/core';
-import { isTerminalRuntimeEvent } from '@maka/core';
+import { DurableStoreWriteError, isTerminalRuntimeEvent } from '@maka/core';
 import { redactSecrets } from '@maka/core/redaction';
 import type {
   SessionBlockedReason,
@@ -134,7 +134,6 @@ export class AgentRun {
     owner: 'event' | 'stop';
     event?: RuntimeEvent;
     write?: Promise<void>;
-    persisted?: boolean;
     stopCompleted?: boolean;
   } | undefined;
 
@@ -540,7 +539,12 @@ export class AgentRun {
         continue;
       }
       const write = this.enqueueRuntimeEventStore('append runtime event', async () => {
-        await this.input.runtimeEventStore?.appendRuntimeEvent(this.sessionId, this.runId, eventForStore);
+        await this.input.runtimeEventStore?.appendRuntimeEvent(
+          this.sessionId,
+          this.runId,
+          eventForStore,
+          { durable: terminal || options.requireDurableWrite === true },
+        );
       }, { rethrow: terminal || options.requireTerminalWrite || options.requireDurableWrite });
       if (terminal && this.terminalClaim) this.terminalClaim.write = write;
       if (options.requireDurableWrite && !terminal) {
@@ -554,6 +558,7 @@ export class AgentRun {
         try {
           await write;
         } catch (error) {
+          if (error instanceof DurableStoreWriteError) throw error;
           if (!(await this.eventLandedInLedger(eventForStore.id))) throw error;
           // The write landed and the ledger answered a fresh read — the
           // failure was in the reporting, not the store. Lift the
@@ -565,9 +570,6 @@ export class AgentRun {
         continue;
       }
       await write;
-      if (terminal) {
-        if (this.terminalClaim) this.terminalClaim.persisted = true;
-      }
     }
   }
 
@@ -678,19 +680,25 @@ export class AgentRun {
         : {}),
     };
     try {
-      await this.input.runStore.createRun(header);
-      await this.input.runStore.appendEvent(this.sessionId, this.runId, {
-        type: 'run_created',
-        id: this.input.newId(),
-        runId: this.runId,
-        sessionId: this.sessionId,
-        turnId: this.turnId,
-        ts: createdAt,
-        data: {
-          textLength: this.input.userInput.text.length,
-          attachmentCount: this.input.userInput.attachments?.length ?? 0,
+      const durable = this.requiresDurablePersistence();
+      await this.input.runStore.createRun(header, { durable });
+      await this.input.runStore.appendEvent(
+        this.sessionId,
+        this.runId,
+        {
+          type: 'run_created',
+          id: this.input.newId(),
+          runId: this.runId,
+          sessionId: this.sessionId,
+          turnId: this.turnId,
+          ts: createdAt,
+          data: {
+            textLength: this.input.userInput.text.length,
+            attachmentCount: this.input.userInput.attachments?.length ?? 0,
+          },
         },
-      });
+        { durable },
+      );
     } catch (error) {
       this.runStoreAvailable = false;
       if (this.requiresDurablePersistence()) throw error;
@@ -800,18 +808,28 @@ export class AgentRun {
 
   private async markRunStarted(ts: number): Promise<void> {
     if (!this.input.runStore || !this.runStoreAvailable) return;
-    const write = this.enqueueRunStore('mark run started', async () => {
-      await this.input.runStore?.appendEvent(this.sessionId, this.runId, {
-        type: 'run_started',
-        id: this.input.newId(),
-        runId: this.runId,
-        sessionId: this.sessionId,
-        turnId: this.turnId,
-        ts,
-      });
-      await this.input.runStore?.updateRun(this.sessionId, this.runId, { status: 'running', updatedAt: ts });
-    }, { rethrow: this.requiresDurablePersistence() });
-    if (this.requiresDurablePersistence()) await write;
+    const durable = this.requiresDurablePersistence();
+    const write = this.enqueueRunStore(
+      'mark run started',
+      async () => {
+        await this.input.runStore?.appendEvent(
+          this.sessionId,
+          this.runId,
+          {
+            type: 'run_started',
+            id: this.input.newId(),
+            runId: this.runId,
+            sessionId: this.sessionId,
+            turnId: this.turnId,
+            ts,
+          },
+          { durable },
+        );
+        await this.input.runStore?.updateRun(this.sessionId, this.runId, { status: 'running', updatedAt: ts }, { durable });
+      },
+      { rethrow: durable },
+    );
+    if (durable) await write;
   }
 
   private recordStatusFromTransition(
@@ -975,7 +993,6 @@ export class AgentRun {
         turnId: this.turnId,
         ts,
         terminalEvent,
-        terminalEventAlreadyPersisted: terminalClaim.persisted === true,
         ...(this.failureClass ?? finalStatus?.blockedReason
           ? { failureClass: this.failureClass ?? finalStatus?.blockedReason }
           : {}),
@@ -990,7 +1007,6 @@ export class AgentRun {
       });
       if (!terminalClaim.write) terminalClaim.write = commit.then(() => undefined);
       const result = await commit;
-      terminalClaim.persisted = true;
       this.terminalRunHeaderCommitted = result.headerCommitted;
       if (result.headerCommitError !== undefined) {
         await this.enqueueTraceWriteFailure(result.headerCommitError, 'commit terminal run header');

--- a/packages/runtime/src/fake-backend.ts
+++ b/packages/runtime/src/fake-backend.ts
@@ -150,6 +150,11 @@ export class FakeBackend implements AgentBackend {
     // subscription before this deterministic fake emits the request.
     await sleep(100);
     const turnId = input.turnId;
+    if (this.stopped) {
+      yield { type: 'abort', id: randomUUID(), turnId, ts: Date.now(), reason: 'user_stop' };
+      yield { type: 'complete', id: randomUUID(), turnId, ts: Date.now(), stopReason: 'user_stop' };
+      return;
+    }
     const toolUseId = randomUUID();
     const requestId = randomUUID();
     const stepId = randomUUID();

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -10,6 +10,9 @@ export type {
   CompactSessionInput,
   SessionManagerDeps,
   SessionStore,
+  StrictRecoveryAgentRunStore,
+  StrictRecoverySessionStore,
+  StrictRecoveryStores,
   BackendFactory,
   BackendFactoryContext,
   SpawnChildAgentInput,
@@ -18,6 +21,7 @@ export type {
   AgentListResult,
   AgentOutputInput,
   AgentOutputResult,
+  StopSessionInput,
 } from './session-manager.js';
 
 export { PermissionEngine, createDefaultPermissionEngineDeps } from './permission-engine.js';
@@ -842,6 +846,8 @@ export type {
   RuntimeEventTerminalFact,
   RuntimeEventTerminalFactResult,
 } from './runtime-event-read-model.js';
+export { classifyTerminalRuntimeLedger } from './terminal-run-commit.js';
+export type { TerminalRuntimeLedgerClassification } from './terminal-run-commit.js';
 export {
   RuntimeReadModel,
   RuntimeReadModelError,
@@ -855,10 +861,12 @@ export { RuntimeKernel } from './runtime-kernel.js';
 export type {
   RuntimeKernelDeps,
   RuntimeKernelLike,
+  TurnStartOptions,
 } from './runtime-kernel.js';
 export { AgentRun } from './agent-run.js';
 export type {
   AgentRunActiveSession,
+  AgentRunDurability,
   AgentRunLineage,
 } from './agent-run.js';
 

--- a/packages/runtime/src/pi-agent-backend.ts
+++ b/packages/runtime/src/pi-agent-backend.ts
@@ -11,7 +11,7 @@ import type {
   ToolResultMessage,
   TokenUsageMessage,
 } from '@maka/core';
-import { computerUseApprovalSummary } from '@maka/core';
+import { computerUseApprovalSummary, decodeCanonicalToolResultContent } from '@maka/core';
 import type { BackendSendInput, PermissionDecision } from '@maka/core/backend-types';
 import { redactSecrets } from '@maka/core/redaction';
 import { isToolCategory, type ToolCategory } from '@maka/core/permission';
@@ -561,7 +561,7 @@ export function normalizePiAgentFrame(frame: unknown): PiAgentFrame | null {
       type,
       toolUseId: value.toolUseId,
       toolName: value.toolName,
-      args: value.args,
+      args: value.args ?? null,
       ...(typeof value.displayName === 'string' ? { displayName: value.displayName } : {}),
       ...(typeof value.intent === 'string' ? { intent: value.intent } : {}),
     };
@@ -571,7 +571,12 @@ export function normalizePiAgentFrame(frame: unknown): PiAgentFrame | null {
     return { type, toolUseId: value.toolUseId, stream, chunk: value.chunk };
   }
   if (type === 'tool_result' && typeof value.toolUseId === 'string') {
-    return { type, toolUseId: value.toolUseId, isError: value.isError === true, content: value.content };
+    return {
+      type,
+      toolUseId: value.toolUseId,
+      isError: value.isError === true,
+      content: value.content ?? null,
+    };
   }
   if (type === 'token_usage') {
     const input = finiteNumber(value.input);
@@ -594,7 +599,7 @@ export function normalizePiAgentFrame(frame: unknown): PiAgentFrame | null {
       type,
       toolUseId: value.toolUseId,
       toolName: value.toolName,
-      args: value.args,
+      args: value.args ?? null,
       ...(isToolCategory(value.categoryHint) ? { categoryHint: value.categoryHint } : {}),
       ...(typeof value.hint === 'string' ? { hint: value.hint } : {}),
     };
@@ -626,11 +631,13 @@ function finiteNumber(value: unknown): number | undefined {
 }
 
 function normalizeToolResultContent(content: unknown): ToolResultContent {
-  if (content && typeof content === 'object' && 'kind' in content) {
-    return redactUnknown(content) as ToolResultContent;
-  }
   if (typeof content === 'string') return { kind: 'text', text: redactBoundedText(content) };
-  return { kind: 'json', value: redactUnknown(content) };
+  const redacted = redactUnknown(content ?? null);
+  try {
+    return decodeCanonicalToolResultContent(redacted);
+  } catch {
+    return { kind: 'json', value: redacted };
+  }
 }
 
 function redactBoundedText(text: string, maxChars = 8192): string {

--- a/packages/runtime/src/runtime-event-backfill.ts
+++ b/packages/runtime/src/runtime-event-backfill.ts
@@ -54,7 +54,7 @@ export function backfillRuntimeEventsFromStoredMessages(
 ): RuntimeEventBackfillResult {
   const newId = input.newId ?? (() => createRuntimeEventId('rt-backfill'));
   const now = input.now ?? (() => Date.now());
-  const invocationId = input.invocationId ?? `backfill-${input.run.runId}`;
+  const invocationId = input.run.invocationId ?? input.invocationId ?? `backfill-${input.run.runId}`;
   const diagnostics: RuntimeEventBackfillDiagnostic[] = [];
   const events: RuntimeEvent[] = [];
   const turnMessages = input.messages

--- a/packages/runtime/src/runtime-kernel.ts
+++ b/packages/runtime/src/runtime-kernel.ts
@@ -19,7 +19,13 @@ import { isDeepStrictEqual } from 'node:util';
 import type { ChildAgentTurnInput, UserMessageInput } from '@maka/core/runtime-inputs';
 import type { PermissionResponse } from '@maka/core/permission';
 import type { UserQuestionResponse } from '@maka/core/user-question';
-import { AgentRun, type AgentRunActiveSession, type AgentRunBeginResult, type AgentRunLineage } from './agent-run.js';
+import {
+  AgentRun,
+  type AgentRunActiveSession,
+  type AgentRunBeginResult,
+  type AgentRunDurability,
+  type AgentRunLineage,
+} from './agent-run.js';
 import { AiSdkFlow, mapSessionEventToRuntimeEvent } from './ai-sdk-flow.js';
 import type { AgentBackend, SteeringLease } from '@maka/core/backend-types';
 import type { AgentTeamExecutionContext, MakaTool } from './tool-runtime.js';
@@ -46,7 +52,7 @@ import {
 import { shouldAppendContextCompactionFailedOpenNote } from './context-budget.js';
 
 export interface RuntimeKernelLike {
-  startTurn(sessionId: string, input: UserMessageInput): AsyncIterable<SessionEvent>;
+  startTurn(sessionId: string, input: UserMessageInput, options?: TurnStartOptions): AsyncIterable<SessionEvent>;
   compactSession(sessionId: string, input?: CompactSessionInput): AsyncIterable<SessionEvent>;
   startChildTurn(sessionId: string, input: ChildAgentTurnInput): AsyncIterable<SessionEvent>;
   stopSession(sessionId: string, input?: StopSessionInput): Promise<void>;
@@ -63,6 +69,13 @@ export interface RuntimeKernelLike {
   hasActiveRuns(sessionId: string): boolean;
   updateCachedHeader(sessionId: string, header: SessionHeader): void;
   disposeBackend(sessionId: string): Promise<void>;
+}
+
+export interface TurnStartOptions {
+  runId?: string;
+  userMessageId?: string;
+  durability?: AgentRunDurability;
+  onRunStarted?: (runId: string) => void | Promise<void>;
 }
 
 /**
@@ -183,6 +196,7 @@ export class RuntimeKernel implements RuntimeKernelLike {
   async *startTurn(
     sessionId: string,
     input: UserMessageInput,
+    options: TurnStartOptions = {},
   ): AsyncIterable<SessionEvent> {
     this.pendingTurnStarts.set(sessionId, (this.pendingTurnStarts.get(sessionId) ?? 0) + 1);
     let pending = true;
@@ -192,6 +206,9 @@ export class RuntimeKernel implements RuntimeKernelLike {
         sessionId,
         header,
         userInput: input,
+        runId: options.runId,
+        userMessageId: options.userMessageId,
+        durability: options.durability,
         store: this.deps.store,
         runStore: this.deps.runStore,
         runtimeEventStore: this.deps.runtimeEventStore,
@@ -216,7 +233,7 @@ export class RuntimeKernel implements RuntimeKernelLike {
         },
       });
 
-      yield* this.runAgentTurn(sessionId, input, run, true);
+      yield* this.runAgentTurn(sessionId, input, run, true, options.onRunStarted);
     } finally {
       if (pending) this.finishPendingTurnStart(sessionId, false);
     }
@@ -400,6 +417,7 @@ export class RuntimeKernel implements RuntimeKernelLike {
     input: UserMessageInput,
     run: AgentRun,
     steering = false,
+    onRunStarted?: (runId: string) => void | Promise<void>,
   ): AsyncIterable<SessionEvent> {
     const sessionEvents = new AsyncEventQueue<SessionEvent>();
     const abortController = new AbortController();
@@ -407,6 +425,7 @@ export class RuntimeKernel implements RuntimeKernelLike {
     let begin: AgentRunBeginResult;
     try {
       begin = await run.begin();
+      await onRunStarted?.(run.runId);
     } catch (error) {
       await run.recordFailure(error);
       await run.finalize();

--- a/packages/runtime/src/runtime-ledger-repair.ts
+++ b/packages/runtime/src/runtime-ledger-repair.ts
@@ -67,14 +67,6 @@ export class RuntimeLedgerRepair {
         ? recovered
         : recovered.filter((event) => !isMatchingTerminalRuntimeEvent(run, event));
       const eventsToAppend = missingRecoveredRuntimeEvents(run, runtimeEvents, recoveredEventsToPersist);
-      if (recoveredTerminal && canTrustRecoveredTerminal) {
-        for (const event of eventsToAppend) {
-          await this.deps.runtimeEventStore.appendRuntimeEvent(sessionId, run.runId, event);
-        }
-        return await this.repairRunHeaderFromExistingTerminal(sessionId, run, messages, legacyTerminal, recoveredTerminal) ||
-          eventsToAppend.length > 0;
-      }
-
       for (const event of eventsToAppend) {
         await this.deps.runtimeEventStore.appendRuntimeEvent(sessionId, run.runId, event);
       }
@@ -111,6 +103,7 @@ export class RuntimeLedgerRepair {
     const existingEvents = await this.deps.runStore.readEvents(sessionId, run.runId).catch(() => []);
     await commitTerminalRunWithRuntimeFact({
       runStore: this.deps.runStore,
+      runtimeEventStore: this.deps.runtimeEventStore,
       newId: this.deps.newId,
       sessionId,
       runId: run.runId,
@@ -118,7 +111,6 @@ export class RuntimeLedgerRepair {
       status,
       ts,
       terminalEvent: terminal,
-      terminalEventAlreadyPersisted: true,
       ...(failureClass ? { failureClass } : {}),
       ...(abortSource ? { abortSource } : {}),
       runEventData: {
@@ -288,6 +280,7 @@ function isMatchingTerminalRuntimeEvent(run: AgentRunHeader, event: RuntimeEvent
     event.sessionId === run.sessionId &&
     event.runId === run.runId &&
     event.turnId === run.turnId &&
+    (run.invocationId === undefined || event.invocationId === run.invocationId) &&
     isTerminalRuntimeEvent(event);
 }
 

--- a/packages/runtime/src/session-manager.ts
+++ b/packages/runtime/src/session-manager.ts
@@ -1043,8 +1043,13 @@ export class SessionManager {
       if (sourceEvents.length === 0) continue;
 
       const runId = this.deps.newId();
-      const invocationIds = new Map<string, string>();
-      const clonedRun = cloneRunHeaderForBranchCreate(sourceRun, childSessionId, runId);
+      const invocationId = this.deps.newId();
+      const clonedRun = cloneRunHeaderForBranchCreate(
+        sourceRun,
+        childSessionId,
+        runId,
+        invocationId,
+      );
       await this.deps.runStore.createRun(clonedRun);
 
       const sourceTerminalLedger = classifyTerminalRuntimeLedger(sourceRun, sourceEvents);
@@ -1054,7 +1059,7 @@ export class SessionManager {
           sessionId: childSessionId,
           runId,
           eventId: this.deps.newId(),
-          invocationId: remapInvocationId(invocationIds, event.invocationId, this.deps.newId),
+          invocationId,
         });
         await this.deps.runtimeEventStore.appendRuntimeEvent(childSessionId, runId, clonedEvent);
         clonedEventBySourceId.set(event.id, clonedEvent);
@@ -1065,6 +1070,7 @@ export class SessionManager {
         if (!terminalEvent) continue;
         await commitTerminalRunWithRuntimeFact({
           runStore: this.deps.runStore,
+          runtimeEventStore: this.deps.runtimeEventStore,
           newId: this.deps.newId,
           sessionId: childSessionId,
           runId,
@@ -1072,7 +1078,6 @@ export class SessionManager {
           status: sourceTerminalLedger.fact.runStatus,
           ts: terminalEvent.ts,
           terminalEvent,
-          terminalEventAlreadyPersisted: true,
           ...(sourceTerminalLedger.fact.failureClass ? { failureClass: sourceTerminalLedger.fact.failureClass } : {}),
           ...(sourceRun.failureMessage ? { failureMessage: sourceRun.failureMessage } : {}),
           ...(sourceTerminalLedger.fact.abortSource ? { abortSource: sourceTerminalLedger.fact.abortSource } : {}),
@@ -1191,7 +1196,6 @@ export class SessionManager {
         status,
         ts,
         terminalEvent,
-        terminalEventAlreadyPersisted: existingTerminal !== undefined,
         ...(failureClass ? { failureClass } : {}),
         ...(abortSource ? { abortSource } : {}),
         runEventData: { recovered: true, ...decision.diagnostic },
@@ -1449,8 +1453,9 @@ function cloneRunHeaderForBranchCreate(
   sourceRun: AgentRunHeader,
   childSessionId: string,
   runId: string,
+  invocationId: string,
 ): AgentRunHeader {
-  const cloned = { ...sourceRun, sessionId: childSessionId, runId };
+  const cloned = { ...sourceRun, invocationId, sessionId: childSessionId, runId };
   if (isTerminalRunStatus(sourceRun.status)) {
     cloned.status = 'running';
     delete cloned.completedAt;
@@ -1459,18 +1464,6 @@ function cloneRunHeaderForBranchCreate(
     delete cloned.abortSource;
   }
   return cloned;
-}
-
-function remapInvocationId(
-  mapping: Map<string, string>,
-  sourceInvocationId: string,
-  newId: () => string,
-): string {
-  const existing = mapping.get(sourceInvocationId);
-  if (existing) return existing;
-  const next = newId();
-  mapping.set(sourceInvocationId, next);
-  return next;
 }
 
 function copyMessagesThroughTurnBoundary(messages: readonly StoredMessage[], turnId: string): StoredMessage[] {

--- a/packages/runtime/src/session-manager.ts
+++ b/packages/runtime/src/session-manager.ts
@@ -78,7 +78,7 @@ import type {
   InvocationResult,
   InvocationSource,
 } from './invocation-context.js';
-import { RuntimeKernel, type RuntimeKernelLike } from './runtime-kernel.js';
+import { RuntimeKernel, type RuntimeKernelLike, type TurnStartOptions } from './runtime-kernel.js';
 import type { HistoryCompactCleanupRequest } from './runtime-kernel.js';
 import {
   buildStatusPatch,
@@ -189,6 +189,21 @@ export interface SessionStore {
   setFlagged(sessionId: string, isFlagged: boolean): Promise<void>;
   rename(sessionId: string, name: string): Promise<void>;
   remove(sessionId: string): Promise<void>;
+}
+
+export interface StrictRecoverySessionStore extends SessionStore {
+  listForRecovery(): Promise<SessionHeader[]>;
+  readMessagesForRecovery(sessionId: string): Promise<StoredMessage[]>;
+}
+
+export interface StrictRecoveryAgentRunStore extends AgentRunStore {
+  listSessionRunsForRecovery(sessionId: string): Promise<AgentRunHeader[]>;
+  readEventsForRecovery(sessionId: string, runId: string): Promise<AgentRunEvent[]>;
+}
+
+export interface StrictRecoveryStores {
+  sessionStore: StrictRecoverySessionStore;
+  agentRunStore: StrictRecoveryAgentRunStore;
 }
 
 // ============================================================================
@@ -368,31 +383,55 @@ export class SessionManager {
   }
 
   async recoverInterruptedSessions(): Promise<string[]> {
-    const interrupted = (await this.deps.store.list())
+    return this.recoverInterruptedSessionsWithPolicy({ kind: 'best_effort' });
+  }
+
+  async recoverInterruptedSessionsStrict(stores: StrictRecoveryStores): Promise<string[]> {
+    if (stores.sessionStore !== this.deps.store || stores.agentRunStore !== this.deps.runStore) {
+      throw new Error('Strict recovery stores must match the SessionManager composition');
+    }
+    return this.recoverInterruptedSessionsWithPolicy({ kind: 'strict', stores });
+  }
+
+  private async recoverInterruptedSessionsWithPolicy(
+    policy: RecoveryPolicy,
+  ): Promise<string[]> {
+    const interrupted = (await listSessionsForRecovery(this.deps.store, policy))
       .filter((session) => session.status !== 'archived');
     const recovered = new Set<string>();
     for (const session of interrupted) {
       if (this.runtimeKernel.hasActiveRuns(session.id)) continue;
       if (this.deps.shellRuns) {
-        const recoveredShellRuns = await this.deps.shellRuns.recoverOrphanedSession(session.id).catch(() => 0);
+        const recoveredShellRuns = await recoverOr(
+          policy,
+          () => this.deps.shellRuns!.recoverOrphanedSession(session.id),
+          0,
+        );
         if (recoveredShellRuns > 0) recovered.add(session.id);
       }
       let messages: StoredMessage[] = [];
       let messagesReadable = true;
       try {
-        messages = await this.deps.store.readMessages(session.id);
-      } catch {
+        messages = policy.kind === 'strict'
+          ? await policy.stores.sessionStore.readMessagesForRecovery(session.id)
+          : await this.deps.store.readMessages(session.id);
+      } catch (error) {
+        if (policy.kind === 'strict') throw error;
         messagesReadable = false;
       }
 
       if (this.deps.runStore) {
-        const runRecovery = await this.recoverAgentRunsFromLedger(session.id).catch(() => undefined);
+        const runRecovery = await recoverOr(
+          policy,
+          () => this.recoverAgentRunsFromLedger(session.id, policy),
+          undefined,
+        );
         if (runRecovery?.hasLedger) {
           if (runRecovery.recovered) {
-            await this.updateStatus(session.id, 'active').catch(() => {});
+            await recoverOr(policy, () => this.updateStatus(session.id, 'active'), undefined);
             recovered.add(session.id);
           } else if (!messagesReadable && (session.status === 'running' || session.status === 'waiting_for_user')) {
-            await this.updateStatus(session.id, 'active').catch(() => {});
+            await recoverOr(policy, () => this.updateStatus(session.id, 'active'), undefined);
             recovered.add(session.id);
           }
           continue;
@@ -405,7 +444,7 @@ export class SessionManager {
           // run the user started while this session's recovery was in
           // flight, so we never stomp a live run's status.
           if (this.runtimeKernel.hasActiveRuns(session.id)) continue;
-          await this.updateStatus(session.id, 'active').catch(() => {});
+          await recoverOr(policy, () => this.updateStatus(session.id, 'active'), undefined);
           recovered.add(session.id);
         }
         continue;
@@ -414,9 +453,13 @@ export class SessionManager {
       const recoveries = interruptedTurnRecoveries(messages);
       if (recoveries.length === 0) continue;
       for (const recovery of recoveries) {
-        await this.appendTurnState(session.id, recovery.turnId, 'failed', recovery.lineage, {
-          errorClass: recovery.errorClass,
-        }).catch(() => {});
+        await recoverOr(
+          policy,
+          () => this.appendTurnState(session.id, recovery.turnId, 'failed', recovery.lineage, {
+            errorClass: recovery.errorClass,
+          }),
+          undefined,
+        );
       }
       if (session.status === 'running' || session.status === 'waiting_for_user') {
         // Same double-check as above: a message sent mid-recovery owns
@@ -425,7 +468,7 @@ export class SessionManager {
           recovered.add(session.id);
           continue;
         }
-        await this.updateStatus(session.id, 'active').catch(() => {});
+        await recoverOr(policy, () => this.updateStatus(session.id, 'active'), undefined);
       }
       recovered.add(session.id);
     }
@@ -558,8 +601,9 @@ export class SessionManager {
   async *sendMessage(
     sessionId: string,
     input: UserMessageInput,
+    options: TurnStartOptions = {},
   ): AsyncIterable<SessionEvent> {
-    yield* this.runtimeKernel.startTurn(sessionId, input);
+    yield* this.runtimeKernel.startTurn(sessionId, input, options);
   }
 
   async *compactSession(
@@ -1045,32 +1089,59 @@ export class SessionManager {
 
   private async recoverAgentRunsFromLedger(
     sessionId: string,
+    policy: RecoveryPolicy = { kind: 'best_effort' },
   ): Promise<{ hasLedger: boolean; recovered: boolean }> {
     if (!this.deps.runStore || !this.deps.runtimeEventStore) return { hasLedger: false, recovered: false };
-    const runs = await this.deps.runStore.listSessionRuns(sessionId);
+    const runs = policy.kind === 'strict'
+      ? await policy.stores.agentRunStore.listSessionRunsForRecovery(sessionId)
+      : await this.deps.runStore.listSessionRuns(sessionId);
     if (runs.length === 0) return { hasLedger: false, recovered: false };
 
     let recovered = false;
     for (const run of runs) {
+      if (policy.kind === 'strict') {
+        await policy.stores.agentRunStore.readEventsForRecovery(sessionId, run.runId);
+      }
       const inspected = await inspectAgentRunReadModel(
         this.deps.runStore,
         this.deps.runtimeEventStore,
         { sessionId, runId: run.runId, header: run },
       );
-      if (inspected.sourceHealth.runtimeLedger === 'read_failed') continue;
+      if (inspected.sourceHealth.runtimeLedger === 'read_failed') {
+        if (policy.kind === 'strict') {
+          throw new Error(`RuntimeEvent ledger is unreadable for run ${run.runId}`);
+        }
+        continue;
+      }
+      if (
+        policy.kind === 'strict'
+        && inspected.diagnostics.some((diagnostic) =>
+          diagnostic.code === 'operational_ledger_read_failed'
+          || diagnostic.code === 'operational_event_corrupt'
+        )
+      ) {
+        throw new Error(`AgentRun event ledger is unreadable for run ${run.runId}`);
+      }
       const terminalLedger = classifyTerminalRuntimeLedger(run, inspected.runtimeEvents);
-      if (terminalLedger.kind === 'ambiguous') continue;
+      if (terminalLedger.kind === 'ambiguous') {
+        if (policy.kind === 'strict') {
+          throw new Error(`RuntimeEvent ledger has ambiguous terminal facts for run ${run.runId}`);
+        }
+        continue;
+      }
       if (isTerminalRunStatus(run.status) && !inspected.terminalRuntimeFact) {
         const repaired = await this.repairMissingTerminalFactOnce(sessionId, run.runId);
         if (repaired) {
           recovered = true;
+        } else if (policy.kind === 'strict') {
+          throw new Error(`Unable to repair the terminal RuntimeEvent fact for run ${run.runId}`);
         }
         continue;
       }
       const runtimeDecision = this.classifyRuntimeEventRecovery(inspected);
       const decision = runtimeDecision ?? classifyAgentRunRecovery(run, inspected.events);
       if (!decision) continue;
-      if (await this.applyAgentRunRecovery(sessionId, decision, inspected)) {
+      if (await this.applyAgentRunRecovery(sessionId, decision, inspected, policy)) {
         recovered = true;
       }
     }
@@ -1088,6 +1159,7 @@ export class SessionManager {
     sessionId: string,
     decision: AgentRunRecoveryDecision,
     inspected: AgentRunInspectModel,
+    policy: RecoveryPolicy = { kind: 'best_effort' },
   ): Promise<boolean> {
     if (!this.deps.runStore || !this.deps.runtimeEventStore) return false;
     const ts = this.deps.now();
@@ -1125,15 +1197,26 @@ export class SessionManager {
         runEventData: { recovered: true, ...decision.diagnostic },
         existingEvents: inspected.events,
       });
-    } catch {
+    } catch (error) {
+      if (policy.kind === 'strict') throw error;
       return false;
     }
 
-    await this.appendTerminalTurnStateIfNeeded(sessionId, decision, terminalTurnStatus(status), {
-      ts,
-      ...(failureClass ? { errorClass: failureClass } : {}),
-      ...(abortSource ? { abortSource } : {}),
-    }).catch(() => {});
+    await recoverOr(
+      policy,
+      () => this.appendTerminalTurnStateIfNeeded(
+        sessionId,
+        decision,
+        terminalTurnStatus(status),
+        {
+          ts,
+          ...(failureClass ? { errorClass: failureClass } : {}),
+          ...(abortSource ? { abortSource } : {}),
+        },
+        policy,
+      ),
+      undefined,
+    );
     return true;
   }
 
@@ -1142,12 +1225,43 @@ export class SessionManager {
     decision: AgentRunRecoveryDecision,
     status: TurnRecord['status'],
     options: { ts: number; errorClass?: string; abortSource?: string },
+    policy: RecoveryPolicy = { kind: 'best_effort' },
   ): Promise<void> {
     if (decision.lineage.parentRunId) return;
-    const messages = await this.deps.store.readMessages(sessionId).catch(() => []);
+    const messages = await recoverOr(
+      policy,
+      () => this.deps.store.readMessages(sessionId),
+      [] as StoredMessage[],
+    );
     const latest = latestTurnState(messages, decision.turnId);
     if (latest && isTerminalTurnStatus(latest.status) && latest.status === status) return;
     await this.appendTurnState(sessionId, decision.turnId, status, decision.lineage, options);
+  }
+}
+
+type RecoveryPolicy =
+  | { kind: 'best_effort' }
+  | { kind: 'strict'; stores: StrictRecoveryStores };
+
+function listSessionsForRecovery(
+  store: SessionStore,
+  policy: RecoveryPolicy,
+): Promise<Array<SessionHeader | SessionSummary>> {
+  return policy.kind === 'strict'
+    ? policy.stores.sessionStore.listForRecovery()
+    : store.list();
+}
+
+async function recoverOr<T>(
+  policy: RecoveryPolicy,
+  operation: () => Promise<T>,
+  fallback: T,
+): Promise<T> {
+  try {
+    return await operation();
+  } catch (error) {
+    if (policy.kind === 'strict') throw error;
+    return fallback;
   }
 }
 

--- a/packages/runtime/src/terminal-run-commit.ts
+++ b/packages/runtime/src/terminal-run-commit.ts
@@ -49,15 +49,14 @@ export function classifyTerminalRuntimeLedger(
 
 export interface CommitTerminalRunWithRuntimeFactInput {
   runStore: AgentRunStore;
-  runtimeEventStore?: RuntimeEventStore;
+  runtimeEventStore: RuntimeEventStore;
   newId: () => string;
   sessionId: string;
   runId: string;
   turnId: string;
   status: TerminalAgentRunStatus;
   ts: number;
-  terminalEvent?: RuntimeEvent;
-  terminalEventAlreadyPersisted?: boolean;
+  terminalEvent: RuntimeEvent;
   failureClass?: string;
   failureMessage?: string;
   abortSource?: string;
@@ -69,9 +68,6 @@ export interface CommitTerminalRunWithRuntimeFactInput {
 export async function commitTerminalRunWithRuntimeFact(
   input: CommitTerminalRunWithRuntimeFactInput,
 ): Promise<void> {
-  if (!input.terminalEvent) {
-    throw new Error('terminal RuntimeEvent must be provided before terminal run header');
-  }
   if (isPartialRuntimeEvent(input.terminalEvent)) {
     throw new Error('terminal RuntimeEvent must be final before terminal run header');
   }
@@ -89,36 +85,51 @@ export async function commitTerminalRunWithRuntimeFact(
   ) {
     throw new Error('terminal RuntimeEvent identity does not match run header commit');
   }
-  if (!input.terminalEventAlreadyPersisted) {
-    if (!input.runtimeEventStore) {
-      throw new Error('terminal RuntimeEvent must be persisted before terminal run header');
-    }
-    await input.runtimeEventStore.appendRuntimeEvent(input.sessionId, input.runId, input.terminalEvent);
-  }
+  await input.runtimeEventStore.ensureTerminalRuntimeEventDurable(
+    input.sessionId,
+    input.runId,
+    input.terminalEvent,
+  );
 
+  await commitTerminalRunProjection(input);
+}
+
+async function commitTerminalRunProjection(
+  input: CommitTerminalRunWithRuntimeFactInput,
+): Promise<void> {
   const failureClass = input.status === 'failed' ? input.failureClass ?? 'unknown' : undefined;
   const abortSource = input.status === 'cancelled' ? input.abortSource : undefined;
-  await input.runStore.updateRun(input.sessionId, input.runId, {
-    status: input.status,
-    updatedAt: input.ts,
-    completedAt: input.ts,
-    ...(failureClass ? { failureClass } : {}),
-    ...(input.failureMessage ? { failureMessage: input.failureMessage } : {}),
-    ...(abortSource ? { abortSource } : {}),
-  });
+  await input.runStore.updateRun(
+    input.sessionId,
+    input.runId,
+    {
+      status: input.status,
+      updatedAt: input.ts,
+      completedAt: input.ts,
+      ...(failureClass ? { failureClass } : {}),
+      ...(input.failureMessage ? { failureMessage: input.failureMessage } : {}),
+      ...(abortSource ? { abortSource } : {}),
+    },
+    { durable: true },
+  );
 
   if (hasTerminalAgentRunEvent(input.existingEvents ?? [])) return;
   const data = terminalRunEventData(input.status, failureClass, input.runEventData);
-  await input.runStore.appendEvent(input.sessionId, input.runId, {
-    type: terminalAgentRunEventType(input.status),
-    id: input.newId(),
-    runId: input.runId,
-    sessionId: input.sessionId,
-    turnId: input.turnId,
-    ts: input.ts,
-    ...(input.runEventMessage ? { message: input.runEventMessage } : {}),
-    ...(Object.keys(data).length > 0 ? { data } : {}),
-  });
+  await input.runStore.appendEvent(
+    input.sessionId,
+    input.runId,
+    {
+      type: terminalAgentRunEventType(input.status),
+      id: input.newId(),
+      runId: input.runId,
+      sessionId: input.sessionId,
+      turnId: input.turnId,
+      ts: input.ts,
+      ...(input.runEventMessage ? { message: input.runEventMessage } : {}),
+      ...(Object.keys(data).length > 0 ? { data } : {}),
+    },
+    { durable: true },
+  );
 }
 
 export interface CommitOrCreateTerminalRunFactInput extends Omit<
@@ -182,24 +193,20 @@ export async function commitOrCreateTerminalRunFact(
   const failureClass = status === 'failed'
     ? runtimeEventFailureClass(terminalEvent) ?? input.failureClass ?? 'unknown'
     : undefined;
-  let terminalEventAlreadyPersisted = !createdTerminalEvent && input.terminalEventAlreadyPersisted;
-  if (!terminalEventAlreadyPersisted) {
-    if (!input.runtimeEventStore) {
-      throw new Error('terminal RuntimeEvent must be persisted before terminal run header');
-    }
-    await input.runtimeEventStore.appendRuntimeEvent(input.sessionId, input.runId, terminalEvent);
-    terminalEventAlreadyPersisted = true;
-  }
+  await input.runtimeEventStore.ensureTerminalRuntimeEventDurable(
+    input.sessionId,
+    input.runId,
+    terminalEvent,
+  );
   let headerCommitted = false;
   let headerCommitError: unknown;
   try {
-    await commitTerminalRunWithRuntimeFact({
+    await commitTerminalRunProjection({
       ...input,
       terminalEvent,
       status,
       ...(failureClass ? { failureClass } : {}),
       ...(effectiveAbortSource ? { abortSource: effectiveAbortSource } : {}),
-      terminalEventAlreadyPersisted,
     });
     headerCommitted = true;
   } catch (error) {
@@ -269,7 +276,7 @@ export function buildSyntheticTerminalRuntimeEvent(
 
 export interface BuildRecoveredTerminalRuntimeEventInput {
   id: string;
-  run: Pick<AgentRunHeader, 'runId' | 'sessionId' | 'turnId'>;
+  run: Pick<AgentRunHeader, 'runId' | 'sessionId' | 'turnId' | 'invocationId'>;
   status: TerminalAgentRunStatus;
   ts: number;
   invocationId?: string;
@@ -285,7 +292,8 @@ export function buildRecoveredTerminalRuntimeEvent(
 ): RuntimeEvent {
   return buildSyntheticTerminalRuntimeEvent({
     id: input.id,
-    invocationId: input.invocationId ?? `recovery-${input.run.runId}`,
+    invocationId:
+      input.run.invocationId ?? input.invocationId ?? `recovery-${input.run.runId}`,
     run: input.run,
     ts: input.ts,
     status: input.status,

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -7,6 +7,7 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": "./dist/index.js",
+    "./execution-stores": "./dist/execution-stores.js",
     "./root-authority": "./dist/root-authority.js"
   },
   "scripts": {

--- a/packages/storage/src/__tests__/agent-run-store.test.ts
+++ b/packages/storage/src/__tests__/agent-run-store.test.ts
@@ -1,5 +1,5 @@
 import { mkdir, mkdtemp, readFile, readdir, rm, writeFile } from 'node:fs/promises';
-import { join } from 'node:path';
+import { dirname, join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
@@ -74,6 +74,20 @@ describe('AgentRunStore', () => {
         /Invalid AgentRun header for run run-1: malformed fields/,
       );
       assert.equal(await readFile(runPath, 'utf8'), invalid);
+    });
+  });
+
+  it('rejects malformed optional run header fields', async () => {
+    await withStore(async (store, root) => {
+      const runPath = join(root, 'sessions', 'session-1', 'runs', 'run-1', 'run.json');
+      for (const patch of [{ automationId: 42 }, { abortSource: false }]) {
+        await mkdir(dirname(runPath), { recursive: true });
+        await writeFile(runPath, JSON.stringify({ ...makeHeader(), ...patch }) + '\n', 'utf8');
+        await assert.rejects(
+          () => store.readRun('session-1', 'run-1'),
+          /Invalid AgentRun header for run run-1: malformed fields/,
+        );
+      }
     });
   });
 
@@ -410,6 +424,26 @@ describe('AgentRunStore', () => {
     });
   });
 
+  it('does not mistake an invalid unterminated tail for a crash prefix', async () => {
+    await withStore(async (store, root) => {
+      await store.createRun(makeHeader());
+      const eventsPath = join(root, 'sessions', 'session-1', 'runs', 'run-1', 'events.jsonl');
+      const bytes = JSON.stringify(makeEvent({ id: 'good-1', ts: 1 })) + '\n{"type":]';
+      await writeFile(eventsPath, bytes, 'utf8');
+
+      const events = await store.readEvents('session-1', 'run-1');
+      assert.deepEqual(
+        events.map((event) => event.type),
+        ['run_started', 'event_corrupt'],
+      );
+      await assert.rejects(
+        () => store.readEventsForRecovery('session-1', 'run-1'),
+        /AgentRun run-1 has a corrupt JSONL record at line 2/,
+      );
+      assert.equal(await readFile(eventsPath, 'utf8'), bytes);
+    });
+  });
+
   it('keeps newline-terminated corrupt tail events as durable corruption notes', async () => {
     await withStore(async (store, root) => {
       await store.createRun(makeHeader());
@@ -423,9 +457,28 @@ describe('AgentRunStore', () => {
     });
   });
 
+  it('rejects complete schema-invalid and identity-mismatched events during recovery', async () => {
+    await withStore(async (store, root) => {
+      await store.createRun(makeHeader());
+      const eventsPath = join(root, 'sessions', 'session-1', 'runs', 'run-1', 'events.jsonl');
+      for (const record of [
+        {},
+        makeEvent({ sessionId: 'other-session' }),
+        makeEvent({ runId: 'other-run' }),
+        makeEvent({ turnId: 'other-turn' }),
+      ]) {
+        await writeFile(eventsPath, JSON.stringify(record));
+        await assert.rejects(
+          () => store.readEventsForRecovery('session-1', 'run-1'),
+          /AgentRun run-1 has a corrupt JSONL record at line 1/,
+        );
+      }
+    });
+  });
+
   it('appends and reads runtime events from a separate per-run ledger', async () => {
     await withStores(async (runStore, runtimeEventStore, root) => {
-      await runStore.createRun(makeHeader());
+      await runStore.createRun(makeHeader({ invocationId: 'turn-1' }));
       await runStore.appendEvent('session-1', 'run-1', makeEvent({ id: 'operational-event' }));
       await runtimeEventStore.appendRuntimeEvent('session-1', 'run-1', makeRuntimeEvent({ id: 'runtime-1', role: 'user' }));
       await runtimeEventStore.appendRuntimeEvent('session-1', 'run-1', makeRuntimeEvent({ id: 'runtime-2', role: 'model' }));
@@ -821,6 +874,82 @@ describe('AgentRunStore', () => {
     });
   });
 
+  it('re-establishes a terminal durability barrier without duplicating the event', async () => {
+    await withStores(async (runStore, runtimeEventStore) => {
+      await runStore.createRun(makeHeader({ invocationId: 'turn-1' }));
+      const terminal = makeRuntimeEvent({
+        id: 'runtime-terminal',
+        role: 'system',
+        author: 'system',
+        status: 'completed',
+        content: undefined,
+        actions: { endInvocation: true },
+      });
+      await runtimeEventStore.appendRuntimeEvent('session-1', 'run-1', terminal);
+
+      await runtimeEventStore.ensureTerminalRuntimeEventDurable(
+        'session-1',
+        'run-1',
+        terminal,
+      );
+      await runtimeEventStore.ensureTerminalRuntimeEventDurable(
+        'session-1',
+        'run-1',
+        terminal,
+      );
+
+      const events = await runtimeEventStore.readImmutableRuntimeEvents(
+        'session-1',
+        'run-1',
+      );
+      assert.deepEqual(events.map((event) => event.id), ['runtime-terminal']);
+      await assert.rejects(
+        () =>
+          runtimeEventStore.ensureTerminalRuntimeEventDurable(
+            'session-1',
+            'run-1',
+            { ...terminal, ts: terminal.ts + 1 },
+        ),
+        /does not match the durable ledger record/,
+      );
+      await assert.rejects(
+        () =>
+          runtimeEventStore.ensureTerminalRuntimeEventDurable(
+            'session-1',
+            'run-1',
+            { ...terminal, id: 'runtime-terminal-2' },
+          ),
+        /already has terminal RuntimeEvent runtime-terminal/,
+      );
+      assert.deepEqual(
+        (await runtimeEventStore.readImmutableRuntimeEvents('session-1', 'run-1')).map(
+          (event) => event.id,
+        ),
+        ['runtime-terminal'],
+      );
+    });
+  });
+
+  it('rejects complete schema-invalid and path-mismatched runtime events', async () => {
+    await withStores(async (runStore, runtimeEventStore, root) => {
+      await runStore.createRun(makeHeader({ invocationId: 'turn-1' }));
+      const runtimeEventsPath = join(root, 'sessions', 'session-1', 'runs', 'run-1', 'runtime-events.jsonl');
+      for (const record of [
+        {},
+        makeRuntimeEvent({ sessionId: 'other-session' }),
+        makeRuntimeEvent({ runId: 'other-run' }),
+        makeRuntimeEvent({ turnId: 'other-turn' }),
+        makeRuntimeEvent({ invocationId: 'other-invocation' }),
+      ]) {
+        await writeFile(runtimeEventsPath, JSON.stringify(record));
+        await assert.rejects(
+          () => runtimeEventStore.readRuntimeEvents('session-1', 'run-1'),
+          /Invalid RuntimeEvent JSONL line 1 for run run-1/,
+        );
+      }
+    });
+  });
+
   it('ignores an unterminated partial runtime event tail', async () => {
     await withStores(async (runStore, runtimeEventStore, root) => {
       await runStore.createRun(makeHeader());
@@ -833,6 +962,21 @@ describe('AgentRunStore', () => {
 
       const events = await runtimeEventStore.readRuntimeEvents('session-1', 'run-1');
       assert.deepEqual(events.map((event) => event.id), ['runtime-1']);
+    });
+  });
+
+  it('rejects an invalid unterminated runtime event tail without changing it', async () => {
+    await withStores(async (runStore, runtimeEventStore, root) => {
+      await runStore.createRun(makeHeader());
+      const runtimeEventsPath = join(root, 'sessions', 'session-1', 'runs', 'run-1', 'runtime-events.jsonl');
+      const bytes = JSON.stringify(makeRuntimeEvent({ id: 'runtime-1' })) + '\n{"id":]';
+      await writeFile(runtimeEventsPath, bytes, 'utf8');
+
+      await assert.rejects(
+        () => runtimeEventStore.readRuntimeEvents('session-1', 'run-1'),
+        /Invalid RuntimeEvent JSONL line 2 for run run-1/,
+      );
+      assert.equal(await readFile(runtimeEventsPath, 'utf8'), bytes);
     });
   });
 

--- a/packages/storage/src/__tests__/execution-stores.test.ts
+++ b/packages/storage/src/__tests__/execution-stores.test.ts
@@ -1,0 +1,546 @@
+import assert from "node:assert/strict";
+import {
+	appendFile,
+	mkdir,
+	mkdtemp,
+	readFile,
+	rename,
+	rm,
+	stat,
+	writeFile,
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, test } from "node:test";
+import type { AgentRunEvent, AgentRunHeader, RuntimeEvent } from "@maka/core";
+import { createAgentRunStore } from "../agent-run-store.js";
+import {
+	openInteractiveExecutionStoresForRead,
+	openInteractiveExecutionStoresForWrite,
+} from "../execution-stores.js";
+import {
+	resolveStorageRoot,
+	StorageRootAuthorityError,
+	tryAcquireInteractiveRootOwner,
+	tryAcquireInteractiveRootReader,
+} from "../root-authority.js";
+import { createSessionStore } from "../session-store.js";
+
+describe("interactive execution stores", () => {
+	test("commits root-turn admission before Run creation and retains its original identity", async () => {
+		await withRoot(async ({ root }) => {
+			const capability = await resolveStorageRoot({
+				path: root,
+				kind: "interactive",
+			});
+			const owner = await tryAcquireInteractiveRootOwner(capability);
+			assert.ok(owner);
+			if (!owner) return;
+			try {
+				const stores = await openInteractiveExecutionStoresForWrite(
+					owner.lease,
+				);
+				const session = await stores.sessionStore.create(sessionInput(root));
+				const first = await stores.agentRunStore.admitRootTurn({
+					sessionId: session.id,
+					turnId: "turn-1",
+					proposedRunId: "run-1",
+					proposedUserMessageId: "message-1",
+					normalizedInput: { text: "hello" },
+					admittedAt: 10,
+				});
+				assert.equal(first.kind, "admitted");
+				assert.deepEqual(
+					await stores.agentRunStore.listSessionRuns(session.id),
+					[],
+				);
+
+				const retry = await stores.agentRunStore.admitRootTurn({
+					sessionId: session.id,
+					turnId: "turn-1",
+					proposedRunId: "run-never-used",
+					proposedUserMessageId: "message-never-used",
+					normalizedInput: { text: "hello" },
+					admittedAt: 20,
+				});
+				assert.equal(retry.kind, "existing");
+				assert.equal(retry.admission.runId, "run-1");
+				assert.equal(retry.admission.userMessageId, "message-1");
+				assert.equal(retry.admission.admittedAt, 10);
+				assert.deepEqual(retry.admission.normalizedInput, { text: "hello" });
+
+				const conflict = await stores.agentRunStore.admitRootTurn({
+					sessionId: session.id,
+					turnId: "turn-1",
+					proposedRunId: "run-never-used",
+					proposedUserMessageId: "message-never-used",
+					normalizedInput: { text: "changed" },
+					admittedAt: 30,
+				});
+				assert.equal(conflict.kind, "conflict");
+				assert.equal(conflict.admission.runId, "run-1");
+
+				const header = runHeader(session.id, first.admission.runId);
+				await stores.agentRunStore.createRun(header);
+				const bytes = await readFile(
+					join(
+						root,
+						"sessions",
+						session.id,
+						"runs",
+						first.admission.runId,
+						"run.json",
+					),
+					"utf8",
+				);
+				await assert.rejects(
+					() => stores.agentRunStore.createRun({ ...header, updatedAt: 99 }),
+					/Agent run already exists/,
+				);
+				assert.equal(
+					await readFile(
+						join(
+							root,
+							"sessions",
+							session.id,
+							"runs",
+							first.admission.runId,
+							"run.json",
+						),
+						"utf8",
+					),
+					bytes,
+				);
+			} finally {
+				await owner.close();
+			}
+		});
+	});
+
+	test("keeps shared execution reads observational", async () => {
+		await withRoot(async ({ root }) => {
+			const capability = await resolveStorageRoot({
+				path: root,
+				kind: "interactive",
+			});
+			const rawSessionStore = createSessionStore(root);
+			const session = await rawSessionStore.create(sessionInput(root));
+			await rawSessionStore.appendMessage(session.id, {
+				type: "user",
+				id: "message-1",
+				turnId: "turn-1",
+				ts: 10,
+				text: "hello",
+			});
+			const rawAgentRunStore = createAgentRunStore(root);
+			await rawAgentRunStore.admitRootTurn({
+				sessionId: session.id,
+				turnId: "turn-1",
+				proposedRunId: "run-1",
+				proposedUserMessageId: "message-1",
+				normalizedInput: { text: "hello" },
+				admittedAt: 9,
+			});
+			await rawAgentRunStore.createRun(runHeader(session.id, "run-1"));
+			const sessionPath = join(root, "sessions", session.id, "session.jsonl");
+			const before = await readFile(sessionPath, "utf8");
+
+			const reader = await tryAcquireInteractiveRootReader(capability);
+			assert.ok(reader);
+			if (!reader) return;
+			try {
+				const stores = await openInteractiveExecutionStoresForRead(
+					reader.lease,
+				);
+				assert.equal((await stores.sessionStore.list()).length, 1);
+				assert.equal(
+					(await stores.sessionStore.readHeader(session.id)).connectionLocked,
+					false,
+				);
+				assert.equal(
+					(await stores.sessionStore.readMessages(session.id)).length,
+					1,
+				);
+				assert.equal(
+					(await stores.sessionStore.listTurns(session.id)).length,
+					1,
+				);
+				assert.equal(
+					(await stores.agentRunStore.listSessionRuns(session.id)).length,
+					1,
+				);
+				assert.equal(
+					(await stores.agentRunStore.readRun(session.id, "run-1")).turnId,
+					"turn-1",
+				);
+				assert.equal(
+					(await stores.agentRunStore.readEvents(session.id, "run-1")).length,
+					0,
+				);
+				assert.equal(
+					(
+						await stores.agentRunStore.readRootTurnAdmission(
+							session.id,
+							"turn-1",
+						)
+					)?.runId,
+					"run-1",
+				);
+				assert.equal(
+					(
+						await stores.runtimeEventStore.readRuntimeEvents(
+							session.id,
+							"run-1",
+						)
+					).length,
+					0,
+				);
+				assert.equal(
+					(
+						await stores.runtimeEventStore.readImmutableRuntimeEvents(
+							session.id,
+							"run-1",
+						)
+					).length,
+					0,
+				);
+				assert.equal(
+					(await stores.runtimeEventStore.readSessionRuntimeEvents(session.id))
+						.length,
+					0,
+				);
+			} finally {
+				await reader.close();
+			}
+
+			assert.equal(await readFile(sessionPath, "utf8"), before);
+			assert.equal(
+				(await rawSessionStore.readHeaderSnapshot(session.id)).connectionLocked,
+				false,
+			);
+		});
+	});
+
+	test("repairs only an unterminated JSONL tail before the next durable append", async () => {
+		await withRoot(async ({ root }) => {
+			const capability = await resolveStorageRoot({
+				path: root,
+				kind: "interactive",
+			});
+			const owner = await tryAcquireInteractiveRootOwner(capability);
+			assert.ok(owner);
+			if (!owner) return;
+			try {
+				const stores = await openInteractiveExecutionStoresForWrite(
+					owner.lease,
+				);
+				const session = await stores.sessionStore.create(sessionInput(root));
+				const header = runHeader(session.id, "run-1");
+				await stores.agentRunStore.createRun(header);
+
+				const sessionPath = join(root, "sessions", session.id, "session.jsonl");
+				await appendFile(sessionPath, '{"type":"user"', "utf8");
+				await stores.sessionStore.appendMessage(session.id, {
+					type: "user",
+					id: "message-1",
+					turnId: "turn-1",
+					ts: 11,
+					text: "hello",
+				});
+				assert.deepEqual(
+					(await stores.sessionStore.readMessages(session.id)).map(
+						(message) => message.id,
+					),
+					["message-1"],
+				);
+
+				const eventsPath = join(
+					root,
+					"sessions",
+					session.id,
+					"runs",
+					header.runId,
+					"events.jsonl",
+				);
+				await writeFile(
+					eventsPath,
+					JSON.stringify(runEvent(session.id, header.runId, "event-1", 12)),
+					"utf8",
+				);
+				await stores.agentRunStore.appendEvent(
+					session.id,
+					header.runId,
+					runEvent(session.id, header.runId, "event-2", 13),
+				);
+				await appendFile(eventsPath, '{"type":"run_started"', "utf8");
+				await stores.agentRunStore.appendEvent(
+					session.id,
+					header.runId,
+					runEvent(session.id, header.runId, "event-3", 14),
+				);
+				assert.deepEqual(
+					(await stores.agentRunStore.readEvents(session.id, header.runId)).map(
+						(event) => event.id,
+					),
+					["event-1", "event-2", "event-3"],
+				);
+
+				const runtimeEventsPath = join(
+					root,
+					"sessions",
+					session.id,
+					"runs",
+					header.runId,
+					"runtime-events.jsonl",
+				);
+				await writeFile(runtimeEventsPath, '{"id":"truncated"', "utf8");
+				await stores.runtimeEventStore.appendRuntimeEvent(
+					session.id,
+					header.runId,
+					runtimeEvent(session.id, header.runId, "runtime-1", 15),
+				);
+				assert.deepEqual(
+					(
+						await stores.runtimeEventStore.readImmutableRuntimeEvents(
+							session.id,
+							header.runId,
+						)
+					).map((event) => event.id),
+					["runtime-1"],
+				);
+
+				for (const path of [sessionPath, eventsPath, runtimeEventsPath]) {
+					const lines = (await readFile(path, "utf8"))
+						.split("\n")
+						.filter(Boolean);
+					for (const line of lines) assert.doesNotThrow(() => JSON.parse(line));
+				}
+			} finally {
+				await owner.close();
+			}
+		});
+	});
+
+	test("rejects stale writers before a replacement root is mutated", async () => {
+		await withRoot(async ({ base, root }) => {
+			const capability = await resolveStorageRoot({
+				path: root,
+				kind: "interactive",
+			});
+			const owner = await tryAcquireInteractiveRootOwner(capability);
+			assert.ok(owner);
+			if (!owner) return;
+			const stores = await openInteractiveExecutionStoresForWrite(owner.lease);
+			const moved = join(base, "moved-root");
+			await rename(root, moved);
+			await mkdir(root);
+			try {
+				await assert.rejects(
+					() => stores.sessionStore.create(sessionInput(root)),
+					(error: unknown) =>
+						error instanceof StorageRootAuthorityError &&
+						error.code === "root_identity_changed",
+				);
+				await assert.rejects(() => stat(join(root, "sessions")), {
+					code: "ENOENT",
+				});
+			} finally {
+				await owner.close();
+			}
+		});
+	});
+
+	test("strict recovery removes recognizable uncommitted exclusive-create staging", async () => {
+		await withRoot(async ({ root }) => {
+			const capability = await resolveStorageRoot({
+				path: root,
+				kind: "interactive",
+			});
+			const owner = await tryAcquireInteractiveRootOwner(capability);
+			assert.ok(owner);
+			if (!owner) return;
+			try {
+				const stores = await openInteractiveExecutionStoresForWrite(
+					owner.lease,
+				);
+				const session = await stores.sessionStore.create(sessionInput(root));
+				await stores.agentRunStore.admitRootTurn({
+					sessionId: session.id,
+					turnId: "turn-1",
+					proposedRunId: "run-1",
+					proposedUserMessageId: "message-1",
+					normalizedInput: { text: "hello" },
+					admittedAt: 10,
+				});
+
+				const suffix = "123.00000000-0000-4000-8000-000000000000.tmp";
+				const admissionsRoot = join(
+					root,
+					"sessions",
+					session.id,
+					"turn-admissions",
+				);
+				const admissionTemp = join(admissionsRoot, `turn-1.json.${suffix}`);
+				await writeFile(admissionTemp, "staging", "utf8");
+				const runDirectory = join(
+					root,
+					"sessions",
+					session.id,
+					"runs",
+					"run-staging",
+				);
+				await mkdir(runDirectory, { recursive: true });
+				await writeFile(
+					join(runDirectory, `run.json.${suffix}`),
+					"staging",
+					"utf8",
+				);
+
+				const admissions =
+					await stores.agentRunStore.listRootTurnAdmissionsForRecovery(
+						session.id,
+					);
+				assert.deepEqual(
+					admissions.map((admission) => admission.turnId),
+					["turn-1"],
+				);
+				assert.deepEqual(
+					await stores.agentRunStore.listSessionRunsForRecovery(session.id),
+					[],
+				);
+				await assert.rejects(() => stat(admissionTemp), { code: "ENOENT" });
+				await assert.rejects(() => stat(runDirectory), { code: "ENOENT" });
+			} finally {
+				await owner.close();
+			}
+		});
+	});
+
+	test("strict recovery enumeration fails on malformed durable entities", async () => {
+		await withRoot(async ({ root }) => {
+			const capability = await resolveStorageRoot({
+				path: root,
+				kind: "interactive",
+			});
+			const owner = await tryAcquireInteractiveRootOwner(capability);
+			assert.ok(owner);
+			if (!owner) return;
+			try {
+				const stores = await openInteractiveExecutionStoresForWrite(
+					owner.lease,
+				);
+				const session = await stores.sessionStore.create(sessionInput(root));
+				await stores.agentRunStore.admitRootTurn({
+					sessionId: session.id,
+					turnId: "turn-1",
+					proposedRunId: "run-1",
+					proposedUserMessageId: "message-1",
+					normalizedInput: { text: "hello" },
+					admittedAt: 10,
+				});
+				await writeFile(
+					join(root, "sessions", session.id, "turn-admissions", "turn-1.json"),
+					'{"turnId":"wrong"}\n',
+					"utf8",
+				);
+				await assert.rejects(() =>
+					stores.agentRunStore.listRootTurnAdmissionsForRecovery(session.id),
+				);
+
+				await stores.agentRunStore.createRun(runHeader(session.id, "run-1"));
+				await writeFile(
+					join(root, "sessions", session.id, "runs", "run-1", "run.json"),
+					'{"runId":"wrong"}\n',
+					"utf8",
+				);
+				await assert.rejects(() =>
+					stores.agentRunStore.listSessionRunsForRecovery(session.id),
+				);
+
+				await writeFile(
+					join(root, "sessions", session.id, "session.jsonl"),
+					'{"id":"wrong"}\n',
+					"utf8",
+				);
+				await assert.rejects(() => stores.sessionStore.listForRecovery());
+			} finally {
+				await owner.close();
+			}
+		});
+	});
+});
+
+async function withRoot(
+	run: (paths: { base: string; root: string }) => Promise<void>,
+): Promise<void> {
+	const base = await mkdtemp(join(tmpdir(), "maka-execution-stores-"));
+	const root = join(base, "root");
+	try {
+		await run({ base, root });
+	} finally {
+		await rm(base, { recursive: true, force: true });
+	}
+}
+
+function sessionInput(root: string) {
+	return {
+		cwd: root,
+		backend: "fake" as const,
+		llmConnectionSlug: "fake",
+		model: "fake-model",
+		permissionMode: "ask" as const,
+	};
+}
+
+function runHeader(sessionId: string, runId: string): AgentRunHeader {
+	return {
+		runId,
+		invocationId: runId,
+		sessionId,
+		turnId: "turn-1",
+		status: "created",
+		backendKind: "fake",
+		llmConnectionSlug: "fake",
+		modelId: "fake-model",
+		cwd: "/tmp/cwd",
+		permissionMode: "ask",
+		createdAt: 10,
+		updatedAt: 10,
+	};
+}
+
+function runEvent(
+	sessionId: string,
+	runId: string,
+	id: string,
+	ts: number,
+): AgentRunEvent {
+	return {
+		type: "run_started",
+		id,
+		runId,
+		sessionId,
+		turnId: "turn-1",
+		ts,
+	};
+}
+
+function runtimeEvent(
+	sessionId: string,
+	runId: string,
+	id: string,
+	ts: number,
+): RuntimeEvent {
+	return {
+		id,
+		invocationId: runId,
+		runId,
+		sessionId,
+		turnId: "turn-1",
+		ts,
+		partial: false,
+		role: "user",
+		author: "user",
+		content: { kind: "text", text: "hello" },
+	};
+}

--- a/packages/storage/src/__tests__/execution-stores.test.ts
+++ b/packages/storage/src/__tests__/execution-stores.test.ts
@@ -321,6 +321,42 @@ describe("interactive execution stores", () => {
 		});
 	});
 
+	test("refuses to truncate a syntactically invalid JSONL tail", async () => {
+		await withRoot(async ({ root }) => {
+			const capability = await resolveStorageRoot({
+				path: root,
+				kind: "interactive",
+			});
+			const owner = await tryAcquireInteractiveRootOwner(capability);
+			assert.ok(owner);
+			if (!owner) return;
+			try {
+				const stores = await openInteractiveExecutionStoresForWrite(
+					owner.lease,
+				);
+				const session = await stores.sessionStore.create(sessionInput(root));
+				const sessionPath = join(root, "sessions", session.id, "session.jsonl");
+				await appendFile(sessionPath, '{"type":]', "utf8");
+				const before = await readFile(sessionPath, "utf8");
+
+				await assert.rejects(
+					() =>
+						stores.sessionStore.appendMessage(session.id, {
+							type: "user",
+							id: "message-1",
+							turnId: "turn-1",
+							ts: 1,
+							text: "must not overwrite corruption",
+						}),
+					/Cannot append after an invalid JSONL tail record/,
+				);
+				assert.equal(await readFile(sessionPath, "utf8"), before);
+			} finally {
+				await owner.close();
+			}
+		});
+	});
+
 	test("rejects stale writers before a replacement root is mutated", async () => {
 		await withRoot(async ({ base, root }) => {
 			const capability = await resolveStorageRoot({

--- a/packages/storage/src/__tests__/root-authority.test.ts
+++ b/packages/storage/src/__tests__/root-authority.test.ts
@@ -12,6 +12,7 @@ import {
   resolveExistingStorageRoot,
   resolveRootControlNamespace,
   resolveStorageRoot,
+  runWithStorageRootLease,
   STORAGE_ROOT_MARKER_FILE,
   StorageRootAuthorityError,
   tryAcquireInteractiveRootOwner,
@@ -269,6 +270,48 @@ describe('storage root authority', () => {
         () => assertStorageRootLease(forgedLease, 'interactive', 'write'),
         (error: unknown) => error instanceof StorageRootAuthorityError && error.code === 'invalid_lease',
       );
+    });
+  });
+
+  test('keeps the owner lock until an admitted lease operation drains', async () => {
+    await withRoots(async ({ root }) => {
+      const capability = await resolveStorageRoot({ path: root, kind: 'interactive' });
+      const owner = await tryAcquireInteractiveRootOwner(capability);
+      assert.ok(owner);
+      if (!owner) return;
+
+      let releaseOperation!: () => void;
+      const operationBlocked = new Promise<void>((resolve) => {
+        releaseOperation = resolve;
+      });
+      let operationAdmitted!: () => void;
+      const admitted = new Promise<void>((resolve) => {
+        operationAdmitted = resolve;
+      });
+      const operation = runWithStorageRootLease(
+        owner.lease,
+        'interactive',
+        'write',
+        async () => {
+          operationAdmitted();
+          await operationBlocked;
+        },
+      );
+      await admitted;
+
+      const closing = owner.close();
+      assert.equal(owner.closed, true);
+      assert.equal(await tryAcquireInteractiveRootOwner(capability), undefined);
+      await assert.rejects(
+        () => runWithStorageRootLease(owner.lease, 'interactive', 'write', async () => {}),
+        (error: unknown) => error instanceof StorageRootAuthorityError && error.code === 'invalid_lease',
+      );
+
+      releaseOperation();
+      await Promise.all([operation, closing]);
+      const successor = await tryAcquireInteractiveRootOwner(capability);
+      assert.ok(successor);
+      await successor?.close();
     });
   });
 

--- a/packages/storage/src/__tests__/session-store.test.ts
+++ b/packages/storage/src/__tests__/session-store.test.ts
@@ -470,6 +470,10 @@ describe('FileSessionStore CRUD', () => {
         messages.some((message) => message.type === 'system_note' && message.id.startsWith('jsonl-corrupt-')),
         true,
       );
+      await assert.rejects(
+        () => store.readMessagesForRecovery(header.id),
+        /Session .* has a corrupt JSONL record at line 2/,
+      );
     });
   });
 
@@ -533,6 +537,45 @@ describe('FileSessionStore CRUD', () => {
     });
   });
 
+  test('reports an invalid unterminated tail instead of treating it as a crash prefix', async () => {
+    await withStore(async (store, workspaceRoot) => {
+      const sessionId = 'invalid-unterminated-tail';
+      const sessionDir = join(workspaceRoot, 'sessions', sessionId);
+      await mkdir(sessionDir, { recursive: true });
+      const path = join(sessionDir, 'session.jsonl');
+      const bytes = [
+        JSON.stringify(
+          makeRawHeader({
+            id: sessionId,
+            workspaceRoot,
+            name: 'Invalid tail',
+            connectionLocked: true,
+          }),
+        ),
+        JSON.stringify({
+          type: 'user',
+          id: 'u1',
+          turnId: 't1',
+          ts: 2,
+          text: 'survives',
+        }),
+        '{"type":]',
+      ].join('\n');
+      await writeFile(path, bytes, 'utf8');
+
+      const messages = await store.readMessages(sessionId);
+      assert.deepEqual(
+        messages.map((message) => message.type),
+        ['user', 'system_note'],
+      );
+      await assert.rejects(
+        () => store.readMessagesForRecovery(sessionId),
+        /Session invalid-unterminated-tail has a corrupt JSONL record at line 3/,
+      );
+      assert.equal(await readFile(path, 'utf8'), bytes);
+    });
+  });
+
   test('reports a corrupt tail JSONL message line when it was newline-terminated', async () => {
     await withStore(async (store, workspaceRoot) => {
       const sessionId = 'corrupt-terminated-tail-line';
@@ -558,6 +601,134 @@ describe('FileSessionStore CRUD', () => {
       assert.equal(note.kind, 'error');
       assert.equal((note.data as { code?: unknown }).code, 'jsonl_parse_error');
       assert.equal((note.data as { lineNumber?: unknown }).lineNumber, 3);
+    });
+  });
+
+  test('rejects a complete schema-invalid message during strict recovery', async () => {
+    await withStore(async (store, workspaceRoot) => {
+      const sessionId = 'schema-invalid-message';
+      const sessionDir = join(workspaceRoot, 'sessions', sessionId);
+      await mkdir(sessionDir, { recursive: true });
+      await writeFile(
+        join(sessionDir, 'session.jsonl'),
+        [
+          JSON.stringify(
+            makeRawHeader({
+              id: sessionId,
+              workspaceRoot,
+              name: 'Invalid message',
+            }),
+          ),
+          JSON.stringify({}),
+        ].join('\n'),
+        'utf8',
+      );
+
+      await assert.rejects(
+        () => store.readMessagesForRecovery(sessionId),
+        /Session schema-invalid-message has a corrupt JSONL record at line 2/,
+      );
+    });
+  });
+
+  test('recovers a canonical token usage message with nested diagnostics', async () => {
+    await withStore(async (store) => {
+      const session = await store.create(
+        makeInput({ name: 'Token usage recovery' }),
+      );
+      await store.appendMessage(session.id, {
+        type: 'token_usage',
+        id: 'usage-1',
+        turnId: 'turn-1',
+        ts: 10,
+        input: 100,
+        output: 20,
+        cacheHitInput: 80,
+        prefixChangeReason: 'stable',
+        promptSegments: [
+          { kind: 'prior_history', chars: 400, estimatedTokens: 100 },
+        ],
+        contextBudget: {
+          enabled: true,
+          policyName: 'bounded-history',
+          estimatedTokensBefore: 120,
+          estimatedTokensAfter: 100,
+          keptTurns: 4,
+          droppedTurns: 1,
+          keptEvents: 8,
+          droppedEvents: 2,
+          semanticCompactMode: 'validate_only',
+          compactionDecisions: [
+            {
+              stage: 'priorReplay',
+              sourceKind: 'runtimeEvents',
+              decision: 'unchanged',
+              coveredTurns: 4,
+            },
+          ],
+        },
+      });
+
+      const messages = await store.readMessagesForRecovery(session.id);
+      assert.equal(messages[0]?.type, 'token_usage');
+      assert.equal(
+        messages[0]?.type === 'token_usage' &&
+          messages[0].contextBudget?.policyName,
+        'bounded-history',
+      );
+    });
+  });
+
+  test('rejects malformed nested message payloads during strict recovery', async () => {
+    await withStore(async (store, workspaceRoot) => {
+      const malformed = [
+        {
+          type: 'token_usage',
+          id: 'usage-1',
+          turnId: 'turn-1',
+          ts: 1,
+          input: 1,
+          output: 1,
+          contextBudget: {
+            enabled: true,
+            policyName: 42,
+            estimatedTokensBefore: 1,
+            estimatedTokensAfter: 1,
+            keptTurns: 1,
+            droppedTurns: 0,
+            keptEvents: 1,
+            droppedEvents: 0,
+          },
+        },
+        exploreToolResult({ candidateFiles: [null], matches: [] }),
+        exploreToolResult({ candidateFiles: [], matches: [42] }),
+      ];
+
+      for (const [index, message] of malformed.entries()) {
+        const sessionId = `malformed-nested-${index}`;
+        const sessionDir = join(workspaceRoot, 'sessions', sessionId);
+        await mkdir(sessionDir, { recursive: true });
+        await writeFile(
+          join(sessionDir, 'session.jsonl'),
+          [
+            JSON.stringify(
+              makeRawHeader({
+                id: sessionId,
+                workspaceRoot,
+                name: 'Malformed nested',
+              }),
+            ),
+            JSON.stringify(message),
+          ].join('\n'),
+          'utf8',
+        );
+        await assert.rejects(
+          () => store.readMessagesForRecovery(sessionId),
+          new RegExp(
+            `Session malformed-nested-${index} has a corrupt JSONL record at line 2`,
+          ),
+        );
+      }
     });
   });
 
@@ -952,6 +1123,35 @@ function makeRawHeader(overrides: Partial<SessionHeader> = {}): SessionHeader {
     permissionMode: 'ask',
     schemaVersion: 1,
     ...overrides,
+  };
+}
+
+function exploreToolResult(overrides: {
+  candidateFiles: unknown[];
+  matches: unknown[];
+}): unknown {
+  return {
+    type: 'tool_result',
+    id: 'tool-result-1',
+    turnId: 'turn-1',
+    ts: 1,
+    toolUseId: 'tool-1',
+    isError: false,
+    content: {
+      kind: 'explore_agent',
+      ok: true,
+      mode: 'read_only',
+      objective: 'inspect',
+      roots: ['/tmp'],
+      queries: ['needle'],
+      filesInspected: 1,
+      filesSkipped: 0,
+      bytesRead: 10,
+      progress: [],
+      candidateFiles: overrides.candidateFiles,
+      matches: overrides.matches,
+      notes: [],
+    },
   };
 }
 

--- a/packages/storage/src/agent-run-store.ts
+++ b/packages/storage/src/agent-run-store.ts
@@ -1,6 +1,7 @@
 import { createHash, randomUUID } from 'node:crypto';
-import { appendFile, mkdir, readFile, readdir, rename, rm, writeFile } from 'node:fs/promises';
+import { appendFile, link, mkdir, open, readFile, readdir, rename, rm, unlink, writeFile } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
+import { appendJsonl } from './jsonl-append.js';
 import { chainWrite } from './write-queue.js';
 import {
   AGENT_RUN_STATUSES,
@@ -14,6 +15,62 @@ import {
 } from '@maka/core';
 
 const SAFE_ID_PATTERN = /^[A-Za-z0-9_-]{1,128}$/;
+const EXCLUSIVE_TEMP_SUFFIX_PATTERN = /^\d+\.[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\.tmp$/;
+
+export const ROOT_TURN_ADMISSION_SCHEMA_VERSION = 1 as const;
+
+export interface RootTurnAdmissionInput {
+  text: string;
+}
+
+export interface RootTurnAdmission {
+  schemaVersion: typeof ROOT_TURN_ADMISSION_SCHEMA_VERSION;
+  sessionId: string;
+  turnId: string;
+  runId: string;
+  userMessageId: string;
+  normalizedInput: RootTurnAdmissionInput;
+  admittedAt: number;
+}
+
+export interface AdmitRootTurnInput {
+  sessionId: string;
+  turnId: string;
+  proposedRunId: string;
+  proposedUserMessageId: string;
+  normalizedInput: RootTurnAdmissionInput;
+  admittedAt: number;
+}
+
+export type AdmitRootTurnResult =
+  | { kind: 'admitted'; admission: RootTurnAdmission }
+  | { kind: 'existing'; admission: RootTurnAdmission }
+  | { kind: 'conflict'; admission: RootTurnAdmission };
+
+export interface RootTurnAdmissionStore {
+  admitRootTurn(input: AdmitRootTurnInput): Promise<AdmitRootTurnResult>;
+  readRootTurnAdmission(sessionId: string, turnId: string): Promise<RootTurnAdmission | undefined>;
+  listRootTurnAdmissionsForRecovery(sessionId: string): Promise<RootTurnAdmission[]>;
+}
+
+export interface DurableAgentRunStore extends AgentRunStore, RootTurnAdmissionStore {
+  listSessionRunsForRecovery(sessionId: string): Promise<AgentRunHeader[]>;
+  readEventsForRecovery(sessionId: string, runId: string): Promise<AgentRunEvent[]>;
+  readEventProjection(
+    sessionId: string,
+    type: AgentRunEventType,
+  ): Promise<AgentRunEvent | null | undefined>;
+  repairEventProjection(
+    sessionId: string,
+    type: AgentRunEventType,
+    event: AgentRunEvent | null,
+    options?: { replaceEventId?: string },
+  ): Promise<void>;
+}
+
+export interface DurableRuntimeEventStore extends RuntimeEventStore {
+  readImmutableRuntimeEvents(sessionId: string, runId: string): Promise<RuntimeEvent[]>;
+}
 
 interface RuntimePartialSnapshot {
   version: 1;
@@ -21,15 +78,15 @@ interface RuntimePartialSnapshot {
   afterEventId?: string;
 }
 
-export function createAgentRunStore(workspaceRoot: string): AgentRunStore {
+export function createAgentRunStore(workspaceRoot: string): DurableAgentRunStore {
   return new FileAgentRunStore(workspaceRoot);
 }
 
-export function createRuntimeEventStore(workspaceRoot: string): RuntimeEventStore {
+export function createRuntimeEventStore(workspaceRoot: string): DurableRuntimeEventStore {
   return new FileRuntimeEventStore(workspaceRoot);
 }
 
-class FileAgentRunStore implements AgentRunStore {
+class FileAgentRunStore implements DurableAgentRunStore {
   private readonly sessionsRoot: string;
   private readonly writeQueues = new Map<string, Promise<void>>();
   private readonly projectionWriteQueues = new Map<string, Promise<void>>();
@@ -42,8 +99,11 @@ class FileAgentRunStore implements AgentRunStore {
     assertSafeId(header.sessionId, 'Invalid session id');
     assertSafeId(header.runId, 'Invalid run id');
     await this.withQueue(header.sessionId, header.runId, async () => {
-      await mkdir(this.runDir(header.sessionId, header.runId), { recursive: true });
-      await writeAtomic(this.runPath(header.sessionId, header.runId), JSON.stringify(header, sanitizeJson) + '\n');
+      const created = await writeExclusiveAtomic(
+        this.runPath(header.sessionId, header.runId),
+        JSON.stringify(header, sanitizeJson) + '\n',
+      );
+      if (!created) throw new Error(`Agent run already exists: ${header.runId}`);
     });
     await this.withProjectionQueue(header.sessionId, 'history_compact_checkpoint_recorded', async () => {
       await this.initializeEventProjectionUnlocked(
@@ -55,6 +115,82 @@ class FileAgentRunStore implements AgentRunStore {
       // Projection initialization is derived state; recovery can rebuild it from the run ledger.
     });
     return header;
+  }
+
+  async admitRootTurn(input: AdmitRootTurnInput): Promise<AdmitRootTurnResult> {
+    assertSafeId(input.sessionId, 'Invalid session id');
+    assertSafeId(input.turnId, 'Invalid turn id');
+    assertSafeId(input.proposedRunId, 'Invalid run id');
+    assertSafeId(input.proposedUserMessageId, 'Invalid user message id');
+    const normalizedInput = normalizeRootTurnAdmissionInput(input.normalizedInput);
+    if (!Number.isSafeInteger(input.admittedAt) || input.admittedAt < 0) {
+      throw new Error('Invalid root turn admission timestamp');
+    }
+    const admission: RootTurnAdmission = {
+      schemaVersion: ROOT_TURN_ADMISSION_SCHEMA_VERSION,
+      sessionId: input.sessionId,
+      turnId: input.turnId,
+      runId: input.proposedRunId,
+      userMessageId: input.proposedUserMessageId,
+      normalizedInput,
+      admittedAt: input.admittedAt,
+    };
+    const path = this.rootTurnAdmissionPath(input.sessionId, input.turnId);
+    const created = await writeExclusiveAtomic(path, JSON.stringify(admission) + '\n');
+    if (created) return { kind: 'admitted', admission };
+    const existing = await this.readRootTurnAdmission(input.sessionId, input.turnId);
+    if (!existing) throw new Error(`Root turn admission disappeared: ${input.turnId}`);
+    return existing.normalizedInput.text === normalizedInput.text
+      ? { kind: 'existing', admission: existing }
+      : { kind: 'conflict', admission: existing };
+  }
+
+  async readRootTurnAdmission(
+    sessionId: string,
+    turnId: string,
+  ): Promise<RootTurnAdmission | undefined> {
+    assertSafeId(sessionId, 'Invalid session id');
+    assertSafeId(turnId, 'Invalid turn id');
+    let raw: string;
+    try {
+      raw = await readFile(this.rootTurnAdmissionPath(sessionId, turnId), 'utf8');
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') return undefined;
+      throw error;
+    }
+    return normalizeRootTurnAdmission(JSON.parse(raw), sessionId, turnId);
+  }
+
+  async listRootTurnAdmissionsForRecovery(sessionId: string): Promise<RootTurnAdmission[]> {
+    assertSafeId(sessionId, 'Invalid session id');
+    const admissionsRoot = this.rootTurnAdmissionsRoot(sessionId);
+    let entries;
+    try {
+      entries = await readdir(admissionsRoot, { withFileTypes: true });
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') return [];
+      throw error;
+    }
+    const admissions: RootTurnAdmission[] = [];
+    let removedStagingFile = false;
+    for (const entry of entries) {
+      if (!entry.isFile()) {
+        throw new Error(`Invalid root turn admission entry: ${entry.name}`);
+      }
+      const turnId = turnIdFromAdmissionFile(entry.name);
+      if (turnId) {
+        admissions.push(await this.readRootTurnAdmission(sessionId, turnId) as RootTurnAdmission);
+        continue;
+      }
+      if (isRootTurnAdmissionTemp(entry.name)) {
+        await rm(join(admissionsRoot, entry.name), { force: true });
+        removedStagingFile = true;
+        continue;
+      }
+      throw new Error(`Invalid root turn admission entry: ${entry.name}`);
+    }
+    if (removedStagingFile) await syncDirectory(admissionsRoot);
+    return admissions.sort((a, b) => a.admittedAt - b.admittedAt || a.turnId.localeCompare(b.turnId));
   }
 
   async updateRun(sessionId: string, runId: string, patch: Partial<AgentRunHeader>): Promise<AgentRunHeader> {
@@ -94,6 +230,33 @@ class FileAgentRunStore implements AgentRunStore {
     return headers.sort((a, b) => a.createdAt - b.createdAt || a.runId.localeCompare(b.runId));
   }
 
+  async listSessionRunsForRecovery(sessionId: string): Promise<AgentRunHeader[]> {
+    assertSafeId(sessionId, 'Invalid session id');
+    const runsRoot = this.runsRoot(sessionId);
+    let entries;
+    try {
+      entries = await readdir(runsRoot, { withFileTypes: true });
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') return [];
+      throw error;
+    }
+    const headers: AgentRunHeader[] = [];
+    for (const entry of entries) {
+      if (!entry.isDirectory() || !isSafeId(entry.name)) {
+        throw new Error(`Invalid AgentRun entry for session ${sessionId}: ${entry.name}`);
+      }
+      try {
+        headers.push(await this.readRunUnlocked(sessionId, entry.name));
+      } catch (error) {
+        if (isMissingFile(error) && await this.removeUncommittedRunDirectory(sessionId, entry.name)) {
+          continue;
+        }
+        throw error;
+      }
+    }
+    return headers.sort((a, b) => a.createdAt - b.createdAt || a.runId.localeCompare(b.runId));
+  }
+
   async appendEvent(sessionId: string, runId: string, event: AgentRunEvent): Promise<void> {
     assertSafeId(sessionId, 'Invalid session id');
     assertSafeId(runId, 'Invalid run id');
@@ -122,11 +285,23 @@ class FileAgentRunStore implements AgentRunStore {
   private async appendRunEvent(sessionId: string, runId: string, event: AgentRunEvent): Promise<void> {
     await this.withQueue(sessionId, runId, async () => {
       await mkdir(this.runDir(sessionId, runId), { recursive: true });
-      await appendFile(this.eventsPath(sessionId, runId), JSON.stringify(event, sanitizeJson) + '\n', 'utf8');
+      await appendJsonl(this.eventsPath(sessionId, runId), JSON.stringify(event, sanitizeJson) + '\n');
     });
   }
 
   async readEvents(sessionId: string, runId: string): Promise<AgentRunEvent[]> {
+    return this.readEventsWithPolicy(sessionId, runId, false);
+  }
+
+  async readEventsForRecovery(sessionId: string, runId: string): Promise<AgentRunEvent[]> {
+    return this.readEventsWithPolicy(sessionId, runId, true);
+  }
+
+  private async readEventsWithPolicy(
+    sessionId: string,
+    runId: string,
+    strict: boolean,
+  ): Promise<AgentRunEvent[]> {
     assertSafeId(sessionId, 'Invalid session id');
     assertSafeId(runId, 'Invalid run id');
     let text: string;
@@ -149,6 +324,12 @@ class FileAgentRunStore implements AgentRunStore {
         events.push(JSON.parse(entry.line) as AgentRunEvent);
       } catch (error) {
         if (!endsWithNewline && entry.lineNumber === lastLineNumber) continue;
+        if (strict) {
+          const detail = error instanceof Error ? error.message : String(error);
+          throw new Error(
+            `AgentRun ${runId} has a corrupt JSONL record at line ${entry.lineNumber}: ${detail}`,
+          );
+        }
         events.push({
           type: 'event_corrupt',
           id: `run-event-corrupt-${entry.lineNumber}`,
@@ -223,6 +404,25 @@ class FileAgentRunStore implements AgentRunStore {
 
   private eventProjectionPath(sessionId: string, type: AgentRunEventType): string {
     return join(this.sessionsRoot, sessionId, 'projections', `${type}.json`);
+  }
+
+  private rootTurnAdmissionPath(sessionId: string, turnId: string): string {
+    return join(this.rootTurnAdmissionsRoot(sessionId), `${turnId}.json`);
+  }
+
+  private rootTurnAdmissionsRoot(sessionId: string): string {
+    return join(this.sessionsRoot, sessionId, 'turn-admissions');
+  }
+
+  private async removeUncommittedRunDirectory(sessionId: string, runId: string): Promise<boolean> {
+    const directory = this.runDir(sessionId, runId);
+    const entries = await readdir(directory, { withFileTypes: true });
+    if (entries.some((entry) => !entry.isFile() || !isExclusiveWriteTemp(entry.name, 'run.json'))) {
+      return false;
+    }
+    await rm(directory, { recursive: true });
+    await syncDirectory(this.runsRoot(sessionId));
+    return true;
   }
 
   private withQueue(sessionId: string, runId: string, operation: () => Promise<void>): Promise<void> {
@@ -378,7 +578,10 @@ class FileRuntimeEventStore implements RuntimeEventStore {
         }
         return;
       }
-      await appendFile(this.runtimeEventsPath(sessionId, runId), JSON.stringify(event, sanitizeJson) + '\n', 'utf8');
+      await appendJsonl(
+        this.runtimeEventsPath(sessionId, runId),
+        JSON.stringify(event, sanitizeJson) + '\n',
+      );
       const completedPartialKey = completedPartialRuntimeStreamKey(event);
       if (completedPartialKey) {
         await rm(this.runtimePartialPath(sessionId, runId, completedPartialKey), { force: true }).catch(() => {
@@ -640,12 +843,141 @@ async function writeAtomic(path: string, content: string): Promise<void> {
   await rename(tempPath, path);
 }
 
+async function writeExclusiveAtomic(path: string, content: string): Promise<boolean> {
+  const directory = dirname(path);
+  await ensureDirectoryDurable(directory);
+  const tempPath = `${path}.${process.pid}.${randomUUID()}.tmp`;
+  const handle = await open(tempPath, 'wx', 0o600);
+  try {
+    await handle.writeFile(content, 'utf8');
+    await handle.sync();
+  } finally {
+    await handle.close();
+  }
+  try {
+    await link(tempPath, path);
+    await unlink(tempPath);
+    await syncDirectory(directory);
+    return true;
+  } catch (error) {
+    await unlink(tempPath).catch(() => {});
+    if ((error as NodeJS.ErrnoException).code === 'EEXIST') return false;
+    throw error;
+  }
+}
+
+async function ensureDirectoryDurable(path: string): Promise<void> {
+  const firstCreated = await mkdir(path, { recursive: true });
+  if (!firstCreated) return;
+  let created = path;
+  while (true) {
+    await syncDirectory(dirname(created));
+    if (created === firstCreated) return;
+    const parent = dirname(created);
+    if (parent === created) {
+      throw new Error(`Unable to locate newly created directory ancestor for ${path}`);
+    }
+    created = parent;
+  }
+}
+
+async function syncDirectory(path: string): Promise<void> {
+  if (process.platform === 'win32') return;
+  const handle = await open(path, 'r');
+  try {
+    await handle.sync();
+  } finally {
+    await handle.close();
+  }
+}
+
 function assertSafeId(value: string, message: string): void {
   if (!isSafeId(value)) throw new Error(message);
 }
 
 function isSafeId(value: string): boolean {
   return SAFE_ID_PATTERN.test(value);
+}
+
+function normalizeRootTurnAdmission(
+  value: unknown,
+  sessionId: string,
+  turnId: string,
+): RootTurnAdmission {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error(`Invalid root turn admission for turn ${turnId}: expected an object`);
+  }
+  const record = value as Record<string, unknown>;
+  const valid = record.schemaVersion === ROOT_TURN_ADMISSION_SCHEMA_VERSION
+    && record.sessionId === sessionId
+    && record.turnId === turnId
+    && typeof record.runId === 'string'
+    && isSafeId(record.runId)
+    && typeof record.userMessageId === 'string'
+    && isSafeId(record.userMessageId)
+    && Number.isSafeInteger(record.admittedAt)
+    && (record.admittedAt as number) >= 0
+    && hasExactKeys(record, [
+      'schemaVersion',
+      'sessionId',
+      'turnId',
+      'runId',
+      'userMessageId',
+      'normalizedInput',
+      'admittedAt',
+    ]);
+  if (!valid) {
+    throw new Error(`Invalid root turn admission for turn ${turnId}: malformed fields`);
+  }
+  return {
+    schemaVersion: ROOT_TURN_ADMISSION_SCHEMA_VERSION,
+    sessionId,
+    turnId,
+    runId: record.runId as string,
+    userMessageId: record.userMessageId as string,
+    normalizedInput: normalizeRootTurnAdmissionInput(record.normalizedInput),
+    admittedAt: record.admittedAt as number,
+  };
+}
+
+function normalizeRootTurnAdmissionInput(value: unknown): RootTurnAdmissionInput {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error('Invalid root turn normalized input: expected an object');
+  }
+  const record = value as Record<string, unknown>;
+  if (!hasExactKeys(record, ['text']) || typeof record.text !== 'string' || record.text.length === 0) {
+    throw new Error('Invalid root turn normalized input');
+  }
+  return { text: record.text };
+}
+
+function turnIdFromAdmissionFile(name: string): string | undefined {
+  if (!name.endsWith('.json')) return undefined;
+  const turnId = name.slice(0, -'.json'.length);
+  return isSafeId(turnId) ? turnId : undefined;
+}
+
+function isRootTurnAdmissionTemp(name: string): boolean {
+  const marker = '.json.';
+  const markerIndex = name.indexOf(marker);
+  if (markerIndex < 1) return false;
+  return isSafeId(name.slice(0, markerIndex))
+    && EXCLUSIVE_TEMP_SUFFIX_PATTERN.test(name.slice(markerIndex + marker.length));
+}
+
+function isExclusiveWriteTemp(name: string, targetName: string): boolean {
+  const prefix = `${targetName}.`;
+  return name.startsWith(prefix)
+    && EXCLUSIVE_TEMP_SUFFIX_PATTERN.test(name.slice(prefix.length));
+}
+
+function hasExactKeys(record: Record<string, unknown>, expected: readonly string[]): boolean {
+  const keys = Object.keys(record);
+  return keys.length === expected.length && expected.every((key) => Object.hasOwn(record, key));
+}
+
+function isMissingFile(error: unknown): boolean {
+  return (error as NodeJS.ErrnoException | undefined)?.code === 'ENOENT';
 }
 
 function normalizeAgentRunHeader(value: unknown, sessionId: string, runId: string): AgentRunHeader {

--- a/packages/storage/src/agent-run-store.ts
+++ b/packages/storage/src/agent-run-store.ts
@@ -1,11 +1,15 @@
 import { createHash, randomUUID } from 'node:crypto';
 import { appendFile, link, mkdir, open, readFile, readdir, rename, rm, unlink, writeFile } from 'node:fs/promises';
-import { dirname, join } from 'node:path';
+import { dirname, join, resolve } from 'node:path';
+import { isDeepStrictEqual } from 'node:util';
 import { appendJsonl } from './jsonl-append.js';
+import { decodeAgentRunEvent, decodeAgentRunHeader, decodeRuntimeEvent } from './execution-record-codec.js';
+import { classifyJsonRecord } from './json-prefix.js';
+import { syncDirectory, syncDirectoryChain, syncFile } from './stable-storage.js';
 import { chainWrite } from './write-queue.js';
 import {
-  AGENT_RUN_STATUSES,
-  isPermissionMode,
+  DurableStoreWriteError,
+  isTerminalRuntimeEvent,
   type AgentRunEvent,
   type AgentRunEventType,
   type AgentRunHeader,
@@ -87,21 +91,25 @@ export function createRuntimeEventStore(workspaceRoot: string): DurableRuntimeEv
 }
 
 class FileAgentRunStore implements DurableAgentRunStore {
+  private readonly durabilityRoot: string;
   private readonly sessionsRoot: string;
   private readonly writeQueues = new Map<string, Promise<void>>();
   private readonly projectionWriteQueues = new Map<string, Promise<void>>();
 
   constructor(workspaceRoot: string) {
-    this.sessionsRoot = join(workspaceRoot, 'sessions');
+    this.durabilityRoot = resolve(workspaceRoot);
+    this.sessionsRoot = join(this.durabilityRoot, 'sessions');
   }
 
-  async createRun(header: AgentRunHeader): Promise<AgentRunHeader> {
+  async createRun(header: AgentRunHeader, options: { durable?: boolean } = {}): Promise<AgentRunHeader> {
     assertSafeId(header.sessionId, 'Invalid session id');
     assertSafeId(header.runId, 'Invalid run id');
     await this.withQueue(header.sessionId, header.runId, async () => {
       const created = await writeExclusiveAtomic(
         this.runPath(header.sessionId, header.runId),
         JSON.stringify(header, sanitizeJson) + '\n',
+        options,
+        this.durabilityRoot,
       );
       if (!created) throw new Error(`Agent run already exists: ${header.runId}`);
     });
@@ -136,7 +144,12 @@ class FileAgentRunStore implements DurableAgentRunStore {
       admittedAt: input.admittedAt,
     };
     const path = this.rootTurnAdmissionPath(input.sessionId, input.turnId);
-    const created = await writeExclusiveAtomic(path, JSON.stringify(admission) + '\n');
+    const created = await writeExclusiveAtomic(
+      path,
+      JSON.stringify(admission) + '\n',
+      { durable: true },
+      this.durabilityRoot,
+    );
     if (created) return { kind: 'admitted', admission };
     const existing = await this.readRootTurnAdmission(input.sessionId, input.turnId);
     if (!existing) throw new Error(`Root turn admission disappeared: ${input.turnId}`);
@@ -193,12 +206,21 @@ class FileAgentRunStore implements DurableAgentRunStore {
     return admissions.sort((a, b) => a.admittedAt - b.admittedAt || a.turnId.localeCompare(b.turnId));
   }
 
-  async updateRun(sessionId: string, runId: string, patch: Partial<AgentRunHeader>): Promise<AgentRunHeader> {
+  async updateRun(
+    sessionId: string,
+    runId: string,
+    patch: Partial<AgentRunHeader>,
+    options: { durable?: boolean } = {},
+  ): Promise<AgentRunHeader> {
     let next: AgentRunHeader | undefined;
     await this.withQueue(sessionId, runId, async () => {
       const current = await this.readRunUnlocked(sessionId, runId);
       next = { ...current, ...patch, sessionId, runId };
-      await writeAtomic(this.runPath(sessionId, runId), JSON.stringify(next, sanitizeJson) + '\n');
+      await writeAtomic(
+        this.runPath(sessionId, runId),
+        JSON.stringify(next, sanitizeJson) + '\n',
+        { ...options, durabilityRoot: this.durabilityRoot },
+      );
     });
     if (!next) throw new Error(`Failed to update run ${runId}`);
     return next;
@@ -257,7 +279,12 @@ class FileAgentRunStore implements DurableAgentRunStore {
     return headers.sort((a, b) => a.createdAt - b.createdAt || a.runId.localeCompare(b.runId));
   }
 
-  async appendEvent(sessionId: string, runId: string, event: AgentRunEvent): Promise<void> {
+  async appendEvent(
+    sessionId: string,
+    runId: string,
+    event: AgentRunEvent,
+    options: { durable?: boolean } = {},
+  ): Promise<void> {
     assertSafeId(sessionId, 'Invalid session id');
     assertSafeId(runId, 'Invalid run id');
     if (event.type === 'history_compact_checkpoint_recorded') {
@@ -268,8 +295,10 @@ class FileAgentRunStore implements DurableAgentRunStore {
         } catch {
           current = undefined;
         }
-        await rm(this.eventProjectionPath(sessionId, event.type), { force: true });
-        await this.appendRunEvent(sessionId, runId, event);
+        await rm(this.eventProjectionPath(sessionId, event.type), {
+          force: true,
+        });
+        await this.appendRunEvent(sessionId, runId, event, options);
         const projected = shouldPreserveCheckpointProjectionDuringAppend(current, event)
           ? current!
           : event;
@@ -279,13 +308,22 @@ class FileAgentRunStore implements DurableAgentRunStore {
       });
       return;
     }
-    await this.appendRunEvent(sessionId, runId, event);
+    await this.appendRunEvent(sessionId, runId, event, options);
   }
 
-  private async appendRunEvent(sessionId: string, runId: string, event: AgentRunEvent): Promise<void> {
+  private async appendRunEvent(
+    sessionId: string,
+    runId: string,
+    event: AgentRunEvent,
+    options: { durable?: boolean },
+  ): Promise<void> {
     await this.withQueue(sessionId, runId, async () => {
       await mkdir(this.runDir(sessionId, runId), { recursive: true });
-      await appendJsonl(this.eventsPath(sessionId, runId), JSON.stringify(event, sanitizeJson) + '\n');
+      await appendJsonl(
+        this.eventsPath(sessionId, runId),
+        JSON.stringify(event, sanitizeJson) + '\n',
+        { ...options, durabilityRoot: this.durabilityRoot },
+      );
     });
   }
 
@@ -320,10 +358,41 @@ class FileAgentRunStore implements DurableAgentRunStore {
     const lastLineNumber = lines.at(-1)?.lineNumber;
     const events: AgentRunEvent[] = [];
     for (const entry of lines) {
+      let parsed: unknown;
       try {
-        events.push(JSON.parse(entry.line) as AgentRunEvent);
+        parsed = JSON.parse(entry.line);
       } catch (error) {
-        if (!endsWithNewline && entry.lineNumber === lastLineNumber) continue;
+        if (
+          !endsWithNewline &&
+          entry.lineNumber === lastLineNumber &&
+          classifyJsonRecord(entry.line) === 'incomplete-prefix'
+        )
+          continue;
+        if (strict) {
+          const detail = error instanceof Error ? error.message : String(error);
+          throw new Error(`AgentRun ${runId} has a corrupt JSONL record at line ${entry.lineNumber}: ${detail}`);
+        }
+        events.push({
+          type: 'event_corrupt',
+          id: `run-event-corrupt-${entry.lineNumber}`,
+          runId,
+          sessionId,
+          turnId: header.turnId,
+          ts: header.updatedAt,
+          message: error instanceof Error ? error.message : 'Invalid AgentRun event JSONL line',
+          data: { lineNumber: entry.lineNumber },
+        });
+        continue;
+      }
+      try {
+        events.push(
+          decodeAgentRunEvent(parsed, {
+            sessionId,
+            runId,
+            turnId: header.turnId,
+          }),
+        );
+      } catch (error) {
         if (strict) {
           const detail = error instanceof Error ? error.message : String(error);
           throw new Error(
@@ -381,7 +450,10 @@ class FileAgentRunStore implements DurableAgentRunStore {
   private async readRunUnlocked(sessionId: string, runId: string): Promise<AgentRunHeader> {
     assertSafeId(sessionId, 'Invalid session id');
     assertSafeId(runId, 'Invalid run id');
-    return normalizeAgentRunHeader(JSON.parse(await readFile(this.runPath(sessionId, runId), 'utf8')), sessionId, runId);
+    return decodeAgentRunHeader(
+      JSON.parse(await readFile(this.runPath(sessionId, runId), 'utf8')),
+      { sessionId, runId },
+    );
   }
 
   private runsRoot(sessionId: string): string {
@@ -481,7 +553,9 @@ class FileAgentRunStore implements DurableAgentRunStore {
       await readFile(this.eventProjectionPath(sessionId, type), 'utf8');
     } catch (error) {
       if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
-      const runs = await readdir(this.runsRoot(sessionId), { withFileTypes: true });
+      const runs = await readdir(this.runsRoot(sessionId), {
+        withFileTypes: true,
+      });
       if (runs.some((entry) => entry.isDirectory() && isSafeId(entry.name) && entry.name !== currentRunId)) {
         return;
       }
@@ -539,15 +613,22 @@ function historyCompactProjectionCoverage(event: AgentRunEvent): number | undefi
     : undefined;
 }
 
-class FileRuntimeEventStore implements RuntimeEventStore {
+class FileRuntimeEventStore implements DurableRuntimeEventStore {
+  private readonly durabilityRoot: string;
   private readonly sessionsRoot: string;
   private readonly writeQueues = new Map<string, Promise<void>>();
 
   constructor(workspaceRoot: string) {
-    this.sessionsRoot = join(workspaceRoot, 'sessions');
+    this.durabilityRoot = resolve(workspaceRoot);
+    this.sessionsRoot = join(this.durabilityRoot, 'sessions');
   }
 
-  async appendRuntimeEvent(sessionId: string, runId: string, event: RuntimeEvent): Promise<void> {
+  async appendRuntimeEvent(
+    sessionId: string,
+    runId: string,
+    event: RuntimeEvent,
+    options: { durable?: boolean } = {},
+  ): Promise<void> {
     assertSafeId(sessionId, 'Invalid session id');
     assertSafeId(runId, 'Invalid run id');
     await this.withQueue(sessionId, runId, async () => {
@@ -561,7 +642,7 @@ class FileRuntimeEventStore implements RuntimeEventStore {
           if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
           const immutableEvents = await readRuntimeEventJsonl(
             this.runtimeEventsPath(sessionId, runId),
-            runId,
+            await this.readRunHeader(sessionId, runId),
           );
           if (immutableEvents.some((item) => completedPartialRuntimeStreamKey(item) === partial.key)) {
             return;
@@ -571,16 +652,25 @@ class FileRuntimeEventStore implements RuntimeEventStore {
             event: partial.snapshot,
             ...(immutableEvents.at(-1)?.id ? { afterEventId: immutableEvents.at(-1)!.id } : {}),
           };
-          await writeAtomic(partialPath, JSON.stringify(metadata, sanitizeJson) + '\n');
+          await writeAtomic(
+            partialPath,
+            JSON.stringify(metadata, sanitizeJson) + '\n',
+            { ...options, durabilityRoot: this.durabilityRoot },
+          );
         }
         if (partial.text) {
-          await appendFile(partialPath, partial.text, 'utf8');
+          if (options.durable) {
+            await appendFileDurably(partialPath, partial.text, this.durabilityRoot);
+          } else {
+            await appendFile(partialPath, partial.text, 'utf8');
+          }
         }
         return;
       }
       await appendJsonl(
         this.runtimeEventsPath(sessionId, runId),
         JSON.stringify(event, sanitizeJson) + '\n',
+        { ...options, durabilityRoot: this.durabilityRoot },
       );
       const completedPartialKey = completedPartialRuntimeStreamKey(event);
       if (completedPartialKey) {
@@ -591,10 +681,60 @@ class FileRuntimeEventStore implements RuntimeEventStore {
     });
   }
 
+  async ensureTerminalRuntimeEventDurable(
+    sessionId: string,
+    runId: string,
+    event: RuntimeEvent,
+  ): Promise<void> {
+    assertSafeId(sessionId, 'Invalid session id');
+    assertSafeId(runId, 'Invalid run id');
+    if (event.partial || !isTerminalRuntimeEvent(event)) {
+      throw new Error('Only a final terminal RuntimeEvent can cross the terminal durability barrier');
+    }
+    await this.withQueue(sessionId, runId, async () => {
+      const path = this.runtimeEventsPath(sessionId, runId);
+      const header = await this.readRunHeader(sessionId, runId);
+      const existing = await readRuntimeEventJsonl(path, header);
+      const matching = existing.filter((candidate) => candidate.id === event.id);
+      if (matching.length > 1) {
+        throw new Error(`RuntimeEvent ${event.id} appears more than once in run ${runId}`);
+      }
+      if (matching.length === 1) {
+        const canonical = JSON.parse(JSON.stringify(event, sanitizeJson)) as RuntimeEvent;
+        if (!isDeepStrictEqual(matching[0], canonical)) {
+          throw new Error(`RuntimeEvent ${event.id} does not match the durable ledger record`);
+        }
+        try {
+          await syncFile(path);
+          await syncDirectoryChain(dirname(path), this.durabilityRoot);
+        } catch (error) {
+          throw new DurableStoreWriteError(
+            `Terminal RuntimeEvent did not reach stable storage: ${path}`,
+            error,
+          );
+        }
+        return;
+      }
+      const existingTerminal = existing.find(isTerminalRuntimeEvent);
+      if (existingTerminal) {
+        throw new Error(
+          `Run ${runId} already has terminal RuntimeEvent ${existingTerminal.id}`,
+        );
+      }
+      await appendJsonl(path, JSON.stringify(event, sanitizeJson) + '\n', {
+        durable: true,
+        durabilityRoot: this.durabilityRoot,
+      });
+    });
+  }
+
   async readRuntimeEvents(sessionId: string, runId: string): Promise<RuntimeEvent[]> {
     assertSafeId(sessionId, 'Invalid session id');
     assertSafeId(runId, 'Invalid run id');
-    const events = await readRuntimeEventJsonl(this.runtimeEventsPath(sessionId, runId), runId);
+    const events = await readRuntimeEventJsonl(
+      this.runtimeEventsPath(sessionId, runId),
+      await this.readRunHeader(sessionId, runId),
+    );
     const partials = await this.readRuntimePartials(sessionId, runId);
     const completedPartialKeys = new Set(
       events.map(completedPartialRuntimeStreamKey).filter((key): key is string => key !== undefined),
@@ -609,7 +749,7 @@ class FileRuntimeEventStore implements RuntimeEventStore {
   async readImmutableRuntimeEvents(sessionId: string, runId: string): Promise<RuntimeEvent[]> {
     assertSafeId(sessionId, 'Invalid session id');
     assertSafeId(runId, 'Invalid run id');
-    return readRuntimeEventJsonl(this.runtimeEventsPath(sessionId, runId), runId);
+    return readRuntimeEventJsonl(this.runtimeEventsPath(sessionId, runId), await this.readRunHeader(sessionId, runId));
   }
 
   async readSessionRuntimeEvents(sessionId: string): Promise<RuntimeEvent[]> {
@@ -622,12 +762,20 @@ class FileRuntimeEventStore implements RuntimeEventStore {
       if ((error as NodeJS.ErrnoException).code === 'ENOENT') return [];
       throw error;
     }
-    const ordered: Array<{ event: RuntimeEvent; runId: string; eventIndex: number }> = [];
+    const ordered: Array<{
+      event: RuntimeEvent;
+      runId: string;
+      eventIndex: number;
+    }> = [];
     for (const entry of entries) {
       if (!entry.isDirectory() || !isSafeId(entry.name)) continue;
       const events = await this.readRuntimeEvents(sessionId, entry.name);
       for (let eventIndex = 0; eventIndex < events.length; eventIndex += 1) {
-        ordered.push({ event: events[eventIndex]!, runId: entry.name, eventIndex });
+        ordered.push({
+          event: events[eventIndex]!,
+          runId: entry.name,
+          eventIndex,
+        });
       }
     }
     ordered.sort((a, b) =>
@@ -653,6 +801,13 @@ class FileRuntimeEventStore implements RuntimeEventStore {
     return join(this.runDir(sessionId, runId), 'runtime-events.jsonl');
   }
 
+  private async readRunHeader(sessionId: string, runId: string): Promise<AgentRunHeader> {
+    return decodeAgentRunHeader(JSON.parse(await readFile(join(this.runDir(sessionId, runId), 'run.json'), 'utf8')), {
+      sessionId,
+      runId,
+    });
+  }
+
   private runtimePartialsDir(sessionId: string, runId: string): string {
     return join(this.runDir(sessionId, runId), 'runtime-partials');
   }
@@ -664,7 +819,9 @@ class FileRuntimeEventStore implements RuntimeEventStore {
   private async readRuntimePartials(sessionId: string, runId: string): Promise<RuntimePartialSnapshot[]> {
     let entries;
     try {
-      entries = await readdir(this.runtimePartialsDir(sessionId, runId), { withFileTypes: true });
+      entries = await readdir(this.runtimePartialsDir(sessionId, runId), {
+        withFileTypes: true,
+      });
     } catch (error) {
       if ((error as NodeJS.ErrnoException).code === 'ENOENT') return [];
       throw error;
@@ -681,7 +838,10 @@ class FileRuntimeEventStore implements RuntimeEventStore {
         if (snapshot.version !== 1 || !snapshot.event?.partial) continue;
         const event = snapshot.event;
         if (event.content?.kind === 'text' || event.content?.kind === 'thinking') {
-          event.content = { ...event.content, text: stored.slice(headerEnd + 1) };
+          event.content = {
+            ...event.content,
+            text: stored.slice(headerEnd + 1),
+          };
         }
         partials.push({ ...snapshot, event });
       } catch {
@@ -794,7 +954,7 @@ function hasOnlyKeys(value: object, allowed: readonly string[]): boolean {
   return Object.keys(value).every((key) => allowed.includes(key));
 }
 
-async function readRuntimeEventJsonl(path: string, runId: string): Promise<RuntimeEvent[]> {
+async function readRuntimeEventJsonl(path: string, expected: AgentRunHeader): Promise<RuntimeEvent[]> {
   let text: string;
   try {
     text = await readFile(path, 'utf8');
@@ -810,12 +970,24 @@ async function readRuntimeEventJsonl(path: string, runId: string): Promise<Runti
   const lastLineNumber = lines.at(-1)?.lineNumber;
   const events: RuntimeEvent[] = [];
   for (const entry of lines) {
+    let parsed: unknown;
     try {
-      events.push(JSON.parse(entry.line) as RuntimeEvent);
+      parsed = JSON.parse(entry.line);
     } catch (error) {
-      if (!endsWithNewline && entry.lineNumber === lastLineNumber) continue;
+      if (
+        !endsWithNewline &&
+        entry.lineNumber === lastLineNumber &&
+        classifyJsonRecord(entry.line) === 'incomplete-prefix'
+      )
+        continue;
       const message = error instanceof Error ? error.message : 'Invalid JSON';
-      throw new Error(`Invalid RuntimeEvent JSONL line ${entry.lineNumber} for run ${runId}: ${message}`);
+      throw new Error(`Invalid RuntimeEvent JSONL line ${entry.lineNumber} for run ${expected.runId}: ${message}`);
+    }
+    try {
+      events.push(decodeRuntimeEvent(parsed, expected));
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Invalid RuntimeEvent';
+      throw new Error(`Invalid RuntimeEvent JSONL line ${entry.lineNumber} for run ${expected.runId}: ${message}`);
     }
   }
   return events;
@@ -836,58 +1008,104 @@ function isProjectedAgentRunEvent(
     && Number.isFinite(event.ts);
 }
 
-async function writeAtomic(path: string, content: string): Promise<void> {
-  await mkdir(dirname(path), { recursive: true });
-  const tempPath = `${path}.${process.pid}.${Date.now()}.${randomUUID()}.tmp`;
-  await writeFile(tempPath, content, 'utf8');
-  await rename(tempPath, path);
+interface AtomicWriteOptions {
+  durable?: boolean;
+  durabilityRoot?: string;
 }
 
-async function writeExclusiveAtomic(path: string, content: string): Promise<boolean> {
+async function writeAtomic(path: string, content: string, options: AtomicWriteOptions = {}): Promise<void> {
+  try {
+    await writeAtomicUnchecked(path, content, options);
+  } catch (error) {
+    if (!options.durable || error instanceof DurableStoreWriteError) throw error;
+    throw new DurableStoreWriteError(`Durable atomic write did not reach stable storage: ${path}`, error);
+  }
+}
+
+async function appendFileDurably(path: string, content: string, durabilityRoot: string): Promise<void> {
+  try {
+    const handle = await open(path, 'a');
+    try {
+      await handle.appendFile(content, 'utf8');
+      await handle.sync();
+    } finally {
+      await handle.close();
+    }
+    await syncDirectoryChain(dirname(path), durabilityRoot);
+  } catch (error) {
+    if (error instanceof DurableStoreWriteError) throw error;
+    throw new DurableStoreWriteError(`Durable append did not reach stable storage: ${path}`, error);
+  }
+}
+
+async function writeAtomicUnchecked(path: string, content: string, options: AtomicWriteOptions): Promise<void> {
+  await mkdir(dirname(path), { recursive: true });
+  const tempPath = `${path}.${process.pid}.${Date.now()}.${randomUUID()}.tmp`;
+  if (options.durable) {
+    const handle = await open(tempPath, 'wx', 0o600);
+    try {
+      await handle.writeFile(content, 'utf8');
+      await handle.sync();
+    } finally {
+      await handle.close();
+    }
+  } else {
+    await writeFile(tempPath, content, 'utf8');
+  }
+  await rename(tempPath, path);
+  if (options.durable) {
+    if (!options.durabilityRoot) {
+      throw new Error('Durable atomic write requires a durability root');
+    }
+    await syncDirectoryChain(dirname(path), options.durabilityRoot);
+  }
+}
+
+async function writeExclusiveAtomic(
+  path: string,
+  content: string,
+  options: { durable?: boolean },
+  durabilityRoot: string,
+): Promise<boolean> {
+  try {
+    return await writeExclusiveAtomicUnchecked(path, content, options, durabilityRoot);
+  } catch (error) {
+    if (!options.durable || error instanceof DurableStoreWriteError) throw error;
+    throw new DurableStoreWriteError(`Durable exclusive write did not reach stable storage: ${path}`, error);
+  }
+}
+
+async function writeExclusiveAtomicUnchecked(
+  path: string,
+  content: string,
+  options: { durable?: boolean },
+  durabilityRoot: string,
+): Promise<boolean> {
   const directory = dirname(path);
-  await ensureDirectoryDurable(directory);
+  await mkdir(directory, { recursive: true });
   const tempPath = `${path}.${process.pid}.${randomUUID()}.tmp`;
   const handle = await open(tempPath, 'wx', 0o600);
   try {
     await handle.writeFile(content, 'utf8');
-    await handle.sync();
+    if (options.durable) await handle.sync();
   } finally {
     await handle.close();
   }
   try {
     await link(tempPath, path);
     await unlink(tempPath);
-    await syncDirectory(directory);
+    if (options.durable) await syncDirectoryChain(directory, durabilityRoot);
     return true;
   } catch (error) {
     await unlink(tempPath).catch(() => {});
-    if ((error as NodeJS.ErrnoException).code === 'EEXIST') return false;
-    throw error;
-  }
-}
-
-async function ensureDirectoryDurable(path: string): Promise<void> {
-  const firstCreated = await mkdir(path, { recursive: true });
-  if (!firstCreated) return;
-  let created = path;
-  while (true) {
-    await syncDirectory(dirname(created));
-    if (created === firstCreated) return;
-    const parent = dirname(created);
-    if (parent === created) {
-      throw new Error(`Unable to locate newly created directory ancestor for ${path}`);
+    if ((error as NodeJS.ErrnoException).code === 'EEXIST') {
+      if (options.durable) {
+        await syncFile(path);
+        await syncDirectoryChain(directory, durabilityRoot);
+      }
+      return false;
     }
-    created = parent;
-  }
-}
-
-async function syncDirectory(path: string): Promise<void> {
-  if (process.platform === 'win32') return;
-  const handle = await open(path, 'r');
-  try {
-    await handle.sync();
-  } finally {
-    await handle.close();
+    throw error;
   }
 }
 
@@ -978,57 +1196,6 @@ function hasExactKeys(record: Record<string, unknown>, expected: readonly string
 
 function isMissingFile(error: unknown): boolean {
   return (error as NodeJS.ErrnoException | undefined)?.code === 'ENOENT';
-}
-
-function normalizeAgentRunHeader(value: unknown, sessionId: string, runId: string): AgentRunHeader {
-  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
-    throw new Error(`Invalid AgentRun header for run ${runId}: expected an object`);
-  }
-  const record = value as Partial<AgentRunHeader>;
-  const requiredStrings = [
-    record.runId,
-    record.sessionId,
-    record.turnId,
-    record.llmConnectionSlug,
-    record.modelId,
-    record.cwd,
-  ];
-  const optionalStrings = [
-    record.invocationId,
-    record.parentRunId,
-    record.agentId,
-    record.agentName,
-    record.parentTurnId,
-    record.retriedFromTurnId,
-    record.regeneratedFromTurnId,
-    record.branchOfTurnId,
-    record.parentSessionId,
-    record.failureClass,
-    record.failureMessage,
-    record.traceWriteError,
-  ];
-  const valid = requiredStrings.every((item) => typeof item === 'string') &&
-    record.sessionId === sessionId &&
-    record.runId === runId &&
-    (AGENT_RUN_STATUSES as readonly string[]).includes(String(record.status)) &&
-    isBackendKind(record.backendKind) &&
-    isPermissionMode(record.permissionMode) &&
-    isFiniteNumber(record.createdAt) &&
-    isFiniteNumber(record.updatedAt) &&
-    (record.completedAt === undefined || isFiniteNumber(record.completedAt)) &&
-    optionalStrings.every((item) => item === undefined || typeof item === 'string');
-  if (!valid) {
-    throw new Error(`Invalid AgentRun header for run ${runId}: malformed fields`);
-  }
-  return record as AgentRunHeader;
-}
-
-function isBackendKind(value: unknown): boolean {
-  return value === 'ai-sdk' || value === 'fake' || value === 'pi-agent';
-}
-
-function isFiniteNumber(value: unknown): value is number {
-  return typeof value === 'number' && Number.isFinite(value);
 }
 
 function sanitizeJson(_key: string, value: unknown): unknown {

--- a/packages/storage/src/execution-record-codec.ts
+++ b/packages/storage/src/execution-record-codec.ts
@@ -1,0 +1,60 @@
+import {
+  decodeAgentRunEvent as decodeCanonicalAgentRunEvent,
+  decodeAgentRunHeader as decodeCanonicalAgentRunHeader,
+  decodeRuntimeEvent as decodeCanonicalRuntimeEvent,
+  decodeStoredMessageForRead,
+  decodeStoredMessageForRecovery,
+  type AgentRunEvent,
+  type AgentRunHeader,
+  type RuntimeEvent,
+} from '@maka/core';
+
+export { decodeStoredMessageForRead, decodeStoredMessageForRecovery };
+
+export function decodeAgentRunHeader(
+  value: unknown,
+  expected: { sessionId: string; runId: string },
+): AgentRunHeader {
+  try {
+    const header = decodeCanonicalAgentRunHeader(value);
+    if (header.sessionId !== expected.sessionId || header.runId !== expected.runId) {
+      throw new Error('AgentRun header identity does not match its path');
+    }
+    return header;
+  } catch (error) {
+    throw new Error(`Invalid AgentRun header for run ${expected.runId}: malformed fields`, {
+      cause: error,
+    });
+  }
+}
+
+export function decodeAgentRunEvent(
+  value: unknown,
+  expected: { sessionId: string; runId: string; turnId: string },
+): AgentRunEvent {
+  const event = decodeCanonicalAgentRunEvent(value);
+  if (
+    event.sessionId !== expected.sessionId ||
+    event.runId !== expected.runId ||
+    event.turnId !== expected.turnId
+  ) {
+    throw new Error('AgentRun event identity does not match its run');
+  }
+  return event;
+}
+
+export function decodeRuntimeEvent(
+  value: unknown,
+  expected: Pick<AgentRunHeader, 'sessionId' | 'runId' | 'turnId' | 'invocationId'>,
+): RuntimeEvent {
+  const event = decodeCanonicalRuntimeEvent(value);
+  if (
+    event.sessionId !== expected.sessionId ||
+    event.runId !== expected.runId ||
+    event.turnId !== expected.turnId ||
+    (expected.invocationId !== undefined && event.invocationId !== expected.invocationId)
+  ) {
+    throw new Error('RuntimeEvent identity does not match its run');
+  }
+  return event;
+}

--- a/packages/storage/src/execution-stores.ts
+++ b/packages/storage/src/execution-stores.ts
@@ -122,17 +122,18 @@ export async function openInteractiveExecutionStoresForWrite(
 			remove: (sessionId) => run(() => sessionStore.remove(sessionId)),
 		},
 		agentRunStore: {
-			createRun: (header) => run(() => agentRunStore.createRun(header)),
-			updateRun: (sessionId, runId, patch) =>
-				run(() => agentRunStore.updateRun(sessionId, runId, patch)),
+			createRun: (header, options) =>
+				run(() => agentRunStore.createRun(header, options)),
+			updateRun: (sessionId, runId, patch, options) =>
+				run(() => agentRunStore.updateRun(sessionId, runId, patch, options)),
 			readRun: (sessionId, runId) =>
 				run(() => agentRunStore.readRun(sessionId, runId)),
 			listSessionRuns: (sessionId) =>
 				run(() => agentRunStore.listSessionRuns(sessionId)),
 			listSessionRunsForRecovery: (sessionId) =>
 				run(() => agentRunStore.listSessionRunsForRecovery(sessionId)),
-			appendEvent: (sessionId, runId, event) =>
-				run(() => agentRunStore.appendEvent(sessionId, runId, event)),
+			appendEvent: (sessionId, runId, event, options) =>
+				run(() => agentRunStore.appendEvent(sessionId, runId, event, options)),
 			readEvents: (sessionId, runId) =>
 				run(() => agentRunStore.readEvents(sessionId, runId)),
 			readEventsForRecovery: (sessionId, runId) =>
@@ -153,9 +154,22 @@ export async function openInteractiveExecutionStoresForWrite(
 				run(() => agentRunStore.listRootTurnAdmissionsForRecovery(sessionId)),
 		},
 		runtimeEventStore: {
-			appendRuntimeEvent: (sessionId, runId, event) =>
+			appendRuntimeEvent: (sessionId, runId, event, options) =>
 				run(() =>
-					runtimeEventStore.appendRuntimeEvent(sessionId, runId, event),
+					runtimeEventStore.appendRuntimeEvent(
+						sessionId,
+						runId,
+						event,
+						options,
+					),
+				),
+			ensureTerminalRuntimeEventDurable: (sessionId, runId, event) =>
+				run(() =>
+					runtimeEventStore.ensureTerminalRuntimeEventDurable(
+						sessionId,
+						runId,
+						event,
+					),
 				),
 			readRuntimeEvents: (sessionId, runId) =>
 				run(() => runtimeEventStore.readRuntimeEvents(sessionId, runId)),

--- a/packages/storage/src/execution-stores.ts
+++ b/packages/storage/src/execution-stores.ts
@@ -1,0 +1,215 @@
+import type {
+	AgentRunEvent,
+	AgentRunEventType,
+	AgentRunHeader,
+	RuntimeEvent,
+	SessionHeader,
+	SessionListFilter,
+	SessionSummary,
+	StoredMessage,
+	TurnRecord,
+} from "@maka/core";
+import {
+	createAgentRunStore,
+	createRuntimeEventStore,
+	type AdmitRootTurnInput,
+	type AdmitRootTurnResult,
+	type DurableAgentRunStore,
+	type DurableRuntimeEventStore,
+	type RootTurnAdmission,
+} from "./agent-run-store.js";
+import { createSessionStore, type SessionStore } from "./session-store.js";
+import {
+	assertStorageRootLease,
+	runWithStorageRootLease,
+	type StorageRootLease,
+} from "./root-authority.js";
+
+export type {
+	RootTurnAdmission,
+	RootTurnAdmissionInput,
+} from "./agent-run-store.js";
+
+export type InteractiveExecutionSessionWriter = SessionStore;
+export type InteractiveExecutionAgentRunWriter = DurableAgentRunStore;
+export type InteractiveExecutionRuntimeEventWriter = DurableRuntimeEventStore;
+
+export interface InteractiveExecutionStoresWriter {
+	sessionStore: InteractiveExecutionSessionWriter;
+	agentRunStore: InteractiveExecutionAgentRunWriter;
+	runtimeEventStore: InteractiveExecutionRuntimeEventWriter;
+}
+
+export interface InteractiveExecutionSessionReader {
+	list(filter?: SessionListFilter): Promise<SessionSummary[]>;
+	readHeader(sessionId: string): Promise<SessionHeader>;
+	readMessages(sessionId: string): Promise<StoredMessage[]>;
+	listTurns(sessionId: string): Promise<TurnRecord[]>;
+}
+
+export interface InteractiveExecutionAgentRunReader {
+	readRun(sessionId: string, runId: string): Promise<AgentRunHeader>;
+	listSessionRuns(sessionId: string): Promise<AgentRunHeader[]>;
+	readEvents(sessionId: string, runId: string): Promise<AgentRunEvent[]>;
+	readEventProjection(
+		sessionId: string,
+		type: AgentRunEventType,
+	): Promise<AgentRunEvent | null | undefined>;
+	readRootTurnAdmission(
+		sessionId: string,
+		turnId: string,
+	): Promise<RootTurnAdmission | undefined>;
+}
+
+export interface InteractiveExecutionRuntimeEventReader {
+	readRuntimeEvents(sessionId: string, runId: string): Promise<RuntimeEvent[]>;
+	readImmutableRuntimeEvents(
+		sessionId: string,
+		runId: string,
+	): Promise<RuntimeEvent[]>;
+	readSessionRuntimeEvents(sessionId: string): Promise<RuntimeEvent[]>;
+}
+
+export interface InteractiveExecutionStoresReader {
+	sessionStore: InteractiveExecutionSessionReader;
+	agentRunStore: InteractiveExecutionAgentRunReader;
+	runtimeEventStore: InteractiveExecutionRuntimeEventReader;
+}
+
+export async function openInteractiveExecutionStoresForWrite(
+	lease: StorageRootLease<"interactive", "write">,
+): Promise<InteractiveExecutionStoresWriter> {
+	await assertStorageRootLease(lease, "interactive", "write");
+	const sessionStore = createSessionStore(lease.canonicalPath);
+	const agentRunStore = createAgentRunStore(lease.canonicalPath);
+	const runtimeEventStore = createRuntimeEventStore(lease.canonicalPath);
+	const run = <T>(operation: () => Promise<T>) =>
+		runWithStorageRootLease(lease, "interactive", "write", operation);
+
+	return {
+		sessionStore: {
+			create: (input) => run(() => sessionStore.create(input)),
+			list: (filter) => run(() => sessionStore.list(filter)),
+			listForRecovery: () => run(() => sessionStore.listForRecovery()),
+			readHeaderSnapshot: (sessionId) =>
+				run(() => sessionStore.readHeaderSnapshot(sessionId)),
+			readMessagesSnapshot: (sessionId) =>
+				run(() => sessionStore.readMessagesSnapshot(sessionId)),
+			readMessagesForRecovery: (sessionId) =>
+				run(() => sessionStore.readMessagesForRecovery(sessionId)),
+			listTurnsSnapshot: (sessionId) =>
+				run(() => sessionStore.listTurnsSnapshot(sessionId)),
+			readHeader: (sessionId) => run(() => sessionStore.readHeader(sessionId)),
+			readMessages: (sessionId) =>
+				run(() => sessionStore.readMessages(sessionId)),
+			listTurns: (sessionId) => run(() => sessionStore.listTurns(sessionId)),
+			appendMessage: (sessionId, message) =>
+				run(() => sessionStore.appendMessage(sessionId, message)),
+			appendMessages: (sessionId, messages) =>
+				run(() => sessionStore.appendMessages(sessionId, messages)),
+			updateHeader: (sessionId, patch) =>
+				run(() => sessionStore.updateHeader(sessionId, patch)),
+			markSessionReadThrough: (sessionId, readThroughTs) =>
+				run(() =>
+					sessionStore.markSessionReadThrough(sessionId, readThroughTs),
+				),
+			archive: (sessionId) => run(() => sessionStore.archive(sessionId)),
+			unarchive: (sessionId) => run(() => sessionStore.unarchive(sessionId)),
+			setFlagged: (sessionId, isFlagged) =>
+				run(() => sessionStore.setFlagged(sessionId, isFlagged)),
+			rename: (sessionId, name) =>
+				run(() => sessionStore.rename(sessionId, name)),
+			remove: (sessionId) => run(() => sessionStore.remove(sessionId)),
+		},
+		agentRunStore: {
+			createRun: (header) => run(() => agentRunStore.createRun(header)),
+			updateRun: (sessionId, runId, patch) =>
+				run(() => agentRunStore.updateRun(sessionId, runId, patch)),
+			readRun: (sessionId, runId) =>
+				run(() => agentRunStore.readRun(sessionId, runId)),
+			listSessionRuns: (sessionId) =>
+				run(() => agentRunStore.listSessionRuns(sessionId)),
+			listSessionRunsForRecovery: (sessionId) =>
+				run(() => agentRunStore.listSessionRunsForRecovery(sessionId)),
+			appendEvent: (sessionId, runId, event) =>
+				run(() => agentRunStore.appendEvent(sessionId, runId, event)),
+			readEvents: (sessionId, runId) =>
+				run(() => agentRunStore.readEvents(sessionId, runId)),
+			readEventsForRecovery: (sessionId, runId) =>
+				run(() => agentRunStore.readEventsForRecovery(sessionId, runId)),
+			readEventProjection: (sessionId, type) =>
+				run(() => agentRunStore.readEventProjection(sessionId, type)),
+			repairEventProjection: (sessionId, type, event, options) =>
+				run(() =>
+					agentRunStore.repairEventProjection(sessionId, type, event, options),
+				),
+			admitRootTurn: (
+				input: AdmitRootTurnInput,
+			): Promise<AdmitRootTurnResult> =>
+				run(() => agentRunStore.admitRootTurn(input)),
+			readRootTurnAdmission: (sessionId, turnId) =>
+				run(() => agentRunStore.readRootTurnAdmission(sessionId, turnId)),
+			listRootTurnAdmissionsForRecovery: (sessionId) =>
+				run(() => agentRunStore.listRootTurnAdmissionsForRecovery(sessionId)),
+		},
+		runtimeEventStore: {
+			appendRuntimeEvent: (sessionId, runId, event) =>
+				run(() =>
+					runtimeEventStore.appendRuntimeEvent(sessionId, runId, event),
+				),
+			readRuntimeEvents: (sessionId, runId) =>
+				run(() => runtimeEventStore.readRuntimeEvents(sessionId, runId)),
+			readImmutableRuntimeEvents: (sessionId, runId) =>
+				run(() =>
+					runtimeEventStore.readImmutableRuntimeEvents(sessionId, runId),
+				),
+			readSessionRuntimeEvents: (sessionId) =>
+				run(() => runtimeEventStore.readSessionRuntimeEvents(sessionId)),
+		},
+	};
+}
+
+export async function openInteractiveExecutionStoresForRead(
+	lease: StorageRootLease<"interactive", "read">,
+): Promise<InteractiveExecutionStoresReader> {
+	await assertStorageRootLease(lease, "interactive", "read");
+	const sessionStore = createSessionStore(lease.canonicalPath);
+	const agentRunStore = createAgentRunStore(lease.canonicalPath);
+	const runtimeEventStore = createRuntimeEventStore(lease.canonicalPath);
+	const run = <T>(operation: () => Promise<T>) =>
+		runWithStorageRootLease(lease, "interactive", "read", operation);
+
+	return {
+		sessionStore: {
+			list: (filter) => run(() => sessionStore.list(filter)),
+			readHeader: (sessionId) =>
+				run(() => sessionStore.readHeaderSnapshot(sessionId)),
+			readMessages: (sessionId) =>
+				run(() => sessionStore.readMessagesSnapshot(sessionId)),
+			listTurns: (sessionId) =>
+				run(() => sessionStore.listTurnsSnapshot(sessionId)),
+		},
+		agentRunStore: {
+			readRun: (sessionId, runId) =>
+				run(() => agentRunStore.readRun(sessionId, runId)),
+			listSessionRuns: (sessionId) =>
+				run(() => agentRunStore.listSessionRuns(sessionId)),
+			readEvents: (sessionId, runId) =>
+				run(() => agentRunStore.readEvents(sessionId, runId)),
+			readEventProjection: (sessionId, type) =>
+				run(() => agentRunStore.readEventProjection(sessionId, type)),
+			readRootTurnAdmission: (sessionId, turnId) =>
+				run(() => agentRunStore.readRootTurnAdmission(sessionId, turnId)),
+		},
+		runtimeEventStore: {
+			readRuntimeEvents: (sessionId, runId) =>
+				run(() => runtimeEventStore.readRuntimeEvents(sessionId, runId)),
+			readImmutableRuntimeEvents: (sessionId, runId) =>
+				run(() =>
+					runtimeEventStore.readImmutableRuntimeEvents(sessionId, runId),
+				),
+			readSessionRuntimeEvents: (sessionId) =>
+				run(() => runtimeEventStore.readSessionRuntimeEvents(sessionId)),
+		},
+	};
+}

--- a/packages/storage/src/json-prefix.ts
+++ b/packages/storage/src/json-prefix.ts
@@ -1,0 +1,201 @@
+export type JsonRecordClassification = 'complete' | 'incomplete-prefix' | 'invalid';
+
+/** Classifies whether bytes missing only from the end could make this valid JSON. */
+export function classifyJsonRecord(value: string): JsonRecordClassification {
+  try {
+    JSON.parse(value);
+    return 'complete';
+  } catch {
+    // Only parse failures need the stricter prefix distinction below.
+  }
+  return new JsonPrefixParser(value).classify();
+}
+
+class JsonPrefixParser {
+  private index = 0;
+
+  constructor(private readonly value: string) {}
+
+  classify(): JsonRecordClassification {
+    this.skipWhitespace();
+    const state = this.parseValue(0);
+    if (state !== 'complete') return state;
+    this.skipWhitespace();
+    return this.index === this.value.length ? 'complete' : 'invalid';
+  }
+
+  private parseValue(depth: number): JsonRecordClassification {
+    if (depth > 512) return 'invalid';
+    if (this.index === this.value.length) return 'incomplete-prefix';
+    switch (this.value[this.index]) {
+      case '{':
+        return this.parseObject(depth + 1);
+      case '[':
+        return this.parseArray(depth + 1);
+      case '"':
+        return this.parseString();
+      case 't':
+        return this.parseLiteral('true');
+      case 'f':
+        return this.parseLiteral('false');
+      case 'n':
+        return this.parseLiteral('null');
+      default:
+        return this.parseNumber();
+    }
+  }
+
+  private parseObject(depth: number): JsonRecordClassification {
+    this.index += 1;
+    this.skipWhitespace();
+    if (this.index === this.value.length) return 'incomplete-prefix';
+    if (this.value[this.index] === '}') {
+      this.index += 1;
+      return 'complete';
+    }
+    while (true) {
+      if (this.value[this.index] !== '"') return 'invalid';
+      const key = this.parseString();
+      if (key !== 'complete') return key;
+      this.skipWhitespace();
+      if (this.index === this.value.length) return 'incomplete-prefix';
+      if (this.value[this.index] !== ':') return 'invalid';
+      this.index += 1;
+      this.skipWhitespace();
+      const item = this.parseValue(depth);
+      if (item !== 'complete') return item;
+      this.skipWhitespace();
+      if (this.index === this.value.length) return 'incomplete-prefix';
+      const delimiter = this.value[this.index];
+      if (delimiter === '}') {
+        this.index += 1;
+        return 'complete';
+      }
+      if (delimiter !== ',') return 'invalid';
+      this.index += 1;
+      this.skipWhitespace();
+      if (this.index === this.value.length) return 'incomplete-prefix';
+      if (this.value[this.index] === '}') return 'invalid';
+    }
+  }
+
+  private parseArray(depth: number): JsonRecordClassification {
+    this.index += 1;
+    this.skipWhitespace();
+    if (this.index === this.value.length) return 'incomplete-prefix';
+    if (this.value[this.index] === ']') {
+      this.index += 1;
+      return 'complete';
+    }
+    while (true) {
+      const item = this.parseValue(depth);
+      if (item !== 'complete') return item;
+      this.skipWhitespace();
+      if (this.index === this.value.length) return 'incomplete-prefix';
+      const delimiter = this.value[this.index];
+      if (delimiter === ']') {
+        this.index += 1;
+        return 'complete';
+      }
+      if (delimiter !== ',') return 'invalid';
+      this.index += 1;
+      this.skipWhitespace();
+      if (this.index === this.value.length) return 'incomplete-prefix';
+      if (this.value[this.index] === ']') return 'invalid';
+    }
+  }
+
+  private parseString(): JsonRecordClassification {
+    this.index += 1;
+    while (this.index < this.value.length) {
+      const code = this.value.charCodeAt(this.index);
+      const char = this.value[this.index]!;
+      this.index += 1;
+      if (char === '"') return 'complete';
+      if (code < 0x20) return 'invalid';
+      if (char !== '\\') continue;
+      if (this.index === this.value.length) return 'incomplete-prefix';
+      const escape = this.value[this.index]!;
+      this.index += 1;
+      if ('"\\/bfnrt'.includes(escape)) continue;
+      if (escape !== 'u') return 'invalid';
+      const remaining = this.value.length - this.index;
+      if (remaining < 4) {
+        const suffix = this.value.slice(this.index);
+        return /^[0-9a-fA-F]*$/.test(suffix) ? 'incomplete-prefix' : 'invalid';
+      }
+      if (!/^[0-9a-fA-F]{4}$/.test(this.value.slice(this.index, this.index + 4))) {
+        return 'invalid';
+      }
+      this.index += 4;
+    }
+    return 'incomplete-prefix';
+  }
+
+  private parseLiteral(literal: string): JsonRecordClassification {
+    const available = this.value.slice(this.index, this.index + literal.length);
+    if (!literal.startsWith(available)) return 'invalid';
+    if (available.length < literal.length) {
+      this.index = this.value.length;
+      return 'incomplete-prefix';
+    }
+    this.index += literal.length;
+    return 'complete';
+  }
+
+  private parseNumber(): JsonRecordClassification {
+    const start = this.index;
+    if (this.value[this.index] === '-') {
+      this.index += 1;
+      if (this.index === this.value.length) return 'incomplete-prefix';
+    }
+    const first = this.value[this.index];
+    if (first === '0') {
+      this.index += 1;
+      if (isDigit(this.value[this.index])) return 'invalid';
+    } else if (isNonZeroDigit(first)) {
+      this.index += 1;
+      while (isDigit(this.value[this.index])) this.index += 1;
+    } else {
+      this.index = start;
+      return 'invalid';
+    }
+
+    if (this.value[this.index] === '.') {
+      this.index += 1;
+      if (this.index === this.value.length) return 'incomplete-prefix';
+      if (!isDigit(this.value[this.index])) return 'invalid';
+      while (isDigit(this.value[this.index])) this.index += 1;
+    }
+    if (this.value[this.index] === 'e' || this.value[this.index] === 'E') {
+      this.index += 1;
+      if (this.index === this.value.length) return 'incomplete-prefix';
+      if (this.value[this.index] === '+' || this.value[this.index] === '-') {
+        this.index += 1;
+        if (this.index === this.value.length) return 'incomplete-prefix';
+      }
+      if (!isDigit(this.value[this.index])) return 'invalid';
+      while (isDigit(this.value[this.index])) this.index += 1;
+    }
+    return 'complete';
+  }
+
+  private skipWhitespace(): void {
+    while (
+      this.value[this.index] === ' ' ||
+      this.value[this.index] === '\t' ||
+      this.value[this.index] === '\n' ||
+      this.value[this.index] === '\r'
+    ) {
+      this.index += 1;
+    }
+  }
+}
+
+function isDigit(value: string | undefined): boolean {
+  return value !== undefined && value >= '0' && value <= '9';
+}
+
+function isNonZeroDigit(value: string | undefined): boolean {
+  return value !== undefined && value >= '1' && value <= '9';
+}

--- a/packages/storage/src/jsonl-append.ts
+++ b/packages/storage/src/jsonl-append.ts
@@ -1,0 +1,111 @@
+import { constants } from "node:fs";
+import { open, type FileHandle } from "node:fs/promises";
+
+const REVERSE_SCAN_CHUNK_BYTES = 64 * 1024;
+
+export interface AppendJsonlOptions {
+	requireExistingRecord?: boolean;
+}
+
+export async function appendJsonl(
+	path: string,
+	payload: string,
+	options: AppendJsonlOptions = {},
+): Promise<void> {
+	if (payload.length === 0 || !payload.endsWith("\n")) {
+		throw new Error("JSONL append payload must end with a newline");
+	}
+
+	const flags =
+		constants.O_RDWR |
+		constants.O_APPEND |
+		(options.requireExistingRecord ? 0 : constants.O_CREAT);
+	const handle = await open(path, flags, 0o600);
+	try {
+		const size = (await handle.stat()).size;
+		if (size === 0 && options.requireExistingRecord) {
+			throw new Error("Cannot append to an empty JSONL document");
+		}
+
+		let separator = "";
+		if (size > 0 && !(await endsWithNewline(handle, size))) {
+			const tailStart = await findTrailingRecordStart(handle, size);
+			const tail = await readRange(handle, tailStart, size);
+			if (isCompleteJson(tail)) {
+				separator = "\n";
+			} else {
+				if (tailStart === 0 && options.requireExistingRecord) {
+					throw new Error("Cannot repair a truncated JSONL document header");
+				}
+				await handle.truncate(tailStart);
+				await handle.sync();
+			}
+		}
+
+		await handle.appendFile(separator + payload, "utf8");
+	} finally {
+		await handle.close();
+	}
+}
+
+async function endsWithNewline(
+	handle: FileHandle,
+	size: number,
+): Promise<boolean> {
+	const byte = Buffer.allocUnsafe(1);
+	await readFully(handle, byte, size - 1);
+	return byte[0] === 0x0a;
+}
+
+async function findTrailingRecordStart(
+	handle: FileHandle,
+	size: number,
+): Promise<number> {
+	let end = size;
+	while (end > 0) {
+		const start = Math.max(0, end - REVERSE_SCAN_CHUNK_BYTES);
+		const chunk = Buffer.allocUnsafe(end - start);
+		await readFully(handle, chunk, start);
+		const newline = chunk.lastIndexOf(0x0a);
+		if (newline >= 0) return start + newline + 1;
+		end = start;
+	}
+	return 0;
+}
+
+async function readRange(
+	handle: FileHandle,
+	start: number,
+	end: number,
+): Promise<string> {
+	const bytes = Buffer.allocUnsafe(end - start);
+	await readFully(handle, bytes, start);
+	return bytes.toString("utf8");
+}
+
+async function readFully(
+	handle: FileHandle,
+	buffer: Buffer,
+	position: number,
+): Promise<void> {
+	let offset = 0;
+	while (offset < buffer.length) {
+		const { bytesRead } = await handle.read(
+			buffer,
+			offset,
+			buffer.length - offset,
+			position + offset,
+		);
+		if (bytesRead === 0) throw new Error("Unexpected end of JSONL document");
+		offset += bytesRead;
+	}
+}
+
+function isCompleteJson(value: string): boolean {
+	try {
+		JSON.parse(value);
+		return true;
+	} catch {
+		return false;
+	}
+}

--- a/packages/storage/src/jsonl-append.ts
+++ b/packages/storage/src/jsonl-append.ts
@@ -1,9 +1,15 @@
 import { constants } from "node:fs";
 import { open, type FileHandle } from "node:fs/promises";
+import { dirname } from "node:path";
+import { DurableStoreWriteError } from "@maka/core";
+import { classifyJsonRecord } from "./json-prefix.js";
+import { syncDirectoryChain } from "./stable-storage.js";
 
 const REVERSE_SCAN_CHUNK_BYTES = 64 * 1024;
 
 export interface AppendJsonlOptions {
+	durable?: boolean;
+	durabilityRoot?: string;
 	requireExistingRecord?: boolean;
 }
 
@@ -11,6 +17,23 @@ export async function appendJsonl(
 	path: string,
 	payload: string,
 	options: AppendJsonlOptions = {},
+): Promise<void> {
+	try {
+		await appendJsonlUnchecked(path, payload, options);
+	} catch (error) {
+		if (!options.durable || error instanceof DurableStoreWriteError)
+			throw error;
+		throw new DurableStoreWriteError(
+			`Durable JSONL append did not reach stable storage: ${path}`,
+			error,
+		);
+	}
+}
+
+async function appendJsonlUnchecked(
+	path: string,
+	payload: string,
+	options: AppendJsonlOptions,
 ): Promise<void> {
 	if (payload.length === 0 || !payload.endsWith("\n")) {
 		throw new Error("JSONL append payload must end with a newline");
@@ -31,20 +54,30 @@ export async function appendJsonl(
 		if (size > 0 && !(await endsWithNewline(handle, size))) {
 			const tailStart = await findTrailingRecordStart(handle, size);
 			const tail = await readRange(handle, tailStart, size);
-			if (isCompleteJson(tail)) {
+			const classification = classifyJsonRecord(tail);
+			if (classification === "complete") {
 				separator = "\n";
-			} else {
+			} else if (classification === "incomplete-prefix") {
 				if (tailStart === 0 && options.requireExistingRecord) {
 					throw new Error("Cannot repair a truncated JSONL document header");
 				}
 				await handle.truncate(tailStart);
 				await handle.sync();
+			} else {
+				throw new Error("Cannot append after an invalid JSONL tail record");
 			}
 		}
 
 		await handle.appendFile(separator + payload, "utf8");
+		if (options.durable) await handle.sync();
 	} finally {
 		await handle.close();
+	}
+	if (options.durable) {
+		if (!options.durabilityRoot) {
+			throw new Error("Durable JSONL append requires a durability root");
+		}
+		await syncDirectoryChain(dirname(path), options.durabilityRoot);
 	}
 }
 
@@ -98,14 +131,5 @@ async function readFully(
 		);
 		if (bytesRead === 0) throw new Error("Unexpected end of JSONL document");
 		offset += bytesRead;
-	}
-}
-
-function isCompleteJson(value: string): boolean {
-	try {
-		JSON.parse(value);
-		return true;
-	} catch {
-		return false;
 	}
 }

--- a/packages/storage/src/root-authority.ts
+++ b/packages/storage/src/root-authority.ts
@@ -88,6 +88,7 @@ interface LeaseRecord<
 > extends CapabilityRecord<K> {
   access: A;
   isActive: () => boolean;
+  beginOperation: () => () => void;
 }
 
 interface RootMarker {
@@ -314,6 +315,26 @@ export async function assertStorageRootLease<
   requireLease(lease, expectedKind, expectedAccess);
 }
 
+export async function runWithStorageRootLease<
+  K extends StorageRootKind,
+  A extends StorageRootAccess,
+  T,
+>(
+  lease: StorageRootLease<K, A>,
+  expectedKind: K,
+  expectedAccess: A,
+  operation: (canonicalPath: string) => Promise<T>,
+): Promise<T> {
+  const record = requireLease(lease, expectedKind, expectedAccess);
+  const finishOperation = record.beginOperation();
+  try {
+    await assertRootIdentity(record);
+    return await operation(record.canonicalPath);
+  } finally {
+    finishOperation();
+  }
+}
+
 export async function assertStorageRootCapability<K extends StorageRootKind>(
   capability: StorageRootCapability<K>,
   expectedKind: K,
@@ -385,7 +406,25 @@ async function acquireInteractiveRootLock(
   }
 
   let active = true;
+  let activeOperations = 0;
+  const operationDrainWaiters = new Set<() => void>();
   let closePromise: Promise<void> | undefined;
+  const beginOperation = () => {
+    if (!active) throw invalidLease(capabilityRecord.kind, access);
+    activeOperations += 1;
+    let finished = false;
+    return () => {
+      if (finished) return;
+      finished = true;
+      activeOperations -= 1;
+      if (activeOperations !== 0) return;
+      for (const resolve of operationDrainWaiters) resolve();
+      operationDrainWaiters.clear();
+    };
+  };
+  const waitForOperations = () => activeOperations === 0
+    ? Promise.resolve()
+    : new Promise<void>((resolve) => operationDrainWaiters.add(resolve));
   const close = () => {
     if (closePromise) return closePromise;
     active = false;
@@ -393,6 +432,7 @@ async function acquireInteractiveRootLock(
       'lock_failed',
       'Unable to close the interactive storage root lock',
       async () => {
+        await waitForOperations();
         releaseLock(handle);
         await handle.close();
       },
@@ -406,6 +446,7 @@ async function acquireInteractiveRootLock(
     controlDirectory,
     lockPath,
     () => active,
+    beginOperation,
     close,
   );
 }
@@ -417,11 +458,12 @@ function createInteractiveRootLock(
   controlDirectory: string,
   lockPath: string,
   isActive: () => boolean,
+  beginOperation: () => () => void,
   close: () => Promise<void>,
 ): InteractiveRootOwner | InteractiveRootReader {
   const lock = Object.freeze({
     capability,
-    lease: createLease(capabilityRecord, access, isActive),
+    lease: createLease(capabilityRecord, access, isActive, beginOperation),
     controlDirectory,
     lockPath,
     get closed() {
@@ -437,6 +479,10 @@ function createLease<K extends StorageRootKind, A extends StorageRootAccess>(
   capability: CapabilityRecord<K>,
   access: A,
   isActive: () => boolean,
+  beginOperation: () => () => void = () => {
+    if (!isActive()) throw invalidLease(capability.kind, access);
+    return () => {};
+  },
 ): StorageRootLease<K, A> {
   const lease = Object.freeze({
     kind: capability.kind,
@@ -444,7 +490,7 @@ function createLease<K extends StorageRootKind, A extends StorageRootAccess>(
     canonicalPath: capability.canonicalPath,
     rootId: capability.rootId,
   }) as StorageRootLease<K, A>;
-  leases.set(lease, { ...capability, access, isActive });
+  leases.set(lease, { ...capability, access, isActive, beginOperation });
   return lease;
 }
 
@@ -469,12 +515,19 @@ function requireLease<K extends StorageRootKind, A extends StorageRootAccess>(
 ): LeaseRecord<K, A> {
   const record = leases.get(lease);
   if (!record || record.kind !== expectedKind || record.access !== expectedAccess || !record.isActive()) {
-    throw new StorageRootAuthorityError(
-      'invalid_lease',
-      `Expected an active ${expectedKind} ${expectedAccess} storage root lease`,
-    );
+    throw invalidLease(expectedKind, expectedAccess);
   }
   return record as LeaseRecord<K, A>;
+}
+
+function invalidLease(
+  kind: StorageRootKind,
+  access: StorageRootAccess,
+): StorageRootAuthorityError {
+  return new StorageRootAuthorityError(
+    'invalid_lease',
+    `Expected an active ${kind} ${access} storage root lease`,
+  );
 }
 
 async function assertRootIdentity(record: CapabilityRecord): Promise<void> {

--- a/packages/storage/src/session-store.ts
+++ b/packages/storage/src/session-store.ts
@@ -1,7 +1,8 @@
-import { mkdir, open, readFile, rename, rm, writeFile } from 'node:fs/promises';
+import { mkdir, open, readFile, readdir, rename, rm, writeFile } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
 import { randomUUID } from 'node:crypto';
 import { setTimeout as delay } from 'node:timers/promises';
+import { appendJsonl } from './jsonl-append.js';
 import { chainWrite } from './write-queue.js';
 import {
   deriveTurnRecords,
@@ -26,8 +27,15 @@ const SESSION_ID_PATTERN = /^[A-Za-z0-9_-]{1,128}$/;
 export interface SessionStore {
   create(input: CreateSessionInput): Promise<SessionHeader>;
   list(filter?: SessionListFilter): Promise<SessionSummary[]>;
+  listForRecovery(): Promise<SessionHeader[]>;
   /** Read only the durable header without triggering connection-lock self-healing. */
   readHeaderSnapshot(sessionId: string): Promise<SessionHeader>;
+  /** Read durable messages without triggering connection-lock self-healing. */
+  readMessagesSnapshot(sessionId: string): Promise<StoredMessage[]>;
+  /** Read messages for startup recovery, rejecting durable JSONL corruption. */
+  readMessagesForRecovery(sessionId: string): Promise<StoredMessage[]>;
+  /** Derive durable turns without triggering connection-lock self-healing. */
+  listTurnsSnapshot(sessionId: string): Promise<TurnRecord[]>;
   readHeader(sessionId: string): Promise<SessionHeader>;
   readMessages(sessionId: string): Promise<StoredMessage[]>;
   listTurns(sessionId: string): Promise<TurnRecord[]>;
@@ -114,7 +122,7 @@ class FileSessionStore implements SessionStore {
   async list(filter?: SessionListFilter): Promise<SessionSummary[]> {
     let entries;
     try {
-      entries = await import('node:fs/promises').then((fs) => fs.readdir(this.sessionsRoot, { withFileTypes: true }));
+      entries = await readdir(this.sessionsRoot, { withFileTypes: true });
     } catch (error) {
       if ((error as NodeJS.ErrnoException).code === 'ENOENT') return [];
       throw error;
@@ -175,6 +183,24 @@ class FileSessionStore implements SessionStore {
     return summaries;
   }
 
+  async listForRecovery(): Promise<SessionHeader[]> {
+    let entries;
+    try {
+      entries = await readdir(this.sessionsRoot, { withFileTypes: true });
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') return [];
+      throw error;
+    }
+    const headers: SessionHeader[] = [];
+    for (const entry of entries) {
+      if (!entry.isDirectory() || !isSafeSessionId(entry.name)) {
+        throw new Error(`Invalid Session entry: ${entry.name}`);
+      }
+      headers.push(await this.readHeaderOnly(entry.name));
+    }
+    return headers.sort((a, b) => a.id.localeCompare(b.id));
+  }
+
   async readHeader(sessionId: string): Promise<SessionHeader> {
     const { header, messages } = await this.readFileParts(sessionId);
     if (!header.connectionLocked && messages.some((message) => message.type === 'user')) {
@@ -195,6 +221,18 @@ class FileSessionStore implements SessionStore {
     return messages;
   }
 
+  async readMessagesSnapshot(sessionId: string): Promise<StoredMessage[]> {
+    return (await this.readFileParts(sessionId)).messages;
+  }
+
+  async readMessagesForRecovery(sessionId: string): Promise<StoredMessage[]> {
+    return (await this.readFilePartsUnlocked(sessionId, true)).messages;
+  }
+
+  async listTurnsSnapshot(sessionId: string): Promise<TurnRecord[]> {
+    return deriveTurnRecords(await this.readMessagesSnapshot(sessionId));
+  }
+
   async listTurns(sessionId: string): Promise<TurnRecord[]> {
     return deriveTurnRecords(await this.readMessages(sessionId));
   }
@@ -206,9 +244,8 @@ class FileSessionStore implements SessionStore {
   async appendMessages(sessionId: string, messages: StoredMessage[]): Promise<void> {
     if (messages.length === 0) return;
     await this.withQueue(sessionId, async () => {
-      await mkdir(this.sessionDir(sessionId), { recursive: true });
       const payload = messages.map((message) => JSON.stringify(message)).join('\n') + '\n';
-      await import('node:fs/promises').then((fs) => fs.appendFile(this.sessionPath(sessionId), payload, 'utf8'));
+      await appendJsonl(this.sessionPath(sessionId), payload, { requireExistingRecord: true });
     });
   }
 
@@ -352,7 +389,10 @@ class FileSessionStore implements SessionStore {
     return this.readFilePartsUnlocked(sessionId);
   }
 
-  private async readFilePartsUnlocked(sessionId: string): Promise<{ header: SessionHeader; messages: StoredMessage[] }> {
+  private async readFilePartsUnlocked(
+    sessionId: string,
+    strict = false,
+  ): Promise<{ header: SessionHeader; messages: StoredMessage[] }> {
     const text = await readFile(this.sessionPath(sessionId), 'utf8');
     const rawLines = text.split('\n');
     const endsWithNewline = text.endsWith('\n');
@@ -368,6 +408,10 @@ class FileSessionStore implements SessionStore {
         messages.push(normalizeStoredMessageForRead(JSON.parse(entry.line)));
       } catch (error) {
         if (!endsWithNewline && entry.lineNumber === lastLineNumber) continue;
+        if (strict) {
+          const detail = error instanceof Error ? error.message : String(error);
+          throw new Error(`Session ${sessionId} has a corrupt JSONL record at line ${entry.lineNumber}: ${detail}`);
+        }
         messages.push(createJsonlCorruptionNote(header, entry.lineNumber, error));
       }
     }

--- a/packages/storage/src/session-store.ts
+++ b/packages/storage/src/session-store.ts
@@ -2,16 +2,14 @@ import { mkdir, open, readFile, readdir, rename, rm, writeFile } from 'node:fs/p
 import { dirname, join } from 'node:path';
 import { randomUUID } from 'node:crypto';
 import { setTimeout as delay } from 'node:timers/promises';
-import { appendJsonl } from './jsonl-append.js';
-import { chainWrite } from './write-queue.js';
 import {
-  deriveTurnRecords,
-  isPermissionMode,
-  isSessionBlockedReason,
-  isSessionStatus,
-  normalizeShellToolResultContent,
-  normalizeUserSessionName,
-} from '@maka/core';
+  decodeStoredMessageForRead,
+  decodeStoredMessageForRecovery,
+} from './execution-record-codec.js';
+import { appendJsonl } from './jsonl-append.js';
+import { classifyJsonRecord } from './json-prefix.js';
+import { chainWrite } from './write-queue.js';
+import { deriveTurnRecords, isPermissionMode, isSessionBlockedReason, isSessionStatus, normalizeUserSessionName } from '@maka/core';
 import type {
   CreateSessionInput,
   SessionHeader,
@@ -132,7 +130,11 @@ class FileSessionStore implements SessionStore {
     // list() proportional to the number of sessions rather than full
     // transcript size, while preserving sidebar previews and timestamp
     // fallback for sessions outside the top few.
-    const withHeaders: Array<{ id: string; header: SessionHeader; previewMessages: StoredMessage[] }> = [];
+    const withHeaders: Array<{
+      id: string;
+      header: SessionHeader;
+      previewMessages: StoredMessage[];
+    }> = [];
     for (const entry of entries) {
       if (!entry.isDirectory()) continue;
       if (!isSafeSessionId(entry.name)) continue;
@@ -245,7 +247,9 @@ class FileSessionStore implements SessionStore {
     if (messages.length === 0) return;
     await this.withQueue(sessionId, async () => {
       const payload = messages.map((message) => JSON.stringify(message)).join('\n') + '\n';
-      await appendJsonl(this.sessionPath(sessionId), payload, { requireExistingRecord: true });
+      await appendJsonl(this.sessionPath(sessionId), payload, {
+        requireExistingRecord: true,
+      });
     });
   }
 
@@ -280,7 +284,12 @@ class FileSessionStore implements SessionStore {
 
   async archive(sessionId: string): Promise<void> {
     const now = Date.now();
-    await this.updateHeader(sessionId, { isArchived: true, archivedAt: now, status: 'archived', statusUpdatedAt: now });
+    await this.updateHeader(sessionId, {
+      isArchived: true,
+      archivedAt: now,
+      status: 'archived',
+      statusUpdatedAt: now,
+    });
   }
 
   async unarchive(sessionId: string): Promise<void> {
@@ -374,7 +383,7 @@ class FileSessionStore implements SessionStore {
       for (const line of completeLines) {
         if (line.trim().length === 0) continue;
         try {
-          messages.push(normalizeStoredMessageForRead(JSON.parse(line)));
+          messages.push(decodeStoredMessageForRead(JSON.parse(line)));
         } catch {
           // Tail previews are best-effort; full reads still surface durable corruption notes.
         }
@@ -404,10 +413,25 @@ class FileSessionStore implements SessionStore {
     const messages: StoredMessage[] = [];
     const lastLineNumber = lines.at(-1)?.lineNumber;
     for (const entry of lines.slice(1)) {
+      let parsed: unknown;
       try {
-        messages.push(normalizeStoredMessageForRead(JSON.parse(entry.line)));
+        parsed = JSON.parse(entry.line);
       } catch (error) {
-        if (!endsWithNewline && entry.lineNumber === lastLineNumber) continue;
+        if (!endsWithNewline && entry.lineNumber === lastLineNumber && classifyJsonRecord(entry.line) === 'incomplete-prefix') continue;
+        if (strict) {
+          const detail = error instanceof Error ? error.message : String(error);
+          throw new Error(`Session ${sessionId} has a corrupt JSONL record at line ${entry.lineNumber}: ${detail}`);
+        }
+        messages.push(createJsonlCorruptionNote(header, entry.lineNumber, error));
+        continue;
+      }
+      try {
+        messages.push(
+          strict
+            ? decodeStoredMessageForRecovery(parsed)
+            : decodeStoredMessageForRead(parsed),
+        );
+      } catch (error) {
         if (strict) {
           const detail = error instanceof Error ? error.message : String(error);
           throw new Error(`Session ${sessionId} has a corrupt JSONL record at line ${entry.lineNumber}: ${detail}`);
@@ -448,14 +472,6 @@ async function replaceFileWithWindowsReaderRetry(tempPath: string, path: string)
       await delay(attempt * 10);
     }
   }
-}
-
-function normalizeStoredMessageForRead(value: unknown): StoredMessage {
-  const message = value as StoredMessage;
-  if (!value || typeof value !== 'object' || Array.isArray(value) || message.type !== 'tool_result') return message;
-  const normalized = normalizeShellToolResultContent(message.content);
-  if (normalized.state === 'invalid') throw new Error('Invalid shell tool result content');
-  return normalized.state === 'valid' ? { ...message, content: normalized.content } : message;
 }
 
 /** Shared guard for stores that derive filesystem paths from a session id. */

--- a/packages/storage/src/stable-storage.ts
+++ b/packages/storage/src/stable-storage.ts
@@ -1,0 +1,39 @@
+import { open } from 'node:fs/promises';
+import { dirname, isAbsolute, relative, resolve, sep } from 'node:path';
+
+export async function syncFile(path: string): Promise<void> {
+  const handle = await open(path, 'r');
+  try {
+    await handle.sync();
+  } finally {
+    await handle.close();
+  }
+}
+
+export async function syncDirectoryChain(path: string, root: string): Promise<void> {
+  const boundary = resolve(root);
+  let current = resolve(path);
+  const pathFromBoundary = relative(boundary, current);
+  if (
+    pathFromBoundary === '..' ||
+    pathFromBoundary.startsWith(`..${sep}`) ||
+    isAbsolute(pathFromBoundary)
+  ) {
+    throw new Error(`Durability path escapes workspace root: ${path}`);
+  }
+  while (true) {
+    await syncDirectory(current);
+    if (current === boundary) return;
+    current = dirname(current);
+  }
+}
+
+export async function syncDirectory(path: string): Promise<void> {
+  if (process.platform === 'win32') return;
+  const handle = await open(path, 'r');
+  try {
+    await handle.sync();
+  } finally {
+    await handle.close();
+  }
+}


### PR DESCRIPTION
<details open>
<summary><strong>English</strong></summary>

## Summary

Part of #853. Builds on #1154.

M2 proves that the single-owner Runtime Host can execute and recover one real Session/Turn vertical slice in an isolated Interactive root:

- Session, AgentRun, RuntimeEvent, and root-Turn admission writes are bound to the Interactive owner lease;
- `host.status`, `turn.start`, `turn.query`, and `turn.stop` form a closed typed operation surface;
- a pure-Node Host composition owns execution draining, residency, shutdown, and strict startup recovery;
- real child-process tests use the native owner lock, local transport, real file-backed Stores, and the existing deterministic backend.

This remains a test-only execution slice. The production Candidate is still the non-serving M1 Host, and this PR does not migrate any Desktop, TUI, CLI, Bot, Gateway, Headless, Shell/PTY, scheduler, or other Runtime-owned production path.

## Execution contract

```text
turn.start
  -> durable admission
  -> durable Run start barrier
  -> Host-owned execution and drain
  -> one canonical terminal fact
```

- **Admission** is the durable point at which the Host accepts responsibility for a Session-scoped `turnId`. It is committed before any UserMessage or Run side effect.
- **The start barrier** is reached only after the Run and `run_started` fact are durable and the Host has acquired execution residency with an active drainer. A successful `turn.start` response cannot precede that barrier.
- **A terminal fact** is the single durable and internally consistent `completed`, `failed`, or `cancelled` outcome for one Run. A terminal RuntimeEvent alone is not authoritative until the corresponding durable Run state agrees. This closes the Run lifecycle; it does not manufacture certainty for an in-flight domain side effect whose commit cannot be proven. Such a domain still follows the explicit uncertain-outcome contract in #853.
- **Client transport lifetime is not execution lifetime.** Disconnecting the initiating Client releases that connection but does not cancel the admitted Turn or release its execution residency.

## Key decisions

- **Semantic retry is domain-owned.** `requestId` provides wire correlation only. Retrying the same `turnId` with the same normalized input returns the original `runId`; reusing it with different input returns `operation_conflict`; another active root Turn in the Session returns `session_busy`. No in-memory response cache or generic RPC transaction journal is introduced.
- **Recovery closes accepted crash windows without replay.** A Host may die after accepting a Turn or durably starting a Run but before its terminal projection is complete. Before Ready, the successor validates every canonical Session, admission, Run, operational-event, and RuntimeEvent ledger, then follows only what those durable facts prove:

| Durable state | Startup behavior |
| --- | --- |
| No admission | No accepted operation exists |
| Admission without a Run | Resume the same Turn with its preallocated identities |
| Run without a provable terminal outcome | Restore admission-derived data when safe, then record exactly one failed `app_restarted` outcome rather than replaying execution |
| One provable terminal outcome with an incomplete projection | Preserve that outcome and reconcile the missing projection |
| Conflicting, malformed, or otherwise unclassifiable durable state | Fail closed and do not become Ready |

  Only an unterminated final JSON value whose syntax is still incomplete and could become valid by appending bytes is treated as a crash tail. A complete, schema-invalid, or identity-mismatched record is retained and blocks recovery, whether or not it ends with a newline.
- **Wire semantics advance independently.** The operation protocol moves to v2 because M2 replaces the M1 status-frame semantics. Registration remains v1 because its schema is unchanged, and no dual codec is added before production cutover.
- **Strict recovery decodes durable facts instead of casting them.** Core owns the canonical Session-message, AgentRun, RuntimeEvent, and nested tool-result decoders; Storage adds only expected-path identity checks. This keeps producer and recovery schemas aligned and fails closed on every complete unidentifiable fact.
- **Durability is selective and Store-owned.** Required Run-start and terminal writes cross file and necessary directory sync barriers before acknowledgement. Partial and trace writes do not pay that cost, and a terminal RuntimeEvent sync failure cannot be hidden by tolerance for a later projection failure.
- **Ownership closes in one order.** Closing the owner lease rejects new Store admission and waits for admitted writes. Host shutdown then stops and drains active Turns, waits for execution residency to clear, and releases the OS owner lock last.
- **The operation plane stays closed.** One descriptor registry drives runtime validation, typed Client methods, dispatcher signatures, and each operation's allowed errors. It does not expose generic Store methods, object access, or arbitrary JSON-RPC.
- **Production ownership does not move early.** The execution composition is reachable only from an explicit isolated-test Candidate. The existing production connect-or-spawn path remains non-serving until the atomic cutover milestone in #853.

## Verification

- Real-process gates prove two-Client ownership and disconnect behavior, exactly-once Host-death recovery, and response-loss semantic retry.
- Additional process gates cover admission without Run, Run without UserMessage, graceful shutdown, archived Sessions, pre-start durable-write failure, JSONL crash tails, and complete malformed ledgers.
- Root `npm run lint`, `npm run typecheck`, `npm run build`, and `npm run check:stale` pass.
- Root script tests and the serial workspace test runner pass; the latter ends with `All workspace tests passed.`
- `@maka/storage`: 346 passing, 1 existing Windows-only skip.
- `@maka/runtime`: 2105 passing, 7 existing skips.
- `@maka/runtime-host`: 45 passing.
- The default parallel `npm test` passes the M2 suites. On this machine, two pre-existing CLI shutdown tests can hit their external 5-second SIGKILL watchdog under full parallel load; both pass against the same build in the serial full-workspace run.

## Review focus

- Whether admission and the start barrier leave any crash window that can duplicate or orphan a side effect.
- Whether recovery resumes only pre-execution work, preserves every provable terminal outcome, and fails closed when durable state cannot prove one consistent outcome.
- Whether Store draining, execution residency, composition shutdown, and owner-lock release have one deadlock-free ordering.
- Whether the closed operation registry and test-only composition preserve the protocol and atomic-cutover boundaries of #853.

</details>

<details>
<summary><strong>简体中文</strong></summary>

## 概要

属于 #853 的一部分，建立在 #1154 之上。

M2 用隔离的 Interactive root 证明 single-owner Runtime Host 可以执行和恢复一条真实 Session/Turn vertical slice：

- Session、AgentRun、RuntimeEvent 与 root-Turn admission 写入均受 Interactive owner lease 约束；
- `host.status`、`turn.start`、`turn.query` 与 `turn.stop` 构成封闭的 typed operation surface；
- pure-Node Host composition 持有 execution drain、residency、shutdown 与 strict startup recovery；
- 真实子进程测试使用 native owner lock、local transport、真实 file-backed Store 和现有 deterministic backend。

这仍是 test-only execution slice。Production Candidate 继续使用 M1 non-serving Host；本 PR 不迁移 Desktop、TUI、CLI、Bot、Gateway、Headless、Shell/PTY、scheduler 或其它 Runtime-owned production path。

## 执行契约

```text
turn.start
  -> durable admission
  -> durable Run start barrier
  -> Host-owned execution and drain
  -> one canonical terminal fact
```

- **Admission** 是 Host 对 Session-scoped `turnId` 承担责任的持久化时点，提交顺序早于任何 UserMessage 或 Run 副作用。
- **Start barrier** 只有在 Run 与 `run_started` fact 已 durable，并且 Host 已取得 execution residency、启动 drainer 后才成立；成功的 `turn.start` response 不能早于该 barrier。
- **Terminal fact** 是一个 Run 唯一、持久且内部一致的 `completed`、`failed` 或 `cancelled` 结果。单独的 terminal RuntimeEvent 只有在对应 durable Run 状态一致后才构成权威事实。它只关闭 Run 的生命周期，不会凭空确认某个进行中的领域副作用是否已经提交；无法证明 commit 的领域仍遵循 #853 中显式 uncertain outcome 的契约。
- **Client transport lifetime 不等于 execution lifetime。** 发起 Client 断开只释放该连接，不会取消已 admitted Turn，也不会释放其 execution residency。

## 关键决策

- **Semantic retry 由领域状态负责。** `requestId` 只做 wire correlation。相同 `turnId` 与相同 normalized input 的重试返回原 `runId`；相同 identity 携带不同 input 返回 `operation_conflict`；Session 中存在另一个 active root Turn 时返回 `session_busy`。实现不引入内存 response cache 或 generic RPC transaction journal。
- **Recovery 在不重放 execution 的前提下关闭已接纳的 crash window。** Host 可能在接纳 Turn 或持久化 Run start 之后、terminal projection 完成之前死亡。Successor 在 Ready 前验证所有 canonical Session、admission、Run、operational-event 与 RuntimeEvent ledger，并且只依据这些 durable fact 可以证明的内容处理：

| Durable state | Startup behavior |
| --- | --- |
| 不存在 admission | 不存在已接纳操作 |
| 只有 admission，没有 Run | 使用预分配 identity 恢复同一个 Turn |
| Run 存在，但没有可证明的 terminal outcome | 在安全时恢复 admission-derived data，再写入唯一 failed `app_restarted` outcome，不重放旧 execution |
| 存在唯一可证明的 terminal outcome，但 projection 不完整 | 保留原 outcome，并补齐缺失 projection |
| durable state 冲突、malformed 或无法分类 | fail closed，不进入 Ready |

  只有位于文件末尾、未换行、JSON 语法仍未完成并且可以通过继续追加字节变为合法值的记录，才会被视为 crash tail。完整但 schema 非法或 identity 不匹配的记录，无论是否以换行结尾，都会被保留并阻止 recovery。
- **Wire 语义独立升级。** M2 替换了 M1 status frame 的语义，因此 operation protocol 升为 v2；registration schema 没有变化，继续保持 v1。Production cutover 前不增加双 codec。
- **Strict recovery 解码 durable fact，而不是用类型断言穿过边界。** Core 持有 canonical Session message、AgentRun、RuntimeEvent 与嵌套 tool result decoder；Storage 只增加 expected-path identity 校验。这样 producer 与 recovery 使用同一 schema，任何完整但无法识别的事实都会 fail closed。
- **Durability 由 Store 持有，并且只用于必要写入。** Required Run start 与 terminal write 必须在 acknowledgement 前跨过 file sync 和必要的 directory sync barrier；partial 与 trace write 不承担这项成本。Terminal RuntimeEvent 的 sync failure 也不能被后续 projection failure 的容错吞掉。
- **Ownership 只按一个顺序关闭。** Owner lease 关闭时先拒绝新的 Store admission，并等待 admitted write。Host shutdown 随后 stop/drain active Turn，等待 execution residency 清空，最后释放 OS owner lock。
- **Operation plane 保持封闭。** 同一个 descriptor registry 驱动 runtime validation、typed Client method、dispatcher signature 与每个 operation 允许返回的 error，不暴露 generic Store method、内部对象或任意 JSON-RPC。
- **Production ownership 不提前迁移。** Execution composition 只能从显式的 isolated-test Candidate 到达；现有 production connect-or-spawn 路径在 #853 的 atomic cutover milestone 前仍是 non-serving。

## 验证

- 真实进程 gate 证明 two-Client ownership 与断线行为、Host-death exactly-once recovery，以及 response-loss semantic retry。
- 其它进程 gate 覆盖 admission without Run、Run without UserMessage、graceful shutdown、archived Session、start 前 durable-write failure、JSONL crash tail 与完整 malformed ledger。
- 根级 `npm run lint`、`npm run typecheck`、`npm run build` 与 `npm run check:stale` 通过。
- 根级 script test 与串行 workspace test runner 均通过；后者最终输出 `All workspace tests passed.`。
- `@maka/storage`：346 项通过，1 项既有 Windows-only skip。
- `@maka/runtime`：2105 项通过，7 项既有 skip。
- `@maka/runtime-host`：45 项通过。
- 默认并行 `npm test` 中 M2 suite 通过。在本机全仓并行负载下，两个既有 CLI shutdown 测试可能触发外层 5 秒 SIGKILL watchdog；它们使用同一构建产物执行串行全 workspace 测试时均通过。

## 建议审查重点

- admission 与 start barrier 是否仍留下可能重复或遗弃副作用的 crash window。
- recovery 是否只恢复 execution 开始前的工作、保留所有可证明的 terminal outcome，并在 durable state 无法证明唯一一致 outcome 时 fail closed。
- Store draining、execution residency、composition shutdown 与 owner-lock release 是否只有一种无死锁的顺序。
- closed operation registry 与 test-only composition 是否保持 #853 的 protocol 和 atomic-cutover 边界。

</details>
