### PR TITLE
fix(ui): localize permission waits and session counts

### DIFF
--- a/packages/core/src/__tests__/permission-request-health.test.ts
+++ b/packages/core/src/__tests__/permission-request-health.test.ts
@@ -55,4 +55,12 @@ describe('permission request health', () => {
     assert.equal(formatPermissionRequestWait(60 * 60_000), '1 小时');
     assert.equal(formatPermissionRequestWait(95 * 60_000), '1 小时 35 分钟');
   });
+
+  it('formats every wait-duration bucket in English when requested', () => {
+    assert.equal(formatPermissionRequestWait(0, 'en'), '< 1 minute');
+    assert.equal(formatPermissionRequestWait(60_000, 'en'), '1 minute');
+    assert.equal(formatPermissionRequestWait(5 * 60_000, 'en'), '5 minutes');
+    assert.equal(formatPermissionRequestWait(60 * 60_000, 'en'), '1 hour');
+    assert.equal(formatPermissionRequestWait(95 * 60_000, 'en'), '1 hour 35 minutes');
+  });
 });

--- a/packages/core/src/permission-request-health.ts
+++ b/packages/core/src/permission-request-health.ts
@@ -1,3 +1,5 @@
+import type { UiLocale } from './ui-locale.js';
+
 export const PERMISSION_REQUEST_HEALTH_STATUSES = ['fresh', 'stale', 'expired'] as const;
 
 export type PermissionRequestHealthStatus = (typeof PERMISSION_REQUEST_HEALTH_STATUSES)[number];
@@ -33,10 +35,19 @@ export function derivePermissionRequestHealth(input: {
   return { status: 'fresh', ageMs };
 }
 
-export function formatPermissionRequestWait(ageMs: number): string {
+export function formatPermissionRequestWait(ageMs: number, locale: UiLocale = 'zh'): string {
   const clamped = Math.max(0, ageMs);
-  if (clamped < 60_000) return '< 1 分钟';
+  if (clamped < 60_000) return locale === 'en' ? '< 1 minute' : '< 1 分钟';
   const minutes = Math.floor(clamped / 60_000);
+  if (locale === 'en') {
+    if (minutes < 60) return `${minutes} ${minutes === 1 ? 'minute' : 'minutes'}`;
+    const hours = Math.floor(minutes / 60);
+    const remainder = minutes % 60;
+    const hourLabel = `${hours} ${hours === 1 ? 'hour' : 'hours'}`;
+    return remainder > 0
+      ? `${hourLabel} ${remainder} ${remainder === 1 ? 'minute' : 'minutes'}`
+      : hourLabel;
+  }
   if (minutes < 60) return `${minutes} 分钟`;
   const hours = Math.floor(minutes / 60);
   const remainder = minutes % 60;

--- a/packages/ui/src/__tests__/conversation-localization.test.tsx
+++ b/packages/ui/src/__tests__/conversation-localization.test.tsx
@@ -1,12 +1,18 @@
 import { strict as assert } from 'node:assert';
 import { describe, it } from 'node:test';
-import type { AnyPermissionRequestEvent, UiLocale, UserQuestionRequestEvent } from '@maka/core';
+import type {
+  AnyPermissionRequestEvent,
+  SessionSummary,
+  UiLocale,
+  UserQuestionRequestEvent,
+} from '@maka/core';
 import type { ReactNode } from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
 import { EmptyChatHero } from '../chat-empty-hero.js';
 import { Composer } from '../composer.js';
 import { LocaleProvider } from '../locale-context.js';
 import { PermissionPrompt } from '../permission-dialog.js';
+import { SessionHistoryList } from '../session-history-list.js';
 import { ToolTrow } from '../tool-activity.js';
 import { summarizeTrowTools } from '../tool-activity/trow-summary.js';
 import { UserQuestionPrompt } from '../user-question-prompt.js';
@@ -39,6 +45,21 @@ const questionRequest = {
   toolUseId: 'tool-question',
   questions: [{ question: 'RAW_QUESTION_中文', options: [{ label: 'RAW_OPTION_中文' }] }],
 } satisfies UserQuestionRequestEvent;
+
+const archivedSession = {
+  id: 'session-archived',
+  name: 'Archived conversation',
+  isFlagged: false,
+  isArchived: true,
+  labels: [],
+  hasUnread: false,
+  status: 'archived',
+  backend: 'ai-sdk',
+  llmConnectionSlug: 'test-connection',
+  connectionLocked: false,
+  model: 'test-model',
+  permissionMode: 'ask',
+} satisfies SessionSummary;
 
 describe('localized conversation journey', () => {
   it('renders coherent empty and composer states in Chinese and English', () => {
@@ -80,6 +101,55 @@ describe('localized conversation journey', () => {
       assert.match(zh, new RegExp(raw));
       assert.match(en, new RegExp(raw));
     }
+  });
+
+  it('localizes stale permission wait durations without mixing unit languages', () => {
+    const staleRequest = {
+      ...permissionRequest,
+      ts: Date.now() - 6 * 60_000,
+    } satisfies AnyPermissionRequestEvent;
+    const zh = render(
+      'zh',
+      <PermissionPrompt request={staleRequest} onRespond={() => {}} onStop={() => {}} />,
+    );
+    const en = render(
+      'en',
+      <PermissionPrompt request={staleRequest} onRespond={() => {}} onStop={() => {}} />,
+    );
+
+    assert.match(zh, /已等待 6 分钟/);
+    assert.match(en, /Waiting for 6 minutes/);
+    assert.doesNotMatch(en, /分钟|小时/);
+  });
+
+  it('formats collapsed session-group counts with locale-correct punctuation', () => {
+    const group = (label: string) => ({
+      id: 'archived',
+      label,
+      sessions: [archivedSession],
+      collapsible: true,
+      defaultExpanded: false,
+    });
+    const zh = render(
+      'zh',
+      <SessionHistoryList
+        sessions={[archivedSession]}
+        statusGroups={[group('已归档')]}
+        onSelectSession={() => {}}
+      />,
+    );
+    const en = render(
+      'en',
+      <SessionHistoryList
+        sessions={[archivedSession]}
+        statusGroups={[group('Archived')]}
+        onSelectSession={() => {}}
+      />,
+    );
+
+    assert.match(zh, /已归档[\s\S]*（1）/);
+    assert.match(en, /Archived[\s\S]*\(1\)/);
+    assert.doesNotMatch(en, /Archived[\s\S]*（1）/);
   });
 
   it('localizes live tool activity without rewriting tool-owned text', () => {

--- a/packages/ui/src/conversation-copy.ts
+++ b/packages/ui/src/conversation-copy.ts
@@ -229,6 +229,7 @@ export interface ConversationCopy {
     emptyBody: string;
     showMore: string;
     showMoreAriaLabel: (count: number) => string;
+    groupCount: (count: number) => string;
     renameAriaLabel: string;
     respondingAriaLabel: string;
     respondingTitle: string;
@@ -336,7 +337,7 @@ const CONVERSATION_COPY = {
     sessions: {
       status: { active: '可继续', running: '进行中', waiting_for_user: '等你确认', blocked: '需要处理', review: '待审核', done: '已完成', archived: '已归档', aborted: '已中止' },
       blockedReason: { NO_REAL_CONNECTION: '等待配置可用模型连接', auth: '需要重新登录', permission_required: '等待权限确认', tool_failed: '工具调用失败', unknown: '运行中断，可重试' },
-      listAriaLabel: '对话列表', title: '会话', emptyTitle: '等待开始对话', emptyBody: '和 Maka 的对话会出现在这里。', showMore: '显示更多', showMoreAriaLabel: (count) => `显示 ${count} 条更多对话`, renameAriaLabel: '重命名对话', respondingAriaLabel: '正在响应', respondingTitle: '对话正在流式响应中', staleTitle: '此会话使用的模型连接已不可用，发送时会切换到默认连接', staleAriaLabel: '会话已过期', stale: '已过期', unreadAriaLabel: '未读消息', actionsAriaLabel: '对话操作', pin: '置顶', unpin: '取消置顶', rename: '重命名', archive: '归档', unarchive: '取消归档', delete: '删除', pinned: '已置顶', today: '今天', yesterday: '昨天', past7Days: '过去 7 天', past30Days: '过去 30 天', earlier: '更早', pending: '待发送', groupByStatus: '按状态', groupByProject: '按项目', groupingAriaLabel: '会话分组方式', promptRailAriaLabel: '按提问跳转', emptyPrompt: '（空提问）', jumpToPrompt: (preview) => `跳到提问：${preview}`,
+      listAriaLabel: '对话列表', title: '会话', emptyTitle: '等待开始对话', emptyBody: '和 Maka 的对话会出现在这里。', showMore: '显示更多', showMoreAriaLabel: (count) => `显示 ${count} 条更多对话`, groupCount: (count) => `（${count}）`, renameAriaLabel: '重命名对话', respondingAriaLabel: '正在响应', respondingTitle: '对话正在流式响应中', staleTitle: '此会话使用的模型连接已不可用，发送时会切换到默认连接', staleAriaLabel: '会话已过期', stale: '已过期', unreadAriaLabel: '未读消息', actionsAriaLabel: '对话操作', pin: '置顶', unpin: '取消置顶', rename: '重命名', archive: '归档', unarchive: '取消归档', delete: '删除', pinned: '已置顶', today: '今天', yesterday: '昨天', past7Days: '过去 7 天', past30Days: '过去 30 天', earlier: '更早', pending: '待发送', groupByStatus: '按状态', groupByProject: '按项目', groupingAriaLabel: '会话分组方式', promptRailAriaLabel: '按提问跳转', emptyPrompt: '（空提问）', jumpToPrompt: (preview) => `跳到提问：${preview}`,
     },
   },
   en: {
@@ -444,7 +445,7 @@ const CONVERSATION_COPY = {
     sessions: {
       status: { active: 'Ready', running: 'Running', waiting_for_user: 'Waiting for you', blocked: 'Needs attention', review: 'Review', done: 'Done', archived: 'Archived', aborted: 'Stopped' },
       blockedReason: { NO_REAL_CONNECTION: 'Waiting for an available model connection', auth: 'Sign in again', permission_required: 'Waiting for permission', tool_failed: 'Tool call failed', unknown: 'Run interrupted; retry available' },
-      listAriaLabel: 'Conversation list', title: 'Conversations', emptyTitle: 'Start a conversation', emptyBody: 'Your conversations with Maka will appear here.', showMore: 'Show more', showMoreAriaLabel: (count) => `Show ${count} more conversations`, renameAriaLabel: 'Rename conversation', respondingAriaLabel: 'Responding', respondingTitle: 'This conversation is streaming a response', staleTitle: 'This conversation\'s model connection is unavailable; sending will switch to the default connection', staleAriaLabel: 'Stale conversation', stale: 'Stale', unreadAriaLabel: 'Unread messages', actionsAriaLabel: 'Conversation actions', pin: 'Pin', unpin: 'Unpin', rename: 'Rename', archive: 'Archive', unarchive: 'Unarchive', delete: 'Delete', pinned: 'Pinned', today: 'Today', yesterday: 'Yesterday', past7Days: 'Past 7 days', past30Days: 'Past 30 days', earlier: 'Earlier', pending: 'Pending', groupByStatus: 'By status', groupByProject: 'By project', groupingAriaLabel: 'Conversation grouping', promptRailAriaLabel: 'Jump by prompt', emptyPrompt: '(empty prompt)', jumpToPrompt: (preview) => `Jump to prompt: ${preview}`,
+      listAriaLabel: 'Conversation list', title: 'Conversations', emptyTitle: 'Start a conversation', emptyBody: 'Your conversations with Maka will appear here.', showMore: 'Show more', showMoreAriaLabel: (count) => `Show ${count} more conversations`, groupCount: (count) => `(${count})`, renameAriaLabel: 'Rename conversation', respondingAriaLabel: 'Responding', respondingTitle: 'This conversation is streaming a response', staleTitle: 'This conversation\'s model connection is unavailable; sending will switch to the default connection', staleAriaLabel: 'Stale conversation', stale: 'Stale', unreadAriaLabel: 'Unread messages', actionsAriaLabel: 'Conversation actions', pin: 'Pin', unpin: 'Unpin', rename: 'Rename', archive: 'Archive', unarchive: 'Unarchive', delete: 'Delete', pinned: 'Pinned', today: 'Today', yesterday: 'Yesterday', past7Days: 'Past 7 days', past30Days: 'Past 30 days', earlier: 'Earlier', pending: 'Pending', groupByStatus: 'By status', groupByProject: 'By project', groupingAriaLabel: 'Conversation grouping', promptRailAriaLabel: 'Jump by prompt', emptyPrompt: '(empty prompt)', jumpToPrompt: (preview) => `Jump to prompt: ${preview}`,
     },
   },
 } satisfies UiCatalog<ConversationCopy>;

--- a/packages/ui/src/permission-dialog.tsx
+++ b/packages/ui/src/permission-dialog.tsx
@@ -46,7 +46,8 @@ export function PermissionPrompt(props: {
   onStop(): void | Promise<void>;
   stopPending?: boolean;
 }) {
-  const copy = getConversationCopy(useUiLocale()).permissionPrompt;
+  const locale = useUiLocale();
+  const copy = getConversationCopy(locale).permissionPrompt;
   const [rememberForTurn, setRememberForTurn] = useState(false);
   const [expandedRequestId, setExpandedRequestId] = useState<string | null>(null);
   const [responsePending, setResponsePending] = useState(false);
@@ -117,7 +118,7 @@ export function PermissionPrompt(props: {
     ? copy.destructiveContext
     : undefined);
   const health = derivePermissionRequestHealth({ requestedAt: props.request.ts, now });
-  const waitLabel = formatPermissionRequestWait(health.ageMs);
+  const waitLabel = formatPermissionRequestWait(health.ageMs, locale);
   const decisionsDisabled = props.stopPending || responsePending;
 
   return (

--- a/packages/ui/src/session-history-list.tsx
+++ b/packages/ui/src/session-history-list.tsx
@@ -229,6 +229,7 @@ function SessionListGroups(props: {
   onSelectSession(sessionId: string): void;
   rowActions?: SessionRowActions;
 }) {
+  const copy = getConversationCopy(useUiLocale()).sessions;
   const [expandedByKey, setExpandedByKey] = useState<Record<string, boolean>>(() => {
     const out: Record<string, boolean> = {};
     for (const g of props.groups) out[g.key] = g.defaultExpanded;
@@ -295,7 +296,7 @@ function SessionListGroups(props: {
                 {/* Collapsed history buckets keep a subdued count so users
                   can tell whether expanding the group is worth it. Open
                   groups intentionally omit counts to keep the rail flat. */}
-                <span className="maka-list-group-count">（{group.sessions.length}）</span>
+                <span className="maka-list-group-count">{copy.groupCount(group.sessions.length)}</span>
               </BaseButton>
             ) : (
               <div className="maka-list-group-label">


### PR DESCRIPTION
## Summary
- make permission-request wait durations locale-aware, including English singular/plural units
- move collapsed session-group count punctuation into the typed conversation catalog
- add core and UI regression coverage for both review follow-ups

Follow-up to #1194 and #1052.

## Root cause
The permission dialog localized its wrapper copy but reused a Chinese-only duration formatter. Session groups also rendered full-width parentheses directly in JSX instead of delegating typography to the locale catalog.

## Validation
- npm run lint
- npm run build
- npm run typecheck
- npm test --workspace @maka/core
- npm test --workspace @maka/ui