### PR TITLE
chore(frontend): 2026-07-19 architecture + UI-delta campaign — map, knip zero-hint, resume hook, QR fixture

### DIFF
--- a/apps/desktop/src/main/__tests__/renderer-shell-source-helpers.ts
+++ b/apps/desktop/src/main/__tests__/renderer-shell-source-helpers.ts
@@ -36,6 +36,7 @@ const sourcePaths = [
   'use-shell-connections.ts',
   'use-shell-chat-model.ts',
   'use-shell-live-turn.ts',
+  'use-shell-resume.ts',
   'use-shell-expert-teams.ts',
   'use-shell-memory-pill.ts',
   'use-shell-layout.ts',

--- a/apps/desktop/src/main/__tests__/runtime-resume-routing-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/runtime-resume-routing-contract.test.ts
@@ -9,13 +9,18 @@ const REPO_ROOT = resolve(import.meta.dirname, '../../../../..');
 describe('runtime resume desktop routing contract', () => {
   it('renderer routes interrupted-banner resume and reports parked diagnostics', async () => {
     const shell = await readRendererShellSource('app-shell.tsx');
+    // R2: the resume cluster (state + resumeInterruptedSession handler) moved out of
+    // app-shell.tsx into use-shell-resume.ts (use-shell-connections house style). The
+    // handler-shape assertions read the hook file; app-shell keeps the sendWithAttachments
+    // guard and the banner `safeResumeAction=` wiring.
+    const resume = await readRendererShellSource('use-shell-resume.ts');
     const send = shell.match(/async function sendWithAttachments\(text: string\): Promise<boolean \| void> \{[\s\S]*?\n  \}/)?.[0] ?? '';
 
     assert.doesNotMatch(send, /text\.trim\(\) === '\/resume'/);
-    assert.match(shell, /async function resumeInterruptedSession\(\)/);
-    assert.match(shell, /window\.maka\.sessions\.resumeLatest\(sessionId\)/);
-    assert.match(shell, /resumeParkToastCopy\(result\.rejectionReasons\)/);
-    assert.doesNotMatch(shell, /result\.rejectionReasons\.join/);
+    assert.match(resume, /async function resumeInterruptedSession\(\)/);
+    assert.match(resume, /window\.maka\.sessions\.resumeLatest\(sessionId\)/);
+    assert.match(resume, /resumeParkToastCopy\(result\.rejectionReasons\)/);
+    assert.doesNotMatch(resume, /result\.rejectionReasons\.join/);
     assert.match(shell, /safeResumeAction=/);
 
     const turn = await readFile(resolve(REPO_ROOT, 'packages/ui/src/chat-turn.tsx'), 'utf8');

--- a/apps/desktop/src/main/__tests__/visual-smoke-fixture.test.ts
+++ b/apps/desktop/src/main/__tests__/visual-smoke-fixture.test.ts
@@ -1271,6 +1271,41 @@ describe('visual smoke fixture mode', () => {
   });
 });
 
+describe('settings-bots-onboarding fixture (#1233 deferral)', () => {
+  it('opens 远程接入 and seeds the DingTalk provider so the scan-login modal auto-opens', () => {
+    const fixture = resolveVisualSmokeFixture('settings-bots-onboarding', false);
+    assert.ok(fixture, 'settings-bots-onboarding should resolve');
+    const state = getVisualSmokeState(fixture);
+    assert.equal(state?.scenario, 'settings-bots-onboarding');
+    assert.equal(state?.openSettingsSection, 'bot-chat');
+    // botOnboardingProvider is the contract the renderer reads to jump to the
+    // provider detail + auto-open the QR modal in its waiting state.
+    assert.equal(state?.botOnboardingProvider, 'dingtalk');
+    // Active session is the standard turn fixture so the chat surface behind
+    // the Settings modal renders meaningful context.
+    assert.equal(state?.activeSessionId, 'visual-smoke-turn');
+  });
+
+  it('reuses the standard turn seed so no bot-specific on-disk seed is needed', async () => {
+    const workspaceRoot = await mkdtemp(join(tmpdir(), 'maka-visual-smoke-bots-onboarding-'));
+    try {
+      const fixture = resolveVisualSmokeFixture('settings-bots-onboarding', false);
+      assert.ok(fixture);
+      await seedVisualSmokeFixture({
+        workspaceRoot,
+        fixture,
+        credentialStore: fakeCredentialStore(),
+        now: 1_700_000_000_000,
+      });
+      const file = await readFile(join(workspaceRoot, 'sessions', 'visual-smoke-turn', 'session.jsonl'), 'utf8');
+      const header = JSON.parse(file.split('\n')[0]!) as { id: string };
+      assert.equal(header.id, 'visual-smoke-turn');
+    } finally {
+      await rm(workspaceRoot, { recursive: true, force: true });
+    }
+  });
+});
+
 describe('browser-empty chrome fixture (#819)', () => {
   it('seeds a live browser session id so BrowserPanel mounts over the turn chat in empty state', () => {
     const fixture = resolveVisualSmokeFixture('browser-empty', false);

--- a/apps/desktop/src/main/bot-onboarding-visual-smoke.ts
+++ b/apps/desktop/src/main/bot-onboarding-visual-smoke.ts
@@ -5,13 +5,26 @@ type AdapterMap = Partial<Record<BotOnboardingProvider, BotOnboardingProviderAda
 
 const POLL_INTERVAL_MS = 1_000;
 const NORMAL_TTL_SECONDS = 30;
+// #1233 deferral (settings-bots-onboarding): a long TTL keeps the deterministic
+// waiting-state QR from flipping to '二维码已过期' during the screenshot settle
+// window; a poll that never leaves 'pending' holds the modal in 'waiting'.
+const WAITING_HOLD_TTL_SECONDS = 60 * 60;
 
 /**
  * Deterministic provider adapters for the dev-only Settings visual fixture.
  * They exercise the real main-owned session, IPC, persistence, runtime-effect,
  * and renderer polling paths without contacting an external IM platform.
+ *
+ * Scenario-aware: the `settings-bots-onboarding` fixture needs the modal frozen
+ * in its 'waiting' state so the QR-onboarding capture is stable, so every
+ * provider holds a fixed QR + long TTL + never-confirming poll. All other
+ * scenarios keep the scanned → confirmed happy-path adapters the E2E
+ * onboarding specs rely on.
  */
 export function createVisualSmokeBotOnboardingAdapters(): AdapterMap {
+  if (process.env.MAKA_VISUAL_SMOKE_FIXTURE === 'settings-bots-onboarding') {
+    return createWaitingHoldBotOnboardingAdapters();
+  }
   const pollCounts = new Map<string, number>();
   let startSequence = 0;
 
@@ -99,5 +112,38 @@ export function createVisualSmokeBotOnboardingAdapters(): AdapterMap {
         };
       },
     },
+  };
+}
+
+/**
+ * #1233 deferral (settings-bots-onboarding): adapters that hold the modal in
+ * its 'waiting' state. Every value is FIXED (no Date.now / random) so the
+ * rendered QR image is byte-identical across capture runs, the TTL is long
+ * enough to outlast the screenshot settle window, and `poll` never leaves
+ * 'pending' — so the main service keeps the session 'waiting' and the modal's
+ * waiting layout stays put for a deterministic screenshot.
+ */
+function createWaitingHoldBotOnboardingAdapters(): AdapterMap {
+  function waitingHold(provider: BotOnboardingProvider): BotOnboardingProviderAdapter {
+    return {
+      async start() {
+        return {
+          opaqueToken: `visual-smoke-onboarding-${provider}`,
+          qrValue: `https://example.com/maka/bot-onboarding/${provider}`,
+          verificationUrl: `https://example.com/maka/bot-onboarding/${provider}`,
+          pollIntervalMs: POLL_INTERVAL_MS,
+          expiresInSeconds: WAITING_HOLD_TTL_SECONDS,
+        };
+      },
+      async poll() {
+        return { status: 'pending' };
+      },
+    };
+  }
+  return {
+    dingtalk: waitingHold('dingtalk'),
+    feishu: waitingHold('feishu'),
+    wecom: waitingHold('wecom'),
+    wechat: waitingHold('wechat'),
   };
 }

--- a/apps/desktop/src/main/visual-smoke-fixture.ts
+++ b/apps/desktop/src/main/visual-smoke-fixture.ts
@@ -52,6 +52,11 @@ const VISUAL_SMOKE_SCENARIOS = new Set<VisualSmokeScenario>([
   // daily-review split back apart per WAWQAQ msg `886f6406`.
   'settings-appearance',
   'settings-bots',
+  // #1233 deferral: deterministic bot QR-onboarding modal capture. Shares the
+  // settings-bots seed but auto-opens a provider detail's scan-login modal,
+  // backed by a hold-in-waiting visual-smoke onboarding adapter (fixed QR +
+  // long TTL). See `createVisualSmokeBotOnboardingAdapters`.
+  'settings-bots-onboarding',
   'settings-about',
   'settings-general',
   'settings-memory',
@@ -407,6 +412,18 @@ export function getVisualSmokeState(fixture: VisualSmokeFixture | null): VisualS
       return { ...state, activeSessionId: TURN_SESSION_ID, openSettingsSection: 'appearance' };
     case 'settings-bots':
       return { ...state, activeSessionId: TURN_SESSION_ID, openSettingsSection: 'bot-chat' };
+    case 'settings-bots-onboarding':
+      // #1233 deferral: open 远程接入, then let the bot page auto-open the
+      // DingTalk detail's scan-login modal (via `botOnboardingProvider`). The
+      // visual-smoke onboarding adapter keeps the session in 'waiting' with a
+      // fixed QR + long TTL so the modal's waiting layout is captured
+      // deterministically. DingTalk carries a real brand mark (#1236).
+      return {
+        ...state,
+        activeSessionId: TURN_SESSION_ID,
+        openSettingsSection: 'bot-chat',
+        botOnboardingProvider: 'dingtalk',
+      };
     case 'settings-about':
       return { ...state, activeSessionId: TURN_SESSION_ID, openSettingsSection: 'about' };
     case 'settings-general':

--- a/apps/desktop/src/renderer/app-shell-visual-smoke.ts
+++ b/apps/desktop/src/renderer/app-shell-visual-smoke.ts
@@ -205,6 +205,16 @@ export function createAppShellVisualSmokeActions(options: {
             if (!state.focusActiveRow && document.activeElement instanceof HTMLElement) {
               document.activeElement.blur();
             }
+            // #1233 deferral: the settings-bots-onboarding fixture opens a QR
+            // modal whose 'waiting' state depends on a main-process device-code
+            // start + QR render round-trip that outlasts the fixed idle above.
+            // Wait (bounded) for the QR image to actually paint so the capture
+            // lands on the deterministic waiting layout, not the transient
+            // "正在生成安全二维码…" spinner. `performance.now()` is used because
+            // `Date.now` is frozen to `state.now` in visual-smoke mode.
+            if (state.botOnboardingProvider) {
+              await waitForVisualSmokeElement('.settingsBotOnboardingQrFrame[data-state="waiting"] img');
+            }
             if ('fonts' in document) {
               await document.fonts.ready;
             }
@@ -220,4 +230,18 @@ export function createAppShellVisualSmokeActions(options: {
   }
 
   return { applyVisualSmokeFixture };
+}
+
+/**
+ * #1233 deferral: bounded poll for a selector to appear before an auto-capture.
+ * Used for the QR-onboarding fixture, whose 'waiting' layout only paints after
+ * an async main-process round-trip. Uses `performance.now()` (not `Date.now`,
+ * which visual-smoke freezes) for the timeout bound. Visual-smoke only.
+ */
+async function waitForVisualSmokeElement(selector: string, timeoutMs = 4_000): Promise<void> {
+  const deadline = performance.now() + timeoutMs;
+  while (performance.now() < deadline) {
+    if (document.querySelector(selector)) return;
+    await new Promise<void>((resolve) => setTimeout(resolve, 50));
+  }
 }

--- a/apps/desktop/src/renderer/app-shell.tsx
+++ b/apps/desktop/src/renderer/app-shell.tsx
@@ -26,7 +26,6 @@ import {
   type TurnFooterActionMeta,
   useToast,
   activeInteractionFor,
-  resumeParkToastCopy,
 } from '@maka/ui';
 import { useKeyboardHelp } from './keyboard-help';
 import { useCommandPalette } from './command-palette';
@@ -96,6 +95,7 @@ import { useShellConnections } from './use-shell-connections';
 import { useShellChatModel } from './use-shell-chat-model';
 import { useShellLiveTurn } from './use-shell-live-turn';
 import { useShellLayout } from './use-shell-layout';
+import { useShellResume } from './use-shell-resume';
 import { useSettingsModal } from './use-settings-modal';
 import {
   isSessionWorkspaceUnavailableError,
@@ -265,8 +265,11 @@ function AppShellContent({
   const [paletteOpen, openPalette, closePalette] = useCommandPalette();
   const [viewMode, setViewMode] = useState<SessionViewMode>('status');
   const composerRef = useRef<ComposerHandle>(null);
-  const [resumePendingSessionId, setResumePendingSessionId] = useState<string | null>(null);
-  const [resumeParkDescriptionBySession, setResumeParkDescriptionBySession] = useState<Record<string, string>>({});
+  const {
+    resumePendingSessionId,
+    resumeParkDescriptionBySession,
+    resumeInterruptedSession,
+  } = useShellResume({ activeId, toastApi, shellCopy, uiLocale });
   const rendererMountedRef = useRef(true);
   // Active autonomous goal for the current session drives the header
   // kill-switch pill (visible indicator + one-click clear).
@@ -890,41 +893,6 @@ function AppShellContent({
     toastApi,
     upsertSessionSummary,
   });
-
-  async function resumeInterruptedSession(): Promise<void> {
-    const sessionId = activeId;
-    if (!sessionId || resumePendingSessionId !== null) return;
-    setResumePendingSessionId(sessionId);
-    try {
-      const result = await window.maka.sessions.resumeLatest(sessionId);
-      if (result.disposition === 'park') {
-        const parkCopy = resumeParkToastCopy(result.rejectionReasons);
-        setResumeParkDescriptionBySession((current) => ({
-          ...current,
-          [sessionId]: parkCopy.description,
-        }));
-        toastApi.error(parkCopy.title, parkCopy.description);
-      } else {
-        setResumeParkDescriptionBySession((current) => {
-          const { [sessionId]: _removed, ...remaining } = current;
-          void _removed;
-          return remaining;
-        });
-        toastApi.info(shellCopy.resumeStartedTitle, shellCopy.resumeStartedDescription);
-      }
-    } catch (error) {
-      toastApi.error(
-        shellCopy.resumeFailedTitle,
-        localizedShellErrorMessage(
-          error,
-          shellCopy.resumeFailedFallback,
-          uiLocale,
-        ),
-      );
-    } finally {
-      setResumePendingSessionId((current) => current === sessionId ? null : current);
-    }
-  }
 
   async function sendWithAttachments(text: string): Promise<boolean | void> {
     if (text.trim() === '/compact') {

--- a/apps/desktop/src/renderer/settings/bot-chat-detail.tsx
+++ b/apps/desktop/src/renderer/settings/bot-chat-detail.tsx
@@ -55,6 +55,12 @@ function supportsQuickOnboarding(provider: BotProvider): provider is BotOnboardi
  */
 export function BotChatChannelDetail(props: {
   provider: BotProvider;
+  /**
+   * #1233 deferral: when true (only under the settings-bots-onboarding
+   * visual-smoke fixture), open the scan-login modal at mount so the QR
+   * waiting state captures deterministically. Real users never set this.
+   */
+  autoOpenScanLogin?: boolean;
   channel: BotChannelSettings;
   status: BotStatus | undefined;
   statusLoadError: string | null;
@@ -71,7 +77,7 @@ export function BotChatChannelDetail(props: {
   onRefreshStatuses(): Promise<boolean>;
 }) {
   const { provider, channel, status } = props;
-  const [scanLoginOpen, setScanLoginOpen] = useState(false);
+  const [scanLoginOpen, setScanLoginOpen] = useState(Boolean(props.autoOpenScanLogin));
   const [wechatQrOpen, setWechatQrOpen] = useState(false);
   const [setupMode, setSetupMode] = useState<'quick' | 'manual'>('quick');
   const [feishuBrand, setFeishuBrand] = useState<BotOnboardingBrand>(

--- a/apps/desktop/src/renderer/settings/bot-chat-settings-page.tsx
+++ b/apps/desktop/src/renderer/settings/bot-chat-settings-page.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from 'react';
 import type {
   AppSettings,
+  BotOnboardingProvider,
   BotProvider,
   UpdateAppSettingsResult,
 } from '@maka/core';
@@ -30,6 +31,10 @@ export function BotChatSettingsPage(props: {
 }) {
   const [selected, setSelected] = useState<BotProvider>('telegram');
   const [detailOpen, setDetailOpen] = useState(false);
+  // #1233 deferral: the `settings-bots-onboarding` visual-smoke fixture opens a
+  // provider's scan-login modal deterministically. `visualSmoke.getState()`
+  // resolves null for real users, so this only fires under the dev fixture.
+  const [autoOpenScanProvider, setAutoOpenScanProvider] = useState<BotOnboardingProvider | null>(null);
   const [pendingBotAction, setPendingBotAction] = useState<BotPendingAction | null>(null);
   const [statuses, setStatuses] = useState<Record<BotProvider, BotStatus> | null>(null);
   const [statusLoadError, setStatusLoadError] = useState<string | null>(null);
@@ -45,6 +50,22 @@ export function BotChatSettingsPage(props: {
   useEffect(() => {
     return () => {
       pendingBotActionRef.current = null;
+    };
+  }, []);
+
+  // #1233 deferral: under the settings-bots-onboarding visual-smoke fixture,
+  // jump straight to the seeded provider's detail view and flag the scan-login
+  // modal to auto-open so the QR waiting state captures deterministically.
+  useEffect(() => {
+    let active = true;
+    void window.maka.visualSmoke.getState().then((smoke) => {
+      if (!active || !smoke?.botOnboardingProvider) return;
+      setSelected(smoke.botOnboardingProvider);
+      setDetailOpen(true);
+      setAutoOpenScanProvider(smoke.botOnboardingProvider);
+    }).catch(() => undefined);
+    return () => {
+      active = false;
     };
   }, []);
 
@@ -292,6 +313,7 @@ export function BotChatSettingsPage(props: {
   return (
     <BotChatChannelDetail
       provider={selected}
+      autoOpenScanLogin={autoOpenScanProvider === selected}
       channel={channel}
       status={selectedStatus}
       statusLoadError={statusLoadError}

--- a/apps/desktop/src/renderer/use-shell-resume.ts
+++ b/apps/desktop/src/renderer/use-shell-resume.ts
@@ -1,0 +1,76 @@
+import { useState } from 'react';
+import type { UiLocale } from '@maka/core';
+import { resumeParkToastCopy } from '@maka/ui';
+import { getShellCopy, localizedShellErrorMessage } from './locales/shell-copy.js';
+
+type ToastApi = {
+  info(title: string, description?: string): void;
+  error(title: string, description?: string): void;
+};
+
+/**
+ * Owns the #1223 safe-boundary resume cluster: the in-flight `resumePendingSessionId`
+ * guard and the per-session parked-diagnostic descriptions surfaced on the
+ * interrupted-turn banner, plus the `resumeInterruptedSession` handler that drives
+ * `sessions.resumeLatest`. `activeId` is injected (the handler snapshots it as
+ * `sessionId` so a session switch mid-resume settles the ORIGINAL session's pending
+ * flag) alongside `toastApi` / `shellCopy` / `uiLocale`. The two state values are
+ * returned raw so AppShell's banner JSX keeps its exact `resumePendingSessionId ===
+ * activeId` / `resumeParkDescriptionBySession[activeId]` reads; the wiring
+ * (`safeResumeAction=` element) stays in AppShell. Pure move — zero behavior change.
+ */
+export function useShellResume(options: {
+  activeId: string | undefined;
+  toastApi: ToastApi;
+  shellCopy: ReturnType<typeof getShellCopy>['app'];
+  uiLocale: UiLocale;
+}): {
+  resumePendingSessionId: string | null;
+  resumeParkDescriptionBySession: Record<string, string>;
+  resumeInterruptedSession: () => Promise<void>;
+} {
+  const { activeId, toastApi, shellCopy, uiLocale } = options;
+  const [resumePendingSessionId, setResumePendingSessionId] = useState<string | null>(null);
+  const [resumeParkDescriptionBySession, setResumeParkDescriptionBySession] = useState<Record<string, string>>({});
+
+  async function resumeInterruptedSession(): Promise<void> {
+    const sessionId = activeId;
+    if (!sessionId || resumePendingSessionId !== null) return;
+    setResumePendingSessionId(sessionId);
+    try {
+      const result = await window.maka.sessions.resumeLatest(sessionId);
+      if (result.disposition === 'park') {
+        const parkCopy = resumeParkToastCopy(result.rejectionReasons);
+        setResumeParkDescriptionBySession((current) => ({
+          ...current,
+          [sessionId]: parkCopy.description,
+        }));
+        toastApi.error(parkCopy.title, parkCopy.description);
+      } else {
+        setResumeParkDescriptionBySession((current) => {
+          const { [sessionId]: _removed, ...remaining } = current;
+          void _removed;
+          return remaining;
+        });
+        toastApi.info(shellCopy.resumeStartedTitle, shellCopy.resumeStartedDescription);
+      }
+    } catch (error) {
+      toastApi.error(
+        shellCopy.resumeFailedTitle,
+        localizedShellErrorMessage(
+          error,
+          shellCopy.resumeFailedFallback,
+          uiLocale,
+        ),
+      );
+    } finally {
+      setResumePendingSessionId((current) => current === sessionId ? null : current);
+    }
+  }
+
+  return {
+    resumePendingSessionId,
+    resumeParkDescriptionBySession,
+    resumeInterruptedSession,
+  };
+}

--- a/knip.json
+++ b/knip.json
@@ -6,40 +6,20 @@
     "apps/desktop": {
       "entry": [
         "src/main/main.ts",
-        "src/preload/preload.ts",
         "src/overlay/cursor-overlay.ts",
         "src/overlay/cursor-overlay-preload.ts",
-        "src/renderer/main.tsx",
         "src/main/**/*.test.ts",
-        "src/renderer/**/*.test.ts",
         "e2e/**/*.spec.ts",
-        "e2e/playwright.config.ts",
-        ".storybook/main.ts",
         ".storybook/preview.@(ts|tsx)",
         "stories/**/*.@(ts|tsx)",
-        "scripts/dev.mjs",
         "scripts/browser-observe-act-smoke.mjs"
       ],
       "project": ["src/**/*.{ts,tsx}", "e2e/**/*.ts", "stories/**/*.{ts,tsx}", "scripts/**/*.mjs"],
-      "ignoreDependencies": [
-        "overlayscrollbars",
-        "@fontsource-variable/geist",
-        "@fontsource-variable/geist-mono"
-      ],
+      "ignoreDependencies": ["@fontsource-variable/geist", "@fontsource-variable/geist-mono"],
       "ignoreBinaries": ["taskkill"]
     },
     "packages/ui": {
-      "entry": [
-        "src/index.ts",
-        "src/icons.tsx",
-        "src/artifact-preview-registry.ts",
-        "src/assistant-stream.ts",
-        "src/maka-uri.ts",
-        "src/smooth-stream.ts",
-        "src/**/*.test.ts",
-        "src/**/*.test.tsx",
-        "stories/**/*.@(ts|tsx)"
-      ],
+      "entry": ["src/**/*.test.ts", "src/**/*.test.tsx", "stories/**/*.@(ts|tsx)"],
       "project": ["src/**/*.{ts,tsx}", "stories/**/*.{ts,tsx}"],
       "ignoreDependencies": ["@storybook/react-vite", "storybook"]
     }

--- a/notes/frontend-architecture-map-2026-07-19.md
+++ b/notes/frontend-architecture-map-2026-07-19.md
@@ -1,0 +1,107 @@
+# Frontend Architecture Map (2026-07-19)
+
+Maintainer goal: the frontend has grown again since the 2026-07-13 simplification
+campaign (#865–#887). Prune redundant/messy code at the architecture level — this time
+the bulk sits in the two mega-modules that decomposition has not yet reached (main.ts,
+provider-connection-detail.tsx) plus config/CSS rot. Method unchanged: measure first
+(knip + wc + grep), stage rounds, gate each on the full suite + typecheck + dead-css +
+alignment auditor + CDP spot captures, exit-code gated. Zero behavior change per round.
+
+Baseline (this tip, d48183c2): 84.5K lines TS/TSX (non-test, apps/desktop/src +
+packages/ui/src) + 15.1K lines CSS (all in apps/desktop/src/renderer; packages/ui ships
+no CSS). Per-area non-test TS/TSX: main 28.4K · renderer 31.6K · ui/src 22.6K ·
+preload 1.9K.
+
+Top-10 hotspots (non-test TS/TSX, lines):
+
+| Lines | File | Note |
+|------:|------|------|
+| 2521 | apps/desktop/src/main/visual-smoke-fixture.ts | **OUT-OF-SCOPE** — other-sessions' territory (bot-onboarding fixtures) |
+| 1871 | apps/desktop/src/main/main.ts | R4/R5/R6 targets (contract re-pins required) |
+| 1686 | apps/desktop/src/renderer/app-shell.tsx | R2 target (resume cluster); down from 1733 pre-#887 |
+| 1511 | apps/desktop/src/renderer/locales/shell-copy.ts | copy catalog — data, not logic |
+| 1502 | apps/desktop/src/main/open-gateway.ts | — |
+| 1418 | apps/desktop/src/main/skills.ts | — |
+| 1141 | apps/desktop/src/main/explore-agent-tool.ts | — |
+| 1114 | apps/desktop/src/preload/preload.ts | bridge surface — mostly declarations |
+| 1008 | packages/ui/src/chat-turn.tsx | — |
+|  983 | apps/desktop/src/renderer/settings/provider-connection-detail.tsx | R7 target (17 useState) |
+
+CSS top files: maka-tokens 1490 · plan-reminders 824 · onboarding 809 · sidebar 787 ·
+skills 691 · chat-detail 656 · mcp 626.
+
+Knip verification notes: the 13 config hints this campaign clears (R1) are ALL
+knip-reported redundant/stale config, not code finds — 7 desktop (`overlayscrollbars`
+ignoreDependencies now redundant; `src/renderer/**/*.test.ts` matches nothing; 5 entry
+patterns auto-detected by knip's vite/storybook/playwright/npm-scripts plugins) + 6 ui
+(every explicit entry is already resolved from packages/ui `package.json#exports`). Both
+workspaces are exit 0 today; R1 makes them also report ZERO hints. Storybook stories +
+`.test.*` entries stay real entries and are not touched.
+
+## Rounds
+
+- [ ] **R1 — knip.json de-rot (this PR).** Clear the 13 config hints without weakening
+  coverage: drop the now-redundant `overlayscrollbars` ignoreDependencies entry (the
+  overlay-scrollbars contract forbids declaring it as a *desktop dep* — removing a
+  redundant *ignore* is compatible; overlayscrollbars is owned by packages/ui), delete
+  the dead `src/renderer/**/*.test.ts` entry glob (renderer has zero test files — all 338
+  desktop tests live in `src/main/__tests__/*.test.ts`), and drop the 11 redundant entry
+  patterns (5 desktop + 6 ui) that knip already auto-detects. Gate: `npx knip --workspace
+  apps/desktop` and `packages/ui` both exit 0 AND zero config hints.
+- [ ] **R2 — app-shell resume-cluster extraction (this PR, ~−45 lines).** The #1223
+  safe-boundary resume cluster: state at app-shell.tsx:268–269
+  (`resumePendingSessionId` + `resumeParkDescriptionBySession`) and the
+  `resumeInterruptedSession` handler at :894–926. Extract into `use-shell-resume.ts`
+  following the use-shell-connections / use-shell-chat-model house style (options object,
+  stable identities preserved exactly, pure move, zero behavior change). JSX wiring at
+  :1470–1472 (`pending` / `detail` / `onResume`) and the `safeResumeAction=` element stay
+  in app-shell. Re-pin runtime-resume-routing-contract.test.ts to read the new hook file
+  for the moved assertions (add `use-shell-resume.ts` to renderer-shell-source-helpers
+  sourcePaths per the Round B/E precedent). CDP turn-narrative spot capture proves the
+  render no-op.
+- [ ] **R3 — visual-smoke per-domain split behind a barrel. BLOCKED.** visual-smoke-fixture.ts
+  (2521 lines, the #1 hotspot) should split per domain behind a barrel re-export.
+  Blocked on the concurrent bot-onboarding fixture branch that is actively editing
+  `apps/desktop/src/main/visual-smoke-fixture.ts` + `scripts/capture-screenshots.mjs` +
+  `scripts/audit-alignment.mjs`. Do not touch those three files until that branch lands;
+  this is a later round.
+- [ ] **R4 — main.ts tool-assembly extraction (~L648–809). Requires maintainer-approved
+  contract re-pin.** The deferred-tool/economy assembly block (riveTools, officeTools, the
+  MakaTool catalog filter, webSearchTool, agentTeamChildTools) extracts into a
+  tool-assembly module. The main-process-wiring-contract locks `registerIpc` in main.ts
+  (function at L1222, invoked L1697); `startup`, `tool-assembly`, and `modelSupportsVision`
+  (L964) are direct-pinned to main.ts by contract. Extraction needs the maintainer to
+  re-pin those contracts first.
+- [ ] **R5 — main.ts settings-runtime-effects + session-stream core splits (~L1360–1642).
+  Requires maintainer-approved contract re-pin.** Same direct-pin constraint as R4.
+- [ ] **R6 — main.ts startup/lifecycle module (~L1642–1865). Requires maintainer-approved
+  contract re-pin.** The post-`registerIpc()` startup/lifecycle tail. Same constraint.
+  (main.ts is 1871 lines total; R4–R6 line boundaries are the audit's approximate ranges
+  and must be re-verified against the tip at implementation time.)
+- [ ] **R7 — provider-connection-detail.tsx controller-hook decomposition.** 983 lines,
+  17 useState — the renderer's densest remaining state cluster. Needs its own blade plan
+  (which state clusters extract into which controller hooks, which contracts pin the file)
+  before any extraction; not a mechanical move like R2.
+- [ ] **R8 — CSS raw-hex residue (this PR). VERIFIED CLEAN — no residue on this tip.**
+  Audit premise was stale: prose.css + sidebar.css carry NO raw hex/rgb/rgba/hsl color
+  literals on d48183c2. The `#618`/`#546`/`#739` matches a naive grep surfaces are all
+  GitHub issue references inside comments, not colors; #1085 (`chore(desktop): clean up
+  CSS token governance`) already converted the real residue. The only raw hex anywhere in
+  renderer CSS is `--brand-wechat: #07c160` in maka-tokens.css — a deliberate fixed
+  external-channel brand identity, already documented in-file ("Fixed external channel
+  identity; unlike palette-derived Maka accents"), correctly left as a special case.
+  Inline byte-math sweep: the shared `formatBytes` (packages/ui/src/tool-activity/
+  preview-utils.ts, re-exported through @maka/ui, governed by
+  artifact-pane-format-dedup-contract) already owns the canonical B/KB/MB path. Two
+  remaining local byte formatters are NOT trivial forks and are left in place: (1)
+  `formatPreviewSize` (artifact-preview-registry.ts:315) returns a `未知大小` sentinel and
+  an un-rounded `B` branch — a distinct public contract, not formatBytes; (2)
+  voice-settings-page.tsx:156 renders an integer-MB cap (`Math.round(bytes/1024/1024) MB`,
+  no decimal) inline with a duration — a different display format. The remaining `* 1024`
+  hits are size *constants* (payload caps, stream limits), not formatting. Net: R8 needs
+  no code change; recorded here for the record.
+
+Update checkboxes as rounds ship. Every round: suite + typecheck + dead-css + alignment
+auditor + CDP spot captures, exit-code gated. R4–R6 are gated additionally on
+maintainer-approved contract re-pins; R7 needs its own blade plan; R3 is unblocked only
+after the concurrent visual-smoke fixture branch lands.

--- a/packages/core/src/visual-smoke.ts
+++ b/packages/core/src/visual-smoke.ts
@@ -1,3 +1,4 @@
+import type { BotOnboardingProvider } from './bot-onboarding.js';
 import type { PermissionRequestEvent, ToolResultContent } from './events.js';
 import type { SettingsSection } from './settings.js';
 import type { UiLocale } from './ui-locale.js';
@@ -39,6 +40,13 @@ export type VisualSmokeScenario =
   // their own nav items.
   | 'settings-appearance'
   | 'settings-bots'
+  // #1233 deferral: the bot QR-onboarding modal (bot-onboarding-modal.tsx)
+  // had no deterministic capture because a real device-code start contacts an
+  // external IM platform and the QR + TTL drift every run. This scenario opens
+  // Settings → 远程接入 → a bot detail with the scan-login modal auto-opened,
+  // backed by a visual-smoke adapter that holds the 'waiting' state with a
+  // FIXED QR + long TTL, so the modal's waiting layout captures deterministically.
+  | 'settings-bots-onboarding'
   | 'settings-about'
   | 'settings-general'
   | 'settings-memory'
@@ -297,4 +305,13 @@ export interface VisualSmokeState {
   /** Fixture-only session workbar state for deterministic tab screenshots. */
   workbarCollapsed?: boolean;
   workbarTab?: 'tasks' | 'browser' | 'files';
+  /**
+   * #1233 deferral — bot QR-onboarding modal capture. When set, the Settings
+   * 远程接入 page (bot-chat-settings-page) opens the given provider's detail
+   * view and auto-opens its scan-login modal at mount, so the deterministic
+   * waiting-state QR fixture is what the screenshot pipeline captures. Only the
+   * `settings-bots-onboarding` scenario sets this; real users never receive a
+   * visual smoke state so production onboarding is untouched.
+   */
+  botOnboardingProvider?: BotOnboardingProvider;
 }

--- a/scripts/audit-alignment.mjs
+++ b/scripts/audit-alignment.mjs
@@ -26,6 +26,8 @@ const FIXTURES = [
   'settings-gateway',
   'turn-narrative',
   'settings-permissions',
+  // #1233 deferral: bot QR-onboarding modal in its deterministic waiting state.
+  'settings-bots-onboarding',
 ];
 const BOOT_TIMEOUT_MS = Number(process.env.AUDIT_BOOT_TIMEOUT_MS ?? 30_000);
 const SETTLE_MS = Number(process.env.AUDIT_SETTLE_MS ?? 2_500);

--- a/scripts/capture-screenshots.mjs
+++ b/scripts/capture-screenshots.mjs
@@ -82,6 +82,11 @@ const ALL_SCENARIOS = [
   // PR-SETTINGS-IA-CONSOLIDATE-0 + PR-SETTINGS-REVIEW-0: memory split out.
   'settings-appearance',
   'settings-bots',
+  // #1233 deferral: deterministic bot QR-onboarding modal. Opens 远程接入 →
+  // DingTalk detail with the scan-login modal auto-opened, backed by a
+  // hold-in-waiting onboarding adapter (fixed QR + long TTL) so the modal's
+  // waiting layout is captured deterministically in light + dark.
+  'settings-bots-onboarding',
   'settings-about',
   'settings-general',
   'settings-memory',


### PR DESCRIPTION
One batched campaign PR (goal: 继续 UI/UX 打磨 + 架构洁癖). Three agents: architecture census+map, UI delta audit + fixture implementation, delegable cleanup rounds.

## Architecture (map committed: notes/frontend-architecture-map-2026-07-19.md)
- **Census**: frontend 84.5K non-test TS/TSX + 15.1K CSS; hotspot table; 8 staged rounds (R3 visual-smoke split unblocked by this PR's merge; R4-R6 main.ts splits + R7 provider-connection-detail decomposition staged for maintainer-gated rounds).
- **Discipline autopsy**: the week's +116 app-shell regression was mostly self-healed by other sessions' refactor PRs; the one surviving violation (#1223 resume cluster) is extracted here → **use-shell-resume.ts, app-shell 1686→1654**, byte-identical render proof (sha256, light+dark), resume-routing contract re-pinned per Round B/E precedent.
- **knip.json de-rot**: 13 config hints → 0, coverage intact (no broad ignores).
- **R8 honesty**: raw-hex residue was already cleared by #1085 — verified clean, documented, no churn fabricated.
- Boundary scan: renderer↔main / ui→desktop / ui→window.maka all clean; primitives adoption held.

## UI delta + fixture
- **QR onboarding fixture shipped** (the #1233 deferral): deterministic settings-bots-onboarding scenario — DingTalk modal held in waiting state with fixed QR, light+dark, registered in capture driver + auditor (now 11 fixtures). Includes a real capture-race fix: bounded wait for the QR element replaces the fixed 400ms settle that raced the async modal open.
- **Delta audit verdict: new external surfaces ship pre-governed** (resume button, provider-failure presentation, permission localization all on house primitives with status-color restraint) — zero pre-governance debt found; #1233/#1236 outcomes verified surviving.

## Gates (integrated tree, incl. today's external merges)
desktop 2744 · ui 196 · typecheck · check-dead-css · knip ×2 = 0 with 0 hints · alignment auditor all fixtures clean incl. the new one. Implemented by three opus worktree agents; integration verified by maintainer.