### PR TITLE
fix(shell): unmount the workbar toggle where no workbar exists

### DIFF
--- a/apps/desktop/src/main/__tests__/app-shell-chrome-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/app-shell-chrome-contract.test.ts
@@ -61,11 +61,15 @@ describe('app shell chrome contract', () => {
     assert.match(combined, /aria-label=\{workbarLabel\}/);
   });
 
-  it('keeps the workbar toggle unavailable until a session is active', async () => {
+  it('renders the workbar toggle only when a session is active', async () => {
     const combined = await readRendererShellCombinedSource();
 
+    // The toggle used to render disabled on module pages (MCP / skills / …)
+    // where no workbar exists — a dead button in the topbar. It now
+    // unmounts entirely when unavailable.
     assert.match(combined, /workbarAvailable: boolean/);
-    assert.match(combined, /<UiButton variant="quiet" size="icon-sm" disabled=\{!props\.workbarAvailable\} \/>/);
-    assert.match(combined, /aria-expanded=\{props\.workbarAvailable && !props\.workbarCollapsed\}/);
+    assert.match(combined, /\{props\.workbarAvailable && \([\s\S]*?onClick=\{props\.onToggleWorkbar\}/);
+    assert.doesNotMatch(combined, /disabled=\{!props\.workbarAvailable\}/);
+    assert.match(combined, /aria-expanded=\{!props\.workbarCollapsed\}/);
   });
 });

--- a/apps/desktop/src/renderer/app-shell-chrome-actions.tsx
+++ b/apps/desktop/src/renderer/app-shell-chrome-actions.tsx
@@ -82,11 +82,7 @@ export function AppShellWorkspaceTopActions(props: {
 }) {
   const locale = useUiLocale();
   const copy = getShellCopy(locale).chrome;
-  const workbarLabel = !props.workbarAvailable
-    ? copy.workbarUnavailable
-    : props.workbarCollapsed
-      ? copy.expandWorkbar
-      : copy.collapseWorkbar;
+  const workbarLabel = props.workbarCollapsed ? copy.expandWorkbar : copy.collapseWorkbar;
 
   return (
     <div className="maka-workspace-top-actions" role="toolbar" aria-label={copy.workspaceActions}>
@@ -138,19 +134,21 @@ export function AppShellWorkspaceTopActions(props: {
         </TooltipTrigger>
         <TooltipContent>{copy.openHealth}</TooltipContent>
       </Tooltip>
-      <Tooltip>
-        <TooltipTrigger
-          render={<UiButton variant="quiet" size="icon-sm" disabled={!props.workbarAvailable} />}
-          type="button"
-          className="maka-titlebar-action"
-          onClick={props.onToggleWorkbar}
-          aria-label={workbarLabel}
-          aria-expanded={props.workbarAvailable && !props.workbarCollapsed}
-        >
-          {props.workbarCollapsed ? <PanelRightOpen aria-hidden="true" /> : <PanelRightClose aria-hidden="true" />}
-        </TooltipTrigger>
-        <TooltipContent>{workbarLabel}</TooltipContent>
-      </Tooltip>
+      {props.workbarAvailable && (
+        <Tooltip>
+          <TooltipTrigger
+            render={<UiButton variant="quiet" size="icon-sm" />}
+            type="button"
+            className="maka-titlebar-action"
+            onClick={props.onToggleWorkbar}
+            aria-label={workbarLabel}
+            aria-expanded={!props.workbarCollapsed}
+          >
+            {props.workbarCollapsed ? <PanelRightOpen aria-hidden="true" /> : <PanelRightClose aria-hidden="true" />}
+          </TooltipTrigger>
+          <TooltipContent>{workbarLabel}</TooltipContent>
+        </Tooltip>
+      )}
     </div>
   );
 }

--- a/apps/desktop/src/renderer/locales/shell-copy.ts
+++ b/apps/desktop/src/renderer/locales/shell-copy.ts
@@ -356,7 +356,6 @@ type ShellCopy = {
     expandSidebar: string;
     collapseSidebar: string;
     newTask: string;
-    workbarUnavailable: string;
     expandWorkbar: string;
     collapseWorkbar: string;
     workspaceActions: string;
@@ -987,7 +986,6 @@ const SHELL_COPY_BY_LOCALE = {
       expandSidebar: '展开侧边栏',
       collapseSidebar: '收起侧边栏',
       newTask: '新任务',
-      workbarUnavailable: '暂无可用的会话工作栏',
       expandWorkbar: '展开会话工作栏',
       collapseWorkbar: '收起会话工作栏',
       workspaceActions: '工作区辅助操作',
@@ -1443,7 +1441,6 @@ const SHELL_COPY_BY_LOCALE = {
       expandSidebar: 'Expand sidebar',
       collapseSidebar: 'Collapse sidebar',
       newTask: 'New task',
-      workbarUnavailable: 'No conversation workbar is available',
       expandWorkbar: 'Expand conversation workbar',
       collapseWorkbar: 'Collapse conversation workbar',
       workspaceActions: 'Workspace actions',


### PR DESCRIPTION
User-reported (MCP page screenshot): the rightmost topbar button does nothing there.

The right-panel (workbar) collapse toggle rendered on every surface and was merely `disabled` on module pages (MCP / 技能 / 每日回顾 / 定时任务) where no workbar exists — a dead control. It now unmounts entirely when `workbarAvailable` is false: chat sessions keep the working toggle, module pages drop it.

- app-shell-chrome-contract re-pinned: "keeps the toggle unavailable" (disabled-pattern) → "renders only when a session is active" (hidden-pattern, with a doesNotMatch on the old disabled prop).
- Unused workbarUnavailable copy (zh+en+type) removed from the shell catalog.

Gates: desktop 2693/2693 · ui 183/183 · typecheck · check-dead-css · knip ×2 = 0. CDP: module-skills topbar = 4 actions (toggle gone), turn-narrative = 5 with 收起会话工作栏, zero disabled buttons on either.