### PR TITLE
feat(runtime): add bounded swarm kernel

### DIFF
--- a/packages/runtime/src/__tests__/bounded-swarm.test.ts
+++ b/packages/runtime/src/__tests__/bounded-swarm.test.ts
@@ -1,0 +1,310 @@
+import assert from "node:assert/strict";
+import { describe, test } from "node:test";
+import { runBoundedSwarm, type SwarmItemResult } from "../bounded-swarm.js";
+
+describe("runBoundedSwarm", () => {
+	test("rejects invalid concurrency before starting work", async () => {
+		let starts = 0;
+		const worker = () => {
+			starts += 1;
+			return "started";
+		};
+		const signal = new AbortController().signal;
+
+		for (const maxConcurrency of [0, -1, 1.5, Number.MAX_SAFE_INTEGER + 1]) {
+			await assert.rejects(
+				runBoundedSwarm(["item"], worker, { maxConcurrency, signal }),
+				/positive safe integer/,
+			);
+		}
+		assert.equal(starts, 0);
+	});
+
+	test("returns an empty stable result without invoking the worker", async () => {
+		let starts = 0;
+		const results = await runBoundedSwarm(
+			[],
+			() => {
+				starts += 1;
+			},
+			{ maxConcurrency: 3, signal: new AbortController().signal },
+		);
+
+		assert.deepEqual(results, []);
+		assert.equal(starts, 0);
+	});
+
+	test("enforces local concurrency and applies backpressure", async () => {
+		const gates = Array.from({ length: 6 }, () => deferred<void>());
+		const started: number[] = [];
+		let active = 0;
+		let maxActive = 0;
+		const pending = runBoundedSwarm(
+			[0, 1, 2, 3, 4, 5],
+			async (_item, { index }) => {
+				started.push(index);
+				active += 1;
+				maxActive = Math.max(maxActive, active);
+				await gates[index]!.promise;
+				active -= 1;
+				return `value-${index}`;
+			},
+			{ maxConcurrency: 2, signal: new AbortController().signal },
+		);
+
+		await waitFor(() => started.length === 2);
+		assert.deepEqual(started, [0, 1]);
+		assert.equal(maxActive, 2);
+
+		gates[1]!.resolve();
+		await waitFor(() => started.length === 3);
+		assert.deepEqual(started, [0, 1, 2]);
+		assert.equal(maxActive, 2);
+
+		for (const gate of gates) gate.resolve();
+		const results = await withTimeout(
+			pending,
+			"bounded workers did not settle",
+		);
+
+		assert.equal(active, 0);
+		assert.equal(maxActive, 2);
+		assert.deepEqual(
+			results.map((result) => result.status),
+			Array.from({ length: 6 }, () => "fulfilled"),
+		);
+	});
+
+	test("keeps result slots in input order when workers finish out of order", async () => {
+		const gates = Array.from({ length: 3 }, () => deferred<string>());
+		const completionOrder: number[] = [];
+		const pending = runBoundedSwarm(
+			["first", "second", "third"],
+			async (_item, { index }) => {
+				const value = await gates[index]!.promise;
+				completionOrder.push(index);
+				return value;
+			},
+			{ maxConcurrency: 3, signal: new AbortController().signal },
+		);
+
+		gates[2]!.resolve("third-value");
+		await waitFor(() => completionOrder.length === 1);
+		gates[0]!.resolve("first-value");
+		await waitFor(() => completionOrder.length === 2);
+		gates[1]!.resolve("second-value");
+
+		const results = await pending;
+		assert.deepEqual(completionOrder, [2, 0, 1]);
+		assert.deepEqual(results, [
+			{ index: 0, status: "fulfilled", value: "first-value" },
+			{ index: 1, status: "fulfilled", value: "second-value" },
+			{ index: 2, status: "fulfilled", value: "third-value" },
+		]);
+	});
+
+	test("isolates synchronous throws and asynchronous rejections", async () => {
+		const visited: number[] = [];
+		const results = await runBoundedSwarm(
+			[0, 1, 2, 3],
+			(item) => {
+				visited.push(item);
+				if (item === 1) throw new Error("synchronous failure");
+				if (item === 2) return Promise.reject(new Error("rejected promise"));
+				return `value-${item}`;
+			},
+			{ maxConcurrency: 2, signal: new AbortController().signal },
+		);
+
+		assert.deepEqual(
+			visited.sort((left, right) => left - right),
+			[0, 1, 2, 3],
+		);
+		assert.deepEqual(
+			results.map((result) => result.status),
+			["fulfilled", "rejected", "rejected", "fulfilled"],
+		);
+		assert.match(rejectionReason(results[1]), /synchronous failure/);
+		assert.match(rejectionReason(results[2]), /rejected promise/);
+	});
+
+	test("cancels queued slots, signals active workers, and joins them", async () => {
+		const controller = new AbortController();
+		const started: number[] = [];
+		const observedAbort: number[] = [];
+		const pending = runBoundedSwarm(
+			[0, 1, 2, 3, 4],
+			async (_item, { index, signal }) => {
+				started.push(index);
+				await new Promise<void>((resolve) => {
+					signal.addEventListener(
+						"abort",
+						() => {
+							observedAbort.push(index);
+							resolve();
+						},
+						{ once: true },
+					);
+				});
+				return `late-${index}`;
+			},
+			{ maxConcurrency: 2, signal: controller.signal },
+		);
+
+		await waitFor(() => started.length === 2);
+		controller.abort(new Error("parent stopped"));
+		const results = await withTimeout(
+			pending,
+			"cancelled workers escaped the scope",
+		);
+
+		assert.deepEqual(started, [0, 1]);
+		assert.deepEqual(
+			observedAbort.sort((left, right) => left - right),
+			[0, 1],
+		);
+		assert.deepEqual(
+			results.map((result) => result.status),
+			["cancelled", "cancelled", "cancelled", "cancelled", "cancelled"],
+		);
+		for (const result of results) {
+			assert.match(cancellationReason(result), /parent stopped/);
+		}
+	});
+
+	test("does not start any item when the parent is already aborted", async () => {
+		const controller = new AbortController();
+		controller.abort(new Error("already stopped"));
+		let starts = 0;
+
+		const results = await runBoundedSwarm(
+			[0, 1, 2],
+			() => {
+				starts += 1;
+				return "unreachable";
+			},
+			{ maxConcurrency: 3, signal: controller.signal },
+		);
+
+		assert.equal(starts, 0);
+		assert.deepEqual(
+			results.map((result) => result.status),
+			["cancelled", "cancelled", "cancelled"],
+		);
+	});
+
+	test("settles throw and abort races without starting another queued item", async () => {
+		const controller = new AbortController();
+		const secondStarted = deferred<void>();
+		const started: number[] = [];
+		const pending = runBoundedSwarm(
+			[0, 1, 2],
+			async (_item, { index, signal }) => {
+				started.push(index);
+				if (index === 0) throw new Error("first failed");
+				secondStarted.resolve();
+				await new Promise<void>((resolve) => {
+					signal.addEventListener("abort", () => resolve(), { once: true });
+				});
+				return "late success";
+			},
+			{ maxConcurrency: 1, signal: controller.signal },
+		);
+
+		await secondStarted.promise;
+		controller.abort(new Error("race cancelled"));
+		const results = await withTimeout(
+			pending,
+			"throw/abort race did not settle",
+		);
+
+		assert.deepEqual(started, [0, 1]);
+		assert.deepEqual(
+			results.map((result) => result.status),
+			["rejected", "cancelled", "cancelled"],
+		);
+		assert.match(rejectionReason(results[0]), /first failed/);
+	});
+
+	test("handles single-item and 32-item batches deterministically", async () => {
+		const signal = new AbortController().signal;
+		const single = await runBoundedSwarm(
+			["one"],
+			(item) => item.toUpperCase(),
+			{ maxConcurrency: 1, signal },
+		);
+		const batch = await runBoundedSwarm(
+			Array.from({ length: 32 }, (_, index) => index),
+			(item, { index }) => item + index,
+			{ maxConcurrency: 5, signal },
+		);
+
+		assert.deepEqual(single, [{ index: 0, status: "fulfilled", value: "ONE" }]);
+		assert.deepEqual(
+			batch,
+			Array.from({ length: 32 }, (_, index) => ({
+				index,
+				status: "fulfilled",
+				value: index * 2,
+			})),
+		);
+	});
+});
+
+interface Deferred<Value> {
+	readonly promise: Promise<Value>;
+	resolve(value: Value): void;
+}
+
+function deferred<Value>(): Deferred<Value> {
+	let resolvePromise: ((value: Value) => void) | undefined;
+	const promise = new Promise<Value>((resolve) => {
+		resolvePromise = resolve;
+	});
+	return {
+		promise,
+		resolve: (value) => resolvePromise!(value),
+	};
+}
+
+function rejectionReason<Output>(
+	result: SwarmItemResult<Output> | undefined,
+): string {
+	assert.equal(result?.status, "rejected");
+	return String(result.reason);
+}
+
+function cancellationReason<Output>(result: SwarmItemResult<Output>): string {
+	assert.equal(result.status, "cancelled");
+	return String(result.reason);
+}
+
+async function waitFor(
+	predicate: () => boolean,
+	timeoutMs = 1_000,
+): Promise<void> {
+	const deadline = Date.now() + timeoutMs;
+	while (!predicate()) {
+		if (Date.now() >= deadline)
+			throw new Error("Timed out waiting for condition");
+		await new Promise<void>((resolve) => setImmediate(resolve));
+	}
+}
+
+async function withTimeout<Value>(
+	promise: Promise<Value>,
+	message: string,
+	timeoutMs = 1_000,
+): Promise<Value> {
+	let timer: ReturnType<typeof setTimeout> | undefined;
+	try {
+		return await Promise.race([
+			promise,
+			new Promise<never>((_resolve, reject) => {
+				timer = setTimeout(() => reject(new Error(message)), timeoutMs);
+			}),
+		]);
+	} finally {
+		if (timer !== undefined) clearTimeout(timer);
+	}
+}

--- a/packages/runtime/src/bounded-swarm.ts
+++ b/packages/runtime/src/bounded-swarm.ts
@@ -1,0 +1,161 @@
+export interface BoundedSwarmOptions {
+	readonly maxConcurrency: number;
+	readonly signal: AbortSignal;
+}
+
+export interface SwarmWorkerContext {
+	readonly index: number;
+	readonly signal: AbortSignal;
+}
+
+export type SwarmItemResult<Output> =
+	| {
+			readonly index: number;
+			readonly status: "fulfilled";
+			readonly value: Output;
+	  }
+	| {
+			readonly index: number;
+			readonly status: "rejected";
+			readonly reason: unknown;
+	  }
+	| {
+			readonly index: number;
+			readonly status: "cancelled";
+			readonly reason: unknown;
+	  };
+
+type WorkerSettlement<Output> =
+	| {
+			readonly status: "fulfilled";
+			readonly value: Output;
+	  }
+	| {
+			readonly status: "rejected";
+			readonly reason: unknown;
+	  };
+
+interface CancelledSettlement {
+	readonly status: "cancelled";
+	readonly reason: unknown;
+}
+
+/**
+ * Runs a finite, ordered collection through an all-settled worker pool.
+ *
+ * The returned slots always match input order. Parent cancellation prevents
+ * queued items from starting, signals active workers, and joins those workers
+ * before returning so work cannot escape the scope.
+ */
+export async function runBoundedSwarm<Input, Output>(
+	items: readonly Input[],
+	worker: (
+		item: Input,
+		context: SwarmWorkerContext,
+	) => Output | PromiseLike<Output>,
+	options: BoundedSwarmOptions,
+): Promise<readonly SwarmItemResult<Output>[]> {
+	assertMaxConcurrency(options.maxConcurrency);
+	if (items.length === 0) return [];
+
+	const results = Array.from<SwarmItemResult<Output> | undefined>({
+		length: items.length,
+	});
+	let nextIndex = 0;
+
+	const claimNextIndex = (): number | undefined => {
+		if (options.signal.aborted || nextIndex >= items.length) return undefined;
+		const index = nextIndex;
+		nextIndex += 1;
+		return index;
+	};
+
+	const runWorker = async (): Promise<void> => {
+		while (true) {
+			const index = claimNextIndex();
+			if (index === undefined) return;
+
+			const settlement = invokeWorker(worker, items[index]!, {
+				index,
+				signal: options.signal,
+			});
+			const outcome = await joinWorkerOrCancellation(
+				settlement,
+				options.signal,
+			);
+			results[index] = { index, ...outcome };
+		}
+	};
+
+	const workerCount = Math.min(options.maxConcurrency, items.length);
+	await Promise.all(Array.from({ length: workerCount }, runWorker));
+
+	return results.map((result, index): SwarmItemResult<Output> => {
+		if (result) return result;
+		if (!options.signal.aborted) {
+			throw new Error(`Bounded swarm left item ${index} unsettled`);
+		}
+		return {
+			index,
+			status: "cancelled",
+			reason: cancellationReason(options.signal),
+		};
+	});
+}
+
+function invokeWorker<Input, Output>(
+	worker: (
+		item: Input,
+		context: SwarmWorkerContext,
+	) => Output | PromiseLike<Output>,
+	item: Input,
+	context: SwarmWorkerContext,
+): Promise<WorkerSettlement<Output>> {
+	try {
+		return Promise.resolve(worker(item, context)).then(
+			(value) => ({ status: "fulfilled", value }),
+			(reason: unknown) => ({ status: "rejected", reason }),
+		);
+	} catch (reason) {
+		return Promise.resolve({ status: "rejected", reason });
+	}
+}
+
+async function joinWorkerOrCancellation<Output>(
+	settlement: Promise<WorkerSettlement<Output>>,
+	signal: AbortSignal,
+): Promise<WorkerSettlement<Output> | CancelledSettlement> {
+	if (signal.aborted) {
+		await settlement;
+		return { status: "cancelled", reason: cancellationReason(signal) };
+	}
+
+	let onAbort: (() => void) | undefined;
+	const cancelled = new Promise<CancelledSettlement>((resolve) => {
+		onAbort = () => {
+			resolve({ status: "cancelled", reason: cancellationReason(signal) });
+		};
+		signal.addEventListener("abort", onAbort, { once: true });
+	});
+
+	const outcome = await Promise.race([settlement, cancelled]);
+	if (onAbort) signal.removeEventListener("abort", onAbort);
+
+	if (signal.aborted) {
+		await settlement;
+		return { status: "cancelled", reason: cancellationReason(signal) };
+	}
+	return outcome;
+}
+
+function assertMaxConcurrency(maxConcurrency: number): void {
+	if (!Number.isSafeInteger(maxConcurrency) || maxConcurrency < 1) {
+		throw new RangeError(
+			"Swarm maxConcurrency must be a positive safe integer",
+		);
+	}
+}
+
+function cancellationReason(signal: AbortSignal): unknown {
+	return signal.reason ?? new Error("Bounded swarm cancelled");
+}


### PR DESCRIPTION
## Summary

- add the package-internal `runBoundedSwarm<I, O>` structured-concurrency primitive
- bound local worker concurrency with queue backpressure and stable input-indexed result slots
- isolate worker failures as `fulfilled` / `rejected` / `cancelled` facts
- propagate parent cancellation to active workers, prevent queued work from starting, and join active workers before returning
- cover concurrency, out-of-order completion, failure isolation, cancellation, and throw/abort races with deterministic tests

## Why

This is PR 2 of the staged plan in #1192. It provides the domain-neutral control-flow kernel that the later `AgentSwarm` adapter can compose with the shared child-run permits from #1196.

The kernel intentionally has no dependency on Agent runs, prompts, profiles, tools, permissions, runtime events, artifacts, persistence, or UI, and it is not added to the public package export map.

## Cancellation semantics

- items that have already settled retain their fulfilled or rejected outcome
- parent abort prevents any unclaimed item from starting
- active workers receive the parent `AbortSignal`
- active workers are joined before the scope returns and their slots become cancelled when abort wins

## Validation

- `npx biome check packages/runtime/src/bounded-swarm.ts packages/runtime/src/__tests__/bounded-swarm.test.ts`
- `npm run typecheck --workspace @maka/runtime`
- `npm run build --workspace @maka/runtime`
- `node --test packages/runtime/dist/__tests__/bounded-swarm.test.js` — 9 passed
- full `@maka/runtime` suite — 2,127 passed, 7 skipped, with one unrelated existing macOS sandbox assertion failing because this host does not include the expected `/usr/local` executable root

## Non-goals

No retries, timeouts, quorum policies, reducers, DAG execution, dynamic expansion, persistence/resume, inter-worker messaging, Agent-domain result mapping, or provider-visible tool exposure.

Part of #1192.
