### PR TITLE
ci: drop redundant Runtime resume platform jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,35 +65,6 @@ jobs:
       # throw away this dist and rebuild every package a second time.
       - run: npm run test:dist
 
-  runtime-resume-platforms:
-    name: Runtime resume (${{ matrix.os }})
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-latest, macos-latest]
-    runs-on: ${{ matrix.os }}
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: '22'
-          cache: npm
-      - run: npm ci
-      - run: npm --workspace @maka/core run build
-      - run: npm --workspace @maka/storage run build
-      - run: npm --workspace @maka/runtime run build
-      - name: Durable resume contracts and crash boundaries
-        run: >-
-          node --test
-          packages/storage/dist/__tests__/sqlite-runtime-crash.test.js
-          packages/runtime/dist/__tests__/runtime-resume-crash.test.js
-          packages/runtime/dist/__tests__/runtime-continuation-crash.test.js
-          packages/runtime/dist/__tests__/runtime-resume.test.js
-          packages/runtime/dist/__tests__/runtime-continuation.test.js
-          packages/runtime/dist/__tests__/runtime-commit-sink.test.js
-          packages/runtime/dist/__tests__/tool-runtime-durable-boundary.test.js
-          packages/runtime/dist/__tests__/tool-runtime-sqlite-boundary.test.js
-
   e2e:
     runs-on: ubuntu-latest
     steps:

--- a/docs/architecture/runtime-resume-phase1-safe-boundary-contract.md
+++ b/docs/architecture/runtime-resume-phase1-safe-boundary-contract.md
@@ -160,5 +160,4 @@ The Phase 1 test surface covers:
   terminal-event committed, and terminal-header committed boundaries;
 - desktop IPC/preload/renderer/startup routing contracts;
 - CLI `/resume` routing without a duplicate prompt;
-- Linux and macOS CI jobs for the resume and crash suites;
-- the complete Phase 0 P0-P11 SIGKILL prefix harness.
+- the complete Phase 0 P0-P11 SIGKILL prefix harness (covered by the main unit-test job via package `test:dist`).


### PR DESCRIPTION
## Summary

Removes the `runtime-resume-platforms` matrix job (`Runtime resume` on ubuntu-latest and macos-latest) introduced by #1223.

- Ubuntu: the same resume/crash tests already run in the main `test` job via `npm run test:dist` (`dist/**/*.test.js` in `@maka/runtime` and `@maka/storage`).
- macOS: most developers already run these suites locally on Darwin; a dedicated CI matrix was redundant cost without unique product-gate value relative to the main Linux unit tests.
- Aligns the phase-1 contract doc so coverage is described as the main unit-test path instead of dedicated multi-OS jobs.

## Test plan

- [x] Confirm `ci.yml` no longer defines `runtime-resume-platforms`
- [ ] On PR CI: only the usual typecheck / test / e2e jobs appear; no `Runtime resume (*)` checks
- [ ] Optional local: `npm --workspace @maka/runtime run test:dist` still includes resume/crash suites