### PR TITLE
feat(mcp): add bundled market and cancellable installs

### DIFF
--- a/apps/desktop/e2e/mcp.spec.ts
+++ b/apps/desktop/e2e/mcp.spec.ts
@@ -45,6 +45,24 @@ test('MCP module completes stdio add, discovery, disable, JSON import, and delet
     await page.setViewportSize(viewport);
   }
 
+  const dingtalkCard = mcp.getByRole('article').filter({ hasText: '钉钉' });
+  const installDingtalk = dingtalkCard.getByRole('button', { name: '安装 钉钉' });
+  await installDingtalk.click();
+  const cancelDingtalk = dingtalkCard.getByRole('button', { name: '取消安装 钉钉' });
+  await expect(cancelDingtalk).toBeVisible();
+  await page.mouse.move(0, 0);
+  await expect(cancelDingtalk.locator('.maka-mcp-install-spinner')).toHaveCSS('opacity', '1');
+  if (screenshotPath) await page.screenshot({ path: variantPath(screenshotPath, 'installing') });
+  await cancelDingtalk.hover();
+  await expect(cancelDingtalk.locator('.maka-mcp-install-cancel')).toHaveCSS('opacity', '1');
+  if (screenshotPath) await page.screenshot({ path: variantPath(screenshotPath, 'install-cancel-hover') });
+  await cancelDingtalk.click();
+  await expect(dingtalkCard.getByRole('button', { name: '安装 钉钉' })).toBeVisible();
+  await expect.poll(async () => {
+    const next = await page.evaluate(() => window.maka.mcp.getConfig());
+    return next.mcpServers.dingtalk;
+  }).toBeUndefined();
+
   await mcp.getByRole('button', { name: '添加 MCP' }).click();
   const editor = page.getByRole('dialog', { name: '添加 MCP' });
   if (screenshotPath) await page.screenshot({ path: variantPath(screenshotPath, 'manual') });

--- a/apps/desktop/e2e/session-workbar.spec.ts
+++ b/apps/desktop/e2e/session-workbar.spec.ts
@@ -30,9 +30,8 @@ test('session tools share one user-controlled workbar', async ({ sessionWorkbarW
   await expect(page.getByRole('main', { name: '技能' })).toBeVisible();
 });
 
-test('workbar toggle stays unavailable without an active session', async ({ window: page }) => {
+test('workbar toggle stays unmounted without an active session', async ({ window: page }) => {
   const toggle = page.getByRole('button', { name: '暂无可用的会话工作栏' });
 
-  await expect(toggle).toBeDisabled();
-  await expect(toggle).toHaveAttribute('aria-expanded', 'false');
+  await expect(toggle).toHaveCount(0);
 });

--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -219,7 +219,9 @@ declare global {
         listStatuses(): Promise<McpServerStatus[]>;
         setConfig(config: McpConfigFile): Promise<McpConfigFile>;
         upsert(serverId: string, config: McpServerConfig): Promise<McpConfigFile>;
+        install(serverId: string, config: McpServerConfig): Promise<McpConfigFile>;
         remove(serverId: string): Promise<McpConfigFile>;
+        cancelInstall(serverId: string): Promise<McpConfigFile>;
         test(serverId: string): Promise<McpTestResult>;
         reconnect(serverId: string): Promise<McpServerStatus>;
         subscribeChanges(handler: (statuses: McpServerStatus[]) => void): () => void;

--- a/apps/desktop/src/main/__tests__/mcp-ipc-main.test.ts
+++ b/apps/desktop/src/main/__tests__/mcp-ipc-main.test.ts
@@ -28,6 +28,7 @@ test('MCP IPC reconciles config before invalidating idle backends and emitting s
       },
     },
     manager: {
+      cancelConnect: () => { calls.push('cancel'); return true; },
       sync: async () => { calls.push('sync'); },
       statuses: () => [connected],
       reconnect: async () => connected,
@@ -61,4 +62,69 @@ test('MCP IPC reconciles config before invalidating idle backends and emitting s
   assert.ok(testHandler);
   assert.equal((await testHandler({}, 'fixture')).ok, true);
   assert.deepEqual(calls, ['ready', 'emit']);
+
+  calls.length = 0;
+  config = { version: 1, mcpServers: { fixture: { command: 'node' } } };
+  const cancelInstall = handlers.get('mcp:cancelInstall');
+  assert.ok(cancelInstall);
+  const cancelled = await cancelInstall({}, 'fixture');
+  assert.equal(cancelled.mcpServers.fixture, undefined);
+  assert.deepEqual(calls, ['cancel', 'sync', 'refresh', 'emit']);
+});
+
+test('MCP market cancellation waits for an in-flight config write before rolling it back', async () => {
+  const handlers = new Map<string, (...args: any[]) => Promise<any>>();
+  let config: McpConfigFile = { version: 1, mcpServers: {} };
+  let releaseWrite!: () => void;
+  let markWriteStarted!: () => void;
+  const writeGate = new Promise<void>((resolve) => { releaseWrite = resolve; });
+  const writeStarted = new Promise<void>((resolve) => { markWriteStarted = resolve; });
+  const calls: string[] = [];
+
+  registerMcpIpcMain({
+    ipcMain: { handle(channel, handler) { handlers.set(channel, handler as (...args: any[]) => Promise<any>); } },
+    store: {
+      get: async () => config,
+      set: async (next) => { config = next; return next; },
+      upsert: async (serverId, server) => {
+        calls.push('write:start');
+        markWriteStarted();
+        await writeGate;
+        config = { version: 1, mcpServers: { ...config.mcpServers, [serverId]: server } };
+        calls.push('write:end');
+        return config;
+      },
+      remove: async (serverId) => {
+        calls.push('remove');
+        const { [serverId]: _removed, ...mcpServers } = config.mcpServers;
+        config = { version: 1, mcpServers };
+        return config;
+      },
+    },
+    manager: {
+      cancelConnect: () => { calls.push('cancel'); return true; },
+      sync: async () => { calls.push('sync'); },
+      statuses: () => [],
+      reconnect: async () => { throw new Error('not used'); },
+      test: async () => { throw new Error('not used'); },
+    },
+    ensureReady: async () => {},
+    refreshIdleBackends: async () => { calls.push('refresh'); },
+    emitChanged: () => { calls.push('emit'); },
+  });
+
+  const install = handlers.get('mcp:install');
+  const cancelInstall = handlers.get('mcp:cancelInstall');
+  assert.ok(install);
+  assert.ok(cancelInstall);
+
+  const installing = install({}, 'fixture', { command: 'node' });
+  await writeStarted;
+  const cancelling = cancelInstall({}, 'fixture');
+  releaseWrite();
+
+  const [, cancelled] = await Promise.all([installing, cancelling]);
+  assert.equal(cancelled.mcpServers.fixture, undefined);
+  assert.equal(config.mcpServers.fixture, undefined);
+  assert.deepEqual(calls, ['write:start', 'cancel', 'write:end', 'remove', 'sync', 'refresh', 'emit']);
 });

--- a/apps/desktop/src/main/__tests__/mcp-market-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/mcp-market-contract.test.ts
@@ -1,0 +1,42 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+import { test } from 'node:test';
+
+const repoRoot = resolve(import.meta.dirname, '../../../../..');
+
+test('MCP market ships the requested first-party catalog and cancellable install affordance', async () => {
+  const [catalog, page, styles, preload] = await Promise.all([
+    readFile(resolve(repoRoot, 'apps/desktop/src/renderer/mcp-catalog.ts'), 'utf8'),
+    readFile(resolve(repoRoot, 'apps/desktop/src/renderer/mcp-page.tsx'), 'utf8'),
+    readFile(resolve(repoRoot, 'apps/desktop/src/renderer/styles/module-pages/mcp.css'), 'utf8'),
+    readFile(resolve(repoRoot, 'apps/desktop/src/preload/preload.ts'), 'utf8'),
+  ]);
+
+  for (const id of [
+    'dingtalk', 'feishu', 'slack', 'line', 'notion', 'macos-apps',
+    'google-calendar', 'figma', 'vercel', 'supabase',
+  ]) {
+    assert.match(catalog, new RegExp(`id: ['"]${id}['"]`), `${id} must be present in the MCP market`);
+  }
+
+  for (const packageSpec of [
+    'dingtalk-mcp@1.1.21',
+    '@larksuiteoapi/lark-mcp@0.5.1',
+    '@modelcontextprotocol/server-slack@2025.4.25',
+    '@line/line-bot-mcp-server@0.5.0',
+    'mcp-server-apple-events@1.4.0',
+    '@cocal/google-calendar-mcp@2.6.2',
+    'figma-developer-mcp@0.13.2',
+  ]) {
+    assert.ok(catalog.includes(packageSpec), `${packageSpec} must stay pinned in the bundled catalog`);
+  }
+  assert.doesNotMatch(catalog, /YOUR_APP_(?:ID|SECRET)/, 'Feishu credentials must not be placed in process args');
+  assert.match(catalog, /env: \{ APP_ID: '', APP_SECRET: '' \}/);
+
+  assert.match(page, /data-phase=\{props\.phase \?\? 'idle'\}/);
+  assert.match(page, /onClick=\{installing \? props\.onCancel : props\.onInstall\}/);
+  assert.match(styles, /data-phase="installing"[^}]*:hover \.maka-mcp-install-spinner/s);
+  assert.match(styles, /\.maka-mcp-install-cancel/);
+  assert.match(preload, /cancelInstall\(serverId: string\)/);
+});

--- a/apps/desktop/src/main/mcp-ipc-main.ts
+++ b/apps/desktop/src/main/mcp-ipc-main.ts
@@ -6,13 +6,14 @@ import type { McpConfigStore } from '@maka/storage';
 export interface McpIpcMainDeps {
   ipcMain: Pick<IpcMain, 'handle'>;
   store: McpConfigStore;
-  manager: Pick<McpClientManager, 'sync' | 'statuses' | 'test' | 'reconnect'>;
+  manager: Pick<McpClientManager, 'sync' | 'statuses' | 'test' | 'reconnect' | 'cancelConnect'>;
   ensureReady(): Promise<void>;
   refreshIdleBackends(): Promise<void>;
   emitChanged(statuses: McpServerStatus[]): void;
 }
 
 export function registerMcpIpcMain(deps: McpIpcMainDeps): void {
+  const installs = new Map<string, { cancelled: boolean; settled: Promise<void>; settle(): void }>();
   deps.ipcMain.handle('mcp:getConfig', async () => {
     await deps.ensureReady();
     return deps.store.get();
@@ -33,7 +34,41 @@ export function registerMcpIpcMain(deps: McpIpcMainDeps): void {
     await changed(deps);
     return next;
   });
+  deps.ipcMain.handle('mcp:install', async (_event, serverId: string, config: McpServerConfig) => {
+    if (installs.has(serverId)) throw new Error(`MCP install already in progress: ${serverId}`);
+    let settle!: () => void;
+    const operation = {
+      cancelled: false,
+      settled: new Promise<void>((resolve) => { settle = resolve; }),
+      settle: () => settle(),
+    };
+    installs.set(serverId, operation);
+    try {
+      const next = await deps.store.upsert(serverId, config);
+      if (operation.cancelled) return next;
+      try {
+        await deps.manager.sync(next);
+      } catch (error) {
+        if (!operation.cancelled) throw error;
+      }
+      if (!operation.cancelled) await changed(deps);
+      return next;
+    } finally {
+      if (installs.get(serverId) === operation) installs.delete(serverId);
+      operation.settle();
+    }
+  });
   deps.ipcMain.handle('mcp:remove', async (_event, serverId: string) => {
+    const next = await deps.store.remove(serverId);
+    await deps.manager.sync(next);
+    await changed(deps);
+    return next;
+  });
+  deps.ipcMain.handle('mcp:cancelInstall', async (_event, serverId: string) => {
+    const operation = installs.get(serverId);
+    if (operation) operation.cancelled = true;
+    deps.manager.cancelConnect(serverId);
+    await operation?.settled;
     const next = await deps.store.remove(serverId);
     await deps.manager.sync(next);
     await changed(deps);

--- a/apps/desktop/src/preload/preload.ts
+++ b/apps/desktop/src/preload/preload.ts
@@ -336,8 +336,14 @@ contextBridge.exposeInMainWorld('maka', {
     upsert(serverId: string, config: McpServerConfig): Promise<McpConfigFile> {
       return ipcRenderer.invoke('mcp:upsert', serverId, config);
     },
+    install(serverId: string, config: McpServerConfig): Promise<McpConfigFile> {
+      return ipcRenderer.invoke('mcp:install', serverId, config);
+    },
     remove(serverId: string): Promise<McpConfigFile> {
       return ipcRenderer.invoke('mcp:remove', serverId);
+    },
+    cancelInstall(serverId: string): Promise<McpConfigFile> {
+      return ipcRenderer.invoke('mcp:cancelInstall', serverId);
     },
     test(serverId: string): Promise<McpTestResult> {
       return ipcRenderer.invoke('mcp:test', serverId);

--- a/apps/desktop/src/renderer/maka-tokens.css
+++ b/apps/desktop/src/renderer/maka-tokens.css
@@ -122,6 +122,14 @@
   --brand-deep-hover: oklch(from var(--accent) calc(l - 0.06) c h);
   /* Fixed external channel identity; unlike palette-derived Maka accents. */
   --brand-wechat: #07c160;
+  /* Fixed service identities used only by the MCP market marks. */
+  --brand-dingtalk: #1677ff;
+  --brand-feishu: #3370ff;
+  --brand-slack: #4a154b;
+  --brand-line: #06c755;
+  --brand-google-calendar: #4285f4;
+  --brand-figma: #f24e1e;
+  --brand-supabase: #3ecf8e;
   --bot-brand-default: var(--accent);
   /* PALETTE-LEAK-0: semantic alias for informational system banners (the
      plan-reminders 系统提醒 banner) — component CSS derives its tint family

--- a/apps/desktop/src/renderer/mcp-catalog.ts
+++ b/apps/desktop/src/renderer/mcp-catalog.ts
@@ -1,0 +1,202 @@
+import type { McpServerConfig } from '@maka/core/mcp';
+
+export type McpCatalogEntry = {
+  id: string;
+  name: string;
+  description: string;
+  category: string;
+  mark: string;
+  aliases?: string[];
+  config: McpServerConfig;
+  setupRequired?: boolean;
+  setupLabel?: string;
+  platform?: 'darwin';
+};
+
+export const MCP_CATALOG: McpCatalogEntry[] = [
+  {
+    id: 'dingtalk',
+    name: '钉钉',
+    description: '管理联系人、日历、待办与协作信息。',
+    category: '沟通协作',
+    mark: '钉',
+    aliases: ['DingTalk'],
+    setupRequired: true,
+    setupLabel: '需要 Client ID 与 Client Secret',
+    config: {
+      enabled: false,
+      command: 'npx',
+      args: ['-y', 'dingtalk-mcp@1.1.21'],
+      env: {
+        DINGTALK_Client_ID: '',
+        DINGTALK_Client_Secret: '',
+        ACTIVE_PROFILES: 'dingtalk-contacts,dingtalk-calendar',
+      },
+    },
+  },
+  {
+    id: 'feishu',
+    name: '飞书',
+    description: '访问飞书文档、日历、消息与 OpenAPI。',
+    category: '沟通协作',
+    mark: '飞',
+    aliases: ['Feishu', 'Lark'],
+    setupRequired: true,
+    setupLabel: '需要 App ID 与 App Secret',
+    config: {
+      enabled: false,
+      command: 'npx',
+      args: ['-y', '@larksuiteoapi/lark-mcp@0.5.1', 'mcp'],
+      env: { APP_ID: '', APP_SECRET: '' },
+    },
+  },
+  {
+    id: 'slack',
+    name: 'Slack',
+    description: '发送消息、管理频道并与 Slack workspace 协作。',
+    category: '沟通协作',
+    mark: 'S',
+    setupRequired: true,
+    setupLabel: '需要 Bot Token 与 Team ID',
+    config: {
+      enabled: false,
+      command: 'npx',
+      args: ['-y', '@modelcontextprotocol/server-slack@2025.4.25'],
+      env: { SLACK_BOT_TOKEN: '', SLACK_TEAM_ID: '', SLACK_CHANNEL_IDS: '' },
+    },
+  },
+  {
+    id: 'line',
+    name: 'LINE',
+    description: '通过 LINE Bot Messaging API 发送和管理消息。',
+    category: '沟通协作',
+    mark: 'LINE',
+    setupRequired: true,
+    setupLabel: '需要 Channel Access Token',
+    config: {
+      enabled: false,
+      command: 'npx',
+      args: ['-y', '@line/line-bot-mcp-server@0.5.0'],
+      env: { NPM_CONFIG_IGNORE_SCRIPTS: 'true', CHANNEL_ACCESS_TOKEN: '', DESTINATION_USER_ID: '' },
+    },
+  },
+  {
+    id: 'notion',
+    name: 'Notion',
+    description: '搜索、读取和更新 Notion workspace。',
+    category: '知识与文档',
+    mark: 'N',
+    setupRequired: true,
+    setupLabel: '需要登录授权',
+    config: { enabled: false, url: 'https://mcp.notion.com/mcp', transport: 'streamable-http' },
+  },
+  {
+    id: 'macos-apps',
+    name: 'macOS 应用',
+    description: '连接系统日历与提醒事项，并使用原生权限模型。',
+    category: '系统与效率',
+    mark: '⌘',
+    aliases: ['Apple', 'Calendar', 'Reminders'],
+    platform: 'darwin',
+    config: { enabled: true, command: 'npx', args: ['-y', 'mcp-server-apple-events@1.4.0'] },
+  },
+  {
+    id: 'google-calendar',
+    name: 'Google 日历',
+    description: '管理日程、创建会议并查询空闲时间。',
+    category: '系统与效率',
+    mark: '31',
+    aliases: ['Google Calendar'],
+    setupRequired: true,
+    setupLabel: '需要 OAuth credentials 文件',
+    config: {
+      enabled: false,
+      command: 'npx',
+      args: ['-y', '@cocal/google-calendar-mcp@2.6.2'],
+      env: { GOOGLE_OAUTH_CREDENTIALS: '' },
+    },
+  },
+  {
+    id: 'figma',
+    name: 'Figma',
+    description: '读取设计文件、组件与开发交付信息。',
+    category: '设计与开发',
+    mark: 'F',
+    setupRequired: true,
+    setupLabel: '需要 Personal Access Token',
+    config: {
+      enabled: false,
+      command: 'npx',
+      args: ['-y', 'figma-developer-mcp@0.13.2', '--stdio'],
+      env: { FIGMA_API_KEY: '' },
+    },
+  },
+  {
+    id: 'vercel',
+    name: 'Vercel',
+    description: '检查项目、部署状态、日志与平台文档。',
+    category: '设计与开发',
+    mark: '▲',
+    setupRequired: true,
+    setupLabel: '需要登录授权',
+    config: { enabled: false, url: 'https://mcp.vercel.com', transport: 'streamable-http' },
+  },
+  {
+    id: 'supabase',
+    name: 'Supabase',
+    description: '管理数据库、项目配置、迁移与 Edge Functions。',
+    category: '设计与开发',
+    mark: 'S',
+    setupRequired: true,
+    setupLabel: '需要登录授权',
+    config: { enabled: false, url: 'https://mcp.supabase.com/mcp', transport: 'streamable-http' },
+  },
+  {
+    id: 'filesystem',
+    name: '本地文件',
+    description: '在指定目录中安全地读取、写入和管理文件。',
+    category: '文件与知识',
+    mark: 'FS',
+    setupRequired: true,
+    setupLabel: '需要选择允许访问的目录',
+    config: {
+      enabled: false,
+      command: 'npx',
+      args: ['-y', '@modelcontextprotocol/server-filesystem', '/path/to/folder'],
+    },
+  },
+  {
+    id: 'memory',
+    name: '持久记忆',
+    description: '用结构化知识图谱记住实体、关系和重要事实。',
+    category: '文件与知识',
+    mark: 'M',
+    config: { enabled: true, command: 'npx', args: ['-y', '@modelcontextprotocol/server-memory'] },
+  },
+  {
+    id: 'playwright',
+    name: '浏览器自动化',
+    description: '让 Maka 通过 Playwright 读取和操作真实网页。',
+    category: '设计与开发',
+    mark: 'PW',
+    config: { enabled: true, command: 'npx', args: ['-y', '@playwright/mcp@latest'] },
+  },
+  {
+    id: 'sequential-thinking',
+    name: '序列思考',
+    description: '为复杂问题提供可修正、可验证的结构化推理。',
+    category: '推理与规划',
+    mark: 'ST',
+    config: {
+      enabled: true,
+      command: 'npx',
+      args: ['-y', '@modelcontextprotocol/server-sequential-thinking'],
+    },
+  },
+];
+
+export function catalogEntryMatches(entry: McpCatalogEntry, normalizedQuery: string): boolean {
+  if (!normalizedQuery) return true;
+  return [entry.id, entry.name, entry.description, entry.category, ...(entry.aliases ?? [])]
+    .some((value) => value.toLocaleLowerCase().includes(normalizedQuery));
+}

--- a/apps/desktop/src/renderer/mcp-page.tsx
+++ b/apps/desktop/src/renderer/mcp-page.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import type { McpConfigFile, McpServerConfig, McpServerStatus } from '@maka/core/mcp';
 import { isMcpStdioConfig } from '@maka/core/mcp';
 import {
@@ -17,9 +17,9 @@ import {
   useToast,
 } from '@maka/ui';
 import {
-  Database,
   FileCode,
   Globe,
+  Loader2,
   Pencil,
   Plug,
   Plus,
@@ -27,7 +27,9 @@ import {
   Search,
   Terminal,
   Trash2,
+  X,
 } from '@maka/ui/icons';
+import { MCP_CATALOG, catalogEntryMatches, type McpCatalogEntry } from './mcp-catalog';
 import { parseMcpImport } from './mcp-import';
 import { settingsActionErrorMessage } from './settings/settings-error-copy';
 
@@ -49,67 +51,10 @@ type EditorState =
   | { mode: 'json'; source: string }
   | null;
 
-type CatalogEntry = {
-  id: string;
-  name: string;
-  description: string;
-  category: string;
-  Icon: typeof Plug;
-  draft: Draft;
-};
-
 const EMPTY_CONFIG: McpConfigFile = { version: 1, mcpServers: {} };
+const MIN_INSTALL_INDICATOR_MS = 500;
 
-const MCP_CATALOG: CatalogEntry[] = [
-  {
-    id: 'filesystem',
-    name: '本地文件',
-    description: '在你指定的目录中安全地读取、写入和管理文件。',
-    category: '文件与知识',
-    Icon: FileCode,
-    draft: {
-      id: 'filesystem', kind: 'stdio', enabled: true, command: 'npx',
-      args: '-y\n@modelcontextprotocol/server-filesystem\n/path/to/folder', cwd: '', env: '',
-      url: '', transport: 'auto', headers: '',
-    },
-  },
-  {
-    id: 'memory',
-    name: '持久记忆',
-    description: '用结构化的知识图谱记住实体、关系和重要事实。',
-    category: '文件与知识',
-    Icon: Database,
-    draft: {
-      id: 'memory', kind: 'stdio', enabled: true, command: 'npx',
-      args: '-y\n@modelcontextprotocol/server-memory', cwd: '', env: '',
-      url: '', transport: 'auto', headers: '',
-    },
-  },
-  {
-    id: 'playwright',
-    name: '浏览器自动化',
-    description: '让 Maka 通过 Playwright 读取和操作真实网页。',
-    category: '开发工具',
-    Icon: Globe,
-    draft: {
-      id: 'playwright', kind: 'stdio', enabled: true, command: 'npx',
-      args: '-y\n@playwright/mcp@latest', cwd: '', env: '',
-      url: '', transport: 'auto', headers: '',
-    },
-  },
-  {
-    id: 'sequential-thinking',
-    name: '序列思考',
-    description: '为需要分解、修正和验证的复杂问题提供结构化思考工具。',
-    category: '推理与规划',
-    Icon: Plug,
-    draft: {
-      id: 'sequential-thinking', kind: 'stdio', enabled: true, command: 'npx',
-      args: '-y\n@modelcontextprotocol/server-sequential-thinking', cwd: '', env: '',
-      url: '', transport: 'auto', headers: '',
-    },
-  },
-];
+type InstallPhase = 'installing' | 'cancelling';
 
 export function McpPage() {
   const [config, setConfig] = useState<McpConfigFile>(EMPTY_CONFIG);
@@ -118,6 +63,8 @@ export function McpPage() {
   const [activeTab, setActiveTab] = useState<'market' | 'installed'>('market');
   const [query, setQuery] = useState('');
   const [busy, setBusy] = useState<string | null>('load');
+  const [installPhases, setInstallPhases] = useState<Record<string, InstallPhase>>({});
+  const cancelledInstalls = useRef(new Set<string>());
   const mounted = useMountedRef();
   const toast = useToast();
 
@@ -151,9 +98,7 @@ export function McpPage() {
   );
   const entries = Object.entries(config.mcpServers);
   const normalizedQuery = query.trim().toLocaleLowerCase();
-  const marketEntries = MCP_CATALOG.filter((entry) =>
-    !normalizedQuery || [entry.name, entry.description, entry.category, entry.id]
-      .some((value) => value.toLocaleLowerCase().includes(normalizedQuery)));
+  const marketEntries = MCP_CATALOG.filter((entry) => catalogEntryMatches(entry, normalizedQuery));
   const installedEntries = entries.filter(([serverId, server]) => {
     if (!normalizedQuery) return true;
     const status = statusById.get(serverId);
@@ -167,6 +112,54 @@ export function McpPage() {
 
   function openEdit(serverId: string, server: McpServerConfig) {
     setEditor({ mode: 'manual', draft: draftFromConfig(serverId, server), editingId: serverId });
+  }
+
+  async function installCatalogEntry(entry: McpCatalogEntry) {
+    if (installPhases[entry.id] || config.mcpServers[entry.id]) return;
+    cancelledInstalls.current.delete(entry.id);
+    setInstallPhases((current) => ({ ...current, [entry.id]: 'installing' }));
+    try {
+      const minimumIndicator = delay(MIN_INSTALL_INDICATOR_MS);
+      const next = await window.maka.mcp.install(entry.id, structuredClone(entry.config));
+      await minimumIndicator;
+      if (!mounted.current || cancelledInstalls.current.has(entry.id)) return;
+      setConfig(next);
+      if (entry.setupRequired) {
+        toast.success(`${entry.name} 模板已安装`, '请在「已安装」中完成凭据配置，再启用连接。');
+      } else {
+        toast.success(`${entry.name} 已安装`, '发现的工具会从下一次 agent turn 开始生效。');
+      }
+    } catch (error) {
+      if (mounted.current && !cancelledInstalls.current.has(entry.id)) {
+        toast.error(`安装 ${entry.name} 失败`, settingsActionErrorMessage(error));
+      }
+    } finally {
+      const wasCancelled = cancelledInstalls.current.delete(entry.id);
+      if (mounted.current && !wasCancelled) {
+        setInstallPhases((current) => omitKey(current, entry.id));
+      }
+    }
+  }
+
+  async function cancelCatalogInstall(entry: McpCatalogEntry) {
+    if (installPhases[entry.id] !== 'installing') return;
+    cancelledInstalls.current.add(entry.id);
+    setInstallPhases((current) => ({ ...current, [entry.id]: 'cancelling' }));
+    try {
+      const next = await window.maka.mcp.cancelInstall(entry.id);
+      if (!mounted.current) return;
+      setConfig(next);
+      setStatuses((current) => current.filter((status) => status.serverId !== entry.id));
+      toast.info(`已取消安装 ${entry.name}`);
+    } catch (error) {
+      cancelledInstalls.current.delete(entry.id);
+      if (mounted.current) {
+        toast.error(`取消安装 ${entry.name} 失败`, settingsActionErrorMessage(error));
+        void reload();
+      }
+    } finally {
+      if (mounted.current) setInstallPhases((current) => omitKey(current, entry.id));
+    }
   }
 
   async function saveDraft(event: React.FormEvent) {
@@ -315,7 +308,9 @@ export function McpPage() {
                     key={entry.id}
                     entry={entry}
                     installed={Boolean(config.mcpServers[entry.id])}
-                    onAdd={() => openManual(entry.draft)}
+                    phase={installPhases[entry.id]}
+                    onInstall={() => void installCatalogEntry(entry)}
+                    onCancel={() => void cancelCatalogInstall(entry)}
                     onManage={() => {
                       const installed = config.mcpServers[entry.id];
                       if (installed) openEdit(entry.id, installed);
@@ -365,24 +360,79 @@ export function McpPage() {
   );
 }
 
-function McpCatalogCard(props: { entry: CatalogEntry; installed: boolean; onAdd(): void; onManage(): void }) {
+function McpCatalogCard(props: {
+  entry: McpCatalogEntry;
+  installed: boolean;
+  phase?: InstallPhase;
+  onInstall(): void;
+  onCancel(): void;
+  onManage(): void;
+}) {
+  const installing = props.phase === 'installing';
+  const cancelling = props.phase === 'cancelling';
   return (
     <article className="maka-mcp-market-card">
-      <div className="maka-mcp-market-icon"><props.entry.Icon aria-hidden="true" /></div>
+      <div className="maka-mcp-market-icon" data-brand={props.entry.id} aria-hidden="true">
+        <McpBrandMark entry={props.entry} />
+      </div>
       <div className="maka-mcp-market-copy">
         <strong>{props.entry.name}</strong>
-        <small>{props.entry.category}</small>
         <p>{props.entry.description}</p>
+        <small>
+          {props.entry.category}
+          {props.entry.platform === 'darwin' ? ' · 仅 macOS' : ''}
+          {props.entry.setupLabel ? ` · ${props.entry.setupLabel}` : ''}
+        </small>
       </div>
-      <Button
-        size="sm"
-        variant={props.installed ? 'secondary' : 'quiet'}
-        onClick={props.installed ? props.onManage : props.onAdd}
-      >
-        {props.installed ? '管理' : '添加'}
-      </Button>
+      {props.installed ? (
+        <Button size="sm" variant="secondary" onClick={props.onManage}>管理</Button>
+      ) : (
+        <button
+          type="button"
+          className="maka-mcp-install-button"
+          data-phase={props.phase ?? 'idle'}
+          aria-label={cancelling ? `正在取消安装 ${props.entry.name}` : installing ? `取消安装 ${props.entry.name}` : `安装 ${props.entry.name}`}
+          title={cancelling ? '正在取消…' : installing ? '取消安装' : '安装'}
+          onClick={installing ? props.onCancel : props.onInstall}
+          disabled={cancelling}
+        >
+          {props.phase ? (
+            <>
+              <Loader2 className="maka-mcp-install-spinner animate-spin" aria-hidden="true" />
+              <X className="maka-mcp-install-cancel" aria-hidden="true" />
+            </>
+          ) : <Plus aria-hidden="true" />}
+        </button>
+      )}
     </article>
   );
+}
+
+function McpBrandMark({ entry }: { entry: McpCatalogEntry }) {
+  if (entry.id === 'slack') return (
+    <svg viewBox="0 0 256 256" aria-hidden="true">
+      <path fill="#e01e5a" d="M53.84 161.32c0 14.83-11.99 26.82-26.82 26.82S.2 176.15.2 161.32s11.99-26.82 26.82-26.82h26.82zm13.41 0c0-14.83 11.99-26.82 26.82-26.82s26.82 11.99 26.82 26.82v67.05c0 14.83-11.99 26.82-26.82 26.82s-26.82-11.99-26.82-26.82z" />
+      <path fill="#36c5f0" d="M94.07 53.64c-14.83 0-26.82-11.99-26.82-26.82S79.24 0 94.07 0s26.82 11.99 26.82 26.82v26.82zm0 13.61c14.83 0 26.82 11.99 26.82 26.82s-11.99 26.82-26.82 26.82H26.82C11.99 120.89 0 108.9 0 94.07s11.99-26.82 26.82-26.82z" />
+      <path fill="#2eb67d" d="M201.55 94.07c0-14.83 11.99-26.82 26.82-26.82s26.82 11.99 26.82 26.82s-11.99 26.82-26.82 26.82h-26.82zm-13.41 0c0 14.83-11.99 26.82-26.82 26.82s-26.82-11.99-26.82-26.82V26.82C134.5 11.99 146.49 0 161.32 0s26.82 11.99 26.82 26.82z" />
+      <path fill="#ecb22e" d="M161.32 201.55c14.83 0 26.82 11.99 26.82 26.82s-11.99 26.82-26.82 26.82s-26.82-11.99-26.82-26.82v-26.82zm0-13.41c-14.83 0-26.82-11.99-26.82-26.82s11.99-26.82 26.82-26.82h67.25c14.83 0 26.82 11.99 26.82 26.82s-11.99 26.82-26.82 26.82z" />
+    </svg>
+  );
+  if (entry.id === 'line') return (
+    <svg viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M19.37 9.86a.63.63 0 0 1 0 1.26h-1.76v1.13h1.76a.63.63 0 1 1 0 1.26h-2.39a.63.63 0 0 1-.63-.63V8.11a.63.63 0 0 1 .63-.63h2.39a.63.63 0 0 1 0 1.26h-1.76v1.12zm-3.86 3.02a.63.63 0 0 1-1.14.38l-2.44-3.32v2.94a.63.63 0 0 1-1.26 0V8.11a.63.63 0 0 1 1.12-.38l2.46 3.33V8.11a.63.63 0 0 1 1.26 0zm-5.74 0a.63.63 0 0 1-1.26 0V8.11a.63.63 0 0 1 1.26 0zm-2.47.63H4.92a.63.63 0 0 1-.63-.63V8.11a.63.63 0 0 1 1.26 0v4.14H7.3a.63.63 0 0 1 0 1.26M24 10.31C24 4.94 18.62.57 12 .57S0 4.94 0 10.31c0 4.81 4.27 8.84 10.04 9.61.39.08.92.26 1.06.59.12.3.08.77.04 1.08l-.17 1.02c-.04.3-.24 1.19 1.05.65 1.29-.54 6.92-4.08 9.44-6.98C23.18 14.39 24 12.46 24 10.31" /></svg>
+  );
+  if (entry.id === 'google-calendar') return (
+    <svg viewBox="0 0 256 256" aria-hidden="true">
+      <path fill="#fff" d="M195.37 60.63H60.63v134.74h134.74z" /><path fill="#ea4335" d="M195.37 256 256 195.37l-60.63-5.17z" /><path fill="#188038" d="M0 195.37v40.42A20.21 20.21 0 0 0 20.21 256h40.42l6.23-30.32-6.23-30.31z" /><path fill="#1967d2" d="M256 60.63V20.21A20.21 20.21 0 0 0 235.79 0h-40.42l-5.54 33.2 5.54 27.43z" /><path fill="#fbbc04" d="M256 60.63h-60.63v134.74H256z" /><path fill="#34a853" d="M195.37 195.37H60.63V256h134.74z" /><path fill="#4285f4" d="M195.37 0H20.21A20.21 20.21 0 0 0 0 20.21v175.16h60.63V60.63h134.74z" /><path fill="#4285f4" d="M88.27 165.15c-5.04-3.4-8.52-8.37-10.43-14.94l11.69-4.81c2.77 8.49 7.82 12.71 15.12 12.71 7.67 0 13.48-5.28 13.48-12.36 0-8.32-6.88-12.18-14.72-12.18h-6.75V122h6.06c8.09 0 13.29-4.32 13.29-11.34 0-6.21-4.58-10.31-12.14-10.31-6.77 0-11.18 3.64-12.6 9.5l-11.57-4.81c3.55-10.06 12.38-16.49 24.27-16.49 14.2 0 24.83 8.71 24.83 21 0 8.18-4.12 13.79-10.31 17.04v.69c8.27 3.46 13.07 9.97 13.07 19.12 0 14.01-11.25 24.08-26.88 24.08-5.91.02-11.37-1.68-16.41-5.08m71.8-58-12.84 9.28-6.41-9.73 23.02-16.61h8.83v78.33h-12.6z" />
+    </svg>
+  );
+  if (entry.id === 'figma') return (
+    <svg viewBox="0 0 256 384" aria-hidden="true"><path fill="#0acf83" d="M64 384a64 64 0 0 0 64-64v-64H64a64 64 0 1 0 0 128" /><path fill="#a259ff" d="M0 192a64 64 0 0 1 64-64h64v128H64a64 64 0 0 1-64-64" /><path fill="#f24e1e" d="M0 64A64 64 0 0 1 64 0h64v128H64A64 64 0 0 1 0 64" /><path fill="#ff7262" d="M128 0h64a64 64 0 1 1 0 128h-64z" /><path fill="#1abcfe" d="M256 192a64 64 0 1 1-128 0 64 64 0 0 1 128 0" /></svg>
+  );
+  if (entry.id === 'vercel') return <svg viewBox="0 0 256 222" aria-hidden="true"><path fill="currentColor" d="m128 0 128 221.71H0z" /></svg>;
+  if (entry.id === 'supabase') return (
+    <svg viewBox="0 0 256 263" aria-hidden="true"><path fill="#249361" d="M149.6 258.58c-6.72 8.46-20.34 3.82-20.5-6.98l-2.37-157.98h106.23c19.24 0 29.97 22.22 18.01 37.29z" /><path fill="#3ecf8e" d="M106.4 4.37c6.72-8.46 20.34-3.83 20.5 6.98l1.04 157.98H23.04c-19.24 0-29.97-22.22-18.01-37.29z" /></svg>
+  );
+  return <span>{entry.mark}</span>;
 }
 
 function McpServerRow(props: {
@@ -562,6 +612,15 @@ function endpointFor(server: McpServerConfig): string {
 
 function replaceStatus(statuses: McpServerStatus[], next: McpServerStatus): McpServerStatus[] {
   return [...statuses.filter((status) => status.serverId !== next.serverId), next];
+}
+
+function omitKey<T>(record: Record<string, T>, key: string): Record<string, T> {
+  const { [key]: _removed, ...rest } = record;
+  return rest;
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => window.setTimeout(resolve, ms));
 }
 
 function presentStatus(status: McpServerStatus | undefined, enabled: boolean): { label: string; tone: 'neutral' | 'info' | 'success' | 'warning' | 'destructive' } {

--- a/apps/desktop/src/renderer/styles/module-pages/mcp.css
+++ b/apps/desktop/src/renderer/styles/module-pages/mcp.css
@@ -157,10 +157,10 @@
 
 .maka-mcp-market-card {
   min-width: 0;
-  min-height: 144px;
+  min-height: 112px;
   display: grid;
-  grid-template-columns: 48px minmax(0, 1fr) auto;
-  align-items: start;
+  grid-template-columns: 52px minmax(0, 1fr) auto;
+  align-items: center;
   gap: var(--space-3);
   padding: var(--space-4);
   border: var(--border-width-hairline) solid var(--border);
@@ -175,8 +175,8 @@
 }
 
 .maka-mcp-market-icon {
-  width: 48px;
-  height: 48px;
+  width: 52px;
+  height: 52px;
   display: grid;
   place-items: center;
   border-radius: var(--radius-control);
@@ -184,9 +184,59 @@
   color: var(--foreground-secondary);
 }
 
+.maka-mcp-market-icon span {
+  font-size: var(--font-size-heading);
+  font-weight: var(--font-weight-bold);
+  letter-spacing: var(--tracking-normal);
+}
+
 .maka-mcp-market-icon svg {
-  width: 22px;
-  height: 22px;
+  width: 27px;
+  height: 27px;
+}
+
+.maka-mcp-market-icon[data-brand="figma"] svg {
+  width: 18px;
+  height: 28px;
+}
+
+.maka-mcp-market-icon[data-brand="line"] span {
+  font-size: var(--font-size-caption);
+}
+
+.maka-mcp-market-icon[data-brand="dingtalk"] {
+  background: color-mix(in oklab, var(--brand-dingtalk) 12%, var(--background));
+  color: color-mix(in oklab, var(--brand-dingtalk) 72%, var(--foreground));
+}
+
+.maka-mcp-market-icon[data-brand="feishu"] {
+  background: color-mix(in oklab, var(--brand-feishu) 12%, var(--background));
+  color: color-mix(in oklab, var(--brand-feishu) 72%, var(--foreground));
+}
+
+.maka-mcp-market-icon[data-brand="slack"] {
+  background: color-mix(in oklab, var(--brand-slack) 10%, var(--background));
+  color: color-mix(in oklab, var(--brand-slack) 72%, var(--foreground));
+}
+
+.maka-mcp-market-icon[data-brand="line"] {
+  background: color-mix(in oklab, var(--brand-line) 15%, var(--background));
+  color: color-mix(in oklab, var(--brand-line) 62%, var(--foreground));
+}
+
+.maka-mcp-market-icon[data-brand="google-calendar"] {
+  background: color-mix(in oklab, var(--brand-google-calendar) 12%, var(--background));
+  color: color-mix(in oklab, var(--brand-google-calendar) 72%, var(--foreground));
+}
+
+.maka-mcp-market-icon[data-brand="figma"] {
+  background: color-mix(in oklab, var(--brand-figma) 12%, var(--background));
+  color: color-mix(in oklab, var(--brand-figma) 70%, var(--foreground));
+}
+
+.maka-mcp-market-icon[data-brand="supabase"] {
+  background: color-mix(in oklab, var(--brand-supabase) 14%, var(--background));
+  color: color-mix(in oklab, var(--brand-supabase) 62%, var(--foreground));
 }
 
 .maka-mcp-market-copy {
@@ -209,13 +259,77 @@
 
 .maka-mcp-market-copy p {
   display: -webkit-box;
-  margin: var(--space-1) 0 0;
+  margin: 0;
   overflow: hidden;
   color: var(--foreground-secondary);
   font-size: var(--font-size-ui);
   line-height: var(--leading-normal);
   -webkit-box-orient: vertical;
-  -webkit-line-clamp: 3;
+  -webkit-line-clamp: 2;
+}
+
+.maka-mcp-install-button {
+  position: relative;
+  width: 34px;
+  height: 34px;
+  display: grid;
+  flex: 0 0 auto;
+  place-items: center;
+  padding: 0;
+  border: var(--border-width-hairline) solid transparent;
+  border-radius: var(--radius-pill);
+  background: transparent;
+  color: var(--foreground);
+  transition:
+    background-color var(--duration-quick) var(--ease-out-strong),
+    border-color var(--duration-quick) var(--ease-out-strong),
+    color var(--duration-quick) var(--ease-out-strong);
+}
+
+.maka-mcp-install-button:hover,
+.maka-mcp-install-button:focus-visible {
+  border-color: var(--border);
+  background: var(--state-hover-bg);
+}
+
+.maka-mcp-install-button:focus-visible {
+  outline: var(--focus-ring-width) solid var(--focus-ring);
+  outline-offset: var(--focus-ring-offset);
+}
+
+.maka-mcp-install-button svg {
+  position: absolute;
+  width: 19px;
+  height: 19px;
+}
+
+.maka-mcp-install-cancel {
+  opacity: 0;
+  color: var(--destructive-text);
+  transform: scale(var(--scale-press));
+  transition:
+    opacity var(--duration-quick) var(--ease-out-strong),
+    transform var(--duration-quick) var(--ease-out-strong);
+}
+
+.maka-mcp-install-button[data-phase="installing"]:hover .maka-mcp-install-spinner,
+.maka-mcp-install-button[data-phase="installing"]:focus-visible .maka-mcp-install-spinner {
+  opacity: 0;
+}
+
+.maka-mcp-install-button[data-phase="installing"]:hover .maka-mcp-install-cancel,
+.maka-mcp-install-button[data-phase="installing"]:focus-visible .maka-mcp-install-cancel,
+.maka-mcp-install-button[data-phase="cancelling"] .maka-mcp-install-cancel {
+  opacity: 1;
+  transform: scale(1);
+}
+
+.maka-mcp-install-button[data-phase="cancelling"] .maka-mcp-install-spinner {
+  opacity: 0;
+}
+
+.maka-mcp-install-button:disabled {
+  cursor: wait;
 }
 
 .maka-mcp-server-list {
@@ -537,6 +651,15 @@
 
 @media (prefers-reduced-motion: reduce) {
   .maka-mcp-market-card {
+    transition-duration: 0.01ms;
+  }
+
+  .maka-mcp-install-spinner {
+    animation: none;
+  }
+
+  .maka-mcp-install-button,
+  .maka-mcp-install-cancel {
     transition-duration: 0.01ms;
   }
 }

--- a/docs/architecture/mcp-runtime-architecture-draft.zh-CN.md
+++ b/docs/architecture/mcp-runtime-architecture-draft.zh-CN.md
@@ -13,6 +13,8 @@ V1 支持：
 - text、image、audio、embedded resource、resource link content；MCP `isError` 进入 Maka error path。
 - workspace-scoped `mcp.json`，采用通用的 `mcpServers` 配置结构。
 - 首页侧边栏「扩展 > MCP」模块，提供市场模板、搜索、JSON import、CRUD、test、status/tool list，以及配置变化后的 backend cache invalidation。
+- bundled catalog 对 executable package 固定已核验版本；需要 credential、OAuth 或路径选择的模板默认 `enabled: false`，setup 完成前不启动 server。
+- market install 是可取消 transaction：renderer 展示明确的 installing/cancelling 状态，main process abort 对应 connect、等待未完成的 config write settle，再 rollback config 并 reconcile tool snapshot。
 
 V1 不包含 OAuth browser flow、resources UI、resource subscription 和给 subprocess 使用的 loopback proxy。它们属于 V2；协议层保留 transport 和 content contracts，避免返工。
 
@@ -70,18 +72,23 @@ flowchart LR
 
 Server id 是稳定 identity。配置 reconciliation 使用完整 normalized config fingerprint；新增/删除/修改只影响对应连接。remote headers 在 V1 仍位于 `mcp.json`，文件和目录分别强制 `0600`/`0700`；后续迁移到 Keychain-backed credential store。
 
+Bundled catalog 不是第二份 runtime truth：点击安装只把选中的模板写入同一个 `mcpServers` map。需要 setup 的模板以 disabled snapshot 落盘，用户补齐配置并主动启用后才参与连接；不允许用“已写入配置”冒充“已授权”或“已连接”。
+
 ## 5. 安全与权限
 
 - stdio 默认只继承运行所需 allowlist：`PATH`、`HOME`、`USER`、`SHELL`、`LANG`、`LC_*`、`TMPDIR`、`XDG_*` 和 Windows system variables。配置中的显式 `env` 最后覆盖。
 - 所有 MCP tool 都按 mutation 处理：`categoryHint: network_send`。`readOnlyHint` 是不可信的 server advisory，不能用于降低 permission policy；未来若支持 trusted-server policy，必须由 Maka 侧配置明确授权。
 - MCP tools 不设置 `permissionRequired: false`，明确 deny rule 始终优先。
 - main-process store boundary 对 IPC payload 做 runtime validation，不接受 prototype keys、空 command、非 HTTP(S) URL、非法 headers/env。
+- catalog 中的 executable package 必须 pin 到 reviewed version；stdio credential 优先走显式 env，不进入 process args。V1 的显式 env 仍受 owner-only 文件边界保护，不能等同于 encrypted secret storage。
 - tool 名为 `mcp__{serverId}__{toolName}`；仅允许 provider-safe characters，超过 64 chars 时使用 stable hash suffix，并检测 collision。
 - rich output 对 model text、image count/总 base64 大小和 summary block 数量做 aggregate bounds；audio、resource blob 和 unknown payload 不直接注入 model context。
 
 ## 6. Lifecycle 与错误语义
 
 每个 server 只有一个 active connection promise，避免并发重复 spawn。connect 失败必须关闭半连接 client/transport；disconnect 取消 notification handler 并释放 child process/network stream。manager cache tools；list-changed notification 只刷新对应 server。
+
+install operation 以 server id 串行化。取消时先标记 operation 并 abort active connect，再等待已经开始的 store write 完成；只有随后执行 remove + manager reconcile，才能避免迟到的 upsert 让已取消条目“复活”。renderer 也保留 cancellation marker，防止旧 install promise 覆盖 rollback 后的新 UI state。
 
 timeout 默认值：remote connect 30s、stdio connect 60s、list 15s、call 10min。caller abort 优先于 timeout。协议 `isError` 转为带 server/tool context 的异常；transport/timeout/validation 分别保留可诊断 message，stdio error 附带最多十行经过 redaction/truncation 的 stderr tail。
 
@@ -94,8 +101,9 @@ timeout 默认值：remote connect 30s、stdio connect 60s、list 15s、call 10m
 3. config store 能拒绝非法输入、并发写不损坏、POSIX mode 为 `0600`。
 4. tool name 在 64 chars 内稳定、无 collision；不可信 annotations 无法降低权限，model output aggregate bounds 有测试。
 5. Desktop 首页侧边栏仅在「扩展」分组下提供「技能」和「MCP」；MCP 模块可搜索市场模板、JSON import、添加、编辑、启停、测试和删除 server，状态与 tools 可见。
-6. 更新配置后新 turn 看见新 tools，删除后 tools 消失。
-7. targeted tests、workspace typecheck/build、full tests 和 Electron smoke 均通过。
+6. market `+` 在安装中变为 progress indicator，hover/focus 变为可访问的取消操作；取消后 config 不复活、server 不残留、tools 不可见。
+7. 更新配置后新 turn 看见新 tools，删除后 tools 消失。
+8. targeted tests、workspace typecheck/build、full tests 和 Electron smoke 均通过。
 
 ## 8. V2 backlog
 
@@ -103,3 +111,4 @@ timeout 默认值：remote connect 30s、stdio connect 60s、list 15s、call 10m
 - resources/templates browse、read、subscribe/unsubscribe 及 host UI。
 - authenticated loopback MCP proxy，供受控 subprocess client 共享 pool。
 - per-server health/backoff/automatic crash recovery 与 finer-grained permission policy。
+- signed remote catalog、last-known-good cache、guided setup schema、package provenance 与 update permission diff。

--- a/docs/archive/qoderwork-mcp-reverse-engineering-2026-07-18.md
+++ b/docs/archive/qoderwork-mcp-reverse-engineering-2026-07-18.md
@@ -1,0 +1,293 @@
+# QoderWork MCP 专项逆向与 Maka 演进方案
+
+> 日期：2026-07-18
+> 目标：从本机安装包还原 MCP runtime、market、OAuth、Plugin 与 Agent 接入链路，并映射到 Maka 的可执行路线。
+> 边界：只分析程序代码、公开 catalog、数据库 schema 与非敏感配置结构；没有读取或记录 credential、token、cookie、authorization header 或用户数据行。
+
+## 1. 样本与方法
+
+| 项目 | 值 |
+|---|---|
+| App | `/Applications/QoderWork.app` |
+| Version | `0.9.11` |
+| Bundle ID | `com.qoder.work` |
+| `app.asar` SHA-256 | `0f90145b0efbc18f947b5ec4a8ea00c67486df33315f8456487bd6f491b24292` |
+| Electron | `33.4.5` |
+| 解包样本 | `/tmp/qoderwork-mcp-re-0.9.11.K8JlS0` |
+| 格式化 main bundle | `/tmp/qoderwork-mcp-pretty-0.9.11.yvsnld/main.js` |
+
+方法包括：`asar` 静态解包、bundle formatting、symbol/string 交叉定位、调用链回溯、只读 SQLite schema 检查、公开 market catalog 校验。临时路径只用于复现实验，不是 Maka runtime 依赖。
+
+## 2. 结论摘要
+
+QoderWork 的关键不是“支持三种 transport”，而是把所有来源汇总为一个有生命周期、有权限边界的 MCP control plane：
+
+1. `McpClientPool` 统一管理 builtin、market、custom、Plugin 与 external connector。
+2. 独立 `QoderWorkMcpAdaptor` 把多个 upstream MCP server 汇总成一个本机 authenticated proxy。
+3. Agent runtime 只连接一个稳定的 `qw-builtin` endpoint，不直接感知上游数量和 transport 差异。
+4. market 安装、setup、OAuth、enable 是分离状态；“进入配置”不等于“已经可用”。
+5. tool snapshot 以 chat/subChat 为单位写入，active turn 中的 Plugin reload 延迟到 turn end。
+6. OAuth token 按 user 与 server 隔离，使用 Electron `safeStorage`，logout 会 suspend pool 并断开 upstream。
+7. reconnect、OAuth refresh、HTTP session failure、SSE failure 分流处理，而不是统一粗暴 restart-all。
+
+Maka V1 已具备 transport、tool projection、permission boundary、config reconciliation 与 desktop management；最大差距是 OAuth、authenticated loopback proxy、market setup schema 和 crash recovery。
+
+## 3. Process topology
+
+```mermaid
+flowchart LR
+  UI["Renderer: market / custom / Plugin"] --> SVC["Main: McpService"]
+  SVC --> CFG["Config aggregation"]
+  CFG --> POOL["McpClientPool"]
+  POOL --> A["stdio upstream"]
+  POOL --> B["Streamable HTTP upstream"]
+  POOL --> C["SSE upstream"]
+  POOL --> ADAPTOR["localhost MCP adaptor"]
+  ADAPTOR --> SNAP["per-session tool snapshot"]
+  SNAP --> AGENT["Agent runtime: qw-builtin"]
+```
+
+### 3.1 Pool
+
+Pool entry 持有 normalized config、client、transport、status、connect/reconnect lock、OAuth state 与 tool metadata。所有 source 最终进入相同 pool，因此状态、disconnect、tool refresh 和 error reporting 不需要为 market/Plugin 重复实现。
+
+### 3.2 Adaptor
+
+Adaptor 在 `127.0.0.1` 暴露 MCP HTTP endpoint；macOS/Windows 另提供 Unix Socket/Named Pipe。每次实例使用随机 `x-api-key`。Agent 只看到 adaptor 汇总后的 tool surface。
+
+这层解决了三个问题：
+
+- 多个 upstream 只占 Agent 一个 MCP slot。
+- upstream reload 不要求重启 Agent process。
+- 可以集中做 header filtering、tool snapshot 与 session isolation。
+
+### 3.3 Header boundary
+
+Adaptor 明确拒绝转发：
+
+- `Authorization`
+- `cookie`
+- proxy headers
+- internal headers
+
+上游 credential 只能由对应 connector/OAuth provider 注入，不能借 Agent 请求穿透本机 proxy。
+
+## 4. Config source 与优先级
+
+聚合顺序为：
+
+1. enabled builtin connector
+2. market-installed/custom/enterprise `mcp.json`
+3. enabled Plugin `.mcp.json`
+
+同名 server 不覆盖已有项：要么跳过，要么进入 conflict resolution。Plugin server 使用 namespace `plugin:<folder>:<server>`，并由 `pluginConnectorEnabledList` 控制启用状态。
+
+Plugin enable、disable、install、uninstall 都会触发 `reloadMcpAdaptor()`。如果当前 turn 仍在运行，reload 延迟到 turn end，防止半轮中 tool set 改变。
+
+## 5. Transport 与 lifecycle
+
+支持：
+
+- stdio
+- Streamable HTTP
+- legacy SSE
+
+连接管理包含：
+
+- per-server connect/reconnect lock
+- exponential backoff：1s 到 60s
+- 20% jitter
+- HTTP session failure、SSE close、network error、dynamic token failure、OAuth refresh failure 的独立恢复路径
+- pool/adaptor startup degraded mode：单个 server 失败不阻塞整个桌面启动
+
+这比 stop-all/start-all 更适合桌面 Agent：失败域限制在单 server，已经可用的 tools 不被无关 connector 拖下线。
+
+## 6. Market、custom 与 guided setup
+
+### 6.1 Catalog schema
+
+公开 catalog 使用：
+
+```text
+schemaVersion: 1
+connectors[]
+  id / name / description / icon / category / tags
+  items[]
+    type: mcp | skill
+    required
+    mcpConfig | skillConfig
+```
+
+独立 metadata 文件定义 category、ecosystem 和 sort order。catalog 与 metadata 都有本地 cache、MD5 对比、启动 refresh 和每 10 分钟 refresh。
+
+### 6.2 安装语义
+
+market install 不直接声明连接成功，而是写入 disabled snapshot：
+
+```json
+{
+  "enabled": false,
+  "_builtinId": "...",
+  "_source": "market",
+  "_marketId": "...",
+  "_marketItemId": "..."
+}
+```
+
+connector 如果同时包含 required skill，会同步安装 skill。用户完成 parameters、guided setup 或 OAuth 后才 enable。
+
+### 6.3 `needs-setup`
+
+带 `_setup` 的 config 在 setup 完成前进入 `needs-setup`，Pool 不启动 server。这个状态应与 `disabled`、`connecting`、`needs-auth`、`connected`、`error` 区分，否则 UI 会把“还没配置”错误显示为“连接失败”。
+
+### 6.4 当前公开 market 实例
+
+本次从本地 bundle 还原出的公开 catalog URL 验证到 Notion、Vercel、Supabase 均使用 official remote MCP endpoint：
+
+| Connector | Endpoint | Auth |
+|---|---|---|
+| Notion | `https://mcp.notion.com/mcp` | OAuth |
+| Vercel | `https://mcp.vercel.com` | OAuth + local callback |
+| Supabase | `https://mcp.supabase.com/mcp` | OAuth |
+
+## 7. OAuth 与 user isolation
+
+OAuth flow 覆盖：
+
+1. RFC authorization server metadata discovery
+2. `WWW-Authenticate` 的 `resource_metadata`
+3. Dynamic Client Registration
+4. PKCE S256
+5. random state 与 callback validation
+6. localhost callback 或 app deep link
+7. refresh token single-flight
+8. 401 时 refresh 一次，仍失败再回到 OAuth discovery
+
+Token persistence：
+
+- SQLite table：`mcp_oauth_tokens_by_user`
+- unique key：`(user_id, server_name)`
+- payload：Electron `safeStorage`
+- logout：suspend Pool、取消 pending flow、disconnect upstream
+
+这里最重要的是 user isolation。桌面端不能只以 server name 保存 token，否则账号切换会把上一账号的授权带到新会话。
+
+## 8. Agent adaptor 与 tool snapshot
+
+`buildMcpServersConfig()` 不把每个上游逐个注入 Agent，而是注入单个 `qw-builtin`。每个 chat/subChat 获得对应 adaptor URL，并通过 `setMainSessionMcpToolSnapshot` 维护当前 tools。
+
+优势：
+
+- Agent config 稳定。
+- tool list_changed、Plugin reload、OAuth reconnect 可在 host 内处理。
+- active turn 保持旧 snapshot，下一 turn 使用新 snapshot。
+
+Maka V1 目前通过 backend cache invalidation 达到相似的“下一 turn 生效”语义，但还没有可供 subprocess 共用的 loopback proxy。
+
+## 9. MCP Apps
+
+客户端声明 `io.modelcontextprotocol/ui` capability，识别 `text/html;profile=mcp-app` resource。host 通过 `resources/read` 加载 App，使用 AppBridge 处理 server tool call 与 model context update。
+
+这说明 MCP 不只是一组 tools；后续若 Maka 支持 MCP Apps，必须同时设计：
+
+- iframe/webview trust boundary
+- resource CSP 与 navigation policy
+- server tool call permission
+- App → model context 的 size/type validation
+
+## 10. WorkBuddy 安装 UX 的实现证据
+
+本机 WorkBuddy 5.2.6 的 connector card 使用四态交互：
+
+```text
+idle (+)
+  -> connecting (spinner, disabled)
+  -> cancellable connecting (spinner; hover/focus 显示 red ×)
+  -> connected / disconnected / error
+```
+
+它在进入 `connecting` 后设置 2 秒防误触窗口，随后 `useCancellableConnecting()` 才将 connector 加入可取消集合。点击取消不是纯视觉 reset：
+
+- abort pending server-side OAuth
+- 清理 fresh-auth marker 与 user-initiated marker
+- optimistic status → `disconnected`
+- 调用 adapter `cancelConnector(configId)`
+
+Maka 本次实现保留了该模式的核心：spinner hover/focus 变 `×`、可访问名称随状态变化、点击后 abort connect、序列化等待 config write 完成、remove config、reconcile manager、刷新 tool snapshot。Maka 使用较短的可感知窗口，因为 V1 market 中大量条目只是写入 disabled setup template，并没有长时间 OAuth flow。
+
+## 11. Capability matrix
+
+| 能力 | QoderWork 0.9.11 | Maka 当前 | 结论 |
+|---|---|---|---|
+| stdio | 完整 | 完整 | 已对齐 |
+| Streamable HTTP | 完整 | 完整 | 已对齐 |
+| SSE fallback | 完整 | 完整 | 已对齐 |
+| tools/list pagination | 完整 | 完整 | 已对齐 |
+| list_changed | 完整 | 完整 | 已对齐 |
+| rich tool result | 完整 | 完整且有 aggregate bounds | Maka 更严格 |
+| permission/event boundary | host adaptor | 统一 `MakaTool` runtime | 已对齐 |
+| market templates | remote catalog + cache | bundled catalog | V2 动态化 |
+| guided setup | `_setup` + `needs-setup` | disabled template + manual editor | 待补 |
+| OAuth 2.1/PKCE/DCR | 完整 | 未实现 | P0 |
+| encrypted token/user isolation | `safeStorage` + per-user DB | headers/env in owner-only file | P0 |
+| reconnect/backoff | 分流 + jitter | manual reconnect/基本 close | P1 |
+| loopback aggregate proxy | 有 | 无 | P1 |
+| resources/templates | 有 | protocol contract 未做 UI | P1 |
+| MCP Apps | 有 | 无 | P2 |
+| Plugin `.mcp.json` | 有 | 无统一 Plugin source | P2 |
+
+## 12. Maka roadmap
+
+### P0：授权与 setup 真值
+
+- OAuth metadata discovery、PKCE、state validation、local callback/deep link。
+- Keychain/`safeStorage` token store，以 workspace user + server id 隔离。
+- market item schema 增加 `parameters`、`setup`、`authType`、platform/version constraints。
+- 状态机显式增加 `needs-setup`、`needs-auth`，禁止把未配置模板当作 runtime error。
+- credential 从 process args/header JSON 迁出；stdio secret 通过受控 env 注入。
+
+### P1：稳定 control plane
+
+- per-server backoff、jitter、crash budget、manual retry reset。
+- authenticated loopback aggregate proxy，header denylist 与 random API key。
+- resources/templates browse/read/subscribe。
+- remote catalog 签名或 digest 校验、atomic cache、last-known-good fallback。
+- install operation idempotency、cancel/retry audit event。
+
+### P2：生态与 UI surface
+
+- MCP Apps sandbox 与 AppBridge。
+- Plugin/Skill bundled connector manifest。
+- enterprise catalog/policy overlay 与 conflict resolution。
+- per-tool enable policy、trusted-server read-only policy。
+- market update/version/source provenance 与 permission diff review。
+
+## 13. Maka 本次市场实现说明
+
+本次新增钉钉、飞书、Slack、LINE、Notion、macOS 应用、Google Calendar、Figma、Vercel、Supabase。
+
+来源差异必须透明：WorkBuddy 当前的钉钉/飞书是其私有 CLI connector，不是可直接复用的通用 MCP server；Maka 因此采用公开 npm MCP package。Notion/Vercel/Supabase 使用公开 official remote endpoint。需要 credential/OAuth/setup 的条目安装为 `enabled: false`，用户完成配置后再启用，避免空 credential 启动和虚假“安装成功”。
+
+Bundled catalog 对新增 npm server 固定已核验版本，避免 `latest` 静默漂移。飞书 0.5.1 已核验支持 `APP_ID`/`APP_SECRET` env，因此 credential 不写入 process args；LINE 按 package 建议默认设置 `NPM_CONFIG_IGNORE_SCRIPTS=true`。
+
+Figma credential 使用 `FIGMA_API_KEY` env，不放在 process args。V1 仍会把显式 env 写入 owner-only `mcp.json`；在 P0 encrypted credential store 完成前，UI 必须继续提示该限制。
+
+## 14. Evidence index
+
+格式化 `main.js` 行号以本次样本为准：
+
+| 范围 | 证据 |
+|---|---|
+| 30269–30540 | config 与 OAuth storage |
+| 32590–33540 | OAuth discovery/PKCE/callback/refresh |
+| 34980–37230 | `McpClientPool` lifecycle/reconnect |
+| 79860–80720 | main-session tool snapshot |
+| 101420–102480 | authenticated adaptor 与 header boundary |
+| 102772+ | Plugin `.mcp.json` aggregation |
+| 116300–117240 | market schema/cache/refresh |
+| 118873–119764 | `McpService` |
+| 138927–139170 | pool/adaptor lifecycle |
+| 145899–146000 | runtime adaptor injection |
+| 192767–192820 | startup degraded mode |
+
+WorkBuddy 证据来自本机 5.2.6 `renderer/assets/connector-*.js` formatting 后的 `use-cancellable-connecting.ts`、`renderAvailableCard`、`cancelMcpConnector` 与主进程 connector protocol。报告只记录状态机和调用语义，不复制其产品代码或资产。

--- a/packages/mcp/src/__fixtures__/stdio-server.ts
+++ b/packages/mcp/src/__fixtures__/stdio-server.ts
@@ -13,6 +13,9 @@ if (process.argv.includes('--crash-secret-tail')) {
   process.stderr.write('token=sk-live-secret-token-value');
   process.exit(24);
 }
+if (process.argv.includes('--slow-start')) {
+  await new Promise((resolve) => setTimeout(resolve, 30_000));
+}
 
 const server = new Server(
   { name: 'maka-mcp-fixture', version: '1.0.0' },

--- a/packages/mcp/src/__tests__/manager.test.ts
+++ b/packages/mcp/src/__tests__/manager.test.ts
@@ -109,6 +109,17 @@ describe('McpClientManager stdio E2E', () => {
     assert.deepEqual(status?.stderrTail, ['fixture startup failed: deliberate diagnostic']);
   });
 
+  test('cancels an in-flight installation connect without leaving tools visible', async () => {
+    const manager = createManager();
+    const sync = manager.sync(fixtureConfig(['--slow-start']));
+    await waitFor(() => manager.status('fixture')?.state === 'connecting');
+    assert.equal(manager.cancelConnect('fixture'), true);
+    await sync;
+    await manager.sync({ version: 1, mcpServers: {} });
+    assert.equal(manager.status('fixture'), undefined);
+    assert.deepEqual(manager.tools(), []);
+  });
+
   test('captures and redacts a final stderr fragment without a newline', async () => {
     const manager = createManager();
     await manager.sync(fixtureConfig(['--crash-secret-tail']));
@@ -168,6 +179,14 @@ function remoteConfig(url: string, transport: 'auto' | 'streamable-http' = 'stre
       remote: { url, transport, headers: { Authorization: 'Bearer remote-test' } },
     },
   };
+}
+
+async function waitFor(predicate: () => boolean, timeoutMs = 1_000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (!predicate()) {
+    if (Date.now() >= deadline) throw new Error('condition was not reached');
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
 }
 
 interface RemoteRequest {

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -45,6 +45,7 @@ interface Connection {
   transport?: Transport;
   stdioTransport?: StdioClientTransport;
   connectPromise?: Promise<McpServerStatus>;
+  connectController?: AbortController;
   status: McpServerStatus;
   closing: boolean;
 }
@@ -132,8 +133,20 @@ export class McpClientManager {
     if (entry.config.enabled === false) return cloneStatus(entry.status);
     if (entry.status.state === 'connected') return cloneStatus(entry.status);
     if (entry.connectPromise) return entry.connectPromise;
-    entry.connectPromise = this.connectEntry(serverId, entry).finally(() => { entry.connectPromise = undefined; });
+    const controller = new AbortController();
+    entry.connectController = controller;
+    entry.connectPromise = this.connectEntry(serverId, entry, controller.signal).finally(() => {
+      entry.connectPromise = undefined;
+      if (entry.connectController === controller) entry.connectController = undefined;
+    });
     return entry.connectPromise;
+  }
+
+  cancelConnect(serverId: string): boolean {
+    const controller = this.connections.get(serverId)?.connectController;
+    if (!controller || controller.signal.aborted) return false;
+    controller.abort(new Error(`MCP installation cancelled: ${serverId}`));
+    return true;
   }
 
   async reconnect(serverId: string): Promise<McpServerStatus> {
@@ -145,6 +158,7 @@ export class McpClientManager {
     const entry = this.connections.get(serverId);
     if (!entry) return;
     entry.closing = true;
+    entry.connectController?.abort(new Error(`MCP connection closed: ${serverId}`));
     await entry.connectPromise?.catch(() => {});
     await safeClose(entry.client, entry.transport);
     entry.client = undefined;
@@ -228,11 +242,11 @@ export class McpClientManager {
     }
   }
 
-  private async connectEntry(serverId: string, entry: Connection): Promise<McpServerStatus> {
+  private async connectEntry(serverId: string, entry: Connection, signal: AbortSignal): Promise<McpServerStatus> {
     entry.closing = false;
     this.update(entry, { ...entry.status, state: 'connecting', error: undefined, updatedAt: this.now() });
     try {
-      const connected = await this.openClient(serverId, entry);
+      const connected = await this.openClient(serverId, entry, signal);
       entry.client = connected.client;
       entry.transport = connected.transport;
       entry.stdioTransport = connected.stdioTransport;
@@ -266,12 +280,12 @@ export class McpClientManager {
       entry.client = undefined;
       entry.transport = undefined;
       entry.stdioTransport = undefined;
-      this.markError(entry, error);
+      if (!signal.aborted) this.markError(entry, error);
       throw error;
     }
   }
 
-  private async openClient(serverId: string, entry: Connection): Promise<{
+  private async openClient(serverId: string, entry: Connection, signal: AbortSignal): Promise<{
     client: Client; transport: Transport; stdioTransport?: StdioClientTransport;
     kind: 'stdio' | 'streamable-http' | 'sse';
   }> {
@@ -289,7 +303,7 @@ export class McpClientManager {
       const client = this.createClient();
       client.onclose = () => this.handleTransportClose(entry);
       try {
-        await client.connect(transport, { timeout: this.timeouts.stdioConnectMs });
+        await client.connect(transport, { timeout: this.timeouts.stdioConnectMs, signal });
         return { client, transport, stdioTransport: transport, kind: 'stdio' };
       } catch (error) {
         await safeClose(client, transport);
@@ -305,7 +319,7 @@ export class McpClientManager {
       });
       client.onclose = () => this.handleTransportClose(entry);
       try {
-        await client.connect(transport, { timeout: this.timeouts.remoteConnectMs });
+        await client.connect(transport, { timeout: this.timeouts.remoteConnectMs, signal });
         return { client, transport, kind: 'streamable-http' };
       } catch (error) {
         await safeClose(client, transport);
@@ -318,7 +332,7 @@ export class McpClientManager {
     });
     client.onclose = () => this.handleTransportClose(entry);
     try {
-      await client.connect(transport, { timeout: this.timeouts.remoteConnectMs });
+      await client.connect(transport, { timeout: this.timeouts.remoteConnectMs, signal });
       return { client, transport, kind: 'sse' };
     } catch (error) {
       await safeClose(client, transport);


### PR DESCRIPTION
## Summary
- add a bundled MCP market for DingTalk, Feishu, Slack, LINE, Notion, macOS apps, Google Calendar, Figma, Vercel, and Supabase with pinned package versions and setup-safe disabled templates
- implement cancellable market installation across renderer, IPC, and McpClientManager, including config-write race rollback and stale-promise protection
- add WorkBuddy-style plus → spinner → hover/focus cancel UX, brand-aware two-column cards, dark/narrow coverage, and preserve sidebar session history
- include the generic MCP runtime architecture update and a QoderWork MCP reverse-engineering report

## Validation
- npm --workspace @maka/mcp test (11/11)
- npm --workspace @maka/desktop test (2697/2697)
- npm --workspace @maka/desktop run build
- npm --workspace @maka/desktop run typecheck
- Electron Playwright MCP E2E (1/1): market install/spinner/hover cancel/rollback, stdio discovery, disable, delete, JSON import
- git diff --check

## Current boundary
Remote entries that require OAuth are installed disabled until Maka ships the OAuth browser flow and encrypted credential store described in the V2 backlog.