### PR TITLE
fix(runtime): keep Read schema Anthropic-compatible

### DIFF
--- a/packages/runtime/src/__tests__/builtin-tools.test.ts
+++ b/packages/runtime/src/__tests__/builtin-tools.test.ts
@@ -791,8 +791,13 @@ describe('builtin Bash streaming output', () => {
     };
     const providerSchema = await parameters.jsonSchema;
     expect(providerSchema.type).toBe('object');
-    expect(Array.isArray(providerSchema.anyOf)).toBe(true);
-    expect((providerSchema.anyOf as unknown[]).length).toBe(2);
+    expect(providerSchema.anyOf).toBe(undefined);
+    expect(providerSchema.oneOf).toBe(undefined);
+    const properties = providerSchema.properties as Record<string, { type?: unknown }>;
+    expect(properties.path?.type).toBe('string');
+    expect(properties.offset?.type).toBe('integer');
+    expect(properties.limit?.type).toBe('integer');
+    expect(properties.ref?.type).toBe('string');
     expect((await parameters.validate({ path: 'README.md', offset: 2, limit: 10 })).success).toBe(
       true,
     );

--- a/packages/runtime/src/builtin-tools.ts
+++ b/packages/runtime/src/builtin-tools.ts
@@ -107,40 +107,57 @@ export function buildBuiltinTools(options: BuildBuiltinToolsOptions = {}): MakaT
   const readDescription = `Read a text file${options.snapshotImage ? ' or supported image' : ''} from disk${options.runtimeResources ? ', or read a whole runtime resource using ref' : ''}.`;
   const fileReadParameters = z
     .object({
-      path: z.string().describe('A file path; relative paths are resolved from the session cwd'),
+      path: z
+        .string()
+        .describe(
+          '[file read] A file path; relative paths are resolved from the session cwd. Do not provide ref.',
+        ),
       offset: z
         .number()
         .int()
         .nonnegative()
-        .describe('Zero-based text file line offset')
+        .describe('[file read] Zero-based text file line offset. Only valid with path.')
         .optional(),
-      limit: z.number().int().positive().describe('Maximum text file lines to read').optional(),
+      limit: z
+        .number()
+        .int()
+        .positive()
+        .describe('[file read] Maximum text file lines to read. Only valid with path.')
+        .optional(),
     })
     .strict();
   const runtimeResourceReadParameters = z
     .object({
-      ref: z.string().describe('A runtime resource ref returned by another tool'),
+      ref: z
+        .string()
+        .describe(
+          '[runtime resource read] A runtime resource ref returned by another tool. Do not provide path, offset, or limit.',
+        ),
     })
     .strict();
   const strictReadParameters = z
     .union([fileReadParameters, runtimeResourceReadParameters])
     .describe('Read a file with path, or a whole runtime resource with ref; provide exactly one');
-  const strictReadProviderSchema = zodSchema(strictReadParameters);
+  const readProviderParameters = z
+    .object({
+      ...fileReadParameters.shape,
+      ...runtimeResourceReadParameters.shape,
+    })
+    .partial()
+    .strict()
+    .describe(
+      'Read either a file with path (plus optional offset and limit) or a whole runtime resource with ref. Provide exactly one of path or ref, and never mix their fields.',
+    );
+  const readProviderSchema = zodSchema(readProviderParameters);
   const readParameters = options.runtimeResources
-    ? jsonSchema(
-        async () => ({
-          ...(await strictReadProviderSchema.jsonSchema),
-          type: 'object',
-        }),
-        {
-          validate: async (value) => {
-            const result = await strictReadParameters.safeParseAsync(value);
-            return result.success
-              ? { success: true, value: result.data }
-              : { success: false, error: result.error };
-          },
+    ? jsonSchema(async () => await readProviderSchema.jsonSchema, {
+        validate: async (value) => {
+          const result = await strictReadParameters.safeParseAsync(value);
+          return result.success
+            ? { success: true, value: result.data }
+            : { success: false, error: result.error };
         },
-      )
+      })
     : fileReadParameters;
   const shell = options.shell ?? defaultShellPlan();
   const sandboxPlatform = options.sandboxPlatform ?? process.platform;


### PR DESCRIPTION
## Summary

- keep the runtime-resource-enabled `Read` input schema rooted as a plain JSON Schema object with no top-level `anyOf`/`oneOf`
- retain the strict file-vs-runtime-resource Zod union as the authoritative local validator
- strengthen field and schema descriptions so providers still receive the mutual-exclusion contract without an incompatible union root
- replace the regression assertion that required `anyOf` with Anthropic-compatible schema checks

## Root cause

#1124 serialized the strict `Read` union for providers and overlaid `type: "object"`. That preserved the union alternatives, but it also left the union-generated top-level `anyOf` on the wire. Anthropic rejects that tool `input_schema` before inference.

The fix deliberately separates provider guidance from runtime enforcement. The provider sees one ordinary object with `path`, `offset`, `limit`, and `ref`; the AI SDK custom validator still accepts only `{ path, offset?, limit? }` or `{ ref }`.

Closes #1228

## Validation

- `node --test packages/runtime/dist/__tests__/builtin-tools.test.js` (51 passed)
- `npm --workspace @maka/runtime run typecheck`
- `npx biome check packages/runtime/src/builtin-tools.ts packages/runtime/src/__tests__/builtin-tools.test.ts`
- `git diff --check`
- Full `npm --workspace @maka/runtime test`: 2168 passed, 0 failed, 7 skipped, 1 unrelated cancelled test; Node exited 1 because of the cancellation.
