### PR TITLE
refactor(headless): extract fixed prompt WAL types

### DIFF
--- a/packages/headless/src/fixed-prompt-controller.ts
+++ b/packages/headless/src/fixed-prompt-controller.ts
@@ -4,26 +4,32 @@ import { dirname, resolve } from 'node:path';
 import {
   validateHarborCellOutput,
   hashHarborSystemPrompt,
-  type HarborCellContextBudgetPolicySnapshot,
-  type HarborCellContextBudgetSummary,
-  type HarborCellContinuationSummary,
-  type HarborCellDeadlineSettlement,
   type HarborCellExecutionIdentity,
   type HarborCellOutput,
-  type HarborCellTaskToolSummary,
   type HarborCellTokenSummary,
 } from './cell-output.js';
 import type { Config } from './contracts.js';
 import { syncParentDirectory } from './immutable-file.js';
-import type { MakaChangeAuditRecord } from './change-audit.js';
+import {
+  FIXED_PROMPT_WAL_SCHEMA_VERSION,
+  type FixedPromptTaskAttemptStartedEvent,
+  type FixedPromptTaskBudgetExhaustedEvent,
+  type FixedPromptTaskCompletedEvent,
+  type FixedPromptTaskInfraFailedEvent,
+  type FixedPromptTaskPlumbingFailedEvent,
+  type FixedPromptTaskWalEvent,
+  type FixedPromptWalEvent,
+  type HarborVerifierOutcome,
+  type UnscoredCellFailureClass,
+} from './fixed-prompt-wal-types.js';
 import type { HarborBillingMode } from './harbor-task-runner.js';
 import { assertFinitePositive, assertPositiveInt, assertRatio } from './numeric-guards.js';
 
-export const FIXED_PROMPT_WAL_SCHEMA_VERSION = 1;
+export * from './fixed-prompt-wal-types.js';
+
 export const BUDGET_EXHAUSTED_RUNTIME_UNAVAILABLE_REASON = 'budget_exhausted_before_cell_output';
 const LEGACY_TIMEOUT_MISSING_EXECUTION_IDENTITY_ERROR =
   'Timed-out Harbor attempt did not produce execution identity attestation';
-type UnscoredCellFailureClass = 'infra_failed' | 'setup_failed' | 'verification_error';
 const walWriteTails = new Map<string, Promise<void>>();
 
 export interface FixedPromptTask {
@@ -43,18 +49,6 @@ export type HarborTaskRunCellOutput = HarborCellOutput & {
   traceEventsPath?: string;
   providerTelemetryPath?: string;
 };
-
-export interface HarborVerifierAttempt {
-  attempt: number;
-  classification: 'passed' | 'failed' | 'timeout' | 'infra_setup_failed' | 'infra_failed';
-  durationMs: number;
-  reward?: number;
-}
-
-export interface HarborVerifierOutcome {
-  outcome: 'passed' | 'failed' | 'candidate_timeout';
-  attempts: HarborVerifierAttempt[];
-}
 
 export interface HarborTaskRunOutput {
   harbor: {
@@ -103,259 +97,6 @@ export interface ReadHarborTaskRunOutputInput {
   harborResultPath: string;
   cellOutputPath: string;
 }
-
-export interface FixedPromptTaskCompletedEvent {
-  schemaVersion: typeof FIXED_PROMPT_WAL_SCHEMA_VERSION;
-  type: 'task_completed';
-  id: string;
-  ts: number;
-  runId: string;
-  roundId: string;
-  resumeFingerprint?: string;
-  taskId: string;
-  status: HarborCellOutput['status'];
-  passed: boolean;
-  scored: boolean;
-  eligible: boolean;
-  errorClass?: string;
-  promptHash?: string;
-  executionIdentity?: HarborCellExecutionIdentity;
-  deadlineSettlement?: HarborCellDeadlineSettlement;
-  tokenSummary?: HarborCellTokenSummary;
-  contextBudgetPolicy?: HarborCellContextBudgetPolicySnapshot;
-  contextBudgetSummary?: HarborCellContextBudgetSummary;
-  continuationSummary?: HarborCellContinuationSummary;
-  taskToolSummary?: HarborCellTaskToolSummary;
-  steps: number;
-  durationMs: number;
-  runtimeEventsPath: string;
-  traceEventsPath?: string;
-  providerTelemetryPath?: string;
-  harbor: {
-    reward: number;
-    verifierFailureSummary?: string;
-    verifier?: HarborVerifierOutcome;
-  };
-}
-
-export interface FixedPromptTaskAttemptStartedEvent {
-  schemaVersion: typeof FIXED_PROMPT_WAL_SCHEMA_VERSION;
-  type: 'task_attempt_started';
-  id: string;
-  ts: number;
-  runId: string;
-  roundId: string;
-  resumeFingerprint?: string;
-  taskId: string;
-  promptHash: string;
-}
-
-export interface FixedPromptTaskInfraFailedEvent {
-  schemaVersion: typeof FIXED_PROMPT_WAL_SCHEMA_VERSION;
-  type: 'task_infra_failed';
-  id: string;
-  ts: number;
-  runId: string;
-  roundId: string;
-  resumeFingerprint?: string;
-  taskId: string;
-  status: 'infra_failed';
-  passed: false;
-  scored: false;
-  eligible: false;
-  errorClass:
-    | 'infra_error'
-    | 'provider_billing'
-    | 'auth'
-    | 'rate_limit'
-    | 'provider_unavailable'
-    | 'network';
-  error: string;
-  providerTelemetryPath?: string;
-}
-
-export interface FixedPromptTaskBudgetExhaustedEvent {
-  schemaVersion: typeof FIXED_PROMPT_WAL_SCHEMA_VERSION;
-  type: 'task_budget_exhausted';
-  id: string;
-  ts: number;
-  runId: string;
-  roundId: string;
-  resumeFingerprint?: string;
-  taskId: string;
-  status: 'budget_exhausted';
-  passed: false;
-  scored: false;
-  eligible: boolean;
-  errorClass: 'budget_exhausted';
-  error: string;
-  evidenceErrorClass?:
-    | FixedPromptTaskPlumbingFailedEvent['errorClass']
-    | UnscoredCellFailureClass
-    | FixedPromptTaskInfraFailedEvent['errorClass'];
-  evidenceError?: string;
-  expectedPromptHash: string;
-  runtimeEventsPath?: string;
-  traceEventsPath?: string;
-  providerTelemetryPath?: string;
-  runtimeEventsUnavailableReason?: string;
-  tokenSummary?: HarborCellTokenSummary;
-  tokenSummarySource?: 'final' | 'checkpoint';
-  executionIdentity?: HarborCellExecutionIdentity;
-  contextBudgetPolicy?: HarborCellContextBudgetPolicySnapshot;
-  contextBudgetSummary?: HarborCellContextBudgetSummary;
-  continuationSummary?: HarborCellContinuationSummary;
-  taskToolSummary?: HarborCellTaskToolSummary;
-  steps?: number;
-  durationMs?: number;
-}
-
-export interface FixedPromptTaskPlumbingFailedEvent {
-  schemaVersion: typeof FIXED_PROMPT_WAL_SCHEMA_VERSION;
-  type: 'task_plumbing_failed';
-  id: string;
-  ts: number;
-  runId: string;
-  roundId: string;
-  resumeFingerprint?: string;
-  taskId: string;
-  status: 'plumbing_failed';
-  passed: false;
-  scored: false;
-  eligible: false;
-  errorClass:
-    | 'missing_token_usage'
-    | 'zero_cost_with_tokens'
-    | 'prompt_hash_mismatch'
-    | 'missing_prompt_hash'
-    | 'missing_execution_identity'
-    | 'execution_identity_mismatch'
-    | 'orphaned_sampled_attempt';
-  error: string;
-  promptHash?: string;
-  expectedPromptHash?: string;
-  tokenSummary?: HarborCellTokenSummary;
-  contextBudgetPolicy?: HarborCellContextBudgetPolicySnapshot;
-  contextBudgetSummary?: HarborCellContextBudgetSummary;
-  continuationSummary?: HarborCellContinuationSummary;
-  taskToolSummary?: HarborCellTaskToolSummary;
-  steps?: number;
-  durationMs?: number;
-  runtimeEventsPath?: string;
-  traceEventsPath?: string;
-  providerTelemetryPath?: string;
-  harbor?: {
-    reward: number;
-  };
-}
-
-export interface PromptCandidateCommittedEvent {
-  schemaVersion: typeof FIXED_PROMPT_WAL_SCHEMA_VERSION;
-  type: 'prompt_candidate_committed';
-  id: string;
-  ts: number;
-  runId: string;
-  roundId: string;
-  commitSha: string;
-  summary: string;
-  promptHash: string;
-  heldInTaskSetHash: string;
-  heldInTaskIds: readonly string[];
-  candidateRationaleHash: string;
-  candidateRationale: PromptCandidateRationale;
-}
-
-export const PROMPT_CANDIDATE_FAILURE_PATTERNS = [
-  'coverage_regression',
-  'tool_failed',
-  'max_tokens',
-  'runtime_error',
-  'verification_failed',
-  'other',
-] as const;
-
-export type PromptCandidateFailurePattern = (typeof PROMPT_CANDIDATE_FAILURE_PATTERNS)[number];
-
-export interface PromptCandidateRationale
-  extends MakaChangeAuditRecord<
-    'system_prompt',
-    string,
-    string,
-    string,
-    PromptCandidateFailurePattern
-  > {}
-
-export type PromptCandidateRewardHackScan =
-  | { decision: 'clean' }
-  | { decision: 'quarantine'; reason: string; matchedPatterns?: readonly string[] };
-
-export interface PromptCandidateDecisionEvent {
-  schemaVersion: typeof FIXED_PROMPT_WAL_SCHEMA_VERSION;
-  type: 'prompt_candidate_decided';
-  id: string;
-  ts: number;
-  runId: string;
-  roundId: string;
-  decision: 'keep' | 'discard';
-  reason: string;
-  candidateCommitSha: string;
-  previousLastKeptCommitSha: string;
-  lastKeptCommitSha: string;
-  previousHeldInReferencePassEligibleRate: number | null;
-  heldInReferencePassEligibleRate: number | null;
-  originalCommitSha: string;
-  originalHeldOutPassEligibleRate: number | null;
-  heldInPassRateNoiseBand: number;
-  heldOutPassRateNoiseBand: number;
-  rewardHackScan?: PromptCandidateRewardHackScan;
-  metrics: unknown;
-}
-
-export type RsiPredictedFixOutcome =
-  | 'improved'
-  | 'unchanged'
-  | 'regressed'
-  | 'unscored'
-  | 'missing';
-export type RsiRiskTaskOutcome = 'safe' | 'regressed' | 'unscored' | 'missing';
-export type RsiRootCauseSignalMatch = 'matched' | 'contradicted' | 'unknown';
-
-export interface RsiControllerAttributionEvent {
-  schemaVersion: typeof FIXED_PROMPT_WAL_SCHEMA_VERSION;
-  type: 'rsi_controller_attribution';
-  id: string;
-  ts: number;
-  runId: string;
-  roundId: string;
-  candidateCommitSha: string;
-  heldInTaskSetHash: string;
-  candidateRationaleHash: string;
-  evidenceRefs: readonly string[];
-  predictedFixes: Array<{ taskId: string; outcome: RsiPredictedFixOutcome }>;
-  riskTasks: Array<{ taskId: string; outcome: RsiRiskTaskOutcome }>;
-  unexpectedHeldInFlips: Array<{ taskId: string; from: string; to: string }>;
-  decision: {
-    decision: 'keep' | 'discard';
-    reason: string;
-  };
-  rootCauseSignalMatch: RsiRootCauseSignalMatch;
-}
-
-export type FixedPromptWalEvent =
-  | FixedPromptTaskAttemptStartedEvent
-  | FixedPromptTaskCompletedEvent
-  | FixedPromptTaskInfraFailedEvent
-  | FixedPromptTaskBudgetExhaustedEvent
-  | FixedPromptTaskPlumbingFailedEvent
-  | PromptCandidateCommittedEvent
-  | PromptCandidateDecisionEvent
-  | RsiControllerAttributionEvent;
-
-export type FixedPromptTaskWalEvent =
-  | FixedPromptTaskCompletedEvent
-  | FixedPromptTaskInfraFailedEvent
-  | FixedPromptTaskBudgetExhaustedEvent
-  | FixedPromptTaskPlumbingFailedEvent;
 
 export interface RunFixedPromptControllerInput {
   runId: string;

--- a/packages/headless/src/fixed-prompt-wal-types.ts
+++ b/packages/headless/src/fixed-prompt-wal-types.ts
@@ -1,0 +1,280 @@
+import type {
+  HarborCellContextBudgetPolicySnapshot,
+  HarborCellContextBudgetSummary,
+  HarborCellContinuationSummary,
+  HarborCellDeadlineSettlement,
+  HarborCellExecutionIdentity,
+  HarborCellOutput,
+  HarborCellTaskToolSummary,
+  HarborCellTokenSummary,
+} from './cell-output.js';
+import type { MakaChangeAuditRecord } from './change-audit.js';
+
+export const FIXED_PROMPT_WAL_SCHEMA_VERSION = 1;
+
+export type UnscoredCellFailureClass = 'infra_failed' | 'setup_failed' | 'verification_error';
+
+export interface HarborVerifierAttempt {
+  attempt: number;
+  classification: 'passed' | 'failed' | 'timeout' | 'infra_setup_failed' | 'infra_failed';
+  durationMs: number;
+  reward?: number;
+}
+
+export interface HarborVerifierOutcome {
+  outcome: 'passed' | 'failed' | 'candidate_timeout';
+  attempts: HarborVerifierAttempt[];
+}
+
+export interface FixedPromptTaskCompletedEvent {
+  schemaVersion: typeof FIXED_PROMPT_WAL_SCHEMA_VERSION;
+  type: 'task_completed';
+  id: string;
+  ts: number;
+  runId: string;
+  roundId: string;
+  resumeFingerprint?: string;
+  taskId: string;
+  status: HarborCellOutput['status'];
+  passed: boolean;
+  scored: boolean;
+  eligible: boolean;
+  errorClass?: string;
+  promptHash?: string;
+  executionIdentity?: HarborCellExecutionIdentity;
+  deadlineSettlement?: HarborCellDeadlineSettlement;
+  tokenSummary?: HarborCellTokenSummary;
+  contextBudgetPolicy?: HarborCellContextBudgetPolicySnapshot;
+  contextBudgetSummary?: HarborCellContextBudgetSummary;
+  continuationSummary?: HarborCellContinuationSummary;
+  taskToolSummary?: HarborCellTaskToolSummary;
+  steps: number;
+  durationMs: number;
+  runtimeEventsPath: string;
+  traceEventsPath?: string;
+  providerTelemetryPath?: string;
+  harbor: {
+    reward: number;
+    verifierFailureSummary?: string;
+    verifier?: HarborVerifierOutcome;
+  };
+}
+
+export interface FixedPromptTaskAttemptStartedEvent {
+  schemaVersion: typeof FIXED_PROMPT_WAL_SCHEMA_VERSION;
+  type: 'task_attempt_started';
+  id: string;
+  ts: number;
+  runId: string;
+  roundId: string;
+  resumeFingerprint?: string;
+  taskId: string;
+  promptHash: string;
+}
+
+export interface FixedPromptTaskInfraFailedEvent {
+  schemaVersion: typeof FIXED_PROMPT_WAL_SCHEMA_VERSION;
+  type: 'task_infra_failed';
+  id: string;
+  ts: number;
+  runId: string;
+  roundId: string;
+  resumeFingerprint?: string;
+  taskId: string;
+  status: 'infra_failed';
+  passed: false;
+  scored: false;
+  eligible: false;
+  errorClass:
+    | 'infra_error'
+    | 'provider_billing'
+    | 'auth'
+    | 'rate_limit'
+    | 'provider_unavailable'
+    | 'network';
+  error: string;
+  providerTelemetryPath?: string;
+}
+
+export interface FixedPromptTaskBudgetExhaustedEvent {
+  schemaVersion: typeof FIXED_PROMPT_WAL_SCHEMA_VERSION;
+  type: 'task_budget_exhausted';
+  id: string;
+  ts: number;
+  runId: string;
+  roundId: string;
+  resumeFingerprint?: string;
+  taskId: string;
+  status: 'budget_exhausted';
+  passed: false;
+  scored: false;
+  eligible: boolean;
+  errorClass: 'budget_exhausted';
+  error: string;
+  evidenceErrorClass?:
+    | FixedPromptTaskPlumbingFailedEvent['errorClass']
+    | UnscoredCellFailureClass
+    | FixedPromptTaskInfraFailedEvent['errorClass'];
+  evidenceError?: string;
+  expectedPromptHash: string;
+  runtimeEventsPath?: string;
+  traceEventsPath?: string;
+  providerTelemetryPath?: string;
+  runtimeEventsUnavailableReason?: string;
+  tokenSummary?: HarborCellTokenSummary;
+  tokenSummarySource?: 'final' | 'checkpoint';
+  executionIdentity?: HarborCellExecutionIdentity;
+  contextBudgetPolicy?: HarborCellContextBudgetPolicySnapshot;
+  contextBudgetSummary?: HarborCellContextBudgetSummary;
+  continuationSummary?: HarborCellContinuationSummary;
+  taskToolSummary?: HarborCellTaskToolSummary;
+  steps?: number;
+  durationMs?: number;
+}
+
+export interface FixedPromptTaskPlumbingFailedEvent {
+  schemaVersion: typeof FIXED_PROMPT_WAL_SCHEMA_VERSION;
+  type: 'task_plumbing_failed';
+  id: string;
+  ts: number;
+  runId: string;
+  roundId: string;
+  resumeFingerprint?: string;
+  taskId: string;
+  status: 'plumbing_failed';
+  passed: false;
+  scored: false;
+  eligible: false;
+  errorClass:
+    | 'missing_token_usage'
+    | 'zero_cost_with_tokens'
+    | 'prompt_hash_mismatch'
+    | 'missing_prompt_hash'
+    | 'missing_execution_identity'
+    | 'execution_identity_mismatch'
+    | 'orphaned_sampled_attempt';
+  error: string;
+  promptHash?: string;
+  expectedPromptHash?: string;
+  tokenSummary?: HarborCellTokenSummary;
+  contextBudgetPolicy?: HarborCellContextBudgetPolicySnapshot;
+  contextBudgetSummary?: HarborCellContextBudgetSummary;
+  continuationSummary?: HarborCellContinuationSummary;
+  taskToolSummary?: HarborCellTaskToolSummary;
+  steps?: number;
+  durationMs?: number;
+  runtimeEventsPath?: string;
+  traceEventsPath?: string;
+  providerTelemetryPath?: string;
+  harbor?: {
+    reward: number;
+  };
+}
+
+export interface PromptCandidateCommittedEvent {
+  schemaVersion: typeof FIXED_PROMPT_WAL_SCHEMA_VERSION;
+  type: 'prompt_candidate_committed';
+  id: string;
+  ts: number;
+  runId: string;
+  roundId: string;
+  commitSha: string;
+  summary: string;
+  promptHash: string;
+  heldInTaskSetHash: string;
+  heldInTaskIds: readonly string[];
+  candidateRationaleHash: string;
+  candidateRationale: PromptCandidateRationale;
+}
+
+export const PROMPT_CANDIDATE_FAILURE_PATTERNS = [
+  'coverage_regression',
+  'tool_failed',
+  'max_tokens',
+  'runtime_error',
+  'verification_failed',
+  'other',
+] as const;
+
+export type PromptCandidateFailurePattern = (typeof PROMPT_CANDIDATE_FAILURE_PATTERNS)[number];
+
+export interface PromptCandidateRationale
+  extends MakaChangeAuditRecord<
+    'system_prompt',
+    string,
+    string,
+    string,
+    PromptCandidateFailurePattern
+  > {}
+
+export type PromptCandidateRewardHackScan =
+  | { decision: 'clean' }
+  | { decision: 'quarantine'; reason: string; matchedPatterns?: readonly string[] };
+
+export interface PromptCandidateDecisionEvent {
+  schemaVersion: typeof FIXED_PROMPT_WAL_SCHEMA_VERSION;
+  type: 'prompt_candidate_decided';
+  id: string;
+  ts: number;
+  runId: string;
+  roundId: string;
+  decision: 'keep' | 'discard';
+  reason: string;
+  candidateCommitSha: string;
+  previousLastKeptCommitSha: string;
+  lastKeptCommitSha: string;
+  previousHeldInReferencePassEligibleRate: number | null;
+  heldInReferencePassEligibleRate: number | null;
+  originalCommitSha: string;
+  originalHeldOutPassEligibleRate: number | null;
+  heldInPassRateNoiseBand: number;
+  heldOutPassRateNoiseBand: number;
+  rewardHackScan?: PromptCandidateRewardHackScan;
+  metrics: unknown;
+}
+
+export type RsiPredictedFixOutcome =
+  | 'improved'
+  | 'unchanged'
+  | 'regressed'
+  | 'unscored'
+  | 'missing';
+export type RsiRiskTaskOutcome = 'safe' | 'regressed' | 'unscored' | 'missing';
+export type RsiRootCauseSignalMatch = 'matched' | 'contradicted' | 'unknown';
+
+export interface RsiControllerAttributionEvent {
+  schemaVersion: typeof FIXED_PROMPT_WAL_SCHEMA_VERSION;
+  type: 'rsi_controller_attribution';
+  id: string;
+  ts: number;
+  runId: string;
+  roundId: string;
+  candidateCommitSha: string;
+  heldInTaskSetHash: string;
+  candidateRationaleHash: string;
+  evidenceRefs: readonly string[];
+  predictedFixes: Array<{ taskId: string; outcome: RsiPredictedFixOutcome }>;
+  riskTasks: Array<{ taskId: string; outcome: RsiRiskTaskOutcome }>;
+  unexpectedHeldInFlips: Array<{ taskId: string; from: string; to: string }>;
+  decision: {
+    decision: 'keep' | 'discard';
+    reason: string;
+  };
+  rootCauseSignalMatch: RsiRootCauseSignalMatch;
+}
+
+export type FixedPromptWalEvent =
+  | FixedPromptTaskAttemptStartedEvent
+  | FixedPromptTaskCompletedEvent
+  | FixedPromptTaskInfraFailedEvent
+  | FixedPromptTaskBudgetExhaustedEvent
+  | FixedPromptTaskPlumbingFailedEvent
+  | PromptCandidateCommittedEvent
+  | PromptCandidateDecisionEvent
+  | RsiControllerAttributionEvent;
+
+export type FixedPromptTaskWalEvent =
+  | FixedPromptTaskCompletedEvent
+  | FixedPromptTaskInfraFailedEvent
+  | FixedPromptTaskBudgetExhaustedEvent
+  | FixedPromptTaskPlumbingFailedEvent;

--- a/packages/storage/src/__tests__/settings-store-usage.test.ts
+++ b/packages/storage/src/__tests__/settings-store-usage.test.ts
@@ -138,7 +138,15 @@ describe('SettingsStore.usageStats request logs', () => {
       // are only unique within a session, so both sessions reuse `bash`/`read`
       // ids to prove result matching stays session-scoped after the merge.
       const bashTurn = (sessionId: string, error: boolean, duration: number): StoredMessage[] => [
-        { type: 'tool_call', id: 'bash', turnId: 't1', ts: 10, toolName: 'Bash', displayName: '终端', args: {} },
+        {
+          type: 'tool_call',
+          id: 'bash',
+          turnId: 't1',
+          ts: 10,
+          toolName: 'Bash',
+          displayName: '终端',
+          args: {},
+        },
         {
           type: 'tool_result',
           id: 'bash-result',
@@ -153,7 +161,15 @@ describe('SettingsStore.usageStats request logs', () => {
 
       await seedSession(workspaceRoot, makeHeader({ id: 'session-a' }), [
         ...bashTurn('session-a', false, 20),
-        { type: 'tool_call', id: 'read', turnId: 't1', ts: 12, toolName: 'Read', displayName: '读取', args: {} },
+        {
+          type: 'tool_call',
+          id: 'read',
+          turnId: 't1',
+          ts: 12,
+          toolName: 'Read',
+          displayName: '读取',
+          args: {},
+        },
         {
           type: 'tool_result',
           id: 'read-result',


### PR DESCRIPTION
## Summary

Extract the fixed-prompt WAL schema declarations from `fixed-prompt-controller.ts` into a dedicated `fixed-prompt-wal-types.ts` module.

Existing imports through the controller remain compatible via re-export, and this refactor does not change runtime behavior.

Refs #1084

## Verification

- `npm --workspace @maka/headless run typecheck` — passed
- `npm --workspace @maka/headless run build` — passed
- `node --test packages/headless/dist/__tests__/fixed-prompt-controller.test.js` — passed, 69 tests
- `biome check packages/headless/src/fixed-prompt-controller.ts packages/headless/src/fixed-prompt-wal-types.ts` — passed
- `git diff --check` — passed

The full monorepo test suite was not run. A runtime build encountered pre-existing missing optional SDK dependencies for Lark and WeCom.