### PR TITLE
refactor(desktop): rename visual-smoke to e2e-fixture

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,7 +81,7 @@ jobs:
         run: command -v xvfb-run >/dev/null 2>&1 || { sudo apt-get update && sudo apt-get install -y xvfb; }
       - name: E2E
         run: xvfb-run -a npm --workspace @maka/desktop run e2e
-      # Design governance: the CDP alignment auditor walks the visual-smoke
+      # Design governance: the CDP alignment auditor walks the e2e-fixture
       # fixtures and fails on same-type height mismatches, mixed-type
       # centerline drift, or radius-family splits. Reuses the renderer the
       # e2e step just built; same xvfb pattern.

--- a/apps/desktop/e2e/bot-onboarding.spec.ts
+++ b/apps/desktop/e2e/bot-onboarding.spec.ts
@@ -39,9 +39,9 @@ test('IM 快捷接入完成真实 QR session、扫码状态和本机凭据落盘
   await expect(page.getByText('Maka 测试机器人')).toBeVisible();
 
   const stored = await page.evaluate(() => window.maka.settings.get());
-  expect(stored.botChat.channels.dingtalk.appId).toBe('visual-smoke-dingtalk-client');
-  expect(stored.botChat.channels.dingtalk.appSecret).not.toBe('visual-smoke-dingtalk-secret');
-  expect(JSON.stringify(stored)).not.toContain('visual-smoke-dingtalk-secret');
+  expect(stored.botChat.channels.dingtalk.appId).toBe('e2e-fixture-dingtalk-client');
+  expect(stored.botChat.channels.dingtalk.appSecret).not.toBe('e2e-fixture-dingtalk-secret');
+  expect(JSON.stringify(stored)).not.toContain('e2e-fixture-dingtalk-secret');
 
   await dialog.getByRole('button', { name: '完成' }).click();
   await expect(dialog).toBeHidden();

--- a/apps/desktop/e2e/fixtures.ts
+++ b/apps/desktop/e2e/fixtures.ts
@@ -44,7 +44,7 @@ async function seedE2eLocale(userDataDir: string, locale: 'zh' | 'en'): Promise<
  * CoreFoundation / X11 / sandbox session) that an allow-list would silently
  * drop and break the launch.
  */
-function buildE2eEnv(userDataDir: string, visualSmokeScenario?: string, locale?: 'zh' | 'en'): NodeJS.ProcessEnv {
+function buildE2eEnv(userDataDir: string, e2eFixtureScenario?: string, locale?: 'zh' | 'en'): NodeJS.ProcessEnv {
   const env = { ...process.env };
   for (const key of Object.keys(env)) {
     if (
@@ -52,8 +52,8 @@ function buildE2eEnv(userDataDir: string, visualSmokeScenario?: string, locale?:
       key === 'MAKA_E2E' ||
       key === 'MAKA_E2E_USER_DATA_DIR' ||
       key === 'MAKA_E2E_SHOW_WINDOW' ||
-      key === 'MAKA_VISUAL_SMOKE_FIXTURE' ||
-      key === 'MAKA_VISUAL_SMOKE_LOCALE' ||
+      key === 'MAKA_E2E_FIXTURE' ||
+      key === 'MAKA_E2E_FIXTURE_LOCALE' ||
       /_API_KEY$/.test(key) ||
       /_API_TOKEN$/.test(key) ||
       /_API_SECRET$/.test(key)
@@ -63,8 +63,8 @@ function buildE2eEnv(userDataDir: string, visualSmokeScenario?: string, locale?:
   }
   env.MAKA_E2E = '1';
   env.MAKA_E2E_USER_DATA_DIR = userDataDir;
-  if (visualSmokeScenario) env.MAKA_VISUAL_SMOKE_FIXTURE = visualSmokeScenario;
-  if (locale) env.MAKA_VISUAL_SMOKE_LOCALE = locale;
+  if (e2eFixtureScenario) env.MAKA_E2E_FIXTURE = e2eFixtureScenario;
+  if (locale) env.MAKA_E2E_FIXTURE_LOCALE = locale;
   // E2E windows launch hidden so local and macOS runs never steal the
   // developer's focus. Linux CI runs under xvfb, where a hidden window's
   // compositor is throttled to ~1fps — content-visibility turns never inflate
@@ -82,10 +82,10 @@ function buildE2eEnv(userDataDir: string, visualSmokeScenario?: string, locale?:
  * Electron and a leaked `maka-e2e-*` directory.
  */
 async function withE2eWindow(
-  { seed, readinessSelector, visualSmokeScenario, locale }: {
+  { seed, readinessSelector, e2eFixtureScenario, locale }: {
     seed: boolean;
     readinessSelector: string;
-    visualSmokeScenario?: string;
+    e2eFixtureScenario?: string;
     locale?: 'zh' | 'en';
   },
   use: (page: Page) => Promise<void>,
@@ -98,11 +98,11 @@ async function withE2eWindow(
     if (seed) await seedE2eConnection(userDataDir);
     // Legacy E2E specs assert Chinese labels and should not inherit the CI
     // host locale. Visual-smoke workspaces use the explicit renderer override.
-    if (locale && !visualSmokeScenario) await seedE2eLocale(userDataDir, locale);
+    if (locale && !e2eFixtureScenario) await seedE2eLocale(userDataDir, locale);
     app = await electron.launch({
       args: ['.'],
       cwd: DESKTOP_ROOT,
-      env: buildE2eEnv(userDataDir, visualSmokeScenario, locale),
+      env: buildE2eEnv(userDataDir, e2eFixtureScenario, locale),
     });
     app.on('console', (message) => {
       mainLogs.push(message.text());
@@ -165,7 +165,7 @@ export const test = base.extend<{
   emptyWindow: async ({}, use) => {
     await withE2eWindow({ seed: false, readinessSelector: '#root', locale: 'zh' }, use);
   },
-  // Long transcript: boots the visual-smoke `long-transcript` fixture, which
+  // Long transcript: boots the e2e-fixture `long-transcript` fixture, which
   // seeds a 24-turn (~1300px each) session and opens it as the active
   // session. Fixture mode seeds its own connections, so no connection is
   // pre-staged here. Readiness = turns on screen: the session is open and
@@ -173,7 +173,7 @@ export const test = base.extend<{
   // Used by the scroll-geometry spec.
   longTranscriptWindow: async ({}, use) => {
     await withE2eWindow(
-      { seed: false, readinessSelector: '.maka-turn', visualSmokeScenario: 'long-transcript', locale: 'zh' },
+      { seed: false, readinessSelector: '.maka-turn', e2eFixtureScenario: 'long-transcript', locale: 'zh' },
       use,
     );
   },
@@ -182,11 +182,11 @@ export const test = base.extend<{
   // are covered without a provider or test-only renderer state path.
   permissionWindow: async ({}, use) => {
     await withE2eWindow(
-      { seed: false, readinessSelector: '.maka-permission-prompt', visualSmokeScenario: 'permission-destructive', locale: 'zh' },
+      { seed: false, readinessSelector: '.maka-permission-prompt', e2eFixtureScenario: 'permission-destructive', locale: 'zh' },
       use,
     );
   },
-  // Stale sessions: boots the visual-smoke `stale-sessions` fixture — one
+  // Stale sessions: boots the e2e-fixture `stale-sessions` fixture — one
   // healthy session (zai-live, secret seeded), one unlocked fake session
   // (opened active), and one locked legacy session whose connection is
   // gone. Exercises the #1038 health-notice authority against real IPC
@@ -194,7 +194,7 @@ export const test = base.extend<{
   // Readiness = turns on screen: the fake session is open.
   staleSessionsWindow: async ({}, use) => {
     await withE2eWindow(
-      { seed: false, readinessSelector: '.maka-turn', visualSmokeScenario: 'stale-sessions', locale: 'zh' },
+      { seed: false, readinessSelector: '.maka-turn', e2eFixtureScenario: 'stale-sessions', locale: 'zh' },
       use,
     );
   },
@@ -202,30 +202,30 @@ export const test = base.extend<{
   // workspace so its shell controls and peer tabs run against real IPC data.
   sessionWorkbarWindow: async ({}, use) => {
     await withE2eWindow(
-      { seed: false, readinessSelector: 'aside[aria-label="会话工作栏"]', visualSmokeScenario: 'task-ledger', locale: 'zh' },
+      { seed: false, readinessSelector: 'aside[aria-label="会话工作栏"]', e2eFixtureScenario: 'task-ledger', locale: 'zh' },
       use,
     );
   },
-  // Remote access: uses the visual-smoke workspace so Settings opens on the
+  // Remote access: uses the e2e-fixture workspace so Settings opens on the
   // channel catalog and main injects deterministic IM onboarding adapters.
   // The renderer still talks through the real preload/IPC/session authority.
   botSettingsWindow: async ({}, use) => {
     await withE2eWindow(
-      { seed: false, readinessSelector: '[aria-label="设置内容"]', visualSmokeScenario: 'settings-bots', locale: 'zh' },
+      { seed: false, readinessSelector: '[aria-label="设置内容"]', e2eFixtureScenario: 'settings-bots', locale: 'zh' },
       use,
     );
   },
-  // Representative visual-smoke renderer launches in both supported locales.
+  // Representative e2e-fixture renderer launches in both supported locales.
   // These use the same production LocaleProvider override path as screenshot capture.
   zhLocaleWindow: async ({}, use) => {
     await withE2eWindow(
-      { seed: false, readinessSelector: '.appFrame', visualSmokeScenario: 'all', locale: 'zh' },
+      { seed: false, readinessSelector: '.appFrame', e2eFixtureScenario: 'all', locale: 'zh' },
       use,
     );
   },
   enLocaleWindow: async ({}, use) => {
     await withE2eWindow(
-      { seed: false, readinessSelector: '.appFrame', visualSmokeScenario: 'all', locale: 'en' },
+      { seed: false, readinessSelector: '.appFrame', e2eFixtureScenario: 'all', locale: 'en' },
       use,
     );
   },

--- a/apps/desktop/e2e/fixtures.ts
+++ b/apps/desktop/e2e/fixtures.ts
@@ -97,7 +97,7 @@ async function withE2eWindow(
   try {
     if (seed) await seedE2eConnection(userDataDir);
     // Legacy E2E specs assert Chinese labels and should not inherit the CI
-    // host locale. Visual-smoke workspaces use the explicit renderer override.
+    // host locale. E2e-fixture workspaces use the explicit renderer override.
     if (locale && !e2eFixtureScenario) await seedE2eLocale(userDataDir, locale);
     app = await electron.launch({
       args: ['.'],

--- a/apps/desktop/e2e/locale-renderer.spec.ts
+++ b/apps/desktop/e2e/locale-renderer.spec.ts
@@ -1,13 +1,13 @@
 import { test, expect } from './fixtures';
 
-test('Chinese visual-smoke renderer uses the resolved locale', async ({ zhLocaleWindow: page }) => {
+test('Chinese e2e-fixture renderer uses the resolved locale', async ({ zhLocaleWindow: page }) => {
   await expect(page.locator('html')).toHaveAttribute('lang', 'zh');
   await expect(page.getByRole('button', { name: '展开侧边栏' })).toBeVisible();
   const screenshot = await page.locator('.appFrame').screenshot({ animations: 'disabled' });
   expect(screenshot.byteLength).toBeGreaterThan(10_000);
 });
 
-test('English visual-smoke renderer uses the resolved locale', async ({ enLocaleWindow: page }) => {
+test('English e2e-fixture renderer uses the resolved locale', async ({ enLocaleWindow: page }) => {
   await expect(page.locator('html')).toHaveAttribute('lang', 'en');
   await expect(page.getByRole('button', { name: 'Expand sidebar' })).toBeVisible();
   const screenshot = await page.locator('.appFrame').screenshot({ animations: 'disabled' });

--- a/apps/desktop/e2e/session-health-notice.spec.ts
+++ b/apps/desktop/e2e/session-health-notice.spec.ts
@@ -3,7 +3,7 @@
 // "will the next send fail?" from the same facts as the send gate
 // (connection list, hasSecret probe, connectionLocked on the summary).
 //
-// The stale-sessions visual fixture seeds the exact on-disk states, and
+// The stale-sessions e2e-fixture seeds the exact on-disk states, and
 // both stale sessions carry user messages, so storage self-heals them to
 // `connectionLocked: true` on first read — the send can neither use
 // their connections nor silently rebind, even though a healthy default

--- a/apps/desktop/src/main/__tests__/app-shell-effect-stability-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/app-shell-effect-stability-contract.test.ts
@@ -201,7 +201,7 @@ function BootstrapSubscriptionProbe(props: {
   props.effects.useAppShellBootstrapSubscriptions({
     uiLocale: 'zh',
     activeIdRef: props.refs.activeIdRef,
-    applyE2EFixture: async () => {},
+    applyE2eFixture: async () => {},
     bootstrapSessions: async () => {},
     clearPendingTurnActionsForSession: () => {},
     clearSessionRendererState: () => {},

--- a/apps/desktop/src/main/__tests__/app-shell-effect-stability-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/app-shell-effect-stability-contract.test.ts
@@ -201,7 +201,7 @@ function BootstrapSubscriptionProbe(props: {
   props.effects.useAppShellBootstrapSubscriptions({
     uiLocale: 'zh',
     activeIdRef: props.refs.activeIdRef,
-    applyVisualSmokeFixture: async () => {},
+    applyE2EFixture: async () => {},
     bootstrapSessions: async () => {},
     clearPendingTurnActionsForSession: () => {},
     clearSessionRendererState: () => {},

--- a/apps/desktop/src/main/__tests__/artifact-pane-layout.test.ts
+++ b/apps/desktop/src/main/__tests__/artifact-pane-layout.test.ts
@@ -1,7 +1,7 @@
 /**
  * CSS contract tests for ArtifactPane narrow layout (PR108j).
  *
- * The e2e-fixture path still owns screenshot verification. These tests are
+ * The e2e-fixture path still owns deterministic rendering. These tests are
  * a cheap automated floor for the @kenji gate: at narrow widths the pane must
  * stop being a squeezed right rail and become a bottom sheet that leaves the
  * composer/send path usable.

--- a/apps/desktop/src/main/__tests__/artifact-pane-layout.test.ts
+++ b/apps/desktop/src/main/__tests__/artifact-pane-layout.test.ts
@@ -1,7 +1,7 @@
 /**
  * CSS contract tests for ArtifactPane narrow layout (PR108j).
  *
- * The visual smoke path still owns screenshot verification. These tests are
+ * The e2e-fixture path still owns screenshot verification. These tests are
  * a cheap automated floor for the @kenji gate: at narrow widths the pane must
  * stop being a squeezed right rail and become a bottom sheet that leaves the
  * composer/send path usable.

--- a/apps/desktop/src/main/__tests__/browser-panel-chrome.test.ts
+++ b/apps/desktop/src/main/__tests__/browser-panel-chrome.test.ts
@@ -2,10 +2,10 @@
  * Source contract for BrowserPanel renderer chrome invariants (#819).
  *
  * Symmetric to `artifact-pane-layout.test.ts` (regex over the component's
- * source). The e2e-fixture `browser-empty` fixture owns screenshot
- * verification of the chrome layout; this test locks the declarative
- * wirings that produce the chrome's state-dependent DOM — the invariants
- * the issue lists as not needing a screenshot:
+ * source). The e2e-fixture `browser-empty` fixture renders the chrome
+ * layout; this test locks the declarative wirings that produce the
+ * chrome's state-dependent DOM — the invariants the issue lists as not
+ * needing a dedicated fixture render:
  *
  *  - back / forward buttons `:disabled` track `canGoBack` / `canGoForward`;
  *  - reload / stop icon swaps with `loading` (+ aria-label + onClick branch);

--- a/apps/desktop/src/main/__tests__/browser-panel-chrome.test.ts
+++ b/apps/desktop/src/main/__tests__/browser-panel-chrome.test.ts
@@ -2,7 +2,7 @@
  * Source contract for BrowserPanel renderer chrome invariants (#819).
  *
  * Symmetric to `artifact-pane-layout.test.ts` (regex over the component's
- * source). The visual-smoke `browser-empty` fixture owns screenshot
+ * source). The e2e-fixture `browser-empty` fixture owns screenshot
  * verification of the chrome layout; this test locks the declarative
  * wirings that produce the chrome's state-dependent DOM — the invariants
  * the issue lists as not needing a screenshot:

--- a/apps/desktop/src/main/__tests__/chat-preview-cascade-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/chat-preview-cascade-contract.test.ts
@@ -11,9 +11,9 @@ import { REPO_ROOT, RENDERER_STYLES_DIR, TOKENS_FILE, readAllRendererCss, stripC
  * cards, and the separate `.maka-load-tool-*` card) moved onto the `@maka/ui`
  * `previewVariants` literalize table.
  *
- * The file-diff and terminal shells are proven pixel-identical by the existing
- * e2e-fixture screenshot fixture (it renders a `file_diff` and a `terminal` tool
- * result through the real chat pipeline); the remaining card surfaces are 1:1
+ * The file-diff and terminal shells are rendered by the e2e-fixture (it
+ * renders a `file_diff` and a `terminal` tool result through the real chat
+ * pipeline); the remaining card surfaces are 1:1
  * literal translations of the retired declarations. So this test does NOT
  * re-assert those literals wholesale — that would only mirror the implementation.
  * It locks what a screenshot / computed-style diff cannot cover:

--- a/apps/desktop/src/main/__tests__/chat-preview-cascade-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/chat-preview-cascade-contract.test.ts
@@ -12,7 +12,7 @@ import { REPO_ROOT, RENDERER_STYLES_DIR, TOKENS_FILE, readAllRendererCss, stripC
  * `previewVariants` literalize table.
  *
  * The file-diff and terminal shells are proven pixel-identical by the existing
- * visual-smoke screenshot fixture (it renders a `file_diff` and a `terminal` tool
+ * e2e-fixture screenshot fixture (it renders a `file_diff` and a `terminal` tool
  * result through the real chat pipeline); the remaining card surfaces are 1:1
  * literal translations of the retired declarations. So this test does NOT
  * re-assert those literals wholesale — that would only mirror the implementation.

--- a/apps/desktop/src/main/__tests__/command-palette-a11y-copy-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/command-palette-a11y-copy-contract.test.ts
@@ -199,8 +199,8 @@ describe('Command palette accessibility and visible copy', () => {
     const core = await readRepo('packages/core/src/e2e-fixture.ts');
     const fixture = await readRepo('apps/desktop/src/main/e2e-fixture.ts');
 
-    assert.match(core, /\| 'command-palette-open'/, 'E2EFixtureScenario must include command-palette-open');
-    assert.match(core, /paletteOpen\?: boolean;/, 'E2EFixtureState must expose the paletteOpen hint');
+    assert.match(core, /\| 'command-palette-open'/, 'E2eFixtureScenario must include command-palette-open');
+    assert.match(core, /paletteOpen\?: boolean;/, 'E2eFixtureState must expose the paletteOpen hint');
     assert.match(fixture, /'command-palette-open'/, 'e2e-fixture resolver must accept command-palette-open');
     assert.match(fixture, /case 'command-palette-open':[\s\S]*paletteOpen: true/, 'command-palette-open must auto-open the palette');
     assert.match(main, /if \(state\.paletteOpen\) \{\s*openPalette\(\);\s*\}/, 'renderer must consume paletteOpen and open CommandPalette');

--- a/apps/desktop/src/main/__tests__/command-palette-a11y-copy-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/command-palette-a11y-copy-contract.test.ts
@@ -194,14 +194,14 @@ describe('Command palette accessibility and visible copy', () => {
     assert.match(footerStyle, /background:\s*transparent;/);
   });
 
-  it('has a visual-smoke opener for the command palette input shell', async () => {
+  it('has an e2e-fixture opener for the command palette input shell', async () => {
     const main = await readRendererShellCombinedSource();
-    const core = await readRepo('packages/core/src/visual-smoke.ts');
-    const fixture = await readRepo('apps/desktop/src/main/visual-smoke-fixture.ts');
+    const core = await readRepo('packages/core/src/e2e-fixture.ts');
+    const fixture = await readRepo('apps/desktop/src/main/e2e-fixture.ts');
 
-    assert.match(core, /\| 'command-palette-open'/, 'VisualSmokeScenario must include command-palette-open');
-    assert.match(core, /paletteOpen\?: boolean;/, 'VisualSmokeState must expose the paletteOpen hint');
-    assert.match(fixture, /'command-palette-open'/, 'visual smoke fixture resolver must accept command-palette-open');
+    assert.match(core, /\| 'command-palette-open'/, 'E2EFixtureScenario must include command-palette-open');
+    assert.match(core, /paletteOpen\?: boolean;/, 'E2EFixtureState must expose the paletteOpen hint');
+    assert.match(fixture, /'command-palette-open'/, 'e2e-fixture resolver must accept command-palette-open');
     assert.match(fixture, /case 'command-palette-open':[\s\S]*paletteOpen: true/, 'command-palette-open must auto-open the palette');
     assert.match(main, /if \(state\.paletteOpen\) \{\s*openPalette\(\);\s*\}/, 'renderer must consume paletteOpen and open CommandPalette');
   });

--- a/apps/desktop/src/main/__tests__/e2e-fixture-source-helpers.ts
+++ b/apps/desktop/src/main/__tests__/e2e-fixture-source-helpers.ts
@@ -7,28 +7,28 @@ import { resolve } from 'node:path';
 const REPO_ROOT = resolve(import.meta.dirname, '../../../../..');
 const MAIN_ROOT = resolve(REPO_ROOT, 'apps', 'desktop', 'src', 'main');
 
-// The visual-smoke fixture was split (arch Round 3) from a single
+// The e2e-fixture fixture was split (arch Round 3) from a single
 // ~2.5K-line module into a thin registry barrel
-// (`visual-smoke-fixture.ts`) plus per-domain seeder modules under
-// `visual-smoke/`. Source-scanning contracts (placeholder-copy hygiene,
+// (`e2e-fixture.ts`) plus per-domain seeder modules under
+// `e2e-fixture/`. Source-scanning contracts (placeholder-copy hygiene,
 // visible-copy hygiene) must aggregate ALL of these so the coverage that
 // used to hit the monolith keeps hitting its new homes. Add a new module
 // here whenever the fixture grows another domain file.
 const sourcePaths = [
-  'visual-smoke-fixture.ts',
-  'visual-smoke/seed-helpers.ts',
-  'visual-smoke/scenarios-settings.ts',
-  'visual-smoke/scenarios-modules.ts',
-  'visual-smoke/scenarios-artifacts.ts',
-  'visual-smoke/scenarios-chat.ts',
-  'visual-smoke/scenarios-sessions.ts',
+  'e2e-fixture.ts',
+  'e2e-fixture/seed-helpers.ts',
+  'e2e-fixture/scenarios-settings.ts',
+  'e2e-fixture/scenarios-modules.ts',
+  'e2e-fixture/scenarios-artifacts.ts',
+  'e2e-fixture/scenarios-chat.ts',
+  'e2e-fixture/scenarios-sessions.ts',
 ] as const;
 
-export const VISUAL_SMOKE_FIXTURE_SOURCE_REPO_PATHS: readonly string[] = sourcePaths.map(
+export const E2E_FIXTURE_SOURCE_REPO_PATHS: readonly string[] = sourcePaths.map(
   (sourcePath) => `apps/desktop/src/main/${sourcePath}`,
 );
 
-export async function readVisualSmokeFixtureCombinedSource(): Promise<string> {
+export async function readE2EFixtureCombinedSource(): Promise<string> {
   const sources = await Promise.all(
     sourcePaths.map((sourcePath) => readFile(resolve(MAIN_ROOT, sourcePath), 'utf8')),
   );

--- a/apps/desktop/src/main/__tests__/e2e-fixture-source-helpers.ts
+++ b/apps/desktop/src/main/__tests__/e2e-fixture-source-helpers.ts
@@ -28,7 +28,7 @@ export const E2E_FIXTURE_SOURCE_REPO_PATHS: readonly string[] = sourcePaths.map(
   (sourcePath) => `apps/desktop/src/main/${sourcePath}`,
 );
 
-export async function readE2EFixtureCombinedSource(): Promise<string> {
+export async function readE2eFixtureCombinedSource(): Promise<string> {
   const sources = await Promise.all(
     sourcePaths.map((sourcePath) => readFile(resolve(MAIN_ROOT, sourcePath), 'utf8')),
   );

--- a/apps/desktop/src/main/__tests__/e2e-fixture.test.ts
+++ b/apps/desktop/src/main/__tests__/e2e-fixture.test.ts
@@ -4,38 +4,38 @@ import { join } from 'node:path';
 import { describe, it } from 'node:test';
 import { tmpdir } from 'node:os';
 import {
-  getVisualSmokeState,
-  resolveVisualSmokeFixture,
-  seedVisualSmokeFixture,
-} from '../visual-smoke-fixture.js';
-import { readVisualSmokeFixtureCombinedSource } from './visual-smoke-fixture-source-helpers.js';
+  getE2EFixtureState,
+  resolveE2EFixture,
+  seedE2EFixture,
+} from '../e2e-fixture.js';
+import { readE2EFixtureCombinedSource } from './e2e-fixture-source-helpers.js';
 
-describe('visual smoke fixture mode', () => {
-  it('stays fully disabled when MAKA_VISUAL_SMOKE_FIXTURE is unset', () => {
-    const fixture = resolveVisualSmokeFixture(undefined, false);
+describe('e2e-fixture mode', () => {
+  it('stays fully disabled when MAKA_E2E_FIXTURE is unset', () => {
+    const fixture = resolveE2EFixture(undefined, false);
     assert.equal(fixture, null);
-    assert.equal(getVisualSmokeState(fixture), null);
+    assert.equal(getE2EFixtureState(fixture), null);
   });
 
   it('rejects fixture mode in packaged builds', () => {
     assert.throws(
-      () => resolveVisualSmokeFixture('all', true),
+      () => resolveE2EFixture('all', true),
       /only available in dev\/test builds/,
     );
   });
 
   it('rejects unknown scenarios', () => {
     assert.throws(
-      () => resolveVisualSmokeFixture('unknown-scenario', false),
-      /Unknown MAKA_VISUAL_SMOKE_FIXTURE scenario/,
+      () => resolveE2EFixture('unknown-scenario', false),
+      /Unknown MAKA_E2E_FIXTURE scenario/,
     );
   });
 
   it('resolves known scenarios into isolated workspaces', () => {
-    const fixture = resolveVisualSmokeFixture('provider-workspace', false);
+    const fixture = resolveE2EFixture('provider-workspace', false);
     assert.deepEqual(fixture, {
       scenario: 'provider-workspace',
-      workspaceName: 'visual-smoke-provider-workspace',
+      workspaceName: 'e2e-fixture-provider-workspace',
       reducedMotion: false,
       theme: null,
       locale: null,
@@ -45,44 +45,44 @@ describe('visual smoke fixture mode', () => {
 
   describe('theme override (PR-IR-01b)', () => {
     it('defaults to null when env var unset', () => {
-      const fixture = resolveVisualSmokeFixture('all', false);
+      const fixture = resolveE2EFixture('all', false);
       assert.equal(fixture?.theme, null);
-      const state = getVisualSmokeState(fixture);
+      const state = getE2EFixtureState(fixture);
       assert.equal(state?.theme, undefined);
       assert.equal(state?.now, Date.UTC(2026, 4, 22, 3, 0, 0));
     });
 
     it('accepts the closed enum light / dark / auto', () => {
       for (const raw of ['light', 'dark', 'auto', 'LIGHT', ' Dark ']) {
-        const fixture = resolveVisualSmokeFixture('all', false, undefined, raw);
+        const fixture = resolveE2EFixture('all', false, undefined, raw);
         assert.equal(typeof fixture?.theme, 'string', `raw=${JSON.stringify(raw)}`);
-        const state = getVisualSmokeState(fixture);
+        const state = getE2EFixtureState(fixture);
         assert.ok(state?.theme && ['light', 'dark', 'auto'].includes(state.theme), `raw=${JSON.stringify(raw)}`);
       }
     });
 
     it('rejects unknown values (fail-closed)', () => {
       for (const raw of ['solar', '', 'oklch', 'high-contrast', 'monochrome']) {
-        const fixture = resolveVisualSmokeFixture('all', false, undefined, raw);
+        const fixture = resolveE2EFixture('all', false, undefined, raw);
         assert.equal(fixture?.theme, null, `raw=${JSON.stringify(raw)}`);
       }
     });
   });
 
   describe('UI locale override (PR-UI-VISUAL-SMOKE-LOCALE)', () => {
-    it('defaults to null when MAKA_VISUAL_SMOKE_LOCALE unset', () => {
-      const fixture = resolveVisualSmokeFixture('all', false);
+    it('defaults to null when MAKA_E2E_FIXTURE_LOCALE unset', () => {
+      const fixture = resolveE2EFixture('all', false);
       assert.equal(fixture?.locale, null);
-      const state = getVisualSmokeState(fixture);
+      const state = getE2EFixtureState(fixture);
       assert.equal(state?.locale, undefined);
     });
 
     it('accepts the closed enum zh / en (case + whitespace tolerant)', () => {
       for (const raw of ['zh', 'en', 'ZH', ' En ', 'EN']) {
-        const fixture = resolveVisualSmokeFixture('all', false, undefined, undefined, raw);
+        const fixture = resolveE2EFixture('all', false, undefined, undefined, raw);
         assert.ok(fixture?.locale, `raw=${JSON.stringify(raw)}`);
         assert.ok(['zh', 'en'].includes(fixture!.locale!), `raw=${JSON.stringify(raw)}`);
-        const state = getVisualSmokeState(fixture);
+        const state = getE2EFixtureState(fixture);
         assert.ok(state?.locale && ['zh', 'en'].includes(state.locale), `raw=${JSON.stringify(raw)}`);
       }
     });
@@ -92,26 +92,26 @@ describe('visual smoke fixture mode', () => {
       // bare `zh` / `en` short codes. `zh-CN` etc. fail closed so the
       // override is unambiguous; users wanting CN locale set `zh`.
       for (const raw of ['', 'es', 'ja', 'zh-CN', 'en-US', 'auto', 'system']) {
-        const fixture = resolveVisualSmokeFixture('all', false, undefined, undefined, raw);
+        const fixture = resolveE2EFixture('all', false, undefined, undefined, raw);
         assert.equal(fixture?.locale, null, `raw=${JSON.stringify(raw)}`);
       }
     });
 
-    it('locale flag carries through into VisualSmokeState across all known scenarios', () => {
+    it('locale flag carries through into E2EFixtureState across all known scenarios', () => {
       for (const scenario of ['first-run', 'turn-narrative', 'artifact-pane', 'stale-sessions']) {
-        const fixture = resolveVisualSmokeFixture(scenario, false, undefined, undefined, 'zh');
+        const fixture = resolveE2EFixture(scenario, false, undefined, undefined, 'zh');
         assert.equal(fixture?.locale, 'zh', `scenario=${scenario}`);
-        const state = getVisualSmokeState(fixture);
+        const state = getE2EFixtureState(fixture);
         assert.equal(state?.locale, 'zh', `scenario=${scenario}`);
       }
     });
 
     it('locale is independent from theme / reduced-motion', () => {
-      const fixture = resolveVisualSmokeFixture('all', false, '1', 'dark', 'en');
+      const fixture = resolveE2EFixture('all', false, '1', 'dark', 'en');
       assert.equal(fixture?.locale, 'en');
       assert.equal(fixture?.theme, 'dark');
       assert.equal(fixture?.reducedMotion, true);
-      const state = getVisualSmokeState(fixture);
+      const state = getE2EFixtureState(fixture);
       assert.equal(state?.locale, 'en');
       assert.equal(state?.theme, 'dark');
       assert.equal(state?.reducedMotion, true);
@@ -119,10 +119,10 @@ describe('visual smoke fixture mode', () => {
   });
 
   describe('IANA timezone override (PR-UI-VISUAL-SMOKE-TIMEZONE, @kenji msg 45486cdf)', () => {
-    it('defaults to null when MAKA_VISUAL_SMOKE_TIMEZONE unset', () => {
-      const fixture = resolveVisualSmokeFixture('all', false);
+    it('defaults to null when MAKA_E2E_FIXTURE_TIMEZONE unset', () => {
+      const fixture = resolveE2EFixture('all', false);
       assert.equal(fixture?.timezone, null);
-      const state = getVisualSmokeState(fixture);
+      const state = getE2EFixtureState(fixture);
       assert.equal(state?.timezone, undefined);
     });
 
@@ -140,9 +140,9 @@ describe('visual smoke fixture mode', () => {
         'Pacific/Auckland',
       ];
       for (const tz of valid) {
-        const fixture = resolveVisualSmokeFixture('all', false, undefined, undefined, undefined, tz);
+        const fixture = resolveE2EFixture('all', false, undefined, undefined, undefined, tz);
         assert.equal(fixture?.timezone, tz, `tz=${tz}`);
-        const state = getVisualSmokeState(fixture);
+        const state = getE2EFixtureState(fixture);
         assert.equal(state?.timezone, tz, `tz=${tz}`);
       }
     });
@@ -152,7 +152,7 @@ describe('visual smoke fixture mode', () => {
       // (`America/New_York`, not `america/new_york`). The parser
       // trim-onlys; it does not lowercase, so the canonical form
       // survives.
-      const fixture = resolveVisualSmokeFixture('all', false, undefined, undefined, undefined, '  Asia/Shanghai  ');
+      const fixture = resolveE2EFixture('all', false, undefined, undefined, undefined, '  Asia/Shanghai  ');
       assert.equal(fixture?.timezone, 'Asia/Shanghai');
     });
 
@@ -169,14 +169,14 @@ describe('visual smoke fixture mode', () => {
         'utc/zulu',
       ];
       for (const tz of invalid) {
-        const fixture = resolveVisualSmokeFixture('all', false, undefined, undefined, undefined, tz);
+        const fixture = resolveE2EFixture('all', false, undefined, undefined, undefined, tz);
         assert.equal(fixture?.timezone, null, `tz=${JSON.stringify(tz)}`);
       }
     });
 
     it('rejects oversize inputs (>128 chars) without invoking Intl.DateTimeFormat', () => {
       const oversize = 'A'.repeat(129);
-      const fixture = resolveVisualSmokeFixture('all', false, undefined, undefined, undefined, oversize);
+      const fixture = resolveE2EFixture('all', false, undefined, undefined, undefined, oversize);
       assert.equal(fixture?.timezone, null);
     });
 
@@ -185,9 +185,9 @@ describe('visual smoke fixture mode', () => {
       // approved (msg 45486cdf): the parser only validates +
       // surfaces the IANA name. It does NOT mutate `Date.prototype`,
       // global `Intl.DateTimeFormat`, or `state.now`. `state.now`
-      // is still the canonical clock-freeze for visual smoke.
-      const fixture = resolveVisualSmokeFixture('all', false, undefined, undefined, undefined, 'Asia/Shanghai');
-      const state = getVisualSmokeState(fixture);
+      // is still the canonical clock-freeze for e2e-fixture.
+      const fixture = resolveE2EFixture('all', false, undefined, undefined, undefined, 'Asia/Shanghai');
+      const state = getE2EFixtureState(fixture);
       assert.equal(state?.timezone, 'Asia/Shanghai');
       assert.equal(state?.now, Date.UTC(2026, 4, 22, 3, 0, 0));
       // No global mutation: Date.now / new Date() / Intl.DateTimeFormat
@@ -199,22 +199,22 @@ describe('visual smoke fixture mode', () => {
       assert.equal(typeof formatter.resolvedOptions().timeZone, 'string');
     });
 
-    it('timezone flag carries through into VisualSmokeState across all known scenarios', () => {
+    it('timezone flag carries through into E2EFixtureState across all known scenarios', () => {
       for (const scenario of ['first-run', 'turn-narrative', 'artifact-pane', 'stale-sessions']) {
-        const fixture = resolveVisualSmokeFixture(scenario, false, undefined, undefined, undefined, 'Europe/London');
+        const fixture = resolveE2EFixture(scenario, false, undefined, undefined, undefined, 'Europe/London');
         assert.equal(fixture?.timezone, 'Europe/London', `scenario=${scenario}`);
-        const state = getVisualSmokeState(fixture);
+        const state = getE2EFixtureState(fixture);
         assert.equal(state?.timezone, 'Europe/London', `scenario=${scenario}`);
       }
     });
 
     it('timezone is independent from theme / locale / reduced-motion', () => {
-      const fixture = resolveVisualSmokeFixture('all', false, '1', 'dark', 'en', 'Asia/Tokyo');
+      const fixture = resolveE2EFixture('all', false, '1', 'dark', 'en', 'Asia/Tokyo');
       assert.equal(fixture?.timezone, 'Asia/Tokyo');
       assert.equal(fixture?.locale, 'en');
       assert.equal(fixture?.theme, 'dark');
       assert.equal(fixture?.reducedMotion, true);
-      const state = getVisualSmokeState(fixture);
+      const state = getE2EFixtureState(fixture);
       assert.equal(state?.timezone, 'Asia/Tokyo');
       assert.equal(state?.locale, 'en');
       assert.equal(state?.theme, 'dark');
@@ -224,41 +224,41 @@ describe('visual smoke fixture mode', () => {
 
   describe('reduced-motion variant (PR-IR-04)', () => {
     it('defaults to reducedMotion: false when env var unset', () => {
-      const fixture = resolveVisualSmokeFixture('all', false);
+      const fixture = resolveE2EFixture('all', false);
       assert.equal(fixture?.reducedMotion, false);
-      const state = getVisualSmokeState(fixture);
+      const state = getE2EFixtureState(fixture);
       assert.equal(state?.reducedMotion, undefined);
     });
 
     it('accepts "1" / "true" / "yes" as truthy', () => {
       for (const raw of ['1', 'true', 'yes', 'TRUE', ' yes ']) {
-        const fixture = resolveVisualSmokeFixture('all', false, raw);
+        const fixture = resolveE2EFixture('all', false, raw);
         assert.equal(fixture?.reducedMotion, true, `raw=${JSON.stringify(raw)}`);
-        const state = getVisualSmokeState(fixture);
+        const state = getE2EFixtureState(fixture);
         assert.equal(state?.reducedMotion, true, `raw=${JSON.stringify(raw)}`);
       }
     });
 
     it('treats unrecognized values as false (fail-closed)', () => {
       for (const raw of ['0', 'no', 'false', '', 'maybe']) {
-        const fixture = resolveVisualSmokeFixture('all', false, raw);
+        const fixture = resolveE2EFixture('all', false, raw);
         assert.equal(fixture?.reducedMotion, false, `raw=${JSON.stringify(raw)}`);
       }
     });
 
     it('reduced motion flag works across all known scenarios', () => {
       for (const scenario of ['first-run', 'turn-narrative', 'artifact-pane', 'stale-sessions']) {
-        const fixture = resolveVisualSmokeFixture(scenario, false, '1');
+        const fixture = resolveE2EFixture(scenario, false, '1');
         assert.equal(fixture?.reducedMotion, true, `scenario=${scenario}`);
-        const state = getVisualSmokeState(fixture);
+        const state = getE2EFixtureState(fixture);
         assert.equal(state?.reducedMotion, true, `scenario=${scenario}`);
       }
     });
   });
 
   it('first-run fixture has no transient smoke-only UI state', () => {
-    const fixture = resolveVisualSmokeFixture('first-run', false);
-    const state = getVisualSmokeState(fixture);
+    const fixture = resolveE2EFixture('first-run', false);
+    const state = getE2EFixtureState(fixture);
     assert.equal(state?.enabled, true);
     assert.equal(state?.now, Date.UTC(2026, 4, 22, 3, 0, 0));
     assert.equal(state?.activeSessionId, undefined);
@@ -267,35 +267,35 @@ describe('visual smoke fixture mode', () => {
   });
 
   it('all fixture exposes transient streaming and permission state without persistence', () => {
-    const fixture = resolveVisualSmokeFixture('all', false);
-    const state = getVisualSmokeState(fixture);
+    const fixture = resolveE2EFixture('all', false);
+    const state = getE2EFixtureState(fixture);
     assert.equal(state?.enabled, true);
-    assert.equal(state?.activeSessionId, 'visual-smoke-turn');
+    assert.equal(state?.activeSessionId, 'e2e-fixture-turn');
     const liveTurns = state?.liveTurnBySession;
-    assert.equal(liveTurns?.['visual-smoke-streaming']?.turnId, 'turn-streaming');
-    assert.equal(liveTurns?.['visual-smoke-streaming']?.steps[0]?.tools[0]?.status, 'running');
-    assert.equal(liveTurns?.['visual-smoke-permission']?.turnId, 'turn-permission');
-    assert.equal(liveTurns?.['visual-smoke-permission']?.steps[0]?.tools[0]?.status, 'waiting_permission');
-    const permission = state?.permissionBySession?.['visual-smoke-permission'];
+    assert.equal(liveTurns?.['e2e-fixture-streaming']?.turnId, 'turn-streaming');
+    assert.equal(liveTurns?.['e2e-fixture-streaming']?.steps[0]?.tools[0]?.status, 'running');
+    assert.equal(liveTurns?.['e2e-fixture-permission']?.turnId, 'turn-permission');
+    assert.equal(liveTurns?.['e2e-fixture-permission']?.steps[0]?.tools[0]?.status, 'waiting_permission');
+    const permission = state?.permissionBySession?.['e2e-fixture-permission'];
     assert.ok(permission);
     assert.equal((permission.args as { command?: unknown }).command, 'rm -rf ./dist');
     assert.equal(Object.hasOwn(permission.args as object, 'cmd'), false, 'fixture must match the current Bash input schema');
   });
 
   it('task-ledger fixture seeds the hierarchical desktop read model', async () => {
-    const workspaceRoot = await mkdtemp(join(tmpdir(), 'maka-visual-smoke-task-ledger-'));
+    const workspaceRoot = await mkdtemp(join(tmpdir(), 'maka-e2e-fixture-task-ledger-'));
     try {
-      const fixture = resolveVisualSmokeFixture('task-ledger', false);
+      const fixture = resolveE2EFixture('task-ledger', false);
       assert.ok(fixture);
-      await seedVisualSmokeFixture({
+      await seedE2EFixture({
         workspaceRoot,
         fixture,
         credentialStore: fakeCredentialStore(),
         now: 1_700_000_000_000,
       });
-      assert.equal(getVisualSmokeState(fixture)?.activeSessionId, 'visual-smoke-turn');
+      assert.equal(getE2EFixtureState(fixture)?.activeSessionId, 'e2e-fixture-turn');
       const tasks = JSON.parse(await readFile(
-        join(workspaceRoot, 'sessions', 'visual-smoke-turn', 'tasks.json'),
+        join(workspaceRoot, 'sessions', 'e2e-fixture-turn', 'tasks.json'),
         'utf8',
       )) as Array<{ key: string; parentId?: string; status: string; owner?: { actor: string } }>;
       assert.deepEqual(tasks.map((task) => task.key), ['T1', 'T1.1', 'T1.2', 'T1.2.1', 'T2', 'T3']);
@@ -307,22 +307,22 @@ describe('visual smoke fixture mode', () => {
   });
 
   it('deep-research-progress seeds a completed durable run for visual review', async () => {
-    const workspaceRoot = await mkdtemp(join(tmpdir(), 'maka-visual-smoke-deep-research-'));
+    const workspaceRoot = await mkdtemp(join(tmpdir(), 'maka-e2e-fixture-deep-research-'));
     try {
-      const fixture = resolveVisualSmokeFixture('deep-research-progress', false);
+      const fixture = resolveE2EFixture('deep-research-progress', false);
       assert.ok(fixture);
-      await seedVisualSmokeFixture({
+      await seedE2EFixture({
         workspaceRoot,
         fixture,
         credentialStore: fakeCredentialStore(),
         now: 1_700_000_000_000,
       });
-      assert.equal(getVisualSmokeState(fixture)?.activeSessionId, 'visual-smoke-deep-research');
+      assert.equal(getE2EFixtureState(fixture)?.activeSessionId, 'e2e-fixture-deep-research');
       const ledger = await readFile(
         join(
           workspaceRoot,
           'sessions',
-          'visual-smoke-deep-research',
+          'e2e-fixture-deep-research',
           'deep-research',
           'events.jsonl',
         ),
@@ -346,16 +346,16 @@ describe('visual smoke fixture mode', () => {
     // arch Round 3: the fixture split into a registry barrel + per-domain
     // seeder modules, so this hygiene scan aggregates every fixture source
     // file rather than the single monolith it used to read.
-    const src = await readVisualSmokeFixtureCombinedSource();
-    assert.doesNotMatch(src, /占位用户消息|占位回复/, 'visual smoke screenshots must use product-like chat copy, not placeholder text');
+    const src = await readE2EFixtureCombinedSource();
+    assert.doesNotMatch(src, /占位用户消息|占位回复/, 'e2e-fixture screenshots must use product-like chat copy, not placeholder text');
   });
 
   it('first-run seed keeps the fixture workspace connection-free', async () => {
-    const workspaceRoot = await mkdtemp(join(tmpdir(), 'maka-visual-smoke-first-run-'));
+    const workspaceRoot = await mkdtemp(join(tmpdir(), 'maka-e2e-fixture-first-run-'));
     try {
-      const fixture = resolveVisualSmokeFixture('first-run', false);
+      const fixture = resolveE2EFixture('first-run', false);
       assert.ok(fixture);
-      await seedVisualSmokeFixture({
+      await seedE2EFixture({
         workspaceRoot,
         fixture,
         credentialStore: fakeCredentialStore(),
@@ -378,12 +378,12 @@ describe('visual smoke fixture mode', () => {
   });
 
   it('scenario seed focuses the relevant provider state for connection-dialog screenshots', async () => {
-    const workspaceRoot = await mkdtemp(join(tmpdir(), 'maka-visual-smoke-provider-'));
+    const workspaceRoot = await mkdtemp(join(tmpdir(), 'maka-e2e-fixture-provider-'));
     try {
-      const fixture = resolveVisualSmokeFixture('fallback-source', false);
+      const fixture = resolveE2EFixture('fallback-source', false);
       assert.ok(fixture);
       const secrets: string[] = [];
-      await seedVisualSmokeFixture({
+      await seedE2EFixture({
         workspaceRoot,
         fixture,
         credentialStore: fakeCredentialStore(secrets),
@@ -435,33 +435,33 @@ describe('visual smoke fixture mode', () => {
 
     for (const { scenario, expectedSection } of cases) {
       it(`${scenario} opens Settings · ${expectedSection}`, () => {
-        const fixture = resolveVisualSmokeFixture(scenario, false);
+        const fixture = resolveE2EFixture(scenario, false);
         assert.ok(fixture, `${scenario} should resolve`);
-        const state = getVisualSmokeState(fixture);
+        const state = getE2EFixtureState(fixture);
         assert.equal(state?.openSettingsSection, expectedSection);
         // Active session is the standard turn fixture so the chat
         // surface behind the modal renders meaningful context.
-        assert.equal(state?.activeSessionId, 'visual-smoke-turn');
+        assert.equal(state?.activeSessionId, 'e2e-fixture-turn');
       });
     }
   });
 
   it('stale-sessions seed reproduces the P0 workspace with active stale session', async () => {
-    const workspaceRoot = await mkdtemp(join(tmpdir(), 'maka-visual-smoke-stale-'));
+    const workspaceRoot = await mkdtemp(join(tmpdir(), 'maka-e2e-fixture-stale-'));
     try {
-      const fixture = resolveVisualSmokeFixture('stale-sessions', false);
+      const fixture = resolveE2EFixture('stale-sessions', false);
       assert.ok(fixture);
-      await seedVisualSmokeFixture({
+      await seedE2EFixture({
         workspaceRoot,
         fixture,
         credentialStore: fakeCredentialStore(),
         now: 1_700_000_000_000,
       });
 
-      const state = getVisualSmokeState(fixture);
+      const state = getE2EFixtureState(fixture);
       // @kenji gate: active session intentionally one of the stale ones so
-      // the screenshot proves "active + stale → pill still visible".
-      assert.equal(state?.activeSessionId, 'visual-smoke-stale-fake');
+      // E2E/audit can prove "active + stale → pill still visible".
+      assert.equal(state?.activeSessionId, 'e2e-fixture-stale-fake');
 
       // Connection list MUST NOT contain `fake` / `fake-claude` slugs —
       // those are what makes the seeded sessions stale.
@@ -475,7 +475,7 @@ describe('visual smoke fixture mode', () => {
 
       // Three session.jsonl files: one for each session.
       const sessionDirs = await Promise.all(
-        ['visual-smoke-stale-fake', 'visual-smoke-stale-legacy', 'visual-smoke-healthy'].map(async (id) => {
+        ['e2e-fixture-stale-fake', 'e2e-fixture-stale-legacy', 'e2e-fixture-healthy'].map(async (id) => {
           const file = await readFile(join(workspaceRoot, 'sessions', id, 'session.jsonl'), 'utf8');
           return JSON.parse(file.split('\n')[0]!) as {
             backend: string;
@@ -496,32 +496,32 @@ describe('visual smoke fixture mode', () => {
   });
 
   it('workstation-statuses seed creates one session per SessionStatus including aborted + 4 blocked variants', async () => {
-    const workspaceRoot = await mkdtemp(join(tmpdir(), 'maka-visual-smoke-ws-'));
+    const workspaceRoot = await mkdtemp(join(tmpdir(), 'maka-e2e-fixture-ws-'));
     try {
-      const fixture = resolveVisualSmokeFixture('workstation-statuses', false);
+      const fixture = resolveE2EFixture('workstation-statuses', false);
       assert.ok(fixture);
-      await seedVisualSmokeFixture({
+      await seedE2EFixture({
         workspaceRoot,
         fixture,
         credentialStore: fakeCredentialStore(),
         now: 1_700_000_000_000,
       });
 
-      const state = getVisualSmokeState(fixture);
-      assert.equal(state?.activeSessionId, 'visual-smoke-ws-running');
+      const state = getE2EFixtureState(fixture);
+      assert.equal(state?.activeSessionId, 'e2e-fixture-ws-running');
 
       const expectedSessions = [
-        { id: 'visual-smoke-ws-running', status: 'running' },
-        { id: 'visual-smoke-ws-waiting', status: 'waiting_for_user' },
-        { id: 'visual-smoke-ws-blocked-auth', status: 'blocked', blockedReason: 'auth' },
-        { id: 'visual-smoke-ws-blocked-perm', status: 'blocked', blockedReason: 'permission_required' },
-        { id: 'visual-smoke-ws-blocked-tool', status: 'blocked', blockedReason: 'tool_failed' },
-        { id: 'visual-smoke-ws-blocked-unknown', status: 'blocked', blockedReason: 'unknown' },
-        { id: 'visual-smoke-ws-active', status: 'active' },
-        { id: 'visual-smoke-ws-review', status: 'review' },
-        { id: 'visual-smoke-ws-done', status: 'done' },
-        { id: 'visual-smoke-ws-archived', status: 'archived' },
-        { id: 'visual-smoke-ws-aborted', status: 'aborted' },
+        { id: 'e2e-fixture-ws-running', status: 'running' },
+        { id: 'e2e-fixture-ws-waiting', status: 'waiting_for_user' },
+        { id: 'e2e-fixture-ws-blocked-auth', status: 'blocked', blockedReason: 'auth' },
+        { id: 'e2e-fixture-ws-blocked-perm', status: 'blocked', blockedReason: 'permission_required' },
+        { id: 'e2e-fixture-ws-blocked-tool', status: 'blocked', blockedReason: 'tool_failed' },
+        { id: 'e2e-fixture-ws-blocked-unknown', status: 'blocked', blockedReason: 'unknown' },
+        { id: 'e2e-fixture-ws-active', status: 'active' },
+        { id: 'e2e-fixture-ws-review', status: 'review' },
+        { id: 'e2e-fixture-ws-done', status: 'done' },
+        { id: 'e2e-fixture-ws-archived', status: 'archived' },
+        { id: 'e2e-fixture-ws-aborted', status: 'aborted' },
       ];
 
       for (const expected of expectedSessions) {
@@ -549,14 +549,14 @@ describe('visual smoke fixture mode', () => {
   });
 
   it('model-processing arms a running session with no live stream so the "正在处理…" indicator + Stop show (#646)', async () => {
-    const workspaceRoot = await mkdtemp(join(tmpdir(), 'maka-visual-smoke-processing-'));
+    const workspaceRoot = await mkdtemp(join(tmpdir(), 'maka-e2e-fixture-processing-'));
     try {
-      const fixture = resolveVisualSmokeFixture('model-processing', false);
+      const fixture = resolveE2EFixture('model-processing', false);
       assert.ok(fixture);
-      const state = getVisualSmokeState(fixture);
+      const state = getE2EFixtureState(fixture);
       // The turn is armed on a running session — the derivation's inputs.
-      assert.equal(state?.activeSessionId, 'visual-smoke-processing');
-      assert.deepEqual(state?.liveTurnBySession?.['visual-smoke-processing'], {
+      assert.equal(state?.activeSessionId, 'e2e-fixture-processing');
+      assert.deepEqual(state?.liveTurnBySession?.['e2e-fixture-processing'], {
         turnId: 'turn-processing-1',
         phase: 'waiting',
         steps: [],
@@ -564,9 +564,9 @@ describe('visual smoke fixture mode', () => {
       // Nothing may be streaming / thinking / running as a tool, or the
       // derivation would hide the indicator (it fires only in the zero-content
       // wait). This scenario deliberately seeds none of them.
-      assert.equal(state?.liveTurnBySession?.['visual-smoke-processing']?.steps.length, 0);
+      assert.equal(state?.liveTurnBySession?.['e2e-fixture-processing']?.steps.length, 0);
 
-      await seedVisualSmokeFixture({
+      await seedE2EFixture({
         workspaceRoot,
         fixture,
         credentialStore: fakeCredentialStore(),
@@ -575,7 +575,7 @@ describe('visual smoke fixture mode', () => {
       // The on-disk status is `running` so the status gate self-heals like the
       // real backgrounded-session path; the lone user message is the tail turn
       // the indicator anchors to.
-      const file = await readFile(join(workspaceRoot, 'sessions', 'visual-smoke-processing', 'session.jsonl'), 'utf8');
+      const file = await readFile(join(workspaceRoot, 'sessions', 'e2e-fixture-processing', 'session.jsonl'), 'utf8');
       const lines = file.split('\n').filter(Boolean);
       const header = JSON.parse(lines[0]!) as { status: string };
       assert.equal(header.status, 'running');
@@ -587,21 +587,21 @@ describe('visual smoke fixture mode', () => {
   });
 
   it('plan-reminders opens the Automations module and seeds scheduled / paused / completed reminders', async () => {
-    const workspaceRoot = await mkdtemp(join(tmpdir(), 'maka-visual-smoke-plan-reminders-'));
+    const workspaceRoot = await mkdtemp(join(tmpdir(), 'maka-e2e-fixture-plan-reminders-'));
     try {
-      const fixture = resolveVisualSmokeFixture('plan-reminders', false);
+      const fixture = resolveE2EFixture('plan-reminders', false);
       assert.ok(fixture);
-      await seedVisualSmokeFixture({
+      await seedE2EFixture({
         workspaceRoot,
         fixture,
         credentialStore: fakeCredentialStore(),
         now: 1_700_000_000_000,
       });
 
-      const state = getVisualSmokeState(fixture);
+      const state = getE2EFixtureState(fixture);
       assert.equal(state?.sidebarSection, 'automations');
       assert.equal(state?.sidebarCollapsed, false);
-      assert.equal(state?.activeSessionId, 'visual-smoke-turn');
+      assert.equal(state?.activeSessionId, 'e2e-fixture-turn');
 
       const reminders = JSON.parse(
         await readFile(join(workspaceRoot, 'plan-reminders.json'), 'utf8'),
@@ -635,30 +635,30 @@ describe('visual smoke fixture mode', () => {
   });
 
   it('module fixtures open Skills, MCP and Daily Review in the app module surface', async () => {
-    const skills = resolveVisualSmokeFixture('module-skills', false);
-    const mcp = resolveVisualSmokeFixture('module-mcp', false);
-    const dailyReview = resolveVisualSmokeFixture('module-daily-review', false);
+    const skills = resolveE2EFixture('module-skills', false);
+    const mcp = resolveE2EFixture('module-mcp', false);
+    const dailyReview = resolveE2EFixture('module-daily-review', false);
 
     assert.ok(skills);
     assert.ok(mcp);
     assert.ok(dailyReview);
-    assert.equal(getVisualSmokeState(skills)?.sidebarSection, 'skills');
-    assert.equal(getVisualSmokeState(skills)?.sidebarCollapsed, false);
-    assert.equal(getVisualSmokeState(skills)?.activeSessionId, 'visual-smoke-turn');
-    assert.equal(getVisualSmokeState(mcp)?.sidebarSection, 'mcp');
-    assert.equal(getVisualSmokeState(mcp)?.sidebarCollapsed, false);
-    assert.equal(getVisualSmokeState(mcp)?.activeSessionId, 'visual-smoke-turn');
-    assert.equal(getVisualSmokeState(dailyReview)?.sidebarSection, 'daily-review');
-    assert.equal(getVisualSmokeState(dailyReview)?.sidebarCollapsed, false);
-    assert.equal(getVisualSmokeState(dailyReview)?.activeSessionId, 'visual-smoke-turn');
+    assert.equal(getE2EFixtureState(skills)?.sidebarSection, 'skills');
+    assert.equal(getE2EFixtureState(skills)?.sidebarCollapsed, false);
+    assert.equal(getE2EFixtureState(skills)?.activeSessionId, 'e2e-fixture-turn');
+    assert.equal(getE2EFixtureState(mcp)?.sidebarSection, 'mcp');
+    assert.equal(getE2EFixtureState(mcp)?.sidebarCollapsed, false);
+    assert.equal(getE2EFixtureState(mcp)?.activeSessionId, 'e2e-fixture-turn');
+    assert.equal(getE2EFixtureState(dailyReview)?.sidebarSection, 'daily-review');
+    assert.equal(getE2EFixtureState(dailyReview)?.sidebarCollapsed, false);
+    assert.equal(getE2EFixtureState(dailyReview)?.activeSessionId, 'e2e-fixture-turn');
   });
 
   it('module-mcp seeds a couple of installed servers so the 已安装 list renders', async () => {
-    const workspaceRoot = await mkdtemp(join(tmpdir(), 'maka-visual-smoke-mcp-'));
+    const workspaceRoot = await mkdtemp(join(tmpdir(), 'maka-e2e-fixture-mcp-'));
     try {
-      const fixture = resolveVisualSmokeFixture('module-mcp', false);
+      const fixture = resolveE2EFixture('module-mcp', false);
       assert.ok(fixture);
-      await seedVisualSmokeFixture({
+      await seedE2EFixture({
         workspaceRoot,
         fixture,
         credentialStore: fakeCredentialStore(),
@@ -671,7 +671,7 @@ describe('visual smoke fixture mode', () => {
       assert.equal(config.version, 1);
       const ids = Object.keys(config.mcpServers);
       assert.ok(ids.length >= 2, 'installed list needs >=2 servers to render meaningfully');
-      // enabled:false keeps visual-smoke deterministic — no real npx / HTTP
+      // enabled:false keeps e2e-fixture deterministic — no real npx / HTTP
       // connection is attempted, so the rows settle in the neutral 已停用 state.
       for (const id of ids) {
         assert.equal(config.mcpServers[id].enabled, false, `${id} stays disabled in the fixture`);
@@ -682,12 +682,12 @@ describe('visual smoke fixture mode', () => {
   });
 
   it('module-skills seeds a managed-source market catalog (>=6 entries with categories) plus workspace skills', async () => {
-    const workspaceRoot = await mkdtemp(join(tmpdir(), 'maka-visual-smoke-skills-'));
+    const workspaceRoot = await mkdtemp(join(tmpdir(), 'maka-e2e-fixture-skills-'));
     const previousSourcesRoot = process.env.MAKA_SKILL_SOURCES_ROOT;
     try {
-      const fixture = resolveVisualSmokeFixture('module-skills', false);
+      const fixture = resolveE2EFixture('module-skills', false);
       assert.ok(fixture);
-      await seedVisualSmokeFixture({
+      await seedE2EFixture({
         workspaceRoot,
         fixture,
         credentialStore: fakeCredentialStore(),
@@ -731,36 +731,36 @@ describe('visual smoke fixture mode', () => {
     // kenji `b3d156e9`): the sidebar-row-actions-visible scenario
     // reuses the 60-session seed so the sidebar is identical to
     // the long-sessions baseline; differs only in
-    // `VisualSmokeState.focusActiveRow=true`, which the renderer
+    // `E2EFixtureState.focusActiveRow=true`, which the renderer
     // reads to focus the active row's button after mount. That
     // triggers `:focus-within` and reveals the
-    // `.maka-list-row-menu-trigger` — the screenshot then proves
+    // `.maka-list-row-menu-trigger` — the fixture then proves
     // the time meta / unread dot are correctly hidden underneath.
-    const workspaceRoot = await mkdtemp(join(tmpdir(), 'maka-visual-smoke-row-actions-'));
+    const workspaceRoot = await mkdtemp(join(tmpdir(), 'maka-e2e-fixture-row-actions-'));
     try {
-      const fixture = resolveVisualSmokeFixture('sidebar-row-actions-visible', false);
+      const fixture = resolveE2EFixture('sidebar-row-actions-visible', false);
       assert.ok(fixture);
-      await seedVisualSmokeFixture({
+      await seedE2EFixture({
         workspaceRoot,
         fixture,
         credentialStore: fakeCredentialStore(),
         now: 1_700_000_000_000,
       });
 
-      const state = getVisualSmokeState(fixture);
+      const state = getE2EFixtureState(fixture);
       // focusActiveRow is the contract the renderer reads.
       assert.equal(state?.focusActiveRow, true, 'focusActiveRow must be true so the renderer focuses the active row button');
       assert.equal(state?.sidebarCollapsed, false, 'sidebar row action screenshots must expand the seeded sidebar');
-      assert.equal(state?.activeSessionId, 'visual-smoke-sidebar-long-00');
+      assert.equal(state?.activeSessionId, 'e2e-fixture-sidebar-long-00');
 
       // Same 60-session seed actually lands on disk so the sidebar
       // is fully populated for the actions-visible capture.
       const file = await readFile(
-        join(workspaceRoot, 'sessions', 'visual-smoke-sidebar-long-00', 'session.jsonl'),
+        join(workspaceRoot, 'sessions', 'e2e-fixture-sidebar-long-00', 'session.jsonl'),
         'utf8',
       );
       const header = JSON.parse(file.split('\n')[0]!) as { id: string; status: string };
-      assert.equal(header.id, 'visual-smoke-sidebar-long-00');
+      assert.equal(header.id, 'e2e-fixture-sidebar-long-00');
       assert.equal(header.status, 'active');
     } finally {
       await rm(workspaceRoot, { recursive: true, force: true });
@@ -772,36 +772,36 @@ describe('visual smoke fixture mode', () => {
     // sidebar-search-modal-open scenario reuses the 60-session seed
     // so the sidebar behind the modal matches the long-sessions
     // baseline exactly. The only differentiator from `sidebar-long-
-    // sessions` is `VisualSmokeState.searchModalOpen=true`, which
+    // sessions` is `E2EFixtureState.searchModalOpen=true`, which
     // the renderer reads to call `setSearchModalOpen(true)` before
-    // auto-capture settles, so the SearchModal shell is on screen
-    // in the captured PNG.
-    const workspaceRoot = await mkdtemp(join(tmpdir(), 'maka-visual-smoke-search-modal-'));
+    // the fixture settles, so the SearchModal shell is on screen
+    // for E2E/audit.
+    const workspaceRoot = await mkdtemp(join(tmpdir(), 'maka-e2e-fixture-search-modal-'));
     try {
-      const fixture = resolveVisualSmokeFixture('sidebar-search-modal-open', false);
+      const fixture = resolveE2EFixture('sidebar-search-modal-open', false);
       assert.ok(fixture);
-      await seedVisualSmokeFixture({
+      await seedE2EFixture({
         workspaceRoot,
         fixture,
         credentialStore: fakeCredentialStore(),
         now: 1_700_000_000_000,
       });
 
-      const state = getVisualSmokeState(fixture);
+      const state = getE2EFixtureState(fixture);
       // Modal-open hint is the contract the renderer reads.
       assert.equal(state?.searchModalOpen, true, 'searchModalOpen must be true so the renderer auto-opens the modal');
       // Same active session as the long-sessions scenario so the
       // sidebar behind the modal looks identical to that baseline.
-      assert.equal(state?.activeSessionId, 'visual-smoke-sidebar-long-00');
+      assert.equal(state?.activeSessionId, 'e2e-fixture-sidebar-long-00');
 
       // Same 60-session seed actually lands on disk so the sidebar
       // is fully populated behind the modal.
       const file = await readFile(
-        join(workspaceRoot, 'sessions', 'visual-smoke-sidebar-long-00', 'session.jsonl'),
+        join(workspaceRoot, 'sessions', 'e2e-fixture-sidebar-long-00', 'session.jsonl'),
         'utf8',
       );
       const header = JSON.parse(file.split('\n')[0]!) as { id: string; status: string };
-      assert.equal(header.id, 'visual-smoke-sidebar-long-00');
+      assert.equal(header.id, 'e2e-fixture-sidebar-long-00');
       assert.equal(header.status, 'active');
     } finally {
       await rm(workspaceRoot, { recursive: true, force: true });
@@ -809,27 +809,27 @@ describe('visual smoke fixture mode', () => {
   });
 
   it('command-palette-open shares the 60-session seed and sets paletteOpen for auto-open', async () => {
-    const workspaceRoot = await mkdtemp(join(tmpdir(), 'maka-visual-smoke-command-palette-'));
+    const workspaceRoot = await mkdtemp(join(tmpdir(), 'maka-e2e-fixture-command-palette-'));
     try {
-      const fixture = resolveVisualSmokeFixture('command-palette-open', false);
+      const fixture = resolveE2EFixture('command-palette-open', false);
       assert.ok(fixture);
-      await seedVisualSmokeFixture({
+      await seedE2EFixture({
         workspaceRoot,
         fixture,
         credentialStore: fakeCredentialStore(),
         now: 1_700_000_000_000,
       });
 
-      const state = getVisualSmokeState(fixture);
+      const state = getE2EFixtureState(fixture);
       assert.equal(state?.paletteOpen, true, 'paletteOpen must be true so the renderer auto-opens CommandPalette');
-      assert.equal(state?.activeSessionId, 'visual-smoke-sidebar-long-00');
+      assert.equal(state?.activeSessionId, 'e2e-fixture-sidebar-long-00');
 
       const file = await readFile(
-        join(workspaceRoot, 'sessions', 'visual-smoke-sidebar-long-00', 'session.jsonl'),
+        join(workspaceRoot, 'sessions', 'e2e-fixture-sidebar-long-00', 'session.jsonl'),
         'utf8',
       );
       const header = JSON.parse(file.split('\n')[0]!) as { id: string; status: string };
-      assert.equal(header.id, 'visual-smoke-sidebar-long-00');
+      assert.equal(header.id, 'e2e-fixture-sidebar-long-00');
       assert.equal(header.status, 'active');
     } finally {
       await rm(workspaceRoot, { recursive: true, force: true });
@@ -839,23 +839,23 @@ describe('visual smoke fixture mode', () => {
   it('sidebar-long-sessions seed creates 60 sessions for the scroll-fix gate (PR-SIDEBAR-IA-0 Phase 1)', async () => {
     // PR-SIDEBAR-IA-0 Phase 1 (xuan msg `dc790a54`, kenji `0f7bb872`):
     // hard gate fixture for sidebar scroll fix. The CSS contract is
-    // verified by screenshot baselines; the fixture itself only needs
+    // verified by the scroll-geometry E2E spec; the fixture itself only needs
     // to (a) actually seed 60 sessions, (b) make the newest one the
     // active selection, and (c) keep IDs deterministic.
-    const workspaceRoot = await mkdtemp(join(tmpdir(), 'maka-visual-smoke-long-'));
+    const workspaceRoot = await mkdtemp(join(tmpdir(), 'maka-e2e-fixture-long-'));
     try {
-      const fixture = resolveVisualSmokeFixture('sidebar-long-sessions', false);
+      const fixture = resolveE2EFixture('sidebar-long-sessions', false);
       assert.ok(fixture);
-      await seedVisualSmokeFixture({
+      await seedE2EFixture({
         workspaceRoot,
         fixture,
         credentialStore: fakeCredentialStore(),
         now: 1_700_000_000_000,
       });
 
-      const state = getVisualSmokeState(fixture);
+      const state = getE2EFixtureState(fixture);
       // Active session is the first (newest by lastMessageAt).
-      assert.equal(state?.activeSessionId, 'visual-smoke-sidebar-long-00');
+      assert.equal(state?.activeSessionId, 'e2e-fixture-sidebar-long-00');
       assert.equal(state?.sidebarCollapsed, false, 'sidebar scroll screenshots must expand the seeded sidebar');
 
       // Verify all 60 sessions exist on disk with deterministic IDs +
@@ -863,7 +863,7 @@ describe('visual smoke fixture mode', () => {
       let previousLastMessageAt = Infinity;
       for (let i = 0; i < 60; i++) {
         const idSuffix = String(i).padStart(2, '0');
-        const sessionId = 'visual-smoke-sidebar-long-' + idSuffix;
+        const sessionId = 'e2e-fixture-sidebar-long-' + idSuffix;
         const file = await readFile(join(workspaceRoot, 'sessions', sessionId, 'session.jsonl'), 'utf8');
         const header = JSON.parse(file.split('\n')[0]!) as {
           id: string;
@@ -904,22 +904,22 @@ describe('visual smoke fixture mode', () => {
       // session-prefixed and never start with `/`.
       const record = JSON.parse(line) as { relativePath: string };
       assert.equal(record.relativePath.startsWith('/'), false);
-      assert.equal(record.relativePath.startsWith(`visual-smoke-artifact/`), true);
+      assert.equal(record.relativePath.startsWith(`e2e-fixture-artifact/`), true);
     }
 
     it('artifact-preview-image: single PNG seeded → registry will resolve image(mime_match)', async () => {
-      const workspaceRoot = await mkdtemp(join(tmpdir(), 'maka-visual-smoke-preview-image-'));
+      const workspaceRoot = await mkdtemp(join(tmpdir(), 'maka-e2e-fixture-preview-image-'));
       try {
-        const fixture = resolveVisualSmokeFixture('artifact-preview-image', false);
+        const fixture = resolveE2EFixture('artifact-preview-image', false);
         assert.ok(fixture);
-        await seedVisualSmokeFixture({
+        await seedE2EFixture({
           workspaceRoot,
           fixture,
           credentialStore: fakeCredentialStore(),
           now: 1_700_000_000_000,
         });
-        const state = getVisualSmokeState(fixture);
-        assert.equal(state?.activeSessionId, 'visual-smoke-artifact');
+        const state = getE2EFixtureState(fixture);
+        assert.equal(state?.activeSessionId, 'e2e-fixture-artifact');
 
         const lines = (await readFile(join(workspaceRoot, 'artifacts', 'metadata.jsonl'), 'utf8'))
           .split('\n')
@@ -945,7 +945,7 @@ describe('visual smoke fixture mode', () => {
         const filePath = join(
           workspaceRoot,
           'artifacts',
-          'visual-smoke-artifact',
+          'e2e-fixture-artifact',
           'artifact-preview-image-screenshot.png',
         );
         const bytes = await readFile(filePath);
@@ -960,11 +960,11 @@ describe('visual smoke fixture mode', () => {
     });
 
     it('artifact-preview-unsupported: image/heic disallowed mime → L1 unsupported(mime_disallowed), readBinary never called', async () => {
-      const workspaceRoot = await mkdtemp(join(tmpdir(), 'maka-visual-smoke-preview-unsupported-'));
+      const workspaceRoot = await mkdtemp(join(tmpdir(), 'maka-e2e-fixture-preview-unsupported-'));
       try {
-        const fixture = resolveVisualSmokeFixture('artifact-preview-unsupported', false);
+        const fixture = resolveE2EFixture('artifact-preview-unsupported', false);
         assert.ok(fixture);
-        await seedVisualSmokeFixture({
+        await seedE2EFixture({
           workspaceRoot,
           fixture,
           credentialStore: fakeCredentialStore(),
@@ -994,11 +994,11 @@ describe('visual smoke fixture mode', () => {
     });
 
     it('artifact-preview-oversize: 3MB sizeBytes claim with skipFile → L1 unsupported(oversize)', async () => {
-      const workspaceRoot = await mkdtemp(join(tmpdir(), 'maka-visual-smoke-preview-oversize-'));
+      const workspaceRoot = await mkdtemp(join(tmpdir(), 'maka-e2e-fixture-preview-oversize-'));
       try {
-        const fixture = resolveVisualSmokeFixture('artifact-preview-oversize', false);
+        const fixture = resolveE2EFixture('artifact-preview-oversize', false);
         assert.ok(fixture);
-        await seedVisualSmokeFixture({
+        await seedE2EFixture({
           workspaceRoot,
           fixture,
           credentialStore: fakeCredentialStore(),
@@ -1034,7 +1034,7 @@ describe('visual smoke fixture mode', () => {
             join(
               workspaceRoot,
               'artifacts',
-              'visual-smoke-artifact',
+              'e2e-fixture-artifact',
               'artifact-preview-oversize-huge.png',
             ),
             'utf8',
@@ -1052,27 +1052,27 @@ describe('visual smoke fixture mode', () => {
         'artifact-preview-unsupported',
         'artifact-preview-oversize',
       ] as const) {
-        const fixture = resolveVisualSmokeFixture(scenario, false);
+        const fixture = resolveE2EFixture(scenario, false);
         assert.ok(fixture, `scenario=${scenario}`);
-        const state = getVisualSmokeState(fixture);
-        assert.equal(state?.activeSessionId, 'visual-smoke-artifact', `scenario=${scenario}`);
+        const state = getE2EFixtureState(fixture);
+        assert.equal(state?.activeSessionId, 'e2e-fixture-artifact', `scenario=${scenario}`);
       }
     });
   });
 
   it('artifact-pane seed creates file-backed artifact metadata without absolute paths', async () => {
-    const workspaceRoot = await mkdtemp(join(tmpdir(), 'maka-visual-smoke-artifact-'));
+    const workspaceRoot = await mkdtemp(join(tmpdir(), 'maka-e2e-fixture-artifact-'));
     try {
-      const fixture = resolveVisualSmokeFixture('artifact-pane', false);
+      const fixture = resolveE2EFixture('artifact-pane', false);
       assert.ok(fixture);
-      await seedVisualSmokeFixture({
+      await seedE2EFixture({
         workspaceRoot,
         fixture,
         credentialStore: fakeCredentialStore(),
         now: 1_700_000_000_000,
       });
-      const state = getVisualSmokeState(fixture);
-      assert.equal(state?.activeSessionId, 'visual-smoke-artifact');
+      const state = getE2EFixtureState(fixture);
+      assert.equal(state?.activeSessionId, 'e2e-fixture-artifact');
 
       const metadata = (await readFile(join(workspaceRoot, 'artifacts', 'metadata.jsonl'), 'utf8'))
         .split('\n')
@@ -1082,7 +1082,7 @@ describe('visual smoke fixture mode', () => {
       assert.deepEqual(metadata.map((record) => record.kind), ['html', 'diff', 'file']);
       assert.equal(metadata.every((record) => !record.relativePath.startsWith('/')), true);
       assert.equal(metadata.every((record) => record.status === 'live'), true);
-      const report = await readFile(join(workspaceRoot, 'artifacts', 'visual-smoke-artifact', 'artifact-report-report.html'), 'utf8');
+      const report = await readFile(join(workspaceRoot, 'artifacts', 'e2e-fixture-artifact', 'artifact-report-report.html'), 'utf8');
       assert.match(report, /外部链接应被禁用/);
     } finally {
       await rm(workspaceRoot, { recursive: true, force: true });
@@ -1091,42 +1091,42 @@ describe('visual smoke fixture mode', () => {
 
   describe('turn-control-history seed', () => {
     it('seeds primary + visible-parent branch + orphan branch sharing one on-disk state', async () => {
-      const workspaceRoot = await mkdtemp(join(tmpdir(), 'maka-visual-smoke-turn-control-'));
+      const workspaceRoot = await mkdtemp(join(tmpdir(), 'maka-e2e-fixture-turn-control-'));
       try {
-        const fixture = resolveVisualSmokeFixture('turn-control-history', false);
+        const fixture = resolveE2EFixture('turn-control-history', false);
         assert.ok(fixture);
-        await seedVisualSmokeFixture({
+        await seedE2EFixture({
           workspaceRoot,
           fixture,
           credentialStore: fakeCredentialStore(),
           now: 1_700_000_000_000,
         });
 
-        const state = getVisualSmokeState(fixture);
-        assert.equal(state?.activeSessionId, 'visual-smoke-turn-control-primary');
+        const state = getE2EFixtureState(fixture);
+        assert.equal(state?.activeSessionId, 'e2e-fixture-turn-control-primary');
 
-        const primary = await readSessionHeader(workspaceRoot, 'visual-smoke-turn-control-primary');
+        const primary = await readSessionHeader(workspaceRoot, 'e2e-fixture-turn-control-primary');
         assert.equal(primary.parentSessionId, undefined, 'primary has no parent');
 
-        const visible = await readSessionHeader(workspaceRoot, 'visual-smoke-turn-control-branch-visible');
+        const visible = await readSessionHeader(workspaceRoot, 'e2e-fixture-turn-control-branch-visible');
         assert.equal(
           visible.parentSessionId,
-          'visual-smoke-turn-control-primary',
+          'e2e-fixture-turn-control-primary',
           'visible branch points to seeded primary',
         );
         assert.equal(visible.branchOfTurnId, 'turn-retry-origin');
 
-        const orphan = await readSessionHeader(workspaceRoot, 'visual-smoke-turn-control-branch-orphan');
+        const orphan = await readSessionHeader(workspaceRoot, 'e2e-fixture-turn-control-branch-orphan');
         assert.equal(
           orphan.parentSessionId,
-          'visual-smoke-turn-control-deleted-parent',
+          'e2e-fixture-turn-control-deleted-parent',
           'orphan branch points to NON-existent parent',
         );
 
         // Negative case: the orphan parent must NOT be written to disk.
         await assert.rejects(
           readFile(
-            join(workspaceRoot, 'sessions', 'visual-smoke-turn-control-deleted-parent', 'session.jsonl'),
+            join(workspaceRoot, 'sessions', 'e2e-fixture-turn-control-deleted-parent', 'session.jsonl'),
             'utf8',
           ),
           /ENOENT/,
@@ -1137,18 +1137,18 @@ describe('visual smoke fixture mode', () => {
     });
 
     it('primary session log covers retry / regenerate / aborted / failed turns with TurnState messages', async () => {
-      const workspaceRoot = await mkdtemp(join(tmpdir(), 'maka-visual-smoke-turn-control-turns-'));
+      const workspaceRoot = await mkdtemp(join(tmpdir(), 'maka-e2e-fixture-turn-control-turns-'));
       try {
-        const fixture = resolveVisualSmokeFixture('turn-control-history', false);
+        const fixture = resolveE2EFixture('turn-control-history', false);
         assert.ok(fixture);
-        await seedVisualSmokeFixture({
+        await seedE2EFixture({
           workspaceRoot,
           fixture,
           credentialStore: fakeCredentialStore(),
           now: 1_700_000_000_000,
         });
 
-        const messages = await readSessionMessages(workspaceRoot, 'visual-smoke-turn-control-primary');
+        const messages = await readSessionMessages(workspaceRoot, 'e2e-fixture-turn-control-primary');
         const turnStates = messages.filter((m) => (m as { type?: string }).type === 'turn_state') as Array<{
           turnId: string;
           status: string;
@@ -1182,17 +1182,17 @@ describe('visual smoke fixture mode', () => {
     });
 
     it('turn-control-branch-visible scenario flips active session to the visible-parent branch', () => {
-      const fixture = resolveVisualSmokeFixture('turn-control-branch-visible', false);
+      const fixture = resolveE2EFixture('turn-control-branch-visible', false);
       assert.ok(fixture);
-      const state = getVisualSmokeState(fixture);
-      assert.equal(state?.activeSessionId, 'visual-smoke-turn-control-branch-visible');
+      const state = getE2EFixtureState(fixture);
+      assert.equal(state?.activeSessionId, 'e2e-fixture-turn-control-branch-visible');
     });
 
     it('turn-control-branch-orphan scenario flips active session to the orphan branch', () => {
-      const fixture = resolveVisualSmokeFixture('turn-control-branch-orphan', false);
+      const fixture = resolveE2EFixture('turn-control-branch-orphan', false);
       assert.ok(fixture);
-      const state = getVisualSmokeState(fixture);
-      assert.equal(state?.activeSessionId, 'visual-smoke-turn-control-branch-orphan');
+      const state = getE2EFixtureState(fixture);
+      assert.equal(state?.activeSessionId, 'e2e-fixture-turn-control-branch-orphan');
     });
 
     it('all three turn-control-* scenarios write the same on-disk session set', async () => {
@@ -1201,17 +1201,17 @@ describe('visual smoke fixture mode', () => {
       // future change that diverges their on-disk seed must update
       // this gate and the corresponding screenshot scenario.
       const expected = new Set([
-        'visual-smoke-turn-control-primary',
-        'visual-smoke-turn-control-branch-visible',
-        'visual-smoke-turn-control-branch-orphan',
+        'e2e-fixture-turn-control-primary',
+        'e2e-fixture-turn-control-branch-visible',
+        'e2e-fixture-turn-control-branch-orphan',
       ]);
 
       for (const scenario of ['turn-control-history', 'turn-control-branch-visible', 'turn-control-branch-orphan'] as const) {
-        const workspaceRoot = await mkdtemp(join(tmpdir(), `maka-visual-smoke-tc-${scenario}-`));
+        const workspaceRoot = await mkdtemp(join(tmpdir(), `maka-e2e-fixture-tc-${scenario}-`));
         try {
-          const fixture = resolveVisualSmokeFixture(scenario, false);
+          const fixture = resolveE2EFixture(scenario, false);
           assert.ok(fixture);
-          await seedVisualSmokeFixture({
+          await seedE2EFixture({
             workspaceRoot,
             fixture,
             credentialStore: fakeCredentialStore(),
@@ -1226,7 +1226,7 @@ describe('visual smoke fixture mode', () => {
           }
           await assert.rejects(
             readFile(
-              join(workspaceRoot, 'sessions', 'visual-smoke-turn-control-deleted-parent', 'session.jsonl'),
+              join(workspaceRoot, 'sessions', 'e2e-fixture-turn-control-deleted-parent', 'session.jsonl'),
               'utf8',
             ),
             /ENOENT/,
@@ -1240,18 +1240,18 @@ describe('visual smoke fixture mode', () => {
   });
 
   it('artifact-errors seed covers deleted, missing, and unsupported MIME preview states', async () => {
-    const workspaceRoot = await mkdtemp(join(tmpdir(), 'maka-visual-smoke-artifact-errors-'));
+    const workspaceRoot = await mkdtemp(join(tmpdir(), 'maka-e2e-fixture-artifact-errors-'));
     try {
-      const fixture = resolveVisualSmokeFixture('artifact-errors', false);
+      const fixture = resolveE2EFixture('artifact-errors', false);
       assert.ok(fixture);
-      await seedVisualSmokeFixture({
+      await seedE2EFixture({
         workspaceRoot,
         fixture,
         credentialStore: fakeCredentialStore(),
         now: 1_700_000_000_000,
       });
-      const state = getVisualSmokeState(fixture);
-      assert.equal(state?.activeSessionId, 'visual-smoke-artifact');
+      const state = getE2EFixtureState(fixture);
+      assert.equal(state?.activeSessionId, 'e2e-fixture-artifact');
 
       const metadata = (await readFile(join(workspaceRoot, 'artifacts', 'metadata.jsonl'), 'utf8'))
         .split('\n')
@@ -1268,7 +1268,7 @@ describe('visual smoke fixture mode', () => {
       assert.equal(metadata.find((record) => record.id === 'artifact-deleted')?.status, 'deleted');
       assert.equal(metadata.find((record) => record.id === 'artifact-unsupported')?.kind, 'image');
       await assert.rejects(
-        readFile(join(workspaceRoot, 'artifacts', 'visual-smoke-artifact', 'artifact-missing-missing.md'), 'utf8'),
+        readFile(join(workspaceRoot, 'artifacts', 'e2e-fixture-artifact', 'artifact-missing-missing.md'), 'utf8'),
         /ENOENT/,
       );
     } finally {
@@ -1279,32 +1279,32 @@ describe('visual smoke fixture mode', () => {
 
 describe('settings-bots-onboarding fixture (#1233 deferral)', () => {
   it('opens 远程接入 and seeds the DingTalk provider so the scan-login modal auto-opens', () => {
-    const fixture = resolveVisualSmokeFixture('settings-bots-onboarding', false);
+    const fixture = resolveE2EFixture('settings-bots-onboarding', false);
     assert.ok(fixture, 'settings-bots-onboarding should resolve');
-    const state = getVisualSmokeState(fixture);
+    const state = getE2EFixtureState(fixture);
     assert.equal(state?.openSettingsSection, 'bot-chat');
     // botOnboardingProvider is the contract the renderer reads to jump to the
     // provider detail + auto-open the QR modal in its waiting state.
     assert.equal(state?.botOnboardingProvider, 'dingtalk');
     // Active session is the standard turn fixture so the chat surface behind
     // the Settings modal renders meaningful context.
-    assert.equal(state?.activeSessionId, 'visual-smoke-turn');
+    assert.equal(state?.activeSessionId, 'e2e-fixture-turn');
   });
 
   it('reuses the standard turn seed so no bot-specific on-disk seed is needed', async () => {
-    const workspaceRoot = await mkdtemp(join(tmpdir(), 'maka-visual-smoke-bots-onboarding-'));
+    const workspaceRoot = await mkdtemp(join(tmpdir(), 'maka-e2e-fixture-bots-onboarding-'));
     try {
-      const fixture = resolveVisualSmokeFixture('settings-bots-onboarding', false);
+      const fixture = resolveE2EFixture('settings-bots-onboarding', false);
       assert.ok(fixture);
-      await seedVisualSmokeFixture({
+      await seedE2EFixture({
         workspaceRoot,
         fixture,
         credentialStore: fakeCredentialStore(),
         now: 1_700_000_000_000,
       });
-      const file = await readFile(join(workspaceRoot, 'sessions', 'visual-smoke-turn', 'session.jsonl'), 'utf8');
+      const file = await readFile(join(workspaceRoot, 'sessions', 'e2e-fixture-turn', 'session.jsonl'), 'utf8');
       const header = JSON.parse(file.split('\n')[0]!) as { id: string };
-      assert.equal(header.id, 'visual-smoke-turn');
+      assert.equal(header.id, 'e2e-fixture-turn');
     } finally {
       await rm(workspaceRoot, { recursive: true, force: true });
     }
@@ -1313,27 +1313,27 @@ describe('settings-bots-onboarding fixture (#1233 deferral)', () => {
 
 describe('browser-empty chrome fixture (#819)', () => {
   it('seeds a live browser session id so BrowserPanel mounts over the turn chat in empty state', () => {
-    const fixture = resolveVisualSmokeFixture('browser-empty', false);
+    const fixture = resolveE2EFixture('browser-empty', false);
     assert.ok(fixture, 'browser-empty should resolve');
-    const state = getVisualSmokeState(fixture);
+    const state = getE2EFixtureState(fixture);
     // Active session is the standard turn session so the chat surface
     // behind the browser panel renders meaningful context.
-    assert.equal(state?.activeSessionId, 'visual-smoke-turn');
+    assert.equal(state?.activeSessionId, 'e2e-fixture-turn');
     // liveBrowserSessionIds is the contract the renderer reads to mount
     // BrowserPanel (app-shell gates on activeId && liveBrowserSessionIds
     // .includes(activeId)). Seeding the active session makes the panel
-    // mount; with no real WebContentsView in visual-smoke mode,
+    // mount; with no real WebContentsView in e2e-fixture mode,
     // browser.getState returns null → BrowserPanel renders EMPTY_STATE →
     // the empty-state chrome (#818 defect surface) is what screenshots.
-    assert.deepEqual(state?.liveBrowserSessionIds, ['visual-smoke-turn']);
+    assert.deepEqual(state?.liveBrowserSessionIds, ['e2e-fixture-turn']);
   });
 
   it('reuses the always-seeded turn session so no browser-specific on-disk seed is needed', async () => {
-    const workspaceRoot = await mkdtemp(join(tmpdir(), 'maka-visual-smoke-browser-empty-'));
+    const workspaceRoot = await mkdtemp(join(tmpdir(), 'maka-e2e-fixture-browser-empty-'));
     try {
-      const fixture = resolveVisualSmokeFixture('browser-empty', false);
+      const fixture = resolveE2EFixture('browser-empty', false);
       assert.ok(fixture);
-      await seedVisualSmokeFixture({
+      await seedE2EFixture({
         workspaceRoot,
         fixture,
         credentialStore: fakeCredentialStore(),
@@ -1342,9 +1342,9 @@ describe('browser-empty chrome fixture (#819)', () => {
       // The turn session is part of the standard seed (always written),
       // so the active browser session has a real on-disk chat behind the
       // panel without a browser-specific seed branch.
-      const file = await readFile(join(workspaceRoot, 'sessions', 'visual-smoke-turn', 'session.jsonl'), 'utf8');
+      const file = await readFile(join(workspaceRoot, 'sessions', 'e2e-fixture-turn', 'session.jsonl'), 'utf8');
       const header = JSON.parse(file.split('\n')[0]!) as { id: string };
-      assert.equal(header.id, 'visual-smoke-turn');
+      assert.equal(header.id, 'e2e-fixture-turn');
     } finally {
       await rm(workspaceRoot, { recursive: true, force: true });
     }

--- a/apps/desktop/src/main/__tests__/e2e-fixture.test.ts
+++ b/apps/desktop/src/main/__tests__/e2e-fixture.test.ts
@@ -4,35 +4,35 @@ import { join } from 'node:path';
 import { describe, it } from 'node:test';
 import { tmpdir } from 'node:os';
 import {
-  getE2EFixtureState,
-  resolveE2EFixture,
-  seedE2EFixture,
+  getE2eFixtureState,
+  resolveE2eFixture,
+  seedE2eFixture,
 } from '../e2e-fixture.js';
-import { readE2EFixtureCombinedSource } from './e2e-fixture-source-helpers.js';
+import { readE2eFixtureCombinedSource } from './e2e-fixture-source-helpers.js';
 
 describe('e2e-fixture mode', () => {
   it('stays fully disabled when MAKA_E2E_FIXTURE is unset', () => {
-    const fixture = resolveE2EFixture(undefined, false);
+    const fixture = resolveE2eFixture(undefined, false);
     assert.equal(fixture, null);
-    assert.equal(getE2EFixtureState(fixture), null);
+    assert.equal(getE2eFixtureState(fixture), null);
   });
 
   it('rejects fixture mode in packaged builds', () => {
     assert.throws(
-      () => resolveE2EFixture('all', true),
+      () => resolveE2eFixture('all', true),
       /only available in dev\/test builds/,
     );
   });
 
   it('rejects unknown scenarios', () => {
     assert.throws(
-      () => resolveE2EFixture('unknown-scenario', false),
+      () => resolveE2eFixture('unknown-scenario', false),
       /Unknown MAKA_E2E_FIXTURE scenario/,
     );
   });
 
   it('resolves known scenarios into isolated workspaces', () => {
-    const fixture = resolveE2EFixture('provider-workspace', false);
+    const fixture = resolveE2eFixture('provider-workspace', false);
     assert.deepEqual(fixture, {
       scenario: 'provider-workspace',
       workspaceName: 'e2e-fixture-provider-workspace',
@@ -45,25 +45,25 @@ describe('e2e-fixture mode', () => {
 
   describe('theme override (PR-IR-01b)', () => {
     it('defaults to null when env var unset', () => {
-      const fixture = resolveE2EFixture('all', false);
+      const fixture = resolveE2eFixture('all', false);
       assert.equal(fixture?.theme, null);
-      const state = getE2EFixtureState(fixture);
+      const state = getE2eFixtureState(fixture);
       assert.equal(state?.theme, undefined);
       assert.equal(state?.now, Date.UTC(2026, 4, 22, 3, 0, 0));
     });
 
     it('accepts the closed enum light / dark / auto', () => {
       for (const raw of ['light', 'dark', 'auto', 'LIGHT', ' Dark ']) {
-        const fixture = resolveE2EFixture('all', false, undefined, raw);
+        const fixture = resolveE2eFixture('all', false, undefined, raw);
         assert.equal(typeof fixture?.theme, 'string', `raw=${JSON.stringify(raw)}`);
-        const state = getE2EFixtureState(fixture);
+        const state = getE2eFixtureState(fixture);
         assert.ok(state?.theme && ['light', 'dark', 'auto'].includes(state.theme), `raw=${JSON.stringify(raw)}`);
       }
     });
 
     it('rejects unknown values (fail-closed)', () => {
       for (const raw of ['solar', '', 'oklch', 'high-contrast', 'monochrome']) {
-        const fixture = resolveE2EFixture('all', false, undefined, raw);
+        const fixture = resolveE2eFixture('all', false, undefined, raw);
         assert.equal(fixture?.theme, null, `raw=${JSON.stringify(raw)}`);
       }
     });
@@ -71,18 +71,18 @@ describe('e2e-fixture mode', () => {
 
   describe('UI locale override (PR-UI-VISUAL-SMOKE-LOCALE)', () => {
     it('defaults to null when MAKA_E2E_FIXTURE_LOCALE unset', () => {
-      const fixture = resolveE2EFixture('all', false);
+      const fixture = resolveE2eFixture('all', false);
       assert.equal(fixture?.locale, null);
-      const state = getE2EFixtureState(fixture);
+      const state = getE2eFixtureState(fixture);
       assert.equal(state?.locale, undefined);
     });
 
     it('accepts the closed enum zh / en (case + whitespace tolerant)', () => {
       for (const raw of ['zh', 'en', 'ZH', ' En ', 'EN']) {
-        const fixture = resolveE2EFixture('all', false, undefined, undefined, raw);
+        const fixture = resolveE2eFixture('all', false, undefined, undefined, raw);
         assert.ok(fixture?.locale, `raw=${JSON.stringify(raw)}`);
         assert.ok(['zh', 'en'].includes(fixture!.locale!), `raw=${JSON.stringify(raw)}`);
-        const state = getE2EFixtureState(fixture);
+        const state = getE2eFixtureState(fixture);
         assert.ok(state?.locale && ['zh', 'en'].includes(state.locale), `raw=${JSON.stringify(raw)}`);
       }
     });
@@ -92,26 +92,26 @@ describe('e2e-fixture mode', () => {
       // bare `zh` / `en` short codes. `zh-CN` etc. fail closed so the
       // override is unambiguous; users wanting CN locale set `zh`.
       for (const raw of ['', 'es', 'ja', 'zh-CN', 'en-US', 'auto', 'system']) {
-        const fixture = resolveE2EFixture('all', false, undefined, undefined, raw);
+        const fixture = resolveE2eFixture('all', false, undefined, undefined, raw);
         assert.equal(fixture?.locale, null, `raw=${JSON.stringify(raw)}`);
       }
     });
 
-    it('locale flag carries through into E2EFixtureState across all known scenarios', () => {
+    it('locale flag carries through into E2eFixtureState across all known scenarios', () => {
       for (const scenario of ['first-run', 'turn-narrative', 'artifact-pane', 'stale-sessions']) {
-        const fixture = resolveE2EFixture(scenario, false, undefined, undefined, 'zh');
+        const fixture = resolveE2eFixture(scenario, false, undefined, undefined, 'zh');
         assert.equal(fixture?.locale, 'zh', `scenario=${scenario}`);
-        const state = getE2EFixtureState(fixture);
+        const state = getE2eFixtureState(fixture);
         assert.equal(state?.locale, 'zh', `scenario=${scenario}`);
       }
     });
 
     it('locale is independent from theme / reduced-motion', () => {
-      const fixture = resolveE2EFixture('all', false, '1', 'dark', 'en');
+      const fixture = resolveE2eFixture('all', false, '1', 'dark', 'en');
       assert.equal(fixture?.locale, 'en');
       assert.equal(fixture?.theme, 'dark');
       assert.equal(fixture?.reducedMotion, true);
-      const state = getE2EFixtureState(fixture);
+      const state = getE2eFixtureState(fixture);
       assert.equal(state?.locale, 'en');
       assert.equal(state?.theme, 'dark');
       assert.equal(state?.reducedMotion, true);
@@ -120,9 +120,9 @@ describe('e2e-fixture mode', () => {
 
   describe('IANA timezone override (PR-UI-VISUAL-SMOKE-TIMEZONE, @kenji msg 45486cdf)', () => {
     it('defaults to null when MAKA_E2E_FIXTURE_TIMEZONE unset', () => {
-      const fixture = resolveE2EFixture('all', false);
+      const fixture = resolveE2eFixture('all', false);
       assert.equal(fixture?.timezone, null);
-      const state = getE2EFixtureState(fixture);
+      const state = getE2eFixtureState(fixture);
       assert.equal(state?.timezone, undefined);
     });
 
@@ -140,9 +140,9 @@ describe('e2e-fixture mode', () => {
         'Pacific/Auckland',
       ];
       for (const tz of valid) {
-        const fixture = resolveE2EFixture('all', false, undefined, undefined, undefined, tz);
+        const fixture = resolveE2eFixture('all', false, undefined, undefined, undefined, tz);
         assert.equal(fixture?.timezone, tz, `tz=${tz}`);
-        const state = getE2EFixtureState(fixture);
+        const state = getE2eFixtureState(fixture);
         assert.equal(state?.timezone, tz, `tz=${tz}`);
       }
     });
@@ -152,7 +152,7 @@ describe('e2e-fixture mode', () => {
       // (`America/New_York`, not `america/new_york`). The parser
       // trim-onlys; it does not lowercase, so the canonical form
       // survives.
-      const fixture = resolveE2EFixture('all', false, undefined, undefined, undefined, '  Asia/Shanghai  ');
+      const fixture = resolveE2eFixture('all', false, undefined, undefined, undefined, '  Asia/Shanghai  ');
       assert.equal(fixture?.timezone, 'Asia/Shanghai');
     });
 
@@ -169,14 +169,14 @@ describe('e2e-fixture mode', () => {
         'utc/zulu',
       ];
       for (const tz of invalid) {
-        const fixture = resolveE2EFixture('all', false, undefined, undefined, undefined, tz);
+        const fixture = resolveE2eFixture('all', false, undefined, undefined, undefined, tz);
         assert.equal(fixture?.timezone, null, `tz=${JSON.stringify(tz)}`);
       }
     });
 
     it('rejects oversize inputs (>128 chars) without invoking Intl.DateTimeFormat', () => {
       const oversize = 'A'.repeat(129);
-      const fixture = resolveE2EFixture('all', false, undefined, undefined, undefined, oversize);
+      const fixture = resolveE2eFixture('all', false, undefined, undefined, undefined, oversize);
       assert.equal(fixture?.timezone, null);
     });
 
@@ -186,8 +186,8 @@ describe('e2e-fixture mode', () => {
       // surfaces the IANA name. It does NOT mutate `Date.prototype`,
       // global `Intl.DateTimeFormat`, or `state.now`. `state.now`
       // is still the canonical clock-freeze for e2e-fixture.
-      const fixture = resolveE2EFixture('all', false, undefined, undefined, undefined, 'Asia/Shanghai');
-      const state = getE2EFixtureState(fixture);
+      const fixture = resolveE2eFixture('all', false, undefined, undefined, undefined, 'Asia/Shanghai');
+      const state = getE2eFixtureState(fixture);
       assert.equal(state?.timezone, 'Asia/Shanghai');
       assert.equal(state?.now, Date.UTC(2026, 4, 22, 3, 0, 0));
       // No global mutation: Date.now / new Date() / Intl.DateTimeFormat
@@ -199,22 +199,22 @@ describe('e2e-fixture mode', () => {
       assert.equal(typeof formatter.resolvedOptions().timeZone, 'string');
     });
 
-    it('timezone flag carries through into E2EFixtureState across all known scenarios', () => {
+    it('timezone flag carries through into E2eFixtureState across all known scenarios', () => {
       for (const scenario of ['first-run', 'turn-narrative', 'artifact-pane', 'stale-sessions']) {
-        const fixture = resolveE2EFixture(scenario, false, undefined, undefined, undefined, 'Europe/London');
+        const fixture = resolveE2eFixture(scenario, false, undefined, undefined, undefined, 'Europe/London');
         assert.equal(fixture?.timezone, 'Europe/London', `scenario=${scenario}`);
-        const state = getE2EFixtureState(fixture);
+        const state = getE2eFixtureState(fixture);
         assert.equal(state?.timezone, 'Europe/London', `scenario=${scenario}`);
       }
     });
 
     it('timezone is independent from theme / locale / reduced-motion', () => {
-      const fixture = resolveE2EFixture('all', false, '1', 'dark', 'en', 'Asia/Tokyo');
+      const fixture = resolveE2eFixture('all', false, '1', 'dark', 'en', 'Asia/Tokyo');
       assert.equal(fixture?.timezone, 'Asia/Tokyo');
       assert.equal(fixture?.locale, 'en');
       assert.equal(fixture?.theme, 'dark');
       assert.equal(fixture?.reducedMotion, true);
-      const state = getE2EFixtureState(fixture);
+      const state = getE2eFixtureState(fixture);
       assert.equal(state?.timezone, 'Asia/Tokyo');
       assert.equal(state?.locale, 'en');
       assert.equal(state?.theme, 'dark');
@@ -224,41 +224,41 @@ describe('e2e-fixture mode', () => {
 
   describe('reduced-motion variant (PR-IR-04)', () => {
     it('defaults to reducedMotion: false when env var unset', () => {
-      const fixture = resolveE2EFixture('all', false);
+      const fixture = resolveE2eFixture('all', false);
       assert.equal(fixture?.reducedMotion, false);
-      const state = getE2EFixtureState(fixture);
+      const state = getE2eFixtureState(fixture);
       assert.equal(state?.reducedMotion, undefined);
     });
 
     it('accepts "1" / "true" / "yes" as truthy', () => {
       for (const raw of ['1', 'true', 'yes', 'TRUE', ' yes ']) {
-        const fixture = resolveE2EFixture('all', false, raw);
+        const fixture = resolveE2eFixture('all', false, raw);
         assert.equal(fixture?.reducedMotion, true, `raw=${JSON.stringify(raw)}`);
-        const state = getE2EFixtureState(fixture);
+        const state = getE2eFixtureState(fixture);
         assert.equal(state?.reducedMotion, true, `raw=${JSON.stringify(raw)}`);
       }
     });
 
     it('treats unrecognized values as false (fail-closed)', () => {
       for (const raw of ['0', 'no', 'false', '', 'maybe']) {
-        const fixture = resolveE2EFixture('all', false, raw);
+        const fixture = resolveE2eFixture('all', false, raw);
         assert.equal(fixture?.reducedMotion, false, `raw=${JSON.stringify(raw)}`);
       }
     });
 
     it('reduced motion flag works across all known scenarios', () => {
       for (const scenario of ['first-run', 'turn-narrative', 'artifact-pane', 'stale-sessions']) {
-        const fixture = resolveE2EFixture(scenario, false, '1');
+        const fixture = resolveE2eFixture(scenario, false, '1');
         assert.equal(fixture?.reducedMotion, true, `scenario=${scenario}`);
-        const state = getE2EFixtureState(fixture);
+        const state = getE2eFixtureState(fixture);
         assert.equal(state?.reducedMotion, true, `scenario=${scenario}`);
       }
     });
   });
 
-  it('first-run fixture has no transient smoke-only UI state', () => {
-    const fixture = resolveE2EFixture('first-run', false);
-    const state = getE2EFixtureState(fixture);
+  it('first-run fixture has no transient fixture-only UI state', () => {
+    const fixture = resolveE2eFixture('first-run', false);
+    const state = getE2eFixtureState(fixture);
     assert.equal(state?.enabled, true);
     assert.equal(state?.now, Date.UTC(2026, 4, 22, 3, 0, 0));
     assert.equal(state?.activeSessionId, undefined);
@@ -267,8 +267,8 @@ describe('e2e-fixture mode', () => {
   });
 
   it('all fixture exposes transient streaming and permission state without persistence', () => {
-    const fixture = resolveE2EFixture('all', false);
-    const state = getE2EFixtureState(fixture);
+    const fixture = resolveE2eFixture('all', false);
+    const state = getE2eFixtureState(fixture);
     assert.equal(state?.enabled, true);
     assert.equal(state?.activeSessionId, 'e2e-fixture-turn');
     const liveTurns = state?.liveTurnBySession;
@@ -285,15 +285,15 @@ describe('e2e-fixture mode', () => {
   it('task-ledger fixture seeds the hierarchical desktop read model', async () => {
     const workspaceRoot = await mkdtemp(join(tmpdir(), 'maka-e2e-fixture-task-ledger-'));
     try {
-      const fixture = resolveE2EFixture('task-ledger', false);
+      const fixture = resolveE2eFixture('task-ledger', false);
       assert.ok(fixture);
-      await seedE2EFixture({
+      await seedE2eFixture({
         workspaceRoot,
         fixture,
         credentialStore: fakeCredentialStore(),
         now: 1_700_000_000_000,
       });
-      assert.equal(getE2EFixtureState(fixture)?.activeSessionId, 'e2e-fixture-turn');
+      assert.equal(getE2eFixtureState(fixture)?.activeSessionId, 'e2e-fixture-turn');
       const tasks = JSON.parse(await readFile(
         join(workspaceRoot, 'sessions', 'e2e-fixture-turn', 'tasks.json'),
         'utf8',
@@ -309,15 +309,15 @@ describe('e2e-fixture mode', () => {
   it('deep-research-progress seeds a completed durable run for visual review', async () => {
     const workspaceRoot = await mkdtemp(join(tmpdir(), 'maka-e2e-fixture-deep-research-'));
     try {
-      const fixture = resolveE2EFixture('deep-research-progress', false);
+      const fixture = resolveE2eFixture('deep-research-progress', false);
       assert.ok(fixture);
-      await seedE2EFixture({
+      await seedE2eFixture({
         workspaceRoot,
         fixture,
         credentialStore: fakeCredentialStore(),
         now: 1_700_000_000_000,
       });
-      assert.equal(getE2EFixtureState(fixture)?.activeSessionId, 'e2e-fixture-deep-research');
+      assert.equal(getE2eFixtureState(fixture)?.activeSessionId, 'e2e-fixture-deep-research');
       const ledger = await readFile(
         join(
           workspaceRoot,
@@ -346,16 +346,16 @@ describe('e2e-fixture mode', () => {
     // arch Round 3: the fixture split into a registry barrel + per-domain
     // seeder modules, so this hygiene scan aggregates every fixture source
     // file rather than the single monolith it used to read.
-    const src = await readE2EFixtureCombinedSource();
+    const src = await readE2eFixtureCombinedSource();
     assert.doesNotMatch(src, /占位用户消息|占位回复/, 'e2e-fixture screenshots must use product-like chat copy, not placeholder text');
   });
 
   it('first-run seed keeps the fixture workspace connection-free', async () => {
     const workspaceRoot = await mkdtemp(join(tmpdir(), 'maka-e2e-fixture-first-run-'));
     try {
-      const fixture = resolveE2EFixture('first-run', false);
+      const fixture = resolveE2eFixture('first-run', false);
       assert.ok(fixture);
-      await seedE2EFixture({
+      await seedE2eFixture({
         workspaceRoot,
         fixture,
         credentialStore: fakeCredentialStore(),
@@ -380,10 +380,10 @@ describe('e2e-fixture mode', () => {
   it('scenario seed focuses the relevant provider state for connection-dialog screenshots', async () => {
     const workspaceRoot = await mkdtemp(join(tmpdir(), 'maka-e2e-fixture-provider-'));
     try {
-      const fixture = resolveE2EFixture('fallback-source', false);
+      const fixture = resolveE2eFixture('fallback-source', false);
       assert.ok(fixture);
       const secrets: string[] = [];
-      await seedE2EFixture({
+      await seedE2eFixture({
         workspaceRoot,
         fixture,
         credentialStore: fakeCredentialStore(secrets),
@@ -435,9 +435,9 @@ describe('e2e-fixture mode', () => {
 
     for (const { scenario, expectedSection } of cases) {
       it(`${scenario} opens Settings · ${expectedSection}`, () => {
-        const fixture = resolveE2EFixture(scenario, false);
+        const fixture = resolveE2eFixture(scenario, false);
         assert.ok(fixture, `${scenario} should resolve`);
-        const state = getE2EFixtureState(fixture);
+        const state = getE2eFixtureState(fixture);
         assert.equal(state?.openSettingsSection, expectedSection);
         // Active session is the standard turn fixture so the chat
         // surface behind the modal renders meaningful context.
@@ -449,18 +449,18 @@ describe('e2e-fixture mode', () => {
   it('stale-sessions seed reproduces the P0 workspace with active stale session', async () => {
     const workspaceRoot = await mkdtemp(join(tmpdir(), 'maka-e2e-fixture-stale-'));
     try {
-      const fixture = resolveE2EFixture('stale-sessions', false);
+      const fixture = resolveE2eFixture('stale-sessions', false);
       assert.ok(fixture);
-      await seedE2EFixture({
+      await seedE2eFixture({
         workspaceRoot,
         fixture,
         credentialStore: fakeCredentialStore(),
         now: 1_700_000_000_000,
       });
 
-      const state = getE2EFixtureState(fixture);
+      const state = getE2eFixtureState(fixture);
       // @kenji gate: active session intentionally one of the stale ones so
-      // E2E/audit can prove "active + stale → pill still visible".
+      // the alignment audit can prove "active + stale → pill still visible".
       assert.equal(state?.activeSessionId, 'e2e-fixture-stale-fake');
 
       // Connection list MUST NOT contain `fake` / `fake-claude` slugs —
@@ -498,16 +498,16 @@ describe('e2e-fixture mode', () => {
   it('workstation-statuses seed creates one session per SessionStatus including aborted + 4 blocked variants', async () => {
     const workspaceRoot = await mkdtemp(join(tmpdir(), 'maka-e2e-fixture-ws-'));
     try {
-      const fixture = resolveE2EFixture('workstation-statuses', false);
+      const fixture = resolveE2eFixture('workstation-statuses', false);
       assert.ok(fixture);
-      await seedE2EFixture({
+      await seedE2eFixture({
         workspaceRoot,
         fixture,
         credentialStore: fakeCredentialStore(),
         now: 1_700_000_000_000,
       });
 
-      const state = getE2EFixtureState(fixture);
+      const state = getE2eFixtureState(fixture);
       assert.equal(state?.activeSessionId, 'e2e-fixture-ws-running');
 
       const expectedSessions = [
@@ -551,9 +551,9 @@ describe('e2e-fixture mode', () => {
   it('model-processing arms a running session with no live stream so the "正在处理…" indicator + Stop show (#646)', async () => {
     const workspaceRoot = await mkdtemp(join(tmpdir(), 'maka-e2e-fixture-processing-'));
     try {
-      const fixture = resolveE2EFixture('model-processing', false);
+      const fixture = resolveE2eFixture('model-processing', false);
       assert.ok(fixture);
-      const state = getE2EFixtureState(fixture);
+      const state = getE2eFixtureState(fixture);
       // The turn is armed on a running session — the derivation's inputs.
       assert.equal(state?.activeSessionId, 'e2e-fixture-processing');
       assert.deepEqual(state?.liveTurnBySession?.['e2e-fixture-processing'], {
@@ -566,7 +566,7 @@ describe('e2e-fixture mode', () => {
       // wait). This scenario deliberately seeds none of them.
       assert.equal(state?.liveTurnBySession?.['e2e-fixture-processing']?.steps.length, 0);
 
-      await seedE2EFixture({
+      await seedE2eFixture({
         workspaceRoot,
         fixture,
         credentialStore: fakeCredentialStore(),
@@ -589,16 +589,16 @@ describe('e2e-fixture mode', () => {
   it('plan-reminders opens the Automations module and seeds scheduled / paused / completed reminders', async () => {
     const workspaceRoot = await mkdtemp(join(tmpdir(), 'maka-e2e-fixture-plan-reminders-'));
     try {
-      const fixture = resolveE2EFixture('plan-reminders', false);
+      const fixture = resolveE2eFixture('plan-reminders', false);
       assert.ok(fixture);
-      await seedE2EFixture({
+      await seedE2eFixture({
         workspaceRoot,
         fixture,
         credentialStore: fakeCredentialStore(),
         now: 1_700_000_000_000,
       });
 
-      const state = getE2EFixtureState(fixture);
+      const state = getE2eFixtureState(fixture);
       assert.equal(state?.sidebarSection, 'automations');
       assert.equal(state?.sidebarCollapsed, false);
       assert.equal(state?.activeSessionId, 'e2e-fixture-turn');
@@ -635,30 +635,30 @@ describe('e2e-fixture mode', () => {
   });
 
   it('module fixtures open Skills, MCP and Daily Review in the app module surface', async () => {
-    const skills = resolveE2EFixture('module-skills', false);
-    const mcp = resolveE2EFixture('module-mcp', false);
-    const dailyReview = resolveE2EFixture('module-daily-review', false);
+    const skills = resolveE2eFixture('module-skills', false);
+    const mcp = resolveE2eFixture('module-mcp', false);
+    const dailyReview = resolveE2eFixture('module-daily-review', false);
 
     assert.ok(skills);
     assert.ok(mcp);
     assert.ok(dailyReview);
-    assert.equal(getE2EFixtureState(skills)?.sidebarSection, 'skills');
-    assert.equal(getE2EFixtureState(skills)?.sidebarCollapsed, false);
-    assert.equal(getE2EFixtureState(skills)?.activeSessionId, 'e2e-fixture-turn');
-    assert.equal(getE2EFixtureState(mcp)?.sidebarSection, 'mcp');
-    assert.equal(getE2EFixtureState(mcp)?.sidebarCollapsed, false);
-    assert.equal(getE2EFixtureState(mcp)?.activeSessionId, 'e2e-fixture-turn');
-    assert.equal(getE2EFixtureState(dailyReview)?.sidebarSection, 'daily-review');
-    assert.equal(getE2EFixtureState(dailyReview)?.sidebarCollapsed, false);
-    assert.equal(getE2EFixtureState(dailyReview)?.activeSessionId, 'e2e-fixture-turn');
+    assert.equal(getE2eFixtureState(skills)?.sidebarSection, 'skills');
+    assert.equal(getE2eFixtureState(skills)?.sidebarCollapsed, false);
+    assert.equal(getE2eFixtureState(skills)?.activeSessionId, 'e2e-fixture-turn');
+    assert.equal(getE2eFixtureState(mcp)?.sidebarSection, 'mcp');
+    assert.equal(getE2eFixtureState(mcp)?.sidebarCollapsed, false);
+    assert.equal(getE2eFixtureState(mcp)?.activeSessionId, 'e2e-fixture-turn');
+    assert.equal(getE2eFixtureState(dailyReview)?.sidebarSection, 'daily-review');
+    assert.equal(getE2eFixtureState(dailyReview)?.sidebarCollapsed, false);
+    assert.equal(getE2eFixtureState(dailyReview)?.activeSessionId, 'e2e-fixture-turn');
   });
 
   it('module-mcp seeds a couple of installed servers so the 已安装 list renders', async () => {
     const workspaceRoot = await mkdtemp(join(tmpdir(), 'maka-e2e-fixture-mcp-'));
     try {
-      const fixture = resolveE2EFixture('module-mcp', false);
+      const fixture = resolveE2eFixture('module-mcp', false);
       assert.ok(fixture);
-      await seedE2EFixture({
+      await seedE2eFixture({
         workspaceRoot,
         fixture,
         credentialStore: fakeCredentialStore(),
@@ -685,9 +685,9 @@ describe('e2e-fixture mode', () => {
     const workspaceRoot = await mkdtemp(join(tmpdir(), 'maka-e2e-fixture-skills-'));
     const previousSourcesRoot = process.env.MAKA_SKILL_SOURCES_ROOT;
     try {
-      const fixture = resolveE2EFixture('module-skills', false);
+      const fixture = resolveE2eFixture('module-skills', false);
       assert.ok(fixture);
-      await seedE2EFixture({
+      await seedE2eFixture({
         workspaceRoot,
         fixture,
         credentialStore: fakeCredentialStore(),
@@ -731,23 +731,23 @@ describe('e2e-fixture mode', () => {
     // kenji `b3d156e9`): the sidebar-row-actions-visible scenario
     // reuses the 60-session seed so the sidebar is identical to
     // the long-sessions baseline; differs only in
-    // `E2EFixtureState.focusActiveRow=true`, which the renderer
+    // `E2eFixtureState.focusActiveRow=true`, which the renderer
     // reads to focus the active row's button after mount. That
     // triggers `:focus-within` and reveals the
     // `.maka-list-row-menu-trigger` — the fixture then proves
     // the time meta / unread dot are correctly hidden underneath.
     const workspaceRoot = await mkdtemp(join(tmpdir(), 'maka-e2e-fixture-row-actions-'));
     try {
-      const fixture = resolveE2EFixture('sidebar-row-actions-visible', false);
+      const fixture = resolveE2eFixture('sidebar-row-actions-visible', false);
       assert.ok(fixture);
-      await seedE2EFixture({
+      await seedE2eFixture({
         workspaceRoot,
         fixture,
         credentialStore: fakeCredentialStore(),
         now: 1_700_000_000_000,
       });
 
-      const state = getE2EFixtureState(fixture);
+      const state = getE2eFixtureState(fixture);
       // focusActiveRow is the contract the renderer reads.
       assert.equal(state?.focusActiveRow, true, 'focusActiveRow must be true so the renderer focuses the active row button');
       assert.equal(state?.sidebarCollapsed, false, 'sidebar row action screenshots must expand the seeded sidebar');
@@ -772,22 +772,22 @@ describe('e2e-fixture mode', () => {
     // sidebar-search-modal-open scenario reuses the 60-session seed
     // so the sidebar behind the modal matches the long-sessions
     // baseline exactly. The only differentiator from `sidebar-long-
-    // sessions` is `E2EFixtureState.searchModalOpen=true`, which
+    // sessions` is `E2eFixtureState.searchModalOpen=true`, which
     // the renderer reads to call `setSearchModalOpen(true)` before
     // the fixture settles, so the SearchModal shell is on screen
-    // for E2E/audit.
+    // for the alignment audit.
     const workspaceRoot = await mkdtemp(join(tmpdir(), 'maka-e2e-fixture-search-modal-'));
     try {
-      const fixture = resolveE2EFixture('sidebar-search-modal-open', false);
+      const fixture = resolveE2eFixture('sidebar-search-modal-open', false);
       assert.ok(fixture);
-      await seedE2EFixture({
+      await seedE2eFixture({
         workspaceRoot,
         fixture,
         credentialStore: fakeCredentialStore(),
         now: 1_700_000_000_000,
       });
 
-      const state = getE2EFixtureState(fixture);
+      const state = getE2eFixtureState(fixture);
       // Modal-open hint is the contract the renderer reads.
       assert.equal(state?.searchModalOpen, true, 'searchModalOpen must be true so the renderer auto-opens the modal');
       // Same active session as the long-sessions scenario so the
@@ -811,16 +811,16 @@ describe('e2e-fixture mode', () => {
   it('command-palette-open shares the 60-session seed and sets paletteOpen for auto-open', async () => {
     const workspaceRoot = await mkdtemp(join(tmpdir(), 'maka-e2e-fixture-command-palette-'));
     try {
-      const fixture = resolveE2EFixture('command-palette-open', false);
+      const fixture = resolveE2eFixture('command-palette-open', false);
       assert.ok(fixture);
-      await seedE2EFixture({
+      await seedE2eFixture({
         workspaceRoot,
         fixture,
         credentialStore: fakeCredentialStore(),
         now: 1_700_000_000_000,
       });
 
-      const state = getE2EFixtureState(fixture);
+      const state = getE2eFixtureState(fixture);
       assert.equal(state?.paletteOpen, true, 'paletteOpen must be true so the renderer auto-opens CommandPalette');
       assert.equal(state?.activeSessionId, 'e2e-fixture-sidebar-long-00');
 
@@ -844,16 +844,16 @@ describe('e2e-fixture mode', () => {
     // active selection, and (c) keep IDs deterministic.
     const workspaceRoot = await mkdtemp(join(tmpdir(), 'maka-e2e-fixture-long-'));
     try {
-      const fixture = resolveE2EFixture('sidebar-long-sessions', false);
+      const fixture = resolveE2eFixture('sidebar-long-sessions', false);
       assert.ok(fixture);
-      await seedE2EFixture({
+      await seedE2eFixture({
         workspaceRoot,
         fixture,
         credentialStore: fakeCredentialStore(),
         now: 1_700_000_000_000,
       });
 
-      const state = getE2EFixtureState(fixture);
+      const state = getE2eFixtureState(fixture);
       // Active session is the first (newest by lastMessageAt).
       assert.equal(state?.activeSessionId, 'e2e-fixture-sidebar-long-00');
       assert.equal(state?.sidebarCollapsed, false, 'sidebar scroll screenshots must expand the seeded sidebar');
@@ -910,15 +910,15 @@ describe('e2e-fixture mode', () => {
     it('artifact-preview-image: single PNG seeded → registry will resolve image(mime_match)', async () => {
       const workspaceRoot = await mkdtemp(join(tmpdir(), 'maka-e2e-fixture-preview-image-'));
       try {
-        const fixture = resolveE2EFixture('artifact-preview-image', false);
+        const fixture = resolveE2eFixture('artifact-preview-image', false);
         assert.ok(fixture);
-        await seedE2EFixture({
+        await seedE2eFixture({
           workspaceRoot,
           fixture,
           credentialStore: fakeCredentialStore(),
           now: 1_700_000_000_000,
         });
-        const state = getE2EFixtureState(fixture);
+        const state = getE2eFixtureState(fixture);
         assert.equal(state?.activeSessionId, 'e2e-fixture-artifact');
 
         const lines = (await readFile(join(workspaceRoot, 'artifacts', 'metadata.jsonl'), 'utf8'))
@@ -962,9 +962,9 @@ describe('e2e-fixture mode', () => {
     it('artifact-preview-unsupported: image/heic disallowed mime → L1 unsupported(mime_disallowed), readBinary never called', async () => {
       const workspaceRoot = await mkdtemp(join(tmpdir(), 'maka-e2e-fixture-preview-unsupported-'));
       try {
-        const fixture = resolveE2EFixture('artifact-preview-unsupported', false);
+        const fixture = resolveE2eFixture('artifact-preview-unsupported', false);
         assert.ok(fixture);
-        await seedE2EFixture({
+        await seedE2eFixture({
           workspaceRoot,
           fixture,
           credentialStore: fakeCredentialStore(),
@@ -996,9 +996,9 @@ describe('e2e-fixture mode', () => {
     it('artifact-preview-oversize: 3MB sizeBytes claim with skipFile → L1 unsupported(oversize)', async () => {
       const workspaceRoot = await mkdtemp(join(tmpdir(), 'maka-e2e-fixture-preview-oversize-'));
       try {
-        const fixture = resolveE2EFixture('artifact-preview-oversize', false);
+        const fixture = resolveE2eFixture('artifact-preview-oversize', false);
         assert.ok(fixture);
-        await seedE2EFixture({
+        await seedE2eFixture({
           workspaceRoot,
           fixture,
           credentialStore: fakeCredentialStore(),
@@ -1052,9 +1052,9 @@ describe('e2e-fixture mode', () => {
         'artifact-preview-unsupported',
         'artifact-preview-oversize',
       ] as const) {
-        const fixture = resolveE2EFixture(scenario, false);
+        const fixture = resolveE2eFixture(scenario, false);
         assert.ok(fixture, `scenario=${scenario}`);
-        const state = getE2EFixtureState(fixture);
+        const state = getE2eFixtureState(fixture);
         assert.equal(state?.activeSessionId, 'e2e-fixture-artifact', `scenario=${scenario}`);
       }
     });
@@ -1063,15 +1063,15 @@ describe('e2e-fixture mode', () => {
   it('artifact-pane seed creates file-backed artifact metadata without absolute paths', async () => {
     const workspaceRoot = await mkdtemp(join(tmpdir(), 'maka-e2e-fixture-artifact-'));
     try {
-      const fixture = resolveE2EFixture('artifact-pane', false);
+      const fixture = resolveE2eFixture('artifact-pane', false);
       assert.ok(fixture);
-      await seedE2EFixture({
+      await seedE2eFixture({
         workspaceRoot,
         fixture,
         credentialStore: fakeCredentialStore(),
         now: 1_700_000_000_000,
       });
-      const state = getE2EFixtureState(fixture);
+      const state = getE2eFixtureState(fixture);
       assert.equal(state?.activeSessionId, 'e2e-fixture-artifact');
 
       const metadata = (await readFile(join(workspaceRoot, 'artifacts', 'metadata.jsonl'), 'utf8'))
@@ -1093,16 +1093,16 @@ describe('e2e-fixture mode', () => {
     it('seeds primary + visible-parent branch + orphan branch sharing one on-disk state', async () => {
       const workspaceRoot = await mkdtemp(join(tmpdir(), 'maka-e2e-fixture-turn-control-'));
       try {
-        const fixture = resolveE2EFixture('turn-control-history', false);
+        const fixture = resolveE2eFixture('turn-control-history', false);
         assert.ok(fixture);
-        await seedE2EFixture({
+        await seedE2eFixture({
           workspaceRoot,
           fixture,
           credentialStore: fakeCredentialStore(),
           now: 1_700_000_000_000,
         });
 
-        const state = getE2EFixtureState(fixture);
+        const state = getE2eFixtureState(fixture);
         assert.equal(state?.activeSessionId, 'e2e-fixture-turn-control-primary');
 
         const primary = await readSessionHeader(workspaceRoot, 'e2e-fixture-turn-control-primary');
@@ -1139,9 +1139,9 @@ describe('e2e-fixture mode', () => {
     it('primary session log covers retry / regenerate / aborted / failed turns with TurnState messages', async () => {
       const workspaceRoot = await mkdtemp(join(tmpdir(), 'maka-e2e-fixture-turn-control-turns-'));
       try {
-        const fixture = resolveE2EFixture('turn-control-history', false);
+        const fixture = resolveE2eFixture('turn-control-history', false);
         assert.ok(fixture);
-        await seedE2EFixture({
+        await seedE2eFixture({
           workspaceRoot,
           fixture,
           credentialStore: fakeCredentialStore(),
@@ -1182,16 +1182,16 @@ describe('e2e-fixture mode', () => {
     });
 
     it('turn-control-branch-visible scenario flips active session to the visible-parent branch', () => {
-      const fixture = resolveE2EFixture('turn-control-branch-visible', false);
+      const fixture = resolveE2eFixture('turn-control-branch-visible', false);
       assert.ok(fixture);
-      const state = getE2EFixtureState(fixture);
+      const state = getE2eFixtureState(fixture);
       assert.equal(state?.activeSessionId, 'e2e-fixture-turn-control-branch-visible');
     });
 
     it('turn-control-branch-orphan scenario flips active session to the orphan branch', () => {
-      const fixture = resolveE2EFixture('turn-control-branch-orphan', false);
+      const fixture = resolveE2eFixture('turn-control-branch-orphan', false);
       assert.ok(fixture);
-      const state = getE2EFixtureState(fixture);
+      const state = getE2eFixtureState(fixture);
       assert.equal(state?.activeSessionId, 'e2e-fixture-turn-control-branch-orphan');
     });
 
@@ -1209,9 +1209,9 @@ describe('e2e-fixture mode', () => {
       for (const scenario of ['turn-control-history', 'turn-control-branch-visible', 'turn-control-branch-orphan'] as const) {
         const workspaceRoot = await mkdtemp(join(tmpdir(), `maka-e2e-fixture-tc-${scenario}-`));
         try {
-          const fixture = resolveE2EFixture(scenario, false);
+          const fixture = resolveE2eFixture(scenario, false);
           assert.ok(fixture);
-          await seedE2EFixture({
+          await seedE2eFixture({
             workspaceRoot,
             fixture,
             credentialStore: fakeCredentialStore(),
@@ -1242,15 +1242,15 @@ describe('e2e-fixture mode', () => {
   it('artifact-errors seed covers deleted, missing, and unsupported MIME preview states', async () => {
     const workspaceRoot = await mkdtemp(join(tmpdir(), 'maka-e2e-fixture-artifact-errors-'));
     try {
-      const fixture = resolveE2EFixture('artifact-errors', false);
+      const fixture = resolveE2eFixture('artifact-errors', false);
       assert.ok(fixture);
-      await seedE2EFixture({
+      await seedE2eFixture({
         workspaceRoot,
         fixture,
         credentialStore: fakeCredentialStore(),
         now: 1_700_000_000_000,
       });
-      const state = getE2EFixtureState(fixture);
+      const state = getE2eFixtureState(fixture);
       assert.equal(state?.activeSessionId, 'e2e-fixture-artifact');
 
       const metadata = (await readFile(join(workspaceRoot, 'artifacts', 'metadata.jsonl'), 'utf8'))
@@ -1279,9 +1279,9 @@ describe('e2e-fixture mode', () => {
 
 describe('settings-bots-onboarding fixture (#1233 deferral)', () => {
   it('opens 远程接入 and seeds the DingTalk provider so the scan-login modal auto-opens', () => {
-    const fixture = resolveE2EFixture('settings-bots-onboarding', false);
+    const fixture = resolveE2eFixture('settings-bots-onboarding', false);
     assert.ok(fixture, 'settings-bots-onboarding should resolve');
-    const state = getE2EFixtureState(fixture);
+    const state = getE2eFixtureState(fixture);
     assert.equal(state?.openSettingsSection, 'bot-chat');
     // botOnboardingProvider is the contract the renderer reads to jump to the
     // provider detail + auto-open the QR modal in its waiting state.
@@ -1294,9 +1294,9 @@ describe('settings-bots-onboarding fixture (#1233 deferral)', () => {
   it('reuses the standard turn seed so no bot-specific on-disk seed is needed', async () => {
     const workspaceRoot = await mkdtemp(join(tmpdir(), 'maka-e2e-fixture-bots-onboarding-'));
     try {
-      const fixture = resolveE2EFixture('settings-bots-onboarding', false);
+      const fixture = resolveE2eFixture('settings-bots-onboarding', false);
       assert.ok(fixture);
-      await seedE2EFixture({
+      await seedE2eFixture({
         workspaceRoot,
         fixture,
         credentialStore: fakeCredentialStore(),
@@ -1313,9 +1313,9 @@ describe('settings-bots-onboarding fixture (#1233 deferral)', () => {
 
 describe('browser-empty chrome fixture (#819)', () => {
   it('seeds a live browser session id so BrowserPanel mounts over the turn chat in empty state', () => {
-    const fixture = resolveE2EFixture('browser-empty', false);
+    const fixture = resolveE2eFixture('browser-empty', false);
     assert.ok(fixture, 'browser-empty should resolve');
-    const state = getE2EFixtureState(fixture);
+    const state = getE2eFixtureState(fixture);
     // Active session is the standard turn session so the chat surface
     // behind the browser panel renders meaningful context.
     assert.equal(state?.activeSessionId, 'e2e-fixture-turn');
@@ -1331,9 +1331,9 @@ describe('browser-empty chrome fixture (#819)', () => {
   it('reuses the always-seeded turn session so no browser-specific on-disk seed is needed', async () => {
     const workspaceRoot = await mkdtemp(join(tmpdir(), 'maka-e2e-fixture-browser-empty-'));
     try {
-      const fixture = resolveE2EFixture('browser-empty', false);
+      const fixture = resolveE2eFixture('browser-empty', false);
       assert.ok(fixture);
-      await seedE2EFixture({
+      await seedE2eFixture({
         workspaceRoot,
         fixture,
         credentialStore: fakeCredentialStore(),

--- a/apps/desktop/src/main/__tests__/e2e-fixture.test.ts
+++ b/apps/desktop/src/main/__tests__/e2e-fixture.test.ts
@@ -460,7 +460,7 @@ describe('e2e-fixture mode', () => {
 
       const state = getE2eFixtureState(fixture);
       // @kenji gate: active session intentionally one of the stale ones so
-      // the alignment audit can prove "active + stale → pill still visible".
+      // the "active + stale → pill still visible" invariant is exercised.
       assert.equal(state?.activeSessionId, 'e2e-fixture-stale-fake');
 
       // Connection list MUST NOT contain `fake` / `fake-claude` slugs —
@@ -775,7 +775,7 @@ describe('e2e-fixture mode', () => {
     // sessions` is `E2eFixtureState.searchModalOpen=true`, which
     // the renderer reads to call `setSearchModalOpen(true)` before
     // the fixture settles, so the SearchModal shell is on screen
-    // for the alignment audit.
+    // deterministically.
     const workspaceRoot = await mkdtemp(join(tmpdir(), 'maka-e2e-fixture-search-modal-'));
     try {
       const fixture = resolveE2eFixture('sidebar-search-modal-open', false);
@@ -892,9 +892,7 @@ describe('e2e-fixture mode', () => {
      * field intentionally contains a workspace-relative path (the
      * registry uses it to read the file), but the UI must NEVER
      * surface it. We check the *fixture* metadata here, which is
-     * the source of truth the renderer consumes. The smoke
-     * pipeline's PNG diff covers the rendered DOM separately;
-     * here we lock the input.
+     * the source of truth the renderer consumes; here we lock the input.
      */
     function assertNoAbsolutePathInMetadata(line: string) {
       assert.equal(line.includes('/Users/'), false, `metadata leak: /Users/ in ${line}`);

--- a/apps/desktop/src/main/__tests__/empty-hero-day-period.test.ts
+++ b/apps/desktop/src/main/__tests__/empty-hero-day-period.test.ts
@@ -2,7 +2,7 @@
  * Tests for the PR-UI-LAYOUT-4 / B1-a1 review fixup
  * `detectDayPeriod` boundary contract (@kenji msg 1d7ba56c).
  *
- * Visual-smoke fixtures freeze `Date.now()` to a deterministic
+ * E2e-fixture renders freeze `Date.now()` to a deterministic
  * timestamp; the EmptyChatHero greeting prefix would drift across
  * the 5/11/14/18-hour boundaries if `detectDayPeriod()` read
  * `new Date()` instead. The function now accepts an explicit

--- a/apps/desktop/src/main/__tests__/empty-hero-day-period.test.ts
+++ b/apps/desktop/src/main/__tests__/empty-hero-day-period.test.ts
@@ -61,7 +61,7 @@ describe('detectDayPeriod — day-period bucket boundaries', () => {
 describe('detectDayPeriod — e2e-fixture determinism', () => {
   it('reads Date.now() by default (so the renderer freeze flows through)', () => {
     // Stub Date.now (same trick the renderer uses in
-    // `applyE2EFixture` when `state.now` is set) and verify
+    // `applyE2eFixture` when `state.now` is set) and verify
     // the function uses it without us passing an explicit arg.
     const originalNow = Date.now;
     try {

--- a/apps/desktop/src/main/__tests__/empty-hero-day-period.test.ts
+++ b/apps/desktop/src/main/__tests__/empty-hero-day-period.test.ts
@@ -7,7 +7,7 @@
  * the 5/11/14/18-hour boundaries if `detectDayPeriod()` read
  * `new Date()` instead. The function now accepts an explicit
  * `nowMs: number` argument that defaults to `Date.now()`, so the
- * visual-smoke clock freeze flows through automatically.
+ * e2e-fixture clock freeze flows through automatically.
  *
  * Each test passes an explicit local-time hour so the boundary
  * is testable without any clock dependency.
@@ -19,7 +19,7 @@ import { detectDayPeriod } from '@maka/ui';
 
 /**
  * Build a millisecond timestamp at the requested LOCAL hour on
- * 2026-05-22 (the canonical visual-smoke fixture day). Using local
+ * 2026-05-22 (the canonical e2e-fixture fixture day). Using local
  * time matches what `detectDayPeriod` reads (`new Date(ms).getHours()`).
  */
 function localHour(hour: number, minute = 0): number {
@@ -58,10 +58,10 @@ describe('detectDayPeriod — day-period bucket boundaries', () => {
   });
 });
 
-describe('detectDayPeriod — visual-smoke determinism', () => {
+describe('detectDayPeriod — e2e-fixture determinism', () => {
   it('reads Date.now() by default (so the renderer freeze flows through)', () => {
     // Stub Date.now (same trick the renderer uses in
-    // `applyVisualSmokeFixture` when `state.now` is set) and verify
+    // `applyE2EFixture` when `state.now` is set) and verify
     // the function uses it without us passing an explicit arg.
     const originalNow = Date.now;
     try {

--- a/apps/desktop/src/main/__tests__/motion-token-converge-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/motion-token-converge-contract.test.ts
@@ -243,7 +243,7 @@ describe('PR-MOTION-TOKEN-CONVERGE-0 contract', () => {
     const offenders: string[] = [];
     for (const m of stripped.matchAll(/\b(\d+(?:\.\d+)?)ms\b/g)) {
       const value = m[1];
-      // 0ms (disable transition) + 0.01ms (prefers-reduced-motion / visual-smoke) are a11y/test hacks
+      // 0ms (disable transition) + 0.01ms (prefers-reduced-motion / e2e-fixture) are a11y/test hacks
       if (value === '0' || value === '0.01') continue;
       offenders.push(`${value}ms`);
     }

--- a/apps/desktop/src/main/__tests__/reactive-locale-foundation-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/reactive-locale-foundation-contract.test.ts
@@ -80,17 +80,17 @@ describe('reactive locale foundation', () => {
     assert.doesNotMatch(theme, /applyUiLocale|UiLocalePreference/);
   });
 
-  it('keeps visual-smoke locale overrides in the same provider path', () => {
-    const source = rendererSource('app-shell-visual-smoke.ts');
+  it('keeps e2e-fixture locale overrides in the same provider path', () => {
+    const source = rendererSource('app-shell-e2e-fixture.ts');
     const shellAppearance = rendererSource('use-shell-appearance.ts');
 
     assert.match(source, /setUiLocaleOverride: Dispatch<SetStateAction<UiLocale \| null>>/);
     assert.match(source, /setUiLocaleOverride\(state\.locale \?\? null\)/);
-    assert.doesNotMatch(source, /data-maka-visual-smoke-locale/);
+    assert.doesNotMatch(source, /data-maka-e2e-fixture-locale/);
     assert.ok(
       shellAppearance.indexOf('setUiLocaleOverride(smoke?.locale ?? null)')
         < shellAppearance.indexOf('uiLocaleUpdateGate.commitHydration('),
-      'visual-smoke override hydration must not be gated by persisted preference hydration',
+      'e2e-fixture override hydration must not be gated by persisted preference hydration',
     );
   });
 

--- a/apps/desktop/src/main/__tests__/reactive-locale-foundation-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/reactive-locale-foundation-contract.test.ts
@@ -37,7 +37,7 @@ describe('reactive locale foundation', () => {
       'AppShell must derive one locale exactly once',
     );
     assert.match(shellAppearance, /setUiLocalePreference\(preference\)/);
-    assert.match(shellAppearance, /setUiLocaleOverride\(smoke\?\.locale \?\? null\)/);
+    assert.match(shellAppearance, /setUiLocaleOverride\(fixtureState\?\.locale \?\? null\)/);
     assert.match(
       source,
       /<LocaleProvider locale=\{uiLocale\} override=\{uiLocaleOverride\}>[\s\S]*?<ToastProvider>[\s\S]*?<AppShellOverlays/,
@@ -88,7 +88,7 @@ describe('reactive locale foundation', () => {
     assert.match(source, /setUiLocaleOverride\(state\.locale \?\? null\)/);
     assert.doesNotMatch(source, /data-maka-e2e-fixture-locale/);
     assert.ok(
-      shellAppearance.indexOf('setUiLocaleOverride(smoke?.locale ?? null)')
+      shellAppearance.indexOf('setUiLocaleOverride(fixtureState?.locale ?? null)')
         < shellAppearance.indexOf('uiLocaleUpdateGate.commitHydration('),
       'e2e-fixture override hydration must not be gated by persisted preference hydration',
     );

--- a/apps/desktop/src/main/__tests__/real-window-smoke-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/real-window-smoke-contract.test.ts
@@ -70,7 +70,7 @@ describe('real Electron window smoke gate', () => {
       assert.match(src, new RegExp(`id:\\s*['"]${escapeRegExp(id)}['"]`));
     }
     assert.match(src, /--user-data-dir=/, 'real-window smoke must isolate Electron user data');
-    assert.match(src, /MAKA_VISUAL_SMOKE_FIXTURE/, 'real-window smoke must launch a deterministic fixture');
+    assert.match(src, /MAKA_E2E_FIXTURE/, 'real-window smoke must launch a deterministic fixture');
     assert.match(src, /cleanupStaleElectronProcesses/, 'real-window smoke must clean/report stale Electron smoke processes');
     assert.match(src, /electronPid/, 'real-window smoke report must record the launched Electron pid');
     assert.match(src, /Launch command/, 'real-window smoke report must record the launch command');

--- a/apps/desktop/src/main/__tests__/renderer-important-audit-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/renderer-important-audit-contract.test.ts
@@ -143,6 +143,27 @@ function findFieldFocusSelector(source: string): string | null {
 }
 
 describe('renderer !important audit contract', () => {
+  it('keeps the e2e-fixture deterministic-render CSS hooks in sync with the renderer attribute write', async () => {
+    // The renderer writes `data-maka-e2e-fixture="true"` on <html>
+    // (app-shell-e2e-fixture.ts); base.css must pause decorative
+    // animation and sidebar.css must stop the running-status spinner
+    // under that attribute, or fixture renders drift non-deterministically.
+    // base.css is an isA11yOnlyFile in the !important audit below (skipped
+    // wholesale), so this asserts the selectors directly.
+    const base = await readFile(`${REPO_ROOT}/apps/desktop/src/renderer/styles/base.css`, 'utf8');
+    const sidebar = await readFile(`${REPO_ROOT}/apps/desktop/src/renderer/styles/sidebar.css`, 'utf8');
+    assert.match(
+      base,
+      /\[data-maka-e2e-fixture="true"\] \*/,
+      'base.css must pause decorative animation under the e2e-fixture attribute',
+    );
+    assert.match(
+      sidebar,
+      /\[data-maka-e2e-fixture="true"\] \.maka-list-row-status-icon\[data-status="running"\] svg/,
+      'sidebar.css must stop the running-status spinner under the e2e-fixture attribute',
+    );
+  });
+
   it('keeps non-a11y `!important` sites explicitly justified and allowlisted', async () => {
     const rendererRoot = `${REPO_ROOT}/apps/desktop/src/renderer`;
     const styleFiles = [

--- a/apps/desktop/src/main/__tests__/renderer-important-audit-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/renderer-important-audit-contract.test.ts
@@ -28,8 +28,8 @@ const ALLOWLIST: ImportantAllowance[] = [
   },
   {
     fileSuffix: 'apps/desktop/src/renderer/styles/base.css',
-    anchor: '[data-maka-visual-smoke="true"] *',
-    reason: 'deterministic visual smoke fixture override',
+    anchor: '[data-maka-e2e-fixture="true"] *',
+    reason: 'deterministic e2e-fixture override',
   },
   {
     fileSuffix: 'apps/desktop/src/renderer/maka-tokens.css',

--- a/apps/desktop/src/main/__tests__/renderer-shell-source-helpers.ts
+++ b/apps/desktop/src/main/__tests__/renderer-shell-source-helpers.ts
@@ -47,7 +47,7 @@ const sourcePaths = [
   'chat-workbar.tsx',
   'use-shell-appearance.ts',
   'use-shell-search.ts',
-  'app-shell-visual-smoke.ts',
+  'app-shell-e2e-fixture.ts',
   'cached-theme-bootstrap.ts',
   'chat-model-selection.ts',
   'conversation-markdown.ts',

--- a/apps/desktop/src/main/__tests__/renderer-startup-fail-soft-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/renderer-startup-fail-soft-contract.test.ts
@@ -42,7 +42,7 @@ describe('renderer startup fail-soft contract', () => {
     assert.match(mountEffect, /void (?:options\.|latest\.)?refreshShellSettings\(\)/);
     assert.match(
       refreshShellSettings,
-      /try \{[\s\S]*window\.maka\.settings\.get\(\)[\s\S]*setUiLocaleOverride\(smoke\?\.locale \?\? null\)[\s\S]*uiLocaleUpdateGate\.commitHydration\([\s\S]*setUiLocalePreference\(preference\)[\s\S]*applyTheme\(pref\)[\s\S]*applyThemePalette\(palette\)[\s\S]*\} catch \(error\) \{[\s\S]*const copy = getShellCopy\(uiLocale\)\.app;[\s\S]*toastApi\.error\([\s\S]*copy\.appearanceLoadErrorTitle,[\s\S]*localizedShellErrorMessage\(error, copy\.appearanceLoadErrorFallback, uiLocale\)/,
+      /try \{[\s\S]*window\.maka\.settings\.get\(\)[\s\S]*setUiLocaleOverride\(fixtureState\?\.locale \?\? null\)[\s\S]*uiLocaleUpdateGate\.commitHydration\([\s\S]*setUiLocalePreference\(preference\)[\s\S]*applyTheme\(pref\)[\s\S]*applyThemePalette\(palette\)[\s\S]*\} catch \(error\) \{[\s\S]*const copy = getShellCopy\(uiLocale\)\.app;[\s\S]*toastApi\.error\([\s\S]*copy\.appearanceLoadErrorTitle,[\s\S]*localizedShellErrorMessage\(error, copy\.appearanceLoadErrorFallback, uiLocale\)/,
       'startup shell settings load failures must surface visibly without exposing raw storage/system details',
     );
     assert.doesNotMatch(refreshShellSettings, /toastApi\.error\('载入外观设置失败', cleanErrorMessage\(error\)\)/);

--- a/apps/desktop/src/main/__tests__/scroll-motion-policy.test.ts
+++ b/apps/desktop/src/main/__tests__/scroll-motion-policy.test.ts
@@ -3,10 +3,10 @@
  *
  * @kenji + @xuan review gate: the lineage badge click + future
  * branch-banner navigation must collapse smooth scrolling to `auto`
- * inside the visual-smoke fixture so screenshots stay deterministic.
- * @xuan confirmed on main that visual-smoke ALWAYS writes
- * `data-maka-visual-smoke="true"` but `data-maka-reduced-motion="true"`
- * is only on the reduced variant — so the visual-smoke flag is the
+ * inside the e2e-fixture fixture so screenshots stay deterministic.
+ * @xuan confirmed on main that e2e-fixture ALWAYS writes
+ * `data-maka-e2e-fixture="true"` but `data-maka-reduced-motion="true"`
+ * is only on the reduced variant — so the e2e-fixture flag is the
  * primary signal, not the reduced-motion attribute.
  */
 
@@ -20,7 +20,7 @@ import {
 function inputs(partial: Partial<ScrollMotionPolicyInputs>): ScrollMotionPolicyInputs {
   return {
     reducedMotionAttr: false,
-    visualSmokeAttr: false,
+    e2eFixtureAttr: false,
     prefersReducedMotion: false,
     ...partial,
   };
@@ -38,12 +38,12 @@ describe('resolveScrollMotionBehavior', () => {
     );
   });
 
-  it('returns "auto" when visual-smoke attr is set (any PR-IR-02 capture)', () => {
-    // @xuan PR109f: visual-smoke fixture writes this attribute on every
+  it('returns "auto" when e2e-fixture attr is set (any PR-IR-02 capture)', () => {
+    // @xuan PR109f: e2e-fixture fixture writes this attribute on every
     // capture, regardless of variant. We must collapse smooth scroll
     // even if reduced-motion attr is absent.
     assert.equal(
-      resolveScrollMotionBehavior(inputs({ visualSmokeAttr: true })),
+      resolveScrollMotionBehavior(inputs({ e2eFixtureAttr: true })),
       'auto',
     );
   });
@@ -57,24 +57,24 @@ describe('resolveScrollMotionBehavior', () => {
 
   it('returns "auto" when any combination of triggers is set', () => {
     for (const combo of [
-      { reducedMotionAttr: true, visualSmokeAttr: true },
+      { reducedMotionAttr: true, e2eFixtureAttr: true },
       { reducedMotionAttr: true, prefersReducedMotion: true },
-      { visualSmokeAttr: true, prefersReducedMotion: true },
-      { reducedMotionAttr: true, visualSmokeAttr: true, prefersReducedMotion: true },
+      { e2eFixtureAttr: true, prefersReducedMotion: true },
+      { reducedMotionAttr: true, e2eFixtureAttr: true, prefersReducedMotion: true },
     ] as Array<Partial<ScrollMotionPolicyInputs>>) {
       assert.equal(resolveScrollMotionBehavior(inputs(combo)), 'auto');
     }
   });
 
-  it('@xuan PR109f: visual-smoke alone is sufficient (reduced-motion attr NOT required)', () => {
+  it('@xuan PR109f: e2e-fixture alone is sufficient (reduced-motion attr NOT required)', () => {
     // Regression: an earlier version only checked reduced-motion attr,
-    // which let smooth scrolling leak into the unmodified visual-smoke
-    // capture path. Confirm visual-smoke alone triggers `auto`.
+    // which let smooth scrolling leak into the unmodified e2e-fixture
+    // capture path. Confirm e2e-fixture alone triggers `auto`.
     assert.equal(
       resolveScrollMotionBehavior(
         inputs({
           reducedMotionAttr: false,
-          visualSmokeAttr: true,
+          e2eFixtureAttr: true,
           prefersReducedMotion: false,
         }),
       ),

--- a/apps/desktop/src/main/__tests__/search-modal-lifecycle-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/search-modal-lifecycle-contract.test.ts
@@ -21,9 +21,9 @@
  * desktop test setup has no DOM); the runtime exercise of the
  * mount/unmount cycle is covered by:
  *   - The `sidebar-search-modal-open` e2e-fixture scenario, which
- *     forces the modal open at startup and captures a screenshot
+ *     forces the modal open at startup
  *     (verifies it can MOUNT cleanly).
- *   - The `sidebar-long-sessions` scenario, which captures the
+ *   - The `sidebar-long-sessions` scenario, which renders the
  *     default state (verifies the renderer mounts cleanly WITHOUT
  *     the modal — the parent's `&&` guard skips the SearchModal
  *     subtree).

--- a/apps/desktop/src/main/__tests__/search-modal-lifecycle-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/search-modal-lifecycle-contract.test.ts
@@ -20,7 +20,7 @@
  * This file is a grep-style gate. It does NOT mount React (the
  * desktop test setup has no DOM); the runtime exercise of the
  * mount/unmount cycle is covered by:
- *   - The `sidebar-search-modal-open` visual-smoke scenario, which
+ *   - The `sidebar-search-modal-open` e2e-fixture scenario, which
  *     forces the modal open at startup and captures a screenshot
  *     (verifies it can MOUNT cleanly).
  *   - The `sidebar-long-sessions` scenario, which captures the
@@ -213,7 +213,7 @@ describe('SearchModal lifecycle contract (PR-SIDEBAR-IA-0 Phase 3 P0 fixup)', ()
     assert.match(
       chatScroll,
       /function scrollToBottom\(\) \{[\s\S]*scrollTo\(\{\s*top:\s*viewport\.scrollHeight,\s*behavior:\s*input\.behavior\s*\?\?\s*'smooth'\s*\}\);/,
-      'ChatView jump-to-latest must honor the same reduced-motion/visual-smoke scroll policy as search navigation',
+      'ChatView jump-to-latest must honor the same reduced-motion/e2e-fixture scroll policy as search navigation',
     );
     assert.match(
       chatScroll,

--- a/apps/desktop/src/main/__tests__/session-status-grouping.test.ts
+++ b/apps/desktop/src/main/__tests__/session-status-grouping.test.ts
@@ -3,7 +3,7 @@
  *
  * The group order is locked at the renderer + design-system level
  * (@kenji review). Future edits MUST update this test alongside the
- * helper or the smoke screenshot baseline goes stale silently.
+ * helper or the sidebar status-grouping contract goes stale silently.
  */
 
 import { strict as assert } from 'node:assert';

--- a/apps/desktop/src/main/__tests__/turn-control-matrix.test.ts
+++ b/apps/desktop/src/main/__tests__/turn-control-matrix.test.ts
@@ -103,7 +103,7 @@ describe('turn-control-history matrix', () => {
     // The inline "(已中断)" marker for an aborted turn (not session)
     // is rendered directly in components.tsx; we don't unit-test the
     // copy here to avoid duplicating the JSX literal. Visual placement
-    // is covered by the deterministic screenshot fixture.
+    // lives in that component, not this helper.
   });
 
   describe('S6 no raw enum leaks (regression-proof)', () => {

--- a/apps/desktop/src/main/__tests__/turn-control-matrix.test.ts
+++ b/apps/desktop/src/main/__tests__/turn-control-matrix.test.ts
@@ -87,7 +87,7 @@ describe('turn-control-history matrix', () => {
 
     it('the fixture seed uses `timeout` which maps to "请求超时"', () => {
       // Documents the exact seed → label binding so a reviewer reading
-      // the screenshot knows what copy to expect.
+      // the fixture knows what copy to expect.
       assert.match(describeTurnErrorClass('timeout'), /请求超时/);
     });
   });
@@ -229,14 +229,14 @@ describe('turn-control-history matrix', () => {
       // helper level: an active session with parentSessionId set, but
       // the parent is NOT in the sessions list.
       const orphanActive = {
-        id: 'visual-smoke-turn-control-branch-orphan',
+        id: 'e2e-fixture-turn-control-branch-orphan',
         name: '父会话已删除的分支',
-        parentSessionId: 'visual-smoke-turn-control-deleted-parent',
+        parentSessionId: 'e2e-fixture-turn-control-deleted-parent',
       };
       const visibleSessions = [
         orphanActive,
-        { id: 'visual-smoke-turn-control-primary', name: '回合控制示例（原会话）' },
-        { id: 'visual-smoke-turn-control-branch-visible', name: '从原会话分出的探索', parentSessionId: 'visual-smoke-turn-control-primary' },
+        { id: 'e2e-fixture-turn-control-primary', name: '回合控制示例（原会话）' },
+        { id: 'e2e-fixture-turn-control-branch-visible', name: '从原会话分出的探索', parentSessionId: 'e2e-fixture-turn-control-primary' },
       ];
       const banner = deriveBranchBanner(orphanActive, visibleSessions);
       // ChatView renders banner via `{props.branchBanner && ...}` —
@@ -245,11 +245,11 @@ describe('turn-control-history matrix', () => {
     });
 
     it('visible-parent active session with parent in list DOES return a banner (positive case)', () => {
-      const primary = { id: 'visual-smoke-turn-control-primary', name: '回合控制示例（原会话）' };
+      const primary = { id: 'e2e-fixture-turn-control-primary', name: '回合控制示例（原会话）' };
       const branch = {
-        id: 'visual-smoke-turn-control-branch-visible',
+        id: 'e2e-fixture-turn-control-branch-visible',
         name: '从原会话分出的探索',
-        parentSessionId: 'visual-smoke-turn-control-primary',
+        parentSessionId: 'e2e-fixture-turn-control-primary',
       };
       const banner = deriveBranchBanner(branch, [primary, branch]);
       assert.ok(banner, 'visible-parent branch should produce a banner');

--- a/apps/desktop/src/main/__tests__/turn-control-matrix.test.ts
+++ b/apps/desktop/src/main/__tests__/turn-control-matrix.test.ts
@@ -1,9 +1,9 @@
 /**
  * Locks the observable signals for the
  * turn-control-history fixture, at the helper layer (no DOM /
- * Electron). The deterministic fixture verifies the same matrix against
- * rendered screenshots; this test exists so a regression in the
- * helpers gets caught before the E2E specs run.
+ * Electron). The deterministic fixture renders the same matrix; this
+ * test exists so a regression in the helpers gets caught early at the
+ * pure-helper layer, before any DOM/Electron run.
  *
  *  S1 Failed banner copy comes from `describeTurnErrorClass` — Chinese
  *     generalized phrasing, never the raw enum.

--- a/apps/desktop/src/main/__tests__/turn-control-matrix.test.ts
+++ b/apps/desktop/src/main/__tests__/turn-control-matrix.test.ts
@@ -3,7 +3,7 @@
  * turn-control-history fixture, at the helper layer (no DOM /
  * Electron). The deterministic fixture verifies the same matrix against
  * rendered screenshots; this test exists so a regression in the
- * helpers gets caught before screenshot CI runs.
+ * helpers gets caught before the E2E specs run.
  *
  *  S1 Failed banner copy comes from `describeTurnErrorClass` — Chinese
  *     generalized phrasing, never the raw enum.
@@ -11,7 +11,7 @@
  *  S3 Lineage badges produce stable Chinese copy with direction tags.
  *  S4 Branch banner only renders when parent is in the sessions list
  *     (covered separately in branch-banner.test.ts; cross-linked here).
- *  S5 Visual-smoke flag is enough to collapse smooth scroll to auto
+ *  S5 The e2e-fixture flag is enough to collapse smooth scroll to auto
  *     (covered separately in scroll-motion-policy.test.ts).
  *  S6 No raw enum identifier from `errorClass` / `SessionBlockedReason`
  *     leaks into the user-facing strings.

--- a/apps/desktop/src/main/__tests__/use-onboarding-snapshot.test.ts
+++ b/apps/desktop/src/main/__tests__/use-onboarding-snapshot.test.ts
@@ -6,7 +6,7 @@
  * `createOnboardingSnapshotPoller`. We test the pure poller here —
  * stale-response defense, lifecycle gating, error handling — and
  * verify the helper predicate `isSetupRequired`. The React wiring is
- * covered by the e2e-fixture + manual UI testing in PR110d.
+ * covered by Playwright E2E + manual UI testing in PR110d.
  */
 
 import { strict as assert } from 'node:assert';

--- a/apps/desktop/src/main/__tests__/use-onboarding-snapshot.test.ts
+++ b/apps/desktop/src/main/__tests__/use-onboarding-snapshot.test.ts
@@ -6,7 +6,7 @@
  * `createOnboardingSnapshotPoller`. We test the pure poller here —
  * stale-response defense, lifecycle gating, error handling — and
  * verify the helper predicate `isSetupRequired`. The React wiring is
- * covered by smoke + manual UI testing in PR110d.
+ * covered by the e2e-fixture + manual UI testing in PR110d.
  */
 
 import { strict as assert } from 'node:assert';

--- a/apps/desktop/src/main/__tests__/visible-copy-hygiene-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/visible-copy-hygiene-contract.test.ts
@@ -4,7 +4,7 @@
  *
  * Background:
  *   WAWQAQ noticed `建文` showing up in his real chat surface
- *   (msg `1886c41b`). Tracing it back: the visual-smoke fixture
+ *   (msg `1886c41b`). Tracing it back: the e2e-fixture fixture
  *   seeded `personalization.displayName = '建文'` for screenshot
  *   determinism, but that placeholder name has no product
  *   meaning — a user opening a demo workspace (or anyone
@@ -29,7 +29,7 @@ import { describe, it } from 'node:test';
 import { join, resolve } from 'node:path';
 import { readRendererContractCss } from './contract-css-helpers.js';
 import { RENDERER_SHELL_SOURCE_REPO_PATHS } from './renderer-shell-source-helpers.js';
-import { VISUAL_SMOKE_FIXTURE_SOURCE_REPO_PATHS } from './visual-smoke-fixture-source-helpers.js';
+import { E2E_FIXTURE_SOURCE_REPO_PATHS } from './e2e-fixture-source-helpers.js';
 
 // Cwd is `apps/desktop` when the test runs (per the existing
 // sidebar-scroll-contract pattern).
@@ -54,10 +54,10 @@ const FILES_TO_SCAN = [
   join(process.cwd(), 'src', 'renderer', 'onboarding-hero-copy.ts'),
   join(process.cwd(), 'src', 'renderer', 'session-health-notice.ts'),
   join(process.cwd(), 'src', 'main', 'chat-readiness.ts'),
-  // arch Round 3: the visual-smoke fixture split into a registry barrel +
+  // arch Round 3: the e2e-fixture fixture split into a registry barrel +
   // per-domain seeder modules; scan them all so the seeded-copy hygiene
   // coverage follows the copy into its new homes.
-  ...VISUAL_SMOKE_FIXTURE_SOURCE_REPO_PATHS.map((repoPath) => resolve(process.cwd(), '..', '..', repoPath)),
+  ...E2E_FIXTURE_SOURCE_REPO_PATHS.map((repoPath) => resolve(process.cwd(), '..', '..', repoPath)),
 ];
 
 interface ForbiddenCopy {
@@ -144,10 +144,10 @@ const FORBIDDEN_VISIBLE_COPY: ForbiddenCopy[] = [
       "artifact preview fallback copy must explain the product capability boundary in user terms, not expose renderer implementation details like a preview registry or internal `artifact` naming.",
   },
   {
-    label: 'visual-smoke fixture seeded visible copy leaks implementation terms',
+    label: 'e2e-fixture fixture seeded visible copy leaks implementation terms',
     needle: /Artifact Pane|artifact pane|artifact fixture|(?:生成|已生成)\s*(?:\d+\s*个|三个)\s*artifact|Claude backend|HTML artifact|Artifact Smoke Report|Pane Smoke Report|视觉 smoke|provider capability|ModelTable|source\/fetchedAt|test gate/,
     reason:
-      "visual-smoke fixture chat messages and file contents appear in screenshots/baseline workspaces; they should use product-facing Chinese copy rather than internal fixture/backend/artifact labels.",
+      "e2e-fixture fixture chat messages and file contents appear in screenshots/baseline workspaces; they should use product-facing Chinese copy rather than internal fixture/backend/artifact labels.",
   },
   {
     label: 'English hidden-line markers in tool previews',

--- a/apps/desktop/src/main/__tests__/visible-copy-hygiene-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/visible-copy-hygiene-contract.test.ts
@@ -147,7 +147,7 @@ const FORBIDDEN_VISIBLE_COPY: ForbiddenCopy[] = [
     label: 'e2e-fixture fixture seeded visible copy leaks implementation terms',
     needle: /Artifact Pane|artifact pane|artifact fixture|(?:生成|已生成)\s*(?:\d+\s*个|三个)\s*artifact|Claude backend|HTML artifact|Artifact Smoke Report|Pane Smoke Report|视觉 smoke|provider capability|ModelTable|source\/fetchedAt|test gate/,
     reason:
-      "e2e-fixture fixture chat messages and file contents appear in screenshots/baseline workspaces; they should use product-facing Chinese copy rather than internal fixture/backend/artifact labels.",
+      "e2e-fixture fixture chat messages and file contents are visible in the rendered fixture; they should use product-facing Chinese copy rather than internal fixture/backend/artifact labels.",
   },
   {
     label: 'English hidden-line markers in tool previews',

--- a/apps/desktop/src/main/__tests__/window-reveal-after-first-commit-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/window-reveal-after-first-commit-contract.test.ts
@@ -158,13 +158,13 @@ describe('window reveal gate defers early focus (ChatGPT Pro review P2)', () => 
     readyGate.requestMaximize(readyWin);
     assert.equal(readyWin.maximizeCount, 1);
 
-    const smokeGate = createWindowRevealGate(true);
-    const smokeWin = makeFakeFocusableWindow();
-    smokeGate.requestMaximize(smokeWin);
-    smokeGate.markReady(smokeWin);
-    smokeGate.requestMaximize(smokeWin);
-    assert.equal(smokeWin.maximizeCount, 0);
-    assert.equal(smokeWin.isVisible(), false);
+    const fixtureGate = createWindowRevealGate(true);
+    const fixtureWin = makeFakeFocusableWindow();
+    fixtureGate.requestMaximize(fixtureWin);
+    fixtureGate.markReady(fixtureWin);
+    fixtureGate.requestMaximize(fixtureWin);
+    assert.equal(fixtureWin.maximizeCount, 0);
+    assert.equal(fixtureWin.isVisible(), false);
   });
 
   it('reset() re-arms the gate for a recreated window (macOS close-all)', () => {
@@ -283,7 +283,7 @@ describe('window reveal wiring (PR-SHOW-AFTER-FIRST-COMMIT)', () => {
     // must clear on close.
     assert.match(
       src,
-      /if \(!keepHiddenForE2EFixture && !mainWindow\.isVisible\(\)\) \{\s*showFallbackTimer = setTimeout/,
+      /if \(!keepHiddenForE2eFixture && !mainWindow\.isVisible\(\)\) \{\s*showFallbackTimer = setTimeout/,
     );
     assert.match(
       src,

--- a/apps/desktop/src/main/__tests__/window-reveal-after-first-commit-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/window-reveal-after-first-commit-contract.test.ts
@@ -5,7 +5,7 @@
  * flashes the index.html `.maka-preload` skeleton before React paints. The
  * renderer signals `window:notifyRendererReady` after its first React commit,
  * and a fallback timer reveals the window if that signal never arrives. Under
- * visual-smoke capture the window must stay hidden for its whole life.
+ * e2e-fixture capture the window must stay hidden for its whole life.
  *
  * The reveal decision lives in showWindowOnceReady (window-reveal.ts) precisely
  * so it can be exercised behaviorally here — main-window.ts can't be imported
@@ -122,7 +122,7 @@ describe('window reveal gate defers early focus (ChatGPT Pro review P2)', () => 
     assert.equal(win.focusCount, 1);
   });
 
-  it('keepHidden (visual-smoke / E2E) never shows or focuses from any path', () => {
+  it('keepHidden (e2e-fixture / E2E) never shows or focuses from any path', () => {
     const gate = createWindowRevealGate(true);
     const win = makeFakeFocusableWindow();
     gate.requestFocus(win);
@@ -209,7 +209,7 @@ describe('window reveal gate (PR-SHOW-AFTER-FIRST-COMMIT)', () => {
     assert.equal(win.isVisible(), true);
   });
 
-  it('visual-smoke (keepHidden) never reveals, from either the signal or the timer', () => {
+  it('e2e-fixture (keepHidden) never reveals, from either the signal or the timer', () => {
     const win = makeFakeWindow();
     // Renderer-ready path.
     showWindowOnceReady(win, true);
@@ -279,11 +279,11 @@ describe('window reveal wiring (PR-SHOW-AFTER-FIRST-COMMIT)', () => {
     assert.notEqual(rendererLoadIndex, -1);
     assert.notEqual(fallbackTimerIndex, -1);
     assert.ok(fallbackTimerIndex > rendererLoadIndex, 'fallback must start after renderer load');
-    // Timer must not run for visual-smoke or already-revealed windows, and
+    // Timer must not run for e2e-fixture or already-revealed windows, and
     // must clear on close.
     assert.match(
       src,
-      /if \(!keepHiddenForVisualSmoke && !mainWindow\.isVisible\(\)\) \{\s*showFallbackTimer = setTimeout/,
+      /if \(!keepHiddenForE2EFixture && !mainWindow\.isVisible\(\)\) \{\s*showFallbackTimer = setTimeout/,
     );
     assert.match(
       src,

--- a/apps/desktop/src/main/app-ipc-main.ts
+++ b/apps/desktop/src/main/app-ipc-main.ts
@@ -5,11 +5,11 @@ import { resolveProjectGitInfo, resolveProjectRoot } from '@maka/runtime';
 import type { createMainWindowController } from './main-window.js';
 import type { ProjectRootController } from './project-root-controller.js';
 import { resolveOpenPath, type OpenPathResult } from './open-path-guard.js';
-import { getE2EFixtureState, type resolveE2EFixture } from './e2e-fixture.js';
+import { getE2eFixtureState, type resolveE2eFixture } from './e2e-fixture.js';
 import type { resolveBuildInfo } from './build-info.js';
 
 type MainWindowController = ReturnType<typeof createMainWindowController>;
-type E2EFixture = ReturnType<typeof resolveE2EFixture>;
+type E2eFixture = ReturnType<typeof resolveE2eFixture>;
 type BuildInfo = ReturnType<typeof resolveBuildInfo>;
 
 export interface AppIpcDeps {
@@ -19,7 +19,7 @@ export interface AppIpcDeps {
   getProjectRoot(sessionId: unknown): Promise<string>;
   workspaceRoot: string;
   buildInfo: BuildInfo;
-  e2eFixture: E2EFixture;
+  e2eFixture: E2eFixture;
 }
 
 export function registerAppIpc(deps: AppIpcDeps): void {
@@ -140,5 +140,5 @@ export function registerAppIpc(deps: AppIpcDeps): void {
       return { ok: true, projectPath: resolved, projectGit: await resolveProjectGitInfo(resolved) };
     },
   );
-  ipcMain.handle('e2eFixture:getState', () => getE2EFixtureState(e2eFixture));
+  ipcMain.handle('e2eFixture:getState', () => getE2eFixtureState(e2eFixture));
 }

--- a/apps/desktop/src/main/app-ipc-main.ts
+++ b/apps/desktop/src/main/app-ipc-main.ts
@@ -5,11 +5,11 @@ import { resolveProjectGitInfo, resolveProjectRoot } from '@maka/runtime';
 import type { createMainWindowController } from './main-window.js';
 import type { ProjectRootController } from './project-root-controller.js';
 import { resolveOpenPath, type OpenPathResult } from './open-path-guard.js';
-import { getVisualSmokeState, type resolveVisualSmokeFixture } from './visual-smoke-fixture.js';
+import { getE2EFixtureState, type resolveE2EFixture } from './e2e-fixture.js';
 import type { resolveBuildInfo } from './build-info.js';
 
 type MainWindowController = ReturnType<typeof createMainWindowController>;
-type VisualSmokeFixture = ReturnType<typeof resolveVisualSmokeFixture>;
+type E2EFixture = ReturnType<typeof resolveE2EFixture>;
 type BuildInfo = ReturnType<typeof resolveBuildInfo>;
 
 export interface AppIpcDeps {
@@ -19,11 +19,11 @@ export interface AppIpcDeps {
   getProjectRoot(sessionId: unknown): Promise<string>;
   workspaceRoot: string;
   buildInfo: BuildInfo;
-  visualSmokeFixture: VisualSmokeFixture;
+  e2eFixture: E2EFixture;
 }
 
 export function registerAppIpc(deps: AppIpcDeps): void {
-  const { mainWindowController, projectRoot, workspaceRoot, buildInfo, visualSmokeFixture } = deps;
+  const { mainWindowController, projectRoot, workspaceRoot, buildInfo, e2eFixture } = deps;
   // Call-time read of the shared project-root authority: every handler must
   // observe the latest selection, not a snapshot taken at registration.
   const currentProjectRoot = (): Promise<string> => projectRoot.current();
@@ -33,7 +33,7 @@ export function registerAppIpc(deps: AppIpcDeps): void {
   });
   // PR-SHOW-AFTER-FIRST-COMMIT: the renderer signals its first React commit so
   // the hidden window (main-window.ts show: false) is revealed only once real
-  // content can paint. Idempotent + visual-smoke-safe inside the controller.
+  // content can paint. Idempotent + e2e-fixture-safe inside the controller.
   ipcMain.handle('window:notifyRendererReady', (): void => {
     mainWindowController.notifyRendererReady();
   });
@@ -140,5 +140,5 @@ export function registerAppIpc(deps: AppIpcDeps): void {
       return { ok: true, projectPath: resolved, projectGit: await resolveProjectGitInfo(resolved) };
     },
   );
-  ipcMain.handle('visualSmoke:getState', () => getVisualSmokeState(visualSmokeFixture));
+  ipcMain.handle('e2eFixture:getState', () => getE2EFixtureState(e2eFixture));
 }

--- a/apps/desktop/src/main/app-lifecycle.ts
+++ b/apps/desktop/src/main/app-lifecycle.ts
@@ -15,8 +15,8 @@ import type { createFileCredentialStore } from './credential-store.js';
 import { startConfigFileWatcher, type ConfigFileWatcher } from './config-file-watcher.js';
 import { toContractNetworkSettings } from './network-settings-main.js';
 import { importLegacyOAuthTokenFiles } from './oauth/shared-credential-bridge.js';
-import { seedE2EFixture } from './e2e-fixture.js';
-import type { resolveE2EFixture } from './e2e-fixture.js';
+import { seedE2eFixture } from './e2e-fixture.js';
+import type { resolveE2eFixture } from './e2e-fixture.js';
 import type { OpenGatewayService } from './open-gateway.js';
 import type { KeepSystemAwakeController } from './keep-system-awake.js';
 import type { createPlanReminderMainService } from './plan-reminders-main.js';
@@ -33,7 +33,7 @@ type PricingLookup = ReturnType<typeof buildPricingLookup>;
 
 export interface AppLifecycleDeps {
   isIsolatedE2e: boolean;
-  e2eFixture: ReturnType<typeof resolveE2EFixture>;
+  e2eFixture: ReturnType<typeof resolveE2eFixture>;
   workspaceRoot: string;
   credentialStore: ReturnType<typeof createFileCredentialStore>;
   connectionStore: ReturnType<typeof createConnectionStore>;
@@ -210,7 +210,7 @@ export function wireAppLifecycle(deps: AppLifecycleDeps): void {
     // for determinism by definition; production launches skip this await.
     if (e2eFixture) {
       console.log(`[e2e-fixture] scenario=${e2eFixture.scenario} workspace=${workspaceRoot}`);
-      await seedE2EFixture({ workspaceRoot, fixture: e2eFixture, credentialStore });
+      await seedE2eFixture({ workspaceRoot, fixture: e2eFixture, credentialStore });
     }
     await runCredentialStartup();
     app.on('second-instance', focusOrCreateMainWindow);

--- a/apps/desktop/src/main/app-lifecycle.ts
+++ b/apps/desktop/src/main/app-lifecycle.ts
@@ -15,8 +15,8 @@ import type { createFileCredentialStore } from './credential-store.js';
 import { startConfigFileWatcher, type ConfigFileWatcher } from './config-file-watcher.js';
 import { toContractNetworkSettings } from './network-settings-main.js';
 import { importLegacyOAuthTokenFiles } from './oauth/shared-credential-bridge.js';
-import { seedVisualSmokeFixture } from './visual-smoke-fixture.js';
-import type { resolveVisualSmokeFixture } from './visual-smoke-fixture.js';
+import { seedE2EFixture } from './e2e-fixture.js';
+import type { resolveE2EFixture } from './e2e-fixture.js';
 import type { OpenGatewayService } from './open-gateway.js';
 import type { KeepSystemAwakeController } from './keep-system-awake.js';
 import type { createPlanReminderMainService } from './plan-reminders-main.js';
@@ -33,7 +33,7 @@ type PricingLookup = ReturnType<typeof buildPricingLookup>;
 
 export interface AppLifecycleDeps {
   isIsolatedE2e: boolean;
-  visualSmokeFixture: ReturnType<typeof resolveVisualSmokeFixture>;
+  e2eFixture: ReturnType<typeof resolveE2EFixture>;
   workspaceRoot: string;
   credentialStore: ReturnType<typeof createFileCredentialStore>;
   connectionStore: ReturnType<typeof createConnectionStore>;
@@ -82,7 +82,7 @@ export interface AppLifecycleDeps {
 export function wireAppLifecycle(deps: AppLifecycleDeps): void {
   const {
     isIsolatedE2e,
-    visualSmokeFixture,
+    e2eFixture,
     workspaceRoot,
     credentialStore,
     connectionStore,
@@ -174,7 +174,7 @@ export function wireAppLifecycle(deps: AppLifecycleDeps): void {
     // builds get the icon via .app bundle Info.plist; this covers the
     // dev path.
     if (process.platform === 'darwin' && app.dock) {
-      if (process.env.MAKA_VISUAL_SMOKE_FIXTURE || isIsolatedE2e) {
+      if (process.env.MAKA_E2E_FIXTURE || isIsolatedE2e) {
         // PR-VISUAL-SMOKE-HEADLESS: hide the dock icon so the spawned
         // Electron runs as an accessory app — no dock bounce, and it
         // never becomes frontmost / steals focus from the developer's
@@ -208,9 +208,9 @@ export function wireAppLifecycle(deps: AppLifecycleDeps): void {
     // read-or-create write (mkdir → tmp → rename), rejecting createWindow
     // so the window never appears. Fixture runs trade first-paint latency
     // for determinism by definition; production launches skip this await.
-    if (visualSmokeFixture) {
-      console.log(`[visual-smoke] scenario=${visualSmokeFixture.scenario} workspace=${workspaceRoot}`);
-      await seedVisualSmokeFixture({ workspaceRoot, fixture: visualSmokeFixture, credentialStore });
+    if (e2eFixture) {
+      console.log(`[e2e-fixture] scenario=${e2eFixture.scenario} workspace=${workspaceRoot}`);
+      await seedE2EFixture({ workspaceRoot, fixture: e2eFixture, credentialStore });
     }
     await runCredentialStartup();
     app.on('second-instance', focusOrCreateMainWindow);
@@ -269,7 +269,7 @@ export function wireAppLifecycle(deps: AppLifecycleDeps): void {
   async function runBackgroundStartup(): Promise<void> {
     // Visual-smoke seeding happens synchronously in `whenReady` before the
     // window opens (see there for why); only the real bootstrap runs here.
-    if (!visualSmokeFixture) {
+    if (!e2eFixture) {
       await ensureBootstrapConnection();
     }
     const settings = await settingsStore.get();

--- a/apps/desktop/src/main/app-lifecycle.ts
+++ b/apps/desktop/src/main/app-lifecycle.ts
@@ -201,7 +201,7 @@ export function wireAppLifecycle(deps: AppLifecycleDeps): void {
     // settled. Any state that background startup mutates is pushed to the
     // renderer via the existing `sessions:changed` / `connections:event`
     // / `settings:bots:statusChanged` channels, so the UI converges lazily.
-    // Visual-smoke fixture mode wipes and reseeds the whole workspace
+    // E2e-fixture mode wipes and reseeds the whole workspace
     // (`rm -rf` first). That wipe must finish BEFORE the window opens and
     // before background startup touches the workspace: createWindow reads
     // the settings store, and a concurrent wipe lands inside the store's
@@ -267,7 +267,7 @@ export function wireAppLifecycle(deps: AppLifecycleDeps): void {
    * with the app shell.
    */
   async function runBackgroundStartup(): Promise<void> {
-    // Visual-smoke seeding happens synchronously in `whenReady` before the
+    // E2e-fixture seeding happens synchronously in `whenReady` before the
     // window opens (see there for why); only the real bootstrap runs here.
     if (!e2eFixture) {
       await ensureBootstrapConnection();

--- a/apps/desktop/src/main/bot-onboarding-e2e-fixture.ts
+++ b/apps/desktop/src/main/bot-onboarding-e2e-fixture.ts
@@ -21,7 +21,7 @@ const WAITING_HOLD_TTL_SECONDS = 60 * 60;
  * scenarios keep the scanned → confirmed happy-path adapters the E2E
  * onboarding specs rely on.
  */
-export function createE2EFixtureBotOnboardingAdapters(): AdapterMap {
+export function createE2eFixtureBotOnboardingAdapters(): AdapterMap {
   if (process.env.MAKA_E2E_FIXTURE === 'settings-bots-onboarding') {
     return createWaitingHoldBotOnboardingAdapters();
   }

--- a/apps/desktop/src/main/bot-onboarding-e2e-fixture.ts
+++ b/apps/desktop/src/main/bot-onboarding-e2e-fixture.ts
@@ -11,7 +11,7 @@ const NORMAL_TTL_SECONDS = 30;
 const WAITING_HOLD_TTL_SECONDS = 60 * 60;
 
 /**
- * Deterministic provider adapters for the dev-only Settings visual fixture.
+ * Deterministic provider adapters for the dev-only Settings e2e-fixture.
  * They exercise the real main-owned session, IPC, persistence, runtime-effect,
  * and renderer polling paths without contacting an external IM platform.
  *

--- a/apps/desktop/src/main/bot-onboarding-e2e-fixture.ts
+++ b/apps/desktop/src/main/bot-onboarding-e2e-fixture.ts
@@ -6,7 +6,7 @@ type AdapterMap = Partial<Record<BotOnboardingProvider, BotOnboardingProviderAda
 const POLL_INTERVAL_MS = 1_000;
 const NORMAL_TTL_SECONDS = 30;
 // #1233 deferral (settings-bots-onboarding): a long TTL keeps the deterministic
-// waiting-state QR from flipping to '二维码已过期' during the screenshot settle
+// waiting-state QR from flipping to '二维码已过期' during the fixture settle
 // window; a poll that never leaves 'pending' holds the modal in 'waiting'.
 const WAITING_HOLD_TTL_SECONDS = 60 * 60;
 
@@ -21,8 +21,8 @@ const WAITING_HOLD_TTL_SECONDS = 60 * 60;
  * scenarios keep the scanned → confirmed happy-path adapters the E2E
  * onboarding specs rely on.
  */
-export function createVisualSmokeBotOnboardingAdapters(): AdapterMap {
-  if (process.env.MAKA_VISUAL_SMOKE_FIXTURE === 'settings-bots-onboarding') {
+export function createE2EFixtureBotOnboardingAdapters(): AdapterMap {
+  if (process.env.MAKA_E2E_FIXTURE === 'settings-bots-onboarding') {
     return createWaitingHoldBotOnboardingAdapters();
   }
   const pollCounts = new Map<string, number>();
@@ -38,7 +38,7 @@ export function createVisualSmokeBotOnboardingAdapters(): AdapterMap {
   function start(provider: BotOnboardingProvider, expiresInSeconds = NORMAL_TTL_SECONDS) {
     startSequence += 1;
     return {
-      opaqueToken: `visual-smoke-${provider}-${startSequence}`,
+      opaqueToken: `e2e-fixture-${provider}-${startSequence}`,
       qrValue: `https://example.com/maka/bot-onboarding/${provider}`,
       verificationUrl: `https://example.com/maka/bot-onboarding/${provider}`,
       pollIntervalMs: POLL_INTERVAL_MS,
@@ -62,10 +62,10 @@ export function createVisualSmokeBotOnboardingAdapters(): AdapterMap {
           status: 'confirmed',
           credential: {
             provider: 'dingtalk',
-            clientId: 'visual-smoke-dingtalk-client',
-            clientSecret: 'visual-smoke-dingtalk-secret',
+            clientId: 'e2e-fixture-dingtalk-client',
+            clientSecret: 'e2e-fixture-dingtalk-secret',
           },
-          identity: { id: 'visual-smoke-dingtalk-client', displayName: 'Maka 测试机器人' },
+          identity: { id: 'e2e-fixture-dingtalk-client', displayName: 'Maka 测试机器人' },
         };
       },
     },
@@ -79,12 +79,12 @@ export function createVisualSmokeBotOnboardingAdapters(): AdapterMap {
           status: 'confirmed',
           credential: {
             provider: 'feishu',
-            appId: `visual-smoke-${brand}-app`,
-            appSecret: `visual-smoke-${brand}-secret`,
+            appId: `e2e-fixture-${brand}-app`,
+            appSecret: `e2e-fixture-${brand}-secret`,
             brand,
             botName: 'Maka 测试机器人',
           },
-          identity: { id: `visual-smoke-${brand}-app`, displayName: 'Maka 测试机器人' },
+          identity: { id: `e2e-fixture-${brand}-app`, displayName: 'Maka 测试机器人' },
         };
       },
     },
@@ -103,12 +103,12 @@ export function createVisualSmokeBotOnboardingAdapters(): AdapterMap {
           status: 'confirmed',
           credential: {
             provider: 'wechat',
-            botToken: 'visual-smoke-wechat-token',
+            botToken: 'e2e-fixture-wechat-token',
             baseUrl: 'https://ilinkai.weixin.qq.com/',
-            botId: 'visual-smoke-wechat-bot',
-            userId: 'visual-smoke-wechat-user',
+            botId: 'e2e-fixture-wechat-bot',
+            userId: 'e2e-fixture-wechat-user',
           },
-          identity: { id: 'visual-smoke-wechat-bot', displayName: 'Maka 测试机器人' },
+          identity: { id: 'e2e-fixture-wechat-bot', displayName: 'Maka 测试机器人' },
         };
       },
     },
@@ -118,17 +118,17 @@ export function createVisualSmokeBotOnboardingAdapters(): AdapterMap {
 /**
  * #1233 deferral (settings-bots-onboarding): adapters that hold the modal in
  * its 'waiting' state. Every value is FIXED (no Date.now / random) so the
- * rendered QR image is byte-identical across capture runs, the TTL is long
- * enough to outlast the screenshot settle window, and `poll` never leaves
+ * rendered QR image is byte-identical across runs, the TTL is long
+ * enough to outlast the fixture settle window, and `poll` never leaves
  * 'pending' — so the main service keeps the session 'waiting' and the modal's
- * waiting layout stays put for a deterministic screenshot.
+ * waiting layout stays put for a deterministic fixture state.
  */
 function createWaitingHoldBotOnboardingAdapters(): AdapterMap {
   function waitingHold(provider: BotOnboardingProvider): BotOnboardingProviderAdapter {
     return {
       async start() {
         return {
-          opaqueToken: `visual-smoke-onboarding-${provider}`,
+          opaqueToken: `e2e-fixture-onboarding-${provider}`,
           qrValue: `https://example.com/maka/bot-onboarding/${provider}`,
           verificationUrl: `https://example.com/maka/bot-onboarding/${provider}`,
           pollIntervalMs: POLL_INTERVAL_MS,

--- a/apps/desktop/src/main/bot-onboarding-main.ts
+++ b/apps/desktop/src/main/bot-onboarding-main.ts
@@ -99,7 +99,7 @@ export interface BotOnboardingServiceDeps {
   productVersion?: string;
   /**
    * Fixture/test seam for the post-persist connection-health read (P0-3).
-   * Defaults to the live `botRegistry.getStatus`. The dev-only visual-smoke
+   * Defaults to the live `botRegistry.getStatus`. The dev-only e2e-fixture
    * fixture overrides it because it deliberately no-ops runtime effects (so no
    * real bridge starts) yet still demonstrates the successful "connected" path.
    */

--- a/apps/desktop/src/main/e2e-fixture.ts
+++ b/apps/desktop/src/main/e2e-fixture.ts
@@ -91,8 +91,8 @@ const E2E_FIXTURE_SCENARIOS = new Set<E2eFixtureScenario>([
   'artifact-errors',
   'streaming-sidebar',
   // PR-STREAM-TURN-CENTER: active session renders the live answer bubble in
-  // the main panel (below a committed turn) so the alignment audit
-  // can lock streaming-vs-committed horizontal alignment.
+  // the main panel (below a committed turn) so
+  // streaming-vs-committed horizontal alignment is locked deterministically.
   'streaming-answer',
   // #646: a running session with an armed turn but nothing streaming yet —
   // captures the "正在处理…" model-wait indicator + composer Stop.
@@ -100,8 +100,8 @@ const E2E_FIXTURE_SCENARIOS = new Set<E2eFixtureScenario>([
   'permission-destructive',
   'stale-sessions',
   // PR108j: per-Settings-section fixtures so each Settings sub-page can
-  // be exercised in light + dark + narrow + reduced-motion variants by
-  // the CI alignment audit. Each scenario reuses the standard
+  // be opened deterministically over the standard seed. Each scenario
+  // reuses the standard
   // connection / session seed and only differs in
   // `openSettingsSection`. (Per-page state — displayName,
   // assistantTone, network proxy, etc. — already comes from the
@@ -129,8 +129,8 @@ const E2E_FIXTURE_SCENARIOS = new Set<E2eFixtureScenario>([
   'module-skills',
   // MCP module page (SVG-governance + polish campaign): opens the 扩展 → MCP
   // surface with a seeded mcp.json so the market grid, tab row, hero banner,
-  // and the installed server list all render for the alignment auditor + E2E
-  // in light / dark.
+  // and the installed server list all render for the alignment auditor
+  // (light).
   'module-mcp',
   'module-daily-review',
   // PR109b: workstation-statuses — seed one session per SessionStatus
@@ -205,9 +205,9 @@ export interface E2eFixture {
   /**
    * PR-IR-04: when `MAKA_E2E_FIXTURE_REDUCED_MOTION=1` is set alongside
    * the scenario var, the renderer collapses all animations to ~0.01ms
-   * via the `[data-maka-reduced-motion="true"]` CSS path. Lets E2E and
-   * the alignment audit exercise a "reduced motion" variant for every
-   * surface without depending on the host OS accessibility setting.
+   * via the `[data-maka-reduced-motion="true"]` CSS path. Lets every
+   * surface be exercised in a "reduced motion" variant without depending
+   * on the host OS accessibility setting.
    */
   reducedMotion: boolean;
   /**
@@ -387,7 +387,7 @@ export function getE2eFixtureState(fixture: E2eFixture | null): E2eFixtureState 
       // session so BrowserPanel mounts over the chat. No native
       // WebContentsView exists in e2e-fixture mode, so browser.getState
       // resolves null → BrowserPanel renders EMPTY_STATE → the empty-state
-      // chrome is what the alignment audit sees (the #818 defect surface).
+      // chrome is what the fixture exposes (the #818 defect surface).
       // Loaded / loading / nav chrome states are locked by the
       // `browser-panel-chrome` source contract; they add no layout
       // value over this empty-state fixture.
@@ -401,7 +401,7 @@ export function getE2eFixtureState(fixture: E2eFixture | null): E2eFixtureState 
     case 'streaming-answer':
       // Active session = the committed turn-narrative session, PLUS a live
       // answer streaming into it. The main panel then shows a settled turn
-      // and the in-flight bubble together, so the alignment audit can prove they
+      // and the in-flight bubble together, so they provably
       // share the same centered column (the streaming-turn-center fix).
       return {
         ...state,
@@ -521,8 +521,8 @@ export function getE2eFixtureState(fixture: E2eFixture | null): E2eFixtureState 
       // the active row; the fixture exposes the scroll affordance
       // plus the visible footer (Settings + Version info) at the
       // bottom of the sidebar. If the scroll fix regresses, the footer
-      // gets pushed off-screen and the regression surfaces in the
-      // scroll-geometry E2E spec.
+      // gets pushed off-screen and the regression is visible in the
+      // rendered fixture.
       return { ...state, activeSessionId: LONG_SIDEBAR_SESSION_PREFIX + '00', sidebarCollapsed: false };
     case 'sidebar-search-modal-open':
       // PR-SIDEBAR-IA-0 Phase 2 fixup v3 (xuan msg `dce5a6fb` #2):
@@ -531,7 +531,7 @@ export function getE2eFixtureState(fixture: E2eFixture | null): E2eFixtureState 
       // fixture; `searchModalOpen: true` is the only differentiator.
       // The renderer reads the flag in `applyE2eFixture()` and
       // calls `setSearchModalOpen(true)` before the fixture settles,
-      // so the SearchModal shell is on screen for the alignment audit.
+      // so the SearchModal shell is on screen deterministically.
       return {
         ...state,
         activeSessionId: LONG_SIDEBAR_SESSION_PREFIX + '00',
@@ -541,7 +541,7 @@ export function getE2eFixtureState(fixture: E2eFixture | null): E2eFixtureState 
     case 'command-palette-open':
       // PR-shared primitive-COMMAND-INPUT-0: same 60-session seed as the sidebar
       // fixtures; `paletteOpen: true` is the only differentiator so
-      // the command palette shell is visible for the alignment audit.
+      // the command palette shell is visible deterministically.
       return {
         ...state,
         activeSessionId: LONG_SIDEBAR_SESSION_PREFIX + '00',

--- a/apps/desktop/src/main/e2e-fixture.ts
+++ b/apps/desktop/src/main/e2e-fixture.ts
@@ -1,5 +1,5 @@
 import { mkdir, rm } from 'node:fs/promises';
-import type { UiLocale, VisualSmokeScenario, VisualSmokeState } from '@maka/core';
+import type { UiLocale, E2EFixtureScenario, E2EFixtureState } from '@maka/core';
 import type { CredentialStore } from './credential-store.js';
 import {
   ARTIFACT_SESSION_ID,
@@ -15,15 +15,15 @@ import {
   TURN_CONTROL_PRIMARY_SESSION_ID,
   TURN_CONTROL_SCENARIOS,
   TURN_SESSION_ID,
-  VISUAL_SMOKE_NOW,
+  E2E_FIXTURE_NOW,
   WORKSTATION_RUNNING_SESSION_ID,
   writeSession,
-} from './visual-smoke/seed-helpers.js';
+} from './e2e-fixture/seed-helpers.js';
 import {
   artifactMessages,
   artifactSession,
   writeArtifacts,
-} from './visual-smoke/scenarios-artifacts.js';
+} from './e2e-fixture/scenarios-artifacts.js';
 import {
   errorMessages,
   errorSession,
@@ -41,11 +41,11 @@ import {
   turnMessages,
   turnSession,
   writeTaskLedgerFixture,
-} from './visual-smoke/scenarios-chat.js';
+} from './e2e-fixture/scenarios-chat.js';
 import {
   seedMcpFixture,
   seedSkillsMarketFixture,
-} from './visual-smoke/scenarios-modules.js';
+} from './e2e-fixture/scenarios-modules.js';
 import {
   healthyMessages,
   healthySession,
@@ -58,22 +58,22 @@ import {
   staleLegacySession,
   turnControlSessions,
   workstationStatusSessions,
-} from './visual-smoke/scenarios-sessions.js';
+} from './e2e-fixture/scenarios-sessions.js';
 import {
   writeConnections,
   writeDailyReviewArchives,
   writePlanReminders,
   writeSettings,
-} from './visual-smoke/scenarios-settings.js';
-import { usageStatsSessions } from './visual-smoke/scenarios-usage.js';
+} from './e2e-fixture/scenarios-settings.js';
+import { usageStatsSessions } from './e2e-fixture/scenarios-usage.js';
 import {
   DEEP_RESEARCH_SESSION_ID,
   deepResearchMessages,
   deepResearchSession,
   writeDeepResearchLedger,
-} from './visual-smoke/scenarios-deep-research.js';
+} from './e2e-fixture/scenarios-deep-research.js';
 
-const VISUAL_SMOKE_SCENARIOS = new Set<VisualSmokeScenario>([
+const E2E_FIXTURE_SCENARIOS = new Set<E2EFixtureScenario>([
   'all',
   'first-run',
   'provider-workspace',
@@ -91,17 +91,17 @@ const VISUAL_SMOKE_SCENARIOS = new Set<VisualSmokeScenario>([
   'artifact-errors',
   'streaming-sidebar',
   // PR-STREAM-TURN-CENTER: active session renders the live answer bubble in
-  // the main panel (below a committed turn) so the screenshot locks
-  // streaming-vs-committed horizontal alignment.
+  // the main panel (below a committed turn) so E2E + the alignment audit
+  // can lock streaming-vs-committed horizontal alignment.
   'streaming-answer',
   // #646: a running session with an armed turn but nothing streaming yet —
   // captures the "正在处理…" model-wait indicator + composer Stop.
   'model-processing',
   'permission-destructive',
   'stale-sessions',
-  // PR108j: per-Settings-section fixtures so the screenshot pipeline
-  // can capture each Settings sub-page in light + dark + narrow +
-  // reduced-motion variants. Each scenario reuses the standard
+  // PR108j: per-Settings-section fixtures so each Settings sub-page can
+  // be exercised in light + dark + narrow + reduced-motion variants by
+  // E2E specs and the CI alignment audit. Each scenario reuses the standard
   // connection / session seed and only differs in
   // `openSettingsSection`. (Per-page state — displayName,
   // assistantTone, network proxy, etc. — already comes from the
@@ -111,10 +111,10 @@ const VISUAL_SMOKE_SCENARIOS = new Set<VisualSmokeScenario>([
   // daily-review split back apart per WAWQAQ msg `886f6406`.
   'settings-appearance',
   'settings-bots',
-  // #1233 deferral: deterministic bot QR-onboarding modal capture. Shares the
+  // #1233 deferral: deterministic bot QR-onboarding modal fixture. Shares the
   // settings-bots seed but auto-opens a provider detail's scan-login modal,
-  // backed by a hold-in-waiting visual-smoke onboarding adapter (fixed QR +
-  // long TTL). See `createVisualSmokeBotOnboardingAdapters`.
+  // backed by a hold-in-waiting e2e-fixture onboarding adapter (fixed QR +
+  // long TTL). See `createE2EFixtureBotOnboardingAdapters`.
   'settings-bots-onboarding',
   'settings-about',
   'settings-general',
@@ -129,16 +129,16 @@ const VISUAL_SMOKE_SCENARIOS = new Set<VisualSmokeScenario>([
   'module-skills',
   // MCP module page (SVG-governance + polish campaign): opens the 扩展 → MCP
   // surface with a seeded mcp.json so the market grid, tab row, hero banner,
-  // and the installed server list all render for the alignment auditor + CDP
-  // capture in light / dark.
+  // and the installed server list all render for the alignment auditor + E2E
+  // in light / dark.
   'module-mcp',
   'module-daily-review',
   // PR109b: workstation-statuses — seed one session per SessionStatus
   // (running / waiting_for_user / blocked × 4 reasons / active / review
-  // / done / archived) so the sidebar grouping screenshot covers every
+  // / done / archived) so the sidebar grouping covers every
   // status badge + group header in one fixture.
   'workstation-statuses',
-  // PR-PLAN-REMINDER-MVP-0: screenshot the first real Automations
+  // PR-PLAN-REMINDER-MVP-0: exercise the first real Automations
   // surface. Seeds scheduled / paused / completed local reminders and
   // opens the 计划 module so reviewers can verify this is real product
   // UI rather than a passive placeholder.
@@ -146,10 +146,9 @@ const VISUAL_SMOKE_SCENARIOS = new Set<VisualSmokeScenario>([
   // PR109f (g): turn-control-history — seeds a primary session whose
   // turn list covers the four TurnStatus values plus retry + regenerate
   // lineage, alongside two branch sessions (visible-parent vs missing-
-  // parent) so deterministic screenshots cover the banner contract end-to-end.
+  // parent) so the banner contract is covered end-to-end.
   // Three variants share the same on-disk seed and only differ in
-  // active session selection, so auto-capture produces three
-  // deterministic screenshots:
+  // active session selection, exposing three deterministic states:
   //   - turn-control-history          → primary active (lineage / aborted / failed)
   //   - turn-control-branch-visible   → visible-parent branch active (banner)
   //   - turn-control-branch-orphan    → orphan branch active (NO banner)
@@ -171,14 +170,14 @@ const VISUAL_SMOKE_SCENARIOS = new Set<VisualSmokeScenario>([
   // PR-SIDEBAR-IA-0 Phase 2 fixup v3 (xuan msg `dce5a6fb` #2):
   // shares the sidebar-long-sessions on-disk seed (60 sessions) so
   // the sidebar behind the modal looks identical to the
-  // sidebar-long-sessions screenshot; differs only in
+  // sidebar-long-sessions fixture; differs only in
   // `searchModalOpen: true`, which auto-opens the sidebar Search
-  // modal at mount. Captures the SearchModal shell deterministically
-  // so xuan's Phase 2 modal gate has a baseline.
+  // modal at mount. Renders the SearchModal shell deterministically
+  // so xuan's Phase 2 modal gate has a stable fixture state.
   'sidebar-search-modal-open',
   // PR-shared primitive-COMMAND-INPUT-0: same 60-session seed; differs only in
   // `paletteOpen: true`, which auto-opens CommandPalette so shared primitive
-  // InputGroup changes to the command input shell have a baseline.
+  // InputGroup changes to the command input shell have a stable fixture state.
   'command-palette-open',
   // PR-SIDEBAR-IA-0 Phase 3 P0 fixup v4 (WAWQAQ msg `5dd1c348`,
   // kenji `b3d156e9`): same 60-session seed; differs in
@@ -194,20 +193,20 @@ const VISUAL_SMOKE_SCENARIOS = new Set<VisualSmokeScenario>([
   'long-transcript',
   // #819: BrowserPanel renderer-chrome fixture. Seeds `liveBrowserSessionIds`
   // with the active turn session so `BrowserPanel` mounts; with no native
-  // `WebContentsView` in visual-smoke mode, `browser.getState` resolves null
+  // `WebContentsView` in e2e-fixture mode, `browser.getState` resolves null
   // → `EMPTY_STATE` → the empty-state chrome (toolbar all-nav-disabled +
   // `<Empty>` strip) the #818 narrow-layout defect regressed against.
   'browser-empty',
 ]);
 
-export interface VisualSmokeFixture {
-  scenario: VisualSmokeScenario;
+export interface E2EFixture {
+  scenario: E2EFixtureScenario;
   workspaceName: string;
   /**
-   * PR-IR-04: when `MAKA_VISUAL_SMOKE_REDUCED_MOTION=1` is set alongside
+   * PR-IR-04: when `MAKA_E2E_FIXTURE_REDUCED_MOTION=1` is set alongside
    * the scenario var, the renderer collapses all animations to ~0.01ms
-   * via the `[data-maka-reduced-motion="true"]` CSS path. Lets the
-   * screenshot pipeline capture a "reduced motion" variant for every
+   * via the `[data-maka-reduced-motion="true"]` CSS path. Lets E2E and
+   * the alignment audit exercise a "reduced motion" variant for every
    * surface without depending on the host OS accessibility setting.
    */
   reducedMotion: boolean;
@@ -222,48 +221,48 @@ export interface VisualSmokeFixture {
    * means "use the persisted locale preference". When set,
    * the renderer passes the value to LocaleProvider, which synchronizes
    * document metadata and consumers to the locked value
-   * deterministically — same fixture, same locale, same screenshot
+   * deterministically — same fixture, same locale, same rendered state
    * across hosts. Driven by env var
-   * `MAKA_VISUAL_SMOKE_LOCALE=zh|en`. Unknown values fail closed.
+   * `MAKA_E2E_FIXTURE_LOCALE=zh|en`. Unknown values fail closed.
    */
   locale: UiLocale | null;
   /**
    * PR-UI-VISUAL-SMOKE-TIMEZONE: IANA timezone override. null means
    * "use the host system timezone" (current behavior). When set, the
-   * renderer applies `data-maka-visual-smoke-tz=<IANA>` to `<html>`
+   * renderer applies `data-maka-e2e-fixture-tz=<IANA>` to `<html>`
    * so any date/time formatting helper that opts in can read the
    * locked value deterministically — same fixture, same timezone,
-   * same screenshot across hosts. Driven by env var
-   * `MAKA_VISUAL_SMOKE_TIMEZONE=<IANA name>`. Validation via
+   * same rendered state across hosts. Driven by env var
+   * `MAKA_E2E_FIXTURE_TIMEZONE=<IANA name>`. Validation via
    * `Intl.DateTimeFormat(undefined, { timeZone })`; invalid values
    * fail closed to null.
    */
   timezone: string | null;
 }
 
-export function resolveVisualSmokeFixture(
+export function resolveE2EFixture(
   rawScenario: string | undefined,
   isPackaged: boolean,
   rawReducedMotion: string | undefined = undefined,
   rawTheme: string | undefined = undefined,
   rawLocale: string | undefined = undefined,
   rawTimezone: string | undefined = undefined,
-): VisualSmokeFixture | null {
+): E2EFixture | null {
   if (!rawScenario) return null;
   if (isPackaged) {
-    throw new Error('MAKA_VISUAL_SMOKE_FIXTURE is only available in dev/test builds.');
+    throw new Error('MAKA_E2E_FIXTURE is only available in dev/test builds.');
   }
-  if (!VISUAL_SMOKE_SCENARIOS.has(rawScenario as VisualSmokeScenario)) {
-    throw new Error(`Unknown MAKA_VISUAL_SMOKE_FIXTURE scenario: ${rawScenario}`);
+  if (!E2E_FIXTURE_SCENARIOS.has(rawScenario as E2EFixtureScenario)) {
+    throw new Error(`Unknown MAKA_E2E_FIXTURE scenario: ${rawScenario}`);
   }
-  const scenario = rawScenario as VisualSmokeScenario;
+  const scenario = rawScenario as E2EFixtureScenario;
   const reducedMotion = parseReducedMotionFlag(rawReducedMotion);
   const theme = parseThemeFlag(rawTheme);
   const locale = parseLocaleFlag(rawLocale);
   const timezone = parseTimezoneFlag(rawTimezone);
   return {
     scenario,
-    workspaceName: `visual-smoke-${scenario}`,
+    workspaceName: `e2e-fixture-${scenario}`,
     reducedMotion,
     theme,
     locale,
@@ -339,11 +338,11 @@ function parseReducedMotionFlag(raw: string | undefined): boolean {
   return normalized === '1' || normalized === 'true' || normalized === 'yes';
 }
 
-export function getVisualSmokeState(fixture: VisualSmokeFixture | null): VisualSmokeState | null {
+export function getE2EFixtureState(fixture: E2EFixture | null): E2EFixtureState | null {
   if (!fixture) return null;
-  const state: VisualSmokeState = {
+  const state: E2EFixtureState = {
     enabled: true,
-    now: VISUAL_SMOKE_NOW,
+    now: E2E_FIXTURE_NOW,
     ...(fixture.reducedMotion ? { reducedMotion: true } : {}),
     ...(fixture.theme ? { theme: fixture.theme } : {}),
     ...(fixture.locale ? { locale: fixture.locale } : {}),
@@ -373,7 +372,7 @@ export function getVisualSmokeState(fixture: VisualSmokeFixture | null): VisualS
     // PR-UI-RENDER-3a-smoke: each preview scenario shares the same
     // chat session as `artifact-pane`; only the on-disk artifact
     // varies. The ArtifactPane selects records[0] by default so the
-    // single seeded artifact is what gets screenshotted.
+    // single seeded artifact is what gets rendered.
     case 'artifact-preview-image':
     case 'artifact-preview-unsupported':
     case 'artifact-preview-oversize':
@@ -386,12 +385,12 @@ export function getVisualSmokeState(fixture: VisualSmokeFixture | null): VisualS
     case 'browser-empty':
       // #819: the active turn session is also seeded as a live browser
       // session so BrowserPanel mounts over the chat. No native
-      // WebContentsView exists in visual-smoke mode, so browser.getState
+      // WebContentsView exists in e2e-fixture mode, so browser.getState
       // resolves null → BrowserPanel renders EMPTY_STATE → the empty-state
-      // chrome is what screenshots capture (the #818 defect surface).
+      // chrome is what E2E/audit see (the #818 defect surface).
       // Loaded / loading / nav chrome states are locked by the
-      // `browser-panel-chrome` source contract; their screenshots add no
-      // layout value over this empty-state baseline.
+      // `browser-panel-chrome` source contract; they add no layout
+      // value over this empty-state fixture.
       return { ...state, activeSessionId: TURN_SESSION_ID, liveBrowserSessionIds: [TURN_SESSION_ID], workbarCollapsed: false, workbarTab: 'browser' };
     case 'streaming-sidebar':
       return {
@@ -402,7 +401,7 @@ export function getVisualSmokeState(fixture: VisualSmokeFixture | null): VisualS
     case 'streaming-answer':
       // Active session = the committed turn-narrative session, PLUS a live
       // answer streaming into it. The main panel then shows a settled turn
-      // and the in-flight bubble together, so the screenshot proves they
+      // and the in-flight bubble together, so E2E/audit can prove they
       // share the same centered column (the streaming-turn-center fix).
       return {
         ...state,
@@ -446,7 +445,7 @@ export function getVisualSmokeState(fixture: VisualSmokeFixture | null): VisualS
     case 'settings-bots-onboarding':
       // #1233 deferral: open 远程接入, then let the bot page auto-open the
       // DingTalk detail's scan-login modal (via `botOnboardingProvider`). The
-      // visual-smoke onboarding adapter keeps the session in 'waiting' with a
+      // e2e-fixture onboarding adapter keeps the session in 'waiting' with a
       // fixed QR + long TTL so the modal's waiting layout is captured
       // deterministically. DingTalk carries a real brand mark (#1236).
       return {
@@ -480,31 +479,31 @@ export function getVisualSmokeState(fixture: VisualSmokeFixture | null): VisualS
     case 'module-skills':
       return { ...state, activeSessionId: TURN_SESSION_ID, sidebarSection: 'skills', sidebarCollapsed: false };
     case 'module-mcp':
-      // Open the 扩展 → MCP module directly so the CDP baseline captures the
+      // Open the 扩展 → MCP module directly so the alignment audit reaches the
       // real market grid, tab row, hero banner, and installed server list.
       return { ...state, activeSessionId: TURN_SESSION_ID, sidebarSection: 'mcp', sidebarCollapsed: false };
     case 'module-daily-review':
       return { ...state, activeSessionId: TURN_SESSION_ID, sidebarSection: 'daily-review', sidebarCollapsed: false };
     case 'workstation-statuses':
       // Active session is the running one so the chat header status
-      // badge ("进行中") is visible in the screenshot alongside the
+      // badge ("进行中") is visible alongside the
       // sidebar grouping. Each session in the seed maps to one
       // SessionStatus enum value (running / waiting_for_user / blocked
       // × 4 reasons / review / done / archived / aborted (filtered)).
       return { ...state, activeSessionId: WORKSTATION_RUNNING_SESSION_ID };
     case 'plan-reminders':
-      // Open the 计划 module directly so the visual-smoke baseline
-      // captures the real local reminder MVP: create form + persisted
+      // Open the 计划 module directly so the alignment audit reaches
+      // the real local reminder MVP: create form + persisted
       // scheduled / paused / completed reminders.
       return { ...state, activeSessionId: TURN_SESSION_ID, sidebarSection: 'automations', sidebarCollapsed: false };
     case 'turn-control-history':
       // Active = primary so the chat surface shows every turn control
-      // variant in one screenshot: completed baseline, retried pair
+      // variant at once: completed baseline, retried pair
       // (forward + reverse badges), regenerated pair, aborted marker,
       // failed banner with generalized Chinese copy. The two branch
       // sessions sit in the sidebar but are not the active surface
       // here — banner positive/negative cases each get their own
-      // scenario below so auto-capture covers both deterministically.
+      // scenario below so both are covered deterministically.
       return { ...state, activeSessionId: TURN_CONTROL_PRIMARY_SESSION_ID };
     case 'turn-control-branch-visible':
       // Active = visible-parent branch session. Chat header should
@@ -519,20 +518,20 @@ export function getVisualSmokeState(fixture: VisualSmokeFixture | null): VisualS
     case 'sidebar-long-sessions':
       // PR-SIDEBAR-IA-0 Phase 1: active = the FIRST session in the seed
       // (newest by lastMessageAt). The 60-session list scrolls below
-      // the active row; the screenshot captures the scroll affordance
+      // the active row; the fixture exposes the scroll affordance
       // plus the visible footer (Settings + Version info) at the
       // bottom of the sidebar. If the scroll fix regresses, the footer
-      // gets pushed off-screen and the regression is obvious in
-      // baseline diff.
+      // gets pushed off-screen and the regression surfaces in the
+      // scroll-geometry E2E spec.
       return { ...state, activeSessionId: LONG_SIDEBAR_SESSION_PREFIX + '00', sidebarCollapsed: false };
     case 'sidebar-search-modal-open':
       // PR-SIDEBAR-IA-0 Phase 2 fixup v3 (xuan msg `dce5a6fb` #2):
       // shares the sidebar-long-sessions seed (60 sessions) so the
       // sidebar behind the modal is identical to the long-sessions
-      // baseline; `searchModalOpen: true` is the only differentiator.
-      // The renderer reads the flag in `applyVisualSmokeFixture()` and
-      // calls `setSearchModalOpen(true)` BEFORE auto-capture settles,
-      // so the SearchModal shell is on screen for the screenshot.
+      // fixture; `searchModalOpen: true` is the only differentiator.
+      // The renderer reads the flag in `applyE2EFixture()` and
+      // calls `setSearchModalOpen(true)` before the fixture settles,
+      // so the SearchModal shell is on screen for E2E/audit.
       return {
         ...state,
         activeSessionId: LONG_SIDEBAR_SESSION_PREFIX + '00',
@@ -541,8 +540,8 @@ export function getVisualSmokeState(fixture: VisualSmokeFixture | null): VisualS
       };
     case 'command-palette-open':
       // PR-shared primitive-COMMAND-INPUT-0: same 60-session seed as the sidebar
-      // baselines; `paletteOpen: true` is the only differentiator so
-      // the command palette shell is visible for screenshot review.
+      // fixtures; `paletteOpen: true` is the only differentiator so
+      // the command palette shell is visible for E2E/audit.
       return {
         ...state,
         activeSessionId: LONG_SIDEBAR_SESSION_PREFIX + '00',
@@ -582,13 +581,13 @@ export function getVisualSmokeState(fixture: VisualSmokeFixture | null): VisualS
   return state;
 }
 
-export async function seedVisualSmokeFixture(input: {
+export async function seedE2EFixture(input: {
   workspaceRoot: string;
-  fixture: VisualSmokeFixture;
+  fixture: E2EFixture;
   credentialStore: Pick<CredentialStore, 'setSecret'>;
   now?: number;
 }): Promise<void> {
-  const now = input.now ?? VISUAL_SMOKE_NOW;
+  const now = input.now ?? E2E_FIXTURE_NOW;
   await rm(input.workspaceRoot, { recursive: true, force: true });
   await mkdir(input.workspaceRoot, { recursive: true });
   await writeSettings(input.workspaceRoot, input.fixture.scenario);
@@ -648,15 +647,15 @@ export async function seedVisualSmokeFixture(input: {
   // PR-SIDEBAR-IA-0 Phase 1 (xuan msg `dc790a54` + kenji `0f7bb872`):
   // sidebar-long-sessions seeds 60 active sessions so the sidebar
   // scroll fix is verifiable end-to-end. Each row reuses the standard
-  // text content; only the name + timestamp differ so screenshots are
+  // text content; only the name + timestamp differ so the rendered list is
   // deterministic. The hard gate: with 60 rows in a narrow window, the
   // footer (Settings + Version info) must remain visible without
   // page-level scroll, and the inner list scroll container must work.
   //
   // Phase 2 fixup v3: `sidebar-search-modal-open` shares the same
   // 60-session seed so the sidebar behind the modal matches the
-  // long-sessions baseline exactly. The modal-open state itself is a
-  // transient renderer flag (`VisualSmokeState.searchModalOpen`); no
+  // long-sessions fixture exactly. The modal-open state itself is a
+  // transient renderer flag (`E2EFixtureState.searchModalOpen`); no
   // additional on-disk seeding required.
   if (LONG_SIDEBAR_SCENARIOS.has(input.fixture.scenario)) {
     for (const seed of longSidebarSessions(now)) {
@@ -676,7 +675,7 @@ export async function seedVisualSmokeFixture(input: {
     await seedMcpFixture(input.workspaceRoot);
   }
   // Settings → 使用统计: seed extra model + tool traffic so the request log,
-  // provider / model / tool aggregates render real content in the capture.
+  // provider / model / tool aggregates render real content in the fixture.
   // Scenario-gated so no other fixture's sidebar or usage totals shift.
   if (input.fixture.scenario === 'settings-usage') {
     for (const seed of usageStatsSessions(now)) {

--- a/apps/desktop/src/main/e2e-fixture.ts
+++ b/apps/desktop/src/main/e2e-fixture.ts
@@ -1,5 +1,5 @@
 import { mkdir, rm } from 'node:fs/promises';
-import type { UiLocale, E2EFixtureScenario, E2EFixtureState } from '@maka/core';
+import type { UiLocale, E2eFixtureScenario, E2eFixtureState } from '@maka/core';
 import type { CredentialStore } from './credential-store.js';
 import {
   ARTIFACT_SESSION_ID,
@@ -73,7 +73,7 @@ import {
   writeDeepResearchLedger,
 } from './e2e-fixture/scenarios-deep-research.js';
 
-const E2E_FIXTURE_SCENARIOS = new Set<E2EFixtureScenario>([
+const E2E_FIXTURE_SCENARIOS = new Set<E2eFixtureScenario>([
   'all',
   'first-run',
   'provider-workspace',
@@ -91,7 +91,7 @@ const E2E_FIXTURE_SCENARIOS = new Set<E2EFixtureScenario>([
   'artifact-errors',
   'streaming-sidebar',
   // PR-STREAM-TURN-CENTER: active session renders the live answer bubble in
-  // the main panel (below a committed turn) so E2E + the alignment audit
+  // the main panel (below a committed turn) so the alignment audit
   // can lock streaming-vs-committed horizontal alignment.
   'streaming-answer',
   // #646: a running session with an armed turn but nothing streaming yet —
@@ -101,7 +101,7 @@ const E2E_FIXTURE_SCENARIOS = new Set<E2EFixtureScenario>([
   'stale-sessions',
   // PR108j: per-Settings-section fixtures so each Settings sub-page can
   // be exercised in light + dark + narrow + reduced-motion variants by
-  // E2E specs and the CI alignment audit. Each scenario reuses the standard
+  // the CI alignment audit. Each scenario reuses the standard
   // connection / session seed and only differs in
   // `openSettingsSection`. (Per-page state — displayName,
   // assistantTone, network proxy, etc. — already comes from the
@@ -114,7 +114,7 @@ const E2E_FIXTURE_SCENARIOS = new Set<E2EFixtureScenario>([
   // #1233 deferral: deterministic bot QR-onboarding modal fixture. Shares the
   // settings-bots seed but auto-opens a provider detail's scan-login modal,
   // backed by a hold-in-waiting e2e-fixture onboarding adapter (fixed QR +
-  // long TTL). See `createE2EFixtureBotOnboardingAdapters`.
+  // long TTL). See `createE2eFixtureBotOnboardingAdapters`.
   'settings-bots-onboarding',
   'settings-about',
   'settings-general',
@@ -199,8 +199,8 @@ const E2E_FIXTURE_SCENARIOS = new Set<E2EFixtureScenario>([
   'browser-empty',
 ]);
 
-export interface E2EFixture {
-  scenario: E2EFixtureScenario;
+export interface E2eFixture {
+  scenario: E2eFixtureScenario;
   workspaceName: string;
   /**
    * PR-IR-04: when `MAKA_E2E_FIXTURE_REDUCED_MOTION=1` is set alongside
@@ -240,22 +240,22 @@ export interface E2EFixture {
   timezone: string | null;
 }
 
-export function resolveE2EFixture(
+export function resolveE2eFixture(
   rawScenario: string | undefined,
   isPackaged: boolean,
   rawReducedMotion: string | undefined = undefined,
   rawTheme: string | undefined = undefined,
   rawLocale: string | undefined = undefined,
   rawTimezone: string | undefined = undefined,
-): E2EFixture | null {
+): E2eFixture | null {
   if (!rawScenario) return null;
   if (isPackaged) {
     throw new Error('MAKA_E2E_FIXTURE is only available in dev/test builds.');
   }
-  if (!E2E_FIXTURE_SCENARIOS.has(rawScenario as E2EFixtureScenario)) {
+  if (!E2E_FIXTURE_SCENARIOS.has(rawScenario as E2eFixtureScenario)) {
     throw new Error(`Unknown MAKA_E2E_FIXTURE scenario: ${rawScenario}`);
   }
-  const scenario = rawScenario as E2EFixtureScenario;
+  const scenario = rawScenario as E2eFixtureScenario;
   const reducedMotion = parseReducedMotionFlag(rawReducedMotion);
   const theme = parseThemeFlag(rawTheme);
   const locale = parseLocaleFlag(rawLocale);
@@ -338,9 +338,9 @@ function parseReducedMotionFlag(raw: string | undefined): boolean {
   return normalized === '1' || normalized === 'true' || normalized === 'yes';
 }
 
-export function getE2EFixtureState(fixture: E2EFixture | null): E2EFixtureState | null {
+export function getE2eFixtureState(fixture: E2eFixture | null): E2eFixtureState | null {
   if (!fixture) return null;
-  const state: E2EFixtureState = {
+  const state: E2eFixtureState = {
     enabled: true,
     now: E2E_FIXTURE_NOW,
     ...(fixture.reducedMotion ? { reducedMotion: true } : {}),
@@ -387,7 +387,7 @@ export function getE2EFixtureState(fixture: E2EFixture | null): E2EFixtureState 
       // session so BrowserPanel mounts over the chat. No native
       // WebContentsView exists in e2e-fixture mode, so browser.getState
       // resolves null → BrowserPanel renders EMPTY_STATE → the empty-state
-      // chrome is what E2E/audit see (the #818 defect surface).
+      // chrome is what the alignment audit sees (the #818 defect surface).
       // Loaded / loading / nav chrome states are locked by the
       // `browser-panel-chrome` source contract; they add no layout
       // value over this empty-state fixture.
@@ -401,7 +401,7 @@ export function getE2EFixtureState(fixture: E2EFixture | null): E2EFixtureState 
     case 'streaming-answer':
       // Active session = the committed turn-narrative session, PLUS a live
       // answer streaming into it. The main panel then shows a settled turn
-      // and the in-flight bubble together, so E2E/audit can prove they
+      // and the in-flight bubble together, so the alignment audit can prove they
       // share the same centered column (the streaming-turn-center fix).
       return {
         ...state,
@@ -529,9 +529,9 @@ export function getE2EFixtureState(fixture: E2EFixture | null): E2EFixtureState 
       // shares the sidebar-long-sessions seed (60 sessions) so the
       // sidebar behind the modal is identical to the long-sessions
       // fixture; `searchModalOpen: true` is the only differentiator.
-      // The renderer reads the flag in `applyE2EFixture()` and
+      // The renderer reads the flag in `applyE2eFixture()` and
       // calls `setSearchModalOpen(true)` before the fixture settles,
-      // so the SearchModal shell is on screen for E2E/audit.
+      // so the SearchModal shell is on screen for the alignment audit.
       return {
         ...state,
         activeSessionId: LONG_SIDEBAR_SESSION_PREFIX + '00',
@@ -541,7 +541,7 @@ export function getE2EFixtureState(fixture: E2EFixture | null): E2EFixtureState 
     case 'command-palette-open':
       // PR-shared primitive-COMMAND-INPUT-0: same 60-session seed as the sidebar
       // fixtures; `paletteOpen: true` is the only differentiator so
-      // the command palette shell is visible for E2E/audit.
+      // the command palette shell is visible for the alignment audit.
       return {
         ...state,
         activeSessionId: LONG_SIDEBAR_SESSION_PREFIX + '00',
@@ -581,9 +581,9 @@ export function getE2EFixtureState(fixture: E2EFixture | null): E2EFixtureState 
   return state;
 }
 
-export async function seedE2EFixture(input: {
+export async function seedE2eFixture(input: {
   workspaceRoot: string;
-  fixture: E2EFixture;
+  fixture: E2eFixture;
   credentialStore: Pick<CredentialStore, 'setSecret'>;
   now?: number;
 }): Promise<void> {
@@ -655,7 +655,7 @@ export async function seedE2EFixture(input: {
   // Phase 2 fixup v3: `sidebar-search-modal-open` shares the same
   // 60-session seed so the sidebar behind the modal matches the
   // long-sessions fixture exactly. The modal-open state itself is a
-  // transient renderer flag (`E2EFixtureState.searchModalOpen`); no
+  // transient renderer flag (`E2eFixtureState.searchModalOpen`); no
   // additional on-disk seeding required.
   if (LONG_SIDEBAR_SCENARIOS.has(input.fixture.scenario)) {
     for (const seed of longSidebarSessions(now)) {

--- a/apps/desktop/src/main/e2e-fixture/scenarios-artifacts.ts
+++ b/apps/desktop/src/main/e2e-fixture/scenarios-artifacts.ts
@@ -1,6 +1,6 @@
 import { mkdir, stat, writeFile } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
-import type { ArtifactRecord, SessionHeader, StoredMessage, VisualSmokeScenario } from '@maka/core';
+import type { ArtifactRecord, SessionHeader, StoredMessage, E2EFixtureScenario } from '@maka/core';
 import { ARTIFACT_SESSION_ID, header } from './seed-helpers.js';
 
 export function artifactSession(now: number): SessionHeader {
@@ -32,7 +32,7 @@ export function artifactMessages(now: number): StoredMessage[] {
       toolName: 'Write',
       displayName: '写入生成文件',
       intent: '生成 report.html / patch.diff / notes.md 三个生成文件',
-      args: { path: 'artifacts/visual-smoke' },
+      args: { path: 'artifacts/e2e-fixture' },
     },
     {
       type: 'assistant',
@@ -45,12 +45,12 @@ export function artifactMessages(now: number): StoredMessage[] {
   ];
 }
 
-export async function writeArtifacts(workspaceRoot: string, now: number, scenario: VisualSmokeScenario): Promise<void> {
+export async function writeArtifacts(workspaceRoot: string, now: number, scenario: E2EFixtureScenario): Promise<void> {
   const root = join(workspaceRoot, 'artifacts');
   // PR-UI-RENDER-3a-smoke: dedicated preview scenarios get their
   // own short artifact list (single artifact each) so the
   // ArtifactPane default selection deterministically picks the one
-  // the screenshot is meant to capture. The `sizeBytesOverride`
+  // the fixture is meant to render. The `sizeBytesOverride`
   // field bypasses the post-write `stat().size` overwrite so we
   // can claim 3MB in metadata without writing 3MB to disk.
   type ArtifactSpec = {

--- a/apps/desktop/src/main/e2e-fixture/scenarios-artifacts.ts
+++ b/apps/desktop/src/main/e2e-fixture/scenarios-artifacts.ts
@@ -1,6 +1,6 @@
 import { mkdir, stat, writeFile } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
-import type { ArtifactRecord, SessionHeader, StoredMessage, E2EFixtureScenario } from '@maka/core';
+import type { ArtifactRecord, SessionHeader, StoredMessage, E2eFixtureScenario } from '@maka/core';
 import { ARTIFACT_SESSION_ID, header } from './seed-helpers.js';
 
 export function artifactSession(now: number): SessionHeader {
@@ -45,7 +45,7 @@ export function artifactMessages(now: number): StoredMessage[] {
   ];
 }
 
-export async function writeArtifacts(workspaceRoot: string, now: number, scenario: E2EFixtureScenario): Promise<void> {
+export async function writeArtifacts(workspaceRoot: string, now: number, scenario: E2eFixtureScenario): Promise<void> {
   const root = join(workspaceRoot, 'artifacts');
   // PR-UI-RENDER-3a-smoke: dedicated preview scenarios get their
   // own short artifact list (single artifact each) so the

--- a/apps/desktop/src/main/e2e-fixture/scenarios-chat.ts
+++ b/apps/desktop/src/main/e2e-fixture/scenarios-chat.ts
@@ -4,7 +4,7 @@ import type {
   PermissionRequestEvent,
   SessionHeader,
   StoredMessage,
-  VisualSmokeState,
+  E2EFixtureState,
 } from '@maka/core';
 import {
   ERROR_SESSION_ID,
@@ -13,7 +13,7 @@ import {
   PROCESSING_SESSION_ID,
   STREAMING_SESSION_ID,
   TURN_SESSION_ID,
-  VISUAL_SMOKE_NOW,
+  E2E_FIXTURE_NOW,
 } from './seed-helpers.js';
 
 // PR-STREAM-TURN-CENTER: realistic multi-block markdown (heading + paragraph +
@@ -370,7 +370,7 @@ export function errorMessages(now: number): StoredMessage[] {
   ];
 }
 
-export function streamingLiveTurns(): NonNullable<VisualSmokeState['liveTurnBySession']> {
+export function streamingLiveTurns(): NonNullable<E2EFixtureState['liveTurnBySession']> {
   return {
     [STREAMING_SESSION_ID]: {
       turnId: 'turn-streaming',
@@ -389,14 +389,14 @@ export function streamingLiveTurns(): NonNullable<VisualSmokeState['liveTurnBySe
           displayName: '运行中的诊断',
           intent: '模拟后台 stream 中的 tool activity',
           status: 'running',
-          args: { cmd: 'npm run visual-smoke:fixture' },
+          args: { cmd: 'npm run e2e-fixture:fixture' },
         }],
       }],
     },
   };
 }
 
-export function streamingAnswerLiveTurns(): NonNullable<VisualSmokeState['liveTurnBySession']> {
+export function streamingAnswerLiveTurns(): NonNullable<E2EFixtureState['liveTurnBySession']> {
   return {
     [TURN_SESSION_ID]: {
       turnId: 'turn-fixture-2',
@@ -410,7 +410,7 @@ export function streamingAnswerLiveTurns(): NonNullable<VisualSmokeState['liveTu
   };
 }
 
-export function processingLiveTurns(): NonNullable<VisualSmokeState['liveTurnBySession']> {
+export function processingLiveTurns(): NonNullable<E2EFixtureState['liveTurnBySession']> {
   return {
     [PROCESSING_SESSION_ID]: {
       turnId: 'turn-processing-1',
@@ -420,14 +420,14 @@ export function processingLiveTurns(): NonNullable<VisualSmokeState['liveTurnByS
   };
 }
 
-export function permissionState(): NonNullable<VisualSmokeState['permissionBySession']> {
+export function permissionState(): NonNullable<E2EFixtureState['permissionBySession']> {
   return {
-    [PERMISSION_SESSION_ID]: permissionRequest(VISUAL_SMOKE_NOW),
+    [PERMISSION_SESSION_ID]: permissionRequest(E2E_FIXTURE_NOW),
   };
 }
 
-export function permissionLiveTurns(): NonNullable<VisualSmokeState['liveTurnBySession']> {
-  const request = permissionRequest(VISUAL_SMOKE_NOW);
+export function permissionLiveTurns(): NonNullable<E2EFixtureState['liveTurnBySession']> {
+  const request = permissionRequest(E2E_FIXTURE_NOW);
   return {
     [PERMISSION_SESSION_ID]: {
       turnId: 'turn-permission',
@@ -451,10 +451,10 @@ function permissionRequest(now: number): PermissionRequestEvent {
   return {
     type: 'permission_request',
     kind: 'tool_permission',
-    id: 'visual-smoke-permission-event',
+    id: 'e2e-fixture-permission-event',
     turnId: 'turn-permission',
     ts: now,
-    requestId: 'visual-smoke-permission-request',
+    requestId: 'e2e-fixture-permission-request',
     toolUseId: 'permission-tool',
     toolName: 'Bash',
     category: 'fs_destructive',

--- a/apps/desktop/src/main/e2e-fixture/scenarios-chat.ts
+++ b/apps/desktop/src/main/e2e-fixture/scenarios-chat.ts
@@ -4,7 +4,7 @@ import type {
   PermissionRequestEvent,
   SessionHeader,
   StoredMessage,
-  E2EFixtureState,
+  E2eFixtureState,
 } from '@maka/core';
 import {
   ERROR_SESSION_ID,
@@ -370,7 +370,7 @@ export function errorMessages(now: number): StoredMessage[] {
   ];
 }
 
-export function streamingLiveTurns(): NonNullable<E2EFixtureState['liveTurnBySession']> {
+export function streamingLiveTurns(): NonNullable<E2eFixtureState['liveTurnBySession']> {
   return {
     [STREAMING_SESSION_ID]: {
       turnId: 'turn-streaming',
@@ -396,7 +396,7 @@ export function streamingLiveTurns(): NonNullable<E2EFixtureState['liveTurnBySes
   };
 }
 
-export function streamingAnswerLiveTurns(): NonNullable<E2EFixtureState['liveTurnBySession']> {
+export function streamingAnswerLiveTurns(): NonNullable<E2eFixtureState['liveTurnBySession']> {
   return {
     [TURN_SESSION_ID]: {
       turnId: 'turn-fixture-2',
@@ -410,7 +410,7 @@ export function streamingAnswerLiveTurns(): NonNullable<E2EFixtureState['liveTur
   };
 }
 
-export function processingLiveTurns(): NonNullable<E2EFixtureState['liveTurnBySession']> {
+export function processingLiveTurns(): NonNullable<E2eFixtureState['liveTurnBySession']> {
   return {
     [PROCESSING_SESSION_ID]: {
       turnId: 'turn-processing-1',
@@ -420,13 +420,13 @@ export function processingLiveTurns(): NonNullable<E2EFixtureState['liveTurnBySe
   };
 }
 
-export function permissionState(): NonNullable<E2EFixtureState['permissionBySession']> {
+export function permissionState(): NonNullable<E2eFixtureState['permissionBySession']> {
   return {
     [PERMISSION_SESSION_ID]: permissionRequest(E2E_FIXTURE_NOW),
   };
 }
 
-export function permissionLiveTurns(): NonNullable<E2EFixtureState['liveTurnBySession']> {
+export function permissionLiveTurns(): NonNullable<E2eFixtureState['liveTurnBySession']> {
   const request = permissionRequest(E2E_FIXTURE_NOW);
   return {
     [PERMISSION_SESSION_ID]: {

--- a/apps/desktop/src/main/e2e-fixture/scenarios-deep-research.ts
+++ b/apps/desktop/src/main/e2e-fixture/scenarios-deep-research.ts
@@ -7,7 +7,7 @@ import {
 import type { DeepResearchEvent, SessionHeader, StoredMessage } from '@maka/core';
 import { header } from './seed-helpers.js';
 
-export const DEEP_RESEARCH_SESSION_ID = 'visual-smoke-deep-research';
+export const DEEP_RESEARCH_SESSION_ID = 'e2e-fixture-deep-research';
 
 export function deepResearchSession(now: number): SessionHeader {
   return {

--- a/apps/desktop/src/main/e2e-fixture/scenarios-modules.ts
+++ b/apps/desktop/src/main/e2e-fixture/scenarios-modules.ts
@@ -4,8 +4,8 @@ import { writeJson } from './seed-helpers.js';
 
 /**
  * MCP module fixture: seeds an mcp.json with a couple of installed servers so
- * the 已安装 tab and the server rows render for the alignment auditor + CDP
- * capture. Both are `enabled: false` so no real `npx` / HTTP connection is
+ * the 已安装 tab and the server rows render for the alignment auditor.
+ * Both are `enabled: false` so no real `npx` / HTTP connection is
  * attempted in e2e-fixture mode — the rows render deterministically in the
  * neutral 已停用 state (exception-only status: no color unless a real failure).
  * The 市场 tab is the default surface and is driven by the static MCP_CATALOG,

--- a/apps/desktop/src/main/e2e-fixture/scenarios-modules.ts
+++ b/apps/desktop/src/main/e2e-fixture/scenarios-modules.ts
@@ -6,7 +6,7 @@ import { writeJson } from './seed-helpers.js';
  * MCP module fixture: seeds an mcp.json with a couple of installed servers so
  * the 已安装 tab and the server rows render for the alignment auditor + CDP
  * capture. Both are `enabled: false` so no real `npx` / HTTP connection is
- * attempted in visual-smoke mode — the rows render deterministically in the
+ * attempted in e2e-fixture mode — the rows render deterministically in the
  * neutral 已停用 state (exception-only status: no color unless a real failure).
  * The 市场 tab is the default surface and is driven by the static MCP_CATALOG,
  * so it renders without any on-disk seed.

--- a/apps/desktop/src/main/e2e-fixture/scenarios-sessions.ts
+++ b/apps/desktop/src/main/e2e-fixture/scenarios-sessions.ts
@@ -470,7 +470,7 @@ function turnControlPrimaryMessages(now: number): StoredMessage[] {
  * Minimal message log for branch sessions. Branches start with a
  * single completed turn so the chat surface has visible content, but
  * we don't reproduce every parent turn (that would defeat the point of
- * the screenshot — banner-vs-no-banner is the contract under test).
+ * the fixture — banner-vs-no-banner is the contract under test).
  */
 function turnControlBranchMessages(now: number, kind: 'visible' | 'orphan'): StoredMessage[] {
   const turnId = `turn-${kind}-branch`;

--- a/apps/desktop/src/main/e2e-fixture/scenarios-settings.ts
+++ b/apps/desktop/src/main/e2e-fixture/scenarios-settings.ts
@@ -4,18 +4,18 @@ import type {
   DailyReviewArchive,
   LlmConnection,
   PlanReminder,
-  VisualSmokeScenario,
+  E2EFixtureScenario,
 } from '@maka/core';
 import { createDefaultSettings } from '@maka/core/settings';
 import { writeJson } from './seed-helpers.js';
 
 export async function writeSettings(
   workspaceRoot: string,
-  scenario?: VisualSmokeScenario,
+  scenario?: E2EFixtureScenario,
 ): Promise<void> {
   // PR-SIDEBAR-IA-0 Phase 3 P0 fixup v2 (kenji `08be08d8` + WAWQAQ
   // `1886c41b`): the fixture previously seeded a placeholder
-  // Chinese personal name for screenshot baselines, but a real
+  // Chinese personal name for deterministic rendering, but a real
   // user reading the chat surface can't tell who that placeholder
   // is. Worse, if a demo workspace was ever opened on top of a
   // real user's workspace, the placeholder would persist and
@@ -23,13 +23,13 @@ export async function writeSettings(
   //
   // Phase 3 fixup v2 leaves `displayName` empty so screenshots and
   // Settings match a new, unconfigured user. Settings test
-  // (`visual-smoke-fixture.test.ts`) asserts the empty-string value
+  // (`e2e-fixture.test.ts`) asserts the empty-string value
   // so a future patch that re-adds a demo name lands as an explicit
   // copy decision, not silent drift.
   const settings = createDefaultSettings();
   settings.personalization.displayName = '';
   settings.appearance.theme = 'auto';
-  // Settings → 使用统计: the seeded traffic uses the fixed visual-smoke clock,
+  // Settings → 使用统计: the seeded traffic uses the fixed e2e-fixture clock,
   // which sits outside the real-time 24h/7天/30天 windows the store derives
   // from Date.now(). Default the usage view to 全部 + details-on so the
   // capture shows the populated request log and stats tables deterministically.
@@ -40,7 +40,7 @@ export async function writeSettings(
   await writeJson(join(workspaceRoot, 'settings.json'), settings);
 }
 
-export async function writeConnections(workspaceRoot: string, now: number, scenario: VisualSmokeScenario): Promise<void> {
+export async function writeConnections(workspaceRoot: string, now: number, scenario: E2EFixtureScenario): Promise<void> {
   const connections: LlmConnection[] = [
     {
       slug: 'zai-live',
@@ -160,7 +160,7 @@ export async function writeConnections(workspaceRoot: string, now: number, scena
   });
 }
 
-function connectionFocusSlug(scenario: VisualSmokeScenario): string | null {
+function connectionFocusSlug(scenario: E2EFixtureScenario): string | null {
   switch (scenario) {
     case 'fallback-source':
       return 'relay-fallback';
@@ -300,7 +300,7 @@ export async function writeDailyReviewArchives(workspaceRoot: string, now: numbe
     sections: {
       summary: '深度分析覆盖最近一轮 Maka UI 打磨：参考布局学习、权限中心重画、Daily Review 从聚合面板走向可保存报告。',
       gaps: '第一性原理层面需要把“模块页 shell / Settings row / 状态 pill / 操作按钮”抽成真实组件，否则后续仍会在 CSS 中继续堆叠局部规则。',
-      usage: '高频动作是读取源码、运行 contract、构建 renderer、生成 visual-smoke 截图。失败成本主要来自多处页面壳层行为不统一。',
+      usage: '高频动作是读取源码、运行 contract、构建 renderer、生成 e2e-fixture 截图。失败成本主要来自多处页面壳层行为不统一。',
       code: '下一步优先建立模块页 PageShell、SettingsActionRow 和 StatusPill primitives，再迁移 Daily Review、权限中心、计划任务和技能页。',
     },
   };

--- a/apps/desktop/src/main/e2e-fixture/scenarios-settings.ts
+++ b/apps/desktop/src/main/e2e-fixture/scenarios-settings.ts
@@ -4,14 +4,14 @@ import type {
   DailyReviewArchive,
   LlmConnection,
   PlanReminder,
-  E2EFixtureScenario,
+  E2eFixtureScenario,
 } from '@maka/core';
 import { createDefaultSettings } from '@maka/core/settings';
 import { writeJson } from './seed-helpers.js';
 
 export async function writeSettings(
   workspaceRoot: string,
-  scenario?: E2EFixtureScenario,
+  scenario?: E2eFixtureScenario,
 ): Promise<void> {
   // PR-SIDEBAR-IA-0 Phase 3 P0 fixup v2 (kenji `08be08d8` + WAWQAQ
   // `1886c41b`): the fixture previously seeded a placeholder
@@ -40,7 +40,7 @@ export async function writeSettings(
   await writeJson(join(workspaceRoot, 'settings.json'), settings);
 }
 
-export async function writeConnections(workspaceRoot: string, now: number, scenario: E2EFixtureScenario): Promise<void> {
+export async function writeConnections(workspaceRoot: string, now: number, scenario: E2eFixtureScenario): Promise<void> {
   const connections: LlmConnection[] = [
     {
       slug: 'zai-live',
@@ -160,7 +160,7 @@ export async function writeConnections(workspaceRoot: string, now: number, scena
   });
 }
 
-function connectionFocusSlug(scenario: E2EFixtureScenario): string | null {
+function connectionFocusSlug(scenario: E2eFixtureScenario): string | null {
   switch (scenario) {
     case 'fallback-source':
       return 'relay-fallback';

--- a/apps/desktop/src/main/e2e-fixture/scenarios-usage.ts
+++ b/apps/desktop/src/main/e2e-fixture/scenarios-usage.ts
@@ -113,7 +113,7 @@ export function usageStatsSessions(
   return [
     {
       header: usageSession(now, {
-        id: 'visual-smoke-usage-glm',
+        id: 'e2e-fixture-usage-glm',
         name: '用量样本 · GLM 工作区',
         connection: 'zai-live',
         model: 'glm-5.1',
@@ -145,7 +145,7 @@ export function usageStatsSessions(
     },
     {
       header: usageSession(now, {
-        id: 'visual-smoke-usage-claude',
+        id: 'e2e-fixture-usage-claude',
         name: '用量样本 · Claude 中继',
         connection: 'relay-fallback',
         model: 'claude-sonnet-4.5',
@@ -175,7 +175,7 @@ export function usageStatsSessions(
     },
     {
       header: usageSession(now, {
-        id: 'visual-smoke-usage-gpt',
+        id: 'e2e-fixture-usage-gpt',
         name: '用量样本 · GPT 备用',
         connection: 'needs-reauth',
         model: 'gpt-5.1-mini',

--- a/apps/desktop/src/main/e2e-fixture/seed-helpers.ts
+++ b/apps/desktop/src/main/e2e-fixture/seed-helpers.ts
@@ -1,42 +1,42 @@
 import { mkdir, writeFile } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
-import type { SessionHeader, StoredMessage, VisualSmokeScenario } from '@maka/core';
+import type { SessionHeader, StoredMessage, E2EFixtureScenario } from '@maka/core';
 
 // Fixed clock for screenshot fixtures. All seeded timestamps and
 // transient smoke state derive from this value unless tests explicitly
 // pass `now`, so two baseline runs produce identical visible time copy.
-export const VISUAL_SMOKE_NOW = Date.UTC(2026, 4, 22, 3, 0, 0);
+export const E2E_FIXTURE_NOW = Date.UTC(2026, 4, 22, 3, 0, 0);
 
-export const TURN_SESSION_ID = 'visual-smoke-turn';
-export const LONG_TRANSCRIPT_SESSION_ID = 'visual-smoke-long-transcript';
-export const PROCESSING_SESSION_ID = 'visual-smoke-processing';
-export const STREAMING_SESSION_ID = 'visual-smoke-streaming';
-export const PERMISSION_SESSION_ID = 'visual-smoke-permission';
-export const WORKSTATION_RUNNING_SESSION_ID = 'visual-smoke-ws-running';
-export const WORKSTATION_WAITING_SESSION_ID = 'visual-smoke-ws-waiting';
-export const WORKSTATION_BLOCKED_AUTH_SESSION_ID = 'visual-smoke-ws-blocked-auth';
-export const WORKSTATION_BLOCKED_PERM_SESSION_ID = 'visual-smoke-ws-blocked-perm';
-export const WORKSTATION_BLOCKED_TOOL_SESSION_ID = 'visual-smoke-ws-blocked-tool';
-export const WORKSTATION_BLOCKED_UNKNOWN_SESSION_ID = 'visual-smoke-ws-blocked-unknown';
-export const WORKSTATION_ACTIVE_SESSION_ID = 'visual-smoke-ws-active';
-export const WORKSTATION_REVIEW_SESSION_ID = 'visual-smoke-ws-review';
-export const WORKSTATION_DONE_SESSION_ID = 'visual-smoke-ws-done';
-export const WORKSTATION_ARCHIVED_SESSION_ID = 'visual-smoke-ws-archived';
-export const WORKSTATION_ABORTED_SESSION_ID = 'visual-smoke-ws-aborted';
-export const ERROR_SESSION_ID = 'visual-smoke-error';
-export const ARTIFACT_SESSION_ID = 'visual-smoke-artifact';
-export const STALE_FAKE_SESSION_ID = 'visual-smoke-stale-fake';
-export const STALE_LEGACY_SESSION_ID = 'visual-smoke-stale-legacy';
-export const HEALTHY_SESSION_ID = 'visual-smoke-healthy';
+export const TURN_SESSION_ID = 'e2e-fixture-turn';
+export const LONG_TRANSCRIPT_SESSION_ID = 'e2e-fixture-long-transcript';
+export const PROCESSING_SESSION_ID = 'e2e-fixture-processing';
+export const STREAMING_SESSION_ID = 'e2e-fixture-streaming';
+export const PERMISSION_SESSION_ID = 'e2e-fixture-permission';
+export const WORKSTATION_RUNNING_SESSION_ID = 'e2e-fixture-ws-running';
+export const WORKSTATION_WAITING_SESSION_ID = 'e2e-fixture-ws-waiting';
+export const WORKSTATION_BLOCKED_AUTH_SESSION_ID = 'e2e-fixture-ws-blocked-auth';
+export const WORKSTATION_BLOCKED_PERM_SESSION_ID = 'e2e-fixture-ws-blocked-perm';
+export const WORKSTATION_BLOCKED_TOOL_SESSION_ID = 'e2e-fixture-ws-blocked-tool';
+export const WORKSTATION_BLOCKED_UNKNOWN_SESSION_ID = 'e2e-fixture-ws-blocked-unknown';
+export const WORKSTATION_ACTIVE_SESSION_ID = 'e2e-fixture-ws-active';
+export const WORKSTATION_REVIEW_SESSION_ID = 'e2e-fixture-ws-review';
+export const WORKSTATION_DONE_SESSION_ID = 'e2e-fixture-ws-done';
+export const WORKSTATION_ARCHIVED_SESSION_ID = 'e2e-fixture-ws-archived';
+export const WORKSTATION_ABORTED_SESSION_ID = 'e2e-fixture-ws-aborted';
+export const ERROR_SESSION_ID = 'e2e-fixture-error';
+export const ARTIFACT_SESSION_ID = 'e2e-fixture-artifact';
+export const STALE_FAKE_SESSION_ID = 'e2e-fixture-stale-fake';
+export const STALE_LEGACY_SESSION_ID = 'e2e-fixture-stale-legacy';
+export const HEALTHY_SESSION_ID = 'e2e-fixture-healthy';
 // PR109f (g): turn-control-history primary + branch sessions. The
 // `BRANCH_ORPHAN` session's `parentSessionId` intentionally references
 // a session id that is NEVER written to disk so the renderer's
 // `deriveBranchBanner()` resolves the parent as missing and renders no
 // banner in the negative screenshot case.
-export const TURN_CONTROL_PRIMARY_SESSION_ID = 'visual-smoke-turn-control-primary';
-export const TURN_CONTROL_BRANCH_VISIBLE_SESSION_ID = 'visual-smoke-turn-control-branch-visible';
-export const TURN_CONTROL_BRANCH_ORPHAN_SESSION_ID = 'visual-smoke-turn-control-branch-orphan';
-export const TURN_CONTROL_ORPHAN_PARENT_ID = 'visual-smoke-turn-control-deleted-parent';
+export const TURN_CONTROL_PRIMARY_SESSION_ID = 'e2e-fixture-turn-control-primary';
+export const TURN_CONTROL_BRANCH_VISIBLE_SESSION_ID = 'e2e-fixture-turn-control-branch-visible';
+export const TURN_CONTROL_BRANCH_ORPHAN_SESSION_ID = 'e2e-fixture-turn-control-branch-orphan';
+export const TURN_CONTROL_ORPHAN_PARENT_ID = 'e2e-fixture-turn-control-deleted-parent';
 
 /**
  * PR-SIDEBAR-IA-0 Phase 1: sidebar-long-sessions scenario seeds many
@@ -45,7 +45,7 @@ export const TURN_CONTROL_ORPHAN_PARENT_ID = 'visual-smoke-turn-control-deleted-
  * lastMessageAt). Path is short so it stays stable in screenshot
  * baselines.
  */
-export const LONG_SIDEBAR_SESSION_PREFIX = 'visual-smoke-sidebar-long-';
+export const LONG_SIDEBAR_SESSION_PREFIX = 'e2e-fixture-sidebar-long-';
 export const LONG_SIDEBAR_SESSION_COUNT = 60;
 
 /**
@@ -53,7 +53,7 @@ export const LONG_SIDEBAR_SESSION_COUNT = 60;
  * Kept as a Set so future scenarios reusing the same seed can be
  * registered in one place. Mirrors `TURN_CONTROL_SCENARIOS`.
  */
-export const LONG_SIDEBAR_SCENARIOS = new Set<VisualSmokeScenario>([
+export const LONG_SIDEBAR_SCENARIOS = new Set<E2EFixtureScenario>([
   'module-skills',
   'module-daily-review',
   'plan-reminders',
@@ -69,7 +69,7 @@ export const LONG_SIDEBAR_SCENARIOS = new Set<VisualSmokeScenario>([
  * they're variants of the same state family (active session differs,
  * everything else identical).
  */
-export const TURN_CONTROL_SCENARIOS = new Set<VisualSmokeScenario>([
+export const TURN_CONTROL_SCENARIOS = new Set<E2EFixtureScenario>([
   'turn-control-history',
   'turn-control-branch-visible',
   'turn-control-branch-orphan',
@@ -102,7 +102,7 @@ export function header(input: {
 }): SessionHeader {
   return {
     id: input.id,
-    workspaceRoot: 'visual-smoke',
+    workspaceRoot: 'e2e-fixture',
     cwd: '/workspace/maka',
     createdAt: input.now - 3_600_000,
     lastUsedAt: input.lastMessageAt,

--- a/apps/desktop/src/main/e2e-fixture/seed-helpers.ts
+++ b/apps/desktop/src/main/e2e-fixture/seed-helpers.ts
@@ -2,9 +2,9 @@ import { mkdir, writeFile } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
 import type { SessionHeader, StoredMessage, E2EFixtureScenario } from '@maka/core';
 
-// Fixed clock for screenshot fixtures. All seeded timestamps and
-// transient smoke state derive from this value unless tests explicitly
-// pass `now`, so two baseline runs produce identical visible time copy.
+// Fixed clock for the e2e-fixture. All seeded timestamps and
+// transient fixture state derive from this value unless tests explicitly
+// pass `now`, so two runs produce identical visible time copy.
 export const E2E_FIXTURE_NOW = Date.UTC(2026, 4, 22, 3, 0, 0);
 
 export const TURN_SESSION_ID = 'e2e-fixture-turn';

--- a/apps/desktop/src/main/e2e-fixture/seed-helpers.ts
+++ b/apps/desktop/src/main/e2e-fixture/seed-helpers.ts
@@ -1,6 +1,6 @@
 import { mkdir, writeFile } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
-import type { SessionHeader, StoredMessage, E2EFixtureScenario } from '@maka/core';
+import type { SessionHeader, StoredMessage, E2eFixtureScenario } from '@maka/core';
 
 // Fixed clock for the e2e-fixture. All seeded timestamps and
 // transient fixture state derive from this value unless tests explicitly
@@ -53,7 +53,7 @@ export const LONG_SIDEBAR_SESSION_COUNT = 60;
  * Kept as a Set so future scenarios reusing the same seed can be
  * registered in one place. Mirrors `TURN_CONTROL_SCENARIOS`.
  */
-export const LONG_SIDEBAR_SCENARIOS = new Set<E2EFixtureScenario>([
+export const LONG_SIDEBAR_SCENARIOS = new Set<E2eFixtureScenario>([
   'module-skills',
   'module-daily-review',
   'plan-reminders',
@@ -69,7 +69,7 @@ export const LONG_SIDEBAR_SCENARIOS = new Set<E2EFixtureScenario>([
  * they're variants of the same state family (active session differs,
  * everything else identical).
  */
-export const TURN_CONTROL_SCENARIOS = new Set<E2EFixtureScenario>([
+export const TURN_CONTROL_SCENARIOS = new Set<E2eFixtureScenario>([
   'turn-control-history',
   'turn-control-branch-visible',
   'turn-control-branch-orphan',

--- a/apps/desktop/src/main/main-window.ts
+++ b/apps/desktop/src/main/main-window.ts
@@ -367,7 +367,7 @@ export function createMainWindowController(deps: MainWindowControllerDeps): Main
     // let a cold Vite transform or slow disk consume the whole timeout and
     // reveal index.html's preload skeleton before React had a chance to paint.
     // If renderer-ready arrived while loadURL/loadFile was resolving, the
-    // window is already visible and no timer is needed. Visual-smoke windows
+    // window is already visible and no timer is needed. E2e-fixture windows
     // remain hidden for their whole lifecycle.
     if (!keepHiddenForE2EFixture && !mainWindow.isVisible()) {
       showFallbackTimer = setTimeout(() => {

--- a/apps/desktop/src/main/main-window.ts
+++ b/apps/desktop/src/main/main-window.ts
@@ -7,7 +7,7 @@ import { errorMessage } from './chat-readiness.js';
 import { readSavedBounds, writeSavedBounds, SAFE_MIN_HEIGHT, SAFE_MIN_WIDTH, type SavedBounds } from './window-state.js';
 import { BrowserViewController } from './browser/controller.js';
 import { BrowserViewManager } from './browser/view-manager.js';
-import type { VisualSmokeFixture } from './visual-smoke-fixture.js';
+import type { E2EFixture } from './e2e-fixture.js';
 import { isThemePreference, toNativeThemeSource } from './theme-source.js';
 import { createWindowRevealGate } from './window-reveal.js';
 
@@ -19,7 +19,7 @@ export interface MainWindowController {
   createWindow(): Promise<void>;
   send(channel: string, ...args: unknown[]): void;
   // PR-SHOW-AFTER-FIRST-COMMIT: reveal the hidden window after the renderer's
-  // first React commit. Idempotent + visual-smoke-safe (see notifyRendererReady).
+  // first React commit. Idempotent + e2e-fixture-safe (see notifyRendererReady).
   notifyRendererReady(): void;
   setTitlebarControlsVisible(sender: Electron.WebContents, visible: unknown): void;
   setThemeSource(sender: Electron.WebContents, themePref: unknown): void;
@@ -38,7 +38,7 @@ export interface MainWindowController {
 
 interface MainWindowControllerDeps {
   workspaceRoot: string;
-  visualSmokeFixture: VisualSmokeFixture | null;
+  e2eFixture: E2EFixture | null;
   settingsStore: SettingsReader;
   // main.ts computes this from the same isE2e gate that also guards userData
   // and the fake backend, so main-window.ts owns no env policy of its own.
@@ -101,21 +101,21 @@ const titleBarOverlayOptions = (
 });
 
 export function createMainWindowController(deps: MainWindowControllerDeps): MainWindowController {
-  const { workspaceRoot, visualSmokeFixture, settingsStore, startHidden } = deps;
+  const { workspaceRoot, e2eFixture, settingsStore, startHidden } = deps;
 
   // PR-SHOW-AFTER-FIRST-COMMIT: windows launched hidden (startHidden covers
-  // visual-smoke capture and E2E — see main.ts) must never be revealed;
-  // visual-smoke captures run on the hidden window and E2E drives it headless.
+  // e2e-fixture capture and E2E — see main.ts) must never be revealed;
+  // e2e-fixture captures run on the hidden window and E2E drives it headless.
   // `!app.isPackaged` mirrors the original creation-time gate so a packaged
   // build ignores a stray startHidden flag. The fallback timer, the
   // renderer-ready IPC, and focus() all route their show() through this
   // predicate via the reveal gate below.
-  const keepHiddenForVisualSmoke = !app.isPackaged && startHidden;
+  const keepHiddenForE2EFixture = !app.isPackaged && startHidden;
   // ChatGPT Pro review P2: focus() (second-instance / activate) used to call
   // mainWindow.show() directly, bypassing the reveal gate — re-launching or
   // clicking the dock icon during the pre-commit window would flash the
   // skeleton anyway. The gate defers those focus requests until markReady.
-  const revealGate = createWindowRevealGate(keepHiddenForVisualSmoke);
+  const revealGate = createWindowRevealGate(keepHiddenForE2EFixture);
   let showFallbackTimer: NodeJS.Timeout | undefined;
   const clearShowFallbackTimer = (): void => {
     if (showFallbackTimer) {
@@ -151,8 +151,8 @@ export function createMainWindowController(deps: MainWindowControllerDeps): Main
     // load, validate the saved x/y against the current display layout — if
     // the previous external monitor is gone, drop x/y so Electron centers
     // the window on the primary display instead of opening it off-screen.
-    const defaults = visualSmokeWindowBounds(visualSmokeFixture, { width: 1240, height: 820 });
-    const savedBounds = visualSmokeFixture
+    const defaults = e2eFixtureWindowBounds(e2eFixture, { width: 1240, height: 820 });
+    const savedBounds = e2eFixture
       ? defaults
       : await readSavedBounds(workspaceRoot, defaults);
     const bounds = clampBoundsToVisibleDisplay(savedBounds);
@@ -162,12 +162,12 @@ export function createMainWindowController(deps: MainWindowControllerDeps): Main
     // but the BrowserWindow's `backgroundColor` shows during the first frame
     // before the renderer paints. Pick the right initial bg by reading the
     // persisted theme + system preference.
-    // PR-IR-01b: visual smoke theme override wins over the persisted user
+    // PR-IR-01b: e2e-fixture theme override wins over the persisted user
     // pref. This guarantees the BrowserWindow backgroundColor matches the
     // theme variant we're about to screenshot, so the very first frame
     // doesn't capture a light-on-dark or dark-on-light flash.
     const persistedTheme = (await settingsStore.get()).appearance?.theme ?? 'auto';
-    const themePref = visualSmokeFixture?.theme ?? persistedTheme;
+    const themePref = e2eFixture?.theme ?? persistedTheme;
     const isDark =
       themePref === 'dark' ||
       (themePref === 'auto' && nativeTheme.shouldUseDarkColors);
@@ -243,9 +243,9 @@ export function createMainWindowController(deps: MainWindowControllerDeps): Main
       // (Big Sur+). Renderer CSS gates the transparency on
       // `[data-vibrancy="active"]` so non-macOS builds (where vibrancy is
       // a no-op) keep their opaque chrome.
-      // Skip vibrancy under MAKA_VISUAL_SMOKE_FIXTURE — fixture / E2E
+      // Skip vibrancy under MAKA_E2E_FIXTURE — fixture / E2E
       // environments can't paint native window material reliably.
-      ...(process.platform === 'darwin' && !process.env.MAKA_VISUAL_SMOKE_FIXTURE
+      ...(process.platform === 'darwin' && !process.env.MAKA_E2E_FIXTURE
         ? { vibrancy: 'sidebar' as const }
         : {}),
       webPreferences: {
@@ -369,7 +369,7 @@ export function createMainWindowController(deps: MainWindowControllerDeps): Main
     // If renderer-ready arrived while loadURL/loadFile was resolving, the
     // window is already visible and no timer is needed. Visual-smoke windows
     // remain hidden for their whole lifecycle.
-    if (!keepHiddenForVisualSmoke && !mainWindow.isVisible()) {
+    if (!keepHiddenForE2EFixture && !mainWindow.isVisible()) {
       showFallbackTimer = setTimeout(() => {
         showFallbackTimer = undefined;
         revealGate.markReady(mainWindow);
@@ -389,7 +389,7 @@ export function createMainWindowController(deps: MainWindowControllerDeps): Main
       // commit. Cancel the fallback timer and reveal the window through the
       // shared gate — idempotent, so an HMR reload re-firing this signal (or a
       // timer racing it) never re-shows or steals focus, and suppressed for
-      // visual-smoke windows. markReady also flushes a focus request that
+      // e2e-fixture windows. markReady also flushes a focus request that
       // arrived while the window was still hidden (second-instance/activate).
       clearShowFallbackTimer();
       revealGate.markReady(mainWindow);
@@ -481,13 +481,13 @@ function clampBoundsToVisibleDisplay(bounds: SavedBounds): SavedBounds {
   return { width: bounds.width, height: bounds.height, isMaximized: bounds.isMaximized };
 }
 
-function visualSmokeWindowBounds(
-  visualSmokeFixture: VisualSmokeFixture | null,
+function e2eFixtureWindowBounds(
+  e2eFixture: E2EFixture | null,
   defaults: SavedBounds,
 ): SavedBounds {
-  if (!visualSmokeFixture) return defaults;
-  const width = Number(process.env.MAKA_VISUAL_SMOKE_WIDTH);
-  const height = Number(process.env.MAKA_VISUAL_SMOKE_HEIGHT);
+  if (!e2eFixture) return defaults;
+  const width = Number(process.env.MAKA_E2E_FIXTURE_WIDTH);
+  const height = Number(process.env.MAKA_E2E_FIXTURE_HEIGHT);
   if (
     Number.isFinite(width) &&
     Number.isFinite(height) &&

--- a/apps/desktop/src/main/main-window.ts
+++ b/apps/desktop/src/main/main-window.ts
@@ -7,7 +7,7 @@ import { errorMessage } from './chat-readiness.js';
 import { readSavedBounds, writeSavedBounds, SAFE_MIN_HEIGHT, SAFE_MIN_WIDTH, type SavedBounds } from './window-state.js';
 import { BrowserViewController } from './browser/controller.js';
 import { BrowserViewManager } from './browser/view-manager.js';
-import type { E2EFixture } from './e2e-fixture.js';
+import type { E2eFixture } from './e2e-fixture.js';
 import { isThemePreference, toNativeThemeSource } from './theme-source.js';
 import { createWindowRevealGate } from './window-reveal.js';
 
@@ -38,7 +38,7 @@ export interface MainWindowController {
 
 interface MainWindowControllerDeps {
   workspaceRoot: string;
-  e2eFixture: E2EFixture | null;
+  e2eFixture: E2eFixture | null;
   settingsStore: SettingsReader;
   // main.ts computes this from the same isE2e gate that also guards userData
   // and the fake backend, so main-window.ts owns no env policy of its own.
@@ -110,12 +110,12 @@ export function createMainWindowController(deps: MainWindowControllerDeps): Main
   // build ignores a stray startHidden flag. The fallback timer, the
   // renderer-ready IPC, and focus() all route their show() through this
   // predicate via the reveal gate below.
-  const keepHiddenForE2EFixture = !app.isPackaged && startHidden;
+  const keepHiddenForE2eFixture = !app.isPackaged && startHidden;
   // ChatGPT Pro review P2: focus() (second-instance / activate) used to call
   // mainWindow.show() directly, bypassing the reveal gate — re-launching or
   // clicking the dock icon during the pre-commit window would flash the
   // skeleton anyway. The gate defers those focus requests until markReady.
-  const revealGate = createWindowRevealGate(keepHiddenForE2EFixture);
+  const revealGate = createWindowRevealGate(keepHiddenForE2eFixture);
   let showFallbackTimer: NodeJS.Timeout | undefined;
   const clearShowFallbackTimer = (): void => {
     if (showFallbackTimer) {
@@ -369,7 +369,7 @@ export function createMainWindowController(deps: MainWindowControllerDeps): Main
     // If renderer-ready arrived while loadURL/loadFile was resolving, the
     // window is already visible and no timer is needed. E2e-fixture windows
     // remain hidden for their whole lifecycle.
-    if (!keepHiddenForE2EFixture && !mainWindow.isVisible()) {
+    if (!keepHiddenForE2eFixture && !mainWindow.isVisible()) {
       showFallbackTimer = setTimeout(() => {
         showFallbackTimer = undefined;
         revealGate.markReady(mainWindow);
@@ -482,7 +482,7 @@ function clampBoundsToVisibleDisplay(bounds: SavedBounds): SavedBounds {
 }
 
 function e2eFixtureWindowBounds(
-  e2eFixture: E2EFixture | null,
+  e2eFixture: E2eFixture | null,
   defaults: SavedBounds,
 ): SavedBounds {
   if (!e2eFixture) return defaults;

--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -78,7 +78,7 @@ import { bindOnboardingDeps, createOnboardingService } from './onboarding-servic
 import { handleQuickChatStart as runQuickChatStart, type QuickChatResult } from './quick-chat.js';
 import { createDailyReviewArchiveStore } from './daily-review-archive-store.js';
 import { resolveDefaultPermissionMode } from './permission-mode-default.js';
-import { resolveVisualSmokeFixture } from './visual-smoke-fixture.js';
+import { resolveE2EFixture } from './e2e-fixture.js';
 import { resolveBuildInfo } from './build-info.js';
 import { OpenGatewayService } from './open-gateway.js';
 import { LocalMemoryService } from './local-memory-service.js';
@@ -115,7 +115,7 @@ import { registerSessionEntryIpc } from './session-entry-ipc-main.js';
 import { registerPermissionsIpc } from './permissions-ipc-main.js';
 import { registerSettingsIpc } from './settings-ipc-main.js';
 import type { SettingsIpcHandle } from './settings-ipc-main.js';
-import { createVisualSmokeBotOnboardingAdapters } from './bot-onboarding-visual-smoke.js';
+import { createE2EFixtureBotOnboardingAdapters } from './bot-onboarding-e2e-fixture.js';
 import { createKeepSystemAwakeController } from './keep-system-awake.js';
 import { createSettingsRuntimeEffects } from './settings-runtime-effects.js';
 import { createAiSdkBackendFactory, createSessionStreamer } from './session-stream.js';
@@ -166,29 +166,29 @@ if (!app.requestSingleInstanceLock()) {
 const buildInfo = resolveBuildInfo(app.isPackaged, app.getAppPath());
 
 // PR-VISUAL-SMOKE-HEADLESS: resolve the fixture defensively. An unknown
-// scenario (e.g. a stale build, or a typo'd MAKA_VISUAL_SMOKE_FIXTURE) throws
+// scenario (e.g. a stale build, or a typo'd MAKA_E2E_FIXTURE) throws
 // here during top-level module evaluation. Left uncaught it surfaces a
 // blocking native error dialog. In fixture mode we instead log a parseable
 // line and exit fast so the run fails in milliseconds with no dialog.
 // Outside fixture mode the throw is rethrown.
-let visualSmokeFixture: ReturnType<typeof resolveVisualSmokeFixture>;
+let e2eFixture: ReturnType<typeof resolveE2EFixture>;
 try {
-  visualSmokeFixture = resolveVisualSmokeFixture(
-    process.env.MAKA_VISUAL_SMOKE_FIXTURE,
+  e2eFixture = resolveE2EFixture(
+    process.env.MAKA_E2E_FIXTURE,
     app.isPackaged,
-    process.env.MAKA_VISUAL_SMOKE_REDUCED_MOTION,
-    process.env.MAKA_VISUAL_SMOKE_THEME,
-    process.env.MAKA_VISUAL_SMOKE_LOCALE,
-    process.env.MAKA_VISUAL_SMOKE_TIMEZONE,
+    process.env.MAKA_E2E_FIXTURE_REDUCED_MOTION,
+    process.env.MAKA_E2E_FIXTURE_THEME,
+    process.env.MAKA_E2E_FIXTURE_LOCALE,
+    process.env.MAKA_E2E_FIXTURE_TIMEZONE,
   );
 } catch (error) {
-  if (process.env.MAKA_VISUAL_SMOKE_FIXTURE) {
-    console.error(`[visual-smoke] fatal: ${error instanceof Error ? error.message : String(error)}`);
+  if (process.env.MAKA_E2E_FIXTURE) {
+    console.error(`[e2e-fixture] fatal: ${error instanceof Error ? error.message : String(error)}`);
     process.exit(1);
   }
   throw error;
 }
-const workspaceRoot = join(app.getPath('userData'), 'workspaces', visualSmokeFixture?.workspaceName ?? 'default');
+const workspaceRoot = join(app.getPath('userData'), 'workspaces', e2eFixture?.workspaceName ?? 'default');
 // 保持系统唤醒 (settings.system.keepSystemAwake): holds an Electron
 // `powerSaveBlocker` so in-process scheduled tasks keep firing while the
 // machine would otherwise sleep. Injected with electron's blocker; the
@@ -483,7 +483,7 @@ const localMemory = new LocalMemoryService({
 const desktopSessionSkillHosts = new Map<string, HostCapabilities>();
 const resolveDesktopSkillHost: HostCapabilitiesResolver = ({ sessionId }) =>
   desktopSessionSkillHosts.get(sessionId) ?? desktopHostCapabilities;
-// Window is created hidden for E2E and visual-smoke runs so it never steals
+// Window is created hidden for E2E and e2e-fixture runs so it never steals
 // focus. Derived from the same isE2e gate as userData/fake-backend so the
 // hidden-window switch stays in lockstep with the rest of the E2E isolation.
 // MAKA_E2E_SHOW_WINDOW opts back into a visible window where there is no
@@ -491,12 +491,12 @@ const resolveDesktopSkillHost: HostCapabilitiesResolver = ({ sessionId }) =>
 // BeginFrames on Linux, which stalls content-visibility inflation and any
 // frame-paced E2E protocol (measured in the scroll-geometry climb: 38 frames
 // over 31s). The E2E harness sets it, not the workflow — see fixtures.ts.
-const startHidden = (Boolean(visualSmokeFixture) || isIsolatedE2e)
+const startHidden = (Boolean(e2eFixture) || isIsolatedE2e)
   && process.env.MAKA_E2E_SHOW_WINDOW !== '1';
 let onMainWindowClose = (): void => {};
 const mainWindowController = createMainWindowController({
   workspaceRoot,
-  visualSmokeFixture,
+  e2eFixture,
   settingsStore,
   startHidden,
   onClose: () => onMainWindowClose(),
@@ -863,7 +863,7 @@ function registerIpc(): void {
     getProjectRoot: resolveProjectRootForContext,
     workspaceRoot,
     buildInfo,
-    visualSmokeFixture,
+    e2eFixture,
   });
   registerMemoryIpc({ localMemory });
   registerConfigIpc({ connectionStore, settingsStore, credentialStore, workspaceRoot });
@@ -891,7 +891,7 @@ function registerIpc(): void {
     settingsStore,
     connectionStore,
     mainWindowController,
-    visualSmokeFixture,
+    e2eFixture,
     emitSessionsChanged,
     ensureSessionCanSend,
     invalidateSessionBindings: (sessionId) => botIncoming.invalidateSessionBindings(sessionId),
@@ -952,9 +952,9 @@ function registerIpc(): void {
     botRegistry,
     normalizeSettingsPatch,
     applySettingsRuntimeEffects,
-    ...(visualSmokeFixture?.scenario === 'settings-bots'
+    ...(e2eFixture?.scenario === 'settings-bots'
       ? {
-          botOnboardingAdapters: createVisualSmokeBotOnboardingAdapters(),
+          botOnboardingAdapters: createE2EFixtureBotOnboardingAdapters(),
           botOnboardingApplySettingsRuntimeEffects: async () => undefined,
           // The fixture no-ops runtime effects, so no real bridge starts.
           // Report the onboarded channel as running to demonstrate the
@@ -978,7 +978,7 @@ function registerIpc(): void {
 
 function canCreateFakeSessionFromRenderer(): boolean {
   return !app.isPackaged && (
-    Boolean(visualSmokeFixture) ||
+    Boolean(e2eFixture) ||
     Boolean(process.env.VITE_DEV_SERVER_URL) ||
     process.env.NODE_ENV === 'development'
   );
@@ -1151,7 +1151,7 @@ registerIpc();
 
 wireAppLifecycle({
   isIsolatedE2e,
-  visualSmokeFixture,
+  e2eFixture,
   workspaceRoot,
   credentialStore,
   connectionStore,

--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -78,7 +78,7 @@ import { bindOnboardingDeps, createOnboardingService } from './onboarding-servic
 import { handleQuickChatStart as runQuickChatStart, type QuickChatResult } from './quick-chat.js';
 import { createDailyReviewArchiveStore } from './daily-review-archive-store.js';
 import { resolveDefaultPermissionMode } from './permission-mode-default.js';
-import { resolveE2EFixture } from './e2e-fixture.js';
+import { resolveE2eFixture } from './e2e-fixture.js';
 import { resolveBuildInfo } from './build-info.js';
 import { OpenGatewayService } from './open-gateway.js';
 import { LocalMemoryService } from './local-memory-service.js';
@@ -115,7 +115,7 @@ import { registerSessionEntryIpc } from './session-entry-ipc-main.js';
 import { registerPermissionsIpc } from './permissions-ipc-main.js';
 import { registerSettingsIpc } from './settings-ipc-main.js';
 import type { SettingsIpcHandle } from './settings-ipc-main.js';
-import { createE2EFixtureBotOnboardingAdapters } from './bot-onboarding-e2e-fixture.js';
+import { createE2eFixtureBotOnboardingAdapters } from './bot-onboarding-e2e-fixture.js';
 import { createKeepSystemAwakeController } from './keep-system-awake.js';
 import { createSettingsRuntimeEffects } from './settings-runtime-effects.js';
 import { createAiSdkBackendFactory, createSessionStreamer } from './session-stream.js';
@@ -171,9 +171,9 @@ const buildInfo = resolveBuildInfo(app.isPackaged, app.getAppPath());
 // blocking native error dialog. In fixture mode we instead log a parseable
 // line and exit fast so the run fails in milliseconds with no dialog.
 // Outside fixture mode the throw is rethrown.
-let e2eFixture: ReturnType<typeof resolveE2EFixture>;
+let e2eFixture: ReturnType<typeof resolveE2eFixture>;
 try {
-  e2eFixture = resolveE2EFixture(
+  e2eFixture = resolveE2eFixture(
     process.env.MAKA_E2E_FIXTURE,
     app.isPackaged,
     process.env.MAKA_E2E_FIXTURE_REDUCED_MOTION,
@@ -954,7 +954,7 @@ function registerIpc(): void {
     applySettingsRuntimeEffects,
     ...(e2eFixture?.scenario === 'settings-bots'
       ? {
-          botOnboardingAdapters: createE2EFixtureBotOnboardingAdapters(),
+          botOnboardingAdapters: createE2eFixtureBotOnboardingAdapters(),
           botOnboardingApplySettingsRuntimeEffects: async () => undefined,
           // The fixture no-ops runtime effects, so no real bridge starts.
           // Report the onboarded channel as running to demonstrate the

--- a/apps/desktop/src/main/managed-skill-sources.ts
+++ b/apps/desktop/src/main/managed-skill-sources.ts
@@ -71,13 +71,13 @@ export type ReadManagedSkillSourceResult =
   | { ok: false; reason: 'not_found' | 'blocked_path' | 'read_failed' };
 
 export function resolveManagedSkillSourcesRoot(homeDir = homedir()): string {
-  // Dev/test-only override so the visual-smoke fixture can seed a
+  // Dev/test-only override so the e2e-fixture fixture can seed a
   // deterministic managed-source catalog without touching the real
   // ~/.maka/skill-sources. Packaged builds ignore this (app.isPackaged
   // gate lives in main.ts, same as the fixture env vars); here we only
   // honor an absolute path so a relative value can never escape.
   const override = process.env.MAKA_SKILL_SOURCES_ROOT;
-  if (override && isAbsolute(override) && process.env.MAKA_VISUAL_SMOKE_FIXTURE) {
+  if (override && isAbsolute(override) && process.env.MAKA_E2E_FIXTURE) {
     return override;
   }
   return join(homeDir, '.maka', 'skill-sources');

--- a/apps/desktop/src/main/search/thread-search.ts
+++ b/apps/desktop/src/main/search/thread-search.ts
@@ -13,7 +13,7 @@
  *       UserMessage / AssistantMessage / ToolCallMessage / ToolResultMessage.
  *     Excluded: SystemNoteMessage / TokenUsageMessage / TurnStateMessage /
  *     PermissionDecisionMessage.
- *   - Excludes sessions with `backend === 'fake'` (visual-smoke fixtures).
+ *   - Excludes sessions with `backend === 'fake'` (e2e-fixture fixtures).
  *   - Snippets are redacted via `@maka/core/redaction.redactSecrets()`.
  *   - `ToolResultMessage.content` is JSON-serialized for scan and capped to
  *     the first `TOOL_RESULT_SCAN_CAP_BYTES` bytes (worst-case bound).
@@ -160,7 +160,7 @@ export async function runThreadSearch(
   const maxResults = limitResult.value;
 
   const sessions = (await deps.listSessions())
-    // Exclude fake-backend sessions — visual-smoke fixtures and
+    // Exclude fake-backend sessions — e2e-fixture fixtures and
     // similar dev-only state should not surface as real chat hits.
     .filter((session) => session.backend !== 'fake')
     // Newest first by lastMessageAt; secondary by id for determinism.

--- a/apps/desktop/src/main/sessions-ipc-main.ts
+++ b/apps/desktop/src/main/sessions-ipc-main.ts
@@ -37,7 +37,7 @@ import {
   normalizeStopSessionInput,
   normalizeUserQuestionResponse,
 } from './permission-response-guard.js';
-import { getE2EFixtureState, type resolveE2EFixture } from './e2e-fixture.js';
+import { getE2eFixtureState, type resolveE2eFixture } from './e2e-fixture.js';
 import type { requireReadyConnection } from './chat-readiness.js';
 import type { MainTaskLedgerWiring } from './task-ledger-wiring.js';
 import type { MainGoalWiring } from './goal-wiring.js';
@@ -49,7 +49,7 @@ import { handleBranchFromTurn } from './session-branch.js';
 type SessionStore = ReturnType<typeof createSessionStore>;
 type ArtifactStore = ReturnType<typeof createArtifactStore>;
 type MainWindowController = ReturnType<typeof createMainWindowController>;
-type E2EFixture = ReturnType<typeof resolveE2EFixture>;
+type E2eFixture = ReturnType<typeof resolveE2eFixture>;
 
 /** The per-session cleanup subset of the cursor-overlay controller. */
 interface SessionOverlayCleanup {
@@ -73,7 +73,7 @@ export interface SessionsIpcDeps {
   settingsStore: SettingsStore;
   connectionStore: ConnectionStore;
   mainWindowController: MainWindowController;
-  e2eFixture: E2EFixture;
+  e2eFixture: E2eFixture;
   emitSessionsChanged: (
     reason: SessionChangedReason,
     sessionId?: string,
@@ -175,7 +175,7 @@ export function registerSessionsIpc(deps: SessionsIpcDeps): void {
       includeTerminal: true,
       includeArchived: false,
       classifyResumeTrust: true,
-      ...(e2eFixture ? { now: getE2EFixtureState(e2eFixture)?.now ?? Date.now() } : {}),
+      ...(e2eFixture ? { now: getE2eFixtureState(e2eFixture)?.now ?? Date.now() } : {}),
     });
     return tasks.map(sanitizeTaskLedgerTask);
   });

--- a/apps/desktop/src/main/sessions-ipc-main.ts
+++ b/apps/desktop/src/main/sessions-ipc-main.ts
@@ -37,7 +37,7 @@ import {
   normalizeStopSessionInput,
   normalizeUserQuestionResponse,
 } from './permission-response-guard.js';
-import { getVisualSmokeState, type resolveVisualSmokeFixture } from './visual-smoke-fixture.js';
+import { getE2EFixtureState, type resolveE2EFixture } from './e2e-fixture.js';
 import type { requireReadyConnection } from './chat-readiness.js';
 import type { MainTaskLedgerWiring } from './task-ledger-wiring.js';
 import type { MainGoalWiring } from './goal-wiring.js';
@@ -49,7 +49,7 @@ import { handleBranchFromTurn } from './session-branch.js';
 type SessionStore = ReturnType<typeof createSessionStore>;
 type ArtifactStore = ReturnType<typeof createArtifactStore>;
 type MainWindowController = ReturnType<typeof createMainWindowController>;
-type VisualSmokeFixture = ReturnType<typeof resolveVisualSmokeFixture>;
+type E2EFixture = ReturnType<typeof resolveE2EFixture>;
 
 /** The per-session cleanup subset of the cursor-overlay controller. */
 interface SessionOverlayCleanup {
@@ -73,7 +73,7 @@ export interface SessionsIpcDeps {
   settingsStore: SettingsStore;
   connectionStore: ConnectionStore;
   mainWindowController: MainWindowController;
-  visualSmokeFixture: VisualSmokeFixture;
+  e2eFixture: E2EFixture;
   emitSessionsChanged: (
     reason: SessionChangedReason,
     sessionId?: string,
@@ -155,7 +155,7 @@ export function registerSessionsIpc(deps: SessionsIpcDeps): void {
     settingsStore,
     connectionStore,
     mainWindowController,
-    visualSmokeFixture,
+    e2eFixture,
     emitSessionsChanged,
     ensureSessionCanSend,
     invalidateSessionBindings,
@@ -175,7 +175,7 @@ export function registerSessionsIpc(deps: SessionsIpcDeps): void {
       includeTerminal: true,
       includeArchived: false,
       classifyResumeTrust: true,
-      ...(visualSmokeFixture ? { now: getVisualSmokeState(visualSmokeFixture)?.now ?? Date.now() } : {}),
+      ...(e2eFixture ? { now: getE2EFixtureState(e2eFixture)?.now ?? Date.now() } : {}),
     });
     return tasks.map(sanitizeTaskLedgerTask);
   });
@@ -223,7 +223,7 @@ export function registerSessionsIpc(deps: SessionsIpcDeps): void {
     return session;
   });
   ipcMain.handle('sessions:readMessages', async (_event, sessionId: string) => {
-    if (visualSmokeFixture) return store.readMessages(sessionId);
+    if (e2eFixture) return store.readMessages(sessionId);
     let messages: StoredMessage[];
     try {
       messages = await runtime.getMessages(sessionId);

--- a/apps/desktop/src/main/window-reveal.ts
+++ b/apps/desktop/src/main/window-reveal.ts
@@ -19,7 +19,7 @@ export interface RevealableWindow {
 
 /**
  * Reveal `win` unless it must stay hidden. Idempotent and focus-safe:
- * - `keepHidden` true (visual-smoke capture): never reveal — capture runs on
+ * - `keepHidden` true (e2e-fixture capture): never reveal — capture runs on
  *   the hidden window via `paintWhenInitiallyHidden`.
  * - null / destroyed window: no-op (teardown raced the timer or the IPC).
  * - already visible: no-op, so a second signal (HMR reload re-fires
@@ -67,7 +67,7 @@ export interface WindowRevealGate {
  * intent and markReady applies it right before the reveal, so the window's
  * first on-screen frame is already maximized.
  *
- * `keepHidden` windows (visual-smoke capture / E2E) never show, maximize, or
+ * `keepHidden` windows (e2e-fixture capture / E2E) never show, maximize, or
  * take focus from any path — captures run while the developer works elsewhere.
  */
 export function createWindowRevealGate(keepHidden: boolean): WindowRevealGate {

--- a/apps/desktop/src/preload/bridge-contract.d.ts
+++ b/apps/desktop/src/preload/bridge-contract.d.ts
@@ -32,7 +32,7 @@ import type {
   UpdateAppSettingsResult,
   UsageRange,
   UsageStats,
-  E2EFixtureState,
+  E2eFixtureState,
   ArtifactBinaryReadResult,
   ArtifactChangedEvent,
   ArtifactRecord,
@@ -635,7 +635,7 @@ export interface MakaBridge {
     >;
   };
   e2eFixture: {
-    getState(): Promise<E2EFixtureState | null>;
+    getState(): Promise<E2eFixtureState | null>;
   };
   artifacts: {
     list(sessionId: string, opts?: { includeDeleted?: boolean }): Promise<ArtifactRecord[]>;

--- a/apps/desktop/src/preload/bridge-contract.d.ts
+++ b/apps/desktop/src/preload/bridge-contract.d.ts
@@ -32,7 +32,7 @@ import type {
   UpdateAppSettingsResult,
   UsageRange,
   UsageStats,
-  VisualSmokeState,
+  E2EFixtureState,
   ArtifactBinaryReadResult,
   ArtifactChangedEvent,
   ArtifactRecord,
@@ -634,8 +634,8 @@ export interface MakaBridge {
       | { ok: false; reason: 'no_project' | 'search_failed' }
     >;
   };
-  visualSmoke: {
-    getState(): Promise<VisualSmokeState | null>;
+  e2eFixture: {
+    getState(): Promise<E2EFixtureState | null>;
   };
   artifacts: {
     list(sessionId: string, opts?: { includeDeleted?: boolean }): Promise<ArtifactRecord[]>;

--- a/apps/desktop/src/preload/preload.ts
+++ b/apps/desktop/src/preload/preload.ts
@@ -44,7 +44,7 @@ import type {
   UpdateAppSettingsResult,
   UsageRange,
   UsageStats,
-  VisualSmokeState,
+  E2EFixtureState,
   ArtifactBinaryReadResult,
   ArtifactChangedEvent,
   ArtifactRecord,
@@ -997,9 +997,9 @@ const makaBridge = {
       return ipcRenderer.invoke('workspace:searchFiles', { query, ...options });
     },
   },
-  visualSmoke: {
-    getState(): Promise<VisualSmokeState | null> {
-      return ipcRenderer.invoke('visualSmoke:getState');
+  e2eFixture: {
+    getState(): Promise<E2EFixtureState | null> {
+      return ipcRenderer.invoke('e2eFixture:getState');
     },
   },
   artifacts: {

--- a/apps/desktop/src/preload/preload.ts
+++ b/apps/desktop/src/preload/preload.ts
@@ -44,7 +44,7 @@ import type {
   UpdateAppSettingsResult,
   UsageRange,
   UsageStats,
-  E2EFixtureState,
+  E2eFixtureState,
   ArtifactBinaryReadResult,
   ArtifactChangedEvent,
   ArtifactRecord,
@@ -998,7 +998,7 @@ const makaBridge = {
     },
   },
   e2eFixture: {
-    getState(): Promise<E2EFixtureState | null> {
+    getState(): Promise<E2eFixtureState | null> {
       return ipcRenderer.invoke('e2eFixture:getState');
     },
   },

--- a/apps/desktop/src/renderer/app-shell-e2e-fixture.ts
+++ b/apps/desktop/src/renderer/app-shell-e2e-fixture.ts
@@ -7,11 +7,11 @@ import type { SessionWorkbarTab } from './session-workbar-layout';
 
 type StateUpdater<T> = (updater: (current: T) => T) => void;
 
-export interface AppShellVisualSmokeActions {
-  applyVisualSmokeFixture(): Promise<void>;
+export interface AppShellE2EFixtureActions {
+  applyE2EFixture(): Promise<void>;
 }
 
-export function createAppShellVisualSmokeActions(options: {
+export function createAppShellE2EFixtureActions(options: {
   openPalette: () => void;
   openSettingsSection: (section: SettingsSection) => void;
   openConnectionDetail: (slug: string) => void;
@@ -27,7 +27,7 @@ export function createAppShellVisualSmokeActions(options: {
   setWorkbarTab: Dispatch<SetStateAction<SessionWorkbarTab>>;
   setThemePref: Dispatch<SetStateAction<ThemePreference>>;
   setUiLocaleOverride: Dispatch<SetStateAction<UiLocale | null>>;
-}): AppShellVisualSmokeActions {
+}): AppShellE2EFixtureActions {
   const {
     openPalette,
     openSettingsSection,
@@ -46,17 +46,17 @@ export function createAppShellVisualSmokeActions(options: {
     setUiLocaleOverride,
   } = options;
 
-  async function applyVisualSmokeFixture() {
-    const state = await window.maka.visualSmoke.getState();
+  async function applyE2EFixture() {
+    const state = await window.maka.e2eFixture.getState();
     if (!state) return;
     if (state.now) {
-      // Fixture-only clock freeze: screenshot baselines should not drift
+      // Fixture-only clock freeze: the fixture must not drift
       // because relative timestamps or fetched-at labels crossed a minute
-      // boundary between two runs. Real users never receive a visual
-      // smoke state, so their Date API remains untouched.
+      // boundary between two runs. Real users never receive an
+      // e2e-fixture state, so their Date API remains untouched.
       Date.now = () => state.now!;
     }
-    document.documentElement.setAttribute('data-maka-visual-smoke', 'true');
+    document.documentElement.setAttribute('data-maka-e2e-fixture', 'true');
     if (state.liveTurnBySession) {
       setLiveTurnBySession((current) => ({ ...current, ...state.liveTurnBySession }));
     }
@@ -68,20 +68,20 @@ export function createAppShellVisualSmokeActions(options: {
       setInteractionBySession((current) => ({ ...current, ...seeded }));
     }
     // PR-IR-01b: theme override applied BEFORE the persisted user pref so
-    // the screenshot variant matches `<theme>-<viewport>-<motion>.png`
+    // the rendered fixture matches the `<theme>-<viewport>-<motion>` variant
     // exactly. `applyTheme` writes both the React state + the `.dark` class
     // on the html element. Real users never hit this branch because
-    // `state` is null without `MAKA_VISUAL_SMOKE_FIXTURE`.
+    // `state` is null without `MAKA_E2E_FIXTURE`.
     if (state.theme) {
       applyTheme(state.theme);
       setThemePref(state.theme);
     }
     // PR-IR-04: apply reduced-motion attribute when the fixture asks for it.
     // The matching CSS rule in styles.css collapses all animations to
-    // ~0.01ms so the screenshot pipeline can capture a reduced-motion
+    // ~0.01ms so E2E and the alignment audit can exercise a reduced-motion
     // variant without depending on the host OS accessibility setting.
-    // Real users never reach this code path (visualSmoke.getState returns
-    // null without MAKA_VISUAL_SMOKE_FIXTURE).
+    // Real users never reach this code path (e2eFixture.getState returns
+    // null without MAKA_E2E_FIXTURE).
     if (state.reducedMotion) {
       document.documentElement.setAttribute('data-maka-reduced-motion', 'true');
     }
@@ -95,18 +95,18 @@ export function createAppShellVisualSmokeActions(options: {
     // AppShell initial mount already ran when this effect fires,
     // but that initial mount renders no locale-aware copy yet
     // (it's a loading shell), so there's no observable host-locale
-    // leak in the captured baseline. See @kenji review
+    // leak in the rendered fixture. See @kenji review
     // @msg 7b96e182.
     setUiLocaleOverride(state.locale ?? null);
     // PR-UI-VISUAL-SMOKE-TIMEZONE (@kenji msg 45486cdf): mirror the
-    // locale attribute pattern. When `MAKA_VISUAL_SMOKE_TIMEZONE` is
+    // locale attribute pattern. When `MAKA_E2E_FIXTURE_TIMEZONE` is
     // set and validates against `Intl.DateTimeFormat`, the IANA name
     // lands on `<html>` so any date / time formatting helper can
-    // opt in by reading `document.documentElement.dataset.makaVisualSmokeTz`.
+    // opt in by reading `document.documentElement.dataset.makaE2eFixtureTz`.
     // The attribute alone is the contract; per-call timezone
     // consumption is up to individual formatters as they migrate.
     if (state.timezone) {
-      document.documentElement.setAttribute('data-maka-visual-smoke-tz', state.timezone);
+      document.documentElement.setAttribute('data-maka-e2e-fixture-tz', state.timezone);
     }
     await refreshSessions();
     if (state.activeSessionId) {
@@ -115,7 +115,7 @@ export function createAppShellVisualSmokeActions(options: {
     // #819: seed live browser session ids so BrowserPanel mounts for the
     // active session (app-shell gates on `activeId &&
     // liveBrowserSessionIds.includes(activeId)`). Only the `browser-empty`
-    // scenario sets this; real users never receive a visual smoke state.
+    // scenario sets this; real users never receive an e2e-fixture state.
     if (state.liveBrowserSessionIds) {
       setLiveBrowserSessionIds(state.liveBrowserSessionIds);
     }
@@ -127,22 +127,22 @@ export function createAppShellVisualSmokeActions(options: {
     if (state.openConnectionDetailSlug) {
       // oauth-relogin fixture: open Settings → 模型 with the seeded
       // needs_reauth connection's detail sheet expanded so the re-login
-      // affordance is captured. Takes precedence over a bare section open.
+      // affordance is exposed. Takes precedence over a bare section open.
       openConnectionDetail(state.openConnectionDetailSlug);
     } else if (state.openSettingsSection) {
       openSettingsSection(state.openSettingsSection);
     }
     // PR-SIDEBAR-IA-0 Phase 2 fixup v3 (xuan msg `dce5a6fb` #2): when
     // the fixture sets `searchModalOpen`, auto-open the sidebar
-    // Search modal so the screenshot pipeline captures the modal
+    // Search modal so E2E/audit can reach the modal
     // shell deterministically. Real users never reach this branch
-    // (visualSmoke.getState returns null without MAKA_VISUAL_SMOKE_FIXTURE).
+    // (e2eFixture.getState returns null without MAKA_E2E_FIXTURE).
     if (state.searchModalOpen) {
       setSearchModalOpen(true);
     }
-    // PR-shared primitive-COMMAND-INPUT-0: visual-smoke-only opener for the command
-    // palette so screenshot baselines can cover its input shell without
-    // requiring Cmd/Ctrl+K in the capture harness.
+    // PR-shared primitive-COMMAND-INPUT-0: e2e-fixture-only opener for the command
+    // palette so E2E/audit can cover its input shell without
+    // requiring Cmd/Ctrl+K.
     if (state.paletteOpen) {
       openPalette();
     }
@@ -161,7 +161,7 @@ export function createAppShellVisualSmokeActions(options: {
     // kenji `b3d156e9`): when the fixture sets `focusActiveRow`,
     // focus the active row's button after the next paint so the
     // row's `:focus-within` triggers and the `.maka-list-row-menu-trigger`
-    // becomes visible. The auto-capture then shows the overflow
+    // becomes visible. The fixture then shows the overflow
     // trigger against the slim row, proving the time meta
     // + unread dot are hidden underneath (no overlap with the
     // action icons — the bug WAWQAQ flagged). Two RAFs let React
@@ -178,5 +178,5 @@ export function createAppShellVisualSmokeActions(options: {
     }
   }
 
-  return { applyVisualSmokeFixture };
+  return { applyE2EFixture };
 }

--- a/apps/desktop/src/renderer/app-shell-e2e-fixture.ts
+++ b/apps/desktop/src/renderer/app-shell-e2e-fixture.ts
@@ -78,8 +78,8 @@ export function createAppShellE2eFixtureActions(options: {
     }
     // PR-IR-04: apply reduced-motion attribute when the fixture asks for it.
     // The matching CSS rule in styles.css collapses all animations to
-    // ~0.01ms so the alignment audit can exercise a reduced-motion
-    // variant without depending on the host OS accessibility setting.
+    // ~0.01ms so a reduced-motion variant is reachable
+    // without depending on the host OS accessibility setting.
     // Real users never reach this code path (e2eFixture.getState returns
     // null without MAKA_E2E_FIXTURE).
     if (state.reducedMotion) {
@@ -134,14 +134,14 @@ export function createAppShellE2eFixtureActions(options: {
     }
     // PR-SIDEBAR-IA-0 Phase 2 fixup v3 (xuan msg `dce5a6fb` #2): when
     // the fixture sets `searchModalOpen`, auto-open the sidebar
-    // Search modal so the alignment audit can reach the modal
-    // shell deterministically. Real users never reach this branch
+    // Search modal so the modal
+    // shell is on screen deterministically. Real users never reach this branch
     // (e2eFixture.getState returns null without MAKA_E2E_FIXTURE).
     if (state.searchModalOpen) {
       setSearchModalOpen(true);
     }
     // PR-shared primitive-COMMAND-INPUT-0: e2e-fixture-only opener for the command
-    // palette so the alignment audit can cover its input shell without
+    // palette so its input shell is covered without
     // requiring Cmd/Ctrl+K.
     if (state.paletteOpen) {
       openPalette();

--- a/apps/desktop/src/renderer/app-shell-e2e-fixture.ts
+++ b/apps/desktop/src/renderer/app-shell-e2e-fixture.ts
@@ -7,11 +7,11 @@ import type { SessionWorkbarTab } from './session-workbar-layout';
 
 type StateUpdater<T> = (updater: (current: T) => T) => void;
 
-export interface AppShellE2EFixtureActions {
-  applyE2EFixture(): Promise<void>;
+export interface AppShellE2eFixtureActions {
+  applyE2eFixture(): Promise<void>;
 }
 
-export function createAppShellE2EFixtureActions(options: {
+export function createAppShellE2eFixtureActions(options: {
   openPalette: () => void;
   openSettingsSection: (section: SettingsSection) => void;
   openConnectionDetail: (slug: string) => void;
@@ -27,7 +27,7 @@ export function createAppShellE2EFixtureActions(options: {
   setWorkbarTab: Dispatch<SetStateAction<SessionWorkbarTab>>;
   setThemePref: Dispatch<SetStateAction<ThemePreference>>;
   setUiLocaleOverride: Dispatch<SetStateAction<UiLocale | null>>;
-}): AppShellE2EFixtureActions {
+}): AppShellE2eFixtureActions {
   const {
     openPalette,
     openSettingsSection,
@@ -46,7 +46,7 @@ export function createAppShellE2EFixtureActions(options: {
     setUiLocaleOverride,
   } = options;
 
-  async function applyE2EFixture() {
+  async function applyE2eFixture() {
     const state = await window.maka.e2eFixture.getState();
     if (!state) return;
     if (state.now) {
@@ -78,7 +78,7 @@ export function createAppShellE2EFixtureActions(options: {
     }
     // PR-IR-04: apply reduced-motion attribute when the fixture asks for it.
     // The matching CSS rule in styles.css collapses all animations to
-    // ~0.01ms so E2E and the alignment audit can exercise a reduced-motion
+    // ~0.01ms so the alignment audit can exercise a reduced-motion
     // variant without depending on the host OS accessibility setting.
     // Real users never reach this code path (e2eFixture.getState returns
     // null without MAKA_E2E_FIXTURE).
@@ -134,14 +134,14 @@ export function createAppShellE2EFixtureActions(options: {
     }
     // PR-SIDEBAR-IA-0 Phase 2 fixup v3 (xuan msg `dce5a6fb` #2): when
     // the fixture sets `searchModalOpen`, auto-open the sidebar
-    // Search modal so E2E/audit can reach the modal
+    // Search modal so the alignment audit can reach the modal
     // shell deterministically. Real users never reach this branch
     // (e2eFixture.getState returns null without MAKA_E2E_FIXTURE).
     if (state.searchModalOpen) {
       setSearchModalOpen(true);
     }
     // PR-shared primitive-COMMAND-INPUT-0: e2e-fixture-only opener for the command
-    // palette so E2E/audit can cover its input shell without
+    // palette so the alignment audit can cover its input shell without
     // requiring Cmd/Ctrl+K.
     if (state.paletteOpen) {
       openPalette();
@@ -178,5 +178,5 @@ export function createAppShellE2EFixtureActions(options: {
     }
   }
 
-  return { applyE2EFixture };
+  return { applyE2eFixture };
 }

--- a/apps/desktop/src/renderer/app-shell-effects.ts
+++ b/apps/desktop/src/renderer/app-shell-effects.ts
@@ -174,7 +174,7 @@ export function useAppShellPersistenceEffects(options: {
 export function useAppShellBootstrapSubscriptions(options: {
   uiLocale: UiLocale;
   activeIdRef: RefBox<string | undefined>;
-  applyE2EFixture: () => Promise<void>;
+  applyE2eFixture: () => Promise<void>;
   bootstrapSessions: () => Promise<void>;
   clearPendingTurnActionsForSession: (sessionId: string) => void;
   clearSessionRendererState: (sessionId: string) => void;
@@ -211,7 +211,7 @@ export function useAppShellBootstrapSubscriptions(options: {
     void options.refreshManagedSkillSources();
     void options.refreshBundledSkillCatalog();
     void options.refreshPlanReminders();
-    void options.applyE2EFixture();
+    void options.applyE2eFixture();
   });
   const handleConnectionSubscriptionEvent = useEffectEvent((event: ConnectionEvent) => {
     options.handleConnectionEvent(event);

--- a/apps/desktop/src/renderer/app-shell-effects.ts
+++ b/apps/desktop/src/renderer/app-shell-effects.ts
@@ -174,7 +174,7 @@ export function useAppShellPersistenceEffects(options: {
 export function useAppShellBootstrapSubscriptions(options: {
   uiLocale: UiLocale;
   activeIdRef: RefBox<string | undefined>;
-  applyVisualSmokeFixture: () => Promise<void>;
+  applyE2EFixture: () => Promise<void>;
   bootstrapSessions: () => Promise<void>;
   clearPendingTurnActionsForSession: (sessionId: string) => void;
   clearSessionRendererState: (sessionId: string) => void;
@@ -211,7 +211,7 @@ export function useAppShellBootstrapSubscriptions(options: {
     void options.refreshManagedSkillSources();
     void options.refreshBundledSkillCatalog();
     void options.refreshPlanReminders();
-    void options.applyVisualSmokeFixture();
+    void options.applyE2EFixture();
   });
   const handleConnectionSubscriptionEvent = useEffectEvent((event: ConnectionEvent) => {
     options.handleConnectionEvent(event);

--- a/apps/desktop/src/renderer/app-shell.tsx
+++ b/apps/desktop/src/renderer/app-shell.tsx
@@ -74,7 +74,7 @@ import { useAppShellModuleData } from './use-module-data';
 import { useKeepSystemAwake } from './use-keep-system-awake';
 import { useAppShellProjectContext } from './use-project-context';
 import { createAppShellSessionEventHandlers } from './app-shell-session-events';
-import { createAppShellE2EFixtureActions } from './app-shell-e2e-fixture';
+import { createAppShellE2eFixtureActions } from './app-shell-e2e-fixture';
 import { createAppShellChatActions } from './app-shell-chat-actions';
 import { createAppShellTurnActions } from './app-shell-turn-actions';
 import { createAppShellLayoutActions } from './app-shell-layout-actions';
@@ -917,7 +917,7 @@ function AppShellContent({
     toastApi,
   });
 
-  const { applyE2EFixture } = useStableActions(createAppShellE2EFixtureActions, {
+  const { applyE2eFixture } = useStableActions(createAppShellE2eFixtureActions, {
     openPalette,
     openSettingsSection,
     openConnectionDetail,
@@ -1083,7 +1083,7 @@ function AppShellContent({
   useAppShellBootstrapSubscriptions({
     uiLocale,
     activeIdRef,
-    applyE2EFixture,
+    applyE2eFixture,
     bootstrapSessions,
     clearPendingTurnActionsForSession: turnActionRegistry.clearForSession,
     clearSessionRendererState,

--- a/apps/desktop/src/renderer/app-shell.tsx
+++ b/apps/desktop/src/renderer/app-shell.tsx
@@ -74,7 +74,7 @@ import { useAppShellModuleData } from './use-module-data';
 import { useKeepSystemAwake } from './use-keep-system-awake';
 import { useAppShellProjectContext } from './use-project-context';
 import { createAppShellSessionEventHandlers } from './app-shell-session-events';
-import { createAppShellVisualSmokeActions } from './app-shell-visual-smoke';
+import { createAppShellE2EFixtureActions } from './app-shell-e2e-fixture';
 import { createAppShellChatActions } from './app-shell-chat-actions';
 import { createAppShellTurnActions } from './app-shell-turn-actions';
 import { createAppShellLayoutActions } from './app-shell-layout-actions';
@@ -586,14 +586,14 @@ function AppShellContent({
   //
   // @kenji PR109e review + @xuan PR109f follow-up: scrollIntoView with
   // `behavior: 'smooth'` must respect both reduced-motion AND the
-  // visual-smoke capture entry (PR-IR-02). @xuan confirmed on main that
-  // visual-smoke always writes `data-maka-visual-smoke="true"` but
+  // e2e-fixture capture entry (PR-IR-02). @xuan confirmed on main that
+  // e2e-fixture always writes `data-maka-e2e-fixture="true"` but
   // `data-maka-reduced-motion="true"` is only set on the reduced
-  // variant — so the visual-smoke attribute is the broader signal for
+  // variant — so the e2e-fixture attribute is the broader signal for
   // "deterministic capture, no animations". Three triggers collapse to
   // `auto`:
   //   1. `data-maka-reduced-motion="true"` — PR-IR-04 reduced variant
-  //   2. `data-maka-visual-smoke="true"` — PR-IR-02 any capture
+  //   2. `data-maka-e2e-fixture="true"` — PR-IR-02 any capture
   //   3. `prefers-reduced-motion: reduce` — OS-level user preference
   function handleLineageBadgeClick(targetTurnId: string): void {
     requestAnimationFrame(() => {
@@ -917,7 +917,7 @@ function AppShellContent({
     toastApi,
   });
 
-  const { applyVisualSmokeFixture } = useStableActions(createAppShellVisualSmokeActions, {
+  const { applyE2EFixture } = useStableActions(createAppShellE2EFixtureActions, {
     openPalette,
     openSettingsSection,
     openConnectionDetail,
@@ -1083,7 +1083,7 @@ function AppShellContent({
   useAppShellBootstrapSubscriptions({
     uiLocale,
     activeIdRef,
-    applyVisualSmokeFixture,
+    applyE2EFixture,
     bootstrapSessions,
     clearPendingTurnActionsForSession: turnActionRegistry.clearForSession,
     clearSessionRendererState,

--- a/apps/desktop/src/renderer/maka-tokens.css
+++ b/apps/desktop/src/renderer/maka-tokens.css
@@ -1367,7 +1367,7 @@ html[data-os="darwin"].dark {
    as literal utilities in the primitive. Sweeps a clipped light band left→right
    across the glyph shape by translating `background-position`; the two-layer
    primitive keeps an opaque base underneath so the text stays readable. Frozen
-   by the global reduced-motion / visual-smoke rules in base.css and the
+   by the global reduced-motion / e2e-fixture rules in base.css and the
    primitive's own `motion-reduce:` guards. */
 @keyframes maka-text-shimmer {
   from { background-position: 150% 0; }
@@ -1380,7 +1380,7 @@ html[data-os="darwin"].dark {
    boundary) in `.maka-stream-fade` with a negative `animation-delay` (= -age)
    so the entrance resumes mid-flight across React re-renders instead of
    re-flashing. Only opacity animates (no layout). The wrapping is skipped
-   entirely under reduced-motion / visual-smoke (the smoother's snap path), so
+   entirely under reduced-motion / e2e-fixture (the smoother's snap path), so
    this never freezes text at opacity 0 in a deterministic capture. */
 @keyframes maka-stream-fade-in {
   from { opacity: 0; }

--- a/apps/desktop/src/renderer/scroll-motion-policy.ts
+++ b/apps/desktop/src/renderer/scroll-motion-policy.ts
@@ -7,9 +7,9 @@
  *
  * Three triggers collapse motion:
  *   1. `data-maka-reduced-motion="true"` on the document root — set by
- *      the PR-IR-04 reduced variant of the visual-smoke fixture.
- *   2. `data-maka-visual-smoke="true"` on the document root — set by
- *      ANY visual-smoke capture (@xuan PR109f confirmed visual-smoke
+ *      the PR-IR-04 reduced variant of the e2e-fixture fixture.
+ *   2. `data-maka-e2e-fixture="true"` on the document root — set by
+ *      ANY e2e-fixture capture (@xuan PR109f confirmed e2e-fixture
  *      always writes this attribute; the reduced-motion attr is only
  *      set on the reduced variant). This is the broader signal for
  *      "deterministic capture, no animations".
@@ -24,8 +24,8 @@ export type ScrollMotionBehavior = 'auto' | 'smooth';
 export interface ScrollMotionPolicyInputs {
   /** `document.documentElement.dataset.makaReducedMotion === 'true'` */
   reducedMotionAttr: boolean;
-  /** `document.documentElement.dataset.makaVisualSmoke === 'true'` */
-  visualSmokeAttr: boolean;
+  /** `document.documentElement.dataset.makaE2eFixture === 'true'` */
+  e2eFixtureAttr: boolean;
   /** `window.matchMedia('(prefers-reduced-motion: reduce)').matches` */
   prefersReducedMotion: boolean;
 }
@@ -38,7 +38,7 @@ export interface ScrollMotionPolicyInputs {
  * flags from whatever environment they're in.
  */
 export function resolveScrollMotionBehavior(inputs: ScrollMotionPolicyInputs): ScrollMotionBehavior {
-  if (inputs.reducedMotionAttr || inputs.visualSmokeAttr || inputs.prefersReducedMotion) {
+  if (inputs.reducedMotionAttr || inputs.e2eFixtureAttr || inputs.prefersReducedMotion) {
     return 'auto';
   }
   return 'smooth';
@@ -56,7 +56,7 @@ export function readScrollMotionBehavior(): ScrollMotionBehavior {
     window.matchMedia('(prefers-reduced-motion: reduce)').matches;
   return resolveScrollMotionBehavior({
     reducedMotionAttr: root.dataset.makaReducedMotion === 'true',
-    visualSmokeAttr: root.dataset.makaVisualSmoke === 'true',
+    e2eFixtureAttr: root.dataset.makaE2eFixture === 'true',
     prefersReducedMotion,
   });
 }

--- a/apps/desktop/src/renderer/settings/ProvidersPanel.tsx
+++ b/apps/desktop/src/renderer/settings/ProvidersPanel.tsx
@@ -47,7 +47,7 @@ export function ProvidersPanel({ bridge, initialPage = 'connections', initialCon
   initialPage?: 'connections' | 'catalog';
   /**
    * When set, auto-open the connection detail sheet for this slug once the
-   * connection list has loaded. Used by the `oauth-relogin` visual-smoke
+   * connection list has loaded. Used by the `oauth-relogin` e2e-fixture
    * fixture so the re-login affordance in the detail sheet is captured; a
    * real user reaches the same sheet by clicking the connection row.
    */

--- a/apps/desktop/src/renderer/settings/appearance-settings-page.tsx
+++ b/apps/desktop/src/renderer/settings/appearance-settings-page.tsx
@@ -185,7 +185,7 @@ export function PersonalizationSettingsPage(props: {
           PR-LANG-PREF-0 (WAWQAQ msg `edc9cb41` + kenji `7e532892`
           acceptance criteria): 自动 / 中文 / English. User explicit
           choice wins over the temporary auto -> zh fallback;
-          visual-smoke override wins over both (deterministic baselines).
+          e2e-fixture override wins over both (deterministic baselines).
         */}
         <div className="settingsFormRow">
           <div>

--- a/apps/desktop/src/renderer/settings/bot-chat-detail.tsx
+++ b/apps/desktop/src/renderer/settings/bot-chat-detail.tsx
@@ -60,7 +60,7 @@ export function BotChatChannelDetail(props: {
   /**
    * #1233 deferral: when true (only under the settings-bots-onboarding
    * e2e-fixture fixture), open the scan-login modal at mount so the QR
-   * waiting state captures deterministically. Real users never set this.
+   * waiting state renders deterministically. Real users never set this.
    */
   autoOpenScanLogin?: boolean;
   channel: BotChannelSettings;

--- a/apps/desktop/src/renderer/settings/bot-chat-detail.tsx
+++ b/apps/desktop/src/renderer/settings/bot-chat-detail.tsx
@@ -59,7 +59,7 @@ export function BotChatChannelDetail(props: {
   provider: BotProvider;
   /**
    * #1233 deferral: when true (only under the settings-bots-onboarding
-   * visual-smoke fixture), open the scan-login modal at mount so the QR
+   * e2e-fixture fixture), open the scan-login modal at mount so the QR
    * waiting state captures deterministically. Real users never set this.
    */
   autoOpenScanLogin?: boolean;

--- a/apps/desktop/src/renderer/settings/bot-chat-settings-page.tsx
+++ b/apps/desktop/src/renderer/settings/bot-chat-settings-page.tsx
@@ -59,14 +59,14 @@ export function BotChatSettingsPage(props: {
 
   // #1233 deferral: under the settings-bots-onboarding e2e-fixture fixture,
   // jump straight to the seeded provider's detail view and flag the scan-login
-  // modal to auto-open so the QR waiting state captures deterministically.
+  // modal to auto-open so the QR waiting state renders deterministically.
   useEffect(() => {
     let active = true;
-    void window.maka.e2eFixture.getState().then((smoke) => {
-      if (!active || !smoke?.botOnboardingProvider) return;
-      setSelected(smoke.botOnboardingProvider);
+    void window.maka.e2eFixture.getState().then((fixtureState) => {
+      if (!active || !fixtureState?.botOnboardingProvider) return;
+      setSelected(fixtureState.botOnboardingProvider);
       setDetailOpen(true);
-      setAutoOpenScanProvider(smoke.botOnboardingProvider);
+      setAutoOpenScanProvider(fixtureState.botOnboardingProvider);
     }).catch(() => undefined);
     return () => {
       active = false;

--- a/apps/desktop/src/renderer/settings/bot-chat-settings-page.tsx
+++ b/apps/desktop/src/renderer/settings/bot-chat-settings-page.tsx
@@ -32,8 +32,8 @@ export function BotChatSettingsPage(props: {
 }) {
   const [selected, setSelected] = useState<BotProvider>('telegram');
   const [detailOpen, setDetailOpen] = useState(false);
-  // #1233 deferral: the `settings-bots-onboarding` visual-smoke fixture opens a
-  // provider's scan-login modal deterministically. `visualSmoke.getState()`
+  // #1233 deferral: the `settings-bots-onboarding` e2e-fixture fixture opens a
+  // provider's scan-login modal deterministically. `e2eFixture.getState()`
   // resolves null for real users, so this only fires under the dev fixture.
   const [autoOpenScanProvider, setAutoOpenScanProvider] = useState<BotOnboardingProvider | null>(null);
   const [pendingBotAction, setPendingBotAction] = useState<BotPendingAction | null>(null);
@@ -57,12 +57,12 @@ export function BotChatSettingsPage(props: {
     };
   }, []);
 
-  // #1233 deferral: under the settings-bots-onboarding visual-smoke fixture,
+  // #1233 deferral: under the settings-bots-onboarding e2e-fixture fixture,
   // jump straight to the seeded provider's detail view and flag the scan-login
   // modal to auto-open so the QR waiting state captures deterministically.
   useEffect(() => {
     let active = true;
-    void window.maka.visualSmoke.getState().then((smoke) => {
+    void window.maka.e2eFixture.getState().then((smoke) => {
       if (!active || !smoke?.botOnboardingProvider) return;
       setSelected(smoke.botOnboardingProvider);
       setDetailOpen(true);

--- a/apps/desktop/src/renderer/stale-sessions.ts
+++ b/apps/desktop/src/renderer/stale-sessions.ts
@@ -9,8 +9,8 @@
  *
  * Two signals classify a session as stale:
  *
- *   1. `backend === 'fake'` — FakeBackend session, either from a visual
- *      smoke fixture or a legacy install that pre-dates the chat-readiness
+ *   1. `backend === 'fake'` — FakeBackend session, either from an e2e-fixture
+ *      or a legacy install that pre-dates the chat-readiness
  *      gate. With @xuan's send-path silent rebind these will swap to the
  *      default connection on send.
  *

--- a/apps/desktop/src/renderer/styles/base.css
+++ b/apps/desktop/src/renderer/styles/base.css
@@ -91,12 +91,12 @@ button {
   }
 /* PR-IR-04: Test-fixture-driven reduced-motion variant (per
      the reduced-motion contract tests). Mirrors `prefers-reduced-motion: reduce`
-     via an attribute on `<html>` so visual smoke fixtures can capture a
-     "reduced motion" screenshot variant without depending on the host OS
+     via an attribute on `<html>` so e2e-fixture renders can exercise a
+     "reduced motion" variant without depending on the host OS
      accessibility setting.
 
      The `data-maka-reduced-motion="true"` attribute is applied by the
-     renderer when `MAKA_VISUAL_SMOKE_REDUCED_MOTION=1` is set in the env.
+     renderer when `MAKA_E2E_FIXTURE_REDUCED_MOTION=1` is set in the env.
      Real users still get motion as configured by their OS. */
 [data-maka-reduced-motion="true"] *,
   [data-maka-reduced-motion="true"] *::before,
@@ -107,13 +107,13 @@ button {
     /* Scroll behavior + view transition durations also collapse */
     scroll-behavior: auto !important;
   }
-/* Visual smoke captures must be deterministic. We still exercise the
+/* E2E-fixture renders must be deterministic. We still exercise the
      normal DOM for every scenario, but pause purely decorative animation,
-     transitions, and caret blink so screenshot hashes don't depend on the
-     exact millisecond when Electron captures the page. */
-[data-maka-visual-smoke="true"] *,
-  [data-maka-visual-smoke="true"] *::before,
-  [data-maka-visual-smoke="true"] *::after {
+     transitions, and caret blink so the rendered state does not depend on
+     the exact millisecond the fixture settles. */
+[data-maka-e2e-fixture="true"] *,
+  [data-maka-e2e-fixture="true"] *::before,
+  [data-maka-e2e-fixture="true"] *::after {
     animation-play-state: paused !important;
     transition-duration: 0.01ms !important;
     caret-color: transparent !important;

--- a/apps/desktop/src/renderer/styles/sidebar.css
+++ b/apps/desktop/src/renderer/styles/sidebar.css
@@ -76,7 +76,7 @@
    * overlay viewport activates correctly.
    *
    * Hard gate: 50+ sessions in a narrow window must still let the
-   * footer stay visible. See the visual-smoke `sidebar-long-sessions`
+   * footer stay visible. See the e2e-fixture `sidebar-long-sessions`
    * scenario.
    */
   min-height: 0;
@@ -635,7 +635,7 @@
 /* PR109b: SessionStatusIcon — small inline icon next to session name
  * representing lifecycle status. Tone-based color from the
  * design-system token vocabulary; running spins via `animation`
- * (capped under reduced-motion + visual-smoke per PR-IR-04). */
+ * (capped under reduced-motion + e2e-fixture per PR-IR-04). */
 .maka-list-row-status-icon {
   display: inline-flex;
   align-items: center;
@@ -690,7 +690,7 @@
     animation: none;
   }
 }
-[data-maka-visual-smoke="true"] .maka-list-row-status-icon[data-status="running"] svg {
+[data-maka-e2e-fixture="true"] .maka-list-row-status-icon[data-status="running"] svg {
   animation: none;
 }
 

--- a/apps/desktop/src/renderer/use-shell-appearance.ts
+++ b/apps/desktop/src/renderer/use-shell-appearance.ts
@@ -18,7 +18,7 @@ type ToastApi = {
  * Owns the appearance / personalization / default-permission-mode slice
  * (issue #1043): the theme + palette + UI-locale + user-label + default
  * permission mode state, plus the `refreshShellSettings` IPC pull that
- * hydrates them from `window.maka.settings` / `visualSmoke` on mount and on
+ * hydrates them from `window.maka.settings` / `e2eFixture` on mount and on
  * close-settings re-reads.
  *
  * `closeSettings` stays in AppShell: on close it re-reads just the default
@@ -52,7 +52,7 @@ export function useShellAppearance({
     const uiLocaleHydration = uiLocaleUpdateGate.beginHydration();
     try {
       const next = await window.maka.settings.get();
-      const smoke = await window.maka.visualSmoke.getState();
+      const smoke = await window.maka.e2eFixture.getState();
       const pref = smoke?.theme ?? next.appearance?.theme ?? 'auto';
       const palette = next.appearance?.palette ?? 'default';
       const name = next.personalization?.displayName ?? '';

--- a/apps/desktop/src/renderer/use-shell-appearance.ts
+++ b/apps/desktop/src/renderer/use-shell-appearance.ts
@@ -52,12 +52,12 @@ export function useShellAppearance({
     const uiLocaleHydration = uiLocaleUpdateGate.beginHydration();
     try {
       const next = await window.maka.settings.get();
-      const smoke = await window.maka.e2eFixture.getState();
-      const pref = smoke?.theme ?? next.appearance?.theme ?? 'auto';
+      const fixtureState = await window.maka.e2eFixture.getState();
+      const pref = fixtureState?.theme ?? next.appearance?.theme ?? 'auto';
       const palette = next.appearance?.palette ?? 'default';
       const name = next.personalization?.displayName ?? '';
       const uiLocale = next.personalization?.uiLocale ?? 'auto';
-      setUiLocaleOverride(smoke?.locale ?? null);
+      setUiLocaleOverride(fixtureState?.locale ?? null);
       uiLocaleUpdateGate.commitHydration(
         uiLocaleHydration,
         uiLocale,

--- a/apps/desktop/stories/app-shell.stories.tsx
+++ b/apps/desktop/stories/app-shell.stories.tsx
@@ -141,7 +141,7 @@ const baseComposerProps: ComposerProps = {
 function ShellFrame(props: { children: ReactNode }) {
   return (
     <div
-      data-maka-visual-smoke="true"
+      data-maka-e2e-fixture="true"
       style={{ background: 'var(--surface-canvas)', height: '100%', minHeight: 640 }}
     >
       {props.children}

--- a/apps/desktop/stories/onboarding.stories.tsx
+++ b/apps/desktop/stories/onboarding.stories.tsx
@@ -46,7 +46,7 @@ const connections: LlmConnection[] = [
 function DetailPane(props: { children: ReactNode }) {
   return (
     <div
-      data-maka-visual-smoke="true"
+      data-maka-e2e-fixture="true"
       style={{
         background: 'var(--surface-canvas)',
         height: '100%',

--- a/apps/desktop/stories/settings/provider-settings.stories.tsx
+++ b/apps/desktop/stories/settings/provider-settings.stories.tsx
@@ -275,7 +275,7 @@ function ProviderStoryFrame(props: {
         ref={rootRef}
         className="settingsSurface"
         data-modal="true"
-        data-maka-visual-smoke="true"
+        data-maka-e2e-fixture="true"
         style={{
           gridTemplateColumns: 'minmax(0, 1fr)',
           height: 700,

--- a/apps/desktop/stories/settings/settings-pages.stories.tsx
+++ b/apps/desktop/stories/settings/settings-pages.stories.tsx
@@ -195,7 +195,7 @@ function SettingsStory(props: { section: SettingsSection }) {
   return (
     <ToastProvider>
       <div
-        data-maka-visual-smoke="true"
+        data-maka-e2e-fixture="true"
         style={{
           background: 'var(--surface-canvas)',
           height: '100%',

--- a/apps/desktop/tests/smoke.md
+++ b/apps/desktop/tests/smoke.md
@@ -52,10 +52,10 @@ The product's visual baseline is Storybook, not a screenshot harness. Page-level
 npm --workspace @maka/desktop run storybook
 ```
 
-To inspect a deterministic fixture interactively without touching a real workspace (the same `MAKA_VISUAL_SMOKE_FIXTURE` mechanism the Playwright E2E suite uses):
+To inspect a deterministic fixture interactively without touching a real workspace (the same `MAKA_E2E_FIXTURE` mechanism the Playwright E2E suite uses):
 
 ```bash
-MAKA_VISUAL_SMOKE_FIXTURE=all npm --workspace @maka/desktop run dev
+MAKA_E2E_FIXTURE=all npm --workspace @maka/desktop run dev
 ```
 
 Use a scenario name from the fixture registry for a narrower launch.

--- a/docs/architecture/bot-onboarding-runtime.zh-CN.md
+++ b/docs/architecture/bot-onboarding-runtime.zh-CN.md
@@ -140,7 +140,7 @@ Rollback 使用 `SettingsStore.updateIf(predicate, patch)`：只有 current chan
 - Provider error 经过固定 user-facing projection，不把 response body、URL query、credential 或 raw stack 返回 renderer。
 - Settings read IPC 会 mask `token` 与 `appSecret`；E2E 断言完整 renderer response 不包含原始 secret。
 - QR modal unmount 必须 cancel current session；late async result 不能更新 React state 或持久化 credential。
-- 正式 runtime 不提供 test adapter 注入入口给 renderer。deterministic adapter 只在 dev/test visual fixture 中由 main wiring 注入。
+- 正式 runtime 不提供 test adapter 注入入口给 renderer。deterministic adapter 只在 dev/test e2e-fixture 中由 main wiring 注入。
 
 当前 at-rest boundary 是 owner-only settings file，不等同于 encrypted secret storage。迁移 Keychain 时，应保持 `SettingsStore` 的 channel projection 与 masked IPC contract 不变，只替换 secret authority。
 

--- a/docs/frontend-css-governance.md
+++ b/docs/frontend-css-governance.md
@@ -38,7 +38,7 @@ The guard lives in `apps/desktop/src/main/__tests__/renderer-style-layer-cascade
 
 ## 4. `!important`
 
-- `!important` is allowed by default only for accessibility helpers such as `.maka-visually-hidden`, and for reduced-motion or visual-smoke overrides.
+- `!important` is allowed by default only for accessibility helpers such as `.maka-visually-hidden`, and for reduced-motion or e2e-fixture overrides.
 - Every other use requires an adjacent `Justified:` comment and an entry in `renderer-important-audit-contract.test.ts`.
 - Prefer a JSX utility-class reset when the primitive can express the behavior directly.
 

--- a/docs/frontend-css-governance.zh-CN.md
+++ b/docs/frontend-css-governance.zh-CN.md
@@ -51,7 +51,7 @@
 
 - 默认只允许两类场景使用 `!important`：
   - 无障碍辅助规则，例如 `.maka-visually-hidden`
-  - reduced-motion / visual-smoke 这类测试或可访问性覆盖
+  - reduced-motion / e2e-fixture 这类测试或可访问性覆盖
 - 其他任何 `!important` 都必须同时满足：
   - 就地写明 `Justified:` 注释
   - 在 `renderer-important-audit-contract.test.ts` 中登记

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -29,7 +29,7 @@
     "./attachments": "./dist/attachments.js",
     "./artifacts": "./dist/artifacts.js",
     "./runtime-inputs": "./dist/runtime-inputs.js",
-    "./visual-smoke": "./dist/visual-smoke.js",
+    "./e2e-fixture": "./dist/e2e-fixture.js",
     "./capabilities": "./dist/capabilities.js",
     "./capability-audit": "./dist/capability-audit.js",
     "./health": "./dist/health.js",

--- a/packages/core/src/__tests__/memory.test.ts
+++ b/packages/core/src/__tests__/memory.test.ts
@@ -489,7 +489,7 @@ describe('Quasi-memory surfaces cannot enter MemorySource', () => {
       'workspace_instruction',
       'onboarding_milestone',
       'health_probe',
-      'visual_smoke_fixture',
+      'e2e_fixture',
     ];
     for (const name of quasiNames) {
       const result = normalizeMemorySource(name);
@@ -514,7 +514,7 @@ describe('Quasi-memory surfaces cannot enter MemorySource', () => {
       'workspace_instruction',
       'onboarding_milestone',
       'health_probe',
-      'visual_smoke_fixture',
+      'e2e_fixture',
     ];
     for (const name of quasiNames) {
       const result = validateMemoryWriteRequest(

--- a/packages/core/src/e2e-fixture.ts
+++ b/packages/core/src/e2e-fixture.ts
@@ -24,8 +24,8 @@ export type E2eFixtureScenario =
   // PR-STREAM-TURN-CENTER: streaming-sidebar only shows the SIDEBAR dot (its
   // active session is a committed one). This seeds an ACTIVE session whose
   // main panel renders the live answer bubble below a committed turn, so
-  // the alignment audit can lock streaming-vs-committed horizontal
-  // alignment — the gap
+  // streaming-vs-committed horizontal alignment is locked
+  // deterministically — the gap
   // that let the "streaming markdown sits ~110px too far left" bug ship.
   | 'streaming-answer'
   // #646 real-time status language: a running session whose turn is armed with
@@ -108,14 +108,14 @@ export type E2eFixtureScenario =
   // PR-SIDEBAR-IA-0 Phase 2 fixup v3 (xuan msg `dce5a6fb` #2 +
   // WAWQAQ msg `4259bf8c`): seed the same 60-session sidebar as
   // sidebar-long-sessions, then auto-open the Search modal at
-  // mount so the alignment audit can reach the modal shell
+  // mount so the modal shell is on screen
   // without requiring an interaction. The opener uses
   // `E2eFixtureState.searchModalOpen=true`; real users never
   // receive an e2e-fixture state.
   | 'sidebar-search-modal-open'
   // PR-shared primitive-COMMAND-INPUT-0: reuse the long sidebar seed and
-  // auto-open the command palette so the alignment audit can exercise the
-  // shared primitive InputGroup command input shell without requiring a key
+  // auto-open the command palette so the
+  // shared primitive InputGroup command input shell is exercised without requiring a key
   // chord.
   | 'command-palette-open'
   // PR-SIDEBAR-IA-0 Phase 3 P0 fixup v4 (WAWQAQ msg `5dd1c348`,
@@ -130,7 +130,7 @@ export type E2eFixtureScenario =
   // tall, opened as the active session on boot. Off-screen turns mount as
   // 250px content-visibility placeholders, so this seed exercises the
   // warm-up + pinned-bottom geometry invariants (E2E scroll-geometry spec)
-  // and gives the alignment audit a long-transcript surface.
+  // and gives the scroll-geometry Playwright spec a long-transcript surface.
   | 'long-transcript'
   // #819: BrowserPanel renderer-chrome fixture. Seeds `liveBrowserSessionIds`
   // with the active turn session so `BrowserPanel` mounts (app-shell gates
@@ -185,7 +185,7 @@ export interface E2eFixtureState {
    * renderer's `liveBrowserSessionIds` state (app-shell gates `BrowserPanel`
    * mounting on `activeId && liveBrowserSessionIds.includes(activeId)`).
    * Seeded only by the `browser-empty` scenario so the renderer chrome is
-   * reachable by the alignment audit. Real users never receive an e2e-fixture state, so
+   * reachable for inspection. Real users never receive an e2e-fixture state, so
    * this never drives production `browser:live` wiring.
    */
   liveBrowserSessionIds?: string[];
@@ -193,7 +193,7 @@ export interface E2eFixtureState {
   /**
    * When set, open Settings → 模型 with this connection's detail sheet
    * expanded (rather than just the section). Seeded by `oauth-relogin` so the
-   * detail sheet's re-login affordance is what the alignment audit sees; takes
+   * detail sheet's re-login affordance is what gets exposed; takes
    * precedence over `openSettingsSection`.
    */
   openConnectionDetailSlug?: string;
@@ -210,7 +210,7 @@ export interface E2eFixtureState {
   reducedMotion?: boolean;
   /**
    * PR-IR-01b: theme override driven by `MAKA_E2E_FIXTURE_THEME=light|dark|auto`.
-   * Lets the alignment audit exercise each scenario in both light
+   * Lets each scenario be exercised in both light
    * and dark themes without requiring per-fixture seed updates. The
    * renderer applies this BEFORE the user's persisted theme so the
    * first paint already has the right palette.
@@ -247,7 +247,7 @@ export interface E2eFixtureState {
   /**
    * PR-SIDEBAR-IA-0 Phase 2 fixup v3 (xuan msg `dce5a6fb` #2): when
    * `true`, the renderer auto-opens the sidebar Search modal at
-   * mount so the alignment audit can reach the modal shell
+   * mount so the modal shell is on screen
    * deterministically (the modal is not the default state of any
    * scenario; opening it requires either user input or this hint).
    *
@@ -258,8 +258,8 @@ export interface E2eFixtureState {
   searchModalOpen?: boolean;
   /**
    * PR-shared primitive-COMMAND-INPUT-0: when `true`, the renderer auto-opens
-   * the command palette at mount so the alignment audit can
-   * reach the command input shell deterministically. Currently set
+   * the command palette at mount so the
+   * command input shell is on screen deterministically. Currently set
    * only by `command-palette-open`.
    */
   paletteOpen?: boolean;
@@ -272,7 +272,7 @@ export interface E2eFixtureState {
    * then shows the actions cluster — without this hint, default
    * fixture renders never have any focused row, so the overlap fix
    * (`.maka-list-row:focus-within .maka-list-row-meta {
-   * visibility: hidden }`) can't be verified by the alignment audit.
+   * visibility: hidden }`) can't be verified without a focused row.
    *
    * Currently set only by the `sidebar-row-actions-visible`
    * scenario.

--- a/packages/core/src/e2e-fixture.ts
+++ b/packages/core/src/e2e-fixture.ts
@@ -3,7 +3,7 @@ import type { PermissionRequestEvent, ToolResultContent } from './events.js';
 import type { SettingsSection } from './settings.js';
 import type { UiLocale } from './ui-locale.js';
 
-export type VisualSmokeScenario =
+export type E2EFixtureScenario =
   | 'all'
   | 'first-run'
   | 'provider-workspace'
@@ -23,8 +23,9 @@ export type VisualSmokeScenario =
   | 'streaming-sidebar'
   // PR-STREAM-TURN-CENTER: streaming-sidebar only shows the SIDEBAR dot (its
   // active session is a committed one). This seeds an ACTIVE session whose
-  // main panel renders the live answer bubble below a committed turn, so the
-  // screenshot locks streaming-vs-committed horizontal alignment — the gap
+  // main panel renders the live answer bubble below a committed turn, so
+  // E2E + the alignment audit can lock streaming-vs-committed horizontal
+  // alignment — the gap
   // that let the "streaming markdown sits ~110px too far left" bug ship.
   | 'streaming-answer'
   // #646 real-time status language: a running session whose turn is armed with
@@ -45,8 +46,8 @@ export type VisualSmokeScenario =
   // had no deterministic capture because a real device-code start contacts an
   // external IM platform and the QR + TTL drift every run. This scenario opens
   // Settings → 远程接入 → a bot detail with the scan-login modal auto-opened,
-  // backed by a visual-smoke adapter that holds the 'waiting' state with a
-  // FIXED QR + long TTL, so the modal's waiting layout captures deterministically.
+  // backed by an e2e-fixture adapter that holds the 'waiting' state with a
+  // FIXED QR + long TTL, so the modal's waiting layout renders deterministically.
   | 'settings-bots-onboarding'
   | 'settings-about'
   | 'settings-general'
@@ -68,9 +69,9 @@ export type VisualSmokeScenario =
   // branch sessions (one with visible parent showing the banner, one
   // with a missing parent that must NOT render a banner). The three
   // scenarios below share the same on-disk seed; they only differ in
-  // which session is the active one so auto-capture produces three
-  // deterministic screenshots covering both positive and negative
-  // banner cases without requiring manual clicks.
+  // which session is the active one, exposing three deterministic
+  // states covering both positive and negative banner cases without
+  // requiring manual clicks.
   | 'turn-control-history'
   | 'turn-control-branch-visible'
   | 'turn-control-branch-orphan'
@@ -78,8 +79,8 @@ export type VisualSmokeScenario =
   // visual contract for the new registry-driven image path. Each
   // scenario writes a SINGLE artifact to ARTIFACT_SESSION_ID so the
   // ArtifactPane's default selection (records[0]) deterministically
-  // shows the one we want to screenshot. @kenji review @msg
-  // fc9753b9 holds visual-regression sign-off pending these three.
+  // shows the one we want to verify. @kenji review @msg
+  // fc9753b9 holds review sign-off pending these three.
   //   - artifact-preview-image: real tiny PNG → registry resolves
   //     `image(mime_match)`, <img object-fit:contain> inside bounded
   //     container.
@@ -101,19 +102,19 @@ export type VisualSmokeScenario =
   // scroll container can be verified end-to-end: the list must scroll
   // independently, and the footer (Settings + Version info)
   // must stay visible at the bottom regardless of session count.
-  // Auto-capture variant pairs (light + dark, narrow + wide) double
+  // Variant pairs (light + dark, narrow + wide) double
   // as the CI gate that scroll did not regress.
   | 'sidebar-long-sessions'
   // PR-SIDEBAR-IA-0 Phase 2 fixup v3 (xuan msg `dce5a6fb` #2 +
   // WAWQAQ msg `4259bf8c`): seed the same 60-session sidebar as
   // sidebar-long-sessions, then auto-open the Search modal at
-  // mount so the screenshot pipeline captures the modal shell
+  // mount so E2E/audit can reach the modal shell
   // without requiring an interaction. The opener uses
-  // `VisualSmokeState.searchModalOpen=true`; real users never
-  // receive a visual smoke state.
+  // `E2EFixtureState.searchModalOpen=true`; real users never
+  // receive an e2e-fixture state.
   | 'sidebar-search-modal-open'
   // PR-shared primitive-COMMAND-INPUT-0: reuse the long sidebar seed and
-  // auto-open the command palette so screenshots can baseline the
+  // auto-open the command palette so E2E/audit can exercise the
   // shared primitive InputGroup command input shell without requiring a key
   // chord.
   | 'command-palette-open'
@@ -129,21 +130,21 @@ export type VisualSmokeScenario =
   // tall, opened as the active session on boot. Off-screen turns mount as
   // 250px content-visibility placeholders, so this seed exercises the
   // warm-up + pinned-bottom geometry invariants (E2E scroll-geometry spec)
-  // and gives screenshots a long-transcript surface.
+  // and gives E2E/audit a long-transcript surface.
   | 'long-transcript'
   // #819: BrowserPanel renderer-chrome fixture. Seeds `liveBrowserSessionIds`
   // with the active turn session so `BrowserPanel` mounts (app-shell gates
   // on `activeId && liveBrowserSessionIds.includes(activeId)`). In
-  // visual-smoke mode there is no native `WebContentsView`, so
+  // e2e-fixture mode there is no native `WebContentsView`, so
   // `browser.getState` resolves null and `BrowserPanel` renders `EMPTY_STATE`
   // — the empty-state chrome (toolbar with all nav buttons disabled + the
   // `<Empty>` strip) that the #818 narrow-layout defect regressed against.
   // Loaded / loading / nav chrome states are locked by the
   // `browser-panel-chrome` source contract (their wiring IS the behavior);
-  // their screenshots add no layout value over this empty-state baseline.
+  // they add no layout value over this empty-state fixture.
   | 'browser-empty';
 
-export interface VisualSmokeLiveTool {
+export interface E2EFixtureLiveTool {
   toolUseId: string;
   toolName: string;
   stepId?: string;
@@ -155,27 +156,27 @@ export interface VisualSmokeLiveTool {
   durationMs?: number;
 }
 
-export interface VisualSmokeLiveTurnStep {
+export interface E2EFixtureLiveTurnStep {
   stepId: string;
   thinking?: { text: string; truncated: boolean; complete: boolean };
   text?: { text: string; truncated: boolean; complete: boolean };
-  tools: VisualSmokeLiveTool[];
+  tools: E2EFixtureLiveTool[];
 }
 
-export interface VisualSmokeLiveTurnProjection {
+export interface E2EFixtureLiveTurnProjection {
   turnId: string;
   phase: 'waiting' | 'streamed';
   terminal?: true;
-  steps: VisualSmokeLiveTurnStep[];
+  steps: E2EFixtureLiveTurnStep[];
 }
 
-export interface VisualSmokeState {
+export interface E2EFixtureState {
   enabled: true;
   /**
    * Deterministic wall-clock timestamp for fixture rendering. The
-   * renderer uses it to freeze `Date.now()` while visual smoke mode is
+   * renderer uses it to freeze `Date.now()` while e2e-fixture mode is
    * active so relative-time labels, fetched-at copy, and transient
-   * permission timestamps do not drift between screenshot runs.
+   * permission timestamps do not drift between runs.
    */
   now?: number;
   activeSessionId?: string;
@@ -183,8 +184,8 @@ export interface VisualSmokeState {
    * #819: session ids with a live embedded-browser view, mirrorring the
    * renderer's `liveBrowserSessionIds` state (app-shell gates `BrowserPanel`
    * mounting on `activeId && liveBrowserSessionIds.includes(activeId)`).
-   * Seeded only by the `browser-empty` scenario so the renderer chrome can
-   * be screenshot-captured. Real users never receive a visual smoke state, so
+   * Seeded only by the `browser-empty` scenario so the renderer chrome is
+   * reachable by E2E/audit. Real users never receive an e2e-fixture state, so
    * this never drives production `browser:live` wiring.
    */
   liveBrowserSessionIds?: string[];
@@ -192,15 +193,15 @@ export interface VisualSmokeState {
   /**
    * When set, open Settings → 模型 with this connection's detail sheet
    * expanded (rather than just the section). Seeded by `oauth-relogin` so the
-   * detail sheet's re-login affordance is what gets screenshot-captured; takes
+   * detail sheet's re-login affordance is what E2E/audit see; takes
    * precedence over `openSettingsSection`.
    */
   openConnectionDetailSlug?: string;
-  liveTurnBySession?: Record<string, VisualSmokeLiveTurnProjection>;
+  liveTurnBySession?: Record<string, E2EFixtureLiveTurnProjection>;
   permissionBySession?: Record<string, PermissionRequestEvent>;
   /**
    * PR-IR-04: force `prefers-reduced-motion: reduce` behavior regardless
-   * of the host OS setting. Triggered by `MAKA_VISUAL_SMOKE_REDUCED_MOTION=1`
+   * of the host OS setting. Triggered by `MAKA_E2E_FIXTURE_REDUCED_MOTION=1`
    * env var in the main process. The renderer applies
    * `data-maka-reduced-motion="true"` to `<html>` so the matching CSS
    * rule in `styles.css` collapses every animation/transition to
@@ -208,8 +209,8 @@ export interface VisualSmokeState {
    */
   reducedMotion?: boolean;
   /**
-   * PR-IR-01b: theme override driven by `MAKA_VISUAL_SMOKE_THEME=light|dark|auto`.
-   * Lets the screenshot pipeline capture each scenario in both light
+   * PR-IR-01b: theme override driven by `MAKA_E2E_FIXTURE_THEME=light|dark|auto`.
+   * Lets E2E and the alignment audit exercise each scenario in both light
    * and dark themes without requiring per-fixture seed updates. The
    * renderer applies this BEFORE the user's persisted theme so the
    * first paint already has the right palette.
@@ -217,18 +218,18 @@ export interface VisualSmokeState {
   theme?: 'light' | 'dark' | 'auto';
   /**
    * PR-UI-VISUAL-SMOKE-LOCALE: UI locale override driven by
-   * `MAKA_VISUAL_SMOKE_LOCALE=zh|en`. The reactive locale provider
+   * `MAKA_E2E_FIXTURE_LOCALE=zh|en`. The reactive locale provider
    * normally follows the persisted preference. When set, the renderer
-   * records `data-maka-visual-smoke-locale="zh|en"` on `<html>` and
+   * records `data-maka-e2e-fixture-locale="zh|en"` on `<html>` and
    * resolves that override before the persisted preference.
    * Unrecognized values fall back to undefined.
    */
   locale?: UiLocale;
   /**
    * PR-UI-VISUAL-SMOKE-TIMEZONE: IANA timezone override driven by
-   * `MAKA_VISUAL_SMOKE_TIMEZONE=<IANA name>`. Mirrors the locale
+   * `MAKA_E2E_FIXTURE_TIMEZONE=<IANA name>`. Mirrors the locale
    * override pattern: when set, the renderer applies
-   * `data-maka-visual-smoke-tz="<IANA>"` to `<html>` so any date /
+   * `data-maka-e2e-fixture-tz="<IANA>"` to `<html>` so any date /
    * time formatting helper can read it BEFORE falling back to the
    * host system timezone.
    *
@@ -239,26 +240,26 @@ export interface VisualSmokeState {
    * write only; per-call timezone consumption is up to individual
    * formatters as they're added.
    *
-   * Real users never receive a visual smoke state, so their Date
+   * Real users never receive an e2e-fixture state, so their Date
    * formatting remains untouched.
    */
   timezone?: string;
   /**
    * PR-SIDEBAR-IA-0 Phase 2 fixup v3 (xuan msg `dce5a6fb` #2): when
    * `true`, the renderer auto-opens the sidebar Search modal at
-   * mount so the screenshot pipeline can capture the modal shell
+   * mount so E2E/audit can reach the modal shell
    * deterministically (the modal is not the default state of any
    * scenario; opening it requires either user input or this hint).
    *
    * Currently set only by the `sidebar-search-modal-open` scenario.
-   * Real users never receive a visual smoke state, so this never
+   * Real users never receive an e2e-fixture state, so this never
    * affects the production app.
    */
   searchModalOpen?: boolean;
   /**
    * PR-shared primitive-COMMAND-INPUT-0: when `true`, the renderer auto-opens
-   * the command palette at mount so the screenshot pipeline can
-   * capture the command input shell deterministically. Currently set
+   * the command palette at mount so E2E/audit can
+   * reach the command input shell deterministically. Currently set
    * only by `command-palette-open`.
    */
   paletteOpen?: boolean;
@@ -267,11 +268,11 @@ export interface VisualSmokeState {
    * kenji `b3d156e9`): when `true`, the renderer focuses the
    * active row's `.maka-list-row-main` button after mount so the
    * row's `:focus-within` triggers and the absolute-positioned
-   * `.maka-list-row-actions` overlay becomes visible. The capture
+   * `.maka-list-row-actions` overlay becomes visible. The fixture
    * then shows the actions cluster — without this hint, default
-   * captures never have any focused row, so the overlap fix
+   * fixture renders never have any focused row, so the overlap fix
    * (`.maka-list-row:focus-within .maka-list-row-meta {
-   * visibility: hidden }`) can't be screenshot-verified.
+   * visibility: hidden }`) can't be verified by E2E/audit.
    *
    * Currently set only by the `sidebar-row-actions-visible`
    * scenario.
@@ -279,29 +280,29 @@ export interface VisualSmokeState {
   focusActiveRow?: boolean;
   /**
    * Fixture-only sidebar module override. Used by scenarios that need
-   * to screenshot non-session sidebar content without adding a real
+   * to render non-session sidebar content without adding a real
    * router path.
    */
   sidebarSection?: 'sessions' | 'automations' | 'skills' | 'mcp' | 'daily-review';
   /**
-   * Fixture-only sidebar collapsed override. Screenshot runs use a
+   * Fixture-only sidebar collapsed override. Fixture runs use a
    * fresh userData dir, while the real app defaults to the collapsed
    * target-layout like rail when no local preference exists. Sidebar
-   * visual gates must opt into the expanded panel explicitly so their
-   * captures prove the rows, counts, groups, and footer instead of
+   * visual gates must opt into the expanded panel explicitly so the
+   * rendered fixture proves the rows, counts, groups, and footer instead of
    * only the top-left icon rail.
    */
   sidebarCollapsed?: boolean;
-  /** Fixture-only session workbar state for deterministic tab screenshots. */
+  /** Fixture-only session workbar state for deterministic tab rendering. */
   workbarCollapsed?: boolean;
   workbarTab?: 'tasks' | 'browser' | 'files';
   /**
-   * #1233 deferral — bot QR-onboarding modal capture. When set, the Settings
+   * #1233 deferral — bot QR-onboarding modal fixture. When set, the Settings
    * 远程接入 page (bot-chat-settings-page) opens the given provider's detail
    * view and auto-opens its scan-login modal at mount, so the deterministic
-   * waiting-state QR fixture is what the screenshot pipeline captures. Only the
-   * `settings-bots-onboarding` scenario sets this; real users never receive a
-   * visual smoke state so production onboarding is untouched.
+   * waiting-state QR fixture is what E2E/audit see. Only the
+   * `settings-bots-onboarding` scenario sets this; real users never receive an
+   * e2e-fixture state so production onboarding is untouched.
    */
   botOnboardingProvider?: BotOnboardingProvider;
 }

--- a/packages/core/src/e2e-fixture.ts
+++ b/packages/core/src/e2e-fixture.ts
@@ -3,7 +3,7 @@ import type { PermissionRequestEvent, ToolResultContent } from './events.js';
 import type { SettingsSection } from './settings.js';
 import type { UiLocale } from './ui-locale.js';
 
-export type E2EFixtureScenario =
+export type E2eFixtureScenario =
   | 'all'
   | 'first-run'
   | 'provider-workspace'
@@ -24,7 +24,7 @@ export type E2EFixtureScenario =
   // PR-STREAM-TURN-CENTER: streaming-sidebar only shows the SIDEBAR dot (its
   // active session is a committed one). This seeds an ACTIVE session whose
   // main panel renders the live answer bubble below a committed turn, so
-  // E2E + the alignment audit can lock streaming-vs-committed horizontal
+  // the alignment audit can lock streaming-vs-committed horizontal
   // alignment — the gap
   // that let the "streaming markdown sits ~110px too far left" bug ship.
   | 'streaming-answer'
@@ -108,13 +108,13 @@ export type E2EFixtureScenario =
   // PR-SIDEBAR-IA-0 Phase 2 fixup v3 (xuan msg `dce5a6fb` #2 +
   // WAWQAQ msg `4259bf8c`): seed the same 60-session sidebar as
   // sidebar-long-sessions, then auto-open the Search modal at
-  // mount so E2E/audit can reach the modal shell
+  // mount so the alignment audit can reach the modal shell
   // without requiring an interaction. The opener uses
-  // `E2EFixtureState.searchModalOpen=true`; real users never
+  // `E2eFixtureState.searchModalOpen=true`; real users never
   // receive an e2e-fixture state.
   | 'sidebar-search-modal-open'
   // PR-shared primitive-COMMAND-INPUT-0: reuse the long sidebar seed and
-  // auto-open the command palette so E2E/audit can exercise the
+  // auto-open the command palette so the alignment audit can exercise the
   // shared primitive InputGroup command input shell without requiring a key
   // chord.
   | 'command-palette-open'
@@ -130,7 +130,7 @@ export type E2EFixtureScenario =
   // tall, opened as the active session on boot. Off-screen turns mount as
   // 250px content-visibility placeholders, so this seed exercises the
   // warm-up + pinned-bottom geometry invariants (E2E scroll-geometry spec)
-  // and gives E2E/audit a long-transcript surface.
+  // and gives the alignment audit a long-transcript surface.
   | 'long-transcript'
   // #819: BrowserPanel renderer-chrome fixture. Seeds `liveBrowserSessionIds`
   // with the active turn session so `BrowserPanel` mounts (app-shell gates
@@ -144,7 +144,7 @@ export type E2EFixtureScenario =
   // they add no layout value over this empty-state fixture.
   | 'browser-empty';
 
-export interface E2EFixtureLiveTool {
+export interface E2eFixtureLiveTool {
   toolUseId: string;
   toolName: string;
   stepId?: string;
@@ -156,21 +156,21 @@ export interface E2EFixtureLiveTool {
   durationMs?: number;
 }
 
-export interface E2EFixtureLiveTurnStep {
+export interface E2eFixtureLiveTurnStep {
   stepId: string;
   thinking?: { text: string; truncated: boolean; complete: boolean };
   text?: { text: string; truncated: boolean; complete: boolean };
-  tools: E2EFixtureLiveTool[];
+  tools: E2eFixtureLiveTool[];
 }
 
-export interface E2EFixtureLiveTurnProjection {
+export interface E2eFixtureLiveTurnProjection {
   turnId: string;
   phase: 'waiting' | 'streamed';
   terminal?: true;
-  steps: E2EFixtureLiveTurnStep[];
+  steps: E2eFixtureLiveTurnStep[];
 }
 
-export interface E2EFixtureState {
+export interface E2eFixtureState {
   enabled: true;
   /**
    * Deterministic wall-clock timestamp for fixture rendering. The
@@ -185,7 +185,7 @@ export interface E2EFixtureState {
    * renderer's `liveBrowserSessionIds` state (app-shell gates `BrowserPanel`
    * mounting on `activeId && liveBrowserSessionIds.includes(activeId)`).
    * Seeded only by the `browser-empty` scenario so the renderer chrome is
-   * reachable by E2E/audit. Real users never receive an e2e-fixture state, so
+   * reachable by the alignment audit. Real users never receive an e2e-fixture state, so
    * this never drives production `browser:live` wiring.
    */
   liveBrowserSessionIds?: string[];
@@ -193,11 +193,11 @@ export interface E2EFixtureState {
   /**
    * When set, open Settings → 模型 with this connection's detail sheet
    * expanded (rather than just the section). Seeded by `oauth-relogin` so the
-   * detail sheet's re-login affordance is what E2E/audit see; takes
+   * detail sheet's re-login affordance is what the alignment audit sees; takes
    * precedence over `openSettingsSection`.
    */
   openConnectionDetailSlug?: string;
-  liveTurnBySession?: Record<string, E2EFixtureLiveTurnProjection>;
+  liveTurnBySession?: Record<string, E2eFixtureLiveTurnProjection>;
   permissionBySession?: Record<string, PermissionRequestEvent>;
   /**
    * PR-IR-04: force `prefers-reduced-motion: reduce` behavior regardless
@@ -210,7 +210,7 @@ export interface E2EFixtureState {
   reducedMotion?: boolean;
   /**
    * PR-IR-01b: theme override driven by `MAKA_E2E_FIXTURE_THEME=light|dark|auto`.
-   * Lets E2E and the alignment audit exercise each scenario in both light
+   * Lets the alignment audit exercise each scenario in both light
    * and dark themes without requiring per-fixture seed updates. The
    * renderer applies this BEFORE the user's persisted theme so the
    * first paint already has the right palette.
@@ -247,7 +247,7 @@ export interface E2EFixtureState {
   /**
    * PR-SIDEBAR-IA-0 Phase 2 fixup v3 (xuan msg `dce5a6fb` #2): when
    * `true`, the renderer auto-opens the sidebar Search modal at
-   * mount so E2E/audit can reach the modal shell
+   * mount so the alignment audit can reach the modal shell
    * deterministically (the modal is not the default state of any
    * scenario; opening it requires either user input or this hint).
    *
@@ -258,7 +258,7 @@ export interface E2EFixtureState {
   searchModalOpen?: boolean;
   /**
    * PR-shared primitive-COMMAND-INPUT-0: when `true`, the renderer auto-opens
-   * the command palette at mount so E2E/audit can
+   * the command palette at mount so the alignment audit can
    * reach the command input shell deterministically. Currently set
    * only by `command-palette-open`.
    */
@@ -272,7 +272,7 @@ export interface E2EFixtureState {
    * then shows the actions cluster — without this hint, default
    * fixture renders never have any focused row, so the overlap fix
    * (`.maka-list-row:focus-within .maka-list-row-meta {
-   * visibility: hidden }`) can't be verified by E2E/audit.
+   * visibility: hidden }`) can't be verified by the alignment audit.
    *
    * Currently set only by the `sidebar-row-actions-visible`
    * scenario.
@@ -300,7 +300,7 @@ export interface E2EFixtureState {
    * #1233 deferral — bot QR-onboarding modal fixture. When set, the Settings
    * 远程接入 page (bot-chat-settings-page) opens the given provider's detail
    * view and auto-opens its scan-login modal at mount, so the deterministic
-   * waiting-state QR fixture is what E2E/audit see. Only the
+   * waiting-state QR fixture is what the alignment audit sees. Only the
    * `settings-bots-onboarding` scenario sets this; real users never receive an
    * e2e-fixture state so production onboarding is untouched.
    */

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -514,12 +514,12 @@ export type {
   SessionListFilter,
 } from './runtime-inputs.js';
 
-// visual-smoke.ts
+// e2e-fixture.ts
 export type {
-  VisualSmokeLiveTool,
-  VisualSmokeScenario,
-  VisualSmokeState,
-} from './visual-smoke.js';
+  E2EFixtureLiveTool,
+  E2EFixtureScenario,
+  E2EFixtureState,
+} from './e2e-fixture.js';
 
 // capabilities.ts
 export type {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -516,9 +516,9 @@ export type {
 
 // e2e-fixture.ts
 export type {
-  E2EFixtureLiveTool,
-  E2EFixtureScenario,
-  E2EFixtureState,
+  E2eFixtureLiveTool,
+  E2eFixtureScenario,
+  E2eFixtureState,
 } from './e2e-fixture.js';
 
 // capabilities.ts

--- a/packages/core/src/settings.ts
+++ b/packages/core/src/settings.ts
@@ -172,7 +172,7 @@ export interface AppearanceSettings {
  *
  * `'auto'` — temporarily resolve to Chinese-first UI copy.
  * `'zh'` / `'en'` — user explicit override; takes precedence over
- *   the temporary fallback but is itself overridden by the visual-smoke
+ *   the temporary fallback but is itself overridden by the e2e-fixture
  *   fixture locale (fixtures stay deterministic regardless of the
  *   persisted user preference).
  *
@@ -186,7 +186,7 @@ export interface PersonalizationSettings {
   assistantTone: string;
   /**
    * PR-LANG-PREF-0: UI locale preference (kenji `7e532892` acceptance):
-   * user explicit choice > temporary auto-to-Chinese fallback; visual-smoke override
+   * user explicit choice > temporary auto-to-Chinese fallback; e2e-fixture override
    * stays for fixture tests. Defaults to `'auto'`.
    */
   uiLocale: UiLocalePreference;

--- a/packages/storage/src/artifact-store.ts
+++ b/packages/storage/src/artifact-store.ts
@@ -106,7 +106,7 @@ class FileArtifactStore implements ArtifactStore {
         .filter((record) => record.sessionId === sessionId)
         .filter((record) => opts.includeDeleted || record.status !== 'deleted')
         // Secondary `id` sort for determinism when fixture artifacts share
-        // a frozen createdAt (PR108k-yj visual-smoke determinism).
+        // a frozen createdAt (PR108k-yj e2e-fixture determinism).
         .sort((a, b) => {
           const tsDelta = b.createdAt - a.createdAt;
           if (tsDelta !== 0) return tsDelta;

--- a/packages/storage/src/session-store.ts
+++ b/packages/storage/src/session-store.ts
@@ -165,7 +165,7 @@ class FileSessionStore implements SessionStore {
     // lastMessageAt always sort in the same order - fixtures with
     // multiple sessions seeded at the same frozen timestamp would
     // otherwise drift across runs based on filesystem readdir order
-    // (PR108k-yj per @kenji visual-smoke determinism). Negligible cost
+    // (PR108k-yj per @kenji e2e-fixture determinism). Negligible cost
     // for real users; identical lastMessageAt is rare in production.
     withHeaders.sort((a, b) => {
       const aLastMessageAt = maxTimestamp(

--- a/packages/ui/src/__tests__/locale-context.test.tsx
+++ b/packages/ui/src/__tests__/locale-context.test.tsx
@@ -61,12 +61,12 @@ describe('syncUiLocaleDocument', () => {
       syncUiLocaleDocument('zh', 'zh');
       assert.equal(attributes.get('lang'), 'zh');
       assert.equal(attributes.get('data-maka-locale'), 'zh');
-      assert.equal(attributes.get('data-maka-visual-smoke-locale'), 'zh');
+      assert.equal(attributes.get('data-maka-e2e-fixture-locale'), 'zh');
 
       syncUiLocaleDocument('en', null);
       assert.equal(attributes.get('lang'), 'en');
       assert.equal(attributes.get('data-maka-locale'), 'en');
-      assert.equal(attributes.has('data-maka-visual-smoke-locale'), false);
+      assert.equal(attributes.has('data-maka-e2e-fixture-locale'), false);
     } finally {
       globalThis.document = previousDocument;
     }

--- a/packages/ui/src/artifact-preview-registry.ts
+++ b/packages/ui/src/artifact-preview-registry.ts
@@ -101,7 +101,7 @@ export type PreviewResolution =
 
 /**
  * Max decoded image payload allowed into React state. 2MB is well
- * past every visual-smoke fixture and most user screenshots; a
+ * past every e2e-fixture fixture and most user screenshots; a
  * real 10MB PNG should display via Finder open / future blob-URL
  * protocol rather than as a `data:` URL inside `setState`.
  *

--- a/packages/ui/src/chat-empty-hero.tsx
+++ b/packages/ui/src/chat-empty-hero.tsx
@@ -14,10 +14,10 @@
  *
  * Why this seam: the empty-chat hero is the first thing every
  * user sees on a fresh session. Its day-period boundary
- * (5/11/14/18) is screenshot-baseline-pinned by a contract test
+ * (5/11/14/18) is pinned by a contract test
  * because e2e-fixture fixtures freeze `Date.now()` but not the
  * `Date` constructor — getting this wrong silently drifts the
- * baseline. The DeepResearch variant is also where the read-only
+ * rendered greeting. The DeepResearch variant is also where the read-only
  * deep-research workflow rules live. Both deserve their own
  * surface so the boundary rules sit next to the surface they
  * govern, not buried in a 7000-line file.

--- a/packages/ui/src/chat-empty-hero.tsx
+++ b/packages/ui/src/chat-empty-hero.tsx
@@ -33,8 +33,8 @@ export type { DayPeriod } from './conversation-copy.js';
 /**
  * PR-UI-LAYOUT-4 / B1-a1 review fixup (@kenji msg 1d7ba56c):
  * Compute the day-period bucket from a millisecond epoch timestamp,
- * not from `new Date()`. Visual-smoke fixtures freeze `Date.now()`
- * to a deterministic value (see `applyE2EFixture` in
+ * not from `new Date()`. E2e-fixture renders freeze `Date.now()`
+ * to a deterministic value (see `applyE2eFixture` in
  * `apps/desktop/src/renderer/main.tsx`) but do NOT freeze the
  * `Date` constructor itself; reading `new Date()` directly would
  * pick up the host clock and let the rendered fixture drift at the

--- a/packages/ui/src/chat-empty-hero.tsx
+++ b/packages/ui/src/chat-empty-hero.tsx
@@ -15,7 +15,7 @@
  * Why this seam: the empty-chat hero is the first thing every
  * user sees on a fresh session. Its day-period boundary
  * (5/11/14/18) is screenshot-baseline-pinned by a contract test
- * because visual-smoke fixtures freeze `Date.now()` but not the
+ * because e2e-fixture fixtures freeze `Date.now()` but not the
  * `Date` constructor — getting this wrong silently drifts the
  * baseline. The DeepResearch variant is also where the read-only
  * deep-research workflow rules live. Both deserve their own
@@ -34,13 +34,13 @@ export type { DayPeriod } from './conversation-copy.js';
  * PR-UI-LAYOUT-4 / B1-a1 review fixup (@kenji msg 1d7ba56c):
  * Compute the day-period bucket from a millisecond epoch timestamp,
  * not from `new Date()`. Visual-smoke fixtures freeze `Date.now()`
- * to a deterministic value (see `applyVisualSmokeFixture` in
+ * to a deterministic value (see `applyE2EFixture` in
  * `apps/desktop/src/renderer/main.tsx`) but do NOT freeze the
  * `Date` constructor itself; reading `new Date()` directly would
- * pick up the host clock and let screenshot baselines drift at the
+ * pick up the host clock and let the rendered fixture drift at the
  * 11:00 / 14:00 / 18:00 boundaries.
  *
- * Default arg is `Date.now()`, which the visual-smoke renderer
+ * Default arg is `Date.now()`, which the e2e-fixture renderer
  * replaces with `state.now`. Tests pass an explicit timestamp.
  * Exported so the day-period boundary contract is reachable from
  * `apps/desktop/src/main/__tests__/empty-hero-day-period.test.ts`.

--- a/packages/ui/src/chat-turn.tsx
+++ b/packages/ui/src/chat-turn.tsx
@@ -962,15 +962,15 @@ function DeepThinkingBody(props: { text: string; streamFade?: StreamFade }) {
 }
 
 /**
- * PR-UI-RENDER-1 — reduced-motion / visual-smoke probe for the
+ * PR-UI-RENDER-1 — reduced-motion / e2e-fixture probe for the
  * streaming smoother.
  *
  * Three triggers force the smoother to snap (mirroring the rule in
  * `apps/desktop/src/renderer/scroll-motion-policy.ts`):
  *
  *   1. `data-maka-reduced-motion="true"` — set by the PR-IR-04
- *      reduced variant of the visual-smoke fixture.
- *   2. `data-maka-visual-smoke="true"` — set by ANY visual-smoke
+ *      reduced variant of the e2e-fixture fixture.
+ *   2. `data-maka-e2e-fixture="true"` — set by ANY e2e-fixture
  *      capture so screenshots see the final text on the first paint.
  *   3. OS-level `prefers-reduced-motion: reduce`.
  *
@@ -1000,7 +1000,7 @@ function readStreamSnap(): boolean {
   if (typeof document === 'undefined' || typeof window === 'undefined') return true;
   const root = document.documentElement;
   if (root.dataset.makaReducedMotion === 'true') return true;
-  if (root.dataset.makaVisualSmoke === 'true') return true;
+  if (root.dataset.makaE2eFixture === 'true') return true;
   if (typeof window.matchMedia === 'function') {
     return window.matchMedia('(prefers-reduced-motion: reduce)').matches;
   }

--- a/packages/ui/src/empty-state.tsx
+++ b/packages/ui/src/empty-state.tsx
@@ -31,7 +31,7 @@ interface EmptyStateProps {
   secondaryCta?: { label: string; onClick: () => void; disabled?: boolean };
   /** Optional extra class on the container (e.g. `maka-plan-empty`). */
   extraClassName?: string;
-  /** Optional `data-empty-view` passthrough for visual-smoke selectors. */
+  /** Optional `data-empty-view` passthrough for e2e-fixture selectors. */
   dataEmptyView?: string;
 }
 

--- a/packages/ui/src/locale-context.tsx
+++ b/packages/ui/src/locale-context.tsx
@@ -18,9 +18,9 @@ export function syncUiLocaleDocument(
   root.setAttribute('lang', locale);
   root.setAttribute('data-maka-locale', locale);
   if (override) {
-    root.setAttribute('data-maka-visual-smoke-locale', override);
+    root.setAttribute('data-maka-e2e-fixture-locale', override);
   } else {
-    root.removeAttribute('data-maka-visual-smoke-locale');
+    root.removeAttribute('data-maka-e2e-fixture-locale');
   }
 }
 

--- a/packages/ui/src/locale-helpers.ts
+++ b/packages/ui/src/locale-helpers.ts
@@ -5,7 +5,7 @@
  * out of `components.tsx`. Locale types and
  * `getPromptSuggestions` were already public exports from
  * `@maka/ui` (consumed by the renderer's main.tsx, OnboardingHero,
- * theme.ts, visual-smoke fixture, and the
+ * theme.ts, e2e-fixture fixture, and the
  * text-file-import contract test); `PROMPT_SUGGESTIONS_BY_LOCALE`,
  * `PromptSuggestion`, and `PromptSuggestionLocale` were
  * panel-internal. byte-for-byte equivalent; behavior unchanged;

--- a/packages/ui/src/maka-uri.ts
+++ b/packages/ui/src/maka-uri.ts
@@ -195,7 +195,7 @@ export function isMakaUriCandidate(href: string): boolean {
  * `data:`, `file:`. Even though the Markdown pipeline may sanitize
  * some of these, the link chokepoint should not depend
  * on that. Explicit allowlist here makes the boundary visible
- * and inspectable in visual-smoke baselines.
+ * and inspectable in e2e-fixture baselines.
  *
  * Allowed: `http:` (HTTP via OS browser), `https:` (HTTPS via OS
  * browser), `mailto:` (default mail client). Everything else

--- a/packages/ui/src/module-panel-types.ts
+++ b/packages/ui/src/module-panel-types.ts
@@ -136,7 +136,7 @@ export type PlanReminderUpdatePatch = {
  * PR-DAILY-REVIEW-MVP-0: bridge handed in by `main.tsx`. Keeps
  * `@maka/ui` independent of desktop preload globals — the renderer wires a
  * host-injected daily-review reader, and the UI layer stays reusable in fixtures,
- * visual smoke tests, and future surfaces
+ * e2e-fixture tests, and future surfaces
  * (e.g. a desktop notification renderer).
  */
 export interface DailyReviewBridge {

--- a/packages/ui/src/primitives/chat.tsx
+++ b/packages/ui/src/primitives/chat.tsx
@@ -327,7 +327,7 @@ export function TextShimmer({
  *      it stays here and IS diff-proven.
  *   2. the native `<summary>` marker reset (`::-webkit-details-marker` /
  *      `::marker`) — pseudo-elements with no leaf-utility form. Kept as residue.
- * (The reduced-motion / visual-smoke suppression both ride GLOBAL `*` rules in
+ * (The reduced-motion / e2e-fixture suppression both ride GLOBAL `*` rules in
  * maka-tokens.css / base.css, so the dot and card need no per-element motion
  * utilities; the same global rules cover them as before.)
  *
@@ -424,7 +424,7 @@ export { toolVariants };
  *
  * Every value is a LITERAL arbitrary utility that compiles 1:1 to the
  * declaration it replaces, so the cva source string IS the computed-style proof
- * (the visual-smoke screenshot fixture renders the `file_diff` + `terminal` cards
+ * (the e2e-fixture screenshot fixture renders the `file_diff` + `terminal` cards
  * to keep those shells pixel-identical; the PR4 cascade contract pins the absence
  * of the retired selectors + the escape literals). Literals over the semantic
  * scale for the same reason as

--- a/packages/ui/src/primitives/chat.tsx
+++ b/packages/ui/src/primitives/chat.tsx
@@ -424,8 +424,8 @@ export { toolVariants };
  *
  * Every value is a LITERAL arbitrary utility that compiles 1:1 to the
  * declaration it replaces, so the cva source string IS the computed-style proof
- * (the e2e-fixture screenshot fixture renders the `file_diff` + `terminal` cards
- * to keep those shells pixel-identical; the PR4 cascade contract pins the absence
+ * (the e2e-fixture renders the `file_diff` + `terminal` cards; the PR4
+ * cascade contract pins the absence
  * of the retired selectors + the escape literals). Literals over the semantic
  * scale for the same reason as
  * `markerVariants` / `toolVariants`: the retired CSS hardcoded

--- a/packages/ui/src/smooth-stream.ts
+++ b/packages/ui/src/smooth-stream.ts
@@ -28,7 +28,7 @@
  *     `completeFlushBudgetMs` instead of snapping to the final text.
  *   - **Reduced-motion bypass**: callers pass `snap: true` (typically
  *     derived from `prefers-reduced-motion: reduce` or the
- *     visual-smoke fixture attribute) to skip all smoothing.
+ *     e2e-fixture fixture attribute) to skip all smoothing.
  *   - **Single RAF owner**: one `useEffect` schedules one RAF; its
  *     cleanup cancels any in-flight handle before the next effect
  *     re-runs. No way to have two RAFs writing state concurrently
@@ -69,7 +69,7 @@ export interface SmoothStreamOptions {
    * Force an immediate full-text display, bypassing all smoothing.
    * Callers should set this when:
    *   - `prefers-reduced-motion: reduce` matches,
-   *   - the visual-smoke fixture attribute is set,
+   *   - the e2e-fixture fixture attribute is set,
    *   - the content is being hydrated from history (the stream
    *     already finished — there is nothing to "smoothly" replay).
    */

--- a/packages/ui/src/stream-fade.ts
+++ b/packages/ui/src/stream-fade.ts
@@ -19,7 +19,7 @@
  * so we never split an emoji / surrogate pair. The negative `animation-delay`
  * (= -age) makes the CSS animation resume mid-flight, so React re-mounting the
  * spans on each streaming re-render continues the fade instead of restarting
- * it. Under snap (reduced-motion / visual-smoke / OS reduced-motion) the hook
+ * it. Under snap (reduced-motion / e2e-fixture / OS reduced-motion) the hook
  * returns `undefined` and callers skip wrapping entirely — the snap path shows
  * the final text at full opacity with no spans.
  */

--- a/packages/ui/src/tool-activity.tsx
+++ b/packages/ui/src/tool-activity.tsx
@@ -376,7 +376,7 @@ const TROW_KIND_ICON: Record<TrowActivityKind, ComponentType<LucideProps>> = {
 // `var(--duration-emphasized)` / `var(--ease-out-strong)` so it converges with
 // the motion tokens. Applied only when the group was seen running here and
 // just settled, so a replayed transcript's summary stays static. Auto-frozen
-// under reduced-motion / visual-smoke by the global rules in styles/base.css.
+// under reduced-motion / e2e-fixture by the global rules in styles/base.css.
 // The per-row seam is a light-band stop (no opacity fade) so parallel tools
 // finishing together don't stack N fades (#tool-jitter).
 const SETTLE_FADE = '[animation:maka-stream-fade-in_var(--duration-emphasized)_var(--ease-out-strong)_both]';

--- a/packages/ui/stories/capability-audit-strip.stories.tsx
+++ b/packages/ui/stories/capability-audit-strip.stories.tsx
@@ -44,7 +44,7 @@ function report(input: Partial<CapabilityAuditReport['summary']>): CapabilityAud
 function StripFrame(props: { children: React.ReactNode }) {
   return (
     <div
-      data-maka-visual-smoke="true"
+      data-maka-e2e-fixture="true"
       style={{
         background: 'var(--surface-canvas)',
         padding: 24,

--- a/packages/ui/stories/daily-review-panel.stories.tsx
+++ b/packages/ui/stories/daily-review-panel.stories.tsx
@@ -60,7 +60,7 @@ function createBridge(input: { fail?: boolean; loading?: boolean }): DailyReview
 function ModuleFrame(props: { children: React.ReactNode }) {
   return (
     <div
-      data-maka-visual-smoke="true"
+      data-maka-e2e-fixture="true"
       style={{
         background: 'var(--surface-canvas)',
         height: '100%',

--- a/packages/ui/stories/markdown.stories.tsx
+++ b/packages/ui/stories/markdown.stories.tsx
@@ -16,7 +16,7 @@ type Story = StoryObj<typeof meta>;
 function ProseFrame(props: { children: React.ReactNode; width?: number }) {
   return (
     <div
-      data-maka-visual-smoke="true"
+      data-maka-e2e-fixture="true"
       style={{
         background: 'var(--surface-canvas)',
         padding: 24,
@@ -192,8 +192,8 @@ export const WideTable: Story = {
             '',
             '| 会话 ID | 连接 | 模型 | 状态 | 最近一条消息时间 | 输入 tokens | 输出 tokens | 费用（USD） |',
             '| --- | --- | --- | --- | --- | --- | --- | --- |',
-            '| visual-smoke-turn-control-primary | zai-live | glm-5.1 | waiting_for_user | 2026-07-07 18:42:11 | 125,032 | 32,480 | 0.4210 |',
-            '| visual-smoke-turn-control-branch-visible | zai-live | glm-5 | running | 2026-07-07 18:40:02 | 98,771 | 21,006 | 0.2988 |',
+            '| e2e-fixture-turn-control-primary | zai-live | glm-5.1 | waiting_for_user | 2026-07-07 18:42:11 | 125,032 | 32,480 | 0.4210 |',
+            '| e2e-fixture-turn-control-branch-visible | zai-live | glm-5 | running | 2026-07-07 18:40:02 | 98,771 | 21,006 | 0.2988 |',
             '',
             '表格后的正文保持正常段落间距。',
           ].join('\n')}

--- a/packages/ui/stories/permission-dialog.stories.tsx
+++ b/packages/ui/stories/permission-dialog.stories.tsx
@@ -50,7 +50,7 @@ function makeRequest(input: {
 function ComposerSlotBackdrop(props: { children: React.ReactNode }) {
   return (
     <div
-      data-maka-visual-smoke="true"
+      data-maka-e2e-fixture="true"
       style={{
         background: 'var(--surface-canvas)',
         height: '100%',

--- a/packages/ui/stories/plan-reminder-panel.stories.tsx
+++ b/packages/ui/stories/plan-reminder-panel.stories.tsx
@@ -80,7 +80,7 @@ const reminders: PlanReminder[] = [
 function ModuleFrame(props: { children: React.ReactNode }) {
   return (
     <div
-      data-maka-visual-smoke="true"
+      data-maka-e2e-fixture="true"
       style={{
         background: 'var(--surface-canvas)',
         height: '100%',

--- a/packages/ui/stories/session-list-panel.stories.tsx
+++ b/packages/ui/stories/session-list-panel.stories.tsx
@@ -115,7 +115,7 @@ function StoryFrame(props: {
   return (
     <div
       ref={ref}
-      data-maka-visual-smoke="true"
+      data-maka-e2e-fixture="true"
       style={{
         background: 'var(--surface-canvas)',
         height,

--- a/packages/ui/stories/skills-panel.stories.tsx
+++ b/packages/ui/stories/skills-panel.stories.tsx
@@ -48,7 +48,7 @@ const skills: SkillEntry[] = [
 function ModuleFrame(props: { children: React.ReactNode }) {
   return (
     <div
-      data-maka-visual-smoke="true"
+      data-maka-e2e-fixture="true"
       style={{
         background: 'var(--surface-canvas)',
         height: '100%',

--- a/scripts/audit-alignment.mjs
+++ b/scripts/audit-alignment.mjs
@@ -1,6 +1,6 @@
 // Systematic row-alignment auditor (design governance tool).
 //
-// For every visual-smoke fixture, finds horizontal clusters of interactive
+// For every e2e-fixture fixture, finds horizontal clusters of interactive
 // controls and reports:
 //   - height mismatch  (same control type sharing a row)
 //   - centerline drift (mixed control types sharing a row)
@@ -181,8 +181,8 @@ for (const fx of FIXTURES) {
     cwd: DESKTOP_DIR,
     env: {
       ...process.env,
-      MAKA_VISUAL_SMOKE_FIXTURE: fx,
-      MAKA_VISUAL_SMOKE_THEME: 'light',
+      MAKA_E2E_FIXTURE: fx,
+      MAKA_E2E_FIXTURE_THEME: 'light',
     },
     stdio: ['ignore', 'pipe', 'pipe'],
   });

--- a/scripts/check-console.mjs
+++ b/scripts/check-console.mjs
@@ -37,7 +37,7 @@ const ALLOW = new Map([
   ['apps/desktop/src/main/main.ts', 'dev-gated by VITE_DEV_SERVER_URL / NODE_ENV (PR100).'],
   [
     'apps/desktop/src/main/app-lifecycle.ts',
-    'startup/shutdown diagnostics (dock icon, credential migration, visual-smoke marker, cleanup failures); no secrets (moved from main.ts, arch R6).',
+    'startup/shutdown diagnostics (dock icon, credential migration, e2e-fixture marker, cleanup failures); no secrets (moved from main.ts, arch R6).',
   ],
   [
     'apps/desktop/src/main/settings-runtime-effects.ts',
@@ -45,7 +45,7 @@ const ALLOW = new Map([
   ],
   [
     'apps/desktop/src/main/app-ipc-main.ts',
-    'visual-smoke capture marker is fixture-gated and stdout-parsed by capture tooling (moved from main.ts, #1084).',
+    'e2e-fixture capture marker is fixture-gated and stdout-parsed by capture tooling (moved from main.ts, #1084).',
   ],
   [
     'apps/desktop/src/main/daily-review-main.ts',

--- a/scripts/check-console.mjs
+++ b/scripts/check-console.mjs
@@ -44,10 +44,6 @@ const ALLOW = new Map([
     'external-settings apply failure is a main-process diagnostic, no secrets (moved from main.ts, arch R5).',
   ],
   [
-    'apps/desktop/src/main/app-ipc-main.ts',
-    'e2e-fixture capture marker is fixture-gated and stdout-parsed by capture tooling (moved from main.ts, #1084).',
-  ],
-  [
     'apps/desktop/src/main/daily-review-main.ts',
     'scheduler failures are main-process diagnostics and do not expose secrets.',
   ],

--- a/scripts/desktop-real-window-smoke.mjs
+++ b/scripts/desktop-real-window-smoke.mjs
@@ -185,7 +185,7 @@ function isStaleMakaElectronProcess(entry) {
   if (!command.includes('Electron.app/Contents/MacOS/Electron')) return false;
   if (!command.includes('--user-data-dir=')) return false;
   return (
-    /--user-data-dir=(?:\/private)?\/tmp\/maka-(?:visual-smoke|real-window-smoke|p0fix|uxp|v\d|copy|long|modal|narr|test-cap-debug)/.test(
+    /--user-data-dir=(?:\/private)?\/tmp\/maka-(?:e2e-fixture|real-window-smoke|p0fix|uxp|v\d|copy|long|modal|narr|test-cap-debug)/.test(
       command,
     ) || /--user-data-dir=(?:\/private)?\/var\/folders\/.+\/maka-real-window-smoke-/.test(command)
   );
@@ -256,9 +256,9 @@ async function launchElectron(args, diagnostics) {
   const userDataDir = join(os.tmpdir(), `maka-real-window-smoke-${args.scenario}-${process.pid}`);
   const env = {
     ...process.env,
-    MAKA_VISUAL_SMOKE_FIXTURE: args.scenario,
-    MAKA_VISUAL_SMOKE_WIDTH: String(args.width),
-    MAKA_VISUAL_SMOKE_HEIGHT: String(args.height),
+    MAKA_E2E_FIXTURE: args.scenario,
+    MAKA_E2E_FIXTURE_WIDTH: String(args.width),
+    MAKA_E2E_FIXTURE_HEIGHT: String(args.height),
     MAKA_REAL_WINDOW_SMOKE: '1',
   };
   const launchArgs = ['.', `--user-data-dir=${userDataDir}`];

--- a/scripts/desktop-real-window-smoke.mjs
+++ b/scripts/desktop-real-window-smoke.mjs
@@ -2,7 +2,7 @@
 /**
  * PR-DESKTOP-SMOKE-0: real Electron window smoke runner.
  *
- * This is intentionally a human-in-the-loop gate. Visual smoke screenshots
+ * This is intentionally a human-in-the-loop gate. Automated fixtures
  * cannot verify native macOS resize hit areas, titlebar drag, or keyboard
  * traversal through a live Electron window. This script launches a clean,
  * isolated Maka window and records the reviewer-confirmed result as JSON +


### PR DESCRIPTION
## Summary

Closes prerequisite checkbox 2 of #1303. PR #1308 removed the Electron screenshot capture/baseline/diff layer; this PR brings the surviving fixture mechanism's text in line with that reality. Two textual changes, no behavior change beyond restoring CSS hooks the renderer already expected:

1. **Rename** the `visual-smoke` identifier family to `e2e-fixture` across files, directories, TypeScript identifiers, IPC channels, env vars, DOM data attributes, CSS selectors, and docs. Casing follows existing repo convention (`E2E_USER_DATA_DIR`, `E2E_SCENARIOS`, `createCuE2eFixture`): `E2E` stays uppercase, the env family uses `MAKA_E2E_FIXTURE_*` to stay distinct from generic `E2E_*` runtime vars, and DOM dataset access is `makaE2eFixture` per the HTML spec kebab-to-camel conversion.
2. **Refresh** the stale "screenshot pipeline / auto-capture / baseline" rationale comments in the fixture code so they describe the fixture's actual current role: Playwright E2E seeding, the CI `audit-alignment.mjs` audit, and interactive fixture use. Historical PR markers (`PR-IR-01b`, `PR108j`, etc.) are preserved.

Out of scope (tracked separately): #1311, #1312, #1304.

## Verification

All green locally:

- `npm run build` (full workspace) — passes
- `npm run format:check` + `npm run lint` (Biome) — clean
- `npm --workspace @maka/desktop run test:dist` — 2761/2761 pass (includes a new contract test asserting the e2e-fixture CSS selectors exist)
- `node scripts/run-workspace-tests-parallel.mjs` — 1169/1169 pass
- `node scripts/audit-alignment.mjs` — all fixtures clean
- Fixture-driven Playwright E2E (`scroll-geometry`, `settings`, `permission-takeover`, `locale-renderer`, `bot-onboarding`) — 15/15 pass
- `npm run build-storybook` — passes

## Codex review follow-up

A pre-merge codex review (high effort) flagged the first pass as incomplete. The second commit addresses every accepted finding:

- **P2 → fixed:** the rename grep had missed `.css`, so the `data-maka-visual-smoke` selectors in `base.css` / `sidebar.css` were not renamed while the renderer wrote `data-maka-e2e-fixture`. Deterministic-render hooks (decorative animation pause, running-status spinner stop) silently stopped matching. Renamed the selectors and added a contract test that asserts they exist (the `!important` audit skips `base.css` wholesale via `isA11yOnlyFile`, which is why the gap was not caught).
- **P3 → fixed:** leftover `smoke` local variables (the `e2eFixture.getState()` return values) renamed to `fixtureState`, with the two source-grep contract tests that asserted the old name updated. Remaining `Visual-smoke` comments and fixture-context "captures / screenshot / baseline" wording swept. Unrelated smoke terms (voice device smoke test, real-window smoke, prompt smoke) left intact.
- **Deferred (PR1 scope):** the `app-ipc-main.ts` entry in `check-console.mjs`'s allowlist references the removed capture tooling. The file no longer has any `console.*`, so the entry is dead, but allowlist cleanup belongs to the #1308 capture-layer removal rather than this rename, and another entry (`main-window.ts`) still covers real real-window smoke diagnostics. Tracked for a PR1 follow-up.
