### PR TITLE
fix(mcp): real brand marks for 钉钉 / 飞书 / macOS 应用

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -38,6 +38,7 @@
     "screenshots:baseline:stable": "node ../../scripts/diff-screenshots.mjs --update-baseline --subset stable"
   },
   "dependencies": {
+    "@ant-design/icons-svg": "4.5.0",
     "@base-ui/react": "^1.5.0",
     "@fontsource-variable/geist": "^5.2.9",
     "@fontsource-variable/geist-mono": "^5.2.8",

--- a/apps/desktop/src/main/__tests__/icon-governance-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/icon-governance-contract.test.ts
@@ -99,11 +99,13 @@ const STROKE_EXCEPTION_FILES = new Set([
 //     byte-provenance-pinned above to an upstream brand package.
 //   - apps/desktop/src/renderer/mcp-brand-marks.tsx — the MCP catalog brand
 //     marks. This is the SANCTIONED pattern for library-sourced marks: the
-//     `<svg>` is an inert MOUNTING SHELL that wraps a `<path d={si.path}/>`
-//     whose geometry comes straight from the `simple-icons` library (official
-//     brand paths, not hand-drawn art). Lucide ships no brand icons, so these
-//     marks cannot route through @maka/ui/icons. The rot-guard below still
-//     holds because the file genuinely contains an inline `<svg>`.
+//     `<svg>` is an inert MOUNTING SHELL that wraps `<path>` children whose
+//     geometry comes straight from a brand library (simple-icons, plus
+//     @ant-design/icons-svg for DingTalk and the vendored @douyinfe/semi-icons
+//     Feishu mark) — official brand paths, not hand-drawn art. Lucide ships no
+//     brand icons, so these marks cannot route through @maka/ui/icons. The
+//     rot-guard below still holds because the file genuinely contains an inline
+//     `<svg>`.
 // packages/ui/src/icons.tsx is NOT listed: it is a pure lucide re-export with
 // zero `<svg>` literals, so it needs no exemption. Any NEW raw `<svg>` under
 // the two source trees must fail this suite and move to @maka/ui/icons — unless

--- a/apps/desktop/src/renderer/maka-tokens.css
+++ b/apps/desktop/src/renderer/maka-tokens.css
@@ -127,13 +127,10 @@
   --brand-deep-hover: oklch(from var(--accent) calc(l - 0.06) c h);
   /* Fixed external channel identity; unlike palette-derived Maka accents. */
   --brand-wechat: #07c160;
-  /* Fixed service identities for MCP market tiles that fall back to a text mark
-     because simple-icons carries no library mark for them (钉钉/飞书 are absent
-     from every simple-icons release). Brands with a simple-icons mark — Slack,
-     LINE, Google Calendar, Figma, Vercel, Supabase, Notion — render the real
-     mark on a neutral plate (mcp-brand-marks.tsx), so they need no tint token. */
-  --brand-dingtalk: #1677ff;
-  --brand-feishu: #3370ff;
+  /* Every MCP market tile now renders a real library brand mark on a neutral
+     plate (mcp-brand-marks.tsx: simple-icons + @ant-design/icons-svg DingTalk +
+     the vendored Feishu mark), so no per-brand plate-tint tokens are needed —
+     a colourful logo already supplies the brand identity. */
   --bot-brand-default: var(--accent);
   /* PALETTE-LEAK-0: semantic alias for informational system banners (the
      plan-reminders 系统提醒 banner) — component CSS derives its tint family

--- a/apps/desktop/src/renderer/mcp-brand-marks.tsx
+++ b/apps/desktop/src/renderer/mcp-brand-marks.tsx
@@ -1,75 +1,136 @@
 // Official MCP catalog brand marks.
 //
-// Each mark is sourced from the `simple-icons` library — the de-facto brand
-// icon set (official path geometry + official brand hex + CC0 licence). We use
-// per-icon *named* ESM imports so the bundler tree-shakes the multi-thousand
-// icon catalog down to only the marks we render (verified against the
-// dist-renderer chunk size). Lucide deliberately ships no brand icons, so these
-// marks come from simple-icons rather than the @maka/ui/icons lucide funnel.
+// Each mark is LIBRARY-sourced path geometry (official path data + official
+// brand hex/licence) — never hand-drawn art. Marks come from three first-party
+// icon sources, unified behind one `BrandMark` model that carries each source's
+// NATIVE viewBox so no path is rescaled or redrawn:
+//   - `simple-icons` (CC0) — the de-facto brand set; 24×24 viewBox, single path.
+//     Covers Slack, LINE, Google Calendar, Figma, Vercel, Supabase, Notion and
+//     Apple (macOS 应用). Per-icon *named* ESM imports so the bundler tree-shakes
+//     the multi-thousand icon catalog down to only the marks we render.
+//   - `@ant-design/icons-svg` (MIT, Ant Group) — ships DingTalk's mark, since
+//     DingTalk is an Alibaba product. Its AST uses a "64 64 896 896" viewBox; we
+//     deep-import only the one `DingtalkOutlined` asn module (sideEffects:false)
+//     and flatten its `<path>` children.
+//   - `@douyinfe/semi-icons` (MIT, ByteDance) — ships Feishu/Lark's mark, since
+//     Feishu is a ByteDance product. Vendored below as path constants (not a
+//     package dep) — semi-icons ships React components + ~3k files, so a full dep
+//     would couple React and bloat the tree for one mark; mirrors the single-mark
+//     vendoring in settings/provider-brand-marks.tsx.
 //
-// Rendering: each mark is a 24×24 `<svg>` MOUNTING SHELL wrapping the library's
-// single `<path>`. The `<svg>` element is NOT hand-drawn art — it is an inert
+// Rendering: each mark is an `<svg>` MOUNTING SHELL wrapping the library's
+// `<path>` children. The `<svg>` element is NOT hand-drawn art — it is an inert
 // container for LIBRARY-sourced path data. That is the sanctioned reason
 // mcp-brand-marks.tsx sits on the icon-governance INLINE_SVG_ALLOWLIST (see
 // apps/desktop/src/main/__tests__/icon-governance-contract.test.ts); the
 // rot-guard still holds because this file genuinely contains an inline `<svg>`.
 //
-// Colour: light theme fills each mark with its official brand hex (`si.hex`).
+// Colour: light theme fills each mark with its official brand hex (`mark.hex`).
 // Dark theme: marks whose brand hex is too dark to read on the neutral plate
 // fall back to `currentColor` via shouldUseCurrentColorOnDark() — a pure,
 // unit-tested luminance gate that lives in ./mcp-brand-contrast so it can be
 // exercised without JSX. Tiles keep the #1205 neutral-plate recipe.
-//
-// simple-icons does not carry 钉钉 (DingTalk) or 飞书 (Lark/Feishu) in any
-// released version, so those entries keep the catalog text mark. macOS ⌘,
-// filesystem, memory and the other generic entries are non-brand and stay on
-// their lucide/glyph text marks by design.
 
+import type { AbstractNode } from '@ant-design/icons-svg/es/types.js';
+import DingtalkOutlined from '@ant-design/icons-svg/es/asn/DingtalkOutlined.js';
 import type { CSSProperties, ReactElement } from 'react';
 import type { SimpleIcon } from 'simple-icons';
-import { siFigma, siGooglecalendar, siLine, siNotion, siSlack, siSupabase, siVercel } from 'simple-icons';
+import { siApple, siFigma, siGooglecalendar, siLine, siNotion, siSlack, siSupabase, siVercel } from 'simple-icons';
 import { shouldUseCurrentColorOnDark } from './mcp-brand-contrast.js';
 import type { McpCatalogEntry } from './mcp-catalog';
 
-// Catalog id → simple-icons member. Only ids present here render a real library
-// mark (and drive the neutral `data-logo` plate in mcp-page.tsx); every other
-// entry falls back to its text mark.
-const MCP_BRAND_ICONS: Record<string, SimpleIcon> = {
-  slack: siSlack,
-  line: siLine,
-  'google-calendar': siGooglecalendar,
-  figma: siFigma,
-  vercel: siVercel,
-  supabase: siSupabase,
-  notion: siNotion,
+// One or more library path `d` strings, the source viewBox they were authored
+// against, and the brand fill hex the dark-plate luminance gate reads.
+type BrandMark = {
+  paths: string[];
+  viewBox: string;
+  hex: string;
 };
 
-/** True when the catalog entry has a simple-icons library brand mark. */
+/** simple-icons ship a single path against a 24×24 viewBox. */
+function fromSimpleIcon(icon: SimpleIcon): BrandMark {
+  return { paths: [icon.path], viewBox: '0 0 24 24', hex: `#${icon.hex}` };
+}
+
+// DingTalk (钉钉) — official mark from @ant-design/icons-svg (MIT). We pick the
+// OUTLINED (bare pigeon silhouette) over DingtalkCircleFilled: the catalog's
+// data-logo recipe already supplies a neutral plate, so the bare glyph reads
+// like the Slack/Notion/… marks, whereas the circle-filled variant renders as a
+// solid blue disc that double-plates the tile. Filled with the DingTalk brand
+// blue (#0089FF family — supersedes the removed --brand-dingtalk #1677ff plate
+// tint); the luminance gate keeps it blue in dark (well above the near-black cut).
+const DINGTALK_ICON = DingtalkOutlined.icon as AbstractNode;
+const DINGTALK_MARK: BrandMark = {
+  paths: (DINGTALK_ICON.children ?? []).map((child) => child.attrs.d),
+  viewBox: DINGTALK_ICON.attrs.viewBox,
+  hex: '#0089FF',
+};
+
+// Feishu/Lark (飞书) — official monochrome mark vendored byte-for-byte from
+// ByteDance's own first-party icon library:
+//   - package: @douyinfe/semi-icons@2.101.0 (MIT, © DouyinFE)
+//   - source:  packages/semi-icons/src/svgs/feishu_logo.svg
+//   - source SHA-256: 5f9a5066c702ada4acdb752521a7d70293fbe5166ac4a7fa256cff8778670e2d
+//   - viewBox 0 0 24 24; all five <path> children copied verbatim (two are the
+//     source's degenerate specks near 20,14 — kept for byte fidelity).
+// The Feishu mark remains its owner's trademark; used only to identify the
+// connector. Filled with the Feishu brand blue (#3370FF — supersedes the removed
+// --brand-feishu plate tint); stays blue in dark via the luminance gate.
+const FEISHU_MARK: BrandMark = {
+  viewBox: '0 0 24 24',
+  hex: '#3370FF',
+  paths: [
+    'M6.13732 3.80654C8.76716 5.98777 11.0232 8.49408 12.7428 11.4327L14.4397 9.75535C15.2458 8.96545 16.2113 8.34129 17.258 7.93496C16.7802 6.31936 16.0033 4.98005 14.9403 3.65376C14.8135 3.49449 14.6185 3.40346 14.4137 3.40346L6.28362 3.40021C6.06906 3.40021 5.9748 3.67001 6.13732 3.80654Z',
+    'M20.5703 14.1922L20.58 14.1793L20.6155 14.1146C20.6026 14.1372 20.5864 14.1631 20.5703 14.1922Z',
+    'M11.0361 14.5567C12.2714 15.0833 13.3766 15.5287 14.6899 15.883C17.0207 16.5136 19.2311 15.5709 20.3234 13.4872L21.6432 10.8541C21.939 10.2105 22.3128 9.6156 22.7647 9.07273C21.9715 8.78016 21.3149 8.63064 20.4534 8.63064C18.5518 8.63064 16.7606 9.36205 15.4018 10.6948L13.3831 12.6875C12.6647 13.3929 11.878 14.0203 11.0361 14.5567Z',
+    'M20.7945 13.7752L20.8039 13.7566L20.8101 13.7473C20.8039 13.7535 20.8007 13.7659 20.7945 13.7752Z',
+    'M1.62519 9.74885C1.47889 9.60906 1.23511 9.70983 1.23511 9.91463L1.23834 17.8724C1.23834 18.1 1.34887 18.3112 1.53416 18.4348C3.66663 19.8521 6.15343 20.5998 8.72151 20.5998C11.166 20.5998 13.5488 19.9171 15.6098 18.6266C16.3867 18.139 16.9979 17.7099 17.6512 17.0792C16.6013 17.388 15.4472 17.4075 14.2835 17.0922C9.37815 15.7594 5.20097 13.2044 1.62519 9.74885Z',
+  ],
+};
+
+// Catalog id → brand mark. Only ids present here render a real library mark (and
+// drive the neutral `data-logo` plate in mcp-page.tsx); every other entry falls
+// back to its text mark.
+const MCP_BRAND_MARKS: Record<string, BrandMark> = {
+  slack: fromSimpleIcon(siSlack),
+  line: fromSimpleIcon(siLine),
+  'google-calendar': fromSimpleIcon(siGooglecalendar),
+  figma: fromSimpleIcon(siFigma),
+  vercel: fromSimpleIcon(siVercel),
+  supabase: fromSimpleIcon(siSupabase),
+  notion: fromSimpleIcon(siNotion),
+  'macos-apps': fromSimpleIcon(siApple),
+  dingtalk: DINGTALK_MARK,
+  feishu: FEISHU_MARK,
+};
+
+/** True when the catalog entry has a library brand mark. */
 export function hasMcpBrandMark(id: string): boolean {
-  return id in MCP_BRAND_ICONS;
+  return id in MCP_BRAND_MARKS;
 }
 
 /**
- * Official brand mark for a catalog entry. Renders the simple-icons library
- * mark when one exists; otherwise falls back to the entry's text mark.
+ * Official brand mark for a catalog entry. Renders the library mark when one
+ * exists; otherwise falls back to the entry's text mark.
  */
 export function McpBrandMark({ entry }: { entry: McpCatalogEntry }): ReactElement {
-  const icon = MCP_BRAND_ICONS[entry.id];
-  if (!icon) return <span>{entry.mark}</span>;
-  const hex = `#${icon.hex}`;
+  const mark = MCP_BRAND_MARKS[entry.id];
+  if (!mark) return <span>{entry.mark}</span>;
   // Light theme paints the brand hex; the `.dark` plate flips low-contrast
   // marks to currentColor (see mcp.css). Custom property carries the hex so
   // the theme switch is pure CSS, no re-render.
-  const style = { '--mcp-brand-fill': hex } as CSSProperties;
+  const style = { '--mcp-brand-fill': mark.hex } as CSSProperties;
   return (
     <svg
       className="maka-mcp-brand-mark"
-      viewBox="0 0 24 24"
+      viewBox={mark.viewBox}
       aria-hidden="true"
       style={style}
-      data-contrast={shouldUseCurrentColorOnDark(hex) ? 'low' : undefined}
+      data-contrast={shouldUseCurrentColorOnDark(mark.hex) ? 'low' : undefined}
     >
-      <path d={icon.path} />
+      {mark.paths.map((d) => (
+        <path key={d} d={d} />
+      ))}
     </svg>
   );
 }

--- a/apps/desktop/src/renderer/mcp-catalog.ts
+++ b/apps/desktop/src/renderer/mcp-catalog.ts
@@ -5,7 +5,10 @@ export type McpCatalogEntry = {
   name: string;
   description: string;
   category: string;
-  mark: string;
+  /** Text fallback glyph for entries without a library brand mark (see
+      mcp-brand-marks.tsx). Branded entries render their real mark instead, so
+      they omit this. */
+  mark?: string;
   aliases?: string[];
   config: McpServerConfig;
   setupRequired?: boolean;
@@ -19,7 +22,6 @@ export const MCP_CATALOG: McpCatalogEntry[] = [
     name: '钉钉',
     description: '管理联系人、日历、待办与协作信息。',
     category: '沟通协作',
-    mark: '钉',
     aliases: ['DingTalk'],
     setupRequired: true,
     setupLabel: '需要 Client ID 与 Client Secret',
@@ -39,7 +41,6 @@ export const MCP_CATALOG: McpCatalogEntry[] = [
     name: '飞书',
     description: '访问飞书文档、日历、消息与 OpenAPI。',
     category: '沟通协作',
-    mark: '飞',
     aliases: ['Feishu', 'Lark'],
     setupRequired: true,
     setupLabel: '需要 App ID 与 App Secret',
@@ -95,7 +96,6 @@ export const MCP_CATALOG: McpCatalogEntry[] = [
     name: 'macOS 应用',
     description: '连接系统日历与提醒事项，并使用原生权限模型。',
     category: '系统与效率',
-    mark: '⌘',
     aliases: ['Apple', 'Calendar', 'Reminders'],
     platform: 'darwin',
     config: { enabled: true, command: 'npx', args: ['-y', 'mcp-server-apple-events@1.4.0'] },

--- a/apps/desktop/src/renderer/styles/module-pages/mcp.css
+++ b/apps/desktop/src/renderer/styles/module-pages/mcp.css
@@ -212,17 +212,6 @@
   fill: currentColor;
 }
 
-/* Text-mark brands with no library mark (钉钉/飞书) keep their tinted plate. */
-.maka-mcp-market-icon[data-brand="dingtalk"] {
-  background: color-mix(in oklab, var(--brand-dingtalk) 12%, var(--background));
-  color: color-mix(in oklab, var(--brand-dingtalk) 72%, var(--foreground));
-}
-
-.maka-mcp-market-icon[data-brand="feishu"] {
-  background: color-mix(in oklab, var(--brand-feishu) 12%, var(--background));
-  color: color-mix(in oklab, var(--brand-feishu) 72%, var(--foreground));
-}
-
 .maka-mcp-market-copy {
   min-width: 0;
   display: grid;

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
       "name": "@maka/desktop",
       "version": "0.1.0",
       "dependencies": {
+        "@ant-design/icons-svg": "4.5.0",
         "@base-ui/react": "^1.5.0",
         "@fontsource-variable/geist": "^5.2.9",
         "@fontsource-variable/geist-mono": "^5.2.8",
@@ -247,6 +248,12 @@
       "peerDependencies": {
         "zod": "^3.25.76 || ^4.1.8"
       }
+    },
+    "node_modules/@ant-design/icons-svg": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@ant-design/icons-svg/-/icons-svg-4.5.0.tgz",
+      "integrity": "sha512-1BTUFyKPTBZ53MuTP8s0k5SFEXL7o3VHEOwLgzaoWKwnBeqIcqUtVshc4SKzhI6uACfqhJqBwBUE9FsWR3uULA==",
+      "license": "MIT"
     },
     "node_modules/@antfu/install-pkg": {
       "version": "1.1.0",


### PR DESCRIPTION
User-requested completion of the MCP brand-mark work: the last three text-mark tiles (钉/飞/⌘) become real official marks. A prior attempt was lost to a process crash; this is the clean retry with maintainer-verified sourcing facts baked in.

## Sources (all first-party, nothing hand-drawn)
- **macOS 应用 → Apple**: siApple from the existing simple-icons@15.22.0 dependency; luminance gate renders black in light / white in dark.
- **钉钉 → DingTalk**: new dep @ant-design/icons-svg@4.5.0 (MIT, Ant Group — first-party for an Alibaba product), deep-import of the single DingtalkOutlined AST (outlined chosen over CircleFilled after rendering both at tile scale — the filled disc double-plated the tile). Real brand blue #0089FF.
- **飞书 → Feishu**: official monochrome mark vendored byte-for-byte from ByteDance's own @douyinfe/semi-icons@2.101.0 (feishu_logo.svg, SHA-256 documented) — the package itself is React-coupled so the 5 paths are vendored as documented constants, mirroring the provider-brand-marks precedent. A hand-drawn lark.svg found in another bundle was REJECTED per the no-approximation rule; competitor asar held only a raster.

## Mechanics
Mark model generalized to {paths[], viewBox, hex} so 24-viewBox (simple-icons/semi) and 896-viewBox (ant) sources coexist; luminance gate + neutral logo plate unchanged. Text marks and their now-dead --brand-* tokens/tint CSS removed. Governance allowlist unchanged in shape; rationale comment updated to name all three sources. Bundle delta +1.3KB (ant tree-shook to one AST; verified no side chunk).

## Gates
Tree already contains main tip. desktop 2729/2729 · ui 191/191 · typecheck · check-dead-css · knip ×2 (new dep declared+consumed) · alignment auditor exit 0. CDP light+dark captures visually accepted by maintainer (14 tiles, 10 real marks). Implemented by an opus worktree agent.