### PR TITLE
style: fix Biome format in settings-store-usage.test.ts (unbreak main CI)

### DIFF
--- a/packages/storage/src/__tests__/settings-store-usage.test.ts
+++ b/packages/storage/src/__tests__/settings-store-usage.test.ts
@@ -138,7 +138,15 @@ describe('SettingsStore.usageStats request logs', () => {
       // are only unique within a session, so both sessions reuse `bash`/`read`
       // ids to prove result matching stays session-scoped after the merge.
       const bashTurn = (sessionId: string, error: boolean, duration: number): StoredMessage[] => [
-        { type: 'tool_call', id: 'bash', turnId: 't1', ts: 10, toolName: 'Bash', displayName: '终端', args: {} },
+        {
+          type: 'tool_call',
+          id: 'bash',
+          turnId: 't1',
+          ts: 10,
+          toolName: 'Bash',
+          displayName: '终端',
+          args: {},
+        },
         {
           type: 'tool_result',
           id: 'bash-result',
@@ -153,7 +161,15 @@ describe('SettingsStore.usageStats request logs', () => {
 
       await seedSession(workspaceRoot, makeHeader({ id: 'session-a' }), [
         ...bashTurn('session-a', false, 20),
-        { type: 'tool_call', id: 'read', turnId: 't1', ts: 12, toolName: 'Read', displayName: '读取', args: {} },
+        {
+          type: 'tool_call',
+          id: 'read',
+          turnId: 't1',
+          ts: 12,
+          toolName: 'Read',
+          displayName: '读取',
+          args: {},
+        },
         {
           type: 'tool_result',
           id: 'read-result',


### PR DESCRIPTION
The `typecheck` CI job has been failing on `main` since #1254 landed: the Biome format gate (#1122) reports one unformatted file, `packages/storage/src/__tests__/settings-store-usage.test.ts` (two `tool_call` object literals need rewrapping). Every open PR that merges with current `main` inherits the failure — e.g. #1253's latest run.

This is `npx biome check --write` output on that one file, formatting only, no behavior change. Verified `npx biome check` is clean on the file afterwards.

Failing run on `main` for reference: https://github.com/maka-agent/maka-agent/actions/runs/29712288307