### PR TITLE
feat(cli): wire subagents into TUI host

### DIFF
--- a/packages/cli/src/__tests__/pi-transcript.test.ts
+++ b/packages/cli/src/__tests__/pi-transcript.test.ts
@@ -1314,6 +1314,79 @@ describe('Maka Pi TUI transcript', () => {
     assert.match(expanded, /step two/);
   });
 
+  test('folds concurrent child lifecycles into their parent agent cards', () => {
+    const state = createMakaPiTranscriptState();
+    for (const [toolUseId, profile] of [
+      ['agent-a', 'local_read'],
+      ['agent-b', 'web_research'],
+      ['agent-c', 'local_read'],
+    ] as const) {
+      applyMakaSessionEventToTranscript(state, event({
+        type: 'tool_start', toolUseId, toolName: 'agent_spawn', args: { profile, task: `Run ${profile}` },
+      }));
+    }
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_output_delta', toolUseId: 'agent-a', seq: 1, stream: 'stdout',
+      chunk: 'Child tool started: Read\n', redacted: false,
+    }));
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_output_delta', toolUseId: 'agent-b', seq: 1, stream: 'stdout',
+      chunk: 'Child tool started: WebSearch\n', redacted: false,
+    }));
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_result', toolUseId: 'agent-a', isError: false,
+      content: subagentResult({ agentName: 'Local Read', turnId: 'child-a', summary: 'local result' }),
+    }));
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_result', toolUseId: 'agent-b', isError: true,
+      content: subagentResult({
+        agentName: 'Web Research', turnId: 'child-b', status: 'failed', summary: 'network failed',
+      }),
+    }));
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_result', toolUseId: 'agent-c', isError: true,
+      content: subagentResult({
+        agentName: 'Local Read', turnId: 'child-c', status: 'cancelled', summary: 'stopped',
+      }),
+    }));
+
+    const tools = state.entries.filter((entry) => entry.kind === 'tool');
+    assert.deepEqual(tools.map((tool) => [tool.toolUseId, tool.status]), [
+      ['agent-a', 'done'],
+      ['agent-b', 'failed'],
+      ['agent-c', 'aborted'],
+    ]);
+    assert.equal(toggleAllToolExpansion(state), true);
+    const rendered = renderMakaPiTranscript(state, meta(), 120).map(stripAnsi).join('\n');
+    assert.match(rendered, /Child tool started: Read/);
+    assert.match(rendered, /Child tool started: WebSearch/);
+    assert.match(rendered, /local result/);
+    assert.match(rendered, /network failed/);
+    assert.match(rendered, /stopped/);
+  });
+
+  test('restores one parent card with its child terminal state', () => {
+    const state = createMakaPiTranscriptState();
+    replaceTranscriptWithStoredMessages(state, [
+      {
+        type: 'tool_call', id: 'agent-a', turnId: 'turn-1', ts: 1,
+        toolName: 'agent_spawn', args: { profile: 'local_read', task: 'Inspect.' },
+      },
+      {
+        type: 'tool_result', id: 'agent-result', turnId: 'turn-1', ts: 2,
+        toolUseId: 'agent-a', isError: true,
+        content: subagentResult({
+          agentName: 'Local Read', turnId: 'child-a', status: 'cancelled', summary: 'stopped',
+        }),
+      },
+    ] satisfies StoredMessage[]);
+
+    const tools = state.entries.filter((entry) => entry.kind === 'tool');
+    assert.equal(tools.length, 1);
+    assert.equal(tools[0]?.toolUseId, 'agent-a');
+    assert.equal(tools[0]?.status, 'aborted');
+  });
+
   test('keeps a background Bash card running until the process settles', () => {
     const state = createMakaPiTranscriptState();
     applyMakaSessionEventToTranscript(state, event({
@@ -3511,6 +3584,21 @@ function event(input: { type: SessionEvent['type'] } & Record<string, unknown>):
     ts: 1,
     ...input,
   } as SessionEvent;
+}
+
+function subagentResult(
+  overrides: Partial<Extract<ToolResultContent, { kind: 'subagent' }>> = {},
+): Extract<ToolResultContent, { kind: 'subagent' }> {
+  return {
+    kind: 'subagent',
+    agentName: 'Local Read',
+    turnId: 'child-turn',
+    status: 'completed',
+    permissionMode: 'explore',
+    summary: 'done',
+    artifactIds: [],
+    ...overrides,
+  };
 }
 
 function stripAnsi(text: string): string {

--- a/packages/cli/src/__tests__/runtime-bootstrap.test.ts
+++ b/packages/cli/src/__tests__/runtime-bootstrap.test.ts
@@ -12,12 +12,17 @@ import {
 } from '@maka/storage';
 import {
   BackendRegistry,
+  AGENT_LIST_TOOL_NAME,
+  AGENT_OUTPUT_TOOL_NAME,
+  AGENT_SPAWN_TOOL_NAME,
+  AGENT_TOOL_GROUP_ID,
   GOAL_CLEAR_TOOL_NAME,
   GOAL_PAUSE_TOOL_NAME,
   GOAL_RESUME_TOOL_NAME,
   GOAL_SET_TOOL_NAME,
   GOAL_STATUS_TOOL_NAME,
   type AiSdkBackendInput,
+  type MakaTool,
   type SessionStore,
   type ShellRunUpdate,
 } from '@maka/runtime';
@@ -236,9 +241,76 @@ describe('Maka CLI runtime bootstrap', () => {
           run.tools.some((candidate) => goalToolNames.includes(candidate.name)),
           false,
         );
+        const agentToolNames = [
+          AGENT_SPAWN_TOOL_NAME,
+          AGENT_LIST_TOOL_NAME,
+          AGENT_OUTPUT_TOOL_NAME,
+        ];
+        assert.deepEqual(
+          agentToolNames.filter((name) => tui.tools.some((candidate) => candidate.name === name)),
+          agentToolNames,
+        );
+        assert.equal(
+          run.tools.some((candidate) => agentToolNames.includes(candidate.name)),
+          false,
+        );
       } finally {
         await tui.close();
         await run.close();
+      }
+    });
+  });
+
+  test('wires TUI subagent capabilities and a child-safe tool surface', async () => {
+    await withWorkspace(async (workspaceRoot) => {
+      const connectionStore = createConnectionStore(workspaceRoot);
+      await connectionStore.create({
+        slug: 'local',
+        name: 'Local Ollama',
+        providerType: 'ollama',
+        defaultModel: 'llama3.2',
+      });
+
+      const context = await createMakaCliRuntimeContext({
+        surface: 'tui',
+        workspaceRoot,
+        cwd: '/repo',
+      });
+      try {
+        const session = await context.runtime.createSession({
+          cwd: context.cwd,
+          backend: 'ai-sdk',
+          llmConnectionSlug: context.target.connection.slug,
+          model: context.target.model,
+          permissionMode: 'bypass',
+        });
+        const runtimeDeps = (context.runtime as unknown as RuntimeWithPrivateDeps).deps;
+        const header = await runtimeDeps.store.readHeader(session.id);
+        const backend = await runtimeDeps.backends.build('ai-sdk', {
+          sessionId: session.id,
+          workspaceRoot,
+          header,
+          store: runtimeDeps.store,
+        });
+        const backendInput = (backend as unknown as { input: AiSdkBackendInput }).input;
+
+        assert.equal(typeof backendInput.spawnChildAgent, 'function');
+        assert.equal(typeof backendInput.listChildAgents, 'function');
+        assert.equal(typeof backendInput.readChildAgentOutput, 'function');
+        assert.deepEqual(backendInput.toolAvailability, {
+          economy: !process.env.MAKA_DISABLE_DEFERRED_TOOLS,
+          groups: [{
+            id: AGENT_TOOL_GROUP_ID,
+            label: 'Agent',
+            description: 'Spawn and inspect foreground child agents.',
+            toolNames: [AGENT_SPAWN_TOOL_NAME, AGENT_LIST_TOOL_NAME, AGENT_OUTPUT_TOOL_NAME],
+          }],
+        });
+        assert.deepEqual(runtimeDeps.childTools?.map((tool) => tool.name), ['Read', 'Glob', 'Grep']);
+        assert.equal(runtimeDeps.childTools?.some((tool) => ['Bash', 'Write', 'Edit', AGENT_SPAWN_TOOL_NAME].includes(tool.name)), false);
+        assert.equal(context.skills.host.toolNames.has(AGENT_SPAWN_TOOL_NAME), true);
+      } finally {
+        await context.close();
       }
     });
   });
@@ -629,6 +701,7 @@ interface RuntimeWithPrivateDeps {
     backends: BackendRegistry;
     store: SessionStore;
     runtimeInvocationObserver?: (result: unknown) => void | Promise<void>;
+    childTools?: readonly MakaTool[];
   };
 }
 

--- a/packages/cli/src/pi-transcript.ts
+++ b/packages/cli/src/pi-transcript.ts
@@ -579,7 +579,7 @@ export function applyMakaSessionEventToTranscript(
           // error even when its payload is a well-formed (still running) run.
           if (event.isError) tool.status = 'error';
         } else {
-          tool.status = event.isError ? 'error' : 'done';
+          tool.status = toolResultTranscriptStatus(event.content, event.isError);
           tool.result = event.content;
           tool.output = formatToolResultContent(event.content);
           tool.durationMs = event.durationMs;
@@ -597,7 +597,7 @@ export function applyMakaSessionEventToTranscript(
           output: formatToolResultContent(event.content),
           resultVersion: 1,
           durationMs: event.durationMs,
-          status: event.isError ? 'error' : 'done',
+          status: toolResultTranscriptStatus(event.content, event.isError),
           expanded: state.expandAllTools,
         });
       }
@@ -768,6 +768,9 @@ function toolActivityToTranscriptEntry(item: ToolActivityItem): MakaPiToolEntry 
     status: transcriptToolStatus(item.status),
     expanded: false,
   };
+  if (item.result?.kind === 'subagent') {
+    entry.status = subagentTranscriptStatus(item.result.status);
+  }
   // A failed call keeps its error status and raw payload: applying the shell_run
   // as the card's own result would let a still-running or settled payload
   // overwrite the error and swallow the failure on replay. This mirrors the live
@@ -811,6 +814,31 @@ function transcriptToolStatus(status: ToolActivityItem['status']): MakaPiToolEnt
     case 'pending':
     case 'waiting_permission':
     case 'running':
+      return 'running';
+  }
+}
+
+function toolResultTranscriptStatus(
+  result: ToolResultContent,
+  isError: boolean,
+): MakaPiToolEntry['status'] {
+  return result.kind === 'subagent'
+    ? subagentTranscriptStatus(result.status)
+    : isError ? 'error' : 'done';
+}
+
+function subagentTranscriptStatus(
+  status: Extract<ToolResultContent, { kind: 'subagent' }>['status'],
+): MakaPiToolEntry['status'] {
+  switch (status) {
+    case 'completed':
+      return 'done';
+    case 'failed':
+      return 'failed';
+    case 'cancelled':
+      return 'aborted';
+    case 'running':
+    case 'waiting_permission':
       return 'running';
   }
 }

--- a/packages/cli/src/runtime-bootstrap.ts
+++ b/packages/cli/src/runtime-bootstrap.ts
@@ -17,12 +17,16 @@ import {
   buildAskUserQuestionTool,
   buildBuiltinTools,
   buildRuntimeEventModelReplayPlan,
+  buildChildAgentTools,
   createBuiltinSandboxManager,
   createFilesystemWorkerLaunchSpecProvider,
   FilesystemWorkerClient,
   buildDefaultContextBudgetPolicy,
   buildSkillAgentTool,
   buildGoalTools,
+  buildSubagentProjectionTools,
+  buildSubagentSpawnTool,
+  buildSubagentToolGroup,
   buildLlmHistorySummarizer,
   cleanupLegacyHistoryCompactArtifacts,
   buildProviderOptions,
@@ -39,6 +43,7 @@ import {
   type InvocationResult,
   type ShellRunUpdate,
   type SkillSource,
+  type ToolAvailabilityConfig,
 } from '@maka/runtime';
 import {
   createAgentRunStore,
@@ -70,7 +75,7 @@ export interface MakaCliRuntimeContext {
   target: ReadySessionTarget;
   /** Selectable models across every ready connection, for the `/model` picker. */
   modelChoices: ModelChoice[];
-  /** Tools passed to the backend (builtins + automation + goals + Skill). */
+  /** Tools passed to the backend, including TUI-only interactive and subagent tools. */
   tools: MakaTool[];
   /**
    * Explicit skill invocation surface (issue #1148): the discovery source +
@@ -207,6 +212,20 @@ export async function createMakaCliRuntimeContext(
       enableFileToolAdditionalPermissions: true,
     } : {}),
   });
+  // Child sessions get fresh file-only tools. In particular, their Read tool
+  // cannot inspect parent runtime resources and no write/shell/agent tool is
+  // present for the catalog allowlist to select.
+  const childAgentTools = input.surface === 'tui'
+    ? buildChildAgentTools(buildBuiltinTools({
+        snapshotImage: createReadImageSnapshotter(artifactStore),
+        ...(sandboxManager ? { sandboxManager } : {}),
+        ...(filesystemWorker ? {
+          filesystemWorker,
+          enableBashAdditionalPermissions: true,
+          enableFileToolAdditionalPermissions: true,
+        } : {}),
+      }))
+    : [];
   const automationManager = new AutomationManager({
     generateId: () => randomUUID(),
     now: () => Date.now(),
@@ -426,19 +445,41 @@ export async function createMakaCliRuntimeContext(
         getTokenCount: (sessionId: string) => goalTokenCache.get(sessionId) ?? 0,
       })
     : [];
+  const subagentTools = input.surface === 'tui'
+    ? [buildSubagentSpawnTool(), ...buildSubagentProjectionTools()]
+    : [];
+  const toolAvailability: ToolAvailabilityConfig | undefined = input.surface === 'tui'
+    ? {
+        economy: !process.env.MAKA_DISABLE_DEFERRED_TOOLS,
+        groups: [buildSubagentToolGroup()],
+      }
+    : undefined;
   // CLI host capability surface for the skill-compatibility gate: the tool
   // names registered on this host. The CLI has no Office tools, so bundled
   // Office skills (requiredTools includes OfficeDocument/OfficeDocumentEdit)
   // are hard-hidden here without seeding them — desktop owns Office seeding.
   const surfaceTools = input.surface === 'tui' ? [buildAskUserQuestionTool()] : [];
   const host: HostCapabilities = {
-    toolNames: new Set([...tools, automationTool, ...goalTools, ...surfaceTools].map((tool) => tool.name)),
+    toolNames: new Set([
+      ...tools,
+      automationTool,
+      ...goalTools,
+      ...subagentTools,
+      ...surfaceTools,
+    ].map((tool) => tool.name)),
   };
   const skillTool = buildSkillAgentTool(
     ({ cwd }) => resolveSkillDiscoveryPaths(cwd, input.workspaceRoot),
     host,
   );
-  const allTools = [...tools, automationTool, ...goalTools, skillTool, ...surfaceTools];
+  const allTools = [
+    ...tools,
+    automationTool,
+    ...goalTools,
+    skillTool,
+    ...subagentTools,
+    ...surfaceTools,
+  ];
 
   backends.register('ai-sdk', async (ctx) => {
     const header = input.sessionCwdOverride?.sessionId === ctx.sessionId
@@ -474,6 +515,12 @@ export async function createMakaCliRuntimeContext(
       permissionEngine,
       modelFactory: (modelInput) => getAIModel({ ...modelInput, fetch: modelFetch }),
       tools: allTools,
+      toolAvailability,
+      ...(input.surface === 'tui' ? {
+        spawnChildAgent: (childInput) => runtime.spawnChildAgent(ctx.sessionId, childInput),
+        listChildAgents: () => runtime.listChildAgents(ctx.sessionId),
+        readChildAgentOutput: (childInput) => runtime.readChildAgentOutput(ctx.sessionId, childInput),
+      } : {}),
       providerOptions: buildProviderOptions(ready.connection, ready.model, header.thinkingLevel),
       contextBudget: buildDefaultContextBudgetPolicy(ready.connection, {
         name: 'cli-default-history-budget',
@@ -526,6 +573,7 @@ export async function createMakaCliRuntimeContext(
     runtimeEventStore,
     shellRuns,
     backends,
+    ...(input.surface === 'tui' ? { childTools: childAgentTools } : {}),
     runtimeInvocationObserver: input.runtimeInvocationObserver,
     cleanupHistoryCompactArtifacts: async (cleanupInput) => {
       await cleanupLegacyHistoryCompactArtifacts({

--- a/packages/runtime/src/__tests__/deferred-tools-backend.test.ts
+++ b/packages/runtime/src/__tests__/deferred-tools-backend.test.ts
@@ -3,7 +3,7 @@ import { describe, test } from 'node:test';
 import { z } from 'zod';
 import { MockLanguageModelV3, convertArrayToReadableStream } from 'ai/test';
 import type { LanguageModelV3StreamPart, LanguageModelV3Usage } from '@ai-sdk/provider';
-import type { LlmConnection, SessionHeader } from '@maka/core';
+import type { LlmConnection, SessionEvent, SessionHeader } from '@maka/core';
 import type { LlmCallRecord } from '@maka/core/usage-stats/types';
 import type { RuntimeEvent } from '@maka/core/runtime-event';
 
@@ -323,6 +323,7 @@ describe('AiSdkBackend deferred agent tools', () => {
       },
       prompt: 'Inspect the runtime tests.',
       abortSignal: assertAbortSignal(spawnCalls[0]),
+      onEvent: assertOnEvent(spawnCalls[0]),
     });
   });
 });
@@ -511,6 +512,17 @@ function assertAbortSignal(value: unknown): AbortSignal {
     'spawn input carries an AbortSignal',
   );
   return value.abortSignal;
+}
+
+function assertOnEvent(value: unknown): (event: SessionEvent) => void {
+  assert.ok(
+    value &&
+      typeof value === 'object' &&
+      'onEvent' in value &&
+      typeof value.onEvent === 'function',
+    'spawn input carries a child event observer',
+  );
+  return value.onEvent as (event: SessionEvent) => void;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/runtime/src/__tests__/session-manager.test.ts
+++ b/packages/runtime/src/__tests__/session-manager.test.ts
@@ -3181,11 +3181,13 @@ describe('SessionManager permission mode updates', () => {
     const [parentRun] = await runStore.listSessionRuns(session.id);
     if (!parentRun) throw new Error('parent run was not recorded');
 
+    const observed: SessionEvent[] = [];
     const result = await manager.spawnChildAgent(session.id, {
       turnId: 'child-turn',
       parentRunId: parentRun.runId,
       spec: { id: LOCAL_READ_AGENT_ID, name: 'Researcher', systemPrompt: 'read only' },
       prompt: 'produce a large report',
+      onEvent: (event) => observed.push(event),
     });
 
     expect(result.status).toBe('completed');
@@ -3194,6 +3196,9 @@ describe('SessionManager permission mode updates', () => {
     expect(result.summary.startsWith('…')).toBe(true);
     expect(result.summary.includes('chunk-000')).toBe(false);
     expect(result.summary.includes('chunk-511')).toBe(true);
+    expect(observed).toHaveLength(513);
+    expect(observed[0]?.type).toBe('text_delta');
+    expect(observed.at(-1)?.type).toBe('complete');
   });
 
   test('stopSession cancels active child runs and disposes their backend', async () => {

--- a/packages/runtime/src/__tests__/subagent-tools.test.ts
+++ b/packages/runtime/src/__tests__/subagent-tools.test.ts
@@ -358,6 +358,7 @@ describe('subagent tools', () => {
     const tool = buildSubagentSpawnTool();
     const abortController = new AbortController();
     const calls: unknown[] = [];
+    const output: Array<{ stream: string; chunk: string }> = [];
 
     const result = await tool.impl({
       profile: LOCAL_READ_AGENT_PROFILE,
@@ -368,9 +369,17 @@ describe('subagent tools', () => {
       cwd: '/tmp/cwd',
       toolCallId: 'tool-1',
       abortSignal: abortController.signal,
-      emitOutput: () => {},
+      emitOutput: (stream, chunk) => output.push({ stream, chunk }),
       spawnChildAgent: async (input) => {
         calls.push(input);
+        input.onEvent?.({
+          type: 'tool_start', id: 'child-start', turnId: 'child-turn', ts: 1,
+          toolUseId: 'child-tool', toolName: 'Read', displayName: 'Read file', args: { path: 'secret.txt' },
+        });
+        input.onEvent?.({
+          type: 'tool_result', id: 'child-result', turnId: 'child-turn', ts: 2,
+          toolUseId: 'child-tool', isError: false, content: { kind: 'text', text: 'secret body' },
+        });
         return {
           agentId: input.spec.id,
           agentName: input.spec.name,
@@ -386,14 +395,27 @@ describe('subagent tools', () => {
     expect(tool.name).toBe(AGENT_SPAWN_TOOL_NAME);
     expect(tool.categoryHint).toBe('subagent');
     expect(tool.permissionRequired).toBe(true);
-    expect(calls).toEqual([{
-      spec: {
-        id: LOCAL_READ_AGENT_ID,
-        name: 'Local Read',
-        systemPrompt: LOCAL_READ_AGENT_DEFINITION.systemPrompt,
-      },
-      prompt: 'Inspect the runtime tests.',
-    }]);
+    expect(calls).toHaveLength(1);
+    const call = calls[0] as {
+      spec: unknown;
+      prompt: string;
+      onEvent?: (event: SessionEvent) => void;
+    };
+    expect(call.spec).toEqual({
+      id: LOCAL_READ_AGENT_ID,
+      name: 'Local Read',
+      systemPrompt: LOCAL_READ_AGENT_DEFINITION.systemPrompt,
+    });
+    expect(call.prompt).toBe('Inspect the runtime tests.');
+    expect(typeof call.onEvent).toBe('function');
+    expect(output).toEqual([
+      { stream: 'stdout', chunk: 'Starting child agent: Local Read\n' },
+      { stream: 'stdout', chunk: 'Child tool started: Read file\n' },
+      { stream: 'stdout', chunk: 'Child tool finished: Read file\n' },
+      { stream: 'stdout', chunk: 'Child agent Local Read: completed\n' },
+    ]);
+    expect(JSON.stringify(output)).not.toContain('secret.txt');
+    expect(JSON.stringify(output)).not.toContain('secret body');
     expect(result).toEqual({
       kind: 'subagent',
       agentId: LOCAL_READ_AGENT_ID,
@@ -404,6 +426,54 @@ describe('subagent tools', () => {
       summary: 'done',
       artifactIds: [],
     });
+  });
+
+  test('agent_spawn bounds projected child tool activity', async () => {
+    const tool = buildSubagentSpawnTool();
+    const output: string[] = [];
+
+    await tool.impl({
+      profile: LOCAL_READ_AGENT_PROFILE,
+      task: 'Inspect many files.',
+    }, {
+      sessionId: 'session-1', turnId: 'parent-turn', cwd: '/tmp', toolCallId: 'tool-1',
+      abortSignal: new AbortController().signal,
+      emitOutput: (_stream, chunk) => output.push(chunk),
+      spawnChildAgent: async (input) => {
+        for (let index = 0; index < 100; index += 1) {
+          input.onEvent?.({
+            type: 'tool_start', id: `start-${index}`, turnId: 'child-turn', ts: index,
+            toolUseId: `child-tool-${index}`, toolName: 'Read', args: { path: `${index}.txt` },
+          });
+        }
+        return {
+          agentId: input.spec.id, agentName: input.spec.name, turnId: 'child-turn',
+          status: 'completed', permissionMode: 'explore', summary: 'done', artifactIds: [],
+        };
+      },
+    });
+
+    expect(output).toHaveLength(66);
+    expect(output[0]).toBe('Starting child agent: Local Read\n');
+    expect(output.at(-1)).toBe('Child agent Local Read: completed\n');
+  });
+
+  test('agent_spawn bounds projected startup failures', async () => {
+    const tool = buildSubagentSpawnTool();
+    const output: string[] = [];
+
+    await expectRejects(Promise.resolve(tool.impl({
+      profile: LOCAL_READ_AGENT_PROFILE,
+      task: 'Fail.',
+    }, {
+      sessionId: 'session-1', turnId: 'parent-turn', cwd: '/tmp', toolCallId: 'tool-1',
+      abortSignal: new AbortController().signal,
+      emitOutput: (_stream, chunk) => output.push(chunk),
+      spawnChildAgent: async () => { throw new Error('x'.repeat(10_000)); },
+    })), /^x+$/);
+
+    expect(output).toHaveLength(2);
+    expect((output[1]?.length ?? Number.POSITIVE_INFINITY) < 1_100).toBe(true);
   });
 
   test('agent_spawn delegates web_research through the catalog definition', async () => {
@@ -436,14 +506,19 @@ describe('subagent tools', () => {
       },
     });
 
-    expect(calls).toEqual([{
-      spec: {
-        id: WEB_RESEARCH_AGENT_ID,
-        name: 'Web Research',
-        systemPrompt: WEB_RESEARCH_AGENT_DEFINITION.systemPrompt,
-      },
-      prompt: 'Find current sources.',
-    }]);
+    expect(calls).toHaveLength(1);
+    const call = calls[0] as {
+      spec: unknown;
+      prompt: string;
+      onEvent?: (event: SessionEvent) => void;
+    };
+    expect(call.spec).toEqual({
+      id: WEB_RESEARCH_AGENT_ID,
+      name: 'Web Research',
+      systemPrompt: WEB_RESEARCH_AGENT_DEFINITION.systemPrompt,
+    });
+    expect(call.prompt).toBe('Find current sources.');
+    expect(typeof call.onEvent).toBe('function');
     expect(result).toMatchObject({
       kind: 'subagent',
       agentId: WEB_RESEARCH_AGENT_ID,

--- a/packages/runtime/src/ai-sdk-backend.ts
+++ b/packages/runtime/src/ai-sdk-backend.ts
@@ -772,6 +772,7 @@ export interface AiSdkBackendInput {
     prompt: string;
     abortSignal: AbortSignal;
     onReady?: (input: { turnId: string; agentId: string; agentName: string }) => void | Promise<void>;
+    onEvent?: (event: SessionEvent) => void;
   }) => Promise<unknown>;
   listChildAgents?: () => Promise<unknown>;
   readChildAgentOutput?: (input: { runId?: string; turnId?: string; maxEvents?: number }) => Promise<unknown>;

--- a/packages/runtime/src/session-manager.ts
+++ b/packages/runtime/src/session-manager.ts
@@ -107,6 +107,8 @@ export interface SpawnChildAgentInput {
   prompt: string;
   abortSignal?: AbortSignal;
   onReady?: (input: { turnId: string; agentId: string; agentName: string }) => void | Promise<void>;
+  /** Presentation-only observer for projecting child activity into a parent surface. */
+  onEvent?: (event: SessionEvent) => void;
 }
 
 export interface SpawnChildAgentResult {
@@ -648,6 +650,11 @@ export class SessionManager {
         const next = await iterator.next();
         if (next.done) break;
         summary.add(next.value);
+        try {
+          input.onEvent?.(next.value);
+        } catch {
+          // A presentation observer must not change the child run outcome.
+        }
       }
     } finally {
       input.abortSignal?.removeEventListener('abort', onAbort);

--- a/packages/runtime/src/subagent-tools.ts
+++ b/packages/runtime/src/subagent-tools.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 import { TASK_ID_MAX_CHARS, isSafeTaskId, type TaskLedgerStore, type ToolResultContent } from '@maka/core';
-import type { MakaTool } from './tool-runtime.js';
+import type { SessionEvent } from '@maka/core/events';
+import type { MakaTool, MakaToolContext } from './tool-runtime.js';
 import {
   AGENT_WORKSPACE_SAME_WORKSPACE,
   AGENT_WORKSPACE_WORKTREE,
@@ -32,6 +33,9 @@ export const CHILD_AGENT_TOOL_NAMES = [
 ] as readonly string[];
 const AGENT_SPAWN_WRITE_BACK_MODES = [AGENT_WRITE_BACK_SUMMARY, AGENT_WRITE_BACK_PATCH] as const;
 const AGENT_SPAWN_ISOLATION_MODES = [AGENT_WORKSPACE_SAME_WORKSPACE, AGENT_WORKSPACE_WORKTREE] as const;
+const CHILD_PROGRESS_MAX_EVENTS = 64;
+const CHILD_PROGRESS_MAX_CHARS = 8_192;
+const CHILD_PROGRESS_ERROR_MAX_CHARS = 1_000;
 
 type SubagentToolResult = Extract<ToolResultContent, { kind: 'subagent' }>;
 
@@ -128,6 +132,8 @@ export function buildSubagentSpawnTool(deps: { taskLedger?: TaskLedgerStore } = 
       if (input.task_id && !boundTask) throw new Error(`No such task in this session: ${input.task_id}`);
       let claimedOwner: { actor: 'child_agent'; agentId: string; turnId: string } | undefined;
       let result: Omit<SubagentToolResult, 'kind'>;
+      const progress = new ChildAgentProgressProjector(ctx);
+      ctx.emitOutput('stdout', `Starting child agent: ${definition.name}\n`);
       try {
         result = await ctx.spawnChildAgent({
           spec: {
@@ -150,8 +156,13 @@ export function buildSubagentSpawnTool(deps: { taskLedger?: TaskLedgerStore } = 
               claimedOwner = owner;
             },
           } : {}),
+          onEvent: (event) => progress.observe(event),
         }) as Omit<SubagentToolResult, 'kind'>;
       } catch (error) {
+        ctx.emitOutput(
+          'stderr',
+          `Child agent ${definition.name} failed: ${boundedChildError(error)}\n`,
+        );
         if (boundTask && claimedOwner) {
           await deps.taskLedger!.settleAgentOutcome(ctx.sessionId, boundTask.id, {
             status: 'failed',
@@ -166,6 +177,7 @@ export function buildSubagentSpawnTool(deps: { taskLedger?: TaskLedgerStore } = 
         }
         throw error;
       }
+      ctx.emitOutput('stdout', `Child agent ${definition.name}: ${result.status}\n`);
       if (boundTask && claimedOwner) {
         const owner = {
           ...claimedOwner,
@@ -190,6 +202,45 @@ export function buildSubagentSpawnTool(deps: { taskLedger?: TaskLedgerStore } = 
       } satisfies SubagentToolResult;
     },
   };
+}
+
+class ChildAgentProgressProjector {
+  private readonly tools = new Map<string, string>();
+  private projectedEvents = 0;
+  private projectedChars = 0;
+
+  constructor(private readonly ctx: Pick<MakaToolContext, 'emitOutput'>) {}
+
+  observe(event: SessionEvent): void {
+    if (this.projectedEvents >= CHILD_PROGRESS_MAX_EVENTS) return;
+    if (event.type === 'tool_start') {
+      const name = event.displayName ?? event.toolName;
+      this.tools.set(event.toolUseId, name);
+      this.emit('stdout', `Child tool started: ${name}\n`);
+      return;
+    }
+    if (event.type === 'tool_result') {
+      const name = this.tools.get(event.toolUseId) ?? 'tool';
+      this.tools.delete(event.toolUseId);
+      this.emit(event.isError ? 'stderr' : 'stdout', `Child tool ${event.isError ? 'failed' : 'finished'}: ${name}\n`);
+    }
+  }
+
+  private emit(stream: 'stdout' | 'stderr', chunk: string): void {
+    const remaining = CHILD_PROGRESS_MAX_CHARS - this.projectedChars;
+    if (remaining <= 0) return;
+    const bounded = chunk.slice(0, remaining);
+    this.projectedEvents += 1;
+    this.projectedChars += bounded.length;
+    this.ctx.emitOutput(stream, bounded);
+  }
+}
+
+function boundedChildError(error: unknown): string {
+  const message = error instanceof Error ? error.message : 'unknown error';
+  return message.length <= CHILD_PROGRESS_ERROR_MAX_CHARS
+    ? message
+    : `${message.slice(0, CHILD_PROGRESS_ERROR_MAX_CHARS - 1)}…`;
 }
 
 export function buildSubagentListTool(): MakaTool<Record<string, never>, unknown> {

--- a/packages/runtime/src/tool-runtime.ts
+++ b/packages/runtime/src/tool-runtime.ts
@@ -138,6 +138,7 @@ export interface MakaToolContext {
     spec: AgentSpec;
     prompt: string;
     onReady?: (input: { turnId: string; agentId: string; agentName: string }) => void | Promise<void>;
+    onEvent?: (event: SessionEvent) => void;
   }) => Promise<unknown>;
   listChildAgents?: () => Promise<unknown>;
   readChildAgentOutput?: (input: { runId?: string; turnId?: string; maxEvents?: number }) => Promise<unknown>;
@@ -210,6 +211,7 @@ export interface ToolRuntimeInput {
     prompt: string;
     abortSignal: AbortSignal;
     onReady?: (input: { turnId: string; agentId: string; agentName: string }) => void | Promise<void>;
+    onEvent?: (event: SessionEvent) => void;
   }) => Promise<unknown>;
   listChildAgents?: () => Promise<unknown>;
   readChildAgentOutput?: (input: { runId?: string; turnId?: string; maxEvents?: number }) => Promise<unknown>;
@@ -1287,6 +1289,7 @@ export class ToolRuntime {
         prompt: input.prompt,
         abortSignal,
         ...(input.onReady ? { onReady: input.onReady } : {}),
+        ...(input.onEvent ? { onEvent: input.onEvent } : {}),
       }) ?? Promise.reject(new Error('spawnChildAgent is unavailable')),
     };
   }


### PR DESCRIPTION
## Summary

- register the deferred Agent tool group only on the interactive TUI surface and bind spawn/list/output capabilities to the current session
- give child runs a fresh catalog-filtered file-only tool surface with no shell, write, runtime-resource, or nested-agent access
- project bounded child tool activity into the existing parent tool card and preserve completed, failed, and cancelled states across live updates and stored replay

Closes #1102

## Verification

- `npm --workspace @maka/runtime run test:dist` (2107 passed, 7 skipped)
- `npm --workspace maka-agent run test:dist` (507 passed)
- `npm --workspace @maka/runtime run typecheck`
- `npm --workspace maka-agent run typecheck`
- `npm run lint`
- `git diff --check`

Root `npm run typecheck` reaches and passes the affected workspaces, then stops on nine pre-existing desktop test calls that still pass the removed `LocaleProvider locale` prop.

## Review Focus

The new child-event observer is presentation-only and best-effort. The TUI projection exposes tool names and lifecycle states only; it does not forward child args or result payloads, and it caps projected events, characters, and startup errors.