### PR TITLE
feat(runtime): expose active sandbox diagnostics

### DIFF
--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -566,6 +566,7 @@ const {
   builtinTools,
   toolAvailability,
   childAgentTools,
+  sandboxDiagnosticsProvider,
 } = assembleDesktopTools({
   isComputerUseRealModelE2e,
   workspaceRoot,
@@ -686,6 +687,7 @@ backends.register('ai-sdk', createAiSdkBackendFactory({
   agentTeamLeadTools,
   builtinTools,
   toolAvailability,
+  sandboxDiagnosticsProvider,
   persistToolArtifacts,
   persistArchivedToolResult,
   readArchivedToolResult,

--- a/apps/desktop/src/main/session-stream.ts
+++ b/apps/desktop/src/main/session-stream.ts
@@ -92,6 +92,7 @@ export interface AiSdkBackendFactoryDeps {
   agentTeamLeadTools: AssembledTools['agentTeamLeadTools'];
   builtinTools: AssembledTools['builtinTools'];
   toolAvailability: AssembledTools['toolAvailability'];
+  sandboxDiagnosticsProvider: AssembledTools['sandboxDiagnosticsProvider'];
   persistToolArtifacts: ToolArtifactPersistence['persistToolArtifacts'];
   persistArchivedToolResult: ToolArtifactPersistence['persistArchivedToolResult'];
   readArchivedToolResult: ToolArtifactPersistence['readArchivedToolResult'];
@@ -130,6 +131,7 @@ export function createAiSdkBackendFactory(deps: AiSdkBackendFactoryDeps): Backen
     agentTeamLeadTools,
     builtinTools,
     toolAvailability,
+    sandboxDiagnosticsProvider,
     persistToolArtifacts,
     persistArchivedToolResult,
     readArchivedToolResult,
@@ -196,6 +198,10 @@ export function createAiSdkBackendFactory(deps: AiSdkBackendFactoryDeps): Backen
     // narrower tool surface. They do not receive the Desktop Skill tool, so
     // they must not overwrite the parent session's resolver entry.
     if (!ctx.tools) desktopSessionSkillHosts.set(ctx.sessionId, backendSkillHost);
+    const sandboxDiagnosticsSnapshot = await sandboxDiagnosticsProvider.resolve({
+      mode: ctx.header.permissionMode,
+      cwd: ctx.header.cwd,
+    });
 
     return new AiSdkBackend({
       sessionId: ctx.sessionId,
@@ -209,6 +215,7 @@ export function createAiSdkBackendFactory(deps: AiSdkBackendFactoryDeps): Backen
       tools: expertDispatchTool
         ? [...backendTools, expertDispatchTool, ...agentTeamLeadTools]
         : backendTools,
+      sandboxDiagnosticsSnapshot,
       agentTeam,
       toolAvailability: backendToolAvailability,
       spawnChildAgent: (input) => getRuntime().spawnChildAgent(ctx.sessionId, input),

--- a/apps/desktop/src/main/tool-assembly.ts
+++ b/apps/desktop/src/main/tool-assembly.ts
@@ -10,6 +10,7 @@ import {
   buildParentAgentTools,
   assertProductBindingCatalogClean,
   createBuiltinSandboxManager,
+  createSandboxDiagnosticsProvider,
   createFilesystemWorkerLaunchSpecProvider,
   FilesystemWorkerClient,
   resolveSkillDiscoveryPaths,
@@ -92,18 +93,28 @@ export function assembleDesktopTools(deps: DesktopToolAssemblyDeps) {
   } = deps;
 
   const sandboxManager = createBuiltinSandboxManager();
-  const filesystemWorker = process.platform === 'darwin' && sandboxManager
-    ? new FilesystemWorkerClient({
-        sandboxManager,
-        getLaunchSpec: createFilesystemWorkerLaunchSpecProvider({
+  const filesystemWorkerLaunchSpecProvider =
+    process.platform === 'darwin'
+      ? createFilesystemWorkerLaunchSpecProvider({
           runtime: 'electron',
           executable: process.execPath,
           resourceLocation: app.isPackaged
             ? { kind: 'desktop-packaged', resourcesPath: process.resourcesPath }
             : { kind: 'runtime' },
-        }),
+        })
+      : undefined;
+  const filesystemWorker = sandboxManager && filesystemWorkerLaunchSpecProvider
+    ? new FilesystemWorkerClient({
+        sandboxManager,
+        getLaunchSpec: filesystemWorkerLaunchSpecProvider,
       })
     : undefined;
+  const sandboxDiagnosticsProvider = createSandboxDiagnosticsProvider({
+    ...(sandboxManager ? { sandboxManager } : {}),
+    ...(filesystemWorkerLaunchSpecProvider
+      ? { getFilesystemWorkerLaunchSpec: filesystemWorkerLaunchSpecProvider }
+      : {}),
+  });
   // Unified tool availability (issue #37). Deferred capability groups (Rive,
   // Office, browser, agent orchestration) are withheld from the
   // per-turn prompt and loaded on demand via `load_tools`, keeping their schemas
@@ -273,5 +284,6 @@ export function assembleDesktopTools(deps: DesktopToolAssemblyDeps) {
     builtinTools,
     toolAvailability,
     childAgentTools,
+    sandboxDiagnosticsProvider,
   };
 }

--- a/packages/cli/src/runtime-bootstrap.ts
+++ b/packages/cli/src/runtime-bootstrap.ts
@@ -19,6 +19,7 @@ import {
   buildRuntimeEventModelReplayPlan,
   buildChildAgentTools,
   createBuiltinSandboxManager,
+  createSandboxDiagnosticsProvider,
   createFilesystemWorkerLaunchSpecProvider,
   createLocalContinuationSafetyInspector,
   FilesystemWorkerClient,
@@ -217,16 +218,26 @@ export async function createMakaCliRuntimeContext(
     },
   });
   const sandboxManager = createBuiltinSandboxManager();
-  const filesystemWorker =
-    process.platform === 'darwin' && sandboxManager
-      ? new FilesystemWorkerClient({
-          sandboxManager,
-          getLaunchSpec: createFilesystemWorkerLaunchSpecProvider({
-            runtime: 'node',
-            resourceLocation: { kind: 'runtime' },
-          }),
+  const filesystemWorkerLaunchSpecProvider =
+    process.platform === 'darwin'
+      ? createFilesystemWorkerLaunchSpecProvider({
+          runtime: 'node',
+          resourceLocation: { kind: 'runtime' },
         })
       : undefined;
+  const filesystemWorker =
+    sandboxManager && filesystemWorkerLaunchSpecProvider
+      ? new FilesystemWorkerClient({
+          sandboxManager,
+          getLaunchSpec: filesystemWorkerLaunchSpecProvider,
+        })
+      : undefined;
+  const sandboxDiagnosticsProvider = createSandboxDiagnosticsProvider({
+    ...(sandboxManager ? { sandboxManager } : {}),
+    ...(filesystemWorkerLaunchSpecProvider
+      ? { getFilesystemWorkerLaunchSpec: filesystemWorkerLaunchSpecProvider }
+      : {}),
+  });
   const tools = buildBuiltinTools({
     shellRuns,
     runtimeResources: shellRuns,
@@ -571,6 +582,10 @@ export async function createMakaCliRuntimeContext(
           }
         : {}),
     });
+    const sandboxDiagnosticsSnapshot = await sandboxDiagnosticsProvider.resolve({
+      mode: header.permissionMode,
+      cwd: header.cwd,
+    });
     return new AiSdkBackend({
       sessionId: ctx.sessionId,
       header: { ...header, model: ready.model },
@@ -582,6 +597,7 @@ export async function createMakaCliRuntimeContext(
       permissionEngine,
       modelFactory: (modelInput) => getAIModel({ ...modelInput, fetch: modelFetch }),
       tools: allTools,
+      sandboxDiagnosticsSnapshot,
       toolAvailability,
       ...(input.surface === 'tui'
         ? {
@@ -631,6 +647,7 @@ export async function createMakaCliRuntimeContext(
       turnTailPrompt: ({ cwd }) =>
         buildCliTurnTailPrompt({ cwd, sessionId: ctx.sessionId, automationManager, goalManager }),
       shellRunContextSummary: ctx.shellRunContextSummary,
+      recordRunTrace: ctx.recordRunTrace,
       newId: randomUUID,
       now: Date.now,
       ...(input.maxSteps !== undefined ? { maxSteps: input.maxSteps } : {}),

--- a/packages/core/src/agent-run.ts
+++ b/packages/core/src/agent-run.ts
@@ -75,6 +75,7 @@ export const AGENT_RUN_EVENT_TYPES = [
   'run_created',
   'run_started',
   'turn_started',
+  'sandbox_context_resolved',
   'run_status_changed',
   'model_resolved',
   'model_resolve_failed',

--- a/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
+++ b/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
@@ -58,8 +58,174 @@ import { buildRuntimeEventModelReplayPlan, buildSteeringEnvelope } from '../mode
 import type { ActiveFullCompactBlock } from '../active-full-compact.js';
 import type { SemanticCompactBlock } from '../semantic-compact.js';
 import { HistoryCompactSummarizerError } from '../history-compact-summarizer.js';
+import type { AutoApprovalReviewContext } from '../approval-reviewer.js';
+import type { SandboxDiagnosticsSnapshot } from '../sandbox/diagnostics.js';
+import { SandboxCommandError } from '../sandbox/errors.js';
+import { RunTrace } from '../run-trace.js';
 
 describe('AiSdkBackend model history', () => {
+  test('exposes one active sandbox snapshot to the model and durable run trace', async () => {
+    const model = completionModel();
+    const traces: RunTraceEvent[] = [];
+    const backend = new AiSdkBackend({
+      sessionId: 'session-1',
+      header: header(),
+      appendMessage: async () => {},
+      connection: connection(),
+      apiKey: 'sk-test',
+      modelId: 'mock-model-id',
+      permissionEngine: new PermissionEngine({ newId: () => 'permission-id', now: () => 1 }),
+      modelFactory: () => model,
+      tools: [],
+      sandboxDiagnosticsSnapshot: sandboxSnapshot(),
+      recordRunTrace: (event) => traces.push(event),
+      newId: idGenerator(),
+      now: monotonicClock(),
+    });
+
+    await drain(backend.send({ turnId: 'turn-current', text: 'current user', context: [] }));
+
+    assert.match(JSON.stringify(compactPrompt(model)), /Maka runtime sandbox context/);
+    assert.match(JSON.stringify(compactPrompt(model)), /Working directory: \/tmp\/maka/);
+    const contextEvent = traces.find((event) => event.type === 'sandbox_context_resolved');
+    const traceSnapshot = contextEvent?.data?.snapshot as
+      | { profile?: { name?: string } }
+      | undefined;
+    assert.equal(traceSnapshot?.profile?.name, 'workspace-write');
+    assert.equal(JSON.stringify(contextEvent).includes('/tmp/maka'), false);
+  });
+
+  test('passes the active sandbox snapshot into automatic approval review', async () => {
+    let reviewContext: AutoApprovalReviewContext | undefined;
+    const backend = new AiSdkBackend({
+      sessionId: 'session-1',
+      header: header('execute'),
+      appendMessage: async () => {},
+      connection: connection(),
+      apiKey: 'sk-test',
+      modelId: 'mock-model-id',
+      permissionEngine: new PermissionEngine({ newId: idGenerator(), now: () => 1 }),
+      autoApprovalReviewer: {
+        review: async ({ context }) => {
+          reviewContext = context;
+          return { outcome: 'allow', riskLevel: 'high', rationale: 'test approval' };
+        },
+      },
+      modelFactory: () => ({}),
+      tools: [],
+      sandboxDiagnosticsSnapshot: sandboxSnapshot(),
+      newId: idGenerator(),
+      now: monotonicClock(),
+    });
+    const tool: MakaTool = {
+      name: 'Bash',
+      description: 'shell',
+      parameters: {},
+      permissionRequired: true,
+      impl: async () => ({ kind: 'text', text: 'ok' }),
+    };
+    const execute = (
+      backend as unknown as {
+        wrapToolExecute(
+          tool: MakaTool,
+          turnId: string,
+          queue: { push(event: SessionEvent): void },
+        ): (
+          args: unknown,
+          ctx: { toolCallId: string; abortSignal: AbortSignal },
+        ) => Promise<unknown>;
+      }
+    ).wrapToolExecute(tool, 'turn-1', { push: () => {} });
+
+    await execute(
+      { command: 'rm local-file' },
+      { toolCallId: 'tool-1', abortSignal: new AbortController().signal },
+    );
+
+    assert.deepEqual(reviewContext?.sandbox, {
+      platform: 'darwin',
+      profileName: 'workspace-write',
+      fileSystem: 'workspace-write',
+      network: 'restricted',
+      commandSandbox: 'available (macos-seatbelt)',
+      filesystemSandbox: 'available (macos-seatbelt)',
+      commandSandboxSelectionReason: 'platform_sandbox_selected',
+      filesystemSandboxSelectionReason: 'platform_sandbox_selected',
+    });
+  });
+
+  test('records structured sandbox failure metadata on tool failure traces', async () => {
+    const traces: RunTraceEvent[] = [];
+    const backend = new AiSdkBackend({
+      sessionId: 'session-1',
+      header: header('bypass'),
+      appendMessage: async () => {},
+      connection: connection(),
+      apiKey: 'sk-test',
+      modelId: 'mock-model-id',
+      permissionEngine: new PermissionEngine({ newId: idGenerator(), now: () => 1 }),
+      modelFactory: () => ({}),
+      tools: [],
+      newId: idGenerator(),
+      now: monotonicClock(),
+    });
+    (backend as unknown as { currentRunTrace: RunTrace | null }).currentRunTrace = new RunTrace({
+      sessionId: 'session-1',
+      turnId: 'turn-1',
+      connectionSlug: 'anthropic-main',
+      providerId: 'anthropic',
+      modelId: 'mock-model-id',
+      newId: idGenerator(),
+      now: monotonicClock(),
+      record: (event) => traces.push(event),
+    });
+    const tool: MakaTool = {
+      name: 'Bash',
+      description: 'shell',
+      parameters: {},
+      permissionRequired: false,
+      impl: async () => {
+        throw new SandboxCommandError({
+          domain: 'command',
+          stage: 'transform',
+          reason: 'backend_not_available',
+          backend: 'macos-seatbelt',
+          recoverable: false,
+          profileName: 'workspace-write',
+          message: 'contains /private/workspace/path',
+        });
+      },
+    };
+    const execute = (
+      backend as unknown as {
+        wrapToolExecute(
+          tool: MakaTool,
+          turnId: string,
+          queue: { push(event: SessionEvent): void },
+        ): (
+          args: unknown,
+          ctx: { toolCallId: string; abortSignal: AbortSignal },
+        ) => Promise<unknown>;
+      }
+    ).wrapToolExecute(tool, 'turn-1', { push: () => {} });
+
+    await execute(
+      { command: 'true' },
+      { toolCallId: 'tool-1', abortSignal: new AbortController().signal },
+    );
+
+    const failure = traces.find((event) => event.type === 'tool_failed');
+    assert.deepEqual(failure?.data?.sandbox, {
+      domain: 'command',
+      stage: 'transform',
+      reason: 'backend_not_available',
+      recoverable: false,
+      backend: 'macos-seatbelt',
+      profileName: 'workspace-write',
+    });
+    assert.equal(JSON.stringify(failure).includes('/private/workspace/path'), false);
+  });
+
   test('omits an empty system prompt from the provider request', async () => {
     const model = completionModel();
     const backend = new AiSdkBackend({
@@ -11467,6 +11633,34 @@ function header(permissionMode: SessionHeader['permissionMode'] = 'ask'): Sessio
     model: 'claude-sonnet-4-5-20250929',
     permissionMode,
     schemaVersion: 1,
+  };
+}
+
+function sandboxSnapshot(): SandboxDiagnosticsSnapshot {
+  return {
+    schemaVersion: 1,
+    platform: 'darwin',
+    profile: {
+      name: 'workspace-write',
+      type: 'managed',
+      fileSystem: 'workspace-write',
+      network: 'restricted',
+      cwd: '/tmp/maka',
+      workspaceRoots: ['/tmp/maka'],
+      protectedMetadata: ['.git', '.agents', '.codex'],
+    },
+    capabilities: {
+      command: {
+        status: 'available',
+        backend: 'macos-seatbelt',
+        selectionReason: 'platform_sandbox_selected',
+      },
+      filesystem: {
+        status: 'available',
+        backend: 'macos-seatbelt',
+        selectionReason: 'platform_sandbox_selected',
+      },
+    },
   };
 }
 

--- a/packages/runtime/src/__tests__/run-trace.test.ts
+++ b/packages/runtime/src/__tests__/run-trace.test.ts
@@ -3,6 +3,50 @@ import { describe, test } from 'node:test';
 import { RunTrace, type RunTraceEvent } from '../run-trace.js';
 
 describe('RunTrace error diagnostics', () => {
+  test('records a path-free active sandbox snapshot', () => {
+    const events: RunTraceEvent[] = [];
+    const trace = new RunTrace({
+      sessionId: 'session-1',
+      turnId: 'turn-1',
+      connectionSlug: 'deepseek',
+      providerId: 'openai-compatible',
+      modelId: 'deepseek-v4-pro',
+      newId: () => `trace-${events.length + 1}`,
+      now: () => 123,
+      record: (event) => events.push(event),
+    });
+
+    trace.sandboxContextResolved({
+      schemaVersion: 1,
+      platform: 'darwin',
+      profile: {
+        name: 'workspace-write',
+        type: 'managed',
+        fileSystem: 'workspace-write',
+        network: 'restricted',
+        protectedMetadata: ['.git'],
+      },
+      capabilities: {
+        command: {
+          status: 'available',
+          backend: 'macos-seatbelt',
+          selectionReason: 'platform_sandbox_selected',
+        },
+        filesystem: {
+          status: 'unavailable',
+          backend: 'macos-seatbelt',
+          failure: { stage: 'launch', reason: 'filesystem_worker_unavailable' },
+        },
+      },
+    });
+
+    assert.equal(events[0]?.type, 'sandbox_context_resolved');
+    assert.equal(events[0]?.phase, 'sandbox');
+    assert.equal(JSON.stringify(events[0]).includes('/Users/'), false);
+    const snapshot = events[0]?.data?.snapshot as { profile?: { name?: string } } | undefined;
+    assert.equal(snapshot?.profile?.name, 'workspace-write');
+  });
+
   test('model stream failures keep generic copy plus redacted raw diagnostics', () => {
     const events: RunTraceEvent[] = [];
     const trace = new RunTrace({

--- a/packages/runtime/src/__tests__/sandbox-diagnostics.test.ts
+++ b/packages/runtime/src/__tests__/sandbox-diagnostics.test.ts
@@ -1,0 +1,166 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+
+import { createDangerFullAccessPermissionProfile } from '@maka/core';
+
+import { MacosSeatbeltBackend } from '../sandbox/macos-seatbelt.js';
+import { SandboxManager } from '../sandbox/sandbox-manager.js';
+import {
+  createSandboxDiagnosticsProvider,
+  toSandboxRunTraceProjection,
+} from '../sandbox/diagnostics.js';
+import { SandboxCommandError, serializeSandboxError } from '../sandbox/errors.js';
+import { renderSandboxTurnTailPrompt } from '../system-prompt/sandbox-context-prompt.js';
+import { FilesystemWorkerClientError } from '../filesystem-worker/client.js';
+
+describe('sandbox diagnostics', () => {
+  test('reports the effective profile and both active macOS enforcement capabilities', async () => {
+    const provider = createSandboxDiagnosticsProvider({
+      platform: 'darwin',
+      sandboxManager: new SandboxManager([new MacosSeatbeltBackend()]),
+      getFilesystemWorkerLaunchSpec: async () => ({
+        ok: true,
+        spec: {
+          program: '/runtime/node',
+          args: ['/runtime/worker.js'],
+          env: {},
+          runtimeReadableRoots: ['/runtime/worker.js'],
+          executableRoots: ['/runtime'],
+        },
+      }),
+      isExecutable: async () => true,
+      canonicalizePath: async (path) => path,
+    });
+
+    const snapshot = await provider.resolve({ mode: 'ask', cwd: '/workspace' });
+
+    assert.deepEqual(snapshot.profile, {
+      name: 'workspace-write',
+      type: 'managed',
+      fileSystem: 'workspace-write',
+      network: 'restricted',
+      cwd: '/workspace',
+      workspaceRoots: ['/workspace'],
+      protectedMetadata: ['.git', '.agents', '.codex'],
+    });
+    assert.deepEqual(snapshot.capabilities.command, {
+      status: 'available',
+      backend: 'macos-seatbelt',
+      selectionReason: 'platform_sandbox_selected',
+    });
+    assert.deepEqual(snapshot.capabilities.filesystem, {
+      status: 'available',
+      backend: 'macos-seatbelt',
+      selectionReason: 'platform_sandbox_selected',
+    });
+  });
+
+  test('keeps typed selection and filesystem-worker failure reasons', async () => {
+    const unsupported = createSandboxDiagnosticsProvider({
+      platform: 'win32',
+      canonicalizePath: async (path) => path,
+    });
+    const unsupportedSnapshot = await unsupported.resolve({
+      mode: 'execute',
+      cwd: 'C:\\workspace',
+    });
+    assert.deepEqual(unsupportedSnapshot.capabilities.command.failure, {
+      stage: 'selection',
+      reason: 'unsupported_platform',
+    });
+
+    const noWorker = createSandboxDiagnosticsProvider({
+      platform: 'darwin',
+      sandboxManager: new SandboxManager([new MacosSeatbeltBackend()]),
+      isExecutable: async () => true,
+      canonicalizePath: async (path) => path,
+    });
+    const noWorkerSnapshot = await noWorker.resolve({ mode: 'ask', cwd: '/workspace' });
+    assert.deepEqual(noWorkerSnapshot.capabilities.filesystem, {
+      status: 'unavailable',
+      backend: 'macos-seatbelt',
+      selectionReason: 'platform_sandbox_selected',
+      failure: { stage: 'launch', reason: 'filesystem_worker_unavailable' },
+    });
+  });
+
+  test('reports unrestricted profiles as not requiring a Maka sandbox', async () => {
+    const provider = createSandboxDiagnosticsProvider({
+      platform: 'darwin',
+      canonicalizePath: async (path) => path,
+    });
+    const snapshot = await provider.resolve({
+      mode: 'bypass',
+      cwd: '/workspace',
+      permissionProfile: createDangerFullAccessPermissionProfile(),
+    });
+
+    assert.equal(snapshot.profile.name, 'danger-full-access');
+    assert.equal(snapshot.profile.network, 'enabled');
+    assert.deepEqual(snapshot.capabilities.command, {
+      status: 'not_required',
+      backend: 'none',
+      selectionReason: 'sandbox_not_required',
+    });
+    assert.deepEqual(snapshot.capabilities.filesystem, snapshot.capabilities.command);
+  });
+
+  test('removes paths from durable trace projection but renders them in the turn tail', async () => {
+    const provider = createSandboxDiagnosticsProvider({
+      platform: 'darwin',
+      sandboxManager: new SandboxManager([new MacosSeatbeltBackend()]),
+      canonicalizePath: async (path) => path,
+      isExecutable: async () => true,
+    });
+    const snapshot = await provider.resolve({ mode: 'ask', cwd: '/secret/workspace' });
+    const projection = toSandboxRunTraceProjection(snapshot);
+
+    assert.equal(JSON.stringify(projection).includes('/secret/workspace'), false);
+    assert.match(renderSandboxTurnTailPrompt(snapshot), /Working directory: \/secret\/workspace/);
+    assert.match(renderSandboxTurnTailPrompt(snapshot), /launch:filesystem_worker_unavailable/);
+  });
+});
+
+describe('sandbox error diagnostics', () => {
+  test('serializes stable metadata without copying the raw error message', () => {
+    const error = new SandboxCommandError({
+      domain: 'command',
+      stage: 'transform',
+      reason: 'backend_not_available',
+      backend: 'macos-seatbelt',
+      recoverable: false,
+      profileName: 'workspace-write',
+      message: 'private path: /Users/example/secret',
+    });
+
+    const serialized = serializeSandboxError(error);
+    assert.deepEqual(serialized, {
+      domain: 'command',
+      stage: 'transform',
+      reason: 'backend_not_available',
+      recoverable: false,
+      backend: 'macos-seatbelt',
+      profileName: 'workspace-write',
+    });
+    assert.equal(JSON.stringify(serialized).includes('/Users/example/secret'), false);
+  });
+
+  test('serializes filesystem worker validation failures through the same contract', () => {
+    const serialized = serializeSandboxError(
+      new FilesystemWorkerClientError({
+        reason: 'path_denied',
+        stage: 'validation',
+        recoverable: false,
+        requestId: 'request-1',
+      }),
+    );
+
+    assert.deepEqual(serialized, {
+      domain: 'filesystem',
+      stage: 'validation',
+      reason: 'path_denied',
+      recoverable: false,
+      requestId: 'request-1',
+    });
+  });
+});

--- a/packages/runtime/src/ai-sdk-backend.ts
+++ b/packages/runtime/src/ai-sdk-backend.ts
@@ -84,6 +84,7 @@ import { PermissionEngine } from './permission-engine.js';
 import {
   AiSdkAutoApprovalReviewer,
   ApprovalCoordinator,
+  type AutoApprovalReviewContext,
   type AutoApprovalReviewer,
 } from './approval-reviewer.js';
 import { AsyncEventQueue } from './async-queue.js';
@@ -132,6 +133,12 @@ import {
 } from './ai-sdk-compaction.js';
 import type { ToolArtifactRecorder } from './tool-artifacts.js';
 import { RunTrace, type RunTraceRecorder } from './run-trace.js';
+import {
+  toSandboxRunTraceProjection,
+  type SandboxDiagnosticCapability,
+  type SandboxDiagnosticsSnapshot,
+} from './sandbox/diagnostics.js';
+import { renderSandboxTurnTailPrompt } from './system-prompt/sandbox-context-prompt.js';
 import { computeCost } from './telemetry/cost.js';
 import { getBuiltinPricing } from './telemetry/builtin-pricing.js';
 import {
@@ -272,6 +279,32 @@ function joinPromptFragments(fragments: readonly (string | undefined)[]): string
     .filter((fragment): fragment is string => Boolean(fragment))
     .join('\n\n');
   return joined.length > 0 ? joined : undefined;
+}
+
+function autoApprovalSandboxContext(
+  snapshot: SandboxDiagnosticsSnapshot,
+): NonNullable<AutoApprovalReviewContext['sandbox']> {
+  const { command, filesystem } = snapshot.capabilities;
+  return {
+    platform: snapshot.platform,
+    profileName: snapshot.profile.name,
+    fileSystem: snapshot.profile.fileSystem,
+    network: snapshot.profile.network,
+    commandSandbox: formatSandboxCapability(command),
+    filesystemSandbox: formatSandboxCapability(filesystem),
+    ...(command.selectionReason ? { commandSandboxSelectionReason: command.selectionReason } : {}),
+    ...(filesystem.selectionReason
+      ? { filesystemSandboxSelectionReason: filesystem.selectionReason }
+      : {}),
+    ...(command.failure ? { commandSandboxFailureReason: command.failure.reason } : {}),
+    ...(filesystem.failure ? { filesystemSandboxFailureReason: filesystem.failure.reason } : {}),
+  };
+}
+
+function formatSandboxCapability(capability: SandboxDiagnosticCapability): string {
+  return capability.backend === 'none'
+    ? capability.status
+    : `${capability.status} (${capability.backend})`;
 }
 
 // ============================================================================
@@ -422,6 +455,8 @@ export interface AiSdkBackendInput {
   /** Canonical-named tools available this session. Backend wraps each with
    *  permission gating before passing to ai-sdk. */
   tools: MakaTool[];
+  /** Active profile and enforcement capability snapshot for this session backend. */
+  sandboxDiagnosticsSnapshot?: SandboxDiagnosticsSnapshot;
   /** Trusted identity for expert-team lead/member collaboration tools. */
   agentTeam?: AgentTeamExecutionContext;
   /**
@@ -731,6 +766,9 @@ export class AiSdkBackend implements AgentBackend {
       }),
       getAutoApprovalReviewContext: () => ({
         ...(this.currentUserIntent !== undefined ? { userIntent: this.currentUserIntent } : {}),
+        ...(input.sandboxDiagnosticsSnapshot
+          ? { sandbox: autoApprovalSandboxContext(input.sandboxDiagnosticsSnapshot) }
+          : {}),
       }),
     });
   }
@@ -866,6 +904,11 @@ export class AiSdkBackend implements AgentBackend {
     });
     this.currentRunTrace = trace;
     trace.turnStarted();
+    if (this.input.sandboxDiagnosticsSnapshot) {
+      trace.sandboxContextResolved(
+        toSandboxRunTraceProjection(this.input.sandboxDiagnosticsSnapshot),
+      );
+    }
 
     // --- Resolve model (API key already attached at construct time) ---
     let model: unknown;
@@ -997,6 +1040,9 @@ export class AiSdkBackend implements AgentBackend {
           : joinPromptFragments([
               await this.resolveTurnTailPrompt(),
               await this.resolveShellRunContextSummary(),
+              this.input.sandboxDiagnosticsSnapshot
+                ? renderSandboxTurnTailPrompt(this.input.sandboxDiagnosticsSnapshot)
+                : undefined,
             ]);
         const currentUserContent = input.continuation
           ? undefined

--- a/packages/runtime/src/approval-reviewer.ts
+++ b/packages/runtime/src/approval-reviewer.ts
@@ -21,10 +21,16 @@ export interface AutoApprovalReviewContext {
   readonly permissionMode: PermissionMode;
   readonly userIntent?: string;
   readonly sandbox?: {
+    readonly platform?: string;
     readonly profileName?: string;
     readonly fileSystem?: string;
     readonly network?: string;
     readonly commandSandbox?: string;
+    readonly filesystemSandbox?: string;
+    readonly commandSandboxSelectionReason?: string;
+    readonly filesystemSandboxSelectionReason?: string;
+    readonly commandSandboxFailureReason?: string;
+    readonly filesystemSandboxFailureReason?: string;
   };
 }
 

--- a/packages/runtime/src/builtin-tools.ts
+++ b/packages/runtime/src/builtin-tools.ts
@@ -45,6 +45,7 @@ import type { MakaTool, MakaToolContext } from './tool-runtime.js';
 export type { MakaTool, MakaToolContext };
 import { withFileWriteLock } from './file-write-lock.js';
 import type { SandboxManager } from './sandbox/sandbox-manager.js';
+import { SandboxCommandError } from './sandbox/errors.js';
 import { linuxExecutableRoots } from './sandbox/linux-sandbox.js';
 import type { SandboxPlatform, SandboxType } from './sandbox/types.js';
 import type { ChildFdInput } from './child-fd-input.js';
@@ -213,6 +214,7 @@ export function buildBuiltinTools(options: BuildBuiltinToolsOptions = {}): MakaT
                     command,
                     pty,
                     ctx,
+                    'background_command',
                   ),
               }
             : {}),
@@ -756,6 +758,7 @@ function buildExecutorBashTool(
       const executionResult = {
         ...result,
         ...(transformed?.sandboxType ? { sandboxType: transformed.sandboxType } : {}),
+        ...(transformed?.profileName ? { profileName: transformed.profileName } : {}),
         sandboxed:
           transformed?.sandboxType === 'macos-seatbelt' || transformed?.sandboxType === 'linux',
       };
@@ -800,6 +803,7 @@ function sandboxCommand(
   command: string,
   pty: boolean,
   ctx: MakaToolContext,
+  domain: 'command' | 'background_command' = 'command',
 ):
   | {
       argv?: readonly string[];
@@ -807,6 +811,7 @@ function sandboxCommand(
       env?: NodeJS.ProcessEnv;
       fdInputs?: readonly ChildFdInput[];
       sandboxType?: SandboxType;
+      profileName?: string;
     }
   | undefined {
   const cwd = canonicalExistingPath(ctx.cwd);
@@ -815,7 +820,14 @@ function sandboxCommand(
   const additionalGrant = ctx.permissionContext?.additionalGrant;
   const escalationGrant = ctx.permissionContext?.sandboxEscalationGrant;
   if (additionalGrant && escalationGrant) {
-    throw new Error('Additional permissions and sandbox escalation cannot be applied together.');
+    throw new SandboxCommandError({
+      domain,
+      stage: 'validation',
+      reason: 'conflicting_permission_context',
+      recoverable: false,
+      profileName: effective.profile.name ?? effective.profile.type,
+      message: 'Additional permissions and sandbox escalation cannot be applied together.',
+    });
   }
   if (escalationGrant) {
     assertSandboxEscalationGrantForExecution({ grant: escalationGrant, command, cwd });
@@ -823,15 +835,30 @@ function sandboxCommand(
   if (pty) {
     if (escalationGrant) return { cwd, env, sandboxType: 'none' };
     if (profileRequiresSandbox(effective.profile)) {
-      throw new Error(
-        'PTY Bash is unavailable while the active permission profile requires command sandboxing.',
-      );
+      throw new SandboxCommandError({
+        domain,
+        stage: 'capability',
+        reason: 'pty_sandbox_unavailable',
+        recoverable: false,
+        profileName: effective.profile.name ?? effective.profile.type,
+        message:
+          'PTY Bash is unavailable while the active permission profile requires command sandboxing.',
+      });
     }
     return undefined;
   }
   if (!escalationGrant && !manager.canEnforce({ profile: effective.profile, platform })) {
     if (profileRequiresSandbox(effective.profile)) {
-      throw new Error(`Command sandbox is required but unavailable on platform ${platform}.`);
+      const selection = manager.selectInitial({ profile: effective.profile, platform });
+      throw new SandboxCommandError({
+        domain,
+        stage: selection.ok ? 'capability' : 'selection',
+        reason: selection.ok ? 'backend_not_available' : selection.reason,
+        backend: selection.sandboxType,
+        recoverable: false,
+        profileName: effective.profile.name ?? effective.profile.type,
+        message: `Command sandbox is required but unavailable on platform ${platform}.`,
+      });
     }
     return undefined;
   }
@@ -867,7 +894,15 @@ function sandboxCommand(
     ...(escalationGrant ? { preference: 'forbid' as const } : {}),
   });
   if (!result.ok) {
-    throw new Error(result.message ?? `Sandbox transform failed: ${result.reason}`);
+    throw new SandboxCommandError({
+      domain,
+      stage: 'transform',
+      reason: result.reason,
+      backend: result.sandboxType,
+      recoverable: false,
+      profileName: effective.profile.name ?? effective.profile.type,
+      message: result.message ?? `Sandbox transform failed: ${result.reason}`,
+    });
   }
   return {
     argv: result.exec.argv,
@@ -875,6 +910,7 @@ function sandboxCommand(
     ...(result.exec.env ? { env: { ...result.exec.env } } : {}),
     ...(result.exec.fdInputs ? { fdInputs: result.exec.fdInputs } : {}),
     sandboxType: result.exec.sandboxType,
+    profileName: result.exec.effectiveProfile.name ?? result.exec.effectiveProfile.type,
   };
 }
 
@@ -1017,10 +1053,22 @@ function terminalError(
   result: Pick<WorkspaceExecResult, 'stdout' | 'stderr' | 'stdoutTruncated' | 'stderrTruncated'> & {
     sandboxType?: SandboxType;
     sandboxed?: boolean;
+    profileName?: string;
   },
   code: number,
 ): Error {
-  const error = new Error(message);
+  const sandboxDenied = isLikelySandboxDenial(result);
+  const error = sandboxDenied
+    ? new SandboxCommandError({
+        domain: 'command',
+        stage: 'operation',
+        reason: 'sandbox_denial',
+        backend: result.sandboxType,
+        recoverable: true,
+        profileName: result.profileName,
+        message,
+      })
+    : new Error(message);
   Object.assign(error, {
     stdout: result.stdout,
     stderr: result.stderr,
@@ -1029,7 +1077,7 @@ function terminalError(
     code,
     ...(result.sandboxType ? { sandboxType: result.sandboxType } : {}),
     sandboxed: result.sandboxed === true,
-    ...(isLikelySandboxDenial(result) ? { reason: 'sandbox_denial', recoverable: true } : {}),
+    ...(sandboxDenied ? { reason: 'sandbox_denial', recoverable: true } : {}),
   });
   return error;
 }

--- a/packages/runtime/src/filesystem-worker/client.ts
+++ b/packages/runtime/src/filesystem-worker/client.ts
@@ -82,10 +82,13 @@ export type FilesystemWorkerClientErrorReason =
 
 export class FilesystemWorkerClientError extends Error {
   readonly code = 'SANDBOX_FILESYSTEM_OPERATION_FAILED';
+  readonly domain = 'filesystem' as const;
   readonly reason: FilesystemWorkerClientErrorReason;
   readonly stage: 'validation' | 'transform' | 'launch' | 'protocol' | 'operation';
   readonly recoverable: boolean;
   readonly requestId?: string;
+  readonly backend?: 'none' | 'macos-seatbelt' | 'linux';
+  readonly profileName?: string;
 
   constructor(input: {
     reason: FilesystemWorkerClientErrorReason;
@@ -93,6 +96,8 @@ export class FilesystemWorkerClientError extends Error {
     message?: string;
     recoverable?: boolean;
     requestId?: string;
+    backend?: 'none' | 'macos-seatbelt' | 'linux';
+    profileName?: string;
   }) {
     super(input.message ?? `Filesystem worker failed: ${input.reason}.`);
     this.name = 'FilesystemWorkerClientError';
@@ -100,6 +105,8 @@ export class FilesystemWorkerClientError extends Error {
     this.stage = input.stage;
     this.recoverable = input.recoverable ?? false;
     this.requestId = input.requestId;
+    this.backend = input.backend;
+    this.profileName = input.profileName;
   }
 }
 
@@ -219,7 +226,10 @@ export class FilesystemWorkerClient {
       },
     });
     if (!transformed.ok) {
-      throw clientError(transformed.reason, 'transform', requestId, transformed.message);
+      throw clientError(transformed.reason, 'transform', requestId, transformed.message, false, {
+        backend: transformed.sandboxType,
+        profileName: effectiveProfile.name ?? effectiveProfile.type,
+      });
     }
 
     let processResult: Awaited<ReturnType<FilesystemWorkerProcessRunner>>;
@@ -327,6 +337,17 @@ function clientError(
   requestId: string,
   message?: string,
   recoverable = false,
+  metadata: {
+    backend?: 'none' | 'macos-seatbelt' | 'linux';
+    profileName?: string;
+  } = {},
 ): FilesystemWorkerClientError {
-  return new FilesystemWorkerClientError({ reason, stage, requestId, message, recoverable });
+  return new FilesystemWorkerClientError({
+    reason,
+    stage,
+    requestId,
+    message,
+    recoverable,
+    ...metadata,
+  });
 }

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -362,9 +362,11 @@ export {
   buildSeatbeltPolicy,
   createDefaultSandboxManager,
   createBuiltinSandboxManager,
+  createSandboxDiagnosticsProvider,
   createSeatbeltExecArgs,
   escapeSeatbeltRegex,
   detectLinuxSandboxCapability,
+  toSandboxRunTraceProjection,
 } from './sandbox/index.js';
 export type {
   BuildSeatbeltPolicyInput,
@@ -374,6 +376,17 @@ export type {
   DetectLinuxSandboxCapabilityInput,
   LinuxBubblewrapBackendOptions,
   LinuxSandboxCapability,
+  CreateSandboxDiagnosticsProviderInput,
+  ResolveSandboxDiagnosticsInput,
+  SandboxDiagnosticCapability,
+  SandboxDiagnosticCapabilityStatus,
+  SandboxDiagnosticFailureReason,
+  SandboxDiagnosticFailureStage,
+  SandboxDiagnosticFileSystemMode,
+  SandboxDiagnosticNetworkMode,
+  SandboxDiagnosticsProvider,
+  SandboxDiagnosticsSnapshot,
+  SandboxRunTraceProjection,
 } from './sandbox/index.js';
 export type {
   SandboxBackend,
@@ -389,6 +402,15 @@ export type {
   SandboxTransformResult,
   SandboxType,
   SandboxablePreference,
+  SandboxErrorDomain,
+  SandboxErrorMetadata,
+  SandboxErrorStage,
+  SandboxErrorWithMetadata,
+} from './sandbox/index.js';
+export {
+  SandboxCommandError,
+  sandboxErrorMetadata,
+  serializeSandboxError,
 } from './sandbox/index.js';
 export {
   AGENT_CONTEXT_ISOLATED,

--- a/packages/runtime/src/run-trace.ts
+++ b/packages/runtime/src/run-trace.ts
@@ -8,6 +8,7 @@ import type {
   ToolSchemaChangeReason,
   ToolAvailabilityDiagnostic,
 } from '@maka/core/usage-stats/types';
+import type { SandboxRunTraceProjection } from './sandbox/diagnostics.js';
 
 export type RunTracePhase =
   | 'turn'
@@ -20,6 +21,7 @@ export type RunTracePhase =
 
 export type RunTraceEventType =
   | 'turn_started'
+  | 'sandbox_context_resolved'
   | 'model_resolved'
   | 'model_resolve_failed'
   | 'model_stream_started'
@@ -55,7 +57,7 @@ export interface RunTraceEvent {
   data?: Record<string, unknown>;
 }
 
-export type RunTraceRecorder = (event: RunTraceEvent) => void;
+export type RunTraceRecorder = (event: RunTraceEvent) => unknown;
 
 const REDACTED_ERROR_MESSAGE_MAX_CHARS = 2_048;
 
@@ -90,7 +92,8 @@ export class RunTrace {
       ...(data ? { data: sanitizeTraceData(data) } : {}),
     };
     try {
-      this.input.record?.(event);
+      const recorded = this.input.record?.(event);
+      if (isPromiseLike(recorded)) void Promise.resolve(recorded).catch(() => {});
     } catch {
       // Tracing is diagnostic-only and must not perturb model/tool execution.
     }
@@ -102,6 +105,10 @@ export class RunTrace {
       providerId: this.input.providerId,
       modelId: this.input.modelId,
     });
+  }
+
+  sandboxContextResolved(snapshot: SandboxRunTraceProjection): void {
+    this.emit('sandbox', 'sandbox_context_resolved', 'Sandbox context resolved', { snapshot });
   }
 
   modelResolved(): void {
@@ -278,4 +285,13 @@ function sha256(value: string): string {
 
 function sanitizeTraceData(data: Record<string, unknown>): Record<string, unknown> {
   return Object.fromEntries(Object.entries(data).filter(([, value]) => value !== undefined));
+}
+
+function isPromiseLike(value: unknown): value is PromiseLike<unknown> {
+  return Boolean(
+    value &&
+      (typeof value === 'object' || typeof value === 'function') &&
+      'then' in value &&
+      typeof value.then === 'function',
+  );
 }

--- a/packages/runtime/src/sandbox/diagnostics.ts
+++ b/packages/runtime/src/sandbox/diagnostics.ts
@@ -1,0 +1,439 @@
+import { constants } from 'node:fs';
+import { access, realpath } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { resolve } from 'node:path';
+
+import { compilePermissionProfile, type PermissionMode, type PermissionProfile } from '@maka/core';
+
+import type { FilesystemWorkerLaunchSpecProvider } from '../filesystem-worker/launch-spec.js';
+import type { SandboxManager } from './sandbox-manager.js';
+import type {
+  SandboxPlatform,
+  SandboxSelectionReason,
+  SandboxTransformFailureReason,
+  SandboxType,
+} from './types.js';
+
+export type SandboxDiagnosticFileSystemMode =
+  | 'read-only'
+  | 'workspace-write'
+  | 'unrestricted'
+  | 'custom-restricted'
+  | 'external'
+  | 'disabled';
+
+export type SandboxDiagnosticNetworkMode = 'restricted' | 'enabled' | 'unmanaged';
+export type SandboxDiagnosticCapabilityStatus =
+  | 'available'
+  | 'unavailable'
+  | 'not_required'
+  | 'external';
+export type SandboxDiagnosticFailureStage = 'selection' | 'transform' | 'launch' | 'capability';
+export type SandboxDiagnosticFailureReason =
+  | SandboxTransformFailureReason
+  | 'filesystem_worker_unavailable'
+  | 'worker_bundle_unavailable'
+  | 'runtime_executable_unavailable'
+  | 'executable_unavailable'
+  | 'capability_probe_failed';
+
+export interface SandboxDiagnosticCapability {
+  readonly status: SandboxDiagnosticCapabilityStatus;
+  readonly backend: SandboxType;
+  readonly selectionReason?: SandboxSelectionReason;
+  readonly failure?: {
+    readonly stage: SandboxDiagnosticFailureStage;
+    readonly reason: SandboxDiagnosticFailureReason;
+  };
+}
+
+export interface SandboxDiagnosticsSnapshot {
+  readonly schemaVersion: 1;
+  readonly platform: string;
+  readonly profile: {
+    readonly name: string;
+    readonly type: PermissionProfile['type'];
+    readonly fileSystem: SandboxDiagnosticFileSystemMode;
+    readonly network: SandboxDiagnosticNetworkMode;
+    readonly cwd: string;
+    readonly workspaceRoots: readonly string[];
+    readonly protectedMetadata: readonly string[];
+  };
+  readonly capabilities: {
+    readonly command: SandboxDiagnosticCapability;
+    readonly filesystem: SandboxDiagnosticCapability;
+  };
+}
+
+/** Path-free projection suitable for durable diagnostics and telemetry. */
+export interface SandboxRunTraceProjection {
+  readonly schemaVersion: 1;
+  readonly platform: string;
+  readonly profile: {
+    readonly name: string;
+    readonly type: PermissionProfile['type'];
+    readonly fileSystem: SandboxDiagnosticFileSystemMode;
+    readonly network: SandboxDiagnosticNetworkMode;
+    readonly protectedMetadata: readonly string[];
+  };
+  readonly capabilities: SandboxDiagnosticsSnapshot['capabilities'];
+}
+
+export interface ResolveSandboxDiagnosticsInput {
+  mode: PermissionMode;
+  cwd: string;
+  workspaceRoots?: readonly string[];
+  permissionProfile?: PermissionProfile;
+}
+
+export interface SandboxDiagnosticsProvider {
+  resolve(input: ResolveSandboxDiagnosticsInput): Promise<SandboxDiagnosticsSnapshot>;
+}
+
+export interface CreateSandboxDiagnosticsProviderInput {
+  sandboxManager?: SandboxManager;
+  getFilesystemWorkerLaunchSpec?: FilesystemWorkerLaunchSpecProvider;
+  platform?: SandboxPlatform;
+  isExecutable?: (path: string) => Promise<boolean>;
+  canonicalizePath?: (path: string) => Promise<string>;
+}
+
+export function createSandboxDiagnosticsProvider(
+  input: CreateSandboxDiagnosticsProviderInput,
+): SandboxDiagnosticsProvider {
+  return {
+    resolve: async (request) => {
+      const canonicalize = input.canonicalizePath ?? canonicalPath;
+      const cwd = await canonicalize(request.cwd);
+      const workspaceRoots = await Promise.all((request.workspaceRoots ?? [cwd]).map(canonicalize));
+      const compiled = request.permissionProfile
+        ? { profile: request.permissionProfile, workspaceRoots }
+        : compilePermissionProfile({ mode: request.mode, cwd, workspaceRoots });
+      const platform = input.platform ?? process.platform;
+      const capabilityInput: ProbeCapabilityInput = {
+        profile: compiled.profile,
+        cwd,
+        workspaceRoots: compiled.workspaceRoots,
+        platform,
+        sandboxManager: input.sandboxManager,
+        isExecutable: input.isExecutable ?? defaultIsExecutable,
+      };
+      const command = await probeCommandCapability(capabilityInput);
+      const filesystem = await probeFilesystemCapability({
+        ...capabilityInput,
+        getLaunchSpec: input.getFilesystemWorkerLaunchSpec,
+      });
+
+      return {
+        schemaVersion: 1,
+        platform,
+        profile: {
+          name: profileName(compiled.profile),
+          type: compiled.profile.type,
+          fileSystem: summarizeFileSystem(compiled.profile),
+          network: summarizeNetwork(compiled.profile),
+          cwd,
+          workspaceRoots: [...new Set(compiled.workspaceRoots)],
+          protectedMetadata: protectedMetadataNames(compiled.profile),
+        },
+        capabilities: { command, filesystem },
+      };
+    },
+  };
+}
+
+export function toSandboxRunTraceProjection(
+  snapshot: SandboxDiagnosticsSnapshot,
+): SandboxRunTraceProjection {
+  return {
+    schemaVersion: snapshot.schemaVersion,
+    platform: snapshot.platform,
+    profile: {
+      name: snapshot.profile.name,
+      type: snapshot.profile.type,
+      fileSystem: snapshot.profile.fileSystem,
+      network: snapshot.profile.network,
+      protectedMetadata: [...snapshot.profile.protectedMetadata],
+    },
+    capabilities: {
+      command: cloneCapability(snapshot.capabilities.command),
+      filesystem: cloneCapability(snapshot.capabilities.filesystem),
+    },
+  };
+}
+
+interface ProbeCapabilityInput {
+  profile: PermissionProfile;
+  cwd: string;
+  workspaceRoots: readonly string[];
+  platform: SandboxPlatform;
+  sandboxManager?: SandboxManager;
+  isExecutable: (path: string) => Promise<boolean>;
+}
+
+async function probeCommandCapability(
+  input: ProbeCapabilityInput,
+): Promise<SandboxDiagnosticCapability> {
+  const passive = passiveCapability(input.profile);
+  if (passive) return passive;
+  const manager = input.sandboxManager;
+  if (!manager) {
+    return unavailable(
+      expectedSandboxType(input.platform),
+      'selection',
+      input.platform === 'darwin' || input.platform === 'linux'
+        ? 'backend_not_available'
+        : 'unsupported_platform',
+    );
+  }
+
+  const selection = manager.selectInitial({ profile: input.profile, platform: input.platform });
+  if (!selection.ok) {
+    return unavailable(
+      selection.sandboxType ?? expectedSandboxType(input.platform),
+      'selection',
+      selection.reason,
+    );
+  }
+  if (selection.sandboxType === 'none') {
+    return {
+      status: 'not_required',
+      backend: 'none',
+      selectionReason: selection.reason,
+    };
+  }
+
+  try {
+    const transformed = manager.transform({
+      platform: input.platform,
+      command: {
+        program: '/bin/sh',
+        args: ['-c', 'true'],
+        cwd: input.cwd,
+        env: {},
+        profile: input.profile,
+        pathContext: {
+          workspaceRoots: input.workspaceRoots,
+          tmpdir: await canonicalPath(tmpdir()),
+          slashTmp: await canonicalPath('/tmp'),
+        },
+      },
+    });
+    if (!transformed.ok) {
+      return unavailable(
+        transformed.sandboxType ?? selection.sandboxType,
+        'transform',
+        transformed.reason,
+        selection.reason,
+      );
+    }
+    const executable = transformed.exec.argv[0];
+    if (!executable || !(await safelyCheckExecutable(executable, input.isExecutable))) {
+      return unavailable(
+        transformed.sandboxType,
+        'capability',
+        'executable_unavailable',
+        selection.reason,
+      );
+    }
+    return {
+      status: 'available',
+      backend: transformed.sandboxType,
+      selectionReason: selection.reason,
+    };
+  } catch {
+    return unavailable(
+      selection.sandboxType,
+      'capability',
+      'capability_probe_failed',
+      selection.reason,
+    );
+  }
+}
+
+async function probeFilesystemCapability(
+  input: ProbeCapabilityInput & { getLaunchSpec?: FilesystemWorkerLaunchSpecProvider },
+): Promise<SandboxDiagnosticCapability> {
+  const passive = passiveCapability(input.profile);
+  if (passive) return passive;
+  if (!input.sandboxManager) {
+    return unavailable(expectedSandboxType(input.platform), 'selection', 'backend_not_available');
+  }
+
+  const selection = input.sandboxManager.selectInitial({
+    profile: input.profile,
+    platform: input.platform,
+  });
+  if (!selection.ok) {
+    return unavailable(
+      selection.sandboxType ?? expectedSandboxType(input.platform),
+      'selection',
+      selection.reason,
+    );
+  }
+  if (!input.getLaunchSpec) {
+    return unavailable(
+      selection.sandboxType,
+      'launch',
+      'filesystem_worker_unavailable',
+      selection.reason,
+    );
+  }
+
+  let launch: Awaited<ReturnType<FilesystemWorkerLaunchSpecProvider>>;
+  try {
+    launch = await input.getLaunchSpec();
+  } catch {
+    return unavailable(
+      selection.sandboxType,
+      'capability',
+      'capability_probe_failed',
+      selection.reason,
+    );
+  }
+  if (!launch.ok) {
+    return unavailable(selection.sandboxType, 'launch', launch.reason, selection.reason);
+  }
+
+  try {
+    const transformed = input.sandboxManager.transform({
+      platform: input.platform,
+      command: {
+        program: launch.spec.program,
+        args: launch.spec.args,
+        cwd: input.cwd,
+        env: launch.spec.env,
+        profile: input.profile,
+        pathContext: {
+          workspaceRoots: input.workspaceRoots,
+          tmpdir: await canonicalPath(tmpdir()),
+          slashTmp: await canonicalPath('/tmp'),
+          runtimeReadableRoots: launch.spec.runtimeReadableRoots,
+          executableRoots: launch.spec.executableRoots,
+        },
+      },
+    });
+    if (!transformed.ok) {
+      return unavailable(
+        transformed.sandboxType ?? selection.sandboxType,
+        'transform',
+        transformed.reason,
+        selection.reason,
+      );
+    }
+    const executable = transformed.exec.argv[0];
+    if (!executable || !(await safelyCheckExecutable(executable, input.isExecutable))) {
+      return unavailable(
+        transformed.sandboxType,
+        'capability',
+        'executable_unavailable',
+        selection.reason,
+      );
+    }
+    return {
+      status: 'available',
+      backend: transformed.sandboxType,
+      selectionReason: selection.reason,
+    };
+  } catch {
+    return unavailable(
+      selection.sandboxType,
+      'capability',
+      'capability_probe_failed',
+      selection.reason,
+    );
+  }
+}
+
+function passiveCapability(profile: PermissionProfile): SandboxDiagnosticCapability | undefined {
+  if (profile.type === 'external') return { status: 'external', backend: 'none' };
+  if (
+    profile.type === 'disabled' ||
+    (profile.type === 'managed' && profile.fileSystem.kind !== 'restricted')
+  ) {
+    return {
+      status: 'not_required',
+      backend: 'none',
+      selectionReason: 'sandbox_not_required',
+    };
+  }
+  return undefined;
+}
+
+function unavailable(
+  backend: SandboxType,
+  stage: SandboxDiagnosticFailureStage,
+  reason: SandboxDiagnosticFailureReason,
+  selectionReason?: SandboxSelectionReason,
+): SandboxDiagnosticCapability {
+  return {
+    status: 'unavailable',
+    backend,
+    ...(selectionReason ? { selectionReason } : {}),
+    failure: { stage, reason },
+  };
+}
+
+function expectedSandboxType(platform: SandboxPlatform): SandboxType {
+  if (platform === 'darwin') return 'macos-seatbelt';
+  if (platform === 'linux') return 'linux';
+  return 'none';
+}
+
+function profileName(profile: PermissionProfile): string {
+  return profile.name ?? profile.type;
+}
+
+function summarizeFileSystem(profile: PermissionProfile): SandboxDiagnosticFileSystemMode {
+  if (profile.type === 'disabled') return 'disabled';
+  if (profile.type === 'external') return 'external';
+  if (profile.fileSystem.kind === 'unrestricted') return 'unrestricted';
+  if (profile.fileSystem.kind === 'external_sandbox') return 'external';
+  if (!profile.fileSystem.entries.some((entry) => entry.access === 'write')) return 'read-only';
+  return profile.fileSystem.entries.some(
+    (entry) =>
+      entry.kind === 'special' && entry.special === ':workspace_roots' && entry.access === 'write',
+  )
+    ? 'workspace-write'
+    : 'custom-restricted';
+}
+
+function summarizeNetwork(profile: PermissionProfile): SandboxDiagnosticNetworkMode {
+  return profile.type === 'disabled' ? 'unmanaged' : profile.network.kind;
+}
+
+function protectedMetadataNames(profile: PermissionProfile): readonly string[] {
+  if (profile.type !== 'managed') return [];
+  return [...(profile.fileSystem.protectedMetadata?.names ?? [])];
+}
+
+function cloneCapability(capability: SandboxDiagnosticCapability): SandboxDiagnosticCapability {
+  return {
+    ...capability,
+    ...(capability.failure ? { failure: { ...capability.failure } } : {}),
+  };
+}
+
+async function safelyCheckExecutable(
+  path: string,
+  isExecutable: (path: string) => Promise<boolean>,
+): Promise<boolean> {
+  try {
+    return await isExecutable(path);
+  } catch {
+    return false;
+  }
+}
+
+async function defaultIsExecutable(path: string): Promise<boolean> {
+  try {
+    await access(path, constants.X_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function canonicalPath(path: string): Promise<string> {
+  return await realpath(path).catch(() => resolve(path));
+}

--- a/packages/runtime/src/sandbox/errors.ts
+++ b/packages/runtime/src/sandbox/errors.ts
@@ -1,0 +1,100 @@
+import type { SandboxType } from './types.js';
+
+const SANDBOX_ERROR_DOMAINS = ['command', 'background_command', 'filesystem'] as const;
+export type SandboxErrorDomain = (typeof SANDBOX_ERROR_DOMAINS)[number];
+const SANDBOX_ERROR_STAGES = [
+  'capability',
+  'context',
+  'selection',
+  'validation',
+  'transform',
+  'launch',
+  'protocol',
+  'operation',
+] as const;
+export type SandboxErrorStage = (typeof SANDBOX_ERROR_STAGES)[number];
+
+const SANDBOX_TYPES = ['none', 'macos-seatbelt', 'linux'] as const;
+const STABLE_CODE_PATTERN = /^[a-z0-9_]+$/;
+const SAFE_IDENTIFIER_PATTERN = /^[A-Za-z0-9._:-]+$/;
+const MAX_METADATA_VALUE_CHARS = 128;
+
+export interface SandboxErrorMetadata {
+  domain: SandboxErrorDomain;
+  stage: SandboxErrorStage;
+  reason: string;
+  backend?: SandboxType;
+  recoverable: boolean;
+  profileName?: string;
+  requestId?: string;
+}
+
+export interface SandboxErrorWithMetadata extends Error, SandboxErrorMetadata {
+  code: string;
+}
+
+export class SandboxCommandError extends Error implements SandboxErrorWithMetadata {
+  readonly code = 'SANDBOX_COMMAND_EXECUTION_FAILED';
+  readonly domain: SandboxErrorDomain;
+  readonly stage: SandboxErrorStage;
+  readonly reason: string;
+  readonly backend?: SandboxType;
+  readonly recoverable: boolean;
+  readonly profileName?: string;
+
+  constructor(input: SandboxErrorMetadata & { message?: string }) {
+    super(input.message ?? `Command sandbox failed: ${input.reason}.`);
+    this.name = 'SandboxCommandError';
+    this.domain = input.domain;
+    this.stage = input.stage;
+    this.reason = input.reason;
+    this.backend = input.backend;
+    this.recoverable = input.recoverable;
+    this.profileName = input.profileName;
+  }
+}
+
+export function sandboxErrorMetadata(error: unknown): SandboxErrorMetadata | undefined {
+  if (!error || typeof error !== 'object') return undefined;
+  const value = error as Partial<SandboxErrorWithMetadata>;
+  if (
+    !isMember(value.domain, SANDBOX_ERROR_DOMAINS) ||
+    !isMember(value.stage, SANDBOX_ERROR_STAGES) ||
+    !isBoundedMatch(value.reason, STABLE_CODE_PATTERN) ||
+    typeof value.recoverable !== 'boolean' ||
+    (value.backend !== undefined && !isMember(value.backend, SANDBOX_TYPES))
+  ) {
+    return undefined;
+  }
+  return {
+    domain: value.domain,
+    stage: value.stage,
+    reason: value.reason,
+    recoverable: value.recoverable,
+    ...(value.backend ? { backend: value.backend } : {}),
+    ...(isBoundedMatch(value.profileName, SAFE_IDENTIFIER_PATTERN)
+      ? { profileName: value.profileName }
+      : {}),
+    ...(isBoundedMatch(value.requestId, SAFE_IDENTIFIER_PATTERN)
+      ? { requestId: value.requestId }
+      : {}),
+  };
+}
+
+export function serializeSandboxError(error: unknown): Record<string, unknown> | undefined {
+  const metadata = sandboxErrorMetadata(error);
+  return metadata ? { ...metadata } : undefined;
+}
+
+function isMember<T extends string>(value: unknown, values: readonly T[]): value is T {
+  return typeof value === 'string' && values.includes(value as T);
+}
+
+function isBoundedMatch(value: unknown, pattern: RegExp): value is string {
+  return (
+    typeof value === 'string' &&
+    value.length > 0 &&
+    value.length <= MAX_METADATA_VALUE_CHARS &&
+    pattern.test(value)
+  );
+}

--- a/packages/runtime/src/sandbox/index.ts
+++ b/packages/runtime/src/sandbox/index.ts
@@ -1,5 +1,33 @@
 export { SandboxManager } from './sandbox-manager.js';
 export {
+  createSandboxDiagnosticsProvider,
+  toSandboxRunTraceProjection,
+} from './diagnostics.js';
+export type {
+  CreateSandboxDiagnosticsProviderInput,
+  ResolveSandboxDiagnosticsInput,
+  SandboxDiagnosticCapability,
+  SandboxDiagnosticCapabilityStatus,
+  SandboxDiagnosticFailureReason,
+  SandboxDiagnosticFailureStage,
+  SandboxDiagnosticFileSystemMode,
+  SandboxDiagnosticNetworkMode,
+  SandboxDiagnosticsProvider,
+  SandboxDiagnosticsSnapshot,
+  SandboxRunTraceProjection,
+} from './diagnostics.js';
+export {
+  SandboxCommandError,
+  sandboxErrorMetadata,
+  serializeSandboxError,
+} from './errors.js';
+export type {
+  SandboxErrorDomain,
+  SandboxErrorMetadata,
+  SandboxErrorStage,
+  SandboxErrorWithMetadata,
+} from './errors.js';
+export {
   createBuiltinSandboxManager,
   createDefaultSandboxManager,
 } from './default-sandbox-manager.js';

--- a/packages/runtime/src/system-prompt/sandbox-context-prompt.ts
+++ b/packages/runtime/src/system-prompt/sandbox-context-prompt.ts
@@ -1,0 +1,74 @@
+import type {
+  SandboxDiagnosticCapability,
+  SandboxDiagnosticsSnapshot,
+} from '../sandbox/diagnostics.js';
+
+const MAX_RENDERED_ROOTS = 16;
+const MAX_RENDERED_PATH_CHARS = 1_024;
+
+export function renderSandboxTurnTailPrompt(snapshot: SandboxDiagnosticsSnapshot): string {
+  const lines = [
+    'Maka runtime sandbox context (authoritative; enforced by the runtime):',
+    '<sandbox_context>',
+    `  Profile: ${sanitizeLine(snapshot.profile.name, 'profile name')}`,
+    `  File system: ${snapshot.profile.fileSystem}`,
+    `  Network: ${snapshot.profile.network}`,
+    `  Working directory: ${renderPath(snapshot.profile.cwd, 'working directory')}`,
+  ];
+
+  const additionalRoots = snapshot.profile.workspaceRoots.filter(
+    (root) => root !== snapshot.profile.cwd,
+  );
+  if (snapshot.profile.fileSystem === 'unrestricted') {
+    lines.push('  Workspace access: unrestricted by Maka');
+  } else if (snapshot.profile.fileSystem === 'disabled') {
+    lines.push('  Workspace access: not managed by Maka');
+  } else if (additionalRoots.length === 0) {
+    lines.push('  Workspace access: constrained to the current workspace');
+  } else {
+    lines.push('  Workspace roots:');
+    for (const root of additionalRoots.slice(0, MAX_RENDERED_ROOTS)) {
+      lines.push(`    - ${renderPath(root, 'workspace root')}`);
+    }
+    if (additionalRoots.length > MAX_RENDERED_ROOTS) {
+      lines.push(`    - ${additionalRoots.length - MAX_RENDERED_ROOTS} additional root(s) omitted`);
+    }
+  }
+
+  lines.push(
+    `  Protected metadata: ${renderList(snapshot.profile.protectedMetadata)}`,
+    `  Command sandbox: ${renderCapability(snapshot.capabilities.command)}`,
+    `  Filesystem sandbox: ${renderCapability(snapshot.capabilities.filesystem)}`,
+    '</sandbox_context>',
+  );
+  return lines.join('\n');
+}
+
+function renderCapability(capability: SandboxDiagnosticCapability): string {
+  const details = [
+    capability.backend !== 'none' ? capability.backend : undefined,
+    capability.selectionReason,
+    capability.failure ? `${capability.failure.stage}:${capability.failure.reason}` : undefined,
+  ].filter((value): value is string => Boolean(value));
+  return details.length === 0 ? capability.status : `${capability.status} (${details.join(', ')})`;
+}
+
+function renderList(values: readonly string[]): string {
+  return values.length === 0
+    ? 'none'
+    : values.map((value) => sanitizeLine(value, 'metadata name')).join(', ');
+}
+
+function renderPath(value: string, label: string): string {
+  if (value.length > MAX_RENDERED_PATH_CHARS) {
+    throw new Error(`Sandbox context ${label} exceeds the rendering limit.`);
+  }
+  return sanitizeLine(value, label);
+}
+
+function sanitizeLine(value: string, label: string): string {
+  if (!value || /[\r\n\t]/.test(value)) {
+    throw new Error(`Sandbox context ${label} must be a non-empty single-line value.`);
+  }
+  return value;
+}

--- a/packages/runtime/src/tool-runtime.ts
+++ b/packages/runtime/src/tool-runtime.ts
@@ -62,6 +62,7 @@ import {
   type ToolRecoveryMode,
 } from './runtime-commit-sink.js';
 import { ChildAgentRunLimiter } from './child-agent-run-limiter.js';
+import { serializeSandboxError } from './sandbox/errors.js';
 
 export type ToolModelOutputPart =
   | { type: 'text'; text: string }
@@ -1323,6 +1324,7 @@ export class ToolRuntime {
     } catch (err) {
       if (err instanceof RuntimeCommitBoundaryError) throw err;
       output.flush();
+      const sandboxError = serializeSandboxError(err);
       const terminalFailure = coerceTerminalFailure(
         tool,
         this.input.header.cwd,
@@ -1397,6 +1399,7 @@ export class ToolRuntime {
           durationMs,
           status: 'error',
           errorClass: classifyError(err),
+          ...(sandboxError ? { sandbox: sandboxError } : {}),
         });
         return this.errorReturn(terminalFailure.message);
       }
@@ -1429,6 +1432,7 @@ export class ToolRuntime {
         durationMs: Math.max(0, this.input.now() - startedAt),
         status: 'error',
         errorClass: classifyError(err),
+        ...(sandboxError ? { sandbox: sandboxError } : {}),
       });
       return this.errorReturn(msg);
     } finally {


### PR DESCRIPTION
## Summary

- add a session-scoped sandbox diagnostics snapshot that reports the effective permission profile, filesystem and network policy, selected backend, selection reason, and typed capability failures
- wire the same snapshot through Desktop and CLI backend assembly, model turn-tail context, automatic approval review context, and a path-free durable RunTrace projection
- attach allowlisted structured sandbox failure metadata to command and filesystem tool failure traces without persisting raw error messages or workspace paths

Refs #843

## Verification

- `node --test` on the focused runtime suites: 239 passed
- `node --test packages/runtime/dist/__tests__/session-manager.test.js`: 190 passed
- `npm exec tsc -- -p packages/cli/tsconfig.json --noEmit`
- `npm exec tsc -- -p apps/desktop/tsconfig.main.json --noEmit`
- Biome format and lint on all changed files
- Desktop/CLI end-to-end smoke testing was not run
- full runtime typecheck is locally blocked by missing `@larksuiteoapi/node-sdk` and `@wecom/aibot-node-sdk` installations; no diagnostics-related type errors remain

## Security

- durable RunTrace snapshots omit `cwd` and workspace roots
- serialized sandbox failures contain only bounded, allowlisted identifiers and never copy raw error messages