### PR TITLE
fix(modules): unbox 每日回顾 + 定时任务, converge daily-review onto the house language

### DIFF
--- a/apps/desktop/src/main/__tests__/radius-converge-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/radius-converge-contract.test.ts
@@ -398,13 +398,18 @@ describe('radius token governance (#406 gap 4)', () => {
       '.maka-first-run-checklist': '--radius-surface',
       '.providerLogo': '--radius-surface',
       '.maka-browser-address': '--radius-control',
-      '.maka-plan-shell': '--radius-surface',
+      // .maka-plan-shell dropped: unboxed to a plain layout container
+      // (the MCP page set the no-outer-frame precedent) — no card chrome,
+      // no radius.
       '.maka-plan-card': '--radius-surface',
       '.maka-plan-template-strip[data-layout="cards"] .maka-plan-template-card': '--radius-surface',
       // .maka-skill-library dropped: unboxed to a plain layout container
       // (the MCP page set the no-outer-frame precedent) — no card chrome,
       // no radius.
-      '.maka-module-main .maka-daily-review-panel': '--radius-surface',
+      // .maka-module-main .maka-daily-review-panel dropped: unboxed to a
+      // plain layout container alongside the skills / plan module unbox
+      // (the MCP page set the no-outer-frame precedent) — no card chrome,
+      // no radius.
       // .maka-daily-review-info dropped: unboxed to a plain hint line in
       // the daily-review IA restructure — no card chrome, no radius.
       '.maka-daily-review-archive-body': '--radius-surface',

--- a/apps/desktop/src/renderer/styles/daily-review.css
+++ b/apps/desktop/src/renderer/styles/daily-review.css
@@ -288,23 +288,12 @@
   white-space: nowrap;
 }
 
-.maka-daily-review-alert {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: var(--space-2);
-    padding: var(--space-2) var(--space-2-5);
-    border: var(--border-width-hairline) solid oklch(from var(--warning, var(--info)) l c h / 0.3);
-    border-radius: var(--radius-surface);
-    background: oklch(from var(--warning, var(--info)) l c h / 0.08);
-    color: var(--warning-text, var(--foreground));
-    font-size: var(--font-size-ui);
-  }
-
-.maka-daily-review-alert > span {
-    min-width: 0;
-  }
-
+/* Convergence (maintainer 2026-07-18): the retry alert re-implemented the
+   warning surface (flex row + hairline border + tinted bg + radius) by hand,
+   fighting the Alert primitive's own grid slot layout. The `warning` variant
+   already owns border / tint / radius / padding and the description↔action
+   split, so the bespoke chrome is dropped — the shared primitive renders it.
+   Only the retry button keeps `flex: none` so it never shrinks. */
 .maka-daily-review-alert-retry {
   flex: none;
 }
@@ -333,41 +322,23 @@
     background: oklch(from var(--destructive, var(--warning, var(--info))) l c h / 0.06);
   }
 
-/* PR-DAILY-REVIEW-EYEBROW-RHYTHM-0 (WAWQAQ msg `7f0ec4a5`): granularity
-   bump. Each section now starts with a prominent eyebrow badge above
-   the title and a leading accent bar to the left, applying the editorial
-   "minimalist-ui §5 keystroke badges" + "design-taste-frontend §3
-   eyebrow + accent bar" rules from the skills audit. Visible every time
-   the user opens Daily Review. */
+/* Convergence (maintainer 2026-07-18): the 活跃对话 / 模型使用 / 工具调用
+   section titles were a hand-rolled uppercase eyebrow with a bespoke accent
+   bar — the exact dialect section-header.tsx was built to retire — while the
+   已生成报告 header on the same page already spoke the SectionHeader
+   primitive. All section titles now render through SectionHeader (as="h4"
+   accent), so the whole page shares one section-header language. The wrapper
+   keeps only the between-section divider rhythm; the divider token converges
+   to `--foreground-10` to match the header / quick-runs / archives dividers. */
 .maka-daily-review-section {
     display: grid;
     gap: var(--space-2);
     padding: var(--space-3) 0 0;
-    border-top: var(--border-width-hairline) solid oklch(from var(--foreground) l c h / 0.07);
+    border-top: var(--border-width-hairline) solid var(--foreground-10);
   }
 .maka-daily-review-section:first-of-type {
     border-top: 0;
     padding-top: var(--space-1);
-  }
-.maka-daily-review-section-title {
-    display: inline-flex;
-    align-items: center;
-    gap: var(--space-2);
-    font-size: var(--font-size-caption);
-    font-weight: var(--font-weight-semibold);
-    letter-spacing: var(--tracking-widest);
-    text-transform: uppercase;
-    color: var(--foreground-secondary);
-    margin: 0;
-  }
-.maka-daily-review-section-title::before {
-    content: '';
-    display: inline-block;
-    width: 3px;
-    height: 12px;
-    border-radius: var(--radius-pill);
-    background: oklch(from var(--status-running) l c h / 0.85);
-    flex-shrink: 0;
   }
 .maka-daily-review-list {
     list-style: none;

--- a/apps/desktop/src/renderer/styles/daily-review.css
+++ b/apps/desktop/src/renderer/styles/daily-review.css
@@ -1,17 +1,14 @@
-/* Daily Review page-card chrome — recipe parity with
-   Skills + Plan shells (1px hairline border + 6px radius + 4% lift + inner
-   highlight). Was flat (transparent) which felt orphaned next to the other
-   module pages. */
+/* Unboxed (maintainer 2026-07-18): the outer card chrome wrapped the whole
+   每日回顾 module (time bar + quick-runs + archives + stats) in a second frame
+   the MCP page never had — the inner surfaces (archive body, stat tiles,
+   alerts) already carry their own borders, so the wrapper read as a
+   box-in-box. Plain layout container now; padding 0 so content sits flush
+   with the module header like the skills / MCP pages. Width converged
+   980 -> 900 to track the module header's `min(100%, 900px)` measure. */
 .maka-module-main .maka-daily-review-panel {
-    max-width: 980px;
-    width: 100%;
+    width: min(100%, 900px);
     margin-inline: auto;
-    background: var(--card-bg);
-    border: var(--border-width-hairline) solid var(--card-border-color);
-    border-radius: var(--radius-surface);
-    box-shadow:
-      var(--card-shadow),
-      var(--card-highlight);
+    padding: 0;
   }
 /* IA restructure: header is now the single time-context bar —
    stepper + day label on the left, 今日/本周/本月 tabs on the right

--- a/apps/desktop/src/renderer/styles/module-pages/plan-reminders.css
+++ b/apps/desktop/src/renderer/styles/module-pages/plan-reminders.css
@@ -11,15 +11,12 @@
   width: 100%;
 }
 
-/* PR-UI-ALIGN-2 (2026-06-21): the page content is NOT a nested card — it
-   fills the one floating content-area card directly, exactly like 参考实现's
-   定时任务 page (header → banner → tabs → grid sit straight on the white card).
-   Removed the inner border/radius/shadow/1080-center so there's no card-in-card,
-   and opened up the padding so the page breathes like the reference. */
-/* Plan/Reminder
-   page card uses the universal recipe: 1px hairline border + 6px radius +
-   single 4% lift + 1px inner top highlight. Tight 4-6px internal gaps
-   (`--card-gap`) replace the old 14-18px loose stacking. */
+/* Unboxed (maintainer 2026-07-18): the outer card chrome wrapped the whole
+   定时任务 module (hero + system alert + tabs + card grid) in a second frame
+   the MCP page never had — the inner surfaces (system alert, template cards,
+   task cards, run rows, form) already carry their own borders, so the wrapper
+   read as a box-in-box. Plain layout container now; content aligns flush with
+   the module header like the skills / MCP pages. */
 .maka-plan-shell {
   width: min(100%, 900px);
   margin-inline: auto;
@@ -28,13 +25,7 @@
      `--agents-content-area-gap: 4px`; 8 keeps long-page readability while
      pulling toward the dense reference cadence). */
   gap: var(--space-2);
-  padding: var(--space-4) var(--space-5) var(--space-5);
-  background: var(--card-bg);
-  border: var(--border-width-hairline) solid var(--card-border-color);
-  border-radius: var(--radius-surface);
-  box-shadow:
-    var(--card-shadow),
-    var(--card-highlight);
+  padding: 0;
 }
 
 .maka-plan-hero {

--- a/packages/ui/src/daily-review-panel.tsx
+++ b/packages/ui/src/daily-review-panel.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { Button as BaseButton } from '@base-ui/react/button';
 import { useMountedRef } from './use-mounted-ref.js';
-import { CalendarDays } from './icons.js';
+import { CalendarDays, ChevronLeft, ChevronRight } from './icons.js';
 import { SettingsSelect } from './primitives/settings-select.js';
 import type {
   DailyReviewArchive,
@@ -313,7 +313,7 @@ export function DailyReviewPanel(props: {
             onClick={() => setOffsetDays((n) => n - range)}
             aria-label={`查看更早一${stepperLabel}`}
           >
-            ‹
+            <ChevronLeft aria-hidden="true" />
           </UiButton>
           <div className="maka-daily-review-day">{dayLabel}</div>
           <UiButton
@@ -325,7 +325,7 @@ export function DailyReviewPanel(props: {
             disabled={offsetDays >= 0}
             aria-label={`查看更晚一${stepperLabel}`}
           >
-            ›
+            <ChevronRight aria-hidden="true" />
           </UiButton>
         </div>
       </header>
@@ -589,7 +589,7 @@ export function DailyReviewPanel(props: {
 
           {visibleSummary.sessions.length > 0 && (
             <section className="maka-daily-review-section" aria-label="活跃对话">
-              <h4 className="maka-daily-review-section-title">活跃对话</h4>
+              <SectionHeader as="h4" accent title="活跃对话" />
               <ul className="maka-daily-review-list" aria-label="活跃对话列表">
                 {visibleSummary.sessions.map((session) => (
                   <li key={session.id} className="maka-daily-review-list-item">
@@ -718,7 +718,7 @@ function DailyReviewTotalsCell(props: { label: string; value: string; tone?: 'er
 function DailyReviewTopList(props: { title: string; entries: ReadonlyArray<DailyReviewTopEntry> }) {
   return (
     <section className="maka-daily-review-section" aria-label={props.title}>
-      <h4 className="maka-daily-review-section-title">{props.title}</h4>
+      <SectionHeader as="h4" accent title={props.title} />
       <ul className="maka-daily-review-list" aria-label={`${props.title}列表`}>
         {props.entries.map((entry) => (
           <li key={entry.key} className="maka-daily-review-list-item">


### PR DESCRIPTION
Follow-up to #1185 (skills unbox), user-confirmed: the same outer card frame wraps 每日回顾 and 定时任务 — both removed — plus the requested daily-review restyle (不太符合我们的风格 → 重构和优化和美化). One batched PR.

## Unbox (same pattern as #1185)
- .maka-plan-shell (定时任务) and .maka-module-main .maka-daily-review-panel (每日回顾): card chrome stripped, padding → 0, content flush with the module header like skills/MCP. daily-review width converged 980 → min(100%, 900px) to match the header measure. Inner surfaces keep their own borders — nothing floats.
- radius-converge-contract entries dropped with the established unboxing notes.

## Daily-review restyle (presentation-only, zero behavior change)
| Drift | Converged to |
|---|---|
| 活跃对话/模型使用/工具调用 hand-rolled uppercase-eyebrow h4 + bespoke accent bar (the dialect SectionHeader was built to retire) | SectionHeader as="h4" accent — one section-header language page-wide |
| Day-stepper ‹ › bare text glyphs | ChevronLeft/ChevronRight from @maka/ui/icons (governance-compliant, stepper contract pins preserved) |
| .maka-daily-review-alert hand-reimplemented the warning surface with a non-house radius | Alert warning variant owns the chrome |
| One-off 0.07-alpha section divider | --foreground-10, matching sibling dividers |

StatTile/Item/Chip/Segmented/EmptyState usage was already on-language and untouched.

## Gates
Tree already contains current main tip. desktop 2695/2695 · ui 183/183 · typecheck · check-dead-css · knip ×2 = 0 · alignment auditor clean · console/a11y/copy checks 0. CDP light+dark before/after on both pages: frame gone, content flush, each inner card keeps its border; skills page byte-equivalent (untouched). Implemented by an opus worktree agent; verified post-merge.