### PR TITLE
fix(runtime): run sandboxed grep from a readable cwd

### DIFF
--- a/packages/runtime/src/__tests__/filesystem-worker-smoke.test.ts
+++ b/packages/runtime/src/__tests__/filesystem-worker-smoke.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { mkdtemp, readFile, realpath, rm } from 'node:fs/promises';
+import { mkdtemp, mkdir, readFile, realpath, rm, writeFile } from 'node:fs/promises';
 import { homedir, tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { after, before, describe, test } from 'node:test';
@@ -84,7 +84,54 @@ describe('macOS filesystem worker smoke', { skip: process.platform !== 'darwin' 
     });
     assert.equal(await readFile(allowedPath, 'utf8'), 'outside-ok');
   });
+
+  test('runs file and directory Grep inside the operation-scoped sandbox', async () => {
+    const sourceDirectory = join(workspace, 'src');
+    const sourceFile = join(sourceDirectory, 'health.ts');
+    await mkdir(sourceDirectory);
+    await writeFile(sourceFile, 'export const healthSignal = true;\n', 'utf8');
+
+    const fileResult = await client.execute({
+      operation: grepOperation(sourceFile, 'healthSignal'),
+      cwd: workspace,
+      mode: 'ask',
+    });
+    assert.equal(fileResult.kind, 'grep');
+    if (fileResult.kind === 'grep') {
+      assert.equal(fileResult.matches.length, 1);
+      assert.match(fileResult.matches[0] ?? '', /healthSignal/);
+    }
+
+    const directoryResult = await client.execute({
+      operation: grepOperation(sourceDirectory, 'healthSignal'),
+      cwd: workspace,
+      mode: 'ask',
+    });
+    assert.equal(directoryResult.kind, 'grep');
+    if (directoryResult.kind === 'grep') {
+      assert.equal(directoryResult.matches.length, 1);
+      assert.match(directoryResult.matches[0] ?? '', /healthSignal/);
+    }
+
+    const emptyResult = await client.execute({
+      operation: grepOperation(sourceDirectory, 'does-not-exist'),
+      cwd: workspace,
+      mode: 'ask',
+    });
+    assert.deepEqual(emptyResult, { kind: 'grep', matches: [] });
+  });
 });
+
+function grepOperation(path: string, pattern: string) {
+  return {
+    kind: 'grep' as const,
+    path,
+    pattern,
+    maxCountPerFile: 50,
+    limit: 200,
+    timeoutMs: 10_000,
+  };
+}
 
 async function grantFor(path: string, cwd: string): Promise<AdditionalPermissionGrant> {
   const normalized = await normalizeAdditionalPermissionProfile({

--- a/packages/runtime/src/__tests__/filesystem-worker.test.ts
+++ b/packages/runtime/src/__tests__/filesystem-worker.test.ts
@@ -1,7 +1,7 @@
 import { strict as assert } from 'node:assert';
 import { mkdtemp, mkdir, readFile, realpath, rm, symlink, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { join, parse } from 'node:path';
 import { afterEach, describe, test } from 'node:test';
 
 import { hashAdditionalPermissionProfile } from '../additional-permission-hash.js';
@@ -20,6 +20,85 @@ afterEach(async () => {
 });
 
 describe('filesystem worker operations', () => {
+  test('runs Grep from the filesystem root without broadening its target permission', async () => {
+    const root = await temporaryDirectory('maka-worker-grep-root-');
+    const target = join(root, 'file.ts');
+    await writeFile(target, 'const healthSignal = true;', 'utf8');
+    let grepCwd: string | undefined;
+
+    const response = await executeFilesystemWorkerRequest(
+      requestFor(
+        {
+          kind: 'grep',
+          cwd: root,
+          path: target,
+          pattern: 'healthSignal',
+          maxCountPerFile: 50,
+          limit: 200,
+          timeoutMs: 1_000,
+        },
+        { enforcementPath: target, access: 'read', scope: 'exact', targetType: 'file' },
+      ),
+      {
+        grepExecutable: '/usr/bin/rg',
+        runGrep: async (input) => {
+          grepCwd = input.cwd;
+          return { exitCode: 0, stdout: '1:const healthSignal = true;\n', stderrTail: '' };
+        },
+      },
+    );
+
+    assert.equal(grepCwd, parse(target).root);
+    assert.deepEqual(response, {
+      version: FILESYSTEM_WORKER_PROTOCOL_VERSION,
+      requestId: 'request-1',
+      ok: true,
+      result: { kind: 'grep', matches: ['1:const healthSignal = true;'] },
+    });
+  });
+
+  test('returns no Grep matches for exit code 1 and surfaces bounded stderr for failures', async () => {
+    const root = await temporaryDirectory('maka-worker-grep-result-');
+    const target = join(root, 'file.ts');
+    await writeFile(target, 'const value = 1;', 'utf8');
+    const operation = {
+      kind: 'grep' as const,
+      cwd: root,
+      path: target,
+      pattern: 'missing',
+      maxCountPerFile: 50,
+      limit: 200,
+      timeoutMs: 1_000,
+    };
+    const request = requestFor(operation, {
+      enforcementPath: target,
+      access: 'read',
+      scope: 'exact',
+      targetType: 'file',
+    });
+
+    const empty = await executeFilesystemWorkerRequest(request, {
+      grepExecutable: '/usr/bin/rg',
+      runGrep: async () => ({ exitCode: 1, stdout: '', stderrTail: '' }),
+    });
+    assert.equal(empty.ok, true);
+    if (empty.ok) assert.deepEqual(empty.result, { kind: 'grep', matches: [] });
+
+    const failed = await executeFilesystemWorkerRequest(request, {
+      grepExecutable: '/usr/bin/rg',
+      runGrep: async () => ({
+        exitCode: 2,
+        stdout: '',
+        stderrTail: 'rg: invalid regular expression\n',
+      }),
+    });
+    assert.equal(failed.ok, false);
+    if (!failed.ok) {
+      assert.equal(failed.error.code, 'filesystem_error');
+      assert.match(failed.error.message, /rg: invalid regular expression/);
+    }
+  });
+
   test('reads a validated image through the approved path capability', async () => {
     const root = await temporaryDirectory('maka-worker-image-');
     const target = join(root, 'image.png');

--- a/packages/runtime/src/filesystem-worker/operations.ts
+++ b/packages/runtime/src/filesystem-worker/operations.ts
@@ -1,7 +1,7 @@
 import { spawn } from 'node:child_process';
 import { promises as fs } from 'node:fs';
 import { glob as nodeGlob } from 'node:fs/promises';
-import { dirname, isAbsolute, resolve } from 'node:path';
+import { dirname, isAbsolute, parse, resolve } from 'node:path';
 import { isPathInside } from '../path-containment.js';
 import { additionalPermissionAllowsPath } from '@maka/core/additional-permissions';
 
@@ -20,6 +20,7 @@ import {
 
 const DEFAULT_GLOB_LIMIT = 200;
 const MAX_GREP_OUTPUT_BYTES = 8 * 1024 * 1024;
+const MAX_GREP_STDERR_BYTES = 16 * 1024;
 
 export interface FilesystemWorkerOperationDependencies {
   grepExecutable?: string;
@@ -36,6 +37,7 @@ export interface FilesystemWorkerGrepRunInput {
 export interface FilesystemWorkerGrepRunResult {
   exitCode: number;
   stdout: string;
+  stderrTail: string;
 }
 
 export type FilesystemWorkerGrepRunner = (
@@ -228,12 +230,21 @@ export async function executeFilesystemOperation(
       const result = await (dependencies.runGrep ?? runRipgrep)({
         executable: dependencies.grepExecutable,
         args,
-        cwd: await fs.realpath(operation.cwd),
+        // The target is canonical and absolute. Running from its filesystem root avoids
+        // requiring operation-scoped workers to read the broader session workspace.
+        cwd: parse(path).root,
         timeoutMs: operation.timeoutMs,
       });
       if (result.exitCode === 1) return { kind: 'grep', matches: [] };
-      if (result.exitCode !== 0)
-        throw operationError('filesystem_error', 'Grep failed while searching files.');
+      if (result.exitCode !== 0) {
+        const detail = result.stderrTail.trim();
+        throw operationError(
+          'filesystem_error',
+          detail
+            ? `Grep failed while searching files.\n${detail}`
+            : 'Grep failed while searching files.',
+        );
+      }
       return {
         kind: 'grep',
         matches: result.stdout.split('\n').filter(Boolean).slice(0, operation.limit),
@@ -423,10 +434,11 @@ async function runRipgrep(
     const child = spawn(input.executable, [...input.args], {
       cwd: input.cwd,
       shell: false,
-      stdio: ['ignore', 'pipe', 'ignore'],
+      stdio: ['ignore', 'pipe', 'pipe'],
     });
     const chunks: Buffer[] = [];
     let bytes = 0;
+    let stderrTail: Buffer<ArrayBufferLike> = Buffer.alloc(0);
     let settled = false;
     const timer = setTimeout(() => {
       child.kill('SIGKILL');
@@ -441,12 +453,19 @@ async function runRipgrep(
         chunks.push(chunk);
       }
     });
+    child.stderr.on('data', (chunk: Buffer) => {
+      stderrTail = appendBoundedTail(stderrTail, chunk, MAX_GREP_STDERR_BYTES);
+    });
     child.once('error', (error) => rejectOnce(error));
     child.once('close', (exitCode) => {
       if (settled) return;
       settled = true;
       clearTimeout(timer);
-      resolvePromise({ exitCode: exitCode ?? 2, stdout: Buffer.concat(chunks).toString('utf8') });
+      resolvePromise({
+        exitCode: exitCode ?? 2,
+        stdout: Buffer.concat(chunks).toString('utf8'),
+        stderrTail: stderrTail.toString('utf8'),
+      });
     });
 
     function rejectOnce(error: unknown): void {
@@ -456,4 +475,10 @@ async function runRipgrep(
       reject(error);
     }
   });
+}
+
+function appendBoundedTail(current: Buffer, chunk: Buffer, limit: number): Buffer {
+  if (chunk.length >= limit) return chunk.subarray(chunk.length - limit);
+  if (current.length + chunk.length <= limit) return Buffer.concat([current, chunk]);
+  return Buffer.concat([current.subarray(current.length - (limit - chunk.length)), chunk]);
 }


### PR DESCRIPTION
## Summary

- run filesystem-worker ripgrep from the target filesystem root so operation-scoped Seatbelt profiles do not deny `getcwd`
- keep the canonical absolute search target and narrow per-operation file permissions unchanged
- retain a bounded stderr tail so real ripgrep failures are visible instead of collapsing into a generic error
- cover file, directory, no-match, and error-result behavior, including a real macOS Seatbelt smoke test

## Verification

- `npm --workspace @maka/runtime test` (2318 passed, 0 failed, 7 conditionally skipped)
- `npx biome lint packages/runtime/src/filesystem-worker/operations.ts packages/runtime/src/__tests__/filesystem-worker.test.ts packages/runtime/src/__tests__/filesystem-worker-smoke.test.ts`
- `npx biome format packages/runtime/src/filesystem-worker/operations.ts packages/runtime/src/__tests__/filesystem-worker.test.ts packages/runtime/src/__tests__/filesystem-worker-smoke.test.ts`
- `git diff --check`

## Root cause

The filesystem worker narrowed its Seatbelt profile to the current Grep target but launched ripgrep with the broader session workspace as its cwd. Ripgrep calls `getcwd` during startup, so Seatbelt rejected an otherwise authorized search with `Operation not permitted`. Using the already-readable filesystem root as cwd fixes startup without granting workspace-wide read access.