### PR TITLE
fix(runtime): honor selected model output limits

### DIFF
--- a/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
+++ b/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
@@ -81,6 +81,39 @@ describe('AiSdkBackend model history', () => {
     ]);
   });
 
+  test('sends the selected Kimi model output limit instead of the Anthropic unknown-model default', async () => {
+    const model = completionModel();
+    const backend = new AiSdkBackend({
+      sessionId: 'session-1',
+      header: header(),
+      appendMessage: async () => {},
+      connection: {
+        slug: 'kimi-coding-plan',
+        name: 'Kimi Coding Plan',
+        providerType: 'kimi-coding-plan',
+        defaultModel: 'k3',
+        enabled: true,
+        createdAt: 1,
+        updatedAt: 1,
+      },
+      apiKey: 'sk-test',
+      modelId: 'k3',
+      permissionEngine: new PermissionEngine({ newId: () => 'permission-id', now: () => 1 }),
+      modelFactory: () => model,
+      tools: [],
+      newId: idGenerator(),
+      now: monotonicClock(),
+    });
+
+    await drain(backend.send({
+      turnId: 'turn-current',
+      text: 'current user',
+      context: [],
+    }));
+
+    assert.equal(model.doStreamCalls[0]?.maxOutputTokens, 131_072);
+  });
+
   test('prefers RuntimeEvent prior messages and appends current user once', async () => {
     const model = completionModel();
     const backend = new AiSdkBackend({

--- a/packages/runtime/src/model-adapter.ts
+++ b/packages/runtime/src/model-adapter.ts
@@ -6,6 +6,7 @@ import type {
   CompleteEvent,
 } from '@maka/core/events';
 import { providerAuthRequiresSecret, type LlmConnection } from '@maka/core/llm-connections';
+import { lookupModelMetadata } from '@maka/core/model-metadata';
 import { generalizedErrorMessage } from '@maka/core/redaction';
 import type { CacheMissInputSource } from '@maka/core/usage-stats/types';
 import type { ModelMessage } from 'ai';
@@ -180,6 +181,7 @@ export class ModelAdapter {
     };
 
     const maxSteps = input.maxSteps ?? this.input.maxSteps;
+    const maxOutputTokens = selectedModelMaxOutputTokens(this.input.connection, this.input.modelId);
     const configuredStop = maxSteps === undefined
       ? isLoopFinished()
       : isStepCount(maxSteps);
@@ -192,6 +194,7 @@ export class ModelAdapter {
       ...(input.prepareStep ? { prepareStep: input.prepareStep } : {}),
       repairToolCall: input.repairToolCall,
       ...(input.system ? { instructions: input.system } : {}),
+      ...(maxOutputTokens !== undefined ? { maxOutputTokens } : {}),
       providerOptions: this.input.providerOptions,
       // streamText defaults to one step when stopWhen is omitted. Its exported
       // non-stopping condition is required for an unbounded tool loop.
@@ -345,6 +348,11 @@ export class ModelAdapter {
       default:               return 'end_turn';
     }
   }
+}
+
+function selectedModelMaxOutputTokens(connection: LlmConnection, modelId: string): number | undefined {
+  return connection.models?.find((model) => model.id === modelId)?.maxOutputTokens
+    ?? lookupModelMetadata(connection.providerType, modelId).maxOutputTokens;
 }
 
 export interface ModelAdapterRuntimeEventReplaySupport {


### PR DESCRIPTION
## Summary

- Resolve the selected model's output-token limit from the connection override or the canonical model metadata.
- Pass that limit to every AI SDK `streamText` request.
- Cover Kimi K3's 131,072-token contract through the `AiSdkBackend.send()` boundary.

## Verification

- RED: the focused regression observed `maxOutputTokens === undefined` on current `main` instead of `131072`.
- `npm --workspace @maka/runtime test` — 2,112 passed, 7 skipped, 0 failed.
- `git diff --check`

The repository-wide bootstrap rebuild was not used as a gate because this checkout's shared dependency installation is missing `@modelcontextprotocol/sdk`, which stops the unrelated `@maka/mcp` build. The complete runtime workspace build and test suite passed.

## Root cause

The runtime selected the K3 model correctly but did not forward its metadata-backed output limit to `streamText`. The AI SDK/provider adapter therefore fell back to its unknown-model behavior, allowing long responses to terminate at the wrong `max_tokens` boundary.

## Scope

This PR changes only the runtime model request contract. Harbor task deadlines, harness recovery, provider telemetry, and benchmark reporting remain separate follow-ups.
