### PR TITLE
feat(cli): add Swarm Mode commands

### DIFF
--- a/packages/cli/src/__tests__/pi-tui-runner.test.ts
+++ b/packages/cli/src/__tests__/pi-tui-runner.test.ts
@@ -11,6 +11,7 @@ import {
   SHELL_RUN_UPDATE_BUFFER_MAX_ENTRIES,
   type PermissionMode,
   type PermissionResponse,
+  type OrchestrationMode,
   type QueueEnqueueOutcome,
   type SessionEvent,
   type SessionSummary,
@@ -4201,17 +4202,18 @@ describe('Maka Pi TUI runner', () => {
 
     // The input surface did not shift while filtering.
     assert.deepEqual(afterRows, beforeRows);
-    // The 's' filter matches three commands — /session, /setup, /skill — bottom-
+    // The 's' filter matches four commands — /session, /setup, /skill, /swarm — bottom-
     // aligned immediately above the editor's top border. Scope to the overlay so
     // the empty-session home's /session /model /setup hints don't collide (#1098).
-    assert.equal(afterSuggestions.length, 3);
+    assert.equal(afterSuggestions.length, 4);
     assert.deepEqual(
       afterSuggestions.map((line) => line.match(/\/\w+/)?.[0]),
-      ['/session', '/setup', '/skill'],
+      ['/session', '/setup', '/skill', '/swarm'],
     );
-    assert.ok(afterLines[afterRows[0] - 1]!.includes('/skill'));
-    assert.ok(afterLines[afterRows[0] - 2]!.includes('/setup'));
-    assert.ok(afterLines[afterRows[0] - 3]!.includes('/session'));
+    assert.ok(afterLines[afterRows[0] - 1]!.includes('/swarm'));
+    assert.ok(afterLines[afterRows[0] - 2]!.includes('/skill'));
+    assert.ok(afterLines[afterRows[0] - 3]!.includes('/setup'));
+    assert.ok(afterLines[afterRows[0] - 4]!.includes('/session'));
 
     exitMaka(terminal);
     await Promise.race([
@@ -4259,12 +4261,14 @@ describe('Maka Pi TUI runner', () => {
     const afterSessionRow = afterLines.findIndex((line) => line.includes('/session'));
     const afterSkillRow = afterLines.findIndex((line) => line.includes('/skill'));
     const afterSetupRow = afterLines.findIndex((line) => line.includes('/setup'));
+    const afterSwarmRow = afterLines.findIndex((line) => line.includes('/swarm'));
 
     assert.deepEqual(afterRows, beforeRows);
     assert.equal(afterRows[1], terminal.rows - 2);
-    assert.equal(afterSkillRow, afterRows[0] - 1);
-    assert.equal(afterSetupRow, afterRows[0] - 2);
-    assert.equal(afterSessionRow, afterRows[0] - 3);
+    assert.equal(afterSwarmRow, afterRows[0] - 1);
+    assert.equal(afterSkillRow, afterRows[0] - 2);
+    assert.equal(afterSetupRow, afterRows[0] - 3);
+    assert.equal(afterSessionRow, afterRows[0] - 4);
 
     exitMaka(terminal);
     await Promise.race([
@@ -4564,6 +4568,143 @@ describe('Maka Pi TUI runner', () => {
         throw new Error('TUI did not close during test cleanup');
       }),
     ]);
+  });
+
+  test('shows, enables, and disables persistent Swarm Mode without sending a prompt', async () => {
+    const terminal = new FakeTerminal();
+    const driver = new SlashCommandDriver();
+    const run = runMakaPiTui({
+      title: 'Maka',
+      driver,
+      cwd: '/repo',
+      model: 'deepseek-v4-flash',
+      connectionSlug: 'deepseek',
+      permissionMode: 'ask',
+      terminal,
+    });
+
+    terminal.input('/swarm');
+    terminal.input('\r');
+    await waitFor(() => terminal.output().includes('Swarm Mode is off'));
+
+    terminal.input('/swarm on');
+    terminal.input('\r');
+    await waitFor(() => driver.orchestrationModes.length === 1);
+    await waitFor(() => terminal.output().includes('Swarm Mode enabled'));
+    assert.ok(plainTerminalOutput(terminal.screenOutput()).includes('swarm'));
+
+    terminal.input('/swarm status');
+    terminal.input('\r');
+    await waitFor(() => terminal.output().includes('Swarm Mode is on'));
+
+    terminal.input('/swarm off');
+    terminal.input('\r');
+    await waitFor(() => driver.orchestrationModes.length === 2);
+    await waitFor(() => terminal.output().includes('Swarm Mode disabled'));
+
+    assert.deepEqual(driver.orchestrationModes, ['swarm', 'default']);
+    assert.deepEqual(driver.prompts, []);
+
+    exitMaka(terminal);
+    await run;
+  });
+
+  test('runs /swarm <task> as one trusted swarm turn with clean transcript text', async () => {
+    const terminal = new FakeTerminal();
+    const driver = new SlashCommandDriver();
+    const run = runMakaPiTui({
+      title: 'Maka',
+      driver,
+      cwd: '/repo',
+      model: 'deepseek-v4-flash',
+      connectionSlug: 'deepseek',
+      permissionMode: 'ask',
+      terminal,
+    });
+
+    terminal.input('/swarm inspect runtime, UI, and tests');
+    terminal.input('\r');
+    await waitFor(() => driver.prompts.length === 1);
+    await waitFor(() => terminal.output().includes('Using Swarm Mode for this turn only'));
+
+    assert.deepEqual(driver.displayPrompts, ['inspect runtime, UI, and tests']);
+    assert.deepEqual(driver.prompts, ['inspect runtime, UI, and tests']);
+    assert.deepEqual(driver.turnOrchestrations, [{ mode: 'swarm', source: 'slash_command' }]);
+    assert.deepEqual(driver.orchestrationModes, []);
+    const screen = plainTerminalOutput(terminal.screenOutput());
+    assert.ok(screen.includes('inspect runtime, UI, and tests'));
+    assert.equal(screen.includes('/swarm inspect runtime, UI, and tests'), false);
+
+    terminal.input('follow up normally');
+    terminal.input('\r');
+    await waitFor(() => driver.prompts.length === 2);
+    assert.deepEqual(driver.turnOrchestrations, [
+      { mode: 'swarm', source: 'slash_command' },
+      undefined,
+    ]);
+
+    exitMaka(terminal);
+    await run;
+  });
+
+  test('rejects Swarm commands during a running turn instead of steering them', async () => {
+    const terminal = new FakeTerminal();
+    const driver = new SteeringTurnDriver();
+    const run = runMakaPiTui({
+      title: 'Maka',
+      driver,
+      cwd: '/repo',
+      model: 'deepseek-v4-flash',
+      connectionSlug: 'deepseek',
+      permissionMode: 'ask',
+      terminal,
+    });
+
+    terminal.input('keep working');
+    terminal.input('\r');
+    await waitFor(() => terminal.progressStates.at(-1) === true);
+
+    terminal.input('/swarm on');
+    terminal.input('\r');
+    await waitFor(() =>
+      terminal.output().includes('Cannot change or start Swarm Mode while a turn is running.'),
+    );
+    assert.deepEqual(driver.steered, []);
+
+    terminal.input('\x03');
+    await waitFor(() => driver.stopCalls === 1);
+    exitMaka(terminal);
+    await run;
+  });
+
+  test('cancelling a one-shot Swarm turn leaves the persistent mode off', async () => {
+    const terminal = new FakeTerminal();
+    const driver = new SteeringTurnDriver();
+    const run = runMakaPiTui({
+      title: 'Maka',
+      driver,
+      cwd: '/repo',
+      model: 'deepseek-v4-flash',
+      connectionSlug: 'deepseek',
+      permissionMode: 'ask',
+      terminal,
+    });
+
+    terminal.input('/swarm investigate broadly');
+    terminal.input('\r');
+    await waitFor(() => terminal.progressStates.at(-1) === true);
+    assert.deepEqual(driver.turnOrchestrations, [{ mode: 'swarm', source: 'slash_command' }]);
+
+    terminal.input('\x03');
+    await waitFor(() => driver.stopCalls === 1);
+    await waitFor(() => terminal.progressStates.at(-1) === false);
+
+    terminal.input('/swarm status');
+    terminal.input('\r');
+    await waitFor(() => terminal.output().includes('Swarm Mode is off'));
+
+    exitMaka(terminal);
+    await run;
   });
 
   test('handles /thinking high without sending a prompt', async () => {
@@ -8316,7 +8457,9 @@ describe('Maka Pi TUI runner', () => {
 
   test('resumes a session at startup via resumeSessionId', async () => {
     const terminal = new FakeTerminal();
-    const driver = new SlashCommandDriver([fakeSessionSummary('session-2', '/repo')]);
+    const driver = new SlashCommandDriver([
+      { ...fakeSessionSummary('session-2', '/repo'), orchestrationMode: 'swarm' },
+    ]);
     const run = runMakaPiTui({
       title: 'Maka',
       driver,
@@ -8333,6 +8476,11 @@ describe('Maka Pi TUI runner', () => {
 
     assert.deepEqual(driver.sessionIds, ['session-2']);
     assert.deepEqual(driver.prompts, []);
+    assert.ok(plainTerminalOutput(terminal.screenOutput()).includes('swarm'));
+
+    terminal.input('/swarm status');
+    terminal.input('\r');
+    await waitFor(() => terminal.output().includes('Swarm Mode is on for this session.'));
 
     exitMaka(terminal);
     await Promise.race([
@@ -8723,6 +8871,7 @@ class SteeringTurnDriver implements MakaSessionDriver {
   stopCalls = 0;
   readonly steered: string[] = [];
   readonly queuedMessages: string[] = [];
+  readonly turnOrchestrations: Array<MakaPreparePromptOptions['turnOrchestration']> = [];
   retractCalls = 0;
   private steering: string[] = [];
   private followup: string[] = [];
@@ -8740,6 +8889,7 @@ class SteeringTurnDriver implements MakaSessionDriver {
     options: MakaPreparePromptOptions = {},
   ): Promise<MakaPreparedSessionTurn> {
     const turnId = options.turnId ?? 'turn-1';
+    this.turnOrchestrations.push(options.turnOrchestration);
     return Promise.resolve({
       sessionId: this.getSessionId(),
       turnId,
@@ -9599,12 +9749,15 @@ class SlashCommandDriver implements MakaSessionDriver {
   readonly modelConnections: Array<string | undefined> = [];
   readonly permissionModes: PermissionMode[] = [];
   readonly thinkingLevelUpdates: Array<ThinkingLevel | undefined> = [];
+  readonly orchestrationModes: OrchestrationMode[] = [];
+  readonly turnOrchestrations: Array<MakaPreparePromptOptions['turnOrchestration']> = [];
   readonly sessionIds: string[] = [];
   readonly renames: string[] = [];
   readonly moves: string[] = [];
   startNewSessionCalls = 0;
   resumeCalls = 0;
   protected sessionId = 'session-1';
+  protected orchestrationMode: OrchestrationMode = 'default';
 
   constructor(
     private readonly sessions: SessionSummary[] = [fakeSessionSummary('session-2', '/repo')],
@@ -9623,6 +9776,7 @@ class SlashCommandDriver implements MakaSessionDriver {
     const modelText = options.modelText ?? prompt;
     this.displayPrompts.push(prompt);
     this.prompts.push(modelText);
+    this.turnOrchestrations.push(options.turnOrchestration);
     return Promise.resolve({
       sessionId: this.sessionId,
       turnId,
@@ -9700,11 +9854,16 @@ class SlashCommandDriver implements MakaSessionDriver {
   async setThinkingLevel(level: ThinkingLevel | undefined): Promise<void> {
     this.thinkingLevelUpdates.push(level);
   }
+  async setOrchestrationMode(mode: OrchestrationMode): Promise<void> {
+    this.orchestrationModes.push(mode);
+    this.orchestrationMode = mode;
+  }
   async switchSession(sessionId: string): Promise<MakaSessionSwitchResult> {
     this.sessionIds.push(sessionId);
     this.sessionId = sessionId;
     const summary = this.sessions.find((session) => session.id === sessionId);
     const nextSummary = summary ?? fakeSessionSummary(sessionId);
+    this.orchestrationMode = nextSummary.orchestrationMode ?? 'default';
     return switchResult(nextSummary, [...(this.sessionMessages.get(nextSummary.id) ?? [])]);
   }
   async listRewindTargets(): Promise<RewindTarget[]> {
@@ -9719,6 +9878,9 @@ class SlashCommandDriver implements MakaSessionDriver {
   }
   getSessionId(): string | null {
     return this.sessionId;
+  }
+  getOrchestrationMode(): OrchestrationMode {
+    return this.orchestrationMode;
   }
 }
 

--- a/packages/cli/src/__tests__/pi-tui-turn.test.ts
+++ b/packages/cli/src/__tests__/pi-tui-turn.test.ts
@@ -15,7 +15,10 @@ describe('Maka Pi TUI turn', () => {
         async preparePrompt(prompt, options) {
           sequence.push('prepare');
           assert.equal(prompt, 'visible prompt');
-          assert.deepEqual(options, { modelText: 'expanded prompt' });
+          assert.deepEqual(options, {
+            modelText: 'expanded prompt',
+            turnOrchestration: { mode: 'swarm', source: 'slash_command' },
+          });
           return preparedTurn([
             event({
               type: 'text_delta',
@@ -49,6 +52,7 @@ describe('Maka Pi TUI turn', () => {
         prompt: 'visible prompt',
         sendText: 'expanded prompt',
         sessionId: null,
+        turnOrchestration: { mode: 'swarm', source: 'slash_command' },
       },
       shouldAbort: () => false,
       onStart: () => {

--- a/packages/cli/src/__tests__/session-driver.test.ts
+++ b/packages/cli/src/__tests__/session-driver.test.ts
@@ -136,6 +136,75 @@ describe('Maka session driver', () => {
     ]);
   });
 
+  test('uses an updated orchestration mode for a new session', async () => {
+    const runtime = new RecordingRuntime();
+    const driver = createMakaSessionDriver({
+      runtime,
+      cwd: '/repo',
+      llmConnectionSlug: 'anthropic',
+      model: 'claude-sonnet-4-5',
+    });
+
+    await driver.setOrchestrationMode?.('swarm');
+    await collectPrompt(driver, 'analyze in parallel');
+
+    assert.equal(driver.getOrchestrationMode?.(), 'swarm');
+    assert.equal(runtime.created[0]?.orchestrationMode, 'swarm');
+  });
+
+  test('updates orchestration mode on an active session', async () => {
+    const runtime = new RecordingRuntime();
+    const driver = createMakaSessionDriver({
+      runtime,
+      cwd: '/repo',
+      llmConnectionSlug: 'anthropic',
+      model: 'claude-sonnet-4-5',
+    });
+
+    await collectPrompt(driver, 'start');
+    await driver.setOrchestrationMode?.('swarm');
+    await driver.setOrchestrationMode?.('default');
+
+    assert.deepEqual(runtime.orchestrationModes, [
+      { sessionId: 'session-1', mode: 'swarm' },
+      { sessionId: 'session-1', mode: 'default' },
+    ]);
+    assert.equal(driver.getOrchestrationMode?.(), 'default');
+  });
+
+  test('passes a one-turn swarm override as trusted metadata without changing visible text', async () => {
+    const runtime = new RecordingRuntime();
+    const driver = createMakaSessionDriver({
+      runtime,
+      cwd: '/repo',
+      llmConnectionSlug: 'anthropic',
+      model: 'claude-sonnet-4-5',
+      newId: nextId('turn'),
+    });
+
+    await collect(
+      (
+        await driver.preparePrompt('inspect runtime, UI, and tests', {
+          turnOrchestration: { mode: 'swarm', source: 'slash_command' },
+        })
+      ).events,
+    );
+    await collectPrompt(driver, 'summarize normally');
+
+    assert.deepEqual(
+      runtime.sent.map(({ input }) => input),
+      [
+        {
+          turnId: 'turn-1',
+          text: 'inspect runtime, UI, and tests',
+          turnOrchestration: { mode: 'swarm', source: 'slash_command' },
+        },
+        { turnId: 'turn-2', text: 'summarize normally' },
+      ],
+    );
+    assert.equal(driver.getOrchestrationMode?.(), 'default');
+  });
+
   test('uses an updated model for a new session', async () => {
     const runtime = new RecordingRuntime();
     const driver = createMakaSessionDriver({
@@ -380,6 +449,7 @@ describe('Maka session driver', () => {
           connectionLocked: false,
           model: 'claude-opus-4-1',
           permissionMode: 'execute',
+          orchestrationMode: 'swarm',
         },
       ];
       runtime.sessionMessages.set('session-2', [
@@ -401,8 +471,13 @@ describe('Maka session driver', () => {
         summary.messages.map((message) => message.id),
         ['user-1', 'assistant-1'],
       );
-      assert.deepEqual(runtime.created, []);
+      assert.equal(runtime.created.length, 0);
       assert.equal(runtime.sent[0]?.sessionId, 'session-2');
+      assert.equal(driver.getOrchestrationMode?.(), 'swarm');
+
+      driver.startNewSession();
+      await collectPrompt(driver, 'new session keeps swarm');
+      assert.equal(runtime.created[0]?.orchestrationMode, 'swarm');
     } finally {
       await rm(repo, { recursive: true, force: true });
     }
@@ -805,7 +880,9 @@ describe('Maka session driver', () => {
     const repo = await mkdtemp(join(tmpdir(), 'maka-rewind-cwd-'));
     try {
       const runtime = new RecordingRuntime();
-      runtime.sessionSummaries = [sessionSummary({ id: 'session-1', cwd: repo })];
+      runtime.sessionSummaries = [
+        sessionSummary({ id: 'session-1', cwd: repo, orchestrationMode: 'swarm' }),
+      ];
       runtime.sessionMessages.set('session-1', [
         storedUserMessage('user-1', 'turn-1', 'first question'),
         storedAssistantMessage('assistant-1', 'turn-1', 'first answer'),
@@ -830,6 +907,7 @@ describe('Maka session driver', () => {
       assert.equal(result.summary.id, 'session-1-branch');
       assert.equal(result.prompt, 'second question\nwith detail');
       assert.equal(driver.getSessionId(), 'session-1-branch');
+      assert.equal(driver.getOrchestrationMode?.(), 'swarm');
     } finally {
       await rm(repo, { recursive: true, force: true });
     }
@@ -940,6 +1018,10 @@ class RecordingRuntime {
   readonly permissionResponses: Array<{ sessionId: string; response: PermissionResponse }> = [];
   readonly userQuestionResponses: Array<{ sessionId: string; response: UserQuestionResponse }> = [];
   readonly permissionModes: Array<{ sessionId: string; mode: PermissionMode }> = [];
+  readonly orchestrationModes: Array<{
+    sessionId: string;
+    mode: import('@maka/core/orchestration').OrchestrationMode;
+  }> = [];
   readonly sessionUpdates: Array<{
     sessionId: string;
     patch: {
@@ -1099,6 +1181,17 @@ class RecordingRuntime {
       connectionLocked: false,
       model: 'claude-sonnet-4-5',
       permissionMode: mode,
+    };
+  }
+
+  async setOrchestrationMode(
+    sessionId: string,
+    mode: import('@maka/core/orchestration').OrchestrationMode,
+  ): Promise<SessionSummary> {
+    this.orchestrationModes.push({ sessionId, mode });
+    return {
+      ...sessionSummary({ id: sessionId }),
+      orchestrationMode: mode,
     };
   }
 

--- a/packages/cli/src/__tests__/swarm-command.test.ts
+++ b/packages/cli/src/__tests__/swarm-command.test.ts
@@ -1,0 +1,31 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+import { parseSwarmCommand } from '../swarm-command.js';
+
+describe('/swarm parser', () => {
+  test('parses bare and explicit status commands', () => {
+    assert.deepEqual(parseSwarmCommand('/swarm'), { kind: 'status' });
+    assert.deepEqual(parseSwarmCommand('  /swarm status  '), { kind: 'status' });
+  });
+
+  test('parses persistent mode changes only when the whole tail matches', () => {
+    assert.deepEqual(parseSwarmCommand('/swarm on'), { kind: 'set_mode', mode: 'swarm' });
+    assert.deepEqual(parseSwarmCommand('/swarm off'), { kind: 'set_mode', mode: 'default' });
+    assert.deepEqual(parseSwarmCommand('/swarm on the repository'), {
+      kind: 'run_once',
+      task: 'on the repository',
+    });
+  });
+
+  test('preserves a one-shot task as clean user text', () => {
+    assert.deepEqual(parseSwarmCommand('/swarm inspect runtime, UI, and tests'), {
+      kind: 'run_once',
+      task: 'inspect runtime, UI, and tests',
+    });
+  });
+
+  test('does not claim lookalike slash commands', () => {
+    assert.equal(parseSwarmCommand('/swarming now'), null);
+    assert.equal(parseSwarmCommand('please /swarm this'), null);
+  });
+});

--- a/packages/cli/src/pi-transcript.ts
+++ b/packages/cli/src/pi-transcript.ts
@@ -174,6 +174,7 @@ export interface MakaPiTranscriptMetadata {
   model: string;
   connectionSlug: string;
   permissionMode: string;
+  orchestrationMode?: 'default' | 'swarm';
   thinkingLevel?: ThinkingLevel;
   thinkingLevels?: readonly ThinkingLevel[];
   sessionId?: string | null;
@@ -1253,6 +1254,9 @@ export function renderMakaPiStatusLine(metadata: MakaPiTranscriptMetadata, width
   // changes the level. Only a non-default, explicitly set level shows.
   if (metadata.thinkingLevel) {
     parts.push(ansi.dim(`thinking:${metadata.thinkingLevel}`));
+  }
+  if (metadata.orchestrationMode === 'swarm') {
+    parts.push(ansi.accent('swarm'));
   }
   const usage = metadata.usage;
   if (usage) {

--- a/packages/cli/src/pi-tui-pickers.ts
+++ b/packages/cli/src/pi-tui-pickers.ts
@@ -251,7 +251,7 @@ export interface MakaSlashCommandMetadata {
 }
 
 export interface MakaSlashCommand extends MakaSlashCommandMetadata {
-  run(parts: string[], rawTail?: string): void;
+  run(parts: string[], rawTail: string | undefined, context: { idleMs: number }): void;
   /** Alternate names that dispatch to this command without appearing in
    *  completion or the /help menu (e.g. /quit as an alias of /exit). */
   aliases?: readonly string[];

--- a/packages/cli/src/pi-tui-runner.ts
+++ b/packages/cli/src/pi-tui-runner.ts
@@ -20,6 +20,7 @@ import {
   type ThinkingLevel,
 } from '@maka/core/model-thinking';
 import { type ModelInfo, type ProviderType } from '@maka/core/llm-connections';
+import type { OrchestrationMode } from '@maka/core/orchestration';
 import {
   ShellRunUpdateBuffer,
   mergeShellRunUpdate,
@@ -51,6 +52,7 @@ import {
 } from '@maka/runtime';
 import { MakaSkillHighlightEditor } from './skill-highlight-editor.js';
 import { parseSkillInvocationTokens, stripSkillInvocationTokens } from './skill-token.js';
+import { parseSwarmCommand, type ParsedSwarmCommand } from './swarm-command.js';
 import type { CliGoalTurnHost } from './cli-goal-continuation.js';
 import {
   inspectSessionResumeAvailability,
@@ -194,6 +196,7 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
   let providerType = input.providerType;
   let modelContextWindow = input.modelContextWindow;
   let permissionMode = input.permissionMode;
+  let orchestrationMode = input.driver.getOrchestrationMode?.() ?? 'default';
   let thinkingLevel: ThinkingLevel | undefined = undefined;
   let thinkingLevels: readonly ThinkingLevel[] = providerType
     ? thinkingVariantsForModel(providerType, input.model)
@@ -261,6 +264,7 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
     model,
     connectionSlug,
     permissionMode,
+    orchestrationMode,
     thinkingLevel,
     thinkingLevels,
     sessionId: input.driver.getSessionId(),
@@ -731,7 +735,7 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
     // to (not including) this very submission.
     const idleMs = Date.now() - lastActivityAt;
     editor.addToHistory(prompt);
-    if (handleSlashCommand(prompt)) return;
+    if (handleSlashCommand(prompt, idleMs)) return;
     // First-run has no connection, so the wizard is the only surface. This is
     // the single choke point for idle submits (Enter, Alt+Enter, steer
     // fallback): reopen the wizard instead of opening a turn against a
@@ -946,6 +950,21 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
       // input routing): check it before handing off to steering.
       if (isExitPrompt(prompt)) {
         beginGracefulClose();
+        return;
+      }
+      const swarmCommand = parseSwarmCommand(prompt);
+      if (swarmCommand) {
+        editor.addToHistory(prompt);
+        if (swarmCommand.kind === 'status') {
+          showSwarmStatus();
+        } else {
+          state.entries.push({
+            kind: 'notice',
+            level: 'error',
+            text: 'Cannot change or start Swarm Mode while a turn is running.',
+          });
+          requestRender();
+        }
         return;
       }
       steerRunningTurn(prompt);
@@ -1201,6 +1220,7 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
       modelContextWindow = undefined;
     }
     permissionMode = summary.permissionMode;
+    orchestrationMode = summary.orchestrationMode ?? 'default';
     thinkingLevel = summary.thinkingLevel;
     thinkingLevels = providerType ? thinkingVariantsForModel(providerType, summary.model) : [];
     refreshEditorCwd?.(cwd);
@@ -1387,7 +1407,7 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
     if (!providerType || !wizard) return;
     if (apiKey.startsWith('/')) {
       closeWizard();
-      handleSlashCommand(apiKey);
+      handleSlashCommand(apiKey, 0);
       return;
     }
     if (!input.onboarding) {
@@ -1984,6 +2004,61 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
     requestRender();
   };
 
+  const showSwarmStatus = () => {
+    state.entries.push({
+      kind: 'notice',
+      level: 'info',
+      text:
+        orchestrationMode === 'swarm'
+          ? 'Swarm Mode is on for this session.'
+          : 'Swarm Mode is off. The main agent may still use agent_swarm opportunistically.',
+    });
+    requestRender();
+  };
+
+  const setSwarmMode = async (mode: OrchestrationMode) => {
+    if (!input.driver.setOrchestrationMode) {
+      throw new Error('Swarm Mode is unavailable on this session driver.');
+    }
+    await input.driver.setOrchestrationMode(mode);
+    orchestrationMode = mode;
+    state.entries.push({
+      kind: 'notice',
+      level: 'info',
+      text: mode === 'swarm' ? 'Swarm Mode enabled for this session.' : 'Swarm Mode disabled.',
+    });
+    requestRender();
+  };
+
+  const runSwarmCommand = (command: ParsedSwarmCommand, idleMs: number) => {
+    if (command.kind === 'status') {
+      showSwarmStatus();
+      return;
+    }
+    if (command.kind === 'set_mode') {
+      void runControl(() => setSwarmMode(command.mode));
+      return;
+    }
+    if (input.firstRun) {
+      void showSetupWizard();
+      return;
+    }
+    lastActivityAt = Date.now();
+    promptSeq += 1;
+    maybeTriggerAutoRecap(idleMs);
+    state.entries.push({
+      kind: 'notice',
+      level: 'info',
+      text: 'Using Swarm Mode for this turn only.',
+    });
+    void runAgentTurn({
+      kind: 'external',
+      prompt: command.task,
+      sessionId: input.driver.getSessionId(),
+      turnOrchestration: { mode: 'swarm', source: 'slash_command' },
+    });
+  };
+
   const moveSession = async (targetCwd: string): Promise<void> => {
     if (!input.driver.moveSession) {
       state.entries.push({
@@ -2301,9 +2376,17 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
         void runControl(() => switchSession(sessionId));
       },
     },
+    {
+      name: 'swarm',
+      description: 'Show, enable, disable, or run one Swarm turn',
+      run: (_parts: string[], rawTail: string | undefined, context: { idleMs: number }) => {
+        const parsed = parseSwarmCommand(`/swarm${rawTail ? ` ${rawTail}` : ''}`);
+        if (parsed) runSwarmCommand(parsed, context.idleMs);
+      },
+    },
   ].sort((left, right) => left.name.localeCompare(right.name));
 
-  const handleSlashCommand = (prompt: string): boolean => {
+  const handleSlashCommand = (prompt: string, idleMs: number): boolean => {
     const trimmed = prompt.trim();
     const commandToken = trimmed.split(/\s+/, 1)[0] ?? '';
     const command = slashCommands.find(
@@ -2313,7 +2396,7 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
     );
     if (!command) return false;
     const rawTail = trimmed.slice(commandToken.length).trimStart();
-    command.run(trimmed.split(/\s+/), rawTail);
+    command.run(trimmed.split(/\s+/), rawTail, { idleMs });
     return true;
   };
 

--- a/packages/cli/src/pi-tui-turn.ts
+++ b/packages/cli/src/pi-tui-turn.ts
@@ -1,4 +1,5 @@
 import type { SessionEvent } from '@maka/core';
+import type { TurnOrchestration } from '@maka/core/runtime-inputs';
 import {
   drainGoalTurn,
   type GoalExternalTurnStart,
@@ -22,6 +23,8 @@ export type MakaPiTuiTurnRequest =
       sendText?: string;
       /** Session observed before preparation; null is valid for the first turn. */
       sessionId: string | null;
+      /** Trusted one-turn orchestration override supplied by a host command. */
+      turnOrchestration?: TurnOrchestration;
     }
   | {
       kind: 'coordinator';
@@ -80,6 +83,9 @@ export async function runMakaPiTuiTurn(input: RunMakaPiTuiTurnInput): Promise<Go
       ...(request.kind === 'coordinator' ? { turnId: request.turnId } : {}),
       ...(request.kind === 'external' && request.sendText !== undefined
         ? { modelText: request.sendText }
+        : {}),
+      ...(request.kind === 'external' && request.turnOrchestration
+        ? { turnOrchestration: request.turnOrchestration }
         : {}),
     });
     preparedTurnId = turn.turnId;

--- a/packages/cli/src/session-driver.ts
+++ b/packages/cli/src/session-driver.ts
@@ -10,8 +10,10 @@ import type { UserQuestionResponse } from '@maka/core/user-question';
 import type {
   BranchFromTurnInput,
   CreateSessionInput,
+  TurnOrchestration,
   UserMessageInput,
 } from '@maka/core/runtime-inputs';
+import type { OrchestrationMode } from '@maka/core/orchestration';
 import type { SessionSummary, StoredMessage } from '@maka/core/session';
 import { userFacingText } from '@maka/core/session';
 import type { ThinkingLevel } from '@maka/core/model-thinking';
@@ -47,6 +49,7 @@ export interface MakaSessionRuntime {
   respondToPermission(sessionId: string, response: PermissionResponse): Promise<void>;
   respondToUserQuestion?(sessionId: string, response: UserQuestionResponse): Promise<void>;
   setPermissionMode(sessionId: string, mode: PermissionMode): Promise<SessionSummary>;
+  setOrchestrationMode(sessionId: string, mode: OrchestrationMode): Promise<SessionSummary>;
   updateSession(
     sessionId: string,
     patch: {
@@ -87,6 +90,7 @@ export interface MakaSessionDriverInput {
   llmConnectionSlug: string;
   model: string;
   permissionMode?: PermissionMode;
+  orchestrationMode?: OrchestrationMode;
   newId?: () => string;
   inspectCwdChanges?: InspectCwdChanges;
 }
@@ -107,6 +111,8 @@ export interface MakaPreparePromptOptions {
   turnId?: string;
   /** Model-facing text when it differs from the prompt shown to the user. */
   modelText?: string;
+  /** Trusted per-turn orchestration override; never encoded into prompt text. */
+  turnOrchestration?: TurnOrchestration;
 }
 
 export interface MakaSessionDriver {
@@ -145,6 +151,8 @@ export interface MakaSessionDriver {
   setModel(model: string, connectionSlug?: string): Promise<void>;
   setThinkingLevel(level: ThinkingLevel | undefined): Promise<void>;
   setPermissionMode(mode: PermissionMode): Promise<void>;
+  /** Available on Runtime-backed drivers; optional for lightweight host adapters. */
+  setOrchestrationMode?(mode: OrchestrationMode): Promise<void>;
   renameSession(name: string): Promise<string | void>;
   moveSession?(cwd: string): Promise<MakaSessionMoveResult>;
   switchSession(sessionId: string): Promise<MakaSessionSwitchResult>;
@@ -160,6 +168,7 @@ export interface MakaSessionDriver {
   startNewSession(): void;
   stop(): Promise<void>;
   getSessionId(): string | null;
+  getOrchestrationMode?(): OrchestrationMode;
 }
 
 export type SessionResumeAvailability = { available: true } | { available: false; reason: string };
@@ -196,6 +205,7 @@ class RuntimeMakaSessionDriver implements MakaSessionDriver {
   private llmConnectionSlug: string;
   private thinkingLevel: ThinkingLevel | undefined;
   private permissionMode: PermissionMode;
+  private orchestrationMode: OrchestrationMode;
   private pendingCwdReminder: { from: string; to: string } | undefined;
   private readonly newId: () => string;
 
@@ -205,6 +215,7 @@ class RuntimeMakaSessionDriver implements MakaSessionDriver {
     this.model = input.model;
     this.llmConnectionSlug = input.llmConnectionSlug;
     this.permissionMode = input.permissionMode ?? 'ask';
+    this.orchestrationMode = input.orchestrationMode ?? 'default';
   }
 
   async preparePrompt(
@@ -222,6 +233,7 @@ class RuntimeMakaSessionDriver implements MakaSessionDriver {
       turnId,
       text: modelText,
       ...(modelText !== prompt ? { displayText: prompt } : {}),
+      ...(options.turnOrchestration ? { turnOrchestration: options.turnOrchestration } : {}),
     });
     return {
       sessionId,
@@ -376,6 +388,15 @@ class RuntimeMakaSessionDriver implements MakaSessionDriver {
     this.permissionMode = mode;
   }
 
+  async setOrchestrationMode(mode: OrchestrationMode): Promise<void> {
+    if (this.sessionId) {
+      const summary = await this.input.runtime.setOrchestrationMode(this.sessionId, mode);
+      this.orchestrationMode = summary.orchestrationMode ?? mode;
+      return;
+    }
+    this.orchestrationMode = mode;
+  }
+
   async renameSession(name: string): Promise<string> {
     if (!this.sessionId) throw new Error('Cannot rename before a session starts.');
     return (await this.input.runtime.updateSession(this.sessionId, { name })).name;
@@ -419,6 +440,7 @@ class RuntimeMakaSessionDriver implements MakaSessionDriver {
     this.llmConnectionSlug = summary.llmConnectionSlug;
     this.thinkingLevel = summary.thinkingLevel;
     this.permissionMode = summary.permissionMode;
+    this.orchestrationMode = summary.orchestrationMode ?? 'default';
     return { summary, messages };
   }
 
@@ -478,6 +500,10 @@ class RuntimeMakaSessionDriver implements MakaSessionDriver {
     return this.sessionId;
   }
 
+  getOrchestrationMode(): OrchestrationMode {
+    return this.orchestrationMode;
+  }
+
   private async ensureSession(): Promise<string> {
     if (this.sessionId) return this.sessionId;
     const session = await this.input.runtime.createSession({
@@ -487,6 +513,9 @@ class RuntimeMakaSessionDriver implements MakaSessionDriver {
       llmConnectionSlug: this.llmConnectionSlug,
       model: this.model,
       permissionMode: this.permissionMode,
+      ...(this.orchestrationMode !== 'default'
+        ? { orchestrationMode: this.orchestrationMode }
+        : {}),
       ...(this.thinkingLevel !== undefined ? { thinkingLevel: this.thinkingLevel } : {}),
     });
     this.sessionId = session.id;

--- a/packages/cli/src/swarm-command.ts
+++ b/packages/cli/src/swarm-command.ts
@@ -1,0 +1,19 @@
+import type { OrchestrationMode } from '@maka/core/orchestration';
+
+export type ParsedSwarmCommand =
+  | { kind: 'status' }
+  | { kind: 'set_mode'; mode: OrchestrationMode }
+  | { kind: 'run_once'; task: string };
+
+/** Parse the CLI's exact `/swarm` command without treating lookalike prompts as commands. */
+export function parseSwarmCommand(input: string): ParsedSwarmCommand | null {
+  const trimmed = input.trim();
+  const commandToken = trimmed.split(/\s+/, 1)[0] ?? '';
+  if (commandToken !== '/swarm') return null;
+
+  const tail = trimmed.slice(commandToken.length).trim();
+  if (!tail || tail === 'status') return { kind: 'status' };
+  if (tail === 'on') return { kind: 'set_mode', mode: 'swarm' };
+  if (tail === 'off') return { kind: 'set_mode', mode: 'default' };
+  return { kind: 'run_once', task: tail };
+}


### PR DESCRIPTION
## Summary

Implements the CLI slice of Swarm Mode from #1324, on top of the Runtime orchestration contract merged in #1325.

- adds `/swarm` and `/swarm status` for the current session state
- adds persistent `/swarm on` and `/swarm off`
- adds one-shot `/swarm <task>` execution
- carries one-shot mode as trusted `turnOrchestration` metadata instead of prompt text
- shows mode-change and one-shot notices, plus a `swarm` status-line marker
- restores the persisted mode after session switching, startup `--resume`, and rewind/branch flows
- preserves the current mode when `/new` lazily creates the next session
- rejects mode changes and one-shot commands while a turn (including permission handoff) is active

## Semantics

A one-shot command displays and persists only `<task>` as the user message. The slash command itself is not injected into model text.

The override applies to exactly that turn. Normal follow-up turns do not inherit it. If the turn is interrupted, Runtime safe-boundary resume retains the original Run envelope from #1325.

Persistent mode remains session state until `/swarm off`. Default mode remains opportunistic: the main agent may still call `agent_swarm` under the existing approval policy.

## Verification

- `npm --workspace maka-agent test` — 642 tests passed
- targeted Biome check for all changed CLI files
- `git diff --check`

Includes parser, driver, turn-envelope, transcript, cancellation, active-turn rejection, session lifecycle, and startup-resume coverage.

Closes the PR2 portion of #1324. Desktop UX remains for the next PR.