### PR TITLE
feat(headless): expose isolated images to model vision

### DIFF
--- a/packages/headless/src/__tests__/harbor-cell.test.ts
+++ b/packages/headless/src/__tests__/harbor-cell.test.ts
@@ -1950,7 +1950,7 @@ describe('runHarborCell', () => {
       const toolExecutor = fakeToolExecutor();
       const register = buildAiSdkCellBackendRegistration({
         provider: 'openai',
-        model: 'gpt-4o-mini',
+        model: 'gpt-5.6-sol',
         env: {
           OPENAI_API_KEY: 'test-key',
           MAKA_STREAM_CONNECT_TIMEOUT_MS: '456000',
@@ -1964,7 +1964,7 @@ describe('runHarborCell', () => {
           id: 'harbor-ai-sdk',
           backend: 'ai-sdk',
           llmConnectionSlug: 'openai',
-          model: 'gpt-4o-mini',
+          model: 'gpt-5.6-sol',
           systemPrompt: DEFAULT_HEADLESS_SYSTEM_PROMPT,
         },
         task: { id: 'harbor-cell', instruction: 'solve', workspaceDir },
@@ -1982,6 +1982,8 @@ describe('runHarborCell', () => {
             systemPrompt?: string;
             streamConnectTimeoutMs?: number;
             streamIdleTimeoutMs?: number;
+            supportsVision?: boolean;
+            readAttachmentBytes?: unknown;
           };
         }
       ).input;
@@ -2001,6 +2003,71 @@ describe('runHarborCell', () => {
       assert.match(backendInput.systemPrompt ?? '', /Prefer Read, Glob, and Grep/);
       assert.equal(backendInput.streamConnectTimeoutMs, 456_000);
       assert.equal(backendInput.streamIdleTimeoutMs, 789_000);
+      assert.equal(backendInput.supportsVision, true);
+      assert.equal(typeof backendInput.readAttachmentBytes, 'function');
+    });
+  });
+
+  test('Harbor Read persists an isolated screenshot for the provider image input', async () => {
+    await withDirs(async ({ workspaceDir, storageRoot }) => {
+      const pngBytes = Buffer.from(
+        'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8DwHwAFBQIAX8jx0gAAAABJRU5ErkJggg==',
+        'base64',
+      );
+      await writeFile(join(workspaceDir, 'screen.png'), pngBytes);
+      const registry = new BackendRegistry();
+      const toolExecutor = createHarborCellLocalToolExecutor();
+      const register = buildAiSdkCellBackendRegistration({
+        provider: 'openai',
+        model: 'gpt-5.6-sol',
+        env: { OPENAI_API_KEY: 'test-key' },
+        now: () => 123,
+        newId: () => 'id',
+      });
+      await register(registry, {
+        config: {
+          id: 'harbor-ai-sdk',
+          backend: 'ai-sdk',
+          llmConnectionSlug: 'openai',
+          model: 'gpt-5.6-sol',
+        },
+        task: { id: 'harbor-cell', instruction: 'inspect screen', workspaceDir },
+        storageRoot,
+        workspaceDir,
+        realBackendIsolation: { kind: 'external', label: 'Harbor task container', toolExecutor },
+        toolExecutor,
+      });
+
+      const backend = await registry.build('ai-sdk', backendContext(workspaceDir));
+      const backendInput = (
+        backend as unknown as {
+          input: Pick<AiSdkBackendInput, 'tools' | 'readAttachmentBytes'>;
+        }
+      ).input;
+      const read = backendInput.tools.find((candidate) => candidate.name === 'Read');
+      assert.ok(read);
+      const result = (await read.impl(
+        { path: 'screen.png' },
+        {
+          sessionId: 'session-1',
+          turnId: 'turn-1',
+          cwd: workspaceDir,
+          toolCallId: 'tool-1',
+          abortSignal: new AbortController().signal,
+          emitOutput: () => {},
+        },
+      )) as {
+        kind: string;
+        mimeType: string;
+        ref: Parameters<NonNullable<AiSdkBackendInput['readAttachmentBytes']>>[0];
+      };
+
+      assert.equal(result.kind, 'image');
+      assert.equal(result.mimeType, 'image/png');
+      assert.ok(backendInput.readAttachmentBytes);
+      const stored = await backendInput.readAttachmentBytes(result.ref);
+      assert.equal(stored.ok, true);
+      if (stored.ok) assert.deepEqual(Buffer.from(stored.bytes), pngBytes);
     });
   });
 

--- a/packages/headless/src/__tests__/tools.test.ts
+++ b/packages/headless/src/__tests__/tools.test.ts
@@ -488,6 +488,66 @@ describe('isolated headless tools', () => {
     assert.ok(!r.content.includes('RAW-NATIVE-BYPASS'), 'the native readFile result is never used');
   });
 
+  test('Read snapshots an isolated screenshot for model vision', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'maka-headless-read-image-'));
+    const pngBytes = Buffer.from(
+      'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8DwHwAFBQIAX8jx0gAAAABJRU5ErkJggg==',
+      'base64',
+    );
+    await writeFile(join(cwd, 'screen.png'), pngBytes);
+    const snapshots: Array<{ name: string; bytes: Uint8Array; mimeType: string }> = [];
+    const executor: IsolatedToolExecutor = {
+      async exec(input) {
+        try {
+          const { stdout, stderr } = await execAsync(input.command, {
+            cwd: input.cwd,
+            env: process.env,
+            maxBuffer: 16 * 1024 * 1024,
+          });
+          return { exitCode: 0, stdout, stderr };
+        } catch (error: any) {
+          return {
+            exitCode: typeof error?.code === 'number' ? error.code : 1,
+            stdout: typeof error?.stdout === 'string' ? error.stdout : '',
+            stderr: typeof error?.stderr === 'string' ? error.stderr : String(error),
+          };
+        }
+      },
+    };
+    const tools = buildIsolatedHeadlessTools(executor, {
+      snapshotImage: async (input: {
+        sessionId: string;
+        turnId: string;
+        name: string;
+        bytes: Uint8Array;
+        mimeType: string;
+      }) => {
+        snapshots.push({ name: input.name, bytes: input.bytes, mimeType: input.mimeType });
+        return {
+          kind: 'session_file' as const,
+          sessionId: input.sessionId,
+          relativePath: 'artifacts/screen.png',
+        };
+      },
+    } as any);
+
+    const result = await tool(tools, 'Read').impl({ path: 'screen.png' }, toolCtx(cwd));
+
+    assert.deepEqual(result, {
+      kind: 'image',
+      mimeType: 'image/png',
+      ref: {
+        kind: 'session_file',
+        sessionId: 's',
+        relativePath: 'artifacts/screen.png',
+      },
+    });
+    assert.equal(snapshots.length, 1);
+    assert.equal(snapshots[0]?.name, 'screen.png');
+    assert.equal(snapshots[0]?.mimeType, 'image/png');
+    assert.deepEqual(Buffer.from(snapshots[0]?.bytes ?? []), pngBytes);
+  });
+
   test('Read rejects executor stdout outside its output frame', async () => {
     const tools = buildIsolatedHeadlessTools({
       async exec() {

--- a/packages/headless/src/__tests__/tools.test.ts
+++ b/packages/headless/src/__tests__/tools.test.ts
@@ -548,6 +548,46 @@ describe('isolated headless tools', () => {
     assert.deepEqual(Buffer.from(snapshots[0]?.bytes ?? []), pngBytes);
   });
 
+  test('Read rejects an invalid isolated image before snapshotting it', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'maka-headless-read-image-'));
+    await writeFile(join(cwd, 'screen.png'), Buffer.from('\x89PNG\r\n\x1a\n', 'latin1'));
+    let snapshotCalls = 0;
+    const executor: IsolatedToolExecutor = {
+      async exec(input) {
+        try {
+          const { stdout, stderr } = await execAsync(input.command, {
+            cwd: input.cwd,
+            env: process.env,
+            maxBuffer: 16 * 1024 * 1024,
+          });
+          return { exitCode: 0, stdout, stderr };
+        } catch (error: any) {
+          return {
+            exitCode: typeof error?.code === 'number' ? error.code : 1,
+            stdout: typeof error?.stdout === 'string' ? error.stdout : '',
+            stderr: typeof error?.stderr === 'string' ? error.stderr : String(error),
+          };
+        }
+      },
+    };
+    const tools = buildIsolatedHeadlessTools(executor, {
+      snapshotImage: async () => {
+        snapshotCalls += 1;
+        return {
+          kind: 'session_file' as const,
+          sessionId: 's',
+          relativePath: 'artifacts/screen.png',
+        };
+      },
+    });
+
+    await assert.rejects(
+      async () => await tool(tools, 'Read').impl({ path: 'screen.png' }, toolCtx(cwd)),
+      /dimensions/i,
+    );
+    assert.equal(snapshotCalls, 0);
+  });
+
   test('Read rejects executor stdout outside its output frame', async () => {
     const tools = buildIsolatedHeadlessTools({
       async exec() {

--- a/packages/headless/src/harbor-cell.ts
+++ b/packages/headless/src/harbor-cell.ts
@@ -2,7 +2,7 @@ import { mkdir, readFile, rename, rm, writeFile } from 'node:fs/promises';
 import { randomUUID } from 'node:crypto';
 import { join } from 'node:path';
 import type { BackendKind, PricingConfig, ProviderType } from '@maka/core';
-import { isThinkingLevel } from '@maka/core';
+import { isThinkingLevel, resolveModelVisionSupport } from '@maka/core';
 import {
   AiSdkBackend,
   BackendRegistry,
@@ -23,7 +23,9 @@ import {
 } from '@maka/runtime';
 import {
   createAgentRunStore,
+  createAttachmentByteReader,
   createArtifactStore,
+  createReadImageSnapshotter,
   createRuntimeEventStore,
   createSessionStore,
   persistProviderRequestCaptureArtifact,
@@ -760,6 +762,7 @@ export function buildAiSdkCellBackendRegistration(input: {
         ...(taskLedgerExperimentStore && taskLedgerExperimentPolicy
           ? { taskLedgerExperiment: { store: taskLedgerExperimentStore } }
           : {}),
+        snapshotImage: createReadImageSnapshotter(artifactStore),
       });
       return new AiSdkBackend({
         sessionId: ctx.sessionId,
@@ -787,6 +790,15 @@ export function buildAiSdkCellBackendRegistration(input: {
           ? (childInput) => context.readChildAgentOutput!(ctx.sessionId, childInput)
           : undefined,
         providerOptions: buildProviderOptions(connection, input.model, ctx.header.thinkingLevel),
+        supportsVision: resolveModelVisionSupport(
+          connection.providerType,
+          connection.models,
+          input.model,
+        ),
+        readAttachmentBytes: createAttachmentByteReader({
+          artifactStore,
+          sessionId: ctx.sessionId,
+        }),
         ...(streamConnectTimeoutMs !== undefined ? { streamConnectTimeoutMs } : {}),
         ...(streamIdleTimeoutMs !== undefined ? { streamIdleTimeoutMs } : {}),
         systemPrompt: context.config.systemPrompt,

--- a/packages/headless/src/heavy-task-evidence.ts
+++ b/packages/headless/src/heavy-task-evidence.ts
@@ -171,13 +171,20 @@ export function compactToolEvidence(
             limit: input.input.limit,
           },
           ok: true,
-          outputs: [
-            compactTextEvidence(input.result.content, {
-              stream: 'content',
-              refKind: 'future_storage',
-              forceTruncated: input.input.limit !== undefined,
-            }),
-          ],
+          outputs:
+            'content' in input.result
+              ? [
+                  compactTextEvidence(input.result.content, {
+                    stream: 'content',
+                    refKind: 'future_storage',
+                    forceTruncated: input.input.limit !== undefined,
+                  }),
+                ]
+              : [
+                  compactTextEvidence(`[image snapshot: ${input.result.mimeType}]`, {
+                    stream: 'content',
+                  }),
+                ],
           diff: { status: 'not_applicable' },
         },
       };

--- a/packages/headless/src/isolation.ts
+++ b/packages/headless/src/isolation.ts
@@ -1,4 +1,5 @@
 import type { ShellPlan } from '@maka/runtime';
+import type { StorageRef } from '@maka/core';
 import type { Config, Task } from './contracts.js';
 import type { HeavyTaskEvidenceRecorder } from './heavy-task-evidence.js';
 import type { HeavyTaskModeSelection } from './heavy-task-policy.js';
@@ -45,9 +46,13 @@ export interface IsolatedReadFileInput {
   limit?: number;
 }
 
-export interface IsolatedReadFileResult {
-  content: string;
-}
+export type IsolatedReadFileResult =
+  | { content: string }
+  | {
+      kind: 'image';
+      mimeType: string;
+      ref: Extract<StorageRef, { kind: 'session_file' }>;
+    };
 
 export interface IsolatedWriteFileInput {
   cwd: string;

--- a/packages/headless/src/tools.ts
+++ b/packages/headless/src/tools.ts
@@ -1,3 +1,4 @@
+import { MAX_READ_IMAGE_BYTES, type StorageRef } from '@maka/core';
 import type { MakaTool, ToolAvailabilityConfig } from '@maka/runtime';
 import {
   assertProductBindingCatalogClean,
@@ -6,6 +7,8 @@ import {
   buildForegroundBashTool,
   buildParentAgentTools,
   computeEditedSource,
+  isSupportedImagePath,
+  validateImageBytes,
 } from '@maka/runtime';
 import { withFileWriteLock } from '@maka/runtime/file-write-lock';
 import { createHash } from 'node:crypto';
@@ -36,6 +39,13 @@ export interface BuildIsolatedHeadlessToolsOptions {
   taskLedgerExperiment?: {
     store: TaskLedgerExperimentStore;
   };
+  snapshotImage?: (input: {
+    sessionId: string;
+    turnId: string;
+    name: string;
+    bytes: Uint8Array;
+    mimeType: string;
+  }) => Promise<Extract<StorageRef, { kind: 'session_file' }>>;
 }
 
 // Key Write and Edit on a JSON [cwd, path] pair (JSON.stringify so no path
@@ -161,11 +171,12 @@ function cleanupCommandTimeoutMs(command: string): number | undefined {
 
 export function buildIsolatedReadTool(
   executor: IsolatedToolExecutor,
-  options: Pick<BuildIsolatedHeadlessToolsOptions, 'heavyTaskEvidence'> = {},
+  options: Pick<BuildIsolatedHeadlessToolsOptions, 'heavyTaskEvidence' | 'snapshotImage'> = {},
 ): MakaTool {
   return {
     name: 'Read',
-    description: 'Read a file from the isolated headless task workspace.',
+    description:
+      'Read a text file or view a PNG, JPEG, GIF, or WebP image from the isolated headless task workspace. Use Read on screenshots when visual inspection is needed.',
     parameters: z.object({
       path: z.string(),
       offset: z.number().int().nonnegative().optional(),
@@ -176,6 +187,30 @@ export function buildIsolatedReadTool(
       const { cwd } = ctx;
       const normalizedPath = normalizeWorkspacePath(path, cwd, 'Read path');
       const input = { cwd, path: normalizedPath, offset, limit };
+      if (isSupportedImagePath(normalizedPath)) {
+        if (!options.snapshotImage) {
+          throw new Error('Read image snapshots are not available in this toolset.');
+        }
+        const bytes = await readIsolatedFileBytes(
+          executor,
+          cwd,
+          normalizedPath,
+          ctx.abortSignal,
+          READ_IMAGE_BYTES_SCRIPT,
+          'Read image',
+        );
+        const image = validateImageBytes(bytes);
+        const ref = await options.snapshotImage({
+          sessionId: ctx.sessionId,
+          turnId: ctx.turnId,
+          name: pathPosix.basename(normalizedPath),
+          bytes: image.bytes,
+          mimeType: image.mimeType,
+        });
+        const result = { kind: 'image' as const, mimeType: image.mimeType, ref };
+        await options.heavyTaskEvidence?.recordToolEvidence({ name: 'Read', input, result }, ctx);
+        return result;
+      }
       // Read has no native fast path: every result must go through READ_SCRIPT so
       // it carries the line-number / line+byte-cap / binary-guard contract (#92).
       const stdout = await execFramedFileCommand(
@@ -416,46 +451,55 @@ async function readIsolatedFileBytes(
   cwd: string,
   path: string,
   abortSignal: AbortSignal,
+  script = EDIT_READ_BYTES_SCRIPT,
+  integrityLabel = 'Edit read',
 ): Promise<Buffer> {
   const stdout = await execFileCommand(
     executor,
     cwd,
-    shellFileCommand(EDIT_READ_BYTES_SCRIPT, [path]),
+    shellFileCommand(script, [path]),
     abortSignal,
   );
-  return parseEditReadFrame(stdout);
+  return parseEditReadFrame(stdout, integrityLabel);
 }
 
-function parseEditReadFrame(stdout: string): Buffer {
+function parseEditReadFrame(stdout: string, integrityLabel = 'Edit read'): Buffer {
   const lines = stdout.split('\n');
   if (lines.length !== 4 || lines[3] !== '' || lines[2] !== EDIT_READ_FRAME_END) {
-    throw editReadIntegrityError('expected exactly one complete frame with no surrounding output');
+    throw editReadIntegrityError(
+      'expected exactly one complete frame with no surrounding output',
+      integrityLabel,
+    );
   }
 
   const header = lines[0]?.match(EDIT_READ_FRAME_HEADER_PATTERN);
-  if (!header) throw editReadIntegrityError('frame header is missing or malformed');
+  if (!header) throw editReadIntegrityError('frame header is missing or malformed', integrityLabel);
   const expectedLength = Number(header[1]);
   if (!Number.isSafeInteger(expectedLength))
-    throw editReadIntegrityError('declared byte length is not safe');
+    throw editReadIntegrityError('declared byte length is not safe', integrityLabel);
 
   const payload = lines[1] ?? '';
   if (!CANONICAL_BASE64_PATTERN.test(payload)) {
-    throw editReadIntegrityError('payload is not canonical Base64');
+    throw editReadIntegrityError('payload is not canonical Base64', integrityLabel);
   }
   const decoded = Buffer.from(payload, 'base64');
   if (decoded.toString('base64') !== payload) {
-    throw editReadIntegrityError('payload is not canonical Base64');
+    throw editReadIntegrityError('payload is not canonical Base64', integrityLabel);
   }
   if (decoded.length !== expectedLength) {
-    throw editReadIntegrityError(`declared ${expectedLength} bytes but decoded ${decoded.length}`);
+    throw editReadIntegrityError(
+      `declared ${expectedLength} bytes but decoded ${decoded.length}`,
+      integrityLabel,
+    );
   }
   const actualDigest = createHash('sha256').update(decoded).digest('hex');
-  if (actualDigest !== header[2]) throw editReadIntegrityError('SHA-256 digest mismatch');
+  if (actualDigest !== header[2])
+    throw editReadIntegrityError('SHA-256 digest mismatch', integrityLabel);
   return decoded;
 }
 
-function editReadIntegrityError(reason: string): Error {
-  return new Error(`Edit read transport integrity check failed: ${reason}`);
+function editReadIntegrityError(reason: string, label: string): Error {
+  return new Error(`${label} transport integrity check failed: ${reason}`);
 }
 
 function parseFileToolOutputFrame(
@@ -783,6 +827,23 @@ elif command -v shasum >/dev/null 2>&1; then
   digest=$(shasum -a 256 "$target" | awk '{print $1}') || exit 1
 else
   fail 'SHA-256 utility is required for Edit transport'
+fi
+printf 'MAKA_EDIT_BYTES_V1 length=%s sha256=%s\n' "$size" "$digest"
+base64 < "$target" | LC_ALL=C tr -d '\\r\\n'
+printf '\nMAKA_EDIT_BYTES_END\n'
+`;
+
+const READ_IMAGE_BYTES_SCRIPT = `${COMMON_SHELL_HELPERS}
+root=$(pwd -P) || exit 1
+target=$(existing_target "$1" 'Read path') || exit 1
+size=$(wc -c < "$target" | tr -d '[:space:]') || exit 1
+[ "$size" -le ${MAX_READ_IMAGE_BYTES} ] || fail 'Image exceeds the 5MB model input limit; downscale it and try again.'
+if command -v sha256sum >/dev/null 2>&1; then
+  digest=$(sha256sum "$target" | awk '{print $1}') || exit 1
+elif command -v shasum >/dev/null 2>&1; then
+  digest=$(shasum -a 256 "$target" | awk '{print $1}') || exit 1
+else
+  fail 'SHA-256 utility is required for Read image transport'
 fi
 printf 'MAKA_EDIT_BYTES_V1 length=%s sha256=%s\n' "$size" "$digest"
 base64 < "$target" | LC_ALL=C tr -d '\\r\\n'

--- a/packages/runtime/src/__tests__/builtin-tools.test.ts
+++ b/packages/runtime/src/__tests__/builtin-tools.test.ts
@@ -33,6 +33,11 @@ import {
   type WorkspaceExecutorFacts,
 } from '../workspace-executor.js';
 
+const ONE_PIXEL_PNG = Buffer.from(
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8DwHwAFBQIAX8jx0gAAAABJRU5ErkJggg==',
+  'base64',
+);
+
 describe('builtin tool activity kinds', () => {
   test('declares stable semantic categories independently of tool names', () => {
     const kinds = Object.fromEntries(
@@ -1268,7 +1273,7 @@ describe('builtin read tools path containment', () => {
 
   test('Read rejects image content without snapshot support, regardless of extension', async () => {
     const root = await mkdtemp(join(tmpdir(), 'maka-read-image-'));
-    await writeFile(join(root, 'photo.png'), Buffer.from('\x89PNG\r\n\x1a\n', 'latin1'));
+    await writeFile(join(root, 'photo.png'), ONE_PIXEL_PNG);
     await symlink('photo.png', join(root, 'notes.txt'));
     const readWithoutSnapshots = buildBuiltinTools().find((candidate) => candidate.name === 'Read');
     if (!readWithoutSnapshots) throw new Error('Read tool missing');

--- a/packages/runtime/src/__tests__/filesystem-worker.test.ts
+++ b/packages/runtime/src/__tests__/filesystem-worker.test.ts
@@ -14,6 +14,10 @@ import {
 } from '../filesystem-worker/protocol.js';
 
 const cleanup: string[] = [];
+const ONE_PIXEL_PNG = Buffer.from(
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8DwHwAFBQIAX8jx0gAAAABJRU5ErkJggg==',
+  'base64',
+);
 
 afterEach(async () => {
   await Promise.all(cleanup.splice(0).map((path) => rm(path, { recursive: true, force: true })));
@@ -102,8 +106,7 @@ describe('filesystem worker operations', () => {
   test('reads a validated image through the approved path capability', async () => {
     const root = await temporaryDirectory('maka-worker-image-');
     const target = join(root, 'image.png');
-    const bytes = Uint8Array.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
-    await writeFile(target, bytes);
+    await writeFile(target, ONE_PIXEL_PNG);
 
     const response = await executeFilesystemWorkerRequest(
       requestFor(
@@ -116,7 +119,7 @@ describe('filesystem worker operations', () => {
     if (response.ok)
       assert.deepEqual(response.result, {
         kind: 'read_image',
-        base64: Buffer.from(bytes).toString('base64'),
+        base64: ONE_PIXEL_PNG.toString('base64'),
         mimeType: 'image/png',
       });
   });
@@ -127,8 +130,7 @@ describe('filesystem worker operations', () => {
     const imageLink = join(root, 'notes.txt');
     const text = join(root, 'notes.txt.real');
     const textLink = join(root, 'chart.png');
-    const bytes = Buffer.from('\x89PNG\r\n\x1a\n', 'latin1');
-    await writeFile(image, bytes);
+    await writeFile(image, ONE_PIXEL_PNG);
     await writeFile(text, 'notes', 'utf8');
     await symlink(image, imageLink);
     await symlink(text, textLink);

--- a/packages/runtime/src/__tests__/image-file.test.ts
+++ b/packages/runtime/src/__tests__/image-file.test.ts
@@ -3,7 +3,33 @@ import assert from 'node:assert/strict';
 import { mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { readWorkspaceImage } from '../image-file.js';
+import { readWorkspaceImage, validateImageBytes } from '../image-file.js';
+
+const ONE_PIXEL_PNG = Buffer.from(
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8DwHwAFBQIAX8jx0gAAAABJRU5ErkJggg==',
+  'base64',
+);
+
+test('validateImageBytes rejects image signatures without parseable dimensions', () => {
+  assert.throws(
+    () => validateImageBytes(Buffer.from('\x89PNG\r\n\x1a\n', 'latin1')),
+    /dimensions/i,
+  );
+});
+
+test('validateImageBytes accepts a valid one-pixel image', () => {
+  assert.deepEqual(validateImageBytes(ONE_PIXEL_PNG), {
+    bytes: ONE_PIXEL_PNG,
+    mimeType: 'image/png',
+  });
+});
+
+test('validateImageBytes rejects non-positive image dimensions', () => {
+  const png = Buffer.from(ONE_PIXEL_PNG);
+  png.writeUInt32BE(0, 16);
+
+  assert.throws(() => validateImageBytes(png), /dimensions/i);
+});
 
 test('readWorkspaceImage rejects images whose dimensions exceed the model input limit', async () => {
   const root = await mkdtemp(join(tmpdir(), 'maka-image-file-'));

--- a/packages/runtime/src/__tests__/workspace-executor.test.ts
+++ b/packages/runtime/src/__tests__/workspace-executor.test.ts
@@ -6,6 +6,22 @@ import { join } from 'node:path';
 import { expect } from '../test-helpers.js';
 import { LocalWorkspaceExecutor } from '../workspace-executor.js';
 
+const ONE_PIXEL_IMAGES = [
+  [
+    'image.PNG',
+    'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8DwHwAFBQIAX8jx0gAAAABJRU5ErkJggg==',
+    'image/png',
+  ],
+  [
+    'image.jpg',
+    '/9j/4AAQSkZJRgABAQEASABIAAD/2wBDAP//////////////////////////////////////////////////////////////////////////////////////2wBDAf//////////////////////////////////////////////////////////////////////////////////////wAARCAABAAEDASIAAhEBAxEB/8QAFQABAQAAAAAAAAAAAAAAAAAAAAf/xAAUEAEAAAAAAAAAAAAAAAAAAAAA/9oADAMBAAIQAxAAAAF//8QAFBABAAAAAAAAAAAAAAAAAAAAAP/aAAgBAQABBQJ//8QAFBEBAAAAAAAAAAAAAAAAAAAAAP/aAAgBAwEBPwF//8QAFBEBAAAAAAAAAAAAAAAAAAAAAP/aAAgBAgEBPwF//8QAFBABAAAAAAAAAAAAAAAAAAAAAP/aAAgBAQAGPwJ//8QAFBABAAAAAAAAAAAAAAAAAAAAAP/aAAgBAQABPyF//9k=',
+    'image/jpeg',
+  ],
+  ['image.jpeg', 'R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==', 'image/gif'],
+  ['image.webp', 'UklGRiIAAABXRUJQVlA4IBYAAAAwAQCdASoBAAEAAUAmJaQAA3AA/vuUAAA=', 'image/webp'],
+] as const;
+const ONE_PIXEL_PNG = Buffer.from(ONE_PIXEL_IMAGES[0][1], 'base64');
+
 describe('LocalWorkspaceExecutor exec', () => {
   test('runs commands in the provided cwd and streams stdout/stderr', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'maka-workspace-exec-'));
@@ -112,19 +128,14 @@ describe('LocalWorkspaceExecutor exec', () => {
 });
 
 describe('LocalWorkspaceExecutor file operations', () => {
-  test('reads PNG, JPEG, GIF, and WebP images by magic bytes', async () => {
+  test('reads valid PNG, JPEG, GIF, and WebP images by magic bytes', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'maka-workspace-images-'));
     const executor = new LocalWorkspaceExecutor();
-    const fixtures = [
-      ['image.PNG', [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a], 'image/png'],
-      ['image.jpg', [0xff, 0xd8, 0xff], 'image/jpeg'],
-      ['image.jpeg', [...Buffer.from('GIF89a')], 'image/gif'],
-      ['image.webp', [...Buffer.from('RIFF0000WEBP')], 'image/webp'],
-    ] as const;
 
-    for (const [name, bytes, mimeType] of fixtures) {
+    for (const [name, base64, mimeType] of ONE_PIXEL_IMAGES) {
       const file = join(cwd, name);
-      await writeFile(file, Uint8Array.from(bytes));
+      const bytes = Buffer.from(base64, 'base64');
+      await writeFile(file, bytes);
       const result = await executor.readFile({ cwd, path: file });
       if (!('bytes' in result)) throw new Error('expected image result');
       expect(result.mimeType).toBe(mimeType);
@@ -136,13 +147,12 @@ describe('LocalWorkspaceExecutor file operations', () => {
     const cwd = await mkdtemp(join(tmpdir(), 'maka-workspace-images-'));
     const executor = new LocalWorkspaceExecutor();
     const file = join(cwd, 'image.png');
-    const bytes = Uint8Array.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
-    await writeFile(file, bytes);
+    await writeFile(file, ONE_PIXEL_PNG);
 
     const result = await executor.readFile({ cwd, path: file, offset: 1, limit: 1 });
 
     if (!('bytes' in result)) throw new Error('expected image result');
-    expect([...result.bytes]).toEqual([...bytes]);
+    expect([...result.bytes]).toEqual([...ONE_PIXEL_PNG]);
   });
 
   test('rejects extension-only and over-limit image files', async () => {

--- a/packages/runtime/src/image-file.ts
+++ b/packages/runtime/src/image-file.ts
@@ -31,6 +31,13 @@ export async function readWorkspaceImage(
   const bytes = await readFile(path).catch(() => {
     throw new Error('Image could not be read.');
   });
+  return validateImageBytes(bytes);
+}
+
+export function validateImageBytes(bytes: Uint8Array): {
+  bytes: Uint8Array;
+  mimeType: ImageMimeType;
+} {
   if (bytes.length > MAX_READ_IMAGE_BYTES) throw imageTooLargeError();
   const mimeType = sniffImageMime(bytes);
   if (!mimeType) throw new Error('Image content is not a supported PNG, JPEG, GIF, or WebP file.');

--- a/packages/runtime/src/image-file.ts
+++ b/packages/runtime/src/image-file.ts
@@ -42,7 +42,18 @@ export function validateImageBytes(bytes: Uint8Array): {
   const mimeType = sniffImageMime(bytes);
   if (!mimeType) throw new Error('Image content is not a supported PNG, JPEG, GIF, or WebP file.');
   const dimensions = imageDimensionsFromData(bytes);
-  if (dimensions && Math.max(dimensions.width, dimensions.height) > MAX_MODEL_IMAGE_EDGE) {
+  if (
+    !dimensions ||
+    !Number.isFinite(dimensions.width) ||
+    !Number.isFinite(dimensions.height) ||
+    !Number.isInteger(dimensions.width) ||
+    !Number.isInteger(dimensions.height) ||
+    dimensions.width <= 0 ||
+    dimensions.height <= 0
+  ) {
+    throw new Error('Image dimensions could not be read; verify the image file is valid.');
+  }
+  if (Math.max(dimensions.width, dimensions.height) > MAX_MODEL_IMAGE_EDGE) {
     throw new Error(
       `Image dimensions ${dimensions.width}x${dimensions.height} exceed the ${MAX_MODEL_IMAGE_EDGE}px model input limit; downscale it and try again.`,
     );

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -109,6 +109,7 @@ export type {
 } from './filesystem-worker/index.js';
 
 export { AiSdkBackend } from './ai-sdk-backend.js';
+export { isSupportedImagePath, validateImageBytes } from './image-file.js';
 export { findFirstChangedCacheableSegment } from './request-shape.js';
 export { createProviderRequestCaptureRecorder } from './provider-request-telemetry.js';
 export type {


### PR DESCRIPTION
## Summary

Let isolated headless `Read` return PNG, JPEG, GIF, and WebP files as provider-visible image tool results instead of omitted binary text.

Reuse the existing runtime image validator, storage attachment boundary, and model-vision metadata. The unified validator now rejects signature-only, truncated, unparseable, non-integer, and non-positive image dimensions before any artifact snapshot or provider request. This keeps visual capability separate from default-system-prompt experiments without adding a second image path or native decoder dependency.

## Verification

- TDD RED/GREEN: a PNG signature without dimensions was accepted; it is now rejected by `validateImageBytes`
- valid 1×1 PNG, JPEG, GIF, and WebP fixtures pass
- isolated `Read` proves invalid images never call `snapshotImage`
- runtime tests: 2,326 passed, 7 skipped, 0 failed
- headless tests: 1,172 passed, 1 skipped, 0 failed
- `npm run lint`, `npm run format:check`, and `git diff --check` passed

## Review focus

- one validator owns image format, size, dimensions, and edge limits across product and headless callers
- isolated file-byte framing completes before validation and artifact storage
- session-scoped attachment reads and provider image budget behavior remain unchanged