### PR TITLE
feat(runtime): enforce shared child-run permits

### DIFF
--- a/packages/runtime/src/__tests__/child-agent-run-limiter.test.ts
+++ b/packages/runtime/src/__tests__/child-agent-run-limiter.test.ts
@@ -1,0 +1,396 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+import type { LlmConnection, SessionHeader } from '@maka/core';
+import { ChildAgentRunLimiter } from '../child-agent-run-limiter.js';
+import { PermissionEngine } from '../permission-engine.js';
+import {
+  MAX_ACTIVE_CHILD_AGENT_RUNS_PER_TURN,
+  ToolRuntime,
+  type MakaTool,
+  type MakaToolContext,
+} from '../tool-runtime.js';
+
+describe('ChildAgentRunLimiter', () => {
+  test('grants waiting permits in FIFO order and makes release idempotent', async () => {
+    const limiter = new ChildAgentRunLimiter(1);
+    const first = await limiter.acquire(new AbortController().signal);
+    const grants: string[] = [];
+    const secondPending = limiter.acquire(new AbortController().signal).then((permit) => {
+      grants.push('second');
+      return permit;
+    });
+    const thirdPending = limiter.acquire(new AbortController().signal).then((permit) => {
+      grants.push('third');
+      return permit;
+    });
+
+    assert.equal(limiter.activeCount, 1);
+    assert.equal(limiter.waitingCount, 2);
+    first.release();
+    first.release();
+
+    const second = await secondPending;
+    assert.deepEqual(grants, ['second']);
+    assert.equal(limiter.activeCount, 1);
+    assert.equal(limiter.waitingCount, 1);
+
+    second.release();
+    const third = await thirdPending;
+    assert.deepEqual(grants, ['second', 'third']);
+    third.release();
+    assert.equal(limiter.activeCount, 0);
+    assert.equal(limiter.waitingCount, 0);
+  });
+
+  test('removes an aborted waiter without consuming capacity', async () => {
+    const limiter = new ChildAgentRunLimiter(1);
+    const first = await limiter.acquire(new AbortController().signal);
+    const waitingController = new AbortController();
+    const waiting = limiter.acquire(waitingController.signal);
+
+    waitingController.abort(new Error('stop queued child'));
+
+    await assert.rejects(waiting, /stop queued child/);
+    assert.equal(limiter.activeCount, 1);
+    assert.equal(limiter.waitingCount, 0);
+    first.release();
+    assert.equal(limiter.activeCount, 0);
+  });
+
+  test('closes the turn scope for queued and future permits', async () => {
+    const limiter = new ChildAgentRunLimiter(1);
+    const first = await limiter.acquire(new AbortController().signal);
+    const second = limiter.acquire(new AbortController().signal);
+    const third = limiter.acquire(new AbortController().signal);
+
+    limiter.close(new Error('turn scope ended'));
+
+    await assert.rejects(second, /turn scope ended/);
+    await assert.rejects(third, /turn scope ended/);
+    await assert.rejects(
+      limiter.acquire(new AbortController().signal),
+      /turn scope ended/,
+    );
+    assert.equal(limiter.waitingCount, 0);
+    first.release();
+  });
+});
+
+describe('ToolRuntime child-agent run permits', () => {
+  test('caps real child runs spawned inside one admitted subagent tool', async () => {
+    const active = new Set<string>();
+    const started: string[] = [];
+    const releases = new Map<string, () => void>();
+    let maxActive = 0;
+    const runtime = buildRuntime(async (input) => {
+      const prompt = input.prompt;
+      started.push(prompt);
+      active.add(prompt);
+      maxActive = Math.max(maxActive, active.size);
+      return await new Promise((resolve) => {
+        let released = false;
+        releases.set(prompt, () => {
+          if (released) return;
+          released = true;
+          active.delete(prompt);
+          resolve({ prompt });
+        });
+      });
+    });
+    const tool = childBatchProbeTool(MAX_ACTIVE_CHILD_AGENT_RUNS_PER_TURN + 1);
+    const pending = executeTool(runtime, tool, new AbortController());
+
+    await waitFor(() => started.length === MAX_ACTIVE_CHILD_AGENT_RUNS_PER_TURN);
+    assert.equal(maxActive, MAX_ACTIVE_CHILD_AGENT_RUNS_PER_TURN);
+    assert.equal(active.size, MAX_ACTIVE_CHILD_AGENT_RUNS_PER_TURN);
+    assert.equal(releases.has(`child-${MAX_ACTIVE_CHILD_AGENT_RUNS_PER_TURN}`), false);
+
+    releases.get('child-0')?.();
+    await waitFor(() => started.length === MAX_ACTIVE_CHILD_AGENT_RUNS_PER_TURN + 1);
+    assert.equal(maxActive, MAX_ACTIVE_CHILD_AGENT_RUNS_PER_TURN);
+
+    for (const release of releases.values()) release();
+    await pending;
+    assert.equal(active.size, 0);
+  });
+
+  test('does not start a queued child after the parent tool is aborted', async () => {
+    const started: string[] = [];
+    const releases: Array<() => void> = [];
+    const runtime = buildRuntime(async (input) => {
+      started.push(input.prompt);
+      return await new Promise((resolve) => {
+        releases.push(() => resolve({ prompt: input.prompt }));
+      });
+    });
+    const controller = new AbortController();
+    const pending = executeTool(
+      runtime,
+      childBatchProbeTool(MAX_ACTIVE_CHILD_AGENT_RUNS_PER_TURN + 1, true),
+      controller,
+    );
+    await waitFor(() => started.length === MAX_ACTIVE_CHILD_AGENT_RUNS_PER_TURN);
+
+    controller.abort(new Error('parent tool aborted'));
+    for (const release of releases) release();
+    const result = await pending as { kind?: string; value?: { rejected?: number } };
+
+    assert.equal(started.length, MAX_ACTIVE_CHILD_AGENT_RUNS_PER_TURN);
+    assert.equal(result.kind, 'json');
+    assert.equal(result.value?.rejected, 1);
+  });
+
+  test('shares one child-run pool across concurrently admitted tools', async () => {
+    const active = new Set<string>();
+    const started: string[] = [];
+    const releases = new Map<string, () => void>();
+    let maxActive = 0;
+    const runtime = buildRuntime(async (input) => {
+      const prompt = input.prompt;
+      started.push(prompt);
+      active.add(prompt);
+      maxActive = Math.max(maxActive, active.size);
+      return await new Promise((resolve) => {
+        let released = false;
+        releases.set(prompt, () => {
+          if (released) return;
+          released = true;
+          active.delete(prompt);
+          resolve({ prompt });
+        });
+      });
+    });
+    const first = executeTool(
+      runtime,
+      childBatchProbeTool(3, false, 'first_batch_probe', 'first'),
+      new AbortController(),
+    );
+    const second = executeTool(
+      runtime,
+      childBatchProbeTool(3, false, 'second_batch_probe', 'second'),
+      new AbortController(),
+    );
+
+    await waitFor(() => started.length === MAX_ACTIVE_CHILD_AGENT_RUNS_PER_TURN);
+    assert.equal(maxActive, MAX_ACTIVE_CHILD_AGENT_RUNS_PER_TURN);
+    assert.equal(active.size, MAX_ACTIVE_CHILD_AGENT_RUNS_PER_TURN);
+
+    releases.get(started[0]!)?.();
+    await waitFor(() => started.length === 6);
+    assert.equal(maxActive, MAX_ACTIVE_CHILD_AGENT_RUNS_PER_TURN);
+
+    for (const release of releases.values()) release();
+    await Promise.all([first, second]);
+    assert.equal(active.size, 0);
+  });
+
+  test('releases the permit when child startup throws', async () => {
+    let started = 0;
+    const runtime = buildRuntime(async () => {
+      started += 1;
+      throw new Error('child startup failed');
+    });
+    const attempts = MAX_ACTIVE_CHILD_AGENT_RUNS_PER_TURN * 2;
+    const result = await withTimeout(
+      executeTool(runtime, sequentialFailureProbeTool(attempts), new AbortController()),
+      1_000,
+      'permit leak stalled sequential child starts',
+    ) as { kind?: string; value?: { rejected?: number } };
+
+    assert.equal(started, attempts);
+    assert.equal(result.kind, 'json');
+    assert.equal(result.value?.rejected, attempts);
+  });
+
+  test('rejects future child starts from a tool context after its turn ends', async () => {
+    let childStarts = 0;
+    let capturedSpawn: MakaToolContext['spawnChildAgent'];
+    const runtime = buildRuntime(async () => {
+      childStarts += 1;
+      return {};
+    });
+    const tool: MakaTool = {
+      name: 'capture_child_spawn',
+      description: 'test-only spawn capability capture',
+      parameters: {},
+      permissionRequired: false,
+      impl: async (_args, ctx) => {
+        capturedSpawn = ctx.spawnChildAgent;
+        return { kind: 'json', value: { captured: true } };
+      },
+    };
+    await executeTool(runtime, tool, new AbortController());
+    runtime.endTurn('turn-1');
+
+    assert.ok(capturedSpawn);
+    await assert.rejects(
+      capturedSpawn({
+        spec: childSpec(0),
+        prompt: 'late child',
+      }),
+      /permit scope ended/,
+    );
+    assert.equal(childStarts, 0);
+  });
+});
+
+function childBatchProbeTool(
+  count: number,
+  summarizeSettled = false,
+  name = 'child_batch_probe',
+  promptPrefix = 'child',
+): MakaTool {
+  return {
+    name,
+    description: 'test-only child batch probe',
+    parameters: {},
+    permissionRequired: false,
+    categoryHint: 'subagent',
+    impl: async (_args, ctx) => {
+      if (!ctx.spawnChildAgent) throw new Error('missing spawn capability');
+      const pending = Array.from({ length: count }, (_, index) => ctx.spawnChildAgent!({
+        spec: childSpec(index),
+        prompt: `${promptPrefix}-${index}`,
+      }));
+      if (!summarizeSettled) return { kind: 'json', value: await Promise.all(pending) };
+      const settled = await Promise.allSettled(pending);
+      return {
+        kind: 'json',
+        value: {
+          fulfilled: settled.filter((result) => result.status === 'fulfilled').length,
+          rejected: settled.filter((result) => result.status === 'rejected').length,
+        },
+      };
+    },
+  };
+}
+
+function sequentialFailureProbeTool(count: number): MakaTool {
+  return {
+    name: 'sequential_child_failure_probe',
+    description: 'test-only sequential child failure probe',
+    parameters: {},
+    permissionRequired: false,
+    categoryHint: 'subagent',
+    impl: async (_args, ctx) => {
+      if (!ctx.spawnChildAgent) throw new Error('missing spawn capability');
+      let rejected = 0;
+      for (let index = 0; index < count; index += 1) {
+        try {
+          await ctx.spawnChildAgent({
+            spec: childSpec(index),
+            prompt: `failure-${index}`,
+          });
+        } catch {
+          rejected += 1;
+        }
+      }
+      return { kind: 'json', value: { rejected } };
+    },
+  };
+}
+
+function childSpec(index: number) {
+  return {
+    id: `test-child-${index}`,
+    name: `Test Child ${index}`,
+    systemPrompt: 'Test child.',
+  };
+}
+
+function buildRuntime(
+  spawnChildAgent: NonNullable<ConstructorParameters<typeof ToolRuntime>[0]['spawnChildAgent']>,
+): ToolRuntime {
+  const permissionEngine = new PermissionEngine({ newId: nextId(), now: () => 1 });
+  permissionEngine.beginTurn('turn-1');
+  return new ToolRuntime({
+    sessionId: 'session-1',
+    header: testHeader(),
+    connection: testConnection(),
+    modelId: 'mock-model',
+    appendMessage: async () => {},
+    permissionEngine,
+    newId: nextId(),
+    now: () => 1,
+    getPermissionPauseTarget: () => null,
+    getCurrentRunId: () => 'parent-run',
+    spawnChildAgent,
+  });
+}
+
+async function executeTool(
+  runtime: ToolRuntime,
+  tool: MakaTool,
+  controller: AbortController,
+): Promise<unknown> {
+  return await runtime.wrapToolExecute(tool, 'turn-1', { push: () => {} })({}, {
+    toolCallId: `tool-${tool.name}`,
+    abortSignal: controller.signal,
+  });
+}
+
+function testHeader(): SessionHeader {
+  return {
+    id: 'session-1',
+    workspaceRoot: '/tmp',
+    cwd: '/tmp',
+    createdAt: 1,
+    lastUsedAt: 1,
+    name: 'Test',
+    isFlagged: false,
+    labels: [],
+    isArchived: false,
+    status: 'active',
+    statusUpdatedAt: 1,
+    hasUnread: false,
+    backend: 'ai-sdk',
+    llmConnectionSlug: 'anthropic-main',
+    connectionLocked: true,
+    model: 'mock-model',
+    permissionMode: 'explore',
+    schemaVersion: 1,
+  };
+}
+
+function testConnection(): LlmConnection {
+  return {
+    slug: 'anthropic-main',
+    name: 'Anthropic',
+    providerType: 'anthropic',
+    defaultModel: 'mock-model',
+    enabled: true,
+    createdAt: 1,
+    updatedAt: 1,
+  };
+}
+
+function nextId(): () => string {
+  let id = 0;
+  return () => `id-${++id}`;
+}
+
+async function waitFor(predicate: () => boolean, timeoutMs = 1_000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (!predicate()) {
+    if (Date.now() >= deadline) throw new Error('Timed out waiting for condition');
+    await new Promise<void>((resolve) => setImmediate(resolve));
+  }
+}
+
+async function withTimeout<T>(
+  promise: Promise<T>,
+  timeoutMs: number,
+  message: string,
+): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<never>((_resolve, reject) => {
+        timer = setTimeout(() => reject(new Error(message)), timeoutMs);
+      }),
+    ]);
+  } finally {
+    if (timer !== undefined) clearTimeout(timer);
+  }
+}

--- a/packages/runtime/src/ai-sdk-backend.ts
+++ b/packages/runtime/src/ai-sdk-backend.ts
@@ -94,6 +94,7 @@ import {
 import { AsyncEventQueue } from './async-queue.js';
 import { StreamWatchdog, formatStreamWatchdogError } from './stream-watchdog.js';
 import {
+  MAX_ACTIVE_CHILD_AGENT_RUNS_PER_TURN,
   MAX_ACTIVE_SUBAGENT_TOOLS_PER_TURN,
   TOOL_ERROR_RESULT_MAX_CHARS,
   ToolRuntime,
@@ -214,6 +215,7 @@ import {
 } from './mid-turn-capacity-compact.js';
 export {
   DEFAULT_PERMISSION_TIMEOUT_MS,
+  MAX_ACTIVE_CHILD_AGENT_RUNS_PER_TURN,
   MAX_ACTIVE_SUBAGENT_TOOLS_PER_TURN,
   TOOL_ERROR_RESULT_MAX_CHARS,
   formatSyntheticToolErrorText,

--- a/packages/runtime/src/child-agent-run-limiter.ts
+++ b/packages/runtime/src/child-agent-run-limiter.ts
@@ -1,0 +1,103 @@
+export interface ChildAgentRunPermit {
+  release(): void;
+}
+
+interface ChildAgentRunWaiter {
+  signal: AbortSignal;
+  resolve: (permit: ChildAgentRunPermit) => void;
+  reject: (error: unknown) => void;
+  onAbort: () => void;
+}
+
+/**
+ * Abort-aware FIFO permits for real child-agent executions.
+ *
+ * Tool-call admission and child-run capacity are separate boundaries: one
+ * admitted tool may eventually spawn multiple children. This limiter belongs at
+ * the narrow spawn capability so every caller shares the same real-run budget.
+ */
+export class ChildAgentRunLimiter {
+  private active = 0;
+  private readonly waiters: ChildAgentRunWaiter[] = [];
+  private closedError: Error | undefined;
+
+  constructor(readonly capacity: number) {
+    if (!Number.isSafeInteger(capacity) || capacity < 1) {
+      throw new Error('Child agent run capacity must be a positive safe integer');
+    }
+  }
+
+  get activeCount(): number {
+    return this.active;
+  }
+
+  get waitingCount(): number {
+    return this.waiters.length;
+  }
+
+  acquire(signal: AbortSignal): Promise<ChildAgentRunPermit> {
+    if (this.closedError) return Promise.reject(this.closedError);
+    if (signal.aborted) return Promise.reject(abortReason(signal));
+    if (this.active < this.capacity && this.waiters.length === 0) {
+      this.active += 1;
+      return Promise.resolve(this.createPermit());
+    }
+    return new Promise<ChildAgentRunPermit>((resolve, reject) => {
+      const waiter: ChildAgentRunWaiter = {
+        signal,
+        resolve,
+        reject,
+        onAbort: () => {
+          const index = this.waiters.indexOf(waiter);
+          if (index < 0) return;
+          this.waiters.splice(index, 1);
+          signal.removeEventListener('abort', waiter.onAbort);
+          reject(abortReason(signal));
+        },
+      };
+      this.waiters.push(waiter);
+      signal.addEventListener('abort', waiter.onAbort, { once: true });
+    });
+  }
+
+  close(error: Error): void {
+    if (this.closedError) return;
+    this.closedError = error;
+    for (const waiter of this.waiters.splice(0)) {
+      waiter.signal.removeEventListener('abort', waiter.onAbort);
+      waiter.reject(error);
+    }
+  }
+
+  private createPermit(): ChildAgentRunPermit {
+    let released = false;
+    return {
+      release: () => {
+        if (released) return;
+        released = true;
+        this.active -= 1;
+        this.grantWaiting();
+      },
+    };
+  }
+
+  private grantWaiting(): void {
+    if (this.closedError) return;
+    while (this.active < this.capacity && this.waiters.length > 0) {
+      const waiter = this.waiters.shift()!;
+      waiter.signal.removeEventListener('abort', waiter.onAbort);
+      if (waiter.signal.aborted) {
+        waiter.reject(abortReason(waiter.signal));
+        continue;
+      }
+      this.active += 1;
+      waiter.resolve(this.createPermit());
+    }
+  }
+}
+
+function abortReason(signal: AbortSignal): Error {
+  return signal.reason instanceof Error
+    ? signal.reason
+    : new Error('Child agent run cancelled while waiting for runtime capacity');
+}

--- a/packages/runtime/src/tool-runtime.ts
+++ b/packages/runtime/src/tool-runtime.ts
@@ -59,6 +59,7 @@ import {
   type SandboxEscalationPlanResult,
   type SandboxEscalationPlannerContext,
 } from './sandbox-escalation.js';
+import { ChildAgentRunLimiter } from './child-agent-run-limiter.js';
 
 export type ToolModelOutputPart =
   | { type: 'text'; text: string }
@@ -171,6 +172,7 @@ export interface ToolGating {
 
 export const TOOL_ERROR_RESULT_MAX_CHARS = 4000;
 export const MAX_ACTIVE_SUBAGENT_TOOLS_PER_TURN = 5;
+export const MAX_ACTIVE_CHILD_AGENT_RUNS_PER_TURN = 5;
 export const DEFAULT_PERMISSION_TIMEOUT_MS = 300_000;
 
 /**
@@ -233,6 +235,7 @@ export class ToolRuntime {
     { toolUseId: string; questions: UserQuestion[] }
   >();
   private activeSubagentToolCount = 0;
+  private childAgentRunLimiter = new ChildAgentRunLimiter(MAX_ACTIVE_CHILD_AGENT_RUNS_PER_TURN);
   /**
    * Tool-availability gating for the execute boundary. Set by the backend each
    * turn from `ToolAvailabilityRuntime`. Undefined when gating is off (economy
@@ -312,6 +315,11 @@ export class ToolRuntime {
   }
 
   resetTurnState(): void {
+    const priorChildAgentRunLimiter = this.childAgentRunLimiter;
+    this.childAgentRunLimiter = new ChildAgentRunLimiter(MAX_ACTIVE_CHILD_AGENT_RUNS_PER_TURN);
+    priorChildAgentRunLimiter.close(
+      new Error('Child agent run permit scope ended before capacity became available'),
+    );
     this.activeSubagentToolCount = 0;
     this.gating = undefined;
     this.lastFailedToolCallSignature = undefined;
@@ -1281,16 +1289,30 @@ export class ToolRuntime {
     abortSignal: AbortSignal,
   ): Pick<MakaToolContext, 'spawnChildAgent'> {
     const parentRunId = this.input.getCurrentRunId?.();
-    if (!parentRunId || !this.input.spawnChildAgent) return {};
+    const spawnChildAgent = this.input.spawnChildAgent;
+    if (!parentRunId || !spawnChildAgent) return {};
+    const limiter = this.childAgentRunLimiter;
     return {
-      spawnChildAgent: (input) => this.input.spawnChildAgent?.({
-        parentRunId,
-        spec: input.spec,
-        prompt: input.prompt,
-        abortSignal,
-        ...(input.onReady ? { onReady: input.onReady } : {}),
-        ...(input.onEvent ? { onEvent: input.onEvent } : {}),
-      }) ?? Promise.reject(new Error('spawnChildAgent is unavailable')),
+      spawnChildAgent: async (input) => {
+        const permit = await limiter.acquire(abortSignal);
+        try {
+          if (abortSignal.aborted) {
+            throw abortSignal.reason instanceof Error
+              ? abortSignal.reason
+              : new Error('Child agent run cancelled before it started');
+          }
+          return await spawnChildAgent({
+            parentRunId,
+            spec: input.spec,
+            prompt: input.prompt,
+            abortSignal,
+            ...(input.onReady ? { onReady: input.onReady } : {}),
+            ...(input.onEvent ? { onEvent: input.onEvent } : {}),
+          });
+        } finally {
+          permit.release();
+        }
+      },
     };
   }
 


### PR DESCRIPTION
## What changed

- add an abort-aware FIFO `ChildAgentRunLimiter` for real child-agent executions
- acquire and release the shared permit at the narrow `MakaToolContext.spawnChildAgent` capability
- keep the existing per-turn subagent tool-admission guard as a separate model fan-out boundary
- close each turn's permit scope so queued and future calls from stale tool contexts fail closed
- expose the explicit `MAX_ACTIVE_CHILD_AGENT_RUNS_PER_TURN = 5` runtime limit

## Why

The existing `MAX_ACTIVE_SUBAGENT_TOOLS_PER_TURN` limit counts provider-visible subagent tool calls. One admitted tool can still call `spawnChildAgent` multiple times internally, so a future batch adapter could exceed the real child-run budget while consuming only one tool slot.

This PR moves resource safety to the actual spawn boundary shared by `agent_spawn`, `expert_dispatch`, and future adapters. It intentionally does not add a Swarm kernel or a new model tool.

## Behavior and compatibility

- at most five real child runs execute concurrently within one turn
- additional child starts wait FIFO for capacity
- a parent abort removes its queued child before execution
- completion, failure, cancellation, and startup exceptions release permits in `finally`
- existing `agent_spawn` behavior and subagent tool-admission semantics remain unchanged
- no new persistence, event ledger, or Agent run type is introduced

## Validation

- `npm --workspace @maka/core run build`
- `npm --workspace @maka/storage run build`
- `npm --workspace @maka/runtime run typecheck`
- `npm exec -- biome lint packages/runtime/src/child-agent-run-limiter.ts packages/runtime/src/tool-runtime.ts packages/runtime/src/ai-sdk-backend.ts packages/runtime/src/__tests__/child-agent-run-limiter.test.ts`
- 8 new limiter and ToolRuntime integration tests pass
- existing subagent admission regression passes
- 4 targeted `agent_spawn` capability/progress regressions pass
- full clean runtime suite: 2,117 passed, 7 skipped, 1 unrelated existing macOS executable-root assertion failed (`/usr/local` is already root 0 but the test also expects it as root 1)

Part of #1192.
