### PR TITLE
fix(headless): preserve verifier-graded budget outcomes

### DIFF
--- a/packages/headless/src/__tests__/fixed-prompt-controller.test.ts
+++ b/packages/headless/src/__tests__/fixed-prompt-controller.test.ts
@@ -1856,6 +1856,74 @@ describe('fixed prompt controller', () => {
     });
   });
 
+  test('counts a verifier-graded max-token stop as a scored benchmark failure', async () => {
+    await withDir(async (dir) => {
+      const systemPromptPath = join(dir, 'system_prompt.md');
+      await writeFile(systemPromptPath, 'fixed prompt\n', 'utf8');
+
+      const result = await runFixedPromptController({
+        runId: 'run-1',
+        roundId: 'round-1',
+        config,
+        systemPromptPath,
+        resultsJsonlPath: join(dir, 'results.jsonl'),
+        tasks: [{ id: 'task-a', path: '/bench/task-a' }],
+        harborRunner: async () => harborOutput({
+          taskId: 'task-a',
+          reward: 0,
+          status: 'failed',
+          errorClass: 'max_tokens',
+          verifier: {
+            outcome: 'failed',
+            attempts: [{ attempt: 1, classification: 'failed', durationMs: 20, reward: 0 }],
+          },
+        }),
+        now: () => 100,
+        newId: idFactory(),
+      });
+
+      assert.equal(result.events[0]?.type, 'task_completed');
+      assert.equal(result.events[0]?.passed, false);
+      assert.equal(result.events[0]?.scored, true);
+      assert.equal(result.events[0]?.eligible, true);
+      assert.equal(result.events[0]?.errorClass, 'max_tokens');
+    });
+  });
+
+  test('counts a verifier-graded tool-step cap as a scored benchmark failure', async () => {
+    await withDir(async (dir) => {
+      const systemPromptPath = join(dir, 'system_prompt.md');
+      await writeFile(systemPromptPath, 'fixed prompt\n', 'utf8');
+
+      const result = await runFixedPromptController({
+        runId: 'run-1',
+        roundId: 'round-1',
+        config,
+        systemPromptPath,
+        resultsJsonlPath: join(dir, 'results.jsonl'),
+        tasks: [{ id: 'task-a', path: '/bench/task-a' }],
+        harborRunner: async () => harborOutput({
+          taskId: 'task-a',
+          reward: 0,
+          status: 'failed',
+          errorClass: 'tool_step_cap_reached',
+          verifier: {
+            outcome: 'failed',
+            attempts: [{ attempt: 1, classification: 'failed', durationMs: 20, reward: 0 }],
+          },
+        }),
+        now: () => 100,
+        newId: idFactory(),
+      });
+
+      assert.equal(result.events[0]?.type, 'task_completed');
+      assert.equal(result.events[0]?.passed, false);
+      assert.equal(result.events[0]?.scored, true);
+      assert.equal(result.events[0]?.eligible, true);
+      assert.equal(result.events[0]?.errorClass, 'tool_step_cap_reached');
+    });
+  });
+
   test('keeps verifier-graded deadline settlements as scored benchmark outcomes', async () => {
     await withDir(async (dir) => {
       const systemPromptPath = join(dir, 'system_prompt.md');

--- a/packages/headless/src/__tests__/harbor-task-runner.test.ts
+++ b/packages/headless/src/__tests__/harbor-task-runner.test.ts
@@ -831,7 +831,7 @@ describe('createHarborTaskRunner', () => {
     });
   });
 
-  test('treats Harbor agent timeout with verifier reward as budget exhausted', async () => {
+  test('returns the official verifier result after a Harbor agent timeout', async () => {
     await withRun(async ({ jobsDir, repo }) => {
       const timedCell = cellOutput({
         executionIdentity: {
@@ -846,7 +846,7 @@ describe('createHarborTaskRunner', () => {
         jobsDir,
         model: 'deepseek/deepseek-v4-flash',
         runHarbor: fakeRunner({
-          reward: '0\n',
+          reward: '1\n',
           cell: timedCell,
           trialResult: {
             exception_info: {
@@ -856,12 +856,11 @@ describe('createHarborTaskRunner', () => {
           },
         }),
       });
-      await assert.rejects(runner(runInput()), (error: unknown) => {
-        assert.ok(error instanceof FixedPromptBudgetExhaustedError);
-        assert.deepEqual(error.artifactRefs?.tokenSummary, timedCell.tokenSummary);
-        assert.deepEqual(error.artifactRefs?.cellOutput?.executionIdentity, timedCell.executionIdentity);
-        return true;
-      });
+      const output = await runner(runInput());
+      assert.equal(output.harbor.reward, 1);
+      assert.equal(output.harbor.verifier?.outcome, 'passed');
+      assert.deepEqual(output.cell.tokenSummary, timedCell.tokenSummary);
+      assert.deepEqual(output.cell.executionIdentity, timedCell.executionIdentity);
     });
   });
 

--- a/packages/headless/src/fixed-prompt-controller.ts
+++ b/packages/headless/src/fixed-prompt-controller.ts
@@ -810,7 +810,12 @@ function taskCompletedEvent(input: {
 }): FixedPromptTaskCompletedEvent {
   const { output } = input;
   const deadlineSettled = output.cell.deadlineSettlement?.source === 'benchmark.deadline';
-  const verifierGraded = output.cell.status === 'completed' || deadlineSettled;
+  const verifierGraded = output.cell.status === 'completed'
+    || deadlineSettled
+    || (
+      (output.cell.errorClass === 'max_tokens' || output.cell.errorClass === 'tool_step_cap_reached')
+      && output.harbor.verifier !== undefined
+    );
   const passed = verifierGraded && output.harbor.reward > 0;
   const errorClass = output.cell.errorClass ?? (passed ? undefined : 'verification_failed');
   const scored = verifierGraded && !isUnscoredCellFailure(errorClass);

--- a/packages/headless/src/harbor-task-runner.ts
+++ b/packages/headless/src/harbor-task-runner.ts
@@ -267,12 +267,19 @@ export function createHarborTaskRunner(options: HarborTaskRunnerOptions): Harbor
 
     const trialException = await readTrialException(resultPath);
     if (trialException && isBudgetExhaustedTrialException(trialException)) {
-      const artifactRefs = await readTimedOutTrialArtifacts(trialDir, input.task.id);
-      throw new FixedPromptBudgetExhaustedError(
-        `agent budget exhausted for task ${input.task.id}`,
-        trialException,
-        artifactRefs ?? undefined,
-      );
+      const [rewardArtifact, verifierArtifact, cellArtifact] = await Promise.all([
+        readOptionalText(rewardPath),
+        readOptionalText(join(trialDir, TRIAL_VERIFIER_OUTCOME)),
+        readOptionalText(cellOutputPath),
+      ]);
+      if (rewardArtifact === null || verifierArtifact === null || cellArtifact === null) {
+        const artifactRefs = await readTimedOutTrialArtifacts(trialDir, input.task.id);
+        throw new FixedPromptBudgetExhaustedError(
+          `agent budget exhausted for task ${input.task.id}`,
+          trialException,
+          artifactRefs ?? undefined,
+        );
+      }
     }
     const reward = await readReward(rewardPath, resultPath, input.task.id);
     const rawCell = await readCellOutput(cellOutputPath, input.task.id);


### PR DESCRIPTION
## Summary

Preserve official Harbor verifier outcomes when an agent reaches a token, tool-step, or wall-time budget. Structured reward-zero results remain scored failures, while an agent timeout with complete reward, verifier, and cell artifacts now keeps the official pass/fail result. Infrastructure and incomplete-run exclusions remain unchanged.

## Verification

- Added regression coverage for verifier-graded `max_tokens` and `tool_step_cap_reached` outcomes.
- Added regression coverage for an `AgentTimeoutError` whose official verifier completed successfully.
- Confirmed both tests fail before the controller change and pass afterward.
- `npm --workspace @maka/headless test` (1100 passed, 1 skipped)
- `git diff --check`

## Root cause

Two early classifications discarded authoritative results. The controller only treated completed cells and benchmark-deadline settlements as verifier-graded, dropping legitimate reward-zero outcomes after token or tool-step limits. The Harbor runner also threw on `AgentTimeoutError` before reading an already-completed official verifier. The runner now keeps timeout classification only when reward, structured verifier, or cell output is absent.
