### PR TITLE
fix(headless): frame structured tool output

### DIFF
--- a/packages/headless/src/__tests__/harbor-cell-file-tools.test.ts
+++ b/packages/headless/src/__tests__/harbor-cell-file-tools.test.ts
@@ -73,6 +73,22 @@ describe('Harbor local executor file tools (real spawn)', () => {
     //  head-first guarantee covers them too without generating MBs of matches.)
   });
 
+  test('Grep preserves the existing 10 MiB decoded-output capacity after framing', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'maka-harbor-grep-capacity-'));
+    const content = `needle${'x'.repeat(8 * 1024 * 1024)}\n`;
+    await writeFile(join(cwd, 'large.txt'), content, 'utf8');
+    const tools = buildIsolatedHeadlessTools(createHarborCellLocalToolExecutor());
+
+    const result = (await tool(tools, 'Grep').impl(
+      { pattern: 'needle', path: 'large.txt' },
+      toolCtx(cwd),
+    )) as { matches: string[] };
+
+    assert.equal(result.matches.length, 1);
+    assert.ok(result.matches[0]?.startsWith('large.txt:1:needle'));
+    assert.ok((result.matches[0]?.length ?? 0) > 8 * 1024 * 1024);
+  });
+
   test('structured file tools reject stdout appended at the real executor boundary', async (t) => {
     const cwd = await mkdtemp(join(tmpdir(), 'maka-harbor-file-tool-noise-'));
     await writeFile(join(cwd, 'data.txt'), 'needle\n', 'utf8');

--- a/packages/headless/src/__tests__/harbor-cell-file-tools.test.ts
+++ b/packages/headless/src/__tests__/harbor-cell-file-tools.test.ts
@@ -73,6 +73,36 @@ describe('Harbor local executor file tools (real spawn)', () => {
     //  head-first guarantee covers them too without generating MBs of matches.)
   });
 
+  test('structured file tools reject stdout appended at the real executor boundary', async (t) => {
+    const cwd = await mkdtemp(join(tmpdir(), 'maka-harbor-file-tool-noise-'));
+    await writeFile(join(cwd, 'data.txt'), 'needle\n', 'utf8');
+    const realExecutor = createHarborCellLocalToolExecutor();
+    const tools = buildIsolatedHeadlessTools({
+      ...realExecutor,
+      async exec(input, control) {
+        const result = await realExecutor.exec(input, control);
+        if (input.command.includes('MAKA_FILE_TOOL_OUTPUT_V1') && result.exitCode === 0) {
+          return { ...result, stdout: `${result.stdout}[1]+ Done cleanup\n` };
+        }
+        return result;
+      },
+    });
+    const cases = [
+      { name: 'Read', input: { path: 'data.txt' } },
+      { name: 'Glob', input: { pattern: '*.txt' } },
+      { name: 'Grep', input: { pattern: 'needle' } },
+    ];
+
+    for (const scenario of cases) {
+      await t.test(scenario.name, async () => {
+        await assert.rejects(
+          async () => await tool(tools, scenario.name).impl(scenario.input, toolCtx(cwd)),
+          new RegExp(`${scenario.name} output transport integrity check failed`),
+        );
+      });
+    }
+  });
+
   test('Edit fails closed when the real executor boundary appends job-control output', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'maka-harbor-edit-noise-'));
     const file = join(cwd, 'data.txt');

--- a/packages/headless/src/__tests__/tools.test.ts
+++ b/packages/headless/src/__tests__/tools.test.ts
@@ -206,7 +206,7 @@ describe('isolated headless tools', () => {
     const tools = buildIsolatedHeadlessTools({
       async exec(input) {
         seen.push({ boundedTail: (input as { boundedTail?: boolean }).boundedTail });
-        return { exitCode: 0, stdout: '', stderr: '' };
+        return { exitCode: 0, stdout: fileToolOutputForCommand(input.command), stderr: '' };
       },
     });
 
@@ -225,9 +225,9 @@ describe('isolated headless tools', () => {
   test('command-backed file tools forward active-turn cancellation to the isolated executor', async () => {
     const seenSignals: Array<AbortSignal | undefined> = [];
     const tools = buildIsolatedHeadlessTools({
-      async exec(_input, control) {
+      async exec(input, control) {
         seenSignals.push(control?.abortSignal);
-        return { exitCode: 0, stdout: '', stderr: '' };
+        return { exitCode: 0, stdout: fileToolOutputForCommand(input.command), stderr: '' };
       },
     });
     const ctx = toolCtx('/workspace');
@@ -488,6 +488,57 @@ describe('isolated headless tools', () => {
     assert.ok(!r.content.includes('RAW-NATIVE-BYPASS'), 'the native readFile result is never used');
   });
 
+  test('Read rejects executor stdout outside its output frame', async () => {
+    const tools = buildIsolatedHeadlessTools({
+      async exec() {
+        return {
+          exitCode: 0,
+          stdout: `${fileToolOutputFrame('Read', '     1\talpha\n')}[1]+ Done cleanup\n`,
+          stderr: '',
+        };
+      },
+    });
+
+    await assert.rejects(
+      async () => await tool(tools, 'Read').impl({ path: 'data.txt' }, toolCtx('/workspace')),
+      /Read output transport integrity check failed/,
+    );
+  });
+
+  test('Glob rejects executor stdout outside its output frame', async () => {
+    const tools = buildIsolatedHeadlessTools({
+      async exec() {
+        return {
+          exitCode: 0,
+          stdout: `profile noise\n${fileToolOutputFrame('Glob', 'src/a.ts\n')}`,
+          stderr: '',
+        };
+      },
+    });
+
+    await assert.rejects(
+      async () => await tool(tools, 'Glob').impl({ pattern: '**/*.ts' }, toolCtx('/workspace')),
+      /Glob output transport integrity check failed/,
+    );
+  });
+
+  test('Grep rejects executor stdout outside its output frame', async () => {
+    const tools = buildIsolatedHeadlessTools({
+      async exec() {
+        return {
+          exitCode: 0,
+          stdout: `${fileToolOutputFrame('Grep', 'src/a.ts:1:needle\n')}cleanup complete\n`,
+          stderr: '',
+        };
+      },
+    });
+
+    await assert.rejects(
+      async () => await tool(tools, 'Grep').impl({ pattern: 'needle' }, toolCtx('/workspace')),
+      /Grep output transport integrity check failed/,
+    );
+  });
+
   test('Edit ignores native file ops and still uses the shared replacer', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'maka-headless-tools-edit-native-'));
     await mkdir(join(cwd, 'src'));
@@ -670,7 +721,11 @@ describe('isolated headless tools', () => {
           // Read now runs through READ_SCRIPT (no native fast path); the script
           // carries the distinctive 'Read path' label, so stub its content here.
           if (input.command.includes('Read path')) {
-            return { exitCode: 0, stdout: `read src/file.ts\n${'r'.repeat(5_000)}`, stderr: '' };
+            return {
+              exitCode: 0,
+              stdout: fileToolOutputFrame('Read', `read src/file.ts\n${'r'.repeat(5_000)}`),
+              stderr: '',
+            };
           }
           return {
             exitCode: 2,
@@ -821,7 +876,7 @@ describe('isolated headless tools', () => {
     // in /usr/bin, so findTools would silently run rg and the parity check below
     // would be vacuous.
     const noRgBin = await mkdtemp(join(tmpdir(), 'maka-headless-norg-bin-'));
-    for (const bin of ['sh', 'find', 'sed', 'awk', 'sort', 'dirname', 'basename']) {
+    for (const bin of ['sh', 'find', 'sed', 'awk', 'sort', 'dirname', 'basename', 'base64']) {
       const resolved = (await execAsync(`command -v ${bin}`, { env: process.env })).stdout.trim();
       await symlink(resolved, join(noRgBin, bin));
     }
@@ -867,7 +922,7 @@ describe('isolated headless tools', () => {
     const tools = buildIsolatedHeadlessTools({
       async exec(input) {
         captured = input.command;
-        return { exitCode: 0, stdout: '', stderr: '' };
+        return { exitCode: 0, stdout: fileToolOutputFrame('Glob', ''), stderr: '' };
       },
     });
     await tool(tools, 'Glob').impl({ pattern: '*.txt' }, toolCtx('/workspace'));
@@ -1207,7 +1262,7 @@ describe('isolated headless tools', () => {
     const tools = buildIsolatedHeadlessTools({
       async exec(input) {
         captured = input.command;
-        return { exitCode: 0, stdout: '', stderr: '' };
+        return { exitCode: 0, stdout: fileToolOutputFrame('Grep', ''), stderr: '' };
       },
     });
     await tool(tools, 'Grep').impl({ pattern: 'needle' }, toolCtx('/workspace'));
@@ -1640,4 +1695,20 @@ function toolCtx(cwd: string) {
 function editReadFrame(content: Buffer): string {
   const digest = createHash('sha256').update(content).digest('hex');
   return `MAKA_EDIT_BYTES_V1 length=${content.length} sha256=${digest}\n${content.toString('base64')}\nMAKA_EDIT_BYTES_END\n`;
+}
+
+function fileToolOutputFrame(toolName: string, content: string): string {
+  const nonce = '1';
+  const bytes = Buffer.concat([
+    Buffer.from(content, 'utf8'),
+    Buffer.from(`\0MAKA_FILE_TOOL_STATUS_${nonce}=0`, 'ascii'),
+  ]);
+  return `MAKA_FILE_TOOL_OUTPUT_V1 tool=${toolName} nonce=${nonce}\n${bytes.toString('base64')}\nMAKA_FILE_TOOL_OUTPUT_END\n`;
+}
+
+function fileToolOutputForCommand(command: string): string {
+  for (const toolName of ['Read', 'Glob', 'Grep']) {
+    if (command.includes(`-- '${toolName}' `)) return fileToolOutputFrame(toolName, '');
+  }
+  return '';
 }

--- a/packages/headless/src/__tests__/tools.test.ts
+++ b/packages/headless/src/__tests__/tools.test.ts
@@ -539,6 +539,23 @@ describe('isolated headless tools', () => {
     );
   });
 
+  test('Grep rejects framed decoded output above the existing 10 MiB capacity', async () => {
+    const tools = buildIsolatedHeadlessTools({
+      async exec() {
+        return {
+          exitCode: 0,
+          stdout: fileToolOutputFrame('Grep', 'x'.repeat(10 * 1024 * 1024 + 1)),
+          stderr: '',
+        };
+      },
+    });
+
+    await assert.rejects(
+      async () => await tool(tools, 'Grep').impl({ pattern: 'x' }, toolCtx('/workspace')),
+      /Grep output transport integrity check failed: decoded payload exceeds 10485760 bytes/,
+    );
+  });
+
   test('Edit ignores native file ops and still uses the shared replacer', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'maka-headless-tools-edit-native-'));
     await mkdir(join(cwd, 'src'));

--- a/packages/headless/src/harbor-cell-tool-executor.ts
+++ b/packages/headless/src/harbor-cell-tool-executor.ts
@@ -9,10 +9,13 @@ import { defaultShellPlan, runShellWithBoundedTail, type MakaTool } from '@maka/
 import { numericEnv, type RunHarborCellEnv } from './headless-run-env.js';
 import type { IsolatedCommandResult, IsolatedToolExecutor } from './isolation.js';
 import { ISOLATED_HEADLESS_TOOL_NAMES } from './isolation.js';
-import { buildIsolatedHeadlessTools, type BuildIsolatedHeadlessToolsOptions } from './tools.js';
+import {
+  buildIsolatedHeadlessTools,
+  FRAMED_FILE_TOOL_MAX_TRANSPORT_BYTES,
+  type BuildIsolatedHeadlessToolsOptions,
+} from './tools.js';
 
 const execAsync = promisify(nodeExec);
-const HARBOR_CELL_TOOL_MAX_BUFFER_BYTES = 10 * 1024 * 1024;
 
 export const HARBOR_CELL_DEFAULT_COMMAND_TIMEOUT_MS = 120_000;
 
@@ -149,7 +152,7 @@ export function createHarborCellLocalToolExecutor(
           cwd,
           env: childEnv,
           timeout: timeoutMs ?? defaultTimeoutMs,
-          maxBuffer: HARBOR_CELL_TOOL_MAX_BUFFER_BYTES,
+          maxBuffer: FRAMED_FILE_TOOL_MAX_TRANSPORT_BYTES,
           signal: control?.abortSignal,
         });
         return { exitCode: 0, stdout: result.stdout, stderr: result.stderr };

--- a/packages/headless/src/tools.ts
+++ b/packages/headless/src/tools.ts
@@ -58,6 +58,12 @@ const FILE_TOOL_OUTPUT_FRAME_HEADER_PATTERN =
 const FILE_TOOL_OUTPUT_STATUS_PREFIX = '\0MAKA_FILE_TOOL_STATUS_';
 const CANONICAL_BASE64_PATTERN = /^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/;
 type FramedFileToolName = 'Read' | 'Glob' | 'Grep';
+
+// Base64 expands the decoded tool payload by 4/3 before the local executor sees
+// it. Keep the framed transport budget above the existing 10 MiB decoded-output
+// capacity, with room for the embedded status marker and frame lines.
+const FRAMED_FILE_TOOL_MAX_DECODED_BYTES = 10 * 1024 * 1024;
+export const FRAMED_FILE_TOOL_MAX_TRANSPORT_BYTES = 16 * 1024 * 1024;
 /**
  * Build Maka's standard headless tool surface with shell and file operations
  * routed through the isolated executor boundary.
@@ -470,12 +476,14 @@ function parseFileToolOutputFrame(
     return fail(`expected ${expectedTool} frame but received ${header[1]}`);
 
   const payload = lines.slice(1, -2).join('');
-  if (!CANONICAL_BASE64_PATTERN.test(payload)) return fail('payload is not canonical Base64');
   const decoded = Buffer.from(payload, 'base64');
   if (decoded.toString('base64') !== payload) return fail('payload is not canonical Base64');
   const statusMarker = Buffer.from(`${FILE_TOOL_OUTPUT_STATUS_PREFIX}${header[2]}=`, 'ascii');
   const markerIndex = decoded.lastIndexOf(statusMarker);
   if (markerIndex < 0) return fail('inner command status is missing');
+  if (markerIndex > FRAMED_FILE_TOOL_MAX_DECODED_BYTES) {
+    return fail(`decoded payload exceeds ${FRAMED_FILE_TOOL_MAX_DECODED_BYTES} bytes`);
+  }
   const status = decoded.subarray(markerIndex + statusMarker.length).toString('ascii');
   if (!/^(0|[1-9]\d*)$/.test(status)) return fail('inner command status is malformed');
   const exitCode = Number(status);

--- a/packages/headless/src/tools.ts
+++ b/packages/headless/src/tools.ts
@@ -52,7 +52,12 @@ const fileWriteKey = (cwd: string, normalizedPath: string) =>
 const EDIT_READ_FRAME_END = 'MAKA_EDIT_BYTES_END';
 const EDIT_READ_FRAME_HEADER_PATTERN =
   /^MAKA_EDIT_BYTES_V1 length=(0|[1-9]\d*) sha256=([a-f0-9]{64})$/;
+const FILE_TOOL_OUTPUT_FRAME_END = 'MAKA_FILE_TOOL_OUTPUT_END';
+const FILE_TOOL_OUTPUT_FRAME_HEADER_PATTERN =
+  /^MAKA_FILE_TOOL_OUTPUT_V1 tool=([A-Za-z]+) nonce=(0|[1-9]\d*)$/;
+const FILE_TOOL_OUTPUT_STATUS_PREFIX = '\0MAKA_FILE_TOOL_STATUS_';
 const CANONICAL_BASE64_PATTERN = /^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/;
+type FramedFileToolName = 'Read' | 'Glob' | 'Grep';
 /**
  * Build Maka's standard headless tool surface with shell and file operations
  * routed through the isolated executor boundary.
@@ -167,10 +172,12 @@ export function buildIsolatedReadTool(
       const input = { cwd, path: normalizedPath, offset, limit };
       // Read has no native fast path: every result must go through READ_SCRIPT so
       // it carries the line-number / line+byte-cap / binary-guard contract (#92).
-      const stdout = await execFileCommand(
+      const stdout = await execFramedFileCommand(
         executor,
         cwd,
-        shellFileCommand(READ_SCRIPT, [normalizedPath, numberArg(offset), numberArg(limit)]),
+        'Read',
+        READ_SCRIPT,
+        [normalizedPath, numberArg(offset), numberArg(limit)],
         ctx.abortSignal,
       );
       const result = { content: stdout };
@@ -288,14 +295,12 @@ export function buildIsolatedGlobTool(
         await options.heavyTaskEvidence?.recordToolEvidence({ name: 'Glob', input, result }, ctx);
         return result;
       }
-      const stdout = await execFileCommand(
+      const stdout = await execFramedFileCommand(
         executor,
         cwd,
-        shellFileCommand(GLOB_SCRIPT, [
-          normalizedPattern,
-          globPatternToEre(normalizedPattern),
-          normalizedRelCwd ?? '',
-        ]),
+        'Glob',
+        GLOB_SCRIPT,
+        [normalizedPattern, globPatternToEre(normalizedPattern), normalizedRelCwd ?? ''],
         ctx.abortSignal,
       );
       const result = { files: parseLineArray(stdout) };
@@ -335,15 +340,17 @@ export function buildIsolatedGrepTool(
         await options.heavyTaskEvidence?.recordToolEvidence({ name: 'Grep', input, result }, ctx);
         return result;
       }
-      const stdout = await execFileCommand(
+      const stdout = await execFramedFileCommand(
         executor,
         cwd,
-        shellFileCommand(GREP_SCRIPT, [
+        'Grep',
+        GREP_SCRIPT,
+        [
           pattern,
           normalizedPath ?? '',
           normalizedGlob ?? '',
           normalizedGlob === undefined ? '' : globPatternToEre(normalizedGlob),
-        ]),
+        ],
         ctx.abortSignal,
       );
       const result = { matches: parseLineArray(stdout) };
@@ -366,6 +373,36 @@ async function execFileCommand(
     );
   }
   return result.stdout;
+}
+
+async function execFramedFileCommand(
+  executor: IsolatedToolExecutor,
+  cwd: string,
+  toolName: FramedFileToolName,
+  script: string,
+  args: string[],
+  abortSignal: AbortSignal,
+): Promise<string> {
+  const result = await executor.exec(
+    {
+      command: framedShellFileCommand(toolName, script, args),
+      cwd,
+      timeoutMs: 120_000,
+    },
+    { abortSignal },
+  );
+  if (result.exitCode !== 0) {
+    throw new Error(
+      result.stderr.trim() || `isolated file command failed with exit code ${result.exitCode}`,
+    );
+  }
+  const frame = parseFileToolOutputFrame(result.stdout, toolName);
+  if (frame.exitCode !== 0) {
+    throw new Error(
+      result.stderr.trim() || `isolated file command failed with exit code ${frame.exitCode}`,
+    );
+  }
+  return frame.content;
 }
 
 async function readIsolatedFileBytes(
@@ -413,6 +450,37 @@ function parseEditReadFrame(stdout: string): Buffer {
 
 function editReadIntegrityError(reason: string): Error {
   return new Error(`Edit read transport integrity check failed: ${reason}`);
+}
+
+function parseFileToolOutputFrame(
+  stdout: string,
+  expectedTool: FramedFileToolName,
+): { content: string; exitCode: number } {
+  const lines = stdout.split('\n');
+  const fail = (reason: string): never => {
+    throw new Error(`${expectedTool} output transport integrity check failed: ${reason}`);
+  };
+  if (lines.length < 4 || lines.at(-1) !== '' || lines.at(-2) !== FILE_TOOL_OUTPUT_FRAME_END) {
+    return fail('expected exactly one complete frame with no surrounding output');
+  }
+
+  const header = lines[0]?.match(FILE_TOOL_OUTPUT_FRAME_HEADER_PATTERN);
+  if (!header) return fail('frame header is missing or malformed');
+  if (header[1] !== expectedTool)
+    return fail(`expected ${expectedTool} frame but received ${header[1]}`);
+
+  const payload = lines.slice(1, -2).join('');
+  if (!CANONICAL_BASE64_PATTERN.test(payload)) return fail('payload is not canonical Base64');
+  const decoded = Buffer.from(payload, 'base64');
+  if (decoded.toString('base64') !== payload) return fail('payload is not canonical Base64');
+  const statusMarker = Buffer.from(`${FILE_TOOL_OUTPUT_STATUS_PREFIX}${header[2]}=`, 'ascii');
+  const markerIndex = decoded.lastIndexOf(statusMarker);
+  if (markerIndex < 0) return fail('inner command status is missing');
+  const status = decoded.subarray(markerIndex + statusMarker.length).toString('ascii');
+  if (!/^(0|[1-9]\d*)$/.test(status)) return fail('inner command status is malformed');
+  const exitCode = Number(status);
+  if (!Number.isSafeInteger(exitCode)) return fail('inner command status is not safe');
+  return { content: decoded.subarray(0, markerIndex).toString('utf8'), exitCode };
 }
 
 async function writeIsolatedFileBytes(
@@ -485,6 +553,17 @@ function countNewlines(buffer: Buffer, end: number): number {
 
 function shellFileCommand(script: string, args: string[]): string {
   return ['sh', '-c', shellQuote(script), '--', ...args.map(shellQuote)].join(' ');
+}
+
+function framedShellFileCommand(
+  toolName: FramedFileToolName,
+  script: string,
+  args: string[],
+): string {
+  return shellFileCommand(FRAME_FILE_TOOL_OUTPUT_SCRIPT, [
+    toolName,
+    shellFileCommand(script, args),
+  ]);
 }
 
 function shellQuote(value: string): string {
@@ -620,6 +699,21 @@ writable_target() {
   [ -L "$real" ] && fail "$label must stay inside workspace"
   printf '%s\n' "$real"
 }
+`;
+
+const FRAME_FILE_TOOL_OUTPUT_SCRIPT = String.raw`
+tool=$1
+command=$2
+nonce=$$
+printf 'MAKA_FILE_TOOL_OUTPUT_V1 tool=%s nonce=%s\n' "$tool" "$nonce"
+{
+  sh -c "$command"
+  status=$?
+  printf '\000MAKA_FILE_TOOL_STATUS_%s=%s' "$nonce" "$status"
+} | base64
+encoded_status=$?
+[ "$encoded_status" -eq 0 ] || exit "$encoded_status"
+printf 'MAKA_FILE_TOOL_OUTPUT_END\n'
 `;
 
 const READ_SCRIPT = `${COMMON_SHELL_HELPERS}


### PR DESCRIPTION
## Summary

- frame command-backed `Read`, `Glob`, and `Grep` stdout before it crosses the isolated executor boundary
- require one complete tool-specific frame and reject any output before or after it
- preserve arbitrary bytes, trailing newlines, and the inner command exit status through streaming Base64
- preserve the existing 10 MiB decoded-output capacity with a 16 MiB framed transport budget, while rejecting decoded payloads above 10 MiB
- keep native typed `Glob` and `Grep` executor paths unchanged

The executor stdout channel previously carried both tool data and harness or shell diagnostics. Structured tools parsed that mixed string as trusted data, so job-control or profile output could become file content, paths, or matches. This change gives those fallback paths an explicit data boundary. `Edit` keeps its stronger length and SHA-256 frame because its read result drives a write.

Refs #1270.
Refs #1111.

## Verification

- `npm run format:check`
- `npm run lint`
- `npm run build`
- `npm run typecheck`
- `node --test packages/headless/dist/__tests__/tools.test.js packages/headless/dist/__tests__/harbor-cell-file-tools.test.js` (59 passed)
- `node --test --test-name-pattern='createHarborCellLocalToolExecutor' packages/headless/dist/__tests__/harbor-cell.test.js` (8 passed)

The complete local `harbor-cell.test.js` suite was not run because it can read developer-machine credential defaults. The affected local-executor suite was run by test-name pattern; CI runs the complete suite in a clean environment.
