### PR TITLE
feat: wire hosts to shared tool catalog (#1099 S2)

### DIFF
--- a/apps/desktop/src/main/__tests__/agent-swarm-host-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/agent-swarm-host-contract.test.ts
@@ -29,15 +29,37 @@ describe('AgentSwarm host registration contract', () => {
     }
   });
 
-  test('all hosts use the shared deferred Agent group contract', async () => {
-    const [desktop, cli, headless] = await Promise.all([
+  test('all hosts derive deferred groups from the shared catalog', async () => {
+    const [desktop, cli, headless, catalog] = await Promise.all([
       readFile(resolve(REPO_ROOT, 'apps/desktop/src/main/main.ts'), 'utf8'),
       readFile(resolve(REPO_ROOT, 'packages/cli/src/runtime-bootstrap.ts'), 'utf8'),
       readFile(resolve(REPO_ROOT, 'packages/headless/src/tools.ts'), 'utf8'),
+      readFile(resolve(REPO_ROOT, 'packages/core/src/tool-catalog.ts'), 'utf8'),
     ]);
 
-    assert.match(desktop, /buildSubagentToolGroup\(\)/);
-    assert.match(cli, /groups: \[buildSubagentToolGroup\(\)\]/);
-    assert.match(headless, /groups: \[buildSubagentToolGroup\(\)\]/);
+    // Agent pack identity stays owned by the catalog (matches AGENT_TOOL_GROUP_ID).
+    assert.match(catalog, /id:\s*'agent'/);
+    assert.match(catalog, /toolNames:\s*\[[\s\S]*'agent_spawn'[\s\S]*'agent_swarm'/);
+
+    assert.match(
+      desktop,
+      /groups:\s*buildDeferredToolGroupsFromCatalog\(\s*'desktop'/,
+    );
+    assert.match(
+      cli,
+      /groups:\s*buildDeferredToolGroupsFromCatalog\(\s*'cli'/,
+    );
+    assert.match(
+      headless,
+      /groups:\s*buildDeferredToolGroupsFromCatalog\(\s*'headless'/,
+    );
+
+    for (const source of [desktop, cli, headless]) {
+      assert.doesNotMatch(
+        source,
+        /buildSubagentToolGroup\(/,
+        'hosts must project deferred groups from the catalog, not hand-list buildSubagentToolGroup',
+      );
+    }
   });
 });

--- a/apps/desktop/src/main/__tests__/computer-use-capability.test.ts
+++ b/apps/desktop/src/main/__tests__/computer-use-capability.test.ts
@@ -8,12 +8,17 @@ const ROOT = resolve(process.cwd(), '..', '..');
 
 describe('Desktop Computer Use production wiring', () => {
   it('registers the function harness without presentation or provider adapters', async () => {
-    const main = await readMainProcessCombinedSource();
+    const [main, catalog] = await Promise.all([
+      readMainProcessCombinedSource(),
+      readFile(resolve(ROOT, 'packages/core/src/tool-catalog.ts'), 'utf8'),
+    ]);
     assert.match(main, /createComputerUseHost/);
     assert.match(main, /createCursorOverlayController/);
     assert.match(main, /createComputerUseOverlayHook/);
     assert.match(main, /computerUseTools/);
-    assert.match(main, /id:\s*'computer_use'/);
+    // Deferred group identity lives in the shared catalog; desktop derives it.
+    assert.match(catalog, /id:\s*'computer_use'/);
+    assert.match(main, /buildDeferredToolGroupsFromCatalog\(\s*'desktop'/);
     assert.doesNotMatch(main, /createAnthropicComputerHarness|createKimiComputerHarness|createMiniMaxComputerHarness/);
   });
 

--- a/apps/desktop/src/main/__tests__/permission-response-ipc-boundary.test.ts
+++ b/apps/desktop/src/main/__tests__/permission-response-ipc-boundary.test.ts
@@ -33,11 +33,18 @@ describe('permission response IPC boundary', () => {
   it('registers AskUserQuestion only on the Desktop root tool surface and routes its response', async () => {
     const mainPath = fileURLToPath(new URL('../../../src/main/main.ts', import.meta.url));
     const main = await readMainProcessCombinedSource();
-    const rootTools = main.match(/const builtinTools: MakaTool\[\] = \[[\s\S]*?\n\];/)?.[0] ?? '';
+    // Root surface is assembled as toolsBeforeSkill + Skill + toolsAfterSkill → builtinTools.
+    const rootBeforeSkill =
+      main.match(/const toolsBeforeSkill: MakaTool\[\] = \[[\s\S]*?\n\];/)?.[0] ?? '';
+    const rootBuiltin =
+      main.match(
+        /const builtinTools: MakaTool\[\] = \[\.\.\.toolsBeforeSkill, skillTool, \.\.\.toolsAfterSkill\];/,
+      )?.[0] ?? '';
     const childTools = main.match(/const childAgentTools = buildChildAgentTools\([\s\S]*?\n\]\);/)?.[0] ?? '';
     const handler = main.match(/ipcMain\.handle\('sessions:respondToUserQuestion'[\s\S]*?\n  \}\);/)?.[0] ?? '';
 
-    assert.match(rootTools, /buildAskUserQuestionTool\(\)/);
+    assert.match(rootBeforeSkill, /buildAskUserQuestionTool\(\)/);
+    assert.match(rootBuiltin, /toolsBeforeSkill/);
     assert.doesNotMatch(childTools, /buildAskUserQuestionTool\(\)/);
     assert.match(handler, /const normalized = normalizeUserQuestionResponse\(response\)/);
     assert.match(handler, /await ensureSessionWorkspaceAvailable\(sessionId\)/);

--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -56,7 +56,9 @@ import {
   buildAgentTeamLeadTools,
   buildExpertDispatchToolForTeamId,
   buildParentAgentTools,
-  buildSubagentToolGroup,
+  assertProductBindingCatalogClean,
+  buildDeferredToolGroupsFromCatalog,
+  buildHostCapabilitiesFromBinding,
   createLocalContinuationSafetyInspector,
   getAIModel,
   generateSessionTitle as generateRuntimeSessionTitle,
@@ -558,13 +560,6 @@ const localMemory = new LocalMemoryService({
   updateSettings: (patch) => settingsStore.update(patch),
   getPrivacyContext: getWorkspacePrivacyContext,
 });
-const systemPromptService = createSystemPromptMainService({
-  settingsStore,
-  workspaceRoot,
-  localMemory,
-  taskLedger: taskLedgerStore,
-  goalManager: goalWiring.manager,
-});
 // Window is created hidden for E2E and visual-smoke runs so it never steals
 // focus. Derived from the same isE2e gate as userData/fake-backend so the
 // hidden-window switch stays in lockstep with the rest of the E2E isolation.
@@ -720,28 +715,13 @@ const deferredTools: MakaTool[] = [
   ...computerUseTools,
   ...agentTools,
 ];
-const toolAvailability: ToolAvailabilityConfig = {
-  economy: economyEnabled,
-  groups: [
-    { id: 'rive', label: 'Rive', description: 'Durable multi-agent Rive workflows: validate/import/run/status, scheduler, retries.', toolNames: riveTools.map((tool) => tool.name) },
-    { id: 'office', label: 'Office', description: 'Read and edit Office documents (Word, Excel, PowerPoint, PDF).', toolNames: officeTools.map((tool) => tool.name) },
-    { id: 'browser', label: 'Browser', description: 'Drive the embedded browser: navigate, snapshot, click, type, wait, extract.', toolNames: browserTools.map((tool) => tool.name) },
-    ...(computerUseTools.length > 0
-      ? [{
-          id: 'computer_use',
-          label: 'Computer',
-          description: 'Observe and operate an explicitly approved local application.',
-          toolNames: computerUseTools.map((tool) => tool.name),
-        }]
-      : []),
-    buildSubagentToolGroup(),
-  ],
-};
 const webSearchTool = buildWebSearchAgentTool({
   settingsStore,
   getPrivacyContext: getWorkspacePrivacyContext,
 });
-const builtinTools: MakaTool[] = [
+// Assemble product tools first, then derive skill host + deferred groups from
+// the shared catalog ∩ this binding (#1099 S2). Skill listing uses the same host.
+const toolsBeforeSkill: MakaTool[] = [
   buildAskUserQuestionTool(),
   ...buildBuiltinTools({
     shellRuns,
@@ -756,12 +736,8 @@ const builtinTools: MakaTool[] = [
       enableFileToolAdditionalPermissions: true,
     } : {}),
   }).filter((tool: MakaTool) => tool.name !== 'Edit'),
-  // External reference lazy-skill pattern: the prompt lists available skills,
-  // and this read-only tool loads the full SKILL.md only when the task matches.
-  // Resolve per-call from the session cwd so skills at all 5 standard paths
-  // (cwd/.maka, cwd/.agents, workspaceRoot/skills, ~/.maka, ~/.agents) are
-  // discovered — matching the CLI and the Agent Skills spec (#1068).
-  buildSkillAgentTool(({ cwd }) => resolveSkillDiscoveryPaths(cwd, workspaceRoot)),
+];
+const toolsAfterSkill: MakaTool[] = [
   // External reference plan-mode borrow: a bounded read-only local worker for
   // self-contained code/repo investigations. The tool advertises the
   // `subagent` category; explore mode allows it, but the implementation
@@ -783,6 +759,37 @@ const builtinTools: MakaTool[] = [
   // group tools just need to be present so they are dispatchable once loaded.
   ...deferredTools,
 ];
+// Always-on Skill name is part of the host surface even before the tool instance
+// is built (so requiredTools gates and capability tags stay complete).
+const desktopBoundToolNames = [
+  ...toolsBeforeSkill.map((tool) => tool.name),
+  'Skill',
+  ...toolsAfterSkill.map((tool) => tool.name),
+];
+assertProductBindingCatalogClean('desktop', desktopBoundToolNames);
+const desktopHostCapabilities = buildHostCapabilitiesFromBinding(desktopBoundToolNames);
+// External reference lazy-skill pattern: the prompt lists available skills,
+// and this read-only tool loads the full SKILL.md only when the task matches.
+// Resolve per-call from the session cwd so skills at all 5 standard paths
+// (cwd/.maka, cwd/.agents, workspaceRoot/skills, ~/.maka, ~/.agents) are
+// discovered — matching the CLI and the Agent Skills spec (#1068).
+const skillTool = buildSkillAgentTool(
+  ({ cwd }) => resolveSkillDiscoveryPaths(cwd, workspaceRoot),
+  desktopHostCapabilities,
+);
+const builtinTools: MakaTool[] = [...toolsBeforeSkill, skillTool, ...toolsAfterSkill];
+const toolAvailability: ToolAvailabilityConfig = {
+  economy: economyEnabled,
+  groups: buildDeferredToolGroupsFromCatalog('desktop', desktopBoundToolNames),
+};
+const systemPromptService = createSystemPromptMainService({
+  settingsStore,
+  workspaceRoot,
+  localMemory,
+  taskLedger: taskLedgerStore,
+  goalManager: goalWiring.manager,
+  hostCapabilities: desktopHostCapabilities,
+});
 // Child agents stay file-only for local reads; parent runtime refs such as
 // maka://runtime/background-tasks/<id> are not part of their tool surface.
 const childAgentTools = buildChildAgentTools([

--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -59,6 +59,7 @@ import {
   assertProductBindingCatalogClean,
   buildDeferredToolGroupsFromCatalog,
   buildHostCapabilitiesFromBinding,
+  SKILL_TOOL_NAME,
   createLocalContinuationSafetyInspector,
   getAIModel,
   generateSessionTitle as generateRuntimeSessionTitle,
@@ -763,7 +764,7 @@ const toolsAfterSkill: MakaTool[] = [
 // is built (so requiredTools gates and capability tags stay complete).
 const desktopBoundToolNames = [
   ...toolsBeforeSkill.map((tool) => tool.name),
-  'Skill',
+  SKILL_TOOL_NAME,
   ...toolsAfterSkill.map((tool) => tool.name),
 ];
 assertProductBindingCatalogClean('desktop', desktopBoundToolNames);

--- a/apps/desktop/src/main/system-prompt-main.ts
+++ b/apps/desktop/src/main/system-prompt-main.ts
@@ -20,6 +20,7 @@ import {
   buildSessionEnvironmentPromptFragment,
   resolveSkillDiscoveryPaths,
   type GoalManager,
+  type HostCapabilities,
 } from '@maka/runtime';
 import { buildSkillsPromptFragment } from './skills.js';
 import { buildWorkspaceInstructionsPromptFragment } from './workspace-instructions.js';
@@ -35,6 +36,8 @@ interface SystemPromptMainDeps {
   localMemory: Pick<LocalMemoryService, 'getState' | 'consumePendingPromptUpdates'>;
   taskLedger: Pick<TaskLedgerStore, 'list'>;
   goalManager?: Pick<GoalManager, 'get'>;
+  /** Binding-derived skill host gate (#1099 S2). */
+  hostCapabilities?: HostCapabilities;
 }
 
 interface SkillPromptBudgetContext {
@@ -53,7 +56,11 @@ export function createSystemPromptMainService(deps: SystemPromptMainDeps) {
       ? buildPersonalizationPromptFragment(settings.personalization)
       : { text: undefined };
     const skillSource = resolveSkillDiscoveryPaths(cwd ?? deps.workspaceRoot, deps.workspaceRoot);
-    const skills = await buildSkillsPromptFragment(skillSource, undefined, options?.skillBudget);
+    const skills = await buildSkillsPromptFragment(
+      skillSource,
+      deps.hostCapabilities,
+      options?.skillBudget,
+    );
     const workspaceInstructions = settings.workspaceInstructions.enabled && cwd
       ? await buildWorkspaceInstructionsPromptFragment(cwd)
       : undefined;

--- a/packages/cli/src/runtime-bootstrap.ts
+++ b/packages/cli/src/runtime-bootstrap.ts
@@ -24,6 +24,7 @@ import {
   FilesystemWorkerClient,
   buildDefaultContextBudgetPolicy,
   buildSkillAgentTool,
+  SKILL_TOOL_NAME,
   buildGoalTools,
   buildParentAgentTools,
   assertProductBindingCatalogClean,
@@ -520,7 +521,7 @@ export async function createMakaCliRuntimeContext(
     ...surfaceTools,
   ].map((tool) => tool.name);
   // Skill is always registered on this host; include it before the instance exists.
-  const cliBoundToolNamesWithSkill = [...cliBoundToolNames, 'Skill'];
+  const cliBoundToolNamesWithSkill = [...cliBoundToolNames, SKILL_TOOL_NAME];
   assertProductBindingCatalogClean('cli', cliBoundToolNamesWithSkill);
   const host: HostCapabilities = buildHostCapabilitiesFromBinding(cliBoundToolNamesWithSkill);
   const toolAvailability: ToolAvailabilityConfig | undefined =

--- a/packages/cli/src/runtime-bootstrap.ts
+++ b/packages/cli/src/runtime-bootstrap.ts
@@ -26,7 +26,9 @@ import {
   buildSkillAgentTool,
   buildGoalTools,
   buildParentAgentTools,
-  buildSubagentToolGroup,
+  assertProductBindingCatalogClean,
+  buildDeferredToolGroupsFromCatalog,
+  buildHostCapabilitiesFromBinding,
   buildLlmHistorySummarizer,
   cleanupLegacyHistoryCompactArtifacts,
   buildProviderOptions,
@@ -503,25 +505,31 @@ export async function createMakaCliRuntimeContext(
         })
       : [];
   const subagentTools = input.surface === 'tui' ? buildParentAgentTools() : [];
-  const toolAvailability: ToolAvailabilityConfig | undefined =
-    input.surface === 'tui'
-      ? {
-          economy: !process.env.MAKA_DISABLE_DEFERRED_TOOLS,
-          groups: [buildSubagentToolGroup()],
-        }
-      : undefined;
   // CLI host capability surface for the skill-compatibility gate: the tool
   // names registered on this host. The CLI has no Office tools, so bundled
   // Office skills (requiredTools includes OfficeDocument/OfficeDocumentEdit)
   // are hard-hidden here without seeding them — desktop owns Office seeding.
+  // Catalog ∩ binding (#1099 S2): capability tags and deferred groups come from
+  // the shared catalog rather than a parallel hand list.
   const surfaceTools = input.surface === 'tui' ? [buildAskUserQuestionTool()] : [];
-  const host: HostCapabilities = {
-    toolNames: new Set(
-      [...tools, automationTool, ...goalTools, ...subagentTools, ...surfaceTools].map(
-        (tool) => tool.name,
-      ),
-    ),
-  };
+  const cliBoundToolNames = [
+    ...tools,
+    automationTool,
+    ...goalTools,
+    ...subagentTools,
+    ...surfaceTools,
+  ].map((tool) => tool.name);
+  // Skill is always registered on this host; include it before the instance exists.
+  const cliBoundToolNamesWithSkill = [...cliBoundToolNames, 'Skill'];
+  assertProductBindingCatalogClean('cli', cliBoundToolNamesWithSkill);
+  const host: HostCapabilities = buildHostCapabilitiesFromBinding(cliBoundToolNamesWithSkill);
+  const toolAvailability: ToolAvailabilityConfig | undefined =
+    input.surface === 'tui'
+      ? {
+          economy: !process.env.MAKA_DISABLE_DEFERRED_TOOLS,
+          groups: buildDeferredToolGroupsFromCatalog('cli', cliBoundToolNamesWithSkill),
+        }
+      : undefined;
   const skillTool = buildSkillAgentTool(
     ({ cwd }) => resolveSkillDiscoveryPaths(cwd, input.workspaceRoot),
     host,

--- a/packages/core/src/tool-catalog.ts
+++ b/packages/core/src/tool-catalog.ts
@@ -126,7 +126,7 @@ export const MAKA_CATALOG_TOOLS: readonly CatalogToolDef[] = Object.freeze(
     { name: 'maka_computer' },
     // rive surface
     { name: 'RiveWorkflow' },
-    // agent surface (id matches AGENT_TOOL_GROUP_ID / buildSubagentToolGroup)
+    // agent surface (id matches AGENT_TOOL_GROUP_ID)
     { name: 'agent_spawn' },
     { name: 'agent_swarm' },
     { name: 'agent_list' },
@@ -135,8 +135,8 @@ export const MAKA_CATALOG_TOOLS: readonly CatalogToolDef[] = Object.freeze(
 );
 
 /**
- * Jointly governed deferred packs. Id `agent` matches the existing
- * ToolAvailability group (`buildSubagentToolGroup`), not a separate "subagent" id.
+ * Jointly governed deferred packs. Id `agent` matches the runtime
+ * ToolAvailability group id (AGENT_TOOL_GROUP_ID), not a separate "subagent" id.
  * Each surface gets its own hosts object so affinity cannot cross-contaminate.
  */
 export const MAKA_CATALOG_SURFACES: readonly CatalogSurfaceDef[] = Object.freeze(

--- a/packages/core/src/tool-catalog.ts
+++ b/packages/core/src/tool-catalog.ts
@@ -142,6 +142,15 @@ export const MAKA_CATALOG_TOOLS: readonly CatalogToolDef[] = Object.freeze(
 export const MAKA_CATALOG_SURFACES: readonly CatalogSurfaceDef[] = Object.freeze(
   [
     {
+      id: 'rive',
+      label: 'Rive',
+      description:
+        'Durable multi-agent Rive workflows: validate/import/run/status, scheduler, retries.',
+      economy: 'deferred' as const,
+      toolNames: ['RiveWorkflow'],
+      hosts: desktopOnlyHosts(),
+    },
+    {
       id: 'office',
       label: 'Office',
       description: 'Read and edit Office documents (Word, Excel, PowerPoint, PDF).',
@@ -170,15 +179,6 @@ export const MAKA_CATALOG_SURFACES: readonly CatalogSurfaceDef[] = Object.freeze
       description: 'Observe and operate an explicitly approved local application.',
       economy: 'deferred' as const,
       toolNames: ['maka_computer'],
-      hosts: desktopOnlyHosts(),
-    },
-    {
-      id: 'rive',
-      label: 'Rive',
-      description:
-        'Durable multi-agent Rive workflows: validate/import/run/status, scheduler, retries.',
-      economy: 'deferred' as const,
-      toolNames: ['RiveWorkflow'],
       hosts: desktopOnlyHosts(),
     },
     {

--- a/packages/headless/README.md
+++ b/packages/headless/README.md
@@ -86,11 +86,14 @@ await runExperiment(config, task, {
     toolExecutor: executor,
   },
   registerBackends(registry, context) {
-    registry.register('ai-sdk', (ctx) => createAiSdkBackend({
-      ...ctx,
-      tools: [...(ctx.tools ?? buildIsolatedHeadlessTools(context.toolExecutor!))],
-      toolAvailability: buildIsolatedHeadlessToolAvailability(),
-    }));
+    registry.register('ai-sdk', (ctx) => {
+      const tools = [...(ctx.tools ?? buildIsolatedHeadlessTools(context.toolExecutor!))];
+      return createAiSdkBackend({
+        ...ctx,
+        tools,
+        toolAvailability: buildIsolatedHeadlessToolAvailability(tools.map((tool) => tool.name)),
+      });
+    });
   },
 });
 ```

--- a/packages/headless/src/__tests__/tools.test.ts
+++ b/packages/headless/src/__tests__/tools.test.ts
@@ -1593,7 +1593,7 @@ describe('isolated headless tools', () => {
 
     assert.ok(
       readme.includes(
-        'tools: [...(ctx.tools ?? buildIsolatedHeadlessTools(context.toolExecutor!))],',
+        'const tools = [...(ctx.tools ?? buildIsolatedHeadlessTools(context.toolExecutor!))];',
       ),
     );
   });

--- a/packages/headless/src/__tests__/tools.test.ts
+++ b/packages/headless/src/__tests__/tools.test.ts
@@ -1535,12 +1535,16 @@ describe('isolated headless tools', () => {
         return { exitCode: 0, stdout: '', stderr: '' };
       },
     });
-    const plan = new ToolAvailabilityRuntime(tools, buildIsolatedHeadlessToolAvailability(), {
-      name: 'invalid',
-      description: 'invalid',
-      parameters: {},
-      impl: () => ({}),
-    }).prepare([]);
+    const plan = new ToolAvailabilityRuntime(
+      tools,
+      buildIsolatedHeadlessToolAvailability(tools.map((tool) => tool.name)),
+      {
+        name: 'invalid',
+        description: 'invalid',
+        parameters: {},
+        impl: () => ({}),
+      },
+    ).prepare([]);
 
     assert.ok(plan.activeTools.includes('Bash'));
     assert.ok(plan.activeTools.includes('Read'));
@@ -1566,12 +1570,16 @@ describe('isolated headless tools', () => {
       },
     });
     const childTools = buildChildAgentTools(parentTools);
-    const plan = new ToolAvailabilityRuntime(childTools, buildIsolatedHeadlessToolAvailability(), {
-      name: 'invalid',
-      description: 'invalid',
-      parameters: {},
-      impl: () => ({}),
-    }).prepare([]);
+    const plan = new ToolAvailabilityRuntime(
+      childTools,
+      buildIsolatedHeadlessToolAvailability(parentTools.map((tool) => tool.name)),
+      {
+        name: 'invalid',
+        description: 'invalid',
+        parameters: {},
+        impl: () => ({}),
+      },
+    ).prepare([]);
 
     assert.deepEqual([...plan.activeTools].sort(), ['Glob', 'Grep', 'Read']);
     assert.equal(plan.prepareStep, undefined);

--- a/packages/headless/src/harbor-cell.ts
+++ b/packages/headless/src/harbor-cell.ts
@@ -742,6 +742,14 @@ export function buildAiSdkCellBackendRegistration(input: {
         sessionId: ctx.sessionId,
         modelId: input.model,
       });
+      const tools = buildHarborCellAiSdkTools(context.toolExecutor!, {
+        ...(context.heavyTaskEvidence ? { heavyTaskEvidence: context.heavyTaskEvidence } : {}),
+        ...(context.heavyTaskProgress ? { heavyTaskProgress: context.heavyTaskProgress } : {}),
+        ...(context.heavyTaskSelfCheck ? { heavyTaskSelfCheck: context.heavyTaskSelfCheck } : {}),
+        ...(taskLedgerExperimentStore && taskLedgerExperimentPolicy
+          ? { taskLedgerExperiment: { store: taskLedgerExperimentStore } }
+          : {}),
+      });
       return new AiSdkBackend({
         sessionId: ctx.sessionId,
         header: { ...ctx.header, model: input.model },
@@ -756,15 +764,8 @@ export function buildAiSdkCellBackendRegistration(input: {
             ...modelInput,
             ...(subscriptionFetch ? { fetch: subscriptionFetch } : {}),
           }),
-        tools: buildHarborCellAiSdkTools(context.toolExecutor!, {
-          ...(context.heavyTaskEvidence ? { heavyTaskEvidence: context.heavyTaskEvidence } : {}),
-          ...(context.heavyTaskProgress ? { heavyTaskProgress: context.heavyTaskProgress } : {}),
-          ...(context.heavyTaskSelfCheck ? { heavyTaskSelfCheck: context.heavyTaskSelfCheck } : {}),
-          ...(taskLedgerExperimentStore && taskLedgerExperimentPolicy
-            ? { taskLedgerExperiment: { store: taskLedgerExperimentStore } }
-            : {}),
-        }),
-        toolAvailability: buildIsolatedHeadlessToolAvailability(),
+        tools,
+        toolAvailability: buildIsolatedHeadlessToolAvailability(tools.map((tool) => tool.name)),
         spawnChildAgent: context.spawnChildAgent
           ? (childInput) => context.spawnChildAgent!(ctx.sessionId, childInput)
           : undefined,

--- a/packages/headless/src/tools.ts
+++ b/packages/headless/src/tools.ts
@@ -1,9 +1,10 @@
 import type { MakaTool, ToolAvailabilityConfig } from '@maka/runtime';
 import {
+  assertProductBindingCatalogClean,
   bashToolShellGuidance,
+  buildDeferredToolGroupsFromCatalog,
   buildForegroundBashTool,
   buildParentAgentTools,
-  buildSubagentToolGroup,
   computeEditedSource,
 } from '@maka/runtime';
 import { withFileWriteLock } from '@maka/runtime/file-write-lock';
@@ -12,15 +13,18 @@ import { posix as pathPosix } from 'node:path';
 import { z } from 'zod';
 import type { HeavyTaskEvidenceRecorder } from './heavy-task-evidence.js';
 import {
+  HEAVY_TASK_PROGRESS_TOOL_NAMES,
   buildHeavyTaskProgressTools,
   type HeavyTaskProgressRecorder,
 } from './heavy-task-progress.js';
 import {
+  HEAVY_TASK_SELF_CHECK_TOOL_NAMES,
   buildHeavyTaskSelfCheckTools,
   type HeavyTaskSelfCheckRecorder,
 } from './heavy-task-self-check.js';
 import type { IsolatedToolExecutor } from './isolation.js';
 import {
+  TASK_LEDGER_EXPERIMENT_TODO_TOOL_NAMES,
   buildTaskLedgerExperimentTools,
   type TaskLedgerExperimentStore,
 } from './task-ledger-experiment.js';
@@ -53,6 +57,13 @@ const CANONICAL_BASE64_PATTERN = /^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A
  * Build Maka's standard headless tool surface with shell and file operations
  * routed through the isolated executor boundary.
  */
+/** Harness / benchmark experiment tools — not product catalog vocabulary. */
+const HEADLESS_EXPERIMENT_TOOL_NAMES = new Set<string>([
+  ...HEAVY_TASK_PROGRESS_TOOL_NAMES,
+  ...HEAVY_TASK_SELF_CHECK_TOOL_NAMES,
+  ...TASK_LEDGER_EXPERIMENT_TODO_TOOL_NAMES,
+]);
+
 export function buildIsolatedHeadlessTools(
   executor: IsolatedToolExecutor,
   options: BuildIsolatedHeadlessToolsOptions = {},
@@ -66,6 +77,12 @@ export function buildIsolatedHeadlessTools(
     buildIsolatedGrepTool(executor, options),
     ...buildParentAgentTools(),
   ];
+  // Product tools must stay catalog-clean (#1099 S2). Experiment packs below
+  // are harness-only and intentionally outside the product vocabulary.
+  assertProductBindingCatalogClean(
+    'headless',
+    tools.map((tool) => tool.name),
+  );
   if (options.heavyTaskProgress) {
     tools.push(...buildHeavyTaskProgressTools(options.heavyTaskProgress));
   }
@@ -78,10 +95,19 @@ export function buildIsolatedHeadlessTools(
   return tools;
 }
 
-export function buildIsolatedHeadlessToolAvailability(): ToolAvailabilityConfig {
+/**
+ * Deferred groups from catalog ∩ bound product tools. Affinity-unsupported
+ * packs never appear. Optional experiment tools are ignored for derivation.
+ */
+export function buildIsolatedHeadlessToolAvailability(
+  boundToolNames?: Iterable<string>,
+): ToolAvailabilityConfig {
+  const productNames = boundToolNames
+    ? [...boundToolNames].filter((name) => !HEADLESS_EXPERIMENT_TOOL_NAMES.has(name))
+    : ['agent_spawn', 'agent_swarm', 'agent_list', 'agent_output'];
   return {
     economy: true,
-    groups: [buildSubagentToolGroup()],
+    groups: buildDeferredToolGroupsFromCatalog('headless', productNames),
   };
 }
 

--- a/packages/headless/src/tools.ts
+++ b/packages/headless/src/tools.ts
@@ -77,12 +77,6 @@ export function buildIsolatedHeadlessTools(
     buildIsolatedGrepTool(executor, options),
     ...buildParentAgentTools(),
   ];
-  // Product tools must stay catalog-clean (#1099 S2). Experiment packs below
-  // are harness-only and intentionally outside the product vocabulary.
-  assertProductBindingCatalogClean(
-    'headless',
-    tools.map((tool) => tool.name),
-  );
   if (options.heavyTaskProgress) {
     tools.push(...buildHeavyTaskProgressTools(options.heavyTaskProgress));
   }
@@ -92,22 +86,27 @@ export function buildIsolatedHeadlessTools(
   if (options.taskLedgerExperiment) {
     tools.push(...buildTaskLedgerExperimentTools(options.taskLedgerExperiment));
   }
+  // Product tools must stay catalog-clean (#1099 S2). Experiment packs are
+  // harness-only and intentionally outside the product vocabulary, so exclude
+  // them from the cleanliness check (the catalog derive ignores them anyway).
+  assertProductBindingCatalogClean(
+    'headless',
+    tools.map((tool) => tool.name).filter((name) => !HEADLESS_EXPERIMENT_TOOL_NAMES.has(name)),
+  );
   return tools;
 }
 
 /**
  * Deferred groups from catalog ∩ bound product tools. Affinity-unsupported
- * packs never appear. Optional experiment tools are ignored for derivation.
+ * packs never appear; harness experiment names are not catalog members, so
+ * the catalog derive ignores them without an explicit filter.
  */
 export function buildIsolatedHeadlessToolAvailability(
-  boundToolNames?: Iterable<string>,
+  boundToolNames: Iterable<string>,
 ): ToolAvailabilityConfig {
-  const productNames = boundToolNames
-    ? [...boundToolNames].filter((name) => !HEADLESS_EXPERIMENT_TOOL_NAMES.has(name))
-    : ['agent_spawn', 'agent_swarm', 'agent_list', 'agent_output'];
   return {
     economy: true,
-    groups: buildDeferredToolGroupsFromCatalog('headless', productNames),
+    groups: buildDeferredToolGroupsFromCatalog('headless', boundToolNames),
   };
 }
 

--- a/packages/runtime/src/__tests__/deferred-tools-backend.test.ts
+++ b/packages/runtime/src/__tests__/deferred-tools-backend.test.ts
@@ -22,9 +22,10 @@ import {
   AGENT_LIST_TOOL_NAME,
   AGENT_OUTPUT_TOOL_NAME,
   AGENT_SPAWN_TOOL_NAME,
+  AGENT_TOOL_NAMES,
   buildParentAgentTools,
-  buildSubagentToolGroup,
 } from '../subagent-tools.js';
+import { buildDeferredToolGroupsFromCatalog } from '../tool-catalog-derive.js';
 
 // End-to-end through the live AiSdkBackend: the availability config drives the
 // per-step prepareStep activation, the durable seed reconstructs prior-turn
@@ -42,7 +43,7 @@ const config: ToolAvailabilityConfig = {
 
 const agentConfig: ToolAvailabilityConfig = {
   economy: true,
-  groups: [buildSubagentToolGroup()],
+  groups: buildDeferredToolGroupsFromCatalog('headless', AGENT_TOOL_NAMES),
 };
 
 function tools(implCalls: string[]): MakaTool[] {

--- a/packages/runtime/src/__tests__/subagent-tools.test.ts
+++ b/packages/runtime/src/__tests__/subagent-tools.test.ts
@@ -36,8 +36,6 @@ import {
 } from '../agent-catalog.js';
 import { AGENT_SWARM_TOOL_NAME } from '../agent-swarm-tools.js';
 import {
-  AGENT_TOOL_GROUP_ID,
-  AGENT_TOOL_NAMES,
   AGENT_LIST_TOOL_NAME,
   AGENT_OUTPUT_TOOL_NAME,
   AGENT_SPAWN_TOOL_NAME,
@@ -47,26 +45,12 @@ import {
   buildSubagentListTool,
   buildSubagentOutputTool,
   buildSubagentSpawnTool,
-  buildSubagentToolGroup,
 } from '../subagent-tools.js';
 import { ToolRuntime, type MakaTool } from '../tool-runtime.js';
 import { expect } from '../test-helpers.js';
 
 describe('subagent tools', () => {
-  test('agent deferred group declares the parent-facing agent tools only', () => {
-    const group = buildSubagentToolGroup();
-
-    expect(group.id).toBe(AGENT_TOOL_GROUP_ID);
-    expect(group.label).toBe('Agent');
-    expect([...group.toolNames]).toEqual([...AGENT_TOOL_NAMES]);
-    expect([...group.toolNames]).toEqual([
-      AGENT_SPAWN_TOOL_NAME,
-      AGENT_SWARM_TOOL_NAME,
-      AGENT_LIST_TOOL_NAME,
-      AGENT_OUTPUT_TOOL_NAME,
-    ]);
-    expect(group.description).toMatch(/Spawn, fan out, and inspect/);
-
+  test('parent-facing agent tools declare permission hints and names', () => {
     const spawnTool = buildSubagentSpawnTool();
     expect(spawnTool.permissionRequired).toBe(true);
     expect(spawnTool.categoryHint).toBe('subagent');

--- a/packages/runtime/src/__tests__/tool-catalog-derive.test.ts
+++ b/packages/runtime/src/__tests__/tool-catalog-derive.test.ts
@@ -1,6 +1,7 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 import {
+  assertProductBindingCatalogClean,
   buildDeferredToolGroupsFromCatalog,
   buildHostCapabilitiesFromBinding,
 } from '../tool-catalog-derive.js';
@@ -63,5 +64,20 @@ describe('buildDeferredToolGroupsFromCatalog', () => {
   it('returns no group when a supported surface has zero bound members', () => {
     const groups = buildDeferredToolGroupsFromCatalog('desktop', ['Read', 'Bash']);
     assert.deepEqual(groups, []);
+  });
+});
+
+describe('assertProductBindingCatalogClean', () => {
+  it('accepts catalog product names and ignores mcp__ tools', () => {
+    assert.doesNotThrow(() =>
+      assertProductBindingCatalogClean('test', ['Read', 'Bash', 'mcp__server__tool']),
+    );
+  });
+
+  it('throws when a product name is missing from the catalog', () => {
+    assert.throws(
+      () => assertProductBindingCatalogClean('cli', ['Read', 'NotARealTool']),
+      /cli: bound product tools missing from catalog: NotARealTool/,
+    );
   });
 });

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -1060,6 +1060,7 @@ export type {
 
 // tool-catalog-derive.ts — HostCapabilities + deferred groups from catalog ∩ binding (#1099).
 export {
+  assertProductBindingCatalogClean,
   buildDeferredToolGroupsFromCatalog,
   buildHostCapabilitiesFromBinding,
 } from './tool-catalog-derive.js';

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -455,7 +455,6 @@ export {
   buildParentAgentTools,
   buildSubagentProjectionTools,
   buildSubagentSpawnTool,
-  buildSubagentToolGroup,
 } from './subagent-tools.js';
 export {
   BUILTIN_EXPERT_TEAMS,

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -1198,6 +1198,7 @@ export {
   buildSkillsPromptFragment,
   loadSkillInstructions,
   buildSkillAgentTool,
+  SKILL_TOOL_NAME,
   gateSkillsByHostCapabilities,
   parseSkillFrontMatter,
   validateSkillMetadata,

--- a/packages/runtime/src/skills.ts
+++ b/packages/runtime/src/skills.ts
@@ -631,19 +631,22 @@ export function loadSkillInstructionsFromScan(
   return { ok: false, reason: 'not_found', availableSkills };
 }
 
+/** Name of the always-on Skill tool, for hosts that bind it before the instance exists. */
+export const SKILL_TOOL_NAME = 'Skill';
+
 export function buildSkillAgentTool(
   source: SkillSource | SkillSourceResolver,
   host?: HostCapabilities,
 ): MakaTool<{ name: string }, LoadSkillInstructionsResult> {
   return {
-    name: 'Skill',
+    name: SKILL_TOOL_NAME,
     description:
       'Load full instructions for one available local skill by id or name. Use only after the user request matches an available skill.',
     parameters: z.object({
       name: z.string().describe('The skill id or name from the available local skills list.'),
     }),
     permissionRequired: false,
-    displayName: 'Skill',
+    displayName: SKILL_TOOL_NAME,
     impl: async ({ name }, ctx) =>
       loadSkillInstructions(typeof source === 'function' ? source(ctx) : source, name, host),
   };

--- a/packages/runtime/src/subagent-tools.ts
+++ b/packages/runtime/src/subagent-tools.ts
@@ -17,7 +17,6 @@ import {
   buildToolsForAgentDefinition,
   requireBuiltinAgentDefinitionByProfile,
 } from './agent-catalog.js';
-import type { ToolGroup } from './tool-availability.js';
 import { AGENT_TEAM_CHILD_TOOL_NAMES } from './agent-team-tool-names.js';
 import { AGENT_SWARM_TOOL_NAME, buildAgentSwarmTool } from './agent-swarm-tools.js';
 
@@ -350,13 +349,4 @@ export function buildSubagentProjectionTools(): MakaTool[] {
 
 export function buildParentAgentTools(deps: { taskLedger?: TaskLedgerStore } = {}): MakaTool[] {
   return [buildSubagentSpawnTool(deps), buildAgentSwarmTool(), ...buildSubagentProjectionTools()];
-}
-
-export function buildSubagentToolGroup(): ToolGroup {
-  return {
-    id: AGENT_TOOL_GROUP_ID,
-    label: 'Agent',
-    description: 'Spawn, fan out, and inspect foreground child agents.',
-    toolNames: AGENT_TOOL_NAMES,
-  };
 }

--- a/packages/runtime/src/tool-catalog-derive.ts
+++ b/packages/runtime/src/tool-catalog-derive.ts
@@ -1,10 +1,15 @@
 /**
  * Derive HostCapabilities and deferred ToolAvailability groups from the shared
- * tool catalog ∩ host binding (#1099 S1). Hosts still construct MakaTool
+ * tool catalog ∩ host binding (#1099). Hosts still construct MakaTool
  * instances; this module only projects names and surface metadata.
  */
 
-import { MAKA_CATALOG_SURFACES, catalogToolByName, type ToolHostId } from '@maka/core/tool-catalog';
+import {
+  MAKA_CATALOG_SURFACES,
+  catalogToolByName,
+  unknownBoundToolNames,
+  type ToolHostId,
+} from '@maka/core/tool-catalog';
 import type { HostCapabilities } from './skills.js';
 import type { ToolGroup } from './tool-availability.js';
 
@@ -48,4 +53,23 @@ export function buildDeferredToolGroupsFromCatalog(
     });
   }
   return groups;
+}
+
+/**
+ * Product-tool catalog cleanliness for host wiring (#1099 S2).
+ *
+ * MCP tools (`mcp__…`) are external and out of product-catalog scope. Harness /
+ * experiment names may be excluded by the caller before invoking this helper.
+ * Throws when any remaining bound name is missing from the catalog.
+ */
+export function assertProductBindingCatalogClean(
+  hostLabel: string,
+  boundToolNames: Iterable<string>,
+): void {
+  const productNames = [...boundToolNames].filter((name) => !name.startsWith('mcp__'));
+  const unknown = unknownBoundToolNames(productNames);
+  if (unknown.length === 0) return;
+  throw new Error(
+    `[tool-catalog] ${hostLabel}: bound product tools missing from catalog: ${unknown.join(', ')}`,
+  );
 }


### PR DESCRIPTION
## Summary

- **Runtime:** `assertProductBindingCatalogClean` so product tool names stay catalog-clean (MCP `mcp__*` ignored).
- **Desktop:** replace hand-maintained `toolAvailability.groups` with `buildDeferredToolGroupsFromCatalog`; derive `HostCapabilities` from the binding and pass it into Skill + skill listing.
- **CLI:** same derive for host capabilities and deferred groups; assert registered product names ⊆ catalog.
- **Headless:** product tools catalog-clean; deferred groups from catalog ∩ bound product tools; harness experiment tools stay outside the product vocabulary.

Permission and tool implementations are unchanged — only projections (groups / skill host gate / cleanliness) move onto catalog ∩ binding.

## Verification

- [x] `node --test packages/runtime/dist/__tests__/tool-catalog-derive.test.js` (7/7)
- [x] `node --test packages/cli/dist/__tests__/runtime-bootstrap.test.js` (17/17)
- [x] `node --test packages/headless/dist/__tests__/tools.test.js` (47/47)
- [x] desktop `tsc -p tsconfig.main.json` + `computer-use-model-tools` / `task-ledger-contract` tests
- [x] `biome check` on touched files

## Refs

Closes nothing alone — slice 2 of #1099 (after #1232). S3 is CLI `/tools`.