### PR TITLE
fix(headless): align Harbor execution lifecycles

### DIFF
--- a/packages/headless/harbor/kimi_code_agent.py
+++ b/packages/headless/harbor/kimi_code_agent.py
@@ -6,6 +6,7 @@ import asyncio
 import hashlib
 import json
 import os
+import re
 import secrets
 import shlex
 import time
@@ -30,6 +31,9 @@ print_background_mode = "exit"
 keep_alive_on_exit = true
 """
 _REQUEST_TIMEOUT_GRACE_SEC = 120
+_DEFAULT_CELL_TIMEOUT_SEC = 900
+_MAX_SAFE_INTEGER = 9007199254740991
+_POSITIVE_INT_RE = re.compile(r"[1-9][0-9]*")
 
 
 class MakaKimiCodeAgent(BaseInstalledAgent):
@@ -149,13 +153,7 @@ class MakaKimiCodeAgent(BaseInstalledAgent):
         if not model:
             raise ValueError("MAKA_MODEL is required")
         effort = self._get_env("MAKA_REASONING_EFFORT") or "max"
-        task_timeout_raw = (self._get_env("MAKA_CELL_TIMEOUT_SEC") or "").strip()
-        try:
-            task_timeout_sec = int(task_timeout_raw)
-        except ValueError as error:
-            raise ValueError("MAKA_CELL_TIMEOUT_SEC must be a positive integer") from error
-        if task_timeout_sec <= 0 or str(task_timeout_sec) != task_timeout_raw:
-            raise ValueError("MAKA_CELL_TIMEOUT_SEC must be a positive integer")
+        task_timeout_sec = self._cell_timeout_sec()
         return {
             "KIMI_CODE_HOME": str(_KIMI_HOME),
             "KIMI_MODEL_NAME": model,
@@ -171,6 +169,19 @@ class MakaKimiCodeAgent(BaseInstalledAgent):
             "KIMI_MODEL_ADAPTIVE_THINKING": "true",
             "KIMI_MODEL_THINKING_EFFORT": effort,
         }
+
+    def _cell_timeout_sec(self) -> int:
+        raw = self._get_env("MAKA_CELL_TIMEOUT_SEC")
+        if not raw:
+            return _DEFAULT_CELL_TIMEOUT_SEC
+        stripped = raw.strip()
+        if _POSITIVE_INT_RE.fullmatch(stripped) is None:
+            return _DEFAULT_CELL_TIMEOUT_SEC
+        try:
+            value = int(stripped)
+        except ValueError:
+            return _DEFAULT_CELL_TIMEOUT_SEC
+        return value if value <= _MAX_SAFE_INTEGER else _DEFAULT_CELL_TIMEOUT_SEC
 
     def _events(self, *, require_assistant: bool = False) -> list[dict[str, Any]]:
         path = self.logs_dir / _OUTPUT_PATH.name

--- a/packages/headless/harbor/kimi_code_agent.py
+++ b/packages/headless/harbor/kimi_code_agent.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+import asyncio
 import hashlib
 import json
 import os
+import secrets
 import shlex
 import time
 from pathlib import Path
@@ -14,12 +16,20 @@ from harbor.agents.installed.base import BaseInstalledAgent, with_prompt_templat
 from harbor.environments.base import BaseEnvironment
 from harbor.models.agent.context import AgentContext
 
+from process_scope import scoped_command, scoped_process_cleanup_command
+
 _TOOLCHAIN_ROOT = Path("/opt/maka-kimi-code-toolchain")
 _TOOLCHAIN_NODE = _TOOLCHAIN_ROOT / "bin" / "node"
 _TOOLCHAIN_ENTRYPOINT = _TOOLCHAIN_ROOT / "lib" / "kimi-code" / "main.mjs"
 _TOOLCHAIN_MANIFEST = _TOOLCHAIN_ROOT / "manifest.json"
 _TOOLCHAIN_CHECKSUMS = _TOOLCHAIN_ROOT / "checksums.sha256"
 _OUTPUT_PATH = Path("/logs/agent/kimi-code.jsonl")
+_KIMI_HOME = Path("/tmp/maka-kimi-code")
+_PRINT_CONFIG = """[background]
+print_background_mode = "exit"
+keep_alive_on_exit = true
+"""
+_REQUEST_TIMEOUT_GRACE_SEC = 120
 
 
 class MakaKimiCodeAgent(BaseInstalledAgent):
@@ -69,25 +79,63 @@ class MakaKimiCodeAgent(BaseInstalledAgent):
     ) -> None:
         self._started_at_ms = int(time.time() * 1000)
         self._write_execution_identity()
+        command_scope = secrets.token_urlsafe(24)
+        abnormal_exit = False
         try:
+            command = (
+                f"mkdir -p {shlex.quote(str(_KIMI_HOME))}; "
+                f"printf %s {shlex.quote(_PRINT_CONFIG)} > "
+                f"{shlex.quote(str(_KIMI_HOME / 'config.toml'))}; "
+                f"{shlex.quote(str(_TOOLCHAIN_NODE))} "
+                f"{shlex.quote(str(_TOOLCHAIN_ENTRYPOINT))} "
+                "--output-format stream-json --prompt "
+                f"{shlex.quote(instruction)} "
+                f"> {shlex.quote(str(_OUTPUT_PATH))} "
+                "2> /logs/agent/kimi-code.stderr.txt"
+            )
             await self.exec_as_agent(
                 environment,
-                command=(
-                    "mkdir -p /tmp/maka-kimi-code; "
-                    f"{shlex.quote(str(_TOOLCHAIN_NODE))} "
-                    f"{shlex.quote(str(_TOOLCHAIN_ENTRYPOINT))} "
-                    "--output-format stream-json --prompt "
-                    f"{shlex.quote(instruction)} "
-                    f"> {shlex.quote(str(_OUTPUT_PATH))} "
-                    "2> /logs/agent/kimi-code.stderr.txt"
+                command=scoped_command(
+                    command,
+                    command_scope,
+                    secrets.token_urlsafe(12),
                 ),
                 env=self._runtime_env(),
             )
-        except Exception as error:
-            self._failure_class = _classify_failure(error)
+        except BaseException as error:
+            abnormal_exit = True
+            if isinstance(error, Exception):
+                self._failure_class = _classify_failure(error)
             raise
         finally:
-            self._finished_at_ms = int(time.time() * 1000)
+            try:
+                if abnormal_exit:
+                    await self._cleanup_process_scope(environment, command_scope)
+            finally:
+                self._finished_at_ms = int(time.time() * 1000)
+
+    async def _cleanup_process_scope(
+        self, environment: BaseEnvironment, command_scope: str
+    ) -> None:
+        first_error: BaseException | None = None
+        try:
+            await self.exec_as_agent(
+                environment,
+                command=scoped_process_cleanup_command(command_scope, "TERM"),
+            )
+        except BaseException as error:
+            first_error = error
+        await asyncio.sleep(0.2)
+        try:
+            await self.exec_as_agent(
+                environment,
+                command=scoped_process_cleanup_command(command_scope, "KILL"),
+            )
+        except BaseException as error:
+            if first_error is None:
+                first_error = error
+        if first_error is not None:
+            raise first_error
 
     def populate_context_post_run(self, context: AgentContext) -> None:
         self._write_cell_output()
@@ -101,8 +149,15 @@ class MakaKimiCodeAgent(BaseInstalledAgent):
         if not model:
             raise ValueError("MAKA_MODEL is required")
         effort = self._get_env("MAKA_REASONING_EFFORT") or "max"
+        task_timeout_raw = (self._get_env("MAKA_CELL_TIMEOUT_SEC") or "").strip()
+        try:
+            task_timeout_sec = int(task_timeout_raw)
+        except ValueError as error:
+            raise ValueError("MAKA_CELL_TIMEOUT_SEC must be a positive integer") from error
+        if task_timeout_sec <= 0 or str(task_timeout_sec) != task_timeout_raw:
+            raise ValueError("MAKA_CELL_TIMEOUT_SEC must be a positive integer")
         return {
-            "KIMI_CODE_HOME": "/tmp/maka-kimi-code",
+            "KIMI_CODE_HOME": str(_KIMI_HOME),
             "KIMI_MODEL_NAME": model,
             "KIMI_MODEL_API_KEY": proxy_token,
             "KIMI_MODEL_PROVIDER_TYPE": "kimi",
@@ -110,6 +165,9 @@ class MakaKimiCodeAgent(BaseInstalledAgent):
             "KIMI_MODEL_MAX_CONTEXT_SIZE": "1048576",
             "KIMI_MODEL_MAX_OUTPUT_SIZE": "131072",
             "KIMI_MODEL_MAX_COMPLETION_TOKENS": "131072",
+            "KIMI_MODEL_REQUEST_TIMEOUT_MS": str(
+                (task_timeout_sec + _REQUEST_TIMEOUT_GRACE_SEC) * 1000
+            ),
             "KIMI_MODEL_ADAPTIVE_THINKING": "true",
             "KIMI_MODEL_THINKING_EFFORT": effort,
         }

--- a/packages/headless/harbor/maka_agent.py
+++ b/packages/headless/harbor/maka_agent.py
@@ -23,11 +23,14 @@ from harbor.models.trajectories import Agent, FinalMetrics, Step, Trajectory
 from harbor.models.trial.paths import EnvironmentPaths
 from harbor.utils.trajectory_utils import format_trajectory_json
 
+from process_scope import (
+    COMMAND_SCOPE_ENV as _COMMAND_SCOPE_ENV,
+    COMMAND_SCOPE_ROOT as _COMMAND_SCOPE_ROOT,
+    scoped_command as _scoped_command,
+    scoped_command_cleanup_command as _scoped_command_cleanup_command,
+    scoped_process_cleanup_command as _scoped_process_cleanup_command,
+)
 from trial_pricing import estimate_cost, pricing_from_env
-
-
-_COMMAND_SCOPE_ENV = "MAKA_HARBOR_COMMAND_SCOPE"
-_COMMAND_SCOPE_ROOT = "/tmp/maka-harbor-command-scopes"
 
 # Default wall-clock budget for a single bridged tool command when the client
 # does not request its own timeout. Matches the in-container executor floor
@@ -356,11 +359,11 @@ class MakaAgent(BaseInstalledAgent):
             run_log_path.write_bytes(stdout + stderr)
             if process.returncode == 124:
                 # run-host-cell uses 124 only after it has settled the runtime at
-                # the soft deadline and persisted maka-cell-output.json. Reclaim
-                # any command still bridged into the task before returning, or
-                # executor teardown can consume Harbor's outer timeout instead of
-                # letting it grade the task's final filesystem state.
-                executor.mark_reclaim_active_commands()
+                # the soft deadline and persisted maka-cell-output.json. Freeze the
+                # task before grading by reclaiming every process started through
+                # this cell, including background commands that already returned
+                # to the model but can still mutate packages or workspace files.
+                executor.mark_reclaim_scoped_processes()
                 return
             if process.returncode != 0:
                 message = (stderr or stdout).decode("utf-8", errors="replace").strip()
@@ -915,8 +918,8 @@ class _ToolExecutorServer:
         self._future_command_ids: dict[concurrent.futures.Future[Any], str] = {}
         self._futures_lock = threading.Lock()
         self._accepting_requests = False
-        self._reclaim_active_commands = False
         self._reclaim_scoped_processes = False
+        self._command_cleanup_error: BaseException | None = None
         self.token = secrets.token_urlsafe(32)
         self.command_scope = secrets.token_urlsafe(24)
         self.url = ""
@@ -950,51 +953,31 @@ class _ToolExecutorServer:
         """
         self._reclaim_scoped_processes = True
 
-    def mark_reclaim_active_commands(self) -> None:
-        """Make teardown stop only commands still bridged into the task.
-
-        A settled deadline must unblock executor teardown without killing
-        services that completed commands intentionally left for the verifier.
-        """
-        self._reclaim_active_commands = True
-
     async def __aexit__(self, exc_type: Any, exc: Any, tb: Any) -> None:
         stop_error: BaseException | None = None
         cleanup_error: BaseException | None = None
         reclaim_scope = exc_type is not None or self._reclaim_scoped_processes
         try:
-            cleanup_error = await self._stop_server(
-                reclaim_scoped_processes=reclaim_scope,
-                reclaim_active_commands=(
-                    self._reclaim_active_commands and not reclaim_scope
-                ),
-            )
+            cleanup_error = await self._stop_server(reclaim_scoped_processes=reclaim_scope)
         except BaseException as error:
             stop_error = error
         if stop_error is not None and not reclaim_scope:
             cleanup_error = await self._cleanup_all_scoped_processes()
+        with self._futures_lock:
+            command_cleanup_error = self._command_cleanup_error
         if stop_error is not None:
             raise stop_error
         if cleanup_error is not None:
             raise cleanup_error
+        if command_cleanup_error is not None:
+            raise command_cleanup_error
 
-    async def _stop_server(
-        self, *, reclaim_scoped_processes: bool, reclaim_active_commands: bool
-    ) -> BaseException | None:
+    async def _stop_server(self, *, reclaim_scoped_processes: bool) -> BaseException | None:
         with self._futures_lock:
             self._accepting_requests = False
             futures = list(self._futures)
-            active_command_ids = [
-                command_id
-                for future in futures
-                if (command_id := self._future_command_ids.get(future)) is not None
-            ]
         if reclaim_scoped_processes:
             cleanup_error = await self._drain_futures_with_cleanup(futures)
-        elif reclaim_active_commands:
-            cleanup_error = await self._drain_futures_with_cleanup(
-                futures, command_ids=active_command_ids
-            )
         else:
             cleanup_error = await self._drain_futures(futures)
         if self._server is not None:
@@ -1016,10 +999,9 @@ class _ToolExecutorServer:
     async def _drain_futures_with_cleanup(
         self,
         futures: list[concurrent.futures.Future[Any]],
-        command_ids: list[str] | None = None,
     ) -> BaseException | None:
         while any(not future.done() for future in futures):
-            cleanup_error = await self._cleanup_processes(command_ids)
+            cleanup_error = await self._cleanup_processes(None)
             if cleanup_error is not None:
                 for future in futures:
                     future.cancel()
@@ -1027,7 +1009,7 @@ class _ToolExecutorServer:
                 return cleanup_error
             await asyncio.sleep(0.2)
         await self._drain_futures(futures)
-        return await self._cleanup_processes(command_ids)
+        return await self._cleanup_processes(None)
 
     async def _cleanup_processes(
         self, command_ids: list[str] | None
@@ -1067,6 +1049,8 @@ class _ToolExecutorServer:
         if handler.headers.get("authorization") != f"Bearer {self.token}":
             _write_http(handler, 401, {"error": "unauthorized"})
             return
+        command_id: str | None = None
+        future: concurrent.futures.Future[Any] | None = None
         try:
             length = int(handler.headers.get("content-length") or "0")
             payload = json.loads(handler.rfile.read(length).decode("utf-8"))
@@ -1109,71 +1093,29 @@ class _ToolExecutorServer:
                 "stderr": _exec_stderr(result),
             })
         except Exception as exc:  # noqa: BLE001 - RPC boundary returns tool failure text.
+            if command_id is not None and future is not None:
+                cleanup_error = self._cleanup_failed_command(command_id)
+                if cleanup_error is not None:
+                    with self._futures_lock:
+                        if self._command_cleanup_error is None:
+                            self._command_cleanup_error = cleanup_error
             _write_http(handler, 500, {"error": str(exc)})
+
+    def _cleanup_failed_command(self, command_id: str) -> BaseException | None:
+        assert self._loop is not None
+        cleanup = asyncio.run_coroutine_threadsafe(
+            self._cleanup_processes([command_id]),
+            self._loop,
+        )
+        try:
+            return cleanup.result(timeout=30)
+        except BaseException as error:
+            return error
 
     def _discard_future(self, future: concurrent.futures.Future[Any]) -> None:
         with self._futures_lock:
             self._futures.discard(future)
             self._future_command_ids.pop(future, None)
-
-
-def _scoped_command(command: str, scope: str, command_id: str) -> str:
-    scope_dir = shlex.quote(f"{_COMMAND_SCOPE_ROOT}/{scope}")
-    pgid_path = shlex.quote(f"{_COMMAND_SCOPE_ROOT}/{scope}/{command_id}.pgid")
-    return (
-        f"mkdir -p -- {scope_dir}; set -m; "
-        f"env {_COMMAND_SCOPE_ENV}={shlex.quote(scope)} bash -lc {shlex.quote(command)} & "
-        "command_pid=$!; "
-        f"printf '%s\\n' \"$command_pid\" > {pgid_path}; "
-        "wait \"$command_pid\"; command_status=$?; "
-        f"kill -0 -- \"-$command_pid\" 2>/dev/null || rm -f -- {pgid_path}; "
-        "exit \"$command_status\""
-    )
-
-
-def _scoped_process_cleanup_command(scope: str, signal: str) -> str:
-    if signal not in ("TERM", "KILL"):
-        raise ValueError(f"unsupported cleanup signal: {signal}")
-    marker = shlex.quote(f"{_COMMAND_SCOPE_ENV}={scope}")
-    scope_dir = shlex.quote(f"{_COMMAND_SCOPE_ROOT}/{scope}")
-    return (
-        f"for pgid_file in {scope_dir}/*.pgid; do "
-        "[ -r \"$pgid_file\" ] || continue; "
-        "pgid=$(cat -- \"$pgid_file\"); "
-        "case $pgid in ''|*[!0-9]*) continue;; esac; "
-        f"kill -{signal} -- \"-$pgid\" 2>/dev/null || true; "
-        "done; "
-        "for env_file in /proc/[0-9]*/environ; do "
-        "[ -r \"$env_file\" ] || continue; "
-        f"if tr '\\000' '\\n' < \"$env_file\" | grep -Fqx -- {marker}; then "
-        "pid=${env_file#/proc/}; pid=${pid%/environ}; "
-        f"kill -{signal} \"$pid\" 2>/dev/null || true; "
-        "fi; done"
-        + (f"; rm -rf -- {scope_dir}" if signal == "KILL" else "")
-    )
-
-
-def _scoped_command_cleanup_command(
-    scope: str, command_ids: list[str], signal: str
-) -> str:
-    if signal not in ("TERM", "KILL"):
-        raise ValueError(f"unsupported cleanup signal: {signal}")
-    pgid_paths = [
-        shlex.quote(f"{_COMMAND_SCOPE_ROOT}/{scope}/{command_id}.pgid")
-        for command_id in command_ids
-    ]
-    if not pgid_paths:
-        return ":"
-    paths = " ".join(pgid_paths)
-    command = (
-        f"for pgid_file in {paths}; do "
-        "[ -r \"$pgid_file\" ] || continue; "
-        "pgid=$(cat -- \"$pgid_file\"); "
-        "case $pgid in ''|*[!0-9]*) continue;; esac; "
-        f"kill -{signal} -- \"-$pgid\" 2>/dev/null || true; "
-        "done"
-    )
-    return command + (f"; rm -f -- {paths}" if signal == "KILL" else "")
 
 
 def _write_http(handler: BaseHTTPRequestHandler, status: int, payload: dict[str, Any]) -> None:

--- a/packages/headless/harbor/maka_verifier.py
+++ b/packages/headless/harbor/maka_verifier.py
@@ -24,6 +24,7 @@ _INFRA_LINE_PREFIXES = (
     "e: unable to fetch some archives",
     "e: failed to fetch http://",
     "e: failed to fetch https://",
+    "curl: (35) openssl ssl_connect: ssl_error_syscall in connection to astral.sh:443",
 )
 
 
@@ -53,7 +54,7 @@ class _TimedVerifierEnvironment:
             return await self._environment.exec(command, **kwargs)
         wrapped = (
             "timeout --signal=KILL --kill-after=5s "
-            f"{self._timeout_sec:g}s sh -lc {shlex.quote(command)}"
+            f"{self._timeout_sec:g}s bash -lc {shlex.quote(command)}"
         )
         result = await self._environment.exec(
             wrapped,

--- a/packages/headless/harbor/process_scope.py
+++ b/packages/headless/harbor/process_scope.py
@@ -6,6 +6,7 @@ import shlex
 
 
 COMMAND_SCOPE_ENV = "MAKA_HARBOR_COMMAND_SCOPE"
+COMMAND_ID_ENV = "MAKA_HARBOR_COMMAND_ID"
 COMMAND_SCOPE_ROOT = "/tmp/maka-harbor-command-scopes"
 
 
@@ -14,7 +15,9 @@ def scoped_command(command: str, scope: str, command_id: str) -> str:
     pgid_path = shlex.quote(f"{COMMAND_SCOPE_ROOT}/{scope}/{command_id}.pgid")
     return (
         f"mkdir -p -- {scope_dir}; set -m; "
-        f"env {COMMAND_SCOPE_ENV}={shlex.quote(scope)} bash -lc {shlex.quote(command)} & "
+        f"env {COMMAND_SCOPE_ENV}={shlex.quote(scope)} "
+        f"{COMMAND_ID_ENV}={shlex.quote(command_id)} "
+        f"bash -lc {shlex.quote(command)} & "
         "command_pid=$!; "
         f"printf '%s\\n' \"$command_pid\" > {pgid_path}; "
         "wait \"$command_pid\"; command_status=$?; "
@@ -26,7 +29,6 @@ def scoped_command(command: str, scope: str, command_id: str) -> str:
 def scoped_process_cleanup_command(scope: str, signal: str) -> str:
     if signal not in ("TERM", "KILL"):
         raise ValueError(f"unsupported cleanup signal: {signal}")
-    marker = shlex.quote(f"{COMMAND_SCOPE_ENV}={scope}")
     scope_dir = shlex.quote(f"{COMMAND_SCOPE_ROOT}/{scope}")
     return (
         f"for pgid_file in {scope_dir}/*.pgid; do "
@@ -35,12 +37,7 @@ def scoped_process_cleanup_command(scope: str, signal: str) -> str:
         "case $pgid in ''|*[!0-9]*) continue;; esac; "
         f"kill -{signal} -- \"-$pgid\" 2>/dev/null || true; "
         "done; "
-        "for env_file in /proc/[0-9]*/environ; do "
-        "[ -r \"$env_file\" ] || continue; "
-        f"if tr '\\000' '\\n' < \"$env_file\" | grep -Fqx -- {marker}; then "
-        "pid=${env_file#/proc/}; pid=${pid%/environ}; "
-        f"kill -{signal} \"$pid\" 2>/dev/null || true; "
-        "fi; done"
+        + _marked_process_cleanup_command(scope, signal)
         + (f"; rm -rf -- {scope_dir}" if signal == "KILL" else "")
     )
 
@@ -63,6 +60,30 @@ def scoped_command_cleanup_command(
         "pgid=$(cat -- \"$pgid_file\"); "
         "case $pgid in ''|*[!0-9]*) continue;; esac; "
         f"kill -{signal} -- \"-$pgid\" 2>/dev/null || true; "
-        "done"
+        "done; "
+        + _marked_process_cleanup_command(scope, signal, command_ids)
     )
     return command + (f"; rm -f -- {paths}" if signal == "KILL" else "")
+
+
+def _marked_process_cleanup_command(
+    scope: str, signal: str, command_ids: list[str] | None = None
+) -> str:
+    scope_marker = shlex.quote(f"{COMMAND_SCOPE_ENV}={scope}")
+    command_filter = ""
+    if command_ids is not None:
+        command_checks = " || ".join(
+            "tr '\\000' '\\n' 2>/dev/null < \"$env_file\" | grep -Fqx -- "
+            + shlex.quote(f"{COMMAND_ID_ENV}={command_id}")
+            for command_id in command_ids
+        )
+        command_filter = f" && {{ {command_checks}; }}"
+    return (
+        "for env_file in /proc/[0-9]*/environ; do "
+        "[ -r \"$env_file\" ] || continue; "
+        f"if tr '\\000' '\\n' 2>/dev/null < \"$env_file\" | grep -Fqx -- {scope_marker}"
+        f"{command_filter}; then "
+        "pid=${env_file#/proc/}; pid=${pid%/environ}; "
+        f"kill -{signal} \"$pid\" 2>/dev/null || true; "
+        "fi; done"
+    )

--- a/packages/headless/harbor/process_scope.py
+++ b/packages/headless/harbor/process_scope.py
@@ -1,0 +1,68 @@
+"""Process-scope helpers shared by Harbor agent adapters."""
+
+from __future__ import annotations
+
+import shlex
+
+
+COMMAND_SCOPE_ENV = "MAKA_HARBOR_COMMAND_SCOPE"
+COMMAND_SCOPE_ROOT = "/tmp/maka-harbor-command-scopes"
+
+
+def scoped_command(command: str, scope: str, command_id: str) -> str:
+    scope_dir = shlex.quote(f"{COMMAND_SCOPE_ROOT}/{scope}")
+    pgid_path = shlex.quote(f"{COMMAND_SCOPE_ROOT}/{scope}/{command_id}.pgid")
+    return (
+        f"mkdir -p -- {scope_dir}; set -m; "
+        f"env {COMMAND_SCOPE_ENV}={shlex.quote(scope)} bash -lc {shlex.quote(command)} & "
+        "command_pid=$!; "
+        f"printf '%s\\n' \"$command_pid\" > {pgid_path}; "
+        "wait \"$command_pid\"; command_status=$?; "
+        f"kill -0 -- \"-$command_pid\" 2>/dev/null || rm -f -- {pgid_path}; "
+        "exit \"$command_status\""
+    )
+
+
+def scoped_process_cleanup_command(scope: str, signal: str) -> str:
+    if signal not in ("TERM", "KILL"):
+        raise ValueError(f"unsupported cleanup signal: {signal}")
+    marker = shlex.quote(f"{COMMAND_SCOPE_ENV}={scope}")
+    scope_dir = shlex.quote(f"{COMMAND_SCOPE_ROOT}/{scope}")
+    return (
+        f"for pgid_file in {scope_dir}/*.pgid; do "
+        "[ -r \"$pgid_file\" ] || continue; "
+        "pgid=$(cat -- \"$pgid_file\"); "
+        "case $pgid in ''|*[!0-9]*) continue;; esac; "
+        f"kill -{signal} -- \"-$pgid\" 2>/dev/null || true; "
+        "done; "
+        "for env_file in /proc/[0-9]*/environ; do "
+        "[ -r \"$env_file\" ] || continue; "
+        f"if tr '\\000' '\\n' < \"$env_file\" | grep -Fqx -- {marker}; then "
+        "pid=${env_file#/proc/}; pid=${pid%/environ}; "
+        f"kill -{signal} \"$pid\" 2>/dev/null || true; "
+        "fi; done"
+        + (f"; rm -rf -- {scope_dir}" if signal == "KILL" else "")
+    )
+
+
+def scoped_command_cleanup_command(
+    scope: str, command_ids: list[str], signal: str
+) -> str:
+    if signal not in ("TERM", "KILL"):
+        raise ValueError(f"unsupported cleanup signal: {signal}")
+    pgid_paths = [
+        shlex.quote(f"{COMMAND_SCOPE_ROOT}/{scope}/{command_id}.pgid")
+        for command_id in command_ids
+    ]
+    if not pgid_paths:
+        return ":"
+    paths = " ".join(pgid_paths)
+    command = (
+        f"for pgid_file in {paths}; do "
+        "[ -r \"$pgid_file\" ] || continue; "
+        "pgid=$(cat -- \"$pgid_file\"); "
+        "case $pgid in ''|*[!0-9]*) continue;; esac; "
+        f"kill -{signal} -- \"-$pgid\" 2>/dev/null || true; "
+        "done"
+    )
+    return command + (f"; rm -f -- {paths}" if signal == "KILL" else "")

--- a/packages/headless/harbor/process_scope.py
+++ b/packages/headless/harbor/process_scope.py
@@ -73,15 +73,16 @@ def _marked_process_cleanup_command(
     command_filter = ""
     if command_ids is not None:
         command_checks = " || ".join(
-            "tr '\\000' '\\n' 2>/dev/null < \"$env_file\" | grep -Fqx -- "
+            "tr '\\000' '\\n' 2>/dev/null < \"$env_file\" | grep -Fx -- "
             + shlex.quote(f"{COMMAND_ID_ENV}={command_id}")
+            + " > /dev/null"
             for command_id in command_ids
         )
         command_filter = f" && {{ {command_checks}; }}"
     return (
         "for env_file in /proc/[0-9]*/environ; do "
         "[ -r \"$env_file\" ] || continue; "
-        f"if tr '\\000' '\\n' 2>/dev/null < \"$env_file\" | grep -Fqx -- {scope_marker}"
+        f"if tr '\\000' '\\n' 2>/dev/null < \"$env_file\" | grep -Fx -- {scope_marker} > /dev/null"
         f"{command_filter}; then "
         "pid=${env_file#/proc/}; pid=${pid%/environ}; "
         f"kill -{signal} \"$pid\" 2>/dev/null || true; "

--- a/packages/headless/harbor/run-harness-ab.mjs
+++ b/packages/headless/harbor/run-harness-ab.mjs
@@ -62,7 +62,7 @@ import {
 const execFileAsync = promisify(execFile);
 
 const EXPECTED_SOURCE_TASKS = TERMINAL_BENCH_2_1_TASK_IDS.length;
-export const DEFAULT_HARNESS_AB_RUN_ID = 'k3-maka-vs-kimi-code-tbench-2.1-full-v1';
+export const DEFAULT_HARNESS_AB_RUN_ID = 'k3-maka-vs-kimi-code-tbench-2.1-full-v2';
 const CANARY_TASKS = 5;
 const PROVIDER = 'kimi-coding-plan';
 const MODEL = 'k3';
@@ -128,6 +128,15 @@ export function resolveHarnessAbRunId(competitorProfile, explicitRunId) {
     || (competitorProfile.id === 'kimi-code'
       ? DEFAULT_HARNESS_AB_RUN_ID
       : `k3-maka-vs-${competitorProfile.id}-tbench-2.1-full-v1`);
+}
+
+export function resolveHarnessCompetitorToolchainPath(runRoot, competitorProfile) {
+  const fingerprintPrefix = competitorProfile.toolchainFingerprint.slice('sha256:'.length, 'sha256:'.length + 12);
+  return join(
+    runRoot,
+    'toolchains',
+    `${competitorProfile.id}-${competitorProfile.version}-${fingerprintPrefix}-linux-x64`,
+  );
 }
 
 function envPath(name, fallback) {
@@ -309,13 +318,13 @@ async function runLocked({ repoRoot, makaRepoPath, tasksRoot, runId, limit, runR
     ? {
         path: process.env.MAKA_HARNESS_AB_KIMI_CODE_TOOLCHAIN
           ? resolve(process.env.MAKA_HARNESS_AB_KIMI_CODE_TOOLCHAIN)
-          : join(runRoot, 'toolchains', `kimi-code-${KIMI_CODE_TOOLCHAIN_SPEC.kimiCode.version}-linux-x64`),
+          : resolveHarnessCompetitorToolchainPath(runRoot, competitorProfile),
         prepare: prepareKimiCodeToolchain,
       }
     : {
         path: process.env.MAKA_HARNESS_AB_OPENCODE_TOOLCHAIN
           ? resolve(process.env.MAKA_HARNESS_AB_OPENCODE_TOOLCHAIN)
-          : join(runRoot, 'toolchains', `opencode-${OPENCODE_TOOLCHAIN_SPEC.opencode.version}-linux-x64`),
+          : resolveHarnessCompetitorToolchainPath(runRoot, competitorProfile),
         prepare: prepareOpenCodeToolchain,
       };
   await competitorToolchain.prepare(competitorToolchain.path);

--- a/packages/headless/src/__tests__/harbor-adapter.test.ts
+++ b/packages/headless/src/__tests__/harbor-adapter.test.ts
@@ -57,6 +57,8 @@ describe('Harbor adapter contract', () => {
     assert.match(processScopeSource, /def scoped_process_cleanup_command/);
     assert.match(processScopeSource, /def scoped_command_cleanup_command/);
     assert.match(processScopeSource, /\/proc\/\[0-9\]\*\/environ/);
+    assert.doesNotMatch(processScopeSource, /grep -Fqx/);
+    assert.match(processScopeSource, /grep -Fx -- .* > \/dev\/null/);
     assert.match(source, /upload_file\(local_instruction_path, instruction_path\.as_posix\(\)\)/);
     assert.match(source, /bash -lc/);
     assert.match(source, /set -o pipefail/);

--- a/packages/headless/src/__tests__/harbor-adapter.test.ts
+++ b/packages/headless/src/__tests__/harbor-adapter.test.ts
@@ -34,6 +34,7 @@ describe('Harbor adapter contract', () => {
 
   test('maka_agent.py invokes run-cell with the shared artifact contract', async () => {
     const source = await readRepoFile('packages/headless/harbor/maka_agent.py');
+    const processScopeSource = await readRepoFile('packages/headless/harbor/process_scope.py');
 
     assert.match(source, /class MakaAgent\(BaseInstalledAgent\):/);
     assert.match(source, /async def install\(self, environment: BaseEnvironment\) -> None:/);
@@ -48,9 +49,12 @@ describe('Harbor adapter contract', () => {
     assert.match(source, /MAKA_HARBOR_TOOL_EXECUTOR_URL/);
     assert.match(source, /_run_host_cell/);
     assert.match(source, /_ToolExecutorServer/);
-    assert.match(source, /MAKA_HARBOR_COMMAND_SCOPE/);
+    assert.match(source, /from process_scope import/);
     assert.match(source, /_scoped_process_cleanup_command/);
     assert.match(source, /_scoped_command_cleanup_command/);
+    assert.match(processScopeSource, /MAKA_HARBOR_COMMAND_SCOPE/);
+    assert.match(processScopeSource, /def scoped_process_cleanup_command/);
+    assert.match(processScopeSource, /def scoped_command_cleanup_command/);
     assert.match(source, /upload_file\(local_instruction_path, instruction_path\.as_posix\(\)\)/);
     assert.match(source, /bash -lc/);
     assert.match(source, /set -o pipefail/);
@@ -813,6 +817,7 @@ function harborPython(): string | null {
 function pythonBridgeContractScript(root: string): string {
   return String.raw`
 import asyncio
+import contextlib
 import json
 import os
 import signal
@@ -959,7 +964,7 @@ async def fix3_infra_failure_reclaims_scoped_processes():
     assert preserved is None, "clean exit killed a verifier-visible scoped process"
 
 
-async def fix4_deadline_reclaims_only_active_commands():
+async def fix4_deadline_reclaims_all_scoped_commands():
     with tempfile.TemporaryDirectory() as tmp:
         agent = MakaAgent(Path(tmp))
         env = BlockingLocalShellEnv()
@@ -985,12 +990,15 @@ async def fix4_deadline_reclaims_only_active_commands():
                     {"command": "sleep 30"},
                 ))
                 await asyncio.wait_for(env.active_started.wait(), timeout=2)
-                server.mark_reclaim_active_commands()
+                server.mark_reclaim_scoped_processes()
             await request
             assert env.active_process is not None and env.active_process.returncode is not None, (
                 "deadline teardown left an active bridged command running"
             )
-            assert service.poll() is None, "deadline teardown killed a verifier-visible completed service"
+            deadline = time.time() + 2
+            while service.poll() is None and time.time() < deadline:
+                time.sleep(0.02)
+            assert service.poll() is not None, "deadline teardown left a completed background command running"
         finally:
             if request is not None and not request.done():
                 request.cancel()
@@ -1006,10 +1014,69 @@ async def fix4_deadline_reclaims_only_active_commands():
                 scope_dir.rmdir()
 
 
+class TimedOutLocalShellEnv:
+    def __init__(self):
+        self.scope_dir = None
+        self.command_pgid = None
+
+    async def exec(self, command, cwd=None, env=None, timeout_sec=None, user=None):
+        process = await asyncio.create_subprocess_exec("bash", "-lc", command)
+        deadline = time.time() + 2
+        while time.time() < deadline:
+            pgid_files = list(self.scope_dir.glob("*.pgid"))
+            if pgid_files:
+                self.command_pgid = int(pgid_files[0].read_text(encoding="utf-8").strip())
+                break
+            await asyncio.sleep(0.01)
+        assert self.command_pgid is not None, "scoped command did not publish its process group"
+        process.kill()
+        await process.wait()
+        raise asyncio.TimeoutError("simulated Harbor exec timeout")
+
+
+class LocalProcessCleanupAgent:
+    async def exec_as_agent(self, environment, command, **kwargs):
+        process = await asyncio.create_subprocess_exec("bash", "-lc", command)
+        await process.wait()
+        return ExecResult(stdout="", stderr="", return_code=process.returncode)
+
+
+async def fix5_timed_out_command_is_reclaimed_immediately():
+    env = TimedOutLocalShellEnv()
+    server = m._ToolExecutorServer(LocalProcessCleanupAgent(), env)
+    scope_dir = Path(m._COMMAND_SCOPE_ROOT) / server.command_scope
+    env.scope_dir = scope_dir
+    try:
+        async with server:
+            try:
+                await asyncio.to_thread(post, server.url, server.token, {"command": "sleep 30"})
+            except Exception:
+                pass
+        assert env.command_pgid is not None
+        deadline = time.time() + 2
+        while time.time() < deadline:
+            try:
+                os.killpg(env.command_pgid, 0)
+            except ProcessLookupError:
+                break
+            await asyncio.sleep(0.02)
+        else:
+            raise AssertionError("timed-out bridge command left its process group alive")
+    finally:
+        if env.command_pgid is not None:
+            with contextlib.suppress(ProcessLookupError):
+                os.killpg(env.command_pgid, signal.SIGKILL)
+        if scope_dir.exists():
+            for path in scope_dir.glob("*"):
+                path.unlink()
+            scope_dir.rmdir()
+
+
 asyncio.run(fix1_bridge_exec_contract())
 asyncio.run(fix2_workdir_probe_falls_back())
 asyncio.run(fix3_infra_failure_reclaims_scoped_processes())
-asyncio.run(fix4_deadline_reclaims_only_active_commands())
+asyncio.run(fix4_deadline_reclaims_all_scoped_commands())
+asyncio.run(fix5_timed_out_command_is_reclaimed_immediately())
 print("bridge-contract ok")
 `;
 }
@@ -1585,7 +1652,6 @@ with tempfile.TemporaryDirectory() as tmp:
         def __init__(self, agent, environment):
             self.url = "http://127.0.0.1:4321"
             self.token = "tool-token"
-            self.reclaim_active_commands = False
             self.reclaim_scoped_processes = False
             self.instances.append(self)
 
@@ -1597,9 +1663,6 @@ with tempfile.TemporaryDirectory() as tmp:
 
         def mark_reclaim_scoped_processes(self):
             self.reclaim_scoped_processes = True
-
-        def mark_reclaim_active_commands(self):
-            self.reclaim_active_commands = True
 
     class FakeHostProcess:
         returncode = 0
@@ -1654,8 +1717,8 @@ with tempfile.TemporaryDirectory() as tmp:
 
         asyncio.create_subprocess_exec = fake_deadline_subprocess_exec
         asyncio.run(host_process_agent._run_host_cell(host_process_environment, Path(tmp) / "instruction.txt"))
-        assert FakeToolExecutor.instances[-1].reclaim_active_commands, (
-            "a settled deadline must reclaim active bridged commands before Harbor's outer timeout"
+        assert FakeToolExecutor.instances[-1].reclaim_scoped_processes, (
+            "a settled deadline must freeze the workspace by reclaiming every scoped process"
         )
 
         class CancelledHostProcess:

--- a/packages/headless/src/__tests__/harbor-adapter.test.ts
+++ b/packages/headless/src/__tests__/harbor-adapter.test.ts
@@ -53,8 +53,10 @@ describe('Harbor adapter contract', () => {
     assert.match(source, /_scoped_process_cleanup_command/);
     assert.match(source, /_scoped_command_cleanup_command/);
     assert.match(processScopeSource, /MAKA_HARBOR_COMMAND_SCOPE/);
+    assert.match(processScopeSource, /MAKA_HARBOR_COMMAND_ID/);
     assert.match(processScopeSource, /def scoped_process_cleanup_command/);
     assert.match(processScopeSource, /def scoped_command_cleanup_command/);
+    assert.match(processScopeSource, /\/proc\/\[0-9\]\*\/environ/);
     assert.match(source, /upload_file\(local_instruction_path, instruction_path\.as_posix\(\)\)/);
     assert.match(source, /bash -lc/);
     assert.match(source, /set -o pipefail/);
@@ -820,6 +822,7 @@ import asyncio
 import contextlib
 import json
 import os
+import shlex
 import signal
 import subprocess
 import sys
@@ -876,6 +879,7 @@ async def fix1_bridge_exec_contract():
             assert call["env"] is None, call
             assert "should-not-leak" not in json.dumps(call), call
             assert "MAKA_HARBOR_COMMAND_SCOPE=" in call["command"], call
+            assert "MAKA_HARBOR_COMMAND_ID=" in call["command"], call
             # Explicit timeoutMs takes precedence, rounded up to whole seconds.
             await asyncio.to_thread(post, server.url, server.token, {"command": "x", "timeoutMs": 4500})
             assert env.calls[-1]["timeout_sec"] == 5, env.calls[-1]
@@ -1018,13 +1022,17 @@ class TimedOutLocalShellEnv:
     def __init__(self):
         self.scope_dir = None
         self.command_pgid = None
+        self.detached_state_path = None
 
     async def exec(self, command, cwd=None, env=None, timeout_sec=None, user=None):
         process = await asyncio.create_subprocess_exec("bash", "-lc", command)
         deadline = time.time() + 2
         while time.time() < deadline:
             pgid_files = list(self.scope_dir.glob("*.pgid"))
-            if pgid_files:
+            detached_started = (
+                self.detached_state_path is None or self.detached_state_path.exists()
+            )
+            if pgid_files and detached_started:
                 self.command_pgid = int(pgid_files[0].read_text(encoding="utf-8").strip())
                 break
             await asyncio.sleep(0.01)
@@ -1046,26 +1054,69 @@ async def fix5_timed_out_command_is_reclaimed_immediately():
     server = m._ToolExecutorServer(LocalProcessCleanupAgent(), env)
     scope_dir = Path(m._COMMAND_SCOPE_ROOT) / server.command_scope
     env.scope_dir = scope_dir
+    detached_pid = None
+    preserved = subprocess.Popen(
+        ["sleep", "30"],
+        start_new_session=True,
+        env={
+            "PATH": os.environ.get("PATH", ""),
+            m._COMMAND_SCOPE_ENV: server.command_scope,
+            "MAKA_HARBOR_COMMAND_ID": "preserved-command",
+        },
+    )
     try:
-        async with server:
-            try:
-                await asyncio.to_thread(post, server.url, server.token, {"command": "sleep 30"})
-            except Exception:
-                pass
-        assert env.command_pgid is not None
-        deadline = time.time() + 2
-        while time.time() < deadline:
-            try:
-                os.killpg(env.command_pgid, 0)
-            except ProcessLookupError:
-                break
-            await asyncio.sleep(0.02)
-        else:
-            raise AssertionError("timed-out bridge command left its process group alive")
+        with tempfile.TemporaryDirectory() as state_dir:
+            state_path = Path(state_dir) / "detached.pid"
+            env.detached_state_path = state_path
+            detached_script = (
+                "import os,time; os.setsid(); "
+                f"open({str(state_path)!r}, 'w').write(str(os.getpid())); "
+                "time.sleep(30)"
+            )
+            command = (
+                f"{shlex.quote(sys.executable)} -c {shlex.quote(detached_script)} "
+                ">/dev/null 2>&1 & sleep 30"
+            )
+            async with server:
+                try:
+                    await asyncio.to_thread(post, server.url, server.token, {"command": command})
+                except Exception:
+                    pass
+            assert env.command_pgid is not None
+            detached_pid = int(state_path.read_text(encoding="utf-8"))
+            can_scan_process_env = Path("/proc").is_dir()
+            deadline = time.time() + 2
+            while time.time() < deadline:
+                group_alive = True
+                detached_alive = True
+                try:
+                    os.killpg(env.command_pgid, 0)
+                except ProcessLookupError:
+                    group_alive = False
+                try:
+                    os.kill(detached_pid, 0)
+                except ProcessLookupError:
+                    detached_alive = False
+                if not group_alive and (not can_scan_process_env or not detached_alive):
+                    break
+                await asyncio.sleep(0.02)
+            else:
+                raise AssertionError(
+                    "timed-out bridge command left its process group or detached child alive"
+                )
+            assert preserved.poll() is None, (
+                "single-command cleanup killed a service from another successful command"
+            )
     finally:
         if env.command_pgid is not None:
             with contextlib.suppress(ProcessLookupError):
                 os.killpg(env.command_pgid, signal.SIGKILL)
+        if detached_pid is not None:
+            with contextlib.suppress(ProcessLookupError):
+                os.kill(detached_pid, signal.SIGKILL)
+        if preserved.poll() is None:
+            os.killpg(preserved.pid, signal.SIGKILL)
+            preserved.wait()
         if scope_dir.exists():
             for path in scope_dir.glob("*"):
                 path.unlink()

--- a/packages/headless/src/__tests__/harbor-adapter.test.ts
+++ b/packages/headless/src/__tests__/harbor-adapter.test.ts
@@ -2062,8 +2062,12 @@ function pythonKimiCodeAdapterSmokeScript(root: string): string {
 import asyncio
 import json
 import os
+import re
+import signal
+import subprocess
 import sys
 import tempfile
+import time
 import types
 from pathlib import Path
 
@@ -2151,6 +2155,7 @@ with tempfile.TemporaryDirectory() as tmp:
             "MAKA_MODEL": "k3",
             "MAKA_LLM_CONNECTION_SLUG": "kimi-coding-plan",
             "MAKA_REASONING_EFFORT": "max",
+            "MAKA_CELL_TIMEOUT_SEC": "3600",
             "MAKA_SYSTEM_PROMPT": "",
             "MAKA_TRIAL_PRICING_SOURCE": "kimi-coding-plan-account-plan",
         },
@@ -2164,6 +2169,9 @@ with tempfile.TemporaryDirectory() as tmp:
     asyncio.run(agent.run("hi", environment, object()))
     run_command, run_env = commands[-1]
     assert "--output-format stream-json --prompt" in run_command, run_command
+    assert "config.toml" in run_command, run_command
+    assert 'print_background_mode = "exit"' in run_command, run_command
+    assert "keep_alive_on_exit = true" in run_command, run_command
     assert "--yolo" not in run_command, run_command
     assert "templated: hi" in run_command, run_command
     assert run_env["KIMI_MODEL_NAME"] == "k3", run_env
@@ -2171,6 +2179,7 @@ with tempfile.TemporaryDirectory() as tmp:
     assert run_env["KIMI_MODEL_PROVIDER_TYPE"] == "kimi", run_env
     assert run_env["KIMI_MODEL_MAX_CONTEXT_SIZE"] == "1048576", run_env
     assert run_env["KIMI_MODEL_MAX_OUTPUT_SIZE"] == "131072", run_env
+    assert run_env["KIMI_MODEL_REQUEST_TIMEOUT_MS"] == "3720000", run_env
     assert run_env["KIMI_MODEL_ADAPTIVE_THINKING"] == "true", run_env
     assert "ephemeral-token" not in run_command, run_command
     agent.populate_context_post_run(object())
@@ -2201,6 +2210,67 @@ with tempfile.TemporaryDirectory() as tmp:
     failed = json.loads((logs / "maka-cell-output.json").read_text(encoding="utf-8"))
     assert failed["status"] == "failed", failed
     assert failed["errorClass"] == "auth", failed
+
+    class TimeoutEnvironment:
+        def __init__(self):
+            self.process = None
+
+        async def exec(self, command, env=None, **kwargs):
+            if "--output-format stream-json" in command:
+                scope_match = re.search(r"MAKA_HARBOR_COMMAND_SCOPE=([^ ]+)", command)
+                pgid_match = re.search(
+                    r"(/tmp/maka-harbor-command-scopes/[^ ]+\.pgid)", command
+                )
+                child_env = {"PATH": os.environ.get("PATH", "")}
+                if scope_match:
+                    child_env["MAKA_HARBOR_COMMAND_SCOPE"] = scope_match.group(1)
+                self.process = subprocess.Popen(
+                    ["sleep", "30"],
+                    start_new_session=True,
+                    env=child_env,
+                )
+                if pgid_match:
+                    pgid_path = Path(pgid_match.group(1))
+                    pgid_path.parent.mkdir(parents=True, exist_ok=True)
+                    pgid_path.write_text(str(self.process.pid) + "\n", encoding="utf-8")
+                await asyncio.sleep(30)
+                return types.SimpleNamespace(return_code=0, stdout="", stderr="")
+            process = await asyncio.create_subprocess_exec("bash", "-lc", command)
+            await process.wait()
+            return types.SimpleNamespace(return_code=process.returncode, stdout="", stderr="")
+
+    timeout_environment = TimeoutEnvironment()
+    timeout_agent = MakaKimiCodeAgent(
+        logs,
+        model_name="k3",
+        extra_env={
+            "MAKA_PROVIDER_PROXY_URL": "http://host.docker.internal:43210",
+            "MAKA_PROVIDER_PROXY_TOKEN": "ephemeral-token",
+            "MAKA_MODEL": "k3",
+            "MAKA_CELL_TIMEOUT_SEC": "3600",
+        },
+    )
+    try:
+        try:
+            asyncio.run(asyncio.wait_for(
+                timeout_agent.run("cancel me", timeout_environment, object()),
+                timeout=0.05,
+            ))
+        except TimeoutError:
+            pass
+        else:
+            raise AssertionError("expected the simulated Harbor deadline")
+        assert timeout_environment.process is not None
+        deadline = time.time() + 1
+        while timeout_environment.process.poll() is None and time.time() < deadline:
+            time.sleep(0.01)
+        assert timeout_environment.process.poll() is not None, (
+            "Kimi Code deadline left a child process alive for the verifier"
+        )
+    finally:
+        if timeout_environment.process is not None and timeout_environment.process.poll() is None:
+            os.killpg(timeout_environment.process.pid, signal.SIGKILL)
+            timeout_environment.process.wait()
     print("kimi-code adapter ok")
 `;
 }

--- a/packages/headless/src/__tests__/harbor-adapter.test.ts
+++ b/packages/headless/src/__tests__/harbor-adapter.test.ts
@@ -2513,6 +2513,15 @@ class FakeEnvironment:
             self.trial_paths.test_stdout_path.write_text("E: Failed to fetch https://deb.example.invalid/pkg.deb 502 Bad Gateway", encoding="utf-8")
             self.trial_paths.reward_text_path.write_text("0\n", encoding="utf-8")
             return types.SimpleNamespace(return_code=0, stdout="", stderr="")
+        if outcome == "infra_curl_ssl_with_fail_reward":
+            self.trial_paths.test_stdout_path.write_text(
+                "curl: (35) OpenSSL SSL_connect: SSL_ERROR_SYSCALL in connection to astral.sh:443\n"
+                "/tests/test.sh: line 10: /root/.local/bin/env: No such file or directory\n"
+                "/tests/test.sh: line 19: uvx: command not found",
+                encoding="utf-8",
+            )
+            self.trial_paths.reward_text_path.write_text("0\n", encoding="utf-8")
+            return types.SimpleNamespace(return_code=0, stdout="", stderr="")
         if outcome == "warning_with_pass_reward":
             self.trial_paths.test_stdout_path.write_text("APT warning: Failed to fetch optional archive", encoding="utf-8")
             self.trial_paths.reward_text_path.write_text("1\n", encoding="utf-8")
@@ -2560,8 +2569,15 @@ assert result.rewards == {"reward": 1.0}, result.rewards
 assert outcome["outcome"] == "passed", outcome
 assert [item["classification"] for item in outcome["attempts"]] == ["infra_setup_failed", "passed"], outcome
 assert len([command for command in commands if "timeout --signal=KILL" in command]) == 2, commands
+assert all("bash -lc" in command for command in commands if "timeout --signal=KILL" in command), commands
 
 result, outcome, commands = asyncio.run(run_case(["infra_with_fail_reward", "pass"]))
+assert result.rewards == {"reward": 1.0}, result.rewards
+assert outcome["outcome"] == "passed", outcome
+assert [item["classification"] for item in outcome["attempts"]] == ["infra_setup_failed", "passed"], outcome
+assert len([command for command in commands if "timeout --signal=KILL" in command]) == 2, commands
+
+result, outcome, commands = asyncio.run(run_case(["infra_curl_ssl_with_fail_reward", "pass"]))
 assert result.rewards == {"reward": 1.0}, result.rewards
 assert outcome["outcome"] == "passed", outcome
 assert [item["classification"] for item in outcome["attempts"]] == ["infra_setup_failed", "passed"], outcome

--- a/packages/headless/src/__tests__/harbor-adapter.test.ts
+++ b/packages/headless/src/__tests__/harbor-adapter.test.ts
@@ -2245,6 +2245,13 @@ with tempfile.TemporaryDirectory() as tmp:
     assert run_env["KIMI_MODEL_REQUEST_TIMEOUT_MS"] == "3720000", run_env
     assert run_env["KIMI_MODEL_ADAPTIVE_THINKING"] == "true", run_env
     assert "ephemeral-token" not in run_command, run_command
+    for raw_timeout in [None, "", "oops", "0", "+1800", "01800", "1٢", "9" * 5000]:
+        if raw_timeout is None:
+            agent._extra_env.pop("MAKA_CELL_TIMEOUT_SEC", None)
+        else:
+            agent._extra_env["MAKA_CELL_TIMEOUT_SEC"] = raw_timeout
+        assert agent._runtime_env()["KIMI_MODEL_REQUEST_TIMEOUT_MS"] == "1020000", raw_timeout
+    agent._extra_env["MAKA_CELL_TIMEOUT_SEC"] = "3600"
     agent.populate_context_post_run(object())
     cell = json.loads((logs / "maka-cell-output.json").read_text(encoding="utf-8"))
     assert cell["executionIdentity"]["model"] == "k3", cell

--- a/packages/headless/src/__tests__/harbor-task-runner.test.ts
+++ b/packages/headless/src/__tests__/harbor-task-runner.test.ts
@@ -72,6 +72,7 @@ interface FakeOptions {
   executionIdentity?: HarborCellExecutionIdentity;
   usageCheckpoint?: HarborCellOutput['tokenSummary'];
   exitCode?: number;
+  exitCodeAfterArtifacts?: number;
   events?: string;
   verifierStdout?: string;
   verifierOutcome?: Record<string, unknown> | null;
@@ -143,7 +144,11 @@ function fakeRunner(opts: FakeOptions): HarborProcessRunner {
     await writeFile(join(trialDir, 'agent', 'runtime-events.jsonl'), opts.events ?? '{"type":"x"}\n', 'utf8');
     await mkdir(join(trialDir, 'agent', 'maka-storage', 'sessions', 'sess', 'runs', 'run'), { recursive: true });
     await writeFile(join(trialDir, 'agent', 'maka-storage', 'sessions', 'sess', 'runs', 'run', 'events.jsonl'), '{"type":"tool_failed"}\n', 'utf8');
-    return { exitCode: 0, stdout: 'ok', stderr: '' };
+    return {
+      exitCode: opts.exitCodeAfterArtifacts ?? 0,
+      stdout: opts.exitCodeAfterArtifacts ? '' : 'ok',
+      stderr: opts.exitCodeAfterArtifacts ? 'trial failed' : '',
+    };
   };
 }
 
@@ -861,6 +866,72 @@ describe('createHarborTaskRunner', () => {
       assert.equal(output.harbor.verifier?.outcome, 'passed');
       assert.deepEqual(output.cell.tokenSummary, timedCell.tokenSummary);
       assert.deepEqual(output.cell.executionIdentity, timedCell.executionIdentity);
+    });
+  });
+
+  test('treats a non-zero Harbor exit with an incomplete agent-timeout trial as budget exhausted', async () => {
+    await withRun(async ({ jobsDir, repo }) => {
+      const executionIdentity = {
+        llmConnectionSlug: 'deepseek',
+        model: 'deepseek-v4-flash',
+        systemPromptHash: 'sha256:abc',
+        pricingProfile: 'test-profile',
+      };
+      const runner = createHarborTaskRunner({
+        makaRepoPath: repo,
+        jobsDir,
+        model: 'deepseek/deepseek-v4-flash',
+        runHarbor: fakeRunner({
+          exitCodeAfterArtifacts: 1,
+          cell: null,
+          executionIdentity,
+          trialResult: {
+            exception_info: {
+              exception_type: 'AgentTimeoutError',
+              exception_message: 'Agent execution timed out after 900.0 seconds',
+            },
+          },
+        }),
+      });
+
+      await assert.rejects(runner(runInput()), (error: unknown) => {
+        assert.ok(error instanceof FixedPromptBudgetExhaustedError);
+        assert.deepEqual(error.artifactRefs?.executionIdentity, executionIdentity);
+        return true;
+      });
+    });
+  });
+
+  test('returns the official verifier result after a non-zero Harbor timeout exit', async () => {
+    await withRun(async ({ jobsDir, repo }) => {
+      const timedCell = cellOutput({
+        executionIdentity: {
+          llmConnectionSlug: 'deepseek',
+          model: 'deepseek-v4-flash',
+          systemPromptHash: 'sha256:abc',
+          pricingProfile: 'test-profile',
+        },
+      });
+      const runner = createHarborTaskRunner({
+        makaRepoPath: repo,
+        jobsDir,
+        model: 'deepseek/deepseek-v4-flash',
+        runHarbor: fakeRunner({
+          exitCodeAfterArtifacts: 1,
+          reward: '1\n',
+          cell: timedCell,
+          trialResult: {
+            exception_info: {
+              exception_type: 'AgentTimeoutError',
+              exception_message: 'Agent execution timed out after 60.0 seconds',
+            },
+          },
+        }),
+      });
+
+      const output = await runner(runInput());
+      assert.equal(output.harbor.reward, 1);
+      assert.equal(output.harbor.verifier?.outcome, 'passed');
     });
   });
 

--- a/packages/headless/src/__tests__/harness-ab-cli.test.ts
+++ b/packages/headless/src/__tests__/harness-ab-cli.test.ts
@@ -157,7 +157,12 @@ test('harness A/B freezes the stored advisory evidence when resuming a run', asy
 });
 
 test('harness A/B defaults to pinned Kimi Code and keeps OpenCode selectable', async () => {
-  const { buildHarnessAbManifest, resolveHarnessCompetitorProfile } = await import(
+  const {
+    buildHarnessAbManifest,
+    resolveHarnessAbRunId,
+    resolveHarnessCompetitorProfile,
+    resolveHarnessCompetitorToolchainPath,
+  } = await import(
     new URL('../../harbor/run-harness-ab.mjs', import.meta.url).href
   );
 
@@ -189,6 +194,15 @@ test('harness A/B defaults to pinned Kimi Code and keeps OpenCode selectable', a
   assert.equal(manifest.metadata.order.pilotTaskCount, 5);
   assert.equal(manifest.maxConcurrency, 4);
   assert.equal(manifest.maxConcurrentAttempts, 8);
+  const kimiProfile = resolveHarnessCompetitorProfile('kimi-code');
+  assert.equal(
+    resolveHarnessAbRunId(kimiProfile),
+    'k3-maka-vs-kimi-code-tbench-2.1-full-v2',
+  );
+  assert.match(
+    resolveHarnessCompetitorToolchainPath('/run', kimiProfile),
+    new RegExp(`kimi-code-0\\.26\\.0-${kimiProfile.toolchainFingerprint.slice(7, 19)}-linux-x64$`),
+  );
   for (const arm of manifest.arms) {
     assert.equal(arm.metadata.config.billingMode, 'account-plan');
   }

--- a/packages/headless/src/__tests__/kimi-code-toolchain.test.ts
+++ b/packages/headless/src/__tests__/kimi-code-toolchain.test.ts
@@ -1,6 +1,7 @@
 import assert from 'node:assert/strict';
 import { test } from 'node:test';
 import {
+  applyKimiCodeRequestTimeoutPatch,
   KIMI_CODE_TOOLCHAIN_FINGERPRINT,
   KIMI_CODE_TOOLCHAIN_SPEC,
 } from '../kimi-code-toolchain.js';
@@ -12,12 +13,29 @@ test('Kimi Code toolchain pins the official package and extracted entrypoint', (
     'sha512-GadxPxbCYOfkMgX8sF6VyuligSTLU81sxJswMtzM5D0vmB7/ZGM7PBmUn6YF2fV/nKcx1JgPIHEc3vgKCQgqsQ==',
   );
   assert.equal(
-    KIMI_CODE_TOOLCHAIN_SPEC.kimiCode.entrypointSha256,
+    KIMI_CODE_TOOLCHAIN_SPEC.kimiCode.sourceEntrypointSha256,
     'bc310a7d2f0c3c2cb1367fa7b2092375351efff51c6d4a358b8681b4a01fb7b0',
+  );
+  assert.equal(KIMI_CODE_TOOLCHAIN_SPEC.kimiCode.patch.env, 'KIMI_MODEL_REQUEST_TIMEOUT_MS');
+  assert.equal(
+    KIMI_CODE_TOOLCHAIN_SPEC.kimiCode.entrypointSha256,
+    '58f48c418f446e525f2b60765a27221ed7ac771bebed45375a289d1172aa96c6',
   );
   assert.equal(
     KIMI_CODE_TOOLCHAIN_SPEC.kimiCode.packageJsonSha256,
     '65dfa318a882d834e356828d0f371f349f2dcfc99585cb01412f7c0a9e6ae52a',
   );
   assert.match(KIMI_CODE_TOOLCHAIN_FINGERPRINT, /^sha256:[a-f0-9]{64}$/);
+});
+
+test('Kimi Code toolchain patch replaces the OpenAI SDK timeout default used by Kimi chat', () => {
+  const anchor = 'OpenAI.DEFAULT_TIMEOUT = 6e5;';
+  assert.equal(
+    applyKimiCodeRequestTimeoutPatch(`before ${anchor} after`),
+    'before OpenAI.DEFAULT_TIMEOUT = Number(process.env["KIMI_MODEL_REQUEST_TIMEOUT_MS"] ?? 6e5); after',
+  );
+  assert.throws(
+    () => applyKimiCodeRequestTimeoutPatch('no OpenAI timeout default'),
+    /expected 1 OpenAI SDK timeout default, found 0/,
+  );
 });

--- a/packages/headless/src/harbor-task-runner.ts
+++ b/packages/headless/src/harbor-task-runner.ts
@@ -252,20 +252,23 @@ export function createHarborTaskRunner(options: HarborTaskRunnerOptions): Harbor
         tail(result.stderr || result.stdout),
       );
     }
-    if (result.exitCode !== 0) {
+    let trialDir: string;
+    try {
+      trialDir = await findTrialDir(jobDir, basename(input.task.path));
+    } catch (error) {
+      if (result.exitCode === 0) throw error;
       throw new HarborInfraError(
         `harbor run exited ${result.exitCode} for task ${input.task.id}`,
         tail(result.stderr || result.stdout),
       );
     }
-
-    const trialDir = await findTrialDir(jobDir, basename(input.task.path));
     const cellOutputPath = join(trialDir, TRIAL_CELL_OUTPUT);
     const rewardPath = join(trialDir, TRIAL_REWARD);
     const resultPath = join(trialDir, TRIAL_RESULT);
     const hostEventsPath = join(trialDir, TRIAL_RUNTIME_EVENTS);
 
     const trialException = await readTrialException(resultPath);
+    let completeTimedOutTrial = false;
     if (trialException && isBudgetExhaustedTrialException(trialException)) {
       const [rewardArtifact, verifierArtifact, cellArtifact] = await Promise.all([
         readOptionalText(rewardPath),
@@ -280,6 +283,13 @@ export function createHarborTaskRunner(options: HarborTaskRunnerOptions): Harbor
           artifactRefs ?? undefined,
         );
       }
+      completeTimedOutTrial = true;
+    }
+    if (result.exitCode !== 0 && !completeTimedOutTrial) {
+      throw new HarborInfraError(
+        `harbor run exited ${result.exitCode} for task ${input.task.id}`,
+        tail(result.stderr || result.stdout),
+      );
     }
     const reward = await readReward(rewardPath, resultPath, input.task.id);
     const rawCell = await readCellOutput(cellOutputPath, input.task.id);

--- a/packages/headless/src/kimi-code-toolchain.ts
+++ b/packages/headless/src/kimi-code-toolchain.ts
@@ -7,6 +7,18 @@ import {
 
 export const KIMI_CODE_TOOLCHAIN_CONTAINER_PATH = '/opt/maka-kimi-code-toolchain';
 
+const REQUEST_TIMEOUT_PATCH_SEARCH = 'OpenAI.DEFAULT_TIMEOUT = 6e5;';
+const REQUEST_TIMEOUT_PATCH_REPLACEMENT = 'OpenAI.DEFAULT_TIMEOUT = Number(process.env["KIMI_MODEL_REQUEST_TIMEOUT_MS"] ?? 6e5);';
+const REQUEST_TIMEOUT_PATCH_REPLACEMENTS = 1;
+
+export function applyKimiCodeRequestTimeoutPatch(source: string): string {
+  const replacements = source.split(REQUEST_TIMEOUT_PATCH_SEARCH).length - 1;
+  if (replacements !== REQUEST_TIMEOUT_PATCH_REPLACEMENTS) {
+    throw new Error(`expected ${REQUEST_TIMEOUT_PATCH_REPLACEMENTS} OpenAI SDK timeout default, found ${replacements}`);
+  }
+  return source.split(REQUEST_TIMEOUT_PATCH_SEARCH).join(REQUEST_TIMEOUT_PATCH_REPLACEMENT);
+}
+
 export const KIMI_CODE_TOOLCHAIN_SPEC = {
   schemaVersion: 1,
   platform: 'linux',
@@ -21,8 +33,16 @@ export const KIMI_CODE_TOOLCHAIN_SPEC = {
     version: '0.26.0',
     archiveUrl: 'https://registry.npmjs.org/@moonshot-ai/kimi-code/-/kimi-code-0.26.0.tgz',
     archiveIntegrity: 'sha512-GadxPxbCYOfkMgX8sF6VyuligSTLU81sxJswMtzM5D0vmB7/ZGM7PBmUn6YF2fV/nKcx1JgPIHEc3vgKCQgqsQ==',
-    entrypointSha256: 'bc310a7d2f0c3c2cb1367fa7b2092375351efff51c6d4a358b8681b4a01fb7b0',
+    sourceEntrypointSha256: 'bc310a7d2f0c3c2cb1367fa7b2092375351efff51c6d4a358b8681b4a01fb7b0',
+    entrypointSha256: '58f48c418f446e525f2b60765a27221ed7ac771bebed45375a289d1172aa96c6',
     packageJsonSha256: '65dfa318a882d834e356828d0f371f349f2dcfc99585cb01412f7c0a9e6ae52a',
+    patch: {
+      id: 'request-timeout-env-v1',
+      env: 'KIMI_MODEL_REQUEST_TIMEOUT_MS',
+      search: REQUEST_TIMEOUT_PATCH_SEARCH,
+      replacement: REQUEST_TIMEOUT_PATCH_REPLACEMENT,
+      expectedReplacements: REQUEST_TIMEOUT_PATCH_REPLACEMENTS,
+    },
   },
 } as const;
 
@@ -47,7 +67,9 @@ const DEFINITION: PinnedNodeCliToolchainDefinition<typeof KIMI_CODE_TOOLCHAIN_SP
   packageFiles: [{
     archivePath: 'package/dist/main.mjs',
     installedPath: 'lib/kimi-code/main.mjs',
+    sourceSha256: KIMI_CODE_TOOLCHAIN_SPEC.kimiCode.sourceEntrypointSha256,
     sha256: KIMI_CODE_TOOLCHAIN_SPEC.kimiCode.entrypointSha256,
+    transform: applyKimiCodeRequestTimeoutPatch,
   }, {
     archivePath: 'package/package.json',
     installedPath: 'lib/kimi-code/package.json',

--- a/packages/headless/src/node-cli-toolchain.ts
+++ b/packages/headless/src/node-cli-toolchain.ts
@@ -25,6 +25,8 @@ export interface PinnedNodeCliToolchainDefinition<TSpec> {
     archivePath: string;
     installedPath: string;
     sha256: string;
+    sourceSha256?: string;
+    transform?: (source: string) => string;
     executable?: boolean;
     stripComponents?: number;
   }[];
@@ -98,7 +100,8 @@ export async function prepareNodeCliToolchain<TSpec>(
     ]);
     await chmod(join(temporaryPath, 'bin', 'node'), 0o755);
     for (const file of definition.packageFiles) {
-      const targetDir = dirname(join(temporaryPath, file.installedPath));
+      const installedPath = join(temporaryPath, file.installedPath);
+      const targetDir = dirname(installedPath);
       await mkdir(targetDir, { recursive: true });
       await execFileAsync('tar', [
         '-xzf', packageArchive,
@@ -106,7 +109,16 @@ export async function prepareNodeCliToolchain<TSpec>(
         `--strip-components=${file.stripComponents ?? 2}`,
         file.archivePath,
       ]);
-      if (file.executable) await chmod(join(temporaryPath, file.installedPath), 0o755);
+      if (file.transform !== undefined) {
+        if (file.sourceSha256 === undefined) {
+          throw new Error(`${definition.label} toolchain transform requires a source SHA-256`);
+        }
+        if (await sha256File(installedPath) !== file.sourceSha256) {
+          throw new Error(`${definition.label} toolchain ${file.installedPath} source SHA-256 mismatch`);
+        }
+        await writeFile(installedPath, file.transform(await readFile(installedPath, 'utf8')), 'utf8');
+      }
+      if (file.executable) await chmod(installedPath, 0o755);
     }
     await writeFile(join(temporaryPath, 'manifest.json'), `${JSON.stringify({
       schemaVersion: 1,


### PR DESCRIPTION
## Summary

- Align the pinned Kimi Code request timeout with each Harbor cell's native task timeout plus a bounded settlement grace; missing or malformed timeout metadata now follows the shared 900-second fallback instead of failing adapter startup.
- Scope Kimi and Maka child processes so deadline, cancellation, and bridge-command timeout paths reclaim the affected process groups before verification.
- Give each bridged command its own process identity so timeout cleanup also reclaims marker-retaining detached children that leave the wrapper PGID, without killing services owned by other successful commands in the same cell.
- Make `/proc/*/environ` marker scans safe under Harbor's `pipefail`, including large environments where an early-exit grep would otherwise SIGPIPE the producer and skip cleanup.
- Freeze all cell-scoped processes after a settled Maka deadline while preserving Kimi-started background services after a normal print-mode exit.
- Run Terminal-Bench verifier commands under Bash, retry the observed transient TLS bootstrap failure, and preserve official timeout verifier artifacts even when Harbor exits non-zero.
- Rotate the default Kimi experiment run identity and content-address its prepared toolchain directory so the patched toolchain cannot collide with prior runs or version-only caches.

The process cleanup is a lifecycle hygiene boundary, not an adversarial process-containment boundary. A child that deliberately clears both scope markers and leaves the recorded process group requires an execution-owner primitive from Harbor, such as a per-exec cgroup or kill handle; this adapter does not add process-tree heuristics that cannot make that invariant reliable.

## Verification

TDD regressions failed before their corresponding fixes for the stale experiment/cache identity, missing Kimi cell timeout, marker-retaining detached timed-out command, and pipefail-sensitive marker scan. The focused Harbor adapter contract passes locally, and an additional Linux `/proc` integration proved that command cleanup kills both the wrapper and a marker-retaining detached child while preserving another command's service.

- `node ../../worktree-bootstrap.mjs` — complete repository build and stale-dist check passed.
- `npm --workspace @maka/headless test` — 1,105 passed, 0 skipped, 0 failed.
- Linux `python:3.13-slim-bookworm` command-scope cleanup integration — passed.
- Large-environment marker scan with `pipefail` enabled — passed.
- `git diff --check origin/main...HEAD` — passed.

## Review focus

The branch is split into eight Conventional Commits by independently reviewable intent: timeout evidence recovery, Kimi execution lifetime, cell process-scope reclamation, verifier bootstrap retry, missing-timeout fallback, experiment identity rotation, marker-retaining detached timed-out command reclamation, and pipe-safe process-marker scans.

This PR owns Harbor execution lifecycles only. Runtime model output limits are in #1213. Pass@1 recovery, provider telemetry, trace retention, benchmark reporting, and final-usage drain remain separate changes.
