### PR TITLE
feat(cli): add searchable cross-connection /model picker

### DIFF
--- a/packages/cli/src/__tests__/pi-tui-runner.test.ts
+++ b/packages/cli/src/__tests__/pi-tui-runner.test.ts
@@ -4018,6 +4018,281 @@ describe('Maka Pi TUI runner', () => {
     ]);
   });
 
+  test('cross-connection /model filters the model list as you type in the search field', async () => {
+    const terminal = new FakeTerminal();
+    const driver = new SlashCommandDriver();
+    const run = runMakaPiTui({
+      title: 'Maka',
+      driver,
+      cwd: '/repo',
+      model: 'gpt-5.5',
+      connectionSlug: 'openai',
+      providerType: 'openai',
+      modelChoices: [
+        {
+          connectionSlug: 'openai',
+          connectionName: 'OpenAI',
+          providerType: 'openai',
+          model: 'gpt-5.5',
+          isDefaultConnection: true,
+        },
+        {
+          connectionSlug: 'zai',
+          connectionName: 'Z.ai',
+          providerType: 'openai',
+          model: 'glm-5.2',
+          isDefaultConnection: false,
+        },
+      ],
+      permissionMode: 'ask',
+      terminal,
+    });
+
+    await delay(20);
+    terminal.input('/model');
+    terminal.input('\r');
+    await waitFor(() => terminal.output().includes('Select Model'));
+    await waitFor(() => terminal.output().includes('glm-5.2'));
+    const before = plainTerminalOutput(terminal.screenOutput());
+    assert.ok(before.includes('gpt-5.5'));
+    assert.ok(before.includes('glm-5.2'));
+    // The searchable overlay stays bottom-anchored above the editor + status line,
+    // just like the non-searchable picker it replaces.
+    assertBottomPickerPlacement(terminal, 'Select Model', 'Maka · ask · gpt-5.5 · openai · /repo');
+
+    // Typing in the search field filters the cross-connection list live. The
+    // query "gpt" matches only the OpenAI model id, so the Z.ai model leaves
+    // the visible list while the match stays. The current model (gpt-5.5) is
+    // still shown by the status line regardless, so the assertion targets the
+    // model that was filtered out (glm-5.2, not the current model).
+    terminal.input('gpt');
+    await waitFor(() => {
+      const out = plainTerminalOutput(terminal.screenOutput());
+      return out.includes('gpt-5.5') && !out.includes('glm-5.2');
+    });
+
+    exitMaka(terminal);
+    await Promise.race([
+      run,
+      delay(500).then(() => {
+        throw new Error('TUI did not close during test cleanup');
+      }),
+    ]);
+  });
+
+  test('cross-connection /model shows an empty state when no model matches the search', async () => {
+    const terminal = new FakeTerminal();
+    const driver = new SlashCommandDriver();
+    const run = runMakaPiTui({
+      title: 'Maka',
+      driver,
+      cwd: '/repo',
+      model: 'gpt-5.5',
+      connectionSlug: 'openai',
+      providerType: 'openai',
+      modelChoices: [
+        {
+          connectionSlug: 'openai',
+          connectionName: 'OpenAI',
+          providerType: 'openai',
+          model: 'gpt-5.5',
+          isDefaultConnection: true,
+        },
+        {
+          connectionSlug: 'zai',
+          connectionName: 'Z.ai',
+          providerType: 'openai',
+          model: 'glm-5.2',
+          isDefaultConnection: false,
+        },
+      ],
+      permissionMode: 'ask',
+      terminal,
+    });
+
+    await delay(20);
+    terminal.input('/model');
+    terminal.input('\r');
+    await waitFor(() => terminal.output().includes('Select Model'));
+
+    // A query that matches no model id, provider, or connection surfaces an
+    // in-frame empty state instead of the full list.
+    terminal.input('zzz');
+    await waitFor(() => plainTerminalOutput(terminal.screenOutput()).includes('没有匹配的模型'));
+
+    exitMaka(terminal);
+    await Promise.race([
+      run,
+      delay(500).then(() => {
+        throw new Error('TUI did not close during test cleanup');
+      }),
+    ]);
+  });
+
+  test('cross-connection /model rebinds the session to a filtered model on Enter', async () => {
+    const terminal = new FakeTerminal();
+    const driver = new SlashCommandDriver();
+    const run = runMakaPiTui({
+      title: 'Maka',
+      driver,
+      cwd: '/repo',
+      model: 'gpt-5.5',
+      connectionSlug: 'openai',
+      providerType: 'openai',
+      modelChoices: [
+        {
+          connectionSlug: 'openai',
+          connectionName: 'OpenAI',
+          providerType: 'openai',
+          model: 'gpt-5.5',
+          isDefaultConnection: true,
+        },
+        {
+          connectionSlug: 'zai',
+          connectionName: 'Z.ai',
+          providerType: 'openai',
+          model: 'glm-5.2',
+          isDefaultConnection: false,
+        },
+      ],
+      permissionMode: 'ask',
+      terminal,
+    });
+
+    await delay(20);
+    terminal.input('/model');
+    terminal.input('\r');
+    await waitFor(() => terminal.output().includes('Select Model'));
+    // Filter to the Z.ai model alone; the OpenAI connection-name leaves the list
+    // (the status line keeps the lowercase slug, not the capitalized name).
+    terminal.input('glm');
+    await waitFor(() => {
+      const out = plainTerminalOutput(terminal.screenOutput());
+      return out.includes('glm-5.2') && !out.includes('OpenAI');
+    });
+    // The filtered list's first match is already highlighted, so Enter rebinds.
+    terminal.input('\r');
+    await waitFor(() => driver.models.length === 1);
+
+    assert.deepEqual(driver.models, ['glm-5.2']);
+    assert.deepEqual(driver.modelConnections, ['zai']);
+    await waitFor(() =>
+      plainTerminalOutput(terminal.output()).includes('Maka · ask · glm-5.2 · zai · /repo'),
+    );
+
+    exitMaka(terminal);
+    await Promise.race([
+      run,
+      delay(500).then(() => {
+        throw new Error('TUI did not close during test cleanup');
+      }),
+    ]);
+  });
+
+  test('cross-connection /model cancel closes the picker without changing the model', async () => {
+    const terminal = new FakeTerminal();
+    const driver = new SlashCommandDriver();
+    const run = runMakaPiTui({
+      title: 'Maka',
+      driver,
+      cwd: '/repo',
+      model: 'gpt-5.5',
+      connectionSlug: 'openai',
+      providerType: 'openai',
+      modelChoices: [
+        {
+          connectionSlug: 'openai',
+          connectionName: 'OpenAI',
+          providerType: 'openai',
+          model: 'gpt-5.5',
+          isDefaultConnection: true,
+        },
+        {
+          connectionSlug: 'zai',
+          connectionName: 'Z.ai',
+          providerType: 'openai',
+          model: 'glm-5.2',
+          isDefaultConnection: false,
+        },
+      ],
+      permissionMode: 'ask',
+      terminal,
+    });
+
+    await delay(20);
+    terminal.input('/model');
+    terminal.input('\r');
+    await waitFor(() => terminal.output().includes('Select Model'));
+    terminal.input('\x1b');
+    await delay(30);
+
+    // Esc closed the picker without rebinding: no setModel call, and the status
+    // line still shows the original model + connection.
+    assert.deepEqual(driver.models, []);
+    assert.deepEqual(driver.modelConnections, []);
+    assert.ok(
+      plainTerminalOutput(terminal.output()).includes('Maka · ask · gpt-5.5 · openai · /repo'),
+    );
+
+    exitMaka(terminal);
+    await Promise.race([
+      run,
+      delay(500).then(() => {
+        throw new Error('TUI did not close during test cleanup');
+      }),
+    ]);
+  });
+
+  test('typed /model <id> still switches the model directly when modelChoices are present', async () => {
+    const terminal = new FakeTerminal();
+    const driver = new SlashCommandDriver();
+    const run = runMakaPiTui({
+      title: 'Maka',
+      driver,
+      cwd: '/repo',
+      model: 'gpt-5.5',
+      connectionSlug: 'openai',
+      providerType: 'openai',
+      modelChoices: [
+        {
+          connectionSlug: 'openai',
+          connectionName: 'OpenAI',
+          providerType: 'openai',
+          model: 'gpt-5.5',
+          isDefaultConnection: true,
+        },
+        {
+          connectionSlug: 'zai',
+          connectionName: 'Z.ai',
+          providerType: 'openai',
+          model: 'glm-5.2',
+          isDefaultConnection: false,
+        },
+      ],
+      permissionMode: 'ask',
+      terminal,
+    });
+
+    await delay(20);
+    terminal.input('/model glm-5.2');
+    terminal.input('\r');
+    await waitFor(() => driver.models.length === 1);
+
+    // Typed /model sets the model on the current connection without opening the
+    // searchable picker (cross-connection switching is the picker's job).
+    assert.deepEqual(driver.models, ['glm-5.2']);
+    assert.deepEqual(driver.modelConnections, [undefined]);
+    assert.equal(terminal.output().includes('Select Model'), false);
+
+    exitMaka(terminal);
+    await Promise.race([
+      run,
+      delay(500).then(() => {
+        throw new Error('TUI did not close during test cleanup');
+      }),
+    ]);
+  });
+
   test('handles /rename without sending a prompt', async () => {
     const terminal = new FakeTerminal();
     const driver = new SlashCommandDriver();

--- a/packages/cli/src/__tests__/pi-tui-runner.test.ts
+++ b/packages/cli/src/__tests__/pi-tui-runner.test.ts
@@ -4293,6 +4293,92 @@ describe('Maka Pi TUI runner', () => {
     ]);
   });
 
+  test('cross-connection /model search matches by every required criterion', async () => {
+    const terminal = new FakeTerminal();
+    const driver = new SlashCommandDriver();
+    const run = runMakaPiTui({
+      title: 'Maka',
+      driver,
+      cwd: '/repo',
+      // A current model/slug not among the choices, so no choice's model shows
+      // up in the status line — a dropped choice truly leaves the visible list.
+      model: 'legacy-curated-out',
+      connectionSlug: 'ghost',
+      providerType: 'openai',
+      modelChoices: [
+        {
+          connectionSlug: 'alpha',
+          connectionName: 'Aurora',
+          providerType: 'openai',
+          model: 'gpt-5.5',
+          isDefaultConnection: true,
+        },
+        {
+          connectionSlug: 'beta',
+          connectionName: 'Boreal',
+          providerType: 'zai',
+          model: 'glm-max',
+          isDefaultConnection: false,
+        },
+        {
+          connectionSlug: 'gamma',
+          connectionName: 'Crest',
+          providerType: 'google',
+          model: 'text-unicorn',
+          isDefaultConnection: false,
+        },
+      ],
+      permissionMode: 'ask',
+      terminal,
+    });
+
+    await delay(20);
+    terminal.input('/model');
+    terminal.input('\r');
+    await waitFor(() => terminal.output().includes('Select Model'));
+    await waitFor(() => {
+      const out = plainTerminalOutput(terminal.screenOutput());
+      return out.includes('gpt-5.5') && out.includes('glm-max') && out.includes('text-unicorn');
+    });
+
+    // Each query isolates exactly one of the five match criteria named by #1098
+    // (model id, connection name, connection slug, provider type, provider
+    // label) and keeps only its matching choice. The fixture's three distinct
+    // providers (openai / zai / google) let `zai` exercise the providerType
+    // line alone (its label `Z.AI` is not a substring) and `gemini` exercise
+    // the PROVIDER_DEFAULTS label line alone (its type `google` is not), so
+    // deleting either line would fail its assertion. Ctrl+U (deleteToLineStart)
+    // clears the search field in one event so the next criterion starts from
+    // the full list again.
+    const cases = [
+      { query: 'gpt', keep: 'gpt-5.5', drop: ['glm-max', 'text-unicorn'] },
+      { query: 'aurora', keep: 'gpt-5.5', drop: ['glm-max', 'text-unicorn'] },
+      { query: 'alpha', keep: 'gpt-5.5', drop: ['glm-max', 'text-unicorn'] },
+      { query: 'zai', keep: 'glm-max', drop: ['gpt-5.5', 'text-unicorn'] },
+      { query: 'gemini', keep: 'text-unicorn', drop: ['gpt-5.5', 'glm-max'] },
+    ];
+    for (const c of cases) {
+      terminal.input(c.query);
+      await waitFor(() => {
+        const out = plainTerminalOutput(terminal.screenOutput());
+        return out.includes(c.keep) && c.drop.every((d) => !out.includes(d));
+      });
+      terminal.input('\x15');
+      await waitFor(() => {
+        const out = plainTerminalOutput(terminal.screenOutput());
+        return out.includes('gpt-5.5') && out.includes('glm-max') && out.includes('text-unicorn');
+      });
+    }
+
+    exitMaka(terminal);
+    await Promise.race([
+      run,
+      delay(500).then(() => {
+        throw new Error('TUI did not close during test cleanup');
+      }),
+    ]);
+  });
+
   test('handles /rename without sending a prompt', async () => {
     const terminal = new FakeTerminal();
     const driver = new SlashCommandDriver();

--- a/packages/cli/src/pi-tui-pickers.ts
+++ b/packages/cli/src/pi-tui-pickers.ts
@@ -19,7 +19,7 @@ import type { UserQuestionOption } from '@maka/core';
 import { PERMISSION_MODES, type PermissionMode } from '@maka/core/permission';
 import type { ThinkingLevel } from '@maka/core/model-thinking';
 import type { InvocableSkillEntry } from '@maka/runtime';
-import type { ProviderType } from '@maka/core/llm-connections';
+import { PROVIDER_DEFAULTS, type ProviderType } from '@maka/core/llm-connections';
 import type { ModelChoice } from './connection-target.js';
 import type { OnboardableProvider } from './onboarding.js';
 import { skillInvocationPrefixAt } from './skill-token.js';
@@ -536,7 +536,7 @@ export function modelPickerItems(
  * caller maps it back to the {@link ModelChoice}. The description carries the
  * owning connection so identical model ids on different providers are readable.
  */
-export function modelChoicePickerItems(
+function modelChoicePickerItems(
   choices: readonly ModelChoice[],
   current: { model: string; connectionSlug: string },
 ): SelectItem[] {
@@ -548,6 +548,140 @@ export function modelChoicePickerItems(
     else if (choice.isDefaultConnection) tags.push('default');
     return { value: String(index), label: choice.model, description: tags.join(' · ') };
   });
+}
+
+/**
+ * Case-insensitive substring match for the `/model` search field, against every
+ * criterion the issue names: model id, provider label/type, and connection
+ * name/slug. `ModelChoice` carries no display name, so the model id is the only
+ * model-side match target; a display-name enrichment would slot in here.
+ */
+function matchesModelChoice(choice: ModelChoice, query: string): boolean {
+  if (choice.model.toLowerCase().includes(query)) return true;
+  if (choice.connectionName.toLowerCase().includes(query)) return true;
+  if (choice.connectionSlug.toLowerCase().includes(query)) return true;
+  if (choice.providerType.toLowerCase().includes(query)) return true;
+  const providerLabel = PROVIDER_DEFAULTS[choice.providerType]?.label;
+  if (providerLabel && providerLabel.toLowerCase().includes(query)) return true;
+  return false;
+}
+
+export interface ModelSearchOverlayInput {
+  choices: readonly ModelChoice[];
+  current: { model: string; connectionSlug: string };
+  onSelect: (choice: ModelChoice) => void;
+  onCancel: () => void;
+}
+
+/**
+ * One bottom search field + a bounded single-select list, for the cross-
+ * connection `/model` picker (issue #1098 seam 2). Mirrors the OnboardingWizard
+ * search phase — the same one-field-powers-the-list shape — but stays a focused
+ * single-select: it is not a shared base for the setup multi-select. The list is
+ * rebuilt in place on every keystroke (SelectList has no setItems), and Esc /
+ * Ctrl-C close without rebinding. The `models`-only fallback (minimal hosts,
+ * tests) stays on the non-searchable PickerOverlay.
+ */
+export class ModelSearchOverlay implements Component {
+  private readonly searchEditor: Editor;
+  private filtered: readonly ModelChoice[];
+  private list: SelectList;
+  private readonly initialIndex: number;
+
+  constructor(
+    private readonly tui: TUI,
+    private readonly input: ModelSearchOverlayInput,
+  ) {
+    this.filtered = [...input.choices];
+    this.initialIndex = input.choices.findIndex(
+      (choice) =>
+        choice.model === input.current.model &&
+        choice.connectionSlug === input.current.connectionSlug,
+    );
+    this.list = this.buildList();
+    if (this.initialIndex >= 0) this.list.setSelectedIndex(this.initialIndex);
+    this.searchEditor = new Editor(tui, editorTheme(), { paddingX: 0 });
+    this.searchEditor.onChange = (text) => this.applyQuery(text);
+  }
+
+  private buildList(): SelectList {
+    const list = new SelectList(
+      modelChoicePickerItems(this.filtered, this.input.current),
+      10,
+      selectListTheme(),
+      { minPrimaryColumnWidth: 24, maxPrimaryColumnWidth: 48 },
+    );
+    list.onSelect = (item) => {
+      const choice = this.filtered[Number(item.value)];
+      if (!choice) return;
+      this.input.onSelect(choice);
+    };
+    list.onCancel = () => this.input.onCancel();
+    return list;
+  }
+
+  private applyQuery(text: string): void {
+    const query = text.trim().toLowerCase();
+    const next = query
+      ? this.input.choices.filter((choice) => matchesModelChoice(choice, query))
+      : this.input.choices;
+    if (next === this.filtered) return;
+    this.filtered = next;
+    this.list = this.buildList();
+  }
+
+  invalidate(): void {
+    this.searchEditor.invalidate();
+    this.list.invalidate();
+  }
+
+  handleInput(data: string): void {
+    if (matchesKey(data, Key.escape) || matchesKey(data, Key.ctrl('c'))) {
+      this.input.onCancel();
+      return;
+    }
+    // Arrows and Enter drive the list; everything else is typed into the search
+    // field (mirrors the OnboardingWizard search phase).
+    if (matchesKey(data, Key.up) || matchesKey(data, Key.down)) {
+      this.list.handleInput(data);
+      return;
+    }
+    if (matchesKey(data, Key.enter) || matchesKey(data, Key.return)) {
+      if (isKeyRepeat(data)) return;
+      this.list.handleInput(data);
+      return;
+    }
+    this.searchEditor.handleInput(data);
+  }
+
+  render(width: number): string[] {
+    const safeWidth = Math.max(1, width);
+    this.searchEditor.focused = true;
+    return [
+      padLine(`Select Model ${ansi.accent(String(this.filtered.length))}`, safeWidth),
+      padLine(ansi.dim('搜索模型 / 服务商 / 连接 · ↑↓ 选择 · Enter 确认 · Esc 取消'), safeWidth),
+      padLine('', safeWidth),
+      ...this.renderFieldRow(this.searchEditor, '搜索', safeWidth),
+      padLine('', safeWidth),
+      ...(this.filtered.length === 0
+        ? [padLine(ansi.dim('没有匹配的模型'), safeWidth)]
+        : this.list.render(safeWidth).map((line) => formatPickerItemLine(line, safeWidth))),
+      padLine(ansi.accent('-'.repeat(safeWidth)), safeWidth),
+    ];
+  }
+
+  private renderFieldRow(editor: Editor, label: string, width: number): string[] {
+    const prefix = `${label} `;
+    const prefixWidth = visibleWidth(prefix);
+    const contentWidth = Math.max(1, width - prefixWidth);
+    const editorLines = editor.render(contentWidth).slice(1, -1);
+    if (editorLines.length === 0) {
+      return [padLine(prefix, width)];
+    }
+    return editorLines.map((line, index) =>
+      padLine(`${index === 0 ? prefix : ' '.repeat(prefixWidth)}${line}`, width),
+    );
+  }
 }
 
 export function permissionModePickerItems(currentMode: PermissionMode): SelectItem[] {

--- a/packages/cli/src/pi-tui-runner.ts
+++ b/packages/cli/src/pi-tui-runner.ts
@@ -94,10 +94,10 @@ import {
 import {
   MakaAutocompleteProvider,
   DirectoryPickerOverlay,
+  ModelSearchOverlay,
   OnboardingWizard,
   PickerOverlay,
   UserQuestionOverlay,
-  modelChoicePickerItems,
   modelPickerItems,
   permissionModePickerItems,
   skillPickerItems,
@@ -1826,24 +1826,17 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
     // Cross-connection picker when the caller supplied choices across all ready
     // connections; otherwise the single-connection list (typed /model, tests).
     if (choices && choices.length > 0) {
-      const selectedIndex = choices.findIndex(
-        (choice) => choice.model === model && choice.connectionSlug === connectionSlug,
-      );
-      showSelectPicker(
-        'Select Model',
-        connectionSlug,
-        modelChoicePickerItems(choices, { model, connectionSlug }),
-        (item) => {
-          const choice = choices[Number(item.value)];
-          if (!choice) return;
+      let overlay: OverlayHandle | undefined;
+      const picker = new ModelSearchOverlay(tui, {
+        choices,
+        current: { model, connectionSlug },
+        onSelect: (choice) => {
+          overlay?.hide();
           void runControl(() => setModelChoice(choice));
         },
-        {
-          minPrimaryColumnWidth: 24,
-          maxPrimaryColumnWidth: 48,
-          ...(selectedIndex >= 0 ? { selectedIndex } : {}),
-        },
-      );
+        onCancel: () => overlay?.hide(),
+      });
+      overlay = showBottomPicker(picker);
       return;
     }
     showSelectPicker(


### PR DESCRIPTION
## Summary

The cross-connection `/model` picker listed every ready model with no way to narrow it, so finding one across many connections meant scrolling. This is seam 2 of #1098: add one bottom search field that matches model id, provider label/type, and connection name/slug, while keeping the existing cross-connection rebinding and typed `/model <id>` path.

Add a focused `ModelSearchOverlay` (one search field + a bounded single-select list, mirroring the `OnboardingWizard` search phase) and wire it into `/model`'s cross-connection path. The list rebuilds in place on every keystroke; `Esc`/`Ctrl-C` close without rebinding; an empty filter shows an in-frame `没有匹配的模型` state. The `models`-only fallback for minimal hosts/tests stays on the non-searchable `PickerOverlay`, and typed `/model <id>` still sets the model directly without opening the picker. No second picker system or shared abstraction is introduced.

Refs #1098 (seam 2 of three independently mergeable seams).

## Verification

- `npm --workspace maka-agent run build` — clean.
- `npm --workspace maka-agent run test:dist` — 608 pass / 0 fail (was 603; +5 new tests).
- `npm run format:check` — clean.
- `npm run lint` — clean.
- `npm run typecheck` — the CLI workspace (`maka-agent`) and its dependency chain (core, storage, runtime, headless) typecheck clean. The only failure is the pre-existing `apps/desktop` `simple-icons` missing-module error, present on `main` (added in #1236, not installed in the shared `node_modules`); this branch does not touch `apps/desktop` or any dependency declaration.

New tests (`packages/cli/src/__tests__/pi-tui-runner.test.ts`):
- `cross-connection /model filters the model list as you type in the search field` (+ bottom-anchored placement assertion)
- `cross-connection /model shows an empty state when no model matches the search`
- `cross-connection /model rebinds the session to a filtered model on Enter`
- `cross-connection /model cancel closes the picker without changing the model`
- `typed /model <id> still switches the model directly when modelChoices are present`

Existing `/model` tests stay green, including `selects a model from /model` (models-only fallback) and `switches connection and model together from a cross-connection /model` (down + Enter rebind on the now-searchable picker).

Out of scope for this seam (tracked by #1098): seam 1 (branded empty-session home) and seam 3 (complete `/setup` model curation + live model-choice refresh).