### PR TITLE
fix(desktop): route Codex OAuth through active proxy

### DIFF
--- a/apps/desktop/src/main/__tests__/openai-codex-service.test.ts
+++ b/apps/desktop/src/main/__tests__/openai-codex-service.test.ts
@@ -169,9 +169,18 @@ describe('Codex service source-grep contract', () => {
     );
   });
 
-  it('uses globalThis.fetch by default so Electron session proxy applies', async () => {
+  it('uses proxiedFetch by default so the active Maka proxy applies to OAuth requests', async () => {
     const src = await readFile(SERVICE_SOURCE, 'utf8');
-    assert.match(src, /globalThis\.fetch/);
+    assert.match(
+      src,
+      /deps\.fetchFn\s*\?\?\s*\(proxiedFetch as unknown as typeof fetch\)/,
+      'authorization-code exchange and token refresh must use the active Maka proxy by default',
+    );
+    assert.doesNotMatch(
+      src,
+      /deps\.fetchFn\s*\?\?\s*\(globalThis\.fetch/,
+      'Electron global fetch does not honor Maka active-proxy state',
+    );
   });
 
   it('does not expose tokens through the `getAccountState` return object', async () => {

--- a/apps/desktop/src/main/oauth/openai-codex-service.ts
+++ b/apps/desktop/src/main/oauth/openai-codex-service.ts
@@ -37,6 +37,7 @@ import {
   type SubscriptionActionResult,
 } from '@maka/core';
 import {
+  proxiedFetch,
   refreshAndPersistOAuthSubscriptionTokens,
   refreshOAuthSubscriptionTokens,
   resolveAndPersistOAuthSubscriptionTokens,
@@ -115,7 +116,7 @@ export interface OpenAiCodexServiceDeps {
   userDataDir: string;
   /** Function returning current epoch ms. Injectable for tests. */
   now?: () => number;
-  /** fetch implementation. Defaults to global fetch (Node 18+). */
+  /** Fetch implementation. Defaults to Maka's active-proxy-aware fetch. */
   fetchFn?: typeof fetch;
   /** Shared workspace credential store — the authoritative token store for every surface (#1125). */
   credentialStore: SharedOAuthCredentialStore;
@@ -140,7 +141,7 @@ export class OpenAiCodexService {
   constructor(deps: OpenAiCodexServiceDeps) {
     this.legacyTokenFilePath = join(deps.userDataDir, '.codex_subscription_token');
     this.now = deps.now ?? (() => Date.now());
-    this.fetchFn = deps.fetchFn ?? (globalThis.fetch as typeof fetch);
+    this.fetchFn = deps.fetchFn ?? (proxiedFetch as unknown as typeof fetch);
     this.credentialStore = deps.credentialStore;
   }
 


### PR DESCRIPTION
## Summary

- route Codex OAuth authorization-code exchange and token refresh through Maka active-proxy-aware fetch
- preserve injected fetch implementations for tests and callers
- update the regression contract so the service cannot silently fall back to Electron global fetch

Closes #1301

## Verification

- npm --workspace @maka/desktop test — 2752 passed, 0 failed
- npm --workspace @maka/desktop run typecheck
- npm --workspace @maka/runtime run typecheck
- npx biome lint on both changed files
- focused Codex OAuth tests with coverage — 13 passed; helper coverage 89.39% lines / 82.50% branches / 80% functions
- Electron run-as-node local proxy probe — proxyHit true, HTTP 200