### PR TITLE
feat(daily-review): IA redesign — 每日回顾 从控件汤到清晰的三段式

### DIFF
--- a/apps/desktop/src/main/__tests__/radius-converge-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/radius-converge-contract.test.ts
@@ -412,7 +412,11 @@ describe('radius token governance (#406 gap 4)', () => {
       // no radius.
       // .maka-daily-review-info dropped: unboxed to a plain hint line in
       // the daily-review IA restructure — no card chrome, no radius.
-      '.maka-daily-review-archive-body': '--radius-surface',
+      // Daily-review IA redesign: the master-detail archive body card became
+      // the stacked report surface (.maka-daily-review-report). The surface
+      // owns the radius now; the expanded body (.maka-daily-review-report-body)
+      // divides with a hairline and carries no radius of its own.
+      '.maka-daily-review-report': '--radius-surface',
     };
     const offenders: string[] = [];
     for (const [sel, token] of Object.entries(SELECTOR_TIER)) {

--- a/apps/desktop/src/renderer/daily-review-actions.ts
+++ b/apps/desktop/src/renderer/daily-review-actions.ts
@@ -29,7 +29,9 @@ export function buildDailyReviewRunModelOptions(
   connections: readonly LlmConnection[],
 ): Array<readonly [string, string]> {
   return [
-    [DAILY_REVIEW_CONFIG_MODEL_VALUE, '使用设置中的分析模型'],
+    // Compact default option for the panel's inline 分析模型 picker — a run
+    // with no explicit override falls back to the model configured in Settings.
+    [DAILY_REVIEW_CONFIG_MODEL_VALUE, '跟随设置'],
     ...buildCatalogDailyReviewModelOptions(connections, ''),
   ];
 }

--- a/apps/desktop/src/renderer/styles/daily-review.css
+++ b/apps/desktop/src/renderer/styles/daily-review.css
@@ -1,286 +1,111 @@
 /* Unboxed (maintainer 2026-07-18): the outer card chrome wrapped the whole
-   每日回顾 module (time bar + quick-runs + archives + stats) in a second frame
-   the MCP page never had — the inner surfaces (archive body, stat tiles,
-   alerts) already carry their own borders, so the wrapper read as a
-   box-in-box. Plain layout container now; padding 0 so content sits flush
-   with the module header like the skills / MCP pages. Width converged
-   980 -> 900 to track the module header's `min(100%, 900px)` measure. */
+   每日回顾 module in a second frame the MCP page never had — the inner surfaces
+   (report bodies, stat tiles, alerts) already carry their own borders, so the
+   wrapper read as a box-in-box. Plain layout container now; padding 0 so
+   content sits flush with the module header like the skills / MCP pages. Width
+   converged 980 -> 900 to track the module header's `min(100%, 900px)` measure.
+
+   IA redesign (2026-07-18): the PageHeader now lives INSIDE the panel (so the
+   生成 actions ride its actions slot with the panel's run state), followed by a
+   single time-scope row, the always-on 概览 section, and the stacked 报告
+   section. The old two-floating-control-rows + broken master-detail layout is
+   gone. */
 .maka-module-main .maka-daily-review-panel {
     width: min(100%, 900px);
     margin-inline: auto;
     padding: 0;
   }
-/* IA restructure: header is now the single time-context bar —
-   stepper + day label on the left, 今日/本周/本月 tabs on the right
-   (the tabs used to float mid-page above the stats). */
-.maka-daily-review-header {
-    display: flex;
-    align-items: center;
-    /* P2-10: range picker + stepper are one time-control cluster on the
-       left (was space-between, which split them to opposite corners). */
-    justify-content: flex-start;
-    flex-wrap: wrap;
-    gap: var(--space-3);
-    padding: var(--space-0-5) var(--space-0-5) var(--space-1-5);
-    border-bottom: var(--border-width-hairline) solid var(--foreground-10);
-  }
 
-.maka-daily-review-header-time {
-    display: flex;
-    align-items: center;
-    gap: var(--space-1);
-    min-width: 0;
-  }
+.maka-daily-review-panel {
+  min-height: 0;
+  overflow: auto;
+  display: grid;
+  align-content: start;
+  gap: var(--space-5);
+  padding: var(--space-4) var(--space-5) var(--space-5);
+}
 
-/* PR-DAILY-REVIEW-FULL-0: info banner explaining the feature, plus a
-   manual-trigger row. Banner uses the page-card recipe with a softer
-   tint so it reads as supporting context, not a primary surface. */
-.maka-daily-review-quick-runs {
-  /* WAWQAQ msg `3871e56b` 2026-06-25: "按钮的位置也不对。按道理一般都
-     是在右边，现在都是直接靠近文本的。"
-     The 生成每日回顾 / 生成深度分析 buttons were sitting flex-start
-     (left-aligned), hugging the explanatory paragraph above. Right-
-     align them with `justify-content: flex-end` so they read as the
-     panel's primary actions. */
-  display: flex;
+/* ── PageHeader actions: the 生成 cluster ───────────────────────────────
+   The analysis-model select is a COMPACT generation option that sits with the
+   two 生成 buttons (not a page-wide row). `width="compact"` caps the trigger;
+   this only handles the cluster's flow + wrap. */
+.maka-daily-review-generate {
+  display: inline-flex;
   align-items: center;
-  flex-wrap: wrap;
   justify-content: flex-end;
+  /* Single row on desktop: the three run controls stay together and the
+     subtitle column shrinks + wraps beside them (nowrap + flex:none keeps the
+     browser from collapsing the cluster onto a second line while free header
+     width still exists). The ≤820px module breakpoint re-enables wrap once the
+     header stacks into a grid and the cluster owns a full row. */
+  flex-wrap: nowrap;
   gap: var(--space-2);
-  padding: var(--space-0-5) 0 var(--space-1-5);
-  border-bottom: var(--border-width-hairline) solid var(--foreground-10);
+  flex: none;
+}
+
+@media (max-width: 820px) {
+  .maka-daily-review-generate {
+    flex-wrap: wrap;
+    justify-content: flex-start;
+  }
 }
 
 .maka-daily-review-model-select {
-  margin-right: auto;
+  /* Keep the follow-settings label from stretching the header actions row;
+     the primitive's compact bucket already caps it, this just holds shape. */
+  flex: 0 1 auto;
 }
 
 .maka-daily-review-quick-run {
   white-space: nowrap;
 }
 
-.maka-daily-review-archives {
-    display: grid;
-    gap: var(--space-1-5);
-    padding: var(--space-2) 0 var(--space-2-5);
-    border-bottom: var(--border-width-hairline) solid var(--foreground-10);
-  }
-
-.maka-daily-review-archives-header {
-    display: flex;
-    align-items: baseline;
-    justify-content: space-between;
-    gap: var(--space-2);
-  }
-
-.maka-daily-review-archive-count {
-    font-size: var(--font-size-caption);
-    color: var(--muted-foreground);
-    font-variant-numeric: tabular-nums;
-  }
-
-.maka-daily-review-archive-layout {
-    display: grid;
-    grid-template-columns: minmax(180px, 0.34fr) minmax(0, 1fr);
-    gap: var(--space-2);
-    align-items: start;
-  }
-
-.maka-daily-review-archive-list {
-    /* PR-DAILYREVIEW-ARCHIVE-ROW-A11Y-0 (round 7/30): changed
-       from `<div role="list">` to semantic `<ul>`. Reset the
-       UA's default list bullet + padding-left so the visual
-       layout stays grid-driven. */
-    list-style: none;
-    margin: 0;
-    padding: 0;
-    display: grid;
-    gap: var(--space-0-5);
-    min-width: 0;
-  }
-
-.maka-daily-review-archive-list > li {
-    margin: 0;
-    padding: 0;
-  }
-
-/* Migrated onto the Item primitive (round 2): hover 4% / selected 6.5%
-   fills + the stacked title-over-meta column now come from Item +
-   ItemContent, so this rule keeps only geometry (padding, radius) and the
-   selected-state border accent. `data-selected` is Item's selected hook. */
-.maka-daily-review-archive-row {
-  border: var(--border-width-hairline) solid transparent;
-  border-radius: var(--radius-control);
-  min-width: 0;
-  padding: var(--space-1-5) var(--space-2);
+/* ── One time-scope row: range segmented + day stepper as ONE cluster ──── */
+.maka-daily-review-scope {
+  display: flex;
+  align-items: center;
+  /* Range picker + stepper are one time-control cluster on the left — they are
+     both time navigation, so they read as a single group (was two widgets at
+     opposite page corners). */
+  justify-content: flex-start;
+  flex-wrap: wrap;
+  gap: var(--space-3);
 }
-
-.maka-daily-review-archive-row[data-selected] {
-  border-color: var(--border-strong);
-}
-
-.maka-daily-review-archive-row-title {
-    min-width: 0;
-    color: var(--foreground);
-    font-size: var(--font-size-ui);
-    font-weight: var(--font-weight-semibold);
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-  }
-
-.maka-daily-review-archive-row-meta {
-    min-width: 0;
-    color: var(--muted-foreground);
-    font-size: var(--font-size-caption);
-    font-variant-numeric: tabular-nums;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-  }
-
-.maka-daily-review-archive-body {
-    display: grid;
-    gap: var(--space-2);
-    min-width: 0;
-    padding: var(--space-2-5) var(--space-3);
-    border: var(--border-width-hairline) solid var(--card-border-color);
-    border-radius: var(--radius-surface);
-    background: oklch(from var(--foreground) l c h / 0.025);
-    box-shadow: var(--card-highlight);
-  }
-
-.maka-daily-review-archive-body[data-empty="true"],
-  .maka-daily-review-archive-empty {
-    color: var(--muted-foreground);
-    font-size: var(--font-size-ui);
-    line-height: var(--leading-normal);
-  }
-
-.maka-daily-review-archive-body-header {
-    display: flex;
-    align-items: flex-start;
-    justify-content: space-between;
-    gap: var(--space-2-5);
-  }
-
-.maka-daily-review-archive-body-header h4 {
-    margin: 0;
-    color: var(--foreground);
-    font-size: var(--font-size-ui);
-    font-weight: var(--font-weight-semibold);
-    letter-spacing: var(--tracking-normal);
-  }
-
-.maka-daily-review-archive-body-header p {
-    margin: var(--space-0-5) 0 0;
-    color: var(--muted-foreground);
-    font-size: var(--font-size-caption);
-    line-height: var(--leading-normal);
-    overflow-wrap: anywhere;
-  }
-
-/* .maka-daily-review-archive-status is now the Chip primitive (squared status
-   label); tone→alpha from chip.tsx, ok/failed/no_model mapping from
-   dailyReviewArchiveChipTone in daily-review-panel.tsx. The status Chip keeps
-   flex:none so it never shrinks against the archive header title. */
-.maka-daily-review-archive-status {
-    flex: none;
-  }
-
-.maka-daily-review-archive-error {
-    margin: 0;
-    color: var(--destructive, var(--foreground));
-    font-size: var(--font-size-ui);
-    line-height: var(--leading-normal);
-  }
-
-.maka-daily-review-archive-sections {
-    display: grid;
-    /* Section rhythm: 8px title→body inside a section, 16px + hairline
-       BETWEEN sections — the four report blocks (对话摘要/遗漏提醒/
-       使用洞察/代码建议) previously sat at a uniform 8px cadence and
-       read as one undifferentiated slab. Divider over nested cards per
-       the anti-nested-box rule. */
-    gap: var(--space-4);
-  }
-
-.maka-daily-review-archive-section {
-    display: grid;
-    gap: var(--space-1);
-  }
-
-.maka-daily-review-archive-section + .maka-daily-review-archive-section {
-    border-top: var(--border-width-hairline) solid var(--foreground-10);
-    padding-top: var(--space-3);
-  }
-
-.maka-daily-review-archive-section h5 {
-    margin: 0;
-    color: var(--muted-foreground);
-    font-size: var(--font-size-caption);
-    font-weight: var(--font-weight-semibold);
-    letter-spacing: var(--tracking-normal);
-  }
-
-.maka-daily-review-archive-section p {
-    margin: 0;
-    color: var(--foreground-secondary);
-    font-size: var(--font-size-ui);
-    line-height: var(--leading-normal);
-    overflow-wrap: anywhere;
-    white-space: pre-wrap;
-  }
-
-/* Markdown-rendered report body: same type scale as the plain <p> it
-   replaced; restore list markers (Tailwind preflight strips them — see
-   the chat-bubble fix) and keep block rhythm tight inside a section. */
-.maka-daily-review-archive-section-body {
-    color: var(--foreground-secondary);
-    font-size: var(--font-size-ui);
-    line-height: var(--leading-normal);
-    overflow-wrap: anywhere;
-  }
-
-.maka-daily-review-archive-section-body p {
-    margin: 0 0 var(--space-1-5);
-  }
-
-.maka-daily-review-archive-section-body p:last-child,
-.maka-daily-review-archive-section-body ul:last-child,
-.maka-daily-review-archive-section-body ol:last-child {
-    margin-bottom: 0;
-  }
-
-.maka-daily-review-archive-section-body ul,
-.maka-daily-review-archive-section-body ol {
-    margin: 0 0 var(--space-1-5);
-    padding-left: var(--space-5);
-  }
-
-.maka-daily-review-archive-section-body ul { list-style: disc; }
-.maka-daily-review-archive-section-body ol { list-style: decimal; }
-
-.maka-daily-review-day {
-    text-align: center;
-    font-weight: var(--font-weight-semibold);
-    font-size: var(--font-size-ui);
-    font-variant-numeric: tabular-nums;
-    letter-spacing: var(--tracking-normal);
-    color: var(--foreground);
-  }
 
 .maka-daily-review-range-tabs,
-  .maka-daily-review-actions {
-    display: flex;
-    gap: var(--space-1);
-    min-width: 0;
-  }
-
-/* Export row sits directly above the stats it exports. */
 .maka-daily-review-actions {
-    justify-content: flex-end;
-  }
+  display: flex;
+  gap: var(--space-1);
+  min-width: 0;
+}
+
+.maka-daily-review-scope-stepper {
+  display: flex;
+  align-items: center;
+  gap: var(--space-1);
+  min-width: 0;
+}
+
+.maka-daily-review-day {
+  text-align: center;
+  font-weight: var(--font-weight-semibold);
+  font-size: var(--font-size-ui);
+  font-variant-numeric: tabular-nums;
+  letter-spacing: var(--tracking-normal);
+  color: var(--foreground);
+}
+
+/* ── 概览 section (always rendered) ─────────────────────────────────────── */
+.maka-daily-review-overview {
+  display: grid;
+  gap: var(--space-3);
+}
+
+/* Export row sits in the 概览 SectionHeader action slot, right-aligned. */
+.maka-daily-review-actions {
+  justify-content: flex-end;
+  flex-wrap: wrap;
+}
 
 .maka-daily-review-copy,
 .maka-daily-review-append,
@@ -288,21 +113,6 @@
   white-space: nowrap;
 }
 
-/* Convergence (maintainer 2026-07-18): the retry alert re-implemented the
-   warning surface (flex row + hairline border + tinted bg + radius) by hand,
-   fighting the Alert primitive's own grid slot layout. The `warning` variant
-   already owns border / tint / radius / padding and the description↔action
-   split, so the bespoke chrome is dropped — the shared primitive renders it.
-   Only the retry button keeps `flex: none` so it never shrinks. */
-.maka-daily-review-alert-retry {
-  flex: none;
-}
-
-@media (max-width: 720px) {
-    .maka-daily-review-archive-layout {
-      grid-template-columns: 1fr;
-    }
-}
 .maka-daily-review-totals {
     display: grid;
     grid-template-columns: repeat(auto-fill, minmax(72px, 1fr));
@@ -322,23 +132,15 @@
     background: oklch(from var(--destructive, var(--warning, var(--info))) l c h / 0.06);
   }
 
-/* Convergence (maintainer 2026-07-18): the 活跃对话 / 模型使用 / 工具调用
-   section titles were a hand-rolled uppercase eyebrow with a bespoke accent
-   bar — the exact dialect section-header.tsx was built to retire — while the
-   已生成报告 header on the same page already spoke the SectionHeader
-   primitive. All section titles now render through SectionHeader (as="h4"
-   accent), so the whole page shares one section-header language. The wrapper
-   keeps only the between-section divider rhythm; the divider token converges
-   to `--foreground-10` to match the header / quick-runs / archives dividers. */
+/* Convergence (maintainer 2026-07-18): all section titles render through the
+   SectionHeader primitive (as="h4" accent), so the page shares one
+   section-header language. The wrapper keeps only the between-section divider
+   rhythm; divider token `--foreground-10` matches the module dividers. */
 .maka-daily-review-section {
     display: grid;
     gap: var(--space-2);
     padding: var(--space-3) 0 0;
     border-top: var(--border-width-hairline) solid var(--foreground-10);
-  }
-.maka-daily-review-section:first-of-type {
-    border-top: 0;
-    padding-top: var(--space-1);
   }
 .maka-daily-review-list {
     list-style: none;
@@ -426,11 +228,10 @@
     padding: var(--space-2) var(--space-1);
   }
 
-/* Unlayered on purpose: the shared `.maka-empty-state` base
-   (onboarding.css) is unlayered `position: absolute` centering, and
-   unlayered rules always beat @layer rules — inside @layer components
-   this override silently never applied, so the "no activity" card
-   floated over the archived-report pane as a translucent overlay. */
+/* Unlayered on purpose: the shared `.maka-empty-state` base (onboarding.css)
+   is unlayered `position: absolute` centering, and unlayered rules always beat
+   @layer rules — inside @layer components this override silently never applied,
+   so the empty card floated as a translucent overlay. Reset it to in-flow. */
 .maka-daily-review-panel .maka-daily-review-summary-empty {
   position: static;
   left: auto;
@@ -441,25 +242,189 @@
   align-content: center;
 }
 
-/* Designer audit P0-4: one-line stand-in for the full empty-state card when
-   saved reports already occupy the page — a second full-height empty card
-   below them read as a broken section. */
-.maka-daily-review-activity-note {
-  margin: 0;
-  padding: var(--space-2) var(--space-1);
-  color: var(--muted-foreground);
-  font-size: var(--font-size-ui);
+/* Convergence (maintainer 2026-07-18): the retry alert re-implemented the
+   warning surface by hand; the `warning` variant already owns border / tint /
+   radius / padding + the description↔action split, so the shared primitive
+   renders it. Only the retry button keeps `flex: none` so it never shrinks. */
+.maka-daily-review-alert-retry {
+  flex: none;
 }
 
-/* Daily-review sidebar panel body. Relocated from tool-stream.css — issue #546 PR1. */
-/* ────────────────────────────────────────────────────────────────
-   PR-DAILY-REVIEW-MVP-0: 每日回顾 sidebar panel.
-   ──────────────────────────────────────────────────────────────── */
-.maka-daily-review-panel {
-  min-height: 0;
-  overflow: auto;
-  display: grid;
-  align-content: start;
-  gap: var(--space-2);
-  padding: var(--space-4) var(--space-5) var(--space-5);
-}
+/* ── 报告 section: stacked, newest-first, expand-in-place surfaces ──────── */
+.maka-daily-review-reports {
+    display: grid;
+    gap: var(--space-2-5);
+    padding: var(--space-4) 0 0;
+    border-top: var(--border-width-hairline) solid var(--foreground-10);
+  }
+
+.maka-daily-review-archive-count {
+    font-size: var(--font-size-caption);
+    color: var(--muted-foreground);
+    font-variant-numeric: tabular-nums;
+  }
+
+.maka-daily-review-report-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: grid;
+    gap: var(--space-2);
+    min-width: 0;
+  }
+
+.maka-daily-review-report-list > li {
+    margin: 0;
+    padding: 0;
+    min-width: 0;
+  }
+
+/* Each report is one full-width surface. The meta head is always visible; the
+   selected report expands its body below. One frame only (no box-in-box): the
+   body sections divide with hairlines, not nested cards. */
+.maka-daily-review-report {
+    display: grid;
+    min-width: 0;
+    border: var(--border-width-hairline) solid var(--card-border-color);
+    border-radius: var(--radius-surface);
+    background: oklch(from var(--foreground) l c h / 0.025);
+    box-shadow: var(--card-highlight);
+    overflow: hidden;
+  }
+
+.maka-daily-review-report[data-selected] {
+    border-color: var(--border-strong);
+  }
+
+/* The whole meta head is the select/expand target. Reset native button chrome;
+   layout is title-column + optional exception chip. */
+.maka-daily-review-report-head {
+    appearance: none;
+    background: none;
+    border: 0;
+    font: inherit;
+    text-align: left;
+    width: 100%;
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: var(--space-2-5);
+    padding: var(--space-2-5) var(--space-3);
+    color: var(--foreground);
+    transition: background var(--duration-base) var(--ease-out-strong);
+  }
+
+.maka-daily-review-report-head:hover {
+    background: var(--state-hover-bg);
+  }
+
+.maka-daily-review-report[data-selected] .maka-daily-review-report-head {
+    background: var(--state-selected-bg);
+  }
+
+@media (prefers-reduced-motion: reduce) {
+    .maka-daily-review-report-head {
+      transition: background 0ms;
+    }
+  }
+
+.maka-daily-review-report-heading {
+    display: grid;
+    gap: var(--space-0-5);
+    min-width: 0;
+  }
+
+.maka-daily-review-report-title {
+    min-width: 0;
+    color: var(--foreground);
+    font-size: var(--font-size-ui);
+    font-weight: var(--font-weight-semibold);
+    letter-spacing: var(--tracking-normal);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+.maka-daily-review-archive-row-meta {
+    min-width: 0;
+    color: var(--muted-foreground);
+    font-size: var(--font-size-caption);
+    font-variant-numeric: tabular-nums;
+    line-height: var(--leading-normal);
+    overflow-wrap: anywhere;
+  }
+
+/* Exception-only status chip (#651): only failed / no_model raise it, so it
+   never shrinks against the report title. */
+.maka-daily-review-report-status {
+    flex: none;
+  }
+
+/* Expanded body: sits under the meta head inside the same surface, separated
+   by a hairline so it reads as the report's continuation, not a nested card. */
+.maka-daily-review-report-body {
+    display: grid;
+    gap: var(--space-2);
+    min-width: 0;
+    padding: var(--space-1) var(--space-3) var(--space-3);
+    border-top: var(--border-width-hairline) solid var(--foreground-10);
+  }
+
+.maka-daily-review-archive-empty {
+    color: var(--muted-foreground);
+    font-size: var(--font-size-ui);
+    line-height: var(--leading-normal);
+  }
+
+.maka-daily-review-archive-error {
+    margin: 0;
+    color: var(--destructive, var(--foreground));
+    font-size: var(--font-size-ui);
+    line-height: var(--leading-normal);
+  }
+
+.maka-daily-review-archive-sections {
+    display: grid;
+    /* Section rhythm: the four report blocks (对话摘要/遗漏提醒/使用洞察/
+       代码建议) divide with 16px + hairline BETWEEN sections so they don't
+       read as one undifferentiated slab. */
+    gap: var(--space-3);
+  }
+
+.maka-daily-review-archive-section {
+    display: grid;
+    gap: var(--space-1-5);
+  }
+
+.maka-daily-review-archive-section + .maka-daily-review-archive-section {
+    border-top: var(--border-width-hairline) solid var(--foreground-10);
+    padding-top: var(--space-3);
+  }
+
+/* Markdown-rendered report body: restore list markers (Tailwind preflight
+   strips them — see the chat-bubble fix) and keep block rhythm tight. */
+.maka-daily-review-archive-section-body {
+    color: var(--foreground-secondary);
+    font-size: var(--font-size-ui);
+    line-height: var(--leading-normal);
+    overflow-wrap: anywhere;
+  }
+
+.maka-daily-review-archive-section-body p {
+    margin: 0 0 var(--space-1-5);
+  }
+
+.maka-daily-review-archive-section-body p:last-child,
+.maka-daily-review-archive-section-body ul:last-child,
+.maka-daily-review-archive-section-body ol:last-child {
+    margin-bottom: 0;
+  }
+
+.maka-daily-review-archive-section-body ul,
+.maka-daily-review-archive-section-body ol {
+    margin: 0 0 var(--space-1-5);
+    padding-left: var(--space-5);
+  }
+
+.maka-daily-review-archive-section-body ul { list-style: disc; }
+.maka-daily-review-archive-section-body ol { list-style: decimal; }

--- a/packages/ui/src/daily-review-panel.tsx
+++ b/packages/ui/src/daily-review-panel.tsx
@@ -20,13 +20,13 @@ import {
   formatDailyReviewModelLabel,
 } from './daily-review-helpers.js';
 import { Button as UiButton } from './ui.js';
-import { Item, ItemContent } from './primitives/item.js';
 import { Chip, type ChipProps } from './primitives/chip.js';
 import { Segmented } from './primitives/segmented.js';
 import { Alert, AlertAction, AlertDescription } from './primitives/alert.js';
 import { EmptyState } from './empty-state.js';
 import { StatTile } from './primitives/stat-tile.js';
 import { SectionHeader } from './primitives/section-header.js';
+import { PageHeader } from './primitives/page-header.js';
 import type { DailyReviewBridge, DailyReviewMarkdownActionInput } from './module-panel-types.js';
 import { RelativeTime } from './relative-time.js';
 import { Markdown } from './markdown.js';
@@ -237,11 +237,16 @@ export function DailyReviewPanel(props: {
   // Stepper step matches the range size — for 7-day mode the user
   // skips a whole week at a time, not a single day.
   const stepperLabel = range === 1 ? '天' : range === 7 ? '周' : '月';
-  const emptyActivityTitle = offsetDays === 0 && range === 1
+  // IA restructure: the 概览 section is ALWAYS rendered (honest zeros +
+  // this one inline hint) so a no-activity scope no longer collapses the
+  // page to a floating orphan line at the bottom. The hint absorbs the old
+  // bottom-of-page orphan into the 概览 header's flow. Copy keeps the endorsed
+  // waiting-state framing (等待记录今天活动 / 无活动 — visible-copy-hygiene).
+  const emptyOverviewTitle = offsetDays === 0 && range === 1
     ? '等待记录今天活动'
     : `${dayLabel}无活动`;
-  const emptyActivityBody = range === 1
-    ? '这一天没有发起对话，也没有调用模型。'
+  const emptyOverviewBody = offsetDays === 0 && range === 1
+    ? '今天还没有发起对话，也没有调用模型。'
     : `${dayLabel}范围内没有发起对话，也没有调用模型。`;
 
   async function runDailyReviewAction(actionKey: string, action: () => void | Promise<void>) {
@@ -283,17 +288,126 @@ export function DailyReviewPanel(props: {
     });
   }
 
+  // Export actions ride with the 概览 stats they serialize; the guard keeps
+  // them off an all-zero scope (nothing to export). Shape pinned by the
+  // daily-review-copy-feedback contract — do not restructure the condition.
+  const overviewActions =
+    visibleSummary && visibleSummary.totals.sessionCount + visibleSummary.totals.requestCount > 0 && hasDailyReviewActions ? (
+      <div className="maka-daily-review-actions" aria-label="回顾导出操作">
+        {props.onCopyMarkdown && (
+          <UiButton
+            type="button"
+            variant="secondary"
+            size="sm"
+            className="maka-daily-review-copy min-w-[4rem]"
+            onClick={() => void runDailyReviewAction('copy', async () => {
+              const md = formatDailyReviewMarkdown(visibleSummary, dayLabel);
+              await props.onCopyMarkdown?.({ markdown: md, label: dayLabel, summary: visibleSummary });
+            })}
+            disabled={dailyReviewActionBusy}
+            data-pending={pendingDailyReviewAction === 'copy' ? 'true' : undefined}
+            aria-busy={pendingDailyReviewAction === 'copy' ? 'true' : undefined}
+            title="复制为 Markdown 摘要，方便分享 / 贴到笔记"
+          >
+            {pendingDailyReviewAction === 'copy' ? '复制中…' : '复制'}
+          </UiButton>
+        )}
+        {props.onAppendMarkdown && (
+          <UiButton
+            type="button"
+            variant="secondary"
+            size="sm"
+            className="maka-daily-review-append min-w-[5rem]"
+            onClick={() => void runDailyReviewAction('append', async () => {
+              const md = formatDailyReviewMarkdown(visibleSummary, dayLabel);
+              await props.onAppendMarkdown?.({ markdown: md, label: dayLabel, summary: visibleSummary });
+            })}
+            disabled={dailyReviewActionBusy}
+            data-pending={pendingDailyReviewAction === 'append' ? 'true' : undefined}
+            aria-busy={pendingDailyReviewAction === 'append' ? 'true' : undefined}
+            title="追加到当前输入框草稿"
+          >
+            {pendingDailyReviewAction === 'append' ? '追加中…' : '粘到输入框'}
+          </UiButton>
+        )}
+        {props.onSaveMarkdown && (
+          <UiButton
+            type="button"
+            variant="secondary"
+            size="sm"
+            className="maka-daily-review-save min-w-[4rem]"
+            onClick={() => void runDailyReviewAction('save', async () => {
+              const md = formatDailyReviewMarkdown(visibleSummary, dayLabel);
+              await props.onSaveMarkdown?.({ markdown: md, label: dayLabel, summary: visibleSummary });
+            })}
+            disabled={dailyReviewActionBusy}
+            data-pending={pendingDailyReviewAction === 'save' ? 'true' : undefined}
+            aria-busy={pendingDailyReviewAction === 'save' ? 'true' : undefined}
+            title="保存为 Markdown 文件"
+          >
+            {pendingDailyReviewAction === 'save' ? '保存中…' : '保存'}
+          </UiButton>
+        )}
+      </div>
+    ) : null;
+
   return (
     <div className="maka-daily-review-panel" data-loading={loading ? 'true' : undefined}>
-      {/* IA restructure (owner: 页面太乱不直观): time context — the
-          day/week/month tabs and the date stepper — now lives in ONE
-          header bar instead of the tabs floating mid-page above the
-          stats they control. */}
-      {/* Designer audit P2-10: the range tabs sat at the far right while
-          the stepper sat at the far left — two time controls that read as
-          unrelated widgets. They now form ONE cluster: pick the range,
-          then step through it; the stepper steps by the selected span. */}
-      <header className="maka-daily-review-header">
+      {/* IA redesign (owner: 每日回顾 页面很乱): the PageHeader is THE page
+          shell — title + subtitle, and the 生成 actions ride its actions slot
+          (same pattern as the skills page's 添加). The analysis-model select is
+          now a COMPACT generation option inside that same cluster, not a
+          page-wide row. */}
+      <PageHeader
+        className="maka-module-main-header"
+        as="h2"
+        title="每日回顾"
+        subtitle="自动汇总本机对话，生成摘要、遗漏提醒与深度分析；可在设置中开启定时执行。"
+        actions={canManualRun ? (
+          <div className="maka-daily-review-generate" role="group" aria-label="生成回顾">
+            {modelOptions.length > 0 && (
+              <SettingsSelect
+                value={selectedModelKey}
+                ariaLabel="分析模型"
+                options={modelOptions}
+                onChange={setSelectedModelKey}
+                disabled={dailyReviewActionBusy}
+                width="compact"
+                className="maka-daily-review-model-select"
+              />
+            )}
+            <UiButton
+              type="button"
+              variant="default"
+              size="sm"
+              className="maka-daily-review-quick-run min-w-[6rem]"
+              onClick={() => void triggerManualRun('daily')}
+              disabled={dailyReviewActionBusy}
+              data-pending={pendingDailyReviewAction === 'run:daily' ? 'true' : undefined}
+              aria-busy={pendingDailyReviewAction === 'run:daily' ? 'true' : undefined}
+            >
+              {pendingDailyReviewAction === 'run:daily' ? '生成中…' : '生成每日回顾'}
+            </UiButton>
+            <UiButton
+              type="button"
+              variant="secondary"
+              size="sm"
+              className="maka-daily-review-quick-run min-w-[6rem]"
+              onClick={() => void triggerManualRun('deep')}
+              disabled={dailyReviewActionBusy}
+              data-pending={pendingDailyReviewAction === 'run:deep' ? 'true' : undefined}
+              aria-busy={pendingDailyReviewAction === 'run:deep' ? 'true' : undefined}
+            >
+              {pendingDailyReviewAction === 'run:deep' ? '生成中…' : '生成深度分析'}
+            </UiButton>
+          </div>
+        ) : undefined}
+      />
+
+      {/* One time-scope row directly under the header: the 今日/本周/本月
+          segmented + the day-stepper are BOTH time navigation, so they form a
+          single visual cluster (was two floating rows at opposite corners). */}
+      <div className="maka-daily-review-scope" aria-label="时间范围">
         <Segmented
           value={String(range)}
           options={[['1', '今日'], ['7', '本周'], ['30', '本月']]}
@@ -304,7 +418,7 @@ export function DailyReviewPanel(props: {
           ariaLabel="时间范围切换"
           className="maka-daily-review-range-tabs"
         />
-        <div className="maka-daily-review-header-time">
+        <div className="maka-daily-review-scope-stepper">
           <UiButton
             type="button"
             variant="ghost"
@@ -328,52 +442,128 @@ export function DailyReviewPanel(props: {
             <ChevronRight aria-hidden="true" />
           </UiButton>
         </div>
-      </header>
-      {canManualRun && (
-        <div className="maka-daily-review-quick-runs" aria-label="手动触发回顾">
-          {modelOptions.length > 0 && (
-            <SettingsSelect
-              value={selectedModelKey}
-              ariaLabel="每日回顾分析模型"
-              options={modelOptions}
-              onChange={setSelectedModelKey}
-              disabled={dailyReviewActionBusy}
-              className="maka-daily-review-model-select"
-            />
-          )}
-          <UiButton
-            type="button"
-            variant="default"
-            size="sm"
-            className="maka-daily-review-quick-run min-w-[6rem]"
-            onClick={() => void triggerManualRun('daily')}
-            disabled={dailyReviewActionBusy}
-            data-pending={pendingDailyReviewAction === 'run:daily' ? 'true' : undefined}
-            aria-busy={pendingDailyReviewAction === 'run:daily' ? 'true' : undefined}
-          >
-            {pendingDailyReviewAction === 'run:daily' ? '生成中…' : '生成每日回顾'}
-          </UiButton>
-          <UiButton
-            type="button"
-            variant="secondary"
-            size="sm"
-            className="maka-daily-review-quick-run min-w-[6rem]"
-            onClick={() => void triggerManualRun('deep')}
-            disabled={dailyReviewActionBusy}
-            data-pending={pendingDailyReviewAction === 'run:deep' ? 'true' : undefined}
-            aria-busy={pendingDailyReviewAction === 'run:deep' ? 'true' : undefined}
-          >
-            {pendingDailyReviewAction === 'run:deep' ? '生成中…' : '生成深度分析'}
-          </UiButton>
-        </div>
-      )}
+      </div>
+
+      {/* 概览 — ALWAYS rendered for the selected scope. Honest zeros + one
+          inline hint replace the old bottom orphan line, so a no-activity
+          scope no longer collapses the page to nothing. */}
+      <section className="maka-daily-review-overview" aria-label={`${dayLabel}概览`}>
+        <SectionHeader as="h4" accent title="概览" action={overviewActions} />
+        {error && visibleSummary ? (
+          <Alert variant="warning" className="maka-daily-review-alert">
+            <AlertDescription>每日回顾刷新失败：{error}</AlertDescription>
+            <AlertAction>
+              <UiButton
+                type="button"
+                variant="ghost"
+                size="sm"
+                className="maka-daily-review-alert-retry"
+                onClick={() => setReloadToken((n) => n + 1)}
+                disabled={loading}
+              >
+                重试
+              </UiButton>
+            </AlertAction>
+          </Alert>
+        ) : null}
+
+        {error && !visibleSummary ? (
+          <EmptyState
+            Icon={CalendarDays}
+            title="读取失败"
+            body={error}
+            cta={{ label: '重试', onClick: () => setReloadToken((n) => n + 1) }}
+            extraClassName="maka-daily-review-summary-empty"
+          />
+        ) : !visibleSummary ? (
+          <div className="maka-daily-review-loading" aria-busy="true">
+            <div className="maka-skeleton maka-skeleton-line" style={{ width: '60%' }} />
+            <div className="maka-skeleton maka-skeleton-line" style={{ width: '90%' }} />
+            <div className="maka-skeleton maka-skeleton-line" style={{ width: '75%' }} />
+          </div>
+        ) : (
+          <>
+            <div className="maka-daily-review-totals">
+              <DailyReviewTotalsCell label="对话" value={visibleSummary.totals.sessionCount.toString()} />
+              <DailyReviewTotalsCell label="请求" value={visibleSummary.totals.requestCount.toString()} />
+              <DailyReviewTotalsCell
+                label="Token"
+                value={visibleSummary.totals.totalTokens.toLocaleString()}
+              />
+              <DailyReviewTotalsCell
+                label="费用"
+                value={`$${visibleSummary.totals.costUsd.toFixed(2)}`}
+              />
+              {visibleSummary.totals.errorCount > 0 && (
+                <DailyReviewTotalsCell
+                  label="错误"
+                  value={visibleSummary.totals.errorCount.toString()}
+                  tone="error"
+                />
+              )}
+            </div>
+
+            {visibleSummary.totals.sessionCount === 0 && visibleSummary.totals.requestCount === 0 ? (
+              <EmptyState variant="inline" title={emptyOverviewTitle} body={emptyOverviewBody} />
+            ) : (
+              <>
+                {visibleSummary.sessions.length > 0 && (
+                  <section className="maka-daily-review-section" aria-label="活跃对话">
+                    <SectionHeader as="h4" accent title="活跃对话" />
+                    <ul className="maka-daily-review-list" aria-label="活跃对话列表">
+                      {visibleSummary.sessions.map((session) => (
+                        <li key={session.id} className="maka-daily-review-list-item">
+                          {/* Active-conversation rows are composite navigation
+                              controls. Their semantic row seam owns layout and state;
+                              they are not a shared Button size or variant. */}
+                          <BaseButton
+                            type="button"
+                            className="maka-daily-review-session-button"
+                            onClick={() => props.onSelectSession?.(session.id)}
+                            disabled={!props.onSelectSession}
+                          >
+                            <span className="maka-daily-review-session-name">{session.name}</span>
+                            <RelativeTime
+                              ts={session.lastMessageAt}
+                              className="maka-daily-review-session-time"
+                            />
+                          </BaseButton>
+                          {session.lastMessagePreview && (
+                            <span className="maka-daily-review-session-preview">
+                              {session.lastMessagePreview}
+                            </span>
+                          )}
+                        </li>
+                      ))}
+                    </ul>
+                  </section>
+                )}
+
+                {visibleSummary.topModels.length > 0 && (
+                  <DailyReviewTopList title="模型使用" entries={visibleSummary.topModels} />
+                )}
+
+                {visibleSummary.topTools.length > 0 && (
+                  <DailyReviewTopList title="工具调用" entries={visibleSummary.topTools} />
+                )}
+              </>
+            )}
+          </>
+        )}
+      </section>
+
+      {/* 报告 — stacked, newest-first. Each report is a full-width surface
+          whose meta header (date · 模式 · N 对话 · 触发+时间 · 模型) is always
+          visible; the selected one expands its four content sections below.
+          This replaces the broken left-list / right-body master-detail that
+          left the list column half-empty. Body loads stay single-selection
+          (getArchive) — the archive-body-load contract pins that lazy path. */}
       {canLoadArchives && (
-        <section className="maka-daily-review-archives" aria-label="已生成报告">
+        <section className="maka-daily-review-reports" aria-label="报告">
           <SectionHeader
-            className="maka-daily-review-archives-header"
             as="h4"
             accent
-            title="已生成报告"
+            title="报告"
             count={<span className="maka-daily-review-archive-count">{archives.length} 份</span>}
           />
           {archiveError && (
@@ -395,238 +585,65 @@ export function DailyReviewPanel(props: {
           )}
           {archives.length === 0 && !archiveError ? (
             <EmptyState
-              variant="inline"
-              extraClassName="maka-daily-review-archive-empty"
+              Icon={CalendarDays}
               title="还没有生成报告"
-              body="点击上方按钮后，报告会保存到本机并显示在这里。"
+              body="点击「生成每日回顾」后，报告会保存到本机并显示在这里。"
+              cta={canManualRun ? {
+                label: '生成每日回顾',
+                onClick: () => void triggerManualRun('daily'),
+                disabled: dailyReviewActionBusy,
+              } : undefined}
+              extraClassName="maka-daily-review-summary-empty"
             />
           ) : (
-            <div className="maka-daily-review-archive-layout">
-              {/* PR-DAILYREVIEW-ARCHIVE-ROW-A11Y-0 (round 7/30):
-                  the archive list was a `<div role="list">` with
-                  `<button role="listitem">` children. `role` doesn't
-                  layer like that — a `<button>` is already a button,
-                  so giving it `role="listitem"` either gets ignored
-                  by ATs or produces inconsistent announcements.
-                  Switched to semantic `<ul>` / `<li>` and routed the
-                  click target through UiButton so disabled-state +
-                  focus-visible + `:active` come from the shared
-                  contract. */}
-              <ul className="maka-daily-review-archive-list" aria-label="回顾报告历史">
-                {archives.map((archive) => (
+            <ul className="maka-daily-review-report-list" aria-label="回顾报告历史">
+              {archives.map((archive) => {
+                const selected = selectedArchiveId === archive.id;
+                // Status color is exception-only (#651): 已生成 / 无数据 / 已跳过
+                // are EXPECTED outcomes and stay as muted prose meta. Only a
+                // failed / no_model run raises a colored Chip that needs eyes.
+                const exceptional = archive.status === 'failed' || archive.status === 'no_model';
+                const meta = [
+                  `${archive.totals.sessionCount} 对话`,
+                  `${DAILY_REVIEW_ARCHIVE_TRIGGER_LABEL[archive.trigger]}生成 ${formatDailyReviewArchiveGeneratedAt(archive.generatedAt)}`,
+                  archive.modelKey ? formatDailyReviewModelLabel(archive.modelKey) : '默认对话模型',
+                ].join(' · ');
+                return (
                   <li key={archive.id}>
-                    {/* Archive row now speaks the shared Item row language:
-                        hover 4% / selected 6.5% come from the primitive
-                        (selected → --state-selected-bg), ItemContent stacks
-                        the title over the meta line. The row class keeps only
-                        geometry (padding, radius, selected border). */}
-                    <Item
-                      className="maka-daily-review-archive-row"
-                      selected={selectedArchiveId === archive.id}
-                      render={
-                        <button
-                          type="button"
-                          onClick={() => chooseDailyReviewArchive(archive.id)}
-                        />
-                      }
-                    >
-                      <ItemContent>
-                        {/* Plain span (not ItemTitle): the row title relies on
-                            block-level text-overflow ellipsis, which ItemTitle's
-                            flex layout would defeat. */}
-                        <span className="maka-daily-review-archive-row-title">
-                          {formatDailyReviewArchiveTitle(archive)}
+                    <article className="maka-daily-review-report" data-selected={selected ? '' : undefined}>
+                      <button
+                        type="button"
+                        className="maka-daily-review-report-head"
+                        onClick={() => chooseDailyReviewArchive(archive.id)}
+                        aria-expanded={selected}
+                      >
+                        <span className="maka-daily-review-report-heading">
+                          <span className="maka-daily-review-report-title">
+                            {formatDailyReviewArchiveTitle(archive)}
+                          </span>
+                          <span className="maka-daily-review-archive-row-meta">{meta}</span>
                         </span>
-                        {/* Designer audit P2-11: the row used to repeat the
-                            detail card's entire header (status + timestamp).
-                            The list only needs to identify the report; status
-                            and generation time live in the detail. */}
-                        <span className="maka-daily-review-archive-row-meta">
-                          {archive.totals.sessionCount} 对话
-                          {archive.status !== 'ok' ? ` · ${DAILY_REVIEW_ARCHIVE_STATUS_LABEL[archive.status]}` : ''}
-                        </span>
-                      </ItemContent>
-                    </Item>
+                        {exceptional && (
+                          <Chip
+                            size="sm"
+                            variant={dailyReviewArchiveChipTone(archive.status)}
+                            className="maka-daily-review-report-status"
+                            data-status={archive.status}
+                          >
+                            {DAILY_REVIEW_ARCHIVE_STATUS_LABEL[archive.status]}
+                          </Chip>
+                        )}
+                      </button>
+                      {selected && (
+                        <DailyReviewArchiveBody archive={selectedArchive} loading={archiveLoading} />
+                      )}
+                    </article>
                   </li>
-                ))}
-              </ul>
-              <DailyReviewArchiveBody archive={selectedArchive} loading={archiveLoading} />
-            </div>
+                );
+              })}
+            </ul>
           )}
         </section>
-      )}
-      {/* Export actions ride with the stats they export (tabs moved to
-          the header above), so the old mid-page nav bar is gone. */}
-      {visibleSummary && visibleSummary.totals.sessionCount + visibleSummary.totals.requestCount > 0 && hasDailyReviewActions && (
-        <div className="maka-daily-review-actions" aria-label="回顾导出操作">
-          {props.onCopyMarkdown && (
-              <UiButton
-                type="button"
-                variant="secondary"
-                size="sm"
-                className="maka-daily-review-copy min-w-[4rem]"
-                onClick={() => void runDailyReviewAction('copy', async () => {
-                  const md = formatDailyReviewMarkdown(visibleSummary, dayLabel);
-                  await props.onCopyMarkdown?.({ markdown: md, label: dayLabel, summary: visibleSummary });
-                })}
-                disabled={dailyReviewActionBusy}
-                data-pending={pendingDailyReviewAction === 'copy' ? 'true' : undefined}
-                aria-busy={pendingDailyReviewAction === 'copy' ? 'true' : undefined}
-                title="复制为 Markdown 摘要，方便分享 / 贴到笔记"
-              >
-                {pendingDailyReviewAction === 'copy' ? '复制中…' : '复制'}
-              </UiButton>
-            )}
-            {props.onAppendMarkdown && (
-              <UiButton
-                type="button"
-                variant="secondary"
-                size="sm"
-                className="maka-daily-review-append min-w-[5rem]"
-                onClick={() => void runDailyReviewAction('append', async () => {
-                  const md = formatDailyReviewMarkdown(visibleSummary, dayLabel);
-                  await props.onAppendMarkdown?.({ markdown: md, label: dayLabel, summary: visibleSummary });
-                })}
-                disabled={dailyReviewActionBusy}
-                data-pending={pendingDailyReviewAction === 'append' ? 'true' : undefined}
-                aria-busy={pendingDailyReviewAction === 'append' ? 'true' : undefined}
-                title="追加到当前输入框草稿"
-              >
-                {pendingDailyReviewAction === 'append' ? '追加中…' : '粘到输入框'}
-              </UiButton>
-            )}
-            {props.onSaveMarkdown && (
-              <UiButton
-                type="button"
-                variant="secondary"
-                size="sm"
-                className="maka-daily-review-save min-w-[4rem]"
-                onClick={() => void runDailyReviewAction('save', async () => {
-                  const md = formatDailyReviewMarkdown(visibleSummary, dayLabel);
-                  await props.onSaveMarkdown?.({ markdown: md, label: dayLabel, summary: visibleSummary });
-                })}
-                disabled={dailyReviewActionBusy}
-                data-pending={pendingDailyReviewAction === 'save' ? 'true' : undefined}
-                aria-busy={pendingDailyReviewAction === 'save' ? 'true' : undefined}
-                title="保存为 Markdown 文件"
-              >
-                {pendingDailyReviewAction === 'save' ? '保存中…' : '保存'}
-              </UiButton>
-            )}
-        </div>
-      )}
-
-      {error && visibleSummary ? (
-        <Alert variant="warning" className="maka-daily-review-alert">
-          <AlertDescription>每日回顾刷新失败：{error}</AlertDescription>
-          <AlertAction>
-            <UiButton
-              type="button"
-              variant="ghost"
-              size="sm"
-              className="maka-daily-review-alert-retry"
-              onClick={() => setReloadToken((n) => n + 1)}
-              disabled={loading}
-            >
-              重试
-            </UiButton>
-          </AlertAction>
-        </Alert>
-      ) : null}
-
-      {error && !visibleSummary ? (
-        <EmptyState
-          Icon={CalendarDays}
-          title="读取失败"
-          body={error}
-          cta={{ label: '重试', onClick: () => setReloadToken((n) => n + 1) }}
-          extraClassName="maka-daily-review-summary-empty"
-        />
-      ) : !visibleSummary ? (
-        <div className="maka-daily-review-loading" aria-busy="true">
-          <div className="maka-skeleton maka-skeleton-line" style={{ width: '60%' }} />
-          <div className="maka-skeleton maka-skeleton-line" style={{ width: '90%' }} />
-          <div className="maka-skeleton maka-skeleton-line" style={{ width: '75%' }} />
-        </div>
-      ) : visibleSummary.totals.sessionCount === 0 && visibleSummary.totals.requestCount === 0 ? (
-        // When saved reports already fill the page, a second full-height
-        // empty card below them read as a broken half-loaded section
-        // (designer audit P0-4). Collapse to a one-line note in that case;
-        // keep the full empty state only when it is the page's sole content.
-        canLoadArchives && archives.length > 0 ? (
-          <p className="maka-daily-review-activity-note" role="status">
-            {emptyActivityTitle} · {emptyActivityBody}
-          </p>
-        ) : (
-          <EmptyState
-            Icon={CalendarDays}
-            title={emptyActivityTitle}
-            body={emptyActivityBody}
-            extraClassName="maka-daily-review-summary-empty"
-          />
-        )
-      ) : (
-        <>
-          <section className="maka-daily-review-totals" aria-label={`${dayLabel}总览`}>
-            <DailyReviewTotalsCell label="对话" value={visibleSummary.totals.sessionCount.toString()} />
-            <DailyReviewTotalsCell label="请求" value={visibleSummary.totals.requestCount.toString()} />
-            <DailyReviewTotalsCell
-              label="Token"
-              value={visibleSummary.totals.totalTokens.toLocaleString()}
-            />
-            <DailyReviewTotalsCell
-              label="费用"
-              value={`$${visibleSummary.totals.costUsd.toFixed(2)}`}
-            />
-            {visibleSummary.totals.errorCount > 0 && (
-              <DailyReviewTotalsCell
-                label="错误"
-                value={visibleSummary.totals.errorCount.toString()}
-                tone="error"
-              />
-            )}
-          </section>
-
-          {visibleSummary.sessions.length > 0 && (
-            <section className="maka-daily-review-section" aria-label="活跃对话">
-              <SectionHeader as="h4" accent title="活跃对话" />
-              <ul className="maka-daily-review-list" aria-label="活跃对话列表">
-                {visibleSummary.sessions.map((session) => (
-                  <li key={session.id} className="maka-daily-review-list-item">
-                    {/* Active-conversation rows are composite navigation
-                        controls. Their semantic row seam owns layout and state;
-                        they are not a shared Button size or variant. */}
-                    <BaseButton
-                      type="button"
-                      className="maka-daily-review-session-button"
-                      onClick={() => props.onSelectSession?.(session.id)}
-                      disabled={!props.onSelectSession}
-                    >
-                      <span className="maka-daily-review-session-name">{session.name}</span>
-                      <RelativeTime
-                        ts={session.lastMessageAt}
-                        className="maka-daily-review-session-time"
-                      />
-                    </BaseButton>
-                    {session.lastMessagePreview && (
-                      <span className="maka-daily-review-session-preview">
-                        {session.lastMessagePreview}
-                      </span>
-                    )}
-                  </li>
-                ))}
-              </ul>
-            </section>
-          )}
-
-          {visibleSummary.topModels.length > 0 && (
-            <DailyReviewTopList title="模型使用" entries={visibleSummary.topModels} />
-          )}
-
-          {visibleSummary.topTools.length > 0 && (
-            <DailyReviewTopList title="工具调用" entries={visibleSummary.topTools} />
-          )}
-        </>
       )}
     </div>
   );
@@ -635,7 +652,7 @@ export function DailyReviewPanel(props: {
 function DailyReviewArchiveBody(props: { archive: DailyReviewArchive | null; loading: boolean }) {
   if (props.loading) {
     return (
-      <div className="maka-daily-review-archive-body" aria-busy="true">
+      <div className="maka-daily-review-report-body" aria-busy="true">
         <div className="maka-skeleton maka-skeleton-line" style={{ width: '58%' }} />
         <div className="maka-skeleton maka-skeleton-line" style={{ width: '92%' }} />
         <div className="maka-skeleton maka-skeleton-line" style={{ width: '74%' }} />
@@ -644,8 +661,8 @@ function DailyReviewArchiveBody(props: { archive: DailyReviewArchive | null; loa
   }
   if (!props.archive) {
     return (
-      <div className="maka-daily-review-archive-body" data-empty="true">
-        选择一份报告查看生成内容。
+      <div className="maka-daily-review-report-body maka-daily-review-archive-empty">
+        正在打开这份报告…
       </div>
     );
   }
@@ -656,25 +673,11 @@ function DailyReviewArchiveBody(props: { archive: DailyReviewArchive | null; loa
       return content ? { key, content } : null;
     })
     .filter((entry): entry is { key: DailyReviewArchiveSectionKey; content: string } => entry !== null);
+  // The report's date / 模式 / 触发 / 时间 / 模型 meta now lives in the surface
+  // head above this body (no repeated header, no 已生成 status chip on the
+  // expected state) — the body carries only the report substance.
   return (
-    <article className="maka-daily-review-archive-body" aria-label={formatDailyReviewArchiveTitle(archive)}>
-      <header className="maka-daily-review-archive-body-header">
-        <div>
-          <h4>{formatDailyReviewArchiveTitle(archive)}</h4>
-          <p>
-            {DAILY_REVIEW_ARCHIVE_TRIGGER_LABEL[archive.trigger]}生成 · {formatDailyReviewArchiveGeneratedAt(archive.generatedAt)}
-            {archive.modelKey ? ` · ${formatDailyReviewModelLabel(archive.modelKey)}` : ' · 默认对话模型'}
-          </p>
-        </div>
-        <Chip
-          size="sm"
-          variant={dailyReviewArchiveChipTone(archive.status)}
-          className="maka-daily-review-archive-status"
-          data-status={archive.status}
-        >
-          {DAILY_REVIEW_ARCHIVE_STATUS_LABEL[archive.status]}
-        </Chip>
-      </header>
+    <div className="maka-daily-review-report-body" aria-label={formatDailyReviewArchiveTitle(archive)}>
       {archive.errorMessage && (
         <p className="maka-daily-review-archive-error">{archive.errorMessage}</p>
       )}
@@ -682,7 +685,7 @@ function DailyReviewArchiveBody(props: { archive: DailyReviewArchive | null; loa
         <div className="maka-daily-review-archive-sections">
           {sections.map((section) => (
             <section key={section.key} className="maka-daily-review-archive-section">
-              <h5>{DAILY_REVIEW_ARCHIVE_SECTION_LABEL[section.key]}</h5>
+              <SectionHeader as="h4" accent title={DAILY_REVIEW_ARCHIVE_SECTION_LABEL[section.key]} />
               {/* Reports are LLM-generated markdown — bullet lists and
                   inline code rendered as flat pre-wrap text read as mush.
                   Reuse the shared Markdown pipeline (same one chat uses). */}
@@ -697,7 +700,7 @@ function DailyReviewArchiveBody(props: { archive: DailyReviewArchive | null; loa
           这份报告没有生成正文内容。
         </p>
       )}
-    </article>
+    </div>
   );
 }
 

--- a/packages/ui/src/module-pages.tsx
+++ b/packages/ui/src/module-pages.tsx
@@ -101,18 +101,24 @@ export function DailyReviewPage(props: {
 }) {
   return (
     <main className="maka-main detailPane maka-module-main agents-chat-panel" data-module="daily-review" aria-label="每日回顾">
-      <header className="maka-module-main-header">
-        <div>
-          <h2>每日回顾</h2>
-          <p>自动汇总本机对话，生成摘要、遗漏提醒与深度分析；可在设置中开启定时执行。</p>
-        </div>
-      </header>
       {props.bridge ? (
+        // The PageHeader (title + subtitle + the 生成 actions) now lives INSIDE
+        // the panel so the generation buttons can ride the header's actions slot
+        // with the panel's run state. The bridge-less fallback keeps its own
+        // static header below.
         <Suspense fallback={<ModulePanelFallback message="正在加载每日回顾…" />}>
           <DailyReviewPanel {...props} bridge={props.bridge} />
         </Suspense>
       ) : (
-        <EmptyState Icon={CalendarDays} title="等待连接每日回顾数据" body="桌面端数据桥当前未连接。" />
+        <>
+          <header className="maka-module-main-header">
+            <div>
+              <h2>每日回顾</h2>
+              <p>自动汇总本机对话，生成摘要、遗漏提醒与深度分析；可在设置中开启定时执行。</p>
+            </div>
+          </header>
+          <EmptyState Icon={CalendarDays} title="等待连接每日回顾数据" body="桌面端数据桥当前未连接。" />
+        </>
       )}
     </main>
   );


### PR DESCRIPTION
User verdict on the old page: 很混乱、很不好看、很不好用. This is the IA redesign (the #1187 style pass converged primitives; this round restructures the page).

## Problems fixed (diagnosed from live captures)
1. Control soup — two floating control rows with unclear ownership → PageHeader carries the generation actions (default + secondary) with a compact 分析模型 select (跟随设置) beside them; one time-navigation cluster (segmented + day stepper) under the header.
2. Broken master-detail report list (2 rows + dead column) → stacked accordion: every report shows an always-visible meta head (05/21 · 深度分析 · 12 对话 · 定时生成 05/22 10:55 · glm-4.5, muted prose), the selected one expands its four sections in place; same lazy getArchive path (archive-body-load contract preserved).
3. 已生成 chip on an expected state → removed; status color is exception-only (生成失败/缺少模型 raise a warning Chip).
4. Orphan bottom line 等待记录今天活动… → absorbed as the 概览 section's inline hint.
5. Stats vanished on empty days → 概览 StatTiles always render with honest zeros, so the review page always shows something reviewable.

## Fidelity
Zero data/IPC/behavior change — same props, callbacks, and fail-soft guards; copy-feedback and archive-body-load contracts preserved verbatim; radius contract re-pinned for the archive-body → report surface rename. Documented deviations: export actions stay with the 概览 stats they serialize (contract pins the visibleSummary guard); accordion over all-expanded (avoids N eager body fetches).

## Gates
Branch already contains main tip. desktop 2695/2695 · ui 183/183 · typecheck · check-dead-css · knip ×2 = 0 · console/a11y/copy checks OK · alignment auditor clean. CDP before/after light+dark verified (captures in session scratchpad only). Implemented by an opus worktree agent from a maintainer-authored IA brief; visually accepted before merge.