### PR TITLE
feat(cli): trigger /skill: completion mid-message

### DIFF
--- a/packages/cli/src/__tests__/slash-command-completion.test.ts
+++ b/packages/cli/src/__tests__/slash-command-completion.test.ts
@@ -1,0 +1,279 @@
+import assert from 'node:assert/strict';
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { before, describe, test } from 'node:test';
+import { Editor, setKittyProtocolActive, TUI } from '@earendil-works/pi-tui';
+import type { InvocableSkillEntry } from '@maka/runtime';
+import { MakaAutocompleteProvider } from '../pi-tui-pickers.js';
+import { MakaSkillHighlightEditor } from '../skill-highlight-editor.js';
+import { editorTheme } from '../tui-ansi.js';
+import { FakeTerminal, waitFor } from './tui-terminal-mock.js';
+
+// Mid-message slash completion (issue #1100). Only `/skill:<name>` has semantic
+// value mid-message: it is a parseable invocation token, whereas `/compact`,
+// `/model`, etc. only execute at line start (`handleSlashCommand` checks
+// `parts[0]`). So mid-message completion is skill-only; plain commands stay
+// line-start-only.
+//
+// No-auto-submit half: for a mid-message `/skill:` token the provider returns a
+// prefix WITHOUT the `/skill:` head (just the query, e.g. `w`), so pi-tui's
+// select-confirm guard (submit only when `autocompletePrefix` starts with `/`)
+// does not fire. Line-start keeps `/skill:query` so select still submits (the
+// existing "select to invoke" UX).
+
+describe('MakaAutocompleteProvider mid-message skill completion', () => {
+  const commands = [
+    { name: 'compact', description: 'compact the transcript' },
+    { name: 'config', description: 'open config' },
+    { name: 'model', description: 'switch model' },
+  ];
+  const skills: InvocableSkillEntry[] = [
+    { id: 'weekly-report', name: 'Weekly Report', description: 'summarize the week' },
+    { id: 'web-search', name: 'Web Search', description: 'search the web' },
+  ];
+  const listSkills = async (): Promise<readonly InvocableSkillEntry[]> => skills;
+  const signal = new AbortController().signal;
+  let baseDir: string;
+  before(() => {
+    baseDir = mkdtempSync(join(tmpdir(), 'maka-skill-'));
+  });
+
+  test('completes a `/skill:` token mid-message with a slash-less prefix', async () => {
+    const provider = new MakaAutocompleteProvider(baseDir, commands, listSkills);
+    const result = await provider.getSuggestions(['see /skill:w'], 0, 12, { signal });
+    assert.equal(result?.prefix, 'w', 'mid-message prefix must drop /skill: so select does not submit');
+    assert.deepEqual(
+      (result?.items ?? []).map((i) => i.value),
+      ['weekly-report', 'web-search'],
+    );
+  });
+
+  test('applies a mid-message skill completion as `/skill:name ` (no submit)', async () => {
+    const provider = new MakaAutocompleteProvider(baseDir, commands, listSkills);
+    await provider.getSuggestions(['see /skill:w'], 0, 12, { signal });
+    const applied = provider.applyCompletion(
+      ['see /skill:w'], 0, 12,
+      { value: 'weekly-report', label: '/skill:weekly-report' },
+      'w',
+    );
+    assert.deepEqual(applied.lines, ['see /skill:weekly-report ']);
+    assert.equal(applied.cursorCol, 'see /skill:weekly-report '.length);
+  });
+
+  test('does NOT complete plain commands mid-message (only line start)', async () => {
+    const provider = new MakaAutocompleteProvider(baseDir, commands, listSkills);
+    const result = await provider.getSuggestions(['see /co'], 0, 7, { signal });
+    assert.equal(
+      (result?.items ?? []).some((i) => commands.some((c) => c.name === i.value)),
+      false,
+      'plain commands must not complete mid-message',
+    );
+  });
+
+  test('line-start skill completion is unchanged (prefix keeps `/skill:`)', async () => {
+    const provider = new MakaAutocompleteProvider(baseDir, commands, listSkills);
+    const result = await provider.getSuggestions(['/skill:w'], 0, 8, { signal });
+    assert.equal(result?.prefix, '/skill:w');
+    assert.deepEqual(
+      (result?.items ?? []).map((i) => i.value),
+      ['weekly-report', 'web-search'],
+    );
+  });
+
+  test('line-start plain command completion is unchanged', async () => {
+    const provider = new MakaAutocompleteProvider(baseDir, commands, listSkills);
+    const result = await provider.getSuggestions(['/co'], 0, 3, { signal });
+    assert.equal(result?.prefix, '/co');
+    assert.deepEqual(
+      (result?.items ?? []).map((i) => i.value),
+      ['compact', 'config'],
+    );
+  });
+
+  test('mid-message skill completion is first-line only', async () => {
+    const provider = new MakaAutocompleteProvider(baseDir, commands, listSkills);
+    const result = await provider.getSuggestions(['first', 'see /skill:w'], 1, 12, { signal });
+    assert.equal(
+      (result?.items ?? []).some((i) => skills.some((s) => s.id === i.value)),
+      false,
+      'a `/skill:` on a non-first line must not surface skill completion',
+    );
+  });
+
+  test('completes `/skill:xxx` from a bare mid-message `/` token', async () => {
+    const provider = new MakaAutocompleteProvider(baseDir, commands, listSkills);
+    const result = await provider.getSuggestions(['see /'], 0, 5, { signal });
+    assert.equal(result?.prefix, '', 'bare / prefix is empty (slash-less) so select does not submit');
+    assert.deepEqual(
+      (result?.items ?? []).map((i) => i.value),
+      ['skill:weekly-report', 'skill:web-search'],
+    );
+  });
+
+  test('filters bare mid-message `/` completions by the text after `/`', async () => {
+    const provider = new MakaAutocompleteProvider(baseDir, commands, listSkills);
+    const result = await provider.getSuggestions(['see /w'], 0, 6, { signal });
+    assert.equal(result?.prefix, 'w');
+    assert.deepEqual(
+      (result?.items ?? []).map((i) => i.value),
+      ['skill:weekly-report', 'skill:web-search'],
+    );
+  });
+
+  test('applies a bare mid-message `/` skill completion as `/skill:name `', async () => {
+    const provider = new MakaAutocompleteProvider(baseDir, commands, listSkills);
+    await provider.getSuggestions(['see /'], 0, 5, { signal });
+    const applied = provider.applyCompletion(
+      ['see /'], 0, 5,
+      { value: 'skill:weekly-report', label: '/skill:weekly-report' },
+      '',
+    );
+    assert.deepEqual(applied.lines, ['see /skill:weekly-report ']);
+    assert.equal(applied.cursorCol, 'see /skill:weekly-report '.length);
+  });
+
+  test('a bare mid-message `/` with no skill match does not surface skills', async () => {
+    const provider = new MakaAutocompleteProvider(baseDir, commands, listSkills);
+    const result = await provider.getSuggestions(['see /zzz'], 0, 8, { signal });
+    assert.equal(
+      (result?.items ?? []).some((i) => skills.some((s) => s.id === i.value || `skill:${s.id}` === i.value)),
+      false,
+    );
+  });
+
+  test('a bare mid-message `/` with no skill match does NOT fall through to file completion', async () => {
+    // Regression: falling through to the file provider returns a `/`-prefixed
+    // prefix, and pi-tui auto-submits on select when prefix starts with `/` -
+    // so selecting the file item would send the unfinished message. Mid-message
+    // `/`-path completion was not available before this PR either (pi-tui
+    // excludes `/` from triggerCharacters), so returning null restores prior
+    // behavior instead of introducing an auto-submit footgun.
+    const provider = new MakaAutocompleteProvider('/', commands, listSkills);
+    const result = await provider.getSuggestions(['see /U'], 0, 6, { signal });
+    assert.equal(result, null, 'must not fall through to file provider (would auto-submit on select)');
+  });
+
+  test('a bare mid-message `/` keeps the original (non-lowercased) prefix for apply', async () => {
+    // Regression: toLowerCase can change UTF-16 length (e.g. "İ" -> "i̇", len 1->2).
+    // Using the lowercased query as the replacement prefix makes applyCompletion
+    // slice by the wrong length, over-deleting the original text.
+    const provider = new MakaAutocompleteProvider(baseDir, commands, async () => [
+      { id: 'info', name: 'İnfo', description: '' },
+    ]);
+    const result = await provider.getSuggestions(['see /İ'], 0, 6, { signal });
+    assert.equal(result?.prefix, 'İ', 'prefix must be the original text, not its lowercased form');
+    assert.ok(result && result.items.length > 0, 'expected a skill match');
+    const applied = provider.applyCompletion(
+      ['see /İ'], 0, 6,
+      result.items[0],
+      result.prefix,
+    );
+    assert.deepEqual(applied.lines, ['see /skill:info ']);
+  });
+});
+
+describe('MakaSkillHighlightEditor mid-message skill trigger', () => {
+  const commands = [
+    { name: 'compact', description: 'compact the transcript' },
+    { name: 'config', description: 'open config' },
+  ];
+  const skills: InvocableSkillEntry[] = [
+    { id: 'weekly-report', name: 'Weekly Report', description: 'summarize the week' },
+    { id: 'web-search', name: 'Web Search', description: 'search the web' },
+  ];
+  const listSkills = async (): Promise<readonly InvocableSkillEntry[]> => skills;
+
+  test('typing `/skill:` mid-message triggers skill autocomplete', async () => {
+    const tui = new TUI(new FakeTerminal());
+    const editor = new MakaSkillHighlightEditor(tui, editorTheme(), { paddingX: 1 });
+    editor.setAutocompleteProvider(new MakaAutocompleteProvider(tmpdir(), commands, listSkills));
+    for (const ch of 'see /skill:w') editor.handleInput(ch);
+    await waitFor(() => editor.isShowingAutocomplete());
+    const rendered = editor.render(80).join('\n');
+    assert.ok(rendered.includes('/skill:weekly-report'), `expected /skill:weekly-report in:\n${rendered}`);
+    assert.ok(rendered.includes('/skill:web-search'), `expected /skill:web-search in:\n${rendered}`);
+  });
+
+  test('selecting a mid-message skill inserts `/skill:name ` and does not submit', async () => {
+    const tui = new TUI(new FakeTerminal());
+    const editor = new MakaSkillHighlightEditor(tui, editorTheme(), { paddingX: 1 });
+    editor.setAutocompleteProvider(new MakaAutocompleteProvider(tmpdir(), commands, listSkills));
+    let submitted: string | undefined;
+    editor.onSubmit = (prompt: string) => { submitted = prompt; };
+    for (const ch of 'see /skill:w') editor.handleInput(ch);
+    await waitFor(() => editor.isShowingAutocomplete());
+    editor.handleInput('\r');
+    assert.equal(submitted, undefined, 'mid-message skill select must not submit');
+    assert.deepEqual(editor.getLines(), ['see /skill:weekly-report ']);
+  });
+
+  test('typing a plain command mid-message does NOT surface plain commands', async () => {
+    const tui = new TUI(new FakeTerminal());
+    const editor = new MakaSkillHighlightEditor(tui, editorTheme(), { paddingX: 1 });
+    editor.setAutocompleteProvider(new MakaAutocompleteProvider(tmpdir(), commands, listSkills));
+    for (const ch of 'see /co') editor.handleInput(ch);
+    await new Promise((resolve) => setTimeout(resolve, 80));
+    const rendered = editor.render(80).join('\n');
+    // `/co` may trigger file completion (e.g. /cores), but plain slash commands
+    // must never appear mid-message - they only execute at line start.
+    assert.ok(!rendered.includes('/compact'), 'plain commands must not complete mid-message');
+    assert.ok(!rendered.includes('/config'));
+    assert.ok(!rendered.includes('/model'));
+  });
+
+  test('typing a bare `/` mid-message triggers skill autocomplete', async () => {
+    const tui = new TUI(new FakeTerminal());
+    const editor = new MakaSkillHighlightEditor(tui, editorTheme(), { paddingX: 1 });
+    editor.setAutocompleteProvider(new MakaAutocompleteProvider(tmpdir(), commands, listSkills));
+    for (const ch of 'see /') editor.handleInput(ch);
+    await waitFor(() => editor.isShowingAutocomplete());
+    const rendered = editor.render(80).join('\n');
+    assert.ok(rendered.includes('/skill:weekly-report'), `expected /skill:weekly-report in:\n${rendered}`);
+    assert.ok(rendered.includes('/skill:web-search'), `expected /skill:web-search in:\n${rendered}`);
+  });
+
+  test('mid-message trigger works under Kitty CSI-u keyboard protocol', async () => {
+    // Regression: a Kitty keyboard terminal encodes printable chars as CSI-u
+    // (starting with ESC). A naive `data.startsWith('\x1b')` guard skipped
+    // them, so the text was inserted but the completion menu never appeared.
+    setKittyProtocolActive(true);
+    try {
+      const tui = new TUI(new FakeTerminal());
+      const editor = new MakaSkillHighlightEditor(tui, editorTheme(), { paddingX: 1 });
+      editor.setAutocompleteProvider(new MakaAutocompleteProvider(tmpdir(), commands, listSkills));
+      for (const ch of 'see /skill:w') editor.handleInput(`\x1b[${ch.codePointAt(0)}u`);
+      await waitFor(() => editor.isShowingAutocomplete());
+      const rendered = editor.render(80).join('\n');
+      assert.ok(rendered.includes('/skill:weekly-report'), `expected skill completion under Kitty CSI-u:\n${rendered}`);
+    } finally {
+      setKittyProtocolActive(false);
+    }
+  });
+
+  test('mid-message trigger works under xterm modifyOtherKeys encoding', async () => {
+    // Regression: pi-tui's Editor decodes modifyOtherKeys printables
+    // (ESC[27;1;<cp>~), but the trigger guard only recognized Kitty CSI-u, so
+    // the menu never appeared even though the text was inserted.
+    const tui = new TUI(new FakeTerminal());
+    const editor = new MakaSkillHighlightEditor(tui, editorTheme(), { paddingX: 1 });
+    editor.setAutocompleteProvider(new MakaAutocompleteProvider(tmpdir(), commands, listSkills));
+    for (const ch of 'see /') editor.handleInput(`\x1b[27;1;${ch.codePointAt(0)}~`);
+    await waitFor(() => editor.isShowingAutocomplete());
+    const rendered = editor.render(80).join('\n');
+    assert.ok(rendered.includes('/skill:weekly-report'), `expected skill completion under modifyOtherKeys:\n${rendered}`);
+  });
+});
+
+describe('pi-tui Editor contract (mid-message trigger dependency)', () => {
+  test('tryTriggerAutocomplete is a runtime-callable prototype method', () => {
+    // MakaSkillHighlightEditor.handleInput calls this TS-private method; pi-tui
+    // ships plain JS (no #private fields), so it is reachable at runtime. Pin it
+    // so a pi-tui upgrade that renames or makes it truly private fails loudly
+    // instead of silently regressing mid-message skill completion.
+    assert.equal(
+      typeof (Editor.prototype as unknown as Record<string, unknown>).tryTriggerAutocomplete,
+      'function',
+    );
+  });
+});

--- a/packages/cli/src/pi-tui-pickers.ts
+++ b/packages/cli/src/pi-tui-pickers.ts
@@ -28,6 +28,13 @@ export class MakaAutocompleteProvider implements AutocompleteProvider {
   private readonly slashCommands: readonly MakaSlashCommandMetadata[];
   private readonly listSkills?: () => Promise<readonly InvocableSkillEntry[]>;
 
+  // The kind of suggestions last returned by getSuggestions: 'skill' when the
+  // active list was mid-message `/skill:` completions, null otherwise. The
+  // Editor runs getSuggestions before applyCompletion and snapshot-guards the
+  // request, so this reliably disambiguates a mid-message skill selection (no
+  // `/` in prefix) from a file selection sharing the same prefix.
+  private lastSlashKind: 'skill' | null = null;
+
   constructor(
     basePath: string,
     slashCommands: readonly MakaSlashCommandMetadata[],
@@ -44,11 +51,14 @@ export class MakaAutocompleteProvider implements AutocompleteProvider {
     cursorCol: number,
     options: { signal: AbortSignal; force?: boolean },
   ): Promise<AutocompleteSuggestions | null> {
-    // `/skill:<query>` takes precedence everywhere — including at line start,
+    this.lastSlashKind = null;
+    // `/skill:<query>` takes precedence everywhere - including at line start,
     // where it would otherwise parse as a (non-matching) slash command — and
     // it suppresses file completion: the token charset looks path-like.
     const skillPrefix = skillInvocationPrefixAt(lines, cursorLine, cursorCol);
     if (skillPrefix !== null && this.listSkills && !options.force) {
+      // Skill completion is first-line only, matching pi-tui's isSlashMenuAllowed.
+      if (cursorLine !== 0) return null;
       const query = skillPrefix.query.toLowerCase();
       const skills = await this.listSkills();
       if (options.signal.aborted) return null;
@@ -61,7 +71,18 @@ export class MakaAutocompleteProvider implements AutocompleteProvider {
           label: `/skill:${skill.id}`,
           description: skill.description ? `${skill.name} · ${skill.description}` : skill.name,
         }));
-      return items.length > 0 ? { items, prefix: skillPrefix.prefix } : null;
+      if (items.length > 0) {
+        // Line-start keeps `/skill:query` so pi-tui auto-submits on select (the
+        // existing "select to invoke" UX). Mid-message drops the `/skill:` head
+        // (just the query) so selection inserts and returns instead of
+        // submitting - pi-tui submits only when `autocompletePrefix` starts with `/`.
+        this.lastSlashKind = 'skill';
+        const currentLine = lines[cursorLine] || '';
+        const textBeforeCursor = currentLine.slice(0, cursorCol);
+        const atLineStart = textBeforeCursor.slice(0, textBeforeCursor.length - skillPrefix.prefix.length).trim() === '';
+        return { items, prefix: atLineStart ? skillPrefix.prefix : skillPrefix.query };
+      }
+      return null;
     }
     if (skillPrefix !== null && !options.force) {
       // Inside a token but no skill surface: never fall through to path completion.
@@ -78,6 +99,43 @@ export class MakaAutocompleteProvider implements AutocompleteProvider {
           description: command.description,
         }));
       return items.length > 0 ? { items, prefix: slashPrefix } : null;
+    }
+    // A bare mid-message `/`-token (not `/skill:`, handled above): offer
+    // `/skill:xxx` completions so typing `/` surfaces skills immediately. Plain
+    // commands are not offered here - they only execute at line start.
+    const midSlash = midMessageSlashToken(lines, cursorLine, cursorCol);
+    if (midSlash !== null && this.listSkills && !options.force) {
+      // Keep the raw query as the replacement prefix; toLowerCase can change
+      // UTF-16 length (e.g. "İ" -> "i̇", len 1 -> 2), and applyCompletion slices
+      // by prefix.length, so a lowercased prefix would over-delete the original.
+      const rawQuery = midSlash.slice(1);
+      const query = rawQuery.toLowerCase();
+      const skills = await this.listSkills();
+      if (options.signal.aborted) return null;
+      const items = skills
+        .filter((skill) =>
+          skill.id.toLowerCase().startsWith(query)
+          || skill.name.toLowerCase().includes(query))
+        .map((skill) => ({
+          value: `skill:${skill.id}`,
+          label: `/skill:${skill.id}`,
+          description: skill.description ? `${skill.name} · ${skill.description}` : skill.name,
+        }));
+      if (items.length > 0) {
+        // Prefix is the raw text after `/` (no leading `/`) so pi-tui's
+        // select-confirm guard does not auto-submit. applyCompletion reuses the
+        // mid-message skill path: beforePrefix ends with `/`, item.value is
+        // `skill:<id>`, so `${beforePrefix}${item.value} ` yields `/skill:<id> `.
+        this.lastSlashKind = 'skill';
+        return { items, prefix: rawQuery };
+      }
+      // No skill matched. Do NOT fall through to the file provider: a mid-message
+      // `/`-token's file completion would carry a `/`-prefixed prefix, and pi-tui's
+      // select-confirm guard auto-submits when `prefix.startsWith("/")` - so
+      // selecting it would send the unfinished message. Mid-message `/`-path
+      // completion was not available before this PR either (pi-tui excludes `/`
+      // from triggerCharacters), so returning null restores the prior behavior.
+      return null;
     }
     return this.fileProvider.getSuggestions(lines, cursorLine, cursorCol, options);
   }
@@ -109,6 +167,19 @@ export class MakaAutocompleteProvider implements AutocompleteProvider {
         cursorCol: beforePrefix.length + item.value.length + 2,
       };
     }
+    if (this.lastSlashKind === 'skill') {
+      // Mid-message skill: prefix is just the query (no `/skill:`); the
+      // `/skill:` head sits at the end of beforePrefix. Insert
+      // `/skill:<value> ` and leave the cursor after the space; pi-tui will not
+      // auto-submit because the prefix did not start with `/`.
+      const nextLines = [...lines];
+      nextLines[cursorLine] = `${beforePrefix}${item.value} ${currentLine.slice(cursorCol)}`;
+      return {
+        lines: nextLines,
+        cursorLine,
+        cursorCol: beforePrefix.length + item.value.length + 1,
+      };
+    }
     return this.fileProvider.applyCompletion(lines, cursorLine, cursorCol, item, prefix);
   }
 
@@ -131,6 +202,20 @@ function slashCommandPrefix(lines: string[], cursorLine: number, cursorCol: numb
   const currentLine = lines[cursorLine] || '';
   const textBeforeCursor = currentLine.slice(0, cursorCol);
   return textBeforeCursor.startsWith('/') && !textBeforeCursor.includes(' ') ? textBeforeCursor : null;
+}
+
+// A `/`-token that begins mid-message (after whitespace) on the first line,
+// excluding the `/skill:` form (handled by skillInvocationPrefixAt above) and
+// line-start (handled by slashCommandPrefix). Used to offer `/skill:xxx`
+// completions from a bare `/` so typing `/` surfaces skills immediately.
+function midMessageSlashToken(lines: string[], cursorLine: number, cursorCol: number): string | null {
+  if (cursorLine !== 0) return null;
+  const currentLine = lines[cursorLine] || '';
+  const textBeforeCursor = currentLine.slice(0, cursorCol);
+  const match = /(?:\s)(\/\S*)$/.exec(textBeforeCursor);
+  if (!match) return null;
+  const token = match[1];
+  return token.startsWith('/skill:') ? null : token;
 }
 
 export class PickerOverlay implements Component {

--- a/packages/cli/src/skill-highlight-editor.ts
+++ b/packages/cli/src/skill-highlight-editor.ts
@@ -2,6 +2,13 @@ import { Editor } from '@earendil-works/pi-tui';
 import { ansi } from './tui-ansi.js';
 import { SKILL_INVOCATION_TOKEN_SOURCE } from './skill-token.js';
 
+// A `/`-token that begins mid-message (after whitespace). Only `/skill:` has
+// semantic value mid-message (a parseable invocation token); plain commands
+// only execute at line start, so the provider offers `/skill:xxx` (not plain
+// commands) for a mid-message `/`. Line-start `/` is left to pi-tui's own
+// slash trigger; this matches only mid-message tokens (after whitespace).
+const MID_MESSAGE_SLASH_TOKEN = /(?:\s)\/\S*$/;;
+
 /**
  * Editor with `/skill:<name>` invocation highlighting (issue #1148). Valid
  * tokens render in the CLI brand accent; anything else stays plain — the
@@ -36,5 +43,34 @@ export class MakaSkillHighlightEditor extends Editor {
         this.isInvocable(name) ? ansi.accent(whole) : whole,
       ),
     );
+  }
+
+  override handleInput(data: string): void {
+    // Detect a printable input by whether it actually changed the editor text,
+    // instead of re-deriving pi-tui's printable decoding (Kitty CSI-u, xterm
+    // modifyOtherKeys, IME, paste). Navigation/control sequences (arrows, Enter,
+    // Escape) do not change the text, so they are ignored. Capture "before"
+    // here because super.handleInput performs the insertion.
+    const textBefore = this.getText();
+    super.handleInput(data);
+    if (this.isShowingAutocomplete()) return;
+    if (this.getText() === textBefore) return;
+    // pi-tui auto-triggers slash completion only at line start (its
+    // isAtStartOfMessage/isInSlashCommandContext predicates require the `/` at
+    // column 0). Also trigger when a `/`-token begins mid-message, so `see /`
+    // surfaces `/skill:xxx` completions immediately. Plain commands are
+    // intentionally NOT completed mid-message (they only execute at line start);
+    // the provider offers only `/skill:`. The provider shapes the prefix so
+    // selection inserts rather than auto-submits.
+    const { line, col } = this.getCursor();
+    // Slash completion is first-line only, matching pi-tui's isSlashMenuAllowed.
+    if (line !== 0) return;
+    const textBeforeCursor = (this.getLines()[line] ?? '').slice(0, col);
+    if (MID_MESSAGE_SLASH_TOKEN.test(textBeforeCursor)) {
+      // `tryTriggerAutocomplete` is TS-private but runtime-public (pi-tui ships
+      // plain JS with no #private fields). A contract test pins it so a future
+      // rename fails loudly instead of silently regressing mid-message trigger.
+      (this as unknown as { tryTriggerAutocomplete: () => void }).tryTriggerAutocomplete();
+    }
   }
 }


### PR DESCRIPTION
## Summary

A `/skill:<name>` token that begins mid-message (after whitespace) now surfaces skill completions, not only at line start. Typing a bare `/` mid-message immediately offers all `/skill:xxx` completions (filtered by the text after `/`); `/skill:<query>` refines by name. Selecting a mid-message skill inserts `/skill:name ` and returns instead of submitting; line-start `/skill:` keeps the existing select-to-invoke behavior.

Only `/skill:` is completed mid-message. Plain commands (`/compact`, `/model`, …) only execute at line start (`handleSlashCommand` checks `parts[0]`), so completing them mid-message would insert dead text that never runs. `/skill:` is a parseable invocation token (`parseSkillInvocationTokens`) and has value anywhere in the message, e.g. `帮我 /skill:weekly-report 整理一下`.

Closes #1100.

### Scope note (vs the original issue text)

#1100 asks for "mid-message slash-command completion for the general command surface". This PR narrows it to `/skill:` only, because plain commands have no semantic value mid-message (they don't execute there). The `/skill:` half was the real gap: #1148/#1150 added the `/skill:` picker and token, but trigger still depended on pi-tui's line-start `/` auto-trigger, so mid-message `/skill:` never completed. This PR closes that gap.

### Approach (why not obvious)

PR #1144 closed #1100 claiming a repo-only change "cannot deliver the stated behavior" because pi-tui blocks it upstream. That conclusion was wrong. Verified against pi-tui 0.80.3 source (and 0.80.4–0.80.10 blob SHAs are identical for the relevant files): the blockers are real but bypassable without forking or patching pi-tui, by extending the existing `MakaSkillHighlightEditor extends Editor` seam.

Two halves:

- **Trigger**: `MakaSkillHighlightEditor.handleInput` overrides to call pi-tui's `tryTriggerAutocomplete` (TS-private but runtime-public - pi-tui ships plain JS with no `#private` fields) when a `/`-token begins mid-message on the first line. The printable-input guard detects whether `super.handleInput` actually changed the editor text, instead of re-deriving pi-tui's printable decoding - this covers Kitty CSI-u, xterm modifyOtherKeys, IME, and paste uniformly, and drops a duplicated decoding definition. A contract test pins the method's existence so a pi-tui upgrade that renames or makes it truly private fails loudly.
- **No-submit**: the provider returns a slash-less prefix (the original text after `/`, not lowercased) for mid-message `/skill:` tokens, so pi-tui's select-confirm guard (`autocompletePrefix.startsWith('/')`) does not fall through to submit. Line-start keeps `/skill:query` so select-to-invoke is unchanged. A `lastSlashKind` field disambiguates a mid-message skill selection from a file selection sharing the same prefix.

First-line only, matching pi-tui's `isSlashMenuAllowed`. A bare mid-message `/` with no skill match returns null rather than falling through to the file provider: a `/`-prefixed file prefix would trip pi-tui's select-confirm guard and auto-submit the unfinished message, and mid-message `/`-path completion never worked before this PR anyway (pi-tui excludes `/` from triggerCharacters).

## Codex review

Two fresh-eye Codex review rounds found and fixed these:

**Round 1 (P1):**
- *File-completion fallthrough auto-submitted.* A bare mid-message `/` with no skill match fell through to the file provider, whose `/`-prefixed prefix tripped pi-tui's select-confirm guard and submitted the unfinished message on Enter (`see /U` -> submitted `see /Users/`). Now returns null.
- *Kitty CSI-u terminals never triggered.* The printable-input guard used `data.startsWith(ESC)`, which skipped Kitty keyboard protocol's CSI-u printable encoding (also ESC-prefixed). Fixed (see round 2 for the final form).

**Round 2 (P2):**
- *xterm modifyOtherKeys terminals never triggered.* pi-tui's Editor decodes modifyOtherKeys printables (`ESC[27;1;<cp>~`), but the round-1 guard only recognized Kitty CSI-u. Replaced the whole printable guard with a text-change check (trigger iff `super.handleInput` changed the editor text), which covers Kitty CSI-u, modifyOtherKeys, IME, and paste uniformly, and drops the duplicated decoding definition.
- *Lowercased prefix over-deleted on apply.* The bare-`/` branch returned the lowercased query as the replacement prefix, but `toLowerCase` can change UTF-16 length (e.g. `İ` -> `i̇`, len 1 -> 2), so `applyCompletion` sliced too much off the original text. Now returns the original query, lowercasing only for matching.

A design suggestion to delete `lastSlashKind` (derive completion kind from the current line/prefix in `applyCompletion`) was not adopted: it trades one explicit field for re-parsing in `applyCompletion` with no behavior change, and the explicit state reads clearer.

## Verification

- `npm --workspace maka-agent run typecheck` - clean.
- `npx biome lint` on changed files - clean (formatter baseline is a separate open PR #415; not a CI gate).
- `node --test "dist/__tests__/*.test.js"` (full cli suite) - 504 pass / 0 fail.
- New tests in `slash-command-completion.test.ts` (19): bare `/` surfaces all `/skill:xxx`; `/w` filters; bare `/` apply inserts `/skill:name ` without submit; bare `/` keeps original (non-lowercased) prefix under `İ`; no-skill-match returns null (no file fallthrough = no auto-submit); `/skill:w` name completion + slash-less prefix + apply without submit; plain commands NOT completed mid-message; line-start skill + plain command unchanged; first-line only; Editor-level bare-`/` trigger + `/skill:` trigger + select-without-submit + plain-commands-not-surfaced + Kitty CSI-u trigger + xterm modifyOtherKeys trigger; contract test for `tryTriggerAutocomplete`.

Before/after (TUI render, typing mid-message):

```
typed "see /"          old: no popup     new: -> /skill:weekly-report / /skill:web-search (all skills)
typed "see /w"         old: no popup     new: filtered to w-starting skills
typed "see /skill:w"   old: no popup     new: name completion (weekly-report, web-search)
                      old: -            new: Enter -> "see /skill:weekly-report " (not submitted)
typed "see /U"         old: no popup     new: no popup (no skill match; no file fallthrough = no auto-submit)
typed "see /co"        old: no popup     new: no command popup (plain commands stay line-start-only)
```

## Review focus

The main tradeoff is the runtime coupling to one TS-private method name (`tryTriggerAutocomplete`). This is deliberate: it is the narrowest existing seam, the contract test makes an upgrade break loudly, and the long-term clean fix is a small upstream pi-tui change (allow `/` as a provider trigger character + make the select-submit guard position-aware). Filing that upstream issue is tracked separately; it is not a prerequisite for this PR.
