### PR TITLE
fix(models): probe a live discovered model

### DIFF
--- a/packages/runtime/src/__tests__/provider-conformance.test.ts
+++ b/packages/runtime/src/__tests__/provider-conformance.test.ts
@@ -71,6 +71,94 @@ describe('models.dev provider conformance', () => {
     assert.equal(result.ok, false);
   });
 
+  test('connection probe does not revive fallback ids from an authoritative empty inventory', async () => {
+    const result = await testConnection(
+      {
+        slug: 'openai-empty',
+        name: 'OpenAI Empty',
+        providerType: 'openai',
+        baseUrl: 'http://127.0.0.1:1/v1',
+        defaultModel: 'gpt-5.5',
+        enabled: false,
+        models: [],
+        modelSource: 'fetched',
+        createdAt: 1,
+        updatedAt: 1,
+      },
+      'unused',
+    );
+    assert.deepEqual(result, { ok: false, errorMessage: 'No model to test' });
+  });
+
+  test('connection probe skips a stale default when a live inventory is available', async () => {
+    const requestedModels: string[] = [];
+    const server = await startJsonServer(async (request, response) => {
+      assert.equal(request.method, 'POST');
+      assert.equal(request.url, '/v1/chat/completions');
+      const body = JSON.parse(await readBody(request)) as { model: string };
+      requestedModels.push(body.model);
+      respondJson(response, 200, {});
+    });
+    const connection: LlmConnection = {
+      slug: 'moonshot-main',
+      name: 'Moonshot',
+      providerType: 'moonshot',
+      baseUrl: `${server.url}/v1`,
+      defaultModel: 'moonshot-v1-8k',
+      enabledModelIds: ['moonshot-v1-8k', 'kimi-k2.6'],
+      models: [{ id: 'kimi-k2.5' }, { id: 'kimi-k2.6' }],
+      enabled: true,
+      createdAt: 1,
+      updatedAt: 1,
+    };
+
+    assert.equal((await testConnection(connection, 'moonshot-key')).modelTested, 'kimi-k2.6');
+    assert.equal(
+      (await testConnection(connection, 'moonshot-key', 'explicit-preview')).modelTested,
+      'explicit-preview',
+    );
+    const legacy = { ...connection, models: undefined, enabledModelIds: undefined };
+    assert.equal(
+      (await testConnection(legacy, 'moonshot-key')).modelTested,
+      'moonshot-v1-8k',
+    );
+    assert.deepEqual(requestedModels, [
+      'kimi-k2.6',
+      'explicit-preview',
+      'moonshot-v1-8k',
+    ]);
+  });
+
+  test('connection probe bounds a fallback snapshot to its non-empty inventory', async () => {
+    const requestedModels: string[] = [];
+    const server = await startJsonServer(async (request, response) => {
+      assert.equal(request.method, 'POST');
+      assert.equal(request.url, '/v1/chat/completions');
+      const body = JSON.parse(await readBody(request)) as { model: string };
+      requestedModels.push(body.model);
+      respondJson(response, 200, {});
+    });
+    const result = await testConnection(
+      {
+        slug: 'moonshot-fallback',
+        name: 'Moonshot Fallback',
+        providerType: 'moonshot',
+        baseUrl: `${server.url}/v1`,
+        defaultModel: 'custom-moonshot-preview',
+        enabledModelIds: ['custom-moonshot-preview'],
+        models: [{ id: 'kimi-k2.6' }],
+        modelSource: 'fallback',
+        enabled: true,
+        createdAt: 1,
+        updatedAt: 1,
+      },
+      'moonshot-key',
+    );
+
+    assert.equal(result.modelTested, 'kimi-k2.6');
+    assert.deepEqual(requestedModels, ['kimi-k2.6']);
+  });
+
   test('OpenAI routes gpt-5* through the Responses wire and other models through Chat Completions by declaration', async () => {
     const requests: string[] = [];
     const server = await startJsonServer(async (request, response) => {

--- a/packages/runtime/src/test-connection.ts
+++ b/packages/runtime/src/test-connection.ts
@@ -1,5 +1,6 @@
 import {
   PROVIDER_DEFAULTS,
+  connectionEnabledModelIds,
   type ConnectionTestResult,
   type LlmConnection,
 } from '@maka/core/llm-connections';
@@ -10,6 +11,42 @@ import { claudeSubscriptionHeaders } from './subscription-auth.js';
 import { fetchGitHubCopilotModels } from './model-fetcher.js';
 
 const CONNECTION_TEST_TIMEOUT_MS = 15_000;
+
+/**
+ * Prefer an explicit model, then a still-live configured model. Legacy
+ * connections without a discovered inventory keep the historical
+ * default/fallback order.
+ */
+function resolveConnectionTestModel(
+  connection: LlmConnection,
+  model: string | undefined,
+  fallbackModels: readonly string[],
+): string | undefined {
+  const explicitModel = model?.trim();
+  if (explicitModel) return explicitModel;
+
+  const hasAuthoritativeInventory =
+    connection.modelSource === 'fetched' && Array.isArray(connection.models);
+  const discoveredIds =
+    connection.models
+      ?.map(({ id }) => id.trim())
+      .filter((id) => id.length > 0) ?? [];
+  const discovered =
+    hasAuthoritativeInventory || discoveredIds.length > 0
+      ? new Set(discoveredIds)
+      : undefined;
+  const candidates = [
+    ...connectionEnabledModelIds(connection),
+    ...fallbackModels,
+    ...discoveredIds,
+  ];
+  for (const candidate of candidates) {
+    const id = candidate.trim();
+    if (!id || (discovered && !discovered.has(id))) continue;
+    return id;
+  }
+  return undefined;
+}
 
 export async function testConnection(
   connection: LlmConnection,
@@ -25,7 +62,7 @@ export async function testConnection(
   }
   const auth = defaults.authKind;
   const secret = auth === 'none' ? '' : apiKey;
-  const testModel = model || connection.defaultModel || defaults.fallbackModels[0];
+  const testModel = resolveConnectionTestModel(connection, model, defaults.fallbackModels);
 
   if (!testModel) {
     return { ok: false, errorMessage: 'No model to test' };


### PR DESCRIPTION
## Summary

Make explicit connection tests tolerate legacy records whose configured default model is no longer present in an already-discovered live inventory.

- explicit test model still wins
- otherwise prefer the first configured model that is still present live
- then use a provider fallback only if that fallback is present live
- finally fall back to the first discovered model
- connections without a discovered inventory keep the existing default/fallback behavior
- an authoritative fetched-empty inventory remains empty and never revives fallback ids

The regression tests exercise the real local HTTP probe and assert the exact model sent in each request, plus the no-network fetched-empty path.

## Verification

- `npm --workspace @maka/runtime run test` — **2299 passed, 0 failed, 7 skipped** on current official main
- `npm run build:test` — passed
- `npm run typecheck` — passed across all workspaces
- `npx biome lint <changed files>` — passed
- `git diff --check` — passed

## Root cause

`testConnection` always chose `defaultModel` before looking at the connection's discovered `models`. Older persisted connections could therefore probe a retired model even when they already held a valid live inventory. Conversely, treating fetched `models: []` as “no cache” could incorrectly revive curated fallback ids for an account that authoritatively has no usable models.

## Review focus

This changes only the synthetic connection probe. The actual chat send path and explicit model selection remain authoritative and unchanged.
