### PR TITLE
feat(cli): standalone first-run API-key onboarding in the TUI

### DIFF
--- a/packages/cli/src/__tests__/onboarding.test.ts
+++ b/packages/cli/src/__tests__/onboarding.test.ts
@@ -15,13 +15,15 @@ describe('setupApiKeyConnection', () => {
       slug: 'openai',
       apiKey: 'sk-test',
       connectionStore: {
+        get: async () => null,
         create: async (input) => {
           createdInputs.push({ slug: input.slug, providerType: input.providerType });
           return makeConnection({ slug: input.slug, providerType: input.providerType, defaultModel: 'gpt-5.5' });
         },
+        remove: async () => {},
         getDefault: async () => null,
         setDefault: async () => {},
-      } satisfies Pick<ConnectionStore, 'create' | 'getDefault' | 'setDefault'>,
+      } satisfies Pick<ConnectionStore, 'create' | 'get' | 'remove' | 'getDefault' | 'setDefault'>,
       credentialStore: {
         setSecret: async (slug, kind, value) => {
           storedSecrets.push({ slug, kind, value });
@@ -45,7 +47,9 @@ describe('setupApiKeyConnection', () => {
       slug: 'openai',
       apiKey: 'sk-test',
       connectionStore: {
+        get: async () => null,
         create: async (input) => makeConnection({ slug: input.slug, providerType: input.providerType }),
+        remove: async () => {},
         getDefault: async () => null,
         setDefault: async () => {},
       },
@@ -71,10 +75,12 @@ describe('setupApiKeyConnection', () => {
         slug: 'ollama',
         apiKey: 'unused',
         connectionStore: {
+          get: async () => null,
           create: async () => {
             created = true;
             return makeConnection({});
           },
+          remove: async () => {},
           getDefault: async () => null,
           setDefault: async () => {},
         },
@@ -103,7 +109,9 @@ describe('setupApiKeyConnection', () => {
       slug: 'openai',
       apiKey: 'sk-test',
       connectionStore: {
+        get: async () => null,
         create: async (input) => makeConnection({ slug: input.slug, providerType: input.providerType }),
+        remove: async () => {},
         getDefault: async () => defaultSlug,
         setDefault: async (slug) => {
           if (slug) setDefaultCalls.push(slug);
@@ -128,10 +136,12 @@ describe('setupApiKeyConnection', () => {
         slug: 'openai',
         apiKey: '   ',
         connectionStore: {
+          get: async () => null,
           create: async () => {
             created = true;
             return makeConnection({});
           },
+          remove: async () => {},
           getDefault: async () => null,
           setDefault: async () => {},
         },
@@ -153,10 +163,12 @@ describe('setupApiKeyConnection', () => {
       apiKey: 'sk-test',
       baseUrl: 'https://my-gateway.example/v1',
       connectionStore: {
+        get: async () => null,
         create: async (input) => {
           createdInputs.push(input);
           return makeConnection({ slug: input.slug, providerType: input.providerType });
         },
+        remove: async () => {},
         getDefault: async () => null,
         setDefault: async () => {},
       },
@@ -167,6 +179,98 @@ describe('setupApiKeyConnection', () => {
     });
 
     assert.equal(createdInputs[0]?.baseUrl, 'https://my-gateway.example/v1');
+  });
+
+  test('rotates the key when the slug already exists instead of creating a duplicate (upsert)', async () => {
+    // Re-onboarding the same provider (e.g. fixing a typo'd key) must update the
+    // secret on the existing connection rather than throw "slug already exists".
+    const storedSecrets: Array<{ slug: string; value: string }> = [];
+
+    const result = await setupApiKeyConnection({
+      providerType: 'openai',
+      slug: 'openai',
+      apiKey: 'key-rotated',
+      connectionStore: {
+        get: async () => makeConnection({ slug: 'openai', providerType: 'openai' }),
+        create: async () => {
+          throw new Error('create must not be called when the slug already exists');
+        },
+        remove: async () => {},
+        getDefault: async () => 'openai',
+        setDefault: async () => {},
+      },
+      credentialStore: {
+        setSecret: async (slug, _kind, value) => {
+          storedSecrets.push({ slug, value });
+        },
+      } satisfies Pick<CredentialStore, 'setSecret'>,
+      fetchModels: async () => [],
+    });
+
+    assert.equal(result.connection.slug, 'openai');
+    assert.deepEqual(storedSecrets, [{ slug: 'openai', value: 'key-rotated' }]);
+  });
+
+  test('rolls back a newly created connection when the secret write fails', async () => {
+    // Atomicity: create succeeds, setSecret fails -> the orphan connection is
+    // removed so a half-configured connection never becomes the default.
+    const removedSlugs: string[] = [];
+
+    await assert.rejects(
+      setupApiKeyConnection({
+        providerType: 'openai',
+        slug: 'openai',
+        apiKey: 'sk-test',
+        connectionStore: {
+          get: async () => null,
+          create: async (input) => makeConnection({ slug: input.slug, providerType: input.providerType }),
+          remove: async (slug) => {
+            removedSlugs.push(slug);
+          },
+          getDefault: async () => null,
+          setDefault: async () => {},
+        },
+        credentialStore: {
+          setSecret: async () => { throw new Error('disk full'); },
+        },
+        fetchModels: async () => [],
+      }),
+      /disk full/,
+    );
+
+    assert.deepEqual(removedSlugs, ['openai']);
+  });
+
+  test('leaves an existing connection in place when a key rotation secret write fails', async () => {
+    // Upsert atomicity: an existing connection whose key rotation fails must not
+    // be deleted (its previous secret stands); only newly-created ones roll back.
+    const removedSlugs: string[] = [];
+
+    await assert.rejects(
+      setupApiKeyConnection({
+        providerType: 'openai',
+        slug: 'openai',
+        apiKey: 'sk-test',
+        connectionStore: {
+          get: async () => makeConnection({ slug: 'openai', providerType: 'openai' }),
+          create: async () => {
+            throw new Error('create must not be called');
+          },
+          remove: async (slug) => {
+            removedSlugs.push(slug);
+          },
+          getDefault: async () => 'openai',
+          setDefault: async () => {},
+        },
+        credentialStore: {
+          setSecret: async () => { throw new Error('disk full'); },
+        },
+        fetchModels: async () => [],
+      }),
+      /disk full/,
+    );
+
+    assert.deepEqual(removedSlugs, []);
   });
 });
 

--- a/packages/cli/src/__tests__/onboarding.test.ts
+++ b/packages/cli/src/__tests__/onboarding.test.ts
@@ -188,14 +188,21 @@ describe('listApiKeyOnboardableProviders', () => {
     }
   });
 
-  test('flags providers without a default baseUrl so the wizard can prompt for one', () => {
+  test('excludes providers that require a user-supplied baseUrl (phase 1)', () => {
     const providers = listApiKeyOnboardableProviders();
     const anthropic = providers.find((p) => p.providerType === 'anthropic');
 
     // anthropic ships a default baseUrl, so the wizard skips that field for it.
     assert.equal(anthropic?.requiresBaseUrl, false);
-    // at least one catalog provider needs a user-supplied endpoint.
-    assert.ok(providers.some((p) => p.requiresBaseUrl));
+    // Phase 1 cannot collect a base URL, so providers without a default one are
+    // not onboardable yet (they would wedge the install — see PR #1177 review).
+    for (const provider of providers) {
+      assert.equal(
+        provider.requiresBaseUrl,
+        false,
+        `${provider.providerType} requires a base URL and must be excluded until the wizard can prompt for one`,
+      );
+    }
   });
 });
 

--- a/packages/cli/src/__tests__/onboarding.test.ts
+++ b/packages/cli/src/__tests__/onboarding.test.ts
@@ -1,0 +1,213 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+import type { LlmConnection, ModelInfo, ProviderType } from '@maka/core/llm-connections';
+import type { ConnectionStore, CredentialStore } from '@maka/storage';
+import { listApiKeyOnboardableProviders, setupApiKeyConnection } from '../onboarding.js';
+
+describe('setupApiKeyConnection', () => {
+  test('creates the connection, stores the API key secret, and returns discovered models', async () => {
+    const createdInputs: Array<{ slug: string; providerType: ProviderType }> = [];
+    const storedSecrets: Array<{ slug: string; kind: string; value: string }> = [];
+    const fakeModels: ModelInfo[] = [{ id: 'gpt-5.5' }, { id: 'gpt-5.5-mini' }];
+
+    const result = await setupApiKeyConnection({
+      providerType: 'openai',
+      slug: 'openai',
+      apiKey: 'sk-test',
+      connectionStore: {
+        create: async (input) => {
+          createdInputs.push({ slug: input.slug, providerType: input.providerType });
+          return makeConnection({ slug: input.slug, providerType: input.providerType, defaultModel: 'gpt-5.5' });
+        },
+        getDefault: async () => null,
+        setDefault: async () => {},
+      } satisfies Pick<ConnectionStore, 'create' | 'getDefault' | 'setDefault'>,
+      credentialStore: {
+        setSecret: async (slug, kind, value) => {
+          storedSecrets.push({ slug, kind, value });
+        },
+      } satisfies Pick<CredentialStore, 'setSecret'>,
+      fetchModels: async () => fakeModels,
+    });
+
+    // The connection is persisted with the chosen slug and provider type.
+    assert.deepEqual(createdInputs, [{ slug: 'openai', providerType: 'openai' }]);
+    // The API key is stored under the connection slug, typed api_key.
+    assert.deepEqual(storedSecrets, [{ slug: 'openai', kind: 'api_key', value: 'sk-test' }]);
+    // The created connection and the discovered models come back for the next step.
+    assert.equal(result.connection.slug, 'openai');
+    assert.deepEqual(result.models.map((m) => m.id), ['gpt-5.5', 'gpt-5.5-mini']);
+  });
+
+  test('records a model-fetch failure as a non-blocking test error instead of throwing', async () => {
+    const result = await setupApiKeyConnection({
+      providerType: 'openai',
+      slug: 'openai',
+      apiKey: 'sk-test',
+      connectionStore: {
+        create: async (input) => makeConnection({ slug: input.slug, providerType: input.providerType }),
+        getDefault: async () => null,
+        setDefault: async () => {},
+      },
+      credentialStore: {
+        setSecret: async () => {},
+      },
+      fetchModels: async () => { throw new Error('HTTP 401'); },
+    });
+
+    // A failing probe (wrong key, offline, no /models endpoint) must not abort
+    // onboarding — the connection is already saved; the wizard offers manual entry.
+    assert.deepEqual(result.models, []);
+    assert.equal(result.testError, 'HTTP 401');
+  });
+
+  test('rejects a provider that does not accept an API key before touching the stores', async () => {
+    let created = false;
+    let stored = false;
+
+    await assert.rejects(
+      setupApiKeyConnection({
+        providerType: 'ollama', // authKind 'none' — keyless local model
+        slug: 'ollama',
+        apiKey: 'unused',
+        connectionStore: {
+          create: async () => {
+            created = true;
+            return makeConnection({});
+          },
+          getDefault: async () => null,
+          setDefault: async () => {},
+        },
+        credentialStore: {
+          setSecret: async () => {
+            stored = true;
+          },
+        },
+        fetchModels: async () => [],
+      }),
+      /does not accept an API key/,
+    );
+
+    // The guard fires before any write so a miscategorized provider never gets
+    // a bogus api_key secret persisted.
+    assert.equal(created, false);
+    assert.equal(stored, false);
+  });
+
+  test('makes the new connection the default even when one already exists', async () => {
+    let defaultSlug: string | null = 'old-default';
+    const setDefaultCalls: string[] = [];
+
+    await setupApiKeyConnection({
+      providerType: 'openai',
+      slug: 'openai',
+      apiKey: 'sk-test',
+      connectionStore: {
+        create: async (input) => makeConnection({ slug: input.slug, providerType: input.providerType }),
+        getDefault: async () => defaultSlug,
+        setDefault: async (slug) => {
+          if (slug) setDefaultCalls.push(slug);
+          defaultSlug = slug;
+        },
+      },
+      credentialStore: {
+        setSecret: async () => {},
+      },
+      fetchModels: async () => [],
+    });
+
+    // A freshly onboarded connection becomes the active default so the first turn runs on it.
+    assert.deepEqual(setDefaultCalls, ['openai']);
+  });
+
+  test('rejects an empty API key for a provider that requires one, before touching the stores', async () => {
+    let created = false;
+    await assert.rejects(
+      setupApiKeyConnection({
+        providerType: 'openai', // authKind 'api_key' (required)
+        slug: 'openai',
+        apiKey: '   ',
+        connectionStore: {
+          create: async () => {
+            created = true;
+            return makeConnection({});
+          },
+          getDefault: async () => null,
+          setDefault: async () => {},
+        },
+        credentialStore: {
+          setSecret: async () => {},
+        },
+        fetchModels: async () => [],
+      }),
+      /API key is required/,
+    );
+    assert.equal(created, false);
+  });
+
+  test('passes a custom baseUrl through to the created connection', async () => {
+    const createdInputs: Array<{ baseUrl?: string }> = [];
+    await setupApiKeyConnection({
+      providerType: 'openai',
+      slug: 'self-hosted',
+      apiKey: 'sk-test',
+      baseUrl: 'https://my-gateway.example/v1',
+      connectionStore: {
+        create: async (input) => {
+          createdInputs.push(input);
+          return makeConnection({ slug: input.slug, providerType: input.providerType });
+        },
+        getDefault: async () => null,
+        setDefault: async () => {},
+      },
+      credentialStore: {
+        setSecret: async () => {},
+      },
+      fetchModels: async () => [],
+    });
+
+    assert.equal(createdInputs[0]?.baseUrl, 'https://my-gateway.example/v1');
+  });
+});
+
+describe('listApiKeyOnboardableProviders', () => {
+  test('lists only API-key providers, excluding OAuth and keyless ones', () => {
+    const providers = listApiKeyOnboardableProviders();
+    const types = providers.map((p) => p.providerType);
+
+    assert.ok(types.includes('anthropic'));
+    assert.ok(types.includes('openai'));
+    // keyless local models and OAuth subscription providers are not onboardable this way
+    assert.ok(!types.includes('ollama'));
+
+    for (const provider of providers) {
+      assert.ok(
+        provider.authKind === 'api_key' || provider.authKind === 'optional_api_key',
+        `${provider.providerType} should accept an api key`,
+      );
+    }
+  });
+
+  test('flags providers without a default baseUrl so the wizard can prompt for one', () => {
+    const providers = listApiKeyOnboardableProviders();
+    const anthropic = providers.find((p) => p.providerType === 'anthropic');
+
+    // anthropic ships a default baseUrl, so the wizard skips that field for it.
+    assert.equal(anthropic?.requiresBaseUrl, false);
+    // at least one catalog provider needs a user-supplied endpoint.
+    assert.ok(providers.some((p) => p.requiresBaseUrl));
+  });
+});
+
+function makeConnection(input: Partial<LlmConnection>): LlmConnection {
+  return {
+    slug: 'conn',
+    name: 'Connection',
+    providerType: 'ollama',
+    defaultModel: 'llama3.2',
+    enabled: true,
+    createdAt: 1,
+    updatedAt: 1,
+    ...input,
+  };
+}

--- a/packages/cli/src/__tests__/pi-tui-runner.test.ts
+++ b/packages/cli/src/__tests__/pi-tui-runner.test.ts
@@ -464,6 +464,54 @@ describe('Maka Pi TUI runner', () => {
     ]);
   });
 
+  test('/setup without an onboarding surface reports unavailable instead of throwing', async () => {
+    const terminal = new FakeTerminal();
+    const driver = new SlashCommandDriver();
+    // No onboarding surface: a minimal host that can open /setup's picker but
+    // cannot actually collect a key.
+    const run = runMakaPiTui({
+      title: 'Maka',
+      driver,
+      cwd: '/repo',
+      model: 'claude-sonnet-4-5',
+      connectionSlug: 'claude-subscription',
+      permissionMode: 'bypass',
+      terminal,
+    });
+
+    await delay(20);
+    terminal.input('/setup');
+    terminal.input('\r');
+    terminal.input('\r'); // pick the highlighted provider -> arms the key prompt
+    await waitFor(() => {
+      try {
+        return latestPlainLineContaining(terminal.writes.join(''), 'API key') !== null;
+      } catch {
+        return false;
+      }
+    });
+
+    // Submitting a key with no onboarding surface reports unavailable instead
+    // of throwing TypeError on `undefined.then`.
+    terminal.input('sk-test');
+    terminal.input('\r');
+    await waitFor(() => {
+      try {
+        return latestPlainLineContaining(terminal.writes.join(''), 'Onboarding 不可用') !== null;
+      } catch {
+        return false;
+      }
+    });
+
+    process.emit('SIGTERM');
+    await Promise.race([
+      run,
+      delay(500).then(() => {
+        throw new Error('TUI did not close after SIGTERM');
+      }),
+    ]);
+  });
+
   test('first-run picker cancel closes the TUI without configuring', async () => {
     const terminal = new FakeTerminal();
     const driver = new SlashCommandDriver();

--- a/packages/cli/src/__tests__/pi-tui-runner.test.ts
+++ b/packages/cli/src/__tests__/pi-tui-runner.test.ts
@@ -416,6 +416,90 @@ describe('Maka Pi TUI runner', () => {
     ]);
   });
 
+  test('an armed key prompt routes a slash command instead of swallowing it as the key', async () => {
+    const terminal = new FakeTerminal();
+    const driver = new SlashCommandDriver();
+    const setupCalls: Array<unknown> = [];
+    const run = runMakaPiTui({
+      title: 'Maka',
+      driver,
+      cwd: '/repo',
+      model: 'claude-sonnet-4-5',
+      connectionSlug: 'claude-subscription',
+      permissionMode: 'bypass',
+      terminal,
+      onboarding: {
+        setup: async (req) => {
+          setupCalls.push(req);
+          return {};
+        },
+      },
+    });
+
+    await delay(20);
+    terminal.input('/setup');
+    terminal.input('\r');
+    terminal.input('\r'); // pick the highlighted provider -> arms the key prompt
+    await waitFor(() => {
+      try {
+        return latestPlainLineContaining(terminal.writes.join(''), 'API key') !== null;
+      } catch {
+        return false;
+      }
+    });
+
+    // A slash command typed while armed must be routed as a command, not stored
+    // as the API key (otherwise /exit, /model, etc. become persisted secrets).
+    terminal.input('/setup');
+    terminal.input('\r');
+    await delay(60);
+    assert.equal(setupCalls.length, 0);
+
+    process.emit('SIGTERM');
+    await Promise.race([
+      run,
+      delay(500).then(() => {
+        throw new Error('TUI did not close after SIGTERM');
+      }),
+    ]);
+  });
+
+  test('first-run picker cancel closes the TUI without configuring', async () => {
+    const terminal = new FakeTerminal();
+    const driver = new SlashCommandDriver();
+    const run = runMakaPiTui({
+      title: 'Maka',
+      driver,
+      cwd: '/repo',
+      model: '',
+      connectionSlug: '',
+      permissionMode: 'bypass',
+      terminal,
+      firstRun: true,
+      onboarding: {
+        setup: async () => ({}),
+      },
+    });
+
+    await waitFor(() => {
+      try {
+        return latestPlainLineContaining(terminal.writes.join(''), 'Set Up Provider') !== null;
+      } catch {
+        return false;
+      }
+    });
+
+    // Esc cancels the picker; in first-run mode that closes the TUI (the host
+    // sees no configured connection) rather than dropping into a driver-less editor.
+    terminal.input('\x1b');
+    await Promise.race([
+      run,
+      delay(500).then(() => {
+        throw new Error('TUI did not close on first-run picker cancel');
+      }),
+    ]);
+  });
+
   test('first-run mode auto-opens the provider picker without typing /setup', async () => {
     const terminal = new FakeTerminal();
     const driver = new SlashCommandDriver();

--- a/packages/cli/src/__tests__/pi-tui-runner.test.ts
+++ b/packages/cli/src/__tests__/pi-tui-runner.test.ts
@@ -347,6 +347,38 @@ describe('Maka Pi TUI runner', () => {
     ]);
   });
 
+  test('first-run mode auto-opens the provider picker without typing /setup', async () => {
+    const terminal = new FakeTerminal();
+    const driver = new SlashCommandDriver();
+    const run = runMakaPiTui({
+      title: 'Maka',
+      driver,
+      cwd: '/repo',
+      model: '',
+      connectionSlug: '',
+      permissionMode: 'bypass',
+      terminal,
+      firstRun: true,
+      onboarding: {
+        setup: async () => {},
+      },
+    });
+
+    await waitFor(() => {
+      try {
+        return latestPlainLineContaining(terminal.writes.join(''), 'Set Up Provider') !== null;
+      } catch {
+        return false;
+      }
+    });
+
+    process.emit('SIGTERM');
+    await Promise.race([
+      run,
+      delay(500).then(() => { throw new Error('TUI did not close after SIGTERM'); }),
+    ]);
+  });
+
   test('allows a pending permission request from the terminal', async () => {
     const terminal = new FakeTerminal();
     const driver = new PermissionPromptDriver();

--- a/packages/cli/src/__tests__/pi-tui-runner.test.ts
+++ b/packages/cli/src/__tests__/pi-tui-runner.test.ts
@@ -253,6 +253,100 @@ describe('Maka Pi TUI runner', () => {
     }
   });
 
+  test('/setup opens a provider picker listing API-key providers', async () => {
+    const terminal = new FakeTerminal();
+    const driver = new SlashCommandDriver();
+    const run = runMakaPiTui({
+      title: 'Maka',
+      driver,
+      cwd: '/repo',
+      model: 'claude-sonnet-4-5',
+      connectionSlug: 'claude-subscription',
+      permissionMode: 'bypass',
+      terminal,
+    });
+
+    await delay(20);
+    terminal.input('/setup');
+    terminal.input('\r');
+
+    await waitFor(() => {
+      try {
+        return latestPlainLineContaining(terminal.writes.join(''), 'Set Up Provider') !== null;
+      } catch {
+        return false;
+      }
+    });
+
+    const output = plainTerminalOutput(terminal.writes.join(''));
+    assert.ok(
+      output.includes('Anthropic') || output.includes('OpenAI'),
+      'provider picker should list an API-key provider',
+    );
+
+    terminal.input('\x1b');
+    await delay(30);
+    terminal.input('/exit');
+    terminal.input('\r');
+    await Promise.race([
+      run,
+      delay(500).then(() => { throw new Error('TUI did not close after /exit'); }),
+    ]);
+  });
+
+  test('/setup collects an API key after picking a provider and calls onboarding.setup', async () => {
+    const terminal = new FakeTerminal();
+    const driver = new SlashCommandDriver();
+    const setupCalls: Array<{ providerType: string; apiKey: string }> = [];
+    const run = runMakaPiTui({
+      title: 'Maka',
+      driver,
+      cwd: '/repo',
+      model: 'claude-sonnet-4-5',
+      connectionSlug: 'claude-subscription',
+      permissionMode: 'bypass',
+      terminal,
+      onboarding: {
+        setup: async (req) => { setupCalls.push(req); },
+      },
+    });
+
+    await delay(20);
+    terminal.input('/setup');
+    terminal.input('\r');
+    await waitFor(() => {
+      try {
+        return latestPlainLineContaining(terminal.writes.join(''), 'Set Up Provider') !== null;
+      } catch {
+        return false;
+      }
+    });
+
+    // Enter picks the highlighted provider; the wizard then asks for the API key.
+    terminal.input('\r');
+    await waitFor(() => {
+      try {
+        return latestPlainLineContaining(terminal.writes.join(''), 'API key') !== null;
+      } catch {
+        return false;
+      }
+    });
+
+    // Submitting the key fires onboarding.setup instead of an agent turn.
+    terminal.input('sk-test');
+    terminal.input('\r');
+    await waitFor(() => setupCalls.length === 1);
+
+    assert.equal(setupCalls[0]!.apiKey, 'sk-test');
+    assert.ok(setupCalls[0]!.providerType);
+
+    process.emit('SIGTERM');
+    await Promise.race([
+      run,
+      delay(500).then(() => { throw new Error('TUI did not close after SIGTERM'); }),
+    ]);
+  });
+
   test('allows a pending permission request from the terminal', async () => {
     const terminal = new FakeTerminal();
     const driver = new PermissionPromptDriver();
@@ -2161,12 +2255,14 @@ describe('Maka Pi TUI runner', () => {
     const afterRows = inputSurfaceRows(afterLines);
     const afterSessionRow = afterLines.findIndex((line) => line.includes('/session'));
     const afterSkillRow = afterLines.findIndex((line) => line.includes('/skill'));
+    const afterSetupRow = afterLines.findIndex((line) => line.includes('/setup'));
 
     assert.ok(beforeSessionRow >= 0);
     assert.deepEqual(afterRows, beforeRows);
-    // The 's' filter matches two commands — /session then /skill — bottom-aligned.
+    // The 's' filter matches three commands — /session, /setup, /skill — bottom-aligned.
     assert.equal(afterSkillRow, afterRows[0] - 1);
-    assert.equal(afterSessionRow, afterRows[0] - 2);
+    assert.equal(afterSetupRow, afterRows[0] - 2);
+    assert.equal(afterSessionRow, afterRows[0] - 3);
 
     exitMaka(terminal);
     await Promise.race([
@@ -2213,11 +2309,13 @@ describe('Maka Pi TUI runner', () => {
     const afterRows = inputSurfaceRows(afterLines);
     const afterSessionRow = afterLines.findIndex((line) => line.includes('/session'));
     const afterSkillRow = afterLines.findIndex((line) => line.includes('/skill'));
+    const afterSetupRow = afterLines.findIndex((line) => line.includes('/setup'));
 
     assert.deepEqual(afterRows, beforeRows);
     assert.equal(afterRows[1], terminal.rows - 2);
     assert.equal(afterSkillRow, afterRows[0] - 1);
-    assert.equal(afterSessionRow, afterRows[0] - 2);
+    assert.equal(afterSetupRow, afterRows[0] - 2);
+    assert.equal(afterSessionRow, afterRows[0] - 3);
 
     exitMaka(terminal);
     await Promise.race([

--- a/packages/cli/src/__tests__/pi-tui-runner.test.ts
+++ b/packages/cli/src/__tests__/pi-tui-runner.test.ts
@@ -307,7 +307,7 @@ describe('Maka Pi TUI runner', () => {
       permissionMode: 'bypass',
       terminal,
       onboarding: {
-        setup: async (req) => { setupCalls.push(req); },
+        setup: async (req) => { setupCalls.push(req); return {}; },
       },
     });
 
@@ -347,6 +347,75 @@ describe('Maka Pi TUI runner', () => {
     ]);
   });
 
+  test('/setup re-arms the key prompt when the probe fails so the key can be retried', async () => {
+    const terminal = new FakeTerminal();
+    const driver = new SlashCommandDriver();
+    const setupCalls: Array<{ apiKey: string }> = [];
+    const run = runMakaPiTui({
+      title: 'Maka',
+      driver,
+      cwd: '/repo',
+      model: 'claude-sonnet-4-5',
+      connectionSlug: 'claude-subscription',
+      permissionMode: 'bypass',
+      terminal,
+      onboarding: {
+        setup: async (req) => {
+          setupCalls.push({ apiKey: req.apiKey });
+          // First attempt fails the probe (wrong key); the retry verifies.
+          return setupCalls.length === 1 ? { testError: 'HTTP 401 Unauthorized' } : {};
+        },
+      },
+    });
+
+    await delay(20);
+    terminal.input('/setup');
+    terminal.input('\r');
+    terminal.input('\r'); // pick the highlighted provider
+    await waitFor(() => {
+      try {
+        return latestPlainLineContaining(terminal.writes.join(''), 'API key') !== null;
+      } catch {
+        return false;
+      }
+    });
+
+    // Submit a key that fails the probe.
+    terminal.input('sk-bad');
+    terminal.input('\r');
+    await waitFor(() => setupCalls.length === 1);
+    // The failure is surfaced and the prompt re-arms — not the success notice.
+    await waitFor(() => {
+      try {
+        return latestPlainLineContaining(terminal.writes.join(''), '验证失败') !== null;
+      } catch {
+        return false;
+      }
+    });
+
+    // Retrying with a good key succeeds (no testError this time).
+    terminal.input('sk-good');
+    terminal.input('\r');
+    await waitFor(() => setupCalls.length === 2);
+    await waitFor(() => {
+      try {
+        return latestPlainLineContaining(terminal.writes.join(''), '已配置') !== null;
+      } catch {
+        return false;
+      }
+    });
+
+    assert.deepEqual(setupCalls.map((c) => c.apiKey), ['sk-bad', 'sk-good']);
+
+    process.emit('SIGTERM');
+    await Promise.race([
+      run,
+      delay(500).then(() => {
+        throw new Error('TUI did not close after SIGTERM');
+      }),
+    ]);
+  });
+
   test('first-run mode auto-opens the provider picker without typing /setup', async () => {
     const terminal = new FakeTerminal();
     const driver = new SlashCommandDriver();
@@ -360,7 +429,7 @@ describe('Maka Pi TUI runner', () => {
       terminal,
       firstRun: true,
       onboarding: {
-        setup: async () => {},
+        setup: async () => ({}),
       },
     });
 

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -212,7 +212,7 @@ async function runFirstRunOnboarding(workspaceRoot: string): Promise<boolean> {
   const credentialStore = createFileCredentialStore(workspaceRoot);
   let configured = false;
   await runMakaPiTui({
-    driver: createFirstRunSessionDriver(process.cwd()),
+    driver: createFirstRunSessionDriver(),
     title: 'Maka',
     cwd: process.cwd(),
     model: '',
@@ -244,17 +244,12 @@ async function runFirstRunOnboarding(workspaceRoot: string): Promise<boolean> {
 
 /** A minimal session driver for the first-run wizard. The wizard never runs an
  *  agent turn (the editor only collects the API key via the onboarding
- *  intercept), so runtime/chat methods are unreachable stubs. runMakaPiTui does
- *  not touch driver.runtime during first-run. */
-function createFirstRunSessionDriver(cwd: string): MakaSessionDriver {
+ *  intercept), so runtime/chat methods are unreachable stubs. */
+function createFirstRunSessionDriver(): MakaSessionDriver {
   const notReady = async (): Promise<never> => {
     throw new Error('first-run onboarding: no agent turn before a connection exists');
   };
   return {
-    runtime: undefined,
-    cwd,
-    llmConnectionSlug: '',
-    model: '',
     getSessionId: () => null,
     listSessions: async () => [],
     preparePrompt: notReady,
@@ -269,7 +264,7 @@ function createFirstRunSessionDriver(cwd: string): MakaSessionDriver {
     rewindToTurn: notReady,
     startNewSession: () => {},
     stop: async () => {},
-  } as unknown as MakaSessionDriver;
+  };
 }
 
 async function readPackageVersion(): Promise<string> {

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -139,11 +139,21 @@ export async function runMakaCli(argv: string[] = process.argv.slice(2)): Promis
           process.stderr.write(`${formatStartupConnectionError(error, workspaceRoot)}\n`);
           return 1;
         }
-        context = await createMakaCliRuntimeContext({
-          surface: 'tui',
-          workspaceRoot,
-          cwd: process.cwd(),
-        });
+        try {
+          context = await createMakaCliRuntimeContext({
+            surface: 'tui',
+            workspaceRoot,
+            cwd: process.cwd(),
+          });
+        } catch (retryError) {
+          // A failure after onboarding (e.g. the saved connection still isn't
+          // ready) gets the same classified guidance as the first attempt,
+          // not a raw stack propagated to the top-level handler.
+          const guidance = formatStartupConnectionError(retryError, workspaceRoot);
+          if (guidance === null) throw retryError;
+          process.stderr.write(`${guidance}\n`);
+          return 1;
+        }
       }
       try {
         const driver = createMakaSessionDriver({

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -154,6 +154,7 @@ export async function runMakaCli(argv: string[] = process.argv.slice(2)): Promis
           listShellRunUpdates: context.listShellRunUpdates,
           skills: context.skills,
           goalLifecycle: context.goalContinuation,
+          onboarding: context.onboarding,
           onProcessExit: handleMakaCliProcessExit,
         });
         return 0;

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -4,12 +4,14 @@ import { readFile } from 'node:fs/promises';
 import { realpathSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { describeChatConfigurationReason, parseNoRealConnectionError } from '@maka/core';
-import { resolveSelectedModelContextWindow } from '@maka/runtime';
-import { createMakaSessionDriver } from './session-driver.js';
+import { fetchProviderModels, resolveSelectedModelContextWindow, SessionActivityRegistry } from '@maka/runtime';
+import { createConnectionStore, createFileCredentialStore } from '@maka/storage';
+import { createMakaSessionDriver, type MakaSessionDriver } from './session-driver.js';
 import { createMakaCliRuntimeContext } from './runtime-bootstrap.js';
 import { selectableModelIdsForTarget } from './connection-target.js';
 import { resolveMakaWorkspaceRoot } from './workspace-root.js';
-import { runMakaPiTui } from './pi-tui-runner.js';
+import { runMakaPiTui, type MakaPiTuiGoalLifecycle } from './pi-tui-runner.js';
+import { setupApiKeyConnection } from './onboarding.js';
 
 export type MakaCliCommand =
   | { kind: 'tui' }
@@ -122,14 +124,26 @@ export async function runMakaCli(argv: string[] = process.argv.slice(2)): Promis
           cwd: process.cwd(),
         });
       } catch (error) {
-        // A missing / misconfigured connection is the first thing a new user
-        // hits. Translate the raw `NO_REAL_CONNECTION:<reason>` throw into
-        // actionable guidance; let anything else propagate to the top-level
-        // handler unchanged.
-        const guidance = formatStartupConnectionError(error, workspaceRoot);
-        if (guidance === null) throw error;
-        process.stderr.write(`${guidance}\n`);
-        return 1;
+        const { matched, reason } = parseNoRealConnectionError(error);
+        const isFirstRun = matched && reason === 'missing_default_connection';
+        if (!isFirstRun) {
+          const guidance = formatStartupConnectionError(error, workspaceRoot);
+          if (guidance === null) throw error;
+          process.stderr.write(`${guidance}\n`);
+          return 1;
+        }
+        // Fresh install with no connection: run the in-TUI onboarding wizard
+        // before giving up, then retry context creation with the new connection.
+        const configured = await runFirstRunOnboarding(workspaceRoot);
+        if (!configured) {
+          process.stderr.write(`${formatStartupConnectionError(error, workspaceRoot)}\n`);
+          return 1;
+        }
+        context = await createMakaCliRuntimeContext({
+          surface: 'tui',
+          workspaceRoot,
+          cwd: process.cwd(),
+        });
       }
       try {
         const driver = createMakaSessionDriver({
@@ -188,6 +202,74 @@ export function formatStartupConnectionError(error: unknown, workspaceRoot: stri
     '添加并启用一个模型连接（含 API key），然后重新运行 maka。',
     `连接与凭据存储于：${workspaceRoot}`,
   ].join('\n');
+}
+
+/** Run the first-run onboarding wizard when no connection exists yet. Returns
+ *  true if the user configured a connection, false if they cancelled. The host
+ *  owns the stores; the wizard only collects provider + key (see MakaOnboardingSurface). */
+async function runFirstRunOnboarding(workspaceRoot: string): Promise<boolean> {
+  const connectionStore = createConnectionStore(workspaceRoot);
+  const credentialStore = createFileCredentialStore(workspaceRoot);
+  let configured = false;
+  await runMakaPiTui({
+    driver: createFirstRunSessionDriver(process.cwd()),
+    title: 'Maka',
+    cwd: process.cwd(),
+    model: '',
+    connectionSlug: '',
+    permissionMode: 'ask',
+    firstRun: true,
+    goalLifecycle: {
+      activities: new SessionActivityRegistry(),
+      beginExternalTurn: () => ({ kind: 'registered', settle: async () => {} }),
+      bindHost: () => () => {},
+    } satisfies MakaPiTuiGoalLifecycle,
+    onboarding: {
+      setup: async ({ providerType, apiKey, baseUrl }) => {
+        await setupApiKeyConnection({
+          providerType,
+          slug: providerType,
+          apiKey,
+          ...(baseUrl ? { baseUrl } : {}),
+          connectionStore,
+          credentialStore,
+          fetchModels: fetchProviderModels,
+        });
+        configured = true;
+      },
+    },
+  });
+  return configured;
+}
+
+/** A minimal session driver for the first-run wizard. The wizard never runs an
+ *  agent turn (the editor only collects the API key via the onboarding
+ *  intercept), so runtime/chat methods are unreachable stubs. runMakaPiTui does
+ *  not touch driver.runtime during first-run. */
+function createFirstRunSessionDriver(cwd: string): MakaSessionDriver {
+  const notReady = async (): Promise<never> => {
+    throw new Error('first-run onboarding: no agent turn before a connection exists');
+  };
+  return {
+    runtime: undefined,
+    cwd,
+    llmConnectionSlug: '',
+    model: '',
+    getSessionId: () => null,
+    listSessions: async () => [],
+    preparePrompt: notReady,
+    compactSession: async function* () {},
+    respondToPermission: async () => {},
+    setModel: async () => {},
+    setThinkingLevel: async () => {},
+    setPermissionMode: async () => {},
+    renameSession: async () => {},
+    switchSession: notReady,
+    listRewindTargets: async () => [],
+    rewindToTurn: notReady,
+    startNewSession: () => {},
+    stop: async () => {},
+  } as unknown as MakaSessionDriver;
 }
 
 async function readPackageVersion(): Promise<string> {

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -11,7 +11,7 @@ import { createMakaCliRuntimeContext } from './runtime-bootstrap.js';
 import { selectableModelIdsForTarget } from './connection-target.js';
 import { resolveMakaWorkspaceRoot } from './workspace-root.js';
 import { runMakaPiTui, type MakaPiTuiGoalLifecycle } from './pi-tui-runner.js';
-import { setupApiKeyConnection } from './onboarding.js';
+import { createApiKeyOnboardingSurface } from './onboarding.js';
 
 export type MakaCliCommand =
   | { kind: 'tui' }
@@ -210,7 +210,6 @@ export function formatStartupConnectionError(error: unknown, workspaceRoot: stri
 async function runFirstRunOnboarding(workspaceRoot: string): Promise<boolean> {
   const connectionStore = createConnectionStore(workspaceRoot);
   const credentialStore = createFileCredentialStore(workspaceRoot);
-  let configured = false;
   await runMakaPiTui({
     driver: createFirstRunSessionDriver(),
     title: 'Maka',
@@ -224,22 +223,11 @@ async function runFirstRunOnboarding(workspaceRoot: string): Promise<boolean> {
       beginExternalTurn: () => ({ kind: 'registered', settle: async () => {} }),
       bindHost: () => () => {},
     } satisfies MakaPiTuiGoalLifecycle,
-    onboarding: {
-      setup: async ({ providerType, apiKey, baseUrl }) => {
-        await setupApiKeyConnection({
-          providerType,
-          slug: providerType,
-          apiKey,
-          ...(baseUrl ? { baseUrl } : {}),
-          connectionStore,
-          credentialStore,
-          fetchModels: fetchProviderModels,
-        });
-        configured = true;
-      },
-    },
+    onboarding: createApiKeyOnboardingSurface({ connectionStore, credentialStore, fetchModels: fetchProviderModels }),
   });
-  return configured;
+  // Configured iff a connection was actually persisted during the wizard — the
+  // wizard only closes after a verified key (or on cancel; see runner firstRun).
+  return (await connectionStore.getDefault()) !== null;
 }
 
 /** A minimal session driver for the first-run wizard. The wizard never runs an

--- a/packages/cli/src/onboarding.ts
+++ b/packages/cli/src/onboarding.ts
@@ -8,7 +8,7 @@ export interface SetupApiKeyConnectionInput {
   name?: string;
   baseUrl?: string;
   defaultModel?: string;
-  connectionStore: Pick<ConnectionStore, 'create' | 'getDefault' | 'setDefault'>;
+  connectionStore: Pick<ConnectionStore, 'create' | 'get' | 'remove' | 'getDefault' | 'setDefault'>;
   credentialStore: Pick<CredentialStore, 'setSecret'>;
   fetchModels: (connection: LlmConnection, apiKey: string) => Promise<ModelInfo[]>;
 }
@@ -36,14 +36,28 @@ export async function setupApiKeyConnection(
   if (PROVIDER_DEFAULTS[input.providerType]?.authKind === 'api_key' && !input.apiKey.trim()) {
     throw new Error('API key is required');
   }
-  const connection = await input.connectionStore.create({
-    slug: input.slug,
-    name: input.name ?? input.slug,
-    providerType: input.providerType,
-    ...(input.baseUrl ? { baseUrl: input.baseUrl } : {}),
-    ...(input.defaultModel ? { defaultModel: input.defaultModel } : {}),
-  });
-  await input.credentialStore.setSecret(input.slug, 'api_key', input.apiKey);
+  // Upsert by slug so re-onboarding the same provider (e.g. fixing a typo'd
+  // key) rotates the secret instead of throwing "slug already exists". An
+  // existing connection keeps its endpoint/model; only the key is refreshed.
+  const existing = await input.connectionStore.get(input.slug);
+  const connection = existing
+    ? existing
+    : await input.connectionStore.create({
+        slug: input.slug,
+        name: input.name ?? input.slug,
+        providerType: input.providerType,
+        ...(input.baseUrl ? { baseUrl: input.baseUrl } : {}),
+        ...(input.defaultModel ? { defaultModel: input.defaultModel } : {}),
+      });
+  try {
+    await input.credentialStore.setSecret(input.slug, 'api_key', input.apiKey);
+  } catch (error) {
+    // Atomicity: a newly-created connection is rolled back when the secret write
+    // fails, so no half-configured connection becomes the default. An existing
+    // connection is left in place — its previous secret stands.
+    if (!existing) await input.connectionStore.remove(input.slug);
+    throw error;
+  }
   await input.connectionStore.setDefault(input.slug);
   try {
     const models = await input.fetchModels(connection, input.apiKey);
@@ -65,9 +79,36 @@ export interface OnboardableProvider {
 
 /** Host-supplied onboarding surface. The TUI wizard collects a provider + API
  *  key and calls setup(); the host owns the connection/credential stores and
- *  runs the real setupApiKeyConnection. */
+ *  runs the real setupApiKeyConnection. `setup` resolves with `{ testError }`
+ *  when the connection was saved but the model probe failed, so the wizard can
+ *  re-arm the key prompt instead of claiming success. */
 export interface MakaOnboardingSurface {
-  setup: (input: { providerType: ProviderType; apiKey: string; baseUrl?: string }) => Promise<void>;
+  setup: (input: { providerType: ProviderType; apiKey: string; baseUrl?: string }) => Promise<{ testError?: string }>;
+}
+
+/** Build the onboarding surface the TUI wizard calls, owning the connection and
+ *  credential stores plus the model probe. Centralizes the `slug = providerType`
+ *  policy so the first-run host (cli.ts) and the in-session host
+ *  (runtime-bootstrap) share one write path. */
+export function createApiKeyOnboardingSurface(deps: {
+  connectionStore: Pick<ConnectionStore, 'create' | 'get' | 'remove' | 'getDefault' | 'setDefault'>;
+  credentialStore: Pick<CredentialStore, 'setSecret'>;
+  fetchModels: (connection: LlmConnection, apiKey: string) => Promise<ModelInfo[]>;
+}): MakaOnboardingSurface {
+  return {
+    setup: async ({ providerType, apiKey, baseUrl }) => {
+      const result = await setupApiKeyConnection({
+        providerType,
+        slug: providerType,
+        apiKey,
+        ...(baseUrl ? { baseUrl } : {}),
+        connectionStore: deps.connectionStore,
+        credentialStore: deps.credentialStore,
+        fetchModels: deps.fetchModels,
+      });
+      return result.testError ? { testError: result.testError } : {};
+    },
+  };
 }
 
 /** Catalog providers that can be onboarded with an API key, in catalog order.

--- a/packages/cli/src/onboarding.ts
+++ b/packages/cli/src/onboarding.ts
@@ -84,5 +84,9 @@ export function listApiKeyOnboardableProviders(): OnboardableProvider[] {
         requiresBaseUrl: !def.baseUrl,
         fallbackModels: def.fallbackModels,
       };
-    });
+    })
+    // Phase 1 collects only an API key; providers without a default baseUrl
+    // cannot be completed by this wizard and would wedge a fresh install, so
+    // exclude them until the base-URL prompt lands (phase 2).
+    .filter((provider) => !provider.requiresBaseUrl);
 }

--- a/packages/cli/src/onboarding.ts
+++ b/packages/cli/src/onboarding.ts
@@ -1,0 +1,88 @@
+import { CATALOG_PROVIDER_TYPES, PROVIDER_DEFAULTS, providerAuthSupportsApiKey, type LlmConnection, type ModelInfo, type ProviderType } from '@maka/core/llm-connections';
+import type { ConnectionStore, CredentialStore } from '@maka/storage';
+
+export interface SetupApiKeyConnectionInput {
+  providerType: ProviderType;
+  slug: string;
+  apiKey: string;
+  name?: string;
+  baseUrl?: string;
+  defaultModel?: string;
+  connectionStore: Pick<ConnectionStore, 'create' | 'getDefault' | 'setDefault'>;
+  credentialStore: Pick<CredentialStore, 'setSecret'>;
+  fetchModels: (connection: LlmConnection, apiKey: string) => Promise<ModelInfo[]>;
+}
+
+export interface SetupApiKeyConnectionResult {
+  connection: LlmConnection;
+  models: ModelInfo[];
+  /** Set when the model probe failed. The connection is still saved; onboarding
+   *  offers manual model entry instead of aborting (non-blocking test). */
+  testError?: string;
+}
+
+/**
+ * Persist a single API-key connection end to end: create the connection, store
+ * its secret, and probe it for models. Onboarding's write side — the read side
+ * lives in `connection-target.ts`. Pure and dependency-injected so the TUI wizard
+ * (PR②) drives the same seam the tests do.
+ */
+export async function setupApiKeyConnection(
+  input: SetupApiKeyConnectionInput,
+): Promise<SetupApiKeyConnectionResult> {
+  if (!providerAuthSupportsApiKey(input.providerType)) {
+    throw new Error(`Provider "${input.providerType}" does not accept an API key`);
+  }
+  if (PROVIDER_DEFAULTS[input.providerType]?.authKind === 'api_key' && !input.apiKey.trim()) {
+    throw new Error('API key is required');
+  }
+  const connection = await input.connectionStore.create({
+    slug: input.slug,
+    name: input.name ?? input.slug,
+    providerType: input.providerType,
+    ...(input.baseUrl ? { baseUrl: input.baseUrl } : {}),
+    ...(input.defaultModel ? { defaultModel: input.defaultModel } : {}),
+  });
+  await input.credentialStore.setSecret(input.slug, 'api_key', input.apiKey);
+  await input.connectionStore.setDefault(input.slug);
+  try {
+    const models = await input.fetchModels(connection, input.apiKey);
+    return { connection, models };
+  } catch (error) {
+    return { connection, models: [], testError: error instanceof Error ? error.message : String(error) };
+  }
+}
+
+export interface OnboardableProvider {
+  providerType: ProviderType;
+  label: string;
+  authKind: 'api_key' | 'optional_api_key';
+  /** True when the catalog ships no default baseUrl, so the wizard must prompt
+   *  for an endpoint (self-hosted / compatible gateways). */
+  requiresBaseUrl: boolean;
+  fallbackModels: readonly string[];
+}
+
+/** Host-supplied onboarding surface. The TUI wizard collects a provider + API
+ *  key and calls setup(); the host owns the connection/credential stores and
+ *  runs the real setupApiKeyConnection. */
+export interface MakaOnboardingSurface {
+  setup: (input: { providerType: ProviderType; apiKey: string; baseUrl?: string }) => Promise<void>;
+}
+
+/** Catalog providers that can be onboarded with an API key, in catalog order.
+ *  The TUI wizard's first step picks from this list. */
+export function listApiKeyOnboardableProviders(): OnboardableProvider[] {
+  return CATALOG_PROVIDER_TYPES
+    .filter((providerType) => providerAuthSupportsApiKey(providerType))
+    .map((providerType) => {
+      const def = PROVIDER_DEFAULTS[providerType];
+      return {
+        providerType,
+        label: def.label,
+        authKind: def.authKind as 'api_key' | 'optional_api_key',
+        requiresBaseUrl: !def.baseUrl,
+        fallbackModels: def.fallbackModels,
+      };
+    });
+}

--- a/packages/cli/src/pi-tui-pickers.ts
+++ b/packages/cli/src/pi-tui-pickers.ts
@@ -20,6 +20,7 @@ import { PERMISSION_MODES, type PermissionMode } from '@maka/core/permission';
 import type { ThinkingLevel } from '@maka/core/model-thinking';
 import type { InvocableSkillEntry } from '@maka/runtime';
 import type { ModelChoice } from './connection-target.js';
+import type { OnboardableProvider } from './onboarding.js';
 import { skillInvocationPrefixAt } from './skill-token.js';
 import { ansi, editorTheme, stripAnsi } from './tui-ansi.js';
 
@@ -446,6 +447,18 @@ export function skillPickerItems(skills: readonly InvocableSkillEntry[]): Select
     value: skill.id,
     label: skill.name,
     description: skill.description ? `${skill.id} · ${skill.description}` : skill.id,
+  }));
+}
+
+export function onboardableProviderPickerItems(
+  providers: readonly OnboardableProvider[],
+): SelectItem[] {
+  return providers.map((provider) => ({
+    value: provider.providerType,
+    label: provider.label,
+    description: provider.requiresBaseUrl
+      ? `${provider.providerType} · custom endpoint`
+      : provider.providerType,
   }));
 }
 

--- a/packages/cli/src/pi-tui-runner.ts
+++ b/packages/cli/src/pi-tui-runner.ts
@@ -799,7 +799,19 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
       pendingKeyEntry = undefined;
       const providerLabel = PROVIDER_DEFAULTS[entry.providerType]?.label ?? entry.providerType;
       void input.onboarding?.setup({ providerType: entry.providerType, apiKey: prompt }).then(
-        () => {
+        (result) => {
+          if (result.testError) {
+            // Saved but the probe failed (wrong key / offline). Re-arm the key
+            // prompt so the user retries in place — the upsert rotates the key.
+            state.entries.push({
+              kind: 'notice',
+              level: 'error',
+              text: `API key 验证失败：${result.testError}。请检查后重新输入。`,
+            });
+            pendingKeyEntry = entry;
+            requestRender();
+            return;
+          }
           if (input.firstRun) {
             beginClose();
             return;
@@ -807,7 +819,7 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
           state.entries.push({
             kind: 'notice',
             level: 'info',
-            text: `已配置 ${providerLabel}。使用 /model 选择模型，或直接开始对话。`,
+            text: `已配置 ${providerLabel}。新连接将在下次启动 maka 时生效。`,
           });
           requestRender();
         },

--- a/packages/cli/src/pi-tui-runner.ts
+++ b/packages/cli/src/pi-tui-runner.ts
@@ -804,8 +804,18 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
         return;
       }
       pendingKeyEntry = undefined;
+      if (!input.onboarding) {
+        // Minimal host without an onboarding surface cannot collect a key.
+        state.entries.push({
+          kind: 'notice',
+          level: 'error',
+          text: 'Onboarding 不可用：当前运行环境未提供配置入口。',
+        });
+        requestRender();
+        return;
+      }
       const providerLabel = PROVIDER_DEFAULTS[entry.providerType]?.label ?? entry.providerType;
-      void input.onboarding?.setup({ providerType: entry.providerType, apiKey: prompt }).then(
+      void input.onboarding.setup({ providerType: entry.providerType, apiKey: prompt }).then(
         (result) => {
           if (result.testError) {
             // Saved but the probe failed (wrong key / offline). Re-arm the key

--- a/packages/cli/src/pi-tui-runner.ts
+++ b/packages/cli/src/pi-tui-runner.ts
@@ -140,9 +140,6 @@ export interface MakaPiTuiInput {
   /** First-run mode: auto-open the onboarding wizard on launch instead of
    *  waiting for /setup (used when the CLI starts with no configured connection). */
   firstRun?: boolean;
-  /** First-run callback fired after onboarding.setup succeeds, so the host
-   *  can retry context creation and relaunch the normal TUI. */
-  onConfigured?: () => void;
 }
 
 export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
@@ -804,7 +801,6 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
       void input.onboarding?.setup({ providerType: entry.providerType, apiKey: prompt }).then(
         () => {
           if (input.firstRun) {
-            input.onConfigured?.();
             beginClose();
             return;
           }

--- a/packages/cli/src/pi-tui-runner.ts
+++ b/packages/cli/src/pi-tui-runner.ts
@@ -796,6 +796,13 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
   editor.onSubmit = (prompt) => {
     if (pendingKeyEntry) {
       const entry = pendingKeyEntry;
+      // A slash command while the key prompt is armed is routed as a command,
+      // not swallowed as an API key (e.g. /exit must still work).
+      if (prompt.startsWith('/')) {
+        pendingKeyEntry = undefined;
+        handleSlashCommand(prompt);
+        return;
+      }
       pendingKeyEntry = undefined;
       const providerLabel = PROVIDER_DEFAULTS[entry.providerType]?.label ?? entry.providerType;
       void input.onboarding?.setup({ providerType: entry.providerType, apiKey: prompt }).then(
@@ -833,6 +840,12 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
           requestRender();
         },
       );
+      return;
+    }
+    if (input.firstRun) {
+      // First-run mode: no agent turn is possible before a connection exists.
+      // Re-open the picker so the only exits are configure or cancel (Esc).
+      showSetupPicker();
       return;
     }
     if (turnRunning) {
@@ -1192,7 +1205,7 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
     rightLabel: string,
     items: SelectItem[],
     onSelect: (item: SelectItem) => void,
-    options: { minPrimaryColumnWidth: number; maxPrimaryColumnWidth: number; selectedIndex?: number; hint?: string },
+    options: { minPrimaryColumnWidth: number; maxPrimaryColumnWidth: number; selectedIndex?: number; hint?: string; onCancel?: () => void },
   ): void => {
     const list = new SelectList(items, 10, selectListTheme(), {
       minPrimaryColumnWidth: options.minPrimaryColumnWidth,
@@ -1207,6 +1220,7 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
     };
     list.onCancel = () => {
       overlay?.hide();
+      options.onCancel?.();
     };
     overlay = showBottomPicker(picker);
   };
@@ -1237,7 +1251,7 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
         });
         requestRender();
       },
-      { minPrimaryColumnWidth: 16, maxPrimaryColumnWidth: 32 },
+      { minPrimaryColumnWidth: 16, maxPrimaryColumnWidth: 32, onCancel: input.firstRun ? () => beginClose() : undefined },
     );
   };
 

--- a/packages/cli/src/pi-tui-runner.ts
+++ b/packages/cli/src/pi-tui-runner.ts
@@ -137,6 +137,12 @@ export interface MakaPiTuiInput {
   /** API-key onboarding surface (#1098). When present, /setup runs the wizard
    *  and calls setup() with the chosen provider + key; the host owns the stores. */
   onboarding?: MakaOnboardingSurface;
+  /** First-run mode: auto-open the onboarding wizard on launch instead of
+   *  waiting for /setup (used when the CLI starts with no configured connection). */
+  firstRun?: boolean;
+  /** First-run callback fired after onboarding.setup succeeds, so the host
+   *  can retry context creation and relaunch the normal TUI. */
+  onConfigured?: () => void;
 }
 
 export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
@@ -797,6 +803,11 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
       const providerLabel = PROVIDER_DEFAULTS[entry.providerType]?.label ?? entry.providerType;
       void input.onboarding?.setup({ providerType: entry.providerType, apiKey: prompt }).then(
         () => {
+          if (input.firstRun) {
+            input.onConfigured?.();
+            beginClose();
+            return;
+          }
           state.entries.push({
             kind: 'notice',
             level: 'info',
@@ -1192,6 +1203,36 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
     overlay = showBottomPicker(picker);
   };
 
+  const showSetupPicker = () => {
+    const providers = listApiKeyOnboardableProviders();
+    if (providers.length === 0) {
+      state.entries.push({
+        kind: 'notice',
+        level: 'info',
+        text: '没有可配置的 API key 类供应商。',
+      });
+      requestRender();
+      return;
+    }
+    showSelectPicker(
+      'Set Up Provider',
+      String(providers.length),
+      onboardableProviderPickerItems(providers),
+      (item) => {
+        const providerType = item.value as ProviderType;
+        const label = PROVIDER_DEFAULTS[providerType]?.label ?? providerType;
+        pendingKeyEntry = { providerType };
+        state.entries.push({
+          kind: 'notice',
+          level: 'info',
+          text: `请输入 ${label} 的 API key，按回车提交（仅本机存储）。`,
+        });
+        requestRender();
+      },
+      { minPrimaryColumnWidth: 16, maxPrimaryColumnWidth: 32 },
+    );
+  };
+
   const compactSession = async () => {
     state.entries.push({
       kind: 'notice',
@@ -1500,34 +1541,7 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
           requestRender();
           return;
         }
-        const providers = listApiKeyOnboardableProviders();
-        if (providers.length === 0) {
-          state.entries.push({
-            kind: 'notice',
-            level: 'info',
-            text: '没有可配置的 API key 类供应商。',
-          });
-          requestRender();
-          return;
-        }
-        showSelectPicker(
-          'Set Up Provider',
-          String(providers.length),
-          onboardableProviderPickerItems(providers),
-          (item) => {
-            if (!input.onboarding) return;
-            const providerType = item.value as ProviderType;
-            const label = PROVIDER_DEFAULTS[providerType]?.label ?? providerType;
-            pendingKeyEntry = { providerType };
-            state.entries.push({
-              kind: 'notice',
-              level: 'info',
-              text: `请输入 ${label} 的 API key，按回车提交（仅本机存储）。`,
-            });
-            requestRender();
-          },
-          { minPrimaryColumnWidth: 16, maxPrimaryColumnWidth: 32 },
-        );
+        showSetupPicker();
       },
     },
     {
@@ -1868,6 +1882,7 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
     // to the enable sequence (a focus-in `\x1b[I`) is echoed by the cooked-mode
     // line discipline and leaks onto the screen as a stray `^[[I` on launch.
     terminal.write(ENABLE_FOCUS_REPORTING);
+    if (input.firstRun) showSetupPicker();
   } catch (error) {
     beginClose(error instanceof Error ? error : new Error(String(error)));
   }

--- a/packages/cli/src/pi-tui-runner.ts
+++ b/packages/cli/src/pi-tui-runner.ts
@@ -15,7 +15,7 @@ import {
 } from '@earendil-works/pi-tui';
 import { PERMISSION_MODES, isPermissionMode, type PermissionMode } from '@maka/core/permission';
 import { isThinkingLevel, thinkingVariantsForModel, type ThinkingLevel } from '@maka/core/model-thinking';
-import type { ProviderType } from '@maka/core/llm-connections';
+import { PROVIDER_DEFAULTS, type ProviderType } from '@maka/core/llm-connections';
 import {
   ShellRunUpdateBuffer,
   mergeShellRunUpdate,
@@ -24,6 +24,7 @@ import {
 } from '@maka/core';
 import type { GoalTurnOutcome, SessionActivityLease } from '@maka/runtime';
 import type { ModelChoice } from './connection-target.js';
+import { listApiKeyOnboardableProviders, type MakaOnboardingSurface } from './onboarding.js';
 import type { MakaCliSkillSurface } from './runtime-bootstrap.js';
 import {
   composeSkillInvocationMessage,
@@ -82,6 +83,7 @@ import {
   MakaAutocompleteProvider,
   PickerOverlay,
   UserQuestionOverlay,
+  onboardableProviderPickerItems,
   modelChoicePickerItems,
   modelPickerItems,
   permissionModePickerItems,
@@ -132,6 +134,9 @@ export interface MakaPiTuiInput {
   skills?: MakaCliSkillSurface;
   /** Mandatory turn ownership shared with CLI Automation and Goal continuation. */
   goalLifecycle: MakaPiTuiGoalLifecycle;
+  /** API-key onboarding surface (#1098). When present, /setup runs the wizard
+   *  and calls setup() with the chosen provider + key; the host owns the stores. */
+  onboarding?: MakaOnboardingSurface;
 }
 
 export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
@@ -783,7 +788,34 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
     requestRender();
   };
 
+  let pendingKeyEntry: { providerType: ProviderType } | undefined;
+
   editor.onSubmit = (prompt) => {
+    if (pendingKeyEntry) {
+      const entry = pendingKeyEntry;
+      pendingKeyEntry = undefined;
+      const providerLabel = PROVIDER_DEFAULTS[entry.providerType]?.label ?? entry.providerType;
+      void input.onboarding?.setup({ providerType: entry.providerType, apiKey: prompt }).then(
+        () => {
+          state.entries.push({
+            kind: 'notice',
+            level: 'info',
+            text: `已配置 ${providerLabel}。使用 /model 选择模型，或直接开始对话。`,
+          });
+          requestRender();
+        },
+        (error) => {
+          pendingKeyEntry = entry;
+          state.entries.push({
+            kind: 'notice',
+            level: 'error',
+            text: `配置失败：${error instanceof Error ? error.message : String(error)}`,
+          });
+          requestRender();
+        },
+      );
+      return;
+    }
     if (turnRunning) {
       steerRunningTurn(prompt);
       return;
@@ -1453,6 +1485,49 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
           return;
         }
         void showSkillList();
+      },
+    },
+    {
+      name: 'setup',
+      description: 'Set up a model provider (API key)',
+      run: (parts: string[]) => {
+        if (parts.length !== 1) {
+          state.entries.push({
+            kind: 'notice',
+            level: 'error',
+            text: 'Usage: /setup',
+          });
+          requestRender();
+          return;
+        }
+        const providers = listApiKeyOnboardableProviders();
+        if (providers.length === 0) {
+          state.entries.push({
+            kind: 'notice',
+            level: 'info',
+            text: '没有可配置的 API key 类供应商。',
+          });
+          requestRender();
+          return;
+        }
+        showSelectPicker(
+          'Set Up Provider',
+          String(providers.length),
+          onboardableProviderPickerItems(providers),
+          (item) => {
+            if (!input.onboarding) return;
+            const providerType = item.value as ProviderType;
+            const label = PROVIDER_DEFAULTS[providerType]?.label ?? providerType;
+            pendingKeyEntry = { providerType };
+            state.entries.push({
+              kind: 'notice',
+              level: 'info',
+              text: `请输入 ${label} 的 API key，按回车提交（仅本机存储）。`,
+            });
+            requestRender();
+          },
+          { minPrimaryColumnWidth: 16, maxPrimaryColumnWidth: 32 },
+        );
       },
     },
     {

--- a/packages/cli/src/runtime-bootstrap.ts
+++ b/packages/cli/src/runtime-bootstrap.ts
@@ -49,6 +49,8 @@ import {
   createShellRunStore,
 } from '@maka/storage';
 import type { ToolPermissionRule } from '@maka/core/permission';
+import { fetchProviderModels } from '@maka/runtime';
+import { setupApiKeyConnection, type MakaOnboardingSurface } from './onboarding.js';
 import { resolveModelVisionSupport } from '@maka/core';
 import type { ModelChoice, ReadySessionTarget } from './connection-target.js';
 import { listReadyModelChoices, resolveDefaultSessionTarget, resolveSessionTargetForSlug } from './connection-target.js';
@@ -78,6 +80,8 @@ export interface MakaCliRuntimeContext {
   goalManager: GoalManager;
   goalContinuation: CliGoalContinuation;
   close(): Promise<void>;
+  /** API-key onboarding surface for the /setup wizard (#1098). */
+  onboarding: MakaOnboardingSurface;
 }
 
 export interface CreateMakaCliRuntimeContextInput {
@@ -481,6 +485,17 @@ export async function createMakaCliRuntimeContext(
     listShellRunUpdates: (sessionId) => runtime.listShellRunUpdates(sessionId),
     goalManager,
     goalContinuation,
+    onboarding: {
+      setup: ({ providerType, apiKey, baseUrl }) => setupApiKeyConnection({
+        providerType,
+        slug: providerType,
+        apiKey,
+        ...(baseUrl ? { baseUrl } : {}),
+        connectionStore,
+        credentialStore,
+        fetchModels: fetchProviderModels,
+      }).then(() => undefined),
+    },
     close: async () => {
       // Stop the automation scheduler's timer (else it keeps the process alive
       // and ticks into a stopped session), then terminate background shell runs.

--- a/packages/cli/src/runtime-bootstrap.ts
+++ b/packages/cli/src/runtime-bootstrap.ts
@@ -50,7 +50,7 @@ import {
 } from '@maka/storage';
 import type { ToolPermissionRule } from '@maka/core/permission';
 import { fetchProviderModels } from '@maka/runtime';
-import { setupApiKeyConnection, type MakaOnboardingSurface } from './onboarding.js';
+import { createApiKeyOnboardingSurface, type MakaOnboardingSurface } from './onboarding.js';
 import { resolveModelVisionSupport } from '@maka/core';
 import type { ModelChoice, ReadySessionTarget } from './connection-target.js';
 import { listReadyModelChoices, resolveDefaultSessionTarget, resolveSessionTargetForSlug } from './connection-target.js';
@@ -485,17 +485,7 @@ export async function createMakaCliRuntimeContext(
     listShellRunUpdates: (sessionId) => runtime.listShellRunUpdates(sessionId),
     goalManager,
     goalContinuation,
-    onboarding: {
-      setup: ({ providerType, apiKey, baseUrl }) => setupApiKeyConnection({
-        providerType,
-        slug: providerType,
-        apiKey,
-        ...(baseUrl ? { baseUrl } : {}),
-        connectionStore,
-        credentialStore,
-        fetchModels: fetchProviderModels,
-      }).then(() => undefined),
-    },
+    onboarding: createApiKeyOnboardingSurface({ connectionStore, credentialStore, fetchModels: fetchProviderModels }),
     close: async () => {
       // Stop the automation scheduler's timer (else it keeps the process alive
       // and ticks into a stopped session), then terminate background shell runs.


### PR DESCRIPTION
## Summary

Addresses #1098 (phase 1: API-key onboarding). The standalone CLI used to abort on a fresh install with `NO_REAL_CONNECTION:missing_default_connection` and tell the user to configure a connection in Maka Desktop — so it could never stand on its own. This adds an in-TUI onboarding path:

- **First-run**: `maka` with no connection now runs the wizard automatically, then retries context creation and launches the normal TUI.
- **`/setup`**: a slash command to add another API-key connection from an already-running TUI.

The wizard lists the API-key-capable providers from the catalog, collects provider + key, and persists a default connection through the host-agnostic store layer. There is no parallel persistence path — `setupApiKeyConnection` reuses `connectionStore` + `credentialStore` + `fetchProviderModels` that the runtime already uses, so the new connection is immediately usable.

The first-run wizard runs over a stub `MakaSessionDriver` (chat/runtime methods are unreachable; the editor only collects provider + key via the onboarding intercept, and the TUI never touches `driver.runtime`), hands control back to `cli.ts` on success, which retries `createMakaCliRuntimeContext` and launches the normal TUI.

## Verification

- `npm run build` clean.
- `packages/cli` test suite: **136 pass, 0 fail**, including new tests for the provider picker, the key-submission interception → `setupApiKeyConnection`, and first-run auto-opening the picker without `/setup`.
- Manual: fresh workspace (no connection) → `maka` auto-opens the picker → enter API key → normal TUI launches and is chat-ready; a subsequent `/model` lists the provider's models.

## Phase 2 (intentionally not in this PR)

- Base URL prompt in the wizard — the plumbing (`setupApiKeyConnection` + `effectiveBaseUrl`) already supports a custom base URL, but the wizard does not yet ask for it.
- OAuth providers — the loop is currently locked behind Electron subscription services.
- In-wizard model selection.
