### PR TITLE
fix(cli): use fixed summaries for generic tool results

### DIFF
--- a/packages/cli/src/__tests__/pi-transcript.test.ts
+++ b/packages/cli/src/__tests__/pi-transcript.test.ts
@@ -1602,7 +1602,10 @@ describe('Maka Pi TUI transcript', () => {
     assert.equal(poll?.status, 'error');
     const rendered = renderMakaPiTranscript(state, meta(), 100).map(stripAnsi).join('\n');
     assert.match(rendered, /● Read/);
-    assert.match(rendered, /background task no longer exists/);
+    // The error disc carries the failure state; free-text error content stays
+    // out of the compact row under #1086.
+    assert.match(rendered, /\(1 line · 32 bytes\)/);
+    assert.doesNotMatch(rendered, /background task no longer exists/);
   });
 
   test('never renders a StopBackgroundTask card while the stop is in flight', () => {
@@ -2212,7 +2215,7 @@ describe('Maka Pi TUI transcript', () => {
     assert.ok(visibleWidth(row) <= 60, `row width ${visibleWidth(row)} exceeds 60`);
   });
 
-  test('drops an unprotected generic annotation before truncating the target', () => {
+  test('reserves the fixed-shape generic annotation when the row overflows', () => {
     const state = createMakaPiTranscriptState();
     applyMakaSessionEventToTranscript(state, event({
       type: 'tool_start', toolUseId: 'frob-1', toolName: 'Frobnicate',
@@ -2225,10 +2228,10 @@ describe('Maka Pi TUI transcript', () => {
 
     const lines = renderMakaPiTranscript(state, meta(), 40).map(stripAnsi);
     const row = lines[1]!;
-    // The generic first-line annotation is free text: it yields to the target
-    // instead of being reserved like a fixed-shape outcome.
+    // The result content is no longer used as an annotation. Its fixed-shape
+    // summary remains available while the long input target is truncated.
     assert.match(row, /alpha/);
-    assert.doesNotMatch(row, /gamma/);
+    assert.match(row, /\(1 line · \d+ bytes\)$/);
     assert.ok(visibleWidth(row) <= 40, `row width ${visibleWidth(row)} exceeds 40`);
   });
 
@@ -2656,13 +2659,12 @@ describe('Maka Pi TUI transcript', () => {
     }));
 
     const compact = renderMakaPiTranscript(state, meta(), 120).map(stripAnsi).join('\n');
-    // A 3-line error object must not be reported as "3 matches"; fall back to
-    // the generic quiet-value summary instead (#1065: no raw JSON braces).
-    // The multi-line error value renders as `error:` headline + indented body;
-    // the compact card shows only the first line (the key name).
+    // A 3-line error object must not be reported as "3 matches". It uses the
+    // generic fixed-shape summary instead, without raw JSON or result content.
     assert.doesNotMatch(compact, /\d+ matches/);
-    assert.match(compact, /error:/);
+    assert.match(compact, /\(4 lines · 35 bytes\)/);
     assert.doesNotMatch(compact, /"error":"boom/);
+    assert.doesNotMatch(compact, /error:/);
   });
 
   test('does not fabricate a Grep match count when matches is not an array', () => {
@@ -2717,14 +2719,136 @@ describe('Maka Pi TUI transcript', () => {
     // Never more than one card line (plus the leading blank separator):
     // multi-line JSON must not split the header.
     assert.equal(lines.length, 2);
-    // #1065: the generic fallback now uses formatToolInvocationLine /
-    // formatQuietJsonValue instead of dumping raw JSON. A tool with no
-    // custom case extracts headline key:value lines, never JSON braces.
-    // The multi-line key:value input is collapsed to a single line by
-    // collapseToSingleLine so the compact card stays one line.
-    assert.match(lines[1] ?? '', /● Frobnicate  alpha: 1 beta: two \(gamma: 3\)/);
+    // #1086: generic results use a fixed-shape size summary instead of
+    // leaking the first result line into the compact row.
+    assert.match(lines[1] ?? '', /● Frobnicate  alpha: 1 beta: two \(\d+ lines · \d+ bytes\)/);
     assert.doesNotMatch(lines[1] ?? '', /\{"alpha"/);
     assert.doesNotMatch(lines[1] ?? '', /\{"gamma"/);
+    assert.doesNotMatch(lines[1] ?? '', /gamma:/);
+  });
+
+  test('summarizes free-text MCP results with UTF-8 line and byte counts', () => {
+    const state = createMakaPiTranscriptState();
+    const text = '你好\n世界\n';
+
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_start', toolUseId: 'mcp-1', toolName: 'mcp__github__search', args: { query: 'Maka' },
+    }));
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_result', toolUseId: 'mcp-1', isError: false,
+      content: { kind: 'text', text },
+    }));
+
+    const compact = renderMakaPiTranscript(state, meta(), 120).map(stripAnsi).join('\n');
+    assert.match(compact, /\(2 lines · 14 bytes\)/);
+    assert.doesNotMatch(compact, /你好|世界/);
+
+    assert.equal(toggleAllToolExpansion(state), true);
+    const expanded = renderMakaPiTranscript(state, meta(), 120).map(stripAnsi).join('\n');
+    assert.match(expanded, /你好/);
+    assert.match(expanded, /世界/);
+  });
+
+  test('uses no output for empty and whitespace-only generic results', () => {
+    for (const [toolUseId, text] of [['empty', ''], ['blank', ' \n\t ']] as const) {
+      const state = createMakaPiTranscriptState();
+      applyMakaSessionEventToTranscript(state, event({
+        type: 'tool_start', toolUseId, toolName: 'mcp__local__empty', args: {},
+      }));
+      applyMakaSessionEventToTranscript(state, event({
+        type: 'tool_result', toolUseId, isError: false,
+        content: { kind: 'text', text },
+      }));
+
+      const compact = renderMakaPiTranscript(state, meta(), 120).map(stripAnsi).join('\n');
+      assert.match(compact, /\(no output\)/);
+      assert.doesNotMatch(compact, /lines · \d+ bytes/);
+    }
+  });
+
+  test('keeps subagent summaries out of compact rows', () => {
+    const state = createMakaPiTranscriptState();
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_start', toolUseId: 'agent-summary', toolName: 'agent_spawn',
+      args: { profile: 'local_read', task: 'Inspect the repository.' },
+    }));
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_result', toolUseId: 'agent-summary', isError: false,
+      content: subagentResult({ summary: 'first result line\nsecond result line' }),
+    }));
+
+    const compact = renderMakaPiTranscript(state, meta(), 120).map(stripAnsi).join('\n');
+    assert.match(compact, /\(2 lines · \d+ bytes\)/);
+    assert.doesNotMatch(compact, /first result line|second result line/);
+  });
+
+  test('shows archived Read status instead of archived placeholder text', () => {
+    const state = createMakaPiTranscriptState();
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_start', toolUseId: 'read-archived', toolName: 'Read', args: { path: 'README.md' },
+    }));
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_result', toolUseId: 'read-archived', isError: false,
+      content: { kind: 'archived_tool_result', status: 'not_loaded' },
+    }));
+
+    const compact = renderMakaPiTranscript(state, meta(), 120).map(stripAnsi).join('\n');
+    assert.match(compact, /\(archived: not_loaded\)/);
+    assert.doesNotMatch(compact, /Archived tool result:/);
+  });
+
+  test('keeps generic compact summaries bounded for malformed and oversized results', () => {
+    const cases = [
+      { toolUseId: 'malformed', content: { kind: 'text', text: undefined } as unknown as ToolResultContent },
+      { toolUseId: 'oversized', content: { kind: 'text', text: 'x'.repeat(20_000) } satisfies ToolResultContent },
+    ];
+
+    for (const testCase of cases) {
+      const state = createMakaPiTranscriptState();
+      applyMakaSessionEventToTranscript(state, event({
+        type: 'tool_start', toolUseId: testCase.toolUseId, toolName: 'mcp__local__result', args: {},
+      }));
+      applyMakaSessionEventToTranscript(state, event({
+        type: 'tool_result', toolUseId: testCase.toolUseId, isError: false, content: testCase.content,
+      }));
+
+      const row = renderMakaPiTranscript(state, meta(), 80).map(stripAnsi)[1] ?? '';
+      assert.ok(visibleWidth(row) <= 80, `row width ${visibleWidth(row)} exceeds 80`);
+      if (testCase.toolUseId === 'malformed') assert.match(row, /\(no output\)/);
+      else {
+        assert.match(row, /\(1 line · 20000 bytes\)/);
+        assert.doesNotMatch(row, /x{20}/);
+      }
+    }
+  });
+
+  test('renders the same generic result summary for live and stored transcript paths', () => {
+    const live = createMakaPiTranscriptState();
+    const stored = createMakaPiTranscriptState();
+    const text = 'live and replay\nuse the same shape\n';
+
+    applyMakaSessionEventToTranscript(live, event({
+      type: 'tool_start', toolUseId: 'mcp-replay', toolName: 'mcp__github__search', args: { query: 'replay' },
+    }));
+    applyMakaSessionEventToTranscript(live, event({
+      type: 'tool_result', toolUseId: 'mcp-replay', isError: false,
+      content: { kind: 'text', text },
+    }));
+    replaceTranscriptWithStoredMessages(stored, [
+      {
+        type: 'tool_call', id: 'mcp-replay', turnId: 'turn-1', ts: 1,
+        toolName: 'mcp__github__search', args: { query: 'replay' },
+      },
+      {
+        type: 'tool_result', id: 'mcp-result', turnId: 'turn-1', ts: 2,
+        toolUseId: 'mcp-replay', isError: false, content: { kind: 'text', text },
+      },
+    ] satisfies StoredMessage[]);
+
+    assert.deepEqual(
+      renderMakaPiTranscript(live, meta(), 120).map(stripAnsi),
+      renderMakaPiTranscript(stored, meta(), 120).map(stripAnsi),
+    );
   });
 
   test('summarizes file_diff compactly and colors the expanded diff', () => {

--- a/packages/cli/src/__tests__/pi-transcript.test.ts
+++ b/packages/cli/src/__tests__/pi-transcript.test.ts
@@ -2195,7 +2195,7 @@ describe('Maka Pi TUI transcript', () => {
     assert.ok(visibleWidth(row) <= 60, `row width ${visibleWidth(row)} exceeds 60`);
   });
 
-  test('reserves an annotation exactly at the 30-column cap when a row overflows', () => {
+  test('reserves a fixed-shape annotation when it fits alongside the row head', () => {
     const state = createMakaPiTranscriptState();
     applyMakaSessionEventToTranscript(state, event({
       type: 'tool_start', toolUseId: 'bash-cap', toolName: 'Bash',
@@ -2208,11 +2208,27 @@ describe('Maka Pi TUI transcript', () => {
 
     const lines = renderMakaPiTranscript(state, meta(), 60).map(stripAnsi);
     const row = lines[1]!;
-    // `(1234s · timed_out · exit 124)` is exactly 30 columns. The cap is
-    // measured on the annotation alone (the joining space is budgeted
-    // separately), so an at-cap annotation is still reserved whole.
+    // The complete fixed-shape annotation is reserved before the long command
+    // target, so the timeout and exit code remain readable.
     assert.match(row, /\(1234s · timed_out · exit 124\)$/);
     assert.ok(visibleWidth(row) <= 60, `row width ${visibleWidth(row)} exceeds 60`);
+  });
+
+  test('keeps a duration-bearing generic outcome readable when it exceeds the old cap', () => {
+    const state = createMakaPiTranscriptState();
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_start', toolUseId: 'generic-duration', toolName: 'McpTool',
+      args: { target: 'x'.repeat(80) },
+    }));
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_result', toolUseId: 'generic-duration', isError: false,
+      content: { kind: 'text', text: 'line\n'.repeat(100) }, durationMs: 12_000,
+    }));
+
+    const row = renderMakaPiTranscript(state, meta(), 80).map(stripAnsi)[1]!;
+    assert.match(row, /\(12s · 100 lines · 500 bytes\)$/);
+    assert.doesNotMatch(row, /\(1…\)$/);
+    assert.ok(visibleWidth(row) <= 80, `row width ${visibleWidth(row)} exceeds 80`);
   });
 
   test('reserves the fixed-shape generic annotation when the row overflows', () => {
@@ -2800,6 +2816,7 @@ describe('Maka Pi TUI transcript', () => {
   test('keeps generic compact summaries bounded for malformed and oversized results', () => {
     const cases = [
       { toolUseId: 'malformed', content: { kind: 'text', text: undefined } as unknown as ToolResultContent },
+      { toolUseId: 'malformed-truthy', content: { kind: 'text', text: 42 } as unknown as ToolResultContent },
       { toolUseId: 'oversized', content: { kind: 'text', text: 'x'.repeat(20_000) } satisfies ToolResultContent },
     ];
 
@@ -2814,8 +2831,13 @@ describe('Maka Pi TUI transcript', () => {
 
       const row = renderMakaPiTranscript(state, meta(), 80).map(stripAnsi)[1] ?? '';
       assert.ok(visibleWidth(row) <= 80, `row width ${visibleWidth(row)} exceeds 80`);
-      if (testCase.toolUseId === 'malformed') assert.match(row, /\(no output\)/);
-      else {
+      if (testCase.toolUseId.startsWith('malformed')) {
+        assert.match(row, /\(no output\)/);
+        if (testCase.toolUseId === 'malformed-truthy') {
+          assert.equal(toggleAllToolExpansion(state), true);
+          assert.doesNotMatch(renderMakaPiTranscript(state, meta(), 80).map(stripAnsi).join('\n'), /42/);
+        }
+      } else {
         assert.match(row, /\(1 line · 20000 bytes\)/);
         assert.doesNotMatch(row, /x{20}/);
       }

--- a/packages/cli/src/pi-transcript-tools.ts
+++ b/packages/cli/src/pi-transcript-tools.ts
@@ -59,9 +59,10 @@ function toolDurationText(entry: MakaPiToolEntry): string {
  * detached); the parenthesized annotation carries the outcome in short fixed
  * shapes: counts (`5 matches`, `3 lines`), sizes (`42 bytes`), a diff tally
  * (`+1 -3`), durations (`5s`, sharing the parens as `5s · 3 lines`), red exit
- * codes, or the dim `no output` placeholder. Output content never appears on
- * the row — it lives in the expanded card, and the annotation's shapes
- * already say whether there is anything to expand, so the row needs neither
+ * codes, the dim `no output` placeholder, or a free-text `N lines · M bytes`
+ * summary. Output content never appears on the row — it lives in the expanded
+ * card, and the annotation's shapes already say whether there is anything to
+ * expand, so the row needs neither
  * a separator glyph nor an expand marker. Short annotations are reserved
  * whole during truncation: a long command can never hide an `exit 1`.
  */
@@ -100,10 +101,9 @@ const COMPACT_ANNOTATION_RESERVE = 30;
 
 /**
  * Lay out `head  target (annotation)` on one line. The head and a short
- * protected annotation are preserved whole; the free-text target truncates
- * first, so a long command can never hide an exit code. An unprotected
- * annotation (a generic first result line) is never reserved — it takes
- * whatever the target leaves.
+ * protected annotation are preserved whole; the input target truncates first,
+ * so a long command can never hide an exit code. An annotation longer than
+ * the reserve cap takes whatever room the target leaves.
  */
 function assembleCompactToolRow(head: string, input: string, annotation: string, width: number, protect: boolean): string {
   const inputSeg = input ? `  ${input}` : '';
@@ -168,16 +168,24 @@ interface CompactToolSummary {
   /** Placeholder shown only when the annotation would otherwise be empty (`no output`). */
   placeholder?: boolean;
   /**
-   * Fixed-shape outcome (a count, size, diff tally, or exit status) eligible
-   * for whole-annotation reservation when the row overflows. Free text — the
-   * generic first-line fallback or a WriteStdin operation echo — is never
-   * reserved, so it cannot push the command off the row.
+   * Fixed-shape outcome (a count, size, diff tally, exit status, or free-text
+   * line/byte count) eligible for whole-annotation reservation when the row
+   * overflows. A WriteStdin operation echo remains unprotected because it is
+   * an action preview rather than an outcome.
    */
   protect?: boolean;
 }
 
 function noOutput(): CompactToolSummary {
   return { text: ansi.dim('no output'), placeholder: true, protect: true };
+}
+
+function textResultSummary(text: string): CompactToolSummary {
+  if (!text.trim()) return noOutput();
+  return {
+    text: `${linesText(readBodyLineCount(text))} · ${byteLength(text)} bytes`,
+    protect: true,
+  };
 }
 
 function linesText(count: number): string {
@@ -240,21 +248,23 @@ function compactToolSummary(entry: MakaPiToolEntry): CompactToolSummary | undefi
     if (count !== undefined) return { text: `${count} file${count === 1 ? '' : 's'}`, protect: true };
   }
 
+  if (result?.kind === 'archived_tool_result') {
+    return { text: `archived: ${result.status}`, protect: true };
+  }
+
   const text = plainResultText(entry);
-  if (!text) return undefined;
+  if (!text) return result ? noOutput() : undefined;
   // Only a successful filesystem Read that carries real file content gets the
   // line summary — the same guard the expanded card uses. A runtime
-  // resource, errored, or archived Read falls through to the generic first-line
-  // summary so its status shows instead of a fabricated count.
+  // resource or errored Read uses the generic fixed-shape summary instead of a
+  // fabricated file count.
   if (entry.toolName === 'Read'
     && entry.status !== 'error'
     && isFilesystemReadPath(entry)
     && isReadBodyResult(result)) {
     return { text: linesText(readBodyLineCount(text)), protect: true };
   }
-  // The generic first-line fallback is free text, never reserved: the command
-  // a user ran says more than one truncated line of what came back.
-  return { text: text.split('\n', 1)[0] ?? '' };
+  return textResultSummary(text);
 }
 
 function compactTerminalSummary(

--- a/packages/cli/src/pi-transcript-tools.ts
+++ b/packages/cli/src/pi-transcript-tools.ts
@@ -96,23 +96,18 @@ function compactAnnotation(entry: MakaPiToolEntry): { text: string; protect: boo
   return { text: parts.length > 0 ? `(${parts.join(' · ')})` : '', protect };
 }
 
-/** A protected annotation at or below this visible width is reserved whole when the row overflows. */
-const COMPACT_ANNOTATION_RESERVE = 30;
-
 /**
- * Lay out `head  target (annotation)` on one line. The head and a short
- * protected annotation are preserved whole; the input target truncates first,
- * so a long command can never hide an exit code. An annotation longer than
- * the reserve cap takes whatever room the target leaves.
+ * Lay out `head  target (annotation)` on one line. A protected annotation is
+ * preserved whole whenever it fits alongside the head; the input target
+ * truncates first, so a long command can never hide a fixed-shape outcome.
+ * An annotation that cannot fit with the head takes whatever room remains.
  */
 function assembleCompactToolRow(head: string, input: string, annotation: string, width: number, protect: boolean): string {
   const inputSeg = input ? `  ${input}` : '';
   const annSeg = annotation ? ` ${annotation}` : '';
   const full = `${head}${inputSeg}${annSeg}`;
   if (visibleWidth(full) <= width) return full;
-  // The cap is measured on the annotation alone; the joining space is still
-  // budgeted below, so an annotation exactly at the cap is kept whole.
-  const reserved = protect && visibleWidth(annotation) <= COMPACT_ANNOTATION_RESERVE;
+  const reserved = protect && visibleWidth(annSeg) <= Math.max(0, width - visibleWidth(head));
   const budget = Math.max(0, width - visibleWidth(head) - (reserved ? visibleWidth(annSeg) : 0));
   let builtInput = '';
   if (input && budget > 3) {
@@ -514,7 +509,7 @@ function renderToolResult(entry: MakaPiToolEntry, width: number): string[] {
 /** Best-effort extraction of the human-readable body from a tool result. */
 function plainResultText(entry: MakaPiToolEntry): string {
   const result = entry.result;
-  if (result?.kind === 'text') return result.text;
+  if (result?.kind === 'text') return typeof result.text === 'string' ? result.text : '';
   if (result?.kind === 'json') {
     const value = result.value;
     if (value !== null && typeof value === 'object') {


### PR DESCRIPTION
## Summary

- replace the compact-row generic first-result-line fallback with a fixed `N lines · M bytes` summary
- keep MCP, subagent, generic JSON/text, runtime Read errors, empty results, Unicode, malformed payloads, and oversized output out of compact rows
- preserve archived Read status and all existing structured summaries for shell, terminal, Read files, Grep, Glob, diffs, writes, and exit codes
- keep live and stored transcript rendering on the same projection path

Closes #1086

## Implementation Notes

The compact row remains `● Tool  target (annotation)`. Free-text result content is only rendered by the expanded card; its compact annotation is now a bounded fixed-shape line/byte count. Empty or whitespace-only text uses the existing `no output` placeholder, malformed text payloads fail closed to the same placeholder, and archived results expose only their stable archive status. The annotation is protected by the existing overflow reservation logic because it is now a fixed-shape outcome.

## Verification

- `npm --workspace maka-agent test` (581 passed)
- focused transcript test (141 passed)
- `npm --workspace maka-agent run typecheck`
- `npm run lint`
- `git diff --check`

## Review Focus

- compact rows never include free-text result content
- existing structured outcome branches remain unchanged
- empty, whitespace-only, malformed, Unicode, and oversized results have deterministic behavior
- archived Read status remains visible without exposing placeholder text
- live and stored transcript paths produce identical fixed summaries
- overflow preserves the fixed annotation and keeps the row within terminal width

Out of scope: changing expanded result rendering, introducing a new persisted result type, or changing host/runtime tool contracts.