### PR TITLE
feat(runtime): add Swarm Mode orchestration contract

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -13,6 +13,7 @@
     "./events": "./dist/events.js",
     "./session": "./dist/session.js",
     "./collaboration": "./dist/collaboration.js",
+    "./orchestration": "./dist/orchestration.js",
     "./plan": "./dist/plan.js",
     "./agent-run": "./dist/agent-run.js",
     "./shell-run": "./dist/shell-run.js",

--- a/packages/core/src/__tests__/orchestration.test.ts
+++ b/packages/core/src/__tests__/orchestration.test.ts
@@ -1,0 +1,52 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+
+import {
+  isOrchestrationMode,
+  isTurnOrchestrationSource,
+  resolveEffectiveOrchestration,
+} from '../orchestration.js';
+
+describe('orchestration contract', () => {
+  test('legacy sessions resolve to the compatible default mode', () => {
+    assert.deepEqual(resolveEffectiveOrchestration(undefined, undefined), {
+      mode: 'default',
+      source: 'session',
+      agentSwarmAuthorization: 'none',
+    });
+  });
+
+  test('a persisted swarm mode grants only the session-scoped swarm authorization', () => {
+    assert.deepEqual(resolveEffectiveOrchestration('swarm', undefined), {
+      mode: 'swarm',
+      source: 'session',
+      agentSwarmAuthorization: 'session_mode',
+    });
+  });
+
+  test('a trusted turn override wins without changing the persisted session mode', () => {
+    assert.deepEqual(
+      resolveEffectiveOrchestration('default', { mode: 'swarm', source: 'host_api' }),
+      {
+        mode: 'swarm',
+        source: 'turn_override',
+        agentSwarmAuthorization: 'turn_override',
+      },
+    );
+    assert.deepEqual(
+      resolveEffectiveOrchestration('swarm', { mode: 'default', source: 'slash_command' }),
+      {
+        mode: 'default',
+        source: 'turn_override',
+        agentSwarmAuthorization: 'none',
+      },
+    );
+  });
+
+  test('validators accept only the public contract values', () => {
+    assert.equal(isOrchestrationMode('swarm'), true);
+    assert.equal(isOrchestrationMode('parallel'), false);
+    assert.equal(isTurnOrchestrationSource('slash_command'), true);
+    assert.equal(isTurnOrchestrationSource('model_text'), false);
+  });
+});

--- a/packages/core/src/agent-run.ts
+++ b/packages/core/src/agent-run.ts
@@ -1,5 +1,13 @@
 import { isPermissionMode, type PermissionMode } from './permission.js';
 import { isCollaborationMode, type CollaborationMode } from './collaboration.js';
+import {
+  isAgentSwarmAuthorizationSource,
+  isEffectiveOrchestrationSource,
+  isOrchestrationMode,
+  type AgentSwarmAuthorizationSource,
+  type EffectiveOrchestrationSource,
+  type OrchestrationMode,
+} from './orchestration.js';
 import type { BackendKind } from './session.js';
 import {
   defineObjectShape,
@@ -48,6 +56,12 @@ export interface AgentRunHeader {
   permissionMode: PermissionMode;
   /** Snapshot of the session collaboration mode. Optional on legacy runs. */
   collaborationMode?: CollaborationMode;
+  /** Effective orchestration mode for this run. Optional on legacy runs. */
+  orchestrationMode?: OrchestrationMode;
+  /** Whether the effective mode came from the session or this turn. */
+  orchestrationSource?: EffectiveOrchestrationSource;
+  /** Narrow authority for the parent agent_swarm envelope. */
+  agentSwarmAuthorization?: AgentSwarmAuthorizationSource;
   createdAt: number;
   updatedAt: number;
   completedAt?: number;
@@ -171,6 +185,9 @@ const AGENT_RUN_HEADER_SHAPE = defineObjectShape<AgentRunHeader>()(
     'abortSource',
     'traceWriteError',
     'collaborationMode',
+    'orchestrationMode',
+    'orchestrationSource',
+    'agentSwarmAuthorization',
   ],
 );
 
@@ -194,6 +211,11 @@ export function decodeAgentRunHeader(value: unknown): AgentRunHeader {
     typeof value.cwd === 'string' &&
     isPermissionMode(value.permissionMode) &&
     (value.collaborationMode === undefined || isCollaborationMode(value.collaborationMode)) &&
+    (value.orchestrationMode === undefined || isOrchestrationMode(value.orchestrationMode)) &&
+    (value.orchestrationSource === undefined ||
+      isEffectiveOrchestrationSource(value.orchestrationSource)) &&
+    (value.agentSwarmAuthorization === undefined ||
+      isAgentSwarmAuthorizationSource(value.agentSwarmAuthorization)) &&
     isFiniteNumber(value.createdAt) &&
     isFiniteNumber(value.updatedAt) &&
     isOptionalString(value.invocationId) &&

--- a/packages/core/src/backend-types.ts
+++ b/packages/core/src/backend-types.ts
@@ -14,6 +14,7 @@ import type { StoredMessage, BackendKind } from './session.js';
 import type { PermissionResponse } from './permission.js';
 import type { UserQuestionResponse } from './user-question.js';
 import type { ContextBudgetDiagnostic } from './usage-stats/types.js';
+import type { EffectiveOrchestration } from './orchestration.js';
 
 export interface RuntimeContinuationMetadata {
   sourceInvocationId: string;
@@ -29,6 +30,8 @@ export interface BackendSendInput {
   runId?: string;
   /** Caller-generated turn id shared by the persisted UserMessage and every emitted event. */
   turnId: string;
+  /** Trusted effective orchestration snapshot for this run. */
+  orchestration?: EffectiveOrchestration;
   /**
    * The persisted initial user RuntimeEvent for this turn (the head anchor).
    * Mid-turn capacity compaction keeps this event verbatim in every projection

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -9,6 +9,7 @@
 
 export * from './mcp.js';
 export * from './collaboration.js';
+export * from './orchestration.js';
 export * from './plan.js';
 
 // events.ts
@@ -510,6 +511,7 @@ export type {
   ChildAgentTurnInput,
   CreateSessionInput,
   RegenerateTurnInput,
+  TurnOrchestration,
   UserMessageInput,
   SessionListFilter,
 } from './runtime-inputs.js';

--- a/packages/core/src/orchestration.ts
+++ b/packages/core/src/orchestration.ts
@@ -1,0 +1,74 @@
+export const ORCHESTRATION_MODES = ['default', 'swarm'] as const;
+
+export type OrchestrationMode = (typeof ORCHESTRATION_MODES)[number];
+
+export const TURN_ORCHESTRATION_SOURCES = ['slash_command', 'host_api'] as const;
+
+export type TurnOrchestrationSource = (typeof TURN_ORCHESTRATION_SOURCES)[number];
+
+export interface TurnOrchestration {
+  mode: OrchestrationMode;
+  source: TurnOrchestrationSource;
+}
+
+export const EFFECTIVE_ORCHESTRATION_SOURCES = ['session', 'turn_override'] as const;
+
+export type EffectiveOrchestrationSource = (typeof EFFECTIVE_ORCHESTRATION_SOURCES)[number];
+
+export const AGENT_SWARM_AUTHORIZATION_SOURCES = ['none', 'session_mode', 'turn_override'] as const;
+
+export type AgentSwarmAuthorizationSource = (typeof AGENT_SWARM_AUTHORIZATION_SOURCES)[number];
+
+/** Trusted runtime snapshot carried by one AgentRun and every backend send. */
+export interface EffectiveOrchestration {
+  mode: OrchestrationMode;
+  source: EffectiveOrchestrationSource;
+  agentSwarmAuthorization: AgentSwarmAuthorizationSource;
+}
+
+export function isOrchestrationMode(value: unknown): value is OrchestrationMode {
+  return typeof value === 'string' && (ORCHESTRATION_MODES as readonly string[]).includes(value);
+}
+
+export function isTurnOrchestrationSource(value: unknown): value is TurnOrchestrationSource {
+  return (
+    typeof value === 'string' && (TURN_ORCHESTRATION_SOURCES as readonly string[]).includes(value)
+  );
+}
+
+export function isEffectiveOrchestrationSource(
+  value: unknown,
+): value is EffectiveOrchestrationSource {
+  return (
+    typeof value === 'string' &&
+    (EFFECTIVE_ORCHESTRATION_SOURCES as readonly string[]).includes(value)
+  );
+}
+
+export function isAgentSwarmAuthorizationSource(
+  value: unknown,
+): value is AgentSwarmAuthorizationSource {
+  return (
+    typeof value === 'string' &&
+    (AGENT_SWARM_AUTHORIZATION_SOURCES as readonly string[]).includes(value)
+  );
+}
+
+export function resolveEffectiveOrchestration(
+  sessionMode: OrchestrationMode | undefined,
+  override: TurnOrchestration | undefined,
+): EffectiveOrchestration {
+  if (override) {
+    return {
+      mode: override.mode,
+      source: 'turn_override',
+      agentSwarmAuthorization: override.mode === 'swarm' ? 'turn_override' : 'none',
+    };
+  }
+  const mode = sessionMode ?? 'default';
+  return {
+    mode,
+    source: 'session',
+    agentSwarmAuthorization: mode === 'swarm' ? 'session_mode' : 'none',
+  };
+}

--- a/packages/core/src/runtime-inputs.ts
+++ b/packages/core/src/runtime-inputs.ts
@@ -7,6 +7,9 @@ import type { BackendKind, SessionBlockedReason, SessionStatus } from './session
 import type { PermissionMode } from './permission.js';
 import type { ThinkingLevel } from './model-thinking.js';
 import type { CollaborationMode } from './collaboration.js';
+import type { OrchestrationMode, TurnOrchestration } from './orchestration.js';
+
+export type { TurnOrchestration } from './orchestration.js';
 
 export interface CreateSessionInput {
   /** Absolute path to the session's working dir (project root). */
@@ -22,6 +25,8 @@ export interface CreateSessionInput {
   permissionMode: PermissionMode;
   /** Defaults to `agent`. */
   collaborationMode?: CollaborationMode;
+  /** Defaults to `default`. Orthogonal to Agent/Plan collaboration mode. */
+  orchestrationMode?: OrchestrationMode;
   status?: SessionStatus;
   blockedReason?: SessionBlockedReason;
   parentSessionId?: string;
@@ -46,6 +51,8 @@ export interface UserMessageInput {
    * this over `text`. Omit when the two are identical.
    */
   displayText?: string;
+  /** Trusted host-supplied orchestration override for this turn only. */
+  turnOrchestration?: TurnOrchestration;
   attachments?: AttachmentRef[];
   parentRunId?: string;
   agentId?: string;

--- a/packages/core/src/session.ts
+++ b/packages/core/src/session.ts
@@ -14,6 +14,7 @@ import {
 } from './events.js';
 import type { PermissionMode } from './permission.js';
 import type { CollaborationMode } from './collaboration.js';
+import type { OrchestrationMode } from './orchestration.js';
 import type {
   CacheMissInputSource,
   ContextBudgetDiagnostic,
@@ -122,6 +123,8 @@ export interface SessionHeader {
   permissionMode: PermissionMode;
   /** Defaults to `agent` when absent on legacy session records. */
   collaborationMode?: CollaborationMode;
+  /** Defaults to `default` when absent on legacy session records. */
+  orchestrationMode?: OrchestrationMode;
 
   /** Forward-compatible schema versioning. V0.1 only writes 1. */
   schemaVersion: 1;
@@ -162,6 +165,8 @@ export interface SessionSummary {
   permissionMode: PermissionMode;
   /** Defaults to `agent` when absent on legacy summaries. */
   collaborationMode?: CollaborationMode;
+  /** Defaults to `default` when absent on legacy summaries. */
+  orchestrationMode?: OrchestrationMode;
 }
 
 export type SessionChangedReason =

--- a/packages/runtime/src/__tests__/deferred-tools-backend.test.ts
+++ b/packages/runtime/src/__tests__/deferred-tools-backend.test.ts
@@ -322,6 +322,44 @@ describe('AiSdkBackend deferred tool loading', () => {
 });
 
 describe('AiSdkBackend deferred agent tools', () => {
+  test('Swarm Mode injects the shared prompt and pins agent_swarm at step 0', async () => {
+    const capturedTools: string[][] = [];
+    const capturedPrompts: string[] = [];
+    const model = new MockLanguageModelV4({
+      doStream: async ({ tools: stepTools, prompt }) => {
+        capturedTools.push((stepTools ?? []).map((tool) => tool.name));
+        capturedPrompts.push(JSON.stringify(prompt));
+        return {
+          stream: convertArrayToReadableStream<LanguageModelV4StreamPart>([
+            { type: 'stream-start', warnings: [] },
+            {
+              type: 'finish',
+              finishReason: { unified: 'stop', raw: 'stop' },
+              usage: ZERO_USAGE,
+            },
+          ]),
+        };
+      },
+    });
+
+    await drain(
+      agentBackend(model, []).send({
+        turnId: 'turn-swarm-mode',
+        text: 'fan out',
+        context: [],
+        orchestration: {
+          mode: 'swarm',
+          source: 'turn_override',
+          agentSwarmAuthorization: 'turn_override',
+        },
+      }),
+    );
+
+    assert.ok(capturedTools[0]?.includes(AGENT_SWARM_TOOL_NAME));
+    assert.match(capturedPrompts[0] ?? '', /Orchestration Mode: Swarm/);
+    assert.match(capturedPrompts[0] ?? '', /only tool in its assistant step/);
+  });
+
   test('agent tools are hidden by default and visible after load_tools(agent)', async () => {
     const captured: string[][] = [];
     const spawnCalls: unknown[] = [];

--- a/packages/runtime/src/__tests__/session-manager.test.ts
+++ b/packages/runtime/src/__tests__/session-manager.test.ts
@@ -563,6 +563,80 @@ describe('SessionManager permission mode updates', () => {
     expect((await store.readMessages(session.id)).length).toBe(0);
   });
 
+  test('persists orchestration mode changes and records a dimensioned audit note', async () => {
+    const store = new MemorySessionStore();
+    const backends = new BackendRegistry();
+    backends.register('fake', (ctx) => new TestBackend(ctx));
+    const manager = new SessionManager({ store, backends, newId: nextId(), now: nextNow(4_500) });
+    const session = await manager.createSession(makeInput());
+
+    const summary = await manager.setOrchestrationMode(session.id, 'swarm');
+    expect(summary.orchestrationMode).toBe('swarm');
+    expect((await store.readHeader(session.id)).orchestrationMode).toBe('swarm');
+    const notes = (await store.readMessages(session.id)).filter(
+      (message): message is Extract<StoredMessage, { type: 'system_note' }> =>
+        message.type === 'system_note' && message.kind === 'mode_change',
+    );
+    expect(notes).toHaveLength(1);
+    expect(notes[0]?.data).toEqual({
+      dimension: 'orchestration',
+      from: 'default',
+      to: 'swarm',
+    });
+
+    await manager.setOrchestrationMode(session.id, 'swarm');
+    expect(
+      (await store.readMessages(session.id)).filter((message) => message.type === 'system_note'),
+    ).toHaveLength(1);
+  });
+
+  test('snapshots persisted and one-turn orchestration into runs and backend sends', async () => {
+    const store = new MemorySessionStore();
+    const runStore = new MemoryAgentRunStore();
+    const backends = new BackendRegistry();
+    let backend: TestBackend | undefined;
+    backends.register('fake', (ctx) => {
+      backend = new TestBackend(ctx);
+      return backend;
+    });
+    const manager = new SessionManager({
+      store,
+      runStore,
+      runtimeEventStore: runStore,
+      backends,
+      newId: nextId(),
+      now: nextNow(4_600),
+      runtimeSource: 'test',
+    });
+    const session = await manager.createSession(makeInput({ orchestrationMode: 'swarm' }));
+
+    await drain(manager.sendMessage(session.id, { turnId: 'persisted', text: 'first' }));
+    await drain(
+      manager.sendMessage(session.id, {
+        turnId: 'one-shot-default',
+        text: 'second',
+        turnOrchestration: { mode: 'default', source: 'host_api' },
+      }),
+    );
+
+    const runs = await runStore.listSessionRuns(session.id);
+    expect(runs.find((run) => run.turnId === 'persisted')).toMatchObject({
+      orchestrationMode: 'swarm',
+      orchestrationSource: 'session',
+      agentSwarmAuthorization: 'session_mode',
+    });
+    expect(runs.find((run) => run.turnId === 'one-shot-default')).toMatchObject({
+      orchestrationMode: 'default',
+      orchestrationSource: 'turn_override',
+      agentSwarmAuthorization: 'none',
+    });
+    expect(backend?.sendInputs.map((input) => input.orchestration)).toEqual([
+      { mode: 'swarm', source: 'session', agentSwarmAuthorization: 'session_mode' },
+      { mode: 'default', source: 'turn_override', agentSwarmAuthorization: 'none' },
+    ]);
+    expect((await store.readHeader(session.id)).orchestrationMode).toBe('swarm');
+  });
+
   test('leaving explore clears the deep research label so visible read-only copy stays truthful', async () => {
     const store = new MemorySessionStore();
     const backends = new BackendRegistry();
@@ -1117,6 +1191,9 @@ describe('SessionManager permission mode updates', () => {
       modelId: header.model,
       cwd: header.cwd,
       permissionMode: header.permissionMode,
+      orchestrationMode: 'swarm',
+      orchestrationSource: 'turn_override',
+      agentSwarmAuthorization: 'turn_override',
       createdAt: 1,
       updatedAt: 2,
       completedAt: 2,
@@ -1174,6 +1251,11 @@ describe('SessionManager permission mode updates', () => {
     expect(continuationRun.parentRunId).toBe(sourceRunId);
     expect(continuationRun.parentTurnId).toBe(sourceTurnId);
     expect(continuationRun.status).toBe('completed');
+    expect(continuationRun).toMatchObject({
+      orchestrationMode: 'swarm',
+      orchestrationSource: 'turn_override',
+      agentSwarmAuthorization: 'turn_override',
+    });
     const continuationEvents = await runStore.readRuntimeEvents(
       session.id,
       plan.continuation.runId,
@@ -5671,7 +5753,9 @@ describe('SessionManager permission mode updates', () => {
       now: nextNow(6_840),
       runtimeSource: 'test',
     });
-    const session = await manager.createSession(makeInput({ permissionMode: 'ask' }));
+    const session = await manager.createSession(
+      makeInput({ permissionMode: 'ask', orchestrationMode: 'swarm' }),
+    );
 
     await drain(manager.sendMessage(session.id, { turnId: 'parent-turn', text: 'parent context' }));
     const [parentRun] = await runStore.listSessionRuns(session.id);
@@ -5705,6 +5789,15 @@ describe('SessionManager permission mode updates', () => {
     expect(childRun?.agentId).toBe(LOCAL_READ_AGENT_ID);
     expect(childRun?.agentName).toBe(LOCAL_READ_AGENT_DEFINITION.name);
     expect(childRun?.permissionMode).toBe('explore');
+    expect(parentRun).toMatchObject({
+      orchestrationMode: 'swarm',
+      agentSwarmAuthorization: 'session_mode',
+    });
+    expect(childRun).toMatchObject({
+      orchestrationMode: 'default',
+      orchestrationSource: 'session',
+      agentSwarmAuthorization: 'none',
+    });
 
     const childMessages = (await store.readMessages(session.id)).filter(
       (message) => 'turnId' in message && message.turnId === 'child-turn',
@@ -9961,7 +10054,7 @@ describe('SessionManager permission mode updates', () => {
     expect(danglingUpdates[0]?.result.output).toBe(undefined);
   });
 
-  test('branchFromTurn preserves the parent thinking level for future turns', async () => {
+  test('branchFromTurn preserves parent thinking and orchestration modes', async () => {
     const store = new MemorySessionStore();
     const runStore = new MemoryAgentRunStore();
     const backends = new BackendRegistry();
@@ -9979,7 +10072,7 @@ describe('SessionManager permission mode updates', () => {
       now: nextNow(15_500),
     });
     const session = await manager.createSession(
-      makeInput({ name: 'Parent', thinkingLevel: 'high' }),
+      makeInput({ name: 'Parent', thinkingLevel: 'high', orchestrationMode: 'swarm' }),
     );
     await drain(manager.sendMessage(session.id, { turnId: 'source', text: 'context' }));
 
@@ -9989,7 +10082,9 @@ describe('SessionManager permission mode updates', () => {
     });
 
     expect(child.thinkingLevel).toBe('high');
+    expect(child.orchestrationMode).toBe('swarm');
     expect((await store.readHeader(child.id)).thinkingLevel).toBe('high');
+    expect((await store.readHeader(child.id)).orchestrationMode).toBe('swarm');
     await drain(manager.sendMessage(child.id, { turnId: 'child-turn', text: 'continue' }));
     expect(contexts.find((ctx) => ctx.sessionId === child.id)?.header.thinkingLevel).toBe('high');
   });
@@ -12498,6 +12593,7 @@ class MemorySessionStore implements SessionStore {
       model: input.model ?? 'fake-model',
       ...(input.thinkingLevel !== undefined ? { thinkingLevel: input.thinkingLevel } : {}),
       permissionMode: input.permissionMode,
+      orchestrationMode: input.orchestrationMode ?? 'default',
       schemaVersion: 1,
     };
     this.headers.set(header.id, header);

--- a/packages/runtime/src/__tests__/swarm-mode.test.ts
+++ b/packages/runtime/src/__tests__/swarm-mode.test.ts
@@ -1,0 +1,16 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+
+import { renderSwarmModePrompt } from '../swarm-mode.js';
+
+describe('Swarm Mode shared prompt', () => {
+  test('defines bounded dispatch, exclusive use, settlement, and synthesis', () => {
+    const prompt = renderSwarmModePrompt();
+    assert.match(prompt, /<orchestration_mode>/);
+    assert.match(prompt, /meaningful independent items/);
+    assert.match(prompt, /only tool in its assistant step/);
+    assert.match(prompt, /whole batch to settle/);
+    assert.match(prompt, /semantically synthesize/);
+    assert.match(prompt, /Do not manufacture fake parallelism/);
+  });
+});

--- a/packages/runtime/src/__tests__/swarm-orchestration.test.ts
+++ b/packages/runtime/src/__tests__/swarm-orchestration.test.ts
@@ -1,0 +1,197 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+import { z } from 'zod';
+import type {
+  EffectiveOrchestration,
+  SessionEvent,
+  SessionHeader,
+  StoredMessage,
+  ToolPermissionRule,
+} from '@maka/core';
+
+import { PermissionEngine } from '../permission-engine.js';
+import { ToolRuntime, type MakaTool } from '../tool-runtime.js';
+
+function header(): SessionHeader {
+  return {
+    id: 'session-1',
+    workspaceRoot: '/tmp/maka',
+    cwd: '/tmp/maka',
+    createdAt: 1,
+    lastUsedAt: 1,
+    name: 'Test',
+    titleIsManual: true,
+    isFlagged: false,
+    labels: [],
+    isArchived: false,
+    status: 'active',
+    statusUpdatedAt: 1,
+    hasUnread: false,
+    backend: 'ai-sdk',
+    llmConnectionSlug: 'c',
+    connectionLocked: true,
+    model: 'm',
+    permissionMode: 'ask',
+    schemaVersion: 1,
+  };
+}
+
+function tool(
+  name: string,
+  calls: string[],
+  options: Pick<MakaTool, 'executionSemantics' | 'permissionRequired' | 'categoryHint'> = {},
+): MakaTool {
+  return {
+    name,
+    description: name,
+    parameters: z.object({}),
+    permissionRequired: options.permissionRequired ?? false,
+    ...(options.executionSemantics ? { executionSemantics: options.executionSemantics } : {}),
+    ...(options.categoryHint ? { categoryHint: options.categoryHint } : {}),
+    impl: () => {
+      calls.push(name);
+      return { ok: true };
+    },
+  };
+}
+
+function harness(
+  input: {
+    orchestration?: EffectiveOrchestration;
+    permissionRules?: readonly ToolPermissionRule[];
+  } = {},
+) {
+  const appended: StoredMessage[] = [];
+  const events: SessionEvent[] = [];
+  const calls: string[] = [];
+  const engine = new PermissionEngine({ newId: () => 'permission-1', now: () => 1 });
+  let stepId = 'step-1';
+  let id = 0;
+  const runtime = new ToolRuntime({
+    sessionId: 'session-1',
+    header: header(),
+    connection: { providerType: 'openai', slug: 'c' } as never,
+    modelId: 'm',
+    appendMessage: async (message) => {
+      appended.push(message);
+    },
+    permissionEngine: engine,
+    newId: () => `id-${++id}`,
+    now: () => 1,
+    getPermissionPauseTarget: () => null,
+    getCurrentStepId: () => stepId,
+    getCurrentOrchestration: () => input.orchestration,
+    ...(input.permissionRules ? { permissionRules: input.permissionRules } : {}),
+  });
+  engine.beginTurn('turn-1');
+  runtime.beginTurn('turn-1');
+  return {
+    runtime,
+    calls,
+    events,
+    setStepId: (next: string) => {
+      stepId = next;
+    },
+  };
+}
+
+let toolCallSequence = 0;
+async function invoke(fixture: ReturnType<typeof harness>, value: MakaTool): Promise<unknown> {
+  return fixture.runtime.wrapToolExecute(value, 'turn-1', {
+    push: (event) => fixture.events.push(event),
+  })(
+    {},
+    {
+      toolCallId: `tool-call-${++toolCallSequence}`,
+      abortSignal: new AbortController().signal,
+    },
+  );
+}
+
+describe('Swarm orchestration admission', () => {
+  test('an exclusive tool cannot follow or precede another tool in the same step', async () => {
+    const first = harness();
+    const ordinary = tool('Read', first.calls);
+    const exclusive = tool('agent_swarm', first.calls, { executionSemantics: 'exclusive_step' });
+    await invoke(first, ordinary);
+    const rejectedExclusive = await invoke(first, exclusive);
+    assert.deepEqual(first.calls, ['Read']);
+    assert.match(JSON.stringify(rejectedExclusive), /cannot share an assistant step/);
+
+    const second = harness();
+    const exclusiveFirst = tool('agent_swarm', second.calls, {
+      executionSemantics: 'exclusive_step',
+    });
+    const ordinarySecond = tool('Read', second.calls);
+    await invoke(second, exclusiveFirst);
+    const rejectedOrdinary = await invoke(second, ordinarySecond);
+    assert.deepEqual(second.calls, ['agent_swarm']);
+    assert.match(JSON.stringify(rejectedOrdinary), /exclusive tool agent_swarm/i);
+  });
+
+  test('exclusive admission is scoped to one assistant step', async () => {
+    const fixture = harness();
+    await invoke(
+      fixture,
+      tool('agent_swarm', fixture.calls, { executionSemantics: 'exclusive_step' }),
+    );
+    fixture.setStepId('step-2');
+    await invoke(fixture, tool('Read', fixture.calls));
+    assert.deepEqual(fixture.calls, ['agent_swarm', 'Read']);
+  });
+});
+
+describe('Swarm orchestration authorization', () => {
+  const swarm: EffectiveOrchestration = {
+    mode: 'swarm',
+    source: 'turn_override',
+    agentSwarmAuthorization: 'turn_override',
+  };
+
+  test('the trusted envelope allows exactly agent_swarm without prompting', async () => {
+    const fixture = harness({ orchestration: swarm });
+    const result = await invoke(
+      fixture,
+      tool('agent_swarm', fixture.calls, {
+        executionSemantics: 'exclusive_step',
+        permissionRequired: true,
+        categoryHint: 'subagent',
+      }),
+    );
+    assert.deepEqual(result, { ok: true });
+    assert.deepEqual(fixture.calls, ['agent_swarm']);
+    assert.equal(
+      fixture.events.some((event) => event.type === 'permission_request'),
+      false,
+    );
+  });
+
+  test('an explicit deny still wins over Swarm Mode authorization', async () => {
+    const fixture = harness({
+      orchestration: swarm,
+      permissionRules: [{ effect: 'deny', kind: 'tool', toolName: 'agent_swarm' }],
+    });
+    const result = await invoke(
+      fixture,
+      tool('agent_swarm', fixture.calls, {
+        executionSemantics: 'exclusive_step',
+        permissionRequired: true,
+        categoryHint: 'subagent',
+      }),
+    );
+    assert.deepEqual(fixture.calls, []);
+    assert.match(JSON.stringify(result), /denied|blocked|not allowed/i);
+  });
+
+  test('the Swarm envelope does not widen unrelated tool permissions', async () => {
+    const fixture = harness({
+      orchestration: swarm,
+      permissionRules: [{ effect: 'deny', kind: 'tool', toolName: 'Write' }],
+    });
+    await invoke(
+      fixture,
+      tool('Write', fixture.calls, { permissionRequired: true, categoryHint: 'file_write' }),
+    );
+    assert.deepEqual(fixture.calls, []);
+  });
+});

--- a/packages/runtime/src/__tests__/tool-availability.test.ts
+++ b/packages/runtime/src/__tests__/tool-availability.test.ts
@@ -81,6 +81,21 @@ describe('ToolAvailabilityRuntime — economy mode', () => {
     assert.ok(!plan.activeTools.includes('office_edit'));
   });
 
+  test('a required orchestration tool stays pinned for the whole turn', () => {
+    const plan = runtime(true).prepare([], new Set(['rive_run']));
+    assert.ok(plan.activeTools.includes('rive_run'), 'required tool is visible at step 0');
+    assert.ok(plan.gating?.activeNames().has('rive_run'));
+    const next = plan.prepareStep!({ steps: [] });
+    assert.ok(next.activeTools.includes('rive_run'), 'required tool remains visible later');
+    assert.ok(!next.activeTools.includes('office_edit'), 'other deferred groups remain hidden');
+  });
+
+  test('unknown required tool names are ignored', () => {
+    const plan = runtime(true).prepare([], new Set(['not-a-tool']));
+    assert.ok(!plan.activeTools.includes('not-a-tool'));
+    assert.ok(!plan.activeTools.includes('rive_run'));
+  });
+
   test('providerTools keeps every tool dispatchable, including hidden groups + invalid', () => {
     const names = runtime(true)
       .prepare([])

--- a/packages/runtime/src/__tests__/tool-runtime-extraction-contract.test.ts
+++ b/packages/runtime/src/__tests__/tool-runtime-extraction-contract.test.ts
@@ -169,7 +169,8 @@ describe('RunTrace extraction contract', () => {
     assert.match(backend, /from '\.\/run-trace\.js'/);
     assert.match(backend, /recordRunTrace\?: RunTraceRecorder/);
     assert.match(backend, /private currentRunTrace: RunTrace \| null = null;/);
-    assert.match(backend, /trace\.turnStarted\(\)/);
+    assert.match(backend, /trace\.turnStarted\(\{/);
+    assert.match(backend, /orchestrationMode: this\.currentOrchestration\.mode/);
     assert.match(backend, /trace\.modelResolved\(\)/);
     assert.match(backend, /trace\.modelStreamStarted\(activeTools, \{/);
     assert.match(backend, /trace\.usageRecorded\(\{\n\s+\.\.\.tokenUsage,/);

--- a/packages/runtime/src/agent-flow.ts
+++ b/packages/runtime/src/agent-flow.ts
@@ -35,6 +35,7 @@ import type { SteeringLease } from '@maka/core/backend-types';
 import type { StoredMessage } from '@maka/core/session';
 import type { RuntimeEvent } from '@maka/core/runtime-event';
 import type { RuntimeContinuationMetadata } from '@maka/core/backend-types';
+import type { EffectiveOrchestration } from '@maka/core/orchestration';
 import type { InvocationContext } from './invocation-context.js';
 
 export type { InvocationContext } from './invocation-context.js';
@@ -56,6 +57,8 @@ export type { InvocationContext } from './invocation-context.js';
 export interface FlowInput {
   /** Parent AgentRun id when this flow is running a child agent turn. */
   parentRunId?: string;
+  /** Trusted effective orchestration snapshot for this invocation. */
+  orchestration?: EffectiveOrchestration;
   /** User turn text. */
   text: string;
   /** Optional attachments bound to the user message. */

--- a/packages/runtime/src/agent-run.ts
+++ b/packages/runtime/src/agent-run.ts
@@ -18,6 +18,10 @@ import type {
   UserMessage,
 } from '@maka/core/session';
 import type { UserMessageInput } from '@maka/core/runtime-inputs';
+import {
+  resolveEffectiveOrchestration,
+  type EffectiveOrchestration,
+} from '@maka/core/orchestration';
 import { failureClassFromCompleteStopReason, type SessionEvent } from '@maka/core/events';
 import type { AgentBackend, BackendSendInput } from '@maka/core/backend-types';
 import type { RunTraceEvent } from './run-trace.js';
@@ -106,6 +110,8 @@ export interface AgentRunInput {
   hooks: AgentRunHooks;
   recordSessionMessages?: boolean;
   invocationId?: string;
+  /** Pre-resolved snapshot used by continuations; normal turns derive it from header + input. */
+  effectiveOrchestration?: EffectiveOrchestration;
   /** Set only when this run's backend tool path is guarded by canonical T1. */
   toolBoundaryProtocol?: ToolBoundaryProtocol;
 }
@@ -150,6 +156,7 @@ export class AgentRun {
   readonly turnId: string;
   readonly toolBoundaryProtocol: ToolBoundaryProtocol | undefined;
   readonly lineage: AgentRunLineage;
+  readonly effectiveOrchestration: EffectiveOrchestration;
 
   private header: SessionHeader;
   private active: AgentRunActiveSession | undefined;
@@ -191,6 +198,12 @@ export class AgentRun {
     this.turnId = input.userInput.turnId;
     this.toolBoundaryProtocol = input.toolBoundaryProtocol;
     this.header = input.header;
+    this.effectiveOrchestration =
+      input.effectiveOrchestration ??
+      resolveEffectiveOrchestration(
+        input.header.orchestrationMode,
+        input.userInput.turnOrchestration,
+      );
     this.lineage = {
       ...(input.userInput.parentRunId ? { parentRunId: input.userInput.parentRunId } : {}),
       ...(input.userInput.parentTurnId ? { parentTurnId: input.userInput.parentTurnId } : {}),
@@ -383,6 +396,7 @@ export class AgentRun {
         invocationId,
         runId: this.runId,
         turnId: this.turnId,
+        orchestration: this.effectiveOrchestration,
         text: this.input.userInput.text,
         ...(this.input.userInput.attachments
           ? { attachments: this.input.userInput.attachments }
@@ -519,6 +533,7 @@ export class AgentRun {
       backend: this.active.backend,
       backendInput: {
         turnId: this.turnId,
+        orchestration: this.effectiveOrchestration,
         text: this.input.userInput.text,
         ...(this.input.userInput.attachments
           ? { attachments: this.input.userInput.attachments }
@@ -889,6 +904,9 @@ export class AgentRun {
       ...(this.input.workspaceIdentity ? { workspaceIdentity: this.input.workspaceIdentity } : {}),
       permissionMode: this.header.permissionMode,
       collaborationMode: this.header.collaborationMode ?? 'agent',
+      orchestrationMode: this.effectiveOrchestration.mode,
+      orchestrationSource: this.effectiveOrchestration.source,
+      agentSwarmAuthorization: this.effectiveOrchestration.agentSwarmAuthorization,
       createdAt,
       updatedAt: createdAt,
       ...this.lineage,
@@ -924,6 +942,9 @@ export class AgentRun {
           data: {
             textLength: this.input.userInput.text.length,
             attachmentCount: this.input.userInput.attachments?.length ?? 0,
+            orchestrationMode: this.effectiveOrchestration.mode,
+            orchestrationSource: this.effectiveOrchestration.source,
+            agentSwarmAuthorization: this.effectiveOrchestration.agentSwarmAuthorization,
           },
         },
         { durable },

--- a/packages/runtime/src/agent-swarm-tools.ts
+++ b/packages/runtime/src/agent-swarm-tools.ts
@@ -72,6 +72,7 @@ export function buildAgentSwarmTool(
     ].join(' '),
     parameters: agentSwarmInputSchema(),
     permissionRequired: true,
+    executionSemantics: 'exclusive_step',
     categoryHint: 'subagent',
     impl: async (input, ctx) => {
       const prepared = preflightAgentSwarmInput(input);

--- a/packages/runtime/src/ai-sdk-backend.ts
+++ b/packages/runtime/src/ai-sdk-backend.ts
@@ -66,6 +66,10 @@ import type { LlmConnection } from '@maka/core/llm-connections';
 import type { RuntimeEvent } from '@maka/core/runtime-event';
 import type { ToolPermissionRule } from '@maka/core/permission';
 import type { UserQuestionResponse } from '@maka/core/user-question';
+import {
+  resolveEffectiveOrchestration,
+  type EffectiveOrchestration,
+} from '@maka/core/orchestration';
 import type { PlanToolResult } from './plan-tools.js';
 import type { AttachmentByteReader } from '@maka/core/attachments';
 import {
@@ -166,6 +170,7 @@ import {
   type ProviderRequestCaptureRecord,
 } from './provider-request-telemetry.js';
 import { ToolAvailabilityRuntime, type ToolAvailabilityConfig } from './tool-availability.js';
+import { renderSwarmModePrompt } from './swarm-mode.js';
 import {
   applyRuntimeEventContextBudget,
   buildContextBudgetDiagnosticShell,
@@ -679,6 +684,7 @@ export class AiSdkBackend implements AgentBackend {
    */
   private injectedSteeringMessages: ModelMessage[] = [];
   private currentRunId: string | null = null;
+  private currentOrchestration: EffectiveOrchestration | undefined;
   private imageRequestBudget: { used: number; decisions: Map<string, boolean> } | null = null;
   /** Side-channel for tool.execute() callbacks to push events into the iterator. */
   private currentQueue: AsyncEventQueue<SessionEvent> | null = null;
@@ -748,6 +754,7 @@ export class AiSdkBackend implements AgentBackend {
       getCurrentRunId: () => this.currentRunId ?? undefined,
       agentTeam: input.agentTeam,
       getCurrentStepId: () => this.currentStepMessageId ?? undefined,
+      getCurrentOrchestration: () => this.currentOrchestration,
       permissionRules: input.permissionRules,
       spawnChildAgent: input.spawnChildAgent,
       listChildAgents: input.listChildAgents,
@@ -815,6 +822,9 @@ export class AiSdkBackend implements AgentBackend {
     this.currentTurnId = turnId;
     this.currentInvocationId = input.invocationId ?? input.runId ?? null;
     this.currentRunId = input.runId ?? null;
+    this.currentOrchestration =
+      input.orchestration ??
+      resolveEffectiveOrchestration(this.input.header.orchestrationMode, undefined);
     this.currentUserIntent = input.text;
     this.input.permissionEngine.beginTurn(turnId);
     this.toolRuntime.beginTurn(turnId);
@@ -927,7 +937,11 @@ export class AiSdkBackend implements AgentBackend {
       record: this.input.recordRunTrace,
     });
     this.currentRunTrace = trace;
-    trace.turnStarted();
+    trace.turnStarted({
+      orchestrationMode: this.currentOrchestration.mode,
+      orchestrationSource: this.currentOrchestration.source,
+      agentSwarmAuthorization: this.currentOrchestration.agentSwarmAuthorization,
+    });
     if (this.input.planTraceContext) {
       trace.emit('plan', 'plan_context_resolved', 'Plan context resolved', {
         ...this.input.planTraceContext,
@@ -985,6 +999,7 @@ export class AiSdkBackend implements AgentBackend {
     // not committed yet) so a group loaded earlier stays advertised.
     const plan = this.toolAvailabilityRuntime.prepare(
       (input.runtimeContext ?? []).filter((event) => event.turnId !== turnId),
+      this.currentOrchestration.mode === 'swarm' ? new Set(['agent_swarm']) : new Set(),
     );
     const providerTools = plan.providerTools;
     let activeToolResultPruneDiagnosticPatch: ActiveToolResultPruneDiagnosticPatch = {};
@@ -1083,7 +1098,10 @@ export class AiSdkBackend implements AgentBackend {
         this.currentWatchdog = watchdog;
         watchdog.start();
         const activeTools = plan.activeTools;
-        const systemPrompt = await this.resolveSystemPrompt();
+        const systemPrompt = joinPromptFragments([
+          await this.resolveSystemPrompt(),
+          this.currentOrchestration?.mode === 'swarm' ? renderSwarmModePrompt() : undefined,
+        ]);
         const turnTailPrompt = input.continuation
           ? undefined
           : joinPromptFragments([
@@ -2866,6 +2884,7 @@ export class AiSdkBackend implements AgentBackend {
     this.currentTurnId = null;
     this.currentInvocationId = null;
     this.currentRunId = null;
+    this.currentOrchestration = undefined;
     this.currentRunTrace = null;
     this.currentUserIntent = undefined;
     this.currentStepMessageId = null;

--- a/packages/runtime/src/ai-sdk-flow.ts
+++ b/packages/runtime/src/ai-sdk-flow.ts
@@ -711,6 +711,7 @@ export class AiSdkFlow implements AgentFlow, AgentFlowControl {
         invocationId: ctx.invocationId,
         runId: ctx.runId,
         turnId: ctx.turnId,
+        ...(input.orchestration !== undefined ? { orchestration: input.orchestration } : {}),
         // The persisted head anchor: mid-turn capacity compaction keeps this
         // event verbatim and needs its exact ledger identity for coverage.
         ...(ctx.request.initialRuntimeEvent !== undefined

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -33,6 +33,7 @@ export type {
 
 export { PermissionEngine, createDefaultPermissionEngineDeps } from './permission-engine.js';
 export type { EvaluateResult, EvaluateInput, PermissionEngineDeps } from './permission-engine.js';
+export { renderSwarmModePrompt } from './swarm-mode.js';
 
 export {
   MAX_ADDITIONAL_PERMISSION_JUSTIFICATION_CHARS,

--- a/packages/runtime/src/invocation-context.ts
+++ b/packages/runtime/src/invocation-context.ts
@@ -17,6 +17,7 @@ import type { SteeringLease } from '@maka/core/backend-types';
 import type { RuntimeEvent, RuntimeEventStatus } from '@maka/core/runtime-event';
 import type { StoredMessage } from '@maka/core/session';
 import type { RuntimeContinuationMetadata } from '@maka/core/backend-types';
+import type { EffectiveOrchestration } from '@maka/core/orchestration';
 
 // ============================================================================
 // InvocationSource
@@ -76,6 +77,8 @@ export interface InvocationRequest {
   invocationId?: string;
   runId?: string;
   turnId: string;
+  /** Trusted effective orchestration snapshot for this invocation. */
+  orchestration?: EffectiveOrchestration;
   text: string;
   /** Optional attachments bound to this user turn. */
   attachments?: AttachmentRef[];

--- a/packages/runtime/src/run-trace.ts
+++ b/packages/runtime/src/run-trace.ts
@@ -109,11 +109,12 @@ export class RunTrace {
     }
   }
 
-  turnStarted(): void {
+  turnStarted(extra: Record<string, unknown> = {}): void {
     this.emit('turn', 'turn_started', 'Turn started', {
       connectionSlug: this.input.connectionSlug,
       providerId: this.input.providerId,
       modelId: this.input.modelId,
+      ...extra,
     });
   }
 

--- a/packages/runtime/src/runtime-kernel.ts
+++ b/packages/runtime/src/runtime-kernel.ts
@@ -25,6 +25,10 @@ import type {
 import { isDeepStrictEqual } from 'node:util';
 import type { ChildAgentTurnInput, UserMessageInput } from '@maka/core/runtime-inputs';
 import type { PermissionResponse } from '@maka/core/permission';
+import {
+  resolveEffectiveOrchestration,
+  type EffectiveOrchestration,
+} from '@maka/core/orchestration';
 import type { UserQuestionResponse } from '@maka/core/user-question';
 import {
   AgentRun,
@@ -388,6 +392,7 @@ export class RuntimeKernel implements RuntimeKernelLike {
       newId: this.deps.newId,
       now: this.deps.now,
       workspaceIdentity: continuation.safetySnapshot.workspaceIdentity,
+      effectiveOrchestration: effectiveOrchestrationForRun(sourceRun, header),
       continuationFailpoint: this.deps.continuationFailpoint,
       hooks: {
         ensureActive: (targetSessionId, nextHeader) =>
@@ -431,6 +436,7 @@ export class RuntimeKernel implements RuntimeKernelLike {
       repairRunRuntimeLedger: this.deps.repairRunRuntimeLedger,
       newId: this.deps.newId,
       now: this.deps.now,
+      effectiveOrchestration: resolveEffectiveOrchestration('default', undefined),
       hooks: {
         ensureActive: (targetSessionId, nextHeader) =>
           this.ensureActive(targetSessionId, nextHeader),
@@ -567,6 +573,7 @@ export class RuntimeKernel implements RuntimeKernelLike {
       repairRunRuntimeLedger: this.deps.repairRunRuntimeLedger,
       newId: this.deps.newId,
       now: this.deps.now,
+      effectiveOrchestration: resolveEffectiveOrchestration('default', undefined),
       recordSessionMessages: false,
       hooks: {
         ensureActive: (targetSessionId, nextHeader) =>
@@ -729,6 +736,9 @@ export class RuntimeKernel implements RuntimeKernelLike {
         invocationId: begin.initialRuntimeEvent.invocationId,
         runId: run.runId,
         turnId: run.turnId,
+        ...(begin.backendInput.orchestration
+          ? { orchestration: begin.backendInput.orchestration }
+          : {}),
         text: input.text,
         ...(begin.backendInput.attachments ? { attachments: begin.backendInput.attachments } : {}),
         context: begin.backendInput.context,
@@ -830,6 +840,7 @@ export class RuntimeKernel implements RuntimeKernelLike {
     const runnerResult = runner
       .resume(continuation, {
         source: this.deps.runtimeSource ?? 'desktop',
+        orchestration: run.effectiveOrchestration,
         abortSignal: abortController.signal,
       })
       .then(
@@ -1698,6 +1709,24 @@ function runtimeToolBoundaryProtocol(
   header: Pick<SessionHeader, 'backend'>,
 ): ToolBoundaryProtocol | undefined {
   return header.backend === 'ai-sdk' ? deps.toolBoundaryProtocol : undefined;
+}
+
+function effectiveOrchestrationForRun(
+  run: AgentRunHeader,
+  session: SessionHeader,
+): EffectiveOrchestration {
+  if (
+    run.orchestrationMode !== undefined &&
+    run.orchestrationSource !== undefined &&
+    run.agentSwarmAuthorization !== undefined
+  ) {
+    return {
+      mode: run.orchestrationMode,
+      source: run.orchestrationSource,
+      agentSwarmAuthorization: run.agentSwarmAuthorization,
+    };
+  }
+  return resolveEffectiveOrchestration(session.orchestrationMode, undefined);
 }
 
 class AsyncEventQueueClosed extends Error {

--- a/packages/runtime/src/runtime-runner.ts
+++ b/packages/runtime/src/runtime-runner.ts
@@ -150,6 +150,7 @@ export class RuntimeRunner {
     options: {
       source: InvocationRequest['source'];
       context?: InvocationRequest['context'];
+      orchestration?: InvocationRequest['orchestration'];
       abortSignal?: AbortSignal;
     },
   ): Promise<InvocationResult> {
@@ -164,6 +165,7 @@ export class RuntimeRunner {
       runtimeContext: continuation.runtimeContext,
       continuation: invocationContinuationMetadata(continuation),
       source: options.source,
+      ...(options.orchestration ? { orchestration: options.orchestration } : {}),
       ...(options.abortSignal ? { abortSignal: options.abortSignal } : {}),
     });
   }
@@ -517,6 +519,7 @@ function buildFlowInput(request: InvocationRequest): FlowInput {
     : undefined;
   return {
     ...(request.lineage?.parentRunId ? { parentRunId: request.lineage.parentRunId } : {}),
+    ...(request.orchestration !== undefined ? { orchestration: request.orchestration } : {}),
     text: request.text,
     context: request.context ?? [],
     ...(request.runtimeContext !== undefined ? { runtimeContext: request.runtimeContext } : {}),

--- a/packages/runtime/src/session-manager.ts
+++ b/packages/runtime/src/session-manager.ts
@@ -46,6 +46,7 @@ import type { PermissionResponse } from '@maka/core/permission';
 import type { UserQuestionResponse } from '@maka/core/user-question';
 import type { PermissionMode } from '@maka/core/permission';
 import type { CollaborationMode } from '@maka/core/collaboration';
+import type { OrchestrationMode } from '@maka/core/orchestration';
 import type {
   ApprovePlanProposalInput,
   PlanMutationResult,
@@ -745,6 +746,28 @@ export class SessionManager {
     return headerToSummary(next);
   }
 
+  async setOrchestrationMode(sessionId: string, mode: OrchestrationMode): Promise<SessionSummary> {
+    const previous = await this.deps.store.readHeader(sessionId);
+    const from = previous.orchestrationMode ?? 'default';
+    if (from === mode) return headerToSummary(previous);
+    if (this.runtimeKernel.hasActiveRuns(sessionId)) {
+      throw new Error('Cannot change orchestration mode while a turn is running.');
+    }
+    if (previous.status === 'waiting_for_user') {
+      throw new Error('Cannot change orchestration mode while a tool call awaits confirmation.');
+    }
+    const next = await this.deps.store.updateHeader(sessionId, { orchestrationMode: mode });
+    await this.deps.store.appendMessage(sessionId, {
+      type: 'system_note',
+      id: this.deps.newId(),
+      ts: this.deps.now(),
+      kind: 'mode_change',
+      data: { dimension: 'orchestration', from, to: mode },
+    } satisfies SystemNoteMessage);
+    this.runtimeKernel.updateCachedHeader(sessionId, next);
+    return headerToSummary(next);
+  }
+
   async requestPlanRevision(sessionId: string, proposalId: string): Promise<PlanMutationResult> {
     const result = await this.requirePlanStore().requestRevision({ sessionId, proposalId });
     const header = await this.deps.store.readHeader(sessionId);
@@ -1350,6 +1373,7 @@ export class SessionManager {
       model: header.model,
       thinkingLevel: header.thinkingLevel,
       permissionMode: header.permissionMode,
+      orchestrationMode: header.orchestrationMode ?? 'default',
       name: input.name ?? `${header.name} · 分支`,
       labels: header.labels,
       parentSessionId: sessionId,
@@ -1869,6 +1893,7 @@ export function headerToSummary(h: SessionHeader): SessionSummary {
     model: h.model,
     permissionMode: h.permissionMode ?? 'ask',
     collaborationMode: h.collaborationMode ?? 'agent',
+    orchestrationMode: h.orchestrationMode ?? 'default',
   };
   if (h.thinkingLevel !== undefined) summary.thinkingLevel = h.thinkingLevel;
   if (h.lastMessageAt !== undefined) {

--- a/packages/runtime/src/swarm-mode.ts
+++ b/packages/runtime/src/swarm-mode.ts
@@ -1,0 +1,13 @@
+export function renderSwarmModePrompt(): string {
+  return [
+    '<orchestration_mode>',
+    '# Orchestration Mode: Swarm',
+    'Use the agent_swarm tool when the work can be split into at least two meaningful independent items.',
+    'Perform only the lightweight exploration needed to establish boundaries before dispatch.',
+    'Make every item bounded and self-contained with an explicit scope, expected output, and constraints.',
+    'Avoid overlapping writes. Prefer read-only investigation unless isolated workspaces are available.',
+    'Call agent_swarm as the only tool in its assistant step, wait for the whole batch to settle, then verify, deduplicate, and semantically synthesize the results.',
+    'Do not manufacture fake parallelism. If the task cannot be meaningfully split, explain why and continue normally.',
+    '</orchestration_mode>',
+  ].join('\n');
+}

--- a/packages/runtime/src/tool-availability.ts
+++ b/packages/runtime/src/tool-availability.ts
@@ -144,7 +144,10 @@ export class ToolAvailabilityRuntime {
     this.allTools = this.connector ? [...tools, this.connector] : tools;
   }
 
-  prepare(priorEvents: ReadonlyArray<RuntimeEventLike> | undefined): ToolAvailabilityPlan {
+  prepare(
+    priorEvents: ReadonlyArray<RuntimeEventLike> | undefined,
+    requiredToolNames: ReadonlySet<string> = new Set(),
+  ): ToolAvailabilityPlan {
     const canonical = canonicalizeToolSet(this.allTools, this.invalidTool);
 
     if (!this.economy) {
@@ -158,6 +161,8 @@ export class ToolAvailabilityRuntime {
     }
 
     const seedGroups = this.seedLoadedGroups(priorEvents);
+    const knownNames = new Set(canonical.providerTools.map((tool) => tool.name));
+    const requiredNames = [...requiredToolNames].filter((name) => knownNames.has(name));
     // Turn-local snapshot the guard / repair / diagnostics read; recomputed
     // before every step by `prepareStep`. No cross-turn mutable state — a load
     // survives turns only via the ledger seed above (durable by construction),
@@ -167,11 +172,9 @@ export class ToolAvailabilityRuntime {
     const turn = { active: new Set<string>() };
     const computeActive = (steps: ReadonlyArray<StepLike> | undefined): string[] => {
       const loaded = new Set<string>([...seedGroups, ...this.loadedGroupsFromSteps(steps)]);
-      const active = canonicalizeToolSet(
-        this.allTools,
-        this.invalidTool,
-        this.activeNamesFor(loaded),
-      ).activeTools;
+      const activeNames = this.activeNamesFor(loaded);
+      for (const name of requiredNames) activeNames.add(name);
+      const active = canonicalizeToolSet(this.allTools, this.invalidTool, activeNames).activeTools;
       turn.active = new Set(active);
       return active;
     };

--- a/packages/runtime/src/tool-runtime.ts
+++ b/packages/runtime/src/tool-runtime.ts
@@ -34,6 +34,7 @@ import type {
 import { computerUseApprovalSummary } from '@maka/core';
 import type { SessionHeader } from '@maka/core/session';
 import type { ToolInvocationRecord } from '@maka/core/usage-stats/types';
+import type { EffectiveOrchestration } from '@maka/core/orchestration';
 import { redactSecrets } from '@maka/core/redaction';
 import { TOOL_BOUNDARY_PROTOCOL_V1, type RuntimeEvent } from '@maka/core';
 
@@ -104,6 +105,8 @@ export interface MakaTool<P = any, R = unknown> {
   executionFacts?: ToolExecutionFacts;
   /** Crash-recovery contract used by the durable tool boundary. */
   recoveryMode?: ToolRecoveryMode;
+  /** Step-level admission contract. Exclusive tools cannot share an assistant step. */
+  executionSemantics?: 'parallel' | 'exclusive_step';
   /** Optional permission/persistence projection derived from isolated execution args. */
   permissionArgs?: (
     args: P,
@@ -241,6 +244,8 @@ export interface ToolRuntimeInput {
    * (legacy per-turn behavior).
    */
   getCurrentStepId?: () => string | undefined;
+  /** Effective orchestration for the active send; undefined between turns. */
+  getCurrentOrchestration?: () => EffectiveOrchestration | undefined;
   spawnChildAgent?: (input: {
     parentRunId: string;
     spec: AgentSpec;
@@ -320,6 +325,10 @@ export class ToolRuntime {
   private readonly recentSandboxDenials = new Set<string>();
   private readonly autoReviewEscalationAttempts = new Map<string, 'pending' | 'denied'>();
   private readonly durableToolAttempts = new Map<string, DurableToolAttempt>();
+  private readonly stepAdmissions = new Map<
+    string,
+    { callCount: number; exclusiveToolName?: string }
+  >();
   private readonly approvalCoordinator: ApprovalCoordinator;
 
   constructor(private readonly input: ToolRuntimeInput) {
@@ -398,6 +407,7 @@ export class ToolRuntime {
     this.recentSandboxDenials.clear();
     this.autoReviewEscalationAttempts.clear();
     this.durableToolAttempts.clear();
+    this.stepAdmissions.clear();
   }
 
   /**
@@ -463,6 +473,10 @@ export class ToolRuntime {
   ): Promise<unknown> {
     const executionArgs = snapshotToolArgs(args);
     const toolUseId = ctx.toolCallId;
+    const stepId = this.input.getCurrentStepId?.();
+    // Registration is synchronous and happens before the first await, so
+    // parallel AI SDK execute callbacks cannot race past exclusive admission.
+    const admissionFailure = this.admitToolForStep(tool, stepId);
     let permissionArgs = executionArgs;
     let permissionArgsError: unknown;
     try {
@@ -486,7 +500,6 @@ export class ToolRuntime {
     const toolIntent = describeToolIntent(tool, persistedArgs);
     const trace = this.input.getRunTrace?.() ?? null;
 
-    const stepId = this.input.getCurrentStepId?.();
     const runId = this.input.getCurrentRunId?.();
     const invocationId = this.input.getCurrentInvocationId?.() ?? runId;
     if (this.input.runtimeCommitSink && !runId) {
@@ -536,6 +549,18 @@ export class ToolRuntime {
       ...(tool.categoryHint !== undefined ? { categoryHint: tool.categoryHint } : {}),
     });
     const callSignature = `${tool.name} ${loopGateArgsKey(executionArgs, toolUseId)}`;
+    if (admissionFailure) {
+      await this.writeSyntheticToolResult(toolUseId, turnId, admissionFailure, queue);
+      trace?.emit('tool', 'tool_failed', 'Tool rejected by exclusive-step admission', {
+        toolUseId,
+        toolName: tool.name,
+        stepId,
+        status: 'error',
+        errorClass: 'ExclusiveStepConflict',
+      });
+      this.recordLoopGateOutcome(callSignature, true);
+      return this.errorReturn(admissionFailure);
+    }
     const computerSemanticSignature =
       tool.categoryHint === 'computer_use'
         ? computerUseSemanticSignature(permissionArgs)
@@ -784,9 +809,10 @@ export class ToolRuntime {
       this.autoReviewEscalationAttempts.set(autoReviewEscalationKey, 'pending');
     }
 
+    const permissionRules = this.permissionRulesFor(tool.name);
     if (
       tool.permissionRequired !== false ||
-      (this.input.permissionRules?.length ?? 0) > 0 ||
+      permissionRules.length > 0 ||
       additionalPlan.kind === 'request' ||
       escalationPlan.kind === 'request'
     ) {
@@ -799,9 +825,7 @@ export class ToolRuntime {
         ...(tool.categoryHint !== undefined ? { categoryHint: tool.categoryHint } : {}),
         ...(tool.executionFacts !== undefined ? { executionFacts: tool.executionFacts } : {}),
         permissionRequired: tool.permissionRequired !== false,
-        ...(this.input.permissionRules !== undefined
-          ? { permissionRules: this.input.permissionRules }
-          : {}),
+        ...(permissionRules.length > 0 ? { permissionRules } : {}),
         ...(tool.sandbox !== undefined
           ? {
               sandbox:
@@ -1033,6 +1057,12 @@ export class ToolRuntime {
           toolName: tool.name,
           decision: 'allow',
           category: verdict.category,
+          ...(tool.name === 'agent_swarm'
+            ? {
+                authorizationSource:
+                  this.input.getCurrentOrchestration?.()?.agentSwarmAuthorization ?? 'none',
+              }
+            : {}),
         });
       }
     }
@@ -1588,6 +1618,31 @@ export class ToolRuntime {
         return committedOutcome;
       },
     };
+  }
+
+  private admitToolForStep(tool: MakaTool, stepId: string | undefined): string | undefined {
+    if (!stepId) return undefined;
+    const existing = this.stepAdmissions.get(stepId) ?? { callCount: 0 };
+    const exclusive = tool.executionSemantics === 'exclusive_step';
+    if (existing.exclusiveToolName) {
+      return `Tool ${tool.name} cannot share an assistant step with exclusive tool ${existing.exclusiveToolName}. Retry it in a separate step.`;
+    }
+    if (exclusive && existing.callCount > 0) {
+      return `Exclusive tool ${tool.name} cannot share an assistant step with other tool calls. Retry it in a separate step.`;
+    }
+    existing.callCount += 1;
+    if (exclusive) existing.exclusiveToolName = tool.name;
+    this.stepAdmissions.set(stepId, existing);
+    return undefined;
+  }
+
+  private permissionRulesFor(toolName: string): ToolPermissionRule[] {
+    const rules = [...(this.input.permissionRules ?? [])];
+    const authorization = this.input.getCurrentOrchestration?.()?.agentSwarmAuthorization;
+    if (toolName === 'agent_swarm' && authorization && authorization !== 'none') {
+      rules.push({ effect: 'allow', kind: 'tool', toolName: 'agent_swarm' });
+    }
+    return rules;
   }
 
   private async awaitPermissionDecision(

--- a/packages/storage/src/__tests__/session-store.test.ts
+++ b/packages/storage/src/__tests__/session-store.test.ts
@@ -42,6 +42,7 @@ describe('FileSessionStore CRUD', () => {
 
       assert.equal(header.status, 'active');
       assert.equal(header.collaborationMode, 'agent');
+      assert.equal(header.orchestrationMode, 'default');
       assert.equal(typeof header.statusUpdatedAt, 'number');
       const [summary] = await store.list();
       assert.equal(summary?.status, 'active');
@@ -49,6 +50,15 @@ describe('FileSessionStore CRUD', () => {
       assert.equal(summary?.model, 'fake-model');
       assert.equal(summary?.cwd, '/tmp/cwd');
       assert.equal(summary?.collaborationMode, 'agent');
+      assert.equal(summary?.orchestrationMode, 'default');
+    });
+  });
+
+  test('persists a requested orchestration mode in headers and summaries', async () => {
+    await withStore(async (store) => {
+      const header = await store.create(makeInput({ orchestrationMode: 'swarm' }));
+      assert.equal(header.orchestrationMode, 'swarm');
+      assert.equal((await store.list())[0]?.orchestrationMode, 'swarm');
     });
   });
 
@@ -371,9 +381,11 @@ describe('FileSessionStore CRUD', () => {
       assert.equal(header.permissionMode, 'ask');
       assert.equal(header.status, 'active');
       assert.equal(header.titleIsManual, true);
+      assert.equal(header.orchestrationMode, 'default');
       const [summary] = await store.list();
       assert.equal(summary?.permissionMode, 'ask');
       assert.equal(summary?.status, 'active');
+      assert.equal(summary?.orchestrationMode, 'default');
     });
   });
 

--- a/packages/storage/src/session-store.ts
+++ b/packages/storage/src/session-store.ts
@@ -13,6 +13,7 @@ import {
   DEFAULT_SESSION_NAME,
   deriveTurnRecords,
   isCollaborationMode,
+  isOrchestrationMode,
   isPermissionMode,
   isSessionBlockedReason,
   isSessionStatus,
@@ -116,6 +117,7 @@ class FileSessionStore implements SessionStore {
       model: input.model ?? 'default',
       permissionMode: input.permissionMode,
       collaborationMode: input.collaborationMode ?? 'agent',
+      orchestrationMode: input.orchestrationMode ?? 'default',
       ...(input.thinkingLevel !== undefined ? { thinkingLevel: input.thinkingLevel } : {}),
       schemaVersion: 1,
     };
@@ -550,6 +552,7 @@ type StoredSessionHeader = Omit<
   | 'model'
   | 'permissionMode'
   | 'collaborationMode'
+  | 'orchestrationMode'
   | 'status'
   | 'blockedReason'
   | 'titleIsManual'
@@ -558,6 +561,7 @@ type StoredSessionHeader = Omit<
   model?: unknown;
   permissionMode?: unknown;
   collaborationMode?: unknown;
+  orchestrationMode?: unknown;
   status?: unknown;
   blockedReason?: unknown;
   titleIsManual?: unknown;
@@ -586,6 +590,9 @@ function migrateHeader(header: StoredSessionHeader, sessionId: string): SessionH
   const collaborationMode = isCollaborationMode(header.collaborationMode)
     ? header.collaborationMode
     : 'agent';
+  const orchestrationMode = isOrchestrationMode(header.orchestrationMode)
+    ? header.orchestrationMode
+    : 'default';
   const model =
     typeof header.model === 'string' && header.model.length > 0 ? header.model : 'default';
   const status = resolveMigratedStatus(header);
@@ -617,6 +624,7 @@ function migrateHeader(header: StoredSessionHeader, sessionId: string): SessionH
         model,
         permissionMode,
         collaborationMode,
+        orchestrationMode,
       },
       sessionId,
     );
@@ -631,6 +639,7 @@ function migrateHeader(header: StoredSessionHeader, sessionId: string): SessionH
         model,
         permissionMode,
         collaborationMode,
+        orchestrationMode,
       },
       sessionId,
     );
@@ -645,6 +654,7 @@ function migrateHeader(header: StoredSessionHeader, sessionId: string): SessionH
         model,
         permissionMode,
         collaborationMode,
+        orchestrationMode,
       },
       sessionId,
     );
@@ -658,6 +668,7 @@ function migrateHeader(header: StoredSessionHeader, sessionId: string): SessionH
       model,
       permissionMode,
       collaborationMode,
+      orchestrationMode,
     },
     sessionId,
   );
@@ -698,6 +709,7 @@ function normalizeMigratedHeader(header: SessionHeader, sessionId: string): Sess
     typeof header.model === 'string' &&
     isPermissionMode(header.permissionMode) &&
     isCollaborationMode(header.collaborationMode) &&
+    isOrchestrationMode(header.orchestrationMode) &&
     header.schemaVersion === 1;
   if (!valid) {
     throw new Error(`Invalid session header for session ${sessionId}: malformed fields`);
@@ -748,6 +760,7 @@ function toSummary(header: SessionHeader, messages: StoredMessage[] = []): Sessi
     model: header.model,
     permissionMode: header.permissionMode,
     collaborationMode: header.collaborationMode ?? 'agent',
+    orchestrationMode: header.orchestrationMode ?? 'default',
     ...(header.thinkingLevel !== undefined ? { thinkingLevel: header.thinkingLevel } : {}),
   };
 }


### PR DESCRIPTION
## Summary

Adds the host-independent Runtime contract for first-class Swarm Mode, the first delivery from #1324.

Maka already has the bounded `agent_swarm` engine. This PR adds the orchestration policy layer that can persist a session default, accept a trusted one-turn override, and carry the effective contract through the full AgentRun/backend/resume path.

## What changed

- Add `OrchestrationMode = 'default' | 'swarm'`, trusted turn overrides, validators, and legacy `default` fallback.
- Persist the session mode in headers/summaries and snapshot effective mode, source, and Swarm authorization into each `AgentRun`.
- Preserve the exact source-run envelope across safe-boundary continuation; force compact and child runs to `default` so authority is not inherited.
- Add the shared Runtime-owned `renderSwarmModePrompt()`.
- Pin `agent_swarm` into the step-0 active tool set during Swarm turns without disabling tool economy elsewhere.
- Add generic `executionSemantics: 'exclusive_step'` admission and apply it to `agent_swarm`.
- Add an exact, trusted `agent_swarm` allow rule for explicit Swarm Mode while preserving explicit-deny precedence and all child tool permission checks.
- Record orchestration and admission facts in run trace/evidence.
- Preserve orchestration mode when branching a session.

## Runtime guarantees

- Default mode remains backward compatible and opportunistic Swarm keeps its current approval behavior.
- A one-shot override does not mutate the session default.
- Mixed same-step calls cannot execute both `agent_swarm` and another tool.
- Swarm authorization applies only to the parent `agent_swarm` envelope.
- Child AgentRuns receive neither the Swarm prompt nor its authorization.
- Resume reuses the original effective contract rather than whatever mode the session has later.

## Verification

- `npm run build:test`
- `npm run typecheck`
- Core test suite: 1,142 passed
- Storage session-store suite: 50 passed, 1 skipped
- Runtime focused/integration suites for persistence, prompt injection, tool pinning, admission, authorization, child isolation, branch inheritance, and resume all pass
- Runtime full suite: all feature-related tests pass; two existing local macOS sandbox smoke checks remain environment-blocked by Homebrew executable/dynamic-library paths (`/usr/local` expectation and `pcre2` access)
- Targeted Biome format/lint and `git diff --check` pass

## Out of scope

No CLI `/swarm` parser or UX, Desktop toggle/badge, or Headless surface is included here. Those remain PR 2 and PR 3 from #1324.

Closes no issue; this is PR 1 of the staged implementation.
