### PR TITLE
feat(headless): support evidence-safe isolated reruns

### DIFF
--- a/packages/headless/harbor/run-harness-ab-detached.mjs
+++ b/packages/headless/harbor/run-harness-ab-detached.mjs
@@ -21,7 +21,11 @@ function envPath(name) {
 function detachedRunPaths() {
   const outDir = envPath('MAKA_HARNESS_AB_OUT_DIR');
   const competitorProfile = resolveHarnessCompetitorProfile(process.env.MAKA_HARNESS_AB_COMPETITOR || 'kimi-code');
-  const runId = resolveHarnessAbRunId(competitorProfile, process.env.MAKA_HARNESS_AB_RUN_ID);
+  const runId = resolveHarnessAbRunId(
+    competitorProfile,
+    process.env.MAKA_HARNESS_AB_RUN_ID,
+    process.env.MAKA_HARNESS_AB_TASK_ID,
+  );
   const runRoot = resolveFixedPromptRunRoot(outDir, runId, 'MAKA_HARNESS_AB_RUN_ID');
   return {
     runId,

--- a/packages/headless/harbor/run-harness-ab.mjs
+++ b/packages/headless/harbor/run-harness-ab.mjs
@@ -123,7 +123,10 @@ export function resolveHarnessCompetitorProfile(raw = 'kimi-code') {
   return profile;
 }
 
-export function resolveHarnessAbRunId(competitorProfile, explicitRunId) {
+export function resolveHarnessAbRunId(competitorProfile, explicitRunId, isolatedTaskId) {
+  if (isolatedTaskId?.trim() && !explicitRunId?.trim()) {
+    throw new Error('MAKA_HARNESS_AB_RUN_ID is required with MAKA_HARNESS_AB_TASK_ID');
+  }
   return explicitRunId
     || (competitorProfile.id === 'kimi-code'
       ? DEFAULT_HARNESS_AB_RUN_ID
@@ -153,6 +156,30 @@ function runLimit(raw) {
   return parsed;
 }
 
+function runPairConcurrency(raw) {
+  const parsed = Number(raw ?? PAIR_CONCURRENCY);
+  if (!Number.isSafeInteger(parsed) || parsed < 1 || parsed > PAIR_CONCURRENCY) {
+    throw new Error(`MAKA_HARNESS_AB_PAIR_CONCURRENCY must be an integer between 1 and ${PAIR_CONCURRENCY}`);
+  }
+  return parsed;
+}
+
+export function resolveHarnessAbTaskSelection(rawTaskId, rawLimit, rawPairConcurrency) {
+  const pairConcurrency = runPairConcurrency(rawPairConcurrency);
+  const taskId = rawTaskId?.trim();
+  if (!taskId) {
+    return {
+      taskIds: TERMINAL_BENCH_2_1_TASK_IDS,
+      limit: runLimit(rawLimit),
+      pairConcurrency,
+    };
+  }
+  if (!TERMINAL_BENCH_2_1_TASK_IDS.includes(taskId)) {
+    throw new Error('MAKA_HARNESS_AB_TASK_ID must name a Terminal-Bench 2.1 task');
+  }
+  return { taskIds: [taskId], limit: 1, pairConcurrency: 1 };
+}
+
 export function harnessMakaContextBudgetEnv() {
   return {
     MAKA_CONTEXT_ACTIVE_TOOL_RESULT_PRUNE: 'on',
@@ -178,6 +205,7 @@ export function buildHarnessAbManifest({
   taskSourceFingerprint,
   toolchainFingerprint,
   taskIds = TERMINAL_BENCH_2_1_TASK_IDS,
+  pairConcurrency = Math.min(PAIR_CONCURRENCY, taskIds.length),
   oracleEvidence,
   competitorProfile = resolveHarnessCompetitorProfile(),
 }) {
@@ -192,7 +220,7 @@ export function buildHarnessAbManifest({
     },
     taskIds,
     orderSeed: ORDER_SEED,
-    pilotTaskCount: CANARY_TASKS,
+    pilotTaskCount: Math.min(CANARY_TASKS, taskIds.length),
     model: { provider: PROVIDER, id: MODEL, reasoningEffort: REASONING_EFFORT },
     pricing: PRICING,
     arms: [
@@ -220,7 +248,7 @@ export function buildHarnessAbManifest({
     subjectFingerprint,
     taskSourceFingerprint,
     toolchainFingerprint,
-    pairConcurrency: PAIR_CONCURRENCY,
+    pairConcurrency,
     ...(oracleEvidence ? { oracleEvidence } : {}),
   });
 }
@@ -233,15 +261,23 @@ export async function main() {
   const outDir = envPath('MAKA_HARNESS_AB_OUT_DIR');
   const tasksRoot = envPath('MAKA_HARNESS_AB_TASKS_ROOT', join(homedir(), '.cache/harbor/tasks'));
   const competitorProfile = resolveHarnessCompetitorProfile(process.env.MAKA_HARNESS_AB_COMPETITOR || 'kimi-code');
-  const runId = resolveHarnessAbRunId(competitorProfile, process.env.MAKA_HARNESS_AB_RUN_ID);
-  const limit = runLimit(process.env.MAKA_HARNESS_AB_LIMIT);
+  const runId = resolveHarnessAbRunId(
+    competitorProfile,
+    process.env.MAKA_HARNESS_AB_RUN_ID,
+    process.env.MAKA_HARNESS_AB_TASK_ID,
+  );
+  const selection = resolveHarnessAbTaskSelection(
+    process.env.MAKA_HARNESS_AB_TASK_ID,
+    process.env.MAKA_HARNESS_AB_LIMIT,
+    process.env.MAKA_HARNESS_AB_PAIR_CONCURRENCY,
+  );
   const runRoot = resolveFixedPromptRunRoot(outDir, runId, 'MAKA_HARNESS_AB_RUN_ID');
   await withHarnessAbRunLock(runRoot, async () => {
     const journal = backgroundJournal(runRoot);
     if (journal) await writeBackgroundJournal(journal.path, { ...journal.base, status: 'running' });
     let exitCode = 0;
     try {
-      await runLocked({ repoRoot, makaRepoPath, tasksRoot, runId, limit, runRoot, competitorProfile });
+      await runLocked({ repoRoot, makaRepoPath, tasksRoot, runId, selection, runRoot, competitorProfile });
     } catch (error) {
       exitCode = 1;
       throw error;
@@ -258,14 +294,14 @@ export async function main() {
   });
 }
 
-async function runLocked({ repoRoot, makaRepoPath, tasksRoot, runId, limit, runRoot, competitorProfile }) {
+async function runLocked({ repoRoot, makaRepoPath, tasksRoot, runId, selection, runRoot, competitorProfile }) {
   const allTasks = await discoverCachedHarborTasks(tasksRoot);
   assertTerminalBench21TaskSet(allTasks.map((task) => task.id));
   const taskSourceFingerprint = await fingerprintFixedPromptTaskTree(allTasks);
   assertTerminalBench21TaskTreeFingerprint(taskSourceFingerprint);
 
   if (process.env.MAKA_HARNESS_AB_DRY_RUN === '1') {
-    console.log(`dry-run: frozen ${EXPECTED_SOURCE_TASKS}-task profile will run ${limit} paired Pass@1 cells; Oracle evidence is advisory`);
+    console.log(`dry-run: frozen ${EXPECTED_SOURCE_TASKS}-task source will run ${selection.limit} paired Pass@1 cells; Oracle evidence is advisory`);
     return;
   }
 
@@ -306,12 +342,13 @@ async function runLocked({ repoRoot, makaRepoPath, tasksRoot, runId, limit, runR
     subjectFingerprint,
     taskSourceFingerprint,
     toolchainFingerprint,
-    taskIds: TERMINAL_BENCH_2_1_TASK_IDS,
+    taskIds: selection.taskIds,
+    pairConcurrency: selection.pairConcurrency,
     oracleEvidence,
     competitorProfile,
   });
   await ensureAbRunManifest(manifestPath, manifest);
-  const evaluationTasks = manifest.evaluationTaskIds.slice(0, limit).map((taskId) => tasksById.get(taskId));
+  const evaluationTasks = manifest.evaluationTaskIds.slice(0, selection.limit).map((taskId) => tasksById.get(taskId));
   if (evaluationTasks.some((task) => !task)) throw new Error('manifest contains a task absent from the frozen task source');
 
   const competitorToolchain = competitorProfile.id === 'kimi-code'
@@ -400,7 +437,7 @@ async function runLocked({ repoRoot, makaRepoPath, tasksRoot, runId, limit, runR
         }),
       },
     ],
-    pairConcurrency: PAIR_CONCURRENCY,
+    pairConcurrency: selection.pairConcurrency,
   });
   const evaluatedTaskIds = new Set(evaluationTasks.map((task) => task.id));
   const report = buildHarnessAbReport(summary, {

--- a/packages/headless/src/__tests__/fixed-prompt-controller.test.ts
+++ b/packages/headless/src/__tests__/fixed-prompt-controller.test.ts
@@ -2365,6 +2365,168 @@ describe('fixed prompt controller', () => {
       assert.equal(result.events[0]?.expectedPromptHash, hashSystemPrompt('fixed prompt\n'));
     });
   });
+
+  test('resumes a legacy terminal whose prompt hash is attested by execution identity', async () => {
+    await withDir(async (dir) => {
+      const systemPromptPath = join(dir, 'system_prompt.md');
+      const resultsJsonlPath = join(dir, 'results.jsonl');
+      const promptHash = hashSystemPrompt('fixed prompt\n');
+      await writeFile(systemPromptPath, 'fixed prompt\n', 'utf8');
+      const seeded = taskCompletedEvent({ taskId: 'task-a', resumeFingerprint: 'sha256:manifest' });
+      assert.equal(seeded.type, 'task_completed');
+      if (seeded.type !== 'task_completed') throw new Error('expected completed fixture');
+      const { promptHash: _legacyMissingPromptHash, ...withoutPromptHash } = seeded;
+      await appendFixedPromptWalEvent(resultsJsonlPath, {
+        ...withoutPromptHash,
+        executionIdentity: {
+          llmConnectionSlug: 'fake',
+          model: 'fake-model',
+          reasoningEffort: 'off',
+          systemPromptHash: promptHash,
+          pricingProfile: 'test-profile',
+        },
+      });
+      let harborCalls = 0;
+
+      const result = await runFixedPromptController({
+        runId: 'run-1',
+        roundId: 'round-1',
+        config,
+        systemPromptPath,
+        resultsJsonlPath,
+        tasks: [{ id: 'task-a', path: '/bench/task-a' }],
+        resumeFingerprint: 'sha256:manifest',
+        protectPassAtOne: true,
+        harborRunner: async () => {
+          harborCalls += 1;
+          return harborOutput({ taskId: 'task-a' });
+        },
+      });
+
+      assert.equal(harborCalls, 0);
+      assert.equal(result.events[0]?.type, 'task_completed');
+    });
+  });
+
+  test('keeps a scored terminal authoritative over a later orphan marker', async () => {
+    await withDir(async (dir) => {
+      const systemPromptPath = join(dir, 'system_prompt.md');
+      const resultsJsonlPath = join(dir, 'results.jsonl');
+      await writeFile(systemPromptPath, 'fixed prompt\n', 'utf8');
+      await appendFixedPromptWalEvent(resultsJsonlPath, taskCompletedEvent({
+        taskId: 'task-a',
+        resumeFingerprint: 'sha256:manifest',
+      }));
+      await appendFixedPromptWalEvent(resultsJsonlPath, {
+        schemaVersion: 1,
+        type: 'task_plumbing_failed',
+        id: 'orphan-1',
+        ts: 20,
+        runId: 'run-1',
+        roundId: 'round-1',
+        resumeFingerprint: 'sha256:manifest',
+        taskId: 'task-a',
+        status: 'plumbing_failed',
+        passed: false,
+        scored: false,
+        eligible: false,
+        errorClass: 'orphaned_sampled_attempt',
+        error: 'terminal WAL append raced an old orphan marker',
+        expectedPromptHash: hashSystemPrompt('fixed prompt\n'),
+      });
+
+      const result = await runFixedPromptController({
+        runId: 'run-1',
+        roundId: 'round-1',
+        config,
+        systemPromptPath,
+        resultsJsonlPath,
+        tasks: [{ id: 'task-a', path: '/bench/task-a' }],
+        resumeFingerprint: 'sha256:manifest',
+        protectPassAtOne: true,
+        harborRunner: async () => harborOutput({ taskId: 'task-a' }),
+      });
+
+      assert.equal(result.events[0]?.type, 'task_completed');
+      assert.equal(result.events[0]?.scored, true);
+    });
+  });
+
+  test('keeps a structured verifier pass authoritative after an agent infrastructure exit', async () => {
+    await withDir(async (dir) => {
+      const systemPromptPath = join(dir, 'system_prompt.md');
+      await writeFile(systemPromptPath, 'fixed prompt\n', 'utf8');
+
+      const result = await runFixedPromptController({
+        runId: 'run-1',
+        roundId: 'round-1',
+        config,
+        systemPromptPath,
+        resultsJsonlPath: join(dir, 'results.jsonl'),
+        tasks: [{ id: 'task-a', path: '/bench/task-a' }],
+        harborRunner: async () => harborOutput({
+          taskId: 'task-a',
+          reward: 1,
+          status: 'failed',
+          errorClass: 'infra_failed',
+          verifier: {
+            outcome: 'passed',
+            attempts: [{ attempt: 1, classification: 'passed', durationMs: 20, reward: 1 }],
+          },
+        }),
+      });
+
+      assert.equal(result.events[0]?.type, 'task_completed');
+      assert.equal(result.events[0]?.passed, true);
+      assert.equal(result.events[0]?.scored, true);
+      assert.equal(result.events[0]?.errorClass, undefined);
+    });
+  });
+
+  test('projects a stored structured verifier pass without resampling Harbor', async () => {
+    await withDir(async (dir) => {
+      const systemPromptPath = join(dir, 'system_prompt.md');
+      const resultsJsonlPath = join(dir, 'results.jsonl');
+      await writeFile(systemPromptPath, 'fixed prompt\n', 'utf8');
+      const stored = taskCompletedEvent({ taskId: 'task-a' });
+      assert.equal(stored.type, 'task_completed');
+      if (stored.type !== 'task_completed') throw new Error('expected completed fixture');
+      await appendFixedPromptWalEvent(resultsJsonlPath, {
+        ...stored,
+        status: 'failed',
+        passed: false,
+        scored: false,
+        eligible: false,
+        errorClass: 'infra_failed',
+        harbor: {
+          reward: 1,
+          verifier: {
+            outcome: 'passed',
+            attempts: [{ attempt: 1, classification: 'passed', durationMs: 20, reward: 1 }],
+          },
+        },
+      });
+      let harborCalls = 0;
+
+      const result = await runFixedPromptController({
+        runId: 'run-1',
+        roundId: 'round-1',
+        config,
+        systemPromptPath,
+        resultsJsonlPath,
+        tasks: [{ id: 'task-a', path: '/bench/task-a' }],
+        harborRunner: async () => {
+          harborCalls += 1;
+          return harborOutput({ taskId: 'task-a' });
+        },
+      });
+
+      assert.equal(harborCalls, 0);
+      assert.equal(result.events[0]?.passed, true);
+      assert.equal(result.events[0]?.scored, true);
+      assert.equal(result.events[0]?.errorClass, undefined);
+    });
+  });
 });
 
 function taskCompletedEvent(input: { taskId: string; promptHash?: string; resumeFingerprint?: string }): FixedPromptWalEvent {

--- a/packages/headless/src/__tests__/harness-ab-cli.test.ts
+++ b/packages/headless/src/__tests__/harness-ab-cli.test.ts
@@ -44,6 +44,63 @@ test('harness A/B runtime keeps pruning enabled and semantic compact disabled', 
   });
 });
 
+test('harness A/B selects one named task only with an explicit run identity', async () => {
+  const {
+    buildHarnessAbManifest,
+    resolveHarnessAbRunId,
+    resolveHarnessAbTaskSelection,
+    resolveHarnessCompetitorProfile,
+  } = await import(
+    new URL('../../harbor/run-harness-ab.mjs', import.meta.url).href
+  );
+  const taskId = 'extract-moves-from-video';
+  const selection = resolveHarnessAbTaskSelection(taskId, undefined, undefined);
+
+  assert.deepEqual(selection, { taskIds: [taskId], limit: 1, pairConcurrency: 1 });
+  assert.throws(
+    () => resolveHarnessAbTaskSelection('not-a-terminal-bench-task', undefined, undefined),
+    /MAKA_HARNESS_AB_TASK_ID must name a Terminal-Bench 2\.1 task/,
+  );
+  assert.throws(
+    () => resolveHarnessAbRunId(resolveHarnessCompetitorProfile(), undefined, taskId),
+    /MAKA_HARNESS_AB_RUN_ID is required with MAKA_HARNESS_AB_TASK_ID/,
+  );
+
+  const manifest = buildHarnessAbManifest({
+    subjectFingerprint: 'subject',
+    taskSourceFingerprint: 'tasks',
+    toolchainFingerprint: 'tools',
+    taskIds: selection.taskIds,
+    pairConcurrency: selection.pairConcurrency,
+  });
+  assert.deepEqual(manifest.evaluationTaskIds, [taskId]);
+  assert.equal(manifest.metadata.order.pilotTaskCount, 1);
+  assert.equal(manifest.maxConcurrency, 1);
+  assert.equal(manifest.maxConcurrentAttempts, 2);
+});
+
+test('harness A/B records its configured rolling pair concurrency in the manifest', async () => {
+  const { buildHarnessAbManifest, resolveHarnessAbTaskSelection } = await import(
+    new URL('../../harbor/run-harness-ab.mjs', import.meta.url).href
+  );
+  const selection = resolveHarnessAbTaskSelection(undefined, '89', '2');
+  const manifest = buildHarnessAbManifest({
+    subjectFingerprint: 'subject',
+    taskSourceFingerprint: 'tasks',
+    toolchainFingerprint: 'tools',
+    taskIds: selection.taskIds,
+    pairConcurrency: selection.pairConcurrency,
+  });
+
+  assert.equal(selection.limit, 89);
+  assert.equal(manifest.maxConcurrency, 2);
+  assert.equal(manifest.maxConcurrentAttempts, 4);
+  assert.throws(
+    () => resolveHarnessAbTaskSelection(undefined, '89', '5'),
+    /MAKA_HARNESS_AB_PAIR_CONCURRENCY must be an integer between 1 and 4/,
+  );
+});
+
 test('harness Oracle environment selects the linux/amd64 image manifest digest', async () => {
   const { resolvedImageDigestFromInspect } = await import(
     new URL('../../harbor/run-harness-ab.mjs', import.meta.url).href
@@ -213,6 +270,31 @@ test('harness A/B completion log preserves the report status', async () => {
   const source = await readFile(scriptPath, 'utf8');
 
   assert.match(source, /console\.log\(`\$\{report\.runStatus\}:/);
+});
+
+test('detached named-task launcher requires a run id before creating artifacts', async () => {
+  const dir = await mkdtemp(join(tmpdir(), 'maka-harness-ab-detached-identity-'));
+  try {
+    const outDir = join(dir, 'out');
+    const scriptPath = new URL('../../harbor/run-harness-ab-detached.mjs', import.meta.url);
+    await assert.rejects(execFileAsync(process.execPath, [scriptPath.pathname], {
+      cwd: process.cwd(),
+      env: {
+        ...process.env,
+        MAKA_HARNESS_AB_OUT_DIR: outDir,
+        MAKA_HARNESS_AB_RUN_ID: '',
+        MAKA_HARNESS_AB_TASK_ID: 'extract-moves-from-video',
+        MAKA_HARNESS_AB_TASKS_ROOT: join(dir, 'missing-tasks'),
+        MAKA_HARNESS_AB_DRY_RUN: '1',
+      },
+    }), /MAKA_HARNESS_AB_RUN_ID is required with MAKA_HARNESS_AB_TASK_ID/);
+    await assert.rejects(
+      readFile(join(outDir, 'k3-maka-vs-kimi-code-tbench-2.1-full-v2', 'background-run.log')),
+      { code: 'ENOENT' },
+    );
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
 });
 
 test('detached harness launcher persists a terminal failed journal after the worker exits', async () => {

--- a/packages/headless/src/fixed-prompt-controller.ts
+++ b/packages/headless/src/fixed-prompt-controller.ts
@@ -549,7 +549,9 @@ export async function readFixedPromptWal(path: string): Promise<FixedPromptWalEv
       throw error;
     }
   }
-  return events.map(projectLegacyTimeoutOutcome);
+  return events
+    .map(projectLegacyTimeoutOutcome)
+    .map(projectStructuredVerifierPassOutcome);
 }
 
 export async function readHarborTaskRunOutput(
@@ -766,6 +768,8 @@ function taskEventFromOutput(input: {
   id: string;
   ts: number;
 }): FixedPromptTaskCompletedEvent | FixedPromptTaskPlumbingFailedEvent | FixedPromptTaskInfraFailedEvent {
+  const structuredVerifierPassed = input.output.harbor.reward > 0
+    && input.output.harbor.verifier?.outcome === 'passed';
   const identityMismatch = classifyExplicitIdentityMismatch(
     input.output.cell.executionIdentity,
     input.expectedPromptHash,
@@ -779,7 +783,7 @@ function taskEventFromOutput(input: {
       error: identityMismatch.error,
     });
   }
-  if (isProviderInfraFailure(input.output.cell.errorClass)) {
+  if (isProviderInfraFailure(input.output.cell.errorClass) && !structuredVerifierPassed) {
     return taskInfraFailedEvent({
       ...input,
       errorClass: input.output.cell.errorClass,
@@ -815,15 +819,19 @@ function taskCompletedEvent(input: {
   ts: number;
 }): FixedPromptTaskCompletedEvent {
   const { output } = input;
+  const promptHash = output.cell.promptHash ?? output.cell.executionIdentity?.systemPromptHash;
   const deadlineSettled = output.cell.deadlineSettlement?.source === 'benchmark.deadline';
+  const structuredVerifierPassed = output.harbor.reward > 0
+    && output.harbor.verifier?.outcome === 'passed';
   const verifierGraded = output.cell.status === 'completed'
     || deadlineSettled
+    || structuredVerifierPassed
     || (
       (output.cell.errorClass === 'max_tokens' || output.cell.errorClass === 'tool_step_cap_reached')
       && output.harbor.verifier !== undefined
     );
   const passed = verifierGraded && output.harbor.reward > 0;
-  const errorClass = output.cell.errorClass ?? (passed ? undefined : 'verification_failed');
+  const errorClass = passed ? undefined : output.cell.errorClass ?? 'verification_failed';
   const scored = verifierGraded && !isUnscoredCellFailure(errorClass);
   const agentFailure = output.cell.status === 'failed' && errorClass === 'tool_step_cap_reached';
   return {
@@ -840,7 +848,7 @@ function taskCompletedEvent(input: {
     scored,
     eligible: scored || agentFailure,
     ...(errorClass ? { errorClass } : {}),
-    ...(output.cell.promptHash ? { promptHash: output.cell.promptHash } : {}),
+    ...(promptHash ? { promptHash } : {}),
     ...(output.cell.executionIdentity ? { executionIdentity: output.cell.executionIdentity } : {}),
     ...(output.cell.deadlineSettlement ? { deadlineSettlement: output.cell.deadlineSettlement } : {}),
     ...(output.cell.tokenSummary ? { tokenSummary: output.cell.tokenSummary } : {}),
@@ -1204,6 +1212,21 @@ function projectLegacyTimeoutOutcome(event: FixedPromptWalEvent): FixedPromptWal
   };
 }
 
+function projectStructuredVerifierPassOutcome(event: FixedPromptWalEvent): FixedPromptWalEvent {
+  if (
+    event.type !== 'task_completed'
+    || event.harbor.reward <= 0
+    || event.harbor.verifier?.outcome !== 'passed'
+  ) return event;
+  const { errorClass: _legacyFailureClass, ...rest } = event;
+  return {
+    ...rest,
+    passed: true,
+    scored: true,
+    eligible: true,
+  };
+}
+
 function budgetExhaustedArtifactRefs(error: unknown): FixedPromptBudgetExhaustedArtifactRefs {
   if (isBudgetExhaustedError(error)) {
     const refs = (error as { artifactRefs?: FixedPromptBudgetExhaustedArtifactRefs }).artifactRefs;
@@ -1242,7 +1265,7 @@ function terminalTaskEvents(
       || event.type === 'task_plumbing_failed'
       || (includeInfraFailure && event.type === 'task_infra_failed')
     ) {
-      byTask.set(event.taskId, event);
+      setAuthoritativeTaskEvent(byTask, event);
     }
   }
   return byTask;
@@ -1321,9 +1344,22 @@ function roundTaskEvents(
     if (!isTaskEvent(event)) continue;
     if (event.runId !== runId || event.roundId !== roundId) continue;
     if (!eventMatchesResumeIdentity(event, expectedPromptHash, resumeFingerprint)) continue;
-    byTask.set(event.taskId, event);
+    setAuthoritativeTaskEvent(byTask, event);
   }
   return byTask;
+}
+
+function setAuthoritativeTaskEvent(
+  byTask: Map<string, FixedPromptTaskWalEvent>,
+  event: FixedPromptTaskWalEvent,
+): void {
+  const existing = byTask.get(event.taskId);
+  if (
+    existing?.scored
+    && event.type === 'task_plumbing_failed'
+    && event.errorClass === 'orphaned_sampled_attempt'
+  ) return;
+  byTask.set(event.taskId, event);
 }
 
 export function selectFixedPromptRoundTaskEvents(
@@ -1347,6 +1383,10 @@ function eventMatchesResumeIdentity(
     return resumeFingerprint !== undefined && event.expectedPromptHash === expectedPromptHash;
   }
   if (event.promptHash === expectedPromptHash) return true;
+  if (
+    'executionIdentity' in event
+    && event.executionIdentity?.systemPromptHash === expectedPromptHash
+  ) return true;
   return event.type === 'task_plumbing_failed' && event.expectedPromptHash === expectedPromptHash;
 }
 


### PR DESCRIPTION
## Summary

- Allow the Terminal-Bench harness to select one named task or lower rolling pair concurrency, and record the effective concurrency in the immutable run manifest.
- Require an explicit run ID for named-task runs before either the direct or detached launcher creates run artifacts.
- Preserve authoritative resume evidence: a structured verifier pass wins over a trailing agent infrastructure exit, legacy execution identity can attest a missing prompt hash, and a later orphan marker cannot replace an already scored terminal.
- Keep the boundary deliberately small. This PR does not add operator result recovery, replacement admissions, cross-WAL recovery state, or a subject-fingerprint override.

## Verification

- `node --test packages/headless/dist/__tests__/harness-ab-cli.test.js packages/headless/dist/__tests__/harness-ab-run.test.js packages/headless/dist/__tests__/fixed-prompt-controller.test.js` — 94 passed, 0 failed.
- `npm test --workspace=@maka/headless` — 1119 passed, 0 failed.
- Reverted each of the two PR commits independently in detached worktrees and ran `npm --workspace @maka/headless run build` — both builds passed.

## Review focus

The two commits are intentionally independent: the first owns harness selection/run identity, and the second owns fixed-prompt evidence projection and precedence. Either commit can be reverted without breaking the other's build.
