### PR TITLE
refactor(desktop): colocate shell layout and settings-modal state into hooks

### DIFF
--- a/apps/desktop/src/main/__tests__/renderer-shell-source-helpers.ts
+++ b/apps/desktop/src/main/__tests__/renderer-shell-source-helpers.ts
@@ -39,6 +39,7 @@ const sourcePaths = [
   'use-shell-expert-teams.ts',
   'use-shell-memory-pill.ts',
   'use-shell-layout.ts',
+  'use-settings-modal.ts',
   'app-shell-visual-smoke.ts',
   'cached-theme-bootstrap.ts',
   'chat-model-selection.ts',

--- a/apps/desktop/src/main/__tests__/renderer-shell-source-helpers.ts
+++ b/apps/desktop/src/main/__tests__/renderer-shell-source-helpers.ts
@@ -38,6 +38,7 @@ const sourcePaths = [
   'use-shell-live-turn.ts',
   'use-shell-expert-teams.ts',
   'use-shell-memory-pill.ts',
+  'use-shell-layout.ts',
   'app-shell-visual-smoke.ts',
   'cached-theme-bootstrap.ts',
   'chat-model-selection.ts',

--- a/apps/desktop/src/renderer/app-shell.tsx
+++ b/apps/desktop/src/renderer/app-shell.tsx
@@ -65,16 +65,11 @@ import { applyTheme, applyThemePalette } from './theme';
 import { safeLocalStorageSet } from './browser-storage';
 import { filterSessions, readNavSelection } from './nav-selection';
 import {
-  readSessionListCollapsed,
-  readSessionListWidth,
   SESSION_LIST_COLLAPSED_WIDTH,
   SESSION_LIST_EXPANDED_MAX_WIDTH,
   SESSION_LIST_EXPANDED_MIN_WIDTH,
 } from './session-list-layout';
 import {
-  readSessionWorkbarCollapsed,
-  readSessionWorkbarTab,
-  readSessionWorkbarWidth,
   SESSION_WORKBAR_MAX_WIDTH,
   SESSION_WORKBAR_MIN_WIDTH,
 } from './session-workbar-layout';
@@ -119,6 +114,7 @@ import { useShellMemoryPill } from './use-shell-memory-pill';
 import { useShellConnections } from './use-shell-connections';
 import { useShellChatModel } from './use-shell-chat-model';
 import { useShellLiveTurn } from './use-shell-live-turn';
+import { useShellLayout } from './use-shell-layout';
 import {
   isSessionWorkspaceUnavailableError,
   showSessionWorkspaceUnavailableToast,
@@ -690,11 +686,18 @@ export function AppShell({
   const showOnboardingHero =
     sessions.length === 0 && !onboardingSettled && onboardingState !== undefined && onboardingState.kind !== 'ready_with_history';
   const onboardingComposerHidden = isOnboardingLoading || (showOnboardingHero && onboardingState !== undefined);
-  const [sessionListWidth, setSessionListWidth] = useState(() => readSessionListWidth());
-  const [sessionListCollapsed, setSessionListCollapsed] = useState(() => readSessionListCollapsed());
-  const [workbarCollapsed, setWorkbarCollapsed] = useState(() => readSessionWorkbarCollapsed());
-  const [workbarWidth, setWorkbarWidth] = useState(() => readSessionWorkbarWidth());
-  const [workbarTab, setWorkbarTab] = useState(() => readSessionWorkbarTab());
+  const {
+    sessionListWidth,
+    setSessionListWidth,
+    sessionListCollapsed,
+    setSessionListCollapsed,
+    workbarCollapsed,
+    setWorkbarCollapsed,
+    workbarWidth,
+    setWorkbarWidth,
+    workbarTab,
+    setWorkbarTab,
+  } = useShellLayout();
   const { startColumnResize, onResizeHandleKeyDown, startWorkbarResize, onWorkbarResizeHandleKeyDown } = useStableActions(createAppShellLayoutActions, {
     sessionListCollapsed,
     sessionListWidth,

--- a/apps/desktop/src/renderer/app-shell.tsx
+++ b/apps/desktop/src/renderer/app-shell.tsx
@@ -4,7 +4,6 @@ import type {
   PermissionMode,
   PlanReminder,
   SessionSummary,
-  SettingsSection,
   ThemePalette,
   ThemePreference,
   UiLocale,
@@ -62,7 +61,6 @@ import { deriveAppShellTurnViewModel } from './app-shell-turn-view-model';
 import { readScrollMotionBehavior } from './scroll-motion-policy';
 import { deriveBranchBanner } from './branch-banner';
 import { applyTheme, applyThemePalette } from './theme';
-import { safeLocalStorageSet } from './browser-storage';
 import { filterSessions, readNavSelection } from './nav-selection';
 import {
   SESSION_LIST_COLLAPSED_WIDTH,
@@ -115,6 +113,7 @@ import { useShellConnections } from './use-shell-connections';
 import { useShellChatModel } from './use-shell-chat-model';
 import { useShellLiveTurn } from './use-shell-live-turn';
 import { useShellLayout } from './use-shell-layout';
+import { useSettingsModal } from './use-settings-modal';
 import {
   isSessionWorkspaceUnavailableError,
   showSessionWorkspaceUnavailableToast,
@@ -213,9 +212,16 @@ export function AppShell({
     refreshConnections,
     handleConnectionEvent,
   } = useShellConnections({ toastApi });
-  const [settingsOpen, setSettingsOpen] = useState(false);
-  const [settingsRequestedSection, setSettingsRequestedSection] = useState<SettingsSection | undefined>(undefined);
-  const [settingsProviderCatalogOpen, setSettingsProviderCatalogOpen] = useState(false);
+  const {
+    settingsOpen,
+    settingsRequestedSection,
+    settingsProviderCatalogOpen,
+    setSettingsOpen,
+    setSettingsProviderCatalogOpen,
+    openSettings,
+    openSettingsSection,
+    openProviderCatalog,
+  } = useSettingsModal();
   const [themePref, setThemePref] = useState<ThemePreference>('auto');
   const [themePalette, setThemePalette] = useState<ThemePalette>('default');
   const [uiLocalePreference, setUiLocalePreference] = useState<UiLocalePreference>('auto');
@@ -1082,13 +1088,8 @@ export function AppShell({
     });
   }
 
-  function openSettings() {
-    setSettingsProviderCatalogOpen(false);
-    setSettingsOpen(true);
-  }
-
   /**
-   * PR-UI-RENDER-2 — single chokepoint for the Markdown internal-URI
+   * PR-UI-RENDER-2 - single chokepoint for the Markdown internal-URI
    * router. Receives a typed `MakaUriDest` from the link override in
    * `<Markdown>` and dispatches to the existing app navigation
    * surfaces:
@@ -1120,26 +1121,6 @@ export function AppShell({
         return _exhaustive;
       }
     }
-  }
-
-  /**
-   * Opens Settings and jumps directly to the named section. Writes the section
-   * to localStorage (so the next cold-open lands there too) and threads it
-   * through `requestedSection` so an already-open Settings modal switches
-   * tabs without close/reopen.
-   */
-  function openSettingsSection(section: SettingsSection) {
-    safeLocalStorageSet('maka-settings-section-v1', section);
-    setSettingsRequestedSection(section);
-    setSettingsProviderCatalogOpen(false);
-    setSettingsOpen(true);
-  }
-
-  function openProviderCatalog() {
-    safeLocalStorageSet('maka-settings-section-v1', 'models');
-    setSettingsRequestedSection('models');
-    setSettingsProviderCatalogOpen(true);
-    setSettingsOpen(true);
   }
 
   function closeSettings() {

--- a/apps/desktop/src/renderer/use-settings-modal.ts
+++ b/apps/desktop/src/renderer/use-settings-modal.ts
@@ -1,0 +1,50 @@
+import { useState } from 'react';
+import type { SettingsSection } from '@maka/core';
+import { safeLocalStorageSet } from './browser-storage';
+
+/**
+ * Owns the Settings modal surface state (issue #1043): the open flag, the
+ * requested section, and the provider-catalog sub-open flag, plus the openers
+ * that persist the section to localStorage.
+ *
+ * `closeSettings` stays in AppShell: on close it re-pulls the onboarding
+ * snapshot, the memory-visibility flag, and the default permission mode -
+ * cross-slice orchestration that belongs to the shell, not the modal.
+ */
+export function useSettingsModal() {
+  const [settingsOpen, setSettingsOpen] = useState(false);
+  const [settingsRequestedSection, setSettingsRequestedSection] = useState<SettingsSection | undefined>(
+    undefined,
+  );
+  const [settingsProviderCatalogOpen, setSettingsProviderCatalogOpen] = useState(false);
+
+  function openSettings() {
+    setSettingsProviderCatalogOpen(false);
+    setSettingsOpen(true);
+  }
+
+  function openSettingsSection(section: SettingsSection) {
+    safeLocalStorageSet('maka-settings-section-v1', section);
+    setSettingsRequestedSection(section);
+    setSettingsProviderCatalogOpen(false);
+    setSettingsOpen(true);
+  }
+
+  function openProviderCatalog() {
+    safeLocalStorageSet('maka-settings-section-v1', 'models');
+    setSettingsRequestedSection('models');
+    setSettingsProviderCatalogOpen(true);
+    setSettingsOpen(true);
+  }
+
+  return {
+    settingsOpen,
+    settingsRequestedSection,
+    settingsProviderCatalogOpen,
+    setSettingsOpen,
+    setSettingsProviderCatalogOpen,
+    openSettings,
+    openSettingsSection,
+    openProviderCatalog,
+  };
+}

--- a/apps/desktop/src/renderer/use-shell-layout.ts
+++ b/apps/desktop/src/renderer/use-shell-layout.ts
@@ -1,0 +1,35 @@
+import { useState } from 'react';
+import { readSessionListCollapsed, readSessionListWidth } from './session-list-layout';
+import {
+  readSessionWorkbarCollapsed,
+  readSessionWorkbarTab,
+  readSessionWorkbarWidth,
+} from './session-workbar-layout';
+
+/**
+ * Owns the shell layout state (issue #1043): session-list and workbar widths,
+ * collapse flags, and the active workbar tab. Each value is hydrated from
+ * localStorage on first render and persisted by `useAppShellPersistenceEffects`.
+ *
+ * The resize pointer/keyboard handlers live in `createAppShellLayoutActions`
+ * (app-shell-layout-actions.ts); this hook only owns the state and setters.
+ */
+export function useShellLayout() {
+  const [sessionListWidth, setSessionListWidth] = useState(() => readSessionListWidth());
+  const [sessionListCollapsed, setSessionListCollapsed] = useState(() => readSessionListCollapsed());
+  const [workbarCollapsed, setWorkbarCollapsed] = useState(() => readSessionWorkbarCollapsed());
+  const [workbarWidth, setWorkbarWidth] = useState(() => readSessionWorkbarWidth());
+  const [workbarTab, setWorkbarTab] = useState(() => readSessionWorkbarTab());
+  return {
+    sessionListWidth,
+    setSessionListWidth,
+    sessionListCollapsed,
+    setSessionListCollapsed,
+    workbarCollapsed,
+    setWorkbarCollapsed,
+    workbarWidth,
+    setWorkbarWidth,
+    workbarTab,
+    setWorkbarTab,
+  };
+}


### PR DESCRIPTION
## Summary

Refs #1043 (step 3a/3b of the plan documented there). Continues the shell-state colocation started in #1166.

Two more self-contained state slices move out of AppShell's inline hook block into their own hooks, following the existing `useShellConnections` / `useShellMemoryPill` seam:

- `useShellLayout` - the five shell-layout useState calls (session-list/workbar widths, collapse flags, workbar tab), each hydrated from localStorage. The resize pointer/keyboard handlers already live in `createAppShellLayoutActions`; this hook only owns the state and setters.
- `useSettingsModal` - the Settings modal surface state (open flag, requested section, provider-catalog sub-open flag) plus the three openers that persist the section to localStorage.

AppShell calls each hook at the original state-declaration site (hook order preserved) and threads the values to the same consumers unchanged:

- layout values -> `createAppShellLayoutActions`, `useAppShellPersistenceEffects`, and the JSX aria/CSS-var bindings.
- settings openers -> the chat-model / visual-smoke / bootstrap-subscription hooks that take them as deps, the JSX callbacks, and `AppShellOverlays`.

`closeSettings` stays inline in AppShell: on close it re-pulls the onboarding snapshot, the memory-visibility flag, and the default permission mode - cross-slice orchestration that belongs to the shell, not the modal. The hook exposes `setSettingsOpen` / `setSettingsProviderCatalogOpen` so `closeSettings` can clear the surface.

Pure code motion - no behavior change. The `read*` layout hydrators now live with the state; the `SESSION_*` layout constants stay in AppShell (JSX aria-valuemin/max). The two new hook files are registered in `renderer-shell-source-helpers` so the combined-source contract keeps covering them.

## Verification

- `tsc -p tsconfig.main.json` and `tsconfig.renderer.json` - clean.
- `biome lint` (the repo's CI lint command; the formatter is deliberately disabled per `biome.jsonc` / #415) on changed files - clean.
- `node --test dist/main/**/*.test.js` - 2661/2661, 0 failures.
- `npm run build:renderer` - clean.
- Playwright `e2e/send-message.spec.ts` (fake-backend streaming journey) - passes.

## Review focus

The `<ChatWorkspace>` extraction (step 3c) is intentionally deferred to a follow-up PR. It is blocked by source-contract tests that read `app-shell.tsx` directly (not via the combined-source registry) and pin the Composer / `maka-composer-interaction-slot` / `<PermissionPrompt>` structure to that file - notably `permission-composer-takeover-contract`, which locks the always-mounted-Composer invariant. Moving the chat surface into a separate component requires auditing and updating those direct-read contracts, reorganizing ~80 props by owner, and re-running the permission/session-health/attachment E2E - a scope that deserves its own focused PR.
