### PR TITLE
feat(runtime): add AgentSwarm adapter

### DIFF
--- a/packages/cli/src/__tests__/pi-transcript-format.test.ts
+++ b/packages/cli/src/__tests__/pi-transcript-format.test.ts
@@ -1,0 +1,43 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { formatToolResultContent } from '../pi-transcript-format.js';
+
+test('keeps the pre-exposure agent swarm fallback bounded', () => {
+  const output = formatToolResultContent({
+    kind: 'agent_swarm',
+    status: 'partial',
+    items: [
+      {
+        itemId: 'auth',
+        index: 0,
+        profile: 'local_read',
+        started: true,
+        agentId: 'local-read',
+        agentName: 'Local Read',
+        turnId: 'turn-auth',
+        runId: 'run-auth',
+        status: 'completed',
+        summary: 'Auth boundaries are documented.',
+        artifactIds: ['artifact-auth'],
+      },
+      {
+        itemId: 'storage',
+        index: 1,
+        profile: 'local_read',
+        started: false,
+        status: 'failed',
+        summary: 'Storage inspection failed.',
+        artifactIds: [],
+      },
+    ],
+    startedAt: 10,
+    completedAt: 20,
+    durationMs: 10,
+  });
+
+  assert.equal(output, 'Agent swarm: partial');
+  assert.doesNotMatch(
+    output,
+    /auth|storage|turn-auth|run-auth|artifact-auth|local-read/,
+  );
+});

--- a/packages/cli/src/pi-transcript-format.ts
+++ b/packages/cli/src/pi-transcript-format.ts
@@ -69,6 +69,8 @@ export function formatToolResultContent(content: ToolResultContent): string {
       return content.report ?? content.summary ?? content.message ?? `Inspected ${content.filesInspected} files`;
     case 'subagent':
       return content.summary;
+    case 'agent_swarm':
+      return `Agent swarm: ${content.status}`;
     case 'rive_workflow':
       return content.summary;
     case 'archived_tool_result':

--- a/packages/core/src/__tests__/agent-swarm-result.test.ts
+++ b/packages/core/src/__tests__/agent-swarm-result.test.ts
@@ -1,0 +1,80 @@
+import assert from "node:assert/strict";
+import { describe, test } from "node:test";
+import type { ToolResultContent } from "../events.js";
+import { decodeCanonicalToolResultContent } from "../tool-result-record-schema.js";
+import {
+	isCancelledToolResultContent,
+	toolResultActivityStatus,
+} from "../tool-result-status.js";
+
+describe("agent swarm result contract", () => {
+	test("decodes the exact structured result with stable child refs", () => {
+		const result = agentSwarmResult();
+
+		assert.deepEqual(decodeCanonicalToolResultContent(result), result);
+	});
+
+	test("rejects malformed or widened result rows", () => {
+		assert.throws(
+			() =>
+				decodeCanonicalToolResultContent({
+					...agentSwarmResult(),
+					items: [
+						{
+							...agentSwarmResult().items[0],
+							unexpected: true,
+						},
+					],
+				}),
+			/Invalid tool result content/,
+		);
+		assert.throws(
+			() =>
+				decodeCanonicalToolResultContent({
+					...agentSwarmResult(),
+					status: "failed",
+				}),
+			/Invalid tool result content/,
+		);
+	});
+
+	test("keeps partial batches settled and classifies cancellation as interrupted", () => {
+		const partial = { ...agentSwarmResult(), status: "partial" as const };
+		const cancelled = { ...agentSwarmResult(), status: "cancelled" as const };
+
+		assert.equal(toolResultActivityStatus(false, partial), "completed");
+		assert.equal(isCancelledToolResultContent(cancelled), true);
+		assert.equal(toolResultActivityStatus(true, cancelled), "interrupted");
+	});
+});
+
+function agentSwarmResult(): Extract<
+	ToolResultContent,
+	{ kind: "agent_swarm" }
+> {
+	return {
+		kind: "agent_swarm",
+		status: "completed",
+		items: [
+			{
+				itemId: "auth",
+				index: 0,
+				profile: "local_read",
+				started: true,
+				agentId: "local-read",
+				agentName: "Local Read",
+				turnId: "turn-auth",
+				runId: "run-auth",
+				status: "completed",
+				summary: "Auth boundaries are documented.",
+				artifactIds: ["artifact-auth"],
+				startedAt: 10,
+				completedAt: 20,
+				durationMs: 10,
+			},
+		],
+		startedAt: 10,
+		completedAt: 20,
+		durationMs: 10,
+	};
+}

--- a/packages/core/src/events.ts
+++ b/packages/core/src/events.ts
@@ -349,6 +349,30 @@ export type ToolResultContent =
       failureClass?: string;
     }
   | {
+      kind: 'agent_swarm';
+      status: 'completed' | 'partial' | 'cancelled';
+      items: ReadonlyArray<{
+        itemId: string;
+        index: number;
+        profile: string;
+        started: boolean;
+        agentId?: string;
+        agentName?: string;
+        turnId?: string;
+        runId?: string;
+        status: 'completed' | 'failed' | 'cancelled';
+        summary: string;
+        artifactIds: readonly string[];
+        startedAt?: number;
+        completedAt?: number;
+        durationMs?: number;
+        failureClass?: string;
+      }>;
+      startedAt: number;
+      completedAt: number;
+      durationMs: number;
+    }
+  | {
       kind: 'rive_workflow';
       ok: boolean;
       action: string;

--- a/packages/core/src/tool-result-record-schema.ts
+++ b/packages/core/src/tool-result-record-schema.ts
@@ -17,6 +17,7 @@ import { isStorageRef } from './interaction-record-schema.js';
 
 type Result<K extends ToolResultContent['kind']> = Extract<ToolResultContent, { kind: K }>;
 type ExploreResult = Result<'explore_agent'>;
+type AgentSwarmResult = Result<'agent_swarm'>;
 type RiveResult = Result<'rive_workflow'>;
 
 const TEXT_SHAPE = defineObjectShape<Result<'text'>>()(['kind', 'text'], []);
@@ -117,6 +118,15 @@ const EXPLORE_MATCH_SHAPE = defineObjectShape<ExploreMatch>()(
 const SUBAGENT_SHAPE = defineObjectShape<Result<'subagent'>>()(
   ['kind', 'agentName', 'turnId', 'status', 'permissionMode', 'summary', 'artifactIds'],
   ['agentId', 'runId', 'startedAt', 'completedAt', 'durationMs', 'eventCount', 'failureClass'],
+);
+const AGENT_SWARM_SHAPE = defineObjectShape<AgentSwarmResult>()(
+  ['kind', 'status', 'items', 'startedAt', 'completedAt', 'durationMs'],
+  [],
+);
+type AgentSwarmItem = AgentSwarmResult['items'][number];
+const AGENT_SWARM_ITEM_SHAPE = defineObjectShape<AgentSwarmItem>()(
+  ['itemId', 'index', 'profile', 'started', 'status', 'summary', 'artifactIds'],
+  ['agentId', 'agentName', 'turnId', 'runId', 'startedAt', 'completedAt', 'durationMs', 'failureClass'],
 );
 const RIVE_SHAPE = defineObjectShape<RiveResult>()(
   ['kind', 'ok', 'action', 'command', 'ids', 'summary'],
@@ -268,11 +278,48 @@ function isNonShellToolResultContent(value: unknown): value is ToolResultContent
         isOptionalFiniteNumber(value.eventCount) &&
         isOptionalString(value.failureClass)
       );
+    case 'agent_swarm':
+      return isAgentSwarmResult(value);
     case 'rive_workflow':
       return isRiveResult(value);
     default:
       return false;
   }
+}
+
+function isAgentSwarmResult(value: Record<string, unknown>): value is AgentSwarmResult {
+  return (
+    hasExactShape(value, AGENT_SWARM_SHAPE) &&
+    ['completed', 'partial', 'cancelled'].includes(value.status as string) &&
+    Array.isArray(value.items) &&
+    value.items.every(isAgentSwarmItem) &&
+    isFiniteNumber(value.startedAt) &&
+    isFiniteNumber(value.completedAt) &&
+    isFiniteNumber(value.durationMs)
+  );
+}
+
+function isAgentSwarmItem(value: unknown): value is AgentSwarmItem {
+  return (
+    isRecord(value) &&
+    hasExactShape(value, AGENT_SWARM_ITEM_SHAPE) &&
+    typeof value.itemId === 'string' &&
+    Number.isSafeInteger(value.index) &&
+    Number(value.index) >= 0 &&
+    typeof value.profile === 'string' &&
+    typeof value.started === 'boolean' &&
+    isOptionalString(value.agentId) &&
+    isOptionalString(value.agentName) &&
+    isOptionalString(value.turnId) &&
+    isOptionalString(value.runId) &&
+    ['completed', 'failed', 'cancelled'].includes(value.status as string) &&
+    typeof value.summary === 'string' &&
+    isStringArray(value.artifactIds) &&
+    isOptionalFiniteNumber(value.startedAt) &&
+    isOptionalFiniteNumber(value.completedAt) &&
+    isOptionalFiniteNumber(value.durationMs) &&
+    isOptionalString(value.failureClass)
+  );
 }
 
 function isExploreResult(value: Record<string, unknown>): value is ExploreResult {

--- a/packages/core/src/tool-result-status.ts
+++ b/packages/core/src/tool-result-status.ts
@@ -14,6 +14,7 @@ export function isCancelledToolResultContent(
   if (content.kind === 'terminal' || content.kind === 'shell_run') {
     return content.status === 'cancelled';
   }
+  if (content.kind === 'agent_swarm') return content.status === 'cancelled';
   return false;
 }
 

--- a/packages/runtime/src/__tests__/agent-swarm-tools.test.ts
+++ b/packages/runtime/src/__tests__/agent-swarm-tools.test.ts
@@ -1,0 +1,695 @@
+import assert from "node:assert/strict";
+import { describe, test } from "node:test";
+import type { LlmConnection, SessionHeader } from "@maka/core";
+import {
+	AGENT_SWARM_DEFAULT_CONCURRENCY,
+	AGENT_SWARM_MAX_CONCURRENCY,
+	AGENT_SWARM_MAX_ITEMS,
+	AGENT_SWARM_TOOL_NAME,
+	buildAgentSwarmTool,
+	type AgentSwarmToolInput,
+	type AgentSwarmToolResult,
+} from "../agent-swarm-tools.js";
+import {
+	AGENT_WORKSPACE_SAME_WORKSPACE,
+	AGENT_WORKSPACE_WORKTREE,
+	AGENT_WRITE_BACK_PATCH,
+	AGENT_WRITE_BACK_SUMMARY,
+	IMPLEMENTATION_AGENT_PROFILE,
+	LOCAL_READ_AGENT_PROFILE,
+} from "../agent-catalog.js";
+import { buildChildAgentTools, AGENT_TOOL_NAMES } from "../subagent-tools.js";
+import type { SpawnChildAgentResult } from "../session-manager.js";
+import { PermissionEngine } from "../permission-engine.js";
+import {
+	MAX_ACTIVE_CHILD_AGENT_RUNS_PER_TURN,
+	ToolRuntime,
+	type MakaTool,
+	type MakaToolContext,
+} from "../tool-runtime.js";
+
+describe("AgentSwarm adapter", () => {
+	test("declares a bounded schema and reserves the name without host registration", () => {
+		const tool = buildAgentSwarmTool();
+		const schema = tool.parameters as {
+			safeParse(input: unknown): {
+				success: boolean;
+				data?: AgentSwarmToolInput;
+			};
+		};
+
+		assert.equal(tool.name, AGENT_SWARM_TOOL_NAME);
+		assert.equal(tool.permissionRequired, true);
+		assert.equal(tool.categoryHint, "subagent");
+		assert.equal(
+			([...AGENT_TOOL_NAMES] as string[]).includes(AGENT_SWARM_TOOL_NAME),
+			false,
+		);
+		assert.deepEqual(
+			schema.safeParse({
+				items: [
+					{
+						item_id: "auth",
+						profile: LOCAL_READ_AGENT_PROFILE,
+						task: "Inspect auth.",
+					},
+				],
+			}).data,
+			{
+				items: [
+					{
+						item_id: "auth",
+						profile: LOCAL_READ_AGENT_PROFILE,
+						task: "Inspect auth.",
+					},
+				],
+				max_concurrency: AGENT_SWARM_DEFAULT_CONCURRENCY,
+			},
+		);
+		assert.equal(
+			schema.safeParse({
+				items: Array.from({ length: AGENT_SWARM_MAX_ITEMS + 1 }, (_, index) =>
+					swarmItem(index),
+				),
+			}).success,
+			false,
+		);
+		assert.equal(
+			schema.safeParse({
+				items: [swarmItem(0), swarmItem(0)],
+			}).success,
+			false,
+		);
+		assert.equal(
+			schema.safeParse({
+				items: [swarmItem(0)],
+				max_concurrency: AGENT_SWARM_MAX_CONCURRENCY + 1,
+			}).success,
+			false,
+		);
+		assert.equal(
+			schema.safeParse({
+				items: [
+					{
+						...swarmItem(0),
+						write_back: AGENT_WRITE_BACK_PATCH,
+					},
+				],
+			}).success,
+			false,
+		);
+		assert.equal(
+			schema.safeParse({
+				items: [
+					{
+						...swarmItem(0),
+						isolation: AGENT_WORKSPACE_WORKTREE,
+					},
+				],
+			}).success,
+			false,
+		);
+	});
+
+	test("preflights the complete batch before starting any child", async () => {
+		const tool = buildAgentSwarmTool();
+		let starts = 0;
+
+		await assert.rejects(
+			Promise.resolve(
+				tool.impl(
+					{
+						items: [
+							swarmItem(0),
+							{
+								item_id: "implementation",
+								profile: IMPLEMENTATION_AGENT_PROFILE,
+								task: "Edit the repository.",
+								write_back: AGENT_WRITE_BACK_PATCH,
+								isolation: AGENT_WORKSPACE_WORKTREE,
+							},
+						],
+					},
+					context({
+						spawnChildAgent: async () => {
+							starts += 1;
+							return childResult(0);
+						},
+					}),
+				),
+			),
+			/worktree child executor/,
+		);
+		assert.equal(starts, 0);
+	});
+
+	test("fails at the tool boundary when child spawning is unavailable", async () => {
+		const tool = buildAgentSwarmTool();
+
+		await assert.rejects(
+			Promise.resolve(tool.impl({ items: [swarmItem(0)] }, context())),
+			/spawnChildAgent capability is unavailable/,
+		);
+	});
+
+	test("preserves input order and successful refs across partial failure", async () => {
+		const clock = sequence([100, 180]);
+		const tool = buildAgentSwarmTool({ now: clock });
+		const gates = Array.from({ length: 3 }, () =>
+			deferred<SpawnChildAgentResult>(),
+		);
+		const started: number[] = [];
+		const completionOrder: number[] = [];
+		const pending = (async () =>
+			await tool.impl(
+				{
+					items: [swarmItem(0), swarmItem(1), swarmItem(2)],
+					max_concurrency: 3,
+				},
+				context({
+					spawnChildAgent: async (input) => {
+						const index = Number(input.prompt.slice("task-".length));
+						started.push(index);
+						await input.onReady?.({
+							turnId: `turn-${index}`,
+							agentId: input.spec.id,
+							agentName: input.spec.name,
+						});
+						const result = await gates[index]!.promise;
+						completionOrder.push(index);
+						return result;
+					},
+				}),
+			))();
+
+		await waitFor(() => started.length === 3);
+		gates[2]!.resolve(childResult(2));
+		await waitFor(() => completionOrder.length === 1);
+		gates[0]!.resolve(childResult(0));
+		await waitFor(() => completionOrder.length === 2);
+		gates[1]!.resolve(childResult(1, "failed"));
+
+		const result = await pending;
+		assert.deepEqual(completionOrder, [2, 0, 1]);
+		assert.equal(result.status, "partial");
+		assert.deepEqual(
+			result.items.map((item) => ({
+				itemId: item.itemId,
+				index: item.index,
+				runId: item.runId,
+				status: item.status,
+				summary: item.summary,
+			})),
+			[
+				{
+					itemId: "item-0",
+					index: 0,
+					runId: "run-0",
+					status: "completed",
+					summary: "summary-0",
+				},
+				{
+					itemId: "item-1",
+					index: 1,
+					runId: "run-1",
+					status: "failed",
+					summary: "summary-1",
+				},
+				{
+					itemId: "item-2",
+					index: 2,
+					runId: "run-2",
+					status: "completed",
+					summary: "summary-2",
+				},
+			],
+		);
+		assert.deepEqual(
+			result.items.map((item) => item.artifactIds),
+			[["artifact-0"], ["artifact-1"], ["artifact-2"]],
+		);
+		assert.deepEqual(
+			{
+				startedAt: result.startedAt,
+				completedAt: result.completedAt,
+				durationMs: result.durationMs,
+			},
+			{ startedAt: 100, completedAt: 180, durationMs: 80 },
+		);
+	});
+
+	test("isolates a thrown child startup while retaining successful siblings", async () => {
+		const tool = buildAgentSwarmTool();
+		const result = await tool.impl(
+			{
+				items: [swarmItem(0), swarmItem(1), swarmItem(2)],
+				max_concurrency: 2,
+			},
+			context({
+				spawnChildAgent: async (input) => {
+					const index = Number(input.prompt.slice("task-".length));
+					if (index === 1) throw new Error("provider startup failed");
+					await input.onReady?.({
+						turnId: `turn-${index}`,
+						agentId: input.spec.id,
+						agentName: input.spec.name,
+					});
+					return childResult(index);
+				},
+			}),
+		);
+
+		assert.equal(result.status, "partial");
+		assert.deepEqual(
+			result.items.map((item) => item.status),
+			["completed", "failed", "completed"],
+		);
+		assert.equal(result.items[1]?.started, false);
+		assert.match(result.items[1]?.summary ?? "", /provider startup failed/);
+		assert.equal(result.items[1]?.failureClass, "Error");
+	});
+
+	test("distinguishes active cancellation from items that never started", async () => {
+		const controller = new AbortController();
+		const tool = buildAgentSwarmTool();
+		const started: number[] = [];
+		const pending = invokeAgentSwarm(
+			tool,
+			{
+				items: [swarmItem(0), swarmItem(1), swarmItem(2), swarmItem(3)],
+				max_concurrency: 2,
+			},
+			context({
+				abortSignal: controller.signal,
+				spawnChildAgent: async (input) => {
+					const index = Number(input.prompt.slice("task-".length));
+					started.push(index);
+					await input.onReady?.({
+						turnId: `turn-${index}`,
+						agentId: input.spec.id,
+						agentName: input.spec.name,
+					});
+					await onceAborted(controller.signal);
+					return childResult(index, "cancelled");
+				},
+			}),
+		);
+
+		await waitFor(() => started.length === 2);
+		controller.abort(new Error("parent cancelled"));
+		const result = await withTimeout(
+			pending,
+			"cancelled AgentSwarm did not join active children",
+		);
+
+		assert.equal(result.status, "cancelled");
+		assert.deepEqual(started, [0, 1]);
+		assert.deepEqual(
+			result.items.map((item) => ({
+				started: item.started,
+				turnId: item.turnId,
+				runId: item.runId,
+				status: item.status,
+			})),
+			[
+				{
+					started: true,
+					turnId: "turn-0",
+					runId: "run-0",
+					status: "cancelled",
+				},
+				{
+					started: true,
+					turnId: "turn-1",
+					runId: "run-1",
+					status: "cancelled",
+				},
+				{
+					started: false,
+					turnId: undefined,
+					runId: undefined,
+					status: "cancelled",
+				},
+				{
+					started: false,
+					turnId: undefined,
+					runId: undefined,
+					status: "cancelled",
+				},
+			],
+		);
+	});
+
+	test("composes local width with the shared child-run permit pool", async () => {
+		const active = new Set<string>();
+		const started: string[] = [];
+		const releases = new Map<string, () => void>();
+		let maxActive = 0;
+		const runtime = buildRuntime(async (input) => {
+			started.push(input.prompt);
+			active.add(input.prompt);
+			maxActive = Math.max(maxActive, active.size);
+			await input.onReady?.({
+				turnId: `turn-${input.prompt}`,
+				agentId: input.spec.id,
+				agentName: input.spec.name,
+			});
+			return await new Promise((resolve) => {
+				releases.set(input.prompt, () => {
+					active.delete(input.prompt);
+					resolve(childResultForPrompt(input.prompt));
+				});
+			});
+		});
+		const single = executeTool(
+			runtime,
+			singleChildProbeTool(),
+			{},
+			new AbortController(),
+		);
+		await waitFor(() => started.length === 1);
+
+		const swarm = executeTool(
+			runtime,
+			{
+				...buildAgentSwarmTool(),
+				permissionRequired: false,
+			},
+			{
+				items: Array.from({ length: 5 }, (_, index) => swarmItem(index)),
+				max_concurrency: 5,
+			},
+			new AbortController(),
+		);
+		await waitFor(
+			() => started.length === MAX_ACTIVE_CHILD_AGENT_RUNS_PER_TURN,
+		);
+
+		assert.equal(maxActive, MAX_ACTIVE_CHILD_AGENT_RUNS_PER_TURN);
+		assert.equal(
+			started.filter((prompt) => prompt.startsWith("task-")).length,
+			MAX_ACTIVE_CHILD_AGENT_RUNS_PER_TURN - 1,
+		);
+
+		releases.get("single")?.();
+		await waitFor(() => started.length === 6);
+		assert.equal(maxActive, MAX_ACTIVE_CHILD_AGENT_RUNS_PER_TURN);
+
+		for (const release of releases.values()) release();
+		await Promise.all([single, swarm]);
+		assert.equal(active.size, 0);
+	});
+
+	test("persists partial as settled and cancellation as interrupted", async () => {
+		const events: Array<{
+			type: string;
+			toolUseId?: string;
+			isError?: boolean;
+		}> = [];
+		const runtime = buildRuntime(async (input) => {
+			const index = Number(input.prompt.slice("task-".length));
+			return childResult(index, index === 1 ? "failed" : "completed");
+		});
+		const swarmTool = {
+			...buildAgentSwarmTool(),
+			permissionRequired: false,
+		};
+		await executeTool(
+			runtime,
+			swarmTool,
+			{
+				items: [swarmItem(0), swarmItem(1)],
+				max_concurrency: 2,
+			},
+			new AbortController(),
+			events,
+			"tool-partial",
+		);
+
+		const cancelledController = new AbortController();
+		cancelledController.abort(new Error("stop before start"));
+		await executeTool(
+			runtime,
+			swarmTool,
+			{ items: [swarmItem(2)] },
+			cancelledController,
+			events,
+			"tool-cancelled",
+		);
+
+		assert.equal(
+			events.find(
+				(event) =>
+					event.type === "tool_result" && event.toolUseId === "tool-partial",
+			)?.isError,
+			false,
+		);
+		assert.equal(
+			events.find(
+				(event) =>
+					event.type === "tool_result" && event.toolUseId === "tool-cancelled",
+			)?.isError,
+			true,
+		);
+	});
+
+	test("child tool construction excludes agent_swarm", () => {
+		const tools = buildChildAgentTools([
+			...["Read", "Glob", "Grep", "WebSearch"].map((name) => ({
+				name,
+				description: name,
+				parameters: {},
+				permissionRequired: false,
+				categoryHint: "read" as const,
+				impl: async () => ({}),
+			})),
+			buildAgentSwarmTool(),
+		]);
+
+		assert.equal(
+			tools.some((tool) => tool.name === AGENT_SWARM_TOOL_NAME),
+			false,
+		);
+	});
+});
+
+function swarmItem(index: number): AgentSwarmToolInput["items"][number] {
+	return {
+		item_id: `item-${index}`,
+		profile: LOCAL_READ_AGENT_PROFILE,
+		task: `task-${index}`,
+		write_back: AGENT_WRITE_BACK_SUMMARY,
+		isolation: AGENT_WORKSPACE_SAME_WORKSPACE,
+	};
+}
+
+function childResult(
+	index: number,
+	status: SpawnChildAgentResult["status"] = "completed",
+): SpawnChildAgentResult {
+	return {
+		agentId: "local-read",
+		agentName: "Local Read",
+		turnId: `turn-${index}`,
+		runId: `run-${index}`,
+		status,
+		permissionMode: "explore",
+		summary: `summary-${index}`,
+		artifactIds: [`artifact-${index}`],
+		startedAt: index * 10,
+		completedAt: index * 10 + 5,
+		durationMs: 5,
+		eventCount: 1,
+		...(status === "failed" ? { failureClass: "ChildFailed" } : {}),
+	};
+}
+
+function childResultForPrompt(prompt: string): SpawnChildAgentResult {
+	const index = prompt === "single" ? 99 : Number(prompt.slice("task-".length));
+	return childResult(index);
+}
+
+function context(overrides: Partial<MakaToolContext> = {}): MakaToolContext {
+	return {
+		sessionId: "session-1",
+		turnId: "parent-turn",
+		cwd: "/tmp",
+		toolCallId: "tool-swarm",
+		abortSignal: new AbortController().signal,
+		emitOutput: () => {},
+		...overrides,
+	};
+}
+
+async function invokeAgentSwarm(
+	tool: ReturnType<typeof buildAgentSwarmTool>,
+	input: AgentSwarmToolInput,
+	ctx: MakaToolContext,
+): Promise<AgentSwarmToolResult> {
+	return await tool.impl(input, ctx);
+}
+
+function singleChildProbeTool(): MakaTool {
+	return {
+		name: "single_child_probe",
+		description: "test-only single child probe",
+		parameters: {},
+		permissionRequired: false,
+		categoryHint: "subagent",
+		impl: async (_input, ctx) => {
+			if (!ctx.spawnChildAgent) throw new Error("missing spawn capability");
+			return await ctx.spawnChildAgent({
+				spec: {
+					id: "local-read",
+					name: "Local Read",
+					systemPrompt: "Test.",
+				},
+				prompt: "single",
+			});
+		},
+	};
+}
+
+function buildRuntime(
+	spawnChildAgent: NonNullable<
+		ConstructorParameters<typeof ToolRuntime>[0]["spawnChildAgent"]
+	>,
+): ToolRuntime {
+	const permissionEngine = new PermissionEngine({
+		newId: nextId(),
+		now: () => 1,
+	});
+	permissionEngine.beginTurn("turn-1");
+	return new ToolRuntime({
+		sessionId: "session-1",
+		header: testHeader(),
+		connection: testConnection(),
+		modelId: "mock-model",
+		appendMessage: async () => {},
+		permissionEngine,
+		newId: nextId(),
+		now: () => 1,
+		getPermissionPauseTarget: () => null,
+		getCurrentRunId: () => "parent-run",
+		spawnChildAgent,
+	});
+}
+
+async function executeTool(
+	runtime: ToolRuntime,
+	tool: MakaTool,
+	input: unknown,
+	controller: AbortController,
+	events: Array<{
+		type: string;
+		toolUseId?: string;
+		isError?: boolean;
+	}> = [],
+	toolCallId = "tool-test",
+): Promise<unknown> {
+	return await runtime.wrapToolExecute(tool, "turn-1", {
+		push: (event) => events.push(event),
+	})(input, {
+		toolCallId,
+		abortSignal: controller.signal,
+	});
+}
+
+function testHeader(): SessionHeader {
+	return {
+		id: "session-1",
+		workspaceRoot: "/tmp",
+		cwd: "/tmp",
+		createdAt: 1,
+		lastUsedAt: 1,
+		name: "Test",
+		isFlagged: false,
+		labels: [],
+		isArchived: false,
+		status: "active",
+		statusUpdatedAt: 1,
+		hasUnread: false,
+		backend: "ai-sdk",
+		llmConnectionSlug: "anthropic-main",
+		connectionLocked: true,
+		model: "mock-model",
+		permissionMode: "execute",
+		schemaVersion: 1,
+	};
+}
+
+function testConnection(): LlmConnection {
+	return {
+		slug: "anthropic-main",
+		name: "Anthropic",
+		providerType: "anthropic",
+		defaultModel: "mock-model",
+		enabled: true,
+		createdAt: 1,
+		updatedAt: 1,
+	};
+}
+
+function nextId(): () => string {
+	let id = 0;
+	return () => `id-${++id}`;
+}
+
+interface Deferred<Value> {
+	readonly promise: Promise<Value>;
+	resolve(value: Value): void;
+}
+
+function deferred<Value>(): Deferred<Value> {
+	let resolvePromise: ((value: Value) => void) | undefined;
+	const promise = new Promise<Value>((resolve) => {
+		resolvePromise = resolve;
+	});
+	return {
+		promise,
+		resolve: (value) => resolvePromise!(value),
+	};
+}
+
+function sequence(values: readonly number[]): () => number {
+	let index = 0;
+	return () => values[Math.min(index++, values.length - 1)]!;
+}
+
+async function onceAborted(signal: AbortSignal): Promise<void> {
+	if (signal.aborted) return;
+	await new Promise<void>((resolve) => {
+		signal.addEventListener("abort", () => resolve(), { once: true });
+	});
+}
+
+async function waitFor(
+	predicate: () => boolean,
+	timeoutMs = 1_000,
+): Promise<void> {
+	const deadline = Date.now() + timeoutMs;
+	while (!predicate()) {
+		if (Date.now() >= deadline) {
+			throw new Error("Timed out waiting for condition");
+		}
+		await new Promise<void>((resolve) => setImmediate(resolve));
+	}
+}
+
+async function withTimeout<Value>(
+	promise: Promise<Value>,
+	message: string,
+	timeoutMs = 1_000,
+): Promise<Value> {
+	let timer: ReturnType<typeof setTimeout> | undefined;
+	try {
+		return await Promise.race([
+			promise,
+			new Promise<never>((_resolve, reject) => {
+				timer = setTimeout(() => reject(new Error(message)), timeoutMs);
+			}),
+		]);
+	} finally {
+		if (timer !== undefined) clearTimeout(timer);
+	}
+}

--- a/packages/runtime/src/agent-swarm-tools.ts
+++ b/packages/runtime/src/agent-swarm-tools.ts
@@ -1,0 +1,412 @@
+import { redactSecrets } from "@maka/core/redaction";
+import {
+	TASK_ID_MAX_CHARS,
+	isSafeTaskId,
+	type ToolResultContent,
+} from "@maka/core";
+import { z } from "zod";
+import {
+	AGENT_WORKSPACE_SAME_WORKSPACE,
+	AGENT_WORKSPACE_WORKTREE,
+	AGENT_WRITE_BACK_PATCH,
+	AGENT_WRITE_BACK_SUMMARY,
+	BUILTIN_AGENT_PROFILES,
+	requireBuiltinAgentDefinitionByProfile,
+	type AgentDefinition,
+} from "./agent-catalog.js";
+import { runBoundedSwarm, type SwarmItemResult } from "./bounded-swarm.js";
+import type { SpawnChildAgentResult } from "./session-manager.js";
+import type { MakaTool, MakaToolContext } from "./tool-runtime.js";
+
+export const AGENT_SWARM_TOOL_NAME = "agent_swarm";
+export const AGENT_SWARM_DEFAULT_CONCURRENCY = 3;
+export const AGENT_SWARM_MAX_CONCURRENCY = 5;
+export const AGENT_SWARM_MAX_ITEMS = 32;
+
+const AGENT_SWARM_WRITE_BACK_MODES = [
+	AGENT_WRITE_BACK_SUMMARY,
+	AGENT_WRITE_BACK_PATCH,
+] as const;
+const AGENT_SWARM_ISOLATION_MODES = [
+	AGENT_WORKSPACE_SAME_WORKSPACE,
+	AGENT_WORKSPACE_WORKTREE,
+] as const;
+const AGENT_SWARM_TASK_MAX_CHARS = 60_000;
+const AGENT_SWARM_ERROR_MAX_CHARS = 1_000;
+
+export interface AgentSwarmToolInput {
+	items: Array<{
+		item_id: string;
+		profile: string;
+		task: string;
+		write_back?: string;
+		isolation?: string;
+	}>;
+	max_concurrency?: number;
+}
+
+export type AgentSwarmToolResult = Extract<
+	ToolResultContent,
+	{ kind: "agent_swarm" }
+>;
+
+interface PreparedAgentSwarmItem {
+	readonly index: number;
+	readonly itemId: string;
+	readonly profile: string;
+	readonly task: string;
+	readonly definition: AgentDefinition;
+}
+
+interface StartedChildRef {
+	readonly turnId: string;
+	readonly agentId: string;
+	readonly agentName: string;
+}
+
+export function buildAgentSwarmTool(
+	deps: { now?: () => number } = {},
+): MakaTool<AgentSwarmToolInput, AgentSwarmToolResult> {
+	const now = deps.now ?? Date.now;
+	return {
+		name: AGENT_SWARM_TOOL_NAME,
+		displayName: "Agent Swarm",
+		description: [
+			"Run the same kind of bounded foreground child work over several independent items.",
+			"Use this only when every item can run independently. Results return in input order; you remain responsible for semantic synthesis.",
+		].join(" "),
+		parameters: agentSwarmInputSchema(),
+		permissionRequired: true,
+		categoryHint: "subagent",
+		impl: async (input, ctx) => {
+			const prepared = preflightAgentSwarmInput(input);
+			if (!ctx.spawnChildAgent) {
+				throw new Error(
+					"spawnChildAgent capability is unavailable in this runtime context",
+				);
+			}
+
+			const startedAt = now();
+			const readyRefs: Array<StartedChildRef | undefined> = Array.from({
+				length: prepared.items.length,
+			});
+			const childResults: Array<SpawnChildAgentResult | undefined> = Array.from(
+				{
+					length: prepared.items.length,
+				},
+			);
+			const rows = await runBoundedSwarm(
+				prepared.items,
+				async (item, { index }) => {
+					ctx.emitOutput(
+						"stdout",
+						`Agent swarm item ${item.itemId} started: ${item.definition.name}\n`,
+					);
+					try {
+						const result = (await ctx.spawnChildAgent!({
+							spec: {
+								id: item.definition.id,
+								name: item.definition.name,
+								systemPrompt: item.definition.systemPrompt,
+							},
+							prompt: item.task,
+							onReady: ({ turnId, agentId, agentName }) => {
+								readyRefs[index] = { turnId, agentId, agentName };
+							},
+						})) as SpawnChildAgentResult;
+						childResults[index] = result;
+						ctx.emitOutput(
+							result.status === "failed" ? "stderr" : "stdout",
+							`Agent swarm item ${item.itemId}: ${result.status}\n`,
+						);
+						return result;
+					} catch (error) {
+						ctx.emitOutput(
+							"stderr",
+							`Agent swarm item ${item.itemId} failed: ${boundedSwarmError(error)}\n`,
+						);
+						throw error;
+					}
+				},
+				{
+					maxConcurrency: prepared.maxConcurrency,
+					signal: ctx.abortSignal,
+				},
+			);
+
+			const items = rows.map((row, index) =>
+				mapAgentSwarmItem(
+					prepared.items[index]!,
+					row,
+					readyRefs[index],
+					childResults[index],
+				),
+			);
+			const completedAt = now();
+			const status = aggregateAgentSwarmStatus(items);
+			ctx.emitOutput("stdout", `Agent swarm: ${status}\n`);
+			return {
+				kind: "agent_swarm",
+				status,
+				items,
+				startedAt,
+				completedAt,
+				durationMs: Math.max(0, completedAt - startedAt),
+			};
+		},
+	};
+}
+
+function agentSwarmInputSchema() {
+	const itemSchema = z
+		.object({
+			item_id: z
+				.string()
+				.min(1)
+				.max(TASK_ID_MAX_CHARS)
+				.refine(isSafeTaskId)
+				.describe(
+					"Stable item id (letters, digits, dot, underscore, colon, or dash).",
+				),
+			profile: z.enum(BUILTIN_AGENT_PROFILES).describe("Child agent profile."),
+			task: z
+				.string()
+				.min(1)
+				.max(AGENT_SWARM_TASK_MAX_CHARS)
+				.describe("Bounded, self-contained task for this item."),
+			write_back: z
+				.enum(AGENT_SWARM_WRITE_BACK_MODES)
+				.optional()
+				.describe("Requested child write-back mode."),
+			isolation: z
+				.enum(AGENT_SWARM_ISOLATION_MODES)
+				.optional()
+				.describe("Requested child workspace isolation."),
+		})
+		.superRefine((input, ctx) => {
+			addAgentContractIssues(input, ctx);
+		});
+
+	return z.object({
+		items: z
+			.array(itemSchema)
+			.min(1)
+			.max(AGENT_SWARM_MAX_ITEMS)
+			.superRefine((items, ctx) => {
+				const seen = new Set<string>();
+				for (let index = 0; index < items.length; index += 1) {
+					const itemId = items[index]!.item_id;
+					if (seen.has(itemId)) {
+						ctx.addIssue({
+							code: z.ZodIssueCode.custom,
+							path: [index, "item_id"],
+							message: `Duplicate agent swarm item_id "${itemId}".`,
+						});
+					}
+					seen.add(itemId);
+				}
+			}),
+		max_concurrency: z
+			.number()
+			.int()
+			.min(1)
+			.max(AGENT_SWARM_MAX_CONCURRENCY)
+			.default(AGENT_SWARM_DEFAULT_CONCURRENCY)
+			.describe("Maximum number of child items active inside this batch."),
+	});
+}
+
+function addAgentContractIssues(
+	input: AgentSwarmToolInput["items"][number],
+	ctx: z.RefinementCtx,
+): void {
+	const definition = requireBuiltinAgentDefinitionByProfile(input.profile);
+	const writeBack = input.write_back ?? definition.contract.defaultWriteBack;
+	if (
+		!definition.contract.supportedWriteBack.some((mode) => mode === writeBack)
+	) {
+		ctx.addIssue({
+			code: z.ZodIssueCode.custom,
+			path: ["write_back"],
+			message: `Agent profile "${definition.profile}" does not support write_back "${writeBack}".`,
+		});
+	}
+	const isolation = input.isolation ?? definition.contract.workspace;
+	if (isolation !== definition.contract.workspace) {
+		ctx.addIssue({
+			code: z.ZodIssueCode.custom,
+			path: ["isolation"],
+			message: `Agent profile "${definition.profile}" requires isolation "${definition.contract.workspace}", not "${isolation}".`,
+		});
+	}
+}
+
+function preflightAgentSwarmInput(input: AgentSwarmToolInput): {
+	readonly items: readonly PreparedAgentSwarmItem[];
+	readonly maxConcurrency: number;
+} {
+	if (!Array.isArray(input.items) || input.items.length < 1) {
+		throw new Error("Agent swarm requires at least one item.");
+	}
+	if (input.items.length > AGENT_SWARM_MAX_ITEMS) {
+		throw new Error(
+			`Agent swarm supports at most ${AGENT_SWARM_MAX_ITEMS} items.`,
+		);
+	}
+	const maxConcurrency =
+		input.max_concurrency ?? AGENT_SWARM_DEFAULT_CONCURRENCY;
+	if (
+		!Number.isSafeInteger(maxConcurrency) ||
+		maxConcurrency < 1 ||
+		maxConcurrency > AGENT_SWARM_MAX_CONCURRENCY
+	) {
+		throw new Error(
+			`Agent swarm max_concurrency must be an integer from 1 to ${AGENT_SWARM_MAX_CONCURRENCY}.`,
+		);
+	}
+
+	const seen = new Set<string>();
+	const items = input.items.map((item, index): PreparedAgentSwarmItem => {
+		if (!isSafeTaskId(item.item_id)) {
+			throw new Error(`Agent swarm item ${index} has an invalid item_id.`);
+		}
+		if (seen.has(item.item_id)) {
+			throw new Error(`Duplicate agent swarm item_id "${item.item_id}".`);
+		}
+		seen.add(item.item_id);
+		if (
+			typeof item.task !== "string" ||
+			item.task.length < 1 ||
+			item.task.length > AGENT_SWARM_TASK_MAX_CHARS
+		) {
+			throw new Error(
+				`Agent swarm item "${item.item_id}" has an invalid task.`,
+			);
+		}
+
+		const definition = requireBuiltinAgentDefinitionByProfile(item.profile);
+		const writeBack = item.write_back ?? definition.contract.defaultWriteBack;
+		if (
+			!definition.contract.supportedWriteBack.some((mode) => mode === writeBack)
+		) {
+			throw new Error(
+				`Agent profile "${definition.profile}" does not support write_back "${writeBack}".`,
+			);
+		}
+		const isolation = item.isolation ?? definition.contract.workspace;
+		if (isolation !== definition.contract.workspace) {
+			throw new Error(
+				`Agent profile "${definition.profile}" requires isolation "${definition.contract.workspace}", not "${isolation}".`,
+			);
+		}
+		if (isolation !== AGENT_WORKSPACE_SAME_WORKSPACE) {
+			throw new Error(
+				`Agent profile "${definition.profile}" requires "${isolation}" workspace isolation, but this runtime does not provide a worktree child executor yet.`,
+			);
+		}
+
+		return {
+			index,
+			itemId: item.item_id,
+			profile: definition.profile,
+			task: item.task,
+			definition,
+		};
+	});
+	return { items, maxConcurrency };
+}
+
+function mapAgentSwarmItem(
+	item: PreparedAgentSwarmItem,
+	row: SwarmItemResult<SpawnChildAgentResult>,
+	ready: StartedChildRef | undefined,
+	observed: SpawnChildAgentResult | undefined,
+): AgentSwarmToolResult["items"][number] {
+	if (row.status === "fulfilled") {
+		return mapChildResult(
+			item,
+			row.value,
+			row.value.status === "cancelled"
+				? "cancelled"
+				: row.value.status === "completed"
+					? "completed"
+					: "failed",
+		);
+	}
+	if (row.status === "rejected") {
+		return {
+			itemId: item.itemId,
+			index: row.index,
+			profile: item.profile,
+			started: ready !== undefined,
+			...(ready ?? {}),
+			status: "failed",
+			summary: boundedSwarmError(row.reason),
+			artifactIds: [],
+			failureClass: boundedFailureClass(row.reason, "ChildAgentError"),
+		};
+	}
+	if (observed) {
+		return mapChildResult(item, observed, "cancelled");
+	}
+	return {
+		itemId: item.itemId,
+		index: row.index,
+		profile: item.profile,
+		started: ready !== undefined,
+		...(ready ?? {}),
+		status: "cancelled",
+		summary: ready
+			? "Child run was cancelled with its parent swarm."
+			: "Item was cancelled before its child run started.",
+		artifactIds: [],
+		failureClass: "ParentCancelled",
+	};
+}
+
+function mapChildResult(
+	item: PreparedAgentSwarmItem,
+	result: SpawnChildAgentResult,
+	status: AgentSwarmToolResult["items"][number]["status"],
+): AgentSwarmToolResult["items"][number] {
+	return {
+		itemId: item.itemId,
+		index: item.index,
+		profile: item.profile,
+		started: true,
+		agentId: result.agentId,
+		agentName: result.agentName,
+		turnId: result.turnId,
+		...(result.runId ? { runId: result.runId } : {}),
+		status,
+		summary: result.summary,
+		artifactIds: result.artifactIds,
+		startedAt: result.startedAt,
+		completedAt: result.completedAt,
+		durationMs: result.durationMs,
+		...(result.failureClass ? { failureClass: result.failureClass } : {}),
+	};
+}
+
+function aggregateAgentSwarmStatus(
+	items: AgentSwarmToolResult["items"],
+): AgentSwarmToolResult["status"] {
+	if (items.some((item) => item.status === "cancelled")) return "cancelled";
+	if (items.every((item) => item.status === "completed")) return "completed";
+	return "partial";
+}
+
+function boundedSwarmError(error: unknown): string {
+	const message = redactSecrets(
+		error instanceof Error ? error.message : String(error ?? "unknown error"),
+	);
+	return message.length <= AGENT_SWARM_ERROR_MAX_CHARS
+		? message
+		: `${message.slice(0, AGENT_SWARM_ERROR_MAX_CHARS - 1)}…`;
+}
+
+function boundedFailureClass(error: unknown, fallback: string): string {
+	const value =
+		error instanceof Error && error.name.trim() ? error.name : fallback;
+	return boundedSwarmError(value);
+}

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -416,6 +416,17 @@ export type {
   AgentWriteBackMode,
 } from './agent-catalog.js';
 export {
+  AGENT_SWARM_DEFAULT_CONCURRENCY,
+  AGENT_SWARM_MAX_CONCURRENCY,
+  AGENT_SWARM_MAX_ITEMS,
+  AGENT_SWARM_TOOL_NAME,
+  buildAgentSwarmTool,
+} from './agent-swarm-tools.js';
+export type {
+  AgentSwarmToolInput,
+  AgentSwarmToolResult,
+} from './agent-swarm-tools.js';
+export {
   AGENT_LIST_TOOL_NAME,
   AGENT_OUTPUT_TOOL_NAME,
   AGENT_SPAWN_TOOL_NAME,

--- a/packages/runtime/src/tool-runtime.ts
+++ b/packages/runtime/src/tool-runtime.ts
@@ -1839,6 +1839,9 @@ function deriveToolResultStatus(
     if (content.status === 'cancelled') return 'aborted';
     return 'error';
   }
+  if (content.kind === 'agent_swarm') {
+    return content.status === 'cancelled' ? 'aborted' : 'success';
+  }
   if (content.kind === 'rive_workflow' && content.ok === false) return 'error';
   if (content.kind === 'web_search_error') return 'error';
   if (content.kind === 'office_document' && content.ok === false) {


### PR DESCRIPTION
## Summary

- add the provider-facing agent_swarm schema and exact structured result contract
- compose the merged bounded Swarm kernel with the shared spawnChildAgent permit boundary
- preflight every item before execution, preserve stable result order and child refs, isolate failures, and distinguish active from queued cancellation
- keep child toolsets non-recursive and leave desktop, headless, and CLI registration to PR 4

Part of #1192. Depends on the merged PRs #1196 and #1200.

## Validation

- npm run build:test
- npm run typecheck
- npm test --workspace @maka/core (1076 passed)
- npm test --workspace maka-agent (576 passed)
- targeted AgentSwarm runtime tests (9 passed)
- targeted Core result-contract tests (3 passed)
- Biome lint on all changed files

Runtime full-suite note: 2136 tests passed and one existing machine-specific assertion failed because the macOS sandbox test expects /usr/local to be present as an executable root. The AgentSwarm suite passed 9/9 in the same run.