### PR TITLE
fix(providers): refresh Moonshot fallback models

### DIFF
--- a/packages/core/src/__tests__/llm-connections.test.ts
+++ b/packages/core/src/__tests__/llm-connections.test.ts
@@ -1462,6 +1462,16 @@ describe('provider URL defaults', () => {
       'https://www.kimi.com/code/console',
     );
     assert.equal(PROVIDER_DEFAULTS.moonshot.baseUrl, 'https://api.moonshot.cn/v1');
+    assert.equal(PROVIDER_DEFAULTS.moonshot.modelsDevId, 'moonshotai-cn');
+    assert.deepEqual(PROVIDER_DEFAULTS.moonshot.fallbackModels.slice(0, 2), [
+      'kimi-k2.6',
+      'kimi-k2.7-code',
+    ]);
+    assert.ok(PROVIDER_DEFAULTS.moonshot.fallbackModels.includes('kimi-k2.5'));
+    assert.equal(
+      PROVIDER_DEFAULTS.moonshot.fallbackModels.some((id) => id.startsWith('moonshot-v1-')),
+      false,
+    );
     assert.equal(
       PROVIDER_DEFAULTS.moonshot.signupUrl,
       'https://platform.kimi.com/console/api-keys',

--- a/packages/core/src/provider-registry.ts
+++ b/packages/core/src/provider-registry.ts
@@ -486,6 +486,15 @@ const vercelModelIds = toolCallingModelIds(
   GENERATED_MODELS_DEV_METADATA.vercel,
   ['anthropic/claude-opus-4.8'],
 ).filter((id) => GENERATED_MODELS_DEV_METADATA.vercel[id]?.lifecycle !== 'deprecated');
+const moonshot = GENERATED_MODELS_DEV_PROVIDER_FACTS.moonshot;
+if (moonshot.id !== 'moonshotai-cn' || moonshot.api !== 'https://api.moonshot.cn/v1') {
+  throw new Error('models.dev Moonshot provider facts are missing the China platform id or API');
+}
+const moonshotModelIds = toolCallingModelIds(
+  'Moonshot',
+  GENERATED_MODELS_DEV_METADATA.moonshot,
+  ['kimi-k2.6', 'kimi-k2.7-code'],
+).filter((id) => GENERATED_MODELS_DEV_METADATA.moonshot[id]?.lifecycle !== 'deprecated');
 const cloudflareWorkersAi = GENERATED_MODELS_DEV_PROVIDER_FACTS['cloudflare-workers-ai'];
 if (cloudflareWorkersAi.id !== 'cloudflare-workers-ai') {
   throw new Error(
@@ -737,10 +746,10 @@ const providerRegistry = {
   moonshot: {
     label: 'Moonshot',
     description: 'Moonshot Kimi API key access.',
-    baseUrl: 'https://api.moonshot.cn/v1',
+    baseUrl: moonshot.api,
     authKind: 'api_key',
     backendKind: 'ai-sdk',
-    fallbackModels: ['moonshot-v1-8k', 'moonshot-v1-32k', 'moonshot-v1-128k'],
+    fallbackModels: moonshotModelIds,
     status: 'ready',
     protocol: 'openai',
     runtimeAdapter: { kind: 'openai-compatible', name: 'provider' },
@@ -749,6 +758,7 @@ const providerRegistry = {
     catalogGroup: 'api',
     catalogBadge: 'API',
     signupUrl: 'https://platform.kimi.com/console/api-keys',
+    modelsDevId: moonshot.id,
     readyOrder: 5,
     catalogOrder: 4,
   },


### PR DESCRIPTION
## Summary

Replace Moonshot's retired hard-coded `moonshot-v1-*` fallback models with the repository's existing generated models.dev snapshot.

- assert the generated Moonshot provider id and China API boundary
- recommend the snapshot-backed `kimi-k2.6` and `kimi-k2.7-code` first
- append the remaining tool-capable generated Moonshot models automatically
- filter deprecated snapshot entries
- expose the generated `moonshotai-cn` id on the provider declaration

This keeps the no-discovery/fallback path current without duplicating a manually maintained model list.

## Verification

- `npm --workspace @maka/core run test` — **1132 passed, 0 failed** on current official main
- `npm run build:test` — passed
- `npm run typecheck` — passed across all workspaces
- `npx biome lint <changed files>` — passed
- `git diff --check` — passed

## Root cause

The shared generated snapshot already contains current Moonshot models and provider facts, but the provider registry still defaulted new/fallback connections to retired `moonshot-v1-8k/32k/128k` ids.

## Review focus

The recommendation is constrained to model ids present in the repository's locked snapshot. New live models are not consumed until the normal metadata sync updates that snapshot.
