### PR TITLE
fix(runtime): omit empty system prompts

### DIFF
--- a/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
+++ b/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
@@ -53,6 +53,34 @@ import type { SemanticCompactBlock } from '../semantic-compact.js';
 import { HistoryCompactSummarizerError } from '../history-compact-summarizer.js';
 
 describe('AiSdkBackend model history', () => {
+  test('omits an empty system prompt from the provider request', async () => {
+    const model = completionModel();
+    const backend = new AiSdkBackend({
+      sessionId: 'session-1',
+      header: header(),
+      appendMessage: async () => {},
+      connection: connection(),
+      apiKey: 'sk-test',
+      modelId: 'mock-model-id',
+      permissionEngine: new PermissionEngine({ newId: () => 'permission-id', now: () => 1 }),
+      modelFactory: () => model,
+      tools: [],
+      systemPrompt: '',
+      newId: idGenerator(),
+      now: monotonicClock(),
+    });
+
+    await drain(backend.send({
+      turnId: 'turn-current',
+      text: 'current user',
+      context: [],
+    }));
+
+    assert.deepEqual(compactPrompt(model), [
+      { role: 'user', content: [{ type: 'text', text: 'current user' }] },
+    ]);
+  });
+
   test('prefers RuntimeEvent prior messages and appends current user once', async () => {
     const model = completionModel();
     const backend = new AiSdkBackend({

--- a/packages/runtime/src/model-adapter.ts
+++ b/packages/runtime/src/model-adapter.ts
@@ -185,7 +185,7 @@ export class ModelAdapter {
       activeTools: input.activeTools,
       ...(input.prepareStep ? { prepareStep: input.prepareStep } : {}),
       experimental_repairToolCall: input.repairToolCall,
-      system: input.system,
+      ...(input.system ? { system: input.system } : {}),
       providerOptions: this.input.providerOptions,
       // streamText defaults to one step when stopWhen is omitted. Its exported
       // non-stopping condition is required for an unbounded tool loop.


### PR DESCRIPTION
## Summary

Omit an explicitly empty system prompt at the provider request boundary. Empty prompt content is semantically equivalent to no system prompt, while Kimi K3 rejects an empty system message before producing any model step.

The fix stays provider-agnostic in ModelAdapter and adds a regression test through AiSdkBackend.

## Verification

- RED: the new regression test observed `{ role: "system", content: "" }` in the provider request.
- GREEN: targeted AiSdkBackend suite: 129 passed.
- Runtime test suite: 2078 passed, 7 skipped, 0 failed.