### PR TITLE
feat(plans): 保持系统唤醒 — real powerSaveBlocker capability for scheduled tasks

### DIFF
--- a/apps/desktop/src/main/__tests__/keep-system-awake.test.ts
+++ b/apps/desktop/src/main/__tests__/keep-system-awake.test.ts
@@ -1,0 +1,123 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  createKeepSystemAwakeController,
+  type PowerSaveBlockerLike,
+} from '../keep-system-awake.js';
+
+/**
+ * Fake Electron `powerSaveBlocker`: hands out incrementing ids and tracks
+ * which are live, so the controller's start/stop bookkeeping can be asserted
+ * without an Electron runtime (same philosophy as notifications-policy tests).
+ */
+function createFakeBlocker() {
+  const started = new Set<number>();
+  const startCalls: Array<'prevent-app-suspension' | 'prevent-display-sleep'> = [];
+  const stopCalls: number[] = [];
+  let nextId = 0;
+  const blocker: PowerSaveBlockerLike = {
+    start(type) {
+      startCalls.push(type);
+      const id = nextId++;
+      started.add(id);
+      return id;
+    },
+    stop(id) {
+      stopCalls.push(id);
+      started.delete(id);
+    },
+    isStarted(id) {
+      return started.has(id);
+    },
+  };
+  return { blocker, started, startCalls, stopCalls };
+}
+
+describe('keep-system-awake controller', () => {
+  it('starts a prevent-app-suspension blocker when enabled', () => {
+    const fake = createFakeBlocker();
+    const controller = createKeepSystemAwakeController(fake.blocker);
+
+    controller.apply(true);
+
+    assert.deepEqual(fake.startCalls, ['prevent-app-suspension']);
+    assert.equal(controller.isActive(), true);
+    assert.equal(fake.started.size, 1);
+  });
+
+  it('does NOT force the display on (never uses prevent-display-sleep)', () => {
+    const fake = createFakeBlocker();
+    const controller = createKeepSystemAwakeController(fake.blocker);
+
+    controller.apply(true);
+
+    assert.ok(
+      !fake.startCalls.includes('prevent-display-sleep'),
+      'background scheduled work must not keep the monitor lit',
+    );
+  });
+
+  it('guards double-start: re-applying enabled does not leak a second blocker', () => {
+    const fake = createFakeBlocker();
+    const controller = createKeepSystemAwakeController(fake.blocker);
+
+    controller.apply(true);
+    controller.apply(true);
+    controller.apply(true);
+
+    assert.equal(fake.startCalls.length, 1, 'blocker must start exactly once');
+    assert.equal(fake.started.size, 1);
+    assert.equal(controller.isActive(), true);
+  });
+
+  it('stops the blocker when disabled', () => {
+    const fake = createFakeBlocker();
+    const controller = createKeepSystemAwakeController(fake.blocker);
+
+    controller.apply(true);
+    controller.apply(false);
+
+    assert.equal(fake.stopCalls.length, 1);
+    assert.equal(fake.started.size, 0);
+    assert.equal(controller.isActive(), false);
+  });
+
+  it('disabling when nothing is held is a no-op', () => {
+    const fake = createFakeBlocker();
+    const controller = createKeepSystemAwakeController(fake.blocker);
+
+    controller.apply(false);
+
+    assert.equal(fake.startCalls.length, 0);
+    assert.equal(fake.stopCalls.length, 0);
+    assert.equal(controller.isActive(), false);
+  });
+
+  it('re-enabling after a stop starts a fresh blocker', () => {
+    const fake = createFakeBlocker();
+    const controller = createKeepSystemAwakeController(fake.blocker);
+
+    controller.apply(true);
+    controller.apply(false);
+    controller.apply(true);
+
+    assert.equal(fake.startCalls.length, 2, 'a fresh blocker id is acquired after stop');
+    assert.equal(fake.started.size, 1);
+    assert.equal(controller.isActive(), true);
+  });
+
+  it('re-acquires a blocker when the previous id was released underneath it', () => {
+    const fake = createFakeBlocker();
+    const controller = createKeepSystemAwakeController(fake.blocker);
+
+    controller.apply(true);
+    // Simulate the blocker being torn down out of band (e.g. teardown race):
+    // the controller still believes it holds id 0, but it is no longer live.
+    fake.started.clear();
+    assert.equal(controller.isActive(), false);
+
+    controller.apply(true);
+    assert.equal(fake.startCalls.length, 2);
+    assert.equal(controller.isActive(), true);
+  });
+});

--- a/apps/desktop/src/main/__tests__/plan-reminder-panel-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/plan-reminder-panel-contract.test.ts
@@ -71,4 +71,62 @@ describe('Plan Reminder panel async action contract', () => {
     assert.match(panelBlock, /disabled=\{!props\.onRefresh \|\| refreshPending\}/);
     assert.match(panelBlock, /aria-busy=\{refreshPending \? 'true' : undefined\}/);
   });
+
+  it('keeps the 保持系统唤醒 toggle optimistic, revert-on-error, and unmount-safe', async () => {
+    const ui = await readFile(resolve(REPO_ROOT, 'packages/ui/src/plan-reminder-panel.tsx'), 'utf8');
+    const panelBlock = extractFunctionBlock(ui, 'PlanReminderPanel');
+    const toggleBlock = blockBetween(panelBlock, 'async function toggleKeepSystemAwake', 'function openReminderDialog');
+
+    // Pending owner is a ref (sync guard) + React state (disables the switch).
+    assert.match(panelBlock, /const \[keepSystemAwakePending, setKeepSystemAwakePending\] = useState\(false\)/);
+    assert.match(panelBlock, /const keepSystemAwakePendingRef = useRef\(false\)/);
+
+    // The capability is gated on the host wiring BOTH the value and the setter;
+    // otherwise the row hides entirely (fail-soft on an older main / no bridge).
+    assert.match(
+      panelBlock,
+      /const keepSystemAwakeSupported =\s*props\.keepSystemAwake !== undefined && typeof props\.onKeepSystemAwakeChange === 'function';/,
+    );
+    assert.match(panelBlock, /\{keepSystemAwakeSupported && \(/);
+
+    // The unmount cleanup must also release the keep-awake pending owner so a
+    // slow IPC write cannot write state after the panel is gone.
+    assert.match(
+      panelBlock,
+      /refreshPendingRef\.current = false;\s*pendingActionKeysRef\.current = new Set\(\);\s*keepSystemAwakePendingRef\.current = false;/,
+      'keep-awake pending owner must be released on unmount alongside the refresh/action owners',
+    );
+
+    // Toggle: synchronous duplicate-guard, optimistic flip, revert + Chinese
+    // toast on failure, mounted-guarded state writes in finally.
+    assert.match(
+      toggleBlock,
+      /if \(!props\.onKeepSystemAwakeChange \|\| keepSystemAwakePendingRef\.current\) return;\s*keepSystemAwakePendingRef\.current = true;/,
+      'keep-awake toggle must synchronously reject a duplicate/absent-handler flip before awaiting the write',
+    );
+    assert.match(toggleBlock, /setKeepSystemAwakeChecked\(next\); \/\/ optimistic/);
+    // Revert + toast on failure (asserted individually so an explanatory
+    // comment between the catch and the revert does not brittle-break the pin).
+    assert.match(toggleBlock, /catch \(error\) \{/);
+    assert.match(
+      toggleBlock,
+      /if \(planReminderMountedRef\.current\) setKeepSystemAwakeChecked\(!next\);/,
+      'a failed write must revert the optimistic switch',
+    );
+    assert.match(
+      toggleBlock,
+      /toast\.error\(\s*'无法更新保持系统唤醒',/,
+      'a failed write must surface a Chinese error toast',
+    );
+    assert.match(
+      toggleBlock,
+      /finally \{\s*keepSystemAwakePendingRef\.current = false;\s*if \(planReminderMountedRef\.current\) setKeepSystemAwakePending\(false\);/,
+      'keep-awake toggle owner must release without writing React state after unmount',
+    );
+
+    // The switch reflects the optimistic state and disables while a write runs.
+    assert.match(panelBlock, /checked=\{keepSystemAwakeChecked\}/);
+    assert.match(panelBlock, /disabled=\{keepSystemAwakePending\}/);
+    assert.match(panelBlock, /onChange=\{\(next\) => void toggleKeepSystemAwake\(next\)\}/);
+  });
 });

--- a/apps/desktop/src/main/keep-system-awake.ts
+++ b/apps/desktop/src/main/keep-system-awake.ts
@@ -1,0 +1,71 @@
+/**
+ * Keep-system-awake controller for the 定时任务 (scheduled task) capability.
+ *
+ * Scheduled reminders are driven by an in-process timer (see
+ * `plan-reminders`); when the machine sleeps that timer is frozen and the
+ * reminder silently never fires. When the user enables 保持系统唤醒 we hold an
+ * Electron `powerSaveBlocker` so background scheduled work keeps running.
+ *
+ * `prevent-app-suspension` (NOT `prevent-display-sleep`) is deliberate: it
+ * keeps the *system* from suspending the app while still letting the display
+ * sleep. That is exactly right for background scheduled work — we do not want
+ * to force the user's monitor to stay lit just to run a timer.
+ *
+ * Kept free of any `electron` import so the start/stop bookkeeping can be
+ * unit-tested under plain `node --test` (the caller injects electron's
+ * `powerSaveBlocker`), mirroring how `notifications-policy.ts` keeps its
+ * decision logic Electron-free while `notifications-ipc-main.ts` owns the
+ * Electron surface.
+ */
+
+/** Electron `powerSaveBlocker`'s surface, narrowed to what we use. */
+export interface PowerSaveBlockerLike {
+  start(type: 'prevent-app-suspension' | 'prevent-display-sleep'): number;
+  stop(id: number): void;
+  isStarted(id: number): boolean;
+}
+
+export interface KeepSystemAwakeController {
+  /**
+   * Reconcile the blocker with the desired state. Starts the blocker when
+   * `enabled` and it is not already running; stops it when `!enabled` and it
+   * is running. Idempotent — safe to call on every settings change and at
+   * launch.
+   */
+  apply(enabled: boolean): void;
+  /** Whether a blocker is currently held (for diagnostics / tests). */
+  isActive(): boolean;
+}
+
+export function createKeepSystemAwakeController(
+  blocker: PowerSaveBlockerLike,
+): KeepSystemAwakeController {
+  // The single blocker id we own, or null when nothing is held. Tracking the
+  // id (plus an `isStarted` re-check) guards against a double-start leaking a
+  // second, unreleasable blocker.
+  let blockerId: number | null = null;
+
+  function start(): void {
+    // Guard double-start: if we already hold a live blocker, do nothing.
+    if (blockerId !== null && blocker.isStarted(blockerId)) return;
+    blockerId = blocker.start('prevent-app-suspension');
+  }
+
+  function stop(): void {
+    if (blockerId === null) return;
+    // The blocker may have been released out from under us (process teardown
+    // races); only call stop when it is genuinely still running.
+    if (blocker.isStarted(blockerId)) blocker.stop(blockerId);
+    blockerId = null;
+  }
+
+  return {
+    apply(enabled: boolean): void {
+      if (enabled) start();
+      else stop();
+    },
+    isActive(): boolean {
+      return blockerId !== null && blocker.isStarted(blockerId);
+    },
+  };
+}

--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -1,4 +1,4 @@
-import { app, ipcMain, nativeImage, powerMonitor, safeStorage, shell } from 'electron';
+import { app, ipcMain, nativeImage, powerMonitor, powerSaveBlocker, safeStorage, shell } from 'electron';
 import { randomUUID } from 'node:crypto';
 import { mkdir, readFile, realpath } from 'node:fs/promises';
 import { isAbsolute, join, relative, resolve, sep } from 'node:path';
@@ -181,6 +181,7 @@ import { registerOnboardingIpc } from './onboarding-ipc-main.js';
 import { registerSessionEntryIpc } from './session-entry-ipc-main.js';
 import { registerPermissionsIpc } from './permissions-ipc-main.js';
 import { registerSettingsIpc } from './settings-ipc-main.js';
+import { createKeepSystemAwakeController } from './keep-system-awake.js';
 import { registerGatewayIpc } from './gateway-ipc-main.js';
 import { registerSessionsIpc } from './sessions-ipc-main.js';
 import {
@@ -254,6 +255,12 @@ try {
 }
 const workspaceRoot = join(app.getPath('userData'), 'workspaces', visualSmokeFixture?.workspaceName ?? 'default');
 let configWatcher: ConfigFileWatcher | undefined;
+// 保持系统唤醒 (settings.system.keepSystemAwake): holds an Electron
+// `powerSaveBlocker` so in-process scheduled tasks keep firing while the
+// machine would otherwise sleep. Injected with electron's blocker; the
+// controller owns the id + double-start guard. The blocker dies with the
+// process, so quit needs no special teardown.
+const keepSystemAwake = createKeepSystemAwakeController(powerSaveBlocker);
 const store = createSessionStore(workspaceRoot);
 const runStore = createAgentRunStore(workspaceRoot);
 const runtimeEventStore = createRuntimeEventStore(workspaceRoot);
@@ -1299,6 +1306,11 @@ async function applySettingsRuntimeEffects(settings: AppSettings, patch: UpdateA
   if (patch.chatDefaults?.permissionMode) {
     await syncDefaultPermissionModeToSessions(settings.chatDefaults.permissionMode);
   }
+  if (patch.system) {
+    // Start/stop the power-save blocker the instant the toggle flips so the
+    // capability reflects the user's choice without waiting for a relaunch.
+    keepSystemAwake.apply(settings.system.keepSystemAwake);
+  }
 }
 
 async function syncDefaultPermissionModeToSessions(mode: Exclude<PermissionMode, 'explore'>): Promise<void> {
@@ -1324,6 +1336,7 @@ async function handleExternalSettingsChange(): Promise<void> {
       network: settings.network,
       botChat: settings.botChat,
       openGateway: settings.openGateway,
+      system: settings.system,
     };
     await applySettingsRuntimeEffects(settings, fullPatch);
   } catch (error) {
@@ -1708,6 +1721,9 @@ async function runBackgroundStartup(): Promise<void> {
   }
   const settings = await settingsStore.get();
   setActiveProxy(toContractNetworkSettings(settings.network).proxy);
+  // Re-hold the power-save blocker at launch if the user left it enabled, so
+  // scheduled tasks survive machine sleep across restarts.
+  keepSystemAwake.apply(settings.system.keepSystemAwake);
   await telemetryRepo.load();
   lookupPricing = buildPricingLookup(telemetryRepo.listPricingOverrides());
   await recoverInterruptedSessionsOnStartup();

--- a/apps/desktop/src/renderer/app-shell.tsx
+++ b/apps/desktop/src/renderer/app-shell.tsx
@@ -61,6 +61,7 @@ import { AppShellTopbarActions, AppShellWorkspaceTopActions } from './app-shell-
 import { AppShellOverlays } from './app-shell-overlays';
 import { createAppShellDailyReviewBridge } from './app-shell-daily-review-bridge';
 import { useAppShellModuleData } from './use-module-data';
+import { useKeepSystemAwake } from './use-keep-system-awake';
 import { useAppShellProjectContext } from './use-project-context';
 import { createAppShellSessionEventHandlers } from './app-shell-session-events';
 import { createAppShellVisualSmokeActions } from './app-shell-visual-smoke';
@@ -772,6 +773,11 @@ function AppShellContent({
     toastApi,
   });
 
+  // 保持系统唤醒 capability for the 定时任务 page: reads/writes
+  // settings.system.keepSystemAwake over the existing settings bridge. When
+  // the bridge is absent the panel hides the row (fail-soft).
+  const keepSystemAwakeController = useKeepSystemAwake();
+
   // Composer mention popups: `/` skills (enabled only) + `@` workspace file
   // search. The hook owns the window.maka IPC wrapper so app-shell keeps no
   // inline mention state.
@@ -1333,6 +1339,16 @@ function AppShellContent({
                 <AutomationsPage
                   skills={skills}
                   reminders={planReminders}
+                  keepSystemAwake={
+                    keepSystemAwakeController.supported
+                      ? keepSystemAwakeController.keepSystemAwake
+                      : undefined
+                  }
+                  onKeepSystemAwakeChange={
+                    keepSystemAwakeController.supported
+                      ? keepSystemAwakeController.setKeepSystemAwake
+                      : undefined
+                  }
                     onRefresh={() =>
                       refreshPlanReminders({
                         shouldShowError: isAutomationsSurfaceActive,

--- a/apps/desktop/src/renderer/styles/module-pages/plan-reminders.css
+++ b/apps/desktop/src/renderer/styles/module-pages/plan-reminders.css
@@ -257,50 +257,50 @@
   height: 13px;
 }
 
-/* PR-UI-PIXEL-2: reference's info strip is a calm, roomy blue banner
-   (≈#e6f7ff bg / #b0e3ff border, r8, 12×16 padding) — not a tight chip. */
-.maka-plan-system-alert {
+/* 保持系统唤醒 capability row. Status-color restraint (#651): this is an
+   informational-expected capability control, not an exception state — so it
+   uses the house passive neutral surface (matching settingsNotice[data-tone=
+   "passive"]) with a hairline border, radius-surface, and a 4px-grid rhythm,
+   flush with the module content. NOT the reference's saturated blue banner. */
+.maka-plan-system-awake {
   display: flex;
   min-height: 48px;
   align-items: center;
   justify-content: space-between;
   gap: var(--space-3);
-  border-color: oklch(from var(--system-alert-accent) 0.90 min(c, 0.04) h);
+  border: var(--border-width-hairline) solid var(--border);
   border-radius: var(--radius-surface);
-  background: oklch(from var(--system-alert-accent) 0.965 min(c, 0.035) h);
-  color: oklch(from var(--system-alert-accent) 0.50 min(c, 0.13) h);
+  background: var(--foreground-5);
+  color: var(--muted-foreground);
   padding: var(--space-3) var(--space-4);
 }
 
-.maka-plan-system-alert [class*="lucide"] {
-  color: oklch(from var(--system-alert-accent) 0.42 min(c, 0.095) h);
+.maka-plan-system-awake [class*="lucide"] {
+  color: var(--muted-foreground);
 }
 
-.maka-plan-system-alert-main {
+.maka-plan-system-awake-main {
   display: inline-flex;
   min-width: 0;
   align-items: center;
   gap: var(--space-1-5);
 }
 
-.maka-plan-system-alert-main div {
-  display: flex;
-  align-items: center;
-  gap: var(--space-1-5);
-}
-
-.maka-plan-system-alert-main > [class*="lucide"] {
+.maka-plan-system-awake-main > [class*="lucide"] {
   flex: 0 0 auto;
 }
 
-.dark .maka-plan-system-alert {
-  border-color: oklch(from var(--system-alert-accent) 0.56 min(c, 0.08) h / 0.44);
-  background: oklch(from var(--system-alert-accent) 0.25 min(c, 0.04) h / 0.52);
-  color: oklch(from var(--system-alert-accent) 0.84 min(c, 0.07) h);
+.maka-plan-system-awake-control {
+  display: inline-flex;
+  flex: 0 0 auto;
+  align-items: center;
+  gap: var(--space-2-5);
 }
 
-.dark .maka-plan-system-alert [class*="lucide"] {
-  color: oklch(from var(--system-alert-accent) 0.84 min(c, 0.07) h);
+.maka-plan-system-awake-label {
+  color: var(--foreground);
+  font-size: var(--font-size-ui);
+  font-weight: var(--font-weight-medium);
 }
 
 .maka-plan-tabs {
@@ -777,7 +777,7 @@
     display: grid;
   }
 
-  .maka-plan-system-alert {
+  .maka-plan-system-awake {
     display: grid;
   }
 

--- a/apps/desktop/src/renderer/use-keep-system-awake.ts
+++ b/apps/desktop/src/renderer/use-keep-system-awake.ts
@@ -1,0 +1,69 @@
+import { useCallback, useEffect, useState } from 'react';
+import { useMountedRef } from '@maka/ui';
+
+/**
+ * Reads + writes the 保持系统唤醒 (`settings.system.keepSystemAwake`) toggle
+ * that surfaces on the 定时任务 page. Rides the existing `settings:get` /
+ * `settings:update` bridge — no dedicated IPC channel.
+ *
+ * `supported` gates the whole capability on bridge presence: when the
+ * preload bridge is absent (older main, or a non-Electron host), the caller
+ * hides the row entirely rather than rendering a dead control. The
+ * optimistic-update / revert-on-error / toast lifecycle lives in the panel;
+ * this hook only owns the persisted snapshot and the write that rejects on
+ * failure so the panel can revert.
+ */
+export interface KeepSystemAwakeController {
+  /** Whether the settings bridge exposing this toggle exists. */
+  supported: boolean;
+  /** Last-known persisted value. Defaults to false until the first read. */
+  keepSystemAwake: boolean;
+  /**
+   * Persist a new value. Resolves once the store confirms the write (and
+   * updates the local snapshot); rejects on failure so the caller can revert
+   * its optimistic UI.
+   */
+  setKeepSystemAwake(next: boolean): Promise<void>;
+}
+
+export function useKeepSystemAwake(): KeepSystemAwakeController {
+  // Gate on the bridge actually exposing both calls at runtime. `window.maka`
+  // is typed as always-present, so a truthiness check trips TS2774; a
+  // `typeof … === 'function'` probe is the honest runtime guard for a
+  // non-Electron host or an older preload that predates this capability.
+  const supported =
+    typeof window.maka?.settings?.get === 'function' &&
+    typeof window.maka?.settings?.update === 'function';
+  const [keepSystemAwake, setSnapshot] = useState(false);
+  const mountedRef = useMountedRef();
+
+  const refresh = useCallback(async () => {
+    if (!supported) return;
+    try {
+      const settings = await window.maka.settings.get();
+      if (mountedRef.current) setSnapshot(settings.system.keepSystemAwake);
+    } catch {
+      // Best-effort read: leave the last-known snapshot in place. A failed
+      // read must not throw into render or wedge the toggle.
+    }
+  }, [supported, mountedRef]);
+
+  useEffect(() => {
+    void refresh();
+    if (!supported) return;
+    // Keep the snapshot honest when settings.json is edited out of band.
+    return window.maka.settings.subscribeExternalChanged(() => {
+      void refresh();
+    });
+  }, [supported, refresh]);
+
+  const setKeepSystemAwake = useCallback(
+    async (next: boolean) => {
+      const result = await window.maka.settings.update({ system: { keepSystemAwake: next } });
+      if (mountedRef.current) setSnapshot(result.settings.system.keepSystemAwake);
+    },
+    [mountedRef],
+  );
+
+  return { supported, keepSystemAwake, setKeepSystemAwake };
+}

--- a/packages/core/src/__tests__/settings.test.ts
+++ b/packages/core/src/__tests__/settings.test.ts
@@ -385,6 +385,38 @@ describe('run-completion notification settings contract', () => {
   });
 });
 
+describe('keep-system-awake settings contract', () => {
+  test('createDefaultSettings leaves keep-system-awake off by default', () => {
+    const defaults = createDefaultSettings();
+    expect(defaults.system.keepSystemAwake).toBe(false);
+  });
+
+  test('migration: settings.json without a system section defaults to off', () => {
+    const legacy = { appearance: { theme: 'dark' as const } };
+    const normalized = normalizeSettings(legacy);
+    expect(normalized.system.keepSystemAwake).toBe(false);
+  });
+
+  test('mergeSettings carries the toggle through the patch surface', () => {
+    const current = createDefaultSettings();
+    const patched = mergeSettings(current, { system: { keepSystemAwake: true } });
+    expect(patched.system.keepSystemAwake).toBe(true);
+  });
+
+  test('fail-closed: a non-boolean keepSystemAwake normalizes back to off', () => {
+    for (const bad of [1, 0, 'yes', null, {}, []]) {
+      const malformed = { system: { keepSystemAwake: bad } };
+      const normalized = normalizeSettings(malformed);
+      expect(normalized.system.keepSystemAwake).toBe(false);
+    }
+  });
+
+  test('a valid enabled toggle survives normalize untouched', () => {
+    const normalized = normalizeSettings({ system: { keepSystemAwake: true } });
+    expect(normalized.system.keepSystemAwake).toBe(true);
+  });
+});
+
 describe('fixed toast position settings contract', () => {
   test('createDefaultSettings does not persist a toastPosition setting', () => {
     const defaults = createDefaultSettings();

--- a/packages/core/src/settings.ts
+++ b/packages/core/src/settings.ts
@@ -305,6 +305,22 @@ export interface NotificationSettings {
   runComplete: boolean;
 }
 
+/**
+ * System-level power behavior (Settings surface: the 定时任务 page's
+ * capability row). Scheduled tasks are driven by an in-process timer; when
+ * the machine sleeps, that timer is frozen and reminders silently never
+ * fire. `keepSystemAwake` lets the user hold a power-save blocker so
+ * background scheduled work keeps running.
+ *
+ * The main process owns the actual Electron `powerSaveBlocker`
+ * (`prevent-app-suspension`, which keeps the system awake WITHOUT forcing
+ * the display on). This flag is the pure product on/off toggle, mirroring
+ * `notifications.runComplete`.
+ */
+export interface SystemSettings {
+  keepSystemAwake: boolean;
+}
+
 export interface AppSettings {
   schemaVersion: 1;
   network: NetworkSettings;
@@ -320,6 +336,7 @@ export interface AppSettings {
   privacy: PrivacySettings;
   chatDefaults: ChatDefaultsSettings;
   notifications: NotificationSettings;
+  system: SystemSettings;
 }
 
 export interface UsageRequestLog {
@@ -387,6 +404,7 @@ export type UpdateAppSettingsInput = Partial<{
   privacy: Partial<PrivacySettings>;
   chatDefaults: Partial<ChatDefaultsSettings>;
   notifications: Partial<NotificationSettings>;
+  system: Partial<SystemSettings>;
   webSearch: Partial<{
     enabled: boolean;
     defaultProvider: WebSearchProvider;
@@ -511,6 +529,11 @@ export function createDefaultSettings(): AppSettings {
     notifications: {
       runComplete: true,
     },
+    system: {
+      // Off by default: holding a power-save blocker is an explicit,
+      // battery-affecting opt-in, not a silent default.
+      keepSystemAwake: false,
+    },
   };
 }
 
@@ -587,6 +610,10 @@ export function mergeSettings(current: AppSettings, patch: UpdateAppSettingsInpu
     notifications: {
       ...current.notifications,
       ...(patch.notifications ?? {}),
+    },
+    system: {
+      ...current.system,
+      ...(patch.system ?? {}),
     },
     webSearch: mergeWebSearchSettings(current.webSearch, patch.webSearch),
   };
@@ -672,6 +699,7 @@ export function normalizeSettings(input: unknown): AppSettings {
     privacy: value.privacy,
     chatDefaults: value.chatDefaults,
     notifications: value.notifications,
+    system: value.system,
   });
   // PR110b: milestones bypass the generic patch surface so we can
   // sanitize them with the closed-enum + at-most-one validator on
@@ -748,6 +776,16 @@ export function normalizeSettings(input: unknown): AppSettings {
     notifications: {
       runComplete:
         typeof base.notifications.runComplete === 'boolean' ? base.notifications.runComplete : true,
+    },
+    // Fail-closed boolean coercion, same reasoning as
+    // `notifications.runComplete`: a non-boolean `keepSystemAwake` (from a
+    // hand-edited or legacy settings.json) must not reach the main-process
+    // power-save-blocker gate as a truthy/falsy non-boolean. Default a
+    // missing/garbage value to `false` — never silently hold a power
+    // blocker the user did not opt into.
+    system: {
+      keepSystemAwake:
+        typeof base.system.keepSystemAwake === 'boolean' ? base.system.keepSystemAwake : false,
     },
   };
 }

--- a/packages/ui/src/module-pages.tsx
+++ b/packages/ui/src/module-pages.tsx
@@ -70,6 +70,8 @@ export function SkillsPage(props: {
 export function AutomationsPage(props: {
   skills?: SkillEntry[];
   reminders?: PlanReminder[];
+  keepSystemAwake?: boolean;
+  onKeepSystemAwakeChange?: (next: boolean) => Promise<void>;
   onRefresh?: () => void | Promise<void>;
   onCreate?(input: PlanReminderDraftInput): boolean | Promise<boolean> | void | Promise<void>;
   onUpdate?(id: string, patch: PlanReminderUpdatePatch): boolean | Promise<boolean> | void | Promise<void>;

--- a/packages/ui/src/plan-reminder-panel.tsx
+++ b/packages/ui/src/plan-reminder-panel.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from 'react';
 import { Button as BaseButton } from '@base-ui/react/button';
 import { useMountedRef } from './use-mounted-ref.js';
+import { useToast } from './toast.js';
 import {
   ArchiveRestore,
   Clock,
@@ -21,6 +22,7 @@ import type {
 import {
   deriveCapabilityAuditReport,
   formatPlanReminderDeliveryTarget,
+  generalizedErrorMessageChinese,
 } from '@maka/core';
 import {
   PLAN_REMINDER_EXAMPLE_TEMPLATES,
@@ -50,11 +52,11 @@ import {
   TabsRoot,
   TabsTrigger,
 } from './ui.js';
+import { SettingsSwitch } from './primitives/settings-switch.js';
 import { Badge } from './primitives/badge.js';
 import { Chip, type ChipProps } from './primitives/chip.js';
 import { PageHeader } from './primitives/page-header.js';
 import { Input } from './primitives/input.js';
-import { Alert, AlertTitle } from './primitives/alert.js';
 import { Menu, MenuItem, MenuPopup, MenuTrigger } from './primitives/menu.js';
 import { EmptyState } from './empty-state.js';
 import { CapabilityAuditStrip } from './capability-audit-strip.js';
@@ -78,6 +80,13 @@ function planRunStatusChipTone(
 export function PlanReminderPanel(props: {
   reminders: PlanReminder[];
   auditReport?: CapabilityAuditReport;
+  /**
+   * Current persisted 保持系统唤醒 state. `undefined` means the capability is
+   * unavailable (bridge absent / older main) — the row hides entirely.
+   */
+  keepSystemAwake?: boolean;
+  /** Persist a new keep-awake value; rejects on failure so the row reverts. */
+  onKeepSystemAwakeChange?: (next: boolean) => Promise<void>;
   onRefresh?(): void | Promise<void>;
   onCreate?(input: PlanReminderDraftInput): boolean | Promise<boolean> | void | Promise<void>;
   onUpdate?(id: string, patch: PlanReminderUpdatePatch): boolean | Promise<boolean> | void | Promise<void>;
@@ -110,6 +119,17 @@ export function PlanReminderPanel(props: {
   const [listSort, setListSort] = useState<PlanReminderSort>('created-desc');
   const [listQuery, setListQuery] = useState('');
   const [refreshPending, setRefreshPending] = useState(false);
+  const toast = useToast();
+  // 保持系统唤醒 capability control. Available only when the host wires both
+  // the current value and the setter (bridge present); otherwise the row
+  // hides. Local optimistic state drives the switch, initialized from the
+  // persisted snapshot and re-synced when the prop changes (but never while a
+  // write is in flight, so a slow snapshot can't clobber the optimistic flip).
+  const keepSystemAwakeSupported =
+    props.keepSystemAwake !== undefined && typeof props.onKeepSystemAwakeChange === 'function';
+  const [keepSystemAwakeChecked, setKeepSystemAwakeChecked] = useState(props.keepSystemAwake ?? false);
+  const [keepSystemAwakePending, setKeepSystemAwakePending] = useState(false);
+  const keepSystemAwakePendingRef = useRef(false);
   const normalizedListQuery = normalizePlanReminderSearchQuery(listQuery);
   const searchMatchedReminders = normalizedListQuery
     ? props.reminders.filter((reminder) => planReminderMatchesSearch(reminder, normalizedListQuery))
@@ -138,8 +158,37 @@ export function PlanReminderPanel(props: {
     return () => {
       refreshPendingRef.current = false;
       pendingActionKeysRef.current = new Set();
+      keepSystemAwakePendingRef.current = false;
     };
   }, []);
+
+  // Re-sync the switch to the persisted snapshot when it changes (external
+  // edit, relaunch), unless a local write is mid-flight — the optimistic
+  // value wins until the write settles.
+  useEffect(() => {
+    if (keepSystemAwakePendingRef.current) return;
+    if (props.keepSystemAwake !== undefined) setKeepSystemAwakeChecked(props.keepSystemAwake);
+  }, [props.keepSystemAwake]);
+
+  async function toggleKeepSystemAwake(next: boolean) {
+    if (!props.onKeepSystemAwakeChange || keepSystemAwakePendingRef.current) return;
+    keepSystemAwakePendingRef.current = true;
+    setKeepSystemAwakePending(true);
+    setKeepSystemAwakeChecked(next); // optimistic
+    try {
+      await props.onKeepSystemAwakeChange(next);
+    } catch (error) {
+      // Revert to reflect REALITY, and surface the failure in Chinese.
+      if (planReminderMountedRef.current) setKeepSystemAwakeChecked(!next);
+      toast.error(
+        '无法更新保持系统唤醒',
+        generalizedErrorMessageChinese(error, '更新保持系统唤醒设置失败，请稍后重试。'),
+      );
+    } finally {
+      keepSystemAwakePendingRef.current = false;
+      if (planReminderMountedRef.current) setKeepSystemAwakePending(false);
+    }
+  }
 
   function openReminderDialog(seed: PlanReminderFormSeed) {
     setFormSeed(seed);
@@ -238,19 +287,28 @@ export function PlanReminderPanel(props: {
             the empty state (quick-start), so the populated/default view matches
             the reference's clean flow. */}
 
-        {/* Designer audit P1-5: the 保持系统唤醒·即将支持 tag was removed —
-            unshipped features don't belong in first-screen chrome. Reintroduce
-            the control (as a real Switch) when the wake-lock lands. */}
-        <Alert variant="info" className="maka-plan-system-alert">
-          <div className="maka-plan-system-alert-main">
-            <Info aria-hidden="true" />
-            <div>
-              {/* Designer audit P2-12: one sentence, the one that matters —
-                  the queue/run-history mechanics line was engineering trivia. */}
-              <AlertTitle>计划提醒只在本机唤醒时运行</AlertTitle>
+        {/* Designer audit P1-5 follow-through: the earlier placeholder tag
+            (removed for placeholder honesty) is now shipped as a REAL control.
+            Status-color restraint keeps this informational-expected capability
+            row neutral (passive surface + switch), not a saturated banner. The
+            row hides entirely when the host can't wire the toggle. */}
+        {keepSystemAwakeSupported && (
+          <div className="maka-plan-system-awake" data-tone="passive">
+            <div className="maka-plan-system-awake-main">
+              <Info size={15} aria-hidden="true" />
+              <span>定时任务仅在电脑保持唤醒时运行</span>
+            </div>
+            <div className="maka-plan-system-awake-control">
+              <span className="maka-plan-system-awake-label">保持系统唤醒</span>
+              <SettingsSwitch
+                ariaLabel="保持系统唤醒"
+                checked={keepSystemAwakeChecked}
+                disabled={keepSystemAwakePending}
+                onChange={(next) => void toggleKeepSystemAwake(next)}
+              />
             </div>
           </div>
-        </Alert>
+        )}
 
         <CapabilityAuditStrip report={auditReport} />
 


### PR DESCRIPTION
User-requested: the 定时任务 page lacked the keep-system-awake notice + toggle + capability (a 即将支持 placeholder was removed earlier for placeholder honesty — this ships the real thing).

## End-to-end
- **Setting**: `system.keepSystemAwake` on AppSettings (default false), modeled on notifications.runComplete — merge/patch/fail-closed coercion + core tests.
- **Capability**: keep-system-awake.ts wraps Electron powerSaveBlocker with `prevent-app-suspension` (system stays awake, display may sleep — the right mode for background scheduled work). Double-start guard, re-acquire after out-of-band release; 7 unit tests with mocked electron.
- **Wiring**: rides the existing settings:update channel (zero new IPC). Toggle applies instantly; re-held at launch when enabled; reconciles external settings.json edits.
- **UI**: neutral passive row above the plan list — Info icon + 定时任务仅在电脑保持唤醒时运行 + right-aligned 保持系统唤醒 SettingsSwitch. House style (no saturated banner; status-color restraint). Optimistic flip with revert-on-error + Chinese toast, useMountedRef + pending guard, row hides when the bridge is absent.

## Verification
Live CDP: click → aria-checked true → stayed true (full path exercised: optimistic → settings:update → powerSaveBlocker.start). Light+dark captures both states, accepted by maintainer. plan-reminder-panel contract extended (new pins for duplicate-guard/revert/unmount-release), nothing deleted.

## Gates (merged tree with main incl. #1205)
desktop 2709/2709 · ui 183/183 · core green · typecheck · check-dead-css · knip no new debt · alignment auditor all fixtures clean. Implemented by an opus worktree agent.