### PR TITLE
fix(runtime): use matching undici fetch for proxy test

### DIFF
--- a/packages/runtime/src/network/__tests__/proxy-test.test.ts
+++ b/packages/runtime/src/network/__tests__/proxy-test.test.ts
@@ -31,6 +31,68 @@ describe('testProxyConnection', () => {
     expect(result.error ?? '').toMatch(/ECONNREFUSED|fetch failed|bad port|timeout/i);
   });
 
+  test('does not depend on the ambient global fetch when using the proxy dispatcher', async () => {
+    const sockets = new Set<net.Socket>();
+    const server = net.createServer((socket) => {
+      sockets.add(socket);
+      socket.on('close', () => sockets.delete(socket));
+      socket.on('error', () => sockets.delete(socket));
+
+      let buffer = '';
+      let tunnelEstablished = false;
+      socket.on('data', (chunk) => {
+        buffer += chunk.toString('latin1');
+        const headerEnd = buffer.indexOf('\r\n\r\n');
+        if (headerEnd === -1) return;
+
+        const requestHead = buffer.slice(0, headerEnd);
+        buffer = buffer.slice(headerEnd + 4);
+        if (!tunnelEstablished && requestHead.startsWith('CONNECT ')) {
+          tunnelEstablished = true;
+          socket.write('HTTP/1.1 200 Connection Established\r\n\r\n');
+          return;
+        }
+
+        socket.end('HTTP/1.1 200 OK\r\nContent-Length: 0\r\nConnection: close\r\n\r\n');
+      });
+    });
+    await new Promise<void>((resolve, reject) => {
+      server.once('error', reject);
+      server.listen(0, '127.0.0.1', () => resolve());
+    });
+    const address = server.address();
+    assert.ok(address && typeof address === 'object');
+
+    const originalFetch = globalThis.fetch;
+    let ambientFetchCalled = false;
+    globalThis.fetch = (async () => {
+      ambientFetchCalled = true;
+      throw new Error('ambient global fetch must not be used');
+    }) as typeof globalThis.fetch;
+
+    try {
+      const result = await testProxyConnection({
+        proxy: {
+          ...PROXY_DEFAULTS,
+          enabled: true,
+          type: 'http',
+          host: '127.0.0.1',
+          port: address.port,
+        },
+        url: 'http://example.com',
+        timeoutMs: 1_000,
+      });
+
+      expect(result.ok).toBe(true);
+      expect(result.status).toBe(200);
+      expect(ambientFetchCalled).toBe(false);
+    } finally {
+      globalThis.fetch = originalFetch;
+      for (const socket of sockets) socket.destroy();
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+  });
+
   test('times out when the proxy accepts TCP but never responds', async () => {
     const sockets = new Set<net.Socket>();
     const server = net.createServer((socket) => {

--- a/packages/runtime/src/network/proxy-test.ts
+++ b/packages/runtime/src/network/proxy-test.ts
@@ -5,7 +5,7 @@ import type {
   TestProxyInput,
   TestProxyResult,
 } from '@maka/core/settings/network-settings';
-import type { Dispatcher } from 'undici';
+import { fetch, type Dispatcher } from 'undici';
 
 const DEFAULT_PROBE_URL = 'https://icanhazip.com';
 const DEFAULT_TIMEOUT_MS = 8_000;
@@ -51,7 +51,6 @@ export async function testProxyConnection(
   const startedAt = Date.now();
 
   try {
-    // @ts-expect-error undici fetch accepts dispatcher.
     const request = fetch(probeUrl, { dispatcher, signal: controller.signal }).catch((error) => {
       if (timedOut) return new Promise<never>(() => {});
       throw error;
@@ -95,7 +94,6 @@ async function lookupCountry(
 ): Promise<string | undefined> {
   try {
     const response = await fetch(`https://api.country.is/${encodeURIComponent(ip)}`, {
-      // @ts-expect-error undici fetch accepts dispatcher.
       dispatcher,
       signal,
     });


### PR DESCRIPTION
## Summary

- use the workspace `undici.fetch` implementation with the workspace `ProxyAgent`
- avoid passing an undici 8 dispatcher to Electron global fetch, which is backed by a different bundled undici version
- add a local CONNECT proxy regression test that fails if the ambient global fetch is used

## Verification

- `npm --workspace @maka/runtime test` (2305 tests, 0 failures)
- `npm --workspace @maka/runtime run typecheck`
- `npm --workspace @maka/desktop run typecheck`
- `npx biome lint packages/runtime/src/network/proxy-test.ts packages/runtime/src/network/__tests__/proxy-test.test.ts`
- Electron run-as-node proxy probe through `127.0.0.1:7897` returned HTTP 200, an exit IP, and country metadata