### PR TITLE
test(desktop): lock sidebar-long-sessions footer-visibility geometry in e2e

### DIFF
--- a/apps/desktop/e2e/fixtures.ts
+++ b/apps/desktop/e2e/fixtures.ts
@@ -147,6 +147,7 @@ export const test = base.extend<{
   window: Page;
   emptyWindow: Page;
   longTranscriptWindow: Page;
+  sidebarLongSessionsWindow: Page;
   permissionWindow: Page;
   staleSessionsWindow: Page;
   sessionWorkbarWindow: Page;
@@ -174,6 +175,19 @@ export const test = base.extend<{
   longTranscriptWindow: async ({}, use) => {
     await withE2eWindow(
       { seed: false, readinessSelector: '.maka-turn', e2eFixtureScenario: 'long-transcript', locale: 'zh' },
+      use,
+    );
+  },
+  // Long sidebar sessions: boots the e2e-fixture `sidebar-long-sessions`
+  // fixture, which seeds 60 active sessions and opens the newest one
+  // (`...-00`) with the sidebar expanded. Fixture mode seeds its own
+  // connections, so no connection is pre-staged here. Readiness = a session
+  // row on screen: the panel grid has mounted, the session list has loaded
+  // from IPC, and the footer sits below the constrained list row. Used by the
+  // sidebar-geometry spec.
+  sidebarLongSessionsWindow: async ({}, use) => {
+    await withE2eWindow(
+      { seed: false, readinessSelector: '.maka-list-row', e2eFixtureScenario: 'sidebar-long-sessions', locale: 'zh' },
       use,
     );
   },

--- a/apps/desktop/e2e/sidebar-geometry.spec.ts
+++ b/apps/desktop/e2e/sidebar-geometry.spec.ts
@@ -1,0 +1,210 @@
+import { test, expect } from './fixtures';
+import type { Page } from '@playwright/test';
+
+/**
+ * Sidebar footer-visibility geometry contract (`sidebar-long-sessions`).
+ *
+ * The `sidebar-long-sessions` fixture seeds 60 active sessions so the sidebar
+ * scroll container can be verified end-to-end: the session list must scroll
+ * inside its own constrained grid row while the footer (Settings entry +
+ * version info) stays pinned at the bottom of the sidebar panel — never pushed
+ * off-screen — regardless of session count.
+ *
+ * History: this invariant was the P0 WAWQAQ flagged (msg `761141c5`),
+ * historically attributed to `min-height: 0` / `minmax(0, 1fr)` dropping out of
+ * the sidebar grid. At this fixture's window size those grid constraints are
+ * mutually redundant (removing any one of them leaves the layout
+ * byte-identical); the declaration this spec actually bites on is
+ * `.maka-session-panel { height: 100% }` — the definite height the whole
+ * minmax chain resolves against. Remove it and the panel grows to content
+ * height: the list stops overflowing and the footer lands far below the
+ * window (verified red run: footer bottom ~2521px in an 820px viewport).
+ * Before #1308 the only regression lock was a screenshot baseline that never
+ * ran in CI; #1308 retired the screenshot harness, leaving the geometry
+ * explicitly unlocked (issue #1311):
+ *   - `sidebar-scroll-contract.test.ts` is a static grep gate over the CSS
+ *     grid constraints (minmax / min-height); it does not pin `height: 100%`
+ *     and does not assert rendered footer-visibility geometry. The two layers
+ *     deliberately lock different declarations.
+ *   - `scroll-geometry.spec.ts` boots `long-transcript` and probes
+ *     `.maka-chatViewport`, not the sidebar.
+ *
+ * This spec is the rendered-geometry lock. It boots the `sidebar-long-sessions`
+ * fixture and asserts, against the live desktop shell:
+ *   (a) the sidebar list scroller actually overflows and scrolling it moves its
+ *       own scrollTop while the chat viewport's scrollTop is unaffected, and
+ *   (b) the footer's bounding rect stays fully inside both the sidebar panel
+ *       and the window viewport — before and after scrolling the list to the
+ *       bottom.
+ *
+ * Scroll-independence note: the scenario opens the newest session (`...-00`),
+ * whose transcript is a single short exchange, so the chat viewport does NOT
+ * overflow and its scrollTop is fixed at 0. Independence is therefore asserted
+ * in the form the seed makes meaningful — the sidebar list has its own
+ * overflowing scroll container whose scrollTop changes under a scroll, while
+ * the chat scroller's scrollTop stays put. If the panel loses its constrained
+ * height, the list stops being a constrained scroller (its own overflow
+ * collapses) and the footer leaves the viewport; both are caught below.
+ */
+
+const LIST_VIEWPORT = '.maka-list-stackViewport';
+const CHAT_VIEWPORT = '.maka-chatViewport';
+
+interface ScrollerMetrics {
+  scrollTop: number;
+  scrollHeight: number;
+  clientHeight: number;
+}
+
+interface Rect {
+  top: number;
+  right: number;
+  bottom: number;
+  left: number;
+  width: number;
+  height: number;
+}
+
+interface Geometry {
+  footer: Rect | null;
+  panel: Rect | null;
+  viewport: { width: number; height: number };
+  list: ScrollerMetrics | null;
+  chat: ScrollerMetrics | null;
+}
+
+async function readGeometry(page: Page): Promise<Geometry> {
+  return page.evaluate(() => {
+    const rect = (el: Element | null): Rect | null => {
+      if (!el) return null;
+      const { top, right, bottom, left, width, height } = el.getBoundingClientRect();
+      return { top, right, bottom, left, width, height };
+    };
+    const scroller = (el: Element | null): { scrollTop: number; scrollHeight: number; clientHeight: number } | null => {
+      if (!el) return null;
+      const node = el as HTMLElement;
+      return { scrollTop: node.scrollTop, scrollHeight: node.scrollHeight, clientHeight: node.clientHeight };
+    };
+    return {
+      footer: rect(document.querySelector('.maka-session-panel-footer')),
+      panel: rect(document.querySelector('.maka-session-panel')),
+      viewport: { width: window.innerWidth, height: window.innerHeight },
+      list: scroller(document.querySelector('.maka-list-stackViewport')),
+      chat: scroller(document.querySelector('.maka-chatViewport')),
+    };
+  });
+}
+
+// The footer must sit fully inside the sidebar panel AND inside the window
+// viewport. A 1px tolerance absorbs sub-pixel rounding between
+// getBoundingClientRect and the integer window metrics; the regression this
+// guards against pushes the footer hundreds of pixels past the window bottom,
+// so the tolerance never masks it.
+function expectFooterContained(geo: Geometry, label: string): void {
+  const diag = `${label}: ${JSON.stringify(geo)}`;
+  const { footer, panel, viewport } = geo;
+  expect(footer, diag).not.toBeNull();
+  expect(panel, diag).not.toBeNull();
+  if (!footer || !panel) return;
+  // A real, laid-out footer occupies space.
+  expect(footer.height, diag).toBeGreaterThan(0);
+  expect(footer.width, diag).toBeGreaterThan(0);
+  // Inside the sidebar panel.
+  expect(footer.top, diag).toBeGreaterThanOrEqual(panel.top - 1);
+  expect(footer.bottom, diag).toBeLessThanOrEqual(panel.bottom + 1);
+  expect(footer.left, diag).toBeGreaterThanOrEqual(panel.left - 1);
+  expect(footer.right, diag).toBeLessThanOrEqual(panel.right + 1);
+  // Inside the window viewport (the "not pushed off-screen" invariant).
+  expect(footer.top, diag).toBeGreaterThanOrEqual(0);
+  expect(footer.bottom, diag).toBeLessThanOrEqual(viewport.height + 1);
+  expect(footer.left, diag).toBeGreaterThanOrEqual(0);
+  expect(footer.right, diag).toBeLessThanOrEqual(viewport.width + 1);
+}
+
+// Drive the sidebar scroller to the bottom and poll until scrollTop settles.
+// No fixed sleep: OverlayScrollbars may clamp the assigned scrollTop over a
+// frame, so we re-assign and wait for two agreeing reads at the bottom edge.
+async function scrollListToBottom(page: Page): Promise<number> {
+  let previous = -1;
+  await expect
+    .poll(
+      async () => {
+        const metrics = await page.evaluate((selector) => {
+          const el = document.querySelector(selector) as HTMLElement | null;
+          if (!el) return null;
+          el.scrollTop = el.scrollHeight;
+          return {
+            scrollTop: Math.round(el.scrollTop),
+            scrollHeight: el.scrollHeight,
+            clientHeight: el.clientHeight,
+          };
+        }, LIST_VIEWPORT);
+        if (!metrics) return false;
+        const atBottom =
+          metrics.scrollTop > 0 &&
+          metrics.scrollTop === previous &&
+          Math.abs(metrics.scrollHeight - metrics.scrollTop - metrics.clientHeight) <= 2;
+        previous = metrics.scrollTop;
+        return atBottom;
+      },
+      { timeout: 10_000, intervals: [200] },
+    )
+    .toBe(true);
+  return previous;
+}
+
+test('sidebar list scrolls independently and keeps the footer in view with 60 sessions', async ({
+  sidebarLongSessionsWindow: page,
+}) => {
+  // (0) The fixture seeds 60 `sidebar-long-sessions` rows (named "会话 NN"),
+  // all rendered in the expanded panel. `seedE2eFixture` also always writes a
+  // handful of baseline chat sessions; their exact count is not this
+  // contract's concern — the 60-row pin alone proves the overflow
+  // precondition the geometry assertions depend on.
+  await expect(page.locator('.maka-list-row-main[title^="会话 "]')).toHaveCount(60);
+
+  // The list scroller and the chat scroller are distinct elements.
+  await expect(page.locator(LIST_VIEWPORT)).toHaveCount(1);
+  await expect(page.locator(CHAT_VIEWPORT)).toHaveCount(1);
+
+  // (1a) The sidebar list scroller actually overflows its constrained grid
+  // row — this is what makes it an independent scroll container. If the panel
+  // loses its constrained height, the row grows to content height and this
+  // never holds.
+  await expect
+    .poll(
+      async () => {
+        const geo = await readGeometry(page);
+        return geo.list ? geo.list.scrollHeight - geo.list.clientHeight : 0;
+      },
+      { timeout: 10_000, intervals: [200] },
+    )
+    .toBeGreaterThan(50);
+
+  // (b) Footer contained before any scrolling.
+  const before = await readGeometry(page);
+  expectFooterContained(before, 'initial');
+  expect(before.list, JSON.stringify(before)).not.toBeNull();
+  expect(before.chat, JSON.stringify(before)).not.toBeNull();
+  const chatScrollTopBefore = before.chat?.scrollTop ?? -1;
+  const listScrollTopBefore = before.list?.scrollTop ?? -1;
+  expect(listScrollTopBefore).toBe(0);
+
+  // (1b) Scroll the sidebar list to the bottom.
+  const settledListScrollTop = await scrollListToBottom(page);
+  expect(settledListScrollTop).toBeGreaterThan(0);
+
+  const after = await readGeometry(page);
+  const afterDiag = JSON.stringify(after);
+
+  // The sidebar's own scrollTop moved...
+  expect(after.list?.scrollTop ?? -1, afterDiag).toBeGreaterThan(listScrollTopBefore);
+  // ...while the chat viewport's scrollTop is unaffected (short transcript →
+  // stays pinned at 0). This is the scroll-independence lock for this seed.
+  expect(after.chat?.scrollTop ?? -1, afterDiag).toBe(chatScrollTopBefore);
+
+  // (b) Footer still fully inside the panel and the window after scrolling the
+  // list all the way down — the core "footer never gets pushed off-screen"
+  // invariant #1311 locks.
+  expectFooterContained(after, 'after-scroll-to-bottom');
+});


### PR DESCRIPTION
## Summary

Closes #1311.

#1308 retired the screenshot harness, leaving the sidebar footer-visibility geometry invariant (the P0 WAWQAQ flagged in msg `761141c5`) with no rendered regression lock: `sidebar-scroll-contract.test.ts` is a static grep gate over the CSS grid constraints, and `scroll-geometry.spec.ts` boots `long-transcript` and probes the chat viewport, not the sidebar.

This adds the rendered-geometry lock as a Playwright E2E: a new `sidebarLongSessionsWindow` fixture boots the `sidebar-long-sessions` scenario (60 seeded sessions, sidebar expanded), and `sidebar-geometry.spec.ts` asserts against the live shell that (a) the session list scroller actually overflows its constrained grid row and scrolling it moves only its own `scrollTop`, and (b) the footer (Settings + version) bounding rect stays fully inside both the sidebar panel and the window viewport, before and after scrolling the list to the bottom.

Notable finding from the red-proof work, now documented in the spec header: at this fixture size the historically-cited grid constraints (`min-height: 0` / `minmax(0, 1fr)`) are mutually redundant — the declaration this spec actually bites on is `.maka-session-panel { height: 100% }`, which the source-grep contract does not pin. The two layers deliberately lock different declarations.

Scroll-independence caveat, documented in the spec: the scenario's active session has a short transcript, so the chat viewport never overflows; independence is asserted as "list scrollTop moves, chat scrollTop stays 0" — the meaningful form for this seed.

Externally reviewed (Codex + Kimi K3, both PASS); the accepted finding — a row-total assertion that coupled the geometry contract to unrelated baseline seed sessions — has been removed.

## Verification

- New spec green: `npm --workspace @maka/desktop run e2e -- sidebar-geometry.spec.ts` → 1 passed (independently re-run by the reviewer session).
- Full e2e suite green: 32 passed.
- Non-vacuity (break-and-restore, never committed): removing `.maka-session-panel { height: 100% }` reproduces the exact #1311 regression (footer at `bottom=2520.9` vs the 820px window, list overflow collapsed to 0) and the spec fails on both locked assertions.
- `npm run format:check` and `npm run lint` clean.