### PR TITLE
feat(cli): complete /setup model curation with live model-choice refresh

### DIFF
--- a/packages/cli/src/__tests__/onboarding.test.ts
+++ b/packages/cli/src/__tests__/onboarding.test.ts
@@ -250,6 +250,8 @@ describe('saveApiKeyConnection', () => {
         },
       },
       credentialStore: {
+        getSecret: async () => null,
+        deleteSecret: async () => {},
         setSecret: async (slug, _kind, value) => {
           storedSecrets.push({ slug, value });
         },
@@ -302,6 +304,8 @@ describe('saveApiKeyConnection', () => {
         setDefault: async () => {},
       },
       credentialStore: {
+        getSecret: async () => null,
+        deleteSecret: async () => {},
         setSecret: async () => {
           throw new Error('disk full');
         },
@@ -312,6 +316,85 @@ describe('saveApiKeyConnection', () => {
     assert.equal(result.kind, 'error');
     assert.match((result as { text: string }).text, /disk full/);
     assert.deepEqual(removedSlugs, ['openai']);
+  });
+
+  test('rolls back a newly created connection and secret when the model update fails', async () => {
+    const removedSlugs: string[] = [];
+    const deletedSecrets: Array<{ slug: string; kind?: string }> = [];
+    const result = await saveApiKeyConnection({
+      providerType: 'openai',
+      apiKey: 'sk-new',
+      enabledModelIds: ['gpt-5.5'],
+      models: [{ id: 'gpt-5.5' }],
+      connectionStore: {
+        get: async () => null,
+        create: async (input) =>
+          makeConnection({ slug: input.slug, providerType: input.providerType }),
+        update: async () => {
+          throw new Error('disk full');
+        },
+        remove: async (slug) => {
+          removedSlugs.push(slug);
+        },
+        getDefault: async () => null,
+        setDefault: async () => {},
+      },
+      credentialStore: {
+        getSecret: async () => null,
+        setSecret: async () => {},
+        deleteSecret: async (slug, kind) => {
+          deletedSecrets.push({ slug, kind });
+        },
+      },
+      fetchModelChoices: async () => [],
+    });
+
+    assert.equal(result.kind, 'error');
+    assert.match((result as { text: string }).text, /disk full/);
+    assert.deepEqual(removedSlugs, ['openai']);
+    assert.deepEqual(deletedSecrets, [{ slug: 'openai', kind: 'api_key' }]);
+  });
+
+  test('rolls back a rotated secret when the model update fails on an existing connection', async () => {
+    const secretWrites: string[] = [];
+    let currentSecret = 'sk-old';
+    const result = await saveApiKeyConnection({
+      providerType: 'openai',
+      apiKey: 'sk-new',
+      enabledModelIds: ['gpt-5.5'],
+      models: [{ id: 'gpt-5.5' }],
+      connectionStore: {
+        get: async () =>
+          makeConnection({ slug: 'openai', providerType: 'openai', defaultModel: 'gpt-5.5' }),
+        create: async () => {
+          throw new Error('create must not be called for an existing connection');
+        },
+        update: async () => {
+          throw new Error('disk full');
+        },
+        remove: async () => {},
+        getDefault: async () => 'openai',
+        setDefault: async () => {
+          throw new Error('setDefault must not be called when a default already exists');
+        },
+      },
+      credentialStore: {
+        getSecret: async () => currentSecret,
+        setSecret: async (_slug, _kind, value) => {
+          secretWrites.push(value);
+          currentSecret = value;
+        },
+        deleteSecret: async () => {
+          throw new Error('deleteSecret must not be called when an old secret exists');
+        },
+      },
+      fetchModelChoices: async () => [],
+    });
+
+    assert.equal(result.kind, 'error');
+    assert.match((result as { text: string }).text, /disk full/);
+    assert.deepEqual(secretWrites, ['sk-new', 'sk-old']);
+    assert.equal(currentSecret, 'sk-old');
   });
 
   test('updates an existing connection without rotating the key when it is blank', async () => {
@@ -342,6 +425,8 @@ describe('saveApiKeyConnection', () => {
         },
       },
       credentialStore: {
+        getSecret: async () => null,
+        deleteSecret: async () => {},
         setSecret: async () => {
           secretStored = true;
         },
@@ -377,6 +462,8 @@ describe('saveApiKeyConnection', () => {
         setDefault: async () => {},
       },
       credentialStore: {
+        getSecret: async () => null,
+        deleteSecret: async () => {},
         setSecret: async () => {
           throw new Error('disk full');
         },
@@ -411,7 +498,11 @@ describe('saveApiKeyConnection', () => {
           if (slug) setDefaultCalls.push(slug);
         },
       },
-      credentialStore: { setSecret: async () => {} },
+      credentialStore: {
+        getSecret: async () => null,
+        setSecret: async () => {},
+        deleteSecret: async () => {},
+      },
       fetchModelChoices: async () => [],
     });
 
@@ -449,7 +540,11 @@ describe('saveApiKeyConnection', () => {
           getDefault: async () => 'openai',
           setDefault: async () => {},
         },
-        credentialStore: { setSecret: async () => {} },
+        credentialStore: {
+          getSecret: async () => null,
+          setSecret: async () => {},
+          deleteSecret: async () => {},
+        },
         fetchModelChoices: async () => [],
       });
       assert.equal(savedDefault, expected);
@@ -480,6 +575,8 @@ describe('saveApiKeyConnection', () => {
         setDefault: async () => {},
       },
       credentialStore: {
+        getSecret: async () => null,
+        deleteSecret: async () => {},
         setSecret: async () => {
           secretStored = true;
         },
@@ -508,7 +605,11 @@ describe('saveApiKeyConnection', () => {
         getDefault: async () => null,
         setDefault: async () => {},
       },
-      credentialStore: { setSecret: async () => {} },
+      credentialStore: {
+        getSecret: async () => null,
+        setSecret: async () => {},
+        deleteSecret: async () => {},
+      },
       fetchModelChoices: async () => [],
     });
 

--- a/packages/cli/src/__tests__/onboarding.test.ts
+++ b/packages/cli/src/__tests__/onboarding.test.ts
@@ -2,157 +2,246 @@ import assert from 'node:assert/strict';
 import { describe, test } from 'node:test';
 import type { LlmConnection, ModelInfo, ProviderType } from '@maka/core/llm-connections';
 import type { ConnectionStore, CredentialStore } from '@maka/storage';
-import { listApiKeyOnboardableProviders, setupApiKeyConnection } from '../onboarding.js';
+import {
+  listApiKeyOnboardableProviders,
+  listOnboardingProviders,
+  saveApiKeyConnection,
+  verifyApiKeyConnection,
+} from '../onboarding.js';
 
-describe('setupApiKeyConnection', () => {
-  test('creates the connection, stores the API key secret, and returns discovered models', async () => {
-    const createdInputs: Array<{ slug: string; providerType: ProviderType }> = [];
-    const storedSecrets: Array<{ slug: string; kind: string; value: string }> = [];
-    const fakeModels: ModelInfo[] = [{ id: 'gpt-5.5' }, { id: 'gpt-5.5-mini' }];
-
-    const result = await setupApiKeyConnection({
-      providerType: 'openai',
+describe('listOnboardingProviders', () => {
+  test('marks existing connections as set and carries their enabled model ids', async () => {
+    const openai = makeConnection({
       slug: 'openai',
+      providerType: 'openai',
+      defaultModel: 'gpt-5.5',
+      enabledModelIds: ['gpt-5.5', 'gpt-5.5-mini'],
+    });
+
+    const providers = await listOnboardingProviders({
+      connectionStore: {
+        list: async () => [openai],
+      },
+    });
+
+    const openaiEntry = providers.find((p) => p.providerType === 'openai');
+    assert.equal(openaiEntry?.hasConnection, true);
+    assert.deepEqual(openaiEntry?.enabledModelIds, ['gpt-5.5', 'gpt-5.5-mini']);
+    // A provider with no connection is not marked set and starts with no models.
+    const anthropic = providers.find((p) => p.providerType === 'anthropic');
+    assert.equal(anthropic?.hasConnection, false);
+    assert.deepEqual(anthropic?.enabledModelIds, []);
+  });
+
+  test('only lists API-key providers that do not require a base url', async () => {
+    const providers = await listOnboardingProviders({
+      connectionStore: { list: async () => [] },
+    });
+    for (const provider of providers) {
+      assert.equal(provider.requiresBaseUrl, false);
+      assert.ok(provider.authKind === 'api_key' || provider.authKind === 'optional_api_key');
+    }
+    assert.ok(!providers.some((p) => p.providerType === 'ollama'));
+  });
+});
+
+describe('verifyApiKeyConnection', () => {
+  test('probes a new connection with the supplied key without persisting', async () => {
+    let created = false;
+    let secretStored = false;
+    let defaultSet = false;
+    let probed: Array<{ slug: string; providerType: ProviderType; apiKey: string }> = [];
+    const connectionStore: Pick<
+      ConnectionStore,
+      'get' | 'create' | 'update' | 'remove' | 'getDefault' | 'setDefault'
+    > = {
+      get: async () => null,
+      create: async () => {
+        created = true;
+        return makeConnection({});
+      },
+      update: async () => {
+        throw new Error('update must not be called during verify');
+      },
+      remove: async () => {},
+      getDefault: async () => null,
+      setDefault: async () => {
+        defaultSet = true;
+      },
+    };
+    const credentialStore: Pick<CredentialStore, 'getSecret' | 'setSecret'> = {
+      getSecret: async () => null,
+      setSecret: async () => {
+        secretStored = true;
+      },
+    };
+
+    const result = await verifyApiKeyConnection({
+      providerType: 'openai',
       apiKey: 'sk-test',
+      connectionStore,
+      credentialStore,
+      fetchModels: async (connection, apiKey) => {
+        probed.push({ slug: connection.slug, providerType: connection.providerType, apiKey });
+        return [{ id: 'gpt-5.5' }];
+      },
+    });
+
+    assert.deepEqual(result, { kind: 'ok', models: [{ id: 'gpt-5.5' }] });
+    assert.equal(created, false, 'verify must not create the connection');
+    assert.equal(secretStored, false, 'verify must not store the secret');
+    assert.equal(defaultSet, false, 'verify must not set the default');
+    assert.equal(probed.length, 1);
+    assert.equal(probed[0]!.apiKey, 'sk-test');
+    assert.equal(probed[0]!.providerType, 'openai');
+  });
+
+  test('rejects a blank key for a new required-key provider without probing', async () => {
+    let probed = false;
+    const result = await verifyApiKeyConnection({
+      providerType: 'openai',
+      apiKey: '   ',
+      connectionStore: { get: async () => null },
+      credentialStore: { getSecret: async () => null },
+      fetchModels: async () => {
+        probed = true;
+        return [];
+      },
+    });
+
+    assert.equal(result.kind, 'error');
+    assert.match((result as { text: string }).text, /API key is required/);
+    assert.equal(probed, false);
+  });
+
+  test('reuses the stored secret for an existing connection when the key is blank', async () => {
+    let probedKey = '';
+    let secretStored = false;
+    const credentialStore: Pick<CredentialStore, 'getSecret' | 'setSecret'> = {
+      getSecret: async () => 'stored-key',
+      setSecret: async () => {
+        secretStored = true;
+      },
+    };
+    const result = await verifyApiKeyConnection({
+      providerType: 'openai',
+      apiKey: '',
+      connectionStore: {
+        get: async () => makeConnection({ slug: 'openai', providerType: 'openai' }),
+      },
+      credentialStore,
+      fetchModels: async (_connection, apiKey) => {
+        probedKey = apiKey;
+        return [{ id: 'gpt-5.5' }];
+      },
+    });
+
+    assert.equal(result.kind, 'ok');
+    assert.equal(probedKey, 'stored-key');
+    assert.equal(secretStored, false, 'verify must not rotate the stored key');
+  });
+
+  test('probes with a newly supplied key for an existing connection (rotation preview)', async () => {
+    let probedKey = '';
+    let readStored = false;
+    const result = await verifyApiKeyConnection({
+      providerType: 'openai',
+      apiKey: 'sk-rotated',
+      connectionStore: {
+        get: async () => makeConnection({ slug: 'openai', providerType: 'openai' }),
+      },
+      credentialStore: {
+        getSecret: async () => {
+          readStored = true;
+          return 'stored-key';
+        },
+      },
+      fetchModels: async (_connection, apiKey) => {
+        probedKey = apiKey;
+        return [{ id: 'gpt-5.5' }];
+      },
+    });
+
+    assert.equal(result.kind, 'ok');
+    assert.equal(probedKey, 'sk-rotated');
+    assert.equal(readStored, false, 'a supplied key short-circuits the stored secret read');
+  });
+
+  test('records a probe failure as an error without throwing', async () => {
+    const result = await verifyApiKeyConnection({
+      providerType: 'openai',
+      apiKey: 'sk-bad',
+      connectionStore: { get: async () => null },
+      credentialStore: { getSecret: async () => null },
+      fetchModels: async () => {
+        throw new Error('HTTP 401');
+      },
+    });
+
+    assert.deepEqual(result, { kind: 'error', text: 'HTTP 401' });
+  });
+
+  test('rejects a provider that does not accept an API key before probing', async () => {
+    let probed = false;
+    const result = await verifyApiKeyConnection({
+      providerType: 'ollama',
+      apiKey: 'unused',
+      connectionStore: { get: async () => null },
+      credentialStore: { getSecret: async () => null },
+      fetchModels: async () => {
+        probed = true;
+        return [];
+      },
+    });
+
+    assert.equal(result.kind, 'error');
+    assert.match((result as { text: string }).text, /does not accept an API key/);
+    assert.equal(probed, false);
+  });
+});
+
+describe('saveApiKeyConnection', () => {
+  test('persists a new connection with curation and sets default only when none exists', async () => {
+    const createdInputs: Array<{ slug: string; providerType: ProviderType; defaultModel: string }> =
+      [];
+    const updatedPatches: Array<{
+      enabledModelIds?: string[];
+      defaultModel?: string;
+      models?: ModelInfo[];
+      lastTestStatus?: string;
+    }> = [];
+    const storedSecrets: Array<{ slug: string; value: string }> = [];
+    let defaultSlug: string | null = null;
+    const setDefaultCalls: string[] = [];
+
+    const result = await saveApiKeyConnection({
+      providerType: 'openai',
+      apiKey: 'sk-test',
+      enabledModelIds: ['gpt-5.5', 'gpt-5.5-mini'],
+      models: [{ id: 'gpt-5.5' }, { id: 'gpt-5.5-mini' }],
       connectionStore: {
         get: async () => null,
         create: async (input) => {
-          createdInputs.push({ slug: input.slug, providerType: input.providerType });
+          createdInputs.push({
+            slug: input.slug,
+            providerType: input.providerType,
+            defaultModel: input.defaultModel ?? '',
+          });
           return makeConnection({
             slug: input.slug,
             providerType: input.providerType,
-            defaultModel: 'gpt-5.5',
+            defaultModel: input.defaultModel ?? 'gpt-5.5',
           });
         },
-        remove: async () => {},
-        getDefault: async () => null,
-        setDefault: async () => {},
-      } satisfies Pick<ConnectionStore, 'create' | 'get' | 'remove' | 'getDefault' | 'setDefault'>,
-      credentialStore: {
-        setSecret: async (slug, kind, value) => {
-          storedSecrets.push({ slug, kind, value });
+        update: async (_slug, patch) => {
+          updatedPatches.push({
+            enabledModelIds: patch.enabledModelIds,
+            defaultModel: patch.defaultModel,
+            models: patch.models,
+            lastTestStatus: patch.lastTestStatus,
+          });
+          return makeConnection({ slug: 'openai', providerType: 'openai' });
         },
-      } satisfies Pick<CredentialStore, 'setSecret'>,
-      fetchModels: async () => fakeModels,
-    });
-
-    // The connection is persisted with the chosen slug and provider type.
-    assert.deepEqual(createdInputs, [{ slug: 'openai', providerType: 'openai' }]);
-    // The API key is stored under the connection slug, typed api_key.
-    assert.deepEqual(storedSecrets, [{ slug: 'openai', kind: 'api_key', value: 'sk-test' }]);
-    // The created connection and the discovered models come back for the next step.
-    assert.equal(result.connection.slug, 'openai');
-    assert.deepEqual(
-      result.models.map((m) => m.id),
-      ['gpt-5.5', 'gpt-5.5-mini'],
-    );
-  });
-
-  test('records a model-fetch failure as a non-blocking test error instead of throwing', async () => {
-    const result = await setupApiKeyConnection({
-      providerType: 'openai',
-      slug: 'openai',
-      apiKey: 'sk-test',
-      connectionStore: {
-        get: async () => null,
-        create: async (input) =>
-          makeConnection({ slug: input.slug, providerType: input.providerType }),
-        remove: async () => {},
-        getDefault: async () => null,
-        setDefault: async () => {},
-      },
-      credentialStore: {
-        setSecret: async () => {},
-      },
-      fetchModels: async () => {
-        throw new Error('HTTP 401');
-      },
-    });
-
-    // A failing probe (wrong key, offline, no /models endpoint) must not abort
-    // onboarding — the connection is already saved; the wizard offers manual entry.
-    assert.deepEqual(result.models, []);
-    assert.equal(result.testError, 'HTTP 401');
-  });
-
-  test('a failing probe does not make the broken connection the default', async () => {
-    const setDefaultCalls: string[] = [];
-    const result = await setupApiKeyConnection({
-      providerType: 'openai',
-      slug: 'openai',
-      apiKey: 'sk-typo',
-      connectionStore: {
-        get: async () => null,
-        create: async (input) =>
-          makeConnection({ slug: input.slug, providerType: input.providerType }),
-        remove: async () => {},
-        getDefault: async () => null,
-        setDefault: async (slug) => {
-          if (slug) setDefaultCalls.push(slug);
-        },
-      } satisfies Pick<ConnectionStore, 'create' | 'get' | 'remove' | 'getDefault' | 'setDefault'>,
-      credentialStore: {
-        setSecret: async () => {},
-      } satisfies Pick<CredentialStore, 'setSecret'>,
-      fetchModels: async () => {
-        throw new Error('HTTP 401');
-      },
-    });
-
-    // The connection is saved (retrying rotates the key), but a broken key
-    // must NOT become the default — otherwise the host would report it as
-    // configured and trap the next launch out of onboarding.
-    assert.equal(result.testError, 'HTTP 401');
-    assert.deepEqual(setDefaultCalls, []);
-  });
-
-  test('rejects a provider that does not accept an API key before touching the stores', async () => {
-    let created = false;
-    let stored = false;
-
-    await assert.rejects(
-      setupApiKeyConnection({
-        providerType: 'ollama', // authKind 'none' — keyless local model
-        slug: 'ollama',
-        apiKey: 'unused',
-        connectionStore: {
-          get: async () => null,
-          create: async () => {
-            created = true;
-            return makeConnection({});
-          },
-          remove: async () => {},
-          getDefault: async () => null,
-          setDefault: async () => {},
-        },
-        credentialStore: {
-          setSecret: async () => {
-            stored = true;
-          },
-        },
-        fetchModels: async () => [],
-      }),
-      /does not accept an API key/,
-    );
-
-    // The guard fires before any write so a miscategorized provider never gets
-    // a bogus api_key secret persisted.
-    assert.equal(created, false);
-    assert.equal(stored, false);
-  });
-
-  test('makes the new connection the default even when one already exists', async () => {
-    let defaultSlug: string | null = 'old-default';
-    const setDefaultCalls: string[] = [];
-
-    await setupApiKeyConnection({
-      providerType: 'openai',
-      slug: 'openai',
-      apiKey: 'sk-test',
-      connectionStore: {
-        get: async () => null,
-        create: async (input) =>
-          makeConnection({ slug: input.slug, providerType: input.providerType }),
         remove: async () => {},
         getDefault: async () => defaultSlug,
         setDefault: async (slug) => {
@@ -161,163 +250,270 @@ describe('setupApiKeyConnection', () => {
         },
       },
       credentialStore: {
-        setSecret: async () => {},
+        setSecret: async (slug, _kind, value) => {
+          storedSecrets.push({ slug, value });
+        },
       },
-      fetchModels: async () => [],
+      fetchModelChoices: async () => [
+        {
+          connectionSlug: 'openai',
+          connectionName: 'OpenAI',
+          providerType: 'openai',
+          model: 'gpt-5.5',
+          isDefaultConnection: true,
+        },
+      ],
     });
 
-    // A freshly onboarded connection becomes the active default so the first turn runs on it.
+    assert.equal(result.kind, 'ok');
+    // The secret is written for a new connection.
+    assert.deepEqual(storedSecrets, [{ slug: 'openai', value: 'sk-test' }]);
+    // The connection is created then updated with the curated enabled set + cache.
+    assert.equal(createdInputs.length, 1);
+    assert.equal(createdInputs[0]!.slug, 'openai');
+    assert.equal(updatedPatches.length, 1);
+    assert.deepEqual(updatedPatches[0]!.enabledModelIds, ['gpt-5.5', 'gpt-5.5-mini']);
+    assert.deepEqual(updatedPatches[0]!.models, [{ id: 'gpt-5.5' }, { id: 'gpt-5.5-mini' }]);
+    assert.equal(updatedPatches[0]!.lastTestStatus, 'verified');
+    // No default existed, so the new connection becomes the default.
     assert.deepEqual(setDefaultCalls, ['openai']);
+    // The refreshed ready model choices come back for the running TUI.
+    assert.equal((result as { modelChoices: unknown[] }).modelChoices.length, 1);
   });
 
-  test('rejects an empty API key for a provider that requires one, before touching the stores', async () => {
-    let created = false;
-    await assert.rejects(
-      setupApiKeyConnection({
-        providerType: 'openai', // authKind 'api_key' (required)
-        slug: 'openai',
-        apiKey: '   ',
-        connectionStore: {
-          get: async () => null,
-          create: async () => {
-            created = true;
-            return makeConnection({});
-          },
-          remove: async () => {},
-          getDefault: async () => null,
-          setDefault: async () => {},
-        },
-        credentialStore: {
-          setSecret: async () => {},
-        },
-        fetchModels: async () => [],
-      }),
-      /API key is required/,
-    );
-    assert.equal(created, false);
-  });
-
-  test('passes a custom baseUrl through to the created connection', async () => {
-    const createdInputs: Array<{ baseUrl?: string }> = [];
-    await setupApiKeyConnection({
+  test('rolls back a newly created connection when the secret write fails', async () => {
+    const removedSlugs: string[] = [];
+    const result = await saveApiKeyConnection({
       providerType: 'openai',
-      slug: 'self-hosted',
       apiKey: 'sk-test',
-      baseUrl: 'https://my-gateway.example/v1',
+      enabledModelIds: ['gpt-5.5'],
+      models: [{ id: 'gpt-5.5' }],
       connectionStore: {
         get: async () => null,
-        create: async (input) => {
-          createdInputs.push(input);
-          return makeConnection({ slug: input.slug, providerType: input.providerType });
+        create: async (input) =>
+          makeConnection({ slug: input.slug, providerType: input.providerType }),
+        update: async () => {
+          throw new Error('update must not be called when the secret write fails');
         },
-        remove: async () => {},
+        remove: async (slug) => {
+          removedSlugs.push(slug);
+        },
         getDefault: async () => null,
         setDefault: async () => {},
       },
       credentialStore: {
-        setSecret: async () => {},
+        setSecret: async () => {
+          throw new Error('disk full');
+        },
       },
-      fetchModels: async () => [],
+      fetchModelChoices: async () => [],
     });
 
-    assert.equal(createdInputs[0]?.baseUrl, 'https://my-gateway.example/v1');
+    assert.equal(result.kind, 'error');
+    assert.match((result as { text: string }).text, /disk full/);
+    assert.deepEqual(removedSlugs, ['openai']);
   });
 
-  test('rotates the key when the slug already exists instead of creating a duplicate (upsert)', async () => {
-    // Re-onboarding the same provider (e.g. fixing a typo'd key) must update the
-    // secret on the existing connection rather than throw "slug already exists".
-    const storedSecrets: Array<{ slug: string; value: string }> = [];
-
-    const result = await setupApiKeyConnection({
+  test('updates an existing connection without rotating the key when it is blank', async () => {
+    let secretStored = false;
+    const updatedPatches: Array<{ enabledModelIds?: string[]; defaultModel?: string }> = [];
+    const result = await saveApiKeyConnection({
       providerType: 'openai',
-      slug: 'openai',
-      apiKey: 'key-rotated',
+      apiKey: '',
+      enabledModelIds: ['gpt-5.5', 'gpt-5.5-mini'],
+      models: [{ id: 'gpt-5.5' }, { id: 'gpt-5.5-mini' }],
+      connectionStore: {
+        get: async () =>
+          makeConnection({ slug: 'openai', providerType: 'openai', defaultModel: 'gpt-5.5' }),
+        create: async () => {
+          throw new Error('create must not be called for an existing connection');
+        },
+        update: async (_slug, patch) => {
+          updatedPatches.push({
+            enabledModelIds: patch.enabledModelIds,
+            defaultModel: patch.defaultModel,
+          });
+          return makeConnection({ slug: 'openai', providerType: 'openai' });
+        },
+        remove: async () => {},
+        getDefault: async () => 'openai',
+        setDefault: async () => {
+          throw new Error('setDefault must not be called when a default already exists');
+        },
+      },
+      credentialStore: {
+        setSecret: async () => {
+          secretStored = true;
+        },
+      },
+      fetchModelChoices: async () => [],
+    });
+
+    assert.equal(result.kind, 'ok');
+    assert.equal(secretStored, false, 'a blank key must not rotate the stored secret');
+    assert.equal(updatedPatches.length, 1);
+    assert.deepEqual(updatedPatches[0]!.enabledModelIds, ['gpt-5.5', 'gpt-5.5-mini']);
+  });
+
+  test('rotates the key before updating an existing connection and leaves it untouched on failure', async () => {
+    const storedSecrets: Array<string> = [];
+    let updated = false;
+    const result = await saveApiKeyConnection({
+      providerType: 'openai',
+      apiKey: 'sk-rotated',
+      enabledModelIds: ['gpt-5.5'],
+      models: [{ id: 'gpt-5.5' }],
       connectionStore: {
         get: async () => makeConnection({ slug: 'openai', providerType: 'openai' }),
         create: async () => {
-          throw new Error('create must not be called when the slug already exists');
+          throw new Error('create must not be called');
+        },
+        update: async () => {
+          updated = true;
+          return makeConnection({ slug: 'openai', providerType: 'openai' });
         },
         remove: async () => {},
         getDefault: async () => 'openai',
         setDefault: async () => {},
       },
       credentialStore: {
-        setSecret: async (slug, _kind, value) => {
-          storedSecrets.push({ slug, value });
+        setSecret: async () => {
+          throw new Error('disk full');
         },
-      } satisfies Pick<CredentialStore, 'setSecret'>,
-      fetchModels: async () => [],
+      },
+      fetchModelChoices: async () => [],
     });
 
-    assert.equal(result.connection.slug, 'openai');
-    assert.deepEqual(storedSecrets, [{ slug: 'openai', value: 'key-rotated' }]);
+    assert.equal(result.kind, 'error');
+    assert.match((result as { text: string }).text, /disk full/);
+    assert.equal(updated, false, 'a rotation failure must not update the existing connection');
+    assert.deepEqual(storedSecrets, []);
   });
 
-  test('rolls back a newly created connection when the secret write fails', async () => {
-    // Atomicity: create succeeds, setSecret fails -> the orphan connection is
-    // removed so a half-configured connection never becomes the default.
-    const removedSlugs: string[] = [];
-
-    await assert.rejects(
-      setupApiKeyConnection({
-        providerType: 'openai',
-        slug: 'openai',
-        apiKey: 'sk-test',
-        connectionStore: {
-          get: async () => null,
-          create: async (input) =>
-            makeConnection({ slug: input.slug, providerType: input.providerType }),
-          remove: async (slug) => {
-            removedSlugs.push(slug);
-          },
-          getDefault: async () => null,
-          setDefault: async () => {},
+  test('does not replace an existing default connection during in-session setup', async () => {
+    const setDefaultCalls: string[] = [];
+    const result = await saveApiKeyConnection({
+      providerType: 'anthropic',
+      apiKey: 'sk-test',
+      enabledModelIds: ['claude-sonnet-5'],
+      models: [{ id: 'claude-sonnet-5' }],
+      connectionStore: {
+        get: async (slug) =>
+          slug === 'anthropic'
+            ? makeConnection({ slug: 'anthropic', providerType: 'anthropic' })
+            : null,
+        create: async (input) =>
+          makeConnection({ slug: input.slug, providerType: input.providerType }),
+        update: async () => makeConnection({ slug: 'anthropic', providerType: 'anthropic' }),
+        remove: async () => {},
+        getDefault: async () => 'openai', // another connection is already the default
+        setDefault: async (slug) => {
+          if (slug) setDefaultCalls.push(slug);
         },
-        credentialStore: {
-          setSecret: async () => {
-            throw new Error('disk full');
-          },
-        },
-        fetchModels: async () => [],
-      }),
-      /disk full/,
-    );
+      },
+      credentialStore: { setSecret: async () => {} },
+      fetchModelChoices: async () => [],
+    });
 
-    assert.deepEqual(removedSlugs, ['openai']);
+    assert.equal(result.kind, 'ok');
+    assert.deepEqual(setDefaultCalls, [], 'in-session setup must not replace the existing default');
   });
 
-  test('leaves an existing connection in place when a key rotation secret write fails', async () => {
-    // Upsert atomicity: an existing connection whose key rotation fails must not
-    // be deleted (its previous secret stands); only newly-created ones roll back.
-    const removedSlugs: string[] = [];
-
-    await assert.rejects(
-      setupApiKeyConnection({
+  test('keeps the existing defaultModel when it is still enabled, else picks the first enabled', async () => {
+    const cases: Array<{ existingDefault: string; enabled: string[]; expected: string }> = [
+      { existingDefault: 'gpt-5.5', enabled: ['gpt-5.5', 'gpt-5.5-mini'], expected: 'gpt-5.5' },
+      { existingDefault: 'gpt-4', enabled: ['gpt-5.5', 'gpt-5.5-mini'], expected: 'gpt-5.5' },
+    ];
+    for (const { existingDefault, enabled, expected } of cases) {
+      let savedDefault: string | undefined;
+      await saveApiKeyConnection({
         providerType: 'openai',
-        slug: 'openai',
-        apiKey: 'sk-test',
+        apiKey: '',
+        enabledModelIds: enabled,
+        models: enabled.map((id) => ({ id })),
         connectionStore: {
-          get: async () => makeConnection({ slug: 'openai', providerType: 'openai' }),
+          get: async () =>
+            makeConnection({
+              slug: 'openai',
+              providerType: 'openai',
+              defaultModel: existingDefault,
+            }),
           create: async () => {
             throw new Error('create must not be called');
           },
-          remove: async (slug) => {
-            removedSlugs.push(slug);
+          update: async (_slug, patch) => {
+            savedDefault = patch.defaultModel;
+            return makeConnection({ slug: 'openai', providerType: 'openai' });
           },
+          remove: async () => {},
           getDefault: async () => 'openai',
           setDefault: async () => {},
         },
-        credentialStore: {
-          setSecret: async () => {
-            throw new Error('disk full');
-          },
-        },
-        fetchModels: async () => [],
-      }),
-      /disk full/,
-    );
+        credentialStore: { setSecret: async () => {} },
+        fetchModelChoices: async () => [],
+      });
+      assert.equal(savedDefault, expected);
+    }
+  });
 
-    assert.deepEqual(removedSlugs, []);
+  test('rejects an empty enabled-model set before touching the stores', async () => {
+    let created = false;
+    let updated = false;
+    let secretStored = false;
+    const result = await saveApiKeyConnection({
+      providerType: 'openai',
+      apiKey: 'sk-test',
+      enabledModelIds: [],
+      models: [],
+      connectionStore: {
+        get: async () => null,
+        create: async () => {
+          created = true;
+          return makeConnection({});
+        },
+        update: async () => {
+          updated = true;
+          return makeConnection({});
+        },
+        remove: async () => {},
+        getDefault: async () => null,
+        setDefault: async () => {},
+      },
+      credentialStore: {
+        setSecret: async () => {
+          secretStored = true;
+        },
+      },
+      fetchModelChoices: async () => [],
+    });
+
+    assert.equal(result.kind, 'error');
+    assert.match((result as { text: string }).text, /至少选择一个模型|at least one model/i);
+    assert.equal(created, false);
+    assert.equal(updated, false);
+    assert.equal(secretStored, false);
+  });
+
+  test('rejects a provider that does not accept an API key before persisting', async () => {
+    const result = await saveApiKeyConnection({
+      providerType: 'ollama',
+      apiKey: 'unused',
+      enabledModelIds: ['x'],
+      models: [{ id: 'x' }],
+      connectionStore: {
+        get: async () => null,
+        create: async () => makeConnection({}),
+        update: async () => makeConnection({}),
+        remove: async () => {},
+        getDefault: async () => null,
+        setDefault: async () => {},
+      },
+      credentialStore: { setSecret: async () => {} },
+      fetchModelChoices: async () => [],
+    });
+
+    assert.equal(result.kind, 'error');
+    assert.match((result as { text: string }).text, /does not accept an API key/);
   });
 });
 

--- a/packages/cli/src/__tests__/pi-tui-runner.test.ts
+++ b/packages/cli/src/__tests__/pi-tui-runner.test.ts
@@ -37,6 +37,14 @@ import type {
 import { CliGoalContinuation, type CliGoalTurnHost } from '../cli-goal-continuation.js';
 import type { ModelChoice } from '../connection-target.js';
 import {
+  listApiKeyOnboardableProviders,
+  type MakaOnboardingSurface,
+  type OnboardingProviderEntry,
+  type OnboardingSaveResult,
+  type OnboardingVerifyResult,
+} from '../onboarding.js';
+import type { ModelInfo, ProviderType } from '@maka/core/llm-connections';
+import {
   runMakaPiTui as runMakaPiTuiImpl,
   type MakaPiTuiGoalLifecycle,
   type MakaPiTuiInput,
@@ -119,6 +127,44 @@ function deferred<T>() {
     resolve = done;
   });
   return { promise, resolve };
+}
+
+/** Catalog API-key providers as wizard entries with no existing connection —
+ *  the default `/setup` provider list for tests that don't need 已设置 state. */
+function defaultOnboardingProviders(): OnboardingProviderEntry[] {
+  return listApiKeyOnboardableProviders().map((provider) => ({
+    ...provider,
+    hasConnection: false,
+    enabledModelIds: [],
+  }));
+}
+
+interface FakeOnboardingOpts {
+  providers?: OnboardingProviderEntry[];
+  verify?: (input: {
+    providerType: ProviderType;
+    apiKey?: string;
+  }) => Promise<OnboardingVerifyResult>;
+  save?: (input: {
+    providerType: ProviderType;
+    apiKey?: string;
+    enabledModelIds: readonly string[];
+    models: readonly ModelInfo[];
+  }) => Promise<OnboardingSaveResult>;
+}
+
+/** A controllable `/setup` surface: the wizard calls `listProviders` to open,
+ *  `verify` to check a key and discover models, and `save` to persist. Defaults
+ *  verify two models and save ok so a test can drive the whole flow by opting
+ *  into the branches it cares about. */
+function fakeOnboardingSurface(opts: FakeOnboardingOpts = {}): MakaOnboardingSurface {
+  return {
+    listProviders: async () => opts.providers ?? defaultOnboardingProviders(),
+    verify:
+      opts.verify ??
+      (async () => ({ kind: 'ok', models: [{ id: 'gpt-5.5' }, { id: 'gpt-5.5-mini' }] })),
+    save: opts.save ?? (async () => ({ kind: 'ok', modelChoices: [] })),
+  };
 }
 
 describe('Maka Pi TUI runner', () => {
@@ -275,6 +321,7 @@ describe('Maka Pi TUI runner', () => {
       connectionSlug: 'claude-subscription',
       permissionMode: 'bypass',
       terminal,
+      onboarding: fakeOnboardingSurface(),
     });
 
     await delay(20);
@@ -289,11 +336,12 @@ describe('Maka Pi TUI runner', () => {
       }
     });
 
-    const output = plainTerminalOutput(terminal.writes.join(''));
+    const output = plainTerminalOutput(terminal.screenOutput());
     assert.ok(
       output.includes('Anthropic') || output.includes('OpenAI'),
       'provider picker should list an API-key provider',
     );
+    assert.ok(output.includes('1/3'), 'provider search is step 1/3');
 
     terminal.input('\x1b');
     await delay(30);
@@ -307,10 +355,14 @@ describe('Maka Pi TUI runner', () => {
     ]);
   });
 
-  test('/setup collects an API key after picking a provider and calls onboarding.setup', async () => {
+  test('/setup marks existing connections 已设置 in the provider search', async () => {
     const terminal = new FakeTerminal();
     const driver = new SlashCommandDriver();
-    const setupCalls: Array<{ providerType: string; apiKey: string }> = [];
+    const providers = defaultOnboardingProviders().map((p) =>
+      p.providerType === 'anthropic'
+        ? { ...p, hasConnection: true, enabledModelIds: ['claude-sonnet-5'] }
+        : p,
+    );
     const run = runMakaPiTui({
       title: 'Maka',
       driver,
@@ -319,12 +371,7 @@ describe('Maka Pi TUI runner', () => {
       connectionSlug: 'claude-subscription',
       permissionMode: 'bypass',
       terminal,
-      onboarding: {
-        setup: async (req) => {
-          setupCalls.push(req);
-          return {};
-        },
-      },
+      onboarding: fakeOnboardingSurface({ providers }),
     });
 
     await delay(20);
@@ -337,24 +384,7 @@ describe('Maka Pi TUI runner', () => {
         return false;
       }
     });
-
-    // Enter picks the highlighted provider; the wizard then asks for the API key.
-    terminal.input('\r');
-    await waitFor(() => {
-      try {
-        return latestPlainLineContaining(terminal.writes.join(''), 'API key') !== null;
-      } catch {
-        return false;
-      }
-    });
-
-    // Submitting the key fires onboarding.setup instead of an agent turn.
-    terminal.input('sk-test');
-    terminal.input('\r');
-    await waitFor(() => setupCalls.length === 1);
-
-    assert.equal(setupCalls[0]!.apiKey, 'sk-test');
-    assert.ok(setupCalls[0]!.providerType);
+    await waitFor(() => plainTerminalOutput(terminal.screenOutput()).includes('已设置'));
 
     process.emit('SIGTERM');
     await Promise.race([
@@ -365,10 +395,10 @@ describe('Maka Pi TUI runner', () => {
     ]);
   });
 
-  test('/setup re-arms the key prompt when the probe fails so the key can be retried', async () => {
+  test('/setup verifies the key then shows the model multi-select', async () => {
     const terminal = new FakeTerminal();
     const driver = new SlashCommandDriver();
-    const setupCalls: Array<{ apiKey: string }> = [];
+    const verifyCalls: Array<{ providerType: ProviderType; apiKey?: string }> = [];
     const run = runMakaPiTui({
       title: 'Maka',
       driver,
@@ -377,19 +407,25 @@ describe('Maka Pi TUI runner', () => {
       connectionSlug: 'claude-subscription',
       permissionMode: 'bypass',
       terminal,
-      onboarding: {
-        setup: async (req) => {
-          setupCalls.push({ apiKey: req.apiKey });
-          // First attempt fails the probe (wrong key); the retry verifies.
-          return setupCalls.length === 1 ? { testError: 'HTTP 401 Unauthorized' } : {};
+      onboarding: fakeOnboardingSurface({
+        verify: async (input) => {
+          verifyCalls.push(input);
+          return { kind: 'ok', models: [{ id: 'gpt-5.5' }, { id: 'gpt-5.5-mini' }] };
         },
-      },
+      }),
     });
 
     await delay(20);
     terminal.input('/setup');
     terminal.input('\r');
-    terminal.input('\r'); // pick the highlighted provider
+    await waitFor(() => {
+      try {
+        return latestPlainLineContaining(terminal.writes.join(''), 'Set Up Provider') !== null;
+      } catch {
+        return false;
+      }
+    });
+    terminal.input('\r'); // pick the highlighted provider -> key phase
     await waitFor(() => {
       try {
         return latestPlainLineContaining(terminal.writes.join(''), 'API key') !== null;
@@ -397,12 +433,65 @@ describe('Maka Pi TUI runner', () => {
         return false;
       }
     });
+    terminal.input('sk-test');
+    terminal.input('\r');
+    await waitFor(() => verifyCalls.length === 1);
+    assert.equal(verifyCalls[0]!.apiKey, 'sk-test');
+    // Verify success advances to the searchable model multi-select (step 3/3).
+    await waitFor(() => plainTerminalOutput(terminal.screenOutput()).includes('3/3'));
 
-    // Submit a key that fails the probe.
+    process.emit('SIGTERM');
+    await Promise.race([
+      run,
+      delay(500).then(() => {
+        throw new Error('TUI did not close after SIGTERM');
+      }),
+    ]);
+  });
+
+  test('verify failure re-arms the key prompt so the key can be retried', async () => {
+    const terminal = new FakeTerminal();
+    const driver = new SlashCommandDriver();
+    const verifyCalls: string[] = [];
+    const run = runMakaPiTui({
+      title: 'Maka',
+      driver,
+      cwd: '/repo',
+      model: 'claude-sonnet-4-5',
+      connectionSlug: 'claude-subscription',
+      permissionMode: 'bypass',
+      terminal,
+      onboarding: fakeOnboardingSurface({
+        verify: async (input) => {
+          verifyCalls.push(input.apiKey ?? '');
+          return verifyCalls.length === 1
+            ? { kind: 'error', text: 'HTTP 401 Unauthorized' }
+            : { kind: 'ok', models: [{ id: 'gpt-5.5' }] };
+        },
+      }),
+    });
+
+    await delay(20);
+    terminal.input('/setup');
+    terminal.input('\r');
+    await waitFor(() => {
+      try {
+        return latestPlainLineContaining(terminal.writes.join(''), 'Set Up Provider') !== null;
+      } catch {
+        return false;
+      }
+    });
+    terminal.input('\r'); // pick provider -> key phase
+    await waitFor(() => {
+      try {
+        return latestPlainLineContaining(terminal.writes.join(''), 'API key') !== null;
+      } catch {
+        return false;
+      }
+    });
     terminal.input('sk-bad');
     terminal.input('\r');
-    await waitFor(() => setupCalls.length === 1);
-    // The failure is surfaced and the prompt re-arms — not the success notice.
+    await waitFor(() => verifyCalls.length === 1);
     await waitFor(() => {
       try {
         return latestPlainLineContaining(terminal.writes.join(''), '验证失败') !== null;
@@ -410,23 +499,12 @@ describe('Maka Pi TUI runner', () => {
         return false;
       }
     });
-
-    // Retrying with a good key succeeds (no testError this time).
+    // Retrying with a good key verifies and advances to the models step.
     terminal.input('sk-good');
     terminal.input('\r');
-    await waitFor(() => setupCalls.length === 2);
-    await waitFor(() => {
-      try {
-        return latestPlainLineContaining(terminal.writes.join(''), '已配置') !== null;
-      } catch {
-        return false;
-      }
-    });
-
-    assert.deepEqual(
-      setupCalls.map((c) => c.apiKey),
-      ['sk-bad', 'sk-good'],
-    );
+    await waitFor(() => verifyCalls.length === 2);
+    await waitFor(() => plainTerminalOutput(terminal.screenOutput()).includes('3/3'));
+    assert.deepEqual(verifyCalls, ['sk-bad', 'sk-good']);
 
     process.emit('SIGTERM');
     await Promise.race([
@@ -440,7 +518,7 @@ describe('Maka Pi TUI runner', () => {
   test('an armed key prompt routes a slash command instead of swallowing it as the key', async () => {
     const terminal = new FakeTerminal();
     const driver = new SlashCommandDriver();
-    const setupCalls: Array<unknown> = [];
+    const verifyCalls: unknown[] = [];
     const run = runMakaPiTui({
       title: 'Maka',
       driver,
@@ -449,18 +527,25 @@ describe('Maka Pi TUI runner', () => {
       connectionSlug: 'claude-subscription',
       permissionMode: 'bypass',
       terminal,
-      onboarding: {
-        setup: async (req) => {
-          setupCalls.push(req);
-          return {};
+      onboarding: fakeOnboardingSurface({
+        verify: async (req) => {
+          verifyCalls.push(req);
+          return { kind: 'ok', models: [] };
         },
-      },
+      }),
     });
 
     await delay(20);
     terminal.input('/setup');
     terminal.input('\r');
-    terminal.input('\r'); // pick the highlighted provider -> arms the key prompt
+    await waitFor(() => {
+      try {
+        return latestPlainLineContaining(terminal.writes.join(''), 'Set Up Provider') !== null;
+      } catch {
+        return false;
+      }
+    });
+    terminal.input('\r'); // pick provider -> arms the key prompt
     await waitFor(() => {
       try {
         return latestPlainLineContaining(terminal.writes.join(''), 'API key') !== null;
@@ -468,13 +553,12 @@ describe('Maka Pi TUI runner', () => {
         return false;
       }
     });
-
-    // A slash command typed while armed must be routed as a command, not stored
+    // A slash command typed while armed must route as a command, not be stored
     // as the API key (otherwise /exit, /model, etc. become persisted secrets).
     terminal.input('/setup');
     terminal.input('\r');
     await delay(60);
-    assert.equal(setupCalls.length, 0);
+    assert.equal(verifyCalls.length, 0);
 
     process.emit('SIGTERM');
     await Promise.race([
@@ -485,11 +569,11 @@ describe('Maka Pi TUI runner', () => {
     ]);
   });
 
-  test('/setup without an onboarding surface reports unavailable instead of throwing', async () => {
+  test('/setup without an onboarding surface reports unavailable in-frame instead of throwing', async () => {
     const terminal = new FakeTerminal();
     const driver = new SlashCommandDriver();
-    // No onboarding surface: a minimal host that can open /setup's picker but
-    // cannot actually collect a key.
+    // No onboarding surface: a minimal host that can open /setup's picker (via
+    // the catalog fallback) but cannot verify or save.
     const run = runMakaPiTui({
       title: 'Maka',
       driver,
@@ -503,7 +587,14 @@ describe('Maka Pi TUI runner', () => {
     await delay(20);
     terminal.input('/setup');
     terminal.input('\r');
-    terminal.input('\r'); // pick the highlighted provider -> arms the key prompt
+    await waitFor(() => {
+      try {
+        return latestPlainLineContaining(terminal.writes.join(''), 'Set Up Provider') !== null;
+      } catch {
+        return false;
+      }
+    });
+    terminal.input('\r'); // pick provider -> key phase
     await waitFor(() => {
       try {
         return latestPlainLineContaining(terminal.writes.join(''), 'API key') !== null;
@@ -511,9 +602,6 @@ describe('Maka Pi TUI runner', () => {
         return false;
       }
     });
-
-    // Submitting a key with no onboarding surface reports unavailable instead
-    // of throwing TypeError on `undefined.then`.
     terminal.input('sk-test');
     terminal.input('\r');
     await waitFor(() => {
@@ -545,9 +633,7 @@ describe('Maka Pi TUI runner', () => {
       permissionMode: 'bypass',
       terminal,
       firstRun: true,
-      onboarding: {
-        setup: async () => ({}),
-      },
+      onboarding: fakeOnboardingSurface(),
     });
 
     await waitFor(() => {
@@ -557,7 +643,6 @@ describe('Maka Pi TUI runner', () => {
         return false;
       }
     });
-
     // Esc cancels the picker; in first-run mode that closes the TUI (the host
     // sees no configured connection) rather than dropping into a driver-less editor.
     terminal.input('\x1b');
@@ -581,9 +666,7 @@ describe('Maka Pi TUI runner', () => {
       permissionMode: 'bypass',
       terminal,
       firstRun: true,
-      onboarding: {
-        setup: async () => ({}),
-      },
+      onboarding: fakeOnboardingSurface(),
     });
 
     await waitFor(() => {
@@ -615,7 +698,7 @@ describe('Maka Pi TUI runner', () => {
       permissionMode: 'bypass',
       terminal,
       firstRun: true,
-      onboarding: { setup: async () => ({}) },
+      onboarding: fakeOnboardingSurface(),
     });
 
     await waitFor(() => {
@@ -646,10 +729,10 @@ describe('Maka Pi TUI runner', () => {
     ]);
   });
 
-  test('onboarding wizard keeps verifying/failure status beside the input, out of the transcript', async () => {
+  test('verify/saving status stays beside the input, out of the transcript', async () => {
     const terminal = new FakeTerminal();
     const driver = new SlashCommandDriver();
-    const setupCalls: Array<{ apiKey: string }> = [];
+    const verifyCalls: string[] = [];
     const run = runMakaPiTui({
       title: 'Maka',
       driver,
@@ -658,12 +741,14 @@ describe('Maka Pi TUI runner', () => {
       connectionSlug: 'claude-subscription',
       permissionMode: 'bypass',
       terminal,
-      onboarding: {
-        setup: async (req) => {
-          setupCalls.push({ apiKey: req.apiKey });
-          return setupCalls.length === 1 ? { testError: 'HTTP 401 Unauthorized' } : {};
+      onboarding: fakeOnboardingSurface({
+        verify: async (input) => {
+          verifyCalls.push(input.apiKey ?? '');
+          return verifyCalls.length === 1
+            ? { kind: 'error', text: 'HTTP 401 Unauthorized' }
+            : { kind: 'ok', models: [{ id: 'gpt-5.5' }] };
         },
-      },
+      }),
     });
 
     await delay(20);
@@ -676,7 +761,7 @@ describe('Maka Pi TUI runner', () => {
         return false;
       }
     });
-    terminal.input('\r'); // pick the highlighted provider -> key phase
+    terminal.input('\r'); // pick provider -> key phase
     await waitFor(() => {
       try {
         return latestPlainLineContaining(terminal.writes.join(''), 'API key') !== null;
@@ -684,11 +769,9 @@ describe('Maka Pi TUI runner', () => {
         return false;
       }
     });
-
-    // A failing probe surfaces the error beside the key field (wizard overlay).
     terminal.input('sk-bad');
     terminal.input('\r');
-    await waitFor(() => setupCalls.length === 1);
+    await waitFor(() => verifyCalls.length === 1);
     await waitFor(() => {
       try {
         return latestPlainLineContaining(terminal.writes.join(''), '验证失败') !== null;
@@ -696,21 +779,12 @@ describe('Maka Pi TUI runner', () => {
         return false;
       }
     });
-
-    // A succeeding retry closes the wizard. The in-flight failure status lived
-    // only in the overlay, so once it closes it leaves no residue in the
-    // transcript — only the completed-configuration event remains on screen.
+    // A succeeding retry advances to the models step. The in-flight failure
+    // status lived only in the overlay, so it leaves no residue in the transcript.
     terminal.input('sk-good');
     terminal.input('\r');
-    await waitFor(() => setupCalls.length === 2);
-    await waitFor(() => {
-      try {
-        return latestPlainLineContaining(terminal.writes.join(''), '已配置') !== null;
-      } catch {
-        return false;
-      }
-    });
-
+    await waitFor(() => verifyCalls.length === 2);
+    await waitFor(() => plainTerminalOutput(terminal.screenOutput()).includes('3/3'));
     assert.doesNotMatch(plainTerminalOutput(terminal.screenOutput()), /验证失败/);
 
     process.emit('SIGTERM');
@@ -722,7 +796,7 @@ describe('Maka Pi TUI runner', () => {
     ]);
   });
 
-  test('onboarding wizard key Esc returns to the provider search', async () => {
+  test('key Esc returns to the provider search (step 1/3)', async () => {
     const terminal = new FakeTerminal();
     const driver = new SlashCommandDriver();
     const run = runMakaPiTui({
@@ -733,7 +807,7 @@ describe('Maka Pi TUI runner', () => {
       connectionSlug: 'claude-subscription',
       permissionMode: 'bypass',
       terminal,
-      onboarding: { setup: async () => ({}) },
+      onboarding: fakeOnboardingSurface(),
     });
 
     await delay(20);
@@ -746,7 +820,7 @@ describe('Maka Pi TUI runner', () => {
         return false;
       }
     });
-    terminal.input('\r'); // pick the highlighted provider -> key phase
+    terminal.input('\r'); // pick provider -> key phase
     await waitFor(() => {
       try {
         return latestPlainLineContaining(terminal.writes.join(''), 'API key') !== null;
@@ -754,14 +828,694 @@ describe('Maka Pi TUI runner', () => {
         return false;
       }
     });
-
     // Esc from the key field returns to the search phase: the step marker is
-    // back to 1/2 and the provider list is visible again.
+    // back to 1/3 and the provider list is visible again.
     terminal.input('\x1b');
     await waitFor(() => {
       const out = plainTerminalOutput(terminal.screenOutput());
-      return out.includes('1/2') && out.includes('Anthropic');
+      return out.includes('1/3') && out.includes('Anthropic');
     });
+
+    process.emit('SIGTERM');
+    await Promise.race([
+      run,
+      delay(500).then(() => {
+        throw new Error('TUI did not close after SIGTERM');
+      }),
+    ]);
+  });
+
+  test('models Esc returns to the key step (step 2/3)', async () => {
+    const terminal = new FakeTerminal();
+    const driver = new SlashCommandDriver();
+    const run = runMakaPiTui({
+      title: 'Maka',
+      driver,
+      cwd: '/repo',
+      model: 'claude-sonnet-4-5',
+      connectionSlug: 'claude-subscription',
+      permissionMode: 'bypass',
+      terminal,
+      onboarding: fakeOnboardingSurface(),
+    });
+
+    await delay(20);
+    terminal.input('/setup');
+    terminal.input('\r');
+    await waitFor(() => {
+      try {
+        return latestPlainLineContaining(terminal.writes.join(''), 'Set Up Provider') !== null;
+      } catch {
+        return false;
+      }
+    });
+    terminal.input('\r'); // pick provider -> key phase
+    await waitFor(() => {
+      try {
+        return latestPlainLineContaining(terminal.writes.join(''), 'API key') !== null;
+      } catch {
+        return false;
+      }
+    });
+    terminal.input('sk-test');
+    terminal.input('\r');
+    await waitFor(() => plainTerminalOutput(terminal.screenOutput()).includes('3/3'));
+    // Esc from the models step moves back exactly one level to the key step.
+    terminal.input('\x1b');
+    await waitFor(() => {
+      const out = plainTerminalOutput(terminal.screenOutput());
+      return out.includes('2/3') && out.includes('API key');
+    });
+
+    process.emit('SIGTERM');
+    await Promise.race([
+      run,
+      delay(500).then(() => {
+        throw new Error('TUI did not close after SIGTERM');
+      }),
+    ]);
+  });
+
+  test('models Space toggles selection; Enter saves at least one model', async () => {
+    const terminal = new FakeTerminal();
+    const driver = new SlashCommandDriver();
+    const saveCalls: Array<{ enabledModelIds: readonly string[] }> = [];
+    const run = runMakaPiTui({
+      title: 'Maka',
+      driver,
+      cwd: '/repo',
+      model: 'claude-sonnet-4-5',
+      connectionSlug: 'claude-subscription',
+      permissionMode: 'bypass',
+      terminal,
+      onboarding: fakeOnboardingSurface({
+        save: async (input) => {
+          saveCalls.push(input);
+          return { kind: 'ok', modelChoices: [] };
+        },
+      }),
+    });
+
+    await delay(20);
+    terminal.input('/setup');
+    terminal.input('\r');
+    await waitFor(() => {
+      try {
+        return latestPlainLineContaining(terminal.writes.join(''), 'Set Up Provider') !== null;
+      } catch {
+        return false;
+      }
+    });
+    terminal.input('\r'); // pick provider -> key phase
+    await waitFor(() => {
+      try {
+        return latestPlainLineContaining(terminal.writes.join(''), 'API key') !== null;
+      } catch {
+        return false;
+      }
+    });
+    terminal.input('sk-test');
+    terminal.input('\r');
+    await waitFor(() => plainTerminalOutput(terminal.screenOutput()).includes('3/3'));
+    // A new connection starts with no models selected: Enter with 0 does not save.
+    terminal.input('\r');
+    await waitFor(() => {
+      try {
+        return latestPlainLineContaining(terminal.writes.join(''), '至少选择一个模型') !== null;
+      } catch {
+        return false;
+      }
+    });
+    assert.equal(saveCalls.length, 0);
+    // Space toggles the highlighted model on; Enter then saves the selection.
+    terminal.input(' ');
+    await waitFor(() => plainTerminalOutput(terminal.screenOutput()).includes('已选 1 ·'));
+    terminal.input('\r');
+    await waitFor(() => saveCalls.length === 1);
+    assert.deepEqual(saveCalls[0]!.enabledModelIds, ['gpt-5.5']);
+
+    process.emit('SIGTERM');
+    await Promise.race([
+      run,
+      delay(500).then(() => {
+        throw new Error('TUI did not close after SIGTERM');
+      }),
+    ]);
+  });
+
+  test('model search filters without discarding selections', async () => {
+    const terminal = new FakeTerminal();
+    const driver = new SlashCommandDriver();
+    const saveCalls: Array<{ enabledModelIds: readonly string[] }> = [];
+    const run = runMakaPiTui({
+      title: 'Maka',
+      driver,
+      cwd: '/repo',
+      model: 'claude-sonnet-4-5',
+      connectionSlug: 'claude-subscription',
+      permissionMode: 'bypass',
+      terminal,
+      onboarding: fakeOnboardingSurface({
+        save: async (input) => {
+          saveCalls.push(input);
+          return { kind: 'ok', modelChoices: [] };
+        },
+      }),
+    });
+
+    await delay(20);
+    terminal.input('/setup');
+    terminal.input('\r');
+    await waitFor(() => {
+      try {
+        return latestPlainLineContaining(terminal.writes.join(''), 'Set Up Provider') !== null;
+      } catch {
+        return false;
+      }
+    });
+    terminal.input('\r'); // pick provider -> key phase
+    await waitFor(() => {
+      try {
+        return latestPlainLineContaining(terminal.writes.join(''), 'API key') !== null;
+      } catch {
+        return false;
+      }
+    });
+    terminal.input('sk-test');
+    terminal.input('\r');
+    await waitFor(() => plainTerminalOutput(terminal.screenOutput()).includes('3/3'));
+    terminal.input(' '); // toggle the first model on (gpt-5.5)
+    await waitFor(() => plainTerminalOutput(terminal.screenOutput()).includes('已选 1 ·'));
+    // Filtering to 'mini' hides gpt-5.5, but its selection survives.
+    terminal.input('mini');
+    await waitFor(() => {
+      const out = plainTerminalOutput(terminal.screenOutput());
+      return (
+        out.includes('gpt-5.5-mini') && !out.includes('☐ gpt-5.5 ') && !out.includes('☑ gpt-5.5 ')
+      );
+    });
+    terminal.input(' '); // toggle gpt-5.5-mini on while filtered
+    await waitFor(() => plainTerminalOutput(terminal.screenOutput()).includes('已选 2 ·'));
+    terminal.input('\r');
+    await waitFor(() => saveCalls.length === 1);
+    // Both selections reach save — the filtered-out gpt-5.5 was not discarded.
+    assert.deepEqual(saveCalls[0]!.enabledModelIds, ['gpt-5.5', 'gpt-5.5-mini']);
+
+    process.emit('SIGTERM');
+    await Promise.race([
+      run,
+      delay(500).then(() => {
+        throw new Error('TUI did not close after SIGTERM');
+      }),
+    ]);
+  });
+
+  test('existing connection preserves its enabled set; new starts empty', async () => {
+    const terminal = new FakeTerminal();
+    const driver = new SlashCommandDriver();
+    const run = runMakaPiTui({
+      title: 'Maka',
+      driver,
+      cwd: '/repo',
+      model: 'claude-sonnet-4-5',
+      connectionSlug: 'claude-subscription',
+      permissionMode: 'bypass',
+      terminal,
+      onboarding: fakeOnboardingSurface({
+        providers: defaultOnboardingProviders().map((p) =>
+          p.providerType === 'anthropic'
+            ? { ...p, hasConnection: true, enabledModelIds: ['claude-sonnet-5'] }
+            : p,
+        ),
+        verify: async () => ({
+          kind: 'ok',
+          models: [{ id: 'claude-sonnet-5' }, { id: 'claude-haiku-5' }],
+        }),
+      }),
+    });
+
+    await delay(20);
+    terminal.input('/setup');
+    terminal.input('\r');
+    await waitFor(() => {
+      try {
+        return latestPlainLineContaining(terminal.writes.join(''), 'Set Up Provider') !== null;
+      } catch {
+        return false;
+      }
+    });
+    // anthropic may not be the first provider, so filter to it then pick it.
+    terminal.input('anth');
+    await waitFor(() => {
+      const out = plainTerminalOutput(terminal.screenOutput());
+      return out.includes('Anthropic') && !out.includes('DeepSeek');
+    });
+    terminal.input('\r'); // pick anthropic -> key phase
+    await waitFor(() => {
+      try {
+        return latestPlainLineContaining(terminal.writes.join(''), 'API key') !== null;
+      } catch {
+        return false;
+      }
+    });
+    terminal.input('\r'); // blank key reuses the stored secret -> verify -> models
+    await waitFor(() => plainTerminalOutput(terminal.screenOutput()).includes('3/3'));
+    // The existing enabled set (claude-sonnet-5) is pre-selected.
+    await waitFor(() => plainTerminalOutput(terminal.screenOutput()).includes('已选 1 ·'));
+
+    process.emit('SIGTERM');
+    await Promise.race([
+      run,
+      delay(500).then(() => {
+        throw new Error('TUI did not close after SIGTERM');
+      }),
+    ]);
+  });
+
+  test('blank key for an existing connection reuses the stored secret', async () => {
+    const terminal = new FakeTerminal();
+    const driver = new SlashCommandDriver();
+    const verifyCalls: Array<{ apiKey?: string }> = [];
+    const run = runMakaPiTui({
+      title: 'Maka',
+      driver,
+      cwd: '/repo',
+      model: 'claude-sonnet-4-5',
+      connectionSlug: 'claude-subscription',
+      permissionMode: 'bypass',
+      terminal,
+      onboarding: fakeOnboardingSurface({
+        providers: defaultOnboardingProviders().map((p) =>
+          p.providerType === 'anthropic'
+            ? { ...p, hasConnection: true, enabledModelIds: ['claude-sonnet-5'] }
+            : p,
+        ),
+        verify: async (input) => {
+          verifyCalls.push(input);
+          return { kind: 'ok', models: [{ id: 'claude-sonnet-5' }] };
+        },
+      }),
+    });
+
+    await delay(20);
+    terminal.input('/setup');
+    terminal.input('\r');
+    await waitFor(() => {
+      try {
+        return latestPlainLineContaining(terminal.writes.join(''), 'Set Up Provider') !== null;
+      } catch {
+        return false;
+      }
+    });
+    terminal.input('anth');
+    await waitFor(() => {
+      const out = plainTerminalOutput(terminal.screenOutput());
+      return out.includes('Anthropic') && !out.includes('DeepSeek');
+    });
+    terminal.input('\r'); // pick anthropic -> key phase
+    await waitFor(() => {
+      try {
+        return latestPlainLineContaining(terminal.writes.join(''), 'API key') !== null;
+      } catch {
+        return false;
+      }
+    });
+    terminal.input('\r'); // blank submit reuses the stored secret
+    await waitFor(() => verifyCalls.length === 1);
+    assert.equal(verifyCalls[0]!.apiKey, '');
+    await waitFor(() => plainTerminalOutput(terminal.screenOutput()).includes('3/3'));
+
+    process.emit('SIGTERM');
+    await Promise.race([
+      run,
+      delay(500).then(() => {
+        throw new Error('TUI did not close after SIGTERM');
+      }),
+    ]);
+  });
+
+  test('key rotation passes the new key to verify and save', async () => {
+    const terminal = new FakeTerminal();
+    const driver = new SlashCommandDriver();
+    const verifyCalls: Array<{ apiKey?: string }> = [];
+    const saveCalls: Array<{ apiKey?: string; enabledModelIds: readonly string[] }> = [];
+    const run = runMakaPiTui({
+      title: 'Maka',
+      driver,
+      cwd: '/repo',
+      model: 'claude-sonnet-4-5',
+      connectionSlug: 'claude-subscription',
+      permissionMode: 'bypass',
+      terminal,
+      onboarding: fakeOnboardingSurface({
+        providers: defaultOnboardingProviders().map((p) =>
+          p.providerType === 'anthropic'
+            ? { ...p, hasConnection: true, enabledModelIds: ['claude-sonnet-5'] }
+            : p,
+        ),
+        verify: async (input) => {
+          verifyCalls.push(input);
+          return { kind: 'ok', models: [{ id: 'claude-sonnet-5' }, { id: 'claude-haiku-5' }] };
+        },
+        save: async (input) => {
+          saveCalls.push(input);
+          return { kind: 'ok', modelChoices: [] };
+        },
+      }),
+    });
+
+    await delay(20);
+    terminal.input('/setup');
+    terminal.input('\r');
+    await waitFor(() => {
+      try {
+        return latestPlainLineContaining(terminal.writes.join(''), 'Set Up Provider') !== null;
+      } catch {
+        return false;
+      }
+    });
+    terminal.input('anth');
+    await waitFor(() => {
+      const out = plainTerminalOutput(terminal.screenOutput());
+      return out.includes('Anthropic') && !out.includes('DeepSeek');
+    });
+    terminal.input('\r'); // pick anthropic -> key phase
+    await waitFor(() => {
+      try {
+        return latestPlainLineContaining(terminal.writes.join(''), 'API key') !== null;
+      } catch {
+        return false;
+      }
+    });
+    terminal.input('sk-rotated');
+    terminal.input('\r');
+    await waitFor(() => verifyCalls.length === 1);
+    assert.equal(verifyCalls[0]!.apiKey, 'sk-rotated');
+    await waitFor(() => plainTerminalOutput(terminal.screenOutput()).includes('3/3'));
+    // The preserved enabled set already satisfies the minimum, so Enter saves.
+    terminal.input('\r');
+    await waitFor(() => saveCalls.length === 1);
+    assert.equal(saveCalls[0]!.apiKey, 'sk-rotated');
+    assert.deepEqual(saveCalls[0]!.enabledModelIds, ['claude-sonnet-5']);
+
+    process.emit('SIGTERM');
+    await Promise.race([
+      run,
+      delay(500).then(() => {
+        throw new Error('TUI did not close after SIGTERM');
+      }),
+    ]);
+  });
+
+  test('save refreshes the running TUI model choices, shows success in-frame, and does not switch the session', async () => {
+    const terminal = new FakeTerminal();
+    const driver = new SlashCommandDriver();
+    const saveCalls: Array<{ enabledModelIds: readonly string[] }> = [];
+    const run = runMakaPiTui({
+      title: 'Maka',
+      driver,
+      cwd: '/repo',
+      model: 'claude-sonnet-4-5',
+      connectionSlug: 'claude-subscription',
+      permissionMode: 'bypass',
+      terminal,
+      onboarding: fakeOnboardingSurface({
+        save: async (input) => {
+          saveCalls.push(input);
+          return {
+            kind: 'ok',
+            modelChoices: [
+              {
+                connectionSlug: 'openai',
+                connectionName: 'OpenAI',
+                providerType: 'openai',
+                model: 'gpt-5.5-new',
+                isDefaultConnection: true,
+              },
+            ],
+          };
+        },
+      }),
+    });
+
+    await delay(20);
+    terminal.input('/setup');
+    terminal.input('\r');
+    await waitFor(() => {
+      try {
+        return latestPlainLineContaining(terminal.writes.join(''), 'Set Up Provider') !== null;
+      } catch {
+        return false;
+      }
+    });
+    terminal.input('\r'); // pick provider -> key phase
+    await waitFor(() => {
+      try {
+        return latestPlainLineContaining(terminal.writes.join(''), 'API key') !== null;
+      } catch {
+        return false;
+      }
+    });
+    terminal.input('sk-test');
+    terminal.input('\r');
+    await waitFor(() => plainTerminalOutput(terminal.screenOutput()).includes('3/3'));
+    terminal.input(' '); // toggle the first model on
+    terminal.input('\r'); // save
+    await waitFor(() => saveCalls.length === 1);
+    // Success shows the enabled-model count in-frame; no transcript setup Note.
+    await waitFor(() => plainTerminalOutput(terminal.screenOutput()).includes('已启用 1 个模型'));
+    assert.doesNotMatch(plainTerminalOutput(terminal.screenOutput()), /已配置/);
+    terminal.input('\r'); // close the in-frame success
+    await delay(40);
+    // The refreshed ready model choices are immediately available from /model.
+    terminal.input('/model');
+    terminal.input('\r');
+    await waitFor(() => plainTerminalOutput(terminal.screenOutput()).includes('gpt-5.5-new'));
+    // Setup never switched the active session (no setModel call).
+    assert.deepEqual(driver.models, []);
+
+    process.emit('SIGTERM');
+    await Promise.race([
+      run,
+      delay(500).then(() => {
+        throw new Error('TUI did not close after SIGTERM');
+      }),
+    ]);
+  });
+
+  test('first-run setup save closes the TUI so the host re-resolves the new default', async () => {
+    const terminal = new FakeTerminal();
+    const driver = new SlashCommandDriver();
+    const saveCalls: Array<{ enabledModelIds: readonly string[] }> = [];
+    const run = runMakaPiTui({
+      title: 'Maka',
+      driver,
+      cwd: '/repo',
+      model: '',
+      connectionSlug: '',
+      permissionMode: 'bypass',
+      terminal,
+      firstRun: true,
+      onboarding: fakeOnboardingSurface({
+        save: async (input) => {
+          saveCalls.push(input);
+          return { kind: 'ok', modelChoices: [] };
+        },
+      }),
+    });
+
+    await waitFor(() => {
+      try {
+        return latestPlainLineContaining(terminal.writes.join(''), 'Set Up Provider') !== null;
+      } catch {
+        return false;
+      }
+    });
+    terminal.input('\r'); // pick provider -> key phase
+    await waitFor(() => {
+      try {
+        return latestPlainLineContaining(terminal.writes.join(''), 'API key') !== null;
+      } catch {
+        return false;
+      }
+    });
+    terminal.input('sk-test');
+    terminal.input('\r');
+    await waitFor(() => plainTerminalOutput(terminal.screenOutput()).includes('3/3'));
+    terminal.input(' '); // toggle the first model on
+    terminal.input('\r'); // save -> first-run closes the TUI for re-entry
+    await waitFor(() => saveCalls.length === 1);
+    // The wizard does not show an in-frame success on first run; it closes so the
+    // host re-resolves the now-configured default connection and relaunches.
+    await Promise.race([
+      run,
+      delay(500).then(() => {
+        throw new Error('first-run TUI did not close after save');
+      }),
+    ]);
+  });
+
+  test('wizard ignores a verify result from an abandoned attempt', async () => {
+    const terminal = new FakeTerminal();
+    const driver = new SlashCommandDriver();
+    const verifyCalls: Array<{ apiKey?: string }> = [];
+    let resolveFirst!: (value: OnboardingVerifyResult) => void;
+    const run = runMakaPiTui({
+      title: 'Maka',
+      driver,
+      cwd: '/repo',
+      model: 'claude-sonnet-4-5',
+      connectionSlug: 'claude-subscription',
+      permissionMode: 'bypass',
+      terminal,
+      onboarding: fakeOnboardingSurface({
+        verify: (input) => {
+          verifyCalls.push({ apiKey: input.apiKey });
+          return verifyCalls.length === 1
+            ? new Promise<OnboardingVerifyResult>((r) => {
+                resolveFirst = r;
+              })
+            : Promise.resolve<OnboardingVerifyResult>({ kind: 'ok', models: [{ id: 'gpt-5.5' }] });
+        },
+      }),
+    });
+
+    await delay(20);
+    terminal.input('/setup');
+    terminal.input('\r');
+    await waitFor(() => {
+      try {
+        return latestPlainLineContaining(terminal.writes.join(''), 'Set Up Provider') !== null;
+      } catch {
+        return false;
+      }
+    });
+    terminal.input('\r'); // pick provider A -> key phase
+    await waitFor(() => {
+      try {
+        return latestPlainLineContaining(terminal.writes.join(''), 'API key') !== null;
+      } catch {
+        return false;
+      }
+    });
+    terminal.input('sk-a');
+    terminal.input('\r'); // submit A — verify deferred, wizard shows verifying
+    await waitFor(() => verifyCalls.length === 1);
+    await waitFor(() => {
+      try {
+        return latestPlainLineContaining(terminal.writes.join(''), '验证') !== null;
+      } catch {
+        return false;
+      }
+    });
+    // Abandon A: Esc back to search, move to the second provider, pick it, and
+    // start typing its key (do not submit).
+    terminal.input('\x1b');
+    await waitFor(() => {
+      try {
+        return latestPlainLineContaining(terminal.writes.join(''), '1/3') !== null;
+      } catch {
+        return false;
+      }
+    });
+    terminal.input('\x1b[B'); // down to the second provider
+    terminal.input('\r');
+    await waitFor(() => {
+      try {
+        return latestPlainLineContaining(terminal.writes.join(''), 'API key') !== null;
+      } catch {
+        return false;
+      }
+    });
+    terminal.input('sk-b');
+    await waitFor(() => plainTerminalOutput(terminal.screenOutput()).includes('sk-b'));
+    // A's verify now resolves with a failure. It must not clobber attempt B:
+    // no failure status line, and the key being typed for B survives.
+    resolveFirst({ kind: 'error', text: 'HTTP 401 Unauthorized' });
+    await delay(40);
+
+    const out = plainTerminalOutput(terminal.screenOutput());
+    assert.doesNotMatch(out, /验证失败/);
+    assert.ok(out.includes('sk-b'));
+
+    process.emit('SIGTERM');
+    await Promise.race([
+      run,
+      delay(500).then(() => {
+        throw new Error('TUI did not close after SIGTERM');
+      }),
+    ]);
+  });
+
+  test('wizard ignores a save result from an abandoned attempt', async () => {
+    const terminal = new FakeTerminal();
+    const driver = new SlashCommandDriver();
+    const saveCalls: Array<{ enabledModelIds: readonly string[] }> = [];
+    let resolveFirstSave!: (value: OnboardingSaveResult) => void;
+    const run = runMakaPiTui({
+      title: 'Maka',
+      driver,
+      cwd: '/repo',
+      model: 'claude-sonnet-4-5',
+      connectionSlug: 'claude-subscription',
+      permissionMode: 'bypass',
+      terminal,
+      onboarding: fakeOnboardingSurface({
+        save: (input) => {
+          saveCalls.push(input);
+          return saveCalls.length === 1
+            ? new Promise<OnboardingSaveResult>((r) => {
+                resolveFirstSave = r;
+              })
+            : Promise.resolve<OnboardingSaveResult>({ kind: 'ok', modelChoices: [] });
+        },
+      }),
+    });
+
+    await delay(20);
+    terminal.input('/setup');
+    terminal.input('\r');
+    await waitFor(() => {
+      try {
+        return latestPlainLineContaining(terminal.writes.join(''), 'Set Up Provider') !== null;
+      } catch {
+        return false;
+      }
+    });
+    terminal.input('\r'); // pick provider -> key phase
+    await waitFor(() => {
+      try {
+        return latestPlainLineContaining(terminal.writes.join(''), 'API key') !== null;
+      } catch {
+        return false;
+      }
+    });
+    terminal.input('sk-test');
+    terminal.input('\r'); // verify ok -> models
+    await waitFor(() => plainTerminalOutput(terminal.screenOutput()).includes('3/3'));
+    terminal.input(' '); // toggle the first model on
+    terminal.input('\r'); // save A — deferred
+    await waitFor(() => saveCalls.length === 1);
+    await waitFor(() => {
+      try {
+        return latestPlainLineContaining(terminal.writes.join(''), '保存') !== null;
+      } catch {
+        return false;
+      }
+    });
+    // Abandon A: Esc back to the key step.
+    terminal.input('\x1b');
+    await waitFor(() => {
+      try {
+        return latestPlainLineContaining(terminal.writes.join(''), '2/3') !== null;
+      } catch {
+        return false;
+      }
+    });
+    // A's save now resolves ok. It must not show success or refresh choices.
+    resolveFirstSave({ kind: 'ok', modelChoices: [] });
+    await delay(40);
+    assert.doesNotMatch(plainTerminalOutput(terminal.screenOutput()), /已启用/);
 
     process.emit('SIGTERM');
     await Promise.race([
@@ -789,7 +1543,7 @@ describe('Maka Pi TUI runner', () => {
       permissionMode: 'bypass',
       terminal,
       firstRun: true,
-      onboarding: { setup: async () => ({}) },
+      onboarding: fakeOnboardingSurface(),
     });
 
     await waitFor(() => {
@@ -855,7 +1609,7 @@ describe('Maka Pi TUI runner', () => {
       permissionMode: 'bypass',
       terminal,
       firstRun: true,
-      onboarding: { setup: async () => ({}) },
+      onboarding: fakeOnboardingSurface(),
     });
 
     await waitFor(() => {
@@ -914,7 +1668,7 @@ describe('Maka Pi TUI runner', () => {
       permissionMode: 'bypass',
       terminal,
       firstRun: true,
-      onboarding: { setup: async () => ({}) },
+      onboarding: fakeOnboardingSurface(),
     });
 
     await waitFor(() => {
@@ -968,7 +1722,7 @@ describe('Maka Pi TUI runner', () => {
       permissionMode: 'bypass',
       terminal,
       firstRun: true,
-      onboarding: { setup: async () => ({}) },
+      onboarding: fakeOnboardingSurface(),
     });
 
     await waitFor(() => {
@@ -1002,7 +1756,7 @@ describe('Maka Pi TUI runner', () => {
       permissionMode: 'bypass',
       terminal,
       firstRun: true,
-      onboarding: { setup: async () => ({}) },
+      onboarding: fakeOnboardingSurface(),
     });
 
     await waitFor(() => {
@@ -1028,102 +1782,6 @@ describe('Maka Pi TUI runner', () => {
       run,
       delay(500).then(() => {
         throw new Error('Ctrl+C did not close the first-run wizard from the key phase');
-      }),
-    ]);
-  });
-
-  test('onboarding wizard ignores a setup result from an abandoned attempt', async () => {
-    const terminal = new FakeTerminal();
-    const driver = new SlashCommandDriver();
-    const setupCalls: Array<{ apiKey: string }> = [];
-    let resolveFirst!: (value: { testError?: string }) => void;
-    const run = runMakaPiTui({
-      title: 'Maka',
-      driver,
-      cwd: '/repo',
-      model: 'claude-sonnet-4-5',
-      connectionSlug: 'claude-subscription',
-      permissionMode: 'bypass',
-      terminal,
-      onboarding: {
-        setup: (req) => {
-          setupCalls.push({ apiKey: req.apiKey });
-          // First attempt stays in flight (deferred); the user abandons it.
-          return setupCalls.length === 1
-            ? new Promise((r) => {
-                resolveFirst = r;
-              })
-            : Promise.resolve({});
-        },
-      },
-    });
-
-    await delay(20);
-    terminal.input('/setup');
-    terminal.input('\r');
-    await waitFor(() => {
-      try {
-        return latestPlainLineContaining(terminal.writes.join(''), 'Set Up Provider') !== null;
-      } catch {
-        return false;
-      }
-    });
-    terminal.input('\r'); // pick provider A -> key phase
-    await waitFor(() => {
-      try {
-        return latestPlainLineContaining(terminal.writes.join(''), 'API key') !== null;
-      } catch {
-        return false;
-      }
-    });
-
-    terminal.input('sk-a');
-    terminal.input('\r'); // submit A — probe deferred, wizard shows verifying
-    await waitFor(() => setupCalls.length === 1);
-    await waitFor(() => {
-      try {
-        return latestPlainLineContaining(terminal.writes.join(''), '验证') !== null;
-      } catch {
-        return false;
-      }
-    });
-
-    // Abandon A: Esc back to search, move to the second provider, pick it, and
-    // start typing its key (do not submit).
-    terminal.input('\x1b');
-    await waitFor(() => {
-      try {
-        return latestPlainLineContaining(terminal.writes.join(''), '1/2') !== null;
-      } catch {
-        return false;
-      }
-    });
-    terminal.input('\x1b[B'); // down to the second provider
-    terminal.input('\r');
-    await waitFor(() => {
-      try {
-        return latestPlainLineContaining(terminal.writes.join(''), 'API key') !== null;
-      } catch {
-        return false;
-      }
-    });
-    terminal.input('sk-b');
-    await waitFor(() => plainTerminalOutput(terminal.screenOutput()).includes('sk-b'));
-
-    // A's probe now resolves with a failure. It must not clobber attempt B:
-    // no failure status line, and the key being typed for B survives.
-    resolveFirst({ testError: 'HTTP 401 Unauthorized' });
-    await delay(40);
-
-    const out = plainTerminalOutput(terminal.screenOutput());
-    assert.doesNotMatch(out, /验证失败/);
-    assert.ok(out.includes('sk-b'));
-
-    process.emit('SIGTERM');
-    await Promise.race([
-      run,
-      delay(500).then(() => {
-        throw new Error('TUI did not close after SIGTERM');
       }),
     ]);
   });

--- a/packages/cli/src/__tests__/pi-tui-runner.test.ts
+++ b/packages/cli/src/__tests__/pi-tui-runner.test.ts
@@ -621,6 +621,43 @@ describe('Maka Pi TUI runner', () => {
     ]);
   });
 
+  test('/setup reports a listProviders failure as an error instead of "no providers"', async () => {
+    const terminal = new FakeTerminal();
+    const driver = new SlashCommandDriver();
+    const run = runMakaPiTui({
+      title: 'Maka',
+      driver,
+      cwd: '/repo',
+      model: 'claude-sonnet-4-5',
+      connectionSlug: 'claude-subscription',
+      permissionMode: 'bypass',
+      terminal,
+      onboarding: {
+        listProviders: async () => {
+          throw new Error('storage read failed');
+        },
+        verify: async () => ({ kind: 'ok', models: [] }),
+        save: async () => ({ kind: 'ok', modelChoices: [] }),
+      },
+    });
+
+    await delay(20);
+    terminal.input('/setup');
+    terminal.input('\r');
+    await delay(60);
+    const out = plainTerminalOutput(terminal.screenOutput());
+    assert.match(out, /storage read failed/);
+    assert.doesNotMatch(out, /没有可配置的 API key 类供应商/);
+
+    process.emit('SIGTERM');
+    await Promise.race([
+      run,
+      delay(500).then(() => {
+        throw new Error('TUI did not close after SIGTERM');
+      }),
+    ]);
+  });
+
   test('first-run picker cancel closes the TUI without configuring', async () => {
     const terminal = new FakeTerminal();
     const driver = new SlashCommandDriver();
@@ -953,6 +990,62 @@ describe('Maka Pi TUI runner', () => {
     terminal.input('\r');
     await waitFor(() => saveCalls.length === 1);
     assert.deepEqual(saveCalls[0]!.enabledModelIds, ['gpt-5.5']);
+
+    process.emit('SIGTERM');
+    await Promise.race([
+      run,
+      delay(500).then(() => {
+        throw new Error('TUI did not close after SIGTERM');
+      }),
+    ]);
+  });
+
+  test('models search field moves the cursor with arrow keys like the other fields', async () => {
+    const terminal = new FakeTerminal();
+    const driver = new SlashCommandDriver();
+    const run = runMakaPiTui({
+      title: 'Maka',
+      driver,
+      cwd: '/repo',
+      model: 'claude-sonnet-4-5',
+      connectionSlug: 'claude-subscription',
+      permissionMode: 'bypass',
+      terminal,
+      onboarding: fakeOnboardingSurface(),
+    });
+
+    await delay(20);
+    terminal.input('/setup');
+    terminal.input('\r');
+    await waitFor(() => {
+      try {
+        return latestPlainLineContaining(terminal.writes.join(''), 'Set Up Provider') !== null;
+      } catch {
+        return false;
+      }
+    });
+    terminal.input('\r'); // pick provider -> key phase
+    await waitFor(() => {
+      try {
+        return latestPlainLineContaining(terminal.writes.join(''), 'API key') !== null;
+      } catch {
+        return false;
+      }
+    });
+    terminal.input('sk-test');
+    terminal.input('\r');
+    await waitFor(() => plainTerminalOutput(terminal.screenOutput()).includes('3/3'));
+    terminal.input('gpt'); // type into the model search field
+    await delay(30);
+    terminal.input('\x1b[D'); // left arrow — should move the cursor left
+    terminal.input('x'); // insert x at the cursor (before the t)
+    await delay(30);
+    const out = plainTerminalOutput(terminal.screenOutput());
+    assert.ok(
+      out.includes('gpxt'),
+      'left arrow should move the cursor so x inserts before the final t',
+    );
+    assert.ok(!out.includes('gptx'), 'without the left arrow the x would append after t');
 
     process.emit('SIGTERM');
     await Promise.race([
@@ -1516,6 +1609,94 @@ describe('Maka Pi TUI runner', () => {
     resolveFirstSave({ kind: 'ok', modelChoices: [] });
     await delay(40);
     assert.doesNotMatch(plainTerminalOutput(terminal.screenOutput()), /已启用/);
+
+    process.emit('SIGTERM');
+    await Promise.race([
+      run,
+      delay(500).then(() => {
+        throw new Error('TUI did not close after SIGTERM');
+      }),
+    ]);
+  });
+
+  test('save refreshes the running model choices even when the user backs out during saving', async () => {
+    const terminal = new FakeTerminal();
+    const driver = new SlashCommandDriver();
+    let resolveFirstSave!: (value: OnboardingSaveResult) => void;
+    const saveCalls: Array<{ enabledModelIds: readonly string[] }> = [];
+    const run = runMakaPiTui({
+      title: 'Maka',
+      driver,
+      cwd: '/repo',
+      model: 'claude-sonnet-4-5',
+      connectionSlug: 'claude-subscription',
+      permissionMode: 'bypass',
+      terminal,
+      onboarding: fakeOnboardingSurface({
+        save: (input) => {
+          saveCalls.push(input);
+          return new Promise<OnboardingSaveResult>((r) => {
+            resolveFirstSave = r;
+          });
+        },
+      }),
+    });
+
+    await delay(20);
+    terminal.input('/setup');
+    terminal.input('\r');
+    await waitFor(() => {
+      try {
+        return latestPlainLineContaining(terminal.writes.join(''), 'Set Up Provider') !== null;
+      } catch {
+        return false;
+      }
+    });
+    terminal.input('\r'); // pick provider -> key phase
+    await waitFor(() => {
+      try {
+        return latestPlainLineContaining(terminal.writes.join(''), 'API key') !== null;
+      } catch {
+        return false;
+      }
+    });
+    terminal.input('sk-test');
+    terminal.input('\r');
+    await waitFor(() => plainTerminalOutput(terminal.screenOutput()).includes('3/3'));
+    terminal.input(' '); // toggle the first model on
+    terminal.input('\r'); // save — deferred
+    await waitFor(() => saveCalls.length === 1);
+    // Back out during saving: Esc to the key step, then Ctrl+C to close the wizard.
+    terminal.input('\x1b');
+    await waitFor(() => {
+      try {
+        return latestPlainLineContaining(terminal.writes.join(''), '2/3') !== null;
+      } catch {
+        return false;
+      }
+    });
+    terminal.input('\x03'); // Ctrl+C closes the wizard
+    await delay(30);
+    // The save completes after the user left. The running TUI's ready model
+    // choices are still authoritatively refreshed — abandoning the wizard only
+    // drops the in-frame success UI, not the background state sync.
+    resolveFirstSave({
+      kind: 'ok',
+      modelChoices: [
+        {
+          connectionSlug: 'openai',
+          connectionName: 'OpenAI',
+          providerType: 'openai',
+          model: 'gpt-5.5-new',
+          isDefaultConnection: true,
+        },
+      ],
+    });
+    await delay(40);
+    terminal.input('/model');
+    terminal.input('\r');
+    await waitFor(() => plainTerminalOutput(terminal.screenOutput()).includes('gpt-5.5-new'));
+    assert.deepEqual(driver.models, []);
 
     process.emit('SIGTERM');
     await Promise.race([

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -329,7 +329,7 @@ async function runFirstRunOnboarding(workspaceRoot: string): Promise<boolean> {
     }),
   });
   // Configured iff a connection was actually persisted during the wizard — the
-  // wizard only closes after a verified key (or on cancel; see runner firstRun).
+  // wizard only closes after a successful save (or on cancel; see runner firstRun).
   return (await connectionStore.getDefault()) !== null;
 }
 

--- a/packages/cli/src/onboarding.ts
+++ b/packages/cli/src/onboarding.ts
@@ -58,7 +58,7 @@ export function createApiKeyOnboardingSurface(deps: {
     ConnectionStore,
     'list' | 'get' | 'create' | 'update' | 'remove' | 'getDefault' | 'setDefault'
   >;
-  credentialStore: Pick<CredentialStore, 'getSecret' | 'setSecret'>;
+  credentialStore: Pick<CredentialStore, 'getSecret' | 'setSecret' | 'deleteSecret'>;
   fetchModels: (connection: LlmConnection, apiKey: string) => Promise<ModelInfo[]>;
 }): MakaOnboardingSurface {
   return {
@@ -222,7 +222,7 @@ export interface SaveApiKeyConnectionInput {
     ConnectionStore,
     'get' | 'create' | 'update' | 'remove' | 'getDefault' | 'setDefault'
   >;
-  credentialStore: Pick<CredentialStore, 'setSecret'>;
+  credentialStore: Pick<CredentialStore, 'getSecret' | 'setSecret' | 'deleteSecret'>;
   /** Refreshed authoritative ready model choices for the running TUI. */
   fetchModelChoices: () => Promise<ModelChoice[]>;
 }
@@ -267,15 +267,33 @@ export async function saveApiKeyConnection(
 
   if (existing) {
     // Rotate the key first (if supplied): a rotation failure leaves the existing
-    // connection untouched (previous secret + previous curation stand).
+    // connection untouched (previous secret + previous curation stand). A failed
+    // curation write rolls the rotation back so the connection keeps its previous
+    // secret + curation — save stays atomic from the caller's view.
     if (suppliedKey) {
+      const previousSecret = await input.credentialStore.getSecret(input.providerType, 'api_key');
       try {
         await input.credentialStore.setSecret(input.providerType, 'api_key', suppliedKey);
       } catch (error) {
         return { kind: 'error', text: error instanceof Error ? error.message : String(error) };
       }
+      try {
+        await input.connectionStore.update(input.providerType, modelPatch);
+      } catch (error) {
+        if (previousSecret !== null) {
+          await input.credentialStore.setSecret(input.providerType, 'api_key', previousSecret);
+        } else {
+          await input.credentialStore.deleteSecret(input.providerType, 'api_key');
+        }
+        return { kind: 'error', text: error instanceof Error ? error.message : String(error) };
+      }
+    } else {
+      try {
+        await input.connectionStore.update(input.providerType, modelPatch);
+      } catch (error) {
+        return { kind: 'error', text: error instanceof Error ? error.message : String(error) };
+      }
     }
-    await input.connectionStore.update(input.providerType, modelPatch);
   } else {
     await input.connectionStore.create({
       slug: input.providerType,
@@ -291,7 +309,15 @@ export async function saveApiKeyConnection(
       await input.connectionStore.remove(input.providerType);
       return { kind: 'error', text: error instanceof Error ? error.message : String(error) };
     }
-    await input.connectionStore.update(input.providerType, modelPatch);
+    try {
+      await input.connectionStore.update(input.providerType, modelPatch);
+    } catch (error) {
+      // Atomicity: a failed curation write rolls back the new connection + secret
+      // so no half-configured default connection is left behind for first-run.
+      await input.connectionStore.remove(input.providerType);
+      await input.credentialStore.deleteSecret(input.providerType, 'api_key');
+      return { kind: 'error', text: error instanceof Error ? error.message : String(error) };
+    }
   }
 
   // setDefault only when no default connection exists (first run, or a host with

--- a/packages/cli/src/onboarding.ts
+++ b/packages/cli/src/onboarding.ts
@@ -1,85 +1,17 @@
 import {
   CATALOG_PROVIDER_TYPES,
   PROVIDER_DEFAULTS,
+  connectionEnabledModelIds,
   providerAuthSupportsApiKey,
+  type ConnectionLastTestStatus,
   type LlmConnection,
+  type ModelDiscoverySource,
   type ModelInfo,
   type ProviderType,
 } from '@maka/core/llm-connections';
 import type { ConnectionStore, CredentialStore } from '@maka/storage';
-
-export interface SetupApiKeyConnectionInput {
-  providerType: ProviderType;
-  slug: string;
-  apiKey: string;
-  name?: string;
-  baseUrl?: string;
-  defaultModel?: string;
-  connectionStore: Pick<ConnectionStore, 'create' | 'get' | 'remove' | 'getDefault' | 'setDefault'>;
-  credentialStore: Pick<CredentialStore, 'setSecret'>;
-  fetchModels: (connection: LlmConnection, apiKey: string) => Promise<ModelInfo[]>;
-}
-
-export interface SetupApiKeyConnectionResult {
-  connection: LlmConnection;
-  models: ModelInfo[];
-  /** Set when the model probe failed. The connection is still saved; onboarding
-   *  offers manual model entry instead of aborting (non-blocking test). */
-  testError?: string;
-}
-
-/**
- * Persist a single API-key connection end to end: create the connection, store
- * its secret, and probe it for models. Onboarding's write side — the read side
- * lives in `connection-target.ts`. Pure and dependency-injected so the TUI wizard
- * (PR②) drives the same seam the tests do.
- */
-export async function setupApiKeyConnection(
-  input: SetupApiKeyConnectionInput,
-): Promise<SetupApiKeyConnectionResult> {
-  if (!providerAuthSupportsApiKey(input.providerType)) {
-    throw new Error(`Provider "${input.providerType}" does not accept an API key`);
-  }
-  if (PROVIDER_DEFAULTS[input.providerType]?.authKind === 'api_key' && !input.apiKey.trim()) {
-    throw new Error('API key is required');
-  }
-  // Upsert by slug so re-onboarding the same provider (e.g. fixing a typo'd
-  // key) rotates the secret instead of throwing "slug already exists". An
-  // existing connection keeps its endpoint/model; only the key is refreshed.
-  const existing = await input.connectionStore.get(input.slug);
-  const connection = existing
-    ? existing
-    : await input.connectionStore.create({
-        slug: input.slug,
-        name: input.name ?? input.slug,
-        providerType: input.providerType,
-        ...(input.baseUrl ? { baseUrl: input.baseUrl } : {}),
-        ...(input.defaultModel ? { defaultModel: input.defaultModel } : {}),
-      });
-  try {
-    await input.credentialStore.setSecret(input.slug, 'api_key', input.apiKey);
-  } catch (error) {
-    // Atomicity: a newly-created connection is rolled back when the secret write
-    // fails, so no half-configured connection becomes the default. An existing
-    // connection is left in place — its previous secret stands.
-    if (!existing) await input.connectionStore.remove(input.slug);
-    throw error;
-  }
-  try {
-    const models = await input.fetchModels(connection, input.apiKey);
-    // Only a verified connection becomes the default: a probe failure leaves
-    // the host's getDefault() accurate so a cancelled first-run attempt does
-    // not trap the next launch out of onboarding.
-    await input.connectionStore.setDefault(input.slug);
-    return { connection, models };
-  } catch (error) {
-    return {
-      connection,
-      models: [],
-      testError: error instanceof Error ? error.message : String(error),
-    };
-  }
-}
+import type { ModelChoice } from './connection-target.js';
+import { listReadyModelChoices } from './connection-target.js';
 
 export interface OnboardableProvider {
   providerType: ProviderType;
@@ -91,41 +23,68 @@ export interface OnboardableProvider {
   fallbackModels: readonly string[];
 }
 
-/** Host-supplied onboarding surface. The TUI wizard collects a provider + API
- *  key and calls setup(); the host owns the connection/credential stores and
- *  runs the real setupApiKeyConnection. `setup` resolves with `{ testError }`
- *  when the connection was saved but the model probe failed, so the wizard can
- *  re-arm the key prompt instead of claiming success. */
+/** Host-supplied onboarding surface for the three-step `/setup` wizard. The
+ *  wizard is UI-only: it calls `listProviders` to open, `verify` to check a
+ *  supplied-or-stored key and discover models without persisting, and `save` to
+ *  persist the curated enabled-model set + cache and refresh the running TUI's
+ *  ready model choices. The host owns the connection/credential stores; the
+ *  secret never crosses back into the wizard. */
 export interface MakaOnboardingSurface {
-  setup: (input: {
-    providerType: ProviderType;
-    apiKey: string;
-    baseUrl?: string;
-  }) => Promise<{ testError?: string }>;
+  listProviders: () => Promise<OnboardingProviderEntry[]>;
+  verify: (input: OnboardingVerifyInput) => Promise<OnboardingVerifyResult>;
+  save: (input: OnboardingSaveInput) => Promise<OnboardingSaveResult>;
 }
+
+/** Wizard-facing verify input: a provider plus an optional key (blank reuses a
+ *  stored secret for an existing connection). */
+export type OnboardingVerifyInput = Pick<VerifyApiKeyConnectionInput, 'providerType' | 'apiKey'>;
+export type OnboardingVerifyResult = VerifyApiKeyConnectionResult;
+
+/** Wizard-facing save input: the verified provider, an optional key (blank
+ *  keeps the stored secret for an existing connection), the curated enabled
+ *  set, and the discovered models to cache. */
+export type OnboardingSaveInput = Pick<
+  SaveApiKeyConnectionInput,
+  'providerType' | 'apiKey' | 'enabledModelIds' | 'models'
+>;
+export type OnboardingSaveResult = SaveApiKeyConnectionResult;
 
 /** Build the onboarding surface the TUI wizard calls, owning the connection and
  *  credential stores plus the model probe. Centralizes the `slug = providerType`
  *  policy so the first-run host (cli.ts) and the in-session host
  *  (runtime-bootstrap) share one write path. */
 export function createApiKeyOnboardingSurface(deps: {
-  connectionStore: Pick<ConnectionStore, 'create' | 'get' | 'remove' | 'getDefault' | 'setDefault'>;
-  credentialStore: Pick<CredentialStore, 'setSecret'>;
+  connectionStore: Pick<
+    ConnectionStore,
+    'list' | 'get' | 'create' | 'update' | 'remove' | 'getDefault' | 'setDefault'
+  >;
+  credentialStore: Pick<CredentialStore, 'getSecret' | 'setSecret'>;
   fetchModels: (connection: LlmConnection, apiKey: string) => Promise<ModelInfo[]>;
 }): MakaOnboardingSurface {
   return {
-    setup: async ({ providerType, apiKey, baseUrl }) => {
-      const result = await setupApiKeyConnection({
-        providerType,
-        slug: providerType,
-        apiKey,
-        ...(baseUrl ? { baseUrl } : {}),
+    listProviders: () => listOnboardingProviders({ connectionStore: deps.connectionStore }),
+    verify: (input) =>
+      verifyApiKeyConnection({
+        providerType: input.providerType,
+        apiKey: input.apiKey,
         connectionStore: deps.connectionStore,
         credentialStore: deps.credentialStore,
         fetchModels: deps.fetchModels,
-      });
-      return result.testError ? { testError: result.testError } : {};
-    },
+      }),
+    save: (input) =>
+      saveApiKeyConnection({
+        providerType: input.providerType,
+        apiKey: input.apiKey,
+        enabledModelIds: input.enabledModelIds,
+        models: input.models,
+        connectionStore: deps.connectionStore,
+        credentialStore: deps.credentialStore,
+        fetchModelChoices: () =>
+          listReadyModelChoices({
+            connectionStore: deps.connectionStore,
+            credentialStore: deps.credentialStore,
+          }),
+      }),
   };
 }
 
@@ -149,4 +108,198 @@ export function listApiKeyOnboardableProviders(): OnboardableProvider[] {
       // exclude them until the base-URL prompt lands (phase 2).
       .filter((provider) => !provider.requiresBaseUrl)
   );
+}
+
+/** A catalog provider annotated with whether a connection already exists for
+ *  it, plus that connection's curated enabled model ids. The wizard's provider
+ *  search marks existing providers `已设置` and pre-selects their enabled set in
+ *  the model step; new connections start with no models selected. */
+export interface OnboardingProviderEntry extends OnboardableProvider {
+  hasConnection: boolean;
+  enabledModelIds: readonly string[];
+}
+
+/** Catalog API-key providers (phase 1) annotated with the host's existing
+ *  connection state. The wizard calls this when it opens so `已设置` and the
+ *  preserved enabled set reflect live storage, not a startup snapshot. */
+export async function listOnboardingProviders(input: {
+  connectionStore: Pick<ConnectionStore, 'list'>;
+}): Promise<OnboardingProviderEntry[]> {
+  const connections = await input.connectionStore.list();
+  const bySlug = new Map(connections.map((connection) => [connection.slug, connection]));
+  return listApiKeyOnboardableProviders().map((provider) => {
+    const existing = bySlug.get(provider.providerType);
+    return {
+      ...provider,
+      hasConnection: existing !== undefined,
+      enabledModelIds: existing ? connectionEnabledModelIds(existing) : [],
+    };
+  });
+}
+
+export interface VerifyApiKeyConnectionInput {
+  providerType: ProviderType;
+  /** Supplied key. Blank for an existing connection reuses the stored secret;
+   *  blank for a new required-key connection is rejected. Never returned to the
+   *   wizard — verify is host-owned. */
+  apiKey?: string;
+  connectionStore: Pick<ConnectionStore, 'get'>;
+  credentialStore: Pick<CredentialStore, 'getSecret'>;
+  fetchModels: (connection: LlmConnection, apiKey: string) => Promise<ModelInfo[]>;
+}
+
+export type VerifyApiKeyConnectionResult =
+  | { kind: 'ok'; models: ModelInfo[] }
+  | { kind: 'error'; text: string };
+
+/** Probe a provider with a supplied or stored secret without persisting: the
+ *  wizard's key step verifies the key works and discovers models, then defers
+ *  all persistence to {@link saveApiKeyConnection}. An existing connection may
+ *  leave the key blank to reuse the stored secret; a new required-key connection
+ *  must supply one. Pure and dependency-injected so the TUI wizard drives the
+ *  same seam the tests do. */
+export async function verifyApiKeyConnection(
+  input: VerifyApiKeyConnectionInput,
+): Promise<VerifyApiKeyConnectionResult> {
+  if (!providerAuthSupportsApiKey(input.providerType)) {
+    return { kind: 'error', text: `Provider "${input.providerType}" does not accept an API key` };
+  }
+  const def = PROVIDER_DEFAULTS[input.providerType];
+  const requiresKey = def?.authKind === 'api_key';
+  const suppliedKey = input.apiKey?.trim() ?? '';
+  const existing = await input.connectionStore.get(input.providerType);
+  let connection: LlmConnection;
+  let secret: string;
+  if (existing) {
+    connection = existing;
+    if (suppliedKey) {
+      secret = suppliedKey;
+    } else {
+      const stored = (await input.credentialStore.getSecret(input.providerType, 'api_key')) ?? '';
+      if (requiresKey && !stored) return { kind: 'error', text: 'API key is required' };
+      secret = stored;
+    }
+  } else {
+    if (requiresKey && !suppliedKey) return { kind: 'error', text: 'API key is required' };
+    secret = suppliedKey;
+    connection = transientOnboardingConnection(input.providerType);
+  }
+  try {
+    const models = await input.fetchModels(connection, secret);
+    return { kind: 'ok', models };
+  } catch (error) {
+    return { kind: 'error', text: error instanceof Error ? error.message : String(error) };
+  }
+}
+
+/** Build a transient, in-memory connection from catalog defaults so a new
+ *  provider's verify can probe without persisting a half-configured connection. */
+function transientOnboardingConnection(providerType: ProviderType): LlmConnection {
+  const def = PROVIDER_DEFAULTS[providerType];
+  const now = Date.now();
+  return {
+    slug: providerType,
+    name: def.label,
+    providerType,
+    ...(def.baseUrl ? { baseUrl: def.baseUrl } : {}),
+    defaultModel: def.fallbackModels[0] ?? '',
+    enabled: true,
+    createdAt: now,
+    updatedAt: now,
+  };
+}
+
+export interface SaveApiKeyConnectionInput {
+  providerType: ProviderType;
+  /** Supplied key. Blank for an existing connection leaves the stored secret
+   *   untouched; a new connection must supply one (verify already enforced it). */
+  apiKey?: string;
+  /** Curated enabled model ids — at least one is required before saving. */
+  enabledModelIds: readonly string[];
+  /** Discovered models from verify, cached on the connection. */
+  models: readonly ModelInfo[];
+  connectionStore: Pick<
+    ConnectionStore,
+    'get' | 'create' | 'update' | 'remove' | 'getDefault' | 'setDefault'
+  >;
+  credentialStore: Pick<CredentialStore, 'setSecret'>;
+  /** Refreshed authoritative ready model choices for the running TUI. */
+  fetchModelChoices: () => Promise<ModelChoice[]>;
+}
+
+export type SaveApiKeyConnectionResult =
+  | { kind: 'ok'; modelChoices: ModelChoice[] }
+  | { kind: 'error'; text: string };
+
+/** Persist the verified connection with the curated enabled-model set, caching
+ *  discovered models and normalizing the required compatibility `defaultModel`
+ *  (kept when still enabled, otherwise the first enabled model — never a user
+ *  default choice). `setDefault` runs only when no default connection exists, so
+ *  in-session setup never replaces an existing default. A new connection's
+ *  secret-write failure rolls back the created connection; an existing
+ *  connection's rotation failure leaves it untouched. Pure and DI so the TUI
+ *  wizard drives the same seam the tests do. */
+export async function saveApiKeyConnection(
+  input: SaveApiKeyConnectionInput,
+): Promise<SaveApiKeyConnectionResult> {
+  if (!providerAuthSupportsApiKey(input.providerType)) {
+    return { kind: 'error', text: `Provider "${input.providerType}" does not accept an API key` };
+  }
+  const enabled = input.enabledModelIds.map((id) => id.trim()).filter(Boolean);
+  if (enabled.length === 0) {
+    return { kind: 'error', text: '至少选择一个模型再保存' };
+  }
+  const def = PROVIDER_DEFAULTS[input.providerType];
+  const suppliedKey = input.apiKey?.trim() ?? '';
+  const existing = await input.connectionStore.get(input.providerType);
+  const normalizedDefault =
+    existing && enabled.includes(existing.defaultModel) ? existing.defaultModel : enabled[0]!;
+  const testAt = new Date().toISOString();
+  const modelPatch = {
+    defaultModel: normalizedDefault,
+    enabledModelIds: enabled,
+    models: [...input.models],
+    modelSource: 'fetched' as ModelDiscoverySource,
+    modelsFetchedAt: Date.now(),
+    lastTestStatus: 'verified' as ConnectionLastTestStatus,
+    lastTestAt: testAt,
+  };
+
+  if (existing) {
+    // Rotate the key first (if supplied): a rotation failure leaves the existing
+    // connection untouched (previous secret + previous curation stand).
+    if (suppliedKey) {
+      try {
+        await input.credentialStore.setSecret(input.providerType, 'api_key', suppliedKey);
+      } catch (error) {
+        return { kind: 'error', text: error instanceof Error ? error.message : String(error) };
+      }
+    }
+    await input.connectionStore.update(input.providerType, modelPatch);
+  } else {
+    await input.connectionStore.create({
+      slug: input.providerType,
+      name: def.label,
+      providerType: input.providerType,
+      defaultModel: normalizedDefault,
+    });
+    try {
+      await input.credentialStore.setSecret(input.providerType, 'api_key', suppliedKey);
+    } catch (error) {
+      // Atomicity: a newly-created connection is rolled back when the secret
+      // write fails, so no half-configured connection becomes the default.
+      await input.connectionStore.remove(input.providerType);
+      return { kind: 'error', text: error instanceof Error ? error.message : String(error) };
+    }
+    await input.connectionStore.update(input.providerType, modelPatch);
+  }
+
+  // setDefault only when no default connection exists (first run, or a host with
+  // no prior default). In-session setup never replaces an existing default.
+  if ((await input.connectionStore.getDefault()) === null) {
+    await input.connectionStore.setDefault(input.providerType);
+  }
+
+  const modelChoices = await input.fetchModelChoices();
+  return { kind: 'ok', modelChoices };
 }

--- a/packages/cli/src/pi-tui-pickers.ts
+++ b/packages/cli/src/pi-tui-pickers.ts
@@ -19,9 +19,9 @@ import type { UserQuestionOption } from '@maka/core';
 import { PERMISSION_MODES, type PermissionMode } from '@maka/core/permission';
 import type { ThinkingLevel } from '@maka/core/model-thinking';
 import type { InvocableSkillEntry } from '@maka/runtime';
-import { PROVIDER_DEFAULTS, type ProviderType } from '@maka/core/llm-connections';
+import { PROVIDER_DEFAULTS, type ModelInfo, type ProviderType } from '@maka/core/llm-connections';
 import type { ModelChoice } from './connection-target.js';
-import type { OnboardableProvider } from './onboarding.js';
+import type { OnboardingProviderEntry } from './onboarding.js';
 import { skillInvocationPrefixAt } from './skill-token.js';
 import { ansi, editorTheme, selectListTheme, stripAnsi } from './tui-ansi.js';
 
@@ -705,13 +705,17 @@ export function skillPickerItems(skills: readonly InvocableSkillEntry[]): Select
   }));
 }
 
-export function onboardableProviderPickerItems(
-  providers: readonly OnboardableProvider[],
+/** Provider search items for `/setup`, marking connections that already exist
+ *  `已设置` so a re-onboard reads as edit/rotate rather than create. */
+export function onboardingProviderPickerItems(
+  providers: readonly OnboardingProviderEntry[],
 ): SelectItem[] {
   return providers.map((provider) => ({
     value: provider.providerType,
     label: provider.label,
-    description: provider.providerType,
+    description: provider.hasConnection
+      ? `${provider.providerType} · 已设置`
+      : provider.providerType,
   }));
 }
 
@@ -754,39 +758,60 @@ function padLine(text: string, width: number): string {
   return `${trimmed}${' '.repeat(Math.max(0, safeWidth - visibleWidth(trimmed)))}`;
 }
 
-export type OnboardingWizardPhase = 'search' | 'key';
+export type OnboardingWizardPhase = 'search' | 'key' | 'models' | 'success';
 
 export type OnboardingWizardStatus =
   | { kind: 'prompt' }
   | { kind: 'verifying' }
-  | { kind: 'error'; text: string };
+  | { kind: 'error'; text: string }
+  | { kind: 'saving' };
 
 export interface OnboardingWizardInput {
-  providers: readonly OnboardableProvider[];
-  /** search→key: the user picked a provider. The runner records it for setup. */
+  providers: readonly OnboardingProviderEntry[];
+  /** search→key: the user picked a provider. The runner records it for verify/save. */
   onPickProvider: (providerType: ProviderType) => void;
-  /** key submit: the runner runs onboarding.setup with the recorded provider. */
+  /** key submit. The value may be empty — an existing connection reuses the stored
+   *   secret, while a new required-key provider is rejected by verify. */
   onSubmitKey: (apiKey: string) => void;
-  /** search Esc: the runner closes the wizard (and the TUI on first run). */
+  /** models submit: save the curated enabled set (≥1 model). */
+  onSubmitModels: (enabledModelIds: readonly string[]) => void;
+  /** search Esc / Ctrl+C: close (first-run closes the TUI). */
   onCancel: () => void;
-  /** key Esc: the wizard already returned to search; the runner may react. */
+  /** key Esc → search; models Esc → key. The runner invalidates in-flight work. */
   onBack: () => void;
+  /** success Enter/Esc: close. */
+  onClose: () => void;
 }
 
+const ONBOARDING_MODELS_MAX_VISIBLE = 10;
+
 /**
- * One input field, two phases. The same overlay is the search box (filter the
- * provider list as you type) and then the key field, so onboarding never pushes
- * its prompt/verifying/failure notices into the transcript. Status lives in a
- * single status line beside the field instead of the top entry flow (#1098 UX).
+ * One input field, four phases. The same overlay is the provider search, the
+ * API-key field, the searchable model multi-select, and the in-frame success —
+ * so onboarding never pushes its prompt/verifying/failure/saving/success notices
+ * into the transcript. Status lives in a single status line beside the field
+ * instead of the top entry flow (#1098 UX). `Esc` always moves back exactly one
+ * level (models → key → provider → close); late async results are ignored after
+ * back/close/retry because the runner bumps its attempt id on every transition.
  */
 export class OnboardingWizard implements Component {
   private phase: OnboardingWizardPhase = 'search';
-  private picked: OnboardableProvider | undefined;
+  private picked: OnboardingProviderEntry | undefined;
   private status: OnboardingWizardStatus = { kind: 'prompt' };
   private readonly searchEditor: Editor;
   private readonly keyEditor: Editor;
-  private filtered: readonly OnboardableProvider[];
+  private readonly modelsSearchEditor: Editor;
+  private filtered: readonly OnboardingProviderEntry[];
   private list: SelectList;
+  // Models phase state. Selection seeds from the picked provider's enabled set
+  // on first verify; a re-verify preserves the user's toggles (stale ids drop).
+  private models: ModelInfo[] = [];
+  private filteredModels: ModelInfo[] = [];
+  private selectedIds: Set<string> = new Set();
+  private modelsInitialized = false;
+  private modelHighlight = 0;
+  private modelScroll = 0;
+  private successCount = 0;
 
   constructor(
     private readonly tui: TUI,
@@ -800,14 +825,18 @@ export class OnboardingWizard implements Component {
     // the new instance up.
     this.searchEditor.onChange = (text) => this.applyQuery(text);
     this.keyEditor = new Editor(tui, editorTheme(), { paddingX: 0 });
+    // Allow a blank submit: an existing connection reuses the stored secret; the
+    // host's verify rejects a blank key for a new required-key provider.
     this.keyEditor.onSubmit = (value) => {
-      if (this.picked && value) this.input.onSubmitKey(value);
+      if (this.picked) this.input.onSubmitKey(value);
     };
+    this.modelsSearchEditor = new Editor(tui, editorTheme(), { paddingX: 0 });
+    this.modelsSearchEditor.onChange = (text) => this.applyModelQuery(text);
   }
 
   private buildList(): SelectList {
     const list = new SelectList(
-      onboardableProviderPickerItems(this.filtered),
+      onboardingProviderPickerItems(this.filtered),
       10,
       selectListTheme(),
       { minPrimaryColumnWidth: 16, maxPrimaryColumnWidth: 32 },
@@ -815,15 +844,27 @@ export class OnboardingWizard implements Component {
     list.onSelect = (item) => {
       const provider = this.filtered.find((p) => p.providerType === item.value);
       if (!provider) return;
-      this.picked = provider;
-      this.phase = 'key';
-      this.status = { kind: 'prompt' };
-      this.keyEditor.setText('');
-      this.keyEditor.disableSubmit = false;
-      this.searchEditor.setText('');
-      this.input.onPickProvider(provider.providerType);
+      this.enterKeyPhase(provider);
     };
     return list;
+  }
+
+  private enterKeyPhase(provider: OnboardingProviderEntry): void {
+    this.picked = provider;
+    this.phase = 'key';
+    this.status = { kind: 'prompt' };
+    this.keyEditor.setText('');
+    this.keyEditor.disableSubmit = false;
+    this.searchEditor.setText('');
+    // Reset the models phase for the new provider; selection seeds on first verify.
+    this.models = [];
+    this.filteredModels = [];
+    this.selectedIds = new Set();
+    this.modelsInitialized = false;
+    this.modelHighlight = 0;
+    this.modelScroll = 0;
+    this.modelsSearchEditor.setText('');
+    this.input.onPickProvider(provider.providerType);
   }
 
   private applyQuery(text: string): void {
@@ -839,33 +880,96 @@ export class OnboardingWizard implements Component {
     this.list = this.buildList();
   }
 
-  /** Runner hook: the probe is in flight. Lock the key field and show progress. */
+  private applyModelQuery(text: string): void {
+    const query = text.trim().toLowerCase();
+    this.filteredModels = query
+      ? this.models.filter(
+          (m) =>
+            m.id.toLowerCase().includes(query) ||
+            (m.displayName ?? '').toLowerCase().includes(query),
+        )
+      : this.models;
+    this.modelHighlight = 0;
+    this.modelScroll = 0;
+  }
+
+  /** Runner hook: verify is in flight. Lock the key field and show progress. */
   setVerifying(): void {
     if (this.phase !== 'key') return;
     this.status = { kind: 'verifying' };
     this.keyEditor.disableSubmit = true;
   }
 
-  /** Runner hook: the probe settled. An error re-arms the key field in place. */
-  setResult(result: { kind: 'error'; text: string }): void {
-    this.status = result;
-    if (result.kind === 'error') {
-      this.keyEditor.disableSubmit = false;
-      this.keyEditor.setText('');
+  /** Runner hook: verify failed — re-arm the key field in place. */
+  setKeyError(text: string): void {
+    if (this.phase !== 'key') return;
+    this.status = { kind: 'error', text };
+    this.keyEditor.disableSubmit = false;
+    this.keyEditor.setText('');
+  }
+
+  /** Runner hook: verify succeeded — advance to the models step with fresh
+   *  discovered models. Selection seeds from the picked provider's enabled set
+   *  on first entry (existing connections preserve it; new ones start empty);
+   *  a re-verify preserves the user's toggles, dropping ids no longer discovered. */
+  setModels(models: ModelInfo[]): void {
+    if (this.phase !== 'key') return;
+    this.models = models;
+    if (!this.modelsInitialized) {
+      this.selectedIds = new Set(
+        (this.picked?.enabledModelIds ?? []).filter((id) => models.some((m) => m.id === id)),
+      );
+      this.modelsInitialized = true;
+    } else {
+      for (const id of [...this.selectedIds]) {
+        if (!models.some((m) => m.id === id)) this.selectedIds.delete(id);
+      }
     }
+    this.applyModelQuery(this.modelsSearchEditor.getText());
+    this.phase = 'models';
+    this.status = { kind: 'prompt' };
+  }
+
+  /** Runner hook: save is in flight. */
+  setSaving(): void {
+    if (this.phase !== 'models') return;
+    this.status = { kind: 'saving' };
+  }
+
+  /** Runner hook: save failed — stay in the models step with an error. */
+  setModelError(text: string): void {
+    if (this.phase !== 'models') return;
+    this.status = { kind: 'error', text };
+  }
+
+  /** Runner hook: save succeeded — show the enabled-model count in-frame. */
+  setSuccess(enabledCount: number): void {
+    this.phase = 'success';
+    this.successCount = enabledCount;
+    this.status = { kind: 'prompt' };
   }
 
   invalidate(): void {
     this.searchEditor.invalidate();
     this.keyEditor.invalidate();
+    this.modelsSearchEditor.invalidate();
     this.list.invalidate();
   }
 
   handleInput(data: string): void {
-    if (this.phase === 'key') {
-      this.handleKeyInput(data);
-      return;
+    switch (this.phase) {
+      case 'search':
+        return this.handleSearchInput(data);
+      case 'key':
+        return this.handleKeyInput(data);
+      case 'models':
+        return this.handleModelsInput(data);
+      case 'success':
+        return this.handleSuccessInput(data);
     }
+  }
+
+  private handleSearchInput(data: string): void {
     if (matchesKey(data, Key.escape) || matchesKey(data, Key.ctrl('c'))) {
       this.input.onCancel();
       return;
@@ -909,17 +1013,106 @@ export class OnboardingWizard implements Component {
     this.keyEditor.handleInput(data);
   }
 
+  private handleModelsInput(data: string): void {
+    if (matchesKey(data, Key.ctrl('c'))) {
+      this.input.onCancel();
+      return;
+    }
+    if (matchesKey(data, Key.escape)) {
+      // models → key (one level back); query/selection state survives.
+      this.phase = 'key';
+      this.status = { kind: 'prompt' };
+      this.keyEditor.setText('');
+      this.keyEditor.disableSubmit = false;
+      this.input.onBack();
+      return;
+    }
+    if (this.status.kind === 'saving') return;
+    if (matchesKey(data, Key.up)) {
+      this.moveModelHighlight(-1);
+      return;
+    }
+    if (matchesKey(data, Key.down)) {
+      this.moveModelHighlight(1);
+      return;
+    }
+    // Space toggles the highlighted model instead of entering the search query —
+    // model ids never contain spaces, so the search field does not need it.
+    if (matchesKey(data, Key.space)) {
+      this.toggleHighlightedModel();
+      return;
+    }
+    if (matchesKey(data, Key.enter) || matchesKey(data, Key.return)) {
+      if (isKeyRepeat(data)) return;
+      if (this.selectedIds.size === 0) {
+        this.status = { kind: 'error', text: '至少选择一个模型再保存' };
+        return;
+      }
+      this.input.onSubmitModels([...this.selectedIds]);
+      return;
+    }
+    // Everything else printable (non-Space) filters the model list in place.
+    const printable = decodeKittyPrintable(data) ?? (data.charCodeAt(0) >= 32 ? data : undefined);
+    if (printable !== undefined && printable !== ' ') {
+      this.modelsSearchEditor.handleInput(data);
+    }
+  }
+
+  private handleSuccessInput(data: string): void {
+    if (
+      matchesKey(data, Key.enter) ||
+      matchesKey(data, Key.return) ||
+      matchesKey(data, Key.escape) ||
+      matchesKey(data, Key.ctrl('c'))
+    ) {
+      if (matchesKey(data, Key.enter) && isKeyRepeat(data)) return;
+      this.input.onClose();
+    }
+  }
+
+  private moveModelHighlight(delta: number): void {
+    const count = this.filteredModels.length;
+    if (count === 0) return;
+    this.modelHighlight = (this.modelHighlight + delta + count) % count;
+    // Keep the highlight inside the visible window.
+    if (this.modelHighlight < this.modelScroll) this.modelScroll = this.modelHighlight;
+    else if (this.modelHighlight >= this.modelScroll + ONBOARDING_MODELS_MAX_VISIBLE) {
+      this.modelScroll = this.modelHighlight - ONBOARDING_MODELS_MAX_VISIBLE + 1;
+    }
+  }
+
+  private toggleHighlightedModel(): void {
+    const model = this.filteredModels[this.modelHighlight];
+    if (!model) return;
+    if (this.selectedIds.has(model.id)) this.selectedIds.delete(model.id);
+    else this.selectedIds.add(model.id);
+    // Clear a stale "至少选择一个模型" error once a selection exists.
+    if (this.status.kind === 'error' && this.selectedIds.size > 0) {
+      this.status = { kind: 'prompt' };
+    }
+  }
+
   render(width: number): string[] {
     const safeWidth = Math.max(1, width);
-    return this.phase === 'search' ? this.renderSearch(safeWidth) : this.renderKey(safeWidth);
+    switch (this.phase) {
+      case 'search':
+        return this.renderSearch(safeWidth);
+      case 'key':
+        return this.renderKey(safeWidth);
+      case 'models':
+        return this.renderModels(safeWidth);
+      case 'success':
+        return this.renderSuccess(safeWidth);
+    }
   }
 
   private renderSearch(width: number): string[] {
     this.searchEditor.focused = true;
     this.keyEditor.focused = false;
+    this.modelsSearchEditor.focused = false;
     return [
       padLine(
-        `Set Up Provider ${ansi.dim('· 1/2')} ${ansi.accent(String(this.filtered.length))}`,
+        `Set Up Provider ${ansi.dim('· 1/3')} ${ansi.accent(String(this.filtered.length))}`,
         width,
       ),
       padLine(ansi.dim('搜索服务商，↑↓ 选择 · Enter 确认 · Esc 取消'), width),
@@ -935,22 +1128,24 @@ export class OnboardingWizard implements Component {
 
   private renderKey(width: number): string[] {
     this.searchEditor.focused = false;
-    // The cursor stays hidden while the probe is in flight; only an editable
-    // or errored key field takes focus.
     this.keyEditor.focused = this.status.kind === 'prompt' || this.status.kind === 'error';
+    this.modelsSearchEditor.focused = false;
     const label = this.picked?.label ?? '';
+    const hint = this.picked?.hasConnection
+      ? '留空复用已保存的 key，或输入新 key 轮换 · Esc 返回选择服务商'
+      : '输入 API key · 仅本机存储 · Esc 返回选择服务商';
     return [
-      padLine(`Set Up Provider ${ansi.dim('· 2/2')} ${ansi.accent(label)}`, width),
-      padLine(ansi.dim('输入 API key · 仅本机存储 · Esc 返回选择服务商'), width),
+      padLine(`Set Up Provider ${ansi.dim('· 2/3')} ${ansi.accent(label)}`, width),
+      padLine(ansi.dim(hint), width),
       padLine('', width),
       ...this.renderFieldRow(this.keyEditor, 'API key', width),
       padLine('', width),
-      padLine(this.renderStatusLine(), width),
+      padLine(this.renderKeyStatusLine(), width),
       padLine(ansi.accent('-'.repeat(width)), width),
     ];
   }
 
-  private renderStatusLine(): string {
+  private renderKeyStatusLine(): string {
     switch (this.status.kind) {
       case 'prompt':
         return ansi.dim('Enter 提交');
@@ -958,7 +1153,69 @@ export class OnboardingWizard implements Component {
         return `${ansi.yellow('⠋')} 正在验证 key…`;
       case 'error':
         return ansi.red(`✗ ${this.status.text}`);
+      case 'saving':
+        return ansi.dim('Enter 提交');
     }
+  }
+
+  private renderModels(width: number): string[] {
+    this.searchEditor.focused = false;
+    this.keyEditor.focused = false;
+    this.modelsSearchEditor.focused = this.status.kind !== 'saving';
+    const label = this.picked?.label ?? '';
+    const lines = [
+      padLine(`Set Up Provider ${ansi.dim('· 3/3')} ${ansi.accent(label)}`, width),
+      padLine(ansi.dim('搜索模型，↑↓ 选择 · Space 切换 · Enter 保存 · Esc 返回'), width),
+      padLine('', width),
+      ...this.renderFieldRow(this.modelsSearchEditor, '搜索', width),
+      padLine('', width),
+    ];
+    if (this.filteredModels.length === 0) {
+      lines.push(padLine(ansi.dim('没有匹配的模型'), width));
+    } else {
+      const end = Math.min(
+        this.modelScroll + ONBOARDING_MODELS_MAX_VISIBLE,
+        this.filteredModels.length,
+      );
+      for (let i = this.modelScroll; i < end; i++) {
+        const model = this.filteredModels[i]!;
+        const highlighted = i === this.modelHighlight;
+        const mark = this.selectedIds.has(model.id) ? '☑' : '☐';
+        const body = model.displayName ? `${model.displayName} ${ansi.dim(model.id)}` : model.id;
+        lines.push(formatPickerItemLine(`${highlighted ? '→ ' : '  '}${mark} ${body}`, width));
+      }
+    }
+    lines.push(padLine('', width));
+    lines.push(padLine(this.renderModelsStatusLine(), width));
+    lines.push(padLine(ansi.accent('-'.repeat(width)), width));
+    return lines;
+  }
+
+  private renderModelsStatusLine(): string {
+    switch (this.status.kind) {
+      case 'prompt':
+        return ansi.dim(`已选 ${this.selectedIds.size} · Enter 保存`);
+      case 'verifying':
+        return ansi.dim(`已选 ${this.selectedIds.size}`);
+      case 'saving':
+        return `${ansi.yellow('⠋')} 正在保存…`;
+      case 'error':
+        return ansi.red(`✗ ${this.status.text}`);
+    }
+  }
+
+  private renderSuccess(width: number): string[] {
+    this.searchEditor.focused = false;
+    this.keyEditor.focused = false;
+    this.modelsSearchEditor.focused = false;
+    const label = this.picked?.label ?? '';
+    return [
+      padLine(`Set Up Provider ${ansi.dim('· 完成')} ${ansi.accent(label)}`, width),
+      padLine(ansi.green(`✓ 已启用 ${this.successCount} 个模型`), width),
+      padLine('', width),
+      padLine(ansi.dim('Enter 关闭'), width),
+      padLine(ansi.accent('-'.repeat(width)), width),
+    ];
   }
 
   private renderFieldRow(editor: Editor, label: string, width: number): string[] {

--- a/packages/cli/src/pi-tui-pickers.ts
+++ b/packages/cli/src/pi-tui-pickers.ts
@@ -1051,11 +1051,10 @@ export class OnboardingWizard implements Component {
       this.input.onSubmitModels([...this.selectedIds]);
       return;
     }
-    // Everything else printable (non-Space) filters the model list in place.
-    const printable = decodeKittyPrintable(data) ?? (data.charCodeAt(0) >= 32 ? data : undefined);
-    if (printable !== undefined && printable !== ' ') {
-      this.modelsSearchEditor.handleInput(data);
-    }
+    // Everything else (arrows, backspace, paste, printable text) goes to the
+    // search editor — it owns editing semantics; the wizard only intercepts the
+    // keys the list owns (Esc/Ctrl+C/up/down/Space/Enter). Mirrors handleSearchInput.
+    this.modelsSearchEditor.handleInput(data);
   }
 
   private handleSuccessInput(data: string): void {

--- a/packages/cli/src/pi-tui-runner.ts
+++ b/packages/cli/src/pi-tui-runner.ts
@@ -152,8 +152,9 @@ export interface MakaPiTuiInput {
   skills?: MakaCliSkillSurface;
   /** Mandatory turn ownership shared with CLI Automation and Goal continuation. */
   goalLifecycle: MakaPiTuiGoalLifecycle;
-  /** API-key onboarding surface (#1098). When present, /setup runs the wizard
-   *  and calls setup() with the chosen provider + key; the host owns the stores. */
+  /** API-key onboarding surface (#1098). When present, /setup runs the wizard,
+   *  whose listProviders/verify/save calls persist the connection + curated models
+   *  via the host-owned stores. */
   onboarding?: MakaOnboardingSurface;
   /** First-run mode: auto-open the onboarding wizard on launch instead of
    *  waiting for /setup (used when the CLI starts with no configured connection). */
@@ -1441,16 +1442,19 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
       .save({ providerType, apiKey: wizardApiKey, enabledModelIds, models: wizardModels })
       .then(
         (result) => {
-          if (closed || wizard !== targetWizard || attempt !== wizardAttempt) return;
           if (result.kind === 'error') {
+            if (closed || wizard !== targetWizard || attempt !== wizardAttempt) return;
             wizard.setModelError(result.text);
             requestRender();
             return;
           }
           // Authoritatively refresh the running TUI's ready model choices so the
-          // newly configured models are immediately available from /model. The
-          // active session is not switched.
+          // newly configured models are immediately available from /model — even
+          // if the user abandoned the wizard mid-save. Abandonment only drops the
+          // in-frame success UI, not the background state sync. The active
+          // session is not switched.
           modelChoices = result.modelChoices;
+          if (closed || wizard !== targetWizard || attempt !== wizardAttempt) return;
           if (input.firstRun) {
             beginClose();
             return;
@@ -1473,8 +1477,14 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
     if (input.onboarding) {
       try {
         providers = await input.onboarding.listProviders();
-      } catch {
-        providers = [];
+      } catch (error) {
+        state.entries.push({
+          kind: 'notice',
+          level: 'info',
+          text: `无法读取已配置的连接：${error instanceof Error ? error.message : String(error)}`,
+        });
+        requestRender();
+        return;
       }
     } else {
       // No surface (a minimal test host): open with the bare catalog so the

--- a/packages/cli/src/pi-tui-runner.ts
+++ b/packages/cli/src/pi-tui-runner.ts
@@ -19,7 +19,7 @@ import {
   thinkingVariantsForModel,
   type ThinkingLevel,
 } from '@maka/core/model-thinking';
-import { PROVIDER_DEFAULTS, type ProviderType } from '@maka/core/llm-connections';
+import { type ModelInfo, type ProviderType } from '@maka/core/llm-connections';
 import {
   ShellRunUpdateBuffer,
   mergeShellRunUpdate,
@@ -35,7 +35,11 @@ import {
 import type { ForeignSessionStore } from '@maka/storage';
 import type { GoalTurnOutcome, SessionActivityLease } from '@maka/runtime';
 import type { ModelChoice } from './connection-target.js';
-import { listApiKeyOnboardableProviders, type MakaOnboardingSurface } from './onboarding.js';
+import {
+  listApiKeyOnboardableProviders,
+  type MakaOnboardingSurface,
+  type OnboardingProviderEntry,
+} from './onboarding.js';
 import type { MakaCliSkillSurface, SessionRecapGenerator } from './runtime-bootstrap.js';
 import { AUTO_RECAP_DISPLAY_LIMIT_BYTES, shouldAutoRecap } from './session-recap.js';
 import {
@@ -733,7 +737,7 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
     // connection-less driver. Slash commands above already routed to the
     // command layer (/exit still exits, /help still shows help).
     if (input.firstRun) {
-      showSetupWizard();
+      void showSetupWizard();
       return;
     }
     // Refreshed only for a prompt that actually opens a turn: a slash command
@@ -914,14 +918,24 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
   };
 
   // Onboarding wizard (#1098 UX redesign): one overlay spans provider search
-  // → API key entry, keeping every prompt/verifying/failure notice beside the
-  // input field instead of the transcript entry flow.
+  // → API key → model curation, keeping every prompt/verifying/failure/saving/
+  // success notice beside the input field instead of the transcript entry flow.
   let wizardOverlay: OverlayHandle | undefined;
   let wizard: OnboardingWizard | undefined;
   let wizardProviderType: ProviderType | undefined;
+  // The user's supplied key from the key step ('' reuses the stored secret for an
+  // existing connection) and the models from the last verify (cached on save).
+  // The runner holds them so the wizard stays UI-only; the secret never crosses
+  // back into the wizard.
+  let wizardApiKey = '';
+  let wizardModels: readonly ModelInfo[] = [];
+  // Authoritative ready model choices for `/model`. A startup snapshot refreshed
+  // in place after `/setup` saves so newly configured models are immediately
+  // available — the single source the picker and connection/model lookups read.
+  let modelChoices = input.modelChoices;
   // Monotonic attempt id: each setup submit captures one, and any transition
   // that abandons the in-flight attempt (back, re-pick, close) increments it so
-  // a late probe settlement cannot clobber a newer attempt.
+  // a late verify/save settlement cannot clobber a newer attempt.
   let wizardAttempt = 0;
 
   editor.onSubmit = (prompt) => {
@@ -1104,7 +1118,7 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
   const setModel = async (nextModel: string) => {
     await input.driver.setModel(nextModel);
     model = nextModel;
-    const match = input.modelChoices?.find((choice) => choice.model === nextModel);
+    const match = modelChoices?.find((choice) => choice.model === nextModel);
     if (match) modelContextWindow = match.contextWindow;
     thinkingLevel = undefined;
     thinkingLevels = providerType ? thinkingVariantsForModel(providerType, nextModel) : [];
@@ -1158,7 +1172,7 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
     model = summary.model;
     const previousConnectionSlug = connectionSlug;
     connectionSlug = summary.llmConnectionSlug;
-    const matchingChoice = input.modelChoices?.find(
+    const matchingChoice = modelChoices?.find(
       (choice) => choice.connectionSlug === summary.llmConnectionSlug,
     );
     providerType =
@@ -1173,7 +1187,7 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
     // clear the window rather than keep showing the previous session's ctx
     // total under a different model. No match but the target didn't change
     // (e.g. rewind within the same session) leaves the window untouched.
-    const contextWindowMatch = input.modelChoices?.find(
+    const contextWindowMatch = modelChoices?.find(
       (choice) =>
         choice.connectionSlug === summary.llmConnectionSlug && choice.model === summary.model,
     );
@@ -1355,11 +1369,13 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
   };
 
   const closeWizard = (): void => {
-    wizardAttempt += 1; // drop any in-flight setup before clearing the slots
+    wizardAttempt += 1; // drop any in-flight verify/save before clearing the slots
     wizardOverlay?.hide();
     wizardOverlay = undefined;
     wizard = undefined;
     wizardProviderType = undefined;
+    wizardApiKey = '';
+    wizardModels = [];
   };
 
   // Key submit from the wizard. Slash commands route as commands (so /exit
@@ -1374,55 +1390,101 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
       return;
     }
     if (!input.onboarding) {
-      wizard.setResult({ kind: 'error', text: 'Onboarding 不可用：当前运行环境未提供配置入口。' });
+      wizard.setKeyError('Onboarding 不可用：当前运行环境未提供配置入口。');
       requestRender();
       return;
     }
+    wizardApiKey = apiKey;
     const targetWizard = wizard;
     const attempt = ++wizardAttempt;
     targetWizard.setVerifying();
     requestRender();
-    void input.onboarding.setup({ providerType, apiKey }).then(
+    void input.onboarding.verify({ providerType, apiKey }).then(
       (result) => {
         if (closed || wizard !== targetWizard || attempt !== wizardAttempt) return;
-        if (result.testError) {
-          // Probe failed: re-arm the key field in place — the upsert rotates
-          // the key, so retrying does not throw "slug already exists".
-          wizard.setResult({
-            kind: 'error',
-            text: `API key 验证失败：${result.testError}。请检查后重新输入。`,
-          });
+        if (result.kind === 'error') {
+          // Probe failed: re-arm the key field in place. The host stores nothing
+          // during verify, so retrying with a corrected key is clean.
+          wizard.setKeyError(`API key 验证失败：${result.text}。请检查后重新输入。`);
           requestRender();
           return;
         }
-        const label = PROVIDER_DEFAULTS[providerType]?.label ?? providerType;
-        if (input.firstRun) {
-          beginClose();
-          return;
-        }
-        // The wizard's in-flight notices never reached the transcript; only the
-        // completed configuration is recorded as an event for the next launch.
-        closeWizard();
-        state.entries.push({
-          kind: 'notice',
-          level: 'info',
-          text: `已配置 ${label}。新连接将在下次启动 maka 时生效。`,
-        });
+        wizardModels = result.models;
+        wizard.setModels(result.models); // advance to the models step
         requestRender();
       },
       (error) => {
         if (closed || wizard !== targetWizard || attempt !== wizardAttempt) return;
-        wizard.setResult({
-          kind: 'error',
-          text: `配置失败：${error instanceof Error ? error.message : String(error)}`,
-        });
+        wizard.setKeyError(`配置失败：${error instanceof Error ? error.message : String(error)}`);
         requestRender();
       },
     );
   };
 
-  const showSetupWizard = (): void => {
-    const providers = listApiKeyOnboardableProviders();
+  // Models submit from the wizard: persist the curated enabled set, refresh the
+  // running TUI's authoritative ready model choices, and show an in-frame
+  // success (first-run closes the TUI so the host re-resolves the new default).
+  // Setup never appends a transcript Note and never switches the active session.
+  const submitWizardModels = (enabledModelIds: readonly string[]): void => {
+    const providerType = wizardProviderType;
+    if (!providerType || !wizard) return;
+    if (!input.onboarding) {
+      wizard.setModelError('Onboarding 不可用：当前运行环境未提供配置入口。');
+      requestRender();
+      return;
+    }
+    const targetWizard = wizard;
+    const attempt = ++wizardAttempt;
+    targetWizard.setSaving();
+    requestRender();
+    void input.onboarding
+      .save({ providerType, apiKey: wizardApiKey, enabledModelIds, models: wizardModels })
+      .then(
+        (result) => {
+          if (closed || wizard !== targetWizard || attempt !== wizardAttempt) return;
+          if (result.kind === 'error') {
+            wizard.setModelError(result.text);
+            requestRender();
+            return;
+          }
+          // Authoritatively refresh the running TUI's ready model choices so the
+          // newly configured models are immediately available from /model. The
+          // active session is not switched.
+          modelChoices = result.modelChoices;
+          if (input.firstRun) {
+            beginClose();
+            return;
+          }
+          wizard.setSuccess(enabledModelIds.length);
+          requestRender();
+        },
+        (error) => {
+          if (closed || wizard !== targetWizard || attempt !== wizardAttempt) return;
+          wizard.setModelError(
+            `保存失败：${error instanceof Error ? error.message : String(error)}`,
+          );
+          requestRender();
+        },
+      );
+  };
+
+  const showSetupWizard = async (): Promise<void> => {
+    let providers: OnboardingProviderEntry[];
+    if (input.onboarding) {
+      try {
+        providers = await input.onboarding.listProviders();
+      } catch {
+        providers = [];
+      }
+    } else {
+      // No surface (a minimal test host): open with the bare catalog so the
+      // wizard can report unavailability in-frame at submit instead of throwing.
+      providers = listApiKeyOnboardableProviders().map((provider) => ({
+        ...provider,
+        hasConnection: false,
+        enabledModelIds: [],
+      }));
+    }
     if (providers.length === 0) {
       state.entries.push({
         kind: 'notice',
@@ -1437,10 +1499,13 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
       providers,
       onPickProvider: (providerType) => {
         wizardProviderType = providerType;
+        wizardApiKey = '';
+        wizardModels = [];
         wizardAttempt += 1; // a new pick supersedes any in-flight attempt
         requestRender();
       },
       onSubmitKey: submitWizardKey,
+      onSubmitModels: submitWizardModels,
       onCancel: () => {
         closeWizard();
         // First-run has no connection to fall back to: cancelling the wizard
@@ -1448,9 +1513,11 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
         if (input.firstRun) beginClose();
       },
       onBack: () => {
-        wizardProviderType = undefined;
-        wizardAttempt += 1; // abandoning the key field invalidates its probe
+        wizardAttempt += 1; // back one level invalidates any in-flight verify/save
         requestRender();
+      },
+      onClose: () => {
+        closeWizard();
       },
     });
     wizardOverlay = showBottomPicker(wizard);
@@ -1822,7 +1889,7 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
   };
 
   const showModelList = () => {
-    const choices = input.modelChoices;
+    const choices = modelChoices;
     // Cross-connection picker when the caller supplied choices across all ready
     // connections; otherwise the single-connection list (typed /model, tests).
     if (choices && choices.length > 0) {
@@ -2051,7 +2118,7 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
           requestRender();
           return;
         }
-        showSetupWizard();
+        void showSetupWizard();
       },
     },
     {
@@ -2432,7 +2499,7 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
     // to the enable sequence (a focus-in `\x1b[I`) is echoed by the cooked-mode
     // line discipline and leaks onto the screen as a stray `^[[I` on launch.
     terminal.write(ENABLE_FOCUS_REPORTING);
-    if (input.firstRun) showSetupWizard();
+    if (input.firstRun) void showSetupWizard();
   } catch (error) {
     beginClose(error instanceof Error ? error : new Error(String(error)));
   }


### PR DESCRIPTION
## Summary

#1098 seam 3 — `/setup` now completes model curation in three steps instead of stopping at the API key.

- **Provider search → API-key verification → searchable model multi-select → in-frame success.** Existing connections are marked `已设置` and pre-select their enabled set; new connections start with none. The key field may be blank to reuse the stored secret or filled to rotate it. `Space` toggles models (at least one before `Enter` saves), and search never discards selections.
- `Esc` always backs up one level (models → key → provider → close). Late verify/save results are dropped after back/close/retry via an attempt id, so they cannot overwrite a screen the user has already left.
- The host surface splits into `listProviders` / `verify` / `save`: `verify` probes with a supplied or stored secret **without persisting**; `save` persists the curated `enabledModelIds` + discovered-model cache, normalizes the compatibility-only `defaultModel`, and calls `setDefault` **only when no default exists** (first run). In-session setup never replaces an existing default and never switches the active session.
- Saving refreshes the running TUI's authoritative ready model choices in place, so the new models are immediately available from `/model`.
- Loading, errors, empty, saving, and success stay in the bottom frame; setup no longer appends a transcript `Note`.

Refs #1098 (seam 3).

## Verification

- `npm run build` (packages/cli) — clean.
- `node --test dist/**/*.test.js` (packages/cli) — **619 pass / 0 fail**. Rewritten onboarding-wizard tests cover new/existing connections, blank-key reuse, key rotation, multi-query selection retention, minimum-one, back navigation, stale verify/save settlements, first-run re-entry, in-session live refresh, and absence of transcript setup notes.
- `npm run format:check` — clean. `npm run lint` — clean.
- `npx tsc -p tsconfig.json --noEmit` (packages/cli) — clean.
- Workspace `typecheck`: cli/core/storage/runtime/headless/ui pass. `apps/desktop` renderer fails only on `Cannot find module 'simple-icons'`, a pre-existing local-install gap (clean-`main` root checkout fails identically); unrelated to this PR and green under CI's full install.
- Not run: desktop E2E (CLI-only change); no visual recording (the TUI is text-based and tests assert the rendered text states directly).

## Review focus

Flat against `main`, parallel to #1239 (seam 2). They share three files but don't depend on each other: #1239 didn't touch `OnboardingWizard`, and this PR didn't touch the `/model` cross-connection picker that #1239 upgrades to `ModelSearchOverlay`. If #1239 merges first, rebasing this branch is one mechanical resolution — `modelChoicePickerItems` goes private (follow #1239) and its now-unused import in `pi-tui-runner.ts` is removed.