### PR TITLE
polish(settings): lift every surface to the 使用统计 bar — DataTable primitive, dense health/permission rows, dialect cleanup

### DIFF
--- a/apps/desktop/src/main/__tests__/provider-navigation-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/provider-navigation-contract.test.ts
@@ -44,7 +44,10 @@ describe('Settings model provider page hierarchy', () => {
       readFile(PROVIDER_CSS, 'utf8'),
     ]);
 
-    assert.match(source, /className="providerCatalogSection"[\s\S]*id="provider-catalog-title">\{copy\.add\}/);
+    // The catalog title converged onto SectionHeader; it still carries the id
+    // the section's aria-labelledby points at (via the primitive's titleId).
+    assert.match(source, /className="providerCatalogSection" aria-labelledby="provider-catalog-title"/);
+    assert.match(source, /<SectionHeader[\s\S]*titleId="provider-catalog-title"[\s\S]*title=\{copy\.add\}/);
     assert.match(
       source,
       /<PrimitiveTabsList[\s\S]*<InputGroup className="providerCatalogSearch">[\s\S]*<InputGroupAddon>[\s\S]*<Search[\s\S]*<InputGroupInput/,

--- a/apps/desktop/src/main/__tests__/radius-converge-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/radius-converge-contract.test.ts
@@ -380,11 +380,19 @@ describe('radius token governance (#406 gap 4)', () => {
       '.settingsModal': '--radius-modal',
       '.maka-palette-modal': '--radius-modal',
       '.maka-palette-input-wrap': '--radius-control',
-      '.settingsPermissionIntro': '--radius-surface',
+      // .settingsPermissionIntro / .settingsHealthIntro retired (polish wave
+      // Item 5): the second gray-banner PageHeader on each page was converged
+      // onto the SectionHeader primitive, which carries no page-level radius.
       '.settingsPermissionError': '--radius-surface',
-      '.settingsCapabilityRow': '--radius-surface',
+      // .settingsCapabilityRow radius retired (polish wave Item 3): the
+      // per-capability bordered blocks were converged onto the shared dense
+      // row language — the LIST is now the one hairline card, rows carry no
+      // per-row border/radius. Same shape as the OS permission list.
+      '.settingsCapabilityList': '--radius-surface',
       '.settingsOsPermissionList': '--radius-surface',
-      '.settingsHealthIntro': '--radius-surface',
+      // .settingsHealthSignalList is the health-page twin of the capability
+      // list card (polish wave Item 2).
+      '.settingsHealthSignalList': '--radius-surface',
       '.settingsBotRuntime': '--radius-surface',
       // .settingsNotice retired: last consumer (account page) removed in the
       // UI-quality campaign; notices now ride the Alert primitive.

--- a/apps/desktop/src/main/__tests__/radius-converge-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/radius-converge-contract.test.ts
@@ -389,7 +389,10 @@ describe('radius token governance (#406 gap 4)', () => {
       // .settingsNotice retired: last consumer (account page) removed in the
       // UI-quality campaign; notices now ride the Alert primitive.
       '.settingsAboutLogo': '--radius-surface',
-      '.settingsAboutPrivacy': '--radius-surface',
+      // .settingsAboutPrivacy retired (polish wave): the brand-blue section
+      // dialect used by 关于's privacy card + 数据's 配置导入导出 header was
+      // converged onto SectionHeader + Alert; its neutral replacements
+      // (.settingsPrivacyBlock / .settingsConfigSection) carry no radius.
       '.settingsWechatQrFrame': '--radius-surface',
       '.settingsWechatQrState': '--radius-surface',
       '.enabledEmptyChip': '--radius-control',

--- a/apps/desktop/src/main/__tests__/settings-app-info-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/settings-app-info-contract.test.ts
@@ -120,7 +120,10 @@ describe('Settings app-info loading contract', () => {
 
     const zh = getSettingsPreferencesCopy('zh').about;
     const en = getSettingsPreferencesCopy('en').about;
-    assert.match(aboutBlock, /<ul aria-label=\{copy\.privacyLabel\}>/);
+    // Polish wave: the privacy card converged onto SectionHeader + a passive
+    // Alert; the accessible name now scopes the whole block at the section.
+    assert.match(aboutBlock, /<section className="settingsPrivacyBlock" aria-label=\{copy\.privacyLabel\}>/);
+    assert.match(aboutBlock, /<SectionHeader as="h3" title=\{copy\.privacyTitle\} \/>/);
     assert.equal(zh.privacyPoints.length, 5);
     assert.match(zh.privacyPoints.join('\n'), /本机工作区/);
     assert.match(zh.storageDetail, /凭据/);

--- a/apps/desktop/src/main/__tests__/settings-network-gateway-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/settings-network-gateway-contract.test.ts
@@ -187,7 +187,7 @@ describe('Settings network and gateway persistence contract', () => {
     );
     assert.match(
       gatewayBlock,
-      /<div className="settingsUsageSummary" role="group" aria-label=\{copy\.summary\.aria\}>/,
+      /<div className="settingsGatewaySummary" role="group" aria-label=\{copy\.summary\.aria\}>/,
       'Open Gateway runtime metric cards must expose an accessible group name',
     );
     assert.match(
@@ -197,7 +197,7 @@ describe('Settings network and gateway persistence contract', () => {
     );
     assert.doesNotMatch(
       gatewayBlock,
-      /<div className="settingsUsageSummary" aria-label=\{copy\.summary\.aria\}>/,
+      /<div className="settingsGatewaySummary" aria-label=\{copy\.summary\.aria\}>/,
       'Open Gateway runtime metrics must not regress to an anonymous status summary',
     );
     assert.doesNotMatch(

--- a/apps/desktop/src/main/__tests__/settings-usage-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/settings-usage-contract.test.ts
@@ -160,7 +160,7 @@ describe('Settings usage dashboard contract', () => {
     );
   });
 
-  it('names every usage stats table and boxes it in the shared table primitive', async () => {
+  it('names every usage stats table and boxes it in the shared DataTable primitive', async () => {
     const src = await readSettingsCombinedSource();
     const statsTable = statsTableBlock(src);
 
@@ -173,51 +173,33 @@ describe('Settings usage dashboard contract', () => {
     ]) {
       assert.match(src, new RegExp(`ariaLabel=\\{props\\.copy\\.tables\\.${label}\\}`), `A usage tab must name its ${label}`);
     }
-    // Every tab funnels through the one shared table so the column rhythm /
-    // hairline / tabular-nums recipe stays in a single place.
+    // Every tab funnels through the one shared wrapper so the column rhythm /
+    // hairline / tabular-nums recipe stays in a single place. The wrapper keeps
+    // its typed-column + EmptyState signature; the table markup itself now lives
+    // in @maka/ui's DataTable primitive (pinned by packages/ui data-table.test),
+    // so the wrapper delegates the non-empty branch to <DataTable/>.
     assert.match(
       statsTable,
       /function UsageStatsTable\(props: \{\s*ariaLabel: string;\s*columns: UsageColumn\[\];\s*rows: Array<Array<ReactNode>>;\s*empty: UsageEmpty;\s*\}\)/,
       'UsageStatsTable callers must provide a table-specific accessible name, typed columns, and an EmptyState config',
     );
-    assert.match(
-      statsTable,
-      /<table\s+aria-label=\{props\.ariaLabel\}/,
-      'Usage stats table must expose its caller-provided name',
-    );
-    assert.match(
-      statsTable,
-      /<th key=\{column\.header\} scope="col"/,
-      'Usage stats table column headers must expose column scope',
-    );
-    assert.match(
-      statsTable,
-      /cellIndex === 0 \? \(\s*<th key=\{cellIndex\} scope="row"/,
-      'Usage stats table rows must expose the first data cell as a scoped row header',
-    );
-    // Numeric columns right-align + tabular-nums; every non-grow column stays on
-    // one line and sizes to content, while the grow column absorbs slack and
-    // wraps — so numeric columns never float apart and headers never wrap.
-    assert.match(
-      statsTable,
-      /column\.numeric \? 'text-right \[font-variant-numeric:tabular-nums\]' : 'text-left'/,
-      'Usage stats columns must right-align numeric data with tabular-nums',
-    );
-    assert.match(
-      statsTable,
-      /column\.grow \? 'w-full' : 'whitespace-nowrap'/,
-      'Usage stats tables must let one column absorb slack while the rest size to content on one line',
-    );
-    // Empty tabs render the shared EmptyState rather than a header-only table.
+    // Empty tabs render the shared EmptyState rather than a header-only table…
     assert.match(
       statsTable,
       /if \(props\.rows\.length === 0\) \{\s*return \(\s*<EmptyState/,
       'An empty usage tab must render the EmptyState primitive, not a bare header row',
     );
+    // …and the non-empty branch delegates to the shared DataTable primitive,
+    // passing the caller-provided name, typed columns, rows, and the pin class.
+    assert.match(
+      statsTable,
+      /<DataTable\s+ariaLabel=\{props\.ariaLabel\}\s+columns=\{props\.columns\}\s+rows=\{props\.rows\}\s+className="settingsUsageTable"/,
+      'The non-empty usage table must delegate to the shared DataTable primitive',
+    );
     assert.doesNotMatch(
       statsTable,
-      /<table className="settingsStatsTable">\s*<thead>/,
-      'Usage stats tables must not regress to anonymous tables',
+      /<table\b/,
+      'Usage stats tables must not hand-roll a <table> — the markup lives in the DataTable primitive',
     );
   });
 

--- a/apps/desktop/src/main/__tests__/tabular-nums-converge-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/tabular-nums-converge-contract.test.ts
@@ -58,8 +58,8 @@ const TABULAR_NUMS_SELECTORS = [
   '.maka-skill-section-row small',
   // search result counts
   '.maka-search-modal-result-summary',
-  // provider counts
-  '.providerRootHeader > span',
+  // provider counts (the connected-section count converged onto SectionHeader,
+  // whose count slot bakes tabular-nums — pinned against the primitive below)
   '.providerEnabledModelsHeader strong',
   // plan search count
   '.maka-plan-search-summary',
@@ -91,6 +91,11 @@ describe('PR-ANTI-LAYOUT-SHIFT-TABULAR-NUMS-0 contract', () => {
   it('StatTile bakes tabular-nums into its value slot (stat-tile surfaces converged in R4)', async () => {
     const statTile = await readFile(resolve(REPO_ROOT, 'packages/ui/src/primitives/stat-tile.tsx'), 'utf8');
     assert.match(statTile, /\[font-variant-numeric:tabular-nums\]/, 'StatTile value must keep tabular-nums baked in');
+  });
+
+  it('SectionHeader bakes tabular-nums into its count slot (provider count converged here)', async () => {
+    const sectionHeader = await readFile(resolve(REPO_ROOT, 'packages/ui/src/primitives/section-header.tsx'), 'utf8');
+    assert.match(sectionHeader, /\[font-variant-numeric:tabular-nums\]/, 'SectionHeader count must keep tabular-nums baked in');
   });
 
   it('every whitelisted numeric surface declares tabular-nums in renderer CSS', async () => {

--- a/apps/desktop/src/renderer/settings/ProvidersPanel.tsx
+++ b/apps/desktop/src/renderer/settings/ProvidersPanel.tsx
@@ -15,6 +15,7 @@ import {
   InputGroup, InputGroupAddon, InputGroupInput,
   PrimitiveTabs, PrimitiveTabsList, PrimitiveTabsTrigger, PrimitiveTabsPanel,
   Item, ItemMedia, ItemContent, ItemTitle, ItemDescription, ItemActions,
+  SectionHeader,
   useMountedRef,
   useUiLocale,
   useToast,
@@ -181,13 +182,12 @@ export function ProvidersPanel({ bridge, initialPage = 'connections', initialCon
     <div ref={providersPanelRef} className="providersPanel providersMarketPanel">
       <section className="providerMarket">
         <div className="enabledStrip" aria-label={copy.connectionsAria}>
-          <div className="providerRootHeader">
-            <div>
-              <h3>{copy.connected}</h3>
-              <p>{copy.connectedHelp}</p>
-            </div>
-            {connections.length > 0 && <span>{copy.count(connections.length)}</span>}
-          </div>
+          <SectionHeader
+            as="h3"
+            title={copy.connected}
+            subtitle={copy.connectedHelp}
+            count={connections.length > 0 ? copy.count(connections.length) : undefined}
+          />
           {loadError ? (
             <BaseButton className="enabledEmptyChip enabledEmptyAction" type="button" onClick={() => void reload()}>
               <strong>{copy.loadFailed}</strong>
@@ -234,12 +234,12 @@ export function ProvidersPanel({ bridge, initialPage = 'connections', initialCon
         </div>
 
         <section ref={providerCatalogRef} className="providerCatalogSection" aria-labelledby="provider-catalog-title">
-          <div className="providerRootHeader">
-            <div>
-              <h3 id="provider-catalog-title">{copy.add}</h3>
-              <p>{copy.addHelp}</p>
-            </div>
-          </div>
+          <SectionHeader
+            as="h3"
+            titleId="provider-catalog-title"
+            title={copy.add}
+            subtitle={copy.addHelp}
+          />
           <PrimitiveTabs
             className="catalogTabsRoot"
             value={catalogCategory}

--- a/apps/desktop/src/renderer/settings/about-settings-page.tsx
+++ b/apps/desktop/src/renderer/settings/about-settings-page.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useId, useState } from 'react';
 import { Sparkles } from '@maka/ui/icons';
-import { Alert, AlertDescription, AlertTitle, Button, PageHeader, useMountedRef, useToast, useUiLocale } from '@maka/ui';
+import { Alert, AlertDescription, AlertTitle, Button, PageHeader, SectionHeader, useMountedRef, useToast, useUiLocale } from '@maka/ui';
 import { SettingsRows, SettingRow } from './settings-rows';
 import { settingsActionErrorMessage } from './settings-error-copy';
 import { SettingsSkeletonStack } from './settings-skeleton';
@@ -138,11 +138,15 @@ export function AboutSettingsPage() {
         subtitleClassName="settingsAboutTagline"
       />
 
-      <section className="settingsAboutPrivacy" aria-label={copy.privacyLabel}>
-        <h3>{copy.privacyTitle}</h3>
-        <ul aria-label={copy.privacyLabel}>
-          {copy.privacyPoints.map((point) => <li key={point}>{point}</li>)}
-        </ul>
+      <section className="settingsPrivacyBlock" aria-label={copy.privacyLabel}>
+        <SectionHeader as="h3" title={copy.privacyTitle} />
+        <Alert variant="passive">
+          <AlertDescription>
+            <ul className="settingsPrivacyPoints">
+              {copy.privacyPoints.map((point) => <li key={point}>{point}</li>)}
+            </ul>
+          </AlertDescription>
+        </Alert>
       </section>
 
       <SettingsRows>

--- a/apps/desktop/src/renderer/settings/data-settings-page.tsx
+++ b/apps/desktop/src/renderer/settings/data-settings-page.tsx
@@ -4,6 +4,7 @@ import {
   Alert,
   AlertDescription,
   Button,
+  SectionHeader,
   SettingsSelect,
   SettingsSwitch as Switch,
   clearGlobalInputHistory,
@@ -240,11 +241,8 @@ export function DataSettingsPage() {
         </Alert>
       )}
 
-      <section className="settingsAboutPrivacy" aria-label={copy.configAria}>
-        <h3>{copy.configTitle}</h3>
-        <p className="settingsHelpText">
-          {copy.configHelp}
-        </p>
+      <section className="settingsConfigSection" aria-label={copy.configAria}>
+        <SectionHeader as="h3" title={copy.configTitle} subtitle={copy.configHelp} />
         <div role="group" aria-label={copy.categoryAria} className="settingsConfigCategoryList">
           {CONFIG_CATEGORY_IDS.map((id) => {
             const option = copy.categories[id];

--- a/apps/desktop/src/renderer/settings/health-center-page.tsx
+++ b/apps/desktop/src/renderer/settings/health-center-page.tsx
@@ -5,10 +5,9 @@ import type {
   HealthSnapshot,
 } from '@maka/core';
 import { HEALTH_SIGNAL_LAYERS } from '@maka/core';
-import { Alert, AlertAction, AlertDescription, AlertTitle, Button, Badge, RelativeTime, PageHeader, StatTile, useUiLocale } from '@maka/ui';
+import { Alert, AlertAction, AlertDescription, AlertTitle, Button, Badge, Chip, Item, ItemContent, RelativeTime, SectionHeader, StatTile, useUiLocale } from '@maka/ui';
 import { getHealthCenterCopy, type HealthCenterCopy } from '../locales/settings-health-copy';
 import { settingsActionErrorMessage } from './settings-error-copy';
-import { statusBadgeVariant } from './settings-status-badge';
 import { SettingsSkeletonStack } from './settings-skeleton';
 
 /**
@@ -84,8 +83,11 @@ export function HealthCenterPage() {
 
   return (
     <div className="settingsHealthPage">
-      <PageHeader
-        className="settingsHealthIntro"
+      {/* Polish wave Item 5: the intro was a second gray PageHeader banner
+          restating the page title. Converged onto SectionHeader — the unique
+          layer explainer + runtime caveat stay as the subtitle; the read-only
+          badge, last-read timestamp, and refresh move into the action slot. */}
+      <SectionHeader
         as="h3"
         title={copy.title}
         subtitle={
@@ -93,10 +95,10 @@ export function HealthCenterPage() {
             {copy.subtitle} <strong>{copy.validationWarning}</strong>
           </>
         }
-        meta={
-          <div className="settingsHealthMeta">
+        action={
+          <>
             <Badge variant="secondary">{copy.badge}</Badge>
-            <small>
+            <small className="whitespace-nowrap text-[length:var(--font-size-caption)] text-foreground-secondary">
               {copy.lastRead}<RelativeTime ts={healthCheckedAtMs} className="settingsHelpInlineTime" />
             </small>
             <Button
@@ -107,7 +109,7 @@ export function HealthCenterPage() {
             >
               {copy.refresh}
             </Button>
-          </div>
+          </>
         }
       />
 
@@ -189,26 +191,36 @@ function HealthSignalRow(props: { signal: HealthSignal; copy: HealthCenterCopy }
   const { signal, copy } = props;
   const statusCopy = copy.statuses[signal.status];
   const detail = copy.signalDetail(signal);
+  // Polish wave Item 2: was a bordered block per signal. Converged onto the
+  // shared Item row primitive inside one hairline card — signals carry
+  // prose-length message + detail, so an Item with stacked secondary lines
+  // beats a table. Status reads as a squared Chip (exception-only color via
+  // its tone scale; expected `ok`/`unknown` stay neutral); the send/capability
+  // blockers are exception Chips. Meta sits on one tabular-nums line.
   return (
-    <li className="settingsHealthSignalRow" data-status={signal.status}>
-      <div className="settingsHealthSignalHeader">
-        <div className="settingsHealthSignalHeading">
-          <strong>{copy.signalLabel(signal)}</strong>
-          <small className="settingsHealthSignalScope">{copy.scopes[signal.scope]}</small>
+    <Item
+      render={<li />}
+      interactive={false}
+      className="settingsHealthSignalRow flex-col items-stretch gap-1 rounded-none border-transparent px-3 py-2.5"
+    >
+      <ItemContent className="gap-1">
+        <div className="flex items-start justify-between gap-3">
+          <span className="inline-flex flex-wrap items-baseline gap-2">
+            <strong className="text-[length:var(--font-size-ui)] font-semibold text-foreground">{copy.signalLabel(signal)}</strong>
+            <small className="text-[length:var(--font-size-caption)] uppercase tracking-wider text-muted-foreground">{copy.scopes[signal.scope]}</small>
+          </span>
+          <Chip variant={statusCopy.tone}>{statusCopy.label}</Chip>
         </div>
-        <Badge variant={statusBadgeVariant(statusCopy.tone)}>{statusCopy.label}</Badge>
-      </div>
-      <p className="settingsHealthSignalMessage">{copy.signalMessage(signal)}</p>
-      {detail && <small className="settingsHealthSignalDetail">{detail}</small>}
-      <div className="settingsHealthSignalMeta">
-        <span>{copy.source}{copy.sources[signal.source]}</span>
-        <span>
-          {copy.checked}<RelativeTime ts={signal.checkedAt} className="settingsHelpInlineTime" />
-        </span>
-        {signal.blocksSend && <span className="settingsHealthSignalBlocker" data-tone="destructive">{copy.blocksSend}</span>}
-        {signal.blocksCapability && <span className="settingsHealthSignalBlocker" data-tone="warning">{copy.blocksCapability}</span>}
-      </div>
-    </li>
+        <p className="m-0 text-[length:var(--font-size-ui)] leading-normal text-foreground-secondary">{copy.signalMessage(signal)}</p>
+        {detail && <small className="text-[length:var(--font-size-caption)] leading-normal text-foreground-secondary">{detail}</small>}
+        <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-[length:var(--font-size-caption)] text-muted-foreground [font-variant-numeric:tabular-nums]">
+          <span>{copy.source}{copy.sources[signal.source]}</span>
+          <span>{copy.checked}<RelativeTime ts={signal.checkedAt} className="settingsHelpInlineTime" /></span>
+          {signal.blocksSend && <Chip size="sm" variant="destructive">{copy.blocksSend}</Chip>}
+          {signal.blocksCapability && <Chip size="sm" variant="warning">{copy.blocksCapability}</Chip>}
+        </div>
+      </ItemContent>
+    </Item>
   );
 }
 

--- a/apps/desktop/src/renderer/settings/open-gateway-settings-page.tsx
+++ b/apps/desktop/src/renderer/settings/open-gateway-settings-page.tsx
@@ -155,7 +155,7 @@ export function OpenGatewaySettingsPage(props: {
 
   return (
     <div className="settingsStructuredPage">
-      <div className="settingsUsageSummary" role="group" aria-label={copy.summary.aria}>
+      <div className="settingsGatewaySummary" role="group" aria-label={copy.summary.aria}>
         <MetricCard title={copy.summary.status} value={state.label} detail={state.detail} />
         <MetricCard title={copy.summary.address} value={baseUrl} detail={gatewayDraft.host === '0.0.0.0' ? copy.summary.lanAccessible : copy.summary.localOnly} />
         <MetricCard title={copy.summary.credentials} value={gatewayDraft.token ? copy.summary.configured : copy.summary.waitingToken} detail={copy.summary.credentialsDetail} />

--- a/apps/desktop/src/renderer/settings/permission-center-page.tsx
+++ b/apps/desktop/src/renderer/settings/permission-center-page.tsx
@@ -17,7 +17,7 @@ import type {
   UiLocale,
 } from '@maka/core';
 import { OS_PERMISSION_IDS } from '@maka/core';
-import { Button, Badge, EmptyState, RelativeTime, PageHeader, SectionHeader, StatTile, useMountedRef, useToast, useUiLocale } from '@maka/ui';
+import { Button, Badge, Chip, EmptyState, RelativeTime, SectionHeader, StatTile, useMountedRef, useToast, useUiLocale } from '@maka/ui';
 import { getPermissionCenterCopy, type PermissionCenterCopy } from '../locales/permission-center-copy';
 import { settingsActionErrorMessage } from './settings-error-copy';
 import { statusBadgeVariant } from './settings-status-badge';
@@ -143,14 +143,17 @@ export function PermissionCenterPage() {
 
   return (
     <div className="settingsPermissionPage">
-      <PageHeader
-        className="settingsPermissionIntro"
+      {/* Polish wave Item 5: the intro was a second gray PageHeader banner
+          restating the page title. Converged onto SectionHeader — the unique
+          "open Privacy & Security directly" explainer stays as the subtitle;
+          the last-read timestamp + re-detect button move into the action slot. */}
+      <SectionHeader
         as="h3"
         title={copy.title}
         subtitle={copy.subtitle}
-        meta={
-          <div className="settingsPermissionMeta">
-            <small>
+        action={
+          <>
+            <small className="whitespace-nowrap text-[length:var(--font-size-caption)] text-foreground-secondary">
               {copy.lastRead}<RelativeTime ts={checkedAtMs} className="settingsHelpInlineTime" />
             </small>
             <Button
@@ -161,7 +164,7 @@ export function PermissionCenterPage() {
             >
               {copy.detectAgain}
             </Button>
-          </div>
+          </>
         }
       />
 
@@ -329,7 +332,7 @@ function CapabilityRow(props: { capability: CapabilitySnapshot; copy: Permission
           <strong>{capabilityLabel}</strong>
           <small className="settingsCapabilityId">{prettyCapabilityId(capability.id)}</small>
         </div>
-        <Badge variant={statusBadgeVariant(readinessCopy.tone)}>{readinessCopy.label}</Badge>
+        <Chip variant={readinessCopy.tone}>{readinessCopy.label}</Chip>
       </div>
       <p className="settingsCapabilityDetail">{readinessCopy.detail}</p>
       <dl className="settingsCapabilityLayers" aria-label={copy.layers.aria(capabilityLabel)}>

--- a/apps/desktop/src/renderer/settings/usage-settings-page.tsx
+++ b/apps/desktop/src/renderer/settings/usage-settings-page.tsx
@@ -11,6 +11,8 @@ import {
   AlertAction,
   AlertDescription,
   Button,
+  DataTable,
+  type DataTableColumn,
   EmptyState,
   Input,
   Segmented,
@@ -405,22 +407,16 @@ function usageRequestStatusLabel(status: UsageStats['logs'][number]['status'], c
   }
 }
 
-// ── Shared table primitive ─────────────────────────────────────────────────
-// The local table recipe reproduces the retired public Table primitive (a
-// single HTML <table> surface did not justify one in packages/ui). All five
-// usage tabs render through it so the column rhythm, hairline separators,
-// muted+medium header row, and per-column alignment stay identical.
-//
-// Column model: the `grow` column absorbs the row's slack so numeric columns
-// shrink to content (no floating giant gaps); numeric columns right-align and
-// force tabular-nums; the first column is a scoped row header.
+// ── Shared table wrapper ────────────────────────────────────────────────────
+// The hairline/column-rhythm/tabular-nums recipe now lives in the shared
+// `DataTable` primitive (@maka/ui) — the #1252 table grew health + permission
+// consumers, so it was promoted. This thin wrapper keeps the usage-local
+// concern the primitive deliberately omits: routing an empty tab to the shared
+// EmptyState (icon + copy) instead of a bare header row. All five tabs funnel
+// through it, so every tab inherits the same table and the same empty surface.
 
-interface UsageColumn {
+interface UsageColumn extends DataTableColumn {
   header: string;
-  /** Numeric columns right-align and force tabular-nums. */
-  numeric?: boolean;
-  /** The column that absorbs slack so the others size to content. */
-  grow?: boolean;
 }
 
 interface UsageEmpty {
@@ -446,41 +442,12 @@ function UsageStatsTable(props: {
       />
     );
   }
-  const base = 'border-b border-border px-[var(--space-2)] py-[var(--space-1-5)] align-middle';
-  // Only the grow column wraps; every other column stays on one line and sizes
-  // to its content (no per-character header wrapping, no floating giant gaps).
-  const shape = (column: UsageColumn) =>
-    [
-      column.numeric ? 'text-right [font-variant-numeric:tabular-nums]' : 'text-left',
-      column.grow ? 'w-full' : 'whitespace-nowrap',
-    ].join(' ');
-  const cellClass = (column: UsageColumn) => `${base} text-foreground-secondary ${shape(column)}`;
-  const headClass = (column: UsageColumn) => `${base} font-medium text-muted-foreground ${shape(column)}`;
   return (
-    <table
-      aria-label={props.ariaLabel}
-      className="settingsUsageTable w-full border-collapse overflow-hidden rounded-[var(--radius-surface)] border border-border text-[length:var(--font-size-caption)]"
-    >
-      <thead>
-        <tr>
-          {props.columns.map((column) => (
-            <th key={column.header} scope="col" className={headClass(column)}>{column.header}</th>
-          ))}
-        </tr>
-      </thead>
-      <tbody>
-        {props.rows.map((row, rowIndex) => (
-          <tr key={rowIndex}>
-            {row.map((cell, cellIndex) => (
-              cellIndex === 0 ? (
-                <th key={cellIndex} scope="row" className={`${cellClass(props.columns[cellIndex])} font-medium text-foreground`}>{cell}</th>
-              ) : (
-                <td key={cellIndex} className={cellClass(props.columns[cellIndex])}>{cell}</td>
-              )
-            ))}
-          </tr>
-        ))}
-      </tbody>
-    </table>
+    <DataTable
+      ariaLabel={props.ariaLabel}
+      columns={props.columns}
+      rows={props.rows}
+      className="settingsUsageTable"
+    />
   );
 }

--- a/apps/desktop/src/renderer/styles/settings/about.css
+++ b/apps/desktop/src/renderer/styles/settings/about.css
@@ -67,25 +67,27 @@
   line-height: var(--leading-normal);
 }
 
-.settingsAboutPrivacy {
+/* Detail audit / polish wave: the retired `.settingsAboutPrivacy` dialect
+   (uppercase brand-blue h3 + brand-deep tinted card) was a fourth section-
+   header voice used by 关于's privacy card AND 数据's 配置导入导出 header.
+   Both converged onto the sanctioned language — SectionHeader for the
+   heading, Alert variant="passive" for the 关于 callout, plain flow for
+   数据's form — so these blocks are now just neutral gap containers. */
+.settingsPrivacyBlock {
   display: grid;
   gap: var(--space-2);
-  padding: var(--space-3) var(--space-4);
-  /* Detail audit: this card family (关于 privacy card + 数据 import/export)
-     wore --success green as SECTION EMPHASIS — a non-status use that read
-     as residual brand-green after the blue rebrand. Brand family instead. */
-  border: var(--border-width-hairline) solid oklch(from var(--brand-deep) l c h / 0.22);
-  border-radius: var(--radius-surface);
-  background: oklch(from var(--brand-deep) l c h / 0.04);
 }
 
-.settingsAboutPrivacy h3 {
+.settingsPrivacyPoints {
   margin: 0;
-  color: oklch(from var(--brand-deep) calc(l - 0.12) c h);
-  font-size: var(--font-size-ui);
-  font-weight: var(--font-weight-bold);
-  letter-spacing: var(--tracking-wider);
-  text-transform: uppercase;
+  padding: 0 0 0 var(--space-4);
+  display: grid;
+  gap: var(--space-1-5);
+}
+
+.settingsConfigSection {
+  display: grid;
+  gap: var(--space-2);
 }
 
 .settingsConfigCategoryList {
@@ -121,16 +123,3 @@
   white-space: nowrap;
 }
 
-.settingsAboutPrivacy ul {
-  margin: 0;
-  padding: 0 0 0 var(--space-4);
-  display: grid;
-  gap: var(--space-1-5);
-  color: var(--foreground-secondary);
-  font-size: var(--font-size-ui);
-  line-height: var(--leading-normal);
-}
-
-.settingsAboutPrivacy li::marker {
-  color: var(--success);
-}

--- a/apps/desktop/src/renderer/styles/settings/bot.css
+++ b/apps/desktop/src/renderer/styles/settings/bot.css
@@ -354,6 +354,22 @@
   gap: var(--space-1-5);
 }
 
+/* Gateway posture strip: five compact metric tiles. Reusing the usage
+   summary (exactly four columns) left the fifth tile orphaned on a second
+   row. This strip is 5-up on wide and drops to a clean 3-up (3 + 2, no lone
+   orphan) when the settings pane narrows. */
+.settingsGatewaySummary {
+  display: grid;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  gap: var(--space-1-5);
+}
+
+@media (max-width: 760px) {
+  .settingsGatewaySummary {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+
 /* Convergence R4: recipe lives in the StatTile primitive; this class keeps
    only the metric-strip density override. */
 .settingsMetricCard {

--- a/apps/desktop/src/renderer/styles/settings/health.css
+++ b/apps/desktop/src/renderer/styles/settings/health.css
@@ -14,47 +14,9 @@
     gap: var(--space-5);
   }
 
-.settingsHealthIntro {
-    display: flex;
-    justify-content: space-between;
-    align-items: flex-start;
-    gap: var(--space-5);
-    padding: var(--space-4);
-    border: var(--border-width-hairline) solid var(--border);
-    border-radius: var(--radius-surface);
-    background: var(--foreground-3);
-  }
-
-.settingsHealthIntro h3 {
-    margin: 0 0 var(--space-1-5);
-    font-size: var(--font-size-ui);
-    font-weight: var(--font-weight-semibold);
-  }
-
-.settingsHealthIntro p {
-    margin: 0;
-    color: var(--foreground-secondary);
-    font-size: var(--font-size-ui);
-    line-height: var(--leading-normal);
-    max-width: 60ch;
-  }
-
-.settingsHealthIntro p strong {
-    color: var(--foreground);
-  }
-
-.settingsHealthMeta {
-    display: flex;
-    flex-direction: column;
-    align-items: flex-end;
-    gap: var(--space-1-5);
-    flex-shrink: 0;
-  }
-
-.settingsHealthMeta small {
-    color: var(--foreground-secondary);
-    font-size: var(--font-size-caption);
-  }
+/* Polish wave Item 5: the intro gray-banner PageHeader (.settingsHealthIntro
+   + .settingsHealthMeta) was converged onto the shared SectionHeader
+   primitive; its bespoke banner/meta chrome is retired here. */
 
 .settingsHealthSummary {
     /* PR-HEALTH-SUMMARY-LIST-A11Y-0 (round 19/30): switched from
@@ -93,106 +55,24 @@
     font-size: var(--font-size-caption);
   }
 
+/* Polish wave Item 2: the per-signal bordered blocks (.settingsHealthSignalRow*
+   + its status-tinted borders and bespoke meta/blocker chrome) were converged
+   onto the shared Item row primitive + Chip. The list is now the ONE hairline
+   card; rows divide with a per-row top hairline. Status color is exception-only
+   (carried by the Chip's tone scale, not a tinted row border). */
+
 .settingsHealthSignalList {
     list-style: none;
     padding: 0;
     margin: 0;
-    display: grid;
-    gap: var(--space-2);
-  }
-
-.settingsHealthSignalRow {
-    display: flex;
-    flex-direction: column;
-    gap: var(--space-1-5);
-    padding: var(--space-3) var(--space-3);
     border: var(--border-width-hairline) solid var(--border);
     border-radius: var(--radius-surface);
     background: var(--background);
-    transition: border-color var(--duration-base) var(--ease-out-strong);
+    overflow: hidden;
   }
 
-/* data-status="ok" keeps the default hairline — ok is the expected state. */
-
-.settingsHealthSignalRow[data-status="warning"] {
-    border-color: oklch(from var(--warning, var(--info)) l c h / 0.28);
-  }
-
-.settingsHealthSignalRow[data-status="error"] {
-    border-color: oklch(from var(--destructive) l c h / 0.30);
-  }
-
-.settingsHealthSignalHeader {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    gap: var(--space-3);
-  }
-
-.settingsHealthSignalHeading {
-    display: flex;
-    flex-direction: column;
-    gap: var(--space-0-5);
-  }
-
-.settingsHealthSignalHeading strong {
-    font-size: var(--font-size-ui);
-    font-weight: var(--font-weight-semibold);
-  }
-
-.settingsHealthSignalScope {
-    font-size: var(--font-size-caption);
-    color: var(--muted-foreground);
-    letter-spacing: var(--tracking-wider);
-  }
-
-.settingsHealthSignalMessage {
-    margin: 0;
-    font-size: var(--font-size-ui);
-    color: var(--foreground-secondary);
-    line-height: var(--leading-normal);
-  }
-
-.settingsHealthSignalDetail {
-    font-size: var(--font-size-caption);
-    color: var(--foreground-secondary);
-    line-height: var(--leading-normal);
-  }
-
-.settingsHealthSignalMeta {
-    display: flex;
-    flex-wrap: wrap;
-    align-items: center;
-    gap: var(--space-2-5);
-    font-size: var(--font-size-caption);
-    color: var(--muted-foreground);
-  }
-
-.settingsHealthSignalMeta code {
-    font-family: var(--font-mono);
-    background: var(--foreground-5);
-    border-radius: var(--radius-control);
-    padding: 1px var(--space-1);
-    color: var(--foreground-secondary);
-  }
-
-.settingsHealthSignalBlocker {
-    font-size: var(--font-size-caption);
-    padding: 1px var(--space-2);
-    border-radius: var(--radius-pill);
-    border: var(--border-width-hairline) solid var(--border);
-  }
-
-.settingsHealthSignalBlocker[data-tone="destructive"] {
-    color: var(--destructive-text);
-    background: oklch(from var(--destructive) l c h / 0.08);
-    border-color: oklch(from var(--destructive) l c h / 0.22);
-  }
-
-.settingsHealthSignalBlocker[data-tone="warning"] {
-    color: var(--warning-text, var(--info-text));
-    background: oklch(from var(--warning, var(--info)) l c h / 0.10);
-    border-color: oklch(from var(--warning, var(--info)) l c h / 0.22);
+.settingsHealthSignalList > li + li {
+    border-top: var(--border-width-hairline) solid oklch(from var(--foreground) l c h / 0.06);
   }
 
 .settingsHealthFootnote {

--- a/apps/desktop/src/renderer/styles/settings/permission.css
+++ b/apps/desktop/src/renderer/styles/settings/permission.css
@@ -13,43 +13,9 @@
     gap: var(--space-5);
   }
 
-.settingsPermissionIntro {
-    display: flex;
-    justify-content: space-between;
-    align-items: flex-start;
-    gap: var(--space-5);
-    padding: var(--space-4);
-    border: var(--border-width-hairline) solid var(--border);
-    border-radius: var(--radius-surface);
-    background: var(--foreground-3);
-  }
-
-.settingsPermissionIntro h3 {
-    margin: 0 0 var(--space-1-5);
-    font-size: var(--font-size-ui);
-    font-weight: var(--font-weight-semibold);
-  }
-
-.settingsPermissionIntro p {
-    margin: 0;
-    color: var(--foreground-secondary);
-    font-size: var(--font-size-ui);
-    line-height: var(--leading-normal);
-    max-width: 52ch;
-  }
-
-.settingsPermissionMeta {
-    display: flex;
-    flex-direction: column;
-    align-items: flex-end;
-    gap: var(--space-1-5);
-    flex-shrink: 0;
-  }
-
-.settingsPermissionMeta small {
-    color: var(--foreground-secondary);
-    font-size: var(--font-size-caption);
-  }
+/* Polish wave Item 5: the intro gray-banner PageHeader (.settingsPermissionIntro
+   + .settingsPermissionMeta) was converged onto the shared SectionHeader
+   primitive; its bespoke banner/meta chrome is retired here. */
 
 .settingsPermissionError {
     display: flex;
@@ -93,40 +59,33 @@
     font-size: var(--font-size-caption);
   }
 
+/* Polish wave Item 3: the per-capability bordered blocks (border + radius +
+   hover shadow + status-tinted borders) were converged onto the shared dense
+   row language. The list is now the ONE hairline card matching the OS
+   permission list above it; rows divide with a per-row top hairline and carry
+   no per-row border/radius/background. Status color is exception-only (carried
+   by the readiness Chip's tone scale, not a tinted row border). */
+
 .settingsCapabilityList {
     list-style: none;
     padding: 0;
     margin: 0;
-    display: grid;
-    gap: var(--space-2-5);
-  }
-
-.settingsCapabilityRow {
     border: var(--border-width-hairline) solid var(--border);
     border-radius: var(--radius-surface);
     background: var(--background);
+    overflow: hidden;
+  }
+
+.settingsCapabilityRow {
     padding: var(--space-3) var(--space-4);
     display: flex;
     flex-direction: column;
     gap: var(--space-2-5);
-    transition: border-color var(--duration-base) var(--ease-out-strong), box-shadow var(--duration-base) var(--ease-out-strong);
   }
 
-.settingsCapabilityRow:hover {
-    border-color: var(--border-strong);
-    box-shadow: 0 1px 0 0 oklch(from var(--foreground) l c h / 0.03);
+.settingsCapabilityRow + .settingsCapabilityRow {
+    border-top: var(--border-width-hairline) solid oklch(from var(--foreground) l c h / 0.06);
   }
-
-.settingsCapabilityRow[data-readiness="denied"] {
-    border-color: oklch(from var(--destructive) l c h / 0.28);
-  }
-
-.settingsCapabilityRow[data-readiness="degraded"] {
-    border-color: oklch(from var(--warning, var(--info)) l c h / 0.28);
-  }
-
-/* Status-color restraint: "enabled" is the expected state — it keeps the
-   default hairline. Only exceptions (denied/degraded) wear a colored border. */
 
 .settingsCapabilityHeader {
     display: flex;
@@ -159,14 +118,16 @@
     line-height: var(--leading-normal);
   }
 
+/* Polish wave Item 3: the five-layer breakdown was a nested gray boxed grid
+   (a card inside the row). Converged to structured secondary lines — the same
+   label/value pairs, denser, with no nested surface chrome so the diagnostic
+   detail reads as part of the row rather than a second card. */
+
 .settingsCapabilityLayers {
     margin: 0;
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
-    gap: var(--space-2) var(--space-3);
-    padding: var(--space-2-5) var(--space-3);
-    background: var(--foreground-3);
-    border-radius: var(--radius-surface);
+    grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+    gap: var(--space-1-5) var(--space-4);
   }
 
 .settingsCapabilityLayers > div {

--- a/apps/desktop/src/renderer/styles/settings/permission.css
+++ b/apps/desktop/src/renderer/styles/settings/permission.css
@@ -381,7 +381,6 @@
      below) so denied / granted / not_determined still read at a glance. */
 
 .settingsOsPermissionRow {
-    position: relative;
     display: grid;
     grid-template-columns: 36px minmax(0, 1fr) auto;
     align-items: flex-start;
@@ -485,32 +484,12 @@
     flex-shrink: 0;
   }
 
-/* PR-PERMISSIONS-UNIFIED-CARD-0: status accents live as left-edge
-     stripes on the outer grouped card so denied / not_determined /
-     granted are visible at a glance without re-introducing per-row
-     borders that fight the unified card. */
-
-/* Status-color restraint: granted is the expected state — no stripe, no
-   green icon fill; the row label already says 已授权. Only the exception
-   states (denied / not_determined) keep an edge stripe. */
-
-.settingsOsPermissionRow[data-state="denied"]::before,
-  .settingsOsPermissionRow[data-state="not_determined"]::before {
-    content: "";
-    position: absolute;
-    left: 0;
-    top: 0;
-    bottom: 0;
-    width: 3px;
-  }
-
-.settingsOsPermissionRow[data-state="denied"]::before {
-    background: oklch(from var(--destructive) l c h / 0.55);
-  }
-
-.settingsOsPermissionRow[data-state="not_determined"]::before {
-    background: oklch(from var(--warning, var(--info)) l c h / 0.55);
-  }
+/* Polish wave (#651 status-color restraint): the per-row left-edge status
+   stripe (amber on 等待授权, red on 已拒绝) was a second status channel on
+   top of each row's state Badge — redundant, and the amber stripe read as a
+   standing alarm on an expected waiting state. The row's Chip/text is the
+   single source of state now; the denied icon tint (below) stays as the one
+   exception accent. */
 
 /* PR-PERMISSION-PAGE-REDESIGN: 4-cell summary above system permissions.
      Quick read of overall posture (X granted / Y waiting / Z denied /

--- a/apps/desktop/src/renderer/styles/settings/provider-editor.css
+++ b/apps/desktop/src/renderer/styles/settings/provider-editor.css
@@ -420,40 +420,16 @@
   padding-right: var(--space-1);
 }
 
-.providerRootHeader {
-  display: flex;
-  align-items: start;
-  justify-content: space-between;
-  gap: var(--space-4);
-}
+/* Polish wave: .providerRootHeader (connected + catalog section titles)
+   converged onto the shared SectionHeader primitive — the fourth bespoke
+   section-header dialect retired. The primitive owns the title/subtitle/
+   count recipe (count keeps tabular-nums baked in). */
 
 .providerCatalogSection {
   display: grid;
   gap: var(--space-3);
   padding-top: var(--space-5);
   border-top: var(--border-width-hairline) solid var(--border);
-}
-
-.providerRootHeader h3 {
-  margin: 0;
-  color: var(--foreground);
-  font-size: var(--font-size-ui);
-  font-weight: var(--font-weight-bold);
-}
-
-.providerRootHeader p {
-  margin: var(--space-1) 0 0;
-  color: var(--muted-foreground);
-  font-size: var(--font-size-caption);
-  line-height: var(--leading-normal);
-}
-
-.providerRootHeader > span {
-  flex: none;
-  color: var(--muted-foreground);
-  font-size: var(--font-size-caption);
-  font-variant-numeric: tabular-nums;
-  line-height: var(--leading-normal);
 }
 
 .providerCatalogSearch {
@@ -469,16 +445,6 @@
   text-align: center;
 }
 
-@media (max-width: 620px) {
-  .providerRootHeader {
-    align-items: stretch;
-    flex-direction: column;
-  }
-
-  .providerRootHeader > button {
-    align-self: start;
-  }
-}
 .providerOAuthError {
   border: var(--border-width-hairline) solid color-mix(in srgb, var(--warning) 32%, transparent);
   border-radius: var(--radius-surface);

--- a/packages/ui/src/__tests__/data-table.test.ts
+++ b/packages/ui/src/__tests__/data-table.test.ts
@@ -1,0 +1,56 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { createElement } from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { DataTable } from '../primitives/data-table.js';
+
+// The hairline table recipe promoted out of usage-settings (#1252). These
+// assertions are the re-pinned home of the markup the settings-usage-contract
+// used to guard inline: the accessible name, the scoped col/row headers, the
+// numeric right-align + tabular-nums, and the single grow column absorbing
+// slack while the rest size to content on one line.
+
+function render() {
+  return renderToStaticMarkup(
+    createElement(DataTable, {
+      ariaLabel: 'Providers table',
+      className: 'pinnedTable',
+      columns: [
+        { header: 'Provider', grow: true },
+        { header: 'Requests', numeric: true },
+      ],
+      rows: [
+        ['Anthropic', 42],
+        ['OpenAI', 7],
+      ],
+    }),
+  );
+}
+
+test('DataTable exposes the caller-provided accessible name and pin class', () => {
+  const markup = render();
+  assert.match(markup, /^<table\b[^>]*aria-label="Providers table"/);
+  assert.match(markup, /data-slot="data-table"/);
+  assert.match(markup, /class="[^"]*pinnedTable/, 'pin class must pass through for CSS/CDP selectors');
+});
+
+test('DataTable scopes the header row and the first data cell of every row', () => {
+  const markup = render();
+  // Column headers are scoped to their column.
+  assert.equal((markup.match(/<th scope="col"/g) ?? []).length, 2);
+  // The first data cell of each row is promoted to a scoped row header.
+  assert.equal((markup.match(/<th scope="row"/g) ?? []).length, 2);
+  // Non-first cells stay <td>.
+  assert.equal((markup.match(/<td\b/g) ?? []).length, 2);
+});
+
+test('DataTable right-aligns numeric columns with tabular-nums', () => {
+  const markup = render();
+  assert.match(markup, /text-right \[font-variant-numeric:tabular-nums\]/);
+});
+
+test('DataTable lets one column grow while the rest size to content on one line', () => {
+  const markup = render();
+  assert.match(markup, /w-full/, 'the grow column absorbs slack');
+  assert.match(markup, /whitespace-nowrap/, 'non-grow columns stay on one line and size to content');
+});

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -71,6 +71,7 @@ export * from './primitives/kbd.js';
 export * from './primitives/menu.js';
 export * from './primitives/dialog-header.js';
 export * from './primitives/stat-tile.js';
+export * from './primitives/data-table.js';
 export * from './primitives/section-header.js';
 export { EmptyState } from './empty-state.js';
 export * from './primitives/choice-card.js';

--- a/packages/ui/src/primitives/data-table.tsx
+++ b/packages/ui/src/primitives/data-table.tsx
@@ -1,0 +1,105 @@
+// packages/ui/src/primitives/data-table.tsx
+//
+// The ONE hairline data-table recipe. Extracted from usage-settings'
+// inline `UsageStatsTable` (#1252) once it grew a second and third
+// prospective consumer (health signals, permission capabilities) — a
+// real HTML `<table>` with:
+//   - a muted + weight-medium scoped header row (`<th scope="col">`);
+//   - the first data cell of every row promoted to a scoped row header
+//     (`<th scope="row">`, weight-medium ink) so screen readers announce
+//     the row by its name column;
+//   - hairline row separators (`border-b`) and a hairline-boxed surface;
+//   - right-aligned tabular-nums numeric columns so figures never jitter;
+//   - exactly one `grow` column that absorbs the row's slack while every
+//     other column sizes to its content on one line (no floating gaps,
+//     no per-character header wrapping).
+//
+// Empty handling is deliberately NOT here: a table primitive renders a
+// table. Call sites branch to the shared `EmptyState` before rendering it
+// (that decision — icon + copy vs. a bare header row — is a page concern
+// and already converged in `EmptyState`).
+//
+// Styled with Tailwind utilities so the primitive is portable; a call
+// site's pin class passes through via `className` for CSS placement / test
+// + CDP selectors.
+
+import type { ReactNode } from 'react';
+import { cn } from '../utils.js';
+
+export interface DataTableColumn {
+  header: ReactNode;
+  /** Numeric columns right-align and force tabular-nums. */
+  numeric?: boolean;
+  /** The single column that absorbs slack so the others size to content. */
+  grow?: boolean;
+}
+
+export interface DataTableProps {
+  /** Table-specific accessible name (each surface names its own table). */
+  ariaLabel: string;
+  columns: DataTableColumn[];
+  /** Row-major cells; cell 0 of each row becomes the scoped row header. */
+  rows: Array<Array<ReactNode>>;
+  /** Pin class for page-level CSS placement / stable selectors. */
+  className?: string;
+}
+
+const CELL_BASE =
+  'border-b border-border px-[var(--space-2)] py-[var(--space-1-5)] align-middle';
+
+// Only the grow column wraps; every other column stays on one line and sizes
+// to its content (no per-character header wrapping, no floating giant gaps).
+function shape(column: DataTableColumn): string {
+  return [
+    column.numeric ? 'text-right [font-variant-numeric:tabular-nums]' : 'text-left',
+    column.grow ? 'w-full' : 'whitespace-nowrap',
+  ].join(' ');
+}
+
+export function DataTable({ ariaLabel, columns, rows, className }: DataTableProps) {
+  const cellClass = (column: DataTableColumn) =>
+    `${CELL_BASE} text-foreground-secondary ${shape(column)}`;
+  const headClass = (column: DataTableColumn) =>
+    `${CELL_BASE} font-medium text-muted-foreground ${shape(column)}`;
+  return (
+    <table
+      aria-label={ariaLabel}
+      data-slot="data-table"
+      className={cn(
+        'w-full border-collapse overflow-hidden rounded-[var(--radius-surface)] border border-border text-[length:var(--font-size-caption)]',
+        className,
+      )}
+    >
+      <thead>
+        <tr>
+          {columns.map((column, columnIndex) => (
+            <th key={columnIndex} scope="col" className={headClass(column)}>
+              {column.header}
+            </th>
+          ))}
+        </tr>
+      </thead>
+      <tbody>
+        {rows.map((row, rowIndex) => (
+          <tr key={rowIndex}>
+            {row.map((cell, cellIndex) =>
+              cellIndex === 0 ? (
+                <th
+                  key={cellIndex}
+                  scope="row"
+                  className={`${cellClass(columns[cellIndex])} font-medium text-foreground`}
+                >
+                  {cell}
+                </th>
+              ) : (
+                <td key={cellIndex} className={cellClass(columns[cellIndex])}>
+                  {cell}
+                </td>
+              ),
+            )}
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}

--- a/packages/ui/src/primitives/section-header.tsx
+++ b/packages/ui/src/primitives/section-header.tsx
@@ -21,7 +21,9 @@ export interface SectionHeaderProps {
   action?: ReactNode;
   /** Leading accent bar (daily-review's section marker). */
   accent?: boolean;
-  as?: 'h4' | 'span';
+  /** Heading level for the title, or a non-heading `span`. `h3` is for a
+   *  section that sits directly under a page `h2` (关于 privacy, 数据 config). */
+  as?: 'h3' | 'h4' | 'span';
   className?: string;
 }
 

--- a/packages/ui/src/primitives/section-header.tsx
+++ b/packages/ui/src/primitives/section-header.tsx
@@ -13,6 +13,8 @@ import { cn } from '../utils.js';
 
 export interface SectionHeaderProps {
   title: ReactNode;
+  /** `id` on the title element, for a section's `aria-labelledby` link. */
+  titleId?: string;
   /** Muted trailing count (e.g. "3 个" / "2 份"). */
   count?: ReactNode;
   /** One quiet line under the title (permission's layer explainer). */
@@ -29,6 +31,7 @@ export interface SectionHeaderProps {
 
 export function SectionHeader({
   title,
+  titleId,
   count,
   subtitle,
   action,
@@ -43,6 +46,7 @@ export function SectionHeader({
     >
       <div className="min-w-0">
         <Tag
+          id={titleId}
           className={cn(
             'm-0 inline-flex items-center gap-2 text-[length:var(--font-size-ui)] font-semibold text-foreground',
             accent &&

--- a/packages/ui/src/search-modal.tsx
+++ b/packages/ui/src/search-modal.tsx
@@ -4,6 +4,7 @@ import type { SearchErrorReason, SearchRequest, SearchResult, UiLocale } from '@
 import { generalizedErrorMessage, generalizedErrorMessageChinese } from '@maka/core';
 import { Autocomplete } from '@base-ui/react/autocomplete';
 import { Search, X } from './icons.js';
+import { EmptyState } from './empty-state.js';
 import { DialogHeader } from './primitives/dialog-header.js';
 import { InputGroup, InputGroupAddon, InputGroupInput } from './primitives/input-group.js';
 import { DialogContent, DialogRoot, Button as UiButton } from './ui.js';
@@ -322,7 +323,12 @@ export function SearchModal(props: {
               </div>
             )}
             {searchThread && !error && trimmed.length === 0 && (
-              <p className="maka-search-modal-placeholder">{copy.introduction}</p>
+              <EmptyState
+                variant="inline"
+                title={copy.introduction}
+                body=""
+                extraClassName="maka-search-modal-placeholder"
+              />
             )}
             {searchThread && pending && trimmed.length > 0 && (
               <p className="maka-search-modal-placeholder" aria-live="polite">


### PR DESCRIPTION
Campaign PR (goal: 其他的部分也要打磨和深度的优化&美化). One audit + two fix waves, accumulated on one branch.

## The root fix
#1252's table language was deliberately page-local (single consumer). It now has multiple consumers → promoted to the **DataTable primitive** in @maka/ui (typed columns: numeric/grow; scoped th; hairline separators; tabular-nums right-aligned numerics). 使用统计 became a thin wrapper — pixel-faithful (class-identity preserved verbatim + new primitive-level tests).

## Surfaces converged
- **健康**: bespoke tall signal blocks → dense hairline Item rows in one card; status exception-only (Healthy/Unknown neutral, Error red + Blocks-sending chip); meta single-line tabular-nums. Redundant gray intro banner (repeating the page title) → SectionHeader with badge/timestamp/refresh in the action slot.
- **权限与能力**: bespoke capability blocks + nested gray dl → dense rows with structured secondary lines; a11y names and diagnostics collapse preserved; the OS-row status stripe removed (#651). Same intro-banner cleanup.
- **关于/数据**: the .settingsAboutPrivacy brand-blue callout dialect (third parallel callout language) killed — both sites onto SectionHeader + Alert; CSS deleted.
- **模型**: ProvidersPanel section headers onto SectionHeader (counts in the tabular slot, aria-labelledby kept).
- **Minors**: search-modal pre-search hint → EmptyState; 开放网关 5-tile strip no longer orphans the fifth tile.

## Process notes
- Wave 1's sandbox couldn't produce pixel captures — it deliberately shipped only structurally-verifiable items and mapped the rest; wave 2 verified direct-CDP first, then shipped the visual redesigns with light+dark before/after evidence (maintainer-accepted).
- One triage correction caught at merge: a gateway-contract failure earlier labeled pre-existing was actually a missed re-pin from the wave-1 class rename (aria semantics were intact; only the pinned class name changed) — fixed here with the corrected record.
- Deferred with reasons: per-tab fixture captures need a VisualSmokeState initial-tab field (core type surgery — documented, not forced).

## Gates (merged tree)
desktop 2751/2751 · ui 202/202 · typecheck · check-dead-css · knip ×2 · a11y/copy/console · alignment auditor all fixtures clean. ~10 contracts re-pinned across waves, none deleted. Audited AT-BAR surfaces (命令面板/定时任务/每日回顾/模型列表/连接详情) left untouched.