### PR TITLE
test(runtime-host): connect before loser election to avoid idle-grace race

### DIFF
--- a/packages/runtime-host/src/__tests__/host-kernel.test.ts
+++ b/packages/runtime-host/src/__tests__/host-kernel.test.ts
@@ -66,13 +66,10 @@ describe('non-serving Runtime Host kernel', () => {
       });
       assert.equal(winner.kind, 'winner');
       if (winner.kind !== 'winner') return;
-      assert.deepEqual(
-        await startTestRuntimeHostCandidate(paths, {
-          rootPath: paths.root,
-        }),
-        { kind: 'loser' },
-      );
 
+      // Connect before the loser assertion: a resident connection cancels the
+      // winner's idle timer, so the loser candidate's storage work cannot drain
+      // the Host before this one-shot connect lands.
       const connected = await connectRuntimeHost({
         ...paths,
         rootPath: paths.root,
@@ -81,6 +78,13 @@ describe('non-serving Runtime Host kernel', () => {
       });
       assert.equal(connected.kind, 'connected');
       if (connected.kind !== 'connected') return;
+
+      assert.deepEqual(
+        await startTestRuntimeHostCandidate(paths, {
+          rootPath: paths.root,
+        }),
+        { kind: 'loser' },
+      );
       const statuses = await Promise.all([
         connected.connection.status(),
         connected.connection.status(),


### PR DESCRIPTION
## Summary

The `elects one owner, serves status, and releases ownership after true-idle shutdown` test in `packages/runtime-host` started its winner with `idleGraceMs: 250` and ran a full loser-candidate election before a one-shot `connectRuntimeHost`. On a loaded Linux CI runner that front-side window can exceed 250ms, so the winner's idle timer committed shutdown—removing the registration and closing the listener—before the connect landed, yielding `{ kind: "unavailable" }`. Rerunning the job passed.

Connect first instead. A resident handshake cancels the winner's idle timer, so the loser candidate's storage work can no longer race with idle drain. Election semantics are unchanged (ownership is independent of client residency), and connect-before-contention is already this file's established pattern. No production code changed.

Refs #1283 (the PR whose CI first surfaced this flake; this fix is separate).

## Root cause

Not a production readiness race. `RuntimeHostKernel.#start()` awaits `listen()` and `#publishRegistration()` before the winner resolves, so a winner always returns with a listening endpoint and a published registration. The 250ms `idleGrace` serves the test's back side (prompt post-close shutdown); it is also armed on the front side, where it became a deadline the loser-candidate work could blow past on CI.

Confirmed with the real `startRuntimeHostCandidate` + `connectRuntimeHost` path: a controlled delay between winner and connect transitions from 8/8 connected (≤200ms) to 8/8 `unavailable:not_registered` (≥260ms), right at the 250ms grace. With a resident connection held first, the host survives 600–1000ms delays (8/8 connected), proving the reorder removes the race.

## Verification

Ran in the `fix/runtime-host-deterministic-readiness` worktree:

- `npm run build --workspace @maka/runtime-host` — ok
- Target test, `node --test --test-name-pattern="elects one owner"`, 50 iterations — 50 pass
- `packages/runtime-host` full suite (`node --test dist/__tests__/host-kernel.test.js`) — 23/23 pass
- `npm run format:check`, `npm run lint` — clean
- `npm run typecheck --workspace @maka/runtime-host` — clean

Not run: the repo-wide root `npm run test:dist` (headless/desktop suites), since this change is a pure reorder within one runtime-host test with no production code change.
