### PR TITLE
fix(runtime): drop top-level anyOf from the Read tool provider schema

### DIFF
--- a/packages/runtime/src/__tests__/builtin-tools.test.ts
+++ b/packages/runtime/src/__tests__/builtin-tools.test.ts
@@ -790,9 +790,19 @@ describe('builtin Bash streaming output', () => {
       validate(value: unknown): PromiseLike<{ success: boolean }> | { success: boolean };
     };
     const providerSchema = await parameters.jsonSchema;
+    // Anthropic-compatible: a plain top-level object with properties, and no
+    // top-level union combinator (#1228).
     expect(providerSchema.type).toBe('object');
-    expect(Array.isArray(providerSchema.anyOf)).toBe(true);
-    expect((providerSchema.anyOf as unknown[]).length).toBe(2);
+    expect(providerSchema.anyOf).toBeUndefined();
+    expect(providerSchema.oneOf).toBeUndefined();
+    expect(providerSchema.allOf).toBeUndefined();
+    expect(Object.keys(providerSchema.properties as Record<string, unknown>).sort()).toEqual([
+      'limit',
+      'offset',
+      'path',
+      'ref',
+    ]);
+    // The strict file-vs-ref union remains the authoritative runtime validator.
     expect((await parameters.validate({ path: 'README.md', offset: 2, limit: 10 })).success).toBe(
       true,
     );

--- a/packages/runtime/src/builtin-tools.ts
+++ b/packages/runtime/src/builtin-tools.ts
@@ -105,42 +105,70 @@ export function buildBuiltinTools(options: BuildBuiltinToolsOptions = {}): MakaT
   const executor = options.executor ?? createLocalWorkspaceExecutor();
   const executionFacts = executor.facts;
   const readDescription = `Read a text file${options.snapshotImage ? ' or supported image' : ''} from disk${options.runtimeResources ? ', or read a whole runtime resource using ref' : ''}.`;
+  const pathField = z
+    .string()
+    .describe('A file path; relative paths are resolved from the session cwd');
+  const offsetField = z
+    .number()
+    .int()
+    .nonnegative()
+    .describe('Zero-based text file line offset')
+    .optional();
+  const limitField = z
+    .number()
+    .int()
+    .positive()
+    .describe('Maximum text file lines to read')
+    .optional();
+  const refField = z.string().describe('A runtime resource ref returned by another tool');
   const fileReadParameters = z
     .object({
-      path: z.string().describe('A file path; relative paths are resolved from the session cwd'),
-      offset: z
-        .number()
-        .int()
-        .nonnegative()
-        .describe('Zero-based text file line offset')
-        .optional(),
-      limit: z.number().int().positive().describe('Maximum text file lines to read').optional(),
+      path: pathField,
+      offset: offsetField,
+      limit: limitField,
     })
     .strict();
   const runtimeResourceReadParameters = z
     .object({
-      ref: z.string().describe('A runtime resource ref returned by another tool'),
+      ref: refField,
     })
     .strict();
   const strictReadParameters = z
     .union([fileReadParameters, runtimeResourceReadParameters])
     .describe('Read a file with path, or a whole runtime resource with ref; provide exactly one');
-  const strictReadProviderSchema = zodSchema(strictReadParameters);
+  // Provider-facing schema: a single top-level object with every field optional.
+  // Anthropic rejects a tool definition whose input schema carries a top-level
+  // `anyOf`, so the file-vs-ref exclusivity is stated in the field descriptions
+  // here and enforced authoritatively by the strict union in `validate` below
+  // (see #1228 — a union-generated `anyOf` had been leaking onto the wire).
+  const providerReadParameters = z
+    .object({
+      path: pathField
+        .describe(
+          'A file path; relative paths are resolved from the session cwd. Provide either path (optionally with offset/limit) or ref, never both.',
+        )
+        .optional(),
+      offset: offsetField,
+      limit: limitField,
+      ref: refField
+        .describe(
+          'A runtime resource ref returned by another tool. Provide ref on its own, without path/offset/limit.',
+        )
+        .optional(),
+    })
+    .describe(
+      'Read a file with path (optionally offset/limit), or a whole runtime resource with ref; provide exactly one of path or ref.',
+    );
+  const providerReadSchema = zodSchema(providerReadParameters);
   const readParameters = options.runtimeResources
-    ? jsonSchema(
-        async () => ({
-          ...(await strictReadProviderSchema.jsonSchema),
-          type: 'object',
-        }),
-        {
-          validate: async (value) => {
-            const result = await strictReadParameters.safeParseAsync(value);
-            return result.success
-              ? { success: true, value: result.data }
-              : { success: false, error: result.error };
-          },
+    ? jsonSchema(async () => await providerReadSchema.jsonSchema, {
+        validate: async (value) => {
+          const result = await strictReadParameters.safeParseAsync(value);
+          return result.success
+            ? { success: true, value: result.data }
+            : { success: false, error: result.error };
         },
-      )
+      })
     : fileReadParameters;
   const shell = options.shell ?? defaultShellPlan();
   const sandboxPlatform = options.sandboxPlatform ?? process.platform;


### PR DESCRIPTION
## Problem

On `main`, the built-in `Read` tool emits a provider-facing JSON Schema with both `type: "object"` and a top-level `anyOf` whenever runtime-resource reads are enabled. Anthropic rejects that tool definition before inference — a regression from #1124 restoring the strict file-vs-ref union directly in the provider schema.

## Fix

Separate the two contracts that were conflated:

- **Provider schema** — derived from the same field definitions, but a single top-level object with `path` / `offset` / `limit` / `ref` all optional and their mutual exclusivity stated in the descriptions. No top-level union combinator.
- **Runtime validator** — the strict file-vs-ref Zod union stays authoritative via `jsonSchema(..., { validate })`, so exactly `{ path, offset?, limit? }` or `{ ref }` is accepted and empty / mixed / malformed inputs are rejected.

Wire shape is now object-rooted with no top-level `anyOf`/`oneOf`/`allOf`.

## Verification

- Regression test replaces the `anyOf` expectation with assertions for an object-rooted, union-free provider schema (properties = path/offset/limit/ref) plus the existing strict validation cases (path/ref accepted; empty and mixed rejected).
- `builtin-tools` suite green; `@maka/runtime` builds against current `main`.

Fixes #1228.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
