### PR TITLE
feat(cli): add session working directory move

### DIFF
--- a/packages/cli/src/__tests__/pi-tui-runner.test.ts
+++ b/packages/cli/src/__tests__/pi-tui-runner.test.ts
@@ -27,6 +27,7 @@ import {
 import type {
   MakaPreparePromptOptions,
   MakaPreparedSessionTurn,
+  MakaSessionMoveResult,
   MakaSessionDriver,
   MakaSessionRewindResult,
   MakaSessionSwitchResult,
@@ -3681,6 +3682,66 @@ describe('Maka Pi TUI runner', () => {
     ]);
   });
 
+  test('handles /move without sending a prompt and warns about dirty old cwd', async () => {
+    const terminal = new FakeTerminal();
+    const driver = new SlashCommandDriver();
+    const run = runMakaPiTui({
+      title: 'Maka',
+      driver,
+      cwd: '/repo',
+      model: 'claude-sonnet-4-5',
+      connectionSlug: 'claude-subscription',
+      permissionMode: 'ask',
+      terminal,
+    });
+
+    terminal.input('/move /repo/.worktree/feature');
+    terminal.input('\r');
+
+    await waitFor(() => driver.moves.length === 1);
+    await waitFor(() => plainTerminalOutput(terminal.output()).includes('uncommitted changes'));
+    assert.deepEqual(driver.moves, ['/repo/.worktree/feature']);
+    assert.deepEqual(driver.prompts, []);
+
+    exitMaka(terminal);
+    await Promise.race([
+      run,
+      delay(50).then(() => {
+        throw new Error('TUI did not close during test cleanup');
+      }),
+    ]);
+  });
+
+  test('opens the /move directory picker', async () => {
+    const terminal = new FakeTerminal();
+    const driver = new SlashCommandDriver();
+    const run = runMakaPiTui({
+      title: 'Maka',
+      driver,
+      cwd: '/repo',
+      model: 'claude-sonnet-4-5',
+      connectionSlug: 'claude-subscription',
+      permissionMode: 'ask',
+      terminal,
+    });
+
+    terminal.input('/move');
+    terminal.input('\r');
+    await waitFor(() => plainTerminalOutput(terminal.output()).includes('Move Session'));
+    terminal.input('/repo/.worktree/feature');
+    terminal.input('\r');
+    await waitFor(() => driver.moves.length === 1);
+    assert.deepEqual(driver.moves, ['/repo/.worktree/feature']);
+
+    exitMaka(terminal);
+    await Promise.race([
+      run,
+      delay(50).then(() => {
+        throw new Error('TUI did not close during test cleanup');
+      }),
+    ]);
+  });
+
   test('rejects /rename without a new name', async () => {
     const terminal = new FakeTerminal();
     const driver = new SlashCommandDriver();
@@ -7181,6 +7242,7 @@ class SlashCommandDriver implements MakaSessionDriver {
   readonly thinkingLevelUpdates: Array<ThinkingLevel | undefined> = [];
   readonly sessionIds: string[] = [];
   readonly renames: string[] = [];
+  readonly moves: string[] = [];
   startNewSessionCalls = 0;
   protected sessionId = 'session-1';
 
@@ -7245,6 +7307,15 @@ class SlashCommandDriver implements MakaSessionDriver {
   }
   async renameSession(name: string): Promise<void> {
     this.renames.push(name);
+  }
+  async moveSession(cwd: string): Promise<MakaSessionMoveResult> {
+    this.moves.push(cwd);
+    return {
+      previousCwd: '/repo',
+      cwd,
+      changed: true,
+      oldCwdDirty: true,
+    };
   }
   async setPermissionMode(mode: PermissionMode): Promise<void> {
     this.permissionModes.push(mode);

--- a/packages/cli/src/__tests__/pi-tui-runner.test.ts
+++ b/packages/cli/src/__tests__/pi-tui-runner.test.ts
@@ -3712,6 +3712,35 @@ describe('Maka Pi TUI runner', () => {
     ]);
   });
 
+  test('preserves repeated whitespace in a quoted /move path', async () => {
+    const terminal = new FakeTerminal();
+    const driver = new SlashCommandDriver();
+    const run = runMakaPiTui({
+      title: 'Maka',
+      driver,
+      cwd: '/repo',
+      model: 'claude-sonnet-4-5',
+      connectionSlug: 'claude-subscription',
+      permissionMode: 'ask',
+      terminal,
+    });
+
+    terminal.input('/move "/repo/a  b"');
+    terminal.input('\r');
+
+    await waitFor(() => driver.moves.length === 1);
+    assert.deepEqual(driver.moves, ['"/repo/a  b"']);
+    assert.deepEqual(driver.prompts, []);
+
+    exitMaka(terminal);
+    await Promise.race([
+      run,
+      delay(50).then(() => {
+        throw new Error('TUI did not close during test cleanup');
+      }),
+    ]);
+  });
+
   test('opens the /move directory picker', async () => {
     const terminal = new FakeTerminal();
     const driver = new SlashCommandDriver();

--- a/packages/cli/src/__tests__/session-driver.test.ts
+++ b/packages/cli/src/__tests__/session-driver.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { mkdtemp, rm } from 'node:fs/promises';
+import { mkdir, mkdtemp, realpath, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, test } from 'node:test';
@@ -239,6 +239,97 @@ describe('Maka session driver', () => {
 
     await assert.rejects(driver.renameSession('too early'), /before a session starts/);
     assert.deepEqual(runtime.sessionUpdates, []);
+  });
+
+  test('moves an active session, warns about dirty old cwd, and injects one replayable reminder', async () => {
+    const oldCwd = await mkdtemp(join(tmpdir(), 'maka-move-old-'));
+    const nextCwd = join(oldCwd, 'worktree-next');
+    await mkdir(nextCwd);
+    try {
+      const runtime = new RecordingRuntime();
+      const inspected: string[] = [];
+      const canonicalNextCwd = await realpath(nextCwd);
+      const driver = createMakaSessionDriver({
+        runtime,
+        cwd: oldCwd,
+        llmConnectionSlug: 'anthropic',
+        model: 'claude-sonnet-4-5',
+        inspectCwdChanges: async (cwd) => {
+          inspected.push(cwd);
+          return true;
+        },
+        newId: nextId('turn'),
+      });
+
+      await collectPrompt(driver, 'before move');
+      const result = await driver.moveSession!(nextCwd);
+      assert.deepEqual(result, {
+        previousCwd: oldCwd,
+        cwd: canonicalNextCwd,
+        changed: true,
+        oldCwdDirty: true,
+      });
+      assert.deepEqual(inspected, [oldCwd]);
+      assert.deepEqual(runtime.sessionUpdates.at(-1), {
+        sessionId: 'session-1',
+        patch: { cwd: canonicalNextCwd },
+      });
+
+      await collectPrompt(driver, 'after move');
+      assert.match(runtime.sent.at(-1)?.input.text ?? '', new RegExp(`<system-reminder>.*${escapeRegExp(oldCwd)}.*${escapeRegExp(canonicalNextCwd)}`));
+      assert.equal(runtime.sent.at(-1)?.input.displayText, 'after move');
+
+      await collectPrompt(driver, 'later turn');
+      assert.equal(runtime.sent.at(-1)?.input.text, 'later turn');
+    } finally {
+      await rm(oldCwd, { recursive: true, force: true });
+    }
+  });
+
+  test('rejects empty, missing, and non-directory move targets before persistence', async () => {
+    const oldCwd = await mkdtemp(join(tmpdir(), 'maka-move-validate-'));
+    const file = join(oldCwd, 'file.txt');
+    const { writeFile } = await import('node:fs/promises');
+    await writeFile(file, 'file');
+    try {
+      const runtime = new RecordingRuntime();
+      const driver = createMakaSessionDriver({
+        runtime,
+        cwd: oldCwd,
+        llmConnectionSlug: 'anthropic',
+        model: 'claude-sonnet-4-5',
+      });
+      await collectPrompt(driver, 'start');
+      await assert.rejects(driver.moveSession!(''), /cannot be empty/);
+      await assert.rejects(driver.moveSession!(join(oldCwd, 'missing')), /does not exist/);
+      await assert.rejects(driver.moveSession!(file), /not a directory/);
+      assert.deepEqual(runtime.sessionUpdates, []);
+    } finally {
+      await rm(oldCwd, { recursive: true, force: true });
+    }
+  });
+
+  test('does not carry a pending cwd reminder into a new session', async () => {
+    const oldCwd = await mkdtemp(join(tmpdir(), 'maka-move-new-session-'));
+    const nextCwd = join(oldCwd, 'next');
+    await mkdir(nextCwd);
+    try {
+      const runtime = new RecordingRuntime();
+      const driver = createMakaSessionDriver({
+        runtime,
+        cwd: oldCwd,
+        llmConnectionSlug: 'anthropic',
+        model: 'claude-sonnet-4-5',
+        inspectCwdChanges: async () => false,
+      });
+      await collectPrompt(driver, 'first');
+      await driver.moveSession!(nextCwd);
+      driver.startNewSession();
+      await collectPrompt(driver, 'new session');
+      assert.equal(runtime.sent.at(-1)?.input.text, 'new session');
+    } finally {
+      await rm(oldCwd, { recursive: true, force: true });
+    }
   });
 
   test('switches to an existing session for the next prompt', async () => {
@@ -746,7 +837,7 @@ class RecordingRuntime {
   readonly permissionResponses: Array<{ sessionId: string; response: PermissionResponse }> = [];
   readonly userQuestionResponses: Array<{ sessionId: string; response: UserQuestionResponse }> = [];
   readonly permissionModes: Array<{ sessionId: string; mode: PermissionMode }> = [];
-  readonly sessionUpdates: Array<{ sessionId: string; patch: { model?: string; llmConnectionSlug?: string; thinkingLevel?: import('@maka/core/model-thinking').ThinkingLevel | undefined; name?: string } }> = [];
+  readonly sessionUpdates: Array<{ sessionId: string; patch: { cwd?: string; model?: string; llmConnectionSlug?: string; thinkingLevel?: import('@maka/core/model-thinking').ThinkingLevel | undefined; name?: string } }> = [];
   readonly branched: Array<{ sessionId: string; sourceTurnId: string }> = [];
   readonly branchedBefore: Array<{ sessionId: string; sourceTurnId: string }> = [];
   readonly sessionMessages = new Map<string, StoredMessage[]>();
@@ -857,10 +948,11 @@ class RecordingRuntime {
     };
   }
 
-  async updateSession(sessionId: string, patch: { model?: string; llmConnectionSlug?: string; thinkingLevel?: import('@maka/core/model-thinking').ThinkingLevel | undefined; name?: string }): Promise<SessionSummary> {
+  async updateSession(sessionId: string, patch: { cwd?: string; model?: string; llmConnectionSlug?: string; thinkingLevel?: import('@maka/core/model-thinking').ThinkingLevel | undefined; name?: string }): Promise<SessionSummary> {
     this.sessionUpdates.push({ sessionId, patch });
     return {
       id: sessionId,
+      cwd: patch.cwd ?? '/repo',
       name: 'New Chat',
       isFlagged: false,
       isArchived: false,

--- a/packages/cli/src/__tests__/session-driver.test.ts
+++ b/packages/cli/src/__tests__/session-driver.test.ts
@@ -272,7 +272,10 @@ describe('Maka session driver', () => {
       assert.deepEqual(inspected, [oldCwd]);
       assert.deepEqual(runtime.sessionUpdates.at(-1), {
         sessionId: 'session-1',
-        patch: { cwd: canonicalNextCwd },
+        patch: {
+          cwd: canonicalNextCwd,
+          pendingCwdReminder: { from: oldCwd, to: canonicalNextCwd },
+        },
       });
 
       await collectPrompt(driver, 'after move');
@@ -371,6 +374,40 @@ describe('Maka session driver', () => {
       assert.equal(runtime.sent[0]?.sessionId, 'session-2');
     } finally {
       await rm(repo, { recursive: true, force: true });
+    }
+  });
+
+  test('restores a persisted cwd reminder when resuming a moved session', async () => {
+    const oldCwd = await mkdtemp(join(tmpdir(), 'maka-move-persisted-old-'));
+    const nextCwd = join(oldCwd, 'worktree-next');
+    await mkdir(nextCwd);
+    try {
+      const runtime = new RecordingRuntime();
+      const canonicalNextCwd = await realpath(nextCwd);
+      runtime.sessionSummaries = [{
+        ...sessionSummary({ id: 'session-2', cwd: canonicalNextCwd }),
+        pendingCwdReminder: { from: oldCwd, to: canonicalNextCwd },
+      }];
+      const driver = createMakaSessionDriver({
+        runtime,
+        cwd: oldCwd,
+        llmConnectionSlug: 'anthropic',
+        model: 'claude-sonnet-4-5',
+      });
+
+      await driver.switchSession('session-2');
+      await collectPrompt(driver, 'after restart');
+
+      assert.match(
+        runtime.sent.at(-1)?.input.text ?? '',
+        new RegExp(`<system-reminder>.*${escapeRegExp(oldCwd)}.*${escapeRegExp(canonicalNextCwd)}`),
+      );
+      assert.deepEqual(runtime.sessionUpdates.at(-1), {
+        sessionId: 'session-2',
+        patch: { pendingCwdReminder: undefined },
+      });
+    } finally {
+      await rm(oldCwd, { recursive: true, force: true });
     }
   });
 
@@ -837,7 +874,7 @@ class RecordingRuntime {
   readonly permissionResponses: Array<{ sessionId: string; response: PermissionResponse }> = [];
   readonly userQuestionResponses: Array<{ sessionId: string; response: UserQuestionResponse }> = [];
   readonly permissionModes: Array<{ sessionId: string; mode: PermissionMode }> = [];
-  readonly sessionUpdates: Array<{ sessionId: string; patch: { cwd?: string; model?: string; llmConnectionSlug?: string; thinkingLevel?: import('@maka/core/model-thinking').ThinkingLevel | undefined; name?: string } }> = [];
+  readonly sessionUpdates: Array<{ sessionId: string; patch: { cwd?: string; pendingCwdReminder?: SessionSummary['pendingCwdReminder']; model?: string; llmConnectionSlug?: string; thinkingLevel?: import('@maka/core/model-thinking').ThinkingLevel | undefined; name?: string } }> = [];
   readonly branched: Array<{ sessionId: string; sourceTurnId: string }> = [];
   readonly branchedBefore: Array<{ sessionId: string; sourceTurnId: string }> = [];
   readonly sessionMessages = new Map<string, StoredMessage[]>();
@@ -948,11 +985,12 @@ class RecordingRuntime {
     };
   }
 
-  async updateSession(sessionId: string, patch: { cwd?: string; model?: string; llmConnectionSlug?: string; thinkingLevel?: import('@maka/core/model-thinking').ThinkingLevel | undefined; name?: string }): Promise<SessionSummary> {
+  async updateSession(sessionId: string, patch: { cwd?: string; pendingCwdReminder?: SessionSummary['pendingCwdReminder']; model?: string; llmConnectionSlug?: string; thinkingLevel?: import('@maka/core/model-thinking').ThinkingLevel | undefined; name?: string }): Promise<SessionSummary> {
     this.sessionUpdates.push({ sessionId, patch });
     return {
       id: sessionId,
       cwd: patch.cwd ?? '/repo',
+      ...(Object.hasOwn(patch, 'pendingCwdReminder') ? { pendingCwdReminder: patch.pendingCwdReminder } : {}),
       name: 'New Chat',
       isFlagged: false,
       isArchived: false,

--- a/packages/cli/src/__tests__/slash-command-completion.test.ts
+++ b/packages/cli/src/__tests__/slash-command-completion.test.ts
@@ -1,11 +1,11 @@
 import assert from 'node:assert/strict';
-import { mkdtempSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { before, describe, test } from 'node:test';
 import { Editor, setKittyProtocolActive, TUI } from '@earendil-works/pi-tui';
 import type { InvocableSkillEntry } from '@maka/runtime';
-import { MakaAutocompleteProvider } from '../pi-tui-pickers.js';
+import { DirectoryAutocompleteProvider, MakaAutocompleteProvider } from '../pi-tui-pickers.js';
 import { MakaSkillHighlightEditor } from '../skill-highlight-editor.js';
 import { editorTheme } from '../tui-ansi.js';
 import { FakeTerminal, waitFor } from './tui-terminal-mock.js';
@@ -170,6 +170,26 @@ describe('MakaAutocompleteProvider mid-message skill completion', () => {
       result.prefix,
     );
     assert.deepEqual(applied.lines, ['see /skill:info ']);
+  });
+});
+
+describe('DirectoryAutocompleteProvider', () => {
+  test('reuses path completion while filtering out files', async () => {
+    const baseDir = mkdtempSync(join(tmpdir(), 'maka-move-picker-'));
+    mkdirSync(join(baseDir, 'worktree-next'));
+    writeFileSync(join(baseDir, 'notes.txt'), 'notes');
+    try {
+      const provider = new DirectoryAutocompleteProvider(baseDir);
+      const result = await provider.getSuggestions([''], 0, 0, {
+        signal: new AbortController().signal,
+        force: true,
+      });
+      assert.deepEqual(result?.items.map((item) => item.label), ['worktree-next/']);
+    } finally {
+      // The test directory is intentionally tiny; remove it synchronously so
+      // the provider test does not need a second async lifecycle hook.
+      rmSync(baseDir, { recursive: true, force: true });
+    }
   });
 });
 

--- a/packages/cli/src/__tests__/slash-command-completion.test.ts
+++ b/packages/cli/src/__tests__/slash-command-completion.test.ts
@@ -191,6 +191,19 @@ describe('DirectoryAutocompleteProvider', () => {
       rmSync(baseDir, { recursive: true, force: true });
     }
   });
+
+  test('applies the first absolute path segment without adding a second slash', () => {
+    const provider = new DirectoryAutocompleteProvider('/');
+    const applied = provider.applyCompletion(
+      ['/U'],
+      0,
+      2,
+      { value: 'Users/', label: 'Users/' },
+      '/U',
+    );
+    assert.deepEqual(applied.lines, ['/Users/ ']);
+    assert.equal(applied.cursorCol, '/Users/ '.length);
+  });
 });
 
 describe('MakaSkillHighlightEditor mid-message skill trigger', () => {

--- a/packages/cli/src/pi-tui-pickers.ts
+++ b/packages/cli/src/pi-tui-pickers.ts
@@ -218,6 +218,21 @@ export class DirectoryAutocompleteProvider implements AutocompleteProvider {
     item: AutocompleteItem,
     prefix: string,
   ): { lines: string[]; cursorLine: number; cursorCol: number } {
+    const currentLine = lines[cursorLine] || '';
+    const beforePrefix = currentLine.slice(0, cursorCol - prefix.length);
+    if (prefix.startsWith('/') && beforePrefix.trim() === '') {
+      // Directory completion is path syntax even when the editor sees a
+      // slash-prefixed token. Do not route an absolute path through the
+      // slash-command completion rule, which would add a second slash.
+      const completed = item.value.startsWith('/') ? item.value : `/${item.value}`;
+      const nextLines = [...lines];
+      nextLines[cursorLine] = `${beforePrefix}${completed} ${currentLine.slice(cursorCol)}`;
+      return {
+        lines: nextLines,
+        cursorLine,
+        cursorCol: beforePrefix.length + completed.length + 1,
+      };
+    }
     return this.provider.applyCompletion(lines, cursorLine, cursorCol, item, prefix);
   }
 
@@ -232,7 +247,7 @@ export interface MakaSlashCommandMetadata {
 }
 
 export interface MakaSlashCommand extends MakaSlashCommandMetadata {
-  run(parts: string[]): void;
+  run(parts: string[], rawTail?: string): void;
   /** Alternate names that dispatch to this command without appearing in
    *  completion or the /help menu (e.g. /quit as an alias of /exit). */
   aliases?: readonly string[];

--- a/packages/cli/src/pi-tui-pickers.ts
+++ b/packages/cli/src/pi-tui-pickers.ts
@@ -191,6 +191,41 @@ export class MakaAutocompleteProvider implements AutocompleteProvider {
   }
 }
 
+/** Autocomplete surface for `/move`: reuse path completion but expose folders only. */
+export class DirectoryAutocompleteProvider implements AutocompleteProvider {
+  private readonly provider: CombinedAutocompleteProvider;
+
+  constructor(basePath: string) {
+    this.provider = new CombinedAutocompleteProvider([], basePath);
+  }
+
+  async getSuggestions(
+    lines: string[],
+    cursorLine: number,
+    cursorCol: number,
+    options: { signal: AbortSignal; force?: boolean },
+  ): Promise<AutocompleteSuggestions | null> {
+    const suggestions = await this.provider.getSuggestions(lines, cursorLine, cursorCol, options);
+    if (!suggestions) return null;
+    const items = suggestions.items.filter((item) => item.label.endsWith('/'));
+    return items.length > 0 ? { ...suggestions, items } : null;
+  }
+
+  applyCompletion(
+    lines: string[],
+    cursorLine: number,
+    cursorCol: number,
+    item: AutocompleteItem,
+    prefix: string,
+  ): { lines: string[]; cursorLine: number; cursorCol: number } {
+    return this.provider.applyCompletion(lines, cursorLine, cursorCol, item, prefix);
+  }
+
+  shouldTriggerFileCompletion(lines: string[], cursorLine: number, cursorCol: number): boolean {
+    return this.provider.shouldTriggerFileCompletion(lines, cursorLine, cursorCol);
+  }
+}
+
 export interface MakaSlashCommandMetadata {
   name: string;
   description: string;
@@ -250,6 +285,57 @@ export class PickerOverlay implements Component {
       padLine(ansi.dim(this.input.hint ?? 'enter select / esc close'), safeWidth),
       padLine('', safeWidth),
       ...this.list.render(safeWidth).map((line) => formatPickerItemLine(line, safeWidth)),
+      padLine(ansi.accent('-'.repeat(safeWidth)), safeWidth),
+    ];
+  }
+}
+
+export class DirectoryPickerOverlay implements Component {
+  private readonly editor: Editor;
+
+  constructor(
+    tui: TUI,
+    private readonly input: {
+      currentCwd: string;
+      basePath: string;
+      onSubmit: (cwd: string) => void;
+      onCancel: () => void;
+    },
+  ) {
+    this.editor = new Editor(tui, editorTheme(), { paddingX: 0, autocompleteMaxVisible: 8 });
+    this.editor.setAutocompleteProvider(new DirectoryAutocompleteProvider(input.basePath));
+    this.editor.onSubmit = (value) => {
+      const cwd = value.trim();
+      if (cwd) this.input.onSubmit(cwd);
+    };
+  }
+
+  invalidate(): void {
+    this.editor.invalidate();
+  }
+
+  handleInput(data: string): void {
+    if (matchesKey(data, Key.escape) || matchesKey(data, Key.ctrl('c'))) {
+      this.input.onCancel();
+      return;
+    }
+    this.editor.handleInput(data);
+  }
+
+  render(width: number): string[] {
+    const safeWidth = Math.max(1, width);
+    this.editor.focused = true;
+    const label = 'Directory ';
+    const labelWidth = visibleWidth(label);
+    const editorLines = this.editor.render(Math.max(1, safeWidth - labelWidth)).slice(1, -1);
+    return [
+      padLine('Move Session', safeWidth),
+      padLine(ansi.dim('Type a directory · Tab complete · Enter confirm · Esc cancel'), safeWidth),
+      padLine(ansi.dim(`Current: ${this.input.currentCwd}`), safeWidth),
+      padLine('', safeWidth),
+      ...(editorLines.length > 0
+        ? editorLines.map((line, index) => padLine(`${index === 0 ? label : ' '.repeat(labelWidth)}${line}`, safeWidth))
+        : [padLine(label, safeWidth)]),
       padLine(ansi.accent('-'.repeat(safeWidth)), safeWidth),
     ];
   }

--- a/packages/cli/src/pi-tui-runner.ts
+++ b/packages/cli/src/pi-tui-runner.ts
@@ -1874,8 +1874,8 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
     {
       name: 'move',
       description: 'Move current session to another directory',
-      run: (parts: string[]) => {
-        const targetCwd = parts.slice(1).join(' ').trim();
+      run: (parts: string[], rawTail?: string) => {
+        const targetCwd = (rawTail ?? parts.slice(1).join(' ')).trim();
         if (targetCwd) {
           void runControl(() => moveSession(targetCwd));
           return;
@@ -2005,13 +2005,15 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
   ].sort((left, right) => left.name.localeCompare(right.name));
 
   const handleSlashCommand = (prompt: string): boolean => {
-    const parts = prompt.trim().split(/\s+/);
+    const trimmed = prompt.trim();
+    const commandToken = trimmed.split(/\s+/, 1)[0] ?? '';
     const command = slashCommands.find((candidate) => (
-      `/${candidate.name}` === parts[0]
-      || candidate.aliases?.some((alias) => `/${alias}` === parts[0])
+      `/${candidate.name}` === commandToken
+      || candidate.aliases?.some((alias) => `/${alias}` === commandToken)
     ));
     if (!command) return false;
-    command.run(parts);
+    const rawTail = trimmed.slice(commandToken.length).trimStart();
+    command.run(trimmed.split(/\s+/), rawTail);
     return true;
   };
 

--- a/packages/cli/src/pi-tui-runner.ts
+++ b/packages/cli/src/pi-tui-runner.ts
@@ -82,6 +82,7 @@ import {
 } from './pi-tui-layout.js';
 import {
   MakaAutocompleteProvider,
+  DirectoryPickerOverlay,
   OnboardingWizard,
   PickerOverlay,
   UserQuestionOverlay,
@@ -1703,6 +1704,62 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
     requestRender();
   };
 
+  const moveSession = async (targetCwd: string): Promise<void> => {
+    if (!input.driver.moveSession) {
+      state.entries.push({
+        kind: 'notice',
+        level: 'error',
+        text: 'Moving sessions is not available in this environment.',
+      });
+      requestRender();
+      return;
+    }
+    const result = await input.driver.moveSession(targetCwd);
+    if (!result.changed) {
+      state.entries.push({
+        kind: 'notice',
+        level: 'info',
+        text: `Session is already at "${result.cwd}".`,
+      });
+      requestRender();
+      return;
+    }
+    cwd = result.cwd;
+    refreshEditorCwd?.(cwd);
+    const warning = result.oldCwdDirty === true
+      ? ` Warning: the old directory "${result.previousCwd}" has uncommitted changes.`
+      : '';
+    state.entries.push({
+      kind: 'notice',
+      level: 'info',
+      text: `Session moved to "${result.cwd}".${warning}`,
+    });
+    requestRender();
+  };
+
+  const showMovePicker = (): void => {
+    if (!input.driver.moveSession) {
+      state.entries.push({
+        kind: 'notice',
+        level: 'error',
+        text: 'Moving sessions is not available in this environment.',
+      });
+      requestRender();
+      return;
+    }
+    let overlay: OverlayHandle | undefined;
+    const picker = new DirectoryPickerOverlay(tui, {
+      currentCwd: cwd,
+      basePath: cwd,
+      onSubmit: (targetCwd) => {
+        overlay?.hide();
+        void runControl(() => moveSession(targetCwd));
+      },
+      onCancel: () => overlay?.hide(),
+    });
+    overlay = showBottomPicker(picker);
+  };
+
   const showPermissionModeList = () => {
     const items = permissionModePickerItems(permissionMode);
     showSelectPicker(
@@ -1812,6 +1869,18 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
           return;
         }
         void runControl(() => setModel(nextModel));
+      },
+    },
+    {
+      name: 'move',
+      description: 'Move current session to another directory',
+      run: (parts: string[]) => {
+        const targetCwd = parts.slice(1).join(' ').trim();
+        if (targetCwd) {
+          void runControl(() => moveSession(targetCwd));
+          return;
+        }
+        showMovePicker();
       },
     },
     {
@@ -2166,10 +2235,10 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
 
 const BOTTOM_PICKER_MARGIN_ROWS = 4;
 
-// The editor's autocomplete window height. Sized to fit the whole slash-command
-// menu (10 today) with headroom, so a bare `/` shows every command rather than
-// scrolling a subset.
-const EDITOR_AUTOCOMPLETE_MAX_VISIBLE = 13;
+// The editor's autocomplete window height. Keep it at least as large as the
+// full slash-command menu, so a bare `/` shows every command rather than
+// silently clipping the last command.
+const EDITOR_AUTOCOMPLETE_MAX_VISIBLE = 14;
 
 // A short, stable slice of a session id — enough to tell two same-named
 // sessions apart in the picker without showing the full unreadable uuid.

--- a/packages/cli/src/session-driver.ts
+++ b/packages/cli/src/session-driver.ts
@@ -37,7 +37,7 @@ export interface MakaSessionRuntime {
   respondToPermission(sessionId: string, response: PermissionResponse): Promise<void>;
   respondToUserQuestion?(sessionId: string, response: UserQuestionResponse): Promise<void>;
   setPermissionMode(sessionId: string, mode: PermissionMode): Promise<SessionSummary>;
-  updateSession(sessionId: string, patch: { cwd?: string; model?: string; llmConnectionSlug?: string; thinkingLevel?: ThinkingLevel | undefined; name?: string }): Promise<SessionSummary>;
+  updateSession(sessionId: string, patch: { cwd?: string; pendingCwdReminder?: SessionSummary['pendingCwdReminder']; model?: string; llmConnectionSlug?: string; thinkingLevel?: ThinkingLevel | undefined; name?: string }): Promise<SessionSummary>;
   // Rewind reuses the runtime's branch primitives: a non-destructive copy of the
   // transcript + RuntimeEvent ledger at a turn boundary, so resume correctness is
   // inherited and the original session's log is left intact. `branchBeforeTurn`
@@ -205,24 +205,31 @@ class RuntimeMakaSessionDriver implements MakaSessionDriver {
       sessionId,
       turnId,
       events: pendingReminder
-        ? this.clearCwdReminderAfterStart(events, pendingReminder)
+        ? this.clearCwdReminderAfterStart(sessionId, events, pendingReminder)
         : events,
     };
   }
 
   private async *clearCwdReminderAfterStart(
+    sessionId: string,
     events: AsyncIterable<SessionEvent>,
     reminder: { from: string; to: string },
   ): AsyncIterable<SessionEvent> {
     const iterator = events[Symbol.asyncIterator]();
     const first = await iterator.next();
+    if (first.done) return;
     if (
       this.pendingCwdReminder?.from === reminder.from
       && this.pendingCwdReminder.to === reminder.to
     ) {
-      this.pendingCwdReminder = undefined;
+      try {
+        await this.input.runtime.updateSession(sessionId, { pendingCwdReminder: undefined });
+        this.pendingCwdReminder = undefined;
+      } catch {
+        // Keep the durable reminder when header cleanup fails. The next turn
+        // may repeat it, but the session cannot lose the cwd context.
+      }
     }
-    if (first.done) return;
     yield first.value;
     while (true) {
       const next = await iterator.next();
@@ -339,12 +346,16 @@ class RuntimeMakaSessionDriver implements MakaSessionDriver {
     }
     const inspectCwdChanges = this.input.inspectCwdChanges ?? inspectGitCwdChanges;
     const oldCwdDirty = await inspectCwdChanges(previousCwd).catch(() => undefined);
-    const summary = await this.input.runtime.updateSession(this.sessionId, { cwd: nextCwd });
-    this.cwd = summary.cwd ?? nextCwd;
     const reminderFrom = this.pendingCwdReminder?.from ?? previousCwd;
-    this.pendingCwdReminder = reminderFrom === this.cwd
+    const pendingCwdReminder = reminderFrom === nextCwd
       ? undefined
-      : { from: reminderFrom, to: this.cwd };
+      : { from: reminderFrom, to: nextCwd };
+    const summary = await this.input.runtime.updateSession(this.sessionId, {
+      cwd: nextCwd,
+      pendingCwdReminder,
+    });
+    this.cwd = summary.cwd ?? nextCwd;
+    this.pendingCwdReminder = summary.pendingCwdReminder ?? pendingCwdReminder;
     return { previousCwd, cwd: this.cwd, changed: true, oldCwdDirty };
   }
 
@@ -359,7 +370,7 @@ class RuntimeMakaSessionDriver implements MakaSessionDriver {
     const sessionCwd = summary.cwd!;
     const messages = await this.input.runtime.getMessages(summary.id);
     this.sessionId = summary.id;
-    this.pendingCwdReminder = undefined;
+    this.pendingCwdReminder = summary.pendingCwdReminder;
     this.cwd = sessionCwd;
     this.model = summary.model;
     this.llmConnectionSlug = summary.llmConnectionSlug;

--- a/packages/cli/src/session-driver.ts
+++ b/packages/cli/src/session-driver.ts
@@ -1,5 +1,9 @@
+import { execFile } from 'node:child_process';
 import { randomUUID } from 'node:crypto';
-import { realpath } from 'node:fs/promises';
+import { realpath, stat } from 'node:fs/promises';
+import { promisify } from 'node:util';
+import { homedir } from 'node:os';
+import { resolve } from 'node:path';
 import type { QueueEnqueueOutcome, SessionEvent } from '@maka/core/events';
 import type { PermissionMode, PermissionResponse } from '@maka/core/permission';
 import type { UserQuestionResponse } from '@maka/core/user-question';
@@ -7,6 +11,17 @@ import type { BranchFromTurnInput, CreateSessionInput, UserMessageInput } from '
 import type { SessionSummary, StoredMessage } from '@maka/core/session';
 import { userFacingText } from '@maka/core/session';
 import type { ThinkingLevel } from '@maka/core/model-thinking';
+
+const execFileAsync = promisify(execFile);
+
+export interface MakaSessionMoveResult {
+  previousCwd: string;
+  cwd: string;
+  changed: boolean;
+  oldCwdDirty?: boolean;
+}
+
+export type InspectCwdChanges = (cwd: string) => Promise<boolean | undefined>;
 
 export interface MakaSessionRuntime {
   createSession(input: CreateSessionInput): Promise<SessionSummary>;
@@ -22,7 +37,7 @@ export interface MakaSessionRuntime {
   respondToPermission(sessionId: string, response: PermissionResponse): Promise<void>;
   respondToUserQuestion?(sessionId: string, response: UserQuestionResponse): Promise<void>;
   setPermissionMode(sessionId: string, mode: PermissionMode): Promise<SessionSummary>;
-  updateSession(sessionId: string, patch: { model?: string; llmConnectionSlug?: string; thinkingLevel?: ThinkingLevel | undefined; name?: string }): Promise<SessionSummary>;
+  updateSession(sessionId: string, patch: { cwd?: string; model?: string; llmConnectionSlug?: string; thinkingLevel?: ThinkingLevel | undefined; name?: string }): Promise<SessionSummary>;
   // Rewind reuses the runtime's branch primitives: a non-destructive copy of the
   // transcript + RuntimeEvent ledger at a turn boundary, so resume correctness is
   // inherited and the original session's log is left intact. `branchBeforeTurn`
@@ -53,6 +68,7 @@ export interface MakaSessionDriverInput {
   model: string;
   permissionMode?: PermissionMode;
   newId?: () => string;
+  inspectCwdChanges?: InspectCwdChanges;
 }
 
 export interface MakaSessionSwitchResult {
@@ -106,6 +122,7 @@ export interface MakaSessionDriver {
   setThinkingLevel(level: ThinkingLevel | undefined): Promise<void>;
   setPermissionMode(mode: PermissionMode): Promise<void>;
   renameSession(name: string): Promise<void>;
+  moveSession?(cwd: string): Promise<MakaSessionMoveResult>;
   switchSession(sessionId: string): Promise<MakaSessionSwitchResult>;
   /** Every prompted turn the user can rewind to, newest first. */
   listRewindTargets(): Promise<RewindTarget[]>;
@@ -157,6 +174,7 @@ class RuntimeMakaSessionDriver implements MakaSessionDriver {
   private llmConnectionSlug: string;
   private thinkingLevel: ThinkingLevel | undefined;
   private permissionMode: PermissionMode;
+  private pendingCwdReminder: { from: string; to: string } | undefined;
   private readonly newId: () => string;
 
   constructor(private readonly input: MakaSessionDriverInput) {
@@ -173,18 +191,44 @@ class RuntimeMakaSessionDriver implements MakaSessionDriver {
   ): Promise<MakaPreparedSessionTurn> {
     const sessionId = await this.ensureSession(prompt);
     const turnId = options.turnId ?? this.newId();
-    const modelText = options.modelText ?? prompt;
+    const pendingReminder = this.pendingCwdReminder;
+    const baseModelText = options.modelText ?? prompt;
+    const modelText = pendingReminder
+      ? `${cwdChangeReminder(pendingReminder.from, pendingReminder.to)}\n\n${baseModelText}`
+      : baseModelText;
+    const events = this.input.runtime.sendMessage(sessionId, {
+      turnId,
+      text: modelText,
+      ...(modelText !== prompt ? { displayText: prompt } : {}),
+    });
     return {
       sessionId,
       turnId,
-      events: this.input.runtime.sendMessage(sessionId, {
-        turnId,
-        text: modelText,
-        ...(options.modelText !== undefined && modelText !== prompt
-          ? { displayText: prompt }
-          : {}),
-      }),
+      events: pendingReminder
+        ? this.clearCwdReminderAfterStart(events, pendingReminder)
+        : events,
     };
+  }
+
+  private async *clearCwdReminderAfterStart(
+    events: AsyncIterable<SessionEvent>,
+    reminder: { from: string; to: string },
+  ): AsyncIterable<SessionEvent> {
+    const iterator = events[Symbol.asyncIterator]();
+    const first = await iterator.next();
+    if (
+      this.pendingCwdReminder?.from === reminder.from
+      && this.pendingCwdReminder.to === reminder.to
+    ) {
+      this.pendingCwdReminder = undefined;
+    }
+    if (first.done) return;
+    yield first.value;
+    while (true) {
+      const next = await iterator.next();
+      if (next.done) return;
+      yield next.value;
+    }
   }
 
   async *compactSession(): AsyncIterable<SessionEvent> {
@@ -286,6 +330,24 @@ class RuntimeMakaSessionDriver implements MakaSessionDriver {
     await this.input.runtime.updateSession(this.sessionId, { name });
   }
 
+  async moveSession(rawCwd: string): Promise<MakaSessionMoveResult> {
+    if (!this.sessionId) throw new Error('Cannot move before a session starts.');
+    const nextCwd = await resolveMoveCwd(rawCwd, this.cwd);
+    const previousCwd = this.cwd;
+    if (nextCwd === previousCwd) {
+      return { previousCwd, cwd: nextCwd, changed: false, oldCwdDirty: false };
+    }
+    const inspectCwdChanges = this.input.inspectCwdChanges ?? inspectGitCwdChanges;
+    const oldCwdDirty = await inspectCwdChanges(previousCwd).catch(() => undefined);
+    const summary = await this.input.runtime.updateSession(this.sessionId, { cwd: nextCwd });
+    this.cwd = summary.cwd ?? nextCwd;
+    const reminderFrom = this.pendingCwdReminder?.from ?? previousCwd;
+    this.pendingCwdReminder = reminderFrom === this.cwd
+      ? undefined
+      : { from: reminderFrom, to: this.cwd };
+    return { previousCwd, cwd: this.cwd, changed: true, oldCwdDirty };
+  }
+
   async switchSession(sessionId: string): Promise<MakaSessionSwitchResult> {
     const summary = (await this.listSessions()).find((session) => session.id === sessionId);
     if (!summary) throw new Error(`Session not found: ${sessionId}`);
@@ -297,6 +359,7 @@ class RuntimeMakaSessionDriver implements MakaSessionDriver {
     const sessionCwd = summary.cwd!;
     const messages = await this.input.runtime.getMessages(summary.id);
     this.sessionId = summary.id;
+    this.pendingCwdReminder = undefined;
     this.cwd = sessionCwd;
     this.model = summary.model;
     this.llmConnectionSlug = summary.llmConnectionSlug;
@@ -351,6 +414,7 @@ class RuntimeMakaSessionDriver implements MakaSessionDriver {
     // stay put, so the next prompt lazily creates a fresh session that inherits
     // them (via ensureSession). The old session is left intact on disk.
     this.sessionId = null;
+    this.pendingCwdReminder = undefined;
   }
 
   getSessionId(): string | null {
@@ -371,6 +435,63 @@ class RuntimeMakaSessionDriver implements MakaSessionDriver {
     this.sessionId = session.id;
     return session.id;
   }
+}
+
+async function resolveMoveCwd(rawCwd: string, currentCwd: string): Promise<string> {
+  const input = rawCwd.trim();
+  if (!input) throw new Error('Working directory cannot be empty.');
+  const unquoted = input.length >= 2
+    && ((input.startsWith('"') && input.endsWith('"')) || (input.startsWith("'") && input.endsWith("'")))
+    ? input.slice(1, -1)
+    : input;
+  const expanded = unquoted === '~'
+    ? homedir()
+    : unquoted.startsWith('~/')
+      ? resolve(homedir(), unquoted.slice(2))
+      : unquoted;
+  const candidate = resolve(currentCwd, expanded);
+  let canonical: string;
+  try {
+    canonical = await realpath(candidate);
+  } catch (error) {
+    const code = (error as { code?: unknown }).code;
+    if (code === 'ENOENT' || code === 'ENOTDIR') {
+      throw new Error(`Working directory does not exist: ${candidate}`);
+    }
+    throw error;
+  }
+  const details = await stat(canonical);
+  if (!details.isDirectory()) throw new Error(`Working directory is not a directory: ${canonical}`);
+  return canonical;
+}
+
+async function inspectGitCwdChanges(cwd: string): Promise<boolean | undefined> {
+  try {
+    const result = await execFileAsync(
+      'git',
+      ['-c', 'core.fsmonitor=false', 'status', '--porcelain=v1', '--untracked-files=normal'],
+      {
+        cwd,
+        env: { ...process.env, GIT_OPTIONAL_LOCKS: '0' },
+        encoding: 'utf8',
+        maxBuffer: 1024 * 1024,
+        timeout: 5_000,
+      },
+    );
+    return result.stdout.trim().length > 0;
+  } catch {
+    // A non-git directory, inaccessible repository, or a git timeout should
+    // never prevent a successful move. The warning is best-effort by design.
+    return undefined;
+  }
+}
+
+function cwdChangeReminder(from: string, to: string): string {
+  return `<system-reminder>The session working directory changed from ${escapeReminderPath(from)} to ${escapeReminderPath(to)}. This is the same project, possibly at a new location. Use the new working directory for all subsequent file and shell operations.</system-reminder>`;
+}
+
+function escapeReminderPath(value: string): string {
+  return value.replaceAll('&', '&amp;').replaceAll('<', '&lt;').replaceAll('>', '&gt;').replaceAll('"', '&quot;').replaceAll("'", '&apos;');
 }
 
 function cwdRank(session: SessionSummary, cwd: string): number {

--- a/packages/core/src/session.ts
+++ b/packages/core/src/session.ts
@@ -75,6 +75,8 @@ export interface SessionHeader {
   id: string;
   workspaceRoot: string;
   cwd: string;
+  /** One-shot model context to inject after a CLI session cwd move. */
+  pendingCwdReminder?: { from: string; to: string };
 
   // Lifecycle timestamps
   createdAt: number;
@@ -118,6 +120,8 @@ export type BackendKind = 'ai-sdk' | 'fake' | 'pi-agent';
 export interface SessionSummary {
   id: string;
   cwd?: string;
+  /** One-shot model context to inject after a CLI session cwd move. */
+  pendingCwdReminder?: { from: string; to: string };
   name: string;
   isFlagged: boolean;
   isArchived: boolean;

--- a/packages/runtime/src/__tests__/session-manager.test.ts
+++ b/packages/runtime/src/__tests__/session-manager.test.ts
@@ -407,30 +407,35 @@ describe('SessionManager permission mode updates', () => {
     const backends = new BackendRegistry();
     const built: string[] = [];
     backends.register('fake', (ctx) => {
-      built.push(`${ctx.header.backend}:${ctx.header.llmConnectionSlug}:${ctx.header.model}`);
+      built.push(`${ctx.header.backend}:${ctx.header.llmConnectionSlug}:${ctx.header.model}:${ctx.header.cwd}`);
       return new TestBackend(ctx);
     });
     backends.register('ai-sdk', (ctx) => {
-      built.push(`${ctx.header.backend}:${ctx.header.llmConnectionSlug}:${ctx.header.model}`);
+      built.push(`${ctx.header.backend}:${ctx.header.llmConnectionSlug}:${ctx.header.model}:${ctx.header.cwd}`);
       return new TestBackend(ctx);
     });
     const manager = new SessionManager({ store, backends, newId: nextId(), now: nextNow(5_000) });
     const session = await manager.createSession(makeInput());
 
     await drain(manager.sendMessage(session.id, { turnId: 'turn-1', text: 'hello' }));
-    expect(built).toEqual(['fake:fake:fake-model']);
+    expect(built).toEqual(['fake:fake:fake-model:/tmp/cwd']);
 
     const summary = await manager.updateSession(session.id, {
       backend: 'ai-sdk',
       llmConnectionSlug: 'zai-coding-plan',
       model: 'glm-4.7',
+      cwd: '/tmp/worktree-cwd',
     });
     expect(summary.backend).toBe('ai-sdk');
     expect(summary.llmConnectionSlug).toBe('zai-coding-plan');
+    expect(summary.cwd).toBe('/tmp/worktree-cwd');
     expect(store.disposeCount).toBe(1);
 
     await drain(manager.sendMessage(session.id, { turnId: 'turn-2', text: 'again' }));
-    expect(built).toEqual(['fake:fake:fake-model', 'ai-sdk:zai-coding-plan:glm-4.7']);
+    expect(built).toEqual([
+      'fake:fake:fake-model:/tmp/cwd',
+      'ai-sdk:zai-coding-plan:glm-4.7:/tmp/worktree-cwd',
+    ]);
   });
 
   test('metadata-only updates keep the active backend instance', async () => {
@@ -3900,6 +3905,7 @@ describe('SessionManager permission mode updates', () => {
         backend: 'ai-sdk',
         llmConnectionSlug: 'zai-coding-plan',
         model: 'glm-4.7',
+        cwd: '/tmp/worktree-cwd',
       }),
       /Cannot change backend configuration while a turn is running/,
     );

--- a/packages/runtime/src/session-manager.ts
+++ b/packages/runtime/src/session-manager.ts
@@ -1290,6 +1290,7 @@ export function headerToSummary(h: SessionHeader): SessionSummary {
   const summary: SessionSummary = {
     id: h.id,
     cwd: h.cwd,
+    ...(h.pendingCwdReminder ? { pendingCwdReminder: h.pendingCwdReminder } : {}),
     name: h.name === 'New Session' ? 'New Chat' : h.name,
     isFlagged: h.isFlagged,
     isArchived: h.isArchived,

--- a/packages/runtime/src/session-manager.ts
+++ b/packages/runtime/src/session-manager.ts
@@ -1318,7 +1318,11 @@ function isNotFoundError(error: unknown): error is NodeJS.ErrnoException {
 }
 
 export function changesBackendConfig(patch: Partial<SessionHeader>): boolean {
-  return 'backend' in patch || 'llmConnectionSlug' in patch || 'model' in patch || 'thinkingLevel' in patch;
+  return 'backend' in patch
+    || 'llmConnectionSlug' in patch
+    || 'model' in patch
+    || 'thinkingLevel' in patch
+    || 'cwd' in patch;
 }
 
 function agentRunStatusForSpawnResult(status: AgentRunHeader['status']): SpawnChildAgentResult['status'] {

--- a/packages/storage/src/__tests__/session-store.test.ts
+++ b/packages/storage/src/__tests__/session-store.test.ts
@@ -81,6 +81,21 @@ describe('FileSessionStore CRUD', () => {
     });
   });
 
+  test('persists and clears the pending cwd reminder in the session header', async () => {
+    await withStore(async (store) => {
+      const header = await store.create(makeInput({ name: 'Moved session' }));
+      const reminder = { from: '/tmp/old-worktree', to: '/tmp/new-worktree' };
+
+      await store.updateHeader(header.id, { pendingCwdReminder: reminder });
+      assert.deepEqual((await store.readHeader(header.id)).pendingCwdReminder, reminder);
+      assert.deepEqual((await store.list())[0]?.pendingCwdReminder, reminder);
+
+      await store.updateHeader(header.id, { pendingCwdReminder: undefined });
+      assert.equal((await store.readHeader(header.id)).pendingCwdReminder, undefined);
+      assert.equal((await store.list())[0]?.pendingCwdReminder, undefined);
+    });
+  });
+
   test('create with a thinking level surfaces it in the list summary', async () => {
     await withStore(async (store) => {
       const header = await store.create(makeInput({ name: 'Thinking from start', thinkingLevel: 'medium' }));

--- a/packages/storage/src/session-store.ts
+++ b/packages/storage/src/session-store.ts
@@ -547,6 +547,7 @@ function normalizeMigratedHeader(header: SessionHeader, sessionId: string): Sess
   const valid = header.id === sessionId &&
     typeof header.workspaceRoot === 'string' &&
     typeof header.cwd === 'string' &&
+    (header.pendingCwdReminder === undefined || isCwdReminder(header.pendingCwdReminder)) &&
     isFiniteNumber(header.createdAt) &&
     isFiniteNumber(header.lastUsedAt) &&
     (header.lastMessageAt === undefined || isFiniteNumber(header.lastMessageAt)) &&
@@ -583,6 +584,12 @@ function isFiniteNumber(value: unknown): value is number {
   return typeof value === 'number' && Number.isFinite(value);
 }
 
+function isCwdReminder(value: unknown): value is NonNullable<SessionHeader['pendingCwdReminder']> {
+  return typeof value === 'object' && value !== null
+    && typeof (value as { from?: unknown }).from === 'string'
+    && typeof (value as { to?: unknown }).to === 'string';
+}
+
 function toSummary(header: SessionHeader, messages: StoredMessage[] = []): SessionSummary {
   const preview = lastMessagePreview(messages);
   const derivedLastMessageAt = latestVisibleMessageAt(messages);
@@ -590,6 +597,7 @@ function toSummary(header: SessionHeader, messages: StoredMessage[] = []): Sessi
   return {
     id: header.id,
     cwd: header.cwd,
+    ...(header.pendingCwdReminder ? { pendingCwdReminder: header.pendingCwdReminder } : {}),
     name: normalizeSessionName(header.name),
     isFlagged: header.isFlagged,
     isArchived: header.isArchived,


### PR DESCRIPTION
## Summary

- add TUI `/move` with a directory input overlay and directory-only path completion
- validate and canonicalize the selected directory, then persist it to `SessionHeader.cwd`
- treat cwd as backend configuration so the cached backend is disposed and rebuilt for the next turn
- warn when the old cwd has uncommitted changes without making worktree changes
- inject one replayable `<system-reminder>` into the next model-facing prompt while preserving the typed prompt through `displayText`
- keep `maka run`, worktree creation, and worktree copying out of scope

Closes #1101

## Implementation Notes

- The picker reuses `CombinedAutocompleteProvider` and filters suggestions to directories, so users can navigate into a repository or move between existing worktree directories.
- Path input accepts absolute paths, paths relative to the current cwd, home-relative paths, and quoted paths with spaces.
- The old git status check is bounded, disables optional git locks, and is best-effort; a status failure never blocks the move.
- A cwd change is rejected while a turn is actively running by the Runtime backend-configuration fence.
- The cwd reminder is persisted as part of the next user message model envelope, so resume/replay preserves the model-visible context without rendering the reminder as user text.

## Verification

- `npm --workspace @maka/runtime test` (2105 passed, 7 skipped)
- `npm --workspace maka-agent test` (558 passed)
- `npm run typecheck` for affected workspaces
- `npm run lint`
- `git diff --check`

The root typecheck reaches the affected workspaces successfully, then fails on nine pre-existing Desktop tests that still pass the removed `LocaleProvider locale` prop.

## Review Focus

- path validation, canonicalization, and quoted/home-relative input
- dirty old cwd warning failure-open behavior
- backend cache refresh and active-turn rejection
- one-shot reminder persistence, replay, and session-switch/new-session lifecycle
- directory-only autocomplete and existing worktree navigation
- no worktree creation or copy side effects