### PR TITLE
fix(models): preserve Claude subscription capabilities

### DIFF
--- a/packages/core/src/__tests__/model-catalog.test.ts
+++ b/packages/core/src/__tests__/model-catalog.test.ts
@@ -783,7 +783,7 @@ describe('ModelCatalogEntry', () => {
     assert.equal(entry?.maxOutputTokens, 128_000);
   });
 
-  it('keeps Claude subscription limits unknown instead of reusing Anthropic API context', () => {
+  it('keeps Claude subscription access-path limits unknown while reusing model capabilities', () => {
     const [[apiEntry], [subscriptionEntry]] = (
       [
         ['anthropic', 'claude-sonnet-4-6'],
@@ -802,7 +802,11 @@ describe('ModelCatalogEntry', () => {
     assert.equal(apiEntry?.maxOutputTokens, 128_000);
     assert.equal(subscriptionEntry?.contextWindow, undefined);
     assert.equal(subscriptionEntry?.maxOutputTokens, undefined);
-    assert.deepEqual(subscriptionEntry?.capabilities, {});
+    assert.deepEqual(subscriptionEntry?.capabilities, {
+      vision: true,
+      reasoning: true,
+      functionCalling: true,
+    });
   });
 
   it('keeps static model facts on missing default entries without making them sendable', () => {

--- a/packages/core/src/__tests__/model-metadata.test.ts
+++ b/packages/core/src/__tests__/model-metadata.test.ts
@@ -125,6 +125,14 @@ describe('resolveModelVisionSupport', () => {
       true,
     );
     assert.equal(
+      resolveModelVisionSupport(
+        'claude-subscription',
+        [{ id: 'claude-sonnet-4-6' }],
+        'claude-sonnet-4-6',
+      ),
+      true,
+    );
+    assert.equal(
       resolveModelVisionSupport('deepseek', [{ id: 'deepseek-chat' }], 'deepseek-chat'),
       false,
     );

--- a/packages/core/src/model-metadata.ts
+++ b/packages/core/src/model-metadata.ts
@@ -372,6 +372,7 @@ function displayMetadataOnly(
         displayName: metadata.displayName,
         lifecycle: metadata.lifecycle,
         docsUrl: metadata.docsUrl,
+        capabilities: metadata.capabilities,
         thinkingOptions: overrides[id]?.thinkingOptions,
       },
     ]),


### PR DESCRIPTION
## Summary

Preserve generated model capabilities when projecting Anthropic metadata onto the Claude Subscription access path.

- keep context/output limits intentionally unknown for the subscription path
- retain provider-independent capabilities such as vision, reasoning, and function calling
- restore `resolveModelVisionSupport` for bare-id Claude Subscription inventories

## Verification

- `npm --workspace @maka/core run test` — **1132 passed, 0 failed**
- `npm run build:test` — passed
- `npm run typecheck` — passed across all workspaces
- `npx biome lint <changed files>` — passed
- `git diff --check` — passed

## Root cause

`displayMetadataOnly` intentionally removed Anthropic API limits for the subscription path, but also dropped `capabilities`. Desktop and CLI then treated bare-id Claude OAuth models as non-vision models even though the underlying generated metadata declared vision support.

## Review focus

This does not copy Anthropic API context/output limits into Claude Subscription. Only the access-path-independent capability flags are retained.
