### PR TITLE
chore(main): extract startup/lifecycle into app-lifecycle.ts (arch R6)

### DIFF
--- a/apps/desktop/src/main/__tests__/main-process-contract-source-helpers.ts
+++ b/apps/desktop/src/main/__tests__/main-process-contract-source-helpers.ts
@@ -7,6 +7,7 @@ const REPO_ROOT = resolve(import.meta.dirname, '../../../../..');
 export const MAIN_PROCESS_SOURCE_REPO_PATHS: readonly string[] = [
   'apps/desktop/src/main/main.ts',
   'apps/desktop/src/main/app-ipc-main.ts',
+  'apps/desktop/src/main/app-lifecycle.ts',
   'apps/desktop/src/main/bot-incoming-main.ts',
   'apps/desktop/src/main/browser-ipc-main.ts',
   'apps/desktop/src/main/config-ipc-main.ts',

--- a/apps/desktop/src/main/__tests__/runtime-resume-routing-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/runtime-resume-routing-contract.test.ts
@@ -3,6 +3,7 @@ import { readFile } from 'node:fs/promises';
 import { resolve } from 'node:path';
 import { describe, it } from 'node:test';
 import { readRendererShellSource } from './renderer-shell-source-helpers.js';
+import { readMainProcessCombinedSource } from './main-process-contract-source-helpers.js';
 
 const REPO_ROOT = resolve(import.meta.dirname, '../../../../..');
 
@@ -53,8 +54,11 @@ describe('runtime resume desktop routing contract', () => {
   });
 
   it('startup recovery auto-continues only behind the safe-boundary feature flag', async () => {
-    const main = await readFile(resolve(REPO_ROOT, 'apps/desktop/src/main/main.ts'), 'utf8');
-    const recovery = main.match(/async function recoverInterruptedSessionsOnStartup\(\): Promise<void> \{[\s\S]*?\n\}/)?.[0] ?? '';
+    // R6: recoverInterruptedSessionsOnStartup moved to app-lifecycle.ts (nested
+    // in wireAppLifecycle), so read the combined source and tolerate the now
+    // in-function indented block closer.
+    const main = await readMainProcessCombinedSource();
+    const recovery = main.match(/async function recoverInterruptedSessionsOnStartup\(\): Promise<void> \{[\s\S]*?\n  \}/)?.[0] ?? '';
 
     assert.match(recovery, /MAKA_RUNTIME_SAFE_BOUNDARY_RESUME !== '1'/);
     assert.match(recovery, /runtime\.planLatestAuthoritativeSafeBoundaryContinuation\(session\.id\)/);

--- a/apps/desktop/src/main/__tests__/session-startup-recovery-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/session-startup-recovery-contract.test.ts
@@ -2,6 +2,7 @@ import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { readFile } from 'node:fs/promises';
 import { join } from 'node:path';
+import { readMainProcessCombinedSource } from './main-process-contract-source-helpers.js';
 
 const REPO_ROOT = new URL('../../../../..', import.meta.url).pathname;
 
@@ -27,9 +28,12 @@ describe('session startup recovery contract', () => {
     // runId. This contract pins all three legs: recovery still runs at
     // startup, it runs inside runBackgroundStartup (not before the
     // window), and the kernel guard that makes that safe stays put.
-    const src = await readFile(join(REPO_ROOT, 'apps/desktop/src/main/main.ts'), 'utf8');
+    // R6: the startup/lifecycle tail (whenReady flow + runBackgroundStartup +
+    // recoverInterruptedSessionsOnStartup) moved to app-lifecycle.ts. Read the
+    // combined main-process source so the ordering + recovery pins follow it.
+    const src = await readMainProcessCombinedSource();
     const sessionManager = await readFile(join(REPO_ROOT, 'packages/runtime/src/session-manager.ts'), 'utf8');
-    const backgroundBlock = src.match(/async function runBackgroundStartup\(\): Promise<void> \{[\s\S]*?\n\}/)?.[0] ?? '';
+    const backgroundBlock = src.match(/async function runBackgroundStartup\(\): Promise<void> \{[\s\S]*?\n  \}/)?.[0] ?? '';
 
     assert.match(src, /async function recoverInterruptedSessionsOnStartup\(\): Promise<void>/);
     assert.match(backgroundBlock, /await recoverInterruptedSessionsOnStartup\(\);/, 'recovery must run inside background startup');

--- a/apps/desktop/src/main/__tests__/single-instance-lock-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/single-instance-lock-contract.test.ts
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 import { readFile } from 'node:fs/promises';
 import { resolve } from 'node:path';
+import { readMainProcessCombinedSource } from './main-process-contract-source-helpers.js';
 
 const MAIN_TS = resolve(import.meta.dirname, '../../../../../apps/desktop/src/main/main.ts');
 
@@ -30,7 +31,10 @@ describe('single-instance lock contract', () => {
   });
 
   it('second-instance shares behavior with activate: focus an existing window, or create one if none exists', async () => {
-    const src = await readFile(MAIN_TS, 'utf8');
+    // R6: the second-instance / activate registrations moved to
+    // app-lifecycle.ts (focusOrCreateMainWindow itself stays in main.ts), so
+    // read the combined main-process source to follow both across the split.
+    const src = await readMainProcessCombinedSource();
 
     // Regression guard for Astro-Han review (#494) P1: a second launch
     // attempt after all windows were closed (app still alive, e.g. macOS

--- a/apps/desktop/src/main/__tests__/subscription-shared-credential-store.test.ts
+++ b/apps/desktop/src/main/__tests__/subscription-shared-credential-store.test.ts
@@ -13,6 +13,7 @@ import { readdir, readFile } from 'node:fs/promises';
 import { dirname, resolve } from 'node:path';
 import { describe, it } from 'node:test';
 import { fileURLToPath } from 'node:url';
+import { readMainProcessCombinedSource } from './main-process-contract-source-helpers.js';
 
 const DESKTOP_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..', '..');
 const OAUTH_DIR = resolve(DESKTOP_ROOT, 'src', 'main', 'oauth');
@@ -129,16 +130,19 @@ describe('OAuth subscription token authority (shared CredentialStore)', () => {
         `oauth/${file} must not invoke safeStorage`,
       );
     }
-    const mainSrc = await readFile(resolve(DESKTOP_ROOT, 'src', 'main', 'main.ts'), 'utf8');
+    // R6: credential startup moved to app-lifecycle.ts. Read the combined
+    // main-process source so the "hand safeStorage over, never invoke it" pin
+    // follows the code to its new home.
+    const mainSrc = await readMainProcessCombinedSource();
     assert.doesNotMatch(
       mainSrc,
       /safeStorage\s*\./,
-      'main.ts must only hand safeStorage to the legacy importers, never call it',
+      'main process must only hand safeStorage to the legacy importers, never call it',
     );
   });
 
   it('main.ts runs the one-shot legacy token import at startup, non-fatally', async () => {
-    const src = await readFile(resolve(DESKTOP_ROOT, 'src', 'main', 'main.ts'), 'utf8');
+    const src = await readMainProcessCombinedSource();
     assert.match(
       src,
       /try\s*\{[\s\S]{0,600}importLegacyOAuthTokenFiles\(\{[\s\S]*?\}\);?[\s\S]{0,600}catch/,
@@ -154,7 +158,7 @@ describe('OAuth subscription token authority (shared CredentialStore)', () => {
   });
 
   it('finishes credential migration before the first window can issue OAuth mutations', async () => {
-    const src = await readFile(resolve(DESKTOP_ROOT, 'src', 'main', 'main.ts'), 'utf8');
+    const src = await readMainProcessCombinedSource();
     const credentialStartup = src.indexOf('await runCredentialStartup();');
     const backgroundStartup = src.indexOf('const backgroundStartup = runBackgroundStartup();');
     const createWindow = src.indexOf('await mainWindowController.createWindow();', backgroundStartup);

--- a/apps/desktop/src/main/app-lifecycle.ts
+++ b/apps/desktop/src/main/app-lifecycle.ts
@@ -1,0 +1,335 @@
+import { app, nativeImage, safeStorage } from 'electron';
+import { mkdir } from 'node:fs/promises';
+import { join } from 'node:path';
+import { buildPricingLookup, setActiveProxy } from '@maka/runtime';
+import type { BotRegistry, SessionManager, ShellRunProcessManager } from '@maka/runtime';
+import type { McpClientManager } from '@maka/mcp';
+import type {
+  createConnectionStore,
+  createSettingsStore,
+  createTelemetryRepo,
+  openRuntimeEventPersistence,
+} from '@maka/storage';
+import { migrateLegacyCredentials } from './credential-store.js';
+import type { createFileCredentialStore } from './credential-store.js';
+import { startConfigFileWatcher, type ConfigFileWatcher } from './config-file-watcher.js';
+import { toContractNetworkSettings } from './network-settings-main.js';
+import { importLegacyOAuthTokenFiles } from './oauth/shared-credential-bridge.js';
+import { seedVisualSmokeFixture } from './visual-smoke-fixture.js';
+import type { resolveVisualSmokeFixture } from './visual-smoke-fixture.js';
+import type { OpenGatewayService } from './open-gateway.js';
+import type { KeepSystemAwakeController } from './keep-system-awake.js';
+import type { createPlanReminderMainService } from './plan-reminders-main.js';
+import type { createDailyReviewMainService } from './daily-review-main.js';
+import type { createMainAutomationWiring } from './automation-wiring.js';
+import type { createMainGoalWiring } from './goal-wiring.js';
+import type { createMainWindowController } from './main-window.js';
+import type { assembleDesktopTools } from './tool-assembly.js';
+import type { StreamEvents } from './session-stream.js';
+import type { SettingsIpcHandle } from './settings-ipc-main.js';
+
+type AssembledTools = ReturnType<typeof assembleDesktopTools>;
+type PricingLookup = ReturnType<typeof buildPricingLookup>;
+
+export interface AppLifecycleDeps {
+  isIsolatedE2e: boolean;
+  visualSmokeFixture: ReturnType<typeof resolveVisualSmokeFixture>;
+  workspaceRoot: string;
+  credentialStore: ReturnType<typeof createFileCredentialStore>;
+  connectionStore: ReturnType<typeof createConnectionStore>;
+  settingsStore: ReturnType<typeof createSettingsStore>;
+  telemetryRepo: ReturnType<typeof createTelemetryRepo>;
+  keepSystemAwake: KeepSystemAwakeController;
+  botRegistry: BotRegistry;
+  openGateway: OpenGatewayService;
+  planReminders: ReturnType<typeof createPlanReminderMainService>;
+  dailyReview: ReturnType<typeof createDailyReviewMainService>;
+  automationWiring: ReturnType<typeof createMainAutomationWiring>;
+  goalWiring: ReturnType<typeof createMainGoalWiring>;
+  computerUse: AssembledTools['computerUse'];
+  computerUseOverlay: AssembledTools['computerUseOverlay'];
+  shellRuns: ShellRunProcessManager;
+  mcpManager: McpClientManager;
+  runtimePersistence: Awaited<ReturnType<typeof openRuntimeEventPersistence>>;
+  mainWindowController: ReturnType<typeof createMainWindowController>;
+  runtime: SessionManager;
+  streamEvents: StreamEvents;
+  /** Focus-or-create for the main window; stays in main.ts next to the
+   *  controller and is registered here on `second-instance` / `activate`. */
+  focusOrCreateMainWindow: () => void;
+  emitConnectionListChanged: () => void;
+  handleExternalSettingsChange: () => Promise<void>;
+  /** Accessor for the settings IPC handle, which is assigned inside
+   *  main.ts's `registerIpc()`; teardown disposes it if present. */
+  getSettingsIpc: () => SettingsIpcHandle | undefined;
+  /** Reassigns the module-scoped pricing lookup in main.ts, which is read
+   *  live by the session streamer and the usage IPC handler. */
+  setLookupPricing: (value: PricingLookup) => void;
+}
+
+/**
+ * Startup / lifecycle cluster extracted from main.ts (arch R6). Pure move of the
+ * post-`registerIpc()` tail: the `app.whenReady()` startup flow (dock icon,
+ * fixture seeding, credential startup, window creation, background startup),
+ * `runCredentialStartup` / `runBackgroundStartup` / `ensureBootstrapConnection` /
+ * `recoverInterruptedSessionsOnStartup`, the `window-all-closed` and `before-quit`
+ * handlers, and `runBeforeQuitCleanup`. Startup ORDER is the product, so the
+ * bodies stay behaviorally identical to their in-main.ts originals; every
+ * process-scoped collaborator is injected. The single-instance lock and
+ * `registerIpc()` anchor stay in main.ts. Call this once, at the same point the
+ * inline `app.whenReady()` used to sit (immediately after `registerIpc()`).
+ */
+export function wireAppLifecycle(deps: AppLifecycleDeps): void {
+  const {
+    isIsolatedE2e,
+    visualSmokeFixture,
+    workspaceRoot,
+    credentialStore,
+    connectionStore,
+    settingsStore,
+    telemetryRepo,
+    keepSystemAwake,
+    botRegistry,
+    openGateway,
+    planReminders,
+    dailyReview,
+    automationWiring,
+    goalWiring,
+    computerUse,
+    computerUseOverlay,
+    shellRuns,
+    mcpManager,
+    runtimePersistence,
+    mainWindowController,
+    runtime,
+    streamEvents,
+    focusOrCreateMainWindow,
+    emitConnectionListChanged,
+    handleExternalSettingsChange,
+    getSettingsIpc,
+    setLookupPricing,
+  } = deps;
+
+  let configWatcher: ConfigFileWatcher | undefined;
+
+  async function recoverInterruptedSessionsOnStartup(): Promise<void> {
+    try {
+      await runtime.recoverInterruptedSessions();
+      if (process.env.MAKA_RUNTIME_SAFE_BOUNDARY_RESUME !== '1') return;
+      for (const session of await runtime.listSessions()) {
+        const plan = await runtime.planLatestAuthoritativeSafeBoundaryContinuation(session.id);
+        if (!plan.continuation) continue;
+        const iterator = runtime.resumeSafeBoundaryContinuation(plan.continuation);
+        void streamEvents(session.id, iterator, {
+          turnId: plan.continuation.turnId,
+          goalBoundary: 'none',
+        });
+      }
+    } catch {
+      // Best-effort: startup should still reach the renderer so users can inspect
+      // and repair any remaining local session state.
+    }
+  }
+
+  async function ensureBootstrapConnection(): Promise<void> {
+    await mkdir(workspaceRoot, { recursive: true });
+    if ((await connectionStore.list()).length > 0) return;
+
+    if (process.env.ANTHROPIC_API_KEY) {
+      const slug = 'env-anthropic';
+      await connectionStore.create({
+        slug,
+        name: 'Anthropic (env)',
+        providerType: 'anthropic',
+        defaultModel: 'claude-sonnet-4-5-20250929',
+      });
+      await credentialStore.setSecret(slug, 'api_key', process.env.ANTHROPIC_API_KEY);
+      await connectionStore.setDefault(slug);
+      // Bootstrap runs in BACKGROUND startup (#456): the renderer may have
+      // already seeded its connection list from the onboarding snapshot,
+      // so push the change or the model picker stays empty until an
+      // unrelated action refreshes it.
+      emitConnectionListChanged();
+      return;
+    }
+
+    if (process.env.OPENAI_API_KEY) {
+      const slug = 'env-openai';
+      await connectionStore.create({
+        slug,
+        name: 'OpenAI (env)',
+        providerType: 'openai',
+        defaultModel: 'gpt-4o-mini',
+      });
+      await credentialStore.setSecret(slug, 'api_key', process.env.OPENAI_API_KEY);
+      await connectionStore.setDefault(slug);
+      emitConnectionListChanged();
+    }
+  }
+
+  app.whenReady().then(async () => {
+    // PR-GRAY-CARD-LIFT-0 (WAWQAQ msg `0eb99429` 2026-06-20): set the
+    // app's dock icon (macOS) so the dev `npm start` run shows Maka's
+    // brand mark instead of the generic Electron icon. Packaged
+    // builds get the icon via .app bundle Info.plist; this covers the
+    // dev path.
+    if (process.platform === 'darwin' && app.dock) {
+      if (process.env.MAKA_VISUAL_SMOKE_FIXTURE || isIsolatedE2e) {
+        // PR-VISUAL-SMOKE-HEADLESS: hide the dock icon so the spawned
+        // Electron runs as an accessory app — no dock bounce, and it
+        // never becomes frontmost / steals focus from the developer's
+        // active window during a capture run or an E2E run.
+        app.dock.hide();
+      } else {
+        try {
+          const iconPath = join(import.meta.dirname, '..', '..', 'assets', 'icon.png');
+          app.dock.setIcon(nativeImage.createFromPath(iconPath));
+        } catch (error) {
+          console.error('[icon] failed to set dock icon:', error);
+        }
+      }
+    }
+
+    // Credential migration is the one startup phase that must finish before an
+    // interactive window exists: OAuth logout is otherwise able to race the
+    // one-shot legacy import. The work is local and normally a missing-file
+    // check; all non-critical startup below still runs behind the first paint.
+    // The renderer's first
+    // IPC calls (session enumeration, settings read, connection listing)
+    // all read from stores that are initialized synchronously at module load,
+    // so they succeed regardless of whether background startup has
+    // settled. Any state that background startup mutates is pushed to the
+    // renderer via the existing `sessions:changed` / `connections:event`
+    // / `settings:bots:statusChanged` channels, so the UI converges lazily.
+    // Visual-smoke fixture mode wipes and reseeds the whole workspace
+    // (`rm -rf` first). That wipe must finish BEFORE the window opens and
+    // before background startup touches the workspace: createWindow reads
+    // the settings store, and a concurrent wipe lands inside the store's
+    // read-or-create write (mkdir → tmp → rename), rejecting createWindow
+    // so the window never appears. Fixture runs trade first-paint latency
+    // for determinism by definition; production launches skip this await.
+    if (visualSmokeFixture) {
+      console.log(`[visual-smoke] scenario=${visualSmokeFixture.scenario} workspace=${workspaceRoot}`);
+      await seedVisualSmokeFixture({ workspaceRoot, fixture: visualSmokeFixture, credentialStore });
+    }
+    await runCredentialStartup();
+    app.on('second-instance', focusOrCreateMainWindow);
+    app.on('activate', focusOrCreateMainWindow);
+    const backgroundStartup = runBackgroundStartup();
+    await mainWindowController.createWindow();
+    // Keep the process alive until background work settles so schedulers
+    // / bridges aren't torn down mid-start by a fast window-all-closed.
+    await backgroundStartup;
+  });
+
+  async function runCredentialStartup(): Promise<void> {
+    // One-time migration of credentials.json off Electron safeStorage so
+    // the pure-Node runtime can read it (issue #32). Runs before any
+    // credential read/write below; failure is non-fatal (legacy file is
+    // left intact and later credential reads fail closed with guidance).
+    try {
+      await migrateLegacyCredentials(workspaceRoot, safeStorage);
+    } catch (error) {
+      console.error('[credentials] migration off safeStorage failed; legacy file left intact:', error);
+    }
+    // One-shot import of pre-#1125 safeStorage-encrypted OAuth token
+    // files into the shared CredentialStore, which is the only token
+    // authority from here on. Best-effort like the migration above:
+    // files that cannot be decrypted are left intact for a later start.
+    try {
+      const userDataDir = app.getPath('userData');
+      const reports = await importLegacyOAuthTokenFiles({
+        credentialStore,
+        decryptor: safeStorage,
+        files: [
+          { slug: 'claude-subscription', filePath: join(userDataDir, '.claude_subscription_token') },
+          { slug: 'codex-subscription', filePath: join(userDataDir, '.codex_subscription_token') },
+          { slug: 'cursor-subscription', filePath: join(userDataDir, '.cursor_subscription_token') },
+          { slug: 'antigravity-subscription', filePath: join(userDataDir, '.antigravity_subscription_token') },
+        ],
+      });
+      for (const report of reports) {
+        const log = report.outcome === 'failed' ? console.error : console.log;
+        log(`[credentials] legacy OAuth token file for ${report.slug}: ${report.outcome}`, report.error ?? '');
+      }
+    } catch (error) {
+      console.error('[credentials] legacy OAuth token import failed; files left intact:', error);
+    }
+  }
+
+  /**
+   * Non-critical startup work that must NOT block the first window paint.
+   *
+   * `setActiveProxy` must be applied before any network-bearing step
+   * (`botRegistry.applySettings`, `openGateway.sync`); pricing depends on
+   * `telemetryRepo.load()`. Everything here is best-effort and logged on
+   * failure — none of it should prevent the user from seeing and interacting
+   * with the app shell.
+   */
+  async function runBackgroundStartup(): Promise<void> {
+    // Visual-smoke seeding happens synchronously in `whenReady` before the
+    // window opens (see there for why); only the real bootstrap runs here.
+    if (!visualSmokeFixture) {
+      await ensureBootstrapConnection();
+    }
+    const settings = await settingsStore.get();
+    setActiveProxy(toContractNetworkSettings(settings.network).proxy);
+    // Re-hold the power-save blocker at launch if the user left it enabled, so
+    // scheduled tasks survive machine sleep across restarts.
+    keepSystemAwake.apply(settings.system.keepSystemAwake);
+    await telemetryRepo.load();
+    setLookupPricing(buildPricingLookup(telemetryRepo.listPricingOverrides()));
+    await recoverInterruptedSessionsOnStartup();
+    await botRegistry.applySettings(settings.botChat);
+    await openGateway.sync(settings.openGateway);
+    await planReminders.refreshTimers();
+    dailyReview.startScheduler();
+    configWatcher = startConfigFileWatcher(workspaceRoot, {
+      onConnectionsChanged: () => emitConnectionListChanged(),
+      onSettingsChanged: () => void handleExternalSettingsChange(),
+    });
+    automationWiring.scheduler.start();
+  }
+
+  app.on('window-all-closed', () => {
+    computerUseOverlay.destroyAll();
+    if (process.platform !== 'darwin') app.quit();
+  });
+
+  let beforeQuitCleanupComplete = false;
+  let beforeQuitCleanupStarted = false;
+
+  app.on('before-quit', (event) => {
+    if (beforeQuitCleanupComplete) return;
+    event.preventDefault();
+    if (beforeQuitCleanupStarted) return;
+    beforeQuitCleanupStarted = true;
+    void runBeforeQuitCleanup().finally(() => {
+      beforeQuitCleanupComplete = true;
+      app.quit();
+    });
+  });
+
+  async function runBeforeQuitCleanup(): Promise<void> {
+    automationWiring.scheduler.dispose();
+    goalWiring.coordinator.dispose();
+    goalWiring.manager.dispose();
+    configWatcher?.stop();
+    planReminders.stopTimers();
+    dailyReview.stopScheduler();
+    getSettingsIpc()?.dispose();
+    const results = await Promise.allSettled([
+      Promise.resolve().then(() => computerUseOverlay.destroyAll()),
+      Promise.resolve().then(() => computerUse.backend?.dispose?.()),
+      botRegistry.stopAll(),
+      openGateway.stop(),
+      Promise.resolve(mainWindowController.disposeBrowserViews()),
+      shellRuns.terminateAll(),
+      mcpManager.close(),
+    ]);
+    for (const result of results) {
+      if (result.status === 'rejected') console.error('[shutdown] cleanup failed:', result.reason);
+    }
+    runtimePersistence.close();
+  }
+}

--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -1,8 +1,7 @@
-import { app, ipcMain, nativeImage, powerSaveBlocker, safeStorage, shell } from 'electron';
+import { app, ipcMain, powerSaveBlocker, shell } from 'electron';
 import { randomUUID } from 'node:crypto';
-import { mkdir } from 'node:fs/promises';
 import { join } from 'node:path';
-import { startConfigFileWatcher, type ConfigFileWatcher } from './config-file-watcher.js';
+import { wireAppLifecycle } from './app-lifecycle.js';
 import {
   DEFAULT_SESSION_NAME,
   filterModelVisibleTaskLedgerTasks,
@@ -26,7 +25,6 @@ import { OpenAiCodexService } from './oauth/openai-codex-service.js';
 import { GitHubCopilotSubscriptionService } from './oauth/github-copilot-subscription-service.js';
 import { CursorSubscriptionService } from './oauth/cursor-subscription-service.js';
 import { AntigravitySubscriptionService } from './oauth/antigravity-subscription-service.js';
-import { importLegacyOAuthTokenFiles } from './oauth/shared-credential-bridge.js';
 import type { WorkspacePrivacyContext } from '@maka/core/incognito';
 import { ok } from '@maka/core/settings/result';
 import {
@@ -40,7 +38,6 @@ import {
   buildProviderOptions,
   buildPricingLookup,
   BotRegistry,
-  setActiveProxy,
   ShellRunProcessManager,
   SessionActivityRegistry,
 } from '@maka/runtime';
@@ -73,15 +70,12 @@ import {
   errorMessage,
   requireReadyConnection,
 } from './chat-readiness.js';
-import { createFileCredentialStore, migrateLegacyCredentials } from './credential-store.js';
+import { createFileCredentialStore } from './credential-store.js';
 import { bindOnboardingDeps, createOnboardingService } from './onboarding-service.js';
 import { handleQuickChatStart as runQuickChatStart, type QuickChatResult } from './quick-chat.js';
 import { createDailyReviewArchiveStore } from './daily-review-archive-store.js';
 import { resolveDefaultPermissionMode } from './permission-mode-default.js';
-import {
-  resolveVisualSmokeFixture,
-  seedVisualSmokeFixture,
-} from './visual-smoke-fixture.js';
+import { resolveVisualSmokeFixture } from './visual-smoke-fixture.js';
 import { resolveBuildInfo } from './build-info.js';
 import { OpenGatewayService } from './open-gateway.js';
 import { LocalMemoryService } from './local-memory-service.js';
@@ -98,7 +92,6 @@ import { createMainTaskLedgerWiring } from './task-ledger-wiring.js';
 import { createMainAutomationWiring, evaluateAutomationCanFire } from './automation-wiring.js';
 import { createMainGoalWiring } from './goal-wiring.js';
 import { createOAuthModelConnectionsMainService } from './oauth-model-connections-main.js';
-import { toContractNetworkSettings } from './network-settings-main.js';
 import { registerMemoryIpc } from './memory-ipc-main.js';
 import { registerSubscriptionIpc } from './subscription-ipc-main.js';
 import { registerBrowserIpc } from './browser-ipc-main.js';
@@ -195,7 +188,6 @@ try {
   throw error;
 }
 const workspaceRoot = join(app.getPath('userData'), 'workspaces', visualSmokeFixture?.workspaceName ?? 'default');
-let configWatcher: ConfigFileWatcher | undefined;
 // 保持系统唤醒 (settings.system.keepSystemAwake): holds an Electron
 // `powerSaveBlocker` so in-process scheduled tasks keep firing while the
 // machine would otherwise sleep. Injected with electron's blocker; the
@@ -1140,228 +1132,39 @@ function emitSessionsChanged(
   safeSendToRenderer('sessions:changed', event);
 }
 
-async function recoverInterruptedSessionsOnStartup(): Promise<void> {
-  try {
-    await runtime.recoverInterruptedSessions();
-    if (process.env.MAKA_RUNTIME_SAFE_BOUNDARY_RESUME !== '1') return;
-    for (const session of await runtime.listSessions()) {
-      const plan = await runtime.planLatestAuthoritativeSafeBoundaryContinuation(session.id);
-      if (!plan.continuation) continue;
-      const iterator = runtime.resumeSafeBoundaryContinuation(plan.continuation);
-      void streamEvents(session.id, iterator, {
-        turnId: plan.continuation.turnId,
-        goalBoundary: 'none',
-      });
-    }
-  } catch {
-    // Best-effort: startup should still reach the renderer so users can inspect
-    // and repair any remaining local session state.
-  }
-}
-
-async function ensureBootstrapConnection(): Promise<void> {
-  await mkdir(workspaceRoot, { recursive: true });
-  if ((await connectionStore.list()).length > 0) return;
-
-  if (process.env.ANTHROPIC_API_KEY) {
-    const slug = 'env-anthropic';
-    await connectionStore.create({
-      slug,
-      name: 'Anthropic (env)',
-      providerType: 'anthropic',
-      defaultModel: 'claude-sonnet-4-5-20250929',
-    });
-    await credentialStore.setSecret(slug, 'api_key', process.env.ANTHROPIC_API_KEY);
-    await connectionStore.setDefault(slug);
-    // Bootstrap runs in BACKGROUND startup (#456): the renderer may have
-    // already seeded its connection list from the onboarding snapshot,
-    // so push the change or the model picker stays empty until an
-    // unrelated action refreshes it.
-    emitConnectionListChanged();
-    return;
-  }
-
-  if (process.env.OPENAI_API_KEY) {
-    const slug = 'env-openai';
-    await connectionStore.create({
-      slug,
-      name: 'OpenAI (env)',
-      providerType: 'openai',
-      defaultModel: 'gpt-4o-mini',
-    });
-    await credentialStore.setSecret(slug, 'api_key', process.env.OPENAI_API_KEY);
-    await connectionStore.setDefault(slug);
-    emitConnectionListChanged();
-  }
-}
-
 registerIpc();
 
-app.whenReady().then(async () => {
-  // PR-GRAY-CARD-LIFT-0 (WAWQAQ msg `0eb99429` 2026-06-20): set the
-  // app's dock icon (macOS) so the dev `npm start` run shows Maka's
-  // brand mark instead of the generic Electron icon. Packaged
-  // builds get the icon via .app bundle Info.plist; this covers the
-  // dev path.
-  if (process.platform === 'darwin' && app.dock) {
-    if (process.env.MAKA_VISUAL_SMOKE_FIXTURE || isIsolatedE2e) {
-      // PR-VISUAL-SMOKE-HEADLESS: hide the dock icon so the spawned
-      // Electron runs as an accessory app — no dock bounce, and it
-      // never becomes frontmost / steals focus from the developer's
-      // active window during a capture run or an E2E run.
-      app.dock.hide();
-    } else {
-      try {
-        const iconPath = join(import.meta.dirname, '..', '..', 'assets', 'icon.png');
-        app.dock.setIcon(nativeImage.createFromPath(iconPath));
-      } catch (error) {
-        console.error('[icon] failed to set dock icon:', error);
-      }
-    }
-  }
-
-  // Credential migration is the one startup phase that must finish before an
-  // interactive window exists: OAuth logout is otherwise able to race the
-  // one-shot legacy import. The work is local and normally a missing-file
-  // check; all non-critical startup below still runs behind the first paint.
-  // The renderer's first
-  // IPC calls (session enumeration, settings read, connection listing)
-  // all read from stores that are initialized synchronously at module load,
-  // so they succeed regardless of whether background startup has
-  // settled. Any state that background startup mutates is pushed to the
-  // renderer via the existing `sessions:changed` / `connections:event`
-  // / `settings:bots:statusChanged` channels, so the UI converges lazily.
-  // Visual-smoke fixture mode wipes and reseeds the whole workspace
-  // (`rm -rf` first). That wipe must finish BEFORE the window opens and
-  // before background startup touches the workspace: createWindow reads
-  // the settings store, and a concurrent wipe lands inside the store's
-  // read-or-create write (mkdir → tmp → rename), rejecting createWindow
-  // so the window never appears. Fixture runs trade first-paint latency
-  // for determinism by definition; production launches skip this await.
-  if (visualSmokeFixture) {
-    console.log(`[visual-smoke] scenario=${visualSmokeFixture.scenario} workspace=${workspaceRoot}`);
-    await seedVisualSmokeFixture({ workspaceRoot, fixture: visualSmokeFixture, credentialStore });
-  }
-  await runCredentialStartup();
-  app.on('second-instance', focusOrCreateMainWindow);
-  app.on('activate', focusOrCreateMainWindow);
-  const backgroundStartup = runBackgroundStartup();
-  await mainWindowController.createWindow();
-  // Keep the process alive until background work settles so schedulers
-  // / bridges aren't torn down mid-start by a fast window-all-closed.
-  await backgroundStartup;
+wireAppLifecycle({
+  isIsolatedE2e,
+  visualSmokeFixture,
+  workspaceRoot,
+  credentialStore,
+  connectionStore,
+  settingsStore,
+  telemetryRepo,
+  keepSystemAwake,
+  botRegistry,
+  openGateway,
+  planReminders,
+  dailyReview,
+  automationWiring,
+  goalWiring,
+  computerUse,
+  computerUseOverlay,
+  shellRuns,
+  mcpManager,
+  runtimePersistence,
+  mainWindowController,
+  runtime,
+  streamEvents,
+  focusOrCreateMainWindow,
+  emitConnectionListChanged,
+  handleExternalSettingsChange,
+  getSettingsIpc: () => settingsIpc,
+  setLookupPricing: (value) => {
+    lookupPricing = value;
+  },
 });
-
-async function runCredentialStartup(): Promise<void> {
-  // One-time migration of credentials.json off Electron safeStorage so
-  // the pure-Node runtime can read it (issue #32). Runs before any
-  // credential read/write below; failure is non-fatal (legacy file is
-  // left intact and later credential reads fail closed with guidance).
-  try {
-    await migrateLegacyCredentials(workspaceRoot, safeStorage);
-  } catch (error) {
-    console.error('[credentials] migration off safeStorage failed; legacy file left intact:', error);
-  }
-  // One-shot import of pre-#1125 safeStorage-encrypted OAuth token
-  // files into the shared CredentialStore, which is the only token
-  // authority from here on. Best-effort like the migration above:
-  // files that cannot be decrypted are left intact for a later start.
-  try {
-    const userDataDir = app.getPath('userData');
-    const reports = await importLegacyOAuthTokenFiles({
-      credentialStore,
-      decryptor: safeStorage,
-      files: [
-        { slug: 'claude-subscription', filePath: join(userDataDir, '.claude_subscription_token') },
-        { slug: 'codex-subscription', filePath: join(userDataDir, '.codex_subscription_token') },
-        { slug: 'cursor-subscription', filePath: join(userDataDir, '.cursor_subscription_token') },
-        { slug: 'antigravity-subscription', filePath: join(userDataDir, '.antigravity_subscription_token') },
-      ],
-    });
-    for (const report of reports) {
-      const log = report.outcome === 'failed' ? console.error : console.log;
-      log(`[credentials] legacy OAuth token file for ${report.slug}: ${report.outcome}`, report.error ?? '');
-    }
-  } catch (error) {
-    console.error('[credentials] legacy OAuth token import failed; files left intact:', error);
-  }
-}
-
-/**
- * Non-critical startup work that must NOT block the first window paint.
- *
- * `setActiveProxy` must be applied before any network-bearing step
- * (`botRegistry.applySettings`, `openGateway.sync`); pricing depends on
- * `telemetryRepo.load()`. Everything here is best-effort and logged on
- * failure — none of it should prevent the user from seeing and interacting
- * with the app shell.
- */
-async function runBackgroundStartup(): Promise<void> {
-  // Visual-smoke seeding happens synchronously in `whenReady` before the
-  // window opens (see there for why); only the real bootstrap runs here.
-  if (!visualSmokeFixture) {
-    await ensureBootstrapConnection();
-  }
-  const settings = await settingsStore.get();
-  setActiveProxy(toContractNetworkSettings(settings.network).proxy);
-  // Re-hold the power-save blocker at launch if the user left it enabled, so
-  // scheduled tasks survive machine sleep across restarts.
-  keepSystemAwake.apply(settings.system.keepSystemAwake);
-  await telemetryRepo.load();
-  lookupPricing = buildPricingLookup(telemetryRepo.listPricingOverrides());
-  await recoverInterruptedSessionsOnStartup();
-  await botRegistry.applySettings(settings.botChat);
-  await openGateway.sync(settings.openGateway);
-  await planReminders.refreshTimers();
-  dailyReview.startScheduler();
-  configWatcher = startConfigFileWatcher(workspaceRoot, {
-    onConnectionsChanged: () => emitConnectionListChanged(),
-    onSettingsChanged: () => void handleExternalSettingsChange(),
-  });
-  automationWiring.scheduler.start();
-}
-
-app.on('window-all-closed', () => {
-  computerUseOverlay.destroyAll();
-  if (process.platform !== 'darwin') app.quit();
-});
-
-let beforeQuitCleanupComplete = false;
-let beforeQuitCleanupStarted = false;
-
-app.on('before-quit', (event) => {
-  if (beforeQuitCleanupComplete) return;
-  event.preventDefault();
-  if (beforeQuitCleanupStarted) return;
-  beforeQuitCleanupStarted = true;
-  void runBeforeQuitCleanup().finally(() => {
-    beforeQuitCleanupComplete = true;
-    app.quit();
-  });
-});
-
-async function runBeforeQuitCleanup(): Promise<void> {
-  automationWiring.scheduler.dispose();
-  goalWiring.coordinator.dispose();
-  goalWiring.manager.dispose();
-  configWatcher?.stop();
-  planReminders.stopTimers();
-  dailyReview.stopScheduler();
-  settingsIpc?.dispose();
-  const results = await Promise.allSettled([
-    Promise.resolve().then(() => computerUseOverlay.destroyAll()),
-    Promise.resolve().then(() => computerUse.backend?.dispose?.()),
-    botRegistry.stopAll(),
-    openGateway.stop(),
-    Promise.resolve(mainWindowController.disposeBrowserViews()),
-    shellRuns.terminateAll(),
-    mcpManager.close(),
-  ]);
-  for (const result of results) {
-    if (result.status === 'rejected') console.error('[shutdown] cleanup failed:', result.reason);
-  }
-  runtimePersistence.close();
-}
 
 function computerUseCapabilityInput() {
   const serviceState = computerUse.backend?.serviceState?.();

--- a/notes/frontend-architecture-map-2026-07-19.md
+++ b/notes/frontend-architecture-map-2026-07-19.md
@@ -149,10 +149,50 @@ workspaces are exit 0 today; R1 makes them also report ZERO hints. Storybook sto
   backend), CDP smoke: turn-narrative renders chat turns + composer + textarea (the hot
   path), settings-general renders 65 interactive controls (settings-runtime-effects feeds
   it). R6 line boundary below shifts up by ~284.
-- [ ] **R6 — main.ts startup/lifecycle module (~L1642–1865). Requires maintainer-approved
-  contract re-pin.** The post-`registerIpc()` startup/lifecycle tail. Same constraint.
-  (main.ts is 1871 lines total; R4–R6 line boundaries are the audit's approximate ranges
-  and must be re-verified against the tip at implementation time.)
+- [x] **R6 — main.ts startup/lifecycle module (shipped `chore/arch-round-6`, main.ts
+  1372 → 1175, −197).** One pure-move module `apps/desktop/src/main/app-lifecycle.ts`
+  (335 lines) exports `wireAppLifecycle(deps): void` — the entire post-`registerIpc()`
+  startup/lifecycle tail: the `app.whenReady()` flow (dock icon / visual-smoke seeding /
+  credential startup / window creation / background startup), `runCredentialStartup` /
+  `runBackgroundStartup` / `ensureBootstrapConnection` / `recoverInterruptedSessionsOnStartup`,
+  the `window-all-closed` + `before-quit` handlers, and `runBeforeQuitCleanup`. Startup
+  ORDER (whenReady → credential migration → second-instance/activate → background startup →
+  createWindow → await) and teardown ORDER (#1197 botOnboarding/botRegistry dispose,
+  scheduler, keep-awake-dies-with-process) are byte-identical to the originals; every
+  process-scoped collaborator is injected. Entanglement seams follow the R5 accessor
+  precedent: `setLookupPricing` reassigns the module-`let` pricing lookup (read live by the
+  session streamer + usage IPC) and `getSettingsIpc: () => settingsIpc` reads the handle
+  assigned inside `registerIpc()`; `configWatcher` + the `beforeQuitCleanup{Started,Complete}`
+  flags become `wireAppLifecycle` closure state. Stayed in main.ts (injected in): the
+  single-instance lock + `registerIpc()` anchor, `focusOrCreateMainWindow` (next to the
+  window controller), `emitConnectionListChanged` / `emitSessionsChanged`,
+  `computerUseCapabilityInput`, the `lookupPricing` + `settingsIpc` module-`let`s, and
+  `keepSystemAwake`. No entangled remainder — the tail moved whole. Contract re-pins
+  (maintainer-authorized): added `app-lifecycle.ts` to the
+  `main-process-contract-source-helpers` aggregator; switched five direct-main.ts readers
+  of the moved slices to the combined source keeping every assertion —
+  `session-startup-recovery-contract` (runBackgroundStartup block + recovery + whenReady
+  ordering; block-closer regex relaxed for the now in-function indentation per the R4
+  precedent), `runtime-resume-routing-contract` (recovery block, same relaxation),
+  `subscription-shared-credential-store` (safeStorage-never-invoked + one-shot OAuth import
+  + credential-migration ordering), `single-instance-lock-contract` (the second-instance/
+  activate wiring case only — the lock + focusOrCreateMainWindow-definition assertions stay
+  on main.ts). `credential-store-secret-kinds-contract` + `computer-use-capability` +
+  `window-reveal-after-first-commit-contract` already read the combined source, so the
+  aggregator addition carried them. Allowlisted app-lifecycle.ts's startup/shutdown console
+  sites in check-console.mjs. `main-process-wiring-contract` (registerIpc anchor) untouched.
+  Startup fail-soft contracts do NOT read main.ts slices (`renderer-startup-fail-soft`
+  reads the renderer-shell + settings combined sources) — no re-pin needed. Gates: desktop
+  2744 + ui 196 suites green, 4-tsconfig + ui typecheck clean, check-dead-css clean, knip
+  ×2 exit 0 (zero hints), check-console OK, AUDIT_PORT_BASE=25100 alignment auditor exit 0
+  (all 11 fixtures clean — every fixture is a full app boot AND teardown, the strongest
+  lifecycle proof). CDP turn-narrative renders the chat surface (composer + textarea +
+  data-turn-id turns). Quit-path independently verified past the auditor's SIGKILL: a manual
+  boot + graceful `app.quit()` drove `before-quit` → `runBeforeQuitCleanup` → window
+  torn-down → **process exited code 0 @265ms, no orphan, no cleanup failures** (window
+  closes only after cleanup completes, so this proves the moved teardown ran end-to-end);
+  confirmed behavior-identical to the pre-R6 baseline. Campaign main.ts total: 1903 → 1175
+  (−728 across R4–R6).
 - [ ] **R7 — provider-connection-detail.tsx controller-hook decomposition.** 983 lines,
   17 useState — the renderer's densest remaining state cluster. Needs its own blade plan
   (which state clusters extract into which controller hooks, which contracts pin the file)

--- a/scripts/check-console.mjs
+++ b/scripts/check-console.mjs
@@ -36,6 +36,10 @@ const ALLOW = new Map([
   ],
   ['apps/desktop/src/main/main.ts', 'dev-gated by VITE_DEV_SERVER_URL / NODE_ENV (PR100).'],
   [
+    'apps/desktop/src/main/app-lifecycle.ts',
+    'startup/shutdown diagnostics (dock icon, credential migration, visual-smoke marker, cleanup failures); no secrets (moved from main.ts, arch R6).',
+  ],
+  [
     'apps/desktop/src/main/settings-runtime-effects.ts',
     'external-settings apply failure is a main-process diagnostic, no secrets (moved from main.ts, arch R5).',
   ],


### PR DESCRIPTION
Round 6 of notes/frontend-architecture-map-2026-07-19.md: **main.ts 1372 → 1175 (−197); campaign total 1903 → 1175 (−728 across R4-R6)**.

- app-lifecycle.ts (335 L): wireAppLifecycle(deps) — the whole post-registerIpc tail moved: whenReady flow (dock/fixture-seed/credential-startup/window/background-startup), runBackgroundStartup (proxy/keep-awake/pricing/recovery/bots/gateway/reminders/scheduler/watcher/automation), window-all-closed + before-quit + runBeforeQuitCleanup, config-watcher state.
- Stayed anchored in main.ts: single-instance lock, registerIpc (wiring-contract anchor), shared emitters; module-let semantics preserved via accessor injection (setLookupPricing / getSettingsIpc — R5 precedent).
- **Quit-path proof** (the auditor's SIGKILL masks quit bugs): manual fixture boot → app.quit() via main-process inspector → cleanup ran end-to-end (window teardown gated on it) → exit code 0, PID gone, zero [shutdown] failures; behavior-identical to a pre-R6 control run.
- Contracts: app-lifecycle added to the source aggregator; five direct readers switched to combined source with every assertion kept; single-instance-lock contract re-pinned for the moved handlers only; wiring-contract untouched.

Gates (merged tree): desktop 2744 · ui 196 · typecheck · check-dead-css · knip ×2 = 0 · auditor all 11 fixtures clean (each boots AND tears down). Implemented by an opus worktree agent.