### PR TITLE
fix(cu): harden semantic computer tool contracts

### DIFF
--- a/packages/runtime/src/__tests__/computer-use-provider-protocol.test.ts
+++ b/packages/runtime/src/__tests__/computer-use-provider-protocol.test.ts
@@ -269,7 +269,7 @@ describe('Anthropic-compatible Computer Use product loops', () => {
         `failed semantic result must use the provider error-tool-result protocol: ${JSON.stringify(reinjectedFailure)}`,
       );
       assert.match(JSON.stringify(reinjectedFailure), /outcome_unknown/);
-      assert.match(JSON.stringify(reinjectedFailure), /computer\.type failed/);
+      assert.match(JSON.stringify(reinjectedFailure), /computer\.set_value failed/);
     });
   }
 });

--- a/packages/runtime/src/__tests__/computer-use-tools.test.ts
+++ b/packages/runtime/src/__tests__/computer-use-tools.test.ts
@@ -1,6 +1,7 @@
 import assert from 'node:assert/strict';
 import { describe, test } from 'node:test';
 import type { CuAction } from '@maka/core';
+import { zodSchema } from 'ai';
 import {
   adaptToCuAction,
   buildComputerUseTools,
@@ -198,6 +199,21 @@ describe('adaptToCuAction — flat Anthropic grammar → discriminated CuAction'
       /screenshot requires app or window_id/,
     );
   });
+});
+
+test('provider schema explains the required semantic action fields', async () => {
+  const [tool] = buildComputerUseTools({ backend: fakeBackend() });
+  const schema = (await zodSchema(tool.parameters as never).jsonSchema) as {
+    properties?: Record<string, { description?: string }>;
+  };
+
+  assert.match(schema.properties?.action?.description ?? '', /set_value requires/);
+  assert.match(schema.properties?.observation_id?.description ?? '', /Required for every action/);
+  assert.match(
+    schema.properties?.element_id?.description ?? '',
+    /Required for click_element, set_value/,
+  );
+  assert.match(schema.properties?.value?.description ?? '', /Required only for set_value/);
 });
 
 test('computer params are copied and frozen before asynchronous policy checks', () => {
@@ -822,6 +838,61 @@ describe('buildComputerUseTools — the `maka_computer` MakaTool', () => {
       base64: 'AA==',
       mimeType: 'image/png',
     });
+  });
+
+  test('semantic set_value keeps its semantic action name in the model summary', async () => {
+    const backend = fakeBackend() as CuDispatchBackend & {
+      observeApp: NonNullable<CuDispatchBackend['observeApp']>;
+      runSemantic: NonNullable<CuDispatchBackend['runSemantic']>;
+    };
+    backend.observeApp = async () =>
+      observation({
+        elements: [
+          {
+            elementId: '5',
+            role: 'AXTextField',
+            label: 'Field',
+            value: '',
+          },
+        ],
+      });
+    backend.runSemantic = async () => ({
+      outcome: {
+        ok: true,
+        tier: 'ax',
+        verified: true,
+        evidence: { path: 'ax', effect: 'confirmed' },
+      },
+      observation: observation({
+        observationId: 'backend-obs-2',
+        elements: [
+          {
+            elementId: '5',
+            role: 'AXTextField',
+            label: 'Field',
+            value: 'updated',
+          },
+        ],
+      }),
+    });
+    const [tool] = buildComputerUseTools({ backend });
+    const observed = (await tool.impl({ action: 'observe', app: 'Fixture' } as never, ctx())) as {
+      text: string;
+    };
+    const observationId = JSON.parse(observed.text).observation_id as string;
+
+    const result = (await tool.impl(
+      {
+        action: 'set_value',
+        observation_id: observationId,
+        element_id: '5',
+        value: 'updated',
+      } as never,
+      ctx(),
+    )) as { text: string };
+
+    assert.match(result.text, /computer\.set_value ok via ax/);
+    assert.doesNotMatch(result.text, /computer\.type/);
   });
 
   test('coordinate action is bound to a window-local screenshot and consumes the observation', async () => {

--- a/packages/runtime/src/__tests__/computer-use-tools.test.ts
+++ b/packages/runtime/src/__tests__/computer-use-tools.test.ts
@@ -895,6 +895,54 @@ describe('buildComputerUseTools — the `maka_computer` MakaTool', () => {
     assert.doesNotMatch(result.text, /computer\.type/);
   });
 
+  test('semantic recovery keeps the action name when fresh observation is unavailable', async () => {
+    for (const captureMode of ['missing', 'throws'] as const) {
+      const backend = fakeBackend() as CuDispatchBackend & {
+        observeApp: NonNullable<CuDispatchBackend['observeApp']>;
+        runSemantic: NonNullable<CuDispatchBackend['runSemantic']>;
+        captureObservation?: NonNullable<CuDispatchBackend['captureObservation']>;
+      };
+      backend.observeApp = async () =>
+        observation({
+          elements: [
+            {
+              elementId: '5',
+              role: 'AXTextField',
+              label: 'Field',
+              value: '',
+            },
+          ],
+        });
+      backend.runSemantic = async () => ({
+        outcome: { ok: true, tier: 'ax', verified: true },
+      });
+      if (captureMode === 'throws') {
+        backend.captureObservation = async () => {
+          throw new Error('capture failed');
+        };
+      }
+      const [tool] = buildComputerUseTools({ backend });
+      const observed = (await tool.impl({ action: 'observe', app: 'Fixture' } as never, ctx())) as {
+        text: string;
+      };
+      const observationId = JSON.parse(observed.text).observation_id as string;
+
+      const result = (await tool.impl(
+        {
+          action: 'set_value',
+          observation_id: observationId,
+          element_id: '5',
+          value: 'updated',
+        } as never,
+        ctx(),
+      )) as { text: string; error?: string };
+
+      assert.equal(result.error, 'outcome_unknown');
+      assert.match(result.text, /computer\.set_value failed: outcome_unknown/);
+      assert.doesNotMatch(result.text, /computer\.type/);
+    }
+  });
+
   test('coordinate action is bound to a window-local screenshot and consumes the observation', async () => {
     const backend = fakeBackend() as CuDispatchBackend & {
       observeApp: NonNullable<CuDispatchBackend['observeApp']>;

--- a/packages/runtime/src/computer-use-tools.ts
+++ b/packages/runtime/src/computer-use-tools.ts
@@ -901,7 +901,7 @@ export function buildComputerUseTools(deps: {
   }
 
   function deliveredWithoutFreshObservation(
-    action: CuAction,
+    action: ComputerSummaryAction,
     result: CuRunResult,
   ): ComputerToolResult {
     const evidence = summarizeEvidence(result.outcome.evidence);
@@ -1579,11 +1579,11 @@ export function buildComputerUseTools(deps: {
                 : undefined;
             } catch {
               presentation?.finish(result);
-              return deliveredWithoutFreshObservation(summaryAction, result);
+              return deliveredWithoutFreshObservation(semanticAction, result);
             }
             if (result.outcome.ok && !freshObservation) {
               presentation?.finish(result);
-              return deliveredWithoutFreshObservation(summaryAction, result);
+              return deliveredWithoutFreshObservation(semanticAction, result);
             }
             presentation?.finish(result);
             const text = summarize(semanticAction, result);

--- a/packages/runtime/src/computer-use-tools.ts
+++ b/packages/runtime/src/computer-use-tools.ts
@@ -381,28 +381,77 @@ type ComputerParams = z.infer<typeof computerParams>;
 // discriminated union above immediately at execution.
 const computerWireParams = z
   .object({
-    action: z.enum([
-      'list_apps',
-      'observe',
-      'click_element',
-      'set_value',
-      'select_text',
-      'secondary_action',
-      'press_key',
-      ...CU_ACTION_TYPES,
-    ] as [string, ...string[]]),
-    app: z.string().min(1).max(512).optional(),
-    window_id: z.number().int().positive().optional(),
-    include_screenshot: z.boolean().optional(),
-    observation_id: z.string().min(1).max(256).optional(),
-    element_id: z.string().min(1).max(256).optional(),
-    value: text.optional(),
-    coordinate: coordinate.optional(),
-    start_coordinate: coordinate.optional(),
-    text: text.optional(),
-    scroll_direction: z.enum(['up', 'down', 'left', 'right']).optional(),
-    scroll_amount: z.number().int().min(0).max(100).optional(),
-    duration: z.number().min(0).max(60).optional(),
+    action: z
+      .enum([
+        'list_apps',
+        'observe',
+        'click_element',
+        'set_value',
+        'select_text',
+        'secondary_action',
+        'press_key',
+        ...CU_ACTION_TYPES,
+      ] as [string, ...string[]])
+      .describe(
+        'Operation to perform. Required fields by action: observe/screenshot require app or window_id; click_element requires observation_id and element_id; set_value requires observation_id, element_id, and value; select_text/secondary_action require observation_id, element_id, and text; press_key requires observation_id and text; coordinate actions require observation_id plus their coordinate fields.',
+      ),
+    app: z
+      .string()
+      .min(1)
+      .max(512)
+      .optional()
+      .describe(
+        'Exact app id/name from list_apps. Required for observe unless window_id is supplied.',
+      ),
+    window_id: z
+      .number()
+      .int()
+      .positive()
+      .optional()
+      .describe('Exact window_id from list_apps or observe.'),
+    include_screenshot: z
+      .boolean()
+      .optional()
+      .describe('For observe, include a screenshot. Defaults to true.'),
+    observation_id: z
+      .string()
+      .min(1)
+      .max(256)
+      .optional()
+      .describe(
+        'Required for every action that targets an observed element or coordinate. Copy it exactly from the immediately preceding observe or fresh observation result.',
+      ),
+    element_id: z
+      .string()
+      .min(1)
+      .max(256)
+      .optional()
+      .describe(
+        'Required for click_element, set_value, select_text, and secondary_action. Copy the exact element_id from the same observation_id.',
+      ),
+    value: text
+      .optional()
+      .describe('Required only for set_value. The complete replacement value to write.'),
+    coordinate: coordinate
+      .optional()
+      .describe(
+        'Required for coordinate pointer actions. Coordinates are in the referenced observation screenshot.',
+      ),
+    start_coordinate: coordinate.optional().describe('Required only for left_click_drag.'),
+    text: text
+      .optional()
+      .describe('Required for select_text, secondary_action, press_key, type, key, and hold_key.'),
+    scroll_direction: z
+      .enum(['up', 'down', 'left', 'right'])
+      .optional()
+      .describe('Direction for scroll.'),
+    scroll_amount: z.number().int().min(0).max(100).optional().describe('Amount for scroll.'),
+    duration: z
+      .number()
+      .min(0)
+      .max(60)
+      .optional()
+      .describe('Duration in seconds for wait or hold_key.'),
     region: z
       .tuple([
         z.number().int().nonnegative(),
@@ -410,7 +459,8 @@ const computerWireParams = z
         z.number().int().nonnegative(),
         z.number().int().nonnegative(),
       ])
-      .optional(),
+      .optional()
+      .describe('Required only for zoom: [x1, y1, x2, y2] in the referenced observation.'),
   })
   .strict();
 
@@ -533,7 +583,11 @@ function summarizeEvidence(evidence: CuDispatchEvidence | undefined): string {
   return fields.length > 0 ? `; dispatch ${fields.join(', ')}` : '';
 }
 
-function summarize(action: CuAction, result: CuRunResult): string {
+type ComputerSummaryAction = {
+  type: CuAction['type'] | CuSemanticAction['type'];
+};
+
+function summarize(action: ComputerSummaryAction, result: CuRunResult): string {
   const { outcome } = result;
   const evidence = summarizeEvidence(outcome.evidence);
   if (!outcome.ok) {
@@ -1532,7 +1586,7 @@ export function buildComputerUseTools(deps: {
               return deliveredWithoutFreshObservation(summaryAction, result);
             }
             presentation?.finish(result);
-            const text = summarize(summaryAction, result);
+            const text = summarize(semanticAction, result);
             const failureClass =
               !result.outcome.ok && /ambiguous/i.test(result.outcome.message)
                 ? ('ambiguous_target' as const)

--- a/packages/storage/src/__tests__/settings-store-usage.test.ts
+++ b/packages/storage/src/__tests__/settings-store-usage.test.ts
@@ -138,7 +138,15 @@ describe('SettingsStore.usageStats request logs', () => {
       // are only unique within a session, so both sessions reuse `bash`/`read`
       // ids to prove result matching stays session-scoped after the merge.
       const bashTurn = (sessionId: string, error: boolean, duration: number): StoredMessage[] => [
-        { type: 'tool_call', id: 'bash', turnId: 't1', ts: 10, toolName: 'Bash', displayName: '终端', args: {} },
+        {
+          type: 'tool_call',
+          id: 'bash',
+          turnId: 't1',
+          ts: 10,
+          toolName: 'Bash',
+          displayName: '终端',
+          args: {},
+        },
         {
           type: 'tool_result',
           id: 'bash-result',
@@ -153,7 +161,15 @@ describe('SettingsStore.usageStats request logs', () => {
 
       await seedSession(workspaceRoot, makeHeader({ id: 'session-a' }), [
         ...bashTurn('session-a', false, 20),
-        { type: 'tool_call', id: 'read', turnId: 't1', ts: 12, toolName: 'Read', displayName: '读取', args: {} },
+        {
+          type: 'tool_call',
+          id: 'read',
+          turnId: 't1',
+          ts: 12,
+          toolName: 'Read',
+          displayName: '读取',
+          args: {},
+        },
         {
           type: 'tool_result',
           id: 'read-result',


### PR DESCRIPTION
## Summary

- expose select_text, secondary_action, and press_key as strict semantic actions on the provider-neutral computer tool
- bind semantic calls to an explicit observation and fail closed on stale or missing fields
- keep mutation summaries and provider protocol coverage aligned with the expanded action surface

## Stack

This is PR 1 of 2:

1. semantic contract (this PR)
2. background execution + real Desktop qualification (follow-up Draft)

## Base CI repair

Includes the same mechanical Biome formatting fix for `packages/storage/src/__tests__/settings-store-usage.test.ts` that is currently carried by #1255, because the latest main branch otherwise fails repository-wide format checking. It has no semantic changes and will become empty after that baseline lands.

## Validation

- repository-wide Biome lint and format check
- @maka/core, @maka/storage, @maka/runtime builds
- computer-use tool and provider protocol suites: 77 passed
- git diff check
