### PR TITLE
fix(ui): align streaming work log language and rendering

### DIFF
--- a/apps/desktop/src/main/__tests__/response-language-prompt.test.ts
+++ b/apps/desktop/src/main/__tests__/response-language-prompt.test.ts
@@ -1,0 +1,39 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+import type { AppSettings } from '@maka/core';
+import { createSystemPromptMainService } from '../system-prompt-main.js';
+
+describe('desktop response language prompt', () => {
+  test('injects the latest-request language policy into normal and child turns', async () => {
+    const service = createSystemPromptMainService({
+      settingsStore: {
+        get: async () => ({
+          personalization: {},
+          workspaceInstructions: { enabled: false },
+        }) as AppSettings,
+      },
+      workspaceRoot: '/tmp/does-not-matter',
+      localMemory: {
+        getState: async () => ({ status: 'ok', agentReadEnabled: false, content: '' }) as never,
+        consumePendingPromptUpdates: () => [],
+      },
+      taskLedger: { list: async () => [] },
+    });
+
+    const normal = await service.buildBackendSystemPrompt(
+      { labels: [] },
+      undefined,
+      { memoryFragment: null },
+    );
+    const child = await service.buildBackendSystemPrompt(
+      { labels: [] },
+      undefined,
+      { childInstruction: 'Inspect the requested files.' },
+    );
+
+    for (const prompt of [normal, child]) {
+      assert.match(prompt ?? '', /same predominant natural language as the user's latest request/);
+      assert.match(prompt ?? '', /progress updates, visible reasoning summaries, questions, and the final answer/);
+    }
+  });
+});

--- a/apps/desktop/src/main/system-prompt-main.ts
+++ b/apps/desktop/src/main/system-prompt-main.ts
@@ -16,6 +16,7 @@ import {
 import {
   buildExpertTeamLeadSystemPromptFragment,
   buildPersonalizationPromptFragment,
+  buildResponseLanguagePromptFragment,
   resolveProjectGitInfo,
   buildSessionEnvironmentPromptFragment,
   resolveSkillDiscoveryPaths,
@@ -52,6 +53,7 @@ export function createSystemPromptMainService(deps: SystemPromptMainDeps) {
     options?: { memoryFragment?: string | null; includePersonalization?: boolean; skillBudget?: SkillPromptBudgetContext; forChildTurn?: boolean; host?: HostCapabilities },
   ): Promise<string | undefined> {
     const settings = await deps.settingsStore.get();
+    const responseLanguage = buildResponseLanguagePromptFragment();
     const includePersonalization = options?.includePersonalization !== false;
     const personalization = includePersonalization
       ? buildPersonalizationPromptFragment(settings.personalization)
@@ -79,6 +81,7 @@ export function createSystemPromptMainService(deps: SystemPromptMainDeps) {
       ? options.memoryFragment ?? undefined
       : await buildLocalMemoryPromptFragment();
     const fragments = [
+      responseLanguage,
       personalization.text,
       deepResearch,
       expertLead,

--- a/packages/cli/src/__tests__/cli-system-prompt.test.ts
+++ b/packages/cli/src/__tests__/cli-system-prompt.test.ts
@@ -7,6 +7,20 @@ import { buildCliSystemPrompt, buildCliTurnTailPrompt } from '../cli-system-prom
 import type { HostCapabilities } from '@maka/runtime';
 
 describe('CLI system prompt', () => {
+  test('always injects the latest-request language policy', async () => {
+    await withCwdAndWorkspace(async ({ cwd, workspaceRoot, homeDir }) => {
+      const out = await buildCliSystemPrompt({
+        settings: { personalization: {}, workspaceInstructions: { enabled: false } },
+        cwd,
+        workspaceRoot,
+        homeDir,
+      });
+
+      assert.match(out ?? '', /same predominant natural language as the user's latest request/);
+      assert.match(out ?? '', /raw tool output in their original form/);
+    });
+  });
+
   test('injects the skill catalog from workspaceRoot, gated by host capabilities (Office skills auto-filter on the CLI host)', async () => {
     await withCwdAndWorkspace(async ({ cwd, workspaceRoot, homeDir }) => {
       await writeSkill(
@@ -186,9 +200,11 @@ Project body.`,
         workspaceRoot: cwd,
         homeDir,
       });
-      assert.equal(
+      assert.ok(out);
+      assert.match(out, /Response language:/);
+      assert.doesNotMatch(
         out,
-        undefined,
+        /secret project rule/,
         'gate must suppress AGENTS.md when workspaceInstructions is disabled',
       );
     });
@@ -210,7 +226,7 @@ Project body.`,
     });
   });
 
-  test('returns undefined when there is no personalization and no readable instruction file', async () => {
+  test('keeps the base language policy when no optional prompt fragments are available', async () => {
     await withCwd(async (cwd, homeDir) => {
       const out = await buildCliSystemPrompt({
         settings: { personalization: {}, workspaceInstructions: { enabled: true } },
@@ -218,7 +234,10 @@ Project body.`,
         workspaceRoot: cwd,
         homeDir,
       });
-      assert.equal(out, undefined);
+      assert.ok(out);
+      assert.match(out, /Response language:/);
+      assert.doesNotMatch(out, /User personalization preferences/);
+      assert.doesNotMatch(out, /<workspace-instructions/);
     });
   });
 

--- a/packages/cli/src/cli-system-prompt.ts
+++ b/packages/cli/src/cli-system-prompt.ts
@@ -1,6 +1,7 @@
 import { redactSecrets, type PersonalizationSettings } from '@maka/core';
 import {
   buildPersonalizationPromptFragment,
+  buildResponseLanguagePromptFragment,
   buildSessionEnvironmentPromptFragment,
   buildSkillsPromptFragment,
   buildWorkspaceInstructionsPromptFragment,
@@ -59,8 +60,10 @@ export interface BuildCliSystemPromptInput {
 export async function buildCliSystemPrompt(
   input: BuildCliSystemPromptInput,
 ): Promise<string | undefined> {
+  const responseLanguage = buildResponseLanguagePromptFragment();
   const personalization = buildPersonalizationPromptFragment(input.settings.personalization);
-  // personalization -> skills -> workspaceInstructions, matching the desktop app.
+  // responseLanguage -> personalization -> skills -> workspaceInstructions,
+  // matching the desktop app.
   const skillSource = resolveSkillDiscoveryPaths(input.cwd, input.workspaceRoot, input.homeDir);
   const skills = await buildSkillsPromptFragment(skillSource, input.host, {
     contextWindow: input.modelContextWindow,
@@ -68,8 +71,8 @@ export async function buildCliSystemPrompt(
   const workspaceInstructions = input.settings.workspaceInstructions.enabled
     ? await buildWorkspaceInstructionsPromptFragment(input.cwd)
     : undefined;
-  const fragments = [personalization.text, skills, workspaceInstructions].filter((v): v is string =>
-    Boolean(v),
+  const fragments = [responseLanguage, personalization.text, skills, workspaceInstructions].filter(
+    (v): v is string => Boolean(v),
   );
   return fragments.length > 0 ? fragments.join('\n\n') : undefined;
 }

--- a/packages/runtime/src/__tests__/response-language-prompt.test.ts
+++ b/packages/runtime/src/__tests__/response-language-prompt.test.ts
@@ -1,0 +1,23 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+import { buildResponseLanguagePromptFragment } from '../system-prompt/response-language-prompt.js';
+
+describe('response language prompt', () => {
+  test('follows the latest request for every user-visible model-authored stream', () => {
+    const prompt = buildResponseLanguagePromptFragment();
+
+    assert.match(prompt, /same predominant natural language as the user's latest request/);
+    assert.match(
+      prompt,
+      /progress updates, visible reasoning summaries, questions, and the final answer/,
+    );
+    assert.match(prompt, /explicitly requests a different language/);
+  });
+
+  test('does not translate technical or externally produced content by default', () => {
+    const prompt = buildResponseLanguagePromptFragment();
+
+    assert.match(prompt, /code, commands, paths, identifiers, quotations, and raw tool output/);
+    assert.match(prompt, /unless the user asks for translation/);
+  });
+});

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -1159,6 +1159,7 @@ export {
   collectPersonalizationWarnings,
 } from './system-prompt/personalization-prompt.js';
 export type { PersonalizationPromptFragment } from './system-prompt/personalization-prompt.js';
+export { buildResponseLanguagePromptFragment } from './system-prompt/response-language-prompt.js';
 export {
   resolveProjectGitInfo,
   resolveProjectRoot,

--- a/packages/runtime/src/system-prompt/response-language-prompt.ts
+++ b/packages/runtime/src/system-prompt/response-language-prompt.ts
@@ -1,0 +1,17 @@
+/**
+ * Stable language policy shared by every interactive host.
+ *
+ * The model can infer the language of the latest user message more reliably
+ * than a client-side locale or a small language detector. Keeping this in the
+ * durable system prompt also covers streamed narration and final answers
+ * without rewriting model deltas in the UI.
+ */
+export function buildResponseLanguagePromptFragment(): string {
+  return [
+    'Response language:',
+    "- Write all user-visible assistant-authored prose in the same predominant natural language as the user's latest request. This includes progress updates, visible reasoning summaries, questions, and the final answer.",
+    '- If the user explicitly requests a different language, follow that request instead.',
+    '- If the latest request mixes languages, use the language of its main instruction.',
+    '- Keep code, commands, paths, identifiers, quotations, and raw tool output in their original form unless the user asks for translation.',
+  ].join('\n');
+}

--- a/packages/ui/src/__tests__/turn-work-log.test.ts
+++ b/packages/ui/src/__tests__/turn-work-log.test.ts
@@ -1,0 +1,204 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { createElement } from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { TurnView } from '../chat-turn.js';
+import { LocaleProvider } from '../locale-context.js';
+import type { TurnTimelineItem } from '../materialize.js';
+import {
+  areWorkLogTimelineItemsEqual,
+  areWorkLogTimelineListsEqual,
+  resolveWorkLogOpen,
+  shouldAutoCollapseWorkLog,
+  splitTimelineAtLastTool,
+} from '../turn-work-log.js';
+
+const text = (value: string): TurnTimelineItem => ({
+  kind: 'text',
+  text: value,
+  messageId: value,
+});
+
+const tool = (id: string): TurnTimelineItem => ({
+  kind: 'tools',
+  items: [{ toolUseId: id, toolName: 'Bash', status: 'completed', args: {} }],
+});
+
+describe('turn work-log timeline split', () => {
+  it('auto-collapses only when a live process settles', () => {
+    assert.equal(shouldAutoCollapseWorkLog(true, false), true);
+    assert.equal(shouldAutoCollapseWorkLog(true, true), false);
+    assert.equal(shouldAutoCollapseWorkLog(false, false), false);
+  });
+
+  it('resolves the work log closed in the same render that live mode settles', () => {
+    assert.equal(resolveWorkLogOpen(true, true, false), false);
+    assert.equal(resolveWorkLogOpen(true, true, true), true);
+    assert.equal(resolveWorkLogOpen(false, false, false), false);
+  });
+
+  it('treats recreated but unchanged narration as memo-equivalent', () => {
+    const previous = text('稳定的过程说明');
+    const recreated = text('稳定的过程说明');
+    const changed = text('发生变化的过程说明');
+
+    assert.equal(areWorkLogTimelineItemsEqual(previous, recreated), true);
+    assert.equal(areWorkLogTimelineItemsEqual(previous, changed), false);
+    assert.equal(areWorkLogTimelineListsEqual([previous], [recreated]), true);
+  });
+
+  it('invalidates memoized tool groups when a tool object changes', () => {
+    const stableTool = tool('command-1');
+    const stableItems = stableTool.kind === 'tools' ? stableTool.items : [];
+    const sameToolsNewGroup: TurnTimelineItem = {
+      kind: 'tools',
+      items: [...stableItems],
+    };
+    const changedTool: TurnTimelineItem = {
+      kind: 'tools',
+      items: stableItems.map((item) => ({ ...item, status: 'running' as const })),
+    };
+
+    assert.equal(areWorkLogTimelineItemsEqual(stableTool, sameToolsNewGroup), true);
+    assert.equal(areWorkLogTimelineItemsEqual(stableTool, changedTool), false);
+  });
+
+  it('keeps model narration interleaved with tools and leaves the final answer outside', () => {
+    const narration = text('先检查实现');
+    const command = tool('command-1');
+    const followup = text('命令已通过，接下来收尾');
+    const secondCommand = tool('command-2');
+    const finalAnswer = text('修改完成。');
+
+    const result = splitTimelineAtLastTool([
+      narration,
+      command,
+      followup,
+      secondCommand,
+      finalAnswer,
+    ]);
+
+    assert.deepEqual(result.workLog, [narration, command, followup, secondCommand]);
+    assert.deepEqual(result.answer, [finalAnswer]);
+  });
+
+  it('does not add a work disclosure to a text-only response', () => {
+    const answer = text('直接回答');
+    assert.deepEqual(splitTimelineAtLastTool([answer]), {
+      workLog: [],
+      answer: [answer],
+    });
+  });
+
+  it('filters provider reasoning before splitting the process log and final answer', () => {
+    const command = tool('command-1');
+    const finalReasoning: TurnTimelineItem = {
+      kind: 'thinking',
+      text: '确认命令结果后组织最终回答。',
+      messageId: 'final-step',
+    };
+    const finalAnswer = text('最终回答。');
+
+    assert.deepEqual(splitTimelineAtLastTool([command, finalReasoning, finalAnswer]), {
+      workLog: [command],
+      answer: [finalAnswer],
+    });
+  });
+
+  it('never renders raw provider reasoning inside the work log', () => {
+    const markup = renderToStaticMarkup(createElement(LocaleProvider, {
+      locale: 'zh',
+      children: createElement(TurnView, {
+        turn: {
+          turnId: 'turn-1',
+          status: 'completed',
+          partialOutputRetained: false,
+          tools: [],
+          notes: [],
+          startedAt: 1,
+          timeline: [
+            {
+              kind: 'thinking',
+              text: 'The user is asking for local modifications.',
+              messageId: 'step-1',
+            },
+            tool('command-1'),
+          ],
+        },
+        liveStreaming: {},
+      }),
+    }));
+
+    assert.match(markup, /data-turn-work-log="true"/);
+    assert.doesNotMatch(markup, /The user is asking for local modifications/);
+    assert.doesNotMatch(markup, /data-work-log-narration/);
+    assert.doesNotMatch(markup, />深度思考</);
+  });
+
+  it('does not render a trailing thinking disclosure beside the final answer', () => {
+    const markup = renderToStaticMarkup(createElement(LocaleProvider, {
+      locale: 'zh',
+      children: createElement(TurnView, {
+        turn: {
+          turnId: 'turn-final',
+          status: 'completed',
+          partialOutputRetained: false,
+          tools: [],
+          notes: [],
+          startedAt: 1,
+          timeline: [
+            tool('command-final'),
+            { kind: 'thinking', text: '整理结果。', messageId: 'final-step' },
+            text('这是最终回答。'),
+          ],
+        },
+        liveStreaming: {},
+      }),
+    }));
+
+    assert.doesNotMatch(markup, /整理结果。/);
+    assert.doesNotMatch(markup, /data-work-log-narration/);
+    assert.match(markup, /这是最终回答。/);
+    assert.doesNotMatch(markup, />深度思考</);
+  });
+
+  it('hides reasoning for text-only answers as well', () => {
+    const reasoning: TurnTimelineItem = {
+      kind: 'thinking',
+      text: 'I should answer the user in Chinese.',
+      messageId: 'reasoning-only',
+    };
+    const finalAnswer = text('只显示这段中文回答。');
+
+    assert.deepEqual(splitTimelineAtLastTool([reasoning, finalAnswer]), {
+      workLog: [],
+      answer: [finalAnswer],
+    });
+  });
+
+  it('does not render the heavy work-log body while settled and folded', () => {
+    const markup = renderToStaticMarkup(createElement(LocaleProvider, {
+      locale: 'zh',
+      children: createElement(TurnView, {
+        turn: {
+          turnId: 'turn-folded',
+          status: 'completed',
+          partialOutputRetained: false,
+          tools: [],
+          notes: [],
+          startedAt: 1,
+          timeline: [
+            { kind: 'thinking', text: '不应提前渲染的大段过程。', messageId: 'step-1' },
+            tool('command-folded'),
+            text('最终回答保持可见。'),
+          ],
+        },
+      }),
+    }));
+
+    assert.match(markup, /data-turn-work-log="true"/);
+    assert.doesNotMatch(markup, /data-turn-work-log-body="true"/);
+    assert.doesNotMatch(markup, /不应提前渲染的大段过程。/);
+    assert.match(markup, /最终回答保持可见。/);
+  });
+});

--- a/packages/ui/src/chat-turn.tsx
+++ b/packages/ui/src/chat-turn.tsx
@@ -1,12 +1,11 @@
-import { Fragment, memo, useEffect, useRef, useState, type ReactNode } from 'react';
+import { memo, useEffect, useRef, useState, type ReactNode } from 'react';
 import { Button as BaseButton } from '@base-ui/react/button';
 import { useMountedRef } from './use-mounted-ref.js';
-import { AlertOctagon, Ban, Brain, Check, ChevronRight, Copy, GitBranch, Info, Loader2, RefreshCcw, Timer } from './icons.js';
+import { AlertOctagon, Ban, Check, ChevronRight, Copy, GitBranch, Info, Loader2, RefreshCcw, Timer } from './icons.js';
 import { type ClipboardCopyPhase, useClipboardCopyFeedback } from './clipboard-feedback.js';
 import { Markdown } from './markdown.js';
-import { formatAbsoluteTimestamp, formatClockTime, turnAbortMarkerLabel } from './chat-display-helpers.js';
+import { formatAbsoluteTimestamp, formatClockTime, formatTurnDuration, turnAbortMarkerLabel } from './chat-display-helpers.js';
 import { prepareSmoothStreamText, useSmoothStreamContent } from './smooth-stream.js';
-import { tokenizeFade, useStreamFade, type StreamFade } from './stream-fade.js';
 import { Button as UiButton, DialogContent, DialogRoot } from './ui.js';
 import type { AttachmentRef } from '@maka/core';
 import type { TurnTimelineItem, TurnViewModel } from './materialize.js';
@@ -17,6 +16,12 @@ import { Tooltip, TooltipTrigger, TooltipContent } from './primitives/tooltip.js
 import { ToolTrow } from './tool-activity.js';
 import { useUiLocale } from './locale-context.js';
 import { getConversationCopy } from './conversation-copy.js';
+import {
+  areWorkLogTimelineListsEqual,
+  resolveWorkLogOpen,
+  shouldAutoCollapseWorkLog,
+  splitTimelineAtLastTool,
+} from './turn-work-log.js';
 
 /**
  * Injected host capability that reads a session attachment's bytes. @maka/ui is
@@ -284,7 +289,7 @@ export const TurnView = memo(function TurnView(props: {
   searchHighlighted?: boolean;
   /**
    * #642 single render path: set only on the active streaming tail turn. When
-   * present, the assistant `Message` renders the live 深度思考 + answer bubble as
+   * present, the assistant `Message` renders the user-visible live output as
    * the trailing entries of its timeline — the SAME node the committed turn
    * will settle into, so live→settled is a data-source swap (no unmount/mount).
    * While live the footer is a reserved-height placeholder, not the real
@@ -314,13 +319,17 @@ export const TurnView = memo(function TurnView(props: {
   // this is the live streaming tail (a thinking-only / textless streaming turn
   // has an empty committed timeline but must still show its live answer block).
   const showAssistantMessage = turn.timeline.length > 0 || !!props.liveStreaming;
+  const hasLiveThinking = turn.timeline.some(
+    (item) => item.kind === 'thinking' && item.live === true,
+  );
   const hasLiveTimelineContent = turn.timeline.some((item) =>
     item.kind === 'thinking'
-      ? item.live === true
+      ? false
       : item.kind === 'text'
         ? item.live === true
         : item.items.some((tool) => tool.status === 'pending' || tool.status === 'running' || tool.status === 'waiting_permission'),
   );
+  const { workLog, answer } = splitTimelineAtLastTool(turn.timeline);
   return (
     <section
       className="maka-turn"
@@ -429,10 +438,23 @@ export const TurnView = memo(function TurnView(props: {
                 )}
               </Marker>
             )}
-            {/* The turn timeline is the rendering source of truth
-                (materialize.ts): each step's 深度思考 disclosure, answer bubble,
-                and Codex-style tool trow in the order the model produced them. */}
-            {turn.timeline.map((item, index) => (
+            {/* Tool-bearing turns read as one process log, matching the live
+                model narration → tool/command → next narration sequence. The
+                final answer (everything after the last tool group) stays on
+                the main surface instead of being swallowed by the disclosure. */}
+            {workLog.length > 0 && (
+              <TurnWorkLog
+                items={workLog}
+                durationMs={turn.durationMs}
+                live={props.liveStreaming !== undefined}
+                continuing={props.liveStreaming?.continuingIndicator === true
+                  && !props.liveStreaming.processingIndicator
+                  && !hasLiveThinking
+                  && !hasLiveTimelineContent}
+                onStreamingSettled={props.liveStreaming?.onStreamingSettled}
+              />
+            )}
+            {answer.map((item, index) => (
               <TurnTimelineEntry
                 key={timelineEntryKey(item, index)}
                 item={item}
@@ -441,8 +463,8 @@ export const TurnView = memo(function TurnView(props: {
             ))}
             {props.liveStreaming && (
               <>
-                {props.liveStreaming.processingIndicator && !hasLiveTimelineContent && <ModelProcessingIndicator />}
-                {props.liveStreaming.continuingIndicator && !props.liveStreaming.processingIndicator && !hasLiveTimelineContent && <ModelContinuingIndicator />}
+                {(props.liveStreaming.processingIndicator || hasLiveThinking) && workLog.length === 0 && !hasLiveTimelineContent && <ModelProcessingIndicator />}
+                {props.liveStreaming.continuingIndicator && workLog.length === 0 && !props.liveStreaming.processingIndicator && !hasLiveThinking && !hasLiveTimelineContent && <ModelContinuingIndicator />}
               </>
             )}
           </div>
@@ -671,7 +693,7 @@ const STATUS_FOOTER_ICON: Record<TurnFooterActionMeta['id'], ReactNode> = {
  * the smoother catches up, then notify the parent to hand off to history.
  */
 /**
- * #642 single render path: the live 深度思考 + streaming answer, rendered as the
+ * #642 single render path: the live user-visible output, rendered as the
  * trailing entries of the active tail turn. Shared by `TurnView` (the normal
  * path — injected into the committed tail turn's timeline) and the ChatView
  * fallback (rare: streaming began before the optimistic user turn materialized).
@@ -681,9 +703,9 @@ const STATUS_FOOTER_ICON: Record<TurnFooterActionMeta['id'], ReactNode> = {
  */
 /**
  * #646: the "正在处理…" row — the model is being awaited with nothing streaming
- * yet. Same row language as a tool trow / 深度思考 (16px icon + `TextShimmer`
- * label, muted, base tier); a neutral spinner (not Brain — this isn't reasoning)
- * carries the "working" affordance. The 200ms appearance delay lives upstream in
+ * yet. Same row language as a tool trow (16px icon + `TextShimmer`
+ * label, muted, base tier); a neutral spinner carries the working affordance.
+ * The 200ms appearance delay lives upstream in
  * `useDelayedFlag`, so by the time this renders the wait is already worth showing.
  */
 export function ModelProcessingIndicator() {
@@ -789,15 +811,89 @@ function timelineEntryKey(item: TurnTimelineItem, index: number): string {
   return `${item.kind}-${item.messageId}`;
 }
 
-/** Render one timeline entry: reasoning disclosure / answer bubble / tool trow. */
+/** One Kimi/Codex-style disclosure for model narration and tool activity. */
+interface TurnWorkLogProps {
+  items: readonly TurnTimelineItem[];
+  durationMs?: number;
+  live: boolean;
+  continuing: boolean;
+  onStreamingSettled?: (messageId?: string) => void;
+}
+
+const TurnWorkLog = memo(function TurnWorkLog(props: TurnWorkLogProps) {
+  const copy = getConversationCopy(useUiLocale()).messages;
+  // A live log opens as soon as its first tool arrives. Replayed history stays
+  // folded. A user's manual toggle survives ordinary deltas, but the live →
+  // settled transition always closes the process log for the final answer.
+  const [open, setOpen] = useState(props.live);
+  const previousLiveRef = useRef(props.live);
+  const renderedOpen = resolveWorkLogOpen(open, previousLiveRef.current, props.live);
+  useEffect(() => {
+    const wasLive = previousLiveRef.current;
+    previousLiveRef.current = props.live;
+    if (shouldAutoCollapseWorkLog(wasLive, props.live)) setOpen(false);
+  }, [props.live]);
+  const label = props.live
+    ? copy.processing
+    : copy.processed(props.durationMs !== undefined ? formatTurnDuration(props.durationMs) : undefined);
+  return (
+    <Collapsible
+      className="min-w-0"
+      data-turn-work-log="true"
+      data-live={props.live ? 'true' : undefined}
+      open={renderedOpen}
+      onOpenChange={setOpen}
+    >
+      <CollapsibleTrigger className="group w-fit gap-1.5 text-left text-[length:var(--font-size-base)] text-[color:var(--muted-foreground)]">
+        {props.live ? (
+          <TextShimmer active delayed className="min-w-0 shrink-0 truncate">{label}</TextShimmer>
+        ) : (
+          <span className="min-w-0 shrink-0 truncate">{label}</span>
+        )}
+        <ChevronRight
+          size={14}
+          aria-hidden="true"
+          className="shrink-0 [transition:transform_var(--duration-quick)_var(--ease-out-strong)] group-data-[panel-open]:rotate-90"
+        />
+      </CollapsibleTrigger>
+      <span className="mt-2 h-px w-full bg-[var(--border)]" aria-hidden="true" />
+      <CollapsiblePanel>
+        {renderedOpen ? (
+          <div className="flex flex-col gap-3 pt-3" data-turn-work-log-body="true">
+            {props.items.map((item, index) => (
+              <TurnTimelineEntry
+                key={timelineEntryKey(item, index)}
+                item={item}
+                onStreamingSettled={props.onStreamingSettled}
+              />
+            ))}
+            {props.continuing && <ModelContinuingIndicator />}
+          </div>
+        ) : null}
+      </CollapsiblePanel>
+    </Collapsible>
+  );
+}, areTurnWorkLogPropsEqual);
+
+function areTurnWorkLogPropsEqual(previous: TurnWorkLogProps, next: TurnWorkLogProps): boolean {
+  // The settle callback is intentionally excluded. The desktop shell creates a
+  // fresh closure per render, but each closure is permanently scoped to this
+  // same turn/session. Treating its identity as render-bearing would pierce the
+  // memo boundary on every final-answer delta and re-render the whole log.
+  return previous.durationMs === next.durationMs
+    && previous.live === next.live
+    && previous.continuing === next.continuing
+    && Boolean(previous.onStreamingSettled) === Boolean(next.onStreamingSettled)
+    && areWorkLogTimelineListsEqual(previous.items, next.items);
+}
+
+/** Render one user-visible timeline entry: answer bubble or tool trow. */
 function TurnTimelineEntry(props: {
   item: TurnTimelineItem;
   onStreamingSettled?: (messageId?: string) => void;
 }) {
   const { item } = props;
-  if (item.kind === 'thinking') {
-    return <DeepThinking text={item.text} live={item.live === true} truncated={item.truncated === true} />;
-  }
+  if (item.kind === 'thinking') return null;
   if (item.kind === 'tools') return <ToolTrow items={item.items} />;
   if (item.kind === 'text' && item.live) {
     return (
@@ -810,155 +906,6 @@ function TurnTimelineEntry(props: {
     );
   }
   return <MessageBody role="assistant" text={item.text} ts={item.ts} />;
-}
-
-/**
- * "深度思考" — the unified reasoning disclosure for both live streaming and
- * committed history (replaces ReasoningPanel + the retired `.maka-turn-thinking`
- * disclosure). Controlled Collapsible, collapsed by default (no defaultOpen —
- * disclosure-collapsible-contract), fixed title "深度思考".
- *
- * `live=true` (thinking still flowing): the title shimmers (TextShimmer) and the
- * expanded body streams plain redacted text through `useSmoothStreamContent`
- * (non-Markdown for the same frame-pacing reason as the old ReasoningPanel),
- * auto-following the tail. `live=false` (settled / committed): plain title,
- * Markdown render + a "复制思考过程" button.
- *
- * `props.text` is the already-redacted-and-capped buffer (C0 chokepoint);
- * `prepareSmoothStreamText` re-runs `redactSecrets` (idempotent) as
- * defense-in-depth so the smoother never sees a raw secret. The "已截断" pill
- * fires when the thinking cap dropped content.
- */
-function DeepThinking(props: { text: string; live: boolean; truncated?: boolean }) {
-  const copy = getConversationCopy(useUiLocale()).messages;
-  const snap = useStreamSnap();
-  const safeText = prepareSmoothStreamText(props.text);
-  const { displayed } = useSmoothStreamContent(safeText, { streaming: props.live, snap });
-  // Per-word fade over the freshly revealed reasoning tail — same entrance as the
-  // main answer bubble (replaces the old caret). Plain-text path (no Markdown),
-  // so we tokenize `displayed` directly and wrap post-boundary tokens. Inactive
-  // (returns undefined) when settled or under snap.
-  const streamFade = useStreamFade(displayed, props.live && !snap);
-  // Controlled open (see ReasoningPanel history: a raw `open` attribute lets the
-  // ~60Hz stream re-render re-assert open state and undo a manual collapse).
-  // Collapsed by default so the answer reads cleanly; the click sticks.
-  const [open, setOpen] = useState(false);
-  const bodyRef = useRef<HTMLPreElement>(null);
-  useEffect(() => {
-    if (!props.live || !open) return;
-    const el = bodyRef.current;
-    if (el) el.scrollTop = el.scrollHeight;
-  }, [displayed, props.live, open]);
-  return (
-    <Collapsible
-      className="flex flex-col"
-      data-deep-thinking={props.live ? 'live' : undefined}
-      open={open}
-      onOpenChange={setOpen}
-    >
-      {/* Structurally identical to a tool trow row: [16px icon slot] + [label]
-          + [hover-reveal trailing chevron]. One font size (base 13px), one
-          weight (normal), muted color — the whole folded timeline reads as a
-          single tier, hierarchy carried by color, not by size/weight jitter. */}
-      <CollapsibleTrigger className="group flex w-full items-center gap-2 py-0.5 text-left">
-        <Brain
-          size={16}
-          aria-hidden="true"
-          className="shrink-0 text-[color:var(--muted-foreground)]"
-        />
-        {props.live ? (
-          <TextShimmer active={!snap} className="min-w-0 truncate text-[length:var(--font-size-base)]">{copy.thinking}</TextShimmer>
-        ) : (
-          <span className="min-w-0 truncate text-[length:var(--font-size-base)] text-[color:var(--muted-foreground)]">{copy.thinking}</span>
-        )}
-        {/* "已截断" pill: the thinking cap (applyThinkingDelta /
-            applyThinkingComplete) dropped content; same chrome as the
-            tool-output truncated pill. */}
-        {props.truncated && (
-          <span
-            className="rounded-[var(--radius-control)] border border-[oklch(from_var(--warning)_l_c_h_/_0.30)] bg-[oklch(from_var(--warning)_l_c_h_/_0.06)] px-1 text-[length:var(--font-size-caption)] text-[color:var(--warning-text,var(--info-text))]"
-            data-truncated="true"
-            title={copy.thinkingTruncatedTitle}
-          >
-            {copy.truncated}
-          </span>
-        )}
-        {/* Quiet chevron sits right after the label (near the text, not pinned
-            to the far edge), rides in on hover / open, matching the tool trow
-            rows. No always-on affordance so the folded row stays calm. */}
-        <span className="inline-flex shrink-0 items-center text-[color:var(--muted-foreground)] opacity-0 [transition:opacity_var(--duration-quick)_var(--ease-out-strong)] group-hover:opacity-100 group-data-[panel-open]:opacity-100">
-          <ChevronRight
-            size={14}
-            aria-hidden="true"
-            className="[transition:transform_var(--duration-quick)_var(--ease-out-strong)] group-data-[panel-open]:rotate-90"
-          />
-        </span>
-      </CollapsibleTrigger>
-      <CollapsiblePanel>
-        {/* Left-border-indented quiet detail block, one language with the tool
-            trow's expanded body. `live` and settled render the SAME plain-text
-            body at the caption tier so the two states never jump size; settled
-            is muted + regular weight (long reasoning in italic reads poorly).
-            The copy action is an icon-only hover affordance pinned top-right so
-            it never squeezes the reading column into a vertical char stack. */}
-        <div className="group/reasoning relative mt-1 ml-2 border-l border-[var(--border)] pl-2.5 pr-7">
-          {props.live ? (
-            <pre
-              ref={bodyRef}
-              className="m-0 max-h-64 overflow-y-auto whitespace-pre-wrap [word-break:break-word] [font-family:inherit] text-[length:var(--font-size-base)] leading-normal text-[color:var(--muted-foreground)] [scroll-behavior:auto]"
-            >
-              <DeepThinkingBody text={displayed} streamFade={streamFade} />
-            </pre>
-          ) : (
-            <>
-              {/* Same `max-h-64 overflow-y-auto` bound as the live `<pre>` above
-                  so an expanded panel doesn't jump taller the frame thinking
-                  settles (live→settled swaps this body in place). Long reasoning
-                  stays a compact scroll box in both states. Body uses base 13px
-                  so tool output and thinking share one reading size. */}
-              <div className="max-h-64 overflow-y-auto whitespace-pre-wrap [word-break:break-word] text-[length:var(--font-size-base)] leading-normal text-[color:var(--muted-foreground)]">
-                {props.text}
-              </div>
-              <div className="absolute right-0 top-0 opacity-0 [transition:opacity_var(--duration-quick)_var(--ease-out-strong)] group-hover/reasoning:opacity-100 focus-within:opacity-100">
-                <MessageCopyButton text={props.text} label={copy.copyThinking} footerStyle />
-              </div>
-            </>
-          )}
-        </div>
-      </CollapsiblePanel>
-    </Collapsible>
-  );
-}
-
-/**
- * Plain-text reasoning body with the same per-word fade as the answer bubble.
- * When `streamFade` is absent (settled / snap) it renders the raw string so the
- * deterministic capture shows the full text with no spans. Otherwise it splits
- * the whole buffer at grapheme 0 and wraps each post-boundary token in a
- * `.maka-stream-fade` span with a negative `animation-delay` (= -age) so the
- * entrance resumes mid-flight across the ~60Hz streaming re-renders.
- */
-function DeepThinkingBody(props: { text: string; streamFade?: StreamFade }) {
-  const fade = props.streamFade;
-  if (!fade) return <>{props.text}</>;
-  const { tokens } = tokenizeFade(props.text, 0, fade.boundaryOffset);
-  return (
-    <>
-      {tokens.map((token, index) =>
-        token.fade ? (
-          <span
-            key={index}
-            className="maka-stream-fade"
-            style={{ animationDelay: `-${Math.round(fade.ageAt(token.offset))}ms` }}
-          >
-            {token.text}
-          </span>
-        ) : (
-          <Fragment key={index}>{token.text}</Fragment>
-        ),
-      )}
-    </>
-  );
 }
 
 /**

--- a/packages/ui/src/conversation-copy.ts
+++ b/packages/ui/src/conversation-copy.ts
@@ -190,6 +190,7 @@ export interface ConversationCopy {
     assistant: string;
     processing: string;
     continuing: string;
+    processed: (duration?: string) => string;
     safeResumePending: string;
     safeResume: string;
     thinking: string;
@@ -355,7 +356,7 @@ const CONVERSATION_COPY = {
       branchTitle: (branch) => branch ? `分支：${branch}` : '选择分支', branchAriaLabel: (branch) => branch ? `切换分支：${branch}` : '选择分支',
     },
     messages: {
-      you: '你', assistant: 'Maka', processing: '正在处理…', continuing: '继续中…', safeResumePending: '正在验证…', safeResume: '安全恢复', thinking: '深度思考', truncated: '已截断', copied: '已复制', copying: '复制中', copyFailed: '复制失败', copy: '复制', copyMessage: '复制消息', copyThinking: '复制思考过程',
+      you: '你', assistant: 'Maka', processing: '正在处理…', continuing: '继续中…', processed: (duration) => duration ? `已处理 ${duration}` : '已处理', safeResumePending: '正在验证…', safeResume: '安全恢复', thinking: '深度思考', truncated: '已截断', copied: '已复制', copying: '复制中', copyFailed: '复制失败', copy: '复制', copyMessage: '复制消息', copyThinking: '复制思考过程',
       imageAriaLabel: (name) => `查看图片 ${name}`, userAriaLabel: '你发送的消息', assistantAriaLabel: 'Maka 的回答', answerActionsAriaLabel: '本轮回答操作', sourceAriaLabel: '本轮回答的来源', derivativesAriaLabel: '本轮回答的衍生', automationTriggered: '定时任务触发', automationTitle: (id) => `由定时任务触发 · ${id}`,
       thinkingTruncatedTitle: '部分 reasoning 已截断；显示的是最近的内容', outputTruncatedTitle: '助手输出已超过单次回合上限，超出部分未渲染。如需完整内容请重新生成或查看持久化的会话日志。', removeAttachmentAriaLabel: (name) => `移除 ${name}`, aborted: '(已中断)', abortedByStop: '(已中断 · 由停止按钮触发)',
     },
@@ -488,7 +489,7 @@ const CONVERSATION_COPY = {
       branchTitle: (branch) => branch ? `Branch: ${branch}` : 'Choose branch', branchAriaLabel: (branch) => branch ? `Switch branch: ${branch}` : 'Choose branch',
     },
     messages: {
-      you: 'You', assistant: 'Maka', processing: 'Working…', continuing: 'Continuing…', safeResumePending: 'Checking…', safeResume: 'Safe recovery', thinking: 'Thinking', truncated: 'Truncated', copied: 'Copied', copying: 'Copying', copyFailed: 'Copy failed', copy: 'Copy', copyMessage: 'Copy message', copyThinking: 'Copy reasoning',
+      you: 'You', assistant: 'Maka', processing: 'Working…', continuing: 'Continuing…', processed: (duration) => duration ? `Worked for ${duration}` : 'Worked', safeResumePending: 'Checking…', safeResume: 'Safe recovery', thinking: 'Thinking', truncated: 'Truncated', copied: 'Copied', copying: 'Copying', copyFailed: 'Copy failed', copy: 'Copy', copyMessage: 'Copy message', copyThinking: 'Copy reasoning',
       imageAriaLabel: (name) => `View image ${name}`, userAriaLabel: 'Your message', assistantAriaLabel: "Maka's response", answerActionsAriaLabel: 'Response actions', sourceAriaLabel: 'Source of this response', derivativesAriaLabel: 'Responses derived from this one', automationTriggered: 'Triggered by automation', automationTitle: (id) => `Triggered by automation · ${id}`,
       thinkingTruncatedTitle: 'Some reasoning was truncated; showing the most recent content', outputTruncatedTitle: 'The assistant output exceeded the per-turn limit. Regenerate it or inspect the persisted session log for the complete content.', removeAttachmentAriaLabel: (name) => `Remove ${name}`, aborted: '(Interrupted)', abortedByStop: '(Interrupted · Stop button)',
     },

--- a/packages/ui/src/turn-work-log.ts
+++ b/packages/ui/src/turn-work-log.ts
@@ -1,0 +1,98 @@
+import type { TurnTimelineItem } from './materialize.js';
+
+export function shouldAutoCollapseWorkLog(previousLive: boolean, live: boolean): boolean {
+  return previousLive && !live;
+}
+
+/**
+ * Resolve the controlled disclosure state during a live -> settled render.
+ * Returning `false` synchronously keeps the just-settled process body out of
+ * that commit instead of waiting for an effect and paying for one final full
+ * Markdown render before it disappears.
+ */
+export function resolveWorkLogOpen(
+  open: boolean,
+  previousLive: boolean,
+  live: boolean,
+): boolean {
+  return shouldAutoCollapseWorkLog(previousLive, live) ? false : open;
+}
+
+/**
+ * Live-turn overlaying recreates timeline wrapper objects on every answer
+ * delta. Compare their render-bearing fields so an unchanged process log can
+ * stay behind a memo boundary while the final answer continues streaming.
+ */
+export function areWorkLogTimelineItemsEqual(
+  previous: TurnTimelineItem,
+  next: TurnTimelineItem,
+): boolean {
+  if (previous === next) return true;
+  if (previous.kind !== next.kind) return false;
+  if (previous.kind === 'tools' && next.kind === 'tools') {
+    return previous.items.length === next.items.length
+      && previous.items.every((item, index) => item === next.items[index]);
+  }
+  if (previous.kind === 'thinking' && next.kind === 'thinking') {
+    return previous.messageId === next.messageId
+      && previous.text === next.text
+      && previous.live === next.live
+      && previous.truncated === next.truncated;
+  }
+  if (previous.kind === 'text' && next.kind === 'text') {
+    return previous.messageId === next.messageId
+      && previous.text === next.text
+      && previous.ts === next.ts
+      && previous.live === next.live
+      && previous.complete === next.complete
+      && previous.truncated === next.truncated;
+  }
+  return false;
+}
+
+export function areWorkLogTimelineListsEqual(
+  previous: readonly TurnTimelineItem[],
+  next: readonly TurnTimelineItem[],
+): boolean {
+  return previous === next
+    || (previous.length === next.length
+      && previous.every((item, index) => areWorkLogTimelineItemsEqual(item, next[index]!)));
+}
+
+/**
+ * A tool-bearing turn gets exactly one final answer: the last text block after
+ * the last tool. Earlier user-visible text and tools belong to the process log;
+ * provider reasoning is removed from both surfaces.
+ */
+export function splitTimelineAtLastTool(items: readonly TurnTimelineItem[]): {
+  workLog: TurnTimelineItem[];
+  answer: TurnTimelineItem[];
+} {
+  // Provider reasoning is internal model state, not user-facing narration.
+  // Keeping it out of both surfaces prevents raw English chain-of-thought from
+  // appearing beside a Chinese answer (and avoids rendering it while streaming).
+  const visibleItems = items.filter((item) => item.kind !== 'thinking');
+  let lastToolIndex = -1;
+  for (let index = visibleItems.length - 1; index >= 0; index -= 1) {
+    if (visibleItems[index]?.kind === 'tools') {
+      lastToolIndex = index;
+      break;
+    }
+  }
+  if (lastToolIndex < 0) return { workLog: [], answer: visibleItems };
+  let finalAnswerIndex = -1;
+  for (let index = visibleItems.length - 1; index > lastToolIndex; index -= 1) {
+    if (visibleItems[index]?.kind === 'text') {
+      finalAnswerIndex = index;
+      break;
+    }
+  }
+  if (finalAnswerIndex < 0) return { workLog: visibleItems, answer: [] };
+  return {
+    workLog: [
+      ...visibleItems.slice(0, finalAnswerIndex),
+      ...visibleItems.slice(finalAnswerIndex + 1),
+    ],
+    answer: [visibleItems[finalAnswerIndex]!],
+  };
+}

--- a/packages/ui/stories/chat-surface.stories.tsx
+++ b/packages/ui/stories/chat-surface.stories.tsx
@@ -303,8 +303,8 @@ const longMessages: StoredMessage[] = [
 // Multi-step reasoning turn (streaming UI rework): two think->say->call steps
 // in a single turn. Each step persists an assistant row (thinking + text) plus
 // tool_calls tagged with that row's id as `stepId`, so the turn timeline
-// reconstructs the real order — 深度思考 → answer text → tool trow — per step,
-// instead of lumping every tool into one trailing group.
+// reconstructs the real user-visible order — answer text → tool trow — per
+// step. Provider thinking remains in the projection but is never rendered.
 const multiStepConversation: StoredMessage[] = [
   user('msg-user-multistep', 'turn-multistep', 12, '看一下 stream-fade 的环逻辑有没有边界问题，然后跑一下单测。'),
   {
@@ -385,6 +385,17 @@ const multiStepConversation: StoredMessage[] = [
     text: '13 个单测全绿，环的窗口滑动、乱序快照取龄和上限都被覆盖。边界没有问题。',
     thinking: {
       text: '测试包含窗口滑动、乱序 age 查询与上限三类，全过说明剪枝和 cap 的顺序是对的，可以收尾。',
+    },
+    modelId: 'claude-sonnet-4-5',
+  },
+  {
+    type: 'assistant',
+    id: 'msg-assistant-final',
+    turnId: 'turn-multistep',
+    ts: NOW - 7 * 60_000,
+    text: '最终结论：窗口滑动、乱序快照取龄和容量上限都已被测试覆盖，这里不需要继续修改。',
+    thinking: {
+      text: '命令已经完成，最后把验证结果整理成简洁结论。',
     },
     modelId: 'claude-sonnet-4-5',
   },


### PR DESCRIPTION
## What changed

- Group user-visible progress text and tool activity into one auto-collapsing work log while keeping the final answer outside.
- Add a shared desktop/CLI system-prompt policy that follows the language of the user's latest request.
- Keep provider reasoning internal so raw English thinking is never mixed into localized user-facing output.
- Avoid re-rendering stable work-log entries during final-answer streaming and skip hidden Markdown bodies during collapse.

## Why

The streaming surface exposed provider thinking as narration, mixed English reasoning with Chinese replies, left a redundant thinking disclosure near the final answer, and performed an expensive final render/measurement of the entire process log before folding it.

## Impact

Streaming turns now read as localized progress, tools/commands, and one final answer. Completed work logs fold automatically with less layout work, and raw provider reasoning remains hidden.

## Validation

- Runtime response-language tests: 2 passed
- CLI system-prompt tests: 10 passed
- UI test suite: 217 passed
- Desktop response-language test: 1 passed
- Desktop renderer TypeScript check passed
