### PR TITLE
refactor(desktop): extract useShellAppearance and useShellSearch from app-shell

### DIFF
--- a/apps/desktop/src/main/__tests__/default-permission-mode-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/default-permission-mode-contract.test.ts
@@ -91,7 +91,7 @@ describe('default permission mode contract', () => {
   });
 
   it('app-shell keeps a display-only mirror, loaded on mount and re-synced when Settings closes', async () => {
-    const src = await readRendererShellSources(['app-shell.tsx']);
+    const src = await readRendererShellSources(['app-shell.tsx', 'use-shell-appearance.ts']);
 
     assert.match(
       src,

--- a/apps/desktop/src/main/__tests__/reactive-locale-foundation-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/reactive-locale-foundation-contract.test.ts
@@ -16,12 +16,13 @@ function repoSource(file: string): string {
 describe('reactive locale foundation', () => {
   it('owns one persisted preference and one test override in AppShell state', () => {
     const source = rendererSource('app-shell.tsx');
+    const shellAppearance = rendererSource('use-shell-appearance.ts');
     const html = rendererSource('index.html');
 
-    assert.match(source, /useState<UiLocalePreference>\('auto'\)/);
-    assert.match(source, /useState<UiLocale \| null>\(null\)/);
-    assert.match(source, /setUiLocalePreference\(preference\)/);
-    assert.match(source, /setUiLocaleOverride\(smoke\?\.locale \?\? null\)/);
+    assert.match(shellAppearance, /useState<UiLocalePreference>\('auto'\)/);
+    assert.match(shellAppearance, /useState<UiLocale \| null>\(null\)/);
+    assert.match(shellAppearance, /setUiLocalePreference\(preference\)/);
+    assert.match(shellAppearance, /setUiLocaleOverride\(smoke\?\.locale \?\? null\)/);
     assert.match(
       source,
       /<LocaleProvider preference=\{uiLocalePreference\} override=\{uiLocaleOverride\}>[\s\S]*?<AppShellOverlays/,
@@ -31,6 +32,7 @@ describe('reactive locale foundation', () => {
 
   it('feeds the persisted settings result back into React without a DOM side channel', () => {
     const appShell = rendererSource('app-shell.tsx');
+    const shellAppearance = rendererSource('use-shell-appearance.ts');
     const overlays = rendererSource('app-shell-overlays.tsx');
     const modal = rendererSource('settings/SettingsModal.tsx');
     const surface = rendererSource('settings/settings-surface.tsx');
@@ -39,9 +41,9 @@ describe('reactive locale foundation', () => {
 
     assert.match(overlays, /setUiLocalePreference: \(preference: UiLocalePreference\) => void/);
     assert.match(modal, /onUiLocalePreferenceChange\(preference: UiLocalePreference\): void/);
-    assert.match(appShell, /const \[uiLocaleUpdateGate\] = useState\(createUiLocaleUpdateGate\)/);
-    assert.match(appShell, /uiLocaleUpdateGate\.beginHydration\(\)/);
-    assert.match(appShell, /uiLocaleUpdateGate\.commitHydration\(/);
+    assert.match(shellAppearance, /const \[uiLocaleUpdateGate\] = useState\(createUiLocaleUpdateGate\)/);
+    assert.match(shellAppearance, /uiLocaleUpdateGate\.beginHydration\(\)/);
+    assert.match(shellAppearance, /uiLocaleUpdateGate\.commitHydration\(/);
     assert.match(appShell, /uiLocaleUpdateGate=\{uiLocaleUpdateGate\}/);
     assert.match(surface, /uiLocaleUpdateGate: UiLocaleUpdateGate/);
     assert.doesNotMatch(surface, /useState\(createUiLocaleUpdateGate\)/);
@@ -56,14 +58,14 @@ describe('reactive locale foundation', () => {
 
   it('keeps visual-smoke locale overrides in the same provider path', () => {
     const source = rendererSource('app-shell-visual-smoke.ts');
-    const appShell = rendererSource('app-shell.tsx');
+    const shellAppearance = rendererSource('use-shell-appearance.ts');
 
     assert.match(source, /setUiLocaleOverride: Dispatch<SetStateAction<UiLocale \| null>>/);
     assert.match(source, /setUiLocaleOverride\(state\.locale \?\? null\)/);
     assert.doesNotMatch(source, /data-maka-visual-smoke-locale/);
     assert.ok(
-      appShell.indexOf('setUiLocaleOverride(smoke?.locale ?? null)')
-        < appShell.indexOf('uiLocaleUpdateGate.commitHydration('),
+      shellAppearance.indexOf('setUiLocaleOverride(smoke?.locale ?? null)')
+        < shellAppearance.indexOf('uiLocaleUpdateGate.commitHydration('),
       'visual-smoke override hydration must not be gated by persisted preference hydration',
     );
   });

--- a/apps/desktop/src/main/__tests__/renderer-shell-source-helpers.ts
+++ b/apps/desktop/src/main/__tests__/renderer-shell-source-helpers.ts
@@ -45,6 +45,7 @@ const sourcePaths = [
   'chat-composer-region.tsx',
   'chat-workbar.tsx',
   'use-shell-appearance.ts',
+  'use-shell-search.ts',
   'app-shell-visual-smoke.ts',
   'cached-theme-bootstrap.ts',
   'chat-model-selection.ts',

--- a/apps/desktop/src/main/__tests__/renderer-shell-source-helpers.ts
+++ b/apps/desktop/src/main/__tests__/renderer-shell-source-helpers.ts
@@ -44,6 +44,7 @@ const sourcePaths = [
   'chat-message-surface.tsx',
   'chat-composer-region.tsx',
   'chat-workbar.tsx',
+  'use-shell-appearance.ts',
   'app-shell-visual-smoke.ts',
   'cached-theme-bootstrap.ts',
   'chat-model-selection.ts',

--- a/apps/desktop/src/renderer/app-shell.tsx
+++ b/apps/desktop/src/renderer/app-shell.tsx
@@ -34,7 +34,7 @@ import { useOnboardingSnapshot } from './use-onboarding-snapshot';
 import type { OnboardingSnapshot } from '../global';
 import { ProviderLogo } from './settings/provider-display';
 import { ProviderBrandMark } from './settings/provider-brand-marks';
-import { createUiLocaleUpdateGate } from './settings/ui-locale-update-gate';
+import { useShellAppearance } from './use-shell-appearance';
 import { useSessionGoal } from './use-session-goal';
 import { deriveStaleSessionIds } from './stale-sessions';
 import { deriveProjectGroups } from './session-project-grouping';
@@ -42,7 +42,6 @@ import { deriveSessionStatusGroups } from './session-status-grouping';
 import { deriveAppShellTurnViewModel } from './app-shell-turn-view-model';
 import { readScrollMotionBehavior } from './scroll-motion-policy';
 import { deriveBranchBanner } from './branch-banner';
-import { applyTheme, applyThemePalette } from './theme';
 import { filterSessions, readNavSelection } from './nav-selection';
 import {
   SESSION_LIST_COLLAPSED_WIDTH,
@@ -200,19 +199,22 @@ export function AppShell({
     openSettingsSection,
     openProviderCatalog,
   } = useSettingsModal();
-  const [themePref, setThemePref] = useState<ThemePreference>('auto');
-  const [themePalette, setThemePalette] = useState<ThemePalette>('default');
-  const [uiLocalePreference, setUiLocalePreference] = useState<UiLocalePreference>('auto');
-  const [uiLocaleOverride, setUiLocaleOverride] = useState<UiLocale | null>(null);
-  const [uiLocaleUpdateGate] = useState(createUiLocaleUpdateGate);
-  const [userLabel, setUserLabel] = useState<string>('');
-  // Settings → 通用 → 默认权限模式 — DISPLAY-ONLY mirror. The composer's
-  // picker shows it before the user makes a per-session choice; the actual
-  // authority for a new session's mode is main.ts's sessions:create fallback
-  // (the renderer omits permissionMode unless the user explicitly picked),
-  // so a stale value here can briefly mislabel the chip but never changes
-  // which mode a session is created with.
-  const [defaultPermissionMode, setDefaultPermissionMode] = useState<ChatDefaultPermissionMode>('ask');
+  const {
+    themePref,
+    setThemePref,
+    themePalette,
+    setThemePalette,
+    uiLocalePreference,
+    uiLocaleOverride,
+    setUiLocaleOverride,
+    setUiLocalePreference,
+    uiLocaleUpdateGate,
+    userLabel,
+    setUserLabel,
+    defaultPermissionMode,
+    setDefaultPermissionMode,
+    refreshShellSettings,
+  } = useShellAppearance({ toastApi });
   // Persisted composer defaults seed the empty-state model, project path, and
   // recent workspace history so the home view is populated before the async
   // `app:info` round-trip completes on mount.
@@ -1013,32 +1015,6 @@ export function AppShell({
   function isShellSurfaceOwnerActive(owner: ComposerImportOwner): boolean {
     return navSelectionRef.current.section === owner.navSection
       && activeIdRef.current === owner.sessionId;
-  }
-
-  async function refreshShellSettings() {
-    const uiLocaleHydration = uiLocaleUpdateGate.beginHydration();
-    try {
-      const next = await window.maka.settings.get();
-      const smoke = await window.maka.visualSmoke.getState();
-      const pref = smoke?.theme ?? next.appearance?.theme ?? 'auto';
-      const palette = next.appearance?.palette ?? 'default';
-      const name = next.personalization?.displayName ?? '';
-      const uiLocale = next.personalization?.uiLocale ?? 'auto';
-      setUiLocaleOverride(smoke?.locale ?? null);
-      uiLocaleUpdateGate.commitHydration(
-        uiLocaleHydration,
-        uiLocale,
-        (preference) => setUiLocalePreference(preference),
-      );
-      setThemePref(pref);
-      setThemePalette(palette);
-      setUserLabel(name);
-      setDefaultPermissionMode(next.chatDefaults?.permissionMode ?? 'ask');
-      applyTheme(pref);
-      applyThemePalette(palette);
-    } catch (error) {
-      toastApi.error('载入外观设置失败', generalizedErrorMessageChinese(error, '外观设置暂时无法载入，请稍后重试。'));
-    }
   }
 
   async function bootstrapSessions() {

--- a/apps/desktop/src/renderer/app-shell.tsx
+++ b/apps/desktop/src/renderer/app-shell.tsx
@@ -35,6 +35,7 @@ import type { OnboardingSnapshot } from '../global';
 import { ProviderLogo } from './settings/provider-display';
 import { ProviderBrandMark } from './settings/provider-brand-marks';
 import { useShellAppearance } from './use-shell-appearance';
+import { useShellSearch } from './use-shell-search';
 import { useSessionGoal } from './use-session-goal';
 import { deriveStaleSessionIds } from './stale-sessions';
 import { deriveProjectGroups } from './session-project-grouping';
@@ -221,28 +222,7 @@ export function AppShell({
   const persistedComposerDefaults = loadComposerDefaults();
   const [helpOpen, closeHelp, openHelp] = useKeyboardHelp();
   const [paletteOpen, openPalette, closePalette] = useCommandPalette();
-  // Search modal state. Sidebar `搜索` opens the real thread-search
-  // modal; result selection below can also hand ChatView a turn anchor
-  // so the hit is visible after session navigation.
-  const [searchModalOpen, setSearchModalOpen] = useState(false);
-  // Funnel bridge: query handed from the palette's 查看全部结果 row into the
-  // search modal. Topbar opens reset it so a plain open starts blank.
-  const [searchModalInitialQuery, setSearchModalInitialQuery] = useState('');
-  const [searchScrollTarget, setSearchScrollTarget] = useState<{
-    sessionId: string;
-    turnId: string;
-    nonce: number;
-  } | null>(null);
   const [viewMode, setViewMode] = useState<SessionViewMode>('status');
-  function closeSearchModal(options?: { restoreFocus?: boolean }) {
-    setSearchModalOpen(false);
-    if (options?.restoreFocus === false) return;
-    window.requestAnimationFrame(() => {
-      document
-        .querySelector<HTMLButtonElement>('[data-maka-search-trigger="true"]')
-        ?.focus({ preventScroll: true });
-    });
-  }
   const composerRef = useRef<ComposerHandle>(null);
   const rendererMountedRef = useRef(true);
   // Active autonomous goal for the current session drives the header
@@ -513,13 +493,17 @@ export function AppShell({
      change. Stable refs + memos keep the timers alive. */
   const openSessionInChatRef = useRef(openSessionInChat);
   openSessionInChatRef.current = openSessionInChat;
-  const searchModalDeps = useMemo(
-    () => ({ searchThread: (request: Parameters<typeof window.maka.search.thread>[0]) => window.maka.search.thread(request) }),
-    [],
-  );
-  const searchModalOnNavigate = useCallback((sessionId: string, turnId?: string) => {
-    openSessionInChatRef.current(sessionId, turnId);
-  }, []);
+  const {
+    searchModalOpen,
+    setSearchModalOpen,
+    searchModalInitialQuery,
+    setSearchModalInitialQuery,
+    searchScrollTarget,
+    setSearchScrollTarget,
+    closeSearchModal,
+    searchModalDeps,
+    searchModalOnNavigate,
+  } = useShellSearch({ openSessionInChatRef });
   const paletteOnSelectSession = useCallback((sessionId: string, turnId?: string) => {
     openSessionInChatRef.current(sessionId, turnId);
   }, []);

--- a/apps/desktop/src/renderer/use-shell-appearance.ts
+++ b/apps/desktop/src/renderer/use-shell-appearance.ts
@@ -1,0 +1,85 @@
+import { useState } from 'react';
+import { generalizedErrorMessageChinese } from '@maka/core';
+import type {
+  ChatDefaultPermissionMode,
+  ThemePalette,
+  ThemePreference,
+  UiLocale,
+  UiLocalePreference,
+} from '@maka/core';
+import { createUiLocaleUpdateGate } from './settings/ui-locale-update-gate';
+import { applyTheme, applyThemePalette } from './theme';
+
+type ToastApi = {
+  error(title: string, description?: string): void;
+};
+
+/**
+ * Owns the appearance / personalization / default-permission-mode slice
+ * (issue #1043): the theme + palette + UI-locale + user-label + default
+ * permission mode state, plus the `refreshShellSettings` IPC pull that
+ * hydrates them from `window.maka.settings` / `visualSmoke` on mount and on
+ * close-settings re-reads.
+ *
+ * `closeSettings` stays in AppShell: on close it re-reads just the default
+ * permission mode (cross-slice orchestration with onboarding / memory). The
+ * full settings hydration lives here.
+ */
+export function useShellAppearance({ toastApi }: { toastApi: ToastApi }) {
+  const [themePref, setThemePref] = useState<ThemePreference>('auto');
+  const [themePalette, setThemePalette] = useState<ThemePalette>('default');
+  const [uiLocalePreference, setUiLocalePreference] = useState<UiLocalePreference>('auto');
+  const [uiLocaleOverride, setUiLocaleOverride] = useState<UiLocale | null>(null);
+  const [uiLocaleUpdateGate] = useState(createUiLocaleUpdateGate);
+  const [userLabel, setUserLabel] = useState<string>('');
+  // Settings -> 通用 -> 默认权限模式 - DISPLAY-ONLY mirror. The composer's
+  // picker shows it before the user makes a per-session choice; the actual
+  // authority for a new session's mode is main.ts's sessions:create fallback
+  // (the renderer omits permissionMode unless the user explicitly picked),
+  // so a stale value here can briefly mislabel the chip but never changes
+  // which mode a session is created with.
+  const [defaultPermissionMode, setDefaultPermissionMode] = useState<ChatDefaultPermissionMode>('ask');
+
+  async function refreshShellSettings() {
+    const uiLocaleHydration = uiLocaleUpdateGate.beginHydration();
+    try {
+      const next = await window.maka.settings.get();
+      const smoke = await window.maka.visualSmoke.getState();
+      const pref = smoke?.theme ?? next.appearance?.theme ?? 'auto';
+      const palette = next.appearance?.palette ?? 'default';
+      const name = next.personalization?.displayName ?? '';
+      const uiLocale = next.personalization?.uiLocale ?? 'auto';
+      setUiLocaleOverride(smoke?.locale ?? null);
+      uiLocaleUpdateGate.commitHydration(
+        uiLocaleHydration,
+        uiLocale,
+        (preference) => setUiLocalePreference(preference),
+      );
+      setThemePref(pref);
+      setThemePalette(palette);
+      setUserLabel(name);
+      setDefaultPermissionMode(next.chatDefaults?.permissionMode ?? 'ask');
+      applyTheme(pref);
+      applyThemePalette(palette);
+    } catch (error) {
+      toastApi.error('载入外观设置失败', generalizedErrorMessageChinese(error, '外观设置暂时无法载入，请稍后重试。'));
+    }
+  }
+
+  return {
+    themePref,
+    setThemePref,
+    themePalette,
+    setThemePalette,
+    uiLocalePreference,
+    uiLocaleOverride,
+    setUiLocaleOverride,
+    setUiLocalePreference,
+    uiLocaleUpdateGate,
+    userLabel,
+    setUserLabel,
+    defaultPermissionMode,
+    setDefaultPermissionMode,
+    refreshShellSettings,
+  };
+}

--- a/apps/desktop/src/renderer/use-shell-search.ts
+++ b/apps/desktop/src/renderer/use-shell-search.ts
@@ -1,0 +1,53 @@
+import { useCallback, useMemo, useState } from 'react';
+
+type OpenSessionInChat = (sessionId: string, turnId?: string) => void;
+
+/**
+ * Owns the search-modal slice (issue #1043): the open flag, the funnel-bridge
+ * initial query (handed from the palette's 查看全部结果 row), the scroll-target
+ * anchor handed to ChatView, the close handler (restores focus to the sidebar
+ * trigger), and the stable search-thread dep + navigate callback.
+ *
+ * `openSessionInChatRef` is AppShell's stable ref so the navigate callback
+ * stays memoized across renders while always calling the latest opener.
+ */
+export function useShellSearch({ openSessionInChatRef }: { openSessionInChatRef: { current: OpenSessionInChat } }) {
+  const [searchModalOpen, setSearchModalOpen] = useState(false);
+  const [searchModalInitialQuery, setSearchModalInitialQuery] = useState('');
+  const [searchScrollTarget, setSearchScrollTarget] = useState<{
+    sessionId: string;
+    turnId: string;
+    nonce: number;
+  } | null>(null);
+
+  function closeSearchModal(options?: { restoreFocus?: boolean }) {
+    setSearchModalOpen(false);
+    if (options?.restoreFocus === false) return;
+    window.requestAnimationFrame(() => {
+      document
+        .querySelector<HTMLButtonElement>('[data-maka-search-trigger="true"]')
+        ?.focus({ preventScroll: true });
+    });
+  }
+
+  const searchModalDeps = useMemo(
+    () => ({ searchThread: (request: Parameters<typeof window.maka.search.thread>[0]) => window.maka.search.thread(request) }),
+    [],
+  );
+
+  const searchModalOnNavigate = useCallback((sessionId: string, turnId?: string) => {
+    openSessionInChatRef.current(sessionId, turnId);
+  }, [openSessionInChatRef]);
+
+  return {
+    searchModalOpen,
+    setSearchModalOpen,
+    searchModalInitialQuery,
+    setSearchModalInitialQuery,
+    searchScrollTarget,
+    setSearchScrollTarget,
+    closeSearchModal,
+    searchModalDeps,
+    searchModalOnNavigate,
+  };
+}


### PR DESCRIPTION
## Summary

Follow-up to #1169, continuing #1043. Extracts the two largest remaining single-surface owning slices from `app-shell.tsx` into hooks, isomorphic to the existing `useShellLayout` / `useSettingsModal` pattern. Pure code motion - no behavior change.

| Seam | Hook | What moves out of AppShell |
|---|---|---|
| 3 | `useShellAppearance` | theme + palette + UI-locale (+override + update gate) + user-label + default-permission-mode state, plus the `refreshShellSettings` IPC pull that hydrates them from `window.maka.settings` / `visualSmoke`. ~90 lines - the largest remaining owning block. |
| 4 | `useShellSearch` | search-modal open flag + funnel-bridge initial query + scroll-target anchor + `closeSearchModal` (focus restore) + stable search-thread dep + navigate callback. ~40 lines. |

AppShell shrinks from ~1562 to ~1522 lines. Both hooks are registered in the source helper; `default-permission-mode` and `reactive-locale-foundation` contracts now read the appearance hook for state/hydration patterns while the `LocaleProvider` / `AppShellOverlays` call-site wiring stays asserted on app-shell. The search-modal contracts already use combined source (the SearchModal mount lives in AppShellOverlays) so they cover the new file without changes.

## What this PR deliberately does NOT do

The third item from the consult (workspacePicker / branchPicker / permissionModeDisabledReason) is intentionally left in AppShell. Moving them into `ChatComposerRegion` would add ~12 raw props to that component's interface (project-context fields the region doesn't already receive) and rework its `ComponentProps<typeof Composer>` spread, while the `session-status-presentation` contract pins `permissionModeDisabledReason` adjacent to `onPermissionModeChange` - a pattern the spread breaks. The net effect is complexity moving from AppShell to ChatComposerRegion with no clarity gain, and `workspacePicker`/`branchPicker` widen ChatComposerRegion's responsibility into project-context view-model. That is cosmetic (the consult's own word: "病已经好了，剩下的是美容"), so it is out of scope for this PR.

## Verification

- `tsc -p tsconfig.main.json` and `tsconfig.renderer.json` - clean.
- `biome lint` - clean.
- `node --test dist/main/**/*.test.js` - 2661/2661, 0 failures.
- `npm run build:renderer` - clean.
- Playwright `e2e/send-message.spec.ts` - passes.

## Review focus

This is low-risk mechanical extraction (state + handler into hooks, AppShell forwards the returns). The `refreshShellSettings` body is preserved verbatim so the fail-soft / hydration contracts still match. The appearance hook is the largest single-surface owning block that remained; with it and the search slice extracted, AppShell's remaining 1522 lines are, by the "single reason to change" criterion, orchestration (hook wiring + cross-slice handlers like `closeSettings`) plus the section routing - not owning.
