### PR TITLE
feat(headless): add pluggable Kimi Code comparison

### DIFF
--- a/packages/headless/README.md
+++ b/packages/headless/README.md
@@ -182,22 +182,21 @@ node packages/headless/harbor/run-terminal-bench-smoke.mjs --profile maka-heavy 
 node packages/headless/harbor/run-terminal-bench-smoke.mjs --compare --task '*sqlite-with-gcov'
 ```
 
-## GLM-5.2 harness comparison
+## K3 harness comparison
 
-`harbor/run-harness-ab.mjs` compares Maka and OpenCode 1.17.18 on the same Terminal-Bench 2.1 tasks with GLM-5.2 Max. The task root must match the 89 task ids and canonical task-tree fingerprint of the frozen official revision; a matching Harbor export with one task directory per id is accepted directly. The A/B task order is frozen independently of Oracle evidence. Maka keeps active and stale tool-result pruning enabled while semantic compact is explicitly disabled in both the manifest and runtime environment.
+`harbor/run-harness-ab.mjs` compares Maka with the official Kimi Code 0.26.0 CLI on Kimi K3 Max. Set `MAKA_HARNESS_AB_COMPETITOR=opencode` to select the pinned OpenCode 1.17.18 arm instead. The task root must match the 89 task ids and canonical task-tree fingerprint of the frozen official Terminal-Bench 2.1 revision; a matching export with one task directory per id is accepted directly. The A/B task order is frozen independently of Oracle evidence. Maka keeps active and stale tool-result pruning enabled while semantic compact is explicitly disabled in both the manifest and runtime environment.
 
 Validate the frozen task source and preview the A/B plan without reading a key or starting Harbor:
 
 ```sh
 MAKA_HARNESS_AB_OUT_DIR=/path/to/out \
 MAKA_HARNESS_AB_TASKS_ROOT=/path/to/terminal-bench-2.1-tasks \
-MAKA_HARNESS_AB_RUN_ID=glm-5.2-harness-ab \
-MAKA_HARNESS_AB_LIMIT=30 \
+MAKA_HARNESS_AB_LIMIT=5 \
 MAKA_HARNESS_AB_DRY_RUN=1 \
 node packages/headless/harbor/run-harness-ab.mjs
 ```
 
-For a live run, remove `MAKA_HARNESS_AB_DRY_RUN` and set `MAKA_HARNESS_AB_KEY_FILE` to a credential file outside git. Maka reads it in its host-side cell; OpenCode receives only a short-lived host proxy capability, never the provider key or key-file path. `MAKA_HARNESS_AB_LIMIT=2` runs an operational canary, `30` runs the deterministic pilot prefix, and `89` runs the complete frozen profile. Only missing cells run. The immutable manifest rejects configuration changes.
+For a live run, remove `MAKA_HARNESS_AB_DRY_RUN` and set `MAKA_HARNESS_AB_KEY_FILE` to a credential file outside git. Both arms receive only a short-lived host proxy capability, never the provider key or key-file path. `MAKA_HARNESS_AB_LIMIT=5` runs the operational canary; rerun the same run id with `89` to continue the same WAL through the complete frozen profile. Four task pairs run concurrently, for at most eight active attempts. Only missing cells run, and the immutable manifest rejects configuration changes.
 
 Oracle evidence is advisory. To consume a CI-issued registry snapshot, set both `MAKA_HARNESS_AB_ORACLE_REGISTRY_URL` and `MAKA_HARNESS_AB_ORACLE_REGISTRY_FINGERPRINT`. The runner downloads the lightweight pinned snapshot, validates its content and per-task identities, and records `passed`, `failed`, `timed_out`, `infra_failed`, `stale`, or `missing` annotations in the manifest and report. Missing, stale, failed, unavailable, invalid, or unresolvable evidence emits warnings but never invokes Oracle, changes task selection, blocks new A/B execution, or changes statistical inclusion. A resumed run reuses the advisory snapshot frozen in its existing manifest instead of resolving current registry state again. Legacy manifests retain their historical Oracle-gated `qualification` metadata as read-only history; the current runner does not append new cells to a run created by the old qualification profile.
 
@@ -205,7 +204,7 @@ The manual `.github/workflows/oracle-evidence-audit.yml` workflow is the only CI
 
 For an unattended run, invoke `node packages/headless/harbor/run-harness-ab-detached.mjs` with the same environment. It detaches the worker from the terminal and atomically journals `running`, `completed`, or `failed` in `background-run.json`; stdout and stderr go to `background-run.log`.
 
-Outputs are `harness-ab-report.json`, `.csv`, and `.md`. Report schema v2 records scheduled, attempted, model-scored, unscored (including the infrastructure-failed subset), and missing-final-usage cell coverage while keeping paired Pass@1 and fully metered cache-aware API-equivalent cost on separate denominators. A fully attempted schedule with honest evidence gaps finishes as `completed_with_gaps`; an unattempted suffix remains `incomplete`. Reports do not claim fixed-plan spend or publish results.
+Outputs are `harness-ab-report.json`, `.csv`, and `.md`. Report schema v3 records scheduled, attempted, model-scored, unscored (including the infrastructure-failed subset), and missing-final-usage cell coverage while keeping paired Pass@1 and token economy on separate denominators. Account-plan runs record zero cost and use real token totals as the economy measure. Evidence gaps finish as `completed_with_gaps` and fail the completion assertion; an unattempted suffix remains `incomplete`. Reports do not claim fixed-plan spend or publish results.
 
 ## Attention semantic-compaction A/B
 

--- a/packages/headless/harbor/kimi_code_agent.py
+++ b/packages/headless/harbor/kimi_code_agent.py
@@ -76,7 +76,7 @@ class MakaKimiCodeAgent(BaseInstalledAgent):
                     "mkdir -p /tmp/maka-kimi-code; "
                     f"{shlex.quote(str(_TOOLCHAIN_NODE))} "
                     f"{shlex.quote(str(_TOOLCHAIN_ENTRYPOINT))} "
-                    "--yolo --output-format stream-json --prompt "
+                    "--output-format stream-json --prompt "
                     f"{shlex.quote(instruction)} "
                     f"> {shlex.quote(str(_OUTPUT_PATH))} "
                     "2> /logs/agent/kimi-code.stderr.txt"

--- a/packages/headless/harbor/kimi_code_agent.py
+++ b/packages/headless/harbor/kimi_code_agent.py
@@ -114,25 +114,36 @@ class MakaKimiCodeAgent(BaseInstalledAgent):
             "KIMI_MODEL_THINKING_EFFORT": effort,
         }
 
-    def _events(self) -> list[dict[str, Any]]:
+    def _events(self, *, require_assistant: bool = False) -> list[dict[str, Any]]:
         path = self.logs_dir / _OUTPUT_PATH.name
         if not path.exists():
+            if require_assistant:
+                raise ValueError("Kimi Code stream-json did not contain an assistant message")
             return []
         events = []
-        for line in path.read_text(encoding="utf-8").splitlines():
+        for line_number, line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+            if not line.strip():
+                continue
             try:
                 value = json.loads(line)
-            except json.JSONDecodeError:
+            except json.JSONDecodeError as error:
+                if require_assistant:
+                    raise ValueError(f"Kimi Code stream-json line {line_number} is not valid JSON") from error
                 continue
-            if isinstance(value, dict):
-                events.append(value)
+            if not isinstance(value, dict):
+                if require_assistant:
+                    raise ValueError(f"Kimi Code stream-json line {line_number} must be a JSON object")
+                continue
+            events.append(value)
+        if require_assistant and not any(event.get("role") == "assistant" for event in events):
+            raise ValueError("Kimi Code stream-json did not contain an assistant message")
         return events
 
     def _write_cell_output(self) -> None:
         started_at = getattr(self, "_started_at_ms", int(time.time() * 1000))
         finished_at = getattr(self, "_finished_at_ms", started_at)
         identity = self._execution_identity()
-        events = self._events()
+        events = self._events(require_assistant=not hasattr(self, "_failure_class"))
         tool_call_counts: dict[str, int] = {}
         session_id = "kimi-code"
         for event in events:

--- a/packages/headless/harbor/kimi_code_agent.py
+++ b/packages/headless/harbor/kimi_code_agent.py
@@ -1,0 +1,220 @@
+"""Harbor adapter for the pinned official Kimi Code CLI."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import shlex
+import time
+from pathlib import Path
+from typing import Any
+
+from harbor.agents.installed.base import BaseInstalledAgent, with_prompt_template
+from harbor.environments.base import BaseEnvironment
+from harbor.models.agent.context import AgentContext
+
+_TOOLCHAIN_ROOT = Path("/opt/maka-kimi-code-toolchain")
+_TOOLCHAIN_NODE = _TOOLCHAIN_ROOT / "bin" / "node"
+_TOOLCHAIN_ENTRYPOINT = _TOOLCHAIN_ROOT / "lib" / "kimi-code" / "main.mjs"
+_TOOLCHAIN_MANIFEST = _TOOLCHAIN_ROOT / "manifest.json"
+_TOOLCHAIN_CHECKSUMS = _TOOLCHAIN_ROOT / "checksums.sha256"
+_OUTPUT_PATH = Path("/logs/agent/kimi-code.jsonl")
+
+
+class MakaKimiCodeAgent(BaseInstalledAgent):
+    """Run Kimi Code in deterministic print mode for a single Harbor task."""
+
+    @staticmethod
+    def name() -> str:
+        return "kimi-code"
+
+    def get_version_command(self) -> str | None:
+        return (
+            f"{shlex.quote(str(_TOOLCHAIN_NODE))} "
+            f"{shlex.quote(str(_TOOLCHAIN_ENTRYPOINT))} --version"
+        )
+
+    async def install(self, environment: BaseEnvironment) -> None:
+        expected_fingerprint = self._get_env("MAKA_KIMI_CODE_TOOLCHAIN_FINGERPRINT")
+        if not expected_fingerprint:
+            raise ValueError("MAKA_KIMI_CODE_TOOLCHAIN_FINGERPRINT is required")
+        manifest_check = (
+            "const fs = require('node:fs'); "
+            "const manifest = JSON.parse(fs.readFileSync(process.argv[1], 'utf8')); "
+            "if (manifest.fingerprint !== process.env.MAKA_EXPECTED_TOOLCHAIN_FINGERPRINT) "
+            "throw new Error('Kimi Code toolchain fingerprint mismatch');"
+        )
+        command = (
+            "set -euo pipefail; "
+            'test "$(uname -s)" = Linux; '
+            'test "$(uname -m)" = x86_64; '
+            f"cd {shlex.quote(str(_TOOLCHAIN_ROOT))}; "
+            f"sha256sum --check {shlex.quote(_TOOLCHAIN_CHECKSUMS.name)}; "
+            f"{shlex.quote(str(_TOOLCHAIN_NODE))} -e {shlex.quote(manifest_check)} "
+            f"{shlex.quote(str(_TOOLCHAIN_MANIFEST))}"
+        )
+        await self.exec_as_agent(
+            environment,
+            command=command,
+            env={"MAKA_EXPECTED_TOOLCHAIN_FINGERPRINT": expected_fingerprint},
+        )
+
+    @with_prompt_template
+    async def run(
+        self,
+        instruction: str,
+        environment: BaseEnvironment,
+        context: AgentContext,
+    ) -> None:
+        self._started_at_ms = int(time.time() * 1000)
+        self._write_execution_identity()
+        try:
+            await self.exec_as_agent(
+                environment,
+                command=(
+                    "mkdir -p /tmp/maka-kimi-code; "
+                    f"{shlex.quote(str(_TOOLCHAIN_NODE))} "
+                    f"{shlex.quote(str(_TOOLCHAIN_ENTRYPOINT))} "
+                    "--yolo --output-format stream-json --prompt "
+                    f"{shlex.quote(instruction)} "
+                    f"> {shlex.quote(str(_OUTPUT_PATH))} "
+                    "2> /logs/agent/kimi-code.stderr.txt"
+                ),
+                env=self._runtime_env(),
+            )
+        except Exception as error:
+            self._failure_class = _classify_failure(error)
+            raise
+        finally:
+            self._finished_at_ms = int(time.time() * 1000)
+
+    def populate_context_post_run(self, context: AgentContext) -> None:
+        self._write_cell_output()
+
+    def _runtime_env(self) -> dict[str, str]:
+        proxy_url = self._get_env("MAKA_PROVIDER_PROXY_URL")
+        proxy_token = self._get_env("MAKA_PROVIDER_PROXY_TOKEN")
+        if not proxy_url or not proxy_token:
+            raise ValueError("Kimi Code requires the host provider proxy")
+        model = self._get_env("MAKA_MODEL") or self.model_name
+        if not model:
+            raise ValueError("MAKA_MODEL is required")
+        effort = self._get_env("MAKA_REASONING_EFFORT") or "max"
+        return {
+            "KIMI_CODE_HOME": "/tmp/maka-kimi-code",
+            "KIMI_MODEL_NAME": model,
+            "KIMI_MODEL_API_KEY": proxy_token,
+            "KIMI_MODEL_PROVIDER_TYPE": "kimi",
+            "KIMI_MODEL_BASE_URL": proxy_url,
+            "KIMI_MODEL_MAX_CONTEXT_SIZE": "1048576",
+            "KIMI_MODEL_MAX_OUTPUT_SIZE": "131072",
+            "KIMI_MODEL_MAX_COMPLETION_TOKENS": "131072",
+            "KIMI_MODEL_ADAPTIVE_THINKING": "true",
+            "KIMI_MODEL_THINKING_EFFORT": effort,
+        }
+
+    def _events(self) -> list[dict[str, Any]]:
+        path = self.logs_dir / _OUTPUT_PATH.name
+        if not path.exists():
+            return []
+        events = []
+        for line in path.read_text(encoding="utf-8").splitlines():
+            try:
+                value = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if isinstance(value, dict):
+                events.append(value)
+        return events
+
+    def _write_cell_output(self) -> None:
+        started_at = getattr(self, "_started_at_ms", int(time.time() * 1000))
+        finished_at = getattr(self, "_finished_at_ms", started_at)
+        identity = self._execution_identity()
+        events = self._events()
+        tool_call_counts: dict[str, int] = {}
+        session_id = "kimi-code"
+        for event in events:
+            if event.get("type") == "session.resume_hint" and event.get("session_id"):
+                session_id = str(event["session_id"])
+            tool_calls = event.get("tool_calls")
+            if not isinstance(tool_calls, list):
+                continue
+            for tool_call in tool_calls:
+                function = tool_call.get("function") if isinstance(tool_call, dict) else None
+                name = function.get("name") if isinstance(function, dict) else None
+                if name:
+                    key = str(name)
+                    tool_call_counts[key] = tool_call_counts.get(key, 0) + 1
+        self.logs_dir.mkdir(parents=True, exist_ok=True)
+        runtime_events_path = self.logs_dir / "runtime-events.jsonl"
+        source_path = self.logs_dir / _OUTPUT_PATH.name
+        runtime_events_path.write_text(
+            source_path.read_text(encoding="utf-8") if source_path.exists() else "",
+            encoding="utf-8",
+        )
+        output = {
+            "schemaVersion": 1,
+            "status": "failed" if hasattr(self, "_failure_class") else "completed",
+            **({"errorClass": self._failure_class} if hasattr(self, "_failure_class") else {}),
+            "runtimeEventsPath": "/logs/agent/runtime-events.jsonl",
+            "promptHash": identity["systemPromptHash"],
+            "executionIdentity": identity,
+            "toolSummary": {
+                "providerVisibleToolCount": 0,
+                "actualToolCalls": sum(tool_call_counts.values()),
+                "actualToolNames": sorted(tool_call_counts),
+                "actualToolCallCounts": tool_call_counts,
+            },
+            "steps": sum(1 for event in events if event.get("role") == "assistant"),
+            "durationMs": max(0, finished_at - started_at),
+            "startedAt": started_at,
+            "finishedAt": finished_at,
+            "runtimeRefs": {
+                "invocationId": session_id,
+                "sessionId": session_id,
+                "runId": session_id,
+                "turnId": session_id,
+            },
+        }
+        (self.logs_dir / "maka-cell-output.json").write_text(
+            json.dumps(output, indent=2) + "\n", encoding="utf-8"
+        )
+
+    def _execution_identity(self) -> dict[str, str]:
+        system_prompt = self._get_env("MAKA_SYSTEM_PROMPT") or ""
+        prompt_hash = "sha256:" + hashlib.sha256(
+            json.dumps(system_prompt, ensure_ascii=False, separators=(",", ":")).encode("utf-8")
+        ).hexdigest()
+        effort = self._get_env("MAKA_REASONING_EFFORT")
+        return {
+            "llmConnectionSlug": self._get_env("MAKA_LLM_CONNECTION_SLUG") or "kimi-coding-plan",
+            "model": self._get_env("MAKA_MODEL") or self.model_name or "k3",
+            **({"reasoningEffort": effort} if effort else {}),
+            "systemPromptHash": prompt_hash,
+            "pricingProfile": self._get_env("MAKA_TRIAL_PRICING_SOURCE") or "unconfigured",
+        }
+
+    def _write_execution_identity(self) -> None:
+        self.logs_dir.mkdir(parents=True, exist_ok=True)
+        path = self.logs_dir / "maka-cell-execution-identity.json"
+        with path.open("w", encoding="utf-8") as output:
+            output.write(json.dumps(self._execution_identity(), indent=2) + "\n")
+            output.flush()
+            os.fsync(output.fileno())
+
+
+def _classify_failure(error: Exception) -> str:
+    text = str(error).lower()
+    if any(marker in text for marker in ("401", "403", "unauthorized", "authentication", "invalid api key")):
+        return "auth"
+    if any(marker in text for marker in ("429", "rate limit", "too many requests")):
+        return "rate_limit"
+    if any(marker in text for marker in ("billing", "insufficient credit", "quota exceeded")):
+        return "provider_billing"
+    if any(marker in text for marker in ("connection", "network", "dns", "socket")):
+        return "network"
+    if any(marker in text for marker in ("500", "502", "503", "504", "unavailable")):
+        return "provider_unavailable"
+    return "infra_failed"

--- a/packages/headless/harbor/opencode-benchmark.json
+++ b/packages/headless/harbor/opencode-benchmark.json
@@ -6,6 +6,37 @@
         "apiKey": "{env:ZAI_API_KEY}",
         "baseURL": "{env:ZAI_BASE_URL}"
       }
+    },
+    "kimi-coding-plan": {
+      "npm": "@ai-sdk/anthropic",
+      "name": "Kimi Coding Plan",
+      "options": {
+        "apiKey": "{env:KIMI_API_KEY}",
+        "baseURL": "{env:KIMI_BASE_URL}"
+      },
+      "models": {
+        "k3": {
+          "name": "Kimi K3",
+          "limit": {
+            "context": 1048576,
+            "output": 131072
+          },
+          "options": {
+            "thinking": {
+              "type": "adaptive"
+            },
+            "effort": "max"
+          },
+          "variants": {
+            "max": {
+              "thinking": {
+                "type": "adaptive"
+              },
+              "effort": "max"
+            }
+          }
+        }
+      }
     }
   }
 }

--- a/packages/headless/harbor/opencode_agent.py
+++ b/packages/headless/harbor/opencode_agent.py
@@ -148,8 +148,8 @@ class MakaOpenCodeAgent(OpenCode):
         }
         if provider not in provider_env_names:
             raise ValueError(f"Unsupported Maka OpenCode benchmark provider: {provider}")
-        proxy_url = self._get_env("MAKA_OPENCODE_PROVIDER_PROXY_URL")
-        proxy_token = self._get_env("MAKA_OPENCODE_PROVIDER_PROXY_TOKEN")
+        proxy_url = self._get_env("MAKA_PROVIDER_PROXY_URL")
+        proxy_token = self._get_env("MAKA_PROVIDER_PROXY_TOKEN")
         if not proxy_url or not proxy_token:
             raise ValueError(f"{provider} requires the host provider proxy")
         env = self._provider_env(provider)

--- a/packages/headless/harbor/opencode_agent.py
+++ b/packages/headless/harbor/opencode_agent.py
@@ -142,15 +142,20 @@ class MakaOpenCodeAgent(OpenCode):
             raise ValueError("Model name must be in the format provider/model_name")
 
         provider, _ = self.model_name.split("/", 1)
-        if provider != "zai-coding-plan":
+        provider_env_names = {
+            "zai-coding-plan": ("ZAI_BASE_URL", "ZAI_API_KEY"),
+            "kimi-coding-plan": ("KIMI_BASE_URL", "KIMI_API_KEY"),
+        }
+        if provider not in provider_env_names:
             raise ValueError(f"Unsupported Maka OpenCode benchmark provider: {provider}")
         proxy_url = self._get_env("MAKA_OPENCODE_PROVIDER_PROXY_URL")
         proxy_token = self._get_env("MAKA_OPENCODE_PROVIDER_PROXY_TOKEN")
         if not proxy_url or not proxy_token:
-            raise ValueError("zai-coding-plan requires the host provider proxy")
+            raise ValueError(f"{provider} requires the host provider proxy")
         env = self._provider_env(provider)
-        env["ZAI_BASE_URL"] = proxy_url
-        env["ZAI_API_KEY"] = proxy_token
+        base_url_env, api_key_env = provider_env_names[provider]
+        env[base_url_env] = proxy_url
+        env[api_key_env] = proxy_token
         env["OPENCODE_CONFIG"] = self._opencode_config_path()
         env["OPENCODE_FAKE_VCS"] = "git"
 

--- a/packages/headless/harbor/run-harness-ab-detached.mjs
+++ b/packages/headless/harbor/run-harness-ab-detached.mjs
@@ -7,7 +7,7 @@ import { join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { spawn } from 'node:child_process';
 import { resolveFixedPromptRunRoot } from '#fixed-prompt-task-source';
-import { DEFAULT_HARNESS_AB_RUN_ID } from './run-harness-ab.mjs';
+import { resolveHarnessAbRunId, resolveHarnessCompetitorProfile } from './run-harness-ab.mjs';
 
 const JOURNAL_FILENAME = 'background-run.json';
 const LOG_FILENAME = 'background-run.log';
@@ -20,16 +20,18 @@ function envPath(name) {
 
 function detachedRunPaths() {
   const outDir = envPath('MAKA_HARNESS_AB_OUT_DIR');
-  const runId = process.env.MAKA_HARNESS_AB_RUN_ID || DEFAULT_HARNESS_AB_RUN_ID;
+  const competitorProfile = resolveHarnessCompetitorProfile(process.env.MAKA_HARNESS_AB_COMPETITOR || 'kimi-code');
+  const runId = resolveHarnessAbRunId(competitorProfile, process.env.MAKA_HARNESS_AB_RUN_ID);
   const runRoot = resolveFixedPromptRunRoot(outDir, runId, 'MAKA_HARNESS_AB_RUN_ID');
   return {
+    runId,
     runRoot,
     logPath: join(runRoot, LOG_FILENAME),
   };
 }
 
 async function launchDetached() {
-  const { runRoot, logPath } = detachedRunPaths();
+  const { runId, runRoot, logPath } = detachedRunPaths();
   await mkdir(runRoot, { recursive: true });
   const logFd = openSync(logPath, 'a', 0o600);
   const startedAt = new Date().toISOString();
@@ -40,6 +42,7 @@ async function launchDetached() {
       detached: true,
       env: {
         ...process.env,
+        MAKA_HARNESS_AB_RUN_ID: runId,
         MAKA_HARNESS_AB_BACKGROUND_RUN: '1',
         MAKA_HARNESS_AB_DETACHED_STARTED_AT: startedAt,
       },

--- a/packages/headless/harbor/run-harness-ab.mjs
+++ b/packages/headless/harbor/run-harness-ab.mjs
@@ -396,7 +396,7 @@ async function runLocked({ repoRoot, makaRepoPath, tasksRoot, runId, limit, runR
       : {}),
     annotations: oracleEvidence.annotations.filter((annotation) => evaluatedTaskIds.has(annotation.taskId)),
     warnings: oracleEvidence.warnings,
-  });
+  }, BILLING_MODE);
   await writeFile(join(runRoot, 'harness-ab-report.json'), `${JSON.stringify(report, null, 2)}\n`, 'utf8');
   await writeFile(join(runRoot, 'harness-ab-report.csv'), renderHarnessAbReportCsv(report), 'utf8');
   await writeFile(join(runRoot, 'harness-ab-report.md'), renderHarnessAbReportMarkdown(report), 'utf8');

--- a/packages/headless/harbor/run-harness-ab.mjs
+++ b/packages/headless/harbor/run-harness-ab.mjs
@@ -123,6 +123,13 @@ export function resolveHarnessCompetitorProfile(raw = 'kimi-code') {
   return profile;
 }
 
+export function resolveHarnessAbRunId(competitorProfile, explicitRunId) {
+  return explicitRunId
+    || (competitorProfile.id === 'kimi-code'
+      ? DEFAULT_HARNESS_AB_RUN_ID
+      : `k3-maka-vs-${competitorProfile.id}-tbench-2.1-full-v1`);
+}
+
 function envPath(name, fallback) {
   const raw = process.env[name] || fallback;
   if (!raw) throw new Error(`${name} is required`);
@@ -217,10 +224,7 @@ export async function main() {
   const outDir = envPath('MAKA_HARNESS_AB_OUT_DIR');
   const tasksRoot = envPath('MAKA_HARNESS_AB_TASKS_ROOT', join(homedir(), '.cache/harbor/tasks'));
   const competitorProfile = resolveHarnessCompetitorProfile(process.env.MAKA_HARNESS_AB_COMPETITOR || 'kimi-code');
-  const runId = process.env.MAKA_HARNESS_AB_RUN_ID
-    || (competitorProfile.id === 'kimi-code'
-      ? DEFAULT_HARNESS_AB_RUN_ID
-      : `k3-maka-vs-${competitorProfile.id}-tbench-2.1-full-v1`);
+  const runId = resolveHarnessAbRunId(competitorProfile, process.env.MAKA_HARNESS_AB_RUN_ID);
   const limit = runLimit(process.env.MAKA_HARNESS_AB_LIMIT);
   const runRoot = resolveFixedPromptRunRoot(outDir, runId, 'MAKA_HARNESS_AB_RUN_ID');
   await withHarnessAbRunLock(runRoot, async () => {

--- a/packages/headless/harbor/run-harness-ab.mjs
+++ b/packages/headless/harbor/run-harness-ab.mjs
@@ -95,7 +95,7 @@ export const HARNESS_COMPETITOR_PROFILES = Object.freeze({
     config: Object.freeze({
       adapter: 'kimi_code_agent:MakaKimiCodeAgent',
       outputFormat: 'stream-json',
-      permissions: 'yolo',
+      permissions: 'prompt-auto',
       attemptPolicy: 'single',
       billingMode: BILLING_MODE,
     }),

--- a/packages/headless/harbor/run-harness-ab.mjs
+++ b/packages/headless/harbor/run-harness-ab.mjs
@@ -57,22 +57,23 @@ import {
 const execFileAsync = promisify(execFile);
 
 const EXPECTED_SOURCE_TASKS = TERMINAL_BENCH_2_1_TASK_IDS.length;
-export const DEFAULT_HARNESS_AB_RUN_ID = 'glm-5.2-maka-vs-opencode-tbench-2.1-full-v2';
-const CANARY_TASKS = 2;
-const PILOT_TASKS = 30;
-const PROVIDER = 'zai-coding-plan';
-const MODEL = 'glm-5.2';
+export const DEFAULT_HARNESS_AB_RUN_ID = 'k3-maka-vs-opencode-tbench-2.1-full-v1';
+const CANARY_TASKS = 5;
+const PROVIDER = 'kimi-coding-plan';
+const MODEL = 'k3';
 const MODEL_SPEC = `${PROVIDER}/${MODEL}`;
 const REASONING_EFFORT = 'max';
-const BASE_URL = 'https://api.z.ai/api/coding/paas/v4';
-const ORDER_SEED = 'terminal-bench-2.1:glm-5.2:maka-vs-opencode:v1';
+const BASE_URL = 'https://api.kimi.com/coding/v1';
+const ORDER_SEED = 'terminal-bench-2.1:k3:maka-vs-opencode:v1';
+const PAIR_CONCURRENCY = 4;
+const BILLING_MODE = 'account-plan';
 const PRICING = {
   currency: 'USD',
   unit: 'per_1m_tokens',
-  input: 1.4,
-  cachedInput: 0.26,
-  output: 4.4,
-  source: 'z.ai-public-2026-07-13',
+  input: 0,
+  cachedInput: 0,
+  output: 0,
+  source: 'kimi-coding-plan-account-plan',
 };
 const HARBOR_SETUP_TEARDOWN_GRACE_SEC = 15 * 60;
 const ORACLE_EVIDENCE_RESOLUTION_TIMEOUT_MS = 15_000;
@@ -88,9 +89,9 @@ function envPath(name, fallback) {
 }
 
 function runLimit(raw) {
-  const parsed = Number(raw ?? PILOT_TASKS);
-  if (parsed !== CANARY_TASKS && parsed !== PILOT_TASKS && parsed !== EXPECTED_SOURCE_TASKS) {
-    throw new Error(`MAKA_HARNESS_AB_LIMIT must be ${CANARY_TASKS}, ${PILOT_TASKS}, or ${EXPECTED_SOURCE_TASKS}`);
+  const parsed = Number(raw ?? CANARY_TASKS);
+  if (parsed !== CANARY_TASKS && parsed !== EXPECTED_SOURCE_TASKS) {
+    throw new Error(`MAKA_HARNESS_AB_LIMIT must be ${CANARY_TASKS} or ${EXPECTED_SOURCE_TASKS}`);
   }
   return parsed;
 }
@@ -133,7 +134,7 @@ export function buildHarnessAbManifest({
     },
     taskIds,
     orderSeed: ORDER_SEED,
-    pilotTaskCount: PILOT_TASKS,
+    pilotTaskCount: CANARY_TASKS,
     model: { provider: PROVIDER, id: MODEL, reasoningEffort: REASONING_EFFORT },
     pricing: PRICING,
     arms: [
@@ -146,6 +147,7 @@ export function buildHarnessAbManifest({
           reasoningEffort: REASONING_EFFORT,
           continuation: false,
           attemptPolicy: 'single',
+          billingMode: BILLING_MODE,
           contextBudget: HARNESS_MAKA_CONTEXT_BUDGET,
         },
       },
@@ -159,6 +161,7 @@ export function buildHarnessAbManifest({
           pure: true,
           permissions: 'auto',
           attemptPolicy: 'single',
+          billingMode: BILLING_MODE,
         },
       },
     ],
@@ -167,6 +170,7 @@ export function buildHarnessAbManifest({
     subjectFingerprint,
     taskSourceFingerprint,
     toolchainFingerprint,
+    pairConcurrency: PAIR_CONCURRENCY,
     ...(oracleEvidence ? { oracleEvidence } : {}),
   });
 }
@@ -262,7 +266,7 @@ async function runLocked({ repoRoot, makaRepoPath, tasksRoot, runId, limit, runR
     : join(runRoot, 'toolchains', `opencode-${OPENCODE_TOOLCHAIN_SPEC.opencode.version}-linux-x64`);
   await prepareOpenCodeToolchain(opencodeToolchainPath);
 
-  const keyFile = envPath('MAKA_HARNESS_AB_KEY_FILE', join(repoRoot, '.local-secrets/zai-key'));
+  const keyFile = envPath('MAKA_HARNESS_AB_KEY_FILE', join(homedir(), '.maka/secrets/kimi-coding-plan.key'));
   if ((await readFile(keyFile, 'utf8')).trim().length === 0) throw new Error('MAKA_HARNESS_AB_KEY_FILE is empty');
   const controllerDir = join(runRoot, 'controller');
   const promptsDir = join(runRoot, 'prompts');
@@ -285,9 +289,9 @@ async function runLocked({ repoRoot, makaRepoPath, tasksRoot, runId, limit, runR
     provider: PROVIDER,
     reasoningEffort: REASONING_EFFORT,
     apiKeyFile: keyFile,
-    apiKeyEnvName: 'ZAI_API_KEY',
+    apiKeyEnvName: 'ANTHROPIC_API_KEY',
     pricing,
-    agentEnv: { ZAI_BASE_URL: BASE_URL },
+    agentEnv: { MAKA_BASE_URL: BASE_URL },
     timeoutMultiplier: 1,
     dockerPlatform: 'linux/amd64',
   };
@@ -311,6 +315,7 @@ async function runLocked({ repoRoot, makaRepoPath, tasksRoot, runId, limit, runR
         id: 'maka',
         config: config('maka'),
         expectedPricingProfile: PRICING.source,
+        billingMode: BILLING_MODE,
         harborRunner: createHarborTaskRunner({
           ...runnerOptions,
           agent: 'maka',
@@ -321,6 +326,7 @@ async function runLocked({ repoRoot, makaRepoPath, tasksRoot, runId, limit, runR
         id: 'opencode',
         config: config('opencode'),
         expectedPricingProfile: PRICING.source,
+        billingMode: BILLING_MODE,
         harborRunner: createHarborTaskRunner({
           ...runnerOptions,
           agent: 'opencode',
@@ -329,6 +335,7 @@ async function runLocked({ repoRoot, makaRepoPath, tasksRoot, runId, limit, runR
         }),
       },
     ],
+    pairConcurrency: PAIR_CONCURRENCY,
   });
   const evaluatedTaskIds = new Set(evaluationTasks.map((task) => task.id));
   const report = buildHarnessAbReport(summary, {

--- a/packages/headless/harbor/run-harness-ab.mjs
+++ b/packages/headless/harbor/run-harness-ab.mjs
@@ -31,6 +31,11 @@ import {
   prepareOpenCodeToolchain,
 } from '#opencode-toolchain';
 import {
+  KIMI_CODE_TOOLCHAIN_FINGERPRINT,
+  KIMI_CODE_TOOLCHAIN_SPEC,
+  prepareKimiCodeToolchain,
+} from '#kimi-code-toolchain';
+import {
   assertTerminalBench21TaskSet,
   assertTerminalBench21TaskTreeFingerprint,
   buildHarnessAbResumeFingerprint,
@@ -57,14 +62,14 @@ import {
 const execFileAsync = promisify(execFile);
 
 const EXPECTED_SOURCE_TASKS = TERMINAL_BENCH_2_1_TASK_IDS.length;
-export const DEFAULT_HARNESS_AB_RUN_ID = 'k3-maka-vs-opencode-tbench-2.1-full-v1';
+export const DEFAULT_HARNESS_AB_RUN_ID = 'k3-maka-vs-kimi-code-tbench-2.1-full-v1';
 const CANARY_TASKS = 5;
 const PROVIDER = 'kimi-coding-plan';
 const MODEL = 'k3';
 const MODEL_SPEC = `${PROVIDER}/${MODEL}`;
 const REASONING_EFFORT = 'max';
 const BASE_URL = 'https://api.kimi.com/coding/v1';
-const ORDER_SEED = 'terminal-bench-2.1:k3:maka-vs-opencode:v1';
+const ORDER_SEED = 'terminal-bench-2.1:k3:harness-comparison:v1';
 const PAIR_CONCURRENCY = 4;
 const BILLING_MODE = 'account-plan';
 const PRICING = {
@@ -81,6 +86,42 @@ const BACKGROUND_RUN_ENV = 'MAKA_HARNESS_AB_BACKGROUND_RUN';
 const BACKGROUND_STARTED_AT_ENV = 'MAKA_HARNESS_AB_DETACHED_STARTED_AT';
 const BACKGROUND_JOURNAL_FILENAME = 'background-run.json';
 const BACKGROUND_LOG_FILENAME = 'background-run.log';
+
+export const HARNESS_COMPETITOR_PROFILES = Object.freeze({
+  'kimi-code': Object.freeze({
+    id: 'kimi-code',
+    version: KIMI_CODE_TOOLCHAIN_SPEC.kimiCode.version,
+    toolchainFingerprint: KIMI_CODE_TOOLCHAIN_FINGERPRINT,
+    config: Object.freeze({
+      adapter: 'kimi_code_agent:MakaKimiCodeAgent',
+      outputFormat: 'stream-json',
+      permissions: 'yolo',
+      attemptPolicy: 'single',
+      billingMode: BILLING_MODE,
+    }),
+  }),
+  opencode: Object.freeze({
+    id: 'opencode',
+    version: OPENCODE_TOOLCHAIN_SPEC.opencode.version,
+    toolchainFingerprint: OPENCODE_TOOLCHAIN_FINGERPRINT,
+    config: Object.freeze({
+      adapter: 'opencode_agent:MakaOpenCodeAgent',
+      variant: REASONING_EFFORT,
+      pure: true,
+      permissions: 'auto',
+      attemptPolicy: 'single',
+      billingMode: BILLING_MODE,
+    }),
+  }),
+});
+
+export function resolveHarnessCompetitorProfile(raw = 'kimi-code') {
+  const profile = HARNESS_COMPETITOR_PROFILES[raw];
+  if (!profile) {
+    throw new Error(`MAKA_HARNESS_AB_COMPETITOR must be one of: ${Object.keys(HARNESS_COMPETITOR_PROFILES).join(', ')}`);
+  }
+  return profile;
+}
 
 function envPath(name, fallback) {
   const raw = process.env[name] || fallback;
@@ -122,6 +163,7 @@ export function buildHarnessAbManifest({
   toolchainFingerprint,
   taskIds = TERMINAL_BENCH_2_1_TASK_IDS,
   oracleEvidence,
+  competitorProfile = resolveHarnessCompetitorProfile(),
 }) {
   return buildHarnessAbRunManifest({
     benchmark: {
@@ -152,17 +194,9 @@ export function buildHarnessAbManifest({
         },
       },
       {
-        id: 'opencode',
-        version: OPENCODE_TOOLCHAIN_SPEC.opencode.version,
-        config: {
-          adapter: 'opencode_agent:MakaOpenCodeAgent',
-          externalSystemPrompt: 'empty',
-          variant: REASONING_EFFORT,
-          pure: true,
-          permissions: 'auto',
-          attemptPolicy: 'single',
-          billingMode: BILLING_MODE,
-        },
+        id: competitorProfile.id,
+        version: competitorProfile.version,
+        config: { ...competitorProfile.config, externalSystemPrompt: 'empty', profile: competitorProfile.id },
       },
     ],
     taskBudgetSec: null,
@@ -182,7 +216,11 @@ export async function main() {
     : repoRoot;
   const outDir = envPath('MAKA_HARNESS_AB_OUT_DIR');
   const tasksRoot = envPath('MAKA_HARNESS_AB_TASKS_ROOT', join(homedir(), '.cache/harbor/tasks'));
-  const runId = process.env.MAKA_HARNESS_AB_RUN_ID || DEFAULT_HARNESS_AB_RUN_ID;
+  const competitorProfile = resolveHarnessCompetitorProfile(process.env.MAKA_HARNESS_AB_COMPETITOR || 'kimi-code');
+  const runId = process.env.MAKA_HARNESS_AB_RUN_ID
+    || (competitorProfile.id === 'kimi-code'
+      ? DEFAULT_HARNESS_AB_RUN_ID
+      : `k3-maka-vs-${competitorProfile.id}-tbench-2.1-full-v1`);
   const limit = runLimit(process.env.MAKA_HARNESS_AB_LIMIT);
   const runRoot = resolveFixedPromptRunRoot(outDir, runId, 'MAKA_HARNESS_AB_RUN_ID');
   await withHarnessAbRunLock(runRoot, async () => {
@@ -190,7 +228,7 @@ export async function main() {
     if (journal) await writeBackgroundJournal(journal.path, { ...journal.base, status: 'running' });
     let exitCode = 0;
     try {
-      await runLocked({ repoRoot, makaRepoPath, tasksRoot, runId, limit, runRoot });
+      await runLocked({ repoRoot, makaRepoPath, tasksRoot, runId, limit, runRoot, competitorProfile });
     } catch (error) {
       exitCode = 1;
       throw error;
@@ -207,7 +245,7 @@ export async function main() {
   });
 }
 
-async function runLocked({ repoRoot, makaRepoPath, tasksRoot, runId, limit, runRoot }) {
+async function runLocked({ repoRoot, makaRepoPath, tasksRoot, runId, limit, runRoot, competitorProfile }) {
   const allTasks = await discoverCachedHarborTasks(tasksRoot);
   assertTerminalBench21TaskSet(allTasks.map((task) => task.id));
   const taskSourceFingerprint = await fingerprintFixedPromptTaskTree(allTasks);
@@ -248,7 +286,8 @@ async function runLocked({ repoRoot, makaRepoPath, tasksRoot, runId, limit, runR
 
   const toolchainFingerprint = `sha256:${createHash('sha256').update(JSON.stringify({
     hostToolchainFingerprint,
-    opencodeToolchainFingerprint: OPENCODE_TOOLCHAIN_FINGERPRINT,
+    competitor: competitorProfile.id,
+    competitorToolchainFingerprint: competitorProfile.toolchainFingerprint,
   })).digest('hex')}`;
   const manifest = buildHarnessAbManifest({
     subjectFingerprint,
@@ -256,15 +295,26 @@ async function runLocked({ repoRoot, makaRepoPath, tasksRoot, runId, limit, runR
     toolchainFingerprint,
     taskIds: TERMINAL_BENCH_2_1_TASK_IDS,
     oracleEvidence,
+    competitorProfile,
   });
   await ensureAbRunManifest(manifestPath, manifest);
   const evaluationTasks = manifest.evaluationTaskIds.slice(0, limit).map((taskId) => tasksById.get(taskId));
   if (evaluationTasks.some((task) => !task)) throw new Error('manifest contains a task absent from the frozen task source');
 
-  const opencodeToolchainPath = process.env.MAKA_HARNESS_AB_OPENCODE_TOOLCHAIN
-    ? resolve(process.env.MAKA_HARNESS_AB_OPENCODE_TOOLCHAIN)
-    : join(runRoot, 'toolchains', `opencode-${OPENCODE_TOOLCHAIN_SPEC.opencode.version}-linux-x64`);
-  await prepareOpenCodeToolchain(opencodeToolchainPath);
+  const competitorToolchain = competitorProfile.id === 'kimi-code'
+    ? {
+        path: process.env.MAKA_HARNESS_AB_KIMI_CODE_TOOLCHAIN
+          ? resolve(process.env.MAKA_HARNESS_AB_KIMI_CODE_TOOLCHAIN)
+          : join(runRoot, 'toolchains', `kimi-code-${KIMI_CODE_TOOLCHAIN_SPEC.kimiCode.version}-linux-x64`),
+        prepare: prepareKimiCodeToolchain,
+      }
+    : {
+        path: process.env.MAKA_HARNESS_AB_OPENCODE_TOOLCHAIN
+          ? resolve(process.env.MAKA_HARNESS_AB_OPENCODE_TOOLCHAIN)
+          : join(runRoot, 'toolchains', `opencode-${OPENCODE_TOOLCHAIN_SPEC.opencode.version}-linux-x64`),
+        prepare: prepareOpenCodeToolchain,
+      };
+  await competitorToolchain.prepare(competitorToolchain.path);
 
   const keyFile = envPath('MAKA_HARNESS_AB_KEY_FILE', join(homedir(), '.maka/secrets/kimi-coding-plan.key'));
   if ((await readFile(keyFile, 'utf8')).trim().length === 0) throw new Error('MAKA_HARNESS_AB_KEY_FILE is empty');
@@ -323,15 +373,17 @@ async function runLocked({ repoRoot, makaRepoPath, tasksRoot, runId, limit, runR
         }),
       },
       {
-        id: 'opencode',
-        config: config('opencode'),
+        id: competitorProfile.id,
+        config: config(competitorProfile.id),
         expectedPricingProfile: PRICING.source,
         billingMode: BILLING_MODE,
         harborRunner: createHarborTaskRunner({
           ...runnerOptions,
-          agent: 'opencode',
-          agentVersion: OPENCODE_TOOLCHAIN_SPEC.opencode.version,
-          opencodeToolchainPath,
+          agent: competitorProfile.id,
+          agentVersion: competitorProfile.version,
+          ...(competitorProfile.id === 'kimi-code'
+            ? { kimiCodeToolchainPath: competitorToolchain.path }
+            : { opencodeToolchainPath: competitorToolchain.path }),
         }),
       },
     ],

--- a/packages/headless/package.json
+++ b/packages/headless/package.json
@@ -39,6 +39,7 @@
     "#provider-env": "./dist/provider-env.js",
     "#harbor-cell": "./dist/harbor-cell.js",
     "#opencode-toolchain": "./dist/opencode-toolchain.js",
+    "#kimi-code-toolchain": "./dist/kimi-code-toolchain.js",
     "#runtime-policy-ab-profile": "./dist/runtime-policy-ab-profile.js",
     "#runtime-policy-ab-spec": "./dist/runtime-policy-ab-spec.js",
     "#runtime-policy-ab-run": "./dist/runtime-policy-ab-run.js",

--- a/packages/headless/src/__tests__/fixed-prompt-controller.test.ts
+++ b/packages/headless/src/__tests__/fixed-prompt-controller.test.ts
@@ -2100,6 +2100,42 @@ describe('fixed prompt controller', () => {
     });
   });
 
+  test('rejects an attested completed result when final usage is required', async () => {
+    await withDir(async (dir) => {
+      const systemPromptPath = join(dir, 'system_prompt.md');
+      await writeFile(systemPromptPath, 'fixed prompt\n', 'utf8');
+
+      const result = await runFixedPromptController({
+        runId: 'run-1',
+        roundId: 'round-1',
+        config,
+        systemPromptPath,
+        resultsJsonlPath: join(dir, 'results.jsonl'),
+        tasks: [{ id: 'task-a', path: '/bench/task-a' }],
+        requireExecutionIdentity: true,
+        requireFinalUsage: true,
+        expectedPricingProfile: 'test-profile',
+        harborRunner: async () => harborOutput({
+          taskId: 'task-a',
+          omitTokenSummary: true,
+          executionIdentity: {
+            llmConnectionSlug: 'fake',
+            model: 'fake-model',
+            systemPromptHash: hashSystemPrompt('fixed prompt\n'),
+            pricingProfile: 'test-profile',
+          },
+        }),
+        now: () => 100,
+        newId: idFactory(),
+      });
+
+      assert.equal(result.events[0]?.type, 'task_plumbing_failed');
+      assert.equal(result.events[0]?.errorClass, 'missing_token_usage');
+      assert.equal(result.events[0]?.eligible, false);
+      assert.equal(result.events[0]?.scored, false);
+    });
+  });
+
   test('keeps an attested tool-step-cap result eligible when usage is unavailable', async () => {
     await withDir(async (dir) => {
       const systemPromptPath = join(dir, 'system_prompt.md');

--- a/packages/headless/src/__tests__/harbor-adapter.test.ts
+++ b/packages/headless/src/__tests__/harbor-adapter.test.ts
@@ -1906,6 +1906,46 @@ try:
             "apiKey": "{env:ZAI_API_KEY}",
             "baseURL": "{env:ZAI_BASE_URL}",
         }, benchmark_config
+        assert benchmark_config["provider"]["kimi-coding-plan"] == {
+            "npm": "@ai-sdk/anthropic",
+            "name": "Kimi Coding Plan",
+            "options": {
+                "apiKey": "{env:KIMI_API_KEY}",
+                "baseURL": "{env:KIMI_BASE_URL}",
+            },
+            "models": {
+                "k3": {
+                    "name": "Kimi K3",
+                    "limit": {"context": 1048576, "output": 131072},
+                    "options": {
+                        "thinking": {"type": "adaptive"},
+                        "effort": "max",
+                    },
+                    "variants": {
+                        "max": {
+                            "thinking": {"type": "adaptive"},
+                            "effort": "max",
+                        }
+                    },
+                }
+            },
+        }, benchmark_config
+        kimi_agent = MakaOpenCodeAgent(Path(tmp), extra_env={
+            "MAKA_OPENCODE_PROVIDER_PROXY_URL": "http://host.docker.internal:43210",
+            "MAKA_OPENCODE_PROVIDER_PROXY_TOKEN": "ephemeral-kimi-token",
+            "MAKA_LLM_CONNECTION_SLUG": "kimi-coding-plan",
+            "MAKA_SYSTEM_PROMPT": "",
+            "MAKA_REASONING_EFFORT": "max",
+            "MAKA_OPENCODE_VARIANT": "max",
+        }, prompt_template_path=template_path, model_name="kimi-coding-plan/k3")
+        kimi_agent.exec_as_agent = exec_as_agent
+        asyncio.run(kimi_agent.run("hi", environment, AgentContext()))
+        kimi_command, kimi_env = environment.agent_commands[-1]
+        assert "opencode --model=kimi-coding-plan/k3 run --format=json" in kimi_command, kimi_command
+        assert "--variant=max" in kimi_command, kimi_command
+        assert kimi_env["KIMI_API_KEY"] == "ephemeral-kimi-token", kimi_env
+        assert kimi_env["KIMI_BASE_URL"] == "http://host.docker.internal:43210", kimi_env
+        assert "ZAI_API_KEY" not in kimi_env, kimi_env
         assert environment.uploaded_files == [], environment.uploaded_files
         assert 'cat --' not in command, command
         assert "test-zai-key" not in command, command

--- a/packages/headless/src/__tests__/harbor-adapter.test.ts
+++ b/packages/headless/src/__tests__/harbor-adapter.test.ts
@@ -2180,6 +2180,27 @@ with tempfile.TemporaryDirectory() as tmp:
     assert cell["runtimeRefs"]["sessionId"] == "session-1", cell
     assert cell["toolSummary"]["actualToolCallCounts"] == {"Shell": 1}, cell
     assert "tokenSummary" not in cell, cell
+
+    def assert_invalid_stream(raw, expected):
+        (logs / "kimi-code.jsonl").write_text(raw, encoding="utf-8")
+        try:
+            agent.populate_context_post_run(object())
+        except ValueError as error:
+            assert expected in str(error), error
+        else:
+            raise AssertionError(f"invalid stream was accepted: {raw!r}")
+
+    assert_invalid_stream("", "assistant message")
+    assert_invalid_stream("{not-json}\n", "valid JSON")
+    assert_invalid_stream('[]\n', "JSON object")
+    assert_invalid_stream(json.dumps({"role": "meta", "type": "session.resume_hint", "session_id": "session-2"}) + '\n', "assistant message")
+
+    agent._failure_class = "auth"
+    (logs / "kimi-code.jsonl").write_text("", encoding="utf-8")
+    agent.populate_context_post_run(object())
+    failed = json.loads((logs / "maka-cell-output.json").read_text(encoding="utf-8"))
+    assert failed["status"] == "failed", failed
+    assert failed["errorClass"] == "auth", failed
     print("kimi-code adapter ok")
 `;
 }

--- a/packages/headless/src/__tests__/harbor-adapter.test.ts
+++ b/packages/headless/src/__tests__/harbor-adapter.test.ts
@@ -668,6 +668,19 @@ describe('Harbor adapter contract', () => {
     assert.match(result.stdout, /opencode_estimated_cost_usd/);
   });
 
+  test('kimi_code_agent.py runs the pinned CLI contract without Harbor installed', (t: TestContext) => {
+    const result = spawnSync('python3', ['-c', pythonKimiCodeAdapterSmokeScript(repoRoot)], {
+      cwd: repoRoot,
+      encoding: 'utf8',
+    });
+    if (result.error && 'code' in result.error && result.error.code === 'ENOENT') {
+      t.skip('python3 is not available');
+      return;
+    }
+    assert.equal(result.status, 0, result.stderr);
+    assert.match(result.stdout, /kimi-code adapter ok/);
+  });
+
   test('trial_pricing.py validates explicit pricing env without Harbor installed', (t: TestContext) => {
     const result = spawnSync('python3', ['-c', pythonTrialPricingSmokeScript(repoRoot)], {
       cwd: repoRoot,
@@ -1842,8 +1855,8 @@ try:
         key_path = Path(tmp) / "zai-key"
         key_path.write_text("test-zai-key\n", encoding="utf-8")
         agent = MakaOpenCodeAgent(Path(tmp), extra_env={
-            "MAKA_OPENCODE_PROVIDER_PROXY_URL": "http://host.docker.internal:43210",
-            "MAKA_OPENCODE_PROVIDER_PROXY_TOKEN": "ephemeral-proxy-token",
+            "MAKA_PROVIDER_PROXY_URL": "http://host.docker.internal:43210",
+            "MAKA_PROVIDER_PROXY_TOKEN": "ephemeral-proxy-token",
             "MAKA_LLM_CONNECTION_SLUG": "zai-coding-plan",
             "MAKA_SYSTEM_PROMPT": "",
             "MAKA_REASONING_EFFORT": "max",
@@ -1931,8 +1944,8 @@ try:
             },
         }, benchmark_config
         kimi_agent = MakaOpenCodeAgent(Path(tmp), extra_env={
-            "MAKA_OPENCODE_PROVIDER_PROXY_URL": "http://host.docker.internal:43210",
-            "MAKA_OPENCODE_PROVIDER_PROXY_TOKEN": "ephemeral-kimi-token",
+            "MAKA_PROVIDER_PROXY_URL": "http://host.docker.internal:43210",
+            "MAKA_PROVIDER_PROXY_TOKEN": "ephemeral-kimi-token",
             "MAKA_LLM_CONNECTION_SLUG": "kimi-coding-plan",
             "MAKA_SYSTEM_PROMPT": "",
             "MAKA_REASONING_EFFORT": "max",
@@ -2007,8 +2020,8 @@ try:
         assert "tokenSummary" not in missing_usage_cell, missing_usage_cell
 
         failing_agent = MakaOpenCodeAgent(Path(tmp), extra_env={
-            "MAKA_OPENCODE_PROVIDER_PROXY_URL": "http://host.docker.internal:43210",
-            "MAKA_OPENCODE_PROVIDER_PROXY_TOKEN": "ephemeral-proxy-token",
+            "MAKA_PROVIDER_PROXY_URL": "http://host.docker.internal:43210",
+            "MAKA_PROVIDER_PROXY_TOKEN": "ephemeral-proxy-token",
             "MAKA_LLM_CONNECTION_SLUG": "zai-coding-plan",
             "MAKA_SYSTEM_PROMPT": "",
             "MAKA_REASONING_EFFORT": "max",
@@ -2041,6 +2054,132 @@ finally:
         os.environ["ZAI_API_KEY"] = old_key
     if old_base is not None:
         os.environ["ZAI_BASE_URL"] = old_base
+`;
+}
+
+function pythonKimiCodeAdapterSmokeScript(root: string): string {
+  return String.raw`
+import asyncio
+import json
+import os
+import sys
+import tempfile
+import types
+from pathlib import Path
+
+root = Path(${JSON.stringify(root)})
+
+def module(name):
+    mod = types.ModuleType(name)
+    sys.modules[name] = mod
+    return mod
+
+module("harbor")
+module("harbor.agents")
+module("harbor.agents.installed")
+base_mod = module("harbor.agents.installed.base")
+
+def with_prompt_template(fn):
+    async def wrapper(self, instruction, *args, **kwargs):
+        return await fn(self, self.render_instruction(instruction), *args, **kwargs)
+    return wrapper
+
+class BaseInstalledAgent:
+    def __init__(self, logs_dir, prompt_template_path=None, version=None, extra_env=None, model_name=None, **kwargs):
+        self.logs_dir = Path(logs_dir)
+        self._prompt_template_path = Path(prompt_template_path) if prompt_template_path else None
+        self._extra_env = extra_env or {}
+        self._version = version
+        self.model_name = model_name
+
+    def _get_env(self, key):
+        return self._extra_env.get(key) or os.environ.get(key)
+
+    def render_instruction(self, instruction):
+        if not self._prompt_template_path:
+            return instruction
+        return self._prompt_template_path.read_text(encoding="utf-8").replace("{{ instruction }}", instruction)
+
+    async def exec_as_agent(self, environment, command, env=None, **kwargs):
+        return await environment.exec(command, env=env or {}, **kwargs)
+
+base_mod.BaseInstalledAgent = BaseInstalledAgent
+base_mod.with_prompt_template = with_prompt_template
+
+module("harbor.environments")
+env_mod = module("harbor.environments.base")
+env_mod.BaseEnvironment = object
+module("harbor.models")
+module("harbor.models.agent")
+context_mod = module("harbor.models.agent.context")
+context_mod.AgentContext = object
+
+sys.path.insert(0, str(root / "packages" / "headless" / "harbor"))
+from kimi_code_agent import MakaKimiCodeAgent
+
+with tempfile.TemporaryDirectory() as tmp:
+    logs = Path(tmp)
+    template = logs / "prompt.j2"
+    template.write_text("templated: {{ instruction }}", encoding="utf-8")
+    commands = []
+
+    class Environment:
+        async def exec(self, command, env=None, **kwargs):
+            commands.append((command, env or {}))
+            if "--output-format stream-json" in command:
+                identity = logs / "maka-cell-execution-identity.json"
+                assert identity.exists(), "execution identity must be durable before sampling"
+                (logs / "kimi-code.jsonl").write_text(
+                    '\n'.join([
+                        json.dumps({"role": "assistant", "tool_calls": [{"function": {"name": "Shell"}}]}),
+                        json.dumps({"role": "tool", "tool_call_id": "1", "content": "ok"}),
+                        json.dumps({"role": "meta", "type": "session.resume_hint", "session_id": "session-1"}),
+                    ]) + '\n',
+                    encoding="utf-8",
+                )
+            return types.SimpleNamespace(return_code=0, stdout="", stderr="")
+
+    agent = MakaKimiCodeAgent(
+        logs,
+        prompt_template_path=template,
+        version="0.26.0",
+        model_name="k3",
+        extra_env={
+            "MAKA_KIMI_CODE_TOOLCHAIN_FINGERPRINT": "sha256:" + "a" * 64,
+            "MAKA_PROVIDER_PROXY_URL": "http://host.docker.internal:43210",
+            "MAKA_PROVIDER_PROXY_TOKEN": "ephemeral-token",
+            "MAKA_MODEL": "k3",
+            "MAKA_LLM_CONNECTION_SLUG": "kimi-coding-plan",
+            "MAKA_REASONING_EFFORT": "max",
+            "MAKA_SYSTEM_PROMPT": "",
+            "MAKA_TRIAL_PRICING_SOURCE": "kimi-coding-plan-account-plan",
+        },
+    )
+    environment = Environment()
+    asyncio.run(agent.install(environment))
+    install_command, install_env = commands[0]
+    assert "sha256sum --check" in install_command, install_command
+    assert "/opt/maka-kimi-code-toolchain/bin/node" in install_command, install_command
+    assert install_env["MAKA_EXPECTED_TOOLCHAIN_FINGERPRINT"] == "sha256:" + "a" * 64, install_env
+    asyncio.run(agent.run("hi", environment, object()))
+    run_command, run_env = commands[-1]
+    assert "--yolo --output-format stream-json --prompt" in run_command, run_command
+    assert "templated: hi" in run_command, run_command
+    assert run_env["KIMI_MODEL_NAME"] == "k3", run_env
+    assert run_env["KIMI_MODEL_API_KEY"] == "ephemeral-token", run_env
+    assert run_env["KIMI_MODEL_PROVIDER_TYPE"] == "kimi", run_env
+    assert run_env["KIMI_MODEL_MAX_CONTEXT_SIZE"] == "1048576", run_env
+    assert run_env["KIMI_MODEL_MAX_OUTPUT_SIZE"] == "131072", run_env
+    assert run_env["KIMI_MODEL_ADAPTIVE_THINKING"] == "true", run_env
+    assert "ephemeral-token" not in run_command, run_command
+    agent.populate_context_post_run(object())
+    cell = json.loads((logs / "maka-cell-output.json").read_text(encoding="utf-8"))
+    assert cell["executionIdentity"]["model"] == "k3", cell
+    assert cell["executionIdentity"]["reasoningEffort"] == "max", cell
+    assert cell["runtimeRefs"]["sessionId"] == "session-1", cell
+    assert cell["toolSummary"]["actualToolCallCounts"] == {"Shell": 1}, cell
+    assert "tokenSummary" not in cell, cell
+    print("kimi-code adapter ok")
 `;
 }
 

--- a/packages/headless/src/__tests__/harbor-adapter.test.ts
+++ b/packages/headless/src/__tests__/harbor-adapter.test.ts
@@ -2163,7 +2163,8 @@ with tempfile.TemporaryDirectory() as tmp:
     assert install_env["MAKA_EXPECTED_TOOLCHAIN_FINGERPRINT"] == "sha256:" + "a" * 64, install_env
     asyncio.run(agent.run("hi", environment, object()))
     run_command, run_env = commands[-1]
-    assert "--yolo --output-format stream-json --prompt" in run_command, run_command
+    assert "--output-format stream-json --prompt" in run_command, run_command
+    assert "--yolo" not in run_command, run_command
     assert "templated: hi" in run_command, run_command
     assert run_env["KIMI_MODEL_NAME"] == "k3", run_env
     assert run_env["KIMI_MODEL_API_KEY"] == "ephemeral-token", run_env

--- a/packages/headless/src/__tests__/harbor-task-runner.test.ts
+++ b/packages/headless/src/__tests__/harbor-task-runner.test.ts
@@ -383,12 +383,12 @@ describe('createHarborTaskRunner', () => {
       await runner(runInput());
 
       assert.equal(harborEnv?.ZAI_API_KEY_FILE, undefined);
-      assert.match(harborEnv?.MAKA_OPENCODE_PROVIDER_PROXY_URL ?? '', /^http:\/\/host\.docker\.internal:\d+$/);
-      assert.match(harborEnv?.MAKA_OPENCODE_PROVIDER_PROXY_TOKEN ?? '', /^[a-f0-9]{64}$/);
-      assert.notEqual(harborEnv?.MAKA_OPENCODE_PROVIDER_PROXY_TOKEN, keyFile);
+      assert.match(harborEnv?.MAKA_PROVIDER_PROXY_URL ?? '', /^http:\/\/host\.docker\.internal:\d+$/);
+      assert.match(harborEnv?.MAKA_PROVIDER_PROXY_TOKEN ?? '', /^[a-f0-9]{64}$/);
+      assert.notEqual(harborEnv?.MAKA_PROVIDER_PROXY_TOKEN, keyFile);
       assert.doesNotMatch(JSON.stringify(harborEnv), /deepseek-key|sk-secret/);
       assert.doesNotMatch(JSON.stringify(captured.config), /ZAI_API_KEY|deepseek-key|sk-secret/);
-      const closedProxyUrl = harborEnv?.MAKA_OPENCODE_PROVIDER_PROXY_URL?.replace('host.docker.internal', '127.0.0.1');
+      const closedProxyUrl = harborEnv?.MAKA_PROVIDER_PROXY_URL?.replace('host.docker.internal', '127.0.0.1');
       assert.ok(closedProxyUrl);
       await assert.rejects(fetch(closedProxyUrl));
     });
@@ -417,9 +417,9 @@ describe('createHarborTaskRunner', () => {
           apiKeyFile: keyFile,
           agentEnv: { MAKA_BASE_URL: `http://127.0.0.1:${address.port}/coding/v1` },
           runHarbor: async (request) => {
-            const proxyUrl = request.env?.MAKA_OPENCODE_PROVIDER_PROXY_URL
+            const proxyUrl = request.env?.MAKA_PROVIDER_PROXY_URL
               ?.replace('host.docker.internal', '127.0.0.1');
-            const proxyToken = request.env?.MAKA_OPENCODE_PROVIDER_PROXY_TOKEN;
+            const proxyToken = request.env?.MAKA_PROVIDER_PROXY_TOKEN;
             assert.ok(proxyUrl && proxyToken);
             const response = await fetch(`${proxyUrl}/messages`, {
               method: 'POST',
@@ -433,6 +433,75 @@ describe('createHarborTaskRunner', () => {
 
         await runner(runInput());
         assert.equal(upstreamApiKey, 'sk-secret');
+      } finally {
+        await new Promise<void>((resolve, reject) => upstream.close((error) => error ? reject(error) : resolve()));
+      }
+    });
+  });
+
+  test('gives Kimi Code bearer auth and fills missing cell usage from the provider stream', async () => {
+    await withRun(async ({ jobsDir, repo, keyFile }) => {
+      let upstreamAuthorization = '';
+      const upstream = createServer((request, response) => {
+        upstreamAuthorization = request.headers.authorization ?? '';
+        response.writeHead(200, { 'content-type': 'text/event-stream' });
+        response.end([
+          'data: {"type":"message_start","message":{"usage":{"input_tokens":70,"cache_creation_input_tokens":10,"cache_read_input_tokens":20,"output_tokens":1}}}',
+          '',
+          'data: {"type":"message_delta","usage":{"output_tokens":25}}',
+          '',
+        ].join('\n'));
+      });
+      await new Promise<void>((resolve) => upstream.listen(0, '127.0.0.1', resolve));
+      const address = upstream.address();
+      assert.ok(address && typeof address !== 'string');
+      try {
+        const runner = createHarborTaskRunner({
+          makaRepoPath: repo,
+          jobsDir,
+          agent: 'kimi-code',
+          kimiCodeToolchainPath: '/toolchain',
+          agentVersion: '0.26.0',
+          model: 'kimi-coding-plan/k3',
+          provider: 'kimi-coding-plan',
+          reasoningEffort: 'max',
+          apiKeyFile: keyFile,
+          pricing: { inputUsdPer1M: 0, cacheReadUsdPer1M: 0, cacheWriteUsdPer1M: 0, outputUsdPer1M: 0 },
+          agentEnv: { MAKA_BASE_URL: `http://127.0.0.1:${address.port}/coding/v1` },
+          runHarbor: async (request) => {
+            const proxyUrl = request.env?.MAKA_PROVIDER_PROXY_URL
+              ?.replace('host.docker.internal', '127.0.0.1');
+            const proxyToken = request.env?.MAKA_PROVIDER_PROXY_TOKEN;
+            assert.ok(proxyUrl && proxyToken);
+            const response = await fetch(`${proxyUrl}/messages`, {
+              method: 'POST',
+              headers: { authorization: `Bearer ${proxyToken}` },
+              body: '{}',
+            });
+            assert.equal(response.status, 200);
+            await response.text();
+            return fakeRunner({
+              reward: '1\n',
+              cell: cellOutput({ tokenSummary: undefined }),
+            })(request);
+          },
+        });
+
+        const output = await runner(runInput());
+        assert.equal(upstreamAuthorization, 'Bearer sk-secret');
+        assert.deepEqual(output.cell.tokenSummary, {
+          input: 100,
+          output: 25,
+          cachedInput: 20,
+          cacheHitInput: 20,
+          cacheMissInput: 70,
+          cacheWriteInput: 10,
+          cacheMissInputSource: 'explicit',
+          reasoning: 0,
+          total: 125,
+          costUsd: 0,
+          pricingSource: 'runtime',
+        });
       } finally {
         await new Promise<void>((resolve, reject) => upstream.close((error) => error ? reject(error) : resolve()));
       }
@@ -460,7 +529,7 @@ describe('createHarborTaskRunner', () => {
       await runner(runInput());
 
       assert.equal(harborEnv?.MAKA_HOST_NO_AUTH, undefined);
-      assert.equal(harborEnv?.MAKA_OPENCODE_PROVIDER_PROXY_URL, undefined);
+      assert.equal(harborEnv?.MAKA_PROVIDER_PROXY_URL, undefined);
     });
   });
 
@@ -1185,6 +1254,37 @@ describe('buildHarborJobConfig', () => {
       (config.environment as { extra_docker_compose?: string[] }).extra_docker_compose,
       ['/repo/packages/headless/harbor/docker-compose-linux-amd64.yaml'],
     );
+  });
+
+  test('pins the Kimi Code adapter and official toolchain without serializing credentials', () => {
+    const config = buildHarborJobConfig(runInput(), {
+      makaRepoPath: '/repo',
+      jobsDir: '/jobs/x',
+      jobName: 'trial',
+      agent: 'kimi-code',
+      model: 'kimi-coding-plan/k3',
+      provider: 'kimi-coding-plan',
+      reasoningEffort: 'max',
+      agentVersion: '0.26.0',
+      kimiCodeToolchainPath: '/cache/kimi-code-0.26.0-linux-x64',
+      dockerPlatform: 'linux/amd64',
+    });
+    const agent = (config.agents as Array<Record<string, unknown>>)[0]!;
+    const env = agent.env as Record<string, string>;
+    const mounts = (config.environment as { mounts: Array<Record<string, unknown>> }).mounts;
+
+    assert.equal(agent.name, undefined);
+    assert.equal(agent.import_path, 'kimi_code_agent:MakaKimiCodeAgent');
+    assert.equal(agent.model_name, 'k3');
+    assert.deepEqual(agent.kwargs, { version: '0.26.0' });
+    assert.match(env.MAKA_KIMI_CODE_TOOLCHAIN_FINGERPRINT, /^sha256:[a-f0-9]{64}$/);
+    assert.ok(mounts.some((mount) => (
+      mount.source === '/cache/kimi-code-0.26.0-linux-x64'
+      && mount.target === '/opt/maka-kimi-code-toolchain'
+      && mount.read_only === true
+    )));
+    assert.equal(env.KIMI_API_KEY, undefined);
+    assert.equal(env.ANTHROPIC_API_KEY, undefined);
   });
 
   test('requires a prepared toolchain for OpenCode before Harbor starts', () => {

--- a/packages/headless/src/__tests__/harbor-task-runner.test.ts
+++ b/packages/headless/src/__tests__/harbor-task-runner.test.ts
@@ -359,6 +359,27 @@ describe('createHarborTaskRunner', () => {
     });
   });
 
+  test('rejects the unsupported Kimi Code Harbor route before creating a Copilot auth proxy', async () => {
+    await withRun(async ({ jobsDir, repo, keyFile }) => {
+      const runner = createHarborTaskRunner({
+        makaRepoPath: repo,
+        jobsDir,
+        agent: 'kimi-code',
+        kimiCodeToolchainPath: '/toolchain',
+        agentVersion: '0.26.0',
+        model: 'github-copilot/gpt-5.4',
+        provider: 'github-copilot',
+        apiKeyFile: keyFile,
+      });
+
+      await assert.rejects(runner(runInput()), (error: unknown) => {
+        assert.ok(error instanceof HarborInfraError);
+        assert.match(error.detail ?? '', /Kimi Code Harbor adapter does not support this provider/);
+        return true;
+      });
+    });
+  });
+
   test('gives OpenCode an ephemeral host proxy without exposing the provider key file', async () => {
     await withRun(async ({ jobsDir, repo, keyFile }) => {
       const captured: { config?: Record<string, unknown> } = {};
@@ -446,9 +467,9 @@ describe('createHarborTaskRunner', () => {
         upstreamAuthorization = request.headers.authorization ?? '';
         response.writeHead(200, { 'content-type': 'text/event-stream' });
         response.end([
-          'data: {"type":"message_start","message":{"usage":{"input_tokens":70,"cache_creation_input_tokens":10,"cache_read_input_tokens":20,"output_tokens":1}}}',
+          'data: {"id":"chatcmpl-1","choices":[],"usage":{"prompt_tokens":100,"completion_tokens":25,"prompt_tokens_details":{"cached_tokens":20}}}',
           '',
-          'data: {"type":"message_delta","usage":{"output_tokens":25}}',
+          'data: [DONE]',
           '',
         ].join('\n'));
       });
@@ -473,7 +494,7 @@ describe('createHarborTaskRunner', () => {
               ?.replace('host.docker.internal', '127.0.0.1');
             const proxyToken = request.env?.MAKA_PROVIDER_PROXY_TOKEN;
             assert.ok(proxyUrl && proxyToken);
-            const response = await fetch(`${proxyUrl}/messages`, {
+            const response = await fetch(`${proxyUrl}/chat/completions`, {
               method: 'POST',
               headers: { authorization: `Bearer ${proxyToken}` },
               body: '{}',
@@ -494,8 +515,8 @@ describe('createHarborTaskRunner', () => {
           output: 25,
           cachedInput: 20,
           cacheHitInput: 20,
-          cacheMissInput: 70,
-          cacheWriteInput: 10,
+          cacheMissInput: 80,
+          cacheWriteInput: 0,
           cacheMissInputSource: 'explicit',
           reasoning: 0,
           total: 125,
@@ -1299,6 +1320,34 @@ describe('buildHarborJobConfig', () => {
         agentVersion: '1.17.18',
       }),
       /opencodeToolchainPath is required for the OpenCode adapter/,
+    );
+  });
+
+  test('requires the pinned Kimi Code toolchain before Harbor starts', () => {
+    assert.throws(
+      () => buildHarborJobConfig(runInput(), {
+        makaRepoPath: '/repo',
+        jobsDir: '/jobs/x',
+        jobName: 'trial',
+        agent: 'kimi-code',
+        model: 'kimi-coding-plan/k3',
+        provider: 'kimi-coding-plan',
+        agentVersion: '0.26.0',
+      }),
+      /kimiCodeToolchainPath is required for the Kimi Code adapter/,
+    );
+    assert.throws(
+      () => buildHarborJobConfig(runInput(), {
+        makaRepoPath: '/repo',
+        jobsDir: '/jobs/x',
+        jobName: 'trial',
+        agent: 'kimi-code',
+        model: 'kimi-coding-plan/k3',
+        provider: 'kimi-coding-plan',
+        agentVersion: '0.25.0',
+        kimiCodeToolchainPath: '/toolchain',
+      }),
+      /Kimi Code adapter version must match toolchain version 0\.26\.0/,
     );
   });
 

--- a/packages/headless/src/__tests__/harbor-task-runner.test.ts
+++ b/packages/headless/src/__tests__/harbor-task-runner.test.ts
@@ -1,5 +1,6 @@
 import assert from 'node:assert/strict';
 import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { createServer } from 'node:http';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, test } from 'node:test';
@@ -390,6 +391,51 @@ describe('createHarborTaskRunner', () => {
       const closedProxyUrl = harborEnv?.MAKA_OPENCODE_PROVIDER_PROXY_URL?.replace('host.docker.internal', '127.0.0.1');
       assert.ok(closedProxyUrl);
       await assert.rejects(fetch(closedProxyUrl));
+    });
+  });
+
+  test('selects Anthropic x-api-key auth for the OpenCode Kimi Coding Plan proxy', async () => {
+    await withRun(async ({ jobsDir, repo, keyFile }) => {
+      let upstreamApiKey = '';
+      const upstream = createServer((request, response) => {
+        upstreamApiKey = String(request.headers['x-api-key'] ?? '');
+        response.writeHead(200).end('ok');
+      });
+      await new Promise<void>((resolve) => upstream.listen(0, '127.0.0.1', resolve));
+      const address = upstream.address();
+      assert.ok(address && typeof address !== 'string');
+      try {
+        const runner = createHarborTaskRunner({
+          makaRepoPath: repo,
+          jobsDir,
+          agent: 'opencode',
+          opencodeToolchainPath: '/toolchain',
+          agentVersion: '1.17.18',
+          model: 'kimi-coding-plan/k3',
+          provider: 'kimi-coding-plan',
+          reasoningEffort: 'max',
+          apiKeyFile: keyFile,
+          agentEnv: { MAKA_BASE_URL: `http://127.0.0.1:${address.port}/coding/v1` },
+          runHarbor: async (request) => {
+            const proxyUrl = request.env?.MAKA_OPENCODE_PROVIDER_PROXY_URL
+              ?.replace('host.docker.internal', '127.0.0.1');
+            const proxyToken = request.env?.MAKA_OPENCODE_PROVIDER_PROXY_TOKEN;
+            assert.ok(proxyUrl && proxyToken);
+            const response = await fetch(`${proxyUrl}/messages`, {
+              method: 'POST',
+              headers: { 'x-api-key': proxyToken },
+              body: '{}',
+            });
+            assert.equal(response.status, 200);
+            return fakeRunner({ reward: '1\n' })(request);
+          },
+        });
+
+        await runner(runInput());
+        assert.equal(upstreamApiKey, 'sk-secret');
+      } finally {
+        await new Promise<void>((resolve, reject) => upstream.close((error) => error ? reject(error) : resolve()));
+      }
     });
   });
 

--- a/packages/headless/src/__tests__/harness-ab-cli.test.ts
+++ b/packages/headless/src/__tests__/harness-ab-cli.test.ts
@@ -156,8 +156,8 @@ test('harness A/B freezes the stored advisory evidence when resuming a run', asy
   }
 });
 
-test('harness A/B manifest uses the pinned OpenCode toolchain version', async () => {
-  const { buildHarnessAbManifest } = await import(
+test('harness A/B defaults to pinned Kimi Code and keeps OpenCode selectable', async () => {
+  const { buildHarnessAbManifest, resolveHarnessCompetitorProfile } = await import(
     new URL('../../harbor/run-harness-ab.mjs', import.meta.url).href
   );
 
@@ -167,10 +167,11 @@ test('harness A/B manifest uses the pinned OpenCode toolchain version', async ()
     toolchainFingerprint: 'tools',
   });
 
-  assert.equal(
-    manifest.arms.find((arm: { id: string }) => arm.id === 'opencode')?.metadata.version,
-    '1.17.18',
-  );
+  const competitor = manifest.arms.find((arm: { id: string }) => arm.id === 'kimi-code');
+  assert.equal(competitor?.metadata.version, '0.26.0');
+  assert.equal(competitor?.metadata.config.profile, 'kimi-code');
+  assert.equal(resolveHarnessCompetitorProfile('opencode').version, '1.17.18');
+  assert.throws(() => resolveHarnessCompetitorProfile('unknown'), /MAKA_HARNESS_AB_COMPETITOR/);
   assert.deepEqual(manifest.metadata.model, {
     provider: 'kimi-coding-plan',
     id: 'k3',

--- a/packages/headless/src/__tests__/harness-ab-cli.test.ts
+++ b/packages/headless/src/__tests__/harness-ab-cli.test.ts
@@ -9,7 +9,7 @@ import { TERMINAL_BENCH_2_1_TASK_IDS } from '../harness-ab-manifest.js';
 
 const execFileAsync = promisify(execFile);
 
-test('harness A/B CLI accepts a 2-task operational canary', async () => {
+test('harness A/B CLI accepts a 5-task operational canary', async () => {
   const dir = await mkdtemp(join(tmpdir(), 'maka-harness-ab-cli-'));
   try {
     const scriptPath = new URL('../../harbor/run-harness-ab.mjs', import.meta.url);
@@ -19,7 +19,7 @@ test('harness A/B CLI accepts a 2-task operational canary', async () => {
         ...process.env,
         MAKA_HARNESS_AB_OUT_DIR: join(dir, 'out'),
         MAKA_HARNESS_AB_TASKS_ROOT: join(dir, 'missing-tasks'),
-        MAKA_HARNESS_AB_LIMIT: '2',
+        MAKA_HARNESS_AB_LIMIT: '5',
         MAKA_HARNESS_AB_DRY_RUN: '1',
       },
     }), /Terminal-Bench 2\.1 task set mismatch/);
@@ -171,6 +171,25 @@ test('harness A/B manifest uses the pinned OpenCode toolchain version', async ()
     manifest.arms.find((arm: { id: string }) => arm.id === 'opencode')?.metadata.version,
     '1.17.18',
   );
+  assert.deepEqual(manifest.metadata.model, {
+    provider: 'kimi-coding-plan',
+    id: 'k3',
+    reasoningEffort: 'max',
+  });
+  assert.deepEqual(manifest.metadata.pricing, {
+    currency: 'USD',
+    unit: 'per_1m_tokens',
+    input: 0,
+    cachedInput: 0,
+    output: 0,
+    source: 'kimi-coding-plan-account-plan',
+  });
+  assert.equal(manifest.metadata.order.pilotTaskCount, 5);
+  assert.equal(manifest.maxConcurrency, 4);
+  assert.equal(manifest.maxConcurrentAttempts, 8);
+  for (const arm of manifest.arms) {
+    assert.equal(arm.metadata.config.billingMode, 'account-plan');
+  }
 });
 
 test('harness A/B completion log preserves the report status', async () => {
@@ -193,7 +212,7 @@ test('detached harness launcher persists a terminal failed journal after the wor
         MAKA_HARNESS_AB_OUT_DIR: outDir,
         MAKA_HARNESS_AB_RUN_ID: runId,
         MAKA_HARNESS_AB_TASKS_ROOT: join(dir, 'missing-tasks'),
-        MAKA_HARNESS_AB_LIMIT: '2',
+        MAKA_HARNESS_AB_LIMIT: '5',
         MAKA_HARNESS_AB_DRY_RUN: '1',
       },
     });
@@ -237,7 +256,7 @@ test('duplicate detached launch does not overwrite the active run journal', asyn
         MAKA_HARNESS_AB_OUT_DIR: outDir,
         MAKA_HARNESS_AB_RUN_ID: runId,
         MAKA_HARNESS_AB_TASKS_ROOT: join(dir, 'missing-tasks'),
-        MAKA_HARNESS_AB_LIMIT: '2',
+        MAKA_HARNESS_AB_LIMIT: '5',
         MAKA_HARNESS_AB_DRY_RUN: '1',
       },
     }), /before acquiring the run lock/);
@@ -252,7 +271,7 @@ test('duplicate detached launch does not overwrite the active run journal', asyn
   }
 });
 
-test('harness A/B CLI accepts the fixed 30-task pilot limit', async () => {
+test('harness A/B CLI rejects the superseded 30-task pilot checkpoint', async () => {
   const dir = await mkdtemp(join(tmpdir(), 'maka-harness-ab-cli-'));
   try {
     const scriptPath = new URL('../../harbor/run-harness-ab.mjs', import.meta.url);
@@ -265,7 +284,7 @@ test('harness A/B CLI accepts the fixed 30-task pilot limit', async () => {
         MAKA_HARNESS_AB_LIMIT: '30',
         MAKA_HARNESS_AB_DRY_RUN: '1',
       },
-    }), /Terminal-Bench 2\.1 task set mismatch/);
+    }), /MAKA_HARNESS_AB_LIMIT must be 5 or 89/);
   } finally {
     await rm(dir, { recursive: true, force: true });
   }
@@ -308,7 +327,7 @@ test('harness A/B CLI rejects modified task contents before reading credentials'
         MAKA_HARNESS_AB_OUT_DIR: outDir,
         MAKA_HARNESS_AB_TASKS_ROOT: tasksRoot,
         MAKA_HARNESS_AB_RUN_ID: 'dry-run',
-        MAKA_HARNESS_AB_LIMIT: '30',
+        MAKA_HARNESS_AB_LIMIT: '5',
         MAKA_HARNESS_AB_DRY_RUN: '1',
         MAKA_HARNESS_AB_KEY_FILE: join(dir, 'must-not-be-read'),
         MAKA_HARNESS_AB_EXPLICIT_SUBJECT_FINGERPRINT: `sha256:${'a'.repeat(64)}`,

--- a/packages/headless/src/__tests__/harness-ab-cli.test.ts
+++ b/packages/headless/src/__tests__/harness-ab-cli.test.ts
@@ -232,6 +232,34 @@ test('detached harness launcher persists a terminal failed journal after the wor
   }
 });
 
+test('detached OpenCode launcher and worker share the competitor default run id', async () => {
+  const dir = await mkdtemp(join(tmpdir(), 'maka-harness-ab-detached-opencode-'));
+  try {
+    const outDir = join(dir, 'out');
+    const runId = 'k3-maka-vs-opencode-tbench-2.1-full-v1';
+    const scriptPath = new URL('../../harbor/run-harness-ab-detached.mjs', import.meta.url);
+    await execFileAsync(process.execPath, [scriptPath.pathname], {
+      cwd: process.cwd(),
+      env: {
+        ...process.env,
+        MAKA_HARNESS_AB_OUT_DIR: outDir,
+        MAKA_HARNESS_AB_COMPETITOR: 'opencode',
+        MAKA_HARNESS_AB_TASKS_ROOT: join(dir, 'missing-tasks'),
+        MAKA_HARNESS_AB_LIMIT: '5',
+        MAKA_HARNESS_AB_DRY_RUN: '1',
+      },
+    });
+
+    const journal = await waitForJournal(
+      join(outDir, runId, 'background-run.json'),
+      (value) => value.status === 'failed',
+    );
+    assert.equal(journal.exitCode, 1);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
 test('duplicate detached launch does not overwrite the active run journal', async () => {
   const dir = await mkdtemp(join(tmpdir(), 'maka-harness-ab-detached-'));
   try {

--- a/packages/headless/src/__tests__/harness-ab-cli.test.ts
+++ b/packages/headless/src/__tests__/harness-ab-cli.test.ts
@@ -170,6 +170,7 @@ test('harness A/B defaults to pinned Kimi Code and keeps OpenCode selectable', a
   const competitor = manifest.arms.find((arm: { id: string }) => arm.id === 'kimi-code');
   assert.equal(competitor?.metadata.version, '0.26.0');
   assert.equal(competitor?.metadata.config.profile, 'kimi-code');
+  assert.equal(competitor?.metadata.config.permissions, 'prompt-auto');
   assert.equal(resolveHarnessCompetitorProfile('opencode').version, '1.17.18');
   assert.throws(() => resolveHarnessCompetitorProfile('unknown'), /MAKA_HARNESS_AB_COMPETITOR/);
   assert.deepEqual(manifest.metadata.model, {

--- a/packages/headless/src/__tests__/harness-ab-report.test.ts
+++ b/packages/headless/src/__tests__/harness-ab-report.test.ts
@@ -30,7 +30,7 @@ describe('harness A/B report', () => {
 
     const report = buildHarnessAbReport(summary);
 
-    assert.equal(report.schemaVersion, 'maka.harness_ab.report.v2');
+    assert.equal(report.schemaVersion, 'maka.harness_ab.report.v3');
     assert.deepEqual(report.effectiveness, {
       metric: 'pass@1',
       pairedEvaluated: 2,
@@ -43,23 +43,44 @@ describe('harness A/B report', () => {
     });
     assert.equal(report.economy.baseline.totalTokens, 240);
     assert.equal(report.economy.candidate.totalTokens, 360);
-    assert.equal(report.economy.baseline.apiEquivalentCostUsd, 0.00036);
-    assert.equal(report.economy.candidate.apiEquivalentCostUsd, 0.00064);
+    assert.equal(report.economy.baseline.costUsd, 0.00036);
+    assert.equal(report.economy.candidate.costUsd, 0.00064);
     assert.equal(report.economy.baseline.costPerPassUsd, 0.00018);
     assert.equal(report.economy.candidate.costPerPassUsd, 0.00064);
     assert.equal('score' in report, false);
 
     const csv = renderHarnessAbReportCsv(report);
-    assert.match(csv, /^run_status,stop_reason,scheduled_cells,attempted_cells,model_scored_cells,infra_failed_cells,unscored_cells,missing_final_usage_cells,paired_evaluated,paired_metered,missing_usage_pairs,axis,metric,baseline_arm,baseline_value,candidate_arm,candidate_value,candidate_minus_baseline\n/);
-    assert.match(csv, /completed,,4,4,4,0,0,0,2,2,0,effectiveness,pass_rate,maka,1,opencode,0.5,-0.5/);
-    assert.match(csv, /completed,,4,4,4,0,0,0,2,2,0,economy,total_tokens,maka,240,opencode,360,120/);
+    assert.match(csv, /^run_status,stop_reason,billing_mode,economy_basis,scheduled_cells,attempted_cells,model_scored_cells,infra_failed_cells,unscored_cells,missing_final_usage_cells,paired_evaluated,paired_metered,missing_usage_pairs,axis,metric,baseline_arm,baseline_value,candidate_arm,candidate_value,candidate_minus_baseline\n/);
+    assert.match(csv, /completed,,metered,cache-aware-api-equivalent-usd,4,4,4,0,0,0,2,2,0,effectiveness,pass_rate,maka,1,opencode,0.5,-0.5/);
+    assert.match(csv, /completed,,metered,cache-aware-api-equivalent-usd,4,4,4,0,0,0,2,2,0,economy,total_tokens,maka,240,opencode,360,120/);
 
     const markdown = renderHarnessAbReportMarkdown(report);
-    assert.match(markdown, /# Maka vs OpenCode — GLM-5\.2 Harness Comparison/);
+    assert.match(markdown, /# maka vs opencode — Harness Comparison/);
     assert.match(markdown, /Pass@1/);
-    assert.match(markdown, /API-equivalent cost/);
+    assert.match(markdown, /Recorded cost/);
     assert.match(markdown, /Cell coverage: 4\/4 attempted; 4 model-scored; 0 unscored \(including 0 infra-failed\); 0 missing final usage\./);
     assert.match(markdown, /No composite score/);
+  });
+
+  test('labels account-plan cost without presenting it as public API pricing', () => {
+    const summary = summarizeAbComparison({
+      runId: 'k3-maka-vs-kimi-code',
+      roundId: 'ab-summary',
+      baselineArmId: 'maka',
+      candidateArmId: 'kimi-code',
+      evaluationTaskIds: ['a'],
+      baselineRuns: [[usage('a', true, 100, 20, 25, 0)]],
+      candidateRuns: [[usage('a', true, 120, 30, 30, 0)]],
+    });
+
+    const report = buildHarnessAbReport(summary, undefined, 'account-plan');
+    const markdown = renderHarnessAbReportMarkdown(report);
+
+    assert.equal(report.billingMode, 'account-plan');
+    assert.equal(report.economy.basis, 'account-plan-recorded-usd');
+    assert.match(markdown, /# maka vs kimi-code — Harness Comparison/);
+    assert.match(markdown, /Recorded cost is zero under the frozen account-plan billing profile/);
+    assert.doesNotMatch(markdown, /public price snapshot/);
   });
 
   test('completes with explicit cell coverage when every cell is attempted but one fails in infrastructure', () => {
@@ -75,7 +96,7 @@ describe('harness A/B report', () => {
 
     const report = buildHarnessAbReport(summary);
 
-    assert.equal(report.schemaVersion, 'maka.harness_ab.report.v2');
+    assert.equal(report.schemaVersion, 'maka.harness_ab.report.v3');
     assert.equal(report.runStatus, 'completed_with_gaps');
     assert.deepEqual(report.coverage, {
       scheduledCells: 4,
@@ -85,8 +106,8 @@ describe('harness A/B report', () => {
       unscoredCells: 1,
       missingFinalUsageCells: 0,
     });
-    assert.doesNotThrow(() => assertHarnessAbReportCompleted(report));
-    assert.match(renderHarnessAbReportCsv(report), /completed_with_gaps,,4,4,3,1,1,0,1,1,0,effectiveness,pass_rate/);
+    assert.throws(() => assertHarnessAbReportCompleted(report), /completed with gaps/);
+    assert.match(renderHarnessAbReportCsv(report), /completed_with_gaps,,metered,cache-aware-api-equivalent-usd,4,4,3,1,1,0,1,1,0,effectiveness,pass_rate/);
     assert.match(renderHarnessAbReportMarkdown(report), /Status: completed_with_gaps\./);
     assert.deepEqual(report.effectiveness.baseline, {
       armId: 'maka',
@@ -216,7 +237,7 @@ describe('harness A/B report', () => {
     assert.equal(report.economy.baseline.costPerPassUsd, 0.1);
     assert.equal(report.economy.candidate.costPerPassUsd, 0.2);
     assert.match(renderHarnessAbReportMarkdown(report), /fully metered pairs: 1; missing usage: 1/);
-    assert.doesNotThrow(() => assertHarnessAbReportCompleted(report));
+    assert.throws(() => assertHarnessAbReportCompleted(report), /completed with gaps/);
   });
 
   test('keeps timeout usage checkpoints out of final metering without making execution incomplete', () => {
@@ -260,8 +281,8 @@ describe('harness A/B report', () => {
 
     assert.equal(report.runStatus, 'stopped');
     assert.equal(report.stopReason, 'systemic_provider_failure');
-    assert.match(renderHarnessAbReportCsv(report), /^run_status,stop_reason,scheduled_cells,attempted_cells,model_scored_cells,infra_failed_cells,unscored_cells,missing_final_usage_cells,paired_evaluated,paired_metered,missing_usage_pairs,axis,metric,/);
-    assert.match(renderHarnessAbReportCsv(report), /stopped,systemic_provider_failure,2,2,1,1,1,0,0,0,0,effectiveness,pass_rate/);
+    assert.match(renderHarnessAbReportCsv(report), /^run_status,stop_reason,billing_mode,economy_basis,scheduled_cells,attempted_cells,model_scored_cells,infra_failed_cells,unscored_cells,missing_final_usage_cells,paired_evaluated,paired_metered,missing_usage_pairs,axis,metric,/);
+    assert.match(renderHarnessAbReportCsv(report), /stopped,systemic_provider_failure,metered,cache-aware-api-equivalent-usd,2,2,1,1,1,0,0,0,0,effectiveness,pass_rate/);
     assert.match(renderHarnessAbReportMarkdown(report), /Status: stopped \(systemic_provider_failure\)\./);
     assert.throws(
       () => assertHarnessAbReportCompleted(report),

--- a/packages/headless/src/__tests__/harness-ab-run.test.ts
+++ b/packages/headless/src/__tests__/harness-ab-run.test.ts
@@ -5,7 +5,7 @@ import { join } from 'node:path';
 import { describe, test } from 'node:test';
 import { hashHarborSystemPrompt, type HarborCellOutput } from '../cell-output.js';
 import type { HarborTaskRunner } from '../fixed-prompt-controller.js';
-import { buildHarnessAbReport } from '../harness-ab-report.js';
+import { assertHarnessAbReportCompleted, buildHarnessAbReport } from '../harness-ab-report.js';
 import { runHarnessAbComparison } from '../harness-ab-run.js';
 import { HarborInfraError } from '../harbor-task-runner.js';
 import { tokenSummary } from './helpers/cell-output-fixtures.js';
@@ -258,6 +258,46 @@ describe('runHarnessAbComparison', () => {
         unscoredCells: 1,
         missingFinalUsageCells: 0,
       });
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  test('fails closed when an otherwise completed harness cell has no final usage', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'maka-harness-ab-final-usage-'));
+    try {
+      const promptPath = join(dir, 'empty-system-prompt.txt');
+      const resultsPath = join(dir, 'results.jsonl');
+      await writeFile(promptPath, '', 'utf8');
+      const calls: string[] = [];
+      const maka = harnessArm('maka', calls);
+      const meteredRunner = maka.harborRunner;
+      maka.harborRunner = async (input) => {
+        const output = await meteredRunner(input);
+        const { tokenSummary: _tokenSummary, ...cell } = output.cell;
+        return { ...output, cell };
+      };
+
+      const summary = await runHarnessAbComparison({
+        runId: 'glm-harness-ab',
+        runRoot: dir,
+        resultsJsonlPath: resultsPath,
+        systemPromptPath: promptPath,
+        resumeFingerprint: 'sha256:manifest',
+        evaluationTasks: [{ id: 'a', path: '/tasks/a' }],
+        arms: [maka, harnessArm('opencode', calls)],
+      });
+      const events = (await readFile(resultsPath, 'utf8')).trim().split('\n').map((line) => JSON.parse(line) as {
+        type: string;
+        errorClass?: string;
+      });
+      const report = buildHarnessAbReport(summary);
+
+      assert.ok(events.some((event) => (
+        event.type === 'task_plumbing_failed' && event.errorClass === 'missing_token_usage'
+      )));
+      assert.equal(report.runStatus, 'completed_with_gaps');
+      assert.throws(() => assertHarnessAbReportCompleted(report), /completed with gaps/);
     } finally {
       await rm(dir, { recursive: true, force: true });
     }

--- a/packages/headless/src/__tests__/kimi-code-toolchain.test.ts
+++ b/packages/headless/src/__tests__/kimi-code-toolchain.test.ts
@@ -1,0 +1,23 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import {
+  KIMI_CODE_TOOLCHAIN_FINGERPRINT,
+  KIMI_CODE_TOOLCHAIN_SPEC,
+} from '../kimi-code-toolchain.js';
+
+test('Kimi Code toolchain pins the official package and extracted entrypoint', () => {
+  assert.equal(KIMI_CODE_TOOLCHAIN_SPEC.kimiCode.version, '0.26.0');
+  assert.equal(
+    KIMI_CODE_TOOLCHAIN_SPEC.kimiCode.archiveIntegrity,
+    'sha512-GadxPxbCYOfkMgX8sF6VyuligSTLU81sxJswMtzM5D0vmB7/ZGM7PBmUn6YF2fV/nKcx1JgPIHEc3vgKCQgqsQ==',
+  );
+  assert.equal(
+    KIMI_CODE_TOOLCHAIN_SPEC.kimiCode.entrypointSha256,
+    'bc310a7d2f0c3c2cb1367fa7b2092375351efff51c6d4a358b8681b4a01fb7b0',
+  );
+  assert.equal(
+    KIMI_CODE_TOOLCHAIN_SPEC.kimiCode.packageJsonSha256,
+    '65dfa318a882d834e356828d0f371f349f2dcfc99585cb01412f7c0a9e6ae52a',
+  );
+  assert.match(KIMI_CODE_TOOLCHAIN_FINGERPRINT, /^sha256:[a-f0-9]{64}$/);
+});

--- a/packages/headless/src/__tests__/provider-auth-proxy.test.ts
+++ b/packages/headless/src/__tests__/provider-auth-proxy.test.ts
@@ -97,6 +97,52 @@ test('provider auth proxy supports Anthropic x-api-key without replacing the cli
   }
 });
 
+test('provider auth proxy totals Anthropic streaming usage without changing the response bytes', async () => {
+  const dir = await mkdtemp(join(tmpdir(), 'maka-provider-proxy-usage-'));
+  const stream = [
+    'event: message_start',
+    'data: {"type":"message_start","message":{"usage":{"input_tokens":70,"cache_creation_input_tokens":10,"cache_read_input_tokens":20,"output_tokens":1}}}',
+    '',
+    'event: message_delta',
+    'data: {"type":"message_delta","usage":{"output_tokens":25}}',
+    '',
+  ].join('\n');
+  const upstream = createServer((_request, response) => {
+    response.writeHead(200, { 'content-type': 'text/event-stream' });
+    response.write(stream.slice(0, 91));
+    response.end(stream.slice(91));
+  });
+  await new Promise<void>((resolve) => upstream.listen(0, '127.0.0.1', resolve));
+  const address = upstream.address();
+  assert.ok(address && typeof address !== 'string');
+  const keyFile = join(dir, 'provider-key');
+  await writeFile(keyFile, 'provider-secret-key\n', 'utf8');
+  const proxy = await startProviderAuthProxy({
+    upstreamBaseUrl: `http://127.0.0.1:${address.port}`,
+    apiKeyFile: keyFile,
+    advertisedHost: '127.0.0.1',
+  });
+
+  try {
+    const response = await fetch(`${proxy.baseUrl}/messages`, {
+      method: 'POST',
+      headers: { authorization: `Bearer ${proxy.token}` },
+      body: '{}',
+    });
+    assert.equal(await response.text(), stream);
+    assert.deepEqual(proxy.usage(), {
+      input: 100,
+      cacheRead: 20,
+      cacheWrite: 10,
+      output: 25,
+    });
+  } finally {
+    await proxy.close();
+    await new Promise<void>((resolve, reject) => upstream.close((error) => error ? reject(error) : resolve()));
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
 test('provider auth proxy aborts an in-flight upstream request on close', async () => {
   const dir = await mkdtemp(join(tmpdir(), 'maka-provider-proxy-close-'));
   let received!: () => void;

--- a/packages/headless/src/__tests__/provider-auth-proxy.test.ts
+++ b/packages/headless/src/__tests__/provider-auth-proxy.test.ts
@@ -121,6 +121,7 @@ test('provider auth proxy totals Anthropic streaming usage without changing the 
     upstreamBaseUrl: `http://127.0.0.1:${address.port}`,
     apiKeyFile: keyFile,
     advertisedHost: '127.0.0.1',
+    usageProtocol: 'anthropic-sse',
   });
 
   try {
@@ -136,6 +137,84 @@ test('provider auth proxy totals Anthropic streaming usage without changing the 
       cacheWrite: 10,
       output: 25,
     });
+  } finally {
+    await proxy.close();
+    await new Promise<void>((resolve, reject) => upstream.close((error) => error ? reject(error) : resolve()));
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test('provider auth proxy totals OpenAI chat streaming usage without changing the response bytes', async () => {
+  const dir = await mkdtemp(join(tmpdir(), 'maka-provider-proxy-openai-usage-'));
+  const stream = [
+    'data: {"id":"chatcmpl-1","choices":[],"usage":{"prompt_tokens":100,"completion_tokens":25,"prompt_tokens_details":{"cached_tokens":20}}}',
+    '',
+    'data: [DONE]',
+    '',
+  ].join('\n');
+  const upstream = createServer((_request, response) => {
+    response.writeHead(200, { 'content-type': 'text/event-stream' });
+    response.write(stream.slice(0, 73));
+    response.end(stream.slice(73));
+  });
+  await new Promise<void>((resolve) => upstream.listen(0, '127.0.0.1', resolve));
+  const address = upstream.address();
+  assert.ok(address && typeof address !== 'string');
+  const keyFile = join(dir, 'provider-key');
+  await writeFile(keyFile, 'provider-secret-key\n', 'utf8');
+  const proxy = await startProviderAuthProxy({
+    upstreamBaseUrl: `http://127.0.0.1:${address.port}`,
+    apiKeyFile: keyFile,
+    advertisedHost: '127.0.0.1',
+    usageProtocol: 'openai-chat-sse',
+  });
+
+  try {
+    const response = await fetch(`${proxy.baseUrl}/chat/completions`, {
+      method: 'POST',
+      headers: { authorization: `Bearer ${proxy.token}` },
+      body: '{}',
+    });
+    assert.equal(await response.text(), stream);
+    assert.deepEqual(proxy.usage(), {
+      input: 100,
+      cacheRead: 20,
+      cacheWrite: 0,
+      output: 25,
+    });
+  } finally {
+    await proxy.close();
+    await new Promise<void>((resolve, reject) => upstream.close((error) => error ? reject(error) : resolve()));
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test('provider auth proxy keeps unknown streaming usage schemas missing', async () => {
+  const dir = await mkdtemp(join(tmpdir(), 'maka-provider-proxy-unknown-usage-'));
+  const upstream = createServer((_request, response) => {
+    response.writeHead(200, { 'content-type': 'text/event-stream' });
+    response.end('data: {"choices":[],"usage":{"unknown_tokens":99}}\n\n');
+  });
+  await new Promise<void>((resolve) => upstream.listen(0, '127.0.0.1', resolve));
+  const address = upstream.address();
+  assert.ok(address && typeof address !== 'string');
+  const keyFile = join(dir, 'provider-key');
+  await writeFile(keyFile, 'provider-secret-key\n', 'utf8');
+  const proxy = await startProviderAuthProxy({
+    upstreamBaseUrl: `http://127.0.0.1:${address.port}`,
+    apiKeyFile: keyFile,
+    advertisedHost: '127.0.0.1',
+    usageProtocol: 'openai-chat-sse',
+  });
+
+  try {
+    const response = await fetch(`${proxy.baseUrl}/chat/completions`, {
+      method: 'POST',
+      headers: { authorization: `Bearer ${proxy.token}` },
+      body: '{}',
+    });
+    await response.text();
+    assert.equal(proxy.usage(), null);
   } finally {
     await proxy.close();
     await new Promise<void>((resolve, reject) => upstream.close((error) => error ? reject(error) : resolve()));

--- a/packages/headless/src/__tests__/provider-auth-proxy.test.ts
+++ b/packages/headless/src/__tests__/provider-auth-proxy.test.ts
@@ -53,6 +53,50 @@ test('provider auth proxy keeps the provider key host-side', async () => {
   }
 });
 
+test('provider auth proxy supports Anthropic x-api-key without replacing the client user agent', async () => {
+  const dir = await mkdtemp(join(tmpdir(), 'maka-provider-proxy-anthropic-'));
+  const providerKey = 'anthropic-provider-secret';
+  let upstreamApiKey = '';
+  let upstreamAuthorization = '';
+  let upstreamUserAgent = '';
+  const upstream = createServer((request, response) => {
+    upstreamApiKey = String(request.headers['x-api-key'] ?? '');
+    upstreamAuthorization = request.headers.authorization ?? '';
+    upstreamUserAgent = request.headers['user-agent'] ?? '';
+    response.writeHead(200).end('ok');
+  });
+  await new Promise<void>((resolve) => upstream.listen(0, '127.0.0.1', resolve));
+  const address = upstream.address();
+  assert.ok(address && typeof address !== 'string');
+  const keyFile = join(dir, 'provider-key');
+  await writeFile(keyFile, `${providerKey}\n`, 'utf8');
+  const proxy = await startProviderAuthProxy({
+    upstreamBaseUrl: `http://127.0.0.1:${address.port}/coding/v1`,
+    apiKeyFile: keyFile,
+    advertisedHost: '127.0.0.1',
+    authMode: 'x-api-key',
+  });
+
+  try {
+    const response = await fetch(`${proxy.baseUrl}/messages`, {
+      method: 'POST',
+      headers: {
+        'x-api-key': proxy.token,
+        'user-agent': 'opencode/1.17.18 ai-sdk/6',
+      },
+      body: '{}',
+    });
+    assert.equal(response.status, 200);
+    assert.equal(upstreamApiKey, providerKey);
+    assert.equal(upstreamAuthorization, '');
+    assert.equal(upstreamUserAgent, 'opencode/1.17.18 ai-sdk/6');
+  } finally {
+    await proxy.close();
+    await new Promise<void>((resolve, reject) => upstream.close((error) => error ? reject(error) : resolve()));
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
 test('provider auth proxy aborts an in-flight upstream request on close', async () => {
   const dir = await mkdtemp(join(tmpdir(), 'maka-provider-proxy-close-'));
   let received!: () => void;

--- a/packages/headless/src/fixed-prompt-controller.ts
+++ b/packages/headless/src/fixed-prompt-controller.ts
@@ -342,6 +342,7 @@ export interface RunFixedPromptControllerInput {
   infraFailurePolicy?: 'retry-once' | 'terminal';
   resumeFingerprint?: string;
   requireExecutionIdentity?: boolean;
+  requireFinalUsage?: boolean;
   expectedPricingProfile?: string;
   billingMode?: HarborBillingMode;
   /** Refuse resume when a model attempt was durably admitted but no terminal
@@ -463,6 +464,7 @@ export async function runFixedPromptController(
         systemPrompt,
         expectedPromptHash,
         requireExecutionIdentity: input.requireExecutionIdentity,
+        requireFinalUsage: input.requireFinalUsage,
         expectedPricingProfile: input.expectedPricingProfile,
         billingMode: input.billingMode,
         resumeFingerprint: input.resumeFingerprint,
@@ -621,6 +623,7 @@ async function runTaskAndBuildEvent(input: {
   systemPrompt: string;
   expectedPromptHash: string;
   requireExecutionIdentity?: boolean;
+  requireFinalUsage?: boolean;
   expectedPricingProfile?: string;
   billingMode?: HarborBillingMode;
   resumeFingerprint?: string;
@@ -667,6 +670,7 @@ async function runTaskAndBuildEvent(input: {
         expectedPromptHash: input.expectedPromptHash,
         expectedConfig: input.config,
         requireExecutionIdentity: input.requireExecutionIdentity,
+        requireFinalUsage: input.requireFinalUsage,
         expectedPricingProfile: input.expectedPricingProfile,
         billingMode: input.billingMode,
         resumeFingerprint: input.resumeFingerprint,
@@ -705,6 +709,7 @@ async function runTaskAndBuildEvent(input: {
           expectedPromptHash: input.expectedPromptHash,
           expectedConfig: input.config,
           requireExecutionIdentity: input.requireExecutionIdentity,
+          requireFinalUsage: input.requireFinalUsage,
           expectedPricingProfile: input.expectedPricingProfile,
           billingMode: input.billingMode,
           resumeFingerprint: input.resumeFingerprint,
@@ -728,6 +733,7 @@ async function runTaskAndBuildEvent(input: {
     expectedConfig: input.config,
     expectedPromptHash: input.expectedPromptHash,
     requireExecutionIdentity: input.requireExecutionIdentity,
+    requireFinalUsage: input.requireFinalUsage,
     expectedPricingProfile: input.expectedPricingProfile,
     billingMode: input.billingMode,
     resumeFingerprint: input.resumeFingerprint,
@@ -744,6 +750,7 @@ function taskEventFromOutput(input: {
   expectedConfig: Config;
   expectedPromptHash: string;
   requireExecutionIdentity?: boolean;
+  requireFinalUsage?: boolean;
   expectedPricingProfile?: string;
   billingMode?: HarborBillingMode;
   resumeFingerprint?: string;
@@ -778,6 +785,7 @@ function taskEventFromOutput(input: {
     input.expectedPromptHash,
     input.expectedConfig,
     input.requireExecutionIdentity ?? false,
+    input.requireFinalUsage ?? false,
     input.expectedPricingProfile,
     input.billingMode,
   );
@@ -902,6 +910,7 @@ function classifyPlumbingFailure(
   expectedPromptHash: string,
   expectedConfig: Config,
   requireExecutionIdentity: boolean,
+  requireFinalUsage: boolean,
   expectedPricingProfile: string | undefined,
   billingMode: HarborBillingMode | undefined,
 ): {
@@ -926,6 +935,12 @@ function classifyPlumbingFailure(
     return {
       errorClass: 'prompt_hash_mismatch',
       error: `Harbor cell prompt hash ${output.cell.promptHash} did not match ${expectedPromptHash}`,
+    };
+  }
+  if (requireFinalUsage && output.cell.status === 'completed' && output.cell.tokenSummary === undefined) {
+    return {
+      errorClass: 'missing_token_usage',
+      error: 'Harbor cell did not report final token usage',
     };
   }
   if (billingMode !== 'account-plan' && output.cell.tokenSummary && output.cell.tokenSummary.total > 0 && output.cell.tokenSummary.costUsd === 0) {
@@ -1023,6 +1038,7 @@ function taskBudgetExhaustedEvent(input: {
   expectedPromptHash: string;
   expectedConfig: Config;
   requireExecutionIdentity?: boolean;
+  requireFinalUsage?: boolean;
   expectedPricingProfile?: string;
   billingMode?: HarborBillingMode;
   resumeFingerprint?: string;
@@ -1057,6 +1073,7 @@ function taskBudgetExhaustedEvent(input: {
             input.expectedPromptHash,
             input.expectedConfig,
             input.requireExecutionIdentity ?? false,
+            input.requireFinalUsage ?? false,
             input.expectedPricingProfile,
             input.billingMode,
           ));

--- a/packages/headless/src/harbor-task-runner.ts
+++ b/packages/headless/src/harbor-task-runner.ts
@@ -27,7 +27,7 @@ import {
   resolveHarnessOracleWatchdogTimeoutMs,
   type HarnessOracleTaskResult,
 } from './harness-oracle-policy.js';
-import { startProviderAuthProxy } from './provider-auth-proxy.js';
+import { startProviderAuthProxy, type ProviderTokenUsage } from './provider-auth-proxy.js';
 import {
   providerBaseUrlFromEnv,
   providerCredentialEnv,
@@ -39,6 +39,11 @@ import {
   OPENCODE_TOOLCHAIN_FINGERPRINT,
   OPENCODE_TOOLCHAIN_SPEC,
 } from './opencode-toolchain.js';
+import {
+  KIMI_CODE_TOOLCHAIN_CONTAINER_PATH,
+  KIMI_CODE_TOOLCHAIN_FINGERPRINT,
+  KIMI_CODE_TOOLCHAIN_SPEC,
+} from './kimi-code-toolchain.js';
 
 const execFileAsync = promisify(execFile);
 
@@ -81,11 +86,13 @@ export interface HarborTaskRunnerOptions {
   /** Host path to the maka repo, mounted read-only at /opt/maka-agent. */
   makaRepoPath: string;
   /** Harbor adapter under test (default: Maka). */
-  agent?: 'maka' | 'opencode';
-  /** Version passed to Harbor's installed-agent adapter (used to pin OpenCode). */
+  agent?: 'maka' | 'opencode' | 'kimi-code';
+  /** Version passed to Harbor's installed-agent adapter. */
   agentVersion?: string;
   /** Prepared OpenCode toolchain mounted read-only into task containers. */
   opencodeToolchainPath?: string;
+  /** Prepared Kimi Code toolchain mounted read-only into task containers. */
+  kimiCodeToolchainPath?: string;
   /** Explicit Docker target platform shared by comparison arms. */
   dockerPlatform?: 'linux/amd64';
   /** Base directory under which each task gets an isolated per-task job dir. */
@@ -200,7 +207,7 @@ export function createHarborTaskRunner(options: HarborTaskRunnerOptions): Harbor
     assertNoProviderSecretsInAgentEnv(runnerOptions.agentEnv);
     const hasHostProviderRuntime = runnerOptions.apiKeyFile !== undefined
       || githubCopilotAccountTokenFromEnv(runnerOptions.provider, runnerOptions.agentEnv) !== undefined
-      || (runnerOptions.agent !== 'opencode' && !providerRequiresSecret(runnerOptions.provider));
+      || (!usesHostProviderProxy(runnerOptions.agent) && !providerRequiresSecret(runnerOptions.provider));
     const configPath = join(jobsDir, 'job-config.json');
     const { agentEnv: _attemptAgentEnv, ...inputWithoutAttemptEnv } = input;
     const config = buildHarborJobConfig(inputWithoutAttemptEnv, {
@@ -213,6 +220,7 @@ export function createHarborTaskRunner(options: HarborTaskRunnerOptions): Harbor
 
     const args = ['run', '--config', configPath, '--yes'];
     let result: HarborRunResult;
+    let providerUsage: ProviderTokenUsage | null = null;
     try {
       const providerRuntime = await hostSideProviderRuntime(runnerOptions);
       try {
@@ -226,6 +234,7 @@ export function createHarborTaskRunner(options: HarborTaskRunnerOptions): Harbor
           timeoutMs: resolveHarborTimeoutMs(runnerOptions, input),
           env: { PYTHONPATH: pythonPath, ...(providerRuntime?.env ?? {}) },
         });
+        providerUsage = providerRuntime?.usage?.() ?? null;
       } finally {
         await providerRuntime?.close?.();
       }
@@ -262,7 +271,10 @@ export function createHarborTaskRunner(options: HarborTaskRunnerOptions): Harbor
       );
     }
     const reward = await readReward(rewardPath, resultPath, input.task.id);
-    const cell = await readCellOutput(cellOutputPath, input.task.id);
+    const rawCell = await readCellOutput(cellOutputPath, input.task.id);
+    const cell = rawCell.tokenSummary || !providerUsage || !runnerOptions.pricing
+      ? rawCell
+      : { ...rawCell, tokenSummary: providerTokenSummary(providerUsage, runnerOptions.pricing) };
     const verifierStdout = await readOptionalText(join(trialDir, TRIAL_VERIFIER_STDOUT));
     const verifier = await readVerifierOutcome(join(trialDir, TRIAL_VERIFIER_OUTCOME), input.task.id);
     if (!verifier) {
@@ -605,11 +617,19 @@ export function buildHarborJobConfig(
   if (adapter === 'opencode' && options.agentVersion !== OPENCODE_TOOLCHAIN_SPEC.opencode.version) {
     throw new Error(`OpenCode adapter version must match toolchain version ${OPENCODE_TOOLCHAIN_SPEC.opencode.version}`);
   }
+  if (adapter === 'kimi-code' && !options.kimiCodeToolchainPath) {
+    throw new Error('kimiCodeToolchainPath is required for the Kimi Code adapter');
+  }
+  if (adapter === 'kimi-code' && options.agentVersion !== KIMI_CODE_TOOLCHAIN_SPEC.kimiCode.version) {
+    throw new Error(`Kimi Code adapter version must match toolchain version ${KIMI_CODE_TOOLCHAIN_SPEC.kimiCode.version}`);
+  }
   const mounts: Array<Record<string, unknown>> = [
     { type: 'bind', source: options.makaRepoPath, target: CONTAINER_MAKA_REPO, read_only: true },
     ...(adapter === 'opencode'
       ? [{ type: 'bind', source: options.opencodeToolchainPath!, target: OPENCODE_TOOLCHAIN_CONTAINER_PATH, read_only: true }]
-      : []),
+      : adapter === 'kimi-code'
+        ? [{ type: 'bind', source: options.kimiCodeToolchainPath!, target: KIMI_CODE_TOOLCHAIN_CONTAINER_PATH, read_only: true }]
+        : []),
   ];
 
   const agentEnv: Record<string, string> = {
@@ -626,6 +646,9 @@ export function buildHarborJobConfig(
   }
   if (adapter === 'opencode') {
     agentEnv.MAKA_OPENCODE_TOOLCHAIN_FINGERPRINT = OPENCODE_TOOLCHAIN_FINGERPRINT;
+  }
+  if (adapter === 'kimi-code') {
+    agentEnv.MAKA_KIMI_CODE_TOOLCHAIN_FINGERPRINT = KIMI_CODE_TOOLCHAIN_FINGERPRINT;
   }
 
   if (options.pricing) {
@@ -671,7 +694,11 @@ export function buildHarborJobConfig(
     agents: [
       {
         ...(adapter === 'maka' ? { name: adapter } : {}),
-        import_path: adapter === 'opencode' ? 'opencode_agent:MakaOpenCodeAgent' : 'maka_agent:MakaAgent',
+        import_path: adapter === 'opencode'
+          ? 'opencode_agent:MakaOpenCodeAgent'
+          : adapter === 'kimi-code'
+            ? 'kimi_code_agent:MakaKimiCodeAgent'
+            : 'maka_agent:MakaAgent',
         model_name: agentModel,
         kwargs: adapter === 'maka'
           ? { backend: 'ai-sdk' }
@@ -718,6 +745,7 @@ function verifierPolicy(task: HarborTaskRunInput['task']): {
 
 async function hostSideProviderRuntime(options: HarborTaskRunnerOptions): Promise<{
   env: Record<string, string>;
+  usage?: () => ProviderTokenUsage | null;
   close?: () => Promise<void>;
 } | null> {
   const provider = options.provider ?? 'deepseek';
@@ -744,20 +772,21 @@ async function hostSideProviderRuntime(options: HarborTaskRunnerOptions): Promis
       )
     : undefined;
   const baseUrl = copilotCredential?.baseUrl ?? configuredBaseUrl;
-  if (options.agent === 'opencode') {
+  if (usesHostProviderProxy(options.agent)) {
     const apiKeyFile = options.apiKeyFile;
     if (!apiKeyFile) return null;
-    if (!baseUrl) throw new Error(`OpenCode provider ${provider} requires a base URL`);
+    if (!baseUrl) throw new Error(`${options.agent} provider ${provider} requires a base URL`);
     const proxy = await startProviderAuthProxy({
       upstreamBaseUrl: baseUrl,
       apiKeyFile,
-      authMode: providerProxyAuthMode(provider),
+      authMode: options.agent === 'kimi-code' ? 'bearer' : providerProxyAuthMode(provider),
     });
     return {
       env: {
-        MAKA_OPENCODE_PROVIDER_PROXY_URL: proxy.baseUrl,
-        MAKA_OPENCODE_PROVIDER_PROXY_TOKEN: proxy.token,
+        MAKA_PROVIDER_PROXY_URL: proxy.baseUrl,
+        MAKA_PROVIDER_PROXY_TOKEN: proxy.token,
       },
+      usage: proxy.usage,
       close: proxy.close,
     };
   }
@@ -779,6 +808,36 @@ async function hostSideProviderRuntime(options: HarborTaskRunnerOptions): Promis
       ...(baseUrl ? { MAKA_HOST_BASE_URL: baseUrl } : {}),
       ...(copilotCredential ? { MAKA_HOST_MODEL_API_PROTOCOL: copilotCredential.apiProtocol } : {}),
     },
+  };
+}
+
+function usesHostProviderProxy(agent: HarborTaskRunnerOptions['agent']): boolean {
+  return agent === 'opencode' || agent === 'kimi-code';
+}
+
+function providerTokenSummary(
+  usage: ProviderTokenUsage,
+  pricing: HarborTaskPricing,
+): NonNullable<HarborCellOutput['tokenSummary']> {
+  const cacheMissInput = Math.max(0, usage.input - usage.cacheRead - usage.cacheWrite);
+  const costUsd = (
+    cacheMissInput * pricing.inputUsdPer1M
+    + usage.cacheRead * (pricing.cacheReadUsdPer1M ?? pricing.inputUsdPer1M)
+    + usage.cacheWrite * (pricing.cacheWriteUsdPer1M ?? pricing.inputUsdPer1M)
+    + usage.output * pricing.outputUsdPer1M
+  ) / 1_000_000;
+  return {
+    input: usage.input,
+    output: usage.output,
+    cachedInput: usage.cacheRead,
+    cacheHitInput: usage.cacheRead,
+    cacheMissInput,
+    cacheWriteInput: usage.cacheWrite,
+    cacheMissInputSource: 'explicit',
+    reasoning: 0,
+    total: usage.input + usage.output,
+    costUsd,
+    pricingSource: 'runtime',
   };
 }
 

--- a/packages/headless/src/harbor-task-runner.ts
+++ b/packages/headless/src/harbor-task-runner.ts
@@ -751,6 +751,7 @@ async function hostSideProviderRuntime(options: HarborTaskRunnerOptions): Promis
     const proxy = await startProviderAuthProxy({
       upstreamBaseUrl: baseUrl,
       apiKeyFile,
+      authMode: providerProxyAuthMode(provider),
     });
     return {
       env: {
@@ -779,6 +780,14 @@ async function hostSideProviderRuntime(options: HarborTaskRunnerOptions): Promis
       ...(copilotCredential ? { MAKA_HOST_MODEL_API_PROTOCOL: copilotCredential.apiProtocol } : {}),
     },
   };
+}
+
+function providerProxyAuthMode(provider: string): 'bearer' | 'x-api-key' {
+  const definition = (PROVIDER_DEFAULTS as Partial<Record<string, (typeof PROVIDER_DEFAULTS)[ProviderType]>>)[provider];
+  return definition?.runtimeAdapter.kind === 'anthropic'
+    && definition.runtimeAdapter.auth === 'api-key'
+    ? 'x-api-key'
+    : 'bearer';
 }
 
 async function resolveGitHubCopilotHostCredential(

--- a/packages/headless/src/harbor-task-runner.ts
+++ b/packages/headless/src/harbor-task-runner.ts
@@ -27,7 +27,11 @@ import {
   resolveHarnessOracleWatchdogTimeoutMs,
   type HarnessOracleTaskResult,
 } from './harness-oracle-policy.js';
-import { startProviderAuthProxy, type ProviderTokenUsage } from './provider-auth-proxy.js';
+import {
+  startProviderAuthProxy,
+  type ProviderTokenUsage,
+  type ProviderUsageProtocol,
+} from './provider-auth-proxy.js';
 import {
   providerBaseUrlFromEnv,
   providerCredentialEnv,
@@ -749,8 +753,9 @@ async function hostSideProviderRuntime(options: HarborTaskRunnerOptions): Promis
   close?: () => Promise<void>;
 } | null> {
   const provider = options.provider ?? 'deepseek';
-  if (options.agent === 'opencode' && provider === 'github-copilot') {
-    throw new Error('GitHub Copilot Harbor runs use the Maka host agent; the OpenCode Harbor adapter does not support this provider');
+  if (usesHostProviderProxy(options.agent) && provider === 'github-copilot') {
+    const adapter = options.agent === 'kimi-code' ? 'Kimi Code' : 'OpenCode';
+    throw new Error(`GitHub Copilot Harbor runs use the Maka host agent; the ${adapter} Harbor adapter does not support this provider`);
   }
   const githubToken = provider === 'github-copilot'
     ? options.apiKeyFile
@@ -780,6 +785,7 @@ async function hostSideProviderRuntime(options: HarborTaskRunnerOptions): Promis
       upstreamBaseUrl: baseUrl,
       apiKeyFile,
       authMode: options.agent === 'kimi-code' ? 'bearer' : providerProxyAuthMode(provider),
+      usageProtocol: providerProxyUsageProtocol(options.agent, provider),
     });
     return {
       env: {
@@ -847,6 +853,17 @@ function providerProxyAuthMode(provider: string): 'bearer' | 'x-api-key' {
     && definition.runtimeAdapter.auth === 'api-key'
     ? 'x-api-key'
     : 'bearer';
+}
+
+function providerProxyUsageProtocol(
+  agent: HarborTaskRunnerOptions['agent'],
+  provider: string,
+): ProviderUsageProtocol | undefined {
+  if (agent === 'kimi-code') return 'openai-chat-sse';
+  const definition = (PROVIDER_DEFAULTS as Partial<Record<string, (typeof PROVIDER_DEFAULTS)[ProviderType]>>)[provider];
+  if (definition?.runtimeAdapter.kind === 'anthropic') return 'anthropic-sse';
+  if (definition?.runtimeAdapter.kind === 'openai-compatible') return 'openai-chat-sse';
+  return undefined;
 }
 
 async function resolveGitHubCopilotHostCredential(

--- a/packages/headless/src/harness-ab-manifest.ts
+++ b/packages/headless/src/harness-ab-manifest.ts
@@ -3,7 +3,7 @@ import { buildAbRunManifest, buildRunManifestFingerprint } from './ab-manifest.j
 import type { AbRunManifest } from './ab-types.js';
 import type { HarnessOracleAnnotation } from './harness-oracle-registry.js';
 
-export type HarnessAbArmId = 'maka' | 'opencode';
+export type HarnessAbArmId = 'maka' | 'opencode' | 'kimi-code';
 
 export const HARNESS_AB_PAIR_CONCURRENCY = 2;
 export const HARNESS_AB_MAX_CONCURRENT_ATTEMPTS = HARNESS_AB_PAIR_CONCURRENCY * 2;

--- a/packages/headless/src/harness-ab-manifest.ts
+++ b/packages/headless/src/harness-ab-manifest.ts
@@ -176,6 +176,7 @@ export interface HarnessAbRunManifestInput {
   subjectFingerprint: string;
   taskSourceFingerprint: string;
   toolchainFingerprint: string;
+  pairConcurrency?: number;
   oracleEvidence?: {
     registryUrl?: string;
     expectedSnapshotFingerprint?: string;
@@ -223,6 +224,10 @@ export function deterministicHarnessTaskOrder(taskIds: readonly string[], seed: 
 
 export function buildHarnessAbRunManifest(input: HarnessAbRunManifestInput): HarnessAbRunManifest {
   const evaluationTaskIds = deterministicHarnessTaskOrder(input.taskIds, input.orderSeed);
+  const pairConcurrency = input.pairConcurrency ?? HARNESS_AB_PAIR_CONCURRENCY;
+  if (!Number.isSafeInteger(pairConcurrency) || pairConcurrency < 1) {
+    throw new Error('pairConcurrency must be a positive integer');
+  }
   if (
     !Number.isSafeInteger(input.pilotTaskCount)
     || input.pilotTaskCount < 1
@@ -266,8 +271,8 @@ export function buildHarnessAbRunManifest(input: HarnessAbRunManifestInput): Har
     pilotTaskIds: evaluationTaskIds.slice(0, input.pilotTaskCount),
     reps: 1,
     candidateLimit: null,
-    maxConcurrency: HARNESS_AB_PAIR_CONCURRENCY,
-    maxConcurrentAttempts: HARNESS_AB_MAX_CONCURRENT_ATTEMPTS,
+    maxConcurrency: pairConcurrency,
+    maxConcurrentAttempts: pairConcurrency * 2,
     selectionMode: 'explicit',
   });
   return manifest as HarnessAbRunManifest;

--- a/packages/headless/src/harness-ab-report.ts
+++ b/packages/headless/src/harness-ab-report.ts
@@ -15,15 +15,16 @@ export interface HarnessAbArmEconomy {
   uncachedInputTokens: number;
   outputTokens: number;
   totalTokens: number;
-  apiEquivalentCostUsd: number;
+  costUsd: number;
   tokensPerMetered: number | null;
   costPerMeteredUsd: number | null;
   costPerPassUsd: number | null;
 }
 
 export interface HarnessAbReport {
-  schemaVersion: 'maka.harness_ab.report.v2';
+  schemaVersion: 'maka.harness_ab.report.v3';
   runId: string;
+  billingMode: 'metered' | 'account-plan';
   runStatus: 'completed' | 'completed_with_gaps' | 'incomplete' | 'stopped';
   stopReason?: NonNullable<AbComparisonSummary['stopReason']>;
   taskCount: number;
@@ -46,7 +47,7 @@ export interface HarnessAbReport {
     ties: number;
   };
   economy: {
-    basis: 'cache-aware-api-equivalent-usd';
+    basis: 'cache-aware-api-equivalent-usd' | 'account-plan-recorded-usd';
     pairedMetered: number;
     missingUsagePairs: number;
     baseline: HarnessAbArmEconomy;
@@ -69,6 +70,7 @@ export interface HarnessAbOracleEvidenceReportInput {
 export function buildHarnessAbReport(
   summary: AbComparisonSummary,
   oracleEvidence?: HarnessAbOracleEvidenceReportInput,
+  billingMode: HarnessAbReport['billingMode'] = 'metered',
 ): HarnessAbReport {
   const coverage = {
     scheduledCells: summary.baseline.attempts + summary.candidate.attempts,
@@ -87,8 +89,9 @@ export function buildHarnessAbReport(
         ? 'completed_with_gaps'
         : 'completed';
   return {
-    schemaVersion: 'maka.harness_ab.report.v2',
+    schemaVersion: 'maka.harness_ab.report.v3',
     runId: summary.runId,
+    billingMode,
     runStatus,
     ...(summary.stopReason ? { stopReason: summary.stopReason } : {}),
     taskCount: summary.taskCount,
@@ -112,7 +115,9 @@ export function buildHarnessAbReport(
       ties: summary.pairedAttempts.ties,
     },
     economy: {
-      basis: 'cache-aware-api-equivalent-usd',
+      basis: billingMode === 'account-plan'
+        ? 'account-plan-recorded-usd'
+        : 'cache-aware-api-equivalent-usd',
       pairedMetered: summary.pairedAttempts.fullyMeteredPairs,
       missingUsagePairs: summary.pairedAttempts.missingUsagePairIds.length,
       baseline: armEconomy(
@@ -154,16 +159,18 @@ export function renderHarnessAbReportCsv(report: HarnessAbReport): string {
     ['economy', 'uncached_input_tokens', baselineEconomy.armId, baselineEconomy.uncachedInputTokens, candidateEconomy.armId, candidateEconomy.uncachedInputTokens, candidateEconomy.uncachedInputTokens - baselineEconomy.uncachedInputTokens],
     ['economy', 'output_tokens', baselineEconomy.armId, baselineEconomy.outputTokens, candidateEconomy.armId, candidateEconomy.outputTokens, candidateEconomy.outputTokens - baselineEconomy.outputTokens],
     ['economy', 'total_tokens', baselineEconomy.armId, baselineEconomy.totalTokens, candidateEconomy.armId, candidateEconomy.totalTokens, candidateEconomy.totalTokens - baselineEconomy.totalTokens],
-    ['economy', 'api_equivalent_cost_usd', baselineEconomy.armId, baselineEconomy.apiEquivalentCostUsd, candidateEconomy.armId, candidateEconomy.apiEquivalentCostUsd, candidateEconomy.apiEquivalentCostUsd - baselineEconomy.apiEquivalentCostUsd],
+    ['economy', 'recorded_cost_usd', baselineEconomy.armId, baselineEconomy.costUsd, candidateEconomy.armId, candidateEconomy.costUsd, candidateEconomy.costUsd - baselineEconomy.costUsd],
     ['economy', 'tokens_per_metered', baselineEconomy.armId, baselineEconomy.tokensPerMetered, candidateEconomy.armId, candidateEconomy.tokensPerMetered, nullableDelta(candidateEconomy.tokensPerMetered, baselineEconomy.tokensPerMetered)],
     ['economy', 'cost_per_metered_usd', baselineEconomy.armId, baselineEconomy.costPerMeteredUsd, candidateEconomy.armId, candidateEconomy.costPerMeteredUsd, nullableDelta(candidateEconomy.costPerMeteredUsd, baselineEconomy.costPerMeteredUsd)],
     ['economy', 'cost_per_pass_usd', baselineEconomy.armId, baselineEconomy.costPerPassUsd, candidateEconomy.armId, candidateEconomy.costPerPassUsd, nullableDelta(candidateEconomy.costPerPassUsd, baselineEconomy.costPerPassUsd)],
   ];
   return [
-    'run_status,stop_reason,scheduled_cells,attempted_cells,model_scored_cells,infra_failed_cells,unscored_cells,missing_final_usage_cells,paired_evaluated,paired_metered,missing_usage_pairs,axis,metric,baseline_arm,baseline_value,candidate_arm,candidate_value,candidate_minus_baseline',
+    'run_status,stop_reason,billing_mode,economy_basis,scheduled_cells,attempted_cells,model_scored_cells,infra_failed_cells,unscored_cells,missing_final_usage_cells,paired_evaluated,paired_metered,missing_usage_pairs,axis,metric,baseline_arm,baseline_value,candidate_arm,candidate_value,candidate_minus_baseline',
     ...rows.map((row) => [
       report.runStatus,
       report.stopReason ?? '',
+      report.billingMode,
+      report.economy.basis,
       report.coverage.scheduledCells,
       report.coverage.attemptedCells,
       report.coverage.modelScoredCells,
@@ -182,7 +189,7 @@ export function renderHarnessAbReportMarkdown(report: HarnessAbReport): string {
   const { baseline: baselineEffectiveness, candidate: candidateEffectiveness } = report.effectiveness;
   const { baseline: baselineEconomy, candidate: candidateEconomy } = report.economy;
   return [
-    '# Maka vs OpenCode — GLM-5.2 Harness Comparison',
+    `# ${baselineEffectiveness.armId} vs ${candidateEffectiveness.armId} — Harness Comparison`,
     '',
     `Status: ${report.runStatus}${report.stopReason ? ` (${report.stopReason})` : ''}.`,
     '',
@@ -206,13 +213,15 @@ export function renderHarnessAbReportMarkdown(report: HarnessAbReport): string {
     `| Cached input tokens | ${baselineEconomy.cachedInputTokens} | ${candidateEconomy.cachedInputTokens} |`,
     `| Uncached input tokens | ${baselineEconomy.uncachedInputTokens} | ${candidateEconomy.uncachedInputTokens} |`,
     `| Output tokens | ${baselineEconomy.outputTokens} | ${candidateEconomy.outputTokens} |`,
-    `| API-equivalent cost (USD) | ${baselineEconomy.apiEquivalentCostUsd} | ${candidateEconomy.apiEquivalentCostUsd} |`,
+    `| Recorded cost (USD) | ${baselineEconomy.costUsd} | ${candidateEconomy.costUsd} |`,
     `| Cost per fully metered task (USD) | ${value(baselineEconomy.costPerMeteredUsd)} | ${value(candidateEconomy.costPerMeteredUsd)} |`,
     `| Cost per pass (USD) | ${value(baselineEconomy.costPerPassUsd)} | ${value(candidateEconomy.costPerPassUsd)} |`,
     '',
     '## Interpretation boundary',
     '',
-    'No composite score: effectiveness and economy are reported as separate axes. Cost is a cache-aware API-equivalent estimate from the frozen public price snapshot, not the fixed-plan bill.',
+    report.billingMode === 'account-plan'
+      ? 'No composite score: effectiveness and economy are reported as separate axes. Recorded cost is zero under the frozen account-plan billing profile; real token usage remains the economy measure.'
+      : 'No composite score: effectiveness and economy are reported as separate axes. Recorded cost is a cache-aware API-equivalent estimate from the frozen pricing profile.',
     '',
   ].join('\n');
 }
@@ -252,6 +261,9 @@ export function assertHarnessAbReportCompleted(report: HarnessAbReport): void {
   if (report.runStatus === 'incomplete') {
     throw new Error(`harness A/B incomplete: ${report.coverage.attemptedCells}/${report.coverage.scheduledCells} scheduled cells attempted`);
   }
+  if (report.runStatus === 'completed_with_gaps') {
+    throw new Error(`harness A/B completed with gaps: ${report.coverage.unscoredCells} unscored cells; ${report.coverage.missingFinalUsageCells} missing final usage`);
+  }
 }
 
 function pairedArmEffectiveness(
@@ -275,7 +287,7 @@ function armEconomy(
     uncachedInputTokens: tokens.cacheMissInput,
     outputTokens: tokens.output,
     totalTokens: tokens.total,
-    apiEquivalentCostUsd: tokens.costUsd,
+    costUsd: tokens.costUsd,
     tokensPerMetered: divide(tokens.total, evaluated),
     costPerMeteredUsd: divide(tokens.costUsd, evaluated),
     costPerPassUsd: divide(tokens.costUsd, passed),

--- a/packages/headless/src/harness-ab-run.ts
+++ b/packages/headless/src/harness-ab-run.ts
@@ -83,6 +83,7 @@ export async function runHarnessAbComparisonUnlocked(
         infraFailurePolicy: 'terminal',
         protectPassAtOne: true,
         requireExecutionIdentity: true,
+        requireFinalUsage: true,
         expectedPricingProfile: runtimeArm.expectedPricingProfile,
         ...(runtimeArm.billingMode ? { billingMode: runtimeArm.billingMode } : {}),
         resumeFingerprint: input.resumeFingerprint,

--- a/packages/headless/src/harness-ab-run.ts
+++ b/packages/headless/src/harness-ab-run.ts
@@ -3,6 +3,7 @@ import { runAbComparison } from './ab-run.js';
 import { withAbRunLock } from './ab-run-lock.js';
 import type { AbComparisonSummary } from './ab-types.js';
 import type { Config } from './contracts.js';
+import type { HarborBillingMode } from './harbor-task-runner.js';
 import {
   runFixedPromptController,
   type FixedPromptTask,
@@ -17,6 +18,7 @@ export interface HarnessAbRuntimeArm {
   id: HarnessAbArmId;
   config: Config;
   expectedPricingProfile: string;
+  billingMode?: HarborBillingMode;
   harborRunner: HarborTaskRunner;
 }
 
@@ -28,6 +30,7 @@ export interface RunHarnessAbComparisonInput {
   resumeFingerprint: string;
   evaluationTasks: readonly FixedPromptTask[];
   arms: readonly [HarnessAbRuntimeArm, HarnessAbRuntimeArm];
+  pairConcurrency?: number;
   now?: () => number;
   newId?: () => string;
 }
@@ -45,6 +48,10 @@ export function withHarnessAbRunLock<T>(runRoot: string, action: () => Promise<T
 export async function runHarnessAbComparisonUnlocked(
   input: RunHarnessAbComparisonInput,
 ): Promise<AbComparisonSummary> {
+  const pairConcurrency = input.pairConcurrency ?? HARNESS_AB_PAIR_CONCURRENCY;
+  if (!Number.isSafeInteger(pairConcurrency) || pairConcurrency < 1) {
+    throw new Error('pairConcurrency must be a positive integer');
+  }
   return runAbComparison({
     runId: input.runId,
     arms: input.arms.map((arm) => ({
@@ -53,6 +60,7 @@ export async function runHarnessAbComparisonUnlocked(
       fingerprint: buildRunManifestFingerprint({
         config: arm.config,
         expectedPricingProfile: arm.expectedPricingProfile,
+        billingMode: arm.billingMode,
       }),
     })) as unknown as [
       { id: HarnessAbArmId; kind: 'harness'; fingerprint: string },
@@ -60,7 +68,7 @@ export async function runHarnessAbComparisonUnlocked(
     ],
     evaluationTasks: input.evaluationTasks,
     reps: 1,
-    maxConcurrency: HARNESS_AB_PAIR_CONCURRENCY,
+    maxConcurrency: pairConcurrency,
     armExecution: 'parallel',
     runArm: async ({ roundId, arm, task }) => {
       const runtimeArm = input.arms.find((candidate) => candidate.id === arm.id);
@@ -76,6 +84,7 @@ export async function runHarnessAbComparisonUnlocked(
         protectPassAtOne: true,
         requireExecutionIdentity: true,
         expectedPricingProfile: runtimeArm.expectedPricingProfile,
+        ...(runtimeArm.billingMode ? { billingMode: runtimeArm.billingMode } : {}),
         resumeFingerprint: input.resumeFingerprint,
         harborRunner: runtimeArm.harborRunner,
         ...(input.now ? { now: input.now } : {}),

--- a/packages/headless/src/kimi-code-toolchain.ts
+++ b/packages/headless/src/kimi-code-toolchain.ts
@@ -1,0 +1,70 @@
+import { createHash } from 'node:crypto';
+import {
+  prepareNodeCliToolchain,
+  validatePreparedNodeCliToolchain,
+  type PinnedNodeCliToolchainDefinition,
+} from './node-cli-toolchain.js';
+
+export const KIMI_CODE_TOOLCHAIN_CONTAINER_PATH = '/opt/maka-kimi-code-toolchain';
+
+export const KIMI_CODE_TOOLCHAIN_SPEC = {
+  schemaVersion: 1,
+  platform: 'linux',
+  arch: 'x64',
+  node: {
+    version: '22.23.1',
+    archiveUrl: 'https://nodejs.org/dist/v22.23.1/node-v22.23.1-linux-x64.tar.gz',
+    archiveSha256: '7a8cb04b4a1df4eaf432125324b81b29a088e73570a23259a8de1c65d07fc129',
+    binarySha256: '93956de2e59480474a7b46571da1651180b1a050cdf32641ebec4ce6e478e068',
+  },
+  kimiCode: {
+    version: '0.26.0',
+    archiveUrl: 'https://registry.npmjs.org/@moonshot-ai/kimi-code/-/kimi-code-0.26.0.tgz',
+    archiveIntegrity: 'sha512-GadxPxbCYOfkMgX8sF6VyuligSTLU81sxJswMtzM5D0vmB7/ZGM7PBmUn6YF2fV/nKcx1JgPIHEc3vgKCQgqsQ==',
+    entrypointSha256: 'bc310a7d2f0c3c2cb1367fa7b2092375351efff51c6d4a358b8681b4a01fb7b0',
+    packageJsonSha256: '65dfa318a882d834e356828d0f371f349f2dcfc99585cb01412f7c0a9e6ae52a',
+  },
+} as const;
+
+export const KIMI_CODE_TOOLCHAIN_FINGERPRINT = `sha256:${createHash('sha256')
+  .update(JSON.stringify(KIMI_CODE_TOOLCHAIN_SPEC))
+  .digest('hex')}`;
+
+export interface PreparedKimiCodeToolchain {
+  path: string;
+  fingerprint: typeof KIMI_CODE_TOOLCHAIN_FINGERPRINT;
+}
+
+const DEFINITION: PinnedNodeCliToolchainDefinition<typeof KIMI_CODE_TOOLCHAIN_SPEC> = {
+  label: 'Kimi Code',
+  fingerprint: KIMI_CODE_TOOLCHAIN_FINGERPRINT,
+  spec: KIMI_CODE_TOOLCHAIN_SPEC,
+  node: KIMI_CODE_TOOLCHAIN_SPEC.node,
+  packageArchive: {
+    url: KIMI_CODE_TOOLCHAIN_SPEC.kimiCode.archiveUrl,
+    integrity: KIMI_CODE_TOOLCHAIN_SPEC.kimiCode.archiveIntegrity,
+  },
+  packageFiles: [{
+    archivePath: 'package/dist/main.mjs',
+    installedPath: 'lib/kimi-code/main.mjs',
+    sha256: KIMI_CODE_TOOLCHAIN_SPEC.kimiCode.entrypointSha256,
+  }, {
+    archivePath: 'package/package.json',
+    installedPath: 'lib/kimi-code/package.json',
+    sha256: KIMI_CODE_TOOLCHAIN_SPEC.kimiCode.packageJsonSha256,
+    stripComponents: 1,
+  }],
+};
+
+export async function validatePreparedKimiCodeToolchain(path: string): Promise<PreparedKimiCodeToolchain> {
+  await validatePreparedNodeCliToolchain(path, DEFINITION);
+  return { path, fingerprint: KIMI_CODE_TOOLCHAIN_FINGERPRINT };
+}
+
+export async function prepareKimiCodeToolchain(
+  path: string,
+  options: { fetchFn?: typeof fetch } = {},
+): Promise<PreparedKimiCodeToolchain> {
+  await prepareNodeCliToolchain(path, DEFINITION, options);
+  return { path, fingerprint: KIMI_CODE_TOOLCHAIN_FINGERPRINT };
+}

--- a/packages/headless/src/node-cli-toolchain.ts
+++ b/packages/headless/src/node-cli-toolchain.ts
@@ -176,8 +176,9 @@ async function exists(path: string): Promise<boolean> {
   try {
     await access(path);
     return true;
-  } catch {
-    return false;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return false;
+    throw error;
   }
 }
 

--- a/packages/headless/src/node-cli-toolchain.ts
+++ b/packages/headless/src/node-cli-toolchain.ts
@@ -1,0 +1,186 @@
+import { createHash } from 'node:crypto';
+import { execFile } from 'node:child_process';
+import { createReadStream } from 'node:fs';
+import { access, chmod, mkdir, mkdtemp, readFile, rename, rm, writeFile } from 'node:fs/promises';
+import { basename, dirname, join } from 'node:path';
+import { promisify } from 'node:util';
+
+const execFileAsync = promisify(execFile);
+
+export interface PinnedNodeCliToolchainDefinition<TSpec> {
+  label: string;
+  fingerprint: string;
+  spec: TSpec;
+  node: {
+    version: string;
+    archiveUrl: string;
+    archiveSha256: string;
+    binarySha256: string;
+  };
+  packageArchive: {
+    url: string;
+    integrity: `sha512-${string}`;
+  };
+  packageFiles: readonly {
+    archivePath: string;
+    installedPath: string;
+    sha256: string;
+    executable?: boolean;
+    stripComponents?: number;
+  }[];
+}
+
+export interface PreparedNodeCliToolchain {
+  path: string;
+  fingerprint: string;
+}
+
+export async function validatePreparedNodeCliToolchain<TSpec>(
+  path: string,
+  definition: PinnedNodeCliToolchainDefinition<TSpec>,
+): Promise<PreparedNodeCliToolchain> {
+  const manifest = parseManifest(await readFile(join(path, 'manifest.json'), 'utf8'), definition.label);
+  if (manifest.fingerprint !== definition.fingerprint) {
+    throw new Error(`${definition.label} toolchain fingerprint mismatch: ${manifest.fingerprint}`);
+  }
+  if (JSON.stringify(manifest.spec) !== JSON.stringify(definition.spec)) {
+    throw new Error(`${definition.label} toolchain spec does not match the pinned contract`);
+  }
+  const pinnedFiles = [
+    { installedPath: 'bin/node', sha256: definition.node.binarySha256 },
+    ...definition.packageFiles,
+  ];
+  const checksums: string[] = [];
+  for (const file of pinnedFiles) {
+    if (await sha256File(join(path, file.installedPath)) !== file.sha256) {
+      throw new Error(`${definition.label} toolchain ${file.installedPath} SHA-256 mismatch`);
+    }
+    checksums.push(`${file.sha256}  ${file.installedPath}\n`);
+  }
+  if (await readFile(join(path, 'checksums.sha256'), 'utf8') !== checksums.join('')) {
+    throw new Error(`${definition.label} toolchain checksums.sha256 does not match its manifest`);
+  }
+  return { path, fingerprint: definition.fingerprint };
+}
+
+export async function prepareNodeCliToolchain<TSpec>(
+  path: string,
+  definition: PinnedNodeCliToolchainDefinition<TSpec>,
+  options: { fetchFn?: typeof fetch } = {},
+): Promise<PreparedNodeCliToolchain> {
+  if (await exists(join(path, 'manifest.json'))) return validatePreparedNodeCliToolchain(path, definition);
+  await mkdir(dirname(path), { recursive: true });
+  const temporaryPath = await mkdtemp(join(dirname(path), `.${basename(path)}-`));
+  try {
+    const nodeArchive = join(temporaryPath, 'node.tar.gz');
+    const packageArchive = join(temporaryPath, 'package.tgz');
+    await downloadVerified({
+      url: definition.node.archiveUrl,
+      path: nodeArchive,
+      algorithm: 'sha256',
+      expected: definition.node.archiveSha256,
+      fetchFn: options.fetchFn ?? fetch,
+    });
+    await downloadVerified({
+      url: definition.packageArchive.url,
+      path: packageArchive,
+      algorithm: 'sha512',
+      expected: definition.packageArchive.integrity.slice('sha512-'.length),
+      encoding: 'base64',
+      fetchFn: options.fetchFn ?? fetch,
+    });
+    await mkdir(join(temporaryPath, 'bin'));
+    await execFileAsync('tar', [
+      '-xzf', nodeArchive,
+      '-C', join(temporaryPath, 'bin'),
+      '--strip-components=2',
+      `node-v${definition.node.version}-linux-x64/bin/node`,
+    ]);
+    await chmod(join(temporaryPath, 'bin', 'node'), 0o755);
+    for (const file of definition.packageFiles) {
+      const targetDir = dirname(join(temporaryPath, file.installedPath));
+      await mkdir(targetDir, { recursive: true });
+      await execFileAsync('tar', [
+        '-xzf', packageArchive,
+        '-C', targetDir,
+        `--strip-components=${file.stripComponents ?? 2}`,
+        file.archivePath,
+      ]);
+      if (file.executable) await chmod(join(temporaryPath, file.installedPath), 0o755);
+    }
+    await writeFile(join(temporaryPath, 'manifest.json'), `${JSON.stringify({
+      schemaVersion: 1,
+      fingerprint: definition.fingerprint,
+      spec: definition.spec,
+    }, null, 2)}\n`, 'utf8');
+    await writeFile(
+      join(temporaryPath, 'checksums.sha256'),
+      [
+        { installedPath: 'bin/node', sha256: definition.node.binarySha256 },
+        ...definition.packageFiles,
+      ].map((file) => `${file.sha256}  ${file.installedPath}\n`).join(''),
+      'utf8',
+    );
+    await rm(nodeArchive);
+    await rm(packageArchive);
+    await validatePreparedNodeCliToolchain(temporaryPath, definition);
+    try {
+      await rename(temporaryPath, path);
+    } catch (error) {
+      const code = (error as NodeJS.ErrnoException).code;
+      if (code !== 'EEXIST' && code !== 'ENOTEMPTY') throw error;
+      await validatePreparedNodeCliToolchain(path, definition);
+    }
+    return { path, fingerprint: definition.fingerprint };
+  } finally {
+    await rm(temporaryPath, { recursive: true, force: true });
+  }
+}
+
+function parseManifest(raw: string, label: string): { fingerprint: string; spec: unknown } {
+  let value: unknown;
+  try {
+    value = JSON.parse(raw);
+  } catch (error) {
+    throw new Error(`${label} toolchain manifest is not valid JSON`, { cause: error });
+  }
+  if (!isRecord(value) || value.schemaVersion !== 1 || !isRecord(value.spec) || typeof value.fingerprint !== 'string') {
+    throw new Error(`${label} toolchain manifest has an invalid shape`);
+  }
+  return { fingerprint: value.fingerprint, spec: value.spec };
+}
+
+async function downloadVerified(input: {
+  url: string;
+  path: string;
+  algorithm: 'sha256' | 'sha512';
+  expected: string;
+  encoding?: 'hex' | 'base64';
+  fetchFn: typeof fetch;
+}): Promise<void> {
+  const response = await input.fetchFn(input.url);
+  if (!response.ok) throw new Error(`failed to download ${input.url}: HTTP ${response.status}`);
+  const bytes = new Uint8Array(await response.arrayBuffer());
+  const actual = createHash(input.algorithm).update(bytes).digest(input.encoding ?? 'hex');
+  if (actual !== input.expected) throw new Error(`archive checksum mismatch for ${input.url}`);
+  await writeFile(input.path, bytes);
+}
+
+async function sha256File(path: string): Promise<string> {
+  const hash = createHash('sha256');
+  for await (const chunk of createReadStream(path)) hash.update(chunk);
+  return hash.digest('hex');
+}
+
+async function exists(path: string): Promise<boolean> {
+  try {
+    await access(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}

--- a/packages/headless/src/opencode-toolchain.ts
+++ b/packages/headless/src/opencode-toolchain.ts
@@ -1,20 +1,9 @@
 import { createHash } from 'node:crypto';
-import { execFile } from 'node:child_process';
-import { createReadStream } from 'node:fs';
 import {
-  access,
-  chmod,
-  mkdir,
-  mkdtemp,
-  readFile,
-  rename,
-  rm,
-  writeFile,
-} from 'node:fs/promises';
-import { basename, dirname, join } from 'node:path';
-import { promisify } from 'node:util';
-
-const execFileAsync = promisify(execFile);
+  prepareNodeCliToolchain,
+  validatePreparedNodeCliToolchain,
+  type PinnedNodeCliToolchainDefinition,
+} from './node-cli-toolchain.js';
 
 export const OPENCODE_TOOLCHAIN_CONTAINER_PATH = '/opt/maka-opencode-toolchain';
 
@@ -45,36 +34,25 @@ export interface PreparedOpenCodeToolchain {
   fingerprint: typeof OPENCODE_TOOLCHAIN_FINGERPRINT;
 }
 
-interface OpenCodeToolchainManifest {
-  schemaVersion: 1;
-  fingerprint: typeof OPENCODE_TOOLCHAIN_FINGERPRINT;
-  spec: typeof OPENCODE_TOOLCHAIN_SPEC;
-}
+const DEFINITION: PinnedNodeCliToolchainDefinition<typeof OPENCODE_TOOLCHAIN_SPEC> = {
+  label: 'OpenCode',
+  fingerprint: OPENCODE_TOOLCHAIN_FINGERPRINT,
+  spec: OPENCODE_TOOLCHAIN_SPEC,
+  node: OPENCODE_TOOLCHAIN_SPEC.node,
+  packageArchive: {
+    url: OPENCODE_TOOLCHAIN_SPEC.opencode.archiveUrl,
+    integrity: OPENCODE_TOOLCHAIN_SPEC.opencode.archiveIntegrity,
+  },
+  packageFiles: [{
+    archivePath: 'package/bin/opencode',
+    installedPath: 'bin/opencode',
+    sha256: OPENCODE_TOOLCHAIN_SPEC.opencode.binarySha256,
+    executable: true,
+  }],
+};
 
 export async function validatePreparedOpenCodeToolchain(path: string): Promise<PreparedOpenCodeToolchain> {
-  const manifest = parseManifest(await readFile(join(path, 'manifest.json'), 'utf8'));
-  if (manifest.fingerprint !== OPENCODE_TOOLCHAIN_FINGERPRINT) {
-    throw new Error(`OpenCode toolchain fingerprint mismatch: ${manifest.fingerprint}`);
-  }
-  if (JSON.stringify(manifest.spec) !== JSON.stringify(OPENCODE_TOOLCHAIN_SPEC)) {
-    throw new Error('OpenCode toolchain spec does not match the pinned contract');
-  }
-  const pinnedFiles = {
-    'bin/node': OPENCODE_TOOLCHAIN_SPEC.node.binarySha256,
-    'bin/opencode': OPENCODE_TOOLCHAIN_SPEC.opencode.binarySha256,
-  } as const;
-  const checksums: string[] = [];
-  for (const relativePath of ['bin/node', 'bin/opencode'] as const) {
-    const expected = pinnedFiles[relativePath];
-    const actual = await sha256File(join(path, relativePath));
-    if (actual !== expected) {
-      throw new Error(`OpenCode toolchain ${relativePath} SHA-256 mismatch`);
-    }
-    checksums.push(`${expected}  ${relativePath}\n`);
-  }
-  if (await readFile(join(path, 'checksums.sha256'), 'utf8') !== checksums.join('')) {
-    throw new Error('OpenCode toolchain checksums.sha256 does not match its manifest');
-  }
+  await validatePreparedNodeCliToolchain(path, DEFINITION);
   return { path, fingerprint: OPENCODE_TOOLCHAIN_FINGERPRINT };
 }
 
@@ -82,123 +60,6 @@ export async function prepareOpenCodeToolchain(
   path: string,
   options: { fetchFn?: typeof fetch } = {},
 ): Promise<PreparedOpenCodeToolchain> {
-  if (await exists(join(path, 'manifest.json'))) {
-    return validatePreparedOpenCodeToolchain(path);
-  }
-  await mkdir(dirname(path), { recursive: true });
-  const temporaryPath = await mkdtemp(join(dirname(path), `.${basename(path)}-`));
-  try {
-    const nodeArchive = join(temporaryPath, 'node.tar.gz');
-    const opencodeArchive = join(temporaryPath, 'opencode.tgz');
-    await downloadVerified({
-      url: OPENCODE_TOOLCHAIN_SPEC.node.archiveUrl,
-      path: nodeArchive,
-      algorithm: 'sha256',
-      expected: OPENCODE_TOOLCHAIN_SPEC.node.archiveSha256,
-      fetchFn: options.fetchFn ?? fetch,
-    });
-    await downloadVerified({
-      url: OPENCODE_TOOLCHAIN_SPEC.opencode.archiveUrl,
-      path: opencodeArchive,
-      algorithm: 'sha512',
-      expected: OPENCODE_TOOLCHAIN_SPEC.opencode.archiveIntegrity.slice('sha512-'.length),
-      encoding: 'base64',
-      fetchFn: options.fetchFn ?? fetch,
-    });
-
-    const binDir = join(temporaryPath, 'bin');
-    await mkdir(binDir);
-    await execFileAsync('tar', [
-      '-xzf', nodeArchive,
-      '-C', binDir,
-      '--strip-components=2',
-      `node-v${OPENCODE_TOOLCHAIN_SPEC.node.version}-linux-x64/bin/node`,
-    ]);
-    await execFileAsync('tar', [
-      '-xzf', opencodeArchive,
-      '-C', binDir,
-      '--strip-components=2',
-      'package/bin/opencode',
-    ]);
-    await chmod(join(binDir, 'node'), 0o755);
-    await chmod(join(binDir, 'opencode'), 0o755);
-
-    const files = {
-      'bin/node': OPENCODE_TOOLCHAIN_SPEC.node.binarySha256,
-      'bin/opencode': OPENCODE_TOOLCHAIN_SPEC.opencode.binarySha256,
-    };
-    const manifest: OpenCodeToolchainManifest = {
-      schemaVersion: 1,
-      fingerprint: OPENCODE_TOOLCHAIN_FINGERPRINT,
-      spec: OPENCODE_TOOLCHAIN_SPEC,
-    };
-    await writeFile(join(temporaryPath, 'manifest.json'), `${JSON.stringify(manifest, null, 2)}\n`, 'utf8');
-    await writeFile(
-      join(temporaryPath, 'checksums.sha256'),
-      Object.entries(files).map(([relativePath, hash]) => `${hash}  ${relativePath}\n`).join(''),
-      'utf8',
-    );
-    await rm(nodeArchive);
-    await rm(opencodeArchive);
-    await validatePreparedOpenCodeToolchain(temporaryPath);
-    try {
-      await rename(temporaryPath, path);
-    } catch (error) {
-      const code = (error as NodeJS.ErrnoException).code;
-      if (code !== 'EEXIST' && code !== 'ENOTEMPTY') throw error;
-      await validatePreparedOpenCodeToolchain(path);
-    }
-    return { path, fingerprint: OPENCODE_TOOLCHAIN_FINGERPRINT };
-  } finally {
-    await rm(temporaryPath, { recursive: true, force: true });
-  }
-}
-
-function parseManifest(raw: string): OpenCodeToolchainManifest {
-  let value: unknown;
-  try {
-    value = JSON.parse(raw);
-  } catch (error) {
-    throw new Error('OpenCode toolchain manifest is not valid JSON', { cause: error });
-  }
-  if (!isRecord(value) || value.schemaVersion !== 1 || !isRecord(value.spec)) {
-    throw new Error('OpenCode toolchain manifest has an invalid shape');
-  }
-  return value as unknown as OpenCodeToolchainManifest;
-}
-
-async function downloadVerified(input: {
-  url: string;
-  path: string;
-  algorithm: 'sha256' | 'sha512';
-  expected: string;
-  encoding?: 'hex' | 'base64';
-  fetchFn: typeof fetch;
-}): Promise<void> {
-  const response = await input.fetchFn(input.url);
-  if (!response.ok) throw new Error(`failed to download ${input.url}: HTTP ${response.status}`);
-  const bytes = new Uint8Array(await response.arrayBuffer());
-  const actual = createHash(input.algorithm).update(bytes).digest(input.encoding ?? 'hex');
-  if (actual !== input.expected) throw new Error(`archive checksum mismatch for ${input.url}`);
-  await writeFile(input.path, bytes);
-}
-
-async function sha256File(path: string): Promise<string> {
-  const hash = createHash('sha256');
-  for await (const chunk of createReadStream(path)) hash.update(chunk);
-  return hash.digest('hex');
-}
-
-async function exists(path: string): Promise<boolean> {
-  try {
-    await access(path);
-    return true;
-  } catch (error) {
-    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return false;
-    throw error;
-  }
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null && !Array.isArray(value);
+  await prepareNodeCliToolchain(path, DEFINITION, options);
+  return { path, fingerprint: OPENCODE_TOOLCHAIN_FINGERPRINT };
 }

--- a/packages/headless/src/provider-auth-proxy.ts
+++ b/packages/headless/src/provider-auth-proxy.ts
@@ -6,7 +6,15 @@ import type { Socket } from 'node:net';
 export interface ProviderAuthProxy {
   baseUrl: string;
   token: string;
+  usage(): ProviderTokenUsage | null;
   close(): Promise<void>;
+}
+
+export interface ProviderTokenUsage {
+  input: number;
+  cacheRead: number;
+  cacheWrite: number;
+  output: number;
 }
 
 export type ProviderAuthProxyMode = 'bearer' | 'x-api-key';
@@ -25,6 +33,7 @@ export async function startProviderAuthProxy(input: {
   if (providerKey.length === 0) throw new Error('provider API key file is empty');
   const authMode = input.authMode ?? 'bearer';
   const token = randomBytes(32).toString('hex');
+  const usage = new ProviderUsageAccumulator();
   const activeRequests = new Set<AbortController>();
   const sockets = new Set<Socket>();
   const server = createServer((request, response) => {
@@ -37,6 +46,7 @@ export async function startProviderAuthProxy(input: {
       providerKey,
       token,
       authMode,
+      usage,
       signal: controller.signal,
     }).finally(() => activeRequests.delete(controller));
   });
@@ -60,6 +70,7 @@ export async function startProviderAuthProxy(input: {
   return {
     baseUrl: `http://${advertisedHost}:${address.port}`,
     token,
+    usage: () => usage.snapshot(),
     close: async () => {
       const closed = new Promise<void>((resolve, reject) => {
         server.close((error) => error ? reject(error) : resolve());
@@ -78,6 +89,7 @@ async function forwardProviderRequest(input: {
   providerKey: string;
   token: string;
   authMode: ProviderAuthProxyMode;
+  usage: ProviderUsageAccumulator;
   signal: AbortSignal;
 }): Promise<void> {
   try {
@@ -114,15 +126,104 @@ async function forwardProviderRequest(input: {
       if (!HOP_BY_HOP_HEADERS.has(name.toLowerCase())) responseHeaders[name] = value;
     });
     input.response.writeHead(upstreamResponse.status, responseHeaders);
+    const responseUsage = upstreamResponse.headers.get('content-type')?.includes('text/event-stream')
+      ? new AnthropicSseUsageParser()
+      : null;
     if (upstreamResponse.body) {
-      for await (const chunk of upstreamResponse.body) input.response.write(chunk);
+      for await (const chunk of upstreamResponse.body) {
+        responseUsage?.push(chunk);
+        input.response.write(chunk);
+      }
     }
+    if (upstreamResponse.ok && responseUsage) input.usage.add(responseUsage.finish());
     input.response.end();
   } catch {
     if (input.response.destroyed) return;
     if (!input.response.headersSent) input.response.writeHead(502);
     input.response.end('provider proxy request failed');
   }
+}
+
+class ProviderUsageAccumulator {
+  private readonly total: ProviderTokenUsage = { input: 0, cacheRead: 0, cacheWrite: 0, output: 0 };
+  private sawUsage = false;
+
+  add(usage: ProviderTokenUsage | null): void {
+    if (!usage) return;
+    this.sawUsage = true;
+    this.total.input += usage.input;
+    this.total.cacheRead += usage.cacheRead;
+    this.total.cacheWrite += usage.cacheWrite;
+    this.total.output += usage.output;
+  }
+
+  snapshot(): ProviderTokenUsage | null {
+    return this.sawUsage ? { ...this.total } : null;
+  }
+}
+
+class AnthropicSseUsageParser {
+  private readonly decoder = new TextDecoder();
+  private buffer = '';
+  private input = 0;
+  private cacheRead = 0;
+  private cacheWrite = 0;
+  private output = 0;
+  private sawUsage = false;
+
+  push(chunk: Uint8Array): void {
+    this.buffer += this.decoder.decode(chunk, { stream: true });
+    this.consumeCompleteLines();
+  }
+
+  finish(): ProviderTokenUsage | null {
+    this.buffer += this.decoder.decode();
+    this.consumeCompleteLines(true);
+    return this.sawUsage
+      ? {
+          input: this.input + this.cacheRead + this.cacheWrite,
+          cacheRead: this.cacheRead,
+          cacheWrite: this.cacheWrite,
+          output: this.output,
+        }
+      : null;
+  }
+
+  private consumeCompleteLines(flush = false): void {
+    const lines = this.buffer.split(/\r?\n/);
+    this.buffer = flush ? '' : lines.pop() ?? '';
+    for (const line of lines) {
+      if (!line.startsWith('data:')) continue;
+      const raw = line.slice('data:'.length).trim();
+      if (!raw || raw === '[DONE]') continue;
+      let event: unknown;
+      try {
+        event = JSON.parse(raw);
+      } catch {
+        continue;
+      }
+      if (!isRecord(event)) continue;
+      const usage = isRecord(event.usage)
+        ? event.usage
+        : isRecord(event.message) && isRecord(event.message.usage)
+          ? event.message.usage
+          : null;
+      if (!usage) continue;
+      this.sawUsage = true;
+      this.input = Math.max(this.input, nonNegativeNumber(usage.input_tokens));
+      this.cacheRead = Math.max(this.cacheRead, nonNegativeNumber(usage.cache_read_input_tokens));
+      this.cacheWrite = Math.max(this.cacheWrite, nonNegativeNumber(usage.cache_creation_input_tokens));
+      this.output = Math.max(this.output, nonNegativeNumber(usage.output_tokens));
+    }
+  }
+}
+
+function nonNegativeNumber(value: unknown): number {
+  return typeof value === 'number' && Number.isFinite(value) && value >= 0 ? value : 0;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
 
 function authorized(

--- a/packages/headless/src/provider-auth-proxy.ts
+++ b/packages/headless/src/provider-auth-proxy.ts
@@ -9,10 +9,13 @@ export interface ProviderAuthProxy {
   close(): Promise<void>;
 }
 
+export type ProviderAuthProxyMode = 'bearer' | 'x-api-key';
+
 export async function startProviderAuthProxy(input: {
   upstreamBaseUrl: string;
   apiKeyFile: string;
   advertisedHost?: string;
+  authMode?: ProviderAuthProxyMode;
 }): Promise<ProviderAuthProxy> {
   const upstreamBaseUrl = new URL(input.upstreamBaseUrl);
   if (upstreamBaseUrl.protocol !== 'https:' && upstreamBaseUrl.protocol !== 'http:') {
@@ -20,6 +23,7 @@ export async function startProviderAuthProxy(input: {
   }
   const providerKey = (await readFile(input.apiKeyFile, 'utf8')).trim();
   if (providerKey.length === 0) throw new Error('provider API key file is empty');
+  const authMode = input.authMode ?? 'bearer';
   const token = randomBytes(32).toString('hex');
   const activeRequests = new Set<AbortController>();
   const sockets = new Set<Socket>();
@@ -32,6 +36,7 @@ export async function startProviderAuthProxy(input: {
       upstreamBaseUrl,
       providerKey,
       token,
+      authMode,
       signal: controller.signal,
     }).finally(() => activeRequests.delete(controller));
   });
@@ -72,10 +77,14 @@ async function forwardProviderRequest(input: {
   upstreamBaseUrl: URL;
   providerKey: string;
   token: string;
+  authMode: ProviderAuthProxyMode;
   signal: AbortSignal;
 }): Promise<void> {
   try {
-    if (!authorized(input.request.headers.authorization, input.token)) {
+    const presentedCredential = input.authMode === 'x-api-key'
+      ? input.request.headers['x-api-key']
+      : input.request.headers.authorization;
+    if (!authorized(presentedCredential, input.token, input.authMode)) {
       input.response.writeHead(401).end('unauthorized');
       return;
     }
@@ -85,11 +94,12 @@ async function forwardProviderRequest(input: {
     upstreamUrl.search = incomingUrl.search;
     const headers = new Headers();
     for (const [name, value] of Object.entries(input.request.headers)) {
-      if (value === undefined || HOP_BY_HOP_HEADERS.has(name.toLowerCase())) continue;
+      if (value === undefined || REQUEST_HEADER_DENYLIST.has(name.toLowerCase())) continue;
       if (Array.isArray(value)) value.forEach((item) => headers.append(name, item));
       else headers.set(name, value);
     }
-    headers.set('authorization', `Bearer ${input.providerKey}`);
+    if (input.authMode === 'x-api-key') headers.set('x-api-key', input.providerKey);
+    else headers.set('authorization', `Bearer ${input.providerKey}`);
     const body = input.request.method === 'GET' || input.request.method === 'HEAD'
       ? undefined
       : await readRequestBody(input.request);
@@ -115,9 +125,19 @@ async function forwardProviderRequest(input: {
   }
 }
 
-function authorized(header: string | undefined, token: string): boolean {
-  if (!header?.startsWith('Bearer ')) return false;
-  const presented = Buffer.from(header.slice('Bearer '.length));
+function authorized(
+  header: string | string[] | undefined,
+  token: string,
+  authMode: ProviderAuthProxyMode,
+): boolean {
+  if (typeof header !== 'string') return false;
+  const value = authMode === 'bearer'
+    ? header.startsWith('Bearer ')
+      ? header.slice('Bearer '.length)
+      : undefined
+    : header;
+  if (value === undefined) return false;
+  const presented = Buffer.from(value);
   const expected = Buffer.from(token);
   return presented.length === expected.length && timingSafeEqual(presented, expected);
 }
@@ -142,4 +162,9 @@ const HOP_BY_HOP_HEADERS = new Set([
   'trailer',
   'transfer-encoding',
   'upgrade',
+]);
+
+const REQUEST_HEADER_DENYLIST = new Set([
+  ...HOP_BY_HOP_HEADERS,
+  'x-api-key',
 ]);

--- a/packages/headless/src/provider-auth-proxy.ts
+++ b/packages/headless/src/provider-auth-proxy.ts
@@ -18,12 +18,14 @@ export interface ProviderTokenUsage {
 }
 
 export type ProviderAuthProxyMode = 'bearer' | 'x-api-key';
+export type ProviderUsageProtocol = 'anthropic-sse' | 'openai-chat-sse';
 
 export async function startProviderAuthProxy(input: {
   upstreamBaseUrl: string;
   apiKeyFile: string;
   advertisedHost?: string;
   authMode?: ProviderAuthProxyMode;
+  usageProtocol?: ProviderUsageProtocol;
 }): Promise<ProviderAuthProxy> {
   const upstreamBaseUrl = new URL(input.upstreamBaseUrl);
   if (upstreamBaseUrl.protocol !== 'https:' && upstreamBaseUrl.protocol !== 'http:') {
@@ -46,6 +48,7 @@ export async function startProviderAuthProxy(input: {
       providerKey,
       token,
       authMode,
+      usageProtocol: input.usageProtocol,
       usage,
       signal: controller.signal,
     }).finally(() => activeRequests.delete(controller));
@@ -89,6 +92,7 @@ async function forwardProviderRequest(input: {
   providerKey: string;
   token: string;
   authMode: ProviderAuthProxyMode;
+  usageProtocol?: ProviderUsageProtocol;
   usage: ProviderUsageAccumulator;
   signal: AbortSignal;
 }): Promise<void> {
@@ -126,8 +130,9 @@ async function forwardProviderRequest(input: {
       if (!HOP_BY_HOP_HEADERS.has(name.toLowerCase())) responseHeaders[name] = value;
     });
     input.response.writeHead(upstreamResponse.status, responseHeaders);
-    const responseUsage = upstreamResponse.headers.get('content-type')?.includes('text/event-stream')
-      ? new AnthropicSseUsageParser()
+    const responseUsage = input.usageProtocol
+      && upstreamResponse.headers.get('content-type')?.includes('text/event-stream')
+      ? new SseUsageParser(input.usageProtocol)
       : null;
     if (upstreamResponse.body) {
       for await (const chunk of upstreamResponse.body) {
@@ -162,14 +167,13 @@ class ProviderUsageAccumulator {
   }
 }
 
-class AnthropicSseUsageParser {
+class SseUsageParser {
   private readonly decoder = new TextDecoder();
   private buffer = '';
-  private input = 0;
-  private cacheRead = 0;
-  private cacheWrite = 0;
-  private output = 0;
+  private readonly usage: ProviderTokenUsage = { input: 0, cacheRead: 0, cacheWrite: 0, output: 0 };
   private sawUsage = false;
+
+  constructor(private readonly protocol: ProviderUsageProtocol) {}
 
   push(chunk: Uint8Array): void {
     this.buffer += this.decoder.decode(chunk, { stream: true });
@@ -179,14 +183,7 @@ class AnthropicSseUsageParser {
   finish(): ProviderTokenUsage | null {
     this.buffer += this.decoder.decode();
     this.consumeCompleteLines(true);
-    return this.sawUsage
-      ? {
-          input: this.input + this.cacheRead + this.cacheWrite,
-          cacheRead: this.cacheRead,
-          cacheWrite: this.cacheWrite,
-          output: this.output,
-        }
-      : null;
+    return this.sawUsage ? { ...this.usage } : null;
   }
 
   private consumeCompleteLines(flush = false): void {
@@ -203,19 +200,58 @@ class AnthropicSseUsageParser {
         continue;
       }
       if (!isRecord(event)) continue;
-      const usage = isRecord(event.usage)
-        ? event.usage
-        : isRecord(event.message) && isRecord(event.message.usage)
-          ? event.message.usage
-          : null;
+      const usage = this.protocol === 'anthropic-sse'
+        ? anthropicUsage(event)
+        : openAiChatUsage(event);
       if (!usage) continue;
       this.sawUsage = true;
-      this.input = Math.max(this.input, nonNegativeNumber(usage.input_tokens));
-      this.cacheRead = Math.max(this.cacheRead, nonNegativeNumber(usage.cache_read_input_tokens));
-      this.cacheWrite = Math.max(this.cacheWrite, nonNegativeNumber(usage.cache_creation_input_tokens));
-      this.output = Math.max(this.output, nonNegativeNumber(usage.output_tokens));
+      this.usage.input = Math.max(this.usage.input, usage.input);
+      this.usage.cacheRead = Math.max(this.usage.cacheRead, usage.cacheRead);
+      this.usage.cacheWrite = Math.max(this.usage.cacheWrite, usage.cacheWrite);
+      this.usage.output = Math.max(this.usage.output, usage.output);
     }
   }
+}
+
+function anthropicUsage(event: Record<string, unknown>): ProviderTokenUsage | null {
+  const usage = isRecord(event.usage)
+    ? event.usage
+    : isRecord(event.message) && isRecord(event.message.usage)
+      ? event.message.usage
+      : null;
+  if (!usage || !hasAnyNumber(usage, [
+    'input_tokens',
+    'cache_read_input_tokens',
+    'cache_creation_input_tokens',
+    'output_tokens',
+  ])) return null;
+  const cacheRead = nonNegativeNumber(usage.cache_read_input_tokens);
+  const cacheWrite = nonNegativeNumber(usage.cache_creation_input_tokens);
+  return {
+    input: nonNegativeNumber(usage.input_tokens) + cacheRead + cacheWrite,
+    cacheRead,
+    cacheWrite,
+    output: nonNegativeNumber(usage.output_tokens),
+  };
+}
+
+function openAiChatUsage(event: Record<string, unknown>): ProviderTokenUsage | null {
+  if (!isRecord(event.usage) || !hasAnyNumber(event.usage, ['prompt_tokens', 'completion_tokens'])) return null;
+  const details = isRecord(event.usage.prompt_tokens_details) ? event.usage.prompt_tokens_details : null;
+  return {
+    input: nonNegativeNumber(event.usage.prompt_tokens),
+    cacheRead: nonNegativeNumber(details?.cached_tokens),
+    cacheWrite: 0,
+    output: nonNegativeNumber(event.usage.completion_tokens),
+  };
+}
+
+function hasAnyNumber(record: Record<string, unknown>, keys: readonly string[]): boolean {
+  return keys.some((key) => (
+    typeof record[key] === 'number'
+    && Number.isFinite(record[key])
+    && (record[key] as number) >= 0
+  ));
 }
 
 function nonNegativeNumber(value: unknown): number {


### PR DESCRIPTION
## Summary

Compare Maka with the official Kimi Code CLI on the same Kimi K3 Coding Plan endpoint through the existing Terminal-Bench harness. Kimi Code 0.26.0 is the default competitor; OpenCode 1.17.18 remains selectable with `MAKA_HARNESS_AB_COMPETITOR=opencode`, without changing the A/B controller, frozen 89-task schedule, or WAL resume path.

The profile pre-registers all 89 Terminal-Bench 2.1 tasks, runs a 5-task canary before full continuation, records four concurrent pairs/eight attempts, and treats subscription usage as account-plan billing. Maka keeps active and stale tool-result pruning enabled with semantic compaction disabled.

Both competitor profiles use pinned, checksum-verified Node CLI toolchains prepared through one shared seam. Provider credentials stay host-side behind an ephemeral auth proxy. Because Kimi Code's CLI output does not expose usage, the proxy observes the selected upstream SSE protocol while forwarding the original response bytes unchanged, then fills otherwise-missing cell token totals from provider-reported values. Kimi Code uses its real OpenAI Chat Completions wire contract; OpenCode follows the selected provider protocol.

Completed harness cells now require final token usage. Kimi Code stream output fails closed on missing, empty, malformed, non-object, or assistant-free JSONL while preserving the original provider/infra classification for already-failed runs. Reports identify the actual arms and distinguish recorded account-plan cost from API-equivalent pricing.

## Verification

- `npm --workspace @maka/headless test` (1,099 passed, 0 skipped)
- `npm run typecheck`
- `npm run lint` (1,730 files)
- `git diff --check`
- Real Kimi Code 0.26.0 prompt-mode smoke in `linux/amd64`: the pinned toolchain passed argument parsing, called a mock `/chat/completions` upstream, emitted the expected `stream-json` events, and completed
- Adapter contract coverage for Kimi Code env-only model configuration, max effort, durable execution identity, tool events, strict completed-run JSONL validation, failed-run classification preservation, and secret isolation
- Proxy coverage for bearer and `x-api-key` auth, unchanged response bytes, User-Agent preservation, Anthropic and OpenAI streaming usage aggregation, unknown-schema fail-closed behavior, and host-side token-summary hydration
- Manifest coverage for default Kimi Code, selectable OpenCode, K3, the 5-task checkpoint, account-plan pricing, and 4-pair/8-attempt concurrency
- Frozen Terminal-Bench 2.1 revision `d49e28f1e4ddd13d289e85a5f312a66750951932`: 89-task source and tree fingerprint validated in a local dry-run

Live provider validation follows immediately after merge so both comparison arms run from merged `main`.
