### PR TITLE
fix(headless): export real Maka steps in Harbor trajectories

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,11 @@ jobs:
         with:
           node-version: '24'
           cache: npm
+      - uses: astral-sh/setup-uv@v6
+      - name: Install pinned Harbor contract runtime
+        run: |
+          uv tool install "harbor==0.13.2"
+          uv tool dir --bin >> "$GITHUB_PATH"
       - name: Install Linux runtime dependencies
         run: sudo apt-get update && sudo apt-get install -y ripgrep bubblewrap
       # Ubuntu 24.04 hosted runners gate unprivileged user namespaces through
@@ -63,7 +68,10 @@ jobs:
       # test:dist runs the suites against the dist just built above. The
       # workspace `test` scripts each do `clean && build` first, which would
       # throw away this dist and rebuild every package a second time.
-      - run: npm run test:dist
+      - name: Run required test suite
+        env:
+          MAKA_REQUIRE_HARBOR_CONTRACT: '1'
+        run: npm run test:dist
 
   e2e:
     runs-on: ubuntu-latest

--- a/packages/headless/harbor/maka_agent.py
+++ b/packages/headless/harbor/maka_agent.py
@@ -1006,19 +1006,28 @@ class MakaAgent(BaseInstalledAgent):
         env.update(_load_env_file(_DEFAULT_RUNNER_ENV))
         env.update(getattr(self, "_extra_env", {}) or {})
         _normalize_cli_env(env)
-        env.setdefault("MAKA_REPO_DIR", str(self._host_repo_root()))
+        host_repo_root = self._host_repo_root()
+        if not host_repo_root.is_absolute():
+            host_repo_root = Path(os.path.abspath(host_repo_root))
+        env.setdefault("MAKA_REPO_DIR", str(host_repo_root))
         env.setdefault("MAKA_MODEL", "deepseek-chat")
         env.setdefault("MAKA_TASK_RUN_OUT_DIR", str(self.logs_dir / "maka-task-run"))
         env.setdefault("MAKA_CELL_ARTIFACT_DIR", str(self.logs_dir))
         task_run_out_dir = Path(env["MAKA_TASK_RUN_OUT_DIR"])
         if not task_run_out_dir.is_absolute():
-            task_run_out_dir = task_run_out_dir.resolve()
-            env["MAKA_TASK_RUN_OUT_DIR"] = str(task_run_out_dir)
-        # _normalize_cli_env derives MAKA_OUTPUT_DIR/MAKA_STORAGE_ROOT from
-        # MAKA_TASK_RUN_OUT_DIR; re-apply now that the out dir is finalized.
+            task_run_out_dir = host_repo_root / task_run_out_dir
+        env["MAKA_TASK_RUN_OUT_DIR"] = str(task_run_out_dir)
         env.setdefault("MAKA_OUTPUT_DIR", str(task_run_out_dir))
         env.setdefault("MAKA_STORAGE_ROOT", str(task_run_out_dir / "runs"))
-        self._trajectory_storage_root = Path(env["MAKA_STORAGE_ROOT"])
+        output_dir = Path(env["MAKA_OUTPUT_DIR"])
+        storage_root = Path(env["MAKA_STORAGE_ROOT"])
+        if not output_dir.is_absolute():
+            output_dir = host_repo_root / output_dir
+        if not storage_root.is_absolute():
+            storage_root = host_repo_root / storage_root
+        env["MAKA_OUTPUT_DIR"] = str(output_dir)
+        env["MAKA_STORAGE_ROOT"] = str(storage_root)
+        self._trajectory_storage_root = storage_root
         env["MAKA_CELL_SOFT_TIMEOUT_MS"] = str(self._cell_soft_timeout_ms(env))
 
         task_workdir, workdir_probe = await self._resolve_task_workdir(environment)
@@ -1062,7 +1071,7 @@ class MakaAgent(BaseInstalledAgent):
             try:
                 proc = await asyncio.create_subprocess_exec(
                     *command,
-                    cwd=str(self._host_repo_root()),
+                    cwd=str(host_repo_root),
                     stdin=asyncio.subprocess.PIPE,
                     stdout=asyncio.subprocess.PIPE,
                     stderr=asyncio.subprocess.PIPE,

--- a/packages/headless/harbor/maka_agent.py
+++ b/packages/headless/harbor/maka_agent.py
@@ -34,6 +34,11 @@ from harness_compat import (
     format_trajectory_json,
     with_prompt_template,
 )
+from maka_trajectory import (
+    load_runtime_trajectory,
+    redact_value,
+    referenced_image_artifact_paths,
+)
 from process_scope import (
     COMMAND_SCOPE_ENV as _COMMAND_SCOPE_ENV,
     COMMAND_SCOPE_ROOT as _COMMAND_SCOPE_ROOT,
@@ -427,6 +432,8 @@ class MakaAgent(BaseInstalledAgent):
             await self.exec_as_agent(environment, command=command, env=env, timeout_sec=self._cell_timeout_sec())
             await self._download_cell_output(environment)
         output = self._read_cell_output(required=True)
+        await self._download_runtime_events(environment, output)
+        await self._download_runtime_artifacts(environment)
         self._apply_cell_output(context, output)
 
     def populate_context_post_run(self, context: AgentContext) -> None:
@@ -724,19 +731,83 @@ class MakaAgent(BaseInstalledAgent):
         }
         self._write_trajectory(output)
 
+    async def _download_runtime_events(
+        self,
+        environment: BaseEnvironment,
+        output: dict[str, Any],
+    ) -> None:
+        if self._resolve_runtime_events_path() is not None:
+            return
+        remote = output.get("runtimeEventsPath")
+        if not isinstance(remote, str) or not remote:
+            return
+        expected_remote = EnvironmentPaths.agent_dir / self._RUNTIME_EVENTS_FILENAME
+        if Path(remote) != expected_remote:
+            self.logger.debug("Ignoring unexpected Maka runtime events path %s", remote)
+            return
+        local = self.logs_dir / self._RUNTIME_EVENTS_FILENAME
+        try:
+            await environment.download_file(remote, local)
+        except Exception as exc:  # noqa: BLE001 - summary fallback records the missing evidence.
+            self.logger.debug("Could not download Maka runtime events %s: %s", remote, exc)
+
+    def _resolve_runtime_events_path(self) -> Path | None:
+        local = self.logs_dir / self._RUNTIME_EVENTS_FILENAME
+        return local if local.is_file() else None
+
+    async def _download_runtime_artifacts(self, environment: BaseEnvironment) -> None:
+        runtime_events_path = self._resolve_runtime_events_path()
+        if runtime_events_path is None:
+            return
+        local_artifact_root = self._trajectory_artifact_store_root() / "artifacts"
+        metadata_path = local_artifact_root / "metadata.jsonl"
+        if metadata_path.is_file():
+            return
+        remote_artifact_root = EnvironmentPaths.agent_dir / "maka-storage" / "artifacts"
+        try:
+            metadata_path.parent.mkdir(parents=True, exist_ok=True)
+            await environment.download_file(
+                (remote_artifact_root / "metadata.jsonl").as_posix(), metadata_path
+            )
+            for relative_path in referenced_image_artifact_paths(
+                runtime_events_path, metadata_path
+            ):
+                local = local_artifact_root / relative_path
+                local.parent.mkdir(parents=True, exist_ok=True)
+                await environment.download_file(
+                    (remote_artifact_root / relative_path).as_posix(), local
+                )
+        except Exception as exc:  # noqa: BLE001 - trajectory builder fails closed.
+            self.logger.debug("Could not download Maka runtime artifacts: %s", exc)
+
     def _write_trajectory(self, output: dict[str, Any]) -> None:
         token_summary = output.get("tokenSummary")
         tool_summary = output.get("toolSummary")
+        output_status = output.get("status") if isinstance(output.get("status"), str) else None
+        runtime_refs = output.get("runtimeRefs")
+        if not isinstance(runtime_refs, dict):
+            runtime_refs = None
+        evidence = load_runtime_trajectory(
+            self._resolve_runtime_events_path(),
+            output_status,
+            runtime_refs,
+            self._trajectory_artifact_store_root(),
+            self.logs_dir,
+        )
+        steps = [Step(**step) for step in evidence.steps]
         final_metrics = FinalMetrics(
             total_prompt_tokens=_optional_int(token_summary, "input"),
             total_completion_tokens=_optional_int(token_summary, "output"),
+            total_cached_tokens=_optional_int(token_summary, "cachedInput"),
             total_cost_usd=_optional_float(token_summary, "costUsd"),
-            total_steps=output.get("steps") if isinstance(output.get("steps"), int) else None,
-            extra={
+            total_steps=len(steps),
+            extra=redact_value({
                 "maka_status": output.get("status"),
                 "maka_error_class": output.get("errorClass"),
                 "maka_prompt_hash": output.get("promptHash"),
                 "runtime_events_path": output.get("runtimeEventsPath"),
+                "runtime_event_count": evidence.runtime_event_count,
+                "reported_runtime_steps": output.get("steps") if isinstance(output.get("steps"), int) else None,
                 "cached_input_tokens": _optional_int(token_summary, "cachedInput"),
                 "cache_hit_input_tokens": _optional_int(token_summary, "cacheHitInput"),
                 "cache_miss_input_tokens": _optional_int(token_summary, "cacheMissInput"),
@@ -747,16 +818,29 @@ class MakaAgent(BaseInstalledAgent):
                 "actual_tool_calls": _optional_int(tool_summary, "actualToolCalls"),
                 "actual_tool_names": _optional_string_list(tool_summary, "actualToolNames"),
                 "actual_tool_call_counts": _optional_dict(tool_summary, "actualToolCallCounts"),
-            },
+            }),
+        )
+        notes = (
+            f"Complete Maka trajectory derived from {evidence.runtime_event_count} immutable RuntimeEvents."
+            if evidence.artifact_kind == "full"
+            else f"Summary artifact only; complete RuntimeEvent trajectory unavailable: {evidence.reason}."
+        )
+        session_id = (
+            runtime_refs.get("sessionId")
+            if isinstance(runtime_refs, dict) and isinstance(runtime_refs.get("sessionId"), str)
+            else None
         )
         trajectory = Trajectory(
-            session_id=(output.get("runtimeRefs") or {}).get("sessionId"),
+            session_id=session_id,
             agent=Agent(name="maka", version=self.version() or "unknown", model_name=self.model_name),
-            steps=[
-                Step(step_id=1, source="user", message="Harbor task instruction"),
-                Step(step_id=2, source="agent", message=f"Maka cell {output.get('status', 'finished')}"),
-            ],
+            steps=steps,
+            notes=notes,
             final_metrics=final_metrics,
+            extra={
+                "maka_artifact_kind": evidence.artifact_kind,
+                "maka_terminal_status": evidence.terminal_status,
+                **({"maka_summary_reason": evidence.reason} if evidence.reason else {}),
+            },
         )
         trajectory_path = self.logs_dir / "trajectory.json"
         try:
@@ -900,6 +984,13 @@ class MakaAgent(BaseInstalledAgent):
                 await environment.download_file(remote.as_posix(), local)
             except Exception as exc:  # noqa: BLE001 - best-effort artifact hydration.
                 self.logger.debug("Could not download Maka task-run artifact %s: %s", remote, exc)
+    def _trajectory_artifact_store_root(self) -> Path:
+        configured = getattr(self, "_trajectory_storage_root", None)
+        if isinstance(configured, Path):
+            return configured
+        if self._harbor_mode() == "task-run":
+            return self.logs_dir / "maka-task-run" / "runs"
+        return self.logs_dir / "maka-storage"
 
     async def _run_task_run_host(
         self,
@@ -927,6 +1018,7 @@ class MakaAgent(BaseInstalledAgent):
         # MAKA_TASK_RUN_OUT_DIR; re-apply now that the out dir is finalized.
         env.setdefault("MAKA_OUTPUT_DIR", str(task_run_out_dir))
         env.setdefault("MAKA_STORAGE_ROOT", str(task_run_out_dir / "runs"))
+        self._trajectory_storage_root = Path(env["MAKA_STORAGE_ROOT"])
         env["MAKA_CELL_SOFT_TIMEOUT_MS"] = str(self._cell_soft_timeout_ms(env))
 
         task_workdir, workdir_probe = await self._resolve_task_workdir(environment)

--- a/packages/headless/harbor/maka_agent.py
+++ b/packages/headless/harbor/maka_agent.py
@@ -432,7 +432,6 @@ class MakaAgent(BaseInstalledAgent):
             await self.exec_as_agent(environment, command=command, env=env, timeout_sec=self._cell_timeout_sec())
             await self._download_cell_output(environment)
         output = self._read_cell_output(required=True)
-        await self._download_runtime_events(environment, output)
         await self._download_runtime_artifacts(environment)
         self._apply_cell_output(context, output)
 
@@ -730,26 +729,6 @@ class MakaAgent(BaseInstalledAgent):
             "maka_actual_tool_call_counts": _optional_dict(output.get("toolSummary"), "actualToolCallCounts"),
         }
         self._write_trajectory(output)
-
-    async def _download_runtime_events(
-        self,
-        environment: BaseEnvironment,
-        output: dict[str, Any],
-    ) -> None:
-        if self._resolve_runtime_events_path() is not None:
-            return
-        remote = output.get("runtimeEventsPath")
-        if not isinstance(remote, str) or not remote:
-            return
-        expected_remote = EnvironmentPaths.agent_dir / self._RUNTIME_EVENTS_FILENAME
-        if Path(remote) != expected_remote:
-            self.logger.debug("Ignoring unexpected Maka runtime events path %s", remote)
-            return
-        local = self.logs_dir / self._RUNTIME_EVENTS_FILENAME
-        try:
-            await environment.download_file(remote, local)
-        except Exception as exc:  # noqa: BLE001 - summary fallback records the missing evidence.
-            self.logger.debug("Could not download Maka runtime events %s: %s", remote, exc)
 
     def _resolve_runtime_events_path(self) -> Path | None:
         local = self.logs_dir / self._RUNTIME_EVENTS_FILENAME

--- a/packages/headless/harbor/maka_trajectory.py
+++ b/packages/headless/harbor/maka_trajectory.py
@@ -70,7 +70,7 @@ _SECRET_PATTERNS = (
     re.compile(
         r"(?i)((?:--?(?:api[-_]?key|auth[-_]?token|access[-_]?token|token|cookie|set-cookie|password|secret)"
         r"|(?:api[-_]?key|auth[-_]?token|access[-_]?token|token|cookie|set-cookie|password|secret))"
-        r"(?:\s+|\s*[:=]\s*))(?:\"[^\"]*\"|'[^']*'|[^\s,;]+)"
+        r"(?:\s*[:=]\s*|\s+))(?:\"[^\"]*\"|'[^']*'|[^\s,;]+)"
     ),
     re.compile(r"(?i)(authorization\s*:\s*bearer\s+)[^\s,;]+"),
     re.compile(r"(?i)\bbearer\s+[A-Za-z0-9._~+/=-]{8,}"),
@@ -311,6 +311,7 @@ def build_runtime_trajectory(
             )
         previous_identity = identity
         if event.get("partial") is True:
+            previous_was_terminal = False
             continue
         status = _terminal_status(event)
         previous_was_terminal = status is not None
@@ -675,7 +676,8 @@ def _is_attachment_ref(value: Any) -> bool:
     if not isinstance(value, dict):
         return False
     if (
-        value.get("kind") not in {"image", "pdf", "doc", "code", "other"}
+        set(value) != {"kind", "name", "mimeType", "bytes", "ref"}
+        or value.get("kind") not in {"image", "pdf", "doc", "code", "other"}
         or not isinstance(value.get("name"), str)
         or not isinstance(value.get("mimeType"), str)
         or isinstance(value.get("bytes"), bool)
@@ -688,15 +690,24 @@ def _is_attachment_ref(value: Any) -> bool:
         return False
     if ref["kind"] == "session_file":
         return (
-            isinstance(ref.get("sessionId"), str)
+            set(ref) == {"kind", "sessionId", "relativePath"}
+            and isinstance(ref.get("sessionId"), str)
             and bool(ref["sessionId"])
             and isinstance(ref.get("relativePath"), str)
             and bool(ref["relativePath"])
         )
     if ref["kind"] == "workspace_file":
-        return isinstance(ref.get("relativePath"), str) and bool(ref["relativePath"])
+        return (
+            set(ref) == {"kind", "relativePath"}
+            and isinstance(ref.get("relativePath"), str)
+            and bool(ref["relativePath"])
+        )
     if ref["kind"] == "external_file":
-        return isinstance(ref.get("absolutePath"), str) and bool(ref["absolutePath"])
+        return (
+            set(ref) == {"kind", "absolutePath"}
+            and isinstance(ref.get("absolutePath"), str)
+            and bool(ref["absolutePath"])
+        )
     return False
 
 

--- a/packages/headless/harbor/maka_trajectory.py
+++ b/packages/headless/harbor/maka_trajectory.py
@@ -1,0 +1,1006 @@
+"""Build an ATIF trajectory from Maka's immutable RuntimeEvent JSONL."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+import re
+import shutil
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path, PurePosixPath
+from typing import Any, Optional
+
+
+_REDACTED = "[REDACTED]"
+_TERMINAL_STATUSES = {"completed", "failed", "aborted", "cancelled"}
+_IMAGE_MEDIA_TYPES = {"image/gif", "image/jpeg", "image/png", "image/webp"}
+_IMAGE_EXTENSIONS = {
+    "image/gif": ".gif",
+    "image/jpeg": ".jpg",
+    "image/png": ".png",
+    "image/webp": ".webp",
+}
+_SENSITIVE_KEY_PARTS = {
+    "api_key",
+    "access_key",
+    "access_token",
+    "authorization",
+    "client_secret",
+    "cookie",
+    "credential",
+    "credentials",
+    "password",
+    "passwd",
+    "private_key",
+    "refresh_token",
+    "secret",
+}
+_SENSITIVE_COMPACT_KEY_PARTS = {
+    "apikey",
+    "accesskey",
+    "accesstoken",
+    "authtoken",
+    "clientsecret",
+    "idtoken",
+    "privatekey",
+    "refreshtoken",
+    "sessiontoken",
+}
+_QUOTED_FIELD_PATTERN = re.compile(
+    r"(?P<key_quote>[\"'])(?P<key>[A-Za-z][A-Za-z0-9_-]*)(?P=key_quote)"
+    r"(?P<separator>\s*:\s*)"
+    r"(?P<value_quote>[\"'])(?P<value>(?:\\.|[^\\])*?)(?P=value_quote)"
+)
+_SECRET_PATTERNS = (
+    re.compile(
+        r"(?im)((?:set-cookie|cookie)\s*:\s*)"
+        r"(?:\"[^\"]*\"|'[^']*'|[^\r\n,;]+(?:[;,]\s*[^\r\n,;]+)*)"
+    ),
+    re.compile(
+        r"(?i)((?:authorization|x-api-key|api-key)\s*:\s*)"
+        r"(?:bearer\s+|basic\s+)?[^\s,;\"']+"
+    ),
+    re.compile(r"(?i)([a-z][a-z0-9+.-]*://[^/\s:@]+:)[^@\s/]+(?=@)"),
+    re.compile(
+        r"(?i)([?&](?:api[-_]?key|access[-_]?token|auth[-_]?token|token|password|secret)=)"
+        r"[^&#\s]+"
+    ),
+    re.compile(
+        r"(?i)((?:--?(?:api[-_]?key|auth[-_]?token|access[-_]?token|token|cookie|set-cookie|password|secret)"
+        r"|(?:api[-_]?key|auth[-_]?token|access[-_]?token|token|cookie|set-cookie|password|secret))"
+        r"(?:\s+|\s*[:=]\s*))(?:\"[^\"]*\"|'[^']*'|[^\s,;]+)"
+    ),
+    re.compile(r"(?i)(authorization\s*:\s*bearer\s+)[^\s,;]+"),
+    re.compile(r"(?i)\bbearer\s+[A-Za-z0-9._~+/=-]{8,}"),
+    re.compile(r"\bsk-[A-Za-z0-9_-]{8,}"),
+    re.compile(r"\b(?:ghp|gho|ghu|ghs|ghr)_[A-Za-z0-9]{20,}"),
+    re.compile(r"\bgithub_pat_[A-Za-z0-9_]{20,}"),
+    re.compile(r"\bAKIA[0-9A-Z]{16}\b"),
+    re.compile(r"\beyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\b"),
+    re.compile(
+        r"-----BEGIN [A-Z0-9 ]*PRIVATE KEY-----[\s\S]*?-----END [A-Z0-9 ]*PRIVATE KEY-----"
+    ),
+    re.compile(
+        r"(?i)([A-Z][A-Z0-9_]*(?:API_KEY|TOKEN|PASSWORD|SECRET|CREDENTIAL)"
+        r"[A-Z0-9_]*\s*=\s*)(?:\"[^\"]*\"|'[^']*'|[^\s,;]+)"
+    ),
+)
+
+
+@dataclass
+class TrajectoryEvidence:
+    steps: list[dict[str, Any]]
+    artifact_kind: str
+    reason: Optional[str]
+    terminal_status: Optional[str]
+    runtime_event_count: int
+
+
+@dataclass
+class _AgentStep:
+    timestamp: Optional[str]
+    key: Optional[tuple[str, str, str, str]]
+    message_parts: list[str] = field(default_factory=list)
+    reasoning_parts: list[str] = field(default_factory=list)
+    tool_calls: list[dict[str, Any]] = field(default_factory=list)
+    observation_results: list[dict[str, Any]] = field(default_factory=list)
+    runtime_event_ids: list[str] = field(default_factory=list)
+
+    def to_step(self, step_id: int) -> dict[str, Any]:
+        step: dict[str, Any] = {
+            "step_id": step_id,
+            "source": "agent",
+            "message": "\n".join(part for part in self.message_parts if part),
+            "llm_call_count": 1,
+        }
+        if self.timestamp is not None:
+            step["timestamp"] = self.timestamp
+        if self.reasoning_parts:
+            step["reasoning_content"] = "\n".join(
+                part for part in self.reasoning_parts if part
+            )
+        if self.tool_calls:
+            step["tool_calls"] = self.tool_calls
+        if self.observation_results:
+            step["observation"] = {"results": self.observation_results}
+        if self.runtime_event_ids:
+            step["extra"] = {"maka_runtime_event_ids": self.runtime_event_ids}
+        return redact_value(step)
+
+
+class _IncompleteTrajectoryEvidence(ValueError):
+    pass
+
+
+_RUNTIME_REF_KEYS = ("invocationId", "runId", "sessionId", "turnId")
+
+
+class _ImageArtifactResolver:
+    def __init__(self, artifact_store_root: Path, trajectory_root: Path):
+        self.artifact_root = artifact_store_root / "artifacts"
+        self.trajectory_root = trajectory_root
+        self._records: Optional[dict[str, dict[str, Any]]] = None
+
+    def resolve(
+        self, value: dict[str, Any], event: dict[str, Any]
+    ) -> list[dict[str, Any]]:
+        mime_type = value.get("mimeType")
+        ref = value.get("ref")
+        if mime_type not in _IMAGE_MEDIA_TYPES or not isinstance(ref, dict):
+            raise _IncompleteTrajectoryEvidence("image_reference_invalid")
+        artifact_id = ref.get("relativePath")
+        session_id = ref.get("sessionId")
+        if (
+            ref.get("kind") != "session_file"
+            or not isinstance(artifact_id, str)
+            or not artifact_id
+            or not isinstance(session_id, str)
+            or session_id != event.get("sessionId")
+        ):
+            raise _IncompleteTrajectoryEvidence("image_reference_invalid")
+
+        record = self._artifact_records().get(artifact_id)
+        if record is None:
+            raise _IncompleteTrajectoryEvidence("image_artifact_missing")
+        if (
+            record.get("sessionId") != session_id
+            or record.get("kind") != "image"
+            or record.get("status") != "live"
+            or record.get("mimeType") != mime_type
+        ):
+            raise _IncompleteTrajectoryEvidence("image_artifact_metadata_mismatch")
+        relative_path = record.get("relativePath")
+        if not isinstance(relative_path, str) or not _is_safe_artifact_path(relative_path):
+            raise _IncompleteTrajectoryEvidence("image_artifact_path_invalid")
+
+        try:
+            artifact_root = self.artifact_root.resolve(strict=True)
+            source = (artifact_root / relative_path).resolve(strict=True)
+            trajectory_root = self.trajectory_root.resolve(strict=True)
+            source.relative_to(artifact_root)
+        except (OSError, RuntimeError, ValueError):
+            raise _IncompleteTrajectoryEvidence("image_artifact_unavailable") from None
+        if not source.is_file() or _sniff_image_media_type(source) != mime_type:
+            raise _IncompleteTrajectoryEvidence("image_artifact_content_mismatch")
+        try:
+            assets_root = self.trajectory_root / "trajectory-assets"
+            assets_root.mkdir(parents=True, exist_ok=True)
+            assets_root = assets_root.resolve(strict=True)
+            assets_root.relative_to(trajectory_root)
+            digest = hashlib.sha256(artifact_id.encode("utf-8")).hexdigest()
+            filename = f"{digest}{_IMAGE_EXTENSIONS[mime_type]}"
+            target = assets_root / filename
+            shutil.copyfile(source, target)
+            if _sniff_image_media_type(target) != mime_type:
+                raise OSError
+            trajectory_path = target.relative_to(trajectory_root).as_posix()
+        except (OSError, RuntimeError, ValueError):
+            raise _IncompleteTrajectoryEvidence("image_artifact_materialization_failed") from None
+        return [
+            {
+                "type": "image",
+                "source": {"media_type": mime_type, "path": trajectory_path},
+            }
+        ]
+
+    def _artifact_records(self) -> dict[str, dict[str, Any]]:
+        if self._records is not None:
+            return self._records
+        metadata_path = self.artifact_root / "metadata.jsonl"
+        try:
+            raw = metadata_path.read_text(encoding="utf-8")
+        except (OSError, UnicodeError):
+            raise _IncompleteTrajectoryEvidence("image_artifact_metadata_missing") from None
+        records: dict[str, dict[str, Any]] = {}
+        try:
+            for line in raw.splitlines():
+                if not line.strip():
+                    continue
+                record = json.loads(line)
+                artifact_id = record.get("id") if isinstance(record, dict) else None
+                if not isinstance(artifact_id, str) or not artifact_id or artifact_id in records:
+                    raise ValueError
+                records[artifact_id] = record
+        except (json.JSONDecodeError, ValueError):
+            raise _IncompleteTrajectoryEvidence("image_artifact_metadata_invalid") from None
+        self._records = records
+        return records
+
+
+def load_runtime_trajectory(
+    runtime_events_path: Optional[Path],
+    fallback_status: Optional[str] = None,
+    expected_runtime_refs: Optional[dict[str, Any]] = None,
+    artifact_store_root: Optional[Path] = None,
+    trajectory_root: Optional[Path] = None,
+) -> TrajectoryEvidence:
+    if runtime_events_path is None or not runtime_events_path.is_file():
+        return summary_trajectory("runtime_events_missing", fallback_status)
+    try:
+        raw = runtime_events_path.read_text(encoding="utf-8")
+    except (OSError, UnicodeError):
+        return summary_trajectory("runtime_events_unreadable", fallback_status)
+
+    events: list[dict[str, Any]] = []
+    try:
+        for line in raw.splitlines():
+            if not line.strip():
+                continue
+            value = json.loads(line)
+            if not isinstance(value, dict):
+                return summary_trajectory("runtime_event_not_object", fallback_status)
+            events.append(value)
+    except (json.JSONDecodeError, RecursionError, UnicodeError):
+        return summary_trajectory("runtime_events_invalid_jsonl", fallback_status)
+    if not events:
+        return summary_trajectory("runtime_events_empty", fallback_status)
+    return build_runtime_trajectory(
+        events,
+        fallback_status,
+        expected_runtime_refs,
+        artifact_store_root,
+        trajectory_root,
+    )
+
+
+def build_runtime_trajectory(
+    events: list[dict[str, Any]],
+    fallback_status: Optional[str] = None,
+    expected_runtime_refs: Optional[dict[str, Any]] = None,
+    artifact_store_root: Optional[Path] = None,
+    trajectory_root: Optional[Path] = None,
+) -> TrajectoryEvidence:
+    if not _complete_runtime_refs(expected_runtime_refs):
+        return summary_trajectory("runtime_refs_incomplete", fallback_status, len(events))
+    ordered_steps: list[Any] = []
+    agent_steps_by_key: dict[tuple[str, str, str, str], _AgentStep] = {}
+    calls_by_id: dict[tuple[str, str, str, str], _AgentStep] = {}
+    response_ids: set[tuple[str, str, str, str]] = set()
+    active_legacy_agent_step: Optional[_AgentStep] = None
+    terminal_event: Optional[dict[str, Any]] = None
+    terminal_status: Optional[str] = None
+    saw_user = False
+    previous_identity: Optional[tuple[str, str, str, str]] = None
+    previous_was_terminal = False
+    expected_session_id = expected_runtime_refs["sessionId"]
+    image_resolver = (
+        _ImageArtifactResolver(artifact_store_root, trajectory_root)
+        if artifact_store_root is not None and trajectory_root is not None
+        else None
+    )
+
+    for event in events:
+        if not _is_runtime_event(event):
+            return summary_trajectory(
+                "runtime_event_schema_invalid", fallback_status, len(events)
+            )
+        identity = _runtime_identity(event)
+        if identity is None or identity[2] != expected_session_id:
+            return summary_trajectory(
+                "runtime_identity_mismatch", fallback_status, len(events)
+            )
+        if (
+            previous_identity is not None
+            and identity != previous_identity
+            and not previous_was_terminal
+        ):
+            return summary_trajectory(
+                "runtime_identity_mismatch", fallback_status, len(events)
+            )
+        previous_identity = identity
+        if event.get("partial") is True:
+            continue
+        status = _terminal_status(event)
+        previous_was_terminal = status is not None
+        terminal_step = None
+        if status is not None:
+            terminal_event = event
+            terminal_status = status
+            terminal_step = _terminal_step(event, status)
+            active_legacy_agent_step = None
+
+        content = event.get("content")
+        if not isinstance(content, dict):
+            if terminal_step is not None:
+                ordered_steps.append(terminal_step)
+            continue
+        kind = content.get("kind")
+        role = event.get("role")
+
+        if role == "user" and kind == "text":
+            text = content.get("text")
+            if not isinstance(text, str):
+                return summary_trajectory(
+                    "invalid_user_text", fallback_status, len(events)
+                )
+            extra: dict[str, Any] = {"maka_runtime_event_id": _event_id(event)}
+            if "displayText" in content:
+                extra["maka_display_text"] = redact_value(content["displayText"])
+            if "attachments" in content:
+                extra["maka_attachments"] = redact_value(content["attachments"])
+            if "quotes" in content:
+                extra["maka_quotes"] = redact_value(content["quotes"])
+            if content.get("steering") is True:
+                extra["maka_steering"] = True
+            step: dict[str, Any] = {
+                "source": "user",
+                "message": redact_text(text),
+                "extra": extra,
+            }
+            timestamp = _timestamp(event)
+            if timestamp is not None:
+                step["timestamp"] = timestamp
+            ordered_steps.append(step)
+            saw_user = True
+            active_legacy_agent_step = None
+            if terminal_step is not None:
+                ordered_steps.append(terminal_step)
+            continue
+
+        if role == "model" and kind in {"text", "thinking", "function_call"}:
+            key = _model_step_key(event, kind)
+            if key is not None:
+                agent_step = agent_steps_by_key.get(key)
+                if agent_step is None:
+                    agent_step = _AgentStep(timestamp=_timestamp(event), key=key)
+                    agent_steps_by_key[key] = agent_step
+                    ordered_steps.append(agent_step)
+            else:
+                agent_step = active_legacy_agent_step
+                if agent_step is None:
+                    agent_step = _AgentStep(timestamp=_timestamp(event), key=None)
+                    ordered_steps.append(agent_step)
+            active_legacy_agent_step = agent_step
+            agent_step.runtime_event_ids.append(_event_id(event))
+
+            if kind == "text":
+                text = content.get("text")
+                if not isinstance(text, str):
+                    return summary_trajectory(
+                        "invalid_model_text", fallback_status, len(events)
+                    )
+                agent_step.message_parts.append(redact_text(text))
+            elif kind == "thinking":
+                text = content.get("text")
+                if not isinstance(text, str):
+                    return summary_trajectory(
+                        "invalid_model_thinking", fallback_status, len(events)
+                    )
+                agent_step.reasoning_parts.append(redact_text(text))
+            else:
+                call_id = content.get("id")
+                name = content.get("name")
+                if (
+                    not isinstance(call_id, str)
+                    or not call_id
+                    or not isinstance(name, str)
+                    or not name
+                ):
+                    return summary_trajectory(
+                        "invalid_tool_call", fallback_status, len(events)
+                    )
+                correlation_id = _tool_correlation_id(event, call_id)
+                scoped_call_id = _scoped_id(event, correlation_id)
+                if scoped_call_id in calls_by_id:
+                    return summary_trajectory(
+                        "duplicate_tool_call_id", fallback_status, len(events)
+                    )
+                args = content.get("args")
+                arguments = redact_value(args)
+                if not isinstance(arguments, dict):
+                    arguments = {"value": arguments}
+                agent_step.tool_calls.append(
+                    {
+                        "tool_call_id": correlation_id,
+                        "function_name": name,
+                        "arguments": arguments,
+                        "extra": {
+                            "maka_runtime_event_id": _event_id(event),
+                            **(
+                                {"maka_provider_tool_call_id": call_id}
+                                if call_id != correlation_id
+                                else {}
+                            ),
+                        },
+                    }
+                )
+                calls_by_id[scoped_call_id] = agent_step
+            if terminal_step is not None:
+                ordered_steps.append(terminal_step)
+            continue
+
+        if role == "tool" and kind == "function_response":
+            call_id = content.get("id")
+            if not isinstance(call_id, str) or not call_id:
+                return summary_trajectory(
+                    "invalid_tool_response", fallback_status, len(events)
+                )
+            correlation_id = _tool_correlation_id(event, call_id)
+            scoped_call_id = _scoped_id(event, correlation_id)
+            agent_step = calls_by_id.get(scoped_call_id)
+            if agent_step is None:
+                return summary_trajectory(
+                    "unpaired_tool_response", fallback_status, len(events)
+                )
+            if scoped_call_id in response_ids:
+                return summary_trajectory(
+                    "duplicate_tool_response", fallback_status, len(events)
+                )
+            response_ids.add(scoped_call_id)
+            try:
+                observation_content = _observation_content(
+                    content.get("result"), event, image_resolver
+                )
+            except _IncompleteTrajectoryEvidence as exc:
+                return summary_trajectory(str(exc), fallback_status, len(events))
+            agent_step.observation_results.append(
+                {
+                    "source_call_id": correlation_id,
+                    "content": observation_content,
+                    "extra": {
+                        "is_error": content.get("isError") is True,
+                        "maka_runtime_event_id": _event_id(event),
+                        **(
+                            {"maka_provider_tool_response_id": call_id}
+                            if call_id != correlation_id
+                            else {}
+                        ),
+                        **(
+                            {"tool_name": content["name"]}
+                            if isinstance(content.get("name"), str) and content["name"]
+                            else {}
+                        ),
+                    },
+                }
+            )
+            agent_step.runtime_event_ids.append(_event_id(event))
+            active_legacy_agent_step = None
+            if terminal_step is not None:
+                ordered_steps.append(terminal_step)
+            continue
+
+        if role == "system" and kind == "text":
+            step = {
+                "source": "system",
+                "message": redact_text(content["text"]),
+                "extra": {"maka_runtime_event_id": _event_id(event)},
+            }
+            timestamp = _timestamp(event)
+            if timestamp is not None:
+                step["timestamp"] = timestamp
+            ordered_steps.append(step)
+            active_legacy_agent_step = None
+        elif role == "system" and kind == "error":
+            message = content.get("message")
+            if not isinstance(message, str):
+                return summary_trajectory(
+                    "invalid_runtime_error", fallback_status, len(events)
+                )
+            step = {
+                "source": "system",
+                "message": f"Runtime error: {redact_text(message)}",
+                "extra": {
+                    "maka_runtime_event_id": _event_id(event),
+                    **(
+                        {"error_code": content["code"]}
+                        if isinstance(content.get("code"), str)
+                        else {}
+                    ),
+                    **(
+                        {"error_reason": content["reason"]}
+                        if isinstance(content.get("reason"), str)
+                        else {}
+                    ),
+                },
+            }
+            timestamp = _timestamp(event)
+            if timestamp is not None:
+                step["timestamp"] = timestamp
+            ordered_steps.append(redact_value(step))
+            active_legacy_agent_step = None
+        elif content is not None:
+            return summary_trajectory(
+                "unsupported_runtime_event_lane", fallback_status, len(events)
+            )
+
+        if terminal_step is not None:
+            ordered_steps.append(terminal_step)
+
+    if terminal_event is None:
+        return summary_trajectory(
+            "terminal_event_missing", fallback_status, len(events)
+        )
+    if not saw_user:
+        return summary_trajectory("user_event_missing", fallback_status, len(events))
+    if set(calls_by_id) != response_ids:
+        return summary_trajectory("tool_response_missing", fallback_status, len(events))
+
+    assert terminal_status is not None
+    if fallback_status == "completed" and terminal_status != "completed":
+        return summary_trajectory(
+            "terminal_status_mismatch", fallback_status, len(events)
+        )
+    if not _terminal_matches_expected_refs(terminal_event, expected_runtime_refs):
+        return summary_trajectory(
+            "terminal_identity_mismatch", fallback_status, len(events)
+        )
+
+    steps: list[dict[str, Any]] = []
+    for index, item in enumerate(ordered_steps, start=1):
+        if isinstance(item, _AgentStep):
+            steps.append(item.to_step(index))
+        else:
+            item["step_id"] = index
+            steps.append(redact_value(item))
+    return TrajectoryEvidence(
+        steps=steps,
+        artifact_kind="full",
+        reason=None,
+        terminal_status=terminal_status,
+        runtime_event_count=len(events),
+    )
+
+
+def summary_trajectory(
+    reason: str,
+    fallback_status: Optional[str],
+    runtime_event_count: int = 0,
+) -> TrajectoryEvidence:
+    status = fallback_status if fallback_status in _TERMINAL_STATUSES else "finished"
+    return TrajectoryEvidence(
+        steps=[
+            {
+                "step_id": 1,
+                "source": "system",
+                "message": f"Maka trajectory summary: invocation {status}",
+                "extra": {
+                    "maka_artifact_kind": "summary",
+                    "maka_summary_reason": reason,
+                },
+            }
+        ],
+        artifact_kind="summary",
+        reason=reason,
+        terminal_status=fallback_status
+        if fallback_status in _TERMINAL_STATUSES
+        else None,
+        runtime_event_count=runtime_event_count,
+    )
+
+
+def redact_value(value: Any, depth: int = 0) -> Any:
+    if depth > 32:
+        return "[REDACTED:MAX_DEPTH]"
+    if isinstance(value, dict):
+        redacted: dict[str, Any] = {}
+        for key, nested in value.items():
+            string_key = str(key)
+            if _is_sensitive_key(string_key):
+                redacted[string_key] = _REDACTED
+            else:
+                redacted[string_key] = redact_value(nested, depth + 1)
+        return redacted
+    if isinstance(value, list):
+        return [redact_value(item, depth + 1) for item in value]
+    if isinstance(value, str):
+        return redact_text(value)
+    if value is None or isinstance(value, (bool, int, float)):
+        return value
+    return redact_text(str(value))
+
+
+def redact_text(value: str) -> str:
+    redacted = _QUOTED_FIELD_PATTERN.sub(_redact_quoted_secret_field, value)
+    for pattern in _SECRET_PATTERNS:
+        if pattern.groups:
+            redacted = pattern.sub(
+                lambda match: f"{match.group(1)}{_REDACTED}", redacted
+            )
+        else:
+            redacted = pattern.sub(_REDACTED, redacted)
+    return redacted
+
+
+def _redact_quoted_secret_field(match: re.Match[str]) -> str:
+    if not _is_sensitive_key(match.group("key")):
+        return match.group(0)
+    return (
+        f"{match.group('key_quote')}{match.group('key')}{match.group('key_quote')}"
+        f"{match.group('separator')}{match.group('value_quote')}"
+        f"{_REDACTED}{match.group('value_quote')}"
+    )
+
+
+def _is_sensitive_key(key: str) -> bool:
+    normalized = re.sub(r"([a-z0-9])([A-Z])", r"\1_\2", key).replace("-", "_").lower()
+    compact = normalized.replace("_", "")
+    return (
+        normalized == "token"
+        or normalized.endswith("_token")
+        or normalized in _SENSITIVE_KEY_PARTS
+        or any(normalized.endswith(f"_{part}") for part in _SENSITIVE_KEY_PARTS)
+        or any(compact.endswith(part) for part in _SENSITIVE_COMPACT_KEY_PARTS)
+    )
+
+
+def _model_step_key(
+    event: dict[str, Any], kind: Any
+) -> Optional[tuple[str, str, str, str]]:
+    refs = event.get("refs")
+    if not isinstance(refs, dict):
+        return None
+    candidate = (
+        refs.get("stepId") if kind == "function_call" else refs.get("providerEventId")
+    )
+    return _scoped_id(event, candidate) if isinstance(candidate, str) and candidate else None
+
+
+def _complete_runtime_refs(value: Any) -> bool:
+    return isinstance(value, dict) and all(
+        isinstance(value.get(key), str) and bool(value[key]) for key in _RUNTIME_REF_KEYS
+    )
+
+
+def _runtime_identity(event: dict[str, Any]) -> Optional[tuple[str, str, str, str]]:
+    if not all(
+        isinstance(event.get(key), str) and bool(event[key]) for key in _RUNTIME_REF_KEYS
+    ):
+        return None
+    return tuple(event[key] for key in _RUNTIME_REF_KEYS)  # type: ignore[return-value]
+
+
+def _is_attachment_ref(value: Any) -> bool:
+    if not isinstance(value, dict):
+        return False
+    if (
+        value.get("kind") not in {"image", "pdf", "doc", "code", "other"}
+        or not isinstance(value.get("name"), str)
+        or not isinstance(value.get("mimeType"), str)
+        or isinstance(value.get("bytes"), bool)
+        or not isinstance(value.get("bytes"), int)
+        or value.get("bytes") < 0
+    ):
+        return False
+    ref = value.get("ref")
+    if not isinstance(ref, dict) or not isinstance(ref.get("kind"), str):
+        return False
+    if ref["kind"] == "session_file":
+        return (
+            isinstance(ref.get("sessionId"), str)
+            and bool(ref["sessionId"])
+            and isinstance(ref.get("relativePath"), str)
+            and bool(ref["relativePath"])
+        )
+    if ref["kind"] == "workspace_file":
+        return isinstance(ref.get("relativePath"), str) and bool(ref["relativePath"])
+    if ref["kind"] == "external_file":
+        return isinstance(ref.get("absolutePath"), str) and bool(ref["absolutePath"])
+    return False
+
+
+def _is_quote_ref(value: Any) -> bool:
+    return (
+        isinstance(value, dict)
+        and set(value) <= {"text", "label", "sourceTurnId"}
+        and isinstance(value.get("text"), str)
+        and ("label" not in value or isinstance(value["label"], str))
+        and ("sourceTurnId" not in value or isinstance(value["sourceTurnId"], str))
+    )
+
+
+def _scoped_id(event: dict[str, Any], value: str) -> tuple[str, str, str, str]:
+    return (
+        str(event["invocationId"]),
+        str(event["runId"]),
+        str(event["turnId"]),
+        value,
+    )
+
+
+def _tool_correlation_id(event: dict[str, Any], fallback: str) -> str:
+    refs = event.get("refs")
+    if not isinstance(refs, dict):
+        return fallback
+    tool_call_id = refs.get("toolCallId")
+    return tool_call_id if isinstance(tool_call_id, str) and tool_call_id else fallback
+
+
+def _is_runtime_event(event: dict[str, Any]) -> bool:
+    allowed_keys = {
+        "id",
+        "invocationId",
+        "runId",
+        "sessionId",
+        "turnId",
+        "ts",
+        "branch",
+        "partial",
+        "role",
+        "author",
+        "status",
+        "content",
+        "actions",
+        "refs",
+    }
+    if set(event) - allowed_keys:
+        return False
+    if not all(
+        isinstance(event.get(key), str) and bool(event[key])
+        for key in ("id", "invocationId", "runId", "sessionId", "turnId")
+    ):
+        return False
+    timestamp = event.get("ts")
+    if (
+        isinstance(timestamp, bool)
+        or not isinstance(timestamp, (int, float))
+        or not math.isfinite(timestamp)
+    ):
+        return False
+    if not isinstance(event.get("partial"), bool):
+        return False
+    if event.get("role") not in {"user", "model", "tool", "system"}:
+        return False
+    if event.get("author") not in {"user", "agent", "tool", "system"}:
+        return False
+    if "branch" in event and not isinstance(event["branch"], str):
+        return False
+    if "status" in event and event["status"] not in _TERMINAL_STATUSES | {"streaming"}:
+        return False
+    if "actions" in event and not isinstance(event["actions"], dict):
+        return False
+    if "refs" in event and not isinstance(event["refs"], dict):
+        return False
+    return "content" not in event or _is_runtime_content(event["content"])
+
+
+def _is_runtime_content(content: Any) -> bool:
+    if not isinstance(content, dict):
+        return False
+    kind = content.get("kind")
+    if kind == "text":
+        return (
+            set(content) <= {"kind", "text", "displayText", "attachments", "quotes", "steering"}
+            and isinstance(content.get("text"), str)
+            and ("displayText" not in content or isinstance(content["displayText"], str))
+            and ("attachments" not in content or (
+                isinstance(content["attachments"], list)
+                and all(_is_attachment_ref(item) for item in content["attachments"])
+            ))
+            and ("quotes" not in content or (
+                isinstance(content["quotes"], list)
+                and all(_is_quote_ref(item) for item in content["quotes"])
+            ))
+            and ("steering" not in content or content["steering"] is True)
+        )
+    if kind == "thinking":
+        return (
+            set(content) <= {"kind", "text", "signature"}
+            and isinstance(content.get("text"), str)
+            and ("signature" not in content or isinstance(content["signature"], str))
+        )
+    if kind == "function_call":
+        return (
+            set(content) <= {"kind", "id", "name", "args"}
+            and isinstance(content.get("id"), str)
+            and isinstance(content.get("name"), str)
+            and "args" in content
+        )
+    if kind == "function_response":
+        return (
+            set(content) <= {"kind", "id", "name", "result", "isError"}
+            and isinstance(content.get("id"), str)
+            and isinstance(content.get("name"), str)
+            and "result" in content
+            and ("isError" not in content or isinstance(content["isError"], bool))
+        )
+    if kind == "error":
+        return (
+            set(content) <= {"kind", "code", "reason", "message", "details"}
+            and isinstance(content.get("message"), str)
+            and ("code" not in content or isinstance(content["code"], str))
+            and ("reason" not in content or isinstance(content["reason"], str))
+            and (
+                "details" not in content
+                or isinstance(content["details"], dict)
+                or (
+                    isinstance(content["details"], list)
+                    and all(isinstance(item, str) for item in content["details"])
+                )
+            )
+        )
+    return False
+
+
+def _terminal_status(event: dict[str, Any]) -> Optional[str]:
+    status = event.get("status")
+    if status in _TERMINAL_STATUSES:
+        return str(status)
+    actions = event.get("actions")
+    if isinstance(actions, dict) and actions.get("endInvocation") is True:
+        return "completed"
+    return None
+
+
+def _terminal_matches_expected_refs(
+    terminal_event: dict[str, Any],
+    expected_runtime_refs: Optional[dict[str, Any]],
+) -> bool:
+    if not _complete_runtime_refs(expected_runtime_refs):
+        return False
+    return _runtime_identity(terminal_event) == tuple(
+        expected_runtime_refs[key] for key in _RUNTIME_REF_KEYS
+    )
+
+
+def _terminal_step(event: dict[str, Any], status: str) -> dict[str, Any]:
+    step: dict[str, Any] = {
+        "source": "system",
+        "message": f"Maka invocation {status}",
+        "extra": {
+            "maka_runtime_event_id": _event_id(event),
+            "maka_terminal_status": status,
+        },
+    }
+    timestamp = _timestamp(event)
+    if timestamp is not None:
+        step["timestamp"] = timestamp
+    return step
+
+
+def _observation_content(
+    value: Any,
+    event: dict[str, Any],
+    image_resolver: Optional[_ImageArtifactResolver],
+) -> Any:
+    if isinstance(value, dict) and value.get("kind") == "image":
+        if image_resolver is None:
+            raise _IncompleteTrajectoryEvidence("image_artifact_store_missing")
+        return image_resolver.resolve(value, event)
+    redacted = redact_value(value)
+    if isinstance(redacted, str) or redacted is None:
+        return redacted
+    return json.dumps(
+        redacted, ensure_ascii=False, sort_keys=True, separators=(",", ":")
+    )
+
+
+def referenced_image_artifact_paths(
+    runtime_events_path: Path,
+    metadata_path: Path,
+) -> list[str]:
+    """Return validated artifact-root-relative paths needed by image RuntimeEvents."""
+    references: dict[str, tuple[str, str]] = {}
+    try:
+        for line in runtime_events_path.read_text(encoding="utf-8").splitlines():
+            if not line.strip():
+                continue
+            event = json.loads(line)
+            content = event.get("content") if isinstance(event, dict) else None
+            result = content.get("result") if isinstance(content, dict) else None
+            if not isinstance(result, dict) or result.get("kind") != "image":
+                continue
+            ref = result.get("ref")
+            if not isinstance(ref, dict) or ref.get("kind") != "session_file":
+                raise ValueError
+            artifact_id = ref.get("relativePath")
+            session_id = ref.get("sessionId")
+            mime_type = result.get("mimeType")
+            if (
+                not isinstance(artifact_id, str)
+                or not artifact_id
+                or not isinstance(session_id, str)
+                or mime_type not in _IMAGE_MEDIA_TYPES
+                or session_id != event.get("sessionId")
+            ):
+                raise ValueError
+            reference = (session_id, mime_type)
+            if artifact_id in references and references[artifact_id] != reference:
+                raise ValueError
+            references[artifact_id] = reference
+
+        records: dict[str, dict[str, Any]] = {}
+        for line in metadata_path.read_text(encoding="utf-8").splitlines():
+            if not line.strip():
+                continue
+            record = json.loads(line)
+            artifact_id = record.get("id") if isinstance(record, dict) else None
+            if not isinstance(artifact_id, str) or not artifact_id or artifact_id in records:
+                raise ValueError
+            records[artifact_id] = record
+    except (OSError, UnicodeError, json.JSONDecodeError, ValueError, AttributeError):
+        return []
+
+    paths: list[str] = []
+    for artifact_id, (session_id, mime_type) in references.items():
+        record = records.get(artifact_id)
+        relative_path = record.get("relativePath") if isinstance(record, dict) else None
+        if (
+            not isinstance(relative_path, str)
+            or not _is_safe_artifact_path(relative_path)
+            or record.get("sessionId") != session_id
+            or record.get("kind") != "image"
+            or record.get("status") != "live"
+            or record.get("mimeType") != mime_type
+        ):
+            return []
+        paths.append(relative_path)
+    return paths
+
+
+def _is_safe_artifact_path(value: str) -> bool:
+    if (
+        not value
+        or "\\" in value
+        or "\x00" in value
+        or "//" in value
+        or re.match(r"^[A-Za-z][A-Za-z0-9+.-]*:", value)
+    ):
+        return False
+    path = PurePosixPath(value)
+    return (
+        not path.is_absolute()
+        and all(part not in {"", ".", ".."} for part in value.split("/"))
+        and all(part not in {"", ".", ".."} for part in path.parts)
+    )
+
+
+def _sniff_image_media_type(path: Path) -> Optional[str]:
+    try:
+        with path.open("rb") as file:
+            header = file.read(16)
+    except OSError:
+        return None
+    if header.startswith(b"\x89PNG\r\n\x1a\n"):
+        return "image/png"
+    if header.startswith(b"\xff\xd8\xff"):
+        return "image/jpeg"
+    if header.startswith((b"GIF87a", b"GIF89a")):
+        return "image/gif"
+    if len(header) >= 12 and header.startswith(b"RIFF") and header[8:12] == b"WEBP":
+        return "image/webp"
+    return None
+
+
+def _event_id(event: dict[str, Any]) -> str:
+    value = event.get("id")
+    return value if isinstance(value, str) and value else "unknown"
+
+
+def _timestamp(event: dict[str, Any]) -> Optional[str]:
+    value = event.get("ts")
+    if (
+        isinstance(value, bool)
+        or not isinstance(value, (int, float))
+        or not math.isfinite(value)
+    ):
+        return None
+    try:
+        return (
+            datetime.fromtimestamp(value / 1000, timezone.utc)
+            .isoformat()
+            .replace("+00:00", "Z")
+        )
+    except (OverflowError, OSError, ValueError):
+        return None

--- a/packages/headless/harbor/maka_trajectory.py
+++ b/packages/headless/harbor/maka_trajectory.py
@@ -68,9 +68,12 @@ _SECRET_PATTERNS = (
         r"[^&#\s]+"
     ),
     re.compile(
-        r"(?i)((?:--?(?:api[-_]?key|auth[-_]?token|access[-_]?token|token|cookie|set-cookie|password|secret)"
-        r"|(?:api[-_]?key|auth[-_]?token|access[-_]?token|token|cookie|set-cookie|password|secret))"
+        r"(?i)(?<![A-Za-z0-9_])((?:--?(?:api[-_]?key|auth[-_]?token|access[-_]?token|token|cookie|set-cookie|password|secret))"
         r"(?:\s*[:=]\s*|\s+))(?:\"[^\"]*\"|'[^']*'|[^\s,;]+)"
+    ),
+    re.compile(
+        r"(?i)((?:api[-_]?key|auth[-_]?token|access[-_]?token|token|cookie|set-cookie|password|secret)"
+        r"\s*[:=]\s*)(?:\"[^\"]*\"|'[^']*'|[^\s,;]+)"
     ),
     re.compile(r"(?i)(authorization\s*:\s*bearer\s+)[^\s,;]+"),
     re.compile(r"(?i)\bbearer\s+[A-Za-z0-9._~+/=-]{8,}"),
@@ -419,6 +422,15 @@ def build_runtime_trajectory(
                         "arguments": arguments,
                         "extra": {
                             "maka_runtime_event_id": _event_id(event),
+                            **(
+                                {
+                                    "maka_provider_options": redact_value(
+                                        content["providerOptions"]
+                                    )
+                                }
+                                if "providerOptions" in content
+                                else {}
+                            ),
                             **(
                                 {"maka_provider_tool_call_id": call_id}
                                 if call_id != correlation_id
@@ -807,16 +819,24 @@ def _is_runtime_content(content: Any) -> bool:
         )
     if kind == "thinking":
         return (
-            set(content) <= {"kind", "text", "signature"}
+            set(content) <= {"kind", "text", "signature", "providerOptions"}
             and isinstance(content.get("text"), str)
             and ("signature" not in content or isinstance(content["signature"], str))
+            and (
+                "providerOptions" not in content
+                or isinstance(content["providerOptions"], dict)
+            )
         )
     if kind == "function_call":
         return (
-            set(content) <= {"kind", "id", "name", "args"}
+            set(content) <= {"kind", "id", "name", "args", "providerOptions"}
             and isinstance(content.get("id"), str)
             and isinstance(content.get("name"), str)
             and "args" in content
+            and (
+                "providerOptions" not in content
+                or isinstance(content["providerOptions"], dict)
+            )
         )
     if kind == "function_response":
         return (

--- a/packages/headless/harbor/maka_trajectory.py
+++ b/packages/headless/harbor/maka_trajectory.py
@@ -5,8 +5,10 @@ from __future__ import annotations
 import hashlib
 import json
 import math
+import os
 import re
 import shutil
+import tempfile
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path, PurePosixPath
@@ -60,7 +62,7 @@ _SECRET_PATTERNS = (
     ),
     re.compile(
         r"(?i)((?:authorization|x-api-key|api-key)\s*:\s*)"
-        r"(?:bearer\s+|basic\s+)?[^\s,;\"']+"
+        r"(?:\"[^\"]*\"|'[^']*'|(?:bearer\s+|basic\s+)?(?:\"[^\"]*\"|'[^']*'|[^\s,;\"']+))"
     ),
     re.compile(r"(?i)([a-z][a-z0-9+.-]*://[^/\s:@]+:)[^@\s/]+(?=@)"),
     re.compile(
@@ -68,12 +70,13 @@ _SECRET_PATTERNS = (
         r"[^&#\s]+"
     ),
     re.compile(
-        r"(?i)(?<![A-Za-z0-9_])((?:--?(?:api[-_]?key|auth[-_]?token|access[-_]?token|token|cookie|set-cookie|password|secret))"
+        r"(?i)(?<![A-Za-z0-9_])((?:--?(?:[a-z0-9]+[-_])*(?:api[-_]?key|access[-_]?key|auth[-_]?token|access[-_]?token|token|cookie|set[-_]?cookie|password|passwd|secret|credentials?|private[-_]?key|refresh[-_]?token|client[-_]?secret))"
         r"(?:\s*[:=]\s*|\s+))(?:\"[^\"]*\"|'[^']*'|[^\s,;]+)"
     ),
     re.compile(
-        r"(?i)((?:api[-_]?key|auth[-_]?token|access[-_]?token|token|cookie|set-cookie|password|secret)"
-        r"\s*[:=]\s*)(?:\"[^\"]*\"|'[^']*'|[^\s,;]+)"
+        r"(?im)(^[ \t]*(?:api[-_]?key|auth[-_]?token|access[-_]?token|token|cookie|set-cookie|password|secret)"
+        r"\s*:\s*|(?<![A-Za-z0-9_-])(?:api[-_]?key|auth[-_]?token|access[-_]?token|token|cookie|set-cookie|password|secret)"
+        r"\s*=\s*)(?:\"[^\"]*\"|'[^']*'|[^\s,;]+)"
     ),
     re.compile(r"(?i)(authorization\s*:\s*bearer\s+)[^\s,;]+"),
     re.compile(r"(?i)\bbearer\s+[A-Za-z0-9._~+/=-]{8,}"),
@@ -138,6 +141,32 @@ class _IncompleteTrajectoryEvidence(ValueError):
 
 
 _RUNTIME_REF_KEYS = ("invocationId", "runId", "sessionId", "turnId")
+_RUNTIME_ACTION_KEYS = {
+    "stateDelta",
+    "artifactDelta",
+    "permissionRequest",
+    "permissionDecision",
+    "userQuestionRequest",
+    "transferToAgent",
+    "endInvocation",
+    "tokenUsage",
+    "toolDispatch",
+    "runtimeProtocol",
+}
+_RUNTIME_EVENT_REF_KEYS = {
+    "storedMessageId",
+    "traceEventId",
+    "toolCallId",
+    "providerEventId",
+    "providerRequestTraceId",
+    "artifactId",
+    "operationId",
+    "stepId",
+    "sourceInvocationId",
+    "sourceRunId",
+    "sourceTurnId",
+    "sourceRuntimeEventHighWater",
+}
 
 
 class _ImageArtifactResolver:
@@ -195,9 +224,21 @@ class _ImageArtifactResolver:
             digest = hashlib.sha256(artifact_id.encode("utf-8")).hexdigest()
             filename = f"{digest}{_IMAGE_EXTENSIONS[mime_type]}"
             target = assets_root / filename
-            shutil.copyfile(source, target)
-            if _sniff_image_media_type(target) != mime_type:
-                raise OSError
+            temporary_fd, temporary_name = tempfile.mkstemp(
+                dir=assets_root, prefix=f".{filename}.", suffix=".tmp"
+            )
+            os.close(temporary_fd)
+            temporary_target = Path(temporary_name)
+            try:
+                shutil.copyfile(source, temporary_target)
+                if _sniff_image_media_type(temporary_target) != mime_type:
+                    raise OSError
+                os.replace(temporary_target, target)
+            finally:
+                try:
+                    temporary_target.unlink()
+                except FileNotFoundError:
+                    pass
             trajectory_path = target.relative_to(trajectory_root).as_posix()
         except (OSError, RuntimeError, ValueError):
             raise _IncompleteTrajectoryEvidence("image_artifact_materialization_failed") from None
@@ -791,9 +832,15 @@ def _is_runtime_event(event: dict[str, Any]) -> bool:
         return False
     if "status" in event and event["status"] not in _TERMINAL_STATUSES | {"streaming"}:
         return False
-    if "actions" in event and not isinstance(event["actions"], dict):
+    if "actions" in event and (
+        not isinstance(event["actions"], dict)
+        or set(event["actions"]) - _RUNTIME_ACTION_KEYS
+    ):
         return False
-    if "refs" in event and not isinstance(event["refs"], dict):
+    if "refs" in event and (
+        not isinstance(event["refs"], dict)
+        or set(event["refs"]) - _RUNTIME_EVENT_REF_KEYS
+    ):
         return False
     return "content" not in event or _is_runtime_content(event["content"])
 

--- a/packages/headless/src/__tests__/harbor-adapter.test.ts
+++ b/packages/headless/src/__tests__/harbor-adapter.test.ts
@@ -7,6 +7,7 @@ import { dirname, resolve } from 'node:path';
 import { describe, test, type TestContext } from 'node:test';
 import { fileURLToPath } from 'node:url';
 import { promisify } from 'node:util';
+import { decodeRuntimeEvent } from '@maka/core';
 import { HARBOR_CELL_CONTEXT_ENV_KEYS, resolveHarborCellAiSdkEnv } from '../harbor-cell.js';
 import { isBudgetExhaustedTrialException } from '../harbor-task-runner.js';
 
@@ -24,10 +25,38 @@ function validContextEnvValue(key: string): string {
 
 describe('Harbor adapter contract', () => {
   test('Maka trajectory builder preserves multi-step tool pairing and fails closed to a summary', (t: TestContext) => {
-    const result = spawnSync('python3', ['-c', pythonTrajectoryBuilderScript(repoRoot)], {
-      cwd: repoRoot,
-      encoding: 'utf8',
+    const providerOptionsEvent = decodeRuntimeEvent({
+      id: 'call-1-event',
+      invocationId: 'inv-1',
+      runId: 'run-1',
+      sessionId: 'session-1',
+      turnId: 'turn-1',
+      ts: 1200,
+      partial: false,
+      role: 'model',
+      author: 'agent',
+      content: {
+        kind: 'function_call',
+        id: 'call-1',
+        name: 'Bash',
+        args: { command: 'echo ok' },
+        providerOptions: {
+          google: {
+            thoughtSignature: 'provider-thought-signature',
+            apiKey: 'private-provider-api-key',
+          },
+        },
+      },
+      refs: { stepId: 'step-1', toolCallId: 'call-1' },
     });
+    const result = spawnSync(
+      'python3',
+      ['-c', pythonTrajectoryBuilderScript(repoRoot, JSON.stringify(providerOptionsEvent))],
+      {
+        cwd: repoRoot,
+        encoding: 'utf8',
+      },
+    );
     if (result.error && 'code' in result.error && result.error.code === 'ENOENT') {
       t.skip('python3 is not available');
       return;
@@ -39,6 +68,11 @@ describe('Harbor adapter contract', () => {
   test('maka_agent.py emits a Harbor-valid multi-step ATIF trajectory', (t: TestContext) => {
     const python = harborPython();
     if (!python) {
+      assert.notEqual(
+        process.env.MAKA_REQUIRE_HARBOR_CONTRACT,
+        '1',
+        'Harbor 0.13.2 is required for the CI trajectory contract',
+      );
       t.skip('Harbor 0.13.2 python is not available (CI has no harbor)');
       return;
     }
@@ -2723,7 +2757,7 @@ with tempfile.TemporaryDirectory() as tmp:
 `;
 }
 
-function pythonTrajectoryBuilderScript(root: string): string {
+function pythonTrajectoryBuilderScript(root: string, providerOptionsEventJson: string): string {
   return String.raw`
 import json
 import sys
@@ -2864,6 +2898,33 @@ for secret in ("private-token", "private-cookie", "private-set-cookie"):
 spaced = redact_text("token = private-spaced-token --token\t=\tprivate-tabbed-token")
 for secret in ("private-spaced-token", "private-tabbed-token"):
     assert secret not in spaced, spaced
+prose = "Optimize token budget before answering. The cookie policy is documented."
+assert redact_text(prose) == prose, redact_text(prose)
+flagged = redact_text("command --token private-flag-token")
+assert "private-flag-token" not in flagged, flagged
+
+provider_options_events = json.loads(json.dumps(events))
+provider_options_events[2] = json.loads(${JSON.stringify(providerOptionsEventJson)})
+provider_options = build_runtime_trajectory(
+    provider_options_events, "completed", runtime_refs
+)
+assert provider_options.artifact_kind == "full", provider_options
+provider_options_extra = provider_options.steps[1]["tool_calls"][0]["extra"]
+assert provider_options_extra["maka_provider_options"] == {
+    "google": {
+        "thoughtSignature": "provider-thought-signature",
+        "apiKey": "[REDACTED]",
+    }
+}, provider_options_extra
+
+thinking_provider_options_events = json.loads(json.dumps(events))
+thinking_provider_options_events[1]["content"]["providerOptions"] = {
+    "anthropic": {"signature": "provider-thinking-signature"}
+}
+thinking_provider_options = build_runtime_trajectory(
+    thinking_provider_options_events, "completed", runtime_refs
+)
+assert thinking_provider_options.artifact_kind == "full", thinking_provider_options
 
 identity_mismatch = build_runtime_trajectory(events, "completed", {
     "invocationId": "different-invocation",

--- a/packages/headless/src/__tests__/harbor-adapter.test.ts
+++ b/packages/headless/src/__tests__/harbor-adapter.test.ts
@@ -2502,6 +2502,31 @@ with tempfile.TemporaryDirectory() as tmp:
         assert "MAKA_MAX_STEPS" not in task_run_env, task_run_env.get("MAKA_MAX_STEPS")
         assert task_run_timeouts[-1] == 7200, task_run_timeouts
 
+        host_repo_root = Path(tmp) / "different-host-repo"
+        relative_task_run_agent = MakaAgent(Path(tmp), extra_env={
+            "MAKA_BACKEND": "fake",
+            "MAKA_HARBOR_MODE": "task-run",
+            "MAKA_HOST_REPO_ROOT": str(host_repo_root),
+            "MAKA_TASK_RUN_OUT_DIR": "relative-task-run",
+        })
+        relative_task_run_agent._resolve_task_workdir = resolve_task_workdir
+        relative_task_run_agent._communicate_streaming = communicate_task_run
+        asyncio.run(
+            relative_task_run_agent._run_task_run_host(
+                "finish the task",
+                host_process_environment,
+                AgentContext(),
+            )
+        )
+        relative_task_run_env = captured_host_process["kwargs"]["env"]
+        expected_task_run_out = host_repo_root / "relative-task-run"
+        expected_storage_root = expected_task_run_out / "runs"
+        assert relative_task_run_env["MAKA_TASK_RUN_OUT_DIR"] == str(expected_task_run_out), relative_task_run_env
+        assert relative_task_run_env["MAKA_OUTPUT_DIR"] == str(expected_task_run_out), relative_task_run_env
+        assert relative_task_run_env["MAKA_STORAGE_ROOT"] == str(expected_storage_root), relative_task_run_env
+        assert relative_task_run_agent._trajectory_artifact_store_root() == expected_storage_root
+        assert captured_host_process["kwargs"]["cwd"] == str(host_repo_root)
+
         runner_env_path = Path(tmp) / "task-run.env"
         runner_env_path.write_text("MAKA_CELL_TIMEOUT_SEC=4321\n", encoding="utf-8")
         original_runner_env = maka_agent_mod._DEFAULT_RUNNER_ENV
@@ -2836,6 +2861,9 @@ assert "'message': 'keep me'" in quoted, quoted
 raw = redact_text("token=private-token Cookie: session=private-cookie; Path=/ Set-Cookie: sid=private-set-cookie")
 for secret in ("private-token", "private-cookie", "private-set-cookie"):
     assert secret not in raw, raw
+spaced = redact_text("token = private-spaced-token --token\t=\tprivate-tabbed-token")
+for secret in ("private-spaced-token", "private-tabbed-token"):
+    assert secret not in spaced, spaced
 
 identity_mismatch = build_runtime_trajectory(events, "completed", {
     "invocationId": "different-invocation",
@@ -2877,6 +2905,20 @@ terminal_steps = [step for step in continued.steps if step["source"] == "system"
 assert [step["extra"]["maka_terminal_status"] for step in terminal_steps] == ["failed", "completed"], terminal_steps
 assert [step["extra"]["maka_runtime_event_id"] for step in terminal_steps] == ["terminal-first", "terminal-final"], terminal_steps
 
+partial_boundary = event("partial-boundary", 1800, "model", "agent")
+partial_boundary.update({"invocationId": "inv-2", "runId": "run-2", "turnId": "turn-2", "partial": True})
+third_user = event("user-third", 1900, "user", "user", {"kind": "text", "text": "Third invocation"})
+third_user.update({"invocationId": "inv-3", "runId": "run-3", "turnId": "turn-3"})
+third_terminal = event("terminal-third", 2000, "system", "system", status="completed", actions={"endInvocation": True})
+third_terminal.update({"invocationId": "inv-3", "runId": "run-3", "turnId": "turn-3"})
+stale_terminal_allowance = build_runtime_trajectory(
+    events[:1] + [continued_events[-4], partial_boundary, third_user, third_terminal],
+    "completed",
+    {"invocationId": "inv-3", "runId": "run-3", "sessionId": "session-1", "turnId": "turn-3"},
+)
+assert stale_terminal_allowance.artifact_kind == "summary", stale_terminal_allowance
+assert stale_terminal_allowance.reason == "runtime_identity_mismatch", stale_terminal_allowance
+
 missing_refs = build_runtime_trajectory(events, "completed")
 assert missing_refs.artifact_kind == "summary", missing_refs
 assert missing_refs.reason == "runtime_refs_incomplete", missing_refs
@@ -2891,6 +2933,18 @@ invalid_quotes_events[0]["content"]["quotes"] = [{"text": "quoted", "unexpected"
 invalid_quotes = build_runtime_trajectory(invalid_quotes_events, "completed", runtime_refs)
 assert invalid_quotes.artifact_kind == "summary", invalid_quotes
 assert invalid_quotes.reason == "runtime_event_schema_invalid", invalid_quotes
+
+invalid_attachment_events = json.loads(json.dumps(events))
+invalid_attachment_events[0]["content"]["attachments"][0]["unexpected"] = True
+invalid_attachment = build_runtime_trajectory(invalid_attachment_events, "completed", runtime_refs)
+assert invalid_attachment.artifact_kind == "summary", invalid_attachment
+assert invalid_attachment.reason == "runtime_event_schema_invalid", invalid_attachment
+
+invalid_attachment_ref_events = json.loads(json.dumps(events))
+invalid_attachment_ref_events[0]["content"]["attachments"][0]["ref"]["unexpected"] = True
+invalid_attachment_ref = build_runtime_trajectory(invalid_attachment_ref_events, "completed", runtime_refs)
+assert invalid_attachment_ref.artifact_kind == "summary", invalid_attachment_ref
+assert invalid_attachment_ref.reason == "runtime_event_schema_invalid", invalid_attachment_ref
 
 mixed_events = json.loads(json.dumps(events))
 mixed_events[2]["runId"] = "foreign-run"

--- a/packages/headless/src/__tests__/harbor-adapter.test.ts
+++ b/packages/headless/src/__tests__/harbor-adapter.test.ts
@@ -23,6 +23,33 @@ function validContextEnvValue(key: string): string {
 }
 
 describe('Harbor adapter contract', () => {
+  test('Maka trajectory builder preserves multi-step tool pairing and fails closed to a summary', (t: TestContext) => {
+    const result = spawnSync('python3', ['-c', pythonTrajectoryBuilderScript(repoRoot)], {
+      cwd: repoRoot,
+      encoding: 'utf8',
+    });
+    if (result.error && 'code' in result.error && result.error.code === 'ENOENT') {
+      t.skip('python3 is not available');
+      return;
+    }
+    assert.equal(result.status, 0, result.stderr);
+    assert.match(result.stdout, /trajectory-builder ok/);
+  });
+
+  test('maka_agent.py emits a Harbor-valid multi-step ATIF trajectory', (t: TestContext) => {
+    const python = harborPython();
+    if (!python) {
+      t.skip('Harbor 0.13.2 python is not available (CI has no harbor)');
+      return;
+    }
+    const result = spawnSync(python, ['-c', pythonTrajectoryHarborContractScript(repoRoot)], {
+      cwd: repoRoot,
+      encoding: 'utf8',
+    });
+    assert.equal(result.status, 0, result.stderr);
+    assert.match(result.stdout, /trajectory-harbor-contract ok/);
+  });
+
   test('run-cell.mjs delegates to the shared env entrypoint', async () => {
     const source = await readRepoFile('packages/headless/harbor/run-cell.mjs');
     const cellSource = await readRepoFile('packages/headless/src/harbor-cell.ts');
@@ -106,6 +133,7 @@ describe('Harbor adapter contract', () => {
       'packages/headless/harbor/maka-improved-prompt-v1.txt',
       'packages/headless/harbor/codex_agent.py',
       'packages/headless/harbor/maka_agent.py',
+      'packages/headless/harbor/maka_trajectory.py',
       'packages/headless/harbor/maka_verifier.py',
       'packages/headless/harbor/run-cell.mjs',
       'packages/headless/harbor/run-host-cell.mjs',
@@ -2127,7 +2155,7 @@ with tempfile.TemporaryDirectory() as tmp:
             "pricingSource": "runtime",
         },
         "steps": 1,
-        "runtimeRefs": {"sessionId": "session-1"},
+        "runtimeRefs": {"invocationId": "inv-1", "runId": "run-1", "sessionId": "session-1", "turnId": "turn-1"},
     })
     assert context.n_input_tokens == 10, context.n_input_tokens
     assert context.n_output_tokens == 2, context.n_output_tokens
@@ -2163,7 +2191,7 @@ with tempfile.TemporaryDirectory() as tmp:
             "pricingSource": "runtime",
         },
         "steps": 1,
-        "runtimeRefs": {"sessionId": "session-1"},
+        "runtimeRefs": {"invocationId": "inv-1", "runId": "run-1", "sessionId": "session-1", "turnId": "turn-1"},
     })
     expected_cost = (60 / 1_000_000 * 2) + (20 / 1_000_000 * 10) + (40 / 1_000_000 * 0.5)
     assert abs(priced_context.cost_usd - expected_cost) < 1e-12, priced_context.cost_usd
@@ -2190,7 +2218,7 @@ with tempfile.TemporaryDirectory() as tmp:
             "pricingSource": "runtime",
         },
         "steps": 1,
-        "runtimeRefs": {"sessionId": "session-1"},
+        "runtimeRefs": {"invocationId": "inv-1", "runId": "run-1", "sessionId": "session-1", "turnId": "turn-1"},
     })
     assert zero_priced_context.cost_usd == 0, zero_priced_context.cost_usd
     assert zero_priced_context.metadata["maka_pricing_source"] == "env", zero_priced_context.metadata
@@ -2215,7 +2243,7 @@ with tempfile.TemporaryDirectory() as tmp:
                 "pricingSource": "runtime",
             },
             "steps": 1,
-            "runtimeRefs": {"sessionId": "session-1"},
+            "runtimeRefs": {"invocationId": "inv-1", "runId": "run-1", "sessionId": "session-1", "turnId": "turn-1"},
         })
     except ValueError as exc:
         assert "MAKA_TRIAL_INPUT_USD_PER_1M" in str(exc), str(exc)
@@ -2667,6 +2695,506 @@ with tempfile.TemporaryDirectory() as tmp:
     assert host_process_env["MAKA_HOST_API_KEY_FILE"] == "/host/deepseek-key", host_process_env
     assert host_process_env["MAKA_HARBOR_TOOL_EXECUTOR_URL"] == "http://127.0.0.1:4321", host_process_env
     assert host_process_env["MAKA_HARBOR_TOOL_EXECUTOR_TOKEN"] == "tool-token", host_process_env
+`;
+}
+
+function pythonTrajectoryBuilderScript(root: string): string {
+  return String.raw`
+import json
+import sys
+import tempfile
+from pathlib import Path
+
+root = Path(${JSON.stringify(root)})
+sys.path.insert(0, str(root / "packages" / "headless" / "harbor"))
+
+from maka_trajectory import build_runtime_trajectory, load_runtime_trajectory, redact_text
+
+
+def event(event_id, ts, role, author, content=None, refs=None, status=None, actions=None):
+    value = {
+        "id": event_id,
+        "invocationId": "inv-1",
+        "runId": "run-1",
+        "sessionId": "session-1",
+        "turnId": "turn-1",
+        "ts": ts,
+        "partial": False,
+        "role": role,
+        "author": author,
+    }
+    if content is not None:
+        value["content"] = content
+    if refs is not None:
+        value["refs"] = refs
+    if status is not None:
+        value["status"] = status
+    if actions is not None:
+        value["actions"] = actions
+    return value
+
+
+events = [
+    event("user-1", 1000, "user", "user", {"kind": "text", "text": "Fix the repository", "displayText": "/fix", "attachments": [{"kind": "code", "name": "README.md", "mimeType": "text/markdown", "bytes": 12, "ref": {"kind": "workspace_file", "relativePath": "README.md"}}], "quotes": [{"text": "quoted context"}], "steering": True}),
+    event(
+        "thinking-1",
+        1100,
+        "model",
+        "agent",
+        {"kind": "thinking", "text": "Inspect with Bearer private-bearer-token and AUTH_TOKEN=private-auth-token; JSON {\"Authorization\":\"Basic private-json-basic-token\",\"api_key\":\"private-json-api-key\"}"},
+        {"providerEventId": "step-1"},
+    ),
+    event(
+        "call-1-event",
+        1200,
+        "model",
+        "agent",
+        {
+            "kind": "function_call",
+            "id": "call-1",
+            "name": "Bash",
+            "args": {
+                "command": "curl -H 'Authorization: Basic private-basic-token' -H 'X-API-Key: private-x-api-key' 'https://private-user:private-url-password@example.test?access_token=private-query-token' --api-key private-cli-api-key && psql postgres://private-db-user:private-db-password@example.test/db",
+                "apiKey": "sk-private-api-key",
+                "apikey": "private-compact-api-key",
+                "sessionToken": "private-session-token",
+            },
+        },
+        {"stepId": "step-1", "toolCallId": "call-1"},
+    ),
+    event(
+        "usage-1",
+        1250,
+        "system",
+        "system",
+        actions={"tokenUsage": {"input": 20, "output": 5, "cacheHitInput": 4, "costUsd": 0.01, "runtimeSteps": 1}},
+    ),
+    event(
+        "response-1",
+        1300,
+        "tool",
+        "tool",
+        {"kind": "function_response", "id": "call-1", "name": "Bash", "result": {"stdout": "ok", "accessToken": "private-access-token", "accesstoken": "private-compact-access-token", "idToken": "private-id-token"}},
+        {"toolCallId": "call-1"},
+    ),
+    event(
+        "call-2-event",
+        1400,
+        "model",
+        "agent",
+        {"kind": "function_call", "id": "call-2", "name": "Read", "args": {"path": "README.md"}},
+        {"stepId": "step-2", "toolCallId": "call-2"},
+    ),
+    event(
+        "response-2",
+        1500,
+        "tool",
+        "tool",
+        {"kind": "function_response", "id": "call-2", "name": "Read", "result": "contents", "isError": False},
+        {"toolCallId": "call-2"},
+    ),
+    event(
+        "text-3",
+        1600,
+        "model",
+        "agent",
+        {"kind": "text", "text": "Finished"},
+        {"providerEventId": "step-3"},
+    ),
+    event("terminal", 1700, "system", "system", status="completed", actions={"endInvocation": True}),
+]
+
+runtime_refs = {"invocationId": "inv-1", "runId": "run-1", "sessionId": "session-1", "turnId": "turn-1"}
+trajectory = build_runtime_trajectory(events, "completed", runtime_refs)
+assert trajectory.artifact_kind == "full", trajectory
+assert trajectory.terminal_status == "completed", trajectory
+assert len(trajectory.steps) == 5, trajectory.steps
+assert [step["source"] for step in trajectory.steps] == ["user", "agent", "agent", "agent", "system"]
+first_action = trajectory.steps[1]
+assert first_action["tool_calls"][0]["tool_call_id"] == "call-1", first_action
+assert first_action["observation"]["results"][0]["source_call_id"] == "call-1", first_action
+assert "metrics" not in first_action, first_action
+second_action = trajectory.steps[2]
+assert second_action["tool_calls"][0]["tool_call_id"] == "call-2", second_action
+assert second_action["observation"]["results"][0]["source_call_id"] == "call-2", second_action
+user_step = trajectory.steps[0]
+assert user_step["extra"]["maka_display_text"] == "/fix", user_step
+assert user_step["extra"]["maka_steering"] is True, user_step
+assert user_step["extra"]["maka_attachments"][0]["ref"]["relativePath"] == "README.md", user_step
+assert user_step["extra"]["maka_quotes"][0]["text"] == "quoted context", user_step
+serialized = json.dumps(trajectory.steps)
+for secret in ("private-bearer-token", "private-basic-token", "private-x-api-key", "private-url-password", "private-query-token", "private-db-password", "private-cli-api-key", "sk-private-api-key", "private-compact-api-key", "private-access-token", "private-compact-access-token", "private-auth-token", "private-session-token", "private-id-token", "private-json-basic-token", "private-json-api-key"):
+    assert secret not in serialized, serialized
+assert "[REDACTED]" in serialized, serialized
+
+quoted = redact_text("prefix {'sessionToken': 'private-quoted-token', 'apikey': 'private-quoted-api-key', 'message': 'keep me'} suffix")
+assert "private-quoted-token" not in quoted, quoted
+assert "private-quoted-api-key" not in quoted, quoted
+assert "'sessionToken': '[REDACTED]'" in quoted, quoted
+assert "'apikey': '[REDACTED]'" in quoted, quoted
+assert "'message': 'keep me'" in quoted, quoted
+raw = redact_text("token=private-token Cookie: session=private-cookie; Path=/ Set-Cookie: sid=private-set-cookie")
+for secret in ("private-token", "private-cookie", "private-set-cookie"):
+    assert secret not in raw, raw
+
+identity_mismatch = build_runtime_trajectory(events, "completed", {
+    "invocationId": "different-invocation",
+    "runId": "run-1",
+    "sessionId": "session-1",
+    "turnId": "turn-1",
+})
+assert identity_mismatch.artifact_kind == "summary", identity_mismatch
+assert identity_mismatch.reason == "terminal_identity_mismatch", identity_mismatch
+
+aborted_events = events[:-1] + [
+    event("terminal-aborted", 1700, "system", "system", status="aborted", actions={"endInvocation": True}),
+]
+aborted = build_runtime_trajectory(aborted_events, "failed", runtime_refs)
+assert aborted.artifact_kind == "full", aborted
+assert aborted.terminal_status == "aborted", aborted
+
+failed_before_completed_terminal = build_runtime_trajectory(events, "failed", runtime_refs)
+assert failed_before_completed_terminal.artifact_kind == "full", failed_before_completed_terminal
+assert failed_before_completed_terminal.terminal_status == "completed", failed_before_completed_terminal
+
+malformed = build_runtime_trajectory([events[0], {}, events[-1]], "completed", runtime_refs)
+assert malformed.artifact_kind == "summary", malformed
+assert malformed.reason == "runtime_event_schema_invalid", malformed
+
+null_content = dict(events[3], content=None)
+malformed_null = build_runtime_trajectory([events[0], null_content, events[-1]], "completed", runtime_refs)
+assert malformed_null.artifact_kind == "summary", malformed_null
+assert malformed_null.reason == "runtime_event_schema_invalid", malformed_null
+
+continued_events = events[:-1] + [
+    event("terminal-first", 1700, "system", "system", status="failed", actions={"endInvocation": True}),
+    event("user-2", 1800, "user", "user", {"kind": "text", "text": "Continue"}),
+    event("text-4", 1900, "model", "agent", {"kind": "text", "text": "Recovered"}, {"providerEventId": "step-4"}),
+    event("terminal-final", 2000, "system", "system", status="completed", actions={"endInvocation": True}),
+]
+continued = build_runtime_trajectory(continued_events, "completed", runtime_refs)
+terminal_steps = [step for step in continued.steps if step["source"] == "system" and "maka_terminal_status" in step.get("extra", {})]
+assert [step["extra"]["maka_terminal_status"] for step in terminal_steps] == ["failed", "completed"], terminal_steps
+assert [step["extra"]["maka_runtime_event_id"] for step in terminal_steps] == ["terminal-first", "terminal-final"], terminal_steps
+
+missing_refs = build_runtime_trajectory(events, "completed")
+assert missing_refs.artifact_kind == "summary", missing_refs
+assert missing_refs.reason == "runtime_refs_incomplete", missing_refs
+
+malformed_refs = dict(runtime_refs, sessionId=123)
+malformed_refs_result = build_runtime_trajectory(events, "completed", malformed_refs)
+assert malformed_refs_result.artifact_kind == "summary", malformed_refs_result
+assert malformed_refs_result.reason == "runtime_refs_incomplete", malformed_refs_result
+
+invalid_quotes_events = json.loads(json.dumps(events))
+invalid_quotes_events[0]["content"]["quotes"] = [{"text": "quoted", "unexpected": True}]
+invalid_quotes = build_runtime_trajectory(invalid_quotes_events, "completed", runtime_refs)
+assert invalid_quotes.artifact_kind == "summary", invalid_quotes
+assert invalid_quotes.reason == "runtime_event_schema_invalid", invalid_quotes
+
+mixed_events = json.loads(json.dumps(events))
+mixed_events[2]["runId"] = "foreign-run"
+mixed = build_runtime_trajectory(mixed_events, "completed", runtime_refs)
+assert mixed.artifact_kind == "summary", mixed
+assert mixed.reason == "runtime_identity_mismatch", mixed
+
+def continued_event(event_id, ts, role, author, content=None, refs=None, status=None, actions=None):
+    value = event(event_id, ts, role, author, content, refs, status, actions)
+    value.update({"invocationId": "inv-2", "runId": "run-2", "turnId": "turn-2"})
+    return value
+
+reused_ids = events[:-1] + [
+    event("terminal-first", 1700, "system", "system", status="failed", actions={"endInvocation": True}),
+    continued_event("call-reused", 1800, "model", "agent", {"kind": "function_call", "id": "call-1", "name": "Bash", "args": {}}, {"stepId": "step-1"}),
+    continued_event("response-reused", 1900, "tool", "tool", {"kind": "function_response", "id": "call-1", "name": "Bash", "result": "ok"}),
+    continued_event("terminal-final", 2000, "system", "system", status="completed", actions={"endInvocation": True}),
+]
+reused = build_runtime_trajectory(reused_ids, "completed", {
+    "invocationId": "inv-2",
+    "runId": "run-2",
+    "sessionId": "session-1",
+    "turnId": "turn-2",
+})
+assert reused.artifact_kind == "full", reused
+assert len([step for step in reused.steps if step.get("tool_calls")]) == 3, reused.steps
+
+correlated_ids = json.loads(json.dumps(events))
+correlated_ids[2]["content"]["id"] = "provider-call-payload-id"
+correlated_ids[2]["refs"]["toolCallId"] = "shared-runtime-correlation"
+correlated_ids[4]["content"]["id"] = "provider-response-payload-id"
+correlated_ids[4]["refs"]["toolCallId"] = "shared-runtime-correlation"
+correlated = build_runtime_trajectory(correlated_ids, "completed", runtime_refs)
+assert correlated.artifact_kind == "full", correlated
+assert correlated.steps[1]["tool_calls"][0]["tool_call_id"] == "shared-runtime-correlation", correlated.steps
+assert correlated.steps[1]["tool_calls"][0]["extra"]["maka_provider_tool_call_id"] == "provider-call-payload-id", correlated.steps
+assert correlated.steps[1]["observation"]["results"][0]["source_call_id"] == "shared-runtime-correlation", correlated.steps
+assert correlated.steps[1]["observation"]["results"][0]["extra"]["maka_provider_tool_response_id"] == "provider-response-payload-id", correlated.steps
+
+unpaired = build_runtime_trajectory([events[0], events[5], events[-1]], "completed", runtime_refs)
+assert unpaired.artifact_kind == "summary", unpaired
+assert unpaired.reason == "tool_response_missing", unpaired
+assert len(unpaired.steps) == 1 and unpaired.steps[0]["extra"]["maka_artifact_kind"] == "summary"
+
+with tempfile.TemporaryDirectory() as tmp:
+    invalid_path = Path(tmp) / "runtime-events.jsonl"
+    invalid_path.write_text('{"id":\n', encoding="utf-8")
+    invalid = load_runtime_trajectory(invalid_path, "failed")
+    assert invalid.artifact_kind == "summary", invalid
+    assert invalid.reason == "runtime_events_invalid_jsonl", invalid
+
+    invalid_path.write_bytes(b'\xff')
+    invalid_utf8 = load_runtime_trajectory(invalid_path, "failed")
+    assert invalid_utf8.artifact_kind == "summary", invalid_utf8
+    assert invalid_utf8.reason == "runtime_events_unreadable", invalid_utf8
+
+print("trajectory-builder ok")
+`;
+}
+
+function pythonTrajectoryHarborContractScript(root: string): string {
+  return String.raw`
+import asyncio
+import json
+import sys
+import tempfile
+from pathlib import Path
+
+root = Path(${JSON.stringify(root)})
+sys.path.insert(0, str(root / "packages" / "headless" / "harbor"))
+
+from harbor.models.agent.context import AgentContext
+from harbor.models.trajectories import Trajectory
+from maka_agent import MakaAgent
+
+
+def event(event_id, ts, role, author, content=None, refs=None, status=None, actions=None):
+    value = {
+        "id": event_id,
+        "invocationId": "inv-1",
+        "runId": "run-1",
+        "sessionId": "session-1",
+        "turnId": "turn-1",
+        "ts": ts,
+        "partial": False,
+        "role": role,
+        "author": author,
+    }
+    if content is not None:
+        value["content"] = content
+    if refs is not None:
+        value["refs"] = refs
+    if status is not None:
+        value["status"] = status
+    if actions is not None:
+        value["actions"] = actions
+    return value
+
+
+events = [
+    event("user", 1000, "user", "user", {"kind": "text", "text": "Solve the task"}),
+    event("call", 1100, "model", "agent", {"kind": "function_call", "id": "tool-1", "name": "Bash", "args": {"command": "echo ok", "password": "private-password"}}, {"stepId": "step-1"}),
+    event("result", 1200, "tool", "tool", {"kind": "function_response", "id": "tool-1", "name": "Bash", "result": {"stdout": "ok"}}, {"toolCallId": "tool-1"}),
+    event("answer", 1300, "model", "agent", {"kind": "text", "text": "Done"}, {"providerEventId": "step-2"}),
+    event("terminal", 1400, "system", "system", status="completed", actions={"endInvocation": True}),
+]
+
+with tempfile.TemporaryDirectory() as tmp:
+    logs_dir = Path(tmp)
+    runtime_path = logs_dir / "runtime-events.jsonl"
+    runtime_path.write_text("\n".join(json.dumps(event) for event in events) + "\n", encoding="utf-8")
+    agent = MakaAgent(logs_dir)
+    context = AgentContext()
+    agent._apply_cell_output(context, {
+        "status": "completed",
+        "runtimeEventsPath": "/logs/agent/runtime-events.jsonl",
+        "promptHash": "sha256:test",
+        "tokenSummary": {"input": 10, "output": 2, "cachedInput": 3, "costUsd": 0.01},
+        "toolSummary": {"actualToolCalls": 1, "actualToolNames": ["Bash"], "actualToolCallCounts": {"Bash": 1}},
+        "steps": len(events),
+        "runtimeRefs": {"invocationId": "inv-1", "runId": "run-1", "sessionId": "session-1", "turnId": "turn-1"},
+    })
+    payload = json.loads((logs_dir / "trajectory.json").read_text(encoding="utf-8"))
+    validated = Trajectory.model_validate(payload)
+    assert validated.extra["maka_artifact_kind"] == "full", validated.extra
+    assert len(validated.steps) == 4, validated.steps
+    assert validated.steps[1].tool_calls[0].tool_call_id == "tool-1", validated.steps[1]
+    assert validated.steps[1].observation.results[0].source_call_id == "tool-1", validated.steps[1]
+    assert validated.final_metrics.total_steps == len(validated.steps), validated.final_metrics
+    assert validated.final_metrics.total_cached_tokens == 3, validated.final_metrics
+    assert "private-password" not in json.dumps(payload), payload
+
+    image_events = [
+        event("image-user", 2000, "user", "user", {"kind": "text", "text": "Inspect the image"}),
+        event("image-call", 2100, "model", "agent", {"kind": "function_call", "id": "image-tool", "name": "Read", "args": {"path": "shot.png"}}, {"stepId": "image-step"}),
+        event("image-result", 2200, "tool", "tool", {"kind": "function_response", "id": "image-tool", "name": "Read", "result": {"kind": "image", "mimeType": "image/png", "ref": {"kind": "session_file", "sessionId": "session-1", "relativePath": "artifact-image"}}}),
+        event("image-answer", 2300, "model", "agent", {"kind": "text", "text": "Image inspected"}, {"providerEventId": "image-answer-step"}),
+        event("image-terminal", 2400, "system", "system", status="completed", actions={"endInvocation": True}),
+    ]
+    runtime_path.write_text("\n".join(json.dumps(event) for event in image_events) + "\n", encoding="utf-8")
+    artifact_root = logs_dir / "maka-storage" / "artifacts"
+    image_path = artifact_root / "session-1" / "artifact-image-shot.png"
+    image_path.parent.mkdir(parents=True)
+    image_path.write_bytes(b"\x89PNG\r\n\x1a\nfixture")
+    metadata_path = artifact_root / "metadata.jsonl"
+    metadata_path.write_text(json.dumps({
+        "id": "artifact-image",
+        "sessionId": "session-1",
+        "turnId": "turn-1",
+        "createdAt": 2200,
+        "name": "shot.png",
+        "kind": "image",
+        "relativePath": "session-1/artifact-image-shot.png",
+        "sizeBytes": image_path.stat().st_size,
+        "mimeType": "image/png",
+        "source": "tool_result",
+        "status": "live",
+    }) + "\n", encoding="utf-8")
+    agent._apply_cell_output(context, {
+        "status": "completed",
+        "runtimeEventsPath": "/logs/agent/runtime-events.jsonl",
+        "runtimeRefs": {"invocationId": "inv-1", "runId": "run-1", "sessionId": "session-1", "turnId": "turn-1"},
+    })
+    image_payload = json.loads((logs_dir / "trajectory.json").read_text(encoding="utf-8"))
+    image_validated = Trajectory.model_validate(image_payload)
+    image_content = image_validated.steps[1].observation.results[0].content
+    assert image_validated.extra["maka_artifact_kind"] == "full", image_validated.extra
+    assert image_content[0].type == "image", image_content
+    assert image_content[0].source.media_type == "image/png", image_content
+    assert image_content[0].source.path.startswith("trajectory-assets/"), image_content
+    assert image_content[0].source.path.endswith(".png"), image_content
+    assert (logs_dir / image_content[0].source.path).is_file(), image_content
+
+    image_path.unlink()
+    agent._apply_cell_output(context, {
+        "status": "completed",
+        "runtimeEventsPath": "/logs/agent/runtime-events.jsonl",
+        "runtimeRefs": {"invocationId": "inv-1", "runId": "run-1", "sessionId": "session-1", "turnId": "turn-1"},
+    })
+    missing_image_payload = json.loads((logs_dir / "trajectory.json").read_text(encoding="utf-8"))
+    assert missing_image_payload["extra"]["maka_artifact_kind"] == "summary", missing_image_payload
+    assert missing_image_payload["extra"]["maka_summary_reason"] == "image_artifact_unavailable", missing_image_payload
+
+    escaping_metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
+    escaping_metadata["relativePath"] = "../outside.png"
+    metadata_path.write_text(json.dumps(escaping_metadata) + "\n", encoding="utf-8")
+    agent._apply_cell_output(context, {
+        "status": "completed",
+        "runtimeEventsPath": "/logs/agent/runtime-events.jsonl",
+        "runtimeRefs": {"invocationId": "inv-1", "runId": "run-1", "sessionId": "session-1", "turnId": "turn-1"},
+    })
+    escaping_payload = json.loads((logs_dir / "trajectory.json").read_text(encoding="utf-8"))
+    assert escaping_payload["extra"]["maka_artifact_kind"] == "summary", escaping_payload
+    assert escaping_payload["extra"]["maka_summary_reason"] == "image_artifact_path_invalid", escaping_payload
+
+    wrong_session_events = json.loads(json.dumps(image_events))
+    wrong_session_events[2]["content"]["result"]["ref"]["sessionId"] = "other-session"
+    runtime_path.write_text("\n".join(json.dumps(event) for event in wrong_session_events) + "\n", encoding="utf-8")
+    agent._apply_cell_output(context, {
+        "status": "completed",
+        "runtimeEventsPath": "/logs/agent/runtime-events.jsonl",
+        "runtimeRefs": {"invocationId": "inv-1", "runId": "run-1", "sessionId": "session-1", "turnId": "turn-1"},
+    })
+    wrong_session_payload = json.loads((logs_dir / "trajectory.json").read_text(encoding="utf-8"))
+    assert wrong_session_payload["extra"]["maka_artifact_kind"] == "summary", wrong_session_payload
+    assert wrong_session_payload["extra"]["maka_summary_reason"] == "image_reference_invalid", wrong_session_payload
+
+    runtime_path.unlink()
+    unexpected_path = logs_dir / "unexpected-events.jsonl"
+    unexpected_path.write_text("\n".join(json.dumps(event) for event in events) + "\n", encoding="utf-8")
+    agent._apply_cell_output(context, {
+        "status": "completed",
+        "runtimeEventsPath": str(unexpected_path),
+        "runtimeRefs": {"invocationId": "inv-1", "runId": "run-1", "sessionId": "session-1", "turnId": "turn-1"},
+    })
+    summary_payload = json.loads((logs_dir / "trajectory.json").read_text(encoding="utf-8"))
+    assert summary_payload["extra"]["maka_artifact_kind"] == "summary", summary_payload
+    assert summary_payload["extra"]["maka_summary_reason"] == "runtime_events_missing", summary_payload
+
+    download_logs = logs_dir / "downloaded"
+    download_logs.mkdir()
+    download_agent = MakaAgent(download_logs)
+
+    class DownloadEnvironment:
+        async def download_file(self, remote, local):
+            assert remote == "/logs/agent/runtime-events.jsonl", remote
+            Path(local).write_text("\n".join(json.dumps(event) for event in events) + "\n", encoding="utf-8")
+
+    asyncio.run(download_agent._download_runtime_events(DownloadEnvironment(), {
+        "runtimeEventsPath": "/logs/agent/runtime-events.jsonl",
+    }))
+    assert (download_logs / "runtime-events.jsonl").is_file()
+
+    downloaded_image_events = events[:2] + [
+        event("downloaded-image", 1200, "tool", "tool", {"kind": "function_response", "id": "tool-1", "name": "Bash", "result": {"kind": "image", "mimeType": "image/png", "ref": {"kind": "session_file", "sessionId": "session-1", "relativePath": "downloaded-image"}}}),
+        events[3],
+        events[4],
+    ]
+    (download_logs / "runtime-events.jsonl").write_text(
+        "\n".join(json.dumps(event) for event in downloaded_image_events) + "\n",
+        encoding="utf-8",
+    )
+    downloaded_relative_path = "session-1/downloaded-image-shot.png"
+    downloaded_metadata = json.dumps({
+        "id": "downloaded-image",
+        "sessionId": "session-1",
+        "turnId": "turn-1",
+        "createdAt": 1200,
+        "name": "shot.png",
+        "kind": "image",
+        "relativePath": downloaded_relative_path,
+        "sizeBytes": 15,
+        "mimeType": "image/png",
+        "source": "tool_result",
+        "status": "live",
+    }) + "\n"
+
+    class ArtifactDownloadEnvironment:
+        async def download_file(self, remote, local):
+            if remote == "/logs/agent/maka-storage/artifacts/metadata.jsonl":
+                Path(local).write_text(downloaded_metadata, encoding="utf-8")
+                return
+            assert remote == f"/logs/agent/maka-storage/artifacts/{downloaded_relative_path}", remote
+            Path(local).write_bytes(b"\x89PNG\r\n\x1a\nfixture")
+
+    asyncio.run(download_agent._download_runtime_artifacts(ArtifactDownloadEnvironment()))
+    assert (download_logs / "maka-storage" / "artifacts" / downloaded_relative_path).is_file()
+
+    task_run_logs = logs_dir / "task-run"
+    task_run_logs.mkdir()
+    task_run_agent = MakaAgent(task_run_logs, extra_env={"MAKA_HARBOR_MODE": "task-run"})
+    task_run_runtime_path = task_run_logs / "runtime-events.jsonl"
+    task_run_runtime_path.write_text(
+        "\n".join(json.dumps(event) for event in image_events) + "\n", encoding="utf-8"
+    )
+    task_run_artifact_root = task_run_logs / "maka-task-run" / "runs" / "artifacts"
+    task_run_image_path = task_run_artifact_root / "session-1" / "task-run-shot.png"
+    task_run_image_path.parent.mkdir(parents=True)
+    task_run_image_path.write_bytes(b"\x89PNG\r\n\x1a\nfixture")
+    (task_run_artifact_root / "metadata.jsonl").parent.mkdir(parents=True, exist_ok=True)
+    (task_run_artifact_root / "metadata.jsonl").write_text(json.dumps({
+        "id": "artifact-image",
+        "sessionId": "session-1",
+        "turnId": "turn-1",
+        "createdAt": 2200,
+        "name": "task-run-shot.png",
+        "kind": "image",
+        "relativePath": "session-1/task-run-shot.png",
+        "sizeBytes": task_run_image_path.stat().st_size,
+        "mimeType": "image/png",
+        "source": "tool_result",
+        "status": "live",
+    }) + "\n", encoding="utf-8")
+    task_run_agent._apply_cell_output(AgentContext(), {
+        "status": "completed",
+        "runtimeEventsPath": "/logs/agent/runtime-events.jsonl",
+        "runtimeRefs": {"invocationId": "inv-1", "runId": "run-1", "sessionId": "session-1", "turnId": "turn-1"},
+    })
+    task_run_payload = json.loads((task_run_logs / "trajectory.json").read_text(encoding="utf-8"))
+    assert task_run_payload["extra"]["maka_artifact_kind"] == "full", task_run_payload
+    task_run_content = task_run_payload["steps"][1]["observation"]["results"][0]["content"]
+    assert task_run_content[0]["source"]["media_type"] == "image/png", task_run_content
+
+print("trajectory-harbor-contract ok")
 `;
 }
 

--- a/packages/headless/src/__tests__/harbor-adapter.test.ts
+++ b/packages/headless/src/__tests__/harbor-adapter.test.ts
@@ -49,9 +49,38 @@ describe('Harbor adapter contract', () => {
       },
       refs: { stepId: 'step-1', toolCallId: 'call-1' },
     });
+    const schemaCorpus = [
+      { name: 'valid-function-call', event: providerOptionsEvent },
+      {
+        name: 'unknown-refs-key',
+        event: {
+          ...providerOptionsEvent,
+          refs: { ...providerOptionsEvent.refs, unexpected: 'drift' },
+        },
+      },
+      {
+        name: 'unknown-actions-key',
+        event: { ...providerOptionsEvent, actions: { unexpected: true } },
+      },
+    ].map((entry) => {
+      let accepted = true;
+      try {
+        decodeRuntimeEvent(entry.event);
+      } catch {
+        accepted = false;
+      }
+      return { ...entry, accepted };
+    });
     const result = spawnSync(
       'python3',
-      ['-c', pythonTrajectoryBuilderScript(repoRoot, JSON.stringify(providerOptionsEvent))],
+      [
+        '-c',
+        pythonTrajectoryBuilderScript(
+          repoRoot,
+          JSON.stringify(providerOptionsEvent),
+          JSON.stringify(schemaCorpus),
+        ),
+      ],
       {
         cwd: repoRoot,
         encoding: 'utf8',
@@ -2757,7 +2786,11 @@ with tempfile.TemporaryDirectory() as tmp:
 `;
 }
 
-function pythonTrajectoryBuilderScript(root: string, providerOptionsEventJson: string): string {
+function pythonTrajectoryBuilderScript(
+  root: string,
+  providerOptionsEventJson: string,
+  schemaCorpusJson: string,
+): string {
   return String.raw`
 import json
 import sys
@@ -2895,13 +2928,23 @@ assert "'message': 'keep me'" in quoted, quoted
 raw = redact_text("token=private-token Cookie: session=private-cookie; Path=/ Set-Cookie: sid=private-set-cookie")
 for secret in ("private-token", "private-cookie", "private-set-cookie"):
     assert secret not in raw, raw
+quoted_authorization = redact_text("Authorization: \"Basic private-basic-token\"; Authorization: 'Bearer private-bearer-token'")
+for secret in ("private-basic-token", "private-bearer-token"):
+    assert secret not in quoted_authorization, quoted_authorization
 spaced = redact_text("token = private-spaced-token --token\t=\tprivate-tabbed-token")
 for secret in ("private-spaced-token", "private-tabbed-token"):
     assert secret not in spaced, spaced
 prose = "Optimize token budget before answering. The cookie policy is documented."
 assert redact_text(prose) == prose, redact_text(prose)
+colon_prose = "A secret: the answer is 42."
+assert redact_text(colon_prose) == colon_prose, redact_text(colon_prose)
+header = redact_text("token: private-header-token\nnext line")
+assert "private-header-token" not in header, header
 flagged = redact_text("command --token private-flag-token")
 assert "private-flag-token" not in flagged, flagged
+namespaced_flags = redact_text("command --client-secret private-client-secret --github-token private-github-token --openai-api-key private-openai-key")
+for secret in ("private-client-secret", "private-github-token", "private-openai-key"):
+    assert secret not in namespaced_flags, namespaced_flags
 
 provider_options_events = json.loads(json.dumps(events))
 provider_options_events[2] = json.loads(${JSON.stringify(providerOptionsEventJson)})
@@ -2916,6 +2959,16 @@ assert provider_options_extra["maka_provider_options"] == {
         "apiKey": "[REDACTED]",
     }
 }, provider_options_extra
+
+schema_corpus = json.loads(${JSON.stringify(schemaCorpusJson)})
+for case in schema_corpus:
+    corpus_events = json.loads(json.dumps(events))
+    corpus_events[2] = case["event"]
+    corpus_result = build_runtime_trajectory(corpus_events, "completed", runtime_refs)
+    expected_kind = "full" if case["accepted"] else "summary"
+    assert corpus_result.artifact_kind == expected_kind, (case, corpus_result)
+    if not case["accepted"]:
+        assert corpus_result.reason == "runtime_event_schema_invalid", (case, corpus_result)
 
 thinking_provider_options_events = json.loads(json.dumps(events))
 thinking_provider_options_events[1]["content"]["providerOptions"] = {
@@ -3179,6 +3232,19 @@ with tempfile.TemporaryDirectory() as tmp:
     assert image_content[0].source.path.endswith(".png"), image_content
     assert (logs_dir / image_content[0].source.path).is_file(), image_content
 
+    materialized_path = logs_dir / image_content[0].source.path
+    protected_path = logs_dir / "protected-image-target"
+    materialized_path.unlink()
+    protected_path.write_bytes(b"protected")
+    materialized_path.symlink_to(protected_path)
+    agent._apply_cell_output(context, {
+        "status": "completed",
+        "runtimeEventsPath": "/logs/agent/runtime-events.jsonl",
+        "runtimeRefs": {"invocationId": "inv-1", "runId": "run-1", "sessionId": "session-1", "turnId": "turn-1"},
+    })
+    assert not materialized_path.is_symlink(), materialized_path
+    assert protected_path.read_bytes() == b"protected", protected_path
+
     image_path.unlink()
     agent._apply_cell_output(context, {
         "status": "completed",
@@ -3231,12 +3297,15 @@ with tempfile.TemporaryDirectory() as tmp:
 
     class DownloadEnvironment:
         async def download_file(self, remote, local):
+            if remote == "/logs/agent/maka-cell-output.json":
+                Path(local).write_text(json.dumps({
+                    "runtimeEventsPath": "/logs/agent/runtime-events.jsonl",
+                }), encoding="utf-8")
+                return
             assert remote == "/logs/agent/runtime-events.jsonl", remote
             Path(local).write_text("\n".join(json.dumps(event) for event in events) + "\n", encoding="utf-8")
 
-    asyncio.run(download_agent._download_runtime_events(DownloadEnvironment(), {
-        "runtimeEventsPath": "/logs/agent/runtime-events.jsonl",
-    }))
+    asyncio.run(download_agent._download_cell_output(DownloadEnvironment()))
     assert (download_logs / "runtime-events.jsonl").is_file()
 
     downloaded_image_events = events[:2] + [

--- a/packages/headless/src/ahe-target-protocol.ts
+++ b/packages/headless/src/ahe-target-protocol.ts
@@ -408,6 +408,7 @@ export const MAKA_AHE_CURRENT_COMPONENTS: readonly MakaAheTargetComponent[] = [
       { path: 'packages/headless/README.md' },
       { path: 'packages/headless/harbor/run-terminal-bench-smoke.mjs' },
       { path: 'packages/headless/harbor/maka_agent.py' },
+      { path: 'packages/headless/harbor/maka_trajectory.py' },
     ],
   },
 ];


### PR DESCRIPTION
Fixes #1285

## Summary

- Reconstruct Harbor ATIF v1.7 trajectories from immutable Maka RuntimeEvents instead of emitting two synthetic steps.
- Preserve ordered user, model, tool, and terminal evidence while pairing tool calls and results by the canonical `refs.toolCallId` correlation key.
- Recursively redact credential-bearing structured values and raw text before serialization.
- Fail closed to an explicitly labeled summary artifact when runtime evidence is missing, malformed, incomplete, or identity-mismatched.
- Materialize validated image tool results into hashed trajectory-local assets without exposing artifact filenames or internal paths.
- Resolve runtime artifacts from the active normal or task-run storage root and include the trajectory builder in the AHE target fingerprint.

## Review follow-up

- Covers `token=`, `Cookie:`, `Set-Cookie:`, authorization headers, URL credentials, CLI secrets, environment assignments, and structured secret keys.
- Requires complete invocation/run/session/turn references and validates every event identity.
- Preserves display text, attachments, quotes, and steering with strict shape validation.
- Keeps malformed or incomplete evidence as a machine-readable summary artifact.
- Supports provider payload IDs that differ while sharing one runtime tool-call correlation reference.

## Validation

- `python3 -m py_compile packages/headless/harbor/maka_agent.py packages/headless/harbor/maka_trajectory.py`
- `npm run format:check`
- `npm run lint`
- `npm run build:test`
- `npm run typecheck`
- Harbor adapter contract: 38 tests, 37 passed, 1 environment-dependent skip, 0 failed
- `git diff --check`

Benchmark scoring and controller telemetry remain unchanged. A trajectory is labeled `full` only when the complete terminal RuntimeEvent chain and all referenced artifacts validate.
