### PR TITLE
fix(models): reconcile stale defaults after discovery

### DIFF
--- a/packages/core/src/__tests__/llm-connections.test.ts
+++ b/packages/core/src/__tests__/llm-connections.test.ts
@@ -27,6 +27,7 @@ import {
   persistedBaseUrl,
   providerAuthRequiresSecret,
   providerAuthSupportsApiKey,
+  reconcileConnectionAfterModelFetch,
   validateConnectionBaseUrl,
   type ProviderType,
 } from '../llm-connections.js';
@@ -1840,5 +1841,67 @@ describe('normalizeProviderType (persisted providerType alias)', () => {
     });
     assert.equal(migrated.providerType, 'openai-codex');
     assert.equal(migrated.slug, 'codex-subscription');
+  });
+});
+
+describe('reconcileConnectionAfterModelFetch', () => {
+  it('repairs a stale moonshot fallback default to a live enabled model', () => {
+    const next = reconcileConnectionAfterModelFetch(
+      {
+        defaultModel: 'moonshot-v1-8k',
+        enabledModelIds: ['moonshot-v1-8k', 'kimi-k2.6'],
+      },
+      [{ id: 'kimi-k2.5' }, { id: 'kimi-k2.6' }, { id: 'kimi-k2.7-code' }],
+    );
+    assert.equal(next.defaultModel, 'kimi-k2.6');
+    assert.deepEqual(next.enabledModelIds, ['kimi-k2.6']);
+  });
+
+  it('keeps a still-live default and drops retired enabled ids', () => {
+    const next = reconcileConnectionAfterModelFetch(
+      {
+        defaultModel: 'kimi-k2.6',
+        enabledModelIds: ['kimi-k2.6', 'moonshot-v1-8k', 'kimi-k2.5'],
+      },
+      [{ id: 'kimi-k2.6' }, { id: 'kimi-k2.5' }],
+    );
+    assert.equal(next.defaultModel, 'kimi-k2.6');
+    assert.deepEqual(next.enabledModelIds, ['kimi-k2.6', 'kimi-k2.5']);
+  });
+
+  it('falls back to the first discovered model when nothing previously enabled is live', () => {
+    const next = reconcileConnectionAfterModelFetch(
+      {
+        defaultModel: 'moonshot-v1-8k',
+        enabledModelIds: ['moonshot-v1-8k'],
+      },
+      [{ id: 'kimi-k2.6' }, { id: 'kimi-k2.5' }],
+    );
+    assert.equal(next.defaultModel, 'kimi-k2.6');
+    assert.deepEqual(next.enabledModelIds, ['kimi-k2.6']);
+  });
+
+  it('normalizes and deduplicates discovered ids before reconciliation', () => {
+    const next = reconcileConnectionAfterModelFetch(
+      {
+        defaultModel: 'retired-model',
+        enabledModelIds: ['retired-model'],
+      },
+      [{ id: '  live-model  ' }, { id: '' }, { id: 'live-model' }, { id: 1 }],
+    );
+    assert.equal(next.defaultModel, 'live-model');
+    assert.deepEqual(next.enabledModelIds, ['live-model']);
+  });
+
+  it('leaves defaults alone when discovery returns an empty list', () => {
+    const next = reconcileConnectionAfterModelFetch(
+      {
+        defaultModel: 'moonshot-v1-8k',
+        enabledModelIds: ['moonshot-v1-8k'],
+      },
+      [],
+    );
+    assert.equal(next.defaultModel, 'moonshot-v1-8k');
+    assert.deepEqual(next.enabledModelIds, ['moonshot-v1-8k']);
   });
 });

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1093,6 +1093,7 @@ export {
   READY_PROVIDER_TYPES,
   backendKindOf,
   connectionEnabledModelIds,
+  reconcileConnectionAfterModelFetch,
   effectiveBaseUrl,
   migrateConnectionV1ToV2,
   normalizeConnectionBaseUrl,

--- a/packages/core/src/llm-connections.ts
+++ b/packages/core/src/llm-connections.ts
@@ -113,6 +113,67 @@ export function connectionEnabledModelIds(connection: {
   return [...seen];
 }
 
+/**
+ * After a successful live model discovery, keep the connection usable.
+ *
+ * Fetching models used to leave a stale `defaultModel` (e.g. retired
+ * `moonshot-v1-*` fallbacks) that is absent from the live inventory. The
+ * readiness gate then fails with `model_not_enabled` — the "pull models and
+ * the connection breaks" regression. Prefer an already-enabled id that is
+ * still live; otherwise take the first discovered id.
+ */
+export function reconcileConnectionAfterModelFetch(
+  connection: {
+    defaultModel?: unknown;
+    enabledModelIds?: unknown;
+  },
+  models: readonly { id?: unknown }[],
+): {
+  defaultModel: string;
+  enabledModelIds: string[];
+} {
+  const liveIds: string[] = [];
+  const live = new Set<string>();
+  for (const model of models) {
+    if (typeof model?.id !== 'string') continue;
+    const id = model.id.trim();
+    if (!id || live.has(id)) continue;
+    live.add(id);
+    liveIds.push(id);
+  }
+
+  const previousDefault =
+    typeof connection.defaultModel === 'string' ? connection.defaultModel.trim() : '';
+  const previousEnabled = connectionEnabledModelIds(connection);
+
+  if (liveIds.length === 0) {
+    const defaultModel = previousDefault;
+    return {
+      defaultModel,
+      enabledModelIds: connectionEnabledModelIds({
+        defaultModel,
+        enabledModelIds: previousEnabled,
+      }),
+    };
+  }
+
+  const defaultModel =
+    (previousDefault && live.has(previousDefault) ? previousDefault : undefined) ??
+    previousEnabled.find((id) => live.has(id)) ??
+    liveIds[0]!;
+
+  // Keep previously enabled ids that still exist live, plus the (possibly
+  // repaired) default. Do not auto-enable the entire discovered catalog.
+  const keptEnabled = previousEnabled.filter((id) => live.has(id) || id === defaultModel);
+  return {
+    defaultModel,
+    enabledModelIds: connectionEnabledModelIds({
+      defaultModel,
+      enabledModelIds: keptEnabled,
+    }),
+  };
+}
+
 export type ConnectionTestErrorClass =
   | 'auth'
   | 'timeout'

--- a/packages/storage/src/__tests__/connection-store.test.ts
+++ b/packages/storage/src/__tests__/connection-store.test.ts
@@ -79,6 +79,28 @@ describe('FileConnectionStore', () => {
       assert.deepEqual(updated.enabledModelIds, ['gpt-5', 'gpt-4o-mini']);
     });
   });
+  test('repairs a stale default after live models are stored (moonshot regression)', async () => {
+    await withConnectionStore(async (store) => {
+      const created = await store.create({
+        slug: 'moonshot-main',
+        name: 'Moonshot',
+        providerType: 'moonshot',
+        defaultModel: 'moonshot-v1-8k',
+      });
+
+      const updated = await store.update(created.slug, {
+        models: [{ id: 'kimi-k2.6' }, { id: 'kimi-k2.5' }],
+        modelSource: 'fetched',
+        modelsFetchedAt: 1,
+        enabledModelIds: ['moonshot-v1-8k', 'kimi-k2.6'],
+      });
+
+      assert.equal(updated.defaultModel, 'kimi-k2.6');
+      assert.deepEqual(updated.enabledModelIds, ['kimi-k2.6']);
+      assert.equal(updated.modelSource, 'fetched');
+    });
+  });
+
 
   test('persists distinct OpenCode Zen and Go ids with exact selected models', async () => {
     await withConnectionStore(async (store, dir) => {
@@ -859,9 +881,101 @@ describe('FileConnectionStore', () => {
 
       const next = await store.get(created.slug);
       assert.deepEqual(next?.models, [{ id: 'glm-5' }, { id: 'glm-5.1' }]);
-      assert.deepEqual(next?.enabledModelIds, ['glm-4.7']);
+      // Stale default (not in the live inventory) is repaired so readiness
+      // does not fail with model_not_enabled after a successful fetch.
+      assert.equal(next?.defaultModel, 'glm-5');
+      assert.deepEqual(next?.enabledModelIds, ['glm-5']);
       assert.equal(next?.modelSource, 'fetched');
       assert.equal(next?.modelsFetchedAt, 1_800_000_000_000);
+    });
+  });
+
+  test('does not reconcile a stale default from a fallback model catalog', async () => {
+    await withConnectionStore(async (store) => {
+      const created = await store.create({
+        slug: 'fallback-main',
+        name: 'Fallback',
+        providerType: 'openai-compatible',
+        defaultModel: 'configured-model',
+      });
+
+      const next = await store.update(created.slug, {
+        models: [{ id: 'catalog-fallback' }],
+        modelSource: 'fallback',
+        modelsFetchedAt: 1,
+      });
+
+      assert.equal(next.defaultModel, 'configured-model');
+      assert.deepEqual(next.enabledModelIds, ['configured-model']);
+      assert.deepEqual(next.models, [{ id: 'catalog-fallback' }]);
+    });
+  });
+
+  test('does not reconcile when fetched metadata is updated without a model payload', async () => {
+    await withConnectionStore(async (store, dir) => {
+      await writeFile(
+        join(dir, 'llm-connections.json'),
+        JSON.stringify({
+          defaultSlug: 'moonshot-main',
+          connections: [
+            {
+              slug: 'moonshot-main',
+              name: 'Moonshot',
+              providerType: 'moonshot',
+              defaultModel: 'moonshot-v1-8k',
+              enabled: true,
+              enabledModelIds: ['moonshot-v1-8k'],
+              models: [{ id: 'kimi-k2.6' }],
+              modelSource: 'fallback',
+              createdAt: 1,
+              updatedAt: 1,
+            },
+          ],
+        }),
+        'utf8',
+      );
+
+      const next = await store.update('moonshot-main', {
+        modelSource: 'fetched',
+        modelsFetchedAt: 2,
+      });
+      assert.equal(next.defaultModel, 'moonshot-v1-8k');
+      assert.deepEqual(next.enabledModelIds, ['moonshot-v1-8k']);
+      assert.equal(next.models, undefined);
+    });
+  });
+
+  test('does not reconcile a stale default during an unrelated display-only update', async () => {
+    await withConnectionStore(async (store, dir) => {
+      await writeFile(
+        join(dir, 'llm-connections.json'),
+        JSON.stringify({
+          defaultSlug: 'moonshot-main',
+          connections: [
+            {
+              slug: 'moonshot-main',
+              name: 'Moonshot',
+              providerType: 'moonshot',
+              defaultModel: 'moonshot-v1-8k',
+              enabled: true,
+              enabledModelIds: ['moonshot-v1-8k'],
+              models: [{ id: 'kimi-k2.6' }],
+              modelSource: 'fetched',
+              modelsFetchedAt: 1_800_000_000_000,
+              createdAt: 1,
+              updatedAt: 1,
+            },
+          ],
+        }),
+        'utf8',
+      );
+
+      // A rename does not own model discovery and therefore must not silently
+      // switch the selected model. The next discovery write will reconcile it.
+      await store.update('moonshot-main', { name: 'Moonshot Primary' });
+      const next = await store.get('moonshot-main');
+      assert.equal(next?.defaultModel, 'moonshot-v1-8k');
+      assert.deepEqual(next?.enabledModelIds, ['moonshot-v1-8k']);
     });
   });
 

--- a/packages/storage/src/connection-store.ts
+++ b/packages/storage/src/connection-store.ts
@@ -5,6 +5,7 @@ import {
   connectionEnabledModelIds,
   migrateConnectionV1ToV2,
   persistedBaseUrl,
+  reconcileConnectionAfterModelFetch,
   validateSlug,
   type CreateConnectionInput,
   type LlmConnection,
@@ -110,7 +111,27 @@ class FileConnectionStore implements ConnectionStore {
           patch.baseUrl !== undefined ||
           patch.defaultModel !== undefined ||
           patch.models !== undefined);
-      const defaultModel = patch.defaultModel ?? current.defaultModel;
+      const models = updatesModelCache ? patch.models : clearsModelCache ? undefined : current.models;
+      let defaultModel = patch.defaultModel ?? current.defaultModel;
+      let enabledModelIds = connectionEnabledModelIds({
+        defaultModel,
+        enabledModelIds: patch.enabledModelIds ?? current.enabledModelIds,
+      });
+      // Authoritative live inventory wins: a retired default (common after
+      // Moonshot renamed moonshot-v1-* → kimi-k2.*) must not strand the
+      // connection as model_not_enabled once models are fetched. Fallback
+      // catalogs and metadata-only updates do not own this selection.
+      const writesFetchedModels =
+        Object.prototype.hasOwnProperty.call(patch, 'models') &&
+        patch.modelSource === 'fetched';
+      if (writesFetchedModels && models && models.length > 0) {
+        const reconciled = reconcileConnectionAfterModelFetch(
+          { defaultModel, enabledModelIds },
+          models,
+        );
+        defaultModel = reconciled.defaultModel;
+        enabledModelIds = reconciled.enabledModelIds;
+      }
       const next: LlmConnection = {
         ...current,
         name: patch.name ?? current.name,
@@ -120,11 +141,8 @@ class FileConnectionStore implements ConnectionStore {
             : current.baseUrl,
         defaultModel,
         enabled: patch.enabled ?? current.enabled,
-        enabledModelIds: connectionEnabledModelIds({
-          defaultModel,
-          enabledModelIds: patch.enabledModelIds ?? current.enabledModelIds,
-        }),
-        models: updatesModelCache ? patch.models : clearsModelCache ? undefined : current.models,
+        enabledModelIds,
+        models,
         modelSource: updatesModelCache
           ? patch.modelSource
           : clearsModelCache
@@ -168,6 +186,9 @@ class FileConnectionStore implements ConnectionStore {
   }
 
   async save(connection: LlmConnection): Promise<LlmConnection> {
+    // save() is a full-snapshot boundary, so callers providing authoritative
+    // fetched models must already reconcile defaultModel/enabledModelIds.
+    // update() performs that reconciliation for partial fetched-model patches.
     let saved: LlmConnection | null = null;
     await this.withQueue(async () => {
       const file = await this.readUnlocked();


### PR DESCRIPTION
## Summary

Keep a model connection usable after successful live model discovery when its configured default has disappeared from the provider inventory.

- normalize and deduplicate discovered model ids in a shared Core helper
- preserve a still-live default, otherwise prefer a previously enabled live model, then the first discovered model
- drop retired enabled ids without enabling the entire discovered catalog
- apply reconciliation only when Storage receives an authoritative non-empty `models` payload with `modelSource: 'fetched'`
- leave empty discoveries, fallback catalogs, metadata-only writes, and unrelated connection updates unchanged

## Verification

- `npm --workspace @maka/core run test` — **1135 passed, 0 failed**
- `npm --workspace @maka/storage run test` — **401 passed, 0 failed, 1 skipped**
- `npm run build:test` — passed
- `npm run typecheck` — passed across all workspaces after the standard build step
- `npx biome lint <changed files>` — passed
- `git diff --check` — passed

## Root cause

Live discovery persisted the new model inventory but retained a retired `defaultModel` and enabled-model list. The readiness gate then classified the connection as `model_not_enabled`, so pulling models could make an otherwise valid connection unusable.

## Review focus

The reconciliation boundary intentionally lives on the authoritative fetched-inventory write. It does not infer authority from cached fallback models or from `modelSource` / `modelsFetchedAt` metadata alone.
