### PR TITLE
fix(headless): complete Harbor task-run execution contract

### DIFF
--- a/packages/headless/harbor/maka_agent.py
+++ b/packages/headless/harbor/maka_agent.py
@@ -594,7 +594,6 @@ class MakaAgent(BaseInstalledAgent):
         _normalize_cli_env(env)
         env.setdefault("MAKA_REPO_DIR", str(self._host_repo_root()))
         env.setdefault("MAKA_MODEL", "deepseek-chat")
-        env.setdefault("MAKA_MAX_STEPS", "35")
         env.setdefault("MAKA_TASK_RUN_OUT_DIR", str(self.logs_dir / "maka-task-run"))
         env.setdefault("MAKA_CELL_ARTIFACT_DIR", str(self.logs_dir))
         task_run_out_dir = Path(env["MAKA_TASK_RUN_OUT_DIR"])

--- a/packages/headless/harbor/maka_agent.py
+++ b/packages/headless/harbor/maka_agent.py
@@ -1271,18 +1271,6 @@ def _normalize_cli_env(env: dict[str, str]) -> None:
     provider = env.get("MAKA_PROVIDER") or env.get("MAKA_PROVIDER_TYPE")
     if provider:
         env.setdefault("MAKA_PROVIDER", provider)
-    host_api_key = env.get("MAKA_HOST_API_KEY")
-    host_api_key_env_name = env.get("MAKA_HOST_API_KEY_ENV_NAME")
-    if (
-        host_api_key
-        and host_api_key_env_name
-        and re.fullmatch(r"[A-Z][A-Z0-9_]{0,127}", host_api_key_env_name)
-    ):
-        env.setdefault(host_api_key_env_name, host_api_key)
-    if env.get("MAKA_HOST_BASE_URL"):
-        env.setdefault("MAKA_BASE_URL", env["MAKA_HOST_BASE_URL"])
-    if env.get("MAKA_HOST_MODEL_API_PROTOCOL"):
-        env.setdefault("MAKA_MODEL_API_PROTOCOL", env["MAKA_HOST_MODEL_API_PROTOCOL"])
     if env.get("MAKA_API_KEY"):
         env.setdefault(
             _provider_api_key_env(env.get("MAKA_PROVIDER") or provider or "deepseek"),

--- a/packages/headless/harbor/maka_agent.py
+++ b/packages/headless/harbor/maka_agent.py
@@ -630,7 +630,7 @@ class MakaAgent(BaseInstalledAgent):
             },
         )
 
-        timeout_sec = int(env.get("MAKA_HARBOR_AGENT_TIMEOUT_SEC", "1800"))
+        timeout_sec = self._cell_timeout_sec()
         proc: asyncio.subprocess.Process | None = None
         async with _ToolExecutorServer(self, environment) as executor:
             env["MAKA_HARBOR_TOOL_EXECUTOR_URL"] = executor.url
@@ -1420,7 +1420,6 @@ def _runner_env_summary(env: dict[str, str]) -> dict[str, str]:
         "MAKA_CONTEXT_ACTIVE_FULL_COMPACT_ARCHIVE_REQUIRED",
         "MAKA_CONTEXT_ACTIVE_FULL_COMPACT_HIGH_WATER_NAME",
         "MAKA_CONTEXT_ARCHIVE_RETRIEVAL",
-        "MAKA_HARBOR_AGENT_TIMEOUT_SEC",
         "MAKA_HARBOR_MAX_ATTEMPTS",
         "MAKA_AUTONOMOUS_MAX_ATTEMPTS",
         "MAKA_AUTONOMOUS_MAX_RUNTIME_STEPS",

--- a/packages/headless/harbor/maka_agent.py
+++ b/packages/headless/harbor/maka_agent.py
@@ -596,6 +596,7 @@ class MakaAgent(BaseInstalledAgent):
         env.setdefault("MAKA_MODEL", "deepseek-chat")
         env.setdefault("MAKA_MAX_STEPS", "35")
         env.setdefault("MAKA_TASK_RUN_OUT_DIR", str(self.logs_dir / "maka-task-run"))
+        env.setdefault("MAKA_CELL_ARTIFACT_DIR", str(self.logs_dir))
         task_run_out_dir = Path(env["MAKA_TASK_RUN_OUT_DIR"])
         if not task_run_out_dir.is_absolute():
             task_run_out_dir = task_run_out_dir.resolve()

--- a/packages/headless/harbor/maka_agent.py
+++ b/packages/headless/harbor/maka_agent.py
@@ -1271,6 +1271,18 @@ def _normalize_cli_env(env: dict[str, str]) -> None:
     provider = env.get("MAKA_PROVIDER") or env.get("MAKA_PROVIDER_TYPE")
     if provider:
         env.setdefault("MAKA_PROVIDER", provider)
+    host_api_key = env.get("MAKA_HOST_API_KEY")
+    host_api_key_env_name = env.get("MAKA_HOST_API_KEY_ENV_NAME")
+    if (
+        host_api_key
+        and host_api_key_env_name
+        and re.fullmatch(r"[A-Z][A-Z0-9_]{0,127}", host_api_key_env_name)
+    ):
+        env.setdefault(host_api_key_env_name, host_api_key)
+    if env.get("MAKA_HOST_BASE_URL"):
+        env.setdefault("MAKA_BASE_URL", env["MAKA_HOST_BASE_URL"])
+    if env.get("MAKA_HOST_MODEL_API_PROTOCOL"):
+        env.setdefault("MAKA_MODEL_API_PROTOCOL", env["MAKA_HOST_MODEL_API_PROTOCOL"])
     if env.get("MAKA_API_KEY"):
         env.setdefault(
             _provider_api_key_env(env.get("MAKA_PROVIDER") or provider or "deepseek"),

--- a/packages/headless/harbor/maka_agent.py
+++ b/packages/headless/harbor/maka_agent.py
@@ -84,6 +84,14 @@ _HOST_NODE_ENV_ALLOWLIST = {
     "COMSPEC",
 }
 
+_HOST_PROVIDER_AUTHORITY_ENV_KEYS = (
+    "MAKA_HOST_API_KEY",
+    "MAKA_HOST_API_KEY_FILE",
+    "MAKA_HOST_NO_AUTH",
+    "MAKA_HOST_BASE_URL",
+    "MAKA_HOST_MODEL_API_PROTOCOL",
+)
+
 def _host_node_process_env(cell_env: dict[str, str]) -> dict[str, str]:
     env = {key: value for key in _HOST_NODE_ENV_ALLOWLIST if (value := os.environ.get(key))}
     env.update(cell_env)
@@ -393,7 +401,7 @@ class MakaAgent(BaseInstalledAgent):
         env["MAKA_HARBOR_TOOL_EXECUTOR_URL"] = executor.url
         env["MAKA_HARBOR_TOOL_EXECUTOR_TOKEN"] = executor.token
         env["MAKA_CELL_SOFT_TIMEOUT_MS"] = str(self._cell_soft_timeout_ms())
-        for key in ("MAKA_HOST_API_KEY", "MAKA_HOST_API_KEY_FILE", "MAKA_HOST_API_KEY_ENV_NAME", "MAKA_HOST_BASE_URL"):
+        for key in _HOST_PROVIDER_AUTHORITY_ENV_KEYS:
             value = self._get_env(key)
             if value:
                 env[key] = value

--- a/packages/headless/harbor/maka_agent.py
+++ b/packages/headless/harbor/maka_agent.py
@@ -293,7 +293,7 @@ class MakaAgent(BaseInstalledAgent):
     _DEFAULT_CELL_TIMEOUT_SEC = 900
     _DEFAULT_CELL_SETTLEMENT_GRACE_SEC = 30
 
-    def _cell_timeout_sec(self) -> int:
+    def _cell_timeout_sec(self, env: dict[str, str] | None = None) -> int:
         """Wall-clock budget for the in-container cell. A hard-coded value turns
         slow-but-healthy tasks into infra failures, so the operator can raise it
         via MAKA_CELL_TIMEOUT_SEC; a malformed value falls back to the default.
@@ -305,7 +305,11 @@ class MakaAgent(BaseInstalledAgent):
         strings are valid: "1e3", "1.0", "+1800", "01800", "1٢", and over-long
         digit strings all fall back to the default.
         """
-        raw = self._get_env("MAKA_CELL_TIMEOUT_SEC")
+        raw = (
+            env.get("MAKA_CELL_TIMEOUT_SEC")
+            if env is not None
+            else self._get_env("MAKA_CELL_TIMEOUT_SEC")
+        )
         if not raw:
             return self._DEFAULT_CELL_TIMEOUT_SEC
         stripped = raw.strip()
@@ -319,8 +323,12 @@ class MakaAgent(BaseInstalledAgent):
             return self._DEFAULT_CELL_TIMEOUT_SEC
         return value if value <= _MAX_SAFE_INTEGER else self._DEFAULT_CELL_TIMEOUT_SEC
 
-    def _cell_settlement_grace_sec(self) -> int:
-        raw = self._get_env("MAKA_CELL_SETTLEMENT_GRACE_SEC")
+    def _cell_settlement_grace_sec(self, env: dict[str, str] | None = None) -> int:
+        raw = (
+            env.get("MAKA_CELL_SETTLEMENT_GRACE_SEC")
+            if env is not None
+            else self._get_env("MAKA_CELL_SETTLEMENT_GRACE_SEC")
+        )
         if not raw:
             return self._DEFAULT_CELL_SETTLEMENT_GRACE_SEC
         try:
@@ -329,9 +337,9 @@ class MakaAgent(BaseInstalledAgent):
             return self._DEFAULT_CELL_SETTLEMENT_GRACE_SEC
         return value if value > 0 else self._DEFAULT_CELL_SETTLEMENT_GRACE_SEC
 
-    def _cell_soft_timeout_ms(self) -> int:
-        timeout_sec = self._cell_timeout_sec()
-        grace_sec = self._cell_settlement_grace_sec()
+    def _cell_soft_timeout_ms(self, env: dict[str, str] | None = None) -> int:
+        timeout_sec = self._cell_timeout_sec(env)
+        grace_sec = self._cell_settlement_grace_sec(env)
         if grace_sec >= timeout_sec:
             raise RuntimeError(
                 "MAKA_CELL_SETTLEMENT_GRACE_SEC must be smaller than MAKA_CELL_TIMEOUT_SEC"
@@ -612,6 +620,7 @@ class MakaAgent(BaseInstalledAgent):
         # MAKA_TASK_RUN_OUT_DIR; re-apply now that the out dir is finalized.
         env.setdefault("MAKA_OUTPUT_DIR", str(task_run_out_dir))
         env.setdefault("MAKA_STORAGE_ROOT", str(task_run_out_dir / "runs"))
+        env["MAKA_CELL_SOFT_TIMEOUT_MS"] = str(self._cell_soft_timeout_ms(env))
 
         task_workdir, workdir_probe = await self._resolve_task_workdir(environment)
 
@@ -638,7 +647,7 @@ class MakaAgent(BaseInstalledAgent):
             },
         )
 
-        timeout_sec = self._cell_timeout_sec()
+        timeout_sec = self._cell_timeout_sec(env)
         proc: asyncio.subprocess.Process | None = None
         async with _ToolExecutorServer(self, environment) as executor:
             env["MAKA_HARBOR_TOOL_EXECUTOR_URL"] = executor.url
@@ -737,7 +746,13 @@ class MakaAgent(BaseInstalledAgent):
         self._write_status(
             status_path,
             {
-                "status": "completed" if proc.returncode == 0 else "failed",
+                "status": (
+                    "completed"
+                    if proc.returncode == 0
+                    else "budget_exhausted"
+                    if proc.returncode == 124
+                    else "failed"
+                ),
                 "startedAt": started_at,
                 "finishedAt": _utc_now(),
                 "runnerPid": proc.pid,
@@ -787,7 +802,9 @@ class MakaAgent(BaseInstalledAgent):
             context.n_cache_tokens = _int_or_none(usage.get("cacheHitInput"))
             context.n_output_tokens = _int_or_none(usage.get("output"))
 
-        if proc.returncode != 0:
+        if proc.returncode != 0 and not (
+            proc.returncode == 124 and parsed.get("settledByDeadline") is True
+        ):
             raise RuntimeError(f"Maka Harbor task-run failed; see {stderr_path}")
 
     async def _resolve_task_workdir(
@@ -1432,6 +1449,9 @@ def _runner_env_summary(env: dict[str, str]) -> dict[str, str]:
         "MAKA_AUTONOMOUS_MAX_ATTEMPTS",
         "MAKA_AUTONOMOUS_MAX_RUNTIME_STEPS",
         "MAKA_AUTONOMOUS_MAX_WALL_TIME_MS",
+        "MAKA_CELL_TIMEOUT_SEC",
+        "MAKA_CELL_SOFT_TIMEOUT_MS",
+        "MAKA_CELL_SETTLEMENT_GRACE_SEC",
     ]
     return {key: env[key] for key in allowed_keys if key in env}
 

--- a/packages/headless/harbor/maka_agent.py
+++ b/packages/headless/harbor/maka_agent.py
@@ -102,6 +102,7 @@ def _host_node_process_env(cell_env: dict[str, str]) -> dict[str, str]:
 # agree on the upper bound for MAKA_CELL_TIMEOUT_SEC; an over-long digit string
 # is malformed, not a giant timeout.
 _MAX_SAFE_INTEGER = 9007199254740991
+_MAX_NODE_TIMER_MS = 2_147_483_647
 # ASCII decimal positive integer literal only; [0-9] (not \d) rejects Unicode
 # digits on both sides. Matches the TS host's lenientPositiveIntEnv.
 _POSITIVE_INT_RE = re.compile(r"[1-9][0-9]*")
@@ -344,7 +345,13 @@ class MakaAgent(BaseInstalledAgent):
             raise RuntimeError(
                 "MAKA_CELL_SETTLEMENT_GRACE_SEC must be smaller than MAKA_CELL_TIMEOUT_SEC"
             )
-        return (timeout_sec - grace_sec) * 1000
+        soft_timeout_ms = (timeout_sec - grace_sec) * 1000
+        if soft_timeout_ms > _MAX_NODE_TIMER_MS:
+            raise RuntimeError(
+                "MAKA_CELL_SOFT_TIMEOUT_MS exceeds the Node timer limit "
+                f"of {_MAX_NODE_TIMER_MS}ms"
+            )
+        return soft_timeout_ms
 
     def _host_side_llm_enabled(self) -> bool:
         return bool(

--- a/packages/headless/harbor/run-harness-ab.mjs
+++ b/packages/headless/harbor/run-harness-ab.mjs
@@ -123,7 +123,6 @@ export const HARNESS_COMPETITOR_PROFILES = Object.freeze({
       model: 'gpt-5.6-sol',
       reasoningEffort: 'xhigh',
       baseUrl: 'https://chatgpt.com/backend-api/codex',
-      apiKeyEnvName: 'OPENAI_CODEX_OAUTH_TOKEN',
       billingMode: 'account-plan',
       pricing: Object.freeze({
         currency: 'USD',
@@ -161,7 +160,6 @@ export function resolveHarnessRuntimeProfile(competitorProfile) {
       model: MODEL,
       reasoningEffort: REASONING_EFFORT,
       baseUrl: BASE_URL,
-      apiKeyEnvName: 'ANTHROPIC_API_KEY',
       billingMode: BILLING_MODE,
       pricing: PRICING,
     }
@@ -183,7 +181,6 @@ export function buildHarnessExecutionProfile(competitorProfile) {
     model: runtime.model,
     reasoningEffort: runtime.reasoningEffort,
     baseUrl: runtime.baseUrl,
-    apiKeyEnvName: runtime.apiKeyEnvName,
     billingMode: runtime.billingMode,
     pricing: {
       inputUsdPer1M: runtime.pricing.input,
@@ -640,7 +637,6 @@ async function runLocked({
     provider: execution.provider,
     reasoningEffort: execution.reasoningEffort,
     ...credentials,
-    apiKeyEnvName: execution.apiKeyEnvName,
     pricing: execution.pricing,
     agentEnv: { MAKA_BASE_URL: execution.baseUrl },
     timeoutMultiplier: 1,

--- a/packages/headless/harbor/run-host-cell.mjs
+++ b/packages/headless/harbor/run-host-cell.mjs
@@ -3,7 +3,7 @@
 import { readFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { pathToFileURL } from 'node:url';
-import { providerAuthRequiresSecret, providerAuthSupportsApiKey } from '@maka/core/llm-connections';
+import { providerAuthRequiresSecret } from '@maka/core/llm-connections';
 import {
   buildAiSdkCellBackendRegistration,
   buildHarborCellContextBudgetPolicySnapshot,
@@ -14,7 +14,7 @@ import {
   harborCellSoftTimeoutMsFromEnv,
   normalizeHarborCellContextEnv,
   reasoningEffortFromEnv,
-  resolveHostProviderAuthorityEnv,
+  resolveHostProviderAuthority,
   runHarborCell,
   writeHarborCellUsageCheckpoint,
 } from '#harbor-cell';
@@ -119,16 +119,14 @@ export async function backendEnv(env, provider) {
   const result = {
     MAKA_LLM_CONNECTION_SLUG: env.MAKA_LLM_CONNECTION_SLUG || provider,
   };
-  const hasHostApiKey = Boolean(env.MAKA_HOST_API_KEY || env.MAKA_HOST_API_KEY_FILE);
-  if (
-    providerAuthRequiresSecret(provider) ||
-    (providerAuthSupportsApiKey(provider) && hasHostApiKey)
-  ) {
-    if (!hasHostApiKey) {
-      throw new Error('MAKA_HOST_API_KEY_FILE is required for host-side Harbor cells');
-    }
+  const authority = resolveHostProviderAuthority(env);
+  if (providerAuthRequiresSecret(provider) && authority.auth.kind !== 'credential') {
+    throw new Error('MAKA_HOST_API_KEY_FILE is required for host-side Harbor cells');
   }
-  Object.assign(result, resolveHostProviderAuthorityEnv({ provider, env }));
+  if (authority.auth.kind === 'credential') result.MAKA_HOST_API_KEY = authority.auth.apiKey;
+  if (authority.auth.kind === 'none') result.MAKA_HOST_NO_AUTH = 'true';
+  if (authority.baseUrl) result.MAKA_HOST_BASE_URL = authority.baseUrl;
+  if (authority.apiProtocol) result.MAKA_HOST_MODEL_API_PROTOCOL = authority.apiProtocol;
   for (const key of HOST_BACKEND_ENV_KEYS) {
     if (env[key] !== undefined) result[key] = env[key];
   }

--- a/packages/headless/harbor/run-host-cell.mjs
+++ b/packages/headless/harbor/run-host-cell.mjs
@@ -13,8 +13,8 @@ import {
   harborCellMaxStepsFromEnv,
   harborCellSoftTimeoutMsFromEnv,
   normalizeHarborCellContextEnv,
-  providerApiKeyEnvName,
   reasoningEffortFromEnv,
+  resolveHostProviderAuthorityEnv,
   runHarborCell,
   writeHarborCellUsageCheckpoint,
 } from '#harbor-cell';
@@ -124,24 +124,16 @@ export async function backendEnv(env, provider) {
     providerAuthRequiresSecret(provider) ||
     (providerAuthSupportsApiKey(provider) && hasHostApiKey)
   ) {
-    const keyEnvName = env.MAKA_HOST_API_KEY_ENV_NAME || providerApiKeyEnvName(provider);
-    result[keyEnvName] = await hostApiKey(env);
+    if (!hasHostApiKey) {
+      throw new Error('MAKA_HOST_API_KEY_FILE is required for host-side Harbor cells');
+    }
   }
-  if (env.MAKA_HOST_BASE_URL) result.MAKA_BASE_URL = env.MAKA_HOST_BASE_URL;
-  if (env.MAKA_HOST_MODEL_API_PROTOCOL)
-    result.MAKA_MODEL_API_PROTOCOL = env.MAKA_HOST_MODEL_API_PROTOCOL;
+  Object.assign(result, resolveHostProviderAuthorityEnv({ provider, env }));
   for (const key of HOST_BACKEND_ENV_KEYS) {
     if (env[key] !== undefined) result[key] = env[key];
   }
   Object.assign(result, contextEnv);
   return result;
-}
-
-async function hostApiKey(env) {
-  if (env.MAKA_HOST_API_KEY) return env.MAKA_HOST_API_KEY;
-  if (env.MAKA_HOST_API_KEY_FILE)
-    return (await readFile(env.MAKA_HOST_API_KEY_FILE, 'utf8')).trim();
-  throw new Error('MAKA_HOST_API_KEY_FILE is required for host-side Harbor cells');
 }
 
 async function instructionFromEnv(env) {

--- a/packages/headless/harbor/run-terminal-bench-smoke.mjs
+++ b/packages/headless/harbor/run-terminal-bench-smoke.mjs
@@ -44,7 +44,7 @@ Options:
   --job-name NAME             Harbor job name (default: generated with timestamp)
   --model MODEL               Override model. For Maka this sets MAKA_MODEL; for OpenCode it sets model_name.
   --steps N                   Override MAKA_MAX_STEPS for Maka profiles
-  --agent-timeout-sec N       Override MAKA_HARBOR_AGENT_TIMEOUT_SEC for Maka profiles
+  --agent-timeout-sec N       Override MAKA_CELL_TIMEOUT_SEC for Maka profiles
   --dataset NAME              Override dataset name (default: terminal-bench-sample)
   --dataset-version VERSION   Override dataset version (default: 2.0)
   --dry-run                   Generate and print config path/command without running Harbor

--- a/packages/headless/harbor/terminal-bench-smoke-profiles.json
+++ b/packages/headless/harbor/terminal-bench-smoke-profiles.json
@@ -27,7 +27,7 @@
           "MAKA_HARBOR_AUTONOMOUS": "0",
           "MAKA_MODEL": "deepseek-v4-pro",
           "MAKA_MAX_STEPS": "80",
-          "MAKA_HARBOR_AGENT_TIMEOUT_SEC": "3600"
+          "MAKA_CELL_TIMEOUT_SEC": "3600"
         }
       }
     },
@@ -43,7 +43,7 @@
           "MAKA_HEAVY_TASK_MODE": "1",
           "MAKA_MODEL": "deepseek-v4-pro",
           "MAKA_MAX_STEPS": "100",
-          "MAKA_HARBOR_AGENT_TIMEOUT_SEC": "7200"
+          "MAKA_CELL_TIMEOUT_SEC": "7200"
         }
       }
     },
@@ -73,7 +73,7 @@
           "MAKA_MODEL": "deepseek-v4-pro",
           "MAKA_MAX_STEPS": "100",
           "MAKA_AUTONOMOUS_MAX_ATTEMPTS": "3",
-          "MAKA_HARBOR_AGENT_TIMEOUT_SEC": "7200"
+          "MAKA_CELL_TIMEOUT_SEC": "7200"
         }
       }
     },
@@ -91,7 +91,7 @@
           "MAKA_HARBOR_CONTINUATION_MAX_TOTAL_RUNTIME_STEPS": "150",
           "MAKA_MODEL": "deepseek-v4-pro",
           "MAKA_MAX_STEPS": "50",
-          "MAKA_HARBOR_AGENT_TIMEOUT_SEC": "3600"
+          "MAKA_CELL_TIMEOUT_SEC": "3600"
         }
       }
     },
@@ -110,7 +110,7 @@
           "MAKA_CONTEXT_STALE_TOOL_RESULT_PRUNE": "off",
           "MAKA_MODEL": "deepseek-v4-pro",
           "MAKA_MAX_STEPS": "50",
-          "MAKA_HARBOR_AGENT_TIMEOUT_SEC": "3600"
+          "MAKA_CELL_TIMEOUT_SEC": "3600"
         }
       }
     },
@@ -129,7 +129,7 @@
           "MAKA_CONTEXT_ARCHIVE_RETRIEVAL": "on",
           "MAKA_MODEL": "deepseek-v4-pro",
           "MAKA_MAX_STEPS": "50",
-          "MAKA_HARBOR_AGENT_TIMEOUT_SEC": "3600"
+          "MAKA_CELL_TIMEOUT_SEC": "3600"
         }
       }
     },

--- a/packages/headless/src/__tests__/autonomous-agent-loop.test.ts
+++ b/packages/headless/src/__tests__/autonomous-agent-loop.test.ts
@@ -15,6 +15,7 @@ import type { BackendSendInput, PermissionDecision } from '@maka/core/backend-ty
 import type { Config, Task } from '../contracts.js';
 import type { HeadlessBackendContext } from '../isolation.js';
 import { runAutonomousTask } from '../autonomous-agent-loop.js';
+import { countRuntimeSteps } from '../cell-output.js';
 
 const fakeConfig: Config = {
   id: 'fake-cfg',
@@ -118,12 +119,14 @@ class PromptCapturingProgressBackend implements AgentBackend {
     private readonly progress: HeadlessBackendContext['heavyTaskProgress'],
     private readonly evidence: HeadlessBackendContext['heavyTaskEvidence'],
     private readonly prompts: string[],
+    private readonly runtimeContextCounts?: number[],
   ) {
     this.sessionId = sessionId;
   }
 
   async *send(input: BackendSendInput): AsyncIterable<SessionEvent> {
     this.prompts.push(input.text);
+    this.runtimeContextCounts?.push(input.runtimeContext?.length ?? 0);
     if (this.prompts.length === 1 && this.progress) {
       const toolCtx = {
         sessionId: this.sessionId,
@@ -177,7 +180,7 @@ class PromptCapturingProgressBackend implements AgentBackend {
 }
 
 const registerPromptCapturingProgressBackend =
-  (prompts: string[]) =>
+  (prompts: string[], runtimeContextCounts?: number[]) =>
   (registry: BackendRegistry, context: HeadlessBackendContext): void => {
     registry.register(
       'fake',
@@ -187,6 +190,7 @@ const registerPromptCapturingProgressBackend =
           context.heavyTaskProgress,
           context.heavyTaskEvidence,
           prompts,
+          runtimeContextCounts,
         ),
     );
   };
@@ -340,6 +344,33 @@ describe('runAutonomousTask', () => {
         (runtimeContextCounts[1] ?? 0) > 0,
         'expected second attempt to receive prior runtime events',
       );
+    });
+  });
+
+  test('replays every invocation from a heavy-task attempt and counts only runtime steps', async () => {
+    await withDirs(async (fixtureDir, storageRoot) => {
+      const prompts: string[] = [];
+      const runtimeContextCounts: number[] = [];
+      const task: Task = {
+        id: 'replay-heavy-attempt-trajectory',
+        instruction: 'do the thing',
+        workspaceDir: fixtureDir,
+        verification: { command: 'test -f missing.txt', protectedPaths: [] },
+      };
+
+      const result = await runAutonomousTask({ ...fakeConfig, heavyTaskMode: true }, task, {
+        storageRoot,
+        registerBackends: registerPromptCapturingProgressBackend(prompts, runtimeContextCounts),
+        replayPriorAttemptRuntimeContext: true,
+        budget: { maxAttempts: 2 },
+        newId: idFactory(),
+      });
+
+      const firstAttempt = result.attempts[0]!;
+      assert.equal(firstAttempt.invocations.length, 2);
+      const firstTrajectory = firstAttempt.invocations.flatMap((invocation) => invocation.events);
+      assert.equal(runtimeContextCounts[2], firstTrajectory.length);
+      assert.equal(firstAttempt.resultRecord.steps, countRuntimeSteps(firstTrajectory));
     });
   });
 

--- a/packages/headless/src/__tests__/autonomous-agent-loop.test.ts
+++ b/packages/headless/src/__tests__/autonomous-agent-loop.test.ts
@@ -504,6 +504,31 @@ describe('runAutonomousTask', () => {
     });
   });
 
+  test('a benchmark deadline cannot park for budget extension', async () => {
+    await withDirs(async (fixtureDir, storageRoot) => {
+      const task: Task = {
+        id: 'benchmark-deadline-park',
+        instruction: 'must not start',
+        workspaceDir: fixtureDir,
+        verification: { command: 'true', protectedPaths: [] },
+      };
+
+      const result = await runAutonomousTask(fakeConfig, task, {
+        storageRoot,
+        registerBackends: registerFakeBackend,
+        budget: { maxAttempts: 2 },
+        interventionPolicy: { mode: 'park', allowBudgetExtensionRequests: true },
+        deadlineAtMs: Date.now() - 1,
+        newId: idFactory(),
+      });
+
+      assert.equal(result.attempts.at(-1)?.settledByDeadline, true);
+      assert.equal(result.projection.status, 'budget_exhausted');
+      assert.equal(result.projection.events.at(-1)?.type, 'task_run_budget_exhausted');
+      assert.equal(result.projection.parked, undefined);
+    });
+  });
+
   test('maxWallTimeMs admits the first attempt but prevents another one', async () => {
     await withDirs(async (fixtureDir, storageRoot) => {
       const task: Task = {

--- a/packages/headless/src/__tests__/autonomous-agent-loop.test.ts
+++ b/packages/headless/src/__tests__/autonomous-agent-loop.test.ts
@@ -504,7 +504,7 @@ describe('runAutonomousTask', () => {
     });
   });
 
-  test('maxWallTimeMs fails closed before starting another attempt', async () => {
+  test('maxWallTimeMs admits the first attempt but prevents another one', async () => {
     await withDirs(async (fixtureDir, storageRoot) => {
       const task: Task = {
         id: 'wall-cap',
@@ -525,9 +525,9 @@ describe('runAutonomousTask', () => {
         newId: idFactory(),
       });
 
-      assert.equal(result.attempts.length, 0);
+      assert.equal(result.attempts.length, 1);
       assert.equal(result.projection.status, 'budget_exhausted');
-      assert.equal(result.projection.feedback[0]?.source, 'system');
+      assert.equal(result.projection.decisions[0]?.reason, 'wall time cap reached');
       assert.equal(result.projection.error?.class, 'budget_exhausted');
     });
   });

--- a/packages/headless/src/__tests__/cli.test.ts
+++ b/packages/headless/src/__tests__/cli.test.ts
@@ -227,6 +227,54 @@ describe('maka-headless CLI', () => {
     }
   });
 
+  test('harbor run cell forwards its soft timeout to execution', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'maka-headless-harbor-cli-'));
+    try {
+      const fixture = join(dir, 'fixture');
+      const outDir = join(dir, 'out');
+      const storageRoot = join(dir, 'storage');
+      await mkdir(fixture, { recursive: true });
+
+      const result = await runCli(
+        [
+          'harbor',
+          'run',
+          '--mode',
+          'cell',
+          '--backend',
+          'fake',
+          '--isolation',
+          'none',
+          '--instruction',
+          'keep working',
+          '--workdir',
+          fixture,
+          '--out',
+          outDir,
+          '--storage-root',
+          storageRoot,
+        ],
+        {
+          env: {
+            MAKA_MODEL: 'fake-model',
+            MAKA_CELL_SOFT_TIMEOUT_MS: '50',
+          },
+        },
+      );
+
+      assert.equal(result.code, 1, result.stderr);
+      const cell = validateHarborCellOutput(
+        JSON.parse(await readFile(join(outDir, 'maka-cell-output.json'), 'utf8')),
+      );
+      assert.deepEqual(cell.deadlineSettlement, {
+        source: 'benchmark.deadline',
+        mode: 'immediate',
+      });
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
   test('harbor run task-run writes external Harbor verifier export without fake verifier authority', async () => {
     const dir = await mkdtemp(join(tmpdir(), 'maka-headless-harbor-cli-'));
     try {

--- a/packages/headless/src/__tests__/cli.test.ts
+++ b/packages/headless/src/__tests__/cli.test.ts
@@ -367,6 +367,15 @@ describe('maka-headless CLI', () => {
 
       assert.equal(cell.steps, 2);
       assert.equal(completedModelSteps.length, 2);
+      const traceEvents = (await readFile(join(cellArtifactDir, 'trace-events.jsonl'), 'utf8'))
+        .trim()
+        .split('\n')
+        .map((line) => JSON.parse(line));
+      assert.equal(
+        new Set(traceEvents.map((event) => event.runId).filter(Boolean)).size,
+        2,
+        'combined trace must retain both heavy-task runs',
+      );
     } finally {
       await rm(dir, { recursive: true, force: true });
     }

--- a/packages/headless/src/__tests__/cli.test.ts
+++ b/packages/headless/src/__tests__/cli.test.ts
@@ -321,6 +321,57 @@ describe('maka-headless CLI', () => {
     }
   });
 
+  test('harbor run task-run cell evidence covers every heavy-task invocation', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'maka-headless-harbor-heavy-'));
+    try {
+      const fixture = join(dir, 'fixture');
+      const outDir = join(dir, 'out');
+      const cellArtifactDir = join(dir, 'cell-artifacts');
+      await mkdir(fixture, { recursive: true });
+      await writeFile(join(fixture, 'README.txt'), 'Harbor owns the task workspace.\n', 'utf8');
+
+      const result = await runCli(
+        [
+          'harbor',
+          'run',
+          '--backend',
+          'fake',
+          '--isolation',
+          'none',
+          '--instruction',
+          'solve it',
+          '--workdir',
+          fixture,
+          '--task-id',
+          'tb-heavy-trajectory',
+          '--task-run-id',
+          'harbor-heavy-trajectory',
+          '--out',
+          outDir,
+          '--heavy-task',
+        ],
+        { env: { MAKA_CELL_ARTIFACT_DIR: cellArtifactDir, MAKA_MODEL: 'fake-model' } },
+      );
+      assert.equal(result.code, 0, result.stderr);
+
+      const cell = validateHarborCellOutput(
+        JSON.parse(await readFile(join(cellArtifactDir, 'maka-cell-output.json'), 'utf8')),
+      );
+      const runtimeEvents = (await readFile(cell.runtimeEventsPath, 'utf8'))
+        .trim()
+        .split('\n')
+        .map((line) => JSON.parse(line));
+      const completedModelSteps = runtimeEvents.filter(
+        (event) => event.role === 'model' && event.partial !== true,
+      );
+
+      assert.equal(cell.steps, 2);
+      assert.equal(completedModelSteps.length, 2);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
   test('harbor run task-run honors an explicit benchmark dataset override', async () => {
     const dir = await mkdtemp(join(tmpdir(), 'maka-headless-harbor-cli-'));
     try {

--- a/packages/headless/src/__tests__/cli.test.ts
+++ b/packages/headless/src/__tests__/cli.test.ts
@@ -283,6 +283,7 @@ describe('maka-headless CLI', () => {
       assert.equal(cell.executionIdentity?.reasoningEffort, 'xhigh');
       assert.equal(cell.executionIdentity?.pricingProfile, 'test-account-plan');
       assert.equal(cell.toolSummary.actualToolCalls, 0);
+      assert.equal(cell.steps, 1);
       assert.equal(cell.runtimeEventsPath, join(cellArtifactDir, 'runtime-events.jsonl'));
       assert.match(await readFile(cell.runtimeEventsPath, 'utf8'), /"role":"system"/);
       const durableIdentity = JSON.parse(

--- a/packages/headless/src/__tests__/cli.test.ts
+++ b/packages/headless/src/__tests__/cli.test.ts
@@ -232,6 +232,7 @@ describe('maka-headless CLI', () => {
     try {
       const fixture = join(dir, 'fixture');
       const outDir = join(dir, 'out');
+      const cellArtifactDir = join(dir, 'cell-artifacts');
       await mkdir(fixture, { recursive: true });
       await writeFile(join(fixture, 'README.txt'), 'Harbor owns the task workspace.\n', 'utf8');
 
@@ -258,6 +259,7 @@ describe('maka-headless CLI', () => {
         {
           env: {
             MAKA_ECONOMY_TASK_MODE: 'true',
+            MAKA_CELL_ARTIFACT_DIR: cellArtifactDir,
             MAKA_MODEL: 'fake-model',
             MAKA_REASONING_EFFORT: 'xhigh',
             MAKA_TRIAL_PRICING_SOURCE: 'test-account-plan',
@@ -272,7 +274,7 @@ describe('maka-headless CLI', () => {
       assert.equal(summary.authoritative, false);
 
       const cell = validateHarborCellOutput(
-        JSON.parse(await readFile(join(outDir, 'maka-cell-output.json'), 'utf8')),
+        JSON.parse(await readFile(join(cellArtifactDir, 'maka-cell-output.json'), 'utf8')),
       );
       assert.equal(cell.status, 'completed');
       assert.equal(cell.promptHash, cell.executionIdentity?.systemPromptHash);
@@ -281,8 +283,12 @@ describe('maka-headless CLI', () => {
       assert.equal(cell.executionIdentity?.reasoningEffort, 'xhigh');
       assert.equal(cell.executionIdentity?.pricingProfile, 'test-account-plan');
       assert.equal(cell.toolSummary.actualToolCalls, 0);
-      assert.equal(cell.runtimeEventsPath, join(outDir, 'runtime-events.jsonl'));
+      assert.equal(cell.runtimeEventsPath, join(cellArtifactDir, 'runtime-events.jsonl'));
       assert.match(await readFile(cell.runtimeEventsPath, 'utf8'), /"role":"system"/);
+      const durableIdentity = JSON.parse(
+        await readFile(join(cellArtifactDir, 'maka-cell-execution-identity.json'), 'utf8'),
+      );
+      assert.deepEqual(durableIdentity, cell.executionIdentity);
 
       const taskRunJson = JSON.parse(
         await readFile(join(outDir, 'exports', 'harbor-run-1', 'task-run.json'), 'utf8'),

--- a/packages/headless/src/__tests__/cli.test.ts
+++ b/packages/headless/src/__tests__/cli.test.ts
@@ -6,6 +6,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { describe, test } from 'node:test';
+import { validateHarborCellOutput } from '../cell-output.js';
 import { mapLegacyMakaHeadlessArgs } from '../cli.js';
 import { readResults } from '../results.js';
 
@@ -254,7 +255,14 @@ describe('maka-headless CLI', () => {
           outDir,
           '--include-events',
         ],
-        { env: { MAKA_ECONOMY_TASK_MODE: 'true' } },
+        {
+          env: {
+            MAKA_ECONOMY_TASK_MODE: 'true',
+            MAKA_MODEL: 'fake-model',
+            MAKA_REASONING_EFFORT: 'xhigh',
+            MAKA_TRIAL_PRICING_SOURCE: 'test-account-plan',
+          },
+        },
       );
       assert.equal(result.code, 0, result.stderr);
       const summary = JSON.parse(result.stdout);
@@ -262,6 +270,19 @@ describe('maka-headless CLI', () => {
       assert.equal(summary.mode, 'task-run');
       assert.equal(summary.scored, false);
       assert.equal(summary.authoritative, false);
+
+      const cell = validateHarborCellOutput(
+        JSON.parse(await readFile(join(outDir, 'maka-cell-output.json'), 'utf8')),
+      );
+      assert.equal(cell.status, 'completed');
+      assert.equal(cell.promptHash, cell.executionIdentity?.systemPromptHash);
+      assert.equal(cell.executionIdentity?.llmConnectionSlug, 'fake');
+      assert.equal(cell.executionIdentity?.model, 'fake-model');
+      assert.equal(cell.executionIdentity?.reasoningEffort, 'xhigh');
+      assert.equal(cell.executionIdentity?.pricingProfile, 'test-account-plan');
+      assert.equal(cell.toolSummary.actualToolCalls, 0);
+      assert.equal(cell.runtimeEventsPath, join(outDir, 'runtime-events.jsonl'));
+      assert.match(await readFile(cell.runtimeEventsPath, 'utf8'), /"role":"system"/);
 
       const taskRunJson = JSON.parse(
         await readFile(join(outDir, 'exports', 'harbor-run-1', 'task-run.json'), 'utf8'),

--- a/packages/headless/src/__tests__/harbor-adapter.test.ts
+++ b/packages/headless/src/__tests__/harbor-adapter.test.ts
@@ -389,6 +389,20 @@ describe('Harbor adapter contract', () => {
     assert.match(result.stdout, /bridge-contract ok/);
   });
 
+  test('maka_agent.py task-run maps host proxy authority into backend env', (t: TestContext) => {
+    const python = harborPython();
+    if (!python) {
+      t.skip('Harbor 0.13.2 python is not available (CI has no harbor)');
+      return;
+    }
+    const result = spawnSync(python, ['-c', pythonTaskRunHostProxyContractScript(repoRoot)], {
+      cwd: repoRoot,
+      encoding: 'utf8',
+    });
+    assert.equal(result.status, 0, result.stderr);
+    assert.match(result.stdout, /task-run-host-proxy-contract ok/);
+  });
+
   test('run-prompt-optimization.mjs wires the headless run API with a key file, not a raw key', async () => {
     const source = await readRepoFile('packages/headless/harbor/run-prompt-optimization.mjs');
     assert.match(source, /runPromptOptimizationRun/);
@@ -1354,6 +1368,32 @@ asyncio.run(fix4_deadline_reclaims_all_scoped_commands())
 asyncio.run(fix5_timed_out_command_is_reclaimed_immediately())
 asyncio.run(fix6_cleanup_failure_is_not_reported_as_a_typed_timeout())
 print("bridge-contract ok")
+`;
+}
+
+function pythonTaskRunHostProxyContractScript(root: string): string {
+  return String.raw`
+import sys
+from pathlib import Path
+
+root = Path(${JSON.stringify(root)})
+sys.path.insert(0, str(root / "packages" / "headless" / "harbor"))
+
+import maka_agent
+
+env = {
+    "MAKA_PROVIDER": "openai-codex",
+    "MAKA_HOST_API_KEY": "host-proxy-token",
+    "MAKA_HOST_API_KEY_ENV_NAME": "OPENAI_CODEX_OAUTH_TOKEN",
+    "MAKA_HOST_BASE_URL": "http://127.0.0.1:43210/v1",
+    "MAKA_HOST_MODEL_API_PROTOCOL": "openai-responses",
+}
+maka_agent._normalize_cli_env(env)
+
+assert env["OPENAI_CODEX_OAUTH_TOKEN"] == "host-proxy-token", env
+assert env["MAKA_BASE_URL"] == "http://127.0.0.1:43210/v1", env
+assert env["MAKA_MODEL_API_PROTOCOL"] == "openai-responses", env
+print("task-run-host-proxy-contract ok")
 `;
 }
 

--- a/packages/headless/src/__tests__/harbor-adapter.test.ts
+++ b/packages/headless/src/__tests__/harbor-adapter.test.ts
@@ -2150,6 +2150,28 @@ with tempfile.TemporaryDirectory() as tmp:
         assert "MAKA_MAX_STEPS" not in task_run_env, task_run_env.get("MAKA_MAX_STEPS")
         assert task_run_timeouts[-1] == 7200, task_run_timeouts
 
+        runner_env_path = Path(tmp) / "task-run.env"
+        runner_env_path.write_text("MAKA_CELL_TIMEOUT_SEC=4321\n", encoding="utf-8")
+        original_runner_env = maka_agent_mod._DEFAULT_RUNNER_ENV
+        maka_agent_mod._DEFAULT_RUNNER_ENV = runner_env_path
+        try:
+            env_file_task_run_agent = MakaAgent(Path(tmp), extra_env={
+                "MAKA_BACKEND": "fake",
+                "MAKA_HARBOR_MODE": "task-run",
+            })
+            env_file_task_run_agent._resolve_task_workdir = resolve_task_workdir
+            env_file_task_run_agent._communicate_streaming = communicate_task_run
+            asyncio.run(
+                env_file_task_run_agent._run_task_run_host(
+                    "finish the task",
+                    host_process_environment,
+                    AgentContext(),
+                )
+            )
+        finally:
+            maka_agent_mod._DEFAULT_RUNNER_ENV = original_runner_env
+        assert task_run_timeouts[-1] == 4321, task_run_timeouts
+
         capped_task_run_agent = MakaAgent(Path(tmp), extra_env={
             "MAKA_BACKEND": "fake",
             "MAKA_HARBOR_MODE": "task-run",
@@ -2166,6 +2188,40 @@ with tempfile.TemporaryDirectory() as tmp:
         )
         capped_task_run_env = captured_host_process["kwargs"]["env"]
         assert capped_task_run_env["MAKA_MAX_STEPS"] == "64", capped_task_run_env.get("MAKA_MAX_STEPS")
+
+        class DeadlineSettledTaskRunProcess(FakeHostProcess):
+            returncode = 124
+
+        async def fake_task_run_deadline_subprocess_exec(*args, **kwargs):
+            captured_host_process["args"] = args
+            captured_host_process["kwargs"] = kwargs
+            return DeadlineSettledTaskRunProcess()
+
+        async def communicate_task_run_deadline(**kwargs):
+            return (
+                b'{"status":"budget_exhausted","settledByDeadline":true,"benchmarkFailureShouldThrow":false}\n',
+                b"",
+            )
+
+        asyncio.create_subprocess_exec = fake_task_run_deadline_subprocess_exec
+        deadline_task_run_agent = MakaAgent(Path(tmp), extra_env={
+            "MAKA_BACKEND": "fake",
+            "MAKA_HARBOR_MODE": "task-run",
+            "MAKA_CELL_TIMEOUT_SEC": "60",
+            "MAKA_CELL_SETTLEMENT_GRACE_SEC": "10",
+        })
+        deadline_task_run_agent._resolve_task_workdir = resolve_task_workdir
+        deadline_task_run_agent._communicate_streaming = communicate_task_run_deadline
+        asyncio.run(
+            deadline_task_run_agent._run_task_run_host(
+                "finish the task",
+                host_process_environment,
+                AgentContext(),
+            )
+        )
+        assert captured_host_process["kwargs"]["env"]["MAKA_CELL_SOFT_TIMEOUT_MS"] == "50000"
+        assert FakeToolExecutor.instances[-1].reclaim_scoped_processes
+
         captured_host_process.clear()
         captured_host_process.update(host_cell_process)
 

--- a/packages/headless/src/__tests__/harbor-adapter.test.ts
+++ b/packages/headless/src/__tests__/harbor-adapter.test.ts
@@ -1966,6 +1966,14 @@ with tempfile.TemporaryDirectory() as tmp:
         "MAKA_CELL_TIMEOUT_SEC": "1800",
         "MAKA_CELL_SETTLEMENT_GRACE_SEC": "60",
     })._cell_soft_timeout_ms() == 1740000
+    try:
+        MakaAgent(Path(tmp), extra_env={
+            "MAKA_CELL_TIMEOUT_SEC": "2147514",
+        })._cell_soft_timeout_ms()
+    except RuntimeError as exc:
+        assert "Node timer limit" in str(exc), str(exc)
+    else:
+        raise AssertionError("expected an oversized soft timeout to raise")
 
     host_deadline_env = MakaAgent(Path(tmp), extra_env={
         "MAKA_BACKEND": "fake",

--- a/packages/headless/src/__tests__/harbor-adapter.test.ts
+++ b/packages/headless/src/__tests__/harbor-adapter.test.ts
@@ -389,20 +389,6 @@ describe('Harbor adapter contract', () => {
     assert.match(result.stdout, /bridge-contract ok/);
   });
 
-  test('maka_agent.py task-run maps host proxy authority into backend env', (t: TestContext) => {
-    const python = harborPython();
-    if (!python) {
-      t.skip('Harbor 0.13.2 python is not available (CI has no harbor)');
-      return;
-    }
-    const result = spawnSync(python, ['-c', pythonTaskRunHostProxyContractScript(repoRoot)], {
-      cwd: repoRoot,
-      encoding: 'utf8',
-    });
-    assert.equal(result.status, 0, result.stderr);
-    assert.match(result.stdout, /task-run-host-proxy-contract ok/);
-  });
-
   test('run-prompt-optimization.mjs wires the headless run API with a key file, not a raw key', async () => {
     const source = await readRepoFile('packages/headless/harbor/run-prompt-optimization.mjs');
     assert.match(source, /runPromptOptimizationRun/);
@@ -1368,32 +1354,6 @@ asyncio.run(fix4_deadline_reclaims_all_scoped_commands())
 asyncio.run(fix5_timed_out_command_is_reclaimed_immediately())
 asyncio.run(fix6_cleanup_failure_is_not_reported_as_a_typed_timeout())
 print("bridge-contract ok")
-`;
-}
-
-function pythonTaskRunHostProxyContractScript(root: string): string {
-  return String.raw`
-import sys
-from pathlib import Path
-
-root = Path(${JSON.stringify(root)})
-sys.path.insert(0, str(root / "packages" / "headless" / "harbor"))
-
-import maka_agent
-
-env = {
-    "MAKA_PROVIDER": "openai-codex",
-    "MAKA_HOST_API_KEY": "host-proxy-token",
-    "MAKA_HOST_API_KEY_ENV_NAME": "OPENAI_CODEX_OAUTH_TOKEN",
-    "MAKA_HOST_BASE_URL": "http://127.0.0.1:43210/v1",
-    "MAKA_HOST_MODEL_API_PROTOCOL": "openai-responses",
-}
-maka_agent._normalize_cli_env(env)
-
-assert env["OPENAI_CODEX_OAUTH_TOKEN"] == "host-proxy-token", env
-assert env["MAKA_BASE_URL"] == "http://127.0.0.1:43210/v1", env
-assert env["MAKA_MODEL_API_PROTOCOL"] == "openai-responses", env
-print("task-run-host-proxy-contract ok")
 `;
 }
 

--- a/packages/headless/src/__tests__/harbor-adapter.test.ts
+++ b/packages/headless/src/__tests__/harbor-adapter.test.ts
@@ -7,7 +7,7 @@ import { dirname, resolve } from 'node:path';
 import { describe, test, type TestContext } from 'node:test';
 import { fileURLToPath } from 'node:url';
 import { promisify } from 'node:util';
-import { HARBOR_CELL_CONTEXT_ENV_KEYS } from '../harbor-cell.js';
+import { HARBOR_CELL_CONTEXT_ENV_KEYS, resolveHarborCellAiSdkEnv } from '../harbor-cell.js';
 
 const repoRoot = resolve(fileURLToPath(new URL('../../../..', import.meta.url)));
 const execFileAsync = promisify(execFile);
@@ -180,7 +180,7 @@ describe('Harbor adapter contract', () => {
     }
   });
 
-  test('run-host-cell.mjs maps direct SiliconFlow credentials to the SiliconFlow namespace', async () => {
+  test('run-host-cell.mjs resolves direct SiliconFlow credentials without materializing aliases', async () => {
     const tmp = mkdtempSync(resolve(tmpdir(), 'maka-host-cell-siliconflow-'));
     try {
       const keyFile = resolve(tmp, 'key.txt');
@@ -190,18 +190,36 @@ describe('Harbor adapter contract', () => {
       );
 
       const rawEnv = await backendEnv({ MAKA_HOST_API_KEY: 'siliconflow-raw-key' }, 'siliconflow');
-      assert.equal(rawEnv.SILICONFLOW_API_KEY, 'siliconflow-raw-key');
+      assert.equal(
+        resolveHarborCellAiSdkEnv({
+          provider: 'siliconflow',
+          model: 'test-model',
+          env: rawEnv,
+          ts: 1,
+        }).apiKey,
+        'siliconflow-raw-key',
+      );
+      assert.equal(rawEnv.SILICONFLOW_API_KEY, undefined);
       assert.equal(rawEnv.OPENAI_API_KEY, undefined);
 
       const fileEnv = await backendEnv({ MAKA_HOST_API_KEY_FILE: keyFile }, 'siliconflow');
-      assert.equal(fileEnv.SILICONFLOW_API_KEY, 'siliconflow-file-key');
+      assert.equal(
+        resolveHarborCellAiSdkEnv({
+          provider: 'siliconflow',
+          model: 'test-model',
+          env: fileEnv,
+          ts: 1,
+        }).apiKey,
+        'siliconflow-file-key',
+      );
+      assert.equal(fileEnv.SILICONFLOW_API_KEY, undefined);
       assert.equal(fileEnv.OPENAI_API_KEY, undefined);
     } finally {
       rmSync(tmp, { recursive: true, force: true });
     }
   });
 
-  test('run-host-cell.mjs maps Vercel Gateway credentials only to the AI Gateway namespace', async () => {
+  test('run-host-cell.mjs resolves Vercel Gateway credentials without materializing aliases', async () => {
     const tmp = mkdtempSync(resolve(tmpdir(), 'maka-host-cell-vercel-'));
     try {
       const keyFile = resolve(tmp, 'key.txt');
@@ -211,11 +229,29 @@ describe('Harbor adapter contract', () => {
       );
 
       const rawEnv = await backendEnv({ MAKA_HOST_API_KEY: 'vercel-raw-key' }, 'vercel');
-      assert.equal(rawEnv.AI_GATEWAY_API_KEY, 'vercel-raw-key');
+      assert.equal(
+        resolveHarborCellAiSdkEnv({
+          provider: 'vercel',
+          model: 'creator/model',
+          env: rawEnv,
+          ts: 1,
+        }).apiKey,
+        'vercel-raw-key',
+      );
+      assert.equal(rawEnv.AI_GATEWAY_API_KEY, undefined);
       assert.equal(rawEnv.OPENAI_API_KEY, undefined);
 
       const fileEnv = await backendEnv({ MAKA_HOST_API_KEY_FILE: keyFile }, 'vercel');
-      assert.equal(fileEnv.AI_GATEWAY_API_KEY, 'vercel-file-key');
+      assert.equal(
+        resolveHarborCellAiSdkEnv({
+          provider: 'vercel',
+          model: 'creator/model',
+          env: fileEnv,
+          ts: 1,
+        }).apiKey,
+        'vercel-file-key',
+      );
+      assert.equal(fileEnv.AI_GATEWAY_API_KEY, undefined);
       assert.equal(fileEnv.OPENAI_API_KEY, undefined);
     } finally {
       rmSync(tmp, { recursive: true, force: true });
@@ -235,9 +271,16 @@ describe('Harbor adapter contract', () => {
       'github-copilot',
     );
 
-    assert.equal(env.COPILOT_GITHUB_TOKEN, 'github_pat_copilot_requests');
-    assert.equal(env.MAKA_BASE_URL, 'https://api.githubcopilot.com');
-    assert.equal(env.MAKA_MODEL_API_PROTOCOL, 'openai-responses');
+    const resolved = resolveHarborCellAiSdkEnv({
+      provider: 'github-copilot',
+      model: 'gpt-test',
+      env,
+      ts: 1,
+    });
+    assert.equal(resolved.apiKey, 'github_pat_copilot_requests');
+    assert.equal(resolved.connection.baseUrl, 'https://api.githubcopilot.com');
+    assert.equal(resolved.connection.models?.[0]?.apiProtocol, 'openai-responses');
+    assert.equal(env.COPILOT_GITHUB_TOKEN, undefined);
   });
 
   test('run-host-cell.mjs accepts Ollama without provider credentials', async () => {
@@ -258,10 +301,20 @@ describe('Harbor adapter contract', () => {
     assert.deepEqual(await backendEnv({}, 'localai'), {
       MAKA_LLM_CONNECTION_SLUG: 'localai',
     });
-    assert.deepEqual(await backendEnv({ MAKA_HOST_API_KEY: 'localai-user-key' }, 'localai'), {
+    const env = await backendEnv({ MAKA_HOST_API_KEY: 'localai-user-key' }, 'localai');
+    assert.deepEqual(env, {
       MAKA_LLM_CONNECTION_SLUG: 'localai',
-      LOCALAI_API_KEY: 'localai-user-key',
+      MAKA_HOST_API_KEY: 'localai-user-key',
     });
+    assert.equal(
+      resolveHarborCellAiSdkEnv({
+        provider: 'localai',
+        model: 'local-model',
+        env,
+        ts: 1,
+      }).apiKey,
+      'localai-user-key',
+    );
   });
 
   test('run-host-cell.mjs rejects unknown context env instead of dropping it', async () => {
@@ -1922,6 +1975,18 @@ with tempfile.TemporaryDirectory() as tmp:
         token="test-token",
     ))
     assert host_deadline_env["MAKA_CELL_SOFT_TIMEOUT_MS"] == "870000", host_deadline_env
+
+    copilot_host_env = MakaAgent(Path(tmp), extra_env={
+        "MAKA_HOST_API_KEY": "copilot-token",
+        "MAKA_HOST_BASE_URL": "https://api.githubcopilot.com",
+        "MAKA_HOST_MODEL_API_PROTOCOL": "openai-responses",
+        "MAKA_PROVIDER": "github-copilot",
+        "MAKA_MODEL": "gpt-test",
+    })._host_cell_env(Path("/tmp/instruction.txt"), "/workspace", types.SimpleNamespace(
+        url="http://127.0.0.1:1",
+        token="test-token",
+    ))
+    assert copilot_host_env["MAKA_HOST_MODEL_API_PROTOCOL"] == "openai-responses", copilot_host_env
 
     # The default model must not be the deprecated deepseek-chat alias.
     default_model_env = MakaAgent(Path(tmp), extra_env={"MAKA_HOST_API_KEY_FILE": "/host/deepseek-key"})._cell_env(Path("/logs/agent/instruction.txt"))

--- a/packages/headless/src/__tests__/harbor-adapter.test.ts
+++ b/packages/headless/src/__tests__/harbor-adapter.test.ts
@@ -2046,6 +2046,7 @@ with tempfile.TemporaryDirectory() as tmp:
             self.reclaim_scoped_processes = True
 
     class FakeHostProcess:
+        pid = 123
         returncode = 0
 
         async def communicate(self):
@@ -2094,6 +2095,50 @@ with tempfile.TemporaryDirectory() as tmp:
         })
         host_process_environment = types.SimpleNamespace(root_commands=[], agent_commands=[])
         asyncio.run(host_process_agent._run_host_cell(host_process_environment, Path(tmp) / "instruction.txt"))
+        host_cell_process = dict(captured_host_process)
+
+        task_run_agent = MakaAgent(Path(tmp), extra_env={
+            "MAKA_BACKEND": "fake",
+            "MAKA_HARBOR_MODE": "task-run",
+        })
+        task_run_context = AgentContext()
+
+        async def resolve_task_workdir(environment):
+            return ("/app", [])
+
+        async def communicate_task_run(**kwargs):
+            return (b'{"status":"completed","benchmarkFailureShouldThrow":false}\n', b"")
+
+        task_run_agent._resolve_task_workdir = resolve_task_workdir
+        task_run_agent._communicate_streaming = communicate_task_run
+        asyncio.run(
+            task_run_agent._run_task_run_host(
+                "finish the task",
+                host_process_environment,
+                task_run_context,
+            )
+        )
+        task_run_env = captured_host_process["kwargs"]["env"]
+        assert "MAKA_MAX_STEPS" not in task_run_env, task_run_env.get("MAKA_MAX_STEPS")
+
+        capped_task_run_agent = MakaAgent(Path(tmp), extra_env={
+            "MAKA_BACKEND": "fake",
+            "MAKA_HARBOR_MODE": "task-run",
+            "MAKA_MAX_STEPS": "64",
+        })
+        capped_task_run_agent._resolve_task_workdir = resolve_task_workdir
+        capped_task_run_agent._communicate_streaming = communicate_task_run
+        asyncio.run(
+            capped_task_run_agent._run_task_run_host(
+                "finish the task",
+                host_process_environment,
+                AgentContext(),
+            )
+        )
+        capped_task_run_env = captured_host_process["kwargs"]["env"]
+        assert capped_task_run_env["MAKA_MAX_STEPS"] == "64", capped_task_run_env.get("MAKA_MAX_STEPS")
+        captured_host_process.clear()
+        captured_host_process.update(host_cell_process)
 
         class DeadlineSettledHostProcess(FakeHostProcess):
             returncode = 124

--- a/packages/headless/src/__tests__/harbor-adapter.test.ts
+++ b/packages/headless/src/__tests__/harbor-adapter.test.ts
@@ -2060,13 +2060,16 @@ with tempfile.TemporaryDirectory() as tmp:
         task_run_agent = MakaAgent(Path(tmp), extra_env={
             "MAKA_BACKEND": "fake",
             "MAKA_HARBOR_MODE": "task-run",
+            "MAKA_CELL_TIMEOUT_SEC": "7200",
         })
         task_run_context = AgentContext()
+        task_run_timeouts = []
 
         async def resolve_task_workdir(environment):
             return ("/app", [])
 
         async def communicate_task_run(**kwargs):
+            task_run_timeouts.append(kwargs["timeout_sec"])
             return (b'{"status":"completed","benchmarkFailureShouldThrow":false}\n', b"")
 
         task_run_agent._resolve_task_workdir = resolve_task_workdir
@@ -2080,6 +2083,7 @@ with tempfile.TemporaryDirectory() as tmp:
         )
         task_run_env = captured_host_process["kwargs"]["env"]
         assert "MAKA_MAX_STEPS" not in task_run_env, task_run_env.get("MAKA_MAX_STEPS")
+        assert task_run_timeouts[-1] == 7200, task_run_timeouts
 
         capped_task_run_agent = MakaAgent(Path(tmp), extra_env={
             "MAKA_BACKEND": "fake",

--- a/packages/headless/src/__tests__/harbor-cell.test.ts
+++ b/packages/headless/src/__tests__/harbor-cell.test.ts
@@ -4740,15 +4740,16 @@ describe('createHarborCellLocalToolExecutor', () => {
       DEEPSEEK_API_KEY: 'sk-should-not-leak',
       ACME_API_KEY: 'unregistered-secret',
       GOOGLE_APPLICATION_CREDENTIALS: '/tmp/google-credentials.json',
+      PGPASSWORD: 'postgres-secret',
       MAX_TOKENS: '4096',
     });
     const result = await executor.exec({
       command:
-        'printf "[%s][%s][%s][%s][%s]" "${DEEPSEEK_API_KEY_FILE:-}" "${DEEPSEEK_API_KEY:-}" "${ACME_API_KEY:-}" "${GOOGLE_APPLICATION_CREDENTIALS:-}" "${MAX_TOKENS:-}"',
+        'printf "[%s][%s][%s][%s][%s][%s]" "${DEEPSEEK_API_KEY_FILE:-}" "${DEEPSEEK_API_KEY:-}" "${ACME_API_KEY:-}" "${GOOGLE_APPLICATION_CREDENTIALS:-}" "${PGPASSWORD:-}" "${MAX_TOKENS:-}"',
       cwd: process.cwd(),
     });
     assert.equal(result.exitCode, 0);
-    assert.equal(result.stdout, '[][][][][4096]');
+    assert.equal(result.stdout, '[][][][][][4096]');
   });
 
   test('scrubs provider token env so task commands cannot read OAuth credentials', async () => {

--- a/packages/headless/src/__tests__/harbor-cell.test.ts
+++ b/packages/headless/src/__tests__/harbor-cell.test.ts
@@ -38,6 +38,7 @@ import {
   buildHarborCellAiSdkTools,
   buildHarborCellTaskLedgerExperimentPolicy,
   harborCellMaxStepsFromEnv,
+  harborCellSoftTimeoutMsFromEnv,
   createHarborCellLocalToolExecutor,
   createHarborHttpToolExecutor,
   HARBOR_CELL_CONTEXT_ENV_KEYS,
@@ -1754,6 +1755,13 @@ describe('runHarborCell', () => {
       /MAKA_MAX_STEPS must be a positive integer/,
     );
     assert.equal(harborCellMaxStepsFromEnv({}), undefined);
+  });
+
+  test('rejects a soft timeout above the Node timer limit', () => {
+    assert.throws(
+      () => harborCellSoftTimeoutMsFromEnv({ MAKA_CELL_SOFT_TIMEOUT_MS: '2147483648' }),
+      /MAKA_CELL_SOFT_TIMEOUT_MS must not exceed 2147483647/,
+    );
   });
 
   test('host-side Harbor cell config reads MAKA_ECONOMY_TASK_MODE', async () => {

--- a/packages/headless/src/__tests__/harbor-cell.test.ts
+++ b/packages/headless/src/__tests__/harbor-cell.test.ts
@@ -4734,17 +4734,21 @@ describe('createHarborCellLocalToolExecutor', () => {
     assert.equal(result.stdout, 'ok');
   });
 
-  test('scrubs provider API-key env so task commands cannot read the secret', async () => {
+  test('scrubs secret-shaped env so task commands cannot read unregistered credentials', async () => {
     const executor = createHarborCellLocalToolExecutor({
       DEEPSEEK_API_KEY_FILE: '/run/secrets/deepseek-key',
       DEEPSEEK_API_KEY: 'sk-should-not-leak',
+      ACME_API_KEY: 'unregistered-secret',
+      GOOGLE_APPLICATION_CREDENTIALS: '/tmp/google-credentials.json',
+      MAX_TOKENS: '4096',
     });
     const result = await executor.exec({
-      command: 'printf "[%s][%s]" "${DEEPSEEK_API_KEY_FILE:-}" "${DEEPSEEK_API_KEY:-}"',
+      command:
+        'printf "[%s][%s][%s][%s][%s]" "${DEEPSEEK_API_KEY_FILE:-}" "${DEEPSEEK_API_KEY:-}" "${ACME_API_KEY:-}" "${GOOGLE_APPLICATION_CREDENTIALS:-}" "${MAX_TOKENS:-}"',
       cwd: process.cwd(),
     });
     assert.equal(result.exitCode, 0);
-    assert.equal(result.stdout, '[][]');
+    assert.equal(result.stdout, '[][][][][4096]');
   });
 
   test('scrubs provider token env so task commands cannot read OAuth credentials', async () => {

--- a/packages/headless/src/__tests__/harbor-cell.test.ts
+++ b/packages/headless/src/__tests__/harbor-cell.test.ts
@@ -3711,7 +3711,10 @@ setTimeout(() => {
     const missing = resolveHarborCellAiSdkEnv({
       provider: 'ollama-cloud',
       model: 'qwen3.5:397b',
-      env: { OPENAI_API_KEY: 'must-not-cross-provider-boundary' },
+      env: {
+        MAKA_CREDENTIALS_PATH: join(tmpdir(), 'missing-maka-test-credentials.json'),
+        OPENAI_API_KEY: 'must-not-cross-provider-boundary',
+      },
       ts: 1,
     });
     assert.equal(missing.apiKey, '');
@@ -3779,7 +3782,10 @@ setTimeout(() => {
       const missing = resolveHarborCellAiSdkEnv({
         provider: provider.type,
         model: provider.modelId,
-        env: { OPENAI_API_KEY: 'must-not-cross-provider-boundary' },
+        env: {
+          MAKA_CREDENTIALS_PATH: join(tmpdir(), 'missing-maka-test-credentials.json'),
+          OPENAI_API_KEY: 'must-not-cross-provider-boundary',
+        },
         ts: 1,
       });
       assert.equal(missing.apiKey, '');
@@ -4739,6 +4745,21 @@ describe('createHarborCellLocalToolExecutor', () => {
     });
     assert.equal(result.exitCode, 0);
     assert.equal(result.stdout, '[][]');
+  });
+
+  test('scrubs provider token env so task commands cannot read OAuth credentials', async () => {
+    const executor = createHarborCellLocalToolExecutor({
+      OPENAI_CODEX_OAUTH_TOKEN: 'oauth-should-not-leak',
+      COPILOT_GITHUB_TOKEN: 'copilot-should-not-leak',
+      HF_TOKEN: 'hf-should-not-leak',
+    });
+    const result = await executor.exec({
+      command:
+        'printf "[%s][%s][%s]" "${OPENAI_CODEX_OAUTH_TOKEN:-}" "${COPILOT_GITHUB_TOKEN:-}" "${HF_TOKEN:-}"',
+      cwd: process.cwd(),
+    });
+    assert.equal(result.exitCode, 0);
+    assert.equal(result.stdout, '[][][]');
   });
 });
 

--- a/packages/headless/src/__tests__/harbor-cli-connection-defaults.test.ts
+++ b/packages/headless/src/__tests__/harbor-cli-connection-defaults.test.ts
@@ -433,6 +433,15 @@ describe('applyConnectionDefaults', () => {
 });
 
 describe('resolveHarborRunOptions backend guard', () => {
+  test('uses the strict cell soft-timeout parser in task-run mode', async () => {
+    await assert.rejects(
+      resolveHarborRunOptions(['--backend', 'fake', '--instruction', 'test'], {
+        MAKA_CELL_SOFT_TIMEOUT_MS: '1e3',
+      }),
+      /MAKA_CELL_SOFT_TIMEOUT_MS must be a positive integer/,
+    );
+  });
+
   test('explicit host authority overrides stale ambient provider authority', async () => {
     const opts = await resolveHarborRunOptions(
       ['--instruction', 'test', '--isolation', 'harbor-local'],

--- a/packages/headless/src/__tests__/harbor-cli-connection-defaults.test.ts
+++ b/packages/headless/src/__tests__/harbor-cli-connection-defaults.test.ts
@@ -477,6 +477,46 @@ describe('applyConnectionDefaults', () => {
 });
 
 describe('resolveHarborRunOptions backend guard', () => {
+  test('explicit host authority overrides stale ambient provider authority', async () => {
+    const opts = await resolveHarborRunOptions(
+      ['--instruction', 'test', '--isolation', 'harbor-local'],
+      {
+        MAKA_MODEL: 'openai-codex/gpt-5.6-codex',
+        MAKA_HOST_API_KEY: 'selected-host-token',
+        MAKA_HOST_API_KEY_ENV_NAME: 'OPENAI_CODEX_OAUTH_TOKEN',
+        MAKA_HOST_BASE_URL: 'http://127.0.0.1:43210/v1',
+        MAKA_HOST_MODEL_API_PROTOCOL: 'openai-responses',
+        OPENAI_CODEX_OAUTH_TOKEN: 'stale-ambient-token',
+        MAKA_BASE_URL: 'https://stale.example/v1',
+        MAKA_MODEL_API_PROTOCOL: 'openai-chat',
+      },
+    );
+
+    assert.equal(opts.env.OPENAI_CODEX_OAUTH_TOKEN, 'selected-host-token');
+    assert.equal(opts.env.MAKA_BASE_URL, 'http://127.0.0.1:43210/v1');
+    assert.equal(opts.env.MAKA_MODEL_API_PROTOCOL, 'openai-responses');
+  });
+
+  test('file-based host authority overrides stale ambient provider credentials', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'maka-host-authority-'));
+    cleanupDirs.push(dir);
+    const keyFile = join(dir, 'deepseek-key');
+    writeFileSync(keyFile, 'selected-file-token\n', 'utf8');
+
+    const opts = await resolveHarborRunOptions(
+      ['--instruction', 'test', '--isolation', 'harbor-local'],
+      {
+        MAKA_MODEL: 'deepseek/deepseek-chat',
+        MAKA_HOST_API_KEY_FILE: keyFile,
+        MAKA_HOST_API_KEY_ENV_NAME: 'DEEPSEEK_API_KEY',
+        DEEPSEEK_API_KEY: 'stale-deepseek-token',
+        OPENAI_API_KEY: 'stale-fallback-token',
+      },
+    );
+
+    assert.equal(opts.env.DEEPSEEK_API_KEY, 'selected-file-token');
+  });
+
   test('--backend fake flag skips applyConnectionDefaults (no desktop connection pollution)', async () => {
     // cliEnv does not forward the --backend flag into env.MAKA_BACKEND, so the
     // in-function guard inside applyConnectionDefaults only covers the

--- a/packages/headless/src/__tests__/harbor-cli-connection-defaults.test.ts
+++ b/packages/headless/src/__tests__/harbor-cli-connection-defaults.test.ts
@@ -3,7 +3,11 @@ import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { describe, test, afterEach } from 'node:test';
-import { applyConnectionDefaults, resolveHarborRunOptions } from '../harbor-cli.js';
+import {
+  applyConnectionDefaults,
+  resolveHarborRunOptions,
+  summarizeTaskRunRuntimeEvents,
+} from '../harbor-cli.js';
 
 /**
  * Tests for applyConnectionDefaults — the function that reads
@@ -30,6 +34,47 @@ afterEach(() => {
     }
   }
   cleanupDirs = [];
+});
+
+describe('summarizeTaskRunRuntimeEvents', () => {
+  test('preserves authoritative runtime token usage for task-run cell evidence', () => {
+    const summary = summarizeTaskRunRuntimeEvents(
+      [
+        JSON.stringify({
+          type: 'assistant',
+          id: 'usage-1',
+          timestamp: 1,
+          actions: {
+            tokenUsage: {
+              input: 120,
+              output: 30,
+              cacheHitInput: 80,
+              cacheMissInput: 40,
+              cacheMissInputSource: 'explicit',
+              reasoning: 10,
+              total: 160,
+              costUsd: 0.25,
+            },
+          },
+        }),
+        '',
+      ].join('\n'),
+    );
+
+    assert.deepEqual(summary, {
+      input: 120,
+      output: 30,
+      cachedInput: 80,
+      cacheHitInput: 80,
+      cacheMissInput: 40,
+      cacheWriteInput: 0,
+      cacheMissInputSource: 'explicit',
+      reasoning: 10,
+      total: 160,
+      costUsd: 0.25,
+      pricingSource: 'runtime',
+    });
+  });
 });
 
 describe('applyConnectionDefaults', () => {

--- a/packages/headless/src/__tests__/harbor-cli-connection-defaults.test.ts
+++ b/packages/headless/src/__tests__/harbor-cli-connection-defaults.test.ts
@@ -3,6 +3,7 @@ import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { describe, test, afterEach } from 'node:test';
+import { resolveHarborCellAiSdkEnv } from '../harbor-cell.js';
 import { applyConnectionDefaults, resolveHarborRunOptions } from '../harbor-cli.js';
 
 /**
@@ -438,7 +439,6 @@ describe('resolveHarborRunOptions backend guard', () => {
       {
         MAKA_MODEL: 'openai-codex/gpt-5.6-codex',
         MAKA_HOST_API_KEY: 'selected-host-token',
-        MAKA_HOST_API_KEY_ENV_NAME: 'OPENAI_CODEX_OAUTH_TOKEN',
         MAKA_HOST_BASE_URL: 'http://127.0.0.1:43210/v1',
         MAKA_HOST_MODEL_API_PROTOCOL: 'openai-responses',
         OPENAI_CODEX_OAUTH_TOKEN: 'stale-ambient-token',
@@ -447,9 +447,14 @@ describe('resolveHarborRunOptions backend guard', () => {
       },
     );
 
-    assert.equal(opts.env.OPENAI_CODEX_OAUTH_TOKEN, 'selected-host-token');
-    assert.equal(opts.env.MAKA_BASE_URL, 'http://127.0.0.1:43210/v1');
-    assert.equal(opts.env.MAKA_MODEL_API_PROTOCOL, 'openai-responses');
+    const resolved = resolveHarborCellAiSdkEnv({
+      provider: 'openai-codex',
+      model: 'gpt-5.6-codex',
+      env: opts.env,
+      ts: 1,
+    });
+    assert.equal(resolved.apiKey, 'selected-host-token');
+    assert.equal(resolved.connection.baseUrl, 'http://127.0.0.1:43210/v1');
   });
 
   test('file-based host authority overrides stale ambient provider credentials', async () => {
@@ -463,13 +468,67 @@ describe('resolveHarborRunOptions backend guard', () => {
       {
         MAKA_MODEL: 'deepseek/deepseek-chat',
         MAKA_HOST_API_KEY_FILE: keyFile,
-        MAKA_HOST_API_KEY_ENV_NAME: 'DEEPSEEK_API_KEY',
         DEEPSEEK_API_KEY: 'stale-deepseek-token',
         OPENAI_API_KEY: 'stale-fallback-token',
       },
     );
 
-    assert.equal(opts.env.DEEPSEEK_API_KEY, 'selected-file-token');
+    const resolved = resolveHarborCellAiSdkEnv({
+      provider: 'deepseek',
+      model: 'deepseek-chat',
+      env: opts.env,
+      ts: 1,
+    });
+    assert.equal(resolved.apiKey, 'selected-file-token');
+  });
+
+  test('explicit host authority bypasses higher-priority ambient credential aliases', async () => {
+    const opts = await resolveHarborRunOptions(
+      ['--instruction', 'test', '--isolation', 'harbor-local'],
+      {
+        MAKA_MODEL: 'deepseek/deepseek-chat',
+        MAKA_HOST_API_KEY: 'selected-host-token',
+        DEEPSEEK_API_KEY: 'stale-primary-token',
+      },
+    );
+    const resolved = resolveHarborCellAiSdkEnv({
+      provider: 'deepseek',
+      model: 'deepseek-chat',
+      env: opts.env,
+      ts: 1,
+    });
+
+    assert.equal(resolved.apiKey, 'selected-host-token');
+  });
+
+  test('explicit no-auth authority bypasses ambient and stored provider credentials', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'maka-host-no-auth-'));
+    cleanupDirs.push(dir);
+    const credentialsPath = join(dir, 'credentials.json');
+    writeFileSync(
+      credentialsPath,
+      JSON.stringify({ version: 1, values: { 'localai:apiKey': 'stored-token' } }),
+      'utf8',
+    );
+    const opts = await resolveHarborRunOptions(
+      ['--instruction', 'test', '--isolation', 'harbor-local'],
+      {
+        MAKA_MODEL: 'localai/local-model',
+        MAKA_HOST_NO_AUTH: 'true',
+        MAKA_HOST_BASE_URL: 'http://127.0.0.1:8080/v1',
+        MAKA_CREDENTIALS_PATH: credentialsPath,
+        LOCALAI_API_KEY: 'ambient-token',
+      },
+    );
+    const resolved = resolveHarborCellAiSdkEnv({
+      provider: 'localai',
+      model: 'local-model',
+      env: opts.env,
+      ts: 1,
+    });
+
+    assert.equal(resolved.apiKey, '');
+    assert.equal(resolved.connection.baseUrl, 'http://127.0.0.1:8080/v1');
   });
 
   test('--backend fake flag skips applyConnectionDefaults (no desktop connection pollution)', async () => {

--- a/packages/headless/src/__tests__/harbor-cli-connection-defaults.test.ts
+++ b/packages/headless/src/__tests__/harbor-cli-connection-defaults.test.ts
@@ -3,11 +3,7 @@ import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { describe, test, afterEach } from 'node:test';
-import {
-  applyConnectionDefaults,
-  resolveHarborRunOptions,
-  summarizeTaskRunRuntimeEvents,
-} from '../harbor-cli.js';
+import { applyConnectionDefaults, resolveHarborRunOptions } from '../harbor-cli.js';
 
 /**
  * Tests for applyConnectionDefaults — the function that reads
@@ -34,47 +30,6 @@ afterEach(() => {
     }
   }
   cleanupDirs = [];
-});
-
-describe('summarizeTaskRunRuntimeEvents', () => {
-  test('preserves authoritative runtime token usage for task-run cell evidence', () => {
-    const summary = summarizeTaskRunRuntimeEvents(
-      [
-        JSON.stringify({
-          type: 'assistant',
-          id: 'usage-1',
-          timestamp: 1,
-          actions: {
-            tokenUsage: {
-              input: 120,
-              output: 30,
-              cacheHitInput: 80,
-              cacheMissInput: 40,
-              cacheMissInputSource: 'explicit',
-              reasoning: 10,
-              total: 160,
-              costUsd: 0.25,
-            },
-          },
-        }),
-        '',
-      ].join('\n'),
-    );
-
-    assert.deepEqual(summary, {
-      input: 120,
-      output: 30,
-      cachedInput: 80,
-      cacheHitInput: 80,
-      cacheMissInput: 40,
-      cacheWriteInput: 0,
-      cacheMissInputSource: 'explicit',
-      reasoning: 10,
-      total: 160,
-      costUsd: 0.25,
-      pricingSource: 'runtime',
-    });
-  });
 });
 
 describe('applyConnectionDefaults', () => {

--- a/packages/headless/src/__tests__/harbor-smoke-config.test.ts
+++ b/packages/headless/src/__tests__/harbor-smoke-config.test.ts
@@ -63,7 +63,8 @@ describe('harbor smoke config generation', () => {
     assert.equal(env.MAKA_HEAVY_TASK_MODE, '1');
     assert.equal(env.MAKA_HARBOR_USE_TASK_RUN, '1');
     assert.equal(env.MAKA_MAX_STEPS, '100');
-    assert.equal(env.MAKA_HARBOR_AGENT_TIMEOUT_SEC, '7200');
+    assert.equal(env.MAKA_CELL_TIMEOUT_SEC, '7200');
+    assert.equal(env.MAKA_HARBOR_AGENT_TIMEOUT_SEC, undefined);
     assert.equal(config.agent_timeout_multiplier, 8);
   });
 

--- a/packages/headless/src/__tests__/harbor-task-runner.test.ts
+++ b/packages/headless/src/__tests__/harbor-task-runner.test.ts
@@ -94,6 +94,7 @@ interface FakeOptions {
   verifierOutcome?: Record<string, unknown> | null;
   trialResult?: Record<string, unknown>;
   makaTrace?: boolean;
+  taskRunTrace?: boolean;
   captured?: { config?: Record<string, unknown>; request?: HarborRunRequest };
 }
 
@@ -188,6 +189,27 @@ function fakeRunner(opts: FakeOptions): HarborProcessRunner {
         'utf8',
       );
     }
+    if (opts.taskRunTrace) {
+      await mkdir(
+        join(trialDir, 'agent', 'maka-task-run', 'runs', 'sessions', 'sess', 'runs', 'run'),
+        { recursive: true },
+      );
+      await writeFile(
+        join(
+          trialDir,
+          'agent',
+          'maka-task-run',
+          'runs',
+          'sessions',
+          'sess',
+          'runs',
+          'run',
+          'events.jsonl',
+        ),
+        '{"type":"task_run_tool_failed"}\n',
+        'utf8',
+      );
+    }
     return {
       exitCode: opts.exitCodeAfterArtifacts ?? 0,
       stdout: opts.exitCodeAfterArtifacts ? '' : 'ok',
@@ -248,6 +270,29 @@ describe('createHarborTaskRunner', () => {
         /run-1\/round-1\/task-1\/trial\/cobol-modernization__t1\/agent\/maka-storage\/sessions\/sess\/runs\/run\/events\.jsonl$/,
       );
       assert.doesNotMatch(output.cell.traceEventsPath ?? '', /^\/logs\//);
+    });
+  });
+
+  test('uses the task-run trace when the cell stores sessions under its task-run root', async () => {
+    await withRun(async ({ jobsDir, repo, keyFile }) => {
+      const runner = createHarborTaskRunner({
+        makaRepoPath: repo,
+        jobsDir,
+        model: 'deepseek/deepseek-v4-flash',
+        provider: 'deepseek',
+        apiKeyFile: keyFile,
+        runHarbor: fakeRunner({ reward: '1\n', makaTrace: false, taskRunTrace: true }),
+      });
+
+      const output = await runner(runInput());
+      assert.match(
+        output.cell.traceEventsPath ?? '',
+        /agent\/maka-task-run\/runs\/sessions\/sess\/runs\/run\/events\.jsonl$/,
+      );
+      assert.equal(
+        await readFile(output.cell.traceEventsPath ?? '', 'utf8'),
+        '{"type":"task_run_tool_failed"}\n',
+      );
     });
   });
 

--- a/packages/headless/src/__tests__/harbor-task-runner.test.ts
+++ b/packages/headless/src/__tests__/harbor-task-runner.test.ts
@@ -1976,6 +1976,28 @@ describe('buildHarborJobConfig', () => {
     );
   });
 
+  test('rejects token-shaped provider secrets from an unrelated provider', () => {
+    assert.throws(
+      () =>
+        buildHarborJobConfig(runInput(), {
+          makaRepoPath: '/repo',
+          jobsDir: '/jobs/x',
+          jobName: 'trial',
+          model: 'deepseek/deepseek-v4-flash',
+          provider: 'deepseek',
+          agentEnv: {
+            MAKA_API_KEY: 'generic-secret',
+            MAKA_HOST_API_KEY: 'host-secret',
+            MAKA_HOST_API_KEY_FILE: '/tmp/host-secret',
+            OPENAI_CODEX_OAUTH_TOKEN: 'codex-secret',
+            GH_TOKEN: 'github-secret',
+            HF_TOKEN: 'huggingface-secret',
+          },
+        }),
+      /agentEnv must not contain provider secrets: GH_TOKEN, HF_TOKEN, MAKA_API_KEY, MAKA_HOST_API_KEY, MAKA_HOST_API_KEY_FILE, OPENAI_CODEX_OAUTH_TOKEN/,
+    );
+  });
+
   test('omits pricing env when no pricing is configured', () => {
     const config = buildHarborJobConfig(runInput(), {
       makaRepoPath: '/repo',

--- a/packages/headless/src/__tests__/harbor-task-runner.test.ts
+++ b/packages/headless/src/__tests__/harbor-task-runner.test.ts
@@ -95,6 +95,7 @@ interface FakeOptions {
   trialResult?: Record<string, unknown>;
   makaTrace?: boolean;
   taskRunTrace?: boolean;
+  combinedTrace?: boolean;
   captured?: { config?: Record<string, unknown>; request?: HarborRunRequest };
 }
 
@@ -210,6 +211,13 @@ function fakeRunner(opts: FakeOptions): HarborProcessRunner {
         'utf8',
       );
     }
+    if (opts.combinedTrace) {
+      await writeFile(
+        join(trialDir, 'agent', 'trace-events.jsonl'),
+        '{"type":"first_invocation"}\n{"type":"second_invocation"}\n',
+        'utf8',
+      );
+    }
     return {
       exitCode: opts.exitCodeAfterArtifacts ?? 0,
       stdout: opts.exitCodeAfterArtifacts ? '' : 'ok',
@@ -292,6 +300,26 @@ describe('createHarborTaskRunner', () => {
       assert.equal(
         await readFile(output.cell.traceEventsPath ?? '', 'utf8'),
         '{"type":"task_run_tool_failed"}\n',
+      );
+    });
+  });
+
+  test('prefers the complete task-run trace over a last-invocation trace', async () => {
+    await withRun(async ({ jobsDir, repo, keyFile }) => {
+      const runner = createHarborTaskRunner({
+        makaRepoPath: repo,
+        jobsDir,
+        model: 'deepseek/deepseek-v4-flash',
+        provider: 'deepseek',
+        apiKeyFile: keyFile,
+        runHarbor: fakeRunner({ reward: '1\n', taskRunTrace: true, combinedTrace: true }),
+      });
+
+      const output = await runner(runInput());
+      assert.match(output.cell.traceEventsPath ?? '', /agent\/trace-events\.jsonl$/);
+      assert.equal(
+        await readFile(output.cell.traceEventsPath ?? '', 'utf8'),
+        '{"type":"first_invocation"}\n{"type":"second_invocation"}\n',
       );
     });
   });

--- a/packages/headless/src/__tests__/harbor-task-runner.test.ts
+++ b/packages/headless/src/__tests__/harbor-task-runner.test.ts
@@ -2035,9 +2035,10 @@ describe('buildHarborJobConfig', () => {
           agentEnv: {
             ACME_API_KEY: 'unregistered-secret',
             GOOGLE_APPLICATION_CREDENTIALS: '/tmp/google-credentials.json',
+            PGPASSWORD: 'postgres-secret',
           },
         }),
-      /agentEnv must not contain provider secrets: ACME_API_KEY, GOOGLE_APPLICATION_CREDENTIALS/,
+      /agentEnv must not contain provider secrets: ACME_API_KEY, GOOGLE_APPLICATION_CREDENTIALS, PGPASSWORD/,
     );
   });
 

--- a/packages/headless/src/__tests__/harbor-task-runner.test.ts
+++ b/packages/headless/src/__tests__/harbor-task-runner.test.ts
@@ -1998,6 +1998,24 @@ describe('buildHarborJobConfig', () => {
     );
   });
 
+  test('rejects secret-shaped env even when no provider registry entry owns it', () => {
+    assert.throws(
+      () =>
+        buildHarborJobConfig(runInput(), {
+          makaRepoPath: '/repo',
+          jobsDir: '/jobs/x',
+          jobName: 'trial',
+          model: 'deepseek/deepseek-v4-flash',
+          provider: 'deepseek',
+          agentEnv: {
+            ACME_API_KEY: 'unregistered-secret',
+            GOOGLE_APPLICATION_CREDENTIALS: '/tmp/google-credentials.json',
+          },
+        }),
+      /agentEnv must not contain provider secrets: ACME_API_KEY, GOOGLE_APPLICATION_CREDENTIALS/,
+    );
+  });
+
   test('omits pricing env when no pricing is configured', () => {
     const config = buildHarborJobConfig(runInput(), {
       makaRepoPath: '/repo',

--- a/packages/headless/src/__tests__/harbor-task-runner.test.ts
+++ b/packages/headless/src/__tests__/harbor-task-runner.test.ts
@@ -426,7 +426,7 @@ describe('createHarborTaskRunner', () => {
       );
       assert.equal(harborEnv?.MAKA_HOST_REPO_ROOT, repo);
       assert.equal(harborEnv?.MAKA_HOST_API_KEY_FILE, keyFile);
-      assert.equal(harborEnv?.MAKA_HOST_API_KEY_ENV_NAME, 'DEEPSEEK_API_KEY');
+      assert.equal(harborEnv?.MAKA_HOST_API_KEY_ENV_NAME, undefined);
       assert.equal(harborEnv?.MAKA_HOST_BASE_URL, 'https://api.deepseek.com');
       assert.deepEqual(config.tasks, [{ path: '/tasks/cobol-modernization', overwrite: false }]);
     });
@@ -458,7 +458,7 @@ describe('createHarborTaskRunner', () => {
       assert.equal(discoveryAuthorization, 'Bearer gho_account-token');
       assert.equal(harborEnv?.MAKA_HOST_API_KEY, 'gho_account-token');
       assert.equal(harborEnv?.MAKA_HOST_API_KEY_FILE, undefined);
-      assert.equal(harborEnv?.MAKA_HOST_API_KEY_ENV_NAME, 'COPILOT_GITHUB_TOKEN');
+      assert.equal(harborEnv?.MAKA_HOST_API_KEY_ENV_NAME, undefined);
       assert.equal(harborEnv?.MAKA_HOST_BASE_URL, 'https://api.githubcopilot.com');
       assert.equal(harborEnv?.MAKA_HOST_MODEL_API_PROTOCOL, 'openai-responses');
     });
@@ -924,7 +924,7 @@ describe('createHarborTaskRunner', () => {
 
       await runner(runInput());
 
-      assert.equal(harborEnv?.MAKA_HOST_API_KEY_ENV_NAME, 'SILICONFLOW_API_KEY');
+      assert.equal(harborEnv?.MAKA_HOST_API_KEY_ENV_NAME, undefined);
       assert.equal(harborEnv?.MAKA_HOST_BASE_URL, 'https://api.siliconflow.cn/v1');
       const agent = (captured.config!.agents as Array<{ env: Record<string, string> }>)[0]!;
       assert.equal(agent.env.SILICONFLOW_BASE_URL, undefined);
@@ -950,7 +950,7 @@ describe('createHarborTaskRunner', () => {
 
       await runner(runInput());
 
-      assert.equal(harborEnv?.MAKA_HOST_API_KEY_ENV_NAME, 'AI_GATEWAY_API_KEY');
+      assert.equal(harborEnv?.MAKA_HOST_API_KEY_ENV_NAME, undefined);
       assert.equal(harborEnv?.MAKA_HOST_BASE_URL, 'https://ai-gateway.vercel.sh/v1');
       const agent = (captured.config!.agents as Array<{ env: Record<string, string> }>)[0]!;
       assert.equal(agent.env.AI_GATEWAY_BASE_URL, undefined);
@@ -983,7 +983,7 @@ describe('createHarborTaskRunner', () => {
       assert.equal(agentEnv.CLOUDFLARE_ACCOUNT_ID, 'account-123');
       assert.equal(agentEnv.CLOUDFLARE_API_KEY, undefined);
       assert.equal(agentEnv.CLOUDFLARE_API_KEY_FILE, undefined);
-      assert.equal(harborEnv?.MAKA_HOST_API_KEY_ENV_NAME, 'CLOUDFLARE_API_KEY');
+      assert.equal(harborEnv?.MAKA_HOST_API_KEY_ENV_NAME, undefined);
       assert.equal(
         harborEnv?.MAKA_HOST_BASE_URL,
         'https://api.cloudflare.com/client/v4/accounts/account-123/ai/v1',

--- a/packages/headless/src/__tests__/harbor-task-runner.test.ts
+++ b/packages/headless/src/__tests__/harbor-task-runner.test.ts
@@ -289,6 +289,7 @@ describe('createHarborTaskRunner', () => {
         model: 'deepseek/deepseek-v4-flash',
         provider: 'deepseek',
         apiKeyFile: keyFile,
+        agentEnv: { MAKA_HARBOR_MODE: 'task-run' },
         runHarbor: fakeRunner({ reward: '1\n', makaTrace: false, taskRunTrace: true }),
       });
 
@@ -312,6 +313,7 @@ describe('createHarborTaskRunner', () => {
         model: 'deepseek/deepseek-v4-flash',
         provider: 'deepseek',
         apiKeyFile: keyFile,
+        agentEnv: { MAKA_HARBOR_MODE: 'task-run' },
         runHarbor: fakeRunner({ reward: '1\n', taskRunTrace: true, combinedTrace: true }),
       });
 
@@ -320,6 +322,29 @@ describe('createHarborTaskRunner', () => {
       assert.equal(
         await readFile(output.cell.traceEventsPath ?? '', 'utf8'),
         '{"type":"first_invocation"}\n{"type":"second_invocation"}\n',
+      );
+    });
+  });
+
+  test('cell mode ignores stale task-run traces', async () => {
+    await withRun(async ({ jobsDir, repo, keyFile }) => {
+      const runner = createHarborTaskRunner({
+        makaRepoPath: repo,
+        jobsDir,
+        model: 'deepseek/deepseek-v4-flash',
+        provider: 'deepseek',
+        apiKeyFile: keyFile,
+        runHarbor: fakeRunner({ reward: '1\n', taskRunTrace: true, combinedTrace: true }),
+      });
+
+      const output = await runner(runInput());
+      assert.match(
+        output.cell.traceEventsPath ?? '',
+        /agent\/maka-storage\/sessions\/sess\/runs\/run\/events\.jsonl$/,
+      );
+      assert.equal(
+        await readFile(output.cell.traceEventsPath ?? '', 'utf8'),
+        '{"type":"tool_failed"}\n',
       );
     });
   });

--- a/packages/headless/src/__tests__/harness-ab-cli.test.ts
+++ b/packages/headless/src/__tests__/harness-ab-cli.test.ts
@@ -309,7 +309,6 @@ test('harness A/B defaults to pinned Kimi Code and keeps OpenCode selectable', a
     model: 'gpt-5.6-sol',
     reasoningEffort: 'xhigh',
     baseUrl: 'https://chatgpt.com/backend-api/codex',
-    apiKeyEnvName: 'OPENAI_CODEX_OAUTH_TOKEN',
     billingMode: 'account-plan',
     pricing: {
       currency: 'USD',
@@ -425,7 +424,6 @@ test('Codex comparison freezes the OpenAI model, pricing, and run identity', asy
     model: 'gpt-5.6-sol',
     reasoningEffort: 'xhigh',
     baseUrl: 'https://chatgpt.com/backend-api/codex',
-    apiKeyEnvName: 'OPENAI_CODEX_OAUTH_TOKEN',
     billingMode: 'account-plan',
     pricing: {
       inputUsdPer1M: 0,

--- a/packages/headless/src/__tests__/task-agent-controller.test.ts
+++ b/packages/headless/src/__tests__/task-agent-controller.test.ts
@@ -1789,4 +1789,32 @@ describe('runTaskOnce', () => {
       assert.match(runtimeEvents, /report-artifact/);
     });
   });
+
+  test('carries the configured reasoning effort into the runtime session', async () => {
+    await withDirs(async (fixtureDir, storageRoot) => {
+      let observedThinkingLevel: SessionHeader['thinkingLevel'];
+      const task: Task = {
+        id: 'thinking-level-task',
+        instruction: 'do the thing',
+        workspaceDir: fixtureDir,
+        verification: { command: 'true', protectedPaths: [] },
+      };
+
+      await runTaskOnce({ ...fakeConfig, thinkingLevel: 'xhigh' }, task, {
+        storageRoot,
+        registerBackends: (registry) => {
+          registry.register('fake', (ctx) => {
+            observedThinkingLevel = ctx.header.thinkingLevel;
+            return new FakeBackend({
+              sessionId: ctx.sessionId,
+              header: ctx.header,
+              store: ctx.store,
+            });
+          });
+        },
+      });
+
+      assert.equal(observedThinkingLevel, 'xhigh');
+    });
+  });
 });

--- a/packages/headless/src/__tests__/task-agent-controller.test.ts
+++ b/packages/headless/src/__tests__/task-agent-controller.test.ts
@@ -680,6 +680,34 @@ class GateRepairBackend implements AgentBackend {
         toolCtx,
       );
     }
+    const toolUseId = `gate-tool-${turnNumber}`;
+    yield {
+      type: 'tool_start',
+      id: `gate-tool-start-${turnNumber}`,
+      turnId: input.turnId,
+      ts,
+      toolUseId,
+      toolName: turnNumber === 1 ? 'initial_tool' : 'repair_tool',
+      args: {},
+    };
+    yield {
+      type: 'tool_result',
+      id: `gate-tool-result-${turnNumber}`,
+      turnId: input.turnId,
+      ts,
+      toolUseId,
+      isError: false,
+      content: { kind: 'text', text: 'ok' },
+    };
+    yield {
+      type: 'token_usage',
+      id: `gate-usage-${turnNumber}`,
+      turnId: input.turnId,
+      ts,
+      input: turnNumber * 10,
+      output: turnNumber,
+      total: turnNumber * 11,
+    };
     yield {
       type: 'text_complete',
       id: `gate-text-${turnNumber}`,
@@ -1346,6 +1374,21 @@ describe('runTaskOnce', () => {
       assert.equal(result.projection.latestVerifierResult?.passed, true);
       assert.equal(result.resultRecord.passed, true);
       assert.equal(result.invocations.length, 2);
+      const budget = result.projection.latestScoreResult?.details?.budget as
+        | { totals?: { input?: number; output?: number; total?: number } }
+        | undefined;
+      assert.deepEqual(budget?.totals, {
+        input: 30,
+        output: 3,
+        reasoning: 0,
+        total: 33,
+        costUsd: 0,
+      });
+      const tools = result.projection.latestScoreResult?.details?.tools as
+        | { actualToolCalls?: number; actualToolNames?: string[] }
+        | undefined;
+      assert.equal(tools?.actualToolCalls, 2);
+      assert.deepEqual(tools?.actualToolNames, ['initial_tool', 'repair_tool']);
       assert.equal(result.projection.attempts[0]?.executionLineage.length, 2);
       assert.equal(
         new Set(

--- a/packages/headless/src/__tests__/task-agent-controller.test.ts
+++ b/packages/headless/src/__tests__/task-agent-controller.test.ts
@@ -961,8 +961,18 @@ describe('runTaskOnce', () => {
 
       assert.equal(counters.sendCalls, 0);
       assert.equal(result.settledByDeadline, true);
-      assert.equal(latestInvocation(result).status, 'failed');
-      assert.equal(latestInvocation(result).failure?.class, 'aborted');
+      const invocation = latestInvocation(result);
+      assert.equal(invocation.status, 'failed');
+      assert.equal(invocation.failure?.class, 'aborted');
+      const runtimeEvents = await readRuntimeEventLedger(
+        storageRoot,
+        invocation.sessionId,
+        invocation.runId,
+      );
+      const terminal = runtimeEvents.at(-1);
+      assert.equal(terminal?.status, 'aborted');
+      assert.equal(terminal?.actions?.endInvocation, true);
+      assert.equal(terminal?.actions?.stateDelta?.abortSource, 'benchmark.deadline');
     });
   });
 

--- a/packages/headless/src/__tests__/task-agent-controller.test.ts
+++ b/packages/headless/src/__tests__/task-agent-controller.test.ts
@@ -976,6 +976,27 @@ describe('runTaskOnce', () => {
     });
   });
 
+  test('rejects a benchmark deadline beyond the Node timer limit', async () => {
+    await withDirs(async (fixtureDir, storageRoot) => {
+      const task: Task = {
+        id: 'oversized-benchmark-deadline',
+        instruction: 'must not start',
+        workspaceDir: fixtureDir,
+        verification: { command: 'true', protectedPaths: [] },
+      };
+
+      await assert.rejects(
+        runTaskOnce(fakeConfig, task, {
+          storageRoot,
+          registerBackends: registerFakeBackend,
+          deadlineAtMs: 2_147_483_648,
+          now: () => 0,
+        }),
+        /deadlineAtMs exceeds the Node timer limit of 2147483647ms/,
+      );
+    });
+  });
+
   test('settles an active runtime at the benchmark soft deadline', async () => {
     await withDirs(async (fixtureDir, storageRoot) => {
       const task: Task = {

--- a/packages/headless/src/__tests__/task-agent-controller.test.ts
+++ b/packages/headless/src/__tests__/task-agent-controller.test.ts
@@ -121,6 +121,41 @@ class ReportingBackend implements AgentBackend {
   async dispose(): Promise<void> {}
 }
 
+class DeadlineBackend implements AgentBackend {
+  readonly kind: BackendKind = 'fake';
+  readonly sessionId: string;
+  private release!: () => void;
+  private readonly stopped = new Promise<void>((resolve) => {
+    this.release = resolve;
+  });
+
+  constructor(sessionId: string) {
+    this.sessionId = sessionId;
+  }
+
+  async *send(input: BackendSendInput): AsyncIterable<SessionEvent> {
+    await this.stopped;
+    yield {
+      type: 'complete',
+      id: 'deadline-complete',
+      turnId: input.turnId,
+      ts: Date.now(),
+      stopReason: 'user_stop',
+    };
+  }
+
+  async stop(): Promise<void> {
+    this.release();
+  }
+
+  async respondToPermission(_decision: PermissionDecision): Promise<void> {}
+  async dispose(): Promise<void> {}
+}
+
+const registerDeadlineBackend = (registry: BackendRegistry): void => {
+  registry.register('fake', (ctx) => new DeadlineBackend(ctx.sessionId));
+};
+
 const registerReportingBackend = (registry: BackendRegistry): void => {
   registry.register(
     'ai-sdk',
@@ -829,6 +864,32 @@ async function readAgentRunHeader(
 }
 
 describe('runTaskOnce', () => {
+  test('settles an active runtime at the benchmark soft deadline', async () => {
+    await withDirs(async (fixtureDir, storageRoot) => {
+      const task: Task = {
+        id: 'benchmark-deadline',
+        instruction: 'wait forever',
+        workspaceDir: fixtureDir,
+        verification: { command: 'true', protectedPaths: [] },
+      };
+
+      const result = await runTaskOnce(fakeConfig, task, {
+        storageRoot,
+        registerBackends: registerDeadlineBackend,
+        deadlineAtMs: Date.now() + 25,
+      });
+
+      assert.equal(result.settledByDeadline, true);
+      const runHeader = await readAgentRunHeader(
+        storageRoot,
+        latestInvocation(result).sessionId,
+        latestInvocation(result).runId,
+      );
+      assert.equal(runHeader.status, 'cancelled');
+      assert.equal(runHeader.abortSource, 'benchmark.deadline');
+    });
+  });
+
   test('injects the default headless system prompt before registering a backend', async () => {
     await withDirs(async (fixtureDir, storageRoot) => {
       const task: Task = {

--- a/packages/headless/src/__tests__/task-agent-controller.test.ts
+++ b/packages/headless/src/__tests__/task-agent-controller.test.ts
@@ -25,7 +25,7 @@ import { createRuntimeEventStore } from '@maka/storage';
 import type { Config, Task } from '../contracts.js';
 import type { HeadlessBackendContext } from '../isolation.js';
 import { commandResourceScope, hashNormalizedArgs } from '../permission-grants.js';
-import { runTaskOnce } from '../task-agent-controller.js';
+import { runTaskOnce, type RunTaskOnceResult } from '../task-agent-controller.js';
 import type { TaskPermissionGrant } from '../task-contracts.js';
 import { buildIsolatedHeadlessTools } from '../tools.js';
 
@@ -42,6 +42,12 @@ const registerFakeBackend = (registry: BackendRegistry): void => {
     (ctx) => new FakeBackend({ sessionId: ctx.sessionId, header: ctx.header, store: ctx.store }),
   );
 };
+
+function latestInvocation(result: RunTaskOnceResult) {
+  const invocation = result.invocations.at(-1);
+  assert.ok(invocation, 'task attempt must contain at least one invocation');
+  return invocation;
+}
 
 class ReportingBackend implements AgentBackend {
   readonly kind: BackendKind = 'ai-sdk';
@@ -916,12 +922,12 @@ describe('runTaskOnce', () => {
         assert.deepEqual(tools.actualToolCallCounts, {});
         const runtimeLedger = await readRuntimeEventLedger(
           storageRoot,
-          result.invocation.sessionId,
-          result.invocation.runId,
+          latestInvocation(result).sessionId,
+          latestInvocation(result).runId,
         );
         const lineage = result.projection.attempts[0]?.executionLineage[0];
-        assert.equal(lineage?.execution?.invocationId, result.invocation.invocationId);
-        assert.equal(lineage?.execution?.agentRunId, result.invocation.runId);
+        assert.equal(lineage?.execution?.invocationId, latestInvocation(result).invocationId);
+        assert.equal(lineage?.execution?.agentRunId, latestInvocation(result).runId);
         assert.equal(lineage?.runtimeCoverage?.lowWater?.sequence, 0);
         assert.equal(lineage?.runtimeCoverage?.lowWater?.eventId, runtimeLedger[0]?.id);
         assert.equal(lineage?.runtimeCoverage?.highWater.sequence, runtimeLedger.length - 1);
@@ -929,10 +935,10 @@ describe('runTaskOnce', () => {
         assert.equal(lineage?.runtimeCoverage?.eventCount, runtimeLedger.length);
         const runHeader = await readAgentRunHeader(
           storageRoot,
-          result.invocation.sessionId,
-          result.invocation.runId,
+          latestInvocation(result).sessionId,
+          latestInvocation(result).runId,
         );
-        assert.equal(runHeader.invocationId, result.invocation.invocationId);
+        assert.equal(runHeader.invocationId, latestInvocation(result).invocationId);
       } finally {
         SessionManager.prototype.sendMessage = original;
       }
@@ -1163,7 +1169,6 @@ describe('runTaskOnce', () => {
       assert.equal(result.projection.latestVerifierResult?.passed, true);
       assert.equal(result.resultRecord.passed, true);
       assert.equal(result.invocations.length, 2);
-      assert.equal(result.invocations.at(-1), result.invocation);
       assert.equal(result.projection.attempts[0]?.executionLineage.length, 2);
       assert.equal(
         new Set(
@@ -1482,8 +1487,8 @@ describe('runTaskOnce', () => {
       assert.equal(failed.projection.error?.class, 'backend_failed');
       const failedRuntimeEvents = await readRuntimeEventLedger(
         storageRoot,
-        failed.invocation.sessionId,
-        failed.invocation.runId,
+        latestInvocation(failed).sessionId,
+        latestInvocation(failed).runId,
       );
       assert.deepEqual(
         failedRuntimeEvents
@@ -1538,17 +1543,17 @@ describe('runTaskOnce', () => {
         runtimeEventStore,
       });
 
-      assert.equal(result.invocation.status, 'failed');
-      assert.equal(result.invocation.failure?.message, 'terminal append failed');
+      assert.equal(latestInvocation(result).status, 'failed');
+      assert.equal(latestInvocation(result).failure?.message, 'terminal append failed');
       const runtimeEvents = await runtimeEventStore.readRuntimeEvents(
-        result.invocation.sessionId,
-        result.invocation.runId,
+        latestInvocation(result).sessionId,
+        latestInvocation(result).runId,
       );
       assert.equal(runtimeEvents.some(isTerminalRuntimeEvent), false);
       const runHeader = await readAgentRunHeader(
         storageRoot,
-        result.invocation.sessionId,
-        result.invocation.runId,
+        latestInvocation(result).sessionId,
+        latestInvocation(result).runId,
       );
       assert.notEqual(runHeader.status, 'completed');
       assert.notEqual(runHeader.status, 'failed');
@@ -1590,8 +1595,8 @@ describe('runTaskOnce', () => {
       assert.equal(result.projection.permissionRequests[0]?.resourceScope.kind, 'command');
       const runtimeEvents = await readRuntimeEventLedger(
         storageRoot,
-        result.invocation.sessionId,
-        result.invocation.runId,
+        latestInvocation(result).sessionId,
+        latestInvocation(result).runId,
       );
       assert.equal(runtimeEvents.some(isTerminalRuntimeEvent), false);
       assert.ok(
@@ -1762,7 +1767,7 @@ describe('runTaskOnce', () => {
       assert.equal((feedback.details.isolation as { label?: string }).label, 'unit isolation');
       assert.equal(
         (feedback.details.runtimeRefs as { runId?: string }).runId,
-        result.invocation.runId,
+        latestInvocation(result).runId,
       );
       assert.ok(
         (feedback.details.runtimeRefs as { runtimeEventIds?: string[] }).runtimeEventIds?.includes(
@@ -1781,9 +1786,9 @@ describe('runTaskOnce', () => {
       const runtimeEventsPath = join(
         storageRoot,
         'sessions',
-        result.invocation.sessionId,
+        latestInvocation(result).sessionId,
         'runs',
-        result.invocation.runId,
+        latestInvocation(result).runId,
         'runtime-events.jsonl',
       );
       const runtimeEvents = await readFile(runtimeEventsPath, 'utf8');

--- a/packages/headless/src/__tests__/task-agent-controller.test.ts
+++ b/packages/headless/src/__tests__/task-agent-controller.test.ts
@@ -152,6 +152,55 @@ class DeadlineBackend implements AgentBackend {
   async dispose(): Promise<void> {}
 }
 
+class ResettingDeadlineBackend implements AgentBackend {
+  readonly kind: BackendKind = 'fake';
+
+  constructor(
+    readonly sessionId: string,
+    private readonly counters: { sendCalls: number },
+  ) {}
+
+  async *send(input: BackendSendInput): AsyncIterable<SessionEvent> {
+    this.counters.sendCalls += 1;
+    yield {
+      type: 'complete',
+      id: 'resetting-deadline-complete',
+      turnId: input.turnId,
+      ts: Date.now(),
+      stopReason: 'end_turn',
+    };
+  }
+
+  async stop(): Promise<void> {}
+  async respondToPermission(_decision: PermissionDecision): Promise<void> {}
+  async dispose(): Promise<void> {}
+}
+
+class DeadlineRepairBackend implements AgentBackend {
+  readonly kind: BackendKind = 'ai-sdk';
+
+  constructor(
+    readonly sessionId: string,
+    private readonly state: { now: number; prompts: string[] },
+  ) {}
+
+  async *send(input: BackendSendInput): AsyncIterable<SessionEvent> {
+    this.state.prompts.push(input.text);
+    if (this.state.prompts.length === 1) this.state.now = 100;
+    yield {
+      type: 'complete',
+      id: `deadline-repair-complete-${this.state.prompts.length}`,
+      turnId: input.turnId,
+      ts: this.state.now,
+      stopReason: 'end_turn',
+    };
+  }
+
+  async stop(): Promise<void> {}
+  async respondToPermission(_decision: PermissionDecision): Promise<void> {}
+  async dispose(): Promise<void> {}
+}
+
 const registerDeadlineBackend = (registry: BackendRegistry): void => {
   registry.register('fake', (ctx) => new DeadlineBackend(ctx.sessionId));
 };
@@ -864,6 +913,31 @@ async function readAgentRunHeader(
 }
 
 describe('runTaskOnce', () => {
+  test('does not dispatch a runtime attempt after the benchmark deadline', async () => {
+    await withDirs(async (fixtureDir, storageRoot) => {
+      const counters = { sendCalls: 0 };
+      const task: Task = {
+        id: 'expired-benchmark-deadline',
+        instruction: 'must not start',
+        workspaceDir: fixtureDir,
+        verification: { command: 'true', protectedPaths: [] },
+      };
+
+      const result = await runTaskOnce(fakeConfig, task, {
+        storageRoot,
+        registerBackends: (registry) => {
+          registry.register('fake', (ctx) => new ResettingDeadlineBackend(ctx.sessionId, counters));
+        },
+        deadlineAtMs: Date.now() - 1,
+      });
+
+      assert.equal(counters.sendCalls, 0);
+      assert.equal(result.settledByDeadline, true);
+      assert.equal(latestInvocation(result).status, 'failed');
+      assert.equal(latestInvocation(result).failure?.class, 'aborted');
+    });
+  });
+
   test('settles an active runtime at the benchmark soft deadline', async () => {
     await withDirs(async (fixtureDir, storageRoot) => {
       const task: Task = {
@@ -880,6 +954,8 @@ describe('runTaskOnce', () => {
       });
 
       assert.equal(result.settledByDeadline, true);
+      assert.equal(result.projection.status, 'budget_exhausted');
+      assert.equal(result.projection.events.at(-1)?.type, 'task_run_budget_exhausted');
       const runHeader = await readAgentRunHeader(
         storageRoot,
         latestInvocation(result).sessionId,
@@ -887,6 +963,46 @@ describe('runTaskOnce', () => {
       );
       assert.equal(runHeader.status, 'cancelled');
       assert.equal(runHeader.abortSource, 'benchmark.deadline');
+    });
+  });
+
+  test('skips optional heavy-task work after a repair settles at the deadline', async () => {
+    await withDirs(async (fixtureDir, storageRoot) => {
+      const state = { now: 0, prompts: [] as string[] };
+      const config: Config = { ...fakeConfig, backend: 'ai-sdk', heavyTaskMode: true };
+      const task: Task = {
+        id: 'repair-deadline',
+        instruction: 'complete the heavy task',
+        workspaceDir: fixtureDir,
+        verification: { command: 'true', protectedPaths: [] },
+      };
+
+      const result = await runTaskOnce(config, task, {
+        storageRoot,
+        now: () => state.now,
+        registerBackends: (registry) => {
+          registry.register('ai-sdk', (ctx) => new DeadlineRepairBackend(ctx.sessionId, state));
+        },
+        realBackendIsolation: {
+          kind: 'external',
+          label: 'unit isolated executor',
+          toolExecutor: {
+            async exec() {
+              return { exitCode: 0, stdout: '', stderr: '' };
+            },
+          },
+        },
+        deadlineAtMs: 50,
+      });
+
+      assert.equal(state.prompts.length, 1);
+      assert.equal(result.settledByDeadline, true);
+      assert.equal(
+        result.projection.events.filter(
+          (event) => event.type === 'heavy_task_self_check_gate_recorded',
+        ).length,
+        1,
+      );
     });
   });
 

--- a/packages/headless/src/__tests__/task-agent-controller.test.ts
+++ b/packages/headless/src/__tests__/task-agent-controller.test.ts
@@ -1162,6 +1162,8 @@ describe('runTaskOnce', () => {
       assert.equal(result.projection.latestHeavyTaskSelfCheckGate?.action, 'allow_finalize');
       assert.equal(result.projection.latestVerifierResult?.passed, true);
       assert.equal(result.resultRecord.passed, true);
+      assert.equal(result.invocations.length, 2);
+      assert.equal(result.invocations.at(-1), result.invocation);
       assert.equal(result.projection.attempts[0]?.executionLineage.length, 2);
       assert.equal(
         new Set(

--- a/packages/headless/src/autonomous-agent-loop.ts
+++ b/packages/headless/src/autonomous-agent-loop.ts
@@ -277,7 +277,6 @@ export async function runAutonomousTask(
         newId,
         afterAttemptBudget,
         'benchmark deadline reached during attempt',
-        options.interventionPolicy,
       );
       return {
         taskRunId,

--- a/packages/headless/src/autonomous-agent-loop.ts
+++ b/packages/headless/src/autonomous-agent-loop.ts
@@ -255,7 +255,10 @@ export async function runAutonomousTask(
     latestResultRecord = attempt.resultRecord;
     runtimeStepsUsed += attempt.resultRecord.steps;
     if (options.replayPriorAttemptRuntimeContext) {
-      priorRuntimeContext = [...priorRuntimeContext, ...attempt.invocation.events];
+      priorRuntimeContext = [
+        ...priorRuntimeContext,
+        ...attempt.invocations.flatMap((invocation) => invocation.events),
+      ];
     }
 
     const afterAttemptBudget = budgetSnapshot(

--- a/packages/headless/src/autonomous-agent-loop.ts
+++ b/packages/headless/src/autonomous-agent-loop.ts
@@ -268,6 +268,23 @@ export async function runAutonomousTask(
       startedAt,
       now(),
     );
+    if (attempt.settledByDeadline) {
+      await appendBudgetTerminal(
+        taskRunStore,
+        taskRunId,
+        now,
+        newId,
+        afterAttemptBudget,
+        'benchmark deadline reached during attempt',
+        options.interventionPolicy,
+      );
+      return {
+        taskRunId,
+        attempts,
+        projection: await taskRunStore.project(taskRunId),
+        resultRecord: attempt.resultRecord,
+      };
+    }
     const selfCheck = isWallTimeExhausted(afterAttemptBudget)
       ? undefined
       : await maybeRecordSelfCheck(

--- a/packages/headless/src/autonomous-agent-loop.ts
+++ b/packages/headless/src/autonomous-agent-loop.ts
@@ -191,16 +191,17 @@ export async function runAutonomousTask(
   let runtimeStepsUsed = 0;
   let latestResultRecord: ResultRecord | undefined;
   let priorRuntimeContext = options.priorRuntimeContext ? [...options.priorRuntimeContext] : [];
+  const budgetStartedAt = now();
 
   while (attempts.length < options.budget.maxAttempts) {
     const beforeAttemptBudget = budgetSnapshot(
       options.budget,
       attempts.length,
       runtimeStepsUsed,
-      startedAt,
+      budgetStartedAt,
       now(),
     );
-    if (isWallTimeExhausted(beforeAttemptBudget)) {
+    if (attempts.length > 0 && isWallTimeExhausted(beforeAttemptBudget)) {
       await appendSystemFeedback(
         taskRunStore,
         taskRunId,
@@ -265,7 +266,7 @@ export async function runAutonomousTask(
       options.budget,
       attempts.length,
       runtimeStepsUsed,
-      startedAt,
+      budgetStartedAt,
       now(),
     );
     if (attempt.settledByDeadline) {
@@ -389,7 +390,7 @@ export async function runAutonomousTask(
     options.budget,
     attempts.length,
     runtimeStepsUsed,
-    startedAt,
+    budgetStartedAt,
     now(),
   );
   if (latestResultRecord?.passed) {

--- a/packages/headless/src/cell-output.ts
+++ b/packages/headless/src/cell-output.ts
@@ -128,6 +128,7 @@ export interface HarborCellOutput {
 export function buildHarborCellOutput(input: {
   invocation: InvocationResult;
   runtimeEventsPath: string;
+  promptHash?: string;
   executionIdentity?: HarborCellExecutionIdentity;
   deadlineSettlement?: HarborCellDeadlineSettlement;
   contextBudgetPolicy?: HarborCellContextBudgetPolicySnapshot;
@@ -136,12 +137,13 @@ export function buildHarborCellOutput(input: {
 }): HarborCellOutput {
   const { invocation } = input;
   const tokenSummary = summarizeCellTokens(invocation.events);
+  const promptHash = input.promptHash ?? promptHashField(invocation.events).promptHash;
   return {
     schemaVersion: HARBOR_CELL_OUTPUT_SCHEMA_VERSION,
     status: invocation.status,
     ...(invocation.failure?.class ? { errorClass: invocation.failure.class } : {}),
     runtimeEventsPath: input.runtimeEventsPath,
-    ...promptHashField(invocation.events),
+    ...(promptHash ? { promptHash } : {}),
     ...(input.executionIdentity ? { executionIdentity: input.executionIdentity } : {}),
     ...(input.deadlineSettlement ? { deadlineSettlement: input.deadlineSettlement } : {}),
     ...(tokenSummary ? { tokenSummary } : {}),
@@ -160,6 +162,23 @@ export function buildHarborCellOutput(input: {
       runId: invocation.runId,
       turnId: invocation.turnId,
     },
+  };
+}
+
+export function combineInvocations(invocations: readonly InvocationResult[]): InvocationResult {
+  const first = invocations[0];
+  const last = invocations[invocations.length - 1];
+  if (!first || !last) throw new Error('cannot combine empty Harbor invocations');
+  return {
+    invocationId: last.invocationId,
+    sessionId: last.sessionId,
+    runId: last.runId,
+    turnId: last.turnId,
+    status: last.status,
+    ...(last.failure ? { failure: last.failure } : {}),
+    events: invocations.flatMap((candidate) => candidate.events),
+    startedAt: first.startedAt,
+    finishedAt: last.finishedAt,
   };
 }
 

--- a/packages/headless/src/harbor-cell-tool-executor.ts
+++ b/packages/headless/src/harbor-cell-tool-executor.ts
@@ -187,21 +187,13 @@ function requiredHarborEnv(env: RunHarborCellEnv, name: string): string {
   return value;
 }
 
-/** Provider secrets the LLM backend already captured; task tool subprocesses must
- * never see them, or a candidate prompt could `cat $..._API_KEY_FILE` and exfiltrate. */
-const HOST_PROVIDER_SECRET_ENV_NAMES = new Set([
-  'MAKA_API_KEY',
-  'MAKA_HOST_API_KEY',
-  'MAKA_HOST_API_KEY_FILE',
-]);
-
 function childProcessEnv(env: RunHarborCellEnv): NodeJS.ProcessEnv {
   const childEnv: NodeJS.ProcessEnv = { ...process.env };
   for (const [key, value] of Object.entries(env)) {
     if (value !== undefined) childEnv[key] = value;
   }
   for (const key of Object.keys(childEnv)) {
-    if (HOST_PROVIDER_SECRET_ENV_NAMES.has(key) || isProviderCredentialSecretEnvName(key)) {
+    if (isProviderCredentialSecretEnvName(key)) {
       delete childEnv[key];
     }
   }

--- a/packages/headless/src/harbor-cell-tool-executor.ts
+++ b/packages/headless/src/harbor-cell-tool-executor.ts
@@ -9,6 +9,7 @@ import { defaultShellPlan, runShellWithBoundedTail, type MakaTool } from '@maka/
 import { numericEnv, type RunHarborCellEnv } from './headless-run-env.js';
 import type { IsolatedCommandResult, IsolatedToolExecutor } from './isolation.js';
 import { ISOLATED_HEADLESS_TOOL_NAMES } from './isolation.js';
+import { isProviderCredentialSecretEnvName } from './provider-env.js';
 import {
   buildIsolatedHeadlessTools,
   FRAMED_FILE_TOOL_MAX_TRANSPORT_BYTES,
@@ -188,7 +189,11 @@ function requiredHarborEnv(env: RunHarborCellEnv, name: string): string {
 
 /** Provider secrets the LLM backend already captured; task tool subprocesses must
  * never see them, or a candidate prompt could `cat $..._API_KEY_FILE` and exfiltrate. */
-const TOOL_CHILD_SECRET_ENV = /_API_KEY(_FILE)?$/;
+const HOST_PROVIDER_SECRET_ENV_NAMES = new Set([
+  'MAKA_API_KEY',
+  'MAKA_HOST_API_KEY',
+  'MAKA_HOST_API_KEY_FILE',
+]);
 
 function childProcessEnv(env: RunHarborCellEnv): NodeJS.ProcessEnv {
   const childEnv: NodeJS.ProcessEnv = { ...process.env };
@@ -196,7 +201,9 @@ function childProcessEnv(env: RunHarborCellEnv): NodeJS.ProcessEnv {
     if (value !== undefined) childEnv[key] = value;
   }
   for (const key of Object.keys(childEnv)) {
-    if (TOOL_CHILD_SECRET_ENV.test(key)) delete childEnv[key];
+    if (HOST_PROVIDER_SECRET_ENV_NAMES.has(key) || isProviderCredentialSecretEnvName(key)) {
+      delete childEnv[key];
+    }
   }
   return childEnv;
 }

--- a/packages/headless/src/harbor-cell-tool-executor.ts
+++ b/packages/headless/src/harbor-cell-tool-executor.ts
@@ -9,7 +9,7 @@ import { defaultShellPlan, runShellWithBoundedTail, type MakaTool } from '@maka/
 import { numericEnv, type RunHarborCellEnv } from './headless-run-env.js';
 import type { IsolatedCommandResult, IsolatedToolExecutor } from './isolation.js';
 import { ISOLATED_HEADLESS_TOOL_NAMES } from './isolation.js';
-import { isProviderCredentialSecretEnvName } from './provider-env.js';
+import { isSensitiveEnvName } from './provider-env.js';
 import {
   buildIsolatedHeadlessTools,
   FRAMED_FILE_TOOL_MAX_TRANSPORT_BYTES,
@@ -193,7 +193,7 @@ function childProcessEnv(env: RunHarborCellEnv): NodeJS.ProcessEnv {
     if (value !== undefined) childEnv[key] = value;
   }
   for (const key of Object.keys(childEnv)) {
-    if (isProviderCredentialSecretEnvName(key)) {
+    if (isSensitiveEnvName(key)) {
       delete childEnv[key];
     }
   }

--- a/packages/headless/src/harbor-cell.ts
+++ b/packages/headless/src/harbor-cell.ts
@@ -94,8 +94,9 @@ export {
 } from './harbor-cell-tool-executor.js';
 export {
   providerApiKeyEnvName,
-  resolveHostProviderAuthorityEnv,
+  resolveHostProviderAuthority,
   resolveHarborCellAiSdkEnv,
+  type ResolvedHostProviderAuthority,
   type ResolvedHarborCellAiSdkEnv,
 } from './provider-env.js';
 export type { RunHarborCellEnv } from './headless-run-env.js';

--- a/packages/headless/src/harbor-cell.ts
+++ b/packages/headless/src/harbor-cell.ts
@@ -103,6 +103,7 @@ export type { RunHarborCellEnv } from './headless-run-env.js';
 
 export const HARBOR_CELL_OUTPUT_FILENAME = 'maka-cell-output.json';
 export const HARBOR_CELL_RUNTIME_EVENTS_FILENAME = 'runtime-events.jsonl';
+export const HARBOR_CELL_TRACE_EVENTS_FILENAME = 'trace-events.jsonl';
 export const HARBOR_CELL_EXECUTION_IDENTITY_FILENAME = 'maka-cell-execution-identity.json';
 export const HARBOR_CELL_USAGE_CHECKPOINT_FILENAME = 'maka-cell-usage-checkpoint.json';
 
@@ -483,6 +484,35 @@ export async function writeHarborCellArtifacts(
   );
   await writeHarborCellArtifact(outputPath, `${JSON.stringify(output, null, 2)}\n`);
   return { output, outputPath, runtimeEventsPath };
+}
+
+export async function writeHarborTaskRunTrace(input: {
+  outputDir: string;
+  storageRoot: string;
+  invocations: readonly InvocationResult[];
+}): Promise<string> {
+  const chunks = await Promise.all(
+    input.invocations.map((invocation) =>
+      readFile(
+        join(
+          input.storageRoot,
+          'sessions',
+          invocation.sessionId,
+          'runs',
+          invocation.runId,
+          'events.jsonl',
+        ),
+        'utf8',
+      ),
+    ),
+  );
+  const nonEmptyChunks = chunks.map((chunk) => chunk.trimEnd()).filter(Boolean);
+  const traceEventsPath = join(input.outputDir, HARBOR_CELL_TRACE_EVENTS_FILENAME);
+  await writeHarborCellArtifact(
+    traceEventsPath,
+    nonEmptyChunks.length > 0 ? `${nonEmptyChunks.join('\n')}\n` : '',
+  );
+  return traceEventsPath;
 }
 
 export async function runHarborCellFromEnv(

--- a/packages/headless/src/harbor-cell.ts
+++ b/packages/headless/src/harbor-cell.ts
@@ -91,6 +91,7 @@ export {
 } from './harbor-cell-tool-executor.js';
 export {
   providerApiKeyEnvName,
+  resolveHostProviderAuthorityEnv,
   resolveHarborCellAiSdkEnv,
   type ResolvedHarborCellAiSdkEnv,
 } from './provider-env.js';

--- a/packages/headless/src/harbor-cell.ts
+++ b/packages/headless/src/harbor-cell.ts
@@ -58,6 +58,7 @@ import {
 } from './task-ledger-experiment.js';
 import {
   booleanEnv,
+  MAX_NODE_TIMER_MS,
   numericEnv,
   positiveIntEnv,
   type RunHarborCellEnv,
@@ -680,7 +681,11 @@ export function harborCellMaxStepsFromEnv(env: RunHarborCellEnv = process.env): 
 export function harborCellSoftTimeoutMsFromEnv(
   env: RunHarborCellEnv = process.env,
 ): number | undefined {
-  return positiveIntEnv(env.MAKA_CELL_SOFT_TIMEOUT_MS, 'MAKA_CELL_SOFT_TIMEOUT_MS');
+  const value = positiveIntEnv(env.MAKA_CELL_SOFT_TIMEOUT_MS, 'MAKA_CELL_SOFT_TIMEOUT_MS');
+  if (value !== undefined && value > MAX_NODE_TIMER_MS) {
+    throw new Error(`MAKA_CELL_SOFT_TIMEOUT_MS must not exceed ${MAX_NODE_TIMER_MS}`);
+  }
+  return value;
 }
 
 function isToolCallStepCap(invocation: InvocationResult): boolean {

--- a/packages/headless/src/harbor-cell.ts
+++ b/packages/headless/src/harbor-cell.ts
@@ -33,9 +33,12 @@ import {
 import { registerFakeBackend } from './backends.js';
 import {
   buildHarborCellOutput,
+  combineInvocations,
   countRuntimeSteps,
   validateHarborCellOutput,
   type HarborCellContextBudgetPolicySnapshot,
+  type HarborCellDeadlineSettlement,
+  type HarborCellExecutionIdentity,
   type HarborCellOutput,
 } from './cell-output.js';
 import type { Config, Task } from './contracts.js';
@@ -154,6 +157,23 @@ export interface RunHarborCellResult {
   outputPath: string;
   runtimeEventsPath: string;
   settledByDeadline: boolean;
+}
+
+export interface WriteHarborCellArtifactsInput {
+  invocation: InvocationResult;
+  outputDir: string;
+  promptHash?: string;
+  executionIdentity?: HarborCellExecutionIdentity;
+  deadlineSettlement?: HarborCellDeadlineSettlement;
+  contextBudgetPolicy?: HarborCellContextBudgetPolicySnapshot;
+  continuationSummary?: HarborCellContinuationSummary;
+  taskToolSummaryEnabled?: boolean;
+}
+
+export interface WriteHarborCellArtifactsResult {
+  output: HarborCellOutput;
+  outputPath: string;
+  runtimeEventsPath: string;
 }
 
 export const HARBOR_CELL_DEFAULT_CONTINUATION_PROMPT =
@@ -284,12 +304,7 @@ export async function runHarborCell(input: RunHarborCellInput): Promise<RunHarbo
     systemPromptHash: prompt.systemPromptHash,
     pricingProfile: input.pricingProfile ?? 'unconfigured',
   };
-  await mkdir(input.outputDir, { recursive: true });
-  await writeFile(
-    join(input.outputDir, HARBOR_CELL_EXECUTION_IDENTITY_FILENAME),
-    `${JSON.stringify(executionIdentity, null, 2)}\n`,
-    { encoding: 'utf8', flush: true },
-  );
+  await writeHarborCellExecutionIdentity(input.outputDir, executionIdentity);
 
   let invocation: InvocationResult | undefined;
   const manager = new SessionManager({
@@ -407,39 +422,66 @@ export async function runHarborCell(input: RunHarborCellInput): Promise<RunHarbo
     ? buildContinuationSummary(continuationPolicy, invocations, stepCapHits)
     : undefined;
 
+  const artifacts = await writeHarborCellArtifacts({
+    invocation: combinedInvocation,
+    outputDir: input.outputDir,
+    executionIdentity,
+    ...(settledByDeadline
+      ? {
+          deadlineSettlement: {
+            source: 'benchmark.deadline' as const,
+            mode: 'immediate' as const,
+          },
+        }
+      : {}),
+    ...(input.contextBudgetPolicy ? { contextBudgetPolicy: input.contextBudgetPolicy } : {}),
+    ...(continuationSummary ? { continuationSummary } : {}),
+    ...(input.taskToolSummaryEnabled !== undefined
+      ? { taskToolSummaryEnabled: input.taskToolSummaryEnabled }
+      : {}),
+  });
+
+  return {
+    invocation: combinedInvocation,
+    ...artifacts,
+    settledByDeadline,
+  };
+}
+
+export async function writeHarborCellExecutionIdentity(
+  outputDir: string,
+  executionIdentity: HarborCellExecutionIdentity,
+): Promise<void> {
+  await mkdir(outputDir, { recursive: true });
+  await writeHarborCellArtifact(
+    join(outputDir, HARBOR_CELL_EXECUTION_IDENTITY_FILENAME),
+    `${JSON.stringify(executionIdentity, null, 2)}\n`,
+  );
+}
+
+export async function writeHarborCellArtifacts(
+  input: WriteHarborCellArtifactsInput,
+): Promise<WriteHarborCellArtifactsResult> {
   await mkdir(input.outputDir, { recursive: true });
   const runtimeEventsPath = join(input.outputDir, HARBOR_CELL_RUNTIME_EVENTS_FILENAME);
   const outputPath = join(input.outputDir, HARBOR_CELL_OUTPUT_FILENAME);
-  await writeHarborCellArtifact(runtimeEventsPath, runtimeEventsJsonl(combinedInvocation));
+  await writeHarborCellArtifact(runtimeEventsPath, runtimeEventsJsonl(input.invocation));
   const output = validateHarborCellOutput(
     buildHarborCellOutput({
-      invocation: combinedInvocation,
+      invocation: input.invocation,
       runtimeEventsPath,
-      executionIdentity,
-      ...(settledByDeadline
-        ? {
-            deadlineSettlement: {
-              source: 'benchmark.deadline' as const,
-              mode: 'immediate' as const,
-            },
-          }
-        : {}),
+      ...(input.promptHash ? { promptHash: input.promptHash } : {}),
+      ...(input.executionIdentity ? { executionIdentity: input.executionIdentity } : {}),
+      ...(input.deadlineSettlement ? { deadlineSettlement: input.deadlineSettlement } : {}),
       ...(input.contextBudgetPolicy ? { contextBudgetPolicy: input.contextBudgetPolicy } : {}),
-      ...(continuationSummary ? { continuationSummary } : {}),
+      ...(input.continuationSummary ? { continuationSummary: input.continuationSummary } : {}),
       ...(input.taskToolSummaryEnabled !== undefined
         ? { taskToolSummaryEnabled: input.taskToolSummaryEnabled }
         : {}),
     }),
   );
   await writeHarborCellArtifact(outputPath, `${JSON.stringify(output, null, 2)}\n`);
-
-  return {
-    invocation: combinedInvocation,
-    output,
-    outputPath,
-    runtimeEventsPath,
-    settledByDeadline,
-  };
+  return { output, outputPath, runtimeEventsPath };
 }
 
 export async function runHarborCellFromEnv(
@@ -569,7 +611,7 @@ export async function runHarborCellFromEnv(
 export function reasoningEffortFromEnv(
   value: string | undefined,
 ): import('@maka/core').ThinkingLevel | undefined {
-  if (value === undefined) return undefined;
+  if (value === undefined || value === '') return undefined;
   if (!isThinkingLevel(value)) throw new Error(`unsupported MAKA_REASONING_EFFORT: ${value}`);
   return value;
 }
@@ -615,23 +657,6 @@ function isToolCallStepCap(invocation: InvocationResult): boolean {
     invocation.failure?.class === 'tool_step_cap_reached' ||
     invocation.failure?.class === 'incomplete_tool_calls'
   );
-}
-
-function combineInvocations(invocations: readonly InvocationResult[]): InvocationResult {
-  const first = invocations[0];
-  const last = invocations[invocations.length - 1];
-  if (!first || !last) throw new Error('cannot combine empty Harbor invocations');
-  return {
-    invocationId: last.invocationId,
-    sessionId: last.sessionId,
-    runId: last.runId,
-    turnId: last.turnId,
-    status: last.status,
-    ...(last.failure ? { failure: last.failure } : {}),
-    events: invocations.flatMap((candidate) => candidate.events),
-    startedAt: first.startedAt,
-    finishedAt: last.finishedAt,
-  };
 }
 
 function buildContinuationSummary(

--- a/packages/headless/src/harbor-cli.ts
+++ b/packages/headless/src/harbor-cli.ts
@@ -22,6 +22,7 @@ import {
   buildHarborCellContextBudgetPolicySnapshot,
   createHarborCellLocalToolExecutor,
   createHarborHttpToolExecutor,
+  resolveHostProviderAuthorityEnv,
   runHarborCell,
   type RunHarborCellEnv,
   type RunHarborCellInput,
@@ -393,6 +394,13 @@ export async function resolveHarborRunOptions(
     applyConnectionDefaults(env);
   }
   applyApiKeyFile(parsed, env);
+  if (backend === 'ai-sdk') {
+    const modelSpec = parseModelSpec(
+      env.MAKA_MODEL ?? env.HARBOR_MODEL ?? 'deepseek/deepseek-v4-flash',
+      env.MAKA_PROVIDER,
+    );
+    Object.assign(env, resolveHostProviderAuthorityEnv({ provider: modelSpec.provider, env }));
+  }
   const mode = harborMode(valueOf(parsed, env, 'mode', 'MAKA_HARBOR_MODE') ?? 'task-run');
   const isolation = optionalIsolation(
     valueOf(parsed, env, 'isolation', 'MAKA_HARBOR_ISOLATION') ?? env.MAKA_ISOLATION,

--- a/packages/headless/src/harbor-cli.ts
+++ b/packages/headless/src/harbor-cli.ts
@@ -260,14 +260,16 @@ async function runHarborTaskRunMode(options: HarborRunOptions): Promise<number> 
     storageRoot: options.storageRoot,
     invocations,
   });
-  const taxonomy = settledByDeadline
-    ? 'budget_exhausted'
-    : (latestScore?.taxonomy ??
-      run.projection.result?.taxonomy ??
-      taxonomyFromResultRecord(run.resultRecord));
+  const taxonomy =
+    run.projection.status === 'budget_exhausted'
+      ? 'budget_exhausted'
+      : (latestScore?.taxonomy ??
+        run.projection.result?.taxonomy ??
+        taxonomyFromResultRecord(run.resultRecord));
   const benchmarkFailure = classifyExternalHarborBenchmarkFailure({
-    status: settledByDeadline ? 'budget_exhausted' : run.resultRecord.status,
-    errorClass: settledByDeadline ? 'budget_exhausted' : run.resultRecord.errorClass,
+    status:
+      run.projection.status === 'budget_exhausted' ? 'budget_exhausted' : run.resultRecord.status,
+    errorClass: run.resultRecord.errorClass,
     error: run.resultRecord.error,
     taxonomy,
   });
@@ -275,7 +277,7 @@ async function runHarborTaskRunMode(options: HarborRunOptions): Promise<number> 
     `${JSON.stringify({
       mode: 'task-run',
       taskRunId: run.taskRunId,
-      status: settledByDeadline ? 'budget_exhausted' : run.projection.status,
+      status: run.projection.status,
       settledByDeadline,
       taxonomy,
       scored: latestScore?.scored ?? run.resultRecord.scored ?? false,

--- a/packages/headless/src/harbor-cli.ts
+++ b/packages/headless/src/harbor-cli.ts
@@ -145,6 +145,7 @@ async function runHarborCellMode(options: HarborRunOptions): Promise<number> {
     outputDir: options.outDir,
     storageRoot: options.storageRoot,
     ...(options.contextBudgetPolicy ? { contextBudgetPolicy: options.contextBudgetPolicy } : {}),
+    ...(options.softTimeoutMs !== undefined ? { settleAfterMs: options.softTimeoutMs } : {}),
     ...(options.registerBackends ? { registerBackends: options.registerBackends } : {}),
     ...(options.realBackendIsolation ? { realBackendIsolation: options.realBackendIsolation } : {}),
     now: options.now,

--- a/packages/headless/src/harbor-cli.ts
+++ b/packages/headless/src/harbor-cli.ts
@@ -238,28 +238,38 @@ async function runHarborTaskRunMode(options: HarborRunOptions): Promise<number> 
   const latestScore = run.projection.latestScoreResult;
   const invocations =
     'attempts' in run ? run.attempts.flatMap((attempt) => attempt.invocations) : run.invocations;
-  const invocation = combineInvocations(invocations);
+  const invocation = invocations.length > 0 ? combineInvocations(invocations) : undefined;
   const settledByDeadline =
     'attempts' in run
       ? run.attempts.some((attempt) => attempt.settledByDeadline)
       : run.settledByDeadline;
-  const cellArtifacts = await writeHarborCellArtifacts({
-    outputDir: options.cellArtifactDir,
-    executionIdentity,
-    invocation,
-    promptHash: executionIdentity.systemPromptHash,
-    ...(settledByDeadline
-      ? {
-          deadlineSettlement: { source: 'benchmark.deadline' as const, mode: 'immediate' as const },
-        }
-      : {}),
-    ...(options.contextBudgetPolicy ? { contextBudgetPolicy: options.contextBudgetPolicy } : {}),
-  });
-  const traceEventsPath = await writeHarborTaskRunTrace({
-    outputDir: options.cellArtifactDir,
-    storageRoot: options.storageRoot,
-    invocations,
-  });
+  const cellArtifacts = invocation
+    ? await writeHarborCellArtifacts({
+        outputDir: options.cellArtifactDir,
+        executionIdentity,
+        invocation,
+        promptHash: executionIdentity.systemPromptHash,
+        ...(settledByDeadline
+          ? {
+              deadlineSettlement: {
+                source: 'benchmark.deadline' as const,
+                mode: 'immediate' as const,
+              },
+            }
+          : {}),
+        ...(options.contextBudgetPolicy
+          ? { contextBudgetPolicy: options.contextBudgetPolicy }
+          : {}),
+      })
+    : undefined;
+  const traceEventsPath =
+    invocations.length > 0
+      ? await writeHarborTaskRunTrace({
+          outputDir: options.cellArtifactDir,
+          storageRoot: options.storageRoot,
+          invocations,
+        })
+      : undefined;
   const taxonomy =
     run.projection.status === 'budget_exhausted'
       ? 'budget_exhausted'
@@ -284,13 +294,17 @@ async function runHarborTaskRunMode(options: HarborRunOptions): Promise<number> 
       authoritative: latestScore?.authority?.authoritative ?? false,
       benchmarkFailureKind: benchmarkFailure.kind,
       benchmarkFailureShouldThrow: benchmarkFailure.shouldThrow,
-      outputPath: cellArtifacts.outputPath,
-      runtimeEventsPath: cellArtifacts.runtimeEventsPath,
-      traceEventsPath,
+      ...(cellArtifacts
+        ? {
+            outputPath: cellArtifacts.outputPath,
+            runtimeEventsPath: cellArtifacts.runtimeEventsPath,
+          }
+        : {}),
+      ...(traceEventsPath ? { traceEventsPath } : {}),
       exportDir,
       files: exported.files,
       result: {
-        status: settledByDeadline ? 'budget_exhausted' : run.resultRecord.status,
+        status: run.resultRecord.status,
         passed: run.resultRecord.passed,
         errorClass: run.resultRecord.errorClass,
       },

--- a/packages/headless/src/harbor-cli.ts
+++ b/packages/headless/src/harbor-cli.ts
@@ -1,18 +1,15 @@
 import { randomUUID } from 'node:crypto';
 import { readFileSync } from 'node:fs';
-import { copyFile, mkdir, readFile, writeFile } from 'node:fs/promises';
+import { mkdir, readFile } from 'node:fs/promises';
 import { homedir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
-import type { BackendKind, ProviderType, RuntimeEvent } from '@maka/core';
-import { isThinkingLevel, PROVIDER_DEFAULTS, normalizeProviderType } from '@maka/core';
+import type { BackendKind, ProviderType } from '@maka/core';
+import { PROVIDER_DEFAULTS, normalizeProviderType } from '@maka/core';
 import type { Config, Task } from './contracts.js';
 import {
   type HarborCellExecutionIdentity,
-  type HarborCellTokenSummary,
-  countRuntimeSteps,
-  summarizeCellTokens,
+  combineInvocations,
   validateHarborCellExecutionIdentity,
-  validateHarborCellOutput,
 } from './cell-output.js';
 import { runAutonomousTask } from './autonomous-agent-loop.js';
 import type { BenchmarkAdapterRegistry } from './benchmark-adapters.js';
@@ -22,8 +19,11 @@ import {
   buildHarborCellContextBudgetPolicySnapshot,
   createHarborCellLocalToolExecutor,
   createHarborHttpToolExecutor,
+  reasoningEffortFromEnv,
   resolveHostProviderAuthorityEnv,
   runHarborCell,
+  writeHarborCellArtifacts,
+  writeHarborCellExecutionIdentity,
   type RunHarborCellEnv,
   type RunHarborCellInput,
 } from './harbor-cell.js';
@@ -232,11 +232,15 @@ async function runHarborTaskRunMode(options: HarborRunOptions): Promise<number> 
     includeEvents: options.includeEvents,
   });
   const latestScore = run.projection.latestScoreResult;
-  const cellArtifacts = await writeTaskRunCellArtifacts({
-    options,
+  const invocations =
+    'attempts' in run ? run.attempts.flatMap((attempt) => attempt.invocations) : run.invocations;
+  const invocation = combineInvocations(invocations);
+  const cellArtifacts = await writeHarborCellArtifacts({
+    outputDir: options.cellArtifactDir,
     executionIdentity,
-    resultRecord: run.resultRecord,
-    scoreDetails: latestScore?.details,
+    invocation,
+    promptHash: executionIdentity.systemPromptHash,
+    ...(options.contextBudgetPolicy ? { contextBudgetPolicy: options.contextBudgetPolicy } : {}),
   });
   const taxonomy =
     latestScore?.taxonomy ??
@@ -273,73 +277,6 @@ async function runHarborTaskRunMode(options: HarborRunOptions): Promise<number> 
   return benchmarkFailure.shouldThrow ? 1 : 0;
 }
 
-async function writeTaskRunCellArtifacts(input: {
-  options: HarborRunOptions;
-  executionIdentity: HarborCellExecutionIdentity;
-  resultRecord: Awaited<ReturnType<typeof runTaskOnce>>['resultRecord'];
-  scoreDetails: Record<string, unknown> | undefined;
-}): Promise<{ outputPath: string; runtimeEventsPath: string }> {
-  const details = input.scoreDetails ?? {};
-  const runtimeRefs = recordValue(details.runtimeRefs);
-  if (!runtimeRefs) throw new Error('task-run result is missing runtime refs');
-  const sessionId = requiredString(runtimeRefs.sessionId, 'runtimeRefs.sessionId');
-  const runId = requiredString(runtimeRefs.runId, 'runtimeRefs.runId');
-  const runtimeEventsSourcePath = join(
-    input.options.storageRoot,
-    'sessions',
-    sessionId,
-    'runs',
-    runId,
-    'runtime-events.jsonl',
-  );
-  const runtimeEventsJsonl = await readFile(runtimeEventsSourcePath, 'utf8');
-  const runtimeEvents = parseTaskRunRuntimeEvents(runtimeEventsJsonl);
-  const runtimeEventsPath = join(input.options.cellArtifactDir, 'runtime-events.jsonl');
-  await copyFile(runtimeEventsSourcePath, runtimeEventsPath);
-  const tokenSummary = summarizeCellTokens(runtimeEvents);
-
-  const promptHash = input.resultRecord.systemPromptHash;
-  if (promptHash !== input.executionIdentity.systemPromptHash) {
-    throw new Error('task-run result prompt hash disagrees with durable execution identity');
-  }
-  const cell = validateHarborCellOutput({
-    schemaVersion: 1,
-    status: details.invocationStatus ?? input.resultRecord.status,
-    ...(details.runtimeFailureClass ? { errorClass: details.runtimeFailureClass } : {}),
-    runtimeEventsPath,
-    ...(promptHash ? { promptHash } : {}),
-    executionIdentity: input.executionIdentity,
-    ...(tokenSummary ? { tokenSummary } : {}),
-    toolSummary: details.tools,
-    steps: countRuntimeSteps(runtimeEvents),
-    durationMs: input.resultRecord.durationMs,
-    startedAt: input.resultRecord.startedAt,
-    finishedAt: input.resultRecord.finishedAt,
-    runtimeRefs: {
-      invocationId: runtimeRefs.invocationId,
-      sessionId,
-      runId,
-      turnId: runtimeRefs.turnId,
-    },
-  });
-  const outputPath = join(input.options.cellArtifactDir, 'maka-cell-output.json');
-  await writeFile(outputPath, `${JSON.stringify(cell, null, 2)}\n`, 'utf8');
-  return { outputPath, runtimeEventsPath };
-}
-
-export function summarizeTaskRunRuntimeEvents(
-  runtimeEventsJsonl: string,
-): HarborCellTokenSummary | undefined {
-  return summarizeCellTokens(parseTaskRunRuntimeEvents(runtimeEventsJsonl));
-}
-
-function parseTaskRunRuntimeEvents(runtimeEventsJsonl: string): RuntimeEvent[] {
-  return runtimeEventsJsonl
-    .split('\n')
-    .filter((line) => line.trim().length > 0)
-    .map((line) => JSON.parse(line) as RuntimeEvent);
-}
-
 async function writeTaskRunExecutionIdentity(
   options: HarborRunOptions,
   task: Task,
@@ -354,27 +291,10 @@ async function writeTaskRunExecutionIdentity(
     ...(options.config.thinkingLevel ? { reasoningEffort: options.config.thinkingLevel } : {}),
     systemPromptMode: prompt.mode,
     systemPromptHash: prompt.systemPromptHash,
-    pricingProfile: options.env.MAKA_TRIAL_PRICING_SOURCE ?? 'runtime',
+    pricingProfile: options.env.MAKA_TRIAL_PRICING_SOURCE ?? 'unconfigured',
   });
-  await writeFile(
-    join(options.cellArtifactDir, 'maka-cell-execution-identity.json'),
-    `${JSON.stringify(executionIdentity, null, 2)}\n`,
-    'utf8',
-  );
+  await writeHarborCellExecutionIdentity(options.cellArtifactDir, executionIdentity);
   return executionIdentity;
-}
-
-function recordValue(value: unknown): Record<string, unknown> | null {
-  return typeof value === 'object' && value !== null && !Array.isArray(value)
-    ? (value as Record<string, unknown>)
-    : null;
-}
-
-function requiredString(value: unknown, field: string): string {
-  if (typeof value !== 'string' || value.length === 0) {
-    throw new Error(`task-run result is missing ${field}`);
-  }
-  return value;
 }
 
 export async function resolveHarborRunOptions(
@@ -599,12 +519,6 @@ function buildConfig(input: {
       ? { economyTaskMode: { enabled: true, reason: 'maka eval harbor run --economy-task' } }
       : {}),
   };
-}
-
-function reasoningEffortFromEnv(value: string | undefined): Config['thinkingLevel'] {
-  if (value === undefined || value === '') return undefined;
-  if (!isThinkingLevel(value)) throw new Error(`unsupported MAKA_REASONING_EFFORT: ${value}`);
-  return value;
 }
 
 function buildBackendRegistration(input: {

--- a/packages/headless/src/harbor-cli.ts
+++ b/packages/headless/src/harbor-cli.ts
@@ -69,6 +69,7 @@ interface HarborRunOptions {
   maxAttempts: number;
   maxRuntimeSteps?: number;
   maxWallTimeMs?: number;
+  softTimeoutMs?: number;
   replayPriorAttemptRuntimeContext: boolean;
   now: () => number;
   newId: () => string;
@@ -181,6 +182,9 @@ async function runHarborTaskRunMode(options: HarborRunOptions): Promise<number> 
     ...(options.realBackendIsolation ? { realBackendIsolation: options.realBackendIsolation } : {}),
     now: options.now,
     newId: options.newId,
+    ...(options.softTimeoutMs !== undefined
+      ? { deadlineAtMs: options.now() + options.softTimeoutMs }
+      : {}),
   };
   const run = options.autonomous
     ? await runAutonomousTask(options.config, task, {
@@ -235,11 +239,20 @@ async function runHarborTaskRunMode(options: HarborRunOptions): Promise<number> 
   const invocations =
     'attempts' in run ? run.attempts.flatMap((attempt) => attempt.invocations) : run.invocations;
   const invocation = combineInvocations(invocations);
+  const settledByDeadline =
+    'attempts' in run
+      ? run.attempts.some((attempt) => attempt.settledByDeadline)
+      : run.settledByDeadline;
   const cellArtifacts = await writeHarborCellArtifacts({
     outputDir: options.cellArtifactDir,
     executionIdentity,
     invocation,
     promptHash: executionIdentity.systemPromptHash,
+    ...(settledByDeadline
+      ? {
+          deadlineSettlement: { source: 'benchmark.deadline' as const, mode: 'immediate' as const },
+        }
+      : {}),
     ...(options.contextBudgetPolicy ? { contextBudgetPolicy: options.contextBudgetPolicy } : {}),
   });
   const traceEventsPath = await writeHarborTaskRunTrace({
@@ -247,13 +260,14 @@ async function runHarborTaskRunMode(options: HarborRunOptions): Promise<number> 
     storageRoot: options.storageRoot,
     invocations,
   });
-  const taxonomy =
-    latestScore?.taxonomy ??
-    run.projection.result?.taxonomy ??
-    taxonomyFromResultRecord(run.resultRecord);
+  const taxonomy = settledByDeadline
+    ? 'budget_exhausted'
+    : (latestScore?.taxonomy ??
+      run.projection.result?.taxonomy ??
+      taxonomyFromResultRecord(run.resultRecord));
   const benchmarkFailure = classifyExternalHarborBenchmarkFailure({
-    status: run.resultRecord.status,
-    errorClass: run.resultRecord.errorClass,
+    status: settledByDeadline ? 'budget_exhausted' : run.resultRecord.status,
+    errorClass: settledByDeadline ? 'budget_exhausted' : run.resultRecord.errorClass,
     error: run.resultRecord.error,
     taxonomy,
   });
@@ -261,7 +275,8 @@ async function runHarborTaskRunMode(options: HarborRunOptions): Promise<number> 
     `${JSON.stringify({
       mode: 'task-run',
       taskRunId: run.taskRunId,
-      status: run.projection.status,
+      status: settledByDeadline ? 'budget_exhausted' : run.projection.status,
+      settledByDeadline,
       taxonomy,
       scored: latestScore?.scored ?? run.resultRecord.scored ?? false,
       authoritative: latestScore?.authority?.authoritative ?? false,
@@ -273,14 +288,14 @@ async function runHarborTaskRunMode(options: HarborRunOptions): Promise<number> 
       exportDir,
       files: exported.files,
       result: {
-        status: run.resultRecord.status,
+        status: settledByDeadline ? 'budget_exhausted' : run.resultRecord.status,
         passed: run.resultRecord.passed,
         errorClass: run.resultRecord.errorClass,
       },
       runtimeRefs: latestScore?.details?.runtimeRefs,
     })}\n`,
   );
-  return benchmarkFailure.shouldThrow ? 1 : 0;
+  return settledByDeadline ? 124 : benchmarkFailure.shouldThrow ? 1 : 0;
 }
 
 async function writeTaskRunExecutionIdentity(
@@ -360,6 +375,10 @@ export async function resolveHarborRunOptions(
     valueOf(parsed, env, 'max-wall-time-sec', 'MAKA_MAX_WALL_TIME_SEC'),
     '--max-wall-time-sec',
   );
+  const softTimeoutMs = optionalPositiveInt(
+    env.MAKA_CELL_SOFT_TIMEOUT_MS,
+    'MAKA_CELL_SOFT_TIMEOUT_MS',
+  );
   const config = buildConfig({
     parsed,
     env,
@@ -393,6 +412,7 @@ export async function resolveHarborRunOptions(
     ),
     ...(maxRuntimeSteps !== undefined ? { maxRuntimeSteps } : {}),
     ...(maxWallTimeSec !== undefined ? { maxWallTimeMs: maxWallTimeSec * 1000 } : {}),
+    ...(softTimeoutMs !== undefined ? { softTimeoutMs } : {}),
     replayPriorAttemptRuntimeContext:
       parsed.bools['replay-prior-attempt-runtime-context'] ||
       truthyEnv(env.MAKA_REPLAY_PRIOR_ATTEMPT_RUNTIME_CONTEXT),

--- a/packages/headless/src/harbor-cli.ts
+++ b/packages/headless/src/harbor-cli.ts
@@ -19,6 +19,7 @@ import {
   buildHarborCellContextBudgetPolicySnapshot,
   createHarborCellLocalToolExecutor,
   createHarborHttpToolExecutor,
+  harborCellSoftTimeoutMsFromEnv,
   reasoningEffortFromEnv,
   runHarborCell,
   writeHarborCellArtifacts,
@@ -392,10 +393,7 @@ export async function resolveHarborRunOptions(
     valueOf(parsed, env, 'max-wall-time-sec', 'MAKA_MAX_WALL_TIME_SEC'),
     '--max-wall-time-sec',
   );
-  const softTimeoutMs = optionalPositiveInt(
-    env.MAKA_CELL_SOFT_TIMEOUT_MS,
-    'MAKA_CELL_SOFT_TIMEOUT_MS',
-  );
+  const softTimeoutMs = harborCellSoftTimeoutMsFromEnv(env);
   const config = buildConfig({
     parsed,
     env,

--- a/packages/headless/src/harbor-cli.ts
+++ b/packages/headless/src/harbor-cli.ts
@@ -23,6 +23,7 @@ import {
   runHarborCell,
   writeHarborCellArtifacts,
   writeHarborCellExecutionIdentity,
+  writeHarborTaskRunTrace,
   type RunHarborCellEnv,
   type RunHarborCellInput,
 } from './harbor-cell.js';
@@ -241,6 +242,11 @@ async function runHarborTaskRunMode(options: HarborRunOptions): Promise<number> 
     promptHash: executionIdentity.systemPromptHash,
     ...(options.contextBudgetPolicy ? { contextBudgetPolicy: options.contextBudgetPolicy } : {}),
   });
+  const traceEventsPath = await writeHarborTaskRunTrace({
+    outputDir: options.cellArtifactDir,
+    storageRoot: options.storageRoot,
+    invocations,
+  });
   const taxonomy =
     latestScore?.taxonomy ??
     run.projection.result?.taxonomy ??
@@ -263,6 +269,7 @@ async function runHarborTaskRunMode(options: HarborRunOptions): Promise<number> 
       benchmarkFailureShouldThrow: benchmarkFailure.shouldThrow,
       outputPath: cellArtifacts.outputPath,
       runtimeEventsPath: cellArtifacts.runtimeEventsPath,
+      traceEventsPath,
       exportDir,
       files: exported.files,
       result: {

--- a/packages/headless/src/harbor-cli.ts
+++ b/packages/headless/src/harbor-cli.ts
@@ -20,7 +20,6 @@ import {
   createHarborCellLocalToolExecutor,
   createHarborHttpToolExecutor,
   reasoningEffortFromEnv,
-  resolveHostProviderAuthorityEnv,
   runHarborCell,
   writeHarborCellArtifacts,
   writeHarborCellExecutionIdentity,
@@ -314,13 +313,6 @@ export async function resolveHarborRunOptions(
     applyConnectionDefaults(env);
   }
   applyApiKeyFile(parsed, env);
-  if (backend === 'ai-sdk') {
-    const modelSpec = parseModelSpec(
-      env.MAKA_MODEL ?? env.HARBOR_MODEL ?? 'deepseek/deepseek-v4-flash',
-      env.MAKA_PROVIDER,
-    );
-    Object.assign(env, resolveHostProviderAuthorityEnv({ provider: modelSpec.provider, env }));
-  }
   const mode = harborMode(valueOf(parsed, env, 'mode', 'MAKA_HARBOR_MODE') ?? 'task-run');
   const isolation = optionalIsolation(
     valueOf(parsed, env, 'isolation', 'MAKA_HARBOR_ISOLATION') ?? env.MAKA_ISOLATION,

--- a/packages/headless/src/harbor-cli.ts
+++ b/packages/headless/src/harbor-cli.ts
@@ -6,9 +6,14 @@ import { dirname, join, resolve } from 'node:path';
 import type { BackendKind, ProviderType } from '@maka/core';
 import { isThinkingLevel, PROVIDER_DEFAULTS, normalizeProviderType } from '@maka/core';
 import type { Config, Task } from './contracts.js';
-import { validateHarborCellOutput } from './cell-output.js';
+import {
+  type HarborCellExecutionIdentity,
+  validateHarborCellExecutionIdentity,
+  validateHarborCellOutput,
+} from './cell-output.js';
 import { runAutonomousTask } from './autonomous-agent-loop.js';
 import type { BenchmarkAdapterRegistry } from './benchmark-adapters.js';
+import { resolveEconomyTaskMode } from './economy-task-policy.js';
 import {
   buildHarborAiSdkBackendRegistration,
   buildHarborCellContextBudgetPolicySnapshot,
@@ -19,6 +24,7 @@ import {
   type RunHarborCellInput,
 } from './harbor-cell.js';
 import { classifyExternalHarborBenchmarkFailure } from './harbor-failure-policy.js';
+import { resolveHeavyTaskMode } from './heavy-task-policy.js';
 import type { RealBackendIsolation } from './isolation.js';
 import { writeTaskRunExport } from './result-export.js';
 import { backendNeedsIsolation } from './runner.js';
@@ -26,6 +32,7 @@ import { runTaskOnce } from './task-agent-controller.js';
 import { taxonomyFromResultRecord } from './task-contracts.js';
 import { createTaskRunStore } from './task-run-store.js';
 import { requireProviderCredentialEnv } from './provider-env.js';
+import { resolveHeadlessSystemPrompt } from './system-prompts.js';
 
 type HarborMode = 'cell' | 'task-run';
 type HarborIsolationMode = 'none' | 'harbor-local' | 'harbor-http';
@@ -46,6 +53,7 @@ interface HarborRunOptions {
   workdir: string;
   sourceWorkspaceDir: string;
   outDir: string;
+  cellArtifactDir: string;
   storageRoot: string;
   taskId: string;
   taskRunId: string;
@@ -150,12 +158,16 @@ async function runHarborCellMode(options: HarborRunOptions): Promise<number> {
 }
 
 async function runHarborTaskRunMode(options: HarborRunOptions): Promise<number> {
-  await mkdir(options.outDir, { recursive: true });
+  await Promise.all([
+    mkdir(options.outDir, { recursive: true }),
+    mkdir(options.cellArtifactDir, { recursive: true }),
+  ]);
   if (options.sourceWorkspaceDir !== options.workdir) {
     await mkdir(options.sourceWorkspaceDir, { recursive: true });
   }
   const store = createTaskRunStore(options.storageRoot);
   const task = buildHarborTask(options);
+  const executionIdentity = await writeTaskRunExecutionIdentity(options, task);
   const common = {
     storageRoot: options.storageRoot,
     taskRunStore: store,
@@ -218,6 +230,7 @@ async function runHarborTaskRunMode(options: HarborRunOptions): Promise<number> 
   const latestScore = run.projection.latestScoreResult;
   const cellArtifacts = await writeTaskRunCellArtifacts({
     options,
+    executionIdentity,
     resultRecord: run.resultRecord,
     scoreDetails: latestScore?.details,
   });
@@ -258,6 +271,7 @@ async function runHarborTaskRunMode(options: HarborRunOptions): Promise<number> 
 
 async function writeTaskRunCellArtifacts(input: {
   options: HarborRunOptions;
+  executionIdentity: HarborCellExecutionIdentity;
   resultRecord: Awaited<ReturnType<typeof runTaskOnce>>['resultRecord'];
   scoreDetails: Record<string, unknown> | undefined;
 }): Promise<{ outputPath: string; runtimeEventsPath: string }> {
@@ -266,35 +280,23 @@ async function writeTaskRunCellArtifacts(input: {
   if (!runtimeRefs) throw new Error('task-run result is missing runtime refs');
   const sessionId = requiredString(runtimeRefs.sessionId, 'runtimeRefs.sessionId');
   const runId = requiredString(runtimeRefs.runId, 'runtimeRefs.runId');
-  const runtimeEventsPath = join(input.options.outDir, 'runtime-events.jsonl');
+  const runtimeEventsPath = join(input.options.cellArtifactDir, 'runtime-events.jsonl');
   await copyFile(
     join(input.options.storageRoot, 'sessions', sessionId, 'runs', runId, 'runtime-events.jsonl'),
     runtimeEventsPath,
   );
 
   const promptHash = input.resultRecord.systemPromptHash;
+  if (promptHash !== input.executionIdentity.systemPromptHash) {
+    throw new Error('task-run result prompt hash disagrees with durable execution identity');
+  }
   const cell = validateHarborCellOutput({
     schemaVersion: 1,
     status: details.invocationStatus ?? input.resultRecord.status,
     ...(details.runtimeFailureClass ? { errorClass: details.runtimeFailureClass } : {}),
     runtimeEventsPath,
     ...(promptHash ? { promptHash } : {}),
-    ...(promptHash
-      ? {
-          executionIdentity: {
-            llmConnectionSlug: input.options.config.llmConnectionSlug,
-            model: input.options.config.model,
-            ...(input.options.config.thinkingLevel
-              ? { reasoningEffort: input.options.config.thinkingLevel }
-              : {}),
-            ...(input.resultRecord.systemPromptMode
-              ? { systemPromptMode: input.resultRecord.systemPromptMode }
-              : {}),
-            systemPromptHash: promptHash,
-            pricingProfile: input.options.env.MAKA_TRIAL_PRICING_SOURCE ?? 'runtime',
-          },
-        }
-      : {}),
+    executionIdentity: input.executionIdentity,
     toolSummary: details.tools,
     steps: details.steps ?? input.resultRecord.steps,
     durationMs: input.resultRecord.durationMs,
@@ -307,9 +309,33 @@ async function writeTaskRunCellArtifacts(input: {
       turnId: runtimeRefs.turnId,
     },
   });
-  const outputPath = join(input.options.outDir, 'maka-cell-output.json');
+  const outputPath = join(input.options.cellArtifactDir, 'maka-cell-output.json');
   await writeFile(outputPath, `${JSON.stringify(cell, null, 2)}\n`, 'utf8');
   return { outputPath, runtimeEventsPath };
+}
+
+async function writeTaskRunExecutionIdentity(
+  options: HarborRunOptions,
+  task: Task,
+): Promise<HarborCellExecutionIdentity> {
+  const prompt = resolveHeadlessSystemPrompt(options.config, {
+    heavyTaskMode: resolveHeavyTaskMode(options.config, task),
+    economyTaskMode: resolveEconomyTaskMode(options.config, task),
+  });
+  const executionIdentity = validateHarborCellExecutionIdentity({
+    llmConnectionSlug: options.config.llmConnectionSlug,
+    model: options.config.model,
+    ...(options.config.thinkingLevel ? { reasoningEffort: options.config.thinkingLevel } : {}),
+    systemPromptMode: prompt.mode,
+    systemPromptHash: prompt.systemPromptHash,
+    pricingProfile: options.env.MAKA_TRIAL_PRICING_SOURCE ?? 'runtime',
+  });
+  await writeFile(
+    join(options.cellArtifactDir, 'maka-cell-execution-identity.json'),
+    `${JSON.stringify(executionIdentity, null, 2)}\n`,
+    'utf8',
+  );
+  return executionIdentity;
 }
 
 function recordValue(value: unknown): Record<string, unknown> | null {
@@ -349,6 +375,7 @@ export async function resolveHarborRunOptions(
   preflightIsolation(backend, isolation, env);
 
   const outDir = resolve(valueOf(parsed, env, 'out', 'MAKA_OUTPUT_DIR') ?? '/logs/agent');
+  const cellArtifactDir = resolve(env.MAKA_CELL_ARTIFACT_DIR ?? outDir);
   const storageRoot = resolve(
     valueOf(parsed, env, 'storage-root', 'MAKA_STORAGE_ROOT') ??
       (mode === 'task-run' ? join(outDir, 'runs') : join(outDir, 'maka-storage')),
@@ -399,6 +426,7 @@ export async function resolveHarborRunOptions(
     workdir,
     sourceWorkspaceDir,
     outDir,
+    cellArtifactDir,
     storageRoot,
     taskId,
     taskRunId,

--- a/packages/headless/src/harbor-cli.ts
+++ b/packages/headless/src/harbor-cli.ts
@@ -3,11 +3,13 @@ import { readFileSync } from 'node:fs';
 import { copyFile, mkdir, readFile, writeFile } from 'node:fs/promises';
 import { homedir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
-import type { BackendKind, ProviderType } from '@maka/core';
+import type { BackendKind, ProviderType, RuntimeEvent } from '@maka/core';
 import { isThinkingLevel, PROVIDER_DEFAULTS, normalizeProviderType } from '@maka/core';
 import type { Config, Task } from './contracts.js';
 import {
   type HarborCellExecutionIdentity,
+  type HarborCellTokenSummary,
+  summarizeCellTokens,
   validateHarborCellExecutionIdentity,
   validateHarborCellOutput,
 } from './cell-output.js';
@@ -280,11 +282,18 @@ async function writeTaskRunCellArtifacts(input: {
   if (!runtimeRefs) throw new Error('task-run result is missing runtime refs');
   const sessionId = requiredString(runtimeRefs.sessionId, 'runtimeRefs.sessionId');
   const runId = requiredString(runtimeRefs.runId, 'runtimeRefs.runId');
-  const runtimeEventsPath = join(input.options.cellArtifactDir, 'runtime-events.jsonl');
-  await copyFile(
-    join(input.options.storageRoot, 'sessions', sessionId, 'runs', runId, 'runtime-events.jsonl'),
-    runtimeEventsPath,
+  const runtimeEventsSourcePath = join(
+    input.options.storageRoot,
+    'sessions',
+    sessionId,
+    'runs',
+    runId,
+    'runtime-events.jsonl',
   );
+  const runtimeEventsJsonl = await readFile(runtimeEventsSourcePath, 'utf8');
+  const runtimeEventsPath = join(input.options.cellArtifactDir, 'runtime-events.jsonl');
+  await copyFile(runtimeEventsSourcePath, runtimeEventsPath);
+  const tokenSummary = summarizeTaskRunRuntimeEvents(runtimeEventsJsonl);
 
   const promptHash = input.resultRecord.systemPromptHash;
   if (promptHash !== input.executionIdentity.systemPromptHash) {
@@ -297,6 +306,7 @@ async function writeTaskRunCellArtifacts(input: {
     runtimeEventsPath,
     ...(promptHash ? { promptHash } : {}),
     executionIdentity: input.executionIdentity,
+    ...(tokenSummary ? { tokenSummary } : {}),
     toolSummary: details.tools,
     steps: details.steps ?? input.resultRecord.steps,
     durationMs: input.resultRecord.durationMs,
@@ -312,6 +322,16 @@ async function writeTaskRunCellArtifacts(input: {
   const outputPath = join(input.options.cellArtifactDir, 'maka-cell-output.json');
   await writeFile(outputPath, `${JSON.stringify(cell, null, 2)}\n`, 'utf8');
   return { outputPath, runtimeEventsPath };
+}
+
+export function summarizeTaskRunRuntimeEvents(
+  runtimeEventsJsonl: string,
+): HarborCellTokenSummary | undefined {
+  const events = runtimeEventsJsonl
+    .split('\n')
+    .filter((line) => line.trim().length > 0)
+    .map((line) => JSON.parse(line) as RuntimeEvent);
+  return summarizeCellTokens(events);
 }
 
 async function writeTaskRunExecutionIdentity(

--- a/packages/headless/src/harbor-cli.ts
+++ b/packages/headless/src/harbor-cli.ts
@@ -1,11 +1,12 @@
 import { randomUUID } from 'node:crypto';
 import { readFileSync } from 'node:fs';
-import { mkdir, readFile } from 'node:fs/promises';
+import { copyFile, mkdir, readFile, writeFile } from 'node:fs/promises';
 import { homedir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
 import type { BackendKind, ProviderType } from '@maka/core';
-import { PROVIDER_DEFAULTS, normalizeProviderType } from '@maka/core';
+import { isThinkingLevel, PROVIDER_DEFAULTS, normalizeProviderType } from '@maka/core';
 import type { Config, Task } from './contracts.js';
+import { validateHarborCellOutput } from './cell-output.js';
 import { runAutonomousTask } from './autonomous-agent-loop.js';
 import type { BenchmarkAdapterRegistry } from './benchmark-adapters.js';
 import {
@@ -215,6 +216,11 @@ async function runHarborTaskRunMode(options: HarborRunOptions): Promise<number> 
     includeEvents: options.includeEvents,
   });
   const latestScore = run.projection.latestScoreResult;
+  const cellArtifacts = await writeTaskRunCellArtifacts({
+    options,
+    resultRecord: run.resultRecord,
+    scoreDetails: latestScore?.details,
+  });
   const taxonomy =
     latestScore?.taxonomy ??
     run.projection.result?.taxonomy ??
@@ -235,6 +241,8 @@ async function runHarborTaskRunMode(options: HarborRunOptions): Promise<number> 
       authoritative: latestScore?.authority?.authoritative ?? false,
       benchmarkFailureKind: benchmarkFailure.kind,
       benchmarkFailureShouldThrow: benchmarkFailure.shouldThrow,
+      outputPath: cellArtifacts.outputPath,
+      runtimeEventsPath: cellArtifacts.runtimeEventsPath,
       exportDir,
       files: exported.files,
       result: {
@@ -246,6 +254,75 @@ async function runHarborTaskRunMode(options: HarborRunOptions): Promise<number> 
     })}\n`,
   );
   return benchmarkFailure.shouldThrow ? 1 : 0;
+}
+
+async function writeTaskRunCellArtifacts(input: {
+  options: HarborRunOptions;
+  resultRecord: Awaited<ReturnType<typeof runTaskOnce>>['resultRecord'];
+  scoreDetails: Record<string, unknown> | undefined;
+}): Promise<{ outputPath: string; runtimeEventsPath: string }> {
+  const details = input.scoreDetails ?? {};
+  const runtimeRefs = recordValue(details.runtimeRefs);
+  if (!runtimeRefs) throw new Error('task-run result is missing runtime refs');
+  const sessionId = requiredString(runtimeRefs.sessionId, 'runtimeRefs.sessionId');
+  const runId = requiredString(runtimeRefs.runId, 'runtimeRefs.runId');
+  const runtimeEventsPath = join(input.options.outDir, 'runtime-events.jsonl');
+  await copyFile(
+    join(input.options.storageRoot, 'sessions', sessionId, 'runs', runId, 'runtime-events.jsonl'),
+    runtimeEventsPath,
+  );
+
+  const promptHash = input.resultRecord.systemPromptHash;
+  const cell = validateHarborCellOutput({
+    schemaVersion: 1,
+    status: details.invocationStatus ?? input.resultRecord.status,
+    ...(details.runtimeFailureClass ? { errorClass: details.runtimeFailureClass } : {}),
+    runtimeEventsPath,
+    ...(promptHash ? { promptHash } : {}),
+    ...(promptHash
+      ? {
+          executionIdentity: {
+            llmConnectionSlug: input.options.config.llmConnectionSlug,
+            model: input.options.config.model,
+            ...(input.options.config.thinkingLevel
+              ? { reasoningEffort: input.options.config.thinkingLevel }
+              : {}),
+            ...(input.resultRecord.systemPromptMode
+              ? { systemPromptMode: input.resultRecord.systemPromptMode }
+              : {}),
+            systemPromptHash: promptHash,
+            pricingProfile: input.options.env.MAKA_TRIAL_PRICING_SOURCE ?? 'runtime',
+          },
+        }
+      : {}),
+    toolSummary: details.tools,
+    steps: details.steps ?? input.resultRecord.steps,
+    durationMs: input.resultRecord.durationMs,
+    startedAt: input.resultRecord.startedAt,
+    finishedAt: input.resultRecord.finishedAt,
+    runtimeRefs: {
+      invocationId: runtimeRefs.invocationId,
+      sessionId,
+      runId,
+      turnId: runtimeRefs.turnId,
+    },
+  });
+  const outputPath = join(input.options.outDir, 'maka-cell-output.json');
+  await writeFile(outputPath, `${JSON.stringify(cell, null, 2)}\n`, 'utf8');
+  return { outputPath, runtimeEventsPath };
+}
+
+function recordValue(value: unknown): Record<string, unknown> | null {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function requiredString(value: unknown, field: string): string {
+  if (typeof value !== 'string' || value.length === 0) {
+    throw new Error(`task-run result is missing ${field}`);
+  }
+  return value;
 }
 
 export async function resolveHarborRunOptions(
@@ -419,12 +496,14 @@ function buildConfig(input: {
   heavyTask: boolean;
   economyTask: boolean;
 }): Config {
+  const thinkingLevel = reasoningEffortFromEnv(input.env.MAKA_REASONING_EFFORT);
   if (input.backend === 'fake') {
     return {
       id: input.parsed.flags['config-id'] ?? input.env.MAKA_CONFIG_ID ?? 'harbor-fake',
       backend: 'fake',
       llmConnectionSlug: input.env.MAKA_LLM_CONNECTION_SLUG ?? 'fake',
       model: input.env.MAKA_MODEL ?? input.env.HARBOR_MODEL ?? 'fake',
+      ...(thinkingLevel ? { thinkingLevel } : {}),
       ...(input.heavyTask
         ? { heavyTaskMode: { enabled: true, reason: 'maka eval harbor run --heavy-task' } }
         : {}),
@@ -448,6 +527,7 @@ function buildConfig(input: {
     backend: 'ai-sdk',
     llmConnectionSlug: input.env.MAKA_LLM_CONNECTION_SLUG ?? modelSpec.provider,
     model: modelSpec.model,
+    ...(thinkingLevel ? { thinkingLevel } : {}),
     ...(input.env.MAKA_SYSTEM_PROMPT !== undefined
       ? { systemPrompt: input.env.MAKA_SYSTEM_PROMPT }
       : {}),
@@ -458,6 +538,12 @@ function buildConfig(input: {
       ? { economyTaskMode: { enabled: true, reason: 'maka eval harbor run --economy-task' } }
       : {}),
   };
+}
+
+function reasoningEffortFromEnv(value: string | undefined): Config['thinkingLevel'] {
+  if (value === undefined || value === '') return undefined;
+  if (!isThinkingLevel(value)) throw new Error(`unsupported MAKA_REASONING_EFFORT: ${value}`);
+  return value;
 }
 
 function buildBackendRegistration(input: {

--- a/packages/headless/src/harbor-cli.ts
+++ b/packages/headless/src/harbor-cli.ts
@@ -9,6 +9,7 @@ import type { Config, Task } from './contracts.js';
 import {
   type HarborCellExecutionIdentity,
   type HarborCellTokenSummary,
+  countRuntimeSteps,
   summarizeCellTokens,
   validateHarborCellExecutionIdentity,
   validateHarborCellOutput,
@@ -291,9 +292,10 @@ async function writeTaskRunCellArtifacts(input: {
     'runtime-events.jsonl',
   );
   const runtimeEventsJsonl = await readFile(runtimeEventsSourcePath, 'utf8');
+  const runtimeEvents = parseTaskRunRuntimeEvents(runtimeEventsJsonl);
   const runtimeEventsPath = join(input.options.cellArtifactDir, 'runtime-events.jsonl');
   await copyFile(runtimeEventsSourcePath, runtimeEventsPath);
-  const tokenSummary = summarizeTaskRunRuntimeEvents(runtimeEventsJsonl);
+  const tokenSummary = summarizeCellTokens(runtimeEvents);
 
   const promptHash = input.resultRecord.systemPromptHash;
   if (promptHash !== input.executionIdentity.systemPromptHash) {
@@ -308,7 +310,7 @@ async function writeTaskRunCellArtifacts(input: {
     executionIdentity: input.executionIdentity,
     ...(tokenSummary ? { tokenSummary } : {}),
     toolSummary: details.tools,
-    steps: details.steps ?? input.resultRecord.steps,
+    steps: countRuntimeSteps(runtimeEvents),
     durationMs: input.resultRecord.durationMs,
     startedAt: input.resultRecord.startedAt,
     finishedAt: input.resultRecord.finishedAt,
@@ -327,11 +329,14 @@ async function writeTaskRunCellArtifacts(input: {
 export function summarizeTaskRunRuntimeEvents(
   runtimeEventsJsonl: string,
 ): HarborCellTokenSummary | undefined {
-  const events = runtimeEventsJsonl
+  return summarizeCellTokens(parseTaskRunRuntimeEvents(runtimeEventsJsonl));
+}
+
+function parseTaskRunRuntimeEvents(runtimeEventsJsonl: string): RuntimeEvent[] {
+  return runtimeEventsJsonl
     .split('\n')
     .filter((line) => line.trim().length > 0)
     .map((line) => JSON.parse(line) as RuntimeEvent);
-  return summarizeCellTokens(events);
 }
 
 async function writeTaskRunExecutionIdentity(

--- a/packages/headless/src/harbor-smoke-config.ts
+++ b/packages/headless/src/harbor-smoke-config.ts
@@ -173,7 +173,7 @@ export function buildSmokeJobConfig(input: {
   }
 
   if (overrides.maxSteps) agentEnv.MAKA_MAX_STEPS = overrides.maxSteps;
-  if (overrides.agentTimeoutSec) agentEnv.MAKA_HARBOR_AGENT_TIMEOUT_SEC = overrides.agentTimeoutSec;
+  if (overrides.agentTimeoutSec) agentEnv.MAKA_CELL_TIMEOUT_SEC = overrides.agentTimeoutSec;
   if (profileName.startsWith('maka-') && !agentEnv.MAKA_BENCHMARK_DATASET) {
     agentEnv.MAKA_BENCHMARK_DATASET = overrides.benchmarkDataset || datasetName;
   }

--- a/packages/headless/src/harbor-task-runner.ts
+++ b/packages/headless/src/harbor-task-runner.ts
@@ -41,7 +41,11 @@ import {
   type ProviderUpstreamCredentialResolver,
   type ProviderUsageProtocol,
 } from './provider-auth-proxy.js';
-import { providerBaseUrlFromEnv, providerCredentialEnv } from './provider-env.js';
+import {
+  isProviderCredentialSecretEnvName,
+  providerBaseUrlFromEnv,
+  providerCredentialEnv,
+} from './provider-env.js';
 import { lenientPositiveIntEnv } from './headless-run-env.js';
 import {
   OPENCODE_TOOLCHAIN_CONTAINER_PATH,
@@ -225,7 +229,11 @@ export function createHarborTaskRunner(options: HarborTaskRunnerOptions): Harbor
       ...options,
       agentEnv: mergeAgentEnv(options.agentEnv, input.agentEnv),
     };
-    assertNoProviderSecretsInAgentEnv(runnerOptions.agentEnv);
+    const allowedHostCredentialEnvNames =
+      runnerOptions.provider === 'github-copilot'
+        ? new Set(providerCredentialEnv('github-copilot')?.apiKeys ?? [])
+        : undefined;
+    assertNoProviderSecretsInAgentEnv(runnerOptions.agentEnv, allowedHostCredentialEnvNames);
     const hasHostProviderRuntime =
       runnerOptions.apiKeyFile !== undefined ||
       runnerOptions.resolveProviderCredential !== undefined ||
@@ -1192,14 +1200,19 @@ function taskAgentEnvWithoutProviderSecrets(
     )
       continue;
     if (key === 'MAKA_BASE_URL') continue;
-    if (/_API_KEY(_FILE)?$/.test(key)) continue;
+    if (isProviderCredentialSecretEnvName(key)) continue;
     result[key] = value;
   }
   return result;
 }
 
-function assertNoProviderSecretsInAgentEnv(agentEnv: Record<string, string> | undefined): void {
-  const forbidden = Object.keys(agentEnv ?? {}).filter((key) => /_API_KEY(_FILE)?$/.test(key));
+function assertNoProviderSecretsInAgentEnv(
+  agentEnv: Record<string, string> | undefined,
+  allowedHostCredentialEnvNames: ReadonlySet<string> = new Set(),
+): void {
+  const forbidden = Object.keys(agentEnv ?? {}).filter(
+    (key) => isProviderCredentialSecretEnvName(key) && !allowedHostCredentialEnvNames.has(key),
+  );
   if (forbidden.length > 0) {
     throw new Error(`agentEnv must not contain provider secrets: ${forbidden.sort().join(', ')}`);
   }

--- a/packages/headless/src/harbor-task-runner.ts
+++ b/packages/headless/src/harbor-task-runner.ts
@@ -1,4 +1,5 @@
 import { execFile } from 'node:child_process';
+import { existsSync } from 'node:fs';
 import { mkdir, readFile, readdir, rm } from 'node:fs/promises';
 import { writeFile } from 'node:fs/promises';
 import { basename, delimiter, join } from 'node:path';
@@ -73,7 +74,8 @@ const TRIAL_REWARD = 'verifier/reward.txt';
 const TRIAL_VERIFIER_STDOUT = 'verifier/test-stdout.txt';
 const TRIAL_VERIFIER_OUTCOME = 'verifier/maka-verifier-outcome.json';
 const TRIAL_RESULT = 'result.json';
-const TRIAL_TRACE_EVENTS_ROOT = 'agent/maka-storage/sessions';
+const TRIAL_TASK_RUN_TRACE_EVENTS_ROOT = 'agent/maka-task-run/runs/sessions';
+const TRIAL_LEGACY_TRACE_EVENTS_ROOT = 'agent/maka-storage/sessions';
 const PROVIDER_REQUEST_TELEMETRY = 'provider-request-telemetry.json';
 
 /** A Harbor-side failure (build/docker/timeout/missing artifact) — NOT a benchmark
@@ -573,14 +575,12 @@ function hostTraceEventsPath(
   hostEventsPath: string,
 ): string {
   if (agent !== undefined && agent !== 'maka') return hostEventsPath;
-  return join(
-    trialDir,
-    TRIAL_TRACE_EVENTS_ROOT,
-    cell.runtimeRefs.sessionId,
-    'runs',
-    cell.runtimeRefs.runId,
-    'events.jsonl',
-  );
+  const traceSuffix = [cell.runtimeRefs.sessionId, 'runs', cell.runtimeRefs.runId, 'events.jsonl'];
+  const traceCandidates = [
+    join(trialDir, TRIAL_TASK_RUN_TRACE_EVENTS_ROOT, ...traceSuffix),
+    join(trialDir, TRIAL_LEGACY_TRACE_EVENTS_ROOT, ...traceSuffix),
+  ];
+  return traceCandidates.find((path) => existsSync(path)) ?? hostEventsPath;
 }
 
 function cellArtifactRefs(

--- a/packages/headless/src/harbor-task-runner.ts
+++ b/packages/headless/src/harbor-task-runner.ts
@@ -335,6 +335,7 @@ export function createHarborTaskRunner(options: HarborTaskRunnerOptions): Harbor
             trialDir,
             input.task.id,
             runnerOptions.agent,
+            harborTraceMode(runnerOptions.agentEnv),
           );
           throw new FixedPromptBudgetExhaustedError(
             `agent budget exhausted for task ${input.task.id}`,
@@ -394,7 +395,13 @@ export function createHarborTaskRunner(options: HarborTaskRunnerOptions): Harbor
           ...cell,
           ...(providerTelemetry.length > 0 ? { providerTelemetryPath } : {}),
           runtimeEventsPath: hostEventsPath,
-          traceEventsPath: hostTraceEventsPath(runnerOptions.agent, trialDir, cell, hostEventsPath),
+          traceEventsPath: hostTraceEventsPath(
+            runnerOptions.agent,
+            harborTraceMode(runnerOptions.agentEnv),
+            trialDir,
+            cell,
+            hostEventsPath,
+          ),
         },
       };
     } catch (error) {
@@ -572,19 +579,25 @@ async function readOptionalCellOutput(
 
 function hostTraceEventsPath(
   agent: HarborTaskRunnerOptions['agent'],
+  mode: 'cell' | 'task-run',
   trialDir: string,
   cell: HarborCellOutput,
   hostEventsPath: string,
 ): string {
   if (agent !== undefined && agent !== 'maka') return hostEventsPath;
-  const combinedTracePath = join(trialDir, TRIAL_TASK_RUN_TRACE_EVENTS);
-  if (existsSync(combinedTracePath)) return combinedTracePath;
   const traceSuffix = [cell.runtimeRefs.sessionId, 'runs', cell.runtimeRefs.runId, 'events.jsonl'];
-  const traceCandidates = [
-    join(trialDir, TRIAL_TASK_RUN_TRACE_EVENTS_ROOT, ...traceSuffix),
-    join(trialDir, TRIAL_LEGACY_TRACE_EVENTS_ROOT, ...traceSuffix),
-  ];
-  return traceCandidates.find((path) => existsSync(path)) ?? hostEventsPath;
+  if (mode === 'task-run') {
+    const combinedTracePath = join(trialDir, TRIAL_TASK_RUN_TRACE_EVENTS);
+    if (existsSync(combinedTracePath)) return combinedTracePath;
+    const taskRunTracePath = join(trialDir, TRIAL_TASK_RUN_TRACE_EVENTS_ROOT, ...traceSuffix);
+    return existsSync(taskRunTracePath) ? taskRunTracePath : hostEventsPath;
+  }
+  const cellTracePath = join(trialDir, TRIAL_LEGACY_TRACE_EVENTS_ROOT, ...traceSuffix);
+  return existsSync(cellTracePath) ? cellTracePath : hostEventsPath;
+}
+
+function harborTraceMode(agentEnv: Record<string, string> | undefined): 'cell' | 'task-run' {
+  return agentEnv?.MAKA_HARBOR_MODE === 'task-run' ? 'task-run' : 'cell';
 }
 
 function cellArtifactRefs(
@@ -592,8 +605,9 @@ function cellArtifactRefs(
   hostEventsPath: string,
   trialDir: string,
   agent: HarborTaskRunnerOptions['agent'],
+  mode: 'cell' | 'task-run',
 ) {
-  const traceEventsPath = hostTraceEventsPath(agent, trialDir, cell, hostEventsPath);
+  const traceEventsPath = hostTraceEventsPath(agent, mode, trialDir, cell, hostEventsPath);
   return {
     runtimeEventsPath: hostEventsPath,
     traceEventsPath,
@@ -606,9 +620,11 @@ async function readTimedOutTrialArtifacts(
   trialDir: string,
   taskId: string,
   agent: HarborTaskRunnerOptions['agent'],
+  mode: 'cell' | 'task-run',
 ) {
   const cell = await readOptionalCellOutput(join(trialDir, TRIAL_CELL_OUTPUT), taskId);
-  if (cell) return cellArtifactRefs(cell, join(trialDir, TRIAL_RUNTIME_EVENTS), trialDir, agent);
+  if (cell)
+    return cellArtifactRefs(cell, join(trialDir, TRIAL_RUNTIME_EVENTS), trialDir, agent, mode);
   const [executionIdentity, tokenSummary] = await Promise.all([
     readOptionalExecutionIdentity(join(trialDir, TRIAL_EXECUTION_IDENTITY)),
     readOptionalTokenSummary(join(trialDir, TRIAL_USAGE_CHECKPOINT)),

--- a/packages/headless/src/harbor-task-runner.ts
+++ b/packages/headless/src/harbor-task-runner.ts
@@ -66,6 +66,7 @@ const TRIAL_CELL_OUTPUT = 'agent/maka-cell-output.json';
 const TRIAL_EXECUTION_IDENTITY = 'agent/maka-cell-execution-identity.json';
 const TRIAL_USAGE_CHECKPOINT = 'agent/maka-cell-usage-checkpoint.json';
 const TRIAL_RUNTIME_EVENTS = 'agent/runtime-events.jsonl';
+const TRIAL_TASK_RUN_TRACE_EVENTS = 'agent/trace-events.jsonl';
 const TRIAL_REWARD = 'verifier/reward.txt';
 const TRIAL_VERIFIER_STDOUT = 'verifier/test-stdout.txt';
 const TRIAL_VERIFIER_OUTCOME = 'verifier/maka-verifier-outcome.json';
@@ -568,6 +569,8 @@ function hostTraceEventsPath(
   hostEventsPath: string,
 ): string {
   if (agent !== undefined && agent !== 'maka') return hostEventsPath;
+  const combinedTracePath = join(trialDir, TRIAL_TASK_RUN_TRACE_EVENTS);
+  if (existsSync(combinedTracePath)) return combinedTracePath;
   const traceSuffix = [cell.runtimeRefs.sessionId, 'runs', cell.runtimeRefs.runId, 'events.jsonl'];
   const traceCandidates = [
     join(trialDir, TRIAL_TASK_RUN_TRACE_EVENTS_ROOT, ...traceSuffix),

--- a/packages/headless/src/harbor-task-runner.ts
+++ b/packages/headless/src/harbor-task-runner.ts
@@ -41,11 +41,7 @@ import {
   type ProviderUpstreamCredentialResolver,
   type ProviderUsageProtocol,
 } from './provider-auth-proxy.js';
-import {
-  providerBaseUrlFromEnv,
-  providerCredentialEnv,
-  requireProviderCredentialEnv,
-} from './provider-env.js';
+import { providerBaseUrlFromEnv, providerCredentialEnv } from './provider-env.js';
 import { lenientPositiveIntEnv } from './headless-run-env.js';
 import {
   OPENCODE_TOOLCHAIN_CONTAINER_PATH,
@@ -130,9 +126,6 @@ export interface HarborTaskRunnerOptions {
   apiKeyFile?: string;
   /** Resolves the current provider authority inside the host proxy for every request. */
   resolveProviderCredential?: ProviderUpstreamCredentialResolver;
-  /** Raw API-key env var the host-side cell uses (default derived from provider).
-   * A legacy *_API_KEY_FILE name is normalized to its raw *_API_KEY companion. */
-  apiKeyEnvName?: string;
   /** Per-1M USD pricing forwarded as MAKA_TRIAL_* so the cell emits real costUsd. */
   pricing?: HarborTaskPricing;
   /** Extra agent env merged last (e.g. DEEPSEEK_BASE_URL). */
@@ -1071,9 +1064,6 @@ async function hostSideProviderRuntime(options: HarborTaskRunnerOptions): Promis
           ? {
               MAKA_HOST_BASE_URL: proxy.baseUrl,
               MAKA_HOST_API_KEY: proxy.token,
-              MAKA_HOST_API_KEY_ENV_NAME: normalizeRawKeyEnvName(
-                options.apiKeyEnvName ?? requireProviderCredentialEnv(provider).apiKeys[0]!,
-              ),
             }
           : {
               MAKA_PROVIDER_PROXY_URL: proxy.baseUrl,
@@ -1084,13 +1074,6 @@ async function hostSideProviderRuntime(options: HarborTaskRunnerOptions): Promis
       close: proxy.close,
     };
   }
-  const apiKeyEnvName = copilotCredential
-    ? 'COPILOT_GITHUB_TOKEN'
-    : options.apiKeyFile
-      ? normalizeRawKeyEnvName(
-          options.apiKeyEnvName ?? requireProviderCredentialEnv(provider).apiKeys[0]!,
-        )
-      : undefined;
   return {
     env: {
       MAKA_HOST_REPO_ROOT: options.makaRepoPath,
@@ -1099,7 +1082,6 @@ async function hostSideProviderRuntime(options: HarborTaskRunnerOptions): Promis
         : options.apiKeyFile
           ? { MAKA_HOST_API_KEY_FILE: options.apiKeyFile }
           : {}),
-      ...(apiKeyEnvName ? { MAKA_HOST_API_KEY_ENV_NAME: apiKeyEnvName } : {}),
       ...(!options.apiKeyFile && !copilotCredential ? { MAKA_HOST_NO_AUTH: 'true' } : {}),
       ...(baseUrl ? { MAKA_HOST_BASE_URL: baseUrl } : {}),
       ...(copilotCredential ? { MAKA_HOST_MODEL_API_PROTOCOL: copilotCredential.apiProtocol } : {}),
@@ -1229,10 +1211,6 @@ function assertNoExperimentIdentityOverrides(agentEnv: Record<string, string> | 
       `agentEnv must not override experiment identity: ${forbidden.sort().join(', ')}`,
     );
   }
-}
-
-function normalizeRawKeyEnvName(name: string): string {
-  return name.endsWith('_FILE') ? name.slice(0, -'_FILE'.length) : name;
 }
 
 function providerRequiresSecret(provider: string | undefined): boolean {

--- a/packages/headless/src/harbor-task-runner.ts
+++ b/packages/headless/src/harbor-task-runner.ts
@@ -42,7 +42,7 @@ import {
   type ProviderUsageProtocol,
 } from './provider-auth-proxy.js';
 import {
-  isProviderCredentialSecretEnvName,
+  isSensitiveEnvName,
   providerBaseUrlFromEnv,
   providerCredentialEnv,
 } from './provider-env.js';
@@ -1200,7 +1200,7 @@ function taskAgentEnvWithoutProviderSecrets(
     )
       continue;
     if (key === 'MAKA_BASE_URL') continue;
-    if (isProviderCredentialSecretEnvName(key)) continue;
+    if (isSensitiveEnvName(key)) continue;
     result[key] = value;
   }
   return result;
@@ -1211,7 +1211,7 @@ function assertNoProviderSecretsInAgentEnv(
   allowedHostCredentialEnvNames: ReadonlySet<string> = new Set(),
 ): void {
   const forbidden = Object.keys(agentEnv ?? {}).filter(
-    (key) => isProviderCredentialSecretEnvName(key) && !allowedHostCredentialEnvNames.has(key),
+    (key) => isSensitiveEnvName(key) && !allowedHostCredentialEnvNames.has(key),
   );
   if (forbidden.length > 0) {
     throw new Error(`agentEnv must not contain provider secrets: ${forbidden.sort().join(', ')}`);

--- a/packages/headless/src/headless-run-env.ts
+++ b/packages/headless/src/headless-run-env.ts
@@ -12,6 +12,8 @@ import {
   assertRatio,
 } from './numeric-guards.js';
 
+export const MAX_NODE_TIMER_MS = 2_147_483_647;
+
 /** Parse a non-negative integer; throw on a non-integer or negative value. */
 export function envNonNegativeInt(name: string, raw: string | undefined, fallback: number): number {
   if (raw === undefined || raw === '') return fallback;

--- a/packages/headless/src/provider-env.ts
+++ b/packages/headless/src/provider-env.ts
@@ -129,6 +129,38 @@ export function providerApiKeyEnvName(provider: string): string {
   return requireProviderCredentialEnv(provider).apiKeys[0]!;
 }
 
+export function resolveHostProviderAuthorityEnv(input: {
+  provider: string;
+  env: RunHarborCellEnv;
+}): RunHarborCellEnv {
+  const authority: RunHarborCellEnv = {};
+  if (input.env.MAKA_HOST_API_KEY || input.env.MAKA_HOST_API_KEY_FILE) {
+    const keyEnvName = hostApiKeyEnvName(input.env, input.provider);
+    authority[keyEnvName] = input.env.MAKA_HOST_API_KEY ?? readHostApiKeyFile(input.env);
+  }
+  if (input.env.MAKA_HOST_BASE_URL) {
+    authority.MAKA_BASE_URL = input.env.MAKA_HOST_BASE_URL;
+  }
+  if (input.env.MAKA_HOST_MODEL_API_PROTOCOL) {
+    authority.MAKA_MODEL_API_PROTOCOL = input.env.MAKA_HOST_MODEL_API_PROTOCOL;
+  }
+  return authority;
+}
+
+function readHostApiKeyFile(env: RunHarborCellEnv): string {
+  const path = env.MAKA_HOST_API_KEY_FILE;
+  if (!path) throw new Error('MAKA_HOST_API_KEY_FILE is required for host-side Harbor cells');
+  return readFileSync(path, 'utf8').trim();
+}
+
+function hostApiKeyEnvName(env: RunHarborCellEnv, provider: string): string {
+  const name = env.MAKA_HOST_API_KEY_ENV_NAME ?? providerApiKeyEnvName(provider);
+  if (!/^[A-Z][A-Z0-9_]{0,127}$/.test(name)) {
+    throw new Error(`invalid MAKA_HOST_API_KEY_ENV_NAME: ${name}`);
+  }
+  return name;
+}
+
 export function providerFromEnv(value: string | undefined): ProviderType {
   if (!value || !(value in PROVIDER_DEFAULTS)) {
     throw new Error(`unsupported MAKA_PROVIDER: ${value ?? ''}`);

--- a/packages/headless/src/provider-env.ts
+++ b/packages/headless/src/provider-env.ts
@@ -78,13 +78,16 @@ const PROVIDER_CREDENTIAL_ENV = {
   },
 } satisfies Partial<Record<ProviderType, ProviderCredentialEnv>>;
 
-const PROVIDER_CREDENTIAL_SECRET_ENV_NAMES = new Set(
-  (Object.values(PROVIDER_CREDENTIAL_ENV) as ProviderCredentialEnv[]).flatMap((definition) => [
+const PROVIDER_CREDENTIAL_SECRET_ENV_NAMES = new Set([
+  'MAKA_API_KEY',
+  'MAKA_HOST_API_KEY',
+  'MAKA_HOST_API_KEY_FILE',
+  ...(Object.values(PROVIDER_CREDENTIAL_ENV) as ProviderCredentialEnv[]).flatMap((definition) => [
     ...definition.apiKeys,
     ...definition.apiKeys.map((name) => `${name}_FILE`),
     definition.apiKeyFile,
   ]),
-);
+]);
 
 export function providerCredentialEnv(provider: string): ProviderCredentialEnv | undefined {
   return PROVIDER_CREDENTIAL_ENV[provider as keyof typeof PROVIDER_CREDENTIAL_ENV];

--- a/packages/headless/src/provider-env.ts
+++ b/packages/headless/src/provider-env.ts
@@ -78,16 +78,8 @@ const PROVIDER_CREDENTIAL_ENV = {
   },
 } satisfies Partial<Record<ProviderType, ProviderCredentialEnv>>;
 
-const PROVIDER_CREDENTIAL_SECRET_ENV_NAMES = new Set([
-  'MAKA_API_KEY',
-  'MAKA_HOST_API_KEY',
-  'MAKA_HOST_API_KEY_FILE',
-  ...(Object.values(PROVIDER_CREDENTIAL_ENV) as ProviderCredentialEnv[]).flatMap((definition) => [
-    ...definition.apiKeys,
-    ...definition.apiKeys.map((name) => `${name}_FILE`),
-    definition.apiKeyFile,
-  ]),
-]);
+const SENSITIVE_ENV_NAME =
+  /(?:^|_)(?:API_KEY|ACCESS_KEY|PRIVATE_KEY|TOKEN|SECRET|PASSWORD|CREDENTIALS?)(?:_|$)/i;
 
 export function providerCredentialEnv(provider: string): ProviderCredentialEnv | undefined {
   return PROVIDER_CREDENTIAL_ENV[provider as keyof typeof PROVIDER_CREDENTIAL_ENV];
@@ -99,8 +91,8 @@ export function requireProviderCredentialEnv(provider: string): ProviderCredenti
   return definition;
 }
 
-export function isProviderCredentialSecretEnvName(name: string): boolean {
-  return PROVIDER_CREDENTIAL_SECRET_ENV_NAMES.has(name);
+export function isSensitiveEnvName(name: string): boolean {
+  return SENSITIVE_ENV_NAME.test(name);
 }
 
 export function providerBaseUrlFromEnv(

--- a/packages/headless/src/provider-env.ts
+++ b/packages/headless/src/provider-env.ts
@@ -78,6 +78,14 @@ const PROVIDER_CREDENTIAL_ENV = {
   },
 } satisfies Partial<Record<ProviderType, ProviderCredentialEnv>>;
 
+const PROVIDER_CREDENTIAL_SECRET_ENV_NAMES = new Set(
+  (Object.values(PROVIDER_CREDENTIAL_ENV) as ProviderCredentialEnv[]).flatMap((definition) => [
+    ...definition.apiKeys,
+    ...definition.apiKeys.map((name) => `${name}_FILE`),
+    definition.apiKeyFile,
+  ]),
+);
+
 export function providerCredentialEnv(provider: string): ProviderCredentialEnv | undefined {
   return PROVIDER_CREDENTIAL_ENV[provider as keyof typeof PROVIDER_CREDENTIAL_ENV];
 }
@@ -86,6 +94,10 @@ export function requireProviderCredentialEnv(provider: string): ProviderCredenti
   const definition = providerCredentialEnv(provider);
   if (!definition) throw new Error(`provider does not support API key files: ${provider}`);
   return definition;
+}
+
+export function isProviderCredentialSecretEnvName(name: string): boolean {
+  return PROVIDER_CREDENTIAL_SECRET_ENV_NAMES.has(name);
 }
 
 export function providerBaseUrlFromEnv(
@@ -125,40 +137,47 @@ export interface ResolvedHarborCellAiSdkEnv {
   apiKey: string;
 }
 
+export type HostProviderAuth =
+  | { kind: 'inherit' }
+  | { kind: 'none' }
+  | { kind: 'credential'; apiKey: string };
+
+export interface ResolvedHostProviderAuthority {
+  auth: HostProviderAuth;
+  baseUrl?: string;
+  apiProtocol?: ModelInfo['apiProtocol'];
+}
+
 export function providerApiKeyEnvName(provider: string): string {
   return requireProviderCredentialEnv(provider).apiKeys[0]!;
 }
 
-export function resolveHostProviderAuthorityEnv(input: {
-  provider: string;
-  env: RunHarborCellEnv;
-}): RunHarborCellEnv {
-  const authority: RunHarborCellEnv = {};
-  if (input.env.MAKA_HOST_API_KEY || input.env.MAKA_HOST_API_KEY_FILE) {
-    const keyEnvName = hostApiKeyEnvName(input.env, input.provider);
-    authority[keyEnvName] = input.env.MAKA_HOST_API_KEY ?? readHostApiKeyFile(input.env);
+export function resolveHostProviderAuthority(env: RunHarborCellEnv): ResolvedHostProviderAuthority {
+  const noAuth = env.MAKA_HOST_NO_AUTH === 'true';
+  const rawApiKey = env.MAKA_HOST_API_KEY || undefined;
+  const apiKey = rawApiKey ?? (env.MAKA_HOST_API_KEY_FILE ? readHostApiKeyFile(env) : undefined);
+  if (noAuth && apiKey !== undefined) {
+    throw new Error('MAKA_HOST_NO_AUTH cannot be combined with a host provider credential');
   }
-  if (input.env.MAKA_HOST_BASE_URL) {
-    authority.MAKA_BASE_URL = input.env.MAKA_HOST_BASE_URL;
+  if (apiKey !== undefined && !apiKey) {
+    throw new Error('host provider credential must not be empty');
   }
-  if (input.env.MAKA_HOST_MODEL_API_PROTOCOL) {
-    authority.MAKA_MODEL_API_PROTOCOL = input.env.MAKA_HOST_MODEL_API_PROTOCOL;
-  }
-  return authority;
+  const apiProtocol = modelApiProtocolFromEnv(env.MAKA_HOST_MODEL_API_PROTOCOL);
+  return {
+    auth: noAuth
+      ? { kind: 'none' }
+      : apiKey !== undefined
+        ? { kind: 'credential', apiKey }
+        : { kind: 'inherit' },
+    ...(env.MAKA_HOST_BASE_URL ? { baseUrl: env.MAKA_HOST_BASE_URL } : {}),
+    ...(apiProtocol ? { apiProtocol } : {}),
+  };
 }
 
 function readHostApiKeyFile(env: RunHarborCellEnv): string {
   const path = env.MAKA_HOST_API_KEY_FILE;
   if (!path) throw new Error('MAKA_HOST_API_KEY_FILE is required for host-side Harbor cells');
   return readFileSync(path, 'utf8').trim();
-}
-
-function hostApiKeyEnvName(env: RunHarborCellEnv, provider: string): string {
-  const name = env.MAKA_HOST_API_KEY_ENV_NAME ?? providerApiKeyEnvName(provider);
-  if (!/^[A-Z][A-Z0-9_]{0,127}$/.test(name)) {
-    throw new Error(`invalid MAKA_HOST_API_KEY_ENV_NAME: ${name}`);
-  }
-  return name;
 }
 
 export function providerFromEnv(value: string | undefined): ProviderType {
@@ -174,10 +193,16 @@ export function resolveHarborCellAiSdkEnv(input: {
   env: RunHarborCellEnv;
   ts: number;
 }): ResolvedHarborCellAiSdkEnv {
-  const connection = connectionFromEnv(input.provider, input.model, input.env, input.ts);
+  const authority = resolveHostProviderAuthority(input.env);
+  const connection = connectionFromEnv(input.provider, input.model, input.env, input.ts, authority);
   return {
     connection,
-    apiKey: apiKeyFromEnv(input.provider, input.env, connection.slug),
+    apiKey:
+      authority.auth.kind === 'credential'
+        ? authority.auth.apiKey
+        : authority.auth.kind === 'none'
+          ? ''
+          : apiKeyFromEnv(input.provider, input.env, connection.slug),
   };
 }
 
@@ -186,9 +211,11 @@ function connectionFromEnv(
   model: string,
   values: RunHarborCellEnv,
   ts: number,
+  authority: ResolvedHostProviderAuthority,
 ): LlmConnection {
   const defaults = PROVIDER_DEFAULTS[provider];
-  const githubApiProtocol = modelApiProtocolFromEnv(values.MAKA_MODEL_API_PROTOCOL);
+  const githubApiProtocol =
+    authority.apiProtocol ?? modelApiProtocolFromEnv(values.MAKA_MODEL_API_PROTOCOL);
   if (provider === 'github-copilot' && !githubApiProtocol) {
     throw new Error('GitHub Copilot requires an account-discovered model protocol');
   }
@@ -196,7 +223,11 @@ function connectionFromEnv(
     slug: values.MAKA_LLM_CONNECTION_SLUG ?? provider,
     name: defaults.label,
     providerType: provider,
-    baseUrl: values.MAKA_BASE_URL ?? providerBaseUrlFromEnv(provider, values) ?? defaults.baseUrl,
+    baseUrl:
+      authority.baseUrl ??
+      values.MAKA_BASE_URL ??
+      providerBaseUrlFromEnv(provider, values) ??
+      defaults.baseUrl,
     defaultModel: model,
     ...(provider === 'github-copilot'
       ? { models: [{ id: model, apiProtocol: githubApiProtocol }] }

--- a/packages/headless/src/provider-env.ts
+++ b/packages/headless/src/provider-env.ts
@@ -79,7 +79,7 @@ const PROVIDER_CREDENTIAL_ENV = {
 } satisfies Partial<Record<ProviderType, ProviderCredentialEnv>>;
 
 const SENSITIVE_ENV_NAME =
-  /(?:^|_)(?:API_KEY|ACCESS_KEY|PRIVATE_KEY|TOKEN|SECRET|PASSWORD|CREDENTIALS?)(?:_|$)/i;
+  /(?:^|_)(?:API_KEY|ACCESS_KEY|PRIVATE_KEY|TOKEN|SECRET|CREDENTIALS?)(?:_|$)|PASSWORD$/i;
 
 export function providerCredentialEnv(provider: string): ProviderCredentialEnv | undefined {
   return PROVIDER_CREDENTIAL_ENV[provider as keyof typeof PROVIDER_CREDENTIAL_ENV];

--- a/packages/headless/src/task-agent-controller.ts
+++ b/packages/headless/src/task-agent-controller.ts
@@ -304,6 +304,9 @@ export async function runTaskOnce(
       backend: config.backend,
       llmConnectionSlug: effectiveConfig.llmConnectionSlug,
       model: effectiveConfig.model,
+      ...(effectiveConfig.thinkingLevel !== undefined
+        ? { thinkingLevel: effectiveConfig.thinkingLevel }
+        : {}),
       permissionMode: deps.permissionMode ?? 'execute',
       ...(deps.orchestrationMode ? { orchestrationMode: deps.orchestrationMode } : {}),
       name: `task:${config.id}:${task.id}`,

--- a/packages/headless/src/task-agent-controller.ts
+++ b/packages/headless/src/task-agent-controller.ts
@@ -21,7 +21,11 @@ import {
 import { createAgentRunStore, createRuntimeEventStore, createSessionStore } from '@maka/storage';
 import type { Config, ResultRecord, Task } from './contracts.js';
 import { registerFakeBackend } from './backends.js';
-import { summarizeCellTools, type HarborCellToolSummary } from './cell-output.js';
+import {
+  countRuntimeSteps,
+  summarizeCellTools,
+  type HarborCellToolSummary,
+} from './cell-output.js';
 import {
   createHeavyTaskEvidenceRecorder,
   renderHeavyTaskEvidenceForPrompt,
@@ -117,7 +121,6 @@ export interface RunTaskOnceResult {
   resultRecord: ResultRecord;
   projection: TaskRunProjection;
   invocations: readonly InvocationResult[];
-  invocation: InvocationResult;
 }
 
 export class TaskAgentController {
@@ -396,7 +399,6 @@ export async function runTaskOnce(
         resultRecord: permissionHandling.resultRecord,
         projection: await taskRunStore.project(taskRunId),
         invocations: [permissionHandling.invocation],
-        invocation: permissionHandling.invocation,
       };
     }
     let invocation = permissionHandling.invocation;
@@ -504,7 +506,6 @@ export async function runTaskOnce(
             resultRecord: repairPermissionHandling.resultRecord,
             projection: await taskRunStore.project(taskRunId),
             invocations: [...invocations, repairPermissionHandling.invocation],
-            invocation: repairPermissionHandling.invocation,
           };
         }
         invocation = repairPermissionHandling.invocation;
@@ -618,6 +619,7 @@ export async function runTaskOnce(
       startedAt,
       finishedAt,
       systemPrompt: prompt,
+      runtimeSteps: countRuntimeSteps(invocations.flatMap((candidate) => candidate.events)),
       runEvidence,
     });
     const taxonomy = finalScore.taxonomy;
@@ -707,7 +709,6 @@ export async function runTaskOnce(
       resultRecord,
       projection: await taskRunStore.project(taskRunId),
       invocations,
-      invocation,
     };
   } finally {
     await workspace.cleanup();
@@ -985,7 +986,7 @@ async function handlePermissionIntervention(
         runId: input.invocation.runId,
         startedAt: input.startedAt,
         finishedAt: requestedAt,
-        steps: input.invocation.events.length,
+        steps: countRuntimeSteps(input.invocation.events),
         errorClass: 'needs_approval',
         error: `task run needs approval for ${request.toolName}`,
         systemPrompt: input.systemPrompt,
@@ -1298,6 +1299,7 @@ function resultRecordFromInvocation(input: {
   scoreResultId: string;
   startedAt: number;
   finishedAt: number;
+  runtimeSteps: number;
   systemPrompt: Pick<ResolvedHeadlessSystemPrompt, 'mode' | 'systemPromptHash'>;
   runEvidence?: Pick<
     import('@maka/core').AgentRunHeader,
@@ -1332,7 +1334,7 @@ function resultRecordFromInvocation(input: {
     scoreResultId: input.scoreResultId,
     submittedSnapshotId: input.submittedSnapshotId,
     exitCode: input.verifierResult.exitCode ?? null,
-    steps: input.invocation.events.length,
+    steps: input.runtimeSteps,
     durationMs: input.finishedAt - input.startedAt,
     startedAt: input.startedAt,
     finishedAt: input.finishedAt,

--- a/packages/headless/src/task-agent-controller.ts
+++ b/packages/headless/src/task-agent-controller.ts
@@ -32,6 +32,7 @@ import {
 } from './heavy-task-evidence.js';
 import { resolveHeavyTaskMode } from './heavy-task-policy.js';
 import { resolveEconomyTaskMode } from './economy-task-policy.js';
+import { MAX_NODE_TIMER_MS } from './headless-run-env.js';
 import {
   createHeavyTaskProgressRecorder,
   HEAVY_TASK_PROGRESS_TOOL_NAMES,
@@ -1196,6 +1197,9 @@ async function runRuntimeAttempt(input: RunRuntimeAttemptInput): Promise<{
   };
   const remainingMs =
     input.deadlineAtMs === undefined ? undefined : Math.max(0, input.deadlineAtMs - input.now());
+  if (remainingMs !== undefined && remainingMs > MAX_NODE_TIMER_MS) {
+    throw new Error(`deadlineAtMs exceeds the Node timer limit of ${MAX_NODE_TIMER_MS}ms`);
+  }
   const dispatchAbortController = remainingMs === 0 ? new AbortController() : undefined;
   let settlementTimer: ReturnType<typeof setTimeout> | undefined;
   if (dispatchAbortController) {

--- a/packages/headless/src/task-agent-controller.ts
+++ b/packages/headless/src/task-agent-controller.ts
@@ -113,6 +113,8 @@ export interface RunTaskOnceDeps extends RunExperimentDeps {
   permissionMode?: 'execute';
   interventionPolicy?: TaskInterventionPolicy;
   permissionGrants?: readonly TaskPermissionGrant[];
+  /** Absolute wall-clock deadline for settling the active runtime before its outer watchdog. */
+  deadlineAtMs?: number;
 }
 
 export interface RunTaskOnceResult {
@@ -121,6 +123,7 @@ export interface RunTaskOnceResult {
   resultRecord: ResultRecord;
   projection: TaskRunProjection;
   invocations: readonly InvocationResult[];
+  settledByDeadline: boolean;
 }
 
 export class TaskAgentController {
@@ -355,8 +358,9 @@ export async function runTaskOnce(
     });
 
     let runtimeInvocation: InvocationResult;
+    let settledByDeadline = false;
     try {
-      runtimeInvocation = await runRuntimeAttempt({
+      const runtimeAttempt = await runRuntimeAttempt({
         run,
         header,
         instruction,
@@ -364,7 +368,11 @@ export async function runTaskOnce(
         requireTerminalRuntimeEventWrite: Boolean(runtimeEventStore),
         now,
         newId,
+        settleByDeadline: active.settleByDeadline,
+        ...(deps.deadlineAtMs !== undefined ? { deadlineAtMs: deps.deadlineAtMs } : {}),
       });
+      runtimeInvocation = runtimeAttempt.invocation;
+      settledByDeadline = runtimeAttempt.settledByDeadline;
     } finally {
       await active.dispose();
     }
@@ -399,6 +407,7 @@ export async function runTaskOnce(
         resultRecord: permissionHandling.resultRecord,
         projection: await taskRunStore.project(taskRunId),
         invocations: [permissionHandling.invocation],
+        settledByDeadline,
       };
     }
     let invocation = permissionHandling.invocation;
@@ -406,7 +415,7 @@ export async function runTaskOnce(
 
     let runtimeSummary = summarizeRuntime(invocation, deps.realBackendIsolation);
     await appendRuntimeFeedback(taskRunStore, taskRunId, attemptId, now, newId, runtimeSummary);
-    if (heavyTaskMode.enabled) {
+    if (heavyTaskMode.enabled && !settledByDeadline) {
       let gateProjection = await taskRunStore.project(taskRunId);
       const workspaceObservation = await appendHeavyTaskWorkspaceObservation({
         taskRunStore,
@@ -463,7 +472,7 @@ export async function runTaskOnce(
         repairActive.bindRun(repairRun);
         let repairInvocation: InvocationResult;
         try {
-          repairInvocation = await runRuntimeAttempt({
+          const repairRuntimeAttempt = await runRuntimeAttempt({
             run: repairRun,
             header,
             instruction: gateDecision.prompt,
@@ -471,7 +480,11 @@ export async function runTaskOnce(
             requireTerminalRuntimeEventWrite: Boolean(runtimeEventStore),
             now,
             newId,
+            settleByDeadline: repairActive.settleByDeadline,
+            ...(deps.deadlineAtMs !== undefined ? { deadlineAtMs: deps.deadlineAtMs } : {}),
           });
+          repairInvocation = repairRuntimeAttempt.invocation;
+          settledByDeadline ||= repairRuntimeAttempt.settledByDeadline;
         } finally {
           await repairActive.dispose();
         }
@@ -506,6 +519,7 @@ export async function runTaskOnce(
             resultRecord: repairPermissionHandling.resultRecord,
             projection: await taskRunStore.project(taskRunId),
             invocations: [...invocations, repairPermissionHandling.invocation],
+            settledByDeadline,
           };
         }
         invocation = repairPermissionHandling.invocation;
@@ -709,6 +723,7 @@ export async function runTaskOnce(
       resultRecord,
       projection: await taskRunStore.project(taskRunId),
       invocations,
+      settledByDeadline,
     };
   } finally {
     await workspace.cleanup();
@@ -1107,9 +1122,14 @@ interface RunRuntimeAttemptInput {
   requireTerminalRuntimeEventWrite: boolean;
   now: () => number;
   newId: () => string;
+  deadlineAtMs?: number;
+  settleByDeadline(): Promise<boolean>;
 }
 
-async function runRuntimeAttempt(input: RunRuntimeAttemptInput): Promise<InvocationResult> {
+async function runRuntimeAttempt(input: RunRuntimeAttemptInput): Promise<{
+  invocation: InvocationResult;
+  settledByDeadline: boolean;
+}> {
   let begin;
   try {
     begin = await input.run.begin();
@@ -1144,21 +1164,46 @@ async function runRuntimeAttempt(input: RunRuntimeAttemptInput): Promise<Invocat
     ...(begin.backendInput.runtimeContext ?? []),
   ];
 
-  const invocation = await runner.run({
-    sessionId: input.header.id,
-    invocationId: begin.initialRuntimeEvent.invocationId,
-    runId: input.run.runId,
-    turnId: input.run.turnId,
-    text: input.instruction,
-    context: begin.backendInput.context,
-    ...(runtimeContext.length > 0 ? { runtimeContext } : {}),
-    ...(begin.backendInput.attachments ? { attachments: begin.backendInput.attachments } : {}),
-    initialRuntimeEvent: begin.initialRuntimeEvent,
-    source: 'test',
-    lineage: input.run.lineage,
-  });
+  let settledByDeadline = false;
+  let settlementError: unknown;
+  let settlementAttempt: Promise<void> | undefined;
+  const settle = () => {
+    settlementAttempt = input
+      .settleByDeadline()
+      .then((settled) => {
+        settledByDeadline = settled;
+      })
+      .catch((error) => {
+        settlementError = error;
+      });
+  };
+  const remainingMs =
+    input.deadlineAtMs === undefined ? undefined : Math.max(0, input.deadlineAtMs - input.now());
+  let settlementTimer: ReturnType<typeof setTimeout> | undefined;
+  if (remainingMs === 0) settle();
+  else if (remainingMs !== undefined) settlementTimer = setTimeout(settle, remainingMs);
+  let invocation: InvocationResult;
+  try {
+    invocation = await runner.run({
+      sessionId: input.header.id,
+      invocationId: begin.initialRuntimeEvent.invocationId,
+      runId: input.run.runId,
+      turnId: input.run.turnId,
+      text: input.instruction,
+      context: begin.backendInput.context,
+      ...(runtimeContext.length > 0 ? { runtimeContext } : {}),
+      ...(begin.backendInput.attachments ? { attachments: begin.backendInput.attachments } : {}),
+      initialRuntimeEvent: begin.initialRuntimeEvent,
+      source: 'test',
+      lineage: input.run.lineage,
+    });
+  } finally {
+    if (settlementTimer) clearTimeout(settlementTimer);
+  }
+  await settlementAttempt;
+  if (settlementError) throw settlementError;
   await input.run.finalize();
-  return invocation;
+  return { invocation, settledByDeadline };
 }
 
 type AgentRunHooks = ConstructorParameters<typeof AgentRun>[0]['hooks'];
@@ -1171,6 +1216,7 @@ function createSingleRunActiveSession(
 ): {
   hooks: AgentRunHooks;
   bindRun(run: AgentRun): void;
+  settleByDeadline(): Promise<boolean>;
   dispose(): Promise<void>;
 } {
   let boundRun: AgentRun | undefined;
@@ -1180,6 +1226,19 @@ function createSingleRunActiveSession(
   };
   return {
     bindRun,
+    settleByDeadline: async () => {
+      if (!active) return false;
+      const stoppedRuns = [...active.activeRuns.values()].filter((run) =>
+        run.stop('benchmark_deadline'),
+      );
+      if (stoppedRuns.length === 0) return false;
+      try {
+        await active.backend.stop('user_stop', 'immediate');
+      } finally {
+        for (const run of stoppedRuns) run.completeStop();
+      }
+      return true;
+    },
     hooks: {
       ensureActive: async (sessionId, header) => {
         if (active) {

--- a/packages/headless/src/task-agent-controller.ts
+++ b/packages/headless/src/task-agent-controller.ts
@@ -528,45 +528,47 @@ export async function runTaskOnce(
         await appendRuntimeFeedback(taskRunStore, taskRunId, attemptId, now, newId, repairSummary);
         runtimeSummary = mergeRuntimeSummaries(runtimeSummary, repairSummary);
 
-        let boundedProjection = await taskRunStore.project(taskRunId);
-        const repairWorkspaceObservation = await appendHeavyTaskWorkspaceObservation({
-          taskRunStore,
-          taskRunId,
-          projection: boundedProjection,
-          executor: deps.realBackendIsolation?.toolExecutor,
-          cwd: agentWorkspaceDir,
-          now,
-          newId,
-        });
-        await appendHeavyTaskSelfCheckEvidenceLinks({
-          store: taskRunStore,
-          runtimeEventStore,
-          taskRunId,
-          attemptId,
-          invocation,
-          workspaceObservation: repairWorkspaceObservation,
-          now,
-          newId,
-        });
-        boundedProjection = await taskRunStore.project(taskRunId);
-        const boundedDecision = evaluateHeavyTaskSelfCheckGate({
-          task,
-          heavyTaskMode,
-          projection: boundedProjection,
-          repairAttemptsUsed: 1,
-          maxRepairAttempts: 1,
-        });
-        await appendTaskEvent(taskRunStore, taskRunId, {
-          type: 'heavy_task_self_check_gate_recorded',
-          id: newId(),
-          taskRunId,
-          ts: now(),
-          gate: heavyTaskSelfCheckGateStateFromDecision({
-            decision: boundedDecision,
-            attempt: 1,
-            maxAttempts: 1,
-          }),
-        });
+        if (!settledByDeadline) {
+          let boundedProjection = await taskRunStore.project(taskRunId);
+          const repairWorkspaceObservation = await appendHeavyTaskWorkspaceObservation({
+            taskRunStore,
+            taskRunId,
+            projection: boundedProjection,
+            executor: deps.realBackendIsolation?.toolExecutor,
+            cwd: agentWorkspaceDir,
+            now,
+            newId,
+          });
+          await appendHeavyTaskSelfCheckEvidenceLinks({
+            store: taskRunStore,
+            runtimeEventStore,
+            taskRunId,
+            attemptId,
+            invocation,
+            workspaceObservation: repairWorkspaceObservation,
+            now,
+            newId,
+          });
+          boundedProjection = await taskRunStore.project(taskRunId);
+          const boundedDecision = evaluateHeavyTaskSelfCheckGate({
+            task,
+            heavyTaskMode,
+            projection: boundedProjection,
+            repairAttemptsUsed: 1,
+            maxRepairAttempts: 1,
+          });
+          await appendTaskEvent(taskRunStore, taskRunId, {
+            type: 'heavy_task_self_check_gate_recorded',
+            id: newId(),
+            taskRunId,
+            ts: now(),
+            gate: heavyTaskSelfCheckGateStateFromDecision({
+              decision: boundedDecision,
+              attempt: 1,
+              maxAttempts: 1,
+            }),
+          });
+        }
       }
     }
 
@@ -621,7 +623,7 @@ export async function runTaskOnce(
     const runEvidence = await agentRunStore
       .readRun(header.id, invocation.runId)
       .catch(() => undefined);
-    const resultRecord = resultRecordFromInvocation({
+    const invocationResultRecord = resultRecordFromInvocation({
       config,
       task,
       sessionId: header.id,
@@ -636,7 +638,18 @@ export async function runTaskOnce(
       runtimeSteps: countRuntimeSteps(invocations.flatMap((candidate) => candidate.events)),
       runEvidence,
     });
-    const taxonomy = finalScore.taxonomy;
+    const resultRecord: ResultRecord = settledByDeadline
+      ? {
+          ...invocationResultRecord,
+          status: 'failed',
+          runnerCompleted: false,
+          error: 'benchmark deadline reached during attempt',
+          errorClass: 'budget_exhausted',
+        }
+      : invocationResultRecord;
+    const taxonomy: AutonomousResultTaxonomy = settledByDeadline
+      ? 'budget_exhausted'
+      : finalScore.taxonomy;
     const scoreResult: ScoreResult = {
       id: scoreResultId,
       taskRunId,
@@ -647,7 +660,11 @@ export async function runTaskOnce(
       eligible: finalScore.eligible,
       ...(finalScore.score !== undefined ? { score: finalScore.score } : {}),
       ...(finalScore.maxScore !== undefined ? { maxScore: finalScore.maxScore } : {}),
-      ...(finalScore.errorClass ? { errorClass: finalScore.errorClass } : {}),
+      ...(settledByDeadline
+        ? { errorClass: 'budget_exhausted' }
+        : finalScore.errorClass
+          ? { errorClass: finalScore.errorClass }
+          : {}),
       ...(finalScore.excludedReason ? { excludedReason: finalScore.excludedReason } : {}),
       taxonomy,
       ...(verifierResult.authority ? { authority: verifierResult.authority } : {}),
@@ -1179,9 +1196,12 @@ async function runRuntimeAttempt(input: RunRuntimeAttemptInput): Promise<{
   };
   const remainingMs =
     input.deadlineAtMs === undefined ? undefined : Math.max(0, input.deadlineAtMs - input.now());
+  const dispatchAbortController = remainingMs === 0 ? new AbortController() : undefined;
   let settlementTimer: ReturnType<typeof setTimeout> | undefined;
-  if (remainingMs === 0) settle();
-  else if (remainingMs !== undefined) settlementTimer = setTimeout(settle, remainingMs);
+  if (dispatchAbortController) {
+    dispatchAbortController.abort();
+    settle();
+  } else if (remainingMs !== undefined) settlementTimer = setTimeout(settle, remainingMs);
   let invocation: InvocationResult;
   try {
     invocation = await runner.run({
@@ -1196,12 +1216,16 @@ async function runRuntimeAttempt(input: RunRuntimeAttemptInput): Promise<{
       initialRuntimeEvent: begin.initialRuntimeEvent,
       source: 'test',
       lineage: input.run.lineage,
+      ...(dispatchAbortController ? { abortSignal: dispatchAbortController.signal } : {}),
     });
   } finally {
     if (settlementTimer) clearTimeout(settlementTimer);
   }
   await settlementAttempt;
   if (settlementError) throw settlementError;
+  if (dispatchAbortController && invocation.events.length === 0) {
+    invocation = { ...invocation, events: [begin.initialRuntimeEvent] };
+  }
   await input.run.finalize();
   return { invocation, settledByDeadline };
 }

--- a/packages/headless/src/task-agent-controller.ts
+++ b/packages/headless/src/task-agent-controller.ts
@@ -413,7 +413,7 @@ export async function runTaskOnce(
     let invocation = permissionHandling.invocation;
     const invocations = [invocation];
 
-    let runtimeSummary = summarizeRuntime(invocation, deps.realBackendIsolation);
+    let runtimeSummary = summarizeRuntime([invocation], deps.realBackendIsolation);
     await appendRuntimeFeedback(taskRunStore, taskRunId, attemptId, now, newId, runtimeSummary);
     if (heavyTaskMode.enabled && !settledByDeadline) {
       let gateProjection = await taskRunStore.project(taskRunId);
@@ -524,9 +524,9 @@ export async function runTaskOnce(
         }
         invocation = repairPermissionHandling.invocation;
         invocations.push(invocation);
-        const repairSummary = summarizeRuntime(invocation, deps.realBackendIsolation);
+        const repairSummary = summarizeRuntime([invocation], deps.realBackendIsolation);
         await appendRuntimeFeedback(taskRunStore, taskRunId, attemptId, now, newId, repairSummary);
-        runtimeSummary = mergeRuntimeSummaries(runtimeSummary, repairSummary);
+        runtimeSummary = summarizeRuntime(invocations, deps.realBackendIsolation);
 
         if (!settledByDeadline) {
           let boundedProjection = await taskRunStore.project(taskRunId);
@@ -1480,46 +1480,33 @@ interface RuntimeSummary {
 }
 
 function summarizeRuntime(
-  invocation: InvocationResult,
+  invocations: readonly InvocationResult[],
   isolation: RunExperimentDeps['realBackendIsolation'],
 ): RuntimeSummary {
+  const invocation = invocations.at(-1);
+  if (!invocation) throw new Error('runtime summary requires at least one invocation');
+  const events = invocations.flatMap((candidate) => candidate.events);
+  const previousTurns = invocations.slice(0, -1).map((candidate) => ({
+    invocationId: candidate.invocationId,
+    runId: candidate.runId,
+    turnId: candidate.turnId,
+    runtimeEventIds: candidate.events.map((event) => event.id),
+  }));
   return {
     runtimeRefs: {
       invocationId: invocation.invocationId,
       sessionId: invocation.sessionId,
       runId: invocation.runId,
       turnId: invocation.turnId,
-      runtimeEventIds: invocation.events.map((event) => event.id),
+      runtimeEventIds: events.map((event) => event.id),
+      ...(previousTurns.length > 0 ? { previousTurns } : {}),
     },
-    artifactRefs: collectArtifactRefs(invocation.events),
+    artifactRefs: collectArtifactRefs(events),
     isolation: isolation
       ? { kind: isolation.kind, label: isolation.label }
       : { kind: 'inert_fake_backend' },
-    budget: summarizeBudget(invocation),
-    tools: summarizeCellTools(invocation.events),
-  };
-}
-
-function mergeRuntimeSummaries(first: RuntimeSummary, second: RuntimeSummary): RuntimeSummary {
-  return {
-    ...second,
-    runtimeRefs: {
-      ...second.runtimeRefs,
-      runtimeEventIds: uniqueStrings([
-        ...first.runtimeRefs.runtimeEventIds,
-        ...second.runtimeRefs.runtimeEventIds,
-      ]),
-      previousTurns: [
-        ...(first.runtimeRefs.previousTurns ?? []),
-        {
-          invocationId: first.runtimeRefs.invocationId,
-          runId: first.runtimeRefs.runId,
-          turnId: first.runtimeRefs.turnId,
-          runtimeEventIds: first.runtimeRefs.runtimeEventIds,
-        },
-      ],
-    },
-    artifactRefs: [...first.artifactRefs, ...second.artifactRefs],
+    budget: summarizeBudget(invocations),
+    tools: summarizeCellTools(events),
   };
 }
 
@@ -1571,7 +1558,7 @@ function collectArtifactRefs(events: readonly RuntimeEvent[]): Array<Record<stri
   return refs;
 }
 
-function summarizeBudget(invocation: InvocationResult): Record<string, unknown> {
+function summarizeBudget(invocations: readonly InvocationResult[]): Record<string, unknown> {
   const totals = {
     input: 0,
     output: 0,
@@ -1581,7 +1568,8 @@ function summarizeBudget(invocation: InvocationResult): Record<string, unknown> 
   };
   const contextBudget: unknown[] = [];
   const rawFinishReasons: string[] = [];
-  for (const event of invocation.events) {
+  const latestFailureClass = invocations.at(-1)?.failure?.class;
+  for (const event of invocations.flatMap((invocation) => invocation.events)) {
     const usage = event.actions?.tokenUsage;
     if (!usage) continue;
     totals.input += usage.input ?? 0;
@@ -1596,7 +1584,7 @@ function summarizeBudget(invocation: InvocationResult): Record<string, unknown> 
     totals,
     ...(contextBudget.length > 0 ? { contextBudget } : {}),
     ...(rawFinishReasons.length > 0 ? { rawFinishReasons } : {}),
-    ...(invocation.failure?.class ? { failureClass: invocation.failure.class } : {}),
+    ...(latestFailureClass ? { failureClass: latestFailureClass } : {}),
   };
 }
 
@@ -1717,10 +1705,6 @@ function errorMessageFromTaxonomy(taxonomy: AutonomousResultTaxonomy): string {
 
 function appendTaskEvent(store: TaskRunStore, taskRunId: string, event: TaskEvent): Promise<void> {
   return store.appendEvent(taskRunId, event);
-}
-
-function uniqueStrings(values: readonly string[]): string[] {
-  return [...new Set(values)];
 }
 
 function isPermissionHandoffTerminal(event: {

--- a/packages/headless/src/task-agent-controller.ts
+++ b/packages/headless/src/task-agent-controller.ts
@@ -116,6 +116,7 @@ export interface RunTaskOnceResult {
   attemptId: string;
   resultRecord: ResultRecord;
   projection: TaskRunProjection;
+  invocations: readonly InvocationResult[];
   invocation: InvocationResult;
 }
 
@@ -394,10 +395,12 @@ export async function runTaskOnce(
         attemptId,
         resultRecord: permissionHandling.resultRecord,
         projection: await taskRunStore.project(taskRunId),
+        invocations: [permissionHandling.invocation],
         invocation: permissionHandling.invocation,
       };
     }
     let invocation = permissionHandling.invocation;
+    const invocations = [invocation];
 
     let runtimeSummary = summarizeRuntime(invocation, deps.realBackendIsolation);
     await appendRuntimeFeedback(taskRunStore, taskRunId, attemptId, now, newId, runtimeSummary);
@@ -500,10 +503,12 @@ export async function runTaskOnce(
             attemptId,
             resultRecord: repairPermissionHandling.resultRecord,
             projection: await taskRunStore.project(taskRunId),
+            invocations: [...invocations, repairPermissionHandling.invocation],
             invocation: repairPermissionHandling.invocation,
           };
         }
         invocation = repairPermissionHandling.invocation;
+        invocations.push(invocation);
         const repairSummary = summarizeRuntime(invocation, deps.realBackendIsolation);
         await appendRuntimeFeedback(taskRunStore, taskRunId, attemptId, now, newId, repairSummary);
         runtimeSummary = mergeRuntimeSummaries(runtimeSummary, repairSummary);
@@ -701,6 +706,7 @@ export async function runTaskOnce(
       attemptId,
       resultRecord,
       projection: await taskRunStore.project(taskRunId),
+      invocations,
       invocation,
     };
   } finally {


### PR DESCRIPTION
## Summary

- make host provider authority explicit and exclusive without materializing provider credentials in the task environment
- make the benchmark deadline authoritative before dispatch, during execution, and across repair settlement
- preserve the complete TaskRun trajectory across repair turns and autonomous retries
- fail closed on secret-shaped environment variables at both Harbor job and local task-command egress boundaries
- guarantee that every valid scored autonomous run admits its first attempt; wall-time limits constrain subsequent retries
- bind trace selection to the explicit Harbor mode instead of guessing across cell and task-run artifact trees
- forward the already parsed cell soft timeout into cell execution

## Verification

- `npm run build`
- `npm test -w @maka/headless` — 1,197 passed, 0 failed
- `npm run lint`
- `npm run format:check`
- `npm run typecheck` — all workspaces passed
- `git diff --check`

## Security

Credential resolution remains owned by the provider registry. Secret egress is a separate fail-closed boundary using one shared secret-shaped environment-name predicate, so unknown provider aliases and credential-file variables cannot leak merely because they are absent from the current registry.

## Review focus

- `invocations[]` is the TaskRun trajectory authority across heavy-task repair and autonomous retries
- TaskRun lifecycle time and autonomous retry-budget time are separate; setup time cannot manufacture a zero-attempt scored result
- `MAKA_HARBOR_MODE` selects either the cell trace tree or the task-run trace tree; artifacts from the other mode are ignored
- deadline settlement remains a single durable `benchmark.deadline` fact and `budget_exhausted` TaskRun outcome
- the branch is rebased onto current `main` and preserves the new swarm run-evidence fields alongside full trajectory step accounting
