### PR TITLE
test: stabilize concurrent process timing

### DIFF
--- a/packages/cli/src/__tests__/cli.test.ts
+++ b/packages/cli/src/__tests__/cli.test.ts
@@ -178,7 +178,7 @@ describe('Maka CLI args', () => {
     const child = spawn(process.execPath, ['--input-type=module', '-e', childSource], {
       stdio: 'ignore',
     });
-    const watchdog = setTimeout(() => child.kill('SIGKILL'), 5_000);
+    const watchdog = setTimeout(() => child.kill('SIGKILL'), 10_000);
     const [code, signal] = (await once(child, 'exit')) as [number | null, NodeJS.Signals | null];
     clearTimeout(watchdog);
 

--- a/packages/runtime-host/src/__tests__/host-kernel.test.ts
+++ b/packages/runtime-host/src/__tests__/host-kernel.test.ts
@@ -32,6 +32,7 @@ import {
   RUNTIME_HOST_MAX_FRAME_BYTES,
   RUNTIME_HOST_PROTOCOL_VERSION,
   RuntimeHostProtocolError,
+  type ClientSurface,
 } from '../protocol/index.js';
 import {
   RuntimeHostKernel,
@@ -69,13 +70,8 @@ describe('non-serving Runtime Host kernel', () => {
 
       // Connect before the loser assertion: a resident connection cancels the
       // winner's idle timer, so the loser candidate's storage work cannot drain
-      // the Host before this one-shot connect lands.
-      const connected = await connectRuntimeHost({
-        ...paths,
-        rootPath: paths.root,
-        surface: 'tui',
-        protocol: CURRENT_PROTOCOL,
-      });
+      // the Host before this bounded connection attempt establishes residency.
+      const connected = await retryConnect(paths, CURRENT_PROTOCOL);
       assert.equal(connected.kind, 'connected');
       if (connected.kind !== 'connected') return;
 
@@ -114,12 +110,7 @@ describe('non-serving Runtime Host kernel', () => {
       });
       assert.equal(candidate.kind, 'winner');
       if (candidate.kind !== 'winner') return;
-      const resident = await connectRuntimeHost({
-        ...paths,
-        rootPath: paths.root,
-        surface: 'desktop',
-        protocol: CURRENT_PROTOCOL,
-      });
+      const resident = await retryConnect(paths, CURRENT_PROTOCOL, 'desktop');
       assert.equal(resident.kind, 'connected');
       if (resident.kind !== 'connected') return;
 
@@ -163,12 +154,7 @@ describe('non-serving Runtime Host kernel', () => {
       assert.equal(replacement.kind, 'winner');
       if (replacement.kind !== 'winner') return;
       assert.notEqual(replacement.host.hostEpoch, candidate.host.hostEpoch);
-      const attached = await connectRuntimeHost({
-        ...paths,
-        rootPath: paths.root,
-        surface: 'tui',
-        protocol: CURRENT_PROTOCOL,
-      });
+      const attached = await retryConnect(paths, CURRENT_PROTOCOL);
       assert.equal(attached.kind, 'connected');
       if (attached.kind !== 'connected') return;
       await attached.connection.close();
@@ -889,12 +875,7 @@ describe('non-serving Runtime Host kernel', () => {
         Buffer.alloc(RUNTIME_HOST_MAX_FRAME_BYTES + 1, 0x61),
       );
 
-      const connected = await connectRuntimeHost({
-        ...paths,
-        rootPath: paths.root,
-        surface: 'tui',
-        protocol: CURRENT_PROTOCOL,
-      });
+      const connected = await retryConnect(paths, CURRENT_PROTOCOL);
       assert.equal(connected.kind, 'connected');
       if (connected.kind !== 'connected') return;
       assert.equal((await connected.connection.status()).state, 'ready');
@@ -911,11 +892,7 @@ describe('non-serving Runtime Host kernel', () => {
       });
       assert.equal(candidate.kind, 'winner');
       if (candidate.kind !== 'winner') return;
-      const connected = await connectRuntimeHost({
-        rootPath: paths.root,
-        surface: 'tui',
-        protocol: CURRENT_PROTOCOL,
-      });
+      const connected = await retryConnect(paths, CURRENT_PROTOCOL);
       assert.equal(connected.kind, 'connected');
       if (connected.kind !== 'connected') return;
 
@@ -1092,17 +1069,21 @@ function isConnectedClientMessage(
   );
 }
 
-async function retryConnect(paths: HostPaths, protocol: { min: number; max: number }) {
+async function retryConnect(
+  paths: HostPaths,
+  protocol: { min: number; max: number },
+  surface: ClientSurface = 'tui',
+) {
   const deadline = Date.now() + 5_000;
   let result = await connectRuntimeHost({
     ...paths,
     rootPath: paths.root,
-    surface: 'tui',
+    surface,
     protocol,
   });
   while (result.kind !== 'connected' && Date.now() < deadline) {
     await sleep(20);
-    result = await connectRuntimeHost({ ...paths, rootPath: paths.root, surface: 'tui', protocol });
+    result = await connectRuntimeHost({ ...paths, rootPath: paths.root, surface, protocol });
   }
   return result;
 }


### PR DESCRIPTION
## Summary

Stabilize two process-bound tests under parallel CI load without changing production behavior:

- use the existing bounded `retryConnect` helper for the first Runtime Host connection after candidate election, matching the other cold-start tests
- extend the CLI cleanup watchdog from 5s to 10s while keeping the asserted ~3s cleanup behavior unchanged
- keep the shared Runtime Host retry deadline at 5s so real failures do not become slower

## Verification

After the standard `npm run build:test`:

- `npm --workspace maka-agent run test:dist` — **631 passed, 0 failed**, repeated **5 times**
- `npm --workspace @maka/runtime-host run test:dist` — **45 passed, 0 failed**, repeated **5 times**
- `npm run typecheck` — passed across all workspaces
- `npx biome lint <changed files>` — passed
- `git diff --check` — passed

## Root cause

The owner-election test attempted one immediate socket connection even though the rest of the suite treats endpoint publication as an asynchronous cold-start boundary. Separately, the CLI test's watchdog left less than 2s of scheduling margin over its intentional cleanup grace, which is tight under parallel process-heavy test load.
