### PR TITLE
feat(models): add Grok 4.5 thinking levels

### DIFF
--- a/packages/core/src/__tests__/model-thinking.test.ts
+++ b/packages/core/src/__tests__/model-thinking.test.ts
@@ -339,6 +339,15 @@ describe('thinkingVariantsForModel', () => {
     );
   });
 
+  test('xAI Grok 4.5 exposes its declared reasoning effort levels', () => {
+    assert.deepEqual([...thinkingVariantsForModel('xai', 'grok-4.5')], [
+      'low',
+      'medium',
+      'high',
+    ]);
+    assert.deepEqual([...thinkingVariantsForModel('xai', 'grok-4.3')], []);
+  });
+
   test('providers without metadata yield none (miss → no menu)', () => {
     assert.deepEqual([...thinkingVariantsForModel('ollama', 'llama3')], []);
     assert.deepEqual([...thinkingVariantsForModel('openai-compatible', 'some-model')], []);

--- a/packages/core/src/model-metadata.ts
+++ b/packages/core/src/model-metadata.ts
@@ -250,6 +250,10 @@ const STATIC_MODEL_METADATA: Partial<Record<ProviderType, Record<string, ModelMe
   vercel: {
     'xai/grok-4.3': { thinkingOptions: { efforts: ['none', 'low', 'medium', 'high'] } },
   },
+  xai: {
+    // models.dev + xAI declare configurable reasoning_effort for Grok 4.5.
+    'grok-4.5': { thinkingOptions: { efforts: ['low', 'medium', 'high'] } },
+  },
   'tencent-coding-plan': {
     'kimi-k2.5': { capabilities: { vision: false } },
   },

--- a/packages/runtime/src/__tests__/model-factory-thinking.test.ts
+++ b/packages/runtime/src/__tests__/model-factory-thinking.test.ts
@@ -161,6 +161,18 @@ describe('buildProviderOptions: thinking level', () => {
     assert.deepEqual(buildProviderOptions(conn('deepseek'), 'deepseek-chat', 'high'), {});
   });
 
+  test('xAI Grok 4.5 sends its declared reasoning effort under the xai namespace', () => {
+    assert.deepEqual([...thinkingVariantsForModel('xai', 'grok-4.5')], [
+      'low',
+      'medium',
+      'high',
+    ]);
+    assert.deepEqual(buildProviderOptions(conn('xai'), 'grok-4.5', 'high'), {
+      xai: { reasoningEffort: 'high' },
+    });
+    assert.deepEqual(buildProviderOptions(conn('xai'), 'grok-4.5', 'off'), {});
+  });
+
   test('Cloudflare Workers AI sends Kimi K2.6 reasoning effort and its real thinking-off wire', () => {
     const modelId = '@cf/moonshotai/kimi-k2.6';
     assert.deepEqual(
@@ -376,6 +388,7 @@ describe('buildProviderOptions: resolver/options drift guard', () => {
     { providerType: 'google', model: 'gemini-3-pro-preview' },
     { providerType: 'google', model: 'gemini-3.5-flash' },
     { providerType: 'deepseek', model: 'deepseek-v4-flash' },
+    { providerType: 'xai', model: 'grok-4.5' },
     { providerType: 'deepinfra', model: 'moonshotai/Kimi-K2.7-Code' },
     { providerType: 'groq', model: 'openai/gpt-oss-120b' },
     { providerType: 'openrouter', model: 'openai/gpt-5.6-sol' },

--- a/packages/runtime/src/model-factory.ts
+++ b/packages/runtime/src/model-factory.ts
@@ -410,6 +410,7 @@ export function buildProviderOptions(
     case 'groq':
     case 'deepseek':
     case 'moonshot':
+    case 'xai':
     case 'tencent-token-plan':
     case 'zai-coding-plan':
     case 'stepfun-step-plan':


### PR DESCRIPTION
## Summary

Expose xAI Grok 4.5's documented reasoning-effort choices in Maka:

- declare `low`, `medium`, and `high` thinking levels for the exact `xai/grok-4.5` provider/model pair
- route the selected level to the existing OpenAI-compatible xAI namespace as `reasoningEffort`
- keep undeclared xAI models hidden from the thinking-level picker
- add the pair to the resolver/provider-options drift guard

The declared values match both xAI's configurable `reasoning_effort` contract and the current models.dev metadata for `xai/grok-4.5`. This PR intentionally does not infer controls for other Grok models.

## Verification

- `npm --workspace @maka/core run test` — **1131 passed, 0 failed**
- `npm --workspace @maka/runtime run test` — **2270 passed, 0 failed, 7 skipped**
- `npm run build:test` — passed
- `npm run typecheck` — passed across all workspaces
- `npx biome lint <changed files>` — passed
- `git diff --check` — passed

## Review focus

- metadata is exact-model scoped: `grok-4.20-reasoning` remains without a menu
- Grok 4.5 does not expose `off`, because this declaration has no verified disable wire
- the runtime reuses the provider namespace already configured by xAI's OpenAI-compatible adapter
