### PR TITLE
fix(desktop): present provider failures from event reasons

### DIFF
--- a/apps/desktop/src/main/__tests__/conversation-presentation-localization.test.ts
+++ b/apps/desktop/src/main/__tests__/conversation-presentation-localization.test.ts
@@ -36,6 +36,53 @@ describe('desktop conversation presentation localization', () => {
     assert.doesNotMatch(message, /数据库/);
   });
 
+  it('presents stable provider reasons consistently in Chinese and English', () => {
+    const cases = [
+      ['context_overflow', '上下文窗口已超出限制', 'Context window exceeded'],
+      ['timeout', '请求超时', 'Request timed out'],
+      ['auth', '鉴权失败', 'Authentication failed'],
+      ['provider_billing', '模型服务计费受限', 'Provider billing required'],
+      ['provider_unavailable', '模型服务返回错误', 'Model service error'],
+      ['rate_limit', '触发模型速率限制', 'Model rate limit reached'],
+      ['network', '网络错误', 'Network error'],
+    ] as const;
+
+    for (const [reason, zh, en] of cases) {
+      const event = {
+        id: `error-${reason}`,
+        turnId: 'turn-1',
+        ts: 1,
+        type: 'error' as const,
+        recoverable: false,
+        reason,
+        message: 'safe runtime projection',
+      };
+      assert.equal(sessionEventErrorMessage(event, 'zh'), zh);
+      assert.equal(sessionEventErrorMessage(event, 'en'), en);
+      assert.equal(describeTurnErrorClass(reason, 'zh'), zh);
+      assert.equal(describeTurnErrorClass(reason, 'en'), en);
+    }
+  });
+
+  it('keeps unknown event reasons and secret-bearing messages safely generalized', () => {
+    const event = {
+      id: 'error-future-provider',
+      turnId: 'turn-1',
+      ts: 1,
+      type: 'error' as const,
+      recoverable: false,
+      reason: 'future_provider_failure',
+      message: 'Provider failed with token=provider-secret',
+    };
+
+    assert.equal(sessionEventErrorMessage(event, 'zh'), '对话运行失败，请稍后重试。');
+    assert.equal(sessionEventErrorMessage(event, 'en'), 'The conversation run failed. Try again later.');
+    assert.equal(JSON.stringify([
+      sessionEventErrorMessage(event, 'zh'),
+      sessionEventErrorMessage(event, 'en'),
+    ]).includes('provider-secret'), false);
+  });
+
   it('localizes status, recovery, footer, and lineage helpers', () => {
     assert.equal(sessionStatusAriaLabel('running', undefined, 'en'), 'Running');
     assert.equal(sessionStatusAriaLabel('blocked', 'auth', 'en'), 'Needs attention · Sign in again');

--- a/apps/desktop/src/main/__tests__/notifications-wiring-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/notifications-wiring-contract.test.ts
@@ -36,8 +36,8 @@ describe('run-complete notification renderer wiring contract', () => {
     // The error path fires the error notification.
     assert.match(
       source,
-      /notifyRunEnded\?\.\(\{ kind: 'errored'/,
-      'the error event must fire an errored notification',
+      /notifyRunEnded\?\.\(\{ kind: 'errored', sessionId, body: sessionEventErrorMessage\(event, uiLocale\) \}\)/,
+      'the error notification must use the same safe, reason-aware presentation as the toast',
     );
   });
 

--- a/apps/desktop/src/main/__tests__/session-status-presentation.test.ts
+++ b/apps/desktop/src/main/__tests__/session-status-presentation.test.ts
@@ -326,6 +326,11 @@ describe('describeTurnErrorClass (PR109e-d @kenji gate #3)', () => {
     }
   });
 
+  it('returns specific labels for context overflow and provider billing', () => {
+    assert.equal(describeTurnErrorClass('context_overflow'), '上下文窗口已超出限制');
+    assert.equal(describeTurnErrorClass('provider_billing'), '模型服务计费受限');
+  });
+
   it('returns Chinese label for tool_failed', () => {
     assert.match(describeTurnErrorClass('tool_failed'), /工具/);
   });
@@ -403,6 +408,17 @@ describe('deriveFailedTurnRecovery (PawWork run-incident lite)', () => {
       assert.equal(result.action, 'check_connection');
       assert.match(result.label, /模型|连接|登录/);
     }
+  });
+
+  it('routes provider billing failures to connection/account checks before retrying', () => {
+    const result = deriveFailedTurnRecovery({
+      errorClass: 'provider_billing',
+      partialOutputRetained: false,
+      toolActivityCount: 0,
+      erroredToolCount: 0,
+    });
+    assert.equal(result.action, 'check_connection');
+    assert.match(result.label, /模型|连接|登录/);
   });
 
   it('offers continue when partial output was retained and no tool failed', () => {

--- a/apps/desktop/src/renderer/locales/conversation-copy.ts
+++ b/apps/desktop/src/renderer/locales/conversation-copy.ts
@@ -55,8 +55,10 @@ export interface DesktopConversationCopy {
   };
   turnError: {
     unknown: string;
+    contextOverflow: string;
     timeout: string;
     auth: string;
+    providerBilling: string;
     rateLimit: string;
     network: string;
     provider: string;
@@ -110,7 +112,7 @@ const COPY = {
       reauth: { label: '上次连接测试鉴权失败', tooltip: '最近一次连接测试返回鉴权失败（401 / 403），密钥可能已过期或被吊销。这不会拦截发送，但若发送失败请到 设置 · 模型 重新登录。' },
       testError: { label: '上次连接测试失败', tooltip: '最近一次连接测试因网络 / 超时 / 5xx 失败。这不会拦截发送，但若问题持续请到 设置 · 模型 检查 Base URL / 代理。' },
     },
-    turnError: { unknown: '未知错误', timeout: '请求超时', auth: '鉴权失败', rateLimit: '触发模型速率限制', network: '网络错误', provider: '模型服务返回错误', stepCap: '达到工具步骤上限', tool: '工具调用失败', permission: '等待权限确认', restarted: '本地应用重启，上一轮没有完成', recovery: { safeResume: '检查当前状态后，可尝试安全恢复', stepCap: '任务可能尚未完成，可以继续', toolError: '先检查工具结果，再决定是否重试', connection: '先检查模型连接或登录状态', partial: '已保留部分输出，可从这里继续', toolRecord: '工具记录已保留，重试前先看结果', retry: '没有执行工具，可直接重试' } },
+    turnError: { unknown: '未知错误', contextOverflow: '上下文窗口已超出限制', timeout: '请求超时', auth: '鉴权失败', providerBilling: '模型服务计费受限', rateLimit: '触发模型速率限制', network: '网络错误', provider: '模型服务返回错误', stepCap: '达到工具步骤上限', tool: '工具调用失败', permission: '等待权限确认', restarted: '本地应用重启，上一轮没有完成', recovery: { safeResume: '检查当前状态后，可尝试安全恢复', stepCap: '任务可能尚未完成，可以继续', toolError: '先检查工具结果，再决定是否重试', connection: '先检查模型连接或登录状态', partial: '已保留部分输出，可从这里继续', toolRecord: '工具记录已保留，重试前先看结果', retry: '没有执行工具，可直接重试' } },
   },
   en: {
     actions: { stopFailedTitle: 'Failed to stop', stopFailedFallback: 'The conversation action failed. Try again later.', refreshSessionsFailedTitle: 'Failed to refresh conversations', refreshSessionsFailedFallback: 'The conversation list could not be refreshed. Try again later.', conversationErrorTitle: 'Conversation error', conversationErrorFallback: 'The conversation run failed. Try again later.', regenerateStartedTitle: 'Regeneration started', regenerateStartedDescription: 'Generating a new response', branchCreatedTitle: 'Branch created', branchCreatedDescription: (name) => `New conversation: ${name}`, operationFailedTitle: 'Action failed', operationFailedFallback: 'The conversation action failed. Try again later.', attachmentFailedTitle: 'Failed to add attachment', tryAgain: 'Try again later.', modelReboundTitle: 'Switched to an available model', modelReboundDescription: (modelId) => `The previous connection is unavailable${modelId ? ` · ${modelId}` : ''}`, messageReadFailedTitle: 'Failed to load conversation' },
@@ -153,7 +155,7 @@ const COPY = {
       reauth: { label: 'Last connection test failed authentication', tooltip: 'The latest test returned 401 / 403. Sending is not blocked, but sign in again under Settings · Models if it fails.' },
       testError: { label: 'Last connection test failed', tooltip: 'The latest test failed because of a network, timeout, or 5xx error. Sending is not blocked; check Base URL or proxy settings if it persists.' },
     },
-    turnError: { unknown: 'Unknown error', timeout: 'Request timed out', auth: 'Authentication failed', rateLimit: 'Model rate limit reached', network: 'Network error', provider: 'Model service error', stepCap: 'Tool-step limit reached', tool: 'Tool call failed', permission: 'Waiting for permission', restarted: 'The app restarted before the previous turn completed', recovery: { safeResume: 'Inspect the current state, then try safe recovery', stepCap: 'The task may be incomplete; continue from here', toolError: 'Inspect the tool result before retrying', connection: 'Check the model connection or sign-in status', partial: 'Partial output was retained; continue from here', toolRecord: 'Tool history was retained; inspect it before retrying', retry: 'No tools ran; retry directly' } },
+    turnError: { unknown: 'Unknown error', contextOverflow: 'Context window exceeded', timeout: 'Request timed out', auth: 'Authentication failed', providerBilling: 'Provider billing required', rateLimit: 'Model rate limit reached', network: 'Network error', provider: 'Model service error', stepCap: 'Tool-step limit reached', tool: 'Tool call failed', permission: 'Waiting for permission', restarted: 'The app restarted before the previous turn completed', recovery: { safeResume: 'Inspect the current state, then try safe recovery', stepCap: 'The task may be incomplete; continue from here', toolError: 'Inspect the tool result before retrying', connection: 'Check the model connection or sign-in status', partial: 'Partial output was retained; continue from here', toolRecord: 'Tool history was retained; inspect it before retrying', retry: 'No tools ran; retry directly' } },
   },
 } satisfies UiCatalog<DesktopConversationCopy>;
 

--- a/apps/desktop/src/renderer/model-connection-errors.ts
+++ b/apps/desktop/src/renderer/model-connection-errors.ts
@@ -4,6 +4,7 @@ import {
 } from '@maka/core';
 import { getDesktopConversationCopy } from './locales/conversation-copy.js';
 import { localizedShellErrorMessage } from './locales/shell-copy.js';
+import { describeSessionErrorReason } from './session-error-presentation.js';
 
 const NO_REAL_CONNECTION_CODE = 'NO_REAL_CONNECTION';
 const NO_REAL_CONNECTION_REASON_RE = /NO_REAL_CONNECTION:([a-z_]+): /;
@@ -37,6 +38,8 @@ export function sessionEventErrorMessage(
   event: Extract<SessionEvent, { type: 'error' }>,
   locale: UiLocale = 'zh',
 ): string {
+  const reasonDescription = describeSessionErrorReason(event.reason, locale);
+  if (reasonDescription) return reasonDescription;
   const fallback = getDesktopConversationCopy(locale).actions.conversationErrorFallback;
   return localizedShellErrorMessage(new Error(event.message), fallback, locale);
 }

--- a/apps/desktop/src/renderer/session-error-presentation.ts
+++ b/apps/desktop/src/renderer/session-error-presentation.ts
@@ -1,0 +1,29 @@
+import type { UiLocale } from '@maka/core';
+import { getDesktopConversationCopy } from './locales/conversation-copy.js';
+
+/**
+ * Locale-aware allowlist for stable ErrorEvent.reason values emitted by the
+ * runtime. Unknown reasons intentionally return undefined so callers can use
+ * their existing safe fallback instead of displaying raw provider text.
+ */
+export function describeSessionErrorReason(reason: string | undefined, locale: UiLocale = 'zh'): string | undefined {
+  const copy = getDesktopConversationCopy(locale).turnError;
+  switch (reason?.toLowerCase()) {
+    case 'context_overflow':
+      return copy.contextOverflow;
+    case 'timeout':
+      return copy.timeout;
+    case 'auth':
+      return copy.auth;
+    case 'provider_billing':
+      return copy.providerBilling;
+    case 'provider_unavailable':
+      return copy.provider;
+    case 'rate_limit':
+      return copy.rateLimit;
+    case 'network':
+      return copy.network;
+    default:
+      return undefined;
+  }
+}

--- a/apps/desktop/src/renderer/session-status-presentation.ts
+++ b/apps/desktop/src/renderer/session-status-presentation.ts
@@ -29,6 +29,7 @@ import {
   type SessionStatusTone,
 } from '@maka/ui';
 import { getDesktopConversationCopy } from './locales/conversation-copy.js';
+import { describeSessionErrorReason } from './session-error-presentation.js';
 export { presentSessionStatus } from '@maka/ui';
 export { describeBlockedReason } from '@maka/ui';
 export type { SessionStatusPresentation, SessionStatusTone } from '@maka/ui';
@@ -112,6 +113,8 @@ export function sessionStatusAriaLabel(status: SessionStatus, blockedReason?: Se
 export function describeTurnErrorClass(errorClass: string | undefined, locale: UiLocale = 'zh'): string {
   const copy = getDesktopConversationCopy(locale).turnError;
   if (!errorClass) return copy.unknown;
+  const reasonDescription = describeSessionErrorReason(errorClass, locale);
+  if (reasonDescription) return reasonDescription;
   const lower = errorClass.toLowerCase();
   if (lower === 'timeout' || lower.includes('timeout')) return copy.timeout;
   if (lower === 'auth' || lower.includes('auth') || lower === '401' || lower === '403') return copy.auth;
@@ -160,7 +163,7 @@ export function deriveFailedTurnRecovery(input: FailedTurnRecoveryInput, locale:
   if (input.erroredToolCount > 0 || lower === 'tool_failed' || lower.includes('tool')) {
     return { action: 'inspect_tool', label: copy.toolError };
   }
-  if (lower === 'auth' || lower.includes('auth') || lower === '401' || lower === '403') {
+  if (lower === 'provider_billing' || lower === 'auth' || lower.includes('auth') || lower === '401' || lower === '403') {
     return { action: 'check_connection', label: copy.connection };
   }
   if (input.partialOutputRetained) {


### PR DESCRIPTION
## Summary

- present stable runtime `ErrorEvent.reason` values through one localized, typed allowlist
- use the same safe presentation for conversation toasts, native notifications, and failed-turn labels
- route provider billing failures to connection/account recovery while preserving the existing generic fallback for unknown reasons

## Context

This is part 2 of #1216 and intentionally stays separate from the retry-classification change in #1218.

Dependencies: #1218, which is itself stacked on #1214. GitHub cannot use a branch from a contributor fork as the base of an upstream pull request, so this Draft currently targets `main`; the dependency commits will disappear from this diff as those PRs merge.

## Verification

- TDD red phase: focused presentation tests failed on the missing context-overflow/billing mappings and billing recovery route
- focused desktop presentation tests: 45/45 passed
- real Electron app with an isolated user-data directory and loopback OpenAI-compatible provider:
  - verified `context_overflow`, `provider_billing`, `rate_limit`, `auth`, and `provider_unavailable` end to end
  - verified a non-overflow output-limit response remains the generic fallback
  - verified the persisted report contains neither the injected placeholder key nor provider-secret marker
- desktop Electron E2E: 26/26 passed
- `npm run build`
- `npm run typecheck`
- `npm run lint`
- `git diff --check`
- `npm run test:dist`: all workspace tests passed; desktop 2720/2720, 0 failed

Visual evidence from the real Electron run will be attached to this Draft.

Refs #1216
