### PR TITLE
chore(main): extract tool-assembly + artifact-persistence from main.ts (arch R4)

### DIFF
--- a/apps/desktop/src/main/__tests__/agent-swarm-host-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/agent-swarm-host-contract.test.ts
@@ -2,13 +2,17 @@ import assert from 'node:assert/strict';
 import { readFile } from 'node:fs/promises';
 import { resolve } from 'node:path';
 import { describe, test } from 'node:test';
+import { readMainProcessCombinedSource } from './main-process-contract-source-helpers.js';
 
 const REPO_ROOT = resolve(import.meta.dirname, '../../../../../');
 
+// `desktop` reads the combined main-process source: the parent Agent tool
+// builder and the deferred-group projection now live in tool-assembly.ts
+// (arch R4), still part of the same main-process surface this contract locks.
 describe('AgentSwarm host registration contract', () => {
   test('desktop, CLI, and headless use the same parent Agent tool builder', async () => {
     const [desktop, cli, headless] = await Promise.all([
-      readFile(resolve(REPO_ROOT, 'apps/desktop/src/main/main.ts'), 'utf8'),
+      readMainProcessCombinedSource(),
       readFile(resolve(REPO_ROOT, 'packages/cli/src/runtime-bootstrap.ts'), 'utf8'),
       readFile(resolve(REPO_ROOT, 'packages/headless/src/tools.ts'), 'utf8'),
     ]);
@@ -31,7 +35,7 @@ describe('AgentSwarm host registration contract', () => {
 
   test('all hosts derive deferred groups from the shared catalog', async () => {
     const [desktop, cli, headless, catalog] = await Promise.all([
-      readFile(resolve(REPO_ROOT, 'apps/desktop/src/main/main.ts'), 'utf8'),
+      readMainProcessCombinedSource(),
       readFile(resolve(REPO_ROOT, 'packages/cli/src/runtime-bootstrap.ts'), 'utf8'),
       readFile(resolve(REPO_ROOT, 'packages/headless/src/tools.ts'), 'utf8'),
       readFile(resolve(REPO_ROOT, 'packages/core/src/tool-catalog.ts'), 'utf8'),

--- a/apps/desktop/src/main/__tests__/agent-team-collaboration-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/agent-team-collaboration-contract.test.ts
@@ -1,12 +1,14 @@
 import { strict as assert } from 'node:assert';
-import { readFile } from 'node:fs/promises';
-import { fileURLToPath } from 'node:url';
 import { describe, it } from 'node:test';
+import { readMainProcessCombinedSource } from './main-process-contract-source-helpers.js';
 
+// The lead/child team tool builders and the childAgentTools surface moved into
+// tool-assembly.ts (arch R4); the expert-dispatch + agentTeam backend wiring
+// stays in main.ts. Reading the combined main-process source keeps every
+// assertion intact across both files.
 describe('desktop agent-team collaboration wiring', () => {
   it('shares one durable mailbox/task ledger across lead and child tools', async () => {
-    const mainPath = fileURLToPath(new URL('../../../src/main/main.ts', import.meta.url));
-    const main = await readFile(mainPath, 'utf8');
+    const main = await readMainProcessCombinedSource();
 
     assert.match(main, /const agentMailboxStore = createAgentMailboxStore\(workspaceRoot\)/);
     assert.match(

--- a/apps/desktop/src/main/__tests__/attachment-frontend-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/attachment-frontend-contract.test.ts
@@ -6,6 +6,7 @@ import { createElement, type ReactNode } from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
 import type { AttachmentRef, SessionSummary, StoredMessage } from '@maka/core';
 import { ChatView, LocaleProvider } from '@maka/ui';
+import { readMainProcessCombinedSource } from './main-process-contract-source-helpers.js';
 
 const REPO_ROOT = process.cwd().endsWith('apps/desktop')
   ? resolve(process.cwd(), '..', '..')
@@ -106,7 +107,10 @@ describe('attachment frontend contract', () => {
   });
 
   it('snapshots Read images and notifies the existing artifact preview flow', async () => {
-    const main = await readRepo('apps/desktop/src/main/main.ts');
+    // Read image snapshotting moved into tool-artifact-persistence.ts and the
+    // builtin-tool wiring into tool-assembly.ts (arch R4); `storeReadImage`
+    // stays in main.ts. The combined main-process source spans all three.
+    const main = await readMainProcessCombinedSource();
     const artifactAttachments = await readRepo('packages/storage/src/artifact-attachments.ts');
 
     assert.match(main, /snapshotImage: snapshotReadImage/);

--- a/apps/desktop/src/main/__tests__/main-process-contract-source-helpers.ts
+++ b/apps/desktop/src/main/__tests__/main-process-contract-source-helpers.ts
@@ -35,6 +35,8 @@ export const MAIN_PROCESS_SOURCE_REPO_PATHS: readonly string[] = [
   'apps/desktop/src/main/subscription-model-fetch.ts',
   'apps/desktop/src/main/subscription-ipc-main.ts',
   'apps/desktop/src/main/system-prompt-main.ts',
+  'apps/desktop/src/main/tool-assembly.ts',
+  'apps/desktop/src/main/tool-artifact-persistence.ts',
   'apps/desktop/src/main/usage-ipc-main.ts',
   'apps/desktop/src/main/web-search-ipc-main.ts',
   'apps/desktop/src/main/workspace-instructions-ipc-main.ts',

--- a/apps/desktop/src/main/__tests__/permission-response-ipc-boundary.test.ts
+++ b/apps/desktop/src/main/__tests__/permission-response-ipc-boundary.test.ts
@@ -31,16 +31,18 @@ describe('permission response IPC boundary', () => {
   });
 
   it('registers AskUserQuestion only on the Desktop root tool surface and routes its response', async () => {
-    const mainPath = fileURLToPath(new URL('../../../src/main/main.ts', import.meta.url));
     const main = await readMainProcessCombinedSource();
     // Root surface is assembled as toolsBeforeSkill + Skill + toolsAfterSkill → builtinTools.
+    // The tool surface moved into tool-assembly.ts (arch R4), so the block
+    // closers are now indented inside assembleDesktopTools — tolerate leading
+    // whitespace on the closing bracket.
     const rootBeforeSkill =
-      main.match(/const toolsBeforeSkill: MakaTool\[\] = \[[\s\S]*?\n\];/)?.[0] ?? '';
+      main.match(/const toolsBeforeSkill: MakaTool\[\] = \[[\s\S]*?\n\s*\];/)?.[0] ?? '';
     const rootBuiltin =
       main.match(
         /const builtinTools: MakaTool\[\] = \[\.\.\.toolsBeforeSkill, skillTool, \.\.\.toolsAfterSkill\];/,
       )?.[0] ?? '';
-    const childTools = main.match(/const childAgentTools = buildChildAgentTools\([\s\S]*?\n\]\);/)?.[0] ?? '';
+    const childTools = main.match(/const childAgentTools = buildChildAgentTools\([\s\S]*?\n\s*\]\);/)?.[0] ?? '';
     const handler = main.match(/ipcMain\.handle\('sessions:respondToUserQuestion'[\s\S]*?\n  \}\);/)?.[0] ?? '';
 
     assert.match(rootBeforeSkill, /buildAskUserQuestionTool\(\)/);

--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -1,7 +1,7 @@
-import { app, ipcMain, nativeImage, powerMonitor, powerSaveBlocker, safeStorage, shell } from 'electron';
+import { app, ipcMain, nativeImage, powerSaveBlocker, safeStorage, shell } from 'electron';
 import { randomUUID } from 'node:crypto';
-import { mkdir, readFile, realpath } from 'node:fs/promises';
-import { isAbsolute, join, relative, resolve, sep } from 'node:path';
+import { mkdir } from 'node:fs/promises';
+import { join } from 'node:path';
 import { startConfigFileWatcher, type ConfigFileWatcher } from './config-file-watcher.js';
 import {
   DEFAULT_SESSION_NAME,
@@ -23,13 +23,10 @@ import type {
   UpdateAppSettingsInput,
 } from '@maka/core';
 import { deriveBotStatusPersistenceUpdate } from './bot-status-persistence.js';
-import { buildWebSearchAgentTool, WEB_SEARCH_TOOL_NAME } from './web-search/agent-tool.js';
-import { buildRiveWorkflowTool } from './rive-workflow-tool.js';
+import { WEB_SEARCH_TOOL_NAME } from './web-search/agent-tool.js';
 import { runThreadSearch } from './search/thread-search.js';
-import {
-  persistArchivedToolResultToArtifacts,
-  readArchivedToolResultFromArtifacts,
-} from './tool-result-archive-artifacts.js';
+import { assembleDesktopTools } from './tool-assembly.js';
+import { createToolArtifactPersistence } from './tool-artifact-persistence.js';
 import { ClaudeSubscriptionService } from './oauth/claude-subscription-service.js';
 import { OpenAiCodexService } from './oauth/openai-codex-service.js';
 import { GitHubCopilotSubscriptionService } from './oauth/github-copilot-subscription-service.js';
@@ -45,21 +42,8 @@ import {
   FakeBackend,
   PermissionEngine,
   SessionManager,
-  buildBuiltinTools,
   buildMcpTools,
-  buildAskUserQuestionTool,
-  createBuiltinSandboxManager,
-  createFilesystemWorkerLaunchSpecProvider,
-  FilesystemWorkerClient,
-  buildChildAgentTools,
-  buildAgentTeamChildTools,
-  buildAgentTeamLeadTools,
   buildExpertDispatchToolForTeamId,
-  buildParentAgentTools,
-  assertProductBindingCatalogClean,
-  buildDeferredToolGroupsFromCatalog,
-  buildHostCapabilitiesFromBinding,
-  SKILL_TOOL_NAME,
   createLocalContinuationSafetyInspector,
   getAIModel,
   generateSessionTitle as generateRuntimeSessionTitle,
@@ -78,9 +62,7 @@ import type {
   GoalTurnOutcome,
   HostCapabilities,
   HostCapabilitiesResolver,
-  MakaTool,
   SessionActivityLease,
-  ToolAvailabilityConfig,
   ToolArtifactRecorderInput,
   ToolResultArchiveReaderInput,
   ToolResultArchiveReadResult,
@@ -114,12 +96,8 @@ import {
 import { createFileCredentialStore, migrateLegacyCredentials } from './credential-store.js';
 import { bindOnboardingDeps, createOnboardingService } from './onboarding-service.js';
 import { handleQuickChatStart as runQuickChatStart, type QuickChatResult } from './quick-chat.js';
-import { resolveSkillDiscoveryPaths } from '@maka/runtime';
 import { createDailyReviewArchiveStore } from './daily-review-archive-store.js';
 import { preserveSensitivePlaceholders } from './settings-ipc-helpers.js';
-import {
-  buildSkillAgentTool,
-} from './skills.js';
 import { resolveDefaultPermissionMode } from './permission-mode-default.js';
 import {
   resolveVisualSmokeFixture,
@@ -129,8 +107,6 @@ import { resolveBuildInfo } from './build-info.js';
 import { OpenGatewayService } from './open-gateway.js';
 import { LocalMemoryService } from './local-memory-service.js';
 import { createAttachmentApprovalRegistry } from './attachment-approval.js';
-import { buildExploreAgentTool } from './explore-agent-tool.js';
-import { buildOfficeDocumentEditTool, buildOfficeDocumentTool } from './office-document-tool.js';
 import {
   buildLlmHistorySummarizer,
   cleanupLegacyHistoryCompactArtifacts,
@@ -138,21 +114,11 @@ import {
   loadSynthesisCacheBlocksFromArtifacts,
   persistSynthesisCacheBlocksToArtifacts,
 } from '@maka/runtime';
-import { buildBrowserTools } from './browser/browser-tools.js';
-import {
-  computerUseServiceHealth,
-  createComputerUseHost,
-} from './computer-use-host.js';
-import { createCursorOverlayController } from './computer-use/cursor-overlay-window.js';
-import {
-  applyComputerUseRealModelPolicy,
-  parseComputerUseRealModelPolicy,
-} from './computer-use-real-model-policy.js';
+import { computerUseServiceHealth } from './computer-use-host.js';
 import {
   computerUseAvailabilityForModel,
   computerUseToolsForModel,
 } from './computer-use-model-tools.js';
-import { createComputerUseOverlayHook } from '@maka/computer-use';
 import { createMainWindowController } from './main-window.js';
 import { createDailyReviewMainService } from './daily-review-main.js';
 import { createPlanReminderMainService } from './plan-reminders-main.js';
@@ -637,161 +603,41 @@ const shellRuns = new ShellRunProcessManager({
     safeSendToRenderer('shell-runs:update', update);
   },
 });
-const sandboxManager = createBuiltinSandboxManager();
-const filesystemWorker = process.platform === 'darwin' && sandboxManager
-  ? new FilesystemWorkerClient({
-      sandboxManager,
-      getLaunchSpec: createFilesystemWorkerLaunchSpecProvider({
-        runtime: 'electron',
-        executable: process.execPath,
-        resourceLocation: app.isPackaged
-          ? { kind: 'desktop-packaged', resourcesPath: process.resourcesPath }
-          : { kind: 'runtime' },
-      }),
-    })
-  : undefined;
-// Unified tool availability (issue #37). Deferred capability groups (Rive,
-// Office, browser, agent orchestration) are withheld from the
-// per-turn prompt and loaded on demand via `load_tools`, keeping their schemas
-// off the wire until needed. Everything else (ungrouped) stays always-on.
-// Kill-switch: set MAKA_DISABLE_DEFERRED_TOOLS to any value to turn economy off
-// and advertise every tool every turn (legacy behavior).
-const economyEnabled = !process.env.MAKA_DISABLE_DEFERRED_TOOLS;
-const riveTools: MakaTool[] = [buildRiveWorkflowTool()];
-const officeTools: MakaTool[] = [buildOfficeDocumentTool(), buildOfficeDocumentEditTool()];
-// Embedded-browser observe→act tools. They drive the conversation's own
-// WebContentsView via the BrowserViewHost the desktop provides in registerIpc;
-// outside the app (no host) they report the browser as unavailable.
-const browserTools: MakaTool[] = buildBrowserTools();
-const computerUseOverlay = createCursorOverlayController();
-onMainWindowClose = () => computerUseOverlay.destroyAll();
-const computerUseHost = createComputerUseHost({
-  isPackaged: app.isPackaged,
-  resourcesPath: process.resourcesPath,
-  compressFrame: (base64) => {
-    try {
-      const image = nativeImage.createFromBuffer(Buffer.from(base64, 'base64'));
-      return image.isEmpty()
-        ? { base64, mimeType: 'image/png' }
-        : {
-            base64: image.toJPEG(82).toString('base64'),
-            mimeType: 'image/jpeg',
-          };
-    } catch {
-      return { base64, mimeType: 'image/png' };
-    }
-  },
-  physicalInputRecentlyActive: () => powerMonitor.getSystemIdleTime() < 1,
-  ...(isComputerUseRealModelE2e
-    ? {
-        onTrace: (event) => {
-          const tracePath = process.env.MAKA_CU_REAL_MODEL_TRACE;
-          if (!tracePath) return;
-          void import('node:fs/promises').then(({ appendFile }) =>
-            appendFile(tracePath, `${JSON.stringify(event)}\n`, {
-              encoding: 'utf8',
-              mode: 0o600,
-            }),
-          ).catch(() => {});
-        },
-      }
-    : {}),
-  overlay: createComputerUseOverlayHook(computerUseOverlay),
-});
-const computerUse = computerUseHost.selected;
-const computerUseTools = applyComputerUseRealModelPolicy(
-  computerUse.tools,
-  isComputerUseRealModelE2e
-    ? parseComputerUseRealModelPolicy(
-        process.env.MAKA_CU_REAL_MODEL_POLICY,
-      )
-    : undefined,
-);
-const agentTools: MakaTool[] = buildParentAgentTools({
-  taskLedger: taskLedgerStore,
-});
-const agentTeamLeadTools = buildAgentTeamLeadTools({
-  mailbox: agentMailboxStore,
-  taskLedger: taskLedgerStore,
-});
-const agentTeamChildTools = buildAgentTeamChildTools({
-  mailbox: agentMailboxStore,
-  taskLedger: taskLedgerStore,
-});
-const deferredTools: MakaTool[] = [
-  ...riveTools,
-  ...officeTools,
-  ...browserTools,
-  ...computerUseTools,
-  ...agentTools,
-];
-const webSearchTool = buildWebSearchAgentTool({
+const {
+  persistToolArtifacts,
+  snapshotReadImage,
+  persistArchivedToolResult,
+  readArchivedToolResult,
+} = createToolArtifactPersistence({ artifactStore, storeReadImage, safeSendToRenderer });
+
+const {
+  riveTools,
+  officeTools,
+  browserTools,
+  computerUse,
+  computerUseOverlay,
+  computerUseTools,
+  agentTeamLeadTools,
+  desktopHostCapabilities,
+  builtinTools,
+  toolAvailability,
+  childAgentTools,
+} = assembleDesktopTools({
+  isComputerUseRealModelE2e,
+  workspaceRoot,
+  taskLedgerStore,
+  taskLedgerWiring,
+  automationWiring,
+  goalWiring,
+  agentMailboxStore,
   settingsStore,
-  getPrivacyContext: getWorkspacePrivacyContext,
-});
-// Assemble product tools first, then derive skill host + deferred groups from
-// the shared catalog ∩ this binding (#1099 S2). Skill listing uses the same host.
-const toolsBeforeSkill: MakaTool[] = [
-  buildAskUserQuestionTool(),
-  ...buildBuiltinTools({
-    shellRuns,
-    runtimeResources: shellRuns,
-    backgroundTasks: shellRuns,
-    ptyControls: shellRuns,
-    snapshotImage: snapshotReadImage,
-    ...(sandboxManager ? { sandboxManager } : {}),
-    ...(filesystemWorker ? {
-      filesystemWorker,
-      enableBashAdditionalPermissions: true,
-      enableFileToolAdditionalPermissions: true,
-    } : {}),
-  }).filter((tool: MakaTool) => tool.name !== 'Edit'),
-];
-const toolsAfterSkill: MakaTool[] = [
-  // External reference plan-mode borrow: a bounded read-only local worker for
-  // self-contained code/repo investigations. The tool advertises the
-  // `subagent` category; explore mode allows it, but the implementation
-  // itself only reads filenames/text snippets under the session cwd.
-  buildExploreAgentTool(),
-  // PR-AGENT-WEB-SEARCH-TOOL-0: Tavily-backed WebSearch tool. Closed
-  // over settingsStore so the renderer never sees the API key; the
-  // permission engine routes it through the `web_read` policy which
-  // prompts the user in explore / ask modes.
-  webSearchTool,
-  // Session task ledger: model manages a flat task list; the current list is
-  // re-injected each turn tail. Pure local state, so no permission gate.
-  ...taskLedgerWiring.tools,
-  // Unified Automation: heartbeat (session-internal polling) + cron (standalone scheduled runs).
-  ...automationWiring.tools,
-  // Goal execution: GoalSet/Clear/Status/Pause/Resume — autonomous turn-boundary continuation.
-  ...goalWiring.tools,
-  // The `load_tools` connector is built by ToolAvailabilityRuntime; deferred
-  // group tools just need to be present so they are dispatchable once loaded.
-  ...deferredTools,
-];
-// Always-on Skill name is part of the host surface even before the tool instance
-// is built (so requiredTools gates and capability tags stay complete).
-const desktopBoundToolNames = [
-  ...toolsBeforeSkill.map((tool) => tool.name),
-  SKILL_TOOL_NAME,
-  ...toolsAfterSkill.map((tool) => tool.name),
-];
-assertProductBindingCatalogClean('desktop', desktopBoundToolNames);
-const desktopHostCapabilities = buildHostCapabilitiesFromBinding(desktopBoundToolNames);
-// External reference lazy-skill pattern: the prompt lists available skills,
-// and this read-only tool loads the full SKILL.md only when the task matches.
-// Resolve per-call from the session cwd so skills at all 5 standard paths
-// (cwd/.maka, cwd/.agents, workspaceRoot/skills, ~/.maka, ~/.agents) are
-// discovered — matching the CLI and the Agent Skills spec (#1068).
-const skillTool = buildSkillAgentTool(
-  ({ cwd }) => resolveSkillDiscoveryPaths(cwd, workspaceRoot),
+  shellRuns,
+  snapshotReadImage,
+  getWorkspacePrivacyContext,
   resolveDesktopSkillHost,
-);
-const builtinTools: MakaTool[] = [...toolsBeforeSkill, skillTool, ...toolsAfterSkill];
-const toolAvailability: ToolAvailabilityConfig = {
-  economy: economyEnabled,
-  groups: buildDeferredToolGroupsFromCatalog('desktop', desktopBoundToolNames),
-};
+});
+// Cursor-overlay teardown assigns a module-scoped `let`, so it stays in main.ts.
+onMainWindowClose = () => computerUseOverlay.destroyAll();
 const systemPromptService = createSystemPromptMainService({
   settingsStore,
   workspaceRoot,
@@ -800,21 +646,6 @@ const systemPromptService = createSystemPromptMainService({
   goalManager: goalWiring.manager,
   hostCapabilities: desktopHostCapabilities,
 });
-// Child agents stay file-only for local reads; parent runtime refs such as
-// maka://runtime/background-tasks/<id> are not part of their tool surface.
-const childAgentTools = buildChildAgentTools([
-  ...buildBuiltinTools({
-    snapshotImage: snapshotReadImage,
-    ...(sandboxManager ? { sandboxManager } : {}),
-    ...(filesystemWorker ? {
-      filesystemWorker,
-      enableBashAdditionalPermissions: true,
-      enableFileToolAdditionalPermissions: true,
-    } : {}),
-  }).filter((tool: MakaTool) => tool.name !== 'Edit'),
-  webSearchTool,
-  ...agentTeamChildTools,
-]);
 let lookupPricing = buildPricingLookup();
 // Track the last status fields that affect persisted diagnostics. The reason
 // is part of the key because a running bridge can remain degraded while a
@@ -891,84 +722,6 @@ const planReminders = createPlanReminderMainService({
 });
 
 app.setName('Maka');
-
-async function persistToolArtifacts(cwd: string, event: ToolArtifactRecorderInput): Promise<void> {
-  for (const candidate of event.candidates) {
-    let content = candidate.content;
-    if (content === undefined && candidate.sourcePath) {
-      const sourcePath = await resolveToolArtifactSourcePath(cwd, candidate.sourcePath);
-      if (!sourcePath) continue;
-      content = await readFile(sourcePath);
-    }
-    if (content === undefined) continue;
-    const artifact = await artifactStore.create({
-      sessionId: event.sessionId,
-      turnId: event.turnId,
-      name: candidate.name,
-      kind: candidate.kind,
-      content,
-      ...(candidate.mimeType ? { mimeType: candidate.mimeType } : {}),
-      source: candidate.source ?? 'tool_result',
-      ...(candidate.summary ? { summary: candidate.summary } : {}),
-    });
-    safeSendToRenderer('artifacts:changed', {
-      reason: 'created',
-      artifactId: artifact.id,
-      sessionId: artifact.sessionId,
-      ts: Date.now(),
-    });
-  }
-}
-
-async function snapshotReadImage(input: {
-  sessionId: string;
-  turnId: string;
-  name: string;
-  bytes: Uint8Array;
-  mimeType: string;
-}) {
-  const ref = await storeReadImage(input);
-  safeSendToRenderer('artifacts:changed', {
-    reason: 'created',
-    artifactId: ref.relativePath,
-    sessionId: ref.sessionId,
-    ts: Date.now(),
-  });
-  return ref;
-}
-
-async function persistArchivedToolResult(
-  event: ToolResultArchiveRecorderInput,
-): Promise<{ artifactId: string }> {
-  return persistArchivedToolResultToArtifacts(artifactStore, event);
-}
-
-async function readArchivedToolResult(
-  event: ToolResultArchiveReaderInput,
-): Promise<ToolResultArchiveReadResult> {
-  return readArchivedToolResultFromArtifacts(artifactStore, event);
-}
-
-async function resolveToolArtifactSourcePath(cwd: string, sourcePath: string): Promise<string | null> {
-  const candidate = isAbsolute(sourcePath) ? sourcePath : resolve(cwd, sourcePath);
-  let root: string;
-  let target: string;
-  try {
-    [root, target] = await Promise.all([
-      realpath(cwd),
-      realpath(candidate),
-    ]);
-  } catch {
-    return null;
-  }
-  return isInsideOrSamePath(root, target) ? target : null;
-}
-
-function isInsideOrSamePath(root: string, target: string): boolean {
-  if (target === root) return true;
-  const rel = relative(root, target);
-  return rel !== '' && !rel.startsWith('..') && rel !== '..' && !rel.includes(`..${sep}`) && !rel.startsWith(sep);
-}
 
 function modelSupportsVision(connection: LlmConnection, model: string): boolean {
   return resolveModelVisionSupport(connection.providerType, connection.models, model);

--- a/apps/desktop/src/main/tool-artifact-persistence.ts
+++ b/apps/desktop/src/main/tool-artifact-persistence.ts
@@ -1,0 +1,124 @@
+import { readFile, realpath } from 'node:fs/promises';
+import { isAbsolute, relative, resolve, sep } from 'node:path';
+import type {
+  ToolArtifactRecorderInput,
+  ToolResultArchiveReaderInput,
+  ToolResultArchiveReadResult,
+  ToolResultArchiveRecorderInput,
+} from '@maka/runtime';
+import type { createArtifactStore, createReadImageSnapshotter } from '@maka/storage';
+import {
+  persistArchivedToolResultToArtifacts,
+  readArchivedToolResultFromArtifacts,
+} from './tool-result-archive-artifacts.js';
+
+type ArtifactStore = ReturnType<typeof createArtifactStore>;
+type ReadImageSnapshotter = ReturnType<typeof createReadImageSnapshotter>;
+
+export interface ToolArtifactPersistenceDeps {
+  artifactStore: ArtifactStore;
+  storeReadImage: ReadImageSnapshotter;
+  safeSendToRenderer: (channel: string, ...args: unknown[]) => void;
+}
+
+export interface ToolArtifactPersistence {
+  persistToolArtifacts(cwd: string, event: ToolArtifactRecorderInput): Promise<void>;
+  snapshotReadImage(input: {
+    sessionId: string;
+    turnId: string;
+    name: string;
+    bytes: Uint8Array;
+    mimeType: string;
+  }): Promise<Awaited<ReturnType<ReadImageSnapshotter>>>;
+  persistArchivedToolResult(event: ToolResultArchiveRecorderInput): Promise<{ artifactId: string }>;
+  readArchivedToolResult(event: ToolResultArchiveReaderInput): Promise<ToolResultArchiveReadResult>;
+}
+
+function isInsideOrSamePath(root: string, target: string): boolean {
+  if (target === root) return true;
+  const rel = relative(root, target);
+  return rel !== '' && !rel.startsWith('..') && rel !== '..' && !rel.includes(`..${sep}`) && !rel.startsWith(sep);
+}
+
+async function resolveToolArtifactSourcePath(cwd: string, sourcePath: string): Promise<string | null> {
+  const candidate = isAbsolute(sourcePath) ? sourcePath : resolve(cwd, sourcePath);
+  let root: string;
+  let target: string;
+  try {
+    [root, target] = await Promise.all([
+      realpath(cwd),
+      realpath(candidate),
+    ]);
+  } catch {
+    return null;
+  }
+  return isInsideOrSamePath(root, target) ? target : null;
+}
+
+export function createToolArtifactPersistence(deps: ToolArtifactPersistenceDeps): ToolArtifactPersistence {
+  const { artifactStore, storeReadImage, safeSendToRenderer } = deps;
+
+  async function persistToolArtifacts(cwd: string, event: ToolArtifactRecorderInput): Promise<void> {
+    for (const candidate of event.candidates) {
+      let content = candidate.content;
+      if (content === undefined && candidate.sourcePath) {
+        const sourcePath = await resolveToolArtifactSourcePath(cwd, candidate.sourcePath);
+        if (!sourcePath) continue;
+        content = await readFile(sourcePath);
+      }
+      if (content === undefined) continue;
+      const artifact = await artifactStore.create({
+        sessionId: event.sessionId,
+        turnId: event.turnId,
+        name: candidate.name,
+        kind: candidate.kind,
+        content,
+        ...(candidate.mimeType ? { mimeType: candidate.mimeType } : {}),
+        source: candidate.source ?? 'tool_result',
+        ...(candidate.summary ? { summary: candidate.summary } : {}),
+      });
+      safeSendToRenderer('artifacts:changed', {
+        reason: 'created',
+        artifactId: artifact.id,
+        sessionId: artifact.sessionId,
+        ts: Date.now(),
+      });
+    }
+  }
+
+  async function snapshotReadImage(input: {
+    sessionId: string;
+    turnId: string;
+    name: string;
+    bytes: Uint8Array;
+    mimeType: string;
+  }) {
+    const ref = await storeReadImage(input);
+    safeSendToRenderer('artifacts:changed', {
+      reason: 'created',
+      artifactId: ref.relativePath,
+      sessionId: ref.sessionId,
+      ts: Date.now(),
+    });
+    return ref;
+  }
+
+  async function persistArchivedToolResult(
+    event: ToolResultArchiveRecorderInput,
+  ): Promise<{ artifactId: string }> {
+    return persistArchivedToolResultToArtifacts(artifactStore, event);
+  }
+
+  async function readArchivedToolResult(
+    event: ToolResultArchiveReaderInput,
+  ): Promise<ToolResultArchiveReadResult> {
+    return readArchivedToolResultFromArtifacts(artifactStore, event);
+  }
+
+  return {
+    persistToolArtifacts,
+    snapshotReadImage,
+    persistArchivedToolResult,
+    readArchivedToolResult,
+  };
+}

--- a/apps/desktop/src/main/tool-assembly.ts
+++ b/apps/desktop/src/main/tool-assembly.ts
@@ -1,0 +1,277 @@
+import { app, nativeImage, powerMonitor } from 'electron';
+import {
+  buildAgentTeamChildTools,
+  buildAgentTeamLeadTools,
+  buildAskUserQuestionTool,
+  buildBuiltinTools,
+  buildChildAgentTools,
+  buildDeferredToolGroupsFromCatalog,
+  buildHostCapabilitiesFromBinding,
+  buildParentAgentTools,
+  assertProductBindingCatalogClean,
+  createBuiltinSandboxManager,
+  createFilesystemWorkerLaunchSpecProvider,
+  FilesystemWorkerClient,
+  resolveSkillDiscoveryPaths,
+  ShellRunProcessManager,
+  SKILL_TOOL_NAME,
+} from '@maka/runtime';
+import type {
+  HostCapabilitiesResolver,
+  MakaTool,
+  ToolAvailabilityConfig,
+} from '@maka/runtime';
+import type { WorkspacePrivacyContext } from '@maka/core/incognito';
+import { createAgentMailboxStore, createSettingsStore } from '@maka/storage';
+import { createComputerUseOverlayHook } from '@maka/computer-use';
+import { buildWebSearchAgentTool } from './web-search/agent-tool.js';
+import { buildRiveWorkflowTool } from './rive-workflow-tool.js';
+import { buildOfficeDocumentEditTool, buildOfficeDocumentTool } from './office-document-tool.js';
+import { buildExploreAgentTool } from './explore-agent-tool.js';
+import { buildBrowserTools } from './browser/browser-tools.js';
+import { createComputerUseHost } from './computer-use-host.js';
+import { createCursorOverlayController } from './computer-use/cursor-overlay-window.js';
+import {
+  applyComputerUseRealModelPolicy,
+  parseComputerUseRealModelPolicy,
+} from './computer-use-real-model-policy.js';
+import { buildSkillAgentTool } from './skills.js';
+import type { createMainTaskLedgerWiring } from './task-ledger-wiring.js';
+import type { createMainAutomationWiring } from './automation-wiring.js';
+import type { createMainGoalWiring } from './goal-wiring.js';
+import type { ToolArtifactPersistence } from './tool-artifact-persistence.js';
+
+type TaskLedgerWiring = ReturnType<typeof createMainTaskLedgerWiring>;
+type AutomationWiring = ReturnType<typeof createMainAutomationWiring>;
+type GoalWiring = ReturnType<typeof createMainGoalWiring>;
+type AgentMailboxStore = ReturnType<typeof createAgentMailboxStore>;
+type SettingsStore = ReturnType<typeof createSettingsStore>;
+
+export interface DesktopToolAssemblyDeps {
+  /** E2E computer-use flag: routes the ai-sdk backend through the raw
+   *  computer-use tools and disables the economy, matching the legacy path. */
+  isComputerUseRealModelE2e: boolean;
+  workspaceRoot: string;
+  taskLedgerStore: TaskLedgerWiring['store'];
+  taskLedgerWiring: TaskLedgerWiring;
+  automationWiring: AutomationWiring;
+  goalWiring: GoalWiring;
+  agentMailboxStore: AgentMailboxStore;
+  settingsStore: SettingsStore;
+  shellRuns: ShellRunProcessManager;
+  snapshotReadImage: ToolArtifactPersistence['snapshotReadImage'];
+  getWorkspacePrivacyContext: () => Promise<WorkspacePrivacyContext>;
+  resolveDesktopSkillHost: HostCapabilitiesResolver;
+}
+
+/**
+ * Assemble the desktop process's tool surface (issue #37 economy split).
+ * Pure move of main.ts's module-scope tool-assembly cluster: the sandbox /
+ * filesystem worker, the deferred capability groups (Rive, Office, browser,
+ * computer-use, agent orchestration), the WebSearch tool, the builtin + skill
+ * host surface, the deferred-group tool-availability config, and the child
+ * agent tool surface. Declaration order inside the function preserves the
+ * original module-init order. The cursor-overlay `onMainWindowClose` teardown
+ * hook stays in main.ts (it assigns a module-scoped `let`); the overlay
+ * controller is returned so main.ts can wire it.
+ */
+export function assembleDesktopTools(deps: DesktopToolAssemblyDeps) {
+  const {
+    isComputerUseRealModelE2e,
+    workspaceRoot,
+    taskLedgerStore,
+    taskLedgerWiring,
+    automationWiring,
+    goalWiring,
+    agentMailboxStore,
+    settingsStore,
+    shellRuns,
+    snapshotReadImage,
+    getWorkspacePrivacyContext,
+    resolveDesktopSkillHost,
+  } = deps;
+
+  const sandboxManager = createBuiltinSandboxManager();
+  const filesystemWorker = process.platform === 'darwin' && sandboxManager
+    ? new FilesystemWorkerClient({
+        sandboxManager,
+        getLaunchSpec: createFilesystemWorkerLaunchSpecProvider({
+          runtime: 'electron',
+          executable: process.execPath,
+          resourceLocation: app.isPackaged
+            ? { kind: 'desktop-packaged', resourcesPath: process.resourcesPath }
+            : { kind: 'runtime' },
+        }),
+      })
+    : undefined;
+  // Unified tool availability (issue #37). Deferred capability groups (Rive,
+  // Office, browser, agent orchestration) are withheld from the
+  // per-turn prompt and loaded on demand via `load_tools`, keeping their schemas
+  // off the wire until needed. Everything else (ungrouped) stays always-on.
+  // Kill-switch: set MAKA_DISABLE_DEFERRED_TOOLS to any value to turn economy off
+  // and advertise every tool every turn (legacy behavior).
+  const economyEnabled = !process.env.MAKA_DISABLE_DEFERRED_TOOLS;
+  const riveTools: MakaTool[] = [buildRiveWorkflowTool()];
+  const officeTools: MakaTool[] = [buildOfficeDocumentTool(), buildOfficeDocumentEditTool()];
+  // Embedded-browser observe→act tools. They drive the conversation's own
+  // WebContentsView via the BrowserViewHost the desktop provides in registerIpc;
+  // outside the app (no host) they report the browser as unavailable.
+  const browserTools: MakaTool[] = buildBrowserTools();
+  const computerUseOverlay = createCursorOverlayController();
+  const computerUseHost = createComputerUseHost({
+    isPackaged: app.isPackaged,
+    resourcesPath: process.resourcesPath,
+    compressFrame: (base64) => {
+      try {
+        const image = nativeImage.createFromBuffer(Buffer.from(base64, 'base64'));
+        return image.isEmpty()
+          ? { base64, mimeType: 'image/png' }
+          : {
+              base64: image.toJPEG(82).toString('base64'),
+              mimeType: 'image/jpeg',
+            };
+      } catch {
+        return { base64, mimeType: 'image/png' };
+      }
+    },
+    physicalInputRecentlyActive: () => powerMonitor.getSystemIdleTime() < 1,
+    ...(isComputerUseRealModelE2e
+      ? {
+          onTrace: (event) => {
+            const tracePath = process.env.MAKA_CU_REAL_MODEL_TRACE;
+            if (!tracePath) return;
+            void import('node:fs/promises').then(({ appendFile }) =>
+              appendFile(tracePath, `${JSON.stringify(event)}\n`, {
+                encoding: 'utf8',
+                mode: 0o600,
+              }),
+            ).catch(() => {});
+          },
+        }
+      : {}),
+    overlay: createComputerUseOverlayHook(computerUseOverlay),
+  });
+  const computerUse = computerUseHost.selected;
+  const computerUseTools = applyComputerUseRealModelPolicy(
+    computerUse.tools,
+    isComputerUseRealModelE2e
+      ? parseComputerUseRealModelPolicy(
+          process.env.MAKA_CU_REAL_MODEL_POLICY,
+        )
+      : undefined,
+  );
+  const agentTools: MakaTool[] = buildParentAgentTools({
+    taskLedger: taskLedgerStore,
+  });
+  const agentTeamLeadTools = buildAgentTeamLeadTools({
+    mailbox: agentMailboxStore,
+    taskLedger: taskLedgerStore,
+  });
+  const agentTeamChildTools = buildAgentTeamChildTools({
+    mailbox: agentMailboxStore,
+    taskLedger: taskLedgerStore,
+  });
+  const deferredTools: MakaTool[] = [
+    ...riveTools,
+    ...officeTools,
+    ...browserTools,
+    ...computerUseTools,
+    ...agentTools,
+  ];
+  const webSearchTool = buildWebSearchAgentTool({
+    settingsStore,
+    getPrivacyContext: getWorkspacePrivacyContext,
+  });
+  // Assemble product tools first, then derive skill host + deferred groups from
+  // the shared catalog ∩ this binding (#1099 S2). Skill listing uses the same host.
+  const toolsBeforeSkill: MakaTool[] = [
+    buildAskUserQuestionTool(),
+    ...buildBuiltinTools({
+      shellRuns,
+      runtimeResources: shellRuns,
+      backgroundTasks: shellRuns,
+      ptyControls: shellRuns,
+      snapshotImage: snapshotReadImage,
+      ...(sandboxManager ? { sandboxManager } : {}),
+      ...(filesystemWorker ? {
+        filesystemWorker,
+        enableBashAdditionalPermissions: true,
+        enableFileToolAdditionalPermissions: true,
+      } : {}),
+    }).filter((tool: MakaTool) => tool.name !== 'Edit'),
+  ];
+  const toolsAfterSkill: MakaTool[] = [
+    // External reference plan-mode borrow: a bounded read-only local worker for
+    // self-contained code/repo investigations. The tool advertises the
+    // `subagent` category; explore mode allows it, but the implementation
+    // itself only reads filenames/text snippets under the session cwd.
+    buildExploreAgentTool(),
+    // PR-AGENT-WEB-SEARCH-TOOL-0: Tavily-backed WebSearch tool. Closed
+    // over settingsStore so the renderer never sees the API key; the
+    // permission engine routes it through the `web_read` policy which
+    // prompts the user in explore / ask modes.
+    webSearchTool,
+    // Session task ledger: model manages a flat task list; the current list is
+    // re-injected each turn tail. Pure local state, so no permission gate.
+    ...taskLedgerWiring.tools,
+    // Unified Automation: heartbeat (session-internal polling) + cron (standalone scheduled runs).
+    ...automationWiring.tools,
+    // Goal execution: GoalSet/Clear/Status/Pause/Resume — autonomous turn-boundary continuation.
+    ...goalWiring.tools,
+    // The `load_tools` connector is built by ToolAvailabilityRuntime; deferred
+    // group tools just need to be present so they are dispatchable once loaded.
+    ...deferredTools,
+  ];
+  // Always-on Skill name is part of the host surface even before the tool instance
+  // is built (so requiredTools gates and capability tags stay complete).
+  const desktopBoundToolNames = [
+    ...toolsBeforeSkill.map((tool) => tool.name),
+    SKILL_TOOL_NAME,
+    ...toolsAfterSkill.map((tool) => tool.name),
+  ];
+  assertProductBindingCatalogClean('desktop', desktopBoundToolNames);
+  const desktopHostCapabilities = buildHostCapabilitiesFromBinding(desktopBoundToolNames);
+  // External reference lazy-skill pattern: the prompt lists available skills,
+  // and this read-only tool loads the full SKILL.md only when the task matches.
+  // Resolve per-call from the session cwd so skills at all 5 standard paths
+  // (cwd/.maka, cwd/.agents, workspaceRoot/skills, ~/.maka, ~/.agents) are
+  // discovered — matching the CLI and the Agent Skills spec (#1068).
+  const skillTool = buildSkillAgentTool(
+    ({ cwd }) => resolveSkillDiscoveryPaths(cwd, workspaceRoot),
+    resolveDesktopSkillHost,
+  );
+  const builtinTools: MakaTool[] = [...toolsBeforeSkill, skillTool, ...toolsAfterSkill];
+  const toolAvailability: ToolAvailabilityConfig = {
+    economy: economyEnabled,
+    groups: buildDeferredToolGroupsFromCatalog('desktop', desktopBoundToolNames),
+  };
+  // Child agents stay file-only for local reads; parent runtime refs such as
+  // maka://runtime/background-tasks/<id> are not part of their tool surface.
+  const childAgentTools = buildChildAgentTools([
+    ...buildBuiltinTools({
+      snapshotImage: snapshotReadImage,
+      ...(sandboxManager ? { sandboxManager } : {}),
+      ...(filesystemWorker ? {
+        filesystemWorker,
+        enableBashAdditionalPermissions: true,
+        enableFileToolAdditionalPermissions: true,
+      } : {}),
+    }).filter((tool: MakaTool) => tool.name !== 'Edit'),
+    webSearchTool,
+    ...agentTeamChildTools,
+  ]);
+
+  return {
+    riveTools,
+    officeTools,
+    browserTools,
+    computerUse,
+    computerUseOverlay,
+    computerUseTools,
+    agentTeamLeadTools,
+    desktopHostCapabilities,
+    builtinTools,
+    toolAvailability,
+    childAgentTools,
+  };
+}

--- a/notes/frontend-architecture-map-2026-07-19.md
+++ b/notes/frontend-architecture-map-2026-07-19.md
@@ -83,13 +83,36 @@ workspaces are exit 0 today; R1 makes them also report ZERO hints. Storybook sto
   inherently nondeterministic at the byte level (4 captures → 4 hashes, ~1426 KB each,
   pre-existing — the onboarding modal renders a live countdown), so the auditor's
   structural walk is the meaningful proof there.
-- [ ] **R4 — main.ts tool-assembly extraction (~L648–809). Requires maintainer-approved
-  contract re-pin.** The deferred-tool/economy assembly block (riveTools, officeTools, the
-  MakaTool catalog filter, webSearchTool, agentTeamChildTools) extracts into a
-  tool-assembly module. The main-process-wiring-contract locks `registerIpc` in main.ts
-  (function at L1222, invoked L1697); `startup`, `tool-assembly`, and `modelSupportsVision`
-  (L964) are direct-pinned to main.ts by contract. Extraction needs the maintainer to
-  re-pin those contracts first.
+- [x] **R4 — main.ts tool-assembly + tool-artifact-persistence extraction (shipped
+  `chore/arch-round-4`, main.ts 1903 → 1656, −247).** Two pure-move modules under
+  `apps/desktop/src/main/`:
+  `tool-assembly.ts` (277 lines) exports `assembleDesktopTools(deps)` — the sandbox /
+  filesystem-worker init, the deferred capability groups (Rive, Office, browser,
+  computer-use, agent-orchestration), the WebSearch tool, the builtin + skill host surface,
+  the deferred-group `toolAvailability`, and `childAgentTools`; returns the 11 collections
+  main.ts consumes downstream (riveTools/officeTools/browserTools/computerUse/
+  computerUseOverlay/computerUseTools/agentTeamLeadTools/desktopHostCapabilities/
+  builtinTools/toolAvailability/childAgentTools). `tool-artifact-persistence.ts` (124
+  lines) exports `createToolArtifactPersistence(deps)` → `{ persistToolArtifacts,
+  snapshotReadImage, persistArchivedToolResult, readArchivedToolResult }` (internal
+  `resolveToolArtifactSourcePath` / `isInsideOrSamePath`). main.ts keeps every call site
+  and the module-scoped seams: `registerIpc`, the `backends.register('ai-sdk')` closure
+  (`modelSupportsVision` NOT moved — it belongs to the R5 session-stream core),
+  `systemPromptService`, `storeReadImage`, and the `onMainWindowClose = () =>
+  computerUseOverlay.destroyAll()` teardown (it assigns a module `let`). Contract re-pins
+  (maintainer-authorized): added the two module paths to the
+  `main-process-contract-source-helpers` aggregator, so every combined-source consumer
+  auto-covers the moved symbols; switched three direct-main.ts readers to the combined
+  source keeping every assertion — `agent-swarm-host-contract` (buildParentAgentTools +
+  buildDeferredToolGroupsFromCatalog), `agent-team-collaboration-contract` (childAgentTools
+  + team tool builders), `attachment-frontend-contract` (snapshotReadImage); relaxed the
+  block-closer regexes in `permission-response-ipc-boundary` to tolerate the now-indented
+  in-function brackets. `main-process-wiring-contract` (registerIpc anchor) untouched —
+  registerIpc stays in main.ts. Gates: desktop 2744 + ui 196 suites green, 4-tsconfig +
+  ui typecheck clean, check-dead-css clean, knip ×2 exit 0 (zero hints),
+  AUDIT_PORT_BASE=24500 alignment auditor exit 0 (all 11 fixtures clean — full-app boot
+  proves main.ts still assembles), turn-narrative CDP smoke renders the chat surface (10
+  turns + composer). R5/R6 line boundaries below shift up by ~247.
 - [ ] **R5 — main.ts settings-runtime-effects + session-stream core splits (~L1360–1642).
   Requires maintainer-approved contract re-pin.** Same direct-pin constraint as R4.
 - [ ] **R6 — main.ts startup/lifecycle module (~L1642–1865). Requires maintainer-approved


### PR DESCRIPTION
Round 4 of notes/frontend-architecture-map-2026-07-19.md: **main.ts 1903 → 1656 (−247)**.

- `tool-assembly.ts` (277 L): the module-scope tool-assembly block (~L640-817) becomes `assembleDesktopTools(deps)` — sandbox/filesystem workers, agent/team/deferred/web-search/skill tools, computer-use host, product-binding assertion; 11 symbols returned to main.
- `tool-artifact-persistence.ts` (124 L): `createToolArtifactPersistence(deps)` DI factory (persist/snapshot/archive/read paths, containment checks).
- Both follow the register*/create* house DI style: explicit deps objects, no hidden globals. Deliberately NOT moved: registerIpc (wiring-contract anchor), modelSupportsVision + ai-sdk backend closure (session-stream core — R5 territory), the overlay-teardown `let` wiring.
- Contracts: both modules added to the main-process combined-source aggregator (R3 pattern); three direct-read contracts switched to the aggregator with every assertion kept; wiring-contract untouched.
- Proof: alignment auditor boots the full app across all 11 fixtures clean; turn-narrative CDP smoke renders 10 chat turns + composer (tool assembly feeds the session runtime — breakage shows at boot).

Gates (merged tree): desktop 2744 · ui 196 · typecheck · check-dead-css · knip ×2 = 0. Implemented by an opus worktree agent; R5/R6 boundaries in the map shifted accordingly.