### PR TITLE
feat(headless): capture provider stream telemetry

### DIFF
--- a/packages/headless/src/__tests__/fixed-prompt-controller.test.ts
+++ b/packages/headless/src/__tests__/fixed-prompt-controller.test.ts
@@ -506,7 +506,9 @@ describe('fixed prompt controller', () => {
         resultsTsvPath: join(dir, 'results.tsv'),
         tasks: [{ id: 'task-a', path: '/bench/task-a' }],
         harborRunner: async () => {
-          throw new Error('container crashed before result.json');
+          throw Object.assign(new Error('container crashed before result.json'), {
+            artifactRefs: { providerTelemetryPath: '/logs/task-a/provider-request-telemetry.json' },
+          });
         },
         now: () => 100,
         newId: idFactory(),
@@ -517,6 +519,10 @@ describe('fixed prompt controller', () => {
       assert.equal(result.events[0]?.eligible, false);
       assert.equal(result.events[0]?.scored, false);
       assert.equal(result.events[0]?.errorClass, 'infra_error');
+      assert.equal(
+        result.events[0]?.type === 'task_infra_failed' ? result.events[0].providerTelemetryPath : undefined,
+        '/logs/task-a/provider-request-telemetry.json',
+      );
       assert.match(await readFile(resultsJsonlPath, 'utf8'), /"type":"task_infra_failed"/);
     });
   });
@@ -998,6 +1004,7 @@ describe('fixed prompt controller', () => {
       assert.equal(event.tokenSummarySource, 'final');
       assert.equal(event.runtimeEventsPath, cell.runtimeEventsPath);
       assert.equal(event.traceEventsPath, cell.traceEventsPath);
+      assert.equal(event.providerTelemetryPath, '/logs/task-a/provider-request-telemetry.json');
       assert.deepEqual(
         'contextBudgetSummary' in event ? event.contextBudgetSummary : undefined,
         retainedContextBudgetSummary,
@@ -1981,6 +1988,10 @@ describe('fixed prompt controller', () => {
       assert.equal(result.events[0]?.type, 'task_infra_failed');
       assert.equal(result.events[0]?.eligible, false);
       assert.equal(result.events[0]?.errorClass, 'rate_limit');
+      assert.equal(
+        result.events[0]?.type === 'task_infra_failed' ? result.events[0].providerTelemetryPath : undefined,
+        '/logs/task-a/provider-request-telemetry.json',
+      );
     });
   });
 
@@ -2414,6 +2425,7 @@ function harborOutput(input: {
   executionIdentity?: HarborTaskRunOutput['cell']['executionIdentity'];
   deadlineSettlement?: HarborTaskRunOutput['cell']['deadlineSettlement'];
   verifier?: HarborTaskRunOutput['harbor']['verifier'];
+  providerTelemetryPath?: string;
 }): HarborTaskRunOutput {
   return {
     harbor: { reward: input.reward ?? 1, ...(input.verifier ? { verifier: input.verifier } : {}) },
@@ -2423,6 +2435,7 @@ function harborOutput(input: {
       ...(input.errorClass ? { errorClass: input.errorClass } : {}),
       runtimeEventsPath: `/logs/${input.taskId}/runtime-events.jsonl`,
       traceEventsPath: `/logs/${input.taskId}/events.jsonl`,
+      providerTelemetryPath: input.providerTelemetryPath ?? `/logs/${input.taskId}/provider-request-telemetry.json`,
       ...(input.omitPromptHash ? {} : { promptHash: input.promptHash ?? hashSystemPrompt('fixed prompt\n') }),
       ...(input.executionIdentity ? { executionIdentity: input.executionIdentity } : {}),
       ...(input.deadlineSettlement ? { deadlineSettlement: input.deadlineSettlement } : {}),

--- a/packages/headless/src/__tests__/harbor-task-runner.test.ts
+++ b/packages/headless/src/__tests__/harbor-task-runner.test.ts
@@ -472,7 +472,7 @@ describe('createHarborTaskRunner', () => {
         upstreamAuthorization = request.headers.authorization ?? '';
         response.writeHead(200, { 'content-type': 'text/event-stream' });
         response.end([
-          'data: {"id":"chatcmpl-1","choices":[],"usage":{"prompt_tokens":100,"completion_tokens":25,"prompt_tokens_details":{"cached_tokens":20}}}',
+          'data: {"id":"chatcmpl-1","choices":[],"usage":{"prompt_tokens":100,"completion_tokens":25,"prompt_tokens_details":{"cached_tokens":20},"completion_tokens_details":{"reasoning_tokens":15}}}',
           '',
           'data: [DONE]',
           '',
@@ -523,11 +523,23 @@ describe('createHarborTaskRunner', () => {
           cacheMissInput: 80,
           cacheWriteInput: 0,
           cacheMissInputSource: 'explicit',
-          reasoning: 0,
+          reasoning: 15,
           total: 125,
           costUsd: 0,
           pricingSource: 'runtime',
         });
+        assert.ok(output.cell.providerTelemetryPath);
+        const telemetry = JSON.parse(await readFile(output.cell.providerTelemetryPath, 'utf8')) as {
+          schemaVersion: number;
+          summary: { requests: number; completed: number; reasoningTokens: number | null };
+          requests: Array<{ outcome: string; terminalEvent: boolean }>;
+        };
+        assert.equal(telemetry.schemaVersion, 1);
+        assert.equal(telemetry.summary.requests, 1);
+        assert.equal(telemetry.summary.completed, 1);
+        assert.equal(telemetry.summary.reasoningTokens, 15);
+        assert.equal(telemetry.requests[0]?.outcome, 'completed');
+        assert.equal(telemetry.requests[0]?.terminalEvent, true);
       } finally {
         await new Promise<void>((resolve, reject) => upstream.close((error) => error ? reject(error) : resolve()));
       }
@@ -766,6 +778,60 @@ describe('createHarborTaskRunner', () => {
         runHarbor: fakeRunner({ exitCode: 1 }),
       });
       await assert.rejects(runner(runInput()), HarborInfraError);
+    });
+  });
+
+  test('keeps provider telemetry evidence when Harbor exits non-zero', async () => {
+    await withRun(async ({ jobsDir, repo, keyFile }) => {
+      const upstream = createServer((_request, response) => {
+        response.writeHead(429, { 'content-type': 'application/json' });
+        response.end('{"error":"rate_limited"}');
+      });
+      await new Promise<void>((resolve) => upstream.listen(0, '127.0.0.1', resolve));
+      const address = upstream.address();
+      assert.ok(address && typeof address !== 'string');
+      try {
+        const runner = createHarborTaskRunner({
+          makaRepoPath: repo,
+          jobsDir,
+          agent: 'kimi-code',
+          kimiCodeToolchainPath: '/toolchain',
+          agentVersion: '0.26.0',
+          model: 'kimi-coding-plan/k3',
+          provider: 'kimi-coding-plan',
+          apiKeyFile: keyFile,
+          agentEnv: { MAKA_BASE_URL: `http://127.0.0.1:${address.port}/coding/v1` },
+          runHarbor: async (request) => {
+            const proxyUrl = request.env?.MAKA_PROVIDER_PROXY_URL
+              ?.replace('host.docker.internal', '127.0.0.1');
+            const proxyToken = request.env?.MAKA_PROVIDER_PROXY_TOKEN;
+            assert.ok(proxyUrl && proxyToken);
+            const response = await fetch(`${proxyUrl}/chat/completions`, {
+              method: 'POST',
+              headers: { authorization: `Bearer ${proxyToken}` },
+              body: '{}',
+            });
+            assert.equal(response.status, 429);
+            await response.text();
+            return { exitCode: 1, stdout: '', stderr: 'container failed' };
+          },
+        });
+
+        let caught: unknown;
+        try {
+          await runner(runInput());
+        } catch (error) {
+          caught = error;
+        }
+        assert.ok(caught instanceof HarborInfraError);
+        assert.ok(caught.artifactRefs?.providerTelemetryPath);
+        const telemetry = JSON.parse(await readFile(caught.artifactRefs.providerTelemetryPath, 'utf8')) as {
+          summary: { failed: number };
+        };
+        assert.equal(telemetry.summary.failed, 1);
+      } finally {
+        await new Promise<void>((resolve, reject) => upstream.close((error) => error ? reject(error) : resolve()));
+      }
     });
   });
 

--- a/packages/headless/src/__tests__/harbor-task-runner.test.ts
+++ b/packages/headless/src/__tests__/harbor-task-runner.test.ts
@@ -77,6 +77,7 @@ interface FakeOptions {
   verifierStdout?: string;
   verifierOutcome?: Record<string, unknown> | null;
   trialResult?: Record<string, unknown>;
+  makaTrace?: boolean;
   captured?: { config?: Record<string, unknown>; request?: HarborRunRequest };
 }
 
@@ -142,8 +143,10 @@ function fakeRunner(opts: FakeOptions): HarborProcessRunner {
       await writeFile(join(trialDir, 'result.json'), JSON.stringify(opts.trialResult), 'utf8');
     }
     await writeFile(join(trialDir, 'agent', 'runtime-events.jsonl'), opts.events ?? '{"type":"x"}\n', 'utf8');
-    await mkdir(join(trialDir, 'agent', 'maka-storage', 'sessions', 'sess', 'runs', 'run'), { recursive: true });
-    await writeFile(join(trialDir, 'agent', 'maka-storage', 'sessions', 'sess', 'runs', 'run', 'events.jsonl'), '{"type":"tool_failed"}\n', 'utf8');
+    if (opts.makaTrace !== false) {
+      await mkdir(join(trialDir, 'agent', 'maka-storage', 'sessions', 'sess', 'runs', 'run'), { recursive: true });
+      await writeFile(join(trialDir, 'agent', 'maka-storage', 'sessions', 'sess', 'runs', 'run', 'events.jsonl'), '{"type":"tool_failed"}\n', 'utf8');
+    }
     return {
       exitCode: opts.exitCodeAfterArtifacts ?? 0,
       stdout: opts.exitCodeAfterArtifacts ? '' : 'ok',
@@ -543,6 +546,25 @@ describe('createHarborTaskRunner', () => {
       } finally {
         await new Promise<void>((resolve, reject) => upstream.close((error) => error ? reject(error) : resolve()));
       }
+    });
+  });
+
+  test('uses the external agent runtime stream as its readable trace evidence', async () => {
+    await withRun(async ({ jobsDir, repo }) => {
+      const runner = createHarborTaskRunner({
+        makaRepoPath: repo,
+        jobsDir,
+        agent: 'kimi-code',
+        kimiCodeToolchainPath: '/toolchain',
+        agentVersion: '0.26.0',
+        model: 'kimi-coding-plan/k3',
+        provider: 'ollama',
+        runHarbor: fakeRunner({ reward: '1\n', makaTrace: false }),
+      });
+
+      const output = await runner(runInput());
+      assert.equal(output.cell.traceEventsPath, output.cell.runtimeEventsPath);
+      assert.equal(await readFile(output.cell.traceEventsPath, 'utf8'), '{"type":"x"}\n');
     });
   });
 

--- a/packages/headless/src/__tests__/provider-auth-proxy.test.ts
+++ b/packages/headless/src/__tests__/provider-auth-proxy.test.ts
@@ -4,7 +4,7 @@ import { mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { test } from 'node:test';
-import { startProviderAuthProxy } from '../provider-auth-proxy.js';
+import { startProviderAuthProxy, summarizeProviderTelemetry } from '../provider-auth-proxy.js';
 
 test('provider auth proxy keeps the provider key host-side', async () => {
   const dir = await mkdtemp(join(tmpdir(), 'maka-provider-proxy-'));
@@ -147,7 +147,7 @@ test('provider auth proxy totals Anthropic streaming usage without changing the 
 test('provider auth proxy totals OpenAI chat streaming usage without changing the response bytes', async () => {
   const dir = await mkdtemp(join(tmpdir(), 'maka-provider-proxy-openai-usage-'));
   const stream = [
-    'data: {"id":"chatcmpl-1","choices":[],"usage":{"prompt_tokens":100,"completion_tokens":25,"prompt_tokens_details":{"cached_tokens":20}}}',
+    'data: {"id":"chatcmpl-1","choices":[],"usage":{"prompt_tokens":100,"completion_tokens":25,"prompt_tokens_details":{"cached_tokens":20},"completion_tokens_details":{"reasoning_tokens":15}}}',
     '',
     'data: [DONE]',
     '',
@@ -181,7 +181,174 @@ test('provider auth proxy totals OpenAI chat streaming usage without changing th
       cacheRead: 20,
       cacheWrite: 0,
       output: 25,
+      reasoning: 15,
     });
+  } finally {
+    await proxy.close();
+    await new Promise<void>((resolve, reject) => upstream.close((error) => error ? reject(error) : resolve()));
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test('provider telemetry summarizes output, reasoning, and stream-stall evidence', () => {
+  assert.deepEqual(summarizeProviderTelemetry([{
+    requestId: 1,
+    method: 'POST',
+    path: '/chat/completions',
+    protocol: 'openai-chat-sse',
+    status: 200,
+    outcome: 'completed',
+    firstOutputTokenMs: 250,
+    lastOutputTokenMs: 350,
+    firstReasoningTokenMs: 250,
+    lastReasoningTokenMs: 300,
+    reasoningEndMs: 450,
+    maxBodyChunkGapMs: 175,
+    durationMs: 500,
+    bodyChunks: 4,
+    responseBytes: 254,
+    terminalEvent: true,
+    usage: { input: 100, cacheRead: 0, cacheWrite: 0, output: 25, reasoning: 15 },
+  }]), {
+    requests: 1,
+    completed: 1,
+    interrupted: 0,
+    failed: 0,
+    aborted: 0,
+    inputTokens: 100,
+    outputTokens: 25,
+    reasoningTokens: 15,
+    usageMeasuredRequests: 1,
+    reasoningMeasuredRequests: 1,
+    outputTokensPerSecond: 250,
+    reasoningTokensPerSecond: 300,
+    maxBodyChunkGapMs: 175,
+  });
+});
+
+test('provider auth proxy records token timing, stream stalls, and clean completion', async () => {
+  const dir = await mkdtemp(join(tmpdir(), 'maka-provider-proxy-telemetry-'));
+  let clock = 1_000;
+  const upstream = createServer(async (_request, response) => {
+    clock = 1_100;
+    response.writeHead(200, { 'content-type': 'text/event-stream' });
+    response.flushHeaders();
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    clock = 1_250;
+    response.write('data: {"choices":[{"delta":{"reasoning_content":"think"}}]}\n\n');
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    clock = 1_500;
+    response.write('data: {"choices":[{"delta":{"content":"answer"}}]}\n\n');
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    clock = 1_700;
+    response.write('data: {"choices":[],"usage":{"prompt_tokens":100,"completion_tokens":25,"completion_tokens_details":{"reasoning_tokens":15}}}\n\n');
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    clock = 1_750;
+    response.end('data: [DONE]\n\n');
+  });
+  await new Promise<void>((resolve) => upstream.listen(0, '127.0.0.1', resolve));
+  const address = upstream.address();
+  assert.ok(address && typeof address !== 'string');
+  const keyFile = join(dir, 'provider-key');
+  await writeFile(keyFile, 'provider-secret-key\n', 'utf8');
+  const proxy = await startProviderAuthProxy({
+    upstreamBaseUrl: `http://127.0.0.1:${address.port}`,
+    apiKeyFile: keyFile,
+    advertisedHost: '127.0.0.1',
+    usageProtocol: 'openai-chat-sse',
+    now: () => clock,
+  });
+
+  try {
+    const response = await fetch(`${proxy.baseUrl}/chat/completions`, {
+      method: 'POST',
+      headers: { authorization: `Bearer ${proxy.token}` },
+      body: '{}',
+    });
+    await response.text();
+    const [request] = proxy.telemetry();
+    assert.ok(request);
+    assert.equal(request.outcome, 'completed');
+    assert.equal(request.terminalEvent, true);
+    assert.ok(request.responseHeadersMs! <= request.firstBodyChunkMs!);
+    assert.ok(request.firstBodyChunkMs! <= request.firstOutputTokenMs!);
+    assert.ok(request.firstOutputTokenMs! <= request.lastOutputTokenMs!);
+    assert.ok(request.firstReasoningTokenMs! <= request.lastReasoningTokenMs!);
+    assert.ok(request.lastOutputTokenMs! <= request.durationMs);
+    assert.ok(request.maxBodyChunkGapMs! >= 0);
+    assert.deepEqual(request.usage, {
+      input: 100,
+      cacheRead: 0,
+      cacheWrite: 0,
+      output: 25,
+      reasoning: 15,
+    });
+  } finally {
+    await proxy.close();
+    await new Promise<void>((resolve, reject) => upstream.close((error) => error ? reject(error) : resolve()));
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test('provider auth proxy marks a stream without its terminal event as interrupted', async () => {
+  const dir = await mkdtemp(join(tmpdir(), 'maka-provider-proxy-interrupted-'));
+  const upstream = createServer((_request, response) => {
+    response.writeHead(200, { 'content-type': 'text/event-stream' });
+    response.end('data: {"choices":[{"delta":{"content":"partial"}}]}\n\n');
+  });
+  await new Promise<void>((resolve) => upstream.listen(0, '127.0.0.1', resolve));
+  const address = upstream.address();
+  assert.ok(address && typeof address !== 'string');
+  const keyFile = join(dir, 'provider-key');
+  await writeFile(keyFile, 'provider-secret-key\n', 'utf8');
+  const proxy = await startProviderAuthProxy({
+    upstreamBaseUrl: `http://127.0.0.1:${address.port}`,
+    apiKeyFile: keyFile,
+    advertisedHost: '127.0.0.1',
+    usageProtocol: 'openai-chat-sse',
+  });
+
+  try {
+    const response = await fetch(`${proxy.baseUrl}/chat/completions`, {
+      method: 'POST',
+      headers: { authorization: `Bearer ${proxy.token}` },
+      body: '{}',
+    });
+    await response.text();
+    assert.equal(proxy.telemetry()[0]?.outcome, 'interrupted');
+  } finally {
+    await proxy.close();
+    await new Promise<void>((resolve, reject) => upstream.close((error) => error ? reject(error) : resolve()));
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test('provider auth proxy marks an upstream HTTP error as failed', async () => {
+  const dir = await mkdtemp(join(tmpdir(), 'maka-provider-proxy-http-error-'));
+  const upstream = createServer((_request, response) => {
+    response.writeHead(429, { 'content-type': 'application/json' });
+    response.end('{"error":"rate_limited"}');
+  });
+  await new Promise<void>((resolve) => upstream.listen(0, '127.0.0.1', resolve));
+  const address = upstream.address();
+  assert.ok(address && typeof address !== 'string');
+  const keyFile = join(dir, 'provider-key');
+  await writeFile(keyFile, 'provider-secret-key\n', 'utf8');
+  const proxy = await startProviderAuthProxy({
+    upstreamBaseUrl: `http://127.0.0.1:${address.port}`,
+    apiKeyFile: keyFile,
+    advertisedHost: '127.0.0.1',
+  });
+
+  try {
+    const response = await fetch(`${proxy.baseUrl}/chat/completions`, {
+      method: 'POST',
+      headers: { authorization: `Bearer ${proxy.token}` },
+      body: '{}',
+    });
+    assert.equal(response.status, 429);
+    await response.text();
+    assert.equal(proxy.telemetry()[0]?.outcome, 'failed');
   } finally {
     await proxy.close();
     await new Promise<void>((resolve, reject) => upstream.close((error) => error ? reject(error) : resolve()));
@@ -297,7 +464,54 @@ test('provider auth proxy aborts an in-flight upstream request on close', async 
       new Promise((_, reject) => setTimeout(() => reject(new Error('proxy close timed out')), 1_000)),
     ]);
     await assert.rejects(pending);
+    assert.equal(proxy.telemetry()[0]?.outcome, 'aborted');
   } finally {
+    upstream.closeAllConnections();
+    await new Promise<void>((resolve) => upstream.close(() => resolve()));
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test('provider auth proxy aborts the upstream stream when its client disconnects', async () => {
+  const dir = await mkdtemp(join(tmpdir(), 'maka-provider-proxy-client-disconnect-'));
+  let upstreamClosed!: () => void;
+  const upstreamResponseClosed = new Promise<void>((resolve) => { upstreamClosed = resolve; });
+  const upstream = createServer((_request, response) => {
+    response.once('close', upstreamClosed);
+    response.writeHead(200, { 'content-type': 'text/event-stream' });
+    response.write('data: {"choices":[{"delta":{"content":"partial"}}]}\n\n');
+  });
+  await new Promise<void>((resolve) => upstream.listen(0, '127.0.0.1', resolve));
+  const address = upstream.address();
+  assert.ok(address && typeof address !== 'string');
+  const keyFile = join(dir, 'provider-key');
+  await writeFile(keyFile, 'provider-secret-key\n', 'utf8');
+  const proxy = await startProviderAuthProxy({
+    upstreamBaseUrl: `http://127.0.0.1:${address.port}`,
+    apiKeyFile: keyFile,
+    advertisedHost: '127.0.0.1',
+    usageProtocol: 'openai-chat-sse',
+  });
+  const controller = new AbortController();
+
+  try {
+    const response = await fetch(`${proxy.baseUrl}/chat/completions`, {
+      method: 'POST',
+      headers: { authorization: `Bearer ${proxy.token}` },
+      body: '{}',
+      signal: controller.signal,
+    });
+    const firstChunk = await response.body?.getReader().read();
+    assert.equal(firstChunk?.done, false);
+    controller.abort();
+    await Promise.race([
+      upstreamResponseClosed,
+      new Promise((_, reject) => setTimeout(() => reject(new Error('upstream stream was not aborted')), 1_000)),
+    ]);
+    assert.equal(proxy.telemetry()[0]?.outcome, 'aborted');
+  } finally {
+    controller.abort();
+    await proxy.close();
     upstream.closeAllConnections();
     await new Promise<void>((resolve) => upstream.close(() => resolve()));
     await rm(dir, { recursive: true, force: true });

--- a/packages/headless/src/fixed-prompt-controller.ts
+++ b/packages/headless/src/fixed-prompt-controller.ts
@@ -40,6 +40,7 @@ export interface FixedPromptTask {
 
 export type HarborTaskRunCellOutput = HarborCellOutput & {
   traceEventsPath?: string;
+  providerTelemetryPath?: string;
 };
 
 export interface HarborVerifierAttempt {
@@ -79,6 +80,7 @@ export interface HarborTaskRunner {
 export interface FixedPromptBudgetExhaustedArtifactRefs {
   runtimeEventsPath?: string;
   traceEventsPath?: string;
+  providerTelemetryPath?: string;
   runtimeEventsUnavailableReason?: string;
   tokenSummary?: HarborCellTokenSummary;
   cellOutput?: HarborTaskRunCellOutput;
@@ -127,6 +129,7 @@ export interface FixedPromptTaskCompletedEvent {
   durationMs: number;
   runtimeEventsPath: string;
   traceEventsPath?: string;
+  providerTelemetryPath?: string;
   harbor: {
     reward: number;
     verifierFailureSummary?: string;
@@ -161,6 +164,7 @@ export interface FixedPromptTaskInfraFailedEvent {
   eligible: false;
   errorClass: 'infra_error' | 'provider_billing' | 'auth' | 'rate_limit' | 'provider_unavailable' | 'network';
   error: string;
+  providerTelemetryPath?: string;
 }
 
 export interface FixedPromptTaskBudgetExhaustedEvent {
@@ -183,6 +187,7 @@ export interface FixedPromptTaskBudgetExhaustedEvent {
   expectedPromptHash: string;
   runtimeEventsPath?: string;
   traceEventsPath?: string;
+  providerTelemetryPath?: string;
   runtimeEventsUnavailableReason?: string;
   tokenSummary?: HarborCellTokenSummary;
   tokenSummarySource?: 'final' | 'checkpoint';
@@ -221,6 +226,7 @@ export interface FixedPromptTaskPlumbingFailedEvent {
   durationMs?: number;
   runtimeEventsPath?: string;
   traceEventsPath?: string;
+  providerTelemetryPath?: string;
   harbor?: {
     reward: number;
   };
@@ -846,6 +852,7 @@ function taskCompletedEvent(input: {
     durationMs: output.cell.durationMs,
     runtimeEventsPath: output.cell.runtimeEventsPath,
     ...(output.cell.traceEventsPath ? { traceEventsPath: output.cell.traceEventsPath } : {}),
+    ...(output.cell.providerTelemetryPath ? { providerTelemetryPath: output.cell.providerTelemetryPath } : {}),
     harbor: {
       reward: output.harbor.reward,
       ...(output.harbor.verifierFailureSummary ? { verifierFailureSummary: output.harbor.verifierFailureSummary } : {}),
@@ -904,6 +911,9 @@ function taskPlumbingFailedEvent(input: {
     durationMs: input.output.cell.durationMs,
     runtimeEventsPath: input.output.cell.runtimeEventsPath,
     ...(input.output.cell.traceEventsPath ? { traceEventsPath: input.output.cell.traceEventsPath } : {}),
+    ...(input.output.cell.providerTelemetryPath
+      ? { providerTelemetryPath: input.output.cell.providerTelemetryPath }
+      : {}),
     harbor: {
       reward: input.output.harbor.reward,
     },
@@ -1009,6 +1019,7 @@ function classifyExplicitIdentityMismatch(
 
 function taskInfraFailedEvent(input: {
   error: unknown;
+  output?: HarborTaskRunOutput;
   errorClass?: FixedPromptTaskInfraFailedEvent['errorClass'];
   taskId: string;
   runId: string;
@@ -1017,6 +1028,8 @@ function taskInfraFailedEvent(input: {
   id: string;
   ts: number;
 }): FixedPromptTaskInfraFailedEvent {
+  const providerTelemetryPath = input.output?.cell.providerTelemetryPath
+    ?? providerTelemetryPathFromError(input.error);
   return {
     schemaVersion: FIXED_PROMPT_WAL_SCHEMA_VERSION,
     type: 'task_infra_failed',
@@ -1032,7 +1045,16 @@ function taskInfraFailedEvent(input: {
     eligible: false,
     errorClass: input.errorClass ?? 'infra_error',
     error: errorMessage(input.error),
+    ...(providerTelemetryPath ? { providerTelemetryPath } : {}),
   };
+}
+
+function providerTelemetryPathFromError(error: unknown): string | undefined {
+  if (!(error instanceof Error)) return undefined;
+  const path = (error as Error & {
+    artifactRefs?: { providerTelemetryPath?: unknown };
+  }).artifactRefs?.providerTelemetryPath;
+  return typeof path === 'string' && path.length > 0 ? path : undefined;
 }
 
 function taskBudgetExhaustedEvent(input: {
@@ -1104,6 +1126,7 @@ function taskBudgetExhaustedEvent(input: {
   const cellOutput = artifactRefs.cellOutput;
   const runtimeEventsPath = artifactRefs.runtimeEventsPath ?? cellOutput?.runtimeEventsPath;
   const traceEventsPath = artifactRefs.traceEventsPath ?? cellOutput?.traceEventsPath;
+  const providerTelemetryPath = artifactRefs.providerTelemetryPath ?? cellOutput?.providerTelemetryPath;
   return {
     schemaVersion: FIXED_PROMPT_WAL_SCHEMA_VERSION,
     type: 'task_budget_exhausted',
@@ -1127,6 +1150,7 @@ function taskBudgetExhaustedEvent(input: {
     ...(executionIdentity ? { executionIdentity } : {}),
     ...(runtimeEventsPath ? { runtimeEventsPath } : {}),
     ...(traceEventsPath ? { traceEventsPath } : {}),
+    ...(providerTelemetryPath ? { providerTelemetryPath } : {}),
     ...(artifactRefs.runtimeEventsUnavailableReason
       ? { runtimeEventsUnavailableReason: artifactRefs.runtimeEventsUnavailableReason }
       : {}),
@@ -1170,6 +1194,7 @@ function projectLegacyTimeoutOutcome(event: FixedPromptWalEvent): FixedPromptWal
     ...(event.tokenSummary ? { tokenSummary: event.tokenSummary } : {}),
     ...(event.runtimeEventsPath ? { runtimeEventsPath: event.runtimeEventsPath } : {}),
     ...(event.traceEventsPath ? { traceEventsPath: event.traceEventsPath } : {}),
+    ...(event.providerTelemetryPath ? { providerTelemetryPath: event.providerTelemetryPath } : {}),
     ...(event.contextBudgetPolicy ? { contextBudgetPolicy: event.contextBudgetPolicy } : {}),
     ...(event.contextBudgetSummary ? { contextBudgetSummary: event.contextBudgetSummary } : {}),
     ...(event.continuationSummary ? { continuationSummary: event.continuationSummary } : {}),
@@ -1187,6 +1212,7 @@ function budgetExhaustedArtifactRefs(error: unknown): FixedPromptBudgetExhausted
       && (
         refs.runtimeEventsPath
         || refs.traceEventsPath
+        || refs.providerTelemetryPath
         || refs.runtimeEventsUnavailableReason
         || refs.tokenSummary
         || refs.cellOutput

--- a/packages/headless/src/harbor-task-runner.ts
+++ b/packages/headless/src/harbor-task-runner.ts
@@ -28,7 +28,9 @@ import {
   type HarnessOracleTaskResult,
 } from './harness-oracle-policy.js';
 import {
+  summarizeProviderTelemetry,
   startProviderAuthProxy,
+  type ProviderRequestTelemetry,
   type ProviderTokenUsage,
   type ProviderUsageProtocol,
 } from './provider-auth-proxy.js';
@@ -61,6 +63,7 @@ const TRIAL_VERIFIER_STDOUT = 'verifier/test-stdout.txt';
 const TRIAL_VERIFIER_OUTCOME = 'verifier/maka-verifier-outcome.json';
 const TRIAL_RESULT = 'result.json';
 const TRIAL_TRACE_EVENTS_ROOT = 'agent/maka-storage/sessions';
+const PROVIDER_REQUEST_TELEMETRY = 'provider-request-telemetry.json';
 
 /** A Harbor-side failure (build/docker/timeout/missing artifact) — NOT a benchmark
  * result. The controller turns a thrown error into an infra_failed event so it is
@@ -70,6 +73,7 @@ export class HarborInfraError extends Error {
     message: string,
     readonly detail?: string,
     readonly kind: 'infra_failed' | 'timed_out' = 'infra_failed',
+    readonly artifactRefs?: { providerTelemetryPath?: string },
   ) {
     super(message);
     this.name = 'HarborInfraError';
@@ -225,6 +229,8 @@ export function createHarborTaskRunner(options: HarborTaskRunnerOptions): Harbor
     const args = ['run', '--config', configPath, '--yes'];
     let result: HarborRunResult;
     let providerUsage: ProviderTokenUsage | null = null;
+    let providerTelemetry: ProviderRequestTelemetry[] = [];
+    const providerTelemetryPath = join(jobsDir, PROVIDER_REQUEST_TELEMETRY);
     try {
       const providerRuntime = await hostSideProviderRuntime(runnerOptions);
       try {
@@ -238,14 +244,28 @@ export function createHarborTaskRunner(options: HarborTaskRunnerOptions): Harbor
           timeoutMs: resolveHarborTimeoutMs(runnerOptions, input),
           env: { PYTHONPATH: pythonPath, ...(providerRuntime?.env ?? {}) },
         });
-        providerUsage = providerRuntime?.usage?.() ?? null;
       } finally {
         await providerRuntime?.close?.();
+        providerUsage = providerRuntime?.usage?.() ?? null;
+        providerTelemetry = providerRuntime?.telemetry?.() ?? [];
+        if (providerTelemetry.length > 0) {
+          await writeFile(providerTelemetryPath, `${JSON.stringify({
+            schemaVersion: 1,
+            summary: summarizeProviderTelemetry(providerTelemetry),
+            requests: providerTelemetry,
+          }, null, 2)}\n`, 'utf8');
+        }
       }
     } catch (error) {
       if (isBudgetExhaustedError(error)) throw error;
-      throw new HarborInfraError(`harbor run failed to launch for task ${input.task.id}`, errorText(error));
+      throw new HarborInfraError(
+        `harbor run failed to launch for task ${input.task.id}`,
+        errorText(error),
+        'infra_failed',
+        providerTelemetryArtifactRefs(providerTelemetry, providerTelemetryPath),
+      );
     }
+    try {
     if (result.timedOut) {
       throw new HarborInfraError(
         `harbor run timed out for task ${input.task.id}`,
@@ -280,7 +300,9 @@ export function createHarborTaskRunner(options: HarborTaskRunnerOptions): Harbor
         throw new FixedPromptBudgetExhaustedError(
           `agent budget exhausted for task ${input.task.id}`,
           trialException,
-          artifactRefs ?? undefined,
+          artifactRefs || providerTelemetry.length > 0
+            ? { ...(artifactRefs ?? {}), ...(providerTelemetry.length > 0 ? { providerTelemetryPath } : {}) }
+            : undefined,
         );
       }
       completeTimedOutTrial = true;
@@ -318,6 +340,7 @@ export function createHarborTaskRunner(options: HarborTaskRunnerOptions): Harbor
       // controller's reward-hack scan and structural smoke can read raw events.
       cell: {
         ...cell,
+        ...(providerTelemetry.length > 0 ? { providerTelemetryPath } : {}),
         runtimeEventsPath: hostEventsPath,
         traceEventsPath: join(
           trialDir,
@@ -329,8 +352,32 @@ export function createHarborTaskRunner(options: HarborTaskRunnerOptions): Harbor
         ),
       },
     };
+    } catch (error) {
+      throw withProviderTelemetryArtifact(error, providerTelemetry, providerTelemetryPath);
+    }
   };
   return runner;
+}
+
+function providerTelemetryArtifactRefs(
+  telemetry: readonly ProviderRequestTelemetry[],
+  providerTelemetryPath: string,
+): { providerTelemetryPath: string } | undefined {
+  return telemetry.length > 0 ? { providerTelemetryPath } : undefined;
+}
+
+function withProviderTelemetryArtifact(
+  error: unknown,
+  telemetry: readonly ProviderRequestTelemetry[],
+  providerTelemetryPath: string,
+): unknown {
+  const artifactRefs = providerTelemetryArtifactRefs(telemetry, providerTelemetryPath);
+  if (!(error instanceof HarborInfraError) || !artifactRefs || error.artifactRefs?.providerTelemetryPath) {
+    return error;
+  }
+  const enriched = new HarborInfraError(error.message, error.detail, error.kind, artifactRefs);
+  enriched.stack = error.stack;
+  return enriched;
 }
 
 export function createHarborOracleQualifier(options: HarborOracleQualifierOptions): HarborOracleQualifier {
@@ -767,6 +814,7 @@ function verifierPolicy(task: HarborTaskRunInput['task']): {
 async function hostSideProviderRuntime(options: HarborTaskRunnerOptions): Promise<{
   env: Record<string, string>;
   usage?: () => ProviderTokenUsage | null;
+  telemetry?: () => ProviderRequestTelemetry[];
   close?: () => Promise<void>;
 } | null> {
   const provider = options.provider ?? 'deepseek';
@@ -810,6 +858,7 @@ async function hostSideProviderRuntime(options: HarborTaskRunnerOptions): Promis
         MAKA_PROVIDER_PROXY_TOKEN: proxy.token,
       },
       usage: proxy.usage,
+      telemetry: proxy.telemetry,
       close: proxy.close,
     };
   }
@@ -857,7 +906,7 @@ function providerTokenSummary(
     cacheMissInput,
     cacheWriteInput: usage.cacheWrite,
     cacheMissInputSource: 'explicit',
-    reasoning: 0,
+    reasoning: usage.reasoning ?? 0,
     total: usage.input + usage.output,
     costUsd,
     pricingSource: 'runtime',

--- a/packages/headless/src/harbor-task-runner.ts
+++ b/packages/headless/src/harbor-task-runner.ts
@@ -296,7 +296,7 @@ export function createHarborTaskRunner(options: HarborTaskRunnerOptions): Harbor
         readOptionalText(cellOutputPath),
       ]);
       if (rewardArtifact === null || verifierArtifact === null || cellArtifact === null) {
-        const artifactRefs = await readTimedOutTrialArtifacts(trialDir, input.task.id);
+        const artifactRefs = await readTimedOutTrialArtifacts(trialDir, input.task.id, runnerOptions.agent);
         throw new FixedPromptBudgetExhaustedError(
           `agent budget exhausted for task ${input.task.id}`,
           trialException,
@@ -342,14 +342,7 @@ export function createHarborTaskRunner(options: HarborTaskRunnerOptions): Harbor
         ...cell,
         ...(providerTelemetry.length > 0 ? { providerTelemetryPath } : {}),
         runtimeEventsPath: hostEventsPath,
-        traceEventsPath: join(
-          trialDir,
-          TRIAL_TRACE_EVENTS_ROOT,
-          cell.runtimeRefs.sessionId,
-          'runs',
-          cell.runtimeRefs.runId,
-          'events.jsonl',
-        ),
+        traceEventsPath: hostTraceEventsPath(runnerOptions.agent, trialDir, cell, hostEventsPath),
       },
     };
     } catch (error) {
@@ -493,8 +486,14 @@ async function readOptionalCellOutput(cellOutputPath: string, taskId: string): P
   }
 }
 
-function cellArtifactRefs(cell: HarborCellOutput, hostEventsPath: string, trialDir: string) {
-  const traceEventsPath = join(
+function hostTraceEventsPath(
+  agent: HarborTaskRunnerOptions['agent'],
+  trialDir: string,
+  cell: HarborCellOutput,
+  hostEventsPath: string,
+): string {
+  if (agent === 'opencode' || agent === 'kimi-code') return hostEventsPath;
+  return join(
     trialDir,
     TRIAL_TRACE_EVENTS_ROOT,
     cell.runtimeRefs.sessionId,
@@ -502,6 +501,15 @@ function cellArtifactRefs(cell: HarborCellOutput, hostEventsPath: string, trialD
     cell.runtimeRefs.runId,
     'events.jsonl',
   );
+}
+
+function cellArtifactRefs(
+  cell: HarborCellOutput,
+  hostEventsPath: string,
+  trialDir: string,
+  agent: HarborTaskRunnerOptions['agent'],
+) {
+  const traceEventsPath = hostTraceEventsPath(agent, trialDir, cell, hostEventsPath);
   return {
     runtimeEventsPath: hostEventsPath,
     traceEventsPath,
@@ -510,9 +518,13 @@ function cellArtifactRefs(cell: HarborCellOutput, hostEventsPath: string, trialD
   };
 }
 
-async function readTimedOutTrialArtifacts(trialDir: string, taskId: string) {
+async function readTimedOutTrialArtifacts(
+  trialDir: string,
+  taskId: string,
+  agent: HarborTaskRunnerOptions['agent'],
+) {
   const cell = await readOptionalCellOutput(join(trialDir, TRIAL_CELL_OUTPUT), taskId);
-  if (cell) return cellArtifactRefs(cell, join(trialDir, TRIAL_RUNTIME_EVENTS), trialDir);
+  if (cell) return cellArtifactRefs(cell, join(trialDir, TRIAL_RUNTIME_EVENTS), trialDir, agent);
   const [executionIdentity, tokenSummary] = await Promise.all([
     readOptionalExecutionIdentity(join(trialDir, TRIAL_EXECUTION_IDENTITY)),
     readOptionalTokenSummary(join(trialDir, TRIAL_USAGE_CHECKPOINT)),

--- a/packages/headless/src/provider-auth-proxy.ts
+++ b/packages/headless/src/provider-auth-proxy.ts
@@ -7,6 +7,7 @@ export interface ProviderAuthProxy {
   baseUrl: string;
   token: string;
   usage(): ProviderTokenUsage | null;
+  telemetry(): ProviderRequestTelemetry[];
   close(): Promise<void>;
 }
 
@@ -15,6 +16,111 @@ export interface ProviderTokenUsage {
   cacheRead: number;
   cacheWrite: number;
   output: number;
+  /** Present only when the provider reports a reasoning-token breakdown. */
+  reasoning?: number;
+}
+
+export interface ProviderRequestTelemetry {
+  requestId: number;
+  method: string;
+  path: string;
+  protocol?: ProviderUsageProtocol;
+  status?: number;
+  outcome: 'completed' | 'interrupted' | 'failed' | 'aborted';
+  responseHeadersMs?: number;
+  firstBodyChunkMs?: number;
+  firstOutputTokenMs?: number;
+  lastOutputTokenMs?: number;
+  firstReasoningTokenMs?: number;
+  lastReasoningTokenMs?: number;
+  /** First non-reasoning output after reasoning began. */
+  reasoningEndMs?: number;
+  /** Largest observed interval between adjacent upstream body chunks. */
+  maxBodyChunkGapMs?: number;
+  durationMs: number;
+  bodyChunks: number;
+  responseBytes: number;
+  terminalEvent: boolean;
+  usage?: ProviderTokenUsage;
+  errorClass?: string;
+}
+
+export interface ProviderTelemetrySummary {
+  requests: number;
+  completed: number;
+  interrupted: number;
+  failed: number;
+  aborted: number;
+  inputTokens: number;
+  outputTokens: number;
+  reasoningTokens: number | null;
+  usageMeasuredRequests: number;
+  reasoningMeasuredRequests: number;
+  outputTokensPerSecond: number | null;
+  reasoningTokensPerSecond: number | null;
+  maxBodyChunkGapMs: number | null;
+}
+
+export function summarizeProviderTelemetry(
+  requests: readonly ProviderRequestTelemetry[],
+): ProviderTelemetrySummary {
+  let inputTokens = 0;
+  let outputTokens = 0;
+  let reasoningTokens = 0;
+  let usageMeasuredRequests = 0;
+  let reasoningMeasuredRequests = 0;
+  let outputGenerationMs = 0;
+  let outputRateTokens = 0;
+  let reasoningGenerationMs = 0;
+  let reasoningRateTokens = 0;
+  let maxBodyChunkGapMs: number | null = null;
+  for (const request of requests) {
+    if (request.maxBodyChunkGapMs !== undefined) {
+      maxBodyChunkGapMs = Math.max(maxBodyChunkGapMs ?? 0, request.maxBodyChunkGapMs);
+    }
+    if (!request.usage) continue;
+    usageMeasuredRequests += 1;
+    inputTokens += request.usage.input;
+    outputTokens += request.usage.output;
+    if (
+      request.firstOutputTokenMs !== undefined
+      && request.lastOutputTokenMs !== undefined
+      && request.lastOutputTokenMs > request.firstOutputTokenMs
+    ) {
+      outputGenerationMs += request.lastOutputTokenMs - request.firstOutputTokenMs;
+      outputRateTokens += request.usage.output;
+    }
+    if (request.usage.reasoning !== undefined) {
+      reasoningMeasuredRequests += 1;
+      reasoningTokens += request.usage.reasoning;
+      if (
+        request.firstReasoningTokenMs !== undefined
+        && request.lastReasoningTokenMs !== undefined
+        && request.lastReasoningTokenMs > request.firstReasoningTokenMs
+      ) {
+        reasoningGenerationMs += request.lastReasoningTokenMs - request.firstReasoningTokenMs;
+        reasoningRateTokens += request.usage.reasoning;
+      }
+    }
+  }
+  const count = (outcome: ProviderRequestTelemetry['outcome']) => (
+    requests.filter((request) => request.outcome === outcome).length
+  );
+  return {
+    requests: requests.length,
+    completed: count('completed'),
+    interrupted: count('interrupted'),
+    failed: count('failed'),
+    aborted: count('aborted'),
+    inputTokens,
+    outputTokens,
+    reasoningTokens: reasoningMeasuredRequests > 0 ? reasoningTokens : null,
+    usageMeasuredRequests,
+    reasoningMeasuredRequests,
+    outputTokensPerSecond: outputGenerationMs > 0 ? outputRateTokens / (outputGenerationMs / 1_000) : null,
+    reasoningTokensPerSecond: reasoningGenerationMs > 0 ? reasoningRateTokens / (reasoningGenerationMs / 1_000) : null,
+    maxBodyChunkGapMs,
+  };
 }
 
 export type ProviderAuthProxyMode = 'bearer' | 'x-api-key';
@@ -26,6 +132,8 @@ export async function startProviderAuthProxy(input: {
   advertisedHost?: string;
   authMode?: ProviderAuthProxyMode;
   usageProtocol?: ProviderUsageProtocol;
+  /** Injectable monotonic clock for deterministic tests. */
+  now?: () => number;
 }): Promise<ProviderAuthProxy> {
   const upstreamBaseUrl = new URL(input.upstreamBaseUrl);
   if (upstreamBaseUrl.protocol !== 'https:' && upstreamBaseUrl.protocol !== 'http:') {
@@ -36,12 +144,21 @@ export async function startProviderAuthProxy(input: {
   const authMode = input.authMode ?? 'bearer';
   const token = randomBytes(32).toString('hex');
   const usage = new ProviderUsageAccumulator();
+  const telemetry = new ProviderTelemetryAccumulator();
+  const now = input.now ?? performance.now.bind(performance);
   const activeRequests = new Set<AbortController>();
+  const activeForwards = new Set<Promise<void>>();
   const sockets = new Set<Socket>();
   const server = createServer((request, response) => {
     const controller = new AbortController();
+    const abortOnRequest = () => controller.abort();
+    const abortOnResponseClose = () => {
+      if (!response.writableEnded) controller.abort();
+    };
+    request.once('aborted', abortOnRequest);
+    response.once('close', abortOnResponseClose);
     activeRequests.add(controller);
-    void forwardProviderRequest({
+    const forward = forwardProviderRequest({
       request,
       response,
       upstreamBaseUrl,
@@ -50,8 +167,16 @@ export async function startProviderAuthProxy(input: {
       authMode,
       usageProtocol: input.usageProtocol,
       usage,
+      telemetry,
+      now,
       signal: controller.signal,
-    }).finally(() => activeRequests.delete(controller));
+    }).finally(() => {
+      request.off('aborted', abortOnRequest);
+      response.off('close', abortOnResponseClose);
+      activeRequests.delete(controller);
+      activeForwards.delete(forward);
+    });
+    activeForwards.add(forward);
   });
   server.on('connection', (socket) => {
     sockets.add(socket);
@@ -74,13 +199,16 @@ export async function startProviderAuthProxy(input: {
     baseUrl: `http://${advertisedHost}:${address.port}`,
     token,
     usage: () => usage.snapshot(),
+    telemetry: () => telemetry.snapshot(),
     close: async () => {
       const closed = new Promise<void>((resolve, reject) => {
         server.close((error) => error ? reject(error) : resolve());
       });
+      const forwards = [...activeForwards];
       for (const controller of activeRequests) controller.abort();
       for (const socket of sockets) socket.destroy();
       await closed;
+      await Promise.allSettled(forwards);
     },
   };
 }
@@ -94,8 +222,11 @@ async function forwardProviderRequest(input: {
   authMode: ProviderAuthProxyMode;
   usageProtocol?: ProviderUsageProtocol;
   usage: ProviderUsageAccumulator;
+  telemetry: ProviderTelemetryAccumulator;
+  now: () => number;
   signal: AbortSignal;
 }): Promise<void> {
+  let requestTelemetry: MutableProviderRequestTelemetry | null = null;
   try {
     const presentedCredential = input.authMode === 'x-api-key'
       ? input.request.headers['x-api-key']
@@ -104,7 +235,14 @@ async function forwardProviderRequest(input: {
       input.response.writeHead(401).end('unauthorized');
       return;
     }
+    const startedAt = input.now();
     const incomingUrl = new URL(input.request.url ?? '/', 'http://provider-proxy');
+    requestTelemetry = input.telemetry.start({
+      method: input.request.method ?? 'GET',
+      path: incomingUrl.pathname,
+      protocol: input.usageProtocol,
+      startedAt,
+    });
     const upstreamUrl = new URL(input.upstreamBaseUrl);
     upstreamUrl.pathname = `${upstreamUrl.pathname.replace(/\/$/, '')}/${incomingUrl.pathname.replace(/^\//, '')}`;
     upstreamUrl.search = incomingUrl.search;
@@ -125,6 +263,8 @@ async function forwardProviderRequest(input: {
       signal: input.signal,
       ...(body ? { body: new Uint8Array(body) } : {}),
     });
+    requestTelemetry.status = upstreamResponse.status;
+    requestTelemetry.responseHeadersMs = elapsedMs(startedAt, input.now());
     const responseHeaders: Record<string, string> = {};
     upstreamResponse.headers.forEach((value, name) => {
       if (!HOP_BY_HOP_HEADERS.has(name.toLowerCase())) responseHeaders[name] = value;
@@ -137,13 +277,57 @@ async function forwardProviderRequest(input: {
       : null;
     if (upstreamResponse.body) {
       for await (const chunk of upstreamResponse.body) {
-        responseUsage?.push(chunk);
+        const observedAt = input.now();
+        requestTelemetry.bodyChunks += 1;
+        requestTelemetry.responseBytes += chunk.byteLength;
+        requestTelemetry.firstBodyChunkMs ??= elapsedMs(startedAt, observedAt);
+        if (requestTelemetry.lastBodyChunkAt !== undefined) {
+          requestTelemetry.maxBodyChunkGapMs = Math.max(
+            requestTelemetry.maxBodyChunkGapMs ?? 0,
+            elapsedMs(requestTelemetry.lastBodyChunkAt, observedAt),
+          );
+        }
+        requestTelemetry.lastBodyChunkAt = observedAt;
+        const observation = responseUsage?.push(chunk);
+        if (observation?.output) {
+          requestTelemetry.firstOutputTokenMs ??= elapsedMs(startedAt, observedAt);
+          requestTelemetry.lastOutputTokenMs = elapsedMs(startedAt, observedAt);
+        }
+        if (observation?.reasoning) {
+          requestTelemetry.firstReasoningTokenMs ??= elapsedMs(startedAt, observedAt);
+          requestTelemetry.lastReasoningTokenMs = elapsedMs(startedAt, observedAt);
+        }
+        if (
+          observation?.output
+          && !observation.reasoning
+          && requestTelemetry.firstReasoningTokenMs !== undefined
+          && requestTelemetry.reasoningEndMs === undefined
+        ) {
+          requestTelemetry.reasoningEndMs = elapsedMs(startedAt, observedAt);
+        }
         input.response.write(chunk);
       }
     }
-    if (upstreamResponse.ok && responseUsage) input.usage.add(responseUsage.finish());
+    const parsed = responseUsage?.finish() ?? null;
+    if (upstreamResponse.ok && parsed?.usage) input.usage.add(parsed.usage);
+    requestTelemetry.usage = parsed?.usage ?? undefined;
+    requestTelemetry.terminalEvent = parsed?.terminalEvent ?? false;
+    requestTelemetry.outcome = !upstreamResponse.ok
+      ? 'failed'
+      : responseUsage && !parsed?.terminalEvent
+        ? 'interrupted'
+        : 'completed';
+    requestTelemetry.durationMs = elapsedMs(startedAt, input.now());
+    input.telemetry.finish(requestTelemetry);
+    requestTelemetry = null;
     input.response.end();
-  } catch {
+  } catch (error) {
+    if (requestTelemetry) {
+      requestTelemetry.outcome = input.signal.aborted ? 'aborted' : 'failed';
+      requestTelemetry.durationMs = elapsedMs(requestTelemetry.startedAt, input.now());
+      requestTelemetry.errorClass = error instanceof Error ? error.name : 'UnknownError';
+      input.telemetry.finish(requestTelemetry);
+    }
     if (input.response.destroyed) return;
     if (!input.response.headersSent) input.response.writeHead(502);
     input.response.end('provider proxy request failed');
@@ -153,6 +337,7 @@ async function forwardProviderRequest(input: {
 class ProviderUsageAccumulator {
   private readonly total: ProviderTokenUsage = { input: 0, cacheRead: 0, cacheWrite: 0, output: 0 };
   private sawUsage = false;
+  private sawReasoning = false;
 
   add(usage: ProviderTokenUsage | null): void {
     if (!usage) return;
@@ -161,10 +346,58 @@ class ProviderUsageAccumulator {
     this.total.cacheRead += usage.cacheRead;
     this.total.cacheWrite += usage.cacheWrite;
     this.total.output += usage.output;
+    if (usage.reasoning !== undefined) {
+      this.sawReasoning = true;
+      this.total.reasoning = (this.total.reasoning ?? 0) + usage.reasoning;
+    }
   }
 
   snapshot(): ProviderTokenUsage | null {
-    return this.sawUsage ? { ...this.total } : null;
+    if (!this.sawUsage) return null;
+    const snapshot = { ...this.total };
+    if (!this.sawReasoning) delete snapshot.reasoning;
+    return snapshot;
+  }
+}
+
+interface MutableProviderRequestTelemetry extends ProviderRequestTelemetry {
+  startedAt: number;
+  lastBodyChunkAt?: number;
+}
+
+class ProviderTelemetryAccumulator {
+  private nextRequestId = 1;
+  private readonly requests: ProviderRequestTelemetry[] = [];
+
+  start(input: Pick<MutableProviderRequestTelemetry, 'method' | 'path' | 'protocol' | 'startedAt'>): MutableProviderRequestTelemetry {
+    return {
+      requestId: this.nextRequestId++,
+      method: input.method,
+      path: input.path,
+      ...(input.protocol ? { protocol: input.protocol } : {}),
+      startedAt: input.startedAt,
+      outcome: 'failed',
+      durationMs: 0,
+      bodyChunks: 0,
+      responseBytes: 0,
+      terminalEvent: false,
+    };
+  }
+
+  finish(request: MutableProviderRequestTelemetry): void {
+    const {
+      startedAt: _startedAt,
+      lastBodyChunkAt: _lastBodyChunkAt,
+      ...snapshot
+    } = request;
+    this.requests.push(snapshot);
+  }
+
+  snapshot(): ProviderRequestTelemetry[] {
+    return this.requests.map((request) => ({
+      ...request,
+      ...(request.usage ? { usage: { ...request.usage } } : {}),
+    }));
   }
 }
 
@@ -173,27 +406,36 @@ class SseUsageParser {
   private buffer = '';
   private readonly usage: ProviderTokenUsage = { input: 0, cacheRead: 0, cacheWrite: 0, output: 0 };
   private sawUsage = false;
+  private terminalEvent = false;
 
   constructor(private readonly protocol: ProviderUsageProtocol) {}
 
-  push(chunk: Uint8Array): void {
+  push(chunk: Uint8Array): SseChunkObservation {
     this.buffer += this.decoder.decode(chunk, { stream: true });
-    this.consumeCompleteLines();
+    return this.consumeCompleteLines();
   }
 
-  finish(): ProviderTokenUsage | null {
+  finish(): { usage: ProviderTokenUsage | null; terminalEvent: boolean } {
     this.buffer += this.decoder.decode();
     this.consumeCompleteLines(true);
-    return this.sawUsage ? { ...this.usage } : null;
+    return {
+      usage: this.sawUsage ? { ...this.usage } : null,
+      terminalEvent: this.terminalEvent,
+    };
   }
 
-  private consumeCompleteLines(flush = false): void {
+  private consumeCompleteLines(flush = false): SseChunkObservation {
+    const observation: SseChunkObservation = { output: false, reasoning: false };
     const lines = this.buffer.split(/\r?\n/);
     this.buffer = flush ? '' : lines.pop() ?? '';
     for (const line of lines) {
       if (!line.startsWith('data:')) continue;
       const raw = line.slice('data:'.length).trim();
-      if (!raw || raw === '[DONE]') continue;
+      if (!raw) continue;
+      if (raw === '[DONE]') {
+        if (this.protocol === 'openai-chat-sse') this.terminalEvent = true;
+        continue;
+      }
       let event: unknown;
       try {
         event = JSON.parse(raw);
@@ -201,6 +443,10 @@ class SseUsageParser {
         continue;
       }
       if (!isRecord(event)) continue;
+      if (this.protocol === 'anthropic-sse' && event.type === 'message_stop') this.terminalEvent = true;
+      const generated = generatedDelta(this.protocol, event);
+      observation.output ||= generated.output;
+      observation.reasoning ||= generated.reasoning;
       const usage = this.protocol === 'anthropic-sse'
         ? anthropicUsage(event)
         : openAiChatUsage(event);
@@ -210,8 +456,45 @@ class SseUsageParser {
       this.usage.cacheRead = Math.max(this.usage.cacheRead, usage.cacheRead);
       this.usage.cacheWrite = Math.max(this.usage.cacheWrite, usage.cacheWrite);
       this.usage.output = Math.max(this.usage.output, usage.output);
+      if (usage.reasoning !== undefined) {
+        this.usage.reasoning = Math.max(this.usage.reasoning ?? 0, usage.reasoning);
+      }
     }
+    return observation;
   }
+}
+
+interface SseChunkObservation {
+  output: boolean;
+  reasoning: boolean;
+}
+
+function generatedDelta(protocol: ProviderUsageProtocol, event: Record<string, unknown>): SseChunkObservation {
+  if (protocol === 'anthropic-sse') {
+    const delta = isRecord(event.delta) ? event.delta : null;
+    const reasoning = delta?.type === 'thinking_delta'
+      && typeof delta.thinking === 'string'
+      && delta.thinking.length > 0;
+    const output = reasoning
+      || (delta?.type === 'text_delta' && typeof delta.text === 'string' && delta.text.length > 0)
+      || (delta?.type === 'input_json_delta' && typeof delta.partial_json === 'string' && delta.partial_json.length > 0);
+    return { output, reasoning };
+  }
+  const choices = Array.isArray(event.choices) ? event.choices : [];
+  let output = false;
+  let reasoning = false;
+  for (const choice of choices) {
+    if (!isRecord(choice) || !isRecord(choice.delta)) continue;
+    const delta = choice.delta;
+    const hasReasoning = (typeof delta.reasoning_content === 'string' && delta.reasoning_content.length > 0)
+      || (typeof delta.reasoning === 'string' && delta.reasoning.length > 0);
+    reasoning ||= hasReasoning;
+    output ||= hasReasoning
+      || (typeof delta.content === 'string' && delta.content.length > 0)
+      || (Array.isArray(delta.tool_calls) && delta.tool_calls.length > 0)
+      || isRecord(delta.function_call);
+  }
+  return { output, reasoning };
 }
 
 function anthropicUsage(event: Record<string, unknown>): ProviderTokenUsage | null {
@@ -239,12 +522,22 @@ function anthropicUsage(event: Record<string, unknown>): ProviderTokenUsage | nu
 function openAiChatUsage(event: Record<string, unknown>): ProviderTokenUsage | null {
   if (!isRecord(event.usage) || !hasAnyNumber(event.usage, ['prompt_tokens', 'completion_tokens'])) return null;
   const details = isRecord(event.usage.prompt_tokens_details) ? event.usage.prompt_tokens_details : null;
+  const completionDetails = isRecord(event.usage.completion_tokens_details)
+    ? event.usage.completion_tokens_details
+    : null;
   return {
     input: nonNegativeNumber(event.usage.prompt_tokens),
     cacheRead: nonNegativeNumber(details?.cached_tokens),
     cacheWrite: 0,
     output: nonNegativeNumber(event.usage.completion_tokens),
+    ...(hasAnyNumber(completionDetails ?? {}, ['reasoning_tokens'])
+      ? { reasoning: nonNegativeNumber(completionDetails?.reasoning_tokens) }
+      : {}),
   };
+}
+
+function elapsedMs(startedAt: number, finishedAt: number): number {
+  return Math.max(0, finishedAt - startedAt);
 }
 
 function hasAnyNumber(record: Record<string, unknown>, keys: readonly string[]): boolean {


### PR DESCRIPTION
## Summary

Capture provider-stream timing, token, interruption, and terminal metadata at the existing host auth proxy; persist one redaction-safe telemetry artifact per Harbor cell; and carry that artifact path through fixed-prompt WAL and infrastructure evidence.

External OpenCode and Kimi Code cells now point `traceEventsPath` at their actual runtime event stream instead of a nonexistent Maka storage path. This PR observes and preserves evidence only: it does not override Harbor's authoritative task outcome or classify provider failures from telemetry.

## Verification

- `npm --workspace @maka/headless test` — 1,112 passed, 0 failed.
- Focused provider proxy, Harbor runner, and fixed-prompt controller tests — 138 passed, 0 failed.
- Revert `fix(headless): expose external agent trace evidence` while retaining telemetry — build and 137 focused tests passed.
- Revert `feat(headless): capture durable provider stream telemetry` while retaining trace evidence — build and 132 focused tests passed.
- `git diff --check origin/main...HEAD` — passed.

## Review focus

The branch contains two independently revertible commits: durable provider telemetry and external-agent trace evidence. It is based on the Harbor lifecycle behavior merged in #1210, including artifact-first recovery after nonzero timeout exits.

The formal Terminal-Bench 2.1 A/B result remains separate in the docs-only report PR.
