### PR TITLE
refactor(desktop): extract the chat surface from app-shell

### DIFF
--- a/apps/desktop/src/main/__tests__/first-run-task-suggestions.test.ts
+++ b/apps/desktop/src/main/__tests__/first-run-task-suggestions.test.ts
@@ -231,7 +231,8 @@ describe('FIRST_RUN_TASK_SUGGESTIONS', () => {
       /else\s*props\.onOpenSidebarModule\('automations'\);/,
     );
     assert.match(main, /function\s+openPlanReminderForm\(\)/);
-    assert.match(main, /<FirstRunChecklist[\s\S]*onStartPlanReminder=\{openPlanReminderForm\}/);
+    assert.match(main, /<OnboardingEmptyState[\s\S]*onStartPlanReminder=\{openPlanReminderForm\}/);
+    assert.match(main, /<FirstRunChecklist[\s\S]*onStartPlanReminder=\{onStartPlanReminder\}/);
   });
 
   it('does not count exploration-only rows as unfinished setup todos', async () => {

--- a/apps/desktop/src/main/__tests__/first-run-task-suggestions.test.ts
+++ b/apps/desktop/src/main/__tests__/first-run-task-suggestions.test.ts
@@ -231,7 +231,8 @@ describe('FIRST_RUN_TASK_SUGGESTIONS', () => {
       /else\s*props\.onOpenSidebarModule\('automations'\);/,
     );
     assert.match(main, /function\s+openPlanReminderForm\(\)/);
-    assert.match(main, /<OnboardingEmptyState[\s\S]*onStartPlanReminder=\{openPlanReminderForm\}/);
+    assert.match(main, /<ChatMessageSurface[\s\S]*onStartPlanReminder=\{openPlanReminderForm\}/);
+    assert.match(main, /<OnboardingEmptyState[\s\S]*onStartPlanReminder=\{onStartPlanReminder\}/);
     assert.match(main, /<FirstRunChecklist[\s\S]*onStartPlanReminder=\{onStartPlanReminder\}/);
   });
 

--- a/apps/desktop/src/main/__tests__/permission-composer-takeover-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/permission-composer-takeover-contract.test.ts
@@ -12,12 +12,12 @@ function ruleBody(css: string, selector: string): string {
 
 describe('permission composer takeover', () => {
   it('keeps Composer mounted while the permission surface owns its slot', async () => {
-    const appShell = await readFile(join(rendererRoot, 'app-shell.tsx'), 'utf8');
+    const composerRegion = await readFile(join(rendererRoot, 'chat-composer-region.tsx'), 'utf8');
     const overlays = await readFile(join(rendererRoot, 'app-shell-overlays.tsx'), 'utf8');
-    const composerBlock = appShell.match(/<Composer\s+ref=\{composerRef\}[\s\S]*?\/>/)?.[0] ?? '';
+    const composerBlock = composerRegion.match(/<Composer\s+ref=\{composerRef\}[\s\S]*?\/>/)?.[0] ?? '';
 
     assert.match(
-      appShell,
+      composerRegion,
       /className="maka-composer-interaction-slot"[\s\S]*?<PermissionPrompt/,
       'the permission prompt must render in the stable composer interaction slot',
     );
@@ -50,6 +50,7 @@ describe('permission composer takeover', () => {
 
   it('renders a non-modal permission region with an always-visible Stop action', async () => {
     const appShell = await readFile(join(rendererRoot, 'app-shell.tsx'), 'utf8');
+    const composerRegion = await readFile(join(rendererRoot, 'chat-composer-region.tsx'), 'utf8');
     const permissionSource = await readFile(
       join(process.cwd(), '..', '..', 'packages', 'ui', 'src', 'permission-dialog.tsx'),
       'utf8',
@@ -67,7 +68,7 @@ describe('permission composer takeover', () => {
     assert.match(prompt, /denyButtonRef\.current\?\.focus\(\)/, 'focus must move from the hidden composer to the safe decision');
     assert.match(prompt, /ref=\{denyButtonRef\}[\s\S]*?submit\('deny'\)/);
     assert.match(
-      appShell,
+      composerRegion,
       /<PermissionPrompt[\s\S]*?onStop=\{stop\}[\s\S]*?stopPending=\{activeId \? stopPendingBySession\[activeId\] === true : false\}/,
       'the takeover must use the same stop owner and pending state as Composer',
     );

--- a/apps/desktop/src/main/__tests__/permission-response-ipc-boundary.test.ts
+++ b/apps/desktop/src/main/__tests__/permission-response-ipc-boundary.test.ts
@@ -247,9 +247,10 @@ describe('permission response IPC boundary', () => {
 
   it('renderer lets either interaction type take over the mounted composer slot', async () => {
     const shell = await readRendererShellSource('app-shell.tsx');
+    const composerRegion = await readRendererShellSource('chat-composer-region.tsx');
     assert.match(shell, /activeQuestion = activeInteraction\?\.type === 'user_question_request'/);
-    assert.match(shell, /<UserQuestionPrompt[\s\S]*request=\{activeQuestion\}/);
-    assert.match(shell, /hidden=\{[^}]*Boolean\(activeInteraction\)[^}]*\}/);
+    assert.match(composerRegion, /<UserQuestionPrompt[\s\S]*request=\{activeQuestion\}/);
+    assert.match(composerRegion, /hidden=\{[^}]*Boolean\(activeInteraction\)[^}]*\}/);
   });
 
   it('renderer clears the permission prompt when a session completes (PR-PERMISSION-UI-CLEANUP-0)', async () => {

--- a/apps/desktop/src/main/__tests__/renderer-lazy-fallback-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/renderer-lazy-fallback-contract.test.ts
@@ -13,18 +13,24 @@ describe('renderer lazy fallback contract', () => {
   it('keeps visible shell lazy chunks on compact non-null fallbacks', async () => {
     const appShell = await readFile(APP_SHELL_PATH, 'utf8');
     const overlays = await readFile(APP_SHELL_OVERLAYS_PATH, 'utf8');
+    const chatWorkbar = await readFile(resolve(RENDERER_ROOT, 'chat-workbar.tsx'), 'utf8');
 
     assert.match(overlays, /function SettingsModalFallback/, 'Settings modal must reserve a loading shell');
     assert.match(overlays, /<Suspense fallback=\{<SettingsModalFallback \/>\}>/);
     assert.doesNotMatch(overlays, /settingsOpen[\s\S]{0,120}<Suspense fallback=\{null\}>/);
 
-    assert.match(appShell, /function SessionWorkbarFallback/, 'Session workbar must reserve a loading shell');
+    assert.match(chatWorkbar, /function SessionWorkbarFallback/, 'Session workbar must reserve a loading shell');
     assert.match(
       appShell,
-      /\{navSelection\.section === 'sessions' && activeId && !workbarCollapsed && \([\s\S]*?<Suspense fallback=\{<SessionWorkbarFallback \/>\}>[\s\S]*?<SessionWorkbar[\s\S]*?<\/Suspense>[\s\S]*?\)\}/,
+      /navSelection\.section === 'sessions' && activeId && !workbarCollapsed && \([\s\S]*?<ChatWorkbar/,
       'The persisted shell-owned workbar state makes its visible fallback deterministic',
     );
-    assert.match(appShell, /<Suspense fallback=\{<SessionWorkbarFallback \/>\}>/);
+    assert.match(
+      chatWorkbar,
+      /<Suspense fallback=\{<SessionWorkbarFallback \/>\}>[\s\S]*?<SessionWorkbar[\s\S]*?<\/Suspense>/,
+      'The persisted shell-owned workbar state makes its visible fallback deterministic',
+    );
+    assert.match(chatWorkbar, /<Suspense fallback=\{<SessionWorkbarFallback \/>\}>/);
   });
 
   it('keeps module lazy chunks on compact non-null fallbacks', async () => {

--- a/apps/desktop/src/main/__tests__/renderer-shell-source-helpers.ts
+++ b/apps/desktop/src/main/__tests__/renderer-shell-source-helpers.ts
@@ -43,6 +43,7 @@ const sourcePaths = [
   'onboarding-empty-state.tsx',
   'chat-message-surface.tsx',
   'chat-composer-region.tsx',
+  'chat-workbar.tsx',
   'app-shell-visual-smoke.ts',
   'cached-theme-bootstrap.ts',
   'chat-model-selection.ts',

--- a/apps/desktop/src/main/__tests__/renderer-shell-source-helpers.ts
+++ b/apps/desktop/src/main/__tests__/renderer-shell-source-helpers.ts
@@ -41,6 +41,7 @@ const sourcePaths = [
   'use-shell-layout.ts',
   'use-settings-modal.ts',
   'onboarding-empty-state.tsx',
+  'chat-message-surface.tsx',
   'app-shell-visual-smoke.ts',
   'cached-theme-bootstrap.ts',
   'chat-model-selection.ts',

--- a/apps/desktop/src/main/__tests__/renderer-shell-source-helpers.ts
+++ b/apps/desktop/src/main/__tests__/renderer-shell-source-helpers.ts
@@ -42,6 +42,7 @@ const sourcePaths = [
   'use-settings-modal.ts',
   'onboarding-empty-state.tsx',
   'chat-message-surface.tsx',
+  'chat-composer-region.tsx',
   'app-shell-visual-smoke.ts',
   'cached-theme-bootstrap.ts',
   'chat-model-selection.ts',

--- a/apps/desktop/src/main/__tests__/renderer-shell-source-helpers.ts
+++ b/apps/desktop/src/main/__tests__/renderer-shell-source-helpers.ts
@@ -40,6 +40,7 @@ const sourcePaths = [
   'use-shell-memory-pill.ts',
   'use-shell-layout.ts',
   'use-settings-modal.ts',
+  'onboarding-empty-state.tsx',
   'app-shell-visual-smoke.ts',
   'cached-theme-bootstrap.ts',
   'chat-model-selection.ts',

--- a/apps/desktop/src/main/__tests__/session-health-notice-layout-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/session-health-notice-layout-contract.test.ts
@@ -28,26 +28,27 @@ describe('session health notice layout contract (#1032)', () => {
 
   it('mounts the hard-only health notice above the composer interaction slot', async () => {
     const shell = await readRepo('apps/desktop/src/renderer/app-shell.tsx');
-    const noticeIndex = shell.indexOf('className="maka-session-health-notice"');
+    const surface = await readRepo('apps/desktop/src/renderer/chat-message-surface.tsx');
+    const surfaceIndex = shell.indexOf('<ChatMessageSurface');
     const slotIndex = shell.indexOf('className="maka-composer-interaction-slot"');
     const composerIndex = shell.indexOf('<Composer\n                ref={composerRef}');
-    assert.ok(noticeIndex >= 0, 'session health notice should render in app-shell');
+    assert.ok(surfaceIndex >= 0, 'ChatMessageSurface should render in app-shell');
     assert.ok(slotIndex >= 0, 'composer interaction slot should remain');
     assert.ok(composerIndex >= 0, 'composer mount should remain');
     assert.ok(
-      noticeIndex < slotIndex && slotIndex < composerIndex,
-      'notice must sit above the interaction slot and composer',
+      surfaceIndex < slotIndex && slotIndex < composerIndex,
+      'the message surface (with its health notice) must sit above the interaction slot and composer',
     );
     assert.match(
       shell,
-      /navSelection\.section === 'sessions' && sessionHealthNotice &&/,
-      'health notice must stay on the conversation surface, not Skills/Automations/Daily Review',
+      /navSelection\.section === 'daily-review' \?[\s\S]*<ChatMessageSurface/,
+      'the message surface must stay on the conversation surface, not Skills/Automations/Daily Review',
     );
     assert.match(
-      shell,
+      surface,
       /className="maka-session-health-notice"[\s\S]*?role="status"/,
     );
-    assert.match(shell, /sessionHealthNotice\.onClickTarget === 'account' \? '去账号' : '去模型'/);
+    assert.match(surface, /sessionHealthNotice\.onClickTarget === 'account' \? '去账号' : '去模型'/);
   });
 
   it('does not surface routine running or event-stream recovery badges', async () => {

--- a/apps/desktop/src/main/__tests__/session-health-notice-layout-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/session-health-notice-layout-contract.test.ts
@@ -29,15 +29,14 @@ describe('session health notice layout contract (#1032)', () => {
   it('mounts the hard-only health notice above the composer interaction slot', async () => {
     const shell = await readRepo('apps/desktop/src/renderer/app-shell.tsx');
     const surface = await readRepo('apps/desktop/src/renderer/chat-message-surface.tsx');
+    const composerRegion = await readRepo('apps/desktop/src/renderer/chat-composer-region.tsx');
     const surfaceIndex = shell.indexOf('<ChatMessageSurface');
-    const slotIndex = shell.indexOf('className="maka-composer-interaction-slot"');
-    const composerIndex = shell.indexOf('<Composer\n                ref={composerRef}');
+    const composerRegionIndex = shell.indexOf('<ChatComposerRegion');
     assert.ok(surfaceIndex >= 0, 'ChatMessageSurface should render in app-shell');
-    assert.ok(slotIndex >= 0, 'composer interaction slot should remain');
-    assert.ok(composerIndex >= 0, 'composer mount should remain');
+    assert.ok(composerRegionIndex >= 0, 'ChatComposerRegion should render in app-shell');
     assert.ok(
-      surfaceIndex < slotIndex && slotIndex < composerIndex,
-      'the message surface (with its health notice) must sit above the interaction slot and composer',
+      surfaceIndex < composerRegionIndex,
+      'the message surface (with its health notice) must sit above the composer region',
     );
     assert.match(
       shell,
@@ -49,6 +48,7 @@ describe('session health notice layout contract (#1032)', () => {
       /className="maka-session-health-notice"[\s\S]*?role="status"/,
     );
     assert.match(surface, /sessionHealthNotice\.onClickTarget === 'account' \? '去账号' : '去模型'/);
+    assert.match(composerRegion, /className="maka-composer-interaction-slot"/);
   });
 
   it('does not surface routine running or event-stream recovery badges', async () => {

--- a/apps/desktop/src/main/__tests__/session-workbar-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/session-workbar-contract.test.ts
@@ -19,12 +19,13 @@ describe('session workbar contract', () => {
   });
 
   it('is the only shell owner of tasks, browser, and files', async () => {
-    const [appShell, chatView] = await Promise.all([
+    const [appShell, chatView, chatWorkbar] = await Promise.all([
       readFile(resolve(REPO_ROOT, 'apps/desktop/src/renderer/app-shell.tsx'), 'utf8'),
       readFile(resolve(REPO_ROOT, 'packages/ui/src/chat-view.tsx'), 'utf8'),
+      readFile(resolve(REPO_ROOT, 'apps/desktop/src/renderer/chat-workbar.tsx'), 'utf8'),
     ]);
 
-    assert.match(appShell, /<SessionWorkbar\b/);
+    assert.match(chatWorkbar, /<SessionWorkbar\b/);
     assert.doesNotMatch(appShell, /<BrowserPanel\b/);
     assert.doesNotMatch(appShell, /<ArtifactPane\b/);
     assert.doesNotMatch(chatView, /<TaskLedgerPanel\b/);
@@ -45,7 +46,7 @@ describe('session workbar contract', () => {
 
     assert.match(
       appShell,
-      /navSelection\.section === 'sessions' && activeId && !workbarCollapsed && \(/,
+      /navSelection\.section === 'sessions' && activeId && !workbarCollapsed/,
       'module pages must not inherit the active session workbar',
     );
   });

--- a/apps/desktop/src/main/__tests__/streaming-timeline-render-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/streaming-timeline-render-contract.test.ts
@@ -36,7 +36,7 @@ it('renders live thinking and text from timeline items instead of a trailing liv
     'utf8',
   );
   assert.match(shell, /const activeLiveTurn = activeId \? liveTurnBySession\[activeId\] : undefined;/);
-  assert.match(shell, /<ChatView[\s\S]*?liveTurn=\{activeLiveTurn\}/);
+  assert.match(shell, /<ChatMessageSurface[\s\S]*?liveTurn=\{activeLiveTurn\}/);
 });
 
 it('keeps persisted turn materialization stable while live text grows', async () => {

--- a/apps/desktop/src/renderer/app-shell.tsx
+++ b/apps/desktop/src/renderer/app-shell.tsx
@@ -1,4 +1,4 @@
-import { lazy, Suspense, useCallback, useEffect, useEffectEvent, useLayoutEffect, useMemo, useRef, useState, type CSSProperties } from 'react';
+import { useCallback, useEffect, useEffectEvent, useLayoutEffect, useMemo, useRef, useState, type CSSProperties } from 'react';
 import type {
   ChatDefaultPermissionMode,
   PermissionMode,
@@ -29,22 +29,12 @@ import { useKeyboardHelp } from './keyboard-help';
 import { useCommandPalette } from './command-palette';
 import { ChatMessageSurface } from './chat-message-surface';
 import { ChatComposerRegion } from './chat-composer-region';
+import { ChatWorkbar } from './chat-workbar';
 import { useOnboardingSnapshot } from './use-onboarding-snapshot';
 import type { OnboardingSnapshot } from '../global';
 import { ProviderLogo } from './settings/provider-display';
 import { ProviderBrandMark } from './settings/provider-brand-marks';
 import { createUiLocaleUpdateGate } from './settings/ui-locale-update-gate';
-// The session workbar owns the task ledger, embedded browser, and artifact
-// preview. Keep the combined auxiliary surface out of the first chat paint.
-const SessionWorkbar = lazy(() => import('./session-workbar').then((m) => ({ default: m.SessionWorkbar })));
-
-function SessionWorkbarFallback() {
-  return (
-    <aside className="maka-session-workbar" role="status" aria-busy="true" aria-label="正在加载会话工作栏">
-      <div className="maka-lazy-fallback" data-surface="panel">正在加载会话工作栏…</div>
-    </aside>
-  );
-}
 import { useSessionGoal } from './use-session-goal';
 import { deriveStaleSessionIds } from './stale-sessions';
 import { deriveProjectGroups } from './session-project-grouping';
@@ -59,10 +49,6 @@ import {
   SESSION_LIST_EXPANDED_MAX_WIDTH,
   SESSION_LIST_EXPANDED_MIN_WIDTH,
 } from './session-list-layout';
-import {
-  SESSION_WORKBAR_MAX_WIDTH,
-  SESSION_WORKBAR_MIN_WIDTH,
-} from './session-workbar-layout';
 import {
   modelSetupToastCopy,
 } from './model-connection-errors';
@@ -1518,32 +1504,17 @@ export function AppShell({
               />
             </div>
             {navSelection.section === 'sessions' && activeId && !workbarCollapsed && (
-              <>
-                <div
-                  className="maka-workbar-resize-handle"
-                  role="separator"
-                  aria-label="调整会话工作栏宽度"
-                  aria-orientation="vertical"
-                  aria-valuemin={SESSION_WORKBAR_MIN_WIDTH}
-                  aria-valuemax={SESSION_WORKBAR_MAX_WIDTH}
-                  aria-valuenow={workbarWidth}
-                  tabIndex={0}
-                  onPointerDown={startWorkbarResize}
-                  onKeyDown={onWorkbarResizeHandleKeyDown}
-                />
-                <Suspense fallback={<SessionWorkbarFallback />}>
-                  <SessionWorkbar
-                    key={activeId}
-                    sessionId={activeId}
-                    browserLive={liveBrowserSessionIds.includes(activeId)}
-                    hidden={hasModalOpen}
-                    width={workbarWidth}
-                    onDismiss={() => setWorkbarCollapsed(true)}
-                    activeTab={workbarTab}
-                    onActiveTabChange={setWorkbarTab}
-                  />
-                </Suspense>
-              </>
+              <ChatWorkbar
+                activeId={activeId}
+                browserLive={liveBrowserSessionIds.includes(activeId)}
+                hidden={hasModalOpen}
+                width={workbarWidth}
+                onDismiss={() => setWorkbarCollapsed(true)}
+                activeTab={workbarTab}
+                onActiveTabChange={setWorkbarTab}
+                startWorkbarResize={startWorkbarResize}
+                onWorkbarResizeHandleKeyDown={onWorkbarResizeHandleKeyDown}
+              />
             )}
           </div>
           </MakaUriContext.Provider>

--- a/apps/desktop/src/renderer/app-shell.tsx
+++ b/apps/desktop/src/renderer/app-shell.tsx
@@ -12,9 +12,6 @@ import type {
 import { generalizedErrorMessageChinese, hasSettledInitialOnboarding } from '@maka/core';
 import {
   AutomationsPage,
-  Composer,
-  PermissionPrompt,
-  UserQuestionPrompt,
   DailyReviewPage,
   type ComposerHandle,
   type MakaUriDest,
@@ -31,6 +28,7 @@ import {
 import { useKeyboardHelp } from './keyboard-help';
 import { useCommandPalette } from './command-palette';
 import { ChatMessageSurface } from './chat-message-surface';
+import { ChatComposerRegion } from './chat-composer-region';
 import { useOnboardingSnapshot } from './use-onboarding-snapshot';
 import type { OnboardingSnapshot } from '../global';
 import { ProviderLogo } from './settings/provider-display';
@@ -1407,29 +1405,19 @@ export function AppShell({
                 onStartPlanReminder={openPlanReminderForm}
               />
               )}
-              <div className="maka-composer-interaction-slot">
-                {activePermission && (
-                  <PermissionPrompt
-                    request={activePermission}
-                    onRespond={respondToPermission}
-                    onStop={stop}
-                    stopPending={activeId ? stopPendingBySession[activeId] === true : false}
-                  />
-                )}
-                {activeQuestion && (
-                  <UserQuestionPrompt
-                    request={activeQuestion}
-                    onRespond={respondToUserQuestion}
-                    onStop={stop}
-                    stopPending={activeId ? stopPendingBySession[activeId] === true : false}
-                  />
-                )}
-              </div>
-              <Composer
-                ref={composerRef}
-                hidden={navSelection.section !== 'sessions' || onboardingComposerHidden || Boolean(activeInteraction)}
-                draftKey={activeId ?? 'new-session'}
-                // #646: Stop must be available for the WHOLE turn — the moment the
+              <ChatComposerRegion
+                composerRef={composerRef}
+                active={navSelection.section === 'sessions'}
+                onboardingComposerHidden={onboardingComposerHidden}
+                activeInteraction={activeInteraction}
+                activeId={activeId}
+                stopPendingBySession={stopPendingBySession}
+                activePermission={activePermission}
+                respondToPermission={respondToPermission}
+                activeQuestion={activeQuestion}
+                respondToUserQuestion={respondToUserQuestion}
+                stop={stop}
+                // #646: Stop must be available for the WHOLE turn - the moment the
                 // user most wants to interrupt is a long wait with nothing on
                 // screen (first token, or a slow provider's step-to-step lull).
                 // Drive Stop off `turnInFlight` (armed at send, cleared at the
@@ -1451,7 +1439,6 @@ export function AppShell({
                 continuing={showContinuingIndicator && !activeStreamingLive}
                 onSend={sendWithAttachments}
                 onStop={stop}
-                stopPending={activeId ? stopPendingBySession[activeId] === true : false}
                 mentionSkills={mentionSkills}
                 onSearchMentionFiles={searchMentionFiles}
                 pendingAttachments={pendingAttachments}

--- a/apps/desktop/src/renderer/app-shell.tsx
+++ b/apps/desktop/src/renderer/app-shell.tsx
@@ -11,12 +11,7 @@ import type {
 } from '@maka/core';
 import { generalizedErrorMessageChinese, hasSettledInitialOnboarding } from '@maka/core';
 import {
-  Alert,
-  AlertAction,
-  AlertDescription,
-  AlertTitle,
   AutomationsPage,
-  ChatView,
   Composer,
   PermissionPrompt,
   UserQuestionPrompt,
@@ -35,7 +30,7 @@ import {
 } from '@maka/ui';
 import { useKeyboardHelp } from './keyboard-help';
 import { useCommandPalette } from './command-palette';
-import { OnboardingEmptyState } from './onboarding-empty-state';
+import { ChatMessageSurface } from './chat-message-surface';
 import { useOnboardingSnapshot } from './use-onboarding-snapshot';
 import type { OnboardingSnapshot } from '../global';
 import { ProviderLogo } from './settings/provider-display';
@@ -1338,7 +1333,7 @@ export function AppShell({
                   onSaveMarkdown={(input) => saveDailyReviewMarkdown(input, { shouldShowFeedback: isDailyReviewSurfaceActive })}
                 />
               ) : (
-              <ChatView
+              <ChatMessageSurface
                 messages={messages}
                 liveTurn={activeLiveTurn}
                 shellRunUpdates={activeShellRunUpdates}
@@ -1382,74 +1377,35 @@ export function AppShell({
                 scrollBehavior={readScrollMotionBehavior()}
                 branchBanner={branchBanner}
                 onBranchBannerClick={handleBranchBannerClick}
-                emptyOverride={
-                  showOnboardingHero && onboardingState ? (
-                    <OnboardingEmptyState
-                      state={onboardingState}
-                      onOpenSettings={(section) => {
-                        if (section) openSettingsSection(section);
-                        else openSettings();
-                      }}
-                      onBrowseProviders={openProviderCatalog}
-                      onQuickChatSubmit={handleQuickChatSubmit}
-                      quickChatPending={quickChatPending}
-                      connections={connections}
-                      onRefreshConnections={refreshConnections}
-                      onSkip={async () => {
-                        try {
-                          await window.maka.onboarding.setMilestone('initial_onboarding', 'skipped');
-                          onboarding.refresh();
-                        } catch (error) {
-                          toastApi.error('跳过失败', generalizedErrorMessageChinese(error, '请稍后重试。'));
-                        }
-                      }}
-                      onOpenSettingsSection={(section) => openSettingsSection(section)}
-                      onOpenSidebarModule={(target) => {
-                        setNavSelection({ section: target });
-                      }}
-                      onStartPlanReminder={openPlanReminderForm}
-                    />
-                  ) : isOnboardingLoading ? (
-                    // @kenji review: render a no-op skeleton while the
-                    // first snapshot resolves so EmptyChatHero doesn't
-                    // flash. Use an aria-busy live region so screen
-                    // readers know something is loading.
-                    <div
-                      className="maka-onboarding-loading"
-                      role="status"
-                      aria-busy="true"
-                      aria-label="加载中"
-                    />
-                  ) : undefined
-                }
                 onNew={createSession}
                 onPromptSuggestion={(prompt) => composerRef.current?.appendText(prompt)}
+                sessionHealthNotice={sessionHealthNotice}
+                showOnboardingHero={showOnboardingHero}
+                onboardingState={onboardingState}
+                isOnboardingLoading={isOnboardingLoading}
+                onOpenSettings={(section) => {
+                  if (section) openSettingsSection(section);
+                  else openSettings();
+                }}
+                onBrowseProviders={openProviderCatalog}
+                onQuickChatSubmit={handleQuickChatSubmit}
+                quickChatPending={quickChatPending}
+                connections={connections}
+                onRefreshConnections={refreshConnections}
+                onSkip={async () => {
+                  try {
+                    await window.maka.onboarding.setMilestone('initial_onboarding', 'skipped');
+                    onboarding.refresh();
+                  } catch (error) {
+                    toastApi.error('跳过失败', generalizedErrorMessageChinese(error, '请稍后重试。'));
+                  }
+                }}
+                onOpenSettingsSection={(section) => openSettingsSection(section)}
+                onOpenSidebarModule={(target) => {
+                  setNavSelection({ section: target });
+                }}
+                onStartPlanReminder={openPlanReminderForm}
               />
-              )}
-              {navSelection.section === 'sessions' && sessionHealthNotice && (
-                <div className="maka-session-health-notice">
-                  <Alert
-                    className="maka-session-health-notice-alert"
-                    variant={sessionHealthNotice.tone === 'destructive' ? 'error' : sessionHealthNotice.tone === 'warning' ? 'warning' : 'info'}
-                    role="status"
-                    aria-label={sessionHealthNotice.tooltip ?? sessionHealthNotice.label}
-                    title={sessionHealthNotice.tooltip}
-                  >
-                    <AlertTitle>{sessionHealthNotice.label}</AlertTitle>
-                    {sessionHealthNotice.tooltip ? (
-                      <AlertDescription>{sessionHealthNotice.tooltip}</AlertDescription>
-                    ) : null}
-                    <AlertAction>
-                      <button
-                        type="button"
-                        className="maka-session-health-notice-action"
-                        onClick={sessionHealthNotice.onClick}
-                      >
-                        {sessionHealthNotice.onClickTarget === 'account' ? '去账号' : '去模型'}
-                      </button>
-                    </AlertAction>
-                  </Alert>
-                </div>
               )}
               <div className="maka-composer-interaction-slot">
                 {activePermission && (

--- a/apps/desktop/src/renderer/app-shell.tsx
+++ b/apps/desktop/src/renderer/app-shell.tsx
@@ -35,8 +35,7 @@ import {
 } from '@maka/ui';
 import { useKeyboardHelp } from './keyboard-help';
 import { useCommandPalette } from './command-palette';
-import { OnboardingHero } from './OnboardingHero';
-import { FirstRunChecklist } from './FirstRunChecklist';
+import { OnboardingEmptyState } from './onboarding-empty-state';
 import { useOnboardingSnapshot } from './use-onboarding-snapshot';
 import type { OnboardingSnapshot } from '../global';
 import { ProviderLogo } from './settings/provider-display';
@@ -1385,37 +1384,31 @@ export function AppShell({
                 onBranchBannerClick={handleBranchBannerClick}
                 emptyOverride={
                   showOnboardingHero && onboardingState ? (
-                    <div className="maka-onboarding-stack">
-                      <OnboardingHero
-                        state={onboardingState}
-                        onOpenSettings={(section) => {
-                          if (section) openSettingsSection(section);
-                          else openSettings();
-                        }}
-                        onBrowseProviders={openProviderCatalog}
-                        onQuickChatSubmit={handleQuickChatSubmit}
-                        quickChatPending={quickChatPending}
-                        connections={connections}
-                        onRefreshConnections={refreshConnections}
-                        onSkip={async () => {
-                          try {
-                            await window.maka.onboarding.setMilestone('initial_onboarding', 'skipped');
-                            onboarding.refresh();
-                          } catch (error) {
-                            toastApi.error('跳过失败', generalizedErrorMessageChinese(error, '请稍后重试。'));
-                          }
-                        }}
-                      />
-                      {onboardingState.kind === 'ready_empty' && (
-                        <FirstRunChecklist
-                          onOpenSettingsSection={(section) => openSettingsSection(section)}
-                          onOpenSidebarModule={(target) => {
-                            setNavSelection({ section: target });
-                          }}
-                          onStartPlanReminder={openPlanReminderForm}
-                        />
-                      )}
-                    </div>
+                    <OnboardingEmptyState
+                      state={onboardingState}
+                      onOpenSettings={(section) => {
+                        if (section) openSettingsSection(section);
+                        else openSettings();
+                      }}
+                      onBrowseProviders={openProviderCatalog}
+                      onQuickChatSubmit={handleQuickChatSubmit}
+                      quickChatPending={quickChatPending}
+                      connections={connections}
+                      onRefreshConnections={refreshConnections}
+                      onSkip={async () => {
+                        try {
+                          await window.maka.onboarding.setMilestone('initial_onboarding', 'skipped');
+                          onboarding.refresh();
+                        } catch (error) {
+                          toastApi.error('跳过失败', generalizedErrorMessageChinese(error, '请稍后重试。'));
+                        }
+                      }}
+                      onOpenSettingsSection={(section) => openSettingsSection(section)}
+                      onOpenSidebarModule={(target) => {
+                        setNavSelection({ section: target });
+                      }}
+                      onStartPlanReminder={openPlanReminderForm}
+                    />
                   ) : isOnboardingLoading ? (
                     // @kenji review: render a no-op skeleton while the
                     // first snapshot resolves so EmptyChatHero doesn't

--- a/apps/desktop/src/renderer/chat-composer-region.tsx
+++ b/apps/desktop/src/renderer/chat-composer-region.tsx
@@ -1,0 +1,77 @@
+import type { ComponentProps, Ref } from 'react';
+import { Composer, PermissionPrompt, UserQuestionPrompt } from '@maka/ui';
+import type { ComposerHandle, ComposerInteraction } from '@maka/ui';
+
+/**
+ * The composer region of the chat surface (issue #1043): the composer
+ * interaction slot (permission / user-question prompts) plus the always-mounted
+ * Composer itself.
+ *
+ * AppShell renders this as a stable sibling of the section switch, so it is
+ * NEVER conditionally mounted - the Composer keeps its uncontrolled textarea
+ * and draft across section switches and permission takeovers (#646 draft
+ * preservation, permission-composer-takeover contract). `hidden` drives the
+ * native hidden state instead of unmounting.
+ *
+ * Composer props are forwarded via ComponentProps spread; `hidden`,
+ * `draftKey`, and `stopPending` are derived here from the active-session state
+ * so AppShell only forwards the orchestration callbacks and the session maps.
+ */
+interface ChatComposerRegionProps extends Omit<ComponentProps<typeof Composer>, 'hidden' | 'draftKey' | 'stopPending'> {
+  composerRef: Ref<ComposerHandle>;
+  active: boolean;
+  onboardingComposerHidden: boolean;
+  activeInteraction: ComposerInteraction | undefined;
+  activeId: string | undefined;
+  stopPendingBySession: Record<string, boolean>;
+  activePermission: ComponentProps<typeof PermissionPrompt>['request'] | undefined;
+  respondToPermission: ComponentProps<typeof PermissionPrompt>['onRespond'];
+  activeQuestion: ComponentProps<typeof UserQuestionPrompt>['request'] | undefined;
+  respondToUserQuestion: ComponentProps<typeof UserQuestionPrompt>['onRespond'];
+  stop: ComponentProps<typeof PermissionPrompt>['onStop'];
+}
+
+export function ChatComposerRegion({
+  composerRef,
+  active,
+  onboardingComposerHidden,
+  activeInteraction,
+  activeId,
+  stopPendingBySession,
+  activePermission,
+  respondToPermission,
+  activeQuestion,
+  respondToUserQuestion,
+  stop,
+  ...composerRest
+}: ChatComposerRegionProps) {
+  return (
+    <>
+      <div className="maka-composer-interaction-slot">
+        {activePermission && (
+          <PermissionPrompt
+            request={activePermission}
+            onRespond={respondToPermission}
+            onStop={stop}
+            stopPending={activeId ? stopPendingBySession[activeId] === true : false}
+          />
+        )}
+        {activeQuestion && (
+          <UserQuestionPrompt
+            request={activeQuestion}
+            onRespond={respondToUserQuestion}
+            onStop={stop}
+            stopPending={activeId ? stopPendingBySession[activeId] === true : false}
+          />
+        )}
+      </div>
+      <Composer
+        ref={composerRef}
+        {...composerRest}
+        hidden={!active || onboardingComposerHidden || Boolean(activeInteraction)}
+        draftKey={activeId ?? 'new-session'}
+        stopPending={activeId ? stopPendingBySession[activeId] === true : false}
+      />
+    </>
+  );
+}

--- a/apps/desktop/src/renderer/chat-message-surface.tsx
+++ b/apps/desktop/src/renderer/chat-message-surface.tsx
@@ -1,0 +1,109 @@
+import type { ComponentProps, ReactNode } from 'react';
+import type { LlmConnection, OnboardingState, QuickChatMode, SettingsSection } from '@maka/core';
+import { Alert, AlertAction, AlertDescription, AlertTitle, ChatView } from '@maka/ui';
+import { OnboardingEmptyState } from './onboarding-empty-state';
+import type { SessionHealthNoticeView } from './use-shell-chat-model';
+
+/**
+ * The sessions-section message surface (issue #1043): ChatView plus the
+ * session-health notice that sits above the composer. The empty-state stack
+ * (OnboardingEmptyState) is constructed here from the onboarding snapshot so
+ * AppShell only forwards the orchestration callbacks.
+ *
+ * AppShell renders this as the `sessions` branch of the section switch, so it
+ * is conditionally mounted - the always-mounted Composer lives in a separate
+ * region and is not affected by this surface mounting or unmounting.
+ */
+interface ChatMessageSurfaceProps extends Omit<ComponentProps<typeof ChatView>, 'emptyOverride'> {
+  sessionHealthNotice?: SessionHealthNoticeView;
+  showOnboardingHero: boolean;
+  onboardingState: OnboardingState | undefined;
+  isOnboardingLoading: boolean;
+  onOpenSettings: (section?: SettingsSection) => void;
+  onBrowseProviders: () => void;
+  onQuickChatSubmit: (prompt: string, mode?: QuickChatMode) => boolean | Promise<boolean>;
+  quickChatPending?: boolean;
+  connections: LlmConnection[];
+  onRefreshConnections: () => Promise<void> | void;
+  onSkip: () => Promise<void> | void;
+  onOpenSettingsSection: (section: SettingsSection) => void;
+  onOpenSidebarModule: (target: 'daily-review' | 'automations') => void;
+  onStartPlanReminder: () => void;
+}
+
+export function ChatMessageSurface({
+  sessionHealthNotice,
+  showOnboardingHero,
+  onboardingState,
+  isOnboardingLoading,
+  onOpenSettings,
+  onBrowseProviders,
+  onQuickChatSubmit,
+  quickChatPending,
+  connections,
+  onRefreshConnections,
+  onSkip,
+  onOpenSettingsSection,
+  onOpenSidebarModule,
+  onStartPlanReminder,
+  ...chatViewRest
+}: ChatMessageSurfaceProps) {
+  const emptyOverride: ReactNode =
+    showOnboardingHero && onboardingState ? (
+      <OnboardingEmptyState
+        state={onboardingState}
+        onOpenSettings={onOpenSettings}
+        onBrowseProviders={onBrowseProviders}
+        onQuickChatSubmit={onQuickChatSubmit}
+        quickChatPending={quickChatPending}
+        connections={connections}
+        onRefreshConnections={onRefreshConnections}
+        onSkip={onSkip}
+        onOpenSettingsSection={onOpenSettingsSection}
+        onOpenSidebarModule={onOpenSidebarModule}
+        onStartPlanReminder={onStartPlanReminder}
+      />
+    ) : isOnboardingLoading ? (
+      // @kenji review: render a no-op skeleton while the
+      // first snapshot resolves so EmptyChatHero doesn't
+      // flash. Use an aria-busy live region so screen
+      // readers know something is loading.
+      <div
+        className="maka-onboarding-loading"
+        role="status"
+        aria-busy="true"
+        aria-label="加载中"
+      />
+    ) : undefined;
+
+  return (
+    <>
+      <ChatView {...chatViewRest} emptyOverride={emptyOverride} />
+      {sessionHealthNotice && (
+        <div className="maka-session-health-notice">
+          <Alert
+            className="maka-session-health-notice-alert"
+            variant={sessionHealthNotice.tone === 'destructive' ? 'error' : sessionHealthNotice.tone === 'warning' ? 'warning' : 'info'}
+            role="status"
+            aria-label={sessionHealthNotice.tooltip ?? sessionHealthNotice.label}
+            title={sessionHealthNotice.tooltip}
+          >
+            <AlertTitle>{sessionHealthNotice.label}</AlertTitle>
+            {sessionHealthNotice.tooltip ? (
+              <AlertDescription>{sessionHealthNotice.tooltip}</AlertDescription>
+            ) : null}
+            <AlertAction>
+              <button
+                type="button"
+                className="maka-session-health-notice-action"
+                onClick={sessionHealthNotice.onClick}
+              >
+                {sessionHealthNotice.onClickTarget === 'account' ? '去账号' : '去模型'}
+              </button>
+            </AlertAction>
+          </Alert>
+        </div>
+      )}
+    </>
+  );
+}

--- a/apps/desktop/src/renderer/chat-workbar.tsx
+++ b/apps/desktop/src/renderer/chat-workbar.tsx
@@ -1,0 +1,76 @@
+import { lazy, Suspense } from 'react';
+import type { KeyboardEvent, PointerEvent } from 'react';
+import type { SessionWorkbarTab } from './session-workbar-layout';
+import { SESSION_WORKBAR_MAX_WIDTH, SESSION_WORKBAR_MIN_WIDTH } from './session-workbar-layout';
+
+// The session workbar owns the task ledger, embedded browser, and artifact
+// preview. Keep the combined auxiliary surface out of the first chat paint.
+const SessionWorkbar = lazy(() => import('./session-workbar').then((m) => ({ default: m.SessionWorkbar })));
+
+function SessionWorkbarFallback() {
+  return (
+    <aside className="maka-session-workbar" role="status" aria-busy="true" aria-label="正在加载会话工作栏">
+      <div className="maka-lazy-fallback" data-surface="panel">正在加载会话工作栏…</div>
+    </aside>
+  );
+}
+
+/**
+ * The artifacts column of the sessions surface (issue #1043): the workbar
+ * resize handle plus the lazy-mounted SessionWorkbar (task ledger, embedded
+ * browser, artifact pane). AppShell renders this conditionally - only beside
+ * an active session inside the sessions module - so it is not part of the
+ * always-mounted chat surface.
+ */
+interface ChatWorkbarProps {
+  activeId: string;
+  browserLive: boolean;
+  hidden: boolean;
+  width: number;
+  activeTab: SessionWorkbarTab;
+  onActiveTabChange: (tab: SessionWorkbarTab) => void;
+  onDismiss: () => void;
+  startWorkbarResize: (event: PointerEvent<HTMLDivElement>) => void;
+  onWorkbarResizeHandleKeyDown: (event: KeyboardEvent<HTMLDivElement>) => void;
+}
+
+export function ChatWorkbar({
+  activeId,
+  browserLive,
+  hidden,
+  width,
+  activeTab,
+  onActiveTabChange,
+  onDismiss,
+  startWorkbarResize,
+  onWorkbarResizeHandleKeyDown,
+}: ChatWorkbarProps) {
+  return (
+    <>
+      <div
+        className="maka-workbar-resize-handle"
+        role="separator"
+        aria-label="调整会话工作栏宽度"
+        aria-orientation="vertical"
+        aria-valuemin={SESSION_WORKBAR_MIN_WIDTH}
+        aria-valuemax={SESSION_WORKBAR_MAX_WIDTH}
+        aria-valuenow={width}
+        tabIndex={0}
+        onPointerDown={startWorkbarResize}
+        onKeyDown={onWorkbarResizeHandleKeyDown}
+      />
+      <Suspense fallback={<SessionWorkbarFallback />}>
+        <SessionWorkbar
+          key={activeId}
+          sessionId={activeId}
+          browserLive={browserLive}
+          hidden={hidden}
+          width={width}
+          onDismiss={onDismiss}
+          activeTab={activeTab}
+          onActiveTabChange={onActiveTabChange}
+        />
+      </Suspense>
+    </>
+  );
+}

--- a/apps/desktop/src/renderer/onboarding-empty-state.tsx
+++ b/apps/desktop/src/renderer/onboarding-empty-state.tsx
@@ -1,0 +1,59 @@
+import type { LlmConnection, OnboardingState, QuickChatMode, SettingsSection } from '@maka/core';
+import { OnboardingHero } from './OnboardingHero';
+import { FirstRunChecklist } from './FirstRunChecklist';
+
+interface OnboardingEmptyStateProps {
+  state: OnboardingState;
+  onOpenSettings: (section?: SettingsSection) => void;
+  onBrowseProviders: () => void;
+  onQuickChatSubmit: (prompt: string, mode?: QuickChatMode) => boolean | Promise<boolean>;
+  quickChatPending?: boolean;
+  connections: LlmConnection[];
+  onRefreshConnections?: () => Promise<void> | void;
+  onSkip?: () => Promise<void> | void;
+  onOpenSettingsSection: (section: SettingsSection) => void;
+  onOpenSidebarModule: (target: 'daily-review' | 'automations') => void;
+  onStartPlanReminder?: () => void;
+}
+
+/**
+ * The chat surface's empty-state stack (issue #1043): the OnboardingHero plus
+ * the conditional FirstRunChecklist shown when there is no active session.
+ * Presentational - the orchestration callbacks (skip milestone, quick-chat
+ * submit, open settings) stay with the shell and are passed in.
+ */
+export function OnboardingEmptyState({
+  state,
+  onOpenSettings,
+  onBrowseProviders,
+  onQuickChatSubmit,
+  quickChatPending,
+  connections,
+  onRefreshConnections,
+  onSkip,
+  onOpenSettingsSection,
+  onOpenSidebarModule,
+  onStartPlanReminder,
+}: OnboardingEmptyStateProps) {
+  return (
+    <div className="maka-onboarding-stack">
+      <OnboardingHero
+        state={state}
+        onOpenSettings={onOpenSettings}
+        onBrowseProviders={onBrowseProviders}
+        onQuickChatSubmit={onQuickChatSubmit}
+        quickChatPending={quickChatPending}
+        connections={connections}
+        onRefreshConnections={onRefreshConnections}
+        onSkip={onSkip}
+      />
+      {state.kind === 'ready_empty' && (
+        <FirstRunChecklist
+          onOpenSettingsSection={onOpenSettingsSection}
+          onOpenSidebarModule={onOpenSidebarModule}
+          onStartPlanReminder={onStartPlanReminder}
+        />
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Closes #1043 (step 3c). Extracts the entire chat surface out of `app-shell.tsx` so the shell orchestrates rather than owns the chat JSX. Four seams, four commits, pure code motion - no behavior change.

| Seam | Component | What moves out of AppShell |
|---|---|---|
| 1 | `OnboardingEmptyState` | The empty-state stack (`OnboardingHero` + conditional `FirstRunChecklist`) wired into ChatView's `emptyOverride` |
| 2a | `ChatMessageSurface` | `ChatView` plus the session-health notice (the sessions-section message view) |
| 2b | `ChatComposerRegion` | The composer interaction slot (`PermissionPrompt` / `UserQuestionPrompt`) plus the always-mounted `Composer` |
| 2c | `ChatWorkbar` | The workbar resize handle plus the lazy-mounted `SessionWorkbar` and its fallback |

AppShell now renders `<ChatMessageSurface>`, `<ChatComposerRegion>`, and `<ChatWorkbar>` instead of owning ~250 lines of inline chat JSX. The shell shrinks from ~1655 to ~1562 lines; the mainColumn chat surface and the artifacts workbar are all component boundaries.

### Invariants preserved

- **Always-mounted Composer** (#646 draft preservation, permission-composer-takeover): `ChatComposerRegion` is rendered as a stable sibling of the section switch, never conditionally mounted. `hidden` drives the native hidden state, exactly as before. The permission-takeover E2E and contract verify this.
- **Lazy workbar chunk**: the `lazy()` boundary, `SessionWorkbarFallback`, and `Suspense` move into `ChatWorkbar` unchanged, so first-paint behavior is identical.
- **Section routing**: AppShell still owns the `navSelection.section` switch; only the chat-surface JSX moved.

### Contract updates

Each new file is registered in `renderer-shell-source-helpers` so combined-source contracts keep covering it. Direct-read contracts now point at the new files for the relocated patterns:

- `streaming-timeline-render`: `<ChatView liveTurn={activeLiveTurn}>` -> `<ChatMessageSurface liveTurn={activeLiveTurn}>`.
- `session-health-notice-layout`: the health notice now lives inside `ChatMessageSurface`; the layout contract checks the message-surface sits above the composer region.
- `first-run-task-suggestions`: pins the `openPlanReminderForm` -> `ChatMessageSurface` -> `OnboardingEmptyState` -> `FirstRunChecklist` wiring chain.
- `permission-composer-takeover` / `permission-response-ipc-boundary`: the Composer block, interaction slot, and `PermissionPrompt`/`UserQuestionPrompt` patterns now read from `chat-composer-region.tsx`; the `hasModalOpen` and `activeQuestion` derivation assertions stay on app-shell.
- `session-workbar` / `renderer-lazy-fallback`: the `<SessionWorkbar>`, `SessionWorkbarFallback`, and `Suspense` patterns read from `chat-workbar.tsx`; the active-session gating condition stays asserted on app-shell.

## Verification

- `tsc -p tsconfig.main.json` and `tsconfig.renderer.json` - clean.
- `biome lint` (the repo's CI lint command; the formatter is deliberately disabled per `biome.jsonc` / #415) - clean.
- `node --test dist/main/**/*.test.js` - 2661/2661, 0 failures.
- `npm run build:renderer` - clean.
- Playwright `e2e/permission-takeover.spec.ts`, `e2e/send-message.spec.ts`, `e2e/attachment.spec.ts`, `e2e/session-health-notice.spec.ts` - all pass.

## Review focus

This is the largest seam of the #1043 arc. The riskiest invariant is the always-mounted Composer (draft preservation across section switches and permission takeovers); it has no dedicated E2E, so the extraction preserves the exact render structure (Composer stays mounted, `hidden` prop controls visibility) and relies on the `permission-composer-takeover` contract plus the permission-takeover/attachment/send-message E2E to catch regressions. The `ChatComposerRegion` props use a `ComponentProps<typeof Composer>` spread for type safety; `hidden`, `draftKey`, and `stopPending` are derived inside the region to keep the `Boolean(activeInteraction)` gate the takeover contract pins.

The shell's orchestration logic (hooks, handlers, `closeSettings` cross-slice orchestration) stays in AppShell by design - this PR is scoped to the chat-surface JSX extraction, which is the core of "app-shell orchestrates rather than owns".
