### PR TITLE
refactor(desktop): colocate expert-teams and memory-pill slices into hooks

### DIFF
--- a/apps/desktop/src/main/__tests__/renderer-shell-source-helpers.ts
+++ b/apps/desktop/src/main/__tests__/renderer-shell-source-helpers.ts
@@ -36,6 +36,8 @@ const sourcePaths = [
   'use-shell-connections.ts',
   'use-shell-chat-model.ts',
   'use-shell-live-turn.ts',
+  'use-shell-expert-teams.ts',
+  'use-shell-memory-pill.ts',
   'app-shell-visual-smoke.ts',
   'cached-theme-bootstrap.ts',
   'chat-model-selection.ts',

--- a/apps/desktop/src/renderer/app-shell.tsx
+++ b/apps/desktop/src/renderer/app-shell.tsx
@@ -114,6 +114,8 @@ import { useKeyedPendingRegistry } from './use-pending-action-registry';
 import { useAppShellComposerAttachments } from './use-app-shell-composer-attachments';
 import { useComposerMentions } from './use-composer-mentions';
 import { useAppShellSessionWorkspace } from './use-app-shell-session-workspace';
+import { useShellExpertTeams } from './use-shell-expert-teams';
+import { useShellMemoryPill } from './use-shell-memory-pill';
 import { useShellConnections } from './use-shell-connections';
 import { useShellChatModel } from './use-shell-chat-model';
 import { useShellLiveTurn } from './use-shell-live-turn';
@@ -201,13 +203,11 @@ export function AppShell({
     pendingPermissionModeBySession,
     pendingSessionModelBySession,
   } = sessionUiState;
-  // PR-MEMORY-VISIBILITY-INDICATOR-0: surface a small pill in the
-  // chat header when xuan's MEMORY.md is being injected into the
-  // agent's system prompt (PR-MEMORY-PROMPT-INJECT-0). Refreshed
-  // when activeId changes (we re-fetch on every chat switch) and
-  // whenever the Settings modal closes (the user may have toggled
-  // the agentReadEnabled switch).
-  const [memoryActive, setMemoryActive] = useState(false);
+  // PR-MEMORY-VISIBILITY-INDICATOR-0: chat-header memory pill (MEMORY.md
+  // injected into the system prompt). State and the fire-and-forget refresh
+  // live in `useShellMemoryPill`; recompute is triggered on mount (bootstrap
+  // subscriptions) and when Settings closes (closeSettings).
+  const { memoryActive, refreshMemoryActive } = useShellMemoryPill({ toastApi });
   const {
     connections,
     connectionsRevision,
@@ -623,16 +623,9 @@ export function AppShell({
     setQuickChatPending,
     toastApi,
   });
-  // Built-in expert teams for the composer "+" menu. Loaded once — the catalog
-  // is static, so a failure just leaves the 专家团 entry hidden.
-  const [expertTeams, setExpertTeams] = useState<readonly { id: string; name: string; description?: string }[]>([]);
-  useEffect(() => {
-    let cancelled = false;
-    void window.maka.expertTeam.list()
-      .then((result) => { if (!cancelled) setExpertTeams(result.teams); })
-      .catch(() => {});
-    return () => { cancelled = true; };
-  }, []);
+  // Built-in expert teams for the composer "+" menu - loaded once via
+  // `useShellExpertTeams` (static catalog; a failure just hides the 专家团 entry).
+  const expertTeams = useShellExpertTeams();
   const onboardingState = onboarding.snapshot?.state;
   const onboardingSettled = hasSettledInitialOnboarding(onboarding.snapshot?.milestones ?? []);
   // Seed sessions from the onboarding snapshot on first load — the snapshot
@@ -1084,15 +1077,6 @@ export function AppShell({
         .querySelector<HTMLInputElement>('[data-maka-plan-title-input="true"]')
         ?.focus({ preventScroll: false });
     });
-  }
-
-  async function refreshMemoryActive(failureTitle = '刷新本地记忆状态失败') {
-    try {
-      const next = await window.maka.memory.getState();
-      setMemoryActive(next.agentReadEnabled && next.status === 'ok' && next.content.trim().length > 0);
-    } catch (error) {
-      toastApi.error(failureTitle, generalizedErrorMessageChinese(error, '本地记忆状态暂时无法刷新，请稍后重试。'));
-    }
   }
 
   function openSettings() {

--- a/apps/desktop/src/renderer/use-shell-expert-teams.ts
+++ b/apps/desktop/src/renderer/use-shell-expert-teams.ts
@@ -1,0 +1,30 @@
+import { useEffect, useState } from 'react';
+
+/**
+ * Built-in expert teams for the Composer "+" menu (issue #1043).
+ *
+ * The catalog is static, so it is loaded once on mount; a load failure just
+ * leaves the 专家团 entry hidden - no toast, no retry.
+ */
+export function useShellExpertTeams(): readonly {
+  id: string;
+  name: string;
+  description?: string;
+}[] {
+  const [expertTeams, setExpertTeams] = useState<
+    readonly { id: string; name: string; description?: string }[]
+  >([]);
+  useEffect(() => {
+    let cancelled = false;
+    void window.maka.expertTeam
+      .list()
+      .then((result) => {
+        if (!cancelled) setExpertTeams(result.teams);
+      })
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+  return expertTeams;
+}

--- a/apps/desktop/src/renderer/use-shell-memory-pill.ts
+++ b/apps/desktop/src/renderer/use-shell-memory-pill.ts
@@ -1,0 +1,33 @@
+import { useState } from 'react';
+import { generalizedErrorMessageChinese } from '@maka/core';
+
+type ToastApi = {
+  error(title: string, description?: string): void;
+};
+
+/**
+ * Owns the chat-header memory-visibility pill (issue #1043): the `memoryActive`
+ * flag surfaced when xuan's MEMORY.md is injected into the agent's system
+ * prompt, plus the fire-and-forget `refreshMemoryActive` that re-reads
+ * `window.maka.memory.getState()`.
+ *
+ * Refresh failures must stay visible (toast) and must preserve the last known
+ * pill state - never silently flip to false. The mount recompute is driven by
+ * `useAppShellBootstrapSubscriptions`; the Settings-close recompute is driven
+ * by `closeSettings`. Both call the returned `refreshMemoryActive`.
+ */
+export function useShellMemoryPill({ toastApi }: { toastApi: ToastApi }): {
+  memoryActive: boolean;
+  refreshMemoryActive: (failureTitle?: string) => Promise<void>;
+} {
+  const [memoryActive, setMemoryActive] = useState(false);
+  async function refreshMemoryActive(failureTitle = '刷新本地记忆状态失败') {
+    try {
+      const next = await window.maka.memory.getState();
+      setMemoryActive(next.agentReadEnabled && next.status === 'ok' && next.content.trim().length > 0);
+    } catch (error) {
+      toastApi.error(failureTitle, generalizedErrorMessageChinese(error, '本地记忆状态暂时无法刷新，请稍后重试。'));
+    }
+  }
+  return { memoryActive, refreshMemoryActive };
+}


### PR DESCRIPTION
## Summary

Refs #1043 (step 2 of the plan documented there).

Two self-contained state slices that lived inline in `AppShell` move into their own hooks, following the existing `useShellConnections` / `useShellChatModel` seam. AppShell shrinks by ~13 lines and stops owning two lifecycles it only forwards; the state is now grouped by owner, which step 3 (`<ChatWorkspace>` extraction) depends on.

- `useShellExpertTeams` - the Composer "+" menu catalog. A static load-once effect with no AppShell deps; pure relocation. `Composer` lives in `@maka/ui`, so the IPC load stays at the app-shell layer (passed as a prop) rather than coupling the shared UI component to `window.maka`.
- `useShellMemoryPill({ toastApi })` - the chat-header memory-visibility flag plus the fire-and-forget `refreshMemoryActive`. Returns `{ memoryActive, refreshMemoryActive }`.

AppShell calls the hooks at the original state-declaration sites (hook order preserved) and threads the results to the same consumers unchanged: `memoryActive` -> chat-header pill; `refreshMemoryActive` -> `useAppShellBootstrapSubscriptions` (mount recompute) and `closeSettings` (Settings-close recompute); `expertTeams` -> Composer prop.

Pure code motion, no behavior change. `refreshMemoryActive` keeps its exact source shape (2-space indent, identical body) so the `renderer-startup-fail-soft` source contract still matches it after the move; the two new hook files are registered in `renderer-shell-source-helpers` so the combined-source contract keeps covering them. The stale "refreshed when activeId changes" comment is replaced with the two verified recompute triggers (mount + Settings close) - a grep confirmed `refreshMemoryActive` has exactly those two call sites.

## Verification

- `tsc -p tsconfig.main.json` and `tsconfig.renderer.json` - clean.
- `biome lint` (the repo's CI lint command; the formatter is deliberately disabled per `biome.jsonc` / #415) on changed files - clean.
- `node --test dist/main/**/*.test.js` - 2659/2660. The one failure (`menu-highlight-recipe-contract`) fails identically on clean `main`; unrelated, not touched here.
- Targeted: `renderer-startup-fail-soft-contract` (3), `app-shell-effect-stability-contract`, `app-shell-stable-actions-contract` - all green. The fail-soft contract still matches `refreshMemoryActive` from the new hook file via the combined-source registry.
- `npm run build:renderer` - clean.
- Playwright `e2e/send-message.spec.ts` (fake-backend streaming journey) - passes.
