### PR TITLE
fix(headless): classify Harbor executor failures

### DIFF
--- a/packages/headless/harbor/maka_agent.py
+++ b/packages/headless/harbor/maka_agent.py
@@ -1099,7 +1099,18 @@ class _ToolExecutorServer:
                     with self._futures_lock:
                         if self._command_cleanup_error is None:
                             self._command_cleanup_error = cleanup_error
-            _write_http(handler, 500, {"error": str(exc)})
+            if isinstance(
+                exc, (asyncio.TimeoutError, concurrent.futures.TimeoutError)
+            ):
+                _write_http(handler, 200, {
+                    "exitCode": 124,
+                    "returnCode": 124,
+                    "stdout": "",
+                    "stderr": "",
+                    "timedOut": True,
+                })
+            else:
+                _write_http(handler, 500, {"error": str(exc)})
 
     def _cleanup_failed_command(self, command_id: str) -> BaseException | None:
         assert self._loop is not None

--- a/packages/headless/harbor/maka_agent.py
+++ b/packages/headless/harbor/maka_agent.py
@@ -1093,6 +1093,7 @@ class _ToolExecutorServer:
                 "stderr": _exec_stderr(result),
             })
         except Exception as exc:  # noqa: BLE001 - RPC boundary returns tool failure text.
+            cleanup_error: BaseException | None = None
             if command_id is not None and future is not None:
                 cleanup_error = self._cleanup_failed_command(command_id)
                 if cleanup_error is not None:
@@ -1102,13 +1103,18 @@ class _ToolExecutorServer:
             if isinstance(
                 exc, (asyncio.TimeoutError, concurrent.futures.TimeoutError)
             ):
-                _write_http(handler, 200, {
-                    "exitCode": 124,
-                    "returnCode": 124,
-                    "stdout": "",
-                    "stderr": "",
-                    "timedOut": True,
-                })
+                if cleanup_error is not None:
+                    _write_http(handler, 500, {
+                        "error": f"timed-out command cleanup failed: {cleanup_error}"
+                    })
+                else:
+                    _write_http(handler, 200, {
+                        "exitCode": 124,
+                        "returnCode": 124,
+                        "stdout": "",
+                        "stderr": "",
+                        "timedOut": True,
+                    })
             else:
                 _write_http(handler, 500, {"error": str(exc)})
 

--- a/packages/headless/src/__tests__/harbor-adapter.test.ts
+++ b/packages/headless/src/__tests__/harbor-adapter.test.ts
@@ -982,6 +982,7 @@ import sys
 import tempfile
 import time
 import types
+import urllib.error
 import urllib.request
 from pathlib import Path
 
@@ -1002,6 +1003,13 @@ def post(url, token, body):
     )
     resp = urllib.request.urlopen(request, timeout=5)
     return resp.status, json.loads(resp.read())
+
+
+def post_allow_error(url, token, body):
+    try:
+        return post(url, token, body)
+    except urllib.error.HTTPError as error:
+        return error.code, json.loads(error.read())
 
 
 class FakeExecEnv:
@@ -1202,6 +1210,11 @@ class LocalProcessCleanupAgent:
         return ExecResult(stdout="", stderr="", return_code=process.returncode)
 
 
+class ImmediateTimeoutEnv:
+    async def exec(self, command, cwd=None, env=None, timeout_sec=None, user=None):
+        raise asyncio.TimeoutError("simulated Harbor exec timeout")
+
+
 async def fix5_timed_out_command_is_reclaimed_immediately():
     env = TimedOutLocalShellEnv()
     server = m._ToolExecutorServer(LocalProcessCleanupAgent(), env)
@@ -1283,11 +1296,29 @@ async def fix5_timed_out_command_is_reclaimed_immediately():
             scope_dir.rmdir()
 
 
+async def fix6_cleanup_failure_is_not_reported_as_a_typed_timeout():
+    server = m._ToolExecutorServer(LocalProcessCleanupAgent(), ImmediateTimeoutEnv())
+    server._cleanup_failed_command = lambda command_id: RuntimeError("cleanup failed")
+    await server.__aenter__()
+    try:
+        status, body = await asyncio.to_thread(
+            post_allow_error, server.url, server.token, {"command": "sleep 30"}
+        )
+    finally:
+        # This test has no real command to reclaim; suppress the expected
+        # teardown re-raise after capturing the HTTP boundary behavior.
+        server._command_cleanup_error = None
+        await server.__aexit__(None, None, None)
+    assert status == 500, (status, body)
+    assert body == {"error": "timed-out command cleanup failed: cleanup failed"}, body
+
+
 asyncio.run(fix1_bridge_exec_contract())
 asyncio.run(fix2_workdir_probe_falls_back())
 asyncio.run(fix3_infra_failure_reclaims_scoped_processes())
 asyncio.run(fix4_deadline_reclaims_all_scoped_commands())
 asyncio.run(fix5_timed_out_command_is_reclaimed_immediately())
+asyncio.run(fix6_cleanup_failure_is_not_reported_as_a_typed_timeout())
 print("bridge-contract ok")
 `;
 }

--- a/packages/headless/src/__tests__/harbor-adapter.test.ts
+++ b/packages/headless/src/__tests__/harbor-adapter.test.ts
@@ -1231,10 +1231,17 @@ async def fix5_timed_out_command_is_reclaimed_immediately():
                 ">/dev/null 2>&1 & sleep 30"
             )
             async with server:
-                try:
-                    await asyncio.to_thread(post, server.url, server.token, {"command": command})
-                except Exception:
-                    pass
+                status, body = await asyncio.to_thread(
+                    post, server.url, server.token, {"command": command}
+                )
+                assert status == 200, status
+                assert body == {
+                    "exitCode": 124,
+                    "returnCode": 124,
+                    "stdout": "",
+                    "stderr": "",
+                    "timedOut": True,
+                }, body
             assert env.command_pgid is not None
             detached_pid = int(state_path.read_text(encoding="utf-8"))
             can_scan_process_env = Path("/proc").is_dir()

--- a/packages/headless/src/__tests__/harbor-cell.test.ts
+++ b/packages/headless/src/__tests__/harbor-cell.test.ts
@@ -4410,12 +4410,14 @@ describe('createHarborCellLocalToolExecutor', () => {
       'local isolated file command ignored tool cancellation',
     );
     assert.notEqual(result.exitCode, 0);
+    assert.equal(result.timedOut, undefined);
   });
 
   test('lets MAKA_CELL_COMMAND_TIMEOUT_MS lower the default per-command timeout', async () => {
     const executor = createHarborCellLocalToolExecutor({ MAKA_CELL_COMMAND_TIMEOUT_MS: '50' });
     const result = await executor.exec({ command: 'sleep 1', cwd: process.cwd() });
-    assert.notEqual(result.exitCode, 0);
+    assert.equal(result.exitCode, 124);
+    assert.equal(result.timedOut, true);
   });
 
   test('lets MAKA_CELL_COMMAND_TIMEOUT_MS lower the bounded-tail Bash default timeout', async () => {
@@ -4431,7 +4433,15 @@ describe('createHarborCellLocalToolExecutor', () => {
   test('honors an explicit per-command timeout over the configured default', async () => {
     const executor = createHarborCellLocalToolExecutor({ MAKA_CELL_COMMAND_TIMEOUT_MS: '60000' });
     const result = await executor.exec({ command: 'sleep 1', cwd: process.cwd(), timeoutMs: 50 });
-    assert.notEqual(result.exitCode, 0);
+    assert.equal(result.exitCode, 124);
+    assert.equal(result.timedOut, true);
+  });
+
+  test('does not classify a command-authored exit 124 as a timeout', async () => {
+    const executor = createHarborCellLocalToolExecutor({});
+    const result = await executor.exec({ command: 'exit 124', cwd: process.cwd() });
+    assert.equal(result.exitCode, 124);
+    assert.equal(result.timedOut, undefined);
   });
 
   test('runs a quick command to completion under the default timeout', async () => {

--- a/packages/headless/src/__tests__/harbor-cell.test.ts
+++ b/packages/headless/src/__tests__/harbor-cell.test.ts
@@ -4267,6 +4267,65 @@ describe('createHarborHttpToolExecutor', () => {
     }
   });
 
+  test('rejects conflicting bridge exit-code aliases', async () => {
+    const previousFetch = globalThis.fetch;
+    try {
+      globalThis.fetch = async () =>
+        new Response(JSON.stringify({ exitCode: 0, returnCode: 9, stdout: '', stderr: '' }));
+      const executor = createHarborHttpToolExecutor({
+        MAKA_HARBOR_TOOL_EXECUTOR_URL: 'http://127.0.0.1:1',
+        MAKA_HARBOR_TOOL_EXECUTOR_TOKEN: 'test-token',
+      });
+
+      await assert.rejects(
+        executor.exec({ command: 'printf unreachable', cwd: '/workspace' }),
+        /Harbor tool executor returned an invalid response/,
+      );
+    } finally {
+      globalThis.fetch = previousFetch;
+    }
+  });
+
+  test('rejects a bridge timeout paired with a successful exit code', async () => {
+    const previousFetch = globalThis.fetch;
+    try {
+      globalThis.fetch = async () =>
+        new Response(JSON.stringify({ exitCode: 0, stdout: '', stderr: '', timedOut: true }));
+      const executor = createHarborHttpToolExecutor({
+        MAKA_HARBOR_TOOL_EXECUTOR_URL: 'http://127.0.0.1:1',
+        MAKA_HARBOR_TOOL_EXECUTOR_TOKEN: 'test-token',
+      });
+
+      await assert.rejects(
+        executor.exec({ command: 'printf unreachable', cwd: '/workspace' }),
+        /Harbor tool executor returned an invalid response/,
+      );
+    } finally {
+      globalThis.fetch = previousFetch;
+    }
+  });
+
+  test('rejects an unsafe bridge exit code', async () => {
+    const previousFetch = globalThis.fetch;
+    try {
+      globalThis.fetch = async () =>
+        new Response(
+          JSON.stringify({ exitCode: Number.MAX_SAFE_INTEGER + 1, stdout: '', stderr: '' }),
+        );
+      const executor = createHarborHttpToolExecutor({
+        MAKA_HARBOR_TOOL_EXECUTOR_URL: 'http://127.0.0.1:1',
+        MAKA_HARBOR_TOOL_EXECUTOR_TOKEN: 'test-token',
+      });
+
+      await assert.rejects(
+        executor.exec({ command: 'printf unreachable', cwd: '/workspace' }),
+        /Harbor tool executor returned an invalid response/,
+      );
+    } finally {
+      globalThis.fetch = previousFetch;
+    }
+  });
+
   test('preserves a typed bridge timeout instead of command stderr', async () => {
     const previousFetch = globalThis.fetch;
     try {

--- a/packages/headless/src/__tests__/harbor-cell.test.ts
+++ b/packages/headless/src/__tests__/harbor-cell.test.ts
@@ -4230,6 +4230,64 @@ setTimeout(() => {
 });
 
 describe('createHarborHttpToolExecutor', () => {
+  test('keeps bridge failures out of command stderr', async () => {
+    const previousFetch = globalThis.fetch;
+    try {
+      globalThis.fetch = async () =>
+        new Response(JSON.stringify({ error: 'executor bridge failed' }), { status: 500 });
+      const executor = createHarborHttpToolExecutor({
+        MAKA_HARBOR_TOOL_EXECUTOR_URL: 'http://127.0.0.1:1',
+        MAKA_HARBOR_TOOL_EXECUTOR_TOKEN: 'test-token',
+      });
+
+      await assert.rejects(
+        executor.exec({ command: 'printf unreachable', cwd: '/workspace' }),
+        /Harbor tool executor failed: executor bridge failed/,
+      );
+    } finally {
+      globalThis.fetch = previousFetch;
+    }
+  });
+
+  test('rejects a malformed successful bridge response', async () => {
+    const previousFetch = globalThis.fetch;
+    try {
+      globalThis.fetch = async () => new Response(JSON.stringify(['not', 'an', 'envelope']));
+      const executor = createHarborHttpToolExecutor({
+        MAKA_HARBOR_TOOL_EXECUTOR_URL: 'http://127.0.0.1:1',
+        MAKA_HARBOR_TOOL_EXECUTOR_TOKEN: 'test-token',
+      });
+
+      await assert.rejects(
+        executor.exec({ command: 'printf unreachable', cwd: '/workspace' }),
+        /Harbor tool executor returned an invalid response/,
+      );
+    } finally {
+      globalThis.fetch = previousFetch;
+    }
+  });
+
+  test('preserves a typed bridge timeout instead of command stderr', async () => {
+    const previousFetch = globalThis.fetch;
+    try {
+      globalThis.fetch = async () =>
+        new Response(JSON.stringify({ exitCode: 124, stdout: '', stderr: '', timedOut: true }));
+      const executor = createHarborHttpToolExecutor({
+        MAKA_HARBOR_TOOL_EXECUTOR_URL: 'http://127.0.0.1:1',
+        MAKA_HARBOR_TOOL_EXECUTOR_TOKEN: 'test-token',
+      });
+
+      assert.deepEqual(await executor.exec({ command: 'sleep 60', cwd: '/workspace' }), {
+        exitCode: 124,
+        stdout: '',
+        stderr: '',
+        timedOut: true,
+      });
+    } finally {
+      globalThis.fetch = previousFetch;
+    }
+  });
+
   test('forwards active-tool cancellation to fetch without serializing execution control', async () => {
     const previousFetch = globalThis.fetch;
     const controller = new AbortController();

--- a/packages/headless/src/harbor-cell-tool-executor.ts
+++ b/packages/headless/src/harbor-cell-tool-executor.ts
@@ -158,6 +158,7 @@ export function createHarborCellLocalToolExecutor(
           exitCode: shellErrorExitCode(error),
           stdout: shellErrorText(error, 'stdout'),
           stderr: shellErrorText(error, 'stderr') || shellErrorMessage(error),
+          ...(shellErrorTimedOut(error) ? { timedOut: true } : {}),
         };
       }
     },
@@ -201,6 +202,16 @@ function shellErrorExitCode(error: unknown): number {
   if (isRecord(error) && typeof error.code === 'number') return error.code;
   if (isRecord(error) && typeof error.signal === 'string') return 124;
   return 1;
+}
+
+function shellErrorTimedOut(error: unknown): boolean {
+  return (
+    isRecord(error) &&
+    error.killed === true &&
+    typeof error.signal === 'string' &&
+    error.name !== 'AbortError' &&
+    error.code !== 'ABORT_ERR'
+  );
 }
 
 function shellErrorText(error: unknown, field: 'stdout' | 'stderr'): string {

--- a/packages/headless/src/harbor-cell-tool-executor.ts
+++ b/packages/headless/src/harbor-cell-tool-executor.ts
@@ -7,7 +7,7 @@ import { exec as nodeExec } from 'node:child_process';
 import { promisify } from 'node:util';
 import { defaultShellPlan, runShellWithBoundedTail, type MakaTool } from '@maka/runtime';
 import { numericEnv, type RunHarborCellEnv } from './headless-run-env.js';
-import type { IsolatedToolExecutor } from './isolation.js';
+import type { IsolatedCommandResult, IsolatedToolExecutor } from './isolation.js';
 import { ISOLATED_HEADLESS_TOOL_NAMES } from './isolation.js';
 import { buildIsolatedHeadlessTools, type BuildIsolatedHeadlessToolsOptions } from './tools.js';
 
@@ -59,27 +59,37 @@ export function createHarborHttpToolExecutor(
       } catch {
         throw new Error('Harbor tool executor returned an invalid response');
       }
-      if (!isRecord(parsed)) {
-        throw new Error('Harbor tool executor returned an invalid response');
-      }
-      const exitCode = parsed.exitCode ?? parsed.returnCode;
-      if (
-        typeof exitCode !== 'number' ||
-        !Number.isInteger(exitCode) ||
-        typeof parsed.stdout !== 'string' ||
-        typeof parsed.stderr !== 'string' ||
-        (parsed.timedOut !== undefined && typeof parsed.timedOut !== 'boolean')
-      ) {
-        throw new Error('Harbor tool executor returned an invalid response');
-      }
-      return {
-        exitCode,
-        stdout: parsed.stdout,
-        stderr: parsed.stderr,
-        ...(parsed.timedOut !== undefined ? { timedOut: parsed.timedOut } : {}),
-      };
+      return decodeHarborCommandResult(parsed);
     },
   };
+}
+
+function decodeHarborCommandResult(parsed: unknown): IsolatedCommandResult {
+  if (!isRecord(parsed)) throw invalidHarborResponse();
+  const { exitCode, returnCode } = parsed;
+  if (
+    (exitCode !== undefined && (typeof exitCode !== 'number' || !Number.isSafeInteger(exitCode))) ||
+    (returnCode !== undefined &&
+      (typeof returnCode !== 'number' || !Number.isSafeInteger(returnCode))) ||
+    (exitCode === undefined && returnCode === undefined) ||
+    (exitCode !== undefined && returnCode !== undefined && exitCode !== returnCode) ||
+    typeof parsed.stdout !== 'string' ||
+    typeof parsed.stderr !== 'string' ||
+    (parsed.timedOut !== undefined && typeof parsed.timedOut !== 'boolean') ||
+    (parsed.timedOut === true && (exitCode ?? returnCode) !== 124)
+  ) {
+    throw invalidHarborResponse();
+  }
+  return {
+    exitCode: (exitCode ?? returnCode) as number,
+    stdout: parsed.stdout,
+    stderr: parsed.stderr,
+    ...(parsed.timedOut !== undefined ? { timedOut: parsed.timedOut } : {}),
+  };
+}
+
+function invalidHarborResponse(): Error {
+  return new Error('Harbor tool executor returned an invalid response');
 }
 
 export function createHarborCellLocalToolExecutor(

--- a/packages/headless/src/harbor-cell-tool-executor.ts
+++ b/packages/headless/src/harbor-cell-tool-executor.ts
@@ -48,15 +48,35 @@ export function createHarborHttpToolExecutor(
         signal: control?.abortSignal,
       });
       const body = await response.text();
-      if (!response.ok) return { exitCode: 1, stdout: '', stderr: body };
-      const parsed: unknown = JSON.parse(body);
-      if (!isRecord(parsed))
-        return { exitCode: 1, stdout: '', stderr: 'Harbor bridge returned a non-object response' };
+      if (!response.ok) {
+        throw new Error(
+          `Harbor tool executor failed: ${harborBridgeErrorMessage(body, response.status)}`,
+        );
+      }
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(body);
+      } catch {
+        throw new Error('Harbor tool executor returned an invalid response');
+      }
+      if (!isRecord(parsed)) {
+        throw new Error('Harbor tool executor returned an invalid response');
+      }
       const exitCode = parsed.exitCode ?? parsed.returnCode;
+      if (
+        typeof exitCode !== 'number' ||
+        !Number.isInteger(exitCode) ||
+        typeof parsed.stdout !== 'string' ||
+        typeof parsed.stderr !== 'string' ||
+        (parsed.timedOut !== undefined && typeof parsed.timedOut !== 'boolean')
+      ) {
+        throw new Error('Harbor tool executor returned an invalid response');
+      }
       return {
-        exitCode: typeof exitCode === 'number' && Number.isInteger(exitCode) ? exitCode : 1,
-        stdout: typeof parsed.stdout === 'string' ? parsed.stdout : '',
-        stderr: typeof parsed.stderr === 'string' ? parsed.stderr : '',
+        exitCode,
+        stdout: parsed.stdout,
+        stderr: parsed.stderr,
+        ...(parsed.timedOut !== undefined ? { timedOut: parsed.timedOut } : {}),
       };
     },
   };
@@ -98,6 +118,7 @@ export function createHarborCellLocalToolExecutor(
             stderr: result.stderr,
             stdoutTruncated: result.stdoutTruncated,
             stderrTruncated: result.stderrTruncated,
+            timedOut: result.timedOut,
           };
         } catch (error) {
           // runShellWithBoundedTail only rejects when the process cannot be
@@ -131,6 +152,18 @@ export function createHarborCellLocalToolExecutor(
       }
     },
   };
+}
+
+function harborBridgeErrorMessage(body: string, status: number): string {
+  try {
+    const parsed: unknown = JSON.parse(body);
+    if (isRecord(parsed) && typeof parsed.error === 'string' && parsed.error.trim()) {
+      return parsed.error.trim();
+    }
+  } catch {
+    // The bridge response is untrusted transport data; do not expose it as command stderr.
+  }
+  return `HTTP ${status}`;
 }
 
 function requiredHarborEnv(env: RunHarborCellEnv, name: string): string {

--- a/packages/headless/src/heavy-task-evidence.ts
+++ b/packages/headless/src/heavy-task-evidence.ts
@@ -57,7 +57,7 @@ export type HeavyTaskToolEvidenceInput =
   | {
       name: 'Bash';
       input: IsolatedCommandInput;
-      result: IsolatedCommandResult & { timedOut?: boolean };
+      result: IsolatedCommandResult;
       error?: unknown;
     }
   | {

--- a/packages/headless/src/isolation.ts
+++ b/packages/headless/src/isolation.ts
@@ -31,6 +31,7 @@ export interface IsolatedCommandResult {
   stderr: string;
   stdoutTruncated?: boolean;
   stderrTruncated?: boolean;
+  timedOut?: boolean;
 }
 
 export interface IsolatedToolExecutionControl {


### PR DESCRIPTION
## Summary

- keep Harbor bridge and protocol failures out of model-visible command stderr by throwing executor errors
- return typed timeouts only after scoped command cleanup succeeds; surface cleanup failures as bridge failures
- validate the successful HTTP envelope once, including exit-code aliases, safe integers, and timeout consistency
- propagate `timedOut` through both bounded-tail and full-output local execution without misclassifying cancellation or a command-authored exit 124

## Verification

- `npm run format:check`
- `npm run lint`
- `npm run build`
- `npm run typecheck`
- `node --test packages/headless/dist/__tests__/harbor-adapter.test.js` (32 passed)
- `node --test --test-name-pattern='createHarborHttpToolExecutor|createHarborCellLocalToolExecutor' packages/headless/dist/__tests__/harbor-cell.test.js` (15 passed)

The complete local `harbor-cell.test.js` suite was not run because it can read developer-machine credential defaults. The affected executor suites were run by test-name pattern; CI runs the complete suite in a clean environment.
