### PR TITLE
feat(headless): add budget-matched sampling baseline to prompt RSI

### DIFF
--- a/packages/headless/src/__tests__/helpers/prompt-optimization-loop-harness.ts
+++ b/packages/headless/src/__tests__/helpers/prompt-optimization-loop-harness.ts
@@ -178,9 +178,12 @@ function fakeHarborRunner(
     // a plumbing failure — which the stability filter drops.
     const failed = shouldFail?.(roundId, task.id) ?? false;
     const verifierFailureSummary = verifierFailureSummaryFor?.(roundId, task.id);
+    const rewardRoundId = roundId.startsWith('sampling-')
+      ? (systemPrompt.match(/candidate prompt (round-\d+)/)?.[1] ?? 'baseline-0')
+      : roundId;
     return {
       harbor: {
-        reward: failed ? 0 : rewardFor(roundId, task.id),
+        reward: failed ? 0 : rewardFor(rewardRoundId, task.id),
         ...(verifierFailureSummary ? { verifierFailureSummary } : {}),
       },
       cell: {

--- a/packages/headless/src/__tests__/prompt-acceptance-policy.test.ts
+++ b/packages/headless/src/__tests__/prompt-acceptance-policy.test.ts
@@ -339,6 +339,39 @@ describe('prompt acceptance policy', () => {
     assert.equal(decision.metrics.candidate.heldOut.passEligibleRate, 1);
   });
 
+  test('requires a reference-clearing candidate to beat the budget-matched sampling baseline', () => {
+    const decision = decidePromptAcceptance({
+      ...baseDecisionInput(),
+      previousHeldInReferencePassEligibleRate: 0.25,
+      lastKeptEvents: [completed('in-a', false), completed('in-b', false)],
+      candidateEvents: [
+        completed('in-a', true),
+        completed('in-b', false),
+        completed('out-a', true),
+      ],
+      samplingBaselineEvents: [completed('in-a', true), completed('in-b', false)],
+      samplingPromptHash: 'prompt-kept-1',
+    });
+
+    assert.equal(decision.decision, 'discard');
+    assert.equal(decision.reason, 'sampling_baseline_not_beaten');
+    assert.equal(decision.samplingPromptHash, 'prompt-kept-1');
+    assert.equal(decision.metrics.samplingBaseline?.heldIn.passEligibleRate, 0.5);
+  });
+
+  test('fails closed when the sampling baseline is incomplete', () => {
+    const decision = decidePromptAcceptance({
+      ...baseDecisionInput(),
+      previousHeldInReferencePassEligibleRate: 0.25,
+      lastKeptEvents: [completed('in-a', false), completed('in-b', false)],
+      candidateEvents: [completed('in-a', true), completed('in-b', true), completed('out-a', true)],
+      samplingBaselineEvents: [completed('in-a', true)],
+    });
+
+    assert.equal(decision.decision, 'discard');
+    assert.equal(decision.reason, 'sampling_baseline_incomplete');
+  });
+
   test('keeps against the monotonic held-in reference instead of a lucky last-kept run', () => {
     const decision = decidePromptAcceptance({
       ...baseDecisionInput(),

--- a/packages/headless/src/__tests__/prompt-optimization-loop-replay-decision.test.ts
+++ b/packages/headless/src/__tests__/prompt-optimization-loop-replay-decision.test.ts
@@ -250,6 +250,114 @@ describe('runPromptOptimizationLoop replay decision guards', () => {
     });
   });
 
+  test('fails closed when sampling evidence appears after its decision', async () => {
+    await withHarness(async (harness) => {
+      const heldInTasks = makeTasks('hin', 20);
+      const heldOutTasks = makeTasks('hout', 8);
+      const rewardFor = (roundId: string, taskId: string): number => {
+        const index = taskIndex(taskId);
+        if (taskId.startsWith('hout-')) return index < 4 ? 1 : 0;
+        if (roundId.startsWith('baseline-')) return index < 10 ? 1 : 0;
+        return 1;
+      };
+
+      await runLoop(harness, {
+        heldInTasks,
+        heldOutTasks,
+        rewardFor,
+        rounds: 1,
+        baselineRuns: 1,
+      });
+      const events = await readFixedPromptWal(harness.resultsJsonlPath);
+      const samplingIndex = events.findIndex(
+        (event) => event.type === 'task_completed' && event.roundId === 'sampling-0',
+      );
+      const decisionIndex = events.findIndex(
+        (event) => event.type === 'prompt_candidate_decided' && event.roundId === 'round-0',
+      );
+      assert.ok(samplingIndex > -1);
+      assert.ok(decisionIndex > samplingIndex);
+      const samplingEvent = events[samplingIndex]!;
+      const reordered = events.filter((_event, index) => index !== samplingIndex);
+      const shiftedDecisionIndex = reordered.findIndex(
+        (event) => event.type === 'prompt_candidate_decided' && event.roundId === 'round-0',
+      );
+      reordered.splice(shiftedDecisionIndex + 1, 0, samplingEvent);
+      await writeFile(
+        harness.resultsJsonlPath,
+        `${reordered.map((event) => JSON.stringify(event)).join('\n')}\n`,
+        'utf8',
+      );
+
+      await assert.rejects(
+        runLoop(harness, {
+          heldInTasks,
+          heldOutTasks,
+          rewardFor,
+          rounds: 1,
+          baselineRuns: 1,
+        }),
+        /RSI WAL replay missing sampling baseline evidence for round-0/,
+      );
+    });
+  });
+
+  test('fails closed when sampling evidence appears after the candidate commit', async () => {
+    await withHarness(async (harness) => {
+      const heldInTasks = makeTasks('hin', 20);
+      const heldOutTasks = makeTasks('hout', 8);
+      const rewardFor = (roundId: string, taskId: string): number => {
+        const index = taskIndex(taskId);
+        if (taskId.startsWith('hout-')) return index < 4 ? 1 : 0;
+        if (roundId.startsWith('baseline-')) return index < 10 ? 1 : 0;
+        return 1;
+      };
+
+      await runLoop(harness, {
+        heldInTasks,
+        heldOutTasks,
+        rewardFor,
+        rounds: 1,
+        baselineRuns: 1,
+      });
+      const events = await readFixedPromptWal(harness.resultsJsonlPath);
+      const samplingIndex = events.findIndex(
+        (event) => event.type === 'task_completed' && event.roundId === 'sampling-0',
+      );
+      const candidateIndex = events.findIndex(
+        (event) => event.type === 'prompt_candidate_committed' && event.roundId === 'round-0',
+      );
+      const decisionIndex = events.findIndex(
+        (event) => event.type === 'prompt_candidate_decided' && event.roundId === 'round-0',
+      );
+      assert.ok(samplingIndex > -1);
+      assert.ok(candidateIndex > samplingIndex);
+      assert.ok(decisionIndex > candidateIndex);
+      const samplingEvent = events[samplingIndex]!;
+      const withoutSampling = events.filter((_event, index) => index !== samplingIndex);
+      const shiftedDecisionIndex = withoutSampling.findIndex(
+        (event) => event.type === 'prompt_candidate_decided' && event.roundId === 'round-0',
+      );
+      withoutSampling.splice(shiftedDecisionIndex, 0, samplingEvent);
+      await writeFile(
+        harness.resultsJsonlPath,
+        `${withoutSampling.map((event) => JSON.stringify(event)).join('\n')}\n`,
+        'utf8',
+      );
+
+      await assert.rejects(
+        runLoop(harness, {
+          heldInTasks,
+          heldOutTasks,
+          rewardFor,
+          rounds: 1,
+          baselineRuns: 1,
+        }),
+        /RSI WAL replay missing sampling baseline evidence for round-0/,
+      );
+    });
+  });
+
   test('fails closed when a held-out regression decision is missing held-out task evidence', async () => {
     await withHarness(async (harness) => {
       const heldInTasks = makeTasks('hin', 20);

--- a/packages/headless/src/__tests__/prompt-optimization-loop-resume.test.ts
+++ b/packages/headless/src/__tests__/prompt-optimization-loop-resume.test.ts
@@ -60,7 +60,9 @@ describe('runPromptOptimizationLoop resume replay', () => {
       assert.equal(resumed.smoke.status, 'pass');
       assert.ok(Math.abs(resumed.totalCostUsd - resumed.smoke.totalCostUsd) < 1e-9);
       assert.ok(
-        resumedTaskRuns.every((call) => call.startsWith('round-1:')),
+        resumedTaskRuns.every(
+          (call) => call.startsWith('sampling-1:') || call.startsWith('round-1:'),
+        ),
         `unexpected resumed task runs: ${JSON.stringify(resumedTaskRuns)}`,
       );
 
@@ -313,14 +315,14 @@ describe('runPromptOptimizationLoop resume replay', () => {
         },
       });
 
-      assert.deepEqual(resumedMetaAgentRounds, []);
+      assert.deepEqual(resumedMetaAgentRounds, ['round-0']);
       assert.deepEqual(
         resumed.decisions.map((decision) => decision.decision),
         ['keep'],
       );
       assert.equal(resumed.stopReason, 'rounds_complete');
       assert.ok(
-        resumedTaskRuns.every((call) => call.startsWith('round-0:hout-')),
+        resumedTaskRuns.every((call) => call.startsWith('round-0:')),
         `unexpected resumed task runs: ${JSON.stringify(resumedTaskRuns)}`,
       );
     });

--- a/packages/headless/src/__tests__/prompt-optimization-loop.test.ts
+++ b/packages/headless/src/__tests__/prompt-optimization-loop.test.ts
@@ -38,6 +38,105 @@ describe('runPromptOptimizationLoop', () => {
     });
   });
 
+  test('runs a budget-matched sampling arm before each candidate and records its Pass@1 evidence', async () => {
+    await withHarness(async (harness) => {
+      const heldInTasks = makeTasks('hin', 4);
+      const heldOutTasks = makeTasks('hout', 2);
+      const result = await runLoop(harness, {
+        heldInTasks,
+        heldOutTasks,
+        rewardFor: (roundId, taskId) => {
+          if (taskId.startsWith('hout-')) return 1;
+          if (roundId.startsWith('baseline-')) return taskIndex(taskId) < 2 ? 1 : 0;
+          if (roundId.startsWith('sampling-')) return taskIndex(taskId) < 2 ? 1 : 0;
+          return taskIndex(taskId) < 4 ? 1 : 0;
+        },
+        rounds: 1,
+        baselineRuns: 1,
+      });
+
+      assert.equal(result.decisions[0]?.decision, 'keep');
+      assert.equal(result.decisions[0]?.metrics.samplingBaseline?.heldIn.taskCount, 4);
+      assert.equal(result.decisions[0]?.metrics.samplingBaseline?.heldIn.passEligibleRate, 0.5);
+      const events = await readFixedPromptWal(harness.resultsJsonlPath);
+      const sampling = events.filter((event) => event.roundId === 'sampling-0');
+      const candidate = events.filter((event) => event.roundId === 'round-0');
+      assert.equal(sampling.filter((event) => event.type === 'task_completed').length, 4);
+      const samplingAttempts = (
+        await readFile(`${harness.resultsJsonlPath}.attempts.jsonl`, 'utf8')
+      )
+        .trim()
+        .split('\n')
+        .map((line) => JSON.parse(line) as { roundId: string; type: string });
+      assert.equal(samplingAttempts.length, 4);
+      assert.ok(samplingAttempts.every((event) => event.type === 'task_attempt_started'));
+      assert.ok(samplingAttempts.every((event) => event.roundId === 'sampling-0'));
+      assert.equal(
+        candidate.filter(
+          (event) => event.type === 'task_completed' && event.taskId.startsWith('hin-'),
+        ).length,
+        4,
+      );
+      assert.ok(
+        events.findIndex((event) => event.roundId === 'sampling-0') <
+          events.findIndex((event) => event.type === 'prompt_candidate_committed'),
+      );
+      const replayTaskRuns: string[] = [];
+      const replayed = await runLoop(harness, {
+        heldInTasks,
+        heldOutTasks,
+        rewardFor: (roundId, taskId) => {
+          if (taskId.startsWith('hout-')) return 1;
+          if (roundId.startsWith('baseline-') || roundId.startsWith('sampling-')) {
+            return taskIndex(taskId) < 2 ? 1 : 0;
+          }
+          return 1;
+        },
+        rounds: 1,
+        baselineRuns: 1,
+        onTaskRun: (roundId, taskId) => replayTaskRuns.push(`${roundId}:${taskId}`),
+      });
+      assert.deepEqual(replayed.decisions, result.decisions);
+      assert.deepEqual(replayTaskRuns, []);
+    });
+  });
+
+  test('stops after replaying a complete sampling arm when the budget is already exhausted', async () => {
+    await withHarness(async (harness) => {
+      const heldInTasks = makeTasks('hin', 20);
+      const heldOutTasks = makeTasks('hout', 8);
+      const rewardFor = (roundId: string, taskId: string): number => {
+        if (taskId.startsWith('hout-')) return 1;
+        if (roundId.startsWith('baseline-')) return taskIndex(taskId) < 10 ? 1 : 0;
+        return 1;
+      };
+      const first = await runLoop(harness, {
+        heldInTasks,
+        heldOutTasks,
+        rewardFor,
+        rounds: 1,
+        baselineRuns: 1,
+        costCeilingUsd: 0.959,
+      });
+      assert.deepEqual(first.decisions, []);
+      assert.equal(first.stopReason, 'cost_ceiling_exceeded');
+
+      const resumedTaskRuns: string[] = [];
+      const resumed = await runLoop(harness, {
+        heldInTasks,
+        heldOutTasks,
+        rewardFor,
+        rounds: 1,
+        baselineRuns: 1,
+        costCeilingUsd: 0.959,
+        onTaskRun: (roundId, taskId) => resumedTaskRuns.push(`${roundId}:${taskId}`),
+      });
+      assert.deepEqual(resumed.decisions, []);
+      assert.equal(resumed.stopReason, 'cost_ceiling_exceeded');
+      assert.deepEqual(resumedTaskRuns, []);
+    });
+  });
+
   test('keeps an improving candidate, discards a regressing one, and reports a passing smoke', async () => {
     await withHarness(async (harness) => {
       const heldInTasks = makeTasks('hin', 20);
@@ -699,7 +798,7 @@ describe('runPromptOptimizationLoop', () => {
       });
 
       assert.equal(result.stopReason, 'cost_ceiling_exceeded');
-      assert.equal(result.decisions.length, 1);
+      assert.equal(result.decisions.length, 0);
       assert.ok(result.totalCostUsd >= 1.5);
     });
   });
@@ -725,8 +824,8 @@ describe('runPromptOptimizationLoop', () => {
       });
 
       assert.equal(result.stopReason, 'cost_ceiling_exceeded');
-      assert.equal(result.decisions.length, 1);
-      assert.equal(result.smoke.totalCostUsd, 1.68);
+      assert.equal(result.decisions.length, 0);
+      assert.equal(result.smoke.totalCostUsd, 1.92);
       assert.ok(result.smoke.failures.includes('cost_ceiling_exceeded'));
     });
   });

--- a/packages/headless/src/__tests__/prompt-optimization-manifest.test.ts
+++ b/packages/headless/src/__tests__/prompt-optimization-manifest.test.ts
@@ -6,6 +6,7 @@ import { join } from 'node:path';
 import { describe, test } from 'node:test';
 import { promisify } from 'node:util';
 import type { FixedPromptTask } from '../fixed-prompt-controller.js';
+import { buildRunManifestFingerprint } from '../ab-manifest.js';
 import {
   buildPromptOptimizationRunManifest,
   buildPromptOptimizationSubjectFingerprint,
@@ -195,6 +196,36 @@ describe('prompt optimization run manifest', () => {
     });
   });
 
+  test('migrates an existing v1 manifest before resuming with the sampling contract', async () => {
+    await withDir(async (dir) => {
+      const runRoot = join(dir, 'run-1');
+      const manifestPath = join(runRoot, 'prompt-optimization-manifest.json');
+      const original = buildManifest('sha256:task-source', []);
+      const raised = buildManifest('sha256:task-source', [], 'pilot', 1.5);
+      const legacy = { ...original } as Record<string, unknown>;
+      delete legacy.samplingBaseline;
+      delete legacy.fingerprint;
+      delete legacy.costCeilingUsd;
+      const legacyManifest = {
+        ...legacy,
+        fingerprint: buildRunManifestFingerprint(legacy),
+      };
+      await mkdir(runRoot, { recursive: true });
+      await writeFile(manifestPath, `${JSON.stringify(legacyManifest, null, 2)}\n`, 'utf8');
+
+      const migrated = await ensurePromptOptimizationRunManifest(manifestPath, raised, runRoot);
+
+      assert.deepEqual(migrated.samplingBaseline, raised.samplingBaseline);
+      assert.equal(migrated.fingerprint, legacyManifest.fingerprint);
+      assert.equal(migrated.costCeilingUsd, 1.5);
+      assert.deepEqual(JSON.parse(await readFile(manifestPath, 'utf8')), migrated);
+
+      const resumed = await ensurePromptOptimizationRunManifest(manifestPath, raised, runRoot);
+      assert.equal(resumed.fingerprint, legacyManifest.fingerprint);
+      assert.equal(resumed.costCeilingUsd, 1.5);
+    });
+  });
+
   test('records the prompt optimization profile in the resume fingerprint', () => {
     const pilot = buildManifest('sha256:task-source', [], 'pilot');
     const full = buildManifest('sha256:task-source', [], 'full');
@@ -211,6 +242,18 @@ describe('prompt optimization run manifest', () => {
     assert.equal('zScore' in narrow, true);
     assert.equal('zScore' in standard, true);
     assert.notEqual(standard.fingerprint, narrow.fingerprint);
+  });
+
+  test('records the immutable budget-matched sampling arm contract', () => {
+    const manifest = buildManifest('sha256:task-source', []);
+    assert.deepEqual(manifest.samplingBaseline, {
+      enabled: true,
+      armId: 'sampling-baseline',
+      taskSet: 'stable-held-in',
+      budgetBasis: 'candidate-held-in',
+      execution: 'parallel',
+      primaryMetric: 'pass@1',
+    });
   });
 
   test('does not record an always-empty dropped held-in no-pattern field', () => {

--- a/packages/headless/src/fixed-prompt-controller.ts
+++ b/packages/headless/src/fixed-prompt-controller.ts
@@ -308,6 +308,7 @@ export interface PromptCandidateDecisionEvent {
   heldInPassRateNoiseBand: number;
   heldOutPassRateNoiseBand: number;
   rewardHackScan?: PromptCandidateRewardHackScan;
+  samplingPromptHash?: string;
   metrics: unknown;
 }
 

--- a/packages/headless/src/prompt-acceptance-policy.ts
+++ b/packages/headless/src/prompt-acceptance-policy.ts
@@ -18,6 +18,8 @@ export type PromptAcceptanceReason =
   | 'held_in_regressed'
   | 'coverage_regressed'
   | 'held_out_regressed'
+  | 'sampling_baseline_not_beaten'
+  | 'sampling_baseline_incomplete'
   | typeof PROMPT_REWARD_HACK_QUARANTINE_REASON;
 
 export interface PromptAcceptancePartitionSummary {
@@ -44,6 +46,9 @@ export interface PromptAcceptanceMetrics {
   candidate: {
     heldIn: PromptAcceptancePartitionSummary;
     heldOut: PromptAcceptancePartitionSummary;
+  };
+  samplingBaseline?: {
+    heldIn: PromptAcceptancePartitionSummary;
   };
 }
 
@@ -99,6 +104,8 @@ export interface DecidePromptAcceptanceInput {
   originalEvents: readonly FixedPromptTaskWalEvent[];
   lastKeptEvents: readonly FixedPromptTaskWalEvent[];
   candidateEvents: readonly FixedPromptTaskWalEvent[];
+  samplingBaselineEvents?: readonly FixedPromptTaskWalEvent[];
+  samplingPromptHash?: string;
   rewardHackScan?: PromptCandidateRewardHackScan;
 }
 
@@ -117,6 +124,7 @@ export interface PromptAcceptanceResult {
   heldInPassRateNoiseBand: number;
   heldOutPassRateNoiseBand: number;
   rewardHackScan: PromptCandidateRewardHackScan;
+  samplingPromptHash?: string;
   metrics: PromptAcceptanceMetrics;
 }
 
@@ -364,6 +372,16 @@ export function decidePromptAcceptance(input: DecidePromptAcceptanceInput): Prom
       heldIn: summarizePromptAcceptancePartition(input.candidateEvents, input.heldInTaskIds),
       heldOut: summarizePromptAcceptancePartition(input.candidateEvents, input.heldOutTaskIds),
     },
+    ...(input.samplingBaselineEvents
+      ? {
+          samplingBaseline: {
+            heldIn: summarizePromptAcceptancePartition(
+              input.samplingBaselineEvents,
+              input.heldInTaskIds,
+            ),
+          },
+        }
+      : {}),
   };
   const reason =
     rewardHackGateReason(rewardHackScan) ??
@@ -372,6 +390,7 @@ export function decidePromptAcceptance(input: DecidePromptAcceptanceInput): Prom
       originalHeldOutPassEligibleRate: input.originalHeldOutPassEligibleRate,
       heldInPassRateNoiseBand: input.heldInPassRateNoiseBand,
       heldOutPassRateNoiseBand: input.heldOutPassRateNoiseBand,
+      samplingBaseline: metrics.samplingBaseline?.heldIn,
     });
   const decision: PromptAcceptanceDecision = reason === 'held_in_improved' ? 'keep' : 'discard';
   const heldInReferencePassEligibleRate = nextHeldInReferencePassEligibleRate({
@@ -396,6 +415,7 @@ export function decidePromptAcceptance(input: DecidePromptAcceptanceInput): Prom
     heldInPassRateNoiseBand: input.heldInPassRateNoiseBand,
     heldOutPassRateNoiseBand: input.heldOutPassRateNoiseBand,
     rewardHackScan,
+    ...(input.samplingPromptHash ? { samplingPromptHash: input.samplingPromptHash } : {}),
     metrics,
   };
 }
@@ -526,6 +546,9 @@ function promptCandidateDecisionEvent(
     heldInPassRateNoiseBand: input.result.heldInPassRateNoiseBand,
     heldOutPassRateNoiseBand: input.result.heldOutPassRateNoiseBand,
     rewardHackScan: input.result.rewardHackScan,
+    ...(input.result.samplingPromptHash
+      ? { samplingPromptHash: input.result.samplingPromptHash }
+      : {}),
     metrics: input.result.metrics,
   };
 }
@@ -544,6 +567,7 @@ function heldInGateReasonFromSummaries(
   input: {
     previousHeldInReferencePassEligibleRate: number | null;
     heldInPassRateNoiseBand: number;
+    samplingBaseline?: PromptAcceptancePartitionSummary;
   },
 ): PromptAcceptanceReason | null {
   if (hasBlockingTaskFailure(heldInReference) || hasBlockingTaskFailure(heldInCandidate)) {
@@ -556,6 +580,8 @@ function heldInGateReasonFromSummaries(
       input.heldInPassRateNoiseBand,
     )
   ) {
+    const samplingReason = samplingBaselineGateReason(heldInCandidate, input.samplingBaseline);
+    if (samplingReason) return samplingReason;
     return null; // held-in cleared → run held-out
   }
   if (
@@ -568,6 +594,26 @@ function heldInGateReasonFromSummaries(
     return 'held_in_regressed';
   }
   return 'held_in_within_noise';
+}
+
+function samplingBaselineGateReason(
+  candidate: PromptAcceptancePartitionSummary,
+  samplingBaseline: PromptAcceptancePartitionSummary | undefined,
+): PromptAcceptanceReason | null {
+  if (!samplingBaseline) return null;
+  if (
+    hasBlockingTaskFailure(samplingBaseline) ||
+    samplingBaseline.observed !== samplingBaseline.taskCount ||
+    samplingBaseline.eligible !== samplingBaseline.taskCount ||
+    samplingBaseline.scored !== samplingBaseline.taskCount ||
+    samplingBaseline.passEligibleRate === null ||
+    candidate.passEligibleRate === null
+  ) {
+    return 'sampling_baseline_incomplete';
+  }
+  return candidate.passEligibleRate > samplingBaseline.passEligibleRate
+    ? null
+    : 'sampling_baseline_not_beaten';
 }
 
 /** Held-out gate (#64 LOOP step 10). Only meaningful once held-in has cleared.
@@ -610,6 +656,7 @@ export function heldInGateReason(input: {
   previousHeldInReferencePassEligibleRate: number | null;
   heldInPassRateNoiseBand: number;
   rewardHackScan?: PromptCandidateRewardHackScan;
+  samplingBaselineEvents?: readonly FixedPromptTaskWalEvent[];
 }): PromptAcceptanceReason | null {
   const rewardHack = rewardHackGateReason(normalizeRewardHackScan(input.rewardHackScan));
   if (rewardHack) return rewardHack;
@@ -619,6 +666,9 @@ export function heldInGateReason(input: {
     {
       previousHeldInReferencePassEligibleRate: input.previousHeldInReferencePassEligibleRate,
       heldInPassRateNoiseBand: input.heldInPassRateNoiseBand,
+      samplingBaseline: input.samplingBaselineEvents
+        ? summarizePromptAcceptancePartition(input.samplingBaselineEvents, input.heldInTaskIds)
+        : undefined,
     },
   );
 }
@@ -630,11 +680,13 @@ function acceptanceReason(
     originalHeldOutPassEligibleRate: number | null;
     heldInPassRateNoiseBand: number;
     heldOutPassRateNoiseBand: number;
+    samplingBaseline?: PromptAcceptancePartitionSummary;
   },
 ): PromptAcceptanceReason {
   const heldIn = heldInGateReasonFromSummaries(metrics.candidate.heldIn, metrics.lastKept.heldIn, {
     previousHeldInReferencePassEligibleRate: input.previousHeldInReferencePassEligibleRate,
     heldInPassRateNoiseBand: input.heldInPassRateNoiseBand,
+    samplingBaseline: metrics.samplingBaseline?.heldIn,
   });
   if (heldIn !== null) return heldIn;
   const heldOut = heldOutGateReasonFromSummaries(

--- a/packages/headless/src/prompt-optimization-loop.ts
+++ b/packages/headless/src/prompt-optimization-loop.ts
@@ -1,10 +1,12 @@
 import { randomUUID } from 'node:crypto';
+import { readFile } from 'node:fs/promises';
 import { isDeepStrictEqual } from 'node:util';
 import type { Config } from './contracts.js';
 import {
   appendFixedPromptWalEvent,
   FIXED_PROMPT_WAL_SCHEMA_VERSION,
   runFixedPromptController,
+  hashSystemPrompt,
   readFixedPromptWal,
   writeFixedPromptResultsTsv,
   type FixedPromptControllerResult,
@@ -56,7 +58,9 @@ import {
   buildPromptOptimizationReplayPlan,
   replayStateHasRecoverablePendingCandidateEvidence,
   replayPromptBaselinePartition,
+  replayControllerSweep,
   replayPromptDecisionRound,
+  readPromptHashAtCommit,
 } from './prompt-optimization-replay.js';
 
 /**
@@ -245,7 +249,8 @@ export async function runPromptOptimizationLoop(
   const sweep = (
     roundId: string,
     tasks: readonly FixedPromptTask[],
-    resultsTsvPath: string,
+    resultsTsvPath?: string,
+    options?: { protectPassAtOne?: boolean },
   ): Promise<FixedPromptControllerResult> =>
     runFixedPromptController({
       runId: input.runId,
@@ -258,6 +263,7 @@ export async function runPromptOptimizationLoop(
       harborRunner: input.harborRunner,
       ...(input.resumeFingerprint ? { resumeFingerprint: input.resumeFingerprint } : {}),
       ...(input.maxConcurrency !== undefined ? { maxConcurrency: input.maxConcurrency } : {}),
+      ...(options?.protectPassAtOne ? { protectPassAtOne: true } : {}),
       now,
       newId,
     });
@@ -537,7 +543,7 @@ export async function runPromptOptimizationLoop(
         : {}),
       candidateEvents: latestHeldInFeedbackEvents,
     });
-    const existingDecisionRound = replayPromptDecisionRound({
+    const existingDecisionRound = await replayPromptDecisionRound({
       events: resumeEvents,
       state: replayState,
       runId: input.runId,
@@ -547,6 +553,8 @@ export async function runPromptOptimizationLoop(
       executedHeldInTaskIds: stableHeldInTaskIds,
       executedHeldOutTaskIds: stableHeldOutTaskIds,
       ...(input.resumeFingerprint ? { resumeFingerprint: input.resumeFingerprint } : {}),
+      promptRepoDir: input.git.gitRootPath,
+      systemPromptGitPath: input.git.systemPromptGitPath,
       heldInResultsTsvPath: input.heldInResultsTsvPath,
       heldOutResultsTsvPath: input.heldOutResultsTsvPath,
     });
@@ -562,6 +570,7 @@ export async function runPromptOptimizationLoop(
         );
       }
       const existingHeldInEvents = existingDecisionRound.heldIn.events;
+      if (existingDecisionRound.sampling) accumulate(existingDecisionRound.sampling);
       accumulate(existingDecisionRound.executedHeldIn);
       if (existingDecisionRound.executedHeldOut) accumulate(existingDecisionRound.executedHeldOut);
       const replayedRewardHackScan = await scanHeldIn(existingDecisionRound.executedHeldIn.events);
@@ -573,6 +582,9 @@ export async function runPromptOptimizationLoop(
           candidateHeldInEvents: existingHeldInEvents,
           previousHeldInReferencePassEligibleRate: heldInReference,
           heldInPassRateNoiseBand: activeBaseline.heldIn.noiseBand,
+          ...(existingDecisionRound.sampling
+            ? { samplingBaselineEvents: existingDecisionRound.sampling.events }
+            : {}),
           rewardHackScan: replayedRewardHackScan,
         }) === null
       ) {
@@ -596,6 +608,12 @@ export async function runPromptOptimizationLoop(
           ...existingHeldInEvents,
           ...(existingDecisionRound.heldOut?.events ?? []),
         ],
+        ...(existingDecisionRound.sampling
+          ? {
+              samplingBaselineEvents: existingDecisionRound.sampling.events,
+              samplingPromptHash: existingDecisionRound.decision.samplingPromptHash,
+            }
+          : {}),
         rewardHackScan: replayedRewardHackScan,
       });
       assertReplayedDecisionMatchesResult(existingDecisionRound.decision, replayedResult);
@@ -651,6 +669,53 @@ export async function runPromptOptimizationLoop(
     if (existingCandidate) {
       assertCandidateMatchesStableTaskSet(existingCandidate, decisionHeldInTaskIds);
     }
+    let samplingBaseline: FixedPromptControllerResult | undefined;
+    let samplingPromptHash: string | undefined;
+    if (!existingDecisionRound) {
+      const currentPromptHash = existingCandidate
+        ? await readPromptHashAtCommit({
+            promptRepoDir: input.git.gitRootPath,
+            commitSha: `${existingCandidate.commitSha}^`,
+            systemPromptGitPath: input.git.systemPromptGitPath,
+          })
+        : hashSystemPrompt(await readFile(input.systemPromptPath, 'utf8'));
+      const samplingRoundId = `sampling-${round}`;
+      const replayedSampling = replayControllerSweep({
+        events: resumeEvents,
+        runId: input.runId,
+        roundId: samplingRoundId,
+        taskIds: stableHeldInTaskIds,
+        expectedPromptHash: currentPromptHash,
+        ...(input.resumeFingerprint ? { resumeFingerprint: input.resumeFingerprint } : {}),
+        resultsTsvPath: input.heldInResultsTsvPath,
+      });
+      if (replayedSampling) {
+        samplingBaseline = replayedSampling;
+        samplingPromptHash = currentPromptHash;
+        accumulate(replayedSampling);
+        const postSamplingGuard = stopGuard();
+        if (postSamplingGuard) {
+          stopReason = postSamplingGuard;
+          break;
+        }
+      } else if (!existingCandidate) {
+        const samplingGuard = stopGuard();
+        if (samplingGuard) {
+          stopReason = samplingGuard;
+          break;
+        }
+        samplingBaseline = await sweep(samplingRoundId, roundHeldInTasks, undefined, {
+          protectPassAtOne: true,
+        });
+        accumulate(samplingBaseline);
+        samplingPromptHash = currentPromptHash;
+        const postSamplingGuard = stopGuard();
+        if (postSamplingGuard) {
+          stopReason = postSamplingGuard;
+          break;
+        }
+      }
+    }
     const candidate =
       existingCandidate ??
       (await runPromptCandidateRound({
@@ -690,6 +755,7 @@ export async function runPromptOptimizationLoop(
       candidateHeldInEvents: heldInDecisionEvents,
       previousHeldInReferencePassEligibleRate: heldInReference,
       heldInPassRateNoiseBand: activeBaseline.heldIn.noiseBand,
+      ...(samplingBaseline ? { samplingBaselineEvents: samplingBaseline.events } : {}),
       rewardHackScan,
     });
     let heldOutExecutionEvents: readonly FixedPromptTaskWalEvent[] = [];
@@ -727,6 +793,12 @@ export async function runPromptOptimizationLoop(
       originalEvents: originalHeldOutEvents,
       lastKeptEvents: lastKeptHeldInEvents,
       candidateEvents: [...heldInDecisionEvents, ...heldOutDecisionEvents],
+      ...(samplingBaseline
+        ? {
+            samplingBaselineEvents: samplingBaseline.events,
+            samplingPromptHash,
+          }
+        : {}),
       rewardHackScan,
     });
     if (result.decision === 'discard') {

--- a/packages/headless/src/prompt-optimization-manifest.ts
+++ b/packages/headless/src/prompt-optimization-manifest.ts
@@ -33,7 +33,17 @@ export interface PromptOptimizationRunManifest {
   heldInTaskIds: string[];
   heldOutTaskIds: string[];
   heldOutNoPatternTaskIds: string[];
+  samplingBaseline: PromptOptimizationSamplingBaselineManifest;
   fingerprint: string;
+}
+
+export interface PromptOptimizationSamplingBaselineManifest {
+  enabled: true;
+  armId: 'sampling-baseline';
+  taskSet: 'stable-held-in';
+  budgetBasis: 'candidate-held-in';
+  execution: 'parallel';
+  primaryMetric: 'pass@1';
 }
 
 export interface PromptOptimizationRunManifestInput {
@@ -95,6 +105,14 @@ export function buildPromptOptimizationRunManifest(
     heldInTaskIds: input.heldInTasks.map((task) => task.id),
     heldOutTaskIds: input.heldOutTasks.map((task) => task.id),
     heldOutNoPatternTaskIds: input.heldOutNoPattern.map((task) => task.id),
+    samplingBaseline: {
+      enabled: true,
+      armId: 'sampling-baseline',
+      taskSet: 'stable-held-in',
+      budgetBasis: 'candidate-held-in',
+      execution: 'parallel',
+      primaryMetric: 'pass@1',
+    } as const,
   });
   const { costCeilingUsd: _costCeilingUsd, ...fingerprintPayload } = manifestWithoutFingerprint;
   return {
@@ -123,6 +141,10 @@ export async function ensurePromptOptimizationRunManifest(
       );
     }
   }
+  const migrated = await migrateLegacyPromptOptimizationManifest(path, manifest);
+  if (migrated) return migrated;
+  const legacyResumed = await resumeMigratedPromptOptimizationManifest(path, manifest);
+  if (legacyResumed) return legacyResumed;
   try {
     const ensured = await ensureAbRunManifest(path, manifest);
     if (ensured.costCeilingUsd !== manifest.costCeilingUsd) {
@@ -144,6 +166,92 @@ export async function ensurePromptOptimizationRunManifest(
     }
     throw error;
   }
+}
+
+async function migrateLegacyPromptOptimizationManifest(
+  path: string,
+  manifest: PromptOptimizationRunManifest,
+): Promise<PromptOptimizationRunManifest | undefined> {
+  let existing: unknown;
+  try {
+    existing = JSON.parse(await readFile(path, 'utf8')) as unknown;
+  } catch (error) {
+    if (isNotFound(error)) return undefined;
+    throw error;
+  }
+  if (
+    typeof existing !== 'object' ||
+    existing === null ||
+    (existing as { schemaVersion?: unknown }).schemaVersion !==
+      'maka.prompt_optimization.run_manifest.v1' ||
+    'samplingBaseline' in existing
+  ) {
+    return undefined;
+  }
+  const existingFingerprint = (existing as { fingerprint?: unknown }).fingerprint;
+  const {
+    costCeilingUsd: _costCeilingUsd,
+    fingerprint: _fingerprint,
+    samplingBaseline: _sampling,
+    ...legacyPayload
+  } = manifest;
+  if (
+    existingFingerprint !== buildRunManifestFingerprint(legacyPayload) ||
+    typeof existingFingerprint !== 'string'
+  ) {
+    return undefined;
+  }
+  // Existing WAL task events carry the legacy fingerprint. Add the immutable
+  // sampling contract without changing that identity, otherwise resume fails
+  // closed before it can consume the old evidence.
+  const migrated = { ...manifest, fingerprint: existingFingerprint };
+  await writeFile(path, `${JSON.stringify(migrated, null, 2)}\n`, 'utf8');
+  return migrated;
+}
+
+async function resumeMigratedPromptOptimizationManifest(
+  path: string,
+  manifest: PromptOptimizationRunManifest,
+): Promise<PromptOptimizationRunManifest | undefined> {
+  let existing: unknown;
+  try {
+    existing = JSON.parse(await readFile(path, 'utf8')) as unknown;
+  } catch (error) {
+    if (isNotFound(error)) return undefined;
+    throw error;
+  }
+  if (
+    typeof existing !== 'object' ||
+    existing === null ||
+    (existing as { schemaVersion?: unknown }).schemaVersion !==
+      'maka.prompt_optimization.run_manifest.v1' ||
+    !('samplingBaseline' in existing)
+  ) {
+    return undefined;
+  }
+  const existingFingerprint = (existing as { fingerprint?: unknown }).fingerprint;
+  if (typeof existingFingerprint !== 'string') return undefined;
+  const {
+    costCeilingUsd: _costCeilingUsd,
+    fingerprint: _fingerprint,
+    samplingBaseline: _sampling,
+    ...legacyPayload
+  } = manifest;
+  if (existingFingerprint !== buildRunManifestFingerprint(legacyPayload)) return undefined;
+  if (
+    JSON.stringify((existing as { samplingBaseline?: unknown }).samplingBaseline) !==
+    JSON.stringify(manifest.samplingBaseline)
+  ) {
+    return undefined;
+  }
+  const resumed = {
+    ...(existing as PromptOptimizationRunManifest),
+    costCeilingUsd: manifest.costCeilingUsd,
+  };
+  if ((existing as { costCeilingUsd?: unknown }).costCeilingUsd !== manifest.costCeilingUsd) {
+    await writeFile(path, `${JSON.stringify(resumed, null, 2)}\n`, 'utf8');
+  }
+  return resumed;
 }
 
 export async function buildPromptOptimizationSubjectFingerprint(repoPath: string): Promise<string> {

--- a/packages/headless/src/prompt-optimization-replay-evidence.ts
+++ b/packages/headless/src/prompt-optimization-replay-evidence.ts
@@ -10,6 +10,7 @@ import type { PromptAcceptanceResult } from './prompt-acceptance-policy.js';
 import {
   assertCandidateMatchesStableTaskSet,
   matchesRun,
+  readPromptHashAtCommit,
   type PromptOptimizationReplayState,
 } from './prompt-optimization-replay-state.js';
 import {
@@ -20,6 +21,7 @@ import { validateRsiControllerAttribution } from './rsi-controller-attribution.j
 
 export interface ReplayedPromptDecisionRound {
   decision: PromptCandidateDecisionEvent;
+  sampling: FixedPromptControllerResult | undefined;
   executedHeldIn: FixedPromptControllerResult;
   executedHeldOut: FixedPromptControllerResult | undefined;
   heldIn: FixedPromptControllerResult;
@@ -44,6 +46,7 @@ export function assertReplayedDecisionMatchesResult(
     heldInPassRateNoiseBand: result.heldInPassRateNoiseBand,
     heldOutPassRateNoiseBand: result.heldOutPassRateNoiseBand,
     rewardHackScan: result.rewardHackScan,
+    samplingPromptHash: result.samplingPromptHash,
     metrics: result.metrics,
   };
   const persistedDecision = {
@@ -59,6 +62,7 @@ export function assertReplayedDecisionMatchesResult(
     heldInPassRateNoiseBand: decision.heldInPassRateNoiseBand,
     heldOutPassRateNoiseBand: decision.heldOutPassRateNoiseBand,
     rewardHackScan: decision.rewardHackScan,
+    samplingPromptHash: decision.samplingPromptHash,
     metrics: decision.metrics,
   };
   if (
@@ -94,7 +98,7 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
 
-export function replayPromptDecisionRound(input: {
+export async function replayPromptDecisionRound(input: {
   events: readonly FixedPromptWalEvent[];
   state: PromptOptimizationReplayState;
   runId: string;
@@ -104,9 +108,11 @@ export function replayPromptDecisionRound(input: {
   executedHeldInTaskIds?: readonly string[];
   executedHeldOutTaskIds?: readonly string[];
   resumeFingerprint?: string;
+  promptRepoDir?: string;
+  systemPromptGitPath?: string;
   heldInResultsTsvPath: string;
   heldOutResultsTsvPath: string;
-}): ReplayedPromptDecisionRound | undefined {
+}): Promise<ReplayedPromptDecisionRound | undefined> {
   const decision = input.state.decisionByRoundId.get(input.roundId);
   if (!decision) return undefined;
   const candidate = input.state.candidateByRoundId.get(input.roundId);
@@ -124,6 +130,9 @@ export function replayPromptDecisionRound(input: {
     candidate,
     decision,
   });
+  const sampling = decision.samplingPromptHash
+    ? await awaitReplaySampling(input, decision)
+    : undefined;
   const heldIn = replayRequiredControllerSweep({
     events: input.events,
     runId: input.runId,
@@ -164,12 +173,63 @@ export function replayPromptDecisionRound(input: {
   });
   return {
     decision,
+    sampling,
     executedHeldIn,
     executedHeldOut,
     heldIn,
     heldOut,
     attribution,
   };
+}
+
+async function awaitReplaySampling(
+  input: {
+    events: readonly FixedPromptWalEvent[];
+    state: PromptOptimizationReplayState;
+    runId: string;
+    roundId: string;
+    heldInTaskIds: readonly string[];
+    executedHeldInTaskIds?: readonly string[];
+    resumeFingerprint?: string;
+    promptRepoDir?: string;
+    systemPromptGitPath?: string;
+    heldInResultsTsvPath: string;
+  },
+  decision: PromptCandidateDecisionEvent,
+): Promise<FixedPromptControllerResult> {
+  const samplingPromptHash = decision.samplingPromptHash;
+  if (!samplingPromptHash) {
+    throw new Error(`RSI WAL replay missing sampling prompt hash for ${input.roundId}`);
+  }
+  if (input.promptRepoDir && input.systemPromptGitPath) {
+    const expectedPromptHash = await readPromptHashAtCommit({
+      promptRepoDir: input.promptRepoDir,
+      commitSha: decision.previousLastKeptCommitSha,
+      systemPromptGitPath: input.systemPromptGitPath,
+    });
+    if (expectedPromptHash !== samplingPromptHash) {
+      throw new Error(`RSI WAL replay sampling prompt hash mismatch for ${input.roundId}`);
+    }
+  }
+  const candidateIndex = input.events.findIndex(
+    (event) => event === input.state.candidateByRoundId.get(input.roundId),
+  );
+  if (candidateIndex < 0) {
+    throw new Error(`RSI WAL replay missing candidate event for ${input.roundId}`);
+  }
+  return replayRequiredControllerSweep({
+    // Sampling is a pre-candidate control arm. Evidence written after the
+    // candidate commit must not be accepted merely because it precedes the
+    // decision event.
+    events: input.events.slice(0, candidateIndex),
+    runId: input.runId,
+    roundId: `sampling-${input.roundId.slice('round-'.length)}`,
+    taskIds: input.executedHeldInTaskIds ?? input.heldInTaskIds,
+    expectedPromptHash: samplingPromptHash,
+    ...(input.resumeFingerprint ? { resumeFingerprint: input.resumeFingerprint } : {}),
+    resultsTsvPath: input.heldInResultsTsvPath,
+    missingEvidenceMessage: `RSI WAL replay missing sampling baseline evidence for ${input.roundId}`,
+  });
 }
 
 function replayDecisionAttribution(input: {

--- a/packages/headless/src/prompt-optimization-replay-state.ts
+++ b/packages/headless/src/prompt-optimization-replay-state.ts
@@ -393,6 +393,16 @@ export function taskEventMatchesPromptIdentity(
   return promptHashForReplayIdentity(event) === expectedPromptHash;
 }
 
+export async function readPromptHashAtCommit(input: {
+  promptRepoDir: string;
+  commitSha: string;
+  systemPromptGitPath: string;
+}): Promise<string> {
+  return hashSystemPrompt(
+    await gitBlob(input.promptRepoDir, `${input.commitSha}:${input.systemPromptGitPath}`),
+  );
+}
+
 async function gitOutput(cwd: string, ...args: string[]): Promise<string> {
   const { stdout } = await execFileAsync('git', args, { cwd, encoding: 'utf8' });
   return stdout.trim();

--- a/packages/headless/src/prompt-optimization-replay.ts
+++ b/packages/headless/src/prompt-optimization-replay.ts
@@ -4,10 +4,14 @@ export {
   buildPromptOptimizationReplayPlan,
   derivePromptOptimizationReplayState,
   replayStateHasRecoverablePendingCandidateEvidence,
+  readPromptHashAtCommit,
   type PromptOptimizationReplayPlan,
   type PromptOptimizationReplayState,
 } from './prompt-optimization-replay-state.js';
-export { replayPromptBaselinePartition } from './prompt-optimization-replay-sweeps.js';
+export {
+  replayControllerSweep,
+  replayPromptBaselinePartition,
+} from './prompt-optimization-replay-sweeps.js';
 export {
   assertReplayedDecisionMatchesResult,
   replayPromptDecisionRound,

--- a/packages/storage/src/__tests__/settings-store-usage.test.ts
+++ b/packages/storage/src/__tests__/settings-store-usage.test.ts
@@ -138,7 +138,15 @@ describe('SettingsStore.usageStats request logs', () => {
       // are only unique within a session, so both sessions reuse `bash`/`read`
       // ids to prove result matching stays session-scoped after the merge.
       const bashTurn = (sessionId: string, error: boolean, duration: number): StoredMessage[] => [
-        { type: 'tool_call', id: 'bash', turnId: 't1', ts: 10, toolName: 'Bash', displayName: '终端', args: {} },
+        {
+          type: 'tool_call',
+          id: 'bash',
+          turnId: 't1',
+          ts: 10,
+          toolName: 'Bash',
+          displayName: '终端',
+          args: {},
+        },
         {
           type: 'tool_result',
           id: 'bash-result',
@@ -153,7 +161,15 @@ describe('SettingsStore.usageStats request logs', () => {
 
       await seedSession(workspaceRoot, makeHeader({ id: 'session-a' }), [
         ...bashTurn('session-a', false, 20),
-        { type: 'tool_call', id: 'read', turnId: 't1', ts: 12, toolName: 'Read', displayName: '读取', args: {} },
+        {
+          type: 'tool_call',
+          id: 'read',
+          turnId: 't1',
+          ts: 12,
+          toolName: 'Read',
+          displayName: '读取',
+          args: {},
+        },
         {
           type: 'tool_result',
           id: 'read-result',


### PR DESCRIPTION
## Summary

Closes #1245

This adds a budget-matched parallel-sampling baseline to the headless prompt RSI loop. Each candidate round now evaluates the currently kept prompt on the stable held-in set before creating the candidate, and the candidate must strictly beat that sampling Pass@1 after clearing the existing reference/noise gate.

## Design

- The sampling arm is an evaluation baseline, not a calibration baseline. Existing repeated baseline sweeps still define the noise bands.
- Sampling uses the stable held-in task set, the candidate-held-in budget, and the configured `maxConcurrency`.
- Sampling runs with Pass@1 protection and fails closed on incomplete or orphaned evidence.
- Sampling evidence is recorded in the same Fixed Prompt WAL and in decision metrics; it is not exposed through the agent-visible held-in TSV.
- The manifest records the immutable sampling contract: `sampling-baseline`, `stable-held-in`, `candidate-held-in`, parallel execution, and Pass@1.
- Replay validates prompt identity, resume identity, evidence ordering, and the kept prompt commit. It rejects sampling evidence after the candidate commit or after the decision.
- Legacy v1 prompt optimization manifests migrate to the sampling contract while preserving their existing WAL fingerprint, so interrupted runs remain resumable. Cost ceilings retain their mutable guardrail semantics.
- The implementation remains compatible with the powered keep profile from #619.

## Verification

- `npm --workspace @maka/headless run build`
- `npm --workspace @maka/headless run typecheck`
- Focused prompt optimization suite: 60 passed, 0 failed
- Biome lint and format checks on all touched files
- `git diff --check`

The complete headless suite was not runnable in this sandbox because its temporary-directory setup and cleanup require filesystem permissions unavailable here; the focused suite and typecheck passed.

## Out of scope

- Changing the existing calibration baseline or held-out policy.
- Adding multi-sample candidate aggregation beyond the single Pass@1 sampling arm.
- Changing provider pricing, Harbor task semantics, or the #619 powered keep profile contract.
