### PR TITLE
feat(cli): redesign onboarding wizard around the input field

### DIFF
--- a/packages/cli/src/__tests__/onboarding.test.ts
+++ b/packages/cli/src/__tests__/onboarding.test.ts
@@ -65,6 +65,34 @@ describe('setupApiKeyConnection', () => {
     assert.equal(result.testError, 'HTTP 401');
   });
 
+  test('a failing probe does not make the broken connection the default', async () => {
+    const setDefaultCalls: string[] = [];
+    const result = await setupApiKeyConnection({
+      providerType: 'openai',
+      slug: 'openai',
+      apiKey: 'sk-typo',
+      connectionStore: {
+        get: async () => null,
+        create: async (input) => makeConnection({ slug: input.slug, providerType: input.providerType }),
+        remove: async () => {},
+        getDefault: async () => null,
+        setDefault: async (slug) => {
+          if (slug) setDefaultCalls.push(slug);
+        },
+      } satisfies Pick<ConnectionStore, 'create' | 'get' | 'remove' | 'getDefault' | 'setDefault'>,
+      credentialStore: {
+        setSecret: async () => {},
+      } satisfies Pick<CredentialStore, 'setSecret'>,
+      fetchModels: async () => { throw new Error('HTTP 401'); },
+    });
+
+    // The connection is saved (retrying rotates the key), but a broken key
+    // must NOT become the default — otherwise the host would report it as
+    // configured and trap the next launch out of onboarding.
+    assert.equal(result.testError, 'HTTP 401');
+    assert.deepEqual(setDefaultCalls, []);
+  });
+
   test('rejects a provider that does not accept an API key before touching the stores', async () => {
     let created = false;
     let stored = false;

--- a/packages/cli/src/__tests__/pi-tui-runner.test.ts
+++ b/packages/cli/src/__tests__/pi-tui-runner.test.ts
@@ -808,6 +808,120 @@ describe('Maka Pi TUI runner', () => {
     ]);
   });
 
+  test('first-run wizard reopens on Alt+Enter after a slash escape (no agent turn)', async () => {
+    const terminal = new FakeTerminal();
+    const driver = new SlashCommandDriver();
+    let preparePromptCalls = 0;
+    driver.preparePrompt = async () => {
+      preparePromptCalls += 1;
+      throw new Error('first-run onboarding: no agent turn before a connection exists');
+    };
+    const run = runMakaPiTui({
+      title: 'Maka',
+      driver,
+      cwd: '/repo',
+      model: '',
+      connectionSlug: '',
+      permissionMode: 'bypass',
+      terminal,
+      firstRun: true,
+      onboarding: { setup: async () => ({}) },
+    });
+
+    await waitFor(() => {
+      try {
+        return latestPlainLineContaining(terminal.writes.join(''), 'Set Up Provider') !== null;
+      } catch {
+        return false;
+      }
+    });
+    terminal.input('\r'); // pick provider -> key phase
+    await waitFor(() => {
+      try {
+        return latestPlainLineContaining(terminal.writes.join(''), 'API key') !== null;
+      } catch {
+        return false;
+      }
+    });
+
+    // Slash escapes and closes the wizard; Alt+Enter must go through the same
+    // submitPrompt choke point as Enter and reopen the wizard, not hand the
+    // prompt to a connection-less driver.
+    terminal.input('/help');
+    terminal.input('\r');
+    await waitFor(() => {
+      try {
+        return latestPlainLineContaining(terminal.writes.join(''), 'Keybindings') !== null;
+      } catch {
+        return false;
+      }
+    });
+
+    terminal.input('hello');
+    terminal.input('\x1b\r'); // Alt+Enter
+    await delay(40);
+    assert.equal(preparePromptCalls, 0);
+    assert.ok(plainTerminalOutput(terminal.screenOutput()).includes('Set Up Provider'));
+
+    process.emit('SIGTERM');
+    await Promise.race([
+      run,
+      delay(500).then(() => { throw new Error('TUI did not close after SIGTERM'); }),
+    ]);
+  });
+
+  test('first-run /exit in the main editor after a slash escape still exits the TUI', async () => {
+    const terminal = new FakeTerminal();
+    const driver = new SlashCommandDriver();
+    const run = runMakaPiTui({
+      title: 'Maka',
+      driver,
+      cwd: '/repo',
+      model: '',
+      connectionSlug: '',
+      permissionMode: 'bypass',
+      terminal,
+      firstRun: true,
+      onboarding: { setup: async () => ({}) },
+    });
+
+    await waitFor(() => {
+      try {
+        return latestPlainLineContaining(terminal.writes.join(''), 'Set Up Provider') !== null;
+      } catch {
+        return false;
+      }
+    });
+    terminal.input('\r'); // pick provider -> key phase
+    await waitFor(() => {
+      try {
+        return latestPlainLineContaining(terminal.writes.join(''), 'API key') !== null;
+      } catch {
+        return false;
+      }
+    });
+
+    // Slash escape in the key field closes the wizard and shows help.
+    terminal.input('/help');
+    terminal.input('\r');
+    await waitFor(() => {
+      try {
+        return latestPlainLineContaining(terminal.writes.join(''), 'Keybindings') !== null;
+      } catch {
+        return false;
+      }
+    });
+
+    // Now the main editor is active. /exit must reach the command layer, not
+    // be swallowed by the first-run guard that would reopen the wizard.
+    terminal.input('/exit');
+    terminal.input('\r');
+    await Promise.race([
+      run,
+      delay(500).then(() => { throw new Error('/exit did not close the first-run TUI'); }),
+    ]);
+  });
+
   test('onboarding wizard cancels on Ctrl+C as well as Esc (first-run closes the TUI)', async () => {
     const terminal = new FakeTerminal();
     const driver = new SlashCommandDriver();
@@ -837,6 +951,46 @@ describe('Maka Pi TUI runner', () => {
     await Promise.race([
       run,
       delay(500).then(() => { throw new Error('Ctrl+C did not close the first-run wizard'); }),
+    ]);
+  });
+
+  test('onboarding wizard key-phase Ctrl+C cancels while Esc returns to search', async () => {
+    const terminal = new FakeTerminal();
+    const driver = new SlashCommandDriver();
+    const run = runMakaPiTui({
+      title: 'Maka',
+      driver,
+      cwd: '/repo',
+      model: '',
+      connectionSlug: '',
+      permissionMode: 'bypass',
+      terminal,
+      firstRun: true,
+      onboarding: { setup: async () => ({}) },
+    });
+
+    await waitFor(() => {
+      try {
+        return latestPlainLineContaining(terminal.writes.join(''), 'Set Up Provider') !== null;
+      } catch {
+        return false;
+      }
+    });
+    terminal.input('\r'); // pick provider -> key phase
+    await waitFor(() => {
+      try {
+        return latestPlainLineContaining(terminal.writes.join(''), 'API key') !== null;
+      } catch {
+        return false;
+      }
+    });
+
+    // In the key phase, Ctrl+C cancels the whole wizard (first-run closes the
+    // TUI), matching the overlay cancel contract; Esc only returns to search.
+    terminal.input('\x03');
+    await Promise.race([
+      run,
+      delay(500).then(() => { throw new Error('Ctrl+C did not close the first-run wizard from the key phase'); }),
     ]);
   });
 

--- a/packages/cli/src/__tests__/pi-tui-runner.test.ts
+++ b/packages/cli/src/__tests__/pi-tui-runner.test.ts
@@ -581,6 +581,169 @@ describe('Maka Pi TUI runner', () => {
     ]);
   });
 
+  test('onboarding wizard filters the provider list as you type in the search field', async () => {
+    const terminal = new FakeTerminal();
+    const driver = new SlashCommandDriver();
+    const run = runMakaPiTui({
+      title: 'Maka',
+      driver,
+      cwd: '/repo',
+      model: '',
+      connectionSlug: '',
+      permissionMode: 'bypass',
+      terminal,
+      firstRun: true,
+      onboarding: { setup: async () => ({}) },
+    });
+
+    await waitFor(() => {
+      try {
+        return latestPlainLineContaining(terminal.writes.join(''), 'Set Up Provider') !== null;
+      } catch {
+        return false;
+      }
+    });
+    const before = plainTerminalOutput(terminal.screenOutput());
+    assert.ok(before.includes('Anthropic'));
+    assert.ok(before.includes('DeepSeek'));
+
+    // Typing in the wizard's search field filters the provider list live: the
+    // unmatched providers leave the list while the match stays.
+    terminal.input('anth');
+    await waitFor(() => {
+      const out = plainTerminalOutput(terminal.screenOutput());
+      return out.includes('Anthropic') && !out.includes('DeepSeek');
+    });
+
+    process.emit('SIGTERM');
+    await Promise.race([
+      run,
+      delay(500).then(() => { throw new Error('TUI did not close after SIGTERM'); }),
+    ]);
+  });
+
+  test('onboarding wizard keeps verifying/failure status beside the input, out of the transcript', async () => {
+    const terminal = new FakeTerminal();
+    const driver = new SlashCommandDriver();
+    const setupCalls: Array<{ apiKey: string }> = [];
+    const run = runMakaPiTui({
+      title: 'Maka',
+      driver,
+      cwd: '/repo',
+      model: 'claude-sonnet-4-5',
+      connectionSlug: 'claude-subscription',
+      permissionMode: 'bypass',
+      terminal,
+      onboarding: {
+        setup: async (req) => {
+          setupCalls.push({ apiKey: req.apiKey });
+          return setupCalls.length === 1 ? { testError: 'HTTP 401 Unauthorized' } : {};
+        },
+      },
+    });
+
+    await delay(20);
+    terminal.input('/setup');
+    terminal.input('\r');
+    await waitFor(() => {
+      try {
+        return latestPlainLineContaining(terminal.writes.join(''), 'Set Up Provider') !== null;
+      } catch {
+        return false;
+      }
+    });
+    terminal.input('\r'); // pick the highlighted provider -> key phase
+    await waitFor(() => {
+      try {
+        return latestPlainLineContaining(terminal.writes.join(''), 'API key') !== null;
+      } catch {
+        return false;
+      }
+    });
+
+    // A failing probe surfaces the error beside the key field (wizard overlay).
+    terminal.input('sk-bad');
+    terminal.input('\r');
+    await waitFor(() => setupCalls.length === 1);
+    await waitFor(() => {
+      try {
+        return latestPlainLineContaining(terminal.writes.join(''), '验证失败') !== null;
+      } catch {
+        return false;
+      }
+    });
+
+    // A succeeding retry closes the wizard. The in-flight failure status lived
+    // only in the overlay, so once it closes it leaves no residue in the
+    // transcript — only the completed-configuration event remains on screen.
+    terminal.input('sk-good');
+    terminal.input('\r');
+    await waitFor(() => setupCalls.length === 2);
+    await waitFor(() => {
+      try {
+        return latestPlainLineContaining(terminal.writes.join(''), '已配置') !== null;
+      } catch {
+        return false;
+      }
+    });
+
+    assert.doesNotMatch(plainTerminalOutput(terminal.screenOutput()), /验证失败/);
+
+    process.emit('SIGTERM');
+    await Promise.race([
+      run,
+      delay(500).then(() => { throw new Error('TUI did not close after SIGTERM'); }),
+    ]);
+  });
+
+  test('onboarding wizard key Esc returns to the provider search', async () => {
+    const terminal = new FakeTerminal();
+    const driver = new SlashCommandDriver();
+    const run = runMakaPiTui({
+      title: 'Maka',
+      driver,
+      cwd: '/repo',
+      model: 'claude-sonnet-4-5',
+      connectionSlug: 'claude-subscription',
+      permissionMode: 'bypass',
+      terminal,
+      onboarding: { setup: async () => ({}) },
+    });
+
+    await delay(20);
+    terminal.input('/setup');
+    terminal.input('\r');
+    await waitFor(() => {
+      try {
+        return latestPlainLineContaining(terminal.writes.join(''), 'Set Up Provider') !== null;
+      } catch {
+        return false;
+      }
+    });
+    terminal.input('\r'); // pick the highlighted provider -> key phase
+    await waitFor(() => {
+      try {
+        return latestPlainLineContaining(terminal.writes.join(''), 'API key') !== null;
+      } catch {
+        return false;
+      }
+    });
+
+    // Esc from the key field returns to the search phase: the step marker is
+    // back to 1/2 and the provider list is visible again.
+    terminal.input('\x1b');
+    await waitFor(() => {
+      const out = plainTerminalOutput(terminal.screenOutput());
+      return out.includes('1/2') && out.includes('Anthropic');
+    });
+
+    process.emit('SIGTERM');
+    await Promise.race([
+      run,
+      delay(500).then(() => { throw new Error('TUI did not close after SIGTERM'); }),
+    ]);
+  });
+
   test('allows a pending permission request from the terminal', async () => {
     const terminal = new FakeTerminal();
     const driver = new PermissionPromptDriver();

--- a/packages/cli/src/__tests__/pi-tui-runner.test.ts
+++ b/packages/cli/src/__tests__/pi-tui-runner.test.ts
@@ -744,6 +744,161 @@ describe('Maka Pi TUI runner', () => {
     ]);
   });
 
+  test('first-run wizard never reaches an agent turn after a slash command escapes the key field', async () => {
+    const terminal = new FakeTerminal();
+    const driver = new SlashCommandDriver();
+    let preparePromptCalls = 0;
+    driver.preparePrompt = async () => {
+      preparePromptCalls += 1;
+      throw new Error('first-run onboarding: no agent turn before a connection exists');
+    };
+    const run = runMakaPiTui({
+      title: 'Maka',
+      driver,
+      cwd: '/repo',
+      model: '',
+      connectionSlug: '',
+      permissionMode: 'bypass',
+      terminal,
+      firstRun: true,
+      onboarding: { setup: async () => ({}) },
+    });
+
+    await waitFor(() => {
+      try {
+        return latestPlainLineContaining(terminal.writes.join(''), 'Set Up Provider') !== null;
+      } catch {
+        return false;
+      }
+    });
+    terminal.input('\r'); // pick provider -> key phase
+    await waitFor(() => {
+      try {
+        return latestPlainLineContaining(terminal.writes.join(''), 'API key') !== null;
+      } catch {
+        return false;
+      }
+    });
+
+    // A slash command typed in the key field escapes the wizard (designed, so
+    // /exit still works). But after it closes, first-run must not hand control
+    // to a connection-less driver: any later submit reopens the wizard instead
+    // of opening an agent turn.
+    terminal.input('/help');
+    terminal.input('\r');
+    await waitFor(() => {
+      try {
+        return latestPlainLineContaining(terminal.writes.join(''), 'Keybindings') !== null;
+      } catch {
+        return false;
+      }
+    });
+
+    terminal.input('hello');
+    terminal.input('\r');
+    await delay(40);
+    assert.equal(preparePromptCalls, 0);
+    // The wizard is back open as the only first-run surface.
+    assert.ok(plainTerminalOutput(terminal.screenOutput()).includes('Set Up Provider'));
+
+    process.emit('SIGTERM');
+    await Promise.race([
+      run,
+      delay(500).then(() => { throw new Error('TUI did not close after SIGTERM'); }),
+    ]);
+  });
+
+  test('onboarding wizard cancels on Ctrl+C as well as Esc (first-run closes the TUI)', async () => {
+    const terminal = new FakeTerminal();
+    const driver = new SlashCommandDriver();
+    const run = runMakaPiTui({
+      title: 'Maka',
+      driver,
+      cwd: '/repo',
+      model: '',
+      connectionSlug: '',
+      permissionMode: 'bypass',
+      terminal,
+      firstRun: true,
+      onboarding: { setup: async () => ({}) },
+    });
+
+    await waitFor(() => {
+      try {
+        return latestPlainLineContaining(terminal.writes.join(''), 'Set Up Provider') !== null;
+      } catch {
+        return false;
+      }
+    });
+
+    // The overlay cancel contract is Esc AND Ctrl+C (pi-tui `tui.select.cancel`);
+    // in first-run, Ctrl+C must close the TUI like Esc does, not be swallowed.
+    terminal.input('\x03');
+    await Promise.race([
+      run,
+      delay(500).then(() => { throw new Error('Ctrl+C did not close the first-run wizard'); }),
+    ]);
+  });
+
+  test('onboarding wizard ignores a setup result from an abandoned attempt', async () => {
+    const terminal = new FakeTerminal();
+    const driver = new SlashCommandDriver();
+    const setupCalls: Array<{ apiKey: string }> = [];
+    let resolveFirst!: (value: { testError?: string }) => void;
+    const run = runMakaPiTui({
+      title: 'Maka',
+      driver,
+      cwd: '/repo',
+      model: 'claude-sonnet-4-5',
+      connectionSlug: 'claude-subscription',
+      permissionMode: 'bypass',
+      terminal,
+      onboarding: {
+        setup: (req) => {
+          setupCalls.push({ apiKey: req.apiKey });
+          // First attempt stays in flight (deferred); the user abandons it.
+          return setupCalls.length === 1
+            ? new Promise((r) => { resolveFirst = r; })
+            : Promise.resolve({});
+        },
+      },
+    });
+
+    await delay(20);
+    terminal.input('/setup');
+    terminal.input('\r');
+    await waitFor(() => { try { return latestPlainLineContaining(terminal.writes.join(''), 'Set Up Provider') !== null; } catch { return false; } });
+    terminal.input('\r'); // pick provider A -> key phase
+    await waitFor(() => { try { return latestPlainLineContaining(terminal.writes.join(''), 'API key') !== null; } catch { return false; } });
+
+    terminal.input('sk-a');
+    terminal.input('\r'); // submit A — probe deferred, wizard shows verifying
+    await waitFor(() => setupCalls.length === 1);
+    await waitFor(() => { try { return latestPlainLineContaining(terminal.writes.join(''), '验证') !== null; } catch { return false; } });
+
+    // Abandon A: Esc back to search, move to the second provider, pick it, and
+    // start typing its key (do not submit).
+    terminal.input('\x1b');
+    await waitFor(() => { try { return latestPlainLineContaining(terminal.writes.join(''), '1/2') !== null; } catch { return false; } });
+    terminal.input('\x1b[B'); // down to the second provider
+    terminal.input('\r');
+    await waitFor(() => { try { return latestPlainLineContaining(terminal.writes.join(''), 'API key') !== null; } catch { return false; } });
+    terminal.input('sk-b');
+    await waitFor(() => plainTerminalOutput(terminal.screenOutput()).includes('sk-b'));
+
+    // A's probe now resolves with a failure. It must not clobber attempt B:
+    // no failure status line, and the key being typed for B survives.
+    resolveFirst({ testError: 'HTTP 401 Unauthorized' });
+    await delay(40);
+
+    const out = plainTerminalOutput(terminal.screenOutput());
+    assert.doesNotMatch(out, /验证失败/);
+    assert.ok(out.includes('sk-b'));
+
+    process.emit('SIGTERM');
+    await Promise.race([run, delay(500).then(() => { throw new Error('TUI did not close after SIGTERM'); })]);
+  });
+
   test('allows a pending permission request from the terminal', async () => {
     const terminal = new FakeTerminal();
     const driver = new PermissionPromptDriver();

--- a/packages/cli/src/onboarding.ts
+++ b/packages/cli/src/onboarding.ts
@@ -58,9 +58,12 @@ export async function setupApiKeyConnection(
     if (!existing) await input.connectionStore.remove(input.slug);
     throw error;
   }
-  await input.connectionStore.setDefault(input.slug);
   try {
     const models = await input.fetchModels(connection, input.apiKey);
+    // Only a verified connection becomes the default: a probe failure leaves
+    // the host's getDefault() accurate so a cancelled first-run attempt does
+    // not trap the next launch out of onboarding.
+    await input.connectionStore.setDefault(input.slug);
     return { connection, models };
   } catch (error) {
     return { connection, models: [], testError: error instanceof Error ? error.message : String(error) };

--- a/packages/cli/src/pi-tui-pickers.ts
+++ b/packages/cli/src/pi-tui-pickers.ts
@@ -503,8 +503,7 @@ export type OnboardingWizardPhase = 'search' | 'key';
 export type OnboardingWizardStatus =
   | { kind: 'prompt' }
   | { kind: 'verifying' }
-  | { kind: 'error'; text: string }
-  | { kind: 'ok'; text: string };
+  | { kind: 'error'; text: string };
 
 export interface OnboardingWizardInput {
   providers: readonly OnboardableProvider[];
@@ -590,7 +589,7 @@ export class OnboardingWizard implements Component {
   }
 
   /** Runner hook: the probe settled. An error re-arms the key field in place. */
-  setResult(result: { kind: 'ok'; text: string } | { kind: 'error'; text: string }): void {
+  setResult(result: { kind: 'error'; text: string }): void {
     this.status = result;
     if (result.kind === 'error') {
       this.keyEditor.disableSubmit = false;
@@ -609,7 +608,7 @@ export class OnboardingWizard implements Component {
       this.handleKeyInput(data);
       return;
     }
-    if (matchesKey(data, Key.escape)) {
+    if (matchesKey(data, Key.escape) || matchesKey(data, Key.ctrl('c'))) {
       this.input.onCancel();
       return;
     }
@@ -629,7 +628,7 @@ export class OnboardingWizard implements Component {
   }
 
   private handleKeyInput(data: string): void {
-    if (matchesKey(data, Key.escape)) {
+    if (matchesKey(data, Key.escape) || matchesKey(data, Key.ctrl('c'))) {
       this.phase = 'search';
       this.picked = undefined;
       this.status = { kind: 'prompt' };
@@ -638,6 +637,10 @@ export class OnboardingWizard implements Component {
       this.input.onBack();
       return;
     }
+    // The probe owns the key field while it is in flight: disableSubmit only
+    // blocks Enter, so swallow the rest too — otherwise typed text renders and
+    // is then silently wiped by the error path's setText('').
+    if (this.status.kind === 'verifying') return;
     this.keyEditor.handleInput(data);
   }
 
@@ -655,15 +658,17 @@ export class OnboardingWizard implements Component {
       padLine('', width),
       ...this.renderFieldRow(this.searchEditor, '搜索', width),
       padLine('', width),
-      ...this.list.render(width).map((line) => formatPickerItemLine(line, width)),
+      ...(this.filtered.length === 0
+        ? [padLine(ansi.dim('没有匹配的服务商'), width)]
+        : this.list.render(width).map((line) => formatPickerItemLine(line, width))),
       padLine(ansi.accent('-'.repeat(width)), width),
     ];
   }
 
   private renderKey(width: number): string[] {
     this.searchEditor.focused = false;
-    // The cursor stays hidden once the field is locked (verifying) or settled
-    // (ok); only an editable or errored key field takes focus.
+    // The cursor stays hidden while the probe is in flight; only an editable
+    // or errored key field takes focus.
     this.keyEditor.focused = this.status.kind === 'prompt' || this.status.kind === 'error';
     const label = this.picked?.label ?? '';
     return [
@@ -682,7 +687,6 @@ export class OnboardingWizard implements Component {
       case 'prompt': return ansi.dim('Enter 提交');
       case 'verifying': return `${ansi.yellow('⠋')} 正在验证 key…`;
       case 'error': return ansi.red(`✗ ${this.status.text}`);
-      case 'ok': return ansi.green(`✓ ${this.status.text}`);
     }
   }
 

--- a/packages/cli/src/pi-tui-pickers.ts
+++ b/packages/cli/src/pi-tui-pickers.ts
@@ -19,10 +19,11 @@ import type { UserQuestionOption } from '@maka/core';
 import { PERMISSION_MODES, type PermissionMode } from '@maka/core/permission';
 import type { ThinkingLevel } from '@maka/core/model-thinking';
 import type { InvocableSkillEntry } from '@maka/runtime';
+import type { ProviderType } from '@maka/core/llm-connections';
 import type { ModelChoice } from './connection-target.js';
 import type { OnboardableProvider } from './onboarding.js';
 import { skillInvocationPrefixAt } from './skill-token.js';
-import { ansi, editorTheme, stripAnsi } from './tui-ansi.js';
+import { ansi, editorTheme, selectListTheme, stripAnsi } from './tui-ansi.js';
 
 export class MakaAutocompleteProvider implements AutocompleteProvider {
   private readonly fileProvider: CombinedAutocompleteProvider;
@@ -495,4 +496,206 @@ function padLine(text: string, width: number): string {
   const safeWidth = Math.max(1, width);
   const trimmed = visibleWidth(text) > safeWidth ? truncateToWidth(text, safeWidth, '') : text;
   return `${trimmed}${' '.repeat(Math.max(0, safeWidth - visibleWidth(trimmed)))}`;
+}
+
+export type OnboardingWizardPhase = 'search' | 'key';
+
+export type OnboardingWizardStatus =
+  | { kind: 'prompt' }
+  | { kind: 'verifying' }
+  | { kind: 'error'; text: string }
+  | { kind: 'ok'; text: string };
+
+export interface OnboardingWizardInput {
+  providers: readonly OnboardableProvider[];
+  /** search→key: the user picked a provider. The runner records it for setup. */
+  onPickProvider: (providerType: ProviderType) => void;
+  /** key submit: the runner runs onboarding.setup with the recorded provider. */
+  onSubmitKey: (apiKey: string) => void;
+  /** search Esc: the runner closes the wizard (and the TUI on first run). */
+  onCancel: () => void;
+  /** key Esc: the wizard already returned to search; the runner may react. */
+  onBack: () => void;
+}
+
+/**
+ * One input field, two phases. The same overlay is the search box (filter the
+ * provider list as you type) and then the key field, so onboarding never pushes
+ * its prompt/verifying/failure notices into the transcript. Status lives in a
+ * single status line beside the field instead of the top entry flow (#1098 UX).
+ */
+export class OnboardingWizard implements Component {
+  private phase: OnboardingWizardPhase = 'search';
+  private picked: OnboardableProvider | undefined;
+  private status: OnboardingWizardStatus = { kind: 'prompt' };
+  private readonly searchEditor: Editor;
+  private readonly keyEditor: Editor;
+  private filtered: readonly OnboardableProvider[];
+  private list: SelectList;
+
+  constructor(
+    private readonly tui: TUI,
+    private readonly input: OnboardingWizardInput,
+  ) {
+    this.filtered = input.providers;
+    this.list = this.buildList();
+    this.searchEditor = new Editor(tui, editorTheme(), { paddingX: 0 });
+    // editor.onChange fires on every keystroke: refilter the provider list in
+    // place. SelectList has no setItems, so rebuild it; the next render picks
+    // the new instance up.
+    this.searchEditor.onChange = (text) => this.applyQuery(text);
+    this.keyEditor = new Editor(tui, editorTheme(), { paddingX: 0 });
+    this.keyEditor.onSubmit = (value) => {
+      if (this.picked && value) this.input.onSubmitKey(value);
+    };
+  }
+
+  private buildList(): SelectList {
+    const list = new SelectList(
+      onboardableProviderPickerItems(this.filtered),
+      10,
+      selectListTheme(),
+      { minPrimaryColumnWidth: 16, maxPrimaryColumnWidth: 32 },
+    );
+    list.onSelect = (item) => {
+      const provider = this.filtered.find((p) => p.providerType === item.value);
+      if (!provider) return;
+      this.picked = provider;
+      this.phase = 'key';
+      this.status = { kind: 'prompt' };
+      this.keyEditor.setText('');
+      this.keyEditor.disableSubmit = false;
+      this.searchEditor.setText('');
+      this.input.onPickProvider(provider.providerType);
+    };
+    return list;
+  }
+
+  private applyQuery(text: string): void {
+    const query = text.trim().toLowerCase();
+    const next = query
+      ? this.input.providers.filter((p) =>
+        p.label.toLowerCase().includes(query) || p.providerType.toLowerCase().includes(query))
+      : this.input.providers;
+    if (next === this.filtered) return;
+    this.filtered = next;
+    this.list = this.buildList();
+  }
+
+  /** Runner hook: the probe is in flight. Lock the key field and show progress. */
+  setVerifying(): void {
+    if (this.phase !== 'key') return;
+    this.status = { kind: 'verifying' };
+    this.keyEditor.disableSubmit = true;
+  }
+
+  /** Runner hook: the probe settled. An error re-arms the key field in place. */
+  setResult(result: { kind: 'ok'; text: string } | { kind: 'error'; text: string }): void {
+    this.status = result;
+    if (result.kind === 'error') {
+      this.keyEditor.disableSubmit = false;
+      this.keyEditor.setText('');
+    }
+  }
+
+  invalidate(): void {
+    this.searchEditor.invalidate();
+    this.keyEditor.invalidate();
+    this.list.invalidate();
+  }
+
+  handleInput(data: string): void {
+    if (this.phase === 'key') {
+      this.handleKeyInput(data);
+      return;
+    }
+    if (matchesKey(data, Key.escape)) {
+      this.input.onCancel();
+      return;
+    }
+    // Arrows and Enter drive the list (selecting a provider); everything else
+    // is typed into the search field. The search editor therefore never owns
+    // history navigation during the wizard.
+    if (matchesKey(data, Key.up) || matchesKey(data, Key.down)) {
+      this.list.handleInput(data);
+      return;
+    }
+    if (matchesKey(data, Key.enter) || matchesKey(data, Key.return)) {
+      if (isKeyRepeat(data)) return;
+      this.list.handleInput(data);
+      return;
+    }
+    this.searchEditor.handleInput(data);
+  }
+
+  private handleKeyInput(data: string): void {
+    if (matchesKey(data, Key.escape)) {
+      this.phase = 'search';
+      this.picked = undefined;
+      this.status = { kind: 'prompt' };
+      this.keyEditor.setText('');
+      this.keyEditor.disableSubmit = false;
+      this.input.onBack();
+      return;
+    }
+    this.keyEditor.handleInput(data);
+  }
+
+  render(width: number): string[] {
+    const safeWidth = Math.max(1, width);
+    return this.phase === 'search' ? this.renderSearch(safeWidth) : this.renderKey(safeWidth);
+  }
+
+  private renderSearch(width: number): string[] {
+    this.searchEditor.focused = true;
+    this.keyEditor.focused = false;
+    return [
+      padLine(`Set Up Provider ${ansi.dim('· 1/2')} ${ansi.accent(String(this.filtered.length))}`, width),
+      padLine(ansi.dim('搜索服务商，↑↓ 选择 · Enter 确认 · Esc 取消'), width),
+      padLine('', width),
+      ...this.renderFieldRow(this.searchEditor, '搜索', width),
+      padLine('', width),
+      ...this.list.render(width).map((line) => formatPickerItemLine(line, width)),
+      padLine(ansi.accent('-'.repeat(width)), width),
+    ];
+  }
+
+  private renderKey(width: number): string[] {
+    this.searchEditor.focused = false;
+    // The cursor stays hidden once the field is locked (verifying) or settled
+    // (ok); only an editable or errored key field takes focus.
+    this.keyEditor.focused = this.status.kind === 'prompt' || this.status.kind === 'error';
+    const label = this.picked?.label ?? '';
+    return [
+      padLine(`Set Up Provider ${ansi.dim('· 2/2')} ${ansi.accent(label)}`, width),
+      padLine(ansi.dim('输入 API key · 仅本机存储 · Esc 返回选择服务商'), width),
+      padLine('', width),
+      ...this.renderFieldRow(this.keyEditor, 'API key', width),
+      padLine('', width),
+      padLine(this.renderStatusLine(), width),
+      padLine(ansi.accent('-'.repeat(width)), width),
+    ];
+  }
+
+  private renderStatusLine(): string {
+    switch (this.status.kind) {
+      case 'prompt': return ansi.dim('Enter 提交');
+      case 'verifying': return `${ansi.yellow('⠋')} 正在验证 key…`;
+      case 'error': return ansi.red(`✗ ${this.status.text}`);
+      case 'ok': return ansi.green(`✓ ${this.status.text}`);
+    }
+  }
+
+  private renderFieldRow(editor: Editor, label: string, width: number): string[] {
+    const prefix = `${label} `;
+    const prefixWidth = visibleWidth(prefix);
+    const contentWidth = Math.max(1, width - prefixWidth);
+    const editorLines = editor.render(contentWidth).slice(1, -1);
+    if (editorLines.length === 0) {
+      return [padLine(prefix, width)];
+    }
+    return editorLines.map((line, index) => (
+      padLine(`${index === 0 ? prefix : ' '.repeat(prefixWidth)}${line}`, width)
+    ));
+  }
 }

--- a/packages/cli/src/pi-tui-pickers.ts
+++ b/packages/cli/src/pi-tui-pickers.ts
@@ -457,9 +457,7 @@ export function onboardableProviderPickerItems(
   return providers.map((provider) => ({
     value: provider.providerType,
     label: provider.label,
-    description: provider.requiresBaseUrl
-      ? `${provider.providerType} · custom endpoint`
-      : provider.providerType,
+    description: provider.providerType,
   }));
 }
 
@@ -628,7 +626,14 @@ export class OnboardingWizard implements Component {
   }
 
   private handleKeyInput(data: string): void {
-    if (matchesKey(data, Key.escape) || matchesKey(data, Key.ctrl('c'))) {
+    // Ctrl+C cancels the whole wizard (the overlay cancel contract binds both
+    // keys); Esc only returns to the provider search. Both fire while a probe
+    // is in flight, matching pi-tui `tui.select.cancel = [escape, ctrl+c]`.
+    if (matchesKey(data, Key.ctrl('c'))) {
+      this.input.onCancel();
+      return;
+    }
+    if (matchesKey(data, Key.escape)) {
       this.phase = 'search';
       this.picked = undefined;
       this.status = { kind: 'prompt' };

--- a/packages/cli/src/pi-tui-runner.ts
+++ b/packages/cli/src/pi-tui-runner.ts
@@ -829,8 +829,20 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
   let wizardOverlay: OverlayHandle | undefined;
   let wizard: OnboardingWizard | undefined;
   let wizardProviderType: ProviderType | undefined;
+  // Monotonic attempt id: each setup submit captures one, and any transition
+  // that abandons the in-flight attempt (back, re-pick, close) increments it so
+  // a late probe settlement cannot clobber a newer attempt.
+  let wizardAttempt = 0;
 
   editor.onSubmit = (prompt) => {
+    if (input.firstRun) {
+      // First-run has no connection, so the wizard is the only surface. A
+      // submit here — including after a slash command escaped the key field —
+      // must reopen the wizard instead of handing control to a connection-less
+      // driver whose turns only hard-error.
+      showSetupWizard();
+      return;
+    }
     if (turnRunning) {
       steerRunningTurn(prompt);
       return;
@@ -1212,6 +1224,7 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
   };
 
   const closeWizard = (): void => {
+    wizardAttempt += 1; // drop any in-flight setup before clearing the slots
     wizardOverlay?.hide();
     wizardOverlay = undefined;
     wizard = undefined;
@@ -1234,11 +1247,13 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
       requestRender();
       return;
     }
-    wizard.setVerifying();
+    const targetWizard = wizard;
+    const attempt = ++wizardAttempt;
+    targetWizard.setVerifying();
     requestRender();
     void input.onboarding.setup({ providerType, apiKey }).then(
       (result) => {
-        if (!wizard) return;
+        if (wizard !== targetWizard || attempt !== wizardAttempt) return;
         if (result.testError) {
           // Probe failed: re-arm the key field in place — the upsert rotates
           // the key, so retrying does not throw "slug already exists".
@@ -1262,7 +1277,7 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
         requestRender();
       },
       (error) => {
-        if (!wizard) return;
+        if (wizard !== targetWizard || attempt !== wizardAttempt) return;
         wizard.setResult({ kind: 'error', text: `配置失败：${error instanceof Error ? error.message : String(error)}` });
         requestRender();
       },
@@ -1285,6 +1300,7 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
       providers,
       onPickProvider: (providerType) => {
         wizardProviderType = providerType;
+        wizardAttempt += 1; // a new pick supersedes any in-flight attempt
         requestRender();
       },
       onSubmitKey: submitWizardKey,
@@ -1296,6 +1312,7 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
       },
       onBack: () => {
         wizardProviderType = undefined;
+        wizardAttempt += 1; // abandoning the key field invalidates its probe
         requestRender();
       },
     });

--- a/packages/cli/src/pi-tui-runner.ts
+++ b/packages/cli/src/pi-tui-runner.ts
@@ -82,9 +82,9 @@ import {
 } from './pi-tui-layout.js';
 import {
   MakaAutocompleteProvider,
+  OnboardingWizard,
   PickerOverlay,
   UserQuestionOverlay,
-  onboardableProviderPickerItems,
   modelChoicePickerItems,
   modelPickerItems,
   permissionModePickerItems,
@@ -823,73 +823,14 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
     requestRender();
   };
 
-  let pendingKeyEntry: { providerType: ProviderType } | undefined;
+  // Onboarding wizard (#1098 UX redesign): one overlay spans provider search
+  // → API key entry, keeping every prompt/verifying/failure notice beside the
+  // input field instead of the transcript entry flow.
+  let wizardOverlay: OverlayHandle | undefined;
+  let wizard: OnboardingWizard | undefined;
+  let wizardProviderType: ProviderType | undefined;
 
   editor.onSubmit = (prompt) => {
-    if (pendingKeyEntry) {
-      const entry = pendingKeyEntry;
-      // A slash command while the key prompt is armed is routed as a command,
-      // not swallowed as an API key (e.g. /exit must still work).
-      if (prompt.startsWith('/')) {
-        pendingKeyEntry = undefined;
-        handleSlashCommand(prompt);
-        return;
-      }
-      pendingKeyEntry = undefined;
-      if (!input.onboarding) {
-        // Minimal host without an onboarding surface cannot collect a key.
-        state.entries.push({
-          kind: 'notice',
-          level: 'error',
-          text: 'Onboarding 不可用：当前运行环境未提供配置入口。',
-        });
-        requestRender();
-        return;
-      }
-      const providerLabel = PROVIDER_DEFAULTS[entry.providerType]?.label ?? entry.providerType;
-      void input.onboarding.setup({ providerType: entry.providerType, apiKey: prompt }).then(
-        (result) => {
-          if (result.testError) {
-            // Saved but the probe failed (wrong key / offline). Re-arm the key
-            // prompt so the user retries in place — the upsert rotates the key.
-            state.entries.push({
-              kind: 'notice',
-              level: 'error',
-              text: `API key 验证失败：${result.testError}。请检查后重新输入。`,
-            });
-            pendingKeyEntry = entry;
-            requestRender();
-            return;
-          }
-          if (input.firstRun) {
-            beginClose();
-            return;
-          }
-          state.entries.push({
-            kind: 'notice',
-            level: 'info',
-            text: `已配置 ${providerLabel}。新连接将在下次启动 maka 时生效。`,
-          });
-          requestRender();
-        },
-        (error) => {
-          pendingKeyEntry = entry;
-          state.entries.push({
-            kind: 'notice',
-            level: 'error',
-            text: `配置失败：${error instanceof Error ? error.message : String(error)}`,
-          });
-          requestRender();
-        },
-      );
-      return;
-    }
-    if (input.firstRun) {
-      // First-run mode: no agent turn is possible before a connection exists.
-      // Re-open the picker so the only exits are configure or cancel (Esc).
-      showSetupPicker();
-      return;
-    }
     if (turnRunning) {
       steerRunningTurn(prompt);
       return;
@@ -1270,7 +1211,65 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
     overlay = showBottomPicker(picker);
   };
 
-  const showSetupPicker = () => {
+  const closeWizard = (): void => {
+    wizardOverlay?.hide();
+    wizardOverlay = undefined;
+    wizard = undefined;
+    wizardProviderType = undefined;
+  };
+
+  // Key submit from the wizard. Slash commands route as commands (so /exit
+  // still escapes the wizard) instead of being stored as an API key; every
+  // in-flight state stays inside the wizard overlay, never the transcript.
+  const submitWizardKey = (apiKey: string): void => {
+    const providerType = wizardProviderType;
+    if (!providerType || !wizard) return;
+    if (apiKey.startsWith('/')) {
+      closeWizard();
+      handleSlashCommand(apiKey);
+      return;
+    }
+    if (!input.onboarding) {
+      wizard.setResult({ kind: 'error', text: 'Onboarding 不可用：当前运行环境未提供配置入口。' });
+      requestRender();
+      return;
+    }
+    wizard.setVerifying();
+    requestRender();
+    void input.onboarding.setup({ providerType, apiKey }).then(
+      (result) => {
+        if (!wizard) return;
+        if (result.testError) {
+          // Probe failed: re-arm the key field in place — the upsert rotates
+          // the key, so retrying does not throw "slug already exists".
+          wizard.setResult({ kind: 'error', text: `API key 验证失败：${result.testError}。请检查后重新输入。` });
+          requestRender();
+          return;
+        }
+        const label = PROVIDER_DEFAULTS[providerType]?.label ?? providerType;
+        if (input.firstRun) {
+          beginClose();
+          return;
+        }
+        // The wizard's in-flight notices never reached the transcript; only the
+        // completed configuration is recorded as an event for the next launch.
+        closeWizard();
+        state.entries.push({
+          kind: 'notice',
+          level: 'info',
+          text: `已配置 ${label}。新连接将在下次启动 maka 时生效。`,
+        });
+        requestRender();
+      },
+      (error) => {
+        if (!wizard) return;
+        wizard.setResult({ kind: 'error', text: `配置失败：${error instanceof Error ? error.message : String(error)}` });
+        requestRender();
+      },
+    );
+  };
+
+  const showSetupWizard = (): void => {
     const providers = listApiKeyOnboardableProviders();
     if (providers.length === 0) {
       state.entries.push({
@@ -1281,23 +1280,26 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
       requestRender();
       return;
     }
-    showSelectPicker(
-      'Set Up Provider',
-      String(providers.length),
-      onboardableProviderPickerItems(providers),
-      (item) => {
-        const providerType = item.value as ProviderType;
-        const label = PROVIDER_DEFAULTS[providerType]?.label ?? providerType;
-        pendingKeyEntry = { providerType };
-        state.entries.push({
-          kind: 'notice',
-          level: 'info',
-          text: `请输入 ${label} 的 API key，按回车提交（仅本机存储）。`,
-        });
+    wizardOverlay?.hide();
+    wizard = new OnboardingWizard(tui, {
+      providers,
+      onPickProvider: (providerType) => {
+        wizardProviderType = providerType;
         requestRender();
       },
-      { minPrimaryColumnWidth: 16, maxPrimaryColumnWidth: 32, onCancel: input.firstRun ? () => beginClose() : undefined },
-    );
+      onSubmitKey: submitWizardKey,
+      onCancel: () => {
+        closeWizard();
+        // First-run has no connection to fall back to: cancelling the wizard
+        // closes the TUI so the host surfaces its missing-default guidance.
+        if (input.firstRun) beginClose();
+      },
+      onBack: () => {
+        wizardProviderType = undefined;
+        requestRender();
+      },
+    });
+    wizardOverlay = showBottomPicker(wizard);
   };
 
   // One-sentence session recap (issue #1055). Shared by the manual /recap
@@ -1725,7 +1727,7 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
           requestRender();
           return;
         }
-        showSetupPicker();
+        showSetupWizard();
       },
     },
     {
@@ -2073,7 +2075,7 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
     // to the enable sequence (a focus-in `\x1b[I`) is echoed by the cooked-mode
     // line discipline and leaks onto the screen as a stray `^[[I` on launch.
     terminal.write(ENABLE_FOCUS_REPORTING);
-    if (input.firstRun) showSetupPicker();
+    if (input.firstRun) showSetupWizard();
   } catch (error) {
     beginClose(error instanceof Error ? error : new Error(String(error)));
   }

--- a/packages/cli/src/pi-tui-runner.ts
+++ b/packages/cli/src/pi-tui-runner.ts
@@ -645,6 +645,15 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
     const idleMs = Date.now() - lastActivityAt;
     editor.addToHistory(prompt);
     if (handleSlashCommand(prompt)) return;
+    // First-run has no connection, so the wizard is the only surface. This is
+    // the single choke point for idle submits (Enter, Alt+Enter, steer
+    // fallback): reopen the wizard instead of opening a turn against a
+    // connection-less driver. Slash commands above already routed to the
+    // command layer (/exit still exits, /help still shows help).
+    if (input.firstRun) {
+      showSetupWizard();
+      return;
+    }
     // Refreshed only for a prompt that actually opens a turn: a slash command
     // (e.g. /help) typed on the way back from idle must not consume the idle
     // gap the next real prompt is measuring.
@@ -835,14 +844,6 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
   let wizardAttempt = 0;
 
   editor.onSubmit = (prompt) => {
-    if (input.firstRun) {
-      // First-run has no connection, so the wizard is the only surface. A
-      // submit here — including after a slash command escaped the key field —
-      // must reopen the wizard instead of handing control to a connection-less
-      // driver whose turns only hard-error.
-      showSetupWizard();
-      return;
-    }
     if (turnRunning) {
       steerRunningTurn(prompt);
       return;
@@ -1253,7 +1254,7 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
     requestRender();
     void input.onboarding.setup({ providerType, apiKey }).then(
       (result) => {
-        if (wizard !== targetWizard || attempt !== wizardAttempt) return;
+        if (closed || wizard !== targetWizard || attempt !== wizardAttempt) return;
         if (result.testError) {
           // Probe failed: re-arm the key field in place — the upsert rotates
           // the key, so retrying does not throw "slug already exists".
@@ -1277,7 +1278,7 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
         requestRender();
       },
       (error) => {
-        if (wizard !== targetWizard || attempt !== wizardAttempt) return;
+        if (closed || wizard !== targetWizard || attempt !== wizardAttempt) return;
         wizard.setResult({ kind: 'error', text: `配置失败：${error instanceof Error ? error.message : String(error)}` });
         requestRender();
       },


### PR DESCRIPTION
## Summary

The first-run / `/setup` onboarding wizard pushed its prompt, verifying, and failure notices into the transcript entry flow, and the provider picker had no search — both defeated a focused, input-driven configuration experience (#1098).

This redesign makes **one overlay span provider search → API key entry**, driven by the input field itself:

- **Searchable picker.** Typing filters the provider list live (`editor.onChange` rebuilds the `SelectList`, which exposes no `setItems`).
- **Status beside the input, not in the transcript.** The prompt, verifying, and failure states render in a single status line next to the key field. Only the completed-configuration event reaches the transcript on `/setup`; first-run success still closes the TUI so the host rebinds the new connection.
- **One overlay throughout.** An internal `search → key` state machine replaces the old `SelectList` picker plus a one-shot `editor.onSubmit` interception, so there is no longer a split between "picker UI" and "key UI." Slash commands still route from the key field (`/exit` escapes the wizard).

The wizard replaces `showSetupPicker` + `pendingKeyEntry` in the runner. `MakaOnboardingSurface` / `setupApiKeyConnection` are unchanged, so the upsert-by-slug key rotation, atomic secret-write rollback, and probe-error retry all carry over.

A standalone full-screen wizard was considered and rejected: it would reimplement TUI primitives (raw mode, render loop, layout) to delete the ~30-line first-run stub driver — a net complexity increase for no correctness gain. Reusing the existing `runMakaPiTui` frame and rendering the wizard as a bottom overlay keeps the change inside the runner layer.

Refs #1098.

## Verification

- `npm run typecheck` (all workspaces) — clean.
- `packages/cli`: `node --test "dist/**/*.test.js"` — 525 pass, 0 fail.
- New coverage in `pi-tui-runner.test.ts`:
  - `onboarding wizard filters the provider list as you type in the search field`
  - `onboarding wizard keeps verifying/failure status beside the input, out of the transcript`
  - `onboarding wizard key Esc returns to the provider search`
- The pre-existing `/setup` + first-run journey tests (provider list, key collection, probe-failure retry, slash-command routing, no-surface guard, first-run cancel/auto-open) pass unchanged against the new wizard — the search → key path is interaction-compatible.

No screenshot attached; the wizard is exercised through the `FakeTerminal` TUI harness that drives the rest of the runner suite. One live visual pass during review is worthwhile.