### PR TITLE
fix(runtime): preserve provider errors through retries

### DIFF
--- a/packages/runtime/src/__tests__/model-adapter.test.ts
+++ b/packages/runtime/src/__tests__/model-adapter.test.ts
@@ -1,6 +1,7 @@
 import assert from 'node:assert/strict';
 import { describe, test } from 'node:test';
 import type { SessionEvent } from '@maka/core/events';
+import { RetryError } from 'ai';
 
 import { AsyncEventQueue } from '../async-queue.js';
 import { ModelAdapter, normalizeAiSdkUsage, type AiSdkStreamChunk } from '../model-adapter.js';
@@ -225,6 +226,24 @@ describe('ModelAdapter stream and error normalization', () => {
     assert.equal(adapter.mapFinishReason('error'), 'error');
     assert.equal(adapter.mapFinishReason('tool-calls'), 'end_turn');
     assert.equal(adapter.mapFinishReason('provider-new-reason'), 'end_turn');
+  });
+
+  test('projects the final provider error inside an AI SDK retry wrapper', () => {
+    const inner = Object.assign(new Error('Service unavailable: token=provider-secret'), {
+      name: 'AI_APICallError',
+      statusCode: 503,
+    });
+    const wrapped = new RetryError({
+      message: 'Provider request failed after retries',
+      reason: 'maxRetriesExceeded',
+      errors: [inner, inner, inner],
+    });
+
+    const event = newAdapter().makeErrorEvent('turn-1', wrapped);
+
+    assert.equal(event.reason, 'provider_unavailable');
+    assert.equal(event.message, 'Provider returned an error');
+    assert.equal(JSON.stringify(event).includes('provider-secret'), false);
   });
 
   test('projects a structured network error to a consistent reason and safe message', () => {

--- a/packages/runtime/src/__tests__/provider-error-classification.test.ts
+++ b/packages/runtime/src/__tests__/provider-error-classification.test.ts
@@ -1,6 +1,7 @@
 import assert from 'node:assert/strict';
 import { describe, test } from 'node:test';
 import { createJsonErrorResponseHandler } from '@ai-sdk/provider-utils';
+import { RetryError } from 'ai';
 import { z } from 'zod/v4';
 
 import { classifyError, errorPresentationFromClass } from '../provider-error-classification.js';
@@ -423,6 +424,66 @@ describe('Provider error classification', () => {
       '{"error":"Too many completion tokens were requested. This endpoint\'s maximum context length is 262144 tokens."}',
     );
     assert.notEqual(classifyError(outputCapError), 'ContextLength');
+  });
+
+  test('preserves provider evidence through the official AI SDK retry wrapper', async () => {
+    const handler = createJsonErrorResponseHandler({
+      errorSchema: z.object({
+        error: z.object({
+          message: z.string(),
+          code: z.string().optional(),
+        }),
+      }),
+      errorToMessage: (data) => data.error.message,
+    });
+    const apiCallError = async (status: number, body: string) =>
+      (
+        await handler({
+          response: new Response(body, { status, statusText: `HTTP ${status}` }),
+          url: 'https://api.example.test/v1/chat/completions',
+          requestBodyValues: {},
+        })
+      ).value;
+    const retried = (
+      lastError: unknown,
+      reason: 'maxRetriesExceeded' | 'errorNotRetryable' = 'maxRetriesExceeded',
+    ) =>
+      new RetryError({
+        message: 'Provider request failed after retries',
+        reason,
+        errors: [lastError, lastError, lastError],
+      });
+
+    const rateLimit = await apiCallError(429, '{"error":{"message":"Too many requests"}}');
+    const unavailable = await apiCallError(503, '{"error":{"message":"Service unavailable"}}');
+    const overflow = await apiCallError(
+      503,
+      '{"error":{"message":"Service unavailable","code":"context_length_exceeded"}}',
+    );
+
+    assert.equal(classifyError(retried(rateLimit)), 'RateLimit');
+    assert.equal(classifyError(retried(unavailable)), 'ProviderUnavailable');
+    assert.equal(classifyError(retried(overflow, 'errorNotRetryable')), 'ContextLength');
+
+    const aborted = new RetryError({
+      message: 'Retry stopped',
+      reason: 'abort',
+      errors: [new Error('transport stopped')],
+    });
+    assert.equal(classifyError(aborted), 'Abort');
+
+    const empty = new RetryError({
+      message: 'Provider request failed after retries',
+      reason: 'maxRetriesExceeded',
+      errors: [],
+    });
+    assert.equal(classifyError(empty), 'AI_RetryError');
+
+    const spoofed = Object.assign(new Error('Provider request failed after retries'), {
+      name: 'AI_RetryError',
+      lastError: rateLimit,
+    });
+    assert.equal(classifyError(spoofed), 'AI_RetryError');
   });
 
   test('maps provider classes to stable user-safe presentations', () => {

--- a/packages/runtime/src/provider-error-classification.ts
+++ b/packages/runtime/src/provider-error-classification.ts
@@ -1,3 +1,5 @@
+import { RetryError } from 'ai';
+
 /**
  * Structured provider error identifiers that mean the INPUT exceeded the
  * model's context window. These come from the provider's error JSON and are
@@ -218,7 +220,12 @@ export function isContextOverflowErrorText(text: string): boolean {
  * rank last so "generate" can never become a rate limit.
  */
 export function classifyError(error: unknown): string {
-  const evidence = normalizeErrorEvidence(error);
+  if (RetryError.isInstance(error) && error.reason === 'abort') return 'Abort';
+  const classificationTarget =
+    RetryError.isInstance(error) && error.lastError !== undefined && error.lastError !== error
+      ? error.lastError
+      : error;
+  const evidence = normalizeErrorEvidence(classificationTarget);
   if (!evidence) return 'Other';
   const { text, statusCode, code, structuredCodes } = evidence;
   if (text.includes('abort')) return 'Abort';
@@ -246,7 +253,7 @@ export function classifyError(error: unknown): string {
     /\btypeerror\b.*\bterminated\b/.test(text)
   )
     return 'Network';
-  return error instanceof Error ? error.name || 'Other' : 'Other';
+  return classificationTarget instanceof Error ? classificationTarget.name || 'Other' : 'Other';
 }
 
 export function errorPresentationFromClass(errorClass: string): {


### PR DESCRIPTION
## Summary

- unwrap official AI SDK `RetryError` instances before provider error classification
- preserve abort handling and fail closed for malformed or spoofed retry wrappers
- cover rate limits, provider outages, context overflow, and ModelAdapter projection

## Context

This is Part 1 of #1216 and is intentionally stacked on #1214 (`xurui/issue-1084-provider-error-classification`) so the retry-wrapper fix remains independently reviewable. It does not change retry policy or user-facing presentation.

## Verification

- TDD red phase: focused compiled tests failed in the two expected places before implementation
- focused compiled tests: 23 passed, 0 failed
- `npm --workspace @maka/runtime run typecheck`
- `npm --workspace @maka/runtime test`: 2,147 passed, 7 skipped, 0 failed
- `npm run lint`
- `git diff --check`

Refs #1216
