### PR TITLE
feat: resume durable child runs in agent swarm

### DIFF
--- a/apps/desktop/src/main/session-stream.ts
+++ b/apps/desktop/src/main/session-stream.ts
@@ -254,6 +254,9 @@ export function createAiSdkBackendFactory(deps: AiSdkBackendFactoryDeps): Backen
       agentTeam,
       toolAvailability: backendToolAvailability,
       spawnChildAgent: (input) => getRuntime().spawnChildAgent(ctx.sessionId, input),
+      prepareChildAgentResume: (sourceRunId) =>
+        getRuntime().prepareChildAgentResume(ctx.sessionId, sourceRunId),
+      resumeChildAgent: (input) => getRuntime().resumeChildAgent(ctx.sessionId, input),
       listChildAgents: () => getRuntime().listChildAgents(ctx.sessionId),
       readChildAgentOutput: (input) => getRuntime().readChildAgentOutput(ctx.sessionId, input),
       providerOptions: buildProviderOptions(connection, model, ctx.header.thinkingLevel),

--- a/docs/agent-swarm.md
+++ b/docs/agent-swarm.md
@@ -20,7 +20,7 @@ It is intentionally a structured-concurrency convenience over existing child
 | One specialist result, or the next task depends on the previous result | `agent_spawn` sequentially | The dependency is explicit and each result can refine the next prompt. |
 | Several finite, independent items with one final synthesis | `agent_swarm` | Bounded worker-pool execution, stable ordered results, and isolated failures. |
 | Durable ownership, task claiming, or worker communication | Agent Team | Members have roles, mailbox collaboration, and Task Ledger coordination. |
-| DAG dependencies, retries, resume, dynamic expansion, or distributed execution | Rive | Workflow state and recovery need a durable orchestration authority. |
+| DAG dependencies, retry policies, arbitrary workflow resume, dynamic expansion, or distributed execution | Rive | Workflow state and recovery need a durable orchestration authority. |
 
 The main Agent should call Swarm deliberately. The runtime does not infer that a
 request is parallelizable and does not automatically fan work out.
@@ -31,13 +31,61 @@ One call accepts `1..32` items. Local concurrency defaults to `3` and is capped
 at `5`. The entire input is validated before any child starts. Results retain
 input order even when children finish out of order.
 
-The input has two mutually exclusive forms. Callers may provide the explicit
+New work has two mutually exclusive forms. Callers may provide the explicit
 structured items shown below, or use a homogeneous template batch with one
 shared `profile`, a `prompt_template` containing `{{item}}`, and string
 `items`. Template batches replace every placeholder occurrence, reject
 duplicate expanded tasks, generate stable ordered IDs (`item-1`, `item-2`,
 ...), and then enter the same preflight and execution path as explicit items.
 They are input shorthand, not a separate scheduler.
+
+Either form may also include `resume_run_ids`, a map from an existing child
+`runId` to the new prompt that should continue it. A call may contain only
+resumes. Resume entries count toward the same 32-item bound, are presented
+before new items in map insertion order, and use the same local and shared
+concurrency limits as newly spawned children.
+
+## Resuming child runs
+
+Resume creates a fresh child `AgentRun` whose durable lineage names the source
+in `resumedFromRunId`. It replays the complete RuntimeEvent history of that
+source and its resume ancestors, then sends the new prompt. It does not mutate
+or restart the original run, and it does not approximate continuation by
+concatenating a summary into a fresh prompt.
+
+The runtime preflights every resume entry before any resumed or new child
+starts. Resume fails closed unless all of these invariants hold:
+
+- the source and every resume ancestor are built-in child runs in this session;
+- every run has the same Agent profile and current backend, connection, model,
+  working directory, and child permission mode;
+- every RuntimeEvent ledger has a valid terminal fact and a user-anchored,
+  model-replayable history with no indeterminate tool boundary;
+- the immediate source does not already have a resume successor.
+
+Completed, failed, and cancelled child runs may be continued. Each source has
+at most one direct successor, while that successor may itself be resumed to
+form an auditable linear chain. The API deliberately uses `resume_run_ids`
+rather than `resume_agent_ids`: built-in `agentId`s identify reusable profiles
+such as `local-read`, while `runId`s identify the unique execution and history
+being continued.
+
+```ts
+agent_swarm({
+  resume_run_ids: {
+    "child-run-123": "Re-check the failing assertion and propose the smallest fix.",
+    "child-run-456": "Continue from your findings and inspect the UI projection."
+  },
+  items: [
+    {
+      item_id: "fresh-review",
+      profile: "local_read",
+      task: "Independently review the updated cancellation invariant."
+    }
+  ],
+  max_concurrency: 3
+})
+```
 
 Three separate concurrency boundaries remain observable:
 

--- a/packages/cli/src/__tests__/pi-transcript-format.test.ts
+++ b/packages/cli/src/__tests__/pi-transcript-format.test.ts
@@ -16,6 +16,7 @@ test('formats an agent swarm with bounded child evidence references', () => {
         agentName: 'Local Read',
         turnId: 'turn-auth',
         runId: 'run-auth',
+        resumedFromRunId: 'run-auth-source',
         status: 'completed',
         summary: 'Auth boundaries are documented.',
         artifactIds: ['artifact-auth'],
@@ -39,11 +40,11 @@ test('formats an agent swarm with bounded child evidence references', () => {
     output,
     [
       'Agent swarm: partial · 2 items · 1 completed · 1 failed · 0 cancelled · 1 artifacts · 10ms',
-      'auth: completed · local_read · 1 artifacts · run run-auth · turn turn-auth\nAuth boundaries are documented.',
+      'auth: completed · local_read · 1 artifacts · resumed from run-auth-source · run run-auth · turn turn-auth\nAuth boundaries are documented.',
       'storage: failed · local_read · 0 artifacts\nStorage inspection failed.',
     ].join('\n\n'),
   );
-  assert.match(output, /run run-auth · turn turn-auth/);
+  assert.match(output, /resumed from run-auth-source · run run-auth · turn turn-auth/);
   assert.doesNotMatch(output, /artifact-auth|local-read/);
 });
 

--- a/packages/cli/src/pi-transcript-format.ts
+++ b/packages/cli/src/pi-transcript-format.ts
@@ -101,6 +101,7 @@ export function formatToolResultContent(content: ToolResultContent): string {
                 item.profile,
                 item.durationMs !== undefined ? `${item.durationMs}ms` : '',
                 `${item.artifactIds.length} artifacts`,
+                item.resumedFromRunId ? `resumed from ${item.resumedFromRunId}` : '',
                 item.runId ? `run ${item.runId}` : '',
                 item.turnId ? `turn ${item.turnId}` : '',
                 item.failureClass ?? '',

--- a/packages/cli/src/runtime-bootstrap.ts
+++ b/packages/cli/src/runtime-bootstrap.ts
@@ -604,6 +604,9 @@ export async function createMakaCliRuntimeContext(
       ...(input.surface === 'tui'
         ? {
             spawnChildAgent: (childInput) => runtime.spawnChildAgent(ctx.sessionId, childInput),
+            prepareChildAgentResume: (sourceRunId) =>
+              runtime.prepareChildAgentResume(ctx.sessionId, sourceRunId),
+            resumeChildAgent: (childInput) => runtime.resumeChildAgent(ctx.sessionId, childInput),
             listChildAgents: () => runtime.listChildAgents(ctx.sessionId),
             readChildAgentOutput: (childInput) =>
               runtime.readChildAgentOutput(ctx.sessionId, childInput),

--- a/packages/core/src/__tests__/agent-swarm-result.test.ts
+++ b/packages/core/src/__tests__/agent-swarm-result.test.ts
@@ -102,6 +102,7 @@ function agentSwarmResult(): Extract<ToolResultContent, { kind: 'agent_swarm' }>
         agentName: 'Local Read',
         turnId: 'turn-auth',
         runId: 'run-auth',
+        resumedFromRunId: 'run-auth-source',
         status: 'completed',
         summary: 'Auth boundaries are documented.',
         artifactIds: ['artifact-auth'],

--- a/packages/core/src/agent-run.ts
+++ b/packages/core/src/agent-run.ts
@@ -66,6 +66,8 @@ export interface AgentRunHeader {
   updatedAt: number;
   completedAt?: number;
   parentRunId?: string;
+  /** Immediate child AgentRun continued by this run. */
+  resumedFromRunId?: string;
   agentId?: string;
   agentName?: string;
   parentTurnId?: string;
@@ -170,6 +172,7 @@ const AGENT_RUN_HEADER_SHAPE = defineObjectShape<AgentRunHeader>()(
     'invocationId',
     'completedAt',
     'parentRunId',
+    'resumedFromRunId',
     'agentId',
     'agentName',
     'parentTurnId',
@@ -222,6 +225,7 @@ export function decodeAgentRunHeader(value: unknown): AgentRunHeader {
     (value.completedAt === undefined || isFiniteNumber(value.completedAt)) &&
     [
       value.parentRunId,
+      value.resumedFromRunId,
       value.agentId,
       value.agentName,
       value.parentTurnId,

--- a/packages/core/src/events.ts
+++ b/packages/core/src/events.ts
@@ -363,6 +363,7 @@ export type ToolResultContent =
         agentName?: string;
         turnId?: string;
         runId?: string;
+        resumedFromRunId?: string;
         status: 'completed' | 'failed' | 'cancelled';
         summary: string;
         artifactIds: readonly string[];

--- a/packages/core/src/runtime-inputs.ts
+++ b/packages/core/src/runtime-inputs.ts
@@ -55,6 +55,8 @@ export interface UserMessageInput {
   turnOrchestration?: TurnOrchestration;
   attachments?: AttachmentRef[];
   parentRunId?: string;
+  /** Child AgentRun whose durable conversation this child continues. */
+  resumedFromRunId?: string;
   agentId?: string;
   agentName?: string;
   parentTurnId?: string;
@@ -81,6 +83,8 @@ export interface ChildAgentTurnInput {
   parentRunId: string;
   spec: AgentSpec;
   prompt: string;
+  /** Trusted, preflighted child AgentRun whose RuntimeEvent history is replayed. */
+  resumedFromRunId?: string;
 }
 
 export interface RegenerateTurnInput {

--- a/packages/core/src/tool-result-record-schema.ts
+++ b/packages/core/src/tool-result-record-schema.ts
@@ -131,6 +131,7 @@ const AGENT_SWARM_ITEM_SHAPE = defineObjectShape<AgentSwarmItem>()(
     'agentName',
     'turnId',
     'runId',
+    'resumedFromRunId',
     'startedAt',
     'completedAt',
     'durationMs',
@@ -321,6 +322,7 @@ function isAgentSwarmItem(value: unknown): value is AgentSwarmItem {
     isOptionalString(value.agentName) &&
     isOptionalString(value.turnId) &&
     isOptionalString(value.runId) &&
+    isOptionalString(value.resumedFromRunId) &&
     ['completed', 'failed', 'cancelled'].includes(value.status as string) &&
     typeof value.summary === 'string' &&
     isStringArray(value.artifactIds) &&

--- a/packages/headless/src/harbor-cell.ts
+++ b/packages/headless/src/harbor-cell.ts
@@ -783,6 +783,12 @@ export function buildAiSdkCellBackendRegistration(input: {
         spawnChildAgent: context.spawnChildAgent
           ? (childInput) => context.spawnChildAgent!(ctx.sessionId, childInput)
           : undefined,
+        prepareChildAgentResume: context.prepareChildAgentResume
+          ? (sourceRunId) => context.prepareChildAgentResume!(ctx.sessionId, sourceRunId)
+          : undefined,
+        resumeChildAgent: context.resumeChildAgent
+          ? (childInput) => context.resumeChildAgent!(ctx.sessionId, childInput)
+          : undefined,
         listChildAgents: context.listChildAgents
           ? () => context.listChildAgents!(ctx.sessionId)
           : undefined,

--- a/packages/headless/src/session-capabilities.ts
+++ b/packages/headless/src/session-capabilities.ts
@@ -2,6 +2,8 @@ import type {
   AgentListResult,
   AgentOutputInput,
   AgentOutputResult,
+  PrepareChildAgentResumeResult,
+  ResumeChildAgentInput,
   SessionManager,
   SpawnChildAgentInput,
   SpawnChildAgentResult,
@@ -9,6 +11,11 @@ import type {
 
 export interface HeadlessSessionCapabilities {
   spawnChildAgent(sessionId: string, input: SpawnChildAgentInput): Promise<SpawnChildAgentResult>;
+  prepareChildAgentResume(
+    sessionId: string,
+    sourceRunId: string,
+  ): Promise<PrepareChildAgentResumeResult>;
+  resumeChildAgent(sessionId: string, input: ResumeChildAgentInput): Promise<SpawnChildAgentResult>;
   listChildAgents(sessionId: string): Promise<AgentListResult>;
   readChildAgentOutput(sessionId: string, input: AgentOutputInput): Promise<AgentOutputResult>;
 }
@@ -28,6 +35,10 @@ export function createHeadlessSessionCapabilityBridge(): {
     capabilities: {
       spawnChildAgent: async (sessionId, input) =>
         await requireManager().spawnChildAgent(sessionId, input),
+      prepareChildAgentResume: async (sessionId, sourceRunId) =>
+        await requireManager().prepareChildAgentResume(sessionId, sourceRunId),
+      resumeChildAgent: async (sessionId, input) =>
+        await requireManager().resumeChildAgent(sessionId, input),
       listChildAgents: async (sessionId) => await requireManager().listChildAgents(sessionId),
       readChildAgentOutput: async (sessionId, input) =>
         await requireManager().readChildAgentOutput(sessionId, input),

--- a/packages/runtime/src/__tests__/agent-swarm-tools.test.ts
+++ b/packages/runtime/src/__tests__/agent-swarm-tools.test.ts
@@ -237,6 +237,125 @@ describe('AgentSwarm adapter', () => {
     );
   });
 
+  test('accepts resume-only input and enforces the shared total item bound', () => {
+    const schema = buildAgentSwarmTool().parameters as {
+      safeParse(input: unknown): { success: boolean; data?: AgentSwarmToolInput };
+    };
+    expectSchemaSuccess(
+      schema.safeParse({
+        resume_run_ids: {
+          'run-a': 'Continue the runtime review.',
+          'run-b': 'Continue the UI review.',
+        },
+      }),
+      {
+        resume_run_ids: {
+          'run-a': 'Continue the runtime review.',
+          'run-b': 'Continue the UI review.',
+        },
+        max_concurrency: AGENT_SWARM_DEFAULT_CONCURRENCY,
+      },
+    );
+    assert.equal(
+      schema.safeParse({
+        items: Array.from({ length: AGENT_SWARM_MAX_ITEMS }, (_, index) => swarmItem(index)),
+        resume_run_ids: { extra: 'Continue.' },
+      }).success,
+      false,
+    );
+  });
+
+  test('preflights every resume before starting resumed or new child work', async () => {
+    let starts = 0;
+    const tool = buildAgentSwarmTool();
+    await assert.rejects(
+      Promise.resolve(
+        tool.impl(
+          {
+            resume_run_ids: {
+              'run-good': 'Continue good.',
+              'run-unsafe': 'Continue unsafe.',
+            },
+            items: [swarmItem(0)],
+          },
+          context({
+            prepareChildAgentResume: async (sourceRunId) => {
+              if (sourceRunId === 'run-unsafe') throw new Error('unsafe resume history');
+              return preparedResume(sourceRunId);
+            },
+            resumeChildAgent: async () => {
+              starts += 1;
+              return childResult(10);
+            },
+            spawnChildAgent: async () => {
+              starts += 1;
+              return childResult(0);
+            },
+          }),
+        ),
+      ),
+      /unsafe resume history/,
+    );
+    assert.equal(starts, 0);
+  });
+
+  test('orders resumed children before new items and preserves resume evidence', async () => {
+    const calls: string[] = [];
+    const tool = buildAgentSwarmTool();
+    const result = await tool.impl(
+      {
+        resume_run_ids: { 'source-run': 'Continue the source review.' },
+        items: [swarmItem(0)],
+        max_concurrency: 2,
+      },
+      context({
+        prepareChildAgentResume: async (sourceRunId) => preparedResume(sourceRunId),
+        resumeChildAgent: async (input) => {
+          calls.push(`resume:${input.sourceRunId}:${input.prompt}`);
+          await input.onReady?.({
+            turnId: 'turn-resumed',
+            agentId: 'local-read',
+            agentName: 'Local Read',
+          });
+          return {
+            ...childResult(10),
+            turnId: 'turn-resumed',
+            runId: 'new-run',
+            resumedFromRunId: input.sourceRunId,
+          };
+        },
+        spawnChildAgent: async (input) => {
+          calls.push(`spawn:${input.prompt}`);
+          await input.onReady?.({
+            turnId: 'turn-0',
+            agentId: input.spec.id,
+            agentName: input.spec.name,
+          });
+          return childResult(0);
+        },
+      }),
+    );
+
+    assert.deepEqual(calls, ['resume:source-run:Continue the source review.', 'spawn:task-0']);
+    assert.deepEqual(
+      result.items.map((item) => ({
+        itemId: item.itemId,
+        index: item.index,
+        runId: item.runId,
+        resumedFromRunId: item.resumedFromRunId,
+      })),
+      [
+        {
+          itemId: 'resume-1',
+          index: 0,
+          runId: 'new-run',
+          resumedFromRunId: 'source-run',
+        },
+        { itemId: 'item-0', index: 1, runId: 'run-0', resumedFromRunId: undefined },
+      ],
+    );
+  });
+
   test('fails at the tool boundary when child spawning is unavailable', async () => {
     const tool = buildAgentSwarmTool();
 
@@ -355,6 +474,7 @@ describe('AgentSwarm adapter', () => {
         cancelledItemCount: 0,
         artifactCount: 3,
         durationMs: 80,
+        resumedItemCount: 0,
       },
     );
   });
@@ -742,6 +862,23 @@ function childResult(
 function childResultForPrompt(prompt: string): SpawnChildAgentResult {
   const index = prompt === 'single' ? 99 : Number(prompt.slice('task-'.length));
   return childResult(index);
+}
+
+function preparedResume(sourceRunId: string) {
+  return {
+    sourceRunId,
+    agentId: 'local-read',
+    agentName: 'Local Read',
+    profile: LOCAL_READ_AGENT_PROFILE,
+  };
+}
+
+function expectSchemaSuccess(
+  parsed: { success: boolean; data?: AgentSwarmToolInput },
+  expected: AgentSwarmToolInput & { max_concurrency: number },
+): void {
+  assert.equal(parsed.success, true);
+  assert.deepEqual(parsed.data, expected);
 }
 
 function context(overrides: Partial<MakaToolContext> = {}): MakaToolContext {

--- a/packages/runtime/src/__tests__/session-manager.test.ts
+++ b/packages/runtime/src/__tests__/session-manager.test.ts
@@ -5986,6 +5986,148 @@ describe('SessionManager permission mode updates', () => {
     expect(result.artifactIds).toEqual(['artifact-1']);
   });
 
+  test('resumeChildAgent replays durable child history into a fresh lineage run', async () => {
+    const store = new MemorySessionStore();
+    const runStore = new MemoryAgentRunStore();
+    const backends = new BackendRegistry();
+    const childBackends: TestBackend[] = [];
+    backends.register('fake', (ctx) => {
+      const backend = new TestBackend(ctx);
+      if (ctx.systemPrompt) childBackends.push(backend);
+      return backend;
+    });
+    const manager = new SessionManager({
+      store,
+      runStore,
+      runtimeEventStore: runStore,
+      backends,
+      childTools: [testTool('Read'), testTool('Glob'), testTool('Grep')],
+      newId: nextId(),
+      now: nextNow(6_846),
+      runtimeSource: 'test',
+    });
+    const session = await manager.createSession(makeInput({ permissionMode: 'ask' }));
+    await drain(manager.sendMessage(session.id, { turnId: 'parent-turn', text: 'parent context' }));
+    const [parentRun] = await runStore.listSessionRuns(session.id);
+    if (!parentRun) throw new Error('parent run was not recorded');
+
+    const source = await manager.spawnChildAgent(session.id, {
+      turnId: 'child-source',
+      parentRunId: parentRun.runId,
+      spec: { id: LOCAL_READ_AGENT_ID, name: 'ignored', systemPrompt: 'ignored' },
+      prompt: 'inspect runtime',
+    });
+    if (!source.runId) throw new Error('source child run was not recorded');
+
+    expect(await manager.prepareChildAgentResume(session.id, source.runId)).toEqual({
+      sourceRunId: source.runId,
+      agentId: LOCAL_READ_AGENT_ID,
+      agentName: LOCAL_READ_AGENT_DEFINITION.name,
+      profile: LOCAL_READ_AGENT_DEFINITION.profile,
+    });
+    const resumed = await manager.resumeChildAgent(session.id, {
+      turnId: 'child-resumed',
+      parentRunId: parentRun.runId,
+      sourceRunId: source.runId,
+      prompt: 'continue with tests',
+    });
+
+    expect(resumed.resumedFromRunId).toBe(source.runId);
+    const resumedHeader = await runStore.readRun(session.id, resumed.runId!);
+    expect(resumedHeader).toMatchObject({
+      parentRunId: parentRun.runId,
+      resumedFromRunId: source.runId,
+      agentId: LOCAL_READ_AGENT_ID,
+      agentName: LOCAL_READ_AGENT_DEFINITION.name,
+    });
+    const resumedInput = childBackends[1]?.sendInputs[0];
+    expect(resumedInput?.text).toBe('continue with tests');
+    expect(resumedInput?.runtimeContext?.some((event) => event.runId === source.runId)).toBe(true);
+    expect(
+      resumedInput?.runtimeContext?.some(
+        (event) =>
+          event.role === 'user' &&
+          event.content?.kind === 'text' &&
+          event.content.text === 'inspect runtime',
+      ),
+    ).toBe(true);
+    await expectRejects(
+      manager.prepareChildAgentResume(session.id, source.runId),
+      /already has a resume successor/,
+    );
+    expect(await manager.prepareChildAgentResume(session.id, resumed.runId!)).toMatchObject({
+      sourceRunId: resumed.runId,
+    });
+  });
+
+  test('prepareChildAgentResume rejects an indeterminate child tool boundary', async () => {
+    const store = new MemorySessionStore();
+    const runStore = new MemoryAgentRunStore();
+    const backends = new BackendRegistry();
+    backends.register('fake', (ctx) => new TestBackend(ctx));
+    const manager = new SessionManager({
+      store,
+      runStore,
+      runtimeEventStore: runStore,
+      backends,
+      childTools: [testTool('Read'), testTool('Glob'), testTool('Grep')],
+      newId: nextId(),
+      now: nextNow(6_847),
+      runtimeSource: 'test',
+    });
+    const session = await manager.createSession(makeInput({ permissionMode: 'ask' }));
+    const child = makeRunHeader({
+      sessionId: session.id,
+      runId: 'unsafe-child',
+      turnId: 'unsafe-turn',
+      status: 'failed',
+      parentRunId: 'parent-run',
+      agentId: LOCAL_READ_AGENT_ID,
+      agentName: LOCAL_READ_AGENT_DEFINITION.name,
+      permissionMode: 'explore',
+      createdAt: 1,
+      updatedAt: 4,
+      completedAt: 4,
+    });
+    await seedRuntimeRun(runStore, child, [
+      runtimeEvent({
+        id: 'unsafe-user',
+        sessionId: session.id,
+        runId: child.runId,
+        turnId: child.turnId,
+        ts: 1,
+        role: 'user',
+        author: 'user',
+        content: { kind: 'text', text: 'inspect' },
+      }),
+      runtimeEvent({
+        id: 'unsafe-call',
+        sessionId: session.id,
+        runId: child.runId,
+        turnId: child.turnId,
+        ts: 2,
+        role: 'model',
+        author: 'agent',
+        content: { kind: 'function_call', id: 'read-1', name: 'Read', args: { path: 'x' } },
+        refs: { toolCallId: 'read-1', stepId: 'step-1' },
+      }),
+      runtimeEvent({
+        id: 'unsafe-terminal',
+        sessionId: session.id,
+        runId: child.runId,
+        turnId: child.turnId,
+        ts: 4,
+        status: 'failed',
+        actions: { endInvocation: true },
+      }),
+    ]);
+
+    await expectRejects(
+      manager.prepareChildAgentResume(session.id, child.runId),
+      /unmatched_tool_call/,
+    );
+  });
+
   test('the durable turn-ledger seam reaches parent runs but is withheld from child sessions', async () => {
     const store = new MemorySessionStore();
     const runStore = new MemoryAgentRunStore();

--- a/packages/runtime/src/agent-run.ts
+++ b/packages/runtime/src/agent-run.ts
@@ -82,6 +82,7 @@ export type AgentRunLineage = Partial<
   Pick<
     UserMessageInput,
     | 'parentRunId'
+    | 'resumedFromRunId'
     | 'parentTurnId'
     | 'retriedFromTurnId'
     | 'regeneratedFromTurnId'
@@ -206,6 +207,9 @@ export class AgentRun {
       );
     this.lineage = {
       ...(input.userInput.parentRunId ? { parentRunId: input.userInput.parentRunId } : {}),
+      ...(input.userInput.resumedFromRunId
+        ? { resumedFromRunId: input.userInput.resumedFromRunId }
+        : {}),
       ...(input.userInput.parentTurnId ? { parentTurnId: input.userInput.parentTurnId } : {}),
       ...(input.userInput.retriedFromTurnId
         ? { retriedFromTurnId: input.userInput.retriedFromTurnId }
@@ -962,6 +966,9 @@ export class AgentRun {
   }
 
   private async buildPriorRuntimeContext(): Promise<PriorRuntimeContext | undefined> {
+    if (this.lineage.resumedFromRunId) {
+      return await this.buildResumedChildRuntimeContext(this.lineage.resumedFromRunId);
+    }
     if (this.lineage.parentRunId) return undefined;
     if (
       !this.input.runStore ||
@@ -1040,6 +1047,89 @@ export class AgentRun {
     const runtimeReplayPlan = buildRuntimeEventModelReplayPlan(events);
     if (runtimeReplayPlan.items.length === 0) return undefined;
     return { events, runs: priorRuns };
+  }
+
+  private async buildResumedChildRuntimeContext(sourceRunId: string): Promise<PriorRuntimeContext> {
+    if (
+      !this.input.runStore ||
+      !this.input.runtimeEventStore ||
+      !this.runStoreAvailable ||
+      !this.runtimeEventStoreAvailable
+    ) {
+      throw new Error('Child AgentRun resume requires durable run and RuntimeEvent stores');
+    }
+
+    const sessionRuns = await this.input.runStore.listSessionRuns(this.sessionId);
+    const runsById = new Map(sessionRuns.map((run) => [run.runId, run]));
+    const reverseChain: AgentRunHeader[] = [];
+    const visited = new Set<string>();
+    let cursor: string | undefined = sourceRunId;
+    while (cursor) {
+      if (visited.has(cursor)) {
+        throw new Error(`Child AgentRun resume lineage contains a cycle at ${cursor}`);
+      }
+      visited.add(cursor);
+      const run = runsById.get(cursor);
+      if (!run) throw new Error(`Child AgentRun resume source ${cursor} was not found`);
+      if (!run.parentRunId || isSessionInlineRun(run)) {
+        throw new Error(`AgentRun ${cursor} is not a resumable child run`);
+      }
+      if (!run.agentId || run.agentId !== this.input.userInput.agentId) {
+        throw new Error(`Child AgentRun resume profile changed at ${cursor}`);
+      }
+      reverseChain.push(run);
+      cursor = run.resumedFromRunId;
+    }
+
+    const chain = reverseChain.reverse();
+    const effectiveRuns: AgentRunHeader[] = [];
+    const events: RuntimeEvent[] = [];
+    for (const run of chain) {
+      const loaded = await this.loadRequiredChildResumeContext(run);
+      effectiveRuns.push(loaded.run);
+      events.push(...loaded.events);
+    }
+
+    const replay = buildRuntimeEventModelReplayPlan(events);
+    const unsafe = replay.diagnostics.find(
+      (diagnostic) =>
+        diagnostic.code === 'unmatched_tool_call' ||
+        diagnostic.code === 'unmatched_tool_result' ||
+        diagnostic.code === 'tool_id_mismatch' ||
+        diagnostic.code === 'unsupported_role' ||
+        diagnostic.code === 'unsupported_content',
+    );
+    if (unsafe) {
+      throw new Error(`Child AgentRun resume history is unsafe: ${unsafe.code}`);
+    }
+    const first = replay.items[0];
+    if (!first || first.kind !== 'text' || first.role !== 'user') {
+      throw new Error('Child AgentRun resume history has no user-anchored replay boundary');
+    }
+    return { events, runs: effectiveRuns };
+  }
+
+  private async loadRequiredChildResumeContext(
+    run: AgentRunHeader,
+  ): Promise<{ events: RuntimeEvent[]; run: AgentRunHeader }> {
+    let events = await this.input.runtimeEventStore!.readRuntimeEvents(this.sessionId, run.runId);
+    if (events.length === 0 || !events.some(isTerminalRuntimeEvent)) {
+      if (await this.input.repairRunRuntimeLedger?.(this.sessionId, run.runId)) {
+        events = await this.input.runtimeEventStore!.readRuntimeEvents(this.sessionId, run.runId);
+      }
+    }
+    if (events.length === 0 || !events.some(isTerminalRuntimeEvent)) {
+      throw new Error(
+        `Child AgentRun resume source ${run.runId} has no terminal RuntimeEvent fact`,
+      );
+    }
+    const terminalFact = classifyRuntimeEventTerminalFact(run, events).fact;
+    if (!terminalFact) {
+      throw new Error(
+        `Child AgentRun resume source ${run.runId} has an invalid terminal RuntimeEvent fact`,
+      );
+    }
+    return { events, run: effectiveRunHeaderFromTerminalFact(run, terminalFact) };
   }
 
   private async readNonTerminalPriorRunWithTerminalFact(

--- a/packages/runtime/src/agent-swarm-tools.ts
+++ b/packages/runtime/src/agent-swarm-tools.ts
@@ -43,6 +43,7 @@ export interface AgentSwarmExplicitItemInput {
 
 export interface AgentSwarmExplicitToolInput {
   items: AgentSwarmExplicitItemInput[];
+  resume_run_ids?: Record<string, string>;
   max_concurrency?: number;
 }
 
@@ -50,10 +51,19 @@ export interface AgentSwarmTemplateToolInput {
   prompt_template: string;
   profile: string;
   items: string[];
+  resume_run_ids?: Record<string, string>;
   max_concurrency?: number;
 }
 
-export type AgentSwarmToolInput = AgentSwarmExplicitToolInput | AgentSwarmTemplateToolInput;
+export interface AgentSwarmResumeToolInput {
+  resume_run_ids: Record<string, string>;
+  max_concurrency?: number;
+}
+
+export type AgentSwarmToolInput =
+  | AgentSwarmExplicitToolInput
+  | AgentSwarmTemplateToolInput
+  | AgentSwarmResumeToolInput;
 
 export type AgentSwarmToolResult = Extract<ToolResultContent, { kind: 'agent_swarm' }>;
 
@@ -63,6 +73,15 @@ interface PreparedAgentSwarmItem {
   readonly profile: string;
   readonly task: string;
   readonly definition: AgentDefinition;
+  readonly mode: 'spawn' | 'resume';
+  readonly resumedFromRunId?: string;
+}
+
+interface PendingAgentSwarmResume {
+  readonly index: number;
+  readonly itemId: string;
+  readonly sourceRunId: string;
+  readonly task: string;
 }
 
 interface StartedChildRef {
@@ -81,6 +100,7 @@ export function buildAgentSwarmTool(
     description: [
       'Run the same kind of bounded foreground child work over several independent items.',
       `Provide either explicit structured items, or prompt_template with one shared profile and string items; every ${AGENT_SWARM_PROMPT_TEMPLATE_PLACEHOLDER} occurrence is replaced with the item value.`,
+      'Use resume_run_ids to continue terminal child AgentRuns by runId; resumed children are ordered before new items.',
       'Use this only when every item can run independently. Results return in input order; you remain responsible for semantic synthesis.',
     ].join(' '),
     parameters: agentSwarmInputSchema(),
@@ -88,14 +108,21 @@ export function buildAgentSwarmTool(
     executionSemantics: 'exclusive_step',
     categoryHint: 'subagent',
     impl: async (input, ctx) => {
-      const prepared = preflightAgentSwarmInput(input);
-      if (!ctx.spawnChildAgent) {
+      const prepared = await prepareAgentSwarmInput(input, ctx);
+      if (prepared.items.some((item) => item.mode === 'spawn') && !ctx.spawnChildAgent) {
         throw new Error('spawnChildAgent capability is unavailable in this runtime context');
+      }
+      if (
+        prepared.items.some((item) => item.mode === 'resume') &&
+        (!ctx.prepareChildAgentResume || !ctx.resumeChildAgent)
+      ) {
+        throw new Error('Child AgentRun resume capability is unavailable in this runtime context');
       }
 
       const startedAt = now();
       traceAgentSwarm(ctx, 'tool_started', 'batch_started', {
         itemCount: prepared.items.length,
+        resumedItemCount: prepared.items.filter((item) => item.mode === 'resume').length,
         maxConcurrency: prepared.maxConcurrency,
       });
       for (
@@ -108,6 +135,8 @@ export function buildAgentSwarmTool(
           itemId: item.itemId,
           index: item.index,
           profile: item.profile,
+          mode: item.mode,
+          ...(item.resumedFromRunId ? { resumedFromRunId: item.resumedFromRunId } : {}),
           boundary: 'local_swarm_concurrency',
         });
       }
@@ -124,6 +153,8 @@ export function buildAgentSwarmTool(
             itemId: item.itemId,
             index: item.index,
             profile: item.profile,
+            mode: item.mode,
+            ...(item.resumedFromRunId ? { resumedFromRunId: item.resumedFromRunId } : {}),
             boundary: 'local_swarm_concurrency',
           });
           ctx.emitOutput(
@@ -131,17 +162,24 @@ export function buildAgentSwarmTool(
             `Agent swarm item ${item.itemId} started: ${item.definition.name}\n`,
           );
           try {
-            const result = (await ctx.spawnChildAgent!({
-              spec: {
-                id: item.definition.id,
-                name: item.definition.name,
-                systemPrompt: item.definition.systemPrompt,
-              },
-              prompt: item.task,
-              onReady: ({ turnId, agentId, agentName }) => {
-                readyRefs[index] = { turnId, agentId, agentName };
-              },
-            })) as SpawnChildAgentResult;
+            const onReady = ({ turnId, agentId, agentName }: StartedChildRef) => {
+              readyRefs[index] = { turnId, agentId, agentName };
+            };
+            const result = (await (item.mode === 'resume'
+              ? ctx.resumeChildAgent!({
+                  sourceRunId: item.resumedFromRunId!,
+                  prompt: item.task,
+                  onReady,
+                })
+              : ctx.spawnChildAgent!({
+                  spec: {
+                    id: item.definition.id,
+                    name: item.definition.name,
+                    systemPrompt: item.definition.systemPrompt,
+                  },
+                  prompt: item.task,
+                  onReady,
+                }))) as SpawnChildAgentResult;
             childResults[index] = result;
             traceAgentSwarm(
               ctx,
@@ -151,6 +189,8 @@ export function buildAgentSwarmTool(
                 itemId: item.itemId,
                 index: item.index,
                 profile: item.profile,
+                mode: item.mode,
+                ...(item.resumedFromRunId ? { resumedFromRunId: item.resumedFromRunId } : {}),
                 status: result.status,
                 turnId: result.turnId,
                 ...(result.runId ? { runId: result.runId } : {}),
@@ -168,6 +208,8 @@ export function buildAgentSwarmTool(
               itemId: item.itemId,
               index: item.index,
               profile: item.profile,
+              mode: item.mode,
+              ...(item.resumedFromRunId ? { resumedFromRunId: item.resumedFromRunId } : {}),
               status: ctx.abortSignal.aborted ? 'cancelled' : 'failed',
               failureClass: boundedFailureClass(error, 'ChildAgentError'),
             });
@@ -200,6 +242,7 @@ export function buildAgentSwarmTool(
       };
       traceAgentSwarm(ctx, 'tool_completed', 'batch_completed', {
         ...projectAgentSwarmResult(result),
+        resumedItemCount: prepared.items.filter((item) => item.mode === 'resume').length,
       });
       return result;
     },
@@ -268,7 +311,7 @@ function agentSwarmInputSchema() {
 
   return z
     .object({
-      items: z.union([explicitItemsSchema, templateItemsSchema]),
+      items: z.union([explicitItemsSchema, templateItemsSchema]).optional(),
       prompt_template: z
         .string()
         .trim()
@@ -282,6 +325,10 @@ function agentSwarmInputSchema() {
         .enum(BUILTIN_AGENT_PROFILES)
         .optional()
         .describe('Shared child profile for prompt_template string items.'),
+      resume_run_ids: z
+        .record(z.string().trim().min(1), z.string().trim().min(1).max(AGENT_SWARM_TASK_MAX_CHARS))
+        .optional()
+        .describe('Map of terminal child AgentRun runId to its continuation prompt.'),
       max_concurrency: z
         .number()
         .int()
@@ -291,6 +338,39 @@ function agentSwarmInputSchema() {
         .describe('Maximum number of child items active inside this batch.'),
     })
     .superRefine((input, ctx) => {
+      const resumeCount = Object.keys(input.resume_run_ids ?? {}).length;
+      const itemCount = input.items?.length ?? 0;
+      if (resumeCount + itemCount < 1) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: 'Agent swarm requires at least one item or resume_run_ids entry.',
+        });
+      }
+      if (resumeCount + itemCount > AGENT_SWARM_MAX_ITEMS) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: `Agent swarm supports at most ${AGENT_SWARM_MAX_ITEMS} total items.`,
+        });
+      }
+
+      if (!input.items) {
+        if (input.prompt_template !== undefined) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            path: ['prompt_template'],
+            message: 'prompt_template requires string items.',
+          });
+        }
+        if (input.profile !== undefined) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            path: ['profile'],
+            message: 'profile requires string items.',
+          });
+        }
+        return;
+      }
+
       const templateItems = input.items.every((item) => typeof item === 'string');
       if (!templateItems) {
         if (input.prompt_template !== undefined) {
@@ -378,15 +458,60 @@ function addAgentContractIssues(input: AgentSwarmExplicitItemInput, ctx: z.Refin
   }
 }
 
-function preflightAgentSwarmInput(input: AgentSwarmToolInput): {
+async function prepareAgentSwarmInput(
+  input: AgentSwarmToolInput,
+  ctx: MakaToolContext,
+): Promise<{
   readonly items: readonly PreparedAgentSwarmItem[];
   readonly maxConcurrency: number;
-} {
-  if (!Array.isArray(input.items) || input.items.length < 1) {
-    throw new Error('Agent swarm requires at least one item.');
+}> {
+  const preflight = preflightAgentSwarmInput(input);
+  if (preflight.items.length > 0 && !ctx.spawnChildAgent) {
+    throw new Error('spawnChildAgent capability is unavailable in this runtime context');
   }
-  if (input.items.length > AGENT_SWARM_MAX_ITEMS) {
-    throw new Error(`Agent swarm supports at most ${AGENT_SWARM_MAX_ITEMS} items.`);
+  if (preflight.resumes.length > 0 && (!ctx.prepareChildAgentResume || !ctx.resumeChildAgent)) {
+    throw new Error('Child AgentRun resume capability is unavailable in this runtime context');
+  }
+  const resumes = await Promise.all(
+    preflight.resumes.map(async (item): Promise<PreparedAgentSwarmItem> => {
+      const prepared = await ctx.prepareChildAgentResume!(item.sourceRunId);
+      if (prepared.sourceRunId !== item.sourceRunId) {
+        throw new Error(`Child AgentRun resume identity changed for ${item.sourceRunId}`);
+      }
+      const definition = requireBuiltinAgentDefinitionByProfile(prepared.profile);
+      if (definition.id !== prepared.agentId || definition.name !== prepared.agentName) {
+        throw new Error(`Child AgentRun resume profile changed for ${item.sourceRunId}`);
+      }
+      return {
+        index: item.index,
+        itemId: item.itemId,
+        profile: definition.profile,
+        task: item.task,
+        definition,
+        mode: 'resume',
+        resumedFromRunId: item.sourceRunId,
+      };
+    }),
+  );
+  return {
+    items: [...resumes, ...preflight.items],
+    maxConcurrency: preflight.maxConcurrency,
+  };
+}
+
+function preflightAgentSwarmInput(input: AgentSwarmToolInput): {
+  readonly items: readonly PreparedAgentSwarmItem[];
+  readonly resumes: readonly PendingAgentSwarmResume[];
+  readonly maxConcurrency: number;
+} {
+  const resumeEntries = Object.entries(input.resume_run_ids ?? {});
+  const explicitItems = normalizeAgentSwarmItems(input);
+  const totalItems = resumeEntries.length + explicitItems.length;
+  if (totalItems < 1) {
+    throw new Error('Agent swarm requires at least one item or resume_run_ids entry.');
+  }
+  if (totalItems > AGENT_SWARM_MAX_ITEMS) {
+    throw new Error(`Agent swarm supports at most ${AGENT_SWARM_MAX_ITEMS} total items.`);
   }
   const maxConcurrency = input.max_concurrency ?? AGENT_SWARM_DEFAULT_CONCURRENCY;
   if (
@@ -399,7 +524,24 @@ function preflightAgentSwarmInput(input: AgentSwarmToolInput): {
     );
   }
 
-  const explicitItems = normalizeAgentSwarmItems(input);
+  const resumes = resumeEntries.map(([sourceRunId, prompt], index): PendingAgentSwarmResume => {
+    if (sourceRunId.trim().length < 1) {
+      throw new Error(`Agent swarm resume entry ${index} has an invalid runId.`);
+    }
+    if (
+      typeof prompt !== 'string' ||
+      prompt.trim().length < 1 ||
+      prompt.trim().length > AGENT_SWARM_TASK_MAX_CHARS
+    ) {
+      throw new Error(`Agent swarm resume entry ${sourceRunId} has an invalid prompt.`);
+    }
+    return {
+      index,
+      itemId: `resume-${index + 1}`,
+      sourceRunId: sourceRunId.trim(),
+      task: prompt.trim(),
+    };
+  });
   const seen = new Set<string>();
   const items = explicitItems.map((item, index): PreparedAgentSwarmItem => {
     if (!isSafeTaskId(item.item_id)) {
@@ -437,17 +579,24 @@ function preflightAgentSwarmInput(input: AgentSwarmToolInput): {
     }
 
     return {
-      index,
+      index: resumes.length + index,
       itemId: item.item_id,
       profile: definition.profile,
       task: item.task,
       definition,
+      mode: 'spawn',
     };
   });
-  return { items, maxConcurrency };
+  return { items, resumes, maxConcurrency };
 }
 
 function normalizeAgentSwarmItems(input: AgentSwarmToolInput): AgentSwarmExplicitItemInput[] {
+  if (!('items' in input) || !input.items) {
+    if ('prompt_template' in input || 'profile' in input) {
+      throw new Error('prompt_template and shared profile require string items.');
+    }
+    return [];
+  }
   const stringItemCount = input.items.filter((item) => typeof item === 'string').length;
   if (stringItemCount === 0) {
     if ('prompt_template' in input || 'profile' in input) {
@@ -520,6 +669,7 @@ function mapAgentSwarmItem(
       index: row.index,
       profile: item.profile,
       started: ready !== undefined,
+      ...(item.resumedFromRunId ? { resumedFromRunId: item.resumedFromRunId } : {}),
       ...(ready ?? {}),
       status: 'failed',
       summary: boundedSwarmError(row.reason),
@@ -535,6 +685,7 @@ function mapAgentSwarmItem(
     index: row.index,
     profile: item.profile,
     started: ready !== undefined,
+    ...(item.resumedFromRunId ? { resumedFromRunId: item.resumedFromRunId } : {}),
     ...(ready ?? {}),
     status: 'cancelled',
     summary: ready
@@ -559,6 +710,7 @@ function mapChildResult(
     agentName: result.agentName,
     turnId: result.turnId,
     ...(result.runId ? { runId: result.runId } : {}),
+    ...(item.resumedFromRunId ? { resumedFromRunId: item.resumedFromRunId } : {}),
     status,
     summary: result.summary,
     artifactIds: result.artifactIds,

--- a/packages/runtime/src/ai-sdk-backend.ts
+++ b/packages/runtime/src/ai-sdk-backend.ts
@@ -103,6 +103,7 @@ import {
   type MakaTool,
   type MakaToolContext,
   type AgentTeamExecutionContext,
+  type ToolRuntimeInput,
   type ToolModelOutput,
 } from './tool-runtime.js';
 import type { RuntimeCommitSink } from './runtime-commit-sink.js';
@@ -541,6 +542,8 @@ export interface AiSdkBackendInput {
     }) => void | Promise<void>;
     onEvent?: (event: SessionEvent) => void;
   }) => Promise<unknown>;
+  prepareChildAgentResume?: ToolRuntimeInput['prepareChildAgentResume'];
+  resumeChildAgent?: ToolRuntimeInput['resumeChildAgent'];
   listChildAgents?: () => Promise<unknown>;
   readChildAgentOutput?: (input: {
     runId?: string;
@@ -757,6 +760,8 @@ export class AiSdkBackend implements AgentBackend {
       getCurrentOrchestration: () => this.currentOrchestration,
       permissionRules: input.permissionRules,
       spawnChildAgent: input.spawnChildAgent,
+      prepareChildAgentResume: input.prepareChildAgentResume,
+      resumeChildAgent: input.resumeChildAgent,
       listChildAgents: input.listChildAgents,
       readChildAgentOutput: input.readChildAgentOutput,
       getRunTrace: () => this.currentRunTrace,

--- a/packages/runtime/src/execution-inspect.ts
+++ b/packages/runtime/src/execution-inspect.ts
@@ -37,6 +37,7 @@ export interface AgentRunInspectIdentity {
   invocationId?: string;
   turnId: string;
   parentRunId?: string;
+  resumedFromRunId?: string;
   parentTurnId?: string;
   agentId?: string;
   status: AgentRunHeader['status'];
@@ -236,6 +237,7 @@ function inspectIdentity(header: AgentRunHeader): AgentRunInspectIdentity {
     ...(header.invocationId ? { invocationId: header.invocationId } : {}),
     turnId: header.turnId,
     ...(header.parentRunId ? { parentRunId: header.parentRunId } : {}),
+    ...(header.resumedFromRunId ? { resumedFromRunId: header.resumedFromRunId } : {}),
     ...(header.parentTurnId ? { parentTurnId: header.parentTurnId } : {}),
     ...(header.agentId ? { agentId: header.agentId } : {}),
     status: header.status,

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -22,6 +22,8 @@ export type {
   StrictRecoveryStores,
   BackendFactory,
   BackendFactoryContext,
+  PrepareChildAgentResumeResult,
+  ResumeChildAgentInput,
   SpawnChildAgentInput,
   SpawnChildAgentResult,
   AgentListItem,
@@ -492,6 +494,7 @@ export {
 export type {
   AgentSwarmExplicitItemInput,
   AgentSwarmExplicitToolInput,
+  AgentSwarmResumeToolInput,
   AgentSwarmTemplateToolInput,
   AgentSwarmToolInput,
   AgentSwarmToolResult,

--- a/packages/runtime/src/runtime-kernel.ts
+++ b/packages/runtime/src/runtime-kernel.ts
@@ -556,6 +556,7 @@ export class RuntimeKernel implements RuntimeKernelLike {
       turnId: input.turnId,
       text: input.prompt,
       parentRunId: input.parentRunId,
+      ...(input.resumedFromRunId ? { resumedFromRunId: input.resumedFromRunId } : {}),
       agentId: definition.id,
       agentName: definition.name,
     };

--- a/packages/runtime/src/runtime-ledger-repair.ts
+++ b/packages/runtime/src/runtime-ledger-repair.ts
@@ -471,6 +471,7 @@ function latestTurnState(
 function headerLineage(header: AgentRunHeader): AgentRunLineage {
   return {
     ...(header.parentRunId ? { parentRunId: header.parentRunId } : {}),
+    ...(header.resumedFromRunId ? { resumedFromRunId: header.resumedFromRunId } : {}),
     ...(header.parentTurnId ? { parentTurnId: header.parentTurnId } : {}),
     ...(header.retriedFromTurnId ? { retriedFromTurnId: header.retriedFromTurnId } : {}),
     ...(header.regeneratedFromTurnId

--- a/packages/runtime/src/session-manager.ts
+++ b/packages/runtime/src/session-manager.ts
@@ -107,7 +107,14 @@ import {
   buildTurnStateMessage,
   turnHasRetainedOutput as messagesHaveRetainedOutput,
 } from './session-projection-helpers.js';
-import { listBuiltinAgentDefinitions, type AgentDefinitionListItem } from './agent-catalog.js';
+import {
+  assertAgentDefinitionRunnable,
+  getBuiltinAgentDefinition,
+  listBuiltinAgentDefinitions,
+  type AgentDefinition,
+  type AgentDefinitionListItem,
+} from './agent-catalog.js';
+import { buildRuntimeEventModelReplayPlan } from './model-history.js';
 import { requireResolvedAgentDefinition } from './expert-catalog.js';
 import {
   RuntimeContinuationPlanner,
@@ -144,6 +151,24 @@ export interface SpawnChildAgentInput {
   onEvent?: (event: SessionEvent) => void;
 }
 
+export interface PrepareChildAgentResumeResult {
+  sourceRunId: string;
+  agentId: string;
+  agentName: string;
+  profile: string;
+}
+
+export interface ResumeChildAgentInput {
+  parentRunId: string;
+  sourceRunId: string;
+  turnId?: string;
+  prompt: string;
+  abortSignal?: AbortSignal;
+  onReady?: (input: { turnId: string; agentId: string; agentName: string }) => void | Promise<void>;
+  /** Presentation-only observer for projecting child activity into a parent surface. */
+  onEvent?: (event: SessionEvent) => void;
+}
+
 export interface SpawnChildAgentResult {
   agentId: string;
   agentName: string;
@@ -158,6 +183,7 @@ export interface SpawnChildAgentResult {
   durationMs: number;
   eventCount: number;
   failureClass?: string;
+  resumedFromRunId?: string;
 }
 
 const CHILD_AGENT_SUMMARY_MAX_CHARS = 4_000;
@@ -1155,6 +1181,112 @@ export class SessionManager {
     input: SpawnChildAgentInput,
   ): Promise<SpawnChildAgentResult> {
     const definition = requireResolvedAgentDefinition(input.spec.id);
+    return await this.runChildAgent(sessionId, definition, input);
+  }
+
+  async prepareChildAgentResume(
+    sessionId: string,
+    sourceRunId: string,
+  ): Promise<PrepareChildAgentResumeResult> {
+    if (!this.deps.runStore || !this.deps.runtimeEventStore) {
+      throw new Error('Child AgentRun resume requires AgentRunStore and RuntimeEventStore');
+    }
+    const runs = await this.deps.runStore.listSessionRuns(sessionId);
+    const runsById = new Map(runs.map((run) => [run.runId, run]));
+    const source = runsById.get(sourceRunId);
+    if (!source || !source.parentRunId || isSessionInlineRun(source)) {
+      throw new Error(`Child AgentRun resume source ${sourceRunId} was not found`);
+    }
+    const definition = source.agentId ? getBuiltinAgentDefinition(source.agentId) : undefined;
+    if (!definition) {
+      throw new Error(`AgentRun ${sourceRunId} is not a resumable built-in child agent`);
+    }
+
+    const sessionHeader = await this.deps.store.readHeader(sessionId);
+    assertAgentDefinitionRunnable({
+      parentPermissionMode: sessionHeader.permissionMode,
+      definition,
+      tools: this.deps.childTools ?? [],
+    });
+    const visited = new Set<string>();
+    let cursor: AgentRunHeader | undefined = source;
+    while (cursor) {
+      if (visited.has(cursor.runId)) {
+        throw new Error(`Child AgentRun resume lineage contains a cycle at ${cursor.runId}`);
+      }
+      visited.add(cursor.runId);
+      if (!cursor.parentRunId || isSessionInlineRun(cursor) || cursor.agentId !== definition.id) {
+        throw new Error(`Child AgentRun resume profile changed at ${cursor.runId}`);
+      }
+      if (
+        cursor.backendKind !== sessionHeader.backend ||
+        cursor.llmConnectionSlug !== sessionHeader.llmConnectionSlug ||
+        cursor.modelId !== sessionHeader.model ||
+        cursor.cwd !== sessionHeader.cwd ||
+        cursor.permissionMode !== definition.permissionMode
+      ) {
+        throw new Error(`Child AgentRun resume environment changed for ${cursor.runId}`);
+      }
+
+      const events = await this.deps.runtimeEventStore
+        .readRuntimeEvents(sessionId, cursor.runId)
+        .catch(() => []);
+      const replay = buildRuntimeEventModelReplayPlan(events);
+      const unsafe = replay.diagnostics.find((diagnostic) =>
+        isUnsafeChildResumeDiagnostic(diagnostic.code),
+      );
+      if (unsafe) {
+        throw new Error(`Child AgentRun resume history is unsafe: ${unsafe.code}`);
+      }
+      const first = replay.items[0];
+      if (!first || first.kind !== 'text' || first.role !== 'user') {
+        throw new Error(
+          `Child AgentRun resume source ${cursor.runId} has no user-anchored history`,
+        );
+      }
+      const terminal = classifyTerminalRuntimeLedger(cursor, events);
+      if (terminal.kind !== 'fact') {
+        throw new Error(`Child AgentRun resume source ${cursor.runId} is not durably terminal`);
+      }
+      const effective = effectiveRunHeaderFromTerminalFact(cursor, terminal.fact);
+      if (!['completed', 'failed', 'cancelled'].includes(effective.status)) {
+        throw new Error(`Child AgentRun resume source ${cursor.runId} is not in a resumable state`);
+      }
+
+      const previousRunId = cursor.resumedFromRunId;
+      if (!previousRunId) break;
+      cursor = runsById.get(previousRunId);
+      if (!cursor) {
+        throw new Error(`Child AgentRun resume source ${previousRunId} was not found`);
+      }
+    }
+
+    if (runs.some((run) => run.resumedFromRunId === sourceRunId)) {
+      throw new Error(`Child AgentRun ${sourceRunId} already has a resume successor`);
+    }
+    return {
+      sourceRunId,
+      agentId: definition.id,
+      agentName: definition.name,
+      profile: definition.profile,
+    };
+  }
+
+  async resumeChildAgent(
+    sessionId: string,
+    input: ResumeChildAgentInput,
+  ): Promise<SpawnChildAgentResult> {
+    const prepared = await this.prepareChildAgentResume(sessionId, input.sourceRunId);
+    const definition = getBuiltinAgentDefinition(prepared.agentId)!;
+    return await this.runChildAgent(sessionId, definition, input, input.sourceRunId);
+  }
+
+  private async runChildAgent(
+    sessionId: string,
+    definition: AgentDefinition,
+    input: SpawnChildAgentInput | ResumeChildAgentInput,
+    resumedFromRunId?: string,
+  ): Promise<SpawnChildAgentResult> {
     const turnId = input.turnId ?? this.deps.newId();
     const startedAt = this.deps.now();
     const summary = new ChildAgentSummaryAccumulator();
@@ -1163,8 +1295,13 @@ export class SessionManager {
     const iterator = this.startChildTurn(sessionId, {
       turnId,
       parentRunId: input.parentRunId,
-      spec: input.spec,
+      spec: {
+        id: definition.id,
+        name: definition.name,
+        systemPrompt: definition.systemPrompt,
+      },
       prompt: input.prompt,
+      ...(resumedFromRunId ? { resumedFromRunId } : {}),
     })[Symbol.asyncIterator]();
     const onAbort = () => {
       aborted = true;
@@ -1209,6 +1346,7 @@ export class SessionManager {
       durationMs: Math.max(0, completedAt - startedAt),
       eventCount: summary.eventCount,
       ...(failureClass ? { failureClass } : {}),
+      ...(resumedFromRunId ? { resumedFromRunId } : {}),
     };
   }
 
@@ -1925,6 +2063,16 @@ function agentRunStatusForSpawnResult(
   if (status === 'failed') return 'failed';
   if (status === 'running' || status === 'created') return 'running';
   return 'completed';
+}
+
+function isUnsafeChildResumeDiagnostic(code: string): boolean {
+  return (
+    code === 'unmatched_tool_call' ||
+    code === 'unmatched_tool_result' ||
+    code === 'tool_id_mismatch' ||
+    code === 'unsupported_role' ||
+    code === 'unsupported_content'
+  );
 }
 
 function trimSummary(text: string): string {

--- a/packages/runtime/src/tool-runtime.ts
+++ b/packages/runtime/src/tool-runtime.ts
@@ -170,6 +170,22 @@ export interface MakaToolContext {
     }) => void | Promise<void>;
     onEvent?: (event: SessionEvent) => void;
   }) => Promise<unknown>;
+  prepareChildAgentResume?: (sourceRunId: string) => Promise<{
+    sourceRunId: string;
+    agentId: string;
+    agentName: string;
+    profile: string;
+  }>;
+  resumeChildAgent?: (input: {
+    sourceRunId: string;
+    prompt: string;
+    onReady?: (input: {
+      turnId: string;
+      agentId: string;
+      agentName: string;
+    }) => void | Promise<void>;
+    onEvent?: (event: SessionEvent) => void;
+  }) => Promise<unknown>;
   listChildAgents?: () => Promise<unknown>;
   readChildAgentOutput?: (input: {
     runId?: string;
@@ -249,6 +265,24 @@ export interface ToolRuntimeInput {
   spawnChildAgent?: (input: {
     parentRunId: string;
     spec: AgentSpec;
+    prompt: string;
+    abortSignal: AbortSignal;
+    onReady?: (input: {
+      turnId: string;
+      agentId: string;
+      agentName: string;
+    }) => void | Promise<void>;
+    onEvent?: (event: SessionEvent) => void;
+  }) => Promise<unknown>;
+  prepareChildAgentResume?: (sourceRunId: string) => Promise<{
+    sourceRunId: string;
+    agentId: string;
+    agentName: string;
+    profile: string;
+  }>;
+  resumeChildAgent?: (input: {
+    parentRunId: string;
+    sourceRunId: string;
     prompt: string;
     abortSignal: AbortSignal;
     onReady?: (input: {
@@ -1236,7 +1270,7 @@ export class ToolRuntime {
           ...(this.input.readChildAgentOutput
             ? { readChildAgentOutput: this.input.readChildAgentOutput }
             : {}),
-          ...this.buildSpawnChildAgentContext({
+          ...this.buildChildAgentContext({
             abortSignal: ctx.abortSignal,
             trace,
             toolUseId,
@@ -1689,102 +1723,137 @@ export class ToolRuntime {
     return { error: message };
   }
 
-  private buildSpawnChildAgentContext(input: {
+  private buildChildAgentContext(input: {
     abortSignal: AbortSignal;
     trace: RunTraceLike | null;
     toolUseId: string;
     toolName: string;
-  }): Pick<MakaToolContext, 'spawnChildAgent'> {
+  }): Pick<MakaToolContext, 'spawnChildAgent' | 'prepareChildAgentResume' | 'resumeChildAgent'> {
     const parentRunId = this.input.getCurrentRunId?.();
-    const spawnChildAgent = this.input.spawnChildAgent;
-    if (!parentRunId || !spawnChildAgent) return {};
+    if (!parentRunId) return {};
     const limiter = this.childAgentRunLimiter;
-    return {
-      spawnChildAgent: async (spawnInput) => {
-        const waitingForPermit =
-          limiter.activeCount >= limiter.capacity || limiter.waitingCount > 0;
-        if (waitingForPermit) {
-          input.trace?.emit(
-            'tool',
-            'tool_started',
-            'Child run waiting for shared runtime capacity',
-            {
-              toolUseId: input.toolUseId,
-              toolName: input.toolName,
-              boundary: 'shared_child_run_permit',
-              stage: 'waiting',
-              activeChildRuns: limiter.activeCount,
-              waitingChildRuns: limiter.waitingCount + 1,
-              capacity: limiter.capacity,
-            },
-          );
+    const runWithPermit = async <T>(
+      mode: 'spawn' | 'resume',
+      execute: () => Promise<T>,
+    ): Promise<T> => {
+      const waitingForPermit = limiter.activeCount >= limiter.capacity || limiter.waitingCount > 0;
+      if (waitingForPermit) {
+        input.trace?.emit('tool', 'tool_started', 'Child run waiting for shared runtime capacity', {
+          toolUseId: input.toolUseId,
+          toolName: input.toolName,
+          boundary: 'shared_child_run_permit',
+          stage: 'waiting',
+          mode,
+          activeChildRuns: limiter.activeCount,
+          waitingChildRuns: limiter.waitingCount + 1,
+          capacity: limiter.capacity,
+        });
+      }
+      let permit;
+      try {
+        permit = await limiter.acquire(input.abortSignal);
+      } catch (error) {
+        input.trace?.emit(
+          'tool',
+          'tool_failed',
+          'Child run did not acquire shared runtime capacity',
+          {
+            toolUseId: input.toolUseId,
+            toolName: input.toolName,
+            boundary: 'shared_child_run_permit',
+            stage: 'cancelled_while_waiting',
+            mode,
+            status: input.abortSignal.aborted ? 'aborted' : 'error',
+          },
+        );
+        throw error;
+      }
+      const childStartedAt = this.input.now();
+      input.trace?.emit('tool', 'tool_started', 'Child run execution started', {
+        toolUseId: input.toolUseId,
+        toolName: input.toolName,
+        boundary: 'child_run_execution',
+        stage: 'started',
+        mode,
+        waitedForPermit: waitingForPermit,
+        activeChildRuns: limiter.activeCount,
+        waitingChildRuns: limiter.waitingCount,
+        capacity: limiter.capacity,
+      });
+      try {
+        if (input.abortSignal.aborted) {
+          throw input.abortSignal.reason instanceof Error
+            ? input.abortSignal.reason
+            : new Error('Child agent run cancelled before it started');
         }
-        let permit;
-        try {
-          permit = await limiter.acquire(input.abortSignal);
-        } catch (error) {
-          input.trace?.emit(
-            'tool',
-            'tool_failed',
-            'Child run did not acquire shared runtime capacity',
-            {
-              toolUseId: input.toolUseId,
-              toolName: input.toolName,
-              boundary: 'shared_child_run_permit',
-              stage: 'cancelled_while_waiting',
-              status: input.abortSignal.aborted ? 'aborted' : 'error',
-            },
-          );
-          throw error;
-        }
-        const childStartedAt = this.input.now();
-        input.trace?.emit('tool', 'tool_started', 'Child run execution started', {
+        const result = await execute();
+        input.trace?.emit('tool', 'tool_completed', 'Child run execution completed', {
           toolUseId: input.toolUseId,
           toolName: input.toolName,
           boundary: 'child_run_execution',
-          stage: 'started',
-          waitedForPermit: waitingForPermit,
-          activeChildRuns: limiter.activeCount,
-          waitingChildRuns: limiter.waitingCount,
-          capacity: limiter.capacity,
+          stage: 'completed',
+          mode,
+          status: 'success',
+          durationMs: Math.max(0, this.input.now() - childStartedAt),
         });
-        try {
-          if (input.abortSignal.aborted) {
-            throw input.abortSignal.reason instanceof Error
-              ? input.abortSignal.reason
-              : new Error('Child agent run cancelled before it started');
+        return result;
+      } catch (error) {
+        input.trace?.emit('tool', 'tool_failed', 'Child run execution failed', {
+          toolUseId: input.toolUseId,
+          toolName: input.toolName,
+          boundary: 'child_run_execution',
+          stage: 'completed',
+          mode,
+          status: input.abortSignal.aborted ? 'aborted' : 'error',
+          durationMs: Math.max(0, this.input.now() - childStartedAt),
+        });
+        throw error;
+      } finally {
+        permit.release();
+      }
+    };
+
+    const spawnChildAgent = this.input.spawnChildAgent;
+    const prepareChildAgentResume = this.input.prepareChildAgentResume;
+    const resumeChildAgent = this.input.resumeChildAgent;
+    return {
+      ...(spawnChildAgent
+        ? {
+            spawnChildAgent: async (spawnInput) =>
+              await runWithPermit(
+                'spawn',
+                async () =>
+                  await spawnChildAgent({
+                    parentRunId,
+                    spec: spawnInput.spec,
+                    prompt: spawnInput.prompt,
+                    abortSignal: input.abortSignal,
+                    ...(spawnInput.onReady ? { onReady: spawnInput.onReady } : {}),
+                    ...(spawnInput.onEvent ? { onEvent: spawnInput.onEvent } : {}),
+                  }),
+              ),
           }
-          const result = await spawnChildAgent({
-            parentRunId,
-            spec: spawnInput.spec,
-            prompt: spawnInput.prompt,
-            abortSignal: input.abortSignal,
-            ...(spawnInput.onReady ? { onReady: spawnInput.onReady } : {}),
-            ...(spawnInput.onEvent ? { onEvent: spawnInput.onEvent } : {}),
-          });
-          input.trace?.emit('tool', 'tool_completed', 'Child run execution completed', {
-            toolUseId: input.toolUseId,
-            toolName: input.toolName,
-            boundary: 'child_run_execution',
-            stage: 'completed',
-            status: 'success',
-            durationMs: Math.max(0, this.input.now() - childStartedAt),
-          });
-          return result;
-        } catch (error) {
-          input.trace?.emit('tool', 'tool_failed', 'Child run execution failed', {
-            toolUseId: input.toolUseId,
-            toolName: input.toolName,
-            boundary: 'child_run_execution',
-            stage: 'completed',
-            status: input.abortSignal.aborted ? 'aborted' : 'error',
-            durationMs: Math.max(0, this.input.now() - childStartedAt),
-          });
-          throw error;
-        } finally {
-          permit.release();
-        }
-      },
+        : {}),
+      ...(prepareChildAgentResume
+        ? { prepareChildAgentResume: (sourceRunId) => prepareChildAgentResume(sourceRunId) }
+        : {}),
+      ...(resumeChildAgent
+        ? {
+            resumeChildAgent: async (resumeInput) =>
+              await runWithPermit(
+                'resume',
+                async () =>
+                  await resumeChildAgent({
+                    parentRunId,
+                    sourceRunId: resumeInput.sourceRunId,
+                    prompt: resumeInput.prompt,
+                    abortSignal: input.abortSignal,
+                    ...(resumeInput.onReady ? { onReady: resumeInput.onReady } : {}),
+                    ...(resumeInput.onEvent ? { onEvent: resumeInput.onEvent } : {}),
+                  }),
+              ),
+          }
+        : {}),
     };
   }
 

--- a/packages/ui/src/__tests__/tool-activity-presentation.test.ts
+++ b/packages/ui/src/__tests__/tool-activity-presentation.test.ts
@@ -825,6 +825,7 @@ describe('tool activity presentation', () => {
             started: true,
             turnId: 'turn-auth',
             runId: 'run-auth',
+            resumedFromRunId: 'run-auth-source',
             status: 'completed',
             summary: longSummary,
             artifactIds: ['artifact-auth'],
@@ -862,6 +863,7 @@ describe('tool activity presentation', () => {
     assert.match(markup, /1 取消/);
     assert.match(markup, /run run-auth/);
     assert.match(markup, /turn turn-auth/);
+    assert.match(markup, /resumed from run-auth-source/);
     assert.match(markup, /ParentCancelled/);
     assert.match(markup, />已取消</);
     assert.doesNotMatch(markup, /x{300}/);

--- a/packages/ui/src/tool-activity/agent-preview.tsx
+++ b/packages/ui/src/tool-activity/agent-preview.tsx
@@ -56,6 +56,9 @@ export function AgentSwarmPreview(props: {
               item.artifactIds.length > 0 ? copy.swarm.artifactCount(item.artifactIds.length) : '',
             ].filter(Boolean).join(' · ');
             const refs = [
+              item.resumedFromRunId
+                ? `resumed from ${redactSecrets(item.resumedFromRunId)}`
+                : '',
               item.runId ? `run ${redactSecrets(item.runId)}` : '',
               item.turnId ? `turn ${redactSecrets(item.turnId)}` : '',
             ].filter(Boolean).join(' · ');


### PR DESCRIPTION
## Summary

- add `resume_run_ids` to `agent_swarm` for resume-only and mixed resume/new batches
- continue a terminal child as a fresh `AgentRun` with durable `resumedFromRunId` lineage and RuntimeEvent replay
- preflight the complete resume chain before any batch item starts, failing closed on changed environments, unsafe tool boundaries, invalid terminal facts, profile drift, or duplicate successors
- run resumed children through the existing bounded Swarm worker pool, shared child-run limiter, cancellation, all-settled aggregation, and stable result ordering
- expose resume evidence in Runtime inspection, trace, CLI, Desktop, Headless, and UI projections
- document why Maka resumes unique run IDs rather than static Agent profile IDs

## Contract

`resume_run_ids` maps a source child `runId` to its next prompt. Resumed entries are ordered before new items and count toward the existing 32-item total. Each source may have one direct successor; that successor can be resumed again to form an auditable linear chain.

This is genuine model-context continuation. Maka replays the durable RuntimeEvent history of the source and its ancestors instead of concatenating a summary into a new prompt.

## Validation

- `npm --workspace @maka/core test`
- Runtime resume and Agent Swarm targeted suites: 214 tests passed
- CLI transcript resume-evidence tests: 2 passed
- UI tool-activity presentation tests: 30 passed
- Runtime, Headless, CLI, UI, and Desktop typechecks passed
- Biome formatting/lint and `git diff --check` passed

The full Runtime suite reached 2,343 passed and 7 skipped, with two pre-existing machine-specific macOS sandbox failures: the `/usr/local` executable-root expectation and Homebrew `rg` loading PCRE2 outside the sandbox. Neither failure is in this change path.

Tracks #1324
