### PR TITLE
fix(runtime): bound Anthropic-compatible output limits

### DIFF
--- a/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
+++ b/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
@@ -114,6 +114,151 @@ describe('AiSdkBackend model history', () => {
     assert.equal(model.doStreamCalls[0]?.maxOutputTokens, 131_072);
   });
 
+  test('prefers the connection-advertised Kimi output limit over catalog metadata', async () => {
+    const model = completionModel();
+    const backend = new AiSdkBackend({
+      sessionId: 'session-1',
+      header: header(),
+      appendMessage: async () => {},
+      connection: {
+        slug: 'kimi-coding-plan',
+        name: 'Kimi Coding Plan',
+        providerType: 'kimi-coding-plan',
+        defaultModel: 'k3',
+        models: [{ id: 'k3', maxOutputTokens: 65_536 }],
+        enabled: true,
+        createdAt: 1,
+        updatedAt: 1,
+      },
+      apiKey: 'sk-test',
+      modelId: 'k3',
+      permissionEngine: new PermissionEngine({ newId: () => 'permission-id', now: () => 1 }),
+      modelFactory: () => model,
+      tools: [],
+      newId: idGenerator(),
+      now: monotonicClock(),
+    });
+
+    await drain(backend.send({
+      turnId: 'turn-current',
+      text: 'current user',
+      context: [],
+    }));
+
+    assert.equal(model.doStreamCalls[0]?.maxOutputTokens, 65_536);
+  });
+
+  test('honors a Copilot account output limit on its Anthropic messages wire', async () => {
+    const model = completionModel();
+    const backend = new AiSdkBackend({
+      sessionId: 'session-1',
+      header: header(),
+      appendMessage: async () => {},
+      connection: {
+        slug: 'github-copilot',
+        name: 'GitHub Copilot',
+        providerType: 'github-copilot',
+        defaultModel: 'future-claude-model',
+        models: [{
+          id: 'future-claude-model',
+          apiProtocol: 'anthropic-messages',
+          maxOutputTokens: 128_000,
+        }],
+        enabled: true,
+        createdAt: 1,
+        updatedAt: 1,
+      },
+      apiKey: 'github-account-token',
+      modelId: 'future-claude-model',
+      permissionEngine: new PermissionEngine({ newId: () => 'permission-id', now: () => 1 }),
+      modelFactory: () => model,
+      tools: [],
+      newId: idGenerator(),
+      now: monotonicClock(),
+    });
+
+    await drain(backend.send({
+      turnId: 'turn-current',
+      text: 'current user',
+      context: [],
+    }));
+
+    assert.equal(model.doStreamCalls[0]?.maxOutputTokens, 128_000);
+  });
+
+  test('reserves Kimi fixed thinking inside the provider wire output limit', async () => {
+    const model = completionModel();
+    const backend = new AiSdkBackend({
+      sessionId: 'session-1',
+      header: header(),
+      appendMessage: async () => {},
+      connection: {
+        slug: 'kimi-coding-plan',
+        name: 'Kimi Coding Plan',
+        providerType: 'kimi-coding-plan',
+        defaultModel: 'kimi-for-coding',
+        enabled: true,
+        createdAt: 1,
+        updatedAt: 1,
+      },
+      apiKey: 'sk-test',
+      modelId: 'kimi-for-coding',
+      providerOptions: {
+        anthropic: {
+          thinking: { type: 'enabled', budgetTokens: 1_024 },
+          effort: 'max',
+        },
+      },
+      permissionEngine: new PermissionEngine({ newId: () => 'permission-id', now: () => 1 }),
+      modelFactory: () => model,
+      tools: [],
+      newId: idGenerator(),
+      now: monotonicClock(),
+    });
+
+    await drain(backend.send({
+      turnId: 'turn-current',
+      text: 'current user',
+      context: [],
+    }));
+
+    // Anthropic's adapter adds budgetTokens to maxOutputTokens on the wire.
+    assert.equal(model.doStreamCalls[0]?.maxOutputTokens, 32_768 - 1_024);
+  });
+
+  test('leaves OpenAI-compatible output limits to their provider adapter', async () => {
+    const model = completionModel();
+    const backend = new AiSdkBackend({
+      sessionId: 'session-1',
+      header: header(),
+      appendMessage: async () => {},
+      connection: {
+        slug: 'mistral',
+        name: 'Mistral',
+        providerType: 'mistral',
+        defaultModel: 'mistral-large-latest',
+        enabled: true,
+        createdAt: 1,
+        updatedAt: 1,
+      },
+      apiKey: 'sk-test',
+      modelId: 'mistral-large-latest',
+      permissionEngine: new PermissionEngine({ newId: () => 'permission-id', now: () => 1 }),
+      modelFactory: () => model,
+      tools: [],
+      newId: idGenerator(),
+      now: monotonicClock(),
+    });
+
+    await drain(backend.send({
+      turnId: 'turn-current',
+      text: 'current user',
+      context: [],
+    }));
+
+    assert.equal(model.doStreamCalls[0]?.maxOutputTokens, undefined);
+  });
+
   test('prefers RuntimeEvent prior messages and appends current user once', async () => {
     const model = completionModel();
     const backend = new AiSdkBackend({

--- a/packages/runtime/src/__tests__/computer-use-provider-protocol.test.ts
+++ b/packages/runtime/src/__tests__/computer-use-provider-protocol.test.ts
@@ -30,7 +30,10 @@ describe('Anthropic-compatible Computer Use product loops', () => {
       baseSuffix: '/coding',
       expectedPath: '/coding/v1/messages',
       auth: 'x-api-key',
+      expectedAuth: 'test-key',
       expectedThinking: 'enabled',
+      expectedWireOutputLimit: 32_768,
+      apiProtocol: undefined,
     },
     {
       providerType: 'kimi-coding-plan',
@@ -38,7 +41,10 @@ describe('Anthropic-compatible Computer Use product loops', () => {
       baseSuffix: '/coding',
       expectedPath: '/coding/v1/messages',
       auth: 'x-api-key',
+      expectedAuth: 'test-key',
       expectedThinking: 'adaptive',
+      expectedWireOutputLimit: 131_072,
+      apiProtocol: undefined,
     },
     {
       providerType: 'minimax-coding-plan',
@@ -46,7 +52,21 @@ describe('Anthropic-compatible Computer Use product loops', () => {
       baseSuffix: '/anthropic',
       expectedPath: '/anthropic/v1/messages',
       auth: 'x-api-key',
+      expectedAuth: 'test-key',
       expectedThinking: undefined,
+      expectedWireOutputLimit: 128_000,
+      apiProtocol: undefined,
+    },
+    {
+      providerType: 'github-copilot',
+      modelId: 'future-claude-model',
+      baseSuffix: '/copilot',
+      expectedPath: '/copilot/v1/messages',
+      auth: 'authorization',
+      expectedAuth: 'Bearer test-key',
+      expectedThinking: undefined,
+      expectedWireOutputLimit: 128_000,
+      apiProtocol: 'anthropic-messages',
     },
   ] as const) {
     test(`${provider.providerType}/${provider.modelId} completes a multi-step semantic model loop`, async () => {
@@ -54,7 +74,7 @@ describe('Anthropic-compatible Computer Use product loops', () => {
       const server = await startJsonServer(async (request, response) => {
         assert.equal(request.method, 'POST');
         assert.equal(request.url, provider.expectedPath);
-        assert.equal(request.headers[provider.auth], 'test-key');
+        assert.equal(request.headers[provider.auth], provider.expectedAuth);
         const body = JSON.parse(await readBody(request)) as Record<string, unknown>;
         assert.equal(body.model, provider.modelId);
         requestBodies.push(body);
@@ -88,6 +108,8 @@ describe('Anthropic-compatible Computer Use product loops', () => {
         provider.providerType,
         `${server.url}${provider.baseSuffix}`,
         provider.modelId,
+        provider.apiProtocol,
+        provider.expectedWireOutputLimit,
       );
       const runtime = new AiSdkBackend({
         sessionId: `session-${provider.providerType}`,
@@ -149,6 +171,13 @@ describe('Anthropic-compatible Computer Use product loops', () => {
           assert.deepEqual(body.output_config, { effort: 'max' });
         }
       }
+      for (const body of requestBodies) {
+        assert.equal(
+          body.max_tokens,
+          provider.expectedWireOutputLimit,
+          'Anthropic-compatible requests must honor their model wire output limit',
+        );
+      }
       assert.ok(
         containsToolResult(requestBodies[3]?.messages, 'toolu-3'),
         'final semantic tool result must be reinjected into the closing provider request',
@@ -168,7 +197,7 @@ describe('Anthropic-compatible Computer Use product loops', () => {
       const server = await startJsonServer(async (request, response) => {
         assert.equal(request.method, 'POST');
         assert.equal(request.url, provider.expectedPath);
-        assert.equal(request.headers[provider.auth], 'test-key');
+        assert.equal(request.headers[provider.auth], provider.expectedAuth);
         const body = JSON.parse(await readBody(request)) as Record<string, unknown>;
         assert.equal(body.model, provider.modelId);
         requestBodies.push(body);
@@ -203,6 +232,8 @@ describe('Anthropic-compatible Computer Use product loops', () => {
           provider.providerType,
           `${server.url}${provider.baseSuffix}`,
           provider.modelId,
+          provider.apiProtocol,
+          provider.expectedWireOutputLimit,
         ),
         apiKey: 'test-key',
         modelId: provider.modelId,
@@ -489,6 +520,8 @@ function connection(
   providerType: LlmConnection['providerType'],
   baseUrl: string,
   model: string,
+  apiProtocol?: 'anthropic-messages',
+  maxOutputTokens?: number,
 ): LlmConnection {
   return {
     slug: providerType,
@@ -496,6 +529,7 @@ function connection(
     providerType,
     baseUrl,
     defaultModel: model,
+    ...(apiProtocol ? { models: [{ id: model, apiProtocol, maxOutputTokens }] } : {}),
     enabled: true,
     createdAt: 1,
     updatedAt: 1,

--- a/packages/runtime/src/model-adapter.ts
+++ b/packages/runtime/src/model-adapter.ts
@@ -181,7 +181,11 @@ export class ModelAdapter {
     };
 
     const maxSteps = input.maxSteps ?? this.input.maxSteps;
-    const maxOutputTokens = selectedModelMaxOutputTokens(this.input.connection, this.input.modelId);
+    const maxOutputTokens = selectedModelMaxOutputTokens(
+      this.input.connection,
+      this.input.modelId,
+      this.input.providerOptions,
+    );
     const configuredStop = maxSteps === undefined
       ? isLoopFinished()
       : isStepCount(maxSteps);
@@ -350,9 +354,29 @@ export class ModelAdapter {
   }
 }
 
-function selectedModelMaxOutputTokens(connection: LlmConnection, modelId: string): number | undefined {
-  return connection.models?.find((model) => model.id === modelId)?.maxOutputTokens
+function selectedModelMaxOutputTokens(
+  connection: LlmConnection,
+  modelId: string,
+  providerOptions: Record<string, unknown> | undefined,
+): number | undefined {
+  const { adapter, apiProtocol } = resolveModelRuntime(connection, modelId);
+  const usesAnthropicMessages = adapter.kind === 'anthropic'
+    || adapter.kind === 'claude-subscription'
+    || (adapter.kind === 'github-copilot' && apiProtocol === 'anthropic-messages');
+  if (!usesAnthropicMessages) return undefined;
+  const wireOutputLimit = connection.models?.find((model) => model.id === modelId)?.maxOutputTokens
     ?? lookupModelMetadata(connection.providerType, modelId).maxOutputTokens;
+  if (wireOutputLimit === undefined) return undefined;
+  return wireOutputLimit - fixedAnthropicThinkingBudget(providerOptions);
+}
+
+function fixedAnthropicThinkingBudget(providerOptions: Record<string, unknown> | undefined): number {
+  const anthropic = providerOptions?.anthropic;
+  if (!anthropic || typeof anthropic !== 'object' || Array.isArray(anthropic)) return 0;
+  const thinking = (anthropic as { thinking?: unknown }).thinking;
+  if (!thinking || typeof thinking !== 'object' || Array.isArray(thinking)) return 0;
+  const { type, budgetTokens } = thinking as { type?: unknown; budgetTokens?: unknown };
+  return type === 'enabled' && typeof budgetTokens === 'number' ? budgetTokens : 0;
 }
 
 export interface ModelAdapterRuntimeEventReplaySupport {

--- a/packages/runtime/src/model-factory.ts
+++ b/packages/runtime/src/model-factory.ts
@@ -33,7 +33,7 @@ const ANTHROPIC_BETA =
   'interleaved-thinking-2025-05-14,fine-grained-tool-streaming-2025-05-14';
 export function getAIModel(input: ModelFactoryInput): LanguageModelV4 {
   const { connection, apiKey, modelId, fetch } = input;
-  const { adapter, baseUrl: baseURL } = resolveModelRuntime(connection, modelId);
+  const { adapter, baseUrl: baseURL, apiProtocol } = resolveModelRuntime(connection, modelId);
 
   if (adapter.kind === 'google' && adapter.normalizeBaseUrl === false) {
     return createGoogle({ apiKey, baseURL }).chat(modelId);
@@ -64,7 +64,6 @@ export function getAIModel(input: ModelFactoryInput): LanguageModelV4 {
       }).responses(modelId);
 
     case 'github-copilot': {
-      const apiProtocol = connection.models?.find((model) => model.id === modelId)?.apiProtocol;
       if (apiProtocol === 'openai-responses') {
         return createOpenAI({ apiKey, baseURL, fetch }).responses(modelId);
       }

--- a/packages/runtime/src/model-runtime.ts
+++ b/packages/runtime/src/model-runtime.ts
@@ -2,6 +2,7 @@ import {
   PROVIDER_DEFAULTS,
   effectiveBaseUrl,
   type LlmConnection,
+  type ModelInfo,
   type ProviderRuntimeAdapter,
 } from '@maka/core/llm-connections';
 import { lookupModelProviderOverride } from '@maka/core/model-metadata';
@@ -9,6 +10,8 @@ import { lookupModelProviderOverride } from '@maka/core/model-metadata';
 export interface ResolvedModelRuntime {
   adapter: ProviderRuntimeAdapter;
   baseUrl: string;
+  /** Account-advertised request wire for adapters that route per model. */
+  apiProtocol?: ModelInfo['apiProtocol'];
 }
 
 export function resolveModelRuntime(connection: LlmConnection, modelId: string): ResolvedModelRuntime {
@@ -22,11 +25,13 @@ export function resolveModelRuntime(connection: LlmConnection, modelId: string):
   }
   const adapter = override ? runtimeAdapterOverride(override.npm) : defaults.runtimeAdapter;
   const configuredBaseUrl = connection.baseUrl?.trim();
+  const apiProtocol = connection.models?.find((model) => model.id === modelId)?.apiProtocol;
   return {
     adapter,
     baseUrl: configuredBaseUrl
       ? effectiveBaseUrl(connection)
       : override?.api ?? effectiveBaseUrl(connection),
+    ...(apiProtocol ? { apiProtocol } : {}),
   };
 }
 


### PR DESCRIPTION
## Summary

- scope catalog-derived output limits to requests that actually use Anthropic Messages, where SDK-unknown models otherwise fall back to `max_tokens: 4096`
- keep per-model GitHub Copilot routing and output-limit selection on the same account-advertised protocol fact
- reserve fixed Anthropic thinking tokens inside each model's advertised wire output limit, so `kimi-for-coding` sends `max_tokens: 32768` instead of `33792`
- leave OpenAI-compatible adapters such as Mistral on their provider-owned defaults, while preserving connection-advertised limits over catalog metadata

This is a focused follow-up to #1209. Applying catalog maximums to every provider caused models such as `mistral-large-latest`, whose advertised output maximum equals its full context window, to receive an unsafe per-request generation limit. Gating at the final request protocol keeps the explicit limit where the Anthropic SDK requires one, including Kimi K3, SDK-unknown MiniMax models, and account-routed GitHub Copilot Anthropic models.

## Verification

- `npm run build && node --test dist/__tests__/ai-sdk-backend.test.js dist/__tests__/computer-use-provider-protocol.test.js dist/__tests__/model-factory-thinking.test.js` — 197 passed, 0 failed
- `npm test` in `packages/runtime` — 2149 passed, 7 skipped, 0 failed
- scripted HTTP coverage confirms K3 sends `max_tokens: 131072`, `kimi-for-coding` sends `max_tokens: 32768` after the SDK accounts for its 1024-token fixed thinking budget, MiniMax-M3 preserves `max_tokens: 128000`, and an SDK-unknown GitHub Copilot Anthropic model honors its account-advertised `max_tokens: 128000`
