### PR TITLE
fix(desktop): restore archived session lifecycle authority

### DIFF
--- a/apps/desktop/src/main/__tests__/bot-incoming-goal-lifecycle.test.ts
+++ b/apps/desktop/src/main/__tests__/bot-incoming-goal-lifecycle.test.ts
@@ -81,7 +81,7 @@ describe('bot incoming Goal lifecycle', () => {
       getCurrentProjectRoot: async () => '/repo',
       getDefaultConnectionSlug: async () => 'provider',
       getReadyConnection: async () => ({ connection: { slug: 'provider' }, model: 'model' }),
-      readSessionHeader: async () => ({ permissionMode: 'explore' }),
+      readSessionHeader: async () => ({ permissionMode: 'explore', isArchived: false, status: 'active' }),
       ensureSessionCanSend: async () => {},
       emitSessionsChanged() {},
       async runAgentTurn(input) {

--- a/apps/desktop/src/main/__tests__/bot-incoming-project-cwd.test.ts
+++ b/apps/desktop/src/main/__tests__/bot-incoming-project-cwd.test.ts
@@ -31,7 +31,7 @@ describe('bot incoming new-session cwd', () => {
       getCurrentProjectRoot: async () => '/custom/project/root',
       getDefaultConnectionSlug: async () => 'slug',
       getReadyConnection: async () => ({ connection: { slug: 'slug' }, model: 'm' }),
-      readSessionHeader: async () => ({ permissionMode: 'ask' }),
+      readSessionHeader: async () => ({ permissionMode: 'ask', isArchived: false, status: 'active' }),
       ensureSessionCanSend: async () => {},
       emitSessionsChanged() {},
       async runAgentTurn() {

--- a/apps/desktop/src/main/__tests__/bot-incoming-session-lifecycle.test.ts
+++ b/apps/desktop/src/main/__tests__/bot-incoming-session-lifecycle.test.ts
@@ -1,0 +1,90 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+import type { BotIncomingMessage, BotRegistry, SessionManager } from '@maka/runtime';
+import type { SessionEvent } from '@maka/core';
+import { createBotIncomingMainService } from '../bot-incoming-main.js';
+import { SessionLifecycleError } from '../session-lifecycle.js';
+
+async function waitFor(predicate: () => boolean): Promise<void> {
+  const deadline = Date.now() + 1_000;
+  while (!predicate()) {
+    if (Date.now() >= deadline) throw new Error('Timed out waiting for bot lifecycle test');
+    await new Promise<void>((resolve) => setImmediate(resolve));
+  }
+}
+
+describe('bot session lifecycle bindings', () => {
+  test('rebinds a conversation after its archived session rejects a send', async () => {
+    const created: string[] = [];
+    const sent: string[] = [];
+    const replies: string[] = [];
+    let ensureCalls = 0;
+    const runtime = {
+      async createSession() {
+        const id = `bot-session-${created.length + 1}`;
+        created.push(id);
+        return { id };
+      },
+      sendMessage(sessionId: string, input: { turnId: string }) {
+        sent.push(sessionId);
+        return (async function* (): AsyncIterable<SessionEvent> {
+          yield {
+            type: 'text_complete',
+            id: `text-${sessionId}`,
+            turnId: input.turnId,
+            ts: Date.now(),
+            messageId: `message-${sessionId}`,
+            text: `reply from ${sessionId}`,
+          };
+          yield { type: 'complete', id: `complete-${sessionId}`, turnId: input.turnId, ts: Date.now(), stopReason: 'end_turn' };
+        })();
+      },
+    } as unknown as SessionManager;
+
+    const service = createBotIncomingMainService({
+      runtime,
+      createSession: (input) => runtime.createSession(input),
+      botRegistry: {
+        async sendMessage(_platform: string, _chatId: string, text: string) {
+          replies.push(text);
+          return 'message-id';
+        },
+        async sendTypingIndicator() {
+          return true;
+        },
+      } as unknown as BotRegistry,
+      getCurrentProjectRoot: async () => '/repo',
+      getDefaultConnectionSlug: async () => 'provider',
+      getReadyConnection: async () => ({ connection: { slug: 'provider' }, model: 'model' }),
+      readSessionHeader: async () => ({ permissionMode: 'explore', isArchived: false, status: 'active' }),
+      ensureSessionCanSend: async (sessionId) => {
+        ensureCalls += 1;
+        if (sessionId === 'bot-session-1' && ensureCalls === 2) {
+          throw new SessionLifecycleError('archived');
+        }
+      },
+      emitSessionsChanged() {},
+      runAgentTurn: async ({ iterator, turnId, onEvent }) => {
+        for await (const event of iterator) onEvent(event);
+        return { outcome: { kind: 'completed', turnId } } as never;
+      },
+    });
+
+    const base = {
+      platform: 'telegram',
+      userId: 'user',
+      userName: 'User',
+      chatId: 'chat',
+      isGroup: false,
+      receivedAt: Date.now(),
+    };
+    await service.handleBotIncomingMessage({ ...base, text: 'first', sourceMessageId: 'source-1' } as BotIncomingMessage);
+    await waitFor(() => replies.length === 1);
+    await service.handleBotIncomingMessage({ ...base, text: 'second', sourceMessageId: 'source-2', receivedAt: Date.now() + 1 } as BotIncomingMessage);
+    await waitFor(() => replies.length === 2);
+
+    assert.deepEqual(created, ['bot-session-1', 'bot-session-2']);
+    assert.deepEqual(sent, ['bot-session-1', 'bot-session-2']);
+    assert.deepEqual(replies, ['reply from bot-session-1', 'reply from bot-session-2']);
+  });
+});

--- a/apps/desktop/src/main/__tests__/open-gateway.test.ts
+++ b/apps/desktop/src/main/__tests__/open-gateway.test.ts
@@ -3,6 +3,7 @@ import { afterEach, describe, test } from 'node:test';
 import type { AppSettings, SearchResult, SessionEvent, SessionSummary, StoredMessage } from '@maka/core';
 import { createDefaultSettings } from '@maka/core/settings';
 import { OpenGatewayService } from '../open-gateway.js';
+import { SessionLifecycleError } from '../session-lifecycle.js';
 
 const activeServices: OpenGatewayService[] = [];
 
@@ -983,6 +984,35 @@ describe('OpenGatewayService', () => {
     assert.equal(oversize.status, 400);
     assert.equal(oversize.body.error, 'text_too_large');
     assert.equal(calls, 0);
+  });
+
+  test('maps archived and removed send bindings to stable lifecycle responses', async () => {
+    const service = makeService({
+      sendMessage: async (sessionId) => {
+        throw new SessionLifecycleError(sessionId === 'archived' ? 'archived' : 'removed');
+      },
+    });
+    activeServices.push(service);
+    const status = await service.sync(createGatewaySettings({ enabled: true, port: 0, token: 'dev-token' }).openGateway);
+    assert.ok(status.baseUrl);
+
+    const archived = await fetchJson(`${status.baseUrl}/v1/sessions/archived/messages`, {
+      token: 'dev-token',
+      method: 'POST',
+      body: { text: 'hello' },
+    });
+    assert.equal(archived.status, 409);
+    assert.equal(archived.body.ok, false);
+    assert.equal(archived.body.error, 'session_archived');
+
+    const removed = await fetchJson(`${status.baseUrl}/v1/sessions/removed/messages`, {
+      token: 'dev-token',
+      method: 'POST',
+      body: { text: 'hello' },
+    });
+    assert.equal(removed.status, 404);
+    assert.equal(removed.body.ok, false);
+    assert.equal(removed.body.error, 'session_not_found');
   });
 });
 

--- a/apps/desktop/src/main/__tests__/session-lifecycle.test.ts
+++ b/apps/desktop/src/main/__tests__/session-lifecycle.test.ts
@@ -1,0 +1,30 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+import {
+  assertSessionCanSendFromHeader,
+  isSessionLifecycleError,
+  sessionLifecycleErrorFromReadFailure,
+  SessionLifecycleError,
+} from '../session-lifecycle.js';
+
+describe('session lifecycle send admission', () => {
+  test('uses persisted archived state as the send authority', () => {
+    assert.throws(
+      () => assertSessionCanSendFromHeader({ isArchived: true, status: 'active' }),
+      (error: unknown) => isSessionLifecycleError(error)
+        && error.reason === 'archived',
+    );
+    assert.throws(
+      () => assertSessionCanSendFromHeader({ isArchived: false, status: 'archived' }),
+      (error: unknown) => error instanceof SessionLifecycleError
+        && error.reason === 'archived',
+    );
+  });
+
+  test('classifies a missing persisted session as removed', () => {
+    const error = sessionLifecycleErrorFromReadFailure(Object.assign(new Error('missing'), { code: 'ENOENT' }));
+    assert.ok(error);
+    assert.equal(error.reason, 'removed');
+    assert.equal(isSessionLifecycleError(error), true);
+  });
+});

--- a/apps/desktop/src/main/bot-incoming-main.ts
+++ b/apps/desktop/src/main/bot-incoming-main.ts
@@ -22,6 +22,10 @@ import type {
   SessionManager,
 } from '@maka/runtime';
 import { isSessionWorkspaceUnavailableError } from './project-context-root.js';
+import {
+  assertSessionCanSendFromHeader,
+  isSessionLifecycleError,
+} from './session-lifecycle.js';
 
 const BOT_RECENT_SOURCE_EVENT_LIMIT = 1_000;
 const BOT_RECENT_SOURCE_EVENT_TTL_MS = 60 * 60 * 1_000;
@@ -38,6 +42,7 @@ interface BotConversationRateBucket {
 
 export interface BotIncomingMainService {
   handleBotIncomingMessage(message: BotIncomingMessage): Promise<void>;
+  invalidateSessionBindings(sessionId: string): void;
 }
 
 interface BotIncomingMainServiceDeps {
@@ -52,7 +57,11 @@ interface BotIncomingMainServiceDeps {
     slug: string | null | undefined,
     model?: string,
   ): Promise<{ connection: { slug: string }; model: string }>;
-  readSessionHeader(sessionId: string): Promise<{ permissionMode: string }>;
+  readSessionHeader(sessionId: string): Promise<{
+    permissionMode: string;
+    isArchived: boolean;
+    status: string;
+  }>;
   ensureSessionCanSend(sessionId: string): Promise<void>;
   emitSessionsChanged(
     reason: SessionChangedReason,
@@ -72,6 +81,14 @@ export function createBotIncomingMainService(deps: BotIncomingMainServiceDeps): 
   const botConversationQueues = new Map<string, Promise<void>>();
   const botRecentSourceEventKeys = new Map<string, number>();
   const botConversationRateBuckets = new Map<string, BotConversationRateBucket>();
+
+  function invalidateSessionBindings(sessionId: string): void {
+    for (const [conversationKey, boundSessionId] of botConversationSessions) {
+      if (boundSessionId !== sessionId) continue;
+      botConversationSessions.delete(conversationKey);
+      botConversationRateBuckets.delete(conversationKey);
+    }
+  }
 
   async function handleBotIncomingMessage(message: BotIncomingMessage): Promise<void> {
     if (rememberBotSourceEvent(message)) return;
@@ -172,6 +189,35 @@ export function createBotIncomingMainService(deps: BotIncomingMainServiceDeps): 
     ).catch(() => null);
   }
 
+  async function createBotConversationSession(
+    conversationKey: string,
+    message: BotIncomingMessage,
+    noticeTtlMs: number,
+  ): Promise<string | undefined> {
+    if (botConversationSessions.size >= BOT_CONVERSATION_SESSION_LIMIT) {
+      await sendTransientBotNotice(message, 'Maka 当前机器人会话数量已达上限，请重置或清理旧会话后再试。', noticeTtlMs);
+      return undefined;
+    }
+    if (!consumeBotConversationToken(conversationKey)) {
+      await sendTransientBotNotice(message, 'Maka 收到的机器人消息过于频繁，请稍后再试。', noticeTtlMs);
+      return undefined;
+    }
+    const ready = await deps.getReadyConnection(await deps.getDefaultConnectionSlug(), undefined);
+    const summary = await deps.createSession({
+      cwd: await deps.getCurrentProjectRoot(),
+      backend: 'ai-sdk',
+      llmConnectionSlug: ready.connection.slug,
+      model: ready.model,
+      permissionMode: 'explore',
+      name: `${botDisplayLabel(message.platform)} 对话`,
+      labels: ['bot', message.platform],
+    });
+    botConversationSessions.set(conversationKey, summary.id);
+    deps.emitSessionsChanged('created', summary.id);
+    await deps.ensureSessionCanSend(summary.id);
+    return summary.id;
+  }
+
   async function processBotIncomingMessage(
     conversationKey: string,
     message: BotIncomingMessage,
@@ -253,10 +299,19 @@ export function createBotIncomingMainService(deps: BotIncomingMainServiceDeps): 
         deps.emitSessionsChanged('created', sessionId);
         await deps.ensureSessionCanSend(sessionId);
       } else {
-        const permissionModeOk = await ensureBotSessionExploreMode(sessionId, message, SYSTEM_NOTICE_TTL_MS);
-        if (!permissionModeOk) return;
-        await deps.ensureSessionCanSend(sessionId);
-        if (!consumeBotConversationToken(conversationKey)) {
+        let rebound = false;
+        try {
+          const permissionModeOk = await ensureBotSessionExploreMode(sessionId, message, SYSTEM_NOTICE_TTL_MS);
+          if (!permissionModeOk) return;
+          await deps.ensureSessionCanSend(sessionId);
+        } catch (error) {
+          if (!isSessionLifecycleError(error)) throw error;
+          invalidateSessionBindings(sessionId);
+          sessionId = await createBotConversationSession(conversationKey, message, SYSTEM_NOTICE_TTL_MS);
+          if (!sessionId) return;
+          rebound = true;
+        }
+        if (!rebound && !consumeBotConversationToken(conversationKey)) {
           await sendTransientBotNotice(
             message,
             'Maka 收到的机器人消息过于频繁，请稍后再试。',
@@ -350,6 +405,7 @@ export function createBotIncomingMainService(deps: BotIncomingMainServiceDeps): 
     noticeTtlMs: number,
   ): Promise<boolean> {
     const header = await deps.readSessionHeader(sessionId);
+    assertSessionCanSendFromHeader(header);
     if (header.permissionMode === 'explore') return true;
     try {
       await deps.runtime.updateSession(sessionId, { permissionMode: 'explore' });
@@ -388,5 +444,5 @@ export function createBotIncomingMainService(deps: BotIncomingMainServiceDeps): 
     return latestText;
   }
 
-  return { handleBotIncomingMessage };
+  return { handleBotIncomingMessage, invalidateSessionBindings };
 }

--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -178,6 +178,11 @@ import { registerPermissionsIpc } from './permissions-ipc-main.js';
 import { registerSettingsIpc } from './settings-ipc-main.js';
 import { registerGatewayIpc } from './gateway-ipc-main.js';
 import { registerSessionsIpc } from './sessions-ipc-main.js';
+import {
+  assertSessionCanSendFromHeader,
+  isSessionLifecycleError,
+  sessionLifecycleErrorFromReadFailure,
+} from './session-lifecycle.js';
 import { createProjectRootController } from './project-root-controller.js';
 import {
   assertSessionWorkspaceAvailable,
@@ -1060,7 +1065,13 @@ botIncoming = createBotIncomingMainService({
   getCurrentProjectRoot: () => resolveCurrentProjectRoot(),
   getDefaultConnectionSlug: () => connectionStore.getDefault(),
   getReadyConnection,
-  readSessionHeader: (sessionId) => store.readHeader(sessionId),
+  readSessionHeader: async (sessionId) => {
+    try {
+      return await store.readHeader(sessionId);
+    } catch (error) {
+      throw sessionLifecycleErrorFromReadFailure(error) ?? error;
+    }
+  },
   ensureSessionCanSend,
   emitSessionsChanged,
   runAgentTurn: ({ sessionId, iterator, turnId, onEvent }) => streamEvents(sessionId, iterator, {
@@ -1128,6 +1139,7 @@ function registerIpc(): void {
     visualSmokeFixture,
     emitSessionsChanged,
     ensureSessionCanSend,
+    invalidateSessionBindings: (sessionId) => botIncoming.invalidateSessionBindings(sessionId),
     ensureSessionWorkspaceAvailable,
     createSession: createDesktopSession,
     getReadyConnection,
@@ -1357,6 +1369,7 @@ async function ensureSessionCanSend(sessionId: string): Promise<void> {
       }),
     });
   } catch (error) {
+    if (isSessionLifecycleError(error)) throw error;
     await runtime.setSessionStatus(sessionId, 'blocked', 'NO_REAL_CONNECTION').catch(() => {});
     emitSessionsChanged('status-change', sessionId);
     throw error;
@@ -1370,7 +1383,15 @@ async function ensureSessionCanSend(sessionId: string): Promise<void> {
 }
 
 async function readAvailableSessionHeader(sessionId: string) {
-  const header = await store.readHeader(sessionId);
+  let header;
+  try {
+    header = await store.readHeader(sessionId);
+  } catch (error) {
+    const lifecycleError = sessionLifecycleErrorFromReadFailure(error);
+    if (lifecycleError) throw lifecycleError;
+    throw error;
+  }
+  assertSessionCanSendFromHeader(header);
   await assertSessionWorkspaceAvailable(header.cwd);
   return header;
 }

--- a/apps/desktop/src/main/open-gateway.ts
+++ b/apps/desktop/src/main/open-gateway.ts
@@ -11,6 +11,7 @@ import type {
   StoredMessage,
 } from '@maka/core';
 import { redactSecrets } from '@maka/core/redaction';
+import { isSessionLifecycleError } from './session-lifecycle.js';
 
 export type OpenGatewayStatus = OpenGatewayRuntimeStatus;
 
@@ -409,7 +410,19 @@ export class OpenGatewayService {
         writeJson(res, 400, { ok: false, error: input.error });
         return;
       }
-      const result = await this.deps.sendMessage(sessionId, { text: input.text });
+      let result: { turnId: string };
+      try {
+        result = await this.deps.sendMessage(sessionId, { text: input.text });
+      } catch (error) {
+        if (isSessionLifecycleError(error)) {
+          writeJson(res, error.reason === 'archived' ? 409 : 404, {
+            ok: false,
+            error: error.reason === 'archived' ? 'session_archived' : 'session_not_found',
+          });
+          return;
+        }
+        throw error;
+      }
       writeJson(res, 202, { ok: true, turnId: result.turnId });
       return;
     }

--- a/apps/desktop/src/main/session-lifecycle.ts
+++ b/apps/desktop/src/main/session-lifecycle.ts
@@ -1,0 +1,39 @@
+export type SessionLifecycleReason = 'archived' | 'removed';
+
+export const SESSION_LIFECYCLE_CODE = 'SESSION_LIFECYCLE';
+
+export class SessionLifecycleError extends Error {
+  readonly code = SESSION_LIFECYCLE_CODE;
+
+  constructor(readonly reason: SessionLifecycleReason) {
+    super(reason === 'archived' ? 'Session is archived.' : 'Session no longer exists.');
+    this.name = 'SessionLifecycleError';
+  }
+}
+
+export function isSessionLifecycleError(error: unknown): error is SessionLifecycleError {
+  return error instanceof SessionLifecycleError
+    || (error !== null
+      && typeof error === 'object'
+      && (error as { code?: unknown }).code === SESSION_LIFECYCLE_CODE
+      && ((error as { reason?: unknown }).reason === 'archived'
+        || (error as { reason?: unknown }).reason === 'removed'));
+}
+
+export function sessionLifecycleErrorFromReadFailure(error: unknown): SessionLifecycleError | undefined {
+  if (error !== null && typeof error === 'object'
+    && ((error as { code?: unknown }).code === 'ENOENT'
+      || (error as { message?: unknown }).message === 'ENOENT')) {
+    return new SessionLifecycleError('removed');
+  }
+  return undefined;
+}
+
+export function assertSessionCanSendFromHeader(input: {
+  isArchived: boolean;
+  status: string;
+}): void {
+  if (input.isArchived || input.status === 'archived') {
+    throw new SessionLifecycleError('archived');
+  }
+}

--- a/apps/desktop/src/main/sessions-ipc-main.ts
+++ b/apps/desktop/src/main/sessions-ipc-main.ts
@@ -78,6 +78,7 @@ export interface SessionsIpcDeps {
     extra?: Pick<SessionChangedEvent, 'connectionSlug' | 'modelId'>,
   ) => void;
   ensureSessionCanSend: (sessionId: string) => Promise<void>;
+  invalidateSessionBindings?: (sessionId: string) => void;
   ensureSessionWorkspaceAvailable: (sessionId: string) => Promise<void>;
   createSession: (input: CreateSessionInput) => ReturnType<SessionManager['createSession']>;
   getReadyConnection: (
@@ -154,6 +155,7 @@ export function registerSessionsIpc(deps: SessionsIpcDeps): void {
     visualSmokeFixture,
     emitSessionsChanged,
     ensureSessionCanSend,
+    invalidateSessionBindings,
     ensureSessionWorkspaceAvailable,
     createSession,
     getReadyConnection,
@@ -363,6 +365,7 @@ export function registerSessionsIpc(deps: SessionsIpcDeps): void {
     computerUseOverlay.clearForSession(sessionId);
     computerUseTools.clearSession(sessionId);
     await goalWiring.archiveSession(sessionId, () => runtime.archive(sessionId));
+    invalidateSessionBindings?.(sessionId);
     // An archived conversation is no longer shown: drop its browser connection
     // and view so it does not keep a live Chromium page in the background.
     await releaseBrowserSession(sessionId);
@@ -440,6 +443,7 @@ export function registerSessionsIpc(deps: SessionsIpcDeps): void {
     computerUseOverlay.clearForSession(sessionId);
     computerUseTools.clearSession(sessionId);
     await goalWiring.removeSession(sessionId, () => runtime.remove(sessionId));
+    invalidateSessionBindings?.(sessionId);
     // Drop the conversation's browser connection and destroy its view (no-op
     // if it never opened one). releaseBrowserSession disposes the view via the
     // host, covering both agent-driven and hand-opened views.


### PR DESCRIPTION
## Summary

Closes #1161.

- Make persisted archived and missing session state authoritative before ordinary Desktop sends, workspace/connection recovery, attachment ingestion, Runtime send, or Goal registration.
- Keep lifecycle failures out of the NO_REAL_CONNECTION blocked-state path.
- Invalidate bot conversation bindings after successful archive/remove and rebind stale bot conversations to a fresh session on the next message.
- Map archived and removed OpenGateway send targets to stable 409/404 lifecycle responses.
- Keep the Goal close fence and existing stale Goal protections intact.

## Verification

- `npm run lint`
- `npm run typecheck`
- `npm --workspace @maka/desktop test`
- Desktop tests: 2,665 passed, 0 failed
- Focused lifecycle, bot rebinding, source-contract, and OpenGateway tests passed
- `git diff --check`

The independent Codex review command could not complete because the configured review provider returned 401 INVALID_API_KEY; the implementation was manually reviewed against the issue acceptance conditions and existing call sites.