### PR TITLE
feat(cli): /recap and idle-return auto-recap — one-sentence session summary

### DIFF
--- a/packages/cli/src/__tests__/pi-tui-runner.test.ts
+++ b/packages/cli/src/__tests__/pi-tui-runner.test.ts
@@ -39,6 +39,7 @@ import {
   type MakaPiTuiGoalLifecycle,
   type MakaPiTuiInput,
 } from '../pi-tui-runner.js';
+import { AUTO_RECAP_IDLE_MS } from '../session-recap.js';
 import { _setColorLevelForTesting } from '../tui-ansi.js';
 import { BUSY_SPINNER_FRAMES } from '../tui-attention.js';
 import { arrangeAutocompleteAboveEditor } from '../tui-autocomplete-layout.js';
@@ -4873,6 +4874,301 @@ describe('Maka Pi TUI runner', () => {
         sent.endsWith('<user-message>\n整理一下\n</user-message>'),
         `picker-inserted token composes on submit: ${sent}`,
       );
+
+      exitMaka(terminal);
+      await Promise.race([
+        run,
+        delay(50).then(() => {
+          throw new Error('TUI did not close during test cleanup');
+        }),
+      ]);
+    });
+  });
+
+  // #1055: `/recap` and the generator injection point it shares with idle-return
+  // auto-recap. The idle-timer path itself is not covered here (it depends on
+  // real wall-clock gaps with no injectable clock) — see session-recap.test.ts
+  // for the pure `shouldAutoRecap` boundary coverage instead.
+  describe('/recap command', () => {
+    test('reports unavailability when no generator is injected', async () => {
+      const terminal = new FakeTerminal();
+      const driver = new RewindDriver([{ turnId: 'turn-1', label: 'first prompt' }]);
+      const run = runMakaPiTui({
+        title: 'Maka',
+        driver,
+        cwd: '/repo',
+        model: 'claude-sonnet-4-5',
+        connectionSlug: 'claude-subscription',
+        permissionMode: 'ask',
+        terminal,
+      });
+
+      terminal.input('/recap');
+      terminal.input('\r');
+      await waitFor(() =>
+        plainTerminalOutput(terminal.output()).includes('Recap is not available in this environment.'));
+
+      exitMaka(terminal);
+      await Promise.race([
+        run,
+        delay(50).then(() => {
+          throw new Error('TUI did not close during test cleanup');
+        }),
+      ]);
+    });
+
+    test('reports nothing to recap yet when there are no main turns, without calling the generator', async () => {
+      const terminal = new FakeTerminal();
+      const driver = new SlashCommandDriver(); // default listRewindTargets() resolves to []
+      let calls = 0;
+      const run = runMakaPiTui({
+        title: 'Maka',
+        driver,
+        cwd: '/repo',
+        model: 'claude-sonnet-4-5',
+        connectionSlug: 'claude-subscription',
+        permissionMode: 'ask',
+        terminal,
+        recap: {
+          generate: async () => {
+            calls++;
+            return { ok: true, text: 'unused', raw: 'unused' };
+          },
+        },
+      });
+
+      terminal.input('/recap');
+      terminal.input('\r');
+      await waitFor(() => plainTerminalOutput(terminal.output()).includes('Nothing to recap yet.'));
+      assert.equal(calls, 0, 'the generator must not be called when there is nothing to recap');
+
+      exitMaka(terminal);
+      await Promise.race([
+        run,
+        delay(50).then(() => {
+          throw new Error('TUI did not close during test cleanup');
+        }),
+      ]);
+    });
+
+    test('shows the cleaned recap text on success', async () => {
+      const terminal = new FakeTerminal();
+      const driver = new RewindDriver([{ turnId: 'turn-1', label: 'first prompt' }]);
+      const run = runMakaPiTui({
+        title: 'Maka',
+        driver,
+        cwd: '/repo',
+        model: 'claude-sonnet-4-5',
+        connectionSlug: 'claude-subscription',
+        permissionMode: 'ask',
+        terminal,
+        recap: {
+          generate: async () => ({ ok: true, text: 'We fixed the recap bug.', raw: 'We fixed the recap bug.' }),
+        },
+      });
+
+      terminal.input('/recap');
+      terminal.input('\r');
+      await waitFor(() => plainTerminalOutput(terminal.output()).includes('Recap: We fixed the recap bug.'));
+
+      exitMaka(terminal);
+      await Promise.race([
+        run,
+        delay(50).then(() => {
+          throw new Error('TUI did not close during test cleanup');
+        }),
+      ]);
+    });
+
+    test('shows an error notice on failure', async () => {
+      const terminal = new FakeTerminal();
+      const driver = new RewindDriver([{ turnId: 'turn-1', label: 'first prompt' }]);
+      const run = runMakaPiTui({
+        title: 'Maka',
+        driver,
+        cwd: '/repo',
+        model: 'claude-sonnet-4-5',
+        connectionSlug: 'claude-subscription',
+        permissionMode: 'ask',
+        terminal,
+        recap: {
+          generate: async () => ({ ok: false, error: 'connection lost' }),
+        },
+      });
+
+      terminal.input('/recap');
+      terminal.input('\r');
+      await waitFor(() => plainTerminalOutput(terminal.output()).includes('Recap failed: connection lost'));
+
+      exitMaka(terminal);
+      await Promise.race([
+        run,
+        delay(50).then(() => {
+          throw new Error('TUI did not close during test cleanup');
+        }),
+      ]);
+    });
+
+    test('a second /recap while one is in flight reports it is already running, without a second generate() call', async () => {
+      const terminal = new FakeTerminal();
+      const driver = new RewindDriver([{ turnId: 'turn-1', label: 'first prompt' }]);
+      const gate = deferred<void>();
+      let calls = 0;
+      const run = runMakaPiTui({
+        title: 'Maka',
+        driver,
+        cwd: '/repo',
+        model: 'claude-sonnet-4-5',
+        connectionSlug: 'claude-subscription',
+        permissionMode: 'ask',
+        terminal,
+        recap: {
+          generate: async () => {
+            calls++;
+            await gate.promise;
+            return { ok: true, text: 'first recap result', raw: 'first recap result' };
+          },
+        },
+      });
+
+      terminal.input('/recap');
+      terminal.input('\r');
+      await waitFor(() => calls === 1);
+
+      terminal.input('/recap');
+      terminal.input('\r');
+      await waitFor(() => plainTerminalOutput(terminal.output()).includes('Recap already running.'));
+      assert.equal(calls, 1, 'the in-flight lock must prevent a second concurrent generate() call');
+
+      gate.resolve();
+      await waitFor(() => plainTerminalOutput(terminal.output()).includes('Recap: first recap result'));
+
+      exitMaka(terminal);
+      await Promise.race([
+        run,
+        delay(50).then(() => {
+          throw new Error('TUI did not close during test cleanup');
+        }),
+      ]);
+    });
+
+    // The bug this guards against: the idle-return recap is triggered BY the
+    // very prompt that ends the idle gap, and that prompt's own turn runs for
+    // the several seconds the recap call is in flight. A staleness check that
+    // re-samples any turn-count signal after generate() resolves would see
+    // that count already moved (because of that triggering prompt) and would
+    // discard every idle recap unconditionally. The fix samples `promptSeq`
+    // (bumped once per submitted prompt, including the triggering one)
+    // synchronously on entry to runRecap, so only a prompt submitted *after*
+    // entry — a genuinely later one — makes the result stale.
+    test('an idle-triggered recap is discarded when a later prompt supersedes it before it resolves', async (t) => {
+      const terminal = new FakeTerminal();
+      const driver = new RewindDriver([
+        { turnId: 'turn-1', label: 'first' },
+        { turnId: 'turn-2', label: 'second' },
+        { turnId: 'turn-3', label: 'third' },
+      ]);
+      const gate = deferred<void>();
+      let calls = 0;
+      const run = runMakaPiTui({
+        title: 'Maka',
+        driver,
+        cwd: '/repo',
+        model: 'claude-sonnet-4-5',
+        connectionSlug: 'claude-subscription',
+        permissionMode: 'ask',
+        terminal,
+        recap: {
+          generate: async () => {
+            calls++;
+            await gate.promise;
+            return { ok: true, text: 'stale recap result', raw: 'stale recap result' };
+          },
+        },
+      });
+
+      const submit = async (prompt: string, expectedPromptCount: number) => {
+        terminal.input(prompt);
+        terminal.input('\r');
+        await waitFor(() => driver.prompts.length === expectedPromptCount);
+        await waitFor(() => terminal.progressStates.at(-1) === false);
+      };
+
+      // Fake a return-from-idle gap: freeze/advance Date just long enough for
+      // submitPrompt to synchronously capture a qualifying idleMs, then
+      // restore the real clock immediately — everything below (waitFor, the
+      // in-flight generate() gate) depends on real elapsed time.
+      t.mock.timers.enable({ apis: ['Date'], now: Date.now() });
+      t.mock.timers.tick(AUTO_RECAP_IDLE_MS + 1_000);
+      terminal.input('first prompt after idle');
+      terminal.input('\r');
+      t.mock.timers.reset();
+
+      await waitFor(() => calls === 1); // idle auto-recap fired; generate() is in flight
+      await waitFor(() => driver.prompts.length === 1);
+      await waitFor(() => terminal.progressStates.at(-1) === false);
+
+      // Submitted while the idle recap's generate() call is still pending:
+      // this bumps promptSeq past the value runRecap captured on entry.
+      await submit('a later prompt', 2);
+
+      gate.resolve();
+      await delay(50);
+      assert.equal(
+        plainTerminalOutput(terminal.output()).includes('Recap: stale recap result'),
+        false,
+        'an idle recap superseded by a later prompt must be dropped silently',
+      );
+
+      exitMaka(terminal);
+      await Promise.race([
+        run,
+        delay(50).then(() => {
+          throw new Error('TUI did not close during test cleanup');
+        }),
+      ]);
+    });
+
+    test('an idle-triggered recap is shown normally when no later prompt supersedes it', async (t) => {
+      const terminal = new FakeTerminal();
+      const driver = new RewindDriver([
+        { turnId: 'turn-1', label: 'first' },
+        { turnId: 'turn-2', label: 'second' },
+        { turnId: 'turn-3', label: 'third' },
+      ]);
+      const gate = deferred<void>();
+      let calls = 0;
+      const run = runMakaPiTui({
+        title: 'Maka',
+        driver,
+        cwd: '/repo',
+        model: 'claude-sonnet-4-5',
+        connectionSlug: 'claude-subscription',
+        permissionMode: 'ask',
+        terminal,
+        recap: {
+          generate: async () => {
+            calls++;
+            await gate.promise;
+            return { ok: true, text: 'fresh recap result', raw: 'fresh recap result' };
+          },
+        },
+      });
+
+      t.mock.timers.enable({ apis: ['Date'], now: Date.now() });
+      t.mock.timers.tick(AUTO_RECAP_IDLE_MS + 1_000);
+      terminal.input('first prompt after idle');
+      terminal.input('\r');
+      t.mock.timers.reset();
+
+      await waitFor(() => calls === 1); // idle auto-recap fired; generate() is in flight
+      await waitFor(() => driver.prompts.length === 1);
+      await waitFor(() => terminal.progressStates.at(-1) === false);
+
+      // No further prompt is submitted before the recap resolves, so promptSeq
+      // is unchanged from what runRecap captured on entry: the notice shows.
+      gate.resolve();
+      await waitFor(() => plainTerminalOutput(terminal.output()).includes('Recap: fresh recap result'));
 
       exitMaka(terminal);
       await Promise.race([

--- a/packages/cli/src/__tests__/pi-tui-runner.test.ts
+++ b/packages/cli/src/__tests__/pi-tui-runner.test.ts
@@ -5178,6 +5178,168 @@ describe('Maka Pi TUI runner', () => {
         }),
       ]);
     });
+
+    // PR #1182 review fix: recapInFlight must be set synchronously, before any
+    // await, so two /recap submissions with no await between them (unlike the
+    // "already running" test above, which waits for the first generate() call
+    // to start before submitting the second) cannot both pass the
+    // `recapInFlight` check before either sets it.
+    test('two /recap commands submitted back-to-back with no await between them only start one generate() call', async () => {
+      const terminal = new FakeTerminal();
+      const driver = new RewindDriver([{ turnId: 'turn-1', label: 'first prompt' }]);
+      const gate = deferred<void>();
+      let calls = 0;
+      const run = runMakaPiTui({
+        title: 'Maka',
+        driver,
+        cwd: '/repo',
+        model: 'claude-sonnet-4-5',
+        connectionSlug: 'claude-subscription',
+        permissionMode: 'ask',
+        terminal,
+        recap: {
+          generate: async () => {
+            calls++;
+            await gate.promise;
+            return { ok: true, text: 'first recap result', raw: 'first recap result' };
+          },
+        },
+      });
+
+      terminal.input('/recap');
+      terminal.input('\r');
+      terminal.input('/recap');
+      terminal.input('\r');
+
+      await waitFor(() => plainTerminalOutput(terminal.output()).includes('Recap already running.'));
+      assert.equal(
+        calls,
+        1,
+        'the in-flight lock must be held synchronously so a second /recap racing before the first await sees it',
+      );
+
+      gate.resolve();
+      await waitFor(() => plainTerminalOutput(terminal.output()).includes('Recap: first recap result'));
+
+      exitMaka(terminal);
+      await Promise.race([
+        run,
+        delay(50).then(() => {
+          throw new Error('TUI did not close during test cleanup');
+        }),
+      ]);
+    });
+
+    // PR #1182 review fix: a recap must be scoped to the session it started
+    // for. /session, /new, and rewind never bump promptSeq (only submitted
+    // prompts do), so the promptSeq staleness check alone cannot catch a
+    // session switch — the fix compares sessionIds directly instead.
+    test('a recap result is discarded when the active session switches away while generate() is in flight', async () => {
+      const terminal = new FakeTerminal();
+      const driver = new RewindDriver([{ turnId: 'turn-1', label: 'first prompt' }]);
+      const gate = deferred<void>();
+      let calls = 0;
+      const run = runMakaPiTui({
+        title: 'Maka',
+        driver,
+        cwd: '/repo',
+        model: 'claude-sonnet-4-5',
+        connectionSlug: 'claude-subscription',
+        permissionMode: 'ask',
+        terminal,
+        recap: {
+          generate: async () => {
+            calls++;
+            await gate.promise;
+            return { ok: true, text: 'session A recap', raw: 'session A recap' };
+          },
+        },
+      });
+
+      terminal.input('/recap');
+      terminal.input('\r');
+      await waitFor(() => calls === 1); // generate() is in flight for session-1
+
+      // Switch the active session directly on the fake driver while
+      // generate() is still pending — mirrors /session, /new, or a rewind
+      // landing mid-recap.
+      await driver.switchSession('session-2');
+
+      gate.resolve();
+      await delay(50);
+      assert.equal(
+        plainTerminalOutput(terminal.output()).includes('Recap:'),
+        false,
+        'a recap started in a session that has since been switched away from must be dropped silently',
+      );
+
+      exitMaka(terminal);
+      await Promise.race([
+        run,
+        delay(50).then(() => {
+          throw new Error('TUI did not close during test cleanup');
+        }),
+      ]);
+    });
+
+    // PR #1182 review fix: lastActivityAt must only refresh for a prompt that
+    // actually opens a turn. Before the fix it refreshed at submitPrompt's
+    // entry (ahead of the slash-command check), so a slash command typed on
+    // the way back from idle (e.g. /help) would silently consume the idle
+    // gap the next real prompt needed to trigger an auto-recap.
+    test('a slash command submitted on the way back from idle does not consume the idle gap for the next real prompt', async (t) => {
+      const terminal = new FakeTerminal();
+      const driver = new RewindDriver([
+        { turnId: 'turn-1', label: 'first' },
+        { turnId: 'turn-2', label: 'second' },
+        { turnId: 'turn-3', label: 'third' },
+      ]);
+      let calls = 0;
+      const run = runMakaPiTui({
+        title: 'Maka',
+        driver,
+        cwd: '/repo',
+        model: 'claude-sonnet-4-5',
+        connectionSlug: 'claude-subscription',
+        permissionMode: 'ask',
+        terminal,
+        recap: {
+          generate: async () => {
+            calls++;
+            return { ok: true, text: 'recap after help', raw: 'recap after help' };
+          },
+        },
+      });
+
+      // Freeze/advance Date to simulate a qualifying idle gap, then submit a
+      // slash command FIRST — it must not refresh lastActivityAt — followed
+      // by a real prompt while the clock is still frozen at the same instant.
+      // If /help had wrongly refreshed the idle clock, the real prompt's
+      // idleMs would measure ~0 (both reads hit the same frozen Date) instead
+      // of the full gap, and the auto-recap below would never fire.
+      t.mock.timers.enable({ apis: ['Date'], now: Date.now() });
+      t.mock.timers.tick(AUTO_RECAP_IDLE_MS + 1_000);
+
+      terminal.input('/help');
+      terminal.input('\r');
+      await waitFor(() => plainTerminalOutput(terminal.output()).includes('Commands'));
+
+      terminal.input('a real prompt');
+      terminal.input('\r');
+      t.mock.timers.reset();
+
+      await waitFor(() => driver.prompts.length === 1);
+      await waitFor(() => plainTerminalOutput(terminal.output()).includes('Recap: recap after help'));
+      assert.equal(calls, 1);
+
+      exitMaka(terminal);
+      await Promise.race([
+        run,
+        delay(50).then(() => {
+          throw new Error('TUI did not close during test cleanup');
+        }),
+      ]);
+    });
   });
 
 });

--- a/packages/cli/src/__tests__/session-recap.test.ts
+++ b/packages/cli/src/__tests__/session-recap.test.ts
@@ -1,0 +1,192 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+import type { StoredMessage } from '@maka/core';
+import {
+  AUTO_RECAP_DISPLAY_LIMIT_BYTES,
+  AUTO_RECAP_IDLE_MS,
+  AUTO_RECAP_MIN_TURNS,
+  RECAP_INSTRUCTION,
+  buildRecapMessages,
+  cleanRecapText,
+  shouldAutoRecap,
+} from '../session-recap.js';
+
+// AUTO_RECAP_DISPLAY_LIMIT_BYTES itself is a plain constant (contract value
+// consumed by the runner's idle-recap display suppression, exercised in
+// pi-tui-runner.test.ts's "/recap command" suite). Pin its value here so a
+// drift is caught next to the rest of the recap contract constants.
+test('AUTO_RECAP_DISPLAY_LIMIT_BYTES is 500 bytes', () => {
+  assert.equal(AUTO_RECAP_DISPLAY_LIMIT_BYTES, 500);
+});
+
+function userMessage(id: string, text: string): StoredMessage {
+  return { type: 'user', id, turnId: id, ts: 1, text };
+}
+
+function assistantMessage(id: string, text: string): StoredMessage {
+  return { type: 'assistant', id, turnId: id, ts: 1, text, modelId: 'model-1' };
+}
+
+function toolCallMessage(id: string, toolName: string): StoredMessage {
+  return { type: 'tool_call', id, turnId: 't1', ts: 1, toolName, args: {} };
+}
+
+function toolResultMessage(id: string, isError: boolean): StoredMessage {
+  return {
+    type: 'tool_result',
+    id,
+    turnId: 't1',
+    ts: 1,
+    toolUseId: id,
+    isError,
+    content: { kind: 'text', text: 'ok' },
+  };
+}
+
+describe('cleanRecapText', () => {
+  test('collapses whitespace and trims', () => {
+    assert.equal(cleanRecapText('  We   fixed\n\nthe   bug.  '), 'We fixed the bug.');
+  });
+
+  test('strips a leading Recap: label (case-insensitive)', () => {
+    assert.equal(cleanRecapText('Recap: We fixed the bug.'), 'We fixed the bug.');
+    assert.equal(cleanRecapText('RECAP:We fixed the bug.'), 'We fixed the bug.');
+  });
+
+  test('strips a leading Summary: label (case-insensitive)', () => {
+    assert.equal(cleanRecapText('Summary:  We fixed the bug.'), 'We fixed the bug.');
+    assert.equal(cleanRecapText('summary：We fixed the bug.'), 'We fixed the bug.');
+  });
+
+  test('strips a leading 回顾： label', () => {
+    assert.equal(cleanRecapText('回顾：我们修复了问题。'), '我们修复了问题。');
+  });
+
+  test('strips one layer of wrapping quotes', () => {
+    assert.equal(cleanRecapText('"We fixed the bug."'), 'We fixed the bug.');
+    assert.equal(cleanRecapText("'We fixed the bug.'"), 'We fixed the bug.');
+    assert.equal(cleanRecapText('“We fixed the bug.”'), 'We fixed the bug.');
+  });
+
+  test('truncates to 1200 characters with an ellipsis', () => {
+    const long = 'a'.repeat(1300);
+    const result = cleanRecapText(long);
+    assert.equal(result.length, 1201);
+    assert.equal(result.slice(0, 1200), 'a'.repeat(1200));
+    assert.equal(result.at(-1), '…');
+  });
+});
+
+describe('shouldAutoRecap', () => {
+  test('idle-time boundary: 179999ms does not trigger, 180000ms does', () => {
+    assert.equal(
+      shouldAutoRecap({ idleMs: AUTO_RECAP_IDLE_MS - 1, mainTurnCount: 3, lastRecapMainTurnCount: 0 }),
+      false,
+    );
+    assert.equal(
+      shouldAutoRecap({ idleMs: AUTO_RECAP_IDLE_MS, mainTurnCount: 3, lastRecapMainTurnCount: 0 }),
+      true,
+    );
+  });
+
+  test('main-turn boundary: 2 turns does not trigger, 3 turns does', () => {
+    assert.equal(
+      shouldAutoRecap({ idleMs: AUTO_RECAP_IDLE_MS, mainTurnCount: AUTO_RECAP_MIN_TURNS - 1, lastRecapMainTurnCount: 0 }),
+      false,
+    );
+    assert.equal(
+      shouldAutoRecap({ idleMs: AUTO_RECAP_IDLE_MS, mainTurnCount: AUTO_RECAP_MIN_TURNS, lastRecapMainTurnCount: 0 }),
+      true,
+    );
+  });
+
+  test('watermark: equal main-turn count does not re-trigger', () => {
+    assert.equal(
+      shouldAutoRecap({ idleMs: AUTO_RECAP_IDLE_MS, mainTurnCount: 3, lastRecapMainTurnCount: 3 }),
+      false,
+    );
+    assert.equal(
+      shouldAutoRecap({ idleMs: AUTO_RECAP_IDLE_MS, mainTurnCount: 4, lastRecapMainTurnCount: 3 }),
+      true,
+    );
+  });
+});
+
+describe('buildRecapMessages', () => {
+  test('projects user/assistant/tool_call/tool_result and appends the instruction, skipping empty text and non-conversational rows', () => {
+    const messages: StoredMessage[] = [
+      userMessage('u1', 'Please fix the bug'),
+      { type: 'user', id: 'u-empty', turnId: 'u-empty', ts: 1, text: '   ' },
+      assistantMessage('a1', 'Looking into it'),
+      { type: 'assistant', id: 'a-empty', turnId: 'a-empty', ts: 1, text: '', modelId: 'model-1' },
+      toolCallMessage('tc1', 'bash'),
+      toolResultMessage('tr1', false),
+      toolResultMessage('tr2', true),
+      { type: 'permission_decision', id: 'p1', turnId: 't1', ts: 1, toolUseId: 'tc1', toolName: 'bash', decision: 'allow' },
+      { type: 'token_usage', id: 'k1', turnId: 't1', ts: 1, input: 10, output: 10 },
+      { type: 'turn_state', id: 's1', turnId: 't1', ts: 1, status: 'completed', partialOutputRetained: false },
+      { type: 'system_note', id: 'n1', ts: 1, kind: 'session_start' },
+    ];
+
+    const result = buildRecapMessages(messages, { contextWindow: undefined });
+
+    assert.deepEqual(result, [
+      { role: 'user', content: 'Please fix the bug' },
+      { role: 'assistant', content: 'Looking into it' },
+      { role: 'assistant', content: '[tool: bash]' },
+      { role: 'assistant', content: '[tool result: ok]' },
+      { role: 'assistant', content: '[tool result: error]' },
+      { role: 'user', content: RECAP_INSTRUCTION },
+    ]);
+  });
+
+  test('prefers displayText over text for user messages', () => {
+    const messages: StoredMessage[] = [
+      { type: 'user', id: 'u1', turnId: 'u1', ts: 1, text: 'model-facing envelope', displayText: 'what the user typed' },
+    ];
+    const result = buildRecapMessages(messages, { contextWindow: undefined });
+    assert.deepEqual(result[0], { role: 'user', content: 'what the user typed' });
+  });
+
+  test('contextWindow undefined: never trims, even with many messages', () => {
+    const messages: StoredMessage[] = Array.from({ length: 50 }, (_, i) => userMessage(`u${i}`, 'x'.repeat(500)));
+    const result = buildRecapMessages(messages, { contextWindow: undefined });
+    assert.equal(result.length, 51); // 50 projected + instruction
+  });
+
+  test('over budget: drops the trailing dangling tool placeholders first, keeping short head messages intact', () => {
+    const head: StoredMessage[] = Array.from({ length: 8 }, (_, i) => userMessage(`u${i}`, 'short'));
+    const danglingTail: StoredMessage[] = [
+      toolCallMessage('tc-huge', 'x'.repeat(5000)),
+      toolResultMessage('tr-huge', false),
+    ];
+    const messages = [...head, ...danglingTail];
+
+    // Budget comfortably covers the 8 short head messages + instruction, but
+    // not the huge trailing tool-call placeholder.
+    const result = buildRecapMessages(messages, { contextWindow: 5407 });
+
+    assert.equal(result.length, 9); // 8 head messages + instruction
+    for (let i = 0; i < 8; i++) {
+      assert.deepEqual(result[i], { role: 'user', content: 'short' });
+    }
+    assert.deepEqual(result.at(-1), { role: 'user', content: RECAP_INSTRUCTION });
+  });
+
+  test('over budget beyond the dangling-tool drop: trims from the head down to the last 4 messages plus the instruction', () => {
+    const messages: StoredMessage[] = Array.from({ length: 6 }, (_, i) => userMessage(`u${i}`, `keep-${i}`));
+
+    // A tiny context window forces the token budget negative, so trimming
+    // proceeds all the way down to the floor.
+    const result = buildRecapMessages(messages, { contextWindow: 100 });
+
+    assert.equal(result.length, 5); // last 4 projected messages + instruction
+    assert.deepEqual(result.slice(0, 4), [
+      { role: 'user', content: 'keep-2' },
+      { role: 'user', content: 'keep-3' },
+      { role: 'user', content: 'keep-4' },
+      { role: 'user', content: 'keep-5' },
+    ]);
+    assert.deepEqual(result.at(-1), { role: 'user', content: RECAP_INSTRUCTION });
+  });
+});

--- a/packages/cli/src/__tests__/session-recap.test.ts
+++ b/packages/cli/src/__tests__/session-recap.test.ts
@@ -1,12 +1,9 @@
 import assert from 'node:assert/strict';
 import { describe, test } from 'node:test';
-import type { StoredMessage } from '@maka/core';
 import {
   AUTO_RECAP_DISPLAY_LIMIT_BYTES,
   AUTO_RECAP_IDLE_MS,
   AUTO_RECAP_MIN_TURNS,
-  RECAP_INSTRUCTION,
-  buildRecapMessages,
   cleanRecapText,
   shouldAutoRecap,
 } from '../session-recap.js';
@@ -18,30 +15,6 @@ import {
 test('AUTO_RECAP_DISPLAY_LIMIT_BYTES is 500 bytes', () => {
   assert.equal(AUTO_RECAP_DISPLAY_LIMIT_BYTES, 500);
 });
-
-function userMessage(id: string, text: string): StoredMessage {
-  return { type: 'user', id, turnId: id, ts: 1, text };
-}
-
-function assistantMessage(id: string, text: string): StoredMessage {
-  return { type: 'assistant', id, turnId: id, ts: 1, text, modelId: 'model-1' };
-}
-
-function toolCallMessage(id: string, toolName: string): StoredMessage {
-  return { type: 'tool_call', id, turnId: 't1', ts: 1, toolName, args: {} };
-}
-
-function toolResultMessage(id: string, isError: boolean): StoredMessage {
-  return {
-    type: 'tool_result',
-    id,
-    turnId: 't1',
-    ts: 1,
-    toolUseId: id,
-    isError,
-    content: { kind: 'text', text: 'ok' },
-  };
-}
 
 describe('cleanRecapText', () => {
   test('collapses whitespace and trims', () => {
@@ -109,84 +82,5 @@ describe('shouldAutoRecap', () => {
       shouldAutoRecap({ idleMs: AUTO_RECAP_IDLE_MS, mainTurnCount: 4, lastRecapMainTurnCount: 3 }),
       true,
     );
-  });
-});
-
-describe('buildRecapMessages', () => {
-  test('projects user/assistant/tool_call/tool_result and appends the instruction, skipping empty text and non-conversational rows', () => {
-    const messages: StoredMessage[] = [
-      userMessage('u1', 'Please fix the bug'),
-      { type: 'user', id: 'u-empty', turnId: 'u-empty', ts: 1, text: '   ' },
-      assistantMessage('a1', 'Looking into it'),
-      { type: 'assistant', id: 'a-empty', turnId: 'a-empty', ts: 1, text: '', modelId: 'model-1' },
-      toolCallMessage('tc1', 'bash'),
-      toolResultMessage('tr1', false),
-      toolResultMessage('tr2', true),
-      { type: 'permission_decision', id: 'p1', turnId: 't1', ts: 1, toolUseId: 'tc1', toolName: 'bash', decision: 'allow' },
-      { type: 'token_usage', id: 'k1', turnId: 't1', ts: 1, input: 10, output: 10 },
-      { type: 'turn_state', id: 's1', turnId: 't1', ts: 1, status: 'completed', partialOutputRetained: false },
-      { type: 'system_note', id: 'n1', ts: 1, kind: 'session_start' },
-    ];
-
-    const result = buildRecapMessages(messages, { contextWindow: undefined });
-
-    assert.deepEqual(result, [
-      { role: 'user', content: 'Please fix the bug' },
-      { role: 'assistant', content: 'Looking into it' },
-      { role: 'assistant', content: '[tool: bash]' },
-      { role: 'assistant', content: '[tool result: ok]' },
-      { role: 'assistant', content: '[tool result: error]' },
-      { role: 'user', content: RECAP_INSTRUCTION },
-    ]);
-  });
-
-  test('prefers displayText over text for user messages', () => {
-    const messages: StoredMessage[] = [
-      { type: 'user', id: 'u1', turnId: 'u1', ts: 1, text: 'model-facing envelope', displayText: 'what the user typed' },
-    ];
-    const result = buildRecapMessages(messages, { contextWindow: undefined });
-    assert.deepEqual(result[0], { role: 'user', content: 'what the user typed' });
-  });
-
-  test('contextWindow undefined: never trims, even with many messages', () => {
-    const messages: StoredMessage[] = Array.from({ length: 50 }, (_, i) => userMessage(`u${i}`, 'x'.repeat(500)));
-    const result = buildRecapMessages(messages, { contextWindow: undefined });
-    assert.equal(result.length, 51); // 50 projected + instruction
-  });
-
-  test('over budget: drops the trailing dangling tool placeholders first, keeping short head messages intact', () => {
-    const head: StoredMessage[] = Array.from({ length: 8 }, (_, i) => userMessage(`u${i}`, 'short'));
-    const danglingTail: StoredMessage[] = [
-      toolCallMessage('tc-huge', 'x'.repeat(5000)),
-      toolResultMessage('tr-huge', false),
-    ];
-    const messages = [...head, ...danglingTail];
-
-    // Budget comfortably covers the 8 short head messages + instruction, but
-    // not the huge trailing tool-call placeholder.
-    const result = buildRecapMessages(messages, { contextWindow: 5407 });
-
-    assert.equal(result.length, 9); // 8 head messages + instruction
-    for (let i = 0; i < 8; i++) {
-      assert.deepEqual(result[i], { role: 'user', content: 'short' });
-    }
-    assert.deepEqual(result.at(-1), { role: 'user', content: RECAP_INSTRUCTION });
-  });
-
-  test('over budget beyond the dangling-tool drop: trims from the head down to the last 4 messages plus the instruction', () => {
-    const messages: StoredMessage[] = Array.from({ length: 6 }, (_, i) => userMessage(`u${i}`, `keep-${i}`));
-
-    // A tiny context window forces the token budget negative, so trimming
-    // proceeds all the way down to the floor.
-    const result = buildRecapMessages(messages, { contextWindow: 100 });
-
-    assert.equal(result.length, 5); // last 4 projected messages + instruction
-    assert.deepEqual(result.slice(0, 4), [
-      { role: 'user', content: 'keep-2' },
-      { role: 'user', content: 'keep-3' },
-      { role: 'user', content: 'keep-4' },
-      { role: 'user', content: 'keep-5' },
-    ]);
-    assert.deepEqual(result.at(-1), { role: 'user', content: RECAP_INSTRUCTION });
   });
 });

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -179,6 +179,7 @@ export async function runMakaCli(argv: string[] = process.argv.slice(2)): Promis
           skills: context.skills,
           goalLifecycle: context.goalContinuation,
           onboarding: context.onboarding,
+          recap: context.recap,
           onProcessExit: handleMakaCliProcessExit,
         });
         return 0;

--- a/packages/cli/src/pi-tui-runner.ts
+++ b/packages/cli/src/pi-tui-runner.ts
@@ -25,7 +25,8 @@ import {
 import type { GoalTurnOutcome, SessionActivityLease } from '@maka/runtime';
 import type { ModelChoice } from './connection-target.js';
 import { listApiKeyOnboardableProviders, type MakaOnboardingSurface } from './onboarding.js';
-import type { MakaCliSkillSurface } from './runtime-bootstrap.js';
+import type { MakaCliSkillSurface, SessionRecapGenerator } from './runtime-bootstrap.js';
+import { AUTO_RECAP_DISPLAY_LIMIT_BYTES, shouldAutoRecap } from './session-recap.js';
 import {
   composeSkillInvocationMessage,
   listInvocableSkills,
@@ -140,6 +141,12 @@ export interface MakaPiTuiInput {
   /** First-run mode: auto-open the onboarding wizard on launch instead of
    *  waiting for /setup (used when the CLI starts with no configured connection). */
   firstRun?: boolean;
+  /**
+   * One-sentence session recap generator (issue #1055). Powers `/recap` and
+   * the idle-return auto-recap. Omitting it disables both — `/recap` reports
+   * unavailability and no auto-recap is ever scheduled.
+   */
+  recap?: SessionRecapGenerator;
 }
 
 export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
@@ -163,6 +170,15 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
   let closed = false;
   let currentActivityCompletion: Promise<void> | undefined;
   let permissionResponseInFlightRequestId: string | null = null;
+  // Session recap (issue #1055): an in-flight lock shared by manual and
+  // automatic recap calls, an activity clock for idle-return detection, a
+  // watermark so auto-recap fires at most once per newly reached main turn,
+  // and a sequence counter bumped once per submitted prompt so an idle recap
+  // can detect it was superseded by a later prompt while it was generating.
+  let recapInFlight = false;
+  let lastActivityAt = Date.now();
+  let lastRecapMainTurnCount = 0;
+  let promptSeq = 0;
   const beginActivity = () => {
     let finish!: () => void;
     const completion = new Promise<void>((resolve) => { finish = resolve; });
@@ -620,8 +636,17 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
       requestRender();
       return;
     }
+    // Captured BEFORE lastActivityAt is refreshed, so the idle gap measures up
+    // to (not including) this very submission.
+    const idleMs = Date.now() - lastActivityAt;
+    lastActivityAt = Date.now();
     editor.addToHistory(prompt);
     if (handleSlashCommand(prompt)) return;
+    // This prompt is about to open a turn, so it counts toward the sequence
+    // an in-flight idle recap is watching — including when this very prompt
+    // is the idle-return submission that triggers the recap below.
+    promptSeq += 1;
+    maybeTriggerAutoRecap(idleMs);
     if (!input.skills || parseSkillInvocationTokens(prompt).length === 0) {
       void runAgentTurn({
         kind: 'external',
@@ -891,6 +916,9 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
       editor.disableSubmit = false;
       terminal.setProgress(false);
       attention.promptTurnEnded();
+      // A turn ending is activity too — resets the idle clock the next
+      // submission's auto-recap check measures against.
+      lastActivityAt = Date.now();
     };
 
     return runMakaPiTuiTurn({
@@ -1263,6 +1291,104 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
       },
       { minPrimaryColumnWidth: 16, maxPrimaryColumnWidth: 32, onCancel: input.firstRun ? () => beginClose() : undefined },
     );
+  };
+
+  // One-sentence session recap (issue #1055). Shared by the manual /recap
+  // command and idle-return auto-recap; both paths route through the same
+  // in-flight lock so at most one recap call runs at a time.
+  const runRecap = async (reason: 'manual' | 'idle'): Promise<void> => {
+    // Captured synchronously on entry, so for the idle path this already
+    // includes the seq bump from the very prompt that triggered this call
+    // (submitPrompt bumps promptSeq before invoking maybeTriggerAutoRecap).
+    // Only a prompt submitted *after* this point — i.e. later than the one
+    // that triggered the recap — should make the result stale.
+    const seqAtStart = promptSeq;
+    if (!input.recap) {
+      if (reason === 'manual') {
+        state.entries.push({
+          kind: 'notice',
+          level: 'error',
+          text: 'Recap is not available in this environment.',
+        });
+        requestRender();
+      }
+      return;
+    }
+    if (recapInFlight) {
+      if (reason === 'manual') {
+        state.entries.push({
+          kind: 'notice',
+          level: 'error',
+          text: 'Recap already running.',
+        });
+        requestRender();
+      }
+      return;
+    }
+    const mainTurnCount = (await input.driver.listRewindTargets()).length;
+    if (reason === 'manual' && mainTurnCount < 1) {
+      state.entries.push({
+        kind: 'notice',
+        level: 'info',
+        text: 'Nothing to recap yet.',
+      });
+      requestRender();
+      return;
+    }
+    const sessionId = input.driver.getSessionId();
+    if (!sessionId) return;
+
+    recapInFlight = true;
+    let result: Awaited<ReturnType<SessionRecapGenerator['generate']>>;
+    try {
+      result = await input.recap.generate(sessionId, reason);
+    } finally {
+      recapInFlight = false;
+    }
+
+    if (!result.ok) {
+      if (reason === 'manual') {
+        state.entries.push({
+          kind: 'notice',
+          level: 'error',
+          text: `Recap failed: ${result.error}`,
+        });
+        requestRender();
+      }
+      return;
+    }
+
+    if (reason === 'idle') {
+      // Below the display threshold suppresses the notice (still persisted by
+      // the generator); a prompt submitted after seqAtStart while the call
+      // was in flight means a later prompt has superseded this recap — drop
+      // it silently either way.
+      if (Buffer.byteLength(result.raw, 'utf8') > AUTO_RECAP_DISPLAY_LIMIT_BYTES) return;
+      if (promptSeq !== seqAtStart) return;
+    }
+
+    state.entries.push({
+      kind: 'notice',
+      level: 'info',
+      text: `Recap: ${result.text}`,
+    });
+    requestRender();
+  };
+
+  // Fire-and-forget idle-return check: a normal prompt submitted after a long
+  // enough gap auto-triggers a recap, without blocking the turn it opens.
+  const maybeTriggerAutoRecap = (idleMs: number): void => {
+    if (!input.recap) return;
+    void (async () => {
+      try {
+        const mainTurnCount = (await input.driver.listRewindTargets()).length;
+        if (!shouldAutoRecap({ idleMs, mainTurnCount, lastRecapMainTurnCount })) return;
+        lastRecapMainTurnCount = mainTurnCount;
+        void runRecap('idle');
+      } catch {
+        // Best-effort: auto-recap must never surface an error to the user.
+      }
+    })();
   };
 
   const compactSession = async () => {
@@ -1657,6 +1783,13 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
       },
     },
     {
+      name: 'recap',
+      description: 'One-sentence recap of the session so far',
+      run: () => {
+        void runRecap('manual');
+      },
+    },
+    {
       name: 'rename',
       description: 'Rename current session',
       run: (parts: string[]) => {
@@ -1927,7 +2060,7 @@ const BOTTOM_PICKER_MARGIN_ROWS = 4;
 // The editor's autocomplete window height. Sized to fit the whole slash-command
 // menu (10 today) with headroom, so a bare `/` shows every command rather than
 // scrolling a subset.
-const EDITOR_AUTOCOMPLETE_MAX_VISIBLE = 12;
+const EDITOR_AUTOCOMPLETE_MAX_VISIBLE = 13;
 
 // A short, stable slice of a session id — enough to tell two same-named
 // sessions apart in the picker without showing the full unreadable uuid.

--- a/packages/cli/src/pi-tui-runner.ts
+++ b/packages/cli/src/pi-tui-runner.ts
@@ -177,7 +177,11 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
   // can detect it was superseded by a later prompt while it was generating.
   let recapInFlight = false;
   let lastActivityAt = Date.now();
-  let lastRecapMainTurnCount = 0;
+  // Session-scoped watermark: null (or a stale sessionId) is equivalent to a
+  // fresh session that has never had a recap (count 0). Prevents a recap
+  // triggered in session A from suppressing the first eligible recap in a
+  // later session B that happens to reach the same main-turn count.
+  let recapWatermark: { sessionId: string; mainTurnCount: number } | null = null;
   let promptSeq = 0;
   const beginActivity = () => {
     let finish!: () => void;
@@ -639,9 +643,12 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
     // Captured BEFORE lastActivityAt is refreshed, so the idle gap measures up
     // to (not including) this very submission.
     const idleMs = Date.now() - lastActivityAt;
-    lastActivityAt = Date.now();
     editor.addToHistory(prompt);
     if (handleSlashCommand(prompt)) return;
+    // Refreshed only for a prompt that actually opens a turn: a slash command
+    // (e.g. /help) typed on the way back from idle must not consume the idle
+    // gap the next real prompt is measuring.
+    lastActivityAt = Date.now();
     // This prompt is about to open a turn, so it counts toward the sequence
     // an in-flight idle recap is watching — including when this very prompt
     // is the idle-return submission that triggers the recap below.
@@ -1303,6 +1310,10 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
     // Only a prompt submitted *after* this point — i.e. later than the one
     // that triggered the recap — should make the result stale.
     const seqAtStart = promptSeq;
+    // Captured synchronously on entry, before any await: /session, /new, and
+    // rewind never bump promptSeq, so a session switch mid-generate must be
+    // caught by comparing sessionIds directly rather than relying on seq.
+    const sessionIdAtStart = input.driver.getSessionId();
     if (!input.recap) {
       if (reason === 'manual') {
         state.entries.push({
@@ -1325,54 +1336,65 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
       }
       return;
     }
-    const mainTurnCount = (await input.driver.listRewindTargets()).length;
-    if (reason === 'manual' && mainTurnCount < 1) {
+    // Locked synchronously, before any await: two /recap invocations
+    // submitted back-to-back must not both pass the recapInFlight check above
+    // before either sets it. The rest of the body is one try/finally so every
+    // early return (including "Nothing to recap yet" and a null session)
+    // releases the lock.
+    recapInFlight = true;
+    try {
+      const mainTurnCount = (await input.driver.listRewindTargets()).length;
+      if (reason === 'manual' && mainTurnCount < 1) {
+        state.entries.push({
+          kind: 'notice',
+          level: 'info',
+          text: 'Nothing to recap yet.',
+        });
+        requestRender();
+        return;
+      }
+      if (!sessionIdAtStart) return;
+
+      const result = await input.recap.generate(sessionIdAtStart, reason);
+
+      // The active session must still be the one this recap started for —
+      // checked before ANY display (success notice or manual failure notice).
+      // /session, /new, or a rewind switched the active session while
+      // generate() was in flight: the session this result belongs to is gone
+      // from view, so surfacing it (success or error) would land on the wrong
+      // session. Drop it silently regardless of manual/idle.
+      if (input.driver.getSessionId() !== sessionIdAtStart) return;
+
+      if (!result.ok) {
+        if (reason === 'manual') {
+          state.entries.push({
+            kind: 'notice',
+            level: 'error',
+            text: `Recap failed: ${result.error}`,
+          });
+          requestRender();
+        }
+        return;
+      }
+
+      if (reason === 'idle') {
+        // Below the display threshold suppresses the notice (still persisted by
+        // the generator); a prompt submitted after seqAtStart while the call
+        // was in flight means a later prompt has superseded this recap — drop
+        // it silently either way.
+        if (Buffer.byteLength(result.raw, 'utf8') > AUTO_RECAP_DISPLAY_LIMIT_BYTES) return;
+        if (promptSeq !== seqAtStart) return;
+      }
+
       state.entries.push({
         kind: 'notice',
         level: 'info',
-        text: 'Nothing to recap yet.',
+        text: `Recap: ${result.text}`,
       });
       requestRender();
-      return;
-    }
-    const sessionId = input.driver.getSessionId();
-    if (!sessionId) return;
-
-    recapInFlight = true;
-    let result: Awaited<ReturnType<SessionRecapGenerator['generate']>>;
-    try {
-      result = await input.recap.generate(sessionId, reason);
     } finally {
       recapInFlight = false;
     }
-
-    if (!result.ok) {
-      if (reason === 'manual') {
-        state.entries.push({
-          kind: 'notice',
-          level: 'error',
-          text: `Recap failed: ${result.error}`,
-        });
-        requestRender();
-      }
-      return;
-    }
-
-    if (reason === 'idle') {
-      // Below the display threshold suppresses the notice (still persisted by
-      // the generator); a prompt submitted after seqAtStart while the call
-      // was in flight means a later prompt has superseded this recap — drop
-      // it silently either way.
-      if (Buffer.byteLength(result.raw, 'utf8') > AUTO_RECAP_DISPLAY_LIMIT_BYTES) return;
-      if (promptSeq !== seqAtStart) return;
-    }
-
-    state.entries.push({
-      kind: 'notice',
-      level: 'info',
-      text: `Recap: ${result.text}`,
-    });
-    requestRender();
   };
 
   // Fire-and-forget idle-return check: a normal prompt submitted after a long
@@ -1381,9 +1403,13 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
     if (!input.recap) return;
     void (async () => {
       try {
+        const sessionId = input.driver.getSessionId();
         const mainTurnCount = (await input.driver.listRewindTargets()).length;
+        const lastRecapMainTurnCount = sessionId && recapWatermark?.sessionId === sessionId
+          ? recapWatermark.mainTurnCount
+          : 0;
         if (!shouldAutoRecap({ idleMs, mainTurnCount, lastRecapMainTurnCount })) return;
-        lastRecapMainTurnCount = mainTurnCount;
+        if (sessionId) recapWatermark = { sessionId, mainTurnCount };
         void runRecap('idle');
       } catch {
         // Best-effort: auto-recap must never surface an error to the user.

--- a/packages/cli/src/runtime-bootstrap.ts
+++ b/packages/cli/src/runtime-bootstrap.ts
@@ -1,6 +1,7 @@
 import { randomBytes, randomUUID } from 'node:crypto';
 import { chmod, mkdir, readFile, writeFile } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
+import type { ModelMessage } from 'ai';
 import {
   AiSdkBackend,
   AutomationManager,
@@ -8,11 +9,14 @@ import {
   BackendRegistry,
   GoalManager,
   PermissionEngine,
+  RuntimeReadModel,
   SessionManager,
   ShellRunProcessManager,
+  applyRuntimeEventContextBudget,
   buildAutomationTool,
   buildAskUserQuestionTool,
   buildBuiltinTools,
+  buildRuntimeEventModelReplayPlan,
   createBuiltinSandboxManager,
   createFilesystemWorkerLaunchSpecProvider,
   FilesystemWorkerClient,
@@ -26,6 +30,7 @@ import {
   evaluateAutomationCanFire,
   getAIModel,
   loadHistoryCompactBlocksFromArtifacts,
+  replayPlanItemsToModelMessages,
   resolveSkillDiscoveryPaths,
   resolveSelectedModelContextWindow,
   type AutomationDefinition,
@@ -56,7 +61,7 @@ import type { ModelChoice, ReadySessionTarget } from './connection-target.js';
 import { listReadyModelChoices, resolveDefaultSessionTarget, resolveSessionTargetForSlug } from './connection-target.js';
 import { buildCliSystemPrompt, buildCliTurnTailPrompt } from './cli-system-prompt.js';
 import { CliGoalContinuation } from './cli-goal-continuation.js';
-import { buildRecapMessages, cleanRecapText } from './session-recap.js';
+import { RECAP_INSTRUCTION, cleanRecapText } from './session-recap.js';
 
 export interface MakaCliRuntimeContext {
   workspaceRoot: string;
@@ -148,6 +153,11 @@ export async function createMakaCliRuntimeContext(
   const connectionStore = createConnectionStore(input.workspaceRoot);
   const credentialStore = createFileCredentialStore(input.workspaceRoot);
   const settingsStore = createSettingsStore(input.workspaceRoot);
+  // Authoritative RuntimeEvent read model (issue #1055's session-recap
+  // generator projects through this instead of re-deriving its own lossy
+  // StoredMessage-based projection). Built once and shared — mirrors
+  // SessionManager's own construction in session-manager.ts's readModel().
+  const runtimeReadModel = new RuntimeReadModel({ runStore, runtimeEventStore, projectionCache: store });
   const targetInput = {
     connectionStore,
     credentialStore,
@@ -310,13 +320,18 @@ export async function createMakaCliRuntimeContext(
   const recap: SessionRecapGenerator = {
     async generate(sessionId, reason) {
       let modelId = '';
-      let messageCount = 0;
+      // The actual bounded request sent to the model (projection + budget trim
+      // + trailing instruction), persisted verbatim to the artifact below.
+      let requestMessages: ModelMessage[] = [];
       let rawText = '';
       let cleaned = '';
       let errorMessage: string | undefined;
       try {
-        const messages = await runtime.getMessages(sessionId);
-        messageCount = messages.length;
+        // Authoritative RuntimeEvent projection (issue #1182 review): reuses
+        // the same read model, budget policy, and replay-plan projection the
+        // backend uses for its own history, instead of re-deriving a lossy
+        // StoredMessage-based one.
+        const view = await runtimeReadModel.getSessionView(sessionId);
         const header = await store.readHeader(sessionId);
         const ready = await resolveSessionTargetForSlug(header.llmConnectionSlug, {
           connectionStore,
@@ -337,6 +352,24 @@ export async function createMakaCliRuntimeContext(
           } : {}),
         });
         const contextWindow = resolveSelectedModelContextWindow(ready.connection, ready.model);
+        // Same budget-policy construction the backend uses (buildDefaultContextBudgetPolicy
+        // + applyRuntimeEventContextBudget), with the cap overridden to the
+        // recap-specific 85%-of-window-minus-4096 semantics. An unknown context
+        // window skips trimming entirely rather than guessing a cap.
+        let trimmedEvents = view.events;
+        if (contextWindow !== undefined) {
+          const budgetPolicy = buildDefaultContextBudgetPolicy(ready.connection, {
+            name: 'session-recap-history-budget',
+            modelId: ready.model,
+          });
+          if (budgetPolicy?.maxHistoryEstimatedTokens !== undefined) {
+            budgetPolicy.maxHistoryEstimatedTokens = Math.floor(contextWindow * 0.85) - 4096;
+          }
+          trimmedEvents = applyRuntimeEventContextBudget(view.events, budgetPolicy)?.events ?? view.events;
+        }
+        const plan = buildRuntimeEventModelReplayPlan(trimmedEvents);
+        requestMessages = replayPlanItemsToModelMessages(plan.items);
+        requestMessages.push({ role: 'user', content: RECAP_INSTRUCTION });
         const ai = await import('ai') as unknown as {
           generateText(opts: Record<string, unknown>): Promise<{ text: string }>;
         };
@@ -347,7 +380,7 @@ export async function createMakaCliRuntimeContext(
             modelId: ready.model,
             fetch: modelFetch,
           }),
-          messages: buildRecapMessages(messages, { contextWindow }),
+          messages: requestMessages,
           providerOptions: buildProviderOptions(ready.connection, ready.model, header.thinkingLevel),
           maxOutputTokens: 1024,
         });
@@ -368,7 +401,8 @@ export async function createMakaCliRuntimeContext(
               {
                 reason,
                 model: modelId,
-                messageCount,
+                messageCount: requestMessages.length,
+                messages: requestMessages,
                 raw: rawText,
                 cleaned,
                 ...(errorMessage ? { error: errorMessage } : {}),

--- a/packages/cli/src/runtime-bootstrap.ts
+++ b/packages/cli/src/runtime-bootstrap.ts
@@ -56,6 +56,7 @@ import type { ModelChoice, ReadySessionTarget } from './connection-target.js';
 import { listReadyModelChoices, resolveDefaultSessionTarget, resolveSessionTargetForSlug } from './connection-target.js';
 import { buildCliSystemPrompt, buildCliTurnTailPrompt } from './cli-system-prompt.js';
 import { CliGoalContinuation } from './cli-goal-continuation.js';
+import { buildRecapMessages, cleanRecapText } from './session-recap.js';
 
 export interface MakaCliRuntimeContext {
   workspaceRoot: string;
@@ -79,9 +80,24 @@ export interface MakaCliRuntimeContext {
   listShellRunUpdates(sessionId: string): Promise<ShellRunUpdate[]>;
   goalManager: GoalManager;
   goalContinuation: CliGoalContinuation;
+  /** One-sentence session recap generator (issue #1055), shared by `/recap` and idle-return auto-recap. */
+  recap: SessionRecapGenerator;
   close(): Promise<void>;
   /** API-key onboarding surface for the /setup wizard (#1098). */
   onboarding: MakaOnboardingSurface;
+}
+
+/**
+ * Generates a one-sentence recap of a session so far, using a tool-free model
+ * call whose exchange is never written to the session's own history. Never
+ * throws — failures resolve to `{ ok: false }` so callers can surface them
+ * without a try/catch.
+ */
+export interface SessionRecapGenerator {
+  generate(
+    sessionId: string,
+    reason: 'manual' | 'idle',
+  ): Promise<{ ok: true; text: string; raw: string } | { ok: false; error: string }>;
 }
 
 export interface CreateMakaCliRuntimeContextInput {
@@ -287,6 +303,88 @@ export async function createMakaCliRuntimeContext(
     },
     getTokenCount: (sessionId: string) => goalTokenCache.get(sessionId) ?? 0,
   });
+
+  // One-sentence session recap (issue #1055): a tool-free model call over the
+  // session's own history, never written back to it. Mirrors the goal
+  // evaluator's connection resolution + call shape above.
+  const recap: SessionRecapGenerator = {
+    async generate(sessionId, reason) {
+      let modelId = '';
+      let messageCount = 0;
+      let rawText = '';
+      let cleaned = '';
+      let errorMessage: string | undefined;
+      try {
+        const messages = await runtime.getMessages(sessionId);
+        messageCount = messages.length;
+        const header = await store.readHeader(sessionId);
+        const ready = await resolveSessionTargetForSlug(header.llmConnectionSlug, {
+          connectionStore,
+          credentialStore,
+          requestedModel: header.model,
+        });
+        modelId = ready.model;
+        const modelFetch = buildSubscriptionModelFetch({
+          connection: ready.connection,
+          sessionId: 'session-recap',
+          modelId: ready.model,
+          ...(ready.connection.providerType === 'claude-subscription' ? {
+            claude: {
+              cloakEnabled: isMakaClaudeSubscriptionCloakEnabled(),
+              deviceId: await getOrCreateCliClaudeDeviceId(input.workspaceRoot),
+              accountUuid: ready.oauthTokens?.account_uuid ?? '',
+            },
+          } : {}),
+        });
+        const contextWindow = resolveSelectedModelContextWindow(ready.connection, ready.model);
+        const ai = await import('ai') as unknown as {
+          generateText(opts: Record<string, unknown>): Promise<{ text: string }>;
+        };
+        const result = await ai.generateText({
+          model: getAIModel({
+            connection: ready.connection,
+            apiKey: ready.apiKey ?? '',
+            modelId: ready.model,
+            fetch: modelFetch,
+          }),
+          messages: buildRecapMessages(messages, { contextWindow }),
+          providerOptions: buildProviderOptions(ready.connection, ready.model, header.thinkingLevel),
+          maxOutputTokens: 1024,
+        });
+        rawText = result.text;
+        cleaned = cleanRecapText(rawText);
+        return { ok: true as const, text: cleaned, raw: rawText };
+      } catch (error) {
+        errorMessage = error instanceof Error ? error.message : String(error);
+        return { ok: false as const, error: errorMessage };
+      } finally {
+        try {
+          await artifactStore.create({
+            sessionId,
+            turnId: randomUUID(),
+            name: 'recap-request.json',
+            kind: 'file',
+            content: JSON.stringify(
+              {
+                reason,
+                model: modelId,
+                messageCount,
+                raw: rawText,
+                cleaned,
+                ...(errorMessage ? { error: errorMessage } : {}),
+              },
+              null,
+              2,
+            ),
+            ...(cleaned ? { summary: cleaned.slice(0, 100) } : {}),
+          });
+        } catch {
+          // Best-effort persistence; recap must work even if the artifact store fails.
+        }
+      }
+    },
+  };
+
   const goalTools = input.surface === 'tui'
     ? buildGoalTools({
         goalManager,
@@ -486,6 +584,7 @@ export async function createMakaCliRuntimeContext(
     goalManager,
     goalContinuation,
     onboarding: createApiKeyOnboardingSurface({ connectionStore, credentialStore, fetchModels: fetchProviderModels }),
+    recap,
     close: async () => {
       // Stop the automation scheduler's timer (else it keeps the process alive
       // and ticks into a stopped session), then terminate background shell runs.

--- a/packages/cli/src/session-recap.ts
+++ b/packages/cli/src/session-recap.ts
@@ -1,0 +1,157 @@
+import type { ModelMessage } from 'ai';
+import { userFacingText, type StoredMessage } from '@maka/core';
+
+/**
+ * Final instruction appended as the last user message when asking the model
+ * to recap a session. No tools are offered on this call and the exchange is
+ * never persisted to the session's own history.
+ */
+export const RECAP_INSTRUCTION =
+  '<system-reminder>The user is returning to this session after being away. Write ONE sentence (roughly 25-40 words) recapping where things stand so they can resume instantly. Lead with agency: "You asked ..." if the session was mainly questions or review with no landed change; "We fixed/added/wired ..." if the agent landed changes; exactly "You had just begun this session." if almost nothing happened. Output only the sentence - no labels, no quotes, no preamble.</system-reminder>';
+
+/** Idle gap (ms) after which the first normal prompt on return triggers an automatic recap. */
+export const AUTO_RECAP_IDLE_MS = 180_000;
+/** Minimum main-turn count (user-prompted turns) before an automatic recap may fire. */
+export const AUTO_RECAP_MIN_TURNS = 3;
+/** Raw-output size (bytes) above which an automatic recap is not surfaced in the transcript (still persisted). */
+export const AUTO_RECAP_DISPLAY_LIMIT_BYTES = 500;
+
+/** Projected messages are trimmed down to no fewer than this many, plus the instruction. */
+const MIN_PROJECTED_MESSAGES_KEPT = 4;
+
+function isToolPlaceholder(message: ModelMessage): boolean {
+  return (
+    message.role === 'assistant' &&
+    typeof message.content === 'string' &&
+    (message.content.startsWith('[tool: ') || message.content.startsWith('[tool result: '))
+  );
+}
+
+/**
+ * Projects one StoredMessage into a ModelMessage for the recap prompt, or
+ * `undefined` when the message contributes nothing (empty text, or a
+ * non-conversational bookkeeping row such as token usage / turn state /
+ * permission decisions / system notes).
+ */
+function projectMessage(message: StoredMessage): ModelMessage | undefined {
+  switch (message.type) {
+    case 'user': {
+      const text = userFacingText(message);
+      if (!text.trim()) return undefined;
+      return { role: 'user', content: text };
+    }
+    case 'assistant': {
+      if (!message.text.trim()) return undefined;
+      return { role: 'assistant', content: message.text };
+    }
+    case 'tool_call':
+      return { role: 'assistant', content: `[tool: ${message.toolName}]` };
+    case 'tool_result':
+      return { role: 'assistant', content: `[tool result: ${message.isError ? 'error' : 'ok'}]` };
+    default:
+      // permission_decision / token_usage / turn_state / system_note carry no
+      // conversational content for a recap.
+      return undefined;
+  }
+}
+
+function estimateTokens(messages: readonly ModelMessage[]): number {
+  const totalChars = messages.reduce((sum, message) => {
+    return sum + (typeof message.content === 'string' ? message.content.length : 0);
+  }, 0);
+  return Math.ceil(totalChars / 4);
+}
+
+/**
+ * Projects stored session messages into a recap prompt, appending
+ * `RECAP_INSTRUCTION` as the final user message. When `contextWindow` is
+ * known, trims to fit an 85%-of-window budget (minus a 4096-token safety
+ * margin): first the trailing run of dangling tool placeholders, then from
+ * the head — always keeping at least the last 4 projected messages plus the
+ * instruction.
+ */
+export function buildRecapMessages(
+  messages: readonly StoredMessage[],
+  budget: { contextWindow: number | undefined },
+): ModelMessage[] {
+  const instruction: ModelMessage = { role: 'user', content: RECAP_INSTRUCTION };
+  const projected: ModelMessage[] = [];
+  for (const message of messages) {
+    const entry = projectMessage(message);
+    if (entry) projected.push(entry);
+  }
+
+  if (budget.contextWindow === undefined) {
+    return [...projected, instruction];
+  }
+
+  const tokenBudget = Math.floor(budget.contextWindow * 0.85) - 4096;
+  let working = projected;
+  const withinBudget = () => estimateTokens([...working, instruction]) <= tokenBudget;
+
+  if (!withinBudget()) {
+    // Drop the trailing run of dangling tool placeholders first.
+    while (
+      working.length > MIN_PROJECTED_MESSAGES_KEPT &&
+      isToolPlaceholder(working[working.length - 1])
+    ) {
+      working = working.slice(0, -1);
+    }
+    // Still over budget: drop from the head, keeping the most recent messages.
+    while (working.length > MIN_PROJECTED_MESSAGES_KEPT && !withinBudget()) {
+      working = working.slice(1);
+    }
+  }
+
+  return [...working, instruction];
+}
+
+/**
+ * Cleans a raw model recap response: collapses whitespace, strips a leading
+ * `Recap:` / `Summary:` / `回顾：`-style label, strips one layer of wrapping
+ * quotes, and truncates to 1200 characters (with an ellipsis) if needed.
+ */
+export function cleanRecapText(raw: string): string {
+  let text = raw.replace(/\s+/g, ' ').trim();
+  text = text.replace(/^(recap|summary|回顾)\s*[:：]\s*/i, '').trim();
+
+  const quotePairs: ReadonlyArray<readonly [string, string]> = [
+    ['"', '"'],
+    ["'", "'"],
+    ['“', '”'],
+  ];
+  for (const [open, close] of quotePairs) {
+    if (text.length >= 2 && text.startsWith(open) && text.endsWith(close)) {
+      text = text.slice(open.length, text.length - close.length).trim();
+      break;
+    }
+  }
+
+  if (text.length > 1200) {
+    text = `${text.slice(0, 1200)}…`;
+  }
+  return text;
+}
+
+export interface ShouldAutoRecapInput {
+  /** Milliseconds since the last recorded user activity. */
+  idleMs: number;
+  /** Current main (user-prompted) turn count. */
+  mainTurnCount: number;
+  /** Main turn count as of the last recap (manual or automatic). */
+  lastRecapMainTurnCount: number;
+}
+
+/**
+ * Whether a normal-prompt submission after an idle gap should trigger an
+ * automatic recap: idle for at least `AUTO_RECAP_IDLE_MS`, at least
+ * `AUTO_RECAP_MIN_TURNS` main turns so far, and progress since the last recap
+ * (a per-main-turn watermark).
+ */
+export function shouldAutoRecap(input: ShouldAutoRecapInput): boolean {
+  return (
+    input.idleMs >= AUTO_RECAP_IDLE_MS &&
+    input.mainTurnCount >= AUTO_RECAP_MIN_TURNS &&
+    input.mainTurnCount > input.lastRecapMainTurnCount
+  );
+}

--- a/packages/cli/src/session-recap.ts
+++ b/packages/cli/src/session-recap.ts
@@ -1,13 +1,10 @@
-import type { ModelMessage } from 'ai';
-import { userFacingText, type StoredMessage } from '@maka/core';
-
 /**
  * Final instruction appended as the last user message when asking the model
  * to recap a session. No tools are offered on this call and the exchange is
  * never persisted to the session's own history.
  */
 export const RECAP_INSTRUCTION =
-  '<system-reminder>The user is returning to this session after being away. Write ONE sentence (roughly 25-40 words) recapping where things stand so they can resume instantly. Lead with agency: "You asked ..." if the session was mainly questions or review with no landed change; "We fixed/added/wired ..." if the agent landed changes; exactly "You had just begun this session." if almost nothing happened. Output only the sentence - no labels, no quotes, no preamble.</system-reminder>';
+  '<system-reminder>The user is returning to this session after being away. Write ONE sentence (roughly 25-40 words) recapping where things stand so they can resume instantly. Write the sentence in the language of the user\'s most recent substantive message; for mixed-language sessions use the dominant language of the user\'s messages. Lead with agency, phrased naturally in that language: if the session was mainly questions or review with no landed change, open by referencing what the user asked (the equivalent of "You asked ..."); if the agent landed changes, reference what was done (the equivalent of "We fixed/added/wired ..."); if almost nothing happened, say in that language that the session had just begun. Output only the sentence - no labels, no quotes, no preamble.</system-reminder>';
 
 /** Idle gap (ms) after which the first normal prompt on return triggers an automatic recap. */
 export const AUTO_RECAP_IDLE_MS = 180_000;
@@ -15,96 +12,6 @@ export const AUTO_RECAP_IDLE_MS = 180_000;
 export const AUTO_RECAP_MIN_TURNS = 3;
 /** Raw-output size (bytes) above which an automatic recap is not surfaced in the transcript (still persisted). */
 export const AUTO_RECAP_DISPLAY_LIMIT_BYTES = 500;
-
-/** Projected messages are trimmed down to no fewer than this many, plus the instruction. */
-const MIN_PROJECTED_MESSAGES_KEPT = 4;
-
-function isToolPlaceholder(message: ModelMessage): boolean {
-  return (
-    message.role === 'assistant' &&
-    typeof message.content === 'string' &&
-    (message.content.startsWith('[tool: ') || message.content.startsWith('[tool result: '))
-  );
-}
-
-/**
- * Projects one StoredMessage into a ModelMessage for the recap prompt, or
- * `undefined` when the message contributes nothing (empty text, or a
- * non-conversational bookkeeping row such as token usage / turn state /
- * permission decisions / system notes).
- */
-function projectMessage(message: StoredMessage): ModelMessage | undefined {
-  switch (message.type) {
-    case 'user': {
-      const text = userFacingText(message);
-      if (!text.trim()) return undefined;
-      return { role: 'user', content: text };
-    }
-    case 'assistant': {
-      if (!message.text.trim()) return undefined;
-      return { role: 'assistant', content: message.text };
-    }
-    case 'tool_call':
-      return { role: 'assistant', content: `[tool: ${message.toolName}]` };
-    case 'tool_result':
-      return { role: 'assistant', content: `[tool result: ${message.isError ? 'error' : 'ok'}]` };
-    default:
-      // permission_decision / token_usage / turn_state / system_note carry no
-      // conversational content for a recap.
-      return undefined;
-  }
-}
-
-function estimateTokens(messages: readonly ModelMessage[]): number {
-  const totalChars = messages.reduce((sum, message) => {
-    return sum + (typeof message.content === 'string' ? message.content.length : 0);
-  }, 0);
-  return Math.ceil(totalChars / 4);
-}
-
-/**
- * Projects stored session messages into a recap prompt, appending
- * `RECAP_INSTRUCTION` as the final user message. When `contextWindow` is
- * known, trims to fit an 85%-of-window budget (minus a 4096-token safety
- * margin): first the trailing run of dangling tool placeholders, then from
- * the head — always keeping at least the last 4 projected messages plus the
- * instruction.
- */
-export function buildRecapMessages(
-  messages: readonly StoredMessage[],
-  budget: { contextWindow: number | undefined },
-): ModelMessage[] {
-  const instruction: ModelMessage = { role: 'user', content: RECAP_INSTRUCTION };
-  const projected: ModelMessage[] = [];
-  for (const message of messages) {
-    const entry = projectMessage(message);
-    if (entry) projected.push(entry);
-  }
-
-  if (budget.contextWindow === undefined) {
-    return [...projected, instruction];
-  }
-
-  const tokenBudget = Math.floor(budget.contextWindow * 0.85) - 4096;
-  let working = projected;
-  const withinBudget = () => estimateTokens([...working, instruction]) <= tokenBudget;
-
-  if (!withinBudget()) {
-    // Drop the trailing run of dangling tool placeholders first.
-    while (
-      working.length > MIN_PROJECTED_MESSAGES_KEPT &&
-      isToolPlaceholder(working[working.length - 1])
-    ) {
-      working = working.slice(0, -1);
-    }
-    // Still over budget: drop from the head, keeping the most recent messages.
-    while (working.length > MIN_PROJECTED_MESSAGES_KEPT && !withinBudget()) {
-      working = working.slice(1);
-    }
-  }
-
-  return [...working, instruction];
-}
 
 /**
  * Cleans a raw model recap response: collapses whitespace, strips a leading

--- a/packages/runtime/src/history-compact-summarizer.ts
+++ b/packages/runtime/src/history-compact-summarizer.ts
@@ -105,7 +105,7 @@ async function loadAiSdkGenerateText(): Promise<AiSdkGenerateTextLike> {
 
 type ReplayPlanItems = ReturnType<typeof buildRuntimeEventModelReplayPlan>['items'];
 
-function replayPlanItemsToModelMessages(items: ReplayPlanItems): ModelMessage[] {
+export function replayPlanItemsToModelMessages(items: ReplayPlanItems): ModelMessage[] {
   const out: ModelMessage[] = [];
   for (const item of items) {
     if (item.kind === 'text') {

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -907,11 +907,18 @@ export type {
 } from './execution-inspect.js';
 
 // model-history.ts — policy-driven model-history projection.
-export { buildModelHistoryFromRuntimeEvents } from './model-history.js';
+export { buildModelHistoryFromRuntimeEvents, buildRuntimeEventModelReplayPlan } from './model-history.js';
 export type {
   ModelHistoryEntry,
   BuildModelHistoryOptions,
+  RuntimeEventModelReplayPlan,
+  RuntimeEventModelReplayItem,
 } from './model-history.js';
+
+// history-compact-summarizer.ts — replay-plan → ModelMessage[] projection
+// (issue #1055's session-recap generator reuses this authoritative slice
+// instead of re-deriving a lossy projection of its own).
+export { replayPlanItemsToModelMessages } from './history-compact-summarizer.js';
 
 // agent-flow.ts — formal Flow seam.
 export type {


### PR DESCRIPTION
Closes #1055.

## What

A one-sentence session recap for the TUI: manual `/recap`, plus an automatic recap on the first prompt submitted after returning from idle. The recap is a tool-free `generateText` call over the session's own history — never written back to it — mirroring the goal evaluator's connection resolution (`resolveSessionTargetForSlug` + `getAIModel` + `buildSubscriptionModelFetch` + `buildProviderOptions`).

| | Manual `/recap` | Auto (idle return) |
|---|---|---|
| Trigger | slash command | first normal prompt after ≥3 min idle |
| Min main turns | ≥1 | ≥3 |
| Repeat | in-flight lock | once per main turn (watermark) |
| Display | always | suppressed if raw output >500 bytes; discarded if a later prompt supersedes it |

## How

- `session-recap.ts` (new): pure core — `StoredMessage → ModelMessage` projection (tool calls/results become one-line placeholders), 85%-of-context front-trim budget (minus 4k headroom, trailing dangling tool placeholders dropped first, last 4 messages always kept), output cleaning (whitespace/label/quote strip, 1200-char cap), and the auto-trigger predicate.
- `runtime-bootstrap.ts`: `SessionRecapGenerator` — the model call face, plus best-effort persistence of every request as a session artifact (`recap-request.json` via the existing `ArtifactStore`) with reason/model/messageCount/raw/cleaned.
- `pi-tui-runner.ts`: `/recap` command, idle clock (refreshed on prompt submit and turn end), and staleness via a synchronous prompt-seq epoch — the baseline is captured after the triggering prompt's own bump, so only a *later* prompt discards an in-flight auto recap.
- Result renders as an existing `notice` transcript entry (`Recap: …`).

## Deviations from the issue

- **Prefix reuse is approximate, not byte-identical**: exact reuse needs a generic tool-free converse surface on `AgentBackend` (only `send`/`compactHistory` exist today). The projection keeps message order/content so provider KV cache still hits well (~96% observed in manual testing); byte-identical reuse left as a follow-up.
- **Persistence** uses the repo-native `ArtifactStore` instead of a bespoke `{session_dir}/recap_requests/` directory.

## Testing

- 21 unit tests over the pure core (projection, budget trim boundaries, cleaning, auto-trigger gates) + 7 runner tests via the existing harness (unavailable / nothing-to-recap / success / failure / in-flight lock / stale-discard / non-stale-display). The stale-discard test was verified non-vacuous: it fails against the pre-fix staleness check.
- Full `packages/cli` suite: 526/526 pass; workspace typecheck and `biome lint` clean.
- Manually verified end-to-end in the real TUI (tmux-driven and interactive): `/recap` after a multi-turn session produced a correct `Recap: You asked …` notice, and the artifact landed under `artifacts/{sessionId}/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)