### PR TITLE
feat: add Kimi K3 coding plan support

### DIFF
--- a/packages/core/src/__tests__/llm-connections.test.ts
+++ b/packages/core/src/__tests__/llm-connections.test.ts
@@ -227,6 +227,13 @@ describe('provider compatibility contract', () => {
     assert.deepEqual(PROVIDER_REGISTRY['openai-codex'].modelDiscovery, { kind: 'protocol', auth: 'openai-codex' });
   });
 
+  it('offers K3 first for Kimi Coding Plan while preserving the existing legacy alias', () => {
+    assert.deepEqual(PROVIDER_REGISTRY['kimi-coding-plan'].fallbackModels, [
+      'k3',
+      'kimi-for-coding',
+    ]);
+  });
+
   it('owns OpenCode Zen and Go as distinct mixed-protocol access paths', () => {
     const providers = PROVIDER_REGISTRY as Partial<Record<string, (typeof PROVIDER_REGISTRY)[keyof typeof PROVIDER_REGISTRY]>>;
     const zen = providers.opencode;

--- a/packages/core/src/__tests__/model-metadata.test.ts
+++ b/packages/core/src/__tests__/model-metadata.test.ts
@@ -4,6 +4,18 @@ import { lookupModelMetadata, openAiAdapterApiProtocol, resolveModelVisionSuppor
 import { PROVIDER_DEFAULTS, type ModelInfo, type ProviderType } from '../llm-connections.js';
 
 describe('model-metadata vision capability', () => {
+  it('publishes the Kimi K3 Coding Plan limits and sole supported effort', () => {
+    assert.deepEqual(lookupModelMetadata('kimi-coding-plan', 'k3'), {
+      displayName: 'Kimi K3',
+      lifecycle: 'active',
+      docsUrl: 'https://www.kimi.com/code/docs/en/kimi-code/models.html',
+      contextWindow: 1_048_576,
+      maxOutputTokens: 131_072,
+      capabilities: { reasoning: true, functionCalling: true, vision: true },
+      thinkingOptions: { efforts: ['max'] },
+    });
+  });
+
   it('uses Volcengine Coding Plan model facts for its exact fallback allowlist', () => {
     for (const modelId of PROVIDER_DEFAULTS['volcengine-coding-plan'].fallbackModels) {
       assert.equal(

--- a/packages/core/src/model-metadata.ts
+++ b/packages/core/src/model-metadata.ts
@@ -275,6 +275,15 @@ const STATIC_MODEL_METADATA: Partial<Record<ProviderType, Record<string, ModelMe
     'glm-4.5-air': { thinkingOptions: { toggle: true } },
   },
   'kimi-coding-plan': {
+    k3: {
+      displayName: 'Kimi K3',
+      lifecycle: 'active',
+      docsUrl: 'https://www.kimi.com/code/docs/en/kimi-code/models.html',
+      contextWindow: 1_048_576,
+      maxOutputTokens: 131_072,
+      capabilities: { ...REASONING_FUNCTION_CALLING, vision: true },
+      thinkingOptions: { efforts: ['max'] },
+    },
     'kimi-for-coding': { displayName: 'Kimi for Coding', lifecycle: 'active', docsUrl: 'https://www.kimi.com/code/docs/en/', contextWindow: 262_144, maxOutputTokens: 32_768, capabilities: { ...REASONING_FUNCTION_CALLING, vision: true } },
     'kimi-for-coding-highspeed': { displayName: 'Kimi for Coding (HighSpeed)', lifecycle: 'active', docsUrl: 'https://www.kimi.com/code/docs/en/', contextWindow: 262_144, maxOutputTokens: 32_768, capabilities: { ...REASONING_FUNCTION_CALLING, vision: true } },
   },

--- a/packages/core/src/provider-registry.ts
+++ b/packages/core/src/provider-registry.ts
@@ -525,7 +525,7 @@ const providerRegistry = {
     baseUrl: 'https://api.kimi.com/coding/v1',
     authKind: 'api_key',
     backendKind: 'ai-sdk',
-    fallbackModels: ['kimi-for-coding'],
+    fallbackModels: ['k3', 'kimi-for-coding'],
     status: 'ready',
     protocol: 'anthropic',
     runtimeAdapter: { kind: 'anthropic', auth: 'api-key', normalizeBaseUrl: true },

--- a/packages/runtime/src/__tests__/computer-use-provider-protocol.test.ts
+++ b/packages/runtime/src/__tests__/computer-use-provider-protocol.test.ts
@@ -30,6 +30,15 @@ describe('Anthropic-compatible Computer Use product loops', () => {
       baseSuffix: '/coding',
       expectedPath: '/coding/v1/messages',
       auth: 'x-api-key',
+      expectedThinking: 'enabled',
+    },
+    {
+      providerType: 'kimi-coding-plan',
+      modelId: 'k3',
+      baseSuffix: '/coding',
+      expectedPath: '/coding/v1/messages',
+      auth: 'x-api-key',
+      expectedThinking: 'adaptive',
     },
     {
       providerType: 'minimax-coding-plan',
@@ -37,9 +46,10 @@ describe('Anthropic-compatible Computer Use product loops', () => {
       baseSuffix: '/anthropic',
       expectedPath: '/anthropic/v1/messages',
       auth: 'x-api-key',
+      expectedThinking: undefined,
     },
   ] as const) {
-    test(`${provider.providerType} completes a multi-step semantic model loop`, async () => {
+    test(`${provider.providerType}/${provider.modelId} completes a multi-step semantic model loop`, async () => {
       const requestBodies: Array<Record<string, unknown>> = [];
       const server = await startJsonServer(async (request, response) => {
         assert.equal(request.method, 'POST');
@@ -129,12 +139,12 @@ describe('Anthropic-compatible Computer Use product loops', () => {
         (requestBodies[0].tools as Array<{ name: string }>).map((tool) => tool.name),
         ['maka_computer'],
       );
-      if (provider.providerType === 'kimi-coding-plan') {
+      if (provider.expectedThinking) {
         for (const body of requestBodies) {
           assert.equal(
             (body.thinking as { type?: string } | undefined)?.type,
-            'enabled',
-            'Kimi Coding Plan must enable thinking on every turn',
+            provider.expectedThinking,
+            'Kimi Coding Plan must send its model-specific thinking mode on every turn',
           );
           assert.deepEqual(body.output_config, { effort: 'max' });
         }
@@ -153,7 +163,7 @@ describe('Anthropic-compatible Computer Use product loops', () => {
       );
     });
 
-    test(`${provider.providerType} reinjects a failed semantic action as an error tool result`, async () => {
+    test(`${provider.providerType}/${provider.modelId} reinjects a failed semantic action as an error tool result`, async () => {
       const requestBodies: Array<Record<string, unknown>> = [];
       const server = await startJsonServer(async (request, response) => {
         assert.equal(request.method, 'POST');

--- a/packages/runtime/src/__tests__/model-factory-thinking.test.ts
+++ b/packages/runtime/src/__tests__/model-factory-thinking.test.ts
@@ -34,6 +34,13 @@ describe('buildProviderOptions: thinking level', () => {
     assert.deepEqual(buildProviderOptions(conn('anthropic'), 'claude-opus-4-8', 'off'), { anthropic: {} });
   });
 
+  test('Kimi K3 always sends its required adaptive thinking at max effort', () => {
+    assert.deepEqual([...thinkingVariantsForModel('kimi-coding-plan', 'k3')], ['max']);
+    const expected = { anthropic: { thinking: { type: 'adaptive' }, effort: 'max' } };
+    assert.deepEqual(buildProviderOptions(conn('kimi-coding-plan'), 'k3'), expected);
+    assert.deepEqual(buildProviderOptions(conn('kimi-coding-plan'), 'k3', 'max'), expected);
+  });
+
   test('openai gpt-5.5 sends reasoningEffort (none for off, max for max); gpt-4o drops level', () => {
     assert.deepEqual(buildProviderOptions(conn('openai'), 'gpt-4o', 'high'), { openai: { store: false } });
     assert.deepEqual(buildProviderOptions(conn('openai'), 'gpt-5.5', 'medium'), { openai: { store: false, reasoningEffort: 'medium' } });

--- a/packages/runtime/src/model-factory.ts
+++ b/packages/runtime/src/model-factory.ts
@@ -273,7 +273,14 @@ export function buildProviderOptions(
   switch (connection.providerType) {
     case 'kimi-coding-plan':
       return {
-        anthropic: modelId === 'kimi-for-coding'
+        anthropic: modelId === 'k3'
+          ? {
+              // K3 supports adaptive thinking only and currently fixes effort
+              // at max on Kimi Coding Plan.
+              thinking: { type: 'adaptive' as const },
+              effort: 'max',
+            }
+          : modelId === 'kimi-for-coding'
           ? {
               // Kimi's managed coding route requires enabled thinking and max
               // effort. The Anthropic AI SDK also requires a compatibility


### PR DESCRIPTION
## Summary

Add Kimi K3 as the first Kimi Coding Plan model while preserving the existing `kimi-for-coding` fallback.

Publish K3's 1,048,576-token context window, 131,072-token output limit, vision/tool/reasoning capabilities, and sole `max` effort. Send K3 through the existing Anthropic-compatible adapter with its required adaptive thinking mode and maximum effort on every turn.

## Verification

- `npm --workspace @maka/core test` (1,069 passed)
- `npm --workspace @maka/runtime test` (2,068 passed, 7 skipped)
- `npm --workspace @maka/core run typecheck`
- `npm --workspace @maka/runtime run typecheck`
- `npx biome lint` on all changed files
- Added an Anthropic wire-level multi-step test covering `/coding/v1/messages`, `x-api-key`, `thinking.type=adaptive`, and `output_config.effort=max`

Live Kimi API validation is intentionally deferred to the benchmark dry run after the product and harness PRs merge.
