### PR TITLE
fix(headless): require default system prompts

### DIFF
--- a/packages/headless/harbor/maka_agent.py
+++ b/packages/headless/harbor/maka_agent.py
@@ -390,7 +390,7 @@ class MakaAgent(BaseInstalledAgent):
         return env
 
     def _cell_env(self, instruction_path: Any) -> dict[str, str]:
-        system_prompt = self._resolved_flags.get("system_prompt", "") or self._get_env("MAKA_SYSTEM_PROMPT") or ""
+        system_prompt = self._resolved_flags.get("system_prompt") or self._get_env("MAKA_SYSTEM_PROMPT")
         model = self.model_name or self._get_env("MAKA_MODEL") or "deepseek/deepseek-v4-flash"
         backend = self._harbor_backend()
         provider = self._resolved_flags.get("provider", "") or self._get_env("MAKA_PROVIDER") or ""
@@ -403,11 +403,12 @@ class MakaAgent(BaseInstalledAgent):
             "MAKA_BACKEND": backend,
             "MAKA_MODEL": model,
             "MAKA_INSTRUCTION_FILE": instruction_path.as_posix(),
-            "MAKA_SYSTEM_PROMPT": system_prompt,
             "MAKA_OUTPUT_DIR": EnvironmentPaths.agent_dir.as_posix(),
             "MAKA_STORAGE_ROOT": (EnvironmentPaths.agent_dir / "maka-storage").as_posix(),
             "MAKA_ECONOMY_TASK_MODE": "true" if economy_task_mode else "false",
         }
+        if system_prompt is not None:
+            env["MAKA_SYSTEM_PROMPT"] = system_prompt
         if provider:
             env["MAKA_PROVIDER"] = provider
         for key in (

--- a/packages/headless/harbor/run-harness-ab.mjs
+++ b/packages/headless/harbor/run-harness-ab.mjs
@@ -43,6 +43,7 @@ import {
   TERMINAL_BENCH_2_1_TASK_IDS,
 } from '#harness-ab-manifest';
 import { runHarnessAbComparisonUnlocked, withHarnessAbRunLock } from '#harness-ab-run';
+import { DEFAULT_HEADLESS_SYSTEM_PROMPT } from '@maka/headless';
 import {
   assertHarnessAbReportCompleted,
   buildHarnessAbReport,
@@ -411,8 +412,8 @@ async function runLocked({
   await mkdir(controllerDir, { recursive: true });
   await mkdir(promptsDir, { recursive: true });
   await mkdir(jobsDir, { recursive: true });
-  const systemPromptPath = join(promptsDir, 'empty-system-prompt.txt');
-  await writeFile(systemPromptPath, '', 'utf8');
+  const systemPromptPath = join(promptsDir, 'default-system-prompt.txt');
+  await writeFile(systemPromptPath, DEFAULT_HEADLESS_SYSTEM_PROMPT, 'utf8');
   const pricing = {
     inputUsdPer1M: PRICING.input,
     cacheReadUsdPer1M: PRICING.cachedInput,

--- a/packages/headless/harbor/run-prompt-ab.mjs
+++ b/packages/headless/harbor/run-prompt-ab.mjs
@@ -15,7 +15,7 @@ import { homedir } from 'node:os';
 import { basename, join, relative, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { promisify } from 'node:util';
-import { BENCHMARK_BASE_SYSTEM_PROMPT } from '@maka/headless';
+import { DEFAULT_HEADLESS_SYSTEM_PROMPT } from '@maka/headless';
 import { discoverCachedHarborTasks, resolveFixedPromptRunRoot } from '#fixed-prompt-task-source';
 import {
   buildPromptAbRunManifest,
@@ -384,7 +384,7 @@ async function main() {
     throw new Error('no evaluation tasks available for prompt A/B');
   }
 
-  const baselinePrompt = `${BENCHMARK_BASE_SYSTEM_PROMPT}\n`;
+  const baselinePrompt = DEFAULT_HEADLESS_SYSTEM_PROMPT;
   const runManifest = buildPromptAbRunManifest({
     baselinePromptHash: hashSystemPrompt(baselinePrompt),
     candidatePromptHash: hashSystemPrompt(candidatePrompt),

--- a/packages/headless/harbor/run-prompt-optimization.mjs
+++ b/packages/headless/harbor/run-prompt-optimization.mjs
@@ -21,7 +21,7 @@ import { mkdir, writeFile, readFile } from 'node:fs/promises';
 import { availableParallelism, homedir } from 'node:os';
 import { join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { BENCHMARK_BASE_SYSTEM_PROMPT } from '@maka/headless';
+import { DEFAULT_HEADLESS_SYSTEM_PROMPT } from '@maka/headless';
 import { discoverCachedHarborTasks, resolveFixedPromptRunRoot } from '#fixed-prompt-task-source';
 import {
   buildRewardHackVerifierPatterns,
@@ -256,7 +256,7 @@ async function main() {
   await readFile(keyFile, 'utf8');
   const initialSystemPrompt = initialSystemPromptFile
     ? await readFile(initialSystemPromptFile, 'utf8')
-    : `${BENCHMARK_BASE_SYSTEM_PROMPT}\n`;
+    : DEFAULT_HEADLESS_SYSTEM_PROMPT;
 
   const allTasks = await discoverCachedHarborTasks(tasksRoot);
   console.log(`Discovered ${allTasks.length} cached tasks under ${tasksRoot}`);

--- a/packages/headless/harbor/run-runtime-policy-ab.mjs
+++ b/packages/headless/harbor/run-runtime-policy-ab.mjs
@@ -5,7 +5,7 @@ import { mkdir, readFile, writeFile } from 'node:fs/promises';
 import { homedir } from 'node:os';
 import { join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { BENCHMARK_BASE_SYSTEM_PROMPT } from '@maka/headless';
+import { DEFAULT_HEADLESS_SYSTEM_PROMPT } from '@maka/headless';
 import { ensureAbRunManifest } from '#ab-manifest';
 import { discoverCachedHarborTasks, resolveFixedPromptRunRoot } from '#fixed-prompt-task-source';
 import { createHarborTaskRunner } from '#harbor-task-runner';
@@ -56,7 +56,7 @@ async function main() {
   const allTasks = await discoverCachedHarborTasks(tasksRoot, selectedTaskIds);
   const pilotTasks = selectTasks(allTasks, spec.pilotTaskIds, 'pilotTaskIds');
   const evaluationTasks = selectTasks(allTasks, spec.evaluationTaskIds, 'evaluationTaskIds');
-  const systemPrompt = `${BENCHMARK_BASE_SYSTEM_PROMPT}\n`;
+  const systemPrompt = DEFAULT_HEADLESS_SYSTEM_PROMPT;
   const runManifest = buildRuntimePolicyAbRunManifest({
     arms: spec.arms,
     promptHash: `sha256:${createHash('sha256').update(JSON.stringify(systemPrompt)).digest('hex')}`,

--- a/packages/headless/src/__tests__/cell-output.test.ts
+++ b/packages/headless/src/__tests__/cell-output.test.ts
@@ -127,6 +127,7 @@ describe('Harbor cell output contract', () => {
         llmConnectionSlug: 'deepseek',
         model: 'deepseek-v4-flash',
         reasoningEffort: 'max',
+        systemPromptMode: 'custom',
         systemPromptHash: 'sha256:prompt-a',
         pricingProfile: 'deepseek-v4-flash-tbench-v1',
       },
@@ -136,6 +137,7 @@ describe('Harbor cell output contract', () => {
       llmConnectionSlug: 'deepseek',
       model: 'deepseek-v4-flash',
       reasoningEffort: 'max',
+      systemPromptMode: 'custom',
       systemPromptHash: 'sha256:prompt-a',
       pricingProfile: 'deepseek-v4-flash-tbench-v1',
     });

--- a/packages/headless/src/__tests__/economy-task-policy.test.ts
+++ b/packages/headless/src/__tests__/economy-task-policy.test.ts
@@ -4,7 +4,6 @@ import type { Config, Task } from '../contracts.js';
 import {
   appendEconomyTaskPolicyToSystemPrompt,
   buildEconomyTaskSystemPromptPolicy,
-  configWithEconomyTaskPolicy,
   ECONOMY_TASK_POLICY_VERSION,
   resolveEconomyTaskMode,
 } from '../economy-task-policy.js';
@@ -37,7 +36,6 @@ describe('economy-task policy', () => {
       appendEconomyTaskPolicyToSystemPrompt(baseConfig.systemPrompt, selection),
       baseConfig.systemPrompt,
     );
-    assert.equal(configWithEconomyTaskPolicy(baseConfig, selection), baseConfig);
   });
 
   test('config enablement records source, reason, and policy version', () => {

--- a/packages/headless/src/__tests__/harbor-adapter.test.ts
+++ b/packages/headless/src/__tests__/harbor-adapter.test.ts
@@ -535,15 +535,31 @@ describe('Harbor adapter contract', () => {
     assert.doesNotMatch(source, /DEEPSEEK_API_KEY[^_]/);
   });
 
-  test('run-harness-ab.mjs consumes advisory registry evidence without invoking Oracle', async () => {
+  test('run-harness-ab.mjs uses the mandatory default prompt and advisory registry evidence', async () => {
     const source = await readRepoFile('packages/headless/harbor/run-harness-ab.mjs');
 
+    assert.match(source, /DEFAULT_HEADLESS_SYSTEM_PROMPT/);
+    assert.match(source, /default-system-prompt\.txt/);
+    assert.doesNotMatch(source, /empty-system-prompt\.txt/);
     assert.match(source, /loadHarnessOracleRegistrySnapshot/);
     assert.match(source, /resolveHarnessOracleAnnotations/);
     assert.match(source, /taskIds: TERMINAL_BENCH_2_1_TASK_IDS/);
     assert.doesNotMatch(source, /ensureHarnessOracleQualification/);
     assert.doesNotMatch(source, /createHarborOracleQualifier/);
     assert.doesNotMatch(source, /qualification\.selectedTaskIds/);
+  });
+
+  test('prompt experiment baselines use the default headless prompt byte-for-byte', async () => {
+    for (const path of [
+      'packages/headless/harbor/run-prompt-ab.mjs',
+      'packages/headless/harbor/run-prompt-optimization.mjs',
+      'packages/headless/harbor/run-runtime-policy-ab.mjs',
+    ]) {
+      const source = await readRepoFile(path);
+
+      assert.match(source, /DEFAULT_HEADLESS_SYSTEM_PROMPT/);
+      assert.doesNotMatch(source, /`\$\{DEFAULT_HEADLESS_SYSTEM_PROMPT\}\\n`/);
+    }
   });
 
   test('run-prompt-ab.mjs rejects unsupported provider overrides', async (t: TestContext) => {
@@ -1892,6 +1908,20 @@ with tempfile.TemporaryDirectory() as tmp:
     # The default model must not be the deprecated deepseek-chat alias.
     default_model_env = MakaAgent(Path(tmp), extra_env={"MAKA_HOST_API_KEY_FILE": "/host/deepseek-key"})._cell_env(Path("/logs/agent/instruction.txt"))
     assert default_model_env["MAKA_MODEL"] == "deepseek/deepseek-v4-flash", default_model_env
+    assert "MAKA_SYSTEM_PROMPT" not in default_model_env, default_model_env
+
+    custom_prompt = "Custom prompt with exact bytes.\n"
+    custom_prompt_env = MakaAgent(Path(tmp), extra_env={
+        "MAKA_HOST_API_KEY_FILE": "/host/deepseek-key",
+        "MAKA_SYSTEM_PROMPT": custom_prompt,
+    })._cell_env(Path("/logs/agent/instruction.txt"))
+    assert custom_prompt_env["MAKA_SYSTEM_PROMPT"] == custom_prompt, custom_prompt_env
+
+    empty_prompt_env = MakaAgent(Path(tmp), extra_env={
+        "MAKA_HOST_API_KEY_FILE": "/host/deepseek-key",
+        "MAKA_SYSTEM_PROMPT": "",
+    })._cell_env(Path("/logs/agent/instruction.txt"))
+    assert empty_prompt_env["MAKA_SYSTEM_PROMPT"] == "", empty_prompt_env
 
     # The in-container Bash command-timeout floor reaches the cell.
     command_timeout_env = MakaAgent(Path(tmp), extra_env={

--- a/packages/headless/src/__tests__/harbor-cell.test.ts
+++ b/packages/headless/src/__tests__/harbor-cell.test.ts
@@ -46,6 +46,7 @@ import {
   runHarborCell,
   writeHarborCellUsageCheckpoint,
 } from '../harbor-cell.js';
+import { DEFAULT_HEADLESS_SYSTEM_PROMPT } from '../system-prompts.js';
 import { buildIsolatedBashTool } from '../tools.js';
 
 const config: Config = {
@@ -795,6 +796,7 @@ describe('runHarborCell', () => {
       assert.deepEqual(result.output.executionIdentity, {
         llmConnectionSlug: 'fake',
         model: 'fake-model',
+        systemPromptMode: 'custom',
         systemPromptHash: `sha256:${createHash('sha256').update(JSON.stringify(config.systemPrompt)).digest('hex')}`,
         pricingProfile: 'deepseek-v4-flash-tbench-v1',
       });
@@ -1037,6 +1039,7 @@ describe('runHarborCell', () => {
       assert.deepEqual(observedIdentity, {
         llmConnectionSlug: 'fake',
         model: 'fake-model',
+        systemPromptMode: 'custom',
         systemPromptHash: `sha256:${createHash('sha256').update(JSON.stringify(config.systemPrompt)).digest('hex')}`,
         pricingProfile: 'deepseek-v4-flash-tbench-v1',
       });
@@ -1559,6 +1562,62 @@ describe('runHarborCell', () => {
     });
   });
 
+  test('injects the default headless prompt before registering a Harbor backend', async () => {
+    await withDirs(async ({ workspaceDir, outputDir, storageRoot }) => {
+      let capturedPrompt: string | undefined;
+
+      const result = await runHarborCell({
+        config: { ...config, systemPrompt: undefined },
+        instruction: 'solve with the default prompt',
+        cwd: workspaceDir,
+        outputDir,
+        storageRoot,
+        registerBackends: (registry, context) => {
+          capturedPrompt = context.config.systemPrompt;
+          registerCellBackend(registry);
+        },
+      });
+
+      assert.equal(
+        capturedPrompt,
+        [
+          'Complete the task by acting with the available tools, not by narrating.',
+          'Prefer Read, Glob, and Grep for inspection, Edit and Write for file changes, and Bash for shell commands and tests.',
+          'Verify the result when practical.',
+          'Stop when the task is complete.',
+        ].join('\n'),
+      );
+      assert.equal(result.output.executionIdentity?.systemPromptMode, 'default');
+    });
+  });
+
+  test('rejects a blank Harbor system prompt before registering a backend', async () => {
+    await withDirs(async ({ workspaceDir, outputDir, storageRoot }) => {
+      let registered = false;
+
+      await assert.rejects(
+        runHarborCellFromEnv(
+          {
+            MAKA_BACKEND: 'fake',
+            MAKA_INSTRUCTION: 'solve with an invalid prompt',
+            MAKA_WORKDIR: workspaceDir,
+            MAKA_OUTPUT_DIR: outputDir,
+            MAKA_STORAGE_ROOT: storageRoot,
+            MAKA_SYSTEM_PROMPT: ' \n ',
+          },
+          {
+            registerBackends: (registry) => {
+              registered = true;
+              registerCellBackend(registry);
+            },
+          },
+        ),
+        /Config\.systemPrompt must contain non-whitespace text/,
+      );
+      assert.equal(registered, false);
+    });
+  });
+
   test('appends heavy-task policy to Harbor backend context only when explicitly enabled', async () => {
     await withDirs(async ({ workspaceDir, outputDir, storageRoot }) => {
       const seenPrompts: Array<string | undefined> = [];
@@ -1899,6 +1958,7 @@ describe('runHarborCell', () => {
           backend: 'ai-sdk',
           llmConnectionSlug: 'openai',
           model: 'gpt-4o-mini',
+          systemPrompt: DEFAULT_HEADLESS_SYSTEM_PROMPT,
         },
         task: { id: 'harbor-cell', instruction: 'solve', workspaceDir },
         workspaceDir,

--- a/packages/headless/src/__tests__/harness-ab-run.test.ts
+++ b/packages/headless/src/__tests__/harness-ab-run.test.ts
@@ -3,11 +3,12 @@ import { mkdtemp, readFile, readdir, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, test } from 'node:test';
-import { hashHarborSystemPrompt, type HarborCellOutput } from '../cell-output.js';
+import type { HarborCellOutput } from '../cell-output.js';
 import type { HarborTaskRunner } from '../fixed-prompt-controller.js';
 import { assertHarnessAbReportCompleted, buildHarnessAbReport } from '../harness-ab-report.js';
 import { runHarnessAbComparison } from '../harness-ab-run.js';
 import { HarborInfraError } from '../harbor-task-runner.js';
+import { hashHeadlessSystemPrompt } from '../system-prompts.js';
 import { tokenSummary } from './helpers/cell-output-fixtures.js';
 
 describe('runHarnessAbComparison', () => {
@@ -345,7 +346,7 @@ function harnessArm(id: 'maka' | 'opencode', calls: string[], beforeRun?: () => 
   const harborRunner: HarborTaskRunner = async ({ task, systemPrompt }) => {
     await beforeRun?.();
     calls.push(`${task.id}:${id}`);
-    const promptHash = hashHarborSystemPrompt(systemPrompt);
+    const promptHash = hashHeadlessSystemPrompt(systemPrompt);
     const cell: HarborCellOutput = {
       schemaVersion: 1,
       status: 'completed',

--- a/packages/headless/src/__tests__/heavy-task-policy.test.ts
+++ b/packages/headless/src/__tests__/heavy-task-policy.test.ts
@@ -4,7 +4,6 @@ import type { Config, Task } from '../contracts.js';
 import {
   appendHeavyTaskPolicyToSystemPrompt,
   buildHeavyTaskSystemPromptPolicy,
-  configWithHeavyTaskPolicy,
   FORBIDDEN_HEAVY_TASK_POLICY_TERMS,
   HEAVY_TASK_POLICY_VERSION,
   resolveHeavyTaskMode,
@@ -74,7 +73,6 @@ describe('heavy-task policy', () => {
       appendHeavyTaskPolicyToSystemPrompt(baseConfig.systemPrompt, selection),
       baseConfig.systemPrompt,
     );
-    assert.equal(configWithHeavyTaskPolicy(baseConfig, selection), baseConfig);
   });
 
   test('config enablement records source, reason, and policy version', () => {

--- a/packages/headless/src/__tests__/runner.test.ts
+++ b/packages/headless/src/__tests__/runner.test.ts
@@ -1,4 +1,5 @@
 import assert from 'node:assert/strict';
+import { createHash } from 'node:crypto';
 import { mkdtemp, readdir, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -568,6 +569,13 @@ describe('Config.systemPrompt (benchmark config variable, not session state)', (
       });
 
       assert.equal(result.status, 'completed');
+      assert.equal(result.systemPromptMode, 'custom');
+      assert.equal(
+        result.systemPromptHash,
+        `sha256:${createHash('sha256')
+          .update(JSON.stringify(configWithPrompt.systemPrompt))
+          .digest('hex')}`,
+      );
       assert.equal(captured.length, 1);
       assert.equal(
         captured[0]?.systemPrompt,
@@ -577,18 +585,18 @@ describe('Config.systemPrompt (benchmark config variable, not session state)', (
     });
   });
 
-  test('omitting systemPrompt leaves it undefined in the factory context (no default injection)', async () => {
+  test('omitting systemPrompt injects the default headless prompt in the factory context', async () => {
     await withDirs(async (fixtureDir, storageRoot) => {
       await writeFile(join(fixtureDir, 'marker.txt'), 'present', 'utf8');
       const captured: { systemPrompt?: string }[] = [];
       const task: Task = {
-        id: 'no-prompt-task',
+        id: 'default-prompt-task',
         instruction: 'do the thing',
         workspaceDir: fixtureDir,
         verification: { command: 'test -f marker.txt', protectedPaths: [] },
       };
 
-      await runExperiment(fakeConfig, task, {
+      const result = await runExperiment(fakeConfig, task, {
         storageRoot,
         registerBackends: registerCapturingBackend(captured),
       });
@@ -596,9 +604,107 @@ describe('Config.systemPrompt (benchmark config variable, not session state)', (
       assert.equal(captured.length, 1);
       assert.equal(
         captured[0]?.systemPrompt,
-        undefined,
-        'no systemPrompt should be injected when Config omits it',
+        [
+          'Complete the task by acting with the available tools, not by narrating.',
+          'Prefer Read, Glob, and Grep for inspection, Edit and Write for file changes, and Bash for shell commands and tests.',
+          'Verify the result when practical.',
+          'Stop when the task is complete.',
+        ].join('\n'),
+        'the factory must receive the default headless system prompt',
       );
+      assert.equal(result.systemPromptMode, 'default');
+      assert.equal(
+        result.systemPromptHash,
+        `sha256:${createHash('sha256')
+          .update(JSON.stringify(captured[0]?.systemPrompt))
+          .digest('hex')}`,
+      );
+    });
+  });
+
+  test('rejects a blank custom systemPrompt before registering a backend', async () => {
+    await withDirs(async (fixtureDir, storageRoot) => {
+      const task: Task = {
+        id: 'blank-prompt-task',
+        instruction: 'do the thing',
+        workspaceDir: fixtureDir,
+        verification: { command: 'true', protectedPaths: [] },
+      };
+      let registered = false;
+
+      await assert.rejects(
+        runExperiment({ ...fakeConfig, systemPrompt: '\n \t' }, task, {
+          storageRoot,
+          registerBackends: (registry) => {
+            registered = true;
+            registerFakeBackend(registry);
+          },
+        }),
+        /systemPrompt must contain non-whitespace text/,
+      );
+      assert.equal(registered, false);
+    });
+  });
+
+  test('does not append heavy-task policy without the required direct-runner tools', async () => {
+    await withDirs(async (fixtureDir, storageRoot) => {
+      const captured: { systemPrompt?: string }[] = [];
+      const task: Task = {
+        id: 'heavy-default-prompt-task',
+        instruction: 'do the thing',
+        workspaceDir: fixtureDir,
+        verification: { command: 'true', protectedPaths: [] },
+      };
+
+      const result = await runExperiment({ ...fakeConfig, heavyTaskMode: true }, task, {
+        storageRoot,
+        registerBackends: registerCapturingBackend(captured),
+      });
+
+      const prompt = captured[0]?.systemPrompt ?? '';
+      assert.equal(
+        prompt,
+        [
+          'Complete the task by acting with the available tools, not by narrating.',
+          'Prefer Read, Glob, and Grep for inspection, Edit and Write for file changes, and Bash for shell commands and tests.',
+          'Verify the result when practical.',
+          'Stop when the task is complete.',
+        ].join('\n'),
+      );
+      assert.doesNotMatch(prompt, /Heavy-task benchmark policy/);
+      assert.equal(
+        result.systemPromptHash,
+        `sha256:${createHash('sha256').update(JSON.stringify(prompt)).digest('hex')}`,
+      );
+    });
+  });
+
+  test('does not change direct-runner policy behavior while resolving Layer 1', async () => {
+    await withDirs(async (fixtureDir, storageRoot) => {
+      const captured: { systemPrompt?: string }[] = [];
+      const task: Task = {
+        id: 'economy-default-prompt-task',
+        instruction: 'do the thing',
+        workspaceDir: fixtureDir,
+        verification: { command: 'true', protectedPaths: [] },
+      };
+
+      await runExperiment({ ...fakeConfig, economyTaskMode: true }, task, {
+        storageRoot,
+        registerBackends: registerCapturingBackend(captured),
+      });
+
+      const prompt = captured[0]?.systemPrompt ?? '';
+      assert.equal(
+        prompt,
+        [
+          'Complete the task by acting with the available tools, not by narrating.',
+          'Prefer Read, Glob, and Grep for inspection, Edit and Write for file changes, and Bash for shell commands and tests.',
+          'Verify the result when practical.',
+          'Stop when the task is complete.',
+        ].join('\n'),
+      );
+      assert.doesNotMatch(prompt, /Economy-task benchmark policy/);
     });
   });
 

--- a/packages/headless/src/__tests__/task-agent-controller.test.ts
+++ b/packages/headless/src/__tests__/task-agent-controller.test.ts
@@ -1,4 +1,5 @@
 import assert from 'node:assert/strict';
+import { createHash } from 'node:crypto';
 import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -822,6 +823,41 @@ async function readAgentRunHeader(
 }
 
 describe('runTaskOnce', () => {
+  test('injects the default headless system prompt before registering a backend', async () => {
+    await withDirs(async (fixtureDir, storageRoot) => {
+      const task: Task = {
+        id: 'default-prompt-task',
+        instruction: 'do the thing',
+        workspaceDir: fixtureDir,
+        verification: { command: 'true', protectedPaths: [] },
+      };
+      let capturedPrompt: string | undefined;
+
+      const result = await runTaskOnce(fakeConfig, task, {
+        storageRoot,
+        registerBackends: (registry, context) => {
+          capturedPrompt = context.config.systemPrompt;
+          registerFakeBackend(registry);
+        },
+      });
+
+      assert.equal(
+        capturedPrompt,
+        [
+          'Complete the task by acting with the available tools, not by narrating.',
+          'Prefer Read, Glob, and Grep for inspection, Edit and Write for file changes, and Bash for shell commands and tests.',
+          'Verify the result when practical.',
+          'Stop when the task is complete.',
+        ].join('\n'),
+      );
+      assert.equal(result.resultRecord.systemPromptMode, 'default');
+      assert.equal(
+        result.resultRecord.systemPromptHash,
+        `sha256:${createHash('sha256').update(JSON.stringify(capturedPrompt)).digest('hex')}`,
+      );
+    });
+  });
+
   test('uses RuntimeRunner path without SessionManager.sendMessage and writes a passing ledger', async () => {
     await withDirs(async (fixtureDir, storageRoot) => {
       await writeFile(join(fixtureDir, 'marker.txt'), 'present', 'utf8');

--- a/packages/headless/src/cell-output.ts
+++ b/packages/headless/src/cell-output.ts
@@ -1,7 +1,7 @@
-import { createHash } from 'node:crypto';
 import type { RuntimeEvent } from '@maka/core';
 import type { ThinkingLevel } from '@maka/core';
 import type { ContextBudgetPolicy, InvocationResult } from '@maka/runtime';
+import type { HeadlessSystemPromptMode } from './contracts.js';
 
 export const HARBOR_CELL_OUTPUT_SCHEMA_VERSION = 1;
 
@@ -63,6 +63,8 @@ export interface HarborCellExecutionIdentity {
   llmConnectionSlug: string;
   model: string;
   reasoningEffort?: ThinkingLevel;
+  /** Present on artifacts written after prompt-source auditing was introduced. */
+  systemPromptMode?: HeadlessSystemPromptMode;
   systemPromptHash: string;
   pricingProfile: string;
 }
@@ -189,10 +191,6 @@ export function countRuntimeSteps(events: readonly RuntimeEvent[]): number {
   );
 }
 
-export function hashHarborSystemPrompt(systemPrompt: string): string {
-  return `sha256:${createHash('sha256').update(JSON.stringify(systemPrompt)).digest('hex')}`;
-}
-
 export function validateHarborCellOutput(value: unknown): HarborCellOutput {
   if (!isRecord(value)) {
     throw new Error('Harbor cell output must be a JSON object');
@@ -283,6 +281,15 @@ export function validateHarborCellExecutionIdentity(value: unknown): HarborCellE
           reasoningEffort: requireThinkingLevel(
             value.reasoningEffort,
             'executionIdentity.reasoningEffort',
+          ),
+        }
+      : {}),
+    ...('systemPromptMode' in value
+      ? {
+          systemPromptMode: requireStringUnion(
+            value.systemPromptMode,
+            'executionIdentity.systemPromptMode',
+            ['default', 'custom'] as const,
           ),
         }
       : {}),

--- a/packages/headless/src/contracts.ts
+++ b/packages/headless/src/contracts.ts
@@ -134,12 +134,13 @@ export interface Config {
   /** Provider-native reasoning depth for a fixed benchmark configuration. */
   thinkingLevel?: ThinkingLevel;
   /**
-   * Optional system prompt for the config under test. This is a benchmark
-   * variable, NOT persisted session state — the `registerBackends` factory
-   * reads it from its closure and passes it to the backend constructor
-   * directly (same pattern as the desktop interactive path). It never
-   * enters `SessionHeader` or `BackendFactoryContext.systemPrompt` (which
-   * is the child-agent instruction channel, not the main-session prompt).
+   * Complete Layer 1 system prompt for the config under test. Headless uses
+   * its non-empty default when omitted, preserves a non-empty custom string
+   * byte-for-byte, and rejects empty or whitespace-only strings before
+   * execution. Task-run and Harbor paths retain their existing enabled policy
+   * overlays; the legacy direct runner resolves Layer 1 only. This benchmark
+   * variable is passed directly to the backend constructor; it is not persisted
+   * session state or the child-agent instruction channel.
    */
   systemPrompt?: string;
   /**
@@ -168,12 +169,18 @@ export interface EconomyTaskModeConfig {
   policyVersion?: string;
 }
 
+export type HeadlessSystemPromptMode = 'default' | 'custom';
+
 /** One row of canonical truth per run: did it run, did it pass, and how much it cost. */
 export interface ResultRecord {
   taskId: string;
   configId: string;
   sessionId: string;
   runId: string;
+  /** Layer 1 source used by new headless runs; absent on legacy records. */
+  systemPromptMode?: HeadlessSystemPromptMode;
+  /** SHA-256 of the final model-visible system prompt, including policy overlays. */
+  systemPromptHash?: string;
   /** Did the agent invocation finish (vs. error out mid-run)? */
   status: 'completed' | 'failed';
   /** Explicit runner status; legacy `status` is preserved for JSONL readers. */

--- a/packages/headless/src/economy-task-policy.ts
+++ b/packages/headless/src/economy-task-policy.ts
@@ -140,15 +140,6 @@ export function appendEconomyTaskPolicyToSystemPrompt(
     .join('\n\n');
 }
 
-export function configWithEconomyTaskPolicy(
-  config: Config,
-  selection: EconomyTaskModeSelection,
-): Config {
-  const systemPrompt = appendEconomyTaskPolicyToSystemPrompt(config.systemPrompt, selection);
-  if (systemPrompt === config.systemPrompt) return config;
-  return { ...config, systemPrompt };
-}
-
 function normalizeTaskMetadataMode(
   metadata: Record<string, unknown> | undefined,
 ): EconomyTaskModeConfig | undefined {

--- a/packages/headless/src/fixed-prompt-controller.ts
+++ b/packages/headless/src/fixed-prompt-controller.ts
@@ -3,7 +3,6 @@ import { appendFile, mkdir, readFile, truncate, writeFile } from 'node:fs/promis
 import { dirname, resolve } from 'node:path';
 import {
   validateHarborCellOutput,
-  hashHarborSystemPrompt,
   type HarborCellContextBudgetPolicySnapshot,
   type HarborCellContextBudgetSummary,
   type HarborCellContinuationSummary,
@@ -18,6 +17,7 @@ import { syncParentDirectory } from './immutable-file.js';
 import type { MakaChangeAuditRecord } from './change-audit.js';
 import type { HarborBillingMode } from './harbor-task-runner.js';
 import { assertFinitePositive, assertPositiveInt, assertRatio } from './numeric-guards.js';
+import { hashHeadlessSystemPrompt } from './system-prompts.js';
 
 export const FIXED_PROMPT_WAL_SCHEMA_VERSION = 1;
 export const BUDGET_EXHAUSTED_RUNTIME_UNAVAILABLE_REASON = 'budget_exhausted_before_cell_output';
@@ -1603,7 +1603,7 @@ async function truncateTornWalTail(path: string): Promise<void> {
 }
 
 export function hashSystemPrompt(systemPrompt: string): string {
-  return hashHarborSystemPrompt(systemPrompt);
+  return hashHeadlessSystemPrompt(systemPrompt);
 }
 
 async function readJsonObject(path: string): Promise<Record<string, unknown>> {

--- a/packages/headless/src/harbor-cell.ts
+++ b/packages/headless/src/harbor-cell.ts
@@ -30,14 +30,13 @@ import { registerFakeBackend } from './backends.js';
 import {
   buildHarborCellOutput,
   countRuntimeSteps,
-  hashHarborSystemPrompt,
   validateHarborCellOutput,
   type HarborCellContextBudgetPolicySnapshot,
   type HarborCellOutput,
 } from './cell-output.js';
 import type { Config, Task } from './contracts.js';
-import { configWithHeavyTaskPolicy, resolveHeavyTaskMode } from './heavy-task-policy.js';
-import { configWithEconomyTaskPolicy, resolveEconomyTaskMode } from './economy-task-policy.js';
+import { resolveHeavyTaskMode } from './heavy-task-policy.js';
+import { resolveEconomyTaskMode } from './economy-task-policy.js';
 import type { HeadlessBackendContext, RealBackendIsolation } from './isolation.js';
 import { validateRealBackendIsolation } from './isolation.js';
 import { PiCliJsonTransport } from './pi-cli-json-transport.js';
@@ -45,6 +44,7 @@ import { providerFromEnv, resolveHarborCellAiSdkEnv } from './provider-env.js';
 import { backendNeedsIsolation } from './runner.js';
 import { buildIsolatedHeadlessToolAvailability, buildIsolatedHeadlessTools } from './tools.js';
 import { createHeadlessSessionCapabilityBridge } from './session-capabilities.js';
+import { resolveHeadlessSystemPrompt } from './system-prompts.js';
 import {
   createInMemoryTaskLedgerExperimentStore,
   renderTaskLedgerExperimentReplay,
@@ -251,9 +251,9 @@ export async function runHarborCell(input: RunHarborCellInput): Promise<RunHarbo
     workspaceDir: input.cwd,
   };
   const heavyTaskMode = resolveHeavyTaskMode(input.config, task);
-  const configAfterHeavy = configWithHeavyTaskPolicy(input.config, heavyTaskMode);
-  const economyTaskMode = resolveEconomyTaskMode(configAfterHeavy, task);
-  const config = configWithEconomyTaskPolicy(configAfterHeavy, economyTaskMode);
+  const economyTaskMode = resolveEconomyTaskMode(input.config, task);
+  const prompt = resolveHeadlessSystemPrompt(input.config, { heavyTaskMode, economyTaskMode });
+  const config = { ...input.config, systemPrompt: prompt.systemPrompt };
   const registerBackends =
     input.registerBackends ?? ((registry: BackendRegistry) => registerFakeBackend(registry));
   await registerBackends(backends, {
@@ -274,7 +274,8 @@ export async function runHarborCell(input: RunHarborCellInput): Promise<RunHarbo
     llmConnectionSlug: config.llmConnectionSlug,
     model: config.model,
     ...(config.thinkingLevel ? { reasoningEffort: config.thinkingLevel } : {}),
-    systemPromptHash: hashHarborSystemPrompt(config.systemPrompt ?? ''),
+    systemPromptMode: prompt.mode,
+    systemPromptHash: prompt.systemPromptHash,
     pricingProfile: input.pricingProfile ?? 'unconfigured',
   };
   await mkdir(input.outputDir, { recursive: true });
@@ -776,7 +777,7 @@ export function buildAiSdkCellBackendRegistration(input: {
           ? (childInput) => context.readChildAgentOutput!(ctx.sessionId, childInput)
           : undefined,
         providerOptions: buildProviderOptions(connection, input.model, ctx.header.thinkingLevel),
-        systemPrompt: harborCellSystemPrompt(context.config.systemPrompt),
+        systemPrompt: context.config.systemPrompt,
         ...(taskLedgerExperimentStore && taskLedgerExperimentPolicy
           ? {
               turnTailPrompt: async ({ sessionId }) =>
@@ -849,22 +850,6 @@ function buildHarborCellSynthesisCacheCallbacks(
     loadSynthesisCache: (event) => loadSynthesisCacheBlocksFromArtifacts(artifactStore, event),
     writeSynthesisCache: (event) => persistSynthesisCacheBlocksToArtifacts(artifactStore, event),
   };
-}
-
-// When the cell is given an explicit system prompt (MAKA_SYSTEM_PROMPT), it is
-// the complete prompt and is passed through byte-for-byte: the prompt-optimization
-// controller hashes exactly this string and verifies the round-trip against the
-// systemPromptHash the runtime stamps, so any wrapping here would break the check
-// (and make "the prompt being optimized" differ from "the prompt that ran").
-// The built-in preamble is only the default for prompt-less ad-hoc cell runs.
-function harborCellSystemPrompt(configPrompt: string | undefined): string {
-  if (configPrompt !== undefined) return configPrompt;
-  return [
-    'You are Maka Runtime running inside an isolated Harbor benchmark task container.',
-    'Prefer Read, Glob, and Grep for file inspection and search.',
-    'Prefer Edit and Write for file changes.',
-    'Use Bash for running programs, tests, and shell-specific debugging only.',
-  ].join('\n');
 }
 
 // Builtin pricing has no entry for newer DeepSeek models (e.g. deepseek-v4-flash),

--- a/packages/headless/src/heavy-task-policy.ts
+++ b/packages/headless/src/heavy-task-policy.ts
@@ -126,15 +126,6 @@ export function appendHeavyTaskPolicyToSystemPrompt(
     .join('\n\n');
 }
 
-export function configWithHeavyTaskPolicy(
-  config: Config,
-  selection: HeavyTaskModeSelection,
-): Config {
-  const systemPrompt = appendHeavyTaskPolicyToSystemPrompt(config.systemPrompt, selection);
-  if (systemPrompt === config.systemPrompt) return config;
-  return { ...config, systemPrompt };
-}
-
 function normalizeTaskMetadataMode(
   metadata: Record<string, unknown> | undefined,
 ): HeavyTaskModeConfig | undefined {

--- a/packages/headless/src/index.ts
+++ b/packages/headless/src/index.ts
@@ -319,11 +319,10 @@ export {
   writeTaskRunExport,
 } from './result-export.js';
 export { normalizeVerifier } from './verifier.js';
-export { BENCHMARK_BASE_SYSTEM_PROMPT } from './system-prompts.js';
+export { DEFAULT_HEADLESS_SYSTEM_PROMPT } from './system-prompts.js';
 export {
   appendHeavyTaskPolicyToSystemPrompt,
   buildHeavyTaskSystemPromptPolicy,
-  configWithHeavyTaskPolicy,
   FORBIDDEN_HEAVY_TASK_POLICY_TERMS,
   HEAVY_TASK_POLICY_VERSION,
   resolveHeavyTaskMode,
@@ -333,7 +332,6 @@ export {
 export {
   appendEconomyTaskPolicyToSystemPrompt,
   buildEconomyTaskSystemPromptPolicy,
-  configWithEconomyTaskPolicy,
   ECONOMY_TASK_POLICY_VERSION,
   resolveEconomyTaskMode,
   type EconomyTaskModeSelection,

--- a/packages/headless/src/runner.ts
+++ b/packages/headless/src/runner.ts
@@ -22,6 +22,7 @@ import { buildIsolatedHeadlessTools } from './tools.js';
 import { normalizeVerifier, runVerifier, verifierProtectedPaths } from './verifier.js';
 import type { BenchmarkAdapterRegistry } from './benchmark-adapters.js';
 import { createHeadlessSessionCapabilityBridge } from './session-capabilities.js';
+import { resolveHeadlessSystemPrompt } from './system-prompts.js';
 
 export interface RunExperimentDeps {
   /**
@@ -98,6 +99,8 @@ export async function runExperiment(
   const now = deps.now ?? Date.now;
   const newId = deps.newId ?? randomUUID;
   const startedAt = now();
+  const prompt = resolveHeadlessSystemPrompt(config);
+  const effectiveConfig = { ...config, systemPrompt: prompt.systemPrompt };
 
   const workspace = await prepareWorkspace(task.workspaceDir);
   try {
@@ -108,7 +111,7 @@ export async function runExperiment(
     const registerBackends: NonNullable<RunExperimentDeps['registerBackends']> =
       deps.registerBackends ?? ((registry) => registerFakeBackend(registry));
     await registerBackends(backends, {
-      config,
+      config: effectiveConfig,
       task,
       workspaceDir: agentWorkspaceDir,
       ...sessionCapabilities.capabilities,
@@ -205,6 +208,8 @@ export async function runExperiment(
         configId: config.id,
         sessionId: session.id,
         runId: invocation?.runId ?? turnId,
+        systemPromptMode: prompt.mode,
+        systemPromptHash: prompt.systemPromptHash,
         status,
         runnerCompleted,
         passed: finalScore.passed,

--- a/packages/headless/src/system-prompts.ts
+++ b/packages/headless/src/system-prompts.ts
@@ -1,25 +1,62 @@
-/**
- * Benchmark base system prompt.
- *
- * Real models running benchmark tasks (Terminal-Bench, SWE-bench, …) without a
- * system prompt tend to narrate their reasoning in text instead of calling
- * tools, hit the output token limit, and never produce the required artifact.
- * This prompt steers the model toward tool-first action without leaking any
- * task-specific answer — it is a generic "how to work in this environment"
- * prefix, not a hint.
- *
- * This base prompt assumes the standard isolated headless tool surface, which
- * includes an isolated Bash tool (buildIsolatedHeadlessTools). For file-only
- * benchmarks that intentionally drop Bash, derive a variant that says so.
- *
- * Use it by setting `Config.systemPrompt` to this string (or a derivative that
- * adapts the path/tool guidance to a specific benchmark's environment).
- */
-export const BENCHMARK_BASE_SYSTEM_PROMPT = `You are an autonomous coding agent working inside a benchmark evaluation. Your job is to solve the given task by acting, not by narrating.
+import { createHash } from 'node:crypto';
+import type { Config, HeadlessSystemPromptMode } from './contracts.js';
+import {
+  appendEconomyTaskPolicyToSystemPrompt,
+  type EconomyTaskModeSelection,
+} from './economy-task-policy.js';
+import {
+  appendHeavyTaskPolicyToSystemPrompt,
+  type HeavyTaskModeSelection,
+} from './heavy-task-policy.js';
 
-Rules:
-1. Call tools to make changes. Do not write long explanations before acting — think briefly, then use the Write/Edit tools immediately.
-2. The working directory is your current directory. Use relative paths only (e.g. "result.txt", not "/app/result.txt"). Absolute paths will be rejected.
-3. Do not self-test or run verification scripts — the evaluator scores your output separately after you finish. Use shell tools only to produce the required artifacts, not to check your own work.
-4. Once you have produced the required output file(s), stop. Do not write extra files, do not iterate beyond what the task asks.
-5. Keep each response short. The task instruction is the source of truth for what to produce.`;
+export const DEFAULT_HEADLESS_SYSTEM_PROMPT = [
+  'Complete the task by acting with the available tools, not by narrating.',
+  'Prefer Read, Glob, and Grep for inspection, Edit and Write for file changes, and Bash for shell commands and tests.',
+  'Verify the result when practical.',
+  'Stop when the task is complete.',
+].join('\n');
+
+export interface ResolvedHeadlessSystemPrompt {
+  mode: HeadlessSystemPromptMode;
+  systemPrompt: string;
+  systemPromptHash: string;
+}
+
+export interface ResolveHeadlessSystemPromptOptions {
+  heavyTaskMode?: HeavyTaskModeSelection;
+  economyTaskMode?: EconomyTaskModeSelection;
+}
+
+export function resolveHeadlessSystemPrompt(
+  config: Pick<Config, 'systemPrompt'>,
+  options: ResolveHeadlessSystemPromptOptions = {},
+): ResolvedHeadlessSystemPrompt {
+  let mode: HeadlessSystemPromptMode;
+  let systemPrompt: string;
+  if (config.systemPrompt === undefined) {
+    mode = 'default';
+    systemPrompt = DEFAULT_HEADLESS_SYSTEM_PROMPT;
+  } else if (config.systemPrompt.trim().length === 0) {
+    throw new Error('Config.systemPrompt must contain non-whitespace text');
+  } else {
+    mode = 'custom';
+    systemPrompt = config.systemPrompt;
+  }
+  if (options.heavyTaskMode) {
+    systemPrompt =
+      appendHeavyTaskPolicyToSystemPrompt(systemPrompt, options.heavyTaskMode) ?? systemPrompt;
+  }
+  if (options.economyTaskMode) {
+    systemPrompt =
+      appendEconomyTaskPolicyToSystemPrompt(systemPrompt, options.economyTaskMode) ?? systemPrompt;
+  }
+  return {
+    mode,
+    systemPrompt,
+    systemPromptHash: hashHeadlessSystemPrompt(systemPrompt),
+  };
+}
+
+export function hashHeadlessSystemPrompt(systemPrompt: string): string {
+  return `sha256:${createHash('sha256').update(JSON.stringify(systemPrompt)).digest('hex')}`;
+}

--- a/packages/headless/src/task-agent-controller.ts
+++ b/packages/headless/src/task-agent-controller.ts
@@ -26,8 +26,8 @@ import {
   createHeavyTaskEvidenceRecorder,
   renderHeavyTaskEvidenceForPrompt,
 } from './heavy-task-evidence.js';
-import { configWithHeavyTaskPolicy, resolveHeavyTaskMode } from './heavy-task-policy.js';
-import { configWithEconomyTaskPolicy, resolveEconomyTaskMode } from './economy-task-policy.js';
+import { resolveHeavyTaskMode } from './heavy-task-policy.js';
+import { resolveEconomyTaskMode } from './economy-task-policy.js';
 import {
   createHeavyTaskProgressRecorder,
   HEAVY_TASK_PROGRESS_TOOL_NAMES,
@@ -56,6 +56,10 @@ import {
   matchPermissionGrant,
   permissionPreview,
 } from './permission-grants.js';
+import {
+  resolveHeadlessSystemPrompt,
+  type ResolvedHeadlessSystemPrompt,
+} from './system-prompts.js';
 import {
   freezeSubmittedWorkspace,
   prepareScoringWorkspace,
@@ -153,9 +157,9 @@ export async function runTaskOnce(
   const startedAt = now();
   const verifier = normalizeVerifier(task);
   const heavyTaskMode = resolveHeavyTaskMode(config, task);
-  const configAfterHeavy = configWithHeavyTaskPolicy(config, heavyTaskMode);
-  const economyTaskMode = resolveEconomyTaskMode(configAfterHeavy, task);
-  const effectiveConfig = configWithEconomyTaskPolicy(configAfterHeavy, economyTaskMode);
+  const economyTaskMode = resolveEconomyTaskMode(config, task);
+  const prompt = resolveHeadlessSystemPrompt(config, { heavyTaskMode, economyTaskMode });
+  const effectiveConfig = { ...config, systemPrompt: prompt.systemPrompt };
   const priorProjection = heavyTaskMode.enabled ? await taskRunStore.project(taskRunId) : undefined;
   const priorProgressPrompt = priorProjection
     ? renderHeavyTaskProgressForPrompt(priorProjection)
@@ -373,6 +377,7 @@ export async function runTaskOnce(
       sessionId: header.id,
       startedAt,
       closeTaskRun,
+      systemPrompt: prompt,
     });
     if (permissionHandling.parked) {
       return {
@@ -478,6 +483,7 @@ export async function runTaskOnce(
           sessionId: header.id,
           startedAt,
           closeTaskRun,
+          systemPrompt: prompt,
         });
         if (repairPermissionHandling.parked) {
           return {
@@ -594,6 +600,7 @@ export async function runTaskOnce(
       scoreResultId,
       startedAt,
       finishedAt,
+      systemPrompt: prompt,
     });
     const taxonomy = finalScore.taxonomy;
     const scoreResult: ScoreResult = {
@@ -871,6 +878,7 @@ interface PermissionInterventionInput {
   sessionId: string;
   startedAt: number;
   closeTaskRun: boolean;
+  systemPrompt: Pick<ResolvedHeadlessSystemPrompt, 'mode' | 'systemPromptHash'>;
 }
 
 type PermissionInterventionResult =
@@ -961,6 +969,7 @@ async function handlePermissionIntervention(
         steps: input.invocation.events.length,
         errorClass: 'needs_approval',
         error: `task run needs approval for ${request.toolName}`,
+        systemPrompt: input.systemPrompt,
       }),
     };
   }
@@ -1045,12 +1054,15 @@ function syntheticPermissionResultRecord(input: {
   steps: number;
   errorClass: string;
   error: string;
+  systemPrompt: Pick<ResolvedHeadlessSystemPrompt, 'mode' | 'systemPromptHash'>;
 }): ResultRecord {
   return {
     taskId: input.task.id,
     configId: input.config.id,
     sessionId: input.sessionId,
     runId: input.runId,
+    systemPromptMode: input.systemPrompt.mode,
+    systemPromptHash: input.systemPrompt.systemPromptHash,
     status: 'failed',
     runnerCompleted: false,
     passed: false,
@@ -1259,6 +1271,7 @@ function resultRecordFromInvocation(input: {
   scoreResultId: string;
   startedAt: number;
   finishedAt: number;
+  systemPrompt: Pick<ResolvedHeadlessSystemPrompt, 'mode' | 'systemPromptHash'>;
 }): ResultRecord {
   const status = input.invocation.status;
   return {
@@ -1266,6 +1279,8 @@ function resultRecordFromInvocation(input: {
     configId: input.config.id,
     sessionId: input.sessionId,
     runId: input.invocation.runId,
+    systemPromptMode: input.systemPrompt.mode,
+    systemPromptHash: input.systemPrompt.systemPromptHash,
     status,
     runnerCompleted: status === 'completed',
     passed: input.finalScore.passed,


### PR DESCRIPTION
## Summary

- Closes #1267.
- Always resolve a non-empty Layer 1 system prompt before headless backend registration: omitted values use the shared default, non-empty custom strings remain byte-for-byte replacements, and blank strings fail before execution.
- Keep heavy and economy policies as ordered Layer 2 overlays in the established task-run and Harbor paths, and remove the legacy benchmark prompt, Harbor fallback, and parallel config wrapper paths.
- Record the resolved prompt mode and final prompt hash in canonical result records and Harbor execution identity while preserving compatibility with legacy artifacts.

## Verification

- `npm test -w @maka/headless` — 1150 passed, 1 skipped, 0 failed.
- `npm run format:check` — passed.
- `npm run lint` — passed.
- `npm run -w @maka/headless build` — passed.
- Reverted the complete commit in an isolated worktree and confirmed the resulting tree exactly matched `origin/main`.

## Breaking change

Explicit empty or whitespace-only `Config.systemPrompt` and `MAKA_SYSTEM_PROMPT` values now fail fast. Callers that want the standard prompt should omit the value instead.
