### PR TITLE
chore(main): extract settings-runtime-effects + session-stream from main.ts (arch R5)

### DIFF
--- a/apps/desktop/src/main/__tests__/attachment-frontend-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/attachment-frontend-contract.test.ts
@@ -82,7 +82,9 @@ describe('attachment frontend contract', () => {
   });
 
   it('passes selected model vision capability to the runtime attachment renderer', async () => {
-    const main = await readRepo('apps/desktop/src/main/main.ts');
+    // modelSupportsVision + the ai-sdk backend wiring moved into session-stream.ts
+    // (arch R5); scan the combined main-process source so the pins follow the split.
+    const main = await readMainProcessCombinedSource();
 
     assert.match(
       main,

--- a/apps/desktop/src/main/__tests__/ipc-surface-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/ipc-surface-contract.test.ts
@@ -69,8 +69,10 @@ describe('IPC surface contract', () => {
     assert.match(main, /new LocalMemoryService\([\s\S]*getPrivacyContext: getWorkspacePrivacyContext/);
     assert.doesNotMatch(main, /defaultWorkspacePrivacyContext/);
 
-    assert.match(main, /const memoryPromptSnapshot = await systemPromptService\.buildLocalMemoryPromptFragment\(\)/);
-    assert.match(main, /systemPrompt: \(\{ cwd \}\) => systemPromptService\.buildBackendSystemPrompt\(ctx\.header, cwd, \{[\s\S]*childInstruction: ctx\.systemPrompt/);
+    // The ai-sdk backend wiring moved into session-stream.ts (arch R5); these two
+    // pins now target the combined main-process source instead of main.ts itself.
+    assert.match(combinedMainProcess, /const memoryPromptSnapshot = await systemPromptService\.buildLocalMemoryPromptFragment\(\)/);
+    assert.match(combinedMainProcess, /systemPrompt: \(\{ cwd \}\) => systemPromptService\.buildBackendSystemPrompt\(ctx\.header, cwd, \{[\s\S]*childInstruction: ctx\.systemPrompt/);
     assert.match(combinedMainProcess, /async function buildBackendSystemPrompt/);
     assert.match(combinedMainProcess, /childInstruction[\s\S]*memoryFragment: null, includePersonalization: false/);
     assert.match(combinedMainProcess, /子代理必须继承当前会话的权限、隐私、工作区和技能约束/);

--- a/apps/desktop/src/main/__tests__/main-process-contract-source-helpers.ts
+++ b/apps/desktop/src/main/__tests__/main-process-contract-source-helpers.ts
@@ -30,6 +30,7 @@ export const MAIN_PROCESS_SOURCE_REPO_PATHS: readonly string[] = [
   'apps/desktop/src/main/project-root-controller.ts',
   'apps/desktop/src/main/session-entry-ipc-main.ts',
   'apps/desktop/src/main/session-branch.ts',
+  'apps/desktop/src/main/settings-runtime-effects.ts',
   'apps/desktop/src/main/sessions-ipc-main.ts',
   'apps/desktop/src/main/settings-ipc-main.ts',
   'apps/desktop/src/main/subscription-model-fetch.ts',

--- a/apps/desktop/src/main/__tests__/main-process-contract-source-helpers.ts
+++ b/apps/desktop/src/main/__tests__/main-process-contract-source-helpers.ts
@@ -30,6 +30,7 @@ export const MAIN_PROCESS_SOURCE_REPO_PATHS: readonly string[] = [
   'apps/desktop/src/main/project-root-controller.ts',
   'apps/desktop/src/main/session-entry-ipc-main.ts',
   'apps/desktop/src/main/session-branch.ts',
+  'apps/desktop/src/main/session-stream.ts',
   'apps/desktop/src/main/settings-runtime-effects.ts',
   'apps/desktop/src/main/sessions-ipc-main.ts',
   'apps/desktop/src/main/settings-ipc-main.ts',

--- a/apps/desktop/src/main/__tests__/web-search-telemetry-scrub-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/web-search-telemetry-scrub-contract.test.ts
@@ -7,18 +7,14 @@
  */
 
 import { strict as assert } from 'node:assert';
-import { readFile } from 'node:fs/promises';
 import { describe, it } from 'node:test';
-import { join, resolve } from 'node:path';
-
-const REPO_ROOT = resolve(process.cwd(), '..', '..');
+import { readMainProcessCombinedSource } from './main-process-contract-source-helpers.js';
 
 describe('WebSearch telemetry scrub contract', () => {
   it('main.ts recordToolInvocation drops argsSummary for WebSearch', async () => {
-    const src = await readFile(
-      join(REPO_ROOT, 'apps', 'desktop', 'src', 'main', 'main.ts'),
-      'utf8',
-    );
+    // The ai-sdk backend wiring (with the recordToolInvocation scrub) moved into
+    // session-stream.ts (arch R5); scan the combined main-process source.
+    const src = await readMainProcessCombinedSource();
     // Cheap grep: the wrapper that branches on toolName === WEB_SEARCH_TOOL_NAME
     // must spread the event and explicitly drop argsSummary.
     assert.match(

--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -6,13 +6,11 @@ import { startConfigFileWatcher, type ConfigFileWatcher } from './config-file-wa
 import {
   DEFAULT_SESSION_NAME,
   filterModelVisibleTaskLedgerTasks,
-  isDeepResearchSession,
   resolveModelVisionSupport,
   DEEP_RESEARCH_SESSION_LABEL,
   expertTeamIdFromLabels,
 } from '@maka/core';
 import type {
-  AppSettings,
   BotProvider,
   ConnectionEvent,
   CreateSessionInput,
@@ -20,7 +18,6 @@ import type {
   SessionChangedEvent,
   SessionChangedReason,
   SessionEvent,
-  UpdateAppSettingsInput,
 } from '@maka/core';
 import { deriveBotStatusPersistenceUpdate } from './bot-status-persistence.js';
 import { WEB_SEARCH_TOOL_NAME } from './web-search/agent-tool.js';
@@ -97,7 +94,6 @@ import { createFileCredentialStore, migrateLegacyCredentials } from './credentia
 import { bindOnboardingDeps, createOnboardingService } from './onboarding-service.js';
 import { handleQuickChatStart as runQuickChatStart, type QuickChatResult } from './quick-chat.js';
 import { createDailyReviewArchiveStore } from './daily-review-archive-store.js';
-import { preserveSensitivePlaceholders } from './settings-ipc-helpers.js';
 import { resolveDefaultPermissionMode } from './permission-mode-default.js';
 import {
   resolveVisualSmokeFixture,
@@ -131,10 +127,7 @@ import { createMainAutomationWiring, evaluateAutomationCanFire } from './automat
 import { createMainGoalWiring } from './goal-wiring.js';
 import { startDesktopSessionTurn, type SessionGoalBoundary } from './session-turn-stream.js';
 import { createOAuthModelConnectionsMainService } from './oauth-model-connections-main.js';
-import {
-  maskNetworkSettings,
-  toContractNetworkSettings,
-} from './network-settings-main.js';
+import { toContractNetworkSettings } from './network-settings-main.js';
 import { registerMemoryIpc } from './memory-ipc-main.js';
 import { registerSubscriptionIpc } from './subscription-ipc-main.js';
 import { registerBrowserIpc } from './browser-ipc-main.js';
@@ -157,6 +150,7 @@ import { registerSettingsIpc } from './settings-ipc-main.js';
 import type { SettingsIpcHandle } from './settings-ipc-main.js';
 import { createVisualSmokeBotOnboardingAdapters } from './bot-onboarding-visual-smoke.js';
 import { createKeepSystemAwakeController } from './keep-system-awake.js';
+import { createSettingsRuntimeEffects } from './settings-runtime-effects.js';
 import { registerGatewayIpc } from './gateway-ipc-main.js';
 import { registerSessionsIpc } from './sessions-ipc-main.js';
 import {
@@ -1142,66 +1136,16 @@ function canCreateFakeSessionFromRenderer(): boolean {
   );
 }
 
-async function normalizeSettingsPatch(patch: UpdateAppSettingsInput): Promise<UpdateAppSettingsInput> {
-  const current = await settingsStore.get();
-  return preserveSensitivePlaceholders(patch, current);
-}
-
-async function applySettingsRuntimeEffects(settings: AppSettings, patch: UpdateAppSettingsInput): Promise<void> {
-  if (patch.network) {
-    const network = toContractNetworkSettings(settings.network);
-    setActiveProxy(network.proxy);
-    safeSendToRenderer('settings:network:changed', maskNetworkSettings(network));
-  }
-  if (patch.botChat) {
-    await botRegistry.applySettings(settings.botChat);
-  }
-  if (patch.openGateway) {
-    const status = await openGateway.sync(settings.openGateway);
-    safeSendToRenderer('gateway:statusChanged', status);
-  }
-  if (patch.chatDefaults?.permissionMode) {
-    await syncDefaultPermissionModeToSessions(settings.chatDefaults.permissionMode);
-  }
-  if (patch.system) {
-    // Start/stop the power-save blocker the instant the toggle flips so the
-    // capability reflects the user's choice without waiting for a relaunch.
-    keepSystemAwake.apply(settings.system.keepSystemAwake);
-  }
-}
-
-async function syncDefaultPermissionModeToSessions(mode: Exclude<PermissionMode, 'explore'>): Promise<void> {
-  const sessions = await runtime.listSessions();
-  await Promise.all(sessions.map(async (session) => {
-    if (session.permissionMode === mode) return;
-    if (isDeepResearchSession(session.labels)) return;
-    if (session.status === 'running' || session.status === 'waiting_for_user') return;
-    try {
-      await runtime.setPermissionMode(session.id, mode);
-      emitSessionsChanged('mode-change', session.id);
-    } catch {
-      // Best effort: the persisted global default is still the authority for
-      // new sessions; busy sessions can be reconciled on a later change.
-    }
-  }));
-}
-
-async function handleExternalSettingsChange(): Promise<void> {
-  try {
-    const settings = await settingsStore.get();
-    const fullPatch: UpdateAppSettingsInput = {
-      network: settings.network,
-      botChat: settings.botChat,
-      openGateway: settings.openGateway,
-      system: settings.system,
-    };
-    await applySettingsRuntimeEffects(settings, fullPatch);
-  } catch (error) {
-    console.error('[config-watcher] failed to apply external settings change:', error);
-  }
-  // Always notify renderer, even on partial failure above
-  safeSendToRenderer('settings:externalChanged', { ts: Date.now() });
-}
+const { normalizeSettingsPatch, applySettingsRuntimeEffects, handleExternalSettingsChange } =
+  createSettingsRuntimeEffects({
+    settingsStore,
+    botRegistry,
+    openGateway,
+    keepSystemAwake,
+    runtime,
+    safeSendToRenderer,
+    emitSessionsChanged,
+  });
 
 function streamEvents(
   sessionId: string,

--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -6,9 +6,7 @@ import { startConfigFileWatcher, type ConfigFileWatcher } from './config-file-wa
 import {
   DEFAULT_SESSION_NAME,
   filterModelVisibleTaskLedgerTasks,
-  resolveModelVisionSupport,
   DEEP_RESEARCH_SESSION_LABEL,
-  expertTeamIdFromLabels,
 } from '@maka/core';
 import type {
   BotProvider,
@@ -20,7 +18,6 @@ import type {
   SessionEvent,
 } from '@maka/core';
 import { deriveBotStatusPersistenceUpdate } from './bot-status-persistence.js';
-import { WEB_SEARCH_TOOL_NAME } from './web-search/agent-tool.js';
 import { runThreadSearch } from './search/thread-search.js';
 import { assembleDesktopTools } from './tool-assembly.js';
 import { createToolArtifactPersistence } from './tool-artifact-persistence.js';
@@ -31,22 +28,16 @@ import { CursorSubscriptionService } from './oauth/cursor-subscription-service.j
 import { AntigravitySubscriptionService } from './oauth/antigravity-subscription-service.js';
 import { importLegacyOAuthTokenFiles } from './oauth/shared-credential-bridge.js';
 import type { WorkspacePrivacyContext } from '@maka/core/incognito';
-import type { LlmCallRecord, ToolInvocationRecord } from '@maka/core/usage-stats/types';
 import { ok } from '@maka/core/settings/result';
 import {
-  AiSdkBackend,
   BackendRegistry,
   FakeBackend,
   PermissionEngine,
   SessionManager,
-  buildMcpTools,
-  buildExpertDispatchToolForTeamId,
   createLocalContinuationSafetyInspector,
   getAIModel,
   generateSessionTitle as generateRuntimeSessionTitle,
   buildProviderOptions,
-  recordLlmCall,
-  recordToolInvocation,
   buildPricingLookup,
   BotRegistry,
   setActiveProxy,
@@ -59,17 +50,11 @@ import type {
   GoalTurnOutcome,
   HostCapabilities,
   HostCapabilitiesResolver,
-  SessionActivityLease,
-  ToolArtifactRecorderInput,
-  ToolResultArchiveReaderInput,
-  ToolResultArchiveReadResult,
-  ToolResultArchiveRecorderInput,
 } from '@maka/runtime';
 import type { LlmConnection } from '@maka/core/llm-connections';
 import {
   createAgentRunStore,
   createAgentMailboxStore,
-  createAttachmentByteReader,
   createArtifactStore,
   createReadImageSnapshotter,
   createConnectionStore,
@@ -85,9 +70,7 @@ import { McpClientManager } from '@maka/mcp';
 import { registerMcpIpcMain } from './mcp-ipc-main.js';
 import {
   ensureSessionCanSendOrRebind,
-  errorCode,
   errorMessage,
-  errorReason,
   requireReadyConnection,
 } from './chat-readiness.js';
 import { createFileCredentialStore, migrateLegacyCredentials } from './credential-store.js';
@@ -103,29 +86,17 @@ import { resolveBuildInfo } from './build-info.js';
 import { OpenGatewayService } from './open-gateway.js';
 import { LocalMemoryService } from './local-memory-service.js';
 import { createAttachmentApprovalRegistry } from './attachment-approval.js';
-import {
-  buildLlmHistorySummarizer,
-  cleanupLegacyHistoryCompactArtifacts,
-  loadHistoryCompactBlocksFromArtifacts,
-  loadSynthesisCacheBlocksFromArtifacts,
-  persistSynthesisCacheBlocksToArtifacts,
-} from '@maka/runtime';
+import { cleanupLegacyHistoryCompactArtifacts } from '@maka/runtime';
 import { computerUseServiceHealth } from './computer-use-host.js';
-import {
-  computerUseAvailabilityForModel,
-  computerUseToolsForModel,
-} from './computer-use-model-tools.js';
 import { createMainWindowController } from './main-window.js';
 import { createDailyReviewMainService } from './daily-review-main.js';
 import { createPlanReminderMainService } from './plan-reminders-main.js';
 import { createBotIncomingMainService } from './bot-incoming-main.js';
 import { createSubscriptionModelFetch } from './subscription-model-fetch.js';
-import { buildDefaultContextBudgetPolicy, resolveSelectedModelContextWindow } from '@maka/runtime';
 import { createSystemPromptMainService } from './system-prompt-main.js';
 import { createMainTaskLedgerWiring } from './task-ledger-wiring.js';
 import { createMainAutomationWiring, evaluateAutomationCanFire } from './automation-wiring.js';
 import { createMainGoalWiring } from './goal-wiring.js';
-import { startDesktopSessionTurn, type SessionGoalBoundary } from './session-turn-stream.js';
 import { createOAuthModelConnectionsMainService } from './oauth-model-connections-main.js';
 import { toContractNetworkSettings } from './network-settings-main.js';
 import { registerMemoryIpc } from './memory-ipc-main.js';
@@ -151,6 +122,7 @@ import type { SettingsIpcHandle } from './settings-ipc-main.js';
 import { createVisualSmokeBotOnboardingAdapters } from './bot-onboarding-visual-smoke.js';
 import { createKeepSystemAwakeController } from './keep-system-awake.js';
 import { createSettingsRuntimeEffects } from './settings-runtime-effects.js';
+import { createAiSdkBackendFactory, createSessionStreamer } from './session-stream.js';
 import { registerGatewayIpc } from './gateway-ipc-main.js';
 import { registerSessionsIpc } from './sessions-ipc-main.js';
 import {
@@ -340,20 +312,6 @@ const planReminderStore = createPlanReminderStore(workspaceRoot);
 const taskLedgerWiring = createMainTaskLedgerWiring(workspaceRoot);
 const taskLedgerStore = taskLedgerWiring.store;
 const agentMailboxStore = createAgentMailboxStore(workspaceRoot);
-
-interface StreamEventsOptions {
-  turnId: string;
-  goalBoundary: SessionGoalBoundary;
-  activity?: SessionActivityLease;
-  observeEvent?: (event: SessionEvent) => void;
-}
-
-interface StreamEventsResult {
-  turnId: string;
-  ok: boolean;
-  error?: string;
-  outcome: GoalTurnOutcome;
-}
 
 const sessionActivities = new SessionActivityRegistry();
 
@@ -717,148 +675,33 @@ const planReminders = createPlanReminderMainService({
 
 app.setName('Maka');
 
-function modelSupportsVision(connection: LlmConnection, model: string): boolean {
-  return resolveModelVisionSupport(connection.providerType, connection.models, model);
-}
-
-backends.register('ai-sdk', async (ctx) => {
-  // MCP is optional. A corrupt mcp.json remains visible in the MCP module,
-  // but must not prevent builtin-only conversations from creating a backend.
-  await ensureMcpReady().catch(() => {});
-  const { connection, apiKey, model } = await getReadyConnection(ctx.header.llmConnectionSlug, ctx.header.model);
-  const modelFetch = buildSubscriptionModelFetch(connection, ctx.sessionId, model);
-  const memoryPromptSnapshot = await systemPromptService.buildLocalMemoryPromptFragment();
-  const supportsVision = modelSupportsVision(connection, model);
-  const candidateTools = isComputerUseRealModelE2e
-    ? computerUseTools
-    : ctx.tools
-      ? [...ctx.tools]
-      : [...builtinTools, ...buildMcpTools(mcpManager)];
-  const candidateToolAvailability = isComputerUseRealModelE2e
-    ? { economy: false, groups: [] }
-    : toolAvailability;
-  // Expert-team lead: a main session (ctx.tools undefined) labeled
-  // `mode:expert-team:<teamId>` gets the team-bound expert_dispatch tool.
-  // Child turns receive scoped `ctx.tools` and inherit the label, but must NOT
-  // get expert_dispatch — members cannot spawn nested teams.
-  const expertTeamId = ctx.tools ? undefined : expertTeamIdFromLabels(ctx.header.labels);
-  const expertDispatchTool = expertTeamId
-    ? buildExpertDispatchToolForTeamId(expertTeamId, { taskLedger: taskLedgerStore })
-    : undefined;
-  const agentTeam = ctx.agentTeam ?? (expertTeamId
-    ? { role: 'lead' as const, teamId: expertTeamId, agentId: 'lead' }
-    : undefined);
-  const backendTools = computerUseToolsForModel(
-    candidateTools,
-    computerUseTools,
-    supportsVision,
-  );
-  const backendToolAvailability = computerUseAvailabilityForModel(
-    candidateToolAvailability,
-    supportsVision,
-  );
-  const backendToolNames = new Set([
-    ...backendTools.map((tool) => tool.name),
-    ...(expertDispatchTool ? [expertDispatchTool.name, ...agentTeamLeadTools.map((tool) => tool.name)] : []),
-  ]);
-  const backendCapabilities = new Set<string>();
-  for (const [capability, tools] of [
-    ['rive', riveTools],
-    ['office', officeTools],
-    ['browser', browserTools],
-    ['computer_use', computerUseTools],
-  ] as const) {
-    if (tools.some((tool) => backendToolNames.has(tool.name))) backendCapabilities.add(capability);
-  }
-  const backendSkillHost: HostCapabilities = {
-    toolNames: backendToolNames,
-    capabilities: backendCapabilities,
-  };
-  // Child backends share the parent sessionId but intentionally have a
-  // narrower tool surface. They do not receive the Desktop Skill tool, so
-  // they must not overwrite the parent session's resolver entry.
-  if (!ctx.tools) desktopSessionSkillHosts.set(ctx.sessionId, backendSkillHost);
-
-  return new AiSdkBackend({
-    sessionId: ctx.sessionId,
-    header: { ...ctx.header, model },
-    appendMessage: ctx.appendMessage ?? ((message) => ctx.store.appendMessage(ctx.sessionId, message)),
-    connection,
-    apiKey: apiKey ?? '',
-    modelId: model,
-    permissionEngine,
-    modelFactory: (input) => getAIModel({ ...input, fetch: modelFetch }),
-    tools: expertDispatchTool
-      ? [...backendTools, expertDispatchTool, ...agentTeamLeadTools]
-      : backendTools,
-    agentTeam,
-    toolAvailability: backendToolAvailability,
-    spawnChildAgent: (input) => runtime.spawnChildAgent(ctx.sessionId, input),
-    listChildAgents: () => runtime.listChildAgents(ctx.sessionId),
-    readChildAgentOutput: (input) => runtime.readChildAgentOutput(ctx.sessionId, input),
-    providerOptions: buildProviderOptions(connection, model, ctx.header.thinkingLevel),
-    contextBudget: buildDefaultContextBudgetPolicy(connection, {
-      name: 'desktop-default-history-budget',
-      modelId: model,
-    }),
-    systemPrompt: ({ cwd }) => systemPromptService.buildBackendSystemPrompt(ctx.header, cwd, {
-      memoryFragment: memoryPromptSnapshot,
-      childInstruction: ctx.systemPrompt,
-      skillBudget: { contextWindow: resolveSelectedModelContextWindow(connection, model) },
-      host: backendSkillHost,
-    }),
-    turnTailPrompt: ({ cwd, sessionId }) => systemPromptService.buildTurnTailPrompt(cwd, sessionId),
-    shellRunContextSummary: ctx.shellRunContextSummary,
-    lookupPricing,
-    recordLlmCall: (event: LlmCallRecord) => recordLlmCall({ repo: telemetryRepo, lookupPricing }, event),
-    recordToolInvocation: (event: ToolInvocationRecord) =>
-      recordToolInvocation(
-        { repo: telemetryRepo },
-        // PR-AGENT-WEB-SEARCH-TOOL-0: scrub the query out of the
-        // telemetry record. The agent passes the raw user query as
-        // the tool argument; persisting it in `argsSummary` would
-        // leak user-derived content into the usage log.
-        event.toolName === WEB_SEARCH_TOOL_NAME
-          ? { ...event, argsSummary: undefined }
-          : event,
-      ),
-    recordToolArtifacts: (event: ToolArtifactRecorderInput) => persistToolArtifacts(ctx.header.cwd, event),
-    archiveToolResult: (event: ToolResultArchiveRecorderInput) => persistArchivedToolResult(event),
-    readToolResultArchive: (event: ToolResultArchiveReaderInput) => readArchivedToolResult(event),
-    readAttachmentBytes: createAttachmentByteReader({ artifactStore, sessionId: ctx.sessionId }),
-    ...(runtimePersistence.runtimeCommitStore
-      ? { runtimeCommitSink: runtimePersistence.runtimeCommitStore }
-      : {}),
-    supportsVision,
-    loadHistoryCompact: (event) => loadHistoryCompactBlocksFromArtifacts(artifactStore, event),
-    loadHistoryCompactCheckpoint: ctx.loadHistoryCompactCheckpoint,
-    summarizeHistoryCompact: buildLlmHistorySummarizer({
-      // Reuse the same connection/model the session already drives, so the
-      // summary stays consistent with the model that will consume it.
-      resolveModel: () =>
-        getAIModel({ connection, apiKey: apiKey ?? '', modelId: model, fetch: modelFetch }),
-      providerOptions: buildProviderOptions(connection, model, ctx.header.thinkingLevel),
-    }),
-    loadSynthesisCache: (event) => loadSynthesisCacheBlocksFromArtifacts(artifactStore, event),
-    writeSynthesisCache: (event) => persistSynthesisCacheBlocksToArtifacts(artifactStore, event, {
-      onArtifactCreated: (artifact) => {
-        safeSendToRenderer('artifacts:changed', {
-          reason: 'created',
-          artifactId: artifact.id,
-          sessionId: artifact.sessionId,
-          ts: Date.now(),
-        });
-      },
-    }),
-    recordRunTrace: ctx.recordRunTrace,
-    recordHistoryCompactCheckpoint: ctx.recordHistoryCompactCheckpoint,
-    loadTurnRuntimeEvents: ctx.loadTurnRuntimeEvents,
-    recordActiveFullCompactBlock: ctx.recordActiveFullCompactBlock,
-    recordSemanticCompactBlock: ctx.recordSemanticCompactBlock,
-    newId: randomUUID,
-    now: Date.now,
-  });
-});
+backends.register('ai-sdk', createAiSdkBackendFactory({
+  isComputerUseRealModelE2e,
+  ensureMcpReady,
+  getReadyConnection,
+  buildSubscriptionModelFetch,
+  systemPromptService,
+  mcpManager,
+  permissionEngine,
+  taskLedgerStore,
+  telemetryRepo,
+  artifactStore,
+  desktopSessionSkillHosts,
+  riveTools,
+  officeTools,
+  browserTools,
+  computerUseTools,
+  agentTeamLeadTools,
+  builtinTools,
+  toolAvailability,
+  persistToolArtifacts,
+  persistArchivedToolResult,
+  readArchivedToolResult,
+  runtimeCommitStore: runtimePersistence.runtimeCommitStore,
+  safeSendToRenderer,
+  getRuntime: () => runtime,
+  getLookupPricing: () => lookupPricing,
+}));
 
 backends.register('fake', (ctx) =>
   new FakeBackend({ sessionId: ctx.sessionId, header: ctx.header, store: ctx.store, appendMessage: ctx.appendMessage }),
@@ -1147,86 +990,15 @@ const { normalizeSettingsPatch, applySettingsRuntimeEffects, handleExternalSetti
     emitSessionsChanged,
   });
 
-function streamEvents(
-  sessionId: string,
-  iterator: AsyncIterable<SessionEvent>,
-  options: StreamEventsOptions,
-): Promise<StreamEventsResult> {
-  let userAppendBroadcasted = false;
-  const turnId = options.turnId;
-  const started = startDesktopSessionTurn({
-    sessionId,
-    events: iterator,
-    turnId,
-    goalBoundary: options.goalBoundary,
-    activities: sessionActivities,
-    ...(options.activity ? { activity: options.activity } : {}),
-    beginExternalTurn: (externalSessionId, externalTurnId) =>
-      goalWiring.coordinator.beginExternalTurn(externalSessionId, externalTurnId),
-    onEvent: (event) => {
-      if (!userAppendBroadcasted) {
-        emitSessionsChanged('message-appended', sessionId);
-        userAppendBroadcasted = true;
-      }
-      safeSendToRenderer(`sessions:event:${sessionId}`, event);
-      openGateway.publishSessionEvent(sessionId, event);
-      if (isStatusChangingSessionEvent(event)) {
-        emitSessionsChanged('status-change', sessionId);
-      }
-      if (isTurnStatusChangingSessionEvent(event)) {
-        emitSessionsChanged('turn-status-change', sessionId);
-        computerUseOverlay.clearForSession(sessionId);
-        computerUseTools.clearSession(sessionId);
-      }
-      options.observeEvent?.(event);
-    },
-    onStreamError: (error) => {
-      const event = {
-        type: 'error',
-        id: randomUUID(),
-        turnId,
-        ts: Date.now(),
-        recoverable: false,
-        code: errorCode(error),
-        reason: errorReason(error),
-        message: errorMessage(error),
-      } satisfies SessionEvent;
-      safeSendToRenderer(`sessions:event:${sessionId}`, event);
-      openGateway.publishSessionEvent(sessionId, event);
-      emitSessionsChanged('status-change', sessionId);
-      emitSessionsChanged('turn-status-change', sessionId);
-      computerUseOverlay.clearForSession(sessionId);
-      computerUseTools.clearSession(sessionId);
-    },
-    onDrained: () => {
-      emitSessionsChanged('message-appended', sessionId);
-    },
-  });
-  if (started.kind === 'unavailable') throw new Error(started.reason);
-  return started.completion.then((outcome) => {
-    const failureReason = outcome.kind === 'errored' || outcome.kind === 'suspended'
-      ? outcome.reason
-      : undefined;
-    return {
-      turnId,
-      ok: outcome.kind === 'completed',
-      ...(failureReason ? { error: failureReason } : {}),
-      outcome,
-    };
-  });
-}
-
-function isStatusChangingSessionEvent(event: SessionEvent): boolean {
-  return event.type === 'permission_request' ||
-    event.type === 'permission_decision_ack' ||
-    event.type === 'complete' ||
-    event.type === 'abort' ||
-    event.type === 'error';
-}
-
-function isTurnStatusChangingSessionEvent(event: SessionEvent): boolean {
-  return event.type === 'complete' || event.type === 'abort' || event.type === 'error';
-}
+const streamEvents = createSessionStreamer({
+  sessionActivities,
+  goalWiring,
+  openGateway,
+  computerUseOverlay,
+  computerUseTools,
+  safeSendToRenderer,
+  emitSessionsChanged,
+});
 
 async function ensureSessionCanSend(sessionId: string): Promise<void> {
   const header = await readAvailableSessionHeader(sessionId);

--- a/apps/desktop/src/main/session-stream.ts
+++ b/apps/desktop/src/main/session-stream.ts
@@ -1,0 +1,409 @@
+import { randomUUID } from 'node:crypto';
+import { expertTeamIdFromLabels, resolveModelVisionSupport } from '@maka/core';
+import type { SessionChangedReason, SessionEvent } from '@maka/core';
+import type { LlmConnection } from '@maka/core/llm-connections';
+import type { LlmCallRecord, ToolInvocationRecord } from '@maka/core/usage-stats/types';
+import {
+  AiSdkBackend,
+  buildDefaultContextBudgetPolicy,
+  buildExpertDispatchToolForTeamId,
+  buildLlmHistorySummarizer,
+  buildMcpTools,
+  buildProviderOptions,
+  getAIModel,
+  loadHistoryCompactBlocksFromArtifacts,
+  loadSynthesisCacheBlocksFromArtifacts,
+  persistSynthesisCacheBlocksToArtifacts,
+  recordLlmCall,
+  recordToolInvocation,
+  resolveSelectedModelContextWindow,
+} from '@maka/runtime';
+import type {
+  BackendFactory,
+  GoalTurnOutcome,
+  HostCapabilities,
+  PermissionEngine,
+  SessionActivityLease,
+  SessionActivityRegistry,
+  SessionManager,
+  ToolArtifactRecorderInput,
+  ToolResultArchiveReaderInput,
+  ToolResultArchiveRecorderInput,
+  buildPricingLookup,
+} from '@maka/runtime';
+import type { McpClientManager } from '@maka/mcp';
+import {
+  createArtifactStore,
+  createAttachmentByteReader,
+  createTelemetryRepo,
+  openRuntimeEventPersistence,
+} from '@maka/storage';
+import { WEB_SEARCH_TOOL_NAME } from './web-search/agent-tool.js';
+import {
+  computerUseAvailabilityForModel,
+  computerUseToolsForModel,
+} from './computer-use-model-tools.js';
+import { errorCode, errorMessage, errorReason } from './chat-readiness.js';
+import type { ReadyConnection } from './chat-readiness.js';
+import type { assembleDesktopTools } from './tool-assembly.js';
+import type { ToolArtifactPersistence } from './tool-artifact-persistence.js';
+import type { createMainTaskLedgerWiring } from './task-ledger-wiring.js';
+import type { createMainGoalWiring } from './goal-wiring.js';
+import type { createSubscriptionModelFetch } from './subscription-model-fetch.js';
+import type { createSystemPromptMainService } from './system-prompt-main.js';
+import type { OpenGatewayService } from './open-gateway.js';
+import { startDesktopSessionTurn, type SessionGoalBoundary } from './session-turn-stream.js';
+
+type AssembledTools = ReturnType<typeof assembleDesktopTools>;
+type SystemPromptMainService = ReturnType<typeof createSystemPromptMainService>;
+type SubscriptionModelFetchBuilder = ReturnType<typeof createSubscriptionModelFetch>;
+type TaskLedgerStore = ReturnType<typeof createMainTaskLedgerWiring>['store'];
+type GoalWiring = ReturnType<typeof createMainGoalWiring>;
+type ArtifactStore = ReturnType<typeof createArtifactStore>;
+type TelemetryRepo = ReturnType<typeof createTelemetryRepo>;
+type PricingLookup = ReturnType<typeof buildPricingLookup>;
+type RuntimeCommitStore = Awaited<ReturnType<typeof openRuntimeEventPersistence>>['runtimeCommitStore'];
+
+/**
+ * Selected-model image-input capability, consulted before wiring AiSdkBackend.
+ * Stored provider capabilities win; a bare model id falls back to in-repo
+ * metadata (provider `/models` responses do not report image support).
+ */
+function modelSupportsVision(connection: LlmConnection, model: string): boolean {
+  return resolveModelVisionSupport(connection.providerType, connection.models, model);
+}
+
+export interface AiSdkBackendFactoryDeps {
+  isComputerUseRealModelE2e: boolean;
+  ensureMcpReady: () => Promise<void>;
+  getReadyConnection: (slug: string | null | undefined, model?: string) => Promise<ReadyConnection>;
+  buildSubscriptionModelFetch: SubscriptionModelFetchBuilder;
+  systemPromptService: SystemPromptMainService;
+  mcpManager: McpClientManager;
+  permissionEngine: PermissionEngine;
+  taskLedgerStore: TaskLedgerStore;
+  telemetryRepo: TelemetryRepo;
+  artifactStore: ArtifactStore;
+  desktopSessionSkillHosts: Map<string, HostCapabilities>;
+  riveTools: AssembledTools['riveTools'];
+  officeTools: AssembledTools['officeTools'];
+  browserTools: AssembledTools['browserTools'];
+  computerUseTools: AssembledTools['computerUseTools'];
+  agentTeamLeadTools: AssembledTools['agentTeamLeadTools'];
+  builtinTools: AssembledTools['builtinTools'];
+  toolAvailability: AssembledTools['toolAvailability'];
+  persistToolArtifacts: ToolArtifactPersistence['persistToolArtifacts'];
+  persistArchivedToolResult: ToolArtifactPersistence['persistArchivedToolResult'];
+  readArchivedToolResult: ToolArtifactPersistence['readArchivedToolResult'];
+  runtimeCommitStore: RuntimeCommitStore;
+  safeSendToRenderer: (channel: string, ...args: unknown[]) => void;
+  getRuntime: () => SessionManager;
+  getLookupPricing: () => PricingLookup;
+}
+
+/**
+ * Build the real `ai-sdk` backend factory (arch R5). Pure move of main.ts's
+ * `backends.register('ai-sdk', async (ctx) => …)` closure. Two module-scoped
+ * seams that resolve AFTER the registration point are injected as accessors:
+ * `getRuntime` (the SessionManager is constructed after registration) and
+ * `getLookupPricing` (a mutable pricing lookup reassigned by usage IPC + startup;
+ * read live per `recordLlmCall`, snapshotted once for the `lookupPricing` field —
+ * matching the original module-`let` closure semantics exactly).
+ */
+export function createAiSdkBackendFactory(deps: AiSdkBackendFactoryDeps): BackendFactory {
+  const {
+    isComputerUseRealModelE2e,
+    ensureMcpReady,
+    getReadyConnection,
+    buildSubscriptionModelFetch,
+    systemPromptService,
+    mcpManager,
+    permissionEngine,
+    taskLedgerStore,
+    telemetryRepo,
+    artifactStore,
+    desktopSessionSkillHosts,
+    riveTools,
+    officeTools,
+    browserTools,
+    computerUseTools,
+    agentTeamLeadTools,
+    builtinTools,
+    toolAvailability,
+    persistToolArtifacts,
+    persistArchivedToolResult,
+    readArchivedToolResult,
+    runtimeCommitStore,
+    safeSendToRenderer,
+    getRuntime,
+    getLookupPricing,
+  } = deps;
+
+  return async (ctx) => {
+    // MCP is optional. A corrupt mcp.json remains visible in the MCP module,
+    // but must not prevent builtin-only conversations from creating a backend.
+    await ensureMcpReady().catch(() => {});
+    const { connection, apiKey, model } = await getReadyConnection(ctx.header.llmConnectionSlug, ctx.header.model);
+    const modelFetch = buildSubscriptionModelFetch(connection, ctx.sessionId, model);
+    const memoryPromptSnapshot = await systemPromptService.buildLocalMemoryPromptFragment();
+    const supportsVision = modelSupportsVision(connection, model);
+    const candidateTools = isComputerUseRealModelE2e
+      ? computerUseTools
+      : ctx.tools
+        ? [...ctx.tools]
+        : [...builtinTools, ...buildMcpTools(mcpManager)];
+    const candidateToolAvailability = isComputerUseRealModelE2e
+      ? { economy: false, groups: [] }
+      : toolAvailability;
+    // Expert-team lead: a main session (ctx.tools undefined) labeled
+    // `mode:expert-team:<teamId>` gets the team-bound expert_dispatch tool.
+    // Child turns receive scoped `ctx.tools` and inherit the label, but must NOT
+    // get expert_dispatch — members cannot spawn nested teams.
+    const expertTeamId = ctx.tools ? undefined : expertTeamIdFromLabels(ctx.header.labels);
+    const expertDispatchTool = expertTeamId
+      ? buildExpertDispatchToolForTeamId(expertTeamId, { taskLedger: taskLedgerStore })
+      : undefined;
+    const agentTeam = ctx.agentTeam ?? (expertTeamId
+      ? { role: 'lead' as const, teamId: expertTeamId, agentId: 'lead' }
+      : undefined);
+    const backendTools = computerUseToolsForModel(
+      candidateTools,
+      computerUseTools,
+      supportsVision,
+    );
+    const backendToolAvailability = computerUseAvailabilityForModel(
+      candidateToolAvailability,
+      supportsVision,
+    );
+    const backendToolNames = new Set([
+      ...backendTools.map((tool) => tool.name),
+      ...(expertDispatchTool ? [expertDispatchTool.name, ...agentTeamLeadTools.map((tool) => tool.name)] : []),
+    ]);
+    const backendCapabilities = new Set<string>();
+    for (const [capability, tools] of [
+      ['rive', riveTools],
+      ['office', officeTools],
+      ['browser', browserTools],
+      ['computer_use', computerUseTools],
+    ] as const) {
+      if (tools.some((tool) => backendToolNames.has(tool.name))) backendCapabilities.add(capability);
+    }
+    const backendSkillHost: HostCapabilities = {
+      toolNames: backendToolNames,
+      capabilities: backendCapabilities,
+    };
+    // Child backends share the parent sessionId but intentionally have a
+    // narrower tool surface. They do not receive the Desktop Skill tool, so
+    // they must not overwrite the parent session's resolver entry.
+    if (!ctx.tools) desktopSessionSkillHosts.set(ctx.sessionId, backendSkillHost);
+
+    return new AiSdkBackend({
+      sessionId: ctx.sessionId,
+      header: { ...ctx.header, model },
+      appendMessage: ctx.appendMessage ?? ((message) => ctx.store.appendMessage(ctx.sessionId, message)),
+      connection,
+      apiKey: apiKey ?? '',
+      modelId: model,
+      permissionEngine,
+      modelFactory: (input) => getAIModel({ ...input, fetch: modelFetch }),
+      tools: expertDispatchTool
+        ? [...backendTools, expertDispatchTool, ...agentTeamLeadTools]
+        : backendTools,
+      agentTeam,
+      toolAvailability: backendToolAvailability,
+      spawnChildAgent: (input) => getRuntime().spawnChildAgent(ctx.sessionId, input),
+      listChildAgents: () => getRuntime().listChildAgents(ctx.sessionId),
+      readChildAgentOutput: (input) => getRuntime().readChildAgentOutput(ctx.sessionId, input),
+      providerOptions: buildProviderOptions(connection, model, ctx.header.thinkingLevel),
+      contextBudget: buildDefaultContextBudgetPolicy(connection, {
+        name: 'desktop-default-history-budget',
+        modelId: model,
+      }),
+      systemPrompt: ({ cwd }) => systemPromptService.buildBackendSystemPrompt(ctx.header, cwd, {
+        memoryFragment: memoryPromptSnapshot,
+        childInstruction: ctx.systemPrompt,
+        skillBudget: { contextWindow: resolveSelectedModelContextWindow(connection, model) },
+        host: backendSkillHost,
+      }),
+      turnTailPrompt: ({ cwd, sessionId }) => systemPromptService.buildTurnTailPrompt(cwd, sessionId),
+      shellRunContextSummary: ctx.shellRunContextSummary,
+      lookupPricing: getLookupPricing(),
+      recordLlmCall: (event: LlmCallRecord) => recordLlmCall({ repo: telemetryRepo, lookupPricing: getLookupPricing() }, event),
+      recordToolInvocation: (event: ToolInvocationRecord) =>
+        recordToolInvocation(
+          { repo: telemetryRepo },
+          // PR-AGENT-WEB-SEARCH-TOOL-0: scrub the query out of the
+          // telemetry record. The agent passes the raw user query as
+          // the tool argument; persisting it in `argsSummary` would
+          // leak user-derived content into the usage log.
+          event.toolName === WEB_SEARCH_TOOL_NAME
+            ? { ...event, argsSummary: undefined }
+            : event,
+        ),
+      recordToolArtifacts: (event: ToolArtifactRecorderInput) => persistToolArtifacts(ctx.header.cwd, event),
+      archiveToolResult: (event: ToolResultArchiveRecorderInput) => persistArchivedToolResult(event),
+      readToolResultArchive: (event: ToolResultArchiveReaderInput) => readArchivedToolResult(event),
+      readAttachmentBytes: createAttachmentByteReader({ artifactStore, sessionId: ctx.sessionId }),
+      ...(runtimeCommitStore
+        ? { runtimeCommitSink: runtimeCommitStore }
+        : {}),
+      supportsVision,
+      loadHistoryCompact: (event) => loadHistoryCompactBlocksFromArtifacts(artifactStore, event),
+      loadHistoryCompactCheckpoint: ctx.loadHistoryCompactCheckpoint,
+      summarizeHistoryCompact: buildLlmHistorySummarizer({
+        // Reuse the same connection/model the session already drives, so the
+        // summary stays consistent with the model that will consume it.
+        resolveModel: () =>
+          getAIModel({ connection, apiKey: apiKey ?? '', modelId: model, fetch: modelFetch }),
+        providerOptions: buildProviderOptions(connection, model, ctx.header.thinkingLevel),
+      }),
+      loadSynthesisCache: (event) => loadSynthesisCacheBlocksFromArtifacts(artifactStore, event),
+      writeSynthesisCache: (event) => persistSynthesisCacheBlocksToArtifacts(artifactStore, event, {
+        onArtifactCreated: (artifact) => {
+          safeSendToRenderer('artifacts:changed', {
+            reason: 'created',
+            artifactId: artifact.id,
+            sessionId: artifact.sessionId,
+            ts: Date.now(),
+          });
+        },
+      }),
+      recordRunTrace: ctx.recordRunTrace,
+      recordHistoryCompactCheckpoint: ctx.recordHistoryCompactCheckpoint,
+      loadTurnRuntimeEvents: ctx.loadTurnRuntimeEvents,
+      recordActiveFullCompactBlock: ctx.recordActiveFullCompactBlock,
+      recordSemanticCompactBlock: ctx.recordSemanticCompactBlock,
+      newId: randomUUID,
+      now: Date.now,
+    });
+  };
+}
+
+interface StreamEventsOptions {
+  turnId: string;
+  goalBoundary: SessionGoalBoundary;
+  activity?: SessionActivityLease;
+  observeEvent?: (event: SessionEvent) => void;
+}
+
+interface StreamEventsResult {
+  turnId: string;
+  ok: boolean;
+  error?: string;
+  outcome: GoalTurnOutcome;
+}
+
+export type StreamEvents = (
+  sessionId: string,
+  iterator: AsyncIterable<SessionEvent>,
+  options: StreamEventsOptions,
+) => Promise<StreamEventsResult>;
+
+export interface SessionStreamerDeps {
+  sessionActivities: SessionActivityRegistry;
+  goalWiring: GoalWiring;
+  openGateway: OpenGatewayService;
+  computerUseOverlay: AssembledTools['computerUseOverlay'];
+  computerUseTools: AssembledTools['computerUseTools'];
+  safeSendToRenderer: (channel: string, ...args: unknown[]) => void;
+  emitSessionsChanged: (reason: SessionChangedReason, sessionId?: string) => void;
+}
+
+function isStatusChangingSessionEvent(event: SessionEvent): boolean {
+  return event.type === 'permission_request' ||
+    event.type === 'permission_decision_ack' ||
+    event.type === 'complete' ||
+    event.type === 'abort' ||
+    event.type === 'error';
+}
+
+function isTurnStatusChangingSessionEvent(event: SessionEvent): boolean {
+  return event.type === 'complete' || event.type === 'abort' || event.type === 'error';
+}
+
+/**
+ * Session event fan-out plumbing (arch R5). Pure move of main.ts's `streamEvents`
+ * plus its two event-classifier helpers. Returns the `streamEvents` function that
+ * every turn-driving call site in main.ts drives; behavior is identical to the
+ * in-main.ts original.
+ */
+export function createSessionStreamer(deps: SessionStreamerDeps): StreamEvents {
+  const {
+    sessionActivities,
+    goalWiring,
+    openGateway,
+    computerUseOverlay,
+    computerUseTools,
+    safeSendToRenderer,
+    emitSessionsChanged,
+  } = deps;
+
+  return function streamEvents(
+    sessionId: string,
+    iterator: AsyncIterable<SessionEvent>,
+    options: StreamEventsOptions,
+  ): Promise<StreamEventsResult> {
+    let userAppendBroadcasted = false;
+    const turnId = options.turnId;
+    const started = startDesktopSessionTurn({
+      sessionId,
+      events: iterator,
+      turnId,
+      goalBoundary: options.goalBoundary,
+      activities: sessionActivities,
+      ...(options.activity ? { activity: options.activity } : {}),
+      beginExternalTurn: (externalSessionId, externalTurnId) =>
+        goalWiring.coordinator.beginExternalTurn(externalSessionId, externalTurnId),
+      onEvent: (event) => {
+        if (!userAppendBroadcasted) {
+          emitSessionsChanged('message-appended', sessionId);
+          userAppendBroadcasted = true;
+        }
+        safeSendToRenderer(`sessions:event:${sessionId}`, event);
+        openGateway.publishSessionEvent(sessionId, event);
+        if (isStatusChangingSessionEvent(event)) {
+          emitSessionsChanged('status-change', sessionId);
+        }
+        if (isTurnStatusChangingSessionEvent(event)) {
+          emitSessionsChanged('turn-status-change', sessionId);
+          computerUseOverlay.clearForSession(sessionId);
+          computerUseTools.clearSession(sessionId);
+        }
+        options.observeEvent?.(event);
+      },
+      onStreamError: (error) => {
+        const event = {
+          type: 'error',
+          id: randomUUID(),
+          turnId,
+          ts: Date.now(),
+          recoverable: false,
+          code: errorCode(error),
+          reason: errorReason(error),
+          message: errorMessage(error),
+        } satisfies SessionEvent;
+        safeSendToRenderer(`sessions:event:${sessionId}`, event);
+        openGateway.publishSessionEvent(sessionId, event);
+        emitSessionsChanged('status-change', sessionId);
+        emitSessionsChanged('turn-status-change', sessionId);
+        computerUseOverlay.clearForSession(sessionId);
+        computerUseTools.clearSession(sessionId);
+      },
+      onDrained: () => {
+        emitSessionsChanged('message-appended', sessionId);
+      },
+    });
+    if (started.kind === 'unavailable') throw new Error(started.reason);
+    return started.completion.then((outcome) => {
+      const failureReason = outcome.kind === 'errored' || outcome.kind === 'suspended'
+        ? outcome.reason
+        : undefined;
+      return {
+        turnId,
+        ok: outcome.kind === 'completed',
+        ...(failureReason ? { error: failureReason } : {}),
+        outcome,
+      };
+    });
+  };
+}

--- a/apps/desktop/src/main/settings-runtime-effects.ts
+++ b/apps/desktop/src/main/settings-runtime-effects.ts
@@ -1,0 +1,127 @@
+import { isDeepResearchSession } from '@maka/core';
+import type {
+  AppSettings,
+  PermissionMode,
+  SessionChangedReason,
+  UpdateAppSettingsInput,
+} from '@maka/core';
+import { setActiveProxy } from '@maka/runtime';
+import type { BotRegistry, SessionManager } from '@maka/runtime';
+import type { createSettingsStore } from '@maka/storage';
+import { preserveSensitivePlaceholders } from './settings-ipc-helpers.js';
+import { maskNetworkSettings, toContractNetworkSettings } from './network-settings-main.js';
+import type { OpenGatewayService } from './open-gateway.js';
+import type { KeepSystemAwakeController } from './keep-system-awake.js';
+
+type SettingsStore = ReturnType<typeof createSettingsStore>;
+
+export interface SettingsRuntimeEffectsDeps {
+  settingsStore: SettingsStore;
+  botRegistry: BotRegistry;
+  openGateway: OpenGatewayService;
+  keepSystemAwake: KeepSystemAwakeController;
+  runtime: SessionManager;
+  safeSendToRenderer: (channel: string, ...args: unknown[]) => void;
+  emitSessionsChanged: (reason: SessionChangedReason, sessionId?: string) => void;
+}
+
+export interface SettingsRuntimeEffects {
+  /** Merge a settings patch, re-hydrating masked secret placeholders from the
+   *  persisted values so the renderer never has to round-trip a real secret. */
+  normalizeSettingsPatch(patch: UpdateAppSettingsInput): Promise<UpdateAppSettingsInput>;
+  /** Apply the side effects a settings change implies on the live process:
+   *  proxy, bot bridges, open-gateway, per-session permission mode, keep-awake. */
+  applySettingsRuntimeEffects(settings: AppSettings, patch: UpdateAppSettingsInput): Promise<void>;
+  /** Re-apply the full set of runtime effects after an external (config-file)
+   *  settings edit, then notify the renderer to re-read. */
+  handleExternalSettingsChange(): Promise<void>;
+}
+
+/**
+ * Settings runtime-effects cluster extracted from main.ts (arch R5). Pure move
+ * of `normalizeSettingsPatch` / `applySettingsRuntimeEffects` /
+ * `syncDefaultPermissionModeToSessions` (internal) / `handleExternalSettingsChange`.
+ * The keep-awake effect (#1207) rides `applySettingsRuntimeEffects` unchanged.
+ * All process-scoped collaborators are injected so the bodies stay behaviorally
+ * identical to their in-main.ts originals.
+ */
+export function createSettingsRuntimeEffects(
+  deps: SettingsRuntimeEffectsDeps,
+): SettingsRuntimeEffects {
+  const {
+    settingsStore,
+    botRegistry,
+    openGateway,
+    keepSystemAwake,
+    runtime,
+    safeSendToRenderer,
+    emitSessionsChanged,
+  } = deps;
+
+  async function normalizeSettingsPatch(patch: UpdateAppSettingsInput): Promise<UpdateAppSettingsInput> {
+    const current = await settingsStore.get();
+    return preserveSensitivePlaceholders(patch, current);
+  }
+
+  async function applySettingsRuntimeEffects(settings: AppSettings, patch: UpdateAppSettingsInput): Promise<void> {
+    if (patch.network) {
+      const network = toContractNetworkSettings(settings.network);
+      setActiveProxy(network.proxy);
+      safeSendToRenderer('settings:network:changed', maskNetworkSettings(network));
+    }
+    if (patch.botChat) {
+      await botRegistry.applySettings(settings.botChat);
+    }
+    if (patch.openGateway) {
+      const status = await openGateway.sync(settings.openGateway);
+      safeSendToRenderer('gateway:statusChanged', status);
+    }
+    if (patch.chatDefaults?.permissionMode) {
+      await syncDefaultPermissionModeToSessions(settings.chatDefaults.permissionMode);
+    }
+    if (patch.system) {
+      // Start/stop the power-save blocker the instant the toggle flips so the
+      // capability reflects the user's choice without waiting for a relaunch.
+      keepSystemAwake.apply(settings.system.keepSystemAwake);
+    }
+  }
+
+  async function syncDefaultPermissionModeToSessions(mode: Exclude<PermissionMode, 'explore'>): Promise<void> {
+    const sessions = await runtime.listSessions();
+    await Promise.all(sessions.map(async (session) => {
+      if (session.permissionMode === mode) return;
+      if (isDeepResearchSession(session.labels)) return;
+      if (session.status === 'running' || session.status === 'waiting_for_user') return;
+      try {
+        await runtime.setPermissionMode(session.id, mode);
+        emitSessionsChanged('mode-change', session.id);
+      } catch {
+        // Best effort: the persisted global default is still the authority for
+        // new sessions; busy sessions can be reconciled on a later change.
+      }
+    }));
+  }
+
+  async function handleExternalSettingsChange(): Promise<void> {
+    try {
+      const settings = await settingsStore.get();
+      const fullPatch: UpdateAppSettingsInput = {
+        network: settings.network,
+        botChat: settings.botChat,
+        openGateway: settings.openGateway,
+        system: settings.system,
+      };
+      await applySettingsRuntimeEffects(settings, fullPatch);
+    } catch (error) {
+      console.error('[config-watcher] failed to apply external settings change:', error);
+    }
+    // Always notify renderer, even on partial failure above
+    safeSendToRenderer('settings:externalChanged', { ts: Date.now() });
+  }
+
+  return {
+    normalizeSettingsPatch,
+    applySettingsRuntimeEffects,
+    handleExternalSettingsChange,
+  };
+}

--- a/notes/frontend-architecture-map-2026-07-19.md
+++ b/notes/frontend-architecture-map-2026-07-19.md
@@ -113,8 +113,42 @@ workspaces are exit 0 today; R1 makes them also report ZERO hints. Storybook sto
   AUDIT_PORT_BASE=24500 alignment auditor exit 0 (all 11 fixtures clean — full-app boot
   proves main.ts still assembles), turn-narrative CDP smoke renders the chat surface (10
   turns + composer). R5/R6 line boundaries below shift up by ~247.
-- [ ] **R5 — main.ts settings-runtime-effects + session-stream core splits (~L1360–1642).
-  Requires maintainer-approved contract re-pin.** Same direct-pin constraint as R4.
+- [x] **R5 — main.ts settings-runtime-effects + session-stream core splits (shipped
+  `chore/arch-round-5`, main.ts 1656 → 1372, −284).** Two pure-move modules under
+  `apps/desktop/src/main/` (one commit each). Post-R4 the clusters had shifted far from
+  the map's pre-R4 estimates — session-stream sat EARLY (modelSupportsVision + the ai-sdk
+  register at ~L720–861, before registerIpc), settings runtime-effects at ~L1145–1204;
+  true ranges were re-read at implementation time.
+  `settings-runtime-effects.ts` (127 lines) exports `createSettingsRuntimeEffects(deps)`
+  → `{ normalizeSettingsPatch, applySettingsRuntimeEffects, handleExternalSettingsChange }`
+  (internal `syncDefaultPermissionModeToSessions`); deps = settingsStore / botRegistry /
+  openGateway / keepSystemAwake / runtime / safeSendToRenderer / emitSessionsChanged.
+  The keep-awake runtime-effect (#1207) rides `applySettingsRuntimeEffects` byte-identical.
+  `session-stream.ts` (409 lines) exports `createAiSdkBackendFactory(deps): BackendFactory`
+  (the entire `backends.register('ai-sdk', …)` closure + the internal `modelSupportsVision`)
+  and `createSessionStreamer(deps): StreamEvents` (`streamEvents` + the two event
+  classifiers + StreamEventsOptions/Result). Entanglement seams handled without behavior
+  change: `getRuntime: () => runtime` (SessionManager is constructed AFTER the register
+  point — the register call stays put so registry-construction order is preserved) and
+  `getLookupPricing: () => lookupPricing` (the module-`let` is reassigned by usage IPC +
+  startup; used in BOTH the snapshot `lookupPricing` field and the live-read
+  `recordLlmCall` closure — a single accessor reproduces both exactly). `desktopSessionSkillHosts`
+  Map + `sessionActivities` + the `lookupPricing` let + `runtime` + the fake/e2e backend
+  registers + every `streamEvents` call site stay in main.ts. Contract re-pins
+  (maintainer-authorized): added both module paths to the
+  `main-process-contract-source-helpers` aggregator; switched three direct-main.ts readers
+  to the combined source keeping every assertion — `attachment-frontend-contract`
+  (modelSupportsVision + `const supportsVision` + `supportsVision,` vision pin, which was
+  main.ts-anchored → re-pinned to the aggregator), `ipc-surface-contract` (memoryPromptSnapshot
+  + buildBackendSystemPrompt childInstruction), `web-search-telemetry-scrub-contract`
+  (argsSummary scrub); allowlisted the moved `[config-watcher]` console.error at its new
+  path in check-console.mjs. `main-process-wiring-contract` (registerIpc anchor) untouched.
+  Gates: desktop 2744 + ui 196 suites green, 4-tsconfig + ui typecheck clean, check-dead-css
+  clean, knip ×2 exit 0 (zero hints), AUDIT_PORT_BASE=24700 alignment auditor exit 0 (all 11
+  fixtures clean — full-app boot proves main.ts still assembles + registers the ai-sdk
+  backend), CDP smoke: turn-narrative renders chat turns + composer + textarea (the hot
+  path), settings-general renders 65 interactive controls (settings-runtime-effects feeds
+  it). R6 line boundary below shifts up by ~284.
 - [ ] **R6 — main.ts startup/lifecycle module (~L1642–1865). Requires maintainer-approved
   contract re-pin.** The post-`registerIpc()` startup/lifecycle tail. Same constraint.
   (main.ts is 1871 lines total; R4–R6 line boundaries are the audit's approximate ranges

--- a/scripts/check-console.mjs
+++ b/scripts/check-console.mjs
@@ -36,6 +36,10 @@ const ALLOW = new Map([
   ],
   ['apps/desktop/src/main/main.ts', 'dev-gated by VITE_DEV_SERVER_URL / NODE_ENV (PR100).'],
   [
+    'apps/desktop/src/main/settings-runtime-effects.ts',
+    'external-settings apply failure is a main-process diagnostic, no secrets (moved from main.ts, arch R5).',
+  ],
+  [
     'apps/desktop/src/main/app-ipc-main.ts',
     'visual-smoke capture marker is fixture-gated and stdout-parsed by capture tooling (moved from main.ts, #1084).',
   ],


### PR DESCRIPTION
Round 5 of notes/frontend-architecture-map-2026-07-19.md: **main.ts 1656 → 1372 (−284)**, both clusters extracted in full (no escape hatch needed).

- **settings-runtime-effects.ts** (127 L): createSettingsRuntimeEffects(deps) → normalizeSettingsPatch / applySettingsRuntimeEffects (network/bot/gateway/permission-mode/keep-awake #1207 effects byte-identical) / handleExternalSettingsChange.
- **session-stream.ts** (409 L): createAiSdkBackendFactory (the whole backends.register('ai-sdk') closure incl. modelSupportsVision, contract text verbatim) + createSessionStreamer.
- Semantics preserved with care: the register call SITE stays at its original position (registry-construction order); module-let mutations (runtime, lookupPricing) injected as accessors so both snapshot-read and live-read closures keep exact behavior; 9 streamEvents call sites untouched in main.ts.
- Contracts: modules added to the main-process source aggregator; attachment-frontend (vision pin), ipc-surface, web-search-telemetry-scrub switched to combined-source with every assertion kept; wiring-contract (registerIpc anchor) untouched; one console allowlist path updated.
- Proof: auditor boots all 11 fixtures clean; CDP turn-narrative renders the full chat hot path; settings-general renders 65 controls.

Gates (merged tree): desktop 2744 · ui 196 · typecheck · check-dead-css · knip ×2 = 0. Implemented by an opus worktree agent; R6 boundary shifted −284 in the map.