### PR TITLE
feat(core): add qwen3.8-max-preview to Alibaba Token Plan

### DIFF
--- a/packages/core/src/__tests__/llm-connections.test.ts
+++ b/packages/core/src/__tests__/llm-connections.test.ts
@@ -964,6 +964,7 @@ describe('provider compatibility contract', () => {
   });
 
   const alibabaTokenPlanModels = [
+    'qwen3.8-max-preview',
     'qwen3.7-max',
     'qwen3.7-plus',
     'qwen3.6-plus',

--- a/packages/core/src/__tests__/model-catalog.test.ts
+++ b/packages/core/src/__tests__/model-catalog.test.ts
@@ -109,6 +109,7 @@ describe('ModelCatalogEntry', () => {
     assert.deepEqual(
       entries.map((entry) => entry.id),
       [
+        'qwen3.8-max-preview',
         'qwen3.7-max',
         'qwen3.7-plus',
         'qwen3.6-plus',
@@ -137,12 +138,13 @@ describe('ModelCatalogEntry', () => {
         `${imageModel} must not be catalogued`,
       );
     }
-    assert.equal(entries[0]?.displayName, 'Qwen3.7 Max');
+    assert.equal(entries[0]?.displayName, 'Qwen3.8 Max Preview');
     assert.equal(entries[0]?.source, 'static_catalog');
     assert.equal(entries[0]?.provenance.modelSource, 'fallback');
     assert.equal(entries[0]?.contextWindow, 1_000_000);
-    assert.equal(entries[0]?.maxOutputTokens, 65_536);
+    assert.equal(entries[0]?.maxOutputTokens, 131_072);
     assert.deepEqual(entries[0]?.capabilities, {
+      vision: true,
       reasoning: true,
       functionCalling: true,
     });

--- a/packages/core/src/model-metadata.generated.ts
+++ b/packages/core/src/model-metadata.generated.ts
@@ -898,6 +898,14 @@ export const GENERATED_MODELS_DEV_METADATA: Record<
       maxOutputTokens: 64000,
       capabilities: { vision: true, reasoning: true, functionCalling: true },
     },
+    'qwen3.8-max-preview': {
+      displayName: 'Qwen3.8 Max Preview',
+      lifecycle: 'active',
+      docsUrl: 'https://www.alibabacloud.com/help/zh/model-studio/token-plan-overview',
+      contextWindow: 1000000,
+      maxOutputTokens: 131072,
+      capabilities: { vision: true, reasoning: true, functionCalling: true },
+    },
     'wan2.7-image': {
       displayName: 'Wan2.7 Image',
       lifecycle: 'active',
@@ -1042,6 +1050,14 @@ export const GENERATED_MODELS_DEV_METADATA: Record<
       docsUrl: 'https://www.alibabacloud.com/help/en/model-studio/token-plan-overview',
       contextWindow: 1000000,
       maxOutputTokens: 64000,
+      capabilities: { vision: true, reasoning: true, functionCalling: true },
+    },
+    'qwen3.8-max-preview': {
+      displayName: 'Qwen3.8 Max Preview',
+      lifecycle: 'active',
+      docsUrl: 'https://www.alibabacloud.com/help/en/model-studio/token-plan-overview',
+      contextWindow: 1000000,
+      maxOutputTokens: 131072,
       capabilities: { vision: true, reasoning: true, functionCalling: true },
     },
     'wan2.7-image': {

--- a/packages/core/src/provider-registry.ts
+++ b/packages/core/src/provider-registry.ts
@@ -452,6 +452,7 @@ if (!alibabaTokenPlanGlobal.api) {
 // the plan's image models (qwen-image / wan) are not tool-callable, so only the
 // tool-calling text models are pinned here. China and global share one model list.
 const alibabaTokenPlanModelIds = [
+  'qwen3.8-max-preview',
   'qwen3.7-max',
   'qwen3.7-plus',
   'qwen3.6-plus',


### PR DESCRIPTION
## What

Add the new **Qwen3.8 Max Preview** flagship (released 2026-07-19 on models.dev) to the Alibaba Token Plan catalog, for both the China (`cn-beijing`) and global (`Singapore`) access paths. Configuration mirrors the existing `qwen3.7`/`qwen3.6` entries.

## Changes

- `packages/core/src/provider-registry.ts` — register `qwen3.8-max-preview` at the top of `alibabaTokenPlanModelIds` (newest flagship first), which feeds `fallbackModels` for both regions.
- `packages/core/src/model-metadata.generated.ts` — add generated metadata entries for `alibaba-token-plan-cn` (`/zh` docs) and `alibaba-token-plan` (`/en` docs): 1M context, 131072 max output, vision + reasoning + function calling. Source: `https://models.dev/api.json`.
- Tests — update the `model-catalog` and `llm-connections` fixtures that pin the exact token-plan model list, including the `entries[0]` assertions (now `qwen3.8-max-preview`).

The existing provider-registry validation already enforces that every allowlisted id has `functionCalling` in the generated snapshot, so the new entry is covered by that guard.

## Verification

- `npm install` ✔
- `npm --workspace @maka/core run build` ✔
- `npm --workspace @maka/core run test:dist` ✔ (1132 tests)
- `node --test scripts/sync-model-metadata.test.mjs` ✔ (30 tests)

## Notes

- Hand-edited `model-metadata.generated.ts` surgically rather than running `scripts/sync-model-metadata.mjs`, because a full regeneration drifts ~587 lines across unrelated providers (ollama-cloud renames, moonshot additions, lifecycle flips). The added entry exactly matches what the sync script emits for this model.
