### PR TITLE
fix(scripts): repin cu-real-model-launcher test to session-stream split

### DIFF
--- a/scripts/cu-real-model-launcher.test.mjs
+++ b/scripts/cu-real-model-launcher.test.mjs
@@ -13,7 +13,15 @@ import {
 } from './cu-real-model-launcher.mjs';
 
 const launcher = await readFile(new URL('./cu-real-model-launcher.mjs', import.meta.url), 'utf8');
-const main = await readFile(new URL('../apps/desktop/src/main/main.ts', import.meta.url), 'utf8');
+// The ai-sdk backend wiring (the isComputerUseRealModelE2e tool / economy
+// branches) moved into session-stream.ts (arch R5); scan main.ts + the
+// extracted module together so the isolation-gate pins follow the split.
+const main = (
+  await Promise.all([
+    readFile(new URL('../apps/desktop/src/main/main.ts', import.meta.url), 'utf8'),
+    readFile(new URL('../apps/desktop/src/main/session-stream.ts', import.meta.url), 'utf8'),
+  ])
+).join('\n');
 
 test('real-model launcher uses an isolated profile and the production Desktop IPC path', () => {
   assert.match(launcher, /mkdtemp\(join\(tmpdir\(\), 'maka-cu-real-model-'\)\)/);


### PR DESCRIPTION
## Summary

R5 (#1248) moved the `isComputerUseRealModelE2e` tool / economy branches from `main.ts` into `session-stream.ts` and repinned the three `apps/desktop/src/main/__tests__/` contract tests to the combined main-process source. It missed `scripts/cu-real-model-launcher.test.mjs`, which still read `main.ts` alone — so its `Desktop isolation gate does not enable FakeBackend` case stopped matching `? computerUseTools` and `? { economy: false, groups: [] }` (those expressions now live in `session-stream.ts`), turning main CI red (run 29695233566).

Scan `main.ts` + `session-stream.ts` together — the same follow-the-split shape as the R5 contract repins — so the isolation-gate pins follow the extracted module. `scripts/` is `.mjs` and can't import the `.ts` `readMainProcessCombinedSource` helper, so this covers exactly the two files R5 split between instead of the full 38-file aggregator list. Test-only; no production code changes.

## Verification

- Reproduced red locally before the fix: `node --test scripts/cu-real-model-launcher.test.mjs` → `Desktop isolation gate does not enable FakeBackend` fails on `isComputerUseRealModelE2e…? computerUseTools`, matching CI run 29695233566.
- Green after: same command → 9/9 pass.
- `npm run test:scripts` → 116/116 pass (no other scripts test regressed).
- `npx @biomejs/biome check scripts/cu-real-model-launcher.test.mjs` → clean.
- Not run: `typecheck`, `e2e`, and `run-workspace-tests-parallel` — no TS production code or package code touched.