### PR TITLE
fix(oauth): preserve authoritative model inventories

### DIFF
--- a/apps/desktop/src/main/__tests__/claude-subscription-experimental-gate.test.ts
+++ b/apps/desktop/src/main/__tests__/claude-subscription-experimental-gate.test.ts
@@ -434,8 +434,8 @@ describe('Claude OAuth model connection bridge', () => {
     );
     assert.match(
       src,
-      /normalizeOpenAiCodexModels\(existing\.models, fallbackModels\)/,
-      'Codex OAuth sync must migrate stale unsupported model lists',
+      /const hasFetchedSnapshot[\s\S]*normalizeOpenAiCodexModels\(existing\.models \?\? \[\], \[\]\)/,
+      'Codex OAuth sync must normalize authoritative fetched snapshots without reviving fallback ids',
     );
     assert.match(
       src,

--- a/apps/desktop/src/main/__tests__/oauth-model-connections-openai-codex.test.ts
+++ b/apps/desktop/src/main/__tests__/oauth-model-connections-openai-codex.test.ts
@@ -181,6 +181,72 @@ describe('syncOpenAiCodexConnection live discovery behavior', () => {
     assert.equal(saved.enabled, true);
   });
 
+  it('normalizes an enabled fetched-empty snapshot to disabled on transient failure', async () => {
+    const existing = makeExisting({
+      enabled: true,
+      models: [],
+      modelSource: 'fetched',
+      lastTestStatus: 'verified',
+    });
+    const { sync, getSaved } = makeService({
+      existing,
+      token: 'tok',
+      fetchModels: async () => {
+        throw new Error('offline');
+      },
+    });
+
+    const result = await sync();
+
+    assert.deepEqual(result?.models, []);
+    assert.equal(result?.modelSource, 'fetched');
+    assert.equal(result?.enabled, false);
+    assert.equal(result?.lastTestStatus, 'error');
+    assert.deepEqual(getSaved()?.models, []);
+    assert.equal(getSaved()?.enabled, false);
+  });
+
+  it('re-enables a fetched-empty connection after later non-empty discovery', async () => {
+    const { sync, getSaved } = makeService({
+      existing: makeExisting({
+        enabled: false,
+        models: [],
+        modelSource: 'fetched',
+        lastTestStatus: 'error',
+      }),
+      token: 'tok',
+      fetchModels: async () => [{ id: 'gpt-5.6-sol' }],
+    });
+
+    const result = await sync();
+
+    assert.deepEqual(result?.models, [{ id: 'gpt-5.6-sol' }]);
+    assert.equal(result?.modelSource, 'fetched');
+    assert.equal(result?.enabled, true);
+    assert.equal(result?.lastTestStatus, 'verified');
+    assert.equal(getSaved()?.enabled, true);
+  });
+
+  it('does not preserve a non-empty fetched list when every cached id is now unsupported', async () => {
+    const existing = makeExisting({
+      models: [{ id: 'gpt-5-codex' }],
+      modelSource: 'fetched',
+    });
+    const { sync, getSaved } = makeService({
+      existing,
+      token: 'tok',
+      fetchModels: async () => {
+        throw new Error('offline');
+      },
+    });
+
+    const result = await sync();
+    assert.deepEqual(result?.models, []);
+    assert.equal(result?.enabled, false);
+    assert.equal(result?.lastTestStatus, 'error');
+    assert.deepEqual(getSaved()?.models, []);
+  });
+
   it('disables with needs_reauth when /models rejects with 401', async () => {
     const { sync, getSaved } = makeService({
       existing: makeExisting(),

--- a/apps/desktop/src/main/oauth-model-connections-main.ts
+++ b/apps/desktop/src/main/oauth-model-connections-main.ts
@@ -191,14 +191,14 @@ export function createOAuthModelConnectionsMainService(deps: OAuthModelConnectio
     // snapshot is rebuilt from the current registry so renamed/added models
     // (e.g. gpt-5.6-sol) reach existing users instead of being shadowed by a
     // stale copy on disk.
-    const cachedFetchedModels =
-      existing?.modelSource === 'fetched' && existing.models?.length
-        ? normalizeOpenAiCodexModels(existing.models, fallbackModels)
-        : fallbackModels;
+    const hasFetchedSnapshot =
+      existing?.modelSource === 'fetched' && Array.isArray(existing.models);
+    const cachedFetchedModels = hasFetchedSnapshot
+      ? normalizeOpenAiCodexModels(existing.models ?? [], [])
+      : fallbackModels;
 
     let models: NonNullable<LlmConnection['models']> = cachedFetchedModels;
-    let modelSource: ModelDiscoverySource =
-      existing?.modelSource === 'fetched' ? 'fetched' : 'fallback';
+    let modelSource: ModelDiscoverySource = hasFetchedSnapshot ? 'fetched' : 'fallback';
     let modelsFetchedAt = existing?.modelsFetchedAt;
     try {
       const accessToken = await deps.openAiCodex.getAccessTokenInternal();
@@ -277,7 +277,21 @@ export function createOAuthModelConnectionsMainService(deps: OAuthModelConnectio
         }
       }
       // Transient network failure / 5xx / unknown - keep the cached fetched
-      // list or the curated fallback so the connection stays usable.
+      // list or the curated fallback so the connection stays usable. An
+      // authoritative fetched-empty snapshot remains disabled/error; reviving
+      // fallback ids here would make an account with no usable models appear
+      // verified after a temporary outage.
+      if (hasFetchedSnapshot && cachedFetchedModels.length === 0 && existing) {
+        return deps.connectionStore.update(existing.slug, {
+          enabled: false,
+          lastTestStatus: 'error',
+          models: [],
+          modelSource: 'fetched',
+          modelsFetchedAt,
+          lastTestAt: new Date(now).toISOString(),
+          lastTestMessage: '当前账号无可用 Codex 模型。',
+        });
+      }
     }
 
     const normalizedDefaultModel = normalizeOpenAiCodexDefaultModel(


### PR DESCRIPTION
## Summary

Preserve the authority of OpenAI Codex OAuth model discovery across transient failures.

- distinguish a fetched snapshot from a fallback snapshot even when `models` is empty
- keep an authoritative fetched-empty account disabled/error instead of reviving curated fallback ids after an offline/5xx retry
- normalize cached fetched models without injecting fallback ids
- if a previously non-empty fetched cache now normalizes to no supported ids, persist an empty disabled/error state instead of preserving stale unsupported models

## Verification

- `npm --workspace @maka/desktop run test:dist` — **2754 passed, 0 failed**
- `npm run build:test` — passed
- `npm run typecheck` — passed across all workspaces
- `npm --workspace @maka/desktop run test:checks` — console, accessibility, and copy checks passed
- `npx biome lint <changed files>` — passed
- `git diff --check` — passed

## Root cause

The sync path used list truthiness to identify a fetched cache. An authoritative `models: []` therefore fell back to curated ids after a later transient discovery failure, making an account with no usable Codex models appear verified again.

## Review focus

The special-case return applies only to an originally empty fetched snapshot. A non-empty cache that becomes unsupported under current normalization is actively disabled and persisted as empty/error.
