### PR TITLE
test(headless): tolerate Biome-formatted runner contracts

### DIFF
--- a/packages/headless/src/__tests__/harbor-adapter.test.ts
+++ b/packages/headless/src/__tests__/harbor-adapter.test.ts
@@ -412,7 +412,7 @@ describe('Harbor adapter contract', () => {
     );
     assert.match(
       source,
-      /const keyFile = envPath\('MAKA_PROMPT_KEY_FILE', join\(localEvalRoot, '\.local-secrets', 'deepseek-key'\)\);/,
+      /const keyFile = envPath\(\s*'MAKA_PROMPT_KEY_FILE',\s*join\(localEvalRoot, '\.local-secrets', 'deepseek-key'\),\s*\);/,
     );
     assert.match(source, /MAKA_PROMPT_INITIAL_SYSTEM_PROMPT_FILE/);
     assert.match(
@@ -518,7 +518,7 @@ describe('Harbor adapter contract', () => {
     );
     assert.match(
       source,
-      /const harborTimeoutMs = envPosInt\('MAKA_PROMPT_AB_HARBOR_TIMEOUT_MS', \(taskBudgetSec \+ 300\) \* 1000\);/,
+      /const harborTimeoutMs = envPosInt\(\s*'MAKA_PROMPT_AB_HARBOR_TIMEOUT_MS',\s*\(taskBudgetSec \+ 300\) \* 1000,\s*\);/,
     );
     assert.match(source, /Direct evaluation tasks:/);
     assert.doesNotMatch(source, /runPromptAbConcurrencyCalibration/);

--- a/packages/headless/src/__tests__/harness-ab-cli.test.ts
+++ b/packages/headless/src/__tests__/harness-ab-cli.test.ts
@@ -270,7 +270,7 @@ test('harness A/B completion log preserves the report status', async () => {
   const scriptPath = new URL('../../harbor/run-harness-ab.mjs', import.meta.url);
   const source = await readFile(scriptPath, 'utf8');
 
-  assert.match(source, /console\.log\(`\$\{report\.runStatus\}:/);
+  assert.match(source, /console\.log\(\s*`\$\{report\.runStatus\}:/);
 });
 
 test('detached named-task launcher requires a run id before creating artifacts', async () => {


### PR DESCRIPTION
## Summary

Follow-up to #1122. The Biome baseline reformatted three headless runner statements across multiple lines, while their source-contract tests still required the previous single-line layout. This currently fails the `test` job on `main` (`d0407f71`) and on unrelated PRs based on it, including #1224.

- allow whitespace/newlines inside the `MAKA_PROMPT_KEY_FILE` fallback contract;
- allow whitespace/newlines inside the A/B Harbor timeout contract;
- allow whitespace/newlines before the harness completion status template.

The assertions still bind the exact env names, fallback expressions, and `${report.runStatus}` prefix. Production runners are unchanged.

## Verification

- affected source-contract tests: 3 passed
- `npm --workspace @maka/headless run typecheck`
- changed-file Biome lint and format checks
- `git diff --check`
- independent Codex review: no findings

The same three failures are reproducible on the base `main` CI run: https://github.com/maka-agent/maka-agent/actions/runs/29674210573.