### PR TITLE
fix(desktop): resolve login-shell PATH at Electron startup

### DIFF
--- a/apps/desktop/e2e/fixtures.ts
+++ b/apps/desktop/e2e/fixtures.ts
@@ -114,12 +114,10 @@ function buildE2eEnv(
     }
   }
   env.MAKA_E2E = '1';
-  // The login-shell env probe (resolveShellEnv) must never mutate this
-  // sanitized env: it would re-import *_API_KEY from the dev's shell and
-  // bootstrap a real connection, breaking the true first-run assertion. This
-  // is the owning-layer fix — buildE2eEnv owns the launched env, so it owns
-  // the skip flag. Deterministic and CI-safe (unlike relying on TERM, which
-  // is unset under xvfb).
+  // The login-shell PATH probe must not make E2E command resolution depend on
+  // the developer or CI account. buildE2eEnv owns the launched environment,
+  // so it owns the deterministic skip flag (unlike relying on TERM, which is
+  // unset under xvfb).
   env.MAKA_SKIP_SHELL_ENV = '1';
   env.MAKA_E2E_USER_DATA_DIR = userDataDir;
   if (e2eFixtureScenario) env.MAKA_E2E_FIXTURE = e2eFixtureScenario;

--- a/apps/desktop/e2e/fixtures.ts
+++ b/apps/desktop/e2e/fixtures.ts
@@ -114,6 +114,13 @@ function buildE2eEnv(
     }
   }
   env.MAKA_E2E = '1';
+  // The login-shell env probe (resolveShellEnv) must never mutate this
+  // sanitized env: it would re-import *_API_KEY from the dev's shell and
+  // bootstrap a real connection, breaking the true first-run assertion. This
+  // is the owning-layer fix — buildE2eEnv owns the launched env, so it owns
+  // the skip flag. Deterministic and CI-safe (unlike relying on TERM, which
+  // is unset under xvfb).
+  env.MAKA_SKIP_SHELL_ENV = '1';
   env.MAKA_E2E_USER_DATA_DIR = userDataDir;
   if (e2eFixtureScenario) env.MAKA_E2E_FIXTURE = e2eFixtureScenario;
   if (locale) env.MAKA_E2E_FIXTURE_LOCALE = locale;

--- a/apps/desktop/src/main/__tests__/shell-env.test.ts
+++ b/apps/desktop/src/main/__tests__/shell-env.test.ts
@@ -1,0 +1,222 @@
+/**
+ * PR #1316 review coverage: lock the per-shell capture-command quoting, the
+ * marker-adjacency contract (which is why the dead xonsh branch was dropped),
+ * and the mergeEnv preservation / stripping rules. Pure-function unit tests
+ * — same `node:test` + `node:assert/strict` layout as `build-info.test.ts`.
+ */
+
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'node:test';
+
+import { buildCaptureCommand, buildMarkerRegex, mergeEnv } from '../shell-env.js';
+
+const MARK = '0123456789ab';
+
+describe('buildCaptureCommand', () => {
+  describe('POSIX family (bash / zsh / fish / sh)', () => {
+    it('zsh produces the -i -l -c argv and a flush-marker payload', () => {
+      const { command, shellArgs } = buildCaptureCommand('zsh', '/usr/bin/node', MARK);
+      assert.deepEqual(shellArgs, ['-i', '-l', '-c']);
+      assert.equal(
+        command,
+        `'/usr/bin/node' -p '"${MARK}" + JSON.stringify(process.env) + "${MARK}"'`,
+      );
+      // The payload concatenates mark + JSON + mark with no separator, so the
+      // emitted bytes are `<mark>{...}<mark>` — markers flush against the
+      // braces the capture regex anchors on.
+      const emitted = `${MARK}${JSON.stringify({ k: 'v' })}${MARK}`;
+      const match = buildMarkerRegex(MARK).exec(emitted);
+      assert.ok(match);
+      assert.equal(match[1], JSON.stringify({ k: 'v' }));
+    });
+
+    it('tcsh / csh collapse to the legacy single -ic argv', () => {
+      const tcsh = buildCaptureCommand('tcsh', '/usr/bin/node', MARK);
+      assert.deepEqual(tcsh.shellArgs, ['-ic']);
+      const csh = buildCaptureCommand('csh', '/usr/bin/node', MARK);
+      assert.deepEqual(csh.shellArgs, ['-ic']);
+      // Same flush-marker payload as the rest of the POSIX family.
+      assert.equal(
+        tcsh.command,
+        `'/usr/bin/node' -p '"${MARK}" + JSON.stringify(process.env) + "${MARK}"'`,
+      );
+    });
+
+    it('round-trips an apostrophe in execPath via the close-quote / escape / reopen sequence', () => {
+      // POSIX single-quoting cannot contain a literal `'`; the safe escape is
+      // to close the quote, emit a backslash-escaped quote, and reopen.
+      const { command, shellArgs } = buildCaptureCommand('bash', "/Users/Bob's/node", MARK);
+      assert.deepEqual(shellArgs, ['-i', '-l', '-c']);
+      assert.equal(
+        command,
+        `'/Users/Bob'\\''s/node' -p '"${MARK}" + JSON.stringify(process.env) + "${MARK}"'`,
+      );
+    });
+  });
+
+  describe('PowerShell', () => {
+    it('uses -Login -Command and doubles an embedded apostrophe', () => {
+      const { command, shellArgs } = buildCaptureCommand('pwsh', "/Users/Bob's/node", MARK);
+      assert.deepEqual(shellArgs, ['-Login', '-Command']);
+      // PowerShell single-quoted strings escape `'` as `''`.
+      assert.equal(
+        command,
+        `& '/Users/Bob''s/node' -p '''${MARK}'' + JSON.stringify(process.env) + ''${MARK}'''`,
+      );
+    });
+
+    it('matches powershell-preview too and leaves an apostrophe-free path untouched', () => {
+      const { command, shellArgs } = buildCaptureCommand('powershell-preview', '/usr/bin/node', MARK);
+      assert.deepEqual(shellArgs, ['-Login', '-Command']);
+      assert.equal(
+        command,
+        `& '/usr/bin/node' -p '''${MARK}'' + JSON.stringify(process.env) + ''${MARK}'''`,
+      );
+    });
+  });
+
+  describe('nu', () => {
+    it('uses a raw string and -i -l -c (embedded quotes are a documented edge case)', () => {
+      const { command, shellArgs } = buildCaptureCommand('nu', '/usr/bin/node', MARK);
+      assert.deepEqual(shellArgs, ['-i', '-l', '-c']);
+      assert.equal(
+        command,
+        `^'/usr/bin/node' -p '"${MARK}" + JSON.stringify(process.env) + "${MARK}"'`,
+      );
+    });
+  });
+
+  it('xonsh falls into the POSIX branch (the dedicated branch is gone)', () => {
+    // xonsh is intentionally unsupported. It must NOT get a special argv and
+    // must share the POSIX payload — proving the dead branch was removed.
+    const { command, shellArgs } = buildCaptureCommand('xonsh', '/usr/bin/node', MARK);
+    assert.deepEqual(shellArgs, ['-i', '-l', '-c']);
+    assert.equal(
+      command,
+      `'/usr/bin/node' -p '"${MARK}" + JSON.stringify(process.env) + "${MARK}"'`,
+    );
+  });
+});
+
+describe('buildMarkerRegex', () => {
+  it('matches <mark>{...}<mark> and captures the JSON body', () => {
+    const regex = buildMarkerRegex(MARK);
+    const match = regex.exec(`${MARK}${JSON.stringify({ k: 'v' })}${MARK}`);
+    assert.ok(match);
+    assert.equal(match[1], JSON.stringify({ k: 'v' }));
+  });
+
+  it('captures the body across newlines (dotall via [\\s\\S])', () => {
+    // Shell init noise / pretty-printed env can land newlines inside the JSON
+    // object; the regex must span them.
+    const body = JSON.stringify({ k: 'v\nmulti', nested: { a: 1 } });
+    const match = buildMarkerRegex(MARK).exec(`${MARK}${body}${MARK}`);
+    assert.ok(match);
+    assert.equal(match[1], body);
+  });
+
+  it('does NOT match the old xonsh shape `mark {...} mark` (space-separated)', () => {
+    // The dropped xonsh branch ran Python `print(mark, json, mark)`, whose
+    // default sep joins args with a SPACE — producing `mark {...} mark`. That
+    // shape never satisfied the flush-marker regex, which is exactly why the
+    // branch was dead. This test is the guard that would have caught review
+    // item #3 before it shipped.
+    const xonshShape = `${MARK} {"k":"v"} ${MARK}`;
+    assert.equal(buildMarkerRegex(MARK).exec(xonshShape), null);
+  });
+});
+
+describe('mergeEnv', () => {
+  // mergeEnv mutates the global `process.env`; snapshot every key before each
+  // test and restore exactly afterward so the suite stays hermetic.
+  function snapshotEnv(): () => void {
+    const before = new Map<string, string>();
+    for (const [key, value] of Object.entries(process.env)) before.set(key, value as string);
+    return () => {
+      for (const key of Object.keys(process.env)) {
+        if (!before.has(key)) delete process.env[key];
+      }
+      for (const [key, value] of before) process.env[key] = value;
+    };
+  }
+
+  it('applies the resolved PATH (resolved wins for user-configured vars)', () => {
+    const restore = snapshotEnv();
+    try {
+      delete process.env.PATH;
+      mergeEnv({ PATH: '/resolved/bin:/usr/bin' });
+      assert.equal(process.env.PATH, '/resolved/bin:/usr/bin');
+    } finally {
+      restore();
+    }
+  });
+
+  it('strips XDG_RUNTIME_DIR so the login-shell runtime dir never overwrites the original', () => {
+    // microsoft/vscode#22593: the shell's runtime dir must not persist into
+    // GUI-process children. The resolved value is dropped before the apply
+    // loop, so a pre-existing original is left untouched.
+    const restore = snapshotEnv();
+    try {
+      process.env.XDG_RUNTIME_DIR = '/original/runtime';
+      mergeEnv({ XDG_RUNTIME_DIR: '/shell/runtime', PATH: '/bin' });
+      assert.equal(process.env.XDG_RUNTIME_DIR, '/original/runtime');
+    } finally {
+      restore();
+    }
+  });
+
+  it('also drops XDG_RUNTIME_DIR when the original env lacked one', () => {
+    const restore = snapshotEnv();
+    try {
+      delete process.env.XDG_RUNTIME_DIR;
+      mergeEnv({ XDG_RUNTIME_DIR: '/shell/runtime', PATH: '/bin' });
+      assert.equal(process.env.XDG_RUNTIME_DIR, undefined);
+    } finally {
+      restore();
+    }
+  });
+
+  it('preserves a pre-existing MAKA_* value the resolved env tried to overwrite', () => {
+    // The prefix-rule refactor must restore ANY MAKA_* key, even ones not on
+    // a hand-maintained list — this is what survives future MAKA_* renames.
+    const restore = snapshotEnv();
+    try {
+      process.env.MAKA_FUTURE_FLAG = 'original';
+      mergeEnv({ MAKA_FUTURE_FLAG: 'from-shell', PATH: '/bin' });
+      assert.equal(process.env.MAKA_FUTURE_FLAG, 'original');
+    } finally {
+      restore();
+    }
+  });
+
+  it('deletes a preserved key that was absent from the original env', () => {
+    const restore = snapshotEnv();
+    try {
+      delete process.env.ELECTRON_RUN_AS_NODE;
+      mergeEnv({ PATH: '/bin' });
+      assert.equal(process.env.ELECTRON_RUN_AS_NODE, undefined);
+    } finally {
+      restore();
+    }
+  });
+
+  it('preserves the Electron-specific trio even when the resolved env carries it', () => {
+    const restore = snapshotEnv();
+    try {
+      process.env.ELECTRON_RUN_AS_NODE = '1';
+      process.env.ELECTRON_NO_ATTACH_CONSOLE = '1';
+      process.env.ORIGINAL_XDG_CURRENT_DESKTOP = 'GNOME';
+      mergeEnv({
+        ELECTRON_RUN_AS_NODE: 'from-shell',
+        ELECTRON_NO_ATTACH_CONSOLE: 'from-shell',
+        ORIGINAL_XDG_CURRENT_DESKTOP: 'from-shell',
+        PATH: '/bin',
+      });
+      assert.equal(process.env.ELECTRON_RUN_AS_NODE, '1');
+      assert.equal(process.env.ELECTRON_NO_ATTACH_CONSOLE, '1');
+      assert.equal(process.env.ORIGINAL_XDG_CURRENT_DESKTOP, 'GNOME');
+    } finally {
+      restore();
+    }
+  });
+});

--- a/apps/desktop/src/main/__tests__/shell-env.test.ts
+++ b/apps/desktop/src/main/__tests__/shell-env.test.ts
@@ -1,21 +1,212 @@
 /**
  * PR #1316 review coverage: lock the per-shell capture-command quoting, the
  * marker-adjacency contract (which is why the dead xonsh branch was dropped),
- * and the mergeEnv preservation / stripping rules. Pure-function unit tests
- * — same `node:test` + `node:assert/strict` layout as `build-info.test.ts`.
+ * and the public capture path. Same `node:test` + `node:assert/strict` layout
+ * as `build-info.test.ts`.
  */
 
 import { strict as assert } from 'node:assert';
+import { access, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { describe, it } from 'node:test';
+import { setTimeout as delay } from 'node:timers/promises';
 
 import {
   buildCaptureCommand,
   buildMarkerRegex,
-  mergeEnv,
-  sanitizeCapturedEnv,
+  resolveShellEnv,
+  selectLoginShell,
 } from '../shell-env.js';
 
 const MARK = '0123456789ab';
+
+function snapshotEnv(): () => void {
+  const before = new Map<string, string>();
+  for (const [key, value] of Object.entries(process.env)) {
+    before.set(key, value as string);
+  }
+  return () => {
+    for (const key of Object.keys(process.env)) {
+      if (!before.has(key)) delete process.env[key];
+    }
+    for (const [key, value] of before) process.env[key] = value;
+  };
+}
+
+async function createFakeShell(body: string): Promise<{
+  path: string;
+  cleanup: () => Promise<void>;
+}> {
+  const directory = await mkdtemp(join(tmpdir(), 'maka-shell-env-'));
+  const path = join(directory, 'fake-shell');
+  await writeFile(path, `#!/bin/sh\n${body}\n`, { mode: 0o700 });
+  return {
+    path,
+    cleanup: () => rm(directory, { recursive: true, force: true }),
+  };
+}
+
+describe('resolveShellEnv', () => {
+  it(
+    'imports the login PATH without importing application control variables',
+    { skip: process.platform === 'win32' },
+    async () => {
+      const restoreEnv = snapshotEnv();
+      const shell = await createFakeShell(`
+export PATH='/resolved/bin:/usr/bin'
+export MAKA_E2E_FIXTURE='first-run'
+export VITE_DEV_SERVER_URL='https://example.invalid/renderer'
+export XDG_RUNTIME_DIR='/shell/runtime'
+exec /bin/sh -c "$4"
+`);
+      try {
+        process.env.SHELL = shell.path;
+        process.env.PATH = '/usr/bin:/bin:/usr/sbin:/sbin';
+        process.env.XDG_RUNTIME_DIR = '/original/runtime';
+        delete process.env.TERM;
+        delete process.env.COLORTERM;
+        delete process.env.MAKA_SKIP_SHELL_ENV;
+        delete process.env.MAKA_E2E_FIXTURE;
+        delete process.env.VITE_DEV_SERVER_URL;
+        delete process.env.ELECTRON_RUN_AS_NODE;
+        delete process.env.ELECTRON_NO_ATTACH_CONSOLE;
+
+        await resolveShellEnv();
+
+        assert.equal(process.env.PATH, '/resolved/bin:/usr/bin');
+        assert.equal(process.env.MAKA_E2E_FIXTURE, undefined);
+        assert.equal(process.env.VITE_DEV_SERVER_URL, undefined);
+        assert.equal(process.env.XDG_RUNTIME_DIR, '/original/runtime');
+        assert.equal(process.env.ELECTRON_RUN_AS_NODE, undefined);
+        assert.equal(process.env.ELECTRON_NO_ATTACH_CONSOLE, undefined);
+      } finally {
+        restoreEnv();
+        await shell.cleanup();
+      }
+    },
+  );
+
+  it(
+    'keeps the inherited PATH and does not log shell stderr when capture fails',
+    { skip: process.platform === 'win32' },
+    async () => {
+      const restoreEnv = snapshotEnv();
+      const shell = await createFakeShell(`
+printf 'secret-from-shell-startup' >&2
+exit 23
+`);
+      const warnings: string[] = [];
+      const originalWarn = console.warn;
+      console.warn = (...args: unknown[]) => warnings.push(args.map(String).join(' '));
+      try {
+        process.env.SHELL = shell.path;
+        process.env.PATH = '/usr/bin:/bin:/usr/sbin:/sbin';
+        delete process.env.TERM;
+        delete process.env.COLORTERM;
+        delete process.env.MAKA_SKIP_SHELL_ENV;
+
+        await resolveShellEnv();
+
+        assert.equal(process.env.PATH, '/usr/bin:/bin:/usr/sbin:/sbin');
+        assert.match(warnings.join('\n'), /exited with code 23/);
+        assert.doesNotMatch(warnings.join('\n'), /secret-from-shell-startup/);
+      } finally {
+        console.warn = originalWarn;
+        restoreEnv();
+        await shell.cleanup();
+      }
+    },
+  );
+
+  it(
+    'kills login-shell descendants when capture times out',
+    { skip: process.platform === 'win32' },
+    async () => {
+      const restoreEnv = snapshotEnv();
+      const shell = await createFakeShell(`
+(
+  trap '' HUP TERM
+  printf 'started' > "$SHELL_ENV_TEST_STARTED_FILE"
+  sleep 1.5
+  printf 'survived' > "$SHELL_ENV_TEST_SURVIVOR_FILE"
+) </dev/null >/dev/null 2>&1 &
+wait
+`);
+      const startedFile = `${shell.path}.started`;
+      const survivorFile = `${shell.path}.survived`;
+      const originalWarn = console.warn;
+      console.warn = () => {};
+      try {
+        process.env.SHELL = shell.path;
+        process.env.SHELL_ENV_TEST_STARTED_FILE = startedFile;
+        process.env.SHELL_ENV_TEST_SURVIVOR_FILE = survivorFile;
+        process.env.PATH = '/usr/bin:/bin:/usr/sbin:/sbin';
+        delete process.env.TERM;
+        delete process.env.COLORTERM;
+        delete process.env.MAKA_SKIP_SHELL_ENV;
+
+        await resolveShellEnv(1_000);
+        await access(startedFile);
+        await delay(700);
+
+        await assert.rejects(access(survivorFile));
+        assert.equal(process.env.PATH, '/usr/bin:/bin:/usr/sbin:/sbin');
+      } finally {
+        console.warn = originalWarn;
+        restoreEnv();
+        await shell.cleanup();
+      }
+    },
+  );
+
+  it(
+    'bounds shell output instead of buffering until the global timeout',
+    { skip: process.platform === 'win32' },
+    async () => {
+      const restoreEnv = snapshotEnv();
+      const shell = await createFakeShell(`
+while :; do
+  printf '0123456789abcdef0123456789abcdef'
+done
+`);
+      const warnings: string[] = [];
+      const originalWarn = console.warn;
+      console.warn = (...args: unknown[]) => warnings.push(args.map(String).join(' '));
+      try {
+        process.env.SHELL = shell.path;
+        process.env.PATH = '/usr/bin:/bin:/usr/sbin:/sbin';
+        delete process.env.TERM;
+        delete process.env.COLORTERM;
+        delete process.env.MAKA_SKIP_SHELL_ENV;
+
+        await resolveShellEnv(2_000);
+
+        assert.match(warnings.join('\n'), /shell output exceeded 65536 bytes/);
+        assert.equal(process.env.PATH, '/usr/bin:/bin:/usr/sbin:/sbin');
+      } finally {
+        console.warn = originalWarn;
+        restoreEnv();
+        await shell.cleanup();
+      }
+    },
+  );
+});
+
+describe('selectLoginShell', () => {
+  it('prefers the inherited shell over the account shell', () => {
+    assert.equal(selectLoginShell('/bin/bash', '/bin/fish', 'darwin'), '/bin/bash');
+  });
+
+  it('uses the OS account shell when GUI launch omitted SHELL', () => {
+    assert.equal(selectLoginShell(undefined, '/bin/fish', 'linux'), '/bin/fish');
+  });
+
+  it('uses platform-appropriate defaults only when neither source has a shell', () => {
+    assert.equal(selectLoginShell(undefined, undefined, 'darwin'), '/bin/zsh');
+    assert.equal(selectLoginShell(undefined, undefined, 'linux'), '/bin/sh');
+  });
+});
 
 describe('buildCaptureCommand', () => {
   describe('POSIX family (bash / zsh / fish / sh)', () => {
@@ -24,15 +215,15 @@ describe('buildCaptureCommand', () => {
       assert.deepEqual(shellArgs, ['-i', '-l', '-c']);
       assert.equal(
         command,
-        `'/usr/bin/node' -p '"${MARK}" + JSON.stringify(process.env) + "${MARK}"'`,
+        `'/usr/bin/node' -p '"${MARK}" + JSON.stringify({ PATH: process.env.PATH }) + "${MARK}"'`,
       );
       // The payload concatenates mark + JSON + mark with no separator, so the
       // emitted bytes are `<mark>{...}<mark>` — markers flush against the
       // braces the capture regex anchors on.
-      const emitted = `${MARK}${JSON.stringify({ k: 'v' })}${MARK}`;
+      const emitted = `${MARK}${JSON.stringify({ PATH: '/usr/bin' })}${MARK}`;
       const match = buildMarkerRegex(MARK).exec(emitted);
       assert.ok(match);
-      assert.equal(match[1], JSON.stringify({ k: 'v' }));
+      assert.equal(match[1], JSON.stringify({ PATH: '/usr/bin' }));
     });
 
     it('tcsh / csh collapse to the legacy single -ic argv', () => {
@@ -43,7 +234,7 @@ describe('buildCaptureCommand', () => {
       // Same flush-marker payload as the rest of the POSIX family.
       assert.equal(
         tcsh.command,
-        `'/usr/bin/node' -p '"${MARK}" + JSON.stringify(process.env) + "${MARK}"'`,
+        `'/usr/bin/node' -p '"${MARK}" + JSON.stringify({ PATH: process.env.PATH }) + "${MARK}"'`,
       );
     });
 
@@ -54,7 +245,7 @@ describe('buildCaptureCommand', () => {
       assert.deepEqual(shellArgs, ['-i', '-l', '-c']);
       assert.equal(
         command,
-        `'/Users/Bob'\\''s/node' -p '"${MARK}" + JSON.stringify(process.env) + "${MARK}"'`,
+        `'/Users/Bob'\\''s/node' -p '"${MARK}" + JSON.stringify({ PATH: process.env.PATH }) + "${MARK}"'`,
       );
     });
   });
@@ -66,7 +257,7 @@ describe('buildCaptureCommand', () => {
       // PowerShell single-quoted strings escape `'` as `''`.
       assert.equal(
         command,
-        `& '/Users/Bob''s/node' -p '''${MARK}'' + JSON.stringify(process.env) + ''${MARK}'''`,
+        `& '/Users/Bob''s/node' -p '''${MARK}'' + JSON.stringify({ PATH: process.env.PATH }) + ''${MARK}'''`,
       );
     });
 
@@ -75,7 +266,7 @@ describe('buildCaptureCommand', () => {
       assert.deepEqual(shellArgs, ['-Login', '-Command']);
       assert.equal(
         command,
-        `& '/usr/bin/node' -p '''${MARK}'' + JSON.stringify(process.env) + ''${MARK}'''`,
+        `& '/usr/bin/node' -p '''${MARK}'' + JSON.stringify({ PATH: process.env.PATH }) + ''${MARK}'''`,
       );
     });
   });
@@ -86,7 +277,7 @@ describe('buildCaptureCommand', () => {
       assert.deepEqual(shellArgs, ['-i', '-l', '-c']);
       assert.equal(
         command,
-        `^'/usr/bin/node' -p '"${MARK}" + JSON.stringify(process.env) + "${MARK}"'`,
+        `^'/usr/bin/node' -p '"${MARK}" + JSON.stringify({ PATH: process.env.PATH }) + "${MARK}"'`,
       );
     });
   });
@@ -98,7 +289,7 @@ describe('buildCaptureCommand', () => {
     assert.deepEqual(shellArgs, ['-i', '-l', '-c']);
     assert.equal(
       command,
-      `'/usr/bin/node' -p '"${MARK}" + JSON.stringify(process.env) + "${MARK}"'`,
+      `'/usr/bin/node' -p '"${MARK}" + JSON.stringify({ PATH: process.env.PATH }) + "${MARK}"'`,
     );
   });
 });
@@ -112,9 +303,9 @@ describe('buildMarkerRegex', () => {
   });
 
   it('captures the body across newlines (dotall via [\\s\\S])', () => {
-    // Shell init noise / pretty-printed env can land newlines inside the JSON
-    // object; the regex must span them.
-    const body = JSON.stringify({ k: 'v\nmulti', nested: { a: 1 } });
+    const body = `{
+  "PATH": "/usr/bin"
+}`;
     const match = buildMarkerRegex(MARK).exec(`${MARK}${body}${MARK}`);
     assert.ok(match);
     assert.equal(match[1], body);
@@ -128,110 +319,5 @@ describe('buildMarkerRegex', () => {
     // item #3 before it shipped.
     const xonshShape = `${MARK} {"k":"v"} ${MARK}`;
     assert.equal(buildMarkerRegex(MARK).exec(xonshShape), null);
-  });
-});
-
-describe('sanitizeCapturedEnv', () => {
-  it('removes Electron probe variables that were absent from the original process', () => {
-    const sanitized = sanitizeCapturedEnv(
-      {
-        ELECTRON_RUN_AS_NODE: '1',
-        ELECTRON_NO_ATTACH_CONSOLE: '1',
-        PATH: '/resolved/bin',
-      },
-      { PATH: '/original/bin' },
-    );
-
-    assert.equal(sanitized.ELECTRON_RUN_AS_NODE, undefined);
-    assert.equal(sanitized.ELECTRON_NO_ATTACH_CONSOLE, undefined);
-    assert.equal(sanitized.PATH, '/resolved/bin');
-  });
-
-  it('restores the exact Electron values that existed before the probe', () => {
-    const sanitized = sanitizeCapturedEnv(
-      {
-        ELECTRON_RUN_AS_NODE: '1',
-        ELECTRON_NO_ATTACH_CONSOLE: '1',
-        PATH: '/resolved/bin',
-      },
-      {
-        ELECTRON_RUN_AS_NODE: 'original-run-as-node',
-        ELECTRON_NO_ATTACH_CONSOLE: 'original-no-console',
-      },
-    );
-
-    assert.equal(
-      sanitized.ELECTRON_RUN_AS_NODE,
-      'original-run-as-node',
-    );
-    assert.equal(
-      sanitized.ELECTRON_NO_ATTACH_CONSOLE,
-      'original-no-console',
-    );
-  });
-
-  it('drops the login shell runtime directory before it reaches GUI children', () => {
-    const sanitized = sanitizeCapturedEnv(
-      {
-        PATH: '/resolved/bin',
-        XDG_RUNTIME_DIR: '/shell/runtime',
-      },
-      { XDG_RUNTIME_DIR: '/original/runtime' },
-    );
-
-    assert.equal(sanitized.XDG_RUNTIME_DIR, undefined);
-  });
-});
-
-describe('mergeEnv', () => {
-  // mergeEnv mutates the global `process.env`; snapshot every key before each
-  // test and restore exactly afterward so the suite stays hermetic.
-  function snapshotEnv(): () => void {
-    const before = new Map<string, string>();
-    for (const [key, value] of Object.entries(process.env)) before.set(key, value as string);
-    return () => {
-      for (const key of Object.keys(process.env)) {
-        if (!before.has(key)) delete process.env[key];
-      }
-      for (const [key, value] of before) process.env[key] = value;
-    };
-  }
-
-  it('applies the resolved PATH (resolved wins for user-configured vars)', () => {
-    const restore = snapshotEnv();
-    try {
-      delete process.env.PATH;
-      mergeEnv({ PATH: '/resolved/bin:/usr/bin' });
-      assert.equal(process.env.PATH, '/resolved/bin:/usr/bin');
-    } finally {
-      restore();
-    }
-  });
-
-  it('preserves a pre-existing MAKA_* value the resolved env tried to overwrite', () => {
-    // The prefix-rule refactor must restore ANY MAKA_* key, even ones not on
-    // a hand-maintained list — this is what survives future MAKA_* renames.
-    const restore = snapshotEnv();
-    try {
-      process.env.MAKA_FUTURE_FLAG = 'original';
-      mergeEnv({ MAKA_FUTURE_FLAG: 'from-shell', PATH: '/bin' });
-      assert.equal(process.env.MAKA_FUTURE_FLAG, 'original');
-    } finally {
-      restore();
-    }
-  });
-
-  it('preserves the original desktop marker when the resolved env carries it', () => {
-    const restore = snapshotEnv();
-    try {
-      process.env.ORIGINAL_XDG_CURRENT_DESKTOP = 'GNOME';
-      mergeEnv({
-        ORIGINAL_XDG_CURRENT_DESKTOP: 'from-shell',
-        PATH: '/bin',
-      });
-      assert.equal(process.env.ORIGINAL_XDG_CURRENT_DESKTOP, 'GNOME');
-    } finally {
-      restore();
-    }
   });
 });

--- a/apps/desktop/src/main/__tests__/shell-env.test.ts
+++ b/apps/desktop/src/main/__tests__/shell-env.test.ts
@@ -6,7 +6,7 @@
  */
 
 import { strict as assert } from 'node:assert';
-import { access, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, it } from 'node:test';
@@ -47,6 +47,40 @@ async function createFakeShell(body: string): Promise<{
   };
 }
 
+async function readPid(path: string): Promise<number> {
+  const pid = Number.parseInt(await readFile(path, 'utf8'), 10);
+  assert.ok(Number.isInteger(pid) && pid > 0);
+  return pid;
+}
+
+function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ESRCH') return false;
+    throw error;
+  }
+}
+
+async function assertProcessExited(pid: number): Promise<void> {
+  const deadline = Date.now() + 5_000;
+  while (Date.now() < deadline) {
+    if (!isProcessAlive(pid)) return;
+    await delay(20);
+  }
+  assert.fail(`process ${pid} remained alive after shell capture settled`);
+}
+
+function terminateIfAlive(pid: number | undefined): void {
+  if (pid === undefined) return;
+  try {
+    process.kill(pid, 'SIGKILL');
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'ESRCH') throw error;
+  }
+}
+
 describe('resolveShellEnv', () => {
   it(
     'imports the login PATH without importing application control variables',
@@ -54,14 +88,22 @@ describe('resolveShellEnv', () => {
     async () => {
       const restoreEnv = snapshotEnv();
       const shell = await createFakeShell(`
+(
+  trap '' HUP TERM
+  sleep 60
+) </dev/null >/dev/null 2>&1 &
+printf '%s' "$!" > "$SHELL_ENV_TEST_PID_FILE"
 export PATH='/resolved/bin:/usr/bin'
 export MAKA_E2E_FIXTURE='first-run'
 export VITE_DEV_SERVER_URL='https://example.invalid/renderer'
 export XDG_RUNTIME_DIR='/shell/runtime'
 exec /bin/sh -c "$4"
 `);
+      const pidFile = `${shell.path}.pid`;
+      let descendantPid: number | undefined;
       try {
         process.env.SHELL = shell.path;
+        process.env.SHELL_ENV_TEST_PID_FILE = pidFile;
         process.env.PATH = '/usr/bin:/bin:/usr/sbin:/sbin';
         process.env.XDG_RUNTIME_DIR = '/original/runtime';
         delete process.env.TERM;
@@ -73,6 +115,7 @@ exec /bin/sh -c "$4"
         delete process.env.ELECTRON_NO_ATTACH_CONSOLE;
 
         await resolveShellEnv();
+        descendantPid = await readPid(pidFile);
 
         assert.equal(process.env.PATH, '/resolved/bin:/usr/bin');
         assert.equal(process.env.MAKA_E2E_FIXTURE, undefined);
@@ -80,7 +123,9 @@ exec /bin/sh -c "$4"
         assert.equal(process.env.XDG_RUNTIME_DIR, '/original/runtime');
         assert.equal(process.env.ELECTRON_RUN_AS_NODE, undefined);
         assert.equal(process.env.ELECTRON_NO_ATTACH_CONSOLE, undefined);
+        await assertProcessExited(descendantPid);
       } finally {
+        terminateIfAlive(descendantPid);
         restoreEnv();
         await shell.cleanup();
       }
@@ -93,25 +138,36 @@ exec /bin/sh -c "$4"
     async () => {
       const restoreEnv = snapshotEnv();
       const shell = await createFakeShell(`
+(
+  trap '' HUP TERM
+  sleep 60
+) </dev/null >/dev/null 2>&1 &
+printf '%s' "$!" > "$SHELL_ENV_TEST_PID_FILE"
 printf 'secret-from-shell-startup' >&2
 exit 23
 `);
+      const pidFile = `${shell.path}.pid`;
+      let descendantPid: number | undefined;
       const warnings: string[] = [];
       const originalWarn = console.warn;
       console.warn = (...args: unknown[]) => warnings.push(args.map(String).join(' '));
       try {
         process.env.SHELL = shell.path;
+        process.env.SHELL_ENV_TEST_PID_FILE = pidFile;
         process.env.PATH = '/usr/bin:/bin:/usr/sbin:/sbin';
         delete process.env.TERM;
         delete process.env.COLORTERM;
         delete process.env.MAKA_SKIP_SHELL_ENV;
 
         await resolveShellEnv();
+        descendantPid = await readPid(pidFile);
 
         assert.equal(process.env.PATH, '/usr/bin:/bin:/usr/sbin:/sbin');
         assert.match(warnings.join('\n'), /exited with code 23/);
         assert.doesNotMatch(warnings.join('\n'), /secret-from-shell-startup/);
+        await assertProcessExited(descendantPid);
       } finally {
+        terminateIfAlive(descendantPid);
         console.warn = originalWarn;
         restoreEnv();
         await shell.cleanup();
@@ -127,33 +183,60 @@ exit 23
       const shell = await createFakeShell(`
 (
   trap '' HUP TERM
-  printf 'started' > "$SHELL_ENV_TEST_STARTED_FILE"
-  sleep 1.5
-  printf 'survived' > "$SHELL_ENV_TEST_SURVIVOR_FILE"
+  sleep 60
 ) </dev/null >/dev/null 2>&1 &
+printf '%s' "$!" > "$SHELL_ENV_TEST_PID_FILE"
 wait
 `);
-      const startedFile = `${shell.path}.started`;
-      const survivorFile = `${shell.path}.survived`;
+      const pidFile = `${shell.path}.pid`;
+      let descendantPid: number | undefined;
       const originalWarn = console.warn;
       console.warn = () => {};
       try {
         process.env.SHELL = shell.path;
-        process.env.SHELL_ENV_TEST_STARTED_FILE = startedFile;
-        process.env.SHELL_ENV_TEST_SURVIVOR_FILE = survivorFile;
+        process.env.SHELL_ENV_TEST_PID_FILE = pidFile;
         process.env.PATH = '/usr/bin:/bin:/usr/sbin:/sbin';
         delete process.env.TERM;
         delete process.env.COLORTERM;
         delete process.env.MAKA_SKIP_SHELL_ENV;
 
         await resolveShellEnv(1_000);
-        await access(startedFile);
-        await delay(700);
+        descendantPid = await readPid(pidFile);
 
-        await assert.rejects(access(survivorFile));
+        await assertProcessExited(descendantPid);
         assert.equal(process.env.PATH, '/usr/bin:/bin:/usr/sbin:/sbin');
       } finally {
+        terminateIfAlive(descendantPid);
         console.warn = originalWarn;
+        restoreEnv();
+        await shell.cleanup();
+      }
+    },
+  );
+
+  it(
+    'does not execute the shell when MAKA_SKIP_SHELL_ENV is set',
+    { skip: process.platform === 'win32' },
+    async () => {
+      const restoreEnv = snapshotEnv();
+      const shell = await createFakeShell(`
+printf 'executed' > "$SHELL_ENV_TEST_SENTINEL_FILE"
+exit 0
+`);
+      const sentinelFile = `${shell.path}.executed`;
+      try {
+        process.env.SHELL = shell.path;
+        process.env.SHELL_ENV_TEST_SENTINEL_FILE = sentinelFile;
+        process.env.PATH = '/usr/bin:/bin:/usr/sbin:/sbin';
+        process.env.MAKA_SKIP_SHELL_ENV = '1';
+        delete process.env.TERM;
+        delete process.env.COLORTERM;
+
+        await resolveShellEnv();
+
+        assert.equal(process.env.PATH, '/usr/bin:/bin:/usr/sbin:/sbin');
+        await assert.rejects(readFile(sentinelFile));
+      } finally {
         restoreEnv();
         await shell.cleanup();
       }

--- a/apps/desktop/src/main/__tests__/shell-env.test.ts
+++ b/apps/desktop/src/main/__tests__/shell-env.test.ts
@@ -8,7 +8,12 @@
 import { strict as assert } from 'node:assert';
 import { describe, it } from 'node:test';
 
-import { buildCaptureCommand, buildMarkerRegex, mergeEnv } from '../shell-env.js';
+import {
+  buildCaptureCommand,
+  buildMarkerRegex,
+  mergeEnv,
+  sanitizeCapturedEnv,
+} from '../shell-env.js';
 
 const MARK = '0123456789ab';
 
@@ -126,6 +131,58 @@ describe('buildMarkerRegex', () => {
   });
 });
 
+describe('sanitizeCapturedEnv', () => {
+  it('removes Electron probe variables that were absent from the original process', () => {
+    const sanitized = sanitizeCapturedEnv(
+      {
+        ELECTRON_RUN_AS_NODE: '1',
+        ELECTRON_NO_ATTACH_CONSOLE: '1',
+        PATH: '/resolved/bin',
+      },
+      { PATH: '/original/bin' },
+    );
+
+    assert.equal(sanitized.ELECTRON_RUN_AS_NODE, undefined);
+    assert.equal(sanitized.ELECTRON_NO_ATTACH_CONSOLE, undefined);
+    assert.equal(sanitized.PATH, '/resolved/bin');
+  });
+
+  it('restores the exact Electron values that existed before the probe', () => {
+    const sanitized = sanitizeCapturedEnv(
+      {
+        ELECTRON_RUN_AS_NODE: '1',
+        ELECTRON_NO_ATTACH_CONSOLE: '1',
+        PATH: '/resolved/bin',
+      },
+      {
+        ELECTRON_RUN_AS_NODE: 'original-run-as-node',
+        ELECTRON_NO_ATTACH_CONSOLE: 'original-no-console',
+      },
+    );
+
+    assert.equal(
+      sanitized.ELECTRON_RUN_AS_NODE,
+      'original-run-as-node',
+    );
+    assert.equal(
+      sanitized.ELECTRON_NO_ATTACH_CONSOLE,
+      'original-no-console',
+    );
+  });
+
+  it('drops the login shell runtime directory before it reaches GUI children', () => {
+    const sanitized = sanitizeCapturedEnv(
+      {
+        PATH: '/resolved/bin',
+        XDG_RUNTIME_DIR: '/shell/runtime',
+      },
+      { XDG_RUNTIME_DIR: '/original/runtime' },
+    );
+
+    assert.equal(sanitized.XDG_RUNTIME_DIR, undefined);
+  });
+});
+
 describe('mergeEnv', () => {
   // mergeEnv mutates the global `process.env`; snapshot every key before each
   // test and restore exactly afterward so the suite stays hermetic.
@@ -151,31 +208,6 @@ describe('mergeEnv', () => {
     }
   });
 
-  it('strips XDG_RUNTIME_DIR so the login-shell runtime dir never overwrites the original', () => {
-    // microsoft/vscode#22593: the shell's runtime dir must not persist into
-    // GUI-process children. The resolved value is dropped before the apply
-    // loop, so a pre-existing original is left untouched.
-    const restore = snapshotEnv();
-    try {
-      process.env.XDG_RUNTIME_DIR = '/original/runtime';
-      mergeEnv({ XDG_RUNTIME_DIR: '/shell/runtime', PATH: '/bin' });
-      assert.equal(process.env.XDG_RUNTIME_DIR, '/original/runtime');
-    } finally {
-      restore();
-    }
-  });
-
-  it('also drops XDG_RUNTIME_DIR when the original env lacked one', () => {
-    const restore = snapshotEnv();
-    try {
-      delete process.env.XDG_RUNTIME_DIR;
-      mergeEnv({ XDG_RUNTIME_DIR: '/shell/runtime', PATH: '/bin' });
-      assert.equal(process.env.XDG_RUNTIME_DIR, undefined);
-    } finally {
-      restore();
-    }
-  });
-
   it('preserves a pre-existing MAKA_* value the resolved env tried to overwrite', () => {
     // The prefix-rule refactor must restore ANY MAKA_* key, even ones not on
     // a hand-maintained list — this is what survives future MAKA_* renames.
@@ -189,31 +221,14 @@ describe('mergeEnv', () => {
     }
   });
 
-  it('deletes a preserved key that was absent from the original env', () => {
+  it('preserves the original desktop marker when the resolved env carries it', () => {
     const restore = snapshotEnv();
     try {
-      delete process.env.ELECTRON_RUN_AS_NODE;
-      mergeEnv({ PATH: '/bin' });
-      assert.equal(process.env.ELECTRON_RUN_AS_NODE, undefined);
-    } finally {
-      restore();
-    }
-  });
-
-  it('preserves the Electron-specific trio even when the resolved env carries it', () => {
-    const restore = snapshotEnv();
-    try {
-      process.env.ELECTRON_RUN_AS_NODE = '1';
-      process.env.ELECTRON_NO_ATTACH_CONSOLE = '1';
       process.env.ORIGINAL_XDG_CURRENT_DESKTOP = 'GNOME';
       mergeEnv({
-        ELECTRON_RUN_AS_NODE: 'from-shell',
-        ELECTRON_NO_ATTACH_CONSOLE: 'from-shell',
         ORIGINAL_XDG_CURRENT_DESKTOP: 'from-shell',
         PATH: '/bin',
       });
-      assert.equal(process.env.ELECTRON_RUN_AS_NODE, '1');
-      assert.equal(process.env.ELECTRON_NO_ATTACH_CONSOLE, '1');
       assert.equal(process.env.ORIGINAL_XDG_CURRENT_DESKTOP, 'GNOME');
     } finally {
       restore();

--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -180,12 +180,12 @@ if (!app.requestSingleInstanceLock()) {
 
 const buildInfo = resolveBuildInfo(app.isPackaged, app.getAppPath());
 
-// Resolve the user's login-shell environment (PATH, etc.) before any stores,
-// tools, or child processes are created. On macOS, apps launched from
-// Finder/Dock inherit a minimal PATH that lacks /opt/homebrew/bin, ~/.local/bin,
-// etc. This spawns the user's login shell once and merges its env — the same
-// approach VS Code uses. Skipped on Windows, when MAKA_SKIP_SHELL_ENV=1, and
-// when launched from a terminal (TERM/COLORTERM set).
+// Resolve the user's login-shell PATH before any stores, tools, or child
+// processes are created. On macOS, apps launched from Finder/Dock inherit a
+// minimal PATH that lacks /opt/homebrew/bin, ~/.local/bin, etc. Only PATH is
+// imported; application-control variables remain owned by this process.
+// Skipped on Windows, when MAKA_SKIP_SHELL_ENV=1, and when launched from a
+// terminal (TERM/COLORTERM set).
 await resolveShellEnv();
 
 // PR-VISUAL-SMOKE-HEADLESS: resolve the fixture defensively. An unknown

--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -87,6 +87,7 @@ import { createDailyReviewArchiveStore } from './daily-review-archive-store.js';
 import { resolveDefaultPermissionMode } from './permission-mode-default.js';
 import { resolveE2eFixture, seedE2eFixture } from './e2e-fixture.js';
 import { resolveBuildInfo } from './build-info.js';
+import { resolveShellEnv } from './shell-env.js';
 import { OpenGatewayService } from './open-gateway.js';
 import { LocalMemoryService } from './local-memory-service.js';
 import { createAttachmentApprovalRegistry } from './attachment-approval.js';
@@ -178,6 +179,14 @@ if (!app.requestSingleInstanceLock()) {
 }
 
 const buildInfo = resolveBuildInfo(app.isPackaged, app.getAppPath());
+
+// Resolve the user's login-shell environment (PATH, etc.) before any stores,
+// tools, or child processes are created. On macOS, apps launched from
+// Finder/Dock inherit a minimal PATH that lacks /opt/homebrew/bin, ~/.local/bin,
+// etc. This spawns the user's login shell once and merges its env — the same
+// approach VS Code uses. Skipped on Windows, when MAKA_SKIP_SHELL_ENV=1, and
+// when launched from a terminal (TERM/COLORTERM set).
+await resolveShellEnv();
 
 // PR-VISUAL-SMOKE-HEADLESS: resolve the fixture defensively. An unknown
 // scenario (e.g. a stale build, or a typo'd MAKA_E2E_FIXTURE) throws

--- a/apps/desktop/src/main/shell-env.ts
+++ b/apps/desktop/src/main/shell-env.ts
@@ -1,0 +1,237 @@
+// apps/desktop/src/main/shell-env.ts
+//
+// Resolve the user's login-shell environment at Electron startup.
+//
+// On macOS (and Linux), apps launched from Finder / Dock / Spotlight inherit
+// a minimal environment — PATH is typically just /usr/bin:/bin:/usr/sbin:/sbin.
+// User-installed tools (homebrew, ~/.local/bin, nvm, pyenv, etc.) are absent
+// because the GUI process never sources ~/.zshrc / ~/.bash_profile.
+//
+// This module spawns the user's login shell, captures its full environment via
+// JSON.stringify(process.env) with UUID markers, and merges the result into
+// process.env. This is the same battle-tested approach VS Code uses
+// (src/vs/platform/shell/node/shellEnv.ts).
+//
+// Call `resolveShellEnv()` once, early in main.ts, before any stores, tools,
+// or child processes are created.
+
+import { spawn } from 'node:child_process';
+import { basename } from 'node:path';
+import { randomUUID } from 'node:crypto';
+
+const DEFAULT_TIMEOUT_MS = 10_000;
+
+/**
+ * Resolve the user's login-shell environment and merge it into `process.env`.
+ *
+ * Skips resolution when:
+ * - Running on Windows (shell env works differently)
+ * - `MAKA_SKIP_SHELL_ENV=1` is set (escape hatch for CI / debugging)
+ * - Launched from a terminal / dev shell (`TERM` or `COLORTERM` is set).
+ *   LaunchServices (Finder / Dock / Spotlight) never sets either, while every
+ *   terminal and CLI launch always does — so their presence means the session
+ *   already inherited a complete environment and resolution is wasted work.
+ *
+ * On failure the function logs a warning and returns silently — the app
+ * continues with whatever environment Electron was given.
+ */
+export async function resolveShellEnv(): Promise<void> {
+  if (process.platform === 'win32') return;
+  if (process.env.MAKA_SKIP_SHELL_ENV === '1') return;
+  if (process.env.TERM || process.env.COLORTERM) return;
+
+  try {
+    const env = await captureLoginShellEnv(DEFAULT_TIMEOUT_MS);
+    mergeEnv(env);
+  } catch (err) {
+    console.warn(
+      `[shell-env] failed to resolve login-shell environment: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+}
+
+/**
+ * Build the shell command + argv that capture the login shell's full
+ * environment as a marker-wrapped JSON blob. Exported so the per-shell
+ * quoting rules and marker layout can be unit-tested in isolation (matching
+ * the sibling-module pattern: `resolveBuildInfo`, `buildStdioEnvironment`).
+ *
+ * `execPath` is the Node/Electron binary that prints the env; it is
+ * shell-escaped per the target shell's single-quoting rules so a path
+ * containing an apostrophe (e.g. `/Users/Bob's/bin`) round-trips safely.
+ */
+export function buildCaptureCommand(
+  shellName: string,
+  execPath: string,
+  mark: string,
+): { command: string; shellArgs: string[] } {
+  // The inner payload is identical to VS Code's: the binary runs Node and
+  // prints `mark + JSON.stringify(process.env) + mark` with no padding, so
+  // the markers sit flush against the `{` / `}` the capture regex anchors on.
+
+  if (/^(?:pwsh|powershell)(?:-preview)?$/.test(shellName)) {
+    // PowerShell single-quoted strings escape an embedded apostrophe by
+    // doubling it (`''`).
+    const escapedExec = `'${execPath.replace(/'/g, "''")}'`;
+    return {
+      command: `& ${escapedExec} -p '''${mark}'' + JSON.stringify(process.env) + ''${mark}'''`,
+      shellArgs: ['-Login', '-Command'],
+    };
+  }
+
+  if (shellName === 'nu') {
+    // nu raw strings (`^'...'`) cannot escape an embedded quote, so execPath
+    // is left as-is — a known edge case (reviewer-accepted).
+    return {
+      command: `^'${execPath}' -p '"${mark}" + JSON.stringify(process.env) + "${mark}"'`,
+      shellArgs: ['-i', '-l', '-c'],
+    };
+  }
+
+  // POSIX family: bash, zsh, fish, sh, tcsh, csh. xonsh is intentionally
+  // unsupported (not a Maka audience) and falls through here — the previous
+  // dedicated branch never matched the capture regex anyway. A real xonsh
+  // shell fails to capture gracefully and the app continues with the
+  // original env. POSIX single-quoting escapes an embedded apostrophe as
+  // the close-quote / literal-quote / reopen-quote sequence `'\''`.
+  const escapedExec = `'${execPath.replace(/'/g, "'\\''")}'`;
+  return {
+    command: `${escapedExec} -p '"${mark}" + JSON.stringify(process.env) + "${mark}"'`,
+    shellArgs: shellName === 'tcsh' || shellName === 'csh' ? ['-ic'] : ['-i', '-l', '-c'],
+  };
+}
+
+/**
+ * Build the regex that extracts the marker-wrapped JSON body from captured
+ * shell output. Exported so the adjacency contract (marker flush against
+ * the object braces) can be unit-tested.
+ */
+export function buildMarkerRegex(mark: string): RegExp {
+  return new RegExp(`${mark}(\\{[\\s\\S]*\\})${mark}`);
+}
+
+/**
+ * Spawn the user's login shell and capture its full environment.
+ */
+async function captureLoginShellEnv(timeoutMs: number): Promise<Record<string, string>> {
+  const shell = process.env.SHELL ?? '/bin/zsh';
+  const shellName = basename(shell);
+
+  // Build a command that prints the shell's environment as JSON, wrapped in
+  // unique markers so we can extract it from potentially noisy shell output
+  // (motd, conda banners, etc.).
+  const mark = randomUUID().replace(/-/g, '').slice(0, 12);
+  const markerRegex = buildMarkerRegex(mark);
+  const { command, shellArgs } = buildCaptureCommand(shellName, process.execPath, mark);
+
+  const env: Record<string, string | undefined> = {
+    ...process.env,
+    ELECTRON_RUN_AS_NODE: '1',
+    ELECTRON_NO_ATTACH_CONSOLE: '1',
+  };
+
+  return new Promise<Record<string, string>>((resolve, reject) => {
+    const timer = setTimeout(() => {
+      child.kill();
+      reject(new Error(`timed out after ${timeoutMs}ms spawning ${shell}`));
+    }, timeoutMs);
+
+    const child = spawn(shell, [...shellArgs, command], {
+      detached: true,
+      stdio: ['ignore', 'pipe', 'pipe'],
+      env,
+    });
+
+    const stdoutChunks: Buffer[] = [];
+    const stderrChunks: Buffer[] = [];
+
+    child.stdout.on('data', (b: Buffer) => stdoutChunks.push(b));
+    child.stderr.on('data', (b: Buffer) => stderrChunks.push(b));
+
+    child.on('error', (err) => {
+      clearTimeout(timer);
+      reject(new Error(`failed to spawn ${shell}: ${err.message}`));
+    });
+
+    child.on('close', (code, signal) => {
+      clearTimeout(timer);
+
+      const raw = Buffer.concat(stdoutChunks).toString('utf8');
+      const stderrStr = Buffer.concat(stderrChunks).toString('utf8').trim();
+
+      if (stderrStr) {
+        // Shell init noise is expected; only log at debug level.
+        console.debug(`[shell-env] stderr from ${shell}: ${stderrStr.slice(0, 500)}`);
+      }
+
+      if (code !== 0 && code !== null) {
+        reject(new Error(`${shell} exited with code ${code}${signal ? ` (signal ${signal})` : ''}`));
+        return;
+      }
+
+      const match = markerRegex.exec(raw);
+      if (!match) {
+        reject(new Error(`could not find environment markers in ${shell} output`));
+        return;
+      }
+
+      try {
+        const parsed = JSON.parse(match[1]) as Record<string, string>;
+        resolve(parsed);
+      } catch (err) {
+        reject(new Error(`failed to parse environment JSON: ${err instanceof Error ? err.message : String(err)}`));
+      }
+    });
+  });
+}
+
+/**
+ * Merge resolved shell environment into `process.env`. Exported so the
+ * preservation / stripping rules can be unit-tested.
+ *
+ * The resolved env takes precedence for PATH and other user-configured
+ * variables, but we preserve certain Electron-specific variables that the
+ * resolved shell env would not have. Preservation uses a prefix rule over
+ * the `MAKA_*` namespace (plus the Electron trio) so it survives future
+ * `MAKA_*` renames without a hand-maintained allowlist.
+ */
+export function mergeEnv(resolved: Record<string, string>): void {
+  // Snapshot the Electron-specific + MAKA_* keys before the resolved env
+  // overwrites them. Scanning `process.env` (not a fixed list) means every
+  // currently-set MAKA_* value is restored verbatim.
+  const preservedKeys = Object.keys(process.env).filter(
+    (key) =>
+      key === 'ELECTRON_RUN_AS_NODE' ||
+      key === 'ELECTRON_NO_ATTACH_CONSOLE' ||
+      key === 'ORIGINAL_XDG_CURRENT_DESKTOP' ||
+      key.startsWith('MAKA_'),
+  );
+  const preserved: Record<string, string | undefined> = {};
+  for (const key of preservedKeys) {
+    preserved[key] = process.env[key];
+  }
+
+  // The login shell's runtime dir must not persist into GUI-process children
+  // (microsoft/vscode#22593). macOS is unaffected, but strip unconditionally
+  // so the resolved value never overwrites whatever the GUI process had.
+  delete resolved.XDG_RUNTIME_DIR;
+
+  // Apply the resolved environment.
+  for (const [key, value] of Object.entries(resolved)) {
+    if (typeof value === 'string') {
+      process.env[key] = value;
+    }
+  }
+
+  // Restore preserved keys (delete any that were absent originally).
+  for (const [key, value] of Object.entries(preserved)) {
+    if (value !== undefined) {
+      process.env[key] = value;
+    } else {
+      delete process.env[key];
+    }
+  }
+
+  const pathEntries = (process.env.PATH ?? '').split(':').length;
+  console.log(`[shell-env] resolved login-shell environment (${pathEntries} PATH entries)`);
+}

--- a/apps/desktop/src/main/shell-env.ts
+++ b/apps/desktop/src/main/shell-env.ts
@@ -7,26 +7,27 @@
 // User-installed tools (homebrew, ~/.local/bin, nvm, pyenv, etc.) are absent
 // because the GUI process never sources ~/.zshrc / ~/.bash_profile.
 //
-// This module spawns the user's login shell, captures its full environment via
-// JSON.stringify(process.env) with UUID markers, and merges the result into
-// process.env. This is the same battle-tested approach VS Code uses
-// (src/vs/platform/shell/node/shellEnv.ts).
+// This module spawns the user's login shell, captures its PATH with UUID
+// markers, and applies that one value to process.env. Application-control
+// variables remain owned by the process that launched Maka.
 //
 // Call `resolveShellEnv()` once, early in main.ts, before any stores, tools,
 // or child processes are created.
 
-import { spawn } from 'node:child_process';
-import { basename } from 'node:path';
 import { randomUUID } from 'node:crypto';
+import { spawn } from 'node:child_process';
+import { userInfo } from 'node:os';
+import { basename } from 'node:path';
 
 const DEFAULT_TIMEOUT_MS = 10_000;
+const MAX_CAPTURE_BYTES = 64 * 1024;
 const ELECTRON_PROBE_ENV = {
   ELECTRON_RUN_AS_NODE: '1',
   ELECTRON_NO_ATTACH_CONSOLE: '1',
 } as const;
 
 /**
- * Resolve the user's login-shell environment and merge it into `process.env`.
+ * Resolve the user's login-shell PATH and apply it to `process.env`.
  *
  * Skips resolution when:
  * - Running on Windows (shell env works differently)
@@ -39,24 +40,25 @@ const ELECTRON_PROBE_ENV = {
  * On failure the function logs a warning and returns silently — the app
  * continues with whatever environment Electron was given.
  */
-export async function resolveShellEnv(): Promise<void> {
+export async function resolveShellEnv(timeoutMs = DEFAULT_TIMEOUT_MS): Promise<void> {
   if (process.platform === 'win32') return;
   if (process.env.MAKA_SKIP_SHELL_ENV === '1') return;
   if (process.env.TERM || process.env.COLORTERM) return;
 
   try {
-    const env = await captureLoginShellEnv(DEFAULT_TIMEOUT_MS);
-    mergeEnv(env);
+    process.env.PATH = await captureLoginShellPath(timeoutMs);
+    const pathEntries = process.env.PATH.split(':').length;
+    console.log(`[shell-env] resolved login-shell PATH (${pathEntries} entries)`);
   } catch (err) {
     console.warn(
-      `[shell-env] failed to resolve login-shell environment: ${err instanceof Error ? err.message : String(err)}`,
+      `[shell-env] failed to resolve login-shell PATH: ${err instanceof Error ? err.message : String(err)}`,
     );
   }
 }
 
 /**
- * Build the shell command + argv that capture the login shell's full
- * environment as a marker-wrapped JSON blob. Exported so the per-shell
+ * Build the shell command + argv that capture the login shell's PATH as a
+ * marker-wrapped JSON blob. Exported so the per-shell
  * quoting rules and marker layout can be unit-tested in isolation (matching
  * the sibling-module pattern: `resolveBuildInfo`, `buildStdioEnvironment`).
  *
@@ -69,16 +71,17 @@ export function buildCaptureCommand(
   execPath: string,
   mark: string,
 ): { command: string; shellArgs: string[] } {
-  // The inner payload is identical to VS Code's: the binary runs Node and
-  // prints `mark + JSON.stringify(process.env) + mark` with no padding, so
-  // the markers sit flush against the `{` / `}` the capture regex anchors on.
+  // The binary prints only PATH. Importing the entire login environment would
+  // let shell startup files inject Maka's test, debug, and renderer controls
+  // into the already-running application.
+  const payload = 'JSON.stringify({ PATH: process.env.PATH })';
 
   if (/^(?:pwsh|powershell)(?:-preview)?$/.test(shellName)) {
     // PowerShell single-quoted strings escape an embedded apostrophe by
     // doubling it (`''`).
     const escapedExec = `'${execPath.replace(/'/g, "''")}'`;
     return {
-      command: `& ${escapedExec} -p '''${mark}'' + JSON.stringify(process.env) + ''${mark}'''`,
+      command: `& ${escapedExec} -p '''${mark}'' + ${payload} + ''${mark}'''`,
       shellArgs: ['-Login', '-Command'],
     };
   }
@@ -87,7 +90,7 @@ export function buildCaptureCommand(
     // nu raw strings (`^'...'`) cannot escape an embedded quote, so execPath
     // is left as-is — a known edge case (reviewer-accepted).
     return {
-      command: `^'${execPath}' -p '"${mark}" + JSON.stringify(process.env) + "${mark}"'`,
+      command: `^'${execPath}' -p '"${mark}" + ${payload} + "${mark}"'`,
       shellArgs: ['-i', '-l', '-c'],
     };
   }
@@ -100,7 +103,7 @@ export function buildCaptureCommand(
   // the close-quote / literal-quote / reopen-quote sequence `'\''`.
   const escapedExec = `'${execPath.replace(/'/g, "'\\''")}'`;
   return {
-    command: `${escapedExec} -p '"${mark}" + JSON.stringify(process.env) + "${mark}"'`,
+    command: `${escapedExec} -p '"${mark}" + ${payload} + "${mark}"'`,
     shellArgs: shellName === 'tcsh' || shellName === 'csh' ? ['-ic'] : ['-i', '-l', '-c'],
   };
 }
@@ -115,30 +118,48 @@ export function buildMarkerRegex(mark: string): RegExp {
 }
 
 /**
- * Restore the caller's Electron flags and remove the login shell's transient
- * runtime directory before the capture may re-enter the main process.
+ * Prefer the inherited shell, then the OS account shell. GUI launches often
+ * omit SHELL, so a platform default is only the last resort.
  */
-export function sanitizeCapturedEnv(
-  captured: Readonly<Record<string, string>>,
-  original: Readonly<NodeJS.ProcessEnv>,
-): Record<string, string> {
-  const sanitized = { ...captured };
-  for (const key of Object.keys(ELECTRON_PROBE_ENV) as Array<
-    keyof typeof ELECTRON_PROBE_ENV
-  >) {
-    const originalValue = original[key];
-    if (originalValue === undefined) delete sanitized[key];
-    else sanitized[key] = originalValue;
-  }
-  delete sanitized.XDG_RUNTIME_DIR;
-  return sanitized;
+export function selectLoginShell(
+  inheritedShell: string | undefined,
+  accountShell: string | null | undefined,
+  platform: NodeJS.Platform,
+): string {
+  return (
+    inheritedShell?.trim() ||
+    accountShell?.trim() ||
+    (platform === 'darwin' ? '/bin/zsh' : '/bin/sh')
+  );
 }
 
 /**
- * Spawn the user's login shell and capture its full environment.
+ * Kill the detached shell process group so startup-file descendants do not
+ * survive a timeout or an output-limit failure.
  */
-async function captureLoginShellEnv(timeoutMs: number): Promise<Record<string, string>> {
-  const shell = process.env.SHELL ?? '/bin/zsh';
+function terminateProbe(child: ReturnType<typeof spawn>): void {
+  if (process.platform !== 'win32' && child.pid !== undefined) {
+    try {
+      process.kill(-child.pid, 'SIGKILL');
+      return;
+    } catch {
+      // Fall through if the process group has already exited.
+    }
+  }
+  child.kill('SIGKILL');
+}
+
+/**
+ * Spawn the user's login shell and capture only its PATH.
+ */
+async function captureLoginShellPath(timeoutMs: number): Promise<string> {
+  let accountShell: string | null | undefined;
+  try {
+    accountShell = userInfo().shell;
+  } catch {
+    // Account lookup can fail in constrained runtimes; use the platform fallback.
+  }
+  const shell = selectLoginShell(process.env.SHELL, accountShell, process.platform);
   const shellName = basename(shell);
 
   // Build a command that prints the shell's environment as JSON, wrapped in
@@ -148,18 +169,12 @@ async function captureLoginShellEnv(timeoutMs: number): Promise<Record<string, s
   const markerRegex = buildMarkerRegex(mark);
   const { command, shellArgs } = buildCaptureCommand(shellName, process.execPath, mark);
 
-  const originalEnv = { ...process.env };
   const env: Record<string, string | undefined> = {
-    ...originalEnv,
+    ...process.env,
     ...ELECTRON_PROBE_ENV,
   };
 
-  return new Promise<Record<string, string>>((resolve, reject) => {
-    const timer = setTimeout(() => {
-      child.kill();
-      reject(new Error(`timed out after ${timeoutMs}ms spawning ${shell}`));
-    }, timeoutMs);
-
+  return new Promise<string>((resolve, reject) => {
     const child = spawn(shell, [...shellArgs, command], {
       detached: true,
       stdio: ['ignore', 'pipe', 'pipe'],
@@ -167,87 +182,79 @@ async function captureLoginShellEnv(timeoutMs: number): Promise<Record<string, s
     });
 
     const stdoutChunks: Buffer[] = [];
-    const stderrChunks: Buffer[] = [];
+    let capturedBytes = 0;
+    let settled = false;
+    let timer: NodeJS.Timeout | undefined;
 
-    child.stdout.on('data', (b: Buffer) => stdoutChunks.push(b));
-    child.stderr.on('data', (b: Buffer) => stderrChunks.push(b));
+    const cleanup = () => {
+      if (timer) clearTimeout(timer);
+      child.stdout.removeAllListeners();
+      child.stderr.removeAllListeners();
+      child.removeAllListeners();
+      child.stdout.destroy();
+      child.stderr.destroy();
+    };
+
+    const fail = (error: Error, terminate = false) => {
+      if (settled) return;
+      settled = true;
+      if (terminate) terminateProbe(child);
+      cleanup();
+      reject(error);
+    };
+
+    const succeed = (path: string) => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      resolve(path);
+    };
+
+    const capture = (chunk: Buffer, keep: boolean) => {
+      capturedBytes += chunk.length;
+      if (capturedBytes > MAX_CAPTURE_BYTES) {
+        fail(new Error(`shell output exceeded ${MAX_CAPTURE_BYTES} bytes`), true);
+        return;
+      }
+      if (keep) stdoutChunks.push(chunk);
+    };
+
+    child.stdout.on('data', (chunk: Buffer) => capture(chunk, true));
+    // Count stderr toward the bound but never retain or log shell-controlled
+    // bytes: startup files may print secrets.
+    child.stderr.on('data', (chunk: Buffer) => capture(chunk, false));
 
     child.on('error', (err) => {
-      clearTimeout(timer);
-      reject(new Error(`failed to spawn ${shell}: ${err.message}`));
+      fail(new Error(`failed to spawn ${shell}: ${err.message}`));
     });
 
     child.on('close', (code, signal) => {
-      clearTimeout(timer);
-
-      const raw = Buffer.concat(stdoutChunks).toString('utf8');
-      const stderrStr = Buffer.concat(stderrChunks).toString('utf8').trim();
-
-      if (stderrStr) {
-        // Shell init noise is expected; only log at debug level.
-        console.debug(`[shell-env] stderr from ${shell}: ${stderrStr.slice(0, 500)}`);
-      }
-
+      if (settled) return;
       if (code !== 0 && code !== null) {
-        reject(new Error(`${shell} exited with code ${code}${signal ? ` (signal ${signal})` : ''}`));
+        fail(new Error(`${shell} exited with code ${code}${signal ? ` (signal ${signal})` : ''}`));
         return;
       }
 
+      const raw = Buffer.concat(stdoutChunks).toString('utf8');
       const match = markerRegex.exec(raw);
       if (!match) {
-        reject(new Error(`could not find environment markers in ${shell} output`));
+        fail(new Error(`could not find PATH markers in ${shell} output`));
         return;
       }
 
       try {
         const parsed = JSON.parse(match[1]) as Record<string, string>;
-        resolve(sanitizeCapturedEnv(parsed, originalEnv));
-      } catch (err) {
-        reject(new Error(`failed to parse environment JSON: ${err instanceof Error ? err.message : String(err)}`));
+        if (typeof parsed.PATH !== 'string' || parsed.PATH.length === 0) {
+          throw new Error('captured login shell did not provide PATH');
+        }
+        succeed(parsed.PATH);
+      } catch {
+        fail(new Error('failed to parse PATH JSON'));
       }
     });
+
+    timer = setTimeout(() => {
+      fail(new Error(`timed out after ${timeoutMs}ms spawning ${shell}`), true);
+    }, timeoutMs);
   });
-}
-
-/**
- * Merge resolved shell environment into `process.env`. Exported so the
- * preservation / stripping rules can be unit-tested.
- *
- * The resolved env takes precedence for PATH and other user-configured
- * variables, but we preserve the host-owned desktop marker and every `MAKA_*`
- * value that the resolved shell env must not replace. The Electron flags used
- * by the capture probe are already restored at the capture boundary.
- */
-export function mergeEnv(resolved: Record<string, string>): void {
-  // Snapshot the host-owned keys before the resolved env overwrites them.
-  // Scanning `process.env` (not a fixed list) means every currently-set
-  // MAKA_* value is restored verbatim.
-  const preservedKeys = Object.keys(process.env).filter(
-    (key) =>
-      key === 'ORIGINAL_XDG_CURRENT_DESKTOP' ||
-      key.startsWith('MAKA_'),
-  );
-  const preserved: Record<string, string | undefined> = {};
-  for (const key of preservedKeys) {
-    preserved[key] = process.env[key];
-  }
-
-  // Apply the resolved environment.
-  for (const [key, value] of Object.entries(resolved)) {
-    if (typeof value === 'string') {
-      process.env[key] = value;
-    }
-  }
-
-  // Restore preserved keys (delete any that were absent originally).
-  for (const [key, value] of Object.entries(preserved)) {
-    if (value !== undefined) {
-      process.env[key] = value;
-    } else {
-      delete process.env[key];
-    }
-  }
-
-  const pathEntries = (process.env.PATH ?? '').split(':').length;
-  console.log(`[shell-env] resolved login-shell environment (${pathEntries} PATH entries)`);
 }

--- a/apps/desktop/src/main/shell-env.ts
+++ b/apps/desktop/src/main/shell-env.ts
@@ -135,7 +135,7 @@ export function selectLoginShell(
 
 /**
  * Kill the detached shell process group so startup-file descendants do not
- * survive a timeout or an output-limit failure.
+ * survive the dedicated capture, regardless of how it settles.
  */
 function terminateProbe(child: ReturnType<typeof spawn>): void {
   if (process.platform !== 'win32' && child.pid !== undefined) {
@@ -195,10 +195,10 @@ async function captureLoginShellPath(timeoutMs: number): Promise<string> {
       child.stderr.destroy();
     };
 
-    const fail = (error: Error, terminate = false) => {
+    const fail = (error: Error) => {
       if (settled) return;
       settled = true;
-      if (terminate) terminateProbe(child);
+      terminateProbe(child);
       cleanup();
       reject(error);
     };
@@ -206,6 +206,7 @@ async function captureLoginShellPath(timeoutMs: number): Promise<string> {
     const succeed = (path: string) => {
       if (settled) return;
       settled = true;
+      terminateProbe(child);
       cleanup();
       resolve(path);
     };
@@ -213,7 +214,7 @@ async function captureLoginShellPath(timeoutMs: number): Promise<string> {
     const capture = (chunk: Buffer, keep: boolean) => {
       capturedBytes += chunk.length;
       if (capturedBytes > MAX_CAPTURE_BYTES) {
-        fail(new Error(`shell output exceeded ${MAX_CAPTURE_BYTES} bytes`), true);
+        fail(new Error(`shell output exceeded ${MAX_CAPTURE_BYTES} bytes`));
         return;
       }
       if (keep) stdoutChunks.push(chunk);
@@ -254,7 +255,7 @@ async function captureLoginShellPath(timeoutMs: number): Promise<string> {
     });
 
     timer = setTimeout(() => {
-      fail(new Error(`timed out after ${timeoutMs}ms spawning ${shell}`), true);
+      fail(new Error(`timed out after ${timeoutMs}ms spawning ${shell}`));
     }, timeoutMs);
   });
 }

--- a/apps/desktop/src/main/shell-env.ts
+++ b/apps/desktop/src/main/shell-env.ts
@@ -1,6 +1,6 @@
 // apps/desktop/src/main/shell-env.ts
 //
-// Resolve the user's login-shell environment at Electron startup.
+// Resolve the user's login-shell PATH at Electron startup.
 //
 // On macOS (and Linux), apps launched from Finder / Dock / Spotlight inherit
 // a minimal environment — PATH is typically just /usr/bin:/bin:/usr/sbin:/sbin.

--- a/apps/desktop/src/main/shell-env.ts
+++ b/apps/desktop/src/main/shell-env.ts
@@ -20,6 +20,10 @@ import { basename } from 'node:path';
 import { randomUUID } from 'node:crypto';
 
 const DEFAULT_TIMEOUT_MS = 10_000;
+const ELECTRON_PROBE_ENV = {
+  ELECTRON_RUN_AS_NODE: '1',
+  ELECTRON_NO_ATTACH_CONSOLE: '1',
+} as const;
 
 /**
  * Resolve the user's login-shell environment and merge it into `process.env`.
@@ -111,6 +115,26 @@ export function buildMarkerRegex(mark: string): RegExp {
 }
 
 /**
+ * Restore the caller's Electron flags and remove the login shell's transient
+ * runtime directory before the capture may re-enter the main process.
+ */
+export function sanitizeCapturedEnv(
+  captured: Readonly<Record<string, string>>,
+  original: Readonly<NodeJS.ProcessEnv>,
+): Record<string, string> {
+  const sanitized = { ...captured };
+  for (const key of Object.keys(ELECTRON_PROBE_ENV) as Array<
+    keyof typeof ELECTRON_PROBE_ENV
+  >) {
+    const originalValue = original[key];
+    if (originalValue === undefined) delete sanitized[key];
+    else sanitized[key] = originalValue;
+  }
+  delete sanitized.XDG_RUNTIME_DIR;
+  return sanitized;
+}
+
+/**
  * Spawn the user's login shell and capture its full environment.
  */
 async function captureLoginShellEnv(timeoutMs: number): Promise<Record<string, string>> {
@@ -124,10 +148,10 @@ async function captureLoginShellEnv(timeoutMs: number): Promise<Record<string, s
   const markerRegex = buildMarkerRegex(mark);
   const { command, shellArgs } = buildCaptureCommand(shellName, process.execPath, mark);
 
+  const originalEnv = { ...process.env };
   const env: Record<string, string | undefined> = {
-    ...process.env,
-    ELECTRON_RUN_AS_NODE: '1',
-    ELECTRON_NO_ATTACH_CONSOLE: '1',
+    ...originalEnv,
+    ...ELECTRON_PROBE_ENV,
   };
 
   return new Promise<Record<string, string>>((resolve, reject) => {
@@ -177,7 +201,7 @@ async function captureLoginShellEnv(timeoutMs: number): Promise<Record<string, s
 
       try {
         const parsed = JSON.parse(match[1]) as Record<string, string>;
-        resolve(parsed);
+        resolve(sanitizeCapturedEnv(parsed, originalEnv));
       } catch (err) {
         reject(new Error(`failed to parse environment JSON: ${err instanceof Error ? err.message : String(err)}`));
       }
@@ -190,19 +214,16 @@ async function captureLoginShellEnv(timeoutMs: number): Promise<Record<string, s
  * preservation / stripping rules can be unit-tested.
  *
  * The resolved env takes precedence for PATH and other user-configured
- * variables, but we preserve certain Electron-specific variables that the
- * resolved shell env would not have. Preservation uses a prefix rule over
- * the `MAKA_*` namespace (plus the Electron trio) so it survives future
- * `MAKA_*` renames without a hand-maintained allowlist.
+ * variables, but we preserve the host-owned desktop marker and every `MAKA_*`
+ * value that the resolved shell env must not replace. The Electron flags used
+ * by the capture probe are already restored at the capture boundary.
  */
 export function mergeEnv(resolved: Record<string, string>): void {
-  // Snapshot the Electron-specific + MAKA_* keys before the resolved env
-  // overwrites them. Scanning `process.env` (not a fixed list) means every
-  // currently-set MAKA_* value is restored verbatim.
+  // Snapshot the host-owned keys before the resolved env overwrites them.
+  // Scanning `process.env` (not a fixed list) means every currently-set
+  // MAKA_* value is restored verbatim.
   const preservedKeys = Object.keys(process.env).filter(
     (key) =>
-      key === 'ELECTRON_RUN_AS_NODE' ||
-      key === 'ELECTRON_NO_ATTACH_CONSOLE' ||
       key === 'ORIGINAL_XDG_CURRENT_DESKTOP' ||
       key.startsWith('MAKA_'),
   );
@@ -210,11 +231,6 @@ export function mergeEnv(resolved: Record<string, string>): void {
   for (const key of preservedKeys) {
     preserved[key] = process.env[key];
   }
-
-  // The login shell's runtime dir must not persist into GUI-process children
-  // (microsoft/vscode#22593). macOS is unaffected, but strip unconditionally
-  // so the resolved value never overwrites whatever the GUI process had.
-  delete resolved.XDG_RUNTIME_DIR;
 
   // Apply the resolved environment.
   for (const [key, value] of Object.entries(resolved)) {

--- a/scripts/check-console.mjs
+++ b/scripts/check-console.mjs
@@ -83,6 +83,10 @@ const ALLOW = new Map([
     'apps/desktop/src/main/config-file-watcher.ts',
     'Watcher startup failure and runtime error diagnostics; non-fatal, no secrets.',
   ],
+  [
+    'apps/desktop/src/main/shell-env.ts',
+    'login-shell env resolution diagnostics at startup (PATH-entry count, shell stderr snippet, capture failure reason); non-fatal, no secrets.',
+  ],
   ['scripts/check-console.mjs', 'this script — explicit allow.'],
   [
     'apps/desktop/src/main/automation-wiring.ts',

--- a/scripts/check-console.mjs
+++ b/scripts/check-console.mjs
@@ -85,7 +85,7 @@ const ALLOW = new Map([
   ],
   [
     'apps/desktop/src/main/shell-env.ts',
-    'login-shell env resolution diagnostics at startup (PATH-entry count, shell stderr snippet, capture failure reason); non-fatal, no secrets.',
+    'login-shell PATH resolution diagnostics at startup (PATH-entry count and sanitized failure reason); non-fatal, no shell-controlled output.',
   ],
   ['scripts/check-console.mjs', 'this script — explicit allow.'],
   [


### PR DESCRIPTION
## Summary

- Restore the user login-shell `PATH` before desktop stores, tools, and child processes are created, so Finder/Dock/Spotlight launches can find Homebrew, user-local, and version-manager binaries.
- Import only `PATH`; shell startup files cannot inject Maka, Electron, renderer, or other application-control variables into the running main process.
- Prefer the inherited shell, then the OS account shell, with platform-appropriate fallbacks. Capture is bounded, never logs raw shell stderr, degrades to the inherited PATH on failure, and terminates the dedicated process group on every completion path.
- Keep E2E command resolution deterministic through `MAKA_SKIP_SHELL_ENV`.

## Verification

- `npm run build:test`
- `npm run typecheck`
- `npm run lint`
- `npm run format:check`
- `npm --workspace @maka/desktop test` — 2863 passed
- `node --test apps/desktop/dist/main/__tests__/shell-env.test.js` — 18 passed; repeated runs passed
- Desktop console, accessibility, and copy policy checks passed
- Four independent final reviews: no P0–P3 findings, GO

## Review focus

The boundary is intentionally PATH-only. The issue is missing CLI lookup paths in GUI launches; importing the full login environment would mix shell-owned data with application control state and require an open-ended denylist.