### PR TITLE
fix(headless): suppress Harbor job-control notifications

### DIFF
--- a/packages/headless/harbor/process_scope.py
+++ b/packages/headless/harbor/process_scope.py
@@ -20,6 +20,7 @@ def scoped_command(command: str, scope: str, command_id: str) -> str:
         f"bash -lc {shlex.quote(command)} & "
         "command_pid=$!; "
         f"printf '%s\\n' \"$command_pid\" > {pgid_path}; "
+        "set +m; "
         "wait \"$command_pid\"; command_status=$?; "
         f"kill -0 -- \"-$command_pid\" 2>/dev/null || rm -f -- {pgid_path}; "
         "exit \"$command_status\""

--- a/packages/headless/harbor/process_scope.py
+++ b/packages/headless/harbor/process_scope.py
@@ -19,9 +19,9 @@ def scoped_command(command: str, scope: str, command_id: str) -> str:
         f"{COMMAND_ID_ENV}={shlex.quote(command_id)} "
         f"bash -lc {shlex.quote(command)} & "
         "command_pid=$!; "
-        f"printf '%s\\n' \"$command_pid\" > {pgid_path}; "
         "set +m; "
-        "wait \"$command_pid\"; command_status=$?; "
+        f"printf '%s\\n' \"$command_pid\" > {pgid_path}; "
+        "wait \"$command_pid\" 2>/dev/null; command_status=$?; "
         f"kill -0 -- \"-$command_pid\" 2>/dev/null || rm -f -- {pgid_path}; "
         "exit \"$command_status\""
     )

--- a/packages/headless/src/__tests__/harbor-adapter.test.ts
+++ b/packages/headless/src/__tests__/harbor-adapter.test.ts
@@ -810,6 +810,7 @@ describe('Harbor adapter contract', () => {
     assert.deepEqual(JSON.parse(result.stdout), [
       { label: 'success', returnCode: 0, stdout: 'success-out', stderr: 'success-err' },
       { label: 'failure', returnCode: 7, stdout: 'failure-out', stderr: 'failure-err' },
+      { label: 'signal', returnCode: 143, stdout: 'signal-out', stderr: 'signal-err' },
     ]);
   });
 
@@ -1302,6 +1303,7 @@ scope_dir = Path(COMMAND_SCOPE_ROOT) / scope
 cases = [
     ("success", "printf success-out; printf success-err >&2"),
     ("failure", "printf failure-out; printf failure-err >&2; exit 7"),
+    ("signal", "printf signal-out; printf signal-err >&2; kill -TERM $$"),
 ]
 results = []
 

--- a/packages/headless/src/__tests__/harbor-adapter.test.ts
+++ b/packages/headless/src/__tests__/harbor-adapter.test.ts
@@ -797,6 +797,22 @@ describe('Harbor adapter contract', () => {
     assert.match(result.stdout, /maka-cell-output\.json/);
   });
 
+  test('process scope preserves command results without emitting job notifications', (t) => {
+    const result = spawnSync('python3', ['-c', pythonProcessScopeSmokeScript(repoRoot)], {
+      cwd: repoRoot,
+      encoding: 'utf8',
+    });
+    if (result.error && 'code' in result.error && result.error.code === 'ENOENT') {
+      t.skip('python3 is not available');
+      return;
+    }
+    assert.equal(result.status, 0, result.stderr);
+    assert.deepEqual(JSON.parse(result.stdout), [
+      { label: 'success', returnCode: 0, stdout: 'success-out', stderr: 'success-err' },
+      { label: 'failure', returnCode: 7, stdout: 'failure-out', stderr: 'failure-err' },
+    ]);
+  });
+
   test('opencode_agent.py bridges credentials and estimates trial cost without Harbor installed', (t: TestContext) => {
     const result = spawnSync('python3', ['-c', pythonOpenCodeAdapterSmokeScript(repoRoot)], {
       cwd: repoRoot,
@@ -1265,6 +1281,52 @@ asyncio.run(fix3_infra_failure_reclaims_scoped_processes())
 asyncio.run(fix4_deadline_reclaims_all_scoped_commands())
 asyncio.run(fix5_timed_out_command_is_reclaimed_immediately())
 print("bridge-contract ok")
+`;
+}
+
+function pythonProcessScopeSmokeScript(root: string): string {
+  return String.raw`
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+root = Path(${JSON.stringify(root)})
+sys.path.insert(0, str(root / "packages" / "headless" / "harbor"))
+
+from process_scope import COMMAND_SCOPE_ROOT, scoped_command
+
+scope = f"job-notification-test-{os.getpid()}"
+scope_dir = Path(COMMAND_SCOPE_ROOT) / scope
+cases = [
+    ("success", "printf success-out; printf success-err >&2"),
+    ("failure", "printf failure-out; printf failure-err >&2; exit 7"),
+]
+results = []
+
+try:
+    for label, command in cases:
+        result = subprocess.run(
+            ["bash", "-lc", scoped_command(command, scope, label)],
+            capture_output=True,
+            text=True,
+        )
+        results.append(
+            {
+                "label": label,
+                "returnCode": result.returncode,
+                "stdout": result.stdout,
+                "stderr": result.stderr,
+            }
+        )
+finally:
+    if scope_dir.exists():
+        for path in scope_dir.iterdir():
+            path.unlink()
+        scope_dir.rmdir()
+
+print(json.dumps(results))
 `;
 }
 


### PR DESCRIPTION
## Summary

- disable Bash monitor mode immediately after capturing the scoped process-group leader
- suppress only `wait` builtin diagnostics so normal completion, non-zero exit, and signal termination never leak wrapper job text or the full command
- keep command stdout, stderr, exit status, timeout cleanup, and cancellation cleanup unchanged
- add a real-Bash regression test covering successful, failed, and signal-terminated commands without filtering user output

Closes #1270

## Verification

- `node --test packages/headless/dist/__tests__/harbor-adapter.test.js` (31 passed, 1 skipped)
- `npm --workspace @maka/headless run test:dist` (1,119 passed, 1 skipped)
- `npm --workspace @maka/headless run typecheck`
- `npm run lint`
- `npm run format:check`