### PR TITLE
feat(icons+mcp): ban hand-drawn inline SVG repo-wide, polish the MCP page onto the house language

### DIFF
--- a/apps/desktop/src/main/__tests__/icon-governance-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/icon-governance-contract.test.ts
@@ -86,6 +86,25 @@ const STROKE_EXCEPTION_FILES = new Set([
   resolve(REPO_ROOT, 'apps/desktop/src/renderer/settings/provider-brand-marks.tsx'),
 ]);
 
+// Governance: inline hand-drawn `<svg>` literals are an anti-pattern —
+// generic UI glyphs must ride the @maka/ui/icons lucide funnel so they share
+// one stroke, one sizing seam, and one family. The ONLY files allowed to hold
+// a raw `<svg>` are the vendored *brand* marks (each audited below); they carry
+// official multi-color logo geometry that no generic icon can stand in for:
+//   - packages/ui/src/bot-brand-logo.tsx — Telegram/Feishu/WeCom/… channel
+//     brand logos (the icon-set-no-direct-lucide contract pins each provider
+//     to a local SVG component, so this file MUST keep inline SVG).
+//   - apps/desktop/src/renderer/settings/provider-brand-marks.tsx — the LLM
+//     provider brand marks (SiliconCloud, Ollama, xAI, …); every path here is
+//     byte-provenance-pinned above to an upstream brand package.
+// packages/ui/src/icons.tsx is NOT listed: it is a pure lucide re-export with
+// zero `<svg>` literals, so it needs no exemption. Any NEW raw `<svg>` under
+// the two source trees must fail this suite and move to @maka/ui/icons.
+const INLINE_SVG_ALLOWLIST = new Set([
+  resolve(REPO_ROOT, 'packages/ui/src/bot-brand-logo.tsx'),
+  resolve(REPO_ROOT, 'apps/desktop/src/renderer/settings/provider-brand-marks.tsx'),
+]);
+
 async function walkTsx(dir: string): Promise<string[]> {
   const out: string[] = [];
   const entries = await readdir(dir, { withFileTypes: true });
@@ -126,6 +145,46 @@ describe('icon + typography governance contract', () => {
       'icons ride lucide\'s default stroke — per-callsite strokeWidth fragments the family. '
         + `Delete the strokeWidth={...} props in:\n  ${offenders.join('\n  ')}`,
     );
+  });
+
+  it('bans inline hand-drawn <svg> in .tsx outside the brand-mark allowlist', async () => {
+    // Machine-walk both source trees the same way the repo-wide
+    // OverlayScrollbars ban walks its workspaces — any .tsx that isn't a
+    // vendored brand mark must route generic glyphs through @maka/ui/icons
+    // instead of hand-drawing an <svg>.
+    const dirs = [
+      resolve(REPO_ROOT, 'apps/desktop/src/renderer'),
+      resolve(REPO_ROOT, 'packages/ui/src'),
+    ];
+    const offenders: string[] = [];
+    const seenAllowlisted = new Set<string>();
+    for (const dir of dirs) {
+      for (const file of await walkTsx(dir)) {
+        const src = await readFile(file, 'utf8');
+        const hasInlineSvg = /<svg[\s/>]/.test(src);
+        if (INLINE_SVG_ALLOWLIST.has(file)) {
+          if (hasInlineSvg) seenAllowlisted.add(file);
+          continue;
+        }
+        if (hasInlineSvg) offenders.push(rel(file));
+      }
+    }
+    assert.deepEqual(
+      offenders,
+      [],
+      'Inline hand-drawn <svg> is an anti-pattern — replace it with a semantically-correct '
+        + 'icon from @maka/ui/icons (add the re-export to packages/ui/src/icons.tsx if missing). '
+        + `Offending files:\n  ${offenders.join('\n  ')}`,
+    );
+    // Guard the allowlist against rot: if a listed brand-mark file no longer
+    // holds inline SVG, drop it from INLINE_SVG_ALLOWLIST rather than leaving a
+    // stale exemption that would silently re-permit a future offender.
+    for (const file of INLINE_SVG_ALLOWLIST) {
+      assert.ok(
+        seenAllowlisted.has(file),
+        `${rel(file)} is allowlisted for inline SVG but no longer contains any — remove it from INLINE_SVG_ALLOWLIST`,
+      );
+    }
   });
 
   it('session-sidebar-nav imports exactly the decided semantic icon set from ./icons.js', async () => {

--- a/apps/desktop/src/main/__tests__/visual-smoke-fixture.test.ts
+++ b/apps/desktop/src/main/__tests__/visual-smoke-fixture.test.ts
@@ -627,18 +627,51 @@ describe('visual smoke fixture mode', () => {
     }
   });
 
-  it('module fixtures open Skills and Daily Review in the app module surface', async () => {
+  it('module fixtures open Skills, MCP and Daily Review in the app module surface', async () => {
     const skills = resolveVisualSmokeFixture('module-skills', false);
+    const mcp = resolveVisualSmokeFixture('module-mcp', false);
     const dailyReview = resolveVisualSmokeFixture('module-daily-review', false);
 
     assert.ok(skills);
+    assert.ok(mcp);
     assert.ok(dailyReview);
     assert.equal(getVisualSmokeState(skills)?.sidebarSection, 'skills');
     assert.equal(getVisualSmokeState(skills)?.sidebarCollapsed, false);
     assert.equal(getVisualSmokeState(skills)?.activeSessionId, 'visual-smoke-turn');
+    assert.equal(getVisualSmokeState(mcp)?.sidebarSection, 'mcp');
+    assert.equal(getVisualSmokeState(mcp)?.sidebarCollapsed, false);
+    assert.equal(getVisualSmokeState(mcp)?.activeSessionId, 'visual-smoke-turn');
     assert.equal(getVisualSmokeState(dailyReview)?.sidebarSection, 'daily-review');
     assert.equal(getVisualSmokeState(dailyReview)?.sidebarCollapsed, false);
     assert.equal(getVisualSmokeState(dailyReview)?.activeSessionId, 'visual-smoke-turn');
+  });
+
+  it('module-mcp seeds a couple of installed servers so the 已安装 list renders', async () => {
+    const workspaceRoot = await mkdtemp(join(tmpdir(), 'maka-visual-smoke-mcp-'));
+    try {
+      const fixture = resolveVisualSmokeFixture('module-mcp', false);
+      assert.ok(fixture);
+      await seedVisualSmokeFixture({
+        workspaceRoot,
+        fixture,
+        credentialStore: fakeCredentialStore(),
+        now: 1_700_000_000_000,
+      });
+      const config = JSON.parse(await readFile(join(workspaceRoot, 'mcp.json'), 'utf8')) as {
+        version: number;
+        mcpServers: Record<string, { enabled?: boolean }>;
+      };
+      assert.equal(config.version, 1);
+      const ids = Object.keys(config.mcpServers);
+      assert.ok(ids.length >= 2, 'installed list needs >=2 servers to render meaningfully');
+      // enabled:false keeps visual-smoke deterministic — no real npx / HTTP
+      // connection is attempted, so the rows settle in the neutral 已停用 state.
+      for (const id of ids) {
+        assert.equal(config.mcpServers[id].enabled, false, `${id} stays disabled in the fixture`);
+      }
+    } finally {
+      await rm(workspaceRoot, { recursive: true, force: true });
+    }
   });
 
   it('module-skills seeds a managed-source market catalog (>=6 entries with categories) plus workspace skills', async () => {

--- a/apps/desktop/src/main/visual-smoke-fixture.ts
+++ b/apps/desktop/src/main/visual-smoke-fixture.ts
@@ -63,6 +63,11 @@ const VISUAL_SMOKE_SCENARIOS = new Set<VisualSmokeScenario>([
   'settings-usage',
   'settings-health',
   'module-skills',
+  // MCP module page (SVG-governance + polish campaign): opens the 扩展 → MCP
+  // surface with a seeded mcp.json so the market grid, tab row, hero banner,
+  // and the installed server list all render for the alignment auditor + CDP
+  // capture in light / dark.
+  'module-mcp',
   'module-daily-review',
   // PR109b: workstation-statuses — seed one session per SessionStatus
   // (running / waiting_for_user / blocked × 4 reasons / active / review
@@ -418,6 +423,10 @@ export function getVisualSmokeState(fixture: VisualSmokeFixture | null): VisualS
       return { ...state, activeSessionId: TURN_SESSION_ID, openSettingsSection: 'health' };
     case 'module-skills':
       return { ...state, activeSessionId: TURN_SESSION_ID, sidebarSection: 'skills', sidebarCollapsed: false };
+    case 'module-mcp':
+      // Open the 扩展 → MCP module directly so the CDP baseline captures the
+      // real market grid, tab row, hero banner, and installed server list.
+      return { ...state, activeSessionId: TURN_SESSION_ID, sidebarSection: 'mcp', sidebarCollapsed: false };
     case 'module-daily-review':
       return { ...state, activeSessionId: TURN_SESSION_ID, sidebarSection: 'daily-review', sidebarCollapsed: false };
     case 'workstation-statuses':
@@ -603,6 +612,37 @@ export async function seedVisualSmokeFixture(input: {
   if (input.fixture.scenario === 'module-skills') {
     await seedSkillsMarketFixture(input.workspaceRoot);
   }
+  if (input.fixture.scenario === 'module-mcp') {
+    await seedMcpFixture(input.workspaceRoot);
+  }
+}
+
+/**
+ * MCP module fixture: seeds an mcp.json with a couple of installed servers so
+ * the 已安装 tab and the server rows render for the alignment auditor + CDP
+ * capture. Both are `enabled: false` so no real `npx` / HTTP connection is
+ * attempted in visual-smoke mode — the rows render deterministically in the
+ * neutral 已停用 state (exception-only status: no color unless a real failure).
+ * The 市场 tab is the default surface and is driven by the static MCP_CATALOG,
+ * so it renders without any on-disk seed.
+ */
+async function seedMcpFixture(workspaceRoot: string): Promise<void> {
+  const config = {
+    version: 1,
+    mcpServers: {
+      filesystem: {
+        enabled: false,
+        command: 'npx',
+        args: ['-y', '@modelcontextprotocol/server-filesystem', '/workspace/maka'],
+      },
+      'linear-remote': {
+        enabled: false,
+        url: 'https://mcp.linear.app/sse',
+        transport: 'sse',
+      },
+    },
+  };
+  await writeJson(join(workspaceRoot, 'mcp.json'), config);
 }
 
 /**

--- a/apps/desktop/src/renderer/mcp-page.tsx
+++ b/apps/desktop/src/renderer/mcp-page.tsx
@@ -7,11 +7,17 @@ import {
   DialogContent,
   DialogHeader,
   DialogRoot,
+  EmptyState,
   Input,
   InputGroup,
   InputGroupAddon,
   InputGroupInput,
+  PageHeader,
   SettingsSwitch as Switch,
+  TabsList,
+  TabsPanel,
+  TabsRoot,
+  TabsTrigger,
   Textarea,
   useMountedRef,
   useToast,
@@ -252,21 +258,23 @@ export function McpPage() {
 
   return (
     <main className="maka-main detailPane maka-module-main maka-mcp-page agents-chat-panel" data-module="mcp" aria-label="MCP">
-      <header className="maka-module-main-header maka-mcp-header">
-        <div>
-          <h2>MCP</h2>
-          <p>连接外部应用、数据与服务，为 Maka 安全地扩展新工具。</p>
-        </div>
-        <div className="maka-module-main-actions">
-          <Button size="icon-sm" variant="quiet" aria-label="刷新 MCP" title="刷新" onClick={() => void reload()} disabled={busy === 'load'}>
-            <RefreshCcw aria-hidden="true" />
-          </Button>
-          <Button variant="secondary" onClick={() => setEditor({ mode: 'json', source: exampleJson() })}>
-            <FileCode aria-hidden="true" /> JSON 导入
-          </Button>
-          <Button onClick={() => openManual()}><Plus aria-hidden="true" /> 添加 MCP</Button>
-        </div>
-      </header>
+      <PageHeader
+        className="maka-module-main-header"
+        as="h2"
+        title="MCP"
+        subtitle="连接外部应用、数据与服务，为 Maka 安全地扩展新工具。"
+        actions={
+          <div className="maka-module-main-actions" role="group" aria-label="MCP 操作">
+            <Button variant="secondary" onClick={() => void reload()} disabled={busy === 'load'}>
+              <RefreshCcw aria-hidden="true" /> {busy === 'load' ? '刷新中…' : '刷新'}
+            </Button>
+            <Button variant="secondary" onClick={() => setEditor({ mode: 'json', source: exampleJson() })}>
+              <FileCode aria-hidden="true" /> JSON 导入
+            </Button>
+            <Button variant="default" onClick={() => openManual()}><Plus aria-hidden="true" /> 添加 MCP</Button>
+          </div>
+        }
+      />
 
       <section className="maka-mcp-workspace" aria-label="MCP 市场与已安装项">
         <div className="maka-mcp-hero">
@@ -275,33 +283,26 @@ export function McpPage() {
             <span>从精选模板开始，或添加任意 stdio、Streamable HTTP 与 SSE server。</span>
           </div>
           <div className="maka-mcp-hero-signal" aria-hidden="true">
-            <Terminal /><span /><Plug /><span /><Globe />
+            <span><Terminal /><small>本地 stdio</small></span>
+            <span><Plug /><small>连接管理</small></span>
+            <span><Globe /><small>远程 HTTP</small></span>
           </div>
         </div>
 
-        <div className="maka-mcp-controls">
-          <div className="maka-mcp-tabs" role="tablist" aria-label="MCP 分类">
-            <button id="maka-mcp-market-tab" type="button" role="tab" aria-controls="maka-mcp-tab-panel" aria-selected={activeTab === 'market'} data-active={activeTab === 'market'} onClick={() => setActiveTab('market')}>市场</button>
-            <button id="maka-mcp-installed-tab" type="button" role="tab" aria-controls="maka-mcp-tab-panel" aria-selected={activeTab === 'installed'} data-active={activeTab === 'installed'} onClick={() => setActiveTab('installed')}>
-              已安装 <span>{entries.length}</span>
-            </button>
+        <TabsRoot value={activeTab} onValueChange={(value) => setActiveTab(value as 'market' | 'installed')}>
+          <div className="maka-mcp-tabs-bar">
+            <TabsList variant="underline" className="maka-mcp-tabs" aria-label="MCP 分类">
+              <TabsTrigger className="maka-mcp-tab" value="market">市场 <span>{MCP_CATALOG.length}</span></TabsTrigger>
+              <TabsTrigger className="maka-mcp-tab" value="installed">已安装 <span>{entries.length}</span></TabsTrigger>
+            </TabsList>
+            <InputGroup className="maka-mcp-search">
+              <InputGroupAddon><Search aria-hidden="true" /></InputGroupAddon>
+              <InputGroupInput type="search" value={query} onChange={(event) => setQuery(event.currentTarget.value)} placeholder="搜索 MCP…" aria-label="搜索 MCP" />
+            </InputGroup>
           </div>
-          <InputGroup className="maka-mcp-search">
-            <InputGroupAddon><Search aria-hidden="true" /></InputGroupAddon>
-            <InputGroupInput type="search" value={query} onChange={(event) => setQuery(event.currentTarget.value)} placeholder="搜索 MCP…" aria-label="搜索 MCP" />
-          </InputGroup>
-        </div>
 
-        <div
-          id="maka-mcp-tab-panel"
-          className="maka-mcp-tab-panel"
-          role="tabpanel"
-          aria-labelledby={activeTab === 'market' ? 'maka-mcp-market-tab' : 'maka-mcp-installed-tab'}
-        >
-          {busy === 'load' ? (
-            <div className="maka-mcp-loading" role="status">正在读取 MCP 配置…</div>
-          ) : activeTab === 'market' ? (
-            marketEntries.length > 0 ? (
+          <TabsPanel className="maka-mcp-tab-panel" value="market">
+            {marketEntries.length > 0 ? (
               <div className="maka-mcp-market-grid">
                 {marketEntries.map((entry) => (
                   <McpCatalogCard
@@ -318,32 +319,55 @@ export function McpPage() {
                   />
                 ))}
               </div>
-            ) : <McpNoResults query={query} onClear={() => setQuery('')} />
-          ) : entries.length === 0 ? (
-            <div className="maka-mcp-empty">
-              <Plug aria-hidden="true" />
-              <strong>还没有安装 MCP</strong>
-              <span>从市场选择模板，或手动添加你自己的 server。</span>
-              <Button size="sm" onClick={() => setActiveTab('market')}>浏览市场</Button>
-            </div>
-          ) : installedEntries.length > 0 ? (
-            <ul className="maka-mcp-server-list">
-              {installedEntries.map(([serverId, server]) => (
-                <McpServerRow
-                  key={serverId}
-                  serverId={serverId}
-                  server={server}
-                  status={statusById.get(serverId)}
-                  busy={busy}
-                  onToggle={(enabled) => void toggle(serverId, server, enabled)}
-                  onEdit={() => openEdit(serverId, server)}
-                  onTest={() => void testServer(serverId)}
-                  onRemove={() => void remove(serverId)}
-                />
-              ))}
-            </ul>
-          ) : <McpNoResults query={query} onClear={() => setQuery('')} />}
-        </div>
+            ) : (
+              <EmptyState
+                Icon={Search}
+                title="没有找到匹配的 MCP"
+                body={`换一个关键词，或清空「${query}」查看全部模板。`}
+                cta={{ label: '清空搜索', onClick: () => setQuery('') }}
+                extraClassName="maka-mcp-empty"
+              />
+            )}
+          </TabsPanel>
+
+          <TabsPanel className="maka-mcp-tab-panel" value="installed">
+            {busy === 'load' ? (
+              <div className="maka-mcp-loading" role="status">正在读取 MCP 配置…</div>
+            ) : entries.length === 0 ? (
+              <EmptyState
+                Icon={Plug}
+                title="还没有安装 MCP"
+                body="从市场选择模板，或手动添加你自己的 server。"
+                cta={{ label: '浏览市场', onClick: () => setActiveTab('market') }}
+                extraClassName="maka-mcp-empty"
+              />
+            ) : installedEntries.length > 0 ? (
+              <ul className="maka-mcp-server-list">
+                {installedEntries.map(([serverId, server]) => (
+                  <McpServerRow
+                    key={serverId}
+                    serverId={serverId}
+                    server={server}
+                    status={statusById.get(serverId)}
+                    busy={busy}
+                    onToggle={(enabled) => void toggle(serverId, server, enabled)}
+                    onEdit={() => openEdit(serverId, server)}
+                    onTest={() => void testServer(serverId)}
+                    onRemove={() => void remove(serverId)}
+                  />
+                ))}
+              </ul>
+            ) : (
+              <EmptyState
+                Icon={Search}
+                title="没有匹配的已安装 MCP"
+                body={`换一个关键词，或清空「${query}」查看全部已安装项。`}
+                cta={{ label: '清空搜索', onClick: () => setQuery('') }}
+                extraClassName="maka-mcp-empty"
+              />
+            )}
+          </TabsPanel>
+        </TabsRoot>
       </section>
 
       {editor && (
@@ -373,7 +397,7 @@ function McpCatalogCard(props: {
   return (
     <article className="maka-mcp-market-card">
       <div className="maka-mcp-market-icon" data-brand={props.entry.id} aria-hidden="true">
-        <McpBrandMark entry={props.entry} />
+        <span>{props.entry.mark}</span>
       </div>
       <div className="maka-mcp-market-copy">
         <strong>{props.entry.name}</strong>
@@ -408,33 +432,6 @@ function McpCatalogCard(props: {
   );
 }
 
-function McpBrandMark({ entry }: { entry: McpCatalogEntry }) {
-  if (entry.id === 'slack') return (
-    <svg viewBox="0 0 256 256" aria-hidden="true">
-      <path fill="#e01e5a" d="M53.84 161.32c0 14.83-11.99 26.82-26.82 26.82S.2 176.15.2 161.32s11.99-26.82 26.82-26.82h26.82zm13.41 0c0-14.83 11.99-26.82 26.82-26.82s26.82 11.99 26.82 26.82v67.05c0 14.83-11.99 26.82-26.82 26.82s-26.82-11.99-26.82-26.82z" />
-      <path fill="#36c5f0" d="M94.07 53.64c-14.83 0-26.82-11.99-26.82-26.82S79.24 0 94.07 0s26.82 11.99 26.82 26.82v26.82zm0 13.61c14.83 0 26.82 11.99 26.82 26.82s-11.99 26.82-26.82 26.82H26.82C11.99 120.89 0 108.9 0 94.07s11.99-26.82 26.82-26.82z" />
-      <path fill="#2eb67d" d="M201.55 94.07c0-14.83 11.99-26.82 26.82-26.82s26.82 11.99 26.82 26.82s-11.99 26.82-26.82 26.82h-26.82zm-13.41 0c0 14.83-11.99 26.82-26.82 26.82s-26.82-11.99-26.82-26.82V26.82C134.5 11.99 146.49 0 161.32 0s26.82 11.99 26.82 26.82z" />
-      <path fill="#ecb22e" d="M161.32 201.55c14.83 0 26.82 11.99 26.82 26.82s-11.99 26.82-26.82 26.82s-26.82-11.99-26.82-26.82v-26.82zm0-13.41c-14.83 0-26.82-11.99-26.82-26.82s11.99-26.82 26.82-26.82h67.25c14.83 0 26.82 11.99 26.82 26.82s-11.99 26.82-26.82 26.82z" />
-    </svg>
-  );
-  if (entry.id === 'line') return (
-    <svg viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M19.37 9.86a.63.63 0 0 1 0 1.26h-1.76v1.13h1.76a.63.63 0 1 1 0 1.26h-2.39a.63.63 0 0 1-.63-.63V8.11a.63.63 0 0 1 .63-.63h2.39a.63.63 0 0 1 0 1.26h-1.76v1.12zm-3.86 3.02a.63.63 0 0 1-1.14.38l-2.44-3.32v2.94a.63.63 0 0 1-1.26 0V8.11a.63.63 0 0 1 1.12-.38l2.46 3.33V8.11a.63.63 0 0 1 1.26 0zm-5.74 0a.63.63 0 0 1-1.26 0V8.11a.63.63 0 0 1 1.26 0zm-2.47.63H4.92a.63.63 0 0 1-.63-.63V8.11a.63.63 0 0 1 1.26 0v4.14H7.3a.63.63 0 0 1 0 1.26M24 10.31C24 4.94 18.62.57 12 .57S0 4.94 0 10.31c0 4.81 4.27 8.84 10.04 9.61.39.08.92.26 1.06.59.12.3.08.77.04 1.08l-.17 1.02c-.04.3-.24 1.19 1.05.65 1.29-.54 6.92-4.08 9.44-6.98C23.18 14.39 24 12.46 24 10.31" /></svg>
-  );
-  if (entry.id === 'google-calendar') return (
-    <svg viewBox="0 0 256 256" aria-hidden="true">
-      <path fill="#fff" d="M195.37 60.63H60.63v134.74h134.74z" /><path fill="#ea4335" d="M195.37 256 256 195.37l-60.63-5.17z" /><path fill="#188038" d="M0 195.37v40.42A20.21 20.21 0 0 0 20.21 256h40.42l6.23-30.32-6.23-30.31z" /><path fill="#1967d2" d="M256 60.63V20.21A20.21 20.21 0 0 0 235.79 0h-40.42l-5.54 33.2 5.54 27.43z" /><path fill="#fbbc04" d="M256 60.63h-60.63v134.74H256z" /><path fill="#34a853" d="M195.37 195.37H60.63V256h134.74z" /><path fill="#4285f4" d="M195.37 0H20.21A20.21 20.21 0 0 0 0 20.21v175.16h60.63V60.63h134.74z" /><path fill="#4285f4" d="M88.27 165.15c-5.04-3.4-8.52-8.37-10.43-14.94l11.69-4.81c2.77 8.49 7.82 12.71 15.12 12.71 7.67 0 13.48-5.28 13.48-12.36 0-8.32-6.88-12.18-14.72-12.18h-6.75V122h6.06c8.09 0 13.29-4.32 13.29-11.34 0-6.21-4.58-10.31-12.14-10.31-6.77 0-11.18 3.64-12.6 9.5l-11.57-4.81c3.55-10.06 12.38-16.49 24.27-16.49 14.2 0 24.83 8.71 24.83 21 0 8.18-4.12 13.79-10.31 17.04v.69c8.27 3.46 13.07 9.97 13.07 19.12 0 14.01-11.25 24.08-26.88 24.08-5.91.02-11.37-1.68-16.41-5.08m71.8-58-12.84 9.28-6.41-9.73 23.02-16.61h8.83v78.33h-12.6z" />
-    </svg>
-  );
-  if (entry.id === 'figma') return (
-    <svg viewBox="0 0 256 384" aria-hidden="true"><path fill="#0acf83" d="M64 384a64 64 0 0 0 64-64v-64H64a64 64 0 1 0 0 128" /><path fill="#a259ff" d="M0 192a64 64 0 0 1 64-64h64v128H64a64 64 0 0 1-64-64" /><path fill="#f24e1e" d="M0 64A64 64 0 0 1 64 0h64v128H64A64 64 0 0 1 0 64" /><path fill="#ff7262" d="M128 0h64a64 64 0 1 1 0 128h-64z" /><path fill="#1abcfe" d="M256 192a64 64 0 1 1-128 0 64 64 0 0 1 128 0" /></svg>
-  );
-  if (entry.id === 'vercel') return <svg viewBox="0 0 256 222" aria-hidden="true"><path fill="currentColor" d="m128 0 128 221.71H0z" /></svg>;
-  if (entry.id === 'supabase') return (
-    <svg viewBox="0 0 256 263" aria-hidden="true"><path fill="#249361" d="M149.6 258.58c-6.72 8.46-20.34 3.82-20.5-6.98l-2.37-157.98h106.23c19.24 0 29.97 22.22 18.01 37.29z" /><path fill="#3ecf8e" d="M106.4 4.37c6.72-8.46 20.34-3.83 20.5 6.98l1.04 157.98H23.04c-19.24 0-29.97-22.22-18.01-37.29z" /></svg>
-  );
-  return <span>{entry.mark}</span>;
-}
-
 function McpServerRow(props: {
   serverId: string;
   server: McpServerConfig;
@@ -451,9 +448,17 @@ function McpServerRow(props: {
   return (
     <li className="maka-mcp-server-row">
       <div className="maka-mcp-server-summary">
-        <span className="maka-mcp-status-dot" data-tone={state.tone} aria-hidden="true" />
+        <span className="maka-mcp-status-dot" data-tone={state.exception ? state.tone : 'neutral'} aria-hidden="true" />
         <div className="maka-mcp-server-identity">
-          <div><strong>{props.serverId}</strong><Chip size="sm" variant={state.tone}>{state.label}</Chip></div>
+          <div>
+            <strong>{props.serverId}</strong>
+            {/* Status-color restraint (#651): a healthy / expected server stays
+                neutral — its label rides plain muted text. Only an error /
+                unavailable server raises a toned Chip. */}
+            {state.exception
+              ? <Chip size="sm" variant={state.tone}>{state.label}</Chip>
+              : <span className="maka-mcp-server-state">{state.label}</span>}
+          </div>
           <span>{transportLabel} · <code title={endpoint}>{endpoint}</code></span>
         </div>
         <Switch
@@ -481,17 +486,6 @@ function McpServerRow(props: {
         </details>
       ) : null}
     </li>
-  );
-}
-
-function McpNoResults(props: { query: string; onClear(): void }) {
-  return (
-    <div className="maka-mcp-empty">
-      <Search aria-hidden="true" />
-      <strong>没有找到匹配的 MCP</strong>
-      <span>尝试更换关键词，或清空「{props.query}」。</span>
-      <Button size="sm" variant="secondary" onClick={props.onClear}>清空搜索</Button>
-    </div>
   );
 }
 
@@ -623,12 +617,15 @@ function delay(ms: number): Promise<void> {
   return new Promise((resolve) => window.setTimeout(resolve, ms));
 }
 
-function presentStatus(status: McpServerStatus | undefined, enabled: boolean): { label: string; tone: 'neutral' | 'info' | 'success' | 'warning' | 'destructive' } {
-  if (!enabled || status?.state === 'disabled') return { label: '已停用', tone: 'neutral' };
-  if (!status || status.state === 'disconnected') return { label: '未连接', tone: 'neutral' };
-  if (status.state === 'connecting') return { label: '连接中', tone: 'info' };
-  if (status.state === 'connected') return { label: `${status.toolCount} 个工具`, tone: 'success' };
-  return { label: '连接失败', tone: 'destructive' };
+// `exception` marks the states that earn a toned Chip + colored status dot
+// (status-color restraint #651). 已停用 / 未连接 / 连接中 / 已连接 are all
+// expected states and stay neutral; only 连接失败 raises the destructive tone.
+function presentStatus(status: McpServerStatus | undefined, enabled: boolean): { label: string; tone: 'neutral' | 'info' | 'success' | 'warning' | 'destructive'; exception: boolean } {
+  if (!enabled || status?.state === 'disabled') return { label: '已停用', tone: 'neutral', exception: false };
+  if (!status || status.state === 'disconnected') return { label: '未连接', tone: 'neutral', exception: false };
+  if (status.state === 'connecting') return { label: '连接中', tone: 'info', exception: false };
+  if (status.state === 'connected') return { label: `${status.toolCount} 个工具`, tone: 'success', exception: false };
+  return { label: '连接失败', tone: 'destructive', exception: true };
 }
 
 function exampleJson(): string {

--- a/apps/desktop/src/renderer/styles/module-pages/mcp.css
+++ b/apps/desktop/src/renderer/styles/module-pages/mcp.css
@@ -3,10 +3,6 @@
   align-content: start;
 }
 
-.maka-mcp-header {
-  align-items: center;
-}
-
 .maka-mcp-workspace {
   width: min(100%, 900px);
   min-height: 0;
@@ -51,29 +47,44 @@
 }
 
 .maka-mcp-hero-signal {
-  min-width: 240px;
   display: flex;
   align-items: center;
   justify-content: flex-end;
+  gap: var(--space-3);
+}
+
+/* Labeled pictogram cluster — the same "framed glyph + caption" tiles the
+   skills featured banner uses, so the two extension pages read as siblings.
+   Icons ride the @maka/ui library (Task A); no inline SVG here. */
+.maka-mcp-hero-signal span {
+  width: 76px;
+  display: inline-flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--space-1-5);
+  padding: var(--space-3) var(--space-2);
+  border: var(--border-width-hairline) solid var(--border);
+  border-radius: var(--radius-control);
+  background: var(--background);
   color: var(--foreground-secondary);
 }
 
 .maka-mcp-hero-signal svg {
-  width: 38px;
-  height: 38px;
-  padding: var(--space-2);
-  border: var(--border-width-hairline) solid var(--border);
-  border-radius: var(--radius-control);
-  background: var(--background);
+  width: 22px;
+  height: 22px;
 }
 
-.maka-mcp-hero-signal span {
-  width: 24px;
-  height: 1px;
-  background: var(--border);
+.maka-mcp-hero-signal small {
+  color: var(--muted-foreground);
+  font-size: var(--font-size-caption);
+  font-weight: var(--font-weight-medium);
+  line-height: var(--leading-tight);
 }
 
-.maka-mcp-controls {
+/* Tab row rhythm mirrors the skills page (.maka-skill-tabs-bar): an
+   underline TabsList on the left, the search field pinned to the right,
+   so the two extension pages read as siblings. */
+.maka-mcp-tabs-bar {
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -83,46 +94,26 @@
 
 .maka-mcp-tabs {
   display: flex;
-  align-items: center;
   gap: var(--space-4);
+  border-bottom: 0;
 }
 
-.maka-mcp-tabs button {
+.maka-mcp-tab {
   position: relative;
-  min-height: 36px;
+  height: 32px;
   display: inline-flex;
   align-items: center;
   gap: var(--space-1);
   padding: 0 1px;
   border: 0;
+  border-radius: 0;
   background: transparent;
   color: var(--muted-foreground);
-  font: inherit;
   font-size: var(--font-size-ui);
   font-weight: var(--font-weight-medium);
 }
 
-.maka-mcp-tabs button::after {
-  position: absolute;
-  right: 0;
-  bottom: -1px;
-  left: 0;
-  height: 2px;
-  border-radius: var(--radius-pill);
-  background: transparent;
-  content: '';
-}
-
-.maka-mcp-tabs button[data-active="true"] {
-  color: var(--foreground);
-  font-weight: var(--font-weight-semibold);
-}
-
-.maka-mcp-tabs button[data-active="true"]::after {
-  background: var(--foreground);
-}
-
-.maka-mcp-tabs button span {
+.maka-mcp-tab span {
   min-width: 16px;
   height: 16px;
   display: inline-flex;
@@ -130,15 +121,18 @@
   justify-content: center;
   padding-inline: var(--space-1);
   border-radius: var(--radius-pill);
-  background: var(--state-hover-bg);
+  background: oklch(from var(--foreground) l c h / 0.06);
+  color: var(--muted-foreground);
   font-size: var(--font-size-caption);
+  font-weight: var(--font-weight-semibold);
   font-variant-numeric: tabular-nums;
 }
 
 .maka-mcp-search {
   width: min(300px, 38vw);
-  height: var(--h-control-md);
+  height: var(--h-control-sm);
   margin-bottom: var(--space-2);
+  flex: 0 0 auto;
 }
 
 .maka-mcp-tab-panel {
@@ -188,16 +182,6 @@
   font-size: var(--font-size-heading);
   font-weight: var(--font-weight-bold);
   letter-spacing: var(--tracking-normal);
-}
-
-.maka-mcp-market-icon svg {
-  width: 27px;
-  height: 27px;
-}
-
-.maka-mcp-market-icon[data-brand="figma"] svg {
-  width: 18px;
-  height: 28px;
 }
 
 .maka-mcp-market-icon[data-brand="line"] span {
@@ -369,9 +353,15 @@
   background: var(--muted-foreground);
 }
 
-.maka-mcp-status-dot[data-tone="success"] { background: var(--success); }
-.maka-mcp-status-dot[data-tone="info"] { background: var(--info); }
+/* Status-color restraint (#651): the dot stays neutral for every expected
+   state; only a genuine failure (data-tone="destructive") raises color. */
 .maka-mcp-status-dot[data-tone="destructive"] { background: var(--destructive); }
+
+.maka-mcp-server-state {
+  color: var(--muted-foreground);
+  font-size: var(--font-size-caption);
+  font-variant-numeric: tabular-nums;
+}
 
 .maka-mcp-server-identity {
   min-width: 0;
@@ -461,34 +451,20 @@
   white-space: pre-wrap;
 }
 
-.maka-mcp-empty,
+/* The empty / no-results panels ride the shared EmptyState primitive; this
+   class is only a light layout override on top of `.maka-empty-state`. */
+.maka-mcp-empty {
+  align-self: start;
+}
+
 .maka-mcp-loading {
   min-height: 240px;
   display: grid;
   place-items: center;
   align-content: center;
-  gap: var(--space-2);
   padding: var(--space-8);
   color: var(--muted-foreground);
   text-align: center;
-}
-
-.maka-mcp-empty > svg {
-  width: 32px;
-  height: 32px;
-  margin-bottom: var(--space-2);
-  color: var(--foreground-secondary);
-}
-
-.maka-mcp-empty strong {
-  color: var(--foreground);
-  font-size: var(--font-size-heading);
-}
-
-.maka-mcp-empty span {
-  max-width: 52ch;
-  font-size: var(--font-size-ui);
-  line-height: var(--leading-normal);
 }
 
 .maka-mcp-editor-dialog {
@@ -622,17 +598,13 @@
 }
 
 @media (max-width: 760px) {
-  .maka-mcp-header,
-  .maka-mcp-controls {
-    align-items: stretch;
-  }
-
   .maka-mcp-hero-signal {
     display: none;
   }
 
-  .maka-mcp-controls {
-    display: grid;
+  .maka-mcp-tabs-bar {
+    flex-wrap: wrap;
+    align-items: stretch;
   }
 
   .maka-mcp-search {

--- a/packages/core/src/visual-smoke.ts
+++ b/packages/core/src/visual-smoke.ts
@@ -50,6 +50,7 @@ export type VisualSmokeScenario =
   | 'settings-usage'
   | 'settings-health'
   | 'module-skills'
+  | 'module-mcp'
   | 'module-daily-review'
   | 'workstation-statuses'
   | 'plan-reminders'

--- a/packages/ui/src/primitives/menu.tsx
+++ b/packages/ui/src/primitives/menu.tsx
@@ -2,7 +2,7 @@
 
 import { Menu as MenuPrimitive } from "@base-ui/react/menu";
 import { cn } from "../utils.js";
-import { ChevronRightIcon } from "../icons.js";
+import { Check, ChevronRightIcon } from "../icons.js";
 import type * as React from "react";
 
 export const MenuCreateHandle: typeof MenuPrimitive.createHandle =
@@ -163,20 +163,7 @@ export function MenuCheckboxItem({
       ) : (
         <>
           <MenuPrimitive.CheckboxItemIndicator className="col-start-1 -ms-0.5">
-            <svg
-              aria-hidden="true"
-              fill="none"
-              height="24"
-              stroke="currentColor"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              strokeWidth="2"
-              viewBox="0 0 24 24"
-              width="24"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path d="M5.252 12.7 10.2 18.63 18.748 5.37" />
-            </svg>
+            <Check aria-hidden="true" />
           </MenuPrimitive.CheckboxItemIndicator>
           <span className="col-start-2">{children}</span>
         </>
@@ -206,20 +193,7 @@ export function MenuRadioItem({
       {...props}
     >
       <MenuPrimitive.RadioItemIndicator className="col-start-1 -ms-0.5">
-        <svg
-          aria-hidden="true"
-          fill="none"
-          height="24"
-          stroke="currentColor"
-          strokeLinecap="round"
-          strokeLinejoin="round"
-          strokeWidth="2"
-          viewBox="0 0 24 24"
-          width="24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path d="M5.252 12.7 10.2 18.63 18.748 5.37" />
-        </svg>
+        <Check aria-hidden="true" />
       </MenuPrimitive.RadioItemIndicator>
       <span className="col-start-2">{children}</span>
     </MenuPrimitive.RadioItem>

--- a/scripts/audit-alignment.mjs
+++ b/scripts/audit-alignment.mjs
@@ -17,6 +17,7 @@ const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
 const DESKTOP_DIR = join(ROOT, 'apps', 'desktop');
 const FIXTURES = [
   'module-skills',
+  'module-mcp',
   'module-daily-review',
   'plan-reminders',
   'settings-general',


### PR DESCRIPTION
Two user directives in one campaign: 手绘 SVG 是反模式 (replace + govern) and MCP 页面不够美观 (polish).

## Inline-SVG sweep + governance
Scope finding: the 6 inline SVGs in mcp-page.tsx were BRAND LOGOS (Slack/LINE/Google-Calendar/Figma/Vercel/Supabase), not UI glyphs — the banner pictograms were already lucide. Convergence: all market tiles now use the catalog's majority treatment (text marks on brand-tinted tiles — 钉/飞/N/⌘ were already this; the 6 special-cased logos were the inconsistency). menu.tsx's two hand-drawn indicator glyphs → Check from the icons funnel (model-picker precedent).

**Governance**: icon-governance-contract gains a machine tree-walk ban — any `<svg` literal in .tsx under packages/ui/src or apps/desktop/src/renderer outside the audited brand-mark allowlist (bot-brand-logo.tsx, provider-brand-marks.tsx) fails the suite with a pointer to @maka/ui/icons. Allowlist is rot-guarded (losing the SVG fails too). Hand-drawn SVG can no longer re-enter.

## MCP page polish
| Drift | Converged |
|---|---|
| Hand-rolled header | PageHeader primitive, edged actions, 添加 MCP primary |
| Hand-rolled tabs | shared underline TabsList + count pills, search right — skills rhythm |
| Banner icon strip | labeled tiles: Terminal 本地 stdio / Plug 连接管理 / Globe 远程 HTTP |
| Hand-rolled empty states | EmptyState primitive |
| Every install state colored | exception-only: healthy = neutral; only 连接失败 raises destructive Chip |

Zero behavior change (mcp-market contract pins verified verbatim). Plus: module-mcp visual-smoke fixture added and wired into the alignment auditor — the page is now under permanent visual governance.

## Gates (merged tree = main tip already contained)
desktop 2699/2699 · ui 183/183 · typecheck · check-dead-css · knip ×2 = 0 · auditor all fixtures clean incl. module-mcp. CDP light+dark captures visually accepted by maintainer before merge. Implemented by an opus worktree agent.