### PR TITLE
feat(cli): brand the empty-session TUI home with a maka wordmark

### DIFF
--- a/packages/cli/src/__tests__/pi-transcript.test.ts
+++ b/packages/cli/src/__tests__/pi-transcript.test.ts
@@ -29,22 +29,74 @@ import {
 // tests lock (#1064/#1066); matches tui-ansi.test.ts's reset convention.
 before(() => _setColorLevelForTesting(3));
 
+// The branded empty-session home opens on a four-line lowercase ASCII `maka`
+// wordmark in Maka blue (#1098). Stored without trailing spaces so the render
+// and these assertions agree after rtrim; the fallback width is derived from it.
+const MAKA_WORDMARK = [
+  ' _ __    __ _  _  __   __ _',
+  "| '_ \\  / _` | | |/ / / _` |",
+  '| |_) | | (_| | |   <  | (_| |',
+  '|_.__/  \\__,_| |_|\\_\\  \\__,_|',
+];
+const MAKA_WORDMARK_WIDTH = Math.max(...MAKA_WORDMARK.map((line) => line.length));
+
 describe('Maka Pi TUI transcript', () => {
-  test('greets on a fresh empty session and drops the welcome once a prompt lands', () => {
+  test('greets on a fresh empty session with the branded maka home and drops it once a prompt lands', () => {
     const state = createMakaPiTranscriptState();
 
-    const welcome = renderMakaPiTranscript(state, meta(), 100).map(stripAnsi).join('\n');
-    assert.match(welcome, /maka/);
-    assert.match(welcome, /\/help/);
-    // The welcome orients with the active model/connection/folder.
-    assert.match(welcome, /deepseek-v4-flash/);
-    assert.ok(welcome.includes('输入消息开始对话'));
+    const lines = renderMakaPiTranscript(state, meta(), 100).map((line) =>
+      stripAnsi(line).replace(/\s+$/, ''),
+    );
+    // Four-line lowercase ASCII maka wordmark.
+    assert.deepEqual(lines.slice(0, 4), MAKA_WORDMARK);
+    // The wordmark is Maka blue (accent), not plain text.
+    assert.ok(renderMakaPiTranscript(state, meta(), 100)[0].includes('\x1b[38;2;87;163;239m'));
+    // Short Chinese-first tagline.
+    assert.ok(lines.includes('陪你把事做完'));
+    // Command-center hints: direct input + /session + /model + /setup. /help is
+    // no longer a home hint — autocomplete teaches commands as you type.
+    assert.ok(lines.some((line) => line.trim().startsWith('输入消息开始对话')));
+    assert.ok(lines.some((line) => /\/session/.test(line)));
+    assert.ok(lines.some((line) => /\/model/.test(line)));
+    assert.ok(lines.some((line) => /\/setup/.test(line)));
+    assert.equal(
+      lines.some((line) => /\/help/.test(line)),
+      false,
+    );
+    // The active model/connection live in the statusline, not the welcome.
+    assert.equal(
+      lines.some((line) => /deepseek-v4-flash/.test(line)),
+      false,
+    );
 
     // Once a turn exists the transcript takes over — the welcome never returns.
     appendUserPrompt(state, 'hello world');
     const afterPrompt = renderMakaPiTranscript(state, meta(), 100).map(stripAnsi).join('\n');
-    assert.equal(afterPrompt.includes('/help'), false);
+    assert.equal(/\/session/.test(afterPrompt), false);
     assert.ok(afterPrompt.includes('hello world'));
+  });
+
+  test('falls back to a plain maka mark when the terminal is too narrow for the wordmark', () => {
+    const state = createMakaPiTranscriptState();
+
+    // One column below the wordmark's own width degrades it to a single maka line.
+    const narrow = renderMakaPiTranscript(state, meta(), MAKA_WORDMARK_WIDTH - 1).map((line) =>
+      stripAnsi(line).replace(/\s+$/, ''),
+    );
+    assert.equal(narrow[0], 'maka');
+    assert.equal(
+      narrow.slice(0, 4).some((line) => /__/.test(line)),
+      false,
+    );
+    // The tagline and hints still show below the fallback mark.
+    assert.ok(narrow.includes('陪你把事做完'));
+    assert.ok(narrow.some((line) => /\/session/.test(line)));
+
+    // At the wordmark's own width the four-line wordmark still renders.
+    const atThreshold = renderMakaPiTranscript(state, meta(), MAKA_WORDMARK_WIDTH).map((line) =>
+      stripAnsi(line).replace(/\s+$/, ''),
+    );
+    assert.deepEqual(atThreshold.slice(0, 4), MAKA_WORDMARK);
   });
 
   test('keeps assistant text after a tool call visible after the tool block', () => {

--- a/packages/cli/src/__tests__/pi-tui-runner.test.ts
+++ b/packages/cli/src/__tests__/pi-tui-runner.test.ts
@@ -47,6 +47,7 @@ import { BUSY_SPINNER_FRAMES } from '../tui-attention.js';
 import { arrangeAutocompleteAboveEditor } from '../tui-autocomplete-layout.js';
 import {
   assertBottomPickerPlacement,
+  autocompleteSuggestionLines,
   FakeTerminal,
   inputSurfaceRows,
   latestPlainLineContaining,
@@ -3237,12 +3238,20 @@ describe('Maka Pi TUI runner', () => {
 
     terminal.input('/');
 
-    await waitFor(() => plainTerminalOutput(terminal.output()).includes('/session'));
-    const output = plainTerminalOutput(terminal.output());
-    const exitIndex = output.indexOf('/exit');
-    const modelIndex = output.indexOf('/model');
-    const permissionsIndex = output.indexOf('/permissions');
-    const sessionIndex = output.indexOf('/session');
+    await waitFor(() => {
+      const lines = plainTerminalOutput(terminal.screenOutput()).split(/\r?\n/);
+      return autocompleteSuggestionLines(lines).some((line) => line.includes('/session'));
+    });
+    // Scope to the autocomplete overlay — the empty-session home now shows
+    // /session /model /setup as hint text, so a whole-screen grep would pick up
+    // the home's copies and misorder them against the menu (#1098).
+    const suggestions = autocompleteSuggestionLines(
+      plainTerminalOutput(terminal.screenOutput()).split(/\r?\n/),
+    ).join('\n');
+    const exitIndex = suggestions.indexOf('/exit');
+    const modelIndex = suggestions.indexOf('/model');
+    const permissionsIndex = suggestions.indexOf('/permissions');
+    const sessionIndex = suggestions.indexOf('/session');
 
     assert.ok(exitIndex >= 0);
     assert.ok(modelIndex >= 0);
@@ -3253,7 +3262,7 @@ describe('Maka Pi TUI runner', () => {
     assert.ok(permissionsIndex < sessionIndex);
     // The whole menu is visible at once — including the last command
     // alphabetically — so new commands don't push older ones below the fold.
-    assert.ok(output.indexOf('/thinking') > sessionIndex);
+    assert.ok(suggestions.indexOf('/thinking') > sessionIndex);
 
     exitMaka(terminal);
     await Promise.race([
@@ -3279,20 +3288,31 @@ describe('Maka Pi TUI runner', () => {
 
     terminal.input('/');
 
-    await waitFor(() => plainTerminalOutput(terminal.output()).includes('/session'));
-    const lines = plainTerminalOutput(terminal.output()).split(/\r?\n/);
-    const suggestionIndex = lines.findIndex((line) => line.includes('/model'));
+    await waitFor(() => {
+      const lines = plainTerminalOutput(terminal.screenOutput()).split(/\r?\n/);
+      return (
+        lines.some((line) => line.includes('→')) &&
+        autocompleteSuggestionLines(lines).some((line) => line.includes('/model'))
+      );
+    });
+    // Scope to the autocomplete overlay, not the whole screen: the empty-session
+    // home now shows /session /model /setup as hint text, so a whole-screen
+    // findIndex('/model') would land on the home's hint and pass even if the
+    // overlay never rendered (#1098).
+    const lines = plainTerminalOutput(terminal.screenOutput()).split(/\r?\n/);
+    const [editorTopBorder, editorBottomBorder] = inputSurfaceRows(lines);
+    const cursorIndex = lines.findIndex((line) => line.includes('→'));
     const statusLineIndex = lines.findIndex((line) =>
       line.includes('Maka · ask · deepseek-v4-flash · deepseek · /repo'),
     );
-    const editorBorderIndexes = lines
-      .map((line, index) => (/^─+$/.test(line) ? index : -1))
-      .filter((index) => index >= 0);
 
-    assert.ok(suggestionIndex >= 0);
-    assert.ok(editorBorderIndexes.length >= 2);
-    assert.ok(suggestionIndex < editorBorderIndexes[editorBorderIndexes.length - 2]!);
-    assert.equal(editorBorderIndexes[editorBorderIndexes.length - 1], statusLineIndex - 1);
+    // The autocomplete menu (→ cursor) renders above the editor's top border.
+    assert.ok(cursorIndex >= 0);
+    assert.ok(cursorIndex < editorTopBorder);
+    // The menu carries /model, scoped to the overlay rather than the home hint.
+    assert.ok(autocompleteSuggestionLines(lines).some((line) => line.includes('/model')));
+    // The editor's bottom border sits just above the statusline.
+    assert.equal(editorBottomBorder, statusLineIndex - 1);
 
     exitMaka(terminal);
     await Promise.race([
@@ -3318,29 +3338,41 @@ describe('Maka Pi TUI runner', () => {
 
     terminal.input('/');
 
-    await waitFor(() => plainTerminalOutput(terminal.screenOutput()).includes('/session'));
+    await waitFor(() => {
+      const lines = plainTerminalOutput(terminal.screenOutput()).split(/\r?\n/);
+      return autocompleteSuggestionLines(lines).some((line) => line.includes('/session'));
+    });
     const beforeLines = plainTerminalOutput(terminal.screenOutput()).split(/\r?\n/);
     const beforeRows = inputSurfaceRows(beforeLines);
-    const beforeSessionRow = beforeLines.findIndex((line) => line.includes('/session'));
 
     terminal.input('s');
 
     await waitFor(() => {
-      const output = plainTerminalOutput(terminal.screenOutput());
-      return output.includes('/session') && !output.includes('/model');
+      const suggestions = autocompleteSuggestionLines(
+        plainTerminalOutput(terminal.screenOutput()).split(/\r?\n/),
+      );
+      return (
+        suggestions.some((line) => line.includes('/session')) &&
+        !suggestions.some((line) => line.includes('/model'))
+      );
     });
     const afterLines = plainTerminalOutput(terminal.screenOutput()).split(/\r?\n/);
     const afterRows = inputSurfaceRows(afterLines);
-    const afterSessionRow = afterLines.findIndex((line) => line.includes('/session'));
-    const afterSkillRow = afterLines.findIndex((line) => line.includes('/skill'));
-    const afterSetupRow = afterLines.findIndex((line) => line.includes('/setup'));
+    const afterSuggestions = autocompleteSuggestionLines(afterLines);
 
-    assert.ok(beforeSessionRow >= 0);
+    // The input surface did not shift while filtering.
     assert.deepEqual(afterRows, beforeRows);
-    // The 's' filter matches three commands — /session, /setup, /skill — bottom-aligned.
-    assert.equal(afterSkillRow, afterRows[0] - 1);
-    assert.equal(afterSetupRow, afterRows[0] - 2);
-    assert.equal(afterSessionRow, afterRows[0] - 3);
+    // The 's' filter matches three commands — /session, /setup, /skill — bottom-
+    // aligned immediately above the editor's top border. Scope to the overlay so
+    // the empty-session home's /session /model /setup hints don't collide (#1098).
+    assert.equal(afterSuggestions.length, 3);
+    assert.deepEqual(
+      afterSuggestions.map((line) => line.match(/\/\w+/)?.[0]),
+      ['/session', '/setup', '/skill'],
+    );
+    assert.ok(afterLines[afterRows[0] - 1]!.includes('/skill'));
+    assert.ok(afterLines[afterRows[0] - 2]!.includes('/setup'));
+    assert.ok(afterLines[afterRows[0] - 3]!.includes('/session'));
 
     exitMaka(terminal);
     await Promise.race([
@@ -3645,7 +3677,10 @@ describe('Maka Pi TUI runner', () => {
 
     terminal.input('/m');
 
-    await waitFor(() => plainTerminalOutput(terminal.output()).includes('/model'));
+    await waitFor(() => {
+      const lines = plainTerminalOutput(terminal.screenOutput()).split(/\r?\n/);
+      return autocompleteSuggestionLines(lines).some((line) => line.includes('/model'));
+    });
     terminal.input('\r');
     await waitFor(() => terminal.output().includes('Select Model'));
 
@@ -5145,9 +5180,7 @@ describe('Maka Pi TUI runner', () => {
     // /new empties the transcript, so it opens on the same welcome block as a
     // cold start rather than a one-off notice — that block is the "fresh session"
     // cue and a notice would suppress it.
-    await waitFor(() =>
-      plainTerminalOutput(terminal.screenOutput()).includes('输入消息开始对话，或用斜杠命令：'),
-    );
+    await waitFor(() => plainTerminalOutput(terminal.screenOutput()).includes('陪你把事做完'));
     // The previous turn is gone from the visible transcript.
     await waitFor(() => !plainTerminalOutput(terminal.screenOutput()).includes('remember this'));
     assert.equal(terminal.titles.at(-1), 'Maka');

--- a/packages/cli/src/__tests__/tui-terminal-mock.ts
+++ b/packages/cli/src/__tests__/tui-terminal-mock.ts
@@ -78,6 +78,27 @@ export function inputSurfaceRows(lines: readonly string[]): [number, number] {
   ];
 }
 
+/**
+ * The slash-autocomplete suggestion rows on the input surface: the contiguous
+ * `/command` lines sitting immediately above the editor's top border. The
+ * empty-session home also renders `/session `/model `/setup as hint text
+ * (#1098), so autocomplete assertions scope here instead of grepping the whole
+ * screen, which would pick up the home's hints and misorder them against the
+ * menu. Returns an empty list until the autocomplete menu is open (its → cursor
+ * is absent from the home) so this is safe to call inside a polling waitFor.
+ */
+export function autocompleteSuggestionLines(lines: readonly string[]): readonly string[] {
+  if (!lines.some((line) => line.includes('→'))) return [];
+  const editorBorders = lines
+    .map((line, index) => (/^─+$/.test(line) ? index : -1))
+    .filter((index) => index >= 0);
+  if (editorBorders.length < 2) return [];
+  const editorTopBorder = editorBorders[editorBorders.length - 2]!;
+  let start = editorTopBorder;
+  while (start > 0 && /\/\w/.test(lines[start - 1]!)) start -= 1;
+  return lines.slice(start, editorTopBorder);
+}
+
 export function assertBottomPickerPlacement(
   terminal: FakeTerminal,
   title: string,

--- a/packages/cli/src/pi-transcript.ts
+++ b/packages/cli/src/pi-transcript.ts
@@ -1020,7 +1020,7 @@ export function renderMakaPiTranscript(
   // first screen greets and orients instead of showing an empty pane. Once the
   // first prompt lands, entries take over and it never renders again.
   if (state.entries.length === 0 && !state.pendingInteraction) {
-    return renderWelcomeBlock(metadata, safeWidth);
+    return renderWelcomeBlock(safeWidth);
   }
 
   const entryFirstLine = new Map<MakaPiTranscriptEntry, number>();
@@ -1567,26 +1567,46 @@ function renderNotice(entry: MakaPiNoticeEntry, width: number): string[] {
   return renderIndented(`${label}: ${entry.text}`, width, 0).map((line) => fitLine(line, width));
 }
 
-// Shown on a fresh, empty session. Greets, states where we are (model /
-// connection / folder), and lists the handful of commands and keys worth
-// knowing up front — enough to start without reading docs.
-function renderWelcomeBlock(metadata: MakaPiTranscriptMetadata, width: number): string[] {
-  // Point at /help for the full command list rather than duplicating it here —
-  // the autocomplete already teaches commands as you type. Just the greeting plus
-  // the keys you cannot discover by typing `/`.
-  const tips: [string, string][] = [
-    ['/help', '查看全部命令与快捷键'],
-    ['Ctrl+O', '展开或折叠工具输出'],
-    ['Esc Esc', '回退到较早的轮次'],
+// Shown on a fresh, empty session. Greets with the branded maka wordmark and a
+// short tagline, then points at the command-center entry points (direct input,
+// /session, /model, /setup) — enough to start without reading docs.
+// Four-line lowercase ASCII maka wordmark in Maka blue (#1098). Pure ASCII so it
+// renders under any locale; stored without trailing spaces so the welcome lines
+// and their tests agree after rtrim. A terminal too narrow to fit it falls back
+// to a single `maka` line — see renderWelcomeBlock.
+const MAKA_WORDMARK_LINES = [
+  ' _ __    __ _  _  __   __ _',
+  "| '_ \\  / _` | | |/ / / _` |",
+  '| |_) | | (_| | |   <  | (_| |',
+  '|_.__/  \\__,_| |_|\\_\\  \\__,_|',
+];
+const MAKA_WORDMARK_WIDTH = Math.max(...MAKA_WORDMARK_LINES.map((line) => line.length));
+
+function renderWelcomeBlock(width: number): string[] {
+  // The branded home greets with the maka wordmark, a short Chinese-first
+  // tagline, and the command-center entry points (direct input, /session,
+  // /model, /setup) so a fresh session shows the main actions without typing
+  // `/`. The active model and connection live in the statusline, so the
+  // welcome does not repeat them.
+  const hints: [string, string][] = [
+    ['/session', '切换或恢复会话'],
+    ['/model', '切换模型'],
+    ['/setup', '配置模型提供商'],
   ];
-  const keyWidth = Math.max(...tips.map(([key]) => key.length));
-  const lines = [
-    fitLine(ansi.accent('maka'), width),
-    fitLine(ansi.dim(`${metadata.model} · ${metadata.connectionSlug} · ${metadata.cwd}`), width),
-    '',
-    fitLine('输入消息开始对话，或用斜杠命令：', width),
-  ];
-  for (const [key, description] of tips) {
+  const keyWidth = Math.max(...hints.map(([key]) => key.length));
+  const lines: string[] = [];
+  if (width < MAKA_WORDMARK_WIDTH) {
+    lines.push(fitLine(ansi.accent('maka'), width));
+  } else {
+    for (const line of MAKA_WORDMARK_LINES) {
+      lines.push(fitLine(ansi.accent(line), width));
+    }
+  }
+  lines.push('');
+  lines.push(fitLine(ansi.dim('陪你把事做完'), width));
+  lines.push('');
+  lines.push(fitLine('  输入消息开始对话', width));
+  for (const [key, description] of hints) {
     lines.push(fitLine(ansi.dim(`  ${key.padEnd(keyWidth)}  ${description}`), width));
   }
   return lines;


### PR DESCRIPTION
## Summary

The standalone TUI's fresh empty session had little product identity or task guidance: a single `maka` line, a model/connection/folder orientation line that duplicated the statusline, and three tips (`/help`, `Ctrl+O`, `Esc Esc`).

This PR renders the welcome as the branded home from #1098:

- A four-line lowercase ASCII `maka` wordmark in Maka blue (`ansi.accent`).
- A short Chinese-first tagline, `陪你把事做完`.
- Command-center hints for direct input + `/session` + `/model` + `/setup`. Autocomplete already teaches commands as you type, so `/help` is no longer a home hint.
- A terminal too narrow for the wordmark falls back to a single `maka` line; the tagline and hints stay. The fallback width is derived from the wordmark's literal longest line, not hardcoded.
- The active model/connection live in the statusline, so the welcome no longer repeats them.

The change is confined to `renderWelcomeBlock` in `packages/cli/src/pi-transcript.ts`.

Two pre-existing slash-autocomplete tests grepped the whole screen for `/model`/`/session`/etc. and assumed the welcome contained none; the home now legitimately shows those as hints (#1098). They now scope to the autocomplete overlay via a new `autocompleteSuggestionLines` test helper, gated on the menu's `→` cursor so polling `waitFor` calls don't match the home's hints.

Refs #1098 — does not close it; seams 2 (searchable `/model`) and 3 (`/setup` model curation) remain.

## Verification

- `npm --workspace maka-agent run build` (tsc) — passes.
- `npm --workspace maka-agent run test:dist` — 604/604 pass.
- `npm run format:check` — clean.
- `npm run lint` — clean.
- Live render of the empty-session home:

```
wide (width 100):
 _ __    __ _  _  __   __ _
| '_ \  / _` | | |/ / / _` |
| |_) | | (_| | |   <  | (_| |
|_.__/  \__,_| |_|\_\  \__,_|

陪你把事做完

  输入消息开始对话
  /session  切换或恢复会话
  /model    切换模型
  /setup    配置模型提供商

narrow (width 29, below the wordmark's 30-col width):
maka

陪你把事做完

  输入消息开始对话
  /session  切换或恢复会话
  /model    切换模型
  /setup    配置模型提供商
```

The wordmark's first line is wrapped in `\x1b[38;2;87;163;239m` (Maka blue), the same accent the `uses logo blue for TUI accent chrome` contract locks.

New/updated contracts (red → green): the branded home content, the narrow-terminal fallback at the wordmark-width boundary, and `/new` reopening the same home.

## Review focus

The four-line wordmark is a creative asset. If the exact ASCII art should differ (a specific figlet font, different letterforms), that is the one thing worth a pass before merge; everything else is mechanical.