### PR TITLE
feat(runtime): expose AgentSwarm across hosts

### DIFF
--- a/apps/desktop/src/main/__tests__/agent-swarm-host-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/agent-swarm-host-contract.test.ts
@@ -1,0 +1,43 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+import { describe, test } from 'node:test';
+
+const REPO_ROOT = resolve(import.meta.dirname, '../../../../../');
+
+describe('AgentSwarm host registration contract', () => {
+  test('desktop, CLI, and headless use the same parent Agent tool builder', async () => {
+    const [desktop, cli, headless] = await Promise.all([
+      readFile(resolve(REPO_ROOT, 'apps/desktop/src/main/main.ts'), 'utf8'),
+      readFile(resolve(REPO_ROOT, 'packages/cli/src/runtime-bootstrap.ts'), 'utf8'),
+      readFile(resolve(REPO_ROOT, 'packages/headless/src/tools.ts'), 'utf8'),
+    ]);
+
+    assert.match(
+      desktop,
+      /buildParentAgentTools\(\{\s*taskLedger: taskLedgerStore,\s*\}\)/,
+    );
+    assert.match(cli, /const subagentTools = input\.surface === 'tui'\s*\?\s*buildParentAgentTools\(\)/);
+    assert.match(headless, /\.\.\.buildParentAgentTools\(\)/);
+
+    for (const source of [desktop, cli, headless]) {
+      assert.doesNotMatch(
+        source,
+        /buildAgentSwarmTool\(/,
+        'hosts must consume the shared parent tool surface instead of forking AgentSwarm',
+      );
+    }
+  });
+
+  test('all hosts use the shared deferred Agent group contract', async () => {
+    const [desktop, cli, headless] = await Promise.all([
+      readFile(resolve(REPO_ROOT, 'apps/desktop/src/main/main.ts'), 'utf8'),
+      readFile(resolve(REPO_ROOT, 'packages/cli/src/runtime-bootstrap.ts'), 'utf8'),
+      readFile(resolve(REPO_ROOT, 'packages/headless/src/tools.ts'), 'utf8'),
+    ]);
+
+    assert.match(desktop, /buildSubagentToolGroup\(\)/);
+    assert.match(cli, /groups: \[buildSubagentToolGroup\(\)\]/);
+    assert.match(headless, /groups: \[buildSubagentToolGroup\(\)\]/);
+  });
+});

--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -54,8 +54,7 @@ import {
   buildAgentTeamChildTools,
   buildAgentTeamLeadTools,
   buildExpertDispatchToolForTeamId,
-  buildSubagentProjectionTools,
-  buildSubagentSpawnTool,
+  buildParentAgentTools,
   buildSubagentToolGroup,
   getAIModel,
   buildProviderOptions,
@@ -687,10 +686,9 @@ const computerUseTools = applyComputerUseRealModelPolicy(
       )
     : undefined,
 );
-const agentTools: MakaTool[] = [
-  buildSubagentSpawnTool({ taskLedger: taskLedgerStore }),
-  ...buildSubagentProjectionTools(),
-];
+const agentTools: MakaTool[] = buildParentAgentTools({
+  taskLedger: taskLedgerStore,
+});
 const agentTeamLeadTools = buildAgentTeamLeadTools({
   mailbox: agentMailboxStore,
   taskLedger: taskLedgerStore,

--- a/packages/cli/src/__tests__/pi-transcript-format.test.ts
+++ b/packages/cli/src/__tests__/pi-transcript-format.test.ts
@@ -2,7 +2,7 @@ import assert from 'node:assert/strict';
 import { test } from 'node:test';
 import { formatToolResultContent } from '../pi-transcript-format.js';
 
-test('keeps the pre-exposure agent swarm fallback bounded', () => {
+test('formats an agent swarm without exposing internal child references', () => {
   const output = formatToolResultContent({
     kind: 'agent_swarm',
     status: 'partial',
@@ -35,9 +35,40 @@ test('keeps the pre-exposure agent swarm fallback bounded', () => {
     durationMs: 10,
   });
 
-  assert.equal(output, 'Agent swarm: partial');
+  assert.equal(
+    output,
+    [
+      'Agent swarm: partial',
+      'auth: completed\nAuth boundaries are documented.',
+      'storage: failed\nStorage inspection failed.',
+    ].join('\n\n'),
+  );
   assert.doesNotMatch(
     output,
-    /auth|storage|turn-auth|run-auth|artifact-auth|local-read/,
+    /turn-auth|run-auth|artifact-auth|local-read/,
   );
+});
+
+test('bounds individual and aggregate agent swarm text', () => {
+  const output = formatToolResultContent({
+    kind: 'agent_swarm',
+    status: 'completed',
+    items: Array.from({ length: 32 }, (_, index) => ({
+      itemId: `item-${index}`,
+      index,
+      profile: 'local_read',
+      started: true,
+      status: 'completed' as const,
+      summary: 'x'.repeat(2_000),
+      artifactIds: [],
+    })),
+    startedAt: 10,
+    completedAt: 20,
+    durationMs: 10,
+  });
+
+  assert.ok(output.length < 16_100);
+  assert.match(output, /chars truncated/);
+  assert.match(output, /item-0: completed/);
+  assert.doesNotMatch(output, /item-31: completed/);
 });

--- a/packages/cli/src/__tests__/runtime-bootstrap.test.ts
+++ b/packages/cli/src/__tests__/runtime-bootstrap.test.ts
@@ -15,6 +15,7 @@ import {
   AGENT_LIST_TOOL_NAME,
   AGENT_OUTPUT_TOOL_NAME,
   AGENT_SPAWN_TOOL_NAME,
+  AGENT_SWARM_TOOL_NAME,
   AGENT_TOOL_GROUP_ID,
   GOAL_CLEAR_TOOL_NAME,
   GOAL_PAUSE_TOOL_NAME,
@@ -302,13 +303,25 @@ describe('Maka CLI runtime bootstrap', () => {
           groups: [{
             id: AGENT_TOOL_GROUP_ID,
             label: 'Agent',
-            description: 'Spawn and inspect foreground child agents.',
-            toolNames: [AGENT_SPAWN_TOOL_NAME, AGENT_LIST_TOOL_NAME, AGENT_OUTPUT_TOOL_NAME],
+            description: 'Spawn, fan out, and inspect foreground child agents.',
+            toolNames: [
+              AGENT_SPAWN_TOOL_NAME,
+              AGENT_SWARM_TOOL_NAME,
+              AGENT_LIST_TOOL_NAME,
+              AGENT_OUTPUT_TOOL_NAME,
+            ],
           }],
         });
         assert.deepEqual(runtimeDeps.childTools?.map((tool) => tool.name), ['Read', 'Glob', 'Grep']);
-        assert.equal(runtimeDeps.childTools?.some((tool) => ['Bash', 'Write', 'Edit', AGENT_SPAWN_TOOL_NAME].includes(tool.name)), false);
+        assert.equal(
+          runtimeDeps.childTools?.some((tool) =>
+            ['Bash', 'Write', 'Edit', AGENT_SPAWN_TOOL_NAME, AGENT_SWARM_TOOL_NAME]
+              .includes(tool.name)
+          ),
+          false,
+        );
         assert.equal(context.skills.host.toolNames.has(AGENT_SPAWN_TOOL_NAME), true);
+        assert.equal(context.skills.host.toolNames.has(AGENT_SWARM_TOOL_NAME), true);
       } finally {
         await context.close();
       }

--- a/packages/cli/src/pi-transcript-format.ts
+++ b/packages/cli/src/pi-transcript-format.ts
@@ -70,7 +70,12 @@ export function formatToolResultContent(content: ToolResultContent): string {
     case 'subagent':
       return content.summary;
     case 'agent_swarm':
-      return `Agent swarm: ${content.status}`;
+      return limitText([
+        `Agent swarm: ${content.status}`,
+        ...content.items.map(
+          (item) => `${item.itemId}: ${item.status}\n${limitText(item.summary, 1_000)}`,
+        ),
+      ].join('\n\n'), 16_000);
     case 'rive_workflow':
       return content.summary;
     case 'archived_tool_result':

--- a/packages/cli/src/runtime-bootstrap.ts
+++ b/packages/cli/src/runtime-bootstrap.ts
@@ -24,8 +24,7 @@ import {
   buildDefaultContextBudgetPolicy,
   buildSkillAgentTool,
   buildGoalTools,
-  buildSubagentProjectionTools,
-  buildSubagentSpawnTool,
+  buildParentAgentTools,
   buildSubagentToolGroup,
   buildLlmHistorySummarizer,
   cleanupLegacyHistoryCompactArtifacts,
@@ -446,7 +445,7 @@ export async function createMakaCliRuntimeContext(
       })
     : [];
   const subagentTools = input.surface === 'tui'
-    ? [buildSubagentSpawnTool(), ...buildSubagentProjectionTools()]
+    ? buildParentAgentTools()
     : [];
   const toolAvailability: ToolAvailabilityConfig | undefined = input.surface === 'tui'
     ? {

--- a/packages/headless/src/__tests__/runner.test.ts
+++ b/packages/headless/src/__tests__/runner.test.ts
@@ -341,6 +341,14 @@ describe('fail-closed (a model-backed backend does not run without isolation)', 
       assert.equal(contexts[0]?.realBackendIsolation?.label, 'unit-test isolated backend');
       assert.equal(contexts[0]?.config.id, 'real-cfg');
       assert.equal(contexts[0]?.task.id, 'real-task');
+      assert.equal(typeof contexts[0]?.spawnChildAgent, 'function');
+      assert.equal(typeof contexts[0]?.listChildAgents, 'function');
+      assert.equal(typeof contexts[0]?.readChildAgentOutput, 'function');
+      assert.ok(
+        Array.isArray(
+          (await contexts[0]!.listChildAgents!(result.sessionId)).definitions,
+        ),
+      );
     });
   });
 

--- a/packages/headless/src/__tests__/tools.test.ts
+++ b/packages/headless/src/__tests__/tools.test.ts
@@ -7,6 +7,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { promisify } from 'node:util';
 import {
+  AGENT_SWARM_TOOL_NAME,
   buildChildAgentTools,
   LOAD_TOOLS_NAME,
   ToolAvailabilityRuntime,
@@ -239,6 +240,7 @@ describe('isolated headless tools', () => {
     assert.ok(names.includes('Read'));
     assert.ok(names.includes('Write'));
     assert.ok(names.includes('agent_spawn'));
+    assert.ok(names.includes(AGENT_SWARM_TOOL_NAME));
     assert.ok(names.includes('agent_list'));
     assert.ok(names.includes('agent_output'));
     assert.ok(!names.includes('inventory_submit'));
@@ -1280,6 +1282,7 @@ describe('isolated headless tools', () => {
     assert.ok(plan.activeTools.includes('Read'));
     assert.ok(plan.activeTools.includes(LOAD_TOOLS_NAME));
     assert.ok(!plan.activeTools.includes('agent_spawn'));
+    assert.ok(!plan.activeTools.includes(AGENT_SWARM_TOOL_NAME));
     assert.ok(!plan.activeTools.includes('agent_list'));
     assert.ok(!plan.activeTools.includes('agent_output'));
 
@@ -1287,6 +1290,7 @@ describe('isolated headless tools', () => {
       steps: [{ toolCalls: [{ toolName: LOAD_TOOLS_NAME, input: { group: 'agent' } }] }],
     }).activeTools;
     assert.ok(loaded.includes('agent_spawn'));
+    assert.ok(loaded.includes(AGENT_SWARM_TOOL_NAME));
     assert.ok(loaded.includes('agent_list'));
     assert.ok(loaded.includes('agent_output'));
   });
@@ -1308,6 +1312,7 @@ describe('isolated headless tools', () => {
     assert.equal(plan.prepareStep, undefined);
     assert.ok(!plan.activeTools.includes(LOAD_TOOLS_NAME));
     assert.ok(!plan.activeTools.includes('agent_spawn'));
+    assert.ok(!plan.activeTools.includes(AGENT_SWARM_TOOL_NAME));
   });
 
   test('README real-backend sketch preserves child tool overrides', async () => {

--- a/packages/headless/src/harbor-cell.ts
+++ b/packages/headless/src/harbor-cell.ts
@@ -13,6 +13,7 @@ import {
   PermissionEngine,
   PiAgentBackend,
   SessionManager,
+  buildChildAgentTools,
   buildProviderOptions,
   buildSubscriptionModelFetch,
   getAIModel,
@@ -46,7 +47,11 @@ import { validateRealBackendIsolation } from './isolation.js';
 import { PiCliJsonTransport } from './pi-cli-json-transport.js';
 import { providerFromEnv, resolveHarborCellAiSdkEnv } from './provider-env.js';
 import { backendNeedsIsolation } from './runner.js';
-import { buildIsolatedHeadlessToolAvailability } from './tools.js';
+import {
+  buildIsolatedHeadlessToolAvailability,
+  buildIsolatedHeadlessTools,
+} from './tools.js';
+import { createHeadlessSessionCapabilityBridge } from './session-capabilities.js';
 import {
   createInMemoryTaskLedgerExperimentStore,
   renderTaskLedgerExperimentReplay,
@@ -220,6 +225,7 @@ export async function runHarborCell(input: RunHarborCellInput): Promise<RunHarbo
   const agentRunStore = createAgentRunStore(input.storageRoot);
   const runtimeEventStore = createRuntimeEventStore(input.storageRoot);
   const backends = new BackendRegistry();
+  const sessionCapabilities = createHeadlessSessionCapabilityBridge();
   const task: Task = {
     id: 'harbor-cell',
     instruction: input.instruction,
@@ -234,6 +240,7 @@ export async function runHarborCell(input: RunHarborCellInput): Promise<RunHarbo
     config,
     task,
     workspaceDir: input.cwd,
+    ...sessionCapabilities.capabilities,
     ...(backendNeedsIsolation(input.config.backend)
       ? { realBackendIsolation: input.realBackendIsolation, toolExecutor: input.realBackendIsolation?.toolExecutor }
       : {}),
@@ -259,6 +266,13 @@ export async function runHarborCell(input: RunHarborCellInput): Promise<RunHarbo
     runStore: agentRunStore,
     runtimeEventStore,
     backends,
+    ...(input.realBackendIsolation?.toolExecutor
+      ? {
+          childTools: buildChildAgentTools(
+            buildIsolatedHeadlessTools(input.realBackendIsolation.toolExecutor),
+          ),
+        }
+      : {}),
     newId,
     now,
     runtimeSource: 'test',
@@ -266,6 +280,7 @@ export async function runHarborCell(input: RunHarborCellInput): Promise<RunHarbo
       invocation = result;
     },
   });
+  sessionCapabilities.bind(manager);
 
   const session = await manager.createSession({
     cwd: input.cwd,
@@ -675,6 +690,16 @@ export function buildAiSdkCellBackendRegistration(input: {
             : {}),
         }),
         toolAvailability: buildIsolatedHeadlessToolAvailability(),
+        spawnChildAgent: context.spawnChildAgent
+          ? (childInput) => context.spawnChildAgent!(ctx.sessionId, childInput)
+          : undefined,
+        listChildAgents: context.listChildAgents
+          ? () => context.listChildAgents!(ctx.sessionId)
+          : undefined,
+        readChildAgentOutput: context.readChildAgentOutput
+          ? (childInput) =>
+              context.readChildAgentOutput!(ctx.sessionId, childInput)
+          : undefined,
         providerOptions: buildProviderOptions(connection, input.model, ctx.header.thinkingLevel),
         systemPrompt: harborCellSystemPrompt(context.config.systemPrompt),
         ...(taskLedgerExperimentStore && taskLedgerExperimentPolicy

--- a/packages/headless/src/index.ts
+++ b/packages/headless/src/index.ts
@@ -401,6 +401,7 @@ export type {
   IsolatedWriteFileResult,
   RealBackendIsolation,
 } from './isolation.js';
+export type { HeadlessSessionCapabilities } from './session-capabilities.js';
 export {
   ISOLATED_HEADLESS_TOOL_NAMES,
 } from './isolation.js';

--- a/packages/headless/src/isolation.ts
+++ b/packages/headless/src/isolation.ts
@@ -9,6 +9,7 @@ import type {
   TaskIsolationFacts,
   ToolExecutorIdentity,
 } from './task-contracts.js';
+import type { HeadlessSessionCapabilities } from './session-capabilities.js';
 
 export interface IsolatedCommandInput {
   command: string;
@@ -162,7 +163,8 @@ export interface ExternalRealBackendIsolation {
 
 export type RealBackendIsolation = ExternalRealBackendIsolation;
 
-export interface HeadlessBackendContext {
+export interface HeadlessBackendContext
+  extends Partial<HeadlessSessionCapabilities> {
   config: Config;
   task: Task;
   /** Absolute throwaway workspace path for this run. */

--- a/packages/headless/src/runner.ts
+++ b/packages/headless/src/runner.ts
@@ -20,6 +20,7 @@ import { defaultFinalScorer } from './scorer.js';
 import { buildIsolatedHeadlessTools } from './tools.js';
 import { normalizeVerifier, runVerifier, verifierProtectedPaths } from './verifier.js';
 import type { BenchmarkAdapterRegistry } from './benchmark-adapters.js';
+import { createHeadlessSessionCapabilityBridge } from './session-capabilities.js';
 
 export interface RunExperimentDeps {
   /**
@@ -99,12 +100,14 @@ export async function runExperiment(
     const agentWorkspaceDir = deps.realBackendIsolation?.workspaceDir ?? workspace.dir;
     const verifier = normalizeVerifier(task);
     const backends = new BackendRegistry();
+    const sessionCapabilities = createHeadlessSessionCapabilityBridge();
     const registerBackends: NonNullable<RunExperimentDeps['registerBackends']> =
       deps.registerBackends ?? ((registry) => registerFakeBackend(registry));
     await registerBackends(backends, {
       config,
       task,
       workspaceDir: agentWorkspaceDir,
+      ...sessionCapabilities.capabilities,
       ...(backendNeedsIsolation(config.backend)
         ? { realBackendIsolation: deps.realBackendIsolation, toolExecutor: deps.realBackendIsolation?.toolExecutor }
         : {}),
@@ -126,6 +129,7 @@ export async function runExperiment(
         invocation = result;
       },
     });
+    sessionCapabilities.bind(manager);
 
     const session = await manager.createSession({
       cwd: agentWorkspaceDir,

--- a/packages/headless/src/session-capabilities.ts
+++ b/packages/headless/src/session-capabilities.ts
@@ -1,0 +1,51 @@
+import type {
+  AgentListResult,
+  AgentOutputInput,
+  AgentOutputResult,
+  SessionManager,
+  SpawnChildAgentInput,
+  SpawnChildAgentResult,
+} from '@maka/runtime';
+
+export interface HeadlessSessionCapabilities {
+  spawnChildAgent(
+    sessionId: string,
+    input: SpawnChildAgentInput,
+  ): Promise<SpawnChildAgentResult>;
+  listChildAgents(sessionId: string): Promise<AgentListResult>;
+  readChildAgentOutput(
+    sessionId: string,
+    input: AgentOutputInput,
+  ): Promise<AgentOutputResult>;
+}
+
+export function createHeadlessSessionCapabilityBridge(): {
+  capabilities: HeadlessSessionCapabilities;
+  bind(manager: SessionManager): void;
+} {
+  let manager: SessionManager | undefined;
+  const requireManager = (): SessionManager => {
+    if (!manager) {
+      throw new Error(
+        'Headless session capabilities are unavailable during backend registration',
+      );
+    }
+    return manager;
+  };
+  return {
+    capabilities: {
+      spawnChildAgent: async (sessionId, input) =>
+        await requireManager().spawnChildAgent(sessionId, input),
+      listChildAgents: async (sessionId) =>
+        await requireManager().listChildAgents(sessionId),
+      readChildAgentOutput: async (sessionId, input) =>
+        await requireManager().readChildAgentOutput(sessionId, input),
+    },
+    bind(nextManager) {
+      if (manager) {
+        throw new Error('Headless session capabilities are already bound');
+      }
+      manager = nextManager;
+    },
+  };
+}

--- a/packages/headless/src/tools.ts
+++ b/packages/headless/src/tools.ts
@@ -2,8 +2,8 @@ import type { MakaTool, ToolAvailabilityConfig } from '@maka/runtime';
 import {
   bashToolShellGuidance,
   buildForegroundBashTool,
-  buildSubagentProjectionTools,
-  buildSubagentSpawnTool,
+  buildParentAgentTools,
+  buildSubagentToolGroup,
   computeEditedSource,
 } from '@maka/runtime';
 import { withFileWriteLock } from '@maka/runtime/file-write-lock';
@@ -57,8 +57,7 @@ export function buildIsolatedHeadlessTools(
     buildIsolatedEditTool(executor, options),
     buildIsolatedGlobTool(executor, options),
     buildIsolatedGrepTool(executor, options),
-    buildSubagentSpawnTool(),
-    ...buildSubagentProjectionTools(),
+    ...buildParentAgentTools(),
   ];
   if (options.heavyTaskProgress) {
     tools.push(...buildHeavyTaskProgressTools(options.heavyTaskProgress));
@@ -75,12 +74,7 @@ export function buildIsolatedHeadlessTools(
 export function buildIsolatedHeadlessToolAvailability(): ToolAvailabilityConfig {
   return {
     economy: true,
-    groups: [{
-      id: 'agent',
-      label: 'Agent',
-      description: 'Spawn and inspect foreground child agents.',
-      toolNames: ['agent_spawn', 'agent_list', 'agent_output'],
-    }],
+    groups: [buildSubagentToolGroup()],
   };
 }
 

--- a/packages/runtime/src/__tests__/agent-swarm-tools.test.ts
+++ b/packages/runtime/src/__tests__/agent-swarm-tools.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { describe, test } from "node:test";
-import type { LlmConnection, SessionHeader } from "@maka/core";
+import type { LlmConnection, SessionEvent, SessionHeader } from "@maka/core";
 import {
 	AGENT_SWARM_DEFAULT_CONCURRENCY,
 	AGENT_SWARM_MAX_CONCURRENCY,
@@ -29,7 +29,7 @@ import {
 } from "../tool-runtime.js";
 
 describe("AgentSwarm adapter", () => {
-	test("declares a bounded schema and reserves the name without host registration", () => {
+	test("declares a bounded schema and joins the deferred parent Agent group", () => {
 		const tool = buildAgentSwarmTool();
 		const schema = tool.parameters as {
 			safeParse(input: unknown): {
@@ -43,7 +43,7 @@ describe("AgentSwarm adapter", () => {
 		assert.equal(tool.categoryHint, "subagent");
 		assert.equal(
 			([...AGENT_TOOL_NAMES] as string[]).includes(AGENT_SWARM_TOOL_NAME),
-			false,
+			true,
 		);
 		assert.deepEqual(
 			schema.safeParse({
@@ -401,11 +401,7 @@ describe("AgentSwarm adapter", () => {
 	});
 
 	test("persists partial as settled and cancellation as interrupted", async () => {
-		const events: Array<{
-			type: string;
-			toolUseId?: string;
-			isError?: boolean;
-		}> = [];
+		const events: SessionEvent[] = [];
 		const runtime = buildRuntime(async (input) => {
 			const index = Number(input.prompt.slice("task-".length));
 			return childResult(index, index === 1 ? "failed" : "completed");
@@ -439,18 +435,62 @@ describe("AgentSwarm adapter", () => {
 
 		assert.equal(
 			events.find(
-				(event) =>
+				(
+					event,
+				): event is Extract<SessionEvent, { type: "tool_result" }> =>
 					event.type === "tool_result" && event.toolUseId === "tool-partial",
 			)?.isError,
 			false,
 		);
 		assert.equal(
 			events.find(
-				(event) =>
+				(
+					event,
+				): event is Extract<SessionEvent, { type: "tool_result" }> =>
 					event.type === "tool_result" && event.toolUseId === "tool-cancelled",
 			)?.isError,
 			true,
 		);
+	});
+
+	test("one denied parent permission starts zero children", async () => {
+		const events: SessionEvent[] = [];
+		let starts = 0;
+		const permissionEngine = new PermissionEngine({
+			newId: nextId(),
+			now: () => 1,
+		});
+		const runtime = buildRuntime(
+			async () => {
+				starts += 1;
+				return childResult(0);
+			},
+			{ permissionEngine, permissionMode: "ask" },
+		);
+		const pending = executeTool(
+			runtime,
+			buildAgentSwarmTool(),
+			{ items: [swarmItem(0), swarmItem(1)] },
+			new AbortController(),
+			events,
+			"tool-denied",
+		);
+
+		await waitFor(() =>
+			events.some((event) => event.type === "permission_request"),
+		);
+		const requests = events.filter(
+			(event): event is Extract<SessionEvent, { type: "permission_request" }> =>
+				event.type === "permission_request",
+		);
+		assert.equal(requests.length, 1);
+		permissionEngine.recordResponse("turn-1", {
+			requestId: requests[0]!.requestId,
+			decision: "deny",
+		});
+
+		assert.deepEqual(await pending, { error: "用户已拒绝权限请求" });
+		assert.equal(starts, 0);
 	});
 
 	test("child tool construction excludes agent_swarm", () => {
@@ -554,15 +594,21 @@ function buildRuntime(
 	spawnChildAgent: NonNullable<
 		ConstructorParameters<typeof ToolRuntime>[0]["spawnChildAgent"]
 	>,
+	options: {
+		permissionEngine?: PermissionEngine;
+		permissionMode?: SessionHeader["permissionMode"];
+	} = {},
 ): ToolRuntime {
-	const permissionEngine = new PermissionEngine({
-		newId: nextId(),
-		now: () => 1,
-	});
+	const permissionEngine =
+		options.permissionEngine ??
+		new PermissionEngine({
+			newId: nextId(),
+			now: () => 1,
+		});
 	permissionEngine.beginTurn("turn-1");
 	return new ToolRuntime({
 		sessionId: "session-1",
-		header: testHeader(),
+		header: testHeader(options.permissionMode),
 		connection: testConnection(),
 		modelId: "mock-model",
 		appendMessage: async () => {},
@@ -580,11 +626,7 @@ async function executeTool(
 	tool: MakaTool,
 	input: unknown,
 	controller: AbortController,
-	events: Array<{
-		type: string;
-		toolUseId?: string;
-		isError?: boolean;
-	}> = [],
+	events: SessionEvent[] = [],
 	toolCallId = "tool-test",
 ): Promise<unknown> {
 	return await runtime.wrapToolExecute(tool, "turn-1", {
@@ -595,7 +637,9 @@ async function executeTool(
 	});
 }
 
-function testHeader(): SessionHeader {
+function testHeader(
+	permissionMode: SessionHeader["permissionMode"] = "execute",
+): SessionHeader {
 	return {
 		id: "session-1",
 		workspaceRoot: "/tmp",
@@ -613,7 +657,7 @@ function testHeader(): SessionHeader {
 		llmConnectionSlug: "anthropic-main",
 		connectionLocked: true,
 		model: "mock-model",
-		permissionMode: "execute",
+		permissionMode,
 		schemaVersion: 1,
 	};
 }

--- a/packages/runtime/src/__tests__/deferred-tools-backend.test.ts
+++ b/packages/runtime/src/__tests__/deferred-tools-backend.test.ts
@@ -17,12 +17,12 @@ import {
 } from '../tool-availability.js';
 import { toolSchemaCharsForDiagnostics } from '../request-shape.js';
 import { LOCAL_READ_AGENT_ID, LOCAL_READ_AGENT_PROFILE } from '../agent-catalog.js';
+import { AGENT_SWARM_TOOL_NAME } from '../agent-swarm-tools.js';
 import {
   AGENT_LIST_TOOL_NAME,
   AGENT_OUTPUT_TOOL_NAME,
   AGENT_SPAWN_TOOL_NAME,
-  buildSubagentProjectionTools,
-  buildSubagentSpawnTool,
+  buildParentAgentTools,
   buildSubagentToolGroup,
 } from '../subagent-tools.js';
 
@@ -100,18 +100,16 @@ function agentBackend(
     modelId: 'mock-model-id',
     permissionEngine: new PermissionEngine({ newId: () => 'perm', now: () => 1 }),
     modelFactory: () => model,
-    tools: [
-      buildSubagentSpawnTool(),
-      ...buildSubagentProjectionTools(),
-    ],
+    tools: buildParentAgentTools(),
     ...(resolved ? { toolAvailability: resolved } : {}),
     spawnChildAgent: async (input) => {
+      const childIndex = spawnCalls.length;
       spawnCalls.push(input);
       return {
         agentId: input.spec.id,
         agentName: input.spec.name,
-        runId: 'child-run',
-        turnId: 'child-turn',
+        runId: `child-run-${childIndex}`,
+        turnId: `child-turn-${childIndex}`,
         status: 'completed',
         permissionMode: 'explore',
         summary: 'done',
@@ -275,10 +273,12 @@ describe('AiSdkBackend deferred agent tools', () => {
 
     assert.ok(captured[0].includes(LOAD_TOOLS_NAME), 'load_tools advertised');
     assert.ok(!captured[0].includes(AGENT_SPAWN_TOOL_NAME), 'agent_spawn hidden at step 0');
+    assert.ok(!captured[0].includes(AGENT_SWARM_TOOL_NAME), 'agent_swarm hidden at step 0');
     assert.ok(!captured[0].includes(AGENT_LIST_TOOL_NAME), 'agent_list hidden at step 0');
     assert.ok(!captured[0].includes(AGENT_OUTPUT_TOOL_NAME), 'agent_output hidden at step 0');
 
     assert.ok(captured[1].includes(AGENT_SPAWN_TOOL_NAME), 'agent_spawn visible after loading the agent group');
+    assert.ok(captured[1].includes(AGENT_SWARM_TOOL_NAME), 'agent_swarm visible after loading the agent group');
     assert.ok(captured[1].includes(AGENT_LIST_TOOL_NAME), 'agent_list visible after loading the agent group');
     assert.ok(captured[1].includes(AGENT_OUTPUT_TOOL_NAME), 'agent_output visible after loading the agent group');
   });
@@ -295,6 +295,20 @@ describe('AiSdkBackend deferred agent tools', () => {
 
     assert.ok(!captured[0].includes(AGENT_SPAWN_TOOL_NAME), 'agent_spawn is not advertised at step 0');
     assert.deepEqual(spawnCalls, [], 'agent_spawn must not run before the agent group is active');
+  });
+
+  test('guard rejects same-step load_tools(agent)+agent_swarm before spawning children', async () => {
+    const captured: string[][] = [];
+    const spawnCalls: unknown[] = [];
+    await drain(agentBackend(parallelLoadAgentAndSwarmModel(captured), spawnCalls).send({
+      turnId: 'turn-1',
+      text: 'load and fan out in one step',
+      context: [],
+      runId: 'parent-run',
+    }));
+
+    assert.ok(!captured[0].includes(AGENT_SWARM_TOOL_NAME), 'agent_swarm is not advertised at step 0');
+    assert.deepEqual(spawnCalls, [], 'agent_swarm must not run before the agent group is active');
   });
 
   test('deferred agent group is prompt economy only: loaded agent_spawn still uses its permission model', async () => {
@@ -325,6 +339,54 @@ describe('AiSdkBackend deferred agent tools', () => {
       abortSignal: assertAbortSignal(spawnCalls[0]),
       onEvent: assertOnEvent(spawnCalls[0]),
     });
+  });
+
+  test('loaded agent_swarm fans out through the shared spawn capability', async () => {
+    const captured: string[][] = [];
+    const spawnCalls: unknown[] = [];
+    const events = await collect(
+      agentBackend(loadAgentThenSwarmModel(captured), spawnCalls, {
+        permissionMode: 'execute',
+      }).send({
+        turnId: 'turn-1',
+        text: 'load then fan out',
+        context: [],
+        runId: 'parent-run',
+      }),
+    );
+
+    assert.ok(captured[1].includes(AGENT_SWARM_TOOL_NAME));
+    assert.equal(spawnCalls.length, 2);
+    assert.deepEqual(
+      spawnCalls.map((call) => (call as { prompt?: string }).prompt),
+      ['Inspect auth.', 'Inspect storage.'],
+    );
+    assert.ok(
+      spawnCalls.every((call) =>
+        (call as { parentRunId?: string }).parentRunId === 'parent-run'
+      ),
+    );
+    const result = events.find(
+      (
+        event,
+      ): event is Extract<SessionEvent, { type: 'tool_result' }> & {
+        content: Extract<SessionEvent, { type: 'tool_result' }>['content'] & {
+          kind: 'agent_swarm';
+        };
+      } => event.type === 'tool_result' && event.content.kind === 'agent_swarm',
+    );
+    assert.ok(result);
+    assert.deepEqual(
+      result.content.items.map((item) => ({
+        itemId: item.itemId,
+        runId: item.runId,
+        turnId: item.turnId,
+      })),
+      [
+        { itemId: 'auth', runId: 'child-run-0', turnId: 'child-turn-0' },
+        { itemId: 'storage', runId: 'child-run-1', turnId: 'child-turn-1' },
+      ],
+    );
   });
 });
 
@@ -469,6 +531,27 @@ function parallelLoadAgentAndSpawnModel(captured: string[][]): MockLanguageModel
   });
 }
 
+function parallelLoadAgentAndSwarmModel(captured: string[][]): MockLanguageModelV4 {
+  return new MockLanguageModelV4({
+    doStream: async ({ tools: stepTools }) => {
+      captured.push((stepTools ?? []).map((t) => t.name));
+      const first = captured.length === 1;
+      const parts: LanguageModelV4StreamPart[] = first
+        ? [
+            { type: 'stream-start', warnings: [] },
+            { type: 'tool-call', toolCallId: 'tc-load', toolName: LOAD_TOOLS_NAME, input: JSON.stringify({ group: 'agent' }) },
+            { type: 'tool-call', toolCallId: 'tc-swarm', toolName: AGENT_SWARM_TOOL_NAME, input: agentSwarmInput() },
+            { type: 'finish', finishReason: { unified: 'tool-calls', raw: 'tool_calls' }, usage: ZERO_USAGE },
+          ]
+        : [
+            { type: 'stream-start', warnings: [] },
+            { type: 'finish', finishReason: { unified: 'stop', raw: 'stop' }, usage: ZERO_USAGE },
+          ];
+      return { stream: convertArrayToReadableStream(parts) };
+    },
+  });
+}
+
 function loadAgentThenSpawnModel(captured: string[][]): MockLanguageModelV4 {
   return new MockLanguageModelV4({
     doStream: async ({ tools: stepTools }) => {
@@ -496,10 +579,55 @@ function loadAgentThenSpawnModel(captured: string[][]): MockLanguageModelV4 {
   });
 }
 
+function loadAgentThenSwarmModel(captured: string[][]): MockLanguageModelV4 {
+  return new MockLanguageModelV4({
+    doStream: async ({ tools: stepTools }) => {
+      captured.push((stepTools ?? []).map((t) => t.name));
+      const step = captured.length;
+      const parts: LanguageModelV4StreamPart[] =
+        step === 1
+          ? [
+              { type: 'stream-start', warnings: [] },
+              { type: 'tool-call', toolCallId: 'tc-load', toolName: LOAD_TOOLS_NAME, input: JSON.stringify({ group: 'agent' }) },
+              { type: 'finish', finishReason: { unified: 'tool-calls', raw: 'tool_calls' }, usage: ZERO_USAGE },
+            ]
+          : step === 2
+            ? [
+                { type: 'stream-start', warnings: [] },
+                { type: 'tool-call', toolCallId: 'tc-swarm', toolName: AGENT_SWARM_TOOL_NAME, input: agentSwarmInput() },
+                { type: 'finish', finishReason: { unified: 'tool-calls', raw: 'tool_calls' }, usage: ZERO_USAGE },
+              ]
+            : [
+                { type: 'stream-start', warnings: [] },
+                { type: 'finish', finishReason: { unified: 'stop', raw: 'stop' }, usage: ZERO_USAGE },
+              ];
+      return { stream: convertArrayToReadableStream(parts) };
+    },
+  });
+}
+
 function agentSpawnInput(): string {
   return JSON.stringify({
     profile: LOCAL_READ_AGENT_PROFILE,
     task: 'Inspect the runtime tests.',
+  });
+}
+
+function agentSwarmInput(): string {
+  return JSON.stringify({
+    items: [
+      {
+        item_id: 'auth',
+        profile: LOCAL_READ_AGENT_PROFILE,
+        task: 'Inspect auth.',
+      },
+      {
+        item_id: 'storage',
+        profile: LOCAL_READ_AGENT_PROFILE,
+        task: 'Inspect storage.',
+      },
+    ],
+    max_concurrency: 2,
   });
 }
 
@@ -544,6 +672,14 @@ async function drain(iterable: AsyncIterable<unknown>): Promise<void> {
   for await (const _ of iterable) {
     void _;
   }
+}
+
+async function collect(
+  iterable: AsyncIterable<SessionEvent>,
+): Promise<SessionEvent[]> {
+  const events: SessionEvent[] = [];
+  for await (const event of iterable) events.push(event);
+  return events;
 }
 
 function header(permissionMode: SessionHeader['permissionMode'] = 'ask'): SessionHeader {

--- a/packages/runtime/src/__tests__/subagent-tools.test.ts
+++ b/packages/runtime/src/__tests__/subagent-tools.test.ts
@@ -34,6 +34,7 @@ import {
   evaluateAgentDefinitionToolAccess,
   listBuiltinAgentDefinitions,
 } from '../agent-catalog.js';
+import { AGENT_SWARM_TOOL_NAME } from '../agent-swarm-tools.js';
 import {
   AGENT_TOOL_GROUP_ID,
   AGENT_TOOL_NAMES,
@@ -42,6 +43,7 @@ import {
   AGENT_SPAWN_TOOL_NAME,
   CHILD_AGENT_TOOL_NAMES,
   buildChildAgentTools,
+  buildParentAgentTools,
   buildSubagentListTool,
   buildSubagentOutputTool,
   buildSubagentSpawnTool,
@@ -59,16 +61,23 @@ describe('subagent tools', () => {
     expect([...group.toolNames]).toEqual([...AGENT_TOOL_NAMES]);
     expect([...group.toolNames]).toEqual([
       AGENT_SPAWN_TOOL_NAME,
+      AGENT_SWARM_TOOL_NAME,
       AGENT_LIST_TOOL_NAME,
       AGENT_OUTPUT_TOOL_NAME,
     ]);
-    expect(group.description).toMatch(/Spawn and inspect/);
+    expect(group.description).toMatch(/Spawn, fan out, and inspect/);
 
     const spawnTool = buildSubagentSpawnTool();
     expect(spawnTool.permissionRequired).toBe(true);
     expect(spawnTool.categoryHint).toBe('subagent');
     expect(buildSubagentListTool().permissionRequired).toBe(false);
     expect(buildSubagentOutputTool().permissionRequired).toBe(false);
+    expect(buildParentAgentTools().map((tool) => tool.name)).toEqual([
+      AGENT_SPAWN_TOOL_NAME,
+      AGENT_SWARM_TOOL_NAME,
+      AGENT_LIST_TOOL_NAME,
+      AGENT_OUTPUT_TOOL_NAME,
+    ]);
   });
 
   test('built-in catalog exposes local-read without shell, web, nested, or write tools', () => {

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -436,6 +436,7 @@ export {
   buildChildAgentTools,
   buildSubagentListTool,
   buildSubagentOutputTool,
+  buildParentAgentTools,
   buildSubagentProjectionTools,
   buildSubagentSpawnTool,
   buildSubagentToolGroup,

--- a/packages/runtime/src/subagent-tools.ts
+++ b/packages/runtime/src/subagent-tools.ts
@@ -14,6 +14,10 @@ import {
 } from './agent-catalog.js';
 import type { ToolGroup } from './tool-availability.js';
 import { AGENT_TEAM_CHILD_TOOL_NAMES } from './agent-team-tool-names.js';
+import {
+  AGENT_SWARM_TOOL_NAME,
+  buildAgentSwarmTool,
+} from './agent-swarm-tools.js';
 
 export const AGENT_SPAWN_TOOL_NAME = 'agent_spawn';
 export const AGENT_LIST_TOOL_NAME = 'agent_list';
@@ -21,6 +25,7 @@ export const AGENT_OUTPUT_TOOL_NAME = 'agent_output';
 export const AGENT_TOOL_GROUP_ID = 'agent';
 export const AGENT_TOOL_NAMES = [
   AGENT_SPAWN_TOOL_NAME,
+  AGENT_SWARM_TOOL_NAME,
   AGENT_LIST_TOOL_NAME,
   AGENT_OUTPUT_TOOL_NAME,
 ] as const;
@@ -298,11 +303,21 @@ export function buildSubagentProjectionTools(): MakaTool[] {
   return [buildSubagentListTool(), buildSubagentOutputTool()];
 }
 
+export function buildParentAgentTools(
+  deps: { taskLedger?: TaskLedgerStore } = {},
+): MakaTool[] {
+  return [
+    buildSubagentSpawnTool(deps),
+    buildAgentSwarmTool(),
+    ...buildSubagentProjectionTools(),
+  ];
+}
+
 export function buildSubagentToolGroup(): ToolGroup {
   return {
     id: AGENT_TOOL_GROUP_ID,
     label: 'Agent',
-    description: 'Spawn and inspect foreground child agents.',
+    description: 'Spawn, fan out, and inspect foreground child agents.',
     toolNames: AGENT_TOOL_NAMES,
   };
 }


### PR DESCRIPTION
## Summary

- register one shared parent Agent tool surface in desktop, CLI, and headless, including agent_swarm
- add agent_swarm to the existing deferred Agent group while preserving the child no-nesting boundary
- wire headless backends to the existing narrow spawn/list/output SessionManager capabilities without exposing scheduler internals
- add bounded CLI formatting for aggregate and per-item settled results
- cover deferred activation, same-step admission guards, one parent permission denial, host equivalence, structured child refs, and bounded output

Part of #1192. Depends on the merged adapter PR #1202. Product presentation remains in PR 5.

## Validation

- npm run build:test
- npm run typecheck
- npm test --workspace @maka/headless (1100 passed, 2 skipped)
- npm test --workspace maka-agent (577 passed)
- targeted runtime/host suites (Runtime 44, Headless 60, CLI 18, Desktop contract 2)
- Biome lint on all changed files

Runtime full-suite note: 2139 tests passed and one existing machine-specific assertion failed because the macOS sandbox test expects /usr/local to be present as an executable root. The AgentSwarm and deferred Agent suites passed in the same run.